### PR TITLE
[cluster-test] New knob --threads-per-ac for smaller validator sets

### DIFF
--- a/testsuite/cluster-test/src/experiments/multi_region_network_simulation.rs
+++ b/testsuite/cluster-test/src/experiments/multi_region_network_simulation.rs
@@ -18,7 +18,7 @@ use crate::experiments::{Context, ExperimentParam};
 
 use crate::cluster::Cluster;
 use crate::experiments::Experiment;
-use crate::tx_emitter::{EmitJobRequest, EmitThreadParams, TxEmitter};
+use crate::tx_emitter::{EmitJobRequest, TxEmitter};
 use crate::util::unix_timestamp_now;
 use async_trait::async_trait;
 use futures::future::join_all;
@@ -205,11 +205,9 @@ impl Experiment for MultiRegionSimulation {
         for split in &self.params.splits {
             for cross_region_latency in &self.params.cross_region_latencies {
                 let job = emitter
-                    .start_job(EmitJobRequest {
-                        instances: context.cluster.validator_instances().clone(),
-                        accounts_per_client: 10,
-                        thread_params: EmitThreadParams::default(),
-                    })
+                    .start_job(EmitJobRequest::for_instances(
+                        context.cluster.validator_instances().clone(),
+                    ))
                     .await
                     .expect("Failed to start emit job");
                 // Wait for minting to complete and transactions to start

--- a/testsuite/cluster-test/src/experiments/recovery_time.rs
+++ b/testsuite/cluster-test/src/experiments/recovery_time.rs
@@ -12,7 +12,7 @@ use crate::cluster::Cluster;
 use crate::effects::{DeleteLibraData, Effect, StopContainer};
 use crate::experiments::{Context, ExperimentParam};
 use crate::instance::Instance;
-use crate::tx_emitter::{EmitJobRequest, EmitThreadParams};
+use crate::tx_emitter::EmitJobRequest;
 use crate::{effects::Action, experiments::Experiment};
 use async_trait::async_trait;
 use slog_scope::info;
@@ -58,11 +58,7 @@ impl Experiment for RecoveryTime {
         context
             .tx_emitter
             .mint_accounts(
-                &EmitJobRequest {
-                    instances: context.cluster.validator_instances().to_vec(),
-                    accounts_per_client: 100,
-                    thread_params: EmitThreadParams::default(),
-                },
+                &EmitJobRequest::for_instances(context.cluster.validator_instances().to_vec()),
                 self.params.num_accounts_to_mint as usize,
             )
             .await?;


### PR DESCRIPTION
This will allow to customize number of threads per AC.

- Will need this knob for pre-mainnet test, as we going to have fewer validators for now
- Also might help with perf test on small validator count

By default the value is automatically calculated to make a best guess of optimal number of threads per AC:
- We don't want too many threads, so we limit it to 10 per AC
- We want at least 1 thread per AC
- We want to make sure that on average we have about 75-150 AC threads total
- We want to have equal number of threads for each AC
