### PR TITLE
[language][prover] Fixed the parameter of `IsValidReferenceParameter`

### DIFF
--- a/language/move-prover/bytecode-to-boogie/src/boogie_helpers.rs
+++ b/language/move-prover/bytecode-to-boogie/src/boogie_helpers.rs
@@ -87,7 +87,7 @@ pub fn boogie_type_check(env: &GlobalEnv, name: &str, sig: &GlobalType) -> Strin
         GlobalType::Reference(rtype) | GlobalType::MutableReference(rtype) => {
             let n = format!("Dereference(__m, {})", params);
             ret = boogie_type_check(env, &n, rtype);
-            params = format!("__m, __frame, {}", params);
+            params = format!("__m, __local_counter, {}", params);
             "IsValidReferenceParameter"
         }
         // Otherwise it is a type parameter which is opaque

--- a/language/move-prover/bytecode-to-boogie/src/bytecode_translator.rs
+++ b/language/move-prover/bytecode-to-boogie/src/bytecode_translator.rs
@@ -1012,11 +1012,6 @@ impl<'env> ModuleTranslator<'env> {
         emitln!(self.writer, "assume !__abort_flag;");
         emitln!(self.writer, "__saved_m := __m;");
         emitln!(self.writer, "__frame := __local_counter;");
-        emitln!(
-            self.writer,
-            "__local_counter := __local_counter + {};",
-            code.local_types.len()
-        );
 
         emitln!(self.writer, "\n// process and type check arguments");
         for i in 0..num_args {
@@ -1036,6 +1031,13 @@ impl<'env> ModuleTranslator<'env> {
                 );
             }
         }
+
+        emitln!(self.writer, "\n// increase the local counter ");
+        emitln!(
+            self.writer,
+            "__local_counter := __local_counter + {};",
+            code.local_types.len()
+        );
 
         emitln!(self.writer, "\n// bytecode translation starts here");
 

