### PR TITLE
[language][move] Add parser support for bitwise shift operators and type casts

### DIFF
--- a/language/move-lang/src/parser/lexer.rs
+++ b/language/move-lang/src/parser/lexer.rs
@@ -32,10 +32,12 @@ pub enum Tok {
     Semicolon,
     Less,
     LessEqual,
+    LessLess,
     Equal,
     EqualEqual,
     Greater,
     GreaterEqual,
+    GreaterGreater,
     Caret,
     Abort,
     Acquires,
@@ -93,10 +95,12 @@ impl fmt::Display for Tok {
             Semicolon => ";",
             Less => "<",
             LessEqual => "<=",
+            LessLess => "<<",
             Equal => "=",
             EqualEqual => "==",
             Greater => ">",
             GreaterEqual => ">=",
+            GreaterGreater => ">>",
             Caret => "^",
             Abort => "abort",
             Acquires => "acquires",
@@ -195,6 +199,14 @@ impl<'input> Lexer<'input> {
         self.token = token;
         Ok(())
     }
+
+    // Replace the current token. The lexer will always match the longest token,
+    // but sometimes the parser will prefer to replace it with a shorter one,
+    // e.g., ">" instead of ">>".
+    pub fn replace_token(&mut self, token: Tok, len: usize) {
+        self.token = token;
+        self.cur_end = self.cur_start + len
+    }
 }
 
 // Find the next token and its length without changing the state of the lexer.
@@ -256,6 +268,8 @@ fn find_token(file: &'static str, text: &str, start_offset: usize) -> Result<(To
         '<' => {
             if text.starts_with("<=") {
                 (Tok::LessEqual, 2)
+            } else if text.starts_with("<<") {
+                (Tok::LessLess, 2)
             } else {
                 (Tok::Less, 1)
             }
@@ -263,6 +277,8 @@ fn find_token(file: &'static str, text: &str, start_offset: usize) -> Result<(To
         '>' => {
             if text.starts_with(">=") {
                 (Tok::GreaterEqual, 2)
+            } else if text.starts_with(">>") {
+                (Tok::GreaterGreater, 2)
             } else {
                 (Tok::Greater, 1)
             }

--- a/language/move-lang/tests/move_check/parser/expr_binary_operators.move
+++ b/language/move-lang/tests/move_check/parser/expr_binary_operators.move
@@ -11,9 +11,11 @@ fun main() {
     Transaction::assert((2 ^ 3) == 1, 108);
     Transaction::assert((1 | 2) == 3, 109);
     Transaction::assert((2 & 3) == 2, 110);
-    Transaction::assert((1 + 2) == 3, 111);
-    Transaction::assert((3 - 2) == 1, 112);
-    Transaction::assert((2 * 3) == 6, 113);
-    Transaction::assert((9 / 3) == 3, 114);
-    Transaction::assert((8 % 3) == 2, 115);
+    Transaction::assert((2 << 1) == 4, 111);
+    Transaction::assert((8 >> 2) == 2, 112);
+    Transaction::assert((1 + 2) == 3, 113);
+    Transaction::assert((3 - 2) == 1, 114);
+    Transaction::assert((2 * 3) == 6, 115);
+    Transaction::assert((9 / 3) == 3, 116);
+    Transaction::assert((8 % 3) == 2, 117);
 }

--- a/language/move-lang/tests/move_check/parser/expr_unary_ops.exp
+++ b/language/move-lang/tests/move_check/parser/expr_unary_ops.exp
@@ -1,0 +1,11 @@
+error: 
+
+   ┌── tests/move_check/parser/expr_unary_ops.move:6:16 ───
+   │
+ 7 │         -v
+   │         ^^ Invalid argument to '-'
+   ·
+ 6 │     fun sub(v: u64): u64 {
+   │                --- Found: 'u64'. But the operation is not yet supported on any type
+   │
+

--- a/language/move-lang/tests/move_check/parser/expr_unary_ops.move
+++ b/language/move-lang/tests/move_check/parser/expr_unary_ops.move
@@ -3,4 +3,13 @@ module M {
         let x = *&mut *&v; // Test borrows and dereferences
         x;
     }
+    fun sub(v: u64): u64 {
+        -v // Test unary minus
+    }
+    fun annotated(v: u64): u64 {
+        (v : u64) // Test an expression annotated with a type
+    }
+    fun cast(v: u64): u64 {
+        (v as u64) // Test a type cast
+    }
 }

--- a/language/move-lang/tests/move_check/parser/function_type_nested.move
+++ b/language/move-lang/tests/move_check/parser/function_type_nested.move
@@ -1,0 +1,9 @@
+module M {
+    resource struct R {}
+    resource struct B<T> {}
+    fun fn<T>() { }
+    fun caller() {
+        fn<B<R>>(); // make sure '>>' is not parsed as a shift operator
+        fn<B<R,>>(); // also test with trailing comma
+    }
+}


### PR DESCRIPTION
These changes are intended to accompany the addition of u8 and u128 types to Move. This adds both left and right shift operators and a type cast syntax. The ast nodes for these operations are not yet available, so they are temporarily stubbed out to use existing nodes.

## Motivation

Source language support for new Move operations

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

Added tests for these new operators, as well as for the special case of nested type parameter lists where two closing angle brackets can be confused with a right shift operator.