### PR TITLE
[scripts] maintain the cargo_update_outdated script

### DIFF
--- a/scripts/cargo_update_outdated.sh
+++ b/scripts/cargo_update_outdated.sh
@@ -24,7 +24,7 @@ then
    cargo install cargo-edit
 fi
 
-for upgrade in $(cargo outdated | awk 'NF >2 && $2 ~ /[0-9\.]+/ && $3 ~ /[0-9\.]+/ {print $1"@"$3}' | uniq |tr '\n' " ")
+for upgrade in $(cargo outdated | awk 'NF >2 && $2 ~ /[0-9\.]+/ && $4 ~ /[0-9\.]+/ {print $1"@"$4}' | uniq |tr '\n' " ")
 do
     echo $upgrade
     cargo -q upgrade $upgrade --all > /dev/null


### PR DESCRIPTION
The awk command in this script retrieves source-compatible updates in the output of a cargo outdated run and applies them to the Cargo files in the workspace.
cargo-outdated added a column in its output, changing the position of the output portion we want to capture. This adapts to it apporpriately.