### PR TITLE
[move-prover] Track Abort instruction location for execution traces.

### DIFF
--- a/language/move-prover/bytecode-to-boogie/src/bytecode_translator.rs
+++ b/language/move-prover/bytecode-to-boogie/src/bytecode_translator.rs
@@ -1010,7 +1010,18 @@ impl<'env> ModuleTranslator<'env> {
                     bytecode
                 );
             }
-            Abort(_) => emitln!(self.writer, "goto Label_Abort;"),
+            Abort(_) => {
+                // Below we introduce a dummy `if` for $DebugTrackAbort to ensure boogie creates
+                // a execution trace entry for this statement.
+                emitln!(
+                    self.writer,
+                    "if (true) {{ assume $DebugTrackAbort({}, {}, {}); }}",
+                    func_env.module_env.get_module_idx(),
+                    func_env.get_def_idx(),
+                    loc.start(),
+                );
+                emitln!(self.writer, "goto Label_Abort;")
+            },
             GetGasRemaining(idx) => {
                 emitln!(self.writer, "call __tmp := GetGasRemaining();");
                 emitln!(self.writer, &update_and_track_local(*idx, "__tmp"));

--- a/language/move-prover/bytecode-to-boogie/tests/goldenfiles/libra_account.bpl
+++ b/language/move-prover/bytecode-to-boogie/tests/goldenfiles/libra_account.bpl
@@ -293,6 +293,7 @@ ensures old(b#Boolean(Boolean(!(b#Boolean(ExistsResource(__m, LibraCoin_MarketCa
     call __tmp := LdConst(11);
     __m := UpdateLocal(__m, __frame + 11, __tmp);
 
+    if (true) { assume $DebugTrackAbort(0, 1, 2784); }
     goto Label_Abort;
 
 Label_11:
@@ -415,6 +416,7 @@ ensures old(b#Boolean(Boolean(!IsEqual(Address(TxnSenderAddress(__txn)), Address
     call __tmp := LdConst(1);
     __m := UpdateLocal(__m, __frame + 4, __tmp);
 
+    if (true) { assume $DebugTrackAbort(0, 2, 3875); }
     goto Label_Abort;
 
 Label_7:
@@ -762,6 +764,7 @@ ensures old(b#Boolean(Boolean(i#Integer(SelectField(Dereference(__m, coin_ref), 
     call __tmp := LdConst(10);
     __m := UpdateLocal(__m, __frame + 10, __tmp);
 
+    if (true) { assume $DebugTrackAbort(0, 7, 5774); }
     goto Label_Abort;
 
 Label_11:
@@ -1029,6 +1032,7 @@ ensures old(b#Boolean(Boolean(!IsEqual(SelectField(coin, LibraCoin_T_value), Int
     call __tmp := LdConst(11);
     __m := UpdateLocal(__m, __frame + 8, __tmp);
 
+    if (true) { assume $DebugTrackAbort(0, 10, 7282); }
     goto Label_Abort;
 
 Label_10:
@@ -1743,6 +1747,7 @@ ensures old(b#Boolean(Boolean(!(b#Boolean(ExistsResource(__m, LibraAccount_T_typ
     call __tmp := LdConst(7);
     __m := UpdateLocal(__m, __frame + 13, __tmp);
 
+    if (true) { assume $DebugTrackAbort(5, 3, 7356); }
     goto Label_Abort;
 
 Label_10:
@@ -2078,6 +2083,7 @@ ensures old(b#Boolean(SelectField(Dereference(__m, GetResourceReference(LibraAcc
     call __tmp := LdConst(11);
     __m := UpdateLocal(__m, __frame + 7, __tmp);
 
+    if (true) { assume $DebugTrackAbort(5, 6, 11369); }
     goto Label_Abort;
 
 Label_9:
@@ -2276,6 +2282,7 @@ ensures old(b#Boolean(Boolean(!(b#Boolean(ExistsResource(__m, LibraAccount_T_typ
     call __tmp := LdConst(11);
     __m := UpdateLocal(__m, __frame + 10, __tmp);
 
+    if (true) { assume $DebugTrackAbort(5, 8, 13146); }
     goto Label_Abort;
 
 Label_13:
@@ -2569,6 +2576,7 @@ ensures old(b#Boolean(SelectField(Dereference(__m, GetResourceReference(LibraAcc
     call __tmp := LdConst(12);
     __m := UpdateLocal(__m, __frame + 7, __tmp);
 
+    if (true) { assume $DebugTrackAbort(5, 11, 17209); }
     goto Label_Abort;
 
 Label_7:
@@ -2689,6 +2697,7 @@ ensures old(b#Boolean(SelectField(Dereference(__m, GetResourceReference(LibraAcc
     call __tmp := LdConst(12);
     __m := UpdateLocal(__m, __frame + 6, __tmp);
 
+    if (true) { assume $DebugTrackAbort(5, 12, 18744); }
     goto Label_Abort;
 
 Label_7:
@@ -2834,6 +2843,7 @@ ensures old(b#Boolean(Boolean(!(b#Boolean(ExistsResource(__m, LibraAccount_T_typ
     call __tmp := LdConst(11);
     __m := UpdateLocal(__m, __frame + 7, __tmp);
 
+    if (true) { assume $DebugTrackAbort(5, 14, 19846); }
     goto Label_Abort;
 
 Label_9:
@@ -3000,6 +3010,7 @@ ensures old(b#Boolean(Boolean(!(b#Boolean(ExistsResource(__m, LibraAccount_T_typ
     call __tmp := LdConst(11);
     __m := UpdateLocal(__m, __frame + 8, __tmp);
 
+    if (true) { assume $DebugTrackAbort(5, 16, 21465); }
     goto Label_Abort;
 
 Label_11:
@@ -3943,6 +3954,7 @@ requires ExistsTxnSenderAccount(__m, __txn);
     call __tmp := LdConst(5);
     __m := UpdateLocal(__m, __frame + 14, __tmp);
 
+    if (true) { assume $DebugTrackAbort(5, 30, 28718); }
     goto Label_Abort;
 
 Label_8:
@@ -3991,6 +4003,7 @@ Label_8:
     call __tmp := LdConst(2);
     __m := UpdateLocal(__m, __frame + 24, __tmp);
 
+    if (true) { assume $DebugTrackAbort(5, 30, 29064); }
     goto Label_Abort;
 
 Label_21:
@@ -4052,6 +4065,7 @@ Label_21:
     call __tmp := LdConst(6);
     __m := UpdateLocal(__m, __frame + 36, __tmp);
 
+    if (true) { assume $DebugTrackAbort(5, 30, 29429); }
     goto Label_Abort;
 
 Label_38:
@@ -4085,6 +4099,7 @@ Label_38:
     call __tmp := LdConst(3);
     __m := UpdateLocal(__m, __frame + 44, __tmp);
 
+    if (true) { assume $DebugTrackAbort(5, 30, 29682); }
     goto Label_Abort;
 
 Label_49:
@@ -4106,6 +4121,7 @@ Label_49:
     call __tmp := LdConst(4);
     __m := UpdateLocal(__m, __frame + 49, __tmp);
 
+    if (true) { assume $DebugTrackAbort(5, 30, 29759); }
     goto Label_Abort;
 
 Label_56:
@@ -4260,6 +4276,7 @@ requires ExistsTxnSenderAccount(__m, __txn);
     call __tmp := LdConst(6);
     __m := UpdateLocal(__m, __frame + 23, __tmp);
 
+    if (true) { assume $DebugTrackAbort(5, 31, 30720); }
     goto Label_Abort;
 
 Label_20:

--- a/language/move-prover/bytecode-to-boogie/tests/goldenfiles/libra_coin.bpl
+++ b/language/move-prover/bytecode-to-boogie/tests/goldenfiles/libra_coin.bpl
@@ -237,6 +237,7 @@ ensures old(b#Boolean(Boolean(!(b#Boolean(ExistsResource(__m, LibraCoin_MarketCa
     call __tmp := LdConst(11);
     __m := UpdateLocal(__m, __frame + 11, __tmp);
 
+    if (true) { assume $DebugTrackAbort(0, 1, 2784); }
     goto Label_Abort;
 
 Label_11:
@@ -359,6 +360,7 @@ ensures old(b#Boolean(Boolean(!IsEqual(Address(TxnSenderAddress(__txn)), Address
     call __tmp := LdConst(1);
     __m := UpdateLocal(__m, __frame + 4, __tmp);
 
+    if (true) { assume $DebugTrackAbort(0, 2, 3875); }
     goto Label_Abort;
 
 Label_7:
@@ -706,6 +708,7 @@ ensures old(b#Boolean(Boolean(i#Integer(SelectField(Dereference(__m, coin_ref), 
     call __tmp := LdConst(10);
     __m := UpdateLocal(__m, __frame + 10, __tmp);
 
+    if (true) { assume $DebugTrackAbort(0, 7, 5774); }
     goto Label_Abort;
 
 Label_11:
@@ -973,6 +976,7 @@ ensures old(b#Boolean(Boolean(!IsEqual(SelectField(coin, LibraCoin_T_value), Int
     call __tmp := LdConst(11);
     __m := UpdateLocal(__m, __frame + 8, __tmp);
 
+    if (true) { assume $DebugTrackAbort(0, 10, 7282); }
     goto Label_Abort;
 
 Label_10:

--- a/language/move-prover/bytecode-to-boogie/tests/goldenfiles/test-aborts-if.bpl
+++ b/language/move-prover/bytecode-to-boogie/tests/goldenfiles/test-aborts-if.bpl
@@ -61,6 +61,7 @@ ensures old(b#Boolean(Boolean(i#Integer(x) <= i#Integer(y)))) ==> __abort_flag;
     call __tmp := LdConst(1);
     __m := UpdateLocal(__m, __frame + 6, __tmp);
 
+    if (true) { assume $DebugTrackAbort(0, 0, 177); }
     goto Label_Abort;
 
 Label_7:
@@ -161,6 +162,7 @@ ensures old(b#Boolean(Boolean(i#Integer(x) <= i#Integer(y)))) ==> __abort_flag;
     call __tmp := LdConst(2);
     __m := UpdateLocal(__m, __frame + 4, __tmp);
 
+    if (true) { assume $DebugTrackAbort(0, 2, 600); }
     goto Label_Abort;
 
 Label_5:
@@ -228,6 +230,7 @@ ensures old(b#Boolean(Boolean(i#Integer(x) < i#Integer(y)))) ==> __abort_flag;
     call __tmp := LdConst(1);
     __m := UpdateLocal(__m, __frame + 6, __tmp);
 
+    if (true) { assume $DebugTrackAbort(0, 3, 860); }
     goto Label_Abort;
 
 Label_7:
@@ -295,6 +298,7 @@ ensures old(b#Boolean(Boolean(i#Integer(x) <= i#Integer(y)))) ==> __abort_flag;
     call __tmp := LdConst(1);
     __m := UpdateLocal(__m, __frame + 6, __tmp);
 
+    if (true) { assume $DebugTrackAbort(0, 4, 1090); }
     goto Label_Abort;
 
 Label_7:
@@ -362,6 +366,7 @@ ensures old(b#Boolean(Boolean(i#Integer(x) < i#Integer(y)))) ==> __abort_flag;
     call __tmp := LdConst(1);
     __m := UpdateLocal(__m, __frame + 6, __tmp);
 
+    if (true) { assume $DebugTrackAbort(0, 5, 1334); }
     goto Label_Abort;
 
 Label_7:
@@ -429,6 +434,7 @@ ensures old(b#Boolean(Boolean(i#Integer(x) < i#Integer(y)))) ==> __abort_flag;
     call __tmp := LdConst(1);
     __m := UpdateLocal(__m, __frame + 6, __tmp);
 
+    if (true) { assume $DebugTrackAbort(0, 6, 1597); }
     goto Label_Abort;
 
 Label_7:
@@ -501,6 +507,7 @@ ensures old(b#Boolean(Boolean(i#Integer(x) < i#Integer(y)))) ==> __abort_flag;
     call __tmp := LdConst(1);
     __m := UpdateLocal(__m, __frame + 6, __tmp);
 
+    if (true) { assume $DebugTrackAbort(0, 7, 1874); }
     goto Label_Abort;
 
 Label_7:
@@ -588,6 +595,7 @@ ensures old(b#Boolean(Boolean(i#Integer(x) > i#Integer(y))) || b#Boolean(Boolean
     call __tmp := LdConst(1);
     __m := UpdateLocal(__m, __frame + 6, __tmp);
 
+    if (true) { assume $DebugTrackAbort(0, 8, 2439); }
     goto Label_Abort;
 
 Label_7:

--- a/language/move-prover/bytecode-to-boogie/tests/goldenfiles/test-access-path.bpl
+++ b/language/move-prover/bytecode-to-boogie/tests/goldenfiles/test-access-path.bpl
@@ -283,6 +283,7 @@ requires ExistsTxnSenderAccount(__m, __txn);
     call __tmp := LdConst(11);
     __m := UpdateLocal(__m, __frame + 9, __tmp);
 
+    if (true) { assume $DebugTrackAbort(4, 1, 1788); }
     goto Label_Abort;
 
 Label_9:
@@ -397,6 +398,7 @@ requires ExistsTxnSenderAccount(__m, __txn);
     call __tmp := LdConst(1);
     __m := UpdateLocal(__m, __frame + 4, __tmp);
 
+    if (true) { assume $DebugTrackAbort(4, 2, 2371); }
     goto Label_Abort;
 
 Label_7:
@@ -729,6 +731,7 @@ requires ExistsTxnSenderAccount(__m, __txn);
     call __tmp := LdConst(10);
     __m := UpdateLocal(__m, __frame + 10, __tmp);
 
+    if (true) { assume $DebugTrackAbort(4, 7, 3795); }
     goto Label_Abort;
 
 Label_11:
@@ -985,6 +988,7 @@ requires ExistsTxnSenderAccount(__m, __txn);
     call __tmp := LdConst(11);
     __m := UpdateLocal(__m, __frame + 8, __tmp);
 
+    if (true) { assume $DebugTrackAbort(4, 10, 4985); }
     goto Label_Abort;
 
 Label_10:
@@ -1084,6 +1088,7 @@ requires ExistsTxnSenderAccount(__m, __txn);
     call __tmp := LdConst(1);
     __m := UpdateLocal(__m, __frame + 5, __tmp);
 
+    if (true) { assume $DebugTrackAbort(5, 0, 406); }
     goto Label_Abort;
 
 Label_7:
@@ -1215,6 +1220,7 @@ requires ExistsTxnSenderAccount(__m, __txn);
     call __tmp := LdConst(5001);
     __m := UpdateLocal(__m, __frame + 14, __tmp);
 
+    if (true) { assume $DebugTrackAbort(5, 1, 1347); }
     goto Label_Abort;
 
 Label_16:
@@ -1244,6 +1250,7 @@ Label_17:
     call __tmp := LdConst(5001);
     __m := UpdateLocal(__m, __frame + 21, __tmp);
 
+    if (true) { assume $DebugTrackAbort(5, 1, 1492); }
     goto Label_Abort;
 
 Label_26:
@@ -1407,6 +1414,7 @@ requires ExistsTxnSenderAccount(__m, __txn);
     call __tmp := LdConst(1);
     __m := UpdateLocal(__m, __frame + 5, __tmp);
 
+    if (true) { assume $DebugTrackAbort(6, 0, 394); }
     goto Label_Abort;
 
 Label_7:
@@ -1493,6 +1501,7 @@ requires ExistsTxnSenderAccount(__m, __txn);
     call __tmp := LdConst(1);
     __m := UpdateLocal(__m, __frame + 6, __tmp);
 
+    if (true) { assume $DebugTrackAbort(6, 1, 752); }
     goto Label_Abort;
 
 Label_7:
@@ -2155,6 +2164,7 @@ requires ExistsTxnSenderAccount(__m, __txn);
     call __tmp := LdConst(7);
     __m := UpdateLocal(__m, __frame + 13, __tmp);
 
+    if (true) { assume $DebugTrackAbort(7, 2, 4453); }
     goto Label_Abort;
 
 Label_10:
@@ -2473,6 +2483,7 @@ requires ExistsTxnSenderAccount(__m, __txn);
     call __tmp := LdConst(11);
     __m := UpdateLocal(__m, __frame + 7, __tmp);
 
+    if (true) { assume $DebugTrackAbort(7, 5, 6909); }
     goto Label_Abort;
 
 Label_9:
@@ -2661,6 +2672,7 @@ requires ExistsTxnSenderAccount(__m, __txn);
     call __tmp := LdConst(11);
     __m := UpdateLocal(__m, __frame + 10, __tmp);
 
+    if (true) { assume $DebugTrackAbort(7, 7, 8108); }
     goto Label_Abort;
 
 Label_13:
@@ -3143,6 +3155,7 @@ requires ExistsTxnSenderAccount(__m, __txn);
     call __tmp := LdConst(11);
     __m := UpdateLocal(__m, __frame + 7, __tmp);
 
+    if (true) { assume $DebugTrackAbort(7, 13, 11386); }
     goto Label_Abort;
 
 Label_9:
@@ -3302,6 +3315,7 @@ requires ExistsTxnSenderAccount(__m, __txn);
     call __tmp := LdConst(11);
     __m := UpdateLocal(__m, __frame + 8, __tmp);
 
+    if (true) { assume $DebugTrackAbort(7, 15, 12638); }
     goto Label_Abort;
 
 Label_11:
@@ -4217,6 +4231,7 @@ requires ExistsTxnSenderAccount(__m, __txn);
     call __tmp := LdConst(5);
     __m := UpdateLocal(__m, __frame + 15, __tmp);
 
+    if (true) { assume $DebugTrackAbort(7, 29, 18100); }
     goto Label_Abort;
 
 Label_8:
@@ -4265,6 +4280,7 @@ Label_8:
     call __tmp := LdConst(2);
     __m := UpdateLocal(__m, __frame + 25, __tmp);
 
+    if (true) { assume $DebugTrackAbort(7, 29, 18446); }
     goto Label_Abort;
 
 Label_21:
@@ -4326,6 +4342,7 @@ Label_21:
     call __tmp := LdConst(6);
     __m := UpdateLocal(__m, __frame + 37, __tmp);
 
+    if (true) { assume $DebugTrackAbort(7, 29, 18811); }
     goto Label_Abort;
 
 Label_38:
@@ -4359,6 +4376,7 @@ Label_38:
     call __tmp := LdConst(3);
     __m := UpdateLocal(__m, __frame + 45, __tmp);
 
+    if (true) { assume $DebugTrackAbort(7, 29, 19064); }
     goto Label_Abort;
 
 Label_49:
@@ -4380,6 +4398,7 @@ Label_49:
     call __tmp := LdConst(4);
     __m := UpdateLocal(__m, __frame + 50, __tmp);
 
+    if (true) { assume $DebugTrackAbort(7, 29, 19141); }
     goto Label_Abort;
 
 Label_56:
@@ -4404,6 +4423,7 @@ Label_56:
     call __tmp := LdConst(7);
     __m := UpdateLocal(__m, __frame + 54, __tmp);
 
+    if (true) { assume $DebugTrackAbort(7, 29, 19243); }
     goto Label_Abort;
 
 Label_62:
@@ -4558,6 +4578,7 @@ requires ExistsTxnSenderAccount(__m, __txn);
     call __tmp := LdConst(6);
     __m := UpdateLocal(__m, __frame + 23, __tmp);
 
+    if (true) { assume $DebugTrackAbort(7, 30, 20204); }
     goto Label_Abort;
 
 Label_20:
@@ -5194,6 +5215,7 @@ ensures old(b#Boolean(Boolean(!(b#Boolean(ExistsResource(__m, LibraAccount_T_typ
     call __tmp := LdConst(77);
     __m := UpdateLocal(__m, __frame + 5, __tmp);
 
+    if (true) { assume $DebugTrackAbort(8, 0, 1167); }
     goto Label_Abort;
 
 Label_7:

--- a/language/move-prover/bytecode-to-boogie/tests/goldenfiles/test-arithmetic.bpl
+++ b/language/move-prover/bytecode-to-boogie/tests/goldenfiles/test-arithmetic.bpl
@@ -287,6 +287,7 @@ requires ExistsTxnSenderAccount(__m, __txn);
     call __tmp := LdConst(42);
     __m := UpdateLocal(__m, __frame + 22, __tmp);
 
+    if (true) { assume $DebugTrackAbort(0, 2, 521); }
     goto Label_Abort;
 
 Label_23:
@@ -422,6 +423,7 @@ requires ExistsTxnSenderAccount(__m, __txn);
     call __tmp := LdConst(42);
     __m := UpdateLocal(__m, __frame + 18, __tmp);
 
+    if (true) { assume $DebugTrackAbort(0, 3, 675); }
     goto Label_Abort;
 
 Label_19:

--- a/language/move-prover/bytecode-to-boogie/tests/goldenfiles/test-func-call.bpl
+++ b/language/move-prover/bytecode-to-boogie/tests/goldenfiles/test-func-call.bpl
@@ -260,6 +260,7 @@ Label_11:
     call __tmp := LdConst(42);
     __m := UpdateLocal(__m, __frame + 22, __tmp);
 
+    if (true) { assume $DebugTrackAbort(0, 2, 359); }
     goto Label_Abort;
 
 Label_27:

--- a/language/move-prover/bytecode-to-boogie/tests/goldenfiles/test-lib.bpl
+++ b/language/move-prover/bytecode-to-boogie/tests/goldenfiles/test-lib.bpl
@@ -199,6 +199,7 @@ requires ExistsTxnSenderAccount(__m, __txn);
     call __tmp := LdConst(0);
     __m := UpdateLocal(__m, __frame + 5, __tmp);
 
+    if (true) { assume $DebugTrackAbort(6, 0, 1320); }
     goto Label_Abort;
 
 Label_7:
@@ -1432,6 +1433,7 @@ requires ExistsTxnSenderAccount(__m, __txn);
     call __tmp := LdConst(11);
     __m := UpdateLocal(__m, __frame + 9, __tmp);
 
+    if (true) { assume $DebugTrackAbort(8, 1, 1788); }
     goto Label_Abort;
 
 Label_9:
@@ -1546,6 +1548,7 @@ requires ExistsTxnSenderAccount(__m, __txn);
     call __tmp := LdConst(1);
     __m := UpdateLocal(__m, __frame + 4, __tmp);
 
+    if (true) { assume $DebugTrackAbort(8, 2, 2371); }
     goto Label_Abort;
 
 Label_7:
@@ -1878,6 +1881,7 @@ requires ExistsTxnSenderAccount(__m, __txn);
     call __tmp := LdConst(10);
     __m := UpdateLocal(__m, __frame + 10, __tmp);
 
+    if (true) { assume $DebugTrackAbort(8, 7, 3795); }
     goto Label_Abort;
 
 Label_11:
@@ -2134,6 +2138,7 @@ requires ExistsTxnSenderAccount(__m, __txn);
     call __tmp := LdConst(11);
     __m := UpdateLocal(__m, __frame + 8, __tmp);
 
+    if (true) { assume $DebugTrackAbort(8, 10, 4985); }
     goto Label_Abort;
 
 Label_10:
@@ -2233,6 +2238,7 @@ requires ExistsTxnSenderAccount(__m, __txn);
     call __tmp := LdConst(1);
     __m := UpdateLocal(__m, __frame + 5, __tmp);
 
+    if (true) { assume $DebugTrackAbort(9, 0, 406); }
     goto Label_Abort;
 
 Label_7:
@@ -2364,6 +2370,7 @@ requires ExistsTxnSenderAccount(__m, __txn);
     call __tmp := LdConst(5001);
     __m := UpdateLocal(__m, __frame + 14, __tmp);
 
+    if (true) { assume $DebugTrackAbort(9, 1, 1347); }
     goto Label_Abort;
 
 Label_16:
@@ -2393,6 +2400,7 @@ Label_17:
     call __tmp := LdConst(5001);
     __m := UpdateLocal(__m, __frame + 21, __tmp);
 
+    if (true) { assume $DebugTrackAbort(9, 1, 1492); }
     goto Label_Abort;
 
 Label_26:
@@ -2556,6 +2564,7 @@ requires ExistsTxnSenderAccount(__m, __txn);
     call __tmp := LdConst(1);
     __m := UpdateLocal(__m, __frame + 5, __tmp);
 
+    if (true) { assume $DebugTrackAbort(10, 0, 394); }
     goto Label_Abort;
 
 Label_7:
@@ -2642,6 +2651,7 @@ requires ExistsTxnSenderAccount(__m, __txn);
     call __tmp := LdConst(1);
     __m := UpdateLocal(__m, __frame + 6, __tmp);
 
+    if (true) { assume $DebugTrackAbort(10, 1, 752); }
     goto Label_Abort;
 
 Label_7:
@@ -3304,6 +3314,7 @@ requires ExistsTxnSenderAccount(__m, __txn);
     call __tmp := LdConst(7);
     __m := UpdateLocal(__m, __frame + 13, __tmp);
 
+    if (true) { assume $DebugTrackAbort(11, 2, 4453); }
     goto Label_Abort;
 
 Label_10:
@@ -3622,6 +3633,7 @@ requires ExistsTxnSenderAccount(__m, __txn);
     call __tmp := LdConst(11);
     __m := UpdateLocal(__m, __frame + 7, __tmp);
 
+    if (true) { assume $DebugTrackAbort(11, 5, 6909); }
     goto Label_Abort;
 
 Label_9:
@@ -3810,6 +3822,7 @@ requires ExistsTxnSenderAccount(__m, __txn);
     call __tmp := LdConst(11);
     __m := UpdateLocal(__m, __frame + 10, __tmp);
 
+    if (true) { assume $DebugTrackAbort(11, 7, 8108); }
     goto Label_Abort;
 
 Label_13:
@@ -4292,6 +4305,7 @@ requires ExistsTxnSenderAccount(__m, __txn);
     call __tmp := LdConst(11);
     __m := UpdateLocal(__m, __frame + 7, __tmp);
 
+    if (true) { assume $DebugTrackAbort(11, 13, 11386); }
     goto Label_Abort;
 
 Label_9:
@@ -4451,6 +4465,7 @@ requires ExistsTxnSenderAccount(__m, __txn);
     call __tmp := LdConst(11);
     __m := UpdateLocal(__m, __frame + 8, __tmp);
 
+    if (true) { assume $DebugTrackAbort(11, 15, 12638); }
     goto Label_Abort;
 
 Label_11:
@@ -5366,6 +5381,7 @@ requires ExistsTxnSenderAccount(__m, __txn);
     call __tmp := LdConst(5);
     __m := UpdateLocal(__m, __frame + 15, __tmp);
 
+    if (true) { assume $DebugTrackAbort(11, 29, 18100); }
     goto Label_Abort;
 
 Label_8:
@@ -5414,6 +5430,7 @@ Label_8:
     call __tmp := LdConst(2);
     __m := UpdateLocal(__m, __frame + 25, __tmp);
 
+    if (true) { assume $DebugTrackAbort(11, 29, 18446); }
     goto Label_Abort;
 
 Label_21:
@@ -5475,6 +5492,7 @@ Label_21:
     call __tmp := LdConst(6);
     __m := UpdateLocal(__m, __frame + 37, __tmp);
 
+    if (true) { assume $DebugTrackAbort(11, 29, 18811); }
     goto Label_Abort;
 
 Label_38:
@@ -5508,6 +5526,7 @@ Label_38:
     call __tmp := LdConst(3);
     __m := UpdateLocal(__m, __frame + 45, __tmp);
 
+    if (true) { assume $DebugTrackAbort(11, 29, 19064); }
     goto Label_Abort;
 
 Label_49:
@@ -5529,6 +5548,7 @@ Label_49:
     call __tmp := LdConst(4);
     __m := UpdateLocal(__m, __frame + 50, __tmp);
 
+    if (true) { assume $DebugTrackAbort(11, 29, 19141); }
     goto Label_Abort;
 
 Label_56:
@@ -5553,6 +5573,7 @@ Label_56:
     call __tmp := LdConst(7);
     __m := UpdateLocal(__m, __frame + 54, __tmp);
 
+    if (true) { assume $DebugTrackAbort(11, 29, 19243); }
     goto Label_Abort;
 
 Label_62:
@@ -5707,6 +5728,7 @@ requires ExistsTxnSenderAccount(__m, __txn);
     call __tmp := LdConst(6);
     __m := UpdateLocal(__m, __frame + 23, __tmp);
 
+    if (true) { assume $DebugTrackAbort(11, 30, 20204); }
     goto Label_Abort;
 
 Label_20:

--- a/language/move-prover/bytecode-to-boogie/tests/goldenfiles/test-reference.bpl
+++ b/language/move-prover/bytecode-to-boogie/tests/goldenfiles/test-reference.bpl
@@ -165,6 +165,7 @@ ensures old(b#Boolean(Boolean(false))) ==> __abort_flag;
     call __tmp := LdConst(42);
     __m := UpdateLocal(__m, __frame + 11, __tmp);
 
+    if (true) { assume $DebugTrackAbort(0, 1, 427); }
     goto Label_Abort;
 
 Label_16:

--- a/language/move-prover/bytecode-to-boogie/tests/goldenfiles/test-struct.bpl
+++ b/language/move-prover/bytecode-to-boogie/tests/goldenfiles/test-struct.bpl
@@ -243,6 +243,7 @@ requires ExistsTxnSenderAccount(__m, __txn);
     call __tmp := LdConst(42);
     __m := UpdateLocal(__m, __frame + 9, __tmp);
 
+    if (true) { assume $DebugTrackAbort(0, 1, 576); }
     goto Label_Abort;
 
 Label_8:
@@ -449,6 +450,7 @@ Label_11:
     call __tmp := LdConst(42);
     __m := UpdateLocal(__m, __frame + 22, __tmp);
 
+    if (true) { assume $DebugTrackAbort(0, 2, 1328); }
     goto Label_Abort;
 
 Label_26:
@@ -557,6 +559,7 @@ ensures old(b#Boolean(Boolean(false))) ==> __abort_flag;
     call __tmp := LdConst(0);
     __m := UpdateLocal(__m, __frame + 14, __tmp);
 
+    if (true) { assume $DebugTrackAbort(0, 3, 1610); }
     goto Label_Abort;
 
 Label_15:

--- a/language/move-prover/bytecode-to-boogie/tests/goldenfiles/test3.bpl
+++ b/language/move-prover/bytecode-to-boogie/tests/goldenfiles/test3.bpl
@@ -272,6 +272,7 @@ Label_28:
     call __tmp := LdConst(42);
     __m := UpdateLocal(__m, __frame + 41, __tmp);
 
+    if (true) { assume $DebugTrackAbort(0, 0, 719); }
     goto Label_Abort;
 
 Label_52:
@@ -293,6 +294,7 @@ Label_52:
     call __tmp := LdConst(42);
     __m := UpdateLocal(__m, __frame + 46, __tmp);
 
+    if (true) { assume $DebugTrackAbort(0, 0, 749); }
     goto Label_Abort;
 
 Label_59:
@@ -317,6 +319,7 @@ Label_60:
     call __tmp := LdConst(42);
     __m := UpdateLocal(__m, __frame + 51, __tmp);
 
+    if (true) { assume $DebugTrackAbort(0, 0, 790); }
     goto Label_Abort;
 
 Label_67:
@@ -338,6 +341,7 @@ Label_67:
     call __tmp := LdConst(42);
     __m := UpdateLocal(__m, __frame + 56, __tmp);
 
+    if (true) { assume $DebugTrackAbort(0, 0, 820); }
     goto Label_Abort;
 
 Label_74:

--- a/language/move-prover/bytecode-to-boogie/tests/goldenfiles/verify-create-resource.bpl
+++ b/language/move-prover/bytecode-to-boogie/tests/goldenfiles/verify-create-resource.bpl
@@ -75,6 +75,7 @@ ensures old(b#Boolean(ExistsResource(__m, TestSpecs_R_type_value(), a#Address(Ad
     call __tmp := LdConst(1);
     __m := UpdateLocal(__m, __frame + 2, __tmp);
 
+    if (true) { assume $DebugTrackAbort(0, 0, 240); }
     goto Label_Abort;
 
 Label_5:
@@ -141,6 +142,7 @@ ensures old(b#Boolean(ExistsResource(__m, TestSpecs_R_type_value(), a#Address(Ad
     call __tmp := LdConst(1);
     __m := UpdateLocal(__m, __frame + 2, __tmp);
 
+    if (true) { assume $DebugTrackAbort(0, 1, 533); }
     goto Label_Abort;
 
 Label_5:

--- a/language/move-prover/bytecode-to-boogie/tests/goldenfiles/verify-local-ref.bpl
+++ b/language/move-prover/bytecode-to-boogie/tests/goldenfiles/verify-local-ref.bpl
@@ -138,6 +138,7 @@ ensures old(b#Boolean(Boolean(true))) ==> !__abort_flag;
     call __tmp := LdConst(42);
     __m := UpdateLocal(__m, __frame + 11, __tmp);
 
+    if (true) { assume $DebugTrackAbort(0, 1, 430); }
     goto Label_Abort;
 
 Label_16:
@@ -236,6 +237,7 @@ ensures old(b#Boolean(Boolean(true))) ==> !__abort_flag;
     call __tmp := LdConst(42);
     __m := UpdateLocal(__m, __frame + 11, __tmp);
 
+    if (true) { assume $DebugTrackAbort(0, 2, 801); }
     goto Label_Abort;
 
 Label_16:


### PR DESCRIPTION
While we tracked aborts coming via the `abort_flag`, we did not for explicit calls to the `Abort` instruction, so those did not surface correctly in execution traces.

## Motivation

Bug fix.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

Existing tests.

## Related PRs

NA