--- a/language/move-prover/bytecode-to-boogie/src/prelude.bpl
+++ b/language/move-prover/bytecode-to-boogie/src/prelude.bpl
@@ -308,7 +308,7 @@ function {:constructor} Reference(l: Location, p: Path): Reference;
 const DefaultReference: Reference;
 
 function {:inline} IsValidReferenceParameter(m: Memory, local_counter: int, r: Reference): bool {
-  // If the reference parameter is for a local, its index must be less then the current
+  // If the reference parameter is for a local, its index must be less than the current
   // local counter. This prevents any aliasing with locals which we create later.
   (is#Local(l#Reference(r)) ==> i#Local(l#Reference(r)) < local_counter)
   &&

--- a/language/move-prover/bytecode-to-boogie/test_mvir/verify-vector.mvir
+++ b/language/move-prover/bytecode-to-boogie/test_mvir/verify-vector.mvir
@@ -270,9 +270,10 @@ module VerifyVector {
         return (7, *move(y));
     }
 
-    // TODO: This method accesses vector out-of-bounds, so should not be proved. However, Move Prover does not catch it currently.
+    // succeeds. Always aborts due to the out-of-bounds index used.
     public test_borrow2() : u64 * u64
-    ensures RET(0) == RET(1)
+    aborts_if true
+    ensures false
     {
         let ev1: Vector.T<u64>;
         let y : &u64;
@@ -280,5 +281,17 @@ module VerifyVector {
         Vector.push_back<u64>(&mut ev1, 7);
         y = Vector.borrow<u64>(&ev1, 1);
         return (7, *move(y));
+    }
+
+    // fails. 0 != 7
+    public test_borrow3() : u64 * u64
+    ensures RET(0) == RET(1) //! A postcondition might not hold on this return path.
+    {
+        let ev1: Vector.T<u64>;
+        let y : &u64;
+        ev1 = Vector.empty<u64>();
+        Vector.push_back<u64>(&mut ev1, 7);
+        y = Vector.borrow<u64>(&ev1, 0);
+        return (0, *move(y));
     }
 }

--- a/language/move-prover/bytecode-to-boogie/tests/goldenfiles/libra_account.bpl
+++ b/language/move-prover/bytecode-to-boogie/tests/goldenfiles/libra_account.bpl
@@ -140,12 +140,14 @@ ensures old(b#Boolean(Boolean(!(b#Boolean(ExistsResource(__m, LibraCoin_MintCapa
     assume !__abort_flag;
     __saved_m := __m;
     __frame := __local_counter;
-    __local_counter := __local_counter + 5;
 
     // process and type check arguments
     assume IsValidU64(amount);
     __m := UpdateLocal(__m, __frame + 0, amount);
     assume $DebugTrackLocal(0, 0, 0, 806, amount);
+
+    // increase the local counter
+    __local_counter := __local_counter + 5;
 
     // bytecode translation starts here
     call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 0));
@@ -224,16 +226,18 @@ ensures old(b#Boolean(Boolean(!(b#Boolean(ExistsResource(__m, LibraCoin_MarketCa
     assume !__abort_flag;
     __saved_m := __m;
     __frame := __local_counter;
-    __local_counter := __local_counter + 24;
 
     // process and type check arguments
     assume IsValidU64(value);
     __m := UpdateLocal(__m, __frame + 0, value);
     assume $DebugTrackLocal(0, 1, 0, 1723, value);
     assume is#Vector(Dereference(__m, capability));
-    assume IsValidReferenceParameter(__m, __frame, capability);
+    assume IsValidReferenceParameter(__m, __local_counter, capability);
     assume is#Vector(Dereference(__m, capability));
     assume $DebugTrackLocal(0, 1, 1, 1723, Dereference(__m, capability));
+
+    // increase the local counter
+    __local_counter := __local_counter + 24;
 
     // bytecode translation starts here
     call __t4 := CopyOrMoveRef(capability);
@@ -364,9 +368,11 @@ ensures old(b#Boolean(Boolean(!IsEqual(Address(TxnSenderAddress(__txn)), Address
     assume !__abort_flag;
     __saved_m := __m;
     __frame := __local_counter;
-    __local_counter := __local_counter + 9;
 
     // process and type check arguments
+
+    // increase the local counter
+    __local_counter := __local_counter + 9;
 
     // bytecode translation starts here
     call __tmp := GetTxnSenderAddress();
@@ -447,9 +453,11 @@ ensures old(b#Boolean(Boolean(!(b#Boolean(ExistsResource(__m, LibraCoin_MarketCa
     assume !__abort_flag;
     __saved_m := __m;
     __frame := __local_counter;
-    __local_counter := __local_counter + 4;
 
     // process and type check arguments
+
+    // increase the local counter
+    __local_counter := __local_counter + 4;
 
     // bytecode translation starts here
     call __tmp := LdAddr(173345816);
@@ -498,9 +506,11 @@ ensures b#Boolean(Boolean(IsEqual(SelectField(__ret0, LibraCoin_T_value), Intege
     assume !__abort_flag;
     __saved_m := __m;
     __frame := __local_counter;
-    __local_counter := __local_counter + 2;
 
     // process and type check arguments
+
+    // increase the local counter
+    __local_counter := __local_counter + 2;
 
     // bytecode translation starts here
     call __tmp := LdConst(0);
@@ -541,13 +551,15 @@ ensures b#Boolean(Boolean(IsEqual(__ret0, SelectField(Dereference(__m, coin_ref)
     assume !__abort_flag;
     __saved_m := __m;
     __frame := __local_counter;
-    __local_counter := __local_counter + 4;
 
     // process and type check arguments
     assume is#Vector(Dereference(__m, coin_ref));
-    assume IsValidReferenceParameter(__m, __frame, coin_ref);
+    assume IsValidReferenceParameter(__m, __local_counter, coin_ref);
     assume is#Vector(Dereference(__m, coin_ref));
     assume $DebugTrackLocal(0, 5, 0, 4555, Dereference(__m, coin_ref));
+
+    // increase the local counter
+    __local_counter := __local_counter + 4;
 
     // bytecode translation starts here
     call __t1 := CopyOrMoveRef(coin_ref);
@@ -596,7 +608,6 @@ ensures old(b#Boolean(Boolean(i#Integer(SelectField(coin, LibraCoin_T_value)) < 
     assume !__abort_flag;
     __saved_m := __m;
     __frame := __local_counter;
-    __local_counter := __local_counter + 8;
 
     // process and type check arguments
     assume is#Vector(coin);
@@ -605,6 +616,9 @@ ensures old(b#Boolean(Boolean(i#Integer(SelectField(coin, LibraCoin_T_value)) < 
     assume IsValidU64(amount);
     __m := UpdateLocal(__m, __frame + 1, amount);
     assume $DebugTrackLocal(0, 6, 1, 4818, amount);
+
+    // increase the local counter
+    __local_counter := __local_counter + 8;
 
     // bytecode translation starts here
     call __t3 := BorrowLoc(__frame + 0);
@@ -684,16 +698,18 @@ ensures old(b#Boolean(Boolean(i#Integer(SelectField(Dereference(__m, coin_ref), 
     assume !__abort_flag;
     __saved_m := __m;
     __frame := __local_counter;
-    __local_counter := __local_counter + 18;
 
     // process and type check arguments
     assume is#Vector(Dereference(__m, coin_ref));
-    assume IsValidReferenceParameter(__m, __frame, coin_ref);
+    assume IsValidReferenceParameter(__m, __local_counter, coin_ref);
     assume is#Vector(Dereference(__m, coin_ref));
     assume $DebugTrackLocal(0, 7, 0, 5391, Dereference(__m, coin_ref));
     assume IsValidU64(amount);
     __m := UpdateLocal(__m, __frame + 1, amount);
     assume $DebugTrackLocal(0, 7, 1, 5391, amount);
+
+    // increase the local counter
+    __local_counter := __local_counter + 18;
 
     // bytecode translation starts here
     call __t3 := CopyOrMoveRef(coin_ref);
@@ -789,7 +805,6 @@ ensures old(b#Boolean(Boolean(i#Integer(Integer(i#Integer(SelectField(coin1, Lib
     assume !__abort_flag;
     __saved_m := __m;
     __frame := __local_counter;
-    __local_counter := __local_counter + 5;
 
     // process and type check arguments
     assume is#Vector(coin1);
@@ -798,6 +813,9 @@ ensures old(b#Boolean(Boolean(i#Integer(Integer(i#Integer(SelectField(coin1, Lib
     assume is#Vector(coin2);
     __m := UpdateLocal(__m, __frame + 1, coin2);
     assume $DebugTrackLocal(0, 8, 1, 6020, coin2);
+
+    // increase the local counter
+    __local_counter := __local_counter + 5;
 
     // bytecode translation starts here
     call __t2 := BorrowLoc(__frame + 0);
@@ -859,16 +877,18 @@ ensures old(b#Boolean(Boolean(i#Integer(Integer(i#Integer(SelectField(Dereferenc
     assume !__abort_flag;
     __saved_m := __m;
     __frame := __local_counter;
-    __local_counter := __local_counter + 14;
 
     // process and type check arguments
     assume is#Vector(Dereference(__m, coin_ref));
-    assume IsValidReferenceParameter(__m, __frame, coin_ref);
+    assume IsValidReferenceParameter(__m, __local_counter, coin_ref);
     assume is#Vector(Dereference(__m, coin_ref));
     assume $DebugTrackLocal(0, 9, 0, 6465, Dereference(__m, coin_ref));
     assume is#Vector(check);
     __m := UpdateLocal(__m, __frame + 1, check);
     assume $DebugTrackLocal(0, 9, 1, 6465, check);
+
+    // increase the local counter
+    __local_counter := __local_counter + 14;
 
     // bytecode translation starts here
     call __t4 := CopyOrMoveRef(coin_ref);
@@ -948,12 +968,14 @@ ensures old(b#Boolean(Boolean(!IsEqual(SelectField(coin, LibraCoin_T_value), Int
     assume !__abort_flag;
     __saved_m := __m;
     __frame := __local_counter;
-    __local_counter := __local_counter + 9;
 
     // process and type check arguments
     assume is#Vector(coin);
     __m := UpdateLocal(__m, __frame + 0, coin);
     assume $DebugTrackLocal(0, 10, 0, 7117, coin);
+
+    // increase the local counter
+    __local_counter := __local_counter + 9;
 
     // bytecode translation starts here
     call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 0));
@@ -1271,12 +1293,14 @@ ensures b#Boolean(Boolean(b#Boolean(Boolean(IsEqual(SelectField(SelectField(__re
     assume !__abort_flag;
     __saved_m := __m;
     __frame := __local_counter;
-    __local_counter := __local_counter + 26;
 
     // process and type check arguments
     assume is#Address(fresh_address);
     __m := UpdateLocal(__m, __frame + 0, fresh_address);
     assume $DebugTrackLocal(5, 0, 0, 3283, fresh_address);
+
+    // increase the local counter
+    __local_counter := __local_counter + 26;
 
     // bytecode translation starts here
     call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 0));
@@ -1418,7 +1442,6 @@ ensures old(b#Boolean(Boolean(!(b#Boolean(ExistsResource(__m, LibraAccount_T_typ
     assume !__abort_flag;
     __saved_m := __m;
     __frame := __local_counter;
-    __local_counter := __local_counter + 5;
 
     // process and type check arguments
     assume is#Address(payee);
@@ -1427,6 +1450,9 @@ ensures old(b#Boolean(Boolean(!(b#Boolean(ExistsResource(__m, LibraAccount_T_typ
     assume is#Vector(to_deposit);
     __m := UpdateLocal(__m, __frame + 1, to_deposit);
     assume $DebugTrackLocal(5, 1, 1, 4674, to_deposit);
+
+    // increase the local counter
+    __local_counter := __local_counter + 5;
 
     // bytecode translation starts here
     call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 0));
@@ -1476,7 +1502,6 @@ ensures old(b#Boolean(Boolean(!(b#Boolean(ExistsResource(__m, LibraAccount_T_typ
     assume !__abort_flag;
     __saved_m := __m;
     __frame := __local_counter;
-    __local_counter := __local_counter + 7;
 
     // process and type check arguments
     assume is#Address(payee);
@@ -1488,6 +1513,9 @@ ensures old(b#Boolean(Boolean(!(b#Boolean(ExistsResource(__m, LibraAccount_T_typ
     assume is#ByteArray(metadata);
     __m := UpdateLocal(__m, __frame + 2, metadata);
     assume $DebugTrackLocal(5, 2, 2, 5450, metadata);
+
+    // increase the local counter
+    __local_counter := __local_counter + 7;
 
     // bytecode translation starts here
     call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 0));
@@ -1566,7 +1594,6 @@ ensures old(b#Boolean(Boolean(!(b#Boolean(ExistsResource(__m, LibraAccount_T_typ
     assume !__abort_flag;
     __saved_m := __m;
     __frame := __local_counter;
-    __local_counter := __local_counter + 33;
 
     // process and type check arguments
     assume is#Address(payee);
@@ -1581,6 +1608,9 @@ ensures old(b#Boolean(Boolean(!(b#Boolean(ExistsResource(__m, LibraAccount_T_typ
     assume is#ByteArray(metadata);
     __m := UpdateLocal(__m, __frame + 3, metadata);
     assume $DebugTrackLocal(5, 3, 3, 6415, metadata);
+
+    // increase the local counter
+    __local_counter := __local_counter + 33;
 
     // bytecode translation starts here
     call __t7 := BorrowLoc(__frame + 2);
@@ -1741,7 +1771,6 @@ ensures old(b#Boolean(Boolean(!(b#Boolean(ExistsResource(__m, LibraCoin_MintCapa
     assume !__abort_flag;
     __saved_m := __m;
     __frame := __local_counter;
-    __local_counter := __local_counter + 9;
 
     // process and type check arguments
     assume is#Address(payee);
@@ -1750,6 +1779,9 @@ ensures old(b#Boolean(Boolean(!(b#Boolean(ExistsResource(__m, LibraCoin_MintCapa
     assume IsValidU64(amount);
     __m := UpdateLocal(__m, __frame + 1, amount);
     assume $DebugTrackLocal(5, 4, 1, 8679, amount);
+
+    // increase the local counter
+    __local_counter := __local_counter + 9;
 
     // bytecode translation starts here
     call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 0));
@@ -1831,16 +1863,18 @@ ensures old(b#Boolean(Boolean(i#Integer(SelectField(SelectField(Dereference(__m,
     assume !__abort_flag;
     __saved_m := __m;
     __frame := __local_counter;
-    __local_counter := __local_counter + 8;
 
     // process and type check arguments
     assume is#Vector(Dereference(__m, account));
-    assume IsValidReferenceParameter(__m, __frame, account);
+    assume IsValidReferenceParameter(__m, __local_counter, account);
     assume is#Vector(Dereference(__m, account));
     assume $DebugTrackLocal(5, 5, 0, 10231, Dereference(__m, account));
     assume IsValidU64(amount);
     __m := UpdateLocal(__m, __frame + 1, amount);
     assume $DebugTrackLocal(5, 5, 1, 10231, amount);
+
+    // increase the local counter
+    __local_counter := __local_counter + 8;
 
     // bytecode translation starts here
     call __t3 := CopyOrMoveRef(account);
@@ -1909,12 +1943,14 @@ ensures old(b#Boolean(SelectField(Dereference(__m, GetResourceReference(LibraAcc
     assume !__abort_flag;
     __saved_m := __m;
     __frame := __local_counter;
-    __local_counter := __local_counter + 11;
 
     // process and type check arguments
     assume IsValidU64(amount);
     __m := UpdateLocal(__m, __frame + 0, amount);
     assume $DebugTrackLocal(5, 6, 0, 10712, amount);
+
+    // increase the local counter
+    __local_counter := __local_counter + 11;
 
     // bytecode translation starts here
     call __tmp := GetTxnSenderAddress();
@@ -2002,16 +2038,18 @@ ensures old(b#Boolean(Boolean(!(b#Boolean(ExistsResource(__m, LibraAccount_T_typ
     assume !__abort_flag;
     __saved_m := __m;
     __frame := __local_counter;
-    __local_counter := __local_counter + 10;
 
     // process and type check arguments
     assume is#Vector(Dereference(__m, cap));
-    assume IsValidReferenceParameter(__m, __frame, cap);
+    assume IsValidReferenceParameter(__m, __local_counter, cap);
     assume is#Vector(Dereference(__m, cap));
     assume $DebugTrackLocal(5, 7, 0, 11652, Dereference(__m, cap));
     assume IsValidU64(amount);
     __m := UpdateLocal(__m, __frame + 1, amount);
     assume $DebugTrackLocal(5, 7, 1, 11652, amount);
+
+    // increase the local counter
+    __local_counter := __local_counter + 10;
 
     // bytecode translation starts here
     call __t3 := CopyOrMoveRef(cap);
@@ -2094,9 +2132,11 @@ ensures old(b#Boolean(Boolean(!(b#Boolean(ExistsResource(__m, LibraAccount_T_typ
     assume !__abort_flag;
     __saved_m := __m;
     __frame := __local_counter;
-    __local_counter := __local_counter + 15;
 
     // process and type check arguments
+
+    // increase the local counter
+    __local_counter := __local_counter + 15;
 
     // bytecode translation starts here
     call __tmp := GetTxnSenderAddress();
@@ -2196,12 +2236,14 @@ ensures old(b#Boolean(Boolean(!(b#Boolean(ExistsResource(__m, LibraAccount_T_typ
     assume !__abort_flag;
     __saved_m := __m;
     __frame := __local_counter;
-    __local_counter := __local_counter + 10;
 
     // process and type check arguments
     assume is#Vector(cap);
     __m := UpdateLocal(__m, __frame + 0, cap);
     assume $DebugTrackLocal(5, 9, 0, 13429, cap);
+
+    // increase the local counter
+    __local_counter := __local_counter + 10;
 
     // bytecode translation starts here
     call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 0));
@@ -2275,14 +2317,13 @@ ensures b#Boolean(Boolean(b#Boolean(Boolean(!(b#Boolean(Boolean(!(b#Boolean(old(
     assume !__abort_flag;
     __saved_m := __m;
     __frame := __local_counter;
-    __local_counter := __local_counter + 16;
 
     // process and type check arguments
     assume is#Address(payee);
     __m := UpdateLocal(__m, __frame + 0, payee);
     assume $DebugTrackLocal(5, 10, 0, 14433, payee);
     assume is#Vector(Dereference(__m, cap));
-    assume IsValidReferenceParameter(__m, __frame, cap);
+    assume IsValidReferenceParameter(__m, __local_counter, cap);
     assume is#Vector(Dereference(__m, cap));
     assume $DebugTrackLocal(5, 10, 1, 14433, Dereference(__m, cap));
     assume IsValidU64(amount);
@@ -2291,6 +2332,9 @@ ensures b#Boolean(Boolean(b#Boolean(Boolean(!(b#Boolean(Boolean(!(b#Boolean(old(
     assume is#ByteArray(metadata);
     __m := UpdateLocal(__m, __frame + 3, metadata);
     assume $DebugTrackLocal(5, 10, 3, 14433, metadata);
+
+    // increase the local counter
+    __local_counter := __local_counter + 16;
 
     // bytecode translation starts here
     call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 0));
@@ -2393,7 +2437,6 @@ ensures old(b#Boolean(SelectField(Dereference(__m, GetResourceReference(LibraAcc
     assume !__abort_flag;
     __saved_m := __m;
     __frame := __local_counter;
-    __local_counter := __local_counter + 16;
 
     // process and type check arguments
     assume is#Address(payee);
@@ -2405,6 +2448,9 @@ ensures old(b#Boolean(SelectField(Dereference(__m, GetResourceReference(LibraAcc
     assume is#ByteArray(metadata);
     __m := UpdateLocal(__m, __frame + 2, metadata);
     assume $DebugTrackLocal(5, 11, 2, 16060, metadata);
+
+    // increase the local counter
+    __local_counter := __local_counter + 16;
 
     // bytecode translation starts here
     call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 0));
@@ -2514,7 +2560,6 @@ ensures old(b#Boolean(SelectField(Dereference(__m, GetResourceReference(LibraAcc
     assume !__abort_flag;
     __saved_m := __m;
     __frame := __local_counter;
-    __local_counter := __local_counter + 10;
 
     // process and type check arguments
     assume is#Address(payee);
@@ -2523,6 +2568,9 @@ ensures old(b#Boolean(SelectField(Dereference(__m, GetResourceReference(LibraAcc
     assume IsValidU64(amount);
     __m := UpdateLocal(__m, __frame + 1, amount);
     assume $DebugTrackLocal(5, 12, 1, 17668, amount);
+
+    // increase the local counter
+    __local_counter := __local_counter + 10;
 
     // bytecode translation starts here
     call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 0));
@@ -2589,16 +2637,18 @@ ensures b#Boolean(Boolean(IsEqual(SelectField(Dereference(__m, account), LibraAc
     assume !__abort_flag;
     __saved_m := __m;
     __frame := __local_counter;
-    __local_counter := __local_counter + 5;
 
     // process and type check arguments
     assume is#Vector(Dereference(__m, account));
-    assume IsValidReferenceParameter(__m, __frame, account);
+    assume IsValidReferenceParameter(__m, __local_counter, account);
     assume is#Vector(Dereference(__m, account));
     assume $DebugTrackLocal(5, 13, 0, 18853, Dereference(__m, account));
     assume is#ByteArray(new_authentication_key);
     __m := UpdateLocal(__m, __frame + 1, new_authentication_key);
     assume $DebugTrackLocal(5, 13, 1, 18853, new_authentication_key);
+
+    // increase the local counter
+    __local_counter := __local_counter + 5;
 
     // bytecode translation starts here
     call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 1));
@@ -2648,12 +2698,14 @@ ensures old(b#Boolean(Boolean(!(b#Boolean(ExistsResource(__m, LibraAccount_T_typ
     assume !__abort_flag;
     __saved_m := __m;
     __frame := __local_counter;
-    __local_counter := __local_counter + 10;
 
     // process and type check arguments
     assume is#ByteArray(new_authentication_key);
     __m := UpdateLocal(__m, __frame + 0, new_authentication_key);
     assume $DebugTrackLocal(5, 14, 0, 19253, new_authentication_key);
+
+    // increase the local counter
+    __local_counter := __local_counter + 10;
 
     // bytecode translation starts here
     call __tmp := GetTxnSenderAddress();
@@ -2730,16 +2782,18 @@ ensures old(b#Boolean(Boolean(!(b#Boolean(ExistsResource(__m, LibraAccount_T_typ
     assume !__abort_flag;
     __saved_m := __m;
     __frame := __local_counter;
-    __local_counter := __local_counter + 7;
 
     // process and type check arguments
     assume is#Vector(Dereference(__m, cap));
-    assume IsValidReferenceParameter(__m, __frame, cap);
+    assume IsValidReferenceParameter(__m, __local_counter, cap);
     assume is#Vector(Dereference(__m, cap));
     assume $DebugTrackLocal(5, 15, 0, 20225, Dereference(__m, cap));
     assume is#ByteArray(new_authentication_key);
     __m := UpdateLocal(__m, __frame + 1, new_authentication_key);
     assume $DebugTrackLocal(5, 15, 1, 20225, new_authentication_key);
+
+    // increase the local counter
+    __local_counter := __local_counter + 7;
 
     // bytecode translation starts here
     call __t2 := CopyOrMoveRef(cap);
@@ -2807,9 +2861,11 @@ ensures old(b#Boolean(Boolean(!(b#Boolean(ExistsResource(__m, LibraAccount_T_typ
     assume !__abort_flag;
     __saved_m := __m;
     __frame := __local_counter;
-    __local_counter := __local_counter + 13;
 
     // process and type check arguments
+
+    // increase the local counter
+    __local_counter := __local_counter + 13;
 
     // bytecode translation starts here
     call __tmp := GetTxnSenderAddress();
@@ -2903,12 +2959,14 @@ ensures old(b#Boolean(Boolean(!(b#Boolean(ExistsResource(__m, LibraAccount_T_typ
     assume !__abort_flag;
     __saved_m := __m;
     __frame := __local_counter;
-    __local_counter := __local_counter + 10;
 
     // process and type check arguments
     assume is#Vector(cap);
     __m := UpdateLocal(__m, __frame + 0, cap);
     assume $DebugTrackLocal(5, 17, 0, 21751, cap);
+
+    // increase the local counter
+    __local_counter := __local_counter + 10;
 
     // bytecode translation starts here
     call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 0));
@@ -2992,12 +3050,14 @@ ensures old(b#Boolean(ExistsResource(__m, LibraAccount_T_type_value(), a#Address
     assume !__abort_flag;
     __saved_m := __m;
     __frame := __local_counter;
-    __local_counter := __local_counter + 19;
 
     // process and type check arguments
     assume is#Address(fresh_address);
     __m := UpdateLocal(__m, __frame + 0, fresh_address);
     assume $DebugTrackLocal(5, 18, 0, 22651, fresh_address);
+
+    // increase the local counter
+    __local_counter := __local_counter + 19;
 
     // bytecode translation starts here
     call __tmp := LdConst(0);
@@ -3123,7 +3183,6 @@ ensures old(b#Boolean(ExistsResource(__m, LibraAccount_T_type_value(), a#Address
     assume !__abort_flag;
     __saved_m := __m;
     __frame := __local_counter;
-    __local_counter := __local_counter + 8;
 
     // process and type check arguments
     assume is#Address(fresh_address);
@@ -3132,6 +3191,9 @@ ensures old(b#Boolean(ExistsResource(__m, LibraAccount_T_type_value(), a#Address
     assume IsValidU64(initial_balance);
     __m := UpdateLocal(__m, __frame + 1, initial_balance);
     assume $DebugTrackLocal(5, 19, 1, 23890, initial_balance);
+
+    // increase the local counter
+    __local_counter := __local_counter + 8;
 
     // bytecode translation starts here
     call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 0));
@@ -3199,13 +3261,15 @@ ensures b#Boolean(Boolean(IsEqual(__ret0, SelectField(SelectField(Dereference(__
     assume !__abort_flag;
     __saved_m := __m;
     __frame := __local_counter;
-    __local_counter := __local_counter + 6;
 
     // process and type check arguments
     assume is#Vector(Dereference(__m, account));
-    assume IsValidReferenceParameter(__m, __frame, account);
+    assume IsValidReferenceParameter(__m, __local_counter, account);
     assume is#Vector(Dereference(__m, account));
     assume $DebugTrackLocal(5, 21, 0, 25151, Dereference(__m, account));
+
+    // increase the local counter
+    __local_counter := __local_counter + 6;
 
     // bytecode translation starts here
     call __t2 := CopyOrMoveRef(account);
@@ -3263,12 +3327,14 @@ ensures old(b#Boolean(Boolean(!(b#Boolean(ExistsResource(__m, LibraAccount_T_typ
     assume !__abort_flag;
     __saved_m := __m;
     __frame := __local_counter;
-    __local_counter := __local_counter + 4;
 
     // process and type check arguments
     assume is#Address(addr);
     __m := UpdateLocal(__m, __frame + 0, addr);
     assume $DebugTrackLocal(5, 22, 0, 25470, addr);
+
+    // increase the local counter
+    __local_counter := __local_counter + 4;
 
     // bytecode translation starts here
     call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 0));
@@ -3321,13 +3387,15 @@ ensures b#Boolean(Boolean(IsEqual(__ret0, SelectField(Dereference(__m, account),
     assume !__abort_flag;
     __saved_m := __m;
     __frame := __local_counter;
-    __local_counter := __local_counter + 4;
 
     // process and type check arguments
     assume is#Vector(Dereference(__m, account));
-    assume IsValidReferenceParameter(__m, __frame, account);
+    assume IsValidReferenceParameter(__m, __local_counter, account);
     assume is#Vector(Dereference(__m, account));
     assume $DebugTrackLocal(5, 23, 0, 25787, Dereference(__m, account));
+
+    // increase the local counter
+    __local_counter := __local_counter + 4;
 
     // bytecode translation starts here
     call __t1 := CopyOrMoveRef(account);
@@ -3373,12 +3441,14 @@ ensures old(b#Boolean(Boolean(!(b#Boolean(ExistsResource(__m, LibraAccount_T_typ
     assume !__abort_flag;
     __saved_m := __m;
     __frame := __local_counter;
-    __local_counter := __local_counter + 4;
 
     // process and type check arguments
     assume is#Address(addr);
     __m := UpdateLocal(__m, __frame + 0, addr);
     assume $DebugTrackLocal(5, 24, 0, 26004, addr);
+
+    // increase the local counter
+    __local_counter := __local_counter + 4;
 
     // bytecode translation starts here
     call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 0));
@@ -3435,12 +3505,14 @@ ensures old(b#Boolean(Boolean(!(b#Boolean(ExistsResource(__m, LibraAccount_T_typ
     assume !__abort_flag;
     __saved_m := __m;
     __frame := __local_counter;
-    __local_counter := __local_counter + 5;
 
     // process and type check arguments
     assume is#Address(addr);
     __m := UpdateLocal(__m, __frame + 0, addr);
     assume $DebugTrackLocal(5, 25, 0, 26354, addr);
+
+    // increase the local counter
+    __local_counter := __local_counter + 5;
 
     // bytecode translation starts here
     call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 0));
@@ -3494,12 +3566,14 @@ ensures old(b#Boolean(Boolean(!(b#Boolean(ExistsResource(__m, LibraAccount_T_typ
     assume !__abort_flag;
     __saved_m := __m;
     __frame := __local_counter;
-    __local_counter := __local_counter + 5;
 
     // process and type check arguments
     assume is#Address(addr);
     __m := UpdateLocal(__m, __frame + 0, addr);
     assume $DebugTrackLocal(5, 26, 0, 26744, addr);
+
+    // increase the local counter
+    __local_counter := __local_counter + 5;
 
     // bytecode translation starts here
     call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 0));
@@ -3548,13 +3622,15 @@ ensures b#Boolean(Boolean((__ret0) == (SelectFieldFromRef(cap, LibraAccount_With
     assume !__abort_flag;
     __saved_m := __m;
     __frame := __local_counter;
-    __local_counter := __local_counter + 3;
 
     // process and type check arguments
     assume is#Vector(Dereference(__m, cap));
-    assume IsValidReferenceParameter(__m, __frame, cap);
+    assume IsValidReferenceParameter(__m, __local_counter, cap);
     assume is#Vector(Dereference(__m, cap));
     assume $DebugTrackLocal(5, 27, 0, 27134, Dereference(__m, cap));
+
+    // increase the local counter
+    __local_counter := __local_counter + 3;
 
     // bytecode translation starts here
     call __t1 := CopyOrMoveRef(cap);
@@ -3593,13 +3669,15 @@ ensures b#Boolean(Boolean((__ret0) == (SelectFieldFromRef(cap, LibraAccount_KeyR
     assume !__abort_flag;
     __saved_m := __m;
     __frame := __local_counter;
-    __local_counter := __local_counter + 3;
 
     // process and type check arguments
     assume is#Vector(Dereference(__m, cap));
-    assume IsValidReferenceParameter(__m, __frame, cap);
+    assume IsValidReferenceParameter(__m, __local_counter, cap);
     assume is#Vector(Dereference(__m, cap));
     assume $DebugTrackLocal(5, 28, 0, 27410, Dereference(__m, cap));
+
+    // increase the local counter
+    __local_counter := __local_counter + 3;
 
     // bytecode translation starts here
     call __t1 := CopyOrMoveRef(cap);
@@ -3638,12 +3716,14 @@ ensures b#Boolean(Boolean(IsEqual(__ret0, ExistsResource(__m, LibraAccount_T_typ
     assume !__abort_flag;
     __saved_m := __m;
     __frame := __local_counter;
-    __local_counter := __local_counter + 3;
 
     // process and type check arguments
     assume is#Address(check_addr);
     __m := UpdateLocal(__m, __frame + 0, check_addr);
     assume $DebugTrackLocal(5, 29, 0, 27648, check_addr);
+
+    // increase the local counter
+    __local_counter := __local_counter + 3;
 
     // bytecode translation starts here
     call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 0));
@@ -3726,7 +3806,6 @@ requires ExistsTxnSenderAccount(__m, __txn);
     assume !__abort_flag;
     __saved_m := __m;
     __frame := __local_counter;
-    __local_counter := __local_counter + 50;
 
     // process and type check arguments
     assume IsValidU64(txn_sequence_number);
@@ -3741,6 +3820,9 @@ requires ExistsTxnSenderAccount(__m, __txn);
     assume IsValidU64(txn_max_gas_units);
     __m := UpdateLocal(__m, __frame + 3, txn_max_gas_units);
     assume $DebugTrackLocal(5, 30, 3, 28109, txn_max_gas_units);
+
+    // increase the local counter
+    __local_counter := __local_counter + 50;
 
     // bytecode translation starts here
     call __tmp := GetTxnSenderAddress();
@@ -3989,7 +4071,6 @@ requires ExistsTxnSenderAccount(__m, __txn);
     assume !__abort_flag;
     __saved_m := __m;
     __frame := __local_counter;
-    __local_counter := __local_counter + 37;
 
     // process and type check arguments
     assume IsValidU64(txn_sequence_number);
@@ -4004,6 +4085,9 @@ requires ExistsTxnSenderAccount(__m, __txn);
     assume IsValidU64(gas_units_remaining);
     __m := UpdateLocal(__m, __frame + 3, gas_units_remaining);
     assume $DebugTrackLocal(5, 31, 3, 29902, gas_units_remaining);
+
+    // increase the local counter
+    __local_counter := __local_counter + 37;
 
     // bytecode translation starts here
     call __tmp := GetTxnSenderAddress();
@@ -4194,16 +4278,18 @@ ensures old(b#Boolean(Boolean(i#Integer(Integer(i#Integer(SelectField(Dereferenc
     assume !__abort_flag;
     __saved_m := __m;
     __frame := __local_counter;
-    __local_counter := __local_counter + 22;
 
     // process and type check arguments
     assume is#Vector(Dereference(__m, counter));
-    assume IsValidReferenceParameter(__m, __frame, counter);
+    assume IsValidReferenceParameter(__m, __local_counter, counter);
     assume is#Vector(Dereference(__m, counter));
     assume $DebugTrackLocal(5, 32, 0, 31860, Dereference(__m, counter));
     assume is#Address(sender);
     __m := UpdateLocal(__m, __frame + 1, sender);
     assume $DebugTrackLocal(5, 32, 1, 31860, sender);
+
+    // increase the local counter
+    __local_counter := __local_counter + 22;
 
     // bytecode translation starts here
     call __t6 := CopyOrMoveRef(counter);
@@ -4327,16 +4413,18 @@ ensures old(b#Boolean(Boolean(i#Integer(Integer(i#Integer(SelectField(Dereferenc
     assume !__abort_flag;
     __saved_m := __m;
     __frame := __local_counter;
-    __local_counter := __local_counter + 7;
 
     // process and type check arguments
     assume is#Vector(Dereference(__m, counter));
-    assume IsValidReferenceParameter(__m, __frame, counter);
+    assume IsValidReferenceParameter(__m, __local_counter, counter);
     assume is#Vector(Dereference(__m, counter));
     assume $DebugTrackLocal(5, 33, 0, 32671, Dereference(__m, counter));
     assume is#Address(sender);
     __m := UpdateLocal(__m, __frame + 1, sender);
     assume $DebugTrackLocal(5, 33, 1, 32671, sender);
+
+    // increase the local counter
+    __local_counter := __local_counter + 7;
 
     // bytecode translation starts here
     call __tmp := LdConst(0);
@@ -4398,9 +4486,11 @@ ensures old(b#Boolean(Boolean(i#Integer(Integer(i#Integer(SelectField(SelectFiel
     assume !__abort_flag;
     __saved_m := __m;
     __frame := __local_counter;
-    __local_counter := __local_counter + 8;
 
     // process and type check arguments
+
+    // increase the local counter
+    __local_counter := __local_counter + 8;
 
     // bytecode translation starts here
     call __tmp := GetTxnSenderAddress();
@@ -4479,15 +4569,17 @@ ensures old(b#Boolean(Boolean(i#Integer(Integer(i#Integer(SelectField(Dereferenc
     assume !__abort_flag;
     __saved_m := __m;
     __frame := __local_counter;
-    __local_counter := __local_counter + 18;
 
     // process and type check arguments
     assume is#Vector(Dereference(__m, handle_ref));
-    assume IsValidReferenceParameter(__m, __frame, handle_ref);
+    assume IsValidReferenceParameter(__m, __local_counter, handle_ref);
     assume is#Vector(Dereference(__m, handle_ref));
     assume $DebugTrackLocal(5, 35, 0, 33671, Dereference(__m, handle_ref));
     __m := UpdateLocal(__m, __frame + 1, msg);
     assume $DebugTrackLocal(5, 35, 1, 33671, msg);
+
+    // increase the local counter
+    __local_counter := __local_counter + 18;
 
     // bytecode translation starts here
     call __t4 := CopyOrMoveRef(handle_ref);
@@ -4581,12 +4673,14 @@ ensures old(b#Boolean(Boolean(false))) ==> __abort_flag;
     assume !__abort_flag;
     __saved_m := __m;
     __frame := __local_counter;
-    __local_counter := __local_counter + 6;
 
     // process and type check arguments
     assume is#Vector(handle);
     __m := UpdateLocal(__m, __frame + 0, handle);
     assume $DebugTrackLocal(5, 37, 0, 34391, handle);
+
+    // increase the local counter
+    __local_counter := __local_counter + 6;
 
     // bytecode translation starts here
     call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 0));

--- a/language/move-prover/bytecode-to-boogie/tests/goldenfiles/libra_coin.bpl
+++ b/language/move-prover/bytecode-to-boogie/tests/goldenfiles/libra_coin.bpl
@@ -84,12 +84,14 @@ ensures old(b#Boolean(Boolean(!(b#Boolean(ExistsResource(__m, LibraCoin_MintCapa
     assume !__abort_flag;
     __saved_m := __m;
     __frame := __local_counter;
-    __local_counter := __local_counter + 5;
 
     // process and type check arguments
     assume IsValidU64(amount);
     __m := UpdateLocal(__m, __frame + 0, amount);
     assume $DebugTrackLocal(0, 0, 0, 806, amount);
+
+    // increase the local counter
+    __local_counter := __local_counter + 5;
 
     // bytecode translation starts here
     call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 0));
@@ -168,16 +170,18 @@ ensures old(b#Boolean(Boolean(!(b#Boolean(ExistsResource(__m, LibraCoin_MarketCa
     assume !__abort_flag;
     __saved_m := __m;
     __frame := __local_counter;
-    __local_counter := __local_counter + 24;
 
     // process and type check arguments
     assume IsValidU64(value);
     __m := UpdateLocal(__m, __frame + 0, value);
     assume $DebugTrackLocal(0, 1, 0, 1723, value);
     assume is#Vector(Dereference(__m, capability));
-    assume IsValidReferenceParameter(__m, __frame, capability);
+    assume IsValidReferenceParameter(__m, __local_counter, capability);
     assume is#Vector(Dereference(__m, capability));
     assume $DebugTrackLocal(0, 1, 1, 1723, Dereference(__m, capability));
+
+    // increase the local counter
+    __local_counter := __local_counter + 24;
 
     // bytecode translation starts here
     call __t4 := CopyOrMoveRef(capability);
@@ -308,9 +312,11 @@ ensures old(b#Boolean(Boolean(!IsEqual(Address(TxnSenderAddress(__txn)), Address
     assume !__abort_flag;
     __saved_m := __m;
     __frame := __local_counter;
-    __local_counter := __local_counter + 9;
 
     // process and type check arguments
+
+    // increase the local counter
+    __local_counter := __local_counter + 9;
 
     // bytecode translation starts here
     call __tmp := GetTxnSenderAddress();
@@ -391,9 +397,11 @@ ensures old(b#Boolean(Boolean(!(b#Boolean(ExistsResource(__m, LibraCoin_MarketCa
     assume !__abort_flag;
     __saved_m := __m;
     __frame := __local_counter;
-    __local_counter := __local_counter + 4;
 
     // process and type check arguments
+
+    // increase the local counter
+    __local_counter := __local_counter + 4;
 
     // bytecode translation starts here
     call __tmp := LdAddr(173345816);
@@ -442,9 +450,11 @@ ensures b#Boolean(Boolean(IsEqual(SelectField(__ret0, LibraCoin_T_value), Intege
     assume !__abort_flag;
     __saved_m := __m;
     __frame := __local_counter;
-    __local_counter := __local_counter + 2;
 
     // process and type check arguments
+
+    // increase the local counter
+    __local_counter := __local_counter + 2;
 
     // bytecode translation starts here
     call __tmp := LdConst(0);
@@ -485,13 +495,15 @@ ensures b#Boolean(Boolean(IsEqual(__ret0, SelectField(Dereference(__m, coin_ref)
     assume !__abort_flag;
     __saved_m := __m;
     __frame := __local_counter;
-    __local_counter := __local_counter + 4;
 
     // process and type check arguments
     assume is#Vector(Dereference(__m, coin_ref));
-    assume IsValidReferenceParameter(__m, __frame, coin_ref);
+    assume IsValidReferenceParameter(__m, __local_counter, coin_ref);
     assume is#Vector(Dereference(__m, coin_ref));
     assume $DebugTrackLocal(0, 5, 0, 4555, Dereference(__m, coin_ref));
+
+    // increase the local counter
+    __local_counter := __local_counter + 4;
 
     // bytecode translation starts here
     call __t1 := CopyOrMoveRef(coin_ref);
@@ -540,7 +552,6 @@ ensures old(b#Boolean(Boolean(i#Integer(SelectField(coin, LibraCoin_T_value)) < 
     assume !__abort_flag;
     __saved_m := __m;
     __frame := __local_counter;
-    __local_counter := __local_counter + 8;
 
     // process and type check arguments
     assume is#Vector(coin);
@@ -549,6 +560,9 @@ ensures old(b#Boolean(Boolean(i#Integer(SelectField(coin, LibraCoin_T_value)) < 
     assume IsValidU64(amount);
     __m := UpdateLocal(__m, __frame + 1, amount);
     assume $DebugTrackLocal(0, 6, 1, 4818, amount);
+
+    // increase the local counter
+    __local_counter := __local_counter + 8;
 
     // bytecode translation starts here
     call __t3 := BorrowLoc(__frame + 0);
@@ -628,16 +642,18 @@ ensures old(b#Boolean(Boolean(i#Integer(SelectField(Dereference(__m, coin_ref), 
     assume !__abort_flag;
     __saved_m := __m;
     __frame := __local_counter;
-    __local_counter := __local_counter + 18;
 
     // process and type check arguments
     assume is#Vector(Dereference(__m, coin_ref));
-    assume IsValidReferenceParameter(__m, __frame, coin_ref);
+    assume IsValidReferenceParameter(__m, __local_counter, coin_ref);
     assume is#Vector(Dereference(__m, coin_ref));
     assume $DebugTrackLocal(0, 7, 0, 5391, Dereference(__m, coin_ref));
     assume IsValidU64(amount);
     __m := UpdateLocal(__m, __frame + 1, amount);
     assume $DebugTrackLocal(0, 7, 1, 5391, amount);
+
+    // increase the local counter
+    __local_counter := __local_counter + 18;
 
     // bytecode translation starts here
     call __t3 := CopyOrMoveRef(coin_ref);
@@ -733,7 +749,6 @@ ensures old(b#Boolean(Boolean(i#Integer(Integer(i#Integer(SelectField(coin1, Lib
     assume !__abort_flag;
     __saved_m := __m;
     __frame := __local_counter;
-    __local_counter := __local_counter + 5;
 
     // process and type check arguments
     assume is#Vector(coin1);
@@ -742,6 +757,9 @@ ensures old(b#Boolean(Boolean(i#Integer(Integer(i#Integer(SelectField(coin1, Lib
     assume is#Vector(coin2);
     __m := UpdateLocal(__m, __frame + 1, coin2);
     assume $DebugTrackLocal(0, 8, 1, 6020, coin2);
+
+    // increase the local counter
+    __local_counter := __local_counter + 5;
 
     // bytecode translation starts here
     call __t2 := BorrowLoc(__frame + 0);
@@ -803,16 +821,18 @@ ensures old(b#Boolean(Boolean(i#Integer(Integer(i#Integer(SelectField(Dereferenc
     assume !__abort_flag;
     __saved_m := __m;
     __frame := __local_counter;
-    __local_counter := __local_counter + 14;
 
     // process and type check arguments
     assume is#Vector(Dereference(__m, coin_ref));
-    assume IsValidReferenceParameter(__m, __frame, coin_ref);
+    assume IsValidReferenceParameter(__m, __local_counter, coin_ref);
     assume is#Vector(Dereference(__m, coin_ref));
     assume $DebugTrackLocal(0, 9, 0, 6465, Dereference(__m, coin_ref));
     assume is#Vector(check);
     __m := UpdateLocal(__m, __frame + 1, check);
     assume $DebugTrackLocal(0, 9, 1, 6465, check);
+
+    // increase the local counter
+    __local_counter := __local_counter + 14;
 
     // bytecode translation starts here
     call __t4 := CopyOrMoveRef(coin_ref);
@@ -892,12 +912,14 @@ ensures old(b#Boolean(Boolean(!IsEqual(SelectField(coin, LibraCoin_T_value), Int
     assume !__abort_flag;
     __saved_m := __m;
     __frame := __local_counter;
-    __local_counter := __local_counter + 9;
 
     // process and type check arguments
     assume is#Vector(coin);
     __m := UpdateLocal(__m, __frame + 0, coin);
     assume $DebugTrackLocal(0, 10, 0, 7117, coin);
+
+    // increase the local counter
+    __local_counter := __local_counter + 9;
 
     // bytecode translation starts here
     call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 0));

--- a/language/move-prover/bytecode-to-boogie/tests/goldenfiles/test-aborts-if.bpl
+++ b/language/move-prover/bytecode-to-boogie/tests/goldenfiles/test-aborts-if.bpl
@@ -26,7 +26,6 @@ ensures old(b#Boolean(Boolean(i#Integer(x) <= i#Integer(y)))) ==> __abort_flag;
     assume !__abort_flag;
     __saved_m := __m;
     __frame := __local_counter;
-    __local_counter := __local_counter + 7;
 
     // process and type check arguments
     assume IsValidU64(x);
@@ -35,6 +34,9 @@ ensures old(b#Boolean(Boolean(i#Integer(x) <= i#Integer(y)))) ==> __abort_flag;
     assume IsValidU64(y);
     __m := UpdateLocal(__m, __frame + 1, y);
     assume $DebugTrackLocal(0, 0, 1, 66, y);
+
+    // increase the local counter
+    __local_counter := __local_counter + 7;
 
     // bytecode translation starts here
     call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 0));
@@ -86,7 +88,6 @@ ensures old(b#Boolean(Boolean(i#Integer(x) <= i#Integer(y)))) ==> __abort_flag;
     assume !__abort_flag;
     __saved_m := __m;
     __frame := __local_counter;
-    __local_counter := __local_counter + 2;
 
     // process and type check arguments
     assume IsValidU64(x);
@@ -95,6 +96,9 @@ ensures old(b#Boolean(Boolean(i#Integer(x) <= i#Integer(y)))) ==> __abort_flag;
     assume IsValidU64(y);
     __m := UpdateLocal(__m, __frame + 1, y);
     assume $DebugTrackLocal(0, 1, 1, 283, y);
+
+    // increase the local counter
+    __local_counter := __local_counter + 2;
 
     // bytecode translation starts here
     return;
@@ -128,7 +132,6 @@ ensures old(b#Boolean(Boolean(i#Integer(x) <= i#Integer(y)))) ==> __abort_flag;
     assume !__abort_flag;
     __saved_m := __m;
     __frame := __local_counter;
-    __local_counter := __local_counter + 5;
 
     // process and type check arguments
     assume IsValidU64(x);
@@ -137,6 +140,9 @@ ensures old(b#Boolean(Boolean(i#Integer(x) <= i#Integer(y)))) ==> __abort_flag;
     assume IsValidU64(y);
     __m := UpdateLocal(__m, __frame + 1, y);
     assume $DebugTrackLocal(0, 2, 1, 476, y);
+
+    // increase the local counter
+    __local_counter := __local_counter + 5;
 
     // bytecode translation starts here
     call __tmp := LdFalse();
@@ -187,7 +193,6 @@ ensures old(b#Boolean(Boolean(i#Integer(x) < i#Integer(y)))) ==> __abort_flag;
     assume !__abort_flag;
     __saved_m := __m;
     __frame := __local_counter;
-    __local_counter := __local_counter + 7;
 
     // process and type check arguments
     assume IsValidU64(x);
@@ -196,6 +201,9 @@ ensures old(b#Boolean(Boolean(i#Integer(x) < i#Integer(y)))) ==> __abort_flag;
     assume IsValidU64(y);
     __m := UpdateLocal(__m, __frame + 1, y);
     assume $DebugTrackLocal(0, 3, 1, 717, y);
+
+    // increase the local counter
+    __local_counter := __local_counter + 7;
 
     // bytecode translation starts here
     call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 0));
@@ -252,7 +260,6 @@ ensures old(b#Boolean(Boolean(i#Integer(x) <= i#Integer(y)))) ==> __abort_flag;
     assume !__abort_flag;
     __saved_m := __m;
     __frame := __local_counter;
-    __local_counter := __local_counter + 7;
 
     // process and type check arguments
     assume IsValidU64(x);
@@ -261,6 +268,9 @@ ensures old(b#Boolean(Boolean(i#Integer(x) <= i#Integer(y)))) ==> __abort_flag;
     assume IsValidU64(y);
     __m := UpdateLocal(__m, __frame + 1, y);
     assume $DebugTrackLocal(0, 4, 1, 954, y);
+
+    // increase the local counter
+    __local_counter := __local_counter + 7;
 
     // bytecode translation starts here
     call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 0));
@@ -317,7 +327,6 @@ ensures old(b#Boolean(Boolean(i#Integer(x) < i#Integer(y)))) ==> __abort_flag;
     assume !__abort_flag;
     __saved_m := __m;
     __frame := __local_counter;
-    __local_counter := __local_counter + 7;
 
     // process and type check arguments
     assume IsValidU64(x);
@@ -326,6 +335,9 @@ ensures old(b#Boolean(Boolean(i#Integer(x) < i#Integer(y)))) ==> __abort_flag;
     assume IsValidU64(y);
     __m := UpdateLocal(__m, __frame + 1, y);
     assume $DebugTrackLocal(0, 5, 1, 1199, y);
+
+    // increase the local counter
+    __local_counter := __local_counter + 7;
 
     // bytecode translation starts here
     call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 0));
@@ -382,7 +394,6 @@ ensures old(b#Boolean(Boolean(i#Integer(x) < i#Integer(y)))) ==> __abort_flag;
     assume !__abort_flag;
     __saved_m := __m;
     __frame := __local_counter;
-    __local_counter := __local_counter + 7;
 
     // process and type check arguments
     assume IsValidU64(x);
@@ -391,6 +402,9 @@ ensures old(b#Boolean(Boolean(i#Integer(x) < i#Integer(y)))) ==> __abort_flag;
     assume IsValidU64(y);
     __m := UpdateLocal(__m, __frame + 1, y);
     assume $DebugTrackLocal(0, 6, 1, 1423, y);
+
+    // increase the local counter
+    __local_counter := __local_counter + 7;
 
     // bytecode translation starts here
     call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 0));
@@ -452,7 +466,6 @@ ensures old(b#Boolean(Boolean(i#Integer(x) < i#Integer(y)))) ==> __abort_flag;
     assume !__abort_flag;
     __saved_m := __m;
     __frame := __local_counter;
-    __local_counter := __local_counter + 11;
 
     // process and type check arguments
     assume IsValidU64(x);
@@ -461,6 +474,9 @@ ensures old(b#Boolean(Boolean(i#Integer(x) < i#Integer(y)))) ==> __abort_flag;
     assume IsValidU64(y);
     __m := UpdateLocal(__m, __frame + 1, y);
     assume $DebugTrackLocal(0, 7, 1, 1706, y);
+
+    // increase the local counter
+    __local_counter := __local_counter + 11;
 
     // bytecode translation starts here
     call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 0));
@@ -537,7 +553,6 @@ ensures old(b#Boolean(Boolean(i#Integer(x) > i#Integer(y))) || b#Boolean(Boolean
     assume !__abort_flag;
     __saved_m := __m;
     __frame := __local_counter;
-    __local_counter := __local_counter + 7;
 
     // process and type check arguments
     assume IsValidU64(x);
@@ -546,6 +561,9 @@ ensures old(b#Boolean(Boolean(i#Integer(x) > i#Integer(y))) || b#Boolean(Boolean
     assume IsValidU64(y);
     __m := UpdateLocal(__m, __frame + 1, y);
     assume $DebugTrackLocal(0, 8, 1, 2218, y);
+
+    // increase the local counter
+    __local_counter := __local_counter + 7;
 
     // bytecode translation starts here
     call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 0));

--- a/language/move-prover/bytecode-to-boogie/tests/goldenfiles/test-access-path.bpl
+++ b/language/move-prover/bytecode-to-boogie/tests/goldenfiles/test-access-path.bpl
@@ -126,12 +126,14 @@ requires ExistsTxnSenderAccount(__m, __txn);
     assume !__abort_flag;
     __saved_m := __m;
     __frame := __local_counter;
-    __local_counter := __local_counter + 5;
 
     // process and type check arguments
     assume IsValidU64(amount);
     __m := UpdateLocal(__m, __frame + 0, amount);
     assume $DebugTrackLocal(4, 0, 0, 807, amount);
+
+    // increase the local counter
+    __local_counter := __local_counter + 5;
 
     // bytecode translation starts here
     call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 0));
@@ -202,16 +204,18 @@ requires ExistsTxnSenderAccount(__m, __txn);
     assume !__abort_flag;
     __saved_m := __m;
     __frame := __local_counter;
-    __local_counter := __local_counter + 21;
 
     // process and type check arguments
     assume IsValidU64(value);
     __m := UpdateLocal(__m, __frame + 0, value);
     assume $DebugTrackLocal(4, 1, 0, 1231, value);
     assume is#Vector(Dereference(__m, capability));
-    assume IsValidReferenceParameter(__m, __frame, capability);
+    assume IsValidReferenceParameter(__m, __local_counter, capability);
     assume is#Vector(Dereference(__m, capability));
     assume $DebugTrackLocal(4, 1, 1, 1231, Dereference(__m, capability));
+
+    // increase the local counter
+    __local_counter := __local_counter + 21;
 
     // bytecode translation starts here
     call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 0));
@@ -330,9 +334,11 @@ requires ExistsTxnSenderAccount(__m, __txn);
     assume !__abort_flag;
     __saved_m := __m;
     __frame := __local_counter;
-    __local_counter := __local_counter + 9;
 
     // process and type check arguments
+
+    // increase the local counter
+    __local_counter := __local_counter + 9;
 
     // bytecode translation starts here
     call __tmp := GetTxnSenderAddress();
@@ -409,9 +415,11 @@ requires ExistsTxnSenderAccount(__m, __txn);
     assume !__abort_flag;
     __saved_m := __m;
     __frame := __local_counter;
-    __local_counter := __local_counter + 4;
 
     // process and type check arguments
+
+    // increase the local counter
+    __local_counter := __local_counter + 4;
 
     // bytecode translation starts here
     call __tmp := LdAddr(173345816);
@@ -459,9 +467,11 @@ requires ExistsTxnSenderAccount(__m, __txn);
     assume !__abort_flag;
     __saved_m := __m;
     __frame := __local_counter;
-    __local_counter := __local_counter + 2;
 
     // process and type check arguments
+
+    // increase the local counter
+    __local_counter := __local_counter + 2;
 
     // bytecode translation starts here
     call __tmp := LdConst(0);
@@ -501,13 +511,15 @@ requires ExistsTxnSenderAccount(__m, __txn);
     assume !__abort_flag;
     __saved_m := __m;
     __frame := __local_counter;
-    __local_counter := __local_counter + 4;
 
     // process and type check arguments
     assume is#Vector(Dereference(__m, coin_ref));
-    assume IsValidReferenceParameter(__m, __frame, coin_ref);
+    assume IsValidReferenceParameter(__m, __local_counter, coin_ref);
     assume is#Vector(Dereference(__m, coin_ref));
     assume $DebugTrackLocal(4, 5, 0, 2888, Dereference(__m, coin_ref));
+
+    // increase the local counter
+    __local_counter := __local_counter + 4;
 
     // bytecode translation starts here
     call __t1 := CopyOrMoveRef(coin_ref);
@@ -552,7 +564,6 @@ requires ExistsTxnSenderAccount(__m, __txn);
     assume !__abort_flag;
     __saved_m := __m;
     __frame := __local_counter;
-    __local_counter := __local_counter + 8;
 
     // process and type check arguments
     assume is#Vector(coin);
@@ -561,6 +572,9 @@ requires ExistsTxnSenderAccount(__m, __txn);
     assume IsValidU64(amount);
     __m := UpdateLocal(__m, __frame + 1, amount);
     assume $DebugTrackLocal(4, 6, 1, 3109, amount);
+
+    // increase the local counter
+    __local_counter := __local_counter + 8;
 
     // bytecode translation starts here
     call __t3 := BorrowLoc(__frame + 0);
@@ -635,16 +649,18 @@ requires ExistsTxnSenderAccount(__m, __txn);
     assume !__abort_flag;
     __saved_m := __m;
     __frame := __local_counter;
-    __local_counter := __local_counter + 18;
 
     // process and type check arguments
     assume is#Vector(Dereference(__m, coin_ref));
-    assume IsValidReferenceParameter(__m, __frame, coin_ref);
+    assume IsValidReferenceParameter(__m, __local_counter, coin_ref);
     assume is#Vector(Dereference(__m, coin_ref));
     assume $DebugTrackLocal(4, 7, 0, 3557, Dereference(__m, coin_ref));
     assume IsValidU64(amount);
     __m := UpdateLocal(__m, __frame + 1, amount);
     assume $DebugTrackLocal(4, 7, 1, 3557, amount);
+
+    // increase the local counter
+    __local_counter := __local_counter + 18;
 
     // bytecode translation starts here
     call __t3 := CopyOrMoveRef(coin_ref);
@@ -736,7 +752,6 @@ requires ExistsTxnSenderAccount(__m, __txn);
     assume !__abort_flag;
     __saved_m := __m;
     __frame := __local_counter;
-    __local_counter := __local_counter + 5;
 
     // process and type check arguments
     assume is#Vector(coin1);
@@ -745,6 +760,9 @@ requires ExistsTxnSenderAccount(__m, __txn);
     assume is#Vector(coin2);
     __m := UpdateLocal(__m, __frame + 1, coin2);
     assume $DebugTrackLocal(4, 8, 1, 4041, coin2);
+
+    // increase the local counter
+    __local_counter := __local_counter + 5;
 
     // bytecode translation starts here
     call __t2 := BorrowLoc(__frame + 0);
@@ -802,16 +820,18 @@ requires ExistsTxnSenderAccount(__m, __txn);
     assume !__abort_flag;
     __saved_m := __m;
     __frame := __local_counter;
-    __local_counter := __local_counter + 14;
 
     // process and type check arguments
     assume is#Vector(Dereference(__m, coin_ref));
-    assume IsValidReferenceParameter(__m, __frame, coin_ref);
+    assume IsValidReferenceParameter(__m, __local_counter, coin_ref);
     assume is#Vector(Dereference(__m, coin_ref));
     assume $DebugTrackLocal(4, 9, 0, 4352, Dereference(__m, coin_ref));
     assume is#Vector(check);
     __m := UpdateLocal(__m, __frame + 1, check);
     assume $DebugTrackLocal(4, 9, 1, 4352, check);
+
+    // increase the local counter
+    __local_counter := __local_counter + 14;
 
     // bytecode translation starts here
     call __t4 := CopyOrMoveRef(coin_ref);
@@ -888,12 +908,14 @@ requires ExistsTxnSenderAccount(__m, __txn);
     assume !__abort_flag;
     __saved_m := __m;
     __frame := __local_counter;
-    __local_counter := __local_counter + 9;
 
     // process and type check arguments
     assume is#Vector(coin);
     __m := UpdateLocal(__m, __frame + 0, coin);
     assume $DebugTrackLocal(4, 10, 0, 4858, coin);
+
+    // increase the local counter
+    __local_counter := __local_counter + 9;
 
     // bytecode translation starts here
     call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 0));
@@ -988,9 +1010,11 @@ requires ExistsTxnSenderAccount(__m, __txn);
     assume !__abort_flag;
     __saved_m := __m;
     __frame := __local_counter;
-    __local_counter := __local_counter + 9;
 
     // process and type check arguments
+
+    // increase the local counter
+    __local_counter := __local_counter + 9;
 
     // bytecode translation starts here
     call __tmp := GetTxnSenderAddress();
@@ -1081,7 +1105,6 @@ requires ExistsTxnSenderAccount(__m, __txn);
     assume !__abort_flag;
     __saved_m := __m;
     __frame := __local_counter;
-    __local_counter := __local_counter + 25;
 
     // process and type check arguments
     assume is#Address(proposer);
@@ -1090,6 +1113,9 @@ requires ExistsTxnSenderAccount(__m, __txn);
     assume IsValidU64(timestamp);
     __m := UpdateLocal(__m, __frame + 1, timestamp);
     assume $DebugTrackLocal(5, 1, 1, 743, timestamp);
+
+    // increase the local counter
+    __local_counter := __local_counter + 25;
 
     // bytecode translation starts here
     call __tmp := LdAddr(173345816);
@@ -1210,9 +1236,11 @@ requires ExistsTxnSenderAccount(__m, __txn);
     assume !__abort_flag;
     __saved_m := __m;
     __frame := __local_counter;
-    __local_counter := __local_counter + 4;
 
     // process and type check arguments
+
+    // increase the local counter
+    __local_counter := __local_counter + 4;
 
     // bytecode translation starts here
     call __tmp := LdAddr(173345816);
@@ -1294,9 +1322,11 @@ requires ExistsTxnSenderAccount(__m, __txn);
     assume !__abort_flag;
     __saved_m := __m;
     __frame := __local_counter;
-    __local_counter := __local_counter + 9;
 
     // process and type check arguments
+
+    // increase the local counter
+    __local_counter := __local_counter + 9;
 
     // bytecode translation starts here
     call __tmp := GetTxnSenderAddress();
@@ -1375,12 +1405,14 @@ requires ExistsTxnSenderAccount(__m, __txn);
     assume !__abort_flag;
     __saved_m := __m;
     __frame := __local_counter;
-    __local_counter := __local_counter + 12;
 
     // process and type check arguments
     assume IsValidU64(new_duration);
     __m := UpdateLocal(__m, __frame + 0, new_duration);
     assume $DebugTrackLocal(6, 1, 0, 564, new_duration);
+
+    // increase the local counter
+    __local_counter := __local_counter + 12;
 
     // bytecode translation starts here
     call __tmp := GetTxnSenderAddress();
@@ -1473,12 +1505,14 @@ requires ExistsTxnSenderAccount(__m, __txn);
     assume !__abort_flag;
     __saved_m := __m;
     __frame := __local_counter;
-    __local_counter := __local_counter + 23;
 
     // process and type check arguments
     assume IsValidU64(timestamp);
     __m := UpdateLocal(__m, __frame + 0, timestamp);
     assume $DebugTrackLocal(6, 2, 0, 911, timestamp);
+
+    // increase the local counter
+    __local_counter := __local_counter + 23;
 
     // bytecode translation starts here
     call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 0));
@@ -1806,7 +1840,6 @@ requires ExistsTxnSenderAccount(__m, __txn);
     assume !__abort_flag;
     __saved_m := __m;
     __frame := __local_counter;
-    __local_counter := __local_counter + 5;
 
     // process and type check arguments
     assume is#Address(payee);
@@ -1815,6 +1848,9 @@ requires ExistsTxnSenderAccount(__m, __txn);
     assume is#Vector(to_deposit);
     __m := UpdateLocal(__m, __frame + 1, to_deposit);
     assume $DebugTrackLocal(7, 0, 1, 3305, to_deposit);
+
+    // increase the local counter
+    __local_counter := __local_counter + 5;
 
     // bytecode translation starts here
     call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 0));
@@ -1860,7 +1896,6 @@ requires ExistsTxnSenderAccount(__m, __txn);
     assume !__abort_flag;
     __saved_m := __m;
     __frame := __local_counter;
-    __local_counter := __local_counter + 7;
 
     // process and type check arguments
     assume is#Address(payee);
@@ -1872,6 +1907,9 @@ requires ExistsTxnSenderAccount(__m, __txn);
     assume is#ByteArray(metadata);
     __m := UpdateLocal(__m, __frame + 2, metadata);
     assume $DebugTrackLocal(7, 1, 2, 3567, metadata);
+
+    // increase the local counter
+    __local_counter := __local_counter + 7;
 
     // bytecode translation starts here
     call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 0));
@@ -1946,7 +1984,6 @@ requires ExistsTxnSenderAccount(__m, __txn);
     assume !__abort_flag;
     __saved_m := __m;
     __frame := __local_counter;
-    __local_counter := __local_counter + 33;
 
     // process and type check arguments
     assume is#Address(payee);
@@ -1961,6 +1998,9 @@ requires ExistsTxnSenderAccount(__m, __txn);
     assume is#ByteArray(metadata);
     __m := UpdateLocal(__m, __frame + 3, metadata);
     assume $DebugTrackLocal(7, 2, 3, 4018, metadata);
+
+    // increase the local counter
+    __local_counter := __local_counter + 33;
 
     // bytecode translation starts here
     call __t7 := BorrowLoc(__frame + 2);
@@ -2114,7 +2154,6 @@ requires ExistsTxnSenderAccount(__m, __txn);
     assume !__abort_flag;
     __saved_m := __m;
     __frame := __local_counter;
-    __local_counter := __local_counter + 9;
 
     // process and type check arguments
     assume is#Address(payee);
@@ -2123,6 +2162,9 @@ requires ExistsTxnSenderAccount(__m, __txn);
     assume IsValidU64(amount);
     __m := UpdateLocal(__m, __frame + 1, amount);
     assume $DebugTrackLocal(7, 3, 1, 5776, amount);
+
+    // increase the local counter
+    __local_counter := __local_counter + 9;
 
     // bytecode translation starts here
     call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 0));
@@ -2199,16 +2241,18 @@ requires ExistsTxnSenderAccount(__m, __txn);
     assume !__abort_flag;
     __saved_m := __m;
     __frame := __local_counter;
-    __local_counter := __local_counter + 8;
 
     // process and type check arguments
     assume is#Vector(Dereference(__m, account));
-    assume IsValidReferenceParameter(__m, __frame, account);
+    assume IsValidReferenceParameter(__m, __local_counter, account);
     assume is#Vector(Dereference(__m, account));
     assume $DebugTrackLocal(7, 4, 0, 6237, Dereference(__m, account));
     assume IsValidU64(amount);
     __m := UpdateLocal(__m, __frame + 1, amount);
     assume $DebugTrackLocal(7, 4, 1, 6237, amount);
+
+    // increase the local counter
+    __local_counter := __local_counter + 8;
 
     // bytecode translation starts here
     call __t3 := CopyOrMoveRef(account);
@@ -2272,12 +2316,14 @@ requires ExistsTxnSenderAccount(__m, __txn);
     assume !__abort_flag;
     __saved_m := __m;
     __frame := __local_counter;
-    __local_counter := __local_counter + 11;
 
     // process and type check arguments
     assume IsValidU64(amount);
     __m := UpdateLocal(__m, __frame + 0, amount);
     assume $DebugTrackLocal(7, 5, 0, 6552, amount);
+
+    // increase the local counter
+    __local_counter := __local_counter + 11;
 
     // bytecode translation starts here
     call __tmp := GetTxnSenderAddress();
@@ -2360,16 +2406,18 @@ requires ExistsTxnSenderAccount(__m, __txn);
     assume !__abort_flag;
     __saved_m := __m;
     __frame := __local_counter;
-    __local_counter := __local_counter + 10;
 
     // process and type check arguments
     assume is#Vector(Dereference(__m, cap));
-    assume IsValidReferenceParameter(__m, __frame, cap);
+    assume IsValidReferenceParameter(__m, __local_counter, cap);
     assume is#Vector(Dereference(__m, cap));
     assume $DebugTrackLocal(7, 6, 0, 7192, Dereference(__m, cap));
     assume IsValidU64(amount);
     __m := UpdateLocal(__m, __frame + 1, amount);
     assume $DebugTrackLocal(7, 6, 1, 7192, amount);
+
+    // increase the local counter
+    __local_counter := __local_counter + 10;
 
     // bytecode translation starts here
     call __t3 := CopyOrMoveRef(cap);
@@ -2447,9 +2495,11 @@ requires ExistsTxnSenderAccount(__m, __txn);
     assume !__abort_flag;
     __saved_m := __m;
     __frame := __local_counter;
-    __local_counter := __local_counter + 15;
 
     // process and type check arguments
+
+    // increase the local counter
+    __local_counter := __local_counter + 15;
 
     // bytecode translation starts here
     call __tmp := GetTxnSenderAddress();
@@ -2545,12 +2595,14 @@ requires ExistsTxnSenderAccount(__m, __txn);
     assume !__abort_flag;
     __saved_m := __m;
     __frame := __local_counter;
-    __local_counter := __local_counter + 10;
 
     // process and type check arguments
     assume is#Vector(cap);
     __m := UpdateLocal(__m, __frame + 0, cap);
     assume $DebugTrackLocal(7, 8, 0, 8391, cap);
+
+    // increase the local counter
+    __local_counter := __local_counter + 10;
 
     // bytecode translation starts here
     call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 0));
@@ -2622,14 +2674,13 @@ requires ExistsTxnSenderAccount(__m, __txn);
     assume !__abort_flag;
     __saved_m := __m;
     __frame := __local_counter;
-    __local_counter := __local_counter + 16;
 
     // process and type check arguments
     assume is#Address(payee);
     __m := UpdateLocal(__m, __frame + 0, payee);
     assume $DebugTrackLocal(7, 9, 0, 9236, payee);
     assume is#Vector(Dereference(__m, cap));
-    assume IsValidReferenceParameter(__m, __frame, cap);
+    assume IsValidReferenceParameter(__m, __local_counter, cap);
     assume is#Vector(Dereference(__m, cap));
     assume $DebugTrackLocal(7, 9, 1, 9236, Dereference(__m, cap));
     assume IsValidU64(amount);
@@ -2638,6 +2689,9 @@ requires ExistsTxnSenderAccount(__m, __txn);
     assume is#ByteArray(metadata);
     __m := UpdateLocal(__m, __frame + 3, metadata);
     assume $DebugTrackLocal(7, 9, 3, 9236, metadata);
+
+    // increase the local counter
+    __local_counter := __local_counter + 16;
 
     // bytecode translation starts here
     call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 0));
@@ -2729,7 +2783,6 @@ requires ExistsTxnSenderAccount(__m, __txn);
     assume !__abort_flag;
     __saved_m := __m;
     __frame := __local_counter;
-    __local_counter := __local_counter + 11;
 
     // process and type check arguments
     assume is#Address(payee);
@@ -2741,6 +2794,9 @@ requires ExistsTxnSenderAccount(__m, __txn);
     assume is#ByteArray(metadata);
     __m := UpdateLocal(__m, __frame + 2, metadata);
     assume $DebugTrackLocal(7, 10, 2, 9947, metadata);
+
+    // increase the local counter
+    __local_counter := __local_counter + 11;
 
     // bytecode translation starts here
     call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 0));
