### PR TITLE
[vm] Add assertion for discarded transaction.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1421,6 +1421,7 @@ dependencies = [
  "libra-crypto 0.1.0",
  "libra-state-view 0.1.0",
  "libra-types 0.1.0",
+ "mirai-annotations 1.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "once_cell 1.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "regex 1.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "termcolor 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/language/functional-tests/Cargo.toml
+++ b/language/functional-tests/Cargo.toml
@@ -24,3 +24,4 @@ thiserror = "1.0"
 aho-corasick = "0.7.6"
 termcolor = "1.0.5"
 datatest-stable = { path = "../../common/datatest-stable", version = "0.1.0" }
+mirai-annotations = "1.6.0"

--- a/language/functional-tests/src/evaluator.rs
+++ b/language/functional-tests/src/evaluator.rs
@@ -23,6 +23,7 @@ use libra_types::{
     },
     vm_error::{StatusCode, VMStatus},
 };
+use mirai_annotations::checked_verify;
 use std::{
     fmt::{self, Debug},
     str::FromStr,
@@ -343,7 +344,10 @@ fn run_transaction(
                     Err(ErrorKind::VMExecutionFailure(output).into())
                 }
             }
-            TransactionStatus::Discard(_) => Err(ErrorKind::DiscardedTransaction(output).into()),
+            TransactionStatus::Discard(_) => {
+                checked_verify!(output.write_set().is_empty());
+                Err(ErrorKind::DiscardedTransaction(output).into())
+            }
         }
     } else {
         unreachable!("transaction outputs size mismatch")


### PR DESCRIPTION
<!--
Thank you for sending a PR. We appreciate you spending time to help improve the Libra project.

The project is undergoing daily changes. Pull Requests will be reviewed and responded to as time permits.
-->

## Motivation

Add an extra assertion in Move functional test to enforce all discarded transaction should have an empty writeset.
 
### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?

Yes