### PR TITLE
[cluster-test] Add experiment to automatically generate CPU FlameGraph

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -656,6 +656,7 @@ dependencies = [
  "rusoto_ec2 0.41.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "rusoto_ecr 0.41.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "rusoto_ecs 0.41.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rusoto_s3 0.41.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.101 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.40 (registry+https://github.com/rust-lang/crates.io-index)",
  "slog 2.5.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -3890,6 +3891,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "rusoto_s3"
+version = "0.41.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "bytes 0.4.12 (registry+https://github.com/rust-lang/crates.io-index)",
+ "futures 0.1.29 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rusoto_core 0.41.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "xml-rs 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "rust-argon2"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6233,6 +6245,7 @@ dependencies = [
 "checksum rusoto_ec2 0.41.0 (registry+https://github.com/rust-lang/crates.io-index)" = "d41787042d15ec7c5f3542495339e1418aac8aaff914d26129e17b46f63faadd"
 "checksum rusoto_ecr 0.41.0 (registry+https://github.com/rust-lang/crates.io-index)" = "4722ab9d239d0d113c0e628acfb445f904082a36c09397dce318b218dd4cd276"
 "checksum rusoto_ecs 0.41.0 (registry+https://github.com/rust-lang/crates.io-index)" = "f4e2b14019525016c8954c73ec2f080df22673276f859414fd30de7bef83adff"
+"checksum rusoto_s3 0.41.0 (registry+https://github.com/rust-lang/crates.io-index)" = "b6c840fca030950caf0c9bea89eb35311aa5b01c0341fb0aaf28d347b5c416d7"
 "checksum rust-argon2 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)" = "4ca4eaef519b494d1f2848fc602d18816fed808a981aedf4f1f00ceb7c9d32cf"
 "checksum rust_decimal 1.0.3 (registry+https://github.com/rust-lang/crates.io-index)" = "f7a28ded8f10361cefb69a8d8e1d195acf59344150534c165c401d6611cf013d"
 "checksum rustc-demangle 0.1.16 (registry+https://github.com/rust-lang/crates.io-index)" = "4c691c0e608126e00913e33f0ccf3727d5fc84573623b8d65b2df340b5201783"

--- a/testsuite/cluster-test/Cargo.toml
+++ b/testsuite/cluster-test/Cargo.toml
@@ -20,6 +20,7 @@ rusoto_core = {version = "0.41.0", features=["rustls"], default_features = false
 rusoto_ec2 = {version = "0.41.0", features=["rustls"], default_features = false}
 rusoto_ecr = {version = "0.41.0", features=["rustls"], default_features = false}
 rusoto_ecs = {version = "0.41.0", features=["rustls"], default_features = false}
+rusoto_s3 = {version = "0.41.0", features=["rustls"], default_features = false}
 serde_json = "1.0"
 termion = "1.5.3"
 serde = { version = "1.0.89", features = ["derive"] }

--- a/testsuite/cluster-test/src/effects/generate_cpu_flamegraph.rs
+++ b/testsuite/cluster-test/src/effects/generate_cpu_flamegraph.rs
@@ -1,0 +1,54 @@
+// Copyright (c) The Libra Core Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+#![forbid(unsafe_code)]
+
+use crate::{effects::Action, instance::Instance};
+use anyhow::Result;
+use async_trait::async_trait;
+use slog_scope::info;
+use std::fmt;
+
+pub struct GenerateCpuFlamegraph {
+    instance: Instance,
+    duration_secs: usize,
+}
+
+impl GenerateCpuFlamegraph {
+    pub fn new(instance: Instance, duration_secs: usize) -> Self {
+        Self {
+            instance,
+            duration_secs,
+        }
+    }
+}
+
+#[async_trait]
+impl Action for GenerateCpuFlamegraph {
+    async fn apply(&self) -> Result<()> {
+        info!("GenerateCpuFlamegraph {}", self.instance);
+        let cmd = format!(
+            r#"
+                set -e;
+                rm -rf /tmp/perf-data;
+                mkdir /tmp/perf-data;
+                cd /tmp/perf-data;
+                sudo perf record -F 99 -p $(ps aux | grep libra-node | grep -v grep | awk '{{print $2}}') --output=perf.data --call-graph dwarf -- sleep {};
+                sudo perf script --input=perf.data | sudo /usr/local/etc/FlameGraph/stackcollapse-perf.pl > out.perf-folded;
+                sudo /usr/local/etc/FlameGraph/flamegraph.pl out.perf-folded > perf-kernel.svg;
+                "#,
+            self.duration_secs
+        );
+        self.instance.run_cmd(vec![cmd.as_str()]).await?;
+        self.instance
+            .scp("/tmp/perf-data/perf-kernel.svg", "perf-kernel.svg")
+            .await?;
+        Ok(())
+    }
+}
+
+impl fmt::Display for GenerateCpuFlamegraph {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "GenerateCpuFlamegraph {}", self.instance)
+    }
+}

--- a/testsuite/cluster-test/src/effects/mod.rs
+++ b/testsuite/cluster-test/src/effects/mod.rs
@@ -4,6 +4,7 @@
 #![forbid(unsafe_code)]
 
 mod delete_libra_data;
+mod generate_cpu_flamegraph;
 mod network_delay;
 mod packet_loss;
 mod reboot;
@@ -14,6 +15,7 @@ use anyhow::Result;
 pub use delete_libra_data::DeleteLibraData;
 
 use async_trait::async_trait;
+pub use generate_cpu_flamegraph::GenerateCpuFlamegraph;
 pub use network_delay::three_region_simulation_effects;
 pub use network_delay::NetworkDelay;
 pub use packet_loss::PacketLoss;

--- a/testsuite/cluster-test/src/experiments/cpu_flamegraph.rs
+++ b/testsuite/cluster-test/src/experiments/cpu_flamegraph.rs
@@ -1,0 +1,104 @@
+// Copyright (c) The Libra Core Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::experiments::ExperimentParam;
+use crate::{
+    aws, cluster::Cluster, experiments::Context, experiments::Experiment, instance,
+    instance::Instance,
+};
+
+use crate::effects::{Action, GenerateCpuFlamegraph};
+use anyhow::{format_err, Result};
+use async_trait::async_trait;
+use chrono::{Datelike, Timelike, Utc};
+use futures::future::FutureExt;
+use futures::join;
+use std::{
+    collections::HashSet,
+    fmt::{Display, Error, Formatter},
+    time::Duration,
+};
+use structopt::StructOpt;
+
+#[derive(StructOpt, Debug)]
+pub struct CpuFlamegraphParams {
+    #[structopt(
+        long,
+        default_value = "60",
+        help = "Number of seconds for which perf should be run"
+    )]
+    pub duration_secs: usize,
+}
+
+pub struct CpuFlamegraph {
+    duration_secs: usize,
+    perf_instance: Instance,
+}
+
+impl ExperimentParam for CpuFlamegraphParams {
+    type E = CpuFlamegraph;
+    fn build(self, cluster: &Cluster) -> Self::E {
+        let perf_instance = cluster.random_validator_instance();
+        Self::E {
+            duration_secs: self.duration_secs,
+            perf_instance,
+        }
+    }
+}
+
+#[async_trait]
+impl Experiment for CpuFlamegraph {
+    fn affected_validators(&self) -> HashSet<String> {
+        instance::instancelist_to_set(&[self.perf_instance.clone()])
+    }
+
+    async fn run(&mut self, context: &mut Context<'_>) -> Result<()> {
+        let buffer = Duration::from_secs(60);
+        let tx_emitter_duration = 2 * buffer + Duration::from_secs(self.duration_secs as u64);
+        let emit_future = context
+            .tx_emitter
+            .emit_txn_for(
+                tx_emitter_duration,
+                context.cluster.validator_instances().clone(),
+            )
+            .boxed();
+        let flame_graph =
+            GenerateCpuFlamegraph::new(self.perf_instance.clone(), self.duration_secs);
+        let flame_graph_future = tokio::time::delay_for(buffer)
+            .then(|_| flame_graph.apply())
+            .boxed();
+        let (emit_result, flame_graph_result) = join!(emit_future, flame_graph_future);
+        emit_result.map_err(|e| format_err!("Emiting tx failed: {:?}", e))?;
+        flame_graph_result.map_err(|e| format_err!("Failed to generate flamegraph: {:?}", e))?;
+        let now = Utc::now();
+        let filename = format!(
+            "{:04}{:02}{:02}-{:02}{:02}{:02}-libra-node-perf.svg",
+            now.year(),
+            now.month(),
+            now.day(),
+            now.hour(),
+            now.minute(),
+            now.second()
+        );
+        aws::upload_to_s3(
+            "perf-kernel.svg",
+            "toro-cluster-test-flamegraphs",
+            filename.as_str(),
+        )?;
+        context.report.report_text(format!(
+            "perf flamegraph : https://s3.console.aws.amazon.com/s3/object/toro-cluster-test-flamegraphs/{}",
+            filename
+        ));
+        Ok(())
+    }
+
+    fn deadline(&self) -> Duration {
+        Duration::from_secs(480)
+    }
+}
+
+impl Display for CpuFlamegraph {
+    fn fmt(&self, f: &mut Formatter<'_>) -> Result<(), Error> {
+        write!(f, "Generating CpuFlamegraph on {}", self.perf_instance)
+    }
+}