@@ -2817,7 +2873,6 @@ requires ExistsTxnSenderAccount(__m, __txn);
     assume !__abort_flag;
     __saved_m := __m;
     __frame := __local_counter;
-    __local_counter := __local_counter + 5;
 
     // process and type check arguments
     assume is#Address(payee);
@@ -2826,6 +2881,9 @@ requires ExistsTxnSenderAccount(__m, __txn);
     assume IsValidU64(amount);
     __m := UpdateLocal(__m, __frame + 1, amount);
     assume $DebugTrackLocal(7, 11, 1, 10530, amount);
+
+    // increase the local counter
+    __local_counter := __local_counter + 5;
 
     // bytecode translation starts here
     call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 0));
@@ -2870,16 +2928,18 @@ requires ExistsTxnSenderAccount(__m, __txn);
     assume !__abort_flag;
     __saved_m := __m;
     __frame := __local_counter;
-    __local_counter := __local_counter + 5;
 
     // process and type check arguments
     assume is#Vector(Dereference(__m, account));
-    assume IsValidReferenceParameter(__m, __frame, account);
+    assume IsValidReferenceParameter(__m, __local_counter, account);
     assume is#Vector(Dereference(__m, account));
     assume $DebugTrackLocal(7, 12, 0, 10698, Dereference(__m, account));
     assume is#ByteArray(new_authentication_key);
     __m := UpdateLocal(__m, __frame + 1, new_authentication_key);
     assume $DebugTrackLocal(7, 12, 1, 10698, new_authentication_key);
