### PR TITLE
[config-builder] Update docker-run-dynamic.sh to allow for config overrides

### DIFF
--- a/docker/validator-dynamic/docker-run-dynamic.sh
+++ b/docker/validator-dynamic/docker-run-dynamic.sh
@@ -51,4 +51,21 @@ if [ -n "${CFG_FULLNODE_SEED}" ]; then # We have a full node seed, add fullnode 
 
 fi
 
+# Set CFG_OVERRIDES to any values that you want to override in the config
+# Example: CFG_OVERRIDES='grpc_max_receive_len=45,genesis_file_location="genesis2.blob",max_block_size=250'
+# Note: Double quotes are required for string parameters and should be
+# omitted for int parameters.
+# Note: This currently does not work with parameters which are repeated.
+if [ -n "${CFG_OVERRIDES}" ]; then
+  IFS=',' read -ra CFG_OVERRIDES <<< "$CFG_OVERRIDES"
+  for KEY_VAL in "${CFG_OVERRIDES[@]}"; do
+    IFS='=' read -ra KEY_VAL <<< "$KEY_VAL"
+      KEY="${KEY_VAL[0]}"
+      VAL="${KEY_VAL[1]}"
+      echo "Overriding ${KEY} = ${VAL} in node config"
+      sed "s/^${KEY} = .*/${KEY} = ${VAL}/g" /opt/libra/etc/node.config.toml > /tmp/node.config.toml
+      mv /tmp/node.config.toml /opt/libra/etc/node.config.toml
+  done
+fi
+
 exec /opt/libra/bin/libra-node -f /opt/libra/etc/node.config.toml


### PR DESCRIPTION
## Motivation

This allows us to control parameters from the docker run command or the kubernetes pod spec

## Test Plan

Ran locally