### PR TITLE
[land-blocking] Add --marker and --duration to cti invocation

### DIFF
--- a/.github/workflows/land-blocking.yml
+++ b/.github/workflows/land-blocking.yml
@@ -22,6 +22,8 @@ jobs:
       run: |
         JUMPHOST=${{secrets.CLUSTER_TEST_JUMPHOST}} \
         ./scripts/cti \
+          --marker land \
           --tag dev_$LIBRA_GIT_REV \
           --report report.json \
-          --run bench
+          --run bench \
+          -- --duration 60


### PR DESCRIPTION
- --marker will allow to distinguish and gate those calls
- --duration will reduce duration of an experiment

@ankushagarwal raised concern that `60s` might be too small window and contribute to high variation - I propose to start with short window and increase it if needed, when we decide to actually gate landing on TPS data