### PR TITLE
[safety-rules] Implement standalone docker container

### DIFF
--- a/consensus/safety-rules/src/lib.rs
+++ b/consensus/safety-rules/src/lib.rs
@@ -18,7 +18,7 @@ mod thread;
 
 pub use crate::{
     consensus_state::ConsensusState, error::Error,
-    persistent_safety_storage::PersistentSafetyStorage, process::ProcessService,
+    persistent_safety_storage::PersistentSafetyStorage, process::Process,
     safety_rules::SafetyRules, safety_rules_manager::SafetyRulesManager,
     t_safety_rules::TSafetyRules,
 };

--- a/consensus/safety-rules/src/main.rs
+++ b/consensus/safety-rules/src/main.rs
@@ -6,7 +6,7 @@
 #![forbid(unsafe_code)]
 
 use libra_config::config::NodeConfig;
-use safety_rules::ProcessService;
+use safety_rules::Process;
 use std::{env, process};
 
 fn main() {
@@ -22,6 +22,6 @@ fn main() {
         process::exit(1);
     });
 
-    let mut service = ProcessService::new(config);
+    let mut service = Process::new(config);
     service.start();
 }

--- a/docker/safety-rules/Dockerfile
+++ b/docker/safety-rules/Dockerfile
@@ -24,7 +24,8 @@ FROM debian:buster AS prod
 
 RUN addgroup --system --gid 6180 libra && adduser --system --ingroup libra --no-create-home --uid 6180 libra
 
-RUN mkdir -p /opt/libra/bin /opt/libra/etc
+RUN mkdir -p /opt/libra/bin /opt/libra/etc /opt/libra/data/common
+COPY docker/safety-rules/docker-run-dynamic.sh /
 COPY --from=builder /libra/target/release/safety-rules /opt/libra/bin
 COPY --from=builder /libra/target/release/config-builder /opt/libra/bin
 

--- a/docker/safety-rules/docker-run-dynamic.sh
+++ b/docker/safety-rules/docker-run-dynamic.sh
@@ -1,0 +1,29 @@
+#!/bin/bash
+# Copyright (c) The Libra Core Contributors
+# SPDX-License-Identifier: Apache-2.0
+set -ex
+
+declare -a params
+if [ -n "${CFG_BASE_CONFIG}" ]; then # Path to base config
+	    echo "${CFG_BASE_CONFIG}" > /opt/libra/etc/base.config.toml
+	    params+="-t /opt/libra/etc/base.config.toml "
+fi
+if [ -n "${CFG_NODE_INDEX}" ]; then
+	    params+="-i ${CFG_NODE_INDEX} "
+fi
+if [ -n "${CFG_NUM_VALIDATORS}" ]; then # Total number of nodes in this network
+	    params+="-n ${CFG_NUM_VALIDATORS} "
+fi
+if [ -n "${CFG_SEED}" ]; then # Random seed to use
+	    params+="-s ${CFG_SEED} "
+fi
+if [ -n "${CFG_SAFETY_RULES_LISTEN_ADDR}" ]; then
+    params+="--safety-rules-addr ${CFG_SAFETY_RULES_LISTEN_ADDR}"
+fi
+
+/opt/libra/bin/config-builder safety-rules \
+    --data-dir /opt/libra/data/common \
+    --output-dir /opt/libra/etc/ \
+    ${params[@]}
+
+exec /opt/libra/bin/safety-rules /opt/libra/etc/node.config.toml

--- a/docker/safety-rules/run.sh
+++ b/docker/safety-rules/run.sh
@@ -1,0 +1,15 @@
+#!/bin/sh
+# Copyright (c) The Libra Core Contributors
+# SPDX-License-Identifier: Apache-2.0
+set -ex
+
+image="${1:-libra_safety_rules:latest}"
+
+docker network create --subnet 172.18.0.0/24 testnet || true
+
+docker run \
+    -e CFG_NODE_INDEX="0" \
+    -e CFG_SAFETY_RULES_LISTEN_ADDR="0.0.0.0:8888" \
+    --ip 172.18.0.2 \
+    --network testnet \
+    "$image"

--- a/docker/validator-dynamic/validator-dynamic.Dockerfile
+++ b/docker/validator-dynamic/validator-dynamic.Dockerfile
@@ -1,26 +1,5 @@
-FROM debian:buster AS toolchain
-
-# To use http/https proxy while building, use:
-# docker build --build-arg https_proxy=http://fwdproxy:8080 --build-arg http_proxy=http://fwdproxy:8080
-
-RUN apt-get update && apt-get install -y cmake curl clang git
-
-RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --default-toolchain none
-ENV PATH "$PATH:/root/.cargo/bin"
-
-WORKDIR /libra
-COPY rust-toolchain /libra/rust-toolchain
-RUN rustup install $(cat rust-toolchain)
-
-FROM toolchain AS config_builder
-
-COPY . /libra
-
-RUN cargo build --release -p libra-node -p cli -p config-builder -p safety-rules && cd target/release && rm -r build deps incremental
-
 ### Production Image ###
 FROM libra_e2e:latest as validator_with_config
-COPY --from=config_builder /libra/target/release/config-builder /opt/libra/bin
 COPY docker/validator-dynamic/docker-run-dynamic.sh /
 COPY docker/validator-dynamic/docker-run-dynamic-fullnode.sh /
 


### PR DESCRIPTION
This does it all!
* Config builder to support instantiating an appropriate backend config and libra node config
* Docker container with scripts to start the service
* SafetyRules client code to allow consensus to start without any safety rules
* A little bit of cleanup to make building the dynamic-validator docker a little faster

I'm looking forward to the next adventure of getting this integrated into much more complex frameworks.

Note: this is built on top of this PR: https://github.com/libra/libra/pull/2459