### PR TITLE
[cluster-test] Make fullnodes as default for all cluster tests

### DIFF
--- a/testsuite/cluster-test/src/cluster.rs
+++ b/testsuite/cluster-test/src/cluster.rs
@@ -145,7 +145,7 @@ impl Cluster {
         &self.validator_instances
     }
     pub fn fullnode_instances(&self) -> &[Instance] {
-        &self.validator_instances
+        &self.fullnode_instances
     }
 
     pub fn all_instances(&self) -> impl Iterator<Item = &Instance> {

--- a/testsuite/cluster-test/src/experiments/mod.rs
+++ b/testsuite/cluster-test/src/experiments/mod.rs
@@ -57,6 +57,7 @@ pub struct Context<'a> {
     cluster: &'a Cluster,
     report: &'a mut SuiteReport,
     global_emit_job_request: &'a mut Option<EmitJobRequest>,
+    emit_to_validator: bool,
 }
 
 impl<'a> Context<'a> {
@@ -66,6 +67,7 @@ impl<'a> Context<'a> {
         cluster: &'a Cluster,
         report: &'a mut SuiteReport,
         emit_job_request: &'a mut Option<EmitJobRequest>,
+        emit_to_validator: bool,
     ) -> Self {
         Context {
             tx_emitter,
@@ -73,6 +75,7 @@ impl<'a> Context<'a> {
             cluster,
             report,
             global_emit_job_request: emit_job_request,
+            emit_to_validator,
         }
     }
 }

--- a/testsuite/cluster-test/src/main.rs
+++ b/testsuite/cluster-test/src/main.rs
@@ -120,6 +120,12 @@ struct Args {
     //stop_experiment options
     #[structopt(long, default_value = "10")]
     max_stopped: usize,
+
+    #[structopt(
+        long,
+        help = "Whether transactions should be submitted to validators or full nodes"
+    )]
+    pub emit_to_validator: Option<bool>,
 }
 
 pub fn main() {
@@ -288,6 +294,7 @@ struct ClusterTestRunner {
     github: GitHub,
     report: SuiteReport,
     global_emit_job_request: EmitJobRequest,
+    emit_to_validator: bool,
 }
 
 fn parse_host_port(s: &str) -> Result<(String, u32)> {
@@ -467,6 +474,11 @@ impl ClusterTestRunner {
                 wait_committed: !args.burst,
             },
         };
+        let emit_to_validator = if cluster.fullnode_instances().is_empty() {
+            true
+        } else {
+            args.emit_to_validator.unwrap_or(false)
+        };
         Self {
             logs,
             cluster,
@@ -481,6 +493,7 @@ impl ClusterTestRunner {
             github,
             report,
             global_emit_job_request,
+            emit_to_validator,
         }
     }
 
@@ -628,6 +641,7 @@ impl ClusterTestRunner {
             &self.cluster,
             &mut self.report,
             &mut global_emit_job_request,
+            self.emit_to_validator,
         );
         {
             let logs = &mut self.logs;


### PR DESCRIPTION
## Motivation

In production, full nodes will be receiving incoming transactions and serve read requests. To imitate that closely, we are changing cluster test to run with fullnodes by default

## Test Plan

./scripts/cti -W cluster-test-30 --pr 2572 --run bench_three_region

## Related PRs

Continuation from: https://github.com/libra/libra/pull/2072
