### PR TITLE
[language][prover]  Added specification syntax for vectors.

### DIFF
--- a/language/compiler/ir-to-bytecode/src/compiler.rs
+++ b/language/compiler/ir-to-bytecode/src/compiler.rs
@@ -1166,8 +1166,6 @@ fn compile_expression(
                     vec_deque![InferredType::Bool]
                 }
                 BinOp::Subrange => {
-                    // TODO (DD): Realized that I needed to do this late in the game.
-                    //   Considering implementing subrange without using BinOp
                     unreachable!("Subrange operators should only appear in specification ASTs.");
                 }
             }

--- a/language/compiler/ir-to-bytecode/syntax/src/lexer.rs
+++ b/language/compiler/ir-to-bytecode/syntax/src/lexer.rs
@@ -29,6 +29,7 @@ pub enum Tok {
     Period,
     Slash,
     Colon,
+    ColonEqual,
     Semicolon,
     Less,
     LessEqual,
@@ -329,7 +330,13 @@ fn find_token(
             }
         }
         '/' => (Tok::Slash, 1),
-        ':' => (Tok::Colon, 1),
+        ':' => {
+            if text.starts_with(":=") {
+                (Tok::ColonEqual, 2) // spec update
+            } else {
+                (Tok::Colon, 1)
+            }
+        }
         ';' => (Tok::Semicolon, 1),
         '^' => (Tok::Caret, 1),
         '{' => (Tok::LBrace, 1),

--- a/language/move-ir/types/src/spec_language_ast.rs
+++ b/language/move-ir/types/src/spec_language_ast.rs
@@ -60,6 +60,8 @@ pub enum SpecExp {
     Not(Box<SpecExp>),
     /// Binary operators also suported by Move
     Binop(Box<SpecExp>, BinOp, Box<SpecExp>),
+    /// Update expr (i := 1 inside [])
+    Update(Box<SpecExp>, Box<SpecExp>),
     /// Value of expression evaluated in the state before function enter.
     Old(Box<SpecExp>),
     /// Call to a helper function.

--- a/language/move-prover/bytecode-to-boogie/src/boogie_helpers.rs
+++ b/language/move-prover/bytecode-to-boogie/src/boogie_helpers.rs
@@ -41,6 +41,8 @@ pub fn boogie_type_value(env: &GlobalEnv, sig: &GlobalType) -> String {
         GlobalType::Struct(module_idx, struct_idx, args) => {
             boogie_struct_type_value(env, *module_idx, struct_idx, args)
         }
+        // TODO: Need a boogie type for subrange?
+        GlobalType::Subrange => "Unimplemented boogie subrange".to_string(),
     }
 }
 
@@ -106,6 +108,11 @@ pub fn boogie_type_check_expr(env: &GlobalEnv, name: &str, sig: &GlobalType) -> 
                 "IsValidReferenceParameter(__m, __local_counter, {})",
                 name
             ));
+        }
+        // TODO: IsValidSubrange in Boogie should check that args are U64's.
+        // Ok if lb > ub -- subrange is empty in that case.
+        GlobalType::Subrange => {
+            format!("IsValidSubrange({})", name);
         }
         // Otherwise it is a type parameter which is opaque
         GlobalType::TypeParameter(_) => {}

