### PR TITLE
[Storage] start_storage_service waits for server to start listening

### DIFF
--- a/storage/storage-service/src/lib.rs
+++ b/storage/storage-service/src/lib.rs
@@ -53,22 +53,19 @@ pub fn start_storage_service(config: &NodeConfig) -> Runtime {
     );
 
     let addr = format!("http://{}", config.storage.address);
-    let mut server_available = false;
-    for _i in 0..50 {
+    for _i in 0..100 {
         if rt
             .block_on(
                 storage_proto::proto::storage::storage_client::StorageClient::connect(addr.clone()),
             )
             .is_ok()
         {
-            server_available = true;
-            break;
+            return rt;
         }
-        std::thread::sleep(std::time::Duration::from_millis(100));
+        std::thread::sleep(std::time::Duration::from_millis(50));
     }
-    assert!(server_available, "Failed to start storage service.");
 
-    rt
+    panic!("Failed to start storage service.");
 }
 
 /// The implementation of the storage [GRPC](http://grpc.io) service.


### PR DESCRIPTION
<!--
Thank you for sending a PR. We appreciate you spending time to help improve the Libra project.

The project is undergoing daily changes. Pull Requests will be reviewed and responded to as time permits.
-->

## Motivation

In the tests we query storage with a client immediately after calling this function. Sometimes the server does not seem to be available by the time the client calls. The reason seems to be that the server creation is async and the function might return before the server starts listening.

As a workaround, try to connect to the server a couple of times in this function. Panic if the server fails to respond in a few seconds.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?

No.

## Test Plan

Currently running unit tests repeatedly in a loop on my machine.

## Related PRs

(If this PR adds or changes functionality, please take some time to update the docs at https://github.com/libra/website, and link to your PR here.)
