### PR TITLE
[types]  AccountState

### DIFF
--- a/client/cli/src/client_proxy.rs
+++ b/client/cli/src/client_proxy.rs
@@ -10,6 +10,7 @@ use libra_crypto::{
 };
 use libra_logger::prelude::*;
 use libra_temppath::TempPath;
+use libra_types::account_state::AccountState;
 use libra_types::crypto_proxies::LedgerInfoWithSignatures;
 use libra_types::waypoint::Waypoint;
 use libra_types::{
@@ -34,7 +35,7 @@ use num_traits::{
 };
 use rust_decimal::Decimal;
 use std::{
-    collections::{BTreeMap, HashMap},
+    collections::HashMap,
     convert::TryFrom,
     fmt, fs,
     io::{stdout, Write},
@@ -567,8 +568,8 @@ impl ClientProxy {
         for path in paths {
             if path.address != core_code_address() {
                 if let (Some(blob), _) = self.client.get_account_blob(path.address)? {
-                    let map = BTreeMap::<Vec<u8>, Vec<u8>>::try_from(&blob)?;
-                    if let Some(code) = map.get(&path.path) {
+                    let account_state = AccountState::try_from(&blob)?;
+                    if let Some(code) = account_state.get(&path.path) {
                         dependencies.push(code.clone());
                     }
                 }

--- a/storage/libradb/src/lib.rs
+++ b/storage/libradb/src/lib.rs
@@ -68,7 +68,8 @@ use libra_types::{
 use once_cell::sync::Lazy;
 use prometheus::{IntCounter, IntGauge, IntGaugeVec};
 use schemadb::{ColumnFamilyOptions, ColumnFamilyOptionsMap, DB, DEFAULT_CF_NAME};
-use std::{convert::TryInto, iter::Iterator, path::Path, sync::Arc, time::Instant};
+use std::convert::TryFrom;
+use std::{iter::Iterator, path::Path, sync::Arc, time::Instant};
 use storage_proto::StartupInfo;
 use storage_proto::TreeState;
 
@@ -241,7 +242,7 @@ impl LibraDB {
             self.get_account_state_with_proof(query_path.address, ledger_version, ledger_version)?;
 
         let account_resource = if let Some(account_blob) = &account_state_with_proof.blob {
-            AccountResource::make_from(&(&account_blob.try_into()?))?
+            AccountResource::try_from(account_blob)?
         } else {
             return Ok((Vec::new(), account_state_with_proof));
         };

--- a/storage/libradb/src/libradb_test.rs
+++ b/storage/libradb/src/libradb_test.rs
@@ -5,7 +5,9 @@ use super::*;
 use crate::test_helper::{arb_blocks_to_commit, arb_mock_genesis};
 use libra_crypto::hash::CryptoHash;
 use libra_temppath::TempPath;
-use libra_types::{contract_event::ContractEvent, ledger_info::LedgerInfo};
+use libra_types::{
+    account_config::AccountResource, contract_event::ContractEvent, ledger_info::LedgerInfo,
+};
 use proptest::prelude::*;
 use std::collections::HashMap;
 use std::convert::TryFrom;
@@ -270,11 +272,7 @@ fn group_events_by_query_path(
     let mut event_key_to_query_path = HashMap::new();
     for txn in txns_to_commit {
         for (address, account_blob) in txn.account_states().iter() {
-            let account_btree = account_blob
-                .try_into()
-                .expect("The stored account blob can't be parsed as BTreeMap");
-            let account =
-                AccountResource::make_from(&account_btree).expect("AccountResource is not found");
+            let account = AccountResource::try_from(account_blob).unwrap();
             event_key_to_query_path.insert(
                 account.sent_events().key().clone(),
                 AccessPath::new_for_sent_event(*address),

--- a/storage/scratchpad/src/lib.rs
+++ b/storage/scratchpad/src/lib.rs
@@ -5,4 +5,4 @@
 
 mod sparse_merkle;
 
-pub use crate::sparse_merkle::{AccountState, ProofRead, SparseMerkleTree};
+pub use crate::sparse_merkle::{AccountStatus, ProofRead, SparseMerkleTree};

--- a/storage/scratchpad/src/sparse_merkle/mod.rs
+++ b/storage/scratchpad/src/sparse_merkle/mod.rs
@@ -75,9 +75,9 @@ use libra_crypto::{
 use libra_types::{account_state_blob::AccountStateBlob, proof::SparseMerkleProof};
 use std::sync::Arc;
 
-/// `AccountState` describes the result of querying an account from this SparseMerkleTree.
+/// `AccountStatus` describes the result of querying an account from this SparseMerkleTree.
 #[derive(Debug, Eq, PartialEq)]
-pub enum AccountState {
+pub enum AccountStatus {
     /// The account exists in the tree, therefore we can give its value.
     ExistsInScratchPad(AccountStateBlob),
 
@@ -353,7 +353,7 @@ impl SparseMerkleTree {
     }
 
     /// Queries a `key` in this `SparseMerkleTree`.
-    pub fn get(&self, key: HashValue) -> AccountState {
+    pub fn get(&self, key: HashValue) -> AccountStatus {
         let mut current_node = Arc::clone(&self.root);
         let mut bits = key.iter_bits();
 
@@ -379,15 +379,15 @@ impl SparseMerkleTree {
             Node::Leaf(node) => {
                 if key == node.key() {
                     match node.value() {
-                        LeafValue::Blob(blob) => AccountState::ExistsInScratchPad(blob.clone()),
-                        LeafValue::BlobHash(_) => AccountState::ExistsInDB,
+                        LeafValue::Blob(blob) => AccountStatus::ExistsInScratchPad(blob.clone()),
+                        LeafValue::BlobHash(_) => AccountStatus::ExistsInDB,
                     }
                 } else {
-                    AccountState::DoesNotExist
+                    AccountStatus::DoesNotExist
                 }
             }
-            Node::Subtree(_) => AccountState::Unknown,
-            Node::Empty => AccountState::DoesNotExist,
+            Node::Subtree(_) => AccountStatus::Unknown,
+            Node::Empty => AccountStatus::DoesNotExist,
             Node::Internal(_) => {
                 unreachable!("There is an internal node at the bottom of the tree.")
             }

--- a/storage/scratchpad/src/sparse_merkle/sparse_merkle_test.rs
+++ b/storage/scratchpad/src/sparse_merkle/sparse_merkle_test.rs
@@ -3,7 +3,7 @@
 
 use super::{
     node::{LeafNode, LeafValue, SparseMerkleNode},
-    AccountState, ProofRead, SparseMerkleTree,
+    AccountStatus, ProofRead, SparseMerkleTree,
 };
 use libra_crypto::{
     hash::{CryptoHash, TestOnlyHash, SPARSE_MERKLE_PLACEHOLDER_HASH},
@@ -370,9 +370,9 @@ fn test_update_256_siblings_in_proof() {
 
     assert_eq!(
         new_smt.get(key1),
-        AccountState::ExistsInScratchPad(new_blob1)
+        AccountStatus::ExistsInScratchPad(new_blob1)
     );
-    assert_eq!(new_smt.get(key2), AccountState::Unknown);
+    assert_eq!(new_smt.get(key2), AccountStatus::Unknown);
 }
 
 #[test]
@@ -440,17 +440,17 @@ fn test_update() {
     //           y      key3 (subtree)
     //          / \
     //         x   key4
-    assert_eq!(smt1.get(key1), AccountState::Unknown);
-    assert_eq!(smt1.get(key2), AccountState::Unknown);
-    assert_eq!(smt1.get(key3), AccountState::Unknown);
+    assert_eq!(smt1.get(key1), AccountStatus::Unknown);
+    assert_eq!(smt1.get(key2), AccountStatus::Unknown);
+    assert_eq!(smt1.get(key3), AccountStatus::Unknown);
     assert_eq!(
         smt1.get(key4),
-        AccountState::ExistsInScratchPad(value4.clone())
+        AccountStatus::ExistsInScratchPad(value4.clone())
     );
 
     let non_existing_key = b"foo".test_only_hash();
     assert_eq!(non_existing_key[0], 0b0111_0110);
-    assert_eq!(smt1.get(non_existing_key), AccountState::DoesNotExist);
+    assert_eq!(smt1.get(non_existing_key), AccountStatus::DoesNotExist);
 
     // Verify root hash.
     let value4_hash = value4.hash();
@@ -482,11 +482,11 @@ fn test_update() {
     //     key1    key2 (subtree)
     assert_eq!(
         smt2.get(key1),
-        AccountState::ExistsInScratchPad(value1.clone())
+        AccountStatus::ExistsInScratchPad(value1.clone())
     );
-    assert_eq!(smt2.get(key2), AccountState::Unknown);
-    assert_eq!(smt2.get(key3), AccountState::Unknown);
-    assert_eq!(smt2.get(key4), AccountState::ExistsInScratchPad(value4));
+    assert_eq!(smt2.get(key2), AccountStatus::Unknown);
+    assert_eq!(smt2.get(key3), AccountStatus::Unknown);
+    assert_eq!(smt2.get(key4), AccountStatus::ExistsInScratchPad(value4));
 
     // Verify root hash.
     let value1_hash = value1.hash();
@@ -504,12 +504,12 @@ fn test_update() {
         .update(vec![(key4, value4.clone())], &proof_reader)
         .unwrap();
 
-    assert_eq!(smt22.get(key1), AccountState::Unknown);
-    assert_eq!(smt22.get(key2), AccountState::Unknown);
-    assert_eq!(smt22.get(key3), AccountState::Unknown);
+    assert_eq!(smt22.get(key1), AccountStatus::Unknown);
+    assert_eq!(smt22.get(key2), AccountStatus::Unknown);
+    assert_eq!(smt22.get(key3), AccountStatus::Unknown);
     assert_eq!(
         smt22.get(key4),
-        AccountState::ExistsInScratchPad(value4.clone())
+        AccountStatus::ExistsInScratchPad(value4.clone())
     );
 
     // Now prune smt1.
@@ -517,15 +517,15 @@ fn test_update() {
 
     // For smt2, only key1 should be available since smt2 was constructed by updating smt1 with
     // key1.
-    assert_eq!(smt2.get(key1), AccountState::ExistsInScratchPad(value1));
-    assert_eq!(smt2.get(key2), AccountState::Unknown);
-    assert_eq!(smt2.get(key3), AccountState::Unknown);
-    assert_eq!(smt2.get(key4), AccountState::Unknown);
+    assert_eq!(smt2.get(key1), AccountStatus::ExistsInScratchPad(value1));
+    assert_eq!(smt2.get(key2), AccountStatus::Unknown);
+    assert_eq!(smt2.get(key3), AccountStatus::Unknown);
+    assert_eq!(smt2.get(key4), AccountStatus::Unknown);
 
     // For smt22, only key4 should be available since smt22 was constructed by updating smt1 with
     // key4.
-    assert_eq!(smt22.get(key1), AccountState::Unknown);
-    assert_eq!(smt22.get(key2), AccountState::Unknown);
-    assert_eq!(smt22.get(key3), AccountState::Unknown);
-    assert_eq!(smt22.get(key4), AccountState::ExistsInScratchPad(value4));
+    assert_eq!(smt22.get(key1), AccountStatus::Unknown);
+    assert_eq!(smt22.get(key2), AccountStatus::Unknown);
+    assert_eq!(smt22.get(key3), AccountStatus::Unknown);
+    assert_eq!(smt22.get(key4), AccountStatus::ExistsInScratchPad(value4));
 }

--- a/storage/storage-client/src/state_view.rs
+++ b/storage/storage-client/src/state_view.rs
@@ -10,7 +10,7 @@ use libra_types::{
     access_path::AccessPath, account_address::AccountAddress, proof::SparseMerkleProof,
     transaction::Version,
 };
-use scratchpad::{AccountState, SparseMerkleTree};
+use scratchpad::{AccountStatus, SparseMerkleTree};
 use std::{
     cell::RefCell,
     collections::{hash_map::Entry, BTreeMap, HashMap},
@@ -127,11 +127,11 @@ impl<'a> StateView for VerifiedStateView<'a> {
             Entry::Vacant(vacant) => {
                 let address_hash = address.hash();
                 let account_blob_option = match self.speculative_state.get(address_hash) {
-                    AccountState::ExistsInScratchPad(blob) => Some(blob),
-                    AccountState::DoesNotExist => None,
+                    AccountStatus::ExistsInScratchPad(blob) => Some(blob),
+                    AccountStatus::DoesNotExist => None,
                     // No matter it is in db or unknown, we have to query from db since even the
                     // former case, we don't have the blob data but only its hash.
-                    AccountState::ExistsInDB | AccountState::Unknown => {
+                    AccountStatus::ExistsInDB | AccountStatus::Unknown => {
                         let (blob, proof) = match self.latest_persistent_version {
                             Some(version) => {
                                 let reader = self.reader.clone();

--- a/storage/storage-service/src/mocks/mock_storage_client.rs
+++ b/storage/storage-service/src/mocks/mock_storage_client.rs
@@ -215,7 +215,7 @@ fn get_mock_account_state_blob() -> AccountStateBlob {
         0,
     );
 
-    let mut account_state: AccountState = Default::default();
+    let mut account_state = AccountState::default();
     account_state.insert(
         libra_types::account_config::ACCOUNT_RESOURCE_PATH.to_vec(),
         lcs::to_bytes(&account_resource).unwrap(),

--- a/storage/storage-service/src/mocks/mock_storage_client.rs
+++ b/storage/storage-service/src/mocks/mock_storage_client.rs
@@ -216,7 +216,7 @@ fn get_mock_account_state_blob() -> AccountStateBlob {
 
     let mut version_data = BTreeMap::new();
     version_data.insert(
-        libra_types::account_config::account_resource_path(),
+        libra_types::account_config::ACCOUNT_RESOURCE_PATH.to_vec(),
         lcs::to_bytes(&account_resource).unwrap(),
     );
 

--- a/storage/storage-service/src/mocks/mock_storage_client.rs
+++ b/storage/storage-service/src/mocks/mock_storage_client.rs
@@ -8,6 +8,7 @@ use futures::stream::BoxStream;
 use libra_crypto::{ed25519::*, HashValue};
 use libra_types::{
     account_address::{AccountAddress, ADDRESS_LENGTH},
+    account_state::AccountState,
     account_state_blob::AccountStateBlob,
     crypto_proxies::{LedgerInfoWithSignatures, ValidatorChangeProof},
     event::EventHandle,
@@ -28,7 +29,7 @@ use rand::{
     rngs::{OsRng, StdRng},
     Rng, SeedableRng,
 };
-use std::{collections::BTreeMap, convert::TryFrom};
+use std::convert::TryFrom;
 use storage_client::StorageRead;
 use storage_proto::{BackupAccountStateResponse, StartupInfo};
 
@@ -214,13 +215,13 @@ fn get_mock_account_state_blob() -> AccountStateBlob {
         0,
     );
 
-    let mut version_data = BTreeMap::new();
-    version_data.insert(
+    let mut account_state: AccountState = Default::default();
+    account_state.insert(
         libra_types::account_config::ACCOUNT_RESOURCE_PATH.to_vec(),
         lcs::to_bytes(&account_resource).unwrap(),
     );
 
-    AccountStateBlob::from(lcs::to_bytes(&version_data).unwrap())
+    AccountStateBlob::try_from(&account_state).unwrap()
 }
 
 fn get_mock_txn_data(

--- a/types/src/access_path.rs
+++ b/types/src/access_path.rs
@@ -38,7 +38,7 @@
 use crate::{
     account_address::AccountAddress,
     account_config::{
-        account_resource_path, association_address, ACCOUNT_RECEIVED_EVENT_PATH,
+        association_address, ACCOUNT_RECEIVED_EVENT_PATH, ACCOUNT_RESOURCE_PATH,
         ACCOUNT_SENT_EVENT_PATH,
     },
     identifier::{IdentStr, Identifier},
@@ -217,7 +217,7 @@ impl AccessPath {
 
     /// Given an address, returns the corresponding access path that stores the Account resource.
     pub fn new_for_account(address: AccountAddress) -> Self {
-        Self::new(address, account_resource_path())
+        Self::new(address, ACCOUNT_RESOURCE_PATH.to_vec())
     }
 
     /// Create an AccessPath for a ContractEvent.

--- a/types/src/account_config.rs
+++ b/types/src/account_config.rs
@@ -151,10 +151,9 @@ impl AccountResource {
 
     /// Given an account map (typically from storage) retrieves the Account resource associated.
     pub fn make_from(account_map: &BTreeMap<Vec<u8>, Vec<u8>>) -> Result<Self> {
-        let ap = account_resource_path();
-        match account_map.get(&ap) {
+        match account_map.get(&*ACCOUNT_RESOURCE_PATH) {
             Some(bytes) => lcs::from_bytes(bytes).map_err(Into::into),
-            None => bail!("No data for {:?}", ap),
+            None => bail!("No data for {:?}", ACCOUNT_RESOURCE_PATH),
         }
     }
 
@@ -213,16 +212,15 @@ impl TryFrom<&AccountStateBlob> for AccountResource {
     }
 }
 
-/// Return the path to the Account resource. It can be used to create an AccessPath for an
-/// Account resource.
-pub fn account_resource_path() -> Vec<u8> {
-    AccessPath::resource_access_vec(&account_struct_tag(), &Accesses::empty())
-}
+/// Path to the Account resource.
+/// It can be used to create an AccessPath for an Account resource.
+pub static ACCOUNT_RESOURCE_PATH: Lazy<Vec<u8>> =
+    Lazy::new(|| AccessPath::resource_access_vec(&account_struct_tag(), &Accesses::empty()));
 
 /// The path to the sent event counter for an Account resource.
 /// It can be used to query the event DB for the given event.
 pub static ACCOUNT_SENT_EVENT_PATH: Lazy<Vec<u8>> = Lazy::new(|| {
-    let mut path = account_resource_path();
+    let mut path = ACCOUNT_RESOURCE_PATH.to_vec();
     path.extend_from_slice(b"/sent_events_count/");
     path
 });
@@ -230,7 +228,7 @@ pub static ACCOUNT_SENT_EVENT_PATH: Lazy<Vec<u8>> = Lazy::new(|| {
 /// Returns the path to the received event counter for an Account resource.
 /// It can be used to query the event DB for the given event.
 pub static ACCOUNT_RECEIVED_EVENT_PATH: Lazy<Vec<u8>> = Lazy::new(|| {
-    let mut path = account_resource_path();
+    let mut path = ACCOUNT_RESOURCE_PATH.to_vec();
     path.extend_from_slice(b"/received_events_count/");
     path
 });

--- a/types/src/account_config.rs
+++ b/types/src/account_config.rs
@@ -4,21 +4,16 @@
 use crate::{
     access_path::{AccessPath, Accesses},
     account_address::AccountAddress,
-    account_state_blob::AccountStateBlob,
     byte_array::ByteArray,
     event::EventHandle,
     identifier::{IdentStr, Identifier},
     language_storage::StructTag,
 };
-use anyhow::{bail, Error, Result};
+use anyhow::{bail, Result};
 use once_cell::sync::Lazy;
 #[cfg(any(test, feature = "fuzzing"))]
 use proptest_derive::Arbitrary;
 use serde::{Deserialize, Serialize};
-use std::{
-    collections::BTreeMap,
-    convert::{TryFrom, TryInto},
-};
 
 // LibraCoin
 static COIN_MODULE_NAME: Lazy<Identifier> = Lazy::new(|| Identifier::new("LibraCoin").unwrap());
@@ -149,14 +144,6 @@ impl AccountResource {
         }
     }
 
-    /// Given an account map (typically from storage) retrieves the Account resource associated.
-    pub fn make_from(account_map: &BTreeMap<Vec<u8>, Vec<u8>>) -> Result<Self> {
-        match account_map.get(&*ACCOUNT_RESOURCE_PATH) {
-            Some(bytes) => lcs::from_bytes(bytes).map_err(Into::into),
-            None => bail!("No data for {:?}", ACCOUNT_RESOURCE_PATH),
-        }
-    }
-
     /// Return the sequence_number field for the given AccountResource
     pub fn sequence_number(&self) -> u64 {
         self.sequence_number
@@ -200,15 +187,6 @@ impl AccountResource {
         } else {
             bail!("Unrecognized query path: {:?}", query_path);
         }
-    }
-}
-
-impl TryFrom<&AccountStateBlob> for AccountResource {
-    type Error = Error;
-
-    fn try_from(account_state_blob: &AccountStateBlob) -> Result<Self> {
-        let account_btree = account_state_blob.try_into()?;
-        AccountResource::make_from(&account_btree)
     }
 }
 

--- a/types/src/account_state/mod.rs
+++ b/types/src/account_state/mod.rs
@@ -1,0 +1,63 @@
+// Copyright (c) The Libra Core Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::account_config::{AccountResource, ACCOUNT_RESOURCE_PATH};
+use anyhow::{Error, Result};
+use serde::export::Formatter;
+use serde::{Deserialize, Serialize};
+use std::collections::btree_map::BTreeMap;
+use std::convert::TryFrom;
+use std::fmt;
+use std::ops::{Deref, DerefMut};
+
+#[derive(Default, Deserialize, Serialize)]
+pub struct AccountState(BTreeMap<Vec<u8>, Vec<u8>>);
+
+impl AccountState {
+    pub fn get_account_resource(&self) -> Result<Option<AccountResource>> {
+        self.0
+            .get(&*ACCOUNT_RESOURCE_PATH)
+            .map(|bytes| lcs::from_bytes(bytes))
+            .transpose()
+            .map_err(Into::into)
+    }
+}
+
+impl Deref for AccountState {
+    type Target = BTreeMap<Vec<u8>, Vec<u8>>;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+impl DerefMut for AccountState {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.0
+    }
+}
+
+impl fmt::Debug for AccountState {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        let account_resource_str = self
+            .get_account_resource()
+            .map(|account_resource_opt| format!("{:#?}", account_resource_opt))
+            .unwrap_or_else(|e| format!("parse error: {:#?}", e));
+
+        write!(f, "AccountResource {{ {} }}", account_resource_str)
+    }
+}
+
+impl TryFrom<&AccountResource> for AccountState {
+    type Error = Error;
+
+    fn try_from(account_resource: &AccountResource) -> Result<Self> {
+        let mut btree_map: BTreeMap<Vec<u8>, Vec<u8>> = BTreeMap::new();
+        btree_map.insert(
+            ACCOUNT_RESOURCE_PATH.to_vec(),
+            lcs::to_bytes(account_resource)?,
+        );
+
+        Ok(Self(btree_map))
+    }
+}

--- a/types/src/account_state/mod.rs
+++ b/types/src/account_state/mod.rs
@@ -8,7 +8,6 @@ use serde::{Deserialize, Serialize};
 use std::collections::btree_map::BTreeMap;
 use std::convert::TryFrom;
 use std::fmt;
-use std::ops::{Deref, DerefMut};
 
 #[derive(Default, Deserialize, Serialize)]
 pub struct AccountState(BTreeMap<Vec<u8>, Vec<u8>>);
@@ -21,19 +20,21 @@ impl AccountState {
             .transpose()
             .map_err(Into::into)
     }
-}
 
-impl Deref for AccountState {
-    type Target = BTreeMap<Vec<u8>, Vec<u8>>;
-
-    fn deref(&self) -> &Self::Target {
-        &self.0
+    pub fn get(&self, key: &[u8]) -> Option<&Vec<u8>> {
+        self.0.get(key)
     }
-}
 
-impl DerefMut for AccountState {
-    fn deref_mut(&mut self) -> &mut Self::Target {
-        &mut self.0
+    pub fn insert(&mut self, key: Vec<u8>, value: Vec<u8>) -> Option<Vec<u8>> {
+        self.0.insert(key, value)
+    }
+
+    pub fn remove(&mut self, key: &[u8]) -> Option<Vec<u8>> {
+        self.0.remove(key)
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.0.is_empty()
     }
 }
 
@@ -43,6 +44,7 @@ impl fmt::Debug for AccountState {
             .get_account_resource()
             .map(|account_resource_opt| format!("{:#?}", account_resource_opt))
             .unwrap_or_else(|e| format!("parse error: {:#?}", e));
+        // TODO: add support for other types of resources
 
         write!(f, "AccountResource {{ {} }}", account_resource_str)
     }

--- a/types/src/account_state_blob/mod.rs
+++ b/types/src/account_state_blob/mod.rs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #[cfg(any(test, feature = "fuzzing"))]
-use crate::account_config::account_resource_path;
+use crate::account_config::ACCOUNT_RESOURCE_PATH;
 use crate::{
     account_address::AccountAddress, account_config::AccountResource, ledger_info::LedgerInfo,
     proof::AccountStateProof, transaction::Version,
@@ -94,7 +94,7 @@ impl From<AccountResource> for AccountStateBlob {
     fn from(account_resource: AccountResource) -> Self {
         let mut account_state: BTreeMap<Vec<u8>, Vec<u8>> = BTreeMap::new();
         account_state.insert(
-            account_resource_path(),
+            ACCOUNT_RESOURCE_PATH.to_vec(),
             lcs::to_bytes(&account_resource).unwrap(),
         );
         AccountStateBlob::try_from(&account_state).unwrap()

--- a/types/src/account_state_blob/mod.rs
+++ b/types/src/account_state_blob/mod.rs
@@ -1,13 +1,11 @@
 // Copyright (c) The Libra Core Contributors
 // SPDX-License-Identifier: Apache-2.0
 
-#[cfg(any(test, feature = "fuzzing"))]
-use crate::account_config::ACCOUNT_RESOURCE_PATH;
 use crate::{
-    account_address::AccountAddress, account_config::AccountResource, ledger_info::LedgerInfo,
-    proof::AccountStateProof, transaction::Version,
+    account_address::AccountAddress, account_config::AccountResource, account_state::AccountState,
+    ledger_info::LedgerInfo, proof::AccountStateProof, transaction::Version,
 };
-use anyhow::{ensure, format_err, Error, Result};
+use anyhow::{anyhow, ensure, format_err, Error, Result};
 use libra_crypto::{
     hash::{CryptoHash, CryptoHasher},
     HashValue,
@@ -19,7 +17,6 @@ use proptest::{arbitrary::Arbitrary, prelude::*};
 use proptest_derive::Arbitrary;
 use serde::{Deserialize, Serialize};
 use std::{
-    collections::BTreeMap,
     convert::{TryFrom, TryInto},
     fmt,
 };
@@ -31,8 +28,8 @@ pub struct AccountStateBlob {
 
 impl fmt::Debug for AccountStateBlob {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        let decoded = AccountResource::try_from(self)
-            .map(|resource| format!("{:#?}", resource))
+        let decoded = lcs::from_bytes(&self.blob)
+            .map(|account_state: AccountState| format!("{:#?}", account_state))
             .unwrap_or_else(|_| String::from("[fail]"));
 
         write!(
@@ -65,16 +62,6 @@ impl From<Vec<u8>> for AccountStateBlob {
     }
 }
 
-impl TryFrom<&BTreeMap<Vec<u8>, Vec<u8>>> for AccountStateBlob {
-    type Error = Error;
-
-    fn try_from(map: &BTreeMap<Vec<u8>, Vec<u8>>) -> Result<Self> {
-        Ok(Self {
-            blob: lcs::to_bytes(map)?,
-        })
-    }
-}
-
 impl TryFrom<crate::proto::types::AccountStateBlob> for AccountStateBlob {
     type Error = Error;
 
@@ -89,23 +76,39 @@ impl From<AccountStateBlob> for crate::proto::types::AccountStateBlob {
     }
 }
 
-#[cfg(any(test, feature = "fuzzing"))]
-impl From<AccountResource> for AccountStateBlob {
-    fn from(account_resource: AccountResource) -> Self {
-        let mut account_state: BTreeMap<Vec<u8>, Vec<u8>> = BTreeMap::new();
-        account_state.insert(
-            ACCOUNT_RESOURCE_PATH.to_vec(),
-            lcs::to_bytes(&account_resource).unwrap(),
-        );
-        AccountStateBlob::try_from(&account_state).unwrap()
+impl TryFrom<&AccountState> for AccountStateBlob {
+    type Error = Error;
+
+    fn try_from(account_state: &AccountState) -> Result<Self> {
+        Ok(Self {
+            blob: lcs::to_bytes(account_state)?,
+        })
     }
 }
 
-impl TryFrom<&AccountStateBlob> for BTreeMap<Vec<u8>, Vec<u8>> {
+impl TryFrom<&AccountStateBlob> for AccountState {
     type Error = Error;
 
     fn try_from(account_state_blob: &AccountStateBlob) -> Result<Self> {
         lcs::from_bytes(&account_state_blob.blob).map_err(Into::into)
+    }
+}
+
+impl TryFrom<&AccountResource> for AccountStateBlob {
+    type Error = Error;
+
+    fn try_from(account_resource: &AccountResource) -> Result<Self> {
+        Self::try_from(&AccountState::try_from(account_resource)?)
+    }
+}
+
+impl TryFrom<&AccountStateBlob> for AccountResource {
+    type Error = Error;
+
+    fn try_from(account_state_blob: &AccountStateBlob) -> Result<Self> {
+        AccountState::try_from(account_state_blob)?
+            .get_account_resource()?
+            .ok_or_else(|| anyhow!("AccountResource not found."))
     }
 }
 
@@ -121,8 +124,8 @@ impl CryptoHash for AccountStateBlob {
 
 #[cfg(any(test, feature = "fuzzing"))]
 prop_compose! {
-    pub fn account_state_blob_strategy()(account_resource in any::<AccountResource>()) -> AccountStateBlob {
-        AccountStateBlob::from(account_resource)
+    fn account_state_blob_strategy()(account_resource in any::<AccountResource>()) -> AccountStateBlob {
+        AccountStateBlob::try_from(&account_resource).unwrap()
     }
 }
 

--- a/types/src/lib.rs
+++ b/types/src/lib.rs
@@ -6,6 +6,7 @@
 pub mod access_path;
 pub mod account_address;
 pub mod account_config;
+pub mod account_state;
 pub mod account_state_blob;
 pub mod block_info;
 pub mod block_metadata;

--- a/types/src/proptest_types.rs
+++ b/types/src/proptest_types.rs
@@ -41,6 +41,7 @@ use proptest::{
     prelude::*,
 };
 use proptest_derive::Arbitrary;
+use std::convert::TryFrom;
 use std::{
     borrow::Cow,
     iter::{FromIterator, Iterator},
@@ -678,7 +679,7 @@ impl AccountStateBlobGen {
         let account_resource = self
             .account_resource_gen
             .materialize(account_index, universe);
-        AccountStateBlob::from(account_resource)
+        AccountStateBlob::try_from(&account_resource).unwrap()
     }
 }
 


### PR DESCRIPTION
## Motivation

Wrapper type `struct AccountState(BTreeMap<Vec<u8>, Vec<u8>>)` is introduced so that we can provided methods like `AccountState::get_account_resource() -> Option<AccountResource>` to deal with the case where a specific resource is not present under the state. This is useful when we (soon) stop assuming an account_blob is a 1-1 map to a AccountResource. 

For example, when we try to access the DiscoverySet change event stream under a normal user account, we should be able to tell there's no such event under the account, and it should not be an exception.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

(Share your test plan here. If you changed code, please provide us with clear instructions for verifying that your changes work.)

Existing Coverage

## Related PRs
