### PR TITLE
[language][move] Avoid hardcoded 32 byte address length in a few more places

### DIFF
--- a/language/move-lang/src/shared/mod.rs
+++ b/language/move-lang/src/shared/mod.rs
@@ -47,15 +47,15 @@ impl Address {
 
         let mut result = hex::decode(hex_string.as_str()).unwrap();
         let len = result.len();
-        if len < 32 {
+        if len < ADDRESS_LENGTH {
             result.reverse();
-            for _ in len..32 {
+            for _ in len..ADDRESS_LENGTH {
                 result.push(0);
             }
             result.reverse();
         }
 
-        assert!(result.len() >= 32);
+        assert!(result.len() >= ADDRESS_LENGTH);
         Self::try_from(&result[..]).map_err(|_| {
             format!(
                 "Address is {} bytes long. The maximum size is {} bytes",


### PR DESCRIPTION
Most of the references to the address length in shared/mod.rs have already
been replaced to use the ADDRESS_LENGTH constant, and this changes a few
more of them in the code that inserts leading zero bytes for short addresses.

## Motivation

Avoiding hardcoded constants

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

No functional changes here