### PR TITLE
[tf] set faucet dependency on validator instance

### DIFF
--- a/terraform/faucet.tf
+++ b/terraform/faucet.tf
@@ -39,6 +39,7 @@ data "template_file" "ecs_faucet_definition" {
 
 resource "aws_ecs_task_definition" "faucet" {
   family                = "${terraform.workspace}-faucet"
+  depends_on            = [aws_instance.validator]
   container_definitions = data.template_file.ecs_faucet_definition.rendered
   execution_role_arn    = aws_iam_role.ecsTaskExecutionRole.arn
 


### PR DESCRIPTION
<!--
Thank you for sending a PR. We appreciate you spending time to help improve the Libra project.

The project is undergoing daily changes. Pull Requests will be reviewed and responded to as time permits.
-->

## Motivation

We need to make sure validator instance is created before creating faucet instance.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

terraform apply on dev cluster

## Related PRs

(If this PR adds or changes functionality, please take some time to update the docs at https://github.com/libra/website, and link to your PR here.)
