### PR TITLE
[tf] logrotate on host log file size

### DIFF
--- a/terraform/templates/ec2_user_data.sh
+++ b/terraform/templates/ec2_user_data.sh
@@ -36,12 +36,12 @@ EOF
 
 {% if enable_logrotate %}
 cat > /etc/logrotate.d/libra <<EOF
-${log_path} {
-	daily
-	size 100M
+${host_log_path} {
+	size 500M
 	rotate 100
 	compress
 	delaycompress
+	copytruncate
 }
 EOF
 {% end %}

--- a/terraform/validators.tf
+++ b/terraform/validators.tf
@@ -120,7 +120,7 @@ data "template_file" "user_data" {
 
   vars = {
     ecs_cluster      = aws_ecs_cluster.testnet.name
-    log_path         = var.log_path
+    host_log_path    = "/data/libra/libra.log"
     enable_logrotate = var.log_to_file || var.enable_logstash
   }
 }


### PR DESCRIPTION
<!--
Thank you for sending a PR. We appreciate you spending time to help improve the Libra project.

The project is undergoing daily changes. Pull Requests will be reviewed and responded to as time permits.
-->

## Motivation

This is to solve the devnet disk usage issue.
- We should be rotating the log on the host, change the path to the host log.
- `daily` has higher priority on logrotate config, but daily file size is way too big. Let's rotate only based on the file size

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?

(Write your answer here.)

## Test Plan

Apply on my workspace