+
+    // increase the local counter
+    __local_counter := __local_counter + 5;
 
     // bytecode translation starts here
     call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 1));
@@ -2925,12 +2985,14 @@ requires ExistsTxnSenderAccount(__m, __txn);
     assume !__abort_flag;
     __saved_m := __m;
     __frame := __local_counter;
-    __local_counter := __local_counter + 10;
 
     // process and type check arguments
     assume is#ByteArray(new_authentication_key);
     __m := UpdateLocal(__m, __frame + 0, new_authentication_key);
     assume $DebugTrackLocal(7, 13, 0, 11025, new_authentication_key);
+
+    // increase the local counter
+    __local_counter := __local_counter + 10;
 
     // bytecode translation starts here
     call __tmp := GetTxnSenderAddress();
@@ -3004,16 +3066,18 @@ requires ExistsTxnSenderAccount(__m, __txn);
     assume !__abort_flag;
     __saved_m := __m;
     __frame := __local_counter;
-    __local_counter := __local_counter + 7;
 
     // process and type check arguments
     assume is#Vector(Dereference(__m, cap));
-    assume IsValidReferenceParameter(__m, __frame, cap);
+    assume IsValidReferenceParameter(__m, __local_counter, cap);
     assume is#Vector(Dereference(__m, cap));
     assume $DebugTrackLocal(7, 14, 0, 11765, Dereference(__m, cap));
     assume is#ByteArray(new_authentication_key);
     __m := UpdateLocal(__m, __frame + 1, new_authentication_key);
     assume $DebugTrackLocal(7, 14, 1, 11765, new_authentication_key);
+
+    // increase the local counter
+    __local_counter := __local_counter + 7;
 
     // bytecode translation starts here
     call __t2 := CopyOrMoveRef(cap);
@@ -3077,9 +3141,11 @@ requires ExistsTxnSenderAccount(__m, __txn);
     assume !__abort_flag;
     __saved_m := __m;
     __frame := __local_counter;
-    __local_counter := __local_counter + 13;
 
     // process and type check arguments
+
+    // increase the local counter
+    __local_counter := __local_counter + 13;
 
     // bytecode translation starts here
     call __tmp := GetTxnSenderAddress();
@@ -3169,12 +3235,14 @@ requires ExistsTxnSenderAccount(__m, __txn);
     assume !__abort_flag;
     __saved_m := __m;
     __frame := __local_counter;
-    __local_counter := __local_counter + 10;
 
     // process and type check arguments
     assume is#Vector(cap);
     __m := UpdateLocal(__m, __frame + 0, cap);
     assume $DebugTrackLocal(7, 16, 0, 12924, cap);
+
+    // increase the local counter
+    __local_counter := __local_counter + 10;
 
     // bytecode translation starts here
     call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 0));
@@ -3252,12 +3320,14 @@ requires ExistsTxnSenderAccount(__m, __txn);
     assume !__abort_flag;
     __saved_m := __m;
     __frame := __local_counter;
-    __local_counter := __local_counter + 19;
 
     // process and type check arguments
     assume is#Address(fresh_address);
     __m := UpdateLocal(__m, __frame + 0, fresh_address);
     assume $DebugTrackLocal(7, 17, 0, 13761, fresh_address);
+
+    // increase the local counter
+    __local_counter := __local_counter + 19;
 
     // bytecode translation starts here
     call __tmp := LdConst(0);
@@ -3376,7 +3446,6 @@ requires ExistsTxnSenderAccount(__m, __txn);
     assume !__abort_flag;
     __saved_m := __m;
     __frame := __local_counter;
-    __local_counter := __local_counter + 8;
 
     // process and type check arguments
     assume is#Address(fresh_address);
@@ -3385,6 +3454,9 @@ requires ExistsTxnSenderAccount(__m, __txn);
     assume IsValidU64(initial_balance);
     __m := UpdateLocal(__m, __frame + 1, initial_balance);
     assume $DebugTrackLocal(7, 18, 1, 14744, initial_balance);
+
+    // increase the local counter
+    __local_counter := __local_counter + 8;
 
     // bytecode translation starts here
     call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 0));
@@ -3454,13 +3526,15 @@ requires ExistsTxnSenderAccount(__m, __txn);
     assume !__abort_flag;
     __saved_m := __m;
     __frame := __local_counter;
-    __local_counter := __local_counter + 6;
 
     // process and type check arguments
     assume is#Vector(Dereference(__m, account));
-    assume IsValidReferenceParameter(__m, __frame, account);
+    assume IsValidReferenceParameter(__m, __local_counter, account);
     assume is#Vector(Dereference(__m, account));
     assume $DebugTrackLocal(7, 20, 0, 15265, Dereference(__m, account));
+
+    // increase the local counter
+    __local_counter := __local_counter + 6;
 
     // bytecode translation starts here
     call __t2 := CopyOrMoveRef(account);
@@ -3514,12 +3588,14 @@ requires ExistsTxnSenderAccount(__m, __txn);
     assume !__abort_flag;
     __saved_m := __m;
     __frame := __local_counter;
-    __local_counter := __local_counter + 4;
 
     // process and type check arguments
     assume is#Address(addr);
     __m := UpdateLocal(__m, __frame + 0, addr);
     assume $DebugTrackLocal(7, 21, 0, 15535, addr);
+
+    // increase the local counter
+    __local_counter := __local_counter + 4;
 
     // bytecode translation starts here
     call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 0));
@@ -3571,13 +3647,15 @@ requires ExistsTxnSenderAccount(__m, __txn);
     assume !__abort_flag;
     __saved_m := __m;
     __frame := __local_counter;
-    __local_counter := __local_counter + 4;
 
     // process and type check arguments
     assume is#Vector(Dereference(__m, account));
-    assume IsValidReferenceParameter(__m, __frame, account);
+    assume IsValidReferenceParameter(__m, __local_counter, account);
     assume is#Vector(Dereference(__m, account));
     assume $DebugTrackLocal(7, 22, 0, 15735, Dereference(__m, account));
+
+    // increase the local counter
+    __local_counter := __local_counter + 4;
 
     // bytecode translation starts here
     call __t1 := CopyOrMoveRef(account);
@@ -3619,12 +3697,14 @@ requires ExistsTxnSenderAccount(__m, __txn);
     assume !__abort_flag;
     __saved_m := __m;
     __frame := __local_counter;
-    __local_counter := __local_counter + 4;
 
     // process and type check arguments
     assume is#Address(addr);
     __m := UpdateLocal(__m, __frame + 0, addr);
     assume $DebugTrackLocal(7, 23, 0, 15901, addr);
+
+    // increase the local counter
+    __local_counter := __local_counter + 4;
 
     // bytecode translation starts here
     call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 0));
@@ -3677,12 +3757,14 @@ requires ExistsTxnSenderAccount(__m, __txn);
     assume !__abort_flag;
     __saved_m := __m;
     __frame := __local_counter;
-    __local_counter := __local_counter + 5;
 
     // process and type check arguments
     assume is#Address(addr);
     __m := UpdateLocal(__m, __frame + 0, addr);
     assume $DebugTrackLocal(7, 24, 0, 16132, addr);
+
+    // increase the local counter
+    __local_counter := __local_counter + 5;
 
     // bytecode translation starts here
     call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 0));
@@ -3732,12 +3814,14 @@ requires ExistsTxnSenderAccount(__m, __txn);
     assume !__abort_flag;
     __saved_m := __m;
     __frame := __local_counter;
-    __local_counter := __local_counter + 5;
 
     // process and type check arguments
     assume is#Address(addr);
     __m := UpdateLocal(__m, __frame + 0, addr);
     assume $DebugTrackLocal(7, 25, 0, 16385, addr);
+
+    // increase the local counter
+    __local_counter := __local_counter + 5;
 
     // bytecode translation starts here
     call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 0));
@@ -3785,13 +3869,15 @@ requires ExistsTxnSenderAccount(__m, __txn);
     assume !__abort_flag;
     __saved_m := __m;
     __frame := __local_counter;
-    __local_counter := __local_counter + 3;
 
     // process and type check arguments
     assume is#Vector(Dereference(__m, cap));
-    assume IsValidReferenceParameter(__m, __frame, cap);
+    assume IsValidReferenceParameter(__m, __local_counter, cap);
     assume is#Vector(Dereference(__m, cap));
     assume $DebugTrackLocal(7, 26, 0, 16640, Dereference(__m, cap));
+
+    // increase the local counter
+    __local_counter := __local_counter + 3;
 
     // bytecode translation starts here
     call __t1 := CopyOrMoveRef(cap);
@@ -3829,13 +3915,15 @@ requires ExistsTxnSenderAccount(__m, __txn);
     assume !__abort_flag;
     __saved_m := __m;
     __frame := __local_counter;
-    __local_counter := __local_counter + 3;
 
     // process and type check arguments
     assume is#Vector(Dereference(__m, cap));
-    assume IsValidReferenceParameter(__m, __frame, cap);
+    assume IsValidReferenceParameter(__m, __local_counter, cap);
     assume is#Vector(Dereference(__m, cap));
     assume $DebugTrackLocal(7, 27, 0, 16867, Dereference(__m, cap));
+
+    // increase the local counter
+    __local_counter := __local_counter + 3;
 
     // bytecode translation starts here
     call __t1 := CopyOrMoveRef(cap);
@@ -3873,12 +3961,14 @@ requires ExistsTxnSenderAccount(__m, __txn);
     assume !__abort_flag;
     __saved_m := __m;
     __frame := __local_counter;
-    __local_counter := __local_counter + 3;
 
     // process and type check arguments
     assume is#Address(check_addr);
     __m := UpdateLocal(__m, __frame + 0, check_addr);
     assume $DebugTrackLocal(7, 28, 0, 17057, check_addr);
+
+    // increase the local counter
+    __local_counter := __local_counter + 3;
 
     // bytecode translation starts here
     call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 0));
@@ -3965,7 +4055,6 @@ requires ExistsTxnSenderAccount(__m, __txn);
     assume !__abort_flag;
     __saved_m := __m;
     __frame := __local_counter;
-    __local_counter := __local_counter + 55;
 
     // process and type check arguments
     assume IsValidU64(txn_sequence_number);
@@ -3983,6 +4072,9 @@ requires ExistsTxnSenderAccount(__m, __txn);
     assume IsValidU64(txn_expiration_time);
     __m := UpdateLocal(__m, __frame + 4, txn_expiration_time);
     assume $DebugTrackLocal(7, 29, 4, 17457, txn_expiration_time);
+
+    // increase the local counter
+    __local_counter := __local_counter + 55;
 
     // bytecode translation starts here
     call __tmp := GetTxnSenderAddress();
@@ -4255,7 +4347,6 @@ requires ExistsTxnSenderAccount(__m, __txn);
     assume !__abort_flag;
     __saved_m := __m;
     __frame := __local_counter;
-    __local_counter := __local_counter + 37;
 
     // process and type check arguments
     assume IsValidU64(txn_sequence_number);
@@ -4270,6 +4361,9 @@ requires ExistsTxnSenderAccount(__m, __txn);
     assume IsValidU64(gas_units_remaining);
     __m := UpdateLocal(__m, __frame + 3, gas_units_remaining);
     assume $DebugTrackLocal(7, 30, 3, 19386, gas_units_remaining);
+
+    // increase the local counter
+    __local_counter := __local_counter + 37;
 
     // bytecode translation starts here
     call __tmp := GetTxnSenderAddress();
@@ -4457,16 +4551,18 @@ requires ExistsTxnSenderAccount(__m, __txn);
     assume !__abort_flag;
     __saved_m := __m;
     __frame := __local_counter;
-    __local_counter := __local_counter + 22;
 
     // process and type check arguments
     assume is#Vector(Dereference(__m, counter));
-    assume IsValidReferenceParameter(__m, __frame, counter);
+    assume IsValidReferenceParameter(__m, __local_counter, counter);
     assume is#Vector(Dereference(__m, counter));
     assume $DebugTrackLocal(7, 31, 0, 21344, Dereference(__m, counter));
     assume is#Address(sender);
     __m := UpdateLocal(__m, __frame + 1, sender);
     assume $DebugTrackLocal(7, 31, 1, 21344, sender);
+
+    // increase the local counter
+    __local_counter := __local_counter + 22;
 
     // bytecode translation starts here
     call __t6 := CopyOrMoveRef(counter);
@@ -4587,16 +4683,18 @@ requires ExistsTxnSenderAccount(__m, __txn);
     assume !__abort_flag;
     __saved_m := __m;
     __frame := __local_counter;
-    __local_counter := __local_counter + 7;
 
     // process and type check arguments
     assume is#Vector(Dereference(__m, counter));
-    assume IsValidReferenceParameter(__m, __frame, counter);
+    assume IsValidReferenceParameter(__m, __local_counter, counter);
     assume is#Vector(Dereference(__m, counter));
     assume $DebugTrackLocal(7, 32, 0, 22101, Dereference(__m, counter));
     assume is#Address(sender);
     __m := UpdateLocal(__m, __frame + 1, sender);
     assume $DebugTrackLocal(7, 32, 1, 22101, sender);
+
+    // increase the local counter
+    __local_counter := __local_counter + 7;
 
     // bytecode translation starts here
     call __tmp := LdConst(0);
@@ -4655,9 +4753,11 @@ requires ExistsTxnSenderAccount(__m, __txn);
     assume !__abort_flag;
     __saved_m := __m;
     __frame := __local_counter;
-    __local_counter := __local_counter + 8;
 
     // process and type check arguments
+
+    // increase the local counter
+    __local_counter := __local_counter + 8;
 
     // bytecode translation starts here
     call __tmp := GetTxnSenderAddress();
@@ -4733,15 +4833,17 @@ requires ExistsTxnSenderAccount(__m, __txn);
     assume !__abort_flag;
     __saved_m := __m;
     __frame := __local_counter;
-    __local_counter := __local_counter + 18;
 
     // process and type check arguments
     assume is#Vector(Dereference(__m, handle_ref));
-    assume IsValidReferenceParameter(__m, __frame, handle_ref);
+    assume IsValidReferenceParameter(__m, __local_counter, handle_ref);
     assume is#Vector(Dereference(__m, handle_ref));
     assume $DebugTrackLocal(7, 34, 0, 22958, Dereference(__m, handle_ref));
     __m := UpdateLocal(__m, __frame + 1, msg);
     assume $DebugTrackLocal(7, 34, 1, 22958, msg);
+
+    // increase the local counter
+    __local_counter := __local_counter + 18;
 
     // bytecode translation starts here
     call __t4 := CopyOrMoveRef(handle_ref);
@@ -4835,12 +4937,14 @@ requires ExistsTxnSenderAccount(__m, __txn);
     assume !__abort_flag;
     __saved_m := __m;
     __frame := __local_counter;
-    __local_counter := __local_counter + 6;
 
     // process and type check arguments
     assume is#Vector(handle);
     __m := UpdateLocal(__m, __frame + 0, handle);
     assume $DebugTrackLocal(7, 36, 0, 23597, handle);
+
+    // increase the local counter
+    __local_counter := __local_counter + 6;
 
     // bytecode translation starts here
     call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 0));
@@ -4923,12 +5027,14 @@ ensures old(b#Boolean(Boolean(!(b#Boolean(ExistsResource(__m, LibraAccount_T_typ
     assume !__abort_flag;
     __saved_m := __m;
     __frame := __local_counter;
-    __local_counter := __local_counter + 6;
 
     // process and type check arguments
     assume is#Address(a);
     __m := UpdateLocal(__m, __frame + 0, a);
     assume $DebugTrackLocal(8, 0, 0, 943, a);
+
+    // increase the local counter
+    __local_counter := __local_counter + 6;
 
     // bytecode translation starts here
     call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 0));

--- a/language/move-prover/bytecode-to-boogie/tests/goldenfiles/test-arithmetic.bpl
+++ b/language/move-prover/bytecode-to-boogie/tests/goldenfiles/test-arithmetic.bpl
@@ -26,7 +26,6 @@ requires ExistsTxnSenderAccount(__m, __txn);
     assume !__abort_flag;
     __saved_m := __m;
     __frame := __local_counter;
-    __local_counter := __local_counter + 10;
 
     // process and type check arguments
     assume IsValidU64(x);
@@ -35,6 +34,9 @@ requires ExistsTxnSenderAccount(__m, __txn);
     assume IsValidU64(y);
     __m := UpdateLocal(__m, __frame + 1, y);
     assume $DebugTrackLocal(0, 0, 1, 25, y);
+
+    // increase the local counter
+    __local_counter := __local_counter + 10;
 
     // bytecode translation starts here
     call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 0));
@@ -105,7 +107,6 @@ requires ExistsTxnSenderAccount(__m, __txn);
     assume !__abort_flag;
     __saved_m := __m;
     __frame := __local_counter;
-    __local_counter := __local_counter + 10;
 
     // process and type check arguments
     assume IsValidU64(x);
@@ -117,6 +118,9 @@ requires ExistsTxnSenderAccount(__m, __txn);
     assume IsValidU64(z);
     __m := UpdateLocal(__m, __frame + 2, z);
     assume $DebugTrackLocal(0, 1, 2, 173, z);
+
+    // increase the local counter
+    __local_counter := __local_counter + 10;
 
     // bytecode translation starts here
     call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 0));
@@ -198,7 +202,6 @@ requires ExistsTxnSenderAccount(__m, __txn);
     assume !__abort_flag;
     __saved_m := __m;
     __frame := __local_counter;
-    __local_counter := __local_counter + 23;
 
     // process and type check arguments
     assume IsValidU64(a);
@@ -207,6 +210,9 @@ requires ExistsTxnSenderAccount(__m, __txn);
     assume IsValidU64(b);
     __m := UpdateLocal(__m, __frame + 1, b);
     assume $DebugTrackLocal(0, 2, 1, 304, b);
+
+    // increase the local counter
+    __local_counter := __local_counter + 23;
 
     // bytecode translation starts here
     call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 0));
@@ -324,7 +330,6 @@ requires ExistsTxnSenderAccount(__m, __txn);
     assume !__abort_flag;
     __saved_m := __m;
     __frame := __local_counter;
-    __local_counter := __local_counter + 21;
 
     // process and type check arguments
     assume IsValidU64(a);
@@ -333,6 +338,9 @@ requires ExistsTxnSenderAccount(__m, __txn);
     assume IsValidU64(b);
     __m := UpdateLocal(__m, __frame + 1, b);
     assume $DebugTrackLocal(0, 3, 1, 547, b);
+
+    // increase the local counter
+    __local_counter := __local_counter + 21;
 
     // bytecode translation starts here
     call __tmp := LdConst(6);
@@ -456,9 +464,11 @@ requires ExistsTxnSenderAccount(__m, __txn);
     assume !__abort_flag;
     __saved_m := __m;
     __frame := __local_counter;
-    __local_counter := __local_counter + 6;
 
     // process and type check arguments
+
+    // increase the local counter
+    __local_counter := __local_counter + 6;
 
     // bytecode translation starts here
     call __tmp := LdConst(9223372036854775807);
@@ -516,9 +526,11 @@ requires ExistsTxnSenderAccount(__m, __txn);
     assume !__abort_flag;
     __saved_m := __m;
     __frame := __local_counter;
-    __local_counter := __local_counter + 6;
 
     // process and type check arguments
+
+    // increase the local counter
+    __local_counter := __local_counter + 6;
 
     // bytecode translation starts here
     call __tmp := LdConst(0);
@@ -576,9 +588,11 @@ requires ExistsTxnSenderAccount(__m, __txn);
     assume !__abort_flag;
     __saved_m := __m;
     __frame := __local_counter;
-    __local_counter := __local_counter + 6;
 
     // process and type check arguments
+
+    // increase the local counter
+    __local_counter := __local_counter + 6;
 
     // bytecode translation starts here
     call __tmp := LdConst(0);

