### PR TITLE
[logger] Move security log out of logger

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -832,6 +832,7 @@ dependencies = [
  "libra-logger 0.1.0",
  "libra-mempool 0.1.0",
  "libra-metrics 0.1.0",
+ "libra-security-logger 0.1.0",
  "libra-temppath 0.1.0",
  "libra-types 0.1.0",
  "mirai-annotations 1.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2383,7 +2384,6 @@ dependencies = [
 name = "libra-logger"
 version = "0.1.0"
 dependencies = [
- "backtrace 0.3.44 (registry+https://github.com/rust-lang/crates.io-index)",
  "chrono 0.4.10 (registry+https://github.com/rust-lang/crates.io-index)",
  "itertools 0.8.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "once_cell 1.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2416,6 +2416,7 @@ dependencies = [
  "libra-mempool-shared-proto 0.1.0",
  "libra-metrics 0.1.0",
  "libra-proptest-helpers 0.1.0",
+ "libra-security-logger 0.1.0",
  "libra-types 0.1.0",
  "lru-cache 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "mirai-annotations 1.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2540,6 +2541,17 @@ dependencies = [
  "serde_json 1.0.48 (registry+https://github.com/rust-lang/crates.io-index)",
  "thiserror 1.0.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "toml 0.5.6 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "libra-security-logger"
+version = "0.1.0"
+dependencies = [
+ "backtrace 0.3.44 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libra-logger 0.1.0",
+ "rand 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_json 1.0.48 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -3086,6 +3098,7 @@ dependencies = [
  "libra-logger 0.1.0",
  "libra-metrics 0.1.0",
  "libra-proptest-helpers 0.1.0",
+ "libra-security-logger 0.1.0",
  "libra-types 0.1.0",
  "memsocket 0.1.0",
  "netcore 0.1.0",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,6 +20,7 @@ members = [
     "common/num-variants",
     "common/proptest-helpers",
     "common/prost-ext",
+    "common/security-logger",
     "common/temppath",
     "common/util",
     "common/workspace-builder",

--- a/common/logger/Cargo.toml
+++ b/common/logger/Cargo.toml
@@ -12,7 +12,6 @@ edition = "2018"
 # Do NOT add any inter-project dependencies.
 # This is to avoid ever having a circular dependency with the libra-logger crate.
 [dependencies]
-backtrace = { version = "0.3.44", features = ["serialize-serde"] }
 chrono = "0.4.7"
 itertools = "0.8.0"
 once_cell = "1.3.1"

--- a/common/logger/src/lib.rs
+++ b/common/logger/src/lib.rs
@@ -25,7 +25,6 @@ extern crate slog;
 mod collector_serializer;
 mod glog_format;
 mod kv_categorizer;
-mod security;
 mod simple_logger;
 
 use crate::kv_categorizer::ErrorCategorizer;
@@ -42,7 +41,6 @@ use std::sync::Mutex;
 
 /// Logger prelude which includes all logging macros.
 pub mod prelude {
-    pub use crate::security::{security_log, SecurityEvent};
     pub use slog::{slog_crit, slog_debug, slog_error, slog_info, slog_trace, slog_warn};
     pub use slog_scope::{crit, debug, error, info, trace, warn};
 }

--- a/common/security-logger/Cargo.toml
+++ b/common/security-logger/Cargo.toml
@@ -1,0 +1,18 @@
+[package]
+name = "libra-security-logger"
+version = "0.1.0"
+authors = ["Libra Association <opensource@libra.org>"]
+description = "Libra libra-security-logger"
+repository = "https://github.com/libra/libra"
+homepage = "https://libra.org"
+license = "Apache-2.0"
+publish = false
+edition = "2018"
+
+[dependencies]
+backtrace = { version = "0.3.44", features = ["serialize-serde"] }
+rand = "0.6.5"
+serde = { version = "1.0.96", features = ["derive"] }
+serde_json = "1.0.40"
+
+libra-logger = { path = "../logger", version = "0.1.0" }

--- a/common/security-logger/src/lib.rs
+++ b/common/security-logger/src/lib.rs
@@ -1,8 +1,8 @@
 // Copyright (c) The Libra Core Contributors
 // SPDX-License-Identifier: Apache-2.0
 
-use super::error;
 use backtrace::Backtrace;
+use libra_logger::error;
 use rand::{rngs::SmallRng, FromEntropy, Rng};
 use serde::Serialize;
 use std::fmt::{self, Debug};
@@ -78,7 +78,7 @@ pub enum SecurityEvent {
 ///
 /// # Example:
 /// ```rust
-/// use libra_logger::prelude::*;
+/// use libra_security_logger::{security_log, SecurityEvent};
 /// use std::fmt::Debug;
 ///
 /// #[derive(Debug)]
@@ -121,7 +121,7 @@ pub fn security_log(event: SecurityEvent) -> SecurityLog {
 }
 
 impl SecurityLog {
-    pub(crate) fn new(event: SecurityEvent) -> Self {
+    fn new(event: SecurityEvent) -> Self {
         SecurityLog {
             event,
             error: None,

--- a/consensus/Cargo.toml
+++ b/consensus/Cargo.toml
@@ -31,23 +31,24 @@ prometheus = { version = "0.7.0", default-features = false }
 proptest = { version = "0.9.4", optional = true }
 
 channel = { path = "../common/channel", version = "0.1.0" }
-crash-handler = { path = "../common/crash-handler", version = "0.1.0" }
-libra-config = { path = "../config", version = "0.1.0" }
 consensus-types = { path = "consensus-types", version = "0.1.0", default-features = false }
-libra-crypto = { path = "../crypto/crypto", version = "0.1.0" }
+crash-handler = { path = "../common/crash-handler", version = "0.1.0" }
 debug-interface = { path = "../common/debug-interface", version = "0.1.0" }
 executor = { path = "../executor", version = "0.1.0" }
 lcs = { path = "../common/lcs", version = "0.1.0", package = "libra-canonical-serialization" }
+libra-config = { path = "../config", version = "0.1.0" }
+libra-crypto = { path = "../crypto/crypto", version = "0.1.0" }
 libra-logger = { path = "../common/logger", version = "0.1.0" }
 libra-mempool = { path = "../mempool", version = "0.1.0" }
 libra-metrics = { path = "../common/metrics", version = "0.1.0" }
+libra-security-logger = { path = "../common/security-logger", version = "0.1.0" }
+libra-temppath = { path = "../common/temppath", version = "0.1.0" }
+libra-types = { path = "../types", version = "0.1.0" }
 network = { path = "../network", version = "0.1.0" }
 safety-rules = { path = "safety-rules", version = "0.1.0" }
 state-synchronizer = { path = "../state-synchronizer", version = "0.1.0" }
 schemadb = { path = "../storage/schemadb", version = "0.1.0" }
 storage-client = { path = "../storage/storage-client", version = "0.1.0" }
-libra-temppath = { path = "../common/temppath", version = "0.1.0" }
-libra-types = { path = "../types", version = "0.1.0" }
 vm-runtime = { path = "../language/vm/vm-runtime", version = "0.1.0" }
 
 [dev-dependencies]

--- a/consensus/src/chained_bft/event_processor.rs
+++ b/consensus/src/chained_bft/event_processor.rs
@@ -41,6 +41,7 @@ use consensus_types::{
 };
 use libra_crypto::hash::TransactionAccumulatorHasher;
 use libra_logger::prelude::*;
+use libra_security_logger::{security_log, SecurityEvent};
 use libra_types::{
     crypto_proxies::{LedgerInfoWithSignatures, ValidatorChangeProof, ValidatorVerifier},
     transaction::TransactionStatus,

--- a/consensus/src/chained_bft/network.rs
+++ b/consensus/src/chained_bft/network.rs
@@ -19,6 +19,7 @@ use consensus_types::{
 };
 use futures::{channel::oneshot, stream::select, SinkExt, Stream, StreamExt, TryStreamExt};
 use libra_logger::prelude::*;
+use libra_security_logger::{security_log, SecurityEvent};
 use libra_types::{
     account_address::AccountAddress,
     crypto_proxies::{ValidatorChangeProof, ValidatorVerifier},

--- a/mempool/Cargo.toml
+++ b/mempool/Cargo.toml
@@ -29,11 +29,12 @@ libra-crypto = { path = "../crypto/crypto", version = "0.1.0" }
 libra-logger = { path = "../common/logger", version = "0.1.0" }
 libra-mempool-shared-proto = { path = "mempool-shared-proto", version = "0.1.0" }
 libra-metrics = { path = "../common/metrics", version = "0.1.0" }
+libra-security-logger = { path = "../common/security-logger", version = "0.1.0" }
 libra-types = { path = "../types", version = "0.1.0" }
 mirai-annotations = "1.5.0"
 network = { path = "../network", version = "0.1.0" }
-storage-client = { path = "../storage/storage-client", version = "0.1.0" }
 prometheus = { version = "0.7.0", default-features = false }
+storage-client = { path = "../storage/storage-client", version = "0.1.0" }
 vm-validator = { path = "../vm-validator", version = "0.1.0" }
 
 libra-proptest-helpers = { path = "../common/proptest-helpers", optional = true }
@@ -41,7 +42,6 @@ proptest = { version = "0.9.4", optional = true }
 storage-service = { path = "../storage/storage-service", version = "0.1.0", optional = true }
 
 [dev-dependencies]
-channel = { path = "../common/channel", version = "0.1.0" }
 parity-multiaddr = { version = "0.7.2", default-features = false }
 rand = "0.6.5"
 

--- a/mempool/src/shared_mempool.rs
+++ b/mempool/src/shared_mempool.rs
@@ -30,6 +30,7 @@ use libra_mempool_shared_proto::proto::mempool_status::{
     MempoolAddTransactionStatus as MempoolAddTransactionStatusProto,
     MempoolAddTransactionStatusCode,
 };
+use libra_security_logger::{security_log, SecurityEvent};
 use libra_types::{
     account_address::AccountAddress,
     proto::types::{SignedTransaction as SignedTransactionProto, VmStatus as VmStatusProto},

--- a/network/Cargo.toml
+++ b/network/Cargo.toml
@@ -28,9 +28,10 @@ channel = { path = "../common/channel", version = "0.1.0" }
 lcs = { path = "../common/lcs", version = "0.1.0", package = "libra-canonical-serialization" }
 libra-config = { path = "../config", version = "0.1.0" }
 libra-crypto = { path = "../crypto/crypto", version = "0.1.0" }
-libra-metrics = { path = "../common/metrics", version = "0.1.0" }
 libra-types = { path = "../types", version = "0.1.0" }
 libra-logger = { path = "../common/logger", version = "0.1.0" }
+libra-metrics = { path = "../common/metrics", version = "0.1.0" }
+libra-security-logger = { path = "../common/security-logger", version = "0.1.0" }
 memsocket = { path = "memsocket", version = "0.1.0" }
 netcore = { path = "netcore", version = "0.1.0" }
 noise = { path = "noise", version = "0.1.0" }

--- a/network/src/protocols/discovery/mod.rs
+++ b/network/src/protocols/discovery/mod.rs
@@ -52,6 +52,7 @@ use libra_crypto::{
     HashValue, Signature,
 };
 use libra_logger::prelude::*;
+use libra_security_logger::{security_log, SecurityEvent};
 use libra_types::{crypto_proxies::ValidatorSigner as Signer, PeerId};
 use parity_multiaddr::Multiaddr;
 use rand::{rngs::SmallRng, FromEntropy, Rng};

--- a/network/src/protocols/health_checker/mod.rs
+++ b/network/src/protocols/health_checker/mod.rs
@@ -35,6 +35,7 @@ use futures::{
     stream::{FusedStream, FuturesUnordered, Stream, StreamExt},
 };
 use libra_logger::prelude::*;
+use libra_security_logger::{security_log, SecurityEvent};
 use libra_types::PeerId;
 use rand::{rngs::SmallRng, seq::SliceRandom, FromEntropy, Rng};
 use serde::{Deserialize, Serialize};

--- a/network/src/transport.rs
+++ b/network/src/transport.rs
@@ -9,7 +9,7 @@ use libra_crypto::{
     x25519::{X25519StaticPrivateKey, X25519StaticPublicKey},
     ValidKey,
 };
-use libra_logger::prelude::*;
+use libra_security_logger::{security_log, SecurityEvent};
 use libra_types::PeerId;
 use netcore::{
     multiplexing::{yamux::Yamux, StreamMultiplexer},


### PR DESCRIPTION
There doesn't seem to be a clear reason to have these in the same crate.
In fact, one could argue that anything under common should be oblivious
to libra core concepts and security-logger should possibly live in
another path. Also this brings in backtrace, which we can now remove
from the dependencies for libra logger.