### PR TITLE
[move source language] IR Test Translation Tooling

### DIFF
--- a/language/move-lang/Cargo.toml
+++ b/language/move-lang/Cargo.toml
@@ -36,3 +36,7 @@ harness = false
 [[test]]
 name = "functional_testsuite"
 harness = false
+
+[[test]]
+name = "ir_test_coverage"
+harness = true

--- a/language/move-lang/src/bin/ir-file-translation.rs
+++ b/language/move-lang/src/bin/ir-file-translation.rs
@@ -1,0 +1,32 @@
+// Copyright (c) The Libra Core Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+#![forbid(unsafe_code)]
+
+use move_lang::ir_translation::fix_syntax_and_write;
+use std::fs;
+use std::path::Path;
+use structopt::*;
+
+#[derive(Debug, StructOpt)]
+#[structopt(
+    name = "IR Test Translation",
+    about = "Regex based translation tool for IR Functional Tests into the source language"
+)]
+pub struct Options {
+    /// The IR file to translatee
+    #[structopt(name = "FILE_TO_TRANSLATE", short = "i", long = "input")]
+    pub input: String,
+    /// The file to write the outpput
+    #[structopt(name = "OUTPUT_FILE", short = "o", long = "output")]
+    pub output: String,
+}
+
+pub fn main() -> std::io::Result<()> {
+    let Options { input, output } = Options::from_args();
+    let input_path = Path::new(&input);
+    let contents = fs::read_to_string(input_path).unwrap();
+    let output_path = Path::new(&output);
+    fix_syntax_and_write(output_path, contents);
+    Ok(())
+}

--- a/language/move-lang/src/bin/ir-test-translation.rs
+++ b/language/move-lang/src/bin/ir-test-translation.rs
@@ -1,0 +1,48 @@
+// Copyright (c) The Libra Core Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+#![forbid(unsafe_code)]
+
+use move_lang::{ir_translation::fix_syntax_and_write, test_utils::*};
+use regex::Regex;
+use std::fs;
+use std::path::Path;
+use structopt::*;
+
+#[derive(Debug, StructOpt)]
+#[structopt(
+    name = "IR Test Translation",
+    about = "Regex based translation tool for IR Functional Tests into the source language"
+)]
+pub struct Options {
+    /// The IR dirctory to translate
+    #[structopt(name = "DIRECTORY_TO_TRANSLATE", short = "d", long = "directory")]
+    pub directory: String,
+}
+
+const PATH_TO_IR_TESTS: &str = "../ir-testsuite/tests";
+
+pub fn main() -> std::io::Result<()> {
+    let Options { directory } = Options::from_args();
+    let main_regex = Regex::new(r".*main\(.*\)\s*\{").unwrap();
+    for (subdir, name) in ir_tests().filter(|(subdir, _)| subdir == &directory) {
+        let pname = format!("{}/{}/{}", PATH_TO_IR_TESTS, subdir, name);
+        let path = Path::new(&pname);
+        let basename = path.file_stem().unwrap().to_str().unwrap();
+        let contents = fs::read_to_string(path).unwrap();
+
+        let has_main = main_regex.is_match(&contents);
+        let out_name = match translated_ir_test_name(has_main, &subdir, basename) {
+            None => continue,
+            Some(n) => n,
+        };
+        let out_path = Path::new(&out_name);
+        let parent_dir = out_path.parent().unwrap();
+        if !parent_dir.is_dir() {
+            fs::create_dir_all(parent_dir).unwrap();
+        }
+
+        fix_syntax_and_write(out_path, contents);
+    }
+    Ok(())
+}

--- a/language/move-lang/src/ir_translation.rs
+++ b/language/move-lang/src/ir_translation.rs
@@ -1,0 +1,31 @@
+// Copyright (c) The Libra Core Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::{shared::fake_natives::transaction as TXN, shared::Address};
+use regex::{NoExpand, Regex};
+use std::fs;
+use std::path::Path;
+
+fn txn(n: &str) -> String {
+    format!("{}::{}::{}(", Address::LIBRA_CORE, TXN::MOD, n)
+}
+
+macro_rules! replace {
+    ($input:ident, $pat:expr, $replacer:expr) => {{
+        let regex = Regex::new($pat).unwrap();
+        regex.replace_all(&$input, $replacer)
+    }};
+}
+
+#[allow(clippy::trivial_regex)]
+pub fn fix_syntax_and_write(out_path: &Path, contents: String) {
+    let contents = replace!(contents, r"get_txn_sender\(", NoExpand(&txn(TXN::SENDER)));
+    let contents = replace!(contents, r"assert\(", NoExpand(&txn(TXN::ASSERT)));
+    let contents = replace!(contents, r"move\((\w+)\)", "move $1");
+    let contents = replace!(contents, r"copy\((\w+)\)", "copy $1");
+    let contents = replace!(contents, r"resource\s+(\w)", "resource struct $1");
+    let contents = replace!(contents, r"import", NoExpand("use"));
+    let contents = replace!(contents, r"Self\.", NoExpand(""));
+    let contents = replace!(contents, r"(([A-Z]\w*)|(\}\})|(0x\d+))\.", "$1::");
+    fs::write(out_path, contents.as_bytes()).unwrap();
+}

