### PR TITLE
[Consensus] Change per block retrieval timeout to 5 sec for startup sync

### DIFF
--- a/consensus/src/chained_bft/event_processor.rs
+++ b/consensus/src/chained_bft/event_processor.rs
@@ -119,8 +119,8 @@ impl<T: Payload> StartupSyncProcessor<T> {
         );
         let mut retriever = BlockRetriever::new(
             self.network.clone(),
-            // Give a timeout of 1 hour to make sure there's enough time for trying to fetch from all peers
-            Instant::now() + Duration::new(3600, 0),
+            // Give a timeout of 5 sec per attempt try to fetch block from peer
+            Instant::now() + Duration::new(5, 0),
             peer,
         );
         let (blocks, quorum_certs) =


### PR DESCRIPTION
## Motivation
1 hour is too long

## Test Plan
`cargo x test -p consensus`