--- a/language/move-prover/bytecode-to-boogie/src/boogie_wrapper.rs
+++ b/language/move-prover/bytecode-to-boogie/src/boogie_wrapper.rs
@@ -912,6 +912,10 @@ impl ModelValue {
             GlobalType::Reference(bt) | GlobalType::MutableReference(bt) => {
                 Some(PrettyDoc::text("&").append(self.pretty(env, model, &*bt)?))
             }
+            GlobalType::Subrange => {
+                // TODO (DD) *** Not sure how to do this. Need to extract subrange from model?
+                Some(PrettyDoc::text("Unimplemented subrange lb..ub"))
+            }
             GlobalType::TypeParameter(_) => {
                 // The value of a generic cannot be easily displayed because we do not know the
                 // actual type unless we parse it out from the model (via the type value parameter)

--- a/language/move-prover/bytecode-to-boogie/src/env.rs
+++ b/language/move-prover/bytecode-to-boogie/src/env.rs
@@ -52,6 +52,8 @@ pub enum GlobalType {
     Reference(Box<GlobalType>),
     MutableReference(Box<GlobalType>),
     TypeParameter(TypeParameterIndex),
+    // TODO: Separate, so we can't make References, etc. to these.
+    Subrange, // spec type only.
 }
 
 impl GlobalType {

--- a/language/move-prover/bytecode-to-boogie/src/spec_translator.rs
+++ b/language/move-prover/bytecode-to-boogie/src/spec_translator.rs
@@ -636,6 +636,19 @@ impl<'env> SpecTranslator<'env> {
                 let right = self.translate_expr(right);
                 self.translate_binop(op, left, right)
             }
+            SpecExp::Update(ind, new_val) => {
+                let BoogieExpr(ind, t_ind) = self.translate_expr(ind);
+                self.require_type(t_ind, &GlobalType::Bool);
+                let BoogieExpr(new_val, t_nv) = self.translate_expr(new_val);
+                self.require_type(t_nv, &GlobalType::Bool);
+                BoogieExpr(
+                    format!(
+                        "Unimplemented array update: AST ind: {:?}, AST new_val: {:?}",
+                        ind, new_val
+                    ),
+                    GlobalType::Subrange,
+                )
+            }
             SpecExp::Old(expr) => {
                 if *self.in_old.borrow() {
                     self.error("cannot nest `old(_)`", self.error_exp())
@@ -759,8 +772,7 @@ impl<'env> SpecTranslator<'env> {
                 self.translate_op_helper(">=", &operand_type, GlobalType::Bool, left, right)
             }
             BinOp::Subrange => {
-                // TODO(DD): Figure out what to do here.
-                unimplemented!("Subrange is not yet implemented in spec_translator.rs");
+                self.translate_op_helper("..", &GlobalType::U64, GlobalType::Subrange, left, right)
             }
         }
     }

--- a/language/move-prover/bytecode-to-boogie/test_mvir/test-vector-specs.mvir
+++ b/language/move-prover/bytecode-to-boogie/test_mvir/test-vector-specs.mvir
@@ -34,7 +34,7 @@ module VerifyVector {
     public test_empty3() : Vector.T<u64> * Vector.T<u64>
     // TODO: next spec crashes because vec indices don't generate boogie yet.
     // spec should succeed
-    // ensures RET(0)[0] == RET(1)[0]
+    // ensures RET(0)[0] == RET(1)[0]  // inserts nonsense in boogie file
     {
         let ev1: Vector.T<u64>;
         let ev2: Vector.T<u64>;
@@ -48,8 +48,8 @@ module VerifyVector {
     //succeeds. [1,2] != [1].
     public test_empty4() : Vector.T<u64> * Vector.T<u64>
     // TODO: next spec crashes because vec indices don't generate boogie yet.
-    // spec should fail
-    // ensures RET(0)[0..1][1] == RET(1)[0]
+    // spec should succeed
+    // ensures RET(0)[0..1] == RET(0)
     {
         let ev1: Vector.T<u64>;
         let ev2: Vector.T<u64>;
@@ -64,6 +64,7 @@ module VerifyVector {
     //succeeds. [1] != [0].
     public test_empty5() : Vector.T<u64> * Vector.T<u64>
     ensures RET(0) != RET(1)
+    // ensures RET(0)[0 := 0] != RET(1)  // will cause nonsense in boogie file.
     {
         let ev1: Vector.T<u64>;
         let ev2: Vector.T<u64>;


### PR DESCRIPTION
Extended parser, spec AST, etc. to add two features to vectors:

* Subrange:  v[i..j] == v[k..l]
* Update:  v[i := v[j]][j := v[i]]

<!--
Thank you for sending a PR. We appreciate you spending time to help improve the Libra project.

The project is undergoing daily changes. Pull Requests will be reviewed and responded to as time permits.
-->

## Motivation

Improve vector specification in Move prover

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

Cargo test

## Related PRs

(If this PR adds or changes functionality, please take some time to update the docs at https://github.com/libra/website, and link to your PR here.)