--- a/language/move-lang/src/lib.rs
+++ b/language/move-lang/src/lib.rs
@@ -18,6 +18,7 @@ pub mod typing;
 
 pub mod command_line;
 
+pub mod ir_translation;
 pub mod test_utils;
 
 use codespan::{ByteIndex, Span};

--- a/language/move-lang/src/test_utils/mod.rs
+++ b/language/move-lang/src/test_utils/mod.rs
@@ -5,8 +5,33 @@ use std::path::Path;
 
 pub struct StringError(String);
 
-pub const STD_LIB: &str = "stdlib/modules";
 pub const SENDER: &str = "0x8675309";
+
+pub const STD_LIB_DIR: &str = "stdlib/modules";
+pub const FUNCTIONAL_TEST_DIR: &str = "tests/functional";
+pub const MOVE_CHECK_DIR: &str = "tests/move_check";
+pub const STD_LIB_TRANSACTION_SCRIPTS_DIR: &str = "stdlib/transaction_scripts";
+pub const PATH_TO_IR_TESTS: &str = "../ir-testsuite/tests";
+
+pub const MIGRATION_SUB_DIR: &str = "translated_ir_tests";
+pub const TODO_EXTENSION: &str = "move_TODO";
+pub const MOVE_EXTENSION: &str = "move";
+pub const IR_EXTENSION: &str = "mvir";
+
+pub const COMPLETED_DIRECTORIES: &[&str; 0] = &[];
+
+pub fn stdlib_files() -> Vec<String> {
+    let dirfiles = datatest_stable::utils::iterate_directory(Path::new(STD_LIB_DIR));
+    dirfiles
+        .flat_map(|path| {
+            if path.extension()?.to_str()? == MOVE_EXTENSION {
+                path.into_os_string().into_string().ok()
+            } else {
+                None
+            }
+        })
+        .collect()
+}
 
 impl std::fmt::Display for StringError {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
@@ -26,19 +51,6 @@ impl std::error::Error for StringError {
     }
 }
 
-pub fn stdlib_files() -> Vec<String> {
-    let dirfiles = datatest_stable::utils::iterate_directory(Path::new(STD_LIB));
-    dirfiles
-        .flat_map(|path| {
-            if path.extension()?.to_str()? == "move" {
-                path.into_os_string().into_string().ok()
-            } else {
-                None
-            }
-        })
-        .collect()
-}
-
 pub fn read_env_var(v: &str) -> String {
     std::env::var(v).unwrap_or_else(|_| "".into())
 }
