### PR TITLE
[tf] move logrotate cron job from daily to hourly

### DIFF
--- a/terraform/templates/ec2_user_data.sh
+++ b/terraform/templates/ec2_user_data.sh
@@ -36,14 +36,16 @@ EOF
 
 {% if enable_logrotate %}
 cat > /etc/logrotate.d/libra <<EOF
+hourly
 ${host_log_path} {
-	size 500M
+	maxsize 500M
 	rotate 100
 	compress
 	delaycompress
 	copytruncate
 }
 EOF
+sudo mv /etc/cron.daily/logrotate /etc/cron.hourly/
 {% end %}
 
 yum -y install ngrep tcpdump perf gdb nmap-ncat strace htop sysstat tc git


### PR DESCRIPTION
<!--
Thank you for sending a PR. We appreciate you spending time to help improve the Libra project.

The project is undergoing daily changes. Pull Requests will be reviewed and responded to as time permits.
-->

## Motivation

If the cron job only run daily then we won't be able to rotate when size reaches the limit. So make the cron job running hourly.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

Apply on my workspace and devnet

