### PR TITLE
[move source language] Fix Dependency Ordering. Fix Natives Issues

### DIFF
--- a/language/move-lang/src/expansion/translate.rs
+++ b/language/move-lang/src/expansion/translate.rs
@@ -233,6 +233,7 @@ fn module(
     let functions = functions(context, &name, pfunctions);
     let used_aliases = context.clear_aliases();
     let (uses, unused_aliases) = check_aliases(context, used_aliases, alias_map);
+    let is_source_module = is_source_module && !fake_natives::is_fake_native(&current_module);
     let def = E::ModuleDefinition {
         uses,
         unused_aliases,

--- a/language/move-lang/src/naming/uses.rs
+++ b/language/move-lang/src/naming/uses.rs
@@ -32,9 +32,8 @@ pub fn verify(errors: &mut Errors, modules: &mut UniqueMap<ModuleIdent, N::Modul
                 .into_iter()
                 .filter(|m| imm_modules.get(m).unwrap().is_source_module.is_some())
                 .cloned()
-                .enumerate()
                 .collect::<Vec<_>>();
-            for (order, mident) in ordering {
+            for (order, mident) in ordering.into_iter().rev().enumerate() {
                 modules.get_mut(&mident).unwrap().is_source_module = Some(order)
             }
         }

--- a/language/move-lang/src/shared/fake_natives.rs
+++ b/language/move-lang/src/shared/fake_natives.rs
@@ -1,6 +1,9 @@
 // Copyright (c) The Libra Core Contributors
 // SPDX-License-Identifier: Apache-2.0
 
+use super::*;
+use crate::parser::ast::ModuleIdent;
+
 /// 'Native' functions that are actually bytecode isntructions
 
 //**************************************************************************************************
@@ -19,4 +22,8 @@ pub mod transaction {
     pub const PUBLIC_KEY: &str = "public_key";
     /// 'Inlined' during hlir::translate
     pub const ASSERT: &str = "assert";
+}
+
+pub fn is_fake_native(mident: &ModuleIdent) -> bool {
+    mident.0.value.address == Address::LIBRA_CORE && mident.0.value.name.value() == transaction::MOD
 }

--- a/language/move-lang/src/to_bytecode/translate.rs
+++ b/language/move-lang/src/to_bytecode/translate.rs
@@ -1004,10 +1004,12 @@ fn call(
     match (&m.0.value.address, m.0.value.name.value(), f.value()) {
         (&A::LIBRA_CORE, TXN::MOD, TXN::GAS_PRICE) => code.push(B::GetTxnGasUnitPrice),
         (&A::LIBRA_CORE, TXN::MOD, TXN::MAX_GAS) => code.push(B::GetTxnMaxGasUnits),
+        (&A::LIBRA_CORE, TXN::MOD, TXN::GAS_REMAINING) => code.push(B::GetGasRemaining),
         (&A::LIBRA_CORE, TXN::MOD, TXN::SENDER) => code.push(B::GetTxnSenderAddress),
         (&A::LIBRA_CORE, TXN::MOD, TXN::SEQUENCE_NUM) => code.push(B::GetTxnSequenceNumber),
         (&A::LIBRA_CORE, TXN::MOD, TXN::PUBLIC_KEY) => code.push(B::GetTxnPublicKey),
         (&A::LIBRA_CORE, TXN::MOD, TXN::ASSERT) => panic!("ICE should have been covered in hlir"),
+        (&A::LIBRA_CORE, TXN::MOD, f) => panic!("ICE unknown magic transaction function {}", f),
         _ => module_call(context, code, m, f, tys)?,
     }
     Ok(())

--- a/language/move-lang/stdlib/modules/event.move
+++ b/language/move-lang/stdlib/modules/event.move
@@ -60,7 +60,10 @@ module Event {
 
     // Native procedure that writes to the actual event stream in Event store
     // This will replace the "native" portion of EmitEvent bytecode
-    native fun write_to_event_store<T: copyable>(guid: bytearray, count: u64, msg: T);
+    fun write_to_event_store<T: copyable>(guid: bytearray, count: u64, msg: T) {
+        // FIXME native was moved to account
+        abort 0
+    }
 
     // Destroy a unique handle.
     public fun destroy<T: copyable>(handle: Handle<T>) {

--- a/language/move-lang/stdlib/modules/libra_account.move
+++ b/language/move-lang/stdlib/modules/libra_account.move
@@ -72,7 +72,11 @@ module LibraAccount {
     }
 
     // Save an account to a given address if the address does not have an account resource yet
-    native fun save_account(addr: address, account: Self::T);
+    fun save_account(addr: address, account: Self::T) {
+        // FIXME this cant be native struct handle for Self::T is mismatched with
+        // the native dispatch
+        abort 0
+    }
 
     // Deposits the `to_deposit` coin into the `payee`'s account
     public fun deposit(payee: address, to_deposit: LibraCoin::T) acquires T {


### PR DESCRIPTION
## Motivation

- Fixed reverse dependency ordering
- Fixed missing transaction natives
- Added check to always mark Transaction module as a fake native
- Removed 'native' modifier on functions that would not link
  - Will have to fix later

## Test Plan

- Ran @runtian-zhou's building script
- cargo test
