### PR TITLE
[consensus-types] Remove dependency on networking

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -816,7 +816,6 @@ dependencies = [
  "libra-crypto-derive 0.1.0",
  "libra-types 0.1.0",
  "mirai-annotations 1.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "network 0.1.0",
  "proptest 0.9.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.101 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/consensus/consensus-types/Cargo.toml
+++ b/consensus/consensus-types/Cargo.toml
@@ -18,7 +18,6 @@ lcs = { path = "../../common/lcs", version = "0.1.0", package = "libra-canonical
 libra-crypto = { path = "../../crypto/crypto", version = "0.1.0" }
 libra-crypto-derive = { path = "../../crypto/crypto-derive", version = "0.1.0" }
 executor = { path = "../../executor", version = "0.1.0" }
-network = { path = "../../network", version = "0.1.0" }
 libra-types = { path = "../../types", version = "0.1.0" }
 
 [dev-dependencies]

--- a/consensus/consensus-types/src/block.rs
+++ b/consensus/consensus-types/src/block.rs
@@ -22,7 +22,6 @@ use mirai_annotations::debug_checked_verify_eq;
 use serde::{de::DeserializeOwned, Deserialize, Deserializer, Serialize};
 use std::{
     collections::BTreeMap,
-    convert::TryFrom,
     fmt::{Display, Formatter},
 };
 
@@ -285,30 +284,6 @@ where
             "Block id mismatch the hash"
         );
         Ok(())
-    }
-}
-
-impl<T> TryFrom<network::proto::Block> for Block<T>
-where
-    T: DeserializeOwned + Serialize,
-{
-    type Error = anyhow::Error;
-
-    fn try_from(proto: network::proto::Block) -> anyhow::Result<Self> {
-        Ok(lcs::from_bytes(&proto.bytes)?)
-    }
-}
-
-impl<T> TryFrom<Block<T>> for network::proto::Block
-where
-    T: Serialize + Default + PartialEq,
-{
-    type Error = anyhow::Error;
-
-    fn try_from(block: Block<T>) -> anyhow::Result<Self> {
-        Ok(Self {
-            bytes: lcs::to_bytes(&block)?,
-        })
     }
 }
 

--- a/consensus/consensus-types/src/block_retrieval.rs
+++ b/consensus/consensus-types/src/block_retrieval.rs
@@ -6,7 +6,6 @@ use anyhow::ensure;
 use libra_crypto::hash::HashValue;
 use libra_types::crypto_proxies::ValidatorVerifier;
 use serde::{Deserialize, Serialize};
-use std::convert::TryFrom;
 use std::fmt;
 
 /// RPC to get a chain of block of the given length starting from the given block id.
@@ -38,24 +37,6 @@ impl fmt::Display for BlockRetrievalRequest {
             "[BlockRetrievalRequest starting from id {} with {} blocks]",
             self.block_id, self.num_blocks
         )
-    }
-}
-
-impl TryFrom<network::proto::RequestBlock> for BlockRetrievalRequest {
-    type Error = anyhow::Error;
-
-    fn try_from(proto: network::proto::RequestBlock) -> anyhow::Result<Self> {
-        Ok(lcs::from_bytes(&proto.bytes)?)
-    }
-}
-
-impl TryFrom<BlockRetrievalRequest> for network::proto::RequestBlock {
-    type Error = anyhow::Error;
-
-    fn try_from(block_retrieval_request: BlockRetrievalRequest) -> anyhow::Result<Self> {
-        Ok(Self {
-            bytes: lcs::to_bytes(&block_retrieval_request)?,
-        })
     }
 }
 
@@ -139,23 +120,5 @@ impl<T: Payload> fmt::Display for BlockRetrievalResponse<T> {
             }
             _ => write!(f, "[BlockRetrievalResponse: status: {:?}", self.status()),
         }
-    }
-}
-
-impl<T: Payload> TryFrom<network::proto::RespondBlock> for BlockRetrievalResponse<T> {
-    type Error = anyhow::Error;
-
-    fn try_from(proto: network::proto::RespondBlock) -> anyhow::Result<Self> {
-        Ok(lcs::from_bytes(&proto.bytes)?)
-    }
-}
-
-impl<T: Payload> TryFrom<BlockRetrievalResponse<T>> for network::proto::RespondBlock {
-    type Error = anyhow::Error;
-
-    fn try_from(block_retrieval_response: BlockRetrievalResponse<T>) -> anyhow::Result<Self> {
-        Ok(Self {
-            bytes: lcs::to_bytes(&block_retrieval_response)?,
-        })
     }
 }

