### PR TITLE
[CI] post land-blocking test result on PR

### DIFF
--- a/.github/workflows/land-blocking.yml
+++ b/.github/workflows/land-blocking.yml
@@ -11,19 +11,80 @@ jobs:
     name: Build images and run cluster test
     runs-on: self-hosted
     steps:
-    - uses: actions/checkout@v1
-    - name: Setup env
-      run: |
-        echo "::set-env name=LIBRA_GIT_REV::$(git rev-parse --short=8 HEAD)"
-    - name: Build, tag and push images
-      run: |
-        docker/build-aws.sh --build-all --version $LIBRA_GIT_REV --addl_tags canary
-    - name: Launch cluster test
-      run: |
-        JUMPHOST=${{secrets.CLUSTER_TEST_JUMPHOST}} \
-        ./scripts/cti \
-          --marker land \
-          --tag dev_$LIBRA_GIT_REV \
-          --report report.json \
-          --run bench \
-          -- --duration 60
+      - uses: actions/checkout@v1
+      - name: Setup env
+        run: |
+          echo "::set-env name=LIBRA_GIT_REV::$(git rev-parse --short=8 HEAD)"
+      - name: Build, tag and push images
+        run: |
+          docker/build-aws.sh --build-all --version $LIBRA_GIT_REV --addl_tags canary
+      - name: Launch cluster test
+        run: |
+          JUMPHOST=${{secrets.CLUSTER_TEST_JUMPHOST}} \
+          ./scripts/cti \
+            --marker land \
+            --tag dev_$LIBRA_GIT_REV \
+            --report report.json \
+            --run bench
+      - name: Post test results on PR
+        if: always()
+        uses: actions/github-script@0.4.0
+        with:
+          github-token: ${{secrets.GITHUB_TOKEN}}
+          script: |
+            // Find the number of the pull request that trigggers this push
+            const pulls = await github.pulls.list(
+              {
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                state: "open",
+                sort: "updated",
+              }
+            );
+            let pr_num = 0;
+            for (const pull of pulls.data) {
+              if (pull.head.sha === context.sha) {
+                pr_num = pull.number;
+                break;
+                }
+            }
+            if (pr_num === 0) {
+              console.warn("Did not find original pull request. -\\_(O_o)_/-");
+              return;
+            }
+            // Read and check cluster test results
+            let should_fail = false;
+            let body;
+            const fsp = require('fs').promises;
+            try {
+              data = await fsp.readFile('report.json', 'utf-8');
+              var result = JSON.parse(data);
+              // TODO - set P/F based on metrics TPS, latency
+              body = `Cluster Test Result
+            \`\`\`
+            ${result.text}
+            \`\`\`
+            `;
+            } catch (err) {
+              if (err.code === 'ENOENT') {
+                body = "Cluster Test failed - no test report found.";
+              } else {
+                body = "Cluster Test failed - test report processing failed.";
+              }
+              body += " See https://github.com/libra/libra/actions/runs/${{github.run_id}}";
+              // Post comment on PR then fail this workflow
+              should_fail = true;
+            }
+            // Post test result on original pull request
+            await github.issues.createComment(
+                {
+                  issue_number: pr_num,
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  body: body,
+                }
+            );
+            // Fail the workflow if test fails or perf regresses
+            if (should_fail) {
+              throw "Land-blocking test failed";
+            }


### PR DESCRIPTION
## Motivation
The land-blocking test is run at land time in the auto branch. When the
test fails or performance regression is detected, the relevant results
need to be surfaced in the original pull request such that the author
can follow up.

## Test Plan
- Mock 1 - Cluster test fails and doesn't generate test report
https://github.com/sausagee/libra/runs/442190978?check_suite_focus=true
![image](https://user-images.githubusercontent.com/7528420/74389534-50e6a900-4db3-11ea-9909-7ce5b0883e5b.png)


- Mock 2 - Cluster test passes and generates test report  
https://github.com/sausagee/libra/runs/442177298?check_suite_focus=true
![image](https://user-images.githubusercontent.com/7528420/74389544-5a701100-4db3-11ea-80b6-96a5f690f646.png)


- Mock 3 - Cluster test passes but the commit is not found in any open pull request. 
https://github.com/sausagee/libra/runs/442462648?check_suite_focus=true
![image](https://user-images.githubusercontent.com/7528420/74389445-06fdc300-4db3-11ea-948b-67eb5afc2bd1.png)
