### PR TITLE
[Cli] Retrieve a waypoint value from a given url

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -620,6 +620,7 @@ dependencies = [
  "structopt 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "tonic 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "transaction-builder 0.1.0",
+ "ureq 0.11.3 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]

--- a/client/cli/Cargo.toml
+++ b/client/cli/Cargo.toml
@@ -23,6 +23,7 @@ reqwest = { version = "0.10.1", features = ["blocking"], default-features = fals
 serde = { version = "1.0.96", features = ["derive"] }
 serde_json = "1.0.40"
 structopt = "0.3.2"
+ureq = { version = "0.11.3"}
 
 admission-control-proto = { path = "../../admission_control/admission-control-proto", version = "0.1.0" }
 libra-config = { path = "../../config", version = "0.1.0" }

--- a/types/src/waypoint.rs
+++ b/types/src/waypoint.rs
@@ -45,9 +45,21 @@ impl Waypoint {
 
     /// Errors in case the given ledger info does not match the waypoint.
     pub fn verify(&self, ledger_info: &LedgerInfo) -> Result<()> {
-        ensure!(ledger_info.version() == self.version(), "Version mismatch");
+        ensure!(
+            ledger_info.version() == self.version(),
+            "Waypoint version mismatch: waypoint version = {}, given version = {}",
+            self.version(),
+            ledger_info.version()
+        );
         let converter = Ledger2WaypointConverter::new(ledger_info)?;
-        ensure!(converter.hash() == self.value(), "HashValue mismatch");
+        ensure!(
+            converter.hash() == self.value(),
+            format!(
+                "Waypoint value mismatch: waypoint value = {}, given value = {}",
+                self.value().to_hex(),
+                converter.hash().to_hex()
+            )
+        );
         Ok(())
     }
 }


### PR DESCRIPTION
Summary:
Added a waypoint-url cmd line argument to download the waypoint value from.
These are still optional but we might consider making it a non-optional value with a default pointing to https://developers.libra.org/testnet_waypoint.txt.

Testing:
```
./scripts/cli/start_cli_testnet.sh -- --waypoint-url https://developers.libra.org/testnet_waypoint.txt
./scripts/cli/start_cli_testnet.sh
./scripts/cli/start_cli_testnet.sh -- --waypoint 0:997acd1b112a19eb1d2d3dff78677a0009343727926071c3858aeff2ea3499bf
```

Issues: ref #2425