### PR TITLE
[move-prover] Prover model visualization in execution traces.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -117,6 +117,11 @@ dependencies = [
 ]
 
 [[package]]
+name = "arrayvec"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
 name = "assert_approx_eq"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -420,6 +425,7 @@ dependencies = [
  "libra-types 0.1.0",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "num 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "pretty 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "prettydiff 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "proptest 0.9.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "regex 1.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -3136,6 +3142,15 @@ version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "pretty"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "arrayvec 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "typed-arena 2.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "prettydiff"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5308,6 +5323,11 @@ version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "typed-arena"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
 name = "typenum"
 version = "1.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5849,6 +5869,7 @@ dependencies = [
 "checksum arc-swap 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)" = "854ede29f7a0ce90519fb2439d030320c6201119b87dab0ee96044603e1130b9"
 "checksum arrayref 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)" = "0d382e583f07208808f6b1249e60848879ba3543f57c32277bf52d69c2f0f0ee"
 "checksum arrayvec 0.4.11 (registry+https://github.com/rust-lang/crates.io-index)" = "b8d73f9beda665eaa98ab9e4f7442bd4e7de6652587de55b2525e52e29c1b0ba"
+"checksum arrayvec 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)" = "cff77d8686867eceff3105329d4698d96c2391c176d5d03adc90c7389162b5b8"
 "checksum assert_approx_eq 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "3c07dab4369547dbe5114677b33fbbf724971019f3818172d59a97a61c774ffd"
 "checksum assert_matches 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "7deb0a829ca7bcfaf5da70b073a8d128619259a7be8216a355e23f00763059e5"
 "checksum async-stream 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "58982858be7540a465c790b95aaea6710e5139bf8956b1d1344d014fa40100b0"
@@ -6072,6 +6093,7 @@ dependencies = [
 "checksum pin-utils 0.1.0-alpha.4 (registry+https://github.com/rust-lang/crates.io-index)" = "5894c618ce612a3fa23881b152b608bafb8c56cfc22f434a3ba3120b40f7b587"
 "checksum pkg-config 0.3.15 (registry+https://github.com/rust-lang/crates.io-index)" = "a7c1d2cfa5a714db3b5f24f0915e74fcdf91d09d496ba61329705dda7774d2af"
 "checksum ppv-lite86 0.2.5 (registry+https://github.com/rust-lang/crates.io-index)" = "e3cbf9f658cdb5000fcf6f362b8ea2ba154b9f146a61c7a20d647034c6b6561b"
+"checksum pretty 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)" = "1891757f8427ce41706957fde1fec1b86aee3e335bd50320257705061507a24c"
 "checksum prettydiff 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "5240be0c9ea1bc7887819a36264cb9475eb71c58749808e5b989c8c1fdc67acf"
 "checksum prettytable-rs 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)" = "0fd04b170004fa2daccf418a7f8253aaf033c27760b5f225889024cf66d7ac2e"
 "checksum proc-macro-crate 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)" = "e10d4b51f154c8a7fb96fd6dad097cb74b863943ec010ac94b9fd1be8861fe1e"
@@ -6260,6 +6282,7 @@ dependencies = [
 "checksum try-lock 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "e604eb7b43c06650e854be16a2a03155743d3752dd1c943f6829e26b7a36e382"
 "checksum ttl_cache 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)" = "d4d297cea97896dfff8e9a26a92005571d193aff369f3404a77708b65dcc68db"
 "checksum typed-arena 1.5.0 (registry+https://github.com/rust-lang/crates.io-index)" = "7f70f5c346cc11bc044ae427ab2feae213350dca9e2d637047797d5ff316a646"
+"checksum typed-arena 2.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "0685c84d5d54d1c26f7d3eb96cd41550adb97baed141a761cf335d3d33bcd0ae"
 "checksum typenum 1.11.2 (registry+https://github.com/rust-lang/crates.io-index)" = "6d2783fe2d6b8c1101136184eb41be8b1ad379e4657050b8aaff0c79ee7575f9"
 "checksum unicase 2.5.1 (registry+https://github.com/rust-lang/crates.io-index)" = "2e2e6bd1e59e56598518beb94fd6db628ded570326f0a98c679a304bd9f00150"
 "checksum unicode-bidi 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)" = "49f2bd0c6468a8230e1db229cff8029217cf623c767ea5d60bfbd42729ea54d5"

--- a/language/move-prover/bytecode-to-boogie/Cargo.toml
+++ b/language/move-prover/bytecode-to-boogie/Cargo.toml
@@ -19,14 +19,15 @@ stackless-bytecode-generator = { path = "../stackless-bytecode-generator", versi
 stdlib = { path = "../../stdlib", version = "0.1.0" }
 
 # external dependencies
-num = "0.2.0"
-itertools = "0.8.0"
 clap = "2.33.0"
-log = "0.4.8"
-simplelog = "0.7.4"
 codespan = "0.2.1"
 codespan-reporting = "0.2.1"
+itertools = "0.8.0"
+log = "0.4.8"
+num = "0.2.0"
+pretty = "0.9.0"
 regex = "1.3.1"
+simplelog = "0.7.4"
 
 [dev-dependencies]
 proptest = "0.9"

--- a/language/move-prover/bytecode-to-boogie/src/boogie_wrapper.rs
+++ b/language/move-prover/bytecode-to-boogie/src/boogie_wrapper.rs
@@ -6,16 +6,32 @@
 use crate::cli::{abort_on_error, abort_with_error};
 use crate::code_writer::CodeWriter;
 use crate::driver::PSEUDO_PRELUDE_MODULE;
-use crate::env::{GlobalEnv, ModuleIndex};
-use codespan::{ByteIndex, ByteSpan, CodeMap, ColumnIndex, FileName, LineIndex};
+use crate::env::{FunctionEnv, GlobalEnv, GlobalType, ModuleEnv, ModuleIndex};
+use codespan::{
+    ByteIndex, ByteOffset, ByteSpan, CodeMap, ColumnIndex, FileName, LineIndex, RawIndex,
+};
 use codespan_reporting::termcolor::{ColorChoice, StandardStream};
 use codespan_reporting::{Diagnostic, Label, Severity};
 use ir_to_bytecode_syntax::ast::Loc;
 use itertools::Itertools;
+use log::warn;
 use log::{debug, error, info};
-use regex::Regex;
+use num::BigInt;
+use pretty::RcDoc;
+use regex::{Captures, Regex};
+use std::collections::{BTreeMap, BTreeSet, Bound};
 use std::fs;
+use std::iter::FromIterator;
+use std::option::Option::None;
 use std::process::Command;
+use vm::file_format::StructDefinitionIndex;
+
+/// A type alias for the way how we use crate `pretty`'s document type. `pretty` is a
+/// Wadler-style pretty printer. Our simple usage doesn't require any lifetime management.
+type PrettyDoc = RcDoc<'static, ()>;
+
+// -----------------------------------------------
+// # Boogie Wrapper
 
 /// Represents the boogie wrapper.
 pub struct BoogieWrapper<'env> {
@@ -48,6 +64,7 @@ pub struct BoogieError {
     pub position: Position,
     pub message: String,
     pub execution_trace: Vec<(Position, String)>,
+    pub model: Option<Model>,
 }
 
 impl<'env> BoogieWrapper<'env> {
@@ -119,9 +136,12 @@ impl<'env> BoogieWrapper<'env> {
     /// Helper to add a boogie error as a codespan Diagnostic.
     fn add_error(&self, error: &BoogieError, diags_on_target: &mut Vec<Diagnostic>) {
         let (index, location) = self.get_locations(error.position);
+
+        // Determine whether we report this error on the source
         let on_source = error.kind == BoogieErrorKind::Verification
-            && location.is_some()
-            && location.unwrap().0 != PSEUDO_PRELUDE_MODULE;
+            && self.to_proper_source_location(location).is_some();
+
+        // Create label (position information) for main error.
         let label = Label::new_primary(if on_source {
             // Location is on original source.
             location.unwrap().1
@@ -129,6 +149,8 @@ impl<'env> BoogieWrapper<'env> {
             // Location is on generated boogie.
             ByteSpan::new(index, index)
         });
+
+        // Helper to add a diag either to source module or to target
         let mut add_diag = |diag| {
             if on_source {
                 self.env.get_module(location.unwrap().0).add_diag(diag);
@@ -136,56 +158,103 @@ impl<'env> BoogieWrapper<'env> {
                 diags_on_target.push(diag);
             }
         };
-        let severity = if on_source {
-            Severity::Error
-        } else {
-            Severity::Bug
-        };
-        add_diag(Diagnostic::new(severity, &error.message).with_label(label));
+
+        // Add error
+        add_diag(
+            Diagnostic::new(
+                if on_source {
+                    Severity::Error
+                } else {
+                    Severity::Bug
+                },
+                &error.message,
+            )
+            .with_label(label),
+        );
+
+        // Now add trace diagnostics.
         if error.kind == BoogieErrorKind::Verification && !error.execution_trace.is_empty() {
-            let mut trace = error
+            // Get debug variables from model.
+            let debug_vars = error
+                .model
+                .as_ref()
+                .map(|m| m.find_debug_vars())
+                .unwrap_or_else(|| vec![]);
+            let trace = error
                 .execution_trace
                 .iter()
-                .filter_map(|(pos, _)| {
-                    let (_, trace_location) = self.get_locations(*pos);
-                    if self.env.options.minimize_execution_trace
-                        && (trace_location.is_none()
-                            || trace_location.unwrap().0 == PSEUDO_PRELUDE_MODULE)
-                    {
-                        // trace entry has no source location or is from prelude, skip
-                        return None;
-                    }
-                    let (file, act_pos) = if on_source
-                        && trace_location.is_some()
-                        && trace_location.unwrap().0 != PSEUDO_PRELUDE_MODULE
-                    {
-                        // Calculate line/column source position from (ModuleIndex, Loc).
-                        if let Some((module_idx, loc)) = trace_location {
-                            self.env.get_module(module_idx).get_position(loc)
-                        } else {
-                            unreachable!()
-                        }
+                .filter_map(|(pos, msg)| {
+                    // If trace entry has no source location or is from prelude, skip
+                    let trace_location =
+                        self.to_proper_source_location(self.get_locations(*pos).1)?;
+                    Some((pos, trace_location, msg))
+                })
+                .dedup_by(|(_, location1, _), (_, location2, msg2)| {
+                    // Removes consecutive entries which point to the same location if trace
+                    // minimization is active.
+                    self.env.options.minimize_execution_trace
+                        && location1 == location2
+                        // Do not dedup the return trace entry. It may have the same location as
+                        // the entry trace info, but we need to display it.
+                        && !msg2.ends_with("$Return")
+                })
+                .map(|(pos, (module_idx, loc), msg)| {
+                    if on_source {
+                        let module_env = self.env.get_module(module_idx);
+                        let (source_file, source_pos) = module_env.get_position(loc);
+                        self.render_trace_info(
+                            source_file,
+                            source_pos,
+                            self.pretty_trace_info(
+                                &module_env,
+                                loc,
+                                error.model.as_ref(),
+                                &debug_vars,
+                                msg,
+                            ),
+                        )
                     } else {
-                        // Use boogie target position
-                        (self.env.options.output_path.clone(), *pos)
-                    };
-                    Some(format!(
-                        "    at {}:{}:{}",
-                        file,
-                        (act_pos.0).0 + 1,
-                        (act_pos.1).0 + 1,
-                    ))
+                        self.render_trace_info(
+                            self.env.options.output_path.clone(),
+                            *pos,
+                            PrettyDoc::text(format!("<boogie>: {}", msg)),
+                        )
+                    }
                 })
                 .collect_vec();
-            if self.env.options.minimize_execution_trace {
-                // Removes consecutive entries which point to the same line.
-                trace.dedup();
-            }
             add_diag(Diagnostic::new(
                 Severity::Help,
                 &format!("Execution trace for previous error:\n{}", trace.join("\n")),
             ))
         }
+    }
+
+    /// Transform a source location into a proper one, filtering out pseudo module locations.
+    fn to_proper_source_location(
+        &self,
+        location: Option<(ModuleIndex, Loc)>,
+    ) -> Option<(ModuleIndex, Loc)> {
+        location.filter(|(module_idx, _)| *module_idx != PSEUDO_PRELUDE_MODULE)
+    }
+
+    /// Renders trace information.
+    fn render_trace_info(
+        &self,
+        file: String,
+        pos: (LineIndex, ColumnIndex),
+        info: PrettyDoc,
+    ) -> String {
+        let mut lines = vec![];
+        PrettyDoc::text(format!(
+            "    at {}:{}:{}: ",
+            file,
+            (pos.0).0 + 1,
+            (pos.1).0 + 1
+        ))
+        .append(info.nest(8))
+        .render(70, &mut lines)
+        .unwrap();
+        String::from_utf8_lossy(&lines).to_string()
     }
 
     /// Gets the target byte index and source location (if available) from a target line/column
@@ -195,11 +264,94 @@ impl<'env> BoogieWrapper<'env> {
         (index, self.writer.get_source_location(index))
     }
 
+    /// Pretty print trace information, injecting function name and variable bindings if available.
+    fn pretty_trace_info(
+        &'env self,
+        module_env: &ModuleEnv<'env>,
+        mut loc: Loc,
+        model_opt: Option<&'env Model>,
+        debug_vars: &'env [DebugVar],
+        boogie_msg: &str,
+    ) -> PrettyDoc {
+        let mut has_vars = false;
+        if let Some(func_env) = module_env.get_enclosing_function(loc) {
+            let func_name = func_env.get_name().to_string();
+            let mut func_display = func_name.clone();
+            if boogie_msg.ends_with("$Entry") {
+                func_display = format!("{} (entry)", func_display);
+                // Narrow location to the beginning of the function.
+                loc = Loc::new(loc.start(), loc.start() + ByteOffset(1));
+            } else if boogie_msg.ends_with("$Return") {
+                func_display = format!("{} (exit)", func_display);
+                // Narrow location to the end of the function.
+                if loc.end().0 > 0 {
+                    loc = Loc::new(loc.end() - ByteOffset(1), loc.end());
+                }
+            }
+            // DEBUG
+            // func_display = format!("{} ({})", func_display, loc);
+            // debug!("{}", func_display);
+            let model_info = if let Some(model) = model_opt {
+                let displayed_vars = debug_vars
+                    .iter()
+                    .filter(|v| {
+                        v.module_name == func_env.module_env.get_id().name().as_str()
+                            && v.func_name == func_name
+                    })
+                    .map(|v| (v, self.get_type_of_local_or_return(&func_env, v.var_idx)))
+                    .filter_map(|(v, ty)| {
+                        model
+                            .resolve_debug_var(v)
+                            .range((Bound::Unbounded, Bound::Included(&loc.start())))
+                            .next_back()
+                            .filter(|(idx, _)| {
+                                // Because of an apparent bug in [Position]Value, we
+                                // may got back locations which are actually not from this function.
+                                // Filter those out.
+                                // TODO: need to hunt down the bug and remove this hack.
+                                func_env.get_loc().contains(Loc::new(**idx, **idx))
+                            })
+                            .map(|(_, x)| v.pretty(self.env, &func_env, model, &ty, x))
+                    })
+                    .collect_vec();
+                has_vars = !displayed_vars.is_empty();
+                PrettyDoc::intersperse(
+                    displayed_vars,
+                    PrettyDoc::text(",").append(PrettyDoc::hardline()),
+                )
+            } else {
+                PrettyDoc::nil()
+            };
+            if has_vars {
+                PrettyDoc::text(func_display)
+                    .append(PrettyDoc::hardline())
+                    .append(model_info)
+            } else {
+                PrettyDoc::text(func_display)
+            }
+        } else {
+            PrettyDoc::text("<unknown function>")
+        }
+    }
+
+    /// Returns the type of either a local or a return parameter.
+    fn get_type_of_local_or_return(&self, func_env: &FunctionEnv<'_>, idx: usize) -> GlobalType {
+        let n = func_env.get_local_count();
+        if idx < n {
+            func_env.get_local_type(idx as u8)
+        } else {
+            func_env.get_return_types()[idx - n].clone()
+        }
+    }
+
     /// Extracts verification errors from Boogie output.
     ///
     /// This parses the output for errors of the form:
     ///
     /// ```ignore
+    /// *** MODEL
+    /// ...
+    /// *** END MODEL
     /// (0,0): Error BP5003: A postcondition might not hold on this return path.
     /// output.bpl(2964,1): Related location: This is the postcondition that might not hold.
     /// Execution trace:
@@ -209,6 +361,8 @@ impl<'env> BoogieWrapper<'env> {
     ///    ...
     /// ```
     fn extract_verification_errors(&self, out: &str) -> Vec<BoogieError> {
+        let model_region =
+            Regex::new(r"(?m)^\*\*\* MODEL$(?P<mod>(?s:.)*?^\*\*\* END_MODEL$)").unwrap();
         let verification_diag_start = Regex::new(r"(?m)^.*Error BP\d+:(?P<msg>.*)$").unwrap();
         let verification_diag_cond =
             Regex::new(r"(?m)^.+\((?P<line>\d+),(?P<col>\d+)\): Related.*$").unwrap();
@@ -217,36 +371,52 @@ impl<'env> BoogieWrapper<'env> {
             Regex::new(r"(?m)^    .*\((?P<line>\d+),(?P<col>\d+)\): (?P<msg>.*)$").unwrap();
         let mut errors = vec![];
         let mut at: usize = 0;
-        while let Some(cap) = verification_diag_start.captures(&out[at..]) {
-            let msg = cap.name("msg").unwrap().as_str();
-            at += cap.get(0).unwrap().end();
-            if let Some(cap) = verification_diag_cond.captures(&out[at..]) {
-                let line = cap.name("line").unwrap().as_str();
-                let col = cap.name("col").unwrap().as_str();
-                let mut trace = vec![];
+        loop {
+            let model = model_region.captures(&out[at..]).and_then(|cap| {
                 at += cap.get(0).unwrap().end();
-                if let Some(m) = verification_diag_trace.find(&out[at..]) {
-                    at += m.end();
-                    while let Some(cap) = verification_diag_trace_entry.captures(&out[at..]) {
-                        let line = cap.name("line").unwrap().as_str();
-                        let col = cap.name("col").unwrap().as_str();
-                        let msg = cap.name("msg").unwrap().as_str();
-                        trace.push((make_position(line, col), msg.to_string()));
-                        at += cap.get(0).unwrap().end();
-                        if !out[at..].starts_with("\n  ") && !out[at..].starts_with("\r\n  ") {
-                            // Don't read further if this line does not start with an indent,
-                            // as all trace entries do. Otherwise we would match the trace entry
-                            // for the next error.
-                            break;
-                        }
+                match Model::parse(cap.name("mod").unwrap().as_str()) {
+                    Ok(model) => Some(model),
+                    Err(parse_error) => {
+                        warn!("failed to parse boogie model: {}", parse_error.0);
+                        None
                     }
                 }
-                errors.push(BoogieError {
-                    kind: BoogieErrorKind::Verification,
-                    position: make_position(line, col),
-                    message: msg.to_string(),
-                    execution_trace: trace,
-                });
+            });
+
+            if let Some(cap) = verification_diag_start.captures(&out[at..]) {
+                let msg = cap.name("msg").unwrap().as_str();
+                at += cap.get(0).unwrap().end();
+                if let Some(cap) = verification_diag_cond.captures(&out[at..]) {
+                    let line = cap.name("line").unwrap().as_str();
+                    let col = cap.name("col").unwrap().as_str();
+                    let mut trace = vec![];
+                    at += cap.get(0).unwrap().end();
+                    if let Some(m) = verification_diag_trace.find(&out[at..]) {
+                        at += m.end();
+                        while let Some(cap) = verification_diag_trace_entry.captures(&out[at..]) {
+                            let line = cap.name("line").unwrap().as_str();
+                            let col = cap.name("col").unwrap().as_str();
+                            let msg = cap.name("msg").unwrap().as_str();
+                            trace.push((make_position(line, col), msg.to_string()));
+                            at += cap.get(0).unwrap().end();
+                            if !out[at..].starts_with("\n  ") && !out[at..].starts_with("\r\n  ") {
+                                // Don't read further if this line does not start with an indent,
+                                // as all trace entries do. Otherwise we would match the trace entry
+                                // for the next error.
+                                break;
+                            }
+                        }
+                    }
+                    errors.push(BoogieError {
+                        kind: BoogieErrorKind::Verification,
+                        position: make_position(line, col),
+                        message: msg.to_string(),
+                        execution_trace: trace,
+                        model,
+                    });
+                }
+            } else {
+                break;
             }
         }
         errors
@@ -268,6 +438,7 @@ impl<'env> BoogieWrapper<'env> {
                     position: make_position(line, col),
                     message: msg.to_string(),
                     execution_trace: vec![],
+                    model: None,
                 }
             })
             .collect_vec()
@@ -286,4 +457,544 @@ fn make_position(line_str: &str, col_str: &str) -> Position {
         col -= 1;
     }
     (LineIndex(line), ColumnIndex(col))
+}
+
+// -----------------------------------------------
+// # Boogie Model Analysis
+
+/// Represents a boogie model.
+#[derive(Debug)]
+pub struct Model {
+    vars: BTreeMap<ModelValue, ModelValue>,
+}
+
+impl Model {
+    /// Parses the given string into a model. The string is expected to end with MODULE_END_MARKER.
+    fn parse(input: &str) -> Result<Model, ModelParseError> {
+        let mut model_parser = ModelParser { input, at: 0 };
+        model_parser
+            .parse_map()
+            .and_then(|m| {
+                model_parser.expect(MODEL_END_MARKER)?;
+                Ok(m)
+            })
+            .and_then(|m| match m {
+                ModelValue::Map(vars) => Ok(Model { vars }),
+                _ => Err(ModelParseError("expected ModelValue::Map".to_string())),
+            })
+    }
+
+    /// Finds all debug variables in the model.
+    fn find_debug_vars(&self) -> Vec<DebugVar> {
+        let mut vars = self
+            .vars
+            .iter()
+            .filter_map(|(k, v)| {
+                // Only literals can represent debug variables
+                if let ModelValue::Literal(s) = k {
+                    if let Some(dvar) = DebugVar::parse(s, v) {
+                        return Some(dvar);
+                    }
+                }
+                None
+            })
+            .collect_vec();
+
+        // Remove variables with outdated version.
+        vars.sort();
+        let mut i = 0;
+        if !vars.is_empty() {
+            while i < vars.len() - 1 {
+                let drop = {
+                    let v = &vars[i];
+                    let next_v = &vars[i + 1];
+                    v.module_name == next_v.module_name
+                        && v.func_name == next_v.func_name
+                        && v.instance_id == next_v.instance_id
+                        && v.var_idx == next_v.var_idx
+                };
+                if drop {
+                    // next_v the same as v except next_v.version_id > v.version_id.
+                    // Drop this variable.
+                    vars.remove(i);
+                } else {
+                    i += 1;
+                }
+            }
+        }
+        vars
+    }
+
+    /// Resolve the debug var into its values, returning a map from ByteIndex to ModelValue,
+    /// where ByteIndex is the source location.
+    ///
+    /// The values for the debug vars are found in a map as such:
+    //
+    // Store_[Position]Value -> {
+    //  |T@[Position]Value!val!0| (Position 440) (Vector (ValueArray |T@[Int]Value!val!0| 0)) -> |T@[Position]Value!val!1|
+    //  |T@[Position]Value!val!1| (Position 496) (Vector (ValueArray |T@[Int]Value!val!1| 1)) -> |T@[Position]Value!val!3|
+    //  else -> |T@[Position]Value!val!1|
+    /// }
+    ///
+    /// In order to compute the map being described, we need to invert the mapping. For instance,
+    /// if we look for the value of `|T@[Position]Value!val!3|`, we use the last line which maps
+    /// byte index 496 to a vector, then continue to build the map for `|T@[Position]Value!val!1|`
+    /// which maps byte index 440, and so force.
+    fn resolve_debug_var(&self, var: &DebugVar) -> BTreeMap<ByteIndex, ModelValue> {
+        let values = var.value.extract_map_values(self, "Store_[Position]Value");
+        let result: BTreeMap<ByteIndex, ModelValue> =
+            BTreeMap::from_iter(values.iter().filter_map(|(k, v)| {
+                k.extract_primitive("Position").and_then(|index_str| {
+                    index_str
+                        .parse::<usize>()
+                        .and_then(|index| Ok((ByteIndex(index as RawIndex), v.clone())))
+                        .ok()
+                })
+            }));
+        debug!("{}.{} -> {:?}", var.func_name, var.var_name, result); // DEBUG
+        result
+    }
+}
+
+/// Represents a model value.
+#[derive(Debug, Clone, PartialEq, Eq, Hash, PartialOrd, Ord)]
+pub enum ModelValue {
+    Literal(String),
+    List(Vec<ModelValue>),
+    Map(BTreeMap<ModelValue, ModelValue>),
+}
+
+impl ModelValue {
+    /// Makes a literal from a str.
+    fn literal(s: &str) -> ModelValue {
+        ModelValue::Literal(s.to_string())
+    }
+
+    // Makes an error value.
+    fn error() -> ModelValue {
+        ModelValue::List(vec![ModelValue::literal("Error")])
+    }
+
+    /// Extracts a vector from `(Vector value_array)`. This follows indirections in the model
+    /// to extract the actual values.
+    fn extract_vector(&self, model: &Model) -> Option<Vec<ModelValue>> {
+        let args = self.extract_list("Vector")?;
+        if args.len() != 1 {
+            return None;
+        }
+        args[0].extract_value_array(model)
+    }
+
+    /// Extracts a value array from `(ValueArray map_key size)`. This follows indirections in
+    /// the model to extract the actual values.
+    fn extract_value_array(&self, model: &Model) -> Option<Vec<ModelValue>> {
+        let args = self.extract_list("ValueArray")?;
+        if args.len() != 2 {
+            return None;
+        }
+        let map_key = &args[0];
+        let size = (&args[1]).extract_number()?;
+        let entries = &map_key.extract_map_values(model, "Store_[$int]Value");
+        Some(
+            (0..size)
+                .map(|i| {
+                    let key = &ModelValue::literal(&i.to_string());
+                    entries.get(key).cloned().unwrap_or_else(ModelValue::error)
+                })
+                .collect_vec(),
+        )
+    }
+
+    /// Extract the arguments of a list of the form `(<ctor> element...)`.
+    fn extract_list(&self, ctor: &str) -> Option<&[ModelValue]> {
+        if let ModelValue::List(elems) = self {
+            if !elems.is_empty() && elems[0] == ModelValue::literal(ctor) {
+                return Some(&elems[1..]);
+            }
+        }
+        None
+    }
+    /// Extract a number from a literal.
+    fn extract_number(&self) -> Option<usize> {
+        if let Ok(n) = self.extract_literal()?.parse::<usize>() {
+            Some(n)
+        } else {
+            None
+        }
+    }
+    /// Extract the value of a primitive.
+    fn extract_primitive(&self, ctor: &str) -> Option<&String> {
+        let args = self.extract_list(ctor)?;
+        if args.len() != 1 {
+            return None;
+        }
+        (&args[0]).extract_literal()
+    }
+
+    /// Extract a literal.
+    fn extract_literal(&self) -> Option<&String> {
+        if let ModelValue::Literal(s) = self {
+            Some(s)
+        } else {
+            None
+        }
+    }
+
+    /// Extract map values based on the storage variable in the model, which looks like:
+    ///
+    // Store_[Position]Value -> {
+    //  |T@[Position]Value!val!0| (Position 440) (Vector (ValueArray |T@[Int]Value!val!0| 0)) -> |T@[Position]Value!val!1|
+    //  |T@[Position]Value!val!1| (Position 496) (Vector (ValueArray |T@[Int]Value!val!1| 1)) -> |T@[Position]Value!val!3|
+    //  else -> |T@[Position]Value!val!1|
+    /// }
+    ///
+    /// In order to compute the map being described, we need to invert the mapping. For instance,
+    /// if we look for the value of `|T@[Position]Value!val!3|`, we use the last line which maps
+    /// 496 to a vector, then continue to build the map for `|T@[Position]Value!val!1|`
+    /// which maps 440, and so force.
+    fn extract_map_values(
+        &self,
+        model: &Model,
+        store_name: &str,
+    ) -> BTreeMap<ModelValue, ModelValue> {
+        let mut result = BTreeMap::new();
+        if let Some(entries) = model
+            .vars
+            .get(&ModelValue::literal(store_name))
+            .and_then(|v| {
+                if let ModelValue::Map(entries) = v {
+                    Some(entries)
+                } else {
+                    None
+                }
+            })
+        {
+            fn extract_recursively(
+                es: &BTreeMap<ModelValue, ModelValue>,
+                mk: &ModelValue,
+                r: &mut BTreeMap<ModelValue, ModelValue>,
+                visited: &mut BTreeSet<ModelValue>,
+            ) {
+                let else_lit = &ModelValue::literal("else");
+                if let Some((ModelValue::List(elems), _)) =
+                    es.iter().find(|(k, v)| *k != else_lit && *v == mk)
+                {
+                    // Need to first recursively process the older map to preserve update order.
+                    let mk1 = &elems[0];
+                    if visited.insert(mk1.clone()) {
+                        extract_recursively(es, mk1, r, visited);
+                        r.insert(elems[1].clone(), elems[2].clone());
+                    }
+                }
+            }
+            extract_recursively(entries, self, &mut result, &mut BTreeSet::new());
+        }
+        result
+    }
+
+    /// Pretty prints the given model value which has given type. If printing fails, falls
+    /// back to print the debug value.
+    pub fn pretty_or_raw<'env>(
+        &self,
+        env: &'env GlobalEnv,
+        model: &Model,
+        ty: &GlobalType,
+    ) -> PrettyDoc {
+        self.pretty(env, model, ty).unwrap_or_else(|| {
+            // Print the raw debug value.
+            PrettyDoc::text(format!("<? {:?}>", self))
+        })
+    }
+
+    /// Pretty prints the given model value which has given type.
+    pub fn pretty(&self, env: &GlobalEnv, model: &Model, ty: &GlobalType) -> Option<PrettyDoc> {
+        if self.extract_list("Error").is_some() {
+            // This is an undefined value
+            return Some(PrettyDoc::text("<undef>"));
+        }
+        match ty {
+            GlobalType::U8 => Some(PrettyDoc::text(format!(
+                "{}u8",
+                self.extract_primitive("Integer")?
+            ))),
+            GlobalType::U64 => Some(PrettyDoc::text(
+                self.extract_primitive("Integer")?.to_string(),
+            )),
+            GlobalType::U128 => Some(PrettyDoc::text(format!(
+                "{}u128",
+                self.extract_primitive("Integer")?.to_string()
+            ))),
+            GlobalType::Bool => Some(PrettyDoc::text(
+                self.extract_primitive("Boolean")?.to_string(),
+            )),
+            GlobalType::Address => {
+                let addr = BigInt::parse_bytes(
+                    &self.extract_primitive("Address")?.clone().into_bytes(),
+                    10,
+                )?;
+                Some(PrettyDoc::text(format!("0x{}", &addr.to_str_radix(16))))
+            }
+            GlobalType::ByteArray => {
+                // Right now byte arrays are abstract in boogie, so we can only distinguish
+                // instances.
+                let repr = self.extract_primitive("ByteArray")?;
+                let display = if repr.starts_with("T@ByteArray!val!") {
+                    &repr["T@ByteArray!val!".len()..]
+                } else {
+                    repr
+                };
+                Some(PrettyDoc::text(format!("<bytearray {}>", display)))
+            }
+            GlobalType::Struct(module_idx, struct_idx, params) => {
+                self.pretty_struct_or_vector(env, model, *module_idx, *struct_idx, &params)
+            }
+            GlobalType::Reference(bt) | GlobalType::MutableReference(bt) => {
+                Some(PrettyDoc::text("&").append(self.pretty(env, model, &*bt)?))
+            }
+            GlobalType::TypeParameter(_) => {
+                // The value of a generic cannot be easily displayed because we do not know the
+                // actual type unless we parse it out from the model (via the type value parameter)
+                // and convert into a GlobalType. However, since the value is parametric and cannot
+                // effect the verification outcome, we may not have much need for seeing it.
+                Some(PrettyDoc::text("<generic>"))
+            }
+        }
+    }
+
+    /// Pretty prints a struct or vector.
+    pub fn pretty_struct_or_vector(
+        &self,
+        env: &GlobalEnv,
+        model: &Model,
+        module_idx: ModuleIndex,
+        struct_idx: StructDefinitionIndex,
+        params: &[GlobalType],
+    ) -> Option<PrettyDoc> {
+        let error = ModelValue::error();
+        let module_env = env.get_module(module_idx);
+        let struct_env = module_env.get_struct(&struct_idx);
+        let values = self.extract_vector(model)?;
+        let entries = if struct_env.is_vector() {
+            values
+                .iter()
+                .map(|v| v.pretty_or_raw(env, model, &params[0]))
+                .collect_vec()
+        } else {
+            struct_env
+                .get_fields()
+                .enumerate()
+                .map(|(i, f)| {
+                    let ty = f.get_type().instantiate(params);
+                    let v = if i < values.len() { &values[i] } else { &error };
+                    let vp = v.pretty_or_raw(env, model, &ty);
+                    PrettyDoc::text(f.get_name().as_str().to_string())
+                        .append(PrettyDoc::text(" ="))
+                        .append(PrettyDoc::line().append(vp).nest(2).group())
+                })
+                .collect_vec()
+        };
+        Some(
+            PrettyDoc::text(format!(
+                "{}.{}",
+                struct_env.module_env.get_id().name(),
+                struct_env.get_name()
+            ))
+            .append(PrettyDoc::text("{"))
+            .append(
+                PrettyDoc::line_()
+                    .append(PrettyDoc::intersperse(
+                        entries,
+                        PrettyDoc::text(",").append(PrettyDoc::line()),
+                    ))
+                    .nest(2)
+                    .group(),
+            )
+            .append(PrettyDoc::text("}")),
+        )
+    }
+}
+
+/// Represents a debug variable.
+#[derive(Debug, Clone, PartialEq, Eq, Hash, PartialOrd, Ord)]
+struct DebugVar {
+    module_name: String,
+    func_name: String,
+    var_idx: usize,
+    var_name: String,
+    instance_id: usize,
+    version_id: usize,
+    value: ModelValue,
+}
+
+impl DebugVar {
+    /// Parses a model variable name into the components of a debug variable.
+    ///
+    /// Variables have the form
+    /// `inline$<ignored>$<instance>$debug#<module>#<func>#<idx>#<name>@<version>`.
+    /// `instance` above appears to be for distinguishing inlined variables from the same
+    /// function. `version` appears to be the number Boogie appends for variable history
+    /// (i.e. x@1, x@2, ...).
+    fn parse(s: &str, value: &ModelValue) -> Option<DebugVar> {
+        fn get_cap_usize(cap: &Captures, name: &str) -> usize {
+            cap.name(name).unwrap().as_str().parse::<usize>().unwrap()
+        }
+        let re = Regex::new(r"inline\$[^$]+\$(?P<instance>[0-9]+)\$debug#").unwrap();
+        re.captures(s).and_then(|ref cap| {
+            let instance_id = get_cap_usize(cap, "instance");
+            let re =
+                Regex::new(r"(?P<mod>[^#]+)#(?P<func>[^#]+)#(?P<idx>[0-9]+)#(?P<var>[^@]+)@(?P<version>[0-9]+)")
+                    .unwrap();
+
+            re.captures(&s[cap.get(0).unwrap().end()..]).map(|ref cap| {
+                let module = cap.name("mod").unwrap().as_str();
+                let func = cap.name("func").unwrap().as_str();
+                let idx = get_cap_usize(cap, "idx");
+                let var = cap.name("var").unwrap().as_str();
+                let version_id = get_cap_usize(cap, "version");
+                DebugVar {
+                    module_name: module.to_string(),
+                    func_name: func.to_string(),
+                    var_idx: idx,
+                    var_name: var.to_string(),
+                    instance_id,
+                    version_id,
+                    value: value.clone(),
+                }
+            })
+        })
+    }
+
+    /// Pretty prints a debug variable.
+    fn pretty(
+        &self,
+        env: &GlobalEnv,
+        func_env: &FunctionEnv<'_>,
+        model: &Model,
+        ty: &GlobalType,
+        resolved_value: &ModelValue,
+    ) -> PrettyDoc {
+        let n = func_env.get_local_count();
+        let var_name = if self.var_idx >= n {
+            if func_env.get_return_count() > 1 {
+                format!("RET({})", self.var_idx - n)
+            } else {
+                "RET".to_string()
+            }
+        } else {
+            self.var_name.clone()
+        };
+        PrettyDoc::text(var_name)
+            .append(PrettyDoc::space())
+            .append(PrettyDoc::text("="))
+            .append(
+                PrettyDoc::line()
+                    .append(resolved_value.pretty_or_raw(env, model, ty))
+                    .nest(2)
+                    .group(),
+            )
+    }
+}
+
+/// Represents parser for a boogie model.
+struct ModelParser<'s> {
+    input: &'s str,
+    at: usize,
+}
+
+/// Represents error resulting from model parsing.
+struct ModelParseError(String);
+
+const MODEL_END_MARKER: &str = "*** END_MODEL";
+
+impl<'s> ModelParser<'s> {
+    fn skip_space(&mut self) {
+        while self.input[self.at..].starts_with(|ch| [' ', '\r', '\n', '\t'].contains(&ch)) {
+            self.at += 1;
+        }
+    }
+
+    fn looking_at(&mut self, s: &str) -> bool {
+        self.skip_space();
+        self.input[self.at..].starts_with(s)
+    }
+
+    fn looking_at_then_consume(&mut self, s: &str) -> bool {
+        if self.looking_at(s) {
+            self.at += s.len();
+            true
+        } else {
+            false
+        }
+    }
+
+    fn expect(&mut self, s: &str) -> Result<(), ModelParseError> {
+        self.skip_space();
+        if self.input[self.at..].starts_with(s) {
+            self.at += s.len();
+            Ok(())
+        } else {
+            let end = std::cmp::min(self.at + 80, self.input.len());
+            Err(ModelParseError(format!(
+                "expected `{}` (at `{}...`)",
+                s,
+                &self.input[self.at..end]
+            )))
+        }
+    }
+
+    fn parse_map(&mut self) -> Result<ModelValue, ModelParseError> {
+        let mut map = BTreeMap::new();
+        while !self.looking_at("}") && !self.looking_at(MODEL_END_MARKER) {
+            let key = self.parse_key()?;
+            self.expect("->")?;
+            let value = if self.looking_at_then_consume("{") {
+                let value = self.parse_map()?;
+                self.expect("}")?;
+                value
+            } else {
+                self.parse_value()?
+            };
+            map.insert(key, value);
+        }
+        Ok(ModelValue::Map(map))
+    }
+
+    fn parse_key(&mut self) -> Result<ModelValue, ModelParseError> {
+        let mut comps = vec![];
+        while !self.looking_at("->") {
+            let value = self.parse_value()?;
+            comps.push(value);
+        }
+        if comps.is_empty() {
+            Err(ModelParseError(
+                "expected at least one component of a key".to_string(),
+            ))
+        } else if comps.len() == 1 {
+            Ok(comps.pop().unwrap())
+        } else {
+            Ok(ModelValue::List(comps))
+        }
+    }
+
+    fn parse_value(&mut self) -> Result<ModelValue, ModelParseError> {
+        if self.looking_at_then_consume("(") {
+            let mut comps = vec![];
+            while !self.looking_at_then_consume(")") {
+                let value = self.parse_value()?;
+                comps.push(value);
+            }
+            Ok(ModelValue::List(comps))
+        } else {
+            // We do not know the exact lexis, so take everything until next space or ).
+            self.skip_space();
+            let start = self.at;
+            while self.at < self.input.len()
+                && !self.input[self.at..]
+                    .starts_with(|ch| [')', ' ', '\r', '\n', '\t'].contains(&ch))
+            {
+                self.at += 1;
+            }
+            Ok(ModelValue::Literal(self.input[start..self.at].to_string()))
+        }
+    }
 }

--- a/language/move-prover/bytecode-to-boogie/src/cli.rs
+++ b/language/move-prover/bytecode-to-boogie/src/cli.rs
@@ -22,6 +22,7 @@ const DEFAULT_BOOGIE_FLAGS: &[&str] = &[
     "-doModSetAnalysis",
     "-noinfer",
     "-printVerifiedProceduresCount:0",
+    "-printModel:4",
 ];
 
 /// Atomic used to prevent re-initialization of logging.
@@ -58,6 +59,8 @@ pub struct Options {
     pub native_stubs: bool,
     /// Whether to minimize execution traces in errors.
     pub minimize_execution_trace: bool,
+    /// Whether to omit debug information in generated model.
+    pub omit_model_debug: bool,
 }
 
 impl Default for Options {
@@ -75,6 +78,7 @@ impl Default for Options {
             generate_only: false,
             native_stubs: false,
             minimize_execution_trace: true,
+            omit_model_debug: false,
         }
     }
 }
@@ -123,6 +127,11 @@ impl Options {
                 Arg::with_name("native-stubs")
                     .long("native-stubs")
                     .help("whether to generate stubs for native functions"),
+            )
+            .arg(
+                Arg::with_name("omit-model-debug")
+                    .long("omit-model-debug")
+                    .help("whether to omit code for model debugging"),
             )
             .arg(
                 Arg::with_name("boogie-exe")
@@ -198,6 +207,7 @@ impl Options {
         };
         self.generate_only = matches.is_present("generate-only");
         self.native_stubs = matches.is_present("native-stubs");
+        self.omit_model_debug = matches.is_present("omit-model-debug");
         self.use_cvc4 = matches.is_present("use-cvc4");
         self.boogie_exe = get_with_default("boogie-exe");
         self.z3_exe = get_with_default("z3-exe");

--- a/language/move-prover/bytecode-to-boogie/src/prelude.bpl
+++ b/language/move-prover/bytecode-to-boogie/src/prelude.bpl
@@ -1,6 +1,16 @@
 // ================================================================================
 // Domains
 
+// Source Position type
+// --------------------
+
+type {:datatype} Position;
+function {:constructor} Position(index: int) : Position;
+
+const EmptyPositionMap: [Position]Value;
+axiom EmptyPositionMap == (lambda p: Position :: DefaultValue);
+
+
 
 // Path type
 // ---------
@@ -133,7 +143,6 @@ function {:inline 1} SwapValueArray(a: ValueArray, i: int, j: int): ValueArray {
 function {:inline 1} IsEmpty(a: ValueArray): bool {
     l#ValueArray(a) == 0
 }
-
 
 // Stratified Functions on Values
 // ------------------------------
@@ -323,9 +332,11 @@ function {:inline 1} UpdateLocal(m: Memory, idx: int, v: Value): Memory {
     Memory(domain#Memory(m)[Local(idx) := true], contents#Memory(m)[Local(idx) := v])
 }
 
-procedure {:inline 1} InitMemory() {
-  __m := EmptyMemory;
+procedure {:inline 1} InitVerification() {
+  // Set local counter to 0
   __local_counter := 0;
+  // Assume sender account exists.
+  assume ExistsTxnSenderAccount(__m, __txn);
 }
 
 // ============================================================================================

--- a/language/move-prover/bytecode-to-boogie/tests/goldenfiles/libra_account.bpl
+++ b/language/move-prover/bytecode-to-boogie/tests/goldenfiles/libra_account.bpl
@@ -135,16 +135,21 @@ ensures old(b#Boolean(Boolean(!(b#Boolean(ExistsResource(__m, LibraCoin_MintCapa
     var __tmp: Value;
     var __frame: int;
     var __saved_m: Memory;
+    var debug#LibraCoin#mint_with_default_capability#0#amount: [Position]Value;
+    var debug#LibraCoin#mint_with_default_capability#1#__ret: [Position]Value;
 
     // initialize function execution
     assume !__abort_flag;
     __saved_m := __m;
     __frame := __local_counter;
     __local_counter := __local_counter + 5;
+    debug#LibraCoin#mint_with_default_capability#0#amount := EmptyPositionMap;
+    debug#LibraCoin#mint_with_default_capability#1#__ret := EmptyPositionMap;
 
     // process and type check arguments
     assume IsValidU64(amount);
     __m := UpdateLocal(__m, __frame + 0, amount);
+    debug#LibraCoin#mint_with_default_capability#0#amount := debug#LibraCoin#mint_with_default_capability#0#amount[Position(806) := amount];
 
     // bytecode translation starts here
     call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 0));
@@ -163,17 +168,19 @@ ensures old(b#Boolean(Boolean(!(b#Boolean(ExistsResource(__m, LibraCoin_MintCapa
     __m := UpdateLocal(__m, __frame + 4, __t4);
 
     __ret0 := GetLocal(__m, __frame + 4);
+    debug#LibraCoin#mint_with_default_capability#1#__ret := debug#LibraCoin#mint_with_default_capability#1#__ret[Position(1401) := __ret0];
     return;
 
 Label_Abort:
     __abort_flag := true;
     __m := __saved_m;
     __ret0 := DefaultValue;
+    debug#LibraCoin#mint_with_default_capability#1#__ret := debug#LibraCoin#mint_with_default_capability#1#__ret[Position(1486) := __ret0];
 }
 
 procedure LibraCoin_mint_with_default_capability_verify (amount: Value) returns (__ret0: Value)
 {
-    assume ExistsTxnSenderAccount(__m, __txn);
+    call InitVerification();
     call __ret0 := LibraCoin_mint_with_default_capability(amount);
 }
 
@@ -211,18 +218,30 @@ ensures old(b#Boolean(Boolean(!(b#Boolean(ExistsResource(__m, LibraCoin_MarketCa
     var __tmp: Value;
     var __frame: int;
     var __saved_m: Memory;
+    var debug#LibraCoin#mint#0#value: [Position]Value;
+    var debug#LibraCoin#mint#1#capability: [Position]Value;
+    var debug#LibraCoin#mint#2#market_cap_ref: [Position]Value;
+    var debug#LibraCoin#mint#3#market_cap_total_value: [Position]Value;
+    var debug#LibraCoin#mint#4#__ret: [Position]Value;
 
     // initialize function execution
     assume !__abort_flag;
     __saved_m := __m;
     __frame := __local_counter;
     __local_counter := __local_counter + 24;
+    debug#LibraCoin#mint#0#value := EmptyPositionMap;
+    debug#LibraCoin#mint#1#capability := EmptyPositionMap;
+    debug#LibraCoin#mint#2#market_cap_ref := EmptyPositionMap;
+    debug#LibraCoin#mint#3#market_cap_total_value := EmptyPositionMap;
+    debug#LibraCoin#mint#4#__ret := EmptyPositionMap;
 
     // process and type check arguments
     assume IsValidU64(value);
     __m := UpdateLocal(__m, __frame + 0, value);
+    debug#LibraCoin#mint#0#value := debug#LibraCoin#mint#0#value[Position(1723) := value];
     assume is#Vector(Dereference(__m, capability));
     assume IsValidReferenceParameter(__m, __frame, capability);
+    debug#LibraCoin#mint#1#capability := debug#LibraCoin#mint#1#capability[Position(1723) := Dereference(__m, capability)];
 
     // bytecode translation starts here
     call __t4 := CopyOrMoveRef(capability);
@@ -275,6 +294,7 @@ Label_11:
 
     call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 16));
     __m := UpdateLocal(__m, __frame + 3, __tmp);
+    debug#LibraCoin#mint#3#market_cap_total_value := debug#LibraCoin#mint#3#market_cap_total_value[Position(2964) := __tmp];
 
     call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 3));
     __m := UpdateLocal(__m, __frame + 17, __tmp);
@@ -299,17 +319,19 @@ Label_11:
     __m := UpdateLocal(__m, __frame + 23, __tmp);
 
     __ret0 := GetLocal(__m, __frame + 23);
+    debug#LibraCoin#mint#4#__ret := debug#LibraCoin#mint#4#__ret[Position(3129) := __ret0];
     return;
 
 Label_Abort:
     __abort_flag := true;
     __m := __saved_m;
     __ret0 := DefaultValue;
+    debug#LibraCoin#mint#4#__ret := debug#LibraCoin#mint#4#__ret[Position(3163) := __ret0];
 }
 
 procedure LibraCoin_mint_verify (value: Value, capability: Reference) returns (__ret0: Value)
 {
-    assume ExistsTxnSenderAccount(__m, __txn);
+    call InitVerification();
     call __ret0 := LibraCoin_mint(value, capability);
 }
 
@@ -393,7 +415,7 @@ Label_Abort:
 
 procedure LibraCoin_initialize_verify () returns ()
 {
-    assume ExistsTxnSenderAccount(__m, __txn);
+    call InitVerification();
     call LibraCoin_initialize();
 }
 
@@ -412,12 +434,14 @@ ensures old(b#Boolean(Boolean(!(b#Boolean(ExistsResource(__m, LibraCoin_MarketCa
     var __tmp: Value;
     var __frame: int;
     var __saved_m: Memory;
+    var debug#LibraCoin#market_cap#0#__ret: [Position]Value;
 
     // initialize function execution
     assume !__abort_flag;
     __saved_m := __m;
     __frame := __local_counter;
     __local_counter := __local_counter + 4;
+    debug#LibraCoin#market_cap#0#__ret := EmptyPositionMap;
 
     // process and type check arguments
 
@@ -435,17 +459,19 @@ ensures old(b#Boolean(Boolean(!(b#Boolean(ExistsResource(__m, LibraCoin_MarketCa
     __m := UpdateLocal(__m, __frame + 3, __tmp);
 
     __ret0 := GetLocal(__m, __frame + 3);
+    debug#LibraCoin#market_cap#0#__ret := debug#LibraCoin#market_cap#0#__ret[Position(4289) := __ret0];
     return;
 
 Label_Abort:
     __abort_flag := true;
     __m := __saved_m;
     __ret0 := DefaultValue;
+    debug#LibraCoin#market_cap#0#__ret := debug#LibraCoin#market_cap#0#__ret[Position(4353) := __ret0];
 }
 
 procedure LibraCoin_market_cap_verify () returns (__ret0: Value)
 {
-    assume ExistsTxnSenderAccount(__m, __txn);
+    call InitVerification();
     call __ret0 := LibraCoin_market_cap();
 }
 
@@ -459,12 +485,14 @@ ensures b#Boolean(Boolean(IsEqual(SelectField(__ret0, LibraCoin_T_value), Intege
     var __tmp: Value;
     var __frame: int;
     var __saved_m: Memory;
+    var debug#LibraCoin#zero#0#__ret: [Position]Value;
 
     // initialize function execution
     assume !__abort_flag;
     __saved_m := __m;
     __frame := __local_counter;
     __local_counter := __local_counter + 2;
+    debug#LibraCoin#zero#0#__ret := EmptyPositionMap;
 
     // process and type check arguments
 
@@ -476,17 +504,19 @@ ensures b#Boolean(Boolean(IsEqual(SelectField(__ret0, LibraCoin_T_value), Intege
     __m := UpdateLocal(__m, __frame + 1, __tmp);
 
     __ret0 := GetLocal(__m, __frame + 1);
+    debug#LibraCoin#zero#0#__ret := debug#LibraCoin#zero#0#__ret[Position(4477) := __ret0];
     return;
 
 Label_Abort:
     __abort_flag := true;
     __m := __saved_m;
     __ret0 := DefaultValue;
+    debug#LibraCoin#zero#0#__ret := debug#LibraCoin#zero#0#__ret[Position(4501) := __ret0];
 }
 
 procedure LibraCoin_zero_verify () returns (__ret0: Value)
 {
-    assume ExistsTxnSenderAccount(__m, __txn);
+    call InitVerification();
     call __ret0 := LibraCoin_zero();
 }
 
@@ -501,16 +531,21 @@ ensures b#Boolean(Boolean(IsEqual(__ret0, SelectField(Dereference(__m, coin_ref)
     var __tmp: Value;
     var __frame: int;
     var __saved_m: Memory;
+    var debug#LibraCoin#value#0#coin_ref: [Position]Value;
+    var debug#LibraCoin#value#1#__ret: [Position]Value;
 
     // initialize function execution
     assume !__abort_flag;
     __saved_m := __m;
     __frame := __local_counter;
     __local_counter := __local_counter + 4;
+    debug#LibraCoin#value#0#coin_ref := EmptyPositionMap;
+    debug#LibraCoin#value#1#__ret := EmptyPositionMap;
 
     // process and type check arguments
     assume is#Vector(Dereference(__m, coin_ref));
     assume IsValidReferenceParameter(__m, __frame, coin_ref);
+    debug#LibraCoin#value#0#coin_ref := debug#LibraCoin#value#0#coin_ref[Position(4555) := Dereference(__m, coin_ref)];
 
     // bytecode translation starts here
     call __t1 := CopyOrMoveRef(coin_ref);
@@ -522,17 +557,19 @@ ensures b#Boolean(Boolean(IsEqual(__ret0, SelectField(Dereference(__m, coin_ref)
     __m := UpdateLocal(__m, __frame + 3, __tmp);
 
     __ret0 := GetLocal(__m, __frame + 3);
+    debug#LibraCoin#value#1#__ret := debug#LibraCoin#value#1#__ret[Position(4644) := __ret0];
     return;
 
 Label_Abort:
     __abort_flag := true;
     __m := __saved_m;
     __ret0 := DefaultValue;
+    debug#LibraCoin#value#1#__ret := debug#LibraCoin#value#1#__ret[Position(4679) := __ret0];
 }
 
 procedure LibraCoin_value_verify (coin_ref: Reference) returns (__ret0: Value)
 {
-    assume ExistsTxnSenderAccount(__m, __txn);
+    call InitVerification();
     call __ret0 := LibraCoin_value(coin_ref);
 }
 
@@ -553,18 +590,30 @@ ensures old(b#Boolean(Boolean(i#Integer(SelectField(coin, LibraCoin_T_value)) < 
     var __tmp: Value;
     var __frame: int;
     var __saved_m: Memory;
+    var debug#LibraCoin#split#0#coin: [Position]Value;
+    var debug#LibraCoin#split#1#amount: [Position]Value;
+    var debug#LibraCoin#split#2#other: [Position]Value;
+    var debug#LibraCoin#split#3#__ret: [Position]Value;
+    var debug#LibraCoin#split#4#__ret: [Position]Value;
 
     // initialize function execution
     assume !__abort_flag;
     __saved_m := __m;
     __frame := __local_counter;
     __local_counter := __local_counter + 8;
+    debug#LibraCoin#split#0#coin := EmptyPositionMap;
+    debug#LibraCoin#split#1#amount := EmptyPositionMap;
+    debug#LibraCoin#split#2#other := EmptyPositionMap;
+    debug#LibraCoin#split#3#__ret := EmptyPositionMap;
+    debug#LibraCoin#split#4#__ret := EmptyPositionMap;
 
     // process and type check arguments
     assume is#Vector(coin);
     __m := UpdateLocal(__m, __frame + 0, coin);
+    debug#LibraCoin#split#0#coin := debug#LibraCoin#split#0#coin[Position(4818) := coin];
     assume IsValidU64(amount);
     __m := UpdateLocal(__m, __frame + 1, amount);
+    debug#LibraCoin#split#1#amount := debug#LibraCoin#split#1#amount[Position(4818) := amount];
 
     // bytecode translation starts here
     call __t3 := BorrowLoc(__frame + 0);
@@ -577,9 +626,11 @@ ensures old(b#Boolean(Boolean(i#Integer(SelectField(coin, LibraCoin_T_value)) < 
     assume is#Vector(__t5);
 
     __m := UpdateLocal(__m, __frame + 5, __t5);
+    debug#LibraCoin#split#0#coin := debug#LibraCoin#split#0#coin[Position(5045) := GetLocal(__m, __frame + 0)];
 
     call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 5));
     __m := UpdateLocal(__m, __frame + 2, __tmp);
+    debug#LibraCoin#split#2#other := debug#LibraCoin#split#2#other[Position(5037) := __tmp];
 
     call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 0));
     __m := UpdateLocal(__m, __frame + 6, __tmp);
@@ -588,19 +639,23 @@ ensures old(b#Boolean(Boolean(i#Integer(SelectField(coin, LibraCoin_T_value)) < 
     __m := UpdateLocal(__m, __frame + 7, __tmp);
 
     __ret0 := GetLocal(__m, __frame + 6);
+    debug#LibraCoin#split#3#__ret := debug#LibraCoin#split#3#__ret[Position(5093) := __ret0];
     __ret1 := GetLocal(__m, __frame + 7);
+    debug#LibraCoin#split#4#__ret := debug#LibraCoin#split#4#__ret[Position(5093) := __ret1];
     return;
 
 Label_Abort:
     __abort_flag := true;
     __m := __saved_m;
     __ret0 := DefaultValue;
+    debug#LibraCoin#split#3#__ret := debug#LibraCoin#split#3#__ret[Position(5129) := __ret0];
     __ret1 := DefaultValue;
+    debug#LibraCoin#split#4#__ret := debug#LibraCoin#split#4#__ret[Position(5129) := __ret1];
 }
 
 procedure LibraCoin_split_verify (coin: Value, amount: Value) returns (__ret0: Value, __ret1: Value)
 {
-    assume ExistsTxnSenderAccount(__m, __txn);
+    call InitVerification();
     call __ret0, __ret1 := LibraCoin_split(coin, amount);
 }
 
@@ -632,18 +687,28 @@ ensures old(b#Boolean(Boolean(i#Integer(SelectField(Dereference(__m, coin_ref), 
     var __tmp: Value;
     var __frame: int;
     var __saved_m: Memory;
+    var debug#LibraCoin#withdraw#0#coin_ref: [Position]Value;
+    var debug#LibraCoin#withdraw#1#amount: [Position]Value;
+    var debug#LibraCoin#withdraw#2#value: [Position]Value;
+    var debug#LibraCoin#withdraw#3#__ret: [Position]Value;
 
     // initialize function execution
     assume !__abort_flag;
     __saved_m := __m;
     __frame := __local_counter;
     __local_counter := __local_counter + 18;
+    debug#LibraCoin#withdraw#0#coin_ref := EmptyPositionMap;
+    debug#LibraCoin#withdraw#1#amount := EmptyPositionMap;
+    debug#LibraCoin#withdraw#2#value := EmptyPositionMap;
+    debug#LibraCoin#withdraw#3#__ret := EmptyPositionMap;
 
     // process and type check arguments
     assume is#Vector(Dereference(__m, coin_ref));
     assume IsValidReferenceParameter(__m, __frame, coin_ref);
+    debug#LibraCoin#withdraw#0#coin_ref := debug#LibraCoin#withdraw#0#coin_ref[Position(5391) := Dereference(__m, coin_ref)];
     assume IsValidU64(amount);
     __m := UpdateLocal(__m, __frame + 1, amount);
+    debug#LibraCoin#withdraw#1#amount := debug#LibraCoin#withdraw#1#amount[Position(5391) := amount];
 
     // bytecode translation starts here
     call __t3 := CopyOrMoveRef(coin_ref);
@@ -656,6 +721,7 @@ ensures old(b#Boolean(Boolean(i#Integer(SelectField(Dereference(__m, coin_ref), 
 
     call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 5));
     __m := UpdateLocal(__m, __frame + 2, __tmp);
+    debug#LibraCoin#withdraw#2#value := debug#LibraCoin#withdraw#2#value[Position(5692) := __tmp];
 
     call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 2));
     __m := UpdateLocal(__m, __frame + 6, __tmp);
@@ -701,17 +767,19 @@ Label_11:
     __m := UpdateLocal(__m, __frame + 17, __tmp);
 
     __ret0 := GetLocal(__m, __frame + 17);
+    debug#LibraCoin#withdraw#3#__ret := debug#LibraCoin#withdraw#3#__ret[Position(5881) := __ret0];
     return;
 
 Label_Abort:
     __abort_flag := true;
     __m := __saved_m;
     __ret0 := DefaultValue;
+    debug#LibraCoin#withdraw#3#__ret := debug#LibraCoin#withdraw#3#__ret[Position(5916) := __ret0];
 }
 
 procedure LibraCoin_withdraw_verify (coin_ref: Reference, amount: Value) returns (__ret0: Value)
 {
-    assume ExistsTxnSenderAccount(__m, __txn);
+    call InitVerification();
     call __ret0 := LibraCoin_withdraw(coin_ref, amount);
 }
 
@@ -729,18 +797,26 @@ ensures old(b#Boolean(Boolean(i#Integer(Integer(i#Integer(SelectField(coin1, Lib
     var __tmp: Value;
     var __frame: int;
     var __saved_m: Memory;
+    var debug#LibraCoin#join#0#coin1: [Position]Value;
+    var debug#LibraCoin#join#1#coin2: [Position]Value;
+    var debug#LibraCoin#join#2#__ret: [Position]Value;
 
     // initialize function execution
     assume !__abort_flag;
     __saved_m := __m;
     __frame := __local_counter;
     __local_counter := __local_counter + 5;
+    debug#LibraCoin#join#0#coin1 := EmptyPositionMap;
+    debug#LibraCoin#join#1#coin2 := EmptyPositionMap;
+    debug#LibraCoin#join#2#__ret := EmptyPositionMap;
 
     // process and type check arguments
     assume is#Vector(coin1);
     __m := UpdateLocal(__m, __frame + 0, coin1);
+    debug#LibraCoin#join#0#coin1 := debug#LibraCoin#join#0#coin1[Position(6020) := coin1];
     assume is#Vector(coin2);
     __m := UpdateLocal(__m, __frame + 1, coin2);
+    debug#LibraCoin#join#1#coin2 := debug#LibraCoin#join#1#coin2[Position(6020) := coin2];
 
     // bytecode translation starts here
     call __t2 := BorrowLoc(__frame + 0);
@@ -750,22 +826,25 @@ ensures old(b#Boolean(Boolean(i#Integer(Integer(i#Integer(SelectField(coin1, Lib
 
     call LibraCoin_deposit(__t2, GetLocal(__m, __frame + 3));
     if (__abort_flag) { goto Label_Abort; }
+    debug#LibraCoin#join#0#coin1 := debug#LibraCoin#join#0#coin1[Position(6215) := GetLocal(__m, __frame + 0)];
 
     call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 0));
     __m := UpdateLocal(__m, __frame + 4, __tmp);
 
     __ret0 := GetLocal(__m, __frame + 4);
+    debug#LibraCoin#join#2#__ret := debug#LibraCoin#join#2#__ret[Position(6262) := __ret0];
     return;
 
 Label_Abort:
     __abort_flag := true;
     __m := __saved_m;
     __ret0 := DefaultValue;
+    debug#LibraCoin#join#2#__ret := debug#LibraCoin#join#2#__ret[Position(6286) := __ret0];
 }
 
 procedure LibraCoin_join_verify (coin1: Value, coin2: Value) returns (__ret0: Value)
 {
-    assume ExistsTxnSenderAccount(__m, __txn);
+    call InitVerification();
     call __ret0 := LibraCoin_join(coin1, coin2);
 }
 
@@ -792,18 +871,28 @@ ensures old(b#Boolean(Boolean(i#Integer(Integer(i#Integer(SelectField(Dereferenc
     var __tmp: Value;
     var __frame: int;
     var __saved_m: Memory;
+    var debug#LibraCoin#deposit#0#coin_ref: [Position]Value;
+    var debug#LibraCoin#deposit#1#check: [Position]Value;
+    var debug#LibraCoin#deposit#2#value: [Position]Value;
+    var debug#LibraCoin#deposit#3#check_value: [Position]Value;
 
     // initialize function execution
     assume !__abort_flag;
     __saved_m := __m;
     __frame := __local_counter;
     __local_counter := __local_counter + 14;
+    debug#LibraCoin#deposit#0#coin_ref := EmptyPositionMap;
+    debug#LibraCoin#deposit#1#check := EmptyPositionMap;
+    debug#LibraCoin#deposit#2#value := EmptyPositionMap;
+    debug#LibraCoin#deposit#3#check_value := EmptyPositionMap;
 
     // process and type check arguments
     assume is#Vector(Dereference(__m, coin_ref));
     assume IsValidReferenceParameter(__m, __frame, coin_ref);
+    debug#LibraCoin#deposit#0#coin_ref := debug#LibraCoin#deposit#0#coin_ref[Position(6465) := Dereference(__m, coin_ref)];
     assume is#Vector(check);
     __m := UpdateLocal(__m, __frame + 1, check);
+    debug#LibraCoin#deposit#1#check := debug#LibraCoin#deposit#1#check[Position(6465) := check];
 
     // bytecode translation starts here
     call __t4 := CopyOrMoveRef(coin_ref);
@@ -816,6 +905,7 @@ ensures old(b#Boolean(Boolean(i#Integer(Integer(i#Integer(SelectField(Dereferenc
 
     call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 6));
     __m := UpdateLocal(__m, __frame + 2, __tmp);
+    debug#LibraCoin#deposit#2#value := debug#LibraCoin#deposit#2#value[Position(6729) := __tmp];
 
     call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 1));
     __m := UpdateLocal(__m, __frame + 7, __tmp);
@@ -825,6 +915,7 @@ ensures old(b#Boolean(Boolean(i#Integer(Integer(i#Integer(SelectField(Dereferenc
 
     call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 8));
     __m := UpdateLocal(__m, __frame + 3, __tmp);
+    debug#LibraCoin#deposit#3#check_value := debug#LibraCoin#deposit#3#check_value[Position(6779) := __tmp];
 
     call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 2));
     __m := UpdateLocal(__m, __frame + 9, __tmp);
@@ -851,7 +942,7 @@ Label_Abort:
 
 procedure LibraCoin_deposit_verify (coin_ref: Reference, check: Value) returns ()
 {
-    assume ExistsTxnSenderAccount(__m, __txn);
+    call InitVerification();
     call LibraCoin_deposit(coin_ref, check);
 }
 
@@ -873,16 +964,21 @@ ensures old(b#Boolean(Boolean(!IsEqual(SelectField(coin, LibraCoin_T_value), Int
     var __tmp: Value;
     var __frame: int;
     var __saved_m: Memory;
+    var debug#LibraCoin#destroy_zero#0#coin: [Position]Value;
+    var debug#LibraCoin#destroy_zero#1#value: [Position]Value;
 
     // initialize function execution
     assume !__abort_flag;
     __saved_m := __m;
     __frame := __local_counter;
     __local_counter := __local_counter + 9;
+    debug#LibraCoin#destroy_zero#0#coin := EmptyPositionMap;
+    debug#LibraCoin#destroy_zero#1#value := EmptyPositionMap;
 
     // process and type check arguments
     assume is#Vector(coin);
     __m := UpdateLocal(__m, __frame + 0, coin);
+    debug#LibraCoin#destroy_zero#0#coin := debug#LibraCoin#destroy_zero#0#coin[Position(7117) := coin];
 
     // bytecode translation starts here
     call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 0));
@@ -893,6 +989,7 @@ ensures old(b#Boolean(Boolean(!IsEqual(SelectField(coin, LibraCoin_T_value), Int
 
     call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 3));
     __m := UpdateLocal(__m, __frame + 1, __tmp);
+    debug#LibraCoin#destroy_zero#1#value := debug#LibraCoin#destroy_zero#1#value[Position(7227) := __tmp];
 
     call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 1));
     __m := UpdateLocal(__m, __frame + 4, __tmp);
@@ -924,7 +1021,7 @@ Label_Abort:
 
 procedure LibraCoin_destroy_zero_verify (coin: Value) returns ()
 {
-    assume ExistsTxnSenderAccount(__m, __txn);
+    call InitVerification();
     call LibraCoin_destroy_zero(coin);
 }
 
@@ -1194,16 +1291,31 @@ ensures b#Boolean(Boolean(b#Boolean(Boolean(IsEqual(SelectField(SelectField(__re
     var __tmp: Value;
     var __frame: int;
     var __saved_m: Memory;
+    var debug#LibraAccount#make#0#fresh_address: [Position]Value;
+    var debug#LibraAccount#make#1#zero_balance: [Position]Value;
+    var debug#LibraAccount#make#2#generator: [Position]Value;
+    var debug#LibraAccount#make#3#sent_handle: [Position]Value;
+    var debug#LibraAccount#make#4#received_handle: [Position]Value;
+    var debug#LibraAccount#make#5#auth_key: [Position]Value;
+    var debug#LibraAccount#make#6#__ret: [Position]Value;
 
     // initialize function execution
     assume !__abort_flag;
     __saved_m := __m;
     __frame := __local_counter;
     __local_counter := __local_counter + 26;
+    debug#LibraAccount#make#0#fresh_address := EmptyPositionMap;
+    debug#LibraAccount#make#1#zero_balance := EmptyPositionMap;
+    debug#LibraAccount#make#2#generator := EmptyPositionMap;
+    debug#LibraAccount#make#3#sent_handle := EmptyPositionMap;
+    debug#LibraAccount#make#4#received_handle := EmptyPositionMap;
+    debug#LibraAccount#make#5#auth_key := EmptyPositionMap;
+    debug#LibraAccount#make#6#__ret := EmptyPositionMap;
 
     // process and type check arguments
     assume is#Address(fresh_address);
     __m := UpdateLocal(__m, __frame + 0, fresh_address);
+    debug#LibraAccount#make#0#fresh_address := debug#LibraAccount#make#0#fresh_address[Position(3283) := fresh_address];
 
     // bytecode translation starts here
     call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 0));
@@ -1217,6 +1329,7 @@ ensures b#Boolean(Boolean(b#Boolean(Boolean(IsEqual(SelectField(SelectField(__re
 
     call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 7));
     __m := UpdateLocal(__m, __frame + 5, __tmp);
+    debug#LibraAccount#make#5#auth_key := debug#LibraAccount#make#5#auth_key[Position(3812) := __tmp];
 
     call __tmp := LdConst(0);
     __m := UpdateLocal(__m, __frame + 8, __tmp);
@@ -1226,6 +1339,7 @@ ensures b#Boolean(Boolean(b#Boolean(Boolean(IsEqual(SelectField(SelectField(__re
 
     call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 9));
     __m := UpdateLocal(__m, __frame + 2, __tmp);
+    debug#LibraAccount#make#2#generator := debug#LibraAccount#make#2#generator[Position(3882) := __tmp];
 
     call __t10 := BorrowLoc(__frame + 2);
 
@@ -1237,9 +1351,11 @@ ensures b#Boolean(Boolean(b#Boolean(Boolean(IsEqual(SelectField(SelectField(__re
     assume is#Vector(__t12);
 
     __m := UpdateLocal(__m, __frame + 12, __t12);
+    debug#LibraAccount#make#2#generator := debug#LibraAccount#make#2#generator[Position(3951) := GetLocal(__m, __frame + 2)];
 
     call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 12));
     __m := UpdateLocal(__m, __frame + 3, __tmp);
+    debug#LibraAccount#make#3#sent_handle := debug#LibraAccount#make#3#sent_handle[Position(3937) := __tmp];
 
     call __t13 := BorrowLoc(__frame + 2);
 
@@ -1251,9 +1367,11 @@ ensures b#Boolean(Boolean(b#Boolean(Boolean(IsEqual(SelectField(SelectField(__re
     assume is#Vector(__t15);
 
     __m := UpdateLocal(__m, __frame + 15, __t15);
+    debug#LibraAccount#make#2#generator := debug#LibraAccount#make#2#generator[Position(4065) := GetLocal(__m, __frame + 2)];
 
     call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 15));
     __m := UpdateLocal(__m, __frame + 4, __tmp);
+    debug#LibraAccount#make#4#received_handle := debug#LibraAccount#make#4#received_handle[Position(4047) := __tmp];
 
     call __t16 := LibraCoin_zero();
     if (__abort_flag) { goto Label_Abort; }
@@ -1263,6 +1381,7 @@ ensures b#Boolean(Boolean(b#Boolean(Boolean(IsEqual(SelectField(SelectField(__re
 
     call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 16));
     __m := UpdateLocal(__m, __frame + 1, __tmp);
+    debug#LibraAccount#make#1#zero_balance := debug#LibraAccount#make#1#zero_balance[Position(4165) := __tmp];
 
     call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 5));
     __m := UpdateLocal(__m, __frame + 17, __tmp);
@@ -1292,17 +1411,19 @@ ensures b#Boolean(Boolean(b#Boolean(Boolean(IsEqual(SelectField(SelectField(__re
     __m := UpdateLocal(__m, __frame + 25, __tmp);
 
     __ret0 := GetLocal(__m, __frame + 25);
+    debug#LibraAccount#make#6#__ret := debug#LibraAccount#make#6#__ret[Position(4207) := __ret0];
     return;
 
 Label_Abort:
     __abort_flag := true;
     __m := __saved_m;
     __ret0 := DefaultValue;
+    debug#LibraAccount#make#6#__ret := debug#LibraAccount#make#6#__ret[Position(4602) := __ret0];
 }
 
 procedure LibraAccount_make_verify (fresh_address: Value) returns (__ret0: Value)
 {
-    assume ExistsTxnSenderAccount(__m, __txn);
+    call InitVerification();
     call __ret0 := LibraAccount_make(fresh_address);
 }
 
@@ -1320,18 +1441,24 @@ ensures old(b#Boolean(Boolean(!(b#Boolean(ExistsResource(__m, LibraAccount_T_typ
     var __tmp: Value;
     var __frame: int;
     var __saved_m: Memory;
+    var debug#LibraAccount#deposit#0#payee: [Position]Value;
+    var debug#LibraAccount#deposit#1#to_deposit: [Position]Value;
 
     // initialize function execution
     assume !__abort_flag;
     __saved_m := __m;
     __frame := __local_counter;
     __local_counter := __local_counter + 5;
+    debug#LibraAccount#deposit#0#payee := EmptyPositionMap;
+    debug#LibraAccount#deposit#1#to_deposit := EmptyPositionMap;
 
     // process and type check arguments
     assume is#Address(payee);
     __m := UpdateLocal(__m, __frame + 0, payee);
+    debug#LibraAccount#deposit#0#payee := debug#LibraAccount#deposit#0#payee[Position(4674) := payee];
     assume is#Vector(to_deposit);
     __m := UpdateLocal(__m, __frame + 1, to_deposit);
+    debug#LibraAccount#deposit#1#to_deposit := debug#LibraAccount#deposit#1#to_deposit[Position(4674) := to_deposit];
 
     // bytecode translation starts here
     call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 0));
@@ -1354,7 +1481,7 @@ Label_Abort:
 
 procedure LibraAccount_deposit_verify (payee: Value, to_deposit: Value) returns ()
 {
-    assume ExistsTxnSenderAccount(__m, __txn);
+    call InitVerification();
     call LibraAccount_deposit(payee, to_deposit);
 }
 
@@ -1373,20 +1500,29 @@ ensures old(b#Boolean(Boolean(!(b#Boolean(ExistsResource(__m, LibraAccount_T_typ
     var __tmp: Value;
     var __frame: int;
     var __saved_m: Memory;
+    var debug#LibraAccount#deposit_with_metadata#0#payee: [Position]Value;
+    var debug#LibraAccount#deposit_with_metadata#1#to_deposit: [Position]Value;
+    var debug#LibraAccount#deposit_with_metadata#2#metadata: [Position]Value;
 
     // initialize function execution
     assume !__abort_flag;
     __saved_m := __m;
     __frame := __local_counter;
     __local_counter := __local_counter + 7;
+    debug#LibraAccount#deposit_with_metadata#0#payee := EmptyPositionMap;
+    debug#LibraAccount#deposit_with_metadata#1#to_deposit := EmptyPositionMap;
+    debug#LibraAccount#deposit_with_metadata#2#metadata := EmptyPositionMap;
 
     // process and type check arguments
     assume is#Address(payee);
     __m := UpdateLocal(__m, __frame + 0, payee);
+    debug#LibraAccount#deposit_with_metadata#0#payee := debug#LibraAccount#deposit_with_metadata#0#payee[Position(5450) := payee];
     assume is#Vector(to_deposit);
     __m := UpdateLocal(__m, __frame + 1, to_deposit);
+    debug#LibraAccount#deposit_with_metadata#1#to_deposit := debug#LibraAccount#deposit_with_metadata#1#to_deposit[Position(5450) := to_deposit];
     assume is#ByteArray(metadata);
     __m := UpdateLocal(__m, __frame + 2, metadata);
+    debug#LibraAccount#deposit_with_metadata#2#metadata := debug#LibraAccount#deposit_with_metadata#2#metadata[Position(5450) := metadata];
 
     // bytecode translation starts here
     call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 0));
@@ -1413,7 +1549,7 @@ Label_Abort:
 
 procedure LibraAccount_deposit_with_metadata_verify (payee: Value, to_deposit: Value, metadata: Value) returns ()
 {
-    assume ExistsTxnSenderAccount(__m, __txn);
+    call InitVerification();
     call LibraAccount_deposit_with_metadata(payee, to_deposit, metadata);
 }
 
@@ -1457,22 +1593,40 @@ ensures old(b#Boolean(Boolean(!(b#Boolean(ExistsResource(__m, LibraAccount_T_typ
     var __tmp: Value;
     var __frame: int;
     var __saved_m: Memory;
+    var debug#LibraAccount#deposit_with_sender_and_metadata#0#payee: [Position]Value;
+    var debug#LibraAccount#deposit_with_sender_and_metadata#1#sender: [Position]Value;
+    var debug#LibraAccount#deposit_with_sender_and_metadata#2#to_deposit: [Position]Value;
+    var debug#LibraAccount#deposit_with_sender_and_metadata#3#metadata: [Position]Value;
+    var debug#LibraAccount#deposit_with_sender_and_metadata#4#deposit_value: [Position]Value;
+    var debug#LibraAccount#deposit_with_sender_and_metadata#5#payee_account_ref: [Position]Value;
+    var debug#LibraAccount#deposit_with_sender_and_metadata#6#sender_account_ref: [Position]Value;
 
     // initialize function execution
     assume !__abort_flag;
     __saved_m := __m;
     __frame := __local_counter;
     __local_counter := __local_counter + 33;
+    debug#LibraAccount#deposit_with_sender_and_metadata#0#payee := EmptyPositionMap;
+    debug#LibraAccount#deposit_with_sender_and_metadata#1#sender := EmptyPositionMap;
+    debug#LibraAccount#deposit_with_sender_and_metadata#2#to_deposit := EmptyPositionMap;
+    debug#LibraAccount#deposit_with_sender_and_metadata#3#metadata := EmptyPositionMap;
+    debug#LibraAccount#deposit_with_sender_and_metadata#4#deposit_value := EmptyPositionMap;
+    debug#LibraAccount#deposit_with_sender_and_metadata#5#payee_account_ref := EmptyPositionMap;
+    debug#LibraAccount#deposit_with_sender_and_metadata#6#sender_account_ref := EmptyPositionMap;
 
     // process and type check arguments
     assume is#Address(payee);
     __m := UpdateLocal(__m, __frame + 0, payee);
+    debug#LibraAccount#deposit_with_sender_and_metadata#0#payee := debug#LibraAccount#deposit_with_sender_and_metadata#0#payee[Position(6415) := payee];
     assume is#Address(sender);
     __m := UpdateLocal(__m, __frame + 1, sender);
+    debug#LibraAccount#deposit_with_sender_and_metadata#1#sender := debug#LibraAccount#deposit_with_sender_and_metadata#1#sender[Position(6415) := sender];
     assume is#Vector(to_deposit);
     __m := UpdateLocal(__m, __frame + 2, to_deposit);
+    debug#LibraAccount#deposit_with_sender_and_metadata#2#to_deposit := debug#LibraAccount#deposit_with_sender_and_metadata#2#to_deposit[Position(6415) := to_deposit];
     assume is#ByteArray(metadata);
     __m := UpdateLocal(__m, __frame + 3, metadata);
+    debug#LibraAccount#deposit_with_sender_and_metadata#3#metadata := debug#LibraAccount#deposit_with_sender_and_metadata#3#metadata[Position(6415) := metadata];
 
     // bytecode translation starts here
     call __t7 := BorrowLoc(__frame + 2);
@@ -1485,6 +1639,7 @@ ensures old(b#Boolean(Boolean(!(b#Boolean(ExistsResource(__m, LibraAccount_T_typ
 
     call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 8));
     __m := UpdateLocal(__m, __frame + 4, __tmp);
+    debug#LibraAccount#deposit_with_sender_and_metadata#4#deposit_value := debug#LibraAccount#deposit_with_sender_and_metadata#4#deposit_value[Position(7270) := __tmp];
 
     call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 4));
     __m := UpdateLocal(__m, __frame + 9, __tmp);
@@ -1580,7 +1735,7 @@ Label_Abort:
 
 procedure LibraAccount_deposit_with_sender_and_metadata_verify (payee: Value, sender: Value, to_deposit: Value, metadata: Value) returns ()
 {
-    assume ExistsTxnSenderAccount(__m, __txn);
+    call InitVerification();
     call LibraAccount_deposit_with_sender_and_metadata(payee, sender, to_deposit, metadata);
 }
 
@@ -1605,18 +1760,24 @@ ensures old(b#Boolean(Boolean(!(b#Boolean(ExistsResource(__m, LibraCoin_MintCapa
     var __tmp: Value;
     var __frame: int;
     var __saved_m: Memory;
+    var debug#LibraAccount#mint_to_address#0#payee: [Position]Value;
+    var debug#LibraAccount#mint_to_address#1#amount: [Position]Value;
 
     // initialize function execution
     assume !__abort_flag;
     __saved_m := __m;
     __frame := __local_counter;
     __local_counter := __local_counter + 9;
+    debug#LibraAccount#mint_to_address#0#payee := EmptyPositionMap;
+    debug#LibraAccount#mint_to_address#1#amount := EmptyPositionMap;
 
     // process and type check arguments
     assume is#Address(payee);
     __m := UpdateLocal(__m, __frame + 0, payee);
+    debug#LibraAccount#mint_to_address#0#payee := debug#LibraAccount#mint_to_address#0#payee[Position(8679) := payee];
     assume IsValidU64(amount);
     __m := UpdateLocal(__m, __frame + 1, amount);
+    debug#LibraAccount#mint_to_address#1#amount := debug#LibraAccount#mint_to_address#1#amount[Position(8679) := amount];
 
     // bytecode translation starts here
     call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 0));
@@ -1662,7 +1823,7 @@ Label_Abort:
 
 procedure LibraAccount_mint_to_address_verify (payee: Value, amount: Value) returns ()
 {
-    assume ExistsTxnSenderAccount(__m, __txn);
+    call InitVerification();
     call LibraAccount_mint_to_address(payee, amount);
 }
 
@@ -1684,18 +1845,28 @@ ensures old(b#Boolean(Boolean(i#Integer(SelectField(SelectField(Dereference(__m,
     var __tmp: Value;
     var __frame: int;
     var __saved_m: Memory;
+    var debug#LibraAccount#withdraw_from_account#0#account: [Position]Value;
+    var debug#LibraAccount#withdraw_from_account#1#amount: [Position]Value;
+    var debug#LibraAccount#withdraw_from_account#2#to_withdraw: [Position]Value;
+    var debug#LibraAccount#withdraw_from_account#3#__ret: [Position]Value;
 
     // initialize function execution
     assume !__abort_flag;
     __saved_m := __m;
     __frame := __local_counter;
     __local_counter := __local_counter + 8;
+    debug#LibraAccount#withdraw_from_account#0#account := EmptyPositionMap;
+    debug#LibraAccount#withdraw_from_account#1#amount := EmptyPositionMap;
+    debug#LibraAccount#withdraw_from_account#2#to_withdraw := EmptyPositionMap;
+    debug#LibraAccount#withdraw_from_account#3#__ret := EmptyPositionMap;
 
     // process and type check arguments
     assume is#Vector(Dereference(__m, account));
     assume IsValidReferenceParameter(__m, __frame, account);
+    debug#LibraAccount#withdraw_from_account#0#account := debug#LibraAccount#withdraw_from_account#0#account[Position(10231) := Dereference(__m, account)];
     assume IsValidU64(amount);
     __m := UpdateLocal(__m, __frame + 1, amount);
+    debug#LibraAccount#withdraw_from_account#1#amount := debug#LibraAccount#withdraw_from_account#1#amount[Position(10231) := amount];
 
     // bytecode translation starts here
     call __t3 := CopyOrMoveRef(account);
@@ -1713,22 +1884,25 @@ ensures old(b#Boolean(Boolean(i#Integer(SelectField(SelectField(Dereference(__m,
 
     call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 6));
     __m := UpdateLocal(__m, __frame + 2, __tmp);
+    debug#LibraAccount#withdraw_from_account#2#to_withdraw := debug#LibraAccount#withdraw_from_account#2#to_withdraw[Position(10516) := __tmp];
 
     call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 2));
     __m := UpdateLocal(__m, __frame + 7, __tmp);
 
     __ret0 := GetLocal(__m, __frame + 7);
+    debug#LibraAccount#withdraw_from_account#3#__ret := debug#LibraAccount#withdraw_from_account#3#__ret[Position(10600) := __ret0];
     return;
 
 Label_Abort:
     __abort_flag := true;
     __m := __saved_m;
     __ret0 := DefaultValue;
+    debug#LibraAccount#withdraw_from_account#3#__ret := debug#LibraAccount#withdraw_from_account#3#__ret[Position(10630) := __ret0];
 }
 
 procedure LibraAccount_withdraw_from_account_verify (account: Reference, amount: Value) returns (__ret0: Value)
 {
-    assume ExistsTxnSenderAccount(__m, __txn);
+    call InitVerification();
     call __ret0 := LibraAccount_withdraw_from_account(account, amount);
 }
 
@@ -1754,16 +1928,23 @@ ensures old(b#Boolean(SelectField(Dereference(__m, GetResourceReference(LibraAcc
     var __tmp: Value;
     var __frame: int;
     var __saved_m: Memory;
+    var debug#LibraAccount#withdraw_from_sender#0#amount: [Position]Value;
+    var debug#LibraAccount#withdraw_from_sender#1#sender_account: [Position]Value;
+    var debug#LibraAccount#withdraw_from_sender#2#__ret: [Position]Value;
 
     // initialize function execution
     assume !__abort_flag;
     __saved_m := __m;
     __frame := __local_counter;
     __local_counter := __local_counter + 11;
+    debug#LibraAccount#withdraw_from_sender#0#amount := EmptyPositionMap;
+    debug#LibraAccount#withdraw_from_sender#1#sender_account := EmptyPositionMap;
+    debug#LibraAccount#withdraw_from_sender#2#__ret := EmptyPositionMap;
 
     // process and type check arguments
     assume IsValidU64(amount);
     __m := UpdateLocal(__m, __frame + 0, amount);
+    debug#LibraAccount#withdraw_from_sender#0#amount := debug#LibraAccount#withdraw_from_sender#0#amount[Position(10712) := amount];
 
     // bytecode translation starts here
     call __tmp := GetTxnSenderAddress();
@@ -1803,17 +1984,19 @@ Label_9:
     __m := UpdateLocal(__m, __frame + 10, __t10);
 
     __ret0 := GetLocal(__m, __frame + 10);
+    debug#LibraAccount#withdraw_from_sender#2#__ret := debug#LibraAccount#withdraw_from_sender#2#__ret[Position(11484) := __ret0];
     return;
 
 Label_Abort:
     __abort_flag := true;
     __m := __saved_m;
     __ret0 := DefaultValue;
+    debug#LibraAccount#withdraw_from_sender#2#__ret := debug#LibraAccount#withdraw_from_sender#2#__ret[Position(11569) := __ret0];
 }
 
 procedure LibraAccount_withdraw_from_sender_verify (amount: Value) returns (__ret0: Value)
 {
-    assume ExistsTxnSenderAccount(__m, __txn);
+    call InitVerification();
     call __ret0 := LibraAccount_withdraw_from_sender(amount);
 }
 
@@ -1837,18 +2020,28 @@ ensures old(b#Boolean(Boolean(!(b#Boolean(ExistsResource(__m, LibraAccount_T_typ
     var __tmp: Value;
     var __frame: int;
     var __saved_m: Memory;
+    var debug#LibraAccount#withdraw_with_capability#0#cap: [Position]Value;
+    var debug#LibraAccount#withdraw_with_capability#1#amount: [Position]Value;
+    var debug#LibraAccount#withdraw_with_capability#2#account: [Position]Value;
+    var debug#LibraAccount#withdraw_with_capability#3#__ret: [Position]Value;
 
     // initialize function execution
     assume !__abort_flag;
     __saved_m := __m;
     __frame := __local_counter;
     __local_counter := __local_counter + 10;
+    debug#LibraAccount#withdraw_with_capability#0#cap := EmptyPositionMap;
+    debug#LibraAccount#withdraw_with_capability#1#amount := EmptyPositionMap;
+    debug#LibraAccount#withdraw_with_capability#2#account := EmptyPositionMap;
+    debug#LibraAccount#withdraw_with_capability#3#__ret := EmptyPositionMap;
 
     // process and type check arguments
     assume is#Vector(Dereference(__m, cap));
     assume IsValidReferenceParameter(__m, __frame, cap);
+    debug#LibraAccount#withdraw_with_capability#0#cap := debug#LibraAccount#withdraw_with_capability#0#cap[Position(11652) := Dereference(__m, cap)];
     assume IsValidU64(amount);
     __m := UpdateLocal(__m, __frame + 1, amount);
+    debug#LibraAccount#withdraw_with_capability#1#amount := debug#LibraAccount#withdraw_with_capability#1#amount[Position(11652) := amount];
 
     // bytecode translation starts here
     call __t3 := CopyOrMoveRef(cap);
@@ -1876,17 +2069,19 @@ ensures old(b#Boolean(Boolean(!(b#Boolean(ExistsResource(__m, LibraAccount_T_typ
     __m := UpdateLocal(__m, __frame + 9, __t9);
 
     __ret0 := GetLocal(__m, __frame + 9);
+    debug#LibraAccount#withdraw_with_capability#3#__ret := debug#LibraAccount#withdraw_with_capability#3#__ret[Position(12194) := __ret0];
     return;
 
 Label_Abort:
     __abort_flag := true;
     __m := __saved_m;
     __ret0 := DefaultValue;
+    debug#LibraAccount#withdraw_with_capability#3#__ret := debug#LibraAccount#withdraw_with_capability#3#__ret[Position(12262) := __ret0];
 }
 
 procedure LibraAccount_withdraw_with_capability_verify (cap: Reference, amount: Value) returns (__ret0: Value)
 {
-    assume ExistsTxnSenderAccount(__m, __txn);
+    call InitVerification();
     call __ret0 := LibraAccount_withdraw_with_capability(cap, amount);
 }
 
@@ -1917,12 +2112,20 @@ ensures old(b#Boolean(Boolean(!(b#Boolean(ExistsResource(__m, LibraAccount_T_typ
     var __tmp: Value;
     var __frame: int;
     var __saved_m: Memory;
+    var debug#LibraAccount#extract_sender_withdrawal_capability#0#sender: [Position]Value;
+    var debug#LibraAccount#extract_sender_withdrawal_capability#1#sender_account: [Position]Value;
+    var debug#LibraAccount#extract_sender_withdrawal_capability#2#delegated_ref: [Position]Value;
+    var debug#LibraAccount#extract_sender_withdrawal_capability#3#__ret: [Position]Value;
 
     // initialize function execution
     assume !__abort_flag;
     __saved_m := __m;
     __frame := __local_counter;
     __local_counter := __local_counter + 15;
+    debug#LibraAccount#extract_sender_withdrawal_capability#0#sender := EmptyPositionMap;
+    debug#LibraAccount#extract_sender_withdrawal_capability#1#sender_account := EmptyPositionMap;
+    debug#LibraAccount#extract_sender_withdrawal_capability#2#delegated_ref := EmptyPositionMap;
+    debug#LibraAccount#extract_sender_withdrawal_capability#3#__ret := EmptyPositionMap;
 
     // process and type check arguments
 
@@ -1932,6 +2135,7 @@ ensures old(b#Boolean(Boolean(!(b#Boolean(ExistsResource(__m, LibraAccount_T_typ
 
     call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 3));
     __m := UpdateLocal(__m, __frame + 0, __tmp);
+    debug#LibraAccount#extract_sender_withdrawal_capability#0#sender := debug#LibraAccount#extract_sender_withdrawal_capability#0#sender[Position(12840) := __tmp];
 
     call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 0));
     __m := UpdateLocal(__m, __frame + 4, __tmp);
@@ -1976,17 +2180,19 @@ Label_13:
     __m := UpdateLocal(__m, __frame + 14, __tmp);
 
     __ret0 := GetLocal(__m, __frame + 14);
+    debug#LibraAccount#extract_sender_withdrawal_capability#3#__ret := debug#LibraAccount#extract_sender_withdrawal_capability#3#__ret[Position(13266) := __ret0];
     return;
 
 Label_Abort:
     __abort_flag := true;
     __m := __saved_m;
     __ret0 := DefaultValue;
+    debug#LibraAccount#extract_sender_withdrawal_capability#3#__ret := debug#LibraAccount#extract_sender_withdrawal_capability#3#__ret[Position(13343) := __ret0];
 }
 
 procedure LibraAccount_extract_sender_withdrawal_capability_verify () returns (__ret0: Value)
 {
-    assume ExistsTxnSenderAccount(__m, __txn);
+    call InitVerification();
     call __ret0 := LibraAccount_extract_sender_withdrawal_capability();
 }
 
@@ -2010,16 +2216,23 @@ ensures old(b#Boolean(Boolean(!(b#Boolean(ExistsResource(__m, LibraAccount_T_typ
     var __tmp: Value;
     var __frame: int;
     var __saved_m: Memory;
+    var debug#LibraAccount#restore_withdrawal_capability#0#cap: [Position]Value;
+    var debug#LibraAccount#restore_withdrawal_capability#1#account_address: [Position]Value;
+    var debug#LibraAccount#restore_withdrawal_capability#2#account: [Position]Value;
 
     // initialize function execution
     assume !__abort_flag;
     __saved_m := __m;
     __frame := __local_counter;
     __local_counter := __local_counter + 10;
+    debug#LibraAccount#restore_withdrawal_capability#0#cap := EmptyPositionMap;
+    debug#LibraAccount#restore_withdrawal_capability#1#account_address := EmptyPositionMap;
+    debug#LibraAccount#restore_withdrawal_capability#2#account := EmptyPositionMap;
 
     // process and type check arguments
     assume is#Vector(cap);
     __m := UpdateLocal(__m, __frame + 0, cap);
+    debug#LibraAccount#restore_withdrawal_capability#0#cap := debug#LibraAccount#restore_withdrawal_capability#0#cap[Position(13429) := cap];
 
     // bytecode translation starts here
     call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 0));
@@ -2030,6 +2243,7 @@ ensures old(b#Boolean(Boolean(!(b#Boolean(ExistsResource(__m, LibraAccount_T_typ
 
     call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 4));
     __m := UpdateLocal(__m, __frame + 1, __tmp);
+    debug#LibraAccount#restore_withdrawal_capability#1#account_address := debug#LibraAccount#restore_withdrawal_capability#1#account_address[Position(13808) := __tmp];
 
     call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 1));
     __m := UpdateLocal(__m, __frame + 5, __tmp);
@@ -2057,7 +2271,7 @@ Label_Abort:
 
 procedure LibraAccount_restore_withdrawal_capability_verify (cap: Value) returns ()
 {
-    assume ExistsTxnSenderAccount(__m, __txn);
+    call InitVerification();
     call LibraAccount_restore_withdrawal_capability(cap);
 }
 
@@ -2082,22 +2296,34 @@ ensures b#Boolean(Boolean(b#Boolean(Boolean(!(b#Boolean(Boolean(!(b#Boolean(old(
     var __tmp: Value;
     var __frame: int;
     var __saved_m: Memory;
+    var debug#LibraAccount#pay_from_capability#0#payee: [Position]Value;
+    var debug#LibraAccount#pay_from_capability#1#cap: [Position]Value;
+    var debug#LibraAccount#pay_from_capability#2#amount: [Position]Value;
+    var debug#LibraAccount#pay_from_capability#3#metadata: [Position]Value;
 
     // initialize function execution
     assume !__abort_flag;
     __saved_m := __m;
     __frame := __local_counter;
     __local_counter := __local_counter + 16;
+    debug#LibraAccount#pay_from_capability#0#payee := EmptyPositionMap;
+    debug#LibraAccount#pay_from_capability#1#cap := EmptyPositionMap;
+    debug#LibraAccount#pay_from_capability#2#amount := EmptyPositionMap;
+    debug#LibraAccount#pay_from_capability#3#metadata := EmptyPositionMap;
 
     // process and type check arguments
     assume is#Address(payee);
     __m := UpdateLocal(__m, __frame + 0, payee);
+    debug#LibraAccount#pay_from_capability#0#payee := debug#LibraAccount#pay_from_capability#0#payee[Position(14433) := payee];
     assume is#Vector(Dereference(__m, cap));
     assume IsValidReferenceParameter(__m, __frame, cap);
+    debug#LibraAccount#pay_from_capability#1#cap := debug#LibraAccount#pay_from_capability#1#cap[Position(14433) := Dereference(__m, cap)];
     assume IsValidU64(amount);
     __m := UpdateLocal(__m, __frame + 2, amount);
+    debug#LibraAccount#pay_from_capability#2#amount := debug#LibraAccount#pay_from_capability#2#amount[Position(14433) := amount];
     assume is#ByteArray(metadata);
     __m := UpdateLocal(__m, __frame + 3, metadata);
+    debug#LibraAccount#pay_from_capability#3#metadata := debug#LibraAccount#pay_from_capability#3#metadata[Position(14433) := metadata];
 
     // bytecode translation starts here
     call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 0));
@@ -2155,7 +2381,7 @@ Label_Abort:
 
 procedure LibraAccount_pay_from_capability_verify (payee: Value, cap: Reference, amount: Value, metadata: Value) returns ()
 {
-    assume ExistsTxnSenderAccount(__m, __txn);
+    call InitVerification();
     call LibraAccount_pay_from_capability(payee, cap, amount, metadata);
 }
 
@@ -2186,20 +2412,29 @@ ensures old(b#Boolean(SelectField(Dereference(__m, GetResourceReference(LibraAcc
     var __tmp: Value;
     var __frame: int;
     var __saved_m: Memory;
+    var debug#LibraAccount#pay_from_sender_with_metadata#0#payee: [Position]Value;
+    var debug#LibraAccount#pay_from_sender_with_metadata#1#amount: [Position]Value;
+    var debug#LibraAccount#pay_from_sender_with_metadata#2#metadata: [Position]Value;
 
     // initialize function execution
     assume !__abort_flag;
     __saved_m := __m;
     __frame := __local_counter;
     __local_counter := __local_counter + 16;
+    debug#LibraAccount#pay_from_sender_with_metadata#0#payee := EmptyPositionMap;
+    debug#LibraAccount#pay_from_sender_with_metadata#1#amount := EmptyPositionMap;
+    debug#LibraAccount#pay_from_sender_with_metadata#2#metadata := EmptyPositionMap;
 
     // process and type check arguments
     assume is#Address(payee);
     __m := UpdateLocal(__m, __frame + 0, payee);
+    debug#LibraAccount#pay_from_sender_with_metadata#0#payee := debug#LibraAccount#pay_from_sender_with_metadata#0#payee[Position(16060) := payee];
     assume IsValidU64(amount);
     __m := UpdateLocal(__m, __frame + 1, amount);
+    debug#LibraAccount#pay_from_sender_with_metadata#1#amount := debug#LibraAccount#pay_from_sender_with_metadata#1#amount[Position(16060) := amount];
     assume is#ByteArray(metadata);
     __m := UpdateLocal(__m, __frame + 2, metadata);
+    debug#LibraAccount#pay_from_sender_with_metadata#2#metadata := debug#LibraAccount#pay_from_sender_with_metadata#2#metadata[Position(16060) := metadata];
 
     // bytecode translation starts here
     call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 0));
@@ -2269,7 +2504,7 @@ Label_Abort:
 
 procedure LibraAccount_pay_from_sender_with_metadata_verify (payee: Value, amount: Value, metadata: Value) returns ()
 {
-    assume ExistsTxnSenderAccount(__m, __txn);
+    call InitVerification();
     call LibraAccount_pay_from_sender_with_metadata(payee, amount, metadata);
 }
 
@@ -2295,18 +2530,24 @@ ensures old(b#Boolean(SelectField(Dereference(__m, GetResourceReference(LibraAcc
     var __tmp: Value;
     var __frame: int;
     var __saved_m: Memory;
+    var debug#LibraAccount#pay_from_sender#0#payee: [Position]Value;
+    var debug#LibraAccount#pay_from_sender#1#amount: [Position]Value;
 
     // initialize function execution
     assume !__abort_flag;
     __saved_m := __m;
     __frame := __local_counter;
     __local_counter := __local_counter + 10;
+    debug#LibraAccount#pay_from_sender#0#payee := EmptyPositionMap;
+    debug#LibraAccount#pay_from_sender#1#amount := EmptyPositionMap;
 
     // process and type check arguments
     assume is#Address(payee);
     __m := UpdateLocal(__m, __frame + 0, payee);
+    debug#LibraAccount#pay_from_sender#0#payee := debug#LibraAccount#pay_from_sender#0#payee[Position(17668) := payee];
     assume IsValidU64(amount);
     __m := UpdateLocal(__m, __frame + 1, amount);
+    debug#LibraAccount#pay_from_sender#1#amount := debug#LibraAccount#pay_from_sender#1#amount[Position(17668) := amount];
 
     // bytecode translation starts here
     call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 0));
@@ -2350,7 +2591,7 @@ Label_Abort:
 
 procedure LibraAccount_pay_from_sender_verify (payee: Value, amount: Value) returns ()
 {
-    assume ExistsTxnSenderAccount(__m, __txn);
+    call InitVerification();
     call LibraAccount_pay_from_sender(payee, amount);
 }
 
@@ -2365,18 +2606,24 @@ ensures b#Boolean(Boolean(IsEqual(SelectField(Dereference(__m, account), LibraAc
     var __tmp: Value;
     var __frame: int;
     var __saved_m: Memory;
+    var debug#LibraAccount#rotate_authentication_key_for_account#0#account: [Position]Value;
+    var debug#LibraAccount#rotate_authentication_key_for_account#1#new_authentication_key: [Position]Value;
 
     // initialize function execution
     assume !__abort_flag;
     __saved_m := __m;
     __frame := __local_counter;
     __local_counter := __local_counter + 5;
+    debug#LibraAccount#rotate_authentication_key_for_account#0#account := EmptyPositionMap;
+    debug#LibraAccount#rotate_authentication_key_for_account#1#new_authentication_key := EmptyPositionMap;
 
     // process and type check arguments
     assume is#Vector(Dereference(__m, account));
     assume IsValidReferenceParameter(__m, __frame, account);
+    debug#LibraAccount#rotate_authentication_key_for_account#0#account := debug#LibraAccount#rotate_authentication_key_for_account#0#account[Position(18853) := Dereference(__m, account)];
     assume is#ByteArray(new_authentication_key);
     __m := UpdateLocal(__m, __frame + 1, new_authentication_key);
+    debug#LibraAccount#rotate_authentication_key_for_account#1#new_authentication_key := debug#LibraAccount#rotate_authentication_key_for_account#1#new_authentication_key[Position(18853) := new_authentication_key];
 
     // bytecode translation starts here
     call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 1));
@@ -2397,7 +2644,7 @@ Label_Abort:
 
 procedure LibraAccount_rotate_authentication_key_for_account_verify (account: Reference, new_authentication_key: Value) returns ()
 {
-    assume ExistsTxnSenderAccount(__m, __txn);
+    call InitVerification();
     call LibraAccount_rotate_authentication_key_for_account(account, new_authentication_key);
 }
 
@@ -2421,16 +2668,21 @@ ensures old(b#Boolean(Boolean(!(b#Boolean(ExistsResource(__m, LibraAccount_T_typ
     var __tmp: Value;
     var __frame: int;
     var __saved_m: Memory;
+    var debug#LibraAccount#rotate_authentication_key#0#new_authentication_key: [Position]Value;
+    var debug#LibraAccount#rotate_authentication_key#1#sender_account: [Position]Value;
 
     // initialize function execution
     assume !__abort_flag;
     __saved_m := __m;
     __frame := __local_counter;
     __local_counter := __local_counter + 10;
+    debug#LibraAccount#rotate_authentication_key#0#new_authentication_key := EmptyPositionMap;
+    debug#LibraAccount#rotate_authentication_key#1#sender_account := EmptyPositionMap;
 
     // process and type check arguments
     assume is#ByteArray(new_authentication_key);
     __m := UpdateLocal(__m, __frame + 0, new_authentication_key);
+    debug#LibraAccount#rotate_authentication_key#0#new_authentication_key := debug#LibraAccount#rotate_authentication_key#0#new_authentication_key[Position(19253) := new_authentication_key];
 
     // bytecode translation starts here
     call __tmp := GetTxnSenderAddress();
@@ -2475,7 +2727,7 @@ Label_Abort:
 
 procedure LibraAccount_rotate_authentication_key_verify (new_authentication_key: Value) returns ()
 {
-    assume ExistsTxnSenderAccount(__m, __txn);
+    call InitVerification();
     call LibraAccount_rotate_authentication_key(new_authentication_key);
 }
 
@@ -2494,18 +2746,24 @@ ensures old(b#Boolean(Boolean(!(b#Boolean(ExistsResource(__m, LibraAccount_T_typ
     var __tmp: Value;
     var __frame: int;
     var __saved_m: Memory;
+    var debug#LibraAccount#rotate_authentication_key_with_capability#0#cap: [Position]Value;
+    var debug#LibraAccount#rotate_authentication_key_with_capability#1#new_authentication_key: [Position]Value;
 
     // initialize function execution
     assume !__abort_flag;
     __saved_m := __m;
     __frame := __local_counter;
     __local_counter := __local_counter + 7;
+    debug#LibraAccount#rotate_authentication_key_with_capability#0#cap := EmptyPositionMap;
+    debug#LibraAccount#rotate_authentication_key_with_capability#1#new_authentication_key := EmptyPositionMap;
 
     // process and type check arguments
     assume is#Vector(Dereference(__m, cap));
     assume IsValidReferenceParameter(__m, __frame, cap);
+    debug#LibraAccount#rotate_authentication_key_with_capability#0#cap := debug#LibraAccount#rotate_authentication_key_with_capability#0#cap[Position(20225) := Dereference(__m, cap)];
     assume is#ByteArray(new_authentication_key);
     __m := UpdateLocal(__m, __frame + 1, new_authentication_key);
+    debug#LibraAccount#rotate_authentication_key_with_capability#1#new_authentication_key := debug#LibraAccount#rotate_authentication_key_with_capability#1#new_authentication_key[Position(20225) := new_authentication_key];
 
     // bytecode translation starts here
     call __t2 := CopyOrMoveRef(cap);
@@ -2534,7 +2792,7 @@ Label_Abort:
 
 procedure LibraAccount_rotate_authentication_key_with_capability_verify (cap: Reference, new_authentication_key: Value) returns ()
 {
-    assume ExistsTxnSenderAccount(__m, __txn);
+    call InitVerification();
     call LibraAccount_rotate_authentication_key_with_capability(cap, new_authentication_key);
 }
 
@@ -2562,12 +2820,18 @@ ensures old(b#Boolean(Boolean(!(b#Boolean(ExistsResource(__m, LibraAccount_T_typ
     var __tmp: Value;
     var __frame: int;
     var __saved_m: Memory;
+    var debug#LibraAccount#extract_sender_key_rotation_capability#0#sender: [Position]Value;
+    var debug#LibraAccount#extract_sender_key_rotation_capability#1#delegated_ref: [Position]Value;
+    var debug#LibraAccount#extract_sender_key_rotation_capability#2#__ret: [Position]Value;
 
     // initialize function execution
     assume !__abort_flag;
     __saved_m := __m;
     __frame := __local_counter;
     __local_counter := __local_counter + 13;
+    debug#LibraAccount#extract_sender_key_rotation_capability#0#sender := EmptyPositionMap;
+    debug#LibraAccount#extract_sender_key_rotation_capability#1#delegated_ref := EmptyPositionMap;
+    debug#LibraAccount#extract_sender_key_rotation_capability#2#__ret := EmptyPositionMap;
 
     // process and type check arguments
 
@@ -2577,6 +2841,7 @@ ensures old(b#Boolean(Boolean(!(b#Boolean(ExistsResource(__m, LibraAccount_T_typ
 
     call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 2));
     __m := UpdateLocal(__m, __frame + 0, __tmp);
+    debug#LibraAccount#extract_sender_key_rotation_capability#0#sender := debug#LibraAccount#extract_sender_key_rotation_capability#0#sender[Position(21202) := __tmp];
 
     call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 0));
     __m := UpdateLocal(__m, __frame + 3, __tmp);
@@ -2617,17 +2882,19 @@ Label_11:
     __m := UpdateLocal(__m, __frame + 12, __tmp);
 
     __ret0 := GetLocal(__m, __frame + 12);
+    debug#LibraAccount#extract_sender_key_rotation_capability#2#__ret := debug#LibraAccount#extract_sender_key_rotation_capability#2#__ret[Position(21585) := __ret0];
     return;
 
 Label_Abort:
     __abort_flag := true;
     __m := __saved_m;
     __ret0 := DefaultValue;
+    debug#LibraAccount#extract_sender_key_rotation_capability#2#__ret := debug#LibraAccount#extract_sender_key_rotation_capability#2#__ret[Position(21663) := __ret0];
 }
 
 procedure LibraAccount_extract_sender_key_rotation_capability_verify () returns (__ret0: Value)
 {
-    assume ExistsTxnSenderAccount(__m, __txn);
+    call InitVerification();
     call __ret0 := LibraAccount_extract_sender_key_rotation_capability();
 }
 
@@ -2651,16 +2918,23 @@ ensures old(b#Boolean(Boolean(!(b#Boolean(ExistsResource(__m, LibraAccount_T_typ
     var __tmp: Value;
     var __frame: int;
     var __saved_m: Memory;
+    var debug#LibraAccount#restore_key_rotation_capability#0#cap: [Position]Value;
+    var debug#LibraAccount#restore_key_rotation_capability#1#account_address: [Position]Value;
+    var debug#LibraAccount#restore_key_rotation_capability#2#account: [Position]Value;
 
     // initialize function execution
     assume !__abort_flag;
     __saved_m := __m;
     __frame := __local_counter;
     __local_counter := __local_counter + 10;
+    debug#LibraAccount#restore_key_rotation_capability#0#cap := EmptyPositionMap;
+    debug#LibraAccount#restore_key_rotation_capability#1#account_address := EmptyPositionMap;
+    debug#LibraAccount#restore_key_rotation_capability#2#account := EmptyPositionMap;
 
     // process and type check arguments
     assume is#Vector(cap);
     __m := UpdateLocal(__m, __frame + 0, cap);
+    debug#LibraAccount#restore_key_rotation_capability#0#cap := debug#LibraAccount#restore_key_rotation_capability#0#cap[Position(21751) := cap];
 
     // bytecode translation starts here
     call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 0));
@@ -2671,6 +2945,7 @@ ensures old(b#Boolean(Boolean(!(b#Boolean(ExistsResource(__m, LibraAccount_T_typ
 
     call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 4));
     __m := UpdateLocal(__m, __frame + 1, __tmp);
+    debug#LibraAccount#restore_key_rotation_capability#1#account_address := debug#LibraAccount#restore_key_rotation_capability#1#account_address[Position(22136) := __tmp];
 
     call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 1));
     __m := UpdateLocal(__m, __frame + 5, __tmp);
@@ -2698,7 +2973,7 @@ Label_Abort:
 
 procedure LibraAccount_restore_key_rotation_capability_verify (cap: Value) returns ()
 {
-    assume ExistsTxnSenderAccount(__m, __txn);
+    call InitVerification();
     call LibraAccount_restore_key_rotation_capability(cap);
 }
 
@@ -2733,16 +3008,21 @@ ensures old(b#Boolean(ExistsResource(__m, LibraAccount_T_type_value(), a#Address
     var __tmp: Value;
     var __frame: int;
     var __saved_m: Memory;
+    var debug#LibraAccount#create_account#0#fresh_address: [Position]Value;
+    var debug#LibraAccount#create_account#1#generator: [Position]Value;
 
     // initialize function execution
     assume !__abort_flag;
     __saved_m := __m;
     __frame := __local_counter;
     __local_counter := __local_counter + 19;
+    debug#LibraAccount#create_account#0#fresh_address := EmptyPositionMap;
+    debug#LibraAccount#create_account#1#generator := EmptyPositionMap;
 
     // process and type check arguments
     assume is#Address(fresh_address);
     __m := UpdateLocal(__m, __frame + 0, fresh_address);
+    debug#LibraAccount#create_account#0#fresh_address := debug#LibraAccount#create_account#0#fresh_address[Position(22651) := fresh_address];
 
     // bytecode translation starts here
     call __tmp := LdConst(0);
@@ -2753,6 +3033,7 @@ ensures old(b#Boolean(ExistsResource(__m, LibraAccount_T_type_value(), a#Address
 
     call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 3));
     __m := UpdateLocal(__m, __frame + 1, __tmp);
+    debug#LibraAccount#create_account#1#generator := debug#LibraAccount#create_account#1#generator[Position(23014) := __tmp];
 
     call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 0));
     __m := UpdateLocal(__m, __frame + 4, __tmp);
@@ -2788,6 +3069,7 @@ ensures old(b#Boolean(ExistsResource(__m, LibraAccount_T_type_value(), a#Address
     assume is#Vector(__t12);
 
     __m := UpdateLocal(__m, __frame + 12, __t12);
+    debug#LibraAccount#create_account#1#generator := debug#LibraAccount#create_account#1#generator[Position(23414) := GetLocal(__m, __frame + 1)];
 
     call __t13 := BorrowLoc(__frame + 1);
 
@@ -2799,6 +3081,7 @@ ensures old(b#Boolean(ExistsResource(__m, LibraAccount_T_type_value(), a#Address
     assume is#Vector(__t15);
 
     __m := UpdateLocal(__m, __frame + 15, __t15);
+    debug#LibraAccount#create_account#1#generator := debug#LibraAccount#create_account#1#generator[Position(23535) := GetLocal(__m, __frame + 1)];
 
     call __tmp := LdConst(0);
     __m := UpdateLocal(__m, __frame + 16, __tmp);
@@ -2821,7 +3104,7 @@ Label_Abort:
 
 procedure LibraAccount_create_account_verify (fresh_address: Value) returns ()
 {
-    assume ExistsTxnSenderAccount(__m, __txn);
+    call InitVerification();
     call LibraAccount_create_account(fresh_address);
 }
 
@@ -2845,18 +3128,24 @@ ensures old(b#Boolean(ExistsResource(__m, LibraAccount_T_type_value(), a#Address
     var __tmp: Value;
     var __frame: int;
     var __saved_m: Memory;
+    var debug#LibraAccount#create_new_account#0#fresh_address: [Position]Value;
+    var debug#LibraAccount#create_new_account#1#initial_balance: [Position]Value;
 
     // initialize function execution
     assume !__abort_flag;
     __saved_m := __m;
     __frame := __local_counter;
     __local_counter := __local_counter + 8;
+    debug#LibraAccount#create_new_account#0#fresh_address := EmptyPositionMap;
+    debug#LibraAccount#create_new_account#1#initial_balance := EmptyPositionMap;
 
     // process and type check arguments
     assume is#Address(fresh_address);
     __m := UpdateLocal(__m, __frame + 0, fresh_address);
+    debug#LibraAccount#create_new_account#0#fresh_address := debug#LibraAccount#create_new_account#0#fresh_address[Position(23890) := fresh_address];
     assume IsValidU64(initial_balance);
     __m := UpdateLocal(__m, __frame + 1, initial_balance);
+    debug#LibraAccount#create_new_account#1#initial_balance := debug#LibraAccount#create_new_account#1#initial_balance[Position(23890) := initial_balance];
 
     // bytecode translation starts here
     call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 0));
@@ -2896,7 +3185,7 @@ Label_Abort:
 
 procedure LibraAccount_create_new_account_verify (fresh_address: Value, initial_balance: Value) returns ()
 {
-    assume ExistsTxnSenderAccount(__m, __txn);
+    call InitVerification();
     call LibraAccount_create_new_account(fresh_address, initial_balance);
 }
 
@@ -2913,16 +3202,23 @@ ensures b#Boolean(Boolean(IsEqual(__ret0, SelectField(SelectField(Dereference(__
     var __tmp: Value;
     var __frame: int;
     var __saved_m: Memory;
+    var debug#LibraAccount#balance_for_account#0#account: [Position]Value;
+    var debug#LibraAccount#balance_for_account#1#balance_value: [Position]Value;
+    var debug#LibraAccount#balance_for_account#2#__ret: [Position]Value;
 
     // initialize function execution
     assume !__abort_flag;
     __saved_m := __m;
     __frame := __local_counter;
     __local_counter := __local_counter + 6;
+    debug#LibraAccount#balance_for_account#0#account := EmptyPositionMap;
+    debug#LibraAccount#balance_for_account#1#balance_value := EmptyPositionMap;
+    debug#LibraAccount#balance_for_account#2#__ret := EmptyPositionMap;
 
     // process and type check arguments
     assume is#Vector(Dereference(__m, account));
     assume IsValidReferenceParameter(__m, __frame, account);
+    debug#LibraAccount#balance_for_account#0#account := debug#LibraAccount#balance_for_account#0#account[Position(25151) := Dereference(__m, account)];
 
     // bytecode translation starts here
     call __t2 := CopyOrMoveRef(account);
@@ -2937,22 +3233,25 @@ ensures b#Boolean(Boolean(IsEqual(__ret0, SelectField(SelectField(Dereference(__
 
     call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 4));
     __m := UpdateLocal(__m, __frame + 1, __tmp);
+    debug#LibraAccount#balance_for_account#1#balance_value := debug#LibraAccount#balance_for_account#1#balance_value[Position(25285) := __tmp];
 
     call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 1));
     __m := UpdateLocal(__m, __frame + 5, __tmp);
 
     __ret0 := GetLocal(__m, __frame + 5);
+    debug#LibraAccount#balance_for_account#2#__ret := debug#LibraAccount#balance_for_account#2#__ret[Position(25350) := __ret0];
     return;
 
 Label_Abort:
     __abort_flag := true;
     __m := __saved_m;
     __ret0 := DefaultValue;
+    debug#LibraAccount#balance_for_account#2#__ret := debug#LibraAccount#balance_for_account#2#__ret[Position(25382) := __ret0];
 }
 
 procedure LibraAccount_balance_for_account_verify (account: Reference) returns (__ret0: Value)
 {
-    assume ExistsTxnSenderAccount(__m, __txn);
+    call InitVerification();
     call __ret0 := LibraAccount_balance_for_account(account);
 }
 
@@ -2970,16 +3269,21 @@ ensures old(b#Boolean(Boolean(!(b#Boolean(ExistsResource(__m, LibraAccount_T_typ
     var __tmp: Value;
     var __frame: int;
     var __saved_m: Memory;
+    var debug#LibraAccount#balance#0#addr: [Position]Value;
+    var debug#LibraAccount#balance#1#__ret: [Position]Value;
 
     // initialize function execution
     assume !__abort_flag;
     __saved_m := __m;
     __frame := __local_counter;
     __local_counter := __local_counter + 4;
+    debug#LibraAccount#balance#0#addr := EmptyPositionMap;
+    debug#LibraAccount#balance#1#__ret := EmptyPositionMap;
 
     // process and type check arguments
     assume is#Address(addr);
     __m := UpdateLocal(__m, __frame + 0, addr);
+    debug#LibraAccount#balance#0#addr := debug#LibraAccount#balance#0#addr[Position(25470) := addr];
 
     // bytecode translation starts here
     call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 0));
@@ -2995,17 +3299,19 @@ ensures old(b#Boolean(Boolean(!(b#Boolean(ExistsResource(__m, LibraAccount_T_typ
     __m := UpdateLocal(__m, __frame + 3, __t3);
 
     __ret0 := GetLocal(__m, __frame + 3);
+    debug#LibraAccount#balance#1#__ret := debug#LibraAccount#balance#1#__ret[Position(25643) := __ret0];
     return;
 
 Label_Abort:
     __abort_flag := true;
     __m := __saved_m;
     __ret0 := DefaultValue;
+    debug#LibraAccount#balance#1#__ret := debug#LibraAccount#balance#1#__ret[Position(25710) := __ret0];
 }
 
 procedure LibraAccount_balance_verify (addr: Value) returns (__ret0: Value)
 {
-    assume ExistsTxnSenderAccount(__m, __txn);
+    call InitVerification();
     call __ret0 := LibraAccount_balance(addr);
 }
 
@@ -3020,16 +3326,21 @@ ensures b#Boolean(Boolean(IsEqual(__ret0, SelectField(Dereference(__m, account),
     var __tmp: Value;
     var __frame: int;
     var __saved_m: Memory;
+    var debug#LibraAccount#sequence_number_for_account#0#account: [Position]Value;
+    var debug#LibraAccount#sequence_number_for_account#1#__ret: [Position]Value;
 
     // initialize function execution
     assume !__abort_flag;
     __saved_m := __m;
     __frame := __local_counter;
     __local_counter := __local_counter + 4;
+    debug#LibraAccount#sequence_number_for_account#0#account := EmptyPositionMap;
+    debug#LibraAccount#sequence_number_for_account#1#__ret := EmptyPositionMap;
 
     // process and type check arguments
     assume is#Vector(Dereference(__m, account));
     assume IsValidReferenceParameter(__m, __frame, account);
+    debug#LibraAccount#sequence_number_for_account#0#account := debug#LibraAccount#sequence_number_for_account#0#account[Position(25787) := Dereference(__m, account)];
 
     // bytecode translation starts here
     call __t1 := CopyOrMoveRef(account);
@@ -3041,17 +3352,19 @@ ensures b#Boolean(Boolean(IsEqual(__ret0, SelectField(Dereference(__m, account),
     __m := UpdateLocal(__m, __frame + 3, __tmp);
 
     __ret0 := GetLocal(__m, __frame + 3);
+    debug#LibraAccount#sequence_number_for_account#1#__ret := debug#LibraAccount#sequence_number_for_account#1#__ret[Position(25899) := __ret0];
     return;
 
 Label_Abort:
     __abort_flag := true;
     __m := __saved_m;
     __ret0 := DefaultValue;
+    debug#LibraAccount#sequence_number_for_account#1#__ret := debug#LibraAccount#sequence_number_for_account#1#__ret[Position(25945) := __ret0];
 }
 
 procedure LibraAccount_sequence_number_for_account_verify (account: Reference) returns (__ret0: Value)
 {
-    assume ExistsTxnSenderAccount(__m, __txn);
+    call InitVerification();
     call __ret0 := LibraAccount_sequence_number_for_account(account);
 }
 
@@ -3069,16 +3382,21 @@ ensures old(b#Boolean(Boolean(!(b#Boolean(ExistsResource(__m, LibraAccount_T_typ
     var __tmp: Value;
     var __frame: int;
     var __saved_m: Memory;
+    var debug#LibraAccount#sequence_number#0#addr: [Position]Value;
+    var debug#LibraAccount#sequence_number#1#__ret: [Position]Value;
 
     // initialize function execution
     assume !__abort_flag;
     __saved_m := __m;
     __frame := __local_counter;
     __local_counter := __local_counter + 4;
+    debug#LibraAccount#sequence_number#0#addr := EmptyPositionMap;
+    debug#LibraAccount#sequence_number#1#__ret := EmptyPositionMap;
 
     // process and type check arguments
     assume is#Address(addr);
     __m := UpdateLocal(__m, __frame + 0, addr);
+    debug#LibraAccount#sequence_number#0#addr := debug#LibraAccount#sequence_number#0#addr[Position(26004) := addr];
 
     // bytecode translation starts here
     call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 0));
@@ -3094,17 +3412,19 @@ ensures old(b#Boolean(Boolean(!(b#Boolean(ExistsResource(__m, LibraAccount_T_typ
     __m := UpdateLocal(__m, __frame + 3, __t3);
 
     __ret0 := GetLocal(__m, __frame + 3);
+    debug#LibraAccount#sequence_number#1#__ret := debug#LibraAccount#sequence_number#1#__ret[Position(26187) := __ret0];
     return;
 
 Label_Abort:
     __abort_flag := true;
     __m := __saved_m;
     __ret0 := DefaultValue;
+    debug#LibraAccount#sequence_number#1#__ret := debug#LibraAccount#sequence_number#1#__ret[Position(26262) := __ret0];
 }
 
 procedure LibraAccount_sequence_number_verify (addr: Value) returns (__ret0: Value)
 {
-    assume ExistsTxnSenderAccount(__m, __txn);
+    call InitVerification();
     call __ret0 := LibraAccount_sequence_number(addr);
 }
 
@@ -3123,16 +3443,21 @@ ensures old(b#Boolean(Boolean(!(b#Boolean(ExistsResource(__m, LibraAccount_T_typ
     var __tmp: Value;
     var __frame: int;
     var __saved_m: Memory;
+    var debug#LibraAccount#delegated_key_rotation_capability#0#addr: [Position]Value;
+    var debug#LibraAccount#delegated_key_rotation_capability#1#__ret: [Position]Value;
 
     // initialize function execution
     assume !__abort_flag;
     __saved_m := __m;
     __frame := __local_counter;
     __local_counter := __local_counter + 5;
+    debug#LibraAccount#delegated_key_rotation_capability#0#addr := EmptyPositionMap;
+    debug#LibraAccount#delegated_key_rotation_capability#1#__ret := EmptyPositionMap;
 
     // process and type check arguments
     assume is#Address(addr);
     __m := UpdateLocal(__m, __frame + 0, addr);
+    debug#LibraAccount#delegated_key_rotation_capability#0#addr := debug#LibraAccount#delegated_key_rotation_capability#0#addr[Position(26354) := addr];
 
     // bytecode translation starts here
     call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 0));
@@ -3148,17 +3473,19 @@ ensures old(b#Boolean(Boolean(!(b#Boolean(ExistsResource(__m, LibraAccount_T_typ
     __m := UpdateLocal(__m, __frame + 4, __tmp);
 
     __ret0 := GetLocal(__m, __frame + 4);
+    debug#LibraAccount#delegated_key_rotation_capability#1#__ret := debug#LibraAccount#delegated_key_rotation_capability#1#__ret[Position(26574) := __ret0];
     return;
 
 Label_Abort:
     __abort_flag := true;
     __m := __saved_m;
     __ret0 := DefaultValue;
+    debug#LibraAccount#delegated_key_rotation_capability#1#__ret := debug#LibraAccount#delegated_key_rotation_capability#1#__ret[Position(26653) := __ret0];
 }
 
 procedure LibraAccount_delegated_key_rotation_capability_verify (addr: Value) returns (__ret0: Value)
 {
-    assume ExistsTxnSenderAccount(__m, __txn);
+    call InitVerification();
     call __ret0 := LibraAccount_delegated_key_rotation_capability(addr);
 }
 
@@ -3177,16 +3504,21 @@ ensures old(b#Boolean(Boolean(!(b#Boolean(ExistsResource(__m, LibraAccount_T_typ
     var __tmp: Value;
     var __frame: int;
     var __saved_m: Memory;
+    var debug#LibraAccount#delegated_withdrawal_capability#0#addr: [Position]Value;
+    var debug#LibraAccount#delegated_withdrawal_capability#1#__ret: [Position]Value;
 
     // initialize function execution
     assume !__abort_flag;
     __saved_m := __m;
     __frame := __local_counter;
     __local_counter := __local_counter + 5;
+    debug#LibraAccount#delegated_withdrawal_capability#0#addr := EmptyPositionMap;
+    debug#LibraAccount#delegated_withdrawal_capability#1#__ret := EmptyPositionMap;
 
     // process and type check arguments
     assume is#Address(addr);
     __m := UpdateLocal(__m, __frame + 0, addr);
+    debug#LibraAccount#delegated_withdrawal_capability#0#addr := debug#LibraAccount#delegated_withdrawal_capability#0#addr[Position(26744) := addr];
 
     // bytecode translation starts here
     call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 0));
@@ -3202,17 +3534,19 @@ ensures old(b#Boolean(Boolean(!(b#Boolean(ExistsResource(__m, LibraAccount_T_typ
     __m := UpdateLocal(__m, __frame + 4, __tmp);
 
     __ret0 := GetLocal(__m, __frame + 4);
+    debug#LibraAccount#delegated_withdrawal_capability#1#__ret := debug#LibraAccount#delegated_withdrawal_capability#1#__ret[Position(26960) := __ret0];
     return;
 
 Label_Abort:
     __abort_flag := true;
     __m := __saved_m;
     __ret0 := DefaultValue;
+    debug#LibraAccount#delegated_withdrawal_capability#1#__ret := debug#LibraAccount#delegated_withdrawal_capability#1#__ret[Position(27037) := __ret0];
 }
 
 procedure LibraAccount_delegated_withdrawal_capability_verify (addr: Value) returns (__ret0: Value)
 {
-    assume ExistsTxnSenderAccount(__m, __txn);
+    call InitVerification();
     call __ret0 := LibraAccount_delegated_withdrawal_capability(addr);
 }
 
@@ -3226,16 +3560,21 @@ ensures b#Boolean(Boolean((__ret0) == (SelectFieldFromRef(cap, LibraAccount_With
     var __tmp: Value;
     var __frame: int;
     var __saved_m: Memory;
+    var debug#LibraAccount#withdrawal_capability_address#0#cap: [Position]Value;
+    var debug#LibraAccount#withdrawal_capability_address#1#__ret: [Position]Value;
 
     // initialize function execution
     assume !__abort_flag;
     __saved_m := __m;
     __frame := __local_counter;
     __local_counter := __local_counter + 3;
+    debug#LibraAccount#withdrawal_capability_address#0#cap := EmptyPositionMap;
+    debug#LibraAccount#withdrawal_capability_address#1#__ret := EmptyPositionMap;
 
     // process and type check arguments
     assume is#Vector(Dereference(__m, cap));
     assume IsValidReferenceParameter(__m, __frame, cap);
+    debug#LibraAccount#withdrawal_capability_address#0#cap := debug#LibraAccount#withdrawal_capability_address#0#cap[Position(27134) := Dereference(__m, cap)];
 
     // bytecode translation starts here
     call __t1 := CopyOrMoveRef(cap);
@@ -3243,17 +3582,19 @@ ensures b#Boolean(Boolean((__ret0) == (SelectFieldFromRef(cap, LibraAccount_With
     call __t2 := BorrowField(__t1, LibraAccount_WithdrawalCapability_account_address);
 
     __ret0 := __t2;
+    debug#LibraAccount#withdrawal_capability_address#1#__ret := debug#LibraAccount#withdrawal_capability_address#1#__ret[Position(27273) := Dereference(__m, __ret0)];
     return;
 
 Label_Abort:
     __abort_flag := true;
     __m := __saved_m;
     __ret0 := DefaultReference;
+    debug#LibraAccount#withdrawal_capability_address#1#__ret := debug#LibraAccount#withdrawal_capability_address#1#__ret[Position(27312) := Dereference(__m, __ret0)];
 }
 
 procedure LibraAccount_withdrawal_capability_address_verify (cap: Reference) returns (__ret0: Reference)
 {
-    assume ExistsTxnSenderAccount(__m, __txn);
+    call InitVerification();
     call __ret0 := LibraAccount_withdrawal_capability_address(cap);
 }
 
@@ -3267,16 +3608,21 @@ ensures b#Boolean(Boolean((__ret0) == (SelectFieldFromRef(cap, LibraAccount_KeyR
     var __tmp: Value;
     var __frame: int;
     var __saved_m: Memory;
+    var debug#LibraAccount#key_rotation_capability_address#0#cap: [Position]Value;
+    var debug#LibraAccount#key_rotation_capability_address#1#__ret: [Position]Value;
 
     // initialize function execution
     assume !__abort_flag;
     __saved_m := __m;
     __frame := __local_counter;
     __local_counter := __local_counter + 3;
+    debug#LibraAccount#key_rotation_capability_address#0#cap := EmptyPositionMap;
+    debug#LibraAccount#key_rotation_capability_address#1#__ret := EmptyPositionMap;
 
     // process and type check arguments
     assume is#Vector(Dereference(__m, cap));
     assume IsValidReferenceParameter(__m, __frame, cap);
+    debug#LibraAccount#key_rotation_capability_address#0#cap := debug#LibraAccount#key_rotation_capability_address#0#cap[Position(27410) := Dereference(__m, cap)];
 
     // bytecode translation starts here
     call __t1 := CopyOrMoveRef(cap);
@@ -3284,17 +3630,19 @@ ensures b#Boolean(Boolean((__ret0) == (SelectFieldFromRef(cap, LibraAccount_KeyR
     call __t2 := BorrowField(__t1, LibraAccount_KeyRotationCapability_account_address);
 
     __ret0 := __t2;
+    debug#LibraAccount#key_rotation_capability_address#1#__ret := debug#LibraAccount#key_rotation_capability_address#1#__ret[Position(27551) := Dereference(__m, __ret0)];
     return;
 
 Label_Abort:
     __abort_flag := true;
     __m := __saved_m;
     __ret0 := DefaultReference;
+    debug#LibraAccount#key_rotation_capability_address#1#__ret := debug#LibraAccount#key_rotation_capability_address#1#__ret[Position(27590) := Dereference(__m, __ret0)];
 }
 
 procedure LibraAccount_key_rotation_capability_address_verify (cap: Reference) returns (__ret0: Reference)
 {
-    assume ExistsTxnSenderAccount(__m, __txn);
+    call InitVerification();
     call __ret0 := LibraAccount_key_rotation_capability_address(cap);
 }
 
@@ -3308,16 +3656,21 @@ ensures b#Boolean(Boolean(IsEqual(__ret0, ExistsResource(__m, LibraAccount_T_typ
     var __tmp: Value;
     var __frame: int;
     var __saved_m: Memory;
+    var debug#LibraAccount#exists#0#check_addr: [Position]Value;
+    var debug#LibraAccount#exists#1#__ret: [Position]Value;
 
     // initialize function execution
     assume !__abort_flag;
     __saved_m := __m;
     __frame := __local_counter;
     __local_counter := __local_counter + 3;
+    debug#LibraAccount#exists#0#check_addr := EmptyPositionMap;
+    debug#LibraAccount#exists#1#__ret := EmptyPositionMap;
 
     // process and type check arguments
     assume is#Address(check_addr);
     __m := UpdateLocal(__m, __frame + 0, check_addr);
+    debug#LibraAccount#exists#0#check_addr := debug#LibraAccount#exists#0#check_addr[Position(27648) := check_addr];
 
     // bytecode translation starts here
     call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 0));
@@ -3327,17 +3680,19 @@ ensures b#Boolean(Boolean(IsEqual(__ret0, ExistsResource(__m, LibraAccount_T_typ
     __m := UpdateLocal(__m, __frame + 2, __tmp);
 
     __ret0 := GetLocal(__m, __frame + 2);
+    debug#LibraAccount#exists#1#__ret := debug#LibraAccount#exists#1#__ret[Position(27760) := __ret0];
     return;
 
 Label_Abort:
     __abort_flag := true;
     __m := __saved_m;
     __ret0 := DefaultValue;
+    debug#LibraAccount#exists#1#__ret := debug#LibraAccount#exists#1#__ret[Position(27800) := __ret0];
 }
 
 procedure LibraAccount_exists_verify (check_addr: Value) returns (__ret0: Value)
 {
-    assume ExistsTxnSenderAccount(__m, __txn);
+    call InitVerification();
     call __ret0 := LibraAccount_exists(check_addr);
 }
 
@@ -3394,22 +3749,46 @@ requires ExistsTxnSenderAccount(__m, __txn);
     var __tmp: Value;
     var __frame: int;
     var __saved_m: Memory;
+    var debug#LibraAccount#prologue#0#txn_sequence_number: [Position]Value;
+    var debug#LibraAccount#prologue#1#txn_public_key: [Position]Value;
+    var debug#LibraAccount#prologue#2#txn_gas_price: [Position]Value;
+    var debug#LibraAccount#prologue#3#txn_max_gas_units: [Position]Value;
+    var debug#LibraAccount#prologue#4#transaction_sender: [Position]Value;
+    var debug#LibraAccount#prologue#5#sender_account: [Position]Value;
+    var debug#LibraAccount#prologue#6#imm_sender_account: [Position]Value;
+    var debug#LibraAccount#prologue#7#max_transaction_fee: [Position]Value;
+    var debug#LibraAccount#prologue#8#balance_amount: [Position]Value;
+    var debug#LibraAccount#prologue#9#sequence_number_value: [Position]Value;
 
     // initialize function execution
     assume !__abort_flag;
     __saved_m := __m;
     __frame := __local_counter;
     __local_counter := __local_counter + 50;
+    debug#LibraAccount#prologue#0#txn_sequence_number := EmptyPositionMap;
+    debug#LibraAccount#prologue#1#txn_public_key := EmptyPositionMap;
+    debug#LibraAccount#prologue#2#txn_gas_price := EmptyPositionMap;
+    debug#LibraAccount#prologue#3#txn_max_gas_units := EmptyPositionMap;
+    debug#LibraAccount#prologue#4#transaction_sender := EmptyPositionMap;
+    debug#LibraAccount#prologue#5#sender_account := EmptyPositionMap;
+    debug#LibraAccount#prologue#6#imm_sender_account := EmptyPositionMap;
+    debug#LibraAccount#prologue#7#max_transaction_fee := EmptyPositionMap;
+    debug#LibraAccount#prologue#8#balance_amount := EmptyPositionMap;
+    debug#LibraAccount#prologue#9#sequence_number_value := EmptyPositionMap;
 
     // process and type check arguments
     assume IsValidU64(txn_sequence_number);
     __m := UpdateLocal(__m, __frame + 0, txn_sequence_number);
+    debug#LibraAccount#prologue#0#txn_sequence_number := debug#LibraAccount#prologue#0#txn_sequence_number[Position(28109) := txn_sequence_number];
     assume is#ByteArray(txn_public_key);
     __m := UpdateLocal(__m, __frame + 1, txn_public_key);
+    debug#LibraAccount#prologue#1#txn_public_key := debug#LibraAccount#prologue#1#txn_public_key[Position(28109) := txn_public_key];
     assume IsValidU64(txn_gas_price);
     __m := UpdateLocal(__m, __frame + 2, txn_gas_price);
+    debug#LibraAccount#prologue#2#txn_gas_price := debug#LibraAccount#prologue#2#txn_gas_price[Position(28109) := txn_gas_price];
     assume IsValidU64(txn_max_gas_units);
     __m := UpdateLocal(__m, __frame + 3, txn_max_gas_units);
+    debug#LibraAccount#prologue#3#txn_max_gas_units := debug#LibraAccount#prologue#3#txn_max_gas_units[Position(28109) := txn_max_gas_units];
 
     // bytecode translation starts here
     call __tmp := GetTxnSenderAddress();
@@ -3417,6 +3796,7 @@ requires ExistsTxnSenderAccount(__m, __txn);
 
     call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 10));
     __m := UpdateLocal(__m, __frame + 4, __tmp);
+    debug#LibraAccount#prologue#4#transaction_sender := debug#LibraAccount#prologue#4#transaction_sender[Position(28510) := __tmp];
 
     call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 4));
     __m := UpdateLocal(__m, __frame + 11, __tmp);
@@ -3488,6 +3868,7 @@ Label_21:
 
     call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 27));
     __m := UpdateLocal(__m, __frame + 7, __tmp);
+    debug#LibraAccount#prologue#7#max_transaction_fee := debug#LibraAccount#prologue#7#max_transaction_fee[Position(29158) := __tmp];
 
     call __t28 := CopyOrMoveRef(sender_account);
 
@@ -3505,6 +3886,7 @@ Label_21:
 
     call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 31));
     __m := UpdateLocal(__m, __frame + 8, __tmp);
+    debug#LibraAccount#prologue#8#balance_amount := debug#LibraAccount#prologue#8#balance_amount[Position(29294) := __tmp];
 
     call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 8));
     __m := UpdateLocal(__m, __frame + 32, __tmp);
@@ -3537,6 +3919,7 @@ Label_38:
 
     call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 39));
     __m := UpdateLocal(__m, __frame + 9, __tmp);
+    debug#LibraAccount#prologue#9#sequence_number_value := debug#LibraAccount#prologue#9#sequence_number_value[Position(29539) := __tmp];
 
     call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 0));
     __m := UpdateLocal(__m, __frame + 40, __tmp);
@@ -3589,7 +3972,7 @@ Label_Abort:
 
 procedure LibraAccount_prologue_verify (txn_sequence_number: Value, txn_public_key: Value, txn_gas_price: Value, txn_max_gas_units: Value) returns ()
 {
-    assume ExistsTxnSenderAccount(__m, __txn);
+    call InitVerification();
     call LibraAccount_prologue(txn_sequence_number, txn_public_key, txn_gas_price, txn_max_gas_units);
 }
 
@@ -3633,22 +4016,44 @@ requires ExistsTxnSenderAccount(__m, __txn);
     var __tmp: Value;
     var __frame: int;
     var __saved_m: Memory;
+    var debug#LibraAccount#epilogue#0#txn_sequence_number: [Position]Value;
+    var debug#LibraAccount#epilogue#1#txn_gas_price: [Position]Value;
+    var debug#LibraAccount#epilogue#2#txn_max_gas_units: [Position]Value;
+    var debug#LibraAccount#epilogue#3#gas_units_remaining: [Position]Value;
+    var debug#LibraAccount#epilogue#4#sender_account: [Position]Value;
+    var debug#LibraAccount#epilogue#5#transaction_fee_account: [Position]Value;
+    var debug#LibraAccount#epilogue#6#imm_sender_account: [Position]Value;
+    var debug#LibraAccount#epilogue#7#transaction_fee_amount: [Position]Value;
+    var debug#LibraAccount#epilogue#8#transaction_fee: [Position]Value;
 
     // initialize function execution
     assume !__abort_flag;
     __saved_m := __m;
     __frame := __local_counter;
     __local_counter := __local_counter + 37;
+    debug#LibraAccount#epilogue#0#txn_sequence_number := EmptyPositionMap;
+    debug#LibraAccount#epilogue#1#txn_gas_price := EmptyPositionMap;
+    debug#LibraAccount#epilogue#2#txn_max_gas_units := EmptyPositionMap;
+    debug#LibraAccount#epilogue#3#gas_units_remaining := EmptyPositionMap;
+    debug#LibraAccount#epilogue#4#sender_account := EmptyPositionMap;
+    debug#LibraAccount#epilogue#5#transaction_fee_account := EmptyPositionMap;
+    debug#LibraAccount#epilogue#6#imm_sender_account := EmptyPositionMap;
+    debug#LibraAccount#epilogue#7#transaction_fee_amount := EmptyPositionMap;
+    debug#LibraAccount#epilogue#8#transaction_fee := EmptyPositionMap;
 
     // process and type check arguments
     assume IsValidU64(txn_sequence_number);
     __m := UpdateLocal(__m, __frame + 0, txn_sequence_number);
+    debug#LibraAccount#epilogue#0#txn_sequence_number := debug#LibraAccount#epilogue#0#txn_sequence_number[Position(29902) := txn_sequence_number];
     assume IsValidU64(txn_gas_price);
     __m := UpdateLocal(__m, __frame + 1, txn_gas_price);
+    debug#LibraAccount#epilogue#1#txn_gas_price := debug#LibraAccount#epilogue#1#txn_gas_price[Position(29902) := txn_gas_price];
     assume IsValidU64(txn_max_gas_units);
     __m := UpdateLocal(__m, __frame + 2, txn_max_gas_units);
+    debug#LibraAccount#epilogue#2#txn_max_gas_units := debug#LibraAccount#epilogue#2#txn_max_gas_units[Position(29902) := txn_max_gas_units];
     assume IsValidU64(gas_units_remaining);
     __m := UpdateLocal(__m, __frame + 3, gas_units_remaining);
+    debug#LibraAccount#epilogue#3#gas_units_remaining := debug#LibraAccount#epilogue#3#gas_units_remaining[Position(29902) := gas_units_remaining];
 
     // bytecode translation starts here
     call __tmp := GetTxnSenderAddress();
@@ -3678,6 +4083,7 @@ requires ExistsTxnSenderAccount(__m, __txn);
 
     call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 15));
     __m := UpdateLocal(__m, __frame + 7, __tmp);
+    debug#LibraAccount#epilogue#7#transaction_fee_amount := debug#LibraAccount#epilogue#7#transaction_fee_amount[Position(30423) := __tmp];
 
     call __t16 := CopyOrMoveRef(sender_account);
 
@@ -3724,6 +4130,7 @@ Label_20:
 
     call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 26));
     __m := UpdateLocal(__m, __frame + 8, __tmp);
+    debug#LibraAccount#epilogue#8#transaction_fee := debug#LibraAccount#epilogue#8#transaction_fee[Position(30741) := __tmp];
 
     call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 0));
     __m := UpdateLocal(__m, __frame + 27, __tmp);
@@ -3768,7 +4175,7 @@ Label_Abort:
 
 procedure LibraAccount_epilogue_verify (txn_sequence_number: Value, txn_gas_price: Value, txn_max_gas_units: Value, gas_units_remaining: Value) returns ()
 {
-    assume ExistsTxnSenderAccount(__m, __txn);
+    call InitVerification();
     call LibraAccount_epilogue(txn_sequence_number, txn_gas_price, txn_max_gas_units, gas_units_remaining);
 }
 
@@ -3802,18 +4209,34 @@ ensures old(b#Boolean(Boolean(i#Integer(Integer(i#Integer(SelectField(Dereferenc
     var __tmp: Value;
     var __frame: int;
     var __saved_m: Memory;
+    var debug#LibraAccount#fresh_guid#0#counter: [Position]Value;
+    var debug#LibraAccount#fresh_guid#1#sender: [Position]Value;
+    var debug#LibraAccount#fresh_guid#2#count: [Position]Value;
+    var debug#LibraAccount#fresh_guid#3#count_bytes: [Position]Value;
+    var debug#LibraAccount#fresh_guid#4#preimage: [Position]Value;
+    var debug#LibraAccount#fresh_guid#5#sender_bytes: [Position]Value;
+    var debug#LibraAccount#fresh_guid#6#__ret: [Position]Value;
 
     // initialize function execution
     assume !__abort_flag;
     __saved_m := __m;
     __frame := __local_counter;
     __local_counter := __local_counter + 22;
+    debug#LibraAccount#fresh_guid#0#counter := EmptyPositionMap;
+    debug#LibraAccount#fresh_guid#1#sender := EmptyPositionMap;
+    debug#LibraAccount#fresh_guid#2#count := EmptyPositionMap;
+    debug#LibraAccount#fresh_guid#3#count_bytes := EmptyPositionMap;
+    debug#LibraAccount#fresh_guid#4#preimage := EmptyPositionMap;
+    debug#LibraAccount#fresh_guid#5#sender_bytes := EmptyPositionMap;
+    debug#LibraAccount#fresh_guid#6#__ret := EmptyPositionMap;
 
     // process and type check arguments
     assume is#Vector(Dereference(__m, counter));
     assume IsValidReferenceParameter(__m, __frame, counter);
+    debug#LibraAccount#fresh_guid#0#counter := debug#LibraAccount#fresh_guid#0#counter[Position(31860) := Dereference(__m, counter)];
     assume is#Address(sender);
     __m := UpdateLocal(__m, __frame + 1, sender);
+    debug#LibraAccount#fresh_guid#1#sender := debug#LibraAccount#fresh_guid#1#sender[Position(31860) := sender];
 
     // bytecode translation starts here
     call __t6 := CopyOrMoveRef(counter);
@@ -3833,6 +4256,7 @@ ensures old(b#Boolean(Boolean(i#Integer(Integer(i#Integer(SelectField(Dereferenc
 
     call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 9));
     __m := UpdateLocal(__m, __frame + 5, __tmp);
+    debug#LibraAccount#fresh_guid#5#sender_bytes := debug#LibraAccount#fresh_guid#5#sender_bytes[Position(32184) := __tmp];
 
     call __t10 := CopyOrMoveRef(count);
 
@@ -3848,6 +4272,7 @@ ensures old(b#Boolean(Boolean(i#Integer(Integer(i#Integer(SelectField(Dereferenc
 
     call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 12));
     __m := UpdateLocal(__m, __frame + 3, __tmp);
+    debug#LibraAccount#fresh_guid#3#count_bytes := debug#LibraAccount#fresh_guid#3#count_bytes[Position(32252) := __tmp];
 
     call __t13 := CopyOrMoveRef(count);
 
@@ -3880,22 +4305,25 @@ ensures old(b#Boolean(Boolean(i#Integer(Integer(i#Integer(SelectField(Dereferenc
 
     call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 20));
     __m := UpdateLocal(__m, __frame + 4, __tmp);
+    debug#LibraAccount#fresh_guid#4#preimage := debug#LibraAccount#fresh_guid#4#preimage[Position(32449) := __tmp];
 
     call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 4));
     __m := UpdateLocal(__m, __frame + 21, __tmp);
 
     __ret0 := GetLocal(__m, __frame + 21);
+    debug#LibraAccount#fresh_guid#6#__ret := debug#LibraAccount#fresh_guid#6#__ret[Position(32540) := __ret0];
     return;
 
 Label_Abort:
     __abort_flag := true;
     __m := __saved_m;
     __ret0 := DefaultValue;
+    debug#LibraAccount#fresh_guid#6#__ret := debug#LibraAccount#fresh_guid#6#__ret[Position(32567) := __ret0];
 }
 
 procedure LibraAccount_fresh_guid_verify (counter: Reference, sender: Value) returns (__ret0: Value)
 {
-    assume ExistsTxnSenderAccount(__m, __txn);
+    call InitVerification();
     call __ret0 := LibraAccount_fresh_guid(counter, sender);
 }
 
@@ -3914,18 +4342,26 @@ ensures old(b#Boolean(Boolean(i#Integer(Integer(i#Integer(SelectField(Dereferenc
     var __tmp: Value;
     var __frame: int;
     var __saved_m: Memory;
+    var debug#LibraAccount#new_event_handle_impl#0#counter: [Position]Value;
+    var debug#LibraAccount#new_event_handle_impl#1#sender: [Position]Value;
+    var debug#LibraAccount#new_event_handle_impl#2#__ret: [Position]Value;
 
     // initialize function execution
     assume !__abort_flag;
     __saved_m := __m;
     __frame := __local_counter;
     __local_counter := __local_counter + 7;
+    debug#LibraAccount#new_event_handle_impl#0#counter := EmptyPositionMap;
+    debug#LibraAccount#new_event_handle_impl#1#sender := EmptyPositionMap;
+    debug#LibraAccount#new_event_handle_impl#2#__ret := EmptyPositionMap;
 
     // process and type check arguments
     assume is#Vector(Dereference(__m, counter));
     assume IsValidReferenceParameter(__m, __frame, counter);
+    debug#LibraAccount#new_event_handle_impl#0#counter := debug#LibraAccount#new_event_handle_impl#0#counter[Position(32671) := Dereference(__m, counter)];
     assume is#Address(sender);
     __m := UpdateLocal(__m, __frame + 1, sender);
+    debug#LibraAccount#new_event_handle_impl#1#sender := debug#LibraAccount#new_event_handle_impl#1#sender[Position(32671) := sender];
 
     // bytecode translation starts here
     call __tmp := LdConst(0);
@@ -3946,17 +4382,19 @@ ensures old(b#Boolean(Boolean(i#Integer(Integer(i#Integer(SelectField(Dereferenc
     __m := UpdateLocal(__m, __frame + 6, __tmp);
 
     __ret0 := GetLocal(__m, __frame + 6);
+    debug#LibraAccount#new_event_handle_impl#2#__ret := debug#LibraAccount#new_event_handle_impl#2#__ret[Position(32853) := __ret0];
     return;
 
 Label_Abort:
     __abort_flag := true;
     __m := __saved_m;
     __ret0 := DefaultValue;
+    debug#LibraAccount#new_event_handle_impl#2#__ret := debug#LibraAccount#new_event_handle_impl#2#__ret[Position(32945) := __ret0];
 }
 
 procedure LibraAccount_new_event_handle_impl_verify (tv0: TypeValue, counter: Reference, sender: Value) returns (__ret0: Value)
 {
-    assume ExistsTxnSenderAccount(__m, __txn);
+    call InitVerification();
     call __ret0 := LibraAccount_new_event_handle_impl(tv0, counter, sender);
 }
 
@@ -3978,12 +4416,18 @@ ensures old(b#Boolean(Boolean(i#Integer(Integer(i#Integer(SelectField(SelectFiel
     var __tmp: Value;
     var __frame: int;
     var __saved_m: Memory;
+    var debug#LibraAccount#new_event_handle#0#sender_account_ref: [Position]Value;
+    var debug#LibraAccount#new_event_handle#1#sender_bytes: [Position]Value;
+    var debug#LibraAccount#new_event_handle#2#__ret: [Position]Value;
 
     // initialize function execution
     assume !__abort_flag;
     __saved_m := __m;
     __frame := __local_counter;
     __local_counter := __local_counter + 8;
+    debug#LibraAccount#new_event_handle#0#sender_account_ref := EmptyPositionMap;
+    debug#LibraAccount#new_event_handle#1#sender_bytes := EmptyPositionMap;
+    debug#LibraAccount#new_event_handle#2#__ret := EmptyPositionMap;
 
     // process and type check arguments
 
@@ -4010,17 +4454,19 @@ ensures old(b#Boolean(Boolean(i#Integer(Integer(i#Integer(SelectField(SelectFiel
     __m := UpdateLocal(__m, __frame + 7, __t7);
 
     __ret0 := GetLocal(__m, __frame + 7);
+    debug#LibraAccount#new_event_handle#2#__ret := debug#LibraAccount#new_event_handle#2#__ret[Position(33383) := __ret0];
     return;
 
 Label_Abort:
     __abort_flag := true;
     __m := __saved_m;
     __ret0 := DefaultValue;
+    debug#LibraAccount#new_event_handle#2#__ret := debug#LibraAccount#new_event_handle#2#__ret[Position(33492) := __ret0];
 }
 
 procedure LibraAccount_new_event_handle_verify (tv0: TypeValue) returns (__ret0: Value)
 {
-    assume ExistsTxnSenderAccount(__m, __txn);
+    call InitVerification();
     call __ret0 := LibraAccount_new_event_handle(tv0);
 }
 
@@ -4050,17 +4496,27 @@ ensures old(b#Boolean(Boolean(i#Integer(Integer(i#Integer(SelectField(Dereferenc
     var __tmp: Value;
     var __frame: int;
     var __saved_m: Memory;
+    var debug#LibraAccount#emit_event#0#handle_ref: [Position]Value;
+    var debug#LibraAccount#emit_event#1#msg: [Position]Value;
+    var debug#LibraAccount#emit_event#2#count: [Position]Value;
+    var debug#LibraAccount#emit_event#3#guid: [Position]Value;
 
     // initialize function execution
     assume !__abort_flag;
     __saved_m := __m;
     __frame := __local_counter;
     __local_counter := __local_counter + 18;
+    debug#LibraAccount#emit_event#0#handle_ref := EmptyPositionMap;
+    debug#LibraAccount#emit_event#1#msg := EmptyPositionMap;
+    debug#LibraAccount#emit_event#2#count := EmptyPositionMap;
+    debug#LibraAccount#emit_event#3#guid := EmptyPositionMap;
 
     // process and type check arguments
     assume is#Vector(Dereference(__m, handle_ref));
     assume IsValidReferenceParameter(__m, __frame, handle_ref);
+    debug#LibraAccount#emit_event#0#handle_ref := debug#LibraAccount#emit_event#0#handle_ref[Position(33671) := Dereference(__m, handle_ref)];
     __m := UpdateLocal(__m, __frame + 1, msg);
+    debug#LibraAccount#emit_event#1#msg := debug#LibraAccount#emit_event#1#msg[Position(33671) := msg];
 
     // bytecode translation starts here
     call __t4 := CopyOrMoveRef(handle_ref);
@@ -4073,6 +4529,7 @@ ensures old(b#Boolean(Boolean(i#Integer(Integer(i#Integer(SelectField(Dereferenc
 
     call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 6));
     __m := UpdateLocal(__m, __frame + 3, __tmp);
+    debug#LibraAccount#emit_event#3#guid := debug#LibraAccount#emit_event#3#guid[Position(33878) := __tmp];
 
     call __t7 := CopyOrMoveRef(handle_ref);
 
@@ -4121,7 +4578,7 @@ Label_Abort:
 
 procedure LibraAccount_emit_event_verify (tv0: TypeValue, handle_ref: Reference, msg: Value) returns ()
 {
-    assume ExistsTxnSenderAccount(__m, __txn);
+    call InitVerification();
     call LibraAccount_emit_event(tv0, handle_ref, msg);
 }
 
@@ -4140,16 +4597,23 @@ ensures old(b#Boolean(Boolean(false))) ==> __abort_flag;
     var __tmp: Value;
     var __frame: int;
     var __saved_m: Memory;
+    var debug#LibraAccount#destroy_handle#0#handle: [Position]Value;
+    var debug#LibraAccount#destroy_handle#1#guid: [Position]Value;
+    var debug#LibraAccount#destroy_handle#2#count: [Position]Value;
 
     // initialize function execution
     assume !__abort_flag;
     __saved_m := __m;
     __frame := __local_counter;
     __local_counter := __local_counter + 6;
+    debug#LibraAccount#destroy_handle#0#handle := EmptyPositionMap;
+    debug#LibraAccount#destroy_handle#1#guid := EmptyPositionMap;
+    debug#LibraAccount#destroy_handle#2#count := EmptyPositionMap;
 
     // process and type check arguments
     assume is#Vector(handle);
     __m := UpdateLocal(__m, __frame + 0, handle);
+    debug#LibraAccount#destroy_handle#0#handle := debug#LibraAccount#destroy_handle#0#handle[Position(34391) := handle];
 
     // bytecode translation starts here
     call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 0));
@@ -4161,9 +4625,11 @@ ensures old(b#Boolean(Boolean(false))) ==> __abort_flag;
 
     call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 5));
     __m := UpdateLocal(__m, __frame + 1, __tmp);
+    debug#LibraAccount#destroy_handle#1#guid := debug#LibraAccount#destroy_handle#1#guid[Position(34574) := __tmp];
 
     call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 4));
     __m := UpdateLocal(__m, __frame + 2, __tmp);
+    debug#LibraAccount#destroy_handle#2#count := debug#LibraAccount#destroy_handle#2#count[Position(34567) := __tmp];
 
     return;
 
@@ -4174,6 +4640,6 @@ Label_Abort:
 
 procedure LibraAccount_destroy_handle_verify (tv0: TypeValue, handle: Value) returns ()
 {
-    assume ExistsTxnSenderAccount(__m, __txn);
+    call InitVerification();
     call LibraAccount_destroy_handle(tv0, handle);
 }

--- a/language/move-prover/bytecode-to-boogie/tests/goldenfiles/libra_coin.bpl
+++ b/language/move-prover/bytecode-to-boogie/tests/goldenfiles/libra_coin.bpl
@@ -79,16 +79,21 @@ ensures old(b#Boolean(Boolean(!(b#Boolean(ExistsResource(__m, LibraCoin_MintCapa
     var __tmp: Value;
     var __frame: int;
     var __saved_m: Memory;
+    var debug#LibraCoin#mint_with_default_capability#0#amount: [Position]Value;
+    var debug#LibraCoin#mint_with_default_capability#1#__ret: [Position]Value;
 
     // initialize function execution
     assume !__abort_flag;
     __saved_m := __m;
     __frame := __local_counter;
     __local_counter := __local_counter + 5;
+    debug#LibraCoin#mint_with_default_capability#0#amount := EmptyPositionMap;
+    debug#LibraCoin#mint_with_default_capability#1#__ret := EmptyPositionMap;
 
     // process and type check arguments
     assume IsValidU64(amount);
     __m := UpdateLocal(__m, __frame + 0, amount);
+    debug#LibraCoin#mint_with_default_capability#0#amount := debug#LibraCoin#mint_with_default_capability#0#amount[Position(806) := amount];
 
     // bytecode translation starts here
     call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 0));
@@ -107,17 +112,19 @@ ensures old(b#Boolean(Boolean(!(b#Boolean(ExistsResource(__m, LibraCoin_MintCapa
     __m := UpdateLocal(__m, __frame + 4, __t4);
 
     __ret0 := GetLocal(__m, __frame + 4);
+    debug#LibraCoin#mint_with_default_capability#1#__ret := debug#LibraCoin#mint_with_default_capability#1#__ret[Position(1401) := __ret0];
     return;
 
 Label_Abort:
     __abort_flag := true;
     __m := __saved_m;
     __ret0 := DefaultValue;
+    debug#LibraCoin#mint_with_default_capability#1#__ret := debug#LibraCoin#mint_with_default_capability#1#__ret[Position(1486) := __ret0];
 }
 
 procedure LibraCoin_mint_with_default_capability_verify (amount: Value) returns (__ret0: Value)
 {
-    assume ExistsTxnSenderAccount(__m, __txn);
+    call InitVerification();
     call __ret0 := LibraCoin_mint_with_default_capability(amount);
 }
 
@@ -155,18 +162,30 @@ ensures old(b#Boolean(Boolean(!(b#Boolean(ExistsResource(__m, LibraCoin_MarketCa
     var __tmp: Value;
     var __frame: int;
     var __saved_m: Memory;
+    var debug#LibraCoin#mint#0#value: [Position]Value;
+    var debug#LibraCoin#mint#1#capability: [Position]Value;
+    var debug#LibraCoin#mint#2#market_cap_ref: [Position]Value;
+    var debug#LibraCoin#mint#3#market_cap_total_value: [Position]Value;
+    var debug#LibraCoin#mint#4#__ret: [Position]Value;
 
     // initialize function execution
     assume !__abort_flag;
     __saved_m := __m;
     __frame := __local_counter;
     __local_counter := __local_counter + 24;
+    debug#LibraCoin#mint#0#value := EmptyPositionMap;
+    debug#LibraCoin#mint#1#capability := EmptyPositionMap;
+    debug#LibraCoin#mint#2#market_cap_ref := EmptyPositionMap;
+    debug#LibraCoin#mint#3#market_cap_total_value := EmptyPositionMap;
+    debug#LibraCoin#mint#4#__ret := EmptyPositionMap;
 
     // process and type check arguments
     assume IsValidU64(value);
     __m := UpdateLocal(__m, __frame + 0, value);
+    debug#LibraCoin#mint#0#value := debug#LibraCoin#mint#0#value[Position(1723) := value];
     assume is#Vector(Dereference(__m, capability));
     assume IsValidReferenceParameter(__m, __frame, capability);
+    debug#LibraCoin#mint#1#capability := debug#LibraCoin#mint#1#capability[Position(1723) := Dereference(__m, capability)];
 
     // bytecode translation starts here
     call __t4 := CopyOrMoveRef(capability);
@@ -219,6 +238,7 @@ Label_11:
 
     call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 16));
     __m := UpdateLocal(__m, __frame + 3, __tmp);
+    debug#LibraCoin#mint#3#market_cap_total_value := debug#LibraCoin#mint#3#market_cap_total_value[Position(2964) := __tmp];
 
     call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 3));
     __m := UpdateLocal(__m, __frame + 17, __tmp);
@@ -243,17 +263,19 @@ Label_11:
     __m := UpdateLocal(__m, __frame + 23, __tmp);
 
     __ret0 := GetLocal(__m, __frame + 23);
+    debug#LibraCoin#mint#4#__ret := debug#LibraCoin#mint#4#__ret[Position(3129) := __ret0];
     return;
 
 Label_Abort:
     __abort_flag := true;
     __m := __saved_m;
     __ret0 := DefaultValue;
+    debug#LibraCoin#mint#4#__ret := debug#LibraCoin#mint#4#__ret[Position(3163) := __ret0];
 }
 
 procedure LibraCoin_mint_verify (value: Value, capability: Reference) returns (__ret0: Value)
 {
-    assume ExistsTxnSenderAccount(__m, __txn);
+    call InitVerification();
     call __ret0 := LibraCoin_mint(value, capability);
 }
 
@@ -337,7 +359,7 @@ Label_Abort:
 
 procedure LibraCoin_initialize_verify () returns ()
 {
-    assume ExistsTxnSenderAccount(__m, __txn);
+    call InitVerification();
     call LibraCoin_initialize();
 }
 
@@ -356,12 +378,14 @@ ensures old(b#Boolean(Boolean(!(b#Boolean(ExistsResource(__m, LibraCoin_MarketCa
     var __tmp: Value;
     var __frame: int;
     var __saved_m: Memory;
+    var debug#LibraCoin#market_cap#0#__ret: [Position]Value;
 
     // initialize function execution
     assume !__abort_flag;
     __saved_m := __m;
     __frame := __local_counter;
     __local_counter := __local_counter + 4;
+    debug#LibraCoin#market_cap#0#__ret := EmptyPositionMap;
 
     // process and type check arguments
 
@@ -379,17 +403,19 @@ ensures old(b#Boolean(Boolean(!(b#Boolean(ExistsResource(__m, LibraCoin_MarketCa
     __m := UpdateLocal(__m, __frame + 3, __tmp);
 
     __ret0 := GetLocal(__m, __frame + 3);
+    debug#LibraCoin#market_cap#0#__ret := debug#LibraCoin#market_cap#0#__ret[Position(4289) := __ret0];
     return;
 
 Label_Abort:
     __abort_flag := true;
     __m := __saved_m;
     __ret0 := DefaultValue;
+    debug#LibraCoin#market_cap#0#__ret := debug#LibraCoin#market_cap#0#__ret[Position(4353) := __ret0];
 }
 
 procedure LibraCoin_market_cap_verify () returns (__ret0: Value)
 {
-    assume ExistsTxnSenderAccount(__m, __txn);
+    call InitVerification();
     call __ret0 := LibraCoin_market_cap();
 }
 
@@ -403,12 +429,14 @@ ensures b#Boolean(Boolean(IsEqual(SelectField(__ret0, LibraCoin_T_value), Intege
     var __tmp: Value;
     var __frame: int;
     var __saved_m: Memory;
+    var debug#LibraCoin#zero#0#__ret: [Position]Value;
 
     // initialize function execution
     assume !__abort_flag;
     __saved_m := __m;
     __frame := __local_counter;
     __local_counter := __local_counter + 2;
+    debug#LibraCoin#zero#0#__ret := EmptyPositionMap;
 
     // process and type check arguments
 
@@ -420,17 +448,19 @@ ensures b#Boolean(Boolean(IsEqual(SelectField(__ret0, LibraCoin_T_value), Intege
     __m := UpdateLocal(__m, __frame + 1, __tmp);
 
     __ret0 := GetLocal(__m, __frame + 1);
+    debug#LibraCoin#zero#0#__ret := debug#LibraCoin#zero#0#__ret[Position(4477) := __ret0];
     return;
 
 Label_Abort:
     __abort_flag := true;
     __m := __saved_m;
     __ret0 := DefaultValue;
+    debug#LibraCoin#zero#0#__ret := debug#LibraCoin#zero#0#__ret[Position(4501) := __ret0];
 }
 
 procedure LibraCoin_zero_verify () returns (__ret0: Value)
 {
-    assume ExistsTxnSenderAccount(__m, __txn);
+    call InitVerification();
     call __ret0 := LibraCoin_zero();
 }
 
@@ -445,16 +475,21 @@ ensures b#Boolean(Boolean(IsEqual(__ret0, SelectField(Dereference(__m, coin_ref)
     var __tmp: Value;
     var __frame: int;
     var __saved_m: Memory;
+    var debug#LibraCoin#value#0#coin_ref: [Position]Value;
+    var debug#LibraCoin#value#1#__ret: [Position]Value;
 
     // initialize function execution
     assume !__abort_flag;
     __saved_m := __m;
     __frame := __local_counter;
     __local_counter := __local_counter + 4;
+    debug#LibraCoin#value#0#coin_ref := EmptyPositionMap;
+    debug#LibraCoin#value#1#__ret := EmptyPositionMap;
 
     // process and type check arguments
     assume is#Vector(Dereference(__m, coin_ref));
     assume IsValidReferenceParameter(__m, __frame, coin_ref);
+    debug#LibraCoin#value#0#coin_ref := debug#LibraCoin#value#0#coin_ref[Position(4555) := Dereference(__m, coin_ref)];
 
     // bytecode translation starts here
     call __t1 := CopyOrMoveRef(coin_ref);
@@ -466,17 +501,19 @@ ensures b#Boolean(Boolean(IsEqual(__ret0, SelectField(Dereference(__m, coin_ref)
     __m := UpdateLocal(__m, __frame + 3, __tmp);
 
     __ret0 := GetLocal(__m, __frame + 3);
+    debug#LibraCoin#value#1#__ret := debug#LibraCoin#value#1#__ret[Position(4644) := __ret0];
     return;
 
 Label_Abort:
     __abort_flag := true;
     __m := __saved_m;
     __ret0 := DefaultValue;
+    debug#LibraCoin#value#1#__ret := debug#LibraCoin#value#1#__ret[Position(4679) := __ret0];
 }
 
 procedure LibraCoin_value_verify (coin_ref: Reference) returns (__ret0: Value)
 {
-    assume ExistsTxnSenderAccount(__m, __txn);
+    call InitVerification();
     call __ret0 := LibraCoin_value(coin_ref);
 }
 
@@ -497,18 +534,30 @@ ensures old(b#Boolean(Boolean(i#Integer(SelectField(coin, LibraCoin_T_value)) < 
     var __tmp: Value;
     var __frame: int;
     var __saved_m: Memory;
+    var debug#LibraCoin#split#0#coin: [Position]Value;
+    var debug#LibraCoin#split#1#amount: [Position]Value;
+    var debug#LibraCoin#split#2#other: [Position]Value;
+    var debug#LibraCoin#split#3#__ret: [Position]Value;
+    var debug#LibraCoin#split#4#__ret: [Position]Value;
 
     // initialize function execution
     assume !__abort_flag;
     __saved_m := __m;
     __frame := __local_counter;
     __local_counter := __local_counter + 8;
+    debug#LibraCoin#split#0#coin := EmptyPositionMap;
+    debug#LibraCoin#split#1#amount := EmptyPositionMap;
+    debug#LibraCoin#split#2#other := EmptyPositionMap;
+    debug#LibraCoin#split#3#__ret := EmptyPositionMap;
+    debug#LibraCoin#split#4#__ret := EmptyPositionMap;
 
     // process and type check arguments
     assume is#Vector(coin);
     __m := UpdateLocal(__m, __frame + 0, coin);
+    debug#LibraCoin#split#0#coin := debug#LibraCoin#split#0#coin[Position(4818) := coin];
     assume IsValidU64(amount);
     __m := UpdateLocal(__m, __frame + 1, amount);
+    debug#LibraCoin#split#1#amount := debug#LibraCoin#split#1#amount[Position(4818) := amount];
 
     // bytecode translation starts here
     call __t3 := BorrowLoc(__frame + 0);
@@ -521,9 +570,11 @@ ensures old(b#Boolean(Boolean(i#Integer(SelectField(coin, LibraCoin_T_value)) < 
     assume is#Vector(__t5);
 
     __m := UpdateLocal(__m, __frame + 5, __t5);
+    debug#LibraCoin#split#0#coin := debug#LibraCoin#split#0#coin[Position(5045) := GetLocal(__m, __frame + 0)];
 
     call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 5));
     __m := UpdateLocal(__m, __frame + 2, __tmp);
+    debug#LibraCoin#split#2#other := debug#LibraCoin#split#2#other[Position(5037) := __tmp];
 
     call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 0));
     __m := UpdateLocal(__m, __frame + 6, __tmp);
@@ -532,19 +583,23 @@ ensures old(b#Boolean(Boolean(i#Integer(SelectField(coin, LibraCoin_T_value)) < 
     __m := UpdateLocal(__m, __frame + 7, __tmp);
 
     __ret0 := GetLocal(__m, __frame + 6);
+    debug#LibraCoin#split#3#__ret := debug#LibraCoin#split#3#__ret[Position(5093) := __ret0];
     __ret1 := GetLocal(__m, __frame + 7);
+    debug#LibraCoin#split#4#__ret := debug#LibraCoin#split#4#__ret[Position(5093) := __ret1];
     return;
 
 Label_Abort:
     __abort_flag := true;
     __m := __saved_m;
     __ret0 := DefaultValue;
+    debug#LibraCoin#split#3#__ret := debug#LibraCoin#split#3#__ret[Position(5129) := __ret0];
     __ret1 := DefaultValue;
+    debug#LibraCoin#split#4#__ret := debug#LibraCoin#split#4#__ret[Position(5129) := __ret1];
 }
 
 procedure LibraCoin_split_verify (coin: Value, amount: Value) returns (__ret0: Value, __ret1: Value)
 {
-    assume ExistsTxnSenderAccount(__m, __txn);
+    call InitVerification();
     call __ret0, __ret1 := LibraCoin_split(coin, amount);
 }
 
@@ -576,18 +631,28 @@ ensures old(b#Boolean(Boolean(i#Integer(SelectField(Dereference(__m, coin_ref), 
     var __tmp: Value;
     var __frame: int;
     var __saved_m: Memory;
+    var debug#LibraCoin#withdraw#0#coin_ref: [Position]Value;
+    var debug#LibraCoin#withdraw#1#amount: [Position]Value;
+    var debug#LibraCoin#withdraw#2#value: [Position]Value;
+    var debug#LibraCoin#withdraw#3#__ret: [Position]Value;
 
     // initialize function execution
     assume !__abort_flag;
     __saved_m := __m;
     __frame := __local_counter;
     __local_counter := __local_counter + 18;
+    debug#LibraCoin#withdraw#0#coin_ref := EmptyPositionMap;
+    debug#LibraCoin#withdraw#1#amount := EmptyPositionMap;
+    debug#LibraCoin#withdraw#2#value := EmptyPositionMap;
+    debug#LibraCoin#withdraw#3#__ret := EmptyPositionMap;
 
     // process and type check arguments
     assume is#Vector(Dereference(__m, coin_ref));
     assume IsValidReferenceParameter(__m, __frame, coin_ref);
+    debug#LibraCoin#withdraw#0#coin_ref := debug#LibraCoin#withdraw#0#coin_ref[Position(5391) := Dereference(__m, coin_ref)];
     assume IsValidU64(amount);
     __m := UpdateLocal(__m, __frame + 1, amount);
+    debug#LibraCoin#withdraw#1#amount := debug#LibraCoin#withdraw#1#amount[Position(5391) := amount];
 
     // bytecode translation starts here
     call __t3 := CopyOrMoveRef(coin_ref);
@@ -600,6 +665,7 @@ ensures old(b#Boolean(Boolean(i#Integer(SelectField(Dereference(__m, coin_ref), 
 
     call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 5));
     __m := UpdateLocal(__m, __frame + 2, __tmp);
+    debug#LibraCoin#withdraw#2#value := debug#LibraCoin#withdraw#2#value[Position(5692) := __tmp];
 
     call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 2));
     __m := UpdateLocal(__m, __frame + 6, __tmp);
@@ -645,17 +711,19 @@ Label_11:
     __m := UpdateLocal(__m, __frame + 17, __tmp);
 
     __ret0 := GetLocal(__m, __frame + 17);
+    debug#LibraCoin#withdraw#3#__ret := debug#LibraCoin#withdraw#3#__ret[Position(5881) := __ret0];
     return;
 
 Label_Abort:
     __abort_flag := true;
     __m := __saved_m;
     __ret0 := DefaultValue;
+    debug#LibraCoin#withdraw#3#__ret := debug#LibraCoin#withdraw#3#__ret[Position(5916) := __ret0];
 }
 
 procedure LibraCoin_withdraw_verify (coin_ref: Reference, amount: Value) returns (__ret0: Value)
 {
-    assume ExistsTxnSenderAccount(__m, __txn);
+    call InitVerification();
     call __ret0 := LibraCoin_withdraw(coin_ref, amount);
 }
 
@@ -673,18 +741,26 @@ ensures old(b#Boolean(Boolean(i#Integer(Integer(i#Integer(SelectField(coin1, Lib
     var __tmp: Value;
     var __frame: int;
     var __saved_m: Memory;
+    var debug#LibraCoin#join#0#coin1: [Position]Value;
+    var debug#LibraCoin#join#1#coin2: [Position]Value;
+    var debug#LibraCoin#join#2#__ret: [Position]Value;
 
     // initialize function execution
     assume !__abort_flag;
     __saved_m := __m;
     __frame := __local_counter;
     __local_counter := __local_counter + 5;
+    debug#LibraCoin#join#0#coin1 := EmptyPositionMap;
+    debug#LibraCoin#join#1#coin2 := EmptyPositionMap;
+    debug#LibraCoin#join#2#__ret := EmptyPositionMap;
 
     // process and type check arguments
     assume is#Vector(coin1);
     __m := UpdateLocal(__m, __frame + 0, coin1);
+    debug#LibraCoin#join#0#coin1 := debug#LibraCoin#join#0#coin1[Position(6020) := coin1];
     assume is#Vector(coin2);
     __m := UpdateLocal(__m, __frame + 1, coin2);
+    debug#LibraCoin#join#1#coin2 := debug#LibraCoin#join#1#coin2[Position(6020) := coin2];
 
     // bytecode translation starts here
     call __t2 := BorrowLoc(__frame + 0);
@@ -694,22 +770,25 @@ ensures old(b#Boolean(Boolean(i#Integer(Integer(i#Integer(SelectField(coin1, Lib
 
     call LibraCoin_deposit(__t2, GetLocal(__m, __frame + 3));
     if (__abort_flag) { goto Label_Abort; }
+    debug#LibraCoin#join#0#coin1 := debug#LibraCoin#join#0#coin1[Position(6215) := GetLocal(__m, __frame + 0)];
 
     call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 0));
     __m := UpdateLocal(__m, __frame + 4, __tmp);
 
     __ret0 := GetLocal(__m, __frame + 4);
+    debug#LibraCoin#join#2#__ret := debug#LibraCoin#join#2#__ret[Position(6262) := __ret0];
     return;
 
 Label_Abort:
     __abort_flag := true;
     __m := __saved_m;
     __ret0 := DefaultValue;
+    debug#LibraCoin#join#2#__ret := debug#LibraCoin#join#2#__ret[Position(6286) := __ret0];
 }
 
 procedure LibraCoin_join_verify (coin1: Value, coin2: Value) returns (__ret0: Value)
 {
-    assume ExistsTxnSenderAccount(__m, __txn);
+    call InitVerification();
     call __ret0 := LibraCoin_join(coin1, coin2);
 }
 
@@ -736,18 +815,28 @@ ensures old(b#Boolean(Boolean(i#Integer(Integer(i#Integer(SelectField(Dereferenc
     var __tmp: Value;
     var __frame: int;
     var __saved_m: Memory;
+    var debug#LibraCoin#deposit#0#coin_ref: [Position]Value;
+    var debug#LibraCoin#deposit#1#check: [Position]Value;
+    var debug#LibraCoin#deposit#2#value: [Position]Value;
+    var debug#LibraCoin#deposit#3#check_value: [Position]Value;
 
     // initialize function execution
     assume !__abort_flag;
     __saved_m := __m;
     __frame := __local_counter;
     __local_counter := __local_counter + 14;
+    debug#LibraCoin#deposit#0#coin_ref := EmptyPositionMap;
+    debug#LibraCoin#deposit#1#check := EmptyPositionMap;
+    debug#LibraCoin#deposit#2#value := EmptyPositionMap;
+    debug#LibraCoin#deposit#3#check_value := EmptyPositionMap;
 
     // process and type check arguments
     assume is#Vector(Dereference(__m, coin_ref));
     assume IsValidReferenceParameter(__m, __frame, coin_ref);
+    debug#LibraCoin#deposit#0#coin_ref := debug#LibraCoin#deposit#0#coin_ref[Position(6465) := Dereference(__m, coin_ref)];
     assume is#Vector(check);
     __m := UpdateLocal(__m, __frame + 1, check);
+    debug#LibraCoin#deposit#1#check := debug#LibraCoin#deposit#1#check[Position(6465) := check];
 
     // bytecode translation starts here
     call __t4 := CopyOrMoveRef(coin_ref);
@@ -760,6 +849,7 @@ ensures old(b#Boolean(Boolean(i#Integer(Integer(i#Integer(SelectField(Dereferenc
 
     call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 6));
     __m := UpdateLocal(__m, __frame + 2, __tmp);
+    debug#LibraCoin#deposit#2#value := debug#LibraCoin#deposit#2#value[Position(6729) := __tmp];
 
     call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 1));
     __m := UpdateLocal(__m, __frame + 7, __tmp);
@@ -769,6 +859,7 @@ ensures old(b#Boolean(Boolean(i#Integer(Integer(i#Integer(SelectField(Dereferenc
 
     call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 8));
     __m := UpdateLocal(__m, __frame + 3, __tmp);
+    debug#LibraCoin#deposit#3#check_value := debug#LibraCoin#deposit#3#check_value[Position(6779) := __tmp];
 
     call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 2));
     __m := UpdateLocal(__m, __frame + 9, __tmp);
@@ -795,7 +886,7 @@ Label_Abort:
 
 procedure LibraCoin_deposit_verify (coin_ref: Reference, check: Value) returns ()
 {
-    assume ExistsTxnSenderAccount(__m, __txn);
+    call InitVerification();
     call LibraCoin_deposit(coin_ref, check);
 }
 
@@ -817,16 +908,21 @@ ensures old(b#Boolean(Boolean(!IsEqual(SelectField(coin, LibraCoin_T_value), Int
     var __tmp: Value;
     var __frame: int;
     var __saved_m: Memory;
+    var debug#LibraCoin#destroy_zero#0#coin: [Position]Value;
+    var debug#LibraCoin#destroy_zero#1#value: [Position]Value;
 
     // initialize function execution
     assume !__abort_flag;
     __saved_m := __m;
     __frame := __local_counter;
     __local_counter := __local_counter + 9;
+    debug#LibraCoin#destroy_zero#0#coin := EmptyPositionMap;
+    debug#LibraCoin#destroy_zero#1#value := EmptyPositionMap;
 
     // process and type check arguments
     assume is#Vector(coin);
     __m := UpdateLocal(__m, __frame + 0, coin);
+    debug#LibraCoin#destroy_zero#0#coin := debug#LibraCoin#destroy_zero#0#coin[Position(7117) := coin];
 
     // bytecode translation starts here
     call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 0));
@@ -837,6 +933,7 @@ ensures old(b#Boolean(Boolean(!IsEqual(SelectField(coin, LibraCoin_T_value), Int
 
     call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 3));
     __m := UpdateLocal(__m, __frame + 1, __tmp);
+    debug#LibraCoin#destroy_zero#1#value := debug#LibraCoin#destroy_zero#1#value[Position(7227) := __tmp];
 
     call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 1));
     __m := UpdateLocal(__m, __frame + 4, __tmp);
@@ -868,6 +965,6 @@ Label_Abort:
 
 procedure LibraCoin_destroy_zero_verify (coin: Value) returns ()
 {
-    assume ExistsTxnSenderAccount(__m, __txn);
+    call InitVerification();
     call LibraCoin_destroy_zero(coin);
 }

--- a/language/move-prover/bytecode-to-boogie/tests/goldenfiles/test-aborts-if.bpl
+++ b/language/move-prover/bytecode-to-boogie/tests/goldenfiles/test-aborts-if.bpl
@@ -21,18 +21,24 @@ ensures old(b#Boolean(Boolean(i#Integer(x) <= i#Integer(y)))) ==> __abort_flag;
     var __tmp: Value;
     var __frame: int;
     var __saved_m: Memory;
+    var debug#TestAbortIf#abort1#0#x: [Position]Value;
+    var debug#TestAbortIf#abort1#1#y: [Position]Value;
 
     // initialize function execution
     assume !__abort_flag;
     __saved_m := __m;
     __frame := __local_counter;
     __local_counter := __local_counter + 7;
+    debug#TestAbortIf#abort1#0#x := EmptyPositionMap;
+    debug#TestAbortIf#abort1#1#y := EmptyPositionMap;
 
     // process and type check arguments
     assume IsValidU64(x);
     __m := UpdateLocal(__m, __frame + 0, x);
+    debug#TestAbortIf#abort1#0#x := debug#TestAbortIf#abort1#0#x[Position(66) := x];
     assume IsValidU64(y);
     __m := UpdateLocal(__m, __frame + 1, y);
+    debug#TestAbortIf#abort1#1#y := debug#TestAbortIf#abort1#1#y[Position(66) := y];
 
     // bytecode translation starts here
     call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 0));
@@ -65,7 +71,7 @@ Label_Abort:
 
 procedure TestAbortIf_abort1_verify (x: Value, y: Value) returns ()
 {
-    assume ExistsTxnSenderAccount(__m, __txn);
+    call InitVerification();
     call TestAbortIf_abort1(x, y);
 }
 
@@ -79,18 +85,24 @@ ensures old(b#Boolean(Boolean(i#Integer(x) <= i#Integer(y)))) ==> __abort_flag;
     var __tmp: Value;
     var __frame: int;
     var __saved_m: Memory;
+    var debug#TestAbortIf#abort2#0#x: [Position]Value;
+    var debug#TestAbortIf#abort2#1#y: [Position]Value;
 
     // initialize function execution
     assume !__abort_flag;
     __saved_m := __m;
     __frame := __local_counter;
     __local_counter := __local_counter + 2;
+    debug#TestAbortIf#abort2#0#x := EmptyPositionMap;
+    debug#TestAbortIf#abort2#1#y := EmptyPositionMap;
 
     // process and type check arguments
     assume IsValidU64(x);
     __m := UpdateLocal(__m, __frame + 0, x);
+    debug#TestAbortIf#abort2#0#x := debug#TestAbortIf#abort2#0#x[Position(283) := x];
     assume IsValidU64(y);
     __m := UpdateLocal(__m, __frame + 1, y);
+    debug#TestAbortIf#abort2#1#y := debug#TestAbortIf#abort2#1#y[Position(283) := y];
 
     // bytecode translation starts here
     return;
@@ -102,7 +114,7 @@ Label_Abort:
 
 procedure TestAbortIf_abort2_verify (x: Value, y: Value) returns ()
 {
-    assume ExistsTxnSenderAccount(__m, __txn);
+    call InitVerification();
     call TestAbortIf_abort2(x, y);
 }
 
@@ -119,18 +131,24 @@ ensures old(b#Boolean(Boolean(i#Integer(x) <= i#Integer(y)))) ==> __abort_flag;
     var __tmp: Value;
     var __frame: int;
     var __saved_m: Memory;
+    var debug#TestAbortIf#abort3#0#x: [Position]Value;
+    var debug#TestAbortIf#abort3#1#y: [Position]Value;
 
     // initialize function execution
     assume !__abort_flag;
     __saved_m := __m;
     __frame := __local_counter;
     __local_counter := __local_counter + 5;
+    debug#TestAbortIf#abort3#0#x := EmptyPositionMap;
+    debug#TestAbortIf#abort3#1#y := EmptyPositionMap;
 
     // process and type check arguments
     assume IsValidU64(x);
     __m := UpdateLocal(__m, __frame + 0, x);
+    debug#TestAbortIf#abort3#0#x := debug#TestAbortIf#abort3#0#x[Position(476) := x];
     assume IsValidU64(y);
     __m := UpdateLocal(__m, __frame + 1, y);
+    debug#TestAbortIf#abort3#1#y := debug#TestAbortIf#abort3#1#y[Position(476) := y];
 
     // bytecode translation starts here
     call __tmp := LdFalse();
@@ -157,7 +175,7 @@ Label_Abort:
 
 procedure TestAbortIf_abort3_verify (x: Value, y: Value) returns ()
 {
-    assume ExistsTxnSenderAccount(__m, __txn);
+    call InitVerification();
     call TestAbortIf_abort3(x, y);
 }
 
@@ -176,18 +194,24 @@ ensures old(b#Boolean(Boolean(i#Integer(x) < i#Integer(y)))) ==> __abort_flag;
     var __tmp: Value;
     var __frame: int;
     var __saved_m: Memory;
+    var debug#TestAbortIf#abort4#0#x: [Position]Value;
+    var debug#TestAbortIf#abort4#1#y: [Position]Value;
 
     // initialize function execution
     assume !__abort_flag;
     __saved_m := __m;
     __frame := __local_counter;
     __local_counter := __local_counter + 7;
+    debug#TestAbortIf#abort4#0#x := EmptyPositionMap;
+    debug#TestAbortIf#abort4#1#y := EmptyPositionMap;
 
     // process and type check arguments
     assume IsValidU64(x);
     __m := UpdateLocal(__m, __frame + 0, x);
+    debug#TestAbortIf#abort4#0#x := debug#TestAbortIf#abort4#0#x[Position(717) := x];
     assume IsValidU64(y);
     __m := UpdateLocal(__m, __frame + 1, y);
+    debug#TestAbortIf#abort4#1#y := debug#TestAbortIf#abort4#1#y[Position(717) := y];
 
     // bytecode translation starts here
     call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 0));
@@ -220,7 +244,7 @@ Label_Abort:
 
 procedure TestAbortIf_abort4_verify (x: Value, y: Value) returns ()
 {
-    assume ExistsTxnSenderAccount(__m, __txn);
+    call InitVerification();
     call TestAbortIf_abort4(x, y);
 }
 
@@ -239,18 +263,24 @@ ensures old(b#Boolean(Boolean(i#Integer(x) <= i#Integer(y)))) ==> __abort_flag;
     var __tmp: Value;
     var __frame: int;
     var __saved_m: Memory;
+    var debug#TestAbortIf#abort5#0#x: [Position]Value;
+    var debug#TestAbortIf#abort5#1#y: [Position]Value;
 
     // initialize function execution
     assume !__abort_flag;
     __saved_m := __m;
     __frame := __local_counter;
     __local_counter := __local_counter + 7;
+    debug#TestAbortIf#abort5#0#x := EmptyPositionMap;
+    debug#TestAbortIf#abort5#1#y := EmptyPositionMap;
 
     // process and type check arguments
     assume IsValidU64(x);
     __m := UpdateLocal(__m, __frame + 0, x);
+    debug#TestAbortIf#abort5#0#x := debug#TestAbortIf#abort5#0#x[Position(954) := x];
     assume IsValidU64(y);
     __m := UpdateLocal(__m, __frame + 1, y);
+    debug#TestAbortIf#abort5#1#y := debug#TestAbortIf#abort5#1#y[Position(954) := y];
 
     // bytecode translation starts here
     call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 0));
@@ -283,7 +313,7 @@ Label_Abort:
 
 procedure TestAbortIf_abort5_verify (x: Value, y: Value) returns ()
 {
-    assume ExistsTxnSenderAccount(__m, __txn);
+    call InitVerification();
     call TestAbortIf_abort5(x, y);
 }
 
@@ -302,18 +332,24 @@ ensures old(b#Boolean(Boolean(i#Integer(x) < i#Integer(y)))) ==> __abort_flag;
     var __tmp: Value;
     var __frame: int;
     var __saved_m: Memory;
+    var debug#TestAbortIf#abort6#0#x: [Position]Value;
+    var debug#TestAbortIf#abort6#1#y: [Position]Value;
 
     // initialize function execution
     assume !__abort_flag;
     __saved_m := __m;
     __frame := __local_counter;
     __local_counter := __local_counter + 7;
+    debug#TestAbortIf#abort6#0#x := EmptyPositionMap;
+    debug#TestAbortIf#abort6#1#y := EmptyPositionMap;
 
     // process and type check arguments
     assume IsValidU64(x);
     __m := UpdateLocal(__m, __frame + 0, x);
+    debug#TestAbortIf#abort6#0#x := debug#TestAbortIf#abort6#0#x[Position(1199) := x];
     assume IsValidU64(y);
     __m := UpdateLocal(__m, __frame + 1, y);
+    debug#TestAbortIf#abort6#1#y := debug#TestAbortIf#abort6#1#y[Position(1199) := y];
 
     // bytecode translation starts here
     call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 0));
@@ -346,7 +382,7 @@ Label_Abort:
 
 procedure TestAbortIf_abort6_verify (x: Value, y: Value) returns ()
 {
-    assume ExistsTxnSenderAccount(__m, __txn);
+    call InitVerification();
     call TestAbortIf_abort6(x, y);
 }
 
@@ -365,18 +401,24 @@ ensures old(b#Boolean(Boolean(i#Integer(x) < i#Integer(y)))) ==> __abort_flag;
     var __tmp: Value;
     var __frame: int;
     var __saved_m: Memory;
+    var debug#TestAbortIf#abort7#0#x: [Position]Value;
+    var debug#TestAbortIf#abort7#1#y: [Position]Value;
 
     // initialize function execution
     assume !__abort_flag;
     __saved_m := __m;
     __frame := __local_counter;
     __local_counter := __local_counter + 7;
+    debug#TestAbortIf#abort7#0#x := EmptyPositionMap;
+    debug#TestAbortIf#abort7#1#y := EmptyPositionMap;
 
     // process and type check arguments
     assume IsValidU64(x);
     __m := UpdateLocal(__m, __frame + 0, x);
+    debug#TestAbortIf#abort7#0#x := debug#TestAbortIf#abort7#0#x[Position(1423) := x];
     assume IsValidU64(y);
     __m := UpdateLocal(__m, __frame + 1, y);
+    debug#TestAbortIf#abort7#1#y := debug#TestAbortIf#abort7#1#y[Position(1423) := y];
 
     // bytecode translation starts here
     call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 0));
@@ -409,7 +451,7 @@ Label_Abort:
 
 procedure TestAbortIf_abort7_verify (x: Value, y: Value) returns ()
 {
-    assume ExistsTxnSenderAccount(__m, __txn);
+    call InitVerification();
     call TestAbortIf_abort7(x, y);
 }
 
@@ -433,18 +475,26 @@ ensures old(b#Boolean(Boolean(i#Integer(x) < i#Integer(y)))) ==> __abort_flag;
     var __tmp: Value;
     var __frame: int;
     var __saved_m: Memory;
+    var debug#TestAbortIf#abort8#0#x: [Position]Value;
+    var debug#TestAbortIf#abort8#1#y: [Position]Value;
+    var debug#TestAbortIf#abort8#2#__ret: [Position]Value;
 
     // initialize function execution
     assume !__abort_flag;
     __saved_m := __m;
     __frame := __local_counter;
     __local_counter := __local_counter + 11;
+    debug#TestAbortIf#abort8#0#x := EmptyPositionMap;
+    debug#TestAbortIf#abort8#1#y := EmptyPositionMap;
+    debug#TestAbortIf#abort8#2#__ret := EmptyPositionMap;
 
     // process and type check arguments
     assume IsValidU64(x);
     __m := UpdateLocal(__m, __frame + 0, x);
+    debug#TestAbortIf#abort8#0#x := debug#TestAbortIf#abort8#0#x[Position(1706) := x];
     assume IsValidU64(y);
     __m := UpdateLocal(__m, __frame + 1, y);
+    debug#TestAbortIf#abort8#1#y := debug#TestAbortIf#abort8#1#y[Position(1706) := y];
 
     // bytecode translation starts here
     call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 0));
@@ -473,6 +523,7 @@ Label_7:
 
     call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 7));
     __m := UpdateLocal(__m, __frame + 1, __tmp);
+    debug#TestAbortIf#abort8#1#y := debug#TestAbortIf#abort8#1#y[Position(1900) := __tmp];
 
     call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 0));
     __m := UpdateLocal(__m, __frame + 8, __tmp);
@@ -484,17 +535,19 @@ Label_7:
     __m := UpdateLocal(__m, __frame + 10, __tmp);
 
     __ret0 := GetLocal(__m, __frame + 10);
+    debug#TestAbortIf#abort8#2#__ret := debug#TestAbortIf#abort8#2#__ret[Position(1935) := __ret0];
     return;
 
 Label_Abort:
     __abort_flag := true;
     __m := __saved_m;
     __ret0 := DefaultValue;
+    debug#TestAbortIf#abort8#2#__ret := debug#TestAbortIf#abort8#2#__ret[Position(1971) := __ret0];
 }
 
 procedure TestAbortIf_abort8_verify (x: Value, y: Value) returns (__ret0: Value)
 {
-    assume ExistsTxnSenderAccount(__m, __txn);
+    call InitVerification();
     call __ret0 := TestAbortIf_abort8(x, y);
 }
 
@@ -514,18 +567,24 @@ ensures old(b#Boolean(Boolean(i#Integer(x) > i#Integer(y))) || b#Boolean(Boolean
     var __tmp: Value;
     var __frame: int;
     var __saved_m: Memory;
+    var debug#TestAbortIf#abort9#0#x: [Position]Value;
+    var debug#TestAbortIf#abort9#1#y: [Position]Value;
 
     // initialize function execution
     assume !__abort_flag;
     __saved_m := __m;
     __frame := __local_counter;
     __local_counter := __local_counter + 7;
+    debug#TestAbortIf#abort9#0#x := EmptyPositionMap;
+    debug#TestAbortIf#abort9#1#y := EmptyPositionMap;
 
     // process and type check arguments
     assume IsValidU64(x);
     __m := UpdateLocal(__m, __frame + 0, x);
+    debug#TestAbortIf#abort9#0#x := debug#TestAbortIf#abort9#0#x[Position(2218) := x];
     assume IsValidU64(y);
     __m := UpdateLocal(__m, __frame + 1, y);
+    debug#TestAbortIf#abort9#1#y := debug#TestAbortIf#abort9#1#y[Position(2218) := y];
 
     // bytecode translation starts here
     call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 0));
@@ -558,6 +617,6 @@ Label_Abort:
 
 procedure TestAbortIf_abort9_verify (x: Value, y: Value) returns ()
 {
-    assume ExistsTxnSenderAccount(__m, __txn);
+    call InitVerification();
     call TestAbortIf_abort9(x, y);
 }

--- a/language/move-prover/bytecode-to-boogie/tests/goldenfiles/test-access-path.bpl
+++ b/language/move-prover/bytecode-to-boogie/tests/goldenfiles/test-access-path.bpl
@@ -121,16 +121,21 @@ requires ExistsTxnSenderAccount(__m, __txn);
     var __tmp: Value;
     var __frame: int;
     var __saved_m: Memory;
+    var debug#LibraCoin#mint_with_default_capability#0#amount: [Position]Value;
+    var debug#LibraCoin#mint_with_default_capability#1#__ret: [Position]Value;
 
     // initialize function execution
     assume !__abort_flag;
     __saved_m := __m;
     __frame := __local_counter;
     __local_counter := __local_counter + 5;
+    debug#LibraCoin#mint_with_default_capability#0#amount := EmptyPositionMap;
+    debug#LibraCoin#mint_with_default_capability#1#__ret := EmptyPositionMap;
 
     // process and type check arguments
     assume IsValidU64(amount);
     __m := UpdateLocal(__m, __frame + 0, amount);
+    debug#LibraCoin#mint_with_default_capability#0#amount := debug#LibraCoin#mint_with_default_capability#0#amount[Position(807) := amount];
 
     // bytecode translation starts here
     call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 0));
@@ -149,17 +154,19 @@ requires ExistsTxnSenderAccount(__m, __txn);
     __m := UpdateLocal(__m, __frame + 4, __t4);
 
     __ret0 := GetLocal(__m, __frame + 4);
+    debug#LibraCoin#mint_with_default_capability#1#__ret := debug#LibraCoin#mint_with_default_capability#1#__ret[Position(909) := __ret0];
     return;
 
 Label_Abort:
     __abort_flag := true;
     __m := __saved_m;
     __ret0 := DefaultValue;
+    debug#LibraCoin#mint_with_default_capability#1#__ret := debug#LibraCoin#mint_with_default_capability#1#__ret[Position(994) := __ret0];
 }
 
 procedure LibraCoin_mint_with_default_capability_verify (amount: Value) returns (__ret0: Value)
 {
-    assume ExistsTxnSenderAccount(__m, __txn);
+    call InitVerification();
     call __ret0 := LibraCoin_mint_with_default_capability(amount);
 }
 
@@ -189,18 +196,28 @@ requires ExistsTxnSenderAccount(__m, __txn);
     var __tmp: Value;
     var __frame: int;
     var __saved_m: Memory;
+    var debug#LibraCoin#mint#0#value: [Position]Value;
+    var debug#LibraCoin#mint#1#capability: [Position]Value;
+    var debug#LibraCoin#mint#2#total_value_ref: [Position]Value;
+    var debug#LibraCoin#mint#3#__ret: [Position]Value;
 
     // initialize function execution
     assume !__abort_flag;
     __saved_m := __m;
     __frame := __local_counter;
     __local_counter := __local_counter + 21;
+    debug#LibraCoin#mint#0#value := EmptyPositionMap;
+    debug#LibraCoin#mint#1#capability := EmptyPositionMap;
+    debug#LibraCoin#mint#2#total_value_ref := EmptyPositionMap;
+    debug#LibraCoin#mint#3#__ret := EmptyPositionMap;
 
     // process and type check arguments
     assume IsValidU64(value);
     __m := UpdateLocal(__m, __frame + 0, value);
+    debug#LibraCoin#mint#0#value := debug#LibraCoin#mint#0#value[Position(1231) := value];
     assume is#Vector(Dereference(__m, capability));
     assume IsValidReferenceParameter(__m, __frame, capability);
+    debug#LibraCoin#mint#1#capability := debug#LibraCoin#mint#1#capability[Position(1231) := Dereference(__m, capability)];
 
     // bytecode translation starts here
     call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 0));
@@ -269,17 +286,19 @@ Label_9:
     __m := UpdateLocal(__m, __frame + 20, __tmp);
 
     __ret0 := GetLocal(__m, __frame + 20);
+    debug#LibraCoin#mint#3#__ret := debug#LibraCoin#mint#3#__ret[Position(2067) := __ret0];
     return;
 
 Label_Abort:
     __abort_flag := true;
     __m := __saved_m;
     __ret0 := DefaultValue;
+    debug#LibraCoin#mint#3#__ret := debug#LibraCoin#mint#3#__ret[Position(2101) := __ret0];
 }
 
 procedure LibraCoin_mint_verify (value: Value, capability: Reference) returns (__ret0: Value)
 {
-    assume ExistsTxnSenderAccount(__m, __txn);
+    call InitVerification();
     call __ret0 := LibraCoin_mint(value, capability);
 }
 
@@ -357,7 +376,7 @@ Label_Abort:
 
 procedure LibraCoin_initialize_verify () returns ()
 {
-    assume ExistsTxnSenderAccount(__m, __txn);
+    call InitVerification();
     call LibraCoin_initialize();
 }
 
@@ -372,12 +391,14 @@ requires ExistsTxnSenderAccount(__m, __txn);
     var __tmp: Value;
     var __frame: int;
     var __saved_m: Memory;
+    var debug#LibraCoin#market_cap#0#__ret: [Position]Value;
 
     // initialize function execution
     assume !__abort_flag;
     __saved_m := __m;
     __frame := __local_counter;
     __local_counter := __local_counter + 4;
+    debug#LibraCoin#market_cap#0#__ret := EmptyPositionMap;
 
     // process and type check arguments
 
@@ -395,17 +416,19 @@ requires ExistsTxnSenderAccount(__m, __txn);
     __m := UpdateLocal(__m, __frame + 3, __tmp);
 
     __ret0 := GetLocal(__m, __frame + 3);
+    debug#LibraCoin#market_cap#0#__ret := debug#LibraCoin#market_cap#0#__ret[Position(2657) := __ret0];
     return;
 
 Label_Abort:
     __abort_flag := true;
     __m := __saved_m;
     __ret0 := DefaultValue;
+    debug#LibraCoin#market_cap#0#__ret := debug#LibraCoin#market_cap#0#__ret[Position(2721) := __ret0];
 }
 
 procedure LibraCoin_market_cap_verify () returns (__ret0: Value)
 {
-    assume ExistsTxnSenderAccount(__m, __txn);
+    call InitVerification();
     call __ret0 := LibraCoin_market_cap();
 }
 
@@ -418,12 +441,14 @@ requires ExistsTxnSenderAccount(__m, __txn);
     var __tmp: Value;
     var __frame: int;
     var __saved_m: Memory;
+    var debug#LibraCoin#zero#0#__ret: [Position]Value;
 
     // initialize function execution
     assume !__abort_flag;
     __saved_m := __m;
     __frame := __local_counter;
     __local_counter := __local_counter + 2;
+    debug#LibraCoin#zero#0#__ret := EmptyPositionMap;
 
     // process and type check arguments
 
@@ -435,17 +460,19 @@ requires ExistsTxnSenderAccount(__m, __txn);
     __m := UpdateLocal(__m, __frame + 1, __tmp);
 
     __ret0 := GetLocal(__m, __frame + 1);
+    debug#LibraCoin#zero#0#__ret := debug#LibraCoin#zero#0#__ret[Position(2810) := __ret0];
     return;
 
 Label_Abort:
     __abort_flag := true;
     __m := __saved_m;
     __ret0 := DefaultValue;
+    debug#LibraCoin#zero#0#__ret := debug#LibraCoin#zero#0#__ret[Position(2834) := __ret0];
 }
 
 procedure LibraCoin_zero_verify () returns (__ret0: Value)
 {
-    assume ExistsTxnSenderAccount(__m, __txn);
+    call InitVerification();
     call __ret0 := LibraCoin_zero();
 }
 
@@ -459,16 +486,21 @@ requires ExistsTxnSenderAccount(__m, __txn);
     var __tmp: Value;
     var __frame: int;
     var __saved_m: Memory;
+    var debug#LibraCoin#value#0#coin_ref: [Position]Value;
+    var debug#LibraCoin#value#1#__ret: [Position]Value;
 
     // initialize function execution
     assume !__abort_flag;
     __saved_m := __m;
     __frame := __local_counter;
     __local_counter := __local_counter + 4;
+    debug#LibraCoin#value#0#coin_ref := EmptyPositionMap;
+    debug#LibraCoin#value#1#__ret := EmptyPositionMap;
 
     // process and type check arguments
     assume is#Vector(Dereference(__m, coin_ref));
     assume IsValidReferenceParameter(__m, __frame, coin_ref);
+    debug#LibraCoin#value#0#coin_ref := debug#LibraCoin#value#0#coin_ref[Position(2888) := Dereference(__m, coin_ref)];
 
     // bytecode translation starts here
     call __t1 := CopyOrMoveRef(coin_ref);
@@ -480,17 +512,19 @@ requires ExistsTxnSenderAccount(__m, __txn);
     __m := UpdateLocal(__m, __frame + 3, __tmp);
 
     __ret0 := GetLocal(__m, __frame + 3);
+    debug#LibraCoin#value#1#__ret := debug#LibraCoin#value#1#__ret[Position(2935) := __ret0];
     return;
 
 Label_Abort:
     __abort_flag := true;
     __m := __saved_m;
     __ret0 := DefaultValue;
+    debug#LibraCoin#value#1#__ret := debug#LibraCoin#value#1#__ret[Position(2970) := __ret0];
 }
 
 procedure LibraCoin_value_verify (coin_ref: Reference) returns (__ret0: Value)
 {
-    assume ExistsTxnSenderAccount(__m, __txn);
+    call InitVerification();
     call __ret0 := LibraCoin_value(coin_ref);
 }
 
@@ -507,18 +541,30 @@ requires ExistsTxnSenderAccount(__m, __txn);
     var __tmp: Value;
     var __frame: int;
     var __saved_m: Memory;
+    var debug#LibraCoin#split#0#coin: [Position]Value;
+    var debug#LibraCoin#split#1#amount: [Position]Value;
+    var debug#LibraCoin#split#2#other: [Position]Value;
+    var debug#LibraCoin#split#3#__ret: [Position]Value;
+    var debug#LibraCoin#split#4#__ret: [Position]Value;
 
     // initialize function execution
     assume !__abort_flag;
     __saved_m := __m;
     __frame := __local_counter;
     __local_counter := __local_counter + 8;
+    debug#LibraCoin#split#0#coin := EmptyPositionMap;
+    debug#LibraCoin#split#1#amount := EmptyPositionMap;
+    debug#LibraCoin#split#2#other := EmptyPositionMap;
+    debug#LibraCoin#split#3#__ret := EmptyPositionMap;
+    debug#LibraCoin#split#4#__ret := EmptyPositionMap;
 
     // process and type check arguments
     assume is#Vector(coin);
     __m := UpdateLocal(__m, __frame + 0, coin);
+    debug#LibraCoin#split#0#coin := debug#LibraCoin#split#0#coin[Position(3109) := coin];
     assume IsValidU64(amount);
     __m := UpdateLocal(__m, __frame + 1, amount);
+    debug#LibraCoin#split#1#amount := debug#LibraCoin#split#1#amount[Position(3109) := amount];
 
     // bytecode translation starts here
     call __t3 := BorrowLoc(__frame + 0);
@@ -531,9 +577,11 @@ requires ExistsTxnSenderAccount(__m, __txn);
     assume is#Vector(__t5);
 
     __m := UpdateLocal(__m, __frame + 5, __t5);
+    debug#LibraCoin#split#0#coin := debug#LibraCoin#split#0#coin[Position(3211) := GetLocal(__m, __frame + 0)];
 
     call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 5));
     __m := UpdateLocal(__m, __frame + 2, __tmp);
+    debug#LibraCoin#split#2#other := debug#LibraCoin#split#2#other[Position(3203) := __tmp];
 
     call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 0));
     __m := UpdateLocal(__m, __frame + 6, __tmp);
@@ -542,19 +590,23 @@ requires ExistsTxnSenderAccount(__m, __txn);
     __m := UpdateLocal(__m, __frame + 7, __tmp);
 
     __ret0 := GetLocal(__m, __frame + 6);
+    debug#LibraCoin#split#3#__ret := debug#LibraCoin#split#3#__ret[Position(3259) := __ret0];
     __ret1 := GetLocal(__m, __frame + 7);
+    debug#LibraCoin#split#4#__ret := debug#LibraCoin#split#4#__ret[Position(3259) := __ret1];
     return;
 
 Label_Abort:
     __abort_flag := true;
     __m := __saved_m;
     __ret0 := DefaultValue;
+    debug#LibraCoin#split#3#__ret := debug#LibraCoin#split#3#__ret[Position(3295) := __ret0];
     __ret1 := DefaultValue;
+    debug#LibraCoin#split#4#__ret := debug#LibraCoin#split#4#__ret[Position(3295) := __ret1];
 }
 
 procedure LibraCoin_split_verify (coin: Value, amount: Value) returns (__ret0: Value, __ret1: Value)
 {
-    assume ExistsTxnSenderAccount(__m, __txn);
+    call InitVerification();
     call __ret0, __ret1 := LibraCoin_split(coin, amount);
 }
 
@@ -581,18 +633,28 @@ requires ExistsTxnSenderAccount(__m, __txn);
     var __tmp: Value;
     var __frame: int;
     var __saved_m: Memory;
+    var debug#LibraCoin#withdraw#0#coin_ref: [Position]Value;
+    var debug#LibraCoin#withdraw#1#amount: [Position]Value;
+    var debug#LibraCoin#withdraw#2#value: [Position]Value;
+    var debug#LibraCoin#withdraw#3#__ret: [Position]Value;
 
     // initialize function execution
     assume !__abort_flag;
     __saved_m := __m;
     __frame := __local_counter;
     __local_counter := __local_counter + 18;
+    debug#LibraCoin#withdraw#0#coin_ref := EmptyPositionMap;
+    debug#LibraCoin#withdraw#1#amount := EmptyPositionMap;
+    debug#LibraCoin#withdraw#2#value := EmptyPositionMap;
+    debug#LibraCoin#withdraw#3#__ret := EmptyPositionMap;
 
     // process and type check arguments
     assume is#Vector(Dereference(__m, coin_ref));
     assume IsValidReferenceParameter(__m, __frame, coin_ref);
+    debug#LibraCoin#withdraw#0#coin_ref := debug#LibraCoin#withdraw#0#coin_ref[Position(3557) := Dereference(__m, coin_ref)];
     assume IsValidU64(amount);
     __m := UpdateLocal(__m, __frame + 1, amount);
+    debug#LibraCoin#withdraw#1#amount := debug#LibraCoin#withdraw#1#amount[Position(3557) := amount];
 
     // bytecode translation starts here
     call __t3 := CopyOrMoveRef(coin_ref);
@@ -605,6 +667,7 @@ requires ExistsTxnSenderAccount(__m, __txn);
 
     call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 5));
     __m := UpdateLocal(__m, __frame + 2, __tmp);
+    debug#LibraCoin#withdraw#2#value := debug#LibraCoin#withdraw#2#value[Position(3713) := __tmp];
 
     call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 2));
     __m := UpdateLocal(__m, __frame + 6, __tmp);
@@ -650,17 +713,19 @@ Label_11:
     __m := UpdateLocal(__m, __frame + 17, __tmp);
 
     __ret0 := GetLocal(__m, __frame + 17);
+    debug#LibraCoin#withdraw#3#__ret := debug#LibraCoin#withdraw#3#__ret[Position(3902) := __ret0];
     return;
 
 Label_Abort:
     __abort_flag := true;
     __m := __saved_m;
     __ret0 := DefaultValue;
+    debug#LibraCoin#withdraw#3#__ret := debug#LibraCoin#withdraw#3#__ret[Position(3937) := __ret0];
 }
 
 procedure LibraCoin_withdraw_verify (coin_ref: Reference, amount: Value) returns (__ret0: Value)
 {
-    assume ExistsTxnSenderAccount(__m, __txn);
+    call InitVerification();
     call __ret0 := LibraCoin_withdraw(coin_ref, amount);
 }
 
@@ -674,18 +739,26 @@ requires ExistsTxnSenderAccount(__m, __txn);
     var __tmp: Value;
     var __frame: int;
     var __saved_m: Memory;
+    var debug#LibraCoin#join#0#coin1: [Position]Value;
+    var debug#LibraCoin#join#1#coin2: [Position]Value;
+    var debug#LibraCoin#join#2#__ret: [Position]Value;
 
     // initialize function execution
     assume !__abort_flag;
     __saved_m := __m;
     __frame := __local_counter;
     __local_counter := __local_counter + 5;
+    debug#LibraCoin#join#0#coin1 := EmptyPositionMap;
+    debug#LibraCoin#join#1#coin2 := EmptyPositionMap;
+    debug#LibraCoin#join#2#__ret := EmptyPositionMap;
 
     // process and type check arguments
     assume is#Vector(coin1);
     __m := UpdateLocal(__m, __frame + 0, coin1);
+    debug#LibraCoin#join#0#coin1 := debug#LibraCoin#join#0#coin1[Position(4041) := coin1];
     assume is#Vector(coin2);
     __m := UpdateLocal(__m, __frame + 1, coin2);
+    debug#LibraCoin#join#1#coin2 := debug#LibraCoin#join#1#coin2[Position(4041) := coin2];
 
     // bytecode translation starts here
     call __t2 := BorrowLoc(__frame + 0);
@@ -695,22 +768,25 @@ requires ExistsTxnSenderAccount(__m, __txn);
 
     call LibraCoin_deposit(__t2, GetLocal(__m, __frame + 3));
     if (__abort_flag) { goto Label_Abort; }
+    debug#LibraCoin#join#0#coin1 := debug#LibraCoin#join#0#coin1[Position(4102) := GetLocal(__m, __frame + 0)];
 
     call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 0));
     __m := UpdateLocal(__m, __frame + 4, __tmp);
 
     __ret0 := GetLocal(__m, __frame + 4);
+    debug#LibraCoin#join#2#__ret := debug#LibraCoin#join#2#__ret[Position(4149) := __ret0];
     return;
 
 Label_Abort:
     __abort_flag := true;
     __m := __saved_m;
     __ret0 := DefaultValue;
+    debug#LibraCoin#join#2#__ret := debug#LibraCoin#join#2#__ret[Position(4173) := __ret0];
 }
 
 procedure LibraCoin_join_verify (coin1: Value, coin2: Value) returns (__ret0: Value)
 {
-    assume ExistsTxnSenderAccount(__m, __txn);
+    call InitVerification();
     call __ret0 := LibraCoin_join(coin1, coin2);
 }
 
@@ -733,18 +809,28 @@ requires ExistsTxnSenderAccount(__m, __txn);
     var __tmp: Value;
     var __frame: int;
     var __saved_m: Memory;
+    var debug#LibraCoin#deposit#0#coin_ref: [Position]Value;
+    var debug#LibraCoin#deposit#1#check: [Position]Value;
+    var debug#LibraCoin#deposit#2#value: [Position]Value;
+    var debug#LibraCoin#deposit#3#check_value: [Position]Value;
 
     // initialize function execution
     assume !__abort_flag;
     __saved_m := __m;
     __frame := __local_counter;
     __local_counter := __local_counter + 14;
+    debug#LibraCoin#deposit#0#coin_ref := EmptyPositionMap;
+    debug#LibraCoin#deposit#1#check := EmptyPositionMap;
+    debug#LibraCoin#deposit#2#value := EmptyPositionMap;
+    debug#LibraCoin#deposit#3#check_value := EmptyPositionMap;
 
     // process and type check arguments
     assume is#Vector(Dereference(__m, coin_ref));
     assume IsValidReferenceParameter(__m, __frame, coin_ref);
+    debug#LibraCoin#deposit#0#coin_ref := debug#LibraCoin#deposit#0#coin_ref[Position(4352) := Dereference(__m, coin_ref)];
     assume is#Vector(check);
     __m := UpdateLocal(__m, __frame + 1, check);
+    debug#LibraCoin#deposit#1#check := debug#LibraCoin#deposit#1#check[Position(4352) := check];
 
     // bytecode translation starts here
     call __t4 := CopyOrMoveRef(coin_ref);
@@ -757,6 +843,7 @@ requires ExistsTxnSenderAccount(__m, __txn);
 
     call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 6));
     __m := UpdateLocal(__m, __frame + 2, __tmp);
+    debug#LibraCoin#deposit#2#value := debug#LibraCoin#deposit#2#value[Position(4470) := __tmp];
 
     call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 1));
     __m := UpdateLocal(__m, __frame + 7, __tmp);
@@ -766,6 +853,7 @@ requires ExistsTxnSenderAccount(__m, __txn);
 
     call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 8));
     __m := UpdateLocal(__m, __frame + 3, __tmp);
+    debug#LibraCoin#deposit#3#check_value := debug#LibraCoin#deposit#3#check_value[Position(4520) := __tmp];
 
     call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 2));
     __m := UpdateLocal(__m, __frame + 9, __tmp);
@@ -792,7 +880,7 @@ Label_Abort:
 
 procedure LibraCoin_deposit_verify (coin_ref: Reference, check: Value) returns ()
 {
-    assume ExistsTxnSenderAccount(__m, __txn);
+    call InitVerification();
     call LibraCoin_deposit(coin_ref, check);
 }
 
@@ -811,16 +899,21 @@ requires ExistsTxnSenderAccount(__m, __txn);
     var __tmp: Value;
     var __frame: int;
     var __saved_m: Memory;
+    var debug#LibraCoin#destroy_zero#0#coin: [Position]Value;
+    var debug#LibraCoin#destroy_zero#1#value: [Position]Value;
 
     // initialize function execution
     assume !__abort_flag;
     __saved_m := __m;
     __frame := __local_counter;
     __local_counter := __local_counter + 9;
+    debug#LibraCoin#destroy_zero#0#coin := EmptyPositionMap;
+    debug#LibraCoin#destroy_zero#1#value := EmptyPositionMap;
 
     // process and type check arguments
     assume is#Vector(coin);
     __m := UpdateLocal(__m, __frame + 0, coin);
+    debug#LibraCoin#destroy_zero#0#coin := debug#LibraCoin#destroy_zero#0#coin[Position(4858) := coin];
 
     // bytecode translation starts here
     call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 0));
@@ -831,6 +924,7 @@ requires ExistsTxnSenderAccount(__m, __txn);
 
     call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 3));
     __m := UpdateLocal(__m, __frame + 1, __tmp);
+    debug#LibraCoin#destroy_zero#1#value := debug#LibraCoin#destroy_zero#1#value[Position(4930) := __tmp];
 
     call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 1));
     __m := UpdateLocal(__m, __frame + 4, __tmp);
@@ -862,7 +956,7 @@ Label_Abort:
 
 procedure LibraCoin_destroy_zero_verify (coin: Value) returns ()
 {
-    assume ExistsTxnSenderAccount(__m, __txn);
+    call InitVerification();
     call LibraCoin_destroy_zero(coin);
 }
 
@@ -909,12 +1003,14 @@ requires ExistsTxnSenderAccount(__m, __txn);
     var __tmp: Value;
     var __frame: int;
     var __saved_m: Memory;
+    var debug#LibraTimestamp#initialize_timer#0#timer: [Position]Value;
 
     // initialize function execution
     assume !__abort_flag;
     __saved_m := __m;
     __frame := __local_counter;
     __local_counter := __local_counter + 9;
+    debug#LibraTimestamp#initialize_timer#0#timer := EmptyPositionMap;
 
     // process and type check arguments
 
@@ -948,6 +1044,7 @@ Label_7:
 
     call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 7));
     __m := UpdateLocal(__m, __frame + 0, __tmp);
+    debug#LibraTimestamp#initialize_timer#0#timer := debug#LibraTimestamp#initialize_timer#0#timer[Position(490) := __tmp];
 
     call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 0));
     __m := UpdateLocal(__m, __frame + 8, __tmp);
@@ -964,7 +1061,7 @@ Label_Abort:
 
 procedure LibraTimestamp_initialize_timer_verify () returns ()
 {
-    assume ExistsTxnSenderAccount(__m, __txn);
+    call InitVerification();
     call LibraTimestamp_initialize_timer();
 }
 
@@ -998,18 +1095,26 @@ requires ExistsTxnSenderAccount(__m, __txn);
     var __tmp: Value;
     var __frame: int;
     var __saved_m: Memory;
+    var debug#LibraTimestamp#update_global_time#0#proposer: [Position]Value;
+    var debug#LibraTimestamp#update_global_time#1#timestamp: [Position]Value;
+    var debug#LibraTimestamp#update_global_time#2#global_timer: [Position]Value;
 
     // initialize function execution
     assume !__abort_flag;
     __saved_m := __m;
     __frame := __local_counter;
     __local_counter := __local_counter + 25;
+    debug#LibraTimestamp#update_global_time#0#proposer := EmptyPositionMap;
+    debug#LibraTimestamp#update_global_time#1#timestamp := EmptyPositionMap;
+    debug#LibraTimestamp#update_global_time#2#global_timer := EmptyPositionMap;
 
     // process and type check arguments
     assume is#Address(proposer);
     __m := UpdateLocal(__m, __frame + 0, proposer);
+    debug#LibraTimestamp#update_global_time#0#proposer := debug#LibraTimestamp#update_global_time#0#proposer[Position(743) := proposer];
     assume IsValidU64(timestamp);
     __m := UpdateLocal(__m, __frame + 1, timestamp);
+    debug#LibraTimestamp#update_global_time#1#timestamp := debug#LibraTimestamp#update_global_time#1#timestamp[Position(743) := timestamp];
 
     // bytecode translation starts here
     call __tmp := LdAddr(173345816);
@@ -1105,7 +1210,7 @@ Label_Abort:
 
 procedure LibraTimestamp_update_global_time_verify (proposer: Value, timestamp: Value) returns ()
 {
-    assume ExistsTxnSenderAccount(__m, __txn);
+    call InitVerification();
     call LibraTimestamp_update_global_time(proposer, timestamp);
 }
 
@@ -1120,12 +1225,14 @@ requires ExistsTxnSenderAccount(__m, __txn);
     var __tmp: Value;
     var __frame: int;
     var __saved_m: Memory;
+    var debug#LibraTimestamp#now_microseconds#0#__ret: [Position]Value;
 
     // initialize function execution
     assume !__abort_flag;
     __saved_m := __m;
     __frame := __local_counter;
     __local_counter := __local_counter + 4;
+    debug#LibraTimestamp#now_microseconds#0#__ret := EmptyPositionMap;
 
     // process and type check arguments
 
@@ -1143,17 +1250,19 @@ requires ExistsTxnSenderAccount(__m, __txn);
     __m := UpdateLocal(__m, __frame + 3, __tmp);
 
     __ret0 := GetLocal(__m, __frame + 3);
+    debug#LibraTimestamp#now_microseconds#0#__ret := debug#LibraTimestamp#now_microseconds#0#__ret[Position(1736) := __ret0];
     return;
 
 Label_Abort:
     __abort_flag := true;
     __m := __saved_m;
     __ret0 := DefaultValue;
+    debug#LibraTimestamp#now_microseconds#0#__ret := debug#LibraTimestamp#now_microseconds#0#__ret[Position(1815) := __ret0];
 }
 
 procedure LibraTimestamp_now_microseconds_verify () returns (__ret0: Value)
 {
-    assume ExistsTxnSenderAccount(__m, __txn);
+    call InitVerification();
     call __ret0 := LibraTimestamp_now_microseconds();
 }
 
@@ -1200,12 +1309,14 @@ requires ExistsTxnSenderAccount(__m, __txn);
     var __tmp: Value;
     var __frame: int;
     var __saved_m: Memory;
+    var debug#LibraTransactionTimeout#initialize#0#timeout: [Position]Value;
 
     // initialize function execution
     assume !__abort_flag;
     __saved_m := __m;
     __frame := __local_counter;
     __local_counter := __local_counter + 9;
+    debug#LibraTransactionTimeout#initialize#0#timeout := EmptyPositionMap;
 
     // process and type check arguments
 
@@ -1239,6 +1350,7 @@ Label_7:
 
     call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 7));
     __m := UpdateLocal(__m, __frame + 0, __tmp);
+    debug#LibraTransactionTimeout#initialize#0#timeout := debug#LibraTransactionTimeout#initialize#0#timeout[Position(441) := __tmp];
 
     call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 0));
     __m := UpdateLocal(__m, __frame + 8, __tmp);
@@ -1255,7 +1367,7 @@ Label_Abort:
 
 procedure LibraTransactionTimeout_initialize_verify () returns ()
 {
-    assume ExistsTxnSenderAccount(__m, __txn);
+    call InitVerification();
     call LibraTransactionTimeout_initialize();
 }
 
@@ -1277,16 +1389,21 @@ requires ExistsTxnSenderAccount(__m, __txn);
     var __tmp: Value;
     var __frame: int;
     var __saved_m: Memory;
+    var debug#LibraTransactionTimeout#set_timeout#0#new_duration: [Position]Value;
+    var debug#LibraTransactionTimeout#set_timeout#1#timeout: [Position]Value;
 
     // initialize function execution
     assume !__abort_flag;
     __saved_m := __m;
     __frame := __local_counter;
     __local_counter := __local_counter + 12;
+    debug#LibraTransactionTimeout#set_timeout#0#new_duration := EmptyPositionMap;
+    debug#LibraTransactionTimeout#set_timeout#1#timeout := EmptyPositionMap;
 
     // process and type check arguments
     assume IsValidU64(new_duration);
     __m := UpdateLocal(__m, __frame + 0, new_duration);
+    debug#LibraTransactionTimeout#set_timeout#0#new_duration := debug#LibraTransactionTimeout#set_timeout#0#new_duration[Position(564) := new_duration];
 
     // bytecode translation starts here
     call __tmp := GetTxnSenderAddress();
@@ -1336,7 +1453,7 @@ Label_Abort:
 
 procedure LibraTransactionTimeout_set_timeout_verify (new_duration: Value) returns ()
 {
-    assume ExistsTxnSenderAccount(__m, __txn);
+    call InitVerification();
     call LibraTransactionTimeout_set_timeout(new_duration);
 }
 
@@ -1369,16 +1486,29 @@ requires ExistsTxnSenderAccount(__m, __txn);
     var __tmp: Value;
     var __frame: int;
     var __saved_m: Memory;
+    var debug#LibraTransactionTimeout#is_valid_transaction_timestamp#0#timestamp: [Position]Value;
+    var debug#LibraTransactionTimeout#is_valid_transaction_timestamp#1#current_block_time: [Position]Value;
+    var debug#LibraTransactionTimeout#is_valid_transaction_timestamp#2#max_txn_time: [Position]Value;
+    var debug#LibraTransactionTimeout#is_valid_transaction_timestamp#3#timeout: [Position]Value;
+    var debug#LibraTransactionTimeout#is_valid_transaction_timestamp#4#txn_time_microseconds: [Position]Value;
+    var debug#LibraTransactionTimeout#is_valid_transaction_timestamp#5#__ret: [Position]Value;
 
     // initialize function execution
     assume !__abort_flag;
     __saved_m := __m;
     __frame := __local_counter;
     __local_counter := __local_counter + 23;
+    debug#LibraTransactionTimeout#is_valid_transaction_timestamp#0#timestamp := EmptyPositionMap;
+    debug#LibraTransactionTimeout#is_valid_transaction_timestamp#1#current_block_time := EmptyPositionMap;
+    debug#LibraTransactionTimeout#is_valid_transaction_timestamp#2#max_txn_time := EmptyPositionMap;
+    debug#LibraTransactionTimeout#is_valid_transaction_timestamp#3#timeout := EmptyPositionMap;
+    debug#LibraTransactionTimeout#is_valid_transaction_timestamp#4#txn_time_microseconds := EmptyPositionMap;
+    debug#LibraTransactionTimeout#is_valid_transaction_timestamp#5#__ret := EmptyPositionMap;
 
     // process and type check arguments
     assume IsValidU64(timestamp);
     __m := UpdateLocal(__m, __frame + 0, timestamp);
+    debug#LibraTransactionTimeout#is_valid_transaction_timestamp#0#timestamp := debug#LibraTransactionTimeout#is_valid_transaction_timestamp#0#timestamp[Position(911) := timestamp];
 
     // bytecode translation starts here
     call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 0));
@@ -1397,6 +1527,7 @@ requires ExistsTxnSenderAccount(__m, __txn);
     __m := UpdateLocal(__m, __frame + 8, __tmp);
 
     __ret0 := GetLocal(__m, __frame + 8);
+    debug#LibraTransactionTimeout#is_valid_transaction_timestamp#5#__ret := debug#LibraTransactionTimeout#is_valid_transaction_timestamp#5#__ret[Position(1242) := __ret0];
     return;
 
 Label_6:
@@ -1408,6 +1539,7 @@ Label_6:
 
     call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 9));
     __m := UpdateLocal(__m, __frame + 1, __tmp);
+    debug#LibraTransactionTimeout#is_valid_transaction_timestamp#1#current_block_time := debug#LibraTransactionTimeout#is_valid_transaction_timestamp#1#current_block_time[Position(1275) := __tmp];
 
     call __tmp := LdAddr(173345816);
     __m := UpdateLocal(__m, __frame + 10, __tmp);
@@ -1423,6 +1555,7 @@ Label_6:
 
     call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 13));
     __m := UpdateLocal(__m, __frame + 3, __tmp);
+    debug#LibraTransactionTimeout#is_valid_transaction_timestamp#3#timeout := debug#LibraTransactionTimeout#is_valid_transaction_timestamp#3#timeout[Position(1339) := __tmp];
 
     call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 1));
     __m := UpdateLocal(__m, __frame + 14, __tmp);
@@ -1436,6 +1569,7 @@ Label_6:
 
     call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 16));
     __m := UpdateLocal(__m, __frame + 2, __tmp);
+    debug#LibraTransactionTimeout#is_valid_transaction_timestamp#2#max_txn_time := debug#LibraTransactionTimeout#is_valid_transaction_timestamp#2#max_txn_time[Position(1412) := __tmp];
 
     call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 0));
     __m := UpdateLocal(__m, __frame + 17, __tmp);
@@ -1449,6 +1583,7 @@ Label_6:
 
     call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 19));
     __m := UpdateLocal(__m, __frame + 4, __tmp);
+    debug#LibraTransactionTimeout#is_valid_transaction_timestamp#4#txn_time_microseconds := debug#LibraTransactionTimeout#is_valid_transaction_timestamp#4#txn_time_microseconds[Position(1478) := __tmp];
 
     call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 1));
     __m := UpdateLocal(__m, __frame + 20, __tmp);
@@ -1460,17 +1595,19 @@ Label_6:
     __m := UpdateLocal(__m, __frame + 22, __tmp);
 
     __ret0 := GetLocal(__m, __frame + 22);
+    debug#LibraTransactionTimeout#is_valid_transaction_timestamp#5#__ret := debug#LibraTransactionTimeout#is_valid_transaction_timestamp#5#__ret[Position(1893) := __ret0];
     return;
 
 Label_Abort:
     __abort_flag := true;
     __m := __saved_m;
     __ret0 := DefaultValue;
+    debug#LibraTransactionTimeout#is_valid_transaction_timestamp#5#__ret := debug#LibraTransactionTimeout#is_valid_transaction_timestamp#5#__ret[Position(1960) := __ret0];
 }
 
 procedure LibraTransactionTimeout_is_valid_transaction_timestamp_verify (timestamp: Value) returns (__ret0: Value)
 {
-    assume ExistsTxnSenderAccount(__m, __txn);
+    call InitVerification();
     call __ret0 := LibraTransactionTimeout_is_valid_transaction_timestamp(timestamp);
 }
 
@@ -1683,18 +1820,24 @@ requires ExistsTxnSenderAccount(__m, __txn);
     var __tmp: Value;
     var __frame: int;
     var __saved_m: Memory;
+    var debug#LibraAccount#deposit#0#payee: [Position]Value;
+    var debug#LibraAccount#deposit#1#to_deposit: [Position]Value;
 
     // initialize function execution
     assume !__abort_flag;
     __saved_m := __m;
     __frame := __local_counter;
     __local_counter := __local_counter + 5;
+    debug#LibraAccount#deposit#0#payee := EmptyPositionMap;
+    debug#LibraAccount#deposit#1#to_deposit := EmptyPositionMap;
 
     // process and type check arguments
     assume is#Address(payee);
     __m := UpdateLocal(__m, __frame + 0, payee);
+    debug#LibraAccount#deposit#0#payee := debug#LibraAccount#deposit#0#payee[Position(3305) := payee];
     assume is#Vector(to_deposit);
     __m := UpdateLocal(__m, __frame + 1, to_deposit);
+    debug#LibraAccount#deposit#1#to_deposit := debug#LibraAccount#deposit#1#to_deposit[Position(3305) := to_deposit];
 
     // bytecode translation starts here
     call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 0));
@@ -1717,7 +1860,7 @@ Label_Abort:
 
 procedure LibraAccount_deposit_verify (payee: Value, to_deposit: Value) returns ()
 {
-    assume ExistsTxnSenderAccount(__m, __txn);
+    call InitVerification();
     call LibraAccount_deposit(payee, to_deposit);
 }
 
@@ -1732,20 +1875,29 @@ requires ExistsTxnSenderAccount(__m, __txn);
     var __tmp: Value;
     var __frame: int;
     var __saved_m: Memory;
+    var debug#LibraAccount#deposit_with_metadata#0#payee: [Position]Value;
+    var debug#LibraAccount#deposit_with_metadata#1#to_deposit: [Position]Value;
+    var debug#LibraAccount#deposit_with_metadata#2#metadata: [Position]Value;
 
     // initialize function execution
     assume !__abort_flag;
     __saved_m := __m;
     __frame := __local_counter;
     __local_counter := __local_counter + 7;
+    debug#LibraAccount#deposit_with_metadata#0#payee := EmptyPositionMap;
+    debug#LibraAccount#deposit_with_metadata#1#to_deposit := EmptyPositionMap;
+    debug#LibraAccount#deposit_with_metadata#2#metadata := EmptyPositionMap;
 
     // process and type check arguments
     assume is#Address(payee);
     __m := UpdateLocal(__m, __frame + 0, payee);
+    debug#LibraAccount#deposit_with_metadata#0#payee := debug#LibraAccount#deposit_with_metadata#0#payee[Position(3567) := payee];
     assume is#Vector(to_deposit);
     __m := UpdateLocal(__m, __frame + 1, to_deposit);
+    debug#LibraAccount#deposit_with_metadata#1#to_deposit := debug#LibraAccount#deposit_with_metadata#1#to_deposit[Position(3567) := to_deposit];
     assume is#ByteArray(metadata);
     __m := UpdateLocal(__m, __frame + 2, metadata);
+    debug#LibraAccount#deposit_with_metadata#2#metadata := debug#LibraAccount#deposit_with_metadata#2#metadata[Position(3567) := metadata];
 
     // bytecode translation starts here
     call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 0));
@@ -1772,7 +1924,7 @@ Label_Abort:
 
 procedure LibraAccount_deposit_with_metadata_verify (payee: Value, to_deposit: Value, metadata: Value) returns ()
 {
-    assume ExistsTxnSenderAccount(__m, __txn);
+    call InitVerification();
     call LibraAccount_deposit_with_metadata(payee, to_deposit, metadata);
 }
 
@@ -1812,22 +1964,40 @@ requires ExistsTxnSenderAccount(__m, __txn);
     var __tmp: Value;
     var __frame: int;
     var __saved_m: Memory;
+    var debug#LibraAccount#deposit_with_sender_and_metadata#0#payee: [Position]Value;
+    var debug#LibraAccount#deposit_with_sender_and_metadata#1#sender: [Position]Value;
+    var debug#LibraAccount#deposit_with_sender_and_metadata#2#to_deposit: [Position]Value;
+    var debug#LibraAccount#deposit_with_sender_and_metadata#3#metadata: [Position]Value;
+    var debug#LibraAccount#deposit_with_sender_and_metadata#4#deposit_value: [Position]Value;
+    var debug#LibraAccount#deposit_with_sender_and_metadata#5#payee_account_ref: [Position]Value;
+    var debug#LibraAccount#deposit_with_sender_and_metadata#6#sender_account_ref: [Position]Value;
 
     // initialize function execution
     assume !__abort_flag;
     __saved_m := __m;
     __frame := __local_counter;
     __local_counter := __local_counter + 33;
+    debug#LibraAccount#deposit_with_sender_and_metadata#0#payee := EmptyPositionMap;
+    debug#LibraAccount#deposit_with_sender_and_metadata#1#sender := EmptyPositionMap;
+    debug#LibraAccount#deposit_with_sender_and_metadata#2#to_deposit := EmptyPositionMap;
+    debug#LibraAccount#deposit_with_sender_and_metadata#3#metadata := EmptyPositionMap;
+    debug#LibraAccount#deposit_with_sender_and_metadata#4#deposit_value := EmptyPositionMap;
+    debug#LibraAccount#deposit_with_sender_and_metadata#5#payee_account_ref := EmptyPositionMap;
+    debug#LibraAccount#deposit_with_sender_and_metadata#6#sender_account_ref := EmptyPositionMap;
 
     // process and type check arguments
     assume is#Address(payee);
     __m := UpdateLocal(__m, __frame + 0, payee);
+    debug#LibraAccount#deposit_with_sender_and_metadata#0#payee := debug#LibraAccount#deposit_with_sender_and_metadata#0#payee[Position(4018) := payee];
     assume is#Address(sender);
     __m := UpdateLocal(__m, __frame + 1, sender);
+    debug#LibraAccount#deposit_with_sender_and_metadata#1#sender := debug#LibraAccount#deposit_with_sender_and_metadata#1#sender[Position(4018) := sender];
     assume is#Vector(to_deposit);
     __m := UpdateLocal(__m, __frame + 2, to_deposit);
+    debug#LibraAccount#deposit_with_sender_and_metadata#2#to_deposit := debug#LibraAccount#deposit_with_sender_and_metadata#2#to_deposit[Position(4018) := to_deposit];
     assume is#ByteArray(metadata);
     __m := UpdateLocal(__m, __frame + 3, metadata);
+    debug#LibraAccount#deposit_with_sender_and_metadata#3#metadata := debug#LibraAccount#deposit_with_sender_and_metadata#3#metadata[Position(4018) := metadata];
 
     // bytecode translation starts here
     call __t7 := BorrowLoc(__frame + 2);
@@ -1840,6 +2010,7 @@ requires ExistsTxnSenderAccount(__m, __txn);
 
     call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 8));
     __m := UpdateLocal(__m, __frame + 4, __tmp);
+    debug#LibraAccount#deposit_with_sender_and_metadata#4#deposit_value := debug#LibraAccount#deposit_with_sender_and_metadata#4#deposit_value[Position(4367) := __tmp];
 
     call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 4));
     __m := UpdateLocal(__m, __frame + 9, __tmp);
@@ -1935,7 +2106,7 @@ Label_Abort:
 
 procedure LibraAccount_deposit_with_sender_and_metadata_verify (payee: Value, sender: Value, to_deposit: Value, metadata: Value) returns ()
 {
-    assume ExistsTxnSenderAccount(__m, __txn);
+    call InitVerification();
     call LibraAccount_deposit_with_sender_and_metadata(payee, sender, to_deposit, metadata);
 }
 
@@ -1953,18 +2124,24 @@ requires ExistsTxnSenderAccount(__m, __txn);
     var __tmp: Value;
     var __frame: int;
     var __saved_m: Memory;
+    var debug#LibraAccount#mint_to_address#0#payee: [Position]Value;
+    var debug#LibraAccount#mint_to_address#1#amount: [Position]Value;
 
     // initialize function execution
     assume !__abort_flag;
     __saved_m := __m;
     __frame := __local_counter;
     __local_counter := __local_counter + 9;
+    debug#LibraAccount#mint_to_address#0#payee := EmptyPositionMap;
+    debug#LibraAccount#mint_to_address#1#amount := EmptyPositionMap;
 
     // process and type check arguments
     assume is#Address(payee);
     __m := UpdateLocal(__m, __frame + 0, payee);
+    debug#LibraAccount#mint_to_address#0#payee := debug#LibraAccount#mint_to_address#0#payee[Position(5776) := payee];
     assume IsValidU64(amount);
     __m := UpdateLocal(__m, __frame + 1, amount);
+    debug#LibraAccount#mint_to_address#1#amount := debug#LibraAccount#mint_to_address#1#amount[Position(5776) := amount];
 
     // bytecode translation starts here
     call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 0));
@@ -2010,7 +2187,7 @@ Label_Abort:
 
 procedure LibraAccount_mint_to_address_verify (payee: Value, amount: Value) returns ()
 {
-    assume ExistsTxnSenderAccount(__m, __txn);
+    call InitVerification();
     call LibraAccount_mint_to_address(payee, amount);
 }
 
@@ -2027,18 +2204,28 @@ requires ExistsTxnSenderAccount(__m, __txn);
     var __tmp: Value;
     var __frame: int;
     var __saved_m: Memory;
+    var debug#LibraAccount#withdraw_from_account#0#account: [Position]Value;
+    var debug#LibraAccount#withdraw_from_account#1#amount: [Position]Value;
+    var debug#LibraAccount#withdraw_from_account#2#to_withdraw: [Position]Value;
+    var debug#LibraAccount#withdraw_from_account#3#__ret: [Position]Value;
 
     // initialize function execution
     assume !__abort_flag;
     __saved_m := __m;
     __frame := __local_counter;
     __local_counter := __local_counter + 8;
+    debug#LibraAccount#withdraw_from_account#0#account := EmptyPositionMap;
+    debug#LibraAccount#withdraw_from_account#1#amount := EmptyPositionMap;
+    debug#LibraAccount#withdraw_from_account#2#to_withdraw := EmptyPositionMap;
+    debug#LibraAccount#withdraw_from_account#3#__ret := EmptyPositionMap;
 
     // process and type check arguments
     assume is#Vector(Dereference(__m, account));
     assume IsValidReferenceParameter(__m, __frame, account);
+    debug#LibraAccount#withdraw_from_account#0#account := debug#LibraAccount#withdraw_from_account#0#account[Position(6237) := Dereference(__m, account)];
     assume IsValidU64(amount);
     __m := UpdateLocal(__m, __frame + 1, amount);
+    debug#LibraAccount#withdraw_from_account#1#amount := debug#LibraAccount#withdraw_from_account#1#amount[Position(6237) := amount];
 
     // bytecode translation starts here
     call __t3 := CopyOrMoveRef(account);
@@ -2056,22 +2243,25 @@ requires ExistsTxnSenderAccount(__m, __txn);
 
     call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 6));
     __m := UpdateLocal(__m, __frame + 2, __tmp);
+    debug#LibraAccount#withdraw_from_account#2#to_withdraw := debug#LibraAccount#withdraw_from_account#2#to_withdraw[Position(6356) := __tmp];
 
     call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 2));
     __m := UpdateLocal(__m, __frame + 7, __tmp);
 
     __ret0 := GetLocal(__m, __frame + 7);
+    debug#LibraAccount#withdraw_from_account#3#__ret := debug#LibraAccount#withdraw_from_account#3#__ret[Position(6440) := __ret0];
     return;
 
 Label_Abort:
     __abort_flag := true;
     __m := __saved_m;
     __ret0 := DefaultValue;
+    debug#LibraAccount#withdraw_from_account#3#__ret := debug#LibraAccount#withdraw_from_account#3#__ret[Position(6470) := __ret0];
 }
 
 procedure LibraAccount_withdraw_from_account_verify (account: Reference, amount: Value) returns (__ret0: Value)
 {
-    assume ExistsTxnSenderAccount(__m, __txn);
+    call InitVerification();
     call __ret0 := LibraAccount_withdraw_from_account(account, amount);
 }
 
@@ -2092,16 +2282,23 @@ requires ExistsTxnSenderAccount(__m, __txn);
     var __tmp: Value;
     var __frame: int;
     var __saved_m: Memory;
+    var debug#LibraAccount#withdraw_from_sender#0#amount: [Position]Value;
+    var debug#LibraAccount#withdraw_from_sender#1#sender_account: [Position]Value;
+    var debug#LibraAccount#withdraw_from_sender#2#__ret: [Position]Value;
 
     // initialize function execution
     assume !__abort_flag;
     __saved_m := __m;
     __frame := __local_counter;
     __local_counter := __local_counter + 11;
+    debug#LibraAccount#withdraw_from_sender#0#amount := EmptyPositionMap;
+    debug#LibraAccount#withdraw_from_sender#1#sender_account := EmptyPositionMap;
+    debug#LibraAccount#withdraw_from_sender#2#__ret := EmptyPositionMap;
 
     // process and type check arguments
     assume IsValidU64(amount);
     __m := UpdateLocal(__m, __frame + 0, amount);
+    debug#LibraAccount#withdraw_from_sender#0#amount := debug#LibraAccount#withdraw_from_sender#0#amount[Position(6552) := amount];
 
     // bytecode translation starts here
     call __tmp := GetTxnSenderAddress();
@@ -2141,17 +2338,19 @@ Label_9:
     __m := UpdateLocal(__m, __frame + 10, __t10);
 
     __ret0 := GetLocal(__m, __frame + 10);
+    debug#LibraAccount#withdraw_from_sender#2#__ret := debug#LibraAccount#withdraw_from_sender#2#__ret[Position(7024) := __ret0];
     return;
 
 Label_Abort:
     __abort_flag := true;
     __m := __saved_m;
     __ret0 := DefaultValue;
+    debug#LibraAccount#withdraw_from_sender#2#__ret := debug#LibraAccount#withdraw_from_sender#2#__ret[Position(7109) := __ret0];
 }
 
 procedure LibraAccount_withdraw_from_sender_verify (amount: Value) returns (__ret0: Value)
 {
-    assume ExistsTxnSenderAccount(__m, __txn);
+    call InitVerification();
     call __ret0 := LibraAccount_withdraw_from_sender(amount);
 }
 
@@ -2170,18 +2369,28 @@ requires ExistsTxnSenderAccount(__m, __txn);
     var __tmp: Value;
     var __frame: int;
     var __saved_m: Memory;
+    var debug#LibraAccount#withdraw_with_capability#0#cap: [Position]Value;
+    var debug#LibraAccount#withdraw_with_capability#1#amount: [Position]Value;
+    var debug#LibraAccount#withdraw_with_capability#2#account: [Position]Value;
+    var debug#LibraAccount#withdraw_with_capability#3#__ret: [Position]Value;
 
     // initialize function execution
     assume !__abort_flag;
     __saved_m := __m;
     __frame := __local_counter;
     __local_counter := __local_counter + 10;
+    debug#LibraAccount#withdraw_with_capability#0#cap := EmptyPositionMap;
+    debug#LibraAccount#withdraw_with_capability#1#amount := EmptyPositionMap;
+    debug#LibraAccount#withdraw_with_capability#2#account := EmptyPositionMap;
+    debug#LibraAccount#withdraw_with_capability#3#__ret := EmptyPositionMap;
 
     // process and type check arguments
     assume is#Vector(Dereference(__m, cap));
     assume IsValidReferenceParameter(__m, __frame, cap);
+    debug#LibraAccount#withdraw_with_capability#0#cap := debug#LibraAccount#withdraw_with_capability#0#cap[Position(7192) := Dereference(__m, cap)];
     assume IsValidU64(amount);
     __m := UpdateLocal(__m, __frame + 1, amount);
+    debug#LibraAccount#withdraw_with_capability#1#amount := debug#LibraAccount#withdraw_with_capability#1#amount[Position(7192) := amount];
 
     // bytecode translation starts here
     call __t3 := CopyOrMoveRef(cap);
@@ -2209,17 +2418,19 @@ requires ExistsTxnSenderAccount(__m, __txn);
     __m := UpdateLocal(__m, __frame + 9, __t9);
 
     __ret0 := GetLocal(__m, __frame + 9);
+    debug#LibraAccount#withdraw_with_capability#3#__ret := debug#LibraAccount#withdraw_with_capability#3#__ret[Position(7423) := __ret0];
     return;
 
 Label_Abort:
     __abort_flag := true;
     __m := __saved_m;
     __ret0 := DefaultValue;
+    debug#LibraAccount#withdraw_with_capability#3#__ret := debug#LibraAccount#withdraw_with_capability#3#__ret[Position(7491) := __ret0];
 }
 
 procedure LibraAccount_withdraw_with_capability_verify (cap: Reference, amount: Value) returns (__ret0: Value)
 {
-    assume ExistsTxnSenderAccount(__m, __txn);
+    call InitVerification();
     call __ret0 := LibraAccount_withdraw_with_capability(cap, amount);
 }
 
@@ -2245,12 +2456,20 @@ requires ExistsTxnSenderAccount(__m, __txn);
     var __tmp: Value;
     var __frame: int;
     var __saved_m: Memory;
+    var debug#LibraAccount#extract_sender_withdrawal_capability#0#sender: [Position]Value;
+    var debug#LibraAccount#extract_sender_withdrawal_capability#1#sender_account: [Position]Value;
+    var debug#LibraAccount#extract_sender_withdrawal_capability#2#delegated_ref: [Position]Value;
+    var debug#LibraAccount#extract_sender_withdrawal_capability#3#__ret: [Position]Value;
 
     // initialize function execution
     assume !__abort_flag;
     __saved_m := __m;
     __frame := __local_counter;
     __local_counter := __local_counter + 15;
+    debug#LibraAccount#extract_sender_withdrawal_capability#0#sender := EmptyPositionMap;
+    debug#LibraAccount#extract_sender_withdrawal_capability#1#sender_account := EmptyPositionMap;
+    debug#LibraAccount#extract_sender_withdrawal_capability#2#delegated_ref := EmptyPositionMap;
+    debug#LibraAccount#extract_sender_withdrawal_capability#3#__ret := EmptyPositionMap;
 
     // process and type check arguments
 
@@ -2260,6 +2479,7 @@ requires ExistsTxnSenderAccount(__m, __txn);
 
     call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 3));
     __m := UpdateLocal(__m, __frame + 0, __tmp);
+    debug#LibraAccount#extract_sender_withdrawal_capability#0#sender := debug#LibraAccount#extract_sender_withdrawal_capability#0#sender[Position(7802) := __tmp];
 
     call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 0));
     __m := UpdateLocal(__m, __frame + 4, __tmp);
@@ -2304,17 +2524,19 @@ Label_13:
     __m := UpdateLocal(__m, __frame + 14, __tmp);
 
     __ret0 := GetLocal(__m, __frame + 14);
+    debug#LibraAccount#extract_sender_withdrawal_capability#3#__ret := debug#LibraAccount#extract_sender_withdrawal_capability#3#__ret[Position(8228) := __ret0];
     return;
 
 Label_Abort:
     __abort_flag := true;
     __m := __saved_m;
     __ret0 := DefaultValue;
+    debug#LibraAccount#extract_sender_withdrawal_capability#3#__ret := debug#LibraAccount#extract_sender_withdrawal_capability#3#__ret[Position(8305) := __ret0];
 }
 
 procedure LibraAccount_extract_sender_withdrawal_capability_verify () returns (__ret0: Value)
 {
-    assume ExistsTxnSenderAccount(__m, __txn);
+    call InitVerification();
     call __ret0 := LibraAccount_extract_sender_withdrawal_capability();
 }
 
@@ -2334,16 +2556,23 @@ requires ExistsTxnSenderAccount(__m, __txn);
     var __tmp: Value;
     var __frame: int;
     var __saved_m: Memory;
+    var debug#LibraAccount#restore_withdrawal_capability#0#cap: [Position]Value;
+    var debug#LibraAccount#restore_withdrawal_capability#1#account_address: [Position]Value;
+    var debug#LibraAccount#restore_withdrawal_capability#2#account: [Position]Value;
 
     // initialize function execution
     assume !__abort_flag;
     __saved_m := __m;
     __frame := __local_counter;
     __local_counter := __local_counter + 10;
+    debug#LibraAccount#restore_withdrawal_capability#0#cap := EmptyPositionMap;
+    debug#LibraAccount#restore_withdrawal_capability#1#account_address := EmptyPositionMap;
+    debug#LibraAccount#restore_withdrawal_capability#2#account := EmptyPositionMap;
 
     // process and type check arguments
     assume is#Vector(cap);
     __m := UpdateLocal(__m, __frame + 0, cap);
+    debug#LibraAccount#restore_withdrawal_capability#0#cap := debug#LibraAccount#restore_withdrawal_capability#0#cap[Position(8391) := cap];
 
     // bytecode translation starts here
     call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 0));
@@ -2354,6 +2583,7 @@ requires ExistsTxnSenderAccount(__m, __txn);
 
     call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 4));
     __m := UpdateLocal(__m, __frame + 1, __tmp);
+    debug#LibraAccount#restore_withdrawal_capability#1#account_address := debug#LibraAccount#restore_withdrawal_capability#1#account_address[Position(8611) := __tmp];
 
     call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 1));
     __m := UpdateLocal(__m, __frame + 5, __tmp);
@@ -2381,7 +2611,7 @@ Label_Abort:
 
 procedure LibraAccount_restore_withdrawal_capability_verify (cap: Value) returns ()
 {
-    assume ExistsTxnSenderAccount(__m, __txn);
+    call InitVerification();
     call LibraAccount_restore_withdrawal_capability(cap);
 }
 
@@ -2404,22 +2634,34 @@ requires ExistsTxnSenderAccount(__m, __txn);
     var __tmp: Value;
     var __frame: int;
     var __saved_m: Memory;
+    var debug#LibraAccount#pay_from_capability#0#payee: [Position]Value;
+    var debug#LibraAccount#pay_from_capability#1#cap: [Position]Value;
+    var debug#LibraAccount#pay_from_capability#2#amount: [Position]Value;
+    var debug#LibraAccount#pay_from_capability#3#metadata: [Position]Value;
 
     // initialize function execution
     assume !__abort_flag;
     __saved_m := __m;
     __frame := __local_counter;
     __local_counter := __local_counter + 16;
+    debug#LibraAccount#pay_from_capability#0#payee := EmptyPositionMap;
+    debug#LibraAccount#pay_from_capability#1#cap := EmptyPositionMap;
+    debug#LibraAccount#pay_from_capability#2#amount := EmptyPositionMap;
+    debug#LibraAccount#pay_from_capability#3#metadata := EmptyPositionMap;
 
     // process and type check arguments
     assume is#Address(payee);
     __m := UpdateLocal(__m, __frame + 0, payee);
+    debug#LibraAccount#pay_from_capability#0#payee := debug#LibraAccount#pay_from_capability#0#payee[Position(9236) := payee];
     assume is#Vector(Dereference(__m, cap));
     assume IsValidReferenceParameter(__m, __frame, cap);
+    debug#LibraAccount#pay_from_capability#1#cap := debug#LibraAccount#pay_from_capability#1#cap[Position(9236) := Dereference(__m, cap)];
     assume IsValidU64(amount);
     __m := UpdateLocal(__m, __frame + 2, amount);
+    debug#LibraAccount#pay_from_capability#2#amount := debug#LibraAccount#pay_from_capability#2#amount[Position(9236) := amount];
     assume is#ByteArray(metadata);
     __m := UpdateLocal(__m, __frame + 3, metadata);
+    debug#LibraAccount#pay_from_capability#3#metadata := debug#LibraAccount#pay_from_capability#3#metadata[Position(9236) := metadata];
 
     // bytecode translation starts here
     call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 0));
@@ -2478,7 +2720,7 @@ Label_Abort:
 
 procedure LibraAccount_pay_from_capability_verify (payee: Value, cap: Reference, amount: Value, metadata: Value) returns ()
 {
-    assume ExistsTxnSenderAccount(__m, __txn);
+    call InitVerification();
     call LibraAccount_pay_from_capability(payee, cap, amount, metadata);
 }
 
@@ -2497,20 +2739,29 @@ requires ExistsTxnSenderAccount(__m, __txn);
     var __tmp: Value;
     var __frame: int;
     var __saved_m: Memory;
+    var debug#LibraAccount#pay_from_sender_with_metadata#0#payee: [Position]Value;
+    var debug#LibraAccount#pay_from_sender_with_metadata#1#amount: [Position]Value;
+    var debug#LibraAccount#pay_from_sender_with_metadata#2#metadata: [Position]Value;
 
     // initialize function execution
     assume !__abort_flag;
     __saved_m := __m;
     __frame := __local_counter;
     __local_counter := __local_counter + 11;
+    debug#LibraAccount#pay_from_sender_with_metadata#0#payee := EmptyPositionMap;
+    debug#LibraAccount#pay_from_sender_with_metadata#1#amount := EmptyPositionMap;
+    debug#LibraAccount#pay_from_sender_with_metadata#2#metadata := EmptyPositionMap;
 
     // process and type check arguments
     assume is#Address(payee);
     __m := UpdateLocal(__m, __frame + 0, payee);
+    debug#LibraAccount#pay_from_sender_with_metadata#0#payee := debug#LibraAccount#pay_from_sender_with_metadata#0#payee[Position(9947) := payee];
     assume IsValidU64(amount);
     __m := UpdateLocal(__m, __frame + 1, amount);
+    debug#LibraAccount#pay_from_sender_with_metadata#1#amount := debug#LibraAccount#pay_from_sender_with_metadata#1#amount[Position(9947) := amount];
     assume is#ByteArray(metadata);
     __m := UpdateLocal(__m, __frame + 2, metadata);
+    debug#LibraAccount#pay_from_sender_with_metadata#2#metadata := debug#LibraAccount#pay_from_sender_with_metadata#2#metadata[Position(9947) := metadata];
 
     // bytecode translation starts here
     call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 0));
@@ -2559,7 +2810,7 @@ Label_Abort:
 
 procedure LibraAccount_pay_from_sender_with_metadata_verify (payee: Value, amount: Value, metadata: Value) returns ()
 {
-    assume ExistsTxnSenderAccount(__m, __txn);
+    call InitVerification();
     call LibraAccount_pay_from_sender_with_metadata(payee, amount, metadata);
 }
 
@@ -2573,18 +2824,24 @@ requires ExistsTxnSenderAccount(__m, __txn);
     var __tmp: Value;
     var __frame: int;
     var __saved_m: Memory;
+    var debug#LibraAccount#pay_from_sender#0#payee: [Position]Value;
+    var debug#LibraAccount#pay_from_sender#1#amount: [Position]Value;
 
     // initialize function execution
     assume !__abort_flag;
     __saved_m := __m;
     __frame := __local_counter;
     __local_counter := __local_counter + 5;
+    debug#LibraAccount#pay_from_sender#0#payee := EmptyPositionMap;
+    debug#LibraAccount#pay_from_sender#1#amount := EmptyPositionMap;
 
     // process and type check arguments
     assume is#Address(payee);
     __m := UpdateLocal(__m, __frame + 0, payee);
+    debug#LibraAccount#pay_from_sender#0#payee := debug#LibraAccount#pay_from_sender#0#payee[Position(10530) := payee];
     assume IsValidU64(amount);
     __m := UpdateLocal(__m, __frame + 1, amount);
+    debug#LibraAccount#pay_from_sender#1#amount := debug#LibraAccount#pay_from_sender#1#amount[Position(10530) := amount];
 
     // bytecode translation starts here
     call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 0));
@@ -2607,7 +2864,7 @@ Label_Abort:
 
 procedure LibraAccount_pay_from_sender_verify (payee: Value, amount: Value) returns ()
 {
-    assume ExistsTxnSenderAccount(__m, __txn);
+    call InitVerification();
     call LibraAccount_pay_from_sender(payee, amount);
 }
 
@@ -2621,18 +2878,24 @@ requires ExistsTxnSenderAccount(__m, __txn);
     var __tmp: Value;
     var __frame: int;
     var __saved_m: Memory;
+    var debug#LibraAccount#rotate_authentication_key_for_account#0#account: [Position]Value;
+    var debug#LibraAccount#rotate_authentication_key_for_account#1#new_authentication_key: [Position]Value;
 
     // initialize function execution
     assume !__abort_flag;
     __saved_m := __m;
     __frame := __local_counter;
     __local_counter := __local_counter + 5;
+    debug#LibraAccount#rotate_authentication_key_for_account#0#account := EmptyPositionMap;
+    debug#LibraAccount#rotate_authentication_key_for_account#1#new_authentication_key := EmptyPositionMap;
 
     // process and type check arguments
     assume is#Vector(Dereference(__m, account));
     assume IsValidReferenceParameter(__m, __frame, account);
+    debug#LibraAccount#rotate_authentication_key_for_account#0#account := debug#LibraAccount#rotate_authentication_key_for_account#0#account[Position(10698) := Dereference(__m, account)];
     assume is#ByteArray(new_authentication_key);
     __m := UpdateLocal(__m, __frame + 1, new_authentication_key);
+    debug#LibraAccount#rotate_authentication_key_for_account#1#new_authentication_key := debug#LibraAccount#rotate_authentication_key_for_account#1#new_authentication_key[Position(10698) := new_authentication_key];
 
     // bytecode translation starts here
     call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 1));
@@ -2653,7 +2916,7 @@ Label_Abort:
 
 procedure LibraAccount_rotate_authentication_key_for_account_verify (account: Reference, new_authentication_key: Value) returns ()
 {
-    assume ExistsTxnSenderAccount(__m, __txn);
+    call InitVerification();
     call LibraAccount_rotate_authentication_key_for_account(account, new_authentication_key);
 }
 
@@ -2673,16 +2936,21 @@ requires ExistsTxnSenderAccount(__m, __txn);
     var __tmp: Value;
     var __frame: int;
     var __saved_m: Memory;
+    var debug#LibraAccount#rotate_authentication_key#0#new_authentication_key: [Position]Value;
+    var debug#LibraAccount#rotate_authentication_key#1#sender_account: [Position]Value;
 
     // initialize function execution
     assume !__abort_flag;
     __saved_m := __m;
     __frame := __local_counter;
     __local_counter := __local_counter + 10;
+    debug#LibraAccount#rotate_authentication_key#0#new_authentication_key := EmptyPositionMap;
+    debug#LibraAccount#rotate_authentication_key#1#sender_account := EmptyPositionMap;
 
     // process and type check arguments
     assume is#ByteArray(new_authentication_key);
     __m := UpdateLocal(__m, __frame + 0, new_authentication_key);
+    debug#LibraAccount#rotate_authentication_key#0#new_authentication_key := debug#LibraAccount#rotate_authentication_key#0#new_authentication_key[Position(11025) := new_authentication_key];
 
     // bytecode translation starts here
     call __tmp := GetTxnSenderAddress();
@@ -2727,7 +2995,7 @@ Label_Abort:
 
 procedure LibraAccount_rotate_authentication_key_verify (new_authentication_key: Value) returns ()
 {
-    assume ExistsTxnSenderAccount(__m, __txn);
+    call InitVerification();
     call LibraAccount_rotate_authentication_key(new_authentication_key);
 }
 
@@ -2743,18 +3011,24 @@ requires ExistsTxnSenderAccount(__m, __txn);
     var __tmp: Value;
     var __frame: int;
     var __saved_m: Memory;
+    var debug#LibraAccount#rotate_authentication_key_with_capability#0#cap: [Position]Value;
+    var debug#LibraAccount#rotate_authentication_key_with_capability#1#new_authentication_key: [Position]Value;
 
     // initialize function execution
     assume !__abort_flag;
     __saved_m := __m;
     __frame := __local_counter;
     __local_counter := __local_counter + 7;
+    debug#LibraAccount#rotate_authentication_key_with_capability#0#cap := EmptyPositionMap;
+    debug#LibraAccount#rotate_authentication_key_with_capability#1#new_authentication_key := EmptyPositionMap;
 
     // process and type check arguments
     assume is#Vector(Dereference(__m, cap));
     assume IsValidReferenceParameter(__m, __frame, cap);
+    debug#LibraAccount#rotate_authentication_key_with_capability#0#cap := debug#LibraAccount#rotate_authentication_key_with_capability#0#cap[Position(11765) := Dereference(__m, cap)];
     assume is#ByteArray(new_authentication_key);
     __m := UpdateLocal(__m, __frame + 1, new_authentication_key);
+    debug#LibraAccount#rotate_authentication_key_with_capability#1#new_authentication_key := debug#LibraAccount#rotate_authentication_key_with_capability#1#new_authentication_key[Position(11765) := new_authentication_key];
 
     // bytecode translation starts here
     call __t2 := CopyOrMoveRef(cap);
@@ -2783,7 +3057,7 @@ Label_Abort:
 
 procedure LibraAccount_rotate_authentication_key_with_capability_verify (cap: Reference, new_authentication_key: Value) returns ()
 {
-    assume ExistsTxnSenderAccount(__m, __txn);
+    call InitVerification();
     call LibraAccount_rotate_authentication_key_with_capability(cap, new_authentication_key);
 }
 
@@ -2807,12 +3081,18 @@ requires ExistsTxnSenderAccount(__m, __txn);
     var __tmp: Value;
     var __frame: int;
     var __saved_m: Memory;
+    var debug#LibraAccount#extract_sender_key_rotation_capability#0#sender: [Position]Value;
+    var debug#LibraAccount#extract_sender_key_rotation_capability#1#delegated_ref: [Position]Value;
+    var debug#LibraAccount#extract_sender_key_rotation_capability#2#__ret: [Position]Value;
 
     // initialize function execution
     assume !__abort_flag;
     __saved_m := __m;
     __frame := __local_counter;
     __local_counter := __local_counter + 13;
+    debug#LibraAccount#extract_sender_key_rotation_capability#0#sender := EmptyPositionMap;
+    debug#LibraAccount#extract_sender_key_rotation_capability#1#delegated_ref := EmptyPositionMap;
+    debug#LibraAccount#extract_sender_key_rotation_capability#2#__ret := EmptyPositionMap;
 
     // process and type check arguments
 
@@ -2822,6 +3102,7 @@ requires ExistsTxnSenderAccount(__m, __txn);
 
     call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 2));
     __m := UpdateLocal(__m, __frame + 0, __tmp);
+    debug#LibraAccount#extract_sender_key_rotation_capability#0#sender := debug#LibraAccount#extract_sender_key_rotation_capability#0#sender[Position(12375) := __tmp];
 
     call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 0));
     __m := UpdateLocal(__m, __frame + 3, __tmp);
@@ -2862,17 +3143,19 @@ Label_11:
     __m := UpdateLocal(__m, __frame + 12, __tmp);
 
     __ret0 := GetLocal(__m, __frame + 12);
+    debug#LibraAccount#extract_sender_key_rotation_capability#2#__ret := debug#LibraAccount#extract_sender_key_rotation_capability#2#__ret[Position(12758) := __ret0];
     return;
 
 Label_Abort:
     __abort_flag := true;
     __m := __saved_m;
     __ret0 := DefaultValue;
+    debug#LibraAccount#extract_sender_key_rotation_capability#2#__ret := debug#LibraAccount#extract_sender_key_rotation_capability#2#__ret[Position(12836) := __ret0];
 }
 
 procedure LibraAccount_extract_sender_key_rotation_capability_verify () returns (__ret0: Value)
 {
-    assume ExistsTxnSenderAccount(__m, __txn);
+    call InitVerification();
     call __ret0 := LibraAccount_extract_sender_key_rotation_capability();
 }
 
@@ -2892,16 +3175,23 @@ requires ExistsTxnSenderAccount(__m, __txn);
     var __tmp: Value;
     var __frame: int;
     var __saved_m: Memory;
+    var debug#LibraAccount#restore_key_rotation_capability#0#cap: [Position]Value;
+    var debug#LibraAccount#restore_key_rotation_capability#1#account_address: [Position]Value;
+    var debug#LibraAccount#restore_key_rotation_capability#2#account: [Position]Value;
 
     // initialize function execution
     assume !__abort_flag;
     __saved_m := __m;
     __frame := __local_counter;
     __local_counter := __local_counter + 10;
+    debug#LibraAccount#restore_key_rotation_capability#0#cap := EmptyPositionMap;
+    debug#LibraAccount#restore_key_rotation_capability#1#account_address := EmptyPositionMap;
+    debug#LibraAccount#restore_key_rotation_capability#2#account := EmptyPositionMap;
 
     // process and type check arguments
     assume is#Vector(cap);
     __m := UpdateLocal(__m, __frame + 0, cap);
+    debug#LibraAccount#restore_key_rotation_capability#0#cap := debug#LibraAccount#restore_key_rotation_capability#0#cap[Position(12924) := cap];
 
     // bytecode translation starts here
     call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 0));
@@ -2912,6 +3202,7 @@ requires ExistsTxnSenderAccount(__m, __txn);
 
     call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 4));
     __m := UpdateLocal(__m, __frame + 1, __tmp);
+    debug#LibraAccount#restore_key_rotation_capability#1#account_address := debug#LibraAccount#restore_key_rotation_capability#1#account_address[Position(13148) := __tmp];
 
     call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 1));
     __m := UpdateLocal(__m, __frame + 5, __tmp);
@@ -2939,7 +3230,7 @@ Label_Abort:
 
 procedure LibraAccount_restore_key_rotation_capability_verify (cap: Value) returns ()
 {
-    assume ExistsTxnSenderAccount(__m, __txn);
+    call InitVerification();
     call LibraAccount_restore_key_rotation_capability(cap);
 }
 
@@ -2968,16 +3259,21 @@ requires ExistsTxnSenderAccount(__m, __txn);
     var __tmp: Value;
     var __frame: int;
     var __saved_m: Memory;
+    var debug#LibraAccount#create_account#0#fresh_address: [Position]Value;
+    var debug#LibraAccount#create_account#1#generator: [Position]Value;
 
     // initialize function execution
     assume !__abort_flag;
     __saved_m := __m;
     __frame := __local_counter;
     __local_counter := __local_counter + 19;
+    debug#LibraAccount#create_account#0#fresh_address := EmptyPositionMap;
+    debug#LibraAccount#create_account#1#generator := EmptyPositionMap;
 
     // process and type check arguments
     assume is#Address(fresh_address);
     __m := UpdateLocal(__m, __frame + 0, fresh_address);
+    debug#LibraAccount#create_account#0#fresh_address := debug#LibraAccount#create_account#0#fresh_address[Position(13761) := fresh_address];
 
     // bytecode translation starts here
     call __tmp := LdConst(0);
@@ -2988,6 +3284,7 @@ requires ExistsTxnSenderAccount(__m, __txn);
 
     call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 3));
     __m := UpdateLocal(__m, __frame + 1, __tmp);
+    debug#LibraAccount#create_account#1#generator := debug#LibraAccount#create_account#1#generator[Position(13868) := __tmp];
 
     call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 0));
     __m := UpdateLocal(__m, __frame + 4, __tmp);
@@ -3023,6 +3320,7 @@ requires ExistsTxnSenderAccount(__m, __txn);
     assume is#Vector(__t12);
 
     __m := UpdateLocal(__m, __frame + 12, __t12);
+    debug#LibraAccount#create_account#1#generator := debug#LibraAccount#create_account#1#generator[Position(14268) := GetLocal(__m, __frame + 1)];
 
     call __t13 := BorrowLoc(__frame + 1);
 
@@ -3034,6 +3332,7 @@ requires ExistsTxnSenderAccount(__m, __txn);
     assume is#Vector(__t15);
 
     __m := UpdateLocal(__m, __frame + 15, __t15);
+    debug#LibraAccount#create_account#1#generator := debug#LibraAccount#create_account#1#generator[Position(14389) := GetLocal(__m, __frame + 1)];
 
     call __tmp := LdConst(0);
     __m := UpdateLocal(__m, __frame + 16, __tmp);
@@ -3056,7 +3355,7 @@ Label_Abort:
 
 procedure LibraAccount_create_account_verify (fresh_address: Value) returns ()
 {
-    assume ExistsTxnSenderAccount(__m, __txn);
+    call InitVerification();
     call LibraAccount_create_account(fresh_address);
 }
 
@@ -3073,18 +3372,24 @@ requires ExistsTxnSenderAccount(__m, __txn);
     var __tmp: Value;
     var __frame: int;
     var __saved_m: Memory;
+    var debug#LibraAccount#create_new_account#0#fresh_address: [Position]Value;
+    var debug#LibraAccount#create_new_account#1#initial_balance: [Position]Value;
 
     // initialize function execution
     assume !__abort_flag;
     __saved_m := __m;
     __frame := __local_counter;
     __local_counter := __local_counter + 8;
+    debug#LibraAccount#create_new_account#0#fresh_address := EmptyPositionMap;
+    debug#LibraAccount#create_new_account#1#initial_balance := EmptyPositionMap;
 
     // process and type check arguments
     assume is#Address(fresh_address);
     __m := UpdateLocal(__m, __frame + 0, fresh_address);
+    debug#LibraAccount#create_new_account#0#fresh_address := debug#LibraAccount#create_new_account#0#fresh_address[Position(14744) := fresh_address];
     assume IsValidU64(initial_balance);
     __m := UpdateLocal(__m, __frame + 1, initial_balance);
+    debug#LibraAccount#create_new_account#1#initial_balance := debug#LibraAccount#create_new_account#1#initial_balance[Position(14744) := initial_balance];
 
     // bytecode translation starts here
     call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 0));
@@ -3124,7 +3429,7 @@ Label_Abort:
 
 procedure LibraAccount_create_new_account_verify (fresh_address: Value, initial_balance: Value) returns ()
 {
-    assume ExistsTxnSenderAccount(__m, __txn);
+    call InitVerification();
     call LibraAccount_create_new_account(fresh_address, initial_balance);
 }
 
@@ -3143,16 +3448,23 @@ requires ExistsTxnSenderAccount(__m, __txn);
     var __tmp: Value;
     var __frame: int;
     var __saved_m: Memory;
+    var debug#LibraAccount#balance_for_account#0#account: [Position]Value;
+    var debug#LibraAccount#balance_for_account#1#balance_value: [Position]Value;
+    var debug#LibraAccount#balance_for_account#2#__ret: [Position]Value;
 
     // initialize function execution
     assume !__abort_flag;
     __saved_m := __m;
     __frame := __local_counter;
     __local_counter := __local_counter + 6;
+    debug#LibraAccount#balance_for_account#0#account := EmptyPositionMap;
+    debug#LibraAccount#balance_for_account#1#balance_value := EmptyPositionMap;
+    debug#LibraAccount#balance_for_account#2#__ret := EmptyPositionMap;
 
     // process and type check arguments
     assume is#Vector(Dereference(__m, account));
     assume IsValidReferenceParameter(__m, __frame, account);
+    debug#LibraAccount#balance_for_account#0#account := debug#LibraAccount#balance_for_account#0#account[Position(15265) := Dereference(__m, account)];
 
     // bytecode translation starts here
     call __t2 := CopyOrMoveRef(account);
@@ -3167,22 +3479,25 @@ requires ExistsTxnSenderAccount(__m, __txn);
 
     call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 4));
     __m := UpdateLocal(__m, __frame + 1, __tmp);
+    debug#LibraAccount#balance_for_account#1#balance_value := debug#LibraAccount#balance_for_account#1#balance_value[Position(15350) := __tmp];
 
     call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 1));
     __m := UpdateLocal(__m, __frame + 5, __tmp);
 
     __ret0 := GetLocal(__m, __frame + 5);
+    debug#LibraAccount#balance_for_account#2#__ret := debug#LibraAccount#balance_for_account#2#__ret[Position(15415) := __ret0];
     return;
 
 Label_Abort:
     __abort_flag := true;
     __m := __saved_m;
     __ret0 := DefaultValue;
+    debug#LibraAccount#balance_for_account#2#__ret := debug#LibraAccount#balance_for_account#2#__ret[Position(15447) := __ret0];
 }
 
 procedure LibraAccount_balance_for_account_verify (account: Reference) returns (__ret0: Value)
 {
-    assume ExistsTxnSenderAccount(__m, __txn);
+    call InitVerification();
     call __ret0 := LibraAccount_balance_for_account(account);
 }
 
@@ -3196,16 +3511,21 @@ requires ExistsTxnSenderAccount(__m, __txn);
     var __tmp: Value;
     var __frame: int;
     var __saved_m: Memory;
+    var debug#LibraAccount#balance#0#addr: [Position]Value;
+    var debug#LibraAccount#balance#1#__ret: [Position]Value;
 
     // initialize function execution
     assume !__abort_flag;
     __saved_m := __m;
     __frame := __local_counter;
     __local_counter := __local_counter + 4;
+    debug#LibraAccount#balance#0#addr := EmptyPositionMap;
+    debug#LibraAccount#balance#1#__ret := EmptyPositionMap;
 
     // process and type check arguments
     assume is#Address(addr);
     __m := UpdateLocal(__m, __frame + 0, addr);
+    debug#LibraAccount#balance#0#addr := debug#LibraAccount#balance#0#addr[Position(15535) := addr];
 
     // bytecode translation starts here
     call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 0));
@@ -3221,17 +3541,19 @@ requires ExistsTxnSenderAccount(__m, __txn);
     __m := UpdateLocal(__m, __frame + 3, __t3);
 
     __ret0 := GetLocal(__m, __frame + 3);
+    debug#LibraAccount#balance#1#__ret := debug#LibraAccount#balance#1#__ret[Position(15591) := __ret0];
     return;
 
 Label_Abort:
     __abort_flag := true;
     __m := __saved_m;
     __ret0 := DefaultValue;
+    debug#LibraAccount#balance#1#__ret := debug#LibraAccount#balance#1#__ret[Position(15658) := __ret0];
 }
 
 procedure LibraAccount_balance_verify (addr: Value) returns (__ret0: Value)
 {
-    assume ExistsTxnSenderAccount(__m, __txn);
+    call InitVerification();
     call __ret0 := LibraAccount_balance(addr);
 }
 
@@ -3245,16 +3567,21 @@ requires ExistsTxnSenderAccount(__m, __txn);
     var __tmp: Value;
     var __frame: int;
     var __saved_m: Memory;
+    var debug#LibraAccount#sequence_number_for_account#0#account: [Position]Value;
+    var debug#LibraAccount#sequence_number_for_account#1#__ret: [Position]Value;
 
     // initialize function execution
     assume !__abort_flag;
     __saved_m := __m;
     __frame := __local_counter;
     __local_counter := __local_counter + 4;
+    debug#LibraAccount#sequence_number_for_account#0#account := EmptyPositionMap;
+    debug#LibraAccount#sequence_number_for_account#1#__ret := EmptyPositionMap;
 
     // process and type check arguments
     assume is#Vector(Dereference(__m, account));
     assume IsValidReferenceParameter(__m, __frame, account);
+    debug#LibraAccount#sequence_number_for_account#0#account := debug#LibraAccount#sequence_number_for_account#0#account[Position(15735) := Dereference(__m, account)];
 
     // bytecode translation starts here
     call __t1 := CopyOrMoveRef(account);
@@ -3266,17 +3593,19 @@ requires ExistsTxnSenderAccount(__m, __txn);
     __m := UpdateLocal(__m, __frame + 3, __tmp);
 
     __ret0 := GetLocal(__m, __frame + 3);
+    debug#LibraAccount#sequence_number_for_account#1#__ret := debug#LibraAccount#sequence_number_for_account#1#__ret[Position(15796) := __ret0];
     return;
 
 Label_Abort:
     __abort_flag := true;
     __m := __saved_m;
     __ret0 := DefaultValue;
+    debug#LibraAccount#sequence_number_for_account#1#__ret := debug#LibraAccount#sequence_number_for_account#1#__ret[Position(15842) := __ret0];
 }
 
 procedure LibraAccount_sequence_number_for_account_verify (account: Reference) returns (__ret0: Value)
 {
-    assume ExistsTxnSenderAccount(__m, __txn);
+    call InitVerification();
     call __ret0 := LibraAccount_sequence_number_for_account(account);
 }
 
@@ -3290,16 +3619,21 @@ requires ExistsTxnSenderAccount(__m, __txn);
     var __tmp: Value;
     var __frame: int;
     var __saved_m: Memory;
+    var debug#LibraAccount#sequence_number#0#addr: [Position]Value;
+    var debug#LibraAccount#sequence_number#1#__ret: [Position]Value;
 
     // initialize function execution
     assume !__abort_flag;
     __saved_m := __m;
     __frame := __local_counter;
     __local_counter := __local_counter + 4;
+    debug#LibraAccount#sequence_number#0#addr := EmptyPositionMap;
+    debug#LibraAccount#sequence_number#1#__ret := EmptyPositionMap;
 
     // process and type check arguments
     assume is#Address(addr);
     __m := UpdateLocal(__m, __frame + 0, addr);
+    debug#LibraAccount#sequence_number#0#addr := debug#LibraAccount#sequence_number#0#addr[Position(15901) := addr];
 
     // bytecode translation starts here
     call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 0));
@@ -3315,17 +3649,19 @@ requires ExistsTxnSenderAccount(__m, __txn);
     __m := UpdateLocal(__m, __frame + 3, __t3);
 
     __ret0 := GetLocal(__m, __frame + 3);
+    debug#LibraAccount#sequence_number#1#__ret := debug#LibraAccount#sequence_number#1#__ret[Position(15965) := __ret0];
     return;
 
 Label_Abort:
     __abort_flag := true;
     __m := __saved_m;
     __ret0 := DefaultValue;
+    debug#LibraAccount#sequence_number#1#__ret := debug#LibraAccount#sequence_number#1#__ret[Position(16040) := __ret0];
 }
 
 procedure LibraAccount_sequence_number_verify (addr: Value) returns (__ret0: Value)
 {
-    assume ExistsTxnSenderAccount(__m, __txn);
+    call InitVerification();
     call __ret0 := LibraAccount_sequence_number(addr);
 }
 
@@ -3340,16 +3676,21 @@ requires ExistsTxnSenderAccount(__m, __txn);
     var __tmp: Value;
     var __frame: int;
     var __saved_m: Memory;
+    var debug#LibraAccount#delegated_key_rotation_capability#0#addr: [Position]Value;
+    var debug#LibraAccount#delegated_key_rotation_capability#1#__ret: [Position]Value;
 
     // initialize function execution
     assume !__abort_flag;
     __saved_m := __m;
     __frame := __local_counter;
     __local_counter := __local_counter + 5;
+    debug#LibraAccount#delegated_key_rotation_capability#0#addr := EmptyPositionMap;
+    debug#LibraAccount#delegated_key_rotation_capability#1#__ret := EmptyPositionMap;
 
     // process and type check arguments
     assume is#Address(addr);
     __m := UpdateLocal(__m, __frame + 0, addr);
+    debug#LibraAccount#delegated_key_rotation_capability#0#addr := debug#LibraAccount#delegated_key_rotation_capability#0#addr[Position(16132) := addr];
 
     // bytecode translation starts here
     call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 0));
@@ -3365,17 +3706,19 @@ requires ExistsTxnSenderAccount(__m, __txn);
     __m := UpdateLocal(__m, __frame + 4, __tmp);
 
     __ret0 := GetLocal(__m, __frame + 4);
+    debug#LibraAccount#delegated_key_rotation_capability#1#__ret := debug#LibraAccount#delegated_key_rotation_capability#1#__ret[Position(16215) := __ret0];
     return;
 
 Label_Abort:
     __abort_flag := true;
     __m := __saved_m;
     __ret0 := DefaultValue;
+    debug#LibraAccount#delegated_key_rotation_capability#1#__ret := debug#LibraAccount#delegated_key_rotation_capability#1#__ret[Position(16294) := __ret0];
 }
 
 procedure LibraAccount_delegated_key_rotation_capability_verify (addr: Value) returns (__ret0: Value)
 {
-    assume ExistsTxnSenderAccount(__m, __txn);
+    call InitVerification();
     call __ret0 := LibraAccount_delegated_key_rotation_capability(addr);
 }
 
@@ -3390,16 +3733,21 @@ requires ExistsTxnSenderAccount(__m, __txn);
     var __tmp: Value;
     var __frame: int;
     var __saved_m: Memory;
+    var debug#LibraAccount#delegated_withdrawal_capability#0#addr: [Position]Value;
+    var debug#LibraAccount#delegated_withdrawal_capability#1#__ret: [Position]Value;
 
     // initialize function execution
     assume !__abort_flag;
     __saved_m := __m;
     __frame := __local_counter;
     __local_counter := __local_counter + 5;
+    debug#LibraAccount#delegated_withdrawal_capability#0#addr := EmptyPositionMap;
+    debug#LibraAccount#delegated_withdrawal_capability#1#__ret := EmptyPositionMap;
 
     // process and type check arguments
     assume is#Address(addr);
     __m := UpdateLocal(__m, __frame + 0, addr);
+    debug#LibraAccount#delegated_withdrawal_capability#0#addr := debug#LibraAccount#delegated_withdrawal_capability#0#addr[Position(16385) := addr];
 
     // bytecode translation starts here
     call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 0));
@@ -3415,17 +3763,19 @@ requires ExistsTxnSenderAccount(__m, __txn);
     __m := UpdateLocal(__m, __frame + 4, __tmp);
 
     __ret0 := GetLocal(__m, __frame + 4);
+    debug#LibraAccount#delegated_withdrawal_capability#1#__ret := debug#LibraAccount#delegated_withdrawal_capability#1#__ret[Position(16466) := __ret0];
     return;
 
 Label_Abort:
     __abort_flag := true;
     __m := __saved_m;
     __ret0 := DefaultValue;
+    debug#LibraAccount#delegated_withdrawal_capability#1#__ret := debug#LibraAccount#delegated_withdrawal_capability#1#__ret[Position(16543) := __ret0];
 }
 
 procedure LibraAccount_delegated_withdrawal_capability_verify (addr: Value) returns (__ret0: Value)
 {
-    assume ExistsTxnSenderAccount(__m, __txn);
+    call InitVerification();
     call __ret0 := LibraAccount_delegated_withdrawal_capability(addr);
 }
 
@@ -3438,16 +3788,21 @@ requires ExistsTxnSenderAccount(__m, __txn);
     var __tmp: Value;
     var __frame: int;
     var __saved_m: Memory;
+    var debug#LibraAccount#withdrawal_capability_address#0#cap: [Position]Value;
+    var debug#LibraAccount#withdrawal_capability_address#1#__ret: [Position]Value;
 
     // initialize function execution
     assume !__abort_flag;
     __saved_m := __m;
     __frame := __local_counter;
     __local_counter := __local_counter + 3;
+    debug#LibraAccount#withdrawal_capability_address#0#cap := EmptyPositionMap;
+    debug#LibraAccount#withdrawal_capability_address#1#__ret := EmptyPositionMap;
 
     // process and type check arguments
     assume is#Vector(Dereference(__m, cap));
     assume IsValidReferenceParameter(__m, __frame, cap);
+    debug#LibraAccount#withdrawal_capability_address#0#cap := debug#LibraAccount#withdrawal_capability_address#0#cap[Position(16640) := Dereference(__m, cap)];
 
     // bytecode translation starts here
     call __t1 := CopyOrMoveRef(cap);
@@ -3455,17 +3810,19 @@ requires ExistsTxnSenderAccount(__m, __txn);
     call __t2 := BorrowField(__t1, LibraAccount_WithdrawalCapability_account_address);
 
     __ret0 := __t2;
+    debug#LibraAccount#withdrawal_capability_address#1#__ret := debug#LibraAccount#withdrawal_capability_address#1#__ret[Position(16730) := Dereference(__m, __ret0)];
     return;
 
 Label_Abort:
     __abort_flag := true;
     __m := __saved_m;
     __ret0 := DefaultReference;
+    debug#LibraAccount#withdrawal_capability_address#1#__ret := debug#LibraAccount#withdrawal_capability_address#1#__ret[Position(16769) := Dereference(__m, __ret0)];
 }
 
 procedure LibraAccount_withdrawal_capability_address_verify (cap: Reference) returns (__ret0: Reference)
 {
-    assume ExistsTxnSenderAccount(__m, __txn);
+    call InitVerification();
     call __ret0 := LibraAccount_withdrawal_capability_address(cap);
 }
 
@@ -3478,16 +3835,21 @@ requires ExistsTxnSenderAccount(__m, __txn);
     var __tmp: Value;
     var __frame: int;
     var __saved_m: Memory;
+    var debug#LibraAccount#key_rotation_capability_address#0#cap: [Position]Value;
+    var debug#LibraAccount#key_rotation_capability_address#1#__ret: [Position]Value;
 
     // initialize function execution
     assume !__abort_flag;
     __saved_m := __m;
     __frame := __local_counter;
     __local_counter := __local_counter + 3;
+    debug#LibraAccount#key_rotation_capability_address#0#cap := EmptyPositionMap;
+    debug#LibraAccount#key_rotation_capability_address#1#__ret := EmptyPositionMap;
 
     // process and type check arguments
     assume is#Vector(Dereference(__m, cap));
     assume IsValidReferenceParameter(__m, __frame, cap);
+    debug#LibraAccount#key_rotation_capability_address#0#cap := debug#LibraAccount#key_rotation_capability_address#0#cap[Position(16867) := Dereference(__m, cap)];
 
     // bytecode translation starts here
     call __t1 := CopyOrMoveRef(cap);
@@ -3495,17 +3857,19 @@ requires ExistsTxnSenderAccount(__m, __txn);
     call __t2 := BorrowField(__t1, LibraAccount_KeyRotationCapability_account_address);
 
     __ret0 := __t2;
+    debug#LibraAccount#key_rotation_capability_address#1#__ret := debug#LibraAccount#key_rotation_capability_address#1#__ret[Position(16960) := Dereference(__m, __ret0)];
     return;
 
 Label_Abort:
     __abort_flag := true;
     __m := __saved_m;
     __ret0 := DefaultReference;
+    debug#LibraAccount#key_rotation_capability_address#1#__ret := debug#LibraAccount#key_rotation_capability_address#1#__ret[Position(16999) := Dereference(__m, __ret0)];
 }
 
 procedure LibraAccount_key_rotation_capability_address_verify (cap: Reference) returns (__ret0: Reference)
 {
-    assume ExistsTxnSenderAccount(__m, __txn);
+    call InitVerification();
     call __ret0 := LibraAccount_key_rotation_capability_address(cap);
 }
 
@@ -3518,16 +3882,21 @@ requires ExistsTxnSenderAccount(__m, __txn);
     var __tmp: Value;
     var __frame: int;
     var __saved_m: Memory;
+    var debug#LibraAccount#exists#0#check_addr: [Position]Value;
+    var debug#LibraAccount#exists#1#__ret: [Position]Value;
 
     // initialize function execution
     assume !__abort_flag;
     __saved_m := __m;
     __frame := __local_counter;
     __local_counter := __local_counter + 3;
+    debug#LibraAccount#exists#0#check_addr := EmptyPositionMap;
+    debug#LibraAccount#exists#1#__ret := EmptyPositionMap;
 
     // process and type check arguments
     assume is#Address(check_addr);
     __m := UpdateLocal(__m, __frame + 0, check_addr);
+    debug#LibraAccount#exists#0#check_addr := debug#LibraAccount#exists#0#check_addr[Position(17057) := check_addr];
 
     // bytecode translation starts here
     call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 0));
@@ -3537,17 +3906,19 @@ requires ExistsTxnSenderAccount(__m, __txn);
     __m := UpdateLocal(__m, __frame + 2, __tmp);
 
     __ret0 := GetLocal(__m, __frame + 2);
+    debug#LibraAccount#exists#1#__ret := debug#LibraAccount#exists#1#__ret[Position(17108) := __ret0];
     return;
 
 Label_Abort:
     __abort_flag := true;
     __m := __saved_m;
     __ret0 := DefaultValue;
+    debug#LibraAccount#exists#1#__ret := debug#LibraAccount#exists#1#__ret[Position(17148) := __ret0];
 }
 
 procedure LibraAccount_exists_verify (check_addr: Value) returns (__ret0: Value)
 {
-    assume ExistsTxnSenderAccount(__m, __txn);
+    call InitVerification();
     call __ret0 := LibraAccount_exists(check_addr);
 }
 
@@ -3608,24 +3979,51 @@ requires ExistsTxnSenderAccount(__m, __txn);
     var __tmp: Value;
     var __frame: int;
     var __saved_m: Memory;
+    var debug#LibraAccount#prologue#0#txn_sequence_number: [Position]Value;
+    var debug#LibraAccount#prologue#1#txn_public_key: [Position]Value;
+    var debug#LibraAccount#prologue#2#txn_gas_price: [Position]Value;
+    var debug#LibraAccount#prologue#3#txn_max_gas_units: [Position]Value;
+    var debug#LibraAccount#prologue#4#txn_expiration_time: [Position]Value;
+    var debug#LibraAccount#prologue#5#transaction_sender: [Position]Value;
+    var debug#LibraAccount#prologue#6#sender_account: [Position]Value;
+    var debug#LibraAccount#prologue#7#imm_sender_account: [Position]Value;
+    var debug#LibraAccount#prologue#8#max_transaction_fee: [Position]Value;
+    var debug#LibraAccount#prologue#9#balance_amount: [Position]Value;
+    var debug#LibraAccount#prologue#10#sequence_number_value: [Position]Value;
 
     // initialize function execution
     assume !__abort_flag;
     __saved_m := __m;
     __frame := __local_counter;
     __local_counter := __local_counter + 55;
+    debug#LibraAccount#prologue#0#txn_sequence_number := EmptyPositionMap;
+    debug#LibraAccount#prologue#1#txn_public_key := EmptyPositionMap;
+    debug#LibraAccount#prologue#2#txn_gas_price := EmptyPositionMap;
+    debug#LibraAccount#prologue#3#txn_max_gas_units := EmptyPositionMap;
+    debug#LibraAccount#prologue#4#txn_expiration_time := EmptyPositionMap;
+    debug#LibraAccount#prologue#5#transaction_sender := EmptyPositionMap;
+    debug#LibraAccount#prologue#6#sender_account := EmptyPositionMap;
+    debug#LibraAccount#prologue#7#imm_sender_account := EmptyPositionMap;
+    debug#LibraAccount#prologue#8#max_transaction_fee := EmptyPositionMap;
+    debug#LibraAccount#prologue#9#balance_amount := EmptyPositionMap;
+    debug#LibraAccount#prologue#10#sequence_number_value := EmptyPositionMap;
 
     // process and type check arguments
     assume IsValidU64(txn_sequence_number);
     __m := UpdateLocal(__m, __frame + 0, txn_sequence_number);
+    debug#LibraAccount#prologue#0#txn_sequence_number := debug#LibraAccount#prologue#0#txn_sequence_number[Position(17457) := txn_sequence_number];
     assume is#ByteArray(txn_public_key);
     __m := UpdateLocal(__m, __frame + 1, txn_public_key);
+    debug#LibraAccount#prologue#1#txn_public_key := debug#LibraAccount#prologue#1#txn_public_key[Position(17457) := txn_public_key];
     assume IsValidU64(txn_gas_price);
     __m := UpdateLocal(__m, __frame + 2, txn_gas_price);
+    debug#LibraAccount#prologue#2#txn_gas_price := debug#LibraAccount#prologue#2#txn_gas_price[Position(17457) := txn_gas_price];
     assume IsValidU64(txn_max_gas_units);
     __m := UpdateLocal(__m, __frame + 3, txn_max_gas_units);
+    debug#LibraAccount#prologue#3#txn_max_gas_units := debug#LibraAccount#prologue#3#txn_max_gas_units[Position(17457) := txn_max_gas_units];
     assume IsValidU64(txn_expiration_time);
     __m := UpdateLocal(__m, __frame + 4, txn_expiration_time);
+    debug#LibraAccount#prologue#4#txn_expiration_time := debug#LibraAccount#prologue#4#txn_expiration_time[Position(17457) := txn_expiration_time];
 
     // bytecode translation starts here
     call __tmp := GetTxnSenderAddress();
@@ -3633,6 +4031,7 @@ requires ExistsTxnSenderAccount(__m, __txn);
 
     call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 11));
     __m := UpdateLocal(__m, __frame + 5, __tmp);
+    debug#LibraAccount#prologue#5#transaction_sender := debug#LibraAccount#prologue#5#transaction_sender[Position(17892) := __tmp];
 
     call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 5));
     __m := UpdateLocal(__m, __frame + 12, __tmp);
@@ -3704,6 +4103,7 @@ Label_21:
 
     call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 28));
     __m := UpdateLocal(__m, __frame + 8, __tmp);
+    debug#LibraAccount#prologue#8#max_transaction_fee := debug#LibraAccount#prologue#8#max_transaction_fee[Position(18540) := __tmp];
 
     call __t29 := CopyOrMoveRef(sender_account);
 
@@ -3721,6 +4121,7 @@ Label_21:
 
     call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 32));
     __m := UpdateLocal(__m, __frame + 9, __tmp);
+    debug#LibraAccount#prologue#9#balance_amount := debug#LibraAccount#prologue#9#balance_amount[Position(18676) := __tmp];
 
     call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 9));
     __m := UpdateLocal(__m, __frame + 33, __tmp);
@@ -3753,6 +4154,7 @@ Label_38:
 
     call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 40));
     __m := UpdateLocal(__m, __frame + 10, __tmp);
+    debug#LibraAccount#prologue#10#sequence_number_value := debug#LibraAccount#prologue#10#sequence_number_value[Position(18921) := __tmp];
 
     call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 0));
     __m := UpdateLocal(__m, __frame + 41, __tmp);
@@ -3826,7 +4228,7 @@ Label_Abort:
 
 procedure LibraAccount_prologue_verify (txn_sequence_number: Value, txn_public_key: Value, txn_gas_price: Value, txn_max_gas_units: Value, txn_expiration_time: Value) returns ()
 {
-    assume ExistsTxnSenderAccount(__m, __txn);
+    call InitVerification();
     call LibraAccount_prologue(txn_sequence_number, txn_public_key, txn_gas_price, txn_max_gas_units, txn_expiration_time);
 }
 
@@ -3870,22 +4272,44 @@ requires ExistsTxnSenderAccount(__m, __txn);
     var __tmp: Value;
     var __frame: int;
     var __saved_m: Memory;
+    var debug#LibraAccount#epilogue#0#txn_sequence_number: [Position]Value;
+    var debug#LibraAccount#epilogue#1#txn_gas_price: [Position]Value;
+    var debug#LibraAccount#epilogue#2#txn_max_gas_units: [Position]Value;
+    var debug#LibraAccount#epilogue#3#gas_units_remaining: [Position]Value;
+    var debug#LibraAccount#epilogue#4#sender_account: [Position]Value;
+    var debug#LibraAccount#epilogue#5#transaction_fee_account: [Position]Value;
+    var debug#LibraAccount#epilogue#6#imm_sender_account: [Position]Value;
+    var debug#LibraAccount#epilogue#7#transaction_fee_amount: [Position]Value;
+    var debug#LibraAccount#epilogue#8#transaction_fee: [Position]Value;
 
     // initialize function execution
     assume !__abort_flag;
     __saved_m := __m;
     __frame := __local_counter;
     __local_counter := __local_counter + 37;
+    debug#LibraAccount#epilogue#0#txn_sequence_number := EmptyPositionMap;
+    debug#LibraAccount#epilogue#1#txn_gas_price := EmptyPositionMap;
+    debug#LibraAccount#epilogue#2#txn_max_gas_units := EmptyPositionMap;
+    debug#LibraAccount#epilogue#3#gas_units_remaining := EmptyPositionMap;
+    debug#LibraAccount#epilogue#4#sender_account := EmptyPositionMap;
+    debug#LibraAccount#epilogue#5#transaction_fee_account := EmptyPositionMap;
+    debug#LibraAccount#epilogue#6#imm_sender_account := EmptyPositionMap;
+    debug#LibraAccount#epilogue#7#transaction_fee_amount := EmptyPositionMap;
+    debug#LibraAccount#epilogue#8#transaction_fee := EmptyPositionMap;
 
     // process and type check arguments
     assume IsValidU64(txn_sequence_number);
     __m := UpdateLocal(__m, __frame + 0, txn_sequence_number);
+    debug#LibraAccount#epilogue#0#txn_sequence_number := debug#LibraAccount#epilogue#0#txn_sequence_number[Position(19386) := txn_sequence_number];
     assume IsValidU64(txn_gas_price);
     __m := UpdateLocal(__m, __frame + 1, txn_gas_price);
+    debug#LibraAccount#epilogue#1#txn_gas_price := debug#LibraAccount#epilogue#1#txn_gas_price[Position(19386) := txn_gas_price];
     assume IsValidU64(txn_max_gas_units);
     __m := UpdateLocal(__m, __frame + 2, txn_max_gas_units);
+    debug#LibraAccount#epilogue#2#txn_max_gas_units := debug#LibraAccount#epilogue#2#txn_max_gas_units[Position(19386) := txn_max_gas_units];
     assume IsValidU64(gas_units_remaining);
     __m := UpdateLocal(__m, __frame + 3, gas_units_remaining);
+    debug#LibraAccount#epilogue#3#gas_units_remaining := debug#LibraAccount#epilogue#3#gas_units_remaining[Position(19386) := gas_units_remaining];
 
     // bytecode translation starts here
     call __tmp := GetTxnSenderAddress();
@@ -3915,6 +4339,7 @@ requires ExistsTxnSenderAccount(__m, __txn);
 
     call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 15));
     __m := UpdateLocal(__m, __frame + 7, __tmp);
+    debug#LibraAccount#epilogue#7#transaction_fee_amount := debug#LibraAccount#epilogue#7#transaction_fee_amount[Position(19907) := __tmp];
 
     call __t16 := CopyOrMoveRef(sender_account);
 
@@ -3961,6 +4386,7 @@ Label_20:
 
     call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 26));
     __m := UpdateLocal(__m, __frame + 8, __tmp);
+    debug#LibraAccount#epilogue#8#transaction_fee := debug#LibraAccount#epilogue#8#transaction_fee[Position(20225) := __tmp];
 
     call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 0));
     __m := UpdateLocal(__m, __frame + 27, __tmp);
@@ -4005,7 +4431,7 @@ Label_Abort:
 
 procedure LibraAccount_epilogue_verify (txn_sequence_number: Value, txn_gas_price: Value, txn_max_gas_units: Value, gas_units_remaining: Value) returns ()
 {
-    assume ExistsTxnSenderAccount(__m, __txn);
+    call InitVerification();
     call LibraAccount_epilogue(txn_sequence_number, txn_gas_price, txn_max_gas_units, gas_units_remaining);
 }
 
@@ -4036,18 +4462,34 @@ requires ExistsTxnSenderAccount(__m, __txn);
     var __tmp: Value;
     var __frame: int;
     var __saved_m: Memory;
+    var debug#LibraAccount#fresh_guid#0#counter: [Position]Value;
+    var debug#LibraAccount#fresh_guid#1#sender: [Position]Value;
+    var debug#LibraAccount#fresh_guid#2#count: [Position]Value;
+    var debug#LibraAccount#fresh_guid#3#count_bytes: [Position]Value;
+    var debug#LibraAccount#fresh_guid#4#preimage: [Position]Value;
+    var debug#LibraAccount#fresh_guid#5#sender_bytes: [Position]Value;
+    var debug#LibraAccount#fresh_guid#6#__ret: [Position]Value;
 
     // initialize function execution
     assume !__abort_flag;
     __saved_m := __m;
     __frame := __local_counter;
     __local_counter := __local_counter + 22;
+    debug#LibraAccount#fresh_guid#0#counter := EmptyPositionMap;
+    debug#LibraAccount#fresh_guid#1#sender := EmptyPositionMap;
+    debug#LibraAccount#fresh_guid#2#count := EmptyPositionMap;
+    debug#LibraAccount#fresh_guid#3#count_bytes := EmptyPositionMap;
+    debug#LibraAccount#fresh_guid#4#preimage := EmptyPositionMap;
+    debug#LibraAccount#fresh_guid#5#sender_bytes := EmptyPositionMap;
+    debug#LibraAccount#fresh_guid#6#__ret := EmptyPositionMap;
 
     // process and type check arguments
     assume is#Vector(Dereference(__m, counter));
     assume IsValidReferenceParameter(__m, __frame, counter);
+    debug#LibraAccount#fresh_guid#0#counter := debug#LibraAccount#fresh_guid#0#counter[Position(21344) := Dereference(__m, counter)];
     assume is#Address(sender);
     __m := UpdateLocal(__m, __frame + 1, sender);
+    debug#LibraAccount#fresh_guid#1#sender := debug#LibraAccount#fresh_guid#1#sender[Position(21344) := sender];
 
     // bytecode translation starts here
     call __t6 := CopyOrMoveRef(counter);
@@ -4067,6 +4509,7 @@ requires ExistsTxnSenderAccount(__m, __txn);
 
     call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 9));
     __m := UpdateLocal(__m, __frame + 5, __tmp);
+    debug#LibraAccount#fresh_guid#5#sender_bytes := debug#LibraAccount#fresh_guid#5#sender_bytes[Position(21614) := __tmp];
 
     call __t10 := CopyOrMoveRef(count);
 
@@ -4082,6 +4525,7 @@ requires ExistsTxnSenderAccount(__m, __txn);
 
     call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 12));
     __m := UpdateLocal(__m, __frame + 3, __tmp);
+    debug#LibraAccount#fresh_guid#3#count_bytes := debug#LibraAccount#fresh_guid#3#count_bytes[Position(21682) := __tmp];
 
     call __t13 := CopyOrMoveRef(count);
 
@@ -4114,22 +4558,25 @@ requires ExistsTxnSenderAccount(__m, __txn);
 
     call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 20));
     __m := UpdateLocal(__m, __frame + 4, __tmp);
+    debug#LibraAccount#fresh_guid#4#preimage := debug#LibraAccount#fresh_guid#4#preimage[Position(21879) := __tmp];
 
     call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 4));
     __m := UpdateLocal(__m, __frame + 21, __tmp);
 
     __ret0 := GetLocal(__m, __frame + 21);
+    debug#LibraAccount#fresh_guid#6#__ret := debug#LibraAccount#fresh_guid#6#__ret[Position(21970) := __ret0];
     return;
 
 Label_Abort:
     __abort_flag := true;
     __m := __saved_m;
     __ret0 := DefaultValue;
+    debug#LibraAccount#fresh_guid#6#__ret := debug#LibraAccount#fresh_guid#6#__ret[Position(21997) := __ret0];
 }
 
 procedure LibraAccount_fresh_guid_verify (counter: Reference, sender: Value) returns (__ret0: Value)
 {
-    assume ExistsTxnSenderAccount(__m, __txn);
+    call InitVerification();
     call __ret0 := LibraAccount_fresh_guid(counter, sender);
 }
 
@@ -4145,18 +4592,26 @@ requires ExistsTxnSenderAccount(__m, __txn);
     var __tmp: Value;
     var __frame: int;
     var __saved_m: Memory;
+    var debug#LibraAccount#new_event_handle_impl#0#counter: [Position]Value;
+    var debug#LibraAccount#new_event_handle_impl#1#sender: [Position]Value;
+    var debug#LibraAccount#new_event_handle_impl#2#__ret: [Position]Value;
 
     // initialize function execution
     assume !__abort_flag;
     __saved_m := __m;
     __frame := __local_counter;
     __local_counter := __local_counter + 7;
+    debug#LibraAccount#new_event_handle_impl#0#counter := EmptyPositionMap;
+    debug#LibraAccount#new_event_handle_impl#1#sender := EmptyPositionMap;
+    debug#LibraAccount#new_event_handle_impl#2#__ret := EmptyPositionMap;
 
     // process and type check arguments
     assume is#Vector(Dereference(__m, counter));
     assume IsValidReferenceParameter(__m, __frame, counter);
+    debug#LibraAccount#new_event_handle_impl#0#counter := debug#LibraAccount#new_event_handle_impl#0#counter[Position(22101) := Dereference(__m, counter)];
     assume is#Address(sender);
     __m := UpdateLocal(__m, __frame + 1, sender);
+    debug#LibraAccount#new_event_handle_impl#1#sender := debug#LibraAccount#new_event_handle_impl#1#sender[Position(22101) := sender];
 
     // bytecode translation starts here
     call __tmp := LdConst(0);
@@ -4177,17 +4632,19 @@ requires ExistsTxnSenderAccount(__m, __txn);
     __m := UpdateLocal(__m, __frame + 6, __tmp);
 
     __ret0 := GetLocal(__m, __frame + 6);
+    debug#LibraAccount#new_event_handle_impl#2#__ret := debug#LibraAccount#new_event_handle_impl#2#__ret[Position(22229) := __ret0];
     return;
 
 Label_Abort:
     __abort_flag := true;
     __m := __saved_m;
     __ret0 := DefaultValue;
+    debug#LibraAccount#new_event_handle_impl#2#__ret := debug#LibraAccount#new_event_handle_impl#2#__ret[Position(22321) := __ret0];
 }
 
 procedure LibraAccount_new_event_handle_impl_verify (tv0: TypeValue, counter: Reference, sender: Value) returns (__ret0: Value)
 {
-    assume ExistsTxnSenderAccount(__m, __txn);
+    call InitVerification();
     call __ret0 := LibraAccount_new_event_handle_impl(tv0, counter, sender);
 }
 
@@ -4206,12 +4663,18 @@ requires ExistsTxnSenderAccount(__m, __txn);
     var __tmp: Value;
     var __frame: int;
     var __saved_m: Memory;
+    var debug#LibraAccount#new_event_handle#0#sender_account_ref: [Position]Value;
+    var debug#LibraAccount#new_event_handle#1#sender_bytes: [Position]Value;
+    var debug#LibraAccount#new_event_handle#2#__ret: [Position]Value;
 
     // initialize function execution
     assume !__abort_flag;
     __saved_m := __m;
     __frame := __local_counter;
     __local_counter := __local_counter + 8;
+    debug#LibraAccount#new_event_handle#0#sender_account_ref := EmptyPositionMap;
+    debug#LibraAccount#new_event_handle#1#sender_bytes := EmptyPositionMap;
+    debug#LibraAccount#new_event_handle#2#__ret := EmptyPositionMap;
 
     // process and type check arguments
 
@@ -4238,17 +4701,19 @@ requires ExistsTxnSenderAccount(__m, __txn);
     __m := UpdateLocal(__m, __frame + 7, __t7);
 
     __ret0 := GetLocal(__m, __frame + 7);
+    debug#LibraAccount#new_event_handle#2#__ret := debug#LibraAccount#new_event_handle#2#__ret[Position(22670) := __ret0];
     return;
 
 Label_Abort:
     __abort_flag := true;
     __m := __saved_m;
     __ret0 := DefaultValue;
+    debug#LibraAccount#new_event_handle#2#__ret := debug#LibraAccount#new_event_handle#2#__ret[Position(22779) := __ret0];
 }
 
 procedure LibraAccount_new_event_handle_verify (tv0: TypeValue) returns (__ret0: Value)
 {
-    assume ExistsTxnSenderAccount(__m, __txn);
+    call InitVerification();
     call __ret0 := LibraAccount_new_event_handle(tv0);
 }
 
@@ -4275,17 +4740,27 @@ requires ExistsTxnSenderAccount(__m, __txn);
     var __tmp: Value;
     var __frame: int;
     var __saved_m: Memory;
+    var debug#LibraAccount#emit_event#0#handle_ref: [Position]Value;
+    var debug#LibraAccount#emit_event#1#msg: [Position]Value;
+    var debug#LibraAccount#emit_event#2#count: [Position]Value;
+    var debug#LibraAccount#emit_event#3#guid: [Position]Value;
 
     // initialize function execution
     assume !__abort_flag;
     __saved_m := __m;
     __frame := __local_counter;
     __local_counter := __local_counter + 18;
+    debug#LibraAccount#emit_event#0#handle_ref := EmptyPositionMap;
+    debug#LibraAccount#emit_event#1#msg := EmptyPositionMap;
+    debug#LibraAccount#emit_event#2#count := EmptyPositionMap;
+    debug#LibraAccount#emit_event#3#guid := EmptyPositionMap;
 
     // process and type check arguments
     assume is#Vector(Dereference(__m, handle_ref));
     assume IsValidReferenceParameter(__m, __frame, handle_ref);
+    debug#LibraAccount#emit_event#0#handle_ref := debug#LibraAccount#emit_event#0#handle_ref[Position(22958) := Dereference(__m, handle_ref)];
     __m := UpdateLocal(__m, __frame + 1, msg);
+    debug#LibraAccount#emit_event#1#msg := debug#LibraAccount#emit_event#1#msg[Position(22958) := msg];
 
     // bytecode translation starts here
     call __t4 := CopyOrMoveRef(handle_ref);
@@ -4298,6 +4773,7 @@ requires ExistsTxnSenderAccount(__m, __txn);
 
     call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 6));
     __m := UpdateLocal(__m, __frame + 3, __tmp);
+    debug#LibraAccount#emit_event#3#guid := debug#LibraAccount#emit_event#3#guid[Position(23108) := __tmp];
 
     call __t7 := CopyOrMoveRef(handle_ref);
 
@@ -4346,7 +4822,7 @@ Label_Abort:
 
 procedure LibraAccount_emit_event_verify (tv0: TypeValue, handle_ref: Reference, msg: Value) returns ()
 {
-    assume ExistsTxnSenderAccount(__m, __txn);
+    call InitVerification();
     call LibraAccount_emit_event(tv0, handle_ref, msg);
 }
 
@@ -4365,16 +4841,23 @@ requires ExistsTxnSenderAccount(__m, __txn);
     var __tmp: Value;
     var __frame: int;
     var __saved_m: Memory;
+    var debug#LibraAccount#destroy_handle#0#handle: [Position]Value;
+    var debug#LibraAccount#destroy_handle#1#guid: [Position]Value;
+    var debug#LibraAccount#destroy_handle#2#count: [Position]Value;
 
     // initialize function execution
     assume !__abort_flag;
     __saved_m := __m;
     __frame := __local_counter;
     __local_counter := __local_counter + 6;
+    debug#LibraAccount#destroy_handle#0#handle := EmptyPositionMap;
+    debug#LibraAccount#destroy_handle#1#guid := EmptyPositionMap;
+    debug#LibraAccount#destroy_handle#2#count := EmptyPositionMap;
 
     // process and type check arguments
     assume is#Vector(handle);
     __m := UpdateLocal(__m, __frame + 0, handle);
+    debug#LibraAccount#destroy_handle#0#handle := debug#LibraAccount#destroy_handle#0#handle[Position(23597) := handle];
 
     // bytecode translation starts here
     call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 0));
@@ -4386,9 +4869,11 @@ requires ExistsTxnSenderAccount(__m, __txn);
 
     call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 5));
     __m := UpdateLocal(__m, __frame + 1, __tmp);
+    debug#LibraAccount#destroy_handle#1#guid := debug#LibraAccount#destroy_handle#1#guid[Position(23752) := __tmp];
 
     call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 4));
     __m := UpdateLocal(__m, __frame + 2, __tmp);
+    debug#LibraAccount#destroy_handle#2#count := debug#LibraAccount#destroy_handle#2#count[Position(23745) := __tmp];
 
     return;
 
@@ -4399,7 +4884,7 @@ Label_Abort:
 
 procedure LibraAccount_destroy_handle_verify (tv0: TypeValue, handle: Value) returns ()
 {
-    assume ExistsTxnSenderAccount(__m, __txn);
+    call InitVerification();
     call LibraAccount_destroy_handle(tv0, handle);
 }
 
@@ -4450,16 +4935,19 @@ ensures old(b#Boolean(Boolean(!(b#Boolean(ExistsResource(__m, LibraAccount_T_typ
     var __tmp: Value;
     var __frame: int;
     var __saved_m: Memory;
+    var debug#AccessPathTest#fail_if_empty_balance#0#a: [Position]Value;
 
     // initialize function execution
     assume !__abort_flag;
     __saved_m := __m;
     __frame := __local_counter;
     __local_counter := __local_counter + 6;
+    debug#AccessPathTest#fail_if_empty_balance#0#a := EmptyPositionMap;
 
     // process and type check arguments
     assume is#Address(a);
     __m := UpdateLocal(__m, __frame + 0, a);
+    debug#AccessPathTest#fail_if_empty_balance#0#a := debug#AccessPathTest#fail_if_empty_balance#0#a[Position(943) := a];
 
     // bytecode translation starts here
     call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 0));
@@ -4495,6 +4983,6 @@ Label_Abort:
 
 procedure AccessPathTest_fail_if_empty_balance_verify (a: Value) returns ()
 {
-    assume ExistsTxnSenderAccount(__m, __txn);
+    call InitVerification();
     call AccessPathTest_fail_if_empty_balance(a);
 }

--- a/language/move-prover/bytecode-to-boogie/tests/goldenfiles/test-arithmetic.bpl
+++ b/language/move-prover/bytecode-to-boogie/tests/goldenfiles/test-arithmetic.bpl
@@ -21,18 +21,32 @@ requires ExistsTxnSenderAccount(__m, __txn);
     var __tmp: Value;
     var __frame: int;
     var __saved_m: Memory;
+    var debug#TestArithmetic#add_two_number#0#x: [Position]Value;
+    var debug#TestArithmetic#add_two_number#1#y: [Position]Value;
+    var debug#TestArithmetic#add_two_number#2#res: [Position]Value;
+    var debug#TestArithmetic#add_two_number#3#z: [Position]Value;
+    var debug#TestArithmetic#add_two_number#4#__ret: [Position]Value;
+    var debug#TestArithmetic#add_two_number#5#__ret: [Position]Value;
 
     // initialize function execution
     assume !__abort_flag;
     __saved_m := __m;
     __frame := __local_counter;
     __local_counter := __local_counter + 10;
+    debug#TestArithmetic#add_two_number#0#x := EmptyPositionMap;
+    debug#TestArithmetic#add_two_number#1#y := EmptyPositionMap;
+    debug#TestArithmetic#add_two_number#2#res := EmptyPositionMap;
+    debug#TestArithmetic#add_two_number#3#z := EmptyPositionMap;
+    debug#TestArithmetic#add_two_number#4#__ret := EmptyPositionMap;
+    debug#TestArithmetic#add_two_number#5#__ret := EmptyPositionMap;
 
     // process and type check arguments
     assume IsValidU64(x);
     __m := UpdateLocal(__m, __frame + 0, x);
+    debug#TestArithmetic#add_two_number#0#x := debug#TestArithmetic#add_two_number#0#x[Position(25) := x];
     assume IsValidU64(y);
     __m := UpdateLocal(__m, __frame + 1, y);
+    debug#TestArithmetic#add_two_number#1#y := debug#TestArithmetic#add_two_number#1#y[Position(25) := y];
 
     // bytecode translation starts here
     call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 0));
@@ -47,12 +61,14 @@ requires ExistsTxnSenderAccount(__m, __txn);
 
     call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 6));
     __m := UpdateLocal(__m, __frame + 2, __tmp);
+    debug#TestArithmetic#add_two_number#2#res := debug#TestArithmetic#add_two_number#2#res[Position(106) := __tmp];
 
     call __tmp := LdConst(3);
     __m := UpdateLocal(__m, __frame + 7, __tmp);
 
     call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 7));
     __m := UpdateLocal(__m, __frame + 3, __tmp);
+    debug#TestArithmetic#add_two_number#3#z := debug#TestArithmetic#add_two_number#3#z[Position(133) := __tmp];
 
     call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 3));
     __m := UpdateLocal(__m, __frame + 8, __tmp);
@@ -61,19 +77,23 @@ requires ExistsTxnSenderAccount(__m, __txn);
     __m := UpdateLocal(__m, __frame + 9, __tmp);
 
     __ret0 := GetLocal(__m, __frame + 8);
+    debug#TestArithmetic#add_two_number#4#__ret := debug#TestArithmetic#add_two_number#4#__ret[Position(142) := __ret0];
     __ret1 := GetLocal(__m, __frame + 9);
+    debug#TestArithmetic#add_two_number#5#__ret := debug#TestArithmetic#add_two_number#5#__ret[Position(142) := __ret1];
     return;
 
 Label_Abort:
     __abort_flag := true;
     __m := __saved_m;
     __ret0 := DefaultValue;
+    debug#TestArithmetic#add_two_number#4#__ret := debug#TestArithmetic#add_two_number#4#__ret[Position(169) := __ret0];
     __ret1 := DefaultValue;
+    debug#TestArithmetic#add_two_number#5#__ret := debug#TestArithmetic#add_two_number#5#__ret[Position(169) := __ret1];
 }
 
 procedure TestArithmetic_add_two_number_verify (x: Value, y: Value) returns (__ret0: Value, __ret1: Value)
 {
-    assume ExistsTxnSenderAccount(__m, __txn);
+    call InitVerification();
     call __ret0, __ret1 := TestArithmetic_add_two_number(x, y);
 }
 
@@ -91,20 +111,33 @@ requires ExistsTxnSenderAccount(__m, __txn);
     var __tmp: Value;
     var __frame: int;
     var __saved_m: Memory;
+    var debug#TestArithmetic#multiple_ops#0#x: [Position]Value;
+    var debug#TestArithmetic#multiple_ops#1#y: [Position]Value;
+    var debug#TestArithmetic#multiple_ops#2#z: [Position]Value;
+    var debug#TestArithmetic#multiple_ops#3#res: [Position]Value;
+    var debug#TestArithmetic#multiple_ops#4#__ret: [Position]Value;
 
     // initialize function execution
     assume !__abort_flag;
     __saved_m := __m;
     __frame := __local_counter;
     __local_counter := __local_counter + 10;
+    debug#TestArithmetic#multiple_ops#0#x := EmptyPositionMap;
+    debug#TestArithmetic#multiple_ops#1#y := EmptyPositionMap;
+    debug#TestArithmetic#multiple_ops#2#z := EmptyPositionMap;
+    debug#TestArithmetic#multiple_ops#3#res := EmptyPositionMap;
+    debug#TestArithmetic#multiple_ops#4#__ret := EmptyPositionMap;
 
     // process and type check arguments
     assume IsValidU64(x);
     __m := UpdateLocal(__m, __frame + 0, x);
+    debug#TestArithmetic#multiple_ops#0#x := debug#TestArithmetic#multiple_ops#0#x[Position(173) := x];
     assume IsValidU64(y);
     __m := UpdateLocal(__m, __frame + 1, y);
+    debug#TestArithmetic#multiple_ops#1#y := debug#TestArithmetic#multiple_ops#1#y[Position(173) := y];
     assume IsValidU64(z);
     __m := UpdateLocal(__m, __frame + 2, z);
+    debug#TestArithmetic#multiple_ops#2#z := debug#TestArithmetic#multiple_ops#2#z[Position(173) := z];
 
     // bytecode translation starts here
     call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 0));
@@ -126,22 +159,25 @@ requires ExistsTxnSenderAccount(__m, __txn);
 
     call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 8));
     __m := UpdateLocal(__m, __frame + 3, __tmp);
+    debug#TestArithmetic#multiple_ops#3#res := debug#TestArithmetic#multiple_ops#3#res[Position(242) := __tmp];
 
     call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 3));
     __m := UpdateLocal(__m, __frame + 9, __tmp);
 
     __ret0 := GetLocal(__m, __frame + 9);
+    debug#TestArithmetic#multiple_ops#4#__ret := debug#TestArithmetic#multiple_ops#4#__ret[Position(281) := __ret0];
     return;
 
 Label_Abort:
     __abort_flag := true;
     __m := __saved_m;
     __ret0 := DefaultValue;
+    debug#TestArithmetic#multiple_ops#4#__ret := debug#TestArithmetic#multiple_ops#4#__ret[Position(300) := __ret0];
 }
 
 procedure TestArithmetic_multiple_ops_verify (x: Value, y: Value, z: Value) returns (__ret0: Value)
 {
-    assume ExistsTxnSenderAccount(__m, __txn);
+    call InitVerification();
     call __ret0 := TestArithmetic_multiple_ops(x, y, z);
 }
 
@@ -173,18 +209,28 @@ requires ExistsTxnSenderAccount(__m, __txn);
     var __tmp: Value;
     var __frame: int;
     var __saved_m: Memory;
+    var debug#TestArithmetic#bool_ops#0#a: [Position]Value;
+    var debug#TestArithmetic#bool_ops#1#b: [Position]Value;
+    var debug#TestArithmetic#bool_ops#2#c: [Position]Value;
+    var debug#TestArithmetic#bool_ops#3#d: [Position]Value;
 
     // initialize function execution
     assume !__abort_flag;
     __saved_m := __m;
     __frame := __local_counter;
     __local_counter := __local_counter + 23;
+    debug#TestArithmetic#bool_ops#0#a := EmptyPositionMap;
+    debug#TestArithmetic#bool_ops#1#b := EmptyPositionMap;
+    debug#TestArithmetic#bool_ops#2#c := EmptyPositionMap;
+    debug#TestArithmetic#bool_ops#3#d := EmptyPositionMap;
 
     // process and type check arguments
     assume IsValidU64(a);
     __m := UpdateLocal(__m, __frame + 0, a);
+    debug#TestArithmetic#bool_ops#0#a := debug#TestArithmetic#bool_ops#0#a[Position(304) := a];
     assume IsValidU64(b);
     __m := UpdateLocal(__m, __frame + 1, b);
+    debug#TestArithmetic#bool_ops#1#b := debug#TestArithmetic#bool_ops#1#b[Position(304) := b];
 
     // bytecode translation starts here
     call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 0));
@@ -210,6 +256,7 @@ requires ExistsTxnSenderAccount(__m, __txn);
 
     call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 10));
     __m := UpdateLocal(__m, __frame + 2, __tmp);
+    debug#TestArithmetic#bool_ops#2#c := debug#TestArithmetic#bool_ops#2#c[Position(382) := __tmp];
 
     call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 0));
     __m := UpdateLocal(__m, __frame + 11, __tmp);
@@ -234,6 +281,7 @@ requires ExistsTxnSenderAccount(__m, __txn);
 
     call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 17));
     __m := UpdateLocal(__m, __frame + 3, __tmp);
+    debug#TestArithmetic#bool_ops#3#d := debug#TestArithmetic#bool_ops#3#d[Position(437) := __tmp];
 
     call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 2));
     __m := UpdateLocal(__m, __frame + 18, __tmp);
@@ -265,7 +313,7 @@ Label_Abort:
 
 procedure TestArithmetic_bool_ops_verify (a: Value, b: Value) returns ()
 {
-    assume ExistsTxnSenderAccount(__m, __txn);
+    call InitVerification();
     call TestArithmetic_bool_ops(a, b);
 }
 
@@ -295,18 +343,30 @@ requires ExistsTxnSenderAccount(__m, __txn);
     var __tmp: Value;
     var __frame: int;
     var __saved_m: Memory;
+    var debug#TestArithmetic#arithmetic_ops#0#a: [Position]Value;
+    var debug#TestArithmetic#arithmetic_ops#1#b: [Position]Value;
+    var debug#TestArithmetic#arithmetic_ops#2#c: [Position]Value;
+    var debug#TestArithmetic#arithmetic_ops#3#__ret: [Position]Value;
+    var debug#TestArithmetic#arithmetic_ops#4#__ret: [Position]Value;
 
     // initialize function execution
     assume !__abort_flag;
     __saved_m := __m;
     __frame := __local_counter;
     __local_counter := __local_counter + 21;
+    debug#TestArithmetic#arithmetic_ops#0#a := EmptyPositionMap;
+    debug#TestArithmetic#arithmetic_ops#1#b := EmptyPositionMap;
+    debug#TestArithmetic#arithmetic_ops#2#c := EmptyPositionMap;
+    debug#TestArithmetic#arithmetic_ops#3#__ret := EmptyPositionMap;
+    debug#TestArithmetic#arithmetic_ops#4#__ret := EmptyPositionMap;
 
     // process and type check arguments
     assume IsValidU64(a);
     __m := UpdateLocal(__m, __frame + 0, a);
+    debug#TestArithmetic#arithmetic_ops#0#a := debug#TestArithmetic#arithmetic_ops#0#a[Position(547) := a];
     assume IsValidU64(b);
     __m := UpdateLocal(__m, __frame + 1, b);
+    debug#TestArithmetic#arithmetic_ops#1#b := debug#TestArithmetic#arithmetic_ops#1#b[Position(547) := b];
 
     // bytecode translation starts here
     call __tmp := LdConst(6);
@@ -349,6 +409,7 @@ requires ExistsTxnSenderAccount(__m, __txn);
 
     call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 13));
     __m := UpdateLocal(__m, __frame + 2, __tmp);
+    debug#TestArithmetic#arithmetic_ops#2#c := debug#TestArithmetic#arithmetic_ops#2#c[Position(622) := __tmp];
 
     call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 2));
     __m := UpdateLocal(__m, __frame + 14, __tmp);
@@ -378,19 +439,23 @@ Label_19:
     __m := UpdateLocal(__m, __frame + 20, __tmp);
 
     __ret0 := GetLocal(__m, __frame + 19);
+    debug#TestArithmetic#arithmetic_ops#3#__ret := debug#TestArithmetic#arithmetic_ops#3#__ret[Position(686) := __ret0];
     __ret1 := GetLocal(__m, __frame + 20);
+    debug#TestArithmetic#arithmetic_ops#4#__ret := debug#TestArithmetic#arithmetic_ops#4#__ret[Position(686) := __ret1];
     return;
 
 Label_Abort:
     __abort_flag := true;
     __m := __saved_m;
     __ret0 := DefaultValue;
+    debug#TestArithmetic#arithmetic_ops#3#__ret := debug#TestArithmetic#arithmetic_ops#3#__ret[Position(713) := __ret0];
     __ret1 := DefaultValue;
+    debug#TestArithmetic#arithmetic_ops#4#__ret := debug#TestArithmetic#arithmetic_ops#4#__ret[Position(713) := __ret1];
 }
 
 procedure TestArithmetic_arithmetic_ops_verify (a: Value, b: Value) returns (__ret0: Value, __ret1: Value)
 {
-    assume ExistsTxnSenderAccount(__m, __txn);
+    call InitVerification();
     call __ret0, __ret1 := TestArithmetic_arithmetic_ops(a, b);
 }
 
@@ -407,12 +472,16 @@ requires ExistsTxnSenderAccount(__m, __txn);
     var __tmp: Value;
     var __frame: int;
     var __saved_m: Memory;
+    var debug#TestArithmetic#overflow#0#x: [Position]Value;
+    var debug#TestArithmetic#overflow#1#y: [Position]Value;
 
     // initialize function execution
     assume !__abort_flag;
     __saved_m := __m;
     __frame := __local_counter;
     __local_counter := __local_counter + 6;
+    debug#TestArithmetic#overflow#0#x := EmptyPositionMap;
+    debug#TestArithmetic#overflow#1#y := EmptyPositionMap;
 
     // process and type check arguments
 
@@ -422,6 +491,7 @@ requires ExistsTxnSenderAccount(__m, __txn);
 
     call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 2));
     __m := UpdateLocal(__m, __frame + 0, __tmp);
+    debug#TestArithmetic#overflow#0#x := debug#TestArithmetic#overflow#0#x[Position(771) := __tmp];
 
     call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 0));
     __m := UpdateLocal(__m, __frame + 3, __tmp);
@@ -435,6 +505,7 @@ requires ExistsTxnSenderAccount(__m, __txn);
 
     call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 5));
     __m := UpdateLocal(__m, __frame + 1, __tmp);
+    debug#TestArithmetic#overflow#1#y := debug#TestArithmetic#overflow#1#y[Position(799) := __tmp];
 
     return;
 
@@ -445,7 +516,7 @@ Label_Abort:
 
 procedure TestArithmetic_overflow_verify () returns ()
 {
-    assume ExistsTxnSenderAccount(__m, __txn);
+    call InitVerification();
     call TestArithmetic_overflow();
 }
 
@@ -462,12 +533,16 @@ requires ExistsTxnSenderAccount(__m, __txn);
     var __tmp: Value;
     var __frame: int;
     var __saved_m: Memory;
+    var debug#TestArithmetic#underflow#0#x: [Position]Value;
+    var debug#TestArithmetic#underflow#1#y: [Position]Value;
 
     // initialize function execution
     assume !__abort_flag;
     __saved_m := __m;
     __frame := __local_counter;
     __local_counter := __local_counter + 6;
+    debug#TestArithmetic#underflow#0#x := EmptyPositionMap;
+    debug#TestArithmetic#underflow#1#y := EmptyPositionMap;
 
     // process and type check arguments
 
@@ -477,6 +552,7 @@ requires ExistsTxnSenderAccount(__m, __txn);
 
     call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 2));
     __m := UpdateLocal(__m, __frame + 0, __tmp);
+    debug#TestArithmetic#underflow#0#x := debug#TestArithmetic#underflow#0#x[Position(887) := __tmp];
 
     call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 0));
     __m := UpdateLocal(__m, __frame + 3, __tmp);
@@ -490,6 +566,7 @@ requires ExistsTxnSenderAccount(__m, __txn);
 
     call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 5));
     __m := UpdateLocal(__m, __frame + 1, __tmp);
+    debug#TestArithmetic#underflow#1#y := debug#TestArithmetic#underflow#1#y[Position(897) := __tmp];
 
     return;
 
@@ -500,7 +577,7 @@ Label_Abort:
 
 procedure TestArithmetic_underflow_verify () returns ()
 {
-    assume ExistsTxnSenderAccount(__m, __txn);
+    call InitVerification();
     call TestArithmetic_underflow();
 }
 
@@ -517,12 +594,16 @@ requires ExistsTxnSenderAccount(__m, __txn);
     var __tmp: Value;
     var __frame: int;
     var __saved_m: Memory;
+    var debug#TestArithmetic#div_by_zero#0#x: [Position]Value;
+    var debug#TestArithmetic#div_by_zero#1#y: [Position]Value;
 
     // initialize function execution
     assume !__abort_flag;
     __saved_m := __m;
     __frame := __local_counter;
     __local_counter := __local_counter + 6;
+    debug#TestArithmetic#div_by_zero#0#x := EmptyPositionMap;
+    debug#TestArithmetic#div_by_zero#1#y := EmptyPositionMap;
 
     // process and type check arguments
 
@@ -532,6 +613,7 @@ requires ExistsTxnSenderAccount(__m, __txn);
 
     call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 2));
     __m := UpdateLocal(__m, __frame + 0, __tmp);
+    debug#TestArithmetic#div_by_zero#0#x := debug#TestArithmetic#div_by_zero#0#x[Position(987) := __tmp];
 
     call __tmp := LdConst(1);
     __m := UpdateLocal(__m, __frame + 3, __tmp);
@@ -545,6 +627,7 @@ requires ExistsTxnSenderAccount(__m, __txn);
 
     call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 5));
     __m := UpdateLocal(__m, __frame + 1, __tmp);
+    debug#TestArithmetic#div_by_zero#1#y := debug#TestArithmetic#div_by_zero#1#y[Position(997) := __tmp];
 
     return;
 
@@ -555,6 +638,6 @@ Label_Abort:
 
 procedure TestArithmetic_div_by_zero_verify () returns ()
 {
-    assume ExistsTxnSenderAccount(__m, __txn);
+    call InitVerification();
     call TestArithmetic_div_by_zero();
 }

--- a/language/move-prover/bytecode-to-boogie/tests/goldenfiles/test-control-flow.bpl
+++ b/language/move-prover/bytecode-to-boogie/tests/goldenfiles/test-control-flow.bpl
@@ -18,16 +18,21 @@ requires ExistsTxnSenderAccount(__m, __txn);
     var __tmp: Value;
     var __frame: int;
     var __saved_m: Memory;
+    var debug#TestControlFlow#branch_once#0#cond: [Position]Value;
+    var debug#TestControlFlow#branch_once#1#__ret: [Position]Value;
 
     // initialize function execution
     assume !__abort_flag;
     __saved_m := __m;
     __frame := __local_counter;
     __local_counter := __local_counter + 6;
+    debug#TestControlFlow#branch_once#0#cond := EmptyPositionMap;
+    debug#TestControlFlow#branch_once#1#__ret := EmptyPositionMap;
 
     // process and type check arguments
     assume is#Boolean(cond);
     __m := UpdateLocal(__m, __frame + 0, cond);
+    debug#TestControlFlow#branch_once#0#cond := debug#TestControlFlow#branch_once#0#cond[Position(117) := cond];
 
     // bytecode translation starts here
     call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 0));
@@ -47,6 +52,7 @@ requires ExistsTxnSenderAccount(__m, __txn);
     __m := UpdateLocal(__m, __frame + 4, __tmp);
 
     __ret0 := GetLocal(__m, __frame + 4);
+    debug#TestControlFlow#branch_once#1#__ret := debug#TestControlFlow#branch_once#1#__ret[Position(180) := __ret0];
     return;
 
 Label_6:
@@ -54,16 +60,18 @@ Label_6:
     __m := UpdateLocal(__m, __frame + 5, __tmp);
 
     __ret0 := GetLocal(__m, __frame + 5);
+    debug#TestControlFlow#branch_once#1#__ret := debug#TestControlFlow#branch_once#1#__ret[Position(206) := __ret0];
     return;
 
 Label_Abort:
     __abort_flag := true;
     __m := __saved_m;
     __ret0 := DefaultValue;
+    debug#TestControlFlow#branch_once#1#__ret := debug#TestControlFlow#branch_once#1#__ret[Position(221) := __ret0];
 }
 
 procedure TestControlFlow_branch_once_verify (cond: Value) returns (__ret0: Value)
 {
-    assume ExistsTxnSenderAccount(__m, __txn);
+    call InitVerification();
     call __ret0 := TestControlFlow_branch_once(cond);
 }

--- a/language/move-prover/bytecode-to-boogie/tests/goldenfiles/test-func-call.bpl
+++ b/language/move-prover/bytecode-to-boogie/tests/goldenfiles/test-func-call.bpl
@@ -16,16 +16,21 @@ requires ExistsTxnSenderAccount(__m, __txn);
     var __tmp: Value;
     var __frame: int;
     var __saved_m: Memory;
+    var debug#TestFuncCall#f#0#x: [Position]Value;
+    var debug#TestFuncCall#f#1#__ret: [Position]Value;
 
     // initialize function execution
     assume !__abort_flag;
     __saved_m := __m;
     __frame := __local_counter;
     __local_counter := __local_counter + 4;
+    debug#TestFuncCall#f#0#x := EmptyPositionMap;
+    debug#TestFuncCall#f#1#__ret := EmptyPositionMap;
 
     // process and type check arguments
     assume IsValidU64(x);
     __m := UpdateLocal(__m, __frame + 0, x);
+    debug#TestFuncCall#f#0#x := debug#TestFuncCall#f#0#x[Position(25) := x];
 
     // bytecode translation starts here
     call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 0));
@@ -39,17 +44,19 @@ requires ExistsTxnSenderAccount(__m, __txn);
     __m := UpdateLocal(__m, __frame + 3, __tmp);
 
     __ret0 := GetLocal(__m, __frame + 3);
+    debug#TestFuncCall#f#1#__ret := debug#TestFuncCall#f#1#__ret[Position(52) := __ret0];
     return;
 
 Label_Abort:
     __abort_flag := true;
     __m := __saved_m;
     __ret0 := DefaultValue;
+    debug#TestFuncCall#f#1#__ret := debug#TestFuncCall#f#1#__ret[Position(71) := __ret0];
 }
 
 procedure TestFuncCall_f_verify (x: Value) returns (__ret0: Value)
 {
-    assume ExistsTxnSenderAccount(__m, __txn);
+    call InitVerification();
     call __ret0 := TestFuncCall_f(x);
 }
 
@@ -63,16 +70,21 @@ requires ExistsTxnSenderAccount(__m, __txn);
     var __tmp: Value;
     var __frame: int;
     var __saved_m: Memory;
+    var debug#TestFuncCall#g#0#x: [Position]Value;
+    var debug#TestFuncCall#g#1#__ret: [Position]Value;
 
     // initialize function execution
     assume !__abort_flag;
     __saved_m := __m;
     __frame := __local_counter;
     __local_counter := __local_counter + 4;
+    debug#TestFuncCall#g#0#x := EmptyPositionMap;
+    debug#TestFuncCall#g#1#__ret := EmptyPositionMap;
 
     // process and type check arguments
     assume IsValidU64(x);
     __m := UpdateLocal(__m, __frame + 0, x);
+    debug#TestFuncCall#g#0#x := debug#TestFuncCall#g#0#x[Position(75) := x];
 
     // bytecode translation starts here
     call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 0));
@@ -86,17 +98,19 @@ requires ExistsTxnSenderAccount(__m, __txn);
     __m := UpdateLocal(__m, __frame + 3, __tmp);
 
     __ret0 := GetLocal(__m, __frame + 3);
+    debug#TestFuncCall#g#1#__ret := debug#TestFuncCall#g#1#__ret[Position(102) := __ret0];
     return;
 
 Label_Abort:
     __abort_flag := true;
     __m := __saved_m;
     __ret0 := DefaultValue;
+    debug#TestFuncCall#g#1#__ret := debug#TestFuncCall#g#1#__ret[Position(121) := __ret0];
 }
 
 procedure TestFuncCall_g_verify (x: Value) returns (__ret0: Value)
 {
-    assume ExistsTxnSenderAccount(__m, __txn);
+    call InitVerification();
     call __ret0 := TestFuncCall_g(x);
 }
 
@@ -133,16 +147,25 @@ ensures old(b#Boolean(Boolean(false))) ==> __abort_flag;
     var __tmp: Value;
     var __frame: int;
     var __saved_m: Memory;
+    var debug#TestFuncCall#h#0#b: [Position]Value;
+    var debug#TestFuncCall#h#1#x: [Position]Value;
+    var debug#TestFuncCall#h#2#y: [Position]Value;
+    var debug#TestFuncCall#h#3#__ret: [Position]Value;
 
     // initialize function execution
     assume !__abort_flag;
     __saved_m := __m;
     __frame := __local_counter;
     __local_counter := __local_counter + 24;
+    debug#TestFuncCall#h#0#b := EmptyPositionMap;
+    debug#TestFuncCall#h#1#x := EmptyPositionMap;
+    debug#TestFuncCall#h#2#y := EmptyPositionMap;
+    debug#TestFuncCall#h#3#__ret := EmptyPositionMap;
 
     // process and type check arguments
     assume is#Boolean(b);
     __m := UpdateLocal(__m, __frame + 0, b);
+    debug#TestFuncCall#h#0#b := debug#TestFuncCall#h#0#b[Position(125) := b];
 
     // bytecode translation starts here
     call __tmp := LdConst(3);
@@ -150,6 +173,7 @@ ensures old(b#Boolean(Boolean(false))) ==> __abort_flag;
 
     call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 3));
     __m := UpdateLocal(__m, __frame + 1, __tmp);
+    debug#TestFuncCall#h#1#x := debug#TestFuncCall#h#1#x[Position(199) := __tmp];
 
     call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 0));
     __m := UpdateLocal(__m, __frame + 4, __tmp);
@@ -168,6 +192,7 @@ ensures old(b#Boolean(Boolean(false))) ==> __abort_flag;
 
     call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 6));
     __m := UpdateLocal(__m, __frame + 2, __tmp);
+    debug#TestFuncCall#h#2#y := debug#TestFuncCall#h#2#y[Position(226) := __tmp];
 
     goto Label_11;
 
@@ -183,6 +208,7 @@ Label_8:
 
     call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 8));
     __m := UpdateLocal(__m, __frame + 2, __tmp);
+    debug#TestFuncCall#h#2#y := debug#TestFuncCall#h#2#y[Position(264) := __tmp];
 
 Label_11:
     call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 0));
@@ -237,16 +263,18 @@ Label_27:
     __m := UpdateLocal(__m, __frame + 23, __tmp);
 
     __ret0 := GetLocal(__m, __frame + 23);
+    debug#TestFuncCall#h#3#__ret := debug#TestFuncCall#h#3#__ret[Position(366) := __ret0];
     return;
 
 Label_Abort:
     __abort_flag := true;
     __m := __saved_m;
     __ret0 := DefaultValue;
+    debug#TestFuncCall#h#3#__ret := debug#TestFuncCall#h#3#__ret[Position(383) := __ret0];
 }
 
 procedure TestFuncCall_h_verify (b: Value) returns (__ret0: Value)
 {
-    assume ExistsTxnSenderAccount(__m, __txn);
+    call InitVerification();
     call __ret0 := TestFuncCall_h(b);
 }

--- a/language/move-prover/bytecode-to-boogie/tests/goldenfiles/test-generics.bpl
+++ b/language/move-prover/bytecode-to-boogie/tests/goldenfiles/test-generics.bpl
@@ -61,18 +61,28 @@ requires ExistsTxnSenderAccount(__m, __txn);
     var __tmp: Value;
     var __frame: int;
     var __saved_m: Memory;
+    var debug#TestGenerics#move2#0#x1: [Position]Value;
+    var debug#TestGenerics#move2#1#x2: [Position]Value;
+    var debug#TestGenerics#move2#2#v: [Position]Value;
+    var debug#TestGenerics#move2#3#r: [Position]Value;
 
     // initialize function execution
     assume !__abort_flag;
     __saved_m := __m;
     __frame := __local_counter;
     __local_counter := __local_counter + 12;
+    debug#TestGenerics#move2#0#x1 := EmptyPositionMap;
+    debug#TestGenerics#move2#1#x2 := EmptyPositionMap;
+    debug#TestGenerics#move2#2#v := EmptyPositionMap;
+    debug#TestGenerics#move2#3#r := EmptyPositionMap;
 
     // process and type check arguments
     assume IsValidU64(x1);
     __m := UpdateLocal(__m, __frame + 0, x1);
+    debug#TestGenerics#move2#0#x1 := debug#TestGenerics#move2#0#x1[Position(162) := x1];
     assume IsValidU64(x2);
     __m := UpdateLocal(__m, __frame + 1, x2);
+    debug#TestGenerics#move2#1#x2 := debug#TestGenerics#move2#1#x2[Position(162) := x2];
 
     // bytecode translation starts here
     call __t4 := Vector_empty(IntegerType());
@@ -83,6 +93,7 @@ requires ExistsTxnSenderAccount(__m, __txn);
 
     call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 4));
     __m := UpdateLocal(__m, __frame + 2, __tmp);
+    debug#TestGenerics#move2#2#v := debug#TestGenerics#move2#2#v[Position(256) := __tmp];
 
     call __t5 := BorrowLoc(__frame + 2);
 
@@ -91,6 +102,7 @@ requires ExistsTxnSenderAccount(__m, __txn);
 
     call Vector_push_back(IntegerType(), __t5, GetLocal(__m, __frame + 6));
     if (__abort_flag) { goto Label_Abort; }
+    debug#TestGenerics#move2#2#v := debug#TestGenerics#move2#2#v[Position(289) := GetLocal(__m, __frame + 2)];
 
     call __t7 := BorrowLoc(__frame + 2);
 
@@ -99,6 +111,7 @@ requires ExistsTxnSenderAccount(__m, __txn);
 
     call Vector_push_back(IntegerType(), __t7, GetLocal(__m, __frame + 8));
     if (__abort_flag) { goto Label_Abort; }
+    debug#TestGenerics#move2#2#v := debug#TestGenerics#move2#2#v[Position(338) := GetLocal(__m, __frame + 2)];
 
     call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 2));
     __m := UpdateLocal(__m, __frame + 9, __tmp);
@@ -108,6 +121,7 @@ requires ExistsTxnSenderAccount(__m, __txn);
 
     call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 10));
     __m := UpdateLocal(__m, __frame + 3, __tmp);
+    debug#TestGenerics#move2#3#r := debug#TestGenerics#move2#3#r[Position(387) := __tmp];
 
     call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 3));
     __m := UpdateLocal(__m, __frame + 11, __tmp);
@@ -124,7 +138,7 @@ Label_Abort:
 
 procedure TestGenerics_move2_verify (x1: Value, x2: Value) returns ()
 {
-    assume ExistsTxnSenderAccount(__m, __txn);
+    call InitVerification();
     call TestGenerics_move2(x1, x2);
 }
 
@@ -141,15 +155,22 @@ requires ExistsTxnSenderAccount(__m, __txn);
     var __tmp: Value;
     var __frame: int;
     var __saved_m: Memory;
+    var debug#TestGenerics#create#0#x: [Position]Value;
+    var debug#TestGenerics#create#1#v: [Position]Value;
+    var debug#TestGenerics#create#2#__ret: [Position]Value;
 
     // initialize function execution
     assume !__abort_flag;
     __saved_m := __m;
     __frame := __local_counter;
     __local_counter := __local_counter + 7;
+    debug#TestGenerics#create#0#x := EmptyPositionMap;
+    debug#TestGenerics#create#1#v := EmptyPositionMap;
+    debug#TestGenerics#create#2#__ret := EmptyPositionMap;
 
     // process and type check arguments
     __m := UpdateLocal(__m, __frame + 0, x);
+    debug#TestGenerics#create#0#x := debug#TestGenerics#create#0#x[Position(471) := x];
 
     // bytecode translation starts here
     call __t2 := Vector_empty(tv0);
@@ -160,6 +181,7 @@ requires ExistsTxnSenderAccount(__m, __txn);
 
     call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 2));
     __m := UpdateLocal(__m, __frame + 1, __tmp);
+    debug#TestGenerics#create#1#v := debug#TestGenerics#create#1#v[Position(557) := __tmp];
 
     call __t3 := BorrowLoc(__frame + 1);
 
@@ -168,6 +190,7 @@ requires ExistsTxnSenderAccount(__m, __txn);
 
     call Vector_push_back(tv0, __t3, GetLocal(__m, __frame + 4));
     if (__abort_flag) { goto Label_Abort; }
+    debug#TestGenerics#create#1#v := debug#TestGenerics#create#1#v[Position(588) := GetLocal(__m, __frame + 1)];
 
     call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 1));
     __m := UpdateLocal(__m, __frame + 5, __tmp);
@@ -176,17 +199,19 @@ requires ExistsTxnSenderAccount(__m, __txn);
     __m := UpdateLocal(__m, __frame + 6, __tmp);
 
     __ret0 := GetLocal(__m, __frame + 6);
+    debug#TestGenerics#create#2#__ret := debug#TestGenerics#create#2#__ret[Position(634) := __ret0];
     return;
 
 Label_Abort:
     __abort_flag := true;
     __m := __saved_m;
     __ret0 := DefaultValue;
+    debug#TestGenerics#create#2#__ret := debug#TestGenerics#create#2#__ret[Position(665) := __ret0];
 }
 
 procedure TestGenerics_create_verify (tv0: TypeValue, x: Value) returns (__ret0: Value)
 {
-    assume ExistsTxnSenderAccount(__m, __txn);
+    call InitVerification();
     call __ret0 := TestGenerics_create(tv0, x);
 }
 
@@ -208,16 +233,30 @@ requires ExistsTxnSenderAccount(__m, __txn);
     var __tmp: Value;
     var __frame: int;
     var __saved_m: Memory;
+    var debug#TestGenerics#overcomplicated_equals#0#x: [Position]Value;
+    var debug#TestGenerics#overcomplicated_equals#1#y: [Position]Value;
+    var debug#TestGenerics#overcomplicated_equals#2#r: [Position]Value;
+    var debug#TestGenerics#overcomplicated_equals#3#x1: [Position]Value;
+    var debug#TestGenerics#overcomplicated_equals#4#y1: [Position]Value;
+    var debug#TestGenerics#overcomplicated_equals#5#__ret: [Position]Value;
 
     // initialize function execution
     assume !__abort_flag;
     __saved_m := __m;
     __frame := __local_counter;
     __local_counter := __local_counter + 13;
+    debug#TestGenerics#overcomplicated_equals#0#x := EmptyPositionMap;
+    debug#TestGenerics#overcomplicated_equals#1#y := EmptyPositionMap;
+    debug#TestGenerics#overcomplicated_equals#2#r := EmptyPositionMap;
+    debug#TestGenerics#overcomplicated_equals#3#x1 := EmptyPositionMap;
+    debug#TestGenerics#overcomplicated_equals#4#y1 := EmptyPositionMap;
+    debug#TestGenerics#overcomplicated_equals#5#__ret := EmptyPositionMap;
 
     // process and type check arguments
     __m := UpdateLocal(__m, __frame + 0, x);
+    debug#TestGenerics#overcomplicated_equals#0#x := debug#TestGenerics#overcomplicated_equals#0#x[Position(672) := x];
     __m := UpdateLocal(__m, __frame + 1, y);
+    debug#TestGenerics#overcomplicated_equals#1#y := debug#TestGenerics#overcomplicated_equals#1#y[Position(672) := y];
 
     // bytecode translation starts here
     call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 0));
@@ -231,6 +270,7 @@ requires ExistsTxnSenderAccount(__m, __txn);
 
     call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 6));
     __m := UpdateLocal(__m, __frame + 3, __tmp);
+    debug#TestGenerics#overcomplicated_equals#3#x1 := debug#TestGenerics#overcomplicated_equals#3#x1[Position(822) := __tmp];
 
     call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 1));
     __m := UpdateLocal(__m, __frame + 7, __tmp);
@@ -243,6 +283,7 @@ requires ExistsTxnSenderAccount(__m, __txn);
 
     call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 8));
     __m := UpdateLocal(__m, __frame + 4, __tmp);
+    debug#TestGenerics#overcomplicated_equals#4#y1 := debug#TestGenerics#overcomplicated_equals#4#y1[Position(860) := __tmp];
 
     call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 3));
     __m := UpdateLocal(__m, __frame + 9, __tmp);
@@ -255,22 +296,25 @@ requires ExistsTxnSenderAccount(__m, __txn);
 
     call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 11));
     __m := UpdateLocal(__m, __frame + 2, __tmp);
+    debug#TestGenerics#overcomplicated_equals#2#r := debug#TestGenerics#overcomplicated_equals#2#r[Position(898) := __tmp];
 
     call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 2));
     __m := UpdateLocal(__m, __frame + 12, __tmp);
 
     __ret0 := GetLocal(__m, __frame + 12);
+    debug#TestGenerics#overcomplicated_equals#5#__ret := debug#TestGenerics#overcomplicated_equals#5#__ret[Position(932) := __ret0];
     return;
 
 Label_Abort:
     __abort_flag := true;
     __m := __saved_m;
     __ret0 := DefaultValue;
+    debug#TestGenerics#overcomplicated_equals#5#__ret := debug#TestGenerics#overcomplicated_equals#5#__ret[Position(952) := __ret0];
 }
 
 procedure TestGenerics_overcomplicated_equals_verify (tv0: TypeValue, x: Value, y: Value) returns (__ret0: Value)
 {
-    assume ExistsTxnSenderAccount(__m, __txn);
+    call InitVerification();
     call __ret0 := TestGenerics_overcomplicated_equals(tv0, x, y);
 }
 
@@ -286,12 +330,16 @@ requires ExistsTxnSenderAccount(__m, __txn);
     var __tmp: Value;
     var __frame: int;
     var __saved_m: Memory;
+    var debug#TestGenerics#test#0#r: [Position]Value;
+    var debug#TestGenerics#test#1#__ret: [Position]Value;
 
     // initialize function execution
     assume !__abort_flag;
     __saved_m := __m;
     __frame := __local_counter;
     __local_counter := __local_counter + 5;
+    debug#TestGenerics#test#0#r := EmptyPositionMap;
+    debug#TestGenerics#test#1#__ret := EmptyPositionMap;
 
     // process and type check arguments
 
@@ -310,21 +358,24 @@ requires ExistsTxnSenderAccount(__m, __txn);
 
     call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 3));
     __m := UpdateLocal(__m, __frame + 0, __tmp);
+    debug#TestGenerics#test#0#r := debug#TestGenerics#test#0#r[Position(1006) := __tmp];
 
     call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 0));
     __m := UpdateLocal(__m, __frame + 4, __tmp);
 
     __ret0 := GetLocal(__m, __frame + 4);
+    debug#TestGenerics#test#1#__ret := debug#TestGenerics#test#1#__ret[Position(1056) := __ret0];
     return;
 
 Label_Abort:
     __abort_flag := true;
     __m := __saved_m;
     __ret0 := DefaultValue;
+    debug#TestGenerics#test#1#__ret := debug#TestGenerics#test#1#__ret[Position(1076) := __ret0];
 }
 
 procedure TestGenerics_test_verify () returns (__ret0: Value)
 {
-    assume ExistsTxnSenderAccount(__m, __txn);
+    call InitVerification();
     call __ret0 := TestGenerics_test();
 }

--- a/language/move-prover/bytecode-to-boogie/tests/goldenfiles/test-lib.bpl
+++ b/language/move-prover/bytecode-to-boogie/tests/goldenfiles/test-lib.bpl
@@ -128,16 +128,19 @@ requires ExistsTxnSenderAccount(__m, __txn);
     var __tmp: Value;
     var __frame: int;
     var __saved_m: Memory;
+    var debug#GasSchedule#initialize#0#gas_schedule: [Position]Value;
 
     // initialize function execution
     assume !__abort_flag;
     __saved_m := __m;
     __frame := __local_counter;
     __local_counter := __local_counter + 7;
+    debug#GasSchedule#initialize#0#gas_schedule := EmptyPositionMap;
 
     // process and type check arguments
     assume is#Vector(gas_schedule);
     __m := UpdateLocal(__m, __frame + 0, gas_schedule);
+    debug#GasSchedule#initialize#0#gas_schedule := debug#GasSchedule#initialize#0#gas_schedule[Position(1239) := gas_schedule];
 
     // bytecode translation starts here
     call __tmp := GetTxnSenderAddress();
@@ -176,7 +179,7 @@ Label_Abort:
 
 procedure GasSchedule_initialize_verify (gas_schedule: Value) returns ()
 {
-    assume ExistsTxnSenderAccount(__m, __txn);
+    call InitVerification();
     call GasSchedule_initialize(gas_schedule);
 }
 
@@ -195,12 +198,18 @@ requires ExistsTxnSenderAccount(__m, __txn);
     var __tmp: Value;
     var __frame: int;
     var __saved_m: Memory;
+    var debug#GasSchedule#instruction_table_size#0#table: [Position]Value;
+    var debug#GasSchedule#instruction_table_size#1#instruction_table_len: [Position]Value;
+    var debug#GasSchedule#instruction_table_size#2#__ret: [Position]Value;
 
     // initialize function execution
     assume !__abort_flag;
     __saved_m := __m;
     __frame := __local_counter;
     __local_counter := __local_counter + 8;
+    debug#GasSchedule#instruction_table_size#0#table := EmptyPositionMap;
+    debug#GasSchedule#instruction_table_size#1#instruction_table_len := EmptyPositionMap;
+    debug#GasSchedule#instruction_table_size#2#__ret := EmptyPositionMap;
 
     // process and type check arguments
 
@@ -225,22 +234,25 @@ requires ExistsTxnSenderAccount(__m, __txn);
 
     call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 6));
     __m := UpdateLocal(__m, __frame + 1, __tmp);
+    debug#GasSchedule#instruction_table_size#1#instruction_table_len := debug#GasSchedule#instruction_table_size#1#instruction_table_len[Position(1569) := __tmp];
 
     call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 1));
     __m := UpdateLocal(__m, __frame + 7, __tmp);
 
     __ret0 := GetLocal(__m, __frame + 7);
+    debug#GasSchedule#instruction_table_size#2#__ret := debug#GasSchedule#instruction_table_size#2#__ret[Position(1662) := __ret0];
     return;
 
 Label_Abort:
     __abort_flag := true;
     __m := __saved_m;
     __ret0 := DefaultValue;
+    debug#GasSchedule#instruction_table_size#2#__ret := debug#GasSchedule#instruction_table_size#2#__ret[Position(1702) := __ret0];
 }
 
 procedure GasSchedule_instruction_table_size_verify () returns (__ret0: Value)
 {
-    assume ExistsTxnSenderAccount(__m, __txn);
+    call InitVerification();
     call __ret0 := GasSchedule_instruction_table_size();
 }
 
@@ -259,12 +271,18 @@ requires ExistsTxnSenderAccount(__m, __txn);
     var __tmp: Value;
     var __frame: int;
     var __saved_m: Memory;
+    var debug#GasSchedule#native_table_size#0#table: [Position]Value;
+    var debug#GasSchedule#native_table_size#1#native_table_len: [Position]Value;
+    var debug#GasSchedule#native_table_size#2#__ret: [Position]Value;
 
     // initialize function execution
     assume !__abort_flag;
     __saved_m := __m;
     __frame := __local_counter;
     __local_counter := __local_counter + 8;
+    debug#GasSchedule#native_table_size#0#table := EmptyPositionMap;
+    debug#GasSchedule#native_table_size#1#native_table_len := EmptyPositionMap;
+    debug#GasSchedule#native_table_size#2#__ret := EmptyPositionMap;
 
     // process and type check arguments
 
@@ -289,22 +307,25 @@ requires ExistsTxnSenderAccount(__m, __txn);
 
     call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 6));
     __m := UpdateLocal(__m, __frame + 1, __tmp);
+    debug#GasSchedule#native_table_size#1#native_table_len := debug#GasSchedule#native_table_size#1#native_table_len[Position(1870) := __tmp];
 
     call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 1));
     __m := UpdateLocal(__m, __frame + 7, __tmp);
 
     __ret0 := GetLocal(__m, __frame + 7);
+    debug#GasSchedule#native_table_size#2#__ret := debug#GasSchedule#native_table_size#2#__ret[Position(1953) := __ret0];
     return;
 
 Label_Abort:
     __abort_flag := true;
     __m := __saved_m;
     __ret0 := DefaultValue;
+    debug#GasSchedule#native_table_size#2#__ret := debug#GasSchedule#native_table_size#2#__ret[Position(1988) := __ret0];
 }
 
 procedure GasSchedule_native_table_size_verify () returns (__ret0: Value)
 {
-    assume ExistsTxnSenderAccount(__m, __txn);
+    call InitVerification();
     call __ret0 := GasSchedule_native_table_size();
 }
 
@@ -388,16 +409,21 @@ requires ExistsTxnSenderAccount(__m, __txn);
     var __tmp: Value;
     var __frame: int;
     var __saved_m: Memory;
+    var debug#ValidatorConfig#has#0#addr: [Position]Value;
+    var debug#ValidatorConfig#has#1#__ret: [Position]Value;
 
     // initialize function execution
     assume !__abort_flag;
     __saved_m := __m;
     __frame := __local_counter;
     __local_counter := __local_counter + 3;
+    debug#ValidatorConfig#has#0#addr := EmptyPositionMap;
+    debug#ValidatorConfig#has#1#__ret := EmptyPositionMap;
 
     // process and type check arguments
     assume is#Address(addr);
     __m := UpdateLocal(__m, __frame + 0, addr);
+    debug#ValidatorConfig#has#0#addr := debug#ValidatorConfig#has#0#addr[Position(645) := addr];
 
     // bytecode translation starts here
     call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 0));
@@ -407,17 +433,19 @@ requires ExistsTxnSenderAccount(__m, __txn);
     __m := UpdateLocal(__m, __frame + 2, __tmp);
 
     __ret0 := GetLocal(__m, __frame + 2);
+    debug#ValidatorConfig#has#1#__ret := debug#ValidatorConfig#has#1#__ret[Position(687) := __ret0];
     return;
 
 Label_Abort:
     __abort_flag := true;
     __m := __saved_m;
     __ret0 := DefaultValue;
+    debug#ValidatorConfig#has#1#__ret := debug#ValidatorConfig#has#1#__ret[Position(721) := __ret0];
 }
 
 procedure ValidatorConfig_has_verify (addr: Value) returns (__ret0: Value)
 {
-    assume ExistsTxnSenderAccount(__m, __txn);
+    call InitVerification();
     call __ret0 := ValidatorConfig_has(addr);
 }
 
@@ -434,16 +462,23 @@ requires ExistsTxnSenderAccount(__m, __txn);
     var __tmp: Value;
     var __frame: int;
     var __saved_m: Memory;
+    var debug#ValidatorConfig#config#0#addr: [Position]Value;
+    var debug#ValidatorConfig#config#1#t_ref: [Position]Value;
+    var debug#ValidatorConfig#config#2#__ret: [Position]Value;
 
     // initialize function execution
     assume !__abort_flag;
     __saved_m := __m;
     __frame := __local_counter;
     __local_counter := __local_counter + 7;
+    debug#ValidatorConfig#config#0#addr := EmptyPositionMap;
+    debug#ValidatorConfig#config#1#t_ref := EmptyPositionMap;
+    debug#ValidatorConfig#config#2#__ret := EmptyPositionMap;
 
     // process and type check arguments
     assume is#Address(addr);
     __m := UpdateLocal(__m, __frame + 0, addr);
+    debug#ValidatorConfig#config#0#addr := debug#ValidatorConfig#config#0#addr[Position(907) := addr];
 
     // bytecode translation starts here
     call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 0));
@@ -463,17 +498,19 @@ requires ExistsTxnSenderAccount(__m, __txn);
     __m := UpdateLocal(__m, __frame + 6, __tmp);
 
     __ret0 := GetLocal(__m, __frame + 6);
+    debug#ValidatorConfig#config#2#__ret := debug#ValidatorConfig#config#2#__ret[Position(1045) := __ret0];
     return;
 
 Label_Abort:
     __abort_flag := true;
     __m := __saved_m;
     __ret0 := DefaultValue;
+    debug#ValidatorConfig#config#2#__ret := debug#ValidatorConfig#config#2#__ret[Position(1078) := __ret0];
 }
 
 procedure ValidatorConfig_config_verify (addr: Value) returns (__ret0: Value)
 {
-    assume ExistsTxnSenderAccount(__m, __txn);
+    call InitVerification();
     call __ret0 := ValidatorConfig_config(addr);
 }
 
@@ -487,16 +524,21 @@ requires ExistsTxnSenderAccount(__m, __txn);
     var __tmp: Value;
     var __frame: int;
     var __saved_m: Memory;
+    var debug#ValidatorConfig#consensus_pubkey#0#config_ref: [Position]Value;
+    var debug#ValidatorConfig#consensus_pubkey#1#__ret: [Position]Value;
 
     // initialize function execution
     assume !__abort_flag;
     __saved_m := __m;
     __frame := __local_counter;
     __local_counter := __local_counter + 4;
+    debug#ValidatorConfig#consensus_pubkey#0#config_ref := EmptyPositionMap;
+    debug#ValidatorConfig#consensus_pubkey#1#__ret := EmptyPositionMap;
 
     // process and type check arguments
     assume is#Vector(Dereference(__m, config_ref));
     assume IsValidReferenceParameter(__m, __frame, config_ref);
+    debug#ValidatorConfig#consensus_pubkey#0#config_ref := debug#ValidatorConfig#consensus_pubkey#0#config_ref[Position(1129) := Dereference(__m, config_ref)];
 
     // bytecode translation starts here
     call __t1 := CopyOrMoveRef(config_ref);
@@ -508,17 +550,19 @@ requires ExistsTxnSenderAccount(__m, __txn);
     __m := UpdateLocal(__m, __frame + 3, __tmp);
 
     __ret0 := GetLocal(__m, __frame + 3);
+    debug#ValidatorConfig#consensus_pubkey#1#__ret := debug#ValidatorConfig#consensus_pubkey#1#__ret[Position(1200) := __ret0];
     return;
 
 Label_Abort:
     __abort_flag := true;
     __m := __saved_m;
     __ret0 := DefaultValue;
+    debug#ValidatorConfig#consensus_pubkey#1#__ret := debug#ValidatorConfig#consensus_pubkey#1#__ret[Position(1248) := __ret0];
 }
 
 procedure ValidatorConfig_consensus_pubkey_verify (config_ref: Reference) returns (__ret0: Value)
 {
-    assume ExistsTxnSenderAccount(__m, __txn);
+    call InitVerification();
     call __ret0 := ValidatorConfig_consensus_pubkey(config_ref);
 }
 
@@ -532,16 +576,21 @@ requires ExistsTxnSenderAccount(__m, __txn);
     var __tmp: Value;
     var __frame: int;
     var __saved_m: Memory;
+    var debug#ValidatorConfig#validator_network_signing_pubkey#0#config_ref: [Position]Value;
+    var debug#ValidatorConfig#validator_network_signing_pubkey#1#__ret: [Position]Value;
 
     // initialize function execution
     assume !__abort_flag;
     __saved_m := __m;
     __frame := __local_counter;
     __local_counter := __local_counter + 4;
+    debug#ValidatorConfig#validator_network_signing_pubkey#0#config_ref := EmptyPositionMap;
+    debug#ValidatorConfig#validator_network_signing_pubkey#1#__ret := EmptyPositionMap;
 
     // process and type check arguments
     assume is#Vector(Dereference(__m, config_ref));
     assume IsValidReferenceParameter(__m, __frame, config_ref);
+    debug#ValidatorConfig#validator_network_signing_pubkey#0#config_ref := debug#ValidatorConfig#validator_network_signing_pubkey#0#config_ref[Position(1315) := Dereference(__m, config_ref)];
 
     // bytecode translation starts here
     call __t1 := CopyOrMoveRef(config_ref);
@@ -553,17 +602,19 @@ requires ExistsTxnSenderAccount(__m, __txn);
     __m := UpdateLocal(__m, __frame + 3, __tmp);
 
     __ret0 := GetLocal(__m, __frame + 3);
+    debug#ValidatorConfig#validator_network_signing_pubkey#1#__ret := debug#ValidatorConfig#validator_network_signing_pubkey#1#__ret[Position(1402) := __ret0];
     return;
 
 Label_Abort:
     __abort_flag := true;
     __m := __saved_m;
     __ret0 := DefaultValue;
+    debug#ValidatorConfig#validator_network_signing_pubkey#1#__ret := debug#ValidatorConfig#validator_network_signing_pubkey#1#__ret[Position(1466) := __ret0];
 }
 
 procedure ValidatorConfig_validator_network_signing_pubkey_verify (config_ref: Reference) returns (__ret0: Value)
 {
-    assume ExistsTxnSenderAccount(__m, __txn);
+    call InitVerification();
     call __ret0 := ValidatorConfig_validator_network_signing_pubkey(config_ref);
 }
 
@@ -577,16 +628,21 @@ requires ExistsTxnSenderAccount(__m, __txn);
     var __tmp: Value;
     var __frame: int;
     var __saved_m: Memory;
+    var debug#ValidatorConfig#validator_network_identity_pubkey#0#config_ref: [Position]Value;
+    var debug#ValidatorConfig#validator_network_identity_pubkey#1#__ret: [Position]Value;
 
     // initialize function execution
     assume !__abort_flag;
     __saved_m := __m;
     __frame := __local_counter;
     __local_counter := __local_counter + 4;
+    debug#ValidatorConfig#validator_network_identity_pubkey#0#config_ref := EmptyPositionMap;
+    debug#ValidatorConfig#validator_network_identity_pubkey#1#__ret := EmptyPositionMap;
 
     // process and type check arguments
     assume is#Vector(Dereference(__m, config_ref));
     assume IsValidReferenceParameter(__m, __frame, config_ref);
+    debug#ValidatorConfig#validator_network_identity_pubkey#0#config_ref := debug#ValidatorConfig#validator_network_identity_pubkey#0#config_ref[Position(1534) := Dereference(__m, config_ref)];
 
     // bytecode translation starts here
     call __t1 := CopyOrMoveRef(config_ref);
@@ -598,17 +654,19 @@ requires ExistsTxnSenderAccount(__m, __txn);
     __m := UpdateLocal(__m, __frame + 3, __tmp);
 
     __ret0 := GetLocal(__m, __frame + 3);
+    debug#ValidatorConfig#validator_network_identity_pubkey#1#__ret := debug#ValidatorConfig#validator_network_identity_pubkey#1#__ret[Position(1622) := __ret0];
     return;
 
 Label_Abort:
     __abort_flag := true;
     __m := __saved_m;
     __ret0 := DefaultValue;
+    debug#ValidatorConfig#validator_network_identity_pubkey#1#__ret := debug#ValidatorConfig#validator_network_identity_pubkey#1#__ret[Position(1687) := __ret0];
 }
 
 procedure ValidatorConfig_validator_network_identity_pubkey_verify (config_ref: Reference) returns (__ret0: Value)
 {
-    assume ExistsTxnSenderAccount(__m, __txn);
+    call InitVerification();
     call __ret0 := ValidatorConfig_validator_network_identity_pubkey(config_ref);
 }
 
@@ -622,16 +680,21 @@ requires ExistsTxnSenderAccount(__m, __txn);
     var __tmp: Value;
     var __frame: int;
     var __saved_m: Memory;
+    var debug#ValidatorConfig#validator_network_address#0#config_ref: [Position]Value;
+    var debug#ValidatorConfig#validator_network_address#1#__ret: [Position]Value;
 
     // initialize function execution
     assume !__abort_flag;
     __saved_m := __m;
     __frame := __local_counter;
     __local_counter := __local_counter + 4;
+    debug#ValidatorConfig#validator_network_address#0#config_ref := EmptyPositionMap;
+    debug#ValidatorConfig#validator_network_address#1#__ret := EmptyPositionMap;
 
     // process and type check arguments
     assume is#Vector(Dereference(__m, config_ref));
     assume IsValidReferenceParameter(__m, __frame, config_ref);
+    debug#ValidatorConfig#validator_network_address#0#config_ref := debug#ValidatorConfig#validator_network_address#0#config_ref[Position(1747) := Dereference(__m, config_ref)];
 
     // bytecode translation starts here
     call __t1 := CopyOrMoveRef(config_ref);
@@ -643,17 +706,19 @@ requires ExistsTxnSenderAccount(__m, __txn);
     __m := UpdateLocal(__m, __frame + 3, __tmp);
 
     __ret0 := GetLocal(__m, __frame + 3);
+    debug#ValidatorConfig#validator_network_address#1#__ret := debug#ValidatorConfig#validator_network_address#1#__ret[Position(1827) := __ret0];
     return;
 
 Label_Abort:
     __abort_flag := true;
     __m := __saved_m;
     __ret0 := DefaultValue;
+    debug#ValidatorConfig#validator_network_address#1#__ret := debug#ValidatorConfig#validator_network_address#1#__ret[Position(1884) := __ret0];
 }
 
 procedure ValidatorConfig_validator_network_address_verify (config_ref: Reference) returns (__ret0: Value)
 {
-    assume ExistsTxnSenderAccount(__m, __txn);
+    call InitVerification();
     call __ret0 := ValidatorConfig_validator_network_address(config_ref);
 }
 
@@ -667,16 +732,21 @@ requires ExistsTxnSenderAccount(__m, __txn);
     var __tmp: Value;
     var __frame: int;
     var __saved_m: Memory;
+    var debug#ValidatorConfig#fullnodes_network_identity_pubkey#0#config_ref: [Position]Value;
+    var debug#ValidatorConfig#fullnodes_network_identity_pubkey#1#__ret: [Position]Value;
 
     // initialize function execution
     assume !__abort_flag;
     __saved_m := __m;
     __frame := __local_counter;
     __local_counter := __local_counter + 4;
+    debug#ValidatorConfig#fullnodes_network_identity_pubkey#0#config_ref := EmptyPositionMap;
+    debug#ValidatorConfig#fullnodes_network_identity_pubkey#1#__ret := EmptyPositionMap;
 
     // process and type check arguments
     assume is#Vector(Dereference(__m, config_ref));
     assume IsValidReferenceParameter(__m, __frame, config_ref);
+    debug#ValidatorConfig#fullnodes_network_identity_pubkey#0#config_ref := debug#ValidatorConfig#fullnodes_network_identity_pubkey#0#config_ref[Position(1952) := Dereference(__m, config_ref)];
 
     // bytecode translation starts here
     call __t1 := CopyOrMoveRef(config_ref);
@@ -688,17 +758,19 @@ requires ExistsTxnSenderAccount(__m, __txn);
     __m := UpdateLocal(__m, __frame + 3, __tmp);
 
     __ret0 := GetLocal(__m, __frame + 3);
+    debug#ValidatorConfig#fullnodes_network_identity_pubkey#1#__ret := debug#ValidatorConfig#fullnodes_network_identity_pubkey#1#__ret[Position(2040) := __ret0];
     return;
 
 Label_Abort:
     __abort_flag := true;
     __m := __saved_m;
     __ret0 := DefaultValue;
+    debug#ValidatorConfig#fullnodes_network_identity_pubkey#1#__ret := debug#ValidatorConfig#fullnodes_network_identity_pubkey#1#__ret[Position(2105) := __ret0];
 }
 
 procedure ValidatorConfig_fullnodes_network_identity_pubkey_verify (config_ref: Reference) returns (__ret0: Value)
 {
-    assume ExistsTxnSenderAccount(__m, __txn);
+    call InitVerification();
     call __ret0 := ValidatorConfig_fullnodes_network_identity_pubkey(config_ref);
 }
 
@@ -712,16 +784,21 @@ requires ExistsTxnSenderAccount(__m, __txn);
     var __tmp: Value;
     var __frame: int;
     var __saved_m: Memory;
+    var debug#ValidatorConfig#fullnodes_network_address#0#config_ref: [Position]Value;
+    var debug#ValidatorConfig#fullnodes_network_address#1#__ret: [Position]Value;
 
     // initialize function execution
     assume !__abort_flag;
     __saved_m := __m;
     __frame := __local_counter;
     __local_counter := __local_counter + 4;
+    debug#ValidatorConfig#fullnodes_network_address#0#config_ref := EmptyPositionMap;
+    debug#ValidatorConfig#fullnodes_network_address#1#__ret := EmptyPositionMap;
 
     // process and type check arguments
     assume is#Vector(Dereference(__m, config_ref));
     assume IsValidReferenceParameter(__m, __frame, config_ref);
+    debug#ValidatorConfig#fullnodes_network_address#0#config_ref := debug#ValidatorConfig#fullnodes_network_address#0#config_ref[Position(2165) := Dereference(__m, config_ref)];
 
     // bytecode translation starts here
     call __t1 := CopyOrMoveRef(config_ref);
@@ -733,17 +810,19 @@ requires ExistsTxnSenderAccount(__m, __txn);
     __m := UpdateLocal(__m, __frame + 3, __tmp);
 
     __ret0 := GetLocal(__m, __frame + 3);
+    debug#ValidatorConfig#fullnodes_network_address#1#__ret := debug#ValidatorConfig#fullnodes_network_address#1#__ret[Position(2245) := __ret0];
     return;
 
 Label_Abort:
     __abort_flag := true;
     __m := __saved_m;
     __ret0 := DefaultValue;
+    debug#ValidatorConfig#fullnodes_network_address#1#__ret := debug#ValidatorConfig#fullnodes_network_address#1#__ret[Position(2302) := __ret0];
 }
 
 procedure ValidatorConfig_fullnodes_network_address_verify (config_ref: Reference) returns (__ret0: Value)
 {
-    assume ExistsTxnSenderAccount(__m, __txn);
+    call InitVerification();
     call __ret0 := ValidatorConfig_fullnodes_network_address(config_ref);
 }
 
@@ -762,26 +841,44 @@ requires ExistsTxnSenderAccount(__m, __txn);
     var __tmp: Value;
     var __frame: int;
     var __saved_m: Memory;
+    var debug#ValidatorConfig#register_candidate_validator#0#consensus_pubkey: [Position]Value;
+    var debug#ValidatorConfig#register_candidate_validator#1#validator_network_signing_pubkey: [Position]Value;
+    var debug#ValidatorConfig#register_candidate_validator#2#validator_network_identity_pubkey: [Position]Value;
+    var debug#ValidatorConfig#register_candidate_validator#3#validator_network_address: [Position]Value;
+    var debug#ValidatorConfig#register_candidate_validator#4#fullnodes_network_identity_pubkey: [Position]Value;
+    var debug#ValidatorConfig#register_candidate_validator#5#fullnodes_network_address: [Position]Value;
 
     // initialize function execution
     assume !__abort_flag;
     __saved_m := __m;
     __frame := __local_counter;
     __local_counter := __local_counter + 14;
+    debug#ValidatorConfig#register_candidate_validator#0#consensus_pubkey := EmptyPositionMap;
+    debug#ValidatorConfig#register_candidate_validator#1#validator_network_signing_pubkey := EmptyPositionMap;
+    debug#ValidatorConfig#register_candidate_validator#2#validator_network_identity_pubkey := EmptyPositionMap;
+    debug#ValidatorConfig#register_candidate_validator#3#validator_network_address := EmptyPositionMap;
+    debug#ValidatorConfig#register_candidate_validator#4#fullnodes_network_identity_pubkey := EmptyPositionMap;
+    debug#ValidatorConfig#register_candidate_validator#5#fullnodes_network_address := EmptyPositionMap;
 
     // process and type check arguments
     assume is#ByteArray(consensus_pubkey);
     __m := UpdateLocal(__m, __frame + 0, consensus_pubkey);
+    debug#ValidatorConfig#register_candidate_validator#0#consensus_pubkey := debug#ValidatorConfig#register_candidate_validator#0#consensus_pubkey[Position(2532) := consensus_pubkey];
     assume is#ByteArray(validator_network_signing_pubkey);
     __m := UpdateLocal(__m, __frame + 1, validator_network_signing_pubkey);
+    debug#ValidatorConfig#register_candidate_validator#1#validator_network_signing_pubkey := debug#ValidatorConfig#register_candidate_validator#1#validator_network_signing_pubkey[Position(2532) := validator_network_signing_pubkey];
     assume is#ByteArray(validator_network_identity_pubkey);
     __m := UpdateLocal(__m, __frame + 2, validator_network_identity_pubkey);
+    debug#ValidatorConfig#register_candidate_validator#2#validator_network_identity_pubkey := debug#ValidatorConfig#register_candidate_validator#2#validator_network_identity_pubkey[Position(2532) := validator_network_identity_pubkey];
     assume is#ByteArray(validator_network_address);
     __m := UpdateLocal(__m, __frame + 3, validator_network_address);
+    debug#ValidatorConfig#register_candidate_validator#3#validator_network_address := debug#ValidatorConfig#register_candidate_validator#3#validator_network_address[Position(2532) := validator_network_address];
     assume is#ByteArray(fullnodes_network_identity_pubkey);
     __m := UpdateLocal(__m, __frame + 4, fullnodes_network_identity_pubkey);
+    debug#ValidatorConfig#register_candidate_validator#4#fullnodes_network_identity_pubkey := debug#ValidatorConfig#register_candidate_validator#4#fullnodes_network_identity_pubkey[Position(2532) := fullnodes_network_identity_pubkey];
     assume is#ByteArray(fullnodes_network_address);
     __m := UpdateLocal(__m, __frame + 5, fullnodes_network_address);
+    debug#ValidatorConfig#register_candidate_validator#5#fullnodes_network_address := debug#ValidatorConfig#register_candidate_validator#5#fullnodes_network_address[Position(2532) := fullnodes_network_address];
 
     // bytecode translation starts here
     call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 0));
@@ -820,7 +917,7 @@ Label_Abort:
 
 procedure ValidatorConfig_register_candidate_validator_verify (consensus_pubkey: Value, validator_network_signing_pubkey: Value, validator_network_identity_pubkey: Value, validator_network_address: Value, fullnodes_network_identity_pubkey: Value, fullnodes_network_address: Value) returns ()
 {
-    assume ExistsTxnSenderAccount(__m, __txn);
+    call InitVerification();
     call ValidatorConfig_register_candidate_validator(consensus_pubkey, validator_network_signing_pubkey, validator_network_identity_pubkey, validator_network_address, fullnodes_network_identity_pubkey, fullnodes_network_address);
 }
 
@@ -842,16 +939,25 @@ requires ExistsTxnSenderAccount(__m, __txn);
     var __tmp: Value;
     var __frame: int;
     var __saved_m: Memory;
+    var debug#ValidatorConfig#rotate_consensus_pubkey#0#consensus_pubkey: [Position]Value;
+    var debug#ValidatorConfig#rotate_consensus_pubkey#1#t_ref: [Position]Value;
+    var debug#ValidatorConfig#rotate_consensus_pubkey#2#config_ref: [Position]Value;
+    var debug#ValidatorConfig#rotate_consensus_pubkey#3#key_ref: [Position]Value;
 
     // initialize function execution
     assume !__abort_flag;
     __saved_m := __m;
     __frame := __local_counter;
     __local_counter := __local_counter + 12;
+    debug#ValidatorConfig#rotate_consensus_pubkey#0#consensus_pubkey := EmptyPositionMap;
+    debug#ValidatorConfig#rotate_consensus_pubkey#1#t_ref := EmptyPositionMap;
+    debug#ValidatorConfig#rotate_consensus_pubkey#2#config_ref := EmptyPositionMap;
+    debug#ValidatorConfig#rotate_consensus_pubkey#3#key_ref := EmptyPositionMap;
 
     // process and type check arguments
     assume is#ByteArray(consensus_pubkey);
     __m := UpdateLocal(__m, __frame + 0, consensus_pubkey);
+    debug#ValidatorConfig#rotate_consensus_pubkey#0#consensus_pubkey := debug#ValidatorConfig#rotate_consensus_pubkey#0#consensus_pubkey[Position(3648) := consensus_pubkey];
 
     // bytecode translation starts here
     call __tmp := GetTxnSenderAddress();
@@ -890,7 +996,7 @@ Label_Abort:
 
 procedure ValidatorConfig_rotate_consensus_pubkey_verify (consensus_pubkey: Value) returns ()
 {
-    assume ExistsTxnSenderAccount(__m, __txn);
+    call InitVerification();
     call ValidatorConfig_rotate_consensus_pubkey(consensus_pubkey);
 }
 
@@ -912,16 +1018,25 @@ requires ExistsTxnSenderAccount(__m, __txn);
     var __tmp: Value;
     var __frame: int;
     var __saved_m: Memory;
+    var debug#ValidatorConfig#rotate_validator_network_identity_pubkey#0#validator_network_identity_pubkey: [Position]Value;
+    var debug#ValidatorConfig#rotate_validator_network_identity_pubkey#1#t_ref: [Position]Value;
+    var debug#ValidatorConfig#rotate_validator_network_identity_pubkey#2#config_ref: [Position]Value;
+    var debug#ValidatorConfig#rotate_validator_network_identity_pubkey#3#key_ref: [Position]Value;
 
     // initialize function execution
     assume !__abort_flag;
     __saved_m := __m;
     __frame := __local_counter;
     __local_counter := __local_counter + 12;
+    debug#ValidatorConfig#rotate_validator_network_identity_pubkey#0#validator_network_identity_pubkey := EmptyPositionMap;
+    debug#ValidatorConfig#rotate_validator_network_identity_pubkey#1#t_ref := EmptyPositionMap;
+    debug#ValidatorConfig#rotate_validator_network_identity_pubkey#2#config_ref := EmptyPositionMap;
+    debug#ValidatorConfig#rotate_validator_network_identity_pubkey#3#key_ref := EmptyPositionMap;
 
     // process and type check arguments
     assume is#ByteArray(validator_network_identity_pubkey);
     __m := UpdateLocal(__m, __frame + 0, validator_network_identity_pubkey);
+    debug#ValidatorConfig#rotate_validator_network_identity_pubkey#0#validator_network_identity_pubkey := debug#ValidatorConfig#rotate_validator_network_identity_pubkey#0#validator_network_identity_pubkey[Position(4265) := validator_network_identity_pubkey];
 
     // bytecode translation starts here
     call __tmp := GetTxnSenderAddress();
@@ -960,7 +1075,7 @@ Label_Abort:
 
 procedure ValidatorConfig_rotate_validator_network_identity_pubkey_verify (validator_network_identity_pubkey: Value) returns ()
 {
-    assume ExistsTxnSenderAccount(__m, __txn);
+    call InitVerification();
     call ValidatorConfig_rotate_validator_network_identity_pubkey(validator_network_identity_pubkey);
 }
 
@@ -982,16 +1097,25 @@ requires ExistsTxnSenderAccount(__m, __txn);
     var __tmp: Value;
     var __frame: int;
     var __saved_m: Memory;
+    var debug#ValidatorConfig#rotate_validator_network_address#0#validator_network_address: [Position]Value;
+    var debug#ValidatorConfig#rotate_validator_network_address#1#t_ref: [Position]Value;
+    var debug#ValidatorConfig#rotate_validator_network_address#2#config_ref: [Position]Value;
+    var debug#ValidatorConfig#rotate_validator_network_address#3#key_ref: [Position]Value;
 
     // initialize function execution
     assume !__abort_flag;
     __saved_m := __m;
     __frame := __local_counter;
     __local_counter := __local_counter + 12;
+    debug#ValidatorConfig#rotate_validator_network_address#0#validator_network_address := EmptyPositionMap;
+    debug#ValidatorConfig#rotate_validator_network_address#1#t_ref := EmptyPositionMap;
+    debug#ValidatorConfig#rotate_validator_network_address#2#config_ref := EmptyPositionMap;
+    debug#ValidatorConfig#rotate_validator_network_address#3#key_ref := EmptyPositionMap;
 
     // process and type check arguments
     assume is#ByteArray(validator_network_address);
     __m := UpdateLocal(__m, __frame + 0, validator_network_address);
+    debug#ValidatorConfig#rotate_validator_network_address#0#validator_network_address := debug#ValidatorConfig#rotate_validator_network_address#0#validator_network_address[Position(4890) := validator_network_address];
 
     // bytecode translation starts here
     call __tmp := GetTxnSenderAddress();
@@ -1030,7 +1154,7 @@ Label_Abort:
 
 procedure ValidatorConfig_rotate_validator_network_address_verify (validator_network_address: Value) returns ()
 {
-    assume ExistsTxnSenderAccount(__m, __txn);
+    call InitVerification();
     call ValidatorConfig_rotate_validator_network_address(validator_network_address);
 }
 
@@ -1110,16 +1234,21 @@ requires ExistsTxnSenderAccount(__m, __txn);
     var __tmp: Value;
     var __frame: int;
     var __saved_m: Memory;
+    var debug#LibraCoin#mint_with_default_capability#0#amount: [Position]Value;
+    var debug#LibraCoin#mint_with_default_capability#1#__ret: [Position]Value;
 
     // initialize function execution
     assume !__abort_flag;
     __saved_m := __m;
     __frame := __local_counter;
     __local_counter := __local_counter + 5;
+    debug#LibraCoin#mint_with_default_capability#0#amount := EmptyPositionMap;
+    debug#LibraCoin#mint_with_default_capability#1#__ret := EmptyPositionMap;
 
     // process and type check arguments
     assume IsValidU64(amount);
     __m := UpdateLocal(__m, __frame + 0, amount);
+    debug#LibraCoin#mint_with_default_capability#0#amount := debug#LibraCoin#mint_with_default_capability#0#amount[Position(807) := amount];
 
     // bytecode translation starts here
     call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 0));
@@ -1138,17 +1267,19 @@ requires ExistsTxnSenderAccount(__m, __txn);
     __m := UpdateLocal(__m, __frame + 4, __t4);
 
     __ret0 := GetLocal(__m, __frame + 4);
+    debug#LibraCoin#mint_with_default_capability#1#__ret := debug#LibraCoin#mint_with_default_capability#1#__ret[Position(909) := __ret0];
     return;
 
 Label_Abort:
     __abort_flag := true;
     __m := __saved_m;
     __ret0 := DefaultValue;
+    debug#LibraCoin#mint_with_default_capability#1#__ret := debug#LibraCoin#mint_with_default_capability#1#__ret[Position(994) := __ret0];
 }
 
 procedure LibraCoin_mint_with_default_capability_verify (amount: Value) returns (__ret0: Value)
 {
-    assume ExistsTxnSenderAccount(__m, __txn);
+    call InitVerification();
     call __ret0 := LibraCoin_mint_with_default_capability(amount);
 }
 
@@ -1178,18 +1309,28 @@ requires ExistsTxnSenderAccount(__m, __txn);
     var __tmp: Value;
     var __frame: int;
     var __saved_m: Memory;
+    var debug#LibraCoin#mint#0#value: [Position]Value;
+    var debug#LibraCoin#mint#1#capability: [Position]Value;
+    var debug#LibraCoin#mint#2#total_value_ref: [Position]Value;
+    var debug#LibraCoin#mint#3#__ret: [Position]Value;
 
     // initialize function execution
     assume !__abort_flag;
     __saved_m := __m;
     __frame := __local_counter;
     __local_counter := __local_counter + 21;
+    debug#LibraCoin#mint#0#value := EmptyPositionMap;
+    debug#LibraCoin#mint#1#capability := EmptyPositionMap;
+    debug#LibraCoin#mint#2#total_value_ref := EmptyPositionMap;
+    debug#LibraCoin#mint#3#__ret := EmptyPositionMap;
 
     // process and type check arguments
     assume IsValidU64(value);
     __m := UpdateLocal(__m, __frame + 0, value);
+    debug#LibraCoin#mint#0#value := debug#LibraCoin#mint#0#value[Position(1231) := value];
     assume is#Vector(Dereference(__m, capability));
     assume IsValidReferenceParameter(__m, __frame, capability);
+    debug#LibraCoin#mint#1#capability := debug#LibraCoin#mint#1#capability[Position(1231) := Dereference(__m, capability)];
 
     // bytecode translation starts here
     call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 0));
@@ -1258,17 +1399,19 @@ Label_9:
     __m := UpdateLocal(__m, __frame + 20, __tmp);
 
     __ret0 := GetLocal(__m, __frame + 20);
+    debug#LibraCoin#mint#3#__ret := debug#LibraCoin#mint#3#__ret[Position(2067) := __ret0];
     return;
 
 Label_Abort:
     __abort_flag := true;
     __m := __saved_m;
     __ret0 := DefaultValue;
+    debug#LibraCoin#mint#3#__ret := debug#LibraCoin#mint#3#__ret[Position(2101) := __ret0];
 }
 
 procedure LibraCoin_mint_verify (value: Value, capability: Reference) returns (__ret0: Value)
 {
-    assume ExistsTxnSenderAccount(__m, __txn);
+    call InitVerification();
     call __ret0 := LibraCoin_mint(value, capability);
 }
 
@@ -1346,7 +1489,7 @@ Label_Abort:
 
 procedure LibraCoin_initialize_verify () returns ()
 {
-    assume ExistsTxnSenderAccount(__m, __txn);
+    call InitVerification();
     call LibraCoin_initialize();
 }
 
@@ -1361,12 +1504,14 @@ requires ExistsTxnSenderAccount(__m, __txn);
     var __tmp: Value;
     var __frame: int;
     var __saved_m: Memory;
+    var debug#LibraCoin#market_cap#0#__ret: [Position]Value;
 
     // initialize function execution
     assume !__abort_flag;
     __saved_m := __m;
     __frame := __local_counter;
     __local_counter := __local_counter + 4;
+    debug#LibraCoin#market_cap#0#__ret := EmptyPositionMap;
 
     // process and type check arguments
 
@@ -1384,17 +1529,19 @@ requires ExistsTxnSenderAccount(__m, __txn);
     __m := UpdateLocal(__m, __frame + 3, __tmp);
 
     __ret0 := GetLocal(__m, __frame + 3);
+    debug#LibraCoin#market_cap#0#__ret := debug#LibraCoin#market_cap#0#__ret[Position(2657) := __ret0];
     return;
 
 Label_Abort:
     __abort_flag := true;
     __m := __saved_m;
     __ret0 := DefaultValue;
+    debug#LibraCoin#market_cap#0#__ret := debug#LibraCoin#market_cap#0#__ret[Position(2721) := __ret0];
 }
 
 procedure LibraCoin_market_cap_verify () returns (__ret0: Value)
 {
-    assume ExistsTxnSenderAccount(__m, __txn);
+    call InitVerification();
     call __ret0 := LibraCoin_market_cap();
 }
 
@@ -1407,12 +1554,14 @@ requires ExistsTxnSenderAccount(__m, __txn);
     var __tmp: Value;
     var __frame: int;
     var __saved_m: Memory;
+    var debug#LibraCoin#zero#0#__ret: [Position]Value;
 
     // initialize function execution
     assume !__abort_flag;
     __saved_m := __m;
     __frame := __local_counter;
     __local_counter := __local_counter + 2;
+    debug#LibraCoin#zero#0#__ret := EmptyPositionMap;
 
     // process and type check arguments
 
@@ -1424,17 +1573,19 @@ requires ExistsTxnSenderAccount(__m, __txn);
     __m := UpdateLocal(__m, __frame + 1, __tmp);
 
     __ret0 := GetLocal(__m, __frame + 1);
+    debug#LibraCoin#zero#0#__ret := debug#LibraCoin#zero#0#__ret[Position(2810) := __ret0];
     return;
 
 Label_Abort:
     __abort_flag := true;
     __m := __saved_m;
     __ret0 := DefaultValue;
+    debug#LibraCoin#zero#0#__ret := debug#LibraCoin#zero#0#__ret[Position(2834) := __ret0];
 }
 
 procedure LibraCoin_zero_verify () returns (__ret0: Value)
 {
-    assume ExistsTxnSenderAccount(__m, __txn);
+    call InitVerification();
     call __ret0 := LibraCoin_zero();
 }
 
@@ -1448,16 +1599,21 @@ requires ExistsTxnSenderAccount(__m, __txn);
     var __tmp: Value;
     var __frame: int;
     var __saved_m: Memory;
+    var debug#LibraCoin#value#0#coin_ref: [Position]Value;
+    var debug#LibraCoin#value#1#__ret: [Position]Value;
 
     // initialize function execution
     assume !__abort_flag;
     __saved_m := __m;
     __frame := __local_counter;
     __local_counter := __local_counter + 4;
+    debug#LibraCoin#value#0#coin_ref := EmptyPositionMap;
+    debug#LibraCoin#value#1#__ret := EmptyPositionMap;
 
     // process and type check arguments
     assume is#Vector(Dereference(__m, coin_ref));
     assume IsValidReferenceParameter(__m, __frame, coin_ref);
+    debug#LibraCoin#value#0#coin_ref := debug#LibraCoin#value#0#coin_ref[Position(2888) := Dereference(__m, coin_ref)];
 
     // bytecode translation starts here
     call __t1 := CopyOrMoveRef(coin_ref);
@@ -1469,17 +1625,19 @@ requires ExistsTxnSenderAccount(__m, __txn);
     __m := UpdateLocal(__m, __frame + 3, __tmp);
 
     __ret0 := GetLocal(__m, __frame + 3);
+    debug#LibraCoin#value#1#__ret := debug#LibraCoin#value#1#__ret[Position(2935) := __ret0];
     return;
 
 Label_Abort:
     __abort_flag := true;
     __m := __saved_m;
     __ret0 := DefaultValue;
+    debug#LibraCoin#value#1#__ret := debug#LibraCoin#value#1#__ret[Position(2970) := __ret0];
 }
 
 procedure LibraCoin_value_verify (coin_ref: Reference) returns (__ret0: Value)
 {
-    assume ExistsTxnSenderAccount(__m, __txn);
+    call InitVerification();
     call __ret0 := LibraCoin_value(coin_ref);
 }
 
@@ -1496,18 +1654,30 @@ requires ExistsTxnSenderAccount(__m, __txn);
     var __tmp: Value;
     var __frame: int;
     var __saved_m: Memory;
+    var debug#LibraCoin#split#0#coin: [Position]Value;
+    var debug#LibraCoin#split#1#amount: [Position]Value;
+    var debug#LibraCoin#split#2#other: [Position]Value;
+    var debug#LibraCoin#split#3#__ret: [Position]Value;
+    var debug#LibraCoin#split#4#__ret: [Position]Value;
 
     // initialize function execution
     assume !__abort_flag;
     __saved_m := __m;
     __frame := __local_counter;
     __local_counter := __local_counter + 8;
+    debug#LibraCoin#split#0#coin := EmptyPositionMap;
+    debug#LibraCoin#split#1#amount := EmptyPositionMap;
+    debug#LibraCoin#split#2#other := EmptyPositionMap;
+    debug#LibraCoin#split#3#__ret := EmptyPositionMap;
+    debug#LibraCoin#split#4#__ret := EmptyPositionMap;
 
     // process and type check arguments
     assume is#Vector(coin);
     __m := UpdateLocal(__m, __frame + 0, coin);
+    debug#LibraCoin#split#0#coin := debug#LibraCoin#split#0#coin[Position(3109) := coin];
     assume IsValidU64(amount);
     __m := UpdateLocal(__m, __frame + 1, amount);
+    debug#LibraCoin#split#1#amount := debug#LibraCoin#split#1#amount[Position(3109) := amount];
 
     // bytecode translation starts here
     call __t3 := BorrowLoc(__frame + 0);
@@ -1520,9 +1690,11 @@ requires ExistsTxnSenderAccount(__m, __txn);
     assume is#Vector(__t5);
 
     __m := UpdateLocal(__m, __frame + 5, __t5);
+    debug#LibraCoin#split#0#coin := debug#LibraCoin#split#0#coin[Position(3211) := GetLocal(__m, __frame + 0)];
 
     call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 5));
     __m := UpdateLocal(__m, __frame + 2, __tmp);
+    debug#LibraCoin#split#2#other := debug#LibraCoin#split#2#other[Position(3203) := __tmp];
 
     call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 0));
     __m := UpdateLocal(__m, __frame + 6, __tmp);
@@ -1531,19 +1703,23 @@ requires ExistsTxnSenderAccount(__m, __txn);
     __m := UpdateLocal(__m, __frame + 7, __tmp);
 
     __ret0 := GetLocal(__m, __frame + 6);
+    debug#LibraCoin#split#3#__ret := debug#LibraCoin#split#3#__ret[Position(3259) := __ret0];
     __ret1 := GetLocal(__m, __frame + 7);
+    debug#LibraCoin#split#4#__ret := debug#LibraCoin#split#4#__ret[Position(3259) := __ret1];
     return;
 
 Label_Abort:
     __abort_flag := true;
     __m := __saved_m;
     __ret0 := DefaultValue;
+    debug#LibraCoin#split#3#__ret := debug#LibraCoin#split#3#__ret[Position(3295) := __ret0];
     __ret1 := DefaultValue;
+    debug#LibraCoin#split#4#__ret := debug#LibraCoin#split#4#__ret[Position(3295) := __ret1];
 }
 
 procedure LibraCoin_split_verify (coin: Value, amount: Value) returns (__ret0: Value, __ret1: Value)
 {
-    assume ExistsTxnSenderAccount(__m, __txn);
+    call InitVerification();
     call __ret0, __ret1 := LibraCoin_split(coin, amount);
 }
 
@@ -1570,18 +1746,28 @@ requires ExistsTxnSenderAccount(__m, __txn);
     var __tmp: Value;
     var __frame: int;
     var __saved_m: Memory;
+    var debug#LibraCoin#withdraw#0#coin_ref: [Position]Value;
+    var debug#LibraCoin#withdraw#1#amount: [Position]Value;
+    var debug#LibraCoin#withdraw#2#value: [Position]Value;
+    var debug#LibraCoin#withdraw#3#__ret: [Position]Value;
 
     // initialize function execution
     assume !__abort_flag;
     __saved_m := __m;
     __frame := __local_counter;
     __local_counter := __local_counter + 18;
+    debug#LibraCoin#withdraw#0#coin_ref := EmptyPositionMap;
+    debug#LibraCoin#withdraw#1#amount := EmptyPositionMap;
+    debug#LibraCoin#withdraw#2#value := EmptyPositionMap;
+    debug#LibraCoin#withdraw#3#__ret := EmptyPositionMap;
 
     // process and type check arguments
     assume is#Vector(Dereference(__m, coin_ref));
     assume IsValidReferenceParameter(__m, __frame, coin_ref);
+    debug#LibraCoin#withdraw#0#coin_ref := debug#LibraCoin#withdraw#0#coin_ref[Position(3557) := Dereference(__m, coin_ref)];
     assume IsValidU64(amount);
     __m := UpdateLocal(__m, __frame + 1, amount);
+    debug#LibraCoin#withdraw#1#amount := debug#LibraCoin#withdraw#1#amount[Position(3557) := amount];
 
     // bytecode translation starts here
     call __t3 := CopyOrMoveRef(coin_ref);
@@ -1594,6 +1780,7 @@ requires ExistsTxnSenderAccount(__m, __txn);
 
     call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 5));
     __m := UpdateLocal(__m, __frame + 2, __tmp);
+    debug#LibraCoin#withdraw#2#value := debug#LibraCoin#withdraw#2#value[Position(3713) := __tmp];
 
     call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 2));
     __m := UpdateLocal(__m, __frame + 6, __tmp);
@@ -1639,17 +1826,19 @@ Label_11:
     __m := UpdateLocal(__m, __frame + 17, __tmp);
 
     __ret0 := GetLocal(__m, __frame + 17);
+    debug#LibraCoin#withdraw#3#__ret := debug#LibraCoin#withdraw#3#__ret[Position(3902) := __ret0];
     return;
 
 Label_Abort:
     __abort_flag := true;
     __m := __saved_m;
     __ret0 := DefaultValue;
+    debug#LibraCoin#withdraw#3#__ret := debug#LibraCoin#withdraw#3#__ret[Position(3937) := __ret0];
 }
 
 procedure LibraCoin_withdraw_verify (coin_ref: Reference, amount: Value) returns (__ret0: Value)
 {
-    assume ExistsTxnSenderAccount(__m, __txn);
+    call InitVerification();
     call __ret0 := LibraCoin_withdraw(coin_ref, amount);
 }
 
@@ -1663,18 +1852,26 @@ requires ExistsTxnSenderAccount(__m, __txn);
     var __tmp: Value;
     var __frame: int;
     var __saved_m: Memory;
+    var debug#LibraCoin#join#0#coin1: [Position]Value;
+    var debug#LibraCoin#join#1#coin2: [Position]Value;
+    var debug#LibraCoin#join#2#__ret: [Position]Value;
 
     // initialize function execution
     assume !__abort_flag;
     __saved_m := __m;
     __frame := __local_counter;
     __local_counter := __local_counter + 5;
+    debug#LibraCoin#join#0#coin1 := EmptyPositionMap;
+    debug#LibraCoin#join#1#coin2 := EmptyPositionMap;
+    debug#LibraCoin#join#2#__ret := EmptyPositionMap;
 
     // process and type check arguments
     assume is#Vector(coin1);
     __m := UpdateLocal(__m, __frame + 0, coin1);
+    debug#LibraCoin#join#0#coin1 := debug#LibraCoin#join#0#coin1[Position(4041) := coin1];
     assume is#Vector(coin2);
     __m := UpdateLocal(__m, __frame + 1, coin2);
+    debug#LibraCoin#join#1#coin2 := debug#LibraCoin#join#1#coin2[Position(4041) := coin2];
 
     // bytecode translation starts here
     call __t2 := BorrowLoc(__frame + 0);
@@ -1684,22 +1881,25 @@ requires ExistsTxnSenderAccount(__m, __txn);
 
     call LibraCoin_deposit(__t2, GetLocal(__m, __frame + 3));
     if (__abort_flag) { goto Label_Abort; }
+    debug#LibraCoin#join#0#coin1 := debug#LibraCoin#join#0#coin1[Position(4102) := GetLocal(__m, __frame + 0)];
 
     call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 0));
     __m := UpdateLocal(__m, __frame + 4, __tmp);
 
     __ret0 := GetLocal(__m, __frame + 4);
+    debug#LibraCoin#join#2#__ret := debug#LibraCoin#join#2#__ret[Position(4149) := __ret0];
     return;
 
 Label_Abort:
     __abort_flag := true;
     __m := __saved_m;
     __ret0 := DefaultValue;
+    debug#LibraCoin#join#2#__ret := debug#LibraCoin#join#2#__ret[Position(4173) := __ret0];
 }
 
 procedure LibraCoin_join_verify (coin1: Value, coin2: Value) returns (__ret0: Value)
 {
-    assume ExistsTxnSenderAccount(__m, __txn);
+    call InitVerification();
     call __ret0 := LibraCoin_join(coin1, coin2);
 }
 
@@ -1722,18 +1922,28 @@ requires ExistsTxnSenderAccount(__m, __txn);
     var __tmp: Value;
     var __frame: int;
     var __saved_m: Memory;
+    var debug#LibraCoin#deposit#0#coin_ref: [Position]Value;
+    var debug#LibraCoin#deposit#1#check: [Position]Value;
+    var debug#LibraCoin#deposit#2#value: [Position]Value;
+    var debug#LibraCoin#deposit#3#check_value: [Position]Value;
 
     // initialize function execution
     assume !__abort_flag;
     __saved_m := __m;
     __frame := __local_counter;
     __local_counter := __local_counter + 14;
+    debug#LibraCoin#deposit#0#coin_ref := EmptyPositionMap;
+    debug#LibraCoin#deposit#1#check := EmptyPositionMap;
+    debug#LibraCoin#deposit#2#value := EmptyPositionMap;
+    debug#LibraCoin#deposit#3#check_value := EmptyPositionMap;
 
     // process and type check arguments
     assume is#Vector(Dereference(__m, coin_ref));
     assume IsValidReferenceParameter(__m, __frame, coin_ref);
+    debug#LibraCoin#deposit#0#coin_ref := debug#LibraCoin#deposit#0#coin_ref[Position(4352) := Dereference(__m, coin_ref)];
     assume is#Vector(check);
     __m := UpdateLocal(__m, __frame + 1, check);
+    debug#LibraCoin#deposit#1#check := debug#LibraCoin#deposit#1#check[Position(4352) := check];
 
     // bytecode translation starts here
     call __t4 := CopyOrMoveRef(coin_ref);
@@ -1746,6 +1956,7 @@ requires ExistsTxnSenderAccount(__m, __txn);
 
     call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 6));
     __m := UpdateLocal(__m, __frame + 2, __tmp);
+    debug#LibraCoin#deposit#2#value := debug#LibraCoin#deposit#2#value[Position(4470) := __tmp];
 
     call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 1));
     __m := UpdateLocal(__m, __frame + 7, __tmp);
@@ -1755,6 +1966,7 @@ requires ExistsTxnSenderAccount(__m, __txn);
 
     call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 8));
     __m := UpdateLocal(__m, __frame + 3, __tmp);
+    debug#LibraCoin#deposit#3#check_value := debug#LibraCoin#deposit#3#check_value[Position(4520) := __tmp];
 
     call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 2));
     __m := UpdateLocal(__m, __frame + 9, __tmp);
@@ -1781,7 +1993,7 @@ Label_Abort:
 
 procedure LibraCoin_deposit_verify (coin_ref: Reference, check: Value) returns ()
 {
-    assume ExistsTxnSenderAccount(__m, __txn);
+    call InitVerification();
     call LibraCoin_deposit(coin_ref, check);
 }
 
@@ -1800,16 +2012,21 @@ requires ExistsTxnSenderAccount(__m, __txn);
     var __tmp: Value;
     var __frame: int;
     var __saved_m: Memory;
+    var debug#LibraCoin#destroy_zero#0#coin: [Position]Value;
+    var debug#LibraCoin#destroy_zero#1#value: [Position]Value;
 
     // initialize function execution
     assume !__abort_flag;
     __saved_m := __m;
     __frame := __local_counter;
     __local_counter := __local_counter + 9;
+    debug#LibraCoin#destroy_zero#0#coin := EmptyPositionMap;
+    debug#LibraCoin#destroy_zero#1#value := EmptyPositionMap;
 
     // process and type check arguments
     assume is#Vector(coin);
     __m := UpdateLocal(__m, __frame + 0, coin);
+    debug#LibraCoin#destroy_zero#0#coin := debug#LibraCoin#destroy_zero#0#coin[Position(4858) := coin];
 
     // bytecode translation starts here
     call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 0));
@@ -1820,6 +2037,7 @@ requires ExistsTxnSenderAccount(__m, __txn);
 
     call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 3));
     __m := UpdateLocal(__m, __frame + 1, __tmp);
+    debug#LibraCoin#destroy_zero#1#value := debug#LibraCoin#destroy_zero#1#value[Position(4930) := __tmp];
 
     call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 1));
     __m := UpdateLocal(__m, __frame + 4, __tmp);
@@ -1851,7 +2069,7 @@ Label_Abort:
 
 procedure LibraCoin_destroy_zero_verify (coin: Value) returns ()
 {
-    assume ExistsTxnSenderAccount(__m, __txn);
+    call InitVerification();
     call LibraCoin_destroy_zero(coin);
 }
 
@@ -1898,12 +2116,14 @@ requires ExistsTxnSenderAccount(__m, __txn);
     var __tmp: Value;
     var __frame: int;
     var __saved_m: Memory;
+    var debug#LibraTimestamp#initialize_timer#0#timer: [Position]Value;
 
     // initialize function execution
     assume !__abort_flag;
     __saved_m := __m;
     __frame := __local_counter;
     __local_counter := __local_counter + 9;
+    debug#LibraTimestamp#initialize_timer#0#timer := EmptyPositionMap;
 
     // process and type check arguments
 
@@ -1937,6 +2157,7 @@ Label_7:
 
     call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 7));
     __m := UpdateLocal(__m, __frame + 0, __tmp);
+    debug#LibraTimestamp#initialize_timer#0#timer := debug#LibraTimestamp#initialize_timer#0#timer[Position(490) := __tmp];
 
     call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 0));
     __m := UpdateLocal(__m, __frame + 8, __tmp);
@@ -1953,7 +2174,7 @@ Label_Abort:
 
 procedure LibraTimestamp_initialize_timer_verify () returns ()
 {
-    assume ExistsTxnSenderAccount(__m, __txn);
+    call InitVerification();
     call LibraTimestamp_initialize_timer();
 }
 
@@ -1987,18 +2208,26 @@ requires ExistsTxnSenderAccount(__m, __txn);
     var __tmp: Value;
     var __frame: int;
     var __saved_m: Memory;
+    var debug#LibraTimestamp#update_global_time#0#proposer: [Position]Value;
+    var debug#LibraTimestamp#update_global_time#1#timestamp: [Position]Value;
+    var debug#LibraTimestamp#update_global_time#2#global_timer: [Position]Value;
 
     // initialize function execution
     assume !__abort_flag;
     __saved_m := __m;
     __frame := __local_counter;
     __local_counter := __local_counter + 25;
+    debug#LibraTimestamp#update_global_time#0#proposer := EmptyPositionMap;
+    debug#LibraTimestamp#update_global_time#1#timestamp := EmptyPositionMap;
+    debug#LibraTimestamp#update_global_time#2#global_timer := EmptyPositionMap;
 
     // process and type check arguments
     assume is#Address(proposer);
     __m := UpdateLocal(__m, __frame + 0, proposer);
+    debug#LibraTimestamp#update_global_time#0#proposer := debug#LibraTimestamp#update_global_time#0#proposer[Position(743) := proposer];
     assume IsValidU64(timestamp);
     __m := UpdateLocal(__m, __frame + 1, timestamp);
+    debug#LibraTimestamp#update_global_time#1#timestamp := debug#LibraTimestamp#update_global_time#1#timestamp[Position(743) := timestamp];
 
     // bytecode translation starts here
     call __tmp := LdAddr(173345816);
@@ -2094,7 +2323,7 @@ Label_Abort:
 
 procedure LibraTimestamp_update_global_time_verify (proposer: Value, timestamp: Value) returns ()
 {
-    assume ExistsTxnSenderAccount(__m, __txn);
+    call InitVerification();
     call LibraTimestamp_update_global_time(proposer, timestamp);
 }
 
@@ -2109,12 +2338,14 @@ requires ExistsTxnSenderAccount(__m, __txn);
     var __tmp: Value;
     var __frame: int;
     var __saved_m: Memory;
+    var debug#LibraTimestamp#now_microseconds#0#__ret: [Position]Value;
 
     // initialize function execution
     assume !__abort_flag;
     __saved_m := __m;
     __frame := __local_counter;
     __local_counter := __local_counter + 4;
+    debug#LibraTimestamp#now_microseconds#0#__ret := EmptyPositionMap;
 
     // process and type check arguments
 
@@ -2132,17 +2363,19 @@ requires ExistsTxnSenderAccount(__m, __txn);
     __m := UpdateLocal(__m, __frame + 3, __tmp);
 
     __ret0 := GetLocal(__m, __frame + 3);
+    debug#LibraTimestamp#now_microseconds#0#__ret := debug#LibraTimestamp#now_microseconds#0#__ret[Position(1736) := __ret0];
     return;
 
 Label_Abort:
     __abort_flag := true;
     __m := __saved_m;
     __ret0 := DefaultValue;
+    debug#LibraTimestamp#now_microseconds#0#__ret := debug#LibraTimestamp#now_microseconds#0#__ret[Position(1815) := __ret0];
 }
 
 procedure LibraTimestamp_now_microseconds_verify () returns (__ret0: Value)
 {
-    assume ExistsTxnSenderAccount(__m, __txn);
+    call InitVerification();
     call __ret0 := LibraTimestamp_now_microseconds();
 }
 
@@ -2189,12 +2422,14 @@ requires ExistsTxnSenderAccount(__m, __txn);
     var __tmp: Value;
     var __frame: int;
     var __saved_m: Memory;
+    var debug#LibraTransactionTimeout#initialize#0#timeout: [Position]Value;
 
     // initialize function execution
     assume !__abort_flag;
     __saved_m := __m;
     __frame := __local_counter;
     __local_counter := __local_counter + 9;
+    debug#LibraTransactionTimeout#initialize#0#timeout := EmptyPositionMap;
 
     // process and type check arguments
 
@@ -2228,6 +2463,7 @@ Label_7:
 
     call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 7));
     __m := UpdateLocal(__m, __frame + 0, __tmp);
+    debug#LibraTransactionTimeout#initialize#0#timeout := debug#LibraTransactionTimeout#initialize#0#timeout[Position(441) := __tmp];
 
     call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 0));
     __m := UpdateLocal(__m, __frame + 8, __tmp);
@@ -2244,7 +2480,7 @@ Label_Abort:
 
 procedure LibraTransactionTimeout_initialize_verify () returns ()
 {
-    assume ExistsTxnSenderAccount(__m, __txn);
+    call InitVerification();
     call LibraTransactionTimeout_initialize();
 }
 
@@ -2266,16 +2502,21 @@ requires ExistsTxnSenderAccount(__m, __txn);
     var __tmp: Value;
     var __frame: int;
     var __saved_m: Memory;
+    var debug#LibraTransactionTimeout#set_timeout#0#new_duration: [Position]Value;
+    var debug#LibraTransactionTimeout#set_timeout#1#timeout: [Position]Value;
 
     // initialize function execution
     assume !__abort_flag;
     __saved_m := __m;
     __frame := __local_counter;
     __local_counter := __local_counter + 12;
+    debug#LibraTransactionTimeout#set_timeout#0#new_duration := EmptyPositionMap;
+    debug#LibraTransactionTimeout#set_timeout#1#timeout := EmptyPositionMap;
 
     // process and type check arguments
     assume IsValidU64(new_duration);
     __m := UpdateLocal(__m, __frame + 0, new_duration);
+    debug#LibraTransactionTimeout#set_timeout#0#new_duration := debug#LibraTransactionTimeout#set_timeout#0#new_duration[Position(564) := new_duration];
 
     // bytecode translation starts here
     call __tmp := GetTxnSenderAddress();
@@ -2325,7 +2566,7 @@ Label_Abort:
 
 procedure LibraTransactionTimeout_set_timeout_verify (new_duration: Value) returns ()
 {
-    assume ExistsTxnSenderAccount(__m, __txn);
+    call InitVerification();
     call LibraTransactionTimeout_set_timeout(new_duration);
 }
 
@@ -2358,16 +2599,29 @@ requires ExistsTxnSenderAccount(__m, __txn);
     var __tmp: Value;
     var __frame: int;
     var __saved_m: Memory;
+    var debug#LibraTransactionTimeout#is_valid_transaction_timestamp#0#timestamp: [Position]Value;
+    var debug#LibraTransactionTimeout#is_valid_transaction_timestamp#1#current_block_time: [Position]Value;
+    var debug#LibraTransactionTimeout#is_valid_transaction_timestamp#2#max_txn_time: [Position]Value;
+    var debug#LibraTransactionTimeout#is_valid_transaction_timestamp#3#timeout: [Position]Value;
+    var debug#LibraTransactionTimeout#is_valid_transaction_timestamp#4#txn_time_microseconds: [Position]Value;
+    var debug#LibraTransactionTimeout#is_valid_transaction_timestamp#5#__ret: [Position]Value;
 
     // initialize function execution
     assume !__abort_flag;
     __saved_m := __m;
     __frame := __local_counter;
     __local_counter := __local_counter + 23;
+    debug#LibraTransactionTimeout#is_valid_transaction_timestamp#0#timestamp := EmptyPositionMap;
+    debug#LibraTransactionTimeout#is_valid_transaction_timestamp#1#current_block_time := EmptyPositionMap;
+    debug#LibraTransactionTimeout#is_valid_transaction_timestamp#2#max_txn_time := EmptyPositionMap;
+    debug#LibraTransactionTimeout#is_valid_transaction_timestamp#3#timeout := EmptyPositionMap;
+    debug#LibraTransactionTimeout#is_valid_transaction_timestamp#4#txn_time_microseconds := EmptyPositionMap;
+    debug#LibraTransactionTimeout#is_valid_transaction_timestamp#5#__ret := EmptyPositionMap;
 
     // process and type check arguments
     assume IsValidU64(timestamp);
     __m := UpdateLocal(__m, __frame + 0, timestamp);
+    debug#LibraTransactionTimeout#is_valid_transaction_timestamp#0#timestamp := debug#LibraTransactionTimeout#is_valid_transaction_timestamp#0#timestamp[Position(911) := timestamp];
 
     // bytecode translation starts here
     call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 0));
@@ -2386,6 +2640,7 @@ requires ExistsTxnSenderAccount(__m, __txn);
     __m := UpdateLocal(__m, __frame + 8, __tmp);
 
     __ret0 := GetLocal(__m, __frame + 8);
+    debug#LibraTransactionTimeout#is_valid_transaction_timestamp#5#__ret := debug#LibraTransactionTimeout#is_valid_transaction_timestamp#5#__ret[Position(1242) := __ret0];
     return;
 
 Label_6:
@@ -2397,6 +2652,7 @@ Label_6:
 
     call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 9));
     __m := UpdateLocal(__m, __frame + 1, __tmp);
+    debug#LibraTransactionTimeout#is_valid_transaction_timestamp#1#current_block_time := debug#LibraTransactionTimeout#is_valid_transaction_timestamp#1#current_block_time[Position(1275) := __tmp];
 
     call __tmp := LdAddr(173345816);
     __m := UpdateLocal(__m, __frame + 10, __tmp);
@@ -2412,6 +2668,7 @@ Label_6:
 
     call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 13));
     __m := UpdateLocal(__m, __frame + 3, __tmp);
+    debug#LibraTransactionTimeout#is_valid_transaction_timestamp#3#timeout := debug#LibraTransactionTimeout#is_valid_transaction_timestamp#3#timeout[Position(1339) := __tmp];
 
     call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 1));
     __m := UpdateLocal(__m, __frame + 14, __tmp);
@@ -2425,6 +2682,7 @@ Label_6:
 
     call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 16));
     __m := UpdateLocal(__m, __frame + 2, __tmp);
+    debug#LibraTransactionTimeout#is_valid_transaction_timestamp#2#max_txn_time := debug#LibraTransactionTimeout#is_valid_transaction_timestamp#2#max_txn_time[Position(1412) := __tmp];
 
     call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 0));
     __m := UpdateLocal(__m, __frame + 17, __tmp);
@@ -2438,6 +2696,7 @@ Label_6:
 
     call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 19));
     __m := UpdateLocal(__m, __frame + 4, __tmp);
+    debug#LibraTransactionTimeout#is_valid_transaction_timestamp#4#txn_time_microseconds := debug#LibraTransactionTimeout#is_valid_transaction_timestamp#4#txn_time_microseconds[Position(1478) := __tmp];
 
     call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 1));
     __m := UpdateLocal(__m, __frame + 20, __tmp);
@@ -2449,17 +2708,19 @@ Label_6:
     __m := UpdateLocal(__m, __frame + 22, __tmp);
 
     __ret0 := GetLocal(__m, __frame + 22);
+    debug#LibraTransactionTimeout#is_valid_transaction_timestamp#5#__ret := debug#LibraTransactionTimeout#is_valid_transaction_timestamp#5#__ret[Position(1893) := __ret0];
     return;
 
 Label_Abort:
     __abort_flag := true;
     __m := __saved_m;
     __ret0 := DefaultValue;
+    debug#LibraTransactionTimeout#is_valid_transaction_timestamp#5#__ret := debug#LibraTransactionTimeout#is_valid_transaction_timestamp#5#__ret[Position(1960) := __ret0];
 }
 
 procedure LibraTransactionTimeout_is_valid_transaction_timestamp_verify (timestamp: Value) returns (__ret0: Value)
 {
-    assume ExistsTxnSenderAccount(__m, __txn);
+    call InitVerification();
     call __ret0 := LibraTransactionTimeout_is_valid_transaction_timestamp(timestamp);
 }
 
@@ -2672,18 +2933,24 @@ requires ExistsTxnSenderAccount(__m, __txn);
     var __tmp: Value;
     var __frame: int;
     var __saved_m: Memory;
+    var debug#LibraAccount#deposit#0#payee: [Position]Value;
+    var debug#LibraAccount#deposit#1#to_deposit: [Position]Value;
 
     // initialize function execution
     assume !__abort_flag;
     __saved_m := __m;
     __frame := __local_counter;
     __local_counter := __local_counter + 5;
+    debug#LibraAccount#deposit#0#payee := EmptyPositionMap;
+    debug#LibraAccount#deposit#1#to_deposit := EmptyPositionMap;
 
     // process and type check arguments
     assume is#Address(payee);
     __m := UpdateLocal(__m, __frame + 0, payee);
+    debug#LibraAccount#deposit#0#payee := debug#LibraAccount#deposit#0#payee[Position(3305) := payee];
     assume is#Vector(to_deposit);
     __m := UpdateLocal(__m, __frame + 1, to_deposit);
+    debug#LibraAccount#deposit#1#to_deposit := debug#LibraAccount#deposit#1#to_deposit[Position(3305) := to_deposit];
 
     // bytecode translation starts here
     call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 0));
@@ -2706,7 +2973,7 @@ Label_Abort:
 
 procedure LibraAccount_deposit_verify (payee: Value, to_deposit: Value) returns ()
 {
-    assume ExistsTxnSenderAccount(__m, __txn);
+    call InitVerification();
     call LibraAccount_deposit(payee, to_deposit);
 }
 
@@ -2721,20 +2988,29 @@ requires ExistsTxnSenderAccount(__m, __txn);
     var __tmp: Value;
     var __frame: int;
     var __saved_m: Memory;
+    var debug#LibraAccount#deposit_with_metadata#0#payee: [Position]Value;
+    var debug#LibraAccount#deposit_with_metadata#1#to_deposit: [Position]Value;
+    var debug#LibraAccount#deposit_with_metadata#2#metadata: [Position]Value;
 
     // initialize function execution
     assume !__abort_flag;
     __saved_m := __m;
     __frame := __local_counter;
     __local_counter := __local_counter + 7;
+    debug#LibraAccount#deposit_with_metadata#0#payee := EmptyPositionMap;
+    debug#LibraAccount#deposit_with_metadata#1#to_deposit := EmptyPositionMap;
+    debug#LibraAccount#deposit_with_metadata#2#metadata := EmptyPositionMap;
 
     // process and type check arguments
     assume is#Address(payee);
     __m := UpdateLocal(__m, __frame + 0, payee);
+    debug#LibraAccount#deposit_with_metadata#0#payee := debug#LibraAccount#deposit_with_metadata#0#payee[Position(3567) := payee];
     assume is#Vector(to_deposit);
     __m := UpdateLocal(__m, __frame + 1, to_deposit);
+    debug#LibraAccount#deposit_with_metadata#1#to_deposit := debug#LibraAccount#deposit_with_metadata#1#to_deposit[Position(3567) := to_deposit];
     assume is#ByteArray(metadata);
     __m := UpdateLocal(__m, __frame + 2, metadata);
+    debug#LibraAccount#deposit_with_metadata#2#metadata := debug#LibraAccount#deposit_with_metadata#2#metadata[Position(3567) := metadata];
 
     // bytecode translation starts here
     call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 0));
@@ -2761,7 +3037,7 @@ Label_Abort:
 
 procedure LibraAccount_deposit_with_metadata_verify (payee: Value, to_deposit: Value, metadata: Value) returns ()
 {
-    assume ExistsTxnSenderAccount(__m, __txn);
+    call InitVerification();
     call LibraAccount_deposit_with_metadata(payee, to_deposit, metadata);
 }
 
@@ -2801,22 +3077,40 @@ requires ExistsTxnSenderAccount(__m, __txn);
     var __tmp: Value;
     var __frame: int;
     var __saved_m: Memory;
+    var debug#LibraAccount#deposit_with_sender_and_metadata#0#payee: [Position]Value;
+    var debug#LibraAccount#deposit_with_sender_and_metadata#1#sender: [Position]Value;
+    var debug#LibraAccount#deposit_with_sender_and_metadata#2#to_deposit: [Position]Value;
+    var debug#LibraAccount#deposit_with_sender_and_metadata#3#metadata: [Position]Value;
+    var debug#LibraAccount#deposit_with_sender_and_metadata#4#deposit_value: [Position]Value;
+    var debug#LibraAccount#deposit_with_sender_and_metadata#5#payee_account_ref: [Position]Value;
+    var debug#LibraAccount#deposit_with_sender_and_metadata#6#sender_account_ref: [Position]Value;
 
     // initialize function execution
     assume !__abort_flag;
     __saved_m := __m;
     __frame := __local_counter;
     __local_counter := __local_counter + 33;
+    debug#LibraAccount#deposit_with_sender_and_metadata#0#payee := EmptyPositionMap;
+    debug#LibraAccount#deposit_with_sender_and_metadata#1#sender := EmptyPositionMap;
+    debug#LibraAccount#deposit_with_sender_and_metadata#2#to_deposit := EmptyPositionMap;
+    debug#LibraAccount#deposit_with_sender_and_metadata#3#metadata := EmptyPositionMap;
+    debug#LibraAccount#deposit_with_sender_and_metadata#4#deposit_value := EmptyPositionMap;
+    debug#LibraAccount#deposit_with_sender_and_metadata#5#payee_account_ref := EmptyPositionMap;
+    debug#LibraAccount#deposit_with_sender_and_metadata#6#sender_account_ref := EmptyPositionMap;
 
     // process and type check arguments
     assume is#Address(payee);
     __m := UpdateLocal(__m, __frame + 0, payee);
+    debug#LibraAccount#deposit_with_sender_and_metadata#0#payee := debug#LibraAccount#deposit_with_sender_and_metadata#0#payee[Position(4018) := payee];
     assume is#Address(sender);
     __m := UpdateLocal(__m, __frame + 1, sender);
+    debug#LibraAccount#deposit_with_sender_and_metadata#1#sender := debug#LibraAccount#deposit_with_sender_and_metadata#1#sender[Position(4018) := sender];
     assume is#Vector(to_deposit);
     __m := UpdateLocal(__m, __frame + 2, to_deposit);
+    debug#LibraAccount#deposit_with_sender_and_metadata#2#to_deposit := debug#LibraAccount#deposit_with_sender_and_metadata#2#to_deposit[Position(4018) := to_deposit];
     assume is#ByteArray(metadata);
     __m := UpdateLocal(__m, __frame + 3, metadata);
+    debug#LibraAccount#deposit_with_sender_and_metadata#3#metadata := debug#LibraAccount#deposit_with_sender_and_metadata#3#metadata[Position(4018) := metadata];
 
     // bytecode translation starts here
     call __t7 := BorrowLoc(__frame + 2);
@@ -2829,6 +3123,7 @@ requires ExistsTxnSenderAccount(__m, __txn);
 
     call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 8));
     __m := UpdateLocal(__m, __frame + 4, __tmp);
+    debug#LibraAccount#deposit_with_sender_and_metadata#4#deposit_value := debug#LibraAccount#deposit_with_sender_and_metadata#4#deposit_value[Position(4367) := __tmp];
 
     call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 4));
     __m := UpdateLocal(__m, __frame + 9, __tmp);
@@ -2924,7 +3219,7 @@ Label_Abort:
 
 procedure LibraAccount_deposit_with_sender_and_metadata_verify (payee: Value, sender: Value, to_deposit: Value, metadata: Value) returns ()
 {
-    assume ExistsTxnSenderAccount(__m, __txn);
+    call InitVerification();
     call LibraAccount_deposit_with_sender_and_metadata(payee, sender, to_deposit, metadata);
 }
 
@@ -2942,18 +3237,24 @@ requires ExistsTxnSenderAccount(__m, __txn);
     var __tmp: Value;
     var __frame: int;
     var __saved_m: Memory;
+    var debug#LibraAccount#mint_to_address#0#payee: [Position]Value;
+    var debug#LibraAccount#mint_to_address#1#amount: [Position]Value;
 
     // initialize function execution
     assume !__abort_flag;
     __saved_m := __m;
     __frame := __local_counter;
     __local_counter := __local_counter + 9;
+    debug#LibraAccount#mint_to_address#0#payee := EmptyPositionMap;
+    debug#LibraAccount#mint_to_address#1#amount := EmptyPositionMap;
 
     // process and type check arguments
     assume is#Address(payee);
     __m := UpdateLocal(__m, __frame + 0, payee);
+    debug#LibraAccount#mint_to_address#0#payee := debug#LibraAccount#mint_to_address#0#payee[Position(5776) := payee];
     assume IsValidU64(amount);
     __m := UpdateLocal(__m, __frame + 1, amount);
+    debug#LibraAccount#mint_to_address#1#amount := debug#LibraAccount#mint_to_address#1#amount[Position(5776) := amount];
 
     // bytecode translation starts here
     call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 0));
@@ -2999,7 +3300,7 @@ Label_Abort:
 
 procedure LibraAccount_mint_to_address_verify (payee: Value, amount: Value) returns ()
 {
-    assume ExistsTxnSenderAccount(__m, __txn);
+    call InitVerification();
     call LibraAccount_mint_to_address(payee, amount);
 }
 
@@ -3016,18 +3317,28 @@ requires ExistsTxnSenderAccount(__m, __txn);
     var __tmp: Value;
     var __frame: int;
     var __saved_m: Memory;
+    var debug#LibraAccount#withdraw_from_account#0#account: [Position]Value;
+    var debug#LibraAccount#withdraw_from_account#1#amount: [Position]Value;
+    var debug#LibraAccount#withdraw_from_account#2#to_withdraw: [Position]Value;
+    var debug#LibraAccount#withdraw_from_account#3#__ret: [Position]Value;
 
     // initialize function execution
     assume !__abort_flag;
     __saved_m := __m;
     __frame := __local_counter;
     __local_counter := __local_counter + 8;
+    debug#LibraAccount#withdraw_from_account#0#account := EmptyPositionMap;
+    debug#LibraAccount#withdraw_from_account#1#amount := EmptyPositionMap;
+    debug#LibraAccount#withdraw_from_account#2#to_withdraw := EmptyPositionMap;
+    debug#LibraAccount#withdraw_from_account#3#__ret := EmptyPositionMap;
 
     // process and type check arguments
     assume is#Vector(Dereference(__m, account));
     assume IsValidReferenceParameter(__m, __frame, account);
+    debug#LibraAccount#withdraw_from_account#0#account := debug#LibraAccount#withdraw_from_account#0#account[Position(6237) := Dereference(__m, account)];
     assume IsValidU64(amount);
     __m := UpdateLocal(__m, __frame + 1, amount);
+    debug#LibraAccount#withdraw_from_account#1#amount := debug#LibraAccount#withdraw_from_account#1#amount[Position(6237) := amount];
 
     // bytecode translation starts here
     call __t3 := CopyOrMoveRef(account);
@@ -3045,22 +3356,25 @@ requires ExistsTxnSenderAccount(__m, __txn);
 
     call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 6));
     __m := UpdateLocal(__m, __frame + 2, __tmp);
+    debug#LibraAccount#withdraw_from_account#2#to_withdraw := debug#LibraAccount#withdraw_from_account#2#to_withdraw[Position(6356) := __tmp];
 
     call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 2));
     __m := UpdateLocal(__m, __frame + 7, __tmp);
 
     __ret0 := GetLocal(__m, __frame + 7);
+    debug#LibraAccount#withdraw_from_account#3#__ret := debug#LibraAccount#withdraw_from_account#3#__ret[Position(6440) := __ret0];
     return;
 
 Label_Abort:
     __abort_flag := true;
     __m := __saved_m;
     __ret0 := DefaultValue;
+    debug#LibraAccount#withdraw_from_account#3#__ret := debug#LibraAccount#withdraw_from_account#3#__ret[Position(6470) := __ret0];
 }
 
 procedure LibraAccount_withdraw_from_account_verify (account: Reference, amount: Value) returns (__ret0: Value)
 {
-    assume ExistsTxnSenderAccount(__m, __txn);
+    call InitVerification();
     call __ret0 := LibraAccount_withdraw_from_account(account, amount);
 }
 
@@ -3081,16 +3395,23 @@ requires ExistsTxnSenderAccount(__m, __txn);
     var __tmp: Value;
     var __frame: int;
     var __saved_m: Memory;
+    var debug#LibraAccount#withdraw_from_sender#0#amount: [Position]Value;
+    var debug#LibraAccount#withdraw_from_sender#1#sender_account: [Position]Value;
+    var debug#LibraAccount#withdraw_from_sender#2#__ret: [Position]Value;
 
     // initialize function execution
     assume !__abort_flag;
     __saved_m := __m;
     __frame := __local_counter;
     __local_counter := __local_counter + 11;
+    debug#LibraAccount#withdraw_from_sender#0#amount := EmptyPositionMap;
+    debug#LibraAccount#withdraw_from_sender#1#sender_account := EmptyPositionMap;
+    debug#LibraAccount#withdraw_from_sender#2#__ret := EmptyPositionMap;
 
     // process and type check arguments
     assume IsValidU64(amount);
     __m := UpdateLocal(__m, __frame + 0, amount);
+    debug#LibraAccount#withdraw_from_sender#0#amount := debug#LibraAccount#withdraw_from_sender#0#amount[Position(6552) := amount];
 
     // bytecode translation starts here
     call __tmp := GetTxnSenderAddress();
@@ -3130,17 +3451,19 @@ Label_9:
     __m := UpdateLocal(__m, __frame + 10, __t10);
 
     __ret0 := GetLocal(__m, __frame + 10);
+    debug#LibraAccount#withdraw_from_sender#2#__ret := debug#LibraAccount#withdraw_from_sender#2#__ret[Position(7024) := __ret0];
     return;
 
 Label_Abort:
     __abort_flag := true;
     __m := __saved_m;
     __ret0 := DefaultValue;
+    debug#LibraAccount#withdraw_from_sender#2#__ret := debug#LibraAccount#withdraw_from_sender#2#__ret[Position(7109) := __ret0];
 }
 
 procedure LibraAccount_withdraw_from_sender_verify (amount: Value) returns (__ret0: Value)
 {
-    assume ExistsTxnSenderAccount(__m, __txn);
+    call InitVerification();
     call __ret0 := LibraAccount_withdraw_from_sender(amount);
 }
 
@@ -3159,18 +3482,28 @@ requires ExistsTxnSenderAccount(__m, __txn);
     var __tmp: Value;
     var __frame: int;
     var __saved_m: Memory;
+    var debug#LibraAccount#withdraw_with_capability#0#cap: [Position]Value;
+    var debug#LibraAccount#withdraw_with_capability#1#amount: [Position]Value;
+    var debug#LibraAccount#withdraw_with_capability#2#account: [Position]Value;
+    var debug#LibraAccount#withdraw_with_capability#3#__ret: [Position]Value;
 
     // initialize function execution
     assume !__abort_flag;
     __saved_m := __m;
     __frame := __local_counter;
     __local_counter := __local_counter + 10;
+    debug#LibraAccount#withdraw_with_capability#0#cap := EmptyPositionMap;
+    debug#LibraAccount#withdraw_with_capability#1#amount := EmptyPositionMap;
+    debug#LibraAccount#withdraw_with_capability#2#account := EmptyPositionMap;
+    debug#LibraAccount#withdraw_with_capability#3#__ret := EmptyPositionMap;
 
     // process and type check arguments
     assume is#Vector(Dereference(__m, cap));
     assume IsValidReferenceParameter(__m, __frame, cap);
+    debug#LibraAccount#withdraw_with_capability#0#cap := debug#LibraAccount#withdraw_with_capability#0#cap[Position(7192) := Dereference(__m, cap)];
     assume IsValidU64(amount);
     __m := UpdateLocal(__m, __frame + 1, amount);
+    debug#LibraAccount#withdraw_with_capability#1#amount := debug#LibraAccount#withdraw_with_capability#1#amount[Position(7192) := amount];
 
     // bytecode translation starts here
     call __t3 := CopyOrMoveRef(cap);
@@ -3198,17 +3531,19 @@ requires ExistsTxnSenderAccount(__m, __txn);
     __m := UpdateLocal(__m, __frame + 9, __t9);
 
     __ret0 := GetLocal(__m, __frame + 9);
+    debug#LibraAccount#withdraw_with_capability#3#__ret := debug#LibraAccount#withdraw_with_capability#3#__ret[Position(7423) := __ret0];
     return;
 
 Label_Abort:
     __abort_flag := true;
     __m := __saved_m;
     __ret0 := DefaultValue;
+    debug#LibraAccount#withdraw_with_capability#3#__ret := debug#LibraAccount#withdraw_with_capability#3#__ret[Position(7491) := __ret0];
 }
 
 procedure LibraAccount_withdraw_with_capability_verify (cap: Reference, amount: Value) returns (__ret0: Value)
 {
-    assume ExistsTxnSenderAccount(__m, __txn);
+    call InitVerification();
     call __ret0 := LibraAccount_withdraw_with_capability(cap, amount);
 }
 
@@ -3234,12 +3569,20 @@ requires ExistsTxnSenderAccount(__m, __txn);
     var __tmp: Value;
     var __frame: int;
     var __saved_m: Memory;
+    var debug#LibraAccount#extract_sender_withdrawal_capability#0#sender: [Position]Value;
+    var debug#LibraAccount#extract_sender_withdrawal_capability#1#sender_account: [Position]Value;
+    var debug#LibraAccount#extract_sender_withdrawal_capability#2#delegated_ref: [Position]Value;
+    var debug#LibraAccount#extract_sender_withdrawal_capability#3#__ret: [Position]Value;
 
     // initialize function execution
     assume !__abort_flag;
     __saved_m := __m;
     __frame := __local_counter;
     __local_counter := __local_counter + 15;
+    debug#LibraAccount#extract_sender_withdrawal_capability#0#sender := EmptyPositionMap;
+    debug#LibraAccount#extract_sender_withdrawal_capability#1#sender_account := EmptyPositionMap;
+    debug#LibraAccount#extract_sender_withdrawal_capability#2#delegated_ref := EmptyPositionMap;
+    debug#LibraAccount#extract_sender_withdrawal_capability#3#__ret := EmptyPositionMap;
 
     // process and type check arguments
 
@@ -3249,6 +3592,7 @@ requires ExistsTxnSenderAccount(__m, __txn);
 
     call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 3));
     __m := UpdateLocal(__m, __frame + 0, __tmp);
+    debug#LibraAccount#extract_sender_withdrawal_capability#0#sender := debug#LibraAccount#extract_sender_withdrawal_capability#0#sender[Position(7802) := __tmp];
 
     call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 0));
     __m := UpdateLocal(__m, __frame + 4, __tmp);
@@ -3293,17 +3637,19 @@ Label_13:
     __m := UpdateLocal(__m, __frame + 14, __tmp);
 
     __ret0 := GetLocal(__m, __frame + 14);
+    debug#LibraAccount#extract_sender_withdrawal_capability#3#__ret := debug#LibraAccount#extract_sender_withdrawal_capability#3#__ret[Position(8228) := __ret0];
     return;
 
 Label_Abort:
     __abort_flag := true;
     __m := __saved_m;
     __ret0 := DefaultValue;
+    debug#LibraAccount#extract_sender_withdrawal_capability#3#__ret := debug#LibraAccount#extract_sender_withdrawal_capability#3#__ret[Position(8305) := __ret0];
 }
 
 procedure LibraAccount_extract_sender_withdrawal_capability_verify () returns (__ret0: Value)
 {
-    assume ExistsTxnSenderAccount(__m, __txn);
+    call InitVerification();
     call __ret0 := LibraAccount_extract_sender_withdrawal_capability();
 }
 
@@ -3323,16 +3669,23 @@ requires ExistsTxnSenderAccount(__m, __txn);
     var __tmp: Value;
     var __frame: int;
     var __saved_m: Memory;
+    var debug#LibraAccount#restore_withdrawal_capability#0#cap: [Position]Value;
+    var debug#LibraAccount#restore_withdrawal_capability#1#account_address: [Position]Value;
+    var debug#LibraAccount#restore_withdrawal_capability#2#account: [Position]Value;
 
     // initialize function execution
     assume !__abort_flag;
     __saved_m := __m;
     __frame := __local_counter;
     __local_counter := __local_counter + 10;
+    debug#LibraAccount#restore_withdrawal_capability#0#cap := EmptyPositionMap;
+    debug#LibraAccount#restore_withdrawal_capability#1#account_address := EmptyPositionMap;
+    debug#LibraAccount#restore_withdrawal_capability#2#account := EmptyPositionMap;
 
     // process and type check arguments
     assume is#Vector(cap);
     __m := UpdateLocal(__m, __frame + 0, cap);
+    debug#LibraAccount#restore_withdrawal_capability#0#cap := debug#LibraAccount#restore_withdrawal_capability#0#cap[Position(8391) := cap];
 
     // bytecode translation starts here
     call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 0));
@@ -3343,6 +3696,7 @@ requires ExistsTxnSenderAccount(__m, __txn);
 
     call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 4));
     __m := UpdateLocal(__m, __frame + 1, __tmp);
+    debug#LibraAccount#restore_withdrawal_capability#1#account_address := debug#LibraAccount#restore_withdrawal_capability#1#account_address[Position(8611) := __tmp];
 
     call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 1));
     __m := UpdateLocal(__m, __frame + 5, __tmp);
@@ -3370,7 +3724,7 @@ Label_Abort:
 
 procedure LibraAccount_restore_withdrawal_capability_verify (cap: Value) returns ()
 {
-    assume ExistsTxnSenderAccount(__m, __txn);
+    call InitVerification();
     call LibraAccount_restore_withdrawal_capability(cap);
 }
 
@@ -3393,22 +3747,34 @@ requires ExistsTxnSenderAccount(__m, __txn);
     var __tmp: Value;
     var __frame: int;
     var __saved_m: Memory;
+    var debug#LibraAccount#pay_from_capability#0#payee: [Position]Value;
+    var debug#LibraAccount#pay_from_capability#1#cap: [Position]Value;
+    var debug#LibraAccount#pay_from_capability#2#amount: [Position]Value;
+    var debug#LibraAccount#pay_from_capability#3#metadata: [Position]Value;
 
     // initialize function execution
     assume !__abort_flag;
     __saved_m := __m;
     __frame := __local_counter;
     __local_counter := __local_counter + 16;
+    debug#LibraAccount#pay_from_capability#0#payee := EmptyPositionMap;
+    debug#LibraAccount#pay_from_capability#1#cap := EmptyPositionMap;
+    debug#LibraAccount#pay_from_capability#2#amount := EmptyPositionMap;
+    debug#LibraAccount#pay_from_capability#3#metadata := EmptyPositionMap;
 
     // process and type check arguments
     assume is#Address(payee);
     __m := UpdateLocal(__m, __frame + 0, payee);
+    debug#LibraAccount#pay_from_capability#0#payee := debug#LibraAccount#pay_from_capability#0#payee[Position(9236) := payee];
     assume is#Vector(Dereference(__m, cap));
     assume IsValidReferenceParameter(__m, __frame, cap);
+    debug#LibraAccount#pay_from_capability#1#cap := debug#LibraAccount#pay_from_capability#1#cap[Position(9236) := Dereference(__m, cap)];
     assume IsValidU64(amount);
     __m := UpdateLocal(__m, __frame + 2, amount);
+    debug#LibraAccount#pay_from_capability#2#amount := debug#LibraAccount#pay_from_capability#2#amount[Position(9236) := amount];
     assume is#ByteArray(metadata);
     __m := UpdateLocal(__m, __frame + 3, metadata);
+    debug#LibraAccount#pay_from_capability#3#metadata := debug#LibraAccount#pay_from_capability#3#metadata[Position(9236) := metadata];
 
     // bytecode translation starts here
     call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 0));
@@ -3467,7 +3833,7 @@ Label_Abort:
 
 procedure LibraAccount_pay_from_capability_verify (payee: Value, cap: Reference, amount: Value, metadata: Value) returns ()
 {
-    assume ExistsTxnSenderAccount(__m, __txn);
+    call InitVerification();
     call LibraAccount_pay_from_capability(payee, cap, amount, metadata);
 }
 
@@ -3486,20 +3852,29 @@ requires ExistsTxnSenderAccount(__m, __txn);
     var __tmp: Value;
     var __frame: int;
     var __saved_m: Memory;
+    var debug#LibraAccount#pay_from_sender_with_metadata#0#payee: [Position]Value;
+    var debug#LibraAccount#pay_from_sender_with_metadata#1#amount: [Position]Value;
+    var debug#LibraAccount#pay_from_sender_with_metadata#2#metadata: [Position]Value;
 
     // initialize function execution
     assume !__abort_flag;
     __saved_m := __m;
     __frame := __local_counter;
     __local_counter := __local_counter + 11;
+    debug#LibraAccount#pay_from_sender_with_metadata#0#payee := EmptyPositionMap;
+    debug#LibraAccount#pay_from_sender_with_metadata#1#amount := EmptyPositionMap;
+    debug#LibraAccount#pay_from_sender_with_metadata#2#metadata := EmptyPositionMap;
 
     // process and type check arguments
     assume is#Address(payee);
     __m := UpdateLocal(__m, __frame + 0, payee);
+    debug#LibraAccount#pay_from_sender_with_metadata#0#payee := debug#LibraAccount#pay_from_sender_with_metadata#0#payee[Position(9947) := payee];
     assume IsValidU64(amount);
     __m := UpdateLocal(__m, __frame + 1, amount);
+    debug#LibraAccount#pay_from_sender_with_metadata#1#amount := debug#LibraAccount#pay_from_sender_with_metadata#1#amount[Position(9947) := amount];
     assume is#ByteArray(metadata);
     __m := UpdateLocal(__m, __frame + 2, metadata);
+    debug#LibraAccount#pay_from_sender_with_metadata#2#metadata := debug#LibraAccount#pay_from_sender_with_metadata#2#metadata[Position(9947) := metadata];
 
     // bytecode translation starts here
     call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 0));
@@ -3548,7 +3923,7 @@ Label_Abort:
 
 procedure LibraAccount_pay_from_sender_with_metadata_verify (payee: Value, amount: Value, metadata: Value) returns ()
 {
-    assume ExistsTxnSenderAccount(__m, __txn);
+    call InitVerification();
     call LibraAccount_pay_from_sender_with_metadata(payee, amount, metadata);
 }
 
@@ -3562,18 +3937,24 @@ requires ExistsTxnSenderAccount(__m, __txn);
     var __tmp: Value;
     var __frame: int;
     var __saved_m: Memory;
+    var debug#LibraAccount#pay_from_sender#0#payee: [Position]Value;
+    var debug#LibraAccount#pay_from_sender#1#amount: [Position]Value;
 
     // initialize function execution
     assume !__abort_flag;
     __saved_m := __m;
     __frame := __local_counter;
     __local_counter := __local_counter + 5;
+    debug#LibraAccount#pay_from_sender#0#payee := EmptyPositionMap;
+    debug#LibraAccount#pay_from_sender#1#amount := EmptyPositionMap;
 
     // process and type check arguments
     assume is#Address(payee);
     __m := UpdateLocal(__m, __frame + 0, payee);
+    debug#LibraAccount#pay_from_sender#0#payee := debug#LibraAccount#pay_from_sender#0#payee[Position(10530) := payee];
     assume IsValidU64(amount);
     __m := UpdateLocal(__m, __frame + 1, amount);
+    debug#LibraAccount#pay_from_sender#1#amount := debug#LibraAccount#pay_from_sender#1#amount[Position(10530) := amount];
 
     // bytecode translation starts here
     call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 0));
@@ -3596,7 +3977,7 @@ Label_Abort:
 
 procedure LibraAccount_pay_from_sender_verify (payee: Value, amount: Value) returns ()
 {
-    assume ExistsTxnSenderAccount(__m, __txn);
+    call InitVerification();
     call LibraAccount_pay_from_sender(payee, amount);
 }
 
@@ -3610,18 +3991,24 @@ requires ExistsTxnSenderAccount(__m, __txn);
     var __tmp: Value;
     var __frame: int;
     var __saved_m: Memory;
+    var debug#LibraAccount#rotate_authentication_key_for_account#0#account: [Position]Value;
+    var debug#LibraAccount#rotate_authentication_key_for_account#1#new_authentication_key: [Position]Value;
 
     // initialize function execution
     assume !__abort_flag;
     __saved_m := __m;
     __frame := __local_counter;
     __local_counter := __local_counter + 5;
+    debug#LibraAccount#rotate_authentication_key_for_account#0#account := EmptyPositionMap;
+    debug#LibraAccount#rotate_authentication_key_for_account#1#new_authentication_key := EmptyPositionMap;
 
     // process and type check arguments
     assume is#Vector(Dereference(__m, account));
     assume IsValidReferenceParameter(__m, __frame, account);
+    debug#LibraAccount#rotate_authentication_key_for_account#0#account := debug#LibraAccount#rotate_authentication_key_for_account#0#account[Position(10698) := Dereference(__m, account)];
     assume is#ByteArray(new_authentication_key);
     __m := UpdateLocal(__m, __frame + 1, new_authentication_key);
+    debug#LibraAccount#rotate_authentication_key_for_account#1#new_authentication_key := debug#LibraAccount#rotate_authentication_key_for_account#1#new_authentication_key[Position(10698) := new_authentication_key];
 
     // bytecode translation starts here
     call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 1));
@@ -3642,7 +4029,7 @@ Label_Abort:
 
 procedure LibraAccount_rotate_authentication_key_for_account_verify (account: Reference, new_authentication_key: Value) returns ()
 {
-    assume ExistsTxnSenderAccount(__m, __txn);
+    call InitVerification();
     call LibraAccount_rotate_authentication_key_for_account(account, new_authentication_key);
 }
 
@@ -3662,16 +4049,21 @@ requires ExistsTxnSenderAccount(__m, __txn);
     var __tmp: Value;
     var __frame: int;
     var __saved_m: Memory;
+    var debug#LibraAccount#rotate_authentication_key#0#new_authentication_key: [Position]Value;
+    var debug#LibraAccount#rotate_authentication_key#1#sender_account: [Position]Value;
 
     // initialize function execution
     assume !__abort_flag;
     __saved_m := __m;
     __frame := __local_counter;
     __local_counter := __local_counter + 10;
+    debug#LibraAccount#rotate_authentication_key#0#new_authentication_key := EmptyPositionMap;
+    debug#LibraAccount#rotate_authentication_key#1#sender_account := EmptyPositionMap;
 
     // process and type check arguments
     assume is#ByteArray(new_authentication_key);
     __m := UpdateLocal(__m, __frame + 0, new_authentication_key);
+    debug#LibraAccount#rotate_authentication_key#0#new_authentication_key := debug#LibraAccount#rotate_authentication_key#0#new_authentication_key[Position(11025) := new_authentication_key];
 
     // bytecode translation starts here
     call __tmp := GetTxnSenderAddress();
@@ -3716,7 +4108,7 @@ Label_Abort:
 
 procedure LibraAccount_rotate_authentication_key_verify (new_authentication_key: Value) returns ()
 {
-    assume ExistsTxnSenderAccount(__m, __txn);
+    call InitVerification();
     call LibraAccount_rotate_authentication_key(new_authentication_key);
 }
 
@@ -3732,18 +4124,24 @@ requires ExistsTxnSenderAccount(__m, __txn);
     var __tmp: Value;
     var __frame: int;
     var __saved_m: Memory;
+    var debug#LibraAccount#rotate_authentication_key_with_capability#0#cap: [Position]Value;
+    var debug#LibraAccount#rotate_authentication_key_with_capability#1#new_authentication_key: [Position]Value;
 
     // initialize function execution
     assume !__abort_flag;
     __saved_m := __m;
     __frame := __local_counter;
     __local_counter := __local_counter + 7;
+    debug#LibraAccount#rotate_authentication_key_with_capability#0#cap := EmptyPositionMap;
+    debug#LibraAccount#rotate_authentication_key_with_capability#1#new_authentication_key := EmptyPositionMap;
 
     // process and type check arguments
     assume is#Vector(Dereference(__m, cap));
     assume IsValidReferenceParameter(__m, __frame, cap);
+    debug#LibraAccount#rotate_authentication_key_with_capability#0#cap := debug#LibraAccount#rotate_authentication_key_with_capability#0#cap[Position(11765) := Dereference(__m, cap)];
     assume is#ByteArray(new_authentication_key);
     __m := UpdateLocal(__m, __frame + 1, new_authentication_key);
+    debug#LibraAccount#rotate_authentication_key_with_capability#1#new_authentication_key := debug#LibraAccount#rotate_authentication_key_with_capability#1#new_authentication_key[Position(11765) := new_authentication_key];
 
     // bytecode translation starts here
     call __t2 := CopyOrMoveRef(cap);
@@ -3772,7 +4170,7 @@ Label_Abort:
 
 procedure LibraAccount_rotate_authentication_key_with_capability_verify (cap: Reference, new_authentication_key: Value) returns ()
 {
-    assume ExistsTxnSenderAccount(__m, __txn);
+    call InitVerification();
     call LibraAccount_rotate_authentication_key_with_capability(cap, new_authentication_key);
 }
 
@@ -3796,12 +4194,18 @@ requires ExistsTxnSenderAccount(__m, __txn);
     var __tmp: Value;
     var __frame: int;
     var __saved_m: Memory;
+    var debug#LibraAccount#extract_sender_key_rotation_capability#0#sender: [Position]Value;
+    var debug#LibraAccount#extract_sender_key_rotation_capability#1#delegated_ref: [Position]Value;
+    var debug#LibraAccount#extract_sender_key_rotation_capability#2#__ret: [Position]Value;
 
     // initialize function execution
     assume !__abort_flag;
     __saved_m := __m;
     __frame := __local_counter;
     __local_counter := __local_counter + 13;
+    debug#LibraAccount#extract_sender_key_rotation_capability#0#sender := EmptyPositionMap;
+    debug#LibraAccount#extract_sender_key_rotation_capability#1#delegated_ref := EmptyPositionMap;
+    debug#LibraAccount#extract_sender_key_rotation_capability#2#__ret := EmptyPositionMap;
 
     // process and type check arguments
 
@@ -3811,6 +4215,7 @@ requires ExistsTxnSenderAccount(__m, __txn);
 
     call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 2));
     __m := UpdateLocal(__m, __frame + 0, __tmp);
+    debug#LibraAccount#extract_sender_key_rotation_capability#0#sender := debug#LibraAccount#extract_sender_key_rotation_capability#0#sender[Position(12375) := __tmp];
 
     call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 0));
     __m := UpdateLocal(__m, __frame + 3, __tmp);
@@ -3851,17 +4256,19 @@ Label_11:
     __m := UpdateLocal(__m, __frame + 12, __tmp);
 
     __ret0 := GetLocal(__m, __frame + 12);
+    debug#LibraAccount#extract_sender_key_rotation_capability#2#__ret := debug#LibraAccount#extract_sender_key_rotation_capability#2#__ret[Position(12758) := __ret0];
     return;
 
 Label_Abort:
     __abort_flag := true;
     __m := __saved_m;
     __ret0 := DefaultValue;
+    debug#LibraAccount#extract_sender_key_rotation_capability#2#__ret := debug#LibraAccount#extract_sender_key_rotation_capability#2#__ret[Position(12836) := __ret0];
 }
 
 procedure LibraAccount_extract_sender_key_rotation_capability_verify () returns (__ret0: Value)
 {
-    assume ExistsTxnSenderAccount(__m, __txn);
+    call InitVerification();
     call __ret0 := LibraAccount_extract_sender_key_rotation_capability();
 }
 
@@ -3881,16 +4288,23 @@ requires ExistsTxnSenderAccount(__m, __txn);
     var __tmp: Value;
     var __frame: int;
     var __saved_m: Memory;
+    var debug#LibraAccount#restore_key_rotation_capability#0#cap: [Position]Value;
+    var debug#LibraAccount#restore_key_rotation_capability#1#account_address: [Position]Value;
+    var debug#LibraAccount#restore_key_rotation_capability#2#account: [Position]Value;
 
     // initialize function execution
     assume !__abort_flag;
     __saved_m := __m;
     __frame := __local_counter;
     __local_counter := __local_counter + 10;
+    debug#LibraAccount#restore_key_rotation_capability#0#cap := EmptyPositionMap;
+    debug#LibraAccount#restore_key_rotation_capability#1#account_address := EmptyPositionMap;
+    debug#LibraAccount#restore_key_rotation_capability#2#account := EmptyPositionMap;
 
     // process and type check arguments
     assume is#Vector(cap);
     __m := UpdateLocal(__m, __frame + 0, cap);
+    debug#LibraAccount#restore_key_rotation_capability#0#cap := debug#LibraAccount#restore_key_rotation_capability#0#cap[Position(12924) := cap];
 
     // bytecode translation starts here
     call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 0));
@@ -3901,6 +4315,7 @@ requires ExistsTxnSenderAccount(__m, __txn);
 
     call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 4));
     __m := UpdateLocal(__m, __frame + 1, __tmp);
+    debug#LibraAccount#restore_key_rotation_capability#1#account_address := debug#LibraAccount#restore_key_rotation_capability#1#account_address[Position(13148) := __tmp];
 
     call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 1));
     __m := UpdateLocal(__m, __frame + 5, __tmp);
@@ -3928,7 +4343,7 @@ Label_Abort:
 
 procedure LibraAccount_restore_key_rotation_capability_verify (cap: Value) returns ()
 {
-    assume ExistsTxnSenderAccount(__m, __txn);
+    call InitVerification();
     call LibraAccount_restore_key_rotation_capability(cap);
 }
 
@@ -3957,16 +4372,21 @@ requires ExistsTxnSenderAccount(__m, __txn);
     var __tmp: Value;
     var __frame: int;
     var __saved_m: Memory;
+    var debug#LibraAccount#create_account#0#fresh_address: [Position]Value;
+    var debug#LibraAccount#create_account#1#generator: [Position]Value;
 
     // initialize function execution
     assume !__abort_flag;
     __saved_m := __m;
     __frame := __local_counter;
     __local_counter := __local_counter + 19;
+    debug#LibraAccount#create_account#0#fresh_address := EmptyPositionMap;
+    debug#LibraAccount#create_account#1#generator := EmptyPositionMap;
 
     // process and type check arguments
     assume is#Address(fresh_address);
     __m := UpdateLocal(__m, __frame + 0, fresh_address);
+    debug#LibraAccount#create_account#0#fresh_address := debug#LibraAccount#create_account#0#fresh_address[Position(13761) := fresh_address];
 
     // bytecode translation starts here
     call __tmp := LdConst(0);
@@ -3977,6 +4397,7 @@ requires ExistsTxnSenderAccount(__m, __txn);
 
     call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 3));
     __m := UpdateLocal(__m, __frame + 1, __tmp);
+    debug#LibraAccount#create_account#1#generator := debug#LibraAccount#create_account#1#generator[Position(13868) := __tmp];
 
     call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 0));
     __m := UpdateLocal(__m, __frame + 4, __tmp);
@@ -4012,6 +4433,7 @@ requires ExistsTxnSenderAccount(__m, __txn);
     assume is#Vector(__t12);
 
     __m := UpdateLocal(__m, __frame + 12, __t12);
+    debug#LibraAccount#create_account#1#generator := debug#LibraAccount#create_account#1#generator[Position(14268) := GetLocal(__m, __frame + 1)];
 
     call __t13 := BorrowLoc(__frame + 1);
 
@@ -4023,6 +4445,7 @@ requires ExistsTxnSenderAccount(__m, __txn);
     assume is#Vector(__t15);
 
     __m := UpdateLocal(__m, __frame + 15, __t15);
+    debug#LibraAccount#create_account#1#generator := debug#LibraAccount#create_account#1#generator[Position(14389) := GetLocal(__m, __frame + 1)];
 
     call __tmp := LdConst(0);
     __m := UpdateLocal(__m, __frame + 16, __tmp);
@@ -4045,7 +4468,7 @@ Label_Abort:
 
 procedure LibraAccount_create_account_verify (fresh_address: Value) returns ()
 {
-    assume ExistsTxnSenderAccount(__m, __txn);
+    call InitVerification();
     call LibraAccount_create_account(fresh_address);
 }
 
@@ -4062,18 +4485,24 @@ requires ExistsTxnSenderAccount(__m, __txn);
     var __tmp: Value;
     var __frame: int;
     var __saved_m: Memory;
+    var debug#LibraAccount#create_new_account#0#fresh_address: [Position]Value;
+    var debug#LibraAccount#create_new_account#1#initial_balance: [Position]Value;
 
     // initialize function execution
     assume !__abort_flag;
     __saved_m := __m;
     __frame := __local_counter;
     __local_counter := __local_counter + 8;
+    debug#LibraAccount#create_new_account#0#fresh_address := EmptyPositionMap;
+    debug#LibraAccount#create_new_account#1#initial_balance := EmptyPositionMap;
 
     // process and type check arguments
     assume is#Address(fresh_address);
     __m := UpdateLocal(__m, __frame + 0, fresh_address);
+    debug#LibraAccount#create_new_account#0#fresh_address := debug#LibraAccount#create_new_account#0#fresh_address[Position(14744) := fresh_address];
     assume IsValidU64(initial_balance);
     __m := UpdateLocal(__m, __frame + 1, initial_balance);
+    debug#LibraAccount#create_new_account#1#initial_balance := debug#LibraAccount#create_new_account#1#initial_balance[Position(14744) := initial_balance];
 
     // bytecode translation starts here
     call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 0));
@@ -4113,7 +4542,7 @@ Label_Abort:
 
 procedure LibraAccount_create_new_account_verify (fresh_address: Value, initial_balance: Value) returns ()
 {
-    assume ExistsTxnSenderAccount(__m, __txn);
+    call InitVerification();
     call LibraAccount_create_new_account(fresh_address, initial_balance);
 }
 
@@ -4132,16 +4561,23 @@ requires ExistsTxnSenderAccount(__m, __txn);
     var __tmp: Value;
     var __frame: int;
     var __saved_m: Memory;
+    var debug#LibraAccount#balance_for_account#0#account: [Position]Value;
+    var debug#LibraAccount#balance_for_account#1#balance_value: [Position]Value;
+    var debug#LibraAccount#balance_for_account#2#__ret: [Position]Value;
 
     // initialize function execution
     assume !__abort_flag;
     __saved_m := __m;
     __frame := __local_counter;
     __local_counter := __local_counter + 6;
+    debug#LibraAccount#balance_for_account#0#account := EmptyPositionMap;
+    debug#LibraAccount#balance_for_account#1#balance_value := EmptyPositionMap;
+    debug#LibraAccount#balance_for_account#2#__ret := EmptyPositionMap;
 
     // process and type check arguments
     assume is#Vector(Dereference(__m, account));
     assume IsValidReferenceParameter(__m, __frame, account);
+    debug#LibraAccount#balance_for_account#0#account := debug#LibraAccount#balance_for_account#0#account[Position(15265) := Dereference(__m, account)];
 
     // bytecode translation starts here
     call __t2 := CopyOrMoveRef(account);
@@ -4156,22 +4592,25 @@ requires ExistsTxnSenderAccount(__m, __txn);
 
     call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 4));
     __m := UpdateLocal(__m, __frame + 1, __tmp);
+    debug#LibraAccount#balance_for_account#1#balance_value := debug#LibraAccount#balance_for_account#1#balance_value[Position(15350) := __tmp];
 
     call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 1));
     __m := UpdateLocal(__m, __frame + 5, __tmp);
 
     __ret0 := GetLocal(__m, __frame + 5);
+    debug#LibraAccount#balance_for_account#2#__ret := debug#LibraAccount#balance_for_account#2#__ret[Position(15415) := __ret0];
     return;
 
 Label_Abort:
     __abort_flag := true;
     __m := __saved_m;
     __ret0 := DefaultValue;
+    debug#LibraAccount#balance_for_account#2#__ret := debug#LibraAccount#balance_for_account#2#__ret[Position(15447) := __ret0];
 }
 
 procedure LibraAccount_balance_for_account_verify (account: Reference) returns (__ret0: Value)
 {
-    assume ExistsTxnSenderAccount(__m, __txn);
+    call InitVerification();
     call __ret0 := LibraAccount_balance_for_account(account);
 }
 
@@ -4185,16 +4624,21 @@ requires ExistsTxnSenderAccount(__m, __txn);
     var __tmp: Value;
     var __frame: int;
     var __saved_m: Memory;
+    var debug#LibraAccount#balance#0#addr: [Position]Value;
+    var debug#LibraAccount#balance#1#__ret: [Position]Value;
 
     // initialize function execution
     assume !__abort_flag;
     __saved_m := __m;
     __frame := __local_counter;
     __local_counter := __local_counter + 4;
+    debug#LibraAccount#balance#0#addr := EmptyPositionMap;
+    debug#LibraAccount#balance#1#__ret := EmptyPositionMap;
 
     // process and type check arguments
     assume is#Address(addr);
     __m := UpdateLocal(__m, __frame + 0, addr);
+    debug#LibraAccount#balance#0#addr := debug#LibraAccount#balance#0#addr[Position(15535) := addr];
 
     // bytecode translation starts here
     call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 0));
@@ -4210,17 +4654,19 @@ requires ExistsTxnSenderAccount(__m, __txn);
     __m := UpdateLocal(__m, __frame + 3, __t3);
 
     __ret0 := GetLocal(__m, __frame + 3);
+    debug#LibraAccount#balance#1#__ret := debug#LibraAccount#balance#1#__ret[Position(15591) := __ret0];
     return;
 
 Label_Abort:
     __abort_flag := true;
     __m := __saved_m;
     __ret0 := DefaultValue;
+    debug#LibraAccount#balance#1#__ret := debug#LibraAccount#balance#1#__ret[Position(15658) := __ret0];
 }
 
 procedure LibraAccount_balance_verify (addr: Value) returns (__ret0: Value)
 {
-    assume ExistsTxnSenderAccount(__m, __txn);
+    call InitVerification();
     call __ret0 := LibraAccount_balance(addr);
 }
 
@@ -4234,16 +4680,21 @@ requires ExistsTxnSenderAccount(__m, __txn);
     var __tmp: Value;
     var __frame: int;
     var __saved_m: Memory;
+    var debug#LibraAccount#sequence_number_for_account#0#account: [Position]Value;
+    var debug#LibraAccount#sequence_number_for_account#1#__ret: [Position]Value;
 
     // initialize function execution
     assume !__abort_flag;
     __saved_m := __m;
     __frame := __local_counter;
     __local_counter := __local_counter + 4;
+    debug#LibraAccount#sequence_number_for_account#0#account := EmptyPositionMap;
+    debug#LibraAccount#sequence_number_for_account#1#__ret := EmptyPositionMap;
 
     // process and type check arguments
     assume is#Vector(Dereference(__m, account));
     assume IsValidReferenceParameter(__m, __frame, account);
+    debug#LibraAccount#sequence_number_for_account#0#account := debug#LibraAccount#sequence_number_for_account#0#account[Position(15735) := Dereference(__m, account)];
 
     // bytecode translation starts here
     call __t1 := CopyOrMoveRef(account);
@@ -4255,17 +4706,19 @@ requires ExistsTxnSenderAccount(__m, __txn);
     __m := UpdateLocal(__m, __frame + 3, __tmp);
 
     __ret0 := GetLocal(__m, __frame + 3);
+    debug#LibraAccount#sequence_number_for_account#1#__ret := debug#LibraAccount#sequence_number_for_account#1#__ret[Position(15796) := __ret0];
     return;
 
 Label_Abort:
     __abort_flag := true;
     __m := __saved_m;
     __ret0 := DefaultValue;
+    debug#LibraAccount#sequence_number_for_account#1#__ret := debug#LibraAccount#sequence_number_for_account#1#__ret[Position(15842) := __ret0];
 }
 
 procedure LibraAccount_sequence_number_for_account_verify (account: Reference) returns (__ret0: Value)
 {
-    assume ExistsTxnSenderAccount(__m, __txn);
+    call InitVerification();
     call __ret0 := LibraAccount_sequence_number_for_account(account);
 }
 
@@ -4279,16 +4732,21 @@ requires ExistsTxnSenderAccount(__m, __txn);
     var __tmp: Value;
     var __frame: int;
     var __saved_m: Memory;
+    var debug#LibraAccount#sequence_number#0#addr: [Position]Value;
+    var debug#LibraAccount#sequence_number#1#__ret: [Position]Value;
 
     // initialize function execution
     assume !__abort_flag;
     __saved_m := __m;
     __frame := __local_counter;
     __local_counter := __local_counter + 4;
+    debug#LibraAccount#sequence_number#0#addr := EmptyPositionMap;
+    debug#LibraAccount#sequence_number#1#__ret := EmptyPositionMap;
 
     // process and type check arguments
     assume is#Address(addr);
     __m := UpdateLocal(__m, __frame + 0, addr);
+    debug#LibraAccount#sequence_number#0#addr := debug#LibraAccount#sequence_number#0#addr[Position(15901) := addr];
 
     // bytecode translation starts here
     call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 0));
@@ -4304,17 +4762,19 @@ requires ExistsTxnSenderAccount(__m, __txn);
     __m := UpdateLocal(__m, __frame + 3, __t3);
 
     __ret0 := GetLocal(__m, __frame + 3);
+    debug#LibraAccount#sequence_number#1#__ret := debug#LibraAccount#sequence_number#1#__ret[Position(15965) := __ret0];
     return;
 
 Label_Abort:
     __abort_flag := true;
     __m := __saved_m;
     __ret0 := DefaultValue;
+    debug#LibraAccount#sequence_number#1#__ret := debug#LibraAccount#sequence_number#1#__ret[Position(16040) := __ret0];
 }
 
 procedure LibraAccount_sequence_number_verify (addr: Value) returns (__ret0: Value)
 {
-    assume ExistsTxnSenderAccount(__m, __txn);
+    call InitVerification();
     call __ret0 := LibraAccount_sequence_number(addr);
 }
 
@@ -4329,16 +4789,21 @@ requires ExistsTxnSenderAccount(__m, __txn);
     var __tmp: Value;
     var __frame: int;
     var __saved_m: Memory;
+    var debug#LibraAccount#delegated_key_rotation_capability#0#addr: [Position]Value;
+    var debug#LibraAccount#delegated_key_rotation_capability#1#__ret: [Position]Value;
 
     // initialize function execution
     assume !__abort_flag;
     __saved_m := __m;
     __frame := __local_counter;
     __local_counter := __local_counter + 5;
+    debug#LibraAccount#delegated_key_rotation_capability#0#addr := EmptyPositionMap;
+    debug#LibraAccount#delegated_key_rotation_capability#1#__ret := EmptyPositionMap;
 
     // process and type check arguments
     assume is#Address(addr);
     __m := UpdateLocal(__m, __frame + 0, addr);
+    debug#LibraAccount#delegated_key_rotation_capability#0#addr := debug#LibraAccount#delegated_key_rotation_capability#0#addr[Position(16132) := addr];
 
     // bytecode translation starts here
     call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 0));
@@ -4354,17 +4819,19 @@ requires ExistsTxnSenderAccount(__m, __txn);
     __m := UpdateLocal(__m, __frame + 4, __tmp);
 
     __ret0 := GetLocal(__m, __frame + 4);
+    debug#LibraAccount#delegated_key_rotation_capability#1#__ret := debug#LibraAccount#delegated_key_rotation_capability#1#__ret[Position(16215) := __ret0];
     return;
 
 Label_Abort:
     __abort_flag := true;
     __m := __saved_m;
     __ret0 := DefaultValue;
+    debug#LibraAccount#delegated_key_rotation_capability#1#__ret := debug#LibraAccount#delegated_key_rotation_capability#1#__ret[Position(16294) := __ret0];
 }
 
 procedure LibraAccount_delegated_key_rotation_capability_verify (addr: Value) returns (__ret0: Value)
 {
-    assume ExistsTxnSenderAccount(__m, __txn);
+    call InitVerification();
     call __ret0 := LibraAccount_delegated_key_rotation_capability(addr);
 }
 
@@ -4379,16 +4846,21 @@ requires ExistsTxnSenderAccount(__m, __txn);
     var __tmp: Value;
     var __frame: int;
     var __saved_m: Memory;
+    var debug#LibraAccount#delegated_withdrawal_capability#0#addr: [Position]Value;
+    var debug#LibraAccount#delegated_withdrawal_capability#1#__ret: [Position]Value;
 
     // initialize function execution
     assume !__abort_flag;
     __saved_m := __m;
     __frame := __local_counter;
     __local_counter := __local_counter + 5;
+    debug#LibraAccount#delegated_withdrawal_capability#0#addr := EmptyPositionMap;
+    debug#LibraAccount#delegated_withdrawal_capability#1#__ret := EmptyPositionMap;
 
     // process and type check arguments
     assume is#Address(addr);
     __m := UpdateLocal(__m, __frame + 0, addr);
+    debug#LibraAccount#delegated_withdrawal_capability#0#addr := debug#LibraAccount#delegated_withdrawal_capability#0#addr[Position(16385) := addr];
 
     // bytecode translation starts here
     call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 0));
@@ -4404,17 +4876,19 @@ requires ExistsTxnSenderAccount(__m, __txn);
     __m := UpdateLocal(__m, __frame + 4, __tmp);
 
     __ret0 := GetLocal(__m, __frame + 4);
+    debug#LibraAccount#delegated_withdrawal_capability#1#__ret := debug#LibraAccount#delegated_withdrawal_capability#1#__ret[Position(16466) := __ret0];
     return;
 
 Label_Abort:
     __abort_flag := true;
     __m := __saved_m;
     __ret0 := DefaultValue;
+    debug#LibraAccount#delegated_withdrawal_capability#1#__ret := debug#LibraAccount#delegated_withdrawal_capability#1#__ret[Position(16543) := __ret0];
 }
 
 procedure LibraAccount_delegated_withdrawal_capability_verify (addr: Value) returns (__ret0: Value)
 {
-    assume ExistsTxnSenderAccount(__m, __txn);
+    call InitVerification();
     call __ret0 := LibraAccount_delegated_withdrawal_capability(addr);
 }
 
@@ -4427,16 +4901,21 @@ requires ExistsTxnSenderAccount(__m, __txn);
     var __tmp: Value;
     var __frame: int;
     var __saved_m: Memory;
+    var debug#LibraAccount#withdrawal_capability_address#0#cap: [Position]Value;
+    var debug#LibraAccount#withdrawal_capability_address#1#__ret: [Position]Value;
 
     // initialize function execution
     assume !__abort_flag;
     __saved_m := __m;
     __frame := __local_counter;
     __local_counter := __local_counter + 3;
+    debug#LibraAccount#withdrawal_capability_address#0#cap := EmptyPositionMap;
+    debug#LibraAccount#withdrawal_capability_address#1#__ret := EmptyPositionMap;
 
     // process and type check arguments
     assume is#Vector(Dereference(__m, cap));
     assume IsValidReferenceParameter(__m, __frame, cap);
+    debug#LibraAccount#withdrawal_capability_address#0#cap := debug#LibraAccount#withdrawal_capability_address#0#cap[Position(16640) := Dereference(__m, cap)];
 
     // bytecode translation starts here
     call __t1 := CopyOrMoveRef(cap);
@@ -4444,17 +4923,19 @@ requires ExistsTxnSenderAccount(__m, __txn);
     call __t2 := BorrowField(__t1, LibraAccount_WithdrawalCapability_account_address);
 
     __ret0 := __t2;
+    debug#LibraAccount#withdrawal_capability_address#1#__ret := debug#LibraAccount#withdrawal_capability_address#1#__ret[Position(16730) := Dereference(__m, __ret0)];
     return;
 
 Label_Abort:
     __abort_flag := true;
     __m := __saved_m;
     __ret0 := DefaultReference;
+    debug#LibraAccount#withdrawal_capability_address#1#__ret := debug#LibraAccount#withdrawal_capability_address#1#__ret[Position(16769) := Dereference(__m, __ret0)];
 }
 
 procedure LibraAccount_withdrawal_capability_address_verify (cap: Reference) returns (__ret0: Reference)
 {
-    assume ExistsTxnSenderAccount(__m, __txn);
+    call InitVerification();
     call __ret0 := LibraAccount_withdrawal_capability_address(cap);
 }
 
@@ -4467,16 +4948,21 @@ requires ExistsTxnSenderAccount(__m, __txn);
     var __tmp: Value;
     var __frame: int;
     var __saved_m: Memory;
+    var debug#LibraAccount#key_rotation_capability_address#0#cap: [Position]Value;
+    var debug#LibraAccount#key_rotation_capability_address#1#__ret: [Position]Value;
 
     // initialize function execution
     assume !__abort_flag;
     __saved_m := __m;
     __frame := __local_counter;
     __local_counter := __local_counter + 3;
+    debug#LibraAccount#key_rotation_capability_address#0#cap := EmptyPositionMap;
+    debug#LibraAccount#key_rotation_capability_address#1#__ret := EmptyPositionMap;
 
     // process and type check arguments
     assume is#Vector(Dereference(__m, cap));
     assume IsValidReferenceParameter(__m, __frame, cap);
+    debug#LibraAccount#key_rotation_capability_address#0#cap := debug#LibraAccount#key_rotation_capability_address#0#cap[Position(16867) := Dereference(__m, cap)];
 
     // bytecode translation starts here
     call __t1 := CopyOrMoveRef(cap);
@@ -4484,17 +4970,19 @@ requires ExistsTxnSenderAccount(__m, __txn);
     call __t2 := BorrowField(__t1, LibraAccount_KeyRotationCapability_account_address);
 
     __ret0 := __t2;
+    debug#LibraAccount#key_rotation_capability_address#1#__ret := debug#LibraAccount#key_rotation_capability_address#1#__ret[Position(16960) := Dereference(__m, __ret0)];
     return;
 
 Label_Abort:
     __abort_flag := true;
     __m := __saved_m;
     __ret0 := DefaultReference;
+    debug#LibraAccount#key_rotation_capability_address#1#__ret := debug#LibraAccount#key_rotation_capability_address#1#__ret[Position(16999) := Dereference(__m, __ret0)];
 }
 
 procedure LibraAccount_key_rotation_capability_address_verify (cap: Reference) returns (__ret0: Reference)
 {
-    assume ExistsTxnSenderAccount(__m, __txn);
+    call InitVerification();
     call __ret0 := LibraAccount_key_rotation_capability_address(cap);
 }
 
@@ -4507,16 +4995,21 @@ requires ExistsTxnSenderAccount(__m, __txn);
     var __tmp: Value;
     var __frame: int;
     var __saved_m: Memory;
+    var debug#LibraAccount#exists#0#check_addr: [Position]Value;
+    var debug#LibraAccount#exists#1#__ret: [Position]Value;
 
     // initialize function execution
     assume !__abort_flag;
     __saved_m := __m;
     __frame := __local_counter;
     __local_counter := __local_counter + 3;
+    debug#LibraAccount#exists#0#check_addr := EmptyPositionMap;
+    debug#LibraAccount#exists#1#__ret := EmptyPositionMap;
 
     // process and type check arguments
     assume is#Address(check_addr);
     __m := UpdateLocal(__m, __frame + 0, check_addr);
+    debug#LibraAccount#exists#0#check_addr := debug#LibraAccount#exists#0#check_addr[Position(17057) := check_addr];
 
     // bytecode translation starts here
     call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 0));
@@ -4526,17 +5019,19 @@ requires ExistsTxnSenderAccount(__m, __txn);
     __m := UpdateLocal(__m, __frame + 2, __tmp);
 
     __ret0 := GetLocal(__m, __frame + 2);
+    debug#LibraAccount#exists#1#__ret := debug#LibraAccount#exists#1#__ret[Position(17108) := __ret0];
     return;
 
 Label_Abort:
     __abort_flag := true;
     __m := __saved_m;
     __ret0 := DefaultValue;
+    debug#LibraAccount#exists#1#__ret := debug#LibraAccount#exists#1#__ret[Position(17148) := __ret0];
 }
 
 procedure LibraAccount_exists_verify (check_addr: Value) returns (__ret0: Value)
 {
-    assume ExistsTxnSenderAccount(__m, __txn);
+    call InitVerification();
     call __ret0 := LibraAccount_exists(check_addr);
 }
 
@@ -4597,24 +5092,51 @@ requires ExistsTxnSenderAccount(__m, __txn);
     var __tmp: Value;
     var __frame: int;
     var __saved_m: Memory;
+    var debug#LibraAccount#prologue#0#txn_sequence_number: [Position]Value;
+    var debug#LibraAccount#prologue#1#txn_public_key: [Position]Value;
+    var debug#LibraAccount#prologue#2#txn_gas_price: [Position]Value;
+    var debug#LibraAccount#prologue#3#txn_max_gas_units: [Position]Value;
+    var debug#LibraAccount#prologue#4#txn_expiration_time: [Position]Value;
+    var debug#LibraAccount#prologue#5#transaction_sender: [Position]Value;
+    var debug#LibraAccount#prologue#6#sender_account: [Position]Value;
+    var debug#LibraAccount#prologue#7#imm_sender_account: [Position]Value;
+    var debug#LibraAccount#prologue#8#max_transaction_fee: [Position]Value;
+    var debug#LibraAccount#prologue#9#balance_amount: [Position]Value;
+    var debug#LibraAccount#prologue#10#sequence_number_value: [Position]Value;
 
     // initialize function execution
     assume !__abort_flag;
     __saved_m := __m;
     __frame := __local_counter;
     __local_counter := __local_counter + 55;
+    debug#LibraAccount#prologue#0#txn_sequence_number := EmptyPositionMap;
+    debug#LibraAccount#prologue#1#txn_public_key := EmptyPositionMap;
+    debug#LibraAccount#prologue#2#txn_gas_price := EmptyPositionMap;
+    debug#LibraAccount#prologue#3#txn_max_gas_units := EmptyPositionMap;
+    debug#LibraAccount#prologue#4#txn_expiration_time := EmptyPositionMap;
+    debug#LibraAccount#prologue#5#transaction_sender := EmptyPositionMap;
+    debug#LibraAccount#prologue#6#sender_account := EmptyPositionMap;
+    debug#LibraAccount#prologue#7#imm_sender_account := EmptyPositionMap;
+    debug#LibraAccount#prologue#8#max_transaction_fee := EmptyPositionMap;
+    debug#LibraAccount#prologue#9#balance_amount := EmptyPositionMap;
+    debug#LibraAccount#prologue#10#sequence_number_value := EmptyPositionMap;
 
     // process and type check arguments
     assume IsValidU64(txn_sequence_number);
     __m := UpdateLocal(__m, __frame + 0, txn_sequence_number);
+    debug#LibraAccount#prologue#0#txn_sequence_number := debug#LibraAccount#prologue#0#txn_sequence_number[Position(17457) := txn_sequence_number];
     assume is#ByteArray(txn_public_key);
     __m := UpdateLocal(__m, __frame + 1, txn_public_key);
+    debug#LibraAccount#prologue#1#txn_public_key := debug#LibraAccount#prologue#1#txn_public_key[Position(17457) := txn_public_key];
     assume IsValidU64(txn_gas_price);
     __m := UpdateLocal(__m, __frame + 2, txn_gas_price);
+    debug#LibraAccount#prologue#2#txn_gas_price := debug#LibraAccount#prologue#2#txn_gas_price[Position(17457) := txn_gas_price];
     assume IsValidU64(txn_max_gas_units);
     __m := UpdateLocal(__m, __frame + 3, txn_max_gas_units);
+    debug#LibraAccount#prologue#3#txn_max_gas_units := debug#LibraAccount#prologue#3#txn_max_gas_units[Position(17457) := txn_max_gas_units];
     assume IsValidU64(txn_expiration_time);
     __m := UpdateLocal(__m, __frame + 4, txn_expiration_time);
+    debug#LibraAccount#prologue#4#txn_expiration_time := debug#LibraAccount#prologue#4#txn_expiration_time[Position(17457) := txn_expiration_time];
 
     // bytecode translation starts here
     call __tmp := GetTxnSenderAddress();
@@ -4622,6 +5144,7 @@ requires ExistsTxnSenderAccount(__m, __txn);
 
     call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 11));
     __m := UpdateLocal(__m, __frame + 5, __tmp);
+    debug#LibraAccount#prologue#5#transaction_sender := debug#LibraAccount#prologue#5#transaction_sender[Position(17892) := __tmp];
 
     call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 5));
     __m := UpdateLocal(__m, __frame + 12, __tmp);
@@ -4693,6 +5216,7 @@ Label_21:
 
     call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 28));
     __m := UpdateLocal(__m, __frame + 8, __tmp);
+    debug#LibraAccount#prologue#8#max_transaction_fee := debug#LibraAccount#prologue#8#max_transaction_fee[Position(18540) := __tmp];
 
     call __t29 := CopyOrMoveRef(sender_account);
 
@@ -4710,6 +5234,7 @@ Label_21:
 
     call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 32));
     __m := UpdateLocal(__m, __frame + 9, __tmp);
+    debug#LibraAccount#prologue#9#balance_amount := debug#LibraAccount#prologue#9#balance_amount[Position(18676) := __tmp];
 
     call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 9));
     __m := UpdateLocal(__m, __frame + 33, __tmp);
@@ -4742,6 +5267,7 @@ Label_38:
 
     call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 40));
     __m := UpdateLocal(__m, __frame + 10, __tmp);
+    debug#LibraAccount#prologue#10#sequence_number_value := debug#LibraAccount#prologue#10#sequence_number_value[Position(18921) := __tmp];
 
     call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 0));
     __m := UpdateLocal(__m, __frame + 41, __tmp);
@@ -4815,7 +5341,7 @@ Label_Abort:
 
 procedure LibraAccount_prologue_verify (txn_sequence_number: Value, txn_public_key: Value, txn_gas_price: Value, txn_max_gas_units: Value, txn_expiration_time: Value) returns ()
 {
-    assume ExistsTxnSenderAccount(__m, __txn);
+    call InitVerification();
     call LibraAccount_prologue(txn_sequence_number, txn_public_key, txn_gas_price, txn_max_gas_units, txn_expiration_time);
 }
 
@@ -4859,22 +5385,44 @@ requires ExistsTxnSenderAccount(__m, __txn);
     var __tmp: Value;
     var __frame: int;
     var __saved_m: Memory;
+    var debug#LibraAccount#epilogue#0#txn_sequence_number: [Position]Value;
+    var debug#LibraAccount#epilogue#1#txn_gas_price: [Position]Value;
+    var debug#LibraAccount#epilogue#2#txn_max_gas_units: [Position]Value;
+    var debug#LibraAccount#epilogue#3#gas_units_remaining: [Position]Value;
+    var debug#LibraAccount#epilogue#4#sender_account: [Position]Value;
+    var debug#LibraAccount#epilogue#5#transaction_fee_account: [Position]Value;
+    var debug#LibraAccount#epilogue#6#imm_sender_account: [Position]Value;
+    var debug#LibraAccount#epilogue#7#transaction_fee_amount: [Position]Value;
+    var debug#LibraAccount#epilogue#8#transaction_fee: [Position]Value;
 
     // initialize function execution
     assume !__abort_flag;
     __saved_m := __m;
     __frame := __local_counter;
     __local_counter := __local_counter + 37;
+    debug#LibraAccount#epilogue#0#txn_sequence_number := EmptyPositionMap;
+    debug#LibraAccount#epilogue#1#txn_gas_price := EmptyPositionMap;
+    debug#LibraAccount#epilogue#2#txn_max_gas_units := EmptyPositionMap;
+    debug#LibraAccount#epilogue#3#gas_units_remaining := EmptyPositionMap;
+    debug#LibraAccount#epilogue#4#sender_account := EmptyPositionMap;
+    debug#LibraAccount#epilogue#5#transaction_fee_account := EmptyPositionMap;
+    debug#LibraAccount#epilogue#6#imm_sender_account := EmptyPositionMap;
+    debug#LibraAccount#epilogue#7#transaction_fee_amount := EmptyPositionMap;
+    debug#LibraAccount#epilogue#8#transaction_fee := EmptyPositionMap;
 
     // process and type check arguments
     assume IsValidU64(txn_sequence_number);
     __m := UpdateLocal(__m, __frame + 0, txn_sequence_number);
+    debug#LibraAccount#epilogue#0#txn_sequence_number := debug#LibraAccount#epilogue#0#txn_sequence_number[Position(19386) := txn_sequence_number];
     assume IsValidU64(txn_gas_price);
     __m := UpdateLocal(__m, __frame + 1, txn_gas_price);
+    debug#LibraAccount#epilogue#1#txn_gas_price := debug#LibraAccount#epilogue#1#txn_gas_price[Position(19386) := txn_gas_price];
     assume IsValidU64(txn_max_gas_units);
     __m := UpdateLocal(__m, __frame + 2, txn_max_gas_units);
+    debug#LibraAccount#epilogue#2#txn_max_gas_units := debug#LibraAccount#epilogue#2#txn_max_gas_units[Position(19386) := txn_max_gas_units];
     assume IsValidU64(gas_units_remaining);
     __m := UpdateLocal(__m, __frame + 3, gas_units_remaining);
+    debug#LibraAccount#epilogue#3#gas_units_remaining := debug#LibraAccount#epilogue#3#gas_units_remaining[Position(19386) := gas_units_remaining];
 
     // bytecode translation starts here
     call __tmp := GetTxnSenderAddress();
@@ -4904,6 +5452,7 @@ requires ExistsTxnSenderAccount(__m, __txn);
 
     call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 15));
     __m := UpdateLocal(__m, __frame + 7, __tmp);
+    debug#LibraAccount#epilogue#7#transaction_fee_amount := debug#LibraAccount#epilogue#7#transaction_fee_amount[Position(19907) := __tmp];
 
     call __t16 := CopyOrMoveRef(sender_account);
 
@@ -4950,6 +5499,7 @@ Label_20:
 
     call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 26));
     __m := UpdateLocal(__m, __frame + 8, __tmp);
+    debug#LibraAccount#epilogue#8#transaction_fee := debug#LibraAccount#epilogue#8#transaction_fee[Position(20225) := __tmp];
 
     call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 0));
     __m := UpdateLocal(__m, __frame + 27, __tmp);
@@ -4994,7 +5544,7 @@ Label_Abort:
 
 procedure LibraAccount_epilogue_verify (txn_sequence_number: Value, txn_gas_price: Value, txn_max_gas_units: Value, gas_units_remaining: Value) returns ()
 {
-    assume ExistsTxnSenderAccount(__m, __txn);
+    call InitVerification();
     call LibraAccount_epilogue(txn_sequence_number, txn_gas_price, txn_max_gas_units, gas_units_remaining);
 }
 
@@ -5025,18 +5575,34 @@ requires ExistsTxnSenderAccount(__m, __txn);
     var __tmp: Value;
     var __frame: int;
     var __saved_m: Memory;
+    var debug#LibraAccount#fresh_guid#0#counter: [Position]Value;
+    var debug#LibraAccount#fresh_guid#1#sender: [Position]Value;
+    var debug#LibraAccount#fresh_guid#2#count: [Position]Value;
+    var debug#LibraAccount#fresh_guid#3#count_bytes: [Position]Value;
+    var debug#LibraAccount#fresh_guid#4#preimage: [Position]Value;
+    var debug#LibraAccount#fresh_guid#5#sender_bytes: [Position]Value;
+    var debug#LibraAccount#fresh_guid#6#__ret: [Position]Value;
 
     // initialize function execution
     assume !__abort_flag;
     __saved_m := __m;
     __frame := __local_counter;
     __local_counter := __local_counter + 22;
+    debug#LibraAccount#fresh_guid#0#counter := EmptyPositionMap;
+    debug#LibraAccount#fresh_guid#1#sender := EmptyPositionMap;
+    debug#LibraAccount#fresh_guid#2#count := EmptyPositionMap;
+    debug#LibraAccount#fresh_guid#3#count_bytes := EmptyPositionMap;
+    debug#LibraAccount#fresh_guid#4#preimage := EmptyPositionMap;
+    debug#LibraAccount#fresh_guid#5#sender_bytes := EmptyPositionMap;
+    debug#LibraAccount#fresh_guid#6#__ret := EmptyPositionMap;
 
     // process and type check arguments
     assume is#Vector(Dereference(__m, counter));
     assume IsValidReferenceParameter(__m, __frame, counter);
+    debug#LibraAccount#fresh_guid#0#counter := debug#LibraAccount#fresh_guid#0#counter[Position(21344) := Dereference(__m, counter)];
     assume is#Address(sender);
     __m := UpdateLocal(__m, __frame + 1, sender);
+    debug#LibraAccount#fresh_guid#1#sender := debug#LibraAccount#fresh_guid#1#sender[Position(21344) := sender];
 
     // bytecode translation starts here
     call __t6 := CopyOrMoveRef(counter);
@@ -5056,6 +5622,7 @@ requires ExistsTxnSenderAccount(__m, __txn);
 
     call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 9));
     __m := UpdateLocal(__m, __frame + 5, __tmp);
+    debug#LibraAccount#fresh_guid#5#sender_bytes := debug#LibraAccount#fresh_guid#5#sender_bytes[Position(21614) := __tmp];
 
     call __t10 := CopyOrMoveRef(count);
 
@@ -5071,6 +5638,7 @@ requires ExistsTxnSenderAccount(__m, __txn);
 
     call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 12));
     __m := UpdateLocal(__m, __frame + 3, __tmp);
+    debug#LibraAccount#fresh_guid#3#count_bytes := debug#LibraAccount#fresh_guid#3#count_bytes[Position(21682) := __tmp];
 
     call __t13 := CopyOrMoveRef(count);
 
@@ -5103,22 +5671,25 @@ requires ExistsTxnSenderAccount(__m, __txn);
 
     call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 20));
     __m := UpdateLocal(__m, __frame + 4, __tmp);
+    debug#LibraAccount#fresh_guid#4#preimage := debug#LibraAccount#fresh_guid#4#preimage[Position(21879) := __tmp];
 
     call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 4));
     __m := UpdateLocal(__m, __frame + 21, __tmp);
 
     __ret0 := GetLocal(__m, __frame + 21);
+    debug#LibraAccount#fresh_guid#6#__ret := debug#LibraAccount#fresh_guid#6#__ret[Position(21970) := __ret0];
     return;
 
 Label_Abort:
     __abort_flag := true;
     __m := __saved_m;
     __ret0 := DefaultValue;
+    debug#LibraAccount#fresh_guid#6#__ret := debug#LibraAccount#fresh_guid#6#__ret[Position(21997) := __ret0];
 }
 
 procedure LibraAccount_fresh_guid_verify (counter: Reference, sender: Value) returns (__ret0: Value)
 {
-    assume ExistsTxnSenderAccount(__m, __txn);
+    call InitVerification();
     call __ret0 := LibraAccount_fresh_guid(counter, sender);
 }
 
@@ -5134,18 +5705,26 @@ requires ExistsTxnSenderAccount(__m, __txn);
     var __tmp: Value;
     var __frame: int;
     var __saved_m: Memory;
+    var debug#LibraAccount#new_event_handle_impl#0#counter: [Position]Value;
+    var debug#LibraAccount#new_event_handle_impl#1#sender: [Position]Value;
+    var debug#LibraAccount#new_event_handle_impl#2#__ret: [Position]Value;
 
     // initialize function execution
     assume !__abort_flag;
     __saved_m := __m;
     __frame := __local_counter;
     __local_counter := __local_counter + 7;
+    debug#LibraAccount#new_event_handle_impl#0#counter := EmptyPositionMap;
+    debug#LibraAccount#new_event_handle_impl#1#sender := EmptyPositionMap;
+    debug#LibraAccount#new_event_handle_impl#2#__ret := EmptyPositionMap;
 
     // process and type check arguments
     assume is#Vector(Dereference(__m, counter));
     assume IsValidReferenceParameter(__m, __frame, counter);
+    debug#LibraAccount#new_event_handle_impl#0#counter := debug#LibraAccount#new_event_handle_impl#0#counter[Position(22101) := Dereference(__m, counter)];
     assume is#Address(sender);
     __m := UpdateLocal(__m, __frame + 1, sender);
+    debug#LibraAccount#new_event_handle_impl#1#sender := debug#LibraAccount#new_event_handle_impl#1#sender[Position(22101) := sender];
 
     // bytecode translation starts here
     call __tmp := LdConst(0);
@@ -5166,17 +5745,19 @@ requires ExistsTxnSenderAccount(__m, __txn);
     __m := UpdateLocal(__m, __frame + 6, __tmp);
 
     __ret0 := GetLocal(__m, __frame + 6);
+    debug#LibraAccount#new_event_handle_impl#2#__ret := debug#LibraAccount#new_event_handle_impl#2#__ret[Position(22229) := __ret0];
     return;
 
 Label_Abort:
     __abort_flag := true;
     __m := __saved_m;
     __ret0 := DefaultValue;
+    debug#LibraAccount#new_event_handle_impl#2#__ret := debug#LibraAccount#new_event_handle_impl#2#__ret[Position(22321) := __ret0];
 }
 
 procedure LibraAccount_new_event_handle_impl_verify (tv0: TypeValue, counter: Reference, sender: Value) returns (__ret0: Value)
 {
-    assume ExistsTxnSenderAccount(__m, __txn);
+    call InitVerification();
     call __ret0 := LibraAccount_new_event_handle_impl(tv0, counter, sender);
 }
 
@@ -5195,12 +5776,18 @@ requires ExistsTxnSenderAccount(__m, __txn);
     var __tmp: Value;
     var __frame: int;
     var __saved_m: Memory;
+    var debug#LibraAccount#new_event_handle#0#sender_account_ref: [Position]Value;
+    var debug#LibraAccount#new_event_handle#1#sender_bytes: [Position]Value;
+    var debug#LibraAccount#new_event_handle#2#__ret: [Position]Value;
 
     // initialize function execution
     assume !__abort_flag;
     __saved_m := __m;
     __frame := __local_counter;
     __local_counter := __local_counter + 8;
+    debug#LibraAccount#new_event_handle#0#sender_account_ref := EmptyPositionMap;
+    debug#LibraAccount#new_event_handle#1#sender_bytes := EmptyPositionMap;
+    debug#LibraAccount#new_event_handle#2#__ret := EmptyPositionMap;
 
     // process and type check arguments
 
@@ -5227,17 +5814,19 @@ requires ExistsTxnSenderAccount(__m, __txn);
     __m := UpdateLocal(__m, __frame + 7, __t7);
 
     __ret0 := GetLocal(__m, __frame + 7);
+    debug#LibraAccount#new_event_handle#2#__ret := debug#LibraAccount#new_event_handle#2#__ret[Position(22670) := __ret0];
     return;
 
 Label_Abort:
     __abort_flag := true;
     __m := __saved_m;
     __ret0 := DefaultValue;
+    debug#LibraAccount#new_event_handle#2#__ret := debug#LibraAccount#new_event_handle#2#__ret[Position(22779) := __ret0];
 }
 
 procedure LibraAccount_new_event_handle_verify (tv0: TypeValue) returns (__ret0: Value)
 {
-    assume ExistsTxnSenderAccount(__m, __txn);
+    call InitVerification();
     call __ret0 := LibraAccount_new_event_handle(tv0);
 }
 
@@ -5264,17 +5853,27 @@ requires ExistsTxnSenderAccount(__m, __txn);
     var __tmp: Value;
     var __frame: int;
     var __saved_m: Memory;
+    var debug#LibraAccount#emit_event#0#handle_ref: [Position]Value;
+    var debug#LibraAccount#emit_event#1#msg: [Position]Value;
+    var debug#LibraAccount#emit_event#2#count: [Position]Value;
+    var debug#LibraAccount#emit_event#3#guid: [Position]Value;
 
     // initialize function execution
     assume !__abort_flag;
     __saved_m := __m;
     __frame := __local_counter;
     __local_counter := __local_counter + 18;
+    debug#LibraAccount#emit_event#0#handle_ref := EmptyPositionMap;
+    debug#LibraAccount#emit_event#1#msg := EmptyPositionMap;
+    debug#LibraAccount#emit_event#2#count := EmptyPositionMap;
+    debug#LibraAccount#emit_event#3#guid := EmptyPositionMap;
 
     // process and type check arguments
     assume is#Vector(Dereference(__m, handle_ref));
     assume IsValidReferenceParameter(__m, __frame, handle_ref);
+    debug#LibraAccount#emit_event#0#handle_ref := debug#LibraAccount#emit_event#0#handle_ref[Position(22958) := Dereference(__m, handle_ref)];
     __m := UpdateLocal(__m, __frame + 1, msg);
+    debug#LibraAccount#emit_event#1#msg := debug#LibraAccount#emit_event#1#msg[Position(22958) := msg];
 
     // bytecode translation starts here
     call __t4 := CopyOrMoveRef(handle_ref);
@@ -5287,6 +5886,7 @@ requires ExistsTxnSenderAccount(__m, __txn);
 
     call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 6));
     __m := UpdateLocal(__m, __frame + 3, __tmp);
+    debug#LibraAccount#emit_event#3#guid := debug#LibraAccount#emit_event#3#guid[Position(23108) := __tmp];
 
     call __t7 := CopyOrMoveRef(handle_ref);
 
@@ -5335,7 +5935,7 @@ Label_Abort:
 
 procedure LibraAccount_emit_event_verify (tv0: TypeValue, handle_ref: Reference, msg: Value) returns ()
 {
-    assume ExistsTxnSenderAccount(__m, __txn);
+    call InitVerification();
     call LibraAccount_emit_event(tv0, handle_ref, msg);
 }
 
@@ -5354,16 +5954,23 @@ requires ExistsTxnSenderAccount(__m, __txn);
     var __tmp: Value;
     var __frame: int;
     var __saved_m: Memory;
+    var debug#LibraAccount#destroy_handle#0#handle: [Position]Value;
+    var debug#LibraAccount#destroy_handle#1#guid: [Position]Value;
+    var debug#LibraAccount#destroy_handle#2#count: [Position]Value;
 
     // initialize function execution
     assume !__abort_flag;
     __saved_m := __m;
     __frame := __local_counter;
     __local_counter := __local_counter + 6;
+    debug#LibraAccount#destroy_handle#0#handle := EmptyPositionMap;
+    debug#LibraAccount#destroy_handle#1#guid := EmptyPositionMap;
+    debug#LibraAccount#destroy_handle#2#count := EmptyPositionMap;
 
     // process and type check arguments
     assume is#Vector(handle);
     __m := UpdateLocal(__m, __frame + 0, handle);
+    debug#LibraAccount#destroy_handle#0#handle := debug#LibraAccount#destroy_handle#0#handle[Position(23597) := handle];
 
     // bytecode translation starts here
     call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 0));
@@ -5375,9 +5982,11 @@ requires ExistsTxnSenderAccount(__m, __txn);
 
     call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 5));
     __m := UpdateLocal(__m, __frame + 1, __tmp);
+    debug#LibraAccount#destroy_handle#1#guid := debug#LibraAccount#destroy_handle#1#guid[Position(23752) := __tmp];
 
     call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 4));
     __m := UpdateLocal(__m, __frame + 2, __tmp);
+    debug#LibraAccount#destroy_handle#2#count := debug#LibraAccount#destroy_handle#2#count[Position(23745) := __tmp];
 
     return;
 
@@ -5388,7 +5997,7 @@ Label_Abort:
 
 procedure LibraAccount_destroy_handle_verify (tv0: TypeValue, handle: Value) returns ()
 {
-    assume ExistsTxnSenderAccount(__m, __txn);
+    call InitVerification();
     call LibraAccount_destroy_handle(tv0, handle);
 }
 

--- a/language/move-prover/bytecode-to-boogie/tests/goldenfiles/test-reference.bpl
+++ b/language/move-prover/bytecode-to-boogie/tests/goldenfiles/test-reference.bpl
@@ -34,16 +34,19 @@ requires ExistsTxnSenderAccount(__m, __txn);
     var __tmp: Value;
     var __frame: int;
     var __saved_m: Memory;
+    var debug#TestReference#mut_b#0#b: [Position]Value;
 
     // initialize function execution
     assume !__abort_flag;
     __saved_m := __m;
     __frame := __local_counter;
     __local_counter := __local_counter + 3;
+    debug#TestReference#mut_b#0#b := EmptyPositionMap;
 
     // process and type check arguments
     assume IsValidU64(Dereference(__m, b));
     assume IsValidReferenceParameter(__m, __frame, b);
+    debug#TestReference#mut_b#0#b := debug#TestReference#mut_b#0#b[Position(71) := Dereference(__m, b)];
 
     // bytecode translation starts here
     call __tmp := LdConst(10);
@@ -62,7 +65,7 @@ Label_Abort:
 
 procedure TestReference_mut_b_verify (b: Reference) returns ()
 {
-    assume ExistsTxnSenderAccount(__m, __txn);
+    call InitVerification();
     call TestReference_mut_b(b);
 }
 
@@ -88,12 +91,16 @@ ensures old(b#Boolean(Boolean(false))) ==> __abort_flag;
     var __tmp: Value;
     var __frame: int;
     var __saved_m: Memory;
+    var debug#TestReference#mut_ref#0#b: [Position]Value;
+    var debug#TestReference#mut_ref#1#b_ref: [Position]Value;
 
     // initialize function execution
     assume !__abort_flag;
     __saved_m := __m;
     __frame := __local_counter;
     __local_counter := __local_counter + 12;
+    debug#TestReference#mut_ref#0#b := EmptyPositionMap;
+    debug#TestReference#mut_ref#1#b_ref := EmptyPositionMap;
 
     // process and type check arguments
 
@@ -103,6 +110,7 @@ ensures old(b#Boolean(Boolean(false))) ==> __abort_flag;
 
     call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 2));
     __m := UpdateLocal(__m, __frame + 0, __tmp);
+    debug#TestReference#mut_ref#0#b := debug#TestReference#mut_ref#0#b[Position(249) := __tmp];
 
     call __t3 := BorrowLoc(__frame + 0);
 
@@ -112,6 +120,7 @@ ensures old(b#Boolean(Boolean(false))) ==> __abort_flag;
 
     call TestReference_mut_b(__t4);
     if (__abort_flag) { goto Label_Abort; }
+    debug#TestReference#mut_ref#0#b := debug#TestReference#mut_ref#0#b[Position(346) := GetLocal(__m, __frame + 0)];
 
     call __t5 := CopyOrMoveRef(b_ref);
 
@@ -121,6 +130,7 @@ ensures old(b#Boolean(Boolean(false))) ==> __abort_flag;
 
     call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 6));
     __m := UpdateLocal(__m, __frame + 0, __tmp);
+    debug#TestReference#mut_ref#0#b := debug#TestReference#mut_ref#0#b[Position(379) := __tmp];
 
     call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 0));
     __m := UpdateLocal(__m, __frame + 7, __tmp);
@@ -152,6 +162,6 @@ Label_Abort:
 
 procedure TestReference_mut_ref_verify () returns ()
 {
-    assume ExistsTxnSenderAccount(__m, __txn);
+    call InitVerification();
     call TestReference_mut_ref();
 }

--- a/language/move-prover/bytecode-to-boogie/tests/goldenfiles/test-specs-translate.bpl
+++ b/language/move-prover/bytecode-to-boogie/tests/goldenfiles/test-specs-translate.bpl
@@ -73,18 +73,28 @@ ensures old(b#Boolean(Boolean(i#Integer(x1) <= i#Integer(Integer(0))))) ==> __ab
     var __tmp: Value;
     var __frame: int;
     var __saved_m: Memory;
+    var debug#TestSpecs#div#0#x1: [Position]Value;
+    var debug#TestSpecs#div#1#x2: [Position]Value;
+    var debug#TestSpecs#div#2#r: [Position]Value;
+    var debug#TestSpecs#div#3#__ret: [Position]Value;
 
     // initialize function execution
     assume !__abort_flag;
     __saved_m := __m;
     __frame := __local_counter;
     __local_counter := __local_counter + 7;
+    debug#TestSpecs#div#0#x1 := EmptyPositionMap;
+    debug#TestSpecs#div#1#x2 := EmptyPositionMap;
+    debug#TestSpecs#div#2#r := EmptyPositionMap;
+    debug#TestSpecs#div#3#__ret := EmptyPositionMap;
 
     // process and type check arguments
     assume IsValidU64(x1);
     __m := UpdateLocal(__m, __frame + 0, x1);
+    debug#TestSpecs#div#0#x1 := debug#TestSpecs#div#0#x1[Position(293) := x1];
     assume IsValidU64(x2);
     __m := UpdateLocal(__m, __frame + 1, x2);
+    debug#TestSpecs#div#1#x2 := debug#TestSpecs#div#1#x2[Position(293) := x2];
 
     // bytecode translation starts here
     call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 0));
@@ -99,22 +109,25 @@ ensures old(b#Boolean(Boolean(i#Integer(x1) <= i#Integer(Integer(0))))) ==> __ab
 
     call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 5));
     __m := UpdateLocal(__m, __frame + 2, __tmp);
+    debug#TestSpecs#div#2#r := debug#TestSpecs#div#2#r[Position(461) := __tmp];
 
     call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 2));
     __m := UpdateLocal(__m, __frame + 6, __tmp);
 
     __ret0 := GetLocal(__m, __frame + 6);
+    debug#TestSpecs#div#3#__ret := debug#TestSpecs#div#3#__ret[Position(494) := __ret0];
     return;
 
 Label_Abort:
     __abort_flag := true;
     __m := __saved_m;
     __ret0 := DefaultValue;
+    debug#TestSpecs#div#3#__ret := debug#TestSpecs#div#3#__ret[Position(514) := __ret0];
 }
 
 procedure TestSpecs_div_verify (x1: Value, x2: Value) returns (__ret0: Value)
 {
-    assume ExistsTxnSenderAccount(__m, __txn);
+    call InitVerification();
     call __ret0 := TestSpecs_div(x1, x2);
 }
 
@@ -148,7 +161,7 @@ Label_Abort:
 
 procedure TestSpecs_create_resource_verify () returns ()
 {
-    assume ExistsTxnSenderAccount(__m, __txn);
+    call InitVerification();
     call TestSpecs_create_resource();
 }
 
@@ -179,7 +192,7 @@ Label_Abort:
 
 procedure TestSpecs_select_from_global_resource_verify () returns ()
 {
-    assume ExistsTxnSenderAccount(__m, __txn);
+    call InitVerification();
     call TestSpecs_select_from_global_resource();
 }
 
@@ -192,33 +205,40 @@ requires ExistsTxnSenderAccount(__m, __txn);
     var __tmp: Value;
     var __frame: int;
     var __saved_m: Memory;
+    var debug#TestSpecs#select_from_resource#0#r: [Position]Value;
+    var debug#TestSpecs#select_from_resource#1#__ret: [Position]Value;
 
     // initialize function execution
     assume !__abort_flag;
     __saved_m := __m;
     __frame := __local_counter;
     __local_counter := __local_counter + 2;
+    debug#TestSpecs#select_from_resource#0#r := EmptyPositionMap;
+    debug#TestSpecs#select_from_resource#1#__ret := EmptyPositionMap;
 
     // process and type check arguments
     assume is#Vector(r);
     __m := UpdateLocal(__m, __frame + 0, r);
+    debug#TestSpecs#select_from_resource#0#r := debug#TestSpecs#select_from_resource#0#r[Position(770) := r];
 
     // bytecode translation starts here
     call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 0));
     __m := UpdateLocal(__m, __frame + 1, __tmp);
 
     __ret0 := GetLocal(__m, __frame + 1);
+    debug#TestSpecs#select_from_resource#1#__ret := debug#TestSpecs#select_from_resource#1#__ret[Position(852) := __ret0];
     return;
 
 Label_Abort:
     __abort_flag := true;
     __m := __saved_m;
     __ret0 := DefaultValue;
+    debug#TestSpecs#select_from_resource#1#__ret := debug#TestSpecs#select_from_resource#1#__ret[Position(872) := __ret0];
 }
 
 procedure TestSpecs_select_from_resource_verify (r: Value) returns (__ret0: Value)
 {
-    assume ExistsTxnSenderAccount(__m, __txn);
+    call InitVerification();
     call __ret0 := TestSpecs_select_from_resource(r);
 }
 
@@ -231,33 +251,40 @@ requires ExistsTxnSenderAccount(__m, __txn);
     var __tmp: Value;
     var __frame: int;
     var __saved_m: Memory;
+    var debug#TestSpecs#select_from_resource_nested#0#r: [Position]Value;
+    var debug#TestSpecs#select_from_resource_nested#1#__ret: [Position]Value;
 
     // initialize function execution
     assume !__abort_flag;
     __saved_m := __m;
     __frame := __local_counter;
     __local_counter := __local_counter + 2;
+    debug#TestSpecs#select_from_resource_nested#0#r := EmptyPositionMap;
+    debug#TestSpecs#select_from_resource_nested#1#__ret := EmptyPositionMap;
 
     // process and type check arguments
     assume is#Vector(r);
     __m := UpdateLocal(__m, __frame + 0, r);
+    debug#TestSpecs#select_from_resource_nested#0#r := debug#TestSpecs#select_from_resource_nested#0#r[Position(879) := r];
 
     // bytecode translation starts here
     call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 0));
     __m := UpdateLocal(__m, __frame + 1, __tmp);
 
     __ret0 := GetLocal(__m, __frame + 1);
+    debug#TestSpecs#select_from_resource_nested#1#__ret := debug#TestSpecs#select_from_resource_nested#1#__ret[Position(973) := __ret0];
     return;
 
 Label_Abort:
     __abort_flag := true;
     __m := __saved_m;
     __ret0 := DefaultValue;
+    debug#TestSpecs#select_from_resource_nested#1#__ret := debug#TestSpecs#select_from_resource_nested#1#__ret[Position(993) := __ret0];
 }
 
 procedure TestSpecs_select_from_resource_nested_verify (r: Value) returns (__ret0: Value)
 {
-    assume ExistsTxnSenderAccount(__m, __txn);
+    call InitVerification();
     call __ret0 := TestSpecs_select_from_resource_nested(r);
 }
 
@@ -270,33 +297,40 @@ requires ExistsTxnSenderAccount(__m, __txn);
     var __tmp: Value;
     var __frame: int;
     var __saved_m: Memory;
+    var debug#TestSpecs#select_from_global_resource_dynamic_address#0#r: [Position]Value;
+    var debug#TestSpecs#select_from_global_resource_dynamic_address#1#__ret: [Position]Value;
 
     // initialize function execution
     assume !__abort_flag;
     __saved_m := __m;
     __frame := __local_counter;
     __local_counter := __local_counter + 2;
+    debug#TestSpecs#select_from_global_resource_dynamic_address#0#r := EmptyPositionMap;
+    debug#TestSpecs#select_from_global_resource_dynamic_address#1#__ret := EmptyPositionMap;
 
     // process and type check arguments
     assume is#Vector(r);
     __m := UpdateLocal(__m, __frame + 0, r);
+    debug#TestSpecs#select_from_global_resource_dynamic_address#0#r := debug#TestSpecs#select_from_global_resource_dynamic_address#0#r[Position(1000) := r];
 
     // bytecode translation starts here
     call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 0));
     __m := UpdateLocal(__m, __frame + 1, __tmp);
 
     __ret0 := GetLocal(__m, __frame + 1);
+    debug#TestSpecs#select_from_global_resource_dynamic_address#1#__ret := debug#TestSpecs#select_from_global_resource_dynamic_address#1#__ret[Position(1125) := __ret0];
     return;
 
 Label_Abort:
     __abort_flag := true;
     __m := __saved_m;
     __ret0 := DefaultValue;
+    debug#TestSpecs#select_from_global_resource_dynamic_address#1#__ret := debug#TestSpecs#select_from_global_resource_dynamic_address#1#__ret[Position(1145) := __ret0];
 }
 
 procedure TestSpecs_select_from_global_resource_dynamic_address_verify (r: Value) returns (__ret0: Value)
 {
-    assume ExistsTxnSenderAccount(__m, __txn);
+    call InitVerification();
     call __ret0 := TestSpecs_select_from_global_resource_dynamic_address(r);
 }
 
@@ -309,16 +343,19 @@ ensures b#Boolean(Boolean(IsEqual(SelectField(SelectField(Dereference(__m, r), T
     var __tmp: Value;
     var __frame: int;
     var __saved_m: Memory;
+    var debug#TestSpecs#select_from_reference#0#r: [Position]Value;
 
     // initialize function execution
     assume !__abort_flag;
     __saved_m := __m;
     __frame := __local_counter;
     __local_counter := __local_counter + 1;
+    debug#TestSpecs#select_from_reference#0#r := EmptyPositionMap;
 
     // process and type check arguments
     assume is#Vector(Dereference(__m, r));
     assume IsValidReferenceParameter(__m, __frame, r);
+    debug#TestSpecs#select_from_reference#0#r := debug#TestSpecs#select_from_reference#0#r[Position(1152) := Dereference(__m, r)];
 
     // bytecode translation starts here
     return;
@@ -330,7 +367,7 @@ Label_Abort:
 
 procedure TestSpecs_select_from_reference_verify (r: Reference) returns ()
 {
-    assume ExistsTxnSenderAccount(__m, __txn);
+    call InitVerification();
     call TestSpecs_select_from_reference(r);
 }
 
@@ -347,12 +384,18 @@ ensures b#Boolean(Boolean(IsEqual(__ret2, Integer(10))));
     var __tmp: Value;
     var __frame: int;
     var __saved_m: Memory;
+    var debug#TestSpecs#ret_values#0#__ret: [Position]Value;
+    var debug#TestSpecs#ret_values#1#__ret: [Position]Value;
+    var debug#TestSpecs#ret_values#2#__ret: [Position]Value;
 
     // initialize function execution
     assume !__abort_flag;
     __saved_m := __m;
     __frame := __local_counter;
     __local_counter := __local_counter + 3;
+    debug#TestSpecs#ret_values#0#__ret := EmptyPositionMap;
+    debug#TestSpecs#ret_values#1#__ret := EmptyPositionMap;
+    debug#TestSpecs#ret_values#2#__ret := EmptyPositionMap;
 
     // process and type check arguments
 
@@ -367,21 +410,27 @@ ensures b#Boolean(Boolean(IsEqual(__ret2, Integer(10))));
     __m := UpdateLocal(__m, __frame + 2, __tmp);
 
     __ret0 := GetLocal(__m, __frame + 0);
+    debug#TestSpecs#ret_values#0#__ret := debug#TestSpecs#ret_values#0#__ret[Position(1425) := __ret0];
     __ret1 := GetLocal(__m, __frame + 1);
+    debug#TestSpecs#ret_values#1#__ret := debug#TestSpecs#ret_values#1#__ret[Position(1425) := __ret1];
     __ret2 := GetLocal(__m, __frame + 2);
+    debug#TestSpecs#ret_values#2#__ret := debug#TestSpecs#ret_values#2#__ret[Position(1425) := __ret2];
     return;
 
 Label_Abort:
     __abort_flag := true;
     __m := __saved_m;
     __ret0 := DefaultValue;
+    debug#TestSpecs#ret_values#0#__ret := debug#TestSpecs#ret_values#0#__ret[Position(1452) := __ret0];
     __ret1 := DefaultValue;
+    debug#TestSpecs#ret_values#1#__ret := debug#TestSpecs#ret_values#1#__ret[Position(1452) := __ret1];
     __ret2 := DefaultValue;
+    debug#TestSpecs#ret_values#2#__ret := debug#TestSpecs#ret_values#2#__ret[Position(1452) := __ret2];
 }
 
 procedure TestSpecs_ret_values_verify () returns (__ret0: Value, __ret1: Value, __ret2: Value)
 {
-    assume ExistsTxnSenderAccount(__m, __txn);
+    call InitVerification();
     call __ret0, __ret1, __ret2 := TestSpecs_ret_values();
 }
 
@@ -394,32 +443,39 @@ ensures b#Boolean(Boolean(b#Boolean(number_in_range(x)) && b#Boolean(Boolean(i#I
     var __tmp: Value;
     var __frame: int;
     var __saved_m: Memory;
+    var debug#TestSpecs#helper_function#0#x: [Position]Value;
+    var debug#TestSpecs#helper_function#1#__ret: [Position]Value;
 
     // initialize function execution
     assume !__abort_flag;
     __saved_m := __m;
     __frame := __local_counter;
     __local_counter := __local_counter + 2;
+    debug#TestSpecs#helper_function#0#x := EmptyPositionMap;
+    debug#TestSpecs#helper_function#1#__ret := EmptyPositionMap;
 
     // process and type check arguments
     assume IsValidU64(x);
     __m := UpdateLocal(__m, __frame + 0, x);
+    debug#TestSpecs#helper_function#0#x := debug#TestSpecs#helper_function#0#x[Position(1459) := x];
 
     // bytecode translation starts here
     call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 0));
     __m := UpdateLocal(__m, __frame + 1, __tmp);
 
     __ret0 := GetLocal(__m, __frame + 1);
+    debug#TestSpecs#helper_function#1#__ret := debug#TestSpecs#helper_function#1#__ret[Position(1559) := __ret0];
     return;
 
 Label_Abort:
     __abort_flag := true;
     __m := __saved_m;
     __ret0 := DefaultValue;
+    debug#TestSpecs#helper_function#1#__ret := debug#TestSpecs#helper_function#1#__ret[Position(1579) := __ret0];
 }
 
 procedure TestSpecs_helper_function_verify (x: Value) returns (__ret0: Value)
 {
-    assume ExistsTxnSenderAccount(__m, __txn);
+    call InitVerification();
     call __ret0 := TestSpecs_helper_function(x);
 }

--- a/language/move-prover/bytecode-to-boogie/tests/goldenfiles/test-struct.bpl
+++ b/language/move-prover/bytecode-to-boogie/tests/goldenfiles/test-struct.bpl
@@ -106,18 +106,28 @@ requires ExistsTxnSenderAccount(__m, __txn);
     var __tmp: Value;
     var __frame: int;
     var __saved_m: Memory;
+    var debug#TestStruct#identity#0#a: [Position]Value;
+    var debug#TestStruct#identity#1#c: [Position]Value;
+    var debug#TestStruct#identity#2#__ret: [Position]Value;
+    var debug#TestStruct#identity#3#__ret: [Position]Value;
 
     // initialize function execution
     assume !__abort_flag;
     __saved_m := __m;
     __frame := __local_counter;
     __local_counter := __local_counter + 4;
+    debug#TestStruct#identity#0#a := EmptyPositionMap;
+    debug#TestStruct#identity#1#c := EmptyPositionMap;
+    debug#TestStruct#identity#2#__ret := EmptyPositionMap;
+    debug#TestStruct#identity#3#__ret := EmptyPositionMap;
 
     // process and type check arguments
     assume is#Vector(a);
     __m := UpdateLocal(__m, __frame + 0, a);
+    debug#TestStruct#identity#0#a := debug#TestStruct#identity#0#a[Position(252) := a];
     assume is#Vector(c);
     __m := UpdateLocal(__m, __frame + 1, c);
+    debug#TestStruct#identity#1#c := debug#TestStruct#identity#1#c[Position(252) := c];
 
     // bytecode translation starts here
     call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 0));
@@ -127,19 +137,23 @@ requires ExistsTxnSenderAccount(__m, __txn);
     __m := UpdateLocal(__m, __frame + 3, __tmp);
 
     __ret0 := GetLocal(__m, __frame + 2);
+    debug#TestStruct#identity#2#__ret := debug#TestStruct#identity#2#__ret[Position(315) := __ret0];
     __ret1 := GetLocal(__m, __frame + 3);
+    debug#TestStruct#identity#3#__ret := debug#TestStruct#identity#3#__ret[Position(315) := __ret1];
     return;
 
 Label_Abort:
     __abort_flag := true;
     __m := __saved_m;
     __ret0 := DefaultValue;
+    debug#TestStruct#identity#2#__ret := debug#TestStruct#identity#2#__ret[Position(344) := __ret0];
     __ret1 := DefaultValue;
+    debug#TestStruct#identity#3#__ret := debug#TestStruct#identity#3#__ret[Position(344) := __ret1];
 }
 
 procedure TestStruct_identity_verify (a: Value, c: Value) returns (__ret0: Value, __ret1: Value)
 {
-    assume ExistsTxnSenderAccount(__m, __txn);
+    call InitVerification();
     call __ret0, __ret1 := TestStruct_identity(a, c);
 }
 
@@ -169,16 +183,29 @@ requires ExistsTxnSenderAccount(__m, __txn);
     var __tmp: Value;
     var __frame: int;
     var __saved_m: Memory;
+    var debug#TestStruct#module_builtins#0#a: [Position]Value;
+    var debug#TestStruct#module_builtins#1#t: [Position]Value;
+    var debug#TestStruct#module_builtins#2#t_ref1: [Position]Value;
+    var debug#TestStruct#module_builtins#3#t_ref2: [Position]Value;
+    var debug#TestStruct#module_builtins#4#b: [Position]Value;
+    var debug#TestStruct#module_builtins#5#__ret: [Position]Value;
 
     // initialize function execution
     assume !__abort_flag;
     __saved_m := __m;
     __frame := __local_counter;
     __local_counter := __local_counter + 20;
+    debug#TestStruct#module_builtins#0#a := EmptyPositionMap;
+    debug#TestStruct#module_builtins#1#t := EmptyPositionMap;
+    debug#TestStruct#module_builtins#2#t_ref1 := EmptyPositionMap;
+    debug#TestStruct#module_builtins#3#t_ref2 := EmptyPositionMap;
+    debug#TestStruct#module_builtins#4#b := EmptyPositionMap;
+    debug#TestStruct#module_builtins#5#__ret := EmptyPositionMap;
 
     // process and type check arguments
     assume is#Address(a);
     __m := UpdateLocal(__m, __frame + 0, a);
+    debug#TestStruct#module_builtins#0#a := debug#TestStruct#module_builtins#0#a[Position(351) := a];
 
     // bytecode translation starts here
     call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 0));
@@ -189,6 +216,7 @@ requires ExistsTxnSenderAccount(__m, __txn);
 
     call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 6));
     __m := UpdateLocal(__m, __frame + 4, __tmp);
+    debug#TestStruct#module_builtins#4#b := debug#TestStruct#module_builtins#4#b[Position(528) := __tmp];
 
     call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 4));
     __m := UpdateLocal(__m, __frame + 7, __tmp);
@@ -239,6 +267,7 @@ Label_8:
 
     call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 17));
     __m := UpdateLocal(__m, __frame + 1, __tmp);
+    debug#TestStruct#module_builtins#1#t := debug#TestStruct#module_builtins#1#t[Position(737) := __tmp];
 
     call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 1));
     __m := UpdateLocal(__m, __frame + 18, __tmp);
@@ -250,17 +279,19 @@ Label_8:
     __m := UpdateLocal(__m, __frame + 19, __tmp);
 
     __ret0 := GetLocal(__m, __frame + 19);
+    debug#TestStruct#module_builtins#5#__ret := debug#TestStruct#module_builtins#5#__ret[Position(808) := __ret0];
     return;
 
 Label_Abort:
     __abort_flag := true;
     __m := __saved_m;
     __ret0 := DefaultValue;
+    debug#TestStruct#module_builtins#5#__ret := debug#TestStruct#module_builtins#5#__ret[Position(828) := __ret0];
 }
 
 procedure TestStruct_module_builtins_verify (a: Value) returns (__ret0: Value)
 {
-    assume ExistsTxnSenderAccount(__m, __txn);
+    call InitVerification();
     call __ret0 := TestStruct_module_builtins(a);
 }
 
@@ -297,16 +328,31 @@ ensures old(b#Boolean(Boolean(false))) ==> __abort_flag;
     var __tmp: Value;
     var __frame: int;
     var __saved_m: Memory;
+    var debug#TestStruct#nested_struct#0#a: [Position]Value;
+    var debug#TestStruct#nested_struct#1#var_a: [Position]Value;
+    var debug#TestStruct#nested_struct#2#var_b: [Position]Value;
+    var debug#TestStruct#nested_struct#3#var_b_ref: [Position]Value;
+    var debug#TestStruct#nested_struct#4#b_val_ref: [Position]Value;
+    var debug#TestStruct#nested_struct#5#b_val: [Position]Value;
+    var debug#TestStruct#nested_struct#6#__ret: [Position]Value;
 
     // initialize function execution
     assume !__abort_flag;
     __saved_m := __m;
     __frame := __local_counter;
     __local_counter := __local_counter + 24;
+    debug#TestStruct#nested_struct#0#a := EmptyPositionMap;
+    debug#TestStruct#nested_struct#1#var_a := EmptyPositionMap;
+    debug#TestStruct#nested_struct#2#var_b := EmptyPositionMap;
+    debug#TestStruct#nested_struct#3#var_b_ref := EmptyPositionMap;
+    debug#TestStruct#nested_struct#4#b_val_ref := EmptyPositionMap;
+    debug#TestStruct#nested_struct#5#b_val := EmptyPositionMap;
+    debug#TestStruct#nested_struct#6#__ret := EmptyPositionMap;
 
     // process and type check arguments
     assume is#Address(a);
     __m := UpdateLocal(__m, __frame + 0, a);
+    debug#TestStruct#nested_struct#0#a := debug#TestStruct#nested_struct#0#a[Position(835) := a];
 
     // bytecode translation starts here
     call __tmp := LdFalse();
@@ -326,6 +372,7 @@ ensures old(b#Boolean(Boolean(false))) ==> __abort_flag;
 
     call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 9));
     __m := UpdateLocal(__m, __frame + 2, __tmp);
+    debug#TestStruct#nested_struct#2#var_b := debug#TestStruct#nested_struct#2#var_b[Position(1076) := __tmp];
 
     goto Label_11;
 
@@ -341,6 +388,7 @@ Label_7:
 
     call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 12));
     __m := UpdateLocal(__m, __frame + 2, __tmp);
+    debug#TestStruct#nested_struct#2#var_b := debug#TestStruct#nested_struct#2#var_b[Position(1142) := __tmp];
 
 Label_11:
     call __t13 := BorrowLoc(__frame + 2);
@@ -361,6 +409,7 @@ Label_11:
 
     call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 17));
     __m := UpdateLocal(__m, __frame + 5, __tmp);
+    debug#TestStruct#nested_struct#5#b_val := debug#TestStruct#nested_struct#5#b_val[Position(1268) := __tmp];
 
     call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 5));
     __m := UpdateLocal(__m, __frame + 18, __tmp);
@@ -387,17 +436,19 @@ Label_26:
     __m := UpdateLocal(__m, __frame + 23, __tmp);
 
     __ret0 := GetLocal(__m, __frame + 23);
+    debug#TestStruct#nested_struct#6#__ret := debug#TestStruct#nested_struct#6#__ret[Position(1341) := __ret0];
     return;
 
 Label_Abort:
     __abort_flag := true;
     __m := __saved_m;
     __ret0 := DefaultValue;
+    debug#TestStruct#nested_struct#6#__ret := debug#TestStruct#nested_struct#6#__ret[Position(1365) := __ret0];
 }
 
 procedure TestStruct_nested_struct_verify (a: Value) returns (__ret0: Value)
 {
-    assume ExistsTxnSenderAccount(__m, __txn);
+    call InitVerification();
     call __ret0 := TestStruct_nested_struct(a);
 }
 
@@ -426,16 +477,27 @@ ensures old(b#Boolean(Boolean(false))) ==> __abort_flag;
     var __tmp: Value;
     var __frame: int;
     var __saved_m: Memory;
+    var debug#TestStruct#try_unpack#0#a: [Position]Value;
+    var debug#TestStruct#try_unpack#1#v: [Position]Value;
+    var debug#TestStruct#try_unpack#2#b: [Position]Value;
+    var debug#TestStruct#try_unpack#3#aa: [Position]Value;
+    var debug#TestStruct#try_unpack#4#__ret: [Position]Value;
 
     // initialize function execution
     assume !__abort_flag;
     __saved_m := __m;
     __frame := __local_counter;
     __local_counter := __local_counter + 16;
+    debug#TestStruct#try_unpack#0#a := EmptyPositionMap;
+    debug#TestStruct#try_unpack#1#v := EmptyPositionMap;
+    debug#TestStruct#try_unpack#2#b := EmptyPositionMap;
+    debug#TestStruct#try_unpack#3#aa := EmptyPositionMap;
+    debug#TestStruct#try_unpack#4#__ret := EmptyPositionMap;
 
     // process and type check arguments
     assume is#Address(a);
     __m := UpdateLocal(__m, __frame + 0, a);
+    debug#TestStruct#try_unpack#0#a := debug#TestStruct#try_unpack#0#a[Position(1372) := a];
 
     // bytecode translation starts here
     call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 0));
@@ -449,6 +511,7 @@ ensures old(b#Boolean(Boolean(false))) ==> __abort_flag;
 
     call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 6));
     __m := UpdateLocal(__m, __frame + 2, __tmp);
+    debug#TestStruct#try_unpack#2#b := debug#TestStruct#try_unpack#2#b[Position(1509) := __tmp];
 
     call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 2));
     __m := UpdateLocal(__m, __frame + 7, __tmp);
@@ -459,9 +522,11 @@ ensures old(b#Boolean(Boolean(false))) ==> __abort_flag;
 
     call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 9));
     __m := UpdateLocal(__m, __frame + 1, __tmp);
+    debug#TestStruct#try_unpack#1#v := debug#TestStruct#try_unpack#1#v[Position(1559) := __tmp];
 
     call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 8));
     __m := UpdateLocal(__m, __frame + 3, __tmp);
+    debug#TestStruct#try_unpack#3#aa := debug#TestStruct#try_unpack#3#aa[Position(1555) := __tmp];
 
     call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 0));
     __m := UpdateLocal(__m, __frame + 10, __tmp);
@@ -488,16 +553,18 @@ Label_15:
     __m := UpdateLocal(__m, __frame + 15, __tmp);
 
     __ret0 := GetLocal(__m, __frame + 15);
+    debug#TestStruct#try_unpack#4#__ret := debug#TestStruct#try_unpack#4#__ret[Position(1622) := __ret0];
     return;
 
 Label_Abort:
     __abort_flag := true;
     __m := __saved_m;
     __ret0 := DefaultValue;
+    debug#TestStruct#try_unpack#4#__ret := debug#TestStruct#try_unpack#4#__ret[Position(1642) := __ret0];
 }
 
 procedure TestStruct_try_unpack_verify (a: Value) returns (__ret0: Value)
 {
-    assume ExistsTxnSenderAccount(__m, __txn);
+    call InitVerification();
     call __ret0 := TestStruct_try_unpack(a);
 }

--- a/language/move-prover/bytecode-to-boogie/tests/goldenfiles/test3.bpl
+++ b/language/move-prover/bytecode-to-boogie/tests/goldenfiles/test3.bpl
@@ -96,16 +96,35 @@ ensures old(b#Boolean(Boolean(false))) ==> __abort_flag;
     var __tmp: Value;
     var __frame: int;
     var __saved_m: Memory;
+    var debug#Test3#test3#0#flag: [Position]Value;
+    var debug#Test3#test3#1#x: [Position]Value;
+    var debug#Test3#test3#2#x_ref: [Position]Value;
+    var debug#Test3#test3#3#f_or_g_ref: [Position]Value;
+    var debug#Test3#test3#4#f_or_g_ref2: [Position]Value;
+    var debug#Test3#test3#5#f_ref: [Position]Value;
+    var debug#Test3#test3#6#g_ref: [Position]Value;
+    var debug#Test3#test3#7#f: [Position]Value;
+    var debug#Test3#test3#8#g: [Position]Value;
 
     // initialize function execution
     assume !__abort_flag;
     __saved_m := __m;
     __frame := __local_counter;
     __local_counter := __local_counter + 57;
+    debug#Test3#test3#0#flag := EmptyPositionMap;
+    debug#Test3#test3#1#x := EmptyPositionMap;
+    debug#Test3#test3#2#x_ref := EmptyPositionMap;
+    debug#Test3#test3#3#f_or_g_ref := EmptyPositionMap;
+    debug#Test3#test3#4#f_or_g_ref2 := EmptyPositionMap;
+    debug#Test3#test3#5#f_ref := EmptyPositionMap;
+    debug#Test3#test3#6#g_ref := EmptyPositionMap;
+    debug#Test3#test3#7#f := EmptyPositionMap;
+    debug#Test3#test3#8#g := EmptyPositionMap;
 
     // process and type check arguments
     assume is#Boolean(flag);
     __m := UpdateLocal(__m, __frame + 0, flag);
+    debug#Test3#test3#0#flag := debug#Test3#test3#0#flag[Position(53) := flag];
 
     // bytecode translation starts here
     call __tmp := LdConst(0);
@@ -119,6 +138,7 @@ ensures old(b#Boolean(Boolean(false))) ==> __abort_flag;
 
     call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 11));
     __m := UpdateLocal(__m, __frame + 1, __tmp);
+    debug#Test3#test3#1#x := debug#Test3#test3#1#x[Position(267) := __tmp];
 
     call __t12 := BorrowLoc(__frame + 1);
 
@@ -152,6 +172,7 @@ Label_15:
     call __t19 := CopyOrMoveRef(f_or_g_ref);
 
     call WriteRef(__t19, GetLocal(__m, __frame + 18));
+    debug#Test3#test3#1#x := debug#Test3#test3#1#x[Position(417) := GetLocal(__m, __frame + 1)];
 
     call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 0));
     __m := UpdateLocal(__m, __frame + 20, __tmp);
@@ -184,6 +205,7 @@ Label_28:
     call __t27 := CopyOrMoveRef(f_or_g_ref2);
 
     call WriteRef(__t27, GetLocal(__m, __frame + 26));
+    debug#Test3#test3#1#x := debug#Test3#test3#1#x[Position(555) := GetLocal(__m, __frame + 1)];
 
     call __t28 := CopyOrMoveRef(x_ref);
 
@@ -205,6 +227,7 @@ Label_28:
 
     call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 33));
     __m := UpdateLocal(__m, __frame + 7, __tmp);
+    debug#Test3#test3#7#f := debug#Test3#test3#7#f[Position(635) := __tmp];
 
     call __t34 := CopyOrMoveRef(g_ref);
 
@@ -214,6 +237,7 @@ Label_28:
 
     call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 35));
     __m := UpdateLocal(__m, __frame + 8, __tmp);
+    debug#Test3#test3#8#g := debug#Test3#test3#8#g[Position(655) := __tmp];
 
     call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 0));
     __m := UpdateLocal(__m, __frame + 36, __tmp);
@@ -317,6 +341,6 @@ Label_Abort:
 
 procedure Test3_test3_verify (flag: Value) returns ()
 {
-    assume ExistsTxnSenderAccount(__m, __txn);
+    call InitVerification();
     call Test3_test3(flag);
 }

--- a/language/move-prover/bytecode-to-boogie/tests/goldenfiles/verify-addition.bpl
+++ b/language/move-prover/bytecode-to-boogie/tests/goldenfiles/verify-addition.bpl
@@ -19,18 +19,26 @@ ensures old(b#Boolean(Boolean(false))) ==> __abort_flag;
     var __tmp: Value;
     var __frame: int;
     var __saved_m: Memory;
+    var debug#TestAddition#overflow_u8_add_bad#0#x: [Position]Value;
+    var debug#TestAddition#overflow_u8_add_bad#1#y: [Position]Value;
+    var debug#TestAddition#overflow_u8_add_bad#2#__ret: [Position]Value;
 
     // initialize function execution
     assume !__abort_flag;
     __saved_m := __m;
     __frame := __local_counter;
     __local_counter := __local_counter + 5;
+    debug#TestAddition#overflow_u8_add_bad#0#x := EmptyPositionMap;
+    debug#TestAddition#overflow_u8_add_bad#1#y := EmptyPositionMap;
+    debug#TestAddition#overflow_u8_add_bad#2#__ret := EmptyPositionMap;
 
     // process and type check arguments
     assume IsValidU8(x);
     __m := UpdateLocal(__m, __frame + 0, x);
+    debug#TestAddition#overflow_u8_add_bad#0#x := debug#TestAddition#overflow_u8_add_bad#0#x[Position(72) := x];
     assume IsValidU8(y);
     __m := UpdateLocal(__m, __frame + 1, y);
+    debug#TestAddition#overflow_u8_add_bad#1#y := debug#TestAddition#overflow_u8_add_bad#1#y[Position(72) := y];
 
     // bytecode translation starts here
     call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 0));
@@ -44,17 +52,19 @@ ensures old(b#Boolean(Boolean(false))) ==> __abort_flag;
     __m := UpdateLocal(__m, __frame + 4, __tmp);
 
     __ret0 := GetLocal(__m, __frame + 4);
+    debug#TestAddition#overflow_u8_add_bad#2#__ret := debug#TestAddition#overflow_u8_add_bad#2#__ret[Position(188) := __ret0];
     return;
 
 Label_Abort:
     __abort_flag := true;
     __m := __saved_m;
     __ret0 := DefaultValue;
+    debug#TestAddition#overflow_u8_add_bad#2#__ret := debug#TestAddition#overflow_u8_add_bad#2#__ret[Position(218) := __ret0];
 }
 
 procedure TestAddition_overflow_u8_add_bad_verify (x: Value, y: Value) returns (__ret0: Value)
 {
-    assume ExistsTxnSenderAccount(__m, __txn);
+    call InitVerification();
     call __ret0 := TestAddition_overflow_u8_add_bad(x, y);
 }
 
@@ -71,18 +81,26 @@ ensures old(b#Boolean(Boolean(i#Integer(Integer(i#Integer(x) + i#Integer(y))) > 
     var __tmp: Value;
     var __frame: int;
     var __saved_m: Memory;
+    var debug#TestAddition#overflow_u8_add_ok#0#x: [Position]Value;
+    var debug#TestAddition#overflow_u8_add_ok#1#y: [Position]Value;
+    var debug#TestAddition#overflow_u8_add_ok#2#__ret: [Position]Value;
 
     // initialize function execution
     assume !__abort_flag;
     __saved_m := __m;
     __frame := __local_counter;
     __local_counter := __local_counter + 5;
+    debug#TestAddition#overflow_u8_add_ok#0#x := EmptyPositionMap;
+    debug#TestAddition#overflow_u8_add_ok#1#y := EmptyPositionMap;
+    debug#TestAddition#overflow_u8_add_ok#2#__ret := EmptyPositionMap;
 
     // process and type check arguments
     assume IsValidU8(x);
     __m := UpdateLocal(__m, __frame + 0, x);
+    debug#TestAddition#overflow_u8_add_ok#0#x := debug#TestAddition#overflow_u8_add_ok#0#x[Position(270) := x];
     assume IsValidU8(y);
     __m := UpdateLocal(__m, __frame + 1, y);
+    debug#TestAddition#overflow_u8_add_ok#1#y := debug#TestAddition#overflow_u8_add_ok#1#y[Position(270) := y];
 
     // bytecode translation starts here
     call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 0));
@@ -96,17 +114,19 @@ ensures old(b#Boolean(Boolean(i#Integer(Integer(i#Integer(x) + i#Integer(y))) > 
     __m := UpdateLocal(__m, __frame + 4, __tmp);
 
     __ret0 := GetLocal(__m, __frame + 4);
+    debug#TestAddition#overflow_u8_add_ok#2#__ret := debug#TestAddition#overflow_u8_add_ok#2#__ret[Position(370) := __ret0];
     return;
 
 Label_Abort:
     __abort_flag := true;
     __m := __saved_m;
     __ret0 := DefaultValue;
+    debug#TestAddition#overflow_u8_add_ok#2#__ret := debug#TestAddition#overflow_u8_add_ok#2#__ret[Position(400) := __ret0];
 }
 
 procedure TestAddition_overflow_u8_add_ok_verify (x: Value, y: Value) returns (__ret0: Value)
 {
-    assume ExistsTxnSenderAccount(__m, __txn);
+    call InitVerification();
     call __ret0 := TestAddition_overflow_u8_add_ok(x, y);
 }
 
@@ -123,18 +143,26 @@ ensures old(b#Boolean(Boolean(false))) ==> __abort_flag;
     var __tmp: Value;
     var __frame: int;
     var __saved_m: Memory;
+    var debug#TestAddition#overflow_u64_add_bad#0#x: [Position]Value;
+    var debug#TestAddition#overflow_u64_add_bad#1#y: [Position]Value;
+    var debug#TestAddition#overflow_u64_add_bad#2#__ret: [Position]Value;
 
     // initialize function execution
     assume !__abort_flag;
     __saved_m := __m;
     __frame := __local_counter;
     __local_counter := __local_counter + 5;
+    debug#TestAddition#overflow_u64_add_bad#0#x := EmptyPositionMap;
+    debug#TestAddition#overflow_u64_add_bad#1#y := EmptyPositionMap;
+    debug#TestAddition#overflow_u64_add_bad#2#__ret := EmptyPositionMap;
 
     // process and type check arguments
     assume IsValidU64(x);
     __m := UpdateLocal(__m, __frame + 0, x);
+    debug#TestAddition#overflow_u64_add_bad#0#x := debug#TestAddition#overflow_u64_add_bad#0#x[Position(452) := x];
     assume IsValidU64(y);
     __m := UpdateLocal(__m, __frame + 1, y);
+    debug#TestAddition#overflow_u64_add_bad#1#y := debug#TestAddition#overflow_u64_add_bad#1#y[Position(452) := y];
 
     // bytecode translation starts here
     call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 0));
@@ -148,17 +176,19 @@ ensures old(b#Boolean(Boolean(false))) ==> __abort_flag;
     __m := UpdateLocal(__m, __frame + 4, __tmp);
 
     __ret0 := GetLocal(__m, __frame + 4);
+    debug#TestAddition#overflow_u64_add_bad#2#__ret := debug#TestAddition#overflow_u64_add_bad#2#__ret[Position(572) := __ret0];
     return;
 
 Label_Abort:
     __abort_flag := true;
     __m := __saved_m;
     __ret0 := DefaultValue;
+    debug#TestAddition#overflow_u64_add_bad#2#__ret := debug#TestAddition#overflow_u64_add_bad#2#__ret[Position(602) := __ret0];
 }
 
 procedure TestAddition_overflow_u64_add_bad_verify (x: Value, y: Value) returns (__ret0: Value)
 {
-    assume ExistsTxnSenderAccount(__m, __txn);
+    call InitVerification();
     call __ret0 := TestAddition_overflow_u64_add_bad(x, y);
 }
 
@@ -175,18 +205,26 @@ ensures old(b#Boolean(Boolean(i#Integer(Integer(i#Integer(x) + i#Integer(y))) > 
     var __tmp: Value;
     var __frame: int;
     var __saved_m: Memory;
+    var debug#TestAddition#overflow_u64_add_ok#0#x: [Position]Value;
+    var debug#TestAddition#overflow_u64_add_ok#1#y: [Position]Value;
+    var debug#TestAddition#overflow_u64_add_ok#2#__ret: [Position]Value;
 
     // initialize function execution
     assume !__abort_flag;
     __saved_m := __m;
     __frame := __local_counter;
     __local_counter := __local_counter + 5;
+    debug#TestAddition#overflow_u64_add_ok#0#x := EmptyPositionMap;
+    debug#TestAddition#overflow_u64_add_ok#1#y := EmptyPositionMap;
+    debug#TestAddition#overflow_u64_add_ok#2#__ret := EmptyPositionMap;
 
     // process and type check arguments
     assume IsValidU64(x);
     __m := UpdateLocal(__m, __frame + 0, x);
+    debug#TestAddition#overflow_u64_add_ok#0#x := debug#TestAddition#overflow_u64_add_ok#0#x[Position(654) := x];
     assume IsValidU64(y);
     __m := UpdateLocal(__m, __frame + 1, y);
+    debug#TestAddition#overflow_u64_add_ok#1#y := debug#TestAddition#overflow_u64_add_ok#1#y[Position(654) := y];
 
     // bytecode translation starts here
     call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 0));
@@ -200,17 +238,19 @@ ensures old(b#Boolean(Boolean(i#Integer(Integer(i#Integer(x) + i#Integer(y))) > 
     __m := UpdateLocal(__m, __frame + 4, __tmp);
 
     __ret0 := GetLocal(__m, __frame + 4);
+    debug#TestAddition#overflow_u64_add_ok#2#__ret := debug#TestAddition#overflow_u64_add_ok#2#__ret[Position(773) := __ret0];
     return;
 
 Label_Abort:
     __abort_flag := true;
     __m := __saved_m;
     __ret0 := DefaultValue;
+    debug#TestAddition#overflow_u64_add_ok#2#__ret := debug#TestAddition#overflow_u64_add_ok#2#__ret[Position(803) := __ret0];
 }
 
 procedure TestAddition_overflow_u64_add_ok_verify (x: Value, y: Value) returns (__ret0: Value)
 {
-    assume ExistsTxnSenderAccount(__m, __txn);
+    call InitVerification();
     call __ret0 := TestAddition_overflow_u64_add_ok(x, y);
 }
 
@@ -227,18 +267,26 @@ ensures old(b#Boolean(Boolean(false))) ==> __abort_flag;
     var __tmp: Value;
     var __frame: int;
     var __saved_m: Memory;
+    var debug#TestAddition#overflow_u128_add_bad#0#x: [Position]Value;
+    var debug#TestAddition#overflow_u128_add_bad#1#y: [Position]Value;
+    var debug#TestAddition#overflow_u128_add_bad#2#__ret: [Position]Value;
 
     // initialize function execution
     assume !__abort_flag;
     __saved_m := __m;
     __frame := __local_counter;
     __local_counter := __local_counter + 5;
+    debug#TestAddition#overflow_u128_add_bad#0#x := EmptyPositionMap;
+    debug#TestAddition#overflow_u128_add_bad#1#y := EmptyPositionMap;
+    debug#TestAddition#overflow_u128_add_bad#2#__ret := EmptyPositionMap;
 
     // process and type check arguments
     assume IsValidU128(x);
     __m := UpdateLocal(__m, __frame + 0, x);
+    debug#TestAddition#overflow_u128_add_bad#0#x := debug#TestAddition#overflow_u128_add_bad#0#x[Position(855) := x];
     assume IsValidU128(y);
     __m := UpdateLocal(__m, __frame + 1, y);
+    debug#TestAddition#overflow_u128_add_bad#1#y := debug#TestAddition#overflow_u128_add_bad#1#y[Position(855) := y];
 
     // bytecode translation starts here
     call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 0));
@@ -252,16 +300,18 @@ ensures old(b#Boolean(Boolean(false))) ==> __abort_flag;
     __m := UpdateLocal(__m, __frame + 4, __tmp);
 
     __ret0 := GetLocal(__m, __frame + 4);
+    debug#TestAddition#overflow_u128_add_bad#2#__ret := debug#TestAddition#overflow_u128_add_bad#2#__ret[Position(979) := __ret0];
     return;
 
 Label_Abort:
     __abort_flag := true;
     __m := __saved_m;
     __ret0 := DefaultValue;
+    debug#TestAddition#overflow_u128_add_bad#2#__ret := debug#TestAddition#overflow_u128_add_bad#2#__ret[Position(1009) := __ret0];
 }
 
 procedure TestAddition_overflow_u128_add_bad_verify (x: Value, y: Value) returns (__ret0: Value)
 {
-    assume ExistsTxnSenderAccount(__m, __txn);
+    call InitVerification();
     call __ret0 := TestAddition_overflow_u128_add_bad(x, y);
 }

--- a/language/move-prover/bytecode-to-boogie/tests/goldenfiles/verify-cast.bpl
+++ b/language/move-prover/bytecode-to-boogie/tests/goldenfiles/verify-cast.bpl
@@ -18,16 +18,21 @@ ensures old(b#Boolean(Boolean(false))) ==> __abort_flag;
     var __tmp: Value;
     var __frame: int;
     var __saved_m: Memory;
+    var debug#CastBad#aborting_u8_cast_bad#0#x: [Position]Value;
+    var debug#CastBad#aborting_u8_cast_bad#1#__ret: [Position]Value;
 
     // initialize function execution
     assume !__abort_flag;
     __saved_m := __m;
     __frame := __local_counter;
     __local_counter := __local_counter + 3;
+    debug#CastBad#aborting_u8_cast_bad#0#x := EmptyPositionMap;
+    debug#CastBad#aborting_u8_cast_bad#1#__ret := EmptyPositionMap;
 
     // process and type check arguments
     assume IsValidU64(x);
     __m := UpdateLocal(__m, __frame + 0, x);
+    debug#CastBad#aborting_u8_cast_bad#0#x := debug#CastBad#aborting_u8_cast_bad#0#x[Position(71) := x];
 
     // bytecode translation starts here
     call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 0));
@@ -38,17 +43,19 @@ ensures old(b#Boolean(Boolean(false))) ==> __abort_flag;
     __m := UpdateLocal(__m, __frame + 2, __tmp);
 
     __ret0 := GetLocal(__m, __frame + 2);
+    debug#CastBad#aborting_u8_cast_bad#1#__ret := debug#CastBad#aborting_u8_cast_bad#1#__ret[Position(182) := __ret0];
     return;
 
 Label_Abort:
     __abort_flag := true;
     __m := __saved_m;
     __ret0 := DefaultValue;
+    debug#CastBad#aborting_u8_cast_bad#1#__ret := debug#CastBad#aborting_u8_cast_bad#1#__ret[Position(209) := __ret0];
 }
 
 procedure CastBad_aborting_u8_cast_bad_verify (x: Value) returns (__ret0: Value)
 {
-    assume ExistsTxnSenderAccount(__m, __txn);
+    call InitVerification();
     call __ret0 := CastBad_aborting_u8_cast_bad(x);
 }
 
@@ -64,16 +71,21 @@ ensures old(b#Boolean(Boolean(i#Integer(x) > i#Integer(Integer(255))))) ==> __ab
     var __tmp: Value;
     var __frame: int;
     var __saved_m: Memory;
+    var debug#CastBad#aborting_u8_cast_ok#0#x: [Position]Value;
+    var debug#CastBad#aborting_u8_cast_ok#1#__ret: [Position]Value;
 
     // initialize function execution
     assume !__abort_flag;
     __saved_m := __m;
     __frame := __local_counter;
     __local_counter := __local_counter + 3;
+    debug#CastBad#aborting_u8_cast_ok#0#x := EmptyPositionMap;
+    debug#CastBad#aborting_u8_cast_ok#1#__ret := EmptyPositionMap;
 
     // process and type check arguments
     assume IsValidU64(x);
     __m := UpdateLocal(__m, __frame + 0, x);
+    debug#CastBad#aborting_u8_cast_ok#0#x := debug#CastBad#aborting_u8_cast_ok#0#x[Position(261) := x];
 
     // bytecode translation starts here
     call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 0));
@@ -84,17 +96,19 @@ ensures old(b#Boolean(Boolean(i#Integer(x) > i#Integer(Integer(255))))) ==> __ab
     __m := UpdateLocal(__m, __frame + 2, __tmp);
 
     __ret0 := GetLocal(__m, __frame + 2);
+    debug#CastBad#aborting_u8_cast_ok#1#__ret := debug#CastBad#aborting_u8_cast_ok#1#__ret[Position(350) := __ret0];
     return;
 
 Label_Abort:
     __abort_flag := true;
     __m := __saved_m;
     __ret0 := DefaultValue;
+    debug#CastBad#aborting_u8_cast_ok#1#__ret := debug#CastBad#aborting_u8_cast_ok#1#__ret[Position(377) := __ret0];
 }
 
 procedure CastBad_aborting_u8_cast_ok_verify (x: Value) returns (__ret0: Value)
 {
-    assume ExistsTxnSenderAccount(__m, __txn);
+    call InitVerification();
     call __ret0 := CastBad_aborting_u8_cast_ok(x);
 }
 
@@ -110,16 +124,21 @@ ensures old(b#Boolean(Boolean(false))) ==> __abort_flag;
     var __tmp: Value;
     var __frame: int;
     var __saved_m: Memory;
+    var debug#CastBad#aborting_u64_cast_bad#0#x: [Position]Value;
+    var debug#CastBad#aborting_u64_cast_bad#1#__ret: [Position]Value;
 
     // initialize function execution
     assume !__abort_flag;
     __saved_m := __m;
     __frame := __local_counter;
     __local_counter := __local_counter + 3;
+    debug#CastBad#aborting_u64_cast_bad#0#x := EmptyPositionMap;
+    debug#CastBad#aborting_u64_cast_bad#1#__ret := EmptyPositionMap;
 
     // process and type check arguments
     assume IsValidU128(x);
     __m := UpdateLocal(__m, __frame + 0, x);
+    debug#CastBad#aborting_u64_cast_bad#0#x := debug#CastBad#aborting_u64_cast_bad#0#x[Position(433) := x];
 
     // bytecode translation starts here
     call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 0));
@@ -130,17 +149,19 @@ ensures old(b#Boolean(Boolean(false))) ==> __abort_flag;
     __m := UpdateLocal(__m, __frame + 2, __tmp);
 
     __ret0 := GetLocal(__m, __frame + 2);
+    debug#CastBad#aborting_u64_cast_bad#1#__ret := debug#CastBad#aborting_u64_cast_bad#1#__ret[Position(547) := __ret0];
     return;
 
 Label_Abort:
     __abort_flag := true;
     __m := __saved_m;
     __ret0 := DefaultValue;
+    debug#CastBad#aborting_u64_cast_bad#1#__ret := debug#CastBad#aborting_u64_cast_bad#1#__ret[Position(575) := __ret0];
 }
 
 procedure CastBad_aborting_u64_cast_bad_verify (x: Value) returns (__ret0: Value)
 {
-    assume ExistsTxnSenderAccount(__m, __txn);
+    call InitVerification();
     call __ret0 := CastBad_aborting_u64_cast_bad(x);
 }
 
@@ -156,16 +177,21 @@ ensures old(b#Boolean(Boolean(i#Integer(x) > i#Integer(Integer(92233720368547758
     var __tmp: Value;
     var __frame: int;
     var __saved_m: Memory;
+    var debug#CastBad#aborting_u64_cast_ok#0#x: [Position]Value;
+    var debug#CastBad#aborting_u64_cast_ok#1#__ret: [Position]Value;
 
     // initialize function execution
     assume !__abort_flag;
     __saved_m := __m;
     __frame := __local_counter;
     __local_counter := __local_counter + 3;
+    debug#CastBad#aborting_u64_cast_ok#0#x := EmptyPositionMap;
+    debug#CastBad#aborting_u64_cast_ok#1#__ret := EmptyPositionMap;
 
     // process and type check arguments
     assume IsValidU128(x);
     __m := UpdateLocal(__m, __frame + 0, x);
+    debug#CastBad#aborting_u64_cast_ok#0#x := debug#CastBad#aborting_u64_cast_ok#0#x[Position(627) := x];
 
     // bytecode translation starts here
     call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 0));
@@ -176,16 +202,18 @@ ensures old(b#Boolean(Boolean(i#Integer(x) > i#Integer(Integer(92233720368547758
     __m := UpdateLocal(__m, __frame + 2, __tmp);
 
     __ret0 := GetLocal(__m, __frame + 2);
+    debug#CastBad#aborting_u64_cast_ok#1#__ret := debug#CastBad#aborting_u64_cast_ok#1#__ret[Position(755) := __ret0];
     return;
 
 Label_Abort:
     __abort_flag := true;
     __m := __saved_m;
     __ret0 := DefaultValue;
+    debug#CastBad#aborting_u64_cast_ok#1#__ret := debug#CastBad#aborting_u64_cast_ok#1#__ret[Position(783) := __ret0];
 }
 
 procedure CastBad_aborting_u64_cast_ok_verify (x: Value) returns (__ret0: Value)
 {
-    assume ExistsTxnSenderAccount(__m, __txn);
+    call InitVerification();
     call __ret0 := CastBad_aborting_u64_cast_ok(x);
 }

--- a/language/move-prover/bytecode-to-boogie/tests/goldenfiles/verify-create-resource.bpl
+++ b/language/move-prover/bytecode-to-boogie/tests/goldenfiles/verify-create-resource.bpl
@@ -84,7 +84,7 @@ Label_Abort:
 
 procedure TestSpecs_create_resource_verify () returns ()
 {
-    assume ExistsTxnSenderAccount(__m, __txn);
+    call InitVerification();
     call TestSpecs_create_resource();
 }
 
@@ -136,6 +136,6 @@ Label_Abort:
 
 procedure TestSpecs_create_resource_error_verify () returns ()
 {
-    assume ExistsTxnSenderAccount(__m, __txn);
+    call InitVerification();
     call TestSpecs_create_resource_error();
 }

--- a/language/move-prover/bytecode-to-boogie/tests/goldenfiles/verify-div.bpl
+++ b/language/move-prover/bytecode-to-boogie/tests/goldenfiles/verify-div.bpl
@@ -19,18 +19,28 @@ ensures old(b#Boolean(Boolean(i#Integer(y) > i#Integer(Integer(0))))) ==> !__abo
     var __tmp: Value;
     var __frame: int;
     var __saved_m: Memory;
+    var debug#TestSpecs#div#0#x: [Position]Value;
+    var debug#TestSpecs#div#1#y: [Position]Value;
+    var debug#TestSpecs#div#2#r: [Position]Value;
+    var debug#TestSpecs#div#3#__ret: [Position]Value;
 
     // initialize function execution
     assume !__abort_flag;
     __saved_m := __m;
     __frame := __local_counter;
     __local_counter := __local_counter + 7;
+    debug#TestSpecs#div#0#x := EmptyPositionMap;
+    debug#TestSpecs#div#1#y := EmptyPositionMap;
+    debug#TestSpecs#div#2#r := EmptyPositionMap;
+    debug#TestSpecs#div#3#__ret := EmptyPositionMap;
 
     // process and type check arguments
     assume IsValidU64(x);
     __m := UpdateLocal(__m, __frame + 0, x);
+    debug#TestSpecs#div#0#x := debug#TestSpecs#div#0#x[Position(24) := x];
     assume IsValidU64(y);
     __m := UpdateLocal(__m, __frame + 1, y);
+    debug#TestSpecs#div#1#y := debug#TestSpecs#div#1#y[Position(24) := y];
 
     // bytecode translation starts here
     call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 0));
@@ -45,22 +55,25 @@ ensures old(b#Boolean(Boolean(i#Integer(y) > i#Integer(Integer(0))))) ==> !__abo
 
     call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 5));
     __m := UpdateLocal(__m, __frame + 2, __tmp);
+    debug#TestSpecs#div#2#r := debug#TestSpecs#div#2#r[Position(247) := __tmp];
 
     call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 2));
     __m := UpdateLocal(__m, __frame + 6, __tmp);
 
     __ret0 := GetLocal(__m, __frame + 6);
+    debug#TestSpecs#div#3#__ret := debug#TestSpecs#div#3#__ret[Position(276) := __ret0];
     return;
 
 Label_Abort:
     __abort_flag := true;
     __m := __saved_m;
     __ret0 := DefaultValue;
+    debug#TestSpecs#div#3#__ret := debug#TestSpecs#div#3#__ret[Position(296) := __ret0];
 }
 
 procedure TestSpecs_div_verify (x: Value, y: Value) returns (__ret0: Value)
 {
-    assume ExistsTxnSenderAccount(__m, __txn);
+    call InitVerification();
     call __ret0 := TestSpecs_div(x, y);
 }
 
@@ -77,18 +90,28 @@ ensures old(b#Boolean(Boolean(true))) ==> !__abort_flag;
     var __tmp: Value;
     var __frame: int;
     var __saved_m: Memory;
+    var debug#TestSpecs#div_by_zero_detected#0#x: [Position]Value;
+    var debug#TestSpecs#div_by_zero_detected#1#y: [Position]Value;
+    var debug#TestSpecs#div_by_zero_detected#2#r: [Position]Value;
+    var debug#TestSpecs#div_by_zero_detected#3#__ret: [Position]Value;
 
     // initialize function execution
     assume !__abort_flag;
     __saved_m := __m;
     __frame := __local_counter;
     __local_counter := __local_counter + 7;
+    debug#TestSpecs#div_by_zero_detected#0#x := EmptyPositionMap;
+    debug#TestSpecs#div_by_zero_detected#1#y := EmptyPositionMap;
+    debug#TestSpecs#div_by_zero_detected#2#r := EmptyPositionMap;
+    debug#TestSpecs#div_by_zero_detected#3#__ret := EmptyPositionMap;
 
     // process and type check arguments
     assume IsValidU64(x);
     __m := UpdateLocal(__m, __frame + 0, x);
+    debug#TestSpecs#div_by_zero_detected#0#x := debug#TestSpecs#div_by_zero_detected#0#x[Position(303) := x];
     assume IsValidU64(y);
     __m := UpdateLocal(__m, __frame + 1, y);
+    debug#TestSpecs#div_by_zero_detected#1#y := debug#TestSpecs#div_by_zero_detected#1#y[Position(303) := y];
 
     // bytecode translation starts here
     call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 0));
@@ -103,21 +126,24 @@ ensures old(b#Boolean(Boolean(true))) ==> !__abort_flag;
 
     call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 5));
     __m := UpdateLocal(__m, __frame + 2, __tmp);
+    debug#TestSpecs#div_by_zero_detected#2#r := debug#TestSpecs#div_by_zero_detected#2#r[Position(567) := __tmp];
 
     call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 2));
     __m := UpdateLocal(__m, __frame + 6, __tmp);
 
     __ret0 := GetLocal(__m, __frame + 6);
+    debug#TestSpecs#div_by_zero_detected#3#__ret := debug#TestSpecs#div_by_zero_detected#3#__ret[Position(627) := __ret0];
     return;
 
 Label_Abort:
     __abort_flag := true;
     __m := __saved_m;
     __ret0 := DefaultValue;
+    debug#TestSpecs#div_by_zero_detected#3#__ret := debug#TestSpecs#div_by_zero_detected#3#__ret[Position(647) := __ret0];
 }
 
 procedure TestSpecs_div_by_zero_detected_verify (x: Value, y: Value) returns (__ret0: Value)
 {
-    assume ExistsTxnSenderAccount(__m, __txn);
+    call InitVerification();
     call __ret0 := TestSpecs_div_by_zero_detected(x, y);
 }

--- a/language/move-prover/bytecode-to-boogie/tests/goldenfiles/verify-local-ref.bpl
+++ b/language/move-prover/bytecode-to-boogie/tests/goldenfiles/verify-local-ref.bpl
@@ -15,16 +15,19 @@ requires ExistsTxnSenderAccount(__m, __txn);
     var __tmp: Value;
     var __frame: int;
     var __saved_m: Memory;
+    var debug#TestSpecs#mut_b#0#b: [Position]Value;
 
     // initialize function execution
     assume !__abort_flag;
     __saved_m := __m;
     __frame := __local_counter;
     __local_counter := __local_counter + 3;
+    debug#TestSpecs#mut_b#0#b := EmptyPositionMap;
 
     // process and type check arguments
     assume IsValidU64(Dereference(__m, b));
     assume IsValidReferenceParameter(__m, __frame, b);
+    debug#TestSpecs#mut_b#0#b := debug#TestSpecs#mut_b#0#b[Position(24) := Dereference(__m, b)];
 
     // bytecode translation starts here
     call __tmp := LdConst(10);
@@ -43,7 +46,7 @@ Label_Abort:
 
 procedure TestSpecs_mut_b_verify (b: Reference) returns ()
 {
-    assume ExistsTxnSenderAccount(__m, __txn);
+    call InitVerification();
     call TestSpecs_mut_b(b);
 }
 
@@ -67,12 +70,16 @@ ensures old(b#Boolean(Boolean(true))) ==> !__abort_flag;
     var __tmp: Value;
     var __frame: int;
     var __saved_m: Memory;
+    var debug#TestSpecs#mut_ref#0#b: [Position]Value;
+    var debug#TestSpecs#mut_ref#1#b_ref: [Position]Value;
 
     // initialize function execution
     assume !__abort_flag;
     __saved_m := __m;
     __frame := __local_counter;
     __local_counter := __local_counter + 12;
+    debug#TestSpecs#mut_ref#0#b := EmptyPositionMap;
+    debug#TestSpecs#mut_ref#1#b_ref := EmptyPositionMap;
 
     // process and type check arguments
 
@@ -82,6 +89,7 @@ ensures old(b#Boolean(Boolean(true))) ==> !__abort_flag;
 
     call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 2));
     __m := UpdateLocal(__m, __frame + 0, __tmp);
+    debug#TestSpecs#mut_ref#0#b := debug#TestSpecs#mut_ref#0#b[Position(252) := __tmp];
 
     call __t3 := BorrowLoc(__frame + 0);
 
@@ -91,6 +99,7 @@ ensures old(b#Boolean(Boolean(true))) ==> !__abort_flag;
 
     call TestSpecs_mut_b(__t4);
     if (__abort_flag) { goto Label_Abort; }
+    debug#TestSpecs#mut_ref#0#b := debug#TestSpecs#mut_ref#0#b[Position(349) := GetLocal(__m, __frame + 0)];
 
     call __t5 := CopyOrMoveRef(b_ref);
 
@@ -100,6 +109,7 @@ ensures old(b#Boolean(Boolean(true))) ==> !__abort_flag;
 
     call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 6));
     __m := UpdateLocal(__m, __frame + 0, __tmp);
+    debug#TestSpecs#mut_ref#0#b := debug#TestSpecs#mut_ref#0#b[Position(382) := __tmp];
 
     call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 0));
     __m := UpdateLocal(__m, __frame + 7, __tmp);
@@ -131,7 +141,7 @@ Label_Abort:
 
 procedure TestSpecs_mut_ref_verify () returns ()
 {
-    assume ExistsTxnSenderAccount(__m, __txn);
+    call InitVerification();
     call TestSpecs_mut_ref();
 }
 
@@ -155,12 +165,16 @@ ensures old(b#Boolean(Boolean(true))) ==> !__abort_flag;
     var __tmp: Value;
     var __frame: int;
     var __saved_m: Memory;
+    var debug#TestSpecs#mut_ref_failure#0#b: [Position]Value;
+    var debug#TestSpecs#mut_ref_failure#1#b_ref: [Position]Value;
 
     // initialize function execution
     assume !__abort_flag;
     __saved_m := __m;
     __frame := __local_counter;
     __local_counter := __local_counter + 12;
+    debug#TestSpecs#mut_ref_failure#0#b := EmptyPositionMap;
+    debug#TestSpecs#mut_ref_failure#1#b_ref := EmptyPositionMap;
 
     // process and type check arguments
 
@@ -170,6 +184,7 @@ ensures old(b#Boolean(Boolean(true))) ==> !__abort_flag;
 
     call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 2));
     __m := UpdateLocal(__m, __frame + 0, __tmp);
+    debug#TestSpecs#mut_ref_failure#0#b := debug#TestSpecs#mut_ref_failure#0#b[Position(621) := __tmp];
 
     call __t3 := BorrowLoc(__frame + 0);
 
@@ -179,6 +194,7 @@ ensures old(b#Boolean(Boolean(true))) ==> !__abort_flag;
 
     call TestSpecs_mut_b(__t4);
     if (__abort_flag) { goto Label_Abort; }
+    debug#TestSpecs#mut_ref_failure#0#b := debug#TestSpecs#mut_ref_failure#0#b[Position(661) := GetLocal(__m, __frame + 0)];
 
     call __t5 := CopyOrMoveRef(b_ref);
 
@@ -188,6 +204,7 @@ ensures old(b#Boolean(Boolean(true))) ==> !__abort_flag;
 
     call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 6));
     __m := UpdateLocal(__m, __frame + 0, __tmp);
+    debug#TestSpecs#mut_ref_failure#0#b := debug#TestSpecs#mut_ref_failure#0#b[Position(694) := __tmp];
 
     call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 0));
     __m := UpdateLocal(__m, __frame + 7, __tmp);
@@ -219,6 +236,6 @@ Label_Abort:
 
 procedure TestSpecs_mut_ref_failure_verify () returns ()
 {
-    assume ExistsTxnSenderAccount(__m, __txn);
+    call InitVerification();
     call TestSpecs_mut_ref_failure();
 }

--- a/language/move-prover/bytecode-to-boogie/tests/goldenfiles/verify-multiplication.bpl
+++ b/language/move-prover/bytecode-to-boogie/tests/goldenfiles/verify-multiplication.bpl
@@ -19,18 +19,26 @@ ensures old(b#Boolean(Boolean(false))) ==> __abort_flag;
     var __tmp: Value;
     var __frame: int;
     var __saved_m: Memory;
+    var debug#TestMultiplication#overflow_u8_mul_bad#0#x: [Position]Value;
+    var debug#TestMultiplication#overflow_u8_mul_bad#1#y: [Position]Value;
+    var debug#TestMultiplication#overflow_u8_mul_bad#2#__ret: [Position]Value;
 
     // initialize function execution
     assume !__abort_flag;
     __saved_m := __m;
     __frame := __local_counter;
     __local_counter := __local_counter + 5;
+    debug#TestMultiplication#overflow_u8_mul_bad#0#x := EmptyPositionMap;
+    debug#TestMultiplication#overflow_u8_mul_bad#1#y := EmptyPositionMap;
+    debug#TestMultiplication#overflow_u8_mul_bad#2#__ret := EmptyPositionMap;
 
     // process and type check arguments
     assume IsValidU8(x);
     __m := UpdateLocal(__m, __frame + 0, x);
+    debug#TestMultiplication#overflow_u8_mul_bad#0#x := debug#TestMultiplication#overflow_u8_mul_bad#0#x[Position(75) := x];
     assume IsValidU8(y);
     __m := UpdateLocal(__m, __frame + 1, y);
+    debug#TestMultiplication#overflow_u8_mul_bad#1#y := debug#TestMultiplication#overflow_u8_mul_bad#1#y[Position(75) := y];
 
     // bytecode translation starts here
     call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 0));
@@ -44,17 +52,19 @@ ensures old(b#Boolean(Boolean(false))) ==> __abort_flag;
     __m := UpdateLocal(__m, __frame + 4, __tmp);
 
     __ret0 := GetLocal(__m, __frame + 4);
+    debug#TestMultiplication#overflow_u8_mul_bad#2#__ret := debug#TestMultiplication#overflow_u8_mul_bad#2#__ret[Position(191) := __ret0];
     return;
 
 Label_Abort:
     __abort_flag := true;
     __m := __saved_m;
     __ret0 := DefaultValue;
+    debug#TestMultiplication#overflow_u8_mul_bad#2#__ret := debug#TestMultiplication#overflow_u8_mul_bad#2#__ret[Position(221) := __ret0];
 }
 
 procedure TestMultiplication_overflow_u8_mul_bad_verify (x: Value, y: Value) returns (__ret0: Value)
 {
-    assume ExistsTxnSenderAccount(__m, __txn);
+    call InitVerification();
     call __ret0 := TestMultiplication_overflow_u8_mul_bad(x, y);
 }
 
@@ -71,18 +81,26 @@ ensures old(b#Boolean(Boolean(i#Integer(Integer(i#Integer(x) * i#Integer(y))) > 
     var __tmp: Value;
     var __frame: int;
     var __saved_m: Memory;
+    var debug#TestMultiplication#overflow_u8_mul_ok#0#x: [Position]Value;
+    var debug#TestMultiplication#overflow_u8_mul_ok#1#y: [Position]Value;
+    var debug#TestMultiplication#overflow_u8_mul_ok#2#__ret: [Position]Value;
 
     // initialize function execution
     assume !__abort_flag;
     __saved_m := __m;
     __frame := __local_counter;
     __local_counter := __local_counter + 5;
+    debug#TestMultiplication#overflow_u8_mul_ok#0#x := EmptyPositionMap;
+    debug#TestMultiplication#overflow_u8_mul_ok#1#y := EmptyPositionMap;
+    debug#TestMultiplication#overflow_u8_mul_ok#2#__ret := EmptyPositionMap;
 
     // process and type check arguments
     assume IsValidU8(x);
     __m := UpdateLocal(__m, __frame + 0, x);
+    debug#TestMultiplication#overflow_u8_mul_ok#0#x := debug#TestMultiplication#overflow_u8_mul_ok#0#x[Position(273) := x];
     assume IsValidU8(y);
     __m := UpdateLocal(__m, __frame + 1, y);
+    debug#TestMultiplication#overflow_u8_mul_ok#1#y := debug#TestMultiplication#overflow_u8_mul_ok#1#y[Position(273) := y];
 
     // bytecode translation starts here
     call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 0));
@@ -96,17 +114,19 @@ ensures old(b#Boolean(Boolean(i#Integer(Integer(i#Integer(x) * i#Integer(y))) > 
     __m := UpdateLocal(__m, __frame + 4, __tmp);
 
     __ret0 := GetLocal(__m, __frame + 4);
+    debug#TestMultiplication#overflow_u8_mul_ok#2#__ret := debug#TestMultiplication#overflow_u8_mul_ok#2#__ret[Position(373) := __ret0];
     return;
 
 Label_Abort:
     __abort_flag := true;
     __m := __saved_m;
     __ret0 := DefaultValue;
+    debug#TestMultiplication#overflow_u8_mul_ok#2#__ret := debug#TestMultiplication#overflow_u8_mul_ok#2#__ret[Position(403) := __ret0];
 }
 
 procedure TestMultiplication_overflow_u8_mul_ok_verify (x: Value, y: Value) returns (__ret0: Value)
 {
-    assume ExistsTxnSenderAccount(__m, __txn);
+    call InitVerification();
     call __ret0 := TestMultiplication_overflow_u8_mul_ok(x, y);
 }
 
@@ -123,18 +143,26 @@ ensures old(b#Boolean(Boolean(false))) ==> __abort_flag;
     var __tmp: Value;
     var __frame: int;
     var __saved_m: Memory;
+    var debug#TestMultiplication#overflow_u64_mul_bad#0#x: [Position]Value;
+    var debug#TestMultiplication#overflow_u64_mul_bad#1#y: [Position]Value;
+    var debug#TestMultiplication#overflow_u64_mul_bad#2#__ret: [Position]Value;
 
     // initialize function execution
     assume !__abort_flag;
     __saved_m := __m;
     __frame := __local_counter;
     __local_counter := __local_counter + 5;
+    debug#TestMultiplication#overflow_u64_mul_bad#0#x := EmptyPositionMap;
+    debug#TestMultiplication#overflow_u64_mul_bad#1#y := EmptyPositionMap;
+    debug#TestMultiplication#overflow_u64_mul_bad#2#__ret := EmptyPositionMap;
 
     // process and type check arguments
     assume IsValidU64(x);
     __m := UpdateLocal(__m, __frame + 0, x);
+    debug#TestMultiplication#overflow_u64_mul_bad#0#x := debug#TestMultiplication#overflow_u64_mul_bad#0#x[Position(456) := x];
     assume IsValidU64(y);
     __m := UpdateLocal(__m, __frame + 1, y);
+    debug#TestMultiplication#overflow_u64_mul_bad#1#y := debug#TestMultiplication#overflow_u64_mul_bad#1#y[Position(456) := y];
 
     // bytecode translation starts here
     call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 0));
@@ -148,17 +176,19 @@ ensures old(b#Boolean(Boolean(false))) ==> __abort_flag;
     __m := UpdateLocal(__m, __frame + 4, __tmp);
 
     __ret0 := GetLocal(__m, __frame + 4);
+    debug#TestMultiplication#overflow_u64_mul_bad#2#__ret := debug#TestMultiplication#overflow_u64_mul_bad#2#__ret[Position(576) := __ret0];
     return;
 
 Label_Abort:
     __abort_flag := true;
     __m := __saved_m;
     __ret0 := DefaultValue;
+    debug#TestMultiplication#overflow_u64_mul_bad#2#__ret := debug#TestMultiplication#overflow_u64_mul_bad#2#__ret[Position(606) := __ret0];
 }
 
 procedure TestMultiplication_overflow_u64_mul_bad_verify (x: Value, y: Value) returns (__ret0: Value)
 {
-    assume ExistsTxnSenderAccount(__m, __txn);
+    call InitVerification();
     call __ret0 := TestMultiplication_overflow_u64_mul_bad(x, y);
 }
 
@@ -175,18 +205,26 @@ ensures old(b#Boolean(Boolean(false))) ==> __abort_flag;
     var __tmp: Value;
     var __frame: int;
     var __saved_m: Memory;
+    var debug#TestMultiplication#overflow_u128_mul_bad#0#x: [Position]Value;
+    var debug#TestMultiplication#overflow_u128_mul_bad#1#y: [Position]Value;
+    var debug#TestMultiplication#overflow_u128_mul_bad#2#__ret: [Position]Value;
 
     // initialize function execution
     assume !__abort_flag;
     __saved_m := __m;
     __frame := __local_counter;
     __local_counter := __local_counter + 5;
+    debug#TestMultiplication#overflow_u128_mul_bad#0#x := EmptyPositionMap;
+    debug#TestMultiplication#overflow_u128_mul_bad#1#y := EmptyPositionMap;
+    debug#TestMultiplication#overflow_u128_mul_bad#2#__ret := EmptyPositionMap;
 
     // process and type check arguments
     assume IsValidU128(x);
     __m := UpdateLocal(__m, __frame + 0, x);
+    debug#TestMultiplication#overflow_u128_mul_bad#0#x := debug#TestMultiplication#overflow_u128_mul_bad#0#x[Position(858) := x];
     assume IsValidU128(y);
     __m := UpdateLocal(__m, __frame + 1, y);
+    debug#TestMultiplication#overflow_u128_mul_bad#1#y := debug#TestMultiplication#overflow_u128_mul_bad#1#y[Position(858) := y];
 
     // bytecode translation starts here
     call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 0));
@@ -200,16 +238,18 @@ ensures old(b#Boolean(Boolean(false))) ==> __abort_flag;
     __m := UpdateLocal(__m, __frame + 4, __tmp);
 
     __ret0 := GetLocal(__m, __frame + 4);
+    debug#TestMultiplication#overflow_u128_mul_bad#2#__ret := debug#TestMultiplication#overflow_u128_mul_bad#2#__ret[Position(982) := __ret0];
     return;
 
 Label_Abort:
     __abort_flag := true;
     __m := __saved_m;
     __ret0 := DefaultValue;
+    debug#TestMultiplication#overflow_u128_mul_bad#2#__ret := debug#TestMultiplication#overflow_u128_mul_bad#2#__ret[Position(1012) := __ret0];
 }
 
 procedure TestMultiplication_overflow_u128_mul_bad_verify (x: Value, y: Value) returns (__ret0: Value)
 {
-    assume ExistsTxnSenderAccount(__m, __txn);
+    call InitVerification();
     call __ret0 := TestMultiplication_overflow_u128_mul_bad(x, y);
 }

--- a/language/move-prover/bytecode-to-boogie/tests/goldenfiles/verify-ref-param.bpl
+++ b/language/move-prover/bytecode-to-boogie/tests/goldenfiles/verify-ref-param.bpl
@@ -36,16 +36,21 @@ ensures b#Boolean(Boolean(IsEqual(__ret0, SelectField(Dereference(__m, ref), Tes
     var __tmp: Value;
     var __frame: int;
     var __saved_m: Memory;
+    var debug#TestSpecs#value#0#ref: [Position]Value;
+    var debug#TestSpecs#value#1#__ret: [Position]Value;
 
     // initialize function execution
     assume !__abort_flag;
     __saved_m := __m;
     __frame := __local_counter;
     __local_counter := __local_counter + 4;
+    debug#TestSpecs#value#0#ref := EmptyPositionMap;
+    debug#TestSpecs#value#1#__ret := EmptyPositionMap;
 
     // process and type check arguments
     assume is#Vector(Dereference(__m, ref));
     assume IsValidReferenceParameter(__m, __frame, ref);
+    debug#TestSpecs#value#0#ref := debug#TestSpecs#value#0#ref[Position(66) := Dereference(__m, ref)];
 
     // bytecode translation starts here
     call __t1 := CopyOrMoveRef(ref);
@@ -57,16 +62,18 @@ ensures b#Boolean(Boolean(IsEqual(__ret0, SelectField(Dereference(__m, ref), Tes
     __m := UpdateLocal(__m, __frame + 3, __tmp);
 
     __ret0 := GetLocal(__m, __frame + 3);
+    debug#TestSpecs#value#1#__ret := debug#TestSpecs#value#1#__ret[Position(141) := __ret0];
     return;
 
 Label_Abort:
     __abort_flag := true;
     __m := __saved_m;
     __ret0 := DefaultValue;
+    debug#TestSpecs#value#1#__ret := debug#TestSpecs#value#1#__ret[Position(171) := __ret0];
 }
 
 procedure TestSpecs_value_verify (ref: Reference) returns (__ret0: Value)
 {
-    assume ExistsTxnSenderAccount(__m, __txn);
+    call InitVerification();
     call __ret0 := TestSpecs_value(ref);
 }

--- a/language/move-prover/bytecode-to-boogie/tests/goldenfiles/verify-vector.bpl
+++ b/language/move-prover/bytecode-to-boogie/tests/goldenfiles/verify-vector.bpl
@@ -20,12 +20,20 @@ ensures b#Boolean(Boolean(IsEqual(__ret0, __ret1)));
     var __tmp: Value;
     var __frame: int;
     var __saved_m: Memory;
+    var debug#VerifyVector#test_empty1#0#ev1: [Position]Value;
+    var debug#VerifyVector#test_empty1#1#ev2: [Position]Value;
+    var debug#VerifyVector#test_empty1#2#__ret: [Position]Value;
+    var debug#VerifyVector#test_empty1#3#__ret: [Position]Value;
 
     // initialize function execution
     assume !__abort_flag;
     __saved_m := __m;
     __frame := __local_counter;
     __local_counter := __local_counter + 6;
+    debug#VerifyVector#test_empty1#0#ev1 := EmptyPositionMap;
+    debug#VerifyVector#test_empty1#1#ev2 := EmptyPositionMap;
+    debug#VerifyVector#test_empty1#2#__ret := EmptyPositionMap;
+    debug#VerifyVector#test_empty1#3#__ret := EmptyPositionMap;
 
     // process and type check arguments
 
@@ -38,6 +46,7 @@ ensures b#Boolean(Boolean(IsEqual(__ret0, __ret1)));
 
     call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 2));
     __m := UpdateLocal(__m, __frame + 0, __tmp);
+    debug#VerifyVector#test_empty1#0#ev1 := debug#VerifyVector#test_empty1#0#ev1[Position(189) := __tmp];
 
     call __t3 := Vector_empty(IntegerType());
     if (__abort_flag) { goto Label_Abort; }
@@ -47,6 +56,7 @@ ensures b#Boolean(Boolean(IsEqual(__ret0, __ret1)));
 
     call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 3));
     __m := UpdateLocal(__m, __frame + 1, __tmp);
+    debug#VerifyVector#test_empty1#1#ev2 := debug#VerifyVector#test_empty1#1#ev2[Position(217) := __tmp];
 
     call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 0));
     __m := UpdateLocal(__m, __frame + 4, __tmp);
@@ -55,19 +65,23 @@ ensures b#Boolean(Boolean(IsEqual(__ret0, __ret1)));
     __m := UpdateLocal(__m, __frame + 5, __tmp);
 
     __ret0 := GetLocal(__m, __frame + 4);
+    debug#VerifyVector#test_empty1#2#__ret := debug#VerifyVector#test_empty1#2#__ret[Position(245) := __ret0];
     __ret1 := GetLocal(__m, __frame + 5);
+    debug#VerifyVector#test_empty1#3#__ret := debug#VerifyVector#test_empty1#3#__ret[Position(245) := __ret1];
     return;
 
 Label_Abort:
     __abort_flag := true;
     __m := __saved_m;
     __ret0 := DefaultValue;
+    debug#VerifyVector#test_empty1#2#__ret := debug#VerifyVector#test_empty1#2#__ret[Position(280) := __ret0];
     __ret1 := DefaultValue;
+    debug#VerifyVector#test_empty1#3#__ret := debug#VerifyVector#test_empty1#3#__ret[Position(280) := __ret1];
 }
 
 procedure VerifyVector_test_empty1_verify () returns (__ret0: Value, __ret1: Value)
 {
-    assume ExistsTxnSenderAccount(__m, __txn);
+    call InitVerification();
     call __ret0, __ret1 := VerifyVector_test_empty1();
 }
 
@@ -90,12 +104,22 @@ ensures b#Boolean(Boolean(IsEqual(__ret0, __ret1)));
     var __tmp: Value;
     var __frame: int;
     var __saved_m: Memory;
+    var debug#VerifyVector#test_empty2#0#ev1: [Position]Value;
+    var debug#VerifyVector#test_empty2#1#ev2: [Position]Value;
+    var debug#VerifyVector#test_empty2#2#x: [Position]Value;
+    var debug#VerifyVector#test_empty2#3#__ret: [Position]Value;
+    var debug#VerifyVector#test_empty2#4#__ret: [Position]Value;
 
     // initialize function execution
     assume !__abort_flag;
     __saved_m := __m;
     __frame := __local_counter;
     __local_counter := __local_counter + 11;
+    debug#VerifyVector#test_empty2#0#ev1 := EmptyPositionMap;
+    debug#VerifyVector#test_empty2#1#ev2 := EmptyPositionMap;
+    debug#VerifyVector#test_empty2#2#x := EmptyPositionMap;
+    debug#VerifyVector#test_empty2#3#__ret := EmptyPositionMap;
+    debug#VerifyVector#test_empty2#4#__ret := EmptyPositionMap;
 
     // process and type check arguments
 
@@ -108,6 +132,7 @@ ensures b#Boolean(Boolean(IsEqual(__ret0, __ret1)));
 
     call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 3));
     __m := UpdateLocal(__m, __frame + 0, __tmp);
+    debug#VerifyVector#test_empty2#0#ev1 := debug#VerifyVector#test_empty2#0#ev1[Position(440) := __tmp];
 
     call __t4 := Vector_empty(IntegerType());
     if (__abort_flag) { goto Label_Abort; }
@@ -117,6 +142,7 @@ ensures b#Boolean(Boolean(IsEqual(__ret0, __ret1)));
 
     call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 4));
     __m := UpdateLocal(__m, __frame + 1, __tmp);
+    debug#VerifyVector#test_empty2#1#ev2 := debug#VerifyVector#test_empty2#1#ev2[Position(468) := __tmp];
 
     call __t5 := BorrowLoc(__frame + 0);
 
@@ -125,6 +151,7 @@ ensures b#Boolean(Boolean(IsEqual(__ret0, __ret1)));
 
     call Vector_push_back(IntegerType(), __t5, GetLocal(__m, __frame + 6));
     if (__abort_flag) { goto Label_Abort; }
+    debug#VerifyVector#test_empty2#0#ev1 := debug#VerifyVector#test_empty2#0#ev1[Position(496) := GetLocal(__m, __frame + 0)];
 
     call __t7 := BorrowLoc(__frame + 0);
 
@@ -133,9 +160,11 @@ ensures b#Boolean(Boolean(IsEqual(__ret0, __ret1)));
     assume IsValidU64(__t8);
 
     __m := UpdateLocal(__m, __frame + 8, __t8);
+    debug#VerifyVector#test_empty2#0#ev1 := debug#VerifyVector#test_empty2#0#ev1[Position(537) := GetLocal(__m, __frame + 0)];
 
     call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 8));
     __m := UpdateLocal(__m, __frame + 2, __tmp);
+    debug#VerifyVector#test_empty2#2#x := debug#VerifyVector#test_empty2#2#x[Position(533) := __tmp];
 
     call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 0));
     __m := UpdateLocal(__m, __frame + 9, __tmp);
@@ -144,18 +173,22 @@ ensures b#Boolean(Boolean(IsEqual(__ret0, __ret1)));
     __m := UpdateLocal(__m, __frame + 10, __tmp);
 
     __ret0 := GetLocal(__m, __frame + 9);
+    debug#VerifyVector#test_empty2#3#__ret := debug#VerifyVector#test_empty2#3#__ret[Position(570) := __ret0];
     __ret1 := GetLocal(__m, __frame + 10);
+    debug#VerifyVector#test_empty2#4#__ret := debug#VerifyVector#test_empty2#4#__ret[Position(570) := __ret1];
     return;
 
 Label_Abort:
     __abort_flag := true;
     __m := __saved_m;
     __ret0 := DefaultValue;
+    debug#VerifyVector#test_empty2#3#__ret := debug#VerifyVector#test_empty2#3#__ret[Position(605) := __ret0];
     __ret1 := DefaultValue;
+    debug#VerifyVector#test_empty2#4#__ret := debug#VerifyVector#test_empty2#4#__ret[Position(605) := __ret1];
 }
 
 procedure VerifyVector_test_empty2_verify () returns (__ret0: Value, __ret1: Value)
 {
-    assume ExistsTxnSenderAccount(__m, __txn);
+    call InitVerification();
     call __ret0, __ret1 := VerifyVector_test_empty2();
 }


### PR DESCRIPTION
This adds variables to the generated boogie code which track position dependent information of the current value of a (mutable) boogie variable. The `boogie_wrapper.rs` is extended to extract values for those variables out of the model produced on verification failure and inject them in the execution trace.

This looks then for example like this (here we have injected a bug into LibraCoin.withdraw which doesn't actually subtract the withdrawn amount from the account. Therefore the amount in the `coin_ref` is not changed.)

```
error:  A postcondition might not hold on this return path.
- libra_coin.mvir:124:8
124 |         ensures coin_ref.value == old(coin_ref.value) - amount
help: Execution trace for previous error:
    at libra_coin.mvir:122:4: withdraw (entry)
        coin_ref = &LibraCoin.T{value = 3867},
        amount = 365
    at libra_coin.mvir:131:15: withdraw
        coin_ref = &LibraCoin.T{value = 3867},
        amount = 365,
        value = 3867
    at libra_coin.mvir:122:4: withdraw (exit)
        coin_ref = &LibraCoin.T{value = 3867},
        amount = 365,
        value = 3867,
        RET = LibraCoin.T{value = 365}
```

Here is another example of the test_empty2 method in `verify-vector.rs` where we inverted the post condition which illustrates how changes to variable state are tracked:

```
error:  A postcondition might not hold on this return path.
- verify-vector.mvir:16:4
16 |     ensures RET(0) != RET(1)
help: Execution trace for previous error:
    at verify-vector.mvir:15:4: test_empty2 (entry)
    at verify-vector.mvir:21:7: test_empty2
        ev1 = Vector.T{},
    at verify-vector.mvir:22:7: test_empty2
        ev1 = Vector.T{},
        ev2 = Vector.T{},
    at verify-vector.mvir:23:1: test_empty2
        ev1 = Vector.T{1},                    // <-- at this point we pushed 1
        ev2 = Vector.T{},
    at verify-vector.mvir:24:5: test_empty2
        ev1 = Vector.T{},                     // <-- at this point we have popped it
        ev2 = Vector.T{},
        x = 1,
    at verify-vector.mvir:15:4: test_empty2 (exit)
        ev1 = Vector.T{},
        ev2 = Vector.T{},
        x = 1,
        RET(0) = Vector.T{},
        RET(1) = Vector.T{}
```

The feature isn't fully stable yet, and bugs and imprecision are to be expected. Specifically, it appears that there is either a bug in the implementation or in Boogie/Z3 maps which lets some variables appear earlier in the trace as they are initialized.

## Design

The design introduces for each named variable a 'debug' variable which is a map `[Position]Value` in boogie, and which is updated whenever the variable is updated. Example:

```
var ev1: Value;
...
var debug#VerifyVector#test_empty2#0#ev1: [Position]Value;
...
call __t3 := Vector_empty(IntegerType());
__m := UpdateLocal(__m, __frame + 0, __t3);
debug#VerifyVector#test_empty2#0#ev1 := debug#VerifyVector#test_empty2#0#ev1[Position(440) := __t3];
...
```

Above, 440 is the byte index into the corresponding source.

Reference values are dealt with by storing the `Dereference(__m, r)` at each point it is being updated.

Care has to be taken for when a local is borrowed. To this end, the current algorithm approximates the result by first analyzing which variables are borrowed in a function, and then updating all the debug variables of all borrowed variables whenever a function with &mut parameters is called. This can likely be done more efficient by actually tracking which locals references can point to.

Global state isn't dealt with yet. One possible design is to look at `acquires` clauses from functions and track the state of the acquired resource type. One problem with this is that the global memory map is unbounded, so we can't iterate its domain.

The values of the debug map variables are then extracted from the boogie model and injected into the execution trace, using a bunch of tricky/complicated (i.e. not yet ideally designed) code. This includes translating vectors and structs back into Move style representation.

Note that the implementation currently makes a lot of assumptions how the boogie model looks like and likely breaks if we use array theories or CVC4. However, the code should be robust -- it shouldn't crash but visualization may stop working.

## Motivation

Improve DevX.


### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

There are currently no automated tests for model visualization. They need to be added later.

## Related PRs

NA
