### PR TITLE
[docker] Add config-builder to safety-rules image

### DIFF
--- a/docker/safety-rules/Dockerfile
+++ b/docker/safety-rules/Dockerfile
@@ -17,14 +17,16 @@ FROM toolchain AS builder
 COPY . /libra
 
 RUN cargo build --release -p libra-node -p cli -p config-builder -p safety-rules && cd target/release && rm -r build deps incremental
+RUN strip /libra/target/release/config-builder
 
 ### Production Image ###
 FROM debian:buster AS prod
 
 RUN addgroup --system --gid 6180 libra && adduser --system --ingroup libra --no-create-home --uid 6180 libra
 
-RUN mkdir -p /opt/libra/bin
+RUN mkdir -p /opt/libra/bin /opt/libra/etc
 COPY --from=builder /libra/target/release/safety-rules /opt/libra/bin
+COPY --from=builder /libra/target/release/config-builder /opt/libra/bin
 
 ENV RUST_BACKTRACE 1
 CMD /opt/libra/bin/safety-rules

--- a/docker/validator-dynamic/docker-run-dynamic-fullnode.sh
+++ b/docker/validator-dynamic/docker-run-dynamic-fullnode.sh
@@ -5,7 +5,8 @@ set -ex
 
 declare -a params
 if [ -n "${CFG_BASE_CONFIG}" ]; then # Path to base config
-	    params+="-t ${CFG_BASE_CONFIG} "
+	    echo "${CFG_BASE_CONFIG}" > /opt/libra/etc/base.config.toml
+	    params+="-t /opt/libra/etc/base.config.toml "
 fi
 if [ -n "${CFG_LISTEN_ADDR}" ]; then # Advertised listen address for network config
 	    params+="-a /ip4/${CFG_LISTEN_ADDR}/tcp/6180 "

--- a/docker/validator-dynamic/docker-run-dynamic.sh
+++ b/docker/validator-dynamic/docker-run-dynamic.sh
@@ -5,7 +5,8 @@ set -ex
 
 declare -a params
 if [ -n "${CFG_BASE_CONFIG}" ]; then # Path to base config
-	    params+="-t ${CFG_BASE_CONFIG} "
+	    echo "${CFG_BASE_CONFIG}" > /opt/libra/etc/base.config.toml
+	    params+="-t /opt/libra/etc/base.config.toml "
 fi
 if [ -n "${CFG_LISTEN_ADDR}" ]; then # Advertised listen address for network config
 	    params+="-a /ip4/${CFG_LISTEN_ADDR}/tcp/6180 "


### PR DESCRIPTION
## Motivation

safety-rules currently uses the same config as the validator, so we need to be able to generate the config. Add config-builder binary to the image so this is possible.

## Test Plan

Built the image.