### PR TITLE
[language][move] Restrict "break" and "continue" to be top-level expressions

### DIFF
--- a/language/move-lang/src/parser/syntax.rs
+++ b/language/move-lang/src/parser/syntax.rs
@@ -464,8 +464,6 @@ fn parse_sequence<'input>(tokens: &mut Lexer<'input>) -> Result<Sequence, Error>
 //      Term =
 //          "move" <Var>
 //          | "copy" <Var>
-//          | "break"
-//          | "continue"
 //          | <Name>
 //          | <Value>
 //          | "(" Comma<Exp> ")"
@@ -485,16 +483,6 @@ fn parse_term<'input>(tokens: &mut Lexer<'input>) -> Result<Exp, Error> {
         Tok::Copy => {
             tokens.advance()?;
             Exp_::Copy(parse_var(tokens)?)
-        }
-
-        Tok::Break => {
-            tokens.advance()?;
-            Exp_::Break
-        }
-
-        Tok::Continue => {
-            tokens.advance()?;
-            Exp_::Continue
         }
 
         Tok::NameValue => {
@@ -669,10 +657,12 @@ fn parse_call_args<'input>(tokens: &mut Lexer<'input>) -> Result<Spanned<Vec<Exp
 //          "if" "(" <Exp> ")" <Exp> ("else" <Exp>)?
 //          | "while" "(" <Exp> ")" <Exp>
 //          | "loop" <Exp>
-//          | <UnaryExp> "=" <Exp>
 //          | "return" <Exp>
 //          | "abort" <Exp>
+//          | "break"
+//          | "continue"
 //          | <BinOpExp>
+//          | <UnaryExp> "=" <Exp>
 fn parse_exp<'input>(tokens: &mut Lexer<'input>) -> Result<Exp, Error> {
     let start_loc = tokens.start_loc();
     let exp = match tokens.peek() {
@@ -711,6 +701,14 @@ fn parse_exp<'input>(tokens: &mut Lexer<'input>) -> Result<Exp, Error> {
             tokens.advance()?;
             let e = Box::new(parse_exp(tokens)?);
             Exp_::Abort(e)
+        }
+        Tok::Break => {
+            tokens.advance()?;
+            Exp_::Break
+        }
+        Tok::Continue => {
+            tokens.advance()?;
+            Exp_::Continue
         }
         _ => {
             // This could be either an assignment or a binary operator
@@ -758,7 +756,7 @@ fn get_precedence(token: Tok) -> u32 {
 
 // Parse a binary operator expression:
 //      BinOpExp =
-//          <UnaryExp> <BinOp> <BinOpExp>
+//          <UnaryExp> (<BinOp> <BinOpExp>)?
 //      BinOp = (listed from lowest to highest precedence)
 //          "||"
 //          | "&&"

--- a/language/move-lang/tests/move_check/typing/break_any_type.exp
+++ b/language/move-lang/tests/move_check/typing/break_any_type.exp
@@ -2,15 +2,7 @@ error:
 
    ┌── tests/move_check/typing/break_any_type.move:6:17 ───
    │
- 6 │             0 + break;
+ 6 │             foo(break)
    │                 ^^^^^ Invalid use of a divergent expression. The code following the evaluation of this expression will be dead and should be removed. In some cases, this is necessary to prevent unused resource values.
    │
-
-error: 
-
-    ┌── tests/move_check/typing/break_any_type.move:12:17 ───
-    │
- 12 │             foo(break)
-    │                 ^^^^^ Invalid use of a divergent expression. The code following the evaluation of this expression will be dead and should be removed. In some cases, this is necessary to prevent unused resource values.
-    │
 

--- a/language/move-lang/tests/move_check/typing/break_any_type.move
+++ b/language/move-lang/tests/move_check/typing/break_any_type.move
@@ -1,12 +1,6 @@
 module M {
     resource struct Coin {}
 
-    t0() {
-        while (true) {
-            0 + break;
-        }
-    }
-
     t1() {
         while (true) {
             foo(break)

--- a/language/move-lang/tests/move_check/typing/continue_any_type.exp
+++ b/language/move-lang/tests/move_check/typing/continue_any_type.exp
@@ -2,15 +2,7 @@ error:
 
    ┌── tests/move_check/typing/continue_any_type.move:6:17 ───
    │
- 6 │             0 + continue;
+ 6 │             foo(continue)
    │                 ^^^^^^^^ Invalid use of a divergent expression. The code following the evaluation of this expression will be dead and should be removed. In some cases, this is necessary to prevent unused resource values.
    │
-
-error: 
-
-    ┌── tests/move_check/typing/continue_any_type.move:12:17 ───
-    │
- 12 │             foo(continue)
-    │                 ^^^^^^^^ Invalid use of a divergent expression. The code following the evaluation of this expression will be dead and should be removed. In some cases, this is necessary to prevent unused resource values.
-    │
 

--- a/language/move-lang/tests/move_check/typing/continue_any_type.move
+++ b/language/move-lang/tests/move_check/typing/continue_any_type.move
@@ -1,12 +1,6 @@
 module M {
     resource struct Coin {}
 
-    t0() {
-        while (true) {
-            0 + continue;
-        }
-    }
-
     t1() {
         while (true) {
             foo(continue)


### PR DESCRIPTION
"break" and "continue" can be treated like "return" and "abort".
There is no reason to support things like "0 + break".

## Motivation

Allowing break and continue as expression terms lets some strange inputs get through the parser: "&break", "-continue", "*break", "break.f", etc. Later phases of the compiler report error messages but they don't always make sense. It is better to be more restrictive about what gets parsed.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

Adjusted tests to remove expressions that are no longer supported.