### PR TITLE
[Executor] Add output for benchmark

### DIFF
--- a/executor/src/benchmark.rs
+++ b/executor/src/benchmark.rs
@@ -7,6 +7,7 @@ use libra_crypto::{
     hash::{CryptoHash, HashValue},
     traits::{PrivateKey, SigningKey},
 };
+use libra_logger::prelude::*;
 use libra_types::{
     account_address::AccountAddress,
     account_config::{association_address, AccountResource},
@@ -188,7 +189,10 @@ impl TransactionExecutor {
         let mut version = 0;
 
         while let Ok(transactions) = self.block_receiver.recv() {
-            version += transactions.len() as u64;
+            let num_txns = transactions.len();
+            version += num_txns as u64;
+
+            let execute_start = std::time::Instant::now();
 
             let output = self
                 .executor
@@ -198,6 +202,10 @@ impl TransactionExecutor {
                     &self.committed_trees,
                 )
                 .unwrap();
+
+            let execute_time = std::time::Instant::now().duration_since(execute_start);
+            let commit_start = std::time::Instant::now();
+
             let new_committed_trees = output.executed_trees().clone();
             let block_to_commit = (transactions, Arc::new(output));
 
@@ -226,6 +234,17 @@ impl TransactionExecutor {
                 .unwrap();
 
             self.committed_trees = new_committed_trees;
+
+            let commit_time = std::time::Instant::now().duration_since(commit_start);
+            let total_time = execute_time + commit_time;
+
+            info!(
+                "Version: {}. execute time: {} ms. commit time: {} ms. TPS: {}.",
+                version,
+                execute_time.as_millis(),
+                commit_time.as_millis(),
+                num_txns as u128 * 1_000_000 / total_time.as_micros(),
+            );
         }
     }
 }

--- a/executor/src/benchmark.rs
+++ b/executor/src/benchmark.rs
@@ -243,7 +243,7 @@ impl TransactionExecutor {
                 version,
                 execute_time.as_millis(),
                 commit_time.as_millis(),
-                num_txns as u128 * 1_000_000 / total_time.as_micros(),
+                num_txns as u128 * 1_000_000_000 / total_time.as_nanos(),
             );
         }
     }

--- a/executor/src/bin/bench.rs
+++ b/executor/src/bin/bench.rs
@@ -25,6 +25,11 @@ struct Opt {
 fn main() {
     let opt = Opt::from_args();
 
+    let _logger = libra_logger::set_default_global_logger(
+        true, /* async_drain */
+        None, /* chan_size */
+    );
+
     rayon::ThreadPoolBuilder::new()
         .thread_name(|index| format!("rayon-global-{}", index))
         .build_global()


### PR DESCRIPTION
Right now the benchmark does not output anything, which is not very
useful. Add some output.

```
cargo run --package executor --bin bench --release                                                                                                ✔
    Finished release [optimized + debuginfo] target(s) in 0.61s
     Running `target/release/bench`
I0210 20:58:00.528383 123145410199552 storage/libradb/src/lib.rs:173] Opened LibraDB at "/var/folders/n9/0bc3c9y54vg83rwfd7gyz6s40000gn/T/50c43f562c7c991cd902a02df2cc641e/libradb/db/libradb" in 32 ms
C0210 20:58:00.530044 123145410199552 language/vm/vm-runtime/src/code_cache/module_cache.rs:263] [VM] Error fetching module with id ModuleId { address: 0000000000000000000000000000000000000000000000000000000000000000, name: Identifier("GasSchedule") }
I0210 20:58:00.532666 123145410199552 executor/src/lib.rs:384] GENESIS transaction is committed.
I0210 20:58:17.208811 123145410199552 executor/src/benchmark.rs:241] Version: 500. execute time: 202 ms. commit time: 94 ms. TPS: 1680.
I0210 20:58:17.517954 123145410199552 executor/src/benchmark.rs:241] Version: 1000. execute time: 211 ms. commit time: 97 ms. TPS: 1617.
I0210 20:58:17.825662 123145410199552 executor/src/benchmark.rs:241] Version: 1500. execute time: 207 ms. commit time: 100 ms. TPS: 1624.
I0210 20:58:18.176041 123145410199552 executor/src/benchmark.rs:241] Version: 2000. execute time: 226 ms. commit time: 124 ms. TPS: 1427.
I0210 20:58:18.523231 123145410199552 executor/src/benchmark.rs:241] Version: 2500. execute time: 232 ms. commit time: 115 ms. TPS: 1440.
I0210 20:58:18.853462 123145410199552 executor/src/benchmark.rs:241] Version: 3000. execute time: 218 ms. commit time: 111 ms. TPS: 1514.
I0210 20:58:19.189489 123145410199552 executor/src/benchmark.rs:241] Version: 3500. execute time: 219 ms. commit time: 116 ms. TPS: 1487.
I0210 20:58:19.522538 123145410199552 executor/src/benchmark.rs:241] Version: 4000. execute time: 212 ms. commit time: 120 ms. TPS: 1501.
```