### PR TITLE
[move source language] Translated IR borrow_tests. Fixed many bugs

### DIFF
--- a/language/benchmarks/src/bench.move
+++ b/language/benchmarks/src/bench.move
@@ -7,14 +7,14 @@ module Bench {
     //
     // Global helpers
     //
-    assert(check: bool, code: u64) {
+    fun assert(check: bool, code: u64) {
         if (check) () else abort code
     }
 
     //
     // `arith` benchmark
     //
-    public arith() {
+    public fun arith() {
         let i = 0;
         // 10000 is the number of loops to make the benchmark run for a couple of minutes, which is an eternity.
         // Adjust according to your needs, it's just a reference
@@ -33,7 +33,7 @@ module Bench {
     //
     // `call` benchmark
     //
-    public call() {
+    public fun call() {
         let i = 0;
         // 3000 is the number of loops to make the benchmark run for a couple of minutes, which is an eternity.
         // Adjust according to your needs, it's just a reference
@@ -44,30 +44,30 @@ module Bench {
         };
     }
 
-    call_1(addr: address, val: u64): bool {
+    fun call_1(addr: address, val: u64): bool {
         let b = call_1_1(&addr);
         call_1_2(val, val);
         b
     }
 
-    call_1_1(addr: &address): bool {
+    fun call_1_1(addr: &address): bool {
         true
     }
 
-    call_1_2(val1: u64, val2: u64): bool {
+    fun call_1_2(val1: u64, val2: u64): bool {
         val1 == val2
     }
 
-    call_2(b: bool) {
+    fun call_2(b: bool) {
         call_2_1(b);
         assert(call_2_2() == 400, 200);
     }
 
-    call_2_1(b: bool) {
+    fun call_2_1(b: bool) {
         assert(b == b, 100)
     }
 
-    call_2_2(): u64 {
+    fun call_2_2(): u64 {
         100 + 300
     }
 }

--- a/language/move-lang/src/cfgir/locals/state.rs
+++ b/language/move-lang/src/cfgir/locals/state.rs
@@ -18,6 +18,15 @@ pub enum LocalState {
     MaybeUnavailable { available: Loc, unavailable: Loc },
 }
 
+impl LocalState {
+    pub fn is_available(&self) -> bool {
+        match self {
+            LocalState::Available(_) => true,
+            LocalState::Unavailable(_) | LocalState::MaybeUnavailable { .. } => false,
+        }
+    }
+}
+
 #[derive(Clone)]
 pub struct LocalStates {
     local_states: UniqueMap<Var, LocalState>,

--- a/language/move-lang/src/cfgir/mod.rs
+++ b/language/move-lang/src/cfgir/mod.rs
@@ -12,7 +12,10 @@ mod remove_no_ops;
 pub mod translate;
 
 use crate::shared::unique_map::UniqueMap;
-use crate::{errors::Errors, parser::ast::Var};
+use crate::{
+    errors::Errors,
+    parser::ast::{StructName, Var},
+};
 use ast::*;
 use cfg::*;
 use std::collections::BTreeSet;
@@ -20,22 +23,23 @@ use std::collections::BTreeSet;
 pub fn refine_inference_and_verify(
     errors: &mut Errors,
     signature: &FunctionSignature,
+    acquires: &BTreeSet<StructName>,
     locals: &UniqueMap<Var, SingleType>,
     cfg: &mut BlockCFG,
     infinite_loop_starts: &BTreeSet<Label>,
 ) {
     remove_no_ops::optimize(cfg);
-    liveness::refine_inference_and_verify(errors, signature, locals, cfg, infinite_loop_starts);
-}
-
-pub fn verify(
-    errors: &mut Errors,
-    signature: &FunctionSignature,
-    locals: &UniqueMap<Var, SingleType>,
-    cfg: &BlockCFG,
-) {
-    locals::verify(errors, signature, locals, cfg);
-    borrows::verify(errors, signature, locals, cfg)
+    let liveness_states = liveness::refine_inference_and_verify(
+        errors,
+        signature,
+        acquires,
+        locals,
+        cfg,
+        infinite_loop_starts,
+    );
+    let locals_states = locals::verify(errors, signature, acquires, locals, cfg);
+    liveness::release_dead_refs(locals, cfg, &liveness_states, &locals_states);
+    borrows::verify(errors, signature, acquires, locals, cfg);
 }
 
 pub fn optimize(

--- a/language/move-lang/src/cfgir/translate.rs
+++ b/language/move-lang/src/cfgir/translate.rs
@@ -126,7 +126,7 @@ fn function(context: &mut Context, _name: FunctionName, f: H::Function) -> G::Fu
     let visibility = f.visibility;
     let signature = function_signature(context, f.signature);
     let acquires = f.acquires;
-    let body = function_body(context, &signature, f.body);
+    let body = function_body(context, &signature, &acquires, f.body);
     G::Function {
         visibility,
         signature,
@@ -153,6 +153,7 @@ fn function_signature(context: &mut Context, sig: H::FunctionSignature) -> G::Fu
 fn function_body(
     context: &mut Context,
     signature: &G::FunctionSignature,
+    acquires: &BTreeSet<StructName>,
     sp!(loc, tb_): H::FunctionBody,
 ) -> G::FunctionBody {
     use G::FunctionBody_ as GB;
@@ -178,11 +179,11 @@ fn function_body(
             cfgir::refine_inference_and_verify(
                 &mut context.errors,
                 signature,
+                acquires,
                 &locals,
                 &mut cfg,
                 &infinite_loop_starts,
             );
-            cfgir::verify(&mut context.errors, signature, &locals, &cfg);
             cfgir::optimize(signature, &locals, &mut cfg);
 
             GB::Defined {

--- a/language/move-lang/src/typing/core.rs
+++ b/language/move-lang/src/typing/core.rs
@@ -57,6 +57,7 @@ pub struct Context {
     pub modules: UniqueMap<ModuleIdent, ModuleInfo>,
 
     pub current_module: Option<ModuleIdent>,
+    pub current_function: Option<FunctionName>,
     pub return_type: Option<Type>,
     pub locals: UniqueMap<Var, LocalStatus>,
 
@@ -84,6 +85,7 @@ impl Context {
         Context {
             subst: Subst::new(),
             current_module: None,
+            current_function: None,
             return_type: None,
             constraints: vec![],
             errors,

--- a/language/move-lang/src/typing/globals.rs
+++ b/language/move-lang/src/typing/globals.rs
@@ -91,6 +91,10 @@ fn exp(
         | E::Continue
         | E::UnresolvedError => (),
 
+        E::ModuleCall(call) if is_current_function(context, call) => {
+            exp(context, annotated_acquires, seen, &call.arguments);
+        }
+
         E::ModuleCall(call) => {
             let loc = e.exp.loc;
             let acquires = call
@@ -170,6 +174,13 @@ fn exp_list_item(
         I::Single(e, _) | I::Splat(_, e, _) => {
             exp(context, annotated_acquires, seen, e);
         }
+    }
+}
+
+fn is_current_function(context: &Context, call: &T::ModuleCall) -> bool {
+    match (&context.current_module, &context.current_function) {
+        (Some(m), Some(f)) => m == &call.module && f == &call.name,
+        _ => false,
     }
 }
 

--- a/language/move-lang/src/typing/translate.rs
+++ b/language/move-lang/src/typing/translate.rs
@@ -75,7 +75,8 @@ fn main_function(
 // Functions
 //**************************************************************************************************
 
-fn function(context: &mut Context, _name: FunctionName, f: N::Function) -> T::Function {
+fn function(context: &mut Context, name: FunctionName, f: N::Function) -> T::Function {
+    context.current_function = Some(name);
     let N::Function {
         visibility,
         mut signature,
@@ -89,7 +90,7 @@ fn function(context: &mut Context, _name: FunctionName, f: N::Function) -> T::Fu
     expand::function_signature(context, &mut signature);
 
     let body = function_body(context, &acquires, n_body);
-
+    context.current_function = None;
     T::Function {
         visibility,
         signature,

--- a/language/move-lang/tests/functional/translated_ir_tests/borrow_tests/borrow_copy_ok.move
+++ b/language/move-lang/tests/functional/translated_ir_tests/borrow_tests/borrow_copy_ok.move
@@ -1,0 +1,21 @@
+module B {
+    struct T {g: u64}
+
+    public fun new(g: u64): T {
+        T { g }
+    }
+
+    public fun t(this: &T) {
+        let g = &this.g;
+        *g;
+    }
+}
+
+//! new-transaction
+
+use {{default}}::B;
+
+fun main() {
+    let x = B::new(5);
+    B::t(&x);
+}

--- a/language/move-lang/tests/functional/translated_ir_tests/borrow_tests/borrow_field_ok.move
+++ b/language/move-lang/tests/functional/translated_ir_tests/borrow_tests/borrow_field_ok.move
@@ -1,0 +1,29 @@
+module A {
+
+    struct T{v: u64}
+
+    struct K{f: T}
+
+    public fun new_T(v: u64) : T {
+        T { v }
+    }
+
+    public fun new_K(f: T) : K {
+        K { f }
+    }
+
+    public fun value(this: &K) : u64 {
+        this.f.v
+    }
+}
+
+//! new-transaction
+
+use {{default}}::A;
+
+fun main() {
+    let x = A::new_T(2);
+    let y = A::new_K(x);
+    let z = A::value(&y);
+    0x0::Transaction::assert(z == 2, 42);
+}

--- a/language/move-lang/tests/functional/translated_ir_tests/borrow_tests/borrow_local_bad.move
+++ b/language/move-lang/tests/functional/translated_ir_tests/borrow_tests/borrow_local_bad.move
@@ -1,0 +1,20 @@
+module A {
+    struct T{v: u64}
+
+    public fun new(v: u64): T {
+        T { v }
+    }
+
+    public fun value(this: T): u64 {
+        this.v
+    }
+}
+
+//! new-transaction
+
+use {{default}}::A;
+fun main() {
+    let x = A::new(5);
+    let x_ref = A::value(x);
+    0x0::Transaction::assert(x_ref == 5, 42);
+}

--- a/language/move-lang/tests/functional/translated_ir_tests/borrow_tests/borrow_move_ok.move
+++ b/language/move-lang/tests/functional/translated_ir_tests/borrow_tests/borrow_move_ok.move
@@ -1,0 +1,24 @@
+module M {
+    struct T{v: u64}
+
+    public fun new(v: u64) : T {
+        T { v }
+    }
+
+    public fun value(this: &T) : u64 {
+        //borrow of move
+        let f = move this.v;
+        f
+    }
+}
+
+//! new-transaction
+
+use {{default}}::M;
+
+fun main() {
+    let x = M::new(5);
+    let x_ref = &x;
+    let y = M::value(x_ref);
+    0x0::Transaction::assert(y == 5, 42);
+}

--- a/language/move-lang/tests/functional/translated_ir_tests/borrow_tests/borrow_parens_ok.move
+++ b/language/move-lang/tests/functional/translated_ir_tests/borrow_tests/borrow_parens_ok.move
@@ -1,0 +1,24 @@
+module M {
+    struct T{v: u64}
+
+    public fun new(v: u64) : T {
+        T { v }
+    }
+
+    public fun value(this: &T) : u64 {
+        //borrow of move
+        let f = (move this).v;
+        f
+    }
+}
+
+//! new-transaction
+
+use {{default}}::M;
+
+fun main() {
+    let x = M::new(5);
+    let x_ref = &x;
+    let y = M::value(x_ref);
+    0x0::Transaction::assert(y == 5, 42);
+}

--- a/language/move-lang/tests/functional/translated_ir_tests/borrow_tests/borrow_x_in_if_y_in_else.move
+++ b/language/move-lang/tests/functional/translated_ir_tests/borrow_tests/borrow_x_in_if_y_in_else.move
@@ -1,0 +1,12 @@
+fun main() {
+    let x = 1;
+    let y = 2;
+
+    let ref;
+    if (true) {
+        ref = &x;
+    } else {
+        ref = &y;
+    };
+    0x0::Transaction::assert(*ref == 1, 42);
+}

--- a/language/move-lang/tests/functional/translated_ir_tests/borrow_tests/imm_borrow_global.move
+++ b/language/move-lang/tests/functional/translated_ir_tests/borrow_tests/imm_borrow_global.move
@@ -1,0 +1,54 @@
+//! account: alice, 90000
+//! account: bob, 90000
+
+//! sender: alice
+
+module A {
+    resource struct Coin { u: u64 }
+
+    public fun new(): Coin {
+        Coin { u: 1 }
+    }
+
+    public fun join(c1: Coin, c2: Coin): Coin {
+        let Coin { u: u1 } = c1;
+        let Coin { u: u2 } = c2;
+        Coin { u: u1 + u2 }
+    }
+
+    public fun split(c1: Coin, amt: u64): (Coin, Coin) {
+        let Coin { u } = c1;
+        0x0::Transaction::assert(u >= amt, 42);
+        (Coin { u: u - amt }, Coin { u: amt })
+    }
+}
+
+//! new-transaction
+//! sender: bob
+
+module Tester {
+    use {{alice}}::A;
+    use 0x0::Transaction;
+
+    resource struct Pair { x: A::Coin, y: A::Coin }
+
+    public fun test_eq(addr1: address, addr2: address): bool acquires Pair {
+        let p1 = borrow_global<Pair>(addr1);
+        let p2 = borrow_global<Pair>(addr2);
+        p1 == p2
+    }
+
+    public fun test() acquires Pair {
+        move_to_sender<Pair>(Pair { x: A::new(), y: A::new() });
+        Transaction::assert(test_eq(Transaction::sender(), Transaction::sender()), 42);
+    }
+
+}
+
+//! new-transaction
+//! sender: bob
+use {{bob}}::Tester;
+
+fun main() {
+    Tester::test();
+}

--- a/language/move-lang/tests/move_check/locals/assign_partial_resource.exp
+++ b/language/move-lang/tests/move_check/locals/assign_partial_resource.exp
@@ -96,3 +96,14 @@ error:
     │                           - The local might contain a resource value due to this assignment. The resource must be used before you assign to this local again
     │
 
+error: 
+
+    ┌── tests/move_check/locals/assign_partial_resource.move:31:25 ───
+    │
+ 32 │         (x, y)
+    │             ^ Invalid usage of local 'y'
+    ·
+ 31 │         if (cond) { x = y };
+    │                         - The local might not have a value due to this position. The local must be assigned a value before being used
+    │
+

--- a/language/move-lang/tests/move_check/locals/assign_resource.exp
+++ b/language/move-lang/tests/move_check/locals/assign_resource.exp
@@ -66,7 +66,7 @@ error:
     │                ^ Invalid assignment to local 'r'
     ·
  29 │         let r = R{};
-    │             - The local contains a resource value due to this assignment. The resource must be used before you assign to this local again
+    │             - The local might contain a resource value due to this assignment. The resource must be used before you assign to this local again
     │
 
 error: 

--- a/language/move-lang/tests/move_check/locals/use_after_move_loop.exp
+++ b/language/move-lang/tests/move_check/locals/use_after_move_loop.exp
@@ -67,6 +67,17 @@ error:
 
 error: 
 
+    ┌── tests/move_check/locals/use_after_move_loop.move:19:51 ───
+    │
+ 19 │         loop { let y = x; if (cond) continue; _ = move x; y; }
+    │                                                   ^^^^^^ Invalid usage of local 'x'
+    ·
+ 19 │         loop { let y = x; if (cond) continue; _ = move x; y; }
+    │                                                   ------ The local might not have a value due to this position. The local must be assigned a value before being used
+    │
+
+error: 
+
     ┌── tests/move_check/locals/use_after_move_loop.move:24:24 ───
     │
  24 │         loop { let y = &x; _ = move y; _ = move x }

--- a/language/move-lang/tests/move_check/locals/use_after_move_while.exp
+++ b/language/move-lang/tests/move_check/locals/use_after_move_while.exp
@@ -55,6 +55,17 @@ error:
 
 error: 
 
+    ┌── tests/move_check/locals/use_after_move_while.move:19:59 ───
+    │
+ 19 │         while (cond) { let y = x; if (cond) continue; _ = move x; y; };
+    │                                                           ^^^^^^ Invalid usage of local 'x'
+    ·
+ 19 │         while (cond) { let y = x; if (cond) continue; _ = move x; y; };
+    │                                                           ------ The local might not have a value due to this position. The local must be assigned a value before being used
+    │
+
+error: 
+
     ┌── tests/move_check/locals/use_after_move_while.move:24:32 ───
     │
  24 │         while (cond) { let y = &x; _ = move y; _ = move x };

--- a/language/move-lang/tests/move_check/locals/use_before_assign_loop.exp
+++ b/language/move-lang/tests/move_check/locals/use_before_assign_loop.exp
@@ -6,7 +6,7 @@ error:
    │                        ^^^^^^ Invalid usage of local 'x'
    ·
  3 │         let x: u64;
-   │             - The local does not have a value due to this position. The local must be assigned a value before being used
+   │             - The local might not have a value due to this position. The local must be assigned a value before being used
    │
 
 error: 
@@ -17,7 +17,7 @@ error:
    │                        ^ Invalid usage of local 'x'
    ·
  8 │         let x: u64;
-   │             - The local does not have a value due to this position. The local must be assigned a value before being used
+   │             - The local might not have a value due to this position. The local must be assigned a value before being used
    │
 
 error: 
@@ -28,7 +28,7 @@ error:
     │                        ^^ Invalid usage of local 'x'
     ·
  13 │         let x: u64;
-    │             - The local does not have a value due to this position. The local must be assigned a value before being used
+    │             - The local might not have a value due to this position. The local must be assigned a value before being used
     │
 
 error: 
@@ -40,5 +40,16 @@ error:
     ·
  18 │         let x: u64;
     │             - The local does not have a value due to this position. The local must be assigned a value before being used
+    │
+
+error: 
+
+    ┌── tests/move_check/locals/use_before_assign_loop.move:18:13 ───
+    │
+ 20 │         x;
+    │         ^ Invalid usage of local 'x'
+    ·
+ 18 │         let x: u64;
+    │             - The local might not have a value due to this position. The local must be assigned a value before being used
     │
 

--- a/language/move-lang/tests/move_check/locals/use_before_assign_while.exp
+++ b/language/move-lang/tests/move_check/locals/use_before_assign_while.exp
@@ -6,7 +6,7 @@ error:
    │                                ^^^^^^ Invalid usage of local 'x'
    ·
  3 │         let x: u64;
-   │             - The local does not have a value due to this position. The local must be assigned a value before being used
+   │             - The local might not have a value due to this position. The local must be assigned a value before being used
    │
 
 error: 
@@ -17,7 +17,7 @@ error:
    │                                ^^^^^^ Invalid usage of local 'x'
    ·
  8 │         let x: u64;
-   │             - The local does not have a value due to this position. The local must be assigned a value before being used
+   │             - The local might not have a value due to this position. The local must be assigned a value before being used
    │
 
 error: 
@@ -28,7 +28,7 @@ error:
     │                                ^^ Invalid usage of local 'x'
     ·
  13 │         let x: u64;
-    │             - The local does not have a value due to this position. The local must be assigned a value before being used
+    │             - The local might not have a value due to this position. The local must be assigned a value before being used
     │
 
 error: 

--- a/language/move-lang/tests/move_check/parser/invalid_pack_mname_non_addr.move
+++ b/language/move-lang/tests/move_check/parser/invalid_pack_mname_non_addr.move
@@ -5,6 +5,6 @@ module M {
     }
 
     fun bar() {
-        bar()::bar()::M::S { }
+        fun bar()::bar()::M::S { }
     }
 }

--- a/language/move-lang/tests/move_check/translated_ir_tests/borrow_tests/borrow_global_acquires_1.move
+++ b/language/move-lang/tests/move_check/translated_ir_tests/borrow_tests/borrow_global_acquires_1.move
@@ -1,0 +1,14 @@
+module A {
+    use 0x0::Transaction;
+    resource struct T1 {v: u64}
+
+    public fun test(addr: address) acquires T1 {
+        borrow_global_mut<T1>(Transaction::sender());
+        acquires_t1();
+    }
+
+    fun acquires_t1() acquires T1 {
+        T1 { v: _ } = move_from<T1>(Transaction::sender());
+    }
+
+}

--- a/language/move-lang/tests/move_check/translated_ir_tests/borrow_tests/borrow_global_acquires_2.move
+++ b/language/move-lang/tests/move_check/translated_ir_tests/borrow_tests/borrow_global_acquires_2.move
@@ -1,0 +1,33 @@
+module A {
+    use 0x0::Transaction;
+    resource struct T1 {v: u64}
+    resource struct T2 {v: u64}
+
+    public fun test1(addr: address) acquires T1, T2 {
+        let x = borrow_global_mut<T1>(Transaction::sender());
+        acquires_t2();
+        move x;
+        acquires_t1();
+    }
+
+    public fun test2(addr: address) acquires T1, T2 {
+        borrow_global_mut<T1>(Transaction::sender());
+        acquires_t1();
+        acquires_t2();
+    }
+
+    public fun test3(addr: address) acquires T1, T2 {
+        borrow_global_mut<T1>(Transaction::sender());
+        acquires_t2();
+        acquires_t1();
+    }
+
+    fun acquires_t1() acquires T1 {
+        T1 { v: _ } = move_from<T1>(Transaction::sender())
+    }
+
+    fun acquires_t2() acquires T2 {
+        T2 { v: _ } = move_from<T2>(Transaction::sender())
+    }
+
+}

--- a/language/move-lang/tests/move_check/translated_ir_tests/borrow_tests/borrow_global_acquires_3.move
+++ b/language/move-lang/tests/move_check/translated_ir_tests/borrow_tests/borrow_global_acquires_3.move
@@ -1,0 +1,42 @@
+module A {
+    use 0x0::Transaction;
+    resource struct T1 {v: u64}
+    resource struct T2 {v: u64}
+
+    public fun test1(addr: address) acquires T1, T2 {
+        let x = borrow_global_mut<T1>(Transaction::sender());
+        let y = get_v(x);
+        acquires_t2();
+        move y;
+        acquires_t1();
+    }
+
+    public fun test2(addr: address) acquires T1, T2 {
+        let x = borrow_global_mut<T1>(Transaction::sender());
+        let y = get_v(x);
+        move y;
+        acquires_t1();
+        acquires_t2();
+    }
+
+    public fun test3(addr: address) acquires T1, T2 {
+        let x = borrow_global_mut<T1>(Transaction::sender());
+        let y = get_v(x);
+        move y;
+        acquires_t2();
+        acquires_t1();
+    }
+
+    fun get_v(x: &mut T1): &mut u64 {
+        &mut x.v
+    }
+
+    fun acquires_t1() acquires T1 {
+        T1 { v: _ } = move_from<T1>(Transaction::sender())
+    }
+
+    fun acquires_t2() acquires T2 {
+        T2 { v: _ } = move_from<T2>(Transaction::sender())
+    }
+
+}

--- a/language/move-lang/tests/move_check/translated_ir_tests/borrow_tests/borrow_global_acquires_duplicate_annotation.exp
+++ b/language/move-lang/tests/move_check/translated_ir_tests/borrow_tests/borrow_global_acquires_duplicate_annotation.exp
@@ -1,0 +1,11 @@
+error: 
+
+   ┌── tests/move_check/translated_ir_tests/borrow_tests/borrow_global_acquires_duplicate_annotation.move:5:32 ───
+   │
+ 5 │     public fun test() acquires T1, T1 {
+   │                                    ^^ Duplicate acquires item
+   ·
+ 5 │     public fun test() acquires T1, T1 {
+   │                                -- Previously listed here
+   │
+

--- a/language/move-lang/tests/move_check/translated_ir_tests/borrow_tests/borrow_global_acquires_duplicate_annotation.move
+++ b/language/move-lang/tests/move_check/translated_ir_tests/borrow_tests/borrow_global_acquires_duplicate_annotation.move
@@ -1,0 +1,10 @@
+module A {
+    use 0x0::Transaction;
+    resource struct T1{v: u64}
+
+    public fun test() acquires T1, T1 {
+        borrow_global_mut<T1>(Transaction::sender());
+    }
+}
+
+// check: DUPLICATE_ACQUIRES_RESOURCE_ANNOTATION_ERROR

--- a/language/move-lang/tests/move_check/translated_ir_tests/borrow_tests/borrow_global_acquires_extraneous_annotation.exp
+++ b/language/move-lang/tests/move_check/translated_ir_tests/borrow_tests/borrow_global_acquires_extraneous_annotation.exp
@@ -1,0 +1,8 @@
+error: 
+
+   ┌── tests/move_check/translated_ir_tests/borrow_tests/borrow_global_acquires_extraneous_annotation.move:4:32 ───
+   │
+ 4 │     public fun test() acquires T1 {
+   │                                ^^ Invalid 'acquires' list. The resource '0x8675309::A::T1' was never acquired by 'move_from', 'borrow_global', 'borrow_global_mut', or a transitive call
+   │
+

--- a/language/move-lang/tests/move_check/translated_ir_tests/borrow_tests/borrow_global_acquires_extraneous_annotation.move
+++ b/language/move-lang/tests/move_check/translated_ir_tests/borrow_tests/borrow_global_acquires_extraneous_annotation.move
@@ -1,0 +1,9 @@
+module A {
+    resource struct T1 {v: u64}
+
+    public fun test() acquires T1 {
+    }
+
+}
+
+// check: EXTRANEOUS_ACQUIRES_RESOURCE_ANNOTATION_ERROR

--- a/language/move-lang/tests/move_check/translated_ir_tests/borrow_tests/borrow_global_acquires_invalid_1.exp
+++ b/language/move-lang/tests/move_check/translated_ir_tests/borrow_tests/borrow_global_acquires_invalid_1.exp
@@ -1,0 +1,11 @@
+error: 
+
+   ┌── tests/move_check/translated_ir_tests/borrow_tests/borrow_global_acquires_invalid_1.move:6:17 ───
+   │
+ 7 │         acquires_t1();
+   │         ^^^^^^^^^^^^^ Invalid acquiring of resource 'T1'
+   ·
+ 6 │         let x = borrow_global_mut<T1>(Transaction::sender());
+   │                 -------------------------------------------- It is still being mutably borrowed by this reference
+   │
+

--- a/language/move-lang/tests/move_check/translated_ir_tests/borrow_tests/borrow_global_acquires_invalid_1.move
+++ b/language/move-lang/tests/move_check/translated_ir_tests/borrow_tests/borrow_global_acquires_invalid_1.move
@@ -1,0 +1,17 @@
+module A {
+    use 0x0::Transaction;
+    resource struct T1 {v: u64}
+
+    public fun test(addr: address) acquires T1 {
+        let x = borrow_global_mut<T1>(Transaction::sender());
+        acquires_t1();
+        move x;
+    }
+
+    fun acquires_t1() acquires T1 {
+        T1 { v: _ } = move_from<T1>(Transaction::sender());
+    }
+
+}
+
+// check: GLOBAL_REFERENCE_ERROR

--- a/language/move-lang/tests/move_check/translated_ir_tests/borrow_tests/borrow_global_acquires_invalid_2.exp
+++ b/language/move-lang/tests/move_check/translated_ir_tests/borrow_tests/borrow_global_acquires_invalid_2.exp
@@ -1,0 +1,33 @@
+error: 
+
+   ┌── tests/move_check/translated_ir_tests/borrow_tests/borrow_global_acquires_invalid_2.move:7:17 ───
+   │
+ 9 │         acquires_t1();
+   │         ^^^^^^^^^^^^^ Invalid acquiring of resource 'T1'
+   ·
+ 7 │         let x = borrow_global_mut<T1>(Transaction::sender());
+   │                 -------------------------------------------- It is still being mutably borrowed by this reference
+   │
+
+error: 
+
+    ┌── tests/move_check/translated_ir_tests/borrow_tests/borrow_global_acquires_invalid_2.move:14:17 ───
+    │
+ 16 │         acquires_t1();
+    │         ^^^^^^^^^^^^^ Invalid acquiring of resource 'T1'
+    ·
+ 14 │         let x = borrow_global_mut<T1>(Transaction::sender());
+    │                 -------------------------------------------- It is still being mutably borrowed by this reference
+    │
+
+error: 
+
+    ┌── tests/move_check/translated_ir_tests/borrow_tests/borrow_global_acquires_invalid_2.move:21:17 ───
+    │
+ 22 │         acquires_t1();
+    │         ^^^^^^^^^^^^^ Invalid acquiring of resource 'T1'
+    ·
+ 21 │         let x = borrow_global_mut<T1>(Transaction::sender());
+    │                 -------------------------------------------- It is still being mutably borrowed by this reference
+    │
+

--- a/language/move-lang/tests/move_check/translated_ir_tests/borrow_tests/borrow_global_acquires_invalid_2.move
+++ b/language/move-lang/tests/move_check/translated_ir_tests/borrow_tests/borrow_global_acquires_invalid_2.move
@@ -1,0 +1,39 @@
+module A {
+    use 0x0::Transaction;
+    resource struct T1 {v: u64}
+    resource struct T2 {v: u64}
+
+    public fun test1(addr: address) acquires T1, T2 {
+        let x = borrow_global_mut<T1>(Transaction::sender());
+        acquires_t2();
+        acquires_t1();
+        move x;
+    }
+
+    public fun test2(addr: address) acquires T1, T2 {
+        let x = borrow_global_mut<T1>(Transaction::sender());
+        acquires_t2();
+        acquires_t1();
+        move x;
+    }
+
+    public fun test3(addr: address) acquires T1, T2 {
+        let x = borrow_global_mut<T1>(Transaction::sender());
+        acquires_t1();
+        move x;
+        acquires_t2();
+    }
+
+    fun acquires_t1() acquires T1 {
+        T1 { v: _ } = move_from<T1>(Transaction::sender());
+    }
+
+    fun acquires_t2() acquires T2 {
+        T2 { v: _ } = move_from<T2>(Transaction::sender());
+    }
+
+}
+
+// check: GLOBAL_REFERENCE_ERROR
+// check: GLOBAL_REFERENCE_ERROR
+// check: GLOBAL_REFERENCE_ERROR

--- a/language/move-lang/tests/move_check/translated_ir_tests/borrow_tests/borrow_global_acquires_invalid_3.exp
+++ b/language/move-lang/tests/move_check/translated_ir_tests/borrow_tests/borrow_global_acquires_invalid_3.exp
@@ -1,0 +1,33 @@
+error: 
+
+   ┌── tests/move_check/translated_ir_tests/borrow_tests/borrow_global_acquires_invalid_3.move:8:17 ───
+   │
+ 9 │         acquires_t1();
+   │         ^^^^^^^^^^^^^ Invalid acquiring of resource 'T1'
+   ·
+ 8 │         let y = get_v(x);
+   │                 -------- It is still being mutably borrowed by this reference
+   │
+
+error: 
+
+    ┌── tests/move_check/translated_ir_tests/borrow_tests/borrow_global_acquires_invalid_3.move:16:17 ───
+    │
+ 18 │         acquires_t1();
+    │         ^^^^^^^^^^^^^ Invalid acquiring of resource 'T1'
+    ·
+ 16 │         let y = get_v(x);
+    │                 -------- It is still being mutably borrowed by this reference
+    │
+
+error: 
+
+    ┌── tests/move_check/translated_ir_tests/borrow_tests/borrow_global_acquires_invalid_3.move:24:17 ───
+    │
+ 25 │         acquires_t1();
+    │         ^^^^^^^^^^^^^ Invalid acquiring of resource 'T1'
+    ·
+ 24 │         let y = get_v(x);
+    │                 -------- It is still being mutably borrowed by this reference
+    │
+

--- a/language/move-lang/tests/move_check/translated_ir_tests/borrow_tests/borrow_global_acquires_invalid_3.move
+++ b/language/move-lang/tests/move_check/translated_ir_tests/borrow_tests/borrow_global_acquires_invalid_3.move
@@ -1,0 +1,46 @@
+module A {
+    use 0x0::Transaction;
+    resource struct T1 {v: u64}
+    resource struct T2 {v: u64}
+
+    public fun test1(addr: address) acquires T1, T2 {
+        let x = borrow_global_mut<T1>(Transaction::sender());
+        let y = get_v(x);
+        acquires_t1();
+        acquires_t2();
+        move y;
+    }
+
+    public fun test2(addr: address) acquires T1, T2 {
+        let x = borrow_global_mut<T1>(Transaction::sender());
+        let y = get_v(x);
+        acquires_t2();
+        acquires_t1();
+        move y;
+    }
+
+    public fun test3(addr: address) acquires T1, T2 {
+        let x = borrow_global_mut<T1>(Transaction::sender());
+        let y = get_v(x);
+        acquires_t1();
+        move y;
+        acquires_t2();
+    }
+
+    fun get_v(x: &mut T1): &mut u64 {
+        &mut x.v
+    }
+
+    fun acquires_t1() acquires T1 {
+        T1 { v: _ } = move_from<T1>(Transaction::sender())
+    }
+
+    fun acquires_t2() acquires T2 {
+        T2 { v: _ } = move_from<T2>(Transaction::sender())
+    }
+
+}
+
+// check: GLOBAL_REFERENCE_ERROR
+// check: GLOBAL_REFERENCE_ERROR
+// check: GLOBAL_REFERENCE_ERROR

--- a/language/move-lang/tests/move_check/translated_ir_tests/borrow_tests/borrow_global_acquires_invalid_annotation.exp
+++ b/language/move-lang/tests/move_check/translated_ir_tests/borrow_tests/borrow_global_acquires_invalid_annotation.exp
@@ -1,0 +1,8 @@
+error: 
+
+   ┌── tests/move_check/translated_ir_tests/borrow_tests/borrow_global_acquires_invalid_annotation.move:4:32 ───
+   │
+ 4 │     public fun test() acquires T1 {
+   │                                ^^ Invalid 'acquires' list. The resource '0x8675309::A::T1' was never acquired by 'move_from', 'borrow_global', 'borrow_global_mut', or a transitive call
+   │
+

--- a/language/move-lang/tests/move_check/translated_ir_tests/borrow_tests/borrow_global_acquires_invalid_annotation.move
+++ b/language/move-lang/tests/move_check/translated_ir_tests/borrow_tests/borrow_global_acquires_invalid_annotation.move
@@ -1,0 +1,10 @@
+module A {
+    resource struct T1 {v: u64}
+
+    public fun test() acquires T1 {
+        test()
+    }
+
+}
+
+// check: INVALID_ACQUIRES_RESOURCE_ANNOTATION_ERROR

--- a/language/move-lang/tests/move_check/translated_ir_tests/borrow_tests/borrow_global_acquires_missing_annotation.exp
+++ b/language/move-lang/tests/move_check/translated_ir_tests/borrow_tests/borrow_global_acquires_missing_annotation.exp
@@ -1,0 +1,11 @@
+error: 
+
+   ┌── tests/move_check/translated_ir_tests/borrow_tests/borrow_global_acquires_missing_annotation.move:6:9 ───
+   │
+ 6 │         borrow_global_mut<T1>(Transaction::sender());
+   │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Invalid call to borrow_global_mut.
+   ·
+ 6 │         borrow_global_mut<T1>(Transaction::sender());
+   │                           -- The call acquires '0x8675309::A::T1', but the 'acquires' list for the current function does not contain this type. It must be present in the calling context's acquires list
+   │
+

--- a/language/move-lang/tests/move_check/translated_ir_tests/borrow_tests/borrow_global_acquires_missing_annotation.move
+++ b/language/move-lang/tests/move_check/translated_ir_tests/borrow_tests/borrow_global_acquires_missing_annotation.move
@@ -1,0 +1,11 @@
+module A {
+    use 0x0::Transaction;
+    resource struct T1{v: u64}
+
+    public fun test() {
+        borrow_global_mut<T1>(Transaction::sender());
+    }
+
+}
+
+// check: MISSING_ACQUIRES_RESOURCE_ANNOTATION_ERROR

--- a/language/move-lang/tests/move_check/translated_ir_tests/borrow_tests/borrow_global_acquires_return_reference_1.move
+++ b/language/move-lang/tests/move_check/translated_ir_tests/borrow_tests/borrow_global_acquires_return_reference_1.move
@@ -1,0 +1,21 @@
+module A {
+    use 0x0::Transaction;
+    resource struct T1 {v: u64}
+
+    public fun test1(x: &mut T1) acquires T1 {
+        // the acquire of t1 does not pollute y
+        let y = borrow_acquires_t1(x);
+        acquires_t1();
+        move y;
+    }
+
+    fun borrow_acquires_t1(x: &mut T1): &mut u64 acquires T1 {
+        borrow_global_mut<T1>(Transaction::sender());
+        &mut x.v
+    }
+
+    fun acquires_t1() acquires T1 {
+        T1 { v:_ } = move_from<T1>(Transaction::sender())
+    }
+
+}

--- a/language/move-lang/tests/move_check/translated_ir_tests/borrow_tests/borrow_global_acquires_return_reference_invalid_1.exp
+++ b/language/move-lang/tests/move_check/translated_ir_tests/borrow_tests/borrow_global_acquires_return_reference_invalid_1.exp
@@ -1,0 +1,11 @@
+error: 
+
+    ┌── tests/move_check/translated_ir_tests/borrow_tests/borrow_global_acquires_return_reference_invalid_1.move:10:9 ───
+    │
+ 10 │         borrow_global_mut<T1>(Transaction::sender())
+    │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Invalid return. Resource 'T1' is still being borrowed.
+    ·
+ 10 │         borrow_global_mut<T1>(Transaction::sender())
+    │         -------------------------------------------- It is still being mutably borrowed by this reference
+    │
+

--- a/language/move-lang/tests/move_check/translated_ir_tests/borrow_tests/borrow_global_acquires_return_reference_invalid_1.move
+++ b/language/move-lang/tests/move_check/translated_ir_tests/borrow_tests/borrow_global_acquires_return_reference_invalid_1.move
@@ -1,0 +1,14 @@
+module A {
+    use 0x0::Transaction;
+    resource struct T1 {v: u64}
+
+    public fun test1() acquires T1 {
+        borrow_acquires_t1();
+    }
+
+    fun borrow_acquires_t1(): &mut T1 acquires T1 {
+        borrow_global_mut<T1>(Transaction::sender())
+    }
+}
+
+// check: RET_UNSAFE_TO_DESTROY_ERROR

--- a/language/move-lang/tests/move_check/translated_ir_tests/borrow_tests/borrow_global_bad0.exp
+++ b/language/move-lang/tests/move_check/translated_ir_tests/borrow_tests/borrow_global_bad0.exp
@@ -1,0 +1,11 @@
+error: 
+
+   ┌── tests/move_check/translated_ir_tests/borrow_tests/borrow_global_bad0.move:7:17 ───
+   │
+ 9 │         x = borrow_global_mut<T>(sender);
+   │             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Invalid borrowing of resource 'T'
+   ·
+ 7 │         let x = borrow_global_mut<T>(sender);
+   │                 ---------------------------- It is still being mutably borrowed by this reference
+   │
+

--- a/language/move-lang/tests/move_check/translated_ir_tests/borrow_tests/borrow_global_bad0.move
+++ b/language/move-lang/tests/move_check/translated_ir_tests/borrow_tests/borrow_global_bad0.move
@@ -1,0 +1,14 @@
+module A {
+    use 0x0::Transaction;
+    resource struct T {v: u64}
+
+    public fun t0(cond: bool) acquires T {
+        let sender = Transaction::sender();
+        let x = borrow_global_mut<T>(sender);
+        copy x;
+        x = borrow_global_mut<T>(sender);
+        copy x;
+    }
+}
+
+// check: GLOBAL_REFERENCE_ERROR

--- a/language/move-lang/tests/move_check/translated_ir_tests/borrow_tests/borrow_global_bad1.exp
+++ b/language/move-lang/tests/move_check/translated_ir_tests/borrow_tests/borrow_global_bad1.exp
@@ -1,0 +1,11 @@
+error: 
+
+   ┌── tests/move_check/translated_ir_tests/borrow_tests/borrow_global_bad1.move:6:17 ───
+   │
+ 7 │         let y = borrow_global_mut<T>(addr);
+   │                 ^^^^^^^^^^^^^^^^^^^^^^^^^^ Invalid borrowing of resource 'T'
+   ·
+ 6 │         let x = borrow_global_mut<T>(Transaction::sender());
+   │                 ------------------------------------------- It is still being mutably borrowed by this reference
+   │
+

--- a/language/move-lang/tests/move_check/translated_ir_tests/borrow_tests/borrow_global_bad1.move
+++ b/language/move-lang/tests/move_check/translated_ir_tests/borrow_tests/borrow_global_bad1.move
@@ -1,0 +1,13 @@
+module A {
+    use 0x0::Transaction;
+    resource struct T {v: u64}
+
+    public fun A0(addr: address) acquires T {
+        let x = borrow_global_mut<T>(Transaction::sender());
+        let y = borrow_global_mut<T>(addr);
+        x;
+        y;
+    }
+}
+
+// check: GLOBAL_REFERENCE_ERROR

--- a/language/move-lang/tests/move_check/translated_ir_tests/borrow_tests/borrow_global_bad2.exp
+++ b/language/move-lang/tests/move_check/translated_ir_tests/borrow_tests/borrow_global_bad2.exp
@@ -1,0 +1,11 @@
+error: 
+
+   ┌── tests/move_check/translated_ir_tests/borrow_tests/borrow_global_bad2.move:7:21 ───
+   │
+ 8 │         T { v: _ } = move_from<T>(sender);
+   │                      ^^^^^^^^^^^^^^^^^^^^ Invalid extraction of resource 'T'
+   ·
+ 7 │         let t_ref = borrow_global_mut<T>(sender);
+   │                     ---------------------------- It is still being mutably borrowed by this reference
+   │
+

--- a/language/move-lang/tests/move_check/translated_ir_tests/borrow_tests/borrow_global_bad2.move
+++ b/language/move-lang/tests/move_check/translated_ir_tests/borrow_tests/borrow_global_bad2.move
@@ -1,0 +1,13 @@
+module A {
+    use 0x0::Transaction;
+    resource struct T {v: u64}
+
+    public fun A2() acquires T {
+        let sender = Transaction::sender();
+        let t_ref = borrow_global_mut<T>(sender);
+        T { v: _ } = move_from<T>(sender);
+        t_ref;
+    }
+}
+
+// check: GLOBAL_REFERENCE_ERROR

--- a/language/move-lang/tests/move_check/translated_ir_tests/borrow_tests/borrow_global_bad5.exp
+++ b/language/move-lang/tests/move_check/translated_ir_tests/borrow_tests/borrow_global_bad5.exp
@@ -1,0 +1,11 @@
+error: 
+
+   ┌── tests/move_check/translated_ir_tests/borrow_tests/borrow_global_bad5.move:7:29 ───
+   │
+ 8 │         let t2_ref = borrow_global_mut<T>(Transaction::sender());
+   │                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Invalid borrowing of resource 'T'
+   ·
+ 7 │         let t1_ref = if (b) borrow_global_mut<T>(Transaction::sender()) else &mut t;
+   │                             ------------------------------------------- It is still being mutably borrowed by this reference
+   │
+

--- a/language/move-lang/tests/move_check/translated_ir_tests/borrow_tests/borrow_global_bad5.move
+++ b/language/move-lang/tests/move_check/translated_ir_tests/borrow_tests/borrow_global_bad5.move
@@ -1,0 +1,15 @@
+module A {
+    use 0x0::Transaction;
+    resource struct T {v: u64}
+
+    public fun A5(b: bool) acquires T {
+        let t = T { v: 0 };
+        let t1_ref = if (b) borrow_global_mut<T>(Transaction::sender()) else &mut t;
+        let t2_ref = borrow_global_mut<T>(Transaction::sender());
+        t1_ref;
+        t2_ref;
+        T { v: _ } = t;
+    }
+}
+
+// check: GLOBAL_REFERENCE_ERROR

--- a/language/move-lang/tests/move_check/translated_ir_tests/borrow_tests/borrow_global_good.move
+++ b/language/move-lang/tests/move_check/translated_ir_tests/borrow_tests/borrow_global_good.move
@@ -1,0 +1,44 @@
+module A {
+    use 0x0::Transaction;
+    resource struct T {v: u64}
+    resource struct U {v: u64}
+
+    public fun A0() acquires T {
+        let sender = Transaction::sender();
+        let t_ref = borrow_global_mut<T>(sender);
+        move t_ref;
+        borrow_global_mut<T>(sender);
+    }
+
+    public fun A1() acquires T, U {
+        let sender = Transaction::sender();
+        let t_ref = borrow_global_mut<T>(sender);
+        let u_ref = borrow_global_mut<U>(sender);
+        t_ref;
+        u_ref;
+    }
+
+    public fun A2(b: bool) acquires T {
+        let sender = Transaction::sender();
+        let t_ref = if (b) borrow_global_mut<T>(sender) else borrow_global_mut<T>(sender);
+        t_ref;
+    }
+
+    public fun A3(b: bool) acquires T {
+        let sender = Transaction::sender();
+        if (b) {
+            borrow_global_mut<T>(sender);
+        }
+    }
+
+    public fun A4(b: bool) acquires T {
+        let sender = Transaction::sender();
+        let x = move_from<T>(sender);
+        borrow_global_mut<T>(sender);
+        move_to_sender<T>(x);
+    }
+
+    public fun A5() acquires T {
+        borrow_global<T>(Transaction::sender());
+    }
+}

--- a/language/move-lang/tests/move_check/translated_ir_tests/borrow_tests/borrow_if.exp
+++ b/language/move-lang/tests/move_check/translated_ir_tests/borrow_tests/borrow_if.exp
@@ -1,0 +1,11 @@
+error: 
+
+   ┌── tests/move_check/translated_ir_tests/borrow_tests/borrow_if.move:3:9 ───
+   │
+ 7 │     0x0::Transaction::assert(*move ref == 5, 42);
+   │                               ^^^^^^^^ Invalid usage of local 'ref'
+   ·
+ 3 │     let ref;
+   │         --- The local might not have a value due to this position. The local must be assigned a value before being used
+   │
+

--- a/language/move-lang/tests/move_check/translated_ir_tests/borrow_tests/borrow_if.move
+++ b/language/move-lang/tests/move_check/translated_ir_tests/borrow_tests/borrow_if.move
@@ -1,0 +1,10 @@
+fun main() {
+    let x = 5;
+    let ref;
+    if (true) {
+        ref = &x;
+    };
+    0x0::Transaction::assert(*move ref == 5, 42);
+}
+
+// check: MOVELOC_UNAVAILABLE_ERROR

--- a/language/move-lang/tests/move_check/translated_ir_tests/borrow_tests/borrow_return_mutable_borrow_bad.exp
+++ b/language/move-lang/tests/move_check/translated_ir_tests/borrow_tests/borrow_return_mutable_borrow_bad.exp
@@ -1,0 +1,11 @@
+error: 
+
+   ┌── tests/move_check/translated_ir_tests/borrow_tests/borrow_return_mutable_borrow_bad.move:7:25 ───
+   │
+ 9 │         (ref_x_f, ref_x_f_g)
+   │         ^^^^^^^^^^^^^^^^^^^^ Invalid return of reference. Cannot transfer a mutable reference that is being borrowed
+   ·
+ 7 │         let ref_x_f_g = &ref_x_f.g;
+   │                         ---------- Field 'g' is still being borrowed by this reference
+   │
+

--- a/language/move-lang/tests/move_check/translated_ir_tests/borrow_tests/borrow_return_mutable_borrow_bad.move
+++ b/language/move-lang/tests/move_check/translated_ir_tests/borrow_tests/borrow_return_mutable_borrow_bad.move
@@ -1,0 +1,13 @@
+module M {
+    struct X { f: Y }
+    struct Y { g: u64, h: u64 }
+
+    fun t1(ref_x: &mut X): (&mut Y, &u64)  {
+        let ref_x_f = &mut ref_x.f;
+        let ref_x_f_g = &ref_x_f.g;
+
+        (ref_x_f, ref_x_f_g)
+    }
+}
+
+// check: RET_BORROWED_MUTABLE_REFERENCE_ERROR

--- a/language/move-lang/tests/move_check/translated_ir_tests/borrow_tests/copy_loc_borrowed.move
+++ b/language/move-lang/tests/move_check/translated_ir_tests/borrow_tests/copy_loc_borrowed.move
@@ -1,0 +1,10 @@
+module Tester {
+    fun t() {
+        let x = 0;
+        let r1 = &x;
+        let r2 = &x;
+        x + copy x;
+        r1;
+        r2;
+    }
+}

--- a/language/move-lang/tests/move_check/translated_ir_tests/borrow_tests/copy_loc_borrowed_field.move
+++ b/language/move-lang/tests/move_check/translated_ir_tests/borrow_tests/copy_loc_borrowed_field.move
@@ -1,0 +1,12 @@
+module Tester {
+    struct T { f: u64 }
+
+    fun t() {
+        let x = T { f: 0 };
+        let r1 = &x.f;
+        let r2 = &x.f;
+        copy x;
+        r1;
+        r2;
+    }
+}

--- a/language/move-lang/tests/move_check/translated_ir_tests/borrow_tests/copy_loc_borrowed_field_invalid.exp
+++ b/language/move-lang/tests/move_check/translated_ir_tests/borrow_tests/copy_loc_borrowed_field_invalid.exp
@@ -1,0 +1,11 @@
+error: 
+
+   ┌── tests/move_check/translated_ir_tests/borrow_tests/copy_loc_borrowed_field_invalid.move:6:18 ───
+   │
+ 7 │         copy x;
+   │         ^^^^^^ Invalid copy of local 'x'
+   ·
+ 6 │         let r1 = &mut x.f;
+   │                  -------- It is still being mutably borrowed by this reference
+   │
+

--- a/language/move-lang/tests/move_check/translated_ir_tests/borrow_tests/copy_loc_borrowed_field_invalid.move
+++ b/language/move-lang/tests/move_check/translated_ir_tests/borrow_tests/copy_loc_borrowed_field_invalid.move
@@ -1,0 +1,12 @@
+module Tester {
+    struct T { f: u64 }
+
+    fun t() {
+        let x = T { f: 0 };
+        let r1 = &mut x.f;
+        copy x;
+        r1;
+    }
+}
+
+// check: COPYLOC_EXISTS_BORROW_ERROR

--- a/language/move-lang/tests/move_check/translated_ir_tests/borrow_tests/copy_loc_borrowed_indirect.move
+++ b/language/move-lang/tests/move_check/translated_ir_tests/borrow_tests/copy_loc_borrowed_indirect.move
@@ -1,0 +1,16 @@
+module Tester {
+    fun t() {
+        let x = 0;
+        let y = 0;
+        let r1 = foo(&x, &y);
+        let r2 = foo(&x, &y);
+        x + copy x;
+        y + copy y;
+        r1;
+        r2;
+    }
+
+    fun foo(r: &u64, r2: &u64): &u64 {
+        r2
+    }
+}

--- a/language/move-lang/tests/move_check/translated_ir_tests/borrow_tests/copy_loc_borrowed_indirect_invalid.exp
+++ b/language/move-lang/tests/move_check/translated_ir_tests/borrow_tests/copy_loc_borrowed_indirect_invalid.exp
@@ -1,0 +1,11 @@
+error: 
+
+   ┌── tests/move_check/translated_ir_tests/borrow_tests/copy_loc_borrowed_indirect_invalid.move:5:18 ───
+   │
+ 6 │         copy x;
+   │         ^^^^^^ Invalid copy of local 'x'
+   ·
+ 5 │         let r1 = foo(&mut x, &mut y);
+   │                  ------------------- It is still being mutably borrowed by this reference
+   │
+

--- a/language/move-lang/tests/move_check/translated_ir_tests/borrow_tests/copy_loc_borrowed_indirect_invalid.move
+++ b/language/move-lang/tests/move_check/translated_ir_tests/borrow_tests/copy_loc_borrowed_indirect_invalid.move
@@ -1,0 +1,15 @@
+module Tester {
+    fun t() {
+        let x = 0;
+        let y = 0;
+        let r1 = foo(&mut x, &mut y);
+        copy x;
+        r1;
+    }
+
+    fun foo(r: &mut u64, r2: &mut u64): &mut u64 {
+        r2
+    }
+}
+
+// check: COPYLOC_EXISTS_BORROW_ERROR

--- a/language/move-lang/tests/move_check/translated_ir_tests/borrow_tests/copy_loc_borrowed_invalid.exp
+++ b/language/move-lang/tests/move_check/translated_ir_tests/borrow_tests/copy_loc_borrowed_invalid.exp
@@ -1,0 +1,11 @@
+error: 
+
+   ┌── tests/move_check/translated_ir_tests/borrow_tests/copy_loc_borrowed_invalid.move:4:18 ───
+   │
+ 5 │         copy x;
+   │         ^^^^^^ Invalid copy of local 'x'
+   ·
+ 4 │         let r1 = &mut x;
+   │                  ------ It is still being mutably borrowed by this reference
+   │
+

--- a/language/move-lang/tests/move_check/translated_ir_tests/borrow_tests/copy_loc_borrowed_invalid.move
+++ b/language/move-lang/tests/move_check/translated_ir_tests/borrow_tests/copy_loc_borrowed_invalid.move
@@ -1,0 +1,10 @@
+module Tester {
+    fun t() {
+        let x = 0;
+        let r1 = &mut x;
+        copy x;
+        r1;
+    }
+}
+
+// check: COPYLOC_EXISTS_BORROW_ERROR

--- a/language/move-lang/tests/move_check/translated_ir_tests/borrow_tests/factor_invalid_1.exp
+++ b/language/move-lang/tests/move_check/translated_ir_tests/borrow_tests/factor_invalid_1.exp
@@ -1,0 +1,22 @@
+error: 
+
+    ┌── tests/move_check/translated_ir_tests/borrow_tests/factor_invalid_1.move:9:19 ───
+    │
+ 12 │         foo(f_g, f);
+    │         ^^^^^^^^^^^ Invalid usage of reference as function argument. Cannot transfer a mutable reference that is being borrowed
+    ·
+ 9 │         let f_g = &mut f.g;
+    │                   -------- Field 'g' is still being mutably borrowed by this reference
+    │
+
+error: 
+
+    ┌── tests/move_check/translated_ir_tests/borrow_tests/factor_invalid_1.move:19:19 ───
+    │
+ 22 │         bar(f, f_g);
+    │         ^^^^^^^^^^^ Invalid usage of reference as function argument. Cannot transfer a mutable reference that is being borrowed
+    ·
+ 19 │         let f_g = &mut f.g;
+    │                   -------- Field 'g' is still being mutably borrowed by this reference
+    │
+

--- a/language/move-lang/tests/move_check/translated_ir_tests/borrow_tests/factor_invalid_1.move
+++ b/language/move-lang/tests/move_check/translated_ir_tests/borrow_tests/factor_invalid_1.move
@@ -1,0 +1,33 @@
+module M {
+    struct X { f: Y }
+    struct Y { g: u64, h: u64 }
+
+    fun t1() {
+        let x = X { f: Y { g: 0, h: 0 } };
+
+        let f = &mut x.f;
+        let f_g = &mut f.g;
+
+        // Error: the argument for parameter b is borrowed
+        foo(f_g, f);
+    }
+
+    fun t2() {
+        let x = X { f: Y { g: 0, h: 0 } };
+
+        let f = &mut x.f;
+        let f_g = &mut f.g;
+
+        // Error: the argument for parameter a is borrowed
+        bar(f, f_g);
+    }
+
+    fun foo(a: &mut u64, b: &mut Y) {
+    }
+
+    fun bar(a: &mut Y, b: &mut u64) {
+    }
+}
+
+// check: CALL_BORROWED_MUTABLE_REFERENCE_ERROR
+// check: CALL_BORROWED_MUTABLE_REFERENCE_ERROR

--- a/language/move-lang/tests/move_check/translated_ir_tests/borrow_tests/factor_invalid_2.exp
+++ b/language/move-lang/tests/move_check/translated_ir_tests/borrow_tests/factor_invalid_2.exp
@@ -1,0 +1,11 @@
+error: 
+
+   ┌── tests/move_check/translated_ir_tests/borrow_tests/factor_invalid_2.move:6:29 ───
+   │
+ 8 │         &mut root.g;
+   │         ^^^^^^^^^^^ Invalid mutable borrow at field 'g'.
+   ·
+ 6 │         let eps = if (cond) bar(root) else &x1;
+   │                             --------- It is still being borrowed by this reference
+   │
+

--- a/language/move-lang/tests/move_check/translated_ir_tests/borrow_tests/factor_invalid_2.move
+++ b/language/move-lang/tests/move_check/translated_ir_tests/borrow_tests/factor_invalid_2.move
@@ -1,0 +1,17 @@
+module M {
+    struct S { g: u64 }
+
+    fun t1(root: &mut S, cond: bool) {
+        let x1 = 0;
+        let eps = if (cond) bar(root) else &x1;
+        // Error: root has weak empty borrow and hence a field cannot be borrowed mutably
+        &mut root.g;
+        eps;
+    }
+
+    fun bar(a: &mut S): &u64 {
+        &a.g
+    }
+}
+
+// check: BORROWFIELD_EXISTS_MUTABLE_BORROW_ERROR

--- a/language/move-lang/tests/move_check/translated_ir_tests/borrow_tests/factor_valid_1.move
+++ b/language/move-lang/tests/move_check/translated_ir_tests/borrow_tests/factor_valid_1.move
@@ -1,0 +1,18 @@
+module M {
+    struct X { f: Y }
+    struct Y { g: u64, h: u64 }
+
+    fun t1() {
+        let x = X { f: Y { g: 0, h: 0 } };
+        let g = &mut x.f.g;
+        let h = &mut x.f.h;
+
+        *g = *h;
+        *h = *g;
+
+        foo(g, h);
+    }
+
+    fun foo(a: &mut u64, b: &mut u64) {
+    }
+}

--- a/language/move-lang/tests/move_check/translated_ir_tests/borrow_tests/factor_valid_2.move
+++ b/language/move-lang/tests/move_check/translated_ir_tests/borrow_tests/factor_valid_2.move
@@ -1,0 +1,45 @@
+module M {
+    struct S { g: u64 }
+
+    fun t1(root: &mut S, cond: bool) {
+        let x1 = 0;
+        let eps = if (cond) bar(root) else &x1;
+        let g = &root.g;
+        eps;
+        g;
+        eps;
+    }
+
+    fun t2() {
+        let x1 = 0;
+        let x2 = 1;
+        let eps = foo(&x1, &x2);
+        baz(&x1, eps);
+    }
+
+    fun t3() {
+        let x1 = 0;
+        let x2 = 1;
+        let eps = foo(&x1, &x2);
+        baz(freeze(&mut x1), eps);
+    }
+
+    fun foo(a: &u64, b: &u64): &u64 {
+        let ret;
+        if (*a > *b) {
+            ret = move a;
+            move b;
+        } else {
+            ret = move b;
+            move a;
+        };
+        ret
+    }
+
+    fun bar(a: &mut S): &u64 {
+        &a.g
+    }
+
+    fun baz(a: &u64, b: &u64) {
+    }
+}

--- a/language/move-lang/tests/move_check/translated_ir_tests/borrow_tests/imm_borrow_global_invalid.exp
+++ b/language/move-lang/tests/move_check/translated_ir_tests/borrow_tests/imm_borrow_global_invalid.exp
@@ -1,0 +1,33 @@
+error: 
+
+    ┌── tests/move_check/translated_ir_tests/borrow_tests/imm_borrow_global_invalid.move:29:18 ───
+    │
+ 30 │         let p2 = borrow_global_mut<Pair>(addr2);
+    │                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Invalid borrowing of resource 'Pair'
+    ·
+ 29 │         let p1 = borrow_global_mut<Pair>(addr1);
+    │                  ------------------------------ It is still being mutably borrowed by this reference
+    │
+
+error: 
+
+    ┌── tests/move_check/translated_ir_tests/borrow_tests/imm_borrow_global_invalid.move:35:18 ───
+    │
+ 36 │         let p2 = freeze(borrow_global_mut<Pair>(addr2));
+    │                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Invalid borrowing of resource 'Pair'
+    ·
+ 35 │         let p1 = freeze(borrow_global_mut<Pair>(addr1));
+    │                  -------------------------------------- It is still being borrowed by this reference
+    │
+
+error: 
+
+    ┌── tests/move_check/translated_ir_tests/borrow_tests/imm_borrow_global_invalid.move:41:18 ───
+    │
+ 42 │         let c2 = &borrow_global_mut<Pair>(addr2).x;
+    │                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Invalid borrowing of resource 'Pair'
+    ·
+ 41 │         let c1 = &borrow_global_mut<Pair>(addr1).x;
+    │                  --------------------------------- It is still being borrowed by this reference
+    │
+

--- a/language/move-lang/tests/move_check/translated_ir_tests/borrow_tests/imm_borrow_global_invalid.move
+++ b/language/move-lang/tests/move_check/translated_ir_tests/borrow_tests/imm_borrow_global_invalid.move
@@ -1,0 +1,57 @@
+address 0x42:
+
+module A {
+    resource struct Coin { u: u64 }
+
+    public fun new(): Coin {
+        Coin { u: 1 }
+    }
+
+    public fun join(c1: Coin, c2: Coin): Coin {
+        let Coin { u: u1 } = c1;
+        let Coin { u: u2 } = c2;
+        Coin { u: u1 + u2 }
+    }
+
+    public fun split(c1: Coin, amt: u64): (Coin, Coin) {
+        let Coin { u } = c1;
+        0x0::Transaction::assert(u >= amt, 42);
+        (Coin { u: u - amt }, Coin { u: amt })
+    }
+}
+
+module Tester {
+    use 0x42::A;
+
+    resource struct Pair { x: A::Coin, y: A::Coin }
+
+    fun no1(addr1: address, addr2: address): bool acquires Pair {
+        let p1 = borrow_global_mut<Pair>(addr1);
+        let p2 = borrow_global_mut<Pair>(addr2);
+        p1 == p2
+    }
+
+    fun no2(addr1: address, addr2: address): bool acquires Pair {
+        let p1 = freeze(borrow_global_mut<Pair>(addr1));
+        let p2 = freeze(borrow_global_mut<Pair>(addr2));
+        p1 == p2
+    }
+
+    fun no3(addr1: address, addr2: address): bool acquires Pair {
+        let c1 = &borrow_global_mut<Pair>(addr1).x;
+        let c2 = &borrow_global_mut<Pair>(addr2).x;
+        c1 == c2
+    }
+
+    // no4(addr1: address, addr2: address): bool acquires Pair {
+        // let c1 = *&borrow_global_mut<Pair>(addr1).x;
+        // let c2 = *&borrow_global_mut<Pair>(addr2).x;
+        // c1 == c2
+    // }
+
+}
+
+// check: GLOBAL_REFERENCE_ERROR
+// check: GLOBAL_REFERENCE_ERROR
+// check: GLOBAL_REFERENCE_ERROR
+// check: READREF_RESOURCE_ERROR

--- a/language/move-lang/tests/move_check/translated_ir_tests/borrow_tests/imm_borrow_global_lossy_acquire_invalid.exp
+++ b/language/move-lang/tests/move_check/translated_ir_tests/borrow_tests/imm_borrow_global_lossy_acquire_invalid.exp
@@ -1,0 +1,11 @@
+error: 
+
+    ┌── tests/move_check/translated_ir_tests/borrow_tests/imm_borrow_global_lossy_acquire_invalid.move:29:18 ───
+    │
+ 32 │         eq_helper(p1, addr2)
+    │         ^^^^^^^^^^^^^^^^^^^^ Invalid acquiring of resource 'Pair'
+    ·
+ 29 │         let p1 = borrow_global<Pair>(addr1);
+    │                  -------------------------- It is still being borrowed by this reference
+    │
+

--- a/language/move-lang/tests/move_check/translated_ir_tests/borrow_tests/imm_borrow_global_lossy_acquire_invalid.move
+++ b/language/move-lang/tests/move_check/translated_ir_tests/borrow_tests/imm_borrow_global_lossy_acquire_invalid.move
@@ -1,0 +1,42 @@
+address 0x42:
+
+module A {
+    resource struct Coin { u: u64 }
+
+    public fun new(): Coin {
+        Coin { u: 1 }
+    }
+
+    public fun join(c1: Coin, c2: Coin): Coin {
+        let Coin { u: u1 } = c1;
+        let Coin { u: u2 } = c2;
+        Coin { u: u1 + u2 }
+    }
+
+    public fun split(c1: Coin, amt: u64): (Coin, Coin) {
+        let Coin { u } = c1;
+        0x0::Transaction::assert(u >= amt, 42);
+        (Coin { u: u - amt }, Coin { u: amt })
+    }
+}
+
+module Tester {
+    use 0x42::A;
+
+    resource struct Pair { x: A::Coin, y: A::Coin }
+
+    fun test_eq(addr1: address, addr2: address): bool acquires Pair {
+        let p1 = borrow_global<Pair>(addr1);
+        // It is lossy in the sense that this could be acceptable if we had 'acquires imm Pair' or
+        // something to indicate the "acquires" are immutable
+        eq_helper(p1, addr2)
+    }
+
+    fun eq_helper(p1: &Pair, addr2: address): bool acquires Pair {
+        let p2 = borrow_global<Pair>(addr2);
+        p1 == p2
+    }
+
+}
+
+// check: GLOBAL_REFERENCE_ERROR

--- a/language/move-lang/tests/move_check/translated_ir_tests/borrow_tests/imm_borrow_global_requires_acquire.exp
+++ b/language/move-lang/tests/move_check/translated_ir_tests/borrow_tests/imm_borrow_global_requires_acquire.exp
@@ -1,0 +1,11 @@
+error: 
+
+   ┌── tests/move_check/translated_ir_tests/borrow_tests/imm_borrow_global_requires_acquire.move:5:9 ───
+   │
+ 5 │         borrow_global<T1>(addr);
+   │         ^^^^^^^^^^^^^^^^^^^^^^^ Invalid call to borrow_global.
+   ·
+ 5 │         borrow_global<T1>(addr);
+   │                       -- The call acquires '0x8675309::A::T1', but the 'acquires' list for the current function does not contain this type. It must be present in the calling context's acquires list
+   │
+

--- a/language/move-lang/tests/move_check/translated_ir_tests/borrow_tests/imm_borrow_global_requires_acquire.move
+++ b/language/move-lang/tests/move_check/translated_ir_tests/borrow_tests/imm_borrow_global_requires_acquire.move
@@ -1,0 +1,10 @@
+module A {
+    resource struct T1{ b: bool }
+
+    public fun test(addr: address) {
+        borrow_global<T1>(addr);
+    }
+
+}
+
+// check: MISSING_ACQUIRES_RESOURCE_ANNOTATION_ERROR

--- a/language/move-lang/tests/move_check/translated_ir_tests/borrow_tests/imm_borrow_loc.move
+++ b/language/move-lang/tests/move_check/translated_ir_tests/borrow_tests/imm_borrow_loc.move
@@ -1,0 +1,31 @@
+module Tester {
+    resource struct Data { v1: u64, v2: u64 }
+    resource struct Box { f: u64 }
+
+    // the resource struct is here to just give a feeling why the computation might not be reorderable
+    fun bump_and_pick(b1: &mut Box, b2: &mut Box): &u64 acquires Data {
+        let data = borrow_global_mut<Data>(0x0::Transaction::sender());
+        b1.f = data.v1;
+        b2.f = data.v2;
+        if (b1.f > b2.f) &b1.f else &b2.f
+    }
+
+    fun larger_field(drop: address, result: &mut u64) acquires Box, Data {
+        let b1 = move_from<Box>(0x0::Transaction::sender());
+        let b2 = move_from<Box>(drop);
+
+        0x0::Transaction::assert(b1.f == 0, 42);
+        0x0::Transaction::assert(b2.f == 0, 42);
+
+        let returned_ref = bump_and_pick(&mut b1, &mut b2);
+
+        // imagine some more interesting check than these asserts
+        0x0::Transaction::assert(b1.f != 0, 42);
+        0x0::Transaction::assert(b2.f != 0, 42);
+        0x0::Transaction::assert((returned_ref == &b1.f) != (returned_ref == &b2.f), 42);
+
+        *result = *returned_ref;
+        move_to_sender<Box>(b1);
+        Box { f: _ } = b2;
+    }
+}

--- a/language/move-lang/tests/move_check/translated_ir_tests/borrow_tests/imm_borrow_loc_trivial.move
+++ b/language/move-lang/tests/move_check/translated_ir_tests/borrow_tests/imm_borrow_loc_trivial.move
@@ -1,0 +1,18 @@
+module Tester {
+    resource struct X { f: u64 }
+
+    fun bump_and_give(x_ref: &mut X, other: &u64): &u64 {
+        x_ref.f = x_ref.f + 1;
+        &x_ref.f
+    }
+
+    fun contrived_example(result: &mut u64) {
+        let x = X { f: 0 };
+        let other = 100;
+        let returned_ref = bump_and_give(&mut x, &other);
+        // imagine some more interesting check than this assert
+        0x0::Transaction::assert(*returned_ref == x.f, 42);
+        *result = *returned_ref;
+        X { f: _ } = x;
+    }
+}

--- a/language/move-lang/tests/move_check/translated_ir_tests/borrow_tests/imm_borrow_loc_trivial_valid.move
+++ b/language/move-lang/tests/move_check/translated_ir_tests/borrow_tests/imm_borrow_loc_trivial_valid.move
@@ -1,0 +1,18 @@
+module Tester {
+    resource struct X { f: u64 }
+
+    fun bump_and_give(x_ref: &mut X, other: &u64): &u64 {
+        x_ref.f = x_ref.f + 1;
+        &x_ref.f
+    }
+
+    fun contrived_example(result: &mut u64) {
+        let x = X { f: 0 };
+        let other = 100;
+        let returned_ref = bump_and_give(&mut x, &other);
+        // imagine some more interesting check than this assert
+        0x0::Transaction::assert(*returned_ref == freeze(&mut x).f, 42);
+        *result = *returned_ref;
+        X { f: _ } = x;
+    }
+}

--- a/language/move-lang/tests/move_check/translated_ir_tests/borrow_tests/imm_borrow_loc_valid.move
+++ b/language/move-lang/tests/move_check/translated_ir_tests/borrow_tests/imm_borrow_loc_valid.move
@@ -1,0 +1,34 @@
+module Tester {
+    resource struct Data { v1: u64, v2: u64 }
+    resource struct Box { f: u64 }
+
+    // the resource struct is here to just give a feeling why the computation might not be reorderable
+    fun bump_and_pick(b1: &mut Box, b2: &mut Box): &u64 acquires Data {
+        let data = borrow_global_mut<Data>(0x0::Transaction::sender());
+        b1.f = data.v1;
+        b2.f = data.v2;
+        if (b1.f > b2.f) &b1.f else &b2.f
+    }
+
+    fun larger_field(drop: address, result: &mut u64) acquires Box, Data {
+        let b1 = move_from<Box>(0x0::Transaction::sender());
+        let b2 = move_from<Box>(drop);
+
+        0x0::Transaction::assert(b1.f == 0, 42);
+        0x0::Transaction::assert(b2.f == 0, 42);
+
+        let returned_ref = bump_and_pick(&mut b1, &mut b2);
+
+        // imagine some more interesting check than these asserts
+        0x0::Transaction::assert(b1.f != 0, 42);
+        0x0::Transaction::assert(b2.f != 0, 42);
+        0x0::Transaction::assert(
+            (returned_ref == &(&mut b1).f) != (returned_ref == &(&mut b2).f),
+            42
+        );
+
+        *result = *returned_ref;
+        move_to_sender<Box>(b1);
+        Box { f: _ } = b2;
+    }
+}

--- a/language/move-lang/tests/move_check/translated_ir_tests/borrow_tests/imm_borrow_on_mut.move
+++ b/language/move-lang/tests/move_check/translated_ir_tests/borrow_tests/imm_borrow_on_mut.move
@@ -1,0 +1,33 @@
+module Tester {
+    resource struct Initializer { x: u64, y: u64 }
+    struct Point { x: u64, y: u64 }
+
+    // the resource struct is here to just give a feeling why the computation might not be reorderable
+    fun set_and_pick(p: &mut Point): &mut u64 acquires Initializer {
+        let init = borrow_global_mut<Initializer>(0x0::Transaction::sender());
+        p.x = init.x;
+        p.y = init.y;
+        if (p.x >= p.y) &mut p.x else &mut p.y
+    }
+
+    fun bump_and_give(u: &mut u64): &u64 {
+        *u = *u + 1;
+        freeze(u)
+    }
+
+    fun larger_field(point_ref: &mut Point): &u64 acquires Initializer {
+        0x0::Transaction::assert(point_ref.x == 0, 42);
+        0x0::Transaction::assert(point_ref.y == 0, 42);
+
+        let field_ref = set_and_pick(point_ref);
+        let returned_ref = bump_and_give(field_ref);
+
+        // imagine some more interesting check than this assert
+        0x0::Transaction::assert(
+            (*returned_ref == point_ref.x) &&
+            (*returned_ref != point_ref.y),
+            42
+        );
+        returned_ref
+    }
+}

--- a/language/move-lang/tests/move_check/translated_ir_tests/borrow_tests/imm_borrow_on_mut_invalid.exp
+++ b/language/move-lang/tests/move_check/translated_ir_tests/borrow_tests/imm_borrow_on_mut_invalid.exp
@@ -1,0 +1,22 @@
+error: 
+
+    ┌── tests/move_check/translated_ir_tests/borrow_tests/imm_borrow_on_mut_invalid.move:21:25 ───
+    │
+ 22 │         let x_val = *freeze(&mut point_ref.x);
+    │                             ^^^^^^^^^^^^^^^^ Invalid mutable borrow at field 'x'.
+    ·
+ 21 │         let field_ref = set_and_pick(copy point_ref);
+    │                         ---------------------------- It is still being mutably borrowed by this reference
+    │
+
+error: 
+
+    ┌── tests/move_check/translated_ir_tests/borrow_tests/imm_borrow_on_mut_invalid.move:35:25 ───
+    │
+ 36 │         let x_val = *&freeze(point_ref).x;
+    │                       ^^^^^^^^^^^^^^^^^ Invalid freeze.
+    ·
+ 35 │         let field_ref = set_and_pick(copy point_ref);
+    │                         ---------------------------- It is still being mutably borrowed by this reference
+    │
+

--- a/language/move-lang/tests/move_check/translated_ir_tests/borrow_tests/imm_borrow_on_mut_invalid.move
+++ b/language/move-lang/tests/move_check/translated_ir_tests/borrow_tests/imm_borrow_on_mut_invalid.move
@@ -1,0 +1,49 @@
+module Tester {
+    resource struct Initializer { x: u64, y: u64 }
+    struct Point { x: u64, y: u64 }
+
+    // the resource struct is here to just give a feeling why the computation might not be reorderable
+    fun set_and_pick(p: &mut Point): &mut u64 acquires Initializer {
+        let init = borrow_global_mut<Initializer>(0x0::Transaction::sender());
+        p.x = init.x;
+        p.y = init.y;
+        if (p.x >= p.y) &mut p.x else &mut p.y
+    }
+
+    fun bump_and_give(u: &mut u64): &u64 {
+        *u = *u + 1;
+        freeze(u)
+    }
+
+    fun larger_field_1(point_ref: &mut Point): &u64 acquires Initializer {
+        0x0::Transaction::assert(point_ref.x == 0, 42);
+        0x0::Transaction::assert(point_ref.y == 0, 42);
+        let field_ref = set_and_pick(copy point_ref);
+        let x_val = *freeze(&mut point_ref.x);
+        let returned_ref = bump_and_give(field_ref);
+        // imagine some more interesting check than this assert
+        0x0::Transaction::assert(
+            *returned_ref == x_val + 1,
+            42
+        );
+        returned_ref
+    }
+
+    fun larger_field_2(point_ref: &mut Point): &u64 acquires Initializer {
+        0x0::Transaction::assert(point_ref.x == 0, 42);
+        0x0::Transaction::assert(point_ref.y == 0, 42);
+        let field_ref = set_and_pick(copy point_ref);
+        let x_val = *&freeze(point_ref).x;
+        let returned_ref = bump_and_give(field_ref);
+        // imagine some more interesting check than this assert
+        0x0::Transaction::assert(
+            *copy returned_ref == (x_val + 1),
+            42
+        );
+        returned_ref
+    }
+
+}
+
+// check: BORROWFIELD_EXISTS_MUTABLE_BORROW_ERROR
+// check: FREEZEREF_EXISTS_MUTABLE_BORROW_ERROR

--- a/language/move-lang/tests/move_check/translated_ir_tests/borrow_tests/imm_borrow_on_mut_trivial.move
+++ b/language/move-lang/tests/move_check/translated_ir_tests/borrow_tests/imm_borrow_on_mut_trivial.move
@@ -1,0 +1,15 @@
+module Tester {
+    struct X { f: u64 }
+
+    fun bump_and_give(x_ref: &mut X): &u64 {
+        x_ref.f = x_ref.f + 1;
+        &x_ref.f
+    }
+
+    fun contrived_example(x_ref: &mut X): &u64 {
+        let returned_ref = bump_and_give(x_ref);
+        // imagine some more interesting check than this assert
+        0x0::Transaction::assert(*returned_ref == *&x_ref.f, 42);
+        returned_ref
+    }
+}

--- a/language/move-lang/tests/move_check/translated_ir_tests/borrow_tests/imm_borrow_on_mut_trivial_invalid.exp
+++ b/language/move-lang/tests/move_check/translated_ir_tests/borrow_tests/imm_borrow_on_mut_trivial_invalid.exp
@@ -1,0 +1,11 @@
+error: 
+
+    ┌── tests/move_check/translated_ir_tests/borrow_tests/imm_borrow_on_mut_trivial_invalid.move:10:28 ───
+    │
+ 12 │         0x0::Transaction::assert(*returned_ref == *freeze(&mut x_ref.f) + 1, 42);
+    │                                                           ^^^^^^^^^^^^ Invalid mutable borrow at field 'f'.
+    ·
+ 10 │         let returned_ref = bump_and_give(x_ref);
+    │                            -------------------- It is still being borrowed by this reference
+    │
+

--- a/language/move-lang/tests/move_check/translated_ir_tests/borrow_tests/imm_borrow_on_mut_trivial_invalid.move
+++ b/language/move-lang/tests/move_check/translated_ir_tests/borrow_tests/imm_borrow_on_mut_trivial_invalid.move
@@ -1,0 +1,25 @@
+module Tester {
+    struct X { f: u64 }
+
+    fun bump_and_give(x_ref: &mut X): &u64 {
+        x_ref.f = x_ref.f + 1;
+        &x_ref.f
+    }
+
+    fun contrived_example_no(x_ref: &mut X): &u64 {
+        let returned_ref = bump_and_give(x_ref);
+        // ERROR Cannot mutably borrow from `x_ref` it is being borrowed by `returned_ref`
+        0x0::Transaction::assert(*returned_ref == *freeze(&mut x_ref.f) + 1, 42);
+        returned_ref
+    }
+
+    fun contrived_example_valid(x_ref: &mut X): &u64 {
+        let returned_ref = bump_and_give(x_ref);
+        // This is still valid, but might not be in other cases. See other Imm Borrow tests
+        // i.e. you might hit FreezeRefExistsMutableBorrowError
+        0x0::Transaction::assert(*returned_ref == *(&freeze(x_ref).f) + 1, 42);
+        returned_ref
+    }
+}
+
+// check: BORROWFIELD_EXISTS_MUTABLE_BORROW_ERROR

--- a/language/move-lang/tests/move_check/translated_ir_tests/borrow_tests/join_borrow_unavailable_valid.move
+++ b/language/move-lang/tests/move_check/translated_ir_tests/borrow_tests/join_borrow_unavailable_valid.move
@@ -1,0 +1,15 @@
+module M {
+    struct S { f: u64 }
+
+    fun t1(root: &mut S, cond: bool) {
+        let u = 0;
+
+        let x = if (cond) {
+            &u
+        } else {
+            move u;
+            &root.f
+        };
+        *x;
+    }
+}

--- a/language/move-lang/tests/move_check/translated_ir_tests/borrow_tests/move_one_branch.move
+++ b/language/move-lang/tests/move_check/translated_ir_tests/borrow_tests/move_one_branch.move
@@ -1,0 +1,22 @@
+module M {
+    fun t0(cond: bool) {
+        let x = 0;
+        let x_ref = &mut x;
+        if (cond) {
+            *move x_ref = 1;
+        };
+        x = 1;
+        x;
+    }
+
+    fun t1(cond: bool) {
+        let x = 0;
+        let x_ref = &mut x;
+        if (cond) {
+        } else {
+            *move x_ref = 1;
+        };
+        x = 1;
+        x;
+    }
+}

--- a/language/move-lang/tests/move_check/translated_ir_tests/borrow_tests/mutable_borrow_invalid.exp
+++ b/language/move-lang/tests/move_check/translated_ir_tests/borrow_tests/mutable_borrow_invalid.exp
@@ -1,0 +1,22 @@
+error: 
+
+   ┌── tests/move_check/translated_ir_tests/borrow_tests/mutable_borrow_invalid.move:6:27 ───
+   │
+ 9 │         root.f = 1;
+   │         ^^^^^^^^^^ Invalid mutation of reference.
+   ·
+ 6 │         let x = if (cond) &mut root.f else &mut root.g;
+   │                           ----------- It is still being mutably borrowed by this reference
+   │
+
+error: 
+
+    ┌── tests/move_check/translated_ir_tests/borrow_tests/mutable_borrow_invalid.move:14:27 ───
+    │
+ 17 │         foo(x, &mut root.f);
+    │         ^^^^^^^^^^^^^^^^^^^ Invalid usage of reference as function argument. Cannot transfer a mutable reference that is being borrowed
+    ·
+ 14 │         let x = if (cond) &mut root.f else &mut root.g;
+    │                           ----------- It is still being mutably borrowed by this reference
+    │
+

--- a/language/move-lang/tests/move_check/translated_ir_tests/borrow_tests/mutable_borrow_invalid.move
+++ b/language/move-lang/tests/move_check/translated_ir_tests/borrow_tests/mutable_borrow_invalid.move
@@ -1,0 +1,25 @@
+module M {
+    struct S { f: u64, g: u64, h: u64 }
+
+
+    fun t1(root: &mut S, cond: bool) {
+        let x = if (cond) &mut root.f else &mut root.g;
+
+        // INVALID
+        root.f = 1;
+        *x;
+    }
+
+    fun t2(root: &mut S, cond: bool) {
+        let x = if (cond) &mut root.f else &mut root.g;
+
+        // INVALID
+        foo(x, &mut root.f);
+    }
+
+    fun foo(x: &mut u64, y: &mut u64) {
+    }
+}
+
+// check: WRITEREF_EXISTS_BORROW_ERROR
+// check: CALL_BORROWED_MUTABLE_REFERENCE_ERROR

--- a/language/move-lang/tests/move_check/translated_ir_tests/borrow_tests/mutable_borrow_local_twice.move
+++ b/language/move-lang/tests/move_check/translated_ir_tests/borrow_tests/mutable_borrow_local_twice.move
@@ -1,0 +1,9 @@
+module M {
+    fun t1() {
+        let a = 0;
+        let r1 = &mut a;
+        let r2 = &mut a;
+        *r1 = 1;
+        *r2 = 2;
+    }
+}

--- a/language/move-lang/tests/move_check/translated_ir_tests/borrow_tests/mutable_borrow_local_twice_invalid.exp
+++ b/language/move-lang/tests/move_check/translated_ir_tests/borrow_tests/mutable_borrow_local_twice_invalid.exp
@@ -1,0 +1,11 @@
+error: 
+
+   ┌── tests/move_check/translated_ir_tests/borrow_tests/mutable_borrow_local_twice_invalid.move:4:18 ───
+   │
+ 6 │         *r2 = 2;
+   │         ^^^^^^^ Invalid mutation of reference.
+   ·
+ 4 │         let r1 = &mut a;
+   │                  ------ It is still being mutably borrowed by this reference
+   │
+

--- a/language/move-lang/tests/move_check/translated_ir_tests/borrow_tests/mutable_borrow_local_twice_invalid.move
+++ b/language/move-lang/tests/move_check/translated_ir_tests/borrow_tests/mutable_borrow_local_twice_invalid.move
@@ -1,0 +1,11 @@
+module M {
+    fun t1() {
+        let a = 0;
+        let r1 = &mut a;
+        let r2 = &mut a;
+        *r2 = 2;
+        *r1 = 1;
+    }
+}
+
+// check: WRITEREF_EXISTS_BORROW_ERROR

--- a/language/move-lang/tests/move_check/translated_ir_tests/borrow_tests/mutate_with_borrowed_loc.move
+++ b/language/move-lang/tests/move_check/translated_ir_tests/borrow_tests/mutate_with_borrowed_loc.move
@@ -1,0 +1,9 @@
+module M {
+    fun t1() {
+        let x = 0;
+        let y = &x;
+        y;
+        y = &x;
+        y;
+    }
+}

--- a/language/move-lang/tests/move_check/translated_ir_tests/borrow_tests/mutate_with_borrowed_loc_invalid.exp
+++ b/language/move-lang/tests/move_check/translated_ir_tests/borrow_tests/mutate_with_borrowed_loc_invalid.exp
@@ -1,0 +1,11 @@
+error: 
+
+   ┌── tests/move_check/translated_ir_tests/borrow_tests/mutate_with_borrowed_loc_invalid.move:4:17 ───
+   │
+ 5 │         x = 0;
+   │         ^ Invalid assignment of local 'x'
+   ·
+ 4 │         let y = &x;
+   │                 -- It is still being borrowed by this reference
+   │
+

--- a/language/move-lang/tests/move_check/translated_ir_tests/borrow_tests/mutate_with_borrowed_loc_invalid.move
+++ b/language/move-lang/tests/move_check/translated_ir_tests/borrow_tests/mutate_with_borrowed_loc_invalid.move
@@ -1,0 +1,12 @@
+module M {
+    fun t1() {
+        let x = 0;
+        let y = &x;
+        x = 0;
+        y;
+        x;
+    }
+
+}
+
+// check: STLOC_UNSAFE_TO_DESTROY_ERROR

--- a/language/move-lang/tests/move_check/translated_ir_tests/borrow_tests/mutate_with_borrowed_loc_struct_invalid.exp
+++ b/language/move-lang/tests/move_check/translated_ir_tests/borrow_tests/mutate_with_borrowed_loc_struct_invalid.exp
@@ -1,0 +1,33 @@
+error: 
+
+   ┌── tests/move_check/translated_ir_tests/borrow_tests/mutate_with_borrowed_loc_struct_invalid.move:5:13 ───
+   │
+ 7 │         x = X { b: true };
+   │         ^ Invalid assignment to local 'x'
+   ·
+ 5 │         let x = X { b: true };
+   │             - The local contains a resource value due to this assignment. The resource must be used before you assign to this local again
+   │
+
+error: 
+
+   ┌── tests/move_check/translated_ir_tests/borrow_tests/mutate_with_borrowed_loc_struct_invalid.move:6:17 ───
+   │
+ 7 │         x = X { b: true };
+   │         ^ Invalid assignment of local 'x'
+   ·
+ 6 │         let y = &x;
+   │                 -- It is still being borrowed by this reference
+   │
+
+error: 
+
+    ┌── tests/move_check/translated_ir_tests/borrow_tests/mutate_with_borrowed_loc_struct_invalid.move:15:17 ───
+    │
+ 16 │         s = S { z: 7 };
+    │         ^ Invalid assignment of local 's'
+    ·
+ 15 │         let z = &y.z;
+    │                 ---- It is still being borrowed by this reference
+    │
+

--- a/language/move-lang/tests/move_check/translated_ir_tests/borrow_tests/mutate_with_borrowed_loc_struct_invalid.move
+++ b/language/move-lang/tests/move_check/translated_ir_tests/borrow_tests/mutate_with_borrowed_loc_struct_invalid.move
@@ -1,0 +1,24 @@
+module M {
+    resource struct X { b: bool }
+    struct S { z: u64 }
+    fun t1() {
+        let x = X { b: true };
+        let y = &x;
+        x = X { b: true };
+        move y;
+        X { b: _ } = x;
+    }
+
+    fun t2() {
+        let s = S { z: 2 };
+        let y = &s;
+        let z = &y.z;
+        s = S { z: 7 };
+        z;
+        s;
+    }
+
+}
+
+// check: STLOC_UNSAFE_TO_DESTROY_ERROR
+// check: STLOC_UNSAFE_TO_DESTROY_ERROR

--- a/language/move-lang/tests/move_check/translated_ir_tests/borrow_tests/ref_moved_one_branch.move
+++ b/language/move-lang/tests/move_check/translated_ir_tests/borrow_tests/ref_moved_one_branch.move
@@ -1,0 +1,13 @@
+module A {
+    struct S {value: u64}
+
+    public fun t(changed: bool, s: &mut S) {
+        if (changed) {
+            foo(&mut move s.value);
+        }
+    }
+
+    fun foo(x: &mut u64) {
+        *x = *x + 1;
+    }
+}

--- a/language/move-lang/tests/move_check/translated_ir_tests/borrow_tests/release_cycle.move
+++ b/language/move-lang/tests/move_check/translated_ir_tests/borrow_tests/release_cycle.move
@@ -1,0 +1,16 @@
+module M {
+    fun t0(cond: bool) {
+        let v = 0;
+        let x;
+        let y;
+        if (move cond) {
+            x = &v;
+            y = copy x;
+        } else {
+            y = &v;
+            x = copy y;
+        };
+        move x;
+        move y;
+    }
+}

--- a/language/move-lang/tests/move_check/translated_ir_tests/borrow_tests/return_with_borrowed_loc.move
+++ b/language/move-lang/tests/move_check/translated_ir_tests/borrow_tests/return_with_borrowed_loc.move
@@ -1,0 +1,20 @@
+module M {
+    struct X { y: Y }
+    struct Y { u: u64 }
+
+    fun t1() {
+        let x = 0;
+        let y = &x;
+        copy y;
+    }
+
+    fun t2() {
+        let s = X { y: Y { u: 0 } };
+        let x = &s;
+        let y = &x.y;
+        let u = &y.u;
+        copy x;
+        copy y;
+        copy u;
+    }
+}

--- a/language/move-lang/tests/move_check/translated_ir_tests/borrow_tests/return_with_borrowed_loc_invalid.exp
+++ b/language/move-lang/tests/move_check/translated_ir_tests/borrow_tests/return_with_borrowed_loc_invalid.exp
@@ -1,0 +1,44 @@
+error: 
+
+   ┌── tests/move_check/translated_ir_tests/borrow_tests/return_with_borrowed_loc_invalid.move:7:9 ───
+   │
+ 7 │         &x
+   │         ^^ Invalid return. Local 'x' is still being borrowed.
+   ·
+ 7 │         &x
+   │         -- It is still being borrowed by this reference
+   │
+
+error: 
+
+    ┌── tests/move_check/translated_ir_tests/borrow_tests/return_with_borrowed_loc_invalid.move:13:9 ───
+    │
+ 13 │         copy y
+    │         ^^^^^^ Invalid return. Local 'x' is still being borrowed.
+    ·
+ 13 │         copy y
+    │         ------ It is still being borrowed by this reference
+    │
+
+error: 
+
+    ┌── tests/move_check/translated_ir_tests/borrow_tests/return_with_borrowed_loc_invalid.move:20:17 ───
+    │
+ 21 │         move u
+    │         ^^^^^^ Invalid return. Local 's' is still being borrowed.
+    ·
+ 20 │         let u = &y.u;
+    │                 ---- It is still being borrowed by this reference
+    │
+
+error: 
+
+    ┌── tests/move_check/translated_ir_tests/borrow_tests/return_with_borrowed_loc_invalid.move:29:9 ───
+    │
+ 29 │         copy u
+    │         ^^^^^^ Invalid return. Local 's' is still being borrowed.
+    ·
+ 29 │         copy u
+    │         ------ It is still being borrowed by this reference
+    │
+

--- a/language/move-lang/tests/move_check/translated_ir_tests/borrow_tests/return_with_borrowed_loc_invalid.move
+++ b/language/move-lang/tests/move_check/translated_ir_tests/borrow_tests/return_with_borrowed_loc_invalid.move
@@ -1,0 +1,36 @@
+module M {
+    struct X { y: Y }
+    struct Y { u: u64 }
+
+    fun t1(): &u64 {
+        let x = 0;
+        &x
+    }
+
+    fun t2(): &u64 {
+        let x = 0;
+        let y = &x;
+        copy y
+    }
+
+    fun t3(): &u64 {
+        let s = X { y: Y { u: 0 } };
+        let x = &s;
+        let y = &x.y;
+        let u = &y.u;
+        move u
+    }
+
+    fun t4(): &u64 {
+        let s = X { y: Y { u: 0 } };
+        let x = &s;
+        let y = &x.y;
+        let u = &y.u;
+        copy u
+    }
+}
+
+// check: RET_UNSAFE_TO_DESTROY_ERROR
+// check: RET_UNSAFE_TO_DESTROY_ERROR
+// check: RET_UNSAFE_TO_DESTROY_ERROR
+// check: RET_UNSAFE_TO_DESTROY_ERROR

--- a/language/move-lang/tests/move_check/translated_ir_tests/borrow_tests/return_with_borrowed_loc_resource_invalid.exp
+++ b/language/move-lang/tests/move_check/translated_ir_tests/borrow_tests/return_with_borrowed_loc_resource_invalid.exp
@@ -1,0 +1,16 @@
+error: 
+
+   ┌── tests/move_check/translated_ir_tests/borrow_tests/return_with_borrowed_loc_resource_invalid.move:4:13 ───
+   │
+ 4 │       fun t() {
+   │ ╭─────────────^
+ 5 │ │         let s = X { u: 0 };
+ 6 │ │         let u = &s.u;
+ 7 │ │         copy u;
+ 8 │ │     }
+   │ ╰─────^ Invalid return
+   ·
+ 5 │         let s = X { u: 0 };
+   │             - The local 's' still contains a resource value due to this assignment. The resource must be consumed before the function returns
+   │
+

--- a/language/move-lang/tests/move_check/translated_ir_tests/borrow_tests/return_with_borrowed_loc_resource_invalid.move
+++ b/language/move-lang/tests/move_check/translated_ir_tests/borrow_tests/return_with_borrowed_loc_resource_invalid.move
@@ -1,0 +1,11 @@
+module M {
+    resource struct X { u: u64 }
+
+    fun t() {
+        let s = X { u: 0 };
+        let u = &s.u;
+        copy u;
+    }
+}
+
+// check: RET_UNSAFE_TO_DESTROY_ERROR

--- a/language/move-lang/tests/move_check/translated_ir_tests/borrow_tests/writeref_borrow_invalid.exp
+++ b/language/move-lang/tests/move_check/translated_ir_tests/borrow_tests/writeref_borrow_invalid.exp
@@ -1,0 +1,11 @@
+error: 
+
+    ┌── tests/move_check/translated_ir_tests/borrow_tests/writeref_borrow_invalid.move:6:21 ───
+    │
+ 10 │         *g_mut = G { v: 0 };
+    │         ^^^^^^^^^^^^^^^^^^^ Invalid mutation of reference.
+    ·
+ 6 │         let v_mut = &mut root.g.v;
+    │                     ------------- Field 'v' is still being mutably borrowed by this reference
+    │
+

--- a/language/move-lang/tests/move_check/translated_ir_tests/borrow_tests/writeref_borrow_invalid.move
+++ b/language/move-lang/tests/move_check/translated_ir_tests/borrow_tests/writeref_borrow_invalid.move
@@ -1,0 +1,15 @@
+module M {
+    struct G { v: u64 }
+    struct S { g: G }
+
+    fun t1(root: &mut S, cond: bool) {
+        let v_mut = &mut root.g.v;
+        let g_mut = &mut root.g;
+
+        // INVALID
+        *g_mut = G { v: 0 };
+        v_mut;
+    }
+}
+
+// check: WRITEREF_EXISTS_BORROW_ERROR

--- a/language/move-lang/tests/move_check/translated_ir_tests/borrow_tests/writeref_borrow_valid1.move
+++ b/language/move-lang/tests/move_check/translated_ir_tests/borrow_tests/writeref_borrow_valid1.move
@@ -1,0 +1,16 @@
+module M {
+    struct G { v1: u64, v2: u64 }
+    struct S { g1: G, g2: G }
+
+    fun t1(root: &mut S, cond: bool) {
+        let v1_mut = &mut root.g1.v1;
+        let v2_mut = &mut root.g1.v2;
+        let g2_mut = &mut root.g2;
+
+        *g2_mut = G { v1: 0, v2: 0 };
+        *v2_mut = 0;
+        *v1_mut = 1;
+        v2_mut;
+        g2_mut;
+    }
+}

--- a/language/move-lang/tests/move_check/translated_ir_tests/borrow_tests/writeref_borrow_valid2.move
+++ b/language/move-lang/tests/move_check/translated_ir_tests/borrow_tests/writeref_borrow_valid2.move
@@ -1,0 +1,17 @@
+module M {
+    struct S { f: u64, g: u64, h: u64 }
+
+    fun t1(root: &mut S, cond: bool) {
+        let x = if (cond) &mut root.f else &mut root.g;
+        root.h = 0;
+        x;
+    }
+
+    fun t2(root: &mut S, cond: bool) {
+        let x = if (cond) &mut root.f else &mut root.g;
+
+        &mut root.f;
+        &mut root.g;
+        x;
+    }
+}

--- a/language/move-lang/tests/move_check_testsuite.rs
+++ b/language/move-lang/tests/move_check_testsuite.rs
@@ -12,6 +12,7 @@ const EXP_EXT: &str = "exp";
 
 const KEEP_TMP: &str = "KEEP";
 const UPDATE_BASELINE: &str = "UPDATE_BASELINE";
+const UB: &str = "UB";
 
 fn format_diff(expected: String, actual: String) -> String {
     use difference::*;
@@ -65,7 +66,7 @@ fn move_check_testsuite(path: &Path) -> datatest_stable::Result<()> {
     };
 
     let save_errors = read_bool_var(KEEP_TMP);
-    let update_baseline = read_bool_var(UPDATE_BASELINE);
+    let update_baseline = read_bool_var(UPDATE_BASELINE) || read_bool_var(UB);
 
     fs::write(out_path.clone(), error_buffer)?;
     let rendered_errors = fs::read_to_string(out_path.clone())?;


### PR DESCRIPTION
##  Motivation

- Migrated IR borrow_tests
- Fixed bug where acquires were counted as necessary/useful on recursive calls
- Fixed issue where pops were inserted for reference locals without a value
  - This fix will lead to a fix for last copy ~> move in a later PR
- Fixed issue where the borrow checker did not check for released references to global storage
- Fixed a panics in the borrow checker that relied on valid locals
  - This needs to be improved in a future PR

## Test Plan

Migrated + ran

