### PR TITLE
[terraform] Add safety-rules container

### DIFF
--- a/docker/safety-rules/Dockerfile
+++ b/docker/safety-rules/Dockerfile
@@ -30,7 +30,7 @@ COPY --from=builder /libra/target/release/safety-rules /opt/libra/bin
 COPY --from=builder /libra/target/release/config-builder /opt/libra/bin
 
 ENV RUST_BACKTRACE 1
-CMD /opt/libra/bin/safety-rules
+CMD /docker-run-dynamic.sh
 
 ARG BUILD_DATE
 ARG GIT_REV

--- a/terraform/templates/validator.config.toml
+++ b/terraform/templates/validator.config.toml
@@ -1,0 +1,6 @@
+[validator_network]
+
+[consensus.safety_rules.service]
+type = "process"
+server_address = "127.0.0.1:6185"
+consensus_type = "SignedTransactions"

--- a/terraform/templates/validator.json
+++ b/terraform/templates/validator.json
@@ -32,11 +32,12 @@
             {"sourceVolume": "libra-data", "containerPath": "/opt/libra/data"}
         ],
         "environment": [
+            {"name": "CFG_BASE_CONFIG", "value": ${cfg_base_config}},
         %{ if cfg_fullnode_seed != "" }
-	    {"name": "CFG_FULLNODE_SEED", "value": "${cfg_fullnode_seed}"},
-	    {"name": "CFG_NUM_FULLNODES", "value": "${cfg_num_fullnodes}"},
-	%{ endif }
-	    {"name": "CFG_LISTEN_ADDR", "value": "${cfg_listen_addr}"},
+            {"name": "CFG_FULLNODE_SEED", "value": "${cfg_fullnode_seed}"},
+            {"name": "CFG_NUM_FULLNODES", "value": "${cfg_num_fullnodes}"},
+        %{ endif }
+            {"name": "CFG_LISTEN_ADDR", "value": "${cfg_listen_addr}"},
             {"name": "CFG_NODE_INDEX", "value": "${cfg_node_index}"},
             {"name": "CFG_NUM_VALIDATORS", "value": "${cfg_num_validators}"},
             {"name": "CFG_SEED", "value": "${cfg_seed}"},
@@ -68,5 +69,23 @@
             }
 %{ endif }
         }
+    },
+    {
+        "name": "safety-rules",
+        "image": "${safety_rules_image}${safety_rules_image_version}",
+        "command": ["/docker-run-dynamic.sh"],
+        "cpu": 512,
+        "memory": 256,
+        "essential": true,
+        "mountPoints": [
+            {"sourceVolume": "libra-data", "containerPath": "/opt/libra/data"}
+        ],
+        "environment": [
+            {"name": "CFG_NODE_INDEX", "value": "${cfg_node_index}"},
+            {"name": "CFG_NUM_VALIDATORS", "value": "${cfg_num_validators}"},
+            {"name": "CFG_SEED", "value": "${cfg_seed}"},
+            {"name": "CFG_SAFETY_RULES_LISTEN_ADDR", "value": "127.0.0.1:6185"},
+            {"name": "RUST_LOG", "value": "${log_level}"}
+        ]
     }
 ]

