### PR TITLE
[state-sync] Remove nearly all proto from interface

### DIFF
--- a/network/src/proto/mod.rs
+++ b/network/src/proto/mod.rs
@@ -33,8 +33,5 @@ pub use self::{
         identity_msg::Role as IdentityMsg_Role, DiscoveryMsg, FullNodePayload, IdentityMsg, Note,
         PeerInfo, SignedFullNodePayload, SignedPeerInfo,
     },
-    state_synchronizer::{
-        state_synchronizer_msg::Message as StateSynchronizerMsg_oneof, GetChunkRequest,
-        GetChunkResponse, StateSynchronizerMsg,
-    },
+    state_synchronizer::StateSynchronizerMsg,
 };

--- a/network/src/proto/state_synchronizer.proto
+++ b/network/src/proto/state_synchronizer.proto
@@ -5,13 +5,4 @@ syntax = "proto3";
 
 package state_synchronizer;
 
-message GetChunkRequest { bytes bytes = 1; }
-
-message GetChunkResponse { bytes bytes = 1; }
-
-message StateSynchronizerMsg {
-  oneof message {
-    GetChunkRequest chunk_request = 1;
-    GetChunkResponse chunk_response = 2;
-  }
-}
+message StateSynchronizerMsg { bytes message = 1; }

--- a/network/src/validator_network/state_synchronizer.rs
+++ b/network/src/validator_network/state_synchronizer.rs
@@ -80,7 +80,6 @@ mod tests {
     use super::*;
     use crate::{
         peer_manager::{conn_status_channel, PeerManagerNotification, PeerManagerRequest},
-        proto::{GetChunkRequest, GetChunkResponse, StateSynchronizerMsg_oneof},
         protocols::direct_send::Message,
         utils::MessageExt,
         validator_network::Event,
@@ -97,11 +96,7 @@ mod tests {
             libra_channel::new(QueueStyle::FIFO, NonZeroUsize::new(8).unwrap(), None);
         let mut sender = StateSynchronizerSender::new(network_reqs_tx);
         let peer_id = PeerId::random();
-
-        // Create GetChunkRequest and embed in StateSynchronizerMsg.
-        let chunk_request = GetChunkRequest::default();
-        let mut send_msg = StateSynchronizerMsg::default();
-        send_msg.message = Some(StateSynchronizerMsg_oneof::ChunkRequest(chunk_request));
+        let send_msg = StateSynchronizerMsg::default();
 
         // Send msg to network layer.
         sender.send_to(peer_id, send_msg.clone()).unwrap();
@@ -131,11 +126,7 @@ mod tests {
             libra_channel::new(QueueStyle::FIFO, NonZeroUsize::new(8).unwrap(), None);
         let mut stream = StateSynchronizerEvents::new(state_sync_rx, control_notifs_rx);
         let peer_id = PeerId::random();
-
-        // Create GetChunkResponse and embed in StateSynchronizerMsg.
-        let chunk_response = GetChunkResponse::default();
-        let mut state_sync_msg = StateSynchronizerMsg::default();
-        state_sync_msg.message = Some(StateSynchronizerMsg_oneof::ChunkResponse(chunk_response));
+        let state_sync_msg = StateSynchronizerMsg::default();
 
         // mock receiving request.
         let event = PeerManagerNotification::RecvMessage(

--- a/state-synchronizer/src/chunk_request.rs
+++ b/state-synchronizer/src/chunk_request.rs
@@ -1,11 +1,9 @@
 // Copyright (c) The Libra Core Contributors
 // SPDX-License-Identifier: Apache-2.0
 
-use anyhow::{Error, Result};
 use libra_types::crypto_proxies::LedgerInfoWithSignatures;
 use libra_types::transaction::Version;
 use serde::{Deserialize, Serialize};
-use std::convert::TryFrom;
 use std::fmt;
 
 #[derive(Deserialize, Serialize, Clone, Debug, PartialEq, Eq)]
@@ -60,23 +58,5 @@ impl fmt::Display for GetChunkRequest {
             self.limit,
             self.target(),
         )
-    }
-}
-
-impl TryFrom<network::proto::GetChunkRequest> for GetChunkRequest {
-    type Error = Error;
-
-    fn try_from(proto: network::proto::GetChunkRequest) -> Result<Self> {
-        Ok(lcs::from_bytes(&proto.bytes)?)
-    }
-}
-
-impl TryFrom<GetChunkRequest> for network::proto::GetChunkRequest {
-    type Error = Error;
-
-    fn try_from(chunk_request: GetChunkRequest) -> Result<Self> {
-        Ok(Self {
-            bytes: lcs::to_bytes(&chunk_request)?,
-        })
     }
 }

--- a/state-synchronizer/src/chunk_response.rs
+++ b/state-synchronizer/src/chunk_response.rs
@@ -1,11 +1,9 @@
 // Copyright (c) The Libra Core Contributors
 // SPDX-License-Identifier: Apache-2.0
 
-use anyhow::{Error, Result};
 use libra_types::crypto_proxies::LedgerInfoWithSignatures;
 use libra_types::transaction::{TransactionListWithProof, Version};
 use serde::{Deserialize, Serialize};
-use std::convert::TryFrom;
 use std::fmt;
 
 /// The response can carry different LedgerInfo types depending on whether the verification
@@ -90,23 +88,5 @@ impl fmt::Display for GetChunkResponse {
             "[ChunkResponse: response li: {}, txns: {}]",
             response_li_repr, txns_repr,
         )
-    }
-}
-
-impl TryFrom<network::proto::GetChunkResponse> for GetChunkResponse {
-    type Error = Error;
-
-    fn try_from(proto: network::proto::GetChunkResponse) -> Result<Self> {
-        Ok(lcs::from_bytes(&proto.bytes)?)
-    }
-}
-
-impl TryFrom<GetChunkResponse> for network::proto::GetChunkResponse {
-    type Error = Error;
-
-    fn try_from(chunk_response: GetChunkResponse) -> Result<Self> {
-        Ok(Self {
-            bytes: lcs::to_bytes(&chunk_response)?,
-        })
     }
 }


### PR DESCRIPTION
This commit removes all but the StateSychronizerMsg proto and introduces
an LCS layer instead. This matches the earlier work done in https://github.com/libra/libra/pull/2502

Integration tests pass