### PR TITLE
[move-prover] Introduce invariants in the mvir parser.

### DIFF
--- a/language/compiler/ir-to-bytecode/syntax/src/lexer.rs
+++ b/language/compiler/ir-to-bytecode/syntax/src/lexer.rs
@@ -72,6 +72,8 @@ pub enum Tok {
     ToU128,
     If,
     Import,
+    /// For spec language
+    Invariant,
     Let,
     Loop,
     Main,
@@ -92,6 +94,7 @@ pub enum Tok {
     Script,
     Struct,
     SucceedsIf,
+    Synthetic,
     True,
     /// Transaction sender in the specification language
     TxnSender,
@@ -417,6 +420,7 @@ fn get_name_token(name: &str) -> Tok {
         "main" => Tok::Main,
         "module" => Tok::Module,
         "native" => Tok::Native,
+        "invariant" => Tok::Invariant,
         "old" => Tok::Old,
         "public" => Tok::Public,
         "requires" => Tok::Requires,
@@ -425,6 +429,7 @@ fn get_name_token(name: &str) -> Tok {
         "return" => Tok::Return,
         "struct" => Tok::Struct,
         "succeeds_if" => Tok::SucceedsIf,
+        "synthetic" => Tok::Synthetic,
         "true" => Tok::True,
         "txn_sender" => Tok::TxnSender,
         "u8" => Tok::U8,

--- a/language/ir-testsuite/tests/prover/parser/invariants.mvir
+++ b/language/ir-testsuite/tests/prover/parser/invariants.mvir
@@ -1,0 +1,27 @@
+// Tests for parsing invariants in specifications
+
+// Test parsing invariants and synthetics, parsing only.
+//! no-run: runtime
+module TestInvariants {
+
+  synthetic all_values: u128;
+
+  resource SingleInvariant {
+    i: u64,
+    invariant i > 0
+  }
+
+  resource TwoInvariants {
+    i: u64,
+    j: u64,
+    invariant i > 0,
+    invariant j > i
+  }
+
+  resource InvariantWithModifier {
+    i: u64,
+    invariant {update} old(i) < i && all_values == old(old_values) - old(i) + i,
+    invariant {unpack} all_values == old(old_values) - old(i),
+    invariant {pack}   all_values == old(old_values) + i,
+  }
+}

--- a/language/move-ir/types/src/spec_language_ast.rs
+++ b/language/move-ir/types/src/spec_language_ast.rs
@@ -3,8 +3,9 @@
 
 use crate::ast::{BinOp, CopyableVal_, Field_, QualifiedStructIdent, Spanned, Type};
 use libra_types::account_address::AccountAddress;
+use libra_types::identifier::Identifier;
 
-/// AST for the Move Prover specification language. Just postconditions for now
+/// AST for the Move Prover specification language.
 
 /// A location that can store a value
 #[derive(PartialEq, Debug, Clone)]
@@ -61,7 +62,7 @@ pub enum SpecExp {
 
 /// A specification directive to be verified
 #[derive(PartialEq, Debug, Clone)]
-pub enum Condition {
+pub enum Condition_ {
     /// Postconditions
     Ensures(SpecExp),
     /// Preconditions
@@ -73,4 +74,27 @@ pub enum Condition {
 }
 
 /// Specification directive with span.
-pub type Condition_ = Spanned<Condition>;
+pub type Condition = Spanned<Condition_>;
+
+/// An invariant over a resource.
+#[derive(PartialEq, Debug, Clone)]
+pub struct Invariant_ {
+    // A free string (for now) which specifies the function of this invariant.
+    pub modifier: String,
+
+    // A specification expressions
+    pub condition: SpecExp,
+}
+
+/// Invariant with span.
+pub type Invariant = Spanned<Invariant_>;
+
+/// A synthetic variable definition.
+#[derive(PartialEq, Debug, Clone)]
+pub struct SyntheticDefinition_ {
+    pub name: Identifier,
+    pub type_: Type,
+}
+
+/// Synthetic with span.
+pub type SyntheticDefinition = Spanned<SyntheticDefinition_>;

--- a/language/move-prover/bytecode-to-boogie/src/spec_translator.rs
+++ b/language/move-prover/bytecode-to-boogie/src/spec_translator.rs
@@ -8,7 +8,7 @@ use num::{BigInt, Num};
 
 use libra_types::account_address::AccountAddress;
 use move_ir_types::ast::{BinOp, CopyableVal_, Field_, Loc, QualifiedStructIdent, Type};
-use move_ir_types::spec_language_ast::{Condition, SpecExp, StorageLocation};
+use move_ir_types::spec_language_ast::{Condition_, SpecExp, StorageLocation};
 
 use crate::boogie_helpers::{boogie_field_name, boogie_type_value};
 use crate::code_writer::CodeWriter;
@@ -79,7 +79,7 @@ impl<'env> SpecTranslator<'env> {
         // must have existed! So we can assume txn_sender account
         // exists in pre-condition.
         for cond in self.func_env.get_specification() {
-            if let Condition::Requires(expr) = &cond.value {
+            if let Condition_::Requires(expr) = &cond.value {
                 self.update_location(cond.span);
                 emitln!(
                     self.writer,
@@ -98,7 +98,7 @@ impl<'env> SpecTranslator<'env> {
             .get_specification()
             .iter()
             .filter_map(|c| match &c.value {
-                Condition::SucceedsIf(expr) => {
+                Condition_::SucceedsIf(expr) => {
                     self.update_location(c.span);
                     Some(format!("b#Boolean({})", self.translate_expr(expr).result()))
                 }
@@ -113,7 +113,7 @@ impl<'env> SpecTranslator<'env> {
             .get_specification()
             .iter()
             .filter_map(|c| match &c.value {
-                Condition::AbortsIf(expr) => {
+                Condition_::AbortsIf(expr) => {
                     self.update_location(c.span);
                     Some(format!("b#Boolean({})", self.translate_expr(expr).result()))
                 }
@@ -140,7 +140,7 @@ impl<'env> SpecTranslator<'env> {
 
         // Generate explicit ensures conditions
         for cond in self.func_env.get_specification() {
-            if let Condition::Ensures(expr) = &cond.value {
+            if let Condition_::Ensures(expr) = &cond.value {
                 // FIXME: Do we really need to check whether succeeds_if & aborts_if are
                 // empty, below?
                 self.update_location(cond.span);

--- a/language/tools/utils/src/module_generation/generator.rs
+++ b/language/tools/utils/src/module_generation/generator.rs
@@ -253,6 +253,7 @@ impl<'a> ModuleGenerator<'a> {
             name,
             type_formals,
             fields,
+            invariants: vec![],
         };
         self.current_module.structs.push(Spanned::no_loc(strct))
     }
@@ -309,6 +310,7 @@ impl<'a> ModuleGenerator<'a> {
             imports: Self::imports(callable_modules),
             structs: Vec::new(),
             functions: Vec::new(),
+            synthetics: Vec::new(),
         };
         Self {
             options,


### PR DESCRIPTION
This adds ast and parser for invariants in mvir structs and resources, with a syntax as such:

```
resource T {
  i: u64,
  invariant i > 0
}
```

There is also a (more experimental) modifier which can be added to an invariant:

```
resource T {
  i: u64,
  invariant {update} old(i) < i
}
```

We moreover add "synthetic" (ghost) variables for use in specifications:

```
synthetic sum_of_T_i: u128;
resource T {
  i: u64,
  invariant {update} sum_of_T_i == old(sum_of_T_i) - old(i) + i,
  invariant {unpack} sum_of_T_i == old(sum_of_T_i) - old(i),
  invariant {pack}   sum_of_T_i == old(sum_of_T_i) + i,
}
```

These features in the MVIR parser allows us to experiment with the design which will eventually be  in the source language once we've moved the spec language to there. They should be considered experimental for now.

## Motivation

We need invariants and specification variables for global specs.


## Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?

(Write your answer here.)

## Test Plan

Added a parser test.

## Related PRs

NA
