### PR TITLE
[perf][consensus] Use max_block_size 200 to increase TPS by 10%

### DIFF
--- a/config/src/config/consensus_config.rs
+++ b/config/src/config/consensus_config.rs
@@ -19,7 +19,7 @@ pub struct ConsensusConfig {
 impl Default for ConsensusConfig {
     fn default() -> ConsensusConfig {
         ConsensusConfig {
-            max_block_size: 100,
+            max_block_size: 200,
             proposer_type: ConsensusProposerType::MultipleOrderedProposers,
             contiguous_rounds: 2,
             max_pruned_blocks_in_mem: 10000,

--- a/config/src/config/test_data/random.complete.node.config.toml
+++ b/config/src/config/test_data/random.complete.node.config.toml
@@ -12,7 +12,7 @@ data_dir = "/opt/libra/data/common"
 role = "validator"
 
 [consensus]
-max_block_size = 100
+max_block_size = 200
 max_pruned_blocks_in_mem = 10000
 pacemaker_initial_timeout_ms = 1000
 proposer_type = "multiple_ordered_proposers"

--- a/config/src/config/test_data/single.node.config.toml
+++ b/config/src/config/test_data/single.node.config.toml
@@ -48,7 +48,7 @@ network_peers_file = ""
 seed_peers_file = ""
 
 [consensus]
-max_block_size = 100
+max_block_size = 200
 max_pruned_blocks_in_mem = 10000
 pacemaker_initial_timeout_ms = 1000
 proposer_type = "multiple_ordered_proposers"

--- a/consensus/src/chained_bft/chained_bft_smr_test.rs
+++ b/consensus/src/chained_bft/chained_bft_smr_test.rs
@@ -18,6 +18,7 @@ use consensus_types::{
     vote_msg::VoteMsg,
 };
 use futures::{channel::mpsc, executor::block_on, prelude::*};
+use libra_config::config::ConsensusConfig;
 use libra_config::{
     config::{
         ConsensusProposerType::{self, FixedProposer, MultipleOrderedProposers, RotatingProposer},
@@ -543,7 +544,8 @@ fn basic_state_sync() {
             .next()
             .await
             .expect("Fail to be notified by a mempool committed txns");
-        assert_eq!(nodes[3].mempool.get_committed_txns().len(), 100);
+        let max_block_size = ConsensusConfig::default().max_block_size as usize;
+        assert_eq!(nodes[3].mempool.get_committed_txns().len(), max_block_size);
     });
 }
 


### PR DESCRIPTION
## Summary

Consensus was bottlenecked by the 100-number. This change allows it to increase its throughput.

## Test Plan

```
Feb 07 09:38:17.706 INFO avg_txns_per_block: 121.60002576318419
Feb 07 09:38:17.706 INFO Experiment finished, waiting until all affected validators recover
Feb 07 09:38:22.891 INFO Experiment completed
Feb 07 09:38:22.891 INFO Experiment Result: all up : 718 TPS, 839.5 ms latency, no expired txns
```