--- a/terraform/validators.tf
+++ b/terraform/validators.tf
@@ -126,10 +126,12 @@ data "template_file" "user_data" {
 }
 
 locals {
-  image_repo         = var.image_repo
-  instance_public_ip = true
-  user_data          = data.template_file.user_data.rendered
-  image_version      = substr(var.image_tag, 0, 6) == "sha256" ? "@${var.image_tag}" : ":${var.image_tag}"
+  image_repo                 = var.image_repo
+  image_version              = substr(var.image_tag, 0, 6) == "sha256" ? "@${var.image_tag}" : ":${var.image_tag}"
+  safety_rules_image_repo    = var.safety_rules_image_repo
+  safety_rules_image_version = substr(var.safety_rules_image_tag, 0, 6) == "sha256" ? "@${var.safety_rules_image_tag}" : ":${var.safety_rules_image_tag}"
+  instance_public_ip         = true
+  user_data                  = data.template_file.user_data.rendered
 }
 
 resource "aws_instance" "validator" {
@@ -165,13 +167,14 @@ resource "aws_instance" "validator" {
 }
 
 locals {
-  seed_peer_ip = aws_instance.validator.0.private_ip
+  seed_peer_ip           = aws_instance.validator.0.private_ip
+  validator_command      = var.log_to_file || var.enable_logstash ? jsonencode(["bash", "-c", "/docker-run-dynamic.sh >> ${var.log_path} 2>&1"]) : ""
+  aws_elasticsearch_host = var.enable_logstash ? join(",", aws_elasticsearch_domain.logging.*.endpoint) : ""
+  logstash_config        = "input { file { path => '${var.log_path}'\\n}}\\n output {  amazon_es { \\nhosts => ['https://${local.aws_elasticsearch_host}']\\nregion => 'us-west-2'\\nindex => 'validator-logs-%%{+YYYY.MM.dd}'\\n}}"
 }
 
-locals {
-  validator_command = var.log_to_file || var.enable_logstash ? jsonencode(["bash", "-c", "/docker-run-dynamic.sh >> ${var.log_path} 2>&1"]) : ""
-  aws_elasticsearch_host = var.enable_logstash ? join(",", aws_elasticsearch_domain.logging.*.endpoint) : ""
-  logstash_config  = "input { file { path => '${var.log_path}'\\n}}\\n output {  amazon_es { \\nhosts => ['https://${local.aws_elasticsearch_host}']\\nregion => 'us-west-2'\\nindex => 'validator-logs-%%{+YYYY.MM.dd}'\\n}}"
+data "template_file" "validator_config" {
+  template = file("templates/validator.config.toml")
 }
 
 data "template_file" "ecs_task_definition" {
@@ -179,29 +182,32 @@ data "template_file" "ecs_task_definition" {
   template = file("templates/validator.json")
 
   vars = {
-    image            = local.image_repo
-    image_version    = local.image_version
-    cpu              = var.enable_logstash ? local.cpu_by_instance[var.validator_type] - 584 : local.cpu_by_instance[var.validator_type]
-    mem              = var.enable_logstash ? local.mem_by_instance[var.validator_type] - 1024 : local.mem_by_instance[var.validator_type]
-    cfg_listen_addr  = var.validator_use_public_ip == true ? element(aws_instance.validator.*.public_ip, count.index) : element(aws_instance.validator.*.private_ip, count.index)
-    cfg_node_index   = count.index
+    image              = local.image_repo
+    image_version      = local.image_version
+    cpu                = (var.enable_logstash ? local.cpu_by_instance[var.validator_type] - 584 : local.cpu_by_instance[var.validator_type]) - 512
+    mem                = (var.enable_logstash ? local.mem_by_instance[var.validator_type] - 1024 : local.mem_by_instance[var.validator_type]) - 256
+    cfg_base_config    = jsonencode(data.template_file.validator_config.rendered)
+    cfg_listen_addr    = var.validator_use_public_ip == true ? element(aws_instance.validator.*.public_ip, count.index) : element(aws_instance.validator.*.private_ip, count.index)
+    cfg_node_index     = count.index
     cfg_num_validators = var.cfg_num_validators_override == 0 ? var.num_validators : var.cfg_num_validators_override
-    cfg_seed         = var.config_seed
-    cfg_seed_peer_ip = local.seed_peer_ip
+    cfg_seed           = var.config_seed
+    cfg_seed_peer_ip   = local.seed_peer_ip
 
     cfg_fullnode_seed = count.index < var.num_fullnode_networks ? var.fullnode_seed : ""
     cfg_num_fullnodes = var.num_fullnodes
 
-    log_level        = var.validator_log_level
-    log_group        = var.cloudwatch_logs ? aws_cloudwatch_log_group.testnet.name : ""
-    log_region       = var.region
-    log_prefix       = "validator-${count.index}"
-    capabilities     = jsonencode(var.validator_linux_capabilities)
-    command          = local.validator_command
-    logstash         = var.enable_logstash
-    logstash_image   = var.logstash_image
-    logstash_version = ":${var.logstash_version}"
-    logstash_config  = local.logstash_config
+    log_level                  = var.validator_log_level
+    log_group                  = var.cloudwatch_logs ? aws_cloudwatch_log_group.testnet.name : ""
+    log_region                 = var.region
+    log_prefix                 = "validator-${count.index}"
+    capabilities               = jsonencode(var.validator_linux_capabilities)
+    command                    = local.validator_command
+    logstash                   = var.enable_logstash
+    logstash_image             = var.logstash_image
+    logstash_version           = ":${var.logstash_version}"
+    logstash_config            = local.logstash_config
+    safety_rules_image         = local.safety_rules_image_repo
+    safety_rules_image_version = local.safety_rules_image_version
   }
 }
 

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -81,7 +81,7 @@ variable "fullnode_distribution" {
 # which validator they should be connected to
 locals {
   validator_index = range(0, length(var.fullnode_distribution))
-  fullnode_pair = zipmap(local.validator_index, var.fullnode_distribution)
+  fullnode_pair   = zipmap(local.validator_index, var.fullnode_distribution)
   expanded_fullnodes = {
     for key, val in local.fullnode_pair : key => [
       for i in range(val) : format("%d", key)
@@ -165,14 +165,14 @@ variable "log_to_file" {
 }
 
 variable "log_path" {
-  type        = string
-  default     = "/opt/libra/data/libra.log"
+  type    = string
+  default = "/opt/libra/data/libra.log"
 }
 
 variable "enable_logstash" {
-  type    = bool
+  type        = bool
   description = "Enable logstash instance on validator to send logs to elasticservice, this will enable log_to_file"
-  default = false
+  default     = false
 }
 
 variable "logstash_image" {
@@ -186,6 +186,18 @@ variable "logstash_version" {
 }
 
 variable "elastic_storage_size" {
-  default = 500
+  default     = 500
   description = "The volume size for Elasticsearch"
+}
+
+variable "safety_rules_image_repo" {
+  type        = string
+  description = "Docker image repository to use for safety-rules"
+  default     = "docker.libra.org/safety-rules"
+}
+
+variable "safety_rules_image_tag" {
+  type        = string
+  description = "Docker image tag to use for safety-rules"
+  default     = "latest"
 }


### PR DESCRIPTION
Run safety-rules as a process in a separate container, colocated with
each validator. Safety-rules stores data to local disk, on the same data
volume as the validator.

Test Plan: Deployed to mgorven workspace, validators are running,
checked that there is network traffic to safety-rules.