### PR TITLE
[secure storage] Fixes a comment in the OnDiskStorage secure store implementation.

### DIFF
--- a/secure/storage/src/on_disk.rs
+++ b/secure/storage/src/on_disk.rs
@@ -11,12 +11,13 @@ use std::{
 };
 use toml;
 
-/// InMemoryStorage represents a key value store that is purely in memory and intended for single
-/// threads (or must be wrapped by a Arc<RwLock<>>). This provides no permission checks and simply
-/// is a proof of concept to unblock building of applications without more complex data stores.
-/// Internally, it retains all data, which means that it must make copies of all key material which
-/// violates the Libra code base. It violates it because the anticipation is that data stores would
-/// securely handle key material. This should not be used in production.
+/// OnDiskStorage represents a key value store that is persisted to the local filesystem and is
+/// intended for single threads (or must be wrapped by a Arc<RwLock<>>). This provides no permission
+/// checks and simply offers a proof of concept to unblock building of applications without more
+/// complex data stores. Internally, it reads and writes all data to a file, which means that it
+/// must make copies of all key material which violates the Libra code base. It violates it because
+/// the anticipation is that data stores would securely handle key material. This should not be used
+/// in production.
 pub struct OnDiskStorage {
     file_path: PathBuf,
     temp_path: TempPath,


### PR DESCRIPTION
## Motivation

This (tiny) PR fixes a comment in the OnDiskStorage secure store implementation. The comment was originally copied from the InMemoryStorage implementation, but not appropriately modified to reflect the differences in the storage implementations.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?

Yes.

## Test Plan

Although this is only a comment change, all local tests still pass.

## Related PRs

None.
