### PR TITLE
[move prover] add cfg and dataflow analysis framework for stackless bytecode

### DIFF
--- a/language/move-prover/bytecode-to-boogie/src/dataflow_analysis.rs
+++ b/language/move-prover/bytecode-to-boogie/src/dataflow_analysis.rs
@@ -1,0 +1,113 @@
+// Copyright (c) The Libra Core Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+//! Adapted from AbstractInterpreter for Bytecode, this module defines the data-flow analysis
+//! framework for stackless bytecode.
+
+use bytecode_verifier::absint::{AbstractDomain, JoinResult};
+use bytecode_verifier::control_flow_graph::{BlockId, ControlFlowGraph};
+use std::collections::HashMap;
+
+pub struct BlockState<State: Clone> {
+    pub pre: State,
+    pub post: State,
+}
+
+pub type StateMap<State> = HashMap<BlockId, BlockState<State>>;
+
+/// Take a pre-state + instruction and mutate it to produce a post-state。
+pub trait TransferFunctions {
+    type State: AbstractDomain + Clone;
+    type InstrType;
+
+    /// Execute instr found at index in the current basic block from pre-state
+    fn execute(&mut self, pre: &Self::State, instr: &Self::InstrType) -> Self::State;
+}
+
+pub trait DataflowAnalysis: TransferFunctions {
+    fn analyze_function(
+        &mut self,
+        initial_state: Self::State,
+        instrs: &[Self::InstrType],
+        cfg: &dyn ControlFlowGraph,
+    ) -> StateMap<Self::State> {
+        let mut state_map: StateMap<Self::State> = StateMap::new();
+        let entry_block_id = cfg.entry_block_id();
+        let mut work_list = vec![entry_block_id];
+        state_map.insert(
+            entry_block_id,
+            BlockState {
+                pre: initial_state.clone(),
+                post: initial_state.clone(),
+            },
+        );
+
+        while let Some(block_id) = work_list.pop() {
+            let block_res = state_map
+                .get_mut(&block_id)
+                .unwrap_or_else(|| panic!("Missing result for block {}", block_id));
+
+            let pre_state = block_res.pre.clone();
+            let post_state = self.execute_block(block_id, &pre_state, &instrs, cfg);
+
+            // propagate postcondition of this block to successor blocks
+            for next_block_id in cfg.successors(block_id) {
+                match state_map.get_mut(next_block_id) {
+                    Some(next_block_res) => {
+                        let join_result = next_block_res.pre.join(&post_state);
+
+                        match join_result {
+                            JoinResult::Unchanged => {
+                                // Pre is the same after join. Reanalyzing this block would produce
+                                // the same post. Don't schedule it.
+                                continue;
+                            }
+                            JoinResult::Changed => {
+                                // The pre changed. Schedule the next block.
+                                work_list.push(*next_block_id);
+                            }
+                            _ => unreachable!(), // There shouldn't be any error at this point
+                        }
+                    }
+                    None => {
+                        // Haven't visited the next block yet. Use the post of the current block as
+                        // its pre and schedule it.
+                        state_map.insert(
+                            *next_block_id,
+                            BlockState {
+                                pre: post_state.clone(),
+                                post: initial_state.clone(),
+                            },
+                        );
+                        work_list.push(*next_block_id);
+                    }
+                }
+            }
+
+            state_map.insert(
+                block_id,
+                BlockState {
+                    pre: pre_state,
+                    post: post_state,
+                },
+            );
+        }
+
+        state_map
+    }
+
+    fn execute_block(
+        &mut self,
+        block_id: BlockId,
+        pre_state: &Self::State,
+        instrs: &[Self::InstrType],
+        cfg: &dyn ControlFlowGraph,
+    ) -> Self::State {
+        let mut state = pre_state.clone();
+        for offset in cfg.instr_indexes(block_id) {
+            let instr = &instrs[offset as usize];
+            state = self.execute(&state, instr);
+        }
+        state
+    }
+}

