### PR TITLE
[WIP, crypto] Update dalek suite of libraries, update rand

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1059,15 +1059,15 @@ dependencies = [
 
 [[package]]
 name = "curve25519-dalek"
-version = "1.2.3"
-source = "git+https://github.com/calibra/curve25519-dalek.git?branch=fiat#caa6b9028e90351d939cbee102ce91b1a1ca032b"
+version = "2.0.0"
+source = "git+https://github.com/huitseeker/curve25519-dalek.git?branch=fiat2#12f5288726ed7f860a6e66567449950ffc51d690"
 dependencies = [
  "byteorder 1.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "clear_on_drop 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "curve25519-fiat 0.1.4 (git+https://github.com/calibra/rust-curve25519-fiat.git)",
  "digest 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "rand_core 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand_core 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "subtle 2.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "zeroize 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1199,13 +1199,13 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "ed25519-dalek"
-version = "1.0.0-pre.1"
-source = "git+https://github.com/calibra/ed25519-dalek.git?branch=fiat#ecb1d36ade13e719c71ac818942170a2410ae910"
+version = "1.0.0-pre.3"
+source = "git+https://github.com/huitseeker/ed25519-dalek.git?branch=fiat2-test#ac87572259588b84d54ab3868d83321554faf2d9"
 dependencies = [
  "clear_on_drop 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "curve25519-dalek 1.2.3 (git+https://github.com/calibra/curve25519-dalek.git?branch=fiat)",
- "failure 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "rand 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "curve25519-dalek 2.0.0 (git+https://github.com/huitseeker/curve25519-dalek.git?branch=fiat2)",
+ "merlin 1.2.1 (git+https://github.com/isislovecruft/merlin?branch=develop)",
+ "rand 0.7.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)",
  "sha2 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -2075,9 +2075,9 @@ dependencies = [
  "byteorder 1.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "bytes 0.5.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "criterion 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "curve25519-dalek 1.2.3 (git+https://github.com/calibra/curve25519-dalek.git?branch=fiat)",
+ "curve25519-dalek 2.0.0 (git+https://github.com/huitseeker/curve25519-dalek.git?branch=fiat2)",
  "digest 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "ed25519-dalek 1.0.0-pre.1 (git+https://github.com/calibra/ed25519-dalek.git?branch=fiat)",
+ "ed25519-dalek 1.0.0-pre.3 (git+https://github.com/huitseeker/ed25519-dalek.git?branch=fiat2-test)",
  "hex 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "hmac 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "libra-canonical-serialization 0.1.0",
@@ -2088,7 +2088,8 @@ dependencies = [
  "pairing 0.14.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "proptest 0.9.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "proptest-derive 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "rand 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand 0.7.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand_core 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "ripemd160 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)",
  "sha2 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2097,7 +2098,7 @@ dependencies = [
  "thiserror 1.0.10 (registry+https://github.com/rust-lang/crates.io-index)",
  "threshold_crypto 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "tiny-keccak 1.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "x25519-dalek 0.5.2 (git+https://github.com/calibra/x25519-dalek.git?branch=fiat)",
+ "x25519-dalek 0.6.0 (git+https://github.com/huitseeker/x25519-dalek.git?branch=fiat2-test)",
 ]
 
 [[package]]
@@ -2582,6 +2583,17 @@ dependencies = [
  "bytes 0.5.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "once_cell 1.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "merlin"
+version = "1.2.1"
+source = "git+https://github.com/isislovecruft/merlin?branch=develop#c483190db3506732691d4a502a97de9774642111"
+dependencies = [
+ "byteorder 1.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "clear_on_drop 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "keccak 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand_core 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -5836,12 +5848,12 @@ dependencies = [
 
 [[package]]
 name = "x25519-dalek"
-version = "0.5.2"
-source = "git+https://github.com/calibra/x25519-dalek.git?branch=fiat#8d5b63010f8466d75a4fa2fb95f573092aed5611"
+version = "0.6.0"
+source = "git+https://github.com/huitseeker/x25519-dalek.git?branch=fiat2-test#865a23c0d29c0f0c0583abad0bb787dd99688e17"
 dependencies = [
- "clear_on_drop 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "curve25519-dalek 1.2.3 (git+https://github.com/calibra/curve25519-dalek.git?branch=fiat)",
- "rand_core 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "curve25519-dalek 2.0.0 (git+https://github.com/huitseeker/curve25519-dalek.git?branch=fiat2)",
+ "rand_core 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "zeroize 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -5991,7 +6003,7 @@ dependencies = [
 "checksum csv-core 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)" = "9b5cadb6b25c77aeff80ba701712494213f4a8418fcda2ee11b6560c3ad0bf4c"
 "checksum ct-logs 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)" = "4d3686f5fa27dbc1d76c751300376e167c5a43387f44bb451fd1c24776e49113"
 "checksum ctrlc 3.1.3 (registry+https://github.com/rust-lang/crates.io-index)" = "c7dfd2d8b4c82121dfdff120f818e09fc4380b0b7e17a742081a89b94853e87f"
-"checksum curve25519-dalek 1.2.3 (git+https://github.com/calibra/curve25519-dalek.git?branch=fiat)" = "<none>"
+"checksum curve25519-dalek 2.0.0 (git+https://github.com/huitseeker/curve25519-dalek.git?branch=fiat2)" = "<none>"
 "checksum curve25519-dalek 2.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "26778518a7f6cffa1d25a44b602b62b979bd88adb9e99ffec546998cf3404839"
 "checksum curve25519-fiat 0.1.4 (git+https://github.com/calibra/rust-curve25519-fiat.git)" = "<none>"
 "checksum data-encoding 2.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "f4f47ca1860a761136924ddd2422ba77b2ea54fe8cc75b9040804a0d9d32ad97"
@@ -6002,7 +6014,7 @@ dependencies = [
 "checksum dirs 2.0.2 (registry+https://github.com/rust-lang/crates.io-index)" = "13aea89a5c93364a98e9b37b2fa237effbb694d5cfe01c5b70941f7eb087d5e3"
 "checksum dirs-sys 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)" = "afa0b23de8fd801745c471deffa6e12d248f962c9fd4b4c33787b055599bde7b"
 "checksum dtoa 0.4.5 (registry+https://github.com/rust-lang/crates.io-index)" = "4358a9e11b9a09cf52383b451b49a169e8d797b68aa02301ff586d70d9661ea3"
-"checksum ed25519-dalek 1.0.0-pre.1 (git+https://github.com/calibra/ed25519-dalek.git?branch=fiat)" = "<none>"
+"checksum ed25519-dalek 1.0.0-pre.3 (git+https://github.com/huitseeker/ed25519-dalek.git?branch=fiat2-test)" = "<none>"
 "checksum ed25519-dalek 1.0.0-pre.3 (registry+https://github.com/rust-lang/crates.io-index)" = "978710b352437433c97b2bff193f2fb1dfd58a093f863dd95e225a19baa599a2"
 "checksum either 1.5.3 (registry+https://github.com/rust-lang/crates.io-index)" = "bb1f6b1ce1c140482ea30ddd3335fc0024ac7ee112895426e0a629a6c20adfe3"
 "checksum encode_unicode 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)" = "a357d28ed41a50f9c765dbfe56cbc04a64e53e5fc58ba79fbc34c10ef3df831f"
@@ -6086,6 +6098,7 @@ dependencies = [
 "checksum memchr 2.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "3197e20c7edb283f87c071ddfc7a2cca8f8e0b888c242959846a6fce03c72223"
 "checksum memoffset 0.5.3 (registry+https://github.com/rust-lang/crates.io-index)" = "75189eb85871ea5c2e2c15abbdd541185f63b408415e5051f5cac122d8c774b9"
 "checksum memsec 0.5.7 (registry+https://github.com/rust-lang/crates.io-index)" = "0cb9280f8c37546661083aa45eb0318d8469253d31e87649faed25522428398e"
+"checksum merlin 1.2.1 (git+https://github.com/isislovecruft/merlin?branch=develop)" = "<none>"
 "checksum mime 0.3.16 (registry+https://github.com/rust-lang/crates.io-index)" = "2a60c7ce501c71e03a9c9c0d35b861413ae925bd979cc7a4e30d060069aaac8d"
 "checksum mime_guess 2.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "1a0ed03949aef72dbdf3116a383d7b38b4768e6f960528cd6a6044aa9ed68599"
 "checksum miniz_oxide 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)" = "aa679ff6578b1cddee93d7e82e263b94a575e0bfced07284eb0c037c1d2416a5"
@@ -6371,7 +6384,7 @@ dependencies = [
 "checksum winapi-x86_64-pc-windows-gnu 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 "checksum winreg 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)" = "b2986deb581c4fe11b621998a5e53361efe6b48a151178d0cd9eeffa4dc6acc9"
 "checksum ws2_32-sys 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "d59cefebd0c892fa2dd6de581e937301d8552cb44489cdff035c6187cb63fa5e"
-"checksum x25519-dalek 0.5.2 (git+https://github.com/calibra/x25519-dalek.git?branch=fiat)" = "<none>"
+"checksum x25519-dalek 0.6.0 (git+https://github.com/huitseeker/x25519-dalek.git?branch=fiat2-test)" = "<none>"
 "checksum x25519-dalek 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)" = "637ff90c9540fa3073bb577e65033069e4bae7c79d49d74aa3ffdf5342a53217"
 "checksum xml-rs 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)" = "541b12c998c5b56aa2b4e6f18f03664eef9a4fd0a246a55594efae6cc2d964b5"
 "checksum yamux 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "2758f29014c1cb7a6e74c1b1160ac8c8203be342d35b73462fc6a13cc6385423"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9,7 +9,7 @@ dependencies = [
  "libra-types 0.1.0",
  "mirai-annotations 1.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "proptest 0.9.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "rand 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand 0.7.3 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -54,7 +54,7 @@ dependencies = [
  "prometheus 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "proptest 0.9.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "prost 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "rand 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand 0.7.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "storage-client 0.1.0",
  "storage-service 0.1.0",
  "tokio 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -211,7 +211,7 @@ dependencies = [
  "libra-types 0.1.0",
  "libradb 0.1.0",
  "proptest 0.9.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "rand 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand 0.7.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "storage-client 0.1.0",
  "structopt 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "tempfile 3.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -643,7 +643,7 @@ dependencies = [
  "libra-crypto 0.1.0",
  "libra-types 0.1.0",
  "libra-util 0.1.0",
- "rand 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand 0.7.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "regex 1.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "reqwest 0.10.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "rusoto_core 0.41.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -737,7 +737,7 @@ dependencies = [
  "libra-logger 0.1.0",
  "libra-types 0.1.0",
  "parity-multiaddr 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "rand 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand 0.7.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)",
  "structopt 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "thiserror 1.0.10 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -777,7 +777,7 @@ dependencies = [
  "prometheus 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "proptest 0.9.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "prost 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "rand 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand 0.7.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "rusty-fork 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "safety-rules 0.1.0",
  "schemadb 0.1.0",
@@ -808,7 +808,7 @@ dependencies = [
  "libra-types 0.1.0",
  "mirai-annotations 1.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "proptest 0.9.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "rand 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand 0.7.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -850,7 +850,7 @@ dependencies = [
  "libra-crypto 0.1.0",
  "libra-types 0.1.0",
  "once_cell 1.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "rand 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand 0.7.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "stdlib 0.1.0",
  "structopt 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "utils 0.1.0",
@@ -1060,7 +1060,7 @@ dependencies = [
 [[package]]
 name = "curve25519-dalek"
 version = "2.0.0"
-source = "git+https://github.com/huitseeker/curve25519-dalek.git?branch=fiat2#12f5288726ed7f860a6e66567449950ffc51d690"
+source = "git+https://github.com/calibra/curve25519-dalek.git?branch=fiat2#7932bd96431b1e81422cdb145daa51889fe69da3"
 dependencies = [
  "byteorder 1.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "curve25519-fiat 0.1.4 (git+https://github.com/calibra/rust-curve25519-fiat.git)",
@@ -1200,10 +1200,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 [[package]]
 name = "ed25519-dalek"
 version = "1.0.0-pre.3"
-source = "git+https://github.com/huitseeker/ed25519-dalek.git?branch=fiat2-test#ac87572259588b84d54ab3868d83321554faf2d9"
+source = "git+https://github.com/calibra/ed25519-dalek.git?branch=fiat2#2faed3463ea313cf9c5e20f8f1ed4b205fdbc401"
 dependencies = [
  "clear_on_drop 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "curve25519-dalek 2.0.0 (git+https://github.com/huitseeker/curve25519-dalek.git?branch=fiat2)",
+ "curve25519-dalek 2.0.0 (git+https://github.com/calibra/curve25519-dalek.git?branch=fiat2)",
  "merlin 1.2.1 (git+https://github.com/isislovecruft/merlin?branch=develop)",
  "rand 0.7.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1292,7 +1292,7 @@ dependencies = [
  "libra-types 0.1.0",
  "once_cell 1.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "proptest 0.9.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "rand 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand 0.7.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "rayon 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "rusty-fork 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "scratchpad 0.1.0",
@@ -1528,7 +1528,7 @@ dependencies = [
  "libra-canonical-serialization 0.1.0",
  "libra-crypto 0.1.0",
  "libra-temppath 0.1.0",
- "rand 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand 0.7.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "structopt 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -1916,7 +1916,7 @@ dependencies = [
  "num-traits 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "proptest 0.9.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "proptest-derive 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "rand 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand 0.7.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)",
  "thiserror 1.0.10 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -1988,7 +1988,7 @@ dependencies = [
  "proptest 0.9.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "proptest-derive 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "prost 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "rand 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand 0.7.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "stdlib 0.1.0",
  "transaction-builder 0.1.0",
  "vm 0.1.0",
@@ -2059,7 +2059,7 @@ dependencies = [
  "libra-types 0.1.0",
  "mirai-annotations 1.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "parity-multiaddr 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "rand 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand 0.7.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)",
  "slog 2.5.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "thiserror 1.0.10 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2075,9 +2075,9 @@ dependencies = [
  "byteorder 1.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "bytes 0.5.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "criterion 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "curve25519-dalek 2.0.0 (git+https://github.com/huitseeker/curve25519-dalek.git?branch=fiat2)",
+ "curve25519-dalek 2.0.0 (git+https://github.com/calibra/curve25519-dalek.git?branch=fiat2)",
  "digest 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "ed25519-dalek 1.0.0-pre.3 (git+https://github.com/huitseeker/ed25519-dalek.git?branch=fiat2-test)",
+ "ed25519-dalek 1.0.0-pre.3 (git+https://github.com/calibra/ed25519-dalek.git?branch=fiat2)",
  "hex 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "hmac 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "libra-canonical-serialization 0.1.0",
@@ -2098,7 +2098,7 @@ dependencies = [
  "thiserror 1.0.10 (registry+https://github.com/rust-lang/crates.io-index)",
  "threshold_crypto 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "tiny-keccak 1.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "x25519-dalek 0.6.0 (git+https://github.com/huitseeker/x25519-dalek.git?branch=fiat2-test)",
+ "x25519-dalek 0.6.0 (git+https://github.com/calibra/x25519-dalek.git?branch=fiat2)",
 ]
 
 [[package]]
@@ -2146,7 +2146,7 @@ dependencies = [
  "chrono 0.4.10 (registry+https://github.com/rust-lang/crates.io-index)",
  "itertools 0.8.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "once_cell 1.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "rand 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand 0.7.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "regex 1.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.47 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2184,7 +2184,7 @@ dependencies = [
  "prometheus 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "proptest 0.9.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "prost 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "rand 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand 0.7.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "storage-client 0.1.0",
  "storage-service 0.1.0",
  "tokio 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2294,7 +2294,7 @@ dependencies = [
  "libra-crypto 0.1.0",
  "libra-temppath 0.1.0",
  "libra-vault-client 0.1.0",
- "rand 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand 0.7.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.47 (registry+https://github.com/rust-lang/crates.io-index)",
  "thiserror 1.0.10 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2335,7 +2335,7 @@ name = "libra-temppath"
 version = "0.1.0"
 dependencies = [
  "hex 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "rand 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand 0.7.3 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -2363,7 +2363,7 @@ dependencies = [
  "prost 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "prost-build 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "radix_trie 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "rand 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand 0.7.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "ref-cast 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "regex 1.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2400,8 +2400,8 @@ dependencies = [
  "libra-types 0.1.0",
  "mirai-annotations 1.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "pbkdf2 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "rand 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "rand_core 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand 0.7.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand_core 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)",
  "sha2 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "sha3 0.8.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2440,7 +2440,7 @@ dependencies = [
  "prometheus 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "proptest 0.9.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "proptest-derive 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "rand 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand 0.7.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "schemadb 0.1.0",
  "serde 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)",
  "storage-proto 0.1.0",
@@ -2769,7 +2769,7 @@ dependencies = [
  "proptest 0.9.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "prost 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "prost-build 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "rand 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand 0.7.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "socket-bench-server 0.1.0",
  "thiserror 1.0.10 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -3954,7 +3954,7 @@ dependencies = [
  "libra-secure-storage 0.1.0",
  "libra-temppath 0.1.0",
  "libra-types 0.1.0",
- "rand 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand 0.7.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)",
  "tempfile 3.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "thiserror 1.0.10 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -4348,7 +4348,7 @@ dependencies = [
  "once_cell 1.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "parity-multiaddr 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "prometheus 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "rand 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand 0.7.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)",
  "storage-client 0.1.0",
  "tokio 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -4437,7 +4437,7 @@ dependencies = [
  "libra-types 0.1.0",
  "libradb 0.1.0",
  "proptest 0.9.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "rand 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand 0.7.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "storage-client 0.1.0",
  "storage-proto 0.1.0",
  "tokio 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -4638,7 +4638,7 @@ dependencies = [
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "mirai-annotations 1.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "num_cpus 1.12.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "rand 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand 0.7.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "slog 2.5.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "slog-envlogger 2.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "slog-scope 4.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -5453,7 +5453,7 @@ dependencies = [
  "ir-to-bytecode 0.1.0",
  "libra-types 0.1.0",
  "move-ir-types 0.1.0",
- "rand 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand 0.7.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "vm 0.1.0",
 ]
 
@@ -5505,7 +5505,7 @@ dependencies = [
  "chashmap 2.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "crossbeam 0.7.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "proptest 0.9.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "rand 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand 0.7.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "typed-arena 2.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -5525,7 +5525,7 @@ dependencies = [
  "parity-multiaddr 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "proptest 0.9.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "proptest-derive 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "rand 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand 0.7.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "stdlib 0.1.0",
  "transaction-builder 0.1.0",
  "vm 0.1.0",
@@ -5587,7 +5587,7 @@ dependencies = [
  "libra-crypto 0.1.0",
  "libra-state-view 0.1.0",
  "libra-types 0.1.0",
- "rand 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand 0.7.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "scratchpad 0.1.0",
  "storage-client 0.1.0",
  "storage-service 0.1.0",
@@ -5849,9 +5849,9 @@ dependencies = [
 [[package]]
 name = "x25519-dalek"
 version = "0.6.0"
-source = "git+https://github.com/huitseeker/x25519-dalek.git?branch=fiat2-test#865a23c0d29c0f0c0583abad0bb787dd99688e17"
+source = "git+https://github.com/calibra/x25519-dalek.git?branch=fiat2#9681f92239d781be9d931afbdee6ed1f11ce16a8"
 dependencies = [
- "curve25519-dalek 2.0.0 (git+https://github.com/huitseeker/curve25519-dalek.git?branch=fiat2)",
+ "curve25519-dalek 2.0.0 (git+https://github.com/calibra/curve25519-dalek.git?branch=fiat2)",
  "rand_core 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "zeroize 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -6003,7 +6003,7 @@ dependencies = [
 "checksum csv-core 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)" = "9b5cadb6b25c77aeff80ba701712494213f4a8418fcda2ee11b6560c3ad0bf4c"
 "checksum ct-logs 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)" = "4d3686f5fa27dbc1d76c751300376e167c5a43387f44bb451fd1c24776e49113"
 "checksum ctrlc 3.1.3 (registry+https://github.com/rust-lang/crates.io-index)" = "c7dfd2d8b4c82121dfdff120f818e09fc4380b0b7e17a742081a89b94853e87f"
-"checksum curve25519-dalek 2.0.0 (git+https://github.com/huitseeker/curve25519-dalek.git?branch=fiat2)" = "<none>"
+"checksum curve25519-dalek 2.0.0 (git+https://github.com/calibra/curve25519-dalek.git?branch=fiat2)" = "<none>"
 "checksum curve25519-dalek 2.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "26778518a7f6cffa1d25a44b602b62b979bd88adb9e99ffec546998cf3404839"
 "checksum curve25519-fiat 0.1.4 (git+https://github.com/calibra/rust-curve25519-fiat.git)" = "<none>"
 "checksum data-encoding 2.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "f4f47ca1860a761136924ddd2422ba77b2ea54fe8cc75b9040804a0d9d32ad97"
@@ -6014,7 +6014,7 @@ dependencies = [
 "checksum dirs 2.0.2 (registry+https://github.com/rust-lang/crates.io-index)" = "13aea89a5c93364a98e9b37b2fa237effbb694d5cfe01c5b70941f7eb087d5e3"
 "checksum dirs-sys 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)" = "afa0b23de8fd801745c471deffa6e12d248f962c9fd4b4c33787b055599bde7b"
 "checksum dtoa 0.4.5 (registry+https://github.com/rust-lang/crates.io-index)" = "4358a9e11b9a09cf52383b451b49a169e8d797b68aa02301ff586d70d9661ea3"
-"checksum ed25519-dalek 1.0.0-pre.3 (git+https://github.com/huitseeker/ed25519-dalek.git?branch=fiat2-test)" = "<none>"
+"checksum ed25519-dalek 1.0.0-pre.3 (git+https://github.com/calibra/ed25519-dalek.git?branch=fiat2)" = "<none>"
 "checksum ed25519-dalek 1.0.0-pre.3 (registry+https://github.com/rust-lang/crates.io-index)" = "978710b352437433c97b2bff193f2fb1dfd58a093f863dd95e225a19baa599a2"
 "checksum either 1.5.3 (registry+https://github.com/rust-lang/crates.io-index)" = "bb1f6b1ce1c140482ea30ddd3335fc0024ac7ee112895426e0a629a6c20adfe3"
 "checksum encode_unicode 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)" = "a357d28ed41a50f9c765dbfe56cbc04a64e53e5fc58ba79fbc34c10ef3df831f"
@@ -6384,7 +6384,7 @@ dependencies = [
 "checksum winapi-x86_64-pc-windows-gnu 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 "checksum winreg 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)" = "b2986deb581c4fe11b621998a5e53361efe6b48a151178d0cd9eeffa4dc6acc9"
 "checksum ws2_32-sys 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "d59cefebd0c892fa2dd6de581e937301d8552cb44489cdff035c6187cb63fa5e"
-"checksum x25519-dalek 0.6.0 (git+https://github.com/huitseeker/x25519-dalek.git?branch=fiat2-test)" = "<none>"
+"checksum x25519-dalek 0.6.0 (git+https://github.com/calibra/x25519-dalek.git?branch=fiat2)" = "<none>"
 "checksum x25519-dalek 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)" = "637ff90c9540fa3073bb577e65033069e4bae7c79d49d74aa3ffdf5342a53217"
 "checksum xml-rs 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)" = "541b12c998c5b56aa2b4e6f18f03664eef9a4fd0a246a55594efae6cc2d964b5"
 "checksum yamux 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "2758f29014c1cb7a6e74c1b1160ac8c8203be342d35b73462fc6a13cc6385423"

--- a/admission_control/admission-control-service/Cargo.toml
+++ b/admission_control/admission-control-service/Cargo.toml
@@ -16,7 +16,7 @@ prost = "0.6"
 futures = "0.3.0"
 num_cpus = "1.10.1"
 once_cell = "1.3.1"
-rand = "0.6.5"
+rand = "0.7.3"
 tokio = { version = "0.2.8", features = ["full"] }
 tonic = "0.1"
 prometheus = { version = "0.7.0", default-features = false }

--- a/client/libra_wallet/Cargo.toml
+++ b/client/libra_wallet/Cargo.toml
@@ -11,8 +11,8 @@ edition = "2018"
 
 [dependencies]
 anyhow = "1.0"
-rand = "0.6.5"
-rand_core = "0.4.2"
+rand = "0.7.3"
+rand_core = "0.5.1"
 hex = "0.4.1"
 hmac = "0.7.1"
 byteorder = "1.3.2"

--- a/client/libra_wallet/src/mnemonic.rs
+++ b/client/libra_wallet/src/mnemonic.rs
@@ -12,7 +12,7 @@ use anyhow::Result;
 use libra_temppath::TempPath;
 use mirai_annotations::*;
 #[cfg(test)]
-use rand::rngs::EntropyRng;
+use rand::rngs::OsRng;
 #[cfg(test)]
 use rand_core::RngCore;
 use sha2::{Digest, Sha256};
@@ -453,7 +453,7 @@ const WORDS: [&str; 2048] = [
 
 #[test]
 fn test_roundtrip_mnemonic() {
-    let mut rng = EntropyRng::new();
+    let mut rng = OsRng;
     let mut buf = [0u8; 32];
     rng.fill_bytes(&mut buf[..]);
     let file = TempPath::new();

--- a/client/libra_wallet/src/wallet_library.rs
+++ b/client/libra_wallet/src/wallet_library.rs
@@ -23,7 +23,7 @@ use libra_types::{
     account_address::AccountAddress,
     transaction::{helpers::TransactionSigner, RawTransaction, SignedTransaction},
 };
-use rand::{rngs::EntropyRng, Rng};
+use rand::{rngs::OsRng, Rng};
 use std::{collections::HashMap, path::Path};
 
 /// WalletLibrary contains all the information needed to recreate a particular wallet
@@ -39,7 +39,7 @@ impl WalletLibrary {
     /// empty WalletLibrary from that Mnemonic
     #[allow(clippy::new_without_default)]
     pub fn new() -> Self {
-        let mut rng = EntropyRng::new();
+        let mut rng = OsRng;
         let data: [u8; 32] = rng.gen();
         let mnemonic = Mnemonic::mnemonic(&data).unwrap();
         Self::new_from_mnemonic(mnemonic)

--- a/common/logger/Cargo.toml
+++ b/common/logger/Cargo.toml
@@ -16,7 +16,7 @@ backtrace = { version = "0.3.44", features = ["serialize-serde"] }
 chrono = "0.4.7"
 itertools = "0.8.0"
 once_cell = "1.3.1"
-rand = "0.6.5"
+rand = "0.7.3"
 serde = { version = "1.0.96", features = ["derive"] }
 serde_json = "1.0.40"
 # use this line to change verbosity
@@ -28,5 +28,5 @@ slog-term = "2.4.1"
 thread-id = "3.3.0"
 
 [dev-dependencies]
-rand = "0.6.5"
+rand = "0.7.3"
 regex = { version = "1.3.0", default-features = false, features = ["std", "perf"] }

--- a/common/logger/src/security.rs
+++ b/common/logger/src/security.rs
@@ -3,7 +3,7 @@
 
 use super::error;
 use backtrace::Backtrace;
-use rand::{rngs::SmallRng, FromEntropy, Rng};
+use rand::{rngs::SmallRng, SeedableRng, Rng};
 use serde::Serialize;
 use std::fmt::Debug;
 

--- a/common/temppath/Cargo.toml
+++ b/common/temppath/Cargo.toml
@@ -11,4 +11,4 @@ edition = "2018"
 
 [dependencies]
 hex = "0.4.1"
-rand = "0.6.5"
+rand = "0.7.3"

--- a/config/Cargo.toml
+++ b/config/Cargo.toml
@@ -15,7 +15,7 @@ get_if_addrs = { version = "0.5.3", default-features = false }
 hex = { version = "0.4.1", default-features = false }
 mirai-annotations = "1.4.0"
 parity-multiaddr = { version = "0.7.1", default-features = false }
-rand = "0.6.5"
+rand = "0.7.3"
 serde = { version = "1.0.99", features = ["rc"], default-features = false }
 slog = { version = "2.5.0", features = ["max_level_trace", "release_max_level_debug"] }
 thiserror = "1.0"

--- a/config/config-builder/Cargo.toml
+++ b/config/config-builder/Cargo.toml
@@ -13,7 +13,7 @@ edition = "2018"
 anyhow = "1.0"
 hex = { version = "0.4.1", default-features = false }
 parity-multiaddr = { version = "0.7.1", default-features = false }
-rand = "0.6.5"
+rand = "0.7.3"
 serde = { version = "1.0.99", default-features = false }
 structopt = "0.3.2"
 thiserror = "1.0"

--- a/config/generate-keypair/Cargo.toml
+++ b/config/generate-keypair/Cargo.toml
@@ -11,7 +11,7 @@ edition = "2018"
 
 [dependencies]
 anyhow = "1.0"
-rand = "0.6.5"
+rand = "0.7.3"
 structopt = "0.3.2"
 
 lcs = { path = "../../common/lcs", version = "0.1.0", package = "libra-canonical-serialization" }

--- a/config/generate-keypair/src/lib.rs
+++ b/config/generate-keypair/src/lib.rs
@@ -20,7 +20,7 @@ pub fn create_faucet_key_file(output_file: &str) -> KeyPair<Ed25519PrivateKey, E
         panic!("Specified output file path is a directory");
     }
 
-    let mut seed_rng = OsRng::new().expect("can't access OsRng");
+    let mut seed_rng = OsRng;
     let mut rng = rand::rngs::StdRng::from_seed(seed_rng.gen());
 
     let (private_key, _) = compat::generate_keypair(&mut rng);

--- a/consensus/Cargo.toml
+++ b/consensus/Cargo.toml
@@ -21,7 +21,7 @@ num-derive = { version = "0.3.0", default-features = false }
 num-traits = { version = "0.2.8", default-features = false }
 parity-multiaddr = { version = "0.7.1", default-features = false }
 prost = "0.6"
-rand = { version = "0.6.5", default-features = false }
+rand = { version = "0.7.3", default-features = false }
 rusty-fork = { version = "0.2.2", default-features = false }
 serde = { version = "1.0.99", default-features = false }
 serde_json = "1.0"

--- a/consensus/consensus-types/Cargo.toml
+++ b/consensus/consensus-types/Cargo.toml
@@ -11,7 +11,7 @@ anyhow = "1.0"
 hex = { version = "0.4.1", default-features = false }
 mirai-annotations = { version = "1.5.0", default-features = false }
 proptest = { version = "0.9.4", optional = true }
-rand = { version = "0.6.5", default-features = false }
+rand = { version = "0.7.3", default-features = false }
 serde = { version = "1.0.99", default-features = false }
 
 lcs = { path = "../../common/lcs", version = "0.1.0", package = "libra-canonical-serialization" }

--- a/consensus/safety-rules/Cargo.toml
+++ b/consensus/safety-rules/Cargo.toml
@@ -22,7 +22,7 @@ workspace-builder = { path = "../../common/workspace-builder", version = "0.1.0"
 
 [dev-dependencies]
 criterion = "0.3"
-rand = { version = "0.6.5", default-features = false }
+rand = { version = "0.7.3", default-features = false }
 tempfile = "3.1.0"
 
 [[bench]]

--- a/crypto/crypto/Cargo.toml
+++ b/crypto/crypto/Cargo.toml
@@ -21,10 +21,10 @@ hmac = "0.7.1"
 once_cell = "1.3.1"
 mirai-annotations = "1.5.0"
 pairing = "0.14"
-proptest = { version = "0.9", optional = true }
-proptest-derive = { version = "0.1", optional = true }
+proptest = { version = "0.9.1", optional = true }
+proptest-derive = { version = "0.1.0", optional = true }
 rand = "0.7.3"
-rand_core = { version = "^0.5", default-features = false }
+rand_core = { version = "0.5.1", default-features = false }
 serde = { version = "1.0.96", features = ["derive"] }
 sha2 = "0.8.0"
 static_assertions = { version = "1.0.0", optional = true }

--- a/crypto/crypto/Cargo.toml
+++ b/crypto/crypto/Cargo.toml
@@ -13,24 +13,25 @@ edition = "2018"
 anyhow = "1.0"
 byteorder = "1.3.2"
 bytes = "0.5.4"
-curve25519-dalek = { git = "https://github.com/calibra/curve25519-dalek.git", branch = "fiat", default-features = false }
+curve25519-dalek = { git = "https://github.com/calibra/curve25519-dalek.git", branch = "fiat2", default-features = false }
 digest = "0.8.1"
-ed25519-dalek = { git = "https://github.com/calibra/ed25519-dalek.git", branch = "fiat", features = ["serde"], default-features = false }
+ed25519-dalek = { git = "https://github.com/calibra/ed25519-dalek.git", branch = "fiat2", features = ["serde"], default-features = false }
 hex = "0.4.1"
 hmac = "0.7.1"
 once_cell = "1.3.1"
 mirai-annotations = "1.5.0"
 pairing = "0.14"
-proptest = { version = "0.9.1", optional = true }
-proptest-derive = { version = "0.1.0", optional = true }
-rand = "0.6.5"
+proptest = { version = "0.9", optional = true }
+proptest-derive = { version = "0.1", optional = true }
+rand = "0.7.3"
+rand_core = { version = "^0.5", default-features = false }
 serde = { version = "1.0.96", features = ["derive"] }
 sha2 = "0.8.0"
 static_assertions = { version = "1.0.0", optional = true }
 thiserror = "1.0"
 threshold_crypto = "0.3"
 tiny-keccak = "1.5"
-x25519-dalek = { git = "https://github.com/calibra/x25519-dalek.git", branch = "fiat", default-features = false }
+x25519-dalek = { git = "https://github.com/calibra/x25519-dalek.git", branch = "fiat2", default-features = false }
 
 libra-crypto-derive = { path = "../crypto-derive", version = "0.1.0" }
 lcs = { path = "../../common/lcs", version = "0.1.0", package = "libra-canonical-serialization" }
@@ -39,17 +40,16 @@ libra-nibble = { path = "../../common/nibble", version = "0.1.0" }
 [dev-dependencies]
 bitvec = "0.10.2"
 byteorder = "1.3.2"
-proptest = "0.9.1"
-proptest-derive = "0.1.0"
 ripemd160 = "0.8.0"
 criterion = "0.3"
 sha3 = "0.8.2"
 
 [features]
-default = ["std", "u64_backend"]
+default = ["std", "batch", "u64_backend"]
 assert-private-keys-not-cloneable = ["static_assertions"]
 cloneable-private-keys = []
 fuzzing = ["proptest", "proptest-derive", "cloneable-private-keys"]
+batch = ["ed25519-dalek/batch"]
 std = ["curve25519-dalek/std", "ed25519-dalek/std", "x25519-dalek/std"]
 u64_backend = ["curve25519-dalek/u64_backend", "ed25519-dalek/u64_backend", "x25519-dalek/u64_backend"]
 fiat_u64_backend = ["curve25519-dalek/fiat_u64_backend", "ed25519-dalek/fiat_u64_backend", "x25519-dalek/fiat_u64_backend"]

--- a/crypto/crypto/src/hash.rs
+++ b/crypto/crypto/src/hash.rs
@@ -95,7 +95,7 @@ use mirai_annotations::*;
 use once_cell::sync::Lazy;
 #[cfg(any(test, feature = "fuzzing"))]
 use proptest_derive::Arbitrary;
-use rand::{rngs::EntropyRng, Rng};
+use rand::{rngs::OsRng, Rng};
 use serde::{de, ser};
 use std::{self, convert::AsRef, fmt};
 use tiny_keccak::Keccak;
@@ -161,7 +161,7 @@ impl HashValue {
 
     /// Create a cryptographically random instance.
     pub fn random() -> Self {
-        let mut rng = EntropyRng::new();
+        let mut rng = OsRng;
         let hash: [u8; HashValue::LENGTH] = rng.gen();
         HashValue { hash }
     }

--- a/crypto/crypto/src/x25519.rs
+++ b/crypto/crypto/src/x25519.rs
@@ -58,7 +58,7 @@
 
 use crate::{hkdf::Hkdf, traits::*};
 use libra_crypto_derive::{Deref, DeserializeKey, SerializeKey, SilentDebug, SilentDisplay};
-use rand::{rngs::EntropyRng, RngCore};
+use rand::{rngs::OsRng, RngCore};
 use sha2::Sha256;
 use std::{convert::TryFrom, ops::Deref};
 use x25519_dalek;
@@ -155,7 +155,7 @@ impl X25519StaticPrivateKey {
         )
     }
 
-    /// Generates a random keypair `(PrivateKey, PublicKey)` by combining the output of `EntropyRng`
+    /// Generates a random keypair `(PrivateKey, PublicKey)` by combining the output of `OsRng`
     /// with a user-provided seed. This concatenated seed is used as the seed to HKDF (RFC 5869).
     ///
     /// Similarly to `derive_keypair_from_seed` the user provides the following inputs:
@@ -170,7 +170,7 @@ impl X25519StaticPrivateKey {
         seed: &[u8],
         app_info: Option<&[u8]>,
     ) -> (X25519StaticPrivateKey, X25519StaticPublicKey) {
-        let mut rng = EntropyRng::new();
+        let mut rng = OsRng;
         let mut seed_from_rng = [0u8; X25519_PRIVATE_KEY_LENGTH];
         rng.fill_bytes(&mut seed_from_rng);
 

--- a/executor/Cargo.toml
+++ b/executor/Cargo.toml
@@ -14,7 +14,7 @@ anyhow = "1.0"
 futures = "0.3.0"
 itertools = { version = "0.8.0", default-features = false }
 once_cell = "1.3.1"
-rand = "0.6.5"
+rand = "0.7.3"
 rayon = "1"
 serde = { version = "1.0.99", default-features = false }
 structopt = "0.3"

--- a/language/e2e-tests/Cargo.toml
+++ b/language/e2e-tests/Cargo.toml
@@ -16,7 +16,7 @@ lcs = { path = "../../common/lcs", version = "0.1.0", package = "libra-canonical
 compiler = { path = "../compiler", version = "0.1.0" }
 once_cell = "1.3.1"
 libra-crypto = { path = "../../crypto/crypto", version = "0.1.0", features = ["fuzzing"] }
-rand = "0.6.5"
+rand = "0.7.3"
 libra-state-view = { path = "../../storage/state-view", version = "0.1.0" }
 libra-types = { path = "../../types", version = "0.1.0", features = ["fuzzing"] }
 transaction-builder = { path = "../transaction-builder", version = "0.1.0", features = ["fuzzing"]}

--- a/language/e2e-tests/src/account.rs
+++ b/language/e2e-tests/src/account.rs
@@ -48,7 +48,7 @@ impl Account {
     /// [`FakeExecutor::add_account_data`][crate::executor::FakeExecutor::add_account_data].
     /// This function returns distinct values upon every call.
     pub fn new() -> Self {
-        let mut seed_rng = rand::rngs::OsRng::new().expect("can't access OsRng");
+        let mut seed_rng = rand::rngs::OsRng;
         let seed_buf: [u8; 32] = seed_rng.gen();
         let mut rng = rand::rngs::StdRng::from_seed(seed_buf);
 

--- a/language/tools/cost-synthesis/Cargo.toml
+++ b/language/tools/cost-synthesis/Cargo.toml
@@ -11,7 +11,7 @@ edition = "2018"
 
 [dependencies]
 csv = "1.1.1"
-rand = "0.6.5"
+rand = "0.7.3"
 once_cell = "1.3.1"
 
 bytecode-verifier = { path = "../../bytecode-verifier", version = "0.1.0" }

--- a/language/tools/cost-synthesis/src/global_state/account.rs
+++ b/language/tools/cost-synthesis/src/global_state/account.rs
@@ -39,7 +39,7 @@ pub struct Account {
 impl Account {
     /// Create a new Account. The account is a logical entity at this point
     pub fn new() -> Self {
-        let mut seed_rng = OsRng::new().expect("can't access OsRng");
+        let mut seed_rng = OsRng;
         let seed_buf: [u8; 32] = seed_rng.gen();
         let mut rng = StdRng::from_seed(seed_buf);
         let (privkey, pubkey) = compat::generate_keypair(&mut rng);

--- a/language/tools/cost-synthesis/src/module_generator.rs
+++ b/language/tools/cost-synthesis/src/module_generator.rs
@@ -8,7 +8,7 @@
 //! generated -- any function bodies that are generated are simply non-semantic sequences of
 //! instructions to check BrTrue, BrFalse, and Branch instructions.
 use bytecode_verifier::VerifiedModule;
-use rand::{rngs::StdRng, FromEntropy};
+use rand::{rngs::StdRng, SeedableRng};
 use utils::module_generation::{generate_verified_modules, ModuleGeneratorOptions};
 
 pub fn generate_padded_modules(

--- a/language/tools/test-generation/Cargo.toml
+++ b/language/tools/test-generation/Cargo.toml
@@ -10,7 +10,7 @@ publish = false
 edition = "2018"
 
 [dependencies]
-rand = "0.6.5"
+rand = "0.7.3"
 log = "0.4"
 num_cpus = "1.11.1"
 mirai-annotations = "1.4.0"

--- a/language/tools/utils/Cargo.toml
+++ b/language/tools/utils/Cargo.toml
@@ -10,7 +10,7 @@ publish = false
 edition = "2018"
 
 [dependencies]
-rand = "0.6.5"
+rand = "0.7.3"
 
 bytecode-verifier = { path = "../../bytecode-verifier", version = "0.1.0" }
 ir-to-bytecode = { path = "../../compiler/ir-to-bytecode", version = "0.1.0" }

--- a/language/tools/utils/tests/tests.rs
+++ b/language/tools/utils/tests/tests.rs
@@ -2,7 +2,8 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use bytecode_verifier::VerifiedModule;
-use rand::{rngs::StdRng, FromEntropy};
+use rand::rngs::StdRng;
+use rand::SeedableRng;
 use utils::module_generation::{generate_module, ModuleGeneratorOptions};
 
 #[test]

--- a/language/tools/vm-genesis/Cargo.toml
+++ b/language/tools/vm-genesis/Cargo.toml
@@ -12,7 +12,7 @@ publish = false
 [dependencies]
 anyhow = "1.0"
 once_cell = "1.3.1"
-rand = "0.6.5"
+rand = "0.7.3"
 
 bytecode-verifier = { path = "../../bytecode-verifier", version = "0.1.0" }
 lcs = { path = "../../../common/lcs", version = "0.1.0", package = "libra-canonical-serialization" }

--- a/language/vm/vm-runtime/vm-cache-map/Cargo.toml
+++ b/language/vm/vm-runtime/vm-cache-map/Cargo.toml
@@ -16,4 +16,4 @@ typed-arena = "2.0.1"
 [dev-dependencies]
 crossbeam = "0.7.2"
 proptest = "0.9.4"
-rand = "0.6.5"
+rand = "0.7.3"

--- a/mempool/Cargo.toml
+++ b/mempool/Cargo.toml
@@ -43,7 +43,7 @@ storage-service = { path = "../storage/storage-service", version = "0.1.0", opti
 [dev-dependencies]
 channel = { path = "../common/channel", version = "0.1.0" }
 parity-multiaddr = { version = "0.7.1", default-features = false }
-rand = "0.6.5"
+rand = "0.7.3"
 
 [build-dependencies]
 tonic-build = "0.1"

--- a/network/Cargo.toml
+++ b/network/Cargo.toml
@@ -19,7 +19,7 @@ parity-multiaddr = "0.7.1"
 pin-project = "0.4.2"
 prost = "0.6"
 prometheus = { version = "0.7.0", default-features = false }
-rand = "0.6.5"
+rand = "0.7.3"
 thiserror = "1.0"
 tokio = { version = "0.2.8", features = ["full"] }
 tokio-util = { version = "0.2", features = ["codec"] }

--- a/network/src/protocols/discovery/mod.rs
+++ b/network/src/protocols/discovery/mod.rs
@@ -56,7 +56,7 @@ use libra_logger::prelude::*;
 use libra_types::{crypto_proxies::ValidatorSigner as Signer, PeerId};
 use parity_multiaddr::Multiaddr;
 use prost::Message;
-use rand::{rngs::SmallRng, FromEntropy, Rng};
+use rand::{rngs::SmallRng, SeedableRng, Rng};
 use std::{
     cmp::max,
     collections::{HashMap, HashSet},

--- a/network/src/protocols/health_checker/mod.rs
+++ b/network/src/protocols/health_checker/mod.rs
@@ -30,7 +30,7 @@ use futures::{
 };
 use libra_logger::prelude::*;
 use libra_types::PeerId;
-use rand::{rngs::SmallRng, seq::SliceRandom, FromEntropy, Rng};
+use rand::{rngs::SmallRng, seq::SliceRandom, SeedableRng, Rng};
 use std::{collections::HashMap, time::Duration};
 
 #[cfg(test)]

--- a/secure/storage/Cargo.toml
+++ b/secure/storage/Cargo.toml
@@ -22,7 +22,7 @@ toml = { version = "0.5.3", default-features = false }
 
 [dev-dependencies]
 libra-config = { path = "../../config", version = "0.1.0" }
-rand = "0.6.5"
+rand = "0.7.3"
 
 [features]
 fuzzing = ["libra-crypto/fuzzing"]

--- a/state-synchronizer/Cargo.toml
+++ b/state-synchronizer/Cargo.toml
@@ -16,7 +16,7 @@ futures = "0.3.0"
 serde = { version = "1.0.99", default-features = false }
 lcs = { path = "../common/lcs", version = "0.1.0", package = "libra-canonical-serialization" }
 once_cell = "1.3.1"
-rand = "0.6.5"
+rand = "0.7.3"
 tokio = { version = "0.2.8", features = ["full"] }
 prometheus = { version = "0.7.0", default-features = false }
 

--- a/storage/accumulator/Cargo.toml
+++ b/storage/accumulator/Cargo.toml
@@ -16,7 +16,7 @@ mirai-annotations = "1.5.0"
 libra-types = { path = "../../types", version = "0.1.0" }
 
 [dev-dependencies]
-rand = "0.6.5"
+rand = "0.7.3"
 proptest = "0.9.1"
 
 [features]

--- a/storage/backup-restore/Cargo.toml
+++ b/storage/backup-restore/Cargo.toml
@@ -15,7 +15,7 @@ byteorder = "1.3.2"
 futures = "0.3.0"
 hex = "0.4.1"
 itertools = "0.8"
-rand = "0.6.5"
+rand = "0.7.3"
 structopt = "0.3"
 tokio = "0.2"
 

--- a/storage/jellyfish-merkle/Cargo.toml
+++ b/storage/jellyfish-merkle/Cargo.toml
@@ -27,7 +27,7 @@ libra-nibble = { path = "../../common/nibble", version = "0.1.0" }
 libra-types = { path = "../../types", version = "0.1.0" }
 
 [dev-dependencies]
-rand = "0.6.5"
+rand = "0.7.3"
 proptest = "0.9.2"
 proptest-derive = "0.1.2"
 

--- a/storage/libradb/Cargo.toml
+++ b/storage/libradb/Cargo.toml
@@ -20,7 +20,7 @@ num-traits = "0.2"
 proptest = { version = "0.9.2", optional = true }
 proptest-derive = { version = "0.1.2", optional = true }
 prometheus = { version = "0.7.0", default-features = false }
-rand = "0.6.5"
+rand = "0.7.3"
 strum = "0.17.1"
 strum_macros = "0.17.1"
 serde = "1.0.96"

--- a/storage/storage-service/Cargo.toml
+++ b/storage/storage-service/Cargo.toml
@@ -24,7 +24,7 @@ libra-logger = { path = "../../common/logger", version = "0.1.0" }
 libra-metrics = { path = "../../common/metrics", version = "0.1.0" }
 storage-proto = { path = "../storage-proto", version = "0.1.0" }
 libra-types = { path = "../../types", version = "0.1.0" }
-rand = "0.6.5"
+rand = "0.7.3"
 proptest = { version = "0.9.2", optional = true }
 storage-client = { path = "../storage-client", version = "0.1.0", optional = true }
 

--- a/storage/storage-service/src/mocks/mock_storage_client.rs
+++ b/storage/storage-service/src/mocks/mock_storage_client.rs
@@ -248,7 +248,7 @@ fn get_mock_txn_data(
     start_seq: u64,
     end_seq: u64,
 ) -> Vec<libra_types::proto::types::Transaction> {
-    let mut seed_rng = OsRng::new().expect("can't access OsRng");
+    let mut seed_rng = OsRng;
     let seed_buf: [u8; 32] = seed_rng.gen();
     let mut rng = StdRng::from_seed(seed_buf);
     let (priv_key, pub_key) = compat::generate_keypair(&mut rng);

--- a/testsuite/cluster-test/Cargo.toml
+++ b/testsuite/cluster-test/Cargo.toml
@@ -13,7 +13,7 @@ edition = "2018"
 anyhow = "1.0"
 flate2 = { version = "1.0", features = ["rust_backend"], default-features = false }
 itertools = "0.8.0"
-rand = "0.6.5"
+rand = "0.7.3"
 regex = { version = "1.3.0", default-features = false, features = ["std", "perf"] }
 reqwest = { version="0.10.1", features=["blocking", "json", "rustls-tls"], default_features = false }
 rusoto_core = {version = "0.41.0", features=["rustls"], default_features = false}

--- a/testsuite/cluster-test/src/tx_emitter.rs
+++ b/testsuite/cluster-test/src/tx_emitter.rs
@@ -35,7 +35,7 @@ use libra_types::{
 };
 use rand::{
     prelude::ThreadRng,
-    rngs::{EntropyRng, StdRng},
+    rngs::{OsRng, StdRng},
     seq::IteratorRandom,
     seq::SliceRandom,
     Rng, SeedableRng,
@@ -528,7 +528,7 @@ fn gen_random_account(rng: &mut StdRng) -> AccountData {
 }
 
 fn gen_random_accounts(num_accounts: usize) -> Vec<AccountData> {
-    let seed: [u8; 32] = EntropyRng::new().gen();
+    let seed: [u8; 32] = OsRng.gen();
     let mut rng = StdRng::from_seed(seed);
     (0..num_accounts)
         .map(|_| gen_random_account(&mut rng))

--- a/types/Cargo.toml
+++ b/types/Cargo.toml
@@ -24,7 +24,7 @@ proptest = { version = "0.9.4", default-features = false, optional = true }
 proptest-derive = { version = "0.1.2", default-features = false, optional = true }
 prost = "0.6"
 radix_trie = { version = "0.1.4", default-features = false }
-rand = "0.6.5"
+rand = "0.7.3"
 ref-cast = "1.0"
 serde = { version = "1.0.99", default-features = false }
 thiserror = "1.0"

--- a/types/src/account_address.rs
+++ b/types/src/account_address.rs
@@ -34,7 +34,7 @@ impl AccountAddress {
     }
 
     pub fn random() -> Self {
-        let mut rng = OsRng::new().expect("can't access OsRng");
+        let mut rng = OsRng;
         let buf: [u8; 32] = rng.gen();
         AccountAddress::new(buf)
     }

--- a/types/src/event.rs
+++ b/types/src/event.rs
@@ -39,7 +39,7 @@ impl EventKey {
     #[cfg(feature = "fuzzing")]
     /// Create a random event key for testing
     pub fn random() -> Self {
-        let mut rng = OsRng::new().expect("can't access OsRng");
+        let mut rng = OsRng;
         let salt = rng.next_u64();
         EventKey::new_from_address(&AccountAddress::random(), salt)
     }

--- a/vm-validator/Cargo.toml
+++ b/vm-validator/Cargo.toml
@@ -21,7 +21,7 @@ libra-types = { path = "../types", version = "0.1.0" }
 vm-runtime = { path = "../language/vm/vm-runtime", version = "0.1.0" }
 
 [dev-dependencies]
-rand = "0.6.5"
+rand = "0.7.3"
 
 config-builder = { path = "../config/config-builder", version = "0.1.0" }
 libra-crypto = { path = "../crypto/crypto", version = "0.1.0" }


### PR DESCRIPTION
This ports the dalek suite of libraries to >= curve25519-dalek 2.0, and updates rand to 0.7.
WIP to test the complex set of features involved through CI & tune.