--- a/consensus/consensus-types/src/epoch_retrieval.rs
+++ b/consensus/consensus-types/src/epoch_retrieval.rs
@@ -2,29 +2,10 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use serde::{Deserialize, Serialize};
-use std::convert::TryFrom;
 
 /// Request to get a ValidatorChangeProof from current_epoch to target_epoch
 #[derive(Serialize, Deserialize)]
 pub struct EpochRetrievalRequest {
     pub start_epoch: u64,
     pub end_epoch: u64,
-}
-
-impl TryFrom<network::proto::RequestEpoch> for EpochRetrievalRequest {
-    type Error = anyhow::Error;
-
-    fn try_from(proto: network::proto::RequestEpoch) -> anyhow::Result<Self> {
-        Ok(lcs::from_bytes(&proto.bytes)?)
-    }
-}
-
-impl TryFrom<EpochRetrievalRequest> for network::proto::RequestEpoch {
-    type Error = anyhow::Error;
-
-    fn try_from(epoch_retrieval_request: EpochRetrievalRequest) -> anyhow::Result<Self> {
-        Ok(Self {
-            bytes: lcs::to_bytes(&epoch_retrieval_request)?,
-        })
-    }
 }

--- a/consensus/consensus-types/src/sync_info.rs
+++ b/consensus/consensus-types/src/sync_info.rs
@@ -5,12 +5,8 @@ use crate::{common::Round, quorum_cert::QuorumCert, timeout_certificate::Timeout
 use anyhow::{ensure, Context};
 use libra_types::block_info::BlockInfo;
 use libra_types::crypto_proxies::ValidatorVerifier;
-use network;
 use serde::{Deserialize, Serialize};
-use std::{
-    convert::TryFrom,
-    fmt::{Display, Formatter},
-};
+use std::fmt::{Display, Formatter};
 
 #[derive(Deserialize, Serialize, Clone, Debug, Eq, PartialEq)]
 /// This struct describes basic synchronization metadata.
@@ -116,23 +112,5 @@ impl SyncInfo {
 
     pub fn epoch(&self) -> u64 {
         self.highest_quorum_cert.certified_block().epoch()
-    }
-}
-
-impl TryFrom<network::proto::SyncInfo> for SyncInfo {
-    type Error = anyhow::Error;
-
-    fn try_from(proto: network::proto::SyncInfo) -> anyhow::Result<Self> {
-        Ok(lcs::from_bytes(&proto.bytes)?)
-    }
-}
-
-impl TryFrom<SyncInfo> for network::proto::SyncInfo {
-    type Error = anyhow::Error;
-
-    fn try_from(info: SyncInfo) -> anyhow::Result<Self> {
-        Ok(Self {
-            bytes: lcs::to_bytes(&info)?,
-        })
     }
 }

--- a/consensus/consensus-types/src/vote_msg.rs
+++ b/consensus/consensus-types/src/vote_msg.rs
@@ -5,12 +5,7 @@ use crate::{sync_info::SyncInfo, vote::Vote};
 use anyhow::ensure;
 use libra_types::crypto_proxies::ValidatorVerifier;
 use serde::{Deserialize, Serialize};
-#[cfg(any(test, feature = "fuzzing"))]
-use std::convert::TryInto;
-use std::{
-    convert::TryFrom,
-    fmt::{Display, Formatter},
-};
+use std::fmt::{Display, Formatter};
 
 /// VoteMsg is the struct that is ultimately sent by the voter in response for
 /// receiving a proposal.
@@ -58,35 +53,5 @@ impl VoteMsg {
         // it. This way we avoid verifying O(n) SyncInfo messages while aggregating the votes
         // (O(n^2) signature verifications).
         self.vote().verify(validator)
-    }
-}
-
-#[cfg(any(test, feature = "fuzzing"))]
-impl TryFrom<network::proto::ConsensusMsg> for VoteMsg {
-    type Error = anyhow::Error;
-
-    fn try_from(proto: network::proto::ConsensusMsg) -> anyhow::Result<Self> {
-        match proto.message {
-            Some(network::proto::ConsensusMsg_oneof::VoteMsg(vote_msg)) => vote_msg.try_into(),
-            _ => anyhow::bail!("Missing vote"),
-        }
-    }
-}
-
-impl TryFrom<network::proto::VoteMsg> for VoteMsg {
-    type Error = anyhow::Error;
-
-    fn try_from(proto: network::proto::VoteMsg) -> anyhow::Result<Self> {
-        Ok(lcs::from_bytes(&proto.bytes)?)
-    }
-}
-
-impl TryFrom<VoteMsg> for network::proto::VoteMsg {
-    type Error = anyhow::Error;
-
-    fn try_from(vote_msg: VoteMsg) -> anyhow::Result<Self> {
-        Ok(Self {
-            bytes: lcs::to_bytes(&vote_msg)?,
-        })
     }
 }

