### PR TITLE
Some small cleanups for enum macros

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1246,6 +1246,15 @@ version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "enum-macros"
+version = "0.1.0"
+dependencies = [
+ "proc-macro2 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "quote 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "errno"
 version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2894,15 +2903,6 @@ version = "0.2.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "autocfg 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "num-variants"
-version = "0.1.0"
-dependencies = [
- "proc-macro2 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "quote 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "syn 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -5529,13 +5529,13 @@ version = "0.1.0"
 dependencies = [
  "anyhow 1.0.24 (registry+https://github.com/rust-lang/crates.io-index)",
  "byteorder 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "enum-macros 0.1.0",
  "hex 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "libra-canonical-serialization 0.1.0",
  "libra-crypto 0.1.0",
  "libra-proptest-helpers 0.1.0",
  "libra-types 0.1.0",
  "mirai-annotations 1.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "num-variants 0.1.0",
  "once_cell 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "proptest 0.9.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "proptest-derive 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ members = [
     "common/logger",
     "common/metrics",
     "common/nibble",
-    "common/num-variants",
+    "common/enum-macros",
     "common/proptest-helpers",
     "common/prost-ext",
     "common/temppath",

--- a/common/enum-macros/Cargo.toml
+++ b/common/enum-macros/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "num-variants"
+name = "enum-macros"
 version = "0.1.0"
 authors = ["Libra Association <opensource@libra.org>"]
 edition = "2018"

--- a/common/enum-macros/src/lib.rs
+++ b/common/enum-macros/src/lib.rs
@@ -1,59 +1,30 @@
 // Copyright (c) The Libra Core Contributors
 // SPDX-License-Identifier: Apache-2.0
 
-//! Add an associated constant to an enum describing the number of variants it has.
+//! Macro helpers for working with enums.
 
 #![forbid(unsafe_code)]
 #![warn(missing_docs)]
 
 extern crate proc_macro;
 
-use proc_macro2::{Ident, Span, TokenStream};
-use quote::quote;
+mod num_variants;
+
 use syn::spanned::Spanned;
 use syn::{
-    parse_macro_input, Attribute, Data, DeriveInput, Error, Meta, MetaList, NestedMeta, Result,
+    parse_macro_input, Attribute, DeriveInput, Error, Ident, Meta, MetaList, NestedMeta, Result,
 };
 
 /// Derives an associated constant with the number of variants this enum has.
 ///
-/// The default constant name is `NUM_VARIANTS`. This can be customized with `#[num_variants(FOO)]`.
+/// The default constant name is `NUM_VARIANTS`. This can be customized with `#[num_variants =
+/// "FOO")]`.
 #[proc_macro_derive(NumVariants, attributes(num_variants))]
 pub fn derive_num_variants(input: proc_macro::TokenStream) -> proc_macro::TokenStream {
     let input = parse_macro_input!(input as DeriveInput);
-    match derive_num_variants_impl(input) {
+    match num_variants::derive_num_variants_impl(input) {
         Ok(token_stream) => proc_macro::TokenStream::from(token_stream),
         Err(err) => proc_macro::TokenStream::from(err.to_compile_error()),
-    }
-}
-
-fn derive_num_variants_impl(input: DeriveInput) -> Result<TokenStream> {
-    let input_span = input.span();
-    let const_name = compute_ident(input.attrs, "num_variants")?
-        .unwrap_or_else(|| Ident::new("NUM_VARIANTS", Span::call_site()));
-
-    let name = input.ident;
-    let (impl_generics, ty_generics, where_clause) = input.generics.split_for_impl();
-    let num_variants = compute_num_variants(&input.data, input_span)?;
-
-    let expanded = quote! {
-        impl #impl_generics #name #ty_generics #where_clause {
-            /// The number of variants in this enum.
-            pub const #const_name: usize = #num_variants;
-        }
-    };
-
-    Ok(expanded)
-}
-
-/// Computes the number of variants for an enum.
-fn compute_num_variants(data: &Data, span: Span) -> Result<usize> {
-    match data {
-        Data::Enum(data) => Ok(data.variants.len()),
-        Data::Struct(_) | Data::Union(_) => Err(Error::new(
-            span,
-            "#[derive(NumVariants)] can only be used on an enum",
-        )),
     }
 }
 

--- a/common/enum-macros/src/num_variants.rs
+++ b/common/enum-macros/src/num_variants.rs
@@ -1,0 +1,38 @@
+// Copyright (c) The Libra Core Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::compute_ident;
+use proc_macro2::{Ident, Span, TokenStream};
+use quote::quote;
+use syn::spanned::Spanned;
+use syn::{Data, DeriveInput, Error, Result};
+
+pub(crate) fn derive_num_variants_impl(input: DeriveInput) -> Result<TokenStream> {
+    let input_span = input.span();
+    let const_name = compute_ident(input.attrs, "num_variants")?
+        .unwrap_or_else(|| Ident::new("NUM_VARIANTS", Span::call_site()));
+
+    let name = input.ident;
+    let (impl_generics, ty_generics, where_clause) = input.generics.split_for_impl();
+    let num_variants = compute_num_variants(&input.data, input_span)?;
+
+    let expanded = quote! {
+        impl #impl_generics #name #ty_generics #where_clause {
+            /// The number of variants in this enum.
+            pub const #const_name: usize = #num_variants;
+        }
+    };
+
+    Ok(expanded)
+}
+
+/// Computes the number of variants for an enum.
+fn compute_num_variants(data: &Data, span: Span) -> Result<usize> {
+    match data {
+        Data::Enum(data) => Ok(data.variants.len()),
+        Data::Struct(_) | Data::Union(_) => Err(Error::new(
+            span,
+            "#[derive(NumVariants)] can only be used on an enum",
+        )),
+    }
+}

--- a/common/enum-macros/tests/basic.rs
+++ b/common/enum-macros/tests/basic.rs
@@ -6,7 +6,7 @@
 // TODO: There are no negative tests at the moment (e.g. deriving NumVariants on a struct or union).
 // Add some, possibly using trybuild: https://docs.rs/trybuild/1.0.21/trybuild/
 
-use num_variants::NumVariants;
+use enum_macros::NumVariants;
 
 #[derive(NumVariants)]
 enum BasicEnum {

--- a/common/num-variants/tests/basic.rs
+++ b/common/num-variants/tests/basic.rs
@@ -19,7 +19,7 @@ enum BasicEnum {
 enum ZeroEnum {}
 
 #[derive(NumVariants)]
-#[num_variants = "CUSTOM_NAME"]
+#[num_variants(CUSTOM_NAME)]
 enum CustomName {
     Foo,
     Bar,

--- a/common/num-variants/tests/basic.rs
+++ b/common/num-variants/tests/basic.rs
@@ -4,7 +4,7 @@
 #![allow(dead_code)]
 
 // TODO: There are no negative tests at the moment (e.g. deriving NumVariants on a struct or union).
-// Add some, possibly using compiletest-rs: https://github.com/laumann/compiletest-rs
+// Add some, possibly using trybuild: https://docs.rs/trybuild/1.0.21/trybuild/
 
 use num_variants::NumVariants;
 

--- a/language/vm/Cargo.toml
+++ b/language/vm/Cargo.toml
@@ -20,11 +20,11 @@ proptest-derive = { version = "0.1.1", optional = true }
 ref-cast = "1.0"
 serde = { version = "1", features = ["derive"] }
 
+enum-macros = { path = "../../common/enum-macros", version = "0.1.0" }
 lcs = { path = "../../common/lcs", version = "0.1.0", package = "libra-canonical-serialization" }
 libra-crypto = { path = "../../crypto/crypto", version = "0.1.0" }
 libra-proptest-helpers = { path = "../../common/proptest-helpers", version = "0.1.0", optional = true }
 libra-types = { path = "../../types", version = "0.1.0" }
-num-variants = { path = "../../common/num-variants", version = "0.1.0" }
 
 [dev-dependencies]
 proptest = "0.9"

--- a/language/vm/src/file_format.rs
+++ b/language/vm/src/file_format.rs
@@ -805,7 +805,7 @@ impl CodeUnit {
 #[derive(Clone, Hash, Eq, NumVariants, PartialEq)]
 #[cfg_attr(any(test, feature = "fuzzing"), derive(Arbitrary))]
 #[cfg_attr(any(test, feature = "fuzzing"), proptest(no_params))]
-#[num_variants = "NUM_INSTRUCTIONS"]
+#[num_variants(NUM_INSTRUCTIONS)]
 pub enum Bytecode {
     /// Pop and discard the value at the top of the stack.
     /// The value on the stack must be an unrestricted type.

--- a/language/vm/src/file_format.rs
+++ b/language/vm/src/file_format.rs
@@ -30,6 +30,7 @@ use crate::{
     access::ModuleAccess, check_bounds::BoundsChecker, internals::ModuleIndex, IndexKind,
     SignatureTokenKind,
 };
+use enum_macros::NumVariants;
 use libra_types::{
     account_address::AccountAddress,
     byte_array::ByteArray,
@@ -38,7 +39,6 @@ use libra_types::{
     vm_error::{StatusCode, VMStatus},
 };
 use mirai_annotations::*;
-use num_variants::NumVariants;
 use once_cell::sync::Lazy;
 #[cfg(any(test, feature = "fuzzing"))]
 use proptest::{collection::vec, prelude::*, strategy::BoxedStrategy};


### PR DESCRIPTION
* Switch TODO to trybuild per @dtolnay.
* Use a more idiomatic syntax.
* Rename the crate to be slightly more general.