### PR TITLE
[CI] Run cluster test bench at land time

### DIFF
--- a/.github/workflows/land-blocking.yml
+++ b/.github/workflows/land-blocking.yml
@@ -1,0 +1,27 @@
+---
+name: Land-blocking Test
+
+on:
+  push:
+    branches:
+      - auto
+
+jobs:
+  build-and-run-cluster-test:
+    name: Build images and run cluster test
+    runs-on: self-hosted
+    steps:
+    - uses: actions/checkout@v1
+    - name: Setup env
+      run: |
+        echo "::set-env name=LIBRA_GIT_REV::$(git rev-parse --short=8 HEAD)"
+    - name: Build, tag and push images
+      run: |
+        docker/build-aws.sh --build-all --version $LIBRA_GIT_REV --addl_tags canary
+    - name: Launch cluster test
+      run: |
+        JUMPHOST=${{secrets.CLUSTER_TEST_JUMPHOST}} \
+        ./scripts/cti \
+          --tag dev_$LIBRA_GIT_REV \
+          --report report.json \
+          --run bench


### PR DESCRIPTION
## Motivation
Run the test bench suite of cluster test at land time. This relies on
bors to push the PR to the auto branch. A self-hosted GitHub Actions
runner then picks up the push request and carries out the cluster test
workflow. This workflow will block a PR from landing if the cluster test
fails. Currently, the workflow completes in 20 minutes.

## Test Plan
This workflow has been tested in a private repo setup.
![image](https://user-images.githubusercontent.com/7528420/73872437-8f54f480-4804-11ea-9302-99528b740924.png)
