### PR TITLE
[Consensus] Add startup sync processor

### DIFF
--- a/consensus/src/chained_bft/test_utils/mock_storage.rs
+++ b/consensus/src/chained_bft/test_utils/mock_storage.rs
@@ -56,7 +56,7 @@ impl<T: Payload> MockStorage<T> {
 
     pub fn get_ledger_recovery_data(&self) -> LedgerRecoveryData<T> {
         LedgerRecoveryData::new(
-            &self.storage_ledger.lock().unwrap(),
+            self.storage_ledger.lock().unwrap().clone(),
             self.shared_storage.validator_set.clone(),
         )
     }
@@ -205,7 +205,7 @@ impl<T: Payload> PersistentLivenessStorage<T> for EmptyStorage {
     }
 
     async fn recover_from_ledger(&self) -> LedgerRecoveryData<T> {
-        LedgerRecoveryData::new(&LedgerInfo::genesis(), ValidatorSet::new(vec![]))
+        LedgerRecoveryData::new(LedgerInfo::genesis(), ValidatorSet::new(vec![]))
     }
 
     async fn start(&self) -> RecoveryData<T> {


### PR DESCRIPTION
## Motivation
#2188
The startup sync processor is responsible for processing peer messages before an
event processor can be constructed. It will use the sync info in the messages to
try to get blocks(3-chain) for peers.


## Test Plan
`cargo x test -p consensus`, current tests all passes
Will add additional tests when sync processor is being used in `chained_bft_smr`

## TODOs
See Issue