### PR TITLE
[bounded-executor] Add `BoundedExecutor::try_spawn()`

### DIFF
--- a/common/bounded-executor/src/lib.rs
+++ b/common/bounded-executor/src/lib.rs
@@ -8,18 +8,13 @@
 //! `capacity`.
 
 use futures::future::{Future, FutureExt};
-use futures_semaphore::Semaphore;
+use futures_semaphore::{Permit, Semaphore};
 use tokio::{runtime::Handle, task::JoinHandle};
 
 #[derive(Clone, Debug)]
 pub struct BoundedExecutor {
     semaphore: Semaphore,
     executor: Handle,
-}
-
-/// Returned by [`BoundedExecutor::try_spawn`] if it is at capacity.
-pub enum SpawnError {
-    AtCapacity,
 }
 
 impl BoundedExecutor {
@@ -34,15 +29,41 @@ impl BoundedExecutor {
     }
 
     /// Spawn a [`Future`] on the `BoundedExecutor`. This function is async and
-    /// will block if the executor is at capacity.
+    /// will block if the executor is at capacity until one of the other spawned
+    /// futures completes. This function returns a [`JoinHandle`] that the caller
+    /// can `.await` on for the results of the [`Future`].
     pub async fn spawn<F>(&self, f: F) -> JoinHandle<F::Output>
     where
         F: Future + Send + 'static,
         F::Output: Send + 'static,
     {
-        let spawn_permit = self.semaphore.acquire().await;
+        let permit = self.semaphore.acquire().await;
+        self.spawn_with_permit(f, permit)
+    }
+
+    /// Try to spawn a [`Future`] on the `BoundedExecutor`. If the `BoundedExecutor`
+    /// is at capacity, this will return an `Err(F)`, passing back the future the
+    /// caller attempted to spawn. Otherwise, this will spawn the future on the
+    /// executor and send back a [`JoinHandle`] that the caller can `.await` on
+    /// for the results of the [`Future`].
+    pub fn try_spawn<F>(&self, f: F) -> Result<JoinHandle<F::Output>, F>
+    where
+        F: Future + Send + 'static,
+        F::Output: Send + 'static,
+    {
+        match self.semaphore.try_acquire() {
+            Some(permit) => Ok(self.spawn_with_permit(f, permit)),
+            None => Err(f),
+        }
+    }
+
+    fn spawn_with_permit<F>(&self, f: F, spawn_permit: Permit) -> JoinHandle<F::Output>
+    where
+        F: Future + Send + 'static,
+        F::Output: Send + 'static,
+    {
+        // Release the permit back to the semaphore when this task completes.
         let f = f.map(move |ret| {
-            // Release the permit back to the semaphore when this task completes.
             drop(spawn_permit);
             ret
         });
@@ -53,12 +74,45 @@ impl BoundedExecutor {
 #[cfg(test)]
 mod test {
     use super::*;
-    use futures::{executor::block_on, future::Future};
+    use futures::{channel::oneshot, executor::block_on, future::Future};
     use std::{
         sync::atomic::{AtomicU32, Ordering},
         time::Duration,
     };
     use tokio::{runtime::Runtime, time::delay_for};
+
+    #[test]
+    fn try_spawn() {
+        let rt = Runtime::new().unwrap();
+        let executor = rt.handle().clone();
+        let executor = BoundedExecutor::new(1, executor);
+
+        let (tx1, rx1) = oneshot::channel();
+        let (tx2, rx2) = oneshot::channel();
+
+        // executor has a free slot, spawn should succeed
+
+        let f1 = executor.try_spawn(rx1).unwrap();
+
+        // executor is full, try_spawn should return err and give back the task
+        // we attempted to spawn
+
+        let rx2 = executor.try_spawn(rx2).unwrap_err();
+
+        // complete f1 future, should open a free slot in executor
+
+        tx1.send(()).unwrap();
+        block_on(f1).unwrap().unwrap();
+
+        // should successfully spawn a new task now that the first is complete
+
+        let f2 = executor.try_spawn(rx2).unwrap();
+
+        // cleanup
+
+        tx2.send(()).unwrap();
+        block_on(f2).unwrap().unwrap();
+    }
 
     fn yield_task() -> impl Future<Output = ()> {
         delay_for(Duration::from_millis(1)).map(|_| ())


### PR DESCRIPTION
Useful if you want e.g. certain inbound requests to drop instead of
propagate backpressure if the bounded executor is full.

Note: if the executor _only_ uses `try_spawn`, we can do this a lot more
efficiently by just using an atomic counter under-the-hood, since
`try_spawn` isn't async and doesn't need the underlying waker-queue that
the `tokio::sync::Semaphore` provides. Since I only have one place where
I'm using this, it's probably not worth the extra code yet.