--- a/language/move-prover/bytecode-to-boogie/tests/goldenfiles/test-control-flow.bpl
+++ b/language/move-prover/bytecode-to-boogie/tests/goldenfiles/test-control-flow.bpl
@@ -23,12 +23,14 @@ requires ExistsTxnSenderAccount(__m, __txn);
     assume !__abort_flag;
     __saved_m := __m;
     __frame := __local_counter;
-    __local_counter := __local_counter + 6;
 
     // process and type check arguments
     assume is#Boolean(cond);
     __m := UpdateLocal(__m, __frame + 0, cond);
     assume $DebugTrackLocal(0, 0, 0, 117, cond);
+
+    // increase the local counter
+    __local_counter := __local_counter + 6;
 
     // bytecode translation starts here
     call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 0));

--- a/language/move-prover/bytecode-to-boogie/tests/goldenfiles/test-func-call.bpl
+++ b/language/move-prover/bytecode-to-boogie/tests/goldenfiles/test-func-call.bpl
@@ -21,12 +21,14 @@ requires ExistsTxnSenderAccount(__m, __txn);
     assume !__abort_flag;
     __saved_m := __m;
     __frame := __local_counter;
-    __local_counter := __local_counter + 4;
 
     // process and type check arguments
     assume IsValidU64(x);
     __m := UpdateLocal(__m, __frame + 0, x);
     assume $DebugTrackLocal(0, 0, 0, 25, x);
+
+    // increase the local counter
+    __local_counter := __local_counter + 4;
 
     // bytecode translation starts here
     call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 0));
@@ -73,12 +75,14 @@ requires ExistsTxnSenderAccount(__m, __txn);
     assume !__abort_flag;
     __saved_m := __m;
     __frame := __local_counter;
-    __local_counter := __local_counter + 4;
 
     // process and type check arguments
     assume IsValidU64(x);
     __m := UpdateLocal(__m, __frame + 0, x);
     assume $DebugTrackLocal(0, 1, 0, 75, x);
+
+    // increase the local counter
+    __local_counter := __local_counter + 4;
 
     // bytecode translation starts here
     call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 0));
@@ -148,12 +152,14 @@ ensures old(b#Boolean(Boolean(false))) ==> __abort_flag;
     assume !__abort_flag;
     __saved_m := __m;
     __frame := __local_counter;
-    __local_counter := __local_counter + 24;
 
     // process and type check arguments
     assume is#Boolean(b);
     __m := UpdateLocal(__m, __frame + 0, b);
     assume $DebugTrackLocal(0, 2, 0, 125, b);
+
+    // increase the local counter
+    __local_counter := __local_counter + 24;
 
     // bytecode translation starts here
     call __tmp := LdConst(3);

--- a/language/move-prover/bytecode-to-boogie/tests/goldenfiles/test-generics.bpl
+++ b/language/move-prover/bytecode-to-boogie/tests/goldenfiles/test-generics.bpl
@@ -66,7 +66,6 @@ requires ExistsTxnSenderAccount(__m, __txn);
     assume !__abort_flag;
     __saved_m := __m;
     __frame := __local_counter;
-    __local_counter := __local_counter + 12;
 
     // process and type check arguments
     assume IsValidU64(x1);
@@ -75,6 +74,9 @@ requires ExistsTxnSenderAccount(__m, __txn);
     assume IsValidU64(x2);
     __m := UpdateLocal(__m, __frame + 1, x2);
     assume $DebugTrackLocal(1, 0, 1, 162, x2);
+
+    // increase the local counter
+    __local_counter := __local_counter + 12;
 
     // bytecode translation starts here
     call __t4 := Vector_empty(IntegerType());
@@ -164,11 +166,13 @@ requires ExistsTxnSenderAccount(__m, __txn);
     assume !__abort_flag;
     __saved_m := __m;
     __frame := __local_counter;
-    __local_counter := __local_counter + 7;
 
     // process and type check arguments
     __m := UpdateLocal(__m, __frame + 0, x);
     assume $DebugTrackLocal(1, 1, 0, 471, x);
+
+    // increase the local counter
+    __local_counter := __local_counter + 7;
 
     // bytecode translation starts here
     call __t2 := Vector_empty(tv0);
@@ -241,13 +245,15 @@ requires ExistsTxnSenderAccount(__m, __txn);
     assume !__abort_flag;
     __saved_m := __m;
     __frame := __local_counter;
-    __local_counter := __local_counter + 13;
 
     // process and type check arguments
     __m := UpdateLocal(__m, __frame + 0, x);
     assume $DebugTrackLocal(1, 2, 0, 672, x);
     __m := UpdateLocal(__m, __frame + 1, y);
     assume $DebugTrackLocal(1, 2, 1, 672, y);
+
+    // increase the local counter
+    __local_counter := __local_counter + 13;
 
     // bytecode translation starts here
     call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 0));
@@ -331,9 +337,11 @@ requires ExistsTxnSenderAccount(__m, __txn);
     assume !__abort_flag;
     __saved_m := __m;
     __frame := __local_counter;
-    __local_counter := __local_counter + 5;
 
     // process and type check arguments
+
+    // increase the local counter
+    __local_counter := __local_counter + 5;
 
     // bytecode translation starts here
     call __tmp := LdConst(1);

--- a/language/move-prover/bytecode-to-boogie/tests/goldenfiles/test-lib.bpl
+++ b/language/move-prover/bytecode-to-boogie/tests/goldenfiles/test-lib.bpl
@@ -133,12 +133,14 @@ requires ExistsTxnSenderAccount(__m, __txn);
     assume !__abort_flag;
     __saved_m := __m;
     __frame := __local_counter;
-    __local_counter := __local_counter + 7;
 
     // process and type check arguments
     assume is#Vector(gas_schedule);
     __m := UpdateLocal(__m, __frame + 0, gas_schedule);
     assume $DebugTrackLocal(6, 0, 0, 1239, gas_schedule);
+
+    // increase the local counter
+    __local_counter := __local_counter + 7;
 
     // bytecode translation starts here
     call __tmp := GetTxnSenderAddress();
@@ -204,9 +206,11 @@ requires ExistsTxnSenderAccount(__m, __txn);
     assume !__abort_flag;
     __saved_m := __m;
     __frame := __local_counter;
-    __local_counter := __local_counter + 8;
 
     // process and type check arguments
+
+    // increase the local counter
+    __local_counter := __local_counter + 8;
 
     // bytecode translation starts here
     call __tmp := LdAddr(173345816);
@@ -278,9 +282,11 @@ requires ExistsTxnSenderAccount(__m, __txn);
     assume !__abort_flag;
     __saved_m := __m;
     __frame := __local_counter;
-    __local_counter := __local_counter + 8;
 
     // process and type check arguments
+
+    // increase the local counter
+    __local_counter := __local_counter + 8;
 
     // bytecode translation starts here
     call __tmp := LdAddr(173345816);
@@ -417,12 +423,14 @@ requires ExistsTxnSenderAccount(__m, __txn);
     assume !__abort_flag;
     __saved_m := __m;
     __frame := __local_counter;
-    __local_counter := __local_counter + 3;
 
     // process and type check arguments
     assume is#Address(addr);
     __m := UpdateLocal(__m, __frame + 0, addr);
     assume $DebugTrackLocal(7, 0, 0, 645, addr);
+
+    // increase the local counter
+    __local_counter := __local_counter + 3;
 
     // bytecode translation starts here
     call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 0));
@@ -465,12 +473,14 @@ requires ExistsTxnSenderAccount(__m, __txn);
     assume !__abort_flag;
     __saved_m := __m;
     __frame := __local_counter;
-    __local_counter := __local_counter + 7;
 
     // process and type check arguments
     assume is#Address(addr);
     __m := UpdateLocal(__m, __frame + 0, addr);
     assume $DebugTrackLocal(7, 1, 0, 907, addr);
+
+    // increase the local counter
+    __local_counter := __local_counter + 7;
 
     // bytecode translation starts here
     call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 0));
@@ -525,13 +535,15 @@ requires ExistsTxnSenderAccount(__m, __txn);
     assume !__abort_flag;
     __saved_m := __m;
     __frame := __local_counter;
-    __local_counter := __local_counter + 4;
 
     // process and type check arguments
     assume is#Vector(Dereference(__m, config_ref));
-    assume IsValidReferenceParameter(__m, __frame, config_ref);
+    assume IsValidReferenceParameter(__m, __local_counter, config_ref);
     assume is#Vector(Dereference(__m, config_ref));
     assume $DebugTrackLocal(7, 2, 0, 1129, Dereference(__m, config_ref));
+
+    // increase the local counter
+    __local_counter := __local_counter + 4;
 
     // bytecode translation starts here
     call __t1 := CopyOrMoveRef(config_ref);
@@ -573,13 +585,15 @@ requires ExistsTxnSenderAccount(__m, __txn);
     assume !__abort_flag;
     __saved_m := __m;
     __frame := __local_counter;
-    __local_counter := __local_counter + 4;
 
     // process and type check arguments
     assume is#Vector(Dereference(__m, config_ref));
-    assume IsValidReferenceParameter(__m, __frame, config_ref);
+    assume IsValidReferenceParameter(__m, __local_counter, config_ref);
     assume is#Vector(Dereference(__m, config_ref));
     assume $DebugTrackLocal(7, 3, 0, 1315, Dereference(__m, config_ref));
+
+    // increase the local counter
+    __local_counter := __local_counter + 4;
 
     // bytecode translation starts here
     call __t1 := CopyOrMoveRef(config_ref);
@@ -621,13 +635,15 @@ requires ExistsTxnSenderAccount(__m, __txn);
     assume !__abort_flag;
     __saved_m := __m;
     __frame := __local_counter;
-    __local_counter := __local_counter + 4;
 
     // process and type check arguments
     assume is#Vector(Dereference(__m, config_ref));
-    assume IsValidReferenceParameter(__m, __frame, config_ref);
+    assume IsValidReferenceParameter(__m, __local_counter, config_ref);
     assume is#Vector(Dereference(__m, config_ref));
     assume $DebugTrackLocal(7, 4, 0, 1534, Dereference(__m, config_ref));
+
+    // increase the local counter
+    __local_counter := __local_counter + 4;
 
     // bytecode translation starts here
     call __t1 := CopyOrMoveRef(config_ref);
@@ -669,13 +685,15 @@ requires ExistsTxnSenderAccount(__m, __txn);
     assume !__abort_flag;
     __saved_m := __m;
     __frame := __local_counter;
-    __local_counter := __local_counter + 4;
 
     // process and type check arguments
     assume is#Vector(Dereference(__m, config_ref));
-    assume IsValidReferenceParameter(__m, __frame, config_ref);
+    assume IsValidReferenceParameter(__m, __local_counter, config_ref);
     assume is#Vector(Dereference(__m, config_ref));
     assume $DebugTrackLocal(7, 5, 0, 1747, Dereference(__m, config_ref));
+
+    // increase the local counter
+    __local_counter := __local_counter + 4;
 
     // bytecode translation starts here
     call __t1 := CopyOrMoveRef(config_ref);
@@ -717,13 +735,15 @@ requires ExistsTxnSenderAccount(__m, __txn);
     assume !__abort_flag;
     __saved_m := __m;
     __frame := __local_counter;
-    __local_counter := __local_counter + 4;
 
     // process and type check arguments
     assume is#Vector(Dereference(__m, config_ref));
-    assume IsValidReferenceParameter(__m, __frame, config_ref);
+    assume IsValidReferenceParameter(__m, __local_counter, config_ref);
     assume is#Vector(Dereference(__m, config_ref));
     assume $DebugTrackLocal(7, 6, 0, 1952, Dereference(__m, config_ref));
+
+    // increase the local counter
+    __local_counter := __local_counter + 4;
 
     // bytecode translation starts here
     call __t1 := CopyOrMoveRef(config_ref);
@@ -765,13 +785,15 @@ requires ExistsTxnSenderAccount(__m, __txn);
     assume !__abort_flag;
     __saved_m := __m;
     __frame := __local_counter;
-    __local_counter := __local_counter + 4;
 
     // process and type check arguments
     assume is#Vector(Dereference(__m, config_ref));
-    assume IsValidReferenceParameter(__m, __frame, config_ref);
+    assume IsValidReferenceParameter(__m, __local_counter, config_ref);
     assume is#Vector(Dereference(__m, config_ref));
     assume $DebugTrackLocal(7, 7, 0, 2165, Dereference(__m, config_ref));
+
+    // increase the local counter
+    __local_counter := __local_counter + 4;
 
     // bytecode translation starts here
     call __t1 := CopyOrMoveRef(config_ref);
@@ -818,7 +840,6 @@ requires ExistsTxnSenderAccount(__m, __txn);
     assume !__abort_flag;
     __saved_m := __m;
     __frame := __local_counter;
-    __local_counter := __local_counter + 14;
 
     // process and type check arguments
     assume is#ByteArray(consensus_pubkey);
@@ -839,6 +860,9 @@ requires ExistsTxnSenderAccount(__m, __txn);
     assume is#ByteArray(fullnodes_network_address);
     __m := UpdateLocal(__m, __frame + 5, fullnodes_network_address);
     assume $DebugTrackLocal(7, 8, 5, 2532, fullnodes_network_address);
+
+    // increase the local counter
+    __local_counter := __local_counter + 14;
 
     // bytecode translation starts here
     call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 0));
@@ -907,12 +931,14 @@ requires ExistsTxnSenderAccount(__m, __txn);
     assume !__abort_flag;
     __saved_m := __m;
     __frame := __local_counter;
-    __local_counter := __local_counter + 12;
 
     // process and type check arguments
     assume is#ByteArray(consensus_pubkey);
     __m := UpdateLocal(__m, __frame + 0, consensus_pubkey);
     assume $DebugTrackLocal(7, 9, 0, 3648, consensus_pubkey);
+
+    // increase the local counter
+    __local_counter := __local_counter + 12;
 
     // bytecode translation starts here
     call __tmp := GetTxnSenderAddress();
@@ -987,12 +1013,14 @@ requires ExistsTxnSenderAccount(__m, __txn);
     assume !__abort_flag;
     __saved_m := __m;
     __frame := __local_counter;
-    __local_counter := __local_counter + 12;
 
     // process and type check arguments
     assume is#ByteArray(validator_network_identity_pubkey);
     __m := UpdateLocal(__m, __frame + 0, validator_network_identity_pubkey);
     assume $DebugTrackLocal(7, 10, 0, 4265, validator_network_identity_pubkey);
+
+    // increase the local counter
+    __local_counter := __local_counter + 12;
 
     // bytecode translation starts here
     call __tmp := GetTxnSenderAddress();
@@ -1067,12 +1095,14 @@ requires ExistsTxnSenderAccount(__m, __txn);
     assume !__abort_flag;
     __saved_m := __m;
     __frame := __local_counter;
-    __local_counter := __local_counter + 12;
 
     // process and type check arguments
     assume is#ByteArray(validator_network_address);
     __m := UpdateLocal(__m, __frame + 0, validator_network_address);
     assume $DebugTrackLocal(7, 11, 0, 4890, validator_network_address);
+
+    // increase the local counter
+    __local_counter := __local_counter + 12;
 
     // bytecode translation starts here
     call __tmp := GetTxnSenderAddress();
@@ -1205,12 +1235,14 @@ requires ExistsTxnSenderAccount(__m, __txn);
     assume !__abort_flag;
     __saved_m := __m;
     __frame := __local_counter;
-    __local_counter := __local_counter + 5;
 
     // process and type check arguments
     assume IsValidU64(amount);
     __m := UpdateLocal(__m, __frame + 0, amount);
     assume $DebugTrackLocal(8, 0, 0, 807, amount);
+
+    // increase the local counter
+    __local_counter := __local_counter + 5;
 
     // bytecode translation starts here
     call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 0));
@@ -1281,16 +1313,18 @@ requires ExistsTxnSenderAccount(__m, __txn);
     assume !__abort_flag;
     __saved_m := __m;
     __frame := __local_counter;
-    __local_counter := __local_counter + 21;
 
     // process and type check arguments
     assume IsValidU64(value);
     __m := UpdateLocal(__m, __frame + 0, value);
     assume $DebugTrackLocal(8, 1, 0, 1231, value);
     assume is#Vector(Dereference(__m, capability));
-    assume IsValidReferenceParameter(__m, __frame, capability);
+    assume IsValidReferenceParameter(__m, __local_counter, capability);
     assume is#Vector(Dereference(__m, capability));
     assume $DebugTrackLocal(8, 1, 1, 1231, Dereference(__m, capability));
+
+    // increase the local counter
+    __local_counter := __local_counter + 21;
 
     // bytecode translation starts here
     call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 0));
@@ -1409,9 +1443,11 @@ requires ExistsTxnSenderAccount(__m, __txn);
     assume !__abort_flag;
     __saved_m := __m;
     __frame := __local_counter;
-    __local_counter := __local_counter + 9;
 
     // process and type check arguments
+
+    // increase the local counter
+    __local_counter := __local_counter + 9;
 
     // bytecode translation starts here
     call __tmp := GetTxnSenderAddress();
@@ -1488,9 +1524,11 @@ requires ExistsTxnSenderAccount(__m, __txn);
     assume !__abort_flag;
     __saved_m := __m;
     __frame := __local_counter;
-    __local_counter := __local_counter + 4;
 
     // process and type check arguments
+
+    // increase the local counter
+    __local_counter := __local_counter + 4;
 
     // bytecode translation starts here
     call __tmp := LdAddr(173345816);
@@ -1538,9 +1576,11 @@ requires ExistsTxnSenderAccount(__m, __txn);
     assume !__abort_flag;
     __saved_m := __m;
     __frame := __local_counter;
-    __local_counter := __local_counter + 2;
 
     // process and type check arguments
+
+    // increase the local counter
+    __local_counter := __local_counter + 2;
 
     // bytecode translation starts here
     call __tmp := LdConst(0);
@@ -1580,13 +1620,15 @@ requires ExistsTxnSenderAccount(__m, __txn);
     assume !__abort_flag;
     __saved_m := __m;
     __frame := __local_counter;
-    __local_counter := __local_counter + 4;
 
     // process and type check arguments
     assume is#Vector(Dereference(__m, coin_ref));
-    assume IsValidReferenceParameter(__m, __frame, coin_ref);
+    assume IsValidReferenceParameter(__m, __local_counter, coin_ref);
     assume is#Vector(Dereference(__m, coin_ref));
     assume $DebugTrackLocal(8, 5, 0, 2888, Dereference(__m, coin_ref));
+
+    // increase the local counter
+    __local_counter := __local_counter + 4;
 
     // bytecode translation starts here
     call __t1 := CopyOrMoveRef(coin_ref);
@@ -1631,7 +1673,6 @@ requires ExistsTxnSenderAccount(__m, __txn);
     assume !__abort_flag;
     __saved_m := __m;
     __frame := __local_counter;
-    __local_counter := __local_counter + 8;
 
     // process and type check arguments
     assume is#Vector(coin);
@@ -1640,6 +1681,9 @@ requires ExistsTxnSenderAccount(__m, __txn);
     assume IsValidU64(amount);
     __m := UpdateLocal(__m, __frame + 1, amount);
     assume $DebugTrackLocal(8, 6, 1, 3109, amount);
+
+    // increase the local counter
+    __local_counter := __local_counter + 8;
 
     // bytecode translation starts here
     call __t3 := BorrowLoc(__frame + 0);
@@ -1714,16 +1758,18 @@ requires ExistsTxnSenderAccount(__m, __txn);
     assume !__abort_flag;
     __saved_m := __m;
     __frame := __local_counter;
-    __local_counter := __local_counter + 18;
 
     // process and type check arguments
     assume is#Vector(Dereference(__m, coin_ref));
-    assume IsValidReferenceParameter(__m, __frame, coin_ref);
+    assume IsValidReferenceParameter(__m, __local_counter, coin_ref);
     assume is#Vector(Dereference(__m, coin_ref));
     assume $DebugTrackLocal(8, 7, 0, 3557, Dereference(__m, coin_ref));
     assume IsValidU64(amount);
     __m := UpdateLocal(__m, __frame + 1, amount);
     assume $DebugTrackLocal(8, 7, 1, 3557, amount);
+
+    // increase the local counter
+    __local_counter := __local_counter + 18;
 
     // bytecode translation starts here
     call __t3 := CopyOrMoveRef(coin_ref);
@@ -1815,7 +1861,6 @@ requires ExistsTxnSenderAccount(__m, __txn);
     assume !__abort_flag;
     __saved_m := __m;
     __frame := __local_counter;
-    __local_counter := __local_counter + 5;
 
     // process and type check arguments
     assume is#Vector(coin1);
@@ -1824,6 +1869,9 @@ requires ExistsTxnSenderAccount(__m, __txn);
     assume is#Vector(coin2);
     __m := UpdateLocal(__m, __frame + 1, coin2);
     assume $DebugTrackLocal(8, 8, 1, 4041, coin2);
+
+    // increase the local counter
+    __local_counter := __local_counter + 5;
 
     // bytecode translation starts here
     call __t2 := BorrowLoc(__frame + 0);
@@ -1881,16 +1929,18 @@ requires ExistsTxnSenderAccount(__m, __txn);
     assume !__abort_flag;
     __saved_m := __m;
     __frame := __local_counter;
-    __local_counter := __local_counter + 14;
 
     // process and type check arguments
     assume is#Vector(Dereference(__m, coin_ref));
-    assume IsValidReferenceParameter(__m, __frame, coin_ref);
+    assume IsValidReferenceParameter(__m, __local_counter, coin_ref);
     assume is#Vector(Dereference(__m, coin_ref));
     assume $DebugTrackLocal(8, 9, 0, 4352, Dereference(__m, coin_ref));
     assume is#Vector(check);
     __m := UpdateLocal(__m, __frame + 1, check);
     assume $DebugTrackLocal(8, 9, 1, 4352, check);
+
+    // increase the local counter
+    __local_counter := __local_counter + 14;
 
     // bytecode translation starts here
     call __t4 := CopyOrMoveRef(coin_ref);
@@ -1967,12 +2017,14 @@ requires ExistsTxnSenderAccount(__m, __txn);
     assume !__abort_flag;
     __saved_m := __m;
     __frame := __local_counter;
-    __local_counter := __local_counter + 9;
 
     // process and type check arguments
     assume is#Vector(coin);
     __m := UpdateLocal(__m, __frame + 0, coin);
     assume $DebugTrackLocal(8, 10, 0, 4858, coin);
+
+    // increase the local counter
+    __local_counter := __local_counter + 9;
 
     // bytecode translation starts here
     call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 0));
@@ -2067,9 +2119,11 @@ requires ExistsTxnSenderAccount(__m, __txn);
     assume !__abort_flag;
     __saved_m := __m;
     __frame := __local_counter;
-    __local_counter := __local_counter + 9;
 
     // process and type check arguments
+
+    // increase the local counter
+    __local_counter := __local_counter + 9;
 
     // bytecode translation starts here
     call __tmp := GetTxnSenderAddress();
@@ -2160,7 +2214,6 @@ requires ExistsTxnSenderAccount(__m, __txn);
     assume !__abort_flag;
     __saved_m := __m;
     __frame := __local_counter;
-    __local_counter := __local_counter + 25;
 
     // process and type check arguments
     assume is#Address(proposer);
@@ -2169,6 +2222,9 @@ requires ExistsTxnSenderAccount(__m, __txn);
     assume IsValidU64(timestamp);
     __m := UpdateLocal(__m, __frame + 1, timestamp);
     assume $DebugTrackLocal(9, 1, 1, 743, timestamp);
+
+    // increase the local counter
+    __local_counter := __local_counter + 25;
 
     // bytecode translation starts here
     call __tmp := LdAddr(173345816);
@@ -2289,9 +2345,11 @@ requires ExistsTxnSenderAccount(__m, __txn);
     assume !__abort_flag;
     __saved_m := __m;
     __frame := __local_counter;
-    __local_counter := __local_counter + 4;
 
     // process and type check arguments
