### PR TITLE
[cluster-test] Add experiment to automatically generate CPU FlameGraph

### DIFF
--- a/testsuite/cluster-test/src/effects/generate_cpu_flamegraph.rs
+++ b/testsuite/cluster-test/src/effects/generate_cpu_flamegraph.rs
@@ -1,0 +1,53 @@
+// Copyright (c) The Libra Core Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+#![forbid(unsafe_code)]
+
+use crate::{effects::Action, instance::Instance};
+use anyhow::Result;
+use futures::future::{BoxFuture, FutureExt};
+use slog_scope::info;
+use std::fmt;
+
+pub struct GenerateCpuFlamegraph {
+    instance: Instance,
+    duration_secs: usize,
+}
+
+impl GenerateCpuFlamegraph {
+    pub fn new(instance: Instance, duration_secs: usize) -> Self {
+        Self {
+            instance,
+            duration_secs,
+        }
+    }
+}
+
+impl Action for GenerateCpuFlamegraph {
+    fn apply(&self) -> BoxFuture<Result<()>> {
+        async move {
+            info!("GenerateCpuFlamegraph {}", self.instance);
+            let cmd = format!(r#"
+                set -e;
+                rm -rf /tmp/perf-data;
+                mkdir /tmp/perf-data;
+                cd /tmp/perf-data;
+                sudo perf record -F 99 -p $(ps aux | grep libra-node | grep -v grep | awk '{{print $2}}') --output=perf.data --call-graph dwarf -- sleep {};
+                sudo perf script --input=perf.data | sudo /usr/local/etc/FlameGraph/stackcollapse-perf.pl > out.perf-folded;
+                sudo /usr/local/etc/FlameGraph/flamegraph.pl out.perf-folded > perf-kernel.svg;
+                "#, self.duration_secs);
+            self.instance
+                .run_cmd(vec![cmd.as_str()])
+                .await?;
+            self.instance.scp("/tmp/perf-data/perf-kernel.svg", "perf-kernel.svg").await?;
+            Ok(())
+        }
+        .boxed()
+    }
+}
+
+impl fmt::Display for GenerateCpuFlamegraph {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "GenerateCpuFlamegraph {}", self.instance)
+    }
+}

--- a/testsuite/cluster-test/src/effects/mod.rs
+++ b/testsuite/cluster-test/src/effects/mod.rs
@@ -4,6 +4,7 @@
 #![forbid(unsafe_code)]
 
 mod delete_libra_data;
+mod generate_cpu_flamegraph;
 mod network_delay;
 mod packet_loss;
 mod reboot;
@@ -13,6 +14,7 @@ mod stop_container;
 use anyhow::Result;
 pub use delete_libra_data::DeleteLibraData;
 use futures::future::BoxFuture;
+pub use generate_cpu_flamegraph::GenerateCpuFlamegraph;
 pub use network_delay::three_region_simulation_effects;
 pub use network_delay::NetworkDelay;
 pub use packet_loss::PacketLoss;

