### PR TITLE
[language/ir-to-bytecode] fix names of parse_ functions

### DIFF
--- a/language/compiler/ir-to-bytecode/src/parser.rs
+++ b/language/compiler/ir-to-bytecode/src/parser.rs
@@ -109,9 +109,9 @@ pub fn parse_module(modules_str: &str) -> Result<ast::ModuleDefinition> {
     syntax::parse_module_string(stripped_string).or_else(|e| handle_error(e, stripped_string))
 }
 
-/// Given the raw input of a file, creates a single `Cmd` struct
+/// Given the raw input of a file, creates a single `Cmd_` struct
 /// Fails with `Err(_)` if the text cannot be parsed
-pub fn parse_cmd(cmd_str: &str, _sender_address: AccountAddress) -> Result<ast::Cmd_> {
+pub fn parse_cmd_(cmd_str: &str, _sender_address: AccountAddress) -> Result<ast::Cmd_> {
     let stripped_string = &strip_comments_and_verify(cmd_str)?;
     syntax::parse_cmd_string(stripped_string).or_else(|e| handle_error(e, stripped_string))
 }

--- a/language/compiler/ir-to-bytecode/syntax/src/ast.rs
+++ b/language/compiler/ir-to-bytecode/syntax/src/ast.rs
@@ -1061,7 +1061,7 @@ impl Exp_ {
 }
 
 /// Parses a field.
-pub fn parse_field<L>(s: impl Into<Box<str>>) -> Result<Field_, ParseError<L, anyhow::Error>> {
+pub fn parse_field_<L>(s: impl Into<Box<str>>) -> Result<Field_, ParseError<L, anyhow::Error>> {
     Ok(Field_::new(parse_identifier(s.into())?))
 }
 


### PR DESCRIPTION
Followup to #2383. The type names have been reversed so these should be reversed as well.