### PR TITLE
[language] serialize_table offset should be u32 type

### DIFF
--- a/language/vm/src/serializer.rs
+++ b/language/vm/src/serializer.rs
@@ -142,7 +142,7 @@ fn checked_serialize_table(
         bail!(
             "binary size ({}) cannot exceed {}",
             binary.len(),
-            usize::max_value(),
+            u32::max_value(),
         );
     }
     Ok(())


### PR DESCRIPTION
<!--
Thank you for sending a PR. We appreciate you spending time to help improve the Libra project.

The project is undergoing daily changes. Pull Requests will be reviewed and responded to as time permits.
-->

## Motivation

Since start and offset is type `u32` in fn checked_serialize_table, the result of checked_add is also type `u32`, not `usize`.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?

Yes.

## Test Plan

(Share your test plan here. If you changed code, please provide us with clear instructions for verifying that your changes work.)

cargo xtest

## Related PRs

(If this PR adds or changes functionality, please take some time to update the docs at https://github.com/libra/website, and link to your PR here.)
