### PR TITLE
[Crypto] Serialize HashValue as fixed size array

### DIFF
--- a/common/lcs/src/lib.rs
+++ b/common/lcs/src/lib.rs
@@ -82,13 +82,13 @@
 //!
 //! ### Fixed and Variable Length Sequences
 //!
-//! Sequences can be made of up of any LCS supported types (even complex structures) but all
-//! elements in the sequence must be of the same type. If the length of a sequence is fixed and
-//! well known then LCS represents this as just the concatenation of the serialized form of each
-//! individual element in the sequence. If the length of the sequence can be variable, then the
-//! serialized sequence is length prefixed with a 32-bit unsigned integer indicating the number of
-//! elements in the sequence. All variable length sequences must be `MAX_SEQUENCE_LENGTH` elements
-//! long or less.
+//! Sequences can be made up of any LCS supported types (even complex structures) but all elements
+//! in the sequence must be of the same type. If the length of a sequence is fixed and well known
+//! then LCS represents this as just the concatenation of the serialized form of each individual
+//! element in the sequence. If the length of the sequence can be variable, then the serialized
+//! sequence is length prefixed with a 32-bit unsigned integer indicating the number of elements in
+//! the sequence. All variable length sequences must be `MAX_SEQUENCE_LENGTH` elements long or
+//! less.
 //!
 //! ```rust
 //! # use libra_canonical_serialization::{Result, to_bytes};


### PR DESCRIPTION
<!--
Thank you for sending a PR. We appreciate you spending time to help improve the Libra project.

The project is undergoing daily changes. Pull Requests will be reviewed and responded to as time permits.
-->

## Motivation

I ran into a problem where HashValue can not be deserialized properly. Rather than fix the impl for `Serialize` and `Deserialize`, just derive them. As a result, this will serialize HashValue as fixed size array and drop the length prefix in the serialized form.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?

No.

## Test Plan

CI.
