### PR TITLE
[cluster-test] Fix fullnode deployment

### DIFF
--- a/testsuite/cluster-test/src/cluster.rs
+++ b/testsuite/cluster-test/src/cluster.rs
@@ -141,15 +141,17 @@ impl Cluster {
         self.validator_instances.choose(&mut rnd).unwrap().clone()
     }
 
-    pub fn validator_instances(&self) -> &Vec<Instance> {
+    pub fn validator_instances(&self) -> &[Instance] {
+        &self.validator_instances
+    }
+    pub fn fullnode_instances(&self) -> &[Instance] {
         &self.validator_instances
     }
 
-    pub fn get_all_instances(&self) -> Vec<Instance> {
-        let mut all_instances: Vec<Instance> = vec![];
-        all_instances.append(&mut self.validator_instances.clone());
-        all_instances.append(&mut self.fullnode_instances.clone());
-        all_instances
+    pub fn all_instances(&self) -> impl Iterator<Item = &Instance> {
+        self.validator_instances
+            .iter()
+            .chain(self.fullnode_instances.iter())
     }
 
     pub fn into_validator_instances(self) -> Vec<Instance> {

--- a/testsuite/cluster-test/src/deployment.rs
+++ b/testsuite/cluster-test/src/deployment.rs
@@ -63,7 +63,7 @@ impl DeploymentManager {
     }
 
     pub fn update_all_services(&self) -> Result<()> {
-        for instance in &self.cluster.get_all_instances() {
+        for instance in self.cluster.all_instances() {
             let mut request = UpdateServiceRequest::default();
             request.cluster = Some(self.aws.workspace().clone());
             request.force_new_deployment = Some(true);

--- a/testsuite/cluster-test/src/experiments/cpu_flamegraph.rs
+++ b/testsuite/cluster-test/src/experiments/cpu_flamegraph.rs
@@ -61,7 +61,7 @@ impl Experiment for CpuFlamegraph {
         let buffer = Duration::from_secs(60);
         let tx_emitter_duration = 2 * buffer + Duration::from_secs(self.duration_secs as u64);
         let emit_job_request = EmitJobRequest {
-            instances: context.cluster.validator_instances().clone(),
+            instances: context.cluster.validator_instances().to_vec(),
             ..context.global_emit_job_request.clone()
         };
         let emit_future = context

--- a/testsuite/cluster-test/src/experiments/multi_region_network_simulation.rs
+++ b/testsuite/cluster-test/src/experiments/multi_region_network_simulation.rs
@@ -206,7 +206,7 @@ impl Experiment for MultiRegionSimulation {
             for cross_region_latency in &self.params.cross_region_latencies {
                 let job = emitter
                     .start_job(EmitJobRequest::for_instances(
-                        context.cluster.validator_instances().clone(),
+                        context.cluster.validator_instances().to_vec(),
                     ))
                     .await
                     .expect("Failed to start emit job");

--- a/testsuite/cluster-test/src/experiments/performance_benchmark_three_region_simulation.rs
+++ b/testsuite/cluster-test/src/experiments/performance_benchmark_three_region_simulation.rs
@@ -42,9 +42,9 @@ impl Experiment for PerformanceBenchmarkThreeRegionSimulation {
         let (us_west, us_east) = us.split_n_validators_random(40);
         let network_effects = three_region_simulation_effects(
             (
-                us_west.validator_instances().clone(),
-                us_east.validator_instances().clone(),
-                euro.validator_instances().clone(),
+                us_west.validator_instances().to_vec(),
+                us_east.validator_instances().to_vec(),
+                euro.validator_instances().to_vec(),
             ),
             (
                 Duration::from_millis(60), // us_east<->eu one way delay
@@ -55,7 +55,7 @@ impl Experiment for PerformanceBenchmarkThreeRegionSimulation {
         join_all(network_effects.iter().map(|e| e.activate())).await;
         let window = Duration::from_secs(240);
         let emit_job_request = EmitJobRequest {
-            instances: self.cluster.validator_instances().clone(),
+            instances: self.cluster.validator_instances().to_vec(),
             ..context.global_emit_job_request.clone()
         };
         context

--- a/testsuite/cluster-test/src/experiments/reboot_random_validator.rs
+++ b/testsuite/cluster-test/src/experiments/reboot_random_validator.rs
@@ -43,7 +43,7 @@ impl ExperimentParam for RebootRandomValidatorsParams {
             );
         }
         let mut instances = Vec::with_capacity(self.count);
-        let mut all_instances = cluster.validator_instances().clone();
+        let mut all_instances = cluster.validator_instances().to_vec();
         let mut rnd = rand::thread_rng();
         for _i in 0..self.count {
             let instance = all_instances.remove(rnd.gen_range(0, all_instances.len()));


### PR DESCRIPTION
We was not properly deploying on full nodes - we did not stop them, did not wipe db, etc

Also fixes other use cases of `all_instances` vs `validator_instances`