+
+    // increase the local counter
+    __local_counter := __local_counter + 4;
 
     // bytecode translation starts here
     call __tmp := LdAddr(173345816);
@@ -2373,9 +2431,11 @@ requires ExistsTxnSenderAccount(__m, __txn);
     assume !__abort_flag;
     __saved_m := __m;
     __frame := __local_counter;
-    __local_counter := __local_counter + 9;
 
     // process and type check arguments
+
+    // increase the local counter
+    __local_counter := __local_counter + 9;
 
     // bytecode translation starts here
     call __tmp := GetTxnSenderAddress();
@@ -2454,12 +2514,14 @@ requires ExistsTxnSenderAccount(__m, __txn);
     assume !__abort_flag;
     __saved_m := __m;
     __frame := __local_counter;
-    __local_counter := __local_counter + 12;
 
     // process and type check arguments
     assume IsValidU64(new_duration);
     __m := UpdateLocal(__m, __frame + 0, new_duration);
     assume $DebugTrackLocal(10, 1, 0, 564, new_duration);
+
+    // increase the local counter
+    __local_counter := __local_counter + 12;
 
     // bytecode translation starts here
     call __tmp := GetTxnSenderAddress();
@@ -2552,12 +2614,14 @@ requires ExistsTxnSenderAccount(__m, __txn);
     assume !__abort_flag;
     __saved_m := __m;
     __frame := __local_counter;
-    __local_counter := __local_counter + 23;
 
     // process and type check arguments
     assume IsValidU64(timestamp);
     __m := UpdateLocal(__m, __frame + 0, timestamp);
     assume $DebugTrackLocal(10, 2, 0, 911, timestamp);
+
+    // increase the local counter
+    __local_counter := __local_counter + 23;
 
     // bytecode translation starts here
     call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 0));
@@ -2885,7 +2949,6 @@ requires ExistsTxnSenderAccount(__m, __txn);
     assume !__abort_flag;
     __saved_m := __m;
     __frame := __local_counter;
-    __local_counter := __local_counter + 5;
 
     // process and type check arguments
     assume is#Address(payee);
@@ -2894,6 +2957,9 @@ requires ExistsTxnSenderAccount(__m, __txn);
     assume is#Vector(to_deposit);
     __m := UpdateLocal(__m, __frame + 1, to_deposit);
     assume $DebugTrackLocal(11, 0, 1, 3305, to_deposit);
+
+    // increase the local counter
+    __local_counter := __local_counter + 5;
 
     // bytecode translation starts here
     call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 0));
@@ -2939,7 +3005,6 @@ requires ExistsTxnSenderAccount(__m, __txn);
     assume !__abort_flag;
     __saved_m := __m;
     __frame := __local_counter;
-    __local_counter := __local_counter + 7;
 
     // process and type check arguments
     assume is#Address(payee);
@@ -2951,6 +3016,9 @@ requires ExistsTxnSenderAccount(__m, __txn);
     assume is#ByteArray(metadata);
     __m := UpdateLocal(__m, __frame + 2, metadata);
     assume $DebugTrackLocal(11, 1, 2, 3567, metadata);
+
+    // increase the local counter
+    __local_counter := __local_counter + 7;
 
     // bytecode translation starts here
     call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 0));
@@ -3025,7 +3093,6 @@ requires ExistsTxnSenderAccount(__m, __txn);
     assume !__abort_flag;
     __saved_m := __m;
     __frame := __local_counter;
-    __local_counter := __local_counter + 33;
 
     // process and type check arguments
     assume is#Address(payee);
@@ -3040,6 +3107,9 @@ requires ExistsTxnSenderAccount(__m, __txn);
     assume is#ByteArray(metadata);
     __m := UpdateLocal(__m, __frame + 3, metadata);
     assume $DebugTrackLocal(11, 2, 3, 4018, metadata);
+
+    // increase the local counter
+    __local_counter := __local_counter + 33;
 
     // bytecode translation starts here
     call __t7 := BorrowLoc(__frame + 2);
@@ -3193,7 +3263,6 @@ requires ExistsTxnSenderAccount(__m, __txn);
     assume !__abort_flag;
     __saved_m := __m;
     __frame := __local_counter;
-    __local_counter := __local_counter + 9;
 
     // process and type check arguments
     assume is#Address(payee);
@@ -3202,6 +3271,9 @@ requires ExistsTxnSenderAccount(__m, __txn);
     assume IsValidU64(amount);
     __m := UpdateLocal(__m, __frame + 1, amount);
     assume $DebugTrackLocal(11, 3, 1, 5776, amount);
+
+    // increase the local counter
+    __local_counter := __local_counter + 9;
 
     // bytecode translation starts here
     call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 0));
@@ -3278,16 +3350,18 @@ requires ExistsTxnSenderAccount(__m, __txn);
     assume !__abort_flag;
     __saved_m := __m;
     __frame := __local_counter;
-    __local_counter := __local_counter + 8;
 
     // process and type check arguments
     assume is#Vector(Dereference(__m, account));
-    assume IsValidReferenceParameter(__m, __frame, account);
+    assume IsValidReferenceParameter(__m, __local_counter, account);
     assume is#Vector(Dereference(__m, account));
     assume $DebugTrackLocal(11, 4, 0, 6237, Dereference(__m, account));
     assume IsValidU64(amount);
     __m := UpdateLocal(__m, __frame + 1, amount);
     assume $DebugTrackLocal(11, 4, 1, 6237, amount);
+
+    // increase the local counter
+    __local_counter := __local_counter + 8;
 
     // bytecode translation starts here
     call __t3 := CopyOrMoveRef(account);
@@ -3351,12 +3425,14 @@ requires ExistsTxnSenderAccount(__m, __txn);
     assume !__abort_flag;
     __saved_m := __m;
     __frame := __local_counter;
-    __local_counter := __local_counter + 11;
 
     // process and type check arguments
     assume IsValidU64(amount);
     __m := UpdateLocal(__m, __frame + 0, amount);
     assume $DebugTrackLocal(11, 5, 0, 6552, amount);
+
+    // increase the local counter
+    __local_counter := __local_counter + 11;
 
     // bytecode translation starts here
     call __tmp := GetTxnSenderAddress();
@@ -3439,16 +3515,18 @@ requires ExistsTxnSenderAccount(__m, __txn);
     assume !__abort_flag;
     __saved_m := __m;
     __frame := __local_counter;
-    __local_counter := __local_counter + 10;
 
     // process and type check arguments
     assume is#Vector(Dereference(__m, cap));
-    assume IsValidReferenceParameter(__m, __frame, cap);
+    assume IsValidReferenceParameter(__m, __local_counter, cap);
     assume is#Vector(Dereference(__m, cap));
     assume $DebugTrackLocal(11, 6, 0, 7192, Dereference(__m, cap));
     assume IsValidU64(amount);
     __m := UpdateLocal(__m, __frame + 1, amount);
     assume $DebugTrackLocal(11, 6, 1, 7192, amount);
+
+    // increase the local counter
+    __local_counter := __local_counter + 10;
 
     // bytecode translation starts here
     call __t3 := CopyOrMoveRef(cap);
@@ -3526,9 +3604,11 @@ requires ExistsTxnSenderAccount(__m, __txn);
     assume !__abort_flag;
     __saved_m := __m;
     __frame := __local_counter;
-    __local_counter := __local_counter + 15;
 
     // process and type check arguments
+
+    // increase the local counter
+    __local_counter := __local_counter + 15;
 
     // bytecode translation starts here
     call __tmp := GetTxnSenderAddress();
@@ -3624,12 +3704,14 @@ requires ExistsTxnSenderAccount(__m, __txn);
     assume !__abort_flag;
     __saved_m := __m;
     __frame := __local_counter;
-    __local_counter := __local_counter + 10;
 
     // process and type check arguments
     assume is#Vector(cap);
     __m := UpdateLocal(__m, __frame + 0, cap);
     assume $DebugTrackLocal(11, 8, 0, 8391, cap);
+
+    // increase the local counter
+    __local_counter := __local_counter + 10;
 
     // bytecode translation starts here
     call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 0));
@@ -3701,14 +3783,13 @@ requires ExistsTxnSenderAccount(__m, __txn);
     assume !__abort_flag;
     __saved_m := __m;
     __frame := __local_counter;
-    __local_counter := __local_counter + 16;
 
     // process and type check arguments
     assume is#Address(payee);
     __m := UpdateLocal(__m, __frame + 0, payee);
     assume $DebugTrackLocal(11, 9, 0, 9236, payee);
     assume is#Vector(Dereference(__m, cap));
-    assume IsValidReferenceParameter(__m, __frame, cap);
+    assume IsValidReferenceParameter(__m, __local_counter, cap);
     assume is#Vector(Dereference(__m, cap));
     assume $DebugTrackLocal(11, 9, 1, 9236, Dereference(__m, cap));
     assume IsValidU64(amount);
@@ -3717,6 +3798,9 @@ requires ExistsTxnSenderAccount(__m, __txn);
     assume is#ByteArray(metadata);
     __m := UpdateLocal(__m, __frame + 3, metadata);
     assume $DebugTrackLocal(11, 9, 3, 9236, metadata);
+
+    // increase the local counter
+    __local_counter := __local_counter + 16;
 
     // bytecode translation starts here
     call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 0));
@@ -3808,7 +3892,6 @@ requires ExistsTxnSenderAccount(__m, __txn);
     assume !__abort_flag;
     __saved_m := __m;
     __frame := __local_counter;
-    __local_counter := __local_counter + 11;
 
     // process and type check arguments
     assume is#Address(payee);
@@ -3820,6 +3903,9 @@ requires ExistsTxnSenderAccount(__m, __txn);
     assume is#ByteArray(metadata);
     __m := UpdateLocal(__m, __frame + 2, metadata);
     assume $DebugTrackLocal(11, 10, 2, 9947, metadata);
+
+    // increase the local counter
+    __local_counter := __local_counter + 11;
 
     // bytecode translation starts here
     call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 0));
@@ -3896,7 +3982,6 @@ requires ExistsTxnSenderAccount(__m, __txn);
     assume !__abort_flag;
     __saved_m := __m;
     __frame := __local_counter;
-    __local_counter := __local_counter + 5;
 
     // process and type check arguments
     assume is#Address(payee);
@@ -3905,6 +3990,9 @@ requires ExistsTxnSenderAccount(__m, __txn);
     assume IsValidU64(amount);
     __m := UpdateLocal(__m, __frame + 1, amount);
     assume $DebugTrackLocal(11, 11, 1, 10530, amount);
+
+    // increase the local counter
+    __local_counter := __local_counter + 5;
 
     // bytecode translation starts here
     call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 0));
@@ -3949,16 +4037,18 @@ requires ExistsTxnSenderAccount(__m, __txn);
     assume !__abort_flag;
     __saved_m := __m;
     __frame := __local_counter;
-    __local_counter := __local_counter + 5;
 
     // process and type check arguments
     assume is#Vector(Dereference(__m, account));
-    assume IsValidReferenceParameter(__m, __frame, account);
+    assume IsValidReferenceParameter(__m, __local_counter, account);
     assume is#Vector(Dereference(__m, account));
     assume $DebugTrackLocal(11, 12, 0, 10698, Dereference(__m, account));
     assume is#ByteArray(new_authentication_key);
     __m := UpdateLocal(__m, __frame + 1, new_authentication_key);
     assume $DebugTrackLocal(11, 12, 1, 10698, new_authentication_key);
+
+    // increase the local counter
+    __local_counter := __local_counter + 5;
 
     // bytecode translation starts here
     call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 1));
@@ -4004,12 +4094,14 @@ requires ExistsTxnSenderAccount(__m, __txn);
     assume !__abort_flag;
     __saved_m := __m;
     __frame := __local_counter;
-    __local_counter := __local_counter + 10;
 
     // process and type check arguments
     assume is#ByteArray(new_authentication_key);
     __m := UpdateLocal(__m, __frame + 0, new_authentication_key);
     assume $DebugTrackLocal(11, 13, 0, 11025, new_authentication_key);
+
+    // increase the local counter
+    __local_counter := __local_counter + 10;
 
     // bytecode translation starts here
     call __tmp := GetTxnSenderAddress();
@@ -4083,16 +4175,18 @@ requires ExistsTxnSenderAccount(__m, __txn);
     assume !__abort_flag;
     __saved_m := __m;
     __frame := __local_counter;
-    __local_counter := __local_counter + 7;
 
     // process and type check arguments
     assume is#Vector(Dereference(__m, cap));
-    assume IsValidReferenceParameter(__m, __frame, cap);
+    assume IsValidReferenceParameter(__m, __local_counter, cap);
     assume is#Vector(Dereference(__m, cap));
     assume $DebugTrackLocal(11, 14, 0, 11765, Dereference(__m, cap));
     assume is#ByteArray(new_authentication_key);
     __m := UpdateLocal(__m, __frame + 1, new_authentication_key);
     assume $DebugTrackLocal(11, 14, 1, 11765, new_authentication_key);
+
+    // increase the local counter
+    __local_counter := __local_counter + 7;
 
     // bytecode translation starts here
     call __t2 := CopyOrMoveRef(cap);
@@ -4156,9 +4250,11 @@ requires ExistsTxnSenderAccount(__m, __txn);
     assume !__abort_flag;
     __saved_m := __m;
     __frame := __local_counter;
-    __local_counter := __local_counter + 13;
 
     // process and type check arguments
+
+    // increase the local counter
+    __local_counter := __local_counter + 13;
 
     // bytecode translation starts here
     call __tmp := GetTxnSenderAddress();
@@ -4248,12 +4344,14 @@ requires ExistsTxnSenderAccount(__m, __txn);
     assume !__abort_flag;
     __saved_m := __m;
     __frame := __local_counter;
-    __local_counter := __local_counter + 10;
 
     // process and type check arguments
     assume is#Vector(cap);
     __m := UpdateLocal(__m, __frame + 0, cap);
     assume $DebugTrackLocal(11, 16, 0, 12924, cap);
+
+    // increase the local counter
+    __local_counter := __local_counter + 10;
 
     // bytecode translation starts here
     call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 0));
@@ -4331,12 +4429,14 @@ requires ExistsTxnSenderAccount(__m, __txn);
     assume !__abort_flag;
     __saved_m := __m;
     __frame := __local_counter;
-    __local_counter := __local_counter + 19;
 
     // process and type check arguments
     assume is#Address(fresh_address);
     __m := UpdateLocal(__m, __frame + 0, fresh_address);
     assume $DebugTrackLocal(11, 17, 0, 13761, fresh_address);
+
+    // increase the local counter
+    __local_counter := __local_counter + 19;
 
     // bytecode translation starts here
     call __tmp := LdConst(0);
@@ -4455,7 +4555,6 @@ requires ExistsTxnSenderAccount(__m, __txn);
     assume !__abort_flag;
     __saved_m := __m;
     __frame := __local_counter;
-    __local_counter := __local_counter + 8;
 
     // process and type check arguments
     assume is#Address(fresh_address);
@@ -4464,6 +4563,9 @@ requires ExistsTxnSenderAccount(__m, __txn);
     assume IsValidU64(initial_balance);
     __m := UpdateLocal(__m, __frame + 1, initial_balance);
     assume $DebugTrackLocal(11, 18, 1, 14744, initial_balance);
+
+    // increase the local counter
+    __local_counter := __local_counter + 8;
 
     // bytecode translation starts here
     call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 0));
@@ -4533,13 +4635,15 @@ requires ExistsTxnSenderAccount(__m, __txn);
     assume !__abort_flag;
     __saved_m := __m;
     __frame := __local_counter;
-    __local_counter := __local_counter + 6;
 
     // process and type check arguments
     assume is#Vector(Dereference(__m, account));
-    assume IsValidReferenceParameter(__m, __frame, account);
+    assume IsValidReferenceParameter(__m, __local_counter, account);
     assume is#Vector(Dereference(__m, account));
     assume $DebugTrackLocal(11, 20, 0, 15265, Dereference(__m, account));
+
+    // increase the local counter
+    __local_counter := __local_counter + 6;
 
     // bytecode translation starts here
     call __t2 := CopyOrMoveRef(account);
@@ -4593,12 +4697,14 @@ requires ExistsTxnSenderAccount(__m, __txn);
     assume !__abort_flag;
     __saved_m := __m;
     __frame := __local_counter;
-    __local_counter := __local_counter + 4;
 
     // process and type check arguments
     assume is#Address(addr);
     __m := UpdateLocal(__m, __frame + 0, addr);
     assume $DebugTrackLocal(11, 21, 0, 15535, addr);
+
+    // increase the local counter
+    __local_counter := __local_counter + 4;
 
     // bytecode translation starts here
     call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 0));
@@ -4650,13 +4756,15 @@ requires ExistsTxnSenderAccount(__m, __txn);
     assume !__abort_flag;
     __saved_m := __m;
     __frame := __local_counter;
-    __local_counter := __local_counter + 4;
 
     // process and type check arguments
     assume is#Vector(Dereference(__m, account));
-    assume IsValidReferenceParameter(__m, __frame, account);
+    assume IsValidReferenceParameter(__m, __local_counter, account);
     assume is#Vector(Dereference(__m, account));
     assume $DebugTrackLocal(11, 22, 0, 15735, Dereference(__m, account));
+
+    // increase the local counter
+    __local_counter := __local_counter + 4;
 
     // bytecode translation starts here
     call __t1 := CopyOrMoveRef(account);
@@ -4698,12 +4806,14 @@ requires ExistsTxnSenderAccount(__m, __txn);
     assume !__abort_flag;
     __saved_m := __m;
     __frame := __local_counter;
-    __local_counter := __local_counter + 4;
 
     // process and type check arguments
     assume is#Address(addr);
     __m := UpdateLocal(__m, __frame + 0, addr);
     assume $DebugTrackLocal(11, 23, 0, 15901, addr);
+
+    // increase the local counter
+    __local_counter := __local_counter + 4;
 
     // bytecode translation starts here
     call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 0));
@@ -4756,12 +4866,14 @@ requires ExistsTxnSenderAccount(__m, __txn);
     assume !__abort_flag;
     __saved_m := __m;
     __frame := __local_counter;
-    __local_counter := __local_counter + 5;
 
     // process and type check arguments
     assume is#Address(addr);
     __m := UpdateLocal(__m, __frame + 0, addr);
     assume $DebugTrackLocal(11, 24, 0, 16132, addr);
+
+    // increase the local counter
+    __local_counter := __local_counter + 5;
 
     // bytecode translation starts here
     call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 0));
@@ -4811,12 +4923,14 @@ requires ExistsTxnSenderAccount(__m, __txn);
     assume !__abort_flag;
     __saved_m := __m;
     __frame := __local_counter;
-    __local_counter := __local_counter + 5;
 
     // process and type check arguments
     assume is#Address(addr);
     __m := UpdateLocal(__m, __frame + 0, addr);
     assume $DebugTrackLocal(11, 25, 0, 16385, addr);
+
+    // increase the local counter
+    __local_counter := __local_counter + 5;
 
     // bytecode translation starts here
     call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 0));
@@ -4864,13 +4978,15 @@ requires ExistsTxnSenderAccount(__m, __txn);
     assume !__abort_flag;
     __saved_m := __m;
     __frame := __local_counter;
-    __local_counter := __local_counter + 3;
 
     // process and type check arguments
     assume is#Vector(Dereference(__m, cap));
-    assume IsValidReferenceParameter(__m, __frame, cap);
+    assume IsValidReferenceParameter(__m, __local_counter, cap);
     assume is#Vector(Dereference(__m, cap));
     assume $DebugTrackLocal(11, 26, 0, 16640, Dereference(__m, cap));
+
+    // increase the local counter
+    __local_counter := __local_counter + 3;
 
     // bytecode translation starts here
     call __t1 := CopyOrMoveRef(cap);
@@ -4908,13 +5024,15 @@ requires ExistsTxnSenderAccount(__m, __txn);
     assume !__abort_flag;
     __saved_m := __m;
     __frame := __local_counter;
-    __local_counter := __local_counter + 3;
 
     // process and type check arguments
     assume is#Vector(Dereference(__m, cap));
-    assume IsValidReferenceParameter(__m, __frame, cap);
+    assume IsValidReferenceParameter(__m, __local_counter, cap);
     assume is#Vector(Dereference(__m, cap));
     assume $DebugTrackLocal(11, 27, 0, 16867, Dereference(__m, cap));
+
+    // increase the local counter
+    __local_counter := __local_counter + 3;
 
     // bytecode translation starts here
     call __t1 := CopyOrMoveRef(cap);
@@ -4952,12 +5070,14 @@ requires ExistsTxnSenderAccount(__m, __txn);
     assume !__abort_flag;
     __saved_m := __m;
     __frame := __local_counter;
-    __local_counter := __local_counter + 3;
 
     // process and type check arguments
     assume is#Address(check_addr);
     __m := UpdateLocal(__m, __frame + 0, check_addr);
     assume $DebugTrackLocal(11, 28, 0, 17057, check_addr);
+
+    // increase the local counter
+    __local_counter := __local_counter + 3;
 
     // bytecode translation starts here
     call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 0));
@@ -5044,7 +5164,6 @@ requires ExistsTxnSenderAccount(__m, __txn);
     assume !__abort_flag;
     __saved_m := __m;
     __frame := __local_counter;
-    __local_counter := __local_counter + 55;
 
     // process and type check arguments
     assume IsValidU64(txn_sequence_number);
@@ -5062,6 +5181,9 @@ requires ExistsTxnSenderAccount(__m, __txn);
     assume IsValidU64(txn_expiration_time);
     __m := UpdateLocal(__m, __frame + 4, txn_expiration_time);
     assume $DebugTrackLocal(11, 29, 4, 17457, txn_expiration_time);
+
+    // increase the local counter
+    __local_counter := __local_counter + 55;
 
     // bytecode translation starts here
     call __tmp := GetTxnSenderAddress();
@@ -5334,7 +5456,6 @@ requires ExistsTxnSenderAccount(__m, __txn);
     assume !__abort_flag;
     __saved_m := __m;
     __frame := __local_counter;
-    __local_counter := __local_counter + 37;
 
     // process and type check arguments
     assume IsValidU64(txn_sequence_number);
@@ -5349,6 +5470,9 @@ requires ExistsTxnSenderAccount(__m, __txn);
     assume IsValidU64(gas_units_remaining);
     __m := UpdateLocal(__m, __frame + 3, gas_units_remaining);
     assume $DebugTrackLocal(11, 30, 3, 19386, gas_units_remaining);
+
+    // increase the local counter
+    __local_counter := __local_counter + 37;
 
     // bytecode translation starts here
     call __tmp := GetTxnSenderAddress();
@@ -5536,16 +5660,18 @@ requires ExistsTxnSenderAccount(__m, __txn);
     assume !__abort_flag;
     __saved_m := __m;
     __frame := __local_counter;
-    __local_counter := __local_counter + 22;
 
     // process and type check arguments
     assume is#Vector(Dereference(__m, counter));
-    assume IsValidReferenceParameter(__m, __frame, counter);
+    assume IsValidReferenceParameter(__m, __local_counter, counter);
     assume is#Vector(Dereference(__m, counter));
     assume $DebugTrackLocal(11, 31, 0, 21344, Dereference(__m, counter));
     assume is#Address(sender);
     __m := UpdateLocal(__m, __frame + 1, sender);
     assume $DebugTrackLocal(11, 31, 1, 21344, sender);
+
+    // increase the local counter
+    __local_counter := __local_counter + 22;
 
     // bytecode translation starts here
     call __t6 := CopyOrMoveRef(counter);
@@ -5666,16 +5792,18 @@ requires ExistsTxnSenderAccount(__m, __txn);
     assume !__abort_flag;
     __saved_m := __m;
     __frame := __local_counter;
-    __local_counter := __local_counter + 7;
 
     // process and type check arguments
     assume is#Vector(Dereference(__m, counter));
