### PR TITLE
[mempool] add ACK for txn broadcasts

### DIFF
--- a/network/src/proto/mempool.proto
+++ b/network/src/proto/mempool.proto
@@ -5,9 +5,6 @@ syntax = "proto3";
 
 package mempool;
 
-/* MempoolSyncMsg represents the messages exchanging between validators to keep
- * transactions in sync. The proto definition provides the spec on the wire so
- * that others can implement their mempool service in various languages.
- * Mempool service is responsible for sending and receiving MempoolSyncMsg
- * across validators. */
+/* MempoolSyncMsg represents the messages exchanging between nodes to keep
+ * transactions in sync. */
 message MempoolSyncMsg { bytes message = 1; }


### PR DESCRIPTION
## Summary

Mempool now sends ACK back after receiving and processing txn broadcasts.

## Test Plan
Refactored tests to support delivering ACK responses