@@ -50,4 +62,47 @@ pub fn read_bool_var(v: &str) -> bool {
 
 pub fn error(s: String) -> datatest_stable::Result<()> {
     Err(Box::new(StringError(s)))
+}
+
+//**************************************************************************************************
+// IR Test Translation
+//**************************************************************************************************
+
+pub fn ir_tests() -> impl Iterator<Item = (String, String)> {
+    macro_rules! comp_to_string {
+        ($comp_opt:expr) => {{
+            $comp_opt.unwrap().as_os_str().to_str()?.to_owned()
+        }};
+    }
+    datatest_stable::utils::iterate_directory(Path::new(PATH_TO_IR_TESTS)).flat_map(|path| {
+        if path.extension()?.to_str()? != IR_EXTENSION {
+            return None;
+        }
+        let pathbuf = path.canonicalize().ok()?;
+        let mut components = pathbuf.components().rev();
+        let name = comp_to_string!(components.next());
+        let dir = comp_to_string!(components.next());
+        Some((dir, name))
+    })
+}
+
+pub fn translated_ir_test_name(has_main: bool, subdir: &str, name: &str) -> Option<String> {
+    let fmt = |dir, subdir, basename, ext| {
+        format!(
+            "{}/{}/{}/{}.{}",
+            dir, MIGRATION_SUB_DIR, subdir, basename, ext
+        )
+    };
+    let check = |x| Path::new(x).is_file();
+    let ft = fmt(FUNCTIONAL_TEST_DIR, subdir, name, MOVE_EXTENSION);
+    let ft_todo = fmt(FUNCTIONAL_TEST_DIR, subdir, name, TODO_EXTENSION);
+    let mc = fmt(MOVE_CHECK_DIR, subdir, name, MOVE_EXTENSION);
+    let mc_todo = fmt(MOVE_CHECK_DIR, subdir, name, TODO_EXTENSION);
+    if check(&ft) || check(&ft_todo) || check(&mc) || check(&mc_todo) {
+        None
+    } else if has_main {
+        Some(ft)
+    } else {
+        Some(mc)
+    }
 }

--- a/language/move-lang/tests/functional_testsuite.rs
+++ b/language/move-lang/tests/functional_testsuite.rs
@@ -7,7 +7,7 @@ use functional_tests::{
     testsuite,
 };
 use libra_types::account_address::AccountAddress as LibraAddress;
-use move_lang::test_utils::stdlib_files;
+use move_lang::test_utils::{stdlib_files, FUNCTIONAL_TEST_DIR};
 use move_lang::{move_compile_no_report, shared::Address, to_bytecode::translate::CompiledUnit};
 use std::{convert::TryFrom, io::Write, path::Path};
 use tempfile::NamedTempFile;
@@ -71,4 +71,4 @@ fn functional_testsuite(path: &Path) -> datatest_stable::Result<()> {
     testsuite::functional_tests(compiler, path)
 }
 
-datatest_stable::harness!(functional_testsuite, "tests/functional", r".*\.move");
+datatest_stable::harness!(functional_testsuite, FUNCTIONAL_TEST_DIR, r".*\.move");

--- a/language/move-lang/tests/ir_test_coverage.rs
+++ b/language/move-lang/tests/ir_test_coverage.rs
@@ -1,0 +1,44 @@
+// Copyright (c) The Libra Core Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+use move_lang::test_utils::*;
+use std::collections::HashSet;
+use std::path::Path;
+
+#[test]
+fn test_ir_test_coverage() {
+    for completed_directory in COMPLETED_DIRECTORIES {
+        let dir = format!("{}/{}", PATH_TO_IR_TESTS, completed_directory);
+        let p = Path::new(&dir);
+        if !p.is_dir() {
+            panic!("Invalid completed directory. '{}' does not exist", dir)
+        }
+    }
+    let completed_directories: HashSet<String> = COMPLETED_DIRECTORIES
+        .iter()
+        .map(|s| (*s).to_owned())
+        .collect();
+
+    let not_migrated = ir_tests()
+        .filter(|(subdir, name)| {
+            completed_directories.contains(subdir) && !translated_test_exists(subdir, name)
+        })
+        .map(|(subdir, name)| format!("{}/{}/{}", PATH_TO_IR_TESTS, subdir, name))
+        .collect::<Vec<_>>();
+    if !not_migrated.is_empty() {
+        let mut msg = "\nThe following tests have not been migrated:\n".to_owned();
+        for path in not_migrated {
+            msg.push_str(&format!("{}\n", path));
+        }
+        panic!(msg)
+    }
+}
+
+fn translated_test_exists(subdir: &str, name_str: &str) -> bool {
+    let mut stem = name_str.to_owned();
+    (0..=IR_EXTENSION.len()).for_each(|_| {
+        stem.pop().unwrap();
+    });
+    let stem_str = &stem;
+    translated_ir_test_name(false, subdir, stem_str).is_some()
+}

--- a/language/move-lang/tests/move_check_testsuite.rs
+++ b/language/move-lang/tests/move_check_testsuite.rs
@@ -111,4 +111,4 @@ fn move_check_testsuite(path: &Path) -> datatest_stable::Result<()> {
     }
 }
 
-datatest_stable::harness!(move_check_testsuite, "tests/move_check", r".*\.move");
+datatest_stable::harness!(move_check_testsuite, MOVE_CHECK_DIR, r".*\.move");

--- a/language/move-lang/tests/stdlib_sanity_check.rs
+++ b/language/move-lang/tests/stdlib_sanity_check.rs
@@ -48,6 +48,6 @@ fn sanity_check_testsuite(path: &Path) -> datatest_stable::Result<()> {
 
 datatest_stable::harness!(
     sanity_check_testsuite,
-    "stdlib/transaction_scripts",
+    STD_LIB_TRANSACTION_SCRIPTS_DIR,
     r".*\.move"
 );


### PR DESCRIPTION
##  Motivation

- Added regex based tool for translating IR tests into Move source langauge tests
  - Test creates either a functional or move_check test depending on if there is a main
  - Some tests with main that fail will need to be moved manually to move_check
  - The regex removes a lot of cruft and makes the syntax migration easier
- Added a coverage test to mark directories as done to prevent drift

## Test Plan

- Ran em
- Utilized migration tool in upcoming PR