### PR TITLE
[move source language] Record the source location of the last semicolon in a Sequence

### DIFF
--- a/language/move-lang/src/expansion/translate.rs
+++ b/language/move-lang/src/expansion/translate.rs
@@ -598,14 +598,20 @@ fn module_access(
 // TODO Support uses inside functions. AliasMap will become an accumulator
 
 fn sequence(context: &mut Context, loc: Loc, seq: P::Sequence) -> E::Sequence {
-    let (pitems, _, pfinal_item) = seq;
+    let (pitems, maybe_last_semicolon_loc, pfinal_item) = seq;
     let mut items: VecDeque<E::SequenceItem> = pitems
         .into_iter()
         .map(|item| sequence_item(context, item))
         .collect();
     let final_e_opt = pfinal_item.map(|item| exp_(context, item));
     let final_e = match final_e_opt {
-        None => sp(loc, E::Exp_::Unit),
+        None => {
+            let last_semicolon_loc = match maybe_last_semicolon_loc {
+                Some(l) => l,
+                None => loc,
+            };
+            sp(last_semicolon_loc, E::Exp_::Unit)
+        }
         Some(e) => e,
     };
     let final_item = sp(final_e.loc, E::SequenceItem_::Seq(final_e));

--- a/language/move-lang/src/expansion/translate.rs
+++ b/language/move-lang/src/expansion/translate.rs
@@ -598,7 +598,7 @@ fn module_access(
 // TODO Support uses inside functions. AliasMap will become an accumulator
 
 fn sequence(context: &mut Context, loc: Loc, seq: P::Sequence) -> E::Sequence {
-    let (pitems, pfinal_item) = seq;
+    let (pitems, _, pfinal_item) = seq;
     let mut items: VecDeque<E::SequenceItem> = pitems
         .into_iter()
         .map(|item| sequence_item(context, item))

--- a/language/move-lang/src/parser/ast.rs
+++ b/language/move-lang/src/parser/ast.rs
@@ -359,7 +359,8 @@ pub type Exp = Spanned<Exp_>;
 
 // { e1; ... ; en }
 // { e1; ... ; en; }
-pub type Sequence = (Vec<SequenceItem>, Box<Option<Exp>>);
+// The Loc field holds the source location of the final semicolon, if there is one.
+pub type Sequence = (Vec<SequenceItem>, Option<Loc>, Box<Option<Exp>>);
 #[derive(Debug, PartialEq)]
 #[allow(clippy::large_enum_variant)]
 pub enum SequenceItem_ {
@@ -777,9 +778,9 @@ impl AstDebug for ModuleAccess_ {
     }
 }
 
-impl AstDebug for (Vec<SequenceItem>, Box<Option<Exp>>) {
+impl AstDebug for (Vec<SequenceItem>, Option<Loc>, Box<Option<Exp>>) {
     fn ast_debug(&self, w: &mut AstWriter) {
-        let (seq, last_e) = self;
+        let (seq, _, last_e) = self;
         w.semicolon(seq, |w, item| item.ast_debug(w));
         if !seq.is_empty() {
             w.writeln(";")

--- a/language/move-lang/src/parser/syntax.rs
+++ b/language/move-lang/src/parser/syntax.rs
@@ -432,6 +432,7 @@ fn parse_sequence_item<'input>(tokens: &mut Lexer<'input>) -> Result<SequenceIte
 // does consume the closing right brace.
 fn parse_sequence<'input>(tokens: &mut Lexer<'input>) -> Result<Sequence, Error> {
     let mut seq: Vec<SequenceItem> = vec![];
+    let mut last_semicolon_loc = None;
     let mut eopt = None;
     while tokens.peek() != Tok::RBrace {
         let item = parse_sequence_item(tokens)?;
@@ -450,10 +451,11 @@ fn parse_sequence<'input>(tokens: &mut Lexer<'input>) -> Result<Sequence, Error>
             break;
         }
         seq.push(item);
+        last_semicolon_loc = Some(current_token_loc(&tokens));
         consume_token(tokens, Tok::Semicolon)?;
     }
     tokens.advance()?; // consume the RBrace
-    Ok((seq, Box::new(eopt)))
+    Ok((seq, last_semicolon_loc, Box::new(eopt)))
 }
 
 //**************************************************************************************************

--- a/language/move-lang/tests/move_check/liveness/loop_weirdness.exp
+++ b/language/move-lang/tests/move_check/liveness/loop_weirdness.exp
@@ -1,8 +1,8 @@
 error: 
 
-   ┌── tests/move_check/liveness/loop_weirdness.move:9:36 ───
+   ┌── tests/move_check/liveness/loop_weirdness.move:9:43 ───
    │
  9 │                 if (my_local >= 0) { break; };
-   │                                    ^^^^^^^^^^ Unreachable code. This statement (and any following statements) will not be executed. In some cases, this will result in unused resource values.
+   │                                           ^ Unreachable code. This statement (and any following statements) will not be executed. In some cases, this will result in unused resource values.
    │
 

--- a/language/move-lang/tests/move_check/locals/unused_resource.exp
+++ b/language/move-lang/tests/move_check/locals/unused_resource.exp
@@ -1,19 +1,5 @@
 error: 
 
-   ┌── tests/move_check/locals/unused_resource.move:4:14 ───
-   │
- 4 │       fun t0() {
-   │ ╭──────────────^
- 5 │ │         let r = R{};
- 6 │ │     }
-   │ ╰─────^ Invalid return
-   ·
- 5 │         let r = R{};
-   │             - The local 'r' still contains a resource value due to this assignment. The resource must be consumed before the function returns
-   │
-
-error: 
-
    ┌── tests/move_check/locals/unused_resource.move:5:13 ───
    │
  5 │         let r = R{};
@@ -22,18 +8,14 @@ error:
 
 error: 
 
-    ┌── tests/move_check/locals/unused_resource.move:8:24 ───
-    │
- 8 │       fun t1(cond: bool) {
-    │ ╭────────────────────────^
- 9 │ │         let r;
- 10 │ │         if (cond) { r = R{}; };
- 11 │ │     }
-    │ ╰─────^ Invalid return
-    ·
- 10 │         if (cond) { r = R{}; };
-    │                     - The local 'r' might still contain a resource value due to this assignment. The resource must be consumed before the function returns
-    │
+   ┌── tests/move_check/locals/unused_resource.move:5:13 ───
+   │
+ 5 │         let r = R{};
+   │                    ^ Invalid return
+   ·
+ 5 │         let r = R{};
+   │             - The local 'r' still contains a resource value due to this assignment. The resource must be consumed before the function returns
+   │
 
 error: 
 
@@ -45,17 +27,13 @@ error:
 
 error: 
 
-    ┌── tests/move_check/locals/unused_resource.move:13:24 ───
+    ┌── tests/move_check/locals/unused_resource.move:10:21 ───
     │
- 13 │       fun t2(cond: bool) {
-    │ ╭────────────────────────^
- 14 │ │         let r;
- 15 │ │         if (cond) {} else { r = R{}; };
- 16 │ │     }
-    │ ╰─────^ Invalid return
+ 10 │         if (cond) { r = R{}; };
+    │                               ^ Invalid return
     ·
- 15 │         if (cond) {} else { r = R{}; };
-    │                             - The local 'r' might still contain a resource value due to this assignment. The resource must be consumed before the function returns
+ 10 │         if (cond) { r = R{}; };
+    │                     - The local 'r' might still contain a resource value due to this assignment. The resource must be consumed before the function returns
     │
 
 error: 
@@ -68,17 +46,13 @@ error:
 
 error: 
 
-    ┌── tests/move_check/locals/unused_resource.move:18:24 ───
+    ┌── tests/move_check/locals/unused_resource.move:15:29 ───
     │
- 18 │       fun t3(cond: bool) {
-    │ ╭────────────────────────^
- 19 │ │         let r;
- 20 │ │         while (cond) { r = R{} };
- 21 │ │     }
-    │ ╰─────^ Invalid return
+ 15 │         if (cond) {} else { r = R{}; };
+    │                                       ^ Invalid return
     ·
- 20 │         while (cond) { r = R{} };
-    │                        - The local 'r' might still contain a resource value due to this assignment. The resource must be consumed before the function returns
+ 15 │         if (cond) {} else { r = R{}; };
+    │                             - The local 'r' might still contain a resource value due to this assignment. The resource must be consumed before the function returns
     │
 
 error: 
@@ -102,6 +76,17 @@ error:
 
 error: 
 
+    ┌── tests/move_check/locals/unused_resource.move:20:24 ───
+    │
+ 20 │         while (cond) { r = R{} };
+    │                                 ^ Invalid return
+    ·
+ 20 │         while (cond) { r = R{} };
+    │                        - The local 'r' might still contain a resource value due to this assignment. The resource must be consumed before the function returns
+    │
+
+error: 
+
     ┌── tests/move_check/locals/unused_resource.move:24:20 ───
     │
  24 │         loop { let r = R{}; }
@@ -121,13 +106,10 @@ error:
 
 error: 
 
-    ┌── tests/move_check/locals/unused_resource.move:27:14 ───
+    ┌── tests/move_check/locals/unused_resource.move:28:18 ───
     │
- 27 │       fun t5() {
-    │ ╭──────────────^
- 28 │ │         let _ = &R{};
- 29 │ │     }
-    │ ╰─────^ Invalid return
+ 28 │         let _ = &R{};
+    │                     ^ Invalid return
     ·
  28 │         let _ = &R{};
     │                  --- The resource is created but not used. The resource must be consumed before the function returns

--- a/language/move-lang/tests/move_check/locals/use_after_move_loop.exp
+++ b/language/move-lang/tests/move_check/locals/use_after_move_loop.exp
@@ -1,17 +1,5 @@
 error: 
 
-   ┌── tests/move_check/locals/use_after_move_loop.move:2:28 ───
-   │
- 2 │       fun tmove1(cond: bool) {
-   │ ╭────────────────────────────^
- 3 │ │         let x = 0;
- 4 │ │         loop { _ = move x };
- 5 │ │     }
-   │ ╰─────^ Unreachable code. This statement (and any following statements) will not be executed. In some cases, this will result in unused resource values.
-   │
-
-error: 
-
    ┌── tests/move_check/locals/use_after_move_loop.move:4:20 ───
    │
  4 │         loop { _ = move x };
@@ -19,6 +7,14 @@ error:
    ·
  4 │         loop { _ = move x };
    │                    ------ The local might not have a value due to this position. The local must be assigned a value before being used
+   │
+
+error: 
+
+   ┌── tests/move_check/locals/use_after_move_loop.move:4:28 ───
+   │
+ 4 │         loop { _ = move x };
+   │                            ^ Unreachable code. This statement (and any following statements) will not be executed. In some cases, this will result in unused resource values.
    │
 
 error: 

--- a/language/move-lang/tests/move_check/translated_ir_tests/borrow_tests/return_with_borrowed_loc_resource_invalid.exp
+++ b/language/move-lang/tests/move_check/translated_ir_tests/borrow_tests/return_with_borrowed_loc_resource_invalid.exp
@@ -1,14 +1,9 @@
 error: 
 
-   ┌── tests/move_check/translated_ir_tests/borrow_tests/return_with_borrowed_loc_resource_invalid.move:4:13 ───
+   ┌── tests/move_check/translated_ir_tests/borrow_tests/return_with_borrowed_loc_resource_invalid.move:5:13 ───
    │
- 4 │       fun t() {
-   │ ╭─────────────^
- 5 │ │         let s = X { u: 0 };
- 6 │ │         let u = &s.u;
- 7 │ │         copy u;
- 8 │ │     }
-   │ ╰─────^ Invalid return
+ 7 │         copy u;
+   │               ^ Invalid return
    ·
  5 │         let s = X { u: 0 };
    │             - The local 's' still contains a resource value due to this assignment. The resource must be consumed before the function returns

--- a/language/move-lang/tests/move_check/typing/borrow_local_temp_resource.exp
+++ b/language/move-lang/tests/move_check/typing/borrow_local_temp_resource.exp
@@ -1,13 +1,9 @@
 error: 
 
-   ┌── tests/move_check/typing/borrow_local_temp_resource.move:5:14 ───
+   ┌── tests/move_check/typing/borrow_local_temp_resource.move:6:10 ───
    │
- 5 │       fun t0() {
-   │ ╭──────────────^
- 6 │ │         &R{};
- 7 │ │         &mut R{};
- 8 │ │     }
-   │ ╰─────^ Invalid return
+ 7 │         &mut R{};
+   │                 ^ Invalid return
    ·
  6 │         &R{};
    │          --- The resource is created but not used. The resource must be consumed before the function returns
@@ -15,14 +11,10 @@ error:
 
 error: 
 
-   ┌── tests/move_check/typing/borrow_local_temp_resource.move:5:14 ───
+   ┌── tests/move_check/typing/borrow_local_temp_resource.move:7:14 ───
    │
- 5 │       fun t0() {
-   │ ╭──────────────^
- 6 │ │         &R{};
- 7 │ │         &mut R{};
- 8 │ │     }
-   │ ╰─────^ Invalid return
+ 7 │         &mut R{};
+   │                 ^ Invalid return
    ·
  7 │         &mut R{};
    │              --- The resource is created but not used. The resource must be consumed before the function returns


### PR DESCRIPTION
### Motivation

One of the tests from https://github.com/libra/libra/pull/2578 revealed a need to track the source location of the last semicolon in a Sequence, so that unreachable code errors can report the right location. This adds that information to the parser AST, and uses it in the expansion phase for the source location of the Exp_::Unit value that is used in the case where the final expression of  a sequence is missing.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

Updated tests.