### PR TITLE
[cluster-test] Refactor tx_emitter to allow setting all tx_emitter params globally

### DIFF
--- a/testsuite/cluster-test/src/experiments/mod.rs
+++ b/testsuite/cluster-test/src/experiments/mod.rs
@@ -30,7 +30,7 @@ pub use recovery_time::{RecoveryTime, RecoveryTimeParams};
 use crate::cluster::Cluster;
 use crate::prometheus::Prometheus;
 use crate::report::SuiteReport;
-use crate::tx_emitter::TxEmitter;
+use crate::tx_emitter::{EmitJobRequest, TxEmitter};
 
 use async_trait::async_trait;
 pub use cpu_flamegraph::{CpuFlamegraph, CpuFlamegraphParams};
@@ -56,6 +56,7 @@ pub struct Context<'a> {
     prometheus: &'a Prometheus,
     cluster: &'a Cluster,
     report: &'a mut SuiteReport,
+    global_emit_job_request: &'a mut EmitJobRequest,
 }
 
 impl<'a> Context<'a> {
@@ -64,12 +65,14 @@ impl<'a> Context<'a> {
         prometheus: &'a Prometheus,
         cluster: &'a Cluster,
         report: &'a mut SuiteReport,
+        emit_job_request: &'a mut EmitJobRequest,
     ) -> Self {
         Context {
             tx_emitter,
             prometheus,
             cluster,
             report,
+            global_emit_job_request: emit_job_request,
         }
     }
 }

--- a/testsuite/cluster-test/src/experiments/performance_benchmark_nodes_down.rs
+++ b/testsuite/cluster-test/src/experiments/performance_benchmark_nodes_down.rs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::experiments::ExperimentParam;
+use crate::tx_emitter::EmitJobRequest;
 use crate::{
     cluster::Cluster,
     effects::{Effect, StopContainer},
@@ -105,9 +106,13 @@ impl Experiment for PerformanceBenchmarkNodesDown {
         join_all(futures).await;
         let buffer = Duration::from_secs(30);
         let window = self.duration + buffer * 2;
+        let emit_job_request = EmitJobRequest {
+            instances: self.up_instances.clone(),
+            ..context.global_emit_job_request.clone()
+        };
         let stats = context
             .tx_emitter
-            .emit_txn_for(window, self.up_instances.clone())
+            .emit_txn_for(window, emit_job_request)
             .await?;
         let end = unix_timestamp_now() - buffer;
         let start = end - window + 2 * buffer;

--- a/testsuite/cluster-test/src/experiments/performance_benchmark_three_region_simulation.rs
+++ b/testsuite/cluster-test/src/experiments/performance_benchmark_three_region_simulation.rs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::experiments::ExperimentParam;
+use crate::tx_emitter::EmitJobRequest;
 use crate::{
     cluster::Cluster,
     effects::{three_region_simulation_effects, Effect},
@@ -53,9 +54,13 @@ impl Experiment for PerformanceBenchmarkThreeRegionSimulation {
         );
         join_all(network_effects.iter().map(|e| e.activate())).await;
         let window = Duration::from_secs(240);
+        let emit_job_request = EmitJobRequest {
+            instances: self.cluster.validator_instances().clone(),
+            ..context.global_emit_job_request.clone()
+        };
         context
             .tx_emitter
-            .emit_txn_for(window, self.cluster.validator_instances().clone())
+            .emit_txn_for(window, emit_job_request)
             .await?;
         let buffer = Duration::from_secs(30);
         let end = unix_timestamp_now() - buffer;

--- a/testsuite/cluster-test/src/main.rs
+++ b/testsuite/cluster-test/src/main.rs
@@ -287,6 +287,7 @@ struct ClusterTestRunner {
     prometheus: Prometheus,
     github: GitHub,
     report: SuiteReport,
+    global_emit_job_request: EmitJobRequest,
 }
 
 fn parse_host_port(s: &str) -> Result<(String, u32)> {
@@ -456,6 +457,15 @@ impl ClusterTestRunner {
         let github = GitHub::new();
         let report = SuiteReport::new();
         let runtime = Runtime::new().expect("Failed to create tokio runtime");
+        let global_emit_job_request = EmitJobRequest {
+            instances: vec![],
+            accounts_per_client: args.accounts_per_client,
+            threads_per_ac: args.threads_per_ac,
+            thread_params: EmitThreadParams {
+                wait_millis: args.wait_millis,
+                wait_committed: !args.burst,
+            },
+        };
         Self {
             logs,
             cluster,
@@ -469,6 +479,7 @@ impl ClusterTestRunner {
             prometheus,
             github,
             report,
+            global_emit_job_request,
         }
     }
 
@@ -604,6 +615,7 @@ impl ClusterTestRunner {
             &self.prometheus,
             &self.cluster,
             &mut self.report,
+            &mut self.global_emit_job_request,
         );
         {
             let logs = &mut self.logs;

--- a/testsuite/cluster-test/src/tx_emitter.rs
+++ b/testsuite/cluster-test/src/tx_emitter.rs
@@ -85,6 +85,7 @@ impl Default for EmitThreadParams {
     }
 }
 
+#[derive(Clone)]
 pub struct EmitJobRequest {
     pub instances: Vec<Instance>,
     pub accounts_per_client: usize,
@@ -280,11 +281,9 @@ impl TxEmitter {
     pub async fn emit_txn_for(
         &mut self,
         duration: Duration,
-        instances: Vec<Instance>,
+        emit_job_request: EmitJobRequest,
     ) -> Result<TxStats> {
-        let job = self
-            .start_job(EmitJobRequest::for_instances(instances))
-            .await?;
+        let job = self.start_job(emit_job_request).await?;
         thread::sleep(duration);
         let stats = self.stop_job(job);
         Ok(stats)


### PR DESCRIPTION
## Summary

* The current emit_tx params are respected only for `--emit-tx` and not for experiments.
* Refactor `TxEmitter` so that all invocations of it use the related tx_emitter params set in `main.rs`
* This would allow us to experiment with different params for different experiments for tuning performance