--- a/language/move-prover/bytecode-to-boogie/src/lib.rs
+++ b/language/move-prover/bytecode-to-boogie/src/lib.rs
@@ -11,6 +11,8 @@ pub mod boogie_helpers;
 pub mod boogie_wrapper;
 pub mod bytecode_translator;
 pub mod cli;
+pub mod dataflow_analysis;
 pub mod driver;
 pub mod env;
 pub mod spec_translator;
+pub mod stackless_control_flow_graph;

--- a/language/move-prover/bytecode-to-boogie/src/stackless_control_flow_graph.rs
+++ b/language/move-prover/bytecode-to-boogie/src/stackless_control_flow_graph.rs
@@ -1,0 +1,109 @@
+// Copyright (c) The Libra Core Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+//! Adapted from control_flow_graph for Bytecode, this module defines the control-flow graph on
+//! Stackless Bytecode used in analysis as part of Move prover.
+
+use bytecode_verifier::control_flow_graph::{BlockId, ControlFlowGraph};
+use stackless_bytecode_generator::stackless_bytecode::StacklessBytecode;
+use std::collections::{BTreeMap, BTreeSet};
+use vm::file_format::CodeOffset;
+
+type Map<K, V> = BTreeMap<K, V>;
+type Set<V> = BTreeSet<V>;
+
+struct BasicBlock {
+    entry: CodeOffset,
+    exit: CodeOffset,
+    successors: Vec<BlockId>,
+}
+
+pub struct StacklessControlFlowGraph {
+    blocks: Map<BlockId, BasicBlock>,
+}
+
+const ENTRY_BLOCK_ID: BlockId = 0;
+
+impl StacklessControlFlowGraph {
+    pub fn new(code: &[StacklessBytecode]) -> Self {
+        // First go through and collect block ids, i.e., offsets that begin basic blocks.
+        // Need to do this first in order to handle backwards edges.
+        let mut block_ids = Set::new();
+        block_ids.insert(ENTRY_BLOCK_ID);
+        for pc in 0..code.len() {
+            StacklessControlFlowGraph::record_block_ids(pc as CodeOffset, code, &mut block_ids);
+        }
+
+        // Create basic blocks
+        let mut cfg = StacklessControlFlowGraph { blocks: Map::new() };
+        let mut entry = 0;
+        for pc in 0..code.len() {
+            let co_pc: CodeOffset = pc as CodeOffset;
+
+            // Create a basic block
+            if StacklessControlFlowGraph::is_end_of_block(co_pc, code, &block_ids) {
+                let successors = StacklessBytecode::get_successors(co_pc, code);
+                let bb = BasicBlock {
+                    entry,
+                    exit: co_pc,
+                    successors,
+                };
+                cfg.blocks.insert(entry, bb);
+                entry = co_pc + 1;
+            }
+        }
+
+        assert_eq!(entry, code.len() as CodeOffset);
+        cfg
+    }
+
+    fn is_end_of_block(
+        pc: CodeOffset,
+        code: &[StacklessBytecode],
+        block_ids: &Set<BlockId>,
+    ) -> bool {
+        pc + 1 == (code.len() as CodeOffset) || block_ids.contains(&(pc + 1))
+    }
+
+    fn record_block_ids(pc: CodeOffset, code: &[StacklessBytecode], block_ids: &mut Set<BlockId>) {
+        let bytecode = &code[pc as usize];
+
+        if let Some(offset) = bytecode.branch_dest() {
+            block_ids.insert(*offset);
+        }
+
+        if bytecode.is_branch() && pc + 1 < (code.len() as CodeOffset) {
+            block_ids.insert(pc + 1);
+        }
+    }
+}
+
+impl ControlFlowGraph for StacklessControlFlowGraph {
+    fn block_start(&self, block_id: BlockId) -> CodeOffset {
+        self.blocks[&block_id].entry
+    }
+
+    fn block_end(&self, block_id: BlockId) -> CodeOffset {
+        self.blocks[&block_id].exit
+    }
+
+    fn successors(&self, block_id: BlockId) -> &Vec<BlockId> {
+        &self.blocks[&block_id].successors
+    }
+
+    fn blocks(&self) -> Vec<BlockId> {
+        self.blocks.keys().cloned().collect()
+    }
+
+    fn instr_indexes(&self, block_id: BlockId) -> Box<dyn Iterator<Item = CodeOffset>> {
+        Box::new(self.block_start(block_id)..=self.block_end(block_id))
+    }
+
+    fn num_blocks(&self) -> u16 {
+        self.blocks.len() as u16
+    }
+
+    fn entry_block_id(&self) -> BlockId {
+        ENTRY_BLOCK_ID
+    }
+}

