### PR TITLE
[cluster-test] Correctly propagate error code in cti

### DIFF
--- a/scripts/cti
+++ b/scripts/cti
@@ -2,6 +2,7 @@
 # Copyright (c) The Libra Core Contributors
 # SPDX-License-Identifier: Apache-2.0
 set -e
+set -o pipefail
 
 TAG=""
 PR=""

--- a/testsuite/cluster-test/src/tx_emitter.rs
+++ b/testsuite/cluster-test/src/tx_emitter.rs
@@ -148,7 +148,7 @@ impl TxEmitter {
         let mut all_accounts = all_accounts.into_iter();
         let stop = Arc::new(AtomicBool::new(false));
         let stats = Arc::new(TxStats::default());
-        for _ in 1..threads_per_ac {
+        for _ in 0..threads_per_ac {
             for instance in &req.instances {
                 let instance = instance.clone();
                 let client = Self::make_client(&instance);


### PR DESCRIPTION
Cti stopped propagating error code correctly after adding piping in 3a18eca727caf5cb2a20b915092d267b398af3a3
