### PR TITLE
[tf] add option to restore validator data on a new cluster

### DIFF
--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -92,7 +92,7 @@ locals {
 
 variable "validator_type" {
   description = "EC2 instance type of validator instances"
-  default     = "c5d.large"
+  default     = "c5.large"
 }
 
 variable "validator_ebs_size" {
@@ -188,4 +188,9 @@ variable "logstash_version" {
 variable "elastic_storage_size" {
   default = 500
   description = "The volume size for Elasticsearch"
+}
+
+variable "restore_vol_id" {
+  default     = ""
+  description = "volume id to restore validator data from"
 }


### PR DESCRIPTION
<!--
Thank you for sending a PR. We appreciate you spending time to help improve the Libra project.

The project is undergoing daily changes. Pull Requests will be reviewed and responded to as time permits.
-->

## Motivation

- Use ebs block device as storage so that we can take snapshot when needed (currently it's using a local device)
- Add option to restore data from an existing volume id
- Keep supporting local disk option when the machine type is specified. (e.g. c5d)

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

- Apply changes to sherryx workspace without specify a restore_vol_id
- make some changes in /data directory in sherryx validator-1
```
[ec2-user:validator@ip-10-0-9-221 /data]$ sudo mkdir hello
[ec2-user:validator@ip-10-0-9-221 /data]$ ls
hello  libra  lost+found
```
- Switch to sherryxiao workspace, apply changes with `-var "restore_vol_id=vol-017ec625bede4ef44"` (vol from sherryx-validator-1)
- check if the file changes show up in sherryxiao workspace
```
[ec2-user:validator@ip-10-0-8-205 ~]$ df -h
Filesystem      Size  Used Avail Use% Mounted on
devtmpfs        1.9G     0  1.9G   0% /dev
tmpfs           1.9G     0  1.9G   0% /dev/shm
tmpfs           1.9G  420K  1.9G   1% /run
tmpfs           1.9G     0  1.9G   0% /sys/fs/cgroup
/dev/nvme0n1p1   30G  1.9G   28G   7% /
/dev/nvme1n1     30G  124M   28G   1% /data
tmpfs           374M     0  374M   0% /run/user/1000

[ec2-user:validator@ip-10-0-8-205 ~]$ cd /data/
[ec2-user:validator@ip-10-0-8-205 /data]$ ls
hello  libra  lost+found
```

- cluster test shows using ebs block device didn't cause performance regression:
```
Feb 08 01:19:38.383 INFO Experiment finished, waiting until all affected validators recover
Feb 08 01:19:43.547 INFO Experiment completed
Feb 08 01:19:43.547 INFO Experiment Result: all up : 686 TPS, 896.6 ms latency, no expired txns
```

- make sure nothing changes when they instance type is set to c5d with local disk.
```
[ec2-user:validator@ip-10-0-8-154 ~]$ df -h
Filesystem      Size  Used Avail Use% Mounted on
devtmpfs        1.8G     0  1.8G   0% /dev
tmpfs           1.9G     0  1.9G   0% /dev/shm
tmpfs           1.9G  476K  1.9G   1% /run
tmpfs           1.9G     0  1.9G   0% /sys/fs/cgroup
/dev/nvme0n1p1   30G  2.0G   28G   7% /
/dev/nvme1n1     46G  202M   44G   1% /data
tmpfs           371M     0  371M   0% /run/user/0
tmpfs           371M     0  371M   0% /run/user/1000
[ec2-user:validator@ip-10-0-8-154 ~]$ sudo fdisk -l
Disk /dev/nvme1n1: 46.6 GiB, 50000000000 bytes, 97656250 sectors
Units: sectors of 1 * 512 = 512 bytes
Sector size (logical/physical): 512 bytes / 512 bytes
I/O size (minimum/optimal): 512 bytes / 512 bytes


Disk /dev/nvme0n1: 30 GiB, 32212254720 bytes, 62914560 sectors
Units: sectors of 1 * 512 = 512 bytes
Sector size (logical/physical): 512 bytes / 512 bytes
I/O size (minimum/optimal): 512 bytes / 512 bytes
Disklabel type: gpt
Disk identifier: B4D52539-F67D-4E90-A466-F88814B5744B

Device           Start      End  Sectors Size Type
/dev/nvme0n1p1    4096 62914526 62910431  30G Linux filesystem
/dev/nvme0n1p128  2048     4095     2048   1M BIOS boot

Partition table entries are not in disk order.
```