### PR TITLE
[cluster-test] Use async-trait to simplify code

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -152,7 +152,7 @@ dependencies = [
 
 [[package]]
 name = "async-trait"
-version = "0.1.21"
+version = "0.1.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "proc-macro2 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -200,7 +200,7 @@ name = "backup-restore"
 version = "0.1.0"
 dependencies = [
  "anyhow 1.0.24 (registry+https://github.com/rust-lang/crates.io-index)",
- "async-trait 0.1.21 (registry+https://github.com/rust-lang/crates.io-index)",
+ "async-trait 0.1.24 (registry+https://github.com/rust-lang/crates.io-index)",
  "byteorder 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "hex 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -636,6 +636,7 @@ version = "0.1.0"
 dependencies = [
  "admission-control-proto 0.1.0",
  "anyhow 1.0.24 (registry+https://github.com/rust-lang/crates.io-index)",
+ "async-trait 0.1.24 (registry+https://github.com/rust-lang/crates.io-index)",
  "chrono 0.4.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "config-builder 0.1.0",
  "debug-interface 0.1.0",
@@ -753,7 +754,7 @@ name = "consensus"
 version = "0.1.0"
 dependencies = [
  "anyhow 1.0.24 (registry+https://github.com/rust-lang/crates.io-index)",
- "async-trait 0.1.21 (registry+https://github.com/rust-lang/crates.io-index)",
+ "async-trait 0.1.24 (registry+https://github.com/rust-lang/crates.io-index)",
  "byteorder 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "bytes 0.5.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "cached 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -4367,7 +4368,7 @@ name = "state-synchronizer"
 version = "0.1.0"
 dependencies = [
  "anyhow 1.0.24 (registry+https://github.com/rust-lang/crates.io-index)",
- "async-trait 0.1.21 (registry+https://github.com/rust-lang/crates.io-index)",
+ "async-trait 0.1.24 (registry+https://github.com/rust-lang/crates.io-index)",
  "bytes 0.5.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "channel 0.1.0",
  "config-builder 0.1.0",
@@ -4427,7 +4428,7 @@ name = "storage-client"
 version = "0.1.0"
 dependencies = [
  "anyhow 1.0.24 (registry+https://github.com/rust-lang/crates.io-index)",
- "async-trait 0.1.21 (registry+https://github.com/rust-lang/crates.io-index)",
+ "async-trait 0.1.24 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "libra-crypto 0.1.0",
  "libra-state-view 0.1.0",
@@ -4459,7 +4460,7 @@ name = "storage-service"
 version = "0.1.0"
 dependencies = [
  "anyhow 1.0.24 (registry+https://github.com/rust-lang/crates.io-index)",
- "async-trait 0.1.21 (registry+https://github.com/rust-lang/crates.io-index)",
+ "async-trait 0.1.24 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "itertools 0.8.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "libra-canonical-serialization 0.1.0",
@@ -5083,7 +5084,7 @@ version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "async-stream 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "async-trait 0.1.21 (registry+https://github.com/rust-lang/crates.io-index)",
+ "async-trait 0.1.24 (registry+https://github.com/rust-lang/crates.io-index)",
  "base64 0.10.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "bytes 0.5.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures-core 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -5585,7 +5586,7 @@ name = "vm-validator"
 version = "0.1.0"
 dependencies = [
  "anyhow 1.0.24 (registry+https://github.com/rust-lang/crates.io-index)",
- "async-trait 0.1.21 (registry+https://github.com/rust-lang/crates.io-index)",
+ "async-trait 0.1.24 (registry+https://github.com/rust-lang/crates.io-index)",
  "config-builder 0.1.0",
  "executor 0.1.0",
  "libra-config 0.1.0",
@@ -5927,7 +5928,7 @@ dependencies = [
 "checksum assert_matches 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "7deb0a829ca7bcfaf5da70b073a8d128619259a7be8216a355e23f00763059e5"
 "checksum async-stream 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "58982858be7540a465c790b95aaea6710e5139bf8956b1d1344d014fa40100b0"
 "checksum async-stream-impl 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "393356ed99aa7bff0ac486dde592633b83ab02bd254d8c209d5b9f1d0f533480"
-"checksum async-trait 0.1.21 (registry+https://github.com/rust-lang/crates.io-index)" = "8b6dd385bb33043b833ba049048d57bdbb4d654a121ed68c71871ca51ff67070"
+"checksum async-trait 0.1.24 (registry+https://github.com/rust-lang/crates.io-index)" = "750b1c38a1dfadd108da0f01c08f4cdc7ff1bb39b325f9c82cc972361780a6e1"
 "checksum atty 0.2.13 (registry+https://github.com/rust-lang/crates.io-index)" = "1803c647a3ec87095e7ae7acfca019e98de5ec9a7d01343f611cf3152ed71a90"
 "checksum autocfg 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)" = "b671c8fb71b457dd4ae18c4ba1e59aa81793daacc361d82fcd410cef0d491875"
 "checksum backtrace 0.3.37 (registry+https://github.com/rust-lang/crates.io-index)" = "5180c5a20655b14a819b652fd2378fa5f1697b6c9ddad3e695c2f9cedf6df4e2"

--- a/testsuite/cluster-test/Cargo.toml
+++ b/testsuite/cluster-test/Cargo.toml
@@ -45,3 +45,4 @@ hex = { version = "0.3.2", default-features = false }
 
 futures = "0.3.0"
 tokio = { version = "0.2.8", features = ["full"] }
+async-trait = "0.1.24"

--- a/testsuite/cluster-test/src/effects/delete_libra_data.rs
+++ b/testsuite/cluster-test/src/effects/delete_libra_data.rs
@@ -5,7 +5,8 @@
 
 use crate::{effects::Action, instance::Instance};
 use anyhow::Result;
-use futures::future::{BoxFuture, FutureExt};
+
+use async_trait::async_trait;
 use slog_scope::info;
 use std::fmt;
 
@@ -19,15 +20,13 @@ impl DeleteLibraData {
     }
 }
 
+#[async_trait]
 impl Action for DeleteLibraData {
-    fn apply(&self) -> BoxFuture<Result<()>> {
-        async move {
-            info!("DeleteLibraData {}", self.instance);
-            self.instance
-                .run_cmd(vec!["sudo rm -rf /data/libra/common"])
-                .await
-        }
-        .boxed()
+    async fn apply(&self) -> Result<()> {
+        info!("DeleteLibraData {}", self.instance);
+        self.instance
+            .run_cmd(vec!["sudo rm -rf /data/libra/common"])
+            .await
     }
 }
 

--- a/testsuite/cluster-test/src/effects/mod.rs
+++ b/testsuite/cluster-test/src/effects/mod.rs
@@ -12,7 +12,8 @@ mod stop_container;
 
 use anyhow::Result;
 pub use delete_libra_data::DeleteLibraData;
-use futures::future::BoxFuture;
+
+use async_trait::async_trait;
 pub use network_delay::three_region_simulation_effects;
 pub use network_delay::NetworkDelay;
 pub use packet_loss::PacketLoss;
@@ -21,11 +22,13 @@ pub use remove_network_effects::RemoveNetworkEffects;
 use std::fmt::Display;
 pub use stop_container::StopContainer;
 
+#[async_trait]
 pub trait Action: Display + Send {
-    fn apply(&self) -> BoxFuture<Result<()>>;
+    async fn apply(&self) -> Result<()>;
 }
 
+#[async_trait]
 pub trait Effect: Display + Send {
-    fn activate(&self) -> BoxFuture<Result<()>>;
-    fn deactivate(&self) -> BoxFuture<Result<()>>;
+    async fn activate(&self) -> Result<()>;
+    async fn deactivate(&self) -> Result<()>;
 }

--- a/testsuite/cluster-test/src/effects/network_delay.rs
+++ b/testsuite/cluster-test/src/effects/network_delay.rs
@@ -8,7 +8,8 @@ use crate::effects::Effect;
 /// If no instances are provided, network delay is introduced on all outgoing packets
 use crate::instance::Instance;
 use anyhow::Result;
-use futures::future::{BoxFuture, FutureExt};
+
+use async_trait::async_trait;
 use slog_scope::debug;
 use std::fmt;
 use std::time::Duration;
@@ -29,8 +30,9 @@ impl NetworkDelay {
     }
 }
 
+#[async_trait]
 impl Effect for NetworkDelay {
-    fn activate(&self) -> BoxFuture<Result<()>> {
+    async fn activate(&self) -> Result<()> {
         debug!("Injecting NetworkDelays for {}", self.instance);
         let mut command = "".to_string();
         command += "sudo tc qdisc delete dev eth0 root; ";
@@ -61,13 +63,13 @@ impl Effect for NetworkDelay {
             )
             .as_str();
         }
-        self.instance.run_cmd(vec![command]).boxed()
+        self.instance.run_cmd(vec![command]).await
     }
 
-    fn deactivate(&self) -> BoxFuture<Result<()>> {
+    async fn deactivate(&self) -> Result<()> {
         self.instance
             .run_cmd(vec!["sudo tc qdisc delete dev eth0 root; true".to_string()])
-            .boxed()
+            .await
     }
 }
 

--- a/testsuite/cluster-test/src/effects/packet_loss.rs
+++ b/testsuite/cluster-test/src/effects/packet_loss.rs
@@ -6,7 +6,8 @@
 /// PacketLoss introduces a given percentage of PacketLoss for a given instance
 use crate::{effects::Action, instance::Instance};
 use anyhow::Result;
-use futures::future::{BoxFuture, FutureExt};
+
+use async_trait::async_trait;
 use slog_scope::info;
 use std::fmt;
 
@@ -21,15 +22,15 @@ impl PacketLoss {
     }
 }
 
+#[async_trait]
 impl Action for PacketLoss {
-    fn apply(&self) -> BoxFuture<Result<()>> {
+    async fn apply(&self) -> Result<()> {
         info!("PacketLoss {:.*}% for {}", 2, self.percent, self.instance);
-        self.instance
-            .run_cmd(vec![format!(
+        let cmd = format!(
             "sudo tc qdisc delete dev eth0 root; sudo tc qdisc add dev eth0 root netem loss {:.*}%",
             2, self.percent
-        )])
-            .boxed()
+        );
+        self.instance.run_cmd(vec![cmd]).await
     }
 }
 

--- a/testsuite/cluster-test/src/effects/remove_network_effects.rs
+++ b/testsuite/cluster-test/src/effects/remove_network_effects.rs
@@ -6,7 +6,8 @@
 /// RemoveNetworkEffect deletes all network effects introduced on an instance
 use crate::{effects::Action, instance::Instance};
 use anyhow::Result;
-use futures::future::{BoxFuture, FutureExt};
+
+use async_trait::async_trait;
 use slog_scope::debug;
 use std::fmt;
 
@@ -20,12 +21,13 @@ impl RemoveNetworkEffects {
     }
 }
 
+#[async_trait]
 impl Action for RemoveNetworkEffects {
-    fn apply(&self) -> BoxFuture<Result<()>> {
+    async fn apply(&self) -> Result<()> {
         debug!("RemoveNetworkEffects for {}", self.instance);
         self.instance
             .run_cmd(vec!["sudo tc qdisc delete dev eth0 root; true".to_string()])
-            .boxed()
+            .await
     }
 }
 

--- a/testsuite/cluster-test/src/effects/stop_container.rs
+++ b/testsuite/cluster-test/src/effects/stop_container.rs
@@ -5,7 +5,8 @@
 
 use crate::{effects::Effect, instance::Instance};
 use anyhow::Result;
-use futures::future::{BoxFuture, FutureExt};
+
+use async_trait::async_trait;
 use std::fmt;
 
 pub struct StopContainer {
@@ -18,19 +19,20 @@ impl StopContainer {
     }
 }
 
+#[async_trait]
 impl Effect for StopContainer {
-    fn activate(&self) -> BoxFuture<Result<()>> {
+    async fn activate(&self) -> Result<()> {
         self.instance
             .run_cmd(vec!["sudo /usr/sbin/service docker stop"])
-            .boxed()
+            .await
     }
 
-    fn deactivate(&self) -> BoxFuture<Result<()>> {
+    async fn deactivate(&self) -> Result<()> {
         self.instance
             .run_cmd(vec![
                 "sudo /usr/sbin/service docker start && sudo /usr/sbin/service ecs start",
             ])
-            .boxed()
+            .await
     }
 }
 

--- a/testsuite/cluster-test/src/experiments/mod.rs
+++ b/testsuite/cluster-test/src/experiments/mod.rs
@@ -30,15 +30,17 @@ use crate::cluster::Cluster;
 use crate::prometheus::Prometheus;
 use crate::report::SuiteReport;
 use crate::tx_emitter::TxEmitter;
-use futures::future::BoxFuture;
+
+use async_trait::async_trait;
 use std::collections::HashMap;
 use structopt::{clap::AppSettings, StructOpt};
 
+#[async_trait]
 pub trait Experiment: Display + Send {
     fn affected_validators(&self) -> HashSet<String> {
         HashSet::new()
     }
-    fn run<'a>(&'a mut self, context: &'a mut Context<'a>) -> BoxFuture<'a, anyhow::Result<()>>;
+    async fn run(&mut self, context: &mut Context<'_>) -> anyhow::Result<()>;
     fn deadline(&self) -> Duration;
 }
 


### PR DESCRIPTION
## Summary

Refactor cluster-test traits to use `async-trait` so that code can be simplified