### PR TITLE
[cluster-test] Set emit-to-validator true by default

### DIFF
--- a/testsuite/cluster-test/src/main.rs
+++ b/testsuite/cluster-test/src/main.rs
@@ -474,11 +474,12 @@ impl ClusterTestRunner {
                 wait_committed: !args.burst,
             },
         };
-        let emit_to_validator = if cluster.fullnode_instances().is_empty() {
-            true
-        } else {
-            args.emit_to_validator.unwrap_or(false)
-        };
+        let emit_to_validator =
+            if cluster.fullnode_instances().len() < cluster.validator_instances().len() {
+                true
+            } else {
+                args.emit_to_validator.unwrap_or(false)
+            };
         Self {
             logs,
             cluster,


### PR DESCRIPTION
## Summary

The 100 node cluster has 1 full node, so txns are going to that full node I guess. 

