### PR TITLE
[network] Issue new discovery note on receiving older note with higher epoch

### DIFF
--- a/network/src/protocols/discovery/test.rs
+++ b/network/src/protocols/discovery/test.rs
@@ -43,13 +43,6 @@ fn parse_raw_message(msg: Message) -> Result<DiscoveryMsg, NetworkError> {
     Ok(msg)
 }
 
-fn gen_full_node_payload() -> FullNodePayload {
-    let mut payload = FullNodePayload::default();
-    payload.epoch = 1;
-    payload.dns_seed_addr = b"example.com"[..].into();
-    payload
-}
-
 fn get_addrs_from_note(note: &Note) -> Vec<Multiaddr> {
     let signed_peer_info = note.signed_peer_info.as_ref().unwrap();
     let peer_info = PeerInfo::decode(signed_peer_info.peer_info.as_ref()).unwrap();
@@ -58,6 +51,12 @@ fn get_addrs_from_note(note: &Note) -> Vec<Multiaddr> {
         addrs.push(Multiaddr::try_from(addr.clone()).unwrap());
     }
     addrs
+}
+
+fn get_epoch_from_note(note: &Note) -> u64 {
+    let signed_peer_info = note.signed_peer_info.as_ref().unwrap();
+    let peer_info = PeerInfo::decode(signed_peer_info.peer_info.as_ref()).unwrap();
+    peer_info.epoch
 }
 
 fn get_addrs_from_info(peer_info: &PeerInfo) -> Vec<Multiaddr> {
@@ -158,7 +157,6 @@ fn inbound() {
     // Setup seed.
     let seed_peer_info = gen_peer_info();
     let seed_peer_addrs = get_addrs_from_info(&seed_peer_info);
-    let seed_peer_payload = gen_full_node_payload();
     let seed_peer_id = PeerId::random();
     let (seed_pub_keys, seed_signer) = generate_network_pub_keys_and_signer(seed_peer_id);
     let trusted_peers = Arc::new(RwLock::new(
@@ -173,7 +171,7 @@ fn inbound() {
         peer_id,
         addrs,
         seed_peer_id,
-        seed_peer_info.clone(),
+        seed_peer_info,
         self_signer,
         trusted_peers.clone(),
     );
@@ -191,8 +189,9 @@ fn inbound() {
         let seed_note = create_note(
             &seed_signer,
             seed_peer_id,
-            seed_peer_info.clone(),
-            seed_peer_payload.clone(),
+            seed_peer_addrs.clone(),
+            b"example.com",
+            get_unix_epoch(),
         );
         let (pub_keys_other, signer_other) = generate_network_pub_keys_and_signer(peer_id_other);
         trusted_peers
@@ -200,13 +199,13 @@ fn inbound() {
             .unwrap()
             .insert(peer_id_other, pub_keys_other);
         let note_other = {
-            let mut peer_info = PeerInfo::default();
-            peer_info.addrs = addrs_other
-                .iter()
-                .map(|addr| addr.as_ref().into())
-                .collect();
-            let full_node_payload = gen_full_node_payload();
-            create_note(&signer_other, peer_id_other, peer_info, full_node_payload)
+            create_note(
+                &signer_other,
+                peer_id_other,
+                addrs_other.clone(),
+                b"example.com",
+                get_unix_epoch(),
+            )
         };
         let mut msg = DiscoveryMsg::default();
         msg.notes.push(note_other.clone());
@@ -247,12 +246,12 @@ fn inbound() {
         msg.notes.push(note_other);
         let new_seed_addrs = vec![Multiaddr::from_str("/ip4/127.0.0.1/tcp/8098").unwrap()];
         {
-            let seed_peer_info = create_peer_info(new_seed_addrs.clone());
             let seed_note = create_note(
                 &seed_signer,
                 seed_peer_id,
-                seed_peer_info,
-                seed_peer_payload,
+                new_seed_addrs.clone(),
+                b"example.com",
+                get_unix_epoch(),
             );
             msg.notes.push(seed_note);
             let key = (
@@ -376,7 +375,6 @@ fn addr_update_includes_seed_addrs() {
     // Setup seed.
     let seed_peer_info = gen_peer_info();
     let mut seed_peer_addrs = get_addrs_from_info(&seed_peer_info);
-    let seed_peer_payload = gen_full_node_payload();
     let seed_peer_id = PeerId::random();
     let (seed_pub_keys, seed_signer) = generate_network_pub_keys_and_signer(seed_peer_id);
     let trusted_peers = Arc::new(RwLock::new(
@@ -405,8 +403,13 @@ fn addr_update_includes_seed_addrs() {
         // The discovery actor should send the addrs in the new seed peer note
         // _and_ the configured seed addrs to the connectivity manager.
         let new_seed_addrs = vec![Multiaddr::from_str("/ip4/127.0.0.1/tcp/9091").unwrap()];
-        let new_seed_info = create_peer_info(new_seed_addrs.clone());
-        let seed_note = create_note(&seed_signer, seed_peer_id, new_seed_info, seed_peer_payload);
+        let seed_note = create_note(
+            &seed_signer,
+            seed_peer_id,
+            new_seed_addrs.clone(),
+            b"example.com",
+            get_unix_epoch(),
+        );
         let mut msg = DiscoveryMsg::default();
         msg.notes.push(seed_note.clone());
         let key = (
@@ -436,6 +439,217 @@ fn addr_update_includes_seed_addrs() {
             &expected_seed_addrs[..],
         )
         .await;
+    };
+    rt.block_on(f_network);
+}
+
+#[test]
+fn old_note_higher_epoch() {
+    ::libra_logger::try_init_for_testing();
+    let mut rt = Runtime::new().unwrap();
+
+    // Setup self.
+    let peer_id = PeerId::random();
+    let addrs = vec![Multiaddr::from_str("/ip4/127.0.0.1/tcp/9090").unwrap()];
+    let (self_pub_keys, self_signer) = generate_network_pub_keys_and_signer(peer_id);
+
+    // Setup seed.
+    let seed_peer_info = gen_peer_info();
+    let seed_peer_addrs = get_addrs_from_info(&seed_peer_info);
+    let seed_peer_id = PeerId::random();
+    let (seed_pub_keys, _) = generate_network_pub_keys_and_signer(seed_peer_id);
+    let trusted_peers = Arc::new(RwLock::new(
+        vec![(seed_peer_id, seed_pub_keys), (peer_id, self_pub_keys)]
+            .into_iter()
+            .collect(),
+    ));
+
+    // Setup discovery.
+    let (
+        mut network_reqs_rx,
+        mut conn_mgr_reqs_rx,
+        mut network_notifs_tx,
+        mut control_notifs_tx,
+        mut ticker_tx,
+    ) = setup_discovery(
+        &mut rt,
+        peer_id,
+        addrs,
+        seed_peer_id,
+        seed_peer_info,
+        self_signer.clone(),
+        trusted_peers,
+    );
+
+    // Fake connectivity manager and dialer.
+    let f_network = async move {
+        // Connectivity manager receives addresses of the seed peer during bootstrap.
+        expect_address_update(&mut conn_mgr_reqs_rx, seed_peer_id, &seed_peer_addrs[..]).await;
+
+        let (delivered_tx, delivered_rx) = oneshot::channel();
+        // Notify discovery actor of connection to seed peer.
+        control_notifs_tx
+            .push_with_feedback(
+                seed_peer_id,
+                peer_manager::ConnectionStatusNotification::NewPeer(
+                    seed_peer_id,
+                    Multiaddr::try_from(seed_peer_addrs.get(0).unwrap().clone()).unwrap(),
+                ),
+                Some(delivered_tx),
+            )
+            .unwrap();
+        delivered_rx.await.unwrap();
+
+        // Send DiscoveryMsg consisting of the this node's older note which has higher epoch than
+        // current note.
+        let old_self_addrs = vec![Multiaddr::from_str("/ip4/127.0.0.1/tcp/9091").unwrap()];
+        let old_epoch = get_unix_epoch() + 100;
+        let old_note = create_note(
+            &self_signer,
+            peer_id,
+            old_self_addrs.clone(),
+            b"example.com",
+            old_epoch,
+        );
+        let mut msg = DiscoveryMsg::default();
+        msg.notes.push(old_note.clone());
+        let key = (
+            seed_peer_id,
+            ProtocolId::from_static(DISCOVERY_DIRECT_SEND_PROTOCOL),
+        );
+        let (delivered_tx, delivered_rx) = oneshot::channel();
+        network_notifs_tx
+            .push_with_feedback(
+                key.clone(),
+                PeerManagerNotification::RecvMessage(seed_peer_id, get_raw_message(msg)),
+                Some(delivered_tx),
+            )
+            .unwrap();
+        delivered_rx.await.unwrap();
+
+        // Trigger outbound msg.
+        ticker_tx.send(()).await.unwrap();
+
+        // Check request sent as message over network.
+        match network_reqs_rx.select_next_some().await {
+            PeerManagerRequest::SendMessage(peer, raw_msg) => {
+                assert_eq!(peer, seed_peer_id);
+                let msg = parse_raw_message(raw_msg).unwrap();
+                // Receive DiscoveryMsg from actor. The message should contain only a note for the
+                // sending peer since it doesn't yet have the note for the seed peer.
+                assert_eq!(1, msg.notes.len());
+                assert_eq!(Vec::from(peer_id), msg.notes[0].peer_id);
+                assert!(get_epoch_from_note(&msg.notes[0]) > old_epoch);
+            }
+            req => {
+                panic!("Unexpected request to peer manager: {:?}", req);
+            }
+        }
+    };
+    rt.block_on(f_network);
+}
+
+#[test]
+fn old_note_max_epoch() {
+    ::libra_logger::try_init_for_testing();
+    let mut rt = Runtime::new().unwrap();
+
+    // Setup self.
+    let peer_id = PeerId::random();
+    let addrs = vec![Multiaddr::from_str("/ip4/127.0.0.1/tcp/9090").unwrap()];
+    let (self_pub_keys, self_signer) = generate_network_pub_keys_and_signer(peer_id);
+
+    // Setup seed.
+    let seed_peer_info = gen_peer_info();
+    let seed_peer_addrs = get_addrs_from_info(&seed_peer_info);
+    let seed_peer_id = PeerId::random();
+    let (seed_pub_keys, _) = generate_network_pub_keys_and_signer(seed_peer_id);
+    let trusted_peers = Arc::new(RwLock::new(
+        vec![(seed_peer_id, seed_pub_keys), (peer_id, self_pub_keys)]
+            .into_iter()
+            .collect(),
+    ));
+
+    // Setup discovery.
+    let (
+        mut network_reqs_rx,
+        mut conn_mgr_reqs_rx,
+        mut network_notifs_tx,
+        mut control_notifs_tx,
+        mut ticker_tx,
+    ) = setup_discovery(
+        &mut rt,
+        peer_id,
+        addrs,
+        seed_peer_id,
+        seed_peer_info,
+        self_signer.clone(),
+        trusted_peers,
+    );
+
+    // Fake connectivity manager and dialer.
+    let f_network = async move {
+        // Connectivity manager receives addresses of the seed peer during bootstrap.
+        expect_address_update(&mut conn_mgr_reqs_rx, seed_peer_id, &seed_peer_addrs[..]).await;
+
+        let (delivered_tx, delivered_rx) = oneshot::channel();
+        // Notify discovery actor of connection to seed peer.
+        control_notifs_tx
+            .push_with_feedback(
+                seed_peer_id,
+                peer_manager::ConnectionStatusNotification::NewPeer(
+                    seed_peer_id,
+                    Multiaddr::try_from(seed_peer_addrs.get(0).unwrap().clone()).unwrap(),
+                ),
+                Some(delivered_tx),
+            )
+            .unwrap();
+        delivered_rx.await.unwrap();
+
+        // Send DiscoveryMsg consisting of the this node's older note which has u64::MAX epoch.
+        let old_self_addrs = vec![Multiaddr::from_str("/ip4/127.0.0.1/tcp/9091").unwrap()];
+        let old_epoch = std::u64::MAX;
+        let old_note = create_note(
+            &self_signer,
+            peer_id,
+            old_self_addrs.clone(),
+            b"example.com",
+            old_epoch,
+        );
+        let mut msg = DiscoveryMsg::default();
+        msg.notes.push(old_note.clone());
+        let key = (
+            seed_peer_id,
+            ProtocolId::from_static(DISCOVERY_DIRECT_SEND_PROTOCOL),
+        );
+        let (delivered_tx, delivered_rx) = oneshot::channel();
+        network_notifs_tx
+            .push_with_feedback(
+                key.clone(),
+                PeerManagerNotification::RecvMessage(seed_peer_id, get_raw_message(msg)),
+                Some(delivered_tx),
+            )
+            .unwrap();
+        delivered_rx.await.unwrap();
+
+        // Trigger outbound msg.
+        ticker_tx.send(()).await.unwrap();
+
+        // Check request sent as message over network.
+        match network_reqs_rx.select_next_some().await {
+            PeerManagerRequest::SendMessage(peer, raw_msg) => {
+                assert_eq!(peer, seed_peer_id);
+                let msg = parse_raw_message(raw_msg).unwrap();
+                // Receive DiscoveryMsg from actor. The message should contain only a note for the
+                // sending peer since it doesn't yet have the note for the seed peer.
+                assert_eq!(1, msg.notes.len());
+                assert_eq!(Vec::from(peer_id), msg.notes[0].peer_id);
+                assert!(get_epoch_from_note(&msg.notes[0]) < old_epoch);
+            }
+            req => {
+                panic!("Unexpected request to peer manager: {:?}", req);
+            }
+        }
     };
     rt.block_on(f_network);
 }


### PR DESCRIPTION
### Summary:
On receiving a note for self which has a higher epoch than that in the note issued by the current instance, we issue a new note with epoch 1 higher than what was received. This event is unlikely and should happen only in case of clock drift and process restarts.

One interesting case here is if the network signing key is compromised by a byzantine node which is able to insert a note with `epoch == u64::MAX`, forcing us to overflow and wrap around. This case is explicitly checked and a security message is logged.

### Test Plan:
Added tests to test both of the above.

Fixes #2477 
