### PR TITLE
[network] placing benching-only function behind feature flag

### DIFF
--- a/network/Cargo.toml
+++ b/network/Cargo.toml
@@ -53,6 +53,7 @@ fuzzing = ["proptest", "libra-proptest-helpers", "libra-types/fuzzing"]
 [[bench]]
 name = "socket_muxer_bench"
 harness = false
+default = ["testing"]
 
 [[bench]]
 name = "network_bench"

--- a/network/noise/Cargo.toml
+++ b/network/noise/Cargo.toml
@@ -18,3 +18,7 @@ libra-logger = { path = "../../common/logger", version = "0.1.0" }
 
 [dev-dependencies]
 memsocket = { path = "../memsocket", version = "0.1.0" }
+
+[features]
+default = []
+testing = []

--- a/network/noise/src/lib.rs
+++ b/network/noise/src/lib.rs
@@ -23,7 +23,7 @@ pub use self::socket::NoiseSocket;
 use libra_crypto::ValidKey;
 
 const NOISE_IX_25519_AESGCM_SHA256_PROTOCOL_NAME: &[u8] = b"/noise_ix_25519_aesgcm_sha256/1.0.0";
-const NOISE_IX_PARAMETER: &str = "Noise_IX_25519_AESGCM_SHA256";
+const NOISE_PARAMETER: &str = "Noise_IX_25519_AESGCM_SHA256";
 
 /// The Noise protocol configuration to be used to perform a protocol upgrade on an underlying
 /// socket.
@@ -35,7 +35,7 @@ pub struct NoiseConfig {
 impl NoiseConfig {
     /// Create a new NoiseConfig with the provided keypair
     pub fn new(keypair: (X25519StaticPrivateKey, X25519StaticPublicKey)) -> Self {
-        let parameters: NoiseParams = NOISE_IX_PARAMETER.parse().expect("Invalid protocol name");
+        let parameters: NoiseParams = NOISE_PARAMETER.parse().expect("Invalid protocol name");
         let keypair = Keypair {
             private: keypair.0.to_bytes().to_vec(),
             public: keypair.1.to_bytes().to_vec(),
@@ -47,8 +47,9 @@ impl NoiseConfig {
     }
 
     /// Create a new NoiseConfig with an ephemeral static key.
+    #[cfg(feature = "testing")]
     pub fn new_random() -> Self {
-        let parameters: NoiseParams = NOISE_IX_PARAMETER.parse().expect("Invalid protocol name");
+        let parameters: NoiseParams = NOISE_PARAMETER.parse().expect("Invalid protocol name");
         let keypair = snow::Builder::new(parameters.clone())
             .generate_keypair()
             .expect("Noise failed to generate a random static keypair");

--- a/network/noise/src/socket.rs
+++ b/network/noise/src/socket.rs
@@ -625,7 +625,7 @@ where
 mod test {
     use crate::{
         socket::{Handshake, NoiseSocket, MAX_PAYLOAD_LENGTH},
-        NOISE_IX_PARAMETER,
+        NOISE_PARAMETER,
     };
     use futures::{
         executor::block_on,
@@ -643,7 +643,7 @@ mod test {
         ),
         snow::error::Error,
     > {
-        let parameters: NoiseParams = NOISE_IX_PARAMETER.parse().expect("Invalid protocol name");
+        let parameters: NoiseParams = NOISE_PARAMETER.parse().expect("Invalid protocol name");
 
         let dialer_keypair = Builder::new(parameters.clone()).generate_keypair()?;
         let listener_keypair = Builder::new(parameters.clone()).generate_keypair()?;

--- a/network/socket-bench-server/Cargo.toml
+++ b/network/socket-bench-server/Cargo.toml
@@ -20,4 +20,4 @@ tokio-util = { version = "0.2", features = ["codec"] }
 libra-logger = { path = "../../common/logger", version = "0.1.0" }
 memsocket = { path = "../memsocket", version = "0.1.0" }
 netcore = { path = "../netcore", version = "0.1.0" }
-noise = { path = "../noise", version = "0.1.0" }
+noise = { path = "../noise", version = "0.1.0", features = ["testing"] }


### PR DESCRIPTION
MOTIVATION:

network's `NoiseConfig::new_random()` has no reason to live outside of testing (only used for bench).
So I moved it behind the "testing" feature flag.

TEST PLAN:

I tested both benches, and they still work.