### PR TITLE
[move-prover] Data invariants and synthetics (ghost variables).

### DIFF
--- a/language/compiler/ir-to-bytecode/syntax/src/syntax.rs
+++ b/language/compiler/ir-to-bytecode/syntax/src/syntax.rs
@@ -1615,10 +1615,24 @@ fn parse_invariant_<'input>(
     } else {
         String::new()
     };
+    // Check whether this invariant has the assignment form `invariant target = <expr>;`
+    let target = if tokens.peek() == Tok::NameValue {
+        // There must always be some token following (e.g. ;), so we can force lookahead.
+        if tokens.lookahead()? == Tok::Equal {
+            let name = parse_name(tokens)?;
+            consume_token(tokens, Tok::Equal)?;
+            Some(name)
+        } else {
+            None
+        }
+    } else {
+        None
+    };
     let condition = parse_spec_exp(tokens)?;
     Ok(Invariant_ {
         modifier,
-        condition,
+        target,
+        exp: condition,
     })
 }
 

--- a/language/move-ir/types/src/spec_language_ast.rs
+++ b/language/move-ir/types/src/spec_language_ast.rs
@@ -79,11 +79,14 @@ pub type Condition = Spanned<Condition_>;
 /// An invariant over a resource.
 #[derive(PartialEq, Debug, Clone)]
 pub struct Invariant_ {
-    // A free string (for now) which specifies the function of this invariant.
+    /// A free string (for now) which specifies the function of this invariant.
     pub modifier: String,
 
-    // A specification expressions
-    pub condition: SpecExp,
+    /// An optional synthetic variable to which the below expression is assigned to.
+    pub target: Option<String>,
+
+    /// A specification expression.
+    pub exp: SpecExp,
 }
 
 /// Invariant with span.

--- a/language/move-prover/bytecode-to-boogie/src/cli.rs
+++ b/language/move-prover/bytecode-to-boogie/src/cli.rs
@@ -61,6 +61,14 @@ pub struct Options {
     pub minimize_execution_trace: bool,
     /// Whether to omit debug information in generated model.
     pub omit_model_debug: bool,
+    /// The model use for invariant enforcement.
+    pub invariant_model: InvariantModel,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum InvariantModel {
+    LifetimeBased,
+    WriteRefBased,
 }
 
 impl Default for Options {
@@ -79,6 +87,7 @@ impl Default for Options {
             native_stubs: false,
             minimize_execution_trace: true,
             omit_model_debug: false,
+            invariant_model: InvariantModel::LifetimeBased,
         }
     }
 }
@@ -132,6 +141,13 @@ impl Options {
                 Arg::with_name("omit-model-debug")
                     .long("omit-model-debug")
                     .help("whether to omit code for model debugging"),
+            )
+            .arg(
+                Arg::with_name("invariant-model")
+                    .long("invariant-model")
+                    .possible_values(&["lifetime", "writeref"])
+                    .default_value("lifetime")
+                    .help("invariant enforcement model used"),
             )
             .arg(
                 Arg::with_name("boogie-exe")
@@ -208,6 +224,11 @@ impl Options {
         self.generate_only = matches.is_present("generate-only");
         self.native_stubs = matches.is_present("native-stubs");
         self.omit_model_debug = matches.is_present("omit-model-debug");
+        self.invariant_model = match get_with_default("invariant-model").as_str() {
+            "lifetime" => InvariantModel::LifetimeBased,
+            "writeref" => InvariantModel::WriteRefBased,
+            _ => unreachable!("should not happen"),
+        };
         self.use_cvc4 = matches.is_present("use-cvc4");
         self.boogie_exe = get_with_default("boogie-exe");
         self.z3_exe = get_with_default("z3-exe");

--- a/language/move-prover/bytecode-to-boogie/src/code_writer.rs
+++ b/language/move-prover/bytecode-to-boogie/src/code_writer.rs
@@ -65,9 +65,10 @@ impl CodeWriter {
     /// Sets the current location. This location will be associated with all subsequently written
     /// code so we can map back from the generated code to this location. If current module or loc
     /// is already the passed one, nothing will be updated, so it is ok to call this method
-    /// repeatedly with the same values.
-    pub fn set_location(&self, module: ModuleIndex, loc: Loc) {
+    /// repeatedly with the same values. Returns the old location.
+    pub fn set_location(&self, module: ModuleIndex, loc: Loc) -> (ModuleIndex, Loc) {
         let mut data = self.0.borrow_mut();
+        let old = (data.current_module, data.current_location);
         let code_at = ByteIndex(data.output.len() as u32);
         if data.current_module != module {
             data.output_module_map.insert(code_at, module);
@@ -77,6 +78,7 @@ impl CodeWriter {
             data.output_location_map.insert(code_at, loc);
             data.current_location = loc;
         }
+        old
     }
 
     /// Given a byte index in the written output, return the best approximation of the source

--- a/language/move-prover/bytecode-to-boogie/src/spec_translator.rs
+++ b/language/move-prover/bytecode-to-boogie/src/spec_translator.rs
@@ -3,6 +3,9 @@
 
 //! This module translates specification conditions to Boogie code.
 
+use std::cell::RefCell;
+use std::collections::{BTreeMap, LinkedList};
+
 use itertools::Itertools;
 use num::{BigInt, Num};
 
@@ -10,75 +13,178 @@ use libra_types::account_address::AccountAddress;
 use move_ir_types::ast::{BinOp, CopyableVal_, Field_, Loc, QualifiedStructIdent, Type};
 use move_ir_types::spec_language_ast::{Condition_, SpecExp, StorageLocation};
 
-use crate::boogie_helpers::{boogie_field_name, boogie_type_value};
+use crate::boogie_helpers::{
+    boogie_field_name, boogie_struct_name, boogie_struct_type_value, boogie_synthetic_name,
+    boogie_type_check_expr, boogie_type_value,
+};
 use crate::code_writer::CodeWriter;
-use crate::env::{FunctionEnv, GlobalType, Parameter};
-use codespan_reporting::{Diagnostic, Label};
+use crate::env::{
+    FunctionEnv, GlobalType, ModuleEnv, ModuleIndex, StructEnv, TypeParameter, ERROR_TYPE,
+    UNKNOWN_TYPE,
+};
 
 pub struct SpecTranslator<'env> {
-    func_env: &'env FunctionEnv<'env>,
+    /// The module in which context translation happens.
+    module_env: &'env ModuleEnv<'env>,
+    /// The code writer.
     writer: &'env CodeWriter,
-    current_loc: Loc, // Location used for type checking errors
+    // Location for reporting type checking errors
+    current_loc: RefCell<Loc>,
+    /// A symbol table for looking up names. The first element in the list contains the most
+    /// inner scope.
+    symtab: RefCell<LinkedList<SymTabScope>>,
+    /// Whether we are currently in the context of translating an `old(...)` expression.
+    in_old: RefCell<bool>,
+    /// Type parameters for resolving AST types in expressions.
+    type_parameters: Vec<TypeParameter>,
+    /// Whether the translation context supports the `old` expressions (i.e. is a Boogie
+    /// pre/post condition)
+    supports_native_old: bool,
 }
 
-/// Represents a boogie expression as a string and its type. The type is used to access
-/// necessary context information for generating boogie expressions, as well as for type
-/// checking.
-struct BoogieExpr(String, GlobalType);
+/// A key for the symbol table. Consists of a name and whether the name lookup appears within an
+/// `old(...)` context.
+type SymTabKey = (String, bool);
 
-impl BoogieExpr {
-    fn result(self) -> String {
-        self.0
-    }
-}
+/// A scope for the symbol table.
+type SymTabScope = BTreeMap<SymTabKey, BoogieExpr>;
 
-/// A dummy type to represent an error. We use a type parameter for this, with an index
-/// which no one will/can ever realistically use.
-const ERROR_TYPE: GlobalType = GlobalType::TypeParameter(std::u16::MAX);
-
-/// A dummy type to represent an unknown type. We use a type parameter for this, with an index
-/// which no one will/can ever realistically use. We currently need this to support a hack
-/// for specification helper functions (SpecExp::Call) whose type we do not know, and which
-/// are defined in Boogie.
-const UNKNOWN_TYPE: GlobalType = GlobalType::TypeParameter(std::u16::MAX - 1);
+// General
+// =======
 
 impl<'env> SpecTranslator<'env> {
+    /// Creates a translator.
     pub fn new(
-        func_env: &'env FunctionEnv<'env>,
         writer: &'env CodeWriter,
+        module_env: &'env ModuleEnv<'env>,
+        type_parameters: Vec<TypeParameter>,
+        supports_native_old: bool,
     ) -> SpecTranslator<'env> {
         SpecTranslator {
-            func_env,
+            module_env,
             writer,
-            current_loc: Loc::default(),
+            current_loc: RefCell::new(Loc::default()),
+            symtab: RefCell::new(LinkedList::new()),
+            in_old: RefCell::new(false),
+            type_parameters,
+            supports_native_old,
         }
     }
 
     /// Reports a type checking error.
-    pub fn error<T>(&self, msg: &str, pass_through: T) -> T {
-        let diag = Diagnostic::new_error(msg).with_label(Label::new_primary(self.current_loc));
-        self.func_env.module_env.add_diag(diag);
-        pass_through
+    fn error<T>(&self, msg: &str, pass_through: T) -> T {
+        self.module_env
+            .error(*self.current_loc.borrow(), msg, pass_through)
+    }
+
+    /// Returns an error expression.
+    fn error_exp(&self) -> BoogieExpr {
+        BoogieExpr("<error>".to_string(), ERROR_TYPE)
     }
 
     /// Helper to update the current location. This is both used for informing the `error` function
     /// above for type checking errors and the CodeWriter for being able to map boogie errors
     /// back to the source.
-    fn update_location(&mut self, loc: Loc) {
-        self.current_loc = loc;
+    fn update_location(&self, loc: Loc) -> (ModuleIndex, Loc) {
+        *self.current_loc.borrow_mut() = loc;
         self.writer
-            .set_location(self.func_env.module_env.get_module_idx(), loc);
+            .set_location(self.module_env.get_module_idx(), loc)
     }
 
-    /// Generates a boogie containing pre/post conditions.
-    pub fn translate(&mut self) {
+    /// Restore the saved location from a previous saved one.
+    fn restore_saved_location(&self, saved: (ModuleIndex, Loc)) {
+        // This is only for the writer.
+        self.writer.set_location(saved.0, saved.1);
+    }
+
+    /// Enters a new scope in the symbol table.
+    fn enter_scope(&self) {
+        self.symtab.borrow_mut().push_front(SymTabScope::new());
+    }
+
+    /// Exists the most inner scope of the symbol table.
+    fn exit_scope(&self) {
+        self.symtab.borrow_mut().pop_front();
+    }
+
+    /// Defines a symbol in the most inner scope. This produces an error
+    /// if the name already exists.
+    fn define_symbol(&self, name: &str, for_old: bool, def: BoogieExpr) {
+        if self
+            .symtab
+            .borrow_mut()
+            .front_mut()
+            .expect("symbol table empty")
+            .insert((name.to_string(), for_old), def)
+            .is_some()
+        {
+            self.error(&format!("duplicate declaration of `{}`", name), ())
+        }
+    }
+
+    /// Looks up a name in the symbol table. This produces an error and returns an error expression
+    /// if the name is not defined. Iterates the scopes of the symbol table inner-most out.
+    fn lookup_symbol(&self, name: &str, for_old: bool) -> BoogieExpr {
+        let key = (name.to_string(), for_old);
+        for scope in &*self.symtab.borrow() {
+            if let Some(exp) = scope.get(&key) {
+                return exp.clone();
+            }
+        }
+        if for_old {
+            // Try to lookup the plain symbol as no old version of it exists.
+            self.lookup_symbol(name, false)
+        } else {
+            self.error(&format!("undeclared name `{}`", name), self.error_exp())
+        }
+    }
+
+    /// Populates the symbol table with the synthetics of the module.
+    fn define_synthetics(&self) {
+        for (syn, ty) in self.module_env.get_synthetics() {
+            self.define_symbol(
+                syn.name.as_str(),
+                false,
+                BoogieExpr(
+                    boogie_synthetic_name(self.module_env, syn.name.as_str()),
+                    ty.clone(),
+                ),
+            );
+        }
+    }
+}
+
+// Pre/Post Conditions
+// ===================
+
+impl<'env> SpecTranslator<'env> {
+    /// Generates boogie for pre/post conditions. The SpecTranslator must be
+    /// targeted for conditions.
+    pub fn translate_conditions(&self, func_env: &'env FunctionEnv<'env>) {
+        // Populate the symbol table.
+        self.enter_scope();
+        self.define_synthetics();
+        self.enter_scope(); // Parameter names shadow synthetic names
+        for param in &func_env.get_parameters() {
+            self.define_symbol(
+                param.0.as_str(),
+                false,
+                BoogieExpr(param.0.to_string(), param.1.clone()),
+            );
+        }
+        for (i, ty) in func_env.get_return_types().iter().enumerate() {
+            let name = &format!("__ret{}", i);
+            self.define_symbol(name, false, BoogieExpr(name.clone(), ty.clone()));
+        }
+
         // Generate pre-conditions
         // For this transaction to be executed, it MUST have had
         // a valid signature for the sender's account. Therefore,
         // the senders account resource (which contains the pubkey)
         // must have existed! So we can assume txn_sender account
         // exists in pre-condition.
-        for cond in self.func_env.get_specification() {
+        let conds = func_env.get_specification();
+        for cond in conds {
             if let Condition_::Requires(expr) = &cond.value {
                 self.update_location(cond.span);
                 emitln!(
@@ -93,9 +199,7 @@ impl<'env> SpecTranslator<'env> {
         // Generate succeeds_if and aborts_if setup (for post conditions)
 
         // When all succeeds_if conditions hold, function must not abort.
-        let mut succeeds_if_string = self
-            .func_env
-            .get_specification()
+        let mut succeeds_if_string = conds
             .iter()
             .filter_map(|c| match &c.value {
                 Condition_::SucceedsIf(expr) => {
@@ -108,9 +212,7 @@ impl<'env> SpecTranslator<'env> {
 
         // abort_if P means function MUST abort if P holds.
         // multiple abort_if conditions are "or"ed.
-        let aborts_if_string = self
-            .func_env
-            .get_specification()
+        let aborts_if_string = conds
             .iter()
             .filter_map(|c| match &c.value {
                 Condition_::AbortsIf(expr) => {
@@ -139,7 +241,7 @@ impl<'env> SpecTranslator<'env> {
         }
 
         // Generate explicit ensures conditions
-        for cond in self.func_env.get_specification() {
+        for cond in conds {
             if let Condition_::Ensures(expr) = &cond.value {
                 // FIXME: Do we really need to check whether succeeds_if & aborts_if are
                 // empty, below?
@@ -177,11 +279,330 @@ impl<'env> SpecTranslator<'env> {
             );
         }
     }
+}
 
+/// Invariants
+/// ==========
+
+impl<'env> SpecTranslator<'env> {
+    /// Emitting invariant functions
+    /// ----------------------------
+
+    /// Emits functions amd procedures for needed for invariants.
+    pub fn translate_invariant_functions(&self, struct_env: &StructEnv<'env>) {
+        self.enter_scope();
+        self.define_synthetics();
+        self.translate_assume_well_formed(struct_env);
+        self.translate_update_invariant(struct_env);
+        self.exit_scope();
+    }
+
+    /// Separates elements in vector, dropping empty ones.
+    /// Generates a function which assumes the struct to be well-formed. This generates
+    /// both type assumptions for each field and assumptions of the data invariants.
+    fn translate_assume_well_formed(&self, struct_env: &StructEnv<'env>) {
+        emitln!(
+            self.writer,
+            "function {{:inline 1}} ${}_is_well_formed(__this: Value): bool {{",
+            boogie_struct_name(struct_env),
+        );
+        self.writer.indent();
+        self.enter_scope();
+        self.define_invariant_symbols(struct_env, "__this", false);
+        let mut assumptions = vec![];
+
+        // Emit type assumptions.
+        assumptions.push("is#Vector(__this)".to_string());
+        for field in struct_env.get_fields() {
+            let select = format!("SelectField(__this, {})", boogie_field_name(&field));
+            let type_check =
+                boogie_type_check_expr(struct_env.module_env.env, &select, &field.get_type());
+            if !type_check.is_empty() {
+                assumptions.push(type_check);
+            }
+        }
+
+        // Emit invariant assumptions.
+        for inv in struct_env.get_data_invariants() {
+            if inv.target.is_some() {
+                self.error("a data invariant cannot have a synthetic assignment", ());
+            }
+            let cond = self.translate_expr_require_type(&inv.exp, &GlobalType::Bool);
+            assumptions.push(format!("b#Boolean({})", cond));
+        }
+
+        emitln!(self.writer, &assumptions.iter().join("\n    && "));
+        self.exit_scope();
+        self.writer.unindent();
+        emitln!(self.writer, "}");
+        emitln!(self.writer);
+    }
+
+    /// Generates a procedure which asserts the update invariants of the struct.
+    ///
+    pub fn translate_update_invariant(&self, struct_env: &StructEnv<'env>) {
+        if struct_env.get_update_invariants().is_empty() {
+            return;
+        }
+        emitln!(
+            self.writer,
+            "procedure {{:inline 1}} ${}_update_inv(__before: Value, __after: Value) {{",
+            boogie_struct_name(struct_env)
+        );
+        self.writer.indent();
+
+        // Emit update assertions.
+        self.enter_scope();
+        self.define_invariant_symbols(struct_env, "__before", true);
+        self.define_invariant_symbols(struct_env, "__after", false);
+        for inv in struct_env.get_update_invariants() {
+            let saved = self.update_location(inv.span);
+            if let Some(syn_name) = &inv.target {
+                let syn_ty = self.get_synthetic_type(struct_env, syn_name);
+                // Assignment to a synthetic variable.
+                let value = self.translate_expr_require_type(&inv.exp, &syn_ty);
+                emitln!(
+                    self.writer,
+                    "{} := {};",
+                    boogie_synthetic_name(&struct_env.module_env, syn_name),
+                    value
+                );
+            } else {
+                // Delta invariant
+                let cond = self.translate_expr_require_type(&inv.exp, &GlobalType::Bool);
+                emitln!(self.writer, &format!("assert b#Boolean({});", cond));
+            }
+            self.restore_saved_location(saved);
+        }
+        self.exit_scope();
+
+        // Emmit data assertions.
+        self.enter_scope();
+        self.define_invariant_symbols(struct_env, "__after", false);
+        for inv in struct_env.get_data_invariants() {
+            let saved = self.update_location(inv.span);
+            if inv.target.is_some() {
+                self.error("a data invariant cannot have a synthetic assignment", ());
+            }
+            let cond = self.translate_expr_require_type(&inv.exp, &GlobalType::Bool);
+            emitln!(self.writer, &format!("assert b#Boolean({});", cond));
+            self.restore_saved_location(saved);
+        }
+        self.exit_scope();
+
+        self.writer.unindent();
+        emitln!(self.writer, "}");
+        emitln!(self.writer);
+    }
+
+    /// Emits a sequence of statements which assert the pack invariants,
+    pub fn emit_pack_invariants(&self, struct_env: &StructEnv<'env>, target: &str) {
+        self.enter_scope();
+        self.define_synthetics();
+        self.enter_scope();
+        self.define_invariant_symbols(struct_env, target, false);
+
+        // TODO: should we assume type assumptions here instead of on callee side?
+
+        // Emmit data assertions.
+        for inv in struct_env.get_data_invariants() {
+            let saved = self.update_location(inv.span);
+            if inv.target.is_some() {
+                self.error("a data invariant cannot have a synthetic assignment", ());
+            }
+            let cond = self.translate_expr_require_type(&inv.exp, &GlobalType::Bool);
+            emitln!(self.writer, &format!("assert b#Boolean({});", cond));
+            self.restore_saved_location(saved);
+        }
+
+        // Emit synthetic variable updates.
+        for inv in struct_env.get_pack_invariants() {
+            self.update_location(inv.span);
+            if let Some(syn_name) = &inv.target {
+                let syn_ty = self.get_synthetic_type(struct_env, syn_name);
+                let value = self.translate_expr_require_type(&inv.exp, &syn_ty);
+                emitln!(
+                    self.writer,
+                    "{} := {};",
+                    boogie_synthetic_name(&struct_env.module_env, syn_name),
+                    value
+                );
+            } else {
+                self.error("a pack invariant must be assignment to synthetic", ());
+            }
+        }
+        self.exit_scope();
+        self.exit_scope();
+    }
+
+    /// Emits a sequence of statements which assert the unpack invariants.
+    pub fn emit_unpack_invariants(&self, struct_env: &StructEnv<'env>, target: &str) {
+        self.enter_scope();
+        self.define_synthetics();
+        self.enter_scope();
+        self.define_invariant_symbols(struct_env, target, false);
+        for inv in struct_env.get_unpack_invariants() {
+            let saved = self.update_location(inv.span);
+            if let Some(syn_name) = &inv.target {
+                let syn_ty = self.get_synthetic_type(struct_env, syn_name);
+                let value = self.translate_expr_require_type(&inv.exp, &syn_ty);
+                emitln!(
+                    self.writer,
+                    "{} := {};",
+                    boogie_synthetic_name(&struct_env.module_env, syn_name),
+                    value
+                );
+            } else {
+                self.error("an unpack invariant must be assignment to synthetic", ());
+            }
+            self.restore_saved_location(saved);
+        }
+        self.exit_scope();
+        self.exit_scope();
+    }
+
+    /// Looks up a synthetic and returns it type, or generates an error if not found.
+    fn get_synthetic_type(&self, struct_env: &StructEnv<'_>, name: &str) -> GlobalType {
+        if let Some((_, ty)) = struct_env.module_env.find_synthetic(name) {
+            ty.clone()
+        } else {
+            self.error(
+                &format!(
+                    "synthetic `{}` not declared in module `{}`",
+                    name,
+                    struct_env.module_env.get_id().name()
+                ),
+                ERROR_TYPE,
+            )
+        }
+    }
+
+    /// Defines symbols in the symbol table for invariant expression translation.
+    fn define_invariant_symbols(&self, struct_env: &StructEnv<'_>, value: &str, for_old: bool) {
+        for field in struct_env.get_fields() {
+            let name = field.get_name().as_str();
+            let ty = &field.get_type();
+            self.define_symbol(
+                name,
+                for_old,
+                BoogieExpr(
+                    format!("SelectField({}, {})", value, boogie_field_name(&field)),
+                    ty.clone(),
+                ),
+            );
+        }
+    }
+
+    /// Emitting invariant checks
+    /// -------------------------
+
+    /// Emits an update invariant check. `reaching_root_types` is the set of root types the
+    /// updated reference can have. A valid over-approximation is the the set of all structs
+    /// with update invariants in a program, but the update check will be more efficient for
+    /// larger programs if `reaching_root_types` is more specific than that.
+    pub fn emit_update_invariant_check(
+        &self,
+        target: &str,
+        before_value: &str,
+        after_value: &str,
+        reaching_root_types: &[GlobalType],
+    ) {
+        // Determine structs with invariants from the provided root types.
+        let structs = self.get_structs_which(reaching_root_types, |s| {
+            !s.get_update_invariants().is_empty()
+        });
+
+        for struct_env in structs {
+            // Generate:
+            //
+            //   if (RootType($target) == <struct1_type>) {
+            //      <struct1_update_invariant>($old_value, $value);
+            //   }
+            //   if (RootType($target) == <struct2_type>) {
+            //      <struct1_update_invariant>($old_value, $value);
+            //   }
+            //   ...
+            let boogie_type = boogie_struct_type_value(
+                self.module_env.env,
+                struct_env.module_env.get_module_idx(),
+                &struct_env.get_def_idx(),
+                &[],
+            );
+            emitln!(
+                self.writer,
+                "if (RootReferenceType({}) == {}) {{",
+                target,
+                boogie_type
+            );
+            self.writer.indent();
+            emitln!(
+                self.writer,
+                "call ${}_update_inv({}, {});",
+                boogie_struct_name(&struct_env),
+                before_value,
+                after_value
+            );
+            self.writer.unindent();
+            emitln!(self.writer, "}");
+        }
+    }
+
+    /// Determines whether an update invariant check is needed for the reaching root types.
+    pub fn needs_update_invariant_check(&self, reaching_root_types: &[GlobalType]) -> bool {
+        // TODO: may want to avoid collecting the structs first
+        let structs = self.get_structs_which(reaching_root_types, |s| {
+            !s.get_update_invariants().is_empty()
+        });
+        !structs.is_empty()
+    }
+
+    /// Gets the subset of structs in `cands` which satisfy a predicate.
+    fn get_structs_which<P>(&'env self, cands: &[GlobalType], p: P) -> Vec<StructEnv<'env>>
+    where
+        P: Fn(&StructEnv<'_>) -> bool,
+    {
+        cands
+            .iter()
+            .filter_map(|ty| {
+                if let GlobalType::Struct(module_idx, struct_idx, _) = ty {
+                    let struct_env = self
+                        .module_env
+                        .env
+                        .get_module(*module_idx)
+                        .into_get_struct(struct_idx);
+                    if p(&struct_env) {
+                        Some(struct_env)
+                    } else {
+                        None
+                    }
+                } else {
+                    None
+                }
+            })
+            .collect_vec()
+    }
+}
+
+// Expressions
+// ===========
+
+/// Represents a boogie expression as a string and its type. The type is used to access
+/// necessary context information for generating boogie expressions, as well as for type
+/// checking.
+#[derive(Debug, Clone)]
+struct BoogieExpr(String, GlobalType);
+
+impl BoogieExpr {
+    fn result(self) -> String {
+        self.0
+    }
+}
+
+impl<'env> SpecTranslator<'env> {
     /// Translates a specification expression into boogie.
     ///
     /// This returns a boogie expression of type Value or Reference.
-    fn translate_expr(&mut self, expr: &SpecExp) -> BoogieExpr {
+    fn translate_expr(&self, expr: &SpecExp) -> BoogieExpr {
         match expr {
             SpecExp::Constant(val) => self.translate_constant(val),
             SpecExp::StorageLocation(loc) => self.translate_location_as_value(loc),
@@ -216,8 +637,18 @@ impl<'env> SpecTranslator<'env> {
                 self.translate_binop(op, left, right)
             }
             SpecExp::Old(expr) => {
-                let BoogieExpr(s, t) = self.translate_expr(expr);
-                BoogieExpr(format!("old({})", s), t)
+                if *self.in_old.borrow() {
+                    self.error("cannot nest `old(_)`", self.error_exp())
+                } else {
+                    *self.in_old.borrow_mut() = true;
+                    let BoogieExpr(s, t) = self.translate_expr(expr);
+                    *self.in_old.borrow_mut() = false;
+                    if self.supports_native_old {
+                        BoogieExpr(format!("old({})", s), t)
+                    } else {
+                        BoogieExpr(s, t)
+                    }
+                }
             }
             SpecExp::Call(name, exprs) => BoogieExpr(
                 format!(
@@ -232,8 +663,15 @@ impl<'env> SpecTranslator<'env> {
         }
     }
 
+    /// Translate expression and expect it to be of given type.
+    fn translate_expr_require_type(&self, expr: &SpecExp, expected_type: &GlobalType) -> String {
+        let BoogieExpr(s, ty) = self.translate_expr(expr);
+        let _ = self.require_type(ty, expected_type);
+        s
+    }
+
     /// Translate a dereference.
-    fn translate_dref(&mut self, loc: &StorageLocation) -> BoogieExpr {
+    fn translate_dref(&self, loc: &StorageLocation) -> BoogieExpr {
         let BoogieExpr(s, t) = self.translate_location_as_reference(loc);
         if let GlobalType::Reference(sig) | GlobalType::MutableReference(sig) = t {
             BoogieExpr(format!("Dereference(__m, {})", s), *sig)
@@ -241,7 +679,7 @@ impl<'env> SpecTranslator<'env> {
             self.error(
                 &format!(
                     "expected reference type, found `{}`",
-                    boogie_type_value(self.func_env.module_env.env, &t)
+                    boogie_type_value(self.module_env.env, &t)
                 ),
                 BoogieExpr("<deref>".to_string(), ERROR_TYPE),
             )
@@ -249,7 +687,7 @@ impl<'env> SpecTranslator<'env> {
     }
 
     /// Translates a binary operator.
-    fn translate_binop(&mut self, op: &BinOp, left: BoogieExpr, right: BoogieExpr) -> BoogieExpr {
+    fn translate_binop(&self, op: &BinOp, left: BoogieExpr, right: BoogieExpr) -> BoogieExpr {
         let operand_type = left.1.clone();
         match op {
             // u64
@@ -326,7 +764,7 @@ impl<'env> SpecTranslator<'env> {
     /// Helper for translating a binary op with type check of arguments and unwrapping/wrapping
     /// Boogie values.
     fn translate_op_helper(
-        &mut self,
+        &self,
         op: &str,
         expected_operand_type: &GlobalType,
         result_type: GlobalType,
@@ -362,7 +800,7 @@ impl<'env> SpecTranslator<'env> {
     }
 
     /// Translates a constant.
-    fn translate_constant(&mut self, val: &CopyableVal_) -> BoogieExpr {
+    fn translate_constant(&self, val: &CopyableVal_) -> BoogieExpr {
         match val {
             CopyableVal_::Address(addr) => BoogieExpr(
                 format!("Address({})", self.translate_account_address(addr)),
@@ -384,11 +822,10 @@ impl<'env> SpecTranslator<'env> {
     ///
     /// The StorageLocation AST can represent different types in the Boogie model,
     /// therefore we need to interpret in context. See also `translate_location_as_reference`.
-    fn translate_location_as_value(&mut self, loc: &StorageLocation) -> BoogieExpr {
+    fn translate_location_as_value(&self, loc: &StorageLocation) -> BoogieExpr {
         match loc {
-            StorageLocation::Formal(name) => self.translate_param(name),
-
-            StorageLocation::Ret(index) => self.translate_return(*index as usize),
+            StorageLocation::Formal(name) => self.lookup_symbol(name, *self.in_old.borrow()),
+            StorageLocation::Ret(index) => self.lookup_symbol(&format!("__ret{}", index), false),
             StorageLocation::TxnSenderAddress => BoogieExpr(
                 "Address(TxnSenderAddress(__txn))".to_string(),
                 GlobalType::Address,
@@ -405,7 +842,7 @@ impl<'env> SpecTranslator<'env> {
                     t = *vt;
                 }
                 for f in fields {
-                    let (s, tf) = self.translate_field(&t, f);
+                    let (s, tf) = self.translate_field_access(&t, f);
                     res = format!("SelectField({}, {})", res, s);
                     t = tf;
                 }
@@ -419,10 +856,10 @@ impl<'env> SpecTranslator<'env> {
     }
 
     /// Translate a location as Reference.
-    fn translate_location_as_reference(&mut self, loc: &StorageLocation) -> BoogieExpr {
+    fn translate_location_as_reference(&self, loc: &StorageLocation) -> BoogieExpr {
         match loc {
             StorageLocation::Formal(name) => {
-                let BoogieExpr(s, t) = self.translate_param(name);
+                let BoogieExpr(s, t) = self.lookup_symbol(name, *self.in_old.borrow());
                 if let GlobalType::Reference(d) | GlobalType::MutableReference(d) = t {
                     BoogieExpr(s, GlobalType::Reference(Box::new(*d)))
                 } else {
@@ -448,7 +885,7 @@ impl<'env> SpecTranslator<'env> {
             StorageLocation::AccessPath { base, fields } => {
                 let BoogieExpr(mut res, mut t) = self.translate_location_as_reference(base);
                 for f in fields {
-                    let (s, tf) = self.translate_field(&t, f);
+                    let (s, tf) = self.translate_field_access(&t, f);
                     res = format!("SelectFieldFromRef({}, {})", res, s);
                     t = tf;
                 }
@@ -462,14 +899,13 @@ impl<'env> SpecTranslator<'env> {
     }
 
     /// Checks for an expected type.
-    fn require_type(&mut self, t: GlobalType, expected: &GlobalType) -> GlobalType {
+    fn require_type(&self, t: GlobalType, expected: &GlobalType) -> GlobalType {
         if t != ERROR_TYPE && t != UNKNOWN_TYPE && t != *expected {
-            println!("t: {:?} expected {:?}", t, expected);
             self.error(
                 &format!(
                     "incompatible types: expected `{}`, found `{}`",
-                    boogie_type_value(self.func_env.module_env.env, expected),
-                    boogie_type_value(self.func_env.module_env.env, &t)
+                    boogie_type_value(self.module_env.env, expected),
+                    boogie_type_value(self.module_env.env, &t)
                 ),
                 expected.clone(),
             )
@@ -485,83 +921,36 @@ impl<'env> SpecTranslator<'env> {
 
     /// Translates a resource name with type actuals
     fn translate_resource_type(
-        &mut self,
+        &self,
         id: &QualifiedStructIdent,
-        _type_actuals: &[Type],
+        type_actuals: &[Type],
     ) -> (String, GlobalType) {
-        // TODO: incorporate type actuals. For that, we need a translator from Type AST into
-        //   GlobalSignatureToken, which requires name resolution.
-        // TODO: do we need to incorporate address in the resolution?
-        let struct_name = id.name.as_inner();
-        let mut module_name = id.module.as_inner().to_string();
-        if module_name == "Self" {
-            module_name = self.func_env.module_env.get_id().name().to_string();
-        }
-        for module_env in self.func_env.module_env.env.get_modules() {
-            if module_env.get_id().name().as_str() != module_name {
-                continue;
-            }
-            if let Some(struct_env) = module_env.find_struct(struct_name) {
-                let resource_type = GlobalType::Struct(
-                    module_env.get_module_idx(),
-                    struct_env.get_def_idx(),
-                    vec![],
-                );
-                return (
-                    boogie_type_value(self.func_env.module_env.env, &resource_type),
-                    resource_type,
+        let resource_type = self.module_env.translate_struct_ast_type(
+            *self.current_loc.borrow(),
+            id,
+            type_actuals,
+            &self.type_parameters,
+        );
+        // Verify the type is actually a resource.
+        if let GlobalType::Struct(module_idx, struct_idx, _) = &resource_type {
+            let module_env = self.module_env.env.get_module(*module_idx);
+            let struct_env = module_env.get_struct(struct_idx);
+            if !struct_env.is_resource() {
+                self.error(
+                    &format!("type `{}` is not a resource", struct_env.get_name()),
+                    (),
                 );
             }
         }
-        self.error(
-            &format!("Cannot resolve type `{}`", id),
-            (format!("<struct {}>", id), GlobalType::U64),
+        (
+            boogie_type_value(self.module_env.env, &resource_type),
+            resource_type,
         )
-    }
-
-    /// Translate a function parameter.
-    fn translate_param(&mut self, name: &str) -> BoogieExpr {
-        // Look up parameter.
-        if let Some(Parameter(name, sig)) = self
-            .func_env
-            .get_parameters()
-            .iter()
-            .find(|Parameter(n, _)| n.as_str() == name)
-        {
-            BoogieExpr(name.as_str().to_string(), sig.clone())
-        } else {
-            self.error(
-                &format!("parameter `{}` undefined", name),
-                BoogieExpr(name.to_string(), ERROR_TYPE),
-            )
-        }
-    }
-
-    /// Translate a function return value.
-    fn translate_return(&mut self, index: usize) -> BoogieExpr {
-        let return_types = self.func_env.get_return_types();
-        if return_types.is_empty() {
-            self.error(
-                "function does not return a value",
-                BoogieExpr("<ret>".to_string(), GlobalType::U64),
-            )
-        } else if index >= return_types.len() {
-            self.error(
-                &format!(
-                    "RET index {} out of bounds; function declaration has {} return values",
-                    index,
-                    return_types.len()
-                ),
-                BoogieExpr("<ret>".to_string(), GlobalType::U64),
-            )
-        } else {
-            BoogieExpr(format!("__ret{}", index), return_types[index].clone())
-        }
     }
 
     /// Translates a field name, where `sig` is the type from which the field is selected.
     /// Returns boogie field name and type.
-    fn translate_field(&mut self, mut sig: &GlobalType, field: &Field_) -> (String, GlobalType) {
+    fn translate_field_access(&self, mut sig: &GlobalType, field: &Field_) -> (String, GlobalType) {
         // If this is a reference, use the underlying type. This function works with both
         // references and non-references.
         let is_ref = if let GlobalType::Reference(s) = sig {
@@ -580,7 +969,7 @@ impl<'env> SpecTranslator<'env> {
             );
         }
         if let GlobalType::Struct(module_index, struct_index, _actuals) = sig {
-            let module_env = self.func_env.module_env.env.get_module(*module_index);
+            let module_env = self.module_env.env.get_module(*module_index);
             let struct_env = module_env.get_struct(&struct_index);
             if let Some(field_env) = struct_env.find_field(field.name()) {
                 (
@@ -605,7 +994,7 @@ impl<'env> SpecTranslator<'env> {
             self.error(
                 &format!(
                     "expected Struct but found `{}`",
-                    boogie_type_value(self.func_env.module_env.env, sig)
+                    boogie_type_value(self.module_env.env, sig)
                 ),
                 ("<field>".to_string(), ERROR_TYPE),
             )

--- a/language/move-prover/bytecode-to-boogie/test_mvir/verify-invariants.mvir
+++ b/language/move-prover/bytecode-to-boogie/test_mvir/verify-invariants.mvir
@@ -1,0 +1,66 @@
+// Tests basic invariant functionality.
+
+module TestInvariants {
+
+    struct T {
+      i: u64,
+
+      // We must always have a value greater zero.
+      // Expecting one error from `invalid_T` tes`.
+      invariant {data} i > 0, //! This assertion might not hold.
+
+      // When we update via a reference, the new value must be greater than the old one.
+      // Expecting two errors from `invalid_T_update` and `invalid_T_update_indirectly` test.
+      invariant {update} i > old(i) //! This assertion might not hold.
+                                    //! This assertion might not hold.
+    }
+
+    public valid_T(): Self.T
+    ensures RET.i == 1
+    {
+      let t: Self.T;
+      t = T{i:1};
+      return move(t);
+    }
+
+    public invalid_T(): Self.T
+    ensures RET.i == 0
+    {
+      let t: Self.T;
+      t = T{i:0};
+      return move(t);
+    }
+
+    public valid_T_update(): Self.T
+    ensures RET.i == 3
+    {
+      let t: Self.T;
+      let r: &mut Self.T;
+      t = T{i:2};
+      r = &mut t;
+      *move(r) = T{i:3};
+      return move(t);
+    }
+
+    public invalid_T_update(): Self.T
+    ensures RET.i == 2
+    {
+      let t: Self.T;
+      let r: &mut Self.T;
+      t = T{i:2};
+      r = &mut t;
+      *move(r) = T{i:2};
+      return move(t);
+    }
+
+    public invalid_T_update_indirectly(): Self.T
+    ensures RET.i == 2
+    {
+      let t: Self.T;
+      let r: &mut Self.T;
+      t = T{i:2};
+      r = &mut t;
+      *&mut move(r).i = 2;
+      return move(t);
+    }
+}

--- a/language/move-prover/bytecode-to-boogie/test_mvir/verify-synthetics.mvir
+++ b/language/move-prover/bytecode-to-boogie/test_mvir/verify-synthetics.mvir
@@ -1,0 +1,49 @@
+// Tests basic invariant functionality.
+
+module TestInvariants {
+
+    synthetic syn: u64;
+
+    struct T {
+      i: u64,
+
+      // When we update via a reference, the new value must be greater than the old one.
+      // Expecting two errors from `invalid_T_update` and `invalid_T_update_indirectly` test.
+      invariant {pack} syn = syn + i,
+      invariant {unpack} syn = syn - i,
+      invariant {update} syn = syn - old(i) + i
+
+    }
+
+    public valid()
+    ensures syn == old(syn) + 2 + 3 - 3 + 4 - 2
+    {
+      let t: Self.T;
+      let r: Self.T;
+      let s: &mut Self.T;
+      let x: u64;
+
+      t = T{i:2};
+      r = T{i:3};
+      s = &mut r;
+      *&mut move(s).i = 4;
+      T{x} = move(t);
+      return;
+    }
+
+    public invalid()
+    ensures syn == old(syn) + 2 //! A postcondition might not hold
+    {
+      let t: Self.T;
+      let r: Self.T;
+      let s: &mut Self.T;
+      let x: u64;
+
+      t = T{i:2};
+      r = T{i:3};
+      s = &mut r;
+      *&mut move(s).i = 4;
+      T{x} = move(t);
+      return;
+    }
+}

--- a/language/move-prover/bytecode-to-boogie/tests/goldenfiles/libra_account.bpl
+++ b/language/move-prover/bytecode-to-boogie/tests/goldenfiles/libra_account.bpl
@@ -56,6 +56,10 @@ function {:inline 1} max_balance(): Value {
 }
 
 
+// ** synthetics of module LibraCoin
+
+
+
 // ** structs of module LibraCoin
 
 const unique LibraCoin_T: TypeName;
@@ -64,10 +68,16 @@ axiom LibraCoin_T_value == 0;
 function LibraCoin_T_type_value(): TypeValue {
     StructType(LibraCoin_T, ExtendTypeValueArray(EmptyTypeValueArray, IntegerType()))
 }
-procedure {:inline 1} Pack_LibraCoin_T(value: Value) returns (_struct: Value)
+function {:inline 1} $LibraCoin_T_is_well_formed(__this: Value): bool {
+    is#Vector(__this)
+        && IsValidU64(SelectField(__this, LibraCoin_T_value))
+}
+
+procedure {:inline 1} Pack_LibraCoin_T(module_idx: int, func_idx: int, var_idx: int, code_idx: int, value: Value) returns (_struct: Value)
 {
     assume IsValidU64(value);
     _struct := Vector(ExtendValueArray(EmptyValueArray, value));
+    if (code_idx > 0) { assume $DebugTrackLocal(module_idx, func_idx, var_idx, code_idx, _struct); }
 }
 
 procedure {:inline 1} Unpack_LibraCoin_T(_struct: Value) returns (value: Value)
@@ -83,10 +93,16 @@ axiom LibraCoin_MintCapability__dummy == 0;
 function LibraCoin_MintCapability_type_value(): TypeValue {
     StructType(LibraCoin_MintCapability, ExtendTypeValueArray(EmptyTypeValueArray, BooleanType()))
 }
-procedure {:inline 1} Pack_LibraCoin_MintCapability(_dummy: Value) returns (_struct: Value)
+function {:inline 1} $LibraCoin_MintCapability_is_well_formed(__this: Value): bool {
+    is#Vector(__this)
+        && is#Boolean(SelectField(__this, LibraCoin_MintCapability__dummy))
+}
+
+procedure {:inline 1} Pack_LibraCoin_MintCapability(module_idx: int, func_idx: int, var_idx: int, code_idx: int, _dummy: Value) returns (_struct: Value)
 {
     assume is#Boolean(_dummy);
     _struct := Vector(ExtendValueArray(EmptyValueArray, _dummy));
+    if (code_idx > 0) { assume $DebugTrackLocal(module_idx, func_idx, var_idx, code_idx, _struct); }
 }
 
 procedure {:inline 1} Unpack_LibraCoin_MintCapability(_struct: Value) returns (_dummy: Value)
@@ -102,10 +118,16 @@ axiom LibraCoin_MarketCap_total_value == 0;
 function LibraCoin_MarketCap_type_value(): TypeValue {
     StructType(LibraCoin_MarketCap, ExtendTypeValueArray(EmptyTypeValueArray, IntegerType()))
 }
-procedure {:inline 1} Pack_LibraCoin_MarketCap(total_value: Value) returns (_struct: Value)
+function {:inline 1} $LibraCoin_MarketCap_is_well_formed(__this: Value): bool {
+    is#Vector(__this)
+        && IsValidU64(SelectField(__this, LibraCoin_MarketCap_total_value))
+}
+
+procedure {:inline 1} Pack_LibraCoin_MarketCap(module_idx: int, func_idx: int, var_idx: int, code_idx: int, total_value: Value) returns (_struct: Value)
 {
     assume IsValidU64(total_value);
     _struct := Vector(ExtendValueArray(EmptyValueArray, total_value));
+    if (code_idx > 0) { assume $DebugTrackLocal(module_idx, func_idx, var_idx, code_idx, _struct); }
 }
 
 procedure {:inline 1} Unpack_LibraCoin_MarketCap(_struct: Value) returns (total_value: Value)
@@ -167,7 +189,7 @@ ensures old(b#Boolean(Boolean(!(b#Boolean(ExistsResource(__m, LibraCoin_MintCapa
       assume $DebugTrackAbort(0, 0, 1408);
       goto Label_Abort;
     }
-    assume is#Vector(__t4);
+    assume $LibraCoin_T_is_well_formed(__t4);
 
     __m := UpdateLocal(__m, __frame + 4, __t4);
 
@@ -231,9 +253,8 @@ ensures old(b#Boolean(Boolean(!(b#Boolean(ExistsResource(__m, LibraCoin_MarketCa
     assume IsValidU64(value);
     __m := UpdateLocal(__m, __frame + 0, value);
     assume $DebugTrackLocal(0, 1, 0, 1723, value);
-    assume is#Vector(Dereference(__m, capability));
-    assume IsValidReferenceParameter(__m, __local_counter, capability);
-    assume is#Vector(Dereference(__m, capability));
+    assume $LibraCoin_MintCapability_is_well_formed(Dereference(__m, capability)) && IsValidReferenceParameter(__m, __local_counter, capability);
+    assume $LibraCoin_MintCapability_is_well_formed(Dereference(__m, capability));
     assume $DebugTrackLocal(0, 1, 1, 1723, Dereference(__m, capability));
 
     // increase the local counter
@@ -285,7 +306,7 @@ Label_11:
     }
 
     call market_cap_ref := CopyOrMoveRef(__t13);
-    assume is#Vector(Dereference(__m, market_cap_ref));
+    assume $LibraCoin_MarketCap_is_well_formed(Dereference(__m, market_cap_ref));
     assume $DebugTrackLocal(0, 1, 2, 2898, Dereference(__m, market_cap_ref));
 
     call __t14 := CopyOrMoveRef(market_cap_ref);
@@ -319,10 +340,11 @@ Label_11:
 
     call WriteRef(__t21, GetLocal(__m, __frame + 19));
 
+
     call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 0));
     __m := UpdateLocal(__m, __frame + 22, __tmp);
 
-    call __tmp := Pack_LibraCoin_T(GetLocal(__m, __frame + 22));
+    call __tmp := Pack_LibraCoin_T(0, 0, 0, 0, GetLocal(__m, __frame + 22));
     __m := UpdateLocal(__m, __frame + 23, __tmp);
 
     __ret0 := GetLocal(__m, __frame + 23);
@@ -399,7 +421,7 @@ Label_7:
     call __tmp := LdTrue();
     __m := UpdateLocal(__m, __frame + 5, __tmp);
 
-    call __tmp := Pack_LibraCoin_MintCapability(GetLocal(__m, __frame + 5));
+    call __tmp := Pack_LibraCoin_MintCapability(0, 0, 0, 0, GetLocal(__m, __frame + 5));
     __m := UpdateLocal(__m, __frame + 6, __tmp);
 
     call MoveToSender(LibraCoin_MintCapability_type_value(), GetLocal(__m, __frame + 6));
@@ -411,7 +433,7 @@ Label_7:
     call __tmp := LdConst(0);
     __m := UpdateLocal(__m, __frame + 7, __tmp);
 
-    call __tmp := Pack_LibraCoin_MarketCap(GetLocal(__m, __frame + 7));
+    call __tmp := Pack_LibraCoin_MarketCap(0, 0, 0, 0, GetLocal(__m, __frame + 7));
     __m := UpdateLocal(__m, __frame + 8, __tmp);
 
     call MoveToSender(LibraCoin_MarketCap_type_value(), GetLocal(__m, __frame + 8));
@@ -516,7 +538,7 @@ ensures b#Boolean(Boolean(IsEqual(SelectField(__ret0, LibraCoin_T_value), Intege
     call __tmp := LdConst(0);
     __m := UpdateLocal(__m, __frame + 0, __tmp);
 
-    call __tmp := Pack_LibraCoin_T(GetLocal(__m, __frame + 0));
+    call __tmp := Pack_LibraCoin_T(0, 0, 0, 0, GetLocal(__m, __frame + 0));
     __m := UpdateLocal(__m, __frame + 1, __tmp);
 
     __ret0 := GetLocal(__m, __frame + 1);
@@ -553,9 +575,8 @@ ensures b#Boolean(Boolean(IsEqual(__ret0, SelectField(Dereference(__m, coin_ref)
     __frame := __local_counter;
 
     // process and type check arguments
-    assume is#Vector(Dereference(__m, coin_ref));
-    assume IsValidReferenceParameter(__m, __local_counter, coin_ref);
-    assume is#Vector(Dereference(__m, coin_ref));
+    assume $LibraCoin_T_is_well_formed(Dereference(__m, coin_ref)) && IsValidReferenceParameter(__m, __local_counter, coin_ref);
+    assume $LibraCoin_T_is_well_formed(Dereference(__m, coin_ref));
     assume $DebugTrackLocal(0, 5, 0, 4555, Dereference(__m, coin_ref));
 
     // increase the local counter
@@ -610,7 +631,7 @@ ensures old(b#Boolean(Boolean(i#Integer(SelectField(coin, LibraCoin_T_value)) < 
     __frame := __local_counter;
 
     // process and type check arguments
-    assume is#Vector(coin);
+    assume $LibraCoin_T_is_well_formed(coin);
     __m := UpdateLocal(__m, __frame + 0, coin);
     assume $DebugTrackLocal(0, 6, 0, 4818, coin);
     assume IsValidU64(amount);
@@ -621,7 +642,7 @@ ensures old(b#Boolean(Boolean(i#Integer(SelectField(coin, LibraCoin_T_value)) < 
     __local_counter := __local_counter + 8;
 
     // bytecode translation starts here
-    call __t3 := BorrowLoc(__frame + 0);
+    call __t3 := BorrowLoc(__frame + 0, LibraCoin_T_type_value());
 
     call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 1));
     __m := UpdateLocal(__m, __frame + 4, __tmp);
@@ -631,7 +652,7 @@ ensures old(b#Boolean(Boolean(i#Integer(SelectField(coin, LibraCoin_T_value)) < 
       assume $DebugTrackAbort(0, 6, 5045);
       goto Label_Abort;
     }
-    assume is#Vector(__t5);
+    assume $LibraCoin_T_is_well_formed(__t5);
 
     __m := UpdateLocal(__m, __frame + 5, __t5);
     assume $DebugTrackLocal(0, 6, 0, 5045, GetLocal(__m, __frame + 0));
@@ -700,9 +721,8 @@ ensures old(b#Boolean(Boolean(i#Integer(SelectField(Dereference(__m, coin_ref), 
     __frame := __local_counter;
 
     // process and type check arguments
-    assume is#Vector(Dereference(__m, coin_ref));
-    assume IsValidReferenceParameter(__m, __local_counter, coin_ref);
-    assume is#Vector(Dereference(__m, coin_ref));
+    assume $LibraCoin_T_is_well_formed(Dereference(__m, coin_ref)) && IsValidReferenceParameter(__m, __local_counter, coin_ref);
+    assume $LibraCoin_T_is_well_formed(Dereference(__m, coin_ref));
     assume $DebugTrackLocal(0, 7, 0, 5391, Dereference(__m, coin_ref));
     assume IsValidU64(amount);
     __m := UpdateLocal(__m, __frame + 1, amount);
@@ -763,11 +783,13 @@ Label_11:
     call __t15 := BorrowField(__t14, LibraCoin_T_value);
 
     call WriteRef(__t15, GetLocal(__m, __frame + 13));
+    assume $LibraCoin_T_is_well_formed(Dereference(__m, coin_ref));
+    assume $DebugTrackLocal(0, 7, 0, 5814, Dereference(__m, coin_ref));
 
     call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 1));
     __m := UpdateLocal(__m, __frame + 16, __tmp);
 
-    call __tmp := Pack_LibraCoin_T(GetLocal(__m, __frame + 16));
+    call __tmp := Pack_LibraCoin_T(0, 0, 0, 0, GetLocal(__m, __frame + 16));
     __m := UpdateLocal(__m, __frame + 17, __tmp);
 
     __ret0 := GetLocal(__m, __frame + 17);
@@ -807,10 +829,10 @@ ensures old(b#Boolean(Boolean(i#Integer(Integer(i#Integer(SelectField(coin1, Lib
     __frame := __local_counter;
 
     // process and type check arguments
-    assume is#Vector(coin1);
+    assume $LibraCoin_T_is_well_formed(coin1);
     __m := UpdateLocal(__m, __frame + 0, coin1);
     assume $DebugTrackLocal(0, 8, 0, 6020, coin1);
-    assume is#Vector(coin2);
+    assume $LibraCoin_T_is_well_formed(coin2);
     __m := UpdateLocal(__m, __frame + 1, coin2);
     assume $DebugTrackLocal(0, 8, 1, 6020, coin2);
 
@@ -818,7 +840,7 @@ ensures old(b#Boolean(Boolean(i#Integer(Integer(i#Integer(SelectField(coin1, Lib
     __local_counter := __local_counter + 5;
 
     // bytecode translation starts here
-    call __t2 := BorrowLoc(__frame + 0);
+    call __t2 := BorrowLoc(__frame + 0, LibraCoin_T_type_value());
 
     call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 1));
     __m := UpdateLocal(__m, __frame + 3, __tmp);
@@ -879,11 +901,10 @@ ensures old(b#Boolean(Boolean(i#Integer(Integer(i#Integer(SelectField(Dereferenc
     __frame := __local_counter;
 
     // process and type check arguments
-    assume is#Vector(Dereference(__m, coin_ref));
-    assume IsValidReferenceParameter(__m, __local_counter, coin_ref);
-    assume is#Vector(Dereference(__m, coin_ref));
+    assume $LibraCoin_T_is_well_formed(Dereference(__m, coin_ref)) && IsValidReferenceParameter(__m, __local_counter, coin_ref);
+    assume $LibraCoin_T_is_well_formed(Dereference(__m, coin_ref));
     assume $DebugTrackLocal(0, 9, 0, 6465, Dereference(__m, coin_ref));
-    assume is#Vector(check);
+    assume $LibraCoin_T_is_well_formed(check);
     __m := UpdateLocal(__m, __frame + 1, check);
     assume $DebugTrackLocal(0, 9, 1, 6465, check);
 
@@ -931,6 +952,8 @@ ensures old(b#Boolean(Boolean(i#Integer(Integer(i#Integer(SelectField(Dereferenc
     call __t13 := BorrowField(__t12, LibraCoin_T_value);
 
     call WriteRef(__t13, GetLocal(__m, __frame + 11));
+    assume $LibraCoin_T_is_well_formed(Dereference(__m, coin_ref));
+    assume $DebugTrackLocal(0, 9, 0, 6823, Dereference(__m, coin_ref));
 
     return;
 
@@ -970,7 +993,7 @@ ensures old(b#Boolean(Boolean(!IsEqual(SelectField(coin, LibraCoin_T_value), Int
     __frame := __local_counter;
 
     // process and type check arguments
-    assume is#Vector(coin);
+    assume $LibraCoin_T_is_well_formed(coin);
     __m := UpdateLocal(__m, __frame + 0, coin);
     assume $DebugTrackLocal(0, 10, 0, 7117, coin);
 
@@ -1024,11 +1047,19 @@ procedure LibraCoin_destroy_zero_verify (coin: Value) returns ()
 
 
 
+// ** synthetics of module Hash
+
+
+
 // ** structs of module Hash
 
 
 
 // ** functions of module Hash
+
+
+
+// ** synthetics of module U64Util
 
 
 
@@ -1040,6 +1071,10 @@ procedure LibraCoin_destroy_zero_verify (coin: Value) returns ()
 
 
 
+// ** synthetics of module AddressUtil
+
+
+
 // ** structs of module AddressUtil
 
 
@@ -1048,11 +1083,19 @@ procedure LibraCoin_destroy_zero_verify (coin: Value) returns ()
 
 
 
+// ** synthetics of module BytearrayUtil
+
+
+
 // ** structs of module BytearrayUtil
 
 
 
 // ** functions of module BytearrayUtil
+
+
+
+// ** synthetics of module LibraAccount
 
 
 
@@ -1076,17 +1119,30 @@ axiom LibraAccount_T_sequence_number == 6;
 const LibraAccount_T_event_generator: FieldName;
 axiom LibraAccount_T_event_generator == 7;
 axiom LibraAccount_T_type_value() == StructType(LibraAccount_T, ExtendTypeValueArray(ExtendTypeValueArray(ExtendTypeValueArray(ExtendTypeValueArray(ExtendTypeValueArray(ExtendTypeValueArray(ExtendTypeValueArray(ExtendTypeValueArray(EmptyTypeValueArray, ByteArrayType()), LibraCoin_T_type_value()), BooleanType()), BooleanType()), LibraAccount_EventHandle_type_value(LibraAccount_ReceivedPaymentEvent_type_value())), LibraAccount_EventHandle_type_value(LibraAccount_SentPaymentEvent_type_value())), IntegerType()), LibraAccount_EventHandleGenerator_type_value()));
-procedure {:inline 1} Pack_LibraAccount_T(authentication_key: Value, balance: Value, delegated_key_rotation_capability: Value, delegated_withdrawal_capability: Value, received_events: Value, sent_events: Value, sequence_number: Value, event_generator: Value) returns (_struct: Value)
+function {:inline 1} $LibraAccount_T_is_well_formed(__this: Value): bool {
+    is#Vector(__this)
+        && is#ByteArray(SelectField(__this, LibraAccount_T_authentication_key))
+        && $LibraCoin_T_is_well_formed(SelectField(__this, LibraAccount_T_balance))
+        && is#Boolean(SelectField(__this, LibraAccount_T_delegated_key_rotation_capability))
+        && is#Boolean(SelectField(__this, LibraAccount_T_delegated_withdrawal_capability))
+        && $LibraAccount_EventHandle_is_well_formed(SelectField(__this, LibraAccount_T_received_events))
+        && $LibraAccount_EventHandle_is_well_formed(SelectField(__this, LibraAccount_T_sent_events))
+        && IsValidU64(SelectField(__this, LibraAccount_T_sequence_number))
+        && $LibraAccount_EventHandleGenerator_is_well_formed(SelectField(__this, LibraAccount_T_event_generator))
+}
+
+procedure {:inline 1} Pack_LibraAccount_T(module_idx: int, func_idx: int, var_idx: int, code_idx: int, authentication_key: Value, balance: Value, delegated_key_rotation_capability: Value, delegated_withdrawal_capability: Value, received_events: Value, sent_events: Value, sequence_number: Value, event_generator: Value) returns (_struct: Value)
 {
     assume is#ByteArray(authentication_key);
-    assume is#Vector(balance);
+    assume $LibraCoin_T_is_well_formed(balance);
     assume is#Boolean(delegated_key_rotation_capability);
     assume is#Boolean(delegated_withdrawal_capability);
-    assume is#Vector(received_events);
-    assume is#Vector(sent_events);
+    assume $LibraAccount_EventHandle_is_well_formed(received_events);
+    assume $LibraAccount_EventHandle_is_well_formed(sent_events);
     assume IsValidU64(sequence_number);
-    assume is#Vector(event_generator);
+    assume $LibraAccount_EventHandleGenerator_is_well_formed(event_generator);
     _struct := Vector(ExtendValueArray(ExtendValueArray(ExtendValueArray(ExtendValueArray(ExtendValueArray(ExtendValueArray(ExtendValueArray(ExtendValueArray(EmptyValueArray, authentication_key), balance), delegated_key_rotation_capability), delegated_withdrawal_capability), received_events), sent_events), sequence_number), event_generator));
+    if (code_idx > 0) { assume $DebugTrackLocal(module_idx, func_idx, var_idx, code_idx, _struct); }
 }
 
 procedure {:inline 1} Unpack_LibraAccount_T(_struct: Value) returns (authentication_key: Value, balance: Value, delegated_key_rotation_capability: Value, delegated_withdrawal_capability: Value, received_events: Value, sent_events: Value, sequence_number: Value, event_generator: Value)
@@ -1095,19 +1151,19 @@ procedure {:inline 1} Unpack_LibraAccount_T(_struct: Value) returns (authenticat
     authentication_key := SelectField(_struct, LibraAccount_T_authentication_key);
     assume is#ByteArray(authentication_key);
     balance := SelectField(_struct, LibraAccount_T_balance);
-    assume is#Vector(balance);
+    assume $LibraCoin_T_is_well_formed(balance);
     delegated_key_rotation_capability := SelectField(_struct, LibraAccount_T_delegated_key_rotation_capability);
     assume is#Boolean(delegated_key_rotation_capability);
     delegated_withdrawal_capability := SelectField(_struct, LibraAccount_T_delegated_withdrawal_capability);
     assume is#Boolean(delegated_withdrawal_capability);
     received_events := SelectField(_struct, LibraAccount_T_received_events);
-    assume is#Vector(received_events);
+    assume $LibraAccount_EventHandle_is_well_formed(received_events);
     sent_events := SelectField(_struct, LibraAccount_T_sent_events);
-    assume is#Vector(sent_events);
+    assume $LibraAccount_EventHandle_is_well_formed(sent_events);
     sequence_number := SelectField(_struct, LibraAccount_T_sequence_number);
     assume IsValidU64(sequence_number);
     event_generator := SelectField(_struct, LibraAccount_T_event_generator);
-    assume is#Vector(event_generator);
+    assume $LibraAccount_EventHandleGenerator_is_well_formed(event_generator);
 }
 
 const unique LibraAccount_WithdrawalCapability: TypeName;
@@ -1116,10 +1172,16 @@ axiom LibraAccount_WithdrawalCapability_account_address == 0;
 function LibraAccount_WithdrawalCapability_type_value(): TypeValue {
     StructType(LibraAccount_WithdrawalCapability, ExtendTypeValueArray(EmptyTypeValueArray, AddressType()))
 }
-procedure {:inline 1} Pack_LibraAccount_WithdrawalCapability(account_address: Value) returns (_struct: Value)
+function {:inline 1} $LibraAccount_WithdrawalCapability_is_well_formed(__this: Value): bool {
+    is#Vector(__this)
+        && is#Address(SelectField(__this, LibraAccount_WithdrawalCapability_account_address))
+}
+
+procedure {:inline 1} Pack_LibraAccount_WithdrawalCapability(module_idx: int, func_idx: int, var_idx: int, code_idx: int, account_address: Value) returns (_struct: Value)
 {
     assume is#Address(account_address);
     _struct := Vector(ExtendValueArray(EmptyValueArray, account_address));
+    if (code_idx > 0) { assume $DebugTrackLocal(module_idx, func_idx, var_idx, code_idx, _struct); }
 }
 
 procedure {:inline 1} Unpack_LibraAccount_WithdrawalCapability(_struct: Value) returns (account_address: Value)
@@ -1135,10 +1197,16 @@ axiom LibraAccount_KeyRotationCapability_account_address == 0;
 function LibraAccount_KeyRotationCapability_type_value(): TypeValue {
     StructType(LibraAccount_KeyRotationCapability, ExtendTypeValueArray(EmptyTypeValueArray, AddressType()))
 }
-procedure {:inline 1} Pack_LibraAccount_KeyRotationCapability(account_address: Value) returns (_struct: Value)
+function {:inline 1} $LibraAccount_KeyRotationCapability_is_well_formed(__this: Value): bool {
+    is#Vector(__this)
+        && is#Address(SelectField(__this, LibraAccount_KeyRotationCapability_account_address))
+}
+
+procedure {:inline 1} Pack_LibraAccount_KeyRotationCapability(module_idx: int, func_idx: int, var_idx: int, code_idx: int, account_address: Value) returns (_struct: Value)
 {
     assume is#Address(account_address);
     _struct := Vector(ExtendValueArray(EmptyValueArray, account_address));
+    if (code_idx > 0) { assume $DebugTrackLocal(module_idx, func_idx, var_idx, code_idx, _struct); }
 }
 
 procedure {:inline 1} Unpack_LibraAccount_KeyRotationCapability(_struct: Value) returns (account_address: Value)
@@ -1158,12 +1226,20 @@ axiom LibraAccount_SentPaymentEvent_metadata == 2;
 function LibraAccount_SentPaymentEvent_type_value(): TypeValue {
     StructType(LibraAccount_SentPaymentEvent, ExtendTypeValueArray(ExtendTypeValueArray(ExtendTypeValueArray(EmptyTypeValueArray, IntegerType()), AddressType()), ByteArrayType()))
 }
-procedure {:inline 1} Pack_LibraAccount_SentPaymentEvent(amount: Value, payee: Value, metadata: Value) returns (_struct: Value)
+function {:inline 1} $LibraAccount_SentPaymentEvent_is_well_formed(__this: Value): bool {
+    is#Vector(__this)
+        && IsValidU64(SelectField(__this, LibraAccount_SentPaymentEvent_amount))
+        && is#Address(SelectField(__this, LibraAccount_SentPaymentEvent_payee))
+        && is#ByteArray(SelectField(__this, LibraAccount_SentPaymentEvent_metadata))
+}
+
+procedure {:inline 1} Pack_LibraAccount_SentPaymentEvent(module_idx: int, func_idx: int, var_idx: int, code_idx: int, amount: Value, payee: Value, metadata: Value) returns (_struct: Value)
 {
     assume IsValidU64(amount);
     assume is#Address(payee);
     assume is#ByteArray(metadata);
     _struct := Vector(ExtendValueArray(ExtendValueArray(ExtendValueArray(EmptyValueArray, amount), payee), metadata));
+    if (code_idx > 0) { assume $DebugTrackLocal(module_idx, func_idx, var_idx, code_idx, _struct); }
 }
 
 procedure {:inline 1} Unpack_LibraAccount_SentPaymentEvent(_struct: Value) returns (amount: Value, payee: Value, metadata: Value)
@@ -1187,12 +1263,20 @@ axiom LibraAccount_ReceivedPaymentEvent_metadata == 2;
 function LibraAccount_ReceivedPaymentEvent_type_value(): TypeValue {
     StructType(LibraAccount_ReceivedPaymentEvent, ExtendTypeValueArray(ExtendTypeValueArray(ExtendTypeValueArray(EmptyTypeValueArray, IntegerType()), AddressType()), ByteArrayType()))
 }
-procedure {:inline 1} Pack_LibraAccount_ReceivedPaymentEvent(amount: Value, payer: Value, metadata: Value) returns (_struct: Value)
+function {:inline 1} $LibraAccount_ReceivedPaymentEvent_is_well_formed(__this: Value): bool {
+    is#Vector(__this)
+        && IsValidU64(SelectField(__this, LibraAccount_ReceivedPaymentEvent_amount))
+        && is#Address(SelectField(__this, LibraAccount_ReceivedPaymentEvent_payer))
+        && is#ByteArray(SelectField(__this, LibraAccount_ReceivedPaymentEvent_metadata))
+}
+
+procedure {:inline 1} Pack_LibraAccount_ReceivedPaymentEvent(module_idx: int, func_idx: int, var_idx: int, code_idx: int, amount: Value, payer: Value, metadata: Value) returns (_struct: Value)
 {
     assume IsValidU64(amount);
     assume is#Address(payer);
     assume is#ByteArray(metadata);
     _struct := Vector(ExtendValueArray(ExtendValueArray(ExtendValueArray(EmptyValueArray, amount), payer), metadata));
+    if (code_idx > 0) { assume $DebugTrackLocal(module_idx, func_idx, var_idx, code_idx, _struct); }
 }
 
 procedure {:inline 1} Unpack_LibraAccount_ReceivedPaymentEvent(_struct: Value) returns (amount: Value, payer: Value, metadata: Value)
@@ -1212,10 +1296,16 @@ axiom LibraAccount_EventHandleGenerator_counter == 0;
 function LibraAccount_EventHandleGenerator_type_value(): TypeValue {
     StructType(LibraAccount_EventHandleGenerator, ExtendTypeValueArray(EmptyTypeValueArray, IntegerType()))
 }
-procedure {:inline 1} Pack_LibraAccount_EventHandleGenerator(counter: Value) returns (_struct: Value)
+function {:inline 1} $LibraAccount_EventHandleGenerator_is_well_formed(__this: Value): bool {
+    is#Vector(__this)
+        && IsValidU64(SelectField(__this, LibraAccount_EventHandleGenerator_counter))
+}
+
+procedure {:inline 1} Pack_LibraAccount_EventHandleGenerator(module_idx: int, func_idx: int, var_idx: int, code_idx: int, counter: Value) returns (_struct: Value)
 {
     assume IsValidU64(counter);
     _struct := Vector(ExtendValueArray(EmptyValueArray, counter));
+    if (code_idx > 0) { assume $DebugTrackLocal(module_idx, func_idx, var_idx, code_idx, _struct); }
 }
 
 procedure {:inline 1} Unpack_LibraAccount_EventHandleGenerator(_struct: Value) returns (counter: Value)
@@ -1233,11 +1323,18 @@ axiom LibraAccount_EventHandle_guid == 1;
 function LibraAccount_EventHandle_type_value(tv0: TypeValue): TypeValue {
     StructType(LibraAccount_EventHandle, ExtendTypeValueArray(ExtendTypeValueArray(EmptyTypeValueArray, IntegerType()), ByteArrayType()))
 }
-procedure {:inline 1} Pack_LibraAccount_EventHandle(tv0: TypeValue, counter: Value, guid: Value) returns (_struct: Value)
+function {:inline 1} $LibraAccount_EventHandle_is_well_formed(__this: Value): bool {
+    is#Vector(__this)
+        && IsValidU64(SelectField(__this, LibraAccount_EventHandle_counter))
+        && is#ByteArray(SelectField(__this, LibraAccount_EventHandle_guid))
+}
+
+procedure {:inline 1} Pack_LibraAccount_EventHandle(module_idx: int, func_idx: int, var_idx: int, code_idx: int, tv0: TypeValue, counter: Value, guid: Value) returns (_struct: Value)
 {
     assume IsValidU64(counter);
     assume is#ByteArray(guid);
     _struct := Vector(ExtendValueArray(ExtendValueArray(EmptyValueArray, counter), guid));
+    if (code_idx > 0) { assume $DebugTrackLocal(module_idx, func_idx, var_idx, code_idx, _struct); }
 }
 
 procedure {:inline 1} Unpack_LibraAccount_EventHandle(_struct: Value) returns (counter: Value, guid: Value)
@@ -1322,14 +1419,14 @@ ensures b#Boolean(Boolean(b#Boolean(Boolean(IsEqual(SelectField(SelectField(__re
     call __tmp := LdConst(0);
     __m := UpdateLocal(__m, __frame + 8, __tmp);
 
-    call __tmp := Pack_LibraAccount_EventHandleGenerator(GetLocal(__m, __frame + 8));
+    call __tmp := Pack_LibraAccount_EventHandleGenerator(5, 0, 2, 3894, GetLocal(__m, __frame + 8));
     __m := UpdateLocal(__m, __frame + 9, __tmp);
 
     call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 9));
     __m := UpdateLocal(__m, __frame + 2, __tmp);
     assume $DebugTrackLocal(5, 0, 2, 3882, __tmp);
 
-    call __t10 := BorrowLoc(__frame + 2);
+    call __t10 := BorrowLoc(__frame + 2, LibraAccount_EventHandleGenerator_type_value());
 
     call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 0));
     __m := UpdateLocal(__m, __frame + 11, __tmp);
@@ -1339,7 +1436,7 @@ ensures b#Boolean(Boolean(b#Boolean(Boolean(IsEqual(SelectField(SelectField(__re
       assume $DebugTrackAbort(5, 0, 3951);
       goto Label_Abort;
     }
-    assume is#Vector(__t12);
+    assume $LibraAccount_EventHandle_is_well_formed(__t12);
 
     __m := UpdateLocal(__m, __frame + 12, __t12);
     assume $DebugTrackLocal(5, 0, 2, 3951, GetLocal(__m, __frame + 2));
@@ -1348,7 +1445,7 @@ ensures b#Boolean(Boolean(b#Boolean(Boolean(IsEqual(SelectField(SelectField(__re
     __m := UpdateLocal(__m, __frame + 3, __tmp);
     assume $DebugTrackLocal(5, 0, 3, 3937, __tmp);
 
-    call __t13 := BorrowLoc(__frame + 2);
+    call __t13 := BorrowLoc(__frame + 2, LibraAccount_EventHandleGenerator_type_value());
 
     call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 0));
     __m := UpdateLocal(__m, __frame + 14, __tmp);
@@ -1358,7 +1455,7 @@ ensures b#Boolean(Boolean(b#Boolean(Boolean(IsEqual(SelectField(SelectField(__re
       assume $DebugTrackAbort(5, 0, 4065);
       goto Label_Abort;
     }
-    assume is#Vector(__t15);
+    assume $LibraAccount_EventHandle_is_well_formed(__t15);
 
     __m := UpdateLocal(__m, __frame + 15, __t15);
     assume $DebugTrackLocal(5, 0, 2, 4065, GetLocal(__m, __frame + 2));
@@ -1372,7 +1469,7 @@ ensures b#Boolean(Boolean(b#Boolean(Boolean(IsEqual(SelectField(SelectField(__re
       assume $DebugTrackAbort(5, 0, 4180);
       goto Label_Abort;
     }
-    assume is#Vector(__t16);
+    assume $LibraCoin_T_is_well_formed(__t16);
 
     __m := UpdateLocal(__m, __frame + 16, __t16);
 
@@ -1404,7 +1501,7 @@ ensures b#Boolean(Boolean(b#Boolean(Boolean(IsEqual(SelectField(SelectField(__re
     call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 2));
     __m := UpdateLocal(__m, __frame + 24, __tmp);
 
-    call __tmp := Pack_LibraAccount_T(GetLocal(__m, __frame + 17), GetLocal(__m, __frame + 18), GetLocal(__m, __frame + 19), GetLocal(__m, __frame + 20), GetLocal(__m, __frame + 21), GetLocal(__m, __frame + 22), GetLocal(__m, __frame + 23), GetLocal(__m, __frame + 24));
+    call __tmp := Pack_LibraAccount_T(0, 0, 0, 0, GetLocal(__m, __frame + 17), GetLocal(__m, __frame + 18), GetLocal(__m, __frame + 19), GetLocal(__m, __frame + 20), GetLocal(__m, __frame + 21), GetLocal(__m, __frame + 22), GetLocal(__m, __frame + 23), GetLocal(__m, __frame + 24));
     __m := UpdateLocal(__m, __frame + 25, __tmp);
 
     __ret0 := GetLocal(__m, __frame + 25);
@@ -1447,7 +1544,7 @@ ensures old(b#Boolean(Boolean(!(b#Boolean(ExistsResource(__m, LibraAccount_T_typ
     assume is#Address(payee);
     __m := UpdateLocal(__m, __frame + 0, payee);
     assume $DebugTrackLocal(5, 1, 0, 4674, payee);
-    assume is#Vector(to_deposit);
+    assume $LibraCoin_T_is_well_formed(to_deposit);
     __m := UpdateLocal(__m, __frame + 1, to_deposit);
     assume $DebugTrackLocal(5, 1, 1, 4674, to_deposit);
 
@@ -1507,7 +1604,7 @@ ensures old(b#Boolean(Boolean(!(b#Boolean(ExistsResource(__m, LibraAccount_T_typ
     assume is#Address(payee);
     __m := UpdateLocal(__m, __frame + 0, payee);
     assume $DebugTrackLocal(5, 2, 0, 5450, payee);
-    assume is#Vector(to_deposit);
+    assume $LibraCoin_T_is_well_formed(to_deposit);
     __m := UpdateLocal(__m, __frame + 1, to_deposit);
     assume $DebugTrackLocal(5, 2, 1, 5450, to_deposit);
     assume is#ByteArray(metadata);
@@ -1602,7 +1699,7 @@ ensures old(b#Boolean(Boolean(!(b#Boolean(ExistsResource(__m, LibraAccount_T_typ
     assume is#Address(sender);
     __m := UpdateLocal(__m, __frame + 1, sender);
     assume $DebugTrackLocal(5, 3, 1, 6415, sender);
-    assume is#Vector(to_deposit);
+    assume $LibraCoin_T_is_well_formed(to_deposit);
     __m := UpdateLocal(__m, __frame + 2, to_deposit);
     assume $DebugTrackLocal(5, 3, 2, 6415, to_deposit);
     assume is#ByteArray(metadata);
@@ -1613,7 +1710,7 @@ ensures old(b#Boolean(Boolean(!(b#Boolean(ExistsResource(__m, LibraAccount_T_typ
     __local_counter := __local_counter + 33;
 
     // bytecode translation starts here
-    call __t7 := BorrowLoc(__frame + 2);
+    call __t7 := BorrowLoc(__frame + 2, LibraCoin_T_type_value());
 
     call __t8 := LibraCoin_value(__t7);
     if (__abort_flag) {
@@ -1659,7 +1756,7 @@ Label_10:
     }
 
     call sender_account_ref := CopyOrMoveRef(__t15);
-    assume is#Vector(Dereference(__m, sender_account_ref));
+    assume $LibraAccount_T_is_well_formed(Dereference(__m, sender_account_ref));
     assume $DebugTrackLocal(5, 3, 6, 7406, Dereference(__m, sender_account_ref));
 
     call __t16 := CopyOrMoveRef(sender_account_ref);
@@ -1675,7 +1772,7 @@ Label_10:
     call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 3));
     __m := UpdateLocal(__m, __frame + 20, __tmp);
 
-    call __tmp := Pack_LibraAccount_SentPaymentEvent(GetLocal(__m, __frame + 18), GetLocal(__m, __frame + 19), GetLocal(__m, __frame + 20));
+    call __tmp := Pack_LibraAccount_SentPaymentEvent(0, 0, 0, 0, GetLocal(__m, __frame + 18), GetLocal(__m, __frame + 19), GetLocal(__m, __frame + 20));
     __m := UpdateLocal(__m, __frame + 21, __tmp);
 
     call LibraAccount_emit_event(LibraAccount_SentPaymentEvent_type_value(), __t17, GetLocal(__m, __frame + 21));
@@ -1694,7 +1791,7 @@ Label_10:
     }
 
     call payee_account_ref := CopyOrMoveRef(__t23);
-    assume is#Vector(Dereference(__m, payee_account_ref));
+    assume $LibraAccount_T_is_well_formed(Dereference(__m, payee_account_ref));
     assume $DebugTrackLocal(5, 3, 5, 7818, Dereference(__m, payee_account_ref));
 
     call __t24 := CopyOrMoveRef(payee_account_ref);
@@ -1723,7 +1820,7 @@ Label_10:
     call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 3));
     __m := UpdateLocal(__m, __frame + 31, __tmp);
 
-    call __tmp := Pack_LibraAccount_ReceivedPaymentEvent(GetLocal(__m, __frame + 29), GetLocal(__m, __frame + 30), GetLocal(__m, __frame + 31));
+    call __tmp := Pack_LibraAccount_ReceivedPaymentEvent(0, 0, 0, 0, GetLocal(__m, __frame + 29), GetLocal(__m, __frame + 30), GetLocal(__m, __frame + 31));
     __m := UpdateLocal(__m, __frame + 32, __tmp);
 
     call LibraAccount_emit_event(LibraAccount_ReceivedPaymentEvent_type_value(), __t28, GetLocal(__m, __frame + 32));
@@ -1817,7 +1914,7 @@ Label_6:
       assume $DebugTrackAbort(5, 4, 10052);
       goto Label_Abort;
     }
-    assume is#Vector(__t8);
+    assume $LibraCoin_T_is_well_formed(__t8);
 
     __m := UpdateLocal(__m, __frame + 8, __t8);
 
@@ -1865,9 +1962,8 @@ ensures old(b#Boolean(Boolean(i#Integer(SelectField(SelectField(Dereference(__m,
     __frame := __local_counter;
 
     // process and type check arguments
-    assume is#Vector(Dereference(__m, account));
-    assume IsValidReferenceParameter(__m, __local_counter, account);
-    assume is#Vector(Dereference(__m, account));
+    assume $LibraAccount_T_is_well_formed(Dereference(__m, account)) && IsValidReferenceParameter(__m, __local_counter, account);
+    assume $LibraAccount_T_is_well_formed(Dereference(__m, account));
     assume $DebugTrackLocal(5, 5, 0, 10231, Dereference(__m, account));
     assume IsValidU64(amount);
     __m := UpdateLocal(__m, __frame + 1, amount);
@@ -1889,9 +1985,11 @@ ensures old(b#Boolean(Boolean(i#Integer(SelectField(SelectField(Dereference(__m,
       assume $DebugTrackAbort(5, 5, 10530);
       goto Label_Abort;
     }
-    assume is#Vector(__t6);
+    assume $LibraCoin_T_is_well_formed(__t6);
 
     __m := UpdateLocal(__m, __frame + 6, __t6);
+    assume $LibraAccount_T_is_well_formed(Dereference(__m, account));
+    assume $DebugTrackLocal(5, 5, 0, 10530, Dereference(__m, account));
 
     call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 6));
     __m := UpdateLocal(__m, __frame + 2, __tmp);
@@ -1963,7 +2061,7 @@ ensures old(b#Boolean(SelectField(Dereference(__m, GetResourceReference(LibraAcc
     }
 
     call sender_account := CopyOrMoveRef(__t3);
-    assume is#Vector(Dereference(__m, sender_account));
+    assume $LibraAccount_T_is_well_formed(Dereference(__m, sender_account));
     assume $DebugTrackLocal(5, 6, 1, 11129, Dereference(__m, sender_account));
 
     call __t4 := CopyOrMoveRef(sender_account);
@@ -1993,7 +2091,7 @@ Label_9:
       assume $DebugTrackAbort(5, 6, 11491);
       goto Label_Abort;
     }
-    assume is#Vector(__t10);
+    assume $LibraCoin_T_is_well_formed(__t10);
 
     __m := UpdateLocal(__m, __frame + 10, __t10);
 
@@ -2040,9 +2138,8 @@ ensures old(b#Boolean(Boolean(!(b#Boolean(ExistsResource(__m, LibraAccount_T_typ
     __frame := __local_counter;
 
     // process and type check arguments
-    assume is#Vector(Dereference(__m, cap));
-    assume IsValidReferenceParameter(__m, __local_counter, cap);
-    assume is#Vector(Dereference(__m, cap));
+    assume $LibraAccount_WithdrawalCapability_is_well_formed(Dereference(__m, cap)) && IsValidReferenceParameter(__m, __local_counter, cap);
+    assume $LibraAccount_WithdrawalCapability_is_well_formed(Dereference(__m, cap));
     assume $DebugTrackLocal(5, 7, 0, 11652, Dereference(__m, cap));
     assume IsValidU64(amount);
     __m := UpdateLocal(__m, __frame + 1, amount);
@@ -2067,7 +2164,7 @@ ensures old(b#Boolean(Boolean(!(b#Boolean(ExistsResource(__m, LibraAccount_T_typ
     }
 
     call account := CopyOrMoveRef(__t6);
-    assume is#Vector(Dereference(__m, account));
+    assume $LibraAccount_T_is_well_formed(Dereference(__m, account));
     assume $DebugTrackLocal(5, 7, 2, 12125, Dereference(__m, account));
 
     call __t7 := CopyOrMoveRef(account);
@@ -2080,7 +2177,7 @@ ensures old(b#Boolean(Boolean(!(b#Boolean(ExistsResource(__m, LibraAccount_T_typ
       assume $DebugTrackAbort(5, 7, 12201);
       goto Label_Abort;
     }
-    assume is#Vector(__t9);
+    assume $LibraCoin_T_is_well_formed(__t9);
 
     __m := UpdateLocal(__m, __frame + 9, __t9);
 
@@ -2156,7 +2253,7 @@ ensures old(b#Boolean(Boolean(!(b#Boolean(ExistsResource(__m, LibraAccount_T_typ
     }
 
     call sender_account := CopyOrMoveRef(__t5);
-    assume is#Vector(Dereference(__m, sender_account));
+    assume $LibraAccount_T_is_well_formed(Dereference(__m, sender_account));
     assume $DebugTrackLocal(5, 8, 1, 12875, Dereference(__m, sender_account));
 
     call __t6 := CopyOrMoveRef(sender_account);
@@ -2189,10 +2286,11 @@ Label_13:
 
     call WriteRef(__t12, GetLocal(__m, __frame + 11));
 
+
     call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 0));
     __m := UpdateLocal(__m, __frame + 13, __tmp);
 
-    call __tmp := Pack_LibraAccount_WithdrawalCapability(GetLocal(__m, __frame + 13));
+    call __tmp := Pack_LibraAccount_WithdrawalCapability(0, 0, 0, 0, GetLocal(__m, __frame + 13));
     __m := UpdateLocal(__m, __frame + 14, __tmp);
 
     __ret0 := GetLocal(__m, __frame + 14);
@@ -2238,7 +2336,7 @@ ensures old(b#Boolean(Boolean(!(b#Boolean(ExistsResource(__m, LibraAccount_T_typ
     __frame := __local_counter;
 
     // process and type check arguments
-    assume is#Vector(cap);
+    assume $LibraAccount_WithdrawalCapability_is_well_formed(cap);
     __m := UpdateLocal(__m, __frame + 0, cap);
     assume $DebugTrackLocal(5, 9, 0, 13429, cap);
 
@@ -2266,7 +2364,7 @@ ensures old(b#Boolean(Boolean(!(b#Boolean(ExistsResource(__m, LibraAccount_T_typ
     }
 
     call account := CopyOrMoveRef(__t6);
-    assume is#Vector(Dereference(__m, account));
+    assume $LibraAccount_T_is_well_formed(Dereference(__m, account));
     assume $DebugTrackLocal(5, 9, 2, 13847, Dereference(__m, account));
 
     call __tmp := LdFalse();
@@ -2277,6 +2375,7 @@ ensures old(b#Boolean(Boolean(!(b#Boolean(ExistsResource(__m, LibraAccount_T_typ
     call __t9 := BorrowField(__t8, LibraAccount_T_delegated_withdrawal_capability);
 
     call WriteRef(__t9, GetLocal(__m, __frame + 7));
+
 
     return;
 
@@ -2322,9 +2421,8 @@ ensures b#Boolean(Boolean(b#Boolean(Boolean(!(b#Boolean(Boolean(!(b#Boolean(old(
     assume is#Address(payee);
     __m := UpdateLocal(__m, __frame + 0, payee);
     assume $DebugTrackLocal(5, 10, 0, 14433, payee);
-    assume is#Vector(Dereference(__m, cap));
-    assume IsValidReferenceParameter(__m, __local_counter, cap);
-    assume is#Vector(Dereference(__m, cap));
+    assume $LibraAccount_WithdrawalCapability_is_well_formed(Dereference(__m, cap)) && IsValidReferenceParameter(__m, __local_counter, cap);
+    assume $LibraAccount_WithdrawalCapability_is_well_formed(Dereference(__m, cap));
     assume $DebugTrackLocal(5, 10, 1, 14433, Dereference(__m, cap));
     assume IsValidU64(amount);
     __m := UpdateLocal(__m, __frame + 2, amount);
@@ -2380,7 +2478,7 @@ Label_6:
       assume $DebugTrackAbort(5, 10, 15742);
       goto Label_Abort;
     }
-    assume is#Vector(__t14);
+    assume $LibraCoin_T_is_well_formed(__t14);
 
     __m := UpdateLocal(__m, __frame + 14, __t14);
 
@@ -2507,7 +2605,7 @@ Label_13:
       assume $DebugTrackAbort(5, 11, 17383);
       goto Label_Abort;
     }
-    assume is#Vector(__t14);
+    assume $LibraCoin_T_is_well_formed(__t14);
 
     __m := UpdateLocal(__m, __frame + 14, __t14);
 
@@ -2639,9 +2737,8 @@ ensures b#Boolean(Boolean(IsEqual(SelectField(Dereference(__m, account), LibraAc
     __frame := __local_counter;
 
     // process and type check arguments
-    assume is#Vector(Dereference(__m, account));
-    assume IsValidReferenceParameter(__m, __local_counter, account);
-    assume is#Vector(Dereference(__m, account));
+    assume $LibraAccount_T_is_well_formed(Dereference(__m, account)) && IsValidReferenceParameter(__m, __local_counter, account);
+    assume $LibraAccount_T_is_well_formed(Dereference(__m, account));
     assume $DebugTrackLocal(5, 13, 0, 18853, Dereference(__m, account));
     assume is#ByteArray(new_authentication_key);
     __m := UpdateLocal(__m, __frame + 1, new_authentication_key);
@@ -2659,6 +2756,8 @@ ensures b#Boolean(Boolean(IsEqual(SelectField(Dereference(__m, account), LibraAc
     call __t4 := BorrowField(__t3, LibraAccount_T_authentication_key);
 
     call WriteRef(__t4, GetLocal(__m, __frame + 2));
+    assume $LibraAccount_T_is_well_formed(Dereference(__m, account));
+    assume $DebugTrackLocal(5, 13, 0, 19031, Dereference(__m, account));
 
     return;
 
@@ -2718,7 +2817,7 @@ ensures old(b#Boolean(Boolean(!(b#Boolean(ExistsResource(__m, LibraAccount_T_typ
     }
 
     call sender_account := CopyOrMoveRef(__t3);
-    assume is#Vector(Dereference(__m, sender_account));
+    assume $LibraAccount_T_is_well_formed(Dereference(__m, sender_account));
     assume $DebugTrackLocal(5, 14, 1, 19616, Dereference(__m, sender_account));
 
     call __t4 := CopyOrMoveRef(sender_account);
@@ -2784,9 +2883,8 @@ ensures old(b#Boolean(Boolean(!(b#Boolean(ExistsResource(__m, LibraAccount_T_typ
     __frame := __local_counter;
 
     // process and type check arguments
-    assume is#Vector(Dereference(__m, cap));
-    assume IsValidReferenceParameter(__m, __local_counter, cap);
-    assume is#Vector(Dereference(__m, cap));
+    assume $LibraAccount_KeyRotationCapability_is_well_formed(Dereference(__m, cap)) && IsValidReferenceParameter(__m, __local_counter, cap);
+    assume $LibraAccount_KeyRotationCapability_is_well_formed(Dereference(__m, cap));
     assume $DebugTrackLocal(5, 15, 0, 20225, Dereference(__m, cap));
     assume is#ByteArray(new_authentication_key);
     __m := UpdateLocal(__m, __frame + 1, new_authentication_key);
@@ -2912,10 +3010,11 @@ Label_11:
 
     call WriteRef(__t10, GetLocal(__m, __frame + 9));
 
+
     call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 0));
     __m := UpdateLocal(__m, __frame + 11, __tmp);
 
-    call __tmp := Pack_LibraAccount_KeyRotationCapability(GetLocal(__m, __frame + 11));
+    call __tmp := Pack_LibraAccount_KeyRotationCapability(0, 0, 0, 0, GetLocal(__m, __frame + 11));
     __m := UpdateLocal(__m, __frame + 12, __tmp);
 
     __ret0 := GetLocal(__m, __frame + 12);
@@ -2961,7 +3060,7 @@ ensures old(b#Boolean(Boolean(!(b#Boolean(ExistsResource(__m, LibraAccount_T_typ
     __frame := __local_counter;
 
     // process and type check arguments
-    assume is#Vector(cap);
+    assume $LibraAccount_KeyRotationCapability_is_well_formed(cap);
     __m := UpdateLocal(__m, __frame + 0, cap);
     assume $DebugTrackLocal(5, 17, 0, 21751, cap);
 
@@ -2989,7 +3088,7 @@ ensures old(b#Boolean(Boolean(!(b#Boolean(ExistsResource(__m, LibraAccount_T_typ
     }
 
     call account := CopyOrMoveRef(__t6);
-    assume is#Vector(Dereference(__m, account));
+    assume $LibraAccount_T_is_well_formed(Dereference(__m, account));
     assume $DebugTrackLocal(5, 17, 2, 22175, Dereference(__m, account));
 
     call __tmp := LdFalse();
@@ -3000,6 +3099,7 @@ ensures old(b#Boolean(Boolean(!(b#Boolean(ExistsResource(__m, LibraAccount_T_typ
     call __t9 := BorrowField(__t8, LibraAccount_T_delegated_key_rotation_capability);
 
     call WriteRef(__t9, GetLocal(__m, __frame + 7));
+
 
     return;
 
@@ -3063,7 +3163,7 @@ ensures old(b#Boolean(ExistsResource(__m, LibraAccount_T_type_value(), a#Address
     call __tmp := LdConst(0);
     __m := UpdateLocal(__m, __frame + 2, __tmp);
 
-    call __tmp := Pack_LibraAccount_EventHandleGenerator(GetLocal(__m, __frame + 2));
+    call __tmp := Pack_LibraAccount_EventHandleGenerator(5, 18, 1, 23026, GetLocal(__m, __frame + 2));
     __m := UpdateLocal(__m, __frame + 3, __tmp);
 
     call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 3));
@@ -3090,7 +3190,7 @@ ensures old(b#Boolean(ExistsResource(__m, LibraAccount_T_type_value(), a#Address
       assume $DebugTrackAbort(5, 18, 23249);
       goto Label_Abort;
     }
-    assume is#Vector(__t7);
+    assume $LibraCoin_T_is_well_formed(__t7);
 
     __m := UpdateLocal(__m, __frame + 7, __t7);
 
@@ -3100,7 +3200,7 @@ ensures old(b#Boolean(ExistsResource(__m, LibraAccount_T_type_value(), a#Address
     call __tmp := LdFalse();
     __m := UpdateLocal(__m, __frame + 9, __tmp);
 
-    call __t10 := BorrowLoc(__frame + 1);
+    call __t10 := BorrowLoc(__frame + 1, LibraAccount_EventHandleGenerator_type_value());
 
     call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 0));
     __m := UpdateLocal(__m, __frame + 11, __tmp);
@@ -3110,12 +3210,12 @@ ensures old(b#Boolean(ExistsResource(__m, LibraAccount_T_type_value(), a#Address
       assume $DebugTrackAbort(5, 18, 23414);
       goto Label_Abort;
     }
-    assume is#Vector(__t12);
+    assume $LibraAccount_EventHandle_is_well_formed(__t12);
 
     __m := UpdateLocal(__m, __frame + 12, __t12);
     assume $DebugTrackLocal(5, 18, 1, 23414, GetLocal(__m, __frame + 1));
 
-    call __t13 := BorrowLoc(__frame + 1);
+    call __t13 := BorrowLoc(__frame + 1, LibraAccount_EventHandleGenerator_type_value());
 
     call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 0));
     __m := UpdateLocal(__m, __frame + 14, __tmp);
@@ -3125,7 +3225,7 @@ ensures old(b#Boolean(ExistsResource(__m, LibraAccount_T_type_value(), a#Address
       assume $DebugTrackAbort(5, 18, 23535);
       goto Label_Abort;
     }
-    assume is#Vector(__t15);
+    assume $LibraAccount_EventHandle_is_well_formed(__t15);
 
     __m := UpdateLocal(__m, __frame + 15, __t15);
     assume $DebugTrackLocal(5, 18, 1, 23535, GetLocal(__m, __frame + 1));
@@ -3136,7 +3236,7 @@ ensures old(b#Boolean(ExistsResource(__m, LibraAccount_T_type_value(), a#Address
     call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 1));
     __m := UpdateLocal(__m, __frame + 17, __tmp);
 
-    call __tmp := Pack_LibraAccount_T(GetLocal(__m, __frame + 6), GetLocal(__m, __frame + 7), GetLocal(__m, __frame + 8), GetLocal(__m, __frame + 9), GetLocal(__m, __frame + 12), GetLocal(__m, __frame + 15), GetLocal(__m, __frame + 16), GetLocal(__m, __frame + 17));
+    call __tmp := Pack_LibraAccount_T(0, 0, 0, 0, GetLocal(__m, __frame + 6), GetLocal(__m, __frame + 7), GetLocal(__m, __frame + 8), GetLocal(__m, __frame + 9), GetLocal(__m, __frame + 12), GetLocal(__m, __frame + 15), GetLocal(__m, __frame + 16), GetLocal(__m, __frame + 17));
     __m := UpdateLocal(__m, __frame + 18, __tmp);
 
     call LibraAccount_save_account(GetLocal(__m, __frame + 4), GetLocal(__m, __frame + 18));
@@ -3263,9 +3363,8 @@ ensures b#Boolean(Boolean(IsEqual(__ret0, SelectField(SelectField(Dereference(__
     __frame := __local_counter;
 
     // process and type check arguments
-    assume is#Vector(Dereference(__m, account));
-    assume IsValidReferenceParameter(__m, __local_counter, account);
-    assume is#Vector(Dereference(__m, account));
+    assume $LibraAccount_T_is_well_formed(Dereference(__m, account)) && IsValidReferenceParameter(__m, __local_counter, account);
+    assume $LibraAccount_T_is_well_formed(Dereference(__m, account));
     assume $DebugTrackLocal(5, 21, 0, 25151, Dereference(__m, account));
 
     // increase the local counter
@@ -3389,9 +3488,8 @@ ensures b#Boolean(Boolean(IsEqual(__ret0, SelectField(Dereference(__m, account),
     __frame := __local_counter;
 
     // process and type check arguments
-    assume is#Vector(Dereference(__m, account));
-    assume IsValidReferenceParameter(__m, __local_counter, account);
-    assume is#Vector(Dereference(__m, account));
+    assume $LibraAccount_T_is_well_formed(Dereference(__m, account)) && IsValidReferenceParameter(__m, __local_counter, account);
+    assume $LibraAccount_T_is_well_formed(Dereference(__m, account));
     assume $DebugTrackLocal(5, 23, 0, 25787, Dereference(__m, account));
 
     // increase the local counter
@@ -3624,9 +3722,8 @@ ensures b#Boolean(Boolean((__ret0) == (SelectFieldFromRef(cap, LibraAccount_With
     __frame := __local_counter;
 
     // process and type check arguments
-    assume is#Vector(Dereference(__m, cap));
-    assume IsValidReferenceParameter(__m, __local_counter, cap);
-    assume is#Vector(Dereference(__m, cap));
+    assume $LibraAccount_WithdrawalCapability_is_well_formed(Dereference(__m, cap)) && IsValidReferenceParameter(__m, __local_counter, cap);
+    assume $LibraAccount_WithdrawalCapability_is_well_formed(Dereference(__m, cap));
     assume $DebugTrackLocal(5, 27, 0, 27134, Dereference(__m, cap));
 
     // increase the local counter
@@ -3671,9 +3768,8 @@ ensures b#Boolean(Boolean((__ret0) == (SelectFieldFromRef(cap, LibraAccount_KeyR
     __frame := __local_counter;
 
     // process and type check arguments
-    assume is#Vector(Dereference(__m, cap));
-    assume IsValidReferenceParameter(__m, __local_counter, cap);
-    assume is#Vector(Dereference(__m, cap));
+    assume $LibraAccount_KeyRotationCapability_is_well_formed(Dereference(__m, cap)) && IsValidReferenceParameter(__m, __local_counter, cap);
+    assume $LibraAccount_KeyRotationCapability_is_well_formed(Dereference(__m, cap));
     assume $DebugTrackLocal(5, 28, 0, 27410, Dereference(__m, cap));
 
     // increase the local counter
@@ -3860,7 +3956,7 @@ Label_8:
     }
 
     call sender_account := CopyOrMoveRef(__t16);
-    assume is#Vector(Dereference(__m, sender_account));
+    assume $LibraAccount_T_is_well_formed(Dereference(__m, sender_account));
     assume $DebugTrackLocal(5, 30, 5, 28780, Dereference(__m, sender_account));
 
     call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 1));
@@ -3920,7 +4016,7 @@ Label_21:
     call __t29 := FreezeRef(__t28);
 
     call imm_sender_account := CopyOrMoveRef(__t29);
-    assume is#Vector(Dereference(__m, imm_sender_account));
+    assume $LibraAccount_T_is_well_formed(Dereference(__m, imm_sender_account));
     assume $DebugTrackLocal(5, 30, 6, 29235, Dereference(__m, imm_sender_account));
 
     call __t30 := CopyOrMoveRef(imm_sender_account);
@@ -4100,7 +4196,7 @@ requires ExistsTxnSenderAccount(__m, __txn);
     }
 
     call sender_account := CopyOrMoveRef(__t10);
-    assume is#Vector(Dereference(__m, sender_account));
+    assume $LibraAccount_T_is_well_formed(Dereference(__m, sender_account));
     assume $DebugTrackLocal(5, 31, 4, 30331, Dereference(__m, sender_account));
 
     call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 1));
@@ -4135,7 +4231,7 @@ requires ExistsTxnSenderAccount(__m, __txn);
     call __t17 := FreezeRef(__t16);
 
     call imm_sender_account := CopyOrMoveRef(__t17);
-    assume is#Vector(Dereference(__m, imm_sender_account));
+    assume $LibraAccount_T_is_well_formed(Dereference(__m, imm_sender_account));
     assume $DebugTrackLocal(5, 31, 6, 30545, Dereference(__m, imm_sender_account));
 
     call __t18 := CopyOrMoveRef(imm_sender_account);
@@ -4177,7 +4273,7 @@ Label_20:
       assume $DebugTrackAbort(5, 31, 30771);
       goto Label_Abort;
     }
-    assume is#Vector(__t26);
+    assume $LibraCoin_T_is_well_formed(__t26);
 
     __m := UpdateLocal(__m, __frame + 26, __t26);
 
@@ -4204,6 +4300,7 @@ Label_20:
 
     call WriteRef(__t31, GetLocal(__m, __frame + 29));
 
+
     call __tmp := LdAddr(4078);
     __m := UpdateLocal(__m, __frame + 32, __tmp);
 
@@ -4214,7 +4311,7 @@ Label_20:
     }
 
     call transaction_fee_account := CopyOrMoveRef(__t33);
-    assume is#Vector(Dereference(__m, transaction_fee_account));
+    assume $LibraAccount_T_is_well_formed(Dereference(__m, transaction_fee_account));
     assume $DebugTrackLocal(5, 31, 5, 31092, Dereference(__m, transaction_fee_account));
 
     call __t34 := CopyOrMoveRef(transaction_fee_account);
@@ -4280,9 +4377,8 @@ ensures old(b#Boolean(Boolean(i#Integer(Integer(i#Integer(SelectField(Dereferenc
     __frame := __local_counter;
 
     // process and type check arguments
-    assume is#Vector(Dereference(__m, counter));
-    assume IsValidReferenceParameter(__m, __local_counter, counter);
-    assume is#Vector(Dereference(__m, counter));
+    assume $LibraAccount_EventHandleGenerator_is_well_formed(Dereference(__m, counter)) && IsValidReferenceParameter(__m, __local_counter, counter);
+    assume $LibraAccount_EventHandleGenerator_is_well_formed(Dereference(__m, counter));
     assume $DebugTrackLocal(5, 32, 0, 31860, Dereference(__m, counter));
     assume is#Address(sender);
     __m := UpdateLocal(__m, __frame + 1, sender);
@@ -4354,6 +4450,8 @@ ensures old(b#Boolean(Boolean(i#Integer(Integer(i#Integer(SelectField(Dereferenc
     call __t17 := CopyOrMoveRef(count);
 
     call WriteRef(__t17, GetLocal(__m, __frame + 16));
+    assume $LibraAccount_EventHandleGenerator_is_well_formed(Dereference(__m, counter));
+    assume $DebugTrackLocal(5, 32, 0, 32310, Dereference(__m, counter));
 
     call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 3));
     __m := UpdateLocal(__m, __frame + 18, __tmp);
@@ -4415,9 +4513,8 @@ ensures old(b#Boolean(Boolean(i#Integer(Integer(i#Integer(SelectField(Dereferenc
     __frame := __local_counter;
 
     // process and type check arguments
-    assume is#Vector(Dereference(__m, counter));
-    assume IsValidReferenceParameter(__m, __local_counter, counter);
-    assume is#Vector(Dereference(__m, counter));
+    assume $LibraAccount_EventHandleGenerator_is_well_formed(Dereference(__m, counter)) && IsValidReferenceParameter(__m, __local_counter, counter);
+    assume $LibraAccount_EventHandleGenerator_is_well_formed(Dereference(__m, counter));
     assume $DebugTrackLocal(5, 33, 0, 32671, Dereference(__m, counter));
     assume is#Address(sender);
     __m := UpdateLocal(__m, __frame + 1, sender);
@@ -4443,8 +4540,10 @@ ensures old(b#Boolean(Boolean(i#Integer(Integer(i#Integer(SelectField(Dereferenc
     assume is#ByteArray(__t5);
 
     __m := UpdateLocal(__m, __frame + 5, __t5);
+    assume $LibraAccount_EventHandleGenerator_is_well_formed(Dereference(__m, counter));
+    assume $DebugTrackLocal(5, 33, 0, 32894, Dereference(__m, counter));
 
-    call __tmp := Pack_LibraAccount_EventHandle(tv0, GetLocal(__m, __frame + 2), GetLocal(__m, __frame + 5));
+    call __tmp := Pack_LibraAccount_EventHandle(0, 0, 0, 0, tv0, GetLocal(__m, __frame + 2), GetLocal(__m, __frame + 5));
     __m := UpdateLocal(__m, __frame + 6, __tmp);
 
     __ret0 := GetLocal(__m, __frame + 6);
@@ -4503,7 +4602,7 @@ ensures old(b#Boolean(Boolean(i#Integer(Integer(i#Integer(SelectField(SelectFiel
     }
 
     call sender_account_ref := CopyOrMoveRef(__t3);
-    assume is#Vector(Dereference(__m, sender_account_ref));
+    assume $LibraAccount_T_is_well_formed(Dereference(__m, sender_account_ref));
     assume $DebugTrackLocal(5, 34, 0, 33314, Dereference(__m, sender_account_ref));
 
     call __t4 := CopyOrMoveRef(sender_account_ref);
@@ -4518,7 +4617,7 @@ ensures old(b#Boolean(Boolean(i#Integer(Integer(i#Integer(SelectField(SelectFiel
       assume $DebugTrackAbort(5, 34, 33390);
       goto Label_Abort;
     }
-    assume is#Vector(__t7);
+    assume $LibraAccount_EventHandle_is_well_formed(__t7);
 
     __m := UpdateLocal(__m, __frame + 7, __t7);
 
@@ -4571,9 +4670,8 @@ ensures old(b#Boolean(Boolean(i#Integer(Integer(i#Integer(SelectField(Dereferenc
     __frame := __local_counter;
 
     // process and type check arguments
-    assume is#Vector(Dereference(__m, handle_ref));
-    assume IsValidReferenceParameter(__m, __local_counter, handle_ref);
-    assume is#Vector(Dereference(__m, handle_ref));
+    assume $LibraAccount_EventHandle_is_well_formed(Dereference(__m, handle_ref)) && IsValidReferenceParameter(__m, __local_counter, handle_ref);
+    assume $LibraAccount_EventHandle_is_well_formed(Dereference(__m, handle_ref));
     assume $DebugTrackLocal(5, 35, 0, 33671, Dereference(__m, handle_ref));
     __m := UpdateLocal(__m, __frame + 1, msg);
     assume $DebugTrackLocal(5, 35, 1, 33671, msg);
@@ -4639,6 +4737,8 @@ ensures old(b#Boolean(Boolean(i#Integer(Integer(i#Integer(SelectField(Dereferenc
     call __t17 := CopyOrMoveRef(count);
 
     call WriteRef(__t17, GetLocal(__m, __frame + 16));
+    assume $LibraAccount_EventHandle_is_well_formed(Dereference(__m, handle_ref));
+    assume $DebugTrackLocal(5, 35, 0, 34041, Dereference(__m, handle_ref));
 
     return;
 
@@ -4675,7 +4775,7 @@ ensures old(b#Boolean(Boolean(false))) ==> __abort_flag;
     __frame := __local_counter;
 
     // process and type check arguments
-    assume is#Vector(handle);
+    assume $LibraAccount_EventHandle_is_well_formed(handle);
     __m := UpdateLocal(__m, __frame + 0, handle);
     assume $DebugTrackLocal(5, 37, 0, 34391, handle);
 

--- a/language/move-prover/bytecode-to-boogie/tests/goldenfiles/libra_coin.bpl
+++ b/language/move-prover/bytecode-to-boogie/tests/goldenfiles/libra_coin.bpl
@@ -1,5 +1,9 @@
 
 
+// ** synthetics of module LibraCoin
+
+
+
 // ** structs of module LibraCoin
 
 const unique LibraCoin_T: TypeName;
@@ -8,10 +12,16 @@ axiom LibraCoin_T_value == 0;
 function LibraCoin_T_type_value(): TypeValue {
     StructType(LibraCoin_T, ExtendTypeValueArray(EmptyTypeValueArray, IntegerType()))
 }
-procedure {:inline 1} Pack_LibraCoin_T(value: Value) returns (_struct: Value)
+function {:inline 1} $LibraCoin_T_is_well_formed(__this: Value): bool {
+    is#Vector(__this)
+        && IsValidU64(SelectField(__this, LibraCoin_T_value))
+}
+
+procedure {:inline 1} Pack_LibraCoin_T(module_idx: int, func_idx: int, var_idx: int, code_idx: int, value: Value) returns (_struct: Value)
 {
     assume IsValidU64(value);
     _struct := Vector(ExtendValueArray(EmptyValueArray, value));
+    if (code_idx > 0) { assume $DebugTrackLocal(module_idx, func_idx, var_idx, code_idx, _struct); }
 }
 
 procedure {:inline 1} Unpack_LibraCoin_T(_struct: Value) returns (value: Value)
@@ -27,10 +37,16 @@ axiom LibraCoin_MintCapability__dummy == 0;
 function LibraCoin_MintCapability_type_value(): TypeValue {
     StructType(LibraCoin_MintCapability, ExtendTypeValueArray(EmptyTypeValueArray, BooleanType()))
 }
-procedure {:inline 1} Pack_LibraCoin_MintCapability(_dummy: Value) returns (_struct: Value)
+function {:inline 1} $LibraCoin_MintCapability_is_well_formed(__this: Value): bool {
+    is#Vector(__this)
+        && is#Boolean(SelectField(__this, LibraCoin_MintCapability__dummy))
+}
+
+procedure {:inline 1} Pack_LibraCoin_MintCapability(module_idx: int, func_idx: int, var_idx: int, code_idx: int, _dummy: Value) returns (_struct: Value)
 {
     assume is#Boolean(_dummy);
     _struct := Vector(ExtendValueArray(EmptyValueArray, _dummy));
+    if (code_idx > 0) { assume $DebugTrackLocal(module_idx, func_idx, var_idx, code_idx, _struct); }
 }
 
 procedure {:inline 1} Unpack_LibraCoin_MintCapability(_struct: Value) returns (_dummy: Value)
@@ -46,10 +62,16 @@ axiom LibraCoin_MarketCap_total_value == 0;
 function LibraCoin_MarketCap_type_value(): TypeValue {
     StructType(LibraCoin_MarketCap, ExtendTypeValueArray(EmptyTypeValueArray, IntegerType()))
 }
-procedure {:inline 1} Pack_LibraCoin_MarketCap(total_value: Value) returns (_struct: Value)
+function {:inline 1} $LibraCoin_MarketCap_is_well_formed(__this: Value): bool {
+    is#Vector(__this)
+        && IsValidU64(SelectField(__this, LibraCoin_MarketCap_total_value))
+}
+
+procedure {:inline 1} Pack_LibraCoin_MarketCap(module_idx: int, func_idx: int, var_idx: int, code_idx: int, total_value: Value) returns (_struct: Value)
 {
     assume IsValidU64(total_value);
     _struct := Vector(ExtendValueArray(EmptyValueArray, total_value));
+    if (code_idx > 0) { assume $DebugTrackLocal(module_idx, func_idx, var_idx, code_idx, _struct); }
 }
 
 procedure {:inline 1} Unpack_LibraCoin_MarketCap(_struct: Value) returns (total_value: Value)
@@ -111,7 +133,7 @@ ensures old(b#Boolean(Boolean(!(b#Boolean(ExistsResource(__m, LibraCoin_MintCapa
       assume $DebugTrackAbort(0, 0, 1408);
       goto Label_Abort;
     }
-    assume is#Vector(__t4);
+    assume $LibraCoin_T_is_well_formed(__t4);
 
     __m := UpdateLocal(__m, __frame + 4, __t4);
 
@@ -175,9 +197,8 @@ ensures old(b#Boolean(Boolean(!(b#Boolean(ExistsResource(__m, LibraCoin_MarketCa
     assume IsValidU64(value);
     __m := UpdateLocal(__m, __frame + 0, value);
     assume $DebugTrackLocal(0, 1, 0, 1723, value);
-    assume is#Vector(Dereference(__m, capability));
-    assume IsValidReferenceParameter(__m, __local_counter, capability);
-    assume is#Vector(Dereference(__m, capability));
+    assume $LibraCoin_MintCapability_is_well_formed(Dereference(__m, capability)) && IsValidReferenceParameter(__m, __local_counter, capability);
+    assume $LibraCoin_MintCapability_is_well_formed(Dereference(__m, capability));
     assume $DebugTrackLocal(0, 1, 1, 1723, Dereference(__m, capability));
 
     // increase the local counter
@@ -229,7 +250,7 @@ Label_11:
     }
 
     call market_cap_ref := CopyOrMoveRef(__t13);
-    assume is#Vector(Dereference(__m, market_cap_ref));
+    assume $LibraCoin_MarketCap_is_well_formed(Dereference(__m, market_cap_ref));
     assume $DebugTrackLocal(0, 1, 2, 2898, Dereference(__m, market_cap_ref));
 
     call __t14 := CopyOrMoveRef(market_cap_ref);
@@ -263,10 +284,11 @@ Label_11:
 
     call WriteRef(__t21, GetLocal(__m, __frame + 19));
 
+
     call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 0));
     __m := UpdateLocal(__m, __frame + 22, __tmp);
 
-    call __tmp := Pack_LibraCoin_T(GetLocal(__m, __frame + 22));
+    call __tmp := Pack_LibraCoin_T(0, 0, 0, 0, GetLocal(__m, __frame + 22));
     __m := UpdateLocal(__m, __frame + 23, __tmp);
 
     __ret0 := GetLocal(__m, __frame + 23);
@@ -343,7 +365,7 @@ Label_7:
     call __tmp := LdTrue();
     __m := UpdateLocal(__m, __frame + 5, __tmp);
 
-    call __tmp := Pack_LibraCoin_MintCapability(GetLocal(__m, __frame + 5));
+    call __tmp := Pack_LibraCoin_MintCapability(0, 0, 0, 0, GetLocal(__m, __frame + 5));
     __m := UpdateLocal(__m, __frame + 6, __tmp);
 
     call MoveToSender(LibraCoin_MintCapability_type_value(), GetLocal(__m, __frame + 6));
@@ -355,7 +377,7 @@ Label_7:
     call __tmp := LdConst(0);
     __m := UpdateLocal(__m, __frame + 7, __tmp);
 
-    call __tmp := Pack_LibraCoin_MarketCap(GetLocal(__m, __frame + 7));
+    call __tmp := Pack_LibraCoin_MarketCap(0, 0, 0, 0, GetLocal(__m, __frame + 7));
     __m := UpdateLocal(__m, __frame + 8, __tmp);
 
     call MoveToSender(LibraCoin_MarketCap_type_value(), GetLocal(__m, __frame + 8));
@@ -460,7 +482,7 @@ ensures b#Boolean(Boolean(IsEqual(SelectField(__ret0, LibraCoin_T_value), Intege
     call __tmp := LdConst(0);
     __m := UpdateLocal(__m, __frame + 0, __tmp);
 
-    call __tmp := Pack_LibraCoin_T(GetLocal(__m, __frame + 0));
+    call __tmp := Pack_LibraCoin_T(0, 0, 0, 0, GetLocal(__m, __frame + 0));
     __m := UpdateLocal(__m, __frame + 1, __tmp);
 
     __ret0 := GetLocal(__m, __frame + 1);
@@ -497,9 +519,8 @@ ensures b#Boolean(Boolean(IsEqual(__ret0, SelectField(Dereference(__m, coin_ref)
     __frame := __local_counter;
 
     // process and type check arguments
-    assume is#Vector(Dereference(__m, coin_ref));
-    assume IsValidReferenceParameter(__m, __local_counter, coin_ref);
-    assume is#Vector(Dereference(__m, coin_ref));
+    assume $LibraCoin_T_is_well_formed(Dereference(__m, coin_ref)) && IsValidReferenceParameter(__m, __local_counter, coin_ref);
+    assume $LibraCoin_T_is_well_formed(Dereference(__m, coin_ref));
     assume $DebugTrackLocal(0, 5, 0, 4555, Dereference(__m, coin_ref));
 
     // increase the local counter
@@ -554,7 +575,7 @@ ensures old(b#Boolean(Boolean(i#Integer(SelectField(coin, LibraCoin_T_value)) < 
     __frame := __local_counter;
 
     // process and type check arguments
-    assume is#Vector(coin);
+    assume $LibraCoin_T_is_well_formed(coin);
     __m := UpdateLocal(__m, __frame + 0, coin);
     assume $DebugTrackLocal(0, 6, 0, 4818, coin);
     assume IsValidU64(amount);
@@ -565,7 +586,7 @@ ensures old(b#Boolean(Boolean(i#Integer(SelectField(coin, LibraCoin_T_value)) < 
     __local_counter := __local_counter + 8;
 
     // bytecode translation starts here
-    call __t3 := BorrowLoc(__frame + 0);
+    call __t3 := BorrowLoc(__frame + 0, LibraCoin_T_type_value());
 
     call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 1));
     __m := UpdateLocal(__m, __frame + 4, __tmp);
@@ -575,7 +596,7 @@ ensures old(b#Boolean(Boolean(i#Integer(SelectField(coin, LibraCoin_T_value)) < 
       assume $DebugTrackAbort(0, 6, 5045);
       goto Label_Abort;
     }
-    assume is#Vector(__t5);
+    assume $LibraCoin_T_is_well_formed(__t5);
 
     __m := UpdateLocal(__m, __frame + 5, __t5);
     assume $DebugTrackLocal(0, 6, 0, 5045, GetLocal(__m, __frame + 0));
@@ -644,9 +665,8 @@ ensures old(b#Boolean(Boolean(i#Integer(SelectField(Dereference(__m, coin_ref), 
     __frame := __local_counter;
 
     // process and type check arguments
-    assume is#Vector(Dereference(__m, coin_ref));
-    assume IsValidReferenceParameter(__m, __local_counter, coin_ref);
-    assume is#Vector(Dereference(__m, coin_ref));
+    assume $LibraCoin_T_is_well_formed(Dereference(__m, coin_ref)) && IsValidReferenceParameter(__m, __local_counter, coin_ref);
+    assume $LibraCoin_T_is_well_formed(Dereference(__m, coin_ref));
     assume $DebugTrackLocal(0, 7, 0, 5391, Dereference(__m, coin_ref));
     assume IsValidU64(amount);
     __m := UpdateLocal(__m, __frame + 1, amount);
@@ -707,11 +727,13 @@ Label_11:
     call __t15 := BorrowField(__t14, LibraCoin_T_value);
 
     call WriteRef(__t15, GetLocal(__m, __frame + 13));
+    assume $LibraCoin_T_is_well_formed(Dereference(__m, coin_ref));
+    assume $DebugTrackLocal(0, 7, 0, 5814, Dereference(__m, coin_ref));
 
     call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 1));
     __m := UpdateLocal(__m, __frame + 16, __tmp);
 
-    call __tmp := Pack_LibraCoin_T(GetLocal(__m, __frame + 16));
+    call __tmp := Pack_LibraCoin_T(0, 0, 0, 0, GetLocal(__m, __frame + 16));
     __m := UpdateLocal(__m, __frame + 17, __tmp);
 
     __ret0 := GetLocal(__m, __frame + 17);
@@ -751,10 +773,10 @@ ensures old(b#Boolean(Boolean(i#Integer(Integer(i#Integer(SelectField(coin1, Lib
     __frame := __local_counter;
 
     // process and type check arguments
-    assume is#Vector(coin1);
+    assume $LibraCoin_T_is_well_formed(coin1);
     __m := UpdateLocal(__m, __frame + 0, coin1);
     assume $DebugTrackLocal(0, 8, 0, 6020, coin1);
-    assume is#Vector(coin2);
+    assume $LibraCoin_T_is_well_formed(coin2);
     __m := UpdateLocal(__m, __frame + 1, coin2);
     assume $DebugTrackLocal(0, 8, 1, 6020, coin2);
 
@@ -762,7 +784,7 @@ ensures old(b#Boolean(Boolean(i#Integer(Integer(i#Integer(SelectField(coin1, Lib
     __local_counter := __local_counter + 5;
 
     // bytecode translation starts here
-    call __t2 := BorrowLoc(__frame + 0);
+    call __t2 := BorrowLoc(__frame + 0, LibraCoin_T_type_value());
 
     call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 1));
     __m := UpdateLocal(__m, __frame + 3, __tmp);
@@ -823,11 +845,10 @@ ensures old(b#Boolean(Boolean(i#Integer(Integer(i#Integer(SelectField(Dereferenc
     __frame := __local_counter;
 
     // process and type check arguments
-    assume is#Vector(Dereference(__m, coin_ref));
-    assume IsValidReferenceParameter(__m, __local_counter, coin_ref);
-    assume is#Vector(Dereference(__m, coin_ref));
+    assume $LibraCoin_T_is_well_formed(Dereference(__m, coin_ref)) && IsValidReferenceParameter(__m, __local_counter, coin_ref);
+    assume $LibraCoin_T_is_well_formed(Dereference(__m, coin_ref));
     assume $DebugTrackLocal(0, 9, 0, 6465, Dereference(__m, coin_ref));
-    assume is#Vector(check);
+    assume $LibraCoin_T_is_well_formed(check);
     __m := UpdateLocal(__m, __frame + 1, check);
     assume $DebugTrackLocal(0, 9, 1, 6465, check);
 
@@ -875,6 +896,8 @@ ensures old(b#Boolean(Boolean(i#Integer(Integer(i#Integer(SelectField(Dereferenc
     call __t13 := BorrowField(__t12, LibraCoin_T_value);
 
     call WriteRef(__t13, GetLocal(__m, __frame + 11));
+    assume $LibraCoin_T_is_well_formed(Dereference(__m, coin_ref));
+    assume $DebugTrackLocal(0, 9, 0, 6823, Dereference(__m, coin_ref));
 
     return;
 
@@ -914,7 +937,7 @@ ensures old(b#Boolean(Boolean(!IsEqual(SelectField(coin, LibraCoin_T_value), Int
     __frame := __local_counter;
 
     // process and type check arguments
-    assume is#Vector(coin);
+    assume $LibraCoin_T_is_well_formed(coin);
     __m := UpdateLocal(__m, __frame + 0, coin);
     assume $DebugTrackLocal(0, 10, 0, 7117, coin);
 

--- a/language/move-prover/bytecode-to-boogie/tests/goldenfiles/test-aborts-if.bpl
+++ b/language/move-prover/bytecode-to-boogie/tests/goldenfiles/test-aborts-if.bpl
@@ -1,5 +1,9 @@
 
 
+// ** synthetics of module TestAbortIf
+
+
+
 // ** structs of module TestAbortIf
 
 

--- a/language/move-prover/bytecode-to-boogie/tests/goldenfiles/test-access-path.bpl
+++ b/language/move-prover/bytecode-to-boogie/tests/goldenfiles/test-access-path.bpl
@@ -1,5 +1,9 @@
 
 
+// ** synthetics of module U64Util
+
+
+
 // ** structs of module U64Util
 
 
@@ -8,6 +12,10 @@
 
 procedure {:inline 1} U64Util_u64_to_bytes (i: Value) returns (__ret0: Value);
 requires ExistsTxnSenderAccount(__m, __txn);
+
+
+
+// ** synthetics of module AddressUtil
 
 
 
@@ -22,6 +30,10 @@ requires ExistsTxnSenderAccount(__m, __txn);
 
 
 
+// ** synthetics of module BytearrayUtil
+
+
+
 // ** structs of module BytearrayUtil
 
 
@@ -30,6 +42,10 @@ requires ExistsTxnSenderAccount(__m, __txn);
 
 procedure {:inline 1} BytearrayUtil_bytearray_concat (data1: Value, data2: Value) returns (__ret0: Value);
 requires ExistsTxnSenderAccount(__m, __txn);
+
+
+
+// ** synthetics of module Hash
 
 
 
@@ -47,6 +63,10 @@ requires ExistsTxnSenderAccount(__m, __txn);
 
 
 
+// ** synthetics of module LibraCoin
+
+
+
 // ** structs of module LibraCoin
 
 const unique LibraCoin_T: TypeName;
@@ -55,10 +75,16 @@ axiom LibraCoin_T_value == 0;
 function LibraCoin_T_type_value(): TypeValue {
     StructType(LibraCoin_T, ExtendTypeValueArray(EmptyTypeValueArray, IntegerType()))
 }
-procedure {:inline 1} Pack_LibraCoin_T(value: Value) returns (_struct: Value)
+function {:inline 1} $LibraCoin_T_is_well_formed(__this: Value): bool {
+    is#Vector(__this)
+        && IsValidU64(SelectField(__this, LibraCoin_T_value))
+}
+
+procedure {:inline 1} Pack_LibraCoin_T(module_idx: int, func_idx: int, var_idx: int, code_idx: int, value: Value) returns (_struct: Value)
 {
     assume IsValidU64(value);
     _struct := Vector(ExtendValueArray(EmptyValueArray, value));
+    if (code_idx > 0) { assume $DebugTrackLocal(module_idx, func_idx, var_idx, code_idx, _struct); }
 }
 
 procedure {:inline 1} Unpack_LibraCoin_T(_struct: Value) returns (value: Value)
@@ -74,10 +100,16 @@ axiom LibraCoin_MintCapability__dummy == 0;
 function LibraCoin_MintCapability_type_value(): TypeValue {
     StructType(LibraCoin_MintCapability, ExtendTypeValueArray(EmptyTypeValueArray, BooleanType()))
 }
-procedure {:inline 1} Pack_LibraCoin_MintCapability(_dummy: Value) returns (_struct: Value)
+function {:inline 1} $LibraCoin_MintCapability_is_well_formed(__this: Value): bool {
+    is#Vector(__this)
+        && is#Boolean(SelectField(__this, LibraCoin_MintCapability__dummy))
+}
+
+procedure {:inline 1} Pack_LibraCoin_MintCapability(module_idx: int, func_idx: int, var_idx: int, code_idx: int, _dummy: Value) returns (_struct: Value)
 {
     assume is#Boolean(_dummy);
     _struct := Vector(ExtendValueArray(EmptyValueArray, _dummy));
+    if (code_idx > 0) { assume $DebugTrackLocal(module_idx, func_idx, var_idx, code_idx, _struct); }
 }
 
 procedure {:inline 1} Unpack_LibraCoin_MintCapability(_struct: Value) returns (_dummy: Value)
@@ -93,10 +125,16 @@ axiom LibraCoin_MarketCap_total_value == 0;
 function LibraCoin_MarketCap_type_value(): TypeValue {
     StructType(LibraCoin_MarketCap, ExtendTypeValueArray(EmptyTypeValueArray, IntegerType()))
 }
-procedure {:inline 1} Pack_LibraCoin_MarketCap(total_value: Value) returns (_struct: Value)
+function {:inline 1} $LibraCoin_MarketCap_is_well_formed(__this: Value): bool {
+    is#Vector(__this)
+        && IsValidU128(SelectField(__this, LibraCoin_MarketCap_total_value))
+}
+
+procedure {:inline 1} Pack_LibraCoin_MarketCap(module_idx: int, func_idx: int, var_idx: int, code_idx: int, total_value: Value) returns (_struct: Value)
 {
     assume IsValidU128(total_value);
     _struct := Vector(ExtendValueArray(EmptyValueArray, total_value));
+    if (code_idx > 0) { assume $DebugTrackLocal(module_idx, func_idx, var_idx, code_idx, _struct); }
 }
 
 procedure {:inline 1} Unpack_LibraCoin_MarketCap(_struct: Value) returns (total_value: Value)
@@ -153,7 +191,7 @@ requires ExistsTxnSenderAccount(__m, __txn);
       assume $DebugTrackAbort(4, 0, 916);
       goto Label_Abort;
     }
-    assume is#Vector(__t4);
+    assume $LibraCoin_T_is_well_formed(__t4);
 
     __m := UpdateLocal(__m, __frame + 4, __t4);
 
@@ -209,9 +247,8 @@ requires ExistsTxnSenderAccount(__m, __txn);
     assume IsValidU64(value);
     __m := UpdateLocal(__m, __frame + 0, value);
     assume $DebugTrackLocal(4, 1, 0, 1231, value);
-    assume is#Vector(Dereference(__m, capability));
-    assume IsValidReferenceParameter(__m, __local_counter, capability);
-    assume is#Vector(Dereference(__m, capability));
+    assume $LibraCoin_MintCapability_is_well_formed(Dereference(__m, capability)) && IsValidReferenceParameter(__m, __local_counter, capability);
+    assume $LibraCoin_MintCapability_is_well_formed(Dereference(__m, capability));
     assume $DebugTrackLocal(4, 1, 1, 1231, Dereference(__m, capability));
 
     // increase the local counter
@@ -291,10 +328,11 @@ Label_9:
 
     call WriteRef(__t18, GetLocal(__m, __frame + 17));
 
+
     call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 0));
     __m := UpdateLocal(__m, __frame + 19, __tmp);
 
-    call __tmp := Pack_LibraCoin_T(GetLocal(__m, __frame + 19));
+    call __tmp := Pack_LibraCoin_T(0, 0, 0, 0, GetLocal(__m, __frame + 19));
     __m := UpdateLocal(__m, __frame + 20, __tmp);
 
     __ret0 := GetLocal(__m, __frame + 20);
@@ -365,7 +403,7 @@ Label_7:
     call __tmp := LdTrue();
     __m := UpdateLocal(__m, __frame + 5, __tmp);
 
-    call __tmp := Pack_LibraCoin_MintCapability(GetLocal(__m, __frame + 5));
+    call __tmp := Pack_LibraCoin_MintCapability(0, 0, 0, 0, GetLocal(__m, __frame + 5));
     __m := UpdateLocal(__m, __frame + 6, __tmp);
 
     call MoveToSender(LibraCoin_MintCapability_type_value(), GetLocal(__m, __frame + 6));
@@ -377,7 +415,7 @@ Label_7:
     call __tmp := LdConst(0);
     __m := UpdateLocal(__m, __frame + 7, __tmp);
 
-    call __tmp := Pack_LibraCoin_MarketCap(GetLocal(__m, __frame + 7));
+    call __tmp := Pack_LibraCoin_MarketCap(0, 0, 0, 0, GetLocal(__m, __frame + 7));
     __m := UpdateLocal(__m, __frame + 8, __tmp);
 
     call MoveToSender(LibraCoin_MarketCap_type_value(), GetLocal(__m, __frame + 8));
@@ -477,7 +515,7 @@ requires ExistsTxnSenderAccount(__m, __txn);
     call __tmp := LdConst(0);
     __m := UpdateLocal(__m, __frame + 0, __tmp);
 
-    call __tmp := Pack_LibraCoin_T(GetLocal(__m, __frame + 0));
+    call __tmp := Pack_LibraCoin_T(0, 0, 0, 0, GetLocal(__m, __frame + 0));
     __m := UpdateLocal(__m, __frame + 1, __tmp);
 
     __ret0 := GetLocal(__m, __frame + 1);
@@ -513,9 +551,8 @@ requires ExistsTxnSenderAccount(__m, __txn);
     __frame := __local_counter;
 
     // process and type check arguments
-    assume is#Vector(Dereference(__m, coin_ref));
-    assume IsValidReferenceParameter(__m, __local_counter, coin_ref);
-    assume is#Vector(Dereference(__m, coin_ref));
+    assume $LibraCoin_T_is_well_formed(Dereference(__m, coin_ref)) && IsValidReferenceParameter(__m, __local_counter, coin_ref);
+    assume $LibraCoin_T_is_well_formed(Dereference(__m, coin_ref));
     assume $DebugTrackLocal(4, 5, 0, 2888, Dereference(__m, coin_ref));
 
     // increase the local counter
@@ -566,7 +603,7 @@ requires ExistsTxnSenderAccount(__m, __txn);
     __frame := __local_counter;
 
     // process and type check arguments
-    assume is#Vector(coin);
+    assume $LibraCoin_T_is_well_formed(coin);
     __m := UpdateLocal(__m, __frame + 0, coin);
     assume $DebugTrackLocal(4, 6, 0, 3109, coin);
     assume IsValidU64(amount);
@@ -577,7 +614,7 @@ requires ExistsTxnSenderAccount(__m, __txn);
     __local_counter := __local_counter + 8;
 
     // bytecode translation starts here
-    call __t3 := BorrowLoc(__frame + 0);
+    call __t3 := BorrowLoc(__frame + 0, LibraCoin_T_type_value());
 
     call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 1));
     __m := UpdateLocal(__m, __frame + 4, __tmp);
@@ -587,7 +624,7 @@ requires ExistsTxnSenderAccount(__m, __txn);
       assume $DebugTrackAbort(4, 6, 3211);
       goto Label_Abort;
     }
-    assume is#Vector(__t5);
+    assume $LibraCoin_T_is_well_formed(__t5);
 
     __m := UpdateLocal(__m, __frame + 5, __t5);
     assume $DebugTrackLocal(4, 6, 0, 3211, GetLocal(__m, __frame + 0));
@@ -651,9 +688,8 @@ requires ExistsTxnSenderAccount(__m, __txn);
     __frame := __local_counter;
 
     // process and type check arguments
-    assume is#Vector(Dereference(__m, coin_ref));
-    assume IsValidReferenceParameter(__m, __local_counter, coin_ref);
-    assume is#Vector(Dereference(__m, coin_ref));
+    assume $LibraCoin_T_is_well_formed(Dereference(__m, coin_ref)) && IsValidReferenceParameter(__m, __local_counter, coin_ref);
+    assume $LibraCoin_T_is_well_formed(Dereference(__m, coin_ref));
     assume $DebugTrackLocal(4, 7, 0, 3557, Dereference(__m, coin_ref));
     assume IsValidU64(amount);
     __m := UpdateLocal(__m, __frame + 1, amount);
@@ -714,11 +750,13 @@ Label_11:
     call __t15 := BorrowField(__t14, LibraCoin_T_value);
 
     call WriteRef(__t15, GetLocal(__m, __frame + 13));
+    assume $LibraCoin_T_is_well_formed(Dereference(__m, coin_ref));
+    assume $DebugTrackLocal(4, 7, 0, 3835, Dereference(__m, coin_ref));
 
     call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 1));
     __m := UpdateLocal(__m, __frame + 16, __tmp);
 
-    call __tmp := Pack_LibraCoin_T(GetLocal(__m, __frame + 16));
+    call __tmp := Pack_LibraCoin_T(0, 0, 0, 0, GetLocal(__m, __frame + 16));
     __m := UpdateLocal(__m, __frame + 17, __tmp);
 
     __ret0 := GetLocal(__m, __frame + 17);
@@ -754,10 +792,10 @@ requires ExistsTxnSenderAccount(__m, __txn);
     __frame := __local_counter;
 
     // process and type check arguments
-    assume is#Vector(coin1);
+    assume $LibraCoin_T_is_well_formed(coin1);
     __m := UpdateLocal(__m, __frame + 0, coin1);
     assume $DebugTrackLocal(4, 8, 0, 4041, coin1);
-    assume is#Vector(coin2);
+    assume $LibraCoin_T_is_well_formed(coin2);
     __m := UpdateLocal(__m, __frame + 1, coin2);
     assume $DebugTrackLocal(4, 8, 1, 4041, coin2);
 
@@ -765,7 +803,7 @@ requires ExistsTxnSenderAccount(__m, __txn);
     __local_counter := __local_counter + 5;
 
     // bytecode translation starts here
-    call __t2 := BorrowLoc(__frame + 0);
+    call __t2 := BorrowLoc(__frame + 0, LibraCoin_T_type_value());
 
     call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 1));
     __m := UpdateLocal(__m, __frame + 3, __tmp);
@@ -822,11 +860,10 @@ requires ExistsTxnSenderAccount(__m, __txn);
     __frame := __local_counter;
 
     // process and type check arguments
-    assume is#Vector(Dereference(__m, coin_ref));
-    assume IsValidReferenceParameter(__m, __local_counter, coin_ref);
-    assume is#Vector(Dereference(__m, coin_ref));
+    assume $LibraCoin_T_is_well_formed(Dereference(__m, coin_ref)) && IsValidReferenceParameter(__m, __local_counter, coin_ref);
+    assume $LibraCoin_T_is_well_formed(Dereference(__m, coin_ref));
     assume $DebugTrackLocal(4, 9, 0, 4352, Dereference(__m, coin_ref));
-    assume is#Vector(check);
+    assume $LibraCoin_T_is_well_formed(check);
     __m := UpdateLocal(__m, __frame + 1, check);
     assume $DebugTrackLocal(4, 9, 1, 4352, check);
 
@@ -874,6 +911,8 @@ requires ExistsTxnSenderAccount(__m, __txn);
     call __t13 := BorrowField(__t12, LibraCoin_T_value);
 
     call WriteRef(__t13, GetLocal(__m, __frame + 11));
+    assume $LibraCoin_T_is_well_formed(Dereference(__m, coin_ref));
+    assume $DebugTrackLocal(4, 9, 0, 4564, Dereference(__m, coin_ref));
 
     return;
 
@@ -910,7 +949,7 @@ requires ExistsTxnSenderAccount(__m, __txn);
     __frame := __local_counter;
 
     // process and type check arguments
-    assume is#Vector(coin);
+    assume $LibraCoin_T_is_well_formed(coin);
     __m := UpdateLocal(__m, __frame + 0, coin);
     assume $DebugTrackLocal(4, 10, 0, 4858, coin);
 
@@ -964,6 +1003,10 @@ procedure LibraCoin_destroy_zero_verify (coin: Value) returns ()
 
 
 
+// ** synthetics of module LibraTimestamp
+
+
+
 // ** structs of module LibraTimestamp
 
 const unique LibraTimestamp_CurrentTimeMicroseconds: TypeName;
@@ -972,10 +1015,16 @@ axiom LibraTimestamp_CurrentTimeMicroseconds_microseconds == 0;
 function LibraTimestamp_CurrentTimeMicroseconds_type_value(): TypeValue {
     StructType(LibraTimestamp_CurrentTimeMicroseconds, ExtendTypeValueArray(EmptyTypeValueArray, IntegerType()))
 }
-procedure {:inline 1} Pack_LibraTimestamp_CurrentTimeMicroseconds(microseconds: Value) returns (_struct: Value)
+function {:inline 1} $LibraTimestamp_CurrentTimeMicroseconds_is_well_formed(__this: Value): bool {
+    is#Vector(__this)
+        && IsValidU64(SelectField(__this, LibraTimestamp_CurrentTimeMicroseconds_microseconds))
+}
+
+procedure {:inline 1} Pack_LibraTimestamp_CurrentTimeMicroseconds(module_idx: int, func_idx: int, var_idx: int, code_idx: int, microseconds: Value) returns (_struct: Value)
 {
     assume IsValidU64(microseconds);
     _struct := Vector(ExtendValueArray(EmptyValueArray, microseconds));
+    if (code_idx > 0) { assume $DebugTrackLocal(module_idx, func_idx, var_idx, code_idx, _struct); }
 }
 
 procedure {:inline 1} Unpack_LibraTimestamp_CurrentTimeMicroseconds(_struct: Value) returns (microseconds: Value)
@@ -1041,7 +1090,7 @@ Label_7:
     call __tmp := LdConst(0);
     __m := UpdateLocal(__m, __frame + 6, __tmp);
 
-    call __tmp := Pack_LibraTimestamp_CurrentTimeMicroseconds(GetLocal(__m, __frame + 6));
+    call __tmp := Pack_LibraTimestamp_CurrentTimeMicroseconds(5, 0, 0, 498, GetLocal(__m, __frame + 6));
     __m := UpdateLocal(__m, __frame + 7, __tmp);
 
     call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 7));
@@ -1128,7 +1177,7 @@ requires ExistsTxnSenderAccount(__m, __txn);
     }
 
     call global_timer := CopyOrMoveRef(__t4);
-    assume is#Vector(Dereference(__m, global_timer));
+    assume $LibraTimestamp_CurrentTimeMicroseconds_is_well_formed(Dereference(__m, global_timer));
     assume $DebugTrackLocal(5, 1, 2, 1084, Dereference(__m, global_timer));
 
     call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 0));
@@ -1207,6 +1256,7 @@ Label_26:
 
     call WriteRef(__t24, GetLocal(__m, __frame + 22));
 
+
     return;
 
 Label_Abort:
@@ -1276,6 +1326,10 @@ procedure LibraTimestamp_now_microseconds_verify () returns (__ret0: Value)
 
 
 
+// ** synthetics of module LibraTransactionTimeout
+
+
+
 // ** structs of module LibraTransactionTimeout
 
 const unique LibraTransactionTimeout_TTL: TypeName;
@@ -1284,10 +1338,16 @@ axiom LibraTransactionTimeout_TTL_duration_microseconds == 0;
 function LibraTransactionTimeout_TTL_type_value(): TypeValue {
     StructType(LibraTransactionTimeout_TTL, ExtendTypeValueArray(EmptyTypeValueArray, IntegerType()))
 }
-procedure {:inline 1} Pack_LibraTransactionTimeout_TTL(duration_microseconds: Value) returns (_struct: Value)
+function {:inline 1} $LibraTransactionTimeout_TTL_is_well_formed(__this: Value): bool {
+    is#Vector(__this)
+        && IsValidU64(SelectField(__this, LibraTransactionTimeout_TTL_duration_microseconds))
+}
+
+procedure {:inline 1} Pack_LibraTransactionTimeout_TTL(module_idx: int, func_idx: int, var_idx: int, code_idx: int, duration_microseconds: Value) returns (_struct: Value)
 {
     assume IsValidU64(duration_microseconds);
     _struct := Vector(ExtendValueArray(EmptyValueArray, duration_microseconds));
+    if (code_idx > 0) { assume $DebugTrackLocal(module_idx, func_idx, var_idx, code_idx, _struct); }
 }
 
 procedure {:inline 1} Unpack_LibraTransactionTimeout_TTL(_struct: Value) returns (duration_microseconds: Value)
@@ -1353,7 +1413,7 @@ Label_7:
     call __tmp := LdConst(86400000000);
     __m := UpdateLocal(__m, __frame + 6, __tmp);
 
-    call __tmp := Pack_LibraTransactionTimeout_TTL(GetLocal(__m, __frame + 6));
+    call __tmp := Pack_LibraTransactionTimeout_TTL(6, 0, 0, 451, GetLocal(__m, __frame + 6));
     __m := UpdateLocal(__m, __frame + 7, __tmp);
 
     call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 7));
@@ -1446,7 +1506,7 @@ Label_7:
     }
 
     call timeout := CopyOrMoveRef(__t8);
-    assume is#Vector(Dereference(__m, timeout));
+    assume $LibraTransactionTimeout_TTL_is_well_formed(Dereference(__m, timeout));
     assume $DebugTrackLocal(6, 1, 1, 765, Dereference(__m, timeout));
 
     call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 0));
@@ -1457,6 +1517,7 @@ Label_7:
     call __t11 := BorrowField(__t10, LibraTransactionTimeout_TTL_duration_microseconds);
 
     call WriteRef(__t11, GetLocal(__m, __frame + 9));
+
 
     return;
 
@@ -1628,6 +1689,10 @@ procedure LibraTransactionTimeout_is_valid_transaction_timestamp_verify (timesta
 
 
 
+// ** synthetics of module LibraAccount
+
+
+
 // ** structs of module LibraAccount
 
 const unique LibraAccount_T: TypeName;
@@ -1648,17 +1713,30 @@ axiom LibraAccount_T_sequence_number == 6;
 const LibraAccount_T_event_generator: FieldName;
 axiom LibraAccount_T_event_generator == 7;
 axiom LibraAccount_T_type_value() == StructType(LibraAccount_T, ExtendTypeValueArray(ExtendTypeValueArray(ExtendTypeValueArray(ExtendTypeValueArray(ExtendTypeValueArray(ExtendTypeValueArray(ExtendTypeValueArray(ExtendTypeValueArray(EmptyTypeValueArray, ByteArrayType()), LibraCoin_T_type_value()), BooleanType()), BooleanType()), LibraAccount_EventHandle_type_value(LibraAccount_ReceivedPaymentEvent_type_value())), LibraAccount_EventHandle_type_value(LibraAccount_SentPaymentEvent_type_value())), IntegerType()), LibraAccount_EventHandleGenerator_type_value()));
-procedure {:inline 1} Pack_LibraAccount_T(authentication_key: Value, balance: Value, delegated_key_rotation_capability: Value, delegated_withdrawal_capability: Value, received_events: Value, sent_events: Value, sequence_number: Value, event_generator: Value) returns (_struct: Value)
+function {:inline 1} $LibraAccount_T_is_well_formed(__this: Value): bool {
+    is#Vector(__this)
+        && is#ByteArray(SelectField(__this, LibraAccount_T_authentication_key))
+        && $LibraCoin_T_is_well_formed(SelectField(__this, LibraAccount_T_balance))
+        && is#Boolean(SelectField(__this, LibraAccount_T_delegated_key_rotation_capability))
+        && is#Boolean(SelectField(__this, LibraAccount_T_delegated_withdrawal_capability))
+        && $LibraAccount_EventHandle_is_well_formed(SelectField(__this, LibraAccount_T_received_events))
+        && $LibraAccount_EventHandle_is_well_formed(SelectField(__this, LibraAccount_T_sent_events))
+        && IsValidU64(SelectField(__this, LibraAccount_T_sequence_number))
+        && $LibraAccount_EventHandleGenerator_is_well_formed(SelectField(__this, LibraAccount_T_event_generator))
+}
+
+procedure {:inline 1} Pack_LibraAccount_T(module_idx: int, func_idx: int, var_idx: int, code_idx: int, authentication_key: Value, balance: Value, delegated_key_rotation_capability: Value, delegated_withdrawal_capability: Value, received_events: Value, sent_events: Value, sequence_number: Value, event_generator: Value) returns (_struct: Value)
 {
     assume is#ByteArray(authentication_key);
-    assume is#Vector(balance);
+    assume $LibraCoin_T_is_well_formed(balance);
     assume is#Boolean(delegated_key_rotation_capability);
     assume is#Boolean(delegated_withdrawal_capability);
-    assume is#Vector(received_events);
-    assume is#Vector(sent_events);
+    assume $LibraAccount_EventHandle_is_well_formed(received_events);
+    assume $LibraAccount_EventHandle_is_well_formed(sent_events);
     assume IsValidU64(sequence_number);
-    assume is#Vector(event_generator);
+    assume $LibraAccount_EventHandleGenerator_is_well_formed(event_generator);
     _struct := Vector(ExtendValueArray(ExtendValueArray(ExtendValueArray(ExtendValueArray(ExtendValueArray(ExtendValueArray(ExtendValueArray(ExtendValueArray(EmptyValueArray, authentication_key), balance), delegated_key_rotation_capability), delegated_withdrawal_capability), received_events), sent_events), sequence_number), event_generator));
+    if (code_idx > 0) { assume $DebugTrackLocal(module_idx, func_idx, var_idx, code_idx, _struct); }
 }
 
 procedure {:inline 1} Unpack_LibraAccount_T(_struct: Value) returns (authentication_key: Value, balance: Value, delegated_key_rotation_capability: Value, delegated_withdrawal_capability: Value, received_events: Value, sent_events: Value, sequence_number: Value, event_generator: Value)
@@ -1667,19 +1745,19 @@ procedure {:inline 1} Unpack_LibraAccount_T(_struct: Value) returns (authenticat
     authentication_key := SelectField(_struct, LibraAccount_T_authentication_key);
     assume is#ByteArray(authentication_key);
     balance := SelectField(_struct, LibraAccount_T_balance);
-    assume is#Vector(balance);
+    assume $LibraCoin_T_is_well_formed(balance);
     delegated_key_rotation_capability := SelectField(_struct, LibraAccount_T_delegated_key_rotation_capability);
     assume is#Boolean(delegated_key_rotation_capability);
     delegated_withdrawal_capability := SelectField(_struct, LibraAccount_T_delegated_withdrawal_capability);
     assume is#Boolean(delegated_withdrawal_capability);
     received_events := SelectField(_struct, LibraAccount_T_received_events);
-    assume is#Vector(received_events);
+    assume $LibraAccount_EventHandle_is_well_formed(received_events);
     sent_events := SelectField(_struct, LibraAccount_T_sent_events);
-    assume is#Vector(sent_events);
+    assume $LibraAccount_EventHandle_is_well_formed(sent_events);
     sequence_number := SelectField(_struct, LibraAccount_T_sequence_number);
     assume IsValidU64(sequence_number);
     event_generator := SelectField(_struct, LibraAccount_T_event_generator);
-    assume is#Vector(event_generator);
+    assume $LibraAccount_EventHandleGenerator_is_well_formed(event_generator);
 }
 
 const unique LibraAccount_WithdrawalCapability: TypeName;
@@ -1688,10 +1766,16 @@ axiom LibraAccount_WithdrawalCapability_account_address == 0;
 function LibraAccount_WithdrawalCapability_type_value(): TypeValue {
     StructType(LibraAccount_WithdrawalCapability, ExtendTypeValueArray(EmptyTypeValueArray, AddressType()))
 }
-procedure {:inline 1} Pack_LibraAccount_WithdrawalCapability(account_address: Value) returns (_struct: Value)
+function {:inline 1} $LibraAccount_WithdrawalCapability_is_well_formed(__this: Value): bool {
+    is#Vector(__this)
+        && is#Address(SelectField(__this, LibraAccount_WithdrawalCapability_account_address))
+}
+
+procedure {:inline 1} Pack_LibraAccount_WithdrawalCapability(module_idx: int, func_idx: int, var_idx: int, code_idx: int, account_address: Value) returns (_struct: Value)
 {
     assume is#Address(account_address);
     _struct := Vector(ExtendValueArray(EmptyValueArray, account_address));
+    if (code_idx > 0) { assume $DebugTrackLocal(module_idx, func_idx, var_idx, code_idx, _struct); }
 }
 
 procedure {:inline 1} Unpack_LibraAccount_WithdrawalCapability(_struct: Value) returns (account_address: Value)
@@ -1707,10 +1791,16 @@ axiom LibraAccount_KeyRotationCapability_account_address == 0;
 function LibraAccount_KeyRotationCapability_type_value(): TypeValue {
     StructType(LibraAccount_KeyRotationCapability, ExtendTypeValueArray(EmptyTypeValueArray, AddressType()))
 }
-procedure {:inline 1} Pack_LibraAccount_KeyRotationCapability(account_address: Value) returns (_struct: Value)
+function {:inline 1} $LibraAccount_KeyRotationCapability_is_well_formed(__this: Value): bool {
+    is#Vector(__this)
+        && is#Address(SelectField(__this, LibraAccount_KeyRotationCapability_account_address))
+}
+
+procedure {:inline 1} Pack_LibraAccount_KeyRotationCapability(module_idx: int, func_idx: int, var_idx: int, code_idx: int, account_address: Value) returns (_struct: Value)
 {
     assume is#Address(account_address);
     _struct := Vector(ExtendValueArray(EmptyValueArray, account_address));
+    if (code_idx > 0) { assume $DebugTrackLocal(module_idx, func_idx, var_idx, code_idx, _struct); }
 }
 
 procedure {:inline 1} Unpack_LibraAccount_KeyRotationCapability(_struct: Value) returns (account_address: Value)
@@ -1730,12 +1820,20 @@ axiom LibraAccount_SentPaymentEvent_metadata == 2;
 function LibraAccount_SentPaymentEvent_type_value(): TypeValue {
     StructType(LibraAccount_SentPaymentEvent, ExtendTypeValueArray(ExtendTypeValueArray(ExtendTypeValueArray(EmptyTypeValueArray, IntegerType()), AddressType()), ByteArrayType()))
 }
-procedure {:inline 1} Pack_LibraAccount_SentPaymentEvent(amount: Value, payee: Value, metadata: Value) returns (_struct: Value)
+function {:inline 1} $LibraAccount_SentPaymentEvent_is_well_formed(__this: Value): bool {
+    is#Vector(__this)
+        && IsValidU64(SelectField(__this, LibraAccount_SentPaymentEvent_amount))
+        && is#Address(SelectField(__this, LibraAccount_SentPaymentEvent_payee))
+        && is#ByteArray(SelectField(__this, LibraAccount_SentPaymentEvent_metadata))
+}
+
+procedure {:inline 1} Pack_LibraAccount_SentPaymentEvent(module_idx: int, func_idx: int, var_idx: int, code_idx: int, amount: Value, payee: Value, metadata: Value) returns (_struct: Value)
 {
     assume IsValidU64(amount);
     assume is#Address(payee);
     assume is#ByteArray(metadata);
     _struct := Vector(ExtendValueArray(ExtendValueArray(ExtendValueArray(EmptyValueArray, amount), payee), metadata));
+    if (code_idx > 0) { assume $DebugTrackLocal(module_idx, func_idx, var_idx, code_idx, _struct); }
 }
 
 procedure {:inline 1} Unpack_LibraAccount_SentPaymentEvent(_struct: Value) returns (amount: Value, payee: Value, metadata: Value)
@@ -1759,12 +1857,20 @@ axiom LibraAccount_ReceivedPaymentEvent_metadata == 2;
 function LibraAccount_ReceivedPaymentEvent_type_value(): TypeValue {
     StructType(LibraAccount_ReceivedPaymentEvent, ExtendTypeValueArray(ExtendTypeValueArray(ExtendTypeValueArray(EmptyTypeValueArray, IntegerType()), AddressType()), ByteArrayType()))
 }
-procedure {:inline 1} Pack_LibraAccount_ReceivedPaymentEvent(amount: Value, payer: Value, metadata: Value) returns (_struct: Value)
+function {:inline 1} $LibraAccount_ReceivedPaymentEvent_is_well_formed(__this: Value): bool {
+    is#Vector(__this)
+        && IsValidU64(SelectField(__this, LibraAccount_ReceivedPaymentEvent_amount))
+        && is#Address(SelectField(__this, LibraAccount_ReceivedPaymentEvent_payer))
+        && is#ByteArray(SelectField(__this, LibraAccount_ReceivedPaymentEvent_metadata))
+}
+
+procedure {:inline 1} Pack_LibraAccount_ReceivedPaymentEvent(module_idx: int, func_idx: int, var_idx: int, code_idx: int, amount: Value, payer: Value, metadata: Value) returns (_struct: Value)
 {
     assume IsValidU64(amount);
     assume is#Address(payer);
     assume is#ByteArray(metadata);
     _struct := Vector(ExtendValueArray(ExtendValueArray(ExtendValueArray(EmptyValueArray, amount), payer), metadata));
+    if (code_idx > 0) { assume $DebugTrackLocal(module_idx, func_idx, var_idx, code_idx, _struct); }
 }
 
 procedure {:inline 1} Unpack_LibraAccount_ReceivedPaymentEvent(_struct: Value) returns (amount: Value, payer: Value, metadata: Value)
@@ -1784,10 +1890,16 @@ axiom LibraAccount_EventHandleGenerator_counter == 0;
 function LibraAccount_EventHandleGenerator_type_value(): TypeValue {
     StructType(LibraAccount_EventHandleGenerator, ExtendTypeValueArray(EmptyTypeValueArray, IntegerType()))
 }
-procedure {:inline 1} Pack_LibraAccount_EventHandleGenerator(counter: Value) returns (_struct: Value)
+function {:inline 1} $LibraAccount_EventHandleGenerator_is_well_formed(__this: Value): bool {
+    is#Vector(__this)
+        && IsValidU64(SelectField(__this, LibraAccount_EventHandleGenerator_counter))
+}
+
+procedure {:inline 1} Pack_LibraAccount_EventHandleGenerator(module_idx: int, func_idx: int, var_idx: int, code_idx: int, counter: Value) returns (_struct: Value)
 {
     assume IsValidU64(counter);
     _struct := Vector(ExtendValueArray(EmptyValueArray, counter));
+    if (code_idx > 0) { assume $DebugTrackLocal(module_idx, func_idx, var_idx, code_idx, _struct); }
 }
 
 procedure {:inline 1} Unpack_LibraAccount_EventHandleGenerator(_struct: Value) returns (counter: Value)
@@ -1805,11 +1917,18 @@ axiom LibraAccount_EventHandle_guid == 1;
 function LibraAccount_EventHandle_type_value(tv0: TypeValue): TypeValue {
     StructType(LibraAccount_EventHandle, ExtendTypeValueArray(ExtendTypeValueArray(EmptyTypeValueArray, IntegerType()), ByteArrayType()))
 }
-procedure {:inline 1} Pack_LibraAccount_EventHandle(tv0: TypeValue, counter: Value, guid: Value) returns (_struct: Value)
+function {:inline 1} $LibraAccount_EventHandle_is_well_formed(__this: Value): bool {
+    is#Vector(__this)
+        && IsValidU64(SelectField(__this, LibraAccount_EventHandle_counter))
+        && is#ByteArray(SelectField(__this, LibraAccount_EventHandle_guid))
+}
+
+procedure {:inline 1} Pack_LibraAccount_EventHandle(module_idx: int, func_idx: int, var_idx: int, code_idx: int, tv0: TypeValue, counter: Value, guid: Value) returns (_struct: Value)
 {
     assume IsValidU64(counter);
     assume is#ByteArray(guid);
     _struct := Vector(ExtendValueArray(ExtendValueArray(EmptyValueArray, counter), guid));
+    if (code_idx > 0) { assume $DebugTrackLocal(module_idx, func_idx, var_idx, code_idx, _struct); }
 }
 
 procedure {:inline 1} Unpack_LibraAccount_EventHandle(_struct: Value) returns (counter: Value, guid: Value)
@@ -1845,7 +1964,7 @@ requires ExistsTxnSenderAccount(__m, __txn);
     assume is#Address(payee);
     __m := UpdateLocal(__m, __frame + 0, payee);
     assume $DebugTrackLocal(7, 0, 0, 3305, payee);
-    assume is#Vector(to_deposit);
+    assume $LibraCoin_T_is_well_formed(to_deposit);
     __m := UpdateLocal(__m, __frame + 1, to_deposit);
     assume $DebugTrackLocal(7, 0, 1, 3305, to_deposit);
 
@@ -1901,7 +2020,7 @@ requires ExistsTxnSenderAccount(__m, __txn);
     assume is#Address(payee);
     __m := UpdateLocal(__m, __frame + 0, payee);
     assume $DebugTrackLocal(7, 1, 0, 3567, payee);
-    assume is#Vector(to_deposit);
+    assume $LibraCoin_T_is_well_formed(to_deposit);
     __m := UpdateLocal(__m, __frame + 1, to_deposit);
     assume $DebugTrackLocal(7, 1, 1, 3567, to_deposit);
     assume is#ByteArray(metadata);
@@ -1992,7 +2111,7 @@ requires ExistsTxnSenderAccount(__m, __txn);
     assume is#Address(sender);
     __m := UpdateLocal(__m, __frame + 1, sender);
     assume $DebugTrackLocal(7, 2, 1, 4018, sender);
-    assume is#Vector(to_deposit);
+    assume $LibraCoin_T_is_well_formed(to_deposit);
     __m := UpdateLocal(__m, __frame + 2, to_deposit);
     assume $DebugTrackLocal(7, 2, 2, 4018, to_deposit);
     assume is#ByteArray(metadata);
@@ -2003,7 +2122,7 @@ requires ExistsTxnSenderAccount(__m, __txn);
     __local_counter := __local_counter + 33;
 
     // bytecode translation starts here
-    call __t7 := BorrowLoc(__frame + 2);
+    call __t7 := BorrowLoc(__frame + 2, LibraCoin_T_type_value());
 
     call __t8 := LibraCoin_value(__t7);
     if (__abort_flag) {
@@ -2049,7 +2168,7 @@ Label_10:
     }
 
     call sender_account_ref := CopyOrMoveRef(__t15);
-    assume is#Vector(Dereference(__m, sender_account_ref));
+    assume $LibraAccount_T_is_well_formed(Dereference(__m, sender_account_ref));
     assume $DebugTrackLocal(7, 2, 6, 4503, Dereference(__m, sender_account_ref));
 
     call __t16 := CopyOrMoveRef(sender_account_ref);
@@ -2065,7 +2184,7 @@ Label_10:
     call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 3));
     __m := UpdateLocal(__m, __frame + 20, __tmp);
 
-    call __tmp := Pack_LibraAccount_SentPaymentEvent(GetLocal(__m, __frame + 18), GetLocal(__m, __frame + 19), GetLocal(__m, __frame + 20));
+    call __tmp := Pack_LibraAccount_SentPaymentEvent(0, 0, 0, 0, GetLocal(__m, __frame + 18), GetLocal(__m, __frame + 19), GetLocal(__m, __frame + 20));
     __m := UpdateLocal(__m, __frame + 21, __tmp);
 
     call LibraAccount_emit_event(LibraAccount_SentPaymentEvent_type_value(), __t17, GetLocal(__m, __frame + 21));
@@ -2084,7 +2203,7 @@ Label_10:
     }
 
     call payee_account_ref := CopyOrMoveRef(__t23);
-    assume is#Vector(Dereference(__m, payee_account_ref));
+    assume $LibraAccount_T_is_well_formed(Dereference(__m, payee_account_ref));
     assume $DebugTrackLocal(7, 2, 5, 4915, Dereference(__m, payee_account_ref));
 
     call __t24 := CopyOrMoveRef(payee_account_ref);
@@ -2113,7 +2232,7 @@ Label_10:
     call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 3));
     __m := UpdateLocal(__m, __frame + 31, __tmp);
 
-    call __tmp := Pack_LibraAccount_ReceivedPaymentEvent(GetLocal(__m, __frame + 29), GetLocal(__m, __frame + 30), GetLocal(__m, __frame + 31));
+    call __tmp := Pack_LibraAccount_ReceivedPaymentEvent(0, 0, 0, 0, GetLocal(__m, __frame + 29), GetLocal(__m, __frame + 30), GetLocal(__m, __frame + 31));
     __m := UpdateLocal(__m, __frame + 32, __tmp);
 
     call LibraAccount_emit_event(LibraAccount_ReceivedPaymentEvent_type_value(), __t28, GetLocal(__m, __frame + 32));
@@ -2200,7 +2319,7 @@ Label_6:
       assume $DebugTrackAbort(7, 3, 6058);
       goto Label_Abort;
     }
-    assume is#Vector(__t8);
+    assume $LibraCoin_T_is_well_formed(__t8);
 
     __m := UpdateLocal(__m, __frame + 8, __t8);
 
@@ -2243,9 +2362,8 @@ requires ExistsTxnSenderAccount(__m, __txn);
     __frame := __local_counter;
 
     // process and type check arguments
-    assume is#Vector(Dereference(__m, account));
-    assume IsValidReferenceParameter(__m, __local_counter, account);
-    assume is#Vector(Dereference(__m, account));
+    assume $LibraAccount_T_is_well_formed(Dereference(__m, account)) && IsValidReferenceParameter(__m, __local_counter, account);
+    assume $LibraAccount_T_is_well_formed(Dereference(__m, account));
     assume $DebugTrackLocal(7, 4, 0, 6237, Dereference(__m, account));
     assume IsValidU64(amount);
     __m := UpdateLocal(__m, __frame + 1, amount);
@@ -2267,9 +2385,11 @@ requires ExistsTxnSenderAccount(__m, __txn);
       assume $DebugTrackAbort(7, 4, 6370);
       goto Label_Abort;
     }
-    assume is#Vector(__t6);
+    assume $LibraCoin_T_is_well_formed(__t6);
 
     __m := UpdateLocal(__m, __frame + 6, __t6);
+    assume $LibraAccount_T_is_well_formed(Dereference(__m, account));
+    assume $DebugTrackLocal(7, 4, 0, 6370, Dereference(__m, account));
 
     call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 6));
     __m := UpdateLocal(__m, __frame + 2, __tmp);
@@ -2336,7 +2456,7 @@ requires ExistsTxnSenderAccount(__m, __txn);
     }
 
     call sender_account := CopyOrMoveRef(__t3);
-    assume is#Vector(Dereference(__m, sender_account));
+    assume $LibraAccount_T_is_well_formed(Dereference(__m, sender_account));
     assume $DebugTrackLocal(7, 5, 1, 6669, Dereference(__m, sender_account));
 
     call __t4 := CopyOrMoveRef(sender_account);
@@ -2366,7 +2486,7 @@ Label_9:
       assume $DebugTrackAbort(7, 5, 7031);
       goto Label_Abort;
     }
-    assume is#Vector(__t10);
+    assume $LibraCoin_T_is_well_formed(__t10);
 
     __m := UpdateLocal(__m, __frame + 10, __t10);
 
@@ -2408,9 +2528,8 @@ requires ExistsTxnSenderAccount(__m, __txn);
     __frame := __local_counter;
 
     // process and type check arguments
-    assume is#Vector(Dereference(__m, cap));
-    assume IsValidReferenceParameter(__m, __local_counter, cap);
-    assume is#Vector(Dereference(__m, cap));
+    assume $LibraAccount_WithdrawalCapability_is_well_formed(Dereference(__m, cap)) && IsValidReferenceParameter(__m, __local_counter, cap);
+    assume $LibraAccount_WithdrawalCapability_is_well_formed(Dereference(__m, cap));
     assume $DebugTrackLocal(7, 6, 0, 7192, Dereference(__m, cap));
     assume IsValidU64(amount);
     __m := UpdateLocal(__m, __frame + 1, amount);
@@ -2435,7 +2554,7 @@ requires ExistsTxnSenderAccount(__m, __txn);
     }
 
     call account := CopyOrMoveRef(__t6);
-    assume is#Vector(Dereference(__m, account));
+    assume $LibraAccount_T_is_well_formed(Dereference(__m, account));
     assume $DebugTrackLocal(7, 6, 2, 7354, Dereference(__m, account));
 
     call __t7 := CopyOrMoveRef(account);
@@ -2448,7 +2567,7 @@ requires ExistsTxnSenderAccount(__m, __txn);
       assume $DebugTrackAbort(7, 6, 7430);
       goto Label_Abort;
     }
-    assume is#Vector(__t9);
+    assume $LibraCoin_T_is_well_formed(__t9);
 
     __m := UpdateLocal(__m, __frame + 9, __t9);
 
@@ -2519,7 +2638,7 @@ requires ExistsTxnSenderAccount(__m, __txn);
     }
 
     call sender_account := CopyOrMoveRef(__t5);
-    assume is#Vector(Dereference(__m, sender_account));
+    assume $LibraAccount_T_is_well_formed(Dereference(__m, sender_account));
     assume $DebugTrackLocal(7, 7, 1, 7837, Dereference(__m, sender_account));
 
     call __t6 := CopyOrMoveRef(sender_account);
@@ -2552,10 +2671,11 @@ Label_13:
 
     call WriteRef(__t12, GetLocal(__m, __frame + 11));
 
+
     call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 0));
     __m := UpdateLocal(__m, __frame + 13, __tmp);
 
-    call __tmp := Pack_LibraAccount_WithdrawalCapability(GetLocal(__m, __frame + 13));
+    call __tmp := Pack_LibraAccount_WithdrawalCapability(0, 0, 0, 0, GetLocal(__m, __frame + 13));
     __m := UpdateLocal(__m, __frame + 14, __tmp);
 
     __ret0 := GetLocal(__m, __frame + 14);
@@ -2597,7 +2717,7 @@ requires ExistsTxnSenderAccount(__m, __txn);
     __frame := __local_counter;
 
     // process and type check arguments
-    assume is#Vector(cap);
+    assume $LibraAccount_WithdrawalCapability_is_well_formed(cap);
     __m := UpdateLocal(__m, __frame + 0, cap);
     assume $DebugTrackLocal(7, 8, 0, 8391, cap);
 
@@ -2625,7 +2745,7 @@ requires ExistsTxnSenderAccount(__m, __txn);
     }
 
     call account := CopyOrMoveRef(__t6);
-    assume is#Vector(Dereference(__m, account));
+    assume $LibraAccount_T_is_well_formed(Dereference(__m, account));
     assume $DebugTrackLocal(7, 8, 2, 8650, Dereference(__m, account));
 
     call __tmp := LdFalse();
@@ -2636,6 +2756,7 @@ requires ExistsTxnSenderAccount(__m, __txn);
     call __t9 := BorrowField(__t8, LibraAccount_T_delegated_withdrawal_capability);
 
     call WriteRef(__t9, GetLocal(__m, __frame + 7));
+
 
     return;
 
@@ -2679,9 +2800,8 @@ requires ExistsTxnSenderAccount(__m, __txn);
     assume is#Address(payee);
     __m := UpdateLocal(__m, __frame + 0, payee);
     assume $DebugTrackLocal(7, 9, 0, 9236, payee);
-    assume is#Vector(Dereference(__m, cap));
-    assume IsValidReferenceParameter(__m, __local_counter, cap);
-    assume is#Vector(Dereference(__m, cap));
+    assume $LibraAccount_WithdrawalCapability_is_well_formed(Dereference(__m, cap)) && IsValidReferenceParameter(__m, __local_counter, cap);
+    assume $LibraAccount_WithdrawalCapability_is_well_formed(Dereference(__m, cap));
     assume $DebugTrackLocal(7, 9, 1, 9236, Dereference(__m, cap));
     assume IsValidU64(amount);
     __m := UpdateLocal(__m, __frame + 2, amount);
@@ -2737,7 +2857,7 @@ Label_6:
       assume $DebugTrackAbort(7, 9, 9617);
       goto Label_Abort;
     }
-    assume is#Vector(__t14);
+    assume $LibraCoin_T_is_well_formed(__t14);
 
     __m := UpdateLocal(__m, __frame + 14, __t14);
 
@@ -2832,7 +2952,7 @@ Label_6:
       assume $DebugTrackAbort(7, 10, 10245);
       goto Label_Abort;
     }
-    assume is#Vector(__t9);
+    assume $LibraCoin_T_is_well_formed(__t9);
 
     __m := UpdateLocal(__m, __frame + 9, __t9);
 
@@ -2930,9 +3050,8 @@ requires ExistsTxnSenderAccount(__m, __txn);
     __frame := __local_counter;
 
     // process and type check arguments
-    assume is#Vector(Dereference(__m, account));
-    assume IsValidReferenceParameter(__m, __local_counter, account);
-    assume is#Vector(Dereference(__m, account));
+    assume $LibraAccount_T_is_well_formed(Dereference(__m, account)) && IsValidReferenceParameter(__m, __local_counter, account);
+    assume $LibraAccount_T_is_well_formed(Dereference(__m, account));
     assume $DebugTrackLocal(7, 12, 0, 10698, Dereference(__m, account));
     assume is#ByteArray(new_authentication_key);
     __m := UpdateLocal(__m, __frame + 1, new_authentication_key);
@@ -2950,6 +3069,8 @@ requires ExistsTxnSenderAccount(__m, __txn);
     call __t4 := BorrowField(__t3, LibraAccount_T_authentication_key);
 
     call WriteRef(__t4, GetLocal(__m, __frame + 2));
+    assume $LibraAccount_T_is_well_formed(Dereference(__m, account));
+    assume $DebugTrackLocal(7, 12, 0, 10803, Dereference(__m, account));
 
     return;
 
@@ -3005,7 +3126,7 @@ requires ExistsTxnSenderAccount(__m, __txn);
     }
 
     call sender_account := CopyOrMoveRef(__t3);
-    assume is#Vector(Dereference(__m, sender_account));
+    assume $LibraAccount_T_is_well_formed(Dereference(__m, sender_account));
     assume $DebugTrackLocal(7, 13, 1, 11156, Dereference(__m, sender_account));
 
     call __t4 := CopyOrMoveRef(sender_account);
@@ -3068,9 +3189,8 @@ requires ExistsTxnSenderAccount(__m, __txn);
     __frame := __local_counter;
 
     // process and type check arguments
-    assume is#Vector(Dereference(__m, cap));
-    assume IsValidReferenceParameter(__m, __local_counter, cap);
-    assume is#Vector(Dereference(__m, cap));
+    assume $LibraAccount_KeyRotationCapability_is_well_formed(Dereference(__m, cap)) && IsValidReferenceParameter(__m, __local_counter, cap);
+    assume $LibraAccount_KeyRotationCapability_is_well_formed(Dereference(__m, cap));
     assume $DebugTrackLocal(7, 14, 0, 11765, Dereference(__m, cap));
     assume is#ByteArray(new_authentication_key);
     __m := UpdateLocal(__m, __frame + 1, new_authentication_key);
@@ -3192,10 +3312,11 @@ Label_11:
 
     call WriteRef(__t10, GetLocal(__m, __frame + 9));
 
+
     call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 0));
     __m := UpdateLocal(__m, __frame + 11, __tmp);
 
-    call __tmp := Pack_LibraAccount_KeyRotationCapability(GetLocal(__m, __frame + 11));
+    call __tmp := Pack_LibraAccount_KeyRotationCapability(0, 0, 0, 0, GetLocal(__m, __frame + 11));
     __m := UpdateLocal(__m, __frame + 12, __tmp);
 
     __ret0 := GetLocal(__m, __frame + 12);
@@ -3237,7 +3358,7 @@ requires ExistsTxnSenderAccount(__m, __txn);
     __frame := __local_counter;
 
     // process and type check arguments
-    assume is#Vector(cap);
+    assume $LibraAccount_KeyRotationCapability_is_well_formed(cap);
     __m := UpdateLocal(__m, __frame + 0, cap);
     assume $DebugTrackLocal(7, 16, 0, 12924, cap);
 
@@ -3265,7 +3386,7 @@ requires ExistsTxnSenderAccount(__m, __txn);
     }
 
     call account := CopyOrMoveRef(__t6);
-    assume is#Vector(Dereference(__m, account));
+    assume $LibraAccount_T_is_well_formed(Dereference(__m, account));
     assume $DebugTrackLocal(7, 16, 2, 13187, Dereference(__m, account));
 
     call __tmp := LdFalse();
@@ -3276,6 +3397,7 @@ requires ExistsTxnSenderAccount(__m, __txn);
     call __t9 := BorrowField(__t8, LibraAccount_T_delegated_key_rotation_capability);
 
     call WriteRef(__t9, GetLocal(__m, __frame + 7));
+
 
     return;
 
@@ -3333,7 +3455,7 @@ requires ExistsTxnSenderAccount(__m, __txn);
     call __tmp := LdConst(0);
     __m := UpdateLocal(__m, __frame + 2, __tmp);
 
-    call __tmp := Pack_LibraAccount_EventHandleGenerator(GetLocal(__m, __frame + 2));
+    call __tmp := Pack_LibraAccount_EventHandleGenerator(7, 17, 1, 13880, GetLocal(__m, __frame + 2));
     __m := UpdateLocal(__m, __frame + 3, __tmp);
 
     call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 3));
@@ -3360,7 +3482,7 @@ requires ExistsTxnSenderAccount(__m, __txn);
       assume $DebugTrackAbort(7, 17, 14103);
       goto Label_Abort;
     }
-    assume is#Vector(__t7);
+    assume $LibraCoin_T_is_well_formed(__t7);
 
     __m := UpdateLocal(__m, __frame + 7, __t7);
 
@@ -3370,7 +3492,7 @@ requires ExistsTxnSenderAccount(__m, __txn);
     call __tmp := LdFalse();
     __m := UpdateLocal(__m, __frame + 9, __tmp);
 
-    call __t10 := BorrowLoc(__frame + 1);
+    call __t10 := BorrowLoc(__frame + 1, LibraAccount_EventHandleGenerator_type_value());
 
     call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 0));
     __m := UpdateLocal(__m, __frame + 11, __tmp);
@@ -3380,12 +3502,12 @@ requires ExistsTxnSenderAccount(__m, __txn);
       assume $DebugTrackAbort(7, 17, 14268);
       goto Label_Abort;
     }
-    assume is#Vector(__t12);
+    assume $LibraAccount_EventHandle_is_well_formed(__t12);
 
     __m := UpdateLocal(__m, __frame + 12, __t12);
     assume $DebugTrackLocal(7, 17, 1, 14268, GetLocal(__m, __frame + 1));
 
-    call __t13 := BorrowLoc(__frame + 1);
+    call __t13 := BorrowLoc(__frame + 1, LibraAccount_EventHandleGenerator_type_value());
 
     call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 0));
     __m := UpdateLocal(__m, __frame + 14, __tmp);
@@ -3395,7 +3517,7 @@ requires ExistsTxnSenderAccount(__m, __txn);
       assume $DebugTrackAbort(7, 17, 14389);
       goto Label_Abort;
     }
-    assume is#Vector(__t15);
+    assume $LibraAccount_EventHandle_is_well_formed(__t15);
 
     __m := UpdateLocal(__m, __frame + 15, __t15);
     assume $DebugTrackLocal(7, 17, 1, 14389, GetLocal(__m, __frame + 1));
@@ -3406,7 +3528,7 @@ requires ExistsTxnSenderAccount(__m, __txn);
     call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 1));
     __m := UpdateLocal(__m, __frame + 17, __tmp);
 
-    call __tmp := Pack_LibraAccount_T(GetLocal(__m, __frame + 6), GetLocal(__m, __frame + 7), GetLocal(__m, __frame + 8), GetLocal(__m, __frame + 9), GetLocal(__m, __frame + 12), GetLocal(__m, __frame + 15), GetLocal(__m, __frame + 16), GetLocal(__m, __frame + 17));
+    call __tmp := Pack_LibraAccount_T(0, 0, 0, 0, GetLocal(__m, __frame + 6), GetLocal(__m, __frame + 7), GetLocal(__m, __frame + 8), GetLocal(__m, __frame + 9), GetLocal(__m, __frame + 12), GetLocal(__m, __frame + 15), GetLocal(__m, __frame + 16), GetLocal(__m, __frame + 17));
     __m := UpdateLocal(__m, __frame + 18, __tmp);
 
     call LibraAccount_save_account(GetLocal(__m, __frame + 4), GetLocal(__m, __frame + 18));
@@ -3528,9 +3650,8 @@ requires ExistsTxnSenderAccount(__m, __txn);
     __frame := __local_counter;
 
     // process and type check arguments
-    assume is#Vector(Dereference(__m, account));
-    assume IsValidReferenceParameter(__m, __local_counter, account);
-    assume is#Vector(Dereference(__m, account));
+    assume $LibraAccount_T_is_well_formed(Dereference(__m, account)) && IsValidReferenceParameter(__m, __local_counter, account);
+    assume $LibraAccount_T_is_well_formed(Dereference(__m, account));
     assume $DebugTrackLocal(7, 20, 0, 15265, Dereference(__m, account));
 
     // increase the local counter
@@ -3649,9 +3770,8 @@ requires ExistsTxnSenderAccount(__m, __txn);
     __frame := __local_counter;
 
     // process and type check arguments
-    assume is#Vector(Dereference(__m, account));
-    assume IsValidReferenceParameter(__m, __local_counter, account);
-    assume is#Vector(Dereference(__m, account));
+    assume $LibraAccount_T_is_well_formed(Dereference(__m, account)) && IsValidReferenceParameter(__m, __local_counter, account);
+    assume $LibraAccount_T_is_well_formed(Dereference(__m, account));
     assume $DebugTrackLocal(7, 22, 0, 15735, Dereference(__m, account));
 
     // increase the local counter
@@ -3871,9 +3991,8 @@ requires ExistsTxnSenderAccount(__m, __txn);
     __frame := __local_counter;
 
     // process and type check arguments
-    assume is#Vector(Dereference(__m, cap));
-    assume IsValidReferenceParameter(__m, __local_counter, cap);
-    assume is#Vector(Dereference(__m, cap));
+    assume $LibraAccount_WithdrawalCapability_is_well_formed(Dereference(__m, cap)) && IsValidReferenceParameter(__m, __local_counter, cap);
+    assume $LibraAccount_WithdrawalCapability_is_well_formed(Dereference(__m, cap));
     assume $DebugTrackLocal(7, 26, 0, 16640, Dereference(__m, cap));
 
     // increase the local counter
@@ -3917,9 +4036,8 @@ requires ExistsTxnSenderAccount(__m, __txn);
     __frame := __local_counter;
 
     // process and type check arguments
-    assume is#Vector(Dereference(__m, cap));
-    assume IsValidReferenceParameter(__m, __local_counter, cap);
-    assume is#Vector(Dereference(__m, cap));
+    assume $LibraAccount_KeyRotationCapability_is_well_formed(Dereference(__m, cap)) && IsValidReferenceParameter(__m, __local_counter, cap);
+    assume $LibraAccount_KeyRotationCapability_is_well_formed(Dereference(__m, cap));
     assume $DebugTrackLocal(7, 27, 0, 16867, Dereference(__m, cap));
 
     // increase the local counter
@@ -4112,7 +4230,7 @@ Label_8:
     }
 
     call sender_account := CopyOrMoveRef(__t17);
-    assume is#Vector(Dereference(__m, sender_account));
+    assume $LibraAccount_T_is_well_formed(Dereference(__m, sender_account));
     assume $DebugTrackLocal(7, 29, 6, 18162, Dereference(__m, sender_account));
 
     call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 1));
@@ -4172,7 +4290,7 @@ Label_21:
     call __t30 := FreezeRef(__t29);
 
     call imm_sender_account := CopyOrMoveRef(__t30);
-    assume is#Vector(Dereference(__m, imm_sender_account));
+    assume $LibraAccount_T_is_well_formed(Dereference(__m, imm_sender_account));
     assume $DebugTrackLocal(7, 29, 7, 18617, Dereference(__m, imm_sender_account));
 
     call __t31 := CopyOrMoveRef(imm_sender_account);
@@ -4376,7 +4494,7 @@ requires ExistsTxnSenderAccount(__m, __txn);
     }
 
     call sender_account := CopyOrMoveRef(__t10);
-    assume is#Vector(Dereference(__m, sender_account));
+    assume $LibraAccount_T_is_well_formed(Dereference(__m, sender_account));
     assume $DebugTrackLocal(7, 30, 4, 19815, Dereference(__m, sender_account));
 
     call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 1));
@@ -4411,7 +4529,7 @@ requires ExistsTxnSenderAccount(__m, __txn);
     call __t17 := FreezeRef(__t16);
 
     call imm_sender_account := CopyOrMoveRef(__t17);
-    assume is#Vector(Dereference(__m, imm_sender_account));
+    assume $LibraAccount_T_is_well_formed(Dereference(__m, imm_sender_account));
     assume $DebugTrackLocal(7, 30, 6, 20029, Dereference(__m, imm_sender_account));
 
     call __t18 := CopyOrMoveRef(imm_sender_account);
@@ -4453,7 +4571,7 @@ Label_20:
       assume $DebugTrackAbort(7, 30, 20255);
       goto Label_Abort;
     }
-    assume is#Vector(__t26);
+    assume $LibraCoin_T_is_well_formed(__t26);
 
     __m := UpdateLocal(__m, __frame + 26, __t26);
 
@@ -4480,6 +4598,7 @@ Label_20:
 
     call WriteRef(__t31, GetLocal(__m, __frame + 29));
 
+
     call __tmp := LdAddr(4078);
     __m := UpdateLocal(__m, __frame + 32, __tmp);
 
@@ -4490,7 +4609,7 @@ Label_20:
     }
 
     call transaction_fee_account := CopyOrMoveRef(__t33);
-    assume is#Vector(Dereference(__m, transaction_fee_account));
+    assume $LibraAccount_T_is_well_formed(Dereference(__m, transaction_fee_account));
     assume $DebugTrackLocal(7, 30, 5, 20576, Dereference(__m, transaction_fee_account));
 
     call __t34 := CopyOrMoveRef(transaction_fee_account);
@@ -4553,9 +4672,8 @@ requires ExistsTxnSenderAccount(__m, __txn);
     __frame := __local_counter;
 
     // process and type check arguments
-    assume is#Vector(Dereference(__m, counter));
-    assume IsValidReferenceParameter(__m, __local_counter, counter);
-    assume is#Vector(Dereference(__m, counter));
+    assume $LibraAccount_EventHandleGenerator_is_well_formed(Dereference(__m, counter)) && IsValidReferenceParameter(__m, __local_counter, counter);
+    assume $LibraAccount_EventHandleGenerator_is_well_formed(Dereference(__m, counter));
     assume $DebugTrackLocal(7, 31, 0, 21344, Dereference(__m, counter));
     assume is#Address(sender);
     __m := UpdateLocal(__m, __frame + 1, sender);
@@ -4627,6 +4745,8 @@ requires ExistsTxnSenderAccount(__m, __txn);
     call __t17 := CopyOrMoveRef(count);
 
     call WriteRef(__t17, GetLocal(__m, __frame + 16));
+    assume $LibraAccount_EventHandleGenerator_is_well_formed(Dereference(__m, counter));
+    assume $DebugTrackLocal(7, 31, 0, 21740, Dereference(__m, counter));
 
     call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 3));
     __m := UpdateLocal(__m, __frame + 18, __tmp);
@@ -4685,9 +4805,8 @@ requires ExistsTxnSenderAccount(__m, __txn);
     __frame := __local_counter;
 
     // process and type check arguments
-    assume is#Vector(Dereference(__m, counter));
-    assume IsValidReferenceParameter(__m, __local_counter, counter);
-    assume is#Vector(Dereference(__m, counter));
+    assume $LibraAccount_EventHandleGenerator_is_well_formed(Dereference(__m, counter)) && IsValidReferenceParameter(__m, __local_counter, counter);
+    assume $LibraAccount_EventHandleGenerator_is_well_formed(Dereference(__m, counter));
     assume $DebugTrackLocal(7, 32, 0, 22101, Dereference(__m, counter));
     assume is#Address(sender);
     __m := UpdateLocal(__m, __frame + 1, sender);
@@ -4713,8 +4832,10 @@ requires ExistsTxnSenderAccount(__m, __txn);
     assume is#ByteArray(__t5);
 
     __m := UpdateLocal(__m, __frame + 5, __t5);
+    assume $LibraAccount_EventHandleGenerator_is_well_formed(Dereference(__m, counter));
+    assume $DebugTrackLocal(7, 32, 0, 22270, Dereference(__m, counter));
 
-    call __tmp := Pack_LibraAccount_EventHandle(tv0, GetLocal(__m, __frame + 2), GetLocal(__m, __frame + 5));
+    call __tmp := Pack_LibraAccount_EventHandle(0, 0, 0, 0, tv0, GetLocal(__m, __frame + 2), GetLocal(__m, __frame + 5));
     __m := UpdateLocal(__m, __frame + 6, __tmp);
 
     __ret0 := GetLocal(__m, __frame + 6);
@@ -4770,7 +4891,7 @@ requires ExistsTxnSenderAccount(__m, __txn);
     }
 
     call sender_account_ref := CopyOrMoveRef(__t3);
-    assume is#Vector(Dereference(__m, sender_account_ref));
+    assume $LibraAccount_T_is_well_formed(Dereference(__m, sender_account_ref));
     assume $DebugTrackLocal(7, 33, 0, 22601, Dereference(__m, sender_account_ref));
 
     call __t4 := CopyOrMoveRef(sender_account_ref);
@@ -4785,7 +4906,7 @@ requires ExistsTxnSenderAccount(__m, __txn);
       assume $DebugTrackAbort(7, 33, 22677);
       goto Label_Abort;
     }
-    assume is#Vector(__t7);
+    assume $LibraAccount_EventHandle_is_well_formed(__t7);
 
     __m := UpdateLocal(__m, __frame + 7, __t7);
 
@@ -4835,9 +4956,8 @@ requires ExistsTxnSenderAccount(__m, __txn);
     __frame := __local_counter;
 
     // process and type check arguments
-    assume is#Vector(Dereference(__m, handle_ref));
-    assume IsValidReferenceParameter(__m, __local_counter, handle_ref);
-    assume is#Vector(Dereference(__m, handle_ref));
+    assume $LibraAccount_EventHandle_is_well_formed(Dereference(__m, handle_ref)) && IsValidReferenceParameter(__m, __local_counter, handle_ref);
+    assume $LibraAccount_EventHandle_is_well_formed(Dereference(__m, handle_ref));
     assume $DebugTrackLocal(7, 34, 0, 22958, Dereference(__m, handle_ref));
     __m := UpdateLocal(__m, __frame + 1, msg);
     assume $DebugTrackLocal(7, 34, 1, 22958, msg);
@@ -4903,6 +5023,8 @@ requires ExistsTxnSenderAccount(__m, __txn);
     call __t17 := CopyOrMoveRef(count);
 
     call WriteRef(__t17, GetLocal(__m, __frame + 16));
+    assume $LibraAccount_EventHandle_is_well_formed(Dereference(__m, handle_ref));
+    assume $DebugTrackLocal(7, 34, 0, 23271, Dereference(__m, handle_ref));
 
     return;
 
@@ -4939,7 +5061,7 @@ requires ExistsTxnSenderAccount(__m, __txn);
     __frame := __local_counter;
 
     // process and type check arguments
-    assume is#Vector(handle);
+    assume $LibraAccount_EventHandle_is_well_formed(handle);
     __m := UpdateLocal(__m, __frame + 0, handle);
     assume $DebugTrackLocal(7, 36, 0, 23597, handle);
 
@@ -4977,6 +5099,10 @@ procedure LibraAccount_destroy_handle_verify (tv0: TypeValue, handle: Value) ret
 
 
 
+// ** synthetics of module AccessPathTest
+
+
+
 // ** structs of module AccessPathTest
 
 const unique AccessPathTest_ProverGhostTypes: TypeName;
@@ -4987,20 +5113,27 @@ axiom AccessPathTest_ProverGhostTypes_b == 1;
 function AccessPathTest_ProverGhostTypes_type_value(): TypeValue {
     StructType(AccessPathTest_ProverGhostTypes, ExtendTypeValueArray(ExtendTypeValueArray(EmptyTypeValueArray, LibraAccount_T_type_value()), LibraCoin_T_type_value()))
 }
-procedure {:inline 1} Pack_AccessPathTest_ProverGhostTypes(a: Value, b: Value) returns (_struct: Value)
+function {:inline 1} $AccessPathTest_ProverGhostTypes_is_well_formed(__this: Value): bool {
+    is#Vector(__this)
+        && $LibraAccount_T_is_well_formed(SelectField(__this, AccessPathTest_ProverGhostTypes_a))
+        && $LibraCoin_T_is_well_formed(SelectField(__this, AccessPathTest_ProverGhostTypes_b))
+}
+
+procedure {:inline 1} Pack_AccessPathTest_ProverGhostTypes(module_idx: int, func_idx: int, var_idx: int, code_idx: int, a: Value, b: Value) returns (_struct: Value)
 {
-    assume is#Vector(a);
-    assume is#Vector(b);
+    assume $LibraAccount_T_is_well_formed(a);
+    assume $LibraCoin_T_is_well_formed(b);
     _struct := Vector(ExtendValueArray(ExtendValueArray(EmptyValueArray, a), b));
+    if (code_idx > 0) { assume $DebugTrackLocal(module_idx, func_idx, var_idx, code_idx, _struct); }
 }
 
 procedure {:inline 1} Unpack_AccessPathTest_ProverGhostTypes(_struct: Value) returns (a: Value, b: Value)
 {
     assume is#Vector(_struct);
     a := SelectField(_struct, AccessPathTest_ProverGhostTypes_a);
-    assume is#Vector(a);
+    assume $LibraAccount_T_is_well_formed(a);
     b := SelectField(_struct, AccessPathTest_ProverGhostTypes_b);
-    assume is#Vector(b);
+    assume $LibraCoin_T_is_well_formed(b);
 }
 
 

--- a/language/move-prover/bytecode-to-boogie/tests/goldenfiles/test-arithmetic.bpl
+++ b/language/move-prover/bytecode-to-boogie/tests/goldenfiles/test-arithmetic.bpl
@@ -1,5 +1,9 @@
 
 
+// ** synthetics of module TestArithmetic
+
+
+
 // ** structs of module TestArithmetic
 
 

--- a/language/move-prover/bytecode-to-boogie/tests/goldenfiles/test-control-flow.bpl
+++ b/language/move-prover/bytecode-to-boogie/tests/goldenfiles/test-control-flow.bpl
@@ -1,5 +1,9 @@
 
 
+// ** synthetics of module TestControlFlow
+
+
+
 // ** structs of module TestControlFlow
 
 

--- a/language/move-prover/bytecode-to-boogie/tests/goldenfiles/test-func-call.bpl
+++ b/language/move-prover/bytecode-to-boogie/tests/goldenfiles/test-func-call.bpl
@@ -1,5 +1,9 @@
 
 
+// ** synthetics of module TestFuncCall
+
+
+
 // ** structs of module TestFuncCall
 
 

--- a/language/move-prover/bytecode-to-boogie/tests/goldenfiles/test-generics.bpl
+++ b/language/move-prover/bytecode-to-boogie/tests/goldenfiles/test-generics.bpl
@@ -1,5 +1,9 @@
 
 
+// ** synthetics of module TestGenerics
+
+
+
 // ** structs of module TestGenerics
 
 const unique TestGenerics_R: TypeName;
@@ -8,17 +12,23 @@ axiom TestGenerics_R_v == 0;
 function TestGenerics_R_type_value(): TypeValue {
     StructType(TestGenerics_R, ExtendTypeValueArray(EmptyTypeValueArray, Vector_T_type_value(IntegerType())))
 }
-procedure {:inline 1} Pack_TestGenerics_R(v: Value) returns (_struct: Value)
+function {:inline 1} $TestGenerics_R_is_well_formed(__this: Value): bool {
+    is#Vector(__this)
+        && $Vector_T_is_well_formed(SelectField(__this, TestGenerics_R_v))
+}
+
+procedure {:inline 1} Pack_TestGenerics_R(module_idx: int, func_idx: int, var_idx: int, code_idx: int, v: Value) returns (_struct: Value)
 {
-    assume is#Vector(v);
+    assume $Vector_T_is_well_formed(v);
     _struct := Vector(ExtendValueArray(EmptyValueArray, v));
+    if (code_idx > 0) { assume $DebugTrackLocal(module_idx, func_idx, var_idx, code_idx, _struct); }
 }
 
 procedure {:inline 1} Unpack_TestGenerics_R(_struct: Value) returns (v: Value)
 {
     assume is#Vector(_struct);
     v := SelectField(_struct, TestGenerics_R_v);
-    assume is#Vector(v);
+    assume $Vector_T_is_well_formed(v);
 }
 
 const unique TestGenerics_T: TypeName;
@@ -27,17 +37,23 @@ axiom TestGenerics_T_v == 0;
 function TestGenerics_T_type_value(tv0: TypeValue): TypeValue {
     StructType(TestGenerics_T, ExtendTypeValueArray(EmptyTypeValueArray, Vector_T_type_value(tv0)))
 }
-procedure {:inline 1} Pack_TestGenerics_T(tv0: TypeValue, v: Value) returns (_struct: Value)
+function {:inline 1} $TestGenerics_T_is_well_formed(__this: Value): bool {
+    is#Vector(__this)
+        && $Vector_T_is_well_formed(SelectField(__this, TestGenerics_T_v))
+}
+
+procedure {:inline 1} Pack_TestGenerics_T(module_idx: int, func_idx: int, var_idx: int, code_idx: int, tv0: TypeValue, v: Value) returns (_struct: Value)
 {
-    assume is#Vector(v);
+    assume $Vector_T_is_well_formed(v);
     _struct := Vector(ExtendValueArray(EmptyValueArray, v));
+    if (code_idx > 0) { assume $DebugTrackLocal(module_idx, func_idx, var_idx, code_idx, _struct); }
 }
 
 procedure {:inline 1} Unpack_TestGenerics_T(_struct: Value) returns (v: Value)
 {
     assume is#Vector(_struct);
     v := SelectField(_struct, TestGenerics_T_v);
-    assume is#Vector(v);
+    assume $Vector_T_is_well_formed(v);
 }
 
 
@@ -84,7 +100,7 @@ requires ExistsTxnSenderAccount(__m, __txn);
       assume $DebugTrackAbort(1, 0, 260);
       goto Label_Abort;
     }
-    assume is#Vector(__t4);
+    assume $Vector_T_is_well_formed(__t4);
 
     __m := UpdateLocal(__m, __frame + 4, __t4);
 
@@ -92,7 +108,7 @@ requires ExistsTxnSenderAccount(__m, __txn);
     __m := UpdateLocal(__m, __frame + 2, __tmp);
     assume $DebugTrackLocal(1, 0, 2, 256, __tmp);
 
-    call __t5 := BorrowLoc(__frame + 2);
+    call __t5 := BorrowLoc(__frame + 2, Vector_T_type_value(IntegerType()));
 
     call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 0));
     __m := UpdateLocal(__m, __frame + 6, __tmp);
@@ -104,7 +120,7 @@ requires ExistsTxnSenderAccount(__m, __txn);
     }
     assume $DebugTrackLocal(1, 0, 2, 289, GetLocal(__m, __frame + 2));
 
-    call __t7 := BorrowLoc(__frame + 2);
+    call __t7 := BorrowLoc(__frame + 2, Vector_T_type_value(IntegerType()));
 
     call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 1));
     __m := UpdateLocal(__m, __frame + 8, __tmp);
@@ -119,7 +135,7 @@ requires ExistsTxnSenderAccount(__m, __txn);
     call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 2));
     __m := UpdateLocal(__m, __frame + 9, __tmp);
 
-    call __tmp := Pack_TestGenerics_R(GetLocal(__m, __frame + 9));
+    call __tmp := Pack_TestGenerics_R(1, 0, 3, 391, GetLocal(__m, __frame + 9));
     __m := UpdateLocal(__m, __frame + 10, __tmp);
 
     call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 10));
@@ -180,7 +196,7 @@ requires ExistsTxnSenderAccount(__m, __txn);
       assume $DebugTrackAbort(1, 1, 561);
       goto Label_Abort;
     }
-    assume is#Vector(__t2);
+    assume $Vector_T_is_well_formed(__t2);
 
     __m := UpdateLocal(__m, __frame + 2, __t2);
 
@@ -188,7 +204,7 @@ requires ExistsTxnSenderAccount(__m, __txn);
     __m := UpdateLocal(__m, __frame + 1, __tmp);
     assume $DebugTrackLocal(1, 1, 1, 557, __tmp);
 
-    call __t3 := BorrowLoc(__frame + 1);
+    call __t3 := BorrowLoc(__frame + 1, Vector_T_type_value(tv0));
 
     call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 0));
     __m := UpdateLocal(__m, __frame + 4, __tmp);
@@ -203,7 +219,7 @@ requires ExistsTxnSenderAccount(__m, __txn);
     call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 1));
     __m := UpdateLocal(__m, __frame + 5, __tmp);
 
-    call __tmp := Pack_TestGenerics_T(tv0, GetLocal(__m, __frame + 5));
+    call __tmp := Pack_TestGenerics_T(0, 0, 0, 0, tv0, GetLocal(__m, __frame + 5));
     __m := UpdateLocal(__m, __frame + 6, __tmp);
 
     __ret0 := GetLocal(__m, __frame + 6);
@@ -264,7 +280,7 @@ requires ExistsTxnSenderAccount(__m, __txn);
       assume $DebugTrackAbort(1, 2, 827);
       goto Label_Abort;
     }
-    assume is#Vector(__t6);
+    assume $TestGenerics_T_is_well_formed(__t6);
 
     __m := UpdateLocal(__m, __frame + 6, __t6);
 
@@ -280,7 +296,7 @@ requires ExistsTxnSenderAccount(__m, __txn);
       assume $DebugTrackAbort(1, 2, 865);
       goto Label_Abort;
     }
-    assume is#Vector(__t8);
+    assume $TestGenerics_T_is_well_formed(__t8);
 
     __m := UpdateLocal(__m, __frame + 8, __t8);
 

--- a/language/move-prover/bytecode-to-boogie/tests/goldenfiles/test-lib.bpl
+++ b/language/move-prover/bytecode-to-boogie/tests/goldenfiles/test-lib.bpl
@@ -1,5 +1,9 @@
 
 
+// ** synthetics of module U64Util
+
+
+
 // ** structs of module U64Util
 
 
@@ -8,6 +12,10 @@
 
 procedure {:inline 1} U64Util_u64_to_bytes (i: Value) returns (__ret0: Value);
 requires ExistsTxnSenderAccount(__m, __txn);
+
+
+
+// ** synthetics of module AddressUtil
 
 
 
@@ -22,6 +30,10 @@ requires ExistsTxnSenderAccount(__m, __txn);
 
 
 
+// ** synthetics of module BytearrayUtil
+
+
+
 // ** structs of module BytearrayUtil
 
 
@@ -30,6 +42,10 @@ requires ExistsTxnSenderAccount(__m, __txn);
 
 procedure {:inline 1} BytearrayUtil_bytearray_concat (data1: Value, data2: Value) returns (__ret0: Value);
 requires ExistsTxnSenderAccount(__m, __txn);
+
+
+
+// ** synthetics of module Hash
 
 
 
@@ -47,6 +63,10 @@ requires ExistsTxnSenderAccount(__m, __txn);
 
 
 
+// ** synthetics of module Signature
+
+
+
 // ** structs of module Signature
 
 
@@ -61,6 +81,10 @@ requires ExistsTxnSenderAccount(__m, __txn);
 
 
 
+// ** synthetics of module GasSchedule
+
+
+
 // ** structs of module GasSchedule
 
 const unique GasSchedule_Cost: TypeName;
@@ -71,11 +95,18 @@ axiom GasSchedule_Cost_storage == 1;
 function GasSchedule_Cost_type_value(): TypeValue {
     StructType(GasSchedule_Cost, ExtendTypeValueArray(ExtendTypeValueArray(EmptyTypeValueArray, IntegerType()), IntegerType()))
 }
-procedure {:inline 1} Pack_GasSchedule_Cost(cpu: Value, storage: Value) returns (_struct: Value)
+function {:inline 1} $GasSchedule_Cost_is_well_formed(__this: Value): bool {
+    is#Vector(__this)
+        && IsValidU64(SelectField(__this, GasSchedule_Cost_cpu))
+        && IsValidU64(SelectField(__this, GasSchedule_Cost_storage))
+}
+
+procedure {:inline 1} Pack_GasSchedule_Cost(module_idx: int, func_idx: int, var_idx: int, code_idx: int, cpu: Value, storage: Value) returns (_struct: Value)
 {
     assume IsValidU64(cpu);
     assume IsValidU64(storage);
     _struct := Vector(ExtendValueArray(ExtendValueArray(EmptyValueArray, cpu), storage));
+    if (code_idx > 0) { assume $DebugTrackLocal(module_idx, func_idx, var_idx, code_idx, _struct); }
 }
 
 procedure {:inline 1} Unpack_GasSchedule_Cost(_struct: Value) returns (cpu: Value, storage: Value)
@@ -95,20 +126,27 @@ axiom GasSchedule_T_native_schedule == 1;
 function GasSchedule_T_type_value(): TypeValue {
     StructType(GasSchedule_T, ExtendTypeValueArray(ExtendTypeValueArray(EmptyTypeValueArray, Vector_T_type_value(GasSchedule_Cost_type_value())), Vector_T_type_value(GasSchedule_Cost_type_value())))
 }
-procedure {:inline 1} Pack_GasSchedule_T(instruction_schedule: Value, native_schedule: Value) returns (_struct: Value)
+function {:inline 1} $GasSchedule_T_is_well_formed(__this: Value): bool {
+    is#Vector(__this)
+        && $Vector_T_is_well_formed(SelectField(__this, GasSchedule_T_instruction_schedule))
+        && $Vector_T_is_well_formed(SelectField(__this, GasSchedule_T_native_schedule))
+}
+
+procedure {:inline 1} Pack_GasSchedule_T(module_idx: int, func_idx: int, var_idx: int, code_idx: int, instruction_schedule: Value, native_schedule: Value) returns (_struct: Value)
 {
-    assume is#Vector(instruction_schedule);
-    assume is#Vector(native_schedule);
+    assume $Vector_T_is_well_formed(instruction_schedule);
+    assume $Vector_T_is_well_formed(native_schedule);
     _struct := Vector(ExtendValueArray(ExtendValueArray(EmptyValueArray, instruction_schedule), native_schedule));
+    if (code_idx > 0) { assume $DebugTrackLocal(module_idx, func_idx, var_idx, code_idx, _struct); }
 }
 
 procedure {:inline 1} Unpack_GasSchedule_T(_struct: Value) returns (instruction_schedule: Value, native_schedule: Value)
 {
     assume is#Vector(_struct);
     instruction_schedule := SelectField(_struct, GasSchedule_T_instruction_schedule);
-    assume is#Vector(instruction_schedule);
+    assume $Vector_T_is_well_formed(instruction_schedule);
     native_schedule := SelectField(_struct, GasSchedule_T_native_schedule);
-    assume is#Vector(native_schedule);
+    assume $Vector_T_is_well_formed(native_schedule);
 }
 
 
@@ -135,7 +173,7 @@ requires ExistsTxnSenderAccount(__m, __txn);
     __frame := __local_counter;
 
     // process and type check arguments
-    assume is#Vector(gas_schedule);
+    assume $GasSchedule_T_is_well_formed(gas_schedule);
     __m := UpdateLocal(__m, __frame + 0, gas_schedule);
     assume $DebugTrackLocal(6, 0, 0, 1239, gas_schedule);
 
@@ -223,7 +261,7 @@ requires ExistsTxnSenderAccount(__m, __txn);
     }
 
     call table := CopyOrMoveRef(__t3);
-    assume is#Vector(Dereference(__m, table));
+    assume $GasSchedule_T_is_well_formed(Dereference(__m, table));
     assume $DebugTrackLocal(6, 1, 0, 1524, Dereference(__m, table));
 
     call __t4 := CopyOrMoveRef(table);
@@ -299,7 +337,7 @@ requires ExistsTxnSenderAccount(__m, __txn);
     }
 
     call table := CopyOrMoveRef(__t3);
-    assume is#Vector(Dereference(__m, table));
+    assume $GasSchedule_T_is_well_formed(Dereference(__m, table));
     assume $DebugTrackLocal(6, 2, 0, 1825, Dereference(__m, table));
 
     call __t4 := CopyOrMoveRef(table);
@@ -340,6 +378,10 @@ procedure GasSchedule_native_table_size_verify () returns (__ret0: Value)
 
 
 
+// ** synthetics of module ValidatorConfig
+
+
+
 // ** structs of module ValidatorConfig
 
 const unique ValidatorConfig_Config: TypeName;
@@ -358,7 +400,17 @@ axiom ValidatorConfig_Config_fullnodes_network_address == 5;
 function ValidatorConfig_Config_type_value(): TypeValue {
     StructType(ValidatorConfig_Config, ExtendTypeValueArray(ExtendTypeValueArray(ExtendTypeValueArray(ExtendTypeValueArray(ExtendTypeValueArray(ExtendTypeValueArray(EmptyTypeValueArray, ByteArrayType()), ByteArrayType()), ByteArrayType()), ByteArrayType()), ByteArrayType()), ByteArrayType()))
 }
-procedure {:inline 1} Pack_ValidatorConfig_Config(consensus_pubkey: Value, validator_network_signing_pubkey: Value, validator_network_identity_pubkey: Value, validator_network_address: Value, fullnodes_network_identity_pubkey: Value, fullnodes_network_address: Value) returns (_struct: Value)
+function {:inline 1} $ValidatorConfig_Config_is_well_formed(__this: Value): bool {
+    is#Vector(__this)
+        && is#ByteArray(SelectField(__this, ValidatorConfig_Config_consensus_pubkey))
+        && is#ByteArray(SelectField(__this, ValidatorConfig_Config_validator_network_signing_pubkey))
+        && is#ByteArray(SelectField(__this, ValidatorConfig_Config_validator_network_identity_pubkey))
+        && is#ByteArray(SelectField(__this, ValidatorConfig_Config_validator_network_address))
+        && is#ByteArray(SelectField(__this, ValidatorConfig_Config_fullnodes_network_identity_pubkey))
+        && is#ByteArray(SelectField(__this, ValidatorConfig_Config_fullnodes_network_address))
+}
+
+procedure {:inline 1} Pack_ValidatorConfig_Config(module_idx: int, func_idx: int, var_idx: int, code_idx: int, consensus_pubkey: Value, validator_network_signing_pubkey: Value, validator_network_identity_pubkey: Value, validator_network_address: Value, fullnodes_network_identity_pubkey: Value, fullnodes_network_address: Value) returns (_struct: Value)
 {
     assume is#ByteArray(consensus_pubkey);
     assume is#ByteArray(validator_network_signing_pubkey);
@@ -367,6 +419,7 @@ procedure {:inline 1} Pack_ValidatorConfig_Config(consensus_pubkey: Value, valid
     assume is#ByteArray(fullnodes_network_identity_pubkey);
     assume is#ByteArray(fullnodes_network_address);
     _struct := Vector(ExtendValueArray(ExtendValueArray(ExtendValueArray(ExtendValueArray(ExtendValueArray(ExtendValueArray(EmptyValueArray, consensus_pubkey), validator_network_signing_pubkey), validator_network_identity_pubkey), validator_network_address), fullnodes_network_identity_pubkey), fullnodes_network_address));
+    if (code_idx > 0) { assume $DebugTrackLocal(module_idx, func_idx, var_idx, code_idx, _struct); }
 }
 
 procedure {:inline 1} Unpack_ValidatorConfig_Config(_struct: Value) returns (consensus_pubkey: Value, validator_network_signing_pubkey: Value, validator_network_identity_pubkey: Value, validator_network_address: Value, fullnodes_network_identity_pubkey: Value, fullnodes_network_address: Value)
@@ -392,17 +445,23 @@ axiom ValidatorConfig_T_config == 0;
 function ValidatorConfig_T_type_value(): TypeValue {
     StructType(ValidatorConfig_T, ExtendTypeValueArray(EmptyTypeValueArray, ValidatorConfig_Config_type_value()))
 }
-procedure {:inline 1} Pack_ValidatorConfig_T(config: Value) returns (_struct: Value)
+function {:inline 1} $ValidatorConfig_T_is_well_formed(__this: Value): bool {
+    is#Vector(__this)
+        && $ValidatorConfig_Config_is_well_formed(SelectField(__this, ValidatorConfig_T_config))
+}
+
+procedure {:inline 1} Pack_ValidatorConfig_T(module_idx: int, func_idx: int, var_idx: int, code_idx: int, config: Value) returns (_struct: Value)
 {
-    assume is#Vector(config);
+    assume $ValidatorConfig_Config_is_well_formed(config);
     _struct := Vector(ExtendValueArray(EmptyValueArray, config));
+    if (code_idx > 0) { assume $DebugTrackLocal(module_idx, func_idx, var_idx, code_idx, _struct); }
 }
 
 procedure {:inline 1} Unpack_ValidatorConfig_T(_struct: Value) returns (config: Value)
 {
     assume is#Vector(_struct);
     config := SelectField(_struct, ValidatorConfig_T_config);
-    assume is#Vector(config);
+    assume $ValidatorConfig_Config_is_well_formed(config);
 }
 
 
@@ -493,7 +552,7 @@ requires ExistsTxnSenderAccount(__m, __txn);
     }
 
     call t_ref := CopyOrMoveRef(__t3);
-    assume is#Vector(Dereference(__m, t_ref));
+    assume $ValidatorConfig_T_is_well_formed(Dereference(__m, t_ref));
     assume $DebugTrackLocal(7, 1, 1, 999, Dereference(__m, t_ref));
 
     call __t4 := CopyOrMoveRef(t_ref);
@@ -501,7 +560,7 @@ requires ExistsTxnSenderAccount(__m, __txn);
     call __t5 := BorrowField(__t4, ValidatorConfig_T_config);
 
     call __tmp := ReadRef(__t5);
-    assume is#Vector(__tmp);
+    assume $ValidatorConfig_Config_is_well_formed(__tmp);
     __m := UpdateLocal(__m, __frame + 6, __tmp);
 
     __ret0 := GetLocal(__m, __frame + 6);
@@ -537,9 +596,8 @@ requires ExistsTxnSenderAccount(__m, __txn);
     __frame := __local_counter;
 
     // process and type check arguments
-    assume is#Vector(Dereference(__m, config_ref));
-    assume IsValidReferenceParameter(__m, __local_counter, config_ref);
-    assume is#Vector(Dereference(__m, config_ref));
+    assume $ValidatorConfig_Config_is_well_formed(Dereference(__m, config_ref)) && IsValidReferenceParameter(__m, __local_counter, config_ref);
+    assume $ValidatorConfig_Config_is_well_formed(Dereference(__m, config_ref));
     assume $DebugTrackLocal(7, 2, 0, 1129, Dereference(__m, config_ref));
 
     // increase the local counter
@@ -587,9 +645,8 @@ requires ExistsTxnSenderAccount(__m, __txn);
     __frame := __local_counter;
 
     // process and type check arguments
-    assume is#Vector(Dereference(__m, config_ref));
-    assume IsValidReferenceParameter(__m, __local_counter, config_ref);
-    assume is#Vector(Dereference(__m, config_ref));
+    assume $ValidatorConfig_Config_is_well_formed(Dereference(__m, config_ref)) && IsValidReferenceParameter(__m, __local_counter, config_ref);
+    assume $ValidatorConfig_Config_is_well_formed(Dereference(__m, config_ref));
     assume $DebugTrackLocal(7, 3, 0, 1315, Dereference(__m, config_ref));
 
     // increase the local counter
@@ -637,9 +694,8 @@ requires ExistsTxnSenderAccount(__m, __txn);
     __frame := __local_counter;
 
     // process and type check arguments
-    assume is#Vector(Dereference(__m, config_ref));
-    assume IsValidReferenceParameter(__m, __local_counter, config_ref);
-    assume is#Vector(Dereference(__m, config_ref));
+    assume $ValidatorConfig_Config_is_well_formed(Dereference(__m, config_ref)) && IsValidReferenceParameter(__m, __local_counter, config_ref);
+    assume $ValidatorConfig_Config_is_well_formed(Dereference(__m, config_ref));
     assume $DebugTrackLocal(7, 4, 0, 1534, Dereference(__m, config_ref));
 
     // increase the local counter
@@ -687,9 +743,8 @@ requires ExistsTxnSenderAccount(__m, __txn);
     __frame := __local_counter;
 
     // process and type check arguments
-    assume is#Vector(Dereference(__m, config_ref));
-    assume IsValidReferenceParameter(__m, __local_counter, config_ref);
-    assume is#Vector(Dereference(__m, config_ref));
+    assume $ValidatorConfig_Config_is_well_formed(Dereference(__m, config_ref)) && IsValidReferenceParameter(__m, __local_counter, config_ref);
+    assume $ValidatorConfig_Config_is_well_formed(Dereference(__m, config_ref));
     assume $DebugTrackLocal(7, 5, 0, 1747, Dereference(__m, config_ref));
 
     // increase the local counter
@@ -737,9 +792,8 @@ requires ExistsTxnSenderAccount(__m, __txn);
     __frame := __local_counter;
 
     // process and type check arguments
-    assume is#Vector(Dereference(__m, config_ref));
-    assume IsValidReferenceParameter(__m, __local_counter, config_ref);
-    assume is#Vector(Dereference(__m, config_ref));
+    assume $ValidatorConfig_Config_is_well_formed(Dereference(__m, config_ref)) && IsValidReferenceParameter(__m, __local_counter, config_ref);
+    assume $ValidatorConfig_Config_is_well_formed(Dereference(__m, config_ref));
     assume $DebugTrackLocal(7, 6, 0, 1952, Dereference(__m, config_ref));
 
     // increase the local counter
@@ -787,9 +841,8 @@ requires ExistsTxnSenderAccount(__m, __txn);
     __frame := __local_counter;
 
     // process and type check arguments
-    assume is#Vector(Dereference(__m, config_ref));
-    assume IsValidReferenceParameter(__m, __local_counter, config_ref);
-    assume is#Vector(Dereference(__m, config_ref));
+    assume $ValidatorConfig_Config_is_well_formed(Dereference(__m, config_ref)) && IsValidReferenceParameter(__m, __local_counter, config_ref);
+    assume $ValidatorConfig_Config_is_well_formed(Dereference(__m, config_ref));
     assume $DebugTrackLocal(7, 7, 0, 2165, Dereference(__m, config_ref));
 
     // increase the local counter
@@ -883,10 +936,10 @@ requires ExistsTxnSenderAccount(__m, __txn);
     call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 5));
     __m := UpdateLocal(__m, __frame + 11, __tmp);
 
-    call __tmp := Pack_ValidatorConfig_Config(GetLocal(__m, __frame + 6), GetLocal(__m, __frame + 7), GetLocal(__m, __frame + 8), GetLocal(__m, __frame + 9), GetLocal(__m, __frame + 10), GetLocal(__m, __frame + 11));
+    call __tmp := Pack_ValidatorConfig_Config(0, 0, 0, 0, GetLocal(__m, __frame + 6), GetLocal(__m, __frame + 7), GetLocal(__m, __frame + 8), GetLocal(__m, __frame + 9), GetLocal(__m, __frame + 10), GetLocal(__m, __frame + 11));
     __m := UpdateLocal(__m, __frame + 12, __tmp);
 
-    call __tmp := Pack_ValidatorConfig_T(GetLocal(__m, __frame + 12));
+    call __tmp := Pack_ValidatorConfig_T(0, 0, 0, 0, GetLocal(__m, __frame + 12));
     __m := UpdateLocal(__m, __frame + 13, __tmp);
 
     call MoveToSender(ValidatorConfig_T_type_value(), GetLocal(__m, __frame + 13));
@@ -951,7 +1004,7 @@ requires ExistsTxnSenderAccount(__m, __txn);
     }
 
     call t_ref := CopyOrMoveRef(__t5);
-    assume is#Vector(Dereference(__m, t_ref));
+    assume $ValidatorConfig_T_is_well_formed(Dereference(__m, t_ref));
     assume $DebugTrackLocal(7, 9, 1, 3841, Dereference(__m, t_ref));
 
     call __t6 := CopyOrMoveRef(t_ref);
@@ -959,7 +1012,7 @@ requires ExistsTxnSenderAccount(__m, __txn);
     call __t7 := BorrowField(__t6, ValidatorConfig_T_config);
 
     call config_ref := CopyOrMoveRef(__t7);
-    assume is#Vector(Dereference(__m, config_ref));
+    assume $ValidatorConfig_Config_is_well_formed(Dereference(__m, config_ref));
     assume $DebugTrackLocal(7, 9, 2, 3897, Dereference(__m, config_ref));
 
     call __t8 := CopyOrMoveRef(config_ref);
@@ -976,6 +1029,7 @@ requires ExistsTxnSenderAccount(__m, __txn);
     call __t11 := CopyOrMoveRef(key_ref);
 
     call WriteRef(__t11, GetLocal(__m, __frame + 10));
+
 
     return;
 
@@ -1033,7 +1087,7 @@ requires ExistsTxnSenderAccount(__m, __txn);
     }
 
     call t_ref := CopyOrMoveRef(__t5);
-    assume is#Vector(Dereference(__m, t_ref));
+    assume $ValidatorConfig_T_is_well_formed(Dereference(__m, t_ref));
     assume $DebugTrackLocal(7, 10, 1, 4502, Dereference(__m, t_ref));
 
     call __t6 := CopyOrMoveRef(t_ref);
@@ -1041,7 +1095,7 @@ requires ExistsTxnSenderAccount(__m, __txn);
     call __t7 := BorrowField(__t6, ValidatorConfig_T_config);
 
     call config_ref := CopyOrMoveRef(__t7);
-    assume is#Vector(Dereference(__m, config_ref));
+    assume $ValidatorConfig_Config_is_well_formed(Dereference(__m, config_ref));
     assume $DebugTrackLocal(7, 10, 2, 4558, Dereference(__m, config_ref));
 
     call __t8 := CopyOrMoveRef(config_ref);
@@ -1058,6 +1112,7 @@ requires ExistsTxnSenderAccount(__m, __txn);
     call __t11 := CopyOrMoveRef(key_ref);
 
     call WriteRef(__t11, GetLocal(__m, __frame + 10));
+
 
     return;
 
@@ -1115,7 +1170,7 @@ requires ExistsTxnSenderAccount(__m, __txn);
     }
 
     call t_ref := CopyOrMoveRef(__t5);
-    assume is#Vector(Dereference(__m, t_ref));
+    assume $ValidatorConfig_T_is_well_formed(Dereference(__m, t_ref));
     assume $DebugTrackLocal(7, 11, 1, 5111, Dereference(__m, t_ref));
 
     call __t6 := CopyOrMoveRef(t_ref);
@@ -1123,7 +1178,7 @@ requires ExistsTxnSenderAccount(__m, __txn);
     call __t7 := BorrowField(__t6, ValidatorConfig_T_config);
 
     call config_ref := CopyOrMoveRef(__t7);
-    assume is#Vector(Dereference(__m, config_ref));
+    assume $ValidatorConfig_Config_is_well_formed(Dereference(__m, config_ref));
     assume $DebugTrackLocal(7, 11, 2, 5167, Dereference(__m, config_ref));
 
     call __t8 := CopyOrMoveRef(config_ref);
@@ -1141,6 +1196,7 @@ requires ExistsTxnSenderAccount(__m, __txn);
 
     call WriteRef(__t11, GetLocal(__m, __frame + 10));
 
+
     return;
 
 Label_Abort:
@@ -1156,6 +1212,10 @@ procedure ValidatorConfig_rotate_validator_network_address_verify (validator_net
 
 
 
+// ** synthetics of module LibraCoin
+
+
+
 // ** structs of module LibraCoin
 
 const unique LibraCoin_T: TypeName;
@@ -1164,10 +1224,16 @@ axiom LibraCoin_T_value == 0;
 function LibraCoin_T_type_value(): TypeValue {
     StructType(LibraCoin_T, ExtendTypeValueArray(EmptyTypeValueArray, IntegerType()))
 }
-procedure {:inline 1} Pack_LibraCoin_T(value: Value) returns (_struct: Value)
+function {:inline 1} $LibraCoin_T_is_well_formed(__this: Value): bool {
+    is#Vector(__this)
+        && IsValidU64(SelectField(__this, LibraCoin_T_value))
+}
+
+procedure {:inline 1} Pack_LibraCoin_T(module_idx: int, func_idx: int, var_idx: int, code_idx: int, value: Value) returns (_struct: Value)
 {
     assume IsValidU64(value);
     _struct := Vector(ExtendValueArray(EmptyValueArray, value));
+    if (code_idx > 0) { assume $DebugTrackLocal(module_idx, func_idx, var_idx, code_idx, _struct); }
 }
 
 procedure {:inline 1} Unpack_LibraCoin_T(_struct: Value) returns (value: Value)
@@ -1183,10 +1249,16 @@ axiom LibraCoin_MintCapability__dummy == 0;
 function LibraCoin_MintCapability_type_value(): TypeValue {
     StructType(LibraCoin_MintCapability, ExtendTypeValueArray(EmptyTypeValueArray, BooleanType()))
 }
-procedure {:inline 1} Pack_LibraCoin_MintCapability(_dummy: Value) returns (_struct: Value)
+function {:inline 1} $LibraCoin_MintCapability_is_well_formed(__this: Value): bool {
+    is#Vector(__this)
+        && is#Boolean(SelectField(__this, LibraCoin_MintCapability__dummy))
+}
+
+procedure {:inline 1} Pack_LibraCoin_MintCapability(module_idx: int, func_idx: int, var_idx: int, code_idx: int, _dummy: Value) returns (_struct: Value)
 {
     assume is#Boolean(_dummy);
     _struct := Vector(ExtendValueArray(EmptyValueArray, _dummy));
+    if (code_idx > 0) { assume $DebugTrackLocal(module_idx, func_idx, var_idx, code_idx, _struct); }
 }
 
 procedure {:inline 1} Unpack_LibraCoin_MintCapability(_struct: Value) returns (_dummy: Value)
@@ -1202,10 +1274,16 @@ axiom LibraCoin_MarketCap_total_value == 0;
 function LibraCoin_MarketCap_type_value(): TypeValue {
     StructType(LibraCoin_MarketCap, ExtendTypeValueArray(EmptyTypeValueArray, IntegerType()))
 }
-procedure {:inline 1} Pack_LibraCoin_MarketCap(total_value: Value) returns (_struct: Value)
+function {:inline 1} $LibraCoin_MarketCap_is_well_formed(__this: Value): bool {
+    is#Vector(__this)
+        && IsValidU128(SelectField(__this, LibraCoin_MarketCap_total_value))
+}
+
+procedure {:inline 1} Pack_LibraCoin_MarketCap(module_idx: int, func_idx: int, var_idx: int, code_idx: int, total_value: Value) returns (_struct: Value)
 {
     assume IsValidU128(total_value);
     _struct := Vector(ExtendValueArray(EmptyValueArray, total_value));
+    if (code_idx > 0) { assume $DebugTrackLocal(module_idx, func_idx, var_idx, code_idx, _struct); }
 }
 
 procedure {:inline 1} Unpack_LibraCoin_MarketCap(_struct: Value) returns (total_value: Value)
@@ -1262,7 +1340,7 @@ requires ExistsTxnSenderAccount(__m, __txn);
       assume $DebugTrackAbort(8, 0, 916);
       goto Label_Abort;
     }
-    assume is#Vector(__t4);
+    assume $LibraCoin_T_is_well_formed(__t4);
 
     __m := UpdateLocal(__m, __frame + 4, __t4);
 
@@ -1318,9 +1396,8 @@ requires ExistsTxnSenderAccount(__m, __txn);
     assume IsValidU64(value);
     __m := UpdateLocal(__m, __frame + 0, value);
     assume $DebugTrackLocal(8, 1, 0, 1231, value);
-    assume is#Vector(Dereference(__m, capability));
-    assume IsValidReferenceParameter(__m, __local_counter, capability);
-    assume is#Vector(Dereference(__m, capability));
+    assume $LibraCoin_MintCapability_is_well_formed(Dereference(__m, capability)) && IsValidReferenceParameter(__m, __local_counter, capability);
+    assume $LibraCoin_MintCapability_is_well_formed(Dereference(__m, capability));
     assume $DebugTrackLocal(8, 1, 1, 1231, Dereference(__m, capability));
 
     // increase the local counter
@@ -1400,10 +1477,11 @@ Label_9:
 
     call WriteRef(__t18, GetLocal(__m, __frame + 17));
 
+
     call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 0));
     __m := UpdateLocal(__m, __frame + 19, __tmp);
 
-    call __tmp := Pack_LibraCoin_T(GetLocal(__m, __frame + 19));
+    call __tmp := Pack_LibraCoin_T(0, 0, 0, 0, GetLocal(__m, __frame + 19));
     __m := UpdateLocal(__m, __frame + 20, __tmp);
 
     __ret0 := GetLocal(__m, __frame + 20);
@@ -1474,7 +1552,7 @@ Label_7:
     call __tmp := LdTrue();
     __m := UpdateLocal(__m, __frame + 5, __tmp);
 
-    call __tmp := Pack_LibraCoin_MintCapability(GetLocal(__m, __frame + 5));
+    call __tmp := Pack_LibraCoin_MintCapability(0, 0, 0, 0, GetLocal(__m, __frame + 5));
     __m := UpdateLocal(__m, __frame + 6, __tmp);
 
     call MoveToSender(LibraCoin_MintCapability_type_value(), GetLocal(__m, __frame + 6));
@@ -1486,7 +1564,7 @@ Label_7:
     call __tmp := LdConst(0);
     __m := UpdateLocal(__m, __frame + 7, __tmp);
 
-    call __tmp := Pack_LibraCoin_MarketCap(GetLocal(__m, __frame + 7));
+    call __tmp := Pack_LibraCoin_MarketCap(0, 0, 0, 0, GetLocal(__m, __frame + 7));
     __m := UpdateLocal(__m, __frame + 8, __tmp);
 
     call MoveToSender(LibraCoin_MarketCap_type_value(), GetLocal(__m, __frame + 8));
@@ -1586,7 +1664,7 @@ requires ExistsTxnSenderAccount(__m, __txn);
     call __tmp := LdConst(0);
     __m := UpdateLocal(__m, __frame + 0, __tmp);
 
-    call __tmp := Pack_LibraCoin_T(GetLocal(__m, __frame + 0));
+    call __tmp := Pack_LibraCoin_T(0, 0, 0, 0, GetLocal(__m, __frame + 0));
     __m := UpdateLocal(__m, __frame + 1, __tmp);
 
     __ret0 := GetLocal(__m, __frame + 1);
@@ -1622,9 +1700,8 @@ requires ExistsTxnSenderAccount(__m, __txn);
     __frame := __local_counter;
 
     // process and type check arguments
-    assume is#Vector(Dereference(__m, coin_ref));
-    assume IsValidReferenceParameter(__m, __local_counter, coin_ref);
-    assume is#Vector(Dereference(__m, coin_ref));
+    assume $LibraCoin_T_is_well_formed(Dereference(__m, coin_ref)) && IsValidReferenceParameter(__m, __local_counter, coin_ref);
+    assume $LibraCoin_T_is_well_formed(Dereference(__m, coin_ref));
     assume $DebugTrackLocal(8, 5, 0, 2888, Dereference(__m, coin_ref));
 
     // increase the local counter
@@ -1675,7 +1752,7 @@ requires ExistsTxnSenderAccount(__m, __txn);
     __frame := __local_counter;
 
     // process and type check arguments
-    assume is#Vector(coin);
+    assume $LibraCoin_T_is_well_formed(coin);
     __m := UpdateLocal(__m, __frame + 0, coin);
     assume $DebugTrackLocal(8, 6, 0, 3109, coin);
     assume IsValidU64(amount);
@@ -1686,7 +1763,7 @@ requires ExistsTxnSenderAccount(__m, __txn);
     __local_counter := __local_counter + 8;
 
     // bytecode translation starts here
-    call __t3 := BorrowLoc(__frame + 0);
+    call __t3 := BorrowLoc(__frame + 0, LibraCoin_T_type_value());
 
     call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 1));
     __m := UpdateLocal(__m, __frame + 4, __tmp);
@@ -1696,7 +1773,7 @@ requires ExistsTxnSenderAccount(__m, __txn);
       assume $DebugTrackAbort(8, 6, 3211);
       goto Label_Abort;
     }
-    assume is#Vector(__t5);
+    assume $LibraCoin_T_is_well_formed(__t5);
 
     __m := UpdateLocal(__m, __frame + 5, __t5);
     assume $DebugTrackLocal(8, 6, 0, 3211, GetLocal(__m, __frame + 0));
@@ -1760,9 +1837,8 @@ requires ExistsTxnSenderAccount(__m, __txn);
     __frame := __local_counter;
 
     // process and type check arguments
-    assume is#Vector(Dereference(__m, coin_ref));
-    assume IsValidReferenceParameter(__m, __local_counter, coin_ref);
-    assume is#Vector(Dereference(__m, coin_ref));
+    assume $LibraCoin_T_is_well_formed(Dereference(__m, coin_ref)) && IsValidReferenceParameter(__m, __local_counter, coin_ref);
+    assume $LibraCoin_T_is_well_formed(Dereference(__m, coin_ref));
     assume $DebugTrackLocal(8, 7, 0, 3557, Dereference(__m, coin_ref));
     assume IsValidU64(amount);
     __m := UpdateLocal(__m, __frame + 1, amount);
@@ -1823,11 +1899,13 @@ Label_11:
     call __t15 := BorrowField(__t14, LibraCoin_T_value);
 
     call WriteRef(__t15, GetLocal(__m, __frame + 13));
+    assume $LibraCoin_T_is_well_formed(Dereference(__m, coin_ref));
+    assume $DebugTrackLocal(8, 7, 0, 3835, Dereference(__m, coin_ref));
 
     call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 1));
     __m := UpdateLocal(__m, __frame + 16, __tmp);
 
-    call __tmp := Pack_LibraCoin_T(GetLocal(__m, __frame + 16));
+    call __tmp := Pack_LibraCoin_T(0, 0, 0, 0, GetLocal(__m, __frame + 16));
     __m := UpdateLocal(__m, __frame + 17, __tmp);
 
     __ret0 := GetLocal(__m, __frame + 17);
@@ -1863,10 +1941,10 @@ requires ExistsTxnSenderAccount(__m, __txn);
     __frame := __local_counter;
 
     // process and type check arguments
-    assume is#Vector(coin1);
+    assume $LibraCoin_T_is_well_formed(coin1);
     __m := UpdateLocal(__m, __frame + 0, coin1);
     assume $DebugTrackLocal(8, 8, 0, 4041, coin1);
-    assume is#Vector(coin2);
+    assume $LibraCoin_T_is_well_formed(coin2);
     __m := UpdateLocal(__m, __frame + 1, coin2);
     assume $DebugTrackLocal(8, 8, 1, 4041, coin2);
 
@@ -1874,7 +1952,7 @@ requires ExistsTxnSenderAccount(__m, __txn);
     __local_counter := __local_counter + 5;
 
     // bytecode translation starts here
-    call __t2 := BorrowLoc(__frame + 0);
+    call __t2 := BorrowLoc(__frame + 0, LibraCoin_T_type_value());
 
     call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 1));
     __m := UpdateLocal(__m, __frame + 3, __tmp);
@@ -1931,11 +2009,10 @@ requires ExistsTxnSenderAccount(__m, __txn);
     __frame := __local_counter;
 
     // process and type check arguments
-    assume is#Vector(Dereference(__m, coin_ref));
-    assume IsValidReferenceParameter(__m, __local_counter, coin_ref);
-    assume is#Vector(Dereference(__m, coin_ref));
+    assume $LibraCoin_T_is_well_formed(Dereference(__m, coin_ref)) && IsValidReferenceParameter(__m, __local_counter, coin_ref);
+    assume $LibraCoin_T_is_well_formed(Dereference(__m, coin_ref));
     assume $DebugTrackLocal(8, 9, 0, 4352, Dereference(__m, coin_ref));
-    assume is#Vector(check);
+    assume $LibraCoin_T_is_well_formed(check);
     __m := UpdateLocal(__m, __frame + 1, check);
     assume $DebugTrackLocal(8, 9, 1, 4352, check);
 
@@ -1983,6 +2060,8 @@ requires ExistsTxnSenderAccount(__m, __txn);
     call __t13 := BorrowField(__t12, LibraCoin_T_value);
 
     call WriteRef(__t13, GetLocal(__m, __frame + 11));
+    assume $LibraCoin_T_is_well_formed(Dereference(__m, coin_ref));
+    assume $DebugTrackLocal(8, 9, 0, 4564, Dereference(__m, coin_ref));
 
     return;
 
@@ -2019,7 +2098,7 @@ requires ExistsTxnSenderAccount(__m, __txn);
     __frame := __local_counter;
 
     // process and type check arguments
-    assume is#Vector(coin);
+    assume $LibraCoin_T_is_well_formed(coin);
     __m := UpdateLocal(__m, __frame + 0, coin);
     assume $DebugTrackLocal(8, 10, 0, 4858, coin);
 
@@ -2073,6 +2152,10 @@ procedure LibraCoin_destroy_zero_verify (coin: Value) returns ()
 
 
 
+// ** synthetics of module LibraTimestamp
+
+
+
 // ** structs of module LibraTimestamp
 
 const unique LibraTimestamp_CurrentTimeMicroseconds: TypeName;
@@ -2081,10 +2164,16 @@ axiom LibraTimestamp_CurrentTimeMicroseconds_microseconds == 0;
 function LibraTimestamp_CurrentTimeMicroseconds_type_value(): TypeValue {
     StructType(LibraTimestamp_CurrentTimeMicroseconds, ExtendTypeValueArray(EmptyTypeValueArray, IntegerType()))
 }
-procedure {:inline 1} Pack_LibraTimestamp_CurrentTimeMicroseconds(microseconds: Value) returns (_struct: Value)
+function {:inline 1} $LibraTimestamp_CurrentTimeMicroseconds_is_well_formed(__this: Value): bool {
+    is#Vector(__this)
+        && IsValidU64(SelectField(__this, LibraTimestamp_CurrentTimeMicroseconds_microseconds))
+}
+
+procedure {:inline 1} Pack_LibraTimestamp_CurrentTimeMicroseconds(module_idx: int, func_idx: int, var_idx: int, code_idx: int, microseconds: Value) returns (_struct: Value)
 {
     assume IsValidU64(microseconds);
     _struct := Vector(ExtendValueArray(EmptyValueArray, microseconds));
+    if (code_idx > 0) { assume $DebugTrackLocal(module_idx, func_idx, var_idx, code_idx, _struct); }
 }
 
 procedure {:inline 1} Unpack_LibraTimestamp_CurrentTimeMicroseconds(_struct: Value) returns (microseconds: Value)
@@ -2150,7 +2239,7 @@ Label_7:
     call __tmp := LdConst(0);
     __m := UpdateLocal(__m, __frame + 6, __tmp);
 
-    call __tmp := Pack_LibraTimestamp_CurrentTimeMicroseconds(GetLocal(__m, __frame + 6));
+    call __tmp := Pack_LibraTimestamp_CurrentTimeMicroseconds(9, 0, 0, 498, GetLocal(__m, __frame + 6));
     __m := UpdateLocal(__m, __frame + 7, __tmp);
 
     call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 7));
@@ -2237,7 +2326,7 @@ requires ExistsTxnSenderAccount(__m, __txn);
     }
 
     call global_timer := CopyOrMoveRef(__t4);
-    assume is#Vector(Dereference(__m, global_timer));
+    assume $LibraTimestamp_CurrentTimeMicroseconds_is_well_formed(Dereference(__m, global_timer));
     assume $DebugTrackLocal(9, 1, 2, 1084, Dereference(__m, global_timer));
 
     call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 0));
@@ -2316,6 +2405,7 @@ Label_26:
 
     call WriteRef(__t24, GetLocal(__m, __frame + 22));
 
+
     return;
 
 Label_Abort:
@@ -2385,6 +2475,10 @@ procedure LibraTimestamp_now_microseconds_verify () returns (__ret0: Value)
 
 
 
+// ** synthetics of module LibraTransactionTimeout
+
+
+
 // ** structs of module LibraTransactionTimeout
 
 const unique LibraTransactionTimeout_TTL: TypeName;
@@ -2393,10 +2487,16 @@ axiom LibraTransactionTimeout_TTL_duration_microseconds == 0;
 function LibraTransactionTimeout_TTL_type_value(): TypeValue {
     StructType(LibraTransactionTimeout_TTL, ExtendTypeValueArray(EmptyTypeValueArray, IntegerType()))
 }
-procedure {:inline 1} Pack_LibraTransactionTimeout_TTL(duration_microseconds: Value) returns (_struct: Value)
+function {:inline 1} $LibraTransactionTimeout_TTL_is_well_formed(__this: Value): bool {
+    is#Vector(__this)
+        && IsValidU64(SelectField(__this, LibraTransactionTimeout_TTL_duration_microseconds))
+}
+
+procedure {:inline 1} Pack_LibraTransactionTimeout_TTL(module_idx: int, func_idx: int, var_idx: int, code_idx: int, duration_microseconds: Value) returns (_struct: Value)
 {
     assume IsValidU64(duration_microseconds);
     _struct := Vector(ExtendValueArray(EmptyValueArray, duration_microseconds));
+    if (code_idx > 0) { assume $DebugTrackLocal(module_idx, func_idx, var_idx, code_idx, _struct); }
 }
 
 procedure {:inline 1} Unpack_LibraTransactionTimeout_TTL(_struct: Value) returns (duration_microseconds: Value)
@@ -2462,7 +2562,7 @@ Label_7:
     call __tmp := LdConst(86400000000);
     __m := UpdateLocal(__m, __frame + 6, __tmp);
 
-    call __tmp := Pack_LibraTransactionTimeout_TTL(GetLocal(__m, __frame + 6));
+    call __tmp := Pack_LibraTransactionTimeout_TTL(10, 0, 0, 451, GetLocal(__m, __frame + 6));
     __m := UpdateLocal(__m, __frame + 7, __tmp);
 
     call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 7));
@@ -2555,7 +2655,7 @@ Label_7:
     }
 
     call timeout := CopyOrMoveRef(__t8);
-    assume is#Vector(Dereference(__m, timeout));
+    assume $LibraTransactionTimeout_TTL_is_well_formed(Dereference(__m, timeout));
     assume $DebugTrackLocal(10, 1, 1, 765, Dereference(__m, timeout));
 
     call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 0));
@@ -2566,6 +2666,7 @@ Label_7:
     call __t11 := BorrowField(__t10, LibraTransactionTimeout_TTL_duration_microseconds);
 
     call WriteRef(__t11, GetLocal(__m, __frame + 9));
+
 
     return;
 
@@ -2737,6 +2838,10 @@ procedure LibraTransactionTimeout_is_valid_transaction_timestamp_verify (timesta
 
 
 
+// ** synthetics of module LibraAccount
+
+
+
 // ** structs of module LibraAccount
 
 const unique LibraAccount_T: TypeName;
@@ -2757,17 +2862,30 @@ axiom LibraAccount_T_sequence_number == 6;
 const LibraAccount_T_event_generator: FieldName;
 axiom LibraAccount_T_event_generator == 7;
 axiom LibraAccount_T_type_value() == StructType(LibraAccount_T, ExtendTypeValueArray(ExtendTypeValueArray(ExtendTypeValueArray(ExtendTypeValueArray(ExtendTypeValueArray(ExtendTypeValueArray(ExtendTypeValueArray(ExtendTypeValueArray(EmptyTypeValueArray, ByteArrayType()), LibraCoin_T_type_value()), BooleanType()), BooleanType()), LibraAccount_EventHandle_type_value(LibraAccount_ReceivedPaymentEvent_type_value())), LibraAccount_EventHandle_type_value(LibraAccount_SentPaymentEvent_type_value())), IntegerType()), LibraAccount_EventHandleGenerator_type_value()));
-procedure {:inline 1} Pack_LibraAccount_T(authentication_key: Value, balance: Value, delegated_key_rotation_capability: Value, delegated_withdrawal_capability: Value, received_events: Value, sent_events: Value, sequence_number: Value, event_generator: Value) returns (_struct: Value)
+function {:inline 1} $LibraAccount_T_is_well_formed(__this: Value): bool {
+    is#Vector(__this)
+        && is#ByteArray(SelectField(__this, LibraAccount_T_authentication_key))
+        && $LibraCoin_T_is_well_formed(SelectField(__this, LibraAccount_T_balance))
+        && is#Boolean(SelectField(__this, LibraAccount_T_delegated_key_rotation_capability))
+        && is#Boolean(SelectField(__this, LibraAccount_T_delegated_withdrawal_capability))
+        && $LibraAccount_EventHandle_is_well_formed(SelectField(__this, LibraAccount_T_received_events))
+        && $LibraAccount_EventHandle_is_well_formed(SelectField(__this, LibraAccount_T_sent_events))
+        && IsValidU64(SelectField(__this, LibraAccount_T_sequence_number))
+        && $LibraAccount_EventHandleGenerator_is_well_formed(SelectField(__this, LibraAccount_T_event_generator))
+}
+
+procedure {:inline 1} Pack_LibraAccount_T(module_idx: int, func_idx: int, var_idx: int, code_idx: int, authentication_key: Value, balance: Value, delegated_key_rotation_capability: Value, delegated_withdrawal_capability: Value, received_events: Value, sent_events: Value, sequence_number: Value, event_generator: Value) returns (_struct: Value)
 {
     assume is#ByteArray(authentication_key);
-    assume is#Vector(balance);
+    assume $LibraCoin_T_is_well_formed(balance);
     assume is#Boolean(delegated_key_rotation_capability);
     assume is#Boolean(delegated_withdrawal_capability);
-    assume is#Vector(received_events);
-    assume is#Vector(sent_events);
+    assume $LibraAccount_EventHandle_is_well_formed(received_events);
+    assume $LibraAccount_EventHandle_is_well_formed(sent_events);
     assume IsValidU64(sequence_number);
-    assume is#Vector(event_generator);
+    assume $LibraAccount_EventHandleGenerator_is_well_formed(event_generator);
     _struct := Vector(ExtendValueArray(ExtendValueArray(ExtendValueArray(ExtendValueArray(ExtendValueArray(ExtendValueArray(ExtendValueArray(ExtendValueArray(EmptyValueArray, authentication_key), balance), delegated_key_rotation_capability), delegated_withdrawal_capability), received_events), sent_events), sequence_number), event_generator));
+    if (code_idx > 0) { assume $DebugTrackLocal(module_idx, func_idx, var_idx, code_idx, _struct); }
 }
 
 procedure {:inline 1} Unpack_LibraAccount_T(_struct: Value) returns (authentication_key: Value, balance: Value, delegated_key_rotation_capability: Value, delegated_withdrawal_capability: Value, received_events: Value, sent_events: Value, sequence_number: Value, event_generator: Value)
@@ -2776,19 +2894,19 @@ procedure {:inline 1} Unpack_LibraAccount_T(_struct: Value) returns (authenticat
     authentication_key := SelectField(_struct, LibraAccount_T_authentication_key);
     assume is#ByteArray(authentication_key);
     balance := SelectField(_struct, LibraAccount_T_balance);
-    assume is#Vector(balance);
+    assume $LibraCoin_T_is_well_formed(balance);
     delegated_key_rotation_capability := SelectField(_struct, LibraAccount_T_delegated_key_rotation_capability);
     assume is#Boolean(delegated_key_rotation_capability);
     delegated_withdrawal_capability := SelectField(_struct, LibraAccount_T_delegated_withdrawal_capability);
     assume is#Boolean(delegated_withdrawal_capability);
     received_events := SelectField(_struct, LibraAccount_T_received_events);
-    assume is#Vector(received_events);
+    assume $LibraAccount_EventHandle_is_well_formed(received_events);
     sent_events := SelectField(_struct, LibraAccount_T_sent_events);
-    assume is#Vector(sent_events);
+    assume $LibraAccount_EventHandle_is_well_formed(sent_events);
     sequence_number := SelectField(_struct, LibraAccount_T_sequence_number);
     assume IsValidU64(sequence_number);
     event_generator := SelectField(_struct, LibraAccount_T_event_generator);
-    assume is#Vector(event_generator);
+    assume $LibraAccount_EventHandleGenerator_is_well_formed(event_generator);
 }
 
 const unique LibraAccount_WithdrawalCapability: TypeName;
@@ -2797,10 +2915,16 @@ axiom LibraAccount_WithdrawalCapability_account_address == 0;
 function LibraAccount_WithdrawalCapability_type_value(): TypeValue {
     StructType(LibraAccount_WithdrawalCapability, ExtendTypeValueArray(EmptyTypeValueArray, AddressType()))
 }
-procedure {:inline 1} Pack_LibraAccount_WithdrawalCapability(account_address: Value) returns (_struct: Value)
+function {:inline 1} $LibraAccount_WithdrawalCapability_is_well_formed(__this: Value): bool {
+    is#Vector(__this)
+        && is#Address(SelectField(__this, LibraAccount_WithdrawalCapability_account_address))
+}
+
+procedure {:inline 1} Pack_LibraAccount_WithdrawalCapability(module_idx: int, func_idx: int, var_idx: int, code_idx: int, account_address: Value) returns (_struct: Value)
 {
     assume is#Address(account_address);
     _struct := Vector(ExtendValueArray(EmptyValueArray, account_address));
+    if (code_idx > 0) { assume $DebugTrackLocal(module_idx, func_idx, var_idx, code_idx, _struct); }
 }
 
 procedure {:inline 1} Unpack_LibraAccount_WithdrawalCapability(_struct: Value) returns (account_address: Value)
@@ -2816,10 +2940,16 @@ axiom LibraAccount_KeyRotationCapability_account_address == 0;
 function LibraAccount_KeyRotationCapability_type_value(): TypeValue {
     StructType(LibraAccount_KeyRotationCapability, ExtendTypeValueArray(EmptyTypeValueArray, AddressType()))
 }
-procedure {:inline 1} Pack_LibraAccount_KeyRotationCapability(account_address: Value) returns (_struct: Value)
+function {:inline 1} $LibraAccount_KeyRotationCapability_is_well_formed(__this: Value): bool {
+    is#Vector(__this)
+        && is#Address(SelectField(__this, LibraAccount_KeyRotationCapability_account_address))
+}
+
+procedure {:inline 1} Pack_LibraAccount_KeyRotationCapability(module_idx: int, func_idx: int, var_idx: int, code_idx: int, account_address: Value) returns (_struct: Value)
 {
     assume is#Address(account_address);
     _struct := Vector(ExtendValueArray(EmptyValueArray, account_address));
+    if (code_idx > 0) { assume $DebugTrackLocal(module_idx, func_idx, var_idx, code_idx, _struct); }
 }
 
 procedure {:inline 1} Unpack_LibraAccount_KeyRotationCapability(_struct: Value) returns (account_address: Value)
@@ -2839,12 +2969,20 @@ axiom LibraAccount_SentPaymentEvent_metadata == 2;
 function LibraAccount_SentPaymentEvent_type_value(): TypeValue {
     StructType(LibraAccount_SentPaymentEvent, ExtendTypeValueArray(ExtendTypeValueArray(ExtendTypeValueArray(EmptyTypeValueArray, IntegerType()), AddressType()), ByteArrayType()))
 }
-procedure {:inline 1} Pack_LibraAccount_SentPaymentEvent(amount: Value, payee: Value, metadata: Value) returns (_struct: Value)
+function {:inline 1} $LibraAccount_SentPaymentEvent_is_well_formed(__this: Value): bool {
+    is#Vector(__this)
+        && IsValidU64(SelectField(__this, LibraAccount_SentPaymentEvent_amount))
+        && is#Address(SelectField(__this, LibraAccount_SentPaymentEvent_payee))
+        && is#ByteArray(SelectField(__this, LibraAccount_SentPaymentEvent_metadata))
+}
+
+procedure {:inline 1} Pack_LibraAccount_SentPaymentEvent(module_idx: int, func_idx: int, var_idx: int, code_idx: int, amount: Value, payee: Value, metadata: Value) returns (_struct: Value)
 {
     assume IsValidU64(amount);
     assume is#Address(payee);
     assume is#ByteArray(metadata);
     _struct := Vector(ExtendValueArray(ExtendValueArray(ExtendValueArray(EmptyValueArray, amount), payee), metadata));
+    if (code_idx > 0) { assume $DebugTrackLocal(module_idx, func_idx, var_idx, code_idx, _struct); }
 }
 
 procedure {:inline 1} Unpack_LibraAccount_SentPaymentEvent(_struct: Value) returns (amount: Value, payee: Value, metadata: Value)
@@ -2868,12 +3006,20 @@ axiom LibraAccount_ReceivedPaymentEvent_metadata == 2;
 function LibraAccount_ReceivedPaymentEvent_type_value(): TypeValue {
     StructType(LibraAccount_ReceivedPaymentEvent, ExtendTypeValueArray(ExtendTypeValueArray(ExtendTypeValueArray(EmptyTypeValueArray, IntegerType()), AddressType()), ByteArrayType()))
 }
-procedure {:inline 1} Pack_LibraAccount_ReceivedPaymentEvent(amount: Value, payer: Value, metadata: Value) returns (_struct: Value)
+function {:inline 1} $LibraAccount_ReceivedPaymentEvent_is_well_formed(__this: Value): bool {
+    is#Vector(__this)
+        && IsValidU64(SelectField(__this, LibraAccount_ReceivedPaymentEvent_amount))
+        && is#Address(SelectField(__this, LibraAccount_ReceivedPaymentEvent_payer))
+        && is#ByteArray(SelectField(__this, LibraAccount_ReceivedPaymentEvent_metadata))
+}
+
+procedure {:inline 1} Pack_LibraAccount_ReceivedPaymentEvent(module_idx: int, func_idx: int, var_idx: int, code_idx: int, amount: Value, payer: Value, metadata: Value) returns (_struct: Value)
 {
     assume IsValidU64(amount);
     assume is#Address(payer);
     assume is#ByteArray(metadata);
     _struct := Vector(ExtendValueArray(ExtendValueArray(ExtendValueArray(EmptyValueArray, amount), payer), metadata));
+    if (code_idx > 0) { assume $DebugTrackLocal(module_idx, func_idx, var_idx, code_idx, _struct); }
 }
 
 procedure {:inline 1} Unpack_LibraAccount_ReceivedPaymentEvent(_struct: Value) returns (amount: Value, payer: Value, metadata: Value)
@@ -2893,10 +3039,16 @@ axiom LibraAccount_EventHandleGenerator_counter == 0;
 function LibraAccount_EventHandleGenerator_type_value(): TypeValue {
     StructType(LibraAccount_EventHandleGenerator, ExtendTypeValueArray(EmptyTypeValueArray, IntegerType()))
 }
-procedure {:inline 1} Pack_LibraAccount_EventHandleGenerator(counter: Value) returns (_struct: Value)
+function {:inline 1} $LibraAccount_EventHandleGenerator_is_well_formed(__this: Value): bool {
+    is#Vector(__this)
+        && IsValidU64(SelectField(__this, LibraAccount_EventHandleGenerator_counter))
+}
+
+procedure {:inline 1} Pack_LibraAccount_EventHandleGenerator(module_idx: int, func_idx: int, var_idx: int, code_idx: int, counter: Value) returns (_struct: Value)
 {
     assume IsValidU64(counter);
     _struct := Vector(ExtendValueArray(EmptyValueArray, counter));
+    if (code_idx > 0) { assume $DebugTrackLocal(module_idx, func_idx, var_idx, code_idx, _struct); }
 }
 
 procedure {:inline 1} Unpack_LibraAccount_EventHandleGenerator(_struct: Value) returns (counter: Value)
@@ -2914,11 +3066,18 @@ axiom LibraAccount_EventHandle_guid == 1;
 function LibraAccount_EventHandle_type_value(tv0: TypeValue): TypeValue {
     StructType(LibraAccount_EventHandle, ExtendTypeValueArray(ExtendTypeValueArray(EmptyTypeValueArray, IntegerType()), ByteArrayType()))
 }
-procedure {:inline 1} Pack_LibraAccount_EventHandle(tv0: TypeValue, counter: Value, guid: Value) returns (_struct: Value)
+function {:inline 1} $LibraAccount_EventHandle_is_well_formed(__this: Value): bool {
+    is#Vector(__this)
+        && IsValidU64(SelectField(__this, LibraAccount_EventHandle_counter))
+        && is#ByteArray(SelectField(__this, LibraAccount_EventHandle_guid))
+}
+
+procedure {:inline 1} Pack_LibraAccount_EventHandle(module_idx: int, func_idx: int, var_idx: int, code_idx: int, tv0: TypeValue, counter: Value, guid: Value) returns (_struct: Value)
 {
     assume IsValidU64(counter);
     assume is#ByteArray(guid);
     _struct := Vector(ExtendValueArray(ExtendValueArray(EmptyValueArray, counter), guid));
+    if (code_idx > 0) { assume $DebugTrackLocal(module_idx, func_idx, var_idx, code_idx, _struct); }
 }
 
 procedure {:inline 1} Unpack_LibraAccount_EventHandle(_struct: Value) returns (counter: Value, guid: Value)
@@ -2954,7 +3113,7 @@ requires ExistsTxnSenderAccount(__m, __txn);
     assume is#Address(payee);
     __m := UpdateLocal(__m, __frame + 0, payee);
     assume $DebugTrackLocal(11, 0, 0, 3305, payee);
-    assume is#Vector(to_deposit);
+    assume $LibraCoin_T_is_well_formed(to_deposit);
     __m := UpdateLocal(__m, __frame + 1, to_deposit);
     assume $DebugTrackLocal(11, 0, 1, 3305, to_deposit);
 
@@ -3010,7 +3169,7 @@ requires ExistsTxnSenderAccount(__m, __txn);
     assume is#Address(payee);
     __m := UpdateLocal(__m, __frame + 0, payee);
     assume $DebugTrackLocal(11, 1, 0, 3567, payee);
-    assume is#Vector(to_deposit);
+    assume $LibraCoin_T_is_well_formed(to_deposit);
     __m := UpdateLocal(__m, __frame + 1, to_deposit);
     assume $DebugTrackLocal(11, 1, 1, 3567, to_deposit);
     assume is#ByteArray(metadata);
@@ -3101,7 +3260,7 @@ requires ExistsTxnSenderAccount(__m, __txn);
     assume is#Address(sender);
     __m := UpdateLocal(__m, __frame + 1, sender);
     assume $DebugTrackLocal(11, 2, 1, 4018, sender);
-    assume is#Vector(to_deposit);
+    assume $LibraCoin_T_is_well_formed(to_deposit);
     __m := UpdateLocal(__m, __frame + 2, to_deposit);
     assume $DebugTrackLocal(11, 2, 2, 4018, to_deposit);
     assume is#ByteArray(metadata);
@@ -3112,7 +3271,7 @@ requires ExistsTxnSenderAccount(__m, __txn);
     __local_counter := __local_counter + 33;
 
     // bytecode translation starts here
-    call __t7 := BorrowLoc(__frame + 2);
+    call __t7 := BorrowLoc(__frame + 2, LibraCoin_T_type_value());
 
     call __t8 := LibraCoin_value(__t7);
     if (__abort_flag) {
@@ -3158,7 +3317,7 @@ Label_10:
     }
 
     call sender_account_ref := CopyOrMoveRef(__t15);
-    assume is#Vector(Dereference(__m, sender_account_ref));
+    assume $LibraAccount_T_is_well_formed(Dereference(__m, sender_account_ref));
     assume $DebugTrackLocal(11, 2, 6, 4503, Dereference(__m, sender_account_ref));
 
     call __t16 := CopyOrMoveRef(sender_account_ref);
@@ -3174,7 +3333,7 @@ Label_10:
     call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 3));
     __m := UpdateLocal(__m, __frame + 20, __tmp);
 
-    call __tmp := Pack_LibraAccount_SentPaymentEvent(GetLocal(__m, __frame + 18), GetLocal(__m, __frame + 19), GetLocal(__m, __frame + 20));
+    call __tmp := Pack_LibraAccount_SentPaymentEvent(0, 0, 0, 0, GetLocal(__m, __frame + 18), GetLocal(__m, __frame + 19), GetLocal(__m, __frame + 20));
     __m := UpdateLocal(__m, __frame + 21, __tmp);
 
     call LibraAccount_emit_event(LibraAccount_SentPaymentEvent_type_value(), __t17, GetLocal(__m, __frame + 21));
@@ -3193,7 +3352,7 @@ Label_10:
     }
 
     call payee_account_ref := CopyOrMoveRef(__t23);
-    assume is#Vector(Dereference(__m, payee_account_ref));
+    assume $LibraAccount_T_is_well_formed(Dereference(__m, payee_account_ref));
     assume $DebugTrackLocal(11, 2, 5, 4915, Dereference(__m, payee_account_ref));
 
     call __t24 := CopyOrMoveRef(payee_account_ref);
@@ -3222,7 +3381,7 @@ Label_10:
     call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 3));
     __m := UpdateLocal(__m, __frame + 31, __tmp);
 
-    call __tmp := Pack_LibraAccount_ReceivedPaymentEvent(GetLocal(__m, __frame + 29), GetLocal(__m, __frame + 30), GetLocal(__m, __frame + 31));
+    call __tmp := Pack_LibraAccount_ReceivedPaymentEvent(0, 0, 0, 0, GetLocal(__m, __frame + 29), GetLocal(__m, __frame + 30), GetLocal(__m, __frame + 31));
     __m := UpdateLocal(__m, __frame + 32, __tmp);
 
     call LibraAccount_emit_event(LibraAccount_ReceivedPaymentEvent_type_value(), __t28, GetLocal(__m, __frame + 32));
@@ -3309,7 +3468,7 @@ Label_6:
       assume $DebugTrackAbort(11, 3, 6058);
       goto Label_Abort;
     }
-    assume is#Vector(__t8);
+    assume $LibraCoin_T_is_well_formed(__t8);
 
     __m := UpdateLocal(__m, __frame + 8, __t8);
 
@@ -3352,9 +3511,8 @@ requires ExistsTxnSenderAccount(__m, __txn);
     __frame := __local_counter;
 
     // process and type check arguments
-    assume is#Vector(Dereference(__m, account));
-    assume IsValidReferenceParameter(__m, __local_counter, account);
-    assume is#Vector(Dereference(__m, account));
+    assume $LibraAccount_T_is_well_formed(Dereference(__m, account)) && IsValidReferenceParameter(__m, __local_counter, account);
+    assume $LibraAccount_T_is_well_formed(Dereference(__m, account));
     assume $DebugTrackLocal(11, 4, 0, 6237, Dereference(__m, account));
     assume IsValidU64(amount);
     __m := UpdateLocal(__m, __frame + 1, amount);
@@ -3376,9 +3534,11 @@ requires ExistsTxnSenderAccount(__m, __txn);
       assume $DebugTrackAbort(11, 4, 6370);
       goto Label_Abort;
     }
-    assume is#Vector(__t6);
+    assume $LibraCoin_T_is_well_formed(__t6);
 
     __m := UpdateLocal(__m, __frame + 6, __t6);
+    assume $LibraAccount_T_is_well_formed(Dereference(__m, account));
+    assume $DebugTrackLocal(11, 4, 0, 6370, Dereference(__m, account));
 
     call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 6));
     __m := UpdateLocal(__m, __frame + 2, __tmp);
@@ -3445,7 +3605,7 @@ requires ExistsTxnSenderAccount(__m, __txn);
     }
 
     call sender_account := CopyOrMoveRef(__t3);
-    assume is#Vector(Dereference(__m, sender_account));
+    assume $LibraAccount_T_is_well_formed(Dereference(__m, sender_account));
     assume $DebugTrackLocal(11, 5, 1, 6669, Dereference(__m, sender_account));
 
     call __t4 := CopyOrMoveRef(sender_account);
@@ -3475,7 +3635,7 @@ Label_9:
       assume $DebugTrackAbort(11, 5, 7031);
       goto Label_Abort;
     }
-    assume is#Vector(__t10);
+    assume $LibraCoin_T_is_well_formed(__t10);
 
     __m := UpdateLocal(__m, __frame + 10, __t10);
 
@@ -3517,9 +3677,8 @@ requires ExistsTxnSenderAccount(__m, __txn);
     __frame := __local_counter;
 
     // process and type check arguments
-    assume is#Vector(Dereference(__m, cap));
-    assume IsValidReferenceParameter(__m, __local_counter, cap);
-    assume is#Vector(Dereference(__m, cap));
+    assume $LibraAccount_WithdrawalCapability_is_well_formed(Dereference(__m, cap)) && IsValidReferenceParameter(__m, __local_counter, cap);
+    assume $LibraAccount_WithdrawalCapability_is_well_formed(Dereference(__m, cap));
     assume $DebugTrackLocal(11, 6, 0, 7192, Dereference(__m, cap));
     assume IsValidU64(amount);
     __m := UpdateLocal(__m, __frame + 1, amount);
@@ -3544,7 +3703,7 @@ requires ExistsTxnSenderAccount(__m, __txn);
     }
 
     call account := CopyOrMoveRef(__t6);
-    assume is#Vector(Dereference(__m, account));
+    assume $LibraAccount_T_is_well_formed(Dereference(__m, account));
     assume $DebugTrackLocal(11, 6, 2, 7354, Dereference(__m, account));
 
     call __t7 := CopyOrMoveRef(account);
@@ -3557,7 +3716,7 @@ requires ExistsTxnSenderAccount(__m, __txn);
       assume $DebugTrackAbort(11, 6, 7430);
       goto Label_Abort;
     }
-    assume is#Vector(__t9);
+    assume $LibraCoin_T_is_well_formed(__t9);
 
     __m := UpdateLocal(__m, __frame + 9, __t9);
 
@@ -3628,7 +3787,7 @@ requires ExistsTxnSenderAccount(__m, __txn);
     }
 
     call sender_account := CopyOrMoveRef(__t5);
-    assume is#Vector(Dereference(__m, sender_account));
+    assume $LibraAccount_T_is_well_formed(Dereference(__m, sender_account));
     assume $DebugTrackLocal(11, 7, 1, 7837, Dereference(__m, sender_account));
 
     call __t6 := CopyOrMoveRef(sender_account);
@@ -3661,10 +3820,11 @@ Label_13:
 
     call WriteRef(__t12, GetLocal(__m, __frame + 11));
 
+
     call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 0));
     __m := UpdateLocal(__m, __frame + 13, __tmp);
 
-    call __tmp := Pack_LibraAccount_WithdrawalCapability(GetLocal(__m, __frame + 13));
+    call __tmp := Pack_LibraAccount_WithdrawalCapability(0, 0, 0, 0, GetLocal(__m, __frame + 13));
     __m := UpdateLocal(__m, __frame + 14, __tmp);
 
     __ret0 := GetLocal(__m, __frame + 14);
@@ -3706,7 +3866,7 @@ requires ExistsTxnSenderAccount(__m, __txn);
     __frame := __local_counter;
 
     // process and type check arguments
-    assume is#Vector(cap);
+    assume $LibraAccount_WithdrawalCapability_is_well_formed(cap);
     __m := UpdateLocal(__m, __frame + 0, cap);
     assume $DebugTrackLocal(11, 8, 0, 8391, cap);
 
@@ -3734,7 +3894,7 @@ requires ExistsTxnSenderAccount(__m, __txn);
     }
 
     call account := CopyOrMoveRef(__t6);
-    assume is#Vector(Dereference(__m, account));
+    assume $LibraAccount_T_is_well_formed(Dereference(__m, account));
     assume $DebugTrackLocal(11, 8, 2, 8650, Dereference(__m, account));
 
     call __tmp := LdFalse();
@@ -3745,6 +3905,7 @@ requires ExistsTxnSenderAccount(__m, __txn);
     call __t9 := BorrowField(__t8, LibraAccount_T_delegated_withdrawal_capability);
 
     call WriteRef(__t9, GetLocal(__m, __frame + 7));
+
 
     return;
 
@@ -3788,9 +3949,8 @@ requires ExistsTxnSenderAccount(__m, __txn);
     assume is#Address(payee);
     __m := UpdateLocal(__m, __frame + 0, payee);
     assume $DebugTrackLocal(11, 9, 0, 9236, payee);
-    assume is#Vector(Dereference(__m, cap));
-    assume IsValidReferenceParameter(__m, __local_counter, cap);
-    assume is#Vector(Dereference(__m, cap));
+    assume $LibraAccount_WithdrawalCapability_is_well_formed(Dereference(__m, cap)) && IsValidReferenceParameter(__m, __local_counter, cap);
+    assume $LibraAccount_WithdrawalCapability_is_well_formed(Dereference(__m, cap));
     assume $DebugTrackLocal(11, 9, 1, 9236, Dereference(__m, cap));
     assume IsValidU64(amount);
     __m := UpdateLocal(__m, __frame + 2, amount);
@@ -3846,7 +4006,7 @@ Label_6:
       assume $DebugTrackAbort(11, 9, 9617);
       goto Label_Abort;
     }
-    assume is#Vector(__t14);
+    assume $LibraCoin_T_is_well_formed(__t14);
 
     __m := UpdateLocal(__m, __frame + 14, __t14);
 
@@ -3941,7 +4101,7 @@ Label_6:
       assume $DebugTrackAbort(11, 10, 10245);
       goto Label_Abort;
     }
-    assume is#Vector(__t9);
+    assume $LibraCoin_T_is_well_formed(__t9);
 
     __m := UpdateLocal(__m, __frame + 9, __t9);
 
@@ -4039,9 +4199,8 @@ requires ExistsTxnSenderAccount(__m, __txn);
     __frame := __local_counter;
 
     // process and type check arguments
-    assume is#Vector(Dereference(__m, account));
-    assume IsValidReferenceParameter(__m, __local_counter, account);
-    assume is#Vector(Dereference(__m, account));
+    assume $LibraAccount_T_is_well_formed(Dereference(__m, account)) && IsValidReferenceParameter(__m, __local_counter, account);
+    assume $LibraAccount_T_is_well_formed(Dereference(__m, account));
     assume $DebugTrackLocal(11, 12, 0, 10698, Dereference(__m, account));
     assume is#ByteArray(new_authentication_key);
     __m := UpdateLocal(__m, __frame + 1, new_authentication_key);
@@ -4059,6 +4218,8 @@ requires ExistsTxnSenderAccount(__m, __txn);
     call __t4 := BorrowField(__t3, LibraAccount_T_authentication_key);
 
     call WriteRef(__t4, GetLocal(__m, __frame + 2));
+    assume $LibraAccount_T_is_well_formed(Dereference(__m, account));
+    assume $DebugTrackLocal(11, 12, 0, 10803, Dereference(__m, account));
 
     return;
 
@@ -4114,7 +4275,7 @@ requires ExistsTxnSenderAccount(__m, __txn);
     }
 
     call sender_account := CopyOrMoveRef(__t3);
-    assume is#Vector(Dereference(__m, sender_account));
+    assume $LibraAccount_T_is_well_formed(Dereference(__m, sender_account));
     assume $DebugTrackLocal(11, 13, 1, 11156, Dereference(__m, sender_account));
 
     call __t4 := CopyOrMoveRef(sender_account);
@@ -4177,9 +4338,8 @@ requires ExistsTxnSenderAccount(__m, __txn);
     __frame := __local_counter;
 
     // process and type check arguments
-    assume is#Vector(Dereference(__m, cap));
-    assume IsValidReferenceParameter(__m, __local_counter, cap);
-    assume is#Vector(Dereference(__m, cap));
+    assume $LibraAccount_KeyRotationCapability_is_well_formed(Dereference(__m, cap)) && IsValidReferenceParameter(__m, __local_counter, cap);
+    assume $LibraAccount_KeyRotationCapability_is_well_formed(Dereference(__m, cap));
     assume $DebugTrackLocal(11, 14, 0, 11765, Dereference(__m, cap));
     assume is#ByteArray(new_authentication_key);
     __m := UpdateLocal(__m, __frame + 1, new_authentication_key);
@@ -4301,10 +4461,11 @@ Label_11:
 
     call WriteRef(__t10, GetLocal(__m, __frame + 9));
 
+
     call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 0));
     __m := UpdateLocal(__m, __frame + 11, __tmp);
 
-    call __tmp := Pack_LibraAccount_KeyRotationCapability(GetLocal(__m, __frame + 11));
+    call __tmp := Pack_LibraAccount_KeyRotationCapability(0, 0, 0, 0, GetLocal(__m, __frame + 11));
     __m := UpdateLocal(__m, __frame + 12, __tmp);
 
     __ret0 := GetLocal(__m, __frame + 12);
@@ -4346,7 +4507,7 @@ requires ExistsTxnSenderAccount(__m, __txn);
     __frame := __local_counter;
 
     // process and type check arguments
-    assume is#Vector(cap);
+    assume $LibraAccount_KeyRotationCapability_is_well_formed(cap);
     __m := UpdateLocal(__m, __frame + 0, cap);
     assume $DebugTrackLocal(11, 16, 0, 12924, cap);
 
@@ -4374,7 +4535,7 @@ requires ExistsTxnSenderAccount(__m, __txn);
     }
 
     call account := CopyOrMoveRef(__t6);
-    assume is#Vector(Dereference(__m, account));
+    assume $LibraAccount_T_is_well_formed(Dereference(__m, account));
     assume $DebugTrackLocal(11, 16, 2, 13187, Dereference(__m, account));
 
     call __tmp := LdFalse();
@@ -4385,6 +4546,7 @@ requires ExistsTxnSenderAccount(__m, __txn);
     call __t9 := BorrowField(__t8, LibraAccount_T_delegated_key_rotation_capability);
 
     call WriteRef(__t9, GetLocal(__m, __frame + 7));
+
 
     return;
 
@@ -4442,7 +4604,7 @@ requires ExistsTxnSenderAccount(__m, __txn);
     call __tmp := LdConst(0);
     __m := UpdateLocal(__m, __frame + 2, __tmp);
 
-    call __tmp := Pack_LibraAccount_EventHandleGenerator(GetLocal(__m, __frame + 2));
+    call __tmp := Pack_LibraAccount_EventHandleGenerator(11, 17, 1, 13880, GetLocal(__m, __frame + 2));
     __m := UpdateLocal(__m, __frame + 3, __tmp);
 
     call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 3));
@@ -4469,7 +4631,7 @@ requires ExistsTxnSenderAccount(__m, __txn);
       assume $DebugTrackAbort(11, 17, 14103);
       goto Label_Abort;
     }
-    assume is#Vector(__t7);
+    assume $LibraCoin_T_is_well_formed(__t7);
 
     __m := UpdateLocal(__m, __frame + 7, __t7);
 
@@ -4479,7 +4641,7 @@ requires ExistsTxnSenderAccount(__m, __txn);
     call __tmp := LdFalse();
     __m := UpdateLocal(__m, __frame + 9, __tmp);
 
-    call __t10 := BorrowLoc(__frame + 1);
+    call __t10 := BorrowLoc(__frame + 1, LibraAccount_EventHandleGenerator_type_value());
 
     call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 0));
     __m := UpdateLocal(__m, __frame + 11, __tmp);
@@ -4489,12 +4651,12 @@ requires ExistsTxnSenderAccount(__m, __txn);
       assume $DebugTrackAbort(11, 17, 14268);
       goto Label_Abort;
     }
-    assume is#Vector(__t12);
+    assume $LibraAccount_EventHandle_is_well_formed(__t12);
 
     __m := UpdateLocal(__m, __frame + 12, __t12);
     assume $DebugTrackLocal(11, 17, 1, 14268, GetLocal(__m, __frame + 1));
 
-    call __t13 := BorrowLoc(__frame + 1);
+    call __t13 := BorrowLoc(__frame + 1, LibraAccount_EventHandleGenerator_type_value());
 
     call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 0));
     __m := UpdateLocal(__m, __frame + 14, __tmp);
@@ -4504,7 +4666,7 @@ requires ExistsTxnSenderAccount(__m, __txn);
       assume $DebugTrackAbort(11, 17, 14389);
       goto Label_Abort;
     }
-    assume is#Vector(__t15);
+    assume $LibraAccount_EventHandle_is_well_formed(__t15);
 
     __m := UpdateLocal(__m, __frame + 15, __t15);
     assume $DebugTrackLocal(11, 17, 1, 14389, GetLocal(__m, __frame + 1));
@@ -4515,7 +4677,7 @@ requires ExistsTxnSenderAccount(__m, __txn);
     call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 1));
     __m := UpdateLocal(__m, __frame + 17, __tmp);
 
-    call __tmp := Pack_LibraAccount_T(GetLocal(__m, __frame + 6), GetLocal(__m, __frame + 7), GetLocal(__m, __frame + 8), GetLocal(__m, __frame + 9), GetLocal(__m, __frame + 12), GetLocal(__m, __frame + 15), GetLocal(__m, __frame + 16), GetLocal(__m, __frame + 17));
+    call __tmp := Pack_LibraAccount_T(0, 0, 0, 0, GetLocal(__m, __frame + 6), GetLocal(__m, __frame + 7), GetLocal(__m, __frame + 8), GetLocal(__m, __frame + 9), GetLocal(__m, __frame + 12), GetLocal(__m, __frame + 15), GetLocal(__m, __frame + 16), GetLocal(__m, __frame + 17));
     __m := UpdateLocal(__m, __frame + 18, __tmp);
 
     call LibraAccount_save_account(GetLocal(__m, __frame + 4), GetLocal(__m, __frame + 18));
@@ -4637,9 +4799,8 @@ requires ExistsTxnSenderAccount(__m, __txn);
     __frame := __local_counter;
 
     // process and type check arguments
-    assume is#Vector(Dereference(__m, account));
-    assume IsValidReferenceParameter(__m, __local_counter, account);
-    assume is#Vector(Dereference(__m, account));
+    assume $LibraAccount_T_is_well_formed(Dereference(__m, account)) && IsValidReferenceParameter(__m, __local_counter, account);
+    assume $LibraAccount_T_is_well_formed(Dereference(__m, account));
     assume $DebugTrackLocal(11, 20, 0, 15265, Dereference(__m, account));
 
     // increase the local counter
@@ -4758,9 +4919,8 @@ requires ExistsTxnSenderAccount(__m, __txn);
     __frame := __local_counter;
 
     // process and type check arguments
-    assume is#Vector(Dereference(__m, account));
-    assume IsValidReferenceParameter(__m, __local_counter, account);
-    assume is#Vector(Dereference(__m, account));
+    assume $LibraAccount_T_is_well_formed(Dereference(__m, account)) && IsValidReferenceParameter(__m, __local_counter, account);
+    assume $LibraAccount_T_is_well_formed(Dereference(__m, account));
     assume $DebugTrackLocal(11, 22, 0, 15735, Dereference(__m, account));
 
     // increase the local counter
@@ -4980,9 +5140,8 @@ requires ExistsTxnSenderAccount(__m, __txn);
     __frame := __local_counter;
 
     // process and type check arguments
-    assume is#Vector(Dereference(__m, cap));
-    assume IsValidReferenceParameter(__m, __local_counter, cap);
-    assume is#Vector(Dereference(__m, cap));
+    assume $LibraAccount_WithdrawalCapability_is_well_formed(Dereference(__m, cap)) && IsValidReferenceParameter(__m, __local_counter, cap);
+    assume $LibraAccount_WithdrawalCapability_is_well_formed(Dereference(__m, cap));
     assume $DebugTrackLocal(11, 26, 0, 16640, Dereference(__m, cap));
 
     // increase the local counter
@@ -5026,9 +5185,8 @@ requires ExistsTxnSenderAccount(__m, __txn);
     __frame := __local_counter;
 
     // process and type check arguments
-    assume is#Vector(Dereference(__m, cap));
-    assume IsValidReferenceParameter(__m, __local_counter, cap);
-    assume is#Vector(Dereference(__m, cap));
+    assume $LibraAccount_KeyRotationCapability_is_well_formed(Dereference(__m, cap)) && IsValidReferenceParameter(__m, __local_counter, cap);
+    assume $LibraAccount_KeyRotationCapability_is_well_formed(Dereference(__m, cap));
     assume $DebugTrackLocal(11, 27, 0, 16867, Dereference(__m, cap));
 
     // increase the local counter
@@ -5221,7 +5379,7 @@ Label_8:
     }
 
     call sender_account := CopyOrMoveRef(__t17);
-    assume is#Vector(Dereference(__m, sender_account));
+    assume $LibraAccount_T_is_well_formed(Dereference(__m, sender_account));
     assume $DebugTrackLocal(11, 29, 6, 18162, Dereference(__m, sender_account));
 
     call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 1));
@@ -5281,7 +5439,7 @@ Label_21:
     call __t30 := FreezeRef(__t29);
 
     call imm_sender_account := CopyOrMoveRef(__t30);
-    assume is#Vector(Dereference(__m, imm_sender_account));
+    assume $LibraAccount_T_is_well_formed(Dereference(__m, imm_sender_account));
     assume $DebugTrackLocal(11, 29, 7, 18617, Dereference(__m, imm_sender_account));
 
     call __t31 := CopyOrMoveRef(imm_sender_account);
@@ -5485,7 +5643,7 @@ requires ExistsTxnSenderAccount(__m, __txn);
     }
 
     call sender_account := CopyOrMoveRef(__t10);
-    assume is#Vector(Dereference(__m, sender_account));
+    assume $LibraAccount_T_is_well_formed(Dereference(__m, sender_account));
     assume $DebugTrackLocal(11, 30, 4, 19815, Dereference(__m, sender_account));
 
     call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 1));
@@ -5520,7 +5678,7 @@ requires ExistsTxnSenderAccount(__m, __txn);
     call __t17 := FreezeRef(__t16);
 
     call imm_sender_account := CopyOrMoveRef(__t17);
-    assume is#Vector(Dereference(__m, imm_sender_account));
+    assume $LibraAccount_T_is_well_formed(Dereference(__m, imm_sender_account));
     assume $DebugTrackLocal(11, 30, 6, 20029, Dereference(__m, imm_sender_account));
 
     call __t18 := CopyOrMoveRef(imm_sender_account);
@@ -5562,7 +5720,7 @@ Label_20:
       assume $DebugTrackAbort(11, 30, 20255);
       goto Label_Abort;
     }
-    assume is#Vector(__t26);
+    assume $LibraCoin_T_is_well_formed(__t26);
 
     __m := UpdateLocal(__m, __frame + 26, __t26);
 
@@ -5589,6 +5747,7 @@ Label_20:
 
     call WriteRef(__t31, GetLocal(__m, __frame + 29));
 
+
     call __tmp := LdAddr(4078);
     __m := UpdateLocal(__m, __frame + 32, __tmp);
 
@@ -5599,7 +5758,7 @@ Label_20:
     }
 
     call transaction_fee_account := CopyOrMoveRef(__t33);
-    assume is#Vector(Dereference(__m, transaction_fee_account));
+    assume $LibraAccount_T_is_well_formed(Dereference(__m, transaction_fee_account));
     assume $DebugTrackLocal(11, 30, 5, 20576, Dereference(__m, transaction_fee_account));
 
     call __t34 := CopyOrMoveRef(transaction_fee_account);
@@ -5662,9 +5821,8 @@ requires ExistsTxnSenderAccount(__m, __txn);
     __frame := __local_counter;
 
     // process and type check arguments
-    assume is#Vector(Dereference(__m, counter));
-    assume IsValidReferenceParameter(__m, __local_counter, counter);
-    assume is#Vector(Dereference(__m, counter));
+    assume $LibraAccount_EventHandleGenerator_is_well_formed(Dereference(__m, counter)) && IsValidReferenceParameter(__m, __local_counter, counter);
+    assume $LibraAccount_EventHandleGenerator_is_well_formed(Dereference(__m, counter));
     assume $DebugTrackLocal(11, 31, 0, 21344, Dereference(__m, counter));
     assume is#Address(sender);
     __m := UpdateLocal(__m, __frame + 1, sender);
@@ -5736,6 +5894,8 @@ requires ExistsTxnSenderAccount(__m, __txn);
     call __t17 := CopyOrMoveRef(count);
 
     call WriteRef(__t17, GetLocal(__m, __frame + 16));
+    assume $LibraAccount_EventHandleGenerator_is_well_formed(Dereference(__m, counter));
+    assume $DebugTrackLocal(11, 31, 0, 21740, Dereference(__m, counter));
 
     call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 3));
     __m := UpdateLocal(__m, __frame + 18, __tmp);
@@ -5794,9 +5954,8 @@ requires ExistsTxnSenderAccount(__m, __txn);
     __frame := __local_counter;
 
     // process and type check arguments
-    assume is#Vector(Dereference(__m, counter));
-    assume IsValidReferenceParameter(__m, __local_counter, counter);
-    assume is#Vector(Dereference(__m, counter));
+    assume $LibraAccount_EventHandleGenerator_is_well_formed(Dereference(__m, counter)) && IsValidReferenceParameter(__m, __local_counter, counter);
+    assume $LibraAccount_EventHandleGenerator_is_well_formed(Dereference(__m, counter));
     assume $DebugTrackLocal(11, 32, 0, 22101, Dereference(__m, counter));
     assume is#Address(sender);
     __m := UpdateLocal(__m, __frame + 1, sender);
@@ -5822,8 +5981,10 @@ requires ExistsTxnSenderAccount(__m, __txn);
     assume is#ByteArray(__t5);
 
     __m := UpdateLocal(__m, __frame + 5, __t5);
+    assume $LibraAccount_EventHandleGenerator_is_well_formed(Dereference(__m, counter));
+    assume $DebugTrackLocal(11, 32, 0, 22270, Dereference(__m, counter));
 
-    call __tmp := Pack_LibraAccount_EventHandle(tv0, GetLocal(__m, __frame + 2), GetLocal(__m, __frame + 5));
+    call __tmp := Pack_LibraAccount_EventHandle(0, 0, 0, 0, tv0, GetLocal(__m, __frame + 2), GetLocal(__m, __frame + 5));
     __m := UpdateLocal(__m, __frame + 6, __tmp);
 
     __ret0 := GetLocal(__m, __frame + 6);
@@ -5879,7 +6040,7 @@ requires ExistsTxnSenderAccount(__m, __txn);
     }
 
     call sender_account_ref := CopyOrMoveRef(__t3);
-    assume is#Vector(Dereference(__m, sender_account_ref));
+    assume $LibraAccount_T_is_well_formed(Dereference(__m, sender_account_ref));
     assume $DebugTrackLocal(11, 33, 0, 22601, Dereference(__m, sender_account_ref));
 
     call __t4 := CopyOrMoveRef(sender_account_ref);
@@ -5894,7 +6055,7 @@ requires ExistsTxnSenderAccount(__m, __txn);
       assume $DebugTrackAbort(11, 33, 22677);
       goto Label_Abort;
     }
-    assume is#Vector(__t7);
+    assume $LibraAccount_EventHandle_is_well_formed(__t7);
 
     __m := UpdateLocal(__m, __frame + 7, __t7);
 
@@ -5944,9 +6105,8 @@ requires ExistsTxnSenderAccount(__m, __txn);
     __frame := __local_counter;
 
     // process and type check arguments
-    assume is#Vector(Dereference(__m, handle_ref));
-    assume IsValidReferenceParameter(__m, __local_counter, handle_ref);
-    assume is#Vector(Dereference(__m, handle_ref));
+    assume $LibraAccount_EventHandle_is_well_formed(Dereference(__m, handle_ref)) && IsValidReferenceParameter(__m, __local_counter, handle_ref);
+    assume $LibraAccount_EventHandle_is_well_formed(Dereference(__m, handle_ref));
     assume $DebugTrackLocal(11, 34, 0, 22958, Dereference(__m, handle_ref));
     __m := UpdateLocal(__m, __frame + 1, msg);
     assume $DebugTrackLocal(11, 34, 1, 22958, msg);
@@ -6012,6 +6172,8 @@ requires ExistsTxnSenderAccount(__m, __txn);
     call __t17 := CopyOrMoveRef(count);
 
     call WriteRef(__t17, GetLocal(__m, __frame + 16));
+    assume $LibraAccount_EventHandle_is_well_formed(Dereference(__m, handle_ref));
+    assume $DebugTrackLocal(11, 34, 0, 23271, Dereference(__m, handle_ref));
 
     return;
 
@@ -6048,7 +6210,7 @@ requires ExistsTxnSenderAccount(__m, __txn);
     __frame := __local_counter;
 
     // process and type check arguments
-    assume is#Vector(handle);
+    assume $LibraAccount_EventHandle_is_well_formed(handle);
     __m := UpdateLocal(__m, __frame + 0, handle);
     assume $DebugTrackLocal(11, 36, 0, 23597, handle);
 
@@ -6083,6 +6245,10 @@ procedure LibraAccount_destroy_handle_verify (tv0: TypeValue, handle: Value) ret
     call InitVerification();
     call LibraAccount_destroy_handle(tv0, handle);
 }
+
+
+
+// ** synthetics of module TestLib
 
 
 

--- a/language/move-prover/bytecode-to-boogie/tests/goldenfiles/test-reference.bpl
+++ b/language/move-prover/bytecode-to-boogie/tests/goldenfiles/test-reference.bpl
@@ -1,5 +1,9 @@
 
 
+// ** synthetics of module TestReference
+
+
+
 // ** structs of module TestReference
 
 const unique TestReference_T: TypeName;
@@ -8,10 +12,16 @@ axiom TestReference_T_value == 0;
 function TestReference_T_type_value(): TypeValue {
     StructType(TestReference_T, ExtendTypeValueArray(EmptyTypeValueArray, IntegerType()))
 }
-procedure {:inline 1} Pack_TestReference_T(value: Value) returns (_struct: Value)
+function {:inline 1} $TestReference_T_is_well_formed(__this: Value): bool {
+    is#Vector(__this)
+        && IsValidU64(SelectField(__this, TestReference_T_value))
+}
+
+procedure {:inline 1} Pack_TestReference_T(module_idx: int, func_idx: int, var_idx: int, code_idx: int, value: Value) returns (_struct: Value)
 {
     assume IsValidU64(value);
     _struct := Vector(ExtendValueArray(EmptyValueArray, value));
+    if (code_idx > 0) { assume $DebugTrackLocal(module_idx, func_idx, var_idx, code_idx, _struct); }
 }
 
 procedure {:inline 1} Unpack_TestReference_T(_struct: Value) returns (value: Value)
@@ -41,8 +51,7 @@ requires ExistsTxnSenderAccount(__m, __txn);
     __frame := __local_counter;
 
     // process and type check arguments
-    assume IsValidU64(Dereference(__m, b));
-    assume IsValidReferenceParameter(__m, __local_counter, b);
+    assume IsValidU64(Dereference(__m, b)) && IsValidReferenceParameter(__m, __local_counter, b);
     assume IsValidU64(Dereference(__m, b));
     assume $DebugTrackLocal(0, 0, 0, 71, Dereference(__m, b));
 
@@ -56,6 +65,8 @@ requires ExistsTxnSenderAccount(__m, __txn);
     call __t2 := CopyOrMoveRef(b);
 
     call WriteRef(__t2, GetLocal(__m, __frame + 1));
+    assume IsValidU64(Dereference(__m, b));
+    assume $DebugTrackLocal(0, 0, 0, 106, Dereference(__m, b));
 
     return;
 
@@ -111,7 +122,7 @@ ensures old(b#Boolean(Boolean(false))) ==> __abort_flag;
     __m := UpdateLocal(__m, __frame + 0, __tmp);
     assume $DebugTrackLocal(0, 1, 0, 249, __tmp);
 
-    call __t3 := BorrowLoc(__frame + 0);
+    call __t3 := BorrowLoc(__frame + 0, IntegerType());
 
     call b_ref := CopyOrMoveRef(__t3);
     assume IsValidU64(Dereference(__m, b_ref));

--- a/language/move-prover/bytecode-to-boogie/tests/goldenfiles/test-specs-translate.bpl
+++ b/language/move-prover/bytecode-to-boogie/tests/goldenfiles/test-specs-translate.bpl
@@ -7,6 +7,10 @@ function {:inline} number_in_range(x: Value): Value {
 }
 
 
+// ** synthetics of module TestSpecs
+
+
+
 // ** structs of module TestSpecs
 
 const unique TestSpecs_S: TypeName;
@@ -15,10 +19,16 @@ axiom TestSpecs_S_a == 0;
 function TestSpecs_S_type_value(): TypeValue {
     StructType(TestSpecs_S, ExtendTypeValueArray(EmptyTypeValueArray, AddressType()))
 }
-procedure {:inline 1} Pack_TestSpecs_S(a: Value) returns (_struct: Value)
+function {:inline 1} $TestSpecs_S_is_well_formed(__this: Value): bool {
+    is#Vector(__this)
+        && is#Address(SelectField(__this, TestSpecs_S_a))
+}
+
+procedure {:inline 1} Pack_TestSpecs_S(module_idx: int, func_idx: int, var_idx: int, code_idx: int, a: Value) returns (_struct: Value)
 {
     assume is#Address(a);
     _struct := Vector(ExtendValueArray(EmptyValueArray, a));
+    if (code_idx > 0) { assume $DebugTrackLocal(module_idx, func_idx, var_idx, code_idx, _struct); }
 }
 
 procedure {:inline 1} Unpack_TestSpecs_S(_struct: Value) returns (a: Value)
@@ -36,11 +46,18 @@ axiom TestSpecs_R_s == 1;
 function TestSpecs_R_type_value(): TypeValue {
     StructType(TestSpecs_R, ExtendTypeValueArray(ExtendTypeValueArray(EmptyTypeValueArray, IntegerType()), TestSpecs_S_type_value()))
 }
-procedure {:inline 1} Pack_TestSpecs_R(x: Value, s: Value) returns (_struct: Value)
+function {:inline 1} $TestSpecs_R_is_well_formed(__this: Value): bool {
+    is#Vector(__this)
+        && IsValidU64(SelectField(__this, TestSpecs_R_x))
+        && $TestSpecs_S_is_well_formed(SelectField(__this, TestSpecs_R_s))
+}
+
+procedure {:inline 1} Pack_TestSpecs_R(module_idx: int, func_idx: int, var_idx: int, code_idx: int, x: Value, s: Value) returns (_struct: Value)
 {
     assume IsValidU64(x);
-    assume is#Vector(s);
+    assume $TestSpecs_S_is_well_formed(s);
     _struct := Vector(ExtendValueArray(ExtendValueArray(EmptyValueArray, x), s));
+    if (code_idx > 0) { assume $DebugTrackLocal(module_idx, func_idx, var_idx, code_idx, _struct); }
 }
 
 procedure {:inline 1} Unpack_TestSpecs_R(_struct: Value) returns (x: Value, s: Value)
@@ -49,7 +66,7 @@ procedure {:inline 1} Unpack_TestSpecs_R(_struct: Value) returns (x: Value, s: V
     x := SelectField(_struct, TestSpecs_R_x);
     assume IsValidU64(x);
     s := SelectField(_struct, TestSpecs_R_s);
-    assume is#Vector(s);
+    assume $TestSpecs_S_is_well_formed(s);
 }
 
 
@@ -212,7 +229,7 @@ requires ExistsTxnSenderAccount(__m, __txn);
     __frame := __local_counter;
 
     // process and type check arguments
-    assume is#Vector(r);
+    assume $TestSpecs_R_is_well_formed(r);
     __m := UpdateLocal(__m, __frame + 0, r);
     assume $DebugTrackLocal(0, 3, 0, 770, r);
 
@@ -255,7 +272,7 @@ requires ExistsTxnSenderAccount(__m, __txn);
     __frame := __local_counter;
 
     // process and type check arguments
-    assume is#Vector(r);
+    assume $TestSpecs_R_is_well_formed(r);
     __m := UpdateLocal(__m, __frame + 0, r);
     assume $DebugTrackLocal(0, 4, 0, 879, r);
 
@@ -298,7 +315,7 @@ requires ExistsTxnSenderAccount(__m, __txn);
     __frame := __local_counter;
 
     // process and type check arguments
-    assume is#Vector(r);
+    assume $TestSpecs_R_is_well_formed(r);
     __m := UpdateLocal(__m, __frame + 0, r);
     assume $DebugTrackLocal(0, 5, 0, 1000, r);
 
@@ -341,9 +358,8 @@ ensures b#Boolean(Boolean(IsEqual(SelectField(SelectField(Dereference(__m, r), T
     __frame := __local_counter;
 
     // process and type check arguments
-    assume is#Vector(Dereference(__m, r));
-    assume IsValidReferenceParameter(__m, __local_counter, r);
-    assume is#Vector(Dereference(__m, r));
+    assume $TestSpecs_R_is_well_formed(Dereference(__m, r)) && IsValidReferenceParameter(__m, __local_counter, r);
+    assume $TestSpecs_R_is_well_formed(Dereference(__m, r));
     assume $DebugTrackLocal(0, 6, 0, 1152, Dereference(__m, r));
 
     // increase the local counter

--- a/language/move-prover/bytecode-to-boogie/tests/goldenfiles/test-struct.bpl
+++ b/language/move-prover/bytecode-to-boogie/tests/goldenfiles/test-struct.bpl
@@ -1,5 +1,9 @@
 
 
+// ** synthetics of module TestStruct
+
+
+
 // ** structs of module TestStruct
 
 const unique TestStruct_B: TypeName;
@@ -10,11 +14,18 @@ axiom TestStruct_B_val == 1;
 function TestStruct_B_type_value(): TypeValue {
     StructType(TestStruct_B, ExtendTypeValueArray(ExtendTypeValueArray(EmptyTypeValueArray, AddressType()), IntegerType()))
 }
-procedure {:inline 1} Pack_TestStruct_B(addr: Value, val: Value) returns (_struct: Value)
+function {:inline 1} $TestStruct_B_is_well_formed(__this: Value): bool {
+    is#Vector(__this)
+        && is#Address(SelectField(__this, TestStruct_B_addr))
+        && IsValidU64(SelectField(__this, TestStruct_B_val))
+}
+
+procedure {:inline 1} Pack_TestStruct_B(module_idx: int, func_idx: int, var_idx: int, code_idx: int, addr: Value, val: Value) returns (_struct: Value)
 {
     assume is#Address(addr);
     assume IsValidU64(val);
     _struct := Vector(ExtendValueArray(ExtendValueArray(EmptyValueArray, addr), val));
+    if (code_idx > 0) { assume $DebugTrackLocal(module_idx, func_idx, var_idx, code_idx, _struct); }
 }
 
 procedure {:inline 1} Unpack_TestStruct_B(_struct: Value) returns (addr: Value, val: Value)
@@ -34,11 +45,18 @@ axiom TestStruct_A_b == 1;
 function TestStruct_A_type_value(): TypeValue {
     StructType(TestStruct_A, ExtendTypeValueArray(ExtendTypeValueArray(EmptyTypeValueArray, IntegerType()), TestStruct_B_type_value()))
 }
-procedure {:inline 1} Pack_TestStruct_A(val: Value, b: Value) returns (_struct: Value)
+function {:inline 1} $TestStruct_A_is_well_formed(__this: Value): bool {
+    is#Vector(__this)
+        && IsValidU64(SelectField(__this, TestStruct_A_val))
+        && $TestStruct_B_is_well_formed(SelectField(__this, TestStruct_A_b))
+}
+
+procedure {:inline 1} Pack_TestStruct_A(module_idx: int, func_idx: int, var_idx: int, code_idx: int, val: Value, b: Value) returns (_struct: Value)
 {
     assume IsValidU64(val);
-    assume is#Vector(b);
+    assume $TestStruct_B_is_well_formed(b);
     _struct := Vector(ExtendValueArray(ExtendValueArray(EmptyValueArray, val), b));
+    if (code_idx > 0) { assume $DebugTrackLocal(module_idx, func_idx, var_idx, code_idx, _struct); }
 }
 
 procedure {:inline 1} Unpack_TestStruct_A(_struct: Value) returns (val: Value, b: Value)
@@ -47,7 +65,7 @@ procedure {:inline 1} Unpack_TestStruct_A(_struct: Value) returns (val: Value, b
     val := SelectField(_struct, TestStruct_A_val);
     assume IsValidU64(val);
     b := SelectField(_struct, TestStruct_A_b);
-    assume is#Vector(b);
+    assume $TestStruct_B_is_well_formed(b);
 }
 
 const unique TestStruct_C: TypeName;
@@ -58,11 +76,18 @@ axiom TestStruct_C_b == 1;
 function TestStruct_C_type_value(): TypeValue {
     StructType(TestStruct_C, ExtendTypeValueArray(ExtendTypeValueArray(EmptyTypeValueArray, IntegerType()), TestStruct_A_type_value()))
 }
-procedure {:inline 1} Pack_TestStruct_C(val: Value, b: Value) returns (_struct: Value)
+function {:inline 1} $TestStruct_C_is_well_formed(__this: Value): bool {
+    is#Vector(__this)
+        && IsValidU64(SelectField(__this, TestStruct_C_val))
+        && $TestStruct_A_is_well_formed(SelectField(__this, TestStruct_C_b))
+}
+
+procedure {:inline 1} Pack_TestStruct_C(module_idx: int, func_idx: int, var_idx: int, code_idx: int, val: Value, b: Value) returns (_struct: Value)
 {
     assume IsValidU64(val);
-    assume is#Vector(b);
+    assume $TestStruct_A_is_well_formed(b);
     _struct := Vector(ExtendValueArray(ExtendValueArray(EmptyValueArray, val), b));
+    if (code_idx > 0) { assume $DebugTrackLocal(module_idx, func_idx, var_idx, code_idx, _struct); }
 }
 
 procedure {:inline 1} Unpack_TestStruct_C(_struct: Value) returns (val: Value, b: Value)
@@ -71,7 +96,7 @@ procedure {:inline 1} Unpack_TestStruct_C(_struct: Value) returns (val: Value, b
     val := SelectField(_struct, TestStruct_C_val);
     assume IsValidU64(val);
     b := SelectField(_struct, TestStruct_C_b);
-    assume is#Vector(b);
+    assume $TestStruct_A_is_well_formed(b);
 }
 
 const unique TestStruct_T: TypeName;
@@ -80,10 +105,16 @@ axiom TestStruct_T_x == 0;
 function TestStruct_T_type_value(): TypeValue {
     StructType(TestStruct_T, ExtendTypeValueArray(EmptyTypeValueArray, IntegerType()))
 }
-procedure {:inline 1} Pack_TestStruct_T(x: Value) returns (_struct: Value)
+function {:inline 1} $TestStruct_T_is_well_formed(__this: Value): bool {
+    is#Vector(__this)
+        && IsValidU64(SelectField(__this, TestStruct_T_x))
+}
+
+procedure {:inline 1} Pack_TestStruct_T(module_idx: int, func_idx: int, var_idx: int, code_idx: int, x: Value) returns (_struct: Value)
 {
     assume IsValidU64(x);
     _struct := Vector(ExtendValueArray(EmptyValueArray, x));
+    if (code_idx > 0) { assume $DebugTrackLocal(module_idx, func_idx, var_idx, code_idx, _struct); }
 }
 
 procedure {:inline 1} Unpack_TestStruct_T(_struct: Value) returns (x: Value)
@@ -113,10 +144,10 @@ requires ExistsTxnSenderAccount(__m, __txn);
     __frame := __local_counter;
 
     // process and type check arguments
-    assume is#Vector(a);
+    assume $TestStruct_A_is_well_formed(a);
     __m := UpdateLocal(__m, __frame + 0, a);
     assume $DebugTrackLocal(0, 0, 0, 252, a);
-    assume is#Vector(c);
+    assume $TestStruct_C_is_well_formed(c);
     __m := UpdateLocal(__m, __frame + 1, c);
     assume $DebugTrackLocal(0, 0, 1, 252, c);
 
@@ -225,7 +256,7 @@ Label_8:
     }
 
     call t_ref1 := CopyOrMoveRef(__t11);
-    assume is#Vector(Dereference(__m, t_ref1));
+    assume $TestStruct_T_is_well_formed(Dereference(__m, t_ref1));
     assume $DebugTrackLocal(0, 1, 2, 589, Dereference(__m, t_ref1));
 
     call __t12 := CopyOrMoveRef(t_ref1);
@@ -242,7 +273,7 @@ Label_8:
     }
 
     call t_ref2 := CopyOrMoveRef(__t14);
-    assume is#Vector(Dereference(__m, t_ref2));
+    assume $TestStruct_T_is_well_formed(Dereference(__m, t_ref2));
     assume $DebugTrackLocal(0, 1, 3, 663, Dereference(__m, t_ref2));
 
     call __t15 := CopyOrMoveRef(t_ref2);
@@ -254,7 +285,7 @@ Label_8:
 
     call __tmp := MoveFrom(GetLocal(__m, __frame + 16), TestStruct_T_type_value());
     __m := UpdateLocal(__m, __frame + 17, __tmp);
-    assume is#Vector(__t17);
+    assume $TestStruct_T_is_well_formed(__t17);
     if (__abort_flag) {
       assume $DebugTrackAbort(0, 1, 741);
       goto Label_Abort;
@@ -352,7 +383,7 @@ ensures old(b#Boolean(Boolean(false))) ==> __abort_flag;
     call __tmp := LdConst(1);
     __m := UpdateLocal(__m, __frame + 8, __tmp);
 
-    call __tmp := Pack_TestStruct_B(GetLocal(__m, __frame + 7), GetLocal(__m, __frame + 8));
+    call __tmp := Pack_TestStruct_B(0, 2, 2, 1084, GetLocal(__m, __frame + 7), GetLocal(__m, __frame + 8));
     __m := UpdateLocal(__m, __frame + 9, __tmp);
 
     call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 9));
@@ -368,7 +399,7 @@ Label_7:
     call __tmp := LdConst(42);
     __m := UpdateLocal(__m, __frame + 11, __tmp);
 
-    call __tmp := Pack_TestStruct_B(GetLocal(__m, __frame + 10), GetLocal(__m, __frame + 11));
+    call __tmp := Pack_TestStruct_B(0, 2, 2, 1150, GetLocal(__m, __frame + 10), GetLocal(__m, __frame + 11));
     __m := UpdateLocal(__m, __frame + 12, __tmp);
 
     call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 12));
@@ -376,10 +407,10 @@ Label_7:
     assume $DebugTrackLocal(0, 2, 2, 1142, __tmp);
 
 Label_11:
-    call __t13 := BorrowLoc(__frame + 2);
+    call __t13 := BorrowLoc(__frame + 2, TestStruct_B_type_value());
 
     call var_b_ref := CopyOrMoveRef(__t13);
-    assume is#Vector(Dereference(__m, var_b_ref));
+    assume $TestStruct_B_is_well_formed(Dereference(__m, var_b_ref));
     assume $DebugTrackLocal(0, 2, 3, 1198, Dereference(__m, var_b_ref));
 
     call __t14 := CopyOrMoveRef(var_b_ref);
@@ -486,7 +517,7 @@ ensures old(b#Boolean(Boolean(false))) ==> __abort_flag;
     call __tmp := LdConst(42);
     __m := UpdateLocal(__m, __frame + 5, __tmp);
 
-    call __tmp := Pack_TestStruct_B(GetLocal(__m, __frame + 4), GetLocal(__m, __frame + 5));
+    call __tmp := Pack_TestStruct_B(0, 3, 2, 1513, GetLocal(__m, __frame + 4), GetLocal(__m, __frame + 5));
     __m := UpdateLocal(__m, __frame + 6, __tmp);
 
     call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 6));

--- a/language/move-prover/bytecode-to-boogie/tests/goldenfiles/test3.bpl
+++ b/language/move-prover/bytecode-to-boogie/tests/goldenfiles/test3.bpl
@@ -1,5 +1,9 @@
 
 
+// ** synthetics of module Test3
+
+
+
 // ** structs of module Test3
 
 const unique Test3_T: TypeName;
@@ -10,11 +14,18 @@ axiom Test3_T_g == 1;
 function Test3_T_type_value(): TypeValue {
     StructType(Test3_T, ExtendTypeValueArray(ExtendTypeValueArray(EmptyTypeValueArray, IntegerType()), IntegerType()))
 }
-procedure {:inline 1} Pack_Test3_T(f: Value, g: Value) returns (_struct: Value)
+function {:inline 1} $Test3_T_is_well_formed(__this: Value): bool {
+    is#Vector(__this)
+        && IsValidU64(SelectField(__this, Test3_T_f))
+        && IsValidU64(SelectField(__this, Test3_T_g))
+}
+
+procedure {:inline 1} Pack_Test3_T(module_idx: int, func_idx: int, var_idx: int, code_idx: int, f: Value, g: Value) returns (_struct: Value)
 {
     assume IsValidU64(f);
     assume IsValidU64(g);
     _struct := Vector(ExtendValueArray(ExtendValueArray(EmptyValueArray, f), g));
+    if (code_idx > 0) { assume $DebugTrackLocal(module_idx, func_idx, var_idx, code_idx, _struct); }
 }
 
 procedure {:inline 1} Unpack_Test3_T(_struct: Value) returns (f: Value, g: Value)
@@ -117,17 +128,17 @@ ensures old(b#Boolean(Boolean(false))) ==> __abort_flag;
     call __tmp := LdConst(0);
     __m := UpdateLocal(__m, __frame + 10, __tmp);
 
-    call __tmp := Pack_Test3_T(GetLocal(__m, __frame + 9), GetLocal(__m, __frame + 10));
+    call __tmp := Pack_Test3_T(0, 0, 1, 271, GetLocal(__m, __frame + 9), GetLocal(__m, __frame + 10));
     __m := UpdateLocal(__m, __frame + 11, __tmp);
 
     call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 11));
     __m := UpdateLocal(__m, __frame + 1, __tmp);
     assume $DebugTrackLocal(0, 0, 1, 267, __tmp);
 
-    call __t12 := BorrowLoc(__frame + 1);
+    call __t12 := BorrowLoc(__frame + 1, Test3_T_type_value());
 
     call x_ref := CopyOrMoveRef(__t12);
-    assume is#Vector(Dereference(__m, x_ref));
+    assume $Test3_T_is_well_formed(Dereference(__m, x_ref));
     assume $DebugTrackLocal(0, 0, 2, 290, Dereference(__m, x_ref));
 
     call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 0));

--- a/language/move-prover/bytecode-to-boogie/tests/goldenfiles/verify-addition.bpl
+++ b/language/move-prover/bytecode-to-boogie/tests/goldenfiles/verify-addition.bpl
@@ -1,5 +1,9 @@
 
 
+// ** synthetics of module TestAddition
+
+
+
 // ** structs of module TestAddition
 
 

--- a/language/move-prover/bytecode-to-boogie/tests/goldenfiles/verify-cast.bpl
+++ b/language/move-prover/bytecode-to-boogie/tests/goldenfiles/verify-cast.bpl
@@ -1,5 +1,9 @@
 
 
+// ** synthetics of module CastBad
+
+
+
 // ** structs of module CastBad
 
 

--- a/language/move-prover/bytecode-to-boogie/tests/goldenfiles/verify-create-resource.bpl
+++ b/language/move-prover/bytecode-to-boogie/tests/goldenfiles/verify-create-resource.bpl
@@ -1,5 +1,9 @@
 
 
+// ** synthetics of module TestSpecs
+
+
+
 // ** structs of module TestSpecs
 
 const unique TestSpecs_R: TypeName;
@@ -8,10 +12,16 @@ axiom TestSpecs_R_x == 0;
 function TestSpecs_R_type_value(): TypeValue {
     StructType(TestSpecs_R, ExtendTypeValueArray(EmptyTypeValueArray, IntegerType()))
 }
-procedure {:inline 1} Pack_TestSpecs_R(x: Value) returns (_struct: Value)
+function {:inline 1} $TestSpecs_R_is_well_formed(__this: Value): bool {
+    is#Vector(__this)
+        && IsValidU64(SelectField(__this, TestSpecs_R_x))
+}
+
+procedure {:inline 1} Pack_TestSpecs_R(module_idx: int, func_idx: int, var_idx: int, code_idx: int, x: Value) returns (_struct: Value)
 {
     assume IsValidU64(x);
     _struct := Vector(ExtendValueArray(EmptyValueArray, x));
+    if (code_idx > 0) { assume $DebugTrackLocal(module_idx, func_idx, var_idx, code_idx, _struct); }
 }
 
 procedure {:inline 1} Unpack_TestSpecs_R(_struct: Value) returns (x: Value)
@@ -71,7 +81,7 @@ Label_5:
     call __tmp := LdConst(1);
     __m := UpdateLocal(__m, __frame + 3, __tmp);
 
-    call __tmp := Pack_TestSpecs_R(GetLocal(__m, __frame + 3));
+    call __tmp := Pack_TestSpecs_R(0, 0, 0, 0, GetLocal(__m, __frame + 3));
     __m := UpdateLocal(__m, __frame + 4, __tmp);
 
     call MoveToSender(TestSpecs_R_type_value(), GetLocal(__m, __frame + 4));

--- a/language/move-prover/bytecode-to-boogie/tests/goldenfiles/verify-div.bpl
+++ b/language/move-prover/bytecode-to-boogie/tests/goldenfiles/verify-div.bpl
@@ -1,5 +1,9 @@
 
 
+// ** synthetics of module TestSpecs
+
+
+
 // ** structs of module TestSpecs
 
 

--- a/language/move-prover/bytecode-to-boogie/tests/goldenfiles/verify-invariants.bpl
+++ b/language/move-prover/bytecode-to-boogie/tests/goldenfiles/verify-invariants.bpl
@@ -1,0 +1,388 @@
+
+
+// ** synthetics of module TestInvariants
+
+
+
+// ** structs of module TestInvariants
+
+const unique TestInvariants_T: TypeName;
+const TestInvariants_T_i: FieldName;
+axiom TestInvariants_T_i == 0;
+function TestInvariants_T_type_value(): TypeValue {
+    StructType(TestInvariants_T, ExtendTypeValueArray(EmptyTypeValueArray, IntegerType()))
+}
+function {:inline 1} $TestInvariants_T_is_well_formed(__this: Value): bool {
+    is#Vector(__this)
+        && IsValidU64(SelectField(__this, TestInvariants_T_i))
+        && b#Boolean(Boolean(i#Integer(SelectField(__this, TestInvariants_T_i)) > i#Integer(Integer(0))))
+}
+
+procedure {:inline 1} $TestInvariants_T_update_inv(__before: Value, __after: Value) {
+    assert b#Boolean(Boolean(i#Integer(SelectField(__after, TestInvariants_T_i)) > i#Integer(SelectField(__before, TestInvariants_T_i))));
+    assert b#Boolean(Boolean(i#Integer(SelectField(__after, TestInvariants_T_i)) > i#Integer(Integer(0))));
+}
+
+procedure {:inline 1} Pack_TestInvariants_T(module_idx: int, func_idx: int, var_idx: int, code_idx: int, i: Value) returns (_struct: Value)
+{
+    assume IsValidU64(i);
+    _struct := Vector(ExtendValueArray(EmptyValueArray, i));
+    if (code_idx > 0) { assume $DebugTrackLocal(module_idx, func_idx, var_idx, code_idx, _struct); }
+    assert b#Boolean(Boolean(i#Integer(SelectField(_struct, TestInvariants_T_i)) > i#Integer(Integer(0))));
+}
+
+procedure {:inline 1} Unpack_TestInvariants_T(_struct: Value) returns (i: Value)
+{
+    assume is#Vector(_struct);
+    i := SelectField(_struct, TestInvariants_T_i);
+    assume IsValidU64(i);
+}
+
+
+
+// ** functions of module TestInvariants
+
+procedure {:inline 1} TestInvariants_valid_T () returns (__ret0: Value)
+requires ExistsTxnSenderAccount(__m, __txn);
+ensures b#Boolean(Boolean(IsEqual(SelectField(__ret0, TestInvariants_T_i), Integer(1))));
+{
+    // declare local variables
+    var t: Value; // TestInvariants_T_type_value()
+    var __t1: Value; // IntegerType()
+    var __t2: Value; // TestInvariants_T_type_value()
+    var __t3: Value; // TestInvariants_T_type_value()
+    var __tmp: Value;
+    var __frame: int;
+    var __saved_m: Memory;
+
+    // initialize function execution
+    assume !__abort_flag;
+    __saved_m := __m;
+    __frame := __local_counter;
+
+    // process and type check arguments
+
+    // increase the local counter
+    __local_counter := __local_counter + 4;
+
+    // bytecode translation starts here
+    call __tmp := LdConst(1);
+    __m := UpdateLocal(__m, __frame + 1, __tmp);
+
+    call __tmp := Pack_TestInvariants_T(0, 0, 0, 686, GetLocal(__m, __frame + 1));
+    __m := UpdateLocal(__m, __frame + 2, __tmp);
+
+    call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 2));
+    __m := UpdateLocal(__m, __frame + 0, __tmp);
+    assume $DebugTrackLocal(0, 0, 0, 682, __tmp);
+
+    call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 0));
+    __m := UpdateLocal(__m, __frame + 3, __tmp);
+
+    __ret0 := GetLocal(__m, __frame + 3);
+    assume $DebugTrackLocal(0, 0, 1, 700, __ret0);
+    return;
+
+Label_Abort:
+    __abort_flag := true;
+    __m := __saved_m;
+    __ret0 := DefaultValue;
+}
+
+procedure TestInvariants_valid_T_verify () returns (__ret0: Value)
+{
+    call InitVerification();
+    call __ret0 := TestInvariants_valid_T();
+}
+
+procedure {:inline 1} TestInvariants_invalid_T () returns (__ret0: Value)
+requires ExistsTxnSenderAccount(__m, __txn);
+ensures b#Boolean(Boolean(IsEqual(SelectField(__ret0, TestInvariants_T_i), Integer(0))));
+{
+    // declare local variables
+    var t: Value; // TestInvariants_T_type_value()
+    var __t1: Value; // IntegerType()
+    var __t2: Value; // TestInvariants_T_type_value()
+    var __t3: Value; // TestInvariants_T_type_value()
+    var __tmp: Value;
+    var __frame: int;
+    var __saved_m: Memory;
+
+    // initialize function execution
+    assume !__abort_flag;
+    __saved_m := __m;
+    __frame := __local_counter;
+
+    // process and type check arguments
+
+    // increase the local counter
+    __local_counter := __local_counter + 4;
+
+    // bytecode translation starts here
+    call __tmp := LdConst(0);
+    __m := UpdateLocal(__m, __frame + 1, __tmp);
+
+    call __tmp := Pack_TestInvariants_T(0, 1, 0, 814, GetLocal(__m, __frame + 1));
+    __m := UpdateLocal(__m, __frame + 2, __tmp);
+
+    call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 2));
+    __m := UpdateLocal(__m, __frame + 0, __tmp);
+    assume $DebugTrackLocal(0, 1, 0, 810, __tmp);
+
+    call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 0));
+    __m := UpdateLocal(__m, __frame + 3, __tmp);
+
+    __ret0 := GetLocal(__m, __frame + 3);
+    assume $DebugTrackLocal(0, 1, 1, 828, __ret0);
+    return;
+
+Label_Abort:
+    __abort_flag := true;
+    __m := __saved_m;
+    __ret0 := DefaultValue;
+}
+
+procedure TestInvariants_invalid_T_verify () returns (__ret0: Value)
+{
+    call InitVerification();
+    call __ret0 := TestInvariants_invalid_T();
+}
+
+procedure {:inline 1} TestInvariants_valid_T_update () returns (__ret0: Value)
+requires ExistsTxnSenderAccount(__m, __txn);
+ensures b#Boolean(Boolean(IsEqual(SelectField(__ret0, TestInvariants_T_i), Integer(3))));
+{
+    // declare local variables
+    var t: Value; // TestInvariants_T_type_value()
+    var r: Reference; // ReferenceType(TestInvariants_T_type_value())
+    var __t2: Value; // IntegerType()
+    var __t3: Value; // TestInvariants_T_type_value()
+    var __t4: Reference; // ReferenceType(TestInvariants_T_type_value())
+    var __t5: Value; // IntegerType()
+    var __t6: Value; // TestInvariants_T_type_value()
+    var __t7: Reference; // ReferenceType(TestInvariants_T_type_value())
+    var __t8: Value; // TestInvariants_T_type_value()
+    var __tmp: Value;
+    var __frame: int;
+    var __saved_m: Memory;
+    var __before_borrow_0: Value;
+    var __before_borrow_0_ref: Reference;
+
+    // initialize function execution
+    assume !__abort_flag;
+    __saved_m := __m;
+    __frame := __local_counter;
+
+    // process and type check arguments
+
+    // increase the local counter
+    __local_counter := __local_counter + 9;
+
+    // bytecode translation starts here
+    call __tmp := LdConst(2);
+    __m := UpdateLocal(__m, __frame + 2, __tmp);
+
+    call __tmp := Pack_TestInvariants_T(0, 2, 0, 973, GetLocal(__m, __frame + 2));
+    __m := UpdateLocal(__m, __frame + 3, __tmp);
+
+    call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 3));
+    __m := UpdateLocal(__m, __frame + 0, __tmp);
+    assume $DebugTrackLocal(0, 2, 0, 969, __tmp);
+
+    call __t4 := BorrowLoc(__frame + 0, TestInvariants_T_type_value());
+    __before_borrow_0 := Dereference(__m, __t4);
+    __before_borrow_0_ref := __t4;
+
+    call r := CopyOrMoveRef(__t4);
+    assume $TestInvariants_T_is_well_formed(Dereference(__m, r));
+    assume $DebugTrackLocal(0, 2, 1, 987, Dereference(__m, r));
+
+    call __tmp := LdConst(3);
+    __m := UpdateLocal(__m, __frame + 5, __tmp);
+
+    call __tmp := Pack_TestInvariants_T(0, 0, 0, 0, GetLocal(__m, __frame + 5));
+    __m := UpdateLocal(__m, __frame + 6, __tmp);
+
+    call __t7 := CopyOrMoveRef(r);
+
+    call WriteRef(__t7, GetLocal(__m, __frame + 6));
+    assume $DebugTrackLocal(0, 2, 0, 1005, GetLocal(__m, __frame + 0));
+
+    call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 0));
+    __m := UpdateLocal(__m, __frame + 8, __tmp);
+
+    __ret0 := GetLocal(__m, __frame + 8);
+    assume $DebugTrackLocal(0, 2, 2, 1030, __ret0);
+    call $TestInvariants_T_update_inv(__before_borrow_0, Dereference(__m, __before_borrow_0_ref));
+    return;
+
+Label_Abort:
+    __abort_flag := true;
+    __m := __saved_m;
+    __ret0 := DefaultValue;
+}
+
+procedure TestInvariants_valid_T_update_verify () returns (__ret0: Value)
+{
+    call InitVerification();
+    call __ret0 := TestInvariants_valid_T_update();
+}
+
+procedure {:inline 1} TestInvariants_invalid_T_update () returns (__ret0: Value)
+requires ExistsTxnSenderAccount(__m, __txn);
+ensures b#Boolean(Boolean(IsEqual(SelectField(__ret0, TestInvariants_T_i), Integer(2))));
+{
+    // declare local variables
+    var t: Value; // TestInvariants_T_type_value()
+    var r: Reference; // ReferenceType(TestInvariants_T_type_value())
+    var __t2: Value; // IntegerType()
+    var __t3: Value; // TestInvariants_T_type_value()
+    var __t4: Reference; // ReferenceType(TestInvariants_T_type_value())
+    var __t5: Value; // IntegerType()
+    var __t6: Value; // TestInvariants_T_type_value()
+    var __t7: Reference; // ReferenceType(TestInvariants_T_type_value())
+    var __t8: Value; // TestInvariants_T_type_value()
+    var __tmp: Value;
+    var __frame: int;
+    var __saved_m: Memory;
+    var __before_borrow_0: Value;
+    var __before_borrow_0_ref: Reference;
+
+    // initialize function execution
+    assume !__abort_flag;
+    __saved_m := __m;
+    __frame := __local_counter;
+
+    // process and type check arguments
+
+    // increase the local counter
+    __local_counter := __local_counter + 9;
+
+    // bytecode translation starts here
+    call __tmp := LdConst(2);
+    __m := UpdateLocal(__m, __frame + 2, __tmp);
+
+    call __tmp := Pack_TestInvariants_T(0, 3, 0, 1177, GetLocal(__m, __frame + 2));
+    __m := UpdateLocal(__m, __frame + 3, __tmp);
+
+    call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 3));
+    __m := UpdateLocal(__m, __frame + 0, __tmp);
+    assume $DebugTrackLocal(0, 3, 0, 1173, __tmp);
+
+    call __t4 := BorrowLoc(__frame + 0, TestInvariants_T_type_value());
+    __before_borrow_0 := Dereference(__m, __t4);
+    __before_borrow_0_ref := __t4;
+
+    call r := CopyOrMoveRef(__t4);
+    assume $TestInvariants_T_is_well_formed(Dereference(__m, r));
+    assume $DebugTrackLocal(0, 3, 1, 1191, Dereference(__m, r));
+
+    call __tmp := LdConst(2);
+    __m := UpdateLocal(__m, __frame + 5, __tmp);
+
+    call __tmp := Pack_TestInvariants_T(0, 0, 0, 0, GetLocal(__m, __frame + 5));
+    __m := UpdateLocal(__m, __frame + 6, __tmp);
+
+    call __t7 := CopyOrMoveRef(r);
+
+    call WriteRef(__t7, GetLocal(__m, __frame + 6));
+    assume $DebugTrackLocal(0, 3, 0, 1209, GetLocal(__m, __frame + 0));
+
+    call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 0));
+    __m := UpdateLocal(__m, __frame + 8, __tmp);
+
+    __ret0 := GetLocal(__m, __frame + 8);
+    assume $DebugTrackLocal(0, 3, 2, 1234, __ret0);
+    call $TestInvariants_T_update_inv(__before_borrow_0, Dereference(__m, __before_borrow_0_ref));
+    return;
+
+Label_Abort:
+    __abort_flag := true;
+    __m := __saved_m;
+    __ret0 := DefaultValue;
+}
+
+procedure TestInvariants_invalid_T_update_verify () returns (__ret0: Value)
+{
+    call InitVerification();
+    call __ret0 := TestInvariants_invalid_T_update();
+}
+
+procedure {:inline 1} TestInvariants_invalid_T_update_indirectly () returns (__ret0: Value)
+requires ExistsTxnSenderAccount(__m, __txn);
+ensures b#Boolean(Boolean(IsEqual(SelectField(__ret0, TestInvariants_T_i), Integer(2))));
+{
+    // declare local variables
+    var t: Value; // TestInvariants_T_type_value()
+    var r: Reference; // ReferenceType(TestInvariants_T_type_value())
+    var __t2: Value; // IntegerType()
+    var __t3: Value; // TestInvariants_T_type_value()
+    var __t4: Reference; // ReferenceType(TestInvariants_T_type_value())
+    var __t5: Value; // IntegerType()
+    var __t6: Reference; // ReferenceType(TestInvariants_T_type_value())
+    var __t7: Reference; // ReferenceType(IntegerType())
+    var __t8: Value; // TestInvariants_T_type_value()
+    var __tmp: Value;
+    var __frame: int;
+    var __saved_m: Memory;
+    var __before_borrow_0: Value;
+    var __before_borrow_0_ref: Reference;
+
+    // initialize function execution
+    assume !__abort_flag;
+    __saved_m := __m;
+    __frame := __local_counter;
+
+    // process and type check arguments
+
+    // increase the local counter
+    __local_counter := __local_counter + 9;
+
+    // bytecode translation starts here
+    call __tmp := LdConst(2);
+    __m := UpdateLocal(__m, __frame + 2, __tmp);
+
+    call __tmp := Pack_TestInvariants_T(0, 4, 0, 1392, GetLocal(__m, __frame + 2));
+    __m := UpdateLocal(__m, __frame + 3, __tmp);
+
+    call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 3));
+    __m := UpdateLocal(__m, __frame + 0, __tmp);
+    assume $DebugTrackLocal(0, 4, 0, 1388, __tmp);
+
+    call __t4 := BorrowLoc(__frame + 0, TestInvariants_T_type_value());
+    __before_borrow_0 := Dereference(__m, __t4);
+    __before_borrow_0_ref := __t4;
+
+    call r := CopyOrMoveRef(__t4);
+    assume $TestInvariants_T_is_well_formed(Dereference(__m, r));
+    assume $DebugTrackLocal(0, 4, 1, 1406, Dereference(__m, r));
+
+    call __tmp := LdConst(2);
+    __m := UpdateLocal(__m, __frame + 5, __tmp);
+
+    call __t6 := CopyOrMoveRef(r);
+
+    call __t7 := BorrowField(__t6, TestInvariants_T_i);
+
+    call WriteRef(__t7, GetLocal(__m, __frame + 5));
+    assume $DebugTrackLocal(0, 4, 0, 1424, GetLocal(__m, __frame + 0));
+
+    call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 0));
+    __m := UpdateLocal(__m, __frame + 8, __tmp);
+
+    __ret0 := GetLocal(__m, __frame + 8);
+    assume $DebugTrackLocal(0, 4, 2, 1451, __ret0);
+    call $TestInvariants_T_update_inv(__before_borrow_0, Dereference(__m, __before_borrow_0_ref));
+    return;
+
+Label_Abort:
+    __abort_flag := true;
+    __m := __saved_m;
+    __ret0 := DefaultValue;
+}
+
+procedure TestInvariants_invalid_T_update_indirectly_verify () returns (__ret0: Value)
+{
+    call InitVerification();
+    call __ret0 := TestInvariants_invalid_T_update_indirectly();
+}

--- a/language/move-prover/bytecode-to-boogie/tests/goldenfiles/verify-local-ref.bpl
+++ b/language/move-prover/bytecode-to-boogie/tests/goldenfiles/verify-local-ref.bpl
@@ -1,5 +1,9 @@
 
 
+// ** synthetics of module TestSpecs
+
+
+
 // ** structs of module TestSpecs
 
 
@@ -22,8 +26,7 @@ requires ExistsTxnSenderAccount(__m, __txn);
     __frame := __local_counter;
 
     // process and type check arguments
-    assume IsValidU64(Dereference(__m, b));
-    assume IsValidReferenceParameter(__m, __local_counter, b);
+    assume IsValidU64(Dereference(__m, b)) && IsValidReferenceParameter(__m, __local_counter, b);
     assume IsValidU64(Dereference(__m, b));
     assume $DebugTrackLocal(0, 0, 0, 24, Dereference(__m, b));
 
@@ -37,6 +40,8 @@ requires ExistsTxnSenderAccount(__m, __txn);
     call __t2 := CopyOrMoveRef(b);
 
     call WriteRef(__t2, GetLocal(__m, __frame + 1));
+    assume IsValidU64(Dereference(__m, b));
+    assume $DebugTrackLocal(0, 0, 0, 59, Dereference(__m, b));
 
     return;
 
@@ -90,7 +95,7 @@ ensures old(b#Boolean(Boolean(true))) ==> !__abort_flag;
     __m := UpdateLocal(__m, __frame + 0, __tmp);
     assume $DebugTrackLocal(0, 1, 0, 252, __tmp);
 
-    call __t3 := BorrowLoc(__frame + 0);
+    call __t3 := BorrowLoc(__frame + 0, IntegerType());
 
     call b_ref := CopyOrMoveRef(__t3);
     assume IsValidU64(Dereference(__m, b_ref));
@@ -188,7 +193,7 @@ ensures old(b#Boolean(Boolean(true))) ==> !__abort_flag;
     __m := UpdateLocal(__m, __frame + 0, __tmp);
     assume $DebugTrackLocal(0, 2, 0, 621, __tmp);
 
-    call __t3 := BorrowLoc(__frame + 0);
+    call __t3 := BorrowLoc(__frame + 0, IntegerType());
 
     call b_ref := CopyOrMoveRef(__t3);
     assume IsValidU64(Dereference(__m, b_ref));

--- a/language/move-prover/bytecode-to-boogie/tests/goldenfiles/verify-multiplication.bpl
+++ b/language/move-prover/bytecode-to-boogie/tests/goldenfiles/verify-multiplication.bpl
@@ -1,5 +1,9 @@
 
 
+// ** synthetics of module TestMultiplication
+
+
+
 // ** structs of module TestMultiplication
 
 

--- a/language/move-prover/bytecode-to-boogie/tests/goldenfiles/verify-ref-param.bpl
+++ b/language/move-prover/bytecode-to-boogie/tests/goldenfiles/verify-ref-param.bpl
@@ -1,5 +1,9 @@
 
 
+// ** synthetics of module TestSpecs
+
+
+
 // ** structs of module TestSpecs
 
 const unique TestSpecs_T: TypeName;
@@ -8,10 +12,16 @@ axiom TestSpecs_T_value == 0;
 function TestSpecs_T_type_value(): TypeValue {
     StructType(TestSpecs_T, ExtendTypeValueArray(EmptyTypeValueArray, IntegerType()))
 }
-procedure {:inline 1} Pack_TestSpecs_T(value: Value) returns (_struct: Value)
+function {:inline 1} $TestSpecs_T_is_well_formed(__this: Value): bool {
+    is#Vector(__this)
+        && IsValidU64(SelectField(__this, TestSpecs_T_value))
+}
+
+procedure {:inline 1} Pack_TestSpecs_T(module_idx: int, func_idx: int, var_idx: int, code_idx: int, value: Value) returns (_struct: Value)
 {
     assume IsValidU64(value);
     _struct := Vector(ExtendValueArray(EmptyValueArray, value));
+    if (code_idx > 0) { assume $DebugTrackLocal(module_idx, func_idx, var_idx, code_idx, _struct); }
 }
 
 procedure {:inline 1} Unpack_TestSpecs_T(_struct: Value) returns (value: Value)
@@ -43,9 +53,8 @@ ensures b#Boolean(Boolean(IsEqual(__ret0, SelectField(Dereference(__m, ref), Tes
     __frame := __local_counter;
 
     // process and type check arguments
-    assume is#Vector(Dereference(__m, ref));
-    assume IsValidReferenceParameter(__m, __local_counter, ref);
-    assume is#Vector(Dereference(__m, ref));
+    assume $TestSpecs_T_is_well_formed(Dereference(__m, ref)) && IsValidReferenceParameter(__m, __local_counter, ref);
+    assume $TestSpecs_T_is_well_formed(Dereference(__m, ref));
     assume $DebugTrackLocal(0, 0, 0, 66, Dereference(__m, ref));
 
     // increase the local counter

--- a/language/move-prover/bytecode-to-boogie/tests/goldenfiles/verify-synthetics.bpl
+++ b/language/move-prover/bytecode-to-boogie/tests/goldenfiles/verify-synthetics.bpl
@@ -1,0 +1,239 @@
+
+
+// ** synthetics of module TestInvariants
+
+var __TestInvariants_syn : Value where IsValidU64(__TestInvariants_syn);
+
+
+// ** structs of module TestInvariants
+
+const unique TestInvariants_T: TypeName;
+const TestInvariants_T_i: FieldName;
+axiom TestInvariants_T_i == 0;
+function TestInvariants_T_type_value(): TypeValue {
+    StructType(TestInvariants_T, ExtendTypeValueArray(EmptyTypeValueArray, IntegerType()))
+}
+function {:inline 1} $TestInvariants_T_is_well_formed(__this: Value): bool {
+    is#Vector(__this)
+        && IsValidU64(SelectField(__this, TestInvariants_T_i))
+}
+
+procedure {:inline 1} $TestInvariants_T_update_inv(__before: Value, __after: Value) {
+    __TestInvariants_syn := Integer(i#Integer(Integer(i#Integer(__TestInvariants_syn) - i#Integer(SelectField(__before, TestInvariants_T_i)))) + i#Integer(SelectField(__after, TestInvariants_T_i)));
+}
+
+procedure {:inline 1} Pack_TestInvariants_T(module_idx: int, func_idx: int, var_idx: int, code_idx: int, i: Value) returns (_struct: Value)
+{
+    assume IsValidU64(i);
+    _struct := Vector(ExtendValueArray(EmptyValueArray, i));
+    if (code_idx > 0) { assume $DebugTrackLocal(module_idx, func_idx, var_idx, code_idx, _struct); }
+    __TestInvariants_syn := Integer(i#Integer(__TestInvariants_syn) + i#Integer(SelectField(_struct, TestInvariants_T_i)));
+}
+
+procedure {:inline 1} Unpack_TestInvariants_T(_struct: Value) returns (i: Value)
+{
+    assume is#Vector(_struct);
+    i := SelectField(_struct, TestInvariants_T_i);
+    assume IsValidU64(i);
+    __TestInvariants_syn := Integer(i#Integer(__TestInvariants_syn) - i#Integer(SelectField(_struct, TestInvariants_T_i)));
+}
+
+
+
+// ** functions of module TestInvariants
+
+procedure {:inline 1} TestInvariants_valid () returns ()
+requires ExistsTxnSenderAccount(__m, __txn);
+ensures b#Boolean(Boolean(IsEqual(__TestInvariants_syn, Integer(i#Integer(Integer(i#Integer(Integer(i#Integer(Integer(i#Integer(Integer(i#Integer(old(__TestInvariants_syn)) + i#Integer(Integer(2)))) + i#Integer(Integer(3)))) - i#Integer(Integer(3)))) + i#Integer(Integer(4)))) - i#Integer(Integer(2))))));
+{
+    // declare local variables
+    var t: Value; // TestInvariants_T_type_value()
+    var r: Value; // TestInvariants_T_type_value()
+    var s: Reference; // ReferenceType(TestInvariants_T_type_value())
+    var x: Value; // IntegerType()
+    var __t4: Value; // IntegerType()
+    var __t5: Value; // TestInvariants_T_type_value()
+    var __t6: Value; // IntegerType()
+    var __t7: Value; // TestInvariants_T_type_value()
+    var __t8: Reference; // ReferenceType(TestInvariants_T_type_value())
+    var __t9: Value; // IntegerType()
+    var __t10: Reference; // ReferenceType(TestInvariants_T_type_value())
+    var __t11: Reference; // ReferenceType(IntegerType())
+    var __t12: Value; // TestInvariants_T_type_value()
+    var __t13: Value; // IntegerType()
+    var __tmp: Value;
+    var __frame: int;
+    var __saved_m: Memory;
+    var __before_borrow_0: Value;
+    var __before_borrow_0_ref: Reference;
+
+    // initialize function execution
+    assume !__abort_flag;
+    __saved_m := __m;
+    __frame := __local_counter;
+
+    // process and type check arguments
+
+    // increase the local counter
+    __local_counter := __local_counter + 14;
+
+    // bytecode translation starts here
+    call __tmp := LdConst(2);
+    __m := UpdateLocal(__m, __frame + 4, __tmp);
+
+    call __tmp := Pack_TestInvariants_T(0, 0, 0, 608, GetLocal(__m, __frame + 4));
+    __m := UpdateLocal(__m, __frame + 5, __tmp);
+
+    call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 5));
+    __m := UpdateLocal(__m, __frame + 0, __tmp);
+    assume $DebugTrackLocal(0, 0, 0, 604, __tmp);
+
+    call __tmp := LdConst(3);
+    __m := UpdateLocal(__m, __frame + 6, __tmp);
+
+    call __tmp := Pack_TestInvariants_T(0, 0, 1, 626, GetLocal(__m, __frame + 6));
+    __m := UpdateLocal(__m, __frame + 7, __tmp);
+
+    call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 7));
+    __m := UpdateLocal(__m, __frame + 1, __tmp);
+    assume $DebugTrackLocal(0, 0, 1, 622, __tmp);
+
+    call __t8 := BorrowLoc(__frame + 1, TestInvariants_T_type_value());
+    __before_borrow_0 := Dereference(__m, __t8);
+    __before_borrow_0_ref := __t8;
+
+    call s := CopyOrMoveRef(__t8);
+    assume $TestInvariants_T_is_well_formed(Dereference(__m, s));
+    assume $DebugTrackLocal(0, 0, 2, 640, Dereference(__m, s));
+
+    call __tmp := LdConst(4);
+    __m := UpdateLocal(__m, __frame + 9, __tmp);
+
+    call __t10 := CopyOrMoveRef(s);
+
+    call __t11 := BorrowField(__t10, TestInvariants_T_i);
+
+    call WriteRef(__t11, GetLocal(__m, __frame + 9));
+    assume $DebugTrackLocal(0, 0, 1, 658, GetLocal(__m, __frame + 1));
+
+    call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 0));
+    __m := UpdateLocal(__m, __frame + 12, __tmp);
+
+    call __t13 := Unpack_TestInvariants_T(GetLocal(__m, __frame + 12));
+    __m := UpdateLocal(__m, __frame + 13, __t13);
+
+    call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 13));
+    __m := UpdateLocal(__m, __frame + 3, __tmp);
+    assume $DebugTrackLocal(0, 0, 3, 687, __tmp);
+
+    call $TestInvariants_T_update_inv(__before_borrow_0, Dereference(__m, __before_borrow_0_ref));
+    return;
+
+Label_Abort:
+    __abort_flag := true;
+    __m := __saved_m;
+}
+
+procedure TestInvariants_valid_verify () returns ()
+{
+    call InitVerification();
+    call TestInvariants_valid();
+}
+
+procedure {:inline 1} TestInvariants_invalid () returns ()
+requires ExistsTxnSenderAccount(__m, __txn);
+ensures b#Boolean(Boolean(IsEqual(__TestInvariants_syn, Integer(i#Integer(old(__TestInvariants_syn)) + i#Integer(Integer(2))))));
+{
+    // declare local variables
+    var t: Value; // TestInvariants_T_type_value()
+    var r: Value; // TestInvariants_T_type_value()
+    var s: Reference; // ReferenceType(TestInvariants_T_type_value())
+    var x: Value; // IntegerType()
+    var __t4: Value; // IntegerType()
+    var __t5: Value; // TestInvariants_T_type_value()
+    var __t6: Value; // IntegerType()
+    var __t7: Value; // TestInvariants_T_type_value()
+    var __t8: Reference; // ReferenceType(TestInvariants_T_type_value())
+    var __t9: Value; // IntegerType()
+    var __t10: Reference; // ReferenceType(TestInvariants_T_type_value())
+    var __t11: Reference; // ReferenceType(IntegerType())
+    var __t12: Value; // TestInvariants_T_type_value()
+    var __t13: Value; // IntegerType()
+    var __tmp: Value;
+    var __frame: int;
+    var __saved_m: Memory;
+    var __before_borrow_0: Value;
+    var __before_borrow_0_ref: Reference;
+
+    // initialize function execution
+    assume !__abort_flag;
+    __saved_m := __m;
+    __frame := __local_counter;
+
+    // process and type check arguments
+
+    // increase the local counter
+    __local_counter := __local_counter + 14;
+
+    // bytecode translation starts here
+    call __tmp := LdConst(2);
+    __m := UpdateLocal(__m, __frame + 4, __tmp);
+
+    call __tmp := Pack_TestInvariants_T(0, 1, 0, 913, GetLocal(__m, __frame + 4));
+    __m := UpdateLocal(__m, __frame + 5, __tmp);
+
+    call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 5));
+    __m := UpdateLocal(__m, __frame + 0, __tmp);
+    assume $DebugTrackLocal(0, 1, 0, 909, __tmp);
+
+    call __tmp := LdConst(3);
+    __m := UpdateLocal(__m, __frame + 6, __tmp);
+
+    call __tmp := Pack_TestInvariants_T(0, 1, 1, 931, GetLocal(__m, __frame + 6));
+    __m := UpdateLocal(__m, __frame + 7, __tmp);
+
+    call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 7));
+    __m := UpdateLocal(__m, __frame + 1, __tmp);
+    assume $DebugTrackLocal(0, 1, 1, 927, __tmp);
+
+    call __t8 := BorrowLoc(__frame + 1, TestInvariants_T_type_value());
+    __before_borrow_0 := Dereference(__m, __t8);
+    __before_borrow_0_ref := __t8;
+
+    call s := CopyOrMoveRef(__t8);
+    assume $TestInvariants_T_is_well_formed(Dereference(__m, s));
+    assume $DebugTrackLocal(0, 1, 2, 945, Dereference(__m, s));
+
+    call __tmp := LdConst(4);
+    __m := UpdateLocal(__m, __frame + 9, __tmp);
+
+    call __t10 := CopyOrMoveRef(s);
+
+    call __t11 := BorrowField(__t10, TestInvariants_T_i);
+
+    call WriteRef(__t11, GetLocal(__m, __frame + 9));
+    assume $DebugTrackLocal(0, 1, 1, 963, GetLocal(__m, __frame + 1));
+
+    call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 0));
+    __m := UpdateLocal(__m, __frame + 12, __tmp);
+
+    call __t13 := Unpack_TestInvariants_T(GetLocal(__m, __frame + 12));
+    __m := UpdateLocal(__m, __frame + 13, __t13);
+
+    call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 13));
+    __m := UpdateLocal(__m, __frame + 3, __tmp);
+    assume $DebugTrackLocal(0, 1, 3, 992, __tmp);
+
+    call $TestInvariants_T_update_inv(__before_borrow_0, Dereference(__m, __before_borrow_0_ref));
+    return;
+
+Label_Abort:
+    __abort_flag := true;
+    __m := __saved_m;
+}
+
+procedure TestInvariants_invalid_verify () returns ()
+{
+    call InitVerification();
+    call TestInvariants_invalid();
+}

--- a/language/move-prover/bytecode-to-boogie/tests/goldenfiles/verify-vector.bpl
+++ b/language/move-prover/bytecode-to-boogie/tests/goldenfiles/verify-vector.bpl
@@ -1,5 +1,9 @@
 
 
+// ** synthetics of module VerifyVector
+
+
+
 // ** structs of module VerifyVector
 
 
@@ -37,7 +41,7 @@ ensures b#Boolean(Boolean(IsEqual(__ret0, __ret1)));
       assume $DebugTrackAbort(1, 0, 243);
       goto Label_Abort;
     }
-    assume is#Vector(__t2);
+    assume $Vector_T_is_well_formed(__t2);
 
     __m := UpdateLocal(__m, __frame + 2, __t2);
 
@@ -50,7 +54,7 @@ ensures b#Boolean(Boolean(IsEqual(__ret0, __ret1)));
       assume $DebugTrackAbort(1, 0, 278);
       goto Label_Abort;
     }
-    assume is#Vector(__t3);
+    assume $Vector_T_is_well_formed(__t3);
 
     __m := UpdateLocal(__m, __frame + 3, __t3);
 
@@ -119,7 +123,7 @@ ensures b#Boolean(Boolean(IsEqual(__ret0, __ret1)));
       assume $DebugTrackAbort(1, 1, 561);
       goto Label_Abort;
     }
-    assume is#Vector(__t3);
+    assume $Vector_T_is_well_formed(__t3);
 
     __m := UpdateLocal(__m, __frame + 3, __t3);
 
@@ -132,7 +136,7 @@ ensures b#Boolean(Boolean(IsEqual(__ret0, __ret1)));
       assume $DebugTrackAbort(1, 1, 596);
       goto Label_Abort;
     }
-    assume is#Vector(__t4);
+    assume $Vector_T_is_well_formed(__t4);
 
     __m := UpdateLocal(__m, __frame + 4, __t4);
 
@@ -140,7 +144,7 @@ ensures b#Boolean(Boolean(IsEqual(__ret0, __ret1)));
     __m := UpdateLocal(__m, __frame + 1, __tmp);
     assume $DebugTrackLocal(1, 1, 1, 590, __tmp);
 
-    call __t5 := BorrowLoc(__frame + 0);
+    call __t5 := BorrowLoc(__frame + 0, Vector_T_type_value(IntegerType()));
 
     call __tmp := LdConst(1);
     __m := UpdateLocal(__m, __frame + 6, __tmp);
@@ -152,7 +156,7 @@ ensures b#Boolean(Boolean(IsEqual(__ret0, __ret1)));
     }
     assume $DebugTrackLocal(1, 1, 0, 625, GetLocal(__m, __frame + 0));
 
-    call __t7 := BorrowLoc(__frame + 0);
+    call __t7 := BorrowLoc(__frame + 0, Vector_T_type_value(IntegerType()));
 
     call __t8 := Vector_pop_back(IntegerType(), __t7);
     if (__abort_flag) {
@@ -228,7 +232,7 @@ ensures b#Boolean(Boolean(IsEqual(__ret0, __ret1)));
       assume $DebugTrackAbort(1, 2, 949);
       goto Label_Abort;
     }
-    assume is#Vector(__t2);
+    assume $Vector_T_is_well_formed(__t2);
 
     __m := UpdateLocal(__m, __frame + 2, __t2);
 
@@ -241,7 +245,7 @@ ensures b#Boolean(Boolean(IsEqual(__ret0, __ret1)));
       assume $DebugTrackAbort(1, 2, 984);
       goto Label_Abort;
     }
-    assume is#Vector(__t3);
+    assume $Vector_T_is_well_formed(__t3);
 
     __m := UpdateLocal(__m, __frame + 3, __t3);
 
@@ -249,7 +253,7 @@ ensures b#Boolean(Boolean(IsEqual(__ret0, __ret1)));
     __m := UpdateLocal(__m, __frame + 1, __tmp);
     assume $DebugTrackLocal(1, 2, 1, 978, __tmp);
 
-    call __t4 := BorrowLoc(__frame + 0);
+    call __t4 := BorrowLoc(__frame + 0, Vector_T_type_value(IntegerType()));
 
     call __tmp := LdConst(1);
     __m := UpdateLocal(__m, __frame + 5, __tmp);
@@ -262,7 +266,7 @@ ensures b#Boolean(Boolean(IsEqual(__ret0, __ret1)));
     assume $DebugTrackLocal(1, 2, 0, 1013, GetLocal(__m, __frame + 0));
     assume $DebugTrackLocal(1, 2, 1, 1013, GetLocal(__m, __frame + 1));
 
-    call __t6 := BorrowLoc(__frame + 1);
+    call __t6 := BorrowLoc(__frame + 1, Vector_T_type_value(IntegerType()));
 
     call __tmp := LdConst(1);
     __m := UpdateLocal(__m, __frame + 7, __tmp);
@@ -337,7 +341,7 @@ ensures b#Boolean(Boolean(!IsEqual(__ret0, __ret1)));
       assume $DebugTrackAbort(1, 3, 1339);
       goto Label_Abort;
     }
-    assume is#Vector(__t2);
+    assume $Vector_T_is_well_formed(__t2);
 
     __m := UpdateLocal(__m, __frame + 2, __t2);
 
@@ -350,7 +354,7 @@ ensures b#Boolean(Boolean(!IsEqual(__ret0, __ret1)));
       assume $DebugTrackAbort(1, 3, 1374);
       goto Label_Abort;
     }
-    assume is#Vector(__t3);
+    assume $Vector_T_is_well_formed(__t3);
 
     __m := UpdateLocal(__m, __frame + 3, __t3);
 
@@ -358,7 +362,7 @@ ensures b#Boolean(Boolean(!IsEqual(__ret0, __ret1)));
     __m := UpdateLocal(__m, __frame + 1, __tmp);
     assume $DebugTrackLocal(1, 3, 1, 1368, __tmp);
 
-    call __t4 := BorrowLoc(__frame + 0);
+    call __t4 := BorrowLoc(__frame + 0, Vector_T_type_value(IntegerType()));
 
     call __tmp := LdConst(1);
     __m := UpdateLocal(__m, __frame + 5, __tmp);
@@ -371,7 +375,7 @@ ensures b#Boolean(Boolean(!IsEqual(__ret0, __ret1)));
     assume $DebugTrackLocal(1, 3, 0, 1403, GetLocal(__m, __frame + 0));
     assume $DebugTrackLocal(1, 3, 1, 1403, GetLocal(__m, __frame + 1));
 
-    call __t6 := BorrowLoc(__frame + 0);
+    call __t6 := BorrowLoc(__frame + 0, Vector_T_type_value(IntegerType()));
 
     call __tmp := LdConst(2);
     __m := UpdateLocal(__m, __frame + 7, __tmp);
@@ -384,7 +388,7 @@ ensures b#Boolean(Boolean(!IsEqual(__ret0, __ret1)));
     assume $DebugTrackLocal(1, 3, 0, 1447, GetLocal(__m, __frame + 0));
     assume $DebugTrackLocal(1, 3, 1, 1447, GetLocal(__m, __frame + 1));
 
-    call __t8 := BorrowLoc(__frame + 1);
+    call __t8 := BorrowLoc(__frame + 1, Vector_T_type_value(IntegerType()));
 
     call __tmp := LdConst(1);
     __m := UpdateLocal(__m, __frame + 9, __tmp);
@@ -457,7 +461,7 @@ ensures b#Boolean(Boolean(!IsEqual(__ret0, __ret1)));
       assume $DebugTrackAbort(1, 4, 1771);
       goto Label_Abort;
     }
-    assume is#Vector(__t2);
+    assume $Vector_T_is_well_formed(__t2);
 
     __m := UpdateLocal(__m, __frame + 2, __t2);
 
@@ -470,7 +474,7 @@ ensures b#Boolean(Boolean(!IsEqual(__ret0, __ret1)));
       assume $DebugTrackAbort(1, 4, 1806);
       goto Label_Abort;
     }
-    assume is#Vector(__t3);
+    assume $Vector_T_is_well_formed(__t3);
 
     __m := UpdateLocal(__m, __frame + 3, __t3);
 
@@ -478,7 +482,7 @@ ensures b#Boolean(Boolean(!IsEqual(__ret0, __ret1)));
     __m := UpdateLocal(__m, __frame + 1, __tmp);
     assume $DebugTrackLocal(1, 4, 1, 1800, __tmp);
 
-    call __t4 := BorrowLoc(__frame + 0);
+    call __t4 := BorrowLoc(__frame + 0, Vector_T_type_value(IntegerType()));
 
     call __tmp := LdConst(1);
     __m := UpdateLocal(__m, __frame + 5, __tmp);
@@ -491,7 +495,7 @@ ensures b#Boolean(Boolean(!IsEqual(__ret0, __ret1)));
     assume $DebugTrackLocal(1, 4, 0, 1835, GetLocal(__m, __frame + 0));
     assume $DebugTrackLocal(1, 4, 1, 1835, GetLocal(__m, __frame + 1));
 
-    call __t6 := BorrowLoc(__frame + 1);
+    call __t6 := BorrowLoc(__frame + 1, Vector_T_type_value(IntegerType()));
 
     call __tmp := LdConst(0);
     __m := UpdateLocal(__m, __frame + 7, __tmp);
@@ -561,7 +565,7 @@ ensures b#Boolean(Boolean(IsEqual(__ret0, __ret1)));
       assume $DebugTrackAbort(1, 5, 2169);
       goto Label_Abort;
     }
-    assume is#Vector(__t2);
+    assume $Vector_T_is_well_formed(__t2);
 
     __m := UpdateLocal(__m, __frame + 2, __t2);
 
@@ -574,7 +578,7 @@ ensures b#Boolean(Boolean(IsEqual(__ret0, __ret1)));
       assume $DebugTrackAbort(1, 5, 2204);
       goto Label_Abort;
     }
-    assume is#Vector(__t3);
+    assume $Vector_T_is_well_formed(__t3);
 
     __m := UpdateLocal(__m, __frame + 3, __t3);
 
@@ -582,7 +586,7 @@ ensures b#Boolean(Boolean(IsEqual(__ret0, __ret1)));
     __m := UpdateLocal(__m, __frame + 1, __tmp);
     assume $DebugTrackLocal(1, 5, 1, 2198, __tmp);
 
-    call __t4 := BorrowLoc(__frame + 0);
+    call __t4 := BorrowLoc(__frame + 0, Vector_T_type_value(IntegerType()));
 
     call Vector_reverse(IntegerType(), __t4);
     if (__abort_flag) {
@@ -656,7 +660,7 @@ ensures b#Boolean(Boolean(IsEqual(__ret0, __ret1)));
       assume $DebugTrackAbort(1, 6, 2524);
       goto Label_Abort;
     }
-    assume is#Vector(__t2);
+    assume $Vector_T_is_well_formed(__t2);
 
     __m := UpdateLocal(__m, __frame + 2, __t2);
 
@@ -669,7 +673,7 @@ ensures b#Boolean(Boolean(IsEqual(__ret0, __ret1)));
       assume $DebugTrackAbort(1, 6, 2559);
       goto Label_Abort;
     }
-    assume is#Vector(__t3);
+    assume $Vector_T_is_well_formed(__t3);
 
     __m := UpdateLocal(__m, __frame + 3, __t3);
 
@@ -677,7 +681,7 @@ ensures b#Boolean(Boolean(IsEqual(__ret0, __ret1)));
     __m := UpdateLocal(__m, __frame + 1, __tmp);
     assume $DebugTrackLocal(1, 6, 1, 2553, __tmp);
 
-    call __t4 := BorrowLoc(__frame + 0);
+    call __t4 := BorrowLoc(__frame + 0, Vector_T_type_value(IntegerType()));
 
     call __tmp := LdConst(1);
     __m := UpdateLocal(__m, __frame + 5, __tmp);
@@ -690,7 +694,7 @@ ensures b#Boolean(Boolean(IsEqual(__ret0, __ret1)));
     assume $DebugTrackLocal(1, 6, 0, 2588, GetLocal(__m, __frame + 0));
     assume $DebugTrackLocal(1, 6, 1, 2588, GetLocal(__m, __frame + 1));
 
-    call __t6 := BorrowLoc(__frame + 0);
+    call __t6 := BorrowLoc(__frame + 0, Vector_T_type_value(IntegerType()));
 
     call __tmp := LdConst(2);
     __m := UpdateLocal(__m, __frame + 7, __tmp);
@@ -703,7 +707,7 @@ ensures b#Boolean(Boolean(IsEqual(__ret0, __ret1)));
     assume $DebugTrackLocal(1, 6, 0, 2632, GetLocal(__m, __frame + 0));
     assume $DebugTrackLocal(1, 6, 1, 2632, GetLocal(__m, __frame + 1));
 
-    call __t8 := BorrowLoc(__frame + 1);
+    call __t8 := BorrowLoc(__frame + 1, Vector_T_type_value(IntegerType()));
 
     call __tmp := LdConst(2);
     __m := UpdateLocal(__m, __frame + 9, __tmp);
@@ -716,7 +720,7 @@ ensures b#Boolean(Boolean(IsEqual(__ret0, __ret1)));
     assume $DebugTrackLocal(1, 6, 0, 2676, GetLocal(__m, __frame + 0));
     assume $DebugTrackLocal(1, 6, 1, 2676, GetLocal(__m, __frame + 1));
 
-    call __t10 := BorrowLoc(__frame + 1);
+    call __t10 := BorrowLoc(__frame + 1, Vector_T_type_value(IntegerType()));
 
     call __tmp := LdConst(1);
     __m := UpdateLocal(__m, __frame + 11, __tmp);
@@ -729,7 +733,7 @@ ensures b#Boolean(Boolean(IsEqual(__ret0, __ret1)));
     assume $DebugTrackLocal(1, 6, 0, 2720, GetLocal(__m, __frame + 0));
     assume $DebugTrackLocal(1, 6, 1, 2720, GetLocal(__m, __frame + 1));
 
-    call __t12 := BorrowLoc(__frame + 0);
+    call __t12 := BorrowLoc(__frame + 0, Vector_T_type_value(IntegerType()));
 
     call Vector_reverse(IntegerType(), __t12);
     if (__abort_flag) {
@@ -798,7 +802,7 @@ ensures old(b#Boolean(Boolean(true))) ==> __abort_flag;
       assume $DebugTrackAbort(1, 7, 3028);
       goto Label_Abort;
     }
-    assume is#Vector(__t1);
+    assume $Vector_T_is_well_formed(__t1);
 
     __m := UpdateLocal(__m, __frame + 1, __t1);
 
@@ -806,7 +810,7 @@ ensures old(b#Boolean(Boolean(true))) ==> __abort_flag;
     __m := UpdateLocal(__m, __frame + 0, __tmp);
     assume $DebugTrackLocal(1, 7, 0, 3022, __tmp);
 
-    call __t2 := BorrowLoc(__frame + 0);
+    call __t2 := BorrowLoc(__frame + 0, Vector_T_type_value(IntegerType()));
 
     call __tmp := LdConst(0);
     __m := UpdateLocal(__m, __frame + 3, __tmp);
@@ -818,7 +822,7 @@ ensures old(b#Boolean(Boolean(true))) ==> __abort_flag;
     }
     assume $DebugTrackLocal(1, 7, 0, 3057, GetLocal(__m, __frame + 0));
 
-    call __t4 := BorrowLoc(__frame + 0);
+    call __t4 := BorrowLoc(__frame + 0, Vector_T_type_value(IntegerType()));
 
     call __tmp := LdConst(1);
     __m := UpdateLocal(__m, __frame + 5, __tmp);
@@ -880,7 +884,7 @@ ensures old(b#Boolean(Boolean(true))) ==> __abort_flag;
       assume $DebugTrackAbort(1, 8, 3346);
       goto Label_Abort;
     }
-    assume is#Vector(__t1);
+    assume $Vector_T_is_well_formed(__t1);
 
     __m := UpdateLocal(__m, __frame + 1, __t1);
 
@@ -888,7 +892,7 @@ ensures old(b#Boolean(Boolean(true))) ==> __abort_flag;
     __m := UpdateLocal(__m, __frame + 0, __tmp);
     assume $DebugTrackLocal(1, 8, 0, 3340, __tmp);
 
-    call __t2 := BorrowLoc(__frame + 0);
+    call __t2 := BorrowLoc(__frame + 0, Vector_T_type_value(IntegerType()));
 
     call __tmp := LdConst(0);
     __m := UpdateLocal(__m, __frame + 3, __tmp);
@@ -900,7 +904,7 @@ ensures old(b#Boolean(Boolean(true))) ==> __abort_flag;
     }
     assume $DebugTrackLocal(1, 8, 0, 3375, GetLocal(__m, __frame + 0));
 
-    call __t4 := BorrowLoc(__frame + 0);
+    call __t4 := BorrowLoc(__frame + 0, Vector_T_type_value(IntegerType()));
 
     call __tmp := LdConst(0);
     __m := UpdateLocal(__m, __frame + 5, __tmp);
@@ -973,7 +977,7 @@ ensures b#Boolean(Boolean(IsEqual(__ret0, __ret1)));
       assume $DebugTrackAbort(1, 9, 3688);
       goto Label_Abort;
     }
-    assume is#Vector(__t2);
+    assume $Vector_T_is_well_formed(__t2);
 
     __m := UpdateLocal(__m, __frame + 2, __t2);
 
@@ -986,7 +990,7 @@ ensures b#Boolean(Boolean(IsEqual(__ret0, __ret1)));
       assume $DebugTrackAbort(1, 9, 3723);
       goto Label_Abort;
     }
-    assume is#Vector(__t3);
+    assume $Vector_T_is_well_formed(__t3);
 
     __m := UpdateLocal(__m, __frame + 3, __t3);
 
@@ -994,7 +998,7 @@ ensures b#Boolean(Boolean(IsEqual(__ret0, __ret1)));
     __m := UpdateLocal(__m, __frame + 1, __tmp);
     assume $DebugTrackLocal(1, 9, 1, 3717, __tmp);
 
-    call __t4 := BorrowLoc(__frame + 0);
+    call __t4 := BorrowLoc(__frame + 0, Vector_T_type_value(IntegerType()));
 
     call __tmp := LdConst(1);
     __m := UpdateLocal(__m, __frame + 5, __tmp);
@@ -1007,7 +1011,7 @@ ensures b#Boolean(Boolean(IsEqual(__ret0, __ret1)));
     assume $DebugTrackLocal(1, 9, 0, 3752, GetLocal(__m, __frame + 0));
     assume $DebugTrackLocal(1, 9, 1, 3752, GetLocal(__m, __frame + 1));
 
-    call __t6 := BorrowLoc(__frame + 0);
+    call __t6 := BorrowLoc(__frame + 0, Vector_T_type_value(IntegerType()));
 
     call __tmp := LdConst(2);
     __m := UpdateLocal(__m, __frame + 7, __tmp);
@@ -1020,7 +1024,7 @@ ensures b#Boolean(Boolean(IsEqual(__ret0, __ret1)));
     assume $DebugTrackLocal(1, 9, 0, 3796, GetLocal(__m, __frame + 0));
     assume $DebugTrackLocal(1, 9, 1, 3796, GetLocal(__m, __frame + 1));
 
-    call __t8 := BorrowLoc(__frame + 1);
+    call __t8 := BorrowLoc(__frame + 1, Vector_T_type_value(IntegerType()));
 
     call __tmp := LdConst(2);
     __m := UpdateLocal(__m, __frame + 9, __tmp);
@@ -1033,7 +1037,7 @@ ensures b#Boolean(Boolean(IsEqual(__ret0, __ret1)));
     assume $DebugTrackLocal(1, 9, 0, 3840, GetLocal(__m, __frame + 0));
     assume $DebugTrackLocal(1, 9, 1, 3840, GetLocal(__m, __frame + 1));
 
-    call __t10 := BorrowLoc(__frame + 1);
+    call __t10 := BorrowLoc(__frame + 1, Vector_T_type_value(IntegerType()));
 
     call __tmp := LdConst(1);
     __m := UpdateLocal(__m, __frame + 11, __tmp);
@@ -1046,7 +1050,7 @@ ensures b#Boolean(Boolean(IsEqual(__ret0, __ret1)));
     assume $DebugTrackLocal(1, 9, 0, 3884, GetLocal(__m, __frame + 0));
     assume $DebugTrackLocal(1, 9, 1, 3884, GetLocal(__m, __frame + 1));
 
-    call __t12 := BorrowLoc(__frame + 0);
+    call __t12 := BorrowLoc(__frame + 0, Vector_T_type_value(IntegerType()));
 
     call __tmp := LdConst(0);
     __m := UpdateLocal(__m, __frame + 13, __tmp);
@@ -1062,7 +1066,7 @@ ensures b#Boolean(Boolean(IsEqual(__ret0, __ret1)));
     assume $DebugTrackLocal(1, 9, 0, 3928, GetLocal(__m, __frame + 0));
     assume $DebugTrackLocal(1, 9, 1, 3928, GetLocal(__m, __frame + 1));
 
-    call __t15 := BorrowLoc(__frame + 0);
+    call __t15 := BorrowLoc(__frame + 0, Vector_T_type_value(IntegerType()));
 
     call __tmp := LdConst(0);
     __m := UpdateLocal(__m, __frame + 16, __tmp);
@@ -1138,7 +1142,7 @@ ensures b#Boolean(Boolean(IsEqual(__ret0, Integer(i#Integer(__ret1) + i#Integer(
       assume $DebugTrackAbort(1, 10, 4252);
       goto Label_Abort;
     }
-    assume is#Vector(__t2);
+    assume $Vector_T_is_well_formed(__t2);
 
     __m := UpdateLocal(__m, __frame + 2, __t2);
 
@@ -1151,7 +1155,7 @@ ensures b#Boolean(Boolean(IsEqual(__ret0, Integer(i#Integer(__ret1) + i#Integer(
       assume $DebugTrackAbort(1, 10, 4287);
       goto Label_Abort;
     }
-    assume is#Vector(__t3);
+    assume $Vector_T_is_well_formed(__t3);
 
     __m := UpdateLocal(__m, __frame + 3, __t3);
 
@@ -1159,7 +1163,7 @@ ensures b#Boolean(Boolean(IsEqual(__ret0, Integer(i#Integer(__ret1) + i#Integer(
     __m := UpdateLocal(__m, __frame + 1, __tmp);
     assume $DebugTrackLocal(1, 10, 1, 4281, __tmp);
 
-    call __t4 := BorrowLoc(__frame + 0);
+    call __t4 := BorrowLoc(__frame + 0, Vector_T_type_value(IntegerType()));
 
     call __tmp := LdConst(1);
     __m := UpdateLocal(__m, __frame + 5, __tmp);
@@ -1171,7 +1175,7 @@ ensures b#Boolean(Boolean(IsEqual(__ret0, Integer(i#Integer(__ret1) + i#Integer(
     }
     assume $DebugTrackLocal(1, 10, 0, 4316, GetLocal(__m, __frame + 0));
 
-    call __t6 := BorrowLoc(__frame + 0);
+    call __t6 := BorrowLoc(__frame + 0, Vector_T_type_value(IntegerType()));
 
     call __t7 := Vector_length(IntegerType(), __t6);
     if (__abort_flag) {
@@ -1182,7 +1186,7 @@ ensures b#Boolean(Boolean(IsEqual(__ret0, Integer(i#Integer(__ret1) + i#Integer(
 
     __m := UpdateLocal(__m, __frame + 7, __t7);
 
-    call __t8 := BorrowLoc(__frame + 1);
+    call __t8 := BorrowLoc(__frame + 1, Vector_T_type_value(IntegerType()));
 
     call __t9 := Vector_length(IntegerType(), __t8);
     if (__abort_flag) {
@@ -1241,7 +1245,7 @@ ensures b#Boolean(Boolean(IsEqual(Integer(i#Integer(__ret0) + i#Integer(Integer(
     __frame := __local_counter;
 
     // process and type check arguments
-    assume is#Vector(v);
+    assume $Vector_T_is_well_formed(v);
     __m := UpdateLocal(__m, __frame + 0, v);
     assume $DebugTrackLocal(1, 11, 0, 4491, v);
 
@@ -1249,7 +1253,7 @@ ensures b#Boolean(Boolean(IsEqual(Integer(i#Integer(__ret0) + i#Integer(Integer(
     __local_counter := __local_counter + 15;
 
     // bytecode translation starts here
-    call __t3 := BorrowLoc(__frame + 0);
+    call __t3 := BorrowLoc(__frame + 0, Vector_T_type_value(IntegerType()));
 
     call __t4 := Vector_length(IntegerType(), __t3);
     if (__abort_flag) {
@@ -1264,7 +1268,7 @@ ensures b#Boolean(Boolean(IsEqual(Integer(i#Integer(__ret0) + i#Integer(Integer(
     __m := UpdateLocal(__m, __frame + 1, __tmp);
     assume $DebugTrackLocal(1, 11, 1, 4628, __tmp);
 
-    call __t5 := BorrowLoc(__frame + 0);
+    call __t5 := BorrowLoc(__frame + 0, Vector_T_type_value(IntegerType()));
 
     call __tmp := LdConst(1);
     __m := UpdateLocal(__m, __frame + 6, __tmp);
@@ -1276,7 +1280,7 @@ ensures b#Boolean(Boolean(IsEqual(Integer(i#Integer(__ret0) + i#Integer(Integer(
     }
     assume $DebugTrackLocal(1, 11, 0, 4665, GetLocal(__m, __frame + 0));
 
-    call __t7 := BorrowLoc(__frame + 0);
+    call __t7 := BorrowLoc(__frame + 0, Vector_T_type_value(IntegerType()));
 
     call __tmp := LdConst(2);
     __m := UpdateLocal(__m, __frame + 8, __tmp);
@@ -1288,7 +1292,7 @@ ensures b#Boolean(Boolean(IsEqual(Integer(i#Integer(__ret0) + i#Integer(Integer(
     }
     assume $DebugTrackLocal(1, 11, 0, 4707, GetLocal(__m, __frame + 0));
 
-    call __t9 := BorrowLoc(__frame + 0);
+    call __t9 := BorrowLoc(__frame + 0, Vector_T_type_value(IntegerType()));
 
     call __tmp := LdConst(3);
     __m := UpdateLocal(__m, __frame + 10, __tmp);
@@ -1300,7 +1304,7 @@ ensures b#Boolean(Boolean(IsEqual(Integer(i#Integer(__ret0) + i#Integer(Integer(
     }
     assume $DebugTrackLocal(1, 11, 0, 4749, GetLocal(__m, __frame + 0));
 
-    call __t11 := BorrowLoc(__frame + 0);
+    call __t11 := BorrowLoc(__frame + 0, Vector_T_type_value(IntegerType()));
 
     call __t12 := Vector_length(IntegerType(), __t11);
     if (__abort_flag) {
@@ -1356,7 +1360,7 @@ ensures b#Boolean(Boolean(IsEqual(__ret0, old(v))));
     __frame := __local_counter;
 
     // process and type check arguments
-    assume is#Vector(v);
+    assume $Vector_T_is_well_formed(v);
     __m := UpdateLocal(__m, __frame + 0, v);
     assume $DebugTrackLocal(1, 12, 0, 4891, v);
 
@@ -1401,7 +1405,7 @@ ensures b#Boolean(Boolean(IsEqual(__ret0, old(v))));
     __frame := __local_counter;
 
     // process and type check arguments
-    assume is#Vector(v);
+    assume $Vector_T_is_well_formed(v);
     __m := UpdateLocal(__m, __frame + 0, v);
     assume $DebugTrackLocal(1, 13, 0, 5056, v);
 
@@ -1409,7 +1413,7 @@ ensures b#Boolean(Boolean(IsEqual(__ret0, old(v))));
     __local_counter := __local_counter + 4;
 
     // bytecode translation starts here
-    call __t1 := BorrowLoc(__frame + 0);
+    call __t1 := BorrowLoc(__frame + 0, Vector_T_type_value(IntegerType()));
 
     call Vector_reverse(IntegerType(), __t1);
     if (__abort_flag) {
@@ -1418,7 +1422,7 @@ ensures b#Boolean(Boolean(IsEqual(__ret0, old(v))));
     }
     assume $DebugTrackLocal(1, 13, 0, 5149, GetLocal(__m, __frame + 0));
 
-    call __t2 := BorrowLoc(__frame + 0);
+    call __t2 := BorrowLoc(__frame + 0, Vector_T_type_value(IntegerType()));
 
     call Vector_reverse(IntegerType(), __t2);
     if (__abort_flag) {
@@ -1478,7 +1482,7 @@ ensures b#Boolean(Boolean(IsEqual(__ret0, old(v))));
     __frame := __local_counter;
 
     // process and type check arguments
-    assume is#Vector(v);
+    assume $Vector_T_is_well_formed(v);
     __m := UpdateLocal(__m, __frame + 0, v);
     assume $DebugTrackLocal(1, 14, 0, 5316, v);
 
@@ -1486,7 +1490,7 @@ ensures b#Boolean(Boolean(IsEqual(__ret0, old(v))));
     __local_counter := __local_counter + 18;
 
     // bytecode translation starts here
-    call __t2 := BorrowLoc(__frame + 0);
+    call __t2 := BorrowLoc(__frame + 0, Vector_T_type_value(IntegerType()));
 
     call __t3 := Vector_length(IntegerType(), __t2);
     if (__abort_flag) {
@@ -1528,7 +1532,7 @@ Label_8:
     __tmp := GetLocal(__m, __frame + 9);
     if (!b#Boolean(__tmp)) { goto Label_19; }
 
-    call __t10 := BorrowLoc(__frame + 0);
+    call __t10 := BorrowLoc(__frame + 0, Vector_T_type_value(IntegerType()));
 
     call __tmp := LdConst(0);
     __m := UpdateLocal(__m, __frame + 11, __tmp);
@@ -1556,7 +1560,7 @@ Label_8:
     goto Label_21;
 
 Label_19:
-    call __t15 := BorrowLoc(__frame + 0);
+    call __t15 := BorrowLoc(__frame + 0, Vector_T_type_value(IntegerType()));
 
     call Vector_reverse(IntegerType(), __t15);
     if (__abort_flag) {
@@ -1566,7 +1570,7 @@ Label_19:
     assume $DebugTrackLocal(1, 14, 0, 5647, GetLocal(__m, __frame + 0));
 
 Label_21:
-    call __t16 := BorrowLoc(__frame + 0);
+    call __t16 := BorrowLoc(__frame + 0, Vector_T_type_value(IntegerType()));
 
     call Vector_reverse(IntegerType(), __t16);
     if (__abort_flag) {
@@ -1614,7 +1618,7 @@ ensures b#Boolean(Boolean(IsEqual(__ret0, old(v))));
     __frame := __local_counter;
 
     // process and type check arguments
-    assume is#Vector(v);
+    assume $Vector_T_is_well_formed(v);
     __m := UpdateLocal(__m, __frame + 0, v);
     assume $DebugTrackLocal(1, 15, 0, 5864, v);
 
@@ -1622,7 +1626,7 @@ ensures b#Boolean(Boolean(IsEqual(__ret0, old(v))));
     __local_counter := __local_counter + 6;
 
     // bytecode translation starts here
-    call __t1 := BorrowLoc(__frame + 0);
+    call __t1 := BorrowLoc(__frame + 0, Vector_T_type_value(IntegerType()));
 
     call __t2 := Vector_is_empty(IntegerType(), __t1);
     if (__abort_flag) {
@@ -1650,7 +1654,7 @@ ensures b#Boolean(Boolean(IsEqual(__ret0, old(v))));
       assume $DebugTrackAbort(1, 15, 6068);
       goto Label_Abort;
     }
-    assume is#Vector(__t4);
+    assume $Vector_T_is_well_formed(__t4);
 
     __m := UpdateLocal(__m, __frame + 4, __t4);
 
@@ -1701,7 +1705,7 @@ ensures old(b#Boolean(Boolean(true))) ==> __abort_flag;
     __frame := __local_counter;
 
     // process and type check arguments
-    assume is#Vector(v);
+    assume $Vector_T_is_well_formed(v);
     __m := UpdateLocal(__m, __frame + 0, v);
     assume $DebugTrackLocal(1, 16, 0, 6295, v);
 
@@ -1709,7 +1713,7 @@ ensures old(b#Boolean(Boolean(true))) ==> __abort_flag;
     __local_counter := __local_counter + 7;
 
     // bytecode translation starts here
-    call __t1 := BorrowLoc(__frame + 0);
+    call __t1 := BorrowLoc(__frame + 0, Vector_T_type_value(IntegerType()));
 
     call __t2 := Vector_is_empty(IntegerType(), __t1);
     if (__abort_flag) {
@@ -1723,7 +1727,7 @@ ensures old(b#Boolean(Boolean(true))) ==> __abort_flag;
     __tmp := GetLocal(__m, __frame + 2);
     if (!b#Boolean(__tmp)) { goto Label_8; }
 
-    call __t3 := BorrowLoc(__frame + 0);
+    call __t3 := BorrowLoc(__frame + 0, Vector_T_type_value(IntegerType()));
 
     call __tmp := LdConst(0);
     __m := UpdateLocal(__m, __frame + 4, __tmp);
@@ -1810,7 +1814,7 @@ ensures b#Boolean(Boolean(IsEqual(__ret0, __ret1)));
       assume $DebugTrackAbort(1, 17, 6762);
       goto Label_Abort;
     }
-    assume is#Vector(__t3);
+    assume $Vector_T_is_well_formed(__t3);
 
     __m := UpdateLocal(__m, __frame + 3, __t3);
 
@@ -1823,7 +1827,7 @@ ensures b#Boolean(Boolean(IsEqual(__ret0, __ret1)));
       assume $DebugTrackAbort(1, 17, 6797);
       goto Label_Abort;
     }
-    assume is#Vector(__t4);
+    assume $Vector_T_is_well_formed(__t4);
 
     __m := UpdateLocal(__m, __frame + 4, __t4);
 
@@ -1831,7 +1835,7 @@ ensures b#Boolean(Boolean(IsEqual(__ret0, __ret1)));
     __m := UpdateLocal(__m, __frame + 2, __tmp);
     assume $DebugTrackLocal(1, 17, 2, 6791, __tmp);
 
-    call __t5 := BorrowLoc(__frame + 1);
+    call __t5 := BorrowLoc(__frame + 1, Vector_T_type_value(IntegerType()));
 
     call __tmp := LdConst(1);
     __m := UpdateLocal(__m, __frame + 6, __tmp);
@@ -1844,7 +1848,7 @@ ensures b#Boolean(Boolean(IsEqual(__ret0, __ret1)));
     assume $DebugTrackLocal(1, 17, 1, 6826, GetLocal(__m, __frame + 1));
     assume $DebugTrackLocal(1, 17, 2, 6826, GetLocal(__m, __frame + 2));
 
-    call __t7 := BorrowLoc(__frame + 2);
+    call __t7 := BorrowLoc(__frame + 2, Vector_T_type_value(IntegerType()));
 
     call __tmp := LdConst(2);
     __m := UpdateLocal(__m, __frame + 8, __tmp);
@@ -1857,7 +1861,7 @@ ensures b#Boolean(Boolean(IsEqual(__ret0, __ret1)));
     assume $DebugTrackLocal(1, 17, 1, 6870, GetLocal(__m, __frame + 1));
     assume $DebugTrackLocal(1, 17, 2, 6870, GetLocal(__m, __frame + 2));
 
-    call __t9 := BorrowLoc(__frame + 1);
+    call __t9 := BorrowLoc(__frame + 1, Vector_T_type_value(IntegerType()));
 
     call __tmp := LdConst(0);
     __m := UpdateLocal(__m, __frame + 10, __tmp);
@@ -1873,12 +1877,12 @@ ensures b#Boolean(Boolean(IsEqual(__ret0, __ret1)));
     assume $DebugTrackLocal(1, 17, 1, 6914, GetLocal(__m, __frame + 1));
     assume $DebugTrackLocal(1, 17, 2, 6914, GetLocal(__m, __frame + 2));
 
-    call __t12 := BorrowLoc(__frame + 2);
+    call __t12 := BorrowLoc(__frame + 2, Vector_T_type_value(IntegerType()));
 
     call __tmp := LdConst(0);
     __m := UpdateLocal(__m, __frame + 13, __tmp);
 
-    call __t14 := BorrowLoc(__frame + 1);
+    call __t14 := BorrowLoc(__frame + 1, Vector_T_type_value(IntegerType()));
 
     call __tmp := LdConst(0);
     __m := UpdateLocal(__m, __frame + 15, __tmp);
@@ -1957,7 +1961,7 @@ ensures b#Boolean(Boolean(IsEqual(__ret0, Integer(7))));
       assume $DebugTrackAbort(1, 18, 7186);
       goto Label_Abort;
     }
-    assume is#Vector(__t1);
+    assume $Vector_T_is_well_formed(__t1);
 
     __m := UpdateLocal(__m, __frame + 1, __t1);
 
@@ -1965,7 +1969,7 @@ ensures b#Boolean(Boolean(IsEqual(__ret0, Integer(7))));
     __m := UpdateLocal(__m, __frame + 0, __tmp);
     assume $DebugTrackLocal(1, 18, 0, 7180, __tmp);
 
-    call __t2 := BorrowLoc(__frame + 0);
+    call __t2 := BorrowLoc(__frame + 0, Vector_T_type_value(IntegerType()));
 
     call __tmp := LdConst(7);
     __m := UpdateLocal(__m, __frame + 3, __tmp);
@@ -1977,7 +1981,7 @@ ensures b#Boolean(Boolean(IsEqual(__ret0, Integer(7))));
     }
     assume $DebugTrackLocal(1, 18, 0, 7215, GetLocal(__m, __frame + 0));
 
-    call __t4 := BorrowLoc(__frame + 0);
+    call __t4 := BorrowLoc(__frame + 0, Vector_T_type_value(IntegerType()));
 
     call __tmp := LdConst(0);
     __m := UpdateLocal(__m, __frame + 5, __tmp);
@@ -2042,7 +2046,7 @@ ensures old(b#Boolean(Boolean(true))) ==> __abort_flag;
       assume $DebugTrackAbort(1, 19, 7482);
       goto Label_Abort;
     }
-    assume is#Vector(__t2);
+    assume $Vector_T_is_well_formed(__t2);
 
     __m := UpdateLocal(__m, __frame + 2, __t2);
 
@@ -2050,7 +2054,7 @@ ensures old(b#Boolean(Boolean(true))) ==> __abort_flag;
     __m := UpdateLocal(__m, __frame + 1, __tmp);
     assume $DebugTrackLocal(1, 19, 1, 7476, __tmp);
 
-    call __t3 := BorrowLoc(__frame + 1);
+    call __t3 := BorrowLoc(__frame + 1, Vector_T_type_value(IntegerType()));
 
     call __tmp := LdConst(1);
     __m := UpdateLocal(__m, __frame + 4, __tmp);
@@ -2062,7 +2066,7 @@ ensures old(b#Boolean(Boolean(true))) ==> __abort_flag;
     }
     assume $DebugTrackLocal(1, 19, 1, 7511, GetLocal(__m, __frame + 1));
 
-    call __t5 := BorrowLoc(__frame + 1);
+    call __t5 := BorrowLoc(__frame + 1, Vector_T_type_value(IntegerType()));
 
     call __tmp := LdConst(1);
     __m := UpdateLocal(__m, __frame + 6, __tmp);
@@ -2129,7 +2133,7 @@ ensures b#Boolean(Boolean(IsEqual(__ret0, __ret1)));
       assume $DebugTrackAbort(1, 20, 7775);
       goto Label_Abort;
     }
-    assume is#Vector(__t2);
+    assume $Vector_T_is_well_formed(__t2);
 
     __m := UpdateLocal(__m, __frame + 2, __t2);
 
@@ -2137,7 +2141,7 @@ ensures b#Boolean(Boolean(IsEqual(__ret0, __ret1)));
     __m := UpdateLocal(__m, __frame + 0, __tmp);
     assume $DebugTrackLocal(1, 20, 0, 7769, __tmp);
 
-    call __t3 := BorrowLoc(__frame + 0);
+    call __t3 := BorrowLoc(__frame + 0, Vector_T_type_value(IntegerType()));
 
     call __tmp := LdConst(7);
     __m := UpdateLocal(__m, __frame + 4, __tmp);
@@ -2149,7 +2153,7 @@ ensures b#Boolean(Boolean(IsEqual(__ret0, __ret1)));
     }
     assume $DebugTrackLocal(1, 20, 0, 7804, GetLocal(__m, __frame + 0));
 
-    call __t5 := BorrowLoc(__frame + 0);
+    call __t5 := BorrowLoc(__frame + 0, Vector_T_type_value(IntegerType()));
 
     call __tmp := LdConst(0);
     __m := UpdateLocal(__m, __frame + 6, __tmp);
@@ -2159,8 +2163,7 @@ ensures b#Boolean(Boolean(IsEqual(__ret0, __ret1)));
       assume $DebugTrackAbort(1, 20, 7852);
       goto Label_Abort;
     }
-    assume IsValidU64(Dereference(__m, __t7));
-    assume IsValidReferenceParameter(__m, __local_counter, __t7);
+    assume IsValidU64(Dereference(__m, __t7)) && IsValidReferenceParameter(__m, __local_counter, __t7);
 
 
 
@@ -2235,7 +2238,7 @@ ensures old(b#Boolean(Boolean(true))) ==> __abort_flag;
       assume $DebugTrackAbort(1, 21, 8135);
       goto Label_Abort;
     }
-    assume is#Vector(__t2);
+    assume $Vector_T_is_well_formed(__t2);
 
     __m := UpdateLocal(__m, __frame + 2, __t2);
 
@@ -2243,7 +2246,7 @@ ensures old(b#Boolean(Boolean(true))) ==> __abort_flag;
     __m := UpdateLocal(__m, __frame + 0, __tmp);
     assume $DebugTrackLocal(1, 21, 0, 8129, __tmp);
 
-    call __t3 := BorrowLoc(__frame + 0);
+    call __t3 := BorrowLoc(__frame + 0, Vector_T_type_value(IntegerType()));
 
     call __tmp := LdConst(7);
     __m := UpdateLocal(__m, __frame + 4, __tmp);
@@ -2255,7 +2258,7 @@ ensures old(b#Boolean(Boolean(true))) ==> __abort_flag;
     }
     assume $DebugTrackLocal(1, 21, 0, 8164, GetLocal(__m, __frame + 0));
 
-    call __t5 := BorrowLoc(__frame + 0);
+    call __t5 := BorrowLoc(__frame + 0, Vector_T_type_value(IntegerType()));
 
     call __tmp := LdConst(1);
     __m := UpdateLocal(__m, __frame + 6, __tmp);
@@ -2265,8 +2268,7 @@ ensures old(b#Boolean(Boolean(true))) ==> __abort_flag;
       assume $DebugTrackAbort(1, 21, 8212);
       goto Label_Abort;
     }
-    assume IsValidU64(Dereference(__m, __t7));
-    assume IsValidReferenceParameter(__m, __local_counter, __t7);
+    assume IsValidU64(Dereference(__m, __t7)) && IsValidReferenceParameter(__m, __local_counter, __t7);
 
 
 
@@ -2338,7 +2340,7 @@ ensures b#Boolean(Boolean(IsEqual(__ret0, __ret1)));
       assume $DebugTrackAbort(1, 22, 8496);
       goto Label_Abort;
     }
-    assume is#Vector(__t2);
+    assume $Vector_T_is_well_formed(__t2);
 
     __m := UpdateLocal(__m, __frame + 2, __t2);
 
@@ -2346,7 +2348,7 @@ ensures b#Boolean(Boolean(IsEqual(__ret0, __ret1)));
     __m := UpdateLocal(__m, __frame + 0, __tmp);
     assume $DebugTrackLocal(1, 22, 0, 8490, __tmp);
 
-    call __t3 := BorrowLoc(__frame + 0);
+    call __t3 := BorrowLoc(__frame + 0, Vector_T_type_value(IntegerType()));
 
     call __tmp := LdConst(7);
     __m := UpdateLocal(__m, __frame + 4, __tmp);
@@ -2358,7 +2360,7 @@ ensures b#Boolean(Boolean(IsEqual(__ret0, __ret1)));
     }
     assume $DebugTrackLocal(1, 22, 0, 8525, GetLocal(__m, __frame + 0));
 
-    call __t5 := BorrowLoc(__frame + 0);
+    call __t5 := BorrowLoc(__frame + 0, Vector_T_type_value(IntegerType()));
 
     call __tmp := LdConst(0);
     __m := UpdateLocal(__m, __frame + 6, __tmp);
@@ -2368,8 +2370,7 @@ ensures b#Boolean(Boolean(IsEqual(__ret0, __ret1)));
       assume $DebugTrackAbort(1, 22, 8573);
       goto Label_Abort;
     }
-    assume IsValidU64(Dereference(__m, __t7));
-    assume IsValidReferenceParameter(__m, __local_counter, __t7);
+    assume IsValidU64(Dereference(__m, __t7)) && IsValidReferenceParameter(__m, __local_counter, __t7);
 
 
 

--- a/language/move-prover/bytecode-to-boogie/tests/prover_tests.rs
+++ b/language/move-prover/bytecode-to-boogie/tests/prover_tests.rs
@@ -69,3 +69,13 @@ fn verify_libra_account() {
         ],
     )
 }
+
+#[test]
+fn verify_invariants() {
+    test(VERIFY, &["test_mvir/verify-invariants.mvir"]);
+}
+
+#[test]
+fn verify_synthetics() {
+    test(VERIFY, &["test_mvir/verify-synthetics.mvir"]);
+}


### PR DESCRIPTION
This PR provides the initial implementation of data invariants and global synthetic variables to be used in specifications.

Each struct or resource can have a number of invariants associated, for example:

```
struct T {
   i: u64,
   invariant {data} i > 0,
   invariant {update} i > old(i)
}
```

Here, the `{data}` invariant denotes a classical invariant which must hold for every instance. The `{update}` variant is something novel: it must hold for each _modification_ of an instance. That is, whenever a reference to `T` is written to (directly or via a path), this invariant is checked.

Synthetic (ghost) variables allow to record information about resoure evolution. In the below example, we are tracking the sum of values found in living instances of `T`:

```
synthetic sum: u64;

struct T {
   i: u64,
   invariant {pack} sum = sum + i;
   invariant {unpack} sum = sum - i;
   invariant {update} sum = sum - old(i) + i;
}
```

Synthetics can then be used in pre/post conditions or other invariants to formulate conditions.

## Implementation

The implementation is based on injecting according code into the pack/unpack procedures generated for each struct T.

For checking update invariants, there are two models implemented which can be controlled via the new flag `--invariant-model`.

The first update invariant implementation is activated via `--invariant-model=lifetime` (default). In this case, update invariants are checked if a mutual reference to a struct leaves scope, i.e. is destroyed.

The other implementation model is activated by `--invariant_model=writeref`. Here the invariant is enforced on each WriteRef.  This is complicated because of the presence of mutual references pointing to struct fields.

To deal with those, the boogie encoding was slightly extended. For each reference r, we now have a function `RootReference(r)` and `RootReferenceType(r)`. The former erases the path from a reference, the later delivers the type of the root value. On update (WriteRef), we then emit code like this:

```
var after: Value;
var before: Value;

before := Dereference(_m, RootReference(r));
<<update>>
after := Dereference(__m, RootReference(r));

if (RootReferenceType(r) == S1_type) {
  <S1_invariants>(before, after);
}
if (RootReferenceType(r) == S2_type) {
  <S2_invariants>(before, after);
}
... and so on ...
```

Which types we need to check for can be determined by a reaching definition analysis. Currently we check for all types in the program, which is indeed not scaling.

## Motivation

Increase expressiveness of specs.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

Added new tests.

## Related PRs

NA
