### PR TITLE
[cluster-test] Calculate avg block size during bench

### DIFF
--- a/testsuite/cluster-test/src/experiments/performance_benchmark_nodes_down.rs
+++ b/testsuite/cluster-test/src/experiments/performance_benchmark_nodes_down.rs
@@ -91,6 +91,7 @@ impl Experiment for PerformanceBenchmarkNodesDown {
         let end = unix_timestamp_now() - buffer;
         let start = end - window + 2 * buffer;
         let (avg_tps, avg_latency) = stats::txn_stats(&context.prometheus, start, end)?;
+        let avg_txns_per_block = stats::avg_txns_per_block(&context.prometheus, start, end)?;
         info!(
             "Link to dashboard : {}",
             context.prometheus.link_to_dashboard(start, end)
@@ -105,10 +106,14 @@ impl Experiment for PerformanceBenchmarkNodesDown {
         context
             .report
             .report_metric(&self, "expired_txn", expired_txn as f64);
+        context
+            .report
+            .report_metric(&self, "avg_txns_per_block", avg_txns_per_block as f64);
         context.report.report_metric(&self, "avg_tps", avg_tps);
         context
             .report
             .report_metric(&self, "avg_latency", avg_latency);
+        info!("avg_txns_per_block: {}", avg_txns_per_block);
         let expired_text = if expired_txn == 0 {
             "no expired txns".to_string()
         } else {

--- a/testsuite/cluster-test/src/stats.rs
+++ b/testsuite/cluster-test/src/stats.rs
@@ -16,6 +16,17 @@ pub fn avg_tps(prometheus: &Prometheus, start: Duration, end: Duration) -> Resul
         .map_err(|e| format_err!("No tps data: {}", e))
 }
 
+pub fn avg_txns_per_block(prometheus: &Prometheus, start: Duration, end: Duration) -> Result<f64> {
+    prometheus
+        .query_range_avg(
+            "irate(libra_consensus_num_txns_per_block_sum[1m])/irate(libra_consensus_num_txns_per_block_count[1m])".to_string(),
+            &start,
+            &end,
+            10, /* step */
+        )
+        .map_err(|e| format_err!("No txns_per_block data: {}", e))
+}
+
 pub fn avg_latency(prometheus: &Prometheus, start: Duration, end: Duration) -> Result<f64> {
     prometheus.query_range_avg(
         "irate(mempool_duration_sum{op='e2e.latency'}[1m])/irate(mempool_duration_count{op='e2e.latency'}[1m])"


### PR DESCRIPTION
## Summary

Calculate avg block size during bench so that we can detect undersaturated benchmarks.

## Test Plan

```
Feb 06 14:51:41.465 INFO Discovered 20 peers in kush20 workspace
Feb 06 14:51:41.702 INFO Log tail thread started in 236 ms
Feb 06 14:51:41.702 INFO Will use kush20 tag for deployment
Feb 06 14:51:41.947 INFO Starting experiment all up
Feb 06 14:51:41.947 INFO Will use 7 threads per AC with total 140 AC clients
Feb 06 14:51:42.222 INFO Completed minting seed accounts
Feb 06 14:51:43.914 INFO Mint is done
Feb 06 14:55:46.259 INFO Link to dashboard : http://prometheus.kush20.aws.hlw3truzy4ls.com:9091/d/overview10/overview?orgId=1&from=1581000736247&to=1581000916247
Feb 06 14:55:46.259 INFO avg_txns_per_block: 101
Feb 06 14:55:46.260 INFO Experiment finished, waiting until all affected validators recover
Feb 06 14:55:51.301 INFO Experiment completed
Feb 06 14:55:51.302 INFO Experiment Result: all up : 817 TPS, 942.4 ms latency, no expired txns
```