--- a/consensus/consensus-types/src/vote_proposal.rs
+++ b/consensus/consensus-types/src/vote_proposal.rs
@@ -2,14 +2,10 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::{accumulator_extension_proof::AccumulatorExtensionProof, block::Block};
-use anyhow::{Error, Result};
 use libra_crypto::hash::TransactionAccumulatorHasher;
 use libra_types::crypto_proxies::ValidatorSet;
-use serde::{de::DeserializeOwned, Deserialize, Serialize};
-use std::{
-    convert::TryFrom,
-    fmt::{Display, Formatter},
-};
+use serde::{Deserialize, Serialize};
+use std::fmt::{Display, Formatter};
 
 /// This structure contains all the information needed by safety rules to
 /// evaluate a proposal / block for correctness / safety and to produce a Vote.
@@ -56,29 +52,5 @@ impl<T> VoteProposal<T> {
 impl<T: PartialEq> Display for VoteProposal<T> {
     fn fmt(&self, f: &mut Formatter) -> std::fmt::Result {
         write!(f, "VoteProposal[block: {}]", self.block,)
-    }
-}
-
-impl<T> TryFrom<VoteProposal<T>> for network::proto::VoteProposal
-where
-    T: Serialize + Default + PartialEq,
-{
-    type Error = Error;
-
-    fn try_from(vote_proposal: VoteProposal<T>) -> Result<Self> {
-        Ok(Self {
-            bytes: lcs::to_bytes(&vote_proposal)?,
-        })
-    }
-}
-
-impl<T> TryFrom<network::proto::VoteProposal> for VoteProposal<T>
-where
-    T: DeserializeOwned + Serialize,
-{
-    type Error = Error;
-
-    fn try_from(proto: network::proto::VoteProposal) -> Result<Self> {
-        Ok(lcs::from_bytes(&proto.bytes)?)
     }
 }

--- a/consensus/src/chained_bft/block_storage/sync_manager.rs
+++ b/consensus/src/chained_bft/block_storage/sync_manager.rs
@@ -76,7 +76,7 @@ impl<T: Payload> BlockStore<T> {
     pub async fn sync_to(
         &self,
         sync_info: &SyncInfo,
-        mut retriever: BlockRetriever,
+        mut retriever: BlockRetriever<T>,
     ) -> anyhow::Result<()> {
         self.process_highest_commit_cert(sync_info.highest_commit_cert().clone(), &mut retriever)
             .await?;
@@ -101,7 +101,7 @@ impl<T: Payload> BlockStore<T> {
     async fn fetch_quorum_cert(
         &self,
         qc: QuorumCert,
-        mut retriever: BlockRetriever,
+        mut retriever: BlockRetriever<T>,
     ) -> anyhow::Result<()> {
         let mut pending = vec![];
         let mut retrieve_qc = qc.clone();
@@ -135,7 +135,7 @@ impl<T: Payload> BlockStore<T> {
     async fn process_highest_commit_cert(
         &self,
         highest_commit_cert: QuorumCert,
-        retriever: &mut BlockRetriever,
+        retriever: &mut BlockRetriever<T>,
     ) -> anyhow::Result<()> {
         if !self.need_sync_for_quorum_cert(&highest_commit_cert) {
             return Ok(());
@@ -168,7 +168,7 @@ impl<T: Payload> BlockStore<T> {
 
     pub async fn fast_forward_sync(
         highest_commit_cert: &QuorumCert,
-        retriever: &mut BlockRetriever,
+        retriever: &mut BlockRetriever<T>,
     ) -> anyhow::Result<(Vec<Block<T>>, Vec<QuorumCert>)> {
         debug!(
             "Start state sync with peer: {}, to block: {}",
@@ -193,14 +193,14 @@ impl<T: Payload> BlockStore<T> {
 }
 
 /// BlockRetriever is used internally to retrieve blocks
-pub struct BlockRetriever {
-    network: NetworkSender,
+pub struct BlockRetriever<T> {
+    network: NetworkSender<T>,
     deadline: Instant,
     preferred_peer: Author,
 }
 
-impl BlockRetriever {
-    pub fn new(network: NetworkSender, deadline: Instant, preferred_peer: Author) -> Self {
+impl<T: Payload> BlockRetriever<T> {
+    pub fn new(network: NetworkSender<T>, deadline: Instant, preferred_peer: Author) -> Self {
         Self {
             network,
             deadline,
@@ -219,14 +219,11 @@ impl BlockRetriever {
     /// leader to drive quorum certificate creation The other peers from the quorum certificate
     /// will be randomly tried next.  If all members of the quorum certificate are exhausted, an
     /// error is returned
-    async fn retrieve_block_for_qc<'a, T>(
+    async fn retrieve_block_for_qc<'a>(
         &'a mut self,
         qc: &'a QuorumCert,
         num_blocks: u64,
-    ) -> anyhow::Result<Vec<Block<T>>>
-    where
-        T: Payload,
-    {
+    ) -> anyhow::Result<Vec<Block<T>>> {
         let block_id = qc.certified_block().id();
         let mut peers: Vec<&AccountAddress> = qc.ledger_info().signatures().keys().collect();
         let mut attempt = 0_u32;

--- a/network/src/proto/consensus.proto
+++ b/network/src/proto/consensus.proto
@@ -7,30 +7,4 @@ package consensus;
 
 import "validator_change.proto";
 
-message ConsensusMsg {
-  oneof message {
-    Proposal proposal = 1;
-    VoteMsg vote_msg = 2;
-    RequestBlock request_block = 3;
-    RespondBlock respond_block = 4;
-    SyncInfo sync_info = 5;
-    types.ValidatorChangeProof epoch_change = 6;
-    RequestEpoch request_epoch = 7;
-  }
-}
-
-message Proposal { bytes bytes = 1; }
-
-message SyncInfo { bytes bytes = 1; }
-
-message Block { bytes bytes = 1; }
-
-message VoteMsg { bytes bytes = 1; }
-
-message VoteProposal { bytes bytes = 1; }
-
-message RequestBlock { bytes bytes = 1; }
-
-message RespondBlock { bytes bytes = 1; }
-
-message RequestEpoch { bytes bytes = 1; }
+message ConsensusMsg { bytes message = 1; }

--- a/network/src/proto/mod.rs
+++ b/network/src/proto/mod.rs
@@ -24,10 +24,7 @@ mod health_checker {
 use ::libra_types::proto::types;
 
 pub use self::{
-    consensus::{
-        consensus_msg::Message as ConsensusMsg_oneof, Block, ConsensusMsg, Proposal, RequestBlock,
-        RequestEpoch, RespondBlock, SyncInfo, VoteMsg, VoteProposal,
-    },
+    consensus::ConsensusMsg,
     health_checker::{
         health_checker_msg::Message as HealthCheckerMsg_oneof, HealthCheckerMsg, Ping, Pong,
     },

--- a/types/src/validator_change.rs
+++ b/types/src/validator_change.rs
@@ -8,10 +8,11 @@ use crate::waypoint::Waypoint;
 use anyhow::{ensure, format_err, Error, Result};
 #[cfg(any(test, feature = "fuzzing"))]
 use proptest::{collection::vec, prelude::*};
+use serde::{Deserialize, Serialize};
 use std::convert::{TryFrom, TryInto};
 use std::sync::Arc;
 
-#[derive(Clone, Debug, Eq, PartialEq)]
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
 /// A vector of LedgerInfo with contiguous increasing epoch numbers to prove a sequence of
 /// validator changes from the first LedgerInfo's epoch.
 pub struct ValidatorChangeProof {


### PR DESCRIPTION
This removes consensus-types on networking by:
* Removing proto definitions from each type
* Changing the ConsensusMsg to contain only bytes
* Introducing a LCS enum to replace the now missing ConsensusMsg variants

Most of this commit is boilerplate code removal, here's how it was not:
* An LCS enum does not allow to easily convert between types
(ProposalMsg -> ProposalUncheckedSignatures), while it is possible, it
ends up with some ugly serde macro stuff and the LCS enum takes in a
ProposalUncheckedSignatures.
* The network still depends on a proto, so completely eliminating proto
on outgoing messages is impossible without more code refactor, hence
proto was left also on the input functions.

At this point the consensus networking code does not really do much and
the integration tests verify functionality that should already be
evaluated at a lower layer. It might be worth considering to remove the
tests.