### PR TITLE
[language][move] Add parser support for u8 and u128 integer constants.

### DIFF
--- a/language/move-lang/tests/move_check/parser/constant_values.move
+++ b/language/move-lang/tests/move_check/parser/constant_values.move
@@ -1,0 +1,11 @@
+module M {
+    fun int8(): u8 {
+        1u8
+    }
+    fun int64(): u64 {
+        2 + 3u64
+    }
+    fun int128(): u128 {
+        4u128
+    }
+}


### PR DESCRIPTION
###  Motivation

The Move source language needs to support u8 and u128 types.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

I added a test with some of the new integer constants, but it should be updated along with the parser when the new types are actually available.

## Related PRs

https://github.com/libra/libra/pull/2533