-    assume IsValidReferenceParameter(__m, __frame, counter);
+    assume IsValidReferenceParameter(__m, __local_counter, counter);
     assume is#Vector(Dereference(__m, counter));
     assume $DebugTrackLocal(11, 32, 0, 22101, Dereference(__m, counter));
     assume is#Address(sender);
     __m := UpdateLocal(__m, __frame + 1, sender);
     assume $DebugTrackLocal(11, 32, 1, 22101, sender);
+
+    // increase the local counter
+    __local_counter := __local_counter + 7;
 
     // bytecode translation starts here
     call __tmp := LdConst(0);
@@ -5734,9 +5862,11 @@ requires ExistsTxnSenderAccount(__m, __txn);
     assume !__abort_flag;
     __saved_m := __m;
     __frame := __local_counter;
-    __local_counter := __local_counter + 8;
 
     // process and type check arguments
+
+    // increase the local counter
+    __local_counter := __local_counter + 8;
 
     // bytecode translation starts here
     call __tmp := GetTxnSenderAddress();
@@ -5812,15 +5942,17 @@ requires ExistsTxnSenderAccount(__m, __txn);
     assume !__abort_flag;
     __saved_m := __m;
     __frame := __local_counter;
-    __local_counter := __local_counter + 18;
 
     // process and type check arguments
     assume is#Vector(Dereference(__m, handle_ref));
-    assume IsValidReferenceParameter(__m, __frame, handle_ref);
+    assume IsValidReferenceParameter(__m, __local_counter, handle_ref);
     assume is#Vector(Dereference(__m, handle_ref));
     assume $DebugTrackLocal(11, 34, 0, 22958, Dereference(__m, handle_ref));
     __m := UpdateLocal(__m, __frame + 1, msg);
     assume $DebugTrackLocal(11, 34, 1, 22958, msg);
+
+    // increase the local counter
+    __local_counter := __local_counter + 18;
 
     // bytecode translation starts here
     call __t4 := CopyOrMoveRef(handle_ref);
@@ -5914,12 +6046,14 @@ requires ExistsTxnSenderAccount(__m, __txn);
     assume !__abort_flag;
     __saved_m := __m;
     __frame := __local_counter;
-    __local_counter := __local_counter + 6;
 
     // process and type check arguments
     assume is#Vector(handle);
     __m := UpdateLocal(__m, __frame + 0, handle);
     assume $DebugTrackLocal(11, 36, 0, 23597, handle);
+
+    // increase the local counter
+    __local_counter := __local_counter + 6;
 
     // bytecode translation starts here
     call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 0));

--- a/language/move-prover/bytecode-to-boogie/tests/goldenfiles/test-reference.bpl
+++ b/language/move-prover/bytecode-to-boogie/tests/goldenfiles/test-reference.bpl
@@ -39,13 +39,15 @@ requires ExistsTxnSenderAccount(__m, __txn);
     assume !__abort_flag;
     __saved_m := __m;
     __frame := __local_counter;
-    __local_counter := __local_counter + 3;
 
     // process and type check arguments
     assume IsValidU64(Dereference(__m, b));
-    assume IsValidReferenceParameter(__m, __frame, b);
+    assume IsValidReferenceParameter(__m, __local_counter, b);
     assume IsValidU64(Dereference(__m, b));
     assume $DebugTrackLocal(0, 0, 0, 71, Dereference(__m, b));
+
+    // increase the local counter
+    __local_counter := __local_counter + 3;
 
     // bytecode translation starts here
     call __tmp := LdConst(10);
@@ -95,9 +97,11 @@ ensures old(b#Boolean(Boolean(false))) ==> __abort_flag;
     assume !__abort_flag;
     __saved_m := __m;
     __frame := __local_counter;
-    __local_counter := __local_counter + 12;
 
     // process and type check arguments
+
+    // increase the local counter
+    __local_counter := __local_counter + 12;
 
     // bytecode translation starts here
     call __tmp := LdConst(20);

--- a/language/move-prover/bytecode-to-boogie/tests/goldenfiles/test-specs-translate.bpl
+++ b/language/move-prover/bytecode-to-boogie/tests/goldenfiles/test-specs-translate.bpl
@@ -78,7 +78,6 @@ ensures old(b#Boolean(Boolean(i#Integer(x1) <= i#Integer(Integer(0))))) ==> __ab
     assume !__abort_flag;
     __saved_m := __m;
     __frame := __local_counter;
-    __local_counter := __local_counter + 7;
 
     // process and type check arguments
     assume IsValidU64(x1);
@@ -87,6 +86,9 @@ ensures old(b#Boolean(Boolean(i#Integer(x1) <= i#Integer(Integer(0))))) ==> __ab
     assume IsValidU64(x2);
     __m := UpdateLocal(__m, __frame + 1, x2);
     assume $DebugTrackLocal(0, 0, 1, 293, x2);
+
+    // increase the local counter
+    __local_counter := __local_counter + 7;
 
     // bytecode translation starts here
     call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 0));
@@ -141,9 +143,11 @@ ensures old(b#Boolean(ExistsResource(__m, TestSpecs_R_type_value(), a#Address(Ad
     assume !__abort_flag;
     __saved_m := __m;
     __frame := __local_counter;
-    __local_counter := __local_counter + 0;
 
     // process and type check arguments
+
+    // increase the local counter
+    __local_counter := __local_counter + 0;
 
     // bytecode translation starts here
     return;
@@ -172,9 +176,11 @@ requires ExistsTxnSenderAccount(__m, __txn);
     assume !__abort_flag;
     __saved_m := __m;
     __frame := __local_counter;
-    __local_counter := __local_counter + 0;
 
     // process and type check arguments
+
+    // increase the local counter
+    __local_counter := __local_counter + 0;
 
     // bytecode translation starts here
     return;
@@ -204,12 +210,14 @@ requires ExistsTxnSenderAccount(__m, __txn);
     assume !__abort_flag;
     __saved_m := __m;
     __frame := __local_counter;
-    __local_counter := __local_counter + 2;
 
     // process and type check arguments
     assume is#Vector(r);
     __m := UpdateLocal(__m, __frame + 0, r);
     assume $DebugTrackLocal(0, 3, 0, 770, r);
+
+    // increase the local counter
+    __local_counter := __local_counter + 2;
 
     // bytecode translation starts here
     call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 0));
@@ -245,12 +253,14 @@ requires ExistsTxnSenderAccount(__m, __txn);
     assume !__abort_flag;
     __saved_m := __m;
     __frame := __local_counter;
-    __local_counter := __local_counter + 2;
 
     // process and type check arguments
     assume is#Vector(r);
     __m := UpdateLocal(__m, __frame + 0, r);
     assume $DebugTrackLocal(0, 4, 0, 879, r);
+
+    // increase the local counter
+    __local_counter := __local_counter + 2;
 
     // bytecode translation starts here
     call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 0));
@@ -286,12 +296,14 @@ requires ExistsTxnSenderAccount(__m, __txn);
     assume !__abort_flag;
     __saved_m := __m;
     __frame := __local_counter;
-    __local_counter := __local_counter + 2;
 
     // process and type check arguments
     assume is#Vector(r);
     __m := UpdateLocal(__m, __frame + 0, r);
     assume $DebugTrackLocal(0, 5, 0, 1000, r);
+
+    // increase the local counter
+    __local_counter := __local_counter + 2;
 
     // bytecode translation starts here
     call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 0));
@@ -327,13 +339,15 @@ ensures b#Boolean(Boolean(IsEqual(SelectField(SelectField(Dereference(__m, r), T
     assume !__abort_flag;
     __saved_m := __m;
     __frame := __local_counter;
-    __local_counter := __local_counter + 1;
 
     // process and type check arguments
     assume is#Vector(Dereference(__m, r));
-    assume IsValidReferenceParameter(__m, __frame, r);
+    assume IsValidReferenceParameter(__m, __local_counter, r);
     assume is#Vector(Dereference(__m, r));
     assume $DebugTrackLocal(0, 6, 0, 1152, Dereference(__m, r));
+
+    // increase the local counter
+    __local_counter := __local_counter + 1;
 
     // bytecode translation starts here
     return;
@@ -367,9 +381,11 @@ ensures b#Boolean(Boolean(IsEqual(__ret2, Integer(10))));
     assume !__abort_flag;
     __saved_m := __m;
     __frame := __local_counter;
-    __local_counter := __local_counter + 3;
 
     // process and type check arguments
+
+    // increase the local counter
+    __local_counter := __local_counter + 3;
 
     // bytecode translation starts here
     call __tmp := LdConst(7);
@@ -417,12 +433,14 @@ ensures b#Boolean(Boolean(b#Boolean(number_in_range(x)) && b#Boolean(Boolean(i#I
     assume !__abort_flag;
     __saved_m := __m;
     __frame := __local_counter;
-    __local_counter := __local_counter + 2;
 
     // process and type check arguments
     assume IsValidU64(x);
     __m := UpdateLocal(__m, __frame + 0, x);
     assume $DebugTrackLocal(0, 8, 0, 1459, x);
+
+    // increase the local counter
+    __local_counter := __local_counter + 2;
 
     // bytecode translation starts here
     call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 0));

--- a/language/move-prover/bytecode-to-boogie/tests/goldenfiles/test-struct.bpl
+++ b/language/move-prover/bytecode-to-boogie/tests/goldenfiles/test-struct.bpl
@@ -111,7 +111,6 @@ requires ExistsTxnSenderAccount(__m, __txn);
     assume !__abort_flag;
     __saved_m := __m;
     __frame := __local_counter;
-    __local_counter := __local_counter + 4;
 
     // process and type check arguments
     assume is#Vector(a);
@@ -120,6 +119,9 @@ requires ExistsTxnSenderAccount(__m, __txn);
     assume is#Vector(c);
     __m := UpdateLocal(__m, __frame + 1, c);
     assume $DebugTrackLocal(0, 0, 1, 252, c);
+
+    // increase the local counter
+    __local_counter := __local_counter + 4;
 
     // bytecode translation starts here
     call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 0));
@@ -178,12 +180,14 @@ requires ExistsTxnSenderAccount(__m, __txn);
     assume !__abort_flag;
     __saved_m := __m;
     __frame := __local_counter;
-    __local_counter := __local_counter + 20;
 
     // process and type check arguments
     assume is#Address(a);
     __m := UpdateLocal(__m, __frame + 0, a);
     assume $DebugTrackLocal(0, 1, 0, 351, a);
+
+    // increase the local counter
+    __local_counter := __local_counter + 20;
 
     // bytecode translation starts here
     call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 0));
@@ -326,12 +330,14 @@ ensures old(b#Boolean(Boolean(false))) ==> __abort_flag;
     assume !__abort_flag;
     __saved_m := __m;
     __frame := __local_counter;
-    __local_counter := __local_counter + 24;
 
     // process and type check arguments
     assume is#Address(a);
     __m := UpdateLocal(__m, __frame + 0, a);
     assume $DebugTrackLocal(0, 2, 0, 835, a);
+
+    // increase the local counter
+    __local_counter := __local_counter + 24;
 
     // bytecode translation starts here
     call __tmp := LdFalse();
@@ -464,12 +470,14 @@ ensures old(b#Boolean(Boolean(false))) ==> __abort_flag;
     assume !__abort_flag;
     __saved_m := __m;
     __frame := __local_counter;
-    __local_counter := __local_counter + 16;
 
     // process and type check arguments
     assume is#Address(a);
     __m := UpdateLocal(__m, __frame + 0, a);
     assume $DebugTrackLocal(0, 3, 0, 1372, a);
+
+    // increase the local counter
+    __local_counter := __local_counter + 16;
 
     // bytecode translation starts here
     call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 0));

--- a/language/move-prover/bytecode-to-boogie/tests/goldenfiles/test3.bpl
+++ b/language/move-prover/bytecode-to-boogie/tests/goldenfiles/test3.bpl
@@ -101,12 +101,14 @@ ensures old(b#Boolean(Boolean(false))) ==> __abort_flag;
     assume !__abort_flag;
     __saved_m := __m;
     __frame := __local_counter;
-    __local_counter := __local_counter + 57;
 
     // process and type check arguments
     assume is#Boolean(flag);
     __m := UpdateLocal(__m, __frame + 0, flag);
     assume $DebugTrackLocal(0, 0, 0, 53, flag);
+
+    // increase the local counter
+    __local_counter := __local_counter + 57;
 
     // bytecode translation starts here
     call __tmp := LdConst(0);

--- a/language/move-prover/bytecode-to-boogie/tests/goldenfiles/verify-addition.bpl
+++ b/language/move-prover/bytecode-to-boogie/tests/goldenfiles/verify-addition.bpl
@@ -24,7 +24,6 @@ ensures old(b#Boolean(Boolean(false))) ==> __abort_flag;
     assume !__abort_flag;
     __saved_m := __m;
     __frame := __local_counter;
-    __local_counter := __local_counter + 5;
 
     // process and type check arguments
     assume IsValidU8(x);
@@ -33,6 +32,9 @@ ensures old(b#Boolean(Boolean(false))) ==> __abort_flag;
     assume IsValidU8(y);
     __m := UpdateLocal(__m, __frame + 1, y);
     assume $DebugTrackLocal(0, 0, 1, 72, y);
+
+    // increase the local counter
+    __local_counter := __local_counter + 5;
 
     // bytecode translation starts here
     call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 0));
@@ -82,7 +84,6 @@ ensures old(b#Boolean(Boolean(i#Integer(Integer(i#Integer(x) + i#Integer(y))) > 
     assume !__abort_flag;
     __saved_m := __m;
     __frame := __local_counter;
-    __local_counter := __local_counter + 5;
 
     // process and type check arguments
     assume IsValidU8(x);
@@ -91,6 +92,9 @@ ensures old(b#Boolean(Boolean(i#Integer(Integer(i#Integer(x) + i#Integer(y))) > 
     assume IsValidU8(y);
     __m := UpdateLocal(__m, __frame + 1, y);
     assume $DebugTrackLocal(0, 1, 1, 270, y);
+
+    // increase the local counter
+    __local_counter := __local_counter + 5;
 
     // bytecode translation starts here
     call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 0));
@@ -140,7 +144,6 @@ ensures old(b#Boolean(Boolean(false))) ==> __abort_flag;
     assume !__abort_flag;
     __saved_m := __m;
     __frame := __local_counter;
-    __local_counter := __local_counter + 5;
 
     // process and type check arguments
     assume IsValidU64(x);
@@ -149,6 +152,9 @@ ensures old(b#Boolean(Boolean(false))) ==> __abort_flag;
     assume IsValidU64(y);
     __m := UpdateLocal(__m, __frame + 1, y);
     assume $DebugTrackLocal(0, 2, 1, 452, y);
+
+    // increase the local counter
+    __local_counter := __local_counter + 5;
 
     // bytecode translation starts here
     call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 0));
@@ -198,7 +204,6 @@ ensures old(b#Boolean(Boolean(i#Integer(Integer(i#Integer(x) + i#Integer(y))) > 
     assume !__abort_flag;
     __saved_m := __m;
     __frame := __local_counter;
-    __local_counter := __local_counter + 5;
 
     // process and type check arguments
     assume IsValidU64(x);
@@ -207,6 +212,9 @@ ensures old(b#Boolean(Boolean(i#Integer(Integer(i#Integer(x) + i#Integer(y))) > 
     assume IsValidU64(y);
     __m := UpdateLocal(__m, __frame + 1, y);
     assume $DebugTrackLocal(0, 3, 1, 654, y);
+
+    // increase the local counter
+    __local_counter := __local_counter + 5;
 
     // bytecode translation starts here
     call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 0));
@@ -256,7 +264,6 @@ ensures old(b#Boolean(Boolean(false))) ==> __abort_flag;
     assume !__abort_flag;
     __saved_m := __m;
     __frame := __local_counter;
-    __local_counter := __local_counter + 5;
 
     // process and type check arguments
     assume IsValidU128(x);
@@ -265,6 +272,9 @@ ensures old(b#Boolean(Boolean(false))) ==> __abort_flag;
     assume IsValidU128(y);
     __m := UpdateLocal(__m, __frame + 1, y);
     assume $DebugTrackLocal(0, 4, 1, 855, y);
+
+    // increase the local counter
+    __local_counter := __local_counter + 5;
 
     // bytecode translation starts here
     call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 0));

--- a/language/move-prover/bytecode-to-boogie/tests/goldenfiles/verify-cast.bpl
+++ b/language/move-prover/bytecode-to-boogie/tests/goldenfiles/verify-cast.bpl
@@ -23,12 +23,14 @@ ensures old(b#Boolean(Boolean(false))) ==> __abort_flag;
     assume !__abort_flag;
     __saved_m := __m;
     __frame := __local_counter;
-    __local_counter := __local_counter + 3;
 
     // process and type check arguments
     assume IsValidU64(x);
     __m := UpdateLocal(__m, __frame + 0, x);
     assume $DebugTrackLocal(0, 0, 0, 71, x);
+
+    // increase the local counter
+    __local_counter := __local_counter + 3;
 
     // bytecode translation starts here
     call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 0));
@@ -74,12 +76,14 @@ ensures old(b#Boolean(Boolean(i#Integer(x) > i#Integer(Integer(255))))) ==> __ab
     assume !__abort_flag;
     __saved_m := __m;
     __frame := __local_counter;
-    __local_counter := __local_counter + 3;
 
     // process and type check arguments
     assume IsValidU64(x);
     __m := UpdateLocal(__m, __frame + 0, x);
     assume $DebugTrackLocal(0, 1, 0, 261, x);
+
+    // increase the local counter
+    __local_counter := __local_counter + 3;
 
     // bytecode translation starts here
     call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 0));
@@ -125,12 +129,14 @@ ensures old(b#Boolean(Boolean(false))) ==> __abort_flag;
     assume !__abort_flag;
     __saved_m := __m;
     __frame := __local_counter;
-    __local_counter := __local_counter + 3;
 
     // process and type check arguments
     assume IsValidU128(x);
     __m := UpdateLocal(__m, __frame + 0, x);
     assume $DebugTrackLocal(0, 2, 0, 433, x);
+
+    // increase the local counter
+    __local_counter := __local_counter + 3;
 
     // bytecode translation starts here
     call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 0));
@@ -176,12 +182,14 @@ ensures old(b#Boolean(Boolean(i#Integer(x) > i#Integer(Integer(92233720368547758
     assume !__abort_flag;
     __saved_m := __m;
     __frame := __local_counter;
-    __local_counter := __local_counter + 3;
 
     // process and type check arguments
     assume IsValidU128(x);
     __m := UpdateLocal(__m, __frame + 0, x);
     assume $DebugTrackLocal(0, 3, 0, 627, x);
+
+    // increase the local counter
+    __local_counter := __local_counter + 3;
 
     // bytecode translation starts here
     call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 0));