--- a/testsuite/cluster-test/src/experiments/cpu_flamegraph.rs
+++ b/testsuite/cluster-test/src/experiments/cpu_flamegraph.rs
@@ -1,0 +1,77 @@
+// Copyright (c) The Libra Core Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::experiments::ExperimentParam;
+use crate::{
+    cluster::Cluster, experiments::Context, experiments::Experiment, instance, instance::Instance,
+};
+use futures::future::{BoxFuture, FutureExt};
+use futures::join;
+use crate::effects::{Action, GenerateCpuFlamegraph};
+use std::{
+    collections::HashSet,
+    fmt::{Display, Error, Formatter},
+    time::Duration,
+};
+use structopt::StructOpt;
+
+#[derive(StructOpt, Debug)]
+pub struct CpuFlamegraphParams {
+    #[structopt(
+        long,
+        default_value = "60",
+        help = "Number of seconds for which perf should be run"
+    )]
+    pub duration_secs: usize,
+}
+
+pub struct CpuFlamegraph {
+    duration_secs: usize,
+    perf_instance: Instance,
+}
+
+impl ExperimentParam for CpuFlamegraphParams {
+    type E = CpuFlamegraph;
+    fn build(self, cluster: &Cluster) -> Self::E {
+        let perf_instance = cluster.random_validator_instance();
+        Self::E {
+            duration_secs: self.duration_secs,
+            perf_instance,
+        }
+    }
+}
+
+impl Experiment for CpuFlamegraph {
+    fn affected_validators(&self) -> HashSet<String> {
+        instance::instancelist_to_set(&[self.perf_instance.clone()])
+    }
+
+    fn run<'a>(
+        &'a mut self,
+        context: &'a mut Context,
+    ) -> BoxFuture<'a, anyhow::Result<()>> {
+        async move {
+            let buffer = Duration::from_secs(60);
+            let tx_emitter_duration = 2 * buffer + Duration::from_secs(self.duration_secs as u64);
+
+            let emit_future = context.tx_emitter.emit_txn_for(tx_emitter_duration, context.cluster.validator_instances().clone());
+            let flame_graph_future = GenerateCpuFlamegraph::new(self.perf_instance.clone(), self.duration_secs).apply();
+            let flame_graph_future = tokio::time::delay_for(buffer).then(|_| flame_graph_future);
+            let (emit_result, flame_graph_result) =  join!(emit_future, flame_graph_future);
+            emit_result?;
+            flame_graph_result?;
+            Ok(())
+        }
+        .boxed()
+    }
+
+    fn deadline(&self) -> Duration {
+        Duration::from_secs(480)
+    }
+}
+
+impl Display for CpuFlamegraph {
+    fn fmt(&self, f: &mut Formatter<'_>) -> Result<(), Error> {
+        write!(f, "Generating CpuFlamegraph on {}", self.perf_instance)
+    }
+}

--- a/testsuite/cluster-test/src/experiments/mod.rs
+++ b/testsuite/cluster-test/src/experiments/mod.rs
@@ -3,6 +3,7 @@
 
 #![forbid(unsafe_code)]
 
+mod cpu_flamegraph;
 mod multi_region_network_simulation;
 mod packet_loss_random_validators;
 mod performance_benchmark_nodes_down;
@@ -30,6 +31,7 @@ use crate::cluster::Cluster;
 use crate::prometheus::Prometheus;
 use crate::report::SuiteReport;
 use crate::tx_emitter::TxEmitter;
+pub use cpu_flamegraph::{CpuFlamegraph, CpuFlamegraphParams};
 use futures::future::BoxFuture;
 use std::collections::HashMap;
 use structopt::{clap::AppSettings, StructOpt};
@@ -110,6 +112,7 @@ pub fn get_experiment(name: &str, args: &[String], cluster: &Cluster) -> Box<dyn
         "reboot_random_validators",
         f::<RebootRandomValidatorsParams>(),
     );
+    known_experiments.insert("generate_cpu_flamegraph", f::<CpuFlamegraphParams>());
 
     let builder = known_experiments.get(name).expect("Experiment not found");
     builder(args, cluster)


### PR DESCRIPTION
Summary
We generate load on the cluster and pick one validator and run perf against it to generate the FlameGraph
This FlameGraph is then copied locally to cluster-test.
The next step would be to upload this local file to S3

Test Plan
Tested on my cluster

<!--
Thank you for sending a PR. We appreciate you spending time to help improve the Libra project.

The project is undergoing daily changes. Pull Requests will be reviewed and responded to as time permits.
-->

## Motivation

(Write your motivation for proposed changes here.)

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?

(Write your answer here.)

## Test Plan

(Share your test plan here. If you changed code, please provide us with clear instructions for verifying that your changes work.)

## Related PRs

(If this PR adds or changes functionality, please take some time to update the docs at https://github.com/libra/website, and link to your PR here.)