--- a/testsuite/cluster-test/src/experiments/mod.rs
+++ b/testsuite/cluster-test/src/experiments/mod.rs
@@ -3,6 +3,7 @@
 
 #![forbid(unsafe_code)]
 
+mod cpu_flamegraph;
 mod multi_region_network_simulation;
 mod packet_loss_random_validators;
 mod performance_benchmark_nodes_down;
@@ -32,6 +33,7 @@ use crate::report::SuiteReport;
 use crate::tx_emitter::TxEmitter;
 
 use async_trait::async_trait;
+pub use cpu_flamegraph::{CpuFlamegraph, CpuFlamegraphParams};
 use std::collections::HashMap;
 use structopt::{clap::AppSettings, StructOpt};
 
@@ -112,6 +114,7 @@ pub fn get_experiment(name: &str, args: &[String], cluster: &Cluster) -> Box<dyn
         "reboot_random_validators",
         f::<RebootRandomValidatorsParams>(),
     );
+    known_experiments.insert("generate_cpu_flamegraph", f::<CpuFlamegraphParams>());
 
     let builder = known_experiments.get(name).expect("Experiment not found");
     builder(args, cluster)

--- a/testsuite/cluster-test/src/instance.rs
+++ b/testsuite/cluster-test/src/instance.rs
@@ -57,11 +57,33 @@ impl Instance {
             ssh_dest.as_str(),
         ];
         let mut ssh_cmd = tokio::process::Command::new("timeout");