--- a/language/move-prover/bytecode-to-boogie/tests/goldenfiles/verify-create-resource.bpl
+++ b/language/move-prover/bytecode-to-boogie/tests/goldenfiles/verify-create-resource.bpl
@@ -46,9 +46,11 @@ ensures old(b#Boolean(ExistsResource(__m, TestSpecs_R_type_value(), a#Address(Ad
     assume !__abort_flag;
     __saved_m := __m;
     __frame := __local_counter;
-    __local_counter := __local_counter + 5;
 
     // process and type check arguments
+
+    // increase the local counter
+    __local_counter := __local_counter + 5;
 
     // bytecode translation starts here
     call __tmp := GetTxnSenderAddress();
@@ -110,9 +112,11 @@ ensures old(b#Boolean(ExistsResource(__m, TestSpecs_R_type_value(), a#Address(Ad
     assume !__abort_flag;
     __saved_m := __m;
     __frame := __local_counter;
-    __local_counter := __local_counter + 3;
 
     // process and type check arguments
+
+    // increase the local counter
+    __local_counter := __local_counter + 3;
 
     // bytecode translation starts here
     call __tmp := GetTxnSenderAddress();

--- a/language/move-prover/bytecode-to-boogie/tests/goldenfiles/verify-div.bpl
+++ b/language/move-prover/bytecode-to-boogie/tests/goldenfiles/verify-div.bpl
@@ -24,7 +24,6 @@ ensures old(b#Boolean(Boolean(i#Integer(y) > i#Integer(Integer(0))))) ==> !__abo
     assume !__abort_flag;
     __saved_m := __m;
     __frame := __local_counter;
-    __local_counter := __local_counter + 7;
 
     // process and type check arguments
     assume IsValidU64(x);
@@ -33,6 +32,9 @@ ensures old(b#Boolean(Boolean(i#Integer(y) > i#Integer(Integer(0))))) ==> !__abo
     assume IsValidU64(y);
     __m := UpdateLocal(__m, __frame + 1, y);
     assume $DebugTrackLocal(0, 0, 1, 24, y);
+
+    // increase the local counter
+    __local_counter := __local_counter + 7;
 
     // bytecode translation starts here
     call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 0));
@@ -89,7 +91,6 @@ ensures old(b#Boolean(Boolean(true))) ==> !__abort_flag;
     assume !__abort_flag;
     __saved_m := __m;
     __frame := __local_counter;
-    __local_counter := __local_counter + 7;
 
     // process and type check arguments
     assume IsValidU64(x);
@@ -98,6 +99,9 @@ ensures old(b#Boolean(Boolean(true))) ==> !__abort_flag;
     assume IsValidU64(y);
     __m := UpdateLocal(__m, __frame + 1, y);
     assume $DebugTrackLocal(0, 1, 1, 303, y);
+
+    // increase the local counter
+    __local_counter := __local_counter + 7;
 
     // bytecode translation starts here
     call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 0));

--- a/language/move-prover/bytecode-to-boogie/tests/goldenfiles/verify-local-ref.bpl
+++ b/language/move-prover/bytecode-to-boogie/tests/goldenfiles/verify-local-ref.bpl
@@ -20,13 +20,15 @@ requires ExistsTxnSenderAccount(__m, __txn);
     assume !__abort_flag;
     __saved_m := __m;
     __frame := __local_counter;
-    __local_counter := __local_counter + 3;
 
     // process and type check arguments
     assume IsValidU64(Dereference(__m, b));
-    assume IsValidReferenceParameter(__m, __frame, b);
+    assume IsValidReferenceParameter(__m, __local_counter, b);
     assume IsValidU64(Dereference(__m, b));
     assume $DebugTrackLocal(0, 0, 0, 24, Dereference(__m, b));
+
+    // increase the local counter
+    __local_counter := __local_counter + 3;
 
     // bytecode translation starts here
     call __tmp := LdConst(10);
@@ -74,9 +76,11 @@ ensures old(b#Boolean(Boolean(true))) ==> !__abort_flag;
     assume !__abort_flag;
     __saved_m := __m;
     __frame := __local_counter;
-    __local_counter := __local_counter + 12;
 
     // process and type check arguments
+
+    // increase the local counter
+    __local_counter := __local_counter + 12;
 
     // bytecode translation starts here
     call __tmp := LdConst(20);
@@ -170,9 +174,11 @@ ensures old(b#Boolean(Boolean(true))) ==> !__abort_flag;
     assume !__abort_flag;
     __saved_m := __m;
     __frame := __local_counter;
-    __local_counter := __local_counter + 12;
 
     // process and type check arguments
+
+    // increase the local counter
+    __local_counter := __local_counter + 12;
 
     // bytecode translation starts here
     call __tmp := LdConst(20);

--- a/language/move-prover/bytecode-to-boogie/tests/goldenfiles/verify-multiplication.bpl
+++ b/language/move-prover/bytecode-to-boogie/tests/goldenfiles/verify-multiplication.bpl
@@ -24,7 +24,6 @@ ensures old(b#Boolean(Boolean(false))) ==> __abort_flag;
     assume !__abort_flag;
     __saved_m := __m;
     __frame := __local_counter;
-    __local_counter := __local_counter + 5;
 
     // process and type check arguments
     assume IsValidU8(x);
@@ -33,6 +32,9 @@ ensures old(b#Boolean(Boolean(false))) ==> __abort_flag;
     assume IsValidU8(y);
     __m := UpdateLocal(__m, __frame + 1, y);
     assume $DebugTrackLocal(0, 0, 1, 75, y);
+
+    // increase the local counter
+    __local_counter := __local_counter + 5;
 
     // bytecode translation starts here
     call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 0));
@@ -82,7 +84,6 @@ ensures old(b#Boolean(Boolean(i#Integer(Integer(i#Integer(x) * i#Integer(y))) > 
     assume !__abort_flag;
     __saved_m := __m;
     __frame := __local_counter;
-    __local_counter := __local_counter + 5;
 
     // process and type check arguments
     assume IsValidU8(x);
@@ -91,6 +92,9 @@ ensures old(b#Boolean(Boolean(i#Integer(Integer(i#Integer(x) * i#Integer(y))) > 
     assume IsValidU8(y);
     __m := UpdateLocal(__m, __frame + 1, y);
     assume $DebugTrackLocal(0, 1, 1, 273, y);
+
+    // increase the local counter
+    __local_counter := __local_counter + 5;
 
     // bytecode translation starts here
     call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 0));
@@ -140,7 +144,6 @@ ensures old(b#Boolean(Boolean(false))) ==> __abort_flag;
     assume !__abort_flag;
     __saved_m := __m;
     __frame := __local_counter;
-    __local_counter := __local_counter + 5;
 
     // process and type check arguments
     assume IsValidU64(x);
@@ -149,6 +152,9 @@ ensures old(b#Boolean(Boolean(false))) ==> __abort_flag;
     assume IsValidU64(y);
     __m := UpdateLocal(__m, __frame + 1, y);
     assume $DebugTrackLocal(0, 2, 1, 456, y);
+
+    // increase the local counter
+    __local_counter := __local_counter + 5;
 
     // bytecode translation starts here
     call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 0));
@@ -198,7 +204,6 @@ ensures old(b#Boolean(Boolean(false))) ==> __abort_flag;
     assume !__abort_flag;
     __saved_m := __m;
     __frame := __local_counter;
-    __local_counter := __local_counter + 5;
 
     // process and type check arguments
     assume IsValidU128(x);
@@ -207,6 +212,9 @@ ensures old(b#Boolean(Boolean(false))) ==> __abort_flag;
     assume IsValidU128(y);
     __m := UpdateLocal(__m, __frame + 1, y);
     assume $DebugTrackLocal(0, 3, 1, 858, y);
+
+    // increase the local counter
+    __local_counter := __local_counter + 5;
 
     // bytecode translation starts here
     call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 0));

--- a/language/move-prover/bytecode-to-boogie/tests/goldenfiles/verify-ref-param.bpl
+++ b/language/move-prover/bytecode-to-boogie/tests/goldenfiles/verify-ref-param.bpl
@@ -41,13 +41,15 @@ ensures b#Boolean(Boolean(IsEqual(__ret0, SelectField(Dereference(__m, ref), Tes
     assume !__abort_flag;
     __saved_m := __m;
     __frame := __local_counter;
-    __local_counter := __local_counter + 4;
 
     // process and type check arguments
     assume is#Vector(Dereference(__m, ref));
-    assume IsValidReferenceParameter(__m, __frame, ref);
+    assume IsValidReferenceParameter(__m, __local_counter, ref);
     assume is#Vector(Dereference(__m, ref));
     assume $DebugTrackLocal(0, 0, 0, 66, Dereference(__m, ref));
+
+    // increase the local counter
+    __local_counter := __local_counter + 4;
 
     // bytecode translation starts here
     call __t1 := CopyOrMoveRef(ref);

--- a/language/move-prover/bytecode-to-boogie/tests/goldenfiles/verify-vector.bpl
+++ b/language/move-prover/bytecode-to-boogie/tests/goldenfiles/verify-vector.bpl
@@ -25,9 +25,11 @@ ensures b#Boolean(Boolean(IsEqual(__ret0, __ret1)));
     assume !__abort_flag;
     __saved_m := __m;
     __frame := __local_counter;
-    __local_counter := __local_counter + 6;
 
     // process and type check arguments
+
+    // increase the local counter
+    __local_counter := __local_counter + 6;
 
     // bytecode translation starts here
     call __t2 := Vector_empty(IntegerType());
@@ -105,9 +107,11 @@ ensures b#Boolean(Boolean(IsEqual(__ret0, __ret1)));
     assume !__abort_flag;
     __saved_m := __m;
     __frame := __local_counter;
-    __local_counter := __local_counter + 11;
 
     // process and type check arguments
+
+    // increase the local counter
+    __local_counter := __local_counter + 11;
 
     // bytecode translation starts here
     call __t3 := Vector_empty(IntegerType());
@@ -212,9 +216,11 @@ ensures b#Boolean(Boolean(IsEqual(__ret0, __ret1)));
     assume !__abort_flag;
     __saved_m := __m;
     __frame := __local_counter;
-    __local_counter := __local_counter + 10;
 
     // process and type check arguments
+
+    // increase the local counter
+    __local_counter := __local_counter + 10;
 
     // bytecode translation starts here
     call __t2 := Vector_empty(IntegerType());
@@ -319,9 +325,11 @@ ensures b#Boolean(Boolean(!IsEqual(__ret0, __ret1)));
     assume !__abort_flag;
     __saved_m := __m;
     __frame := __local_counter;
-    __local_counter := __local_counter + 12;
 
     // process and type check arguments
+
+    // increase the local counter
+    __local_counter := __local_counter + 12;
 
     // bytecode translation starts here
     call __t2 := Vector_empty(IntegerType());
@@ -437,9 +445,11 @@ ensures b#Boolean(Boolean(!IsEqual(__ret0, __ret1)));
     assume !__abort_flag;
     __saved_m := __m;
     __frame := __local_counter;
-    __local_counter := __local_counter + 10;
 
     // process and type check arguments
+
+    // increase the local counter
+    __local_counter := __local_counter + 10;
 
     // bytecode translation starts here
     call __t2 := Vector_empty(IntegerType());
@@ -539,9 +549,11 @@ ensures b#Boolean(Boolean(IsEqual(__ret0, __ret1)));
     assume !__abort_flag;
     __saved_m := __m;
     __frame := __local_counter;
-    __local_counter := __local_counter + 7;
 
     // process and type check arguments
+
+    // increase the local counter
+    __local_counter := __local_counter + 7;
 
     // bytecode translation starts here
     call __t2 := Vector_empty(IntegerType());
@@ -632,9 +644,11 @@ ensures b#Boolean(Boolean(IsEqual(__ret0, __ret1)));
     assume !__abort_flag;
     __saved_m := __m;
     __frame := __local_counter;
-    __local_counter := __local_counter + 15;
 
     // process and type check arguments
+
+    // increase the local counter
+    __local_counter := __local_counter + 15;
 
     // bytecode translation starts here
     call __t2 := Vector_empty(IntegerType());
@@ -772,9 +786,11 @@ ensures old(b#Boolean(Boolean(true))) ==> __abort_flag;
     assume !__abort_flag;
     __saved_m := __m;
     __frame := __local_counter;
-    __local_counter := __local_counter + 7;
 
     // process and type check arguments
+
+    // increase the local counter
+    __local_counter := __local_counter + 7;
 
     // bytecode translation starts here
     call __t1 := Vector_empty(IntegerType());
@@ -852,9 +868,11 @@ ensures old(b#Boolean(Boolean(true))) ==> __abort_flag;
     assume !__abort_flag;
     __saved_m := __m;
     __frame := __local_counter;
-    __local_counter := __local_counter + 7;
 
     // process and type check arguments
+
+    // increase the local counter
+    __local_counter := __local_counter + 7;
 
     // bytecode translation starts here
     call __t1 := Vector_empty(IntegerType());
@@ -943,9 +961,11 @@ ensures b#Boolean(Boolean(IsEqual(__ret0, __ret1)));
     assume !__abort_flag;
     __saved_m := __m;
     __frame := __local_counter;
-    __local_counter := __local_counter + 20;
 
     // process and type check arguments
+
+    // increase the local counter
+    __local_counter := __local_counter + 20;
 
     // bytecode translation starts here
     call __t2 := Vector_empty(IntegerType());
@@ -1106,9 +1126,11 @@ ensures b#Boolean(Boolean(IsEqual(__ret0, Integer(i#Integer(__ret1) + i#Integer(
     assume !__abort_flag;
     __saved_m := __m;
     __frame := __local_counter;
-    __local_counter := __local_counter + 10;
 
     // process and type check arguments
+
+    // increase the local counter
+    __local_counter := __local_counter + 10;
 
     // bytecode translation starts here
     call __t2 := Vector_empty(IntegerType());
@@ -1217,12 +1239,14 @@ ensures b#Boolean(Boolean(IsEqual(Integer(i#Integer(__ret0) + i#Integer(Integer(
     assume !__abort_flag;
     __saved_m := __m;
     __frame := __local_counter;
-    __local_counter := __local_counter + 15;
 
     // process and type check arguments
     assume is#Vector(v);
     __m := UpdateLocal(__m, __frame + 0, v);
     assume $DebugTrackLocal(1, 11, 0, 4491, v);
+
+    // increase the local counter
+    __local_counter := __local_counter + 15;
 
     // bytecode translation starts here
     call __t3 := BorrowLoc(__frame + 0);
@@ -1330,12 +1354,14 @@ ensures b#Boolean(Boolean(IsEqual(__ret0, old(v))));
     assume !__abort_flag;
     __saved_m := __m;
     __frame := __local_counter;
-    __local_counter := __local_counter + 2;
 
     // process and type check arguments
     assume is#Vector(v);
     __m := UpdateLocal(__m, __frame + 0, v);
     assume $DebugTrackLocal(1, 12, 0, 4891, v);
+
+    // increase the local counter
+    __local_counter := __local_counter + 2;
 
     // bytecode translation starts here
     call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 0));
@@ -1373,12 +1399,14 @@ ensures b#Boolean(Boolean(IsEqual(__ret0, old(v))));
     assume !__abort_flag;
     __saved_m := __m;
     __frame := __local_counter;
-    __local_counter := __local_counter + 4;
 
     // process and type check arguments
     assume is#Vector(v);
     __m := UpdateLocal(__m, __frame + 0, v);
     assume $DebugTrackLocal(1, 13, 0, 5056, v);
+
+    // increase the local counter
+    __local_counter := __local_counter + 4;
 
     // bytecode translation starts here
     call __t1 := BorrowLoc(__frame + 0);
@@ -1448,12 +1476,14 @@ ensures b#Boolean(Boolean(IsEqual(__ret0, old(v))));
     assume !__abort_flag;
     __saved_m := __m;
     __frame := __local_counter;
-    __local_counter := __local_counter + 18;
 
     // process and type check arguments
     assume is#Vector(v);
     __m := UpdateLocal(__m, __frame + 0, v);
     assume $DebugTrackLocal(1, 14, 0, 5316, v);
+
+    // increase the local counter
+    __local_counter := __local_counter + 18;
 
     // bytecode translation starts here
     call __t2 := BorrowLoc(__frame + 0);
@@ -1582,12 +1612,14 @@ ensures b#Boolean(Boolean(IsEqual(__ret0, old(v))));
     assume !__abort_flag;
     __saved_m := __m;
     __frame := __local_counter;
-    __local_counter := __local_counter + 6;
 
     // process and type check arguments
     assume is#Vector(v);
     __m := UpdateLocal(__m, __frame + 0, v);
     assume $DebugTrackLocal(1, 15, 0, 5864, v);
+
+    // increase the local counter
+    __local_counter := __local_counter + 6;
 
     // bytecode translation starts here
     call __t1 := BorrowLoc(__frame + 0);
@@ -1667,12 +1699,14 @@ ensures old(b#Boolean(Boolean(true))) ==> __abort_flag;
     assume !__abort_flag;
     __saved_m := __m;
     __frame := __local_counter;
-    __local_counter := __local_counter + 7;
 
     // process and type check arguments
     assume is#Vector(v);
     __m := UpdateLocal(__m, __frame + 0, v);
     assume $DebugTrackLocal(1, 16, 0, 6295, v);
+
+    // increase the local counter
+    __local_counter := __local_counter + 7;
 
     // bytecode translation starts here
     call __t1 := BorrowLoc(__frame + 0);
@@ -1761,12 +1795,14 @@ ensures b#Boolean(Boolean(IsEqual(__ret0, __ret1)));
     assume !__abort_flag;
     __saved_m := __m;
     __frame := __local_counter;
-    __local_counter := __local_counter + 19;
 
     // process and type check arguments
     assume IsValidU64(x);
     __m := UpdateLocal(__m, __frame + 0, x);
     assume $DebugTrackLocal(1, 17, 0, 6588, x);
+
+    // increase the local counter
+    __local_counter := __local_counter + 19;
 
     // bytecode translation starts here
     call __t3 := Vector_empty(IntegerType());
@@ -1909,9 +1945,11 @@ ensures b#Boolean(Boolean(IsEqual(__ret0, Integer(7))));
     assume !__abort_flag;
     __saved_m := __m;
     __frame := __local_counter;
-    __local_counter := __local_counter + 7;
 
     // process and type check arguments
+
+    // increase the local counter
+    __local_counter := __local_counter + 7;
 
     // bytecode translation starts here
     call __t1 := Vector_empty(IntegerType());
@@ -1992,9 +2030,11 @@ ensures old(b#Boolean(Boolean(true))) ==> __abort_flag;
     assume !__abort_flag;
     __saved_m := __m;
     __frame := __local_counter;
-    __local_counter := __local_counter + 8;
 
     // process and type check arguments
+
+    // increase the local counter
+    __local_counter := __local_counter + 8;
 
     // bytecode translation starts here
     call __t2 := Vector_empty(IntegerType());
@@ -2077,9 +2117,11 @@ ensures b#Boolean(Boolean(IsEqual(__ret0, __ret1)));
     assume !__abort_flag;
     __saved_m := __m;
     __frame := __local_counter;
-    __local_counter := __local_counter + 11;
 
     // process and type check arguments
+
+    // increase the local counter
+    __local_counter := __local_counter + 11;
 
     // bytecode translation starts here
     call __t2 := Vector_empty(IntegerType());
@@ -2118,7 +2160,7 @@ ensures b#Boolean(Boolean(IsEqual(__ret0, __ret1)));
       goto Label_Abort;
     }
     assume IsValidU64(Dereference(__m, __t7));
-    assume IsValidReferenceParameter(__m, __frame, __t7);
+    assume IsValidReferenceParameter(__m, __local_counter, __t7);
 
 
 
@@ -2156,6 +2198,112 @@ procedure VerifyVector_test_borrow1_verify () returns (__ret0: Value, __ret1: Va
 
 procedure {:inline 1} VerifyVector_test_borrow2 () returns (__ret0: Value, __ret1: Value)
 requires ExistsTxnSenderAccount(__m, __txn);
+ensures !__abort_flag ==> b#Boolean(Boolean(false));
+ensures old(!(b#Boolean(Boolean(true)))) ==> !__abort_flag;
+ensures old(b#Boolean(Boolean(true))) ==> __abort_flag;
+
+{
+    // declare local variables
+    var ev1: Value; // Vector_T_type_value(IntegerType())
+    var y: Reference; // ReferenceType(IntegerType())
+    var __t2: Value; // Vector_T_type_value(IntegerType())
+    var __t3: Reference; // ReferenceType(Vector_T_type_value(IntegerType()))
+    var __t4: Value; // IntegerType()
+    var __t5: Reference; // ReferenceType(Vector_T_type_value(IntegerType()))
+    var __t6: Value; // IntegerType()
+    var __t7: Reference; // ReferenceType(IntegerType())
+    var __t8: Value; // IntegerType()
+    var __t9: Reference; // ReferenceType(IntegerType())
+    var __t10: Value; // IntegerType()
+    var __tmp: Value;
+    var __frame: int;
+    var __saved_m: Memory;
+
+    // initialize function execution
+    assume !__abort_flag;
+    __saved_m := __m;
+    __frame := __local_counter;
+
+    // process and type check arguments
+
+    // increase the local counter
+    __local_counter := __local_counter + 11;
+
+    // bytecode translation starts here
+    call __t2 := Vector_empty(IntegerType());
+    if (__abort_flag) {
+      assume $DebugTrackAbort(1, 21, 8135);
+      goto Label_Abort;
+    }
+    assume is#Vector(__t2);
+
+    __m := UpdateLocal(__m, __frame + 2, __t2);
+
+    call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 2));
+    __m := UpdateLocal(__m, __frame + 0, __tmp);
+    assume $DebugTrackLocal(1, 21, 0, 8129, __tmp);
+
+    call __t3 := BorrowLoc(__frame + 0);
+
+    call __tmp := LdConst(7);
+    __m := UpdateLocal(__m, __frame + 4, __tmp);
+
+    call Vector_push_back(IntegerType(), __t3, GetLocal(__m, __frame + 4));
+    if (__abort_flag) {
+      assume $DebugTrackAbort(1, 21, 8164);
+      goto Label_Abort;
+    }
+    assume $DebugTrackLocal(1, 21, 0, 8164, GetLocal(__m, __frame + 0));
+
+    call __t5 := BorrowLoc(__frame + 0);
+
+    call __tmp := LdConst(1);
+    __m := UpdateLocal(__m, __frame + 6, __tmp);
+
+    call __t7 := Vector_borrow(IntegerType(), __t5, GetLocal(__m, __frame + 6));
+    if (__abort_flag) {
+      assume $DebugTrackAbort(1, 21, 8212);
+      goto Label_Abort;
+    }
+    assume IsValidU64(Dereference(__m, __t7));
+    assume IsValidReferenceParameter(__m, __local_counter, __t7);
+
+
+
+    call y := CopyOrMoveRef(__t7);
+    assume IsValidU64(Dereference(__m, y));
+    assume $DebugTrackLocal(1, 21, 1, 8208, Dereference(__m, y));
+
+    call __tmp := LdConst(7);
+    __m := UpdateLocal(__m, __frame + 8, __tmp);
+
+    call __t9 := CopyOrMoveRef(y);
+
+    call __tmp := ReadRef(__t9);
+    assume IsValidU64(__tmp);
+    __m := UpdateLocal(__m, __frame + 10, __tmp);
+
+    __ret0 := GetLocal(__m, __frame + 8);
+    assume $DebugTrackLocal(1, 21, 2, 8249, __ret0);
+    __ret1 := GetLocal(__m, __frame + 10);
+    assume $DebugTrackLocal(1, 21, 3, 8249, __ret1);
+    return;
+
+Label_Abort:
+    __abort_flag := true;
+    __m := __saved_m;
+    __ret0 := DefaultValue;
+    __ret1 := DefaultValue;
+}
+
+procedure VerifyVector_test_borrow2_verify () returns (__ret0: Value, __ret1: Value)
+{
+    call InitVerification();
+    call __ret0, __ret1 := VerifyVector_test_borrow2();
+}
+
+procedure {:inline 1} VerifyVector_test_borrow3 () returns (__ret0: Value, __ret1: Value)
+requires ExistsTxnSenderAccount(__m, __txn);
 ensures b#Boolean(Boolean(IsEqual(__ret0, __ret1)));
 {
     // declare local variables
@@ -2178,14 +2326,16 @@ ensures b#Boolean(Boolean(IsEqual(__ret0, __ret1)));
     assume !__abort_flag;
     __saved_m := __m;
     __frame := __local_counter;
-    __local_counter := __local_counter + 11;
 
     // process and type check arguments
+
+    // increase the local counter
+    __local_counter := __local_counter + 11;
 
     // bytecode translation starts here
     call __t2 := Vector_empty(IntegerType());
     if (__abort_flag) {
-      assume $DebugTrackAbort(1, 21, 8190);
+      assume $DebugTrackAbort(1, 22, 8496);
       goto Label_Abort;
     }
     assume is#Vector(__t2);
@@ -2194,7 +2344,7 @@ ensures b#Boolean(Boolean(IsEqual(__ret0, __ret1)));
 
     call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 2));
     __m := UpdateLocal(__m, __frame + 0, __tmp);
-    assume $DebugTrackLocal(1, 21, 0, 8184, __tmp);
+    assume $DebugTrackLocal(1, 22, 0, 8490, __tmp);
 
     call __t3 := BorrowLoc(__frame + 0);
 
@@ -2203,31 +2353,31 @@ ensures b#Boolean(Boolean(IsEqual(__ret0, __ret1)));
 
     call Vector_push_back(IntegerType(), __t3, GetLocal(__m, __frame + 4));
     if (__abort_flag) {
-      assume $DebugTrackAbort(1, 21, 8219);
+      assume $DebugTrackAbort(1, 22, 8525);
       goto Label_Abort;
     }
-    assume $DebugTrackLocal(1, 21, 0, 8219, GetLocal(__m, __frame + 0));
+    assume $DebugTrackLocal(1, 22, 0, 8525, GetLocal(__m, __frame + 0));
 
     call __t5 := BorrowLoc(__frame + 0);
 
-    call __tmp := LdConst(1);
+    call __tmp := LdConst(0);
     __m := UpdateLocal(__m, __frame + 6, __tmp);
 
     call __t7 := Vector_borrow(IntegerType(), __t5, GetLocal(__m, __frame + 6));
     if (__abort_flag) {
-      assume $DebugTrackAbort(1, 21, 8267);
+      assume $DebugTrackAbort(1, 22, 8573);
       goto Label_Abort;
     }
     assume IsValidU64(Dereference(__m, __t7));
-    assume IsValidReferenceParameter(__m, __frame, __t7);
+    assume IsValidReferenceParameter(__m, __local_counter, __t7);
 
 
 
     call y := CopyOrMoveRef(__t7);
     assume IsValidU64(Dereference(__m, y));
-    assume $DebugTrackLocal(1, 21, 1, 8263, Dereference(__m, y));
+    assume $DebugTrackLocal(1, 22, 1, 8569, Dereference(__m, y));
 
-    call __tmp := LdConst(7);
+    call __tmp := LdConst(0);
     __m := UpdateLocal(__m, __frame + 8, __tmp);
 
     call __t9 := CopyOrMoveRef(y);
@@ -2237,9 +2387,9 @@ ensures b#Boolean(Boolean(IsEqual(__ret0, __ret1)));
     __m := UpdateLocal(__m, __frame + 10, __tmp);
 
     __ret0 := GetLocal(__m, __frame + 8);
-    assume $DebugTrackLocal(1, 21, 2, 8304, __ret0);
+    assume $DebugTrackLocal(1, 22, 2, 8610, __ret0);
     __ret1 := GetLocal(__m, __frame + 10);
-    assume $DebugTrackLocal(1, 21, 3, 8304, __ret1);
+    assume $DebugTrackLocal(1, 22, 3, 8610, __ret1);
     return;
 
 Label_Abort:
@@ -2249,8 +2399,8 @@ Label_Abort:
     __ret1 := DefaultValue;
 }
 
-procedure VerifyVector_test_borrow2_verify () returns (__ret0: Value, __ret1: Value)
+procedure VerifyVector_test_borrow3_verify () returns (__ret0: Value, __ret1: Value)
 {
     call InitVerification();
-    call __ret0, __ret1 := VerifyVector_test_borrow2();
+    call __ret0, __ret1 := VerifyVector_test_borrow3();
 }


### PR DESCRIPTION
- Replaced `__frame` with `__local_counter` as the parameter of `IsValidReferenceParameter` in boogie_type_check in boogie_helpers.rs
- Updated the code generation part to emit the result of boogie_type_check before increasing `__local_counter`
- This commit fixes the issue in proving test_borrow2() in verify-vector.mvir

## Motivation

To fix the bug that introduces inconsistency by `assume IsValidReferenceParameter`.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

cargo test

## Related PRs

