### PR TITLE
[libra-swarm] Fix: Update 'client' to 'cli' to fix broken libra-swarm scripts

### DIFF
--- a/libra-swarm/src/client.rs
+++ b/libra-swarm/src/client.rs
@@ -50,7 +50,7 @@ impl InteractiveClient {
         // unless we convert it to an absolute path
         Self {
             client: Some(
-                Command::new(workspace_builder::get_bin("client"))
+                Command::new(workspace_builder::get_bin("cli"))
                     .current_dir(workspace_builder::workspace_root())
                     .arg("-p")
                     .arg(port.to_string())
@@ -91,7 +91,7 @@ impl InteractiveClient {
             /// from the client CLI. Comment the stdout/stderr lines below
             /// and enjoy pretty Matrix-style output.
             client: Some(
-                Command::new(workspace_builder::get_bin("client"))
+                Command::new(workspace_builder::get_bin("cli"))
                     .current_dir(workspace_builder::workspace_root())
                     .arg("-p")
                     .arg(port.to_string())


### PR DESCRIPTION
## Motivation

Due to a recent renaming of 'client' to 'cli' in a previous PR (https://github.com/libra/libra/pull/2319/), 'libra-swarm' when given the '-s' flag looks for the 'client' binary instead of the 'cli' binary and fails. This PR updates the reference.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?

Yes.

## Test Plan

In addition to the usual tests (e.g. 'cargo xtest'), running 'cargo run -p libra-swarm -- -s -n 4' works locally and does not produce any errors when executing the client binary.

## Related PRs

None.
