### PR TITLE
[RFC][language] beginnings of a proc macro to derive IR bytecode representation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2681,6 +2681,7 @@ dependencies = [
  "hex 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "libra-types 0.1.0",
  "once_cell 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "vm 0.1.0",
 ]
 
 [[package]]
@@ -5542,6 +5543,7 @@ dependencies = [
  "ref-cast 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.101 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.40 (registry+https://github.com/rust-lang/crates.io-index)",
+ "vm-derive 0.1.0",
 ]
 
 [[package]]
@@ -5553,6 +5555,15 @@ dependencies = [
  "proptest 0.9.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "typed-arena 1.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "vm-derive"
+version = "0.1.0"
+dependencies = [
+ "proc-macro2 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "quote 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -56,6 +56,7 @@ members = [
     "language/move-prover/stackless-bytecode-generator",
     "language/stdlib",
     "language/vm",
+    "language/vm/vm-derive",
     "language/vm/serializer_tests",
     "language/vm/vm-runtime",
     "language/vm/vm-runtime/vm-cache-map",

--- a/language/move-ir/types/Cargo.toml
+++ b/language/move-ir/types/Cargo.toml
@@ -16,3 +16,4 @@ codespan = { version = "0.2.1", features = ["serialization"] }
 hex = "0.3.2"
 libra-types = { path = "../../../types", version = "0.1.0" }
 once_cell = "1.2.0"
+vm = { path = "../../vm", version = "0.1.0" }

--- a/language/move-ir/types/src/ast.rs
+++ b/language/move-ir/types/src/ast.rs
@@ -16,6 +16,7 @@ use std::{
     fmt,
     ops::Deref,
 };
+use vm::make_ir_bytecode;
 
 /// Generic wrapper that keeps file locations for any ast-node
 #[derive(Debug, Copy, Clone, Eq, PartialEq, Default)]
@@ -158,6 +159,17 @@ pub enum Kind {
 }
 
 //**************************************************************************************************
+// Labels
+//**************************************************************************************************
+
+/// Newtype for a label in a bytecode function body.
+#[derive(Clone, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
+pub struct Label_(Identifier);
+
+/// The type of a label with a location.
+pub type Label = Spanned<Label_>;
+
+//**************************************************************************************************
 // Types
 //**************************************************************************************************
 
@@ -281,6 +293,8 @@ pub enum FunctionBody {
     /// The body is provided by the runtime
     Native,
 }
+
+make_ir_bytecode!(Bytecode);
 
 /// A Move function/procedure
 #[derive(PartialEq, Debug, Clone)]

--- a/language/vm/Cargo.toml
+++ b/language/vm/Cargo.toml
@@ -25,6 +25,7 @@ libra-crypto = { path = "../../crypto/crypto", version = "0.1.0" }
 libra-proptest-helpers = { path = "../../common/proptest-helpers", version = "0.1.0", optional = true }
 libra-types = { path = "../../types", version = "0.1.0" }
 num-variants = { path = "../../common/num-variants", version = "0.1.0" }
+vm-derive = { path = "vm-derive", version = "0.1.0" }
 
 [dev-dependencies]
 proptest = "0.9"

--- a/language/vm/src/file_format.rs
+++ b/language/vm/src/file_format.rs
@@ -44,6 +44,7 @@ use once_cell::sync::Lazy;
 use proptest::{collection::vec, prelude::*, strategy::BoxedStrategy};
 #[cfg(any(test, feature = "fuzzing"))]
 use proptest_derive::Arbitrary;
+use vm_derive::IRBytecode;
 
 /// Generic index into one of the tables in the binary format.
 pub type TableIndex = u16;
@@ -802,7 +803,7 @@ impl CodeUnit {
 ///
 /// Bytecodes operate on a stack machine and each bytecode has side effect on the stack and the
 /// instruction stream.
-#[derive(Clone, Hash, Eq, NumVariants, PartialEq)]
+#[derive(Clone, Hash, Eq, IRBytecode, NumVariants, PartialEq)]
 #[cfg_attr(any(test, feature = "fuzzing"), derive(Arbitrary))]
 #[cfg_attr(any(test, feature = "fuzzing"), proptest(no_params))]
 #[num_variants = "NUM_INSTRUCTIONS"]

--- a/language/vm/vm-derive/Cargo.toml
+++ b/language/vm/vm-derive/Cargo.toml
@@ -1,0 +1,18 @@
+[package]
+name = "vm-derive"
+version = "0.1.0"
+authors = ["Libra Association <opensource@libra.org>"]
+description = "Macros for the Move VM."
+repository = "https://github.com/libra/libra"
+homepage = "https://libra.org"
+license = "Apache-2.0"
+publish = false
+edition = "2018"
+
+[lib]
+proc-macro = true
+
+[dependencies]
+syn = "1.0.1"
+quote = "1.0.0"
+proc-macro2 = "1.0.1"

--- a/language/vm/vm-derive/src/lib.rs
+++ b/language/vm/vm-derive/src/lib.rs
@@ -1,0 +1,172 @@
+// Copyright (c) The Libra Core Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+//! Macros for the VM file format and related structures.
+
+#![forbid(unsafe_code)]
+#![warn(missing_docs)]
+
+extern crate proc_macro;
+
+use proc_macro2::TokenStream;
+use quote::quote;
+use syn::spanned::Spanned;
+use syn::{
+    parse_macro_input, parse_str, Data, DataEnum, DeriveInput, Error, Field, Fields, FieldsUnnamed,
+    Result, Type, Variant,
+};
+
+/// Derives the IR representation of the bytecode.
+///
+/// This will cause these macros to be defined:
+///
+/// * `make_ir_bytecode!`: Generate the IR bytecode representation.
+#[proc_macro_derive(IRBytecode)]
+pub fn derive_ir_bytecode(input: proc_macro::TokenStream) -> proc_macro::TokenStream {
+    let input = parse_macro_input!(input as DeriveInput);
+    match derive_ir_bytecode_impl(input) {
+        Ok(token_stream) => token_stream.into(),
+        Err(err) => err.to_compile_error().into(),
+    }
+}
+
+fn derive_ir_bytecode_impl(input: DeriveInput) -> Result<TokenStream> {
+    let input_span = input.span();
+
+    let data = match &input.data {
+        Data::Enum(data) => data,
+        Data::Struct(_) | Data::Union(_) => {
+            return Err(Error::new(
+                input_span,
+                "#[derive(IRBytecode)] can only be used on an enum",
+            ))
+        }
+    };
+
+    let gen = IRBytecodeGen::new(data)?;
+    gen.make_ir_enum_macro()
+}
+
+struct IRBytecodeGen<'a> {
+    data: &'a DataEnum,
+}
+
+impl<'a> IRBytecodeGen<'a> {
+    fn new(data: &'a DataEnum) -> Result<Self> {
+        // Discriminants and named fields aren't supported.
+        for variant in &data.variants {
+            if variant.discriminant.is_some() {
+                return Err(Error::new_spanned(
+                    variant,
+                    "#[derive(IRBytecode)] not supported for enums with discriminants",
+                ));
+            }
+            if let Fields::Named(_) = variant.fields {
+                return Err(Error::new_spanned(
+                    variant,
+                    "#[derive(IRBytecode)] not supported for named fields",
+                ));
+            }
+        }
+
+        Ok(Self { data })
+    }
+
+    fn make_ir_enum_macro(&self) -> Result<TokenStream> {
+        let variants: Vec<_> = self
+            .data
+            .variants
+            .iter()
+            .map(|variant| {
+                Ok(Variant {
+                    attrs: variant.attrs.clone(),
+                    ident: variant.ident.clone(),
+                    fields: Self::ir_enum_fields(&variant.fields)?,
+                    discriminant: None,
+                })
+            })
+            .collect::<Result<_>>()?;
+        Ok(quote! {
+            #[macro_export]
+            macro_rules! make_ir_bytecode {
+                ($id: ident) => {
+                    /// An intermediate representation of the Move VM's bytecode.
+                    ///
+                    /// This is isomorphic to the file format bytecode.
+                    #[derive(Clone, Debug, PartialEq)]
+                    pub enum $id {
+                        #(#variants),*
+                    }
+                }
+            }
+        })
+    }
+
+    fn ir_enum_fields(fields: &Fields) -> Result<Fields> {
+        let fields_out = match fields {
+            Fields::Unnamed(fields) => Fields::Unnamed(FieldsUnnamed {
+                paren_token: fields.paren_token.clone(),
+                unnamed: fields
+                    .unnamed
+                    .iter()
+                    .map(|field| Self::ir_enum_field(field))
+                    .collect::<Result<_>>()?,
+            }),
+            Fields::Unit => Fields::Unit,
+            Fields::Named(_) => unreachable!("checked in MoveIRGen constructor"),
+        };
+        Ok(fields_out)
+    }
+
+    fn ir_enum_field(field: &Field) -> Result<Field> {
+        let mut field_out: Field = field.clone();
+        field_out.ty = match &field.ty {
+            Type::Path(ty) => {
+                if ty.qself.is_some() {
+                    return Err(Error::new_spanned(
+                        field,
+                        "#[derive(IRBytecode)] only supports single idents",
+                    ));
+                }
+                match ty.path.get_ident() {
+                    Some(ident) => {
+                        let ident_name = ident.to_string();
+                        let name_out = match ident_name.as_str() {
+                            "CodeOffset" => "Label",
+                            "u8" => "u8",
+                            "u64" => "u64",
+                            "u128" => "u128",
+                            "ByteArrayPoolIndex" => "ByteArray",
+                            "AddressPoolIndex" => "AccountAddress",
+                            "LocalIndex" => "Var",
+                            "FunctionHandleIndex" => "FunctionCall",
+                            "LocalsSignatureIndex" => "Vec<Type>",
+                            "FieldDefinitionIndex" => "Field",
+                            "StructDefinitionIndex" => "StructName",
+                            other => {
+                                return Err(Error::new_spanned(
+                                    field,
+                                    format!("#[derive(IRBytecode)] unable to map type '{}'", other),
+                                ))
+                            }
+                        };
+                        Type::Path(parse_str(name_out)?)
+                    }
+                    None => {
+                        return Err(Error::new_spanned(
+                            field,
+                            "#[derive(IRBytecode)] only supports single idents",
+                        ));
+                    }
+                }
+            }
+            _ => {
+                return Err(Error::new_spanned(
+                    field,
+                    "#[derive(IRBytecode)] only supports single idents",
+                ));
+            }
+        };
+        Ok(field_out)
+    }
+}


### PR DESCRIPTION
By default, Rust doesn't have a way to specify that a macro is isomorphic to
another with some type transformations. This proc macro implements that.

The enum generated is grabbed from the docs:

```
pub enum Bytecode {
    Pop,
    Ret,
    BrTrue(Label),
    BrFalse(Label),
    Branch(Label),
    LdU8(u8),
    LdU64(u64),
    LdU128(u128),
    CastU8,
    CastU64,
    CastU128,
    LdByteArray(ByteArray),
    LdAddr(AccountAddress),
    LdTrue,
    LdFalse,
    CopyLoc(Var),
    MoveLoc(Var),
    StLoc(Var),
    Call(FunctionCall, Vec<Type>),
    Pack(StructName, Vec<Type>),
    Unpack(StructName, Vec<Type>),
    ReadRef,
    WriteRef,
    FreezeRef,
    MutBorrowLoc(Var),
    ImmBorrowLoc(Var),
    MutBorrowField(Field),
    ImmBorrowField(Field),
    MutBorrowGlobal(StructName, Vec<Type>),
    ImmBorrowGlobal(StructName, Vec<Type>),
    Add,
    Sub,
    Mul,
    Mod,
    Div,
    BitOr,
    BitAnd,
    Xor,
    Or,
    And,
    Not,
    Eq,
    Neq,
    Lt,
    Gt,
    Le,
    Ge,
    Abort,
    GetTxnGasUnitPrice,
    GetTxnMaxGasUnits,
    GetGasRemaining,
    GetTxnSenderAddress,
    Exists(StructName, Vec<Type>),
    MoveFrom(StructName, Vec<Type>),
    MoveToSender(StructName, Vec<Type>),
    GetTxnSequenceNumber,
    GetTxnPublicKey,
    Shl,
    Shr,
}
```