### PR TITLE
[storage] rename should_exist to should_exist_vec in schemadb test

### DIFF
--- a/storage/schemadb/tests/db.rs
+++ b/storage/schemadb/tests/db.rs
@@ -166,15 +166,15 @@ proptest! {
         for i in 0..100u32 {
             db.put::<TestSchema1>(&TestField(i), &TestField(i)).unwrap();
         }
-        let mut should_exist = [true; 100];
+        let mut should_exist_vec = [true; 100];
         for (begin, end) in ranges_to_delete {
             db.range_delete::<TestSchema1, TestField>(&TestField(begin), &TestField(end)).unwrap();
             for i in begin..end {
-                should_exist[i as usize] = false;
+                should_exist_vec[i as usize] = false;
             }
         }
 
-        for (i, should_exist) in should_exist.iter().enumerate() {
+        for (i, should_exist) in should_exist_vec.iter().enumerate() {
             assert_eq!(
                 db.get::<TestSchema1>(&TestField(i as u32)).unwrap().is_some(),
                 *should_exist,


### PR DESCRIPTION
<!--
Thank you for sending a PR. We appreciate you spending time to help improve the Libra project.

The project is undergoing daily changes. Pull Requests will be reviewed and responded to as time permits.
-->

## Motivation

rename should_exist to should_exists to avoid name collision.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?

Yes.

## Test Plan

cargo xtest

## Related PRs

(If this PR adds or changes functionality, please take some time to update the docs at https://github.com/libra/website, and link to your PR here.)
