### PR TITLE
Update the libfuzzer dependency & fuzz README

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -95,7 +95,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "arbitrary"
-version = "0.2.0"
+version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -2031,10 +2031,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "libfuzzer-sys"
-version = "0.1.0"
-source = "git+https://github.com/rust-fuzz/libfuzzer-sys.git#0c4507533a79e85e1984f59765bdd35fbdaa7f1b"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "arbitrary 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "arbitrary 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "cc 1.0.45 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -2413,7 +2413,7 @@ dependencies = [
 name = "libra_fuzzer_fuzz"
 version = "0.1.0"
 dependencies = [
- "libfuzzer-sys 0.1.0 (git+https://github.com/rust-fuzz/libfuzzer-sys.git)",
+ "libfuzzer-sys 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "libra-fuzzer 0.1.0",
  "once_cell 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -5959,7 +5959,7 @@ dependencies = [
 "checksum ansi_term 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ee49baf6cb617b853aa8d93bf420db2383fab46d314482ca2803b40d5fde979b"
 "checksum ansi_term 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)" = "23ac7c30002a5accbf7e8987d0632fa6de155b7c3d39d0067317a391e00a2ef6"
 "checksum anyhow 1.0.24 (registry+https://github.com/rust-lang/crates.io-index)" = "b412394828b7ca486b362f300b762d8e43dafd6f0d727b63f1cd2ade207c6cef"
-"checksum arbitrary 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "64cf76cb6e2222ed0ea86b2b0ee2f71c96ec6edd5af42e84d59160e91b836ec4"
+"checksum arbitrary 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "491d5e42b1a073ff1fc1e0a02744b3f8bee9cf4bfd552053cac36c64b879795d"
 "checksum arc-swap 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)" = "854ede29f7a0ce90519fb2439d030320c6201119b87dab0ee96044603e1130b9"
 "checksum arrayref 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)" = "0d382e583f07208808f6b1249e60848879ba3543f57c32277bf52d69c2f0f0ee"
 "checksum arrayvec 0.4.11 (registry+https://github.com/rust-lang/crates.io-index)" = "b8d73f9beda665eaa98ab9e4f7442bd4e7de6652587de55b2525e52e29c1b0ba"
@@ -6117,7 +6117,7 @@ dependencies = [
 "checksum kernel32-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "7507624b29483431c0ba2d82aece8ca6cdba9382bff4ddd0f7490560c056098d"
 "checksum lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 "checksum libc 0.2.66 (registry+https://github.com/rust-lang/crates.io-index)" = "d515b1f41455adea1313a4a2ac8a8a477634fbae63cc6100e3aebb207ce61558"
-"checksum libfuzzer-sys 0.1.0 (git+https://github.com/rust-fuzz/libfuzzer-sys.git)" = "<none>"
+"checksum libfuzzer-sys 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "3e969cd2be7a2aae0acbbe205da49134148db2287fb45a811bf441ed72f09a35"
 "checksum librocksdb_sys 0.1.0 (git+https://github.com/pingcap/rust-rocksdb.git?rev=3cd18c44d160a3cdba586d6502d51b7cc67efc59)" = "<none>"
 "checksum libtitan_sys 0.0.1 (git+https://github.com/pingcap/rust-rocksdb.git?rev=3cd18c44d160a3cdba586d6502d51b7cc67efc59)" = "<none>"
 "checksum libz-sys 1.0.25 (registry+https://github.com/rust-lang/crates.io-index)" = "2eb5e43362e38e2bca2fd5f5134c4d4564a23a5c28e9b95411652021a8675ebe"

--- a/testsuite/libra-fuzzer/README.md
+++ b/testsuite/libra-fuzzer/README.md
@@ -14,19 +14,19 @@ Install [`cargo-fuzz`](https://rust-fuzz.github.io/book/cargo-fuzz.html) if not 
 First, switch to the directory this README is in: `cd
 testsuite/libra_fuzzer`.
 
-To list out known fuzz targets, run `cargo run list`.
+To list out known fuzz targets, run `cargo run --bin libra-fuzzer list`.
 
 To be effective, fuzzing requires a corpus of existing inputs. This
 crate contains support for generating corpuses with `proptest`. Generate
-a corpus with `cargo run generate <target>`.
+a corpus with `cargo run --bin libra-fuzzer generate <target>`.
 
 Once a corpus has been generated, the fuzzer is ready to use, simply run:
 
 ```
-RUSTC_BOOTSTRAP=1 cargo run fuzz <target> -- --release --debug-assertions
+RUSTC_BOOTSTRAP=1 cargo run --bin libra-fuzzer fuzz <target> -- --release --debug-assertions
 ```
 
-For more options, run `cargo run -- --help`. Note that `RUSTC_BOOTSTRAP=1` is
+For more options, run `cargo run --bin libra-fuzzer -- --help`. Note that `RUSTC_BOOTSTRAP=1` is
 required as `cargo fuzz` uses unstable compiler flags.
 
 ### Adding a new target
@@ -37,7 +37,7 @@ creating a new type and implementing `FuzzTargetImpl` for it.
 For examples, see the existing implementations in `src/fuzz_targets/`.
 
 Remember to add your target to `ALL_TARGETS` in `src/fuzz_targets.rs`.
-Once that has been done, `cargo run list` should list your new target.
+Once that has been done, `cargo run --bin libra-fuzzer list` should list your new target.
 
 ### Debugging and testing artifacts
 
@@ -70,7 +70,7 @@ Running the following command (with your own artifact contained in a similar pat
 will run the fuzzer with your input.
 
 ```
-cargo run investigate -- -i artifacts/compiled_module/crash-5d7f403f
+cargo run --bin investigate -- -i artifacts/compiled_module/crash-5d7f403f
 ```
 
 This is helpful to investigate and debug a binary in order to find the root cause

--- a/testsuite/libra-fuzzer/fuzz/Cargo.toml
+++ b/testsuite/libra-fuzzer/fuzz/Cargo.toml
@@ -13,7 +13,7 @@ publish = false
 cargo-fuzz = true
 
 [dependencies]
-libfuzzer-sys = { git = "https://github.com/rust-fuzz/libfuzzer-sys.git" }
+libfuzzer-sys = "0.2.0"
 libra-fuzzer = { path = "..", version = "0.1.0" }
 once_cell = "1.2.0"
 


### PR DESCRIPTION
The fuzzer dependency at https://github.com/rust-fuzz/libfuzzer-sys.git is archived & unmaintained.
This updates it to the new address of the maintained project & updates the README after it introduced two distinct binaries in the fuzz crate.
