### PR TITLE
[terraform] Fix logrotate setup

### DIFF
--- a/terraform/templates/ec2_user_data.sh
+++ b/terraform/templates/ec2_user_data.sh
@@ -34,18 +34,17 @@ cat > /etc/profile.d/libra_prompt.sh <<EOF
 export PS1="[\u:validator@\h \w]$ "
 EOF
 
-if ${enable_logrotate}; then
-	cat >> /etc/logrotate.conf <<"EOF"
-	${log_path} {
-		daily
-		rotate 100
-		compress
-		delaycompress
-	}
-	EOF
-
-	sudo logrotate /etc/logrotate.conf
-fi
+{% if enable_logrotate %}
+cat > /etc/logrotate.d/libra <<EOF
+${log_path} {
+	daily
+	size 100M
+	rotate 100
+	compress
+	delaycompress
+}
+EOF
+{% end %}
 
 yum -y install ngrep tcpdump perf gdb nmap-ncat strace htop sysstat tc git
 

--- a/terraform/validators.tf
+++ b/terraform/validators.tf
@@ -121,7 +121,7 @@ data "template_file" "user_data" {
   vars = {
     ecs_cluster      = aws_ecs_cluster.testnet.name
     log_path         = var.log_path
-    enable_logrotate = var.log_to_file || var.enable_logstash ? true : false
+    enable_logrotate = var.log_to_file || var.enable_logstash
   }
 }
 


### PR DESCRIPTION
Because "EOF" is quoted it has to be used at the beginning of the line. Since it wasn't the heredoc didn't get terminated. Also use the template to decide whether to set this up, and the `.d` directory.