--- a/language/move-prover/bytecode-to-boogie/tests/cfg_tests.rs
+++ b/language/move-prover/bytecode-to-boogie/tests/cfg_tests.rs
@@ -1,0 +1,57 @@
+// Copyright (c) The Libra Core Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+use bytecode_to_boogie::stackless_control_flow_graph::StacklessControlFlowGraph;
+use bytecode_verifier::control_flow_graph::ControlFlowGraph;
+use stackless_bytecode_generator::stackless_bytecode::StacklessBytecode::*;
+
+#[test]
+fn test_straight_line() {
+    let instrs = [CopyLoc(3, 0), MoveLoc(4, 1), Add(5, 3, 4), Ret(vec![])];
+
+    let cfg = StacklessControlFlowGraph::new(&instrs);
+
+    assert_eq!(cfg.blocks(), vec![0]);
+    assert!(cfg.successors(0).is_empty());
+    assert_eq!(cfg.block_start(0), 0);
+    assert_eq!(cfg.block_end(0), 3);
+}
+
+#[test]
+fn test_branch() {
+    let instrs = [
+        LdTrue(0),
+        BrFalse(4, 0),
+        Branch(6),
+        Branch(5),
+        Branch(0),
+        Branch(0),
+        LdFalse(1),
+        Not(2, 1),
+        Not(3, 2),
+        BrFalse(12, 3),
+        LdU64(4, 42),
+        Abort(4),
+        Ret(vec![]),
+    ];
+
+    let cfg = StacklessControlFlowGraph::new(&instrs);
+
+    assert_eq!(cfg.entry_block_id(), 0);
+    assert_eq!(cfg.num_blocks(), 8);
+    assert_eq!(cfg.blocks(), vec![0, 2, 3, 4, 5, 6, 10, 12]);
+
+    assert_eq!(cfg.successors(0).to_vec(), vec![2, 4]);
+    assert_eq!(cfg.block_start(0), 0);
+    assert_eq!(cfg.block_end(0), 1);
+
+    assert_eq!(cfg.successors(3).to_vec(), vec![5]);
+    assert_eq!(cfg.block_start(3), 3);
+    assert_eq!(cfg.block_end(3), 3);
+
+    assert_eq!(cfg.successors(6).to_vec(), vec![10, 12]);
+    assert_eq!(cfg.block_start(6), 6);
+    assert_eq!(cfg.block_end(6), 9);
+
+    assert!(cfg.successors(10).is_empty());
+}


### PR DESCRIPTION

<!--
Thank you for sending a PR. We appreciate you spending time to help improve the Libra project.

The project is undergoing daily changes. Pull Requests will be reviewed and responded to as time permits.
-->

## Motivation

This PR adds control flow graph implementation and a data-flow analysis framework for stackless bytecode, which can later be used to perform analysis in prover. 

Both the cfg and the framework were adapted from bytecode_verifier. Regarding the framework, since our use case is different from that of bytecode_verifier, I made some changes in the interface. Specifically, instead of returning analysis errors we return the states of blocks after convergence. States are defined by the users of framework and can be, say, a set of live variables if we are implementing liveness analysis.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?

Yes.

## Test Plan

cargo test


