### PR TITLE
[Storage] Move state store backup code to BackupHandler

### DIFF
--- a/storage/libradb/src/backup/mod.rs
+++ b/storage/libradb/src/backup/mod.rs
@@ -6,28 +6,34 @@ mod test;
 
 use crate::{
     ledger_store::{LedgerStore, TransactionInfoIter},
+    state_store::StateStore,
     transaction_store::{TransactionIter, TransactionStore},
 };
 use anyhow::Result;
-use libra_types::transaction::Version;
+use jellyfish_merkle::iterator::JellyfishMerkleIterator;
+use libra_crypto::hash::HashValue;
+use libra_types::{
+    account_state_blob::AccountStateBlob, proof::SparseMerkleRangeProof, transaction::Version,
+};
 use std::sync::Arc;
 
 /// `BackupHandler` provides functionalities for LibraDB data backup.
-///
-/// TODO: move the account state related code here.
 pub struct BackupHandler {
     ledger_store: Arc<LedgerStore>,
     transaction_store: Arc<TransactionStore>,
+    state_store: Arc<StateStore>,
 }
 
 impl BackupHandler {
     pub(crate) fn new(
         ledger_store: Arc<LedgerStore>,
         transaction_store: Arc<TransactionStore>,
+        state_store: Arc<StateStore>,
     ) -> Self {
         Self {
             ledger_store,
             transaction_store,
+            state_store,
         }
     }
 
@@ -49,5 +55,28 @@ impl BackupHandler {
     ) -> Result<TransactionInfoIter> {
         self.ledger_store
             .get_transaction_info_iter(start_version, num_transaction_infos)
+    }
+
+    /// Gets an iterator which can yield all accounts in the state tree.
+    pub fn get_account_iter(
+        &self,
+        version: Version,
+    ) -> Result<Box<dyn Iterator<Item = Result<(HashValue, AccountStateBlob)>> + Send>> {
+        let iterator = JellyfishMerkleIterator::new(
+            Arc::clone(&self.state_store),
+            version,
+            HashValue::zero(),
+        )?;
+        Ok(Box::new(iterator))
+    }
+
+    /// Gets the proof that proves a range of accounts.
+    pub fn get_account_state_range_proof(
+        &self,
+        rightmost_key: HashValue,
+        version: Version,
+    ) -> Result<SparseMerkleRangeProof> {
+        self.state_store
+            .get_account_state_range_proof(rightmost_key, version)
     }
 }

--- a/storage/libradb/src/lib.rs
+++ b/storage/libradb/src/lib.rs
@@ -46,7 +46,7 @@ use crate::{
 };
 use anyhow::{ensure, Result};
 use itertools::{izip, zip_eq};
-use jellyfish_merkle::{iterator::JellyfishMerkleIterator, restore::JellyfishMerkleRestore};
+use jellyfish_merkle::restore::JellyfishMerkleRestore;
 use libra_crypto::hash::{CryptoHash, HashValue};
 use libra_logger::prelude::*;
 use libra_metrics::OpMetrics;
@@ -775,30 +775,8 @@ impl LibraDB {
         BackupHandler::new(
             Arc::clone(&self.ledger_store),
             Arc::clone(&self.transaction_store),
-        )
-    }
-
-    /// Gets an iterator which can yield all accounts in the state tree.
-    pub fn get_account_iter(
-        &self,
-        version: Version,
-    ) -> Result<Box<dyn Iterator<Item = Result<(HashValue, AccountStateBlob)>> + Send>> {
-        let iterator = JellyfishMerkleIterator::new(
             Arc::clone(&self.state_store),
-            version,
-            HashValue::zero(),
-        )?;
-        Ok(Box::new(iterator))
-    }
-
-    /// Gets the proof that proves a range of accounts.
-    pub fn get_account_state_range_proof(
-        &self,
-        rightmost_key: HashValue,
-        version: Version,
-    ) -> Result<SparseMerkleRangeProof> {
-        self.state_store
-            .get_account_state_range_proof(rightmost_key, version)
+        )
     }
 
     pub fn restore_account_state(

--- a/storage/libradb/src/state_store/state_store_test.rs
+++ b/storage/libradb/src/state_store/state_store_test.rs
@@ -246,7 +246,9 @@ proptest! {
 
         // Test iterator at each version.
         for i in 0..kvs.len() {
-            let actual_values = db.get_account_iter(i as Version)
+            let actual_values = db
+                .get_backup_handler()
+                .get_account_iter(i as Version)
                 .unwrap()
                 .collect::<Result<Vec<_>>>()
                 .unwrap();

--- a/storage/storage-service/src/lib.rs
+++ b/storage/storage-service/src/lib.rs
@@ -191,6 +191,7 @@ impl StorageService {
         let rust_req = storage_proto::GetAccountStateRangeProofRequest::try_from(req)?;
         let proof = self
             .db
+            .get_backup_handler()
             .get_account_state_range_proof(rust_req.rightmost_key, rust_req.version)?;
         let rust_resp = storage_proto::GetAccountStateRangeProofResponse::new(proof);
         Ok(rust_resp.into())
@@ -305,6 +306,7 @@ impl Storage for StorageService {
         let req = request.into_inner();
         let iter = self
             .db
+            .get_backup_handler()
             .get_account_iter(req.version)
             .map_err(|e| tonic::Status::new(tonic::Code::InvalidArgument, e.to_string()))?;
 


### PR DESCRIPTION
<!--
Thank you for sending a PR. We appreciate you spending time to help improve the Libra project.

The project is undergoing daily changes. Pull Requests will be reviewed and responded to as time permits.
-->

## Motivation

Since we have the backup handler, we put all the backup related code to the same place.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?

No?

## Test Plan

Just move code.

## Related PRs

(If this PR adds or changes functionality, please take some time to update the docs at https://github.com/libra/website, and link to your PR here.)
