### PR TITLE
[logging] add a counter to record peer info

### DIFF
--- a/common/metrics/build.rs
+++ b/common/metrics/build.rs
@@ -1,17 +1,14 @@
 // Copyright (c) The Libra Core Contributors
 // SPDX-License-Identifier: Apache-2.0
 
-use std::env;
 use std::process::Command;
 
 /// Save revision info to environment variable
 fn main() {
-    if env::var("GIT_REV").is_err() {
-        let output = Command::new("git")
-            .args(&["rev-parse", "--short", "HEAD"])
-            .output()
-            .unwrap();
-        let git_rev = String::from_utf8(output.stdout).unwrap();
-        println!("cargo:rustc-env=GIT_REV={}", git_rev);
-    }
+    let output = Command::new("git")
+        .args(&["rev-parse", "--short", "HEAD"])
+        .output()
+        .unwrap();
+    let git_rev = String::from_utf8(output.stdout).unwrap();
+    println!("cargo:rustc-env=GIT_REV={}", git_rev);
 }

--- a/network/src/counters.rs
+++ b/network/src/counters.rs
@@ -17,6 +17,18 @@ pub static LIBRA_NETWORK_PEERS: Lazy<IntGaugeVec> = Lazy::new(|| {
     .unwrap()
 });
 
+pub static LIBRA_NETWORK_PEER_INFO: Lazy<IntGaugeVec> = Lazy::new(|| {
+    register_int_gauge_vec!(
+        // metric name
+        "libra_network_peer_info",
+        // metric description
+        "Libra network peer info",
+        // metric labels (dimensions)
+        &["role_type", "ip_address", "peer_id"]
+    )
+    .unwrap()
+});
+
 pub static LIBRA_NETWORK_DISCOVERY_NOTES: Lazy<IntGaugeVec> = Lazy::new(|| {
     register_int_gauge_vec!(
         // metric name

--- a/network/src/peer_manager/mod.rs
+++ b/network/src/peer_manager/mod.rs
@@ -611,6 +611,13 @@ where
             counters::LIBRA_NETWORK_PEERS
                 .with_label_values(&[identity.role().as_str(), "connected"])
                 .inc();
+            counters::LIBRA_NETWORK_PEER_INFO
+                .with_label_values(&[
+                    identity.role().as_str(),
+                    &address.to_string(),
+                    &peer_id.short_str(),
+                ])
+                .inc();
         }
     }
 
@@ -632,6 +639,13 @@ where
         // update libra_network_peer counter
         counters::LIBRA_NETWORK_PEERS
             .with_label_values(&[identity.role().as_str(), "connected"])
+            .dec();
+        counters::LIBRA_NETWORK_PEER_INFO
+            .with_label_values(&[
+                identity.role().as_str(),
+                &addr.to_string(),
+                &peer_id.short_str(),
+            ])
             .dec();
         // Remove NetworkRequest sender from `active_peers`.
         self.active_peers.remove(&peer_id);


### PR DESCRIPTION
<!--
Thank you for sending a PR. We appreciate you spending time to help improve the Libra project.

The project is undergoing daily changes. Pull Requests will be reviewed and responded to as time permits.
-->

## Motivation

- It would be useful to know the ip addresses of all connected peers, even better if we can see it on dashboard. Hack around prometheus counters to record this.

- Also remove the part of getting git revision info from passed variable, we should always get it by running the git command.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

```
[ec2-user:validator@ip-10-0-8-154 ~]$ curl localhost:9101/metrics | grep libra_network_peer
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100 58952  100 58952    0     0  18.7M      0 --:--:-- --:--:-- --:--:-- 18.7M
# HELP libra_network_peer_info Libra network peer info
# TYPE libra_network_peer_info gauge
libra_network_peer_info{ip_address="/ip4/10.0.1.125/tcp/59838",peer_id="8fd104dc",role_type="validator"} 1
libra_network_peer_info{ip_address="/ip4/10.0.1.8/tcp/46500",peer_id="dca65d55",role_type="validator"} 1
libra_network_peer_info{ip_address="/ip4/10.0.5.18/tcp/55958",peer_id="916dcbd2",role_type="validator"} 1
# HELP libra_network_peers Libra network peers counter
# TYPE libra_network_peers gauge
libra_network_peers{role_type="validator",state="connected"} 3
```

## Related PRs

(If this PR adds or changes functionality, please take some time to update the docs at https://github.com/libra/website, and link to your PR here.)
