### PR TITLE
[config] Add default logging filter level to LoggerConfig

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2064,6 +2064,7 @@ dependencies = [
  "parity-multiaddr 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.101 (registry+https://github.com/rust-lang/crates.io-index)",
+ "slog 2.5.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "thiserror 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "toml 0.5.3 (registry+https://github.com/rust-lang/crates.io-index)",
 ]

--- a/client/cli/src/main.rs
+++ b/client/cli/src/main.rs
@@ -11,7 +11,7 @@ use cli::{
     client_proxy::ClientProxy,
     commands::{get_commands, parse_cmd, report_error, Command},
 };
-use libra_logger::set_default_global_logger;
+use libra_logger::set_global_logger;
 use libra_types::waypoint::Waypoint;
 use rustyline::{config::CompletionType, error::ReadlineError, Config, Editor};
 use std::{
@@ -73,7 +73,7 @@ struct Args {
 }
 
 fn main() {
-    let _logger = set_default_global_logger(false /* async */, None);
+    let _logger = set_global_logger(false /* async */, None);
     crash_handler::setup_panic_handler();
     let args = Args::from_args();
 

--- a/common/executable-helpers/src/helpers.rs
+++ b/common/executable-helpers/src/helpers.rs
@@ -68,8 +68,9 @@ fn set_default_global_logger(
         return None;
     }
 
-    Some(libra_logger::set_global_logger(
+    Some(libra_logger::set_global_logger_with_level(
         logger_config.is_async,
         Some(logger_config.chan_size),
+        logger_config.filter_level,
     ))
 }

--- a/common/executable-helpers/src/helpers.rs
+++ b/common/executable-helpers/src/helpers.rs
@@ -68,7 +68,7 @@ fn set_default_global_logger(
         return None;
     }
 
-    Some(libra_logger::set_default_global_logger(
+    Some(libra_logger::set_global_logger(
         logger_config.is_async,
         Some(logger_config.chan_size),
     ))

--- a/common/logger/src/lib.rs
+++ b/common/logger/src/lib.rs
@@ -56,7 +56,7 @@ pub fn set_global_logger(async_drain: bool, chan_size: Option<usize>) -> GlobalL
 }
 
 /// Creates and sets the global logger with the given filter level.
-fn set_global_logger_with_level(
+pub fn set_global_logger_with_level(
     async_drain: bool,
     chan_size: Option<usize>,
     filter_level: FilterLevel,

--- a/config/Cargo.toml
+++ b/config/Cargo.toml
@@ -17,6 +17,7 @@ mirai-annotations = "1.4.0"
 parity-multiaddr = { version = "0.6.0", default-features = false }
 rand = "0.6.5"
 serde = { version = "1.0.99", features = ["rc"], default-features = false }
+slog = { version = "2.5.0", features = ["max_level_trace", "release_max_level_debug"] }
 thiserror = "1.0"
 toml = { version = "0.5.3", default-features = false }
 

--- a/config/src/config/logger_config.rs
+++ b/config/src/config/logger_config.rs
@@ -1,7 +1,9 @@
 // Copyright (c) The Libra Core Contributors
 // SPDX-License-Identifier: Apache-2.0
 
-use serde::{Deserialize, Serialize};
+use serde::{de, Deserialize, Deserializer, Serialize, Serializer};
+use slog::FilterLevel;
+use std::str::FromStr;
 
 #[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
 #[serde(default, deny_unknown_fields)]
@@ -10,6 +12,10 @@ pub struct LoggerConfig {
     pub is_async: bool,
     // chan_size of slog async drain for node logging.
     pub chan_size: usize,
+    // The default logging level for slog.
+    #[serde(serialize_with = "serialize_filter_level")]
+    #[serde(deserialize_with = "deserialize_filter_level")]
+    pub filter_level: FilterLevel,
 }
 
 impl Default for LoggerConfig {
@@ -17,6 +23,29 @@ impl Default for LoggerConfig {
         LoggerConfig {
             is_async: true,
             chan_size: 256,
+            filter_level: FilterLevel::Info,
         }
     }
+}
+
+fn serialize_filter_level<S>(filter_level: &FilterLevel, serializer: S) -> Result<S::Ok, S::Error>
+where
+    S: Serializer,
+{
+    filter_level.as_str().to_string().serialize(serializer)
+}
+
+fn deserialize_filter_level<'de, D>(deserializer: D) -> Result<FilterLevel, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    let filter_level_string: String = Deserialize::deserialize(deserializer)?;
+    FilterLevel::from_str(&filter_level_string).map_err(|_| {
+        de::Error::unknown_variant(
+            &filter_level_string,
+            &[
+                "OFF", "CRITICAL", "ERROR", "WARNING", "INFO", "DEBUG", "TRACE",
+            ],
+        )
+    })
 }

--- a/config/src/config/test_data/random.complete.node.config.toml
+++ b/config/src/config/test_data/random.complete.node.config.toml
@@ -33,6 +33,7 @@ genesis_file_location = ""
 [logger]
 is_async = true
 chan_size = 256
+filter_level = "INFO"
 
 [metrics]
 collection_interval_ms = 1000

--- a/config/src/config/test_data/single.node.config.toml
+++ b/config/src/config/test_data/single.node.config.toml
@@ -77,6 +77,8 @@ upstream_peers = []
 [logger]
 is_async = true
 chan_size = 256
+filter_level = "INFO"
+
 [vm_config.publishing_options]
 type = "Locked"
 whitelist = [

--- a/executor/src/bin/bench.rs
+++ b/executor/src/bin/bench.rs
@@ -25,10 +25,8 @@ struct Opt {
 fn main() {
     let opt = Opt::from_args();
 
-    let _logger = libra_logger::set_default_global_logger(
-        true, /* async_drain */
-        None, /* chan_size */
-    );
+    let _logger =
+        libra_logger::set_global_logger(true /* async_drain */, None /* chan_size */);
 
     rayon::ThreadPoolBuilder::new()
         .thread_name(|index| format!("rayon-global-{}", index))

--- a/network/socket-bench-server/src/main.rs
+++ b/network/socket-bench-server/src/main.rs
@@ -16,7 +16,7 @@
 //!
 //! `TCP_ADDR=/ip6/::1/tcp/12345 cargo bench -p network remote_tcp`
 
-use libra_logger::{prelude::*, set_default_global_logger};
+use libra_logger::{prelude::*, set_global_logger};
 use netcore::transport::tcp::TcpTransport;
 use socket_bench_server::{
     build_tcp_muxer_transport, build_tcp_noise_muxer_transport, build_tcp_noise_transport,
@@ -25,7 +25,7 @@ use socket_bench_server::{
 use tokio::runtime::Runtime;
 
 fn main() {
-    let _logger = set_default_global_logger(false /* async */, None);
+    let _logger = set_global_logger(false /* async */, None);
 
     let args = Args::from_env();
 


### PR DESCRIPTION
## Motivation

This PR performs two actions, in two separate commits:
1. First, it cleans up the common logging code by: (i) removing unnecessary helper functions; and (ii) it renames the default logger creation function to be consistent with the rest of the code.
2. Second, this PR adds the default logging filter level to the logger config. This is more intuitive than keeping it as a hard coded constant in the logger code.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?

Yes.

## Test Plan

A local run of 'cargo xtest' produces the expected output.

## Related PRs

None.