### PR TITLE
Add support for querying DiscoverySetChangeEvent

### DIFF
--- a/storage/libradb/src/libradb_test.rs
+++ b/storage/libradb/src/libradb_test.rs
@@ -6,7 +6,8 @@ use crate::test_helper::{arb_blocks_to_commit, arb_mock_genesis};
 use libra_crypto::hash::CryptoHash;
 use libra_temppath::TempPath;
 use libra_types::{
-    account_config::AccountResource, contract_event::ContractEvent, ledger_info::LedgerInfo,
+    account_config::AccountResource, contract_event::ContractEvent,
+    discovery_set::DISCOVERY_SET_CHANGE_EVENT_PATH, ledger_info::LedgerInfo,
 };
 use proptest::prelude::*;
 use std::collections::HashMap;
@@ -452,6 +453,40 @@ proptest! {
             .verify(ledger_info_with_sigs.ledger_info(), 0, non_existent_address)
             .unwrap();
         assert!(account_state_with_proof.blob.is_none());
+        assert!(events.is_empty());
+    }
+
+    #[test]
+    fn test_get_from_non_existent_event_stream(
+        (genesis_txn_to_commit, ledger_info_with_sigs) in arb_mock_genesis(),
+    ) {
+        let tmp_dir = TempPath::new();
+        let db = LibraDB::new(&tmp_dir);
+
+        let account = genesis_txn_to_commit
+            .transaction()
+            .as_signed_user_txn()
+            .unwrap()
+            .sender();
+
+        db.save_transactions(&[genesis_txn_to_commit], 0, Some(&ledger_info_with_sigs)).unwrap();
+
+        // The mock genesis txn is really just an ordinary user account, there is no
+        // DiscoverySetResource under it.
+        let (events, account_state_with_proof) = db
+            .get_events_by_query_path(
+                &AccessPath::new(account, DISCOVERY_SET_CHANGE_EVENT_PATH.to_vec()),
+                0,
+                true,
+                100,
+                0,
+            )
+            .unwrap();
+
+        account_state_with_proof
+            .verify(ledger_info_with_sigs.ledger_info(), 0, account)
+            .unwrap();
+        assert!(account_state_with_proof.blob.is_some());
         assert!(events.is_empty());
     }
 }

--- a/storage/libradb/src/libradb_test.rs
+++ b/storage/libradb/src/libradb_test.rs
@@ -6,8 +6,7 @@ use crate::test_helper::{arb_blocks_to_commit, arb_mock_genesis};
 use libra_crypto::hash::CryptoHash;
 use libra_temppath::TempPath;
 use libra_types::{
-    account_config::AccountResource, contract_event::ContractEvent,
-    discovery_set::DISCOVERY_SET_CHANGE_EVENT_PATH, ledger_info::LedgerInfo,
+    account_config::AccountResource, contract_event::ContractEvent, ledger_info::LedgerInfo,
 };
 use proptest::prelude::*;
 use std::collections::HashMap;
@@ -453,40 +452,6 @@ proptest! {
             .verify(ledger_info_with_sigs.ledger_info(), 0, non_existent_address)
             .unwrap();
         assert!(account_state_with_proof.blob.is_none());
-        assert!(events.is_empty());
-    }
-
-    #[test]
-    fn test_get_from_non_existent_event_stream(
-        (genesis_txn_to_commit, ledger_info_with_sigs) in arb_mock_genesis(),
-    ) {
-        let tmp_dir = TempPath::new();
-        let db = LibraDB::new(&tmp_dir);
-
-        let account = genesis_txn_to_commit
-            .transaction()
-            .as_signed_user_txn()
-            .unwrap()
-            .sender();
-
-        db.save_transactions(&[genesis_txn_to_commit], 0, Some(&ledger_info_with_sigs)).unwrap();
-
-        // The mock genesis txn is really just an ordinary user account, there is no
-        // DiscoverySetResource under it.
-        let (events, account_state_with_proof) = db
-            .get_events_by_query_path(
-                &AccessPath::new(account, DISCOVERY_SET_CHANGE_EVENT_PATH.to_vec()),
-                0,
-                true,
-                100,
-                0,
-            )
-            .unwrap();
-
-        account_state_with_proof
-            .verify(ledger_info_with_sigs.ledger_info(), 0, account)
-            .unwrap();
-        assert!(account_state_with_proof.blob.is_some());
         assert!(events.is_empty());
     }
 }

--- a/storage/libradb/src/libradb_test.rs
+++ b/storage/libradb/src/libradb_test.rs
@@ -146,13 +146,9 @@ fn get_events_by_query_path(
             ledger_info.version(),
         )?;
 
-        let expected_event_key_opt = proof_of_latest_event.blob.clone().map(|blob| {
-            let account_resource = AccountResource::try_from(&blob).unwrap();
-            let event_handle = account_resource
-                .get_event_handle_by_query_path(&query_path.path)
-                .unwrap();
-            *event_handle.key()
-        });
+        let (expected_event_key_opt, _count) = proof_of_latest_event
+            .get_event_key_and_count_by_query_path(&query_path.path)
+            .unwrap();
 
         let num_events = events_with_proof.len() as u64;
         proof_of_latest_event.verify(ledger_info, ledger_info.version(), query_path.address)?;

--- a/types/src/access_path.rs
+++ b/types/src/access_path.rs
@@ -220,17 +220,6 @@ impl AccessPath {
         Self::new(address, ACCOUNT_RESOURCE_PATH.to_vec())
     }
 
-    /// Create an AccessPath for a ContractEvent.
-    /// That is an AccessPah that uniquely identifies a given event for a published resource.
-    pub fn new_for_event(address: AccountAddress, root: &[u8], key: &[u8]) -> Self {
-        let mut path: Vec<u8> = Vec::new();
-        path.extend_from_slice(root);
-        path.push(b'/');
-        path.extend_from_slice(key);
-        path.push(b'/');
-        Self::new(address, path)
-    }
-
     /// Create an AccessPath to the event for the sender account in a deposit operation.
     /// The sent counter in LibraAccount.T (LibraAccount.T.sent_events_count) is used to generate
     /// the AccessPath.

--- a/types/src/account_config.rs
+++ b/types/src/account_config.rs
@@ -9,7 +9,7 @@ use crate::{
     identifier::{IdentStr, Identifier},
     language_storage::StructTag,
 };
-use anyhow::{bail, Result};
+use anyhow::Result;
 use once_cell::sync::Lazy;
 #[cfg(any(test, feature = "fuzzing"))]
 use proptest_derive::Arbitrary;
@@ -177,16 +177,6 @@ impl AccountResource {
     /// Return the delegated_withdrawal_capability field for the given AccountResource
     pub fn delegated_withdrawal_capability(&self) -> bool {
         self.delegated_withdrawal_capability
-    }
-
-    pub fn get_event_handle_by_query_path(&self, query_path: &[u8]) -> Result<&EventHandle> {
-        if *ACCOUNT_RECEIVED_EVENT_PATH == query_path {
-            Ok(&self.received_events)
-        } else if *ACCOUNT_SENT_EVENT_PATH == query_path {
-            Ok(&self.sent_events)
-        } else {
-            bail!("Unrecognized query path: {:?}", query_path);
-        }
     }
 }
 

--- a/types/src/account_state/mod.rs
+++ b/types/src/account_state/mod.rs
@@ -27,10 +27,10 @@ impl AccountState {
     pub fn get_event_handle_by_query_path(&self, query_path: &[u8]) -> Result<Option<EventHandle>> {
         let event_handle = if *ACCOUNT_RECEIVED_EVENT_PATH == query_path {
             self.get_account_resource()?
-                .map(|account_resourese| account_resourese.received_events().clone())
+                .map(|account_resource| account_resource.received_events().clone())
         } else if *ACCOUNT_SENT_EVENT_PATH == query_path {
             self.get_account_resource()?
-                .map(|account_resourese| account_resourese.sent_events().clone())
+                .map(|account_resource| account_resource.sent_events().clone())
         } else {
             bail!("Unrecognized query path: {:?}", query_path);
         };

--- a/types/src/get_with_proof.rs
+++ b/types/src/get_with_proof.rs
@@ -367,16 +367,8 @@ fn verify_get_events_by_access_path_resp(
 ) -> Result<()> {
     proof_of_latest_event.verify(ledger_info, ledger_info.version(), req_access_path.address)?;
 
-    let (seq_num_upper_bound, expected_event_key_opt) = {
-        if let Some(blob) = &proof_of_latest_event.blob {
-            let account_resource = AccountResource::try_from(blob)?;
-            let event_handle =
-                account_resource.get_event_handle_by_query_path(&req_access_path.path)?;
-            (event_handle.count(), Some(*event_handle.key()))
-        } else {
-            (0, None)
-        }
-    };
+    let (expected_event_key_opt, seq_num_upper_bound) =
+        proof_of_latest_event.get_event_key_and_count_by_query_path(&req_access_path.path)?;
 
     let cursor =
         if !req_ascending && req_start_seq_num == u64::max_value() && seq_num_upper_bound > 0 {


### PR DESCRIPTION

## Motivation

So that it's queryable via public API `GetEventsByAccessPath`.

At the same time, querying a event stream that's not present is no longer an error, rather, we return a empty vec.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

Unit tests added.

## Related PRs

(If this PR adds or changes functionality, please take some time to update the docs at https://github.com/libra/website, and link to your PR here.)
