### PR TITLE
[language][prover] Extended syntax of specifications to allow vector …

### DIFF
--- a/language/compiler/ir-to-bytecode/src/compiler.rs
+++ b/language/compiler/ir-to-bytecode/src/compiler.rs
@@ -1165,6 +1165,11 @@ fn compile_expression(
                     push_instr!(exp.span, Bytecode::Ge);
                     vec_deque![InferredType::Bool]
                 }
+                BinOp::Subrange => {
+                    // TODO (DD): Realized that I needed to do this late in the game.
+                    //   Considering implementing subrange without using BinOp
+                    unreachable!("Subrange operators should only appear in specification ASTs.");
+                }
             }
         }
         Exp_::Dereference(e) => {

--- a/language/compiler/ir-to-bytecode/syntax/src/lexer.rs
+++ b/language/compiler/ir-to-bytecode/syntax/src/lexer.rs
@@ -107,6 +107,9 @@ pub enum Tok {
     Pipe,
     PipePipe,
     RBrace,
+    LSquare,
+    RSquare,
+    PeriodPeriod,
 }
 
 impl Tok {
@@ -318,13 +321,21 @@ fn find_token(
         '+' => (Tok::Plus, 1),
         ',' => (Tok::Comma, 1),
         '-' => (Tok::Minus, 1),
-        '.' => (Tok::Period, 1),
+        '.' => {
+            if text.starts_with("..") {
+                (Tok::PeriodPeriod, 2) // range, for specs
+            } else {
+                (Tok::Period, 1)
+            }
+        }
         '/' => (Tok::Slash, 1),
         ':' => (Tok::Colon, 1),
         ';' => (Tok::Semicolon, 1),
         '^' => (Tok::Caret, 1),
         '{' => (Tok::LBrace, 1),
         '}' => (Tok::RBrace, 1),
+        '[' => (Tok::LSquare, 1), // for vector specs
+        ']' => (Tok::RSquare, 1), // for vector specs
         _ => {
             return Err(ParseError::InvalidToken {
                 location: start_offset,

--- a/language/move-ir/types/src/ast.rs
+++ b/language/move-ir/types/src/ast.rs
@@ -519,6 +519,8 @@ pub enum BinOp {
     Le,
     /// `>=`
     Ge,
+    /// '..'  only used in specs
+    Subrange,
 }
 
 /// Enum for all expressions
@@ -1551,6 +1553,7 @@ impl fmt::Display for BinOp {
                 BinOp::Gt => ">",
                 BinOp::Le => "<=",
                 BinOp::Ge => ">=",
+                BinOp::Subrange => "..",
             }
         )
     }

--- a/language/move-ir/types/src/spec_language_ast.rs
+++ b/language/move-ir/types/src/spec_language_ast.rs
@@ -7,6 +7,13 @@ use libra_types::identifier::Identifier;
 
 /// AST for the Move Prover specification language.
 
+// .foo or [x + 1]
+#[derive(PartialEq, Debug, Clone)]
+pub enum FieldOrIndex {
+    Field(Field_),
+    Index(SpecExp),
+}
+
 /// A location that can store a value
 #[derive(PartialEq, Debug, Clone)]
 pub enum StorageLocation {
@@ -18,10 +25,10 @@ pub enum StorageLocation {
         type_actuals: Vec<Type>,
         address: Box<StorageLocation>,
     },
-    /// An access path rooted at `base` with nonempty offsets in `fields`
+    /// An access path rooted at `base` with nonempty offsets in `fields_or_indices`
     AccessPath {
         base: Box<StorageLocation>,
-        fields: Vec<Field_>,
+        fields_and_indices: Vec<FieldOrIndex>,
     },
     /// Sender address for the current transaction
     TxnSenderAddress,
@@ -53,7 +60,6 @@ pub enum SpecExp {
     Not(Box<SpecExp>),
     /// Binary operators also suported by Move
     Binop(Box<SpecExp>, BinOp, Box<SpecExp>),
-    // TODO: binary operators not supported by Move like implies and iff
     /// Value of expression evaluated in the state before function enter.
     Old(Box<SpecExp>),
     /// Call to a helper function.

--- a/language/move-prover/bytecode-to-boogie/test_mvir/test-vector-specs.mvir
+++ b/language/move-prover/bytecode-to-boogie/test_mvir/test-vector-specs.mvir
@@ -1,0 +1,305 @@
+// To run from bytecode-to-boogie dir:
+// cargo run test_mvir/verify-stdlib/vector.mvir  test_mvir/test-vector-specs.mvir
+// Delete this comment when it is integrated into tests.
+
+module VerifyVector {
+    import 0x0.Vector;
+
+    // succeeds. [] == [].
+    public test_empty1() : Vector.T<u64> * Vector.T<u64>
+    ensures RET(0) == RET(1)
+    {
+        let ev1: Vector.T<u64>;
+        let ev2: Vector.T<u64>;
+        ev1 = Vector.empty<u64>();
+        ev2 = Vector.empty<u64>();
+        return (move(ev1), move(ev2));
+    }
+
+    //succeeds. [] == [].
+    public test_empty2() : Vector.T<u64> * Vector.T<u64>
+    ensures RET(0) == RET(1)
+    {
+        let ev1: Vector.T<u64>;
+        let ev2: Vector.T<u64>;
+        let x: u64;
+        ev1 = Vector.empty<u64>();
+        ev2 = Vector.empty<u64>();
+        Vector.push_back<u64>(&mut ev1, 1);
+        x = Vector.pop_back<u64>(&mut ev1);
+        return (move(ev1), move(ev2));
+    }
+
+    // succeeds. [1] == [1]
+    public test_empty3() : Vector.T<u64> * Vector.T<u64>
+    // TODO: next spec crashes because vec indices don't generate boogie yet.
+    // spec should succeed
+    // ensures RET(0)[0] == RET(1)[0]
+    {
+        let ev1: Vector.T<u64>;
+        let ev2: Vector.T<u64>;
+        ev1 = Vector.empty<u64>();
+        ev2 = Vector.empty<u64>();
+        Vector.push_back<u64>(&mut ev1, 1);
+        Vector.push_back<u64>(&mut ev2, 1);
+        return (move(ev1), move(ev2));
+    }
+
+    //succeeds. [1,2] != [1].
+    public test_empty4() : Vector.T<u64> * Vector.T<u64>
+    // TODO: next spec crashes because vec indices don't generate boogie yet.
+    // spec should fail
+    // ensures RET(0)[0..1][1] == RET(1)[0]
+    {
+        let ev1: Vector.T<u64>;
+        let ev2: Vector.T<u64>;
+        ev1 = Vector.empty<u64>();
+        ev2 = Vector.empty<u64>();
+        Vector.push_back<u64>(&mut ev1, 1);
+        Vector.push_back<u64>(&mut ev1, 2);
+        Vector.push_back<u64>(&mut ev2, 1);
+        return (move(ev1), move(ev2));
+    }
+
+    //succeeds. [1] != [0].
+    public test_empty5() : Vector.T<u64> * Vector.T<u64>
+    ensures RET(0) != RET(1)
+    {
+        let ev1: Vector.T<u64>;
+        let ev2: Vector.T<u64>;
+        ev1 = Vector.empty<u64>();
+        ev2 = Vector.empty<u64>();
+        Vector.push_back<u64>(&mut ev1, 1);
+        Vector.push_back<u64>(&mut ev2, 0);
+        return (move(ev1), move(ev2));
+    }
+
+    // succeeds. reverse([]) == [].
+    public test_reverse1() : Vector.T<u64> * Vector.T<u64>
+    ensures RET(0) == RET(1)
+    {
+        let ev1: Vector.T<u64>;
+        let ev2: Vector.T<u64>;
+        ev1 = Vector.empty<u64>();
+        ev2 = Vector.empty<u64>();
+        Vector.reverse<u64>(&mut ev1);
+        return (move(ev1), move(ev2));
+    }
+
+    // succeeds. reverse([1,2]) == [2,1].
+    public test_reverse2() : Vector.T<u64> * Vector.T<u64>
+    ensures RET(0) == RET(1)
+    {
+        let ev1: Vector.T<u64>;
+        let ev2: Vector.T<u64>;
+        ev1 = Vector.empty<u64>();
+        ev2 = Vector.empty<u64>();
+        Vector.push_back<u64>(&mut ev1, 1);
+        Vector.push_back<u64>(&mut ev1, 2);
+        Vector.push_back<u64>(&mut ev2, 2);
+        Vector.push_back<u64>(&mut ev2, 1);
+        Vector.reverse<u64>(&mut ev1);
+        return (move(ev1), move(ev2));
+    }
+
+    // succeeds. Always aborts because the first index argument of `swap` is out-of-bounds.
+    public test_swap1()
+    aborts_if true
+    {
+        let ev1: Vector.T<u64>;
+        ev1 = Vector.empty<u64>();
+        Vector.push_back<u64>(&mut ev1, 0);
+        Vector.swap<u64>(&mut ev1, 1, 0);
+        return;
+    }
+
+    // succeeds. Always aborts because the second index argument of `swap` is out-of-bounds.
+    public test_swap2()
+    aborts_if true
+    {
+        let ev1: Vector.T<u64>;
+        ev1 = Vector.empty<u64>();
+        Vector.push_back<u64>(&mut ev1, 0);
+        Vector.swap<u64>(&mut ev1, 0, 1);
+        return;
+    }
+
+    // succeeds. swap([1,2],0,1) == [2,1].
+    public test_swap3() : Vector.T<u64> * Vector.T<u64>
+    ensures RET(0) == RET(1)
+    {
+        let ev1: Vector.T<u64>;
+        let ev2: Vector.T<u64>;
+        ev1 = Vector.empty<u64>();
+        ev2 = Vector.empty<u64>();
+        Vector.push_back<u64>(&mut ev1, 1);
+        Vector.push_back<u64>(&mut ev1, 2);
+        Vector.push_back<u64>(&mut ev2, 2);
+        Vector.push_back<u64>(&mut ev2, 1);
+        Vector.swap<u64>(&mut ev1, 0, 0);
+        Vector.swap<u64>(&mut ev1, 0, 1);
+        return (move(ev1), move(ev2));
+    }
+
+    // succeeds. length([1]) = length([]) + 1.
+    public test_length1() : u64 * u64
+    ensures RET(0) == RET(1) + 1
+    {
+        let ev1: Vector.T<u64>;
+        let ev2: Vector.T<u64>;
+        ev1 = Vector.empty<u64>();
+        ev2 = Vector.empty<u64>();
+        Vector.push_back<u64>(&mut ev1, 1);
+        return (Vector.length<u64>(& ev1), Vector.length<u64>(& ev2));
+    }
+
+    // succeeds. length(v) + 3 == length(v^[1]^[2]^[3]).
+    public test_length2(v: Vector.T<u64>) : u64 * u64
+    ensures RET(0) + 3 == RET(1)
+    {
+        let x: u64;
+        let y: u64;
+        x = Vector.length<u64>(& v);
+        Vector.push_back<u64>(&mut v, 1);
+        Vector.push_back<u64>(&mut v, 2);
+        Vector.push_back<u64>(&mut v, 3);
+        y = Vector.length<u64>(& v);
+        return (move(x), move(y));
+    }
+
+    // succeeds. v == v.
+    public test_id1(v: Vector.T<u64>) : Vector.T<u64>
+    ensures RET(0) == old(v)
+    {
+        return (move(v));
+    }
+
+    // succeeds. reverse(reverse(v)) == v.
+    public test_id2(v: Vector.T<u64>) : Vector.T<u64>
+    ensures RET(0) == old(v)
+    {
+        Vector.reverse<u64>(&mut v);
+        Vector.reverse<u64>(&mut v);
+        return (move(v));
+    }
+
+    // succeeds. reverse(some_obscure_reverse_routine(v)) == v.
+    public test_id3(v: Vector.T<u64>) : Vector.T<u64>
+    ensures RET(0) == old(v)
+    {
+        let l: u64;
+        l = Vector.length<u64>(& v);
+        if(copy(l) <= 1) {
+        }
+        else {
+            if (copy(l) <= 3) {
+                Vector.swap<u64>(&mut v, 0, copy(l)-1);
+            }
+            else {
+                Vector.reverse<u64>(&mut v);
+            }
+        }
+        Vector.reverse<u64>(&mut v);
+        return (move(v));
+    }
+
+    // succeeds. If the input vector is empty, destroy it, and return a new empty vector.
+    public test_destroy_empty1(v: Vector.T<u64>) : Vector.T<u64>
+    ensures RET(0) == old(v)
+    {
+        if (Vector.is_empty<u64>(& v)) {
+            Vector.destroy_empty<u64>(move(v));
+            return Vector.empty<u64>();
+        }
+        else {
+            return move(v);
+        }
+    }
+
+    // succeeds. Always aborts. If v is empty, attempt to access out-of-bounds. Otherwise, attempt to destroy the non-empty vector.
+    public test_destroy_empty2(v: Vector.T<u64>)
+    aborts_if true
+    {
+        if (Vector.is_empty<u64>(& v)) {
+            Vector.set<u64>(&mut v, 0, 0);
+        }
+        else {
+            Vector.destroy_empty<u64>(move(v));
+        }
+        return;
+    }
+
+    // succeeds. [x] == [x].
+    public test_get_set1(x: u64) : Vector.T<u64> * Vector.T<u64>
+    ensures RET(0) == RET(1)
+    {
+        let ev1: Vector.T<u64>;
+        let ev2: Vector.T<u64>;
+        ev1 = Vector.empty<u64>();
+        ev2 = Vector.empty<u64>();
+        Vector.push_back<u64>(&mut ev1, 1);
+        Vector.push_back<u64>(&mut ev2, 2);
+        Vector.set<u64>(&mut ev1, 0, move(x));
+        Vector.set<u64>(&mut ev2, 0, Vector.get<u64>(& ev1, 0));
+        return (move(ev1), move(ev2));
+    }
+
+    // succeeds.
+    public test_get1() : u64
+    ensures RET(0) == 7
+    {
+        let ev1: Vector.T<u64>;
+        ev1 = Vector.empty<u64>();
+        Vector.push_back<u64>(&mut ev1, 7);
+        return Vector.get<u64>(&ev1, 0);
+    }
+
+    // succeeds. Always aborts due to the out-of-bounds index used.
+    public test_get2()
+    aborts_if true
+    {
+        let x : u64;
+        let ev1: Vector.T<u64>;
+        ev1 = Vector.empty<u64>();
+        Vector.push_back<u64>(&mut ev1, 1);
+        x = Vector.get<u64>(& ev1, 1);
+        return;
+    }
+
+    // succeeds. 7 == 7.
+    public test_borrow1() : u64 * u64
+    ensures RET(0) == RET(1)
+    {
+        let ev1: Vector.T<u64>;
+        let y : &u64;
+        ev1 = Vector.empty<u64>();
+        Vector.push_back<u64>(&mut ev1, 7);
+        y = Vector.borrow<u64>(&ev1, 0);
+        return (7, *move(y));
+    }
+
+    // succeeds. Always aborts due to the out-of-bounds index used.
+    public test_borrow2() : u64 * u64
+    aborts_if true
+    ensures false
+    {
+        let ev1: Vector.T<u64>;
+        let y : &u64;
+        ev1 = Vector.empty<u64>();
+        Vector.push_back<u64>(&mut ev1, 7);
+        y = Vector.borrow<u64>(&ev1, 1);
+        return (7, *move(y));
+    }
+
+    // fails. 0 != 7
+    public test_borrow3() : u64 * u64
+    ensures RET(0) == RET(1) //! A postcondition might not hold on this return path.
+    {
+        let ev1: Vector.T<u64>;
+        let y : &u64;
+        ev1 = Vector.empty<u64>();
+        Vector.push_back<u64>(&mut ev1, 7);
+        y = Vector.borrow<u64>(&ev1, 0);
+        return (0, *move(y));
+    }
+}

--- a/language/move-prover/bytecode-to-boogie/tests/prover_tests.rs
+++ b/language/move-prover/bytecode-to-boogie/tests/prover_tests.rs
@@ -40,6 +40,11 @@ fn verify_ref_param() {
 }
 
 #[test]
+fn test_aborts_if() {
+    test(VERIFY, &["test_mvir/test-aborts-if.mvir"]);
+}
+
+#[test]
 fn verify_vector() {
     test(
         VERIFY,

--- a/language/move-prover/bytecode-to-boogie/tests/translator_tests.rs
+++ b/language/move-prover/bytecode-to-boogie/tests/translator_tests.rs
@@ -35,11 +35,6 @@ fn test_struct() {
 }
 
 #[test]
-fn test_aborts_if() {
-    test(VERIFY, &["test_mvir/test-aborts-if.mvir"]);
-}
-
-#[test]
 fn test_access_path() {
     test(
         &["--native-stubs"],


### PR DESCRIPTION
…index

using v[i].  Added a test case.

We plan several more extensions soon to support vector specification.

There is also some code for subranges, although it doesn't generate an AST
yet (I'm having some misgivings about how I added it to the parser).

This is incomplete because boogie is not being generated.  For now, use
of this feature generates dummy boogie code.

I also moved aborts_if test from tests/translator_tests.rs to
prover_tests.rs because it was in the wrong file.

<!--
Thank you for sending a PR. We appreciate you spending time to help improve the Libra project.

The project is undergoing daily changes. Pull Requests will be reviewed and responded to as time permits.
-->

## Motivation

(Write your motivation for proposed changes here.)

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?

(Write your answer here.)

## Test Plan

(Share your test plan here. If you changed code, please provide us with clear instructions for verifying that your changes work.)

## Related PRs

(If this PR adds or changes functionality, please take some time to update the docs at https://github.com/libra/website, and link to your PR here.)
