### PR TITLE
[Consensus] Add event loop to sync up with peers if can't recover from local data

### DIFF
--- a/consensus/src/chained_bft/test_utils/mod.rs
+++ b/consensus/src/chained_bft/test_utils/mod.rs
@@ -24,7 +24,7 @@ mod mock_txn_manager;
 use consensus_types::block::block_test_utils::gen_test_certificate;
 use libra_types::block_info::BlockInfo;
 pub use mock_state_computer::{EmptyStateComputer, MockStateComputer};
-pub use mock_storage::{EmptyStorage, MockStorage};
+pub use mock_storage::{EmptyStorage, MockSharedStorage, MockStorage};
 pub use mock_txn_manager::MockTransactionManager;
 use std::thread;
 use std::time::Duration;

--- a/consensus/src/counters.rs
+++ b/consensus/src/counters.rs
@@ -73,6 +73,28 @@ pub static COMMITTED_TXNS_COUNT: Lazy<IntCounterVec> = Lazy::new(|| {
 });
 
 /// Histogram of idle time of spent in event processing loop
+pub static STARTUP_SYNC_LOOP_IDLE_DURATION_S: Lazy<DurationHistogram> = Lazy::new(|| {
+    DurationHistogram::new(
+        register_histogram!(
+            "libra_consensus_startup_sync_loop_idle_duration_s",
+            "Histogram of idle time of spent in startup sync loop"
+        )
+        .unwrap(),
+    )
+});
+
+/// Histogram of idle time of spent in event processing loop
+pub static STARTUP_SYNC_LOOP_BUSY_DURATION_S: Lazy<DurationHistogram> = Lazy::new(|| {
+    DurationHistogram::new(
+        register_histogram!(
+            "libra_consensus_startup_sync_loop_busy_duration_s",
+            "Histogram of busy time of spent in startup sync loop"
+        )
+        .unwrap(),
+    )
+});
+
+/// Histogram of idle time of spent in event processing loop
 pub static EVENT_PROCESSING_LOOP_IDLE_DURATION_S: Lazy<DurationHistogram> = Lazy::new(|| {
     DurationHistogram::new(
         register_histogram!(


### PR DESCRIPTION
## Motivation
#2188 

This PR adds an additional `startup_sync_loop` before the main event processing loop. The startup sync loop will be entered when we can't get full recovery data from local data source(say, if consensus db is nuked). The loop will wait for peer's message and try to retrieve blocks from them, in a manner very similar to fast forward sync when a node is behind, and construct block store, event processor etc. from retrieve data.
One thing could happen is that when entering the startup sync loop, an epoch change happens. This is also handled in the startup sync loop.

## Test Plan
+ Added unit test for `chained_bft_smr` which clears shared storage and verified the node can still be restarted
+ Added smoke test that removes the `consensusdb` directory and verified the node can still be restarted
## TODOs
- [x] Unit tests for `chained_bft_smr`
- [x] Smoke tests