### PR TITLE
[cluster-test] Fix default structopt flags for tx_emitter

### DIFF
--- a/testsuite/cluster-test/src/main.rs
+++ b/testsuite/cluster-test/src/main.rs
@@ -100,11 +100,11 @@ struct Args {
     changelog: Option<Vec<String>>,
 
     // emit_tx options
-    #[structopt(long, default_value = "10")]
+    #[structopt(long, default_value = "16")]
     accounts_per_client: usize,
     #[structopt(long)]
     threads_per_ac: Option<usize>,
-    #[structopt(long, default_value = "50")]
+    #[structopt(long, default_value = "0")]
     wait_millis: u64,
     #[structopt(long)]
     burst: bool,

--- a/testsuite/cluster-test/src/tx_emitter.rs
+++ b/testsuite/cluster-test/src/tx_emitter.rs
@@ -150,6 +150,10 @@ impl TxEmitter {
             threads_per_ac, num_clients
         );
         let num_accounts = req.accounts_per_client * num_clients;
+        info!(
+            "Will create {} accounts_per_client with total {} accounts",
+            req.accounts_per_client, num_accounts
+        );
         self.mint_accounts(&req, num_accounts).await?;
         let all_accounts = self.accounts.split_off(self.accounts.len() - num_accounts);
         let mut workers = vec![];


### PR DESCRIPTION
## Summary

The default params were changed for `tx_emitter`.  However, when an individual experiment is run, it still uses the params which come from `structopt` flags. This updates `structopt` flags to use the same values as the defaults in `tx_emitter`

## Test Plan

```
ct -c cluster-test-ci --image 853397791086.dkr.ecr.us-west-2.amazonaws.com/libra_cluster_test:dev_kush_pull_2620 --deploy dev_ccelee_pull_2602 --run bench

Experiment Result: all up : 1013 TPS, 3062.1 ms latency, no expired txns
```