### PR TITLE
[cluster-test] Increase deadline to 600 and reduce test dur to 120

### DIFF
--- a/testsuite/cluster-test/src/experiments/performance_benchmark_nodes_down.rs
+++ b/testsuite/cluster-test/src/experiments/performance_benchmark_nodes_down.rs
@@ -52,7 +52,7 @@ pub struct PerformanceBenchmarkNodesDown {
     duration: Duration,
 }
 
-pub const DEFAULT_BENCH_DURATION: u64 = 180;
+pub const DEFAULT_BENCH_DURATION: u64 = 120;
 
 impl PerformanceBenchmarkNodesDownParams {
     pub fn new_nodes_down(num_nodes_down: usize) -> Self {
@@ -153,7 +153,7 @@ impl Experiment for PerformanceBenchmarkNodesDown {
     }
 
     fn deadline(&self) -> Duration {
-        Duration::from_secs(480)
+        Duration::from_secs(600)
     }
 }
 


### PR DESCRIPTION
## Summary

With the new tx params, the 10% down test times out because the validators take longer to recover. Fixing the timeout.


## Test Plan

```
Experiment Result: 10% down : 938 TPS, 2995.8 ms latency, no expired txns
```