-        ssh_cmd.arg("60").args(ssh_args).args(args);
+        ssh_cmd.arg("90").args(ssh_args).args(args);
         if no_std_err {
             ssh_cmd.stderr(Stdio::null());
         }
         let status = ssh_cmd.status().await?;
+        ensure!(
+            status.success(),
+            "Failed with code {}",
+            status.code().unwrap_or(-1)
+        );
+        Ok(())
+    }
+
+    pub async fn scp(&self, remote_file: &str, local_file: &str) -> Result<()> {
+        let remote_file = format!("ec2-user@{}:{}", self.ip, remote_file);
+        let status = tokio::process::Command::new("scp")
+            .args(vec![
+                "-i",
+                "/libra_rsa",
+                "-oStrictHostKeyChecking=no",
+                "-oConnectTimeout=3",
+                "-oConnectionAttempts=10",
+                remote_file.as_str(),
+                local_file,
+            ])
+            .status()
+            .await?;
         ensure!(
             status.success(),
             "Failed with code {}",

--- a/testsuite/cluster-test/src/suite.rs
+++ b/testsuite/cluster-test/src/suite.rs
@@ -5,7 +5,7 @@
 use std::cmp::min;
 use std::env;
 
-use crate::experiments::ExperimentParam;
+use crate::experiments::{CpuFlamegraphParams, ExperimentParam};
 use crate::{
     cluster::Cluster,
     experiments::{
@@ -52,6 +52,9 @@ impl ExperimentSuite {
         ));
         experiments.push(Box::new(
             PerformanceBenchmarkThreeRegionSimulationParams {}.build(cluster),
+        ));
+        experiments.push(Box::new(
+            CpuFlamegraphParams { duration_secs: 60 }.build(cluster),
         ));
         Self { experiments }
     }


### PR DESCRIPTION
# Summary
We generate load on the cluster and pick one validator and run perf against it to generate the FlameGraph
This FlameGraph is copied locally to cluster-test host and then uploaded to S3

# Test Plan

Tested on cluster-test-ci

```
Feb 04 23:50:20.807 INFO Starting experiment Generating CpuFlamegraph on cluster-test-ci-validator-87(10.0.1.53)
Feb 04 23:50:22.278 INFO Completed minting seed accounts
Feb 04 23:50:27.609 INFO Mint is done
Feb 04 23:53:29.720 INFO GenerateCpuFlamegraph cluster-test-ci-validator-87(10.0.1.53)
Feb 04 23:54:32.229 INFO Experiment finished, waiting until all affected validators recover
Feb 04 23:54:37.242 INFO Experiment completed
Feb 04 23:54:37.242 INFO Experiment Result: perf flamegraph : https://s3.console.aws.amazon.com/s3/object/toro-cluster-test-flamegraphs/20200204-235432-libra-node-perf.svg
Shared connection to ssh.cluster-test-ci.aws.hlw3truzy4ls.com closed.
```
