### PR TITLE
[types] Extract genesis definitions from executor to types

### DIFF
--- a/consensus/consensus-types/src/block.rs
+++ b/consensus/consensus-types/src/block.rs
@@ -142,7 +142,7 @@ where
 {
     #[cfg(any(test, feature = "fuzzing"))]
     pub fn make_genesis_block() -> Self {
-        Self::make_genesis_block_from_ledger_info(&LedgerInfo::genesis())
+        Self::make_genesis_block_from_ledger_info(&LedgerInfo::mock_genesis())
     }
 
     /// Construct new genesis block for next epoch deterministically from the end-epoch LedgerInfo

--- a/consensus/consensus-types/src/block_test_utils.rs
+++ b/consensus/consensus-types/src/block_test_utils.rs
@@ -221,7 +221,7 @@ pub fn placeholder_certificate_for_block(
     certified_parent_block_round: u64,
 ) -> QuorumCert {
     // Assuming executed state to be Genesis state.
-    let genesis_ledger_info = LedgerInfo::genesis();
+    let genesis_ledger_info = LedgerInfo::mock_genesis();
     let vote_data = VoteData::new(
         BlockInfo::new(
             genesis_ledger_info.epoch() + 1,
@@ -264,7 +264,7 @@ pub fn placeholder_certificate_for_block(
 }
 
 pub fn certificate_for_genesis() -> QuorumCert {
-    let ledger_info = LedgerInfo::genesis();
+    let ledger_info = LedgerInfo::mock_genesis();
     QuorumCert::certificate_for_genesis_from_ledger_info(
         &ledger_info,
         Block::<Vec<usize>>::make_genesis_block_from_ledger_info(&ledger_info).id(),

--- a/consensus/src/chained_bft/test_utils/mock_storage.rs
+++ b/consensus/src/chained_bft/test_utils/mock_storage.rs
@@ -55,7 +55,7 @@ impl<T: Payload> MockStorage<T> {
     pub fn new(shared_storage: Arc<MockSharedStorage<T>>) -> Self {
         MockStorage {
             shared_storage,
-            storage_ledger: Mutex::new(LedgerInfo::genesis()),
+            storage_ledger: Mutex::new(LedgerInfo::mock_genesis()),
         }
     }
 
@@ -248,7 +248,7 @@ impl<T: Payload> PersistentLivenessStorage<T> for EmptyStorage {
     }
 
     async fn recover_from_ledger(&self) -> LedgerRecoveryData<T> {
-        LedgerRecoveryData::new(LedgerInfo::genesis(), ValidatorSet::new(vec![]))
+        LedgerRecoveryData::new(LedgerInfo::mock_genesis(), ValidatorSet::new(vec![]))
     }
 
     async fn start(&self) -> LivenessStorageData<T> {
@@ -257,7 +257,7 @@ impl<T: Payload> PersistentLivenessStorage<T> for EmptyStorage {
             self.recover_from_ledger().await,
             vec![],
             vec![],
-            &LedgerInfo::genesis(),
+            &LedgerInfo::mock_genesis(),
             ExecutedTrees::new_empty(),
             None,
         ) {

--- a/state-synchronizer/src/tests/integration_tests.rs
+++ b/state-synchronizer/src/tests/integration_tests.rs
@@ -12,20 +12,18 @@ use futures::executor::block_on;
 use libra_config::config::RoleType;
 use libra_crypto::{
     ed25519::*,
+    hash::ACCUMULATOR_PLACEHOLDER_HASH,
     test_utils::TEST_SEED,
     x25519,
     x25519::{X25519StaticPrivateKey, X25519StaticPublicKey},
-    HashValue,
 };
 use libra_logger::set_simple_logger;
 use libra_mempool::mocks::MockSharedMempool;
 use libra_types::{
-    block_info::BlockInfo,
     crypto_proxies::{
         random_validator_verifier, LedgerInfoWithSignatures, ValidatorChangeProof,
         ValidatorPublicKeys, ValidatorSet, ValidatorSigner,
     },
-    ledger_info::LedgerInfo,
     proof::TransactionListProof,
     transaction::TransactionListWithProof,
     waypoint::Waypoint,
@@ -40,7 +38,7 @@ use network::{
 use parity_multiaddr::Multiaddr;
 use rand::{rngs::StdRng, SeedableRng};
 use std::{
-    collections::{BTreeMap, HashMap},
+    collections::HashMap,
     sync::{
         atomic::{AtomicUsize, Ordering},
         Arc, RwLock,
@@ -203,20 +201,9 @@ impl SynchronizerEnv {
     }
 
     fn genesis_li(validators: &[ValidatorPublicKeys]) -> LedgerInfoWithSignatures {
-        LedgerInfoWithSignatures::new(
-            LedgerInfo::new(
-                BlockInfo::new(
-                    0,
-                    0,
-                    HashValue::zero(),
-                    HashValue::zero(),
-                    0,
-                    0,
-                    Some(ValidatorSet::new(validators.to_owned())),
-                ),
-                HashValue::zero(),
-            ),
-            BTreeMap::new(),
+        LedgerInfoWithSignatures::genesis(
+            *ACCUMULATOR_PLACEHOLDER_HASH,
+            ValidatorSet::new(validators.to_vec()),
         )
     }
 

--- a/testsuite/tests/libratest/smoke_test.rs
+++ b/testsuite/tests/libratest/smoke_test.rs
@@ -3,7 +3,7 @@
 
 use cli::client_proxy::ClientProxy;
 use libra_config::config::{NodeConfig, RoleType, VMPublishingOption};
-use libra_crypto::{ed25519::*, hash::CryptoHash, test_utils::KeyPair, HashValue, SigningKey};
+use libra_crypto::{ed25519::*, hash::CryptoHash, test_utils::KeyPair, SigningKey};
 use libra_logger::prelude::*;
 use libra_swarm::swarm::LibraNode;
 use libra_swarm::swarm::LibraSwarm;
@@ -11,7 +11,6 @@ use libra_temppath::TempPath;
 use libra_types::{
     account_address::AccountAddress,
     account_config::association_address,
-    block_info::BlockInfo,
     ledger_info::LedgerInfo,
     transaction::{TransactionArgument, TransactionPayload},
     waypoint::Waypoint,
@@ -934,7 +933,7 @@ fn test_client_waypoints() {
     );
 
     // Verify that a client with the wrong waypoint is not going to be able to connect to the chain.
-    let bad_li = LedgerInfo::new(BlockInfo::empty(), HashValue::zero());
+    let bad_li = LedgerInfo::mock_genesis();
     let bad_waypoint = Waypoint::new(&bad_li).unwrap();
     let mut client_with_bad_waypoint = env.get_validator_ac_client(1, Some(bad_waypoint));
     assert!(client_with_bad_waypoint

--- a/testsuite/tests/libratest/smoke_test.rs
+++ b/testsuite/tests/libratest/smoke_test.rs
@@ -934,7 +934,7 @@ fn test_client_waypoints() {
     );
 
     // Verify that a client with the wrong waypoint is not going to be able to connect to the chain.
-    let bad_li = LedgerInfo::new(BlockInfo::genesis(), HashValue::zero());
+    let bad_li = LedgerInfo::new(BlockInfo::empty(), HashValue::zero());
     let bad_waypoint = Waypoint::new(&bad_li).unwrap();
     let mut client_with_bad_waypoint = env.get_validator_ac_client(1, Some(bad_waypoint));
     assert!(client_with_bad_waypoint

--- a/types/src/ledger_info.rs
+++ b/types/src/ledger_info.rs
@@ -65,6 +65,20 @@ impl LedgerInfo {
         }
     }
 
+    /// Create a new LedgerInfo at genesis with the given genesis state and
+    /// initial validator set.
+    pub fn genesis(genesis_state_root_hash: HashValue, validator_set: ValidatorSet) -> Self {
+        Self::new(
+            BlockInfo::genesis(genesis_state_root_hash, validator_set),
+            HashValue::zero(),
+        )
+    }
+
+    #[cfg(any(test, feature = "fuzzing"))]
+    pub fn mock_genesis() -> Self {
+        Self::new(BlockInfo::mock_genesis(), HashValue::zero())
+    }
+
     /// The `BlockInfo` of a committed block.
     pub fn commit_info(&self) -> &BlockInfo {
         &self.commit_info
@@ -107,12 +121,6 @@ impl LedgerInfo {
 
     pub fn set_consensus_data_hash(&mut self, consensus_data_hash: HashValue) {
         self.consensus_data_hash = consensus_data_hash;
-    }
-
-    /// To bootstrap the system until we execute and commit the genesis txn before start.
-    #[cfg(any(test, feature = "fuzzing"))]
-    pub fn genesis() -> Self {
-        Self::new(BlockInfo::genesis(), HashValue::zero())
     }
 }
 
@@ -199,6 +207,20 @@ impl<Sig: Signature> LedgerInfoWithSignatures<Sig> {
             ledger_info,
             signatures,
         }
+    }
+
+    /// Create a new `LedgerInfoWithSignatures` at genesis with the given genesis
+    /// state and initial validator set.
+    ///
+    /// Note that the genesis `LedgerInfoWithSignatures` is unsigned. Validators
+    /// and FullNodes are configured with the same genesis transaction and generate
+    /// an identical genesis `LedgerInfoWithSignatures` independently. In contrast,
+    /// Clients will likely use a waypoint generated from the genesis `LedgerInfo`.
+    pub fn genesis(genesis_state_root_hash: HashValue, validator_set: ValidatorSet) -> Self {
+        Self::new(
+            LedgerInfo::genesis(genesis_state_root_hash, validator_set),
+            BTreeMap::new(),
+        )
     }
 
     pub fn ledger_info(&self) -> &LedgerInfo {

--- a/types/src/validator_set.rs
+++ b/types/src/validator_set.rs
@@ -69,6 +69,10 @@ impl<PublicKey: VerifyingKey> ValidatorSet<PublicKey> {
         ValidatorSet(payload)
     }
 
+    pub fn empty() -> Self {
+        ValidatorSet::new(Vec::new())
+    }
+
     pub fn change_event_key() -> EventKey {
         EventKey::new_from_address(&account_config::validator_set_address(), 2)
     }


### PR DESCRIPTION
+ Rename and gate previous `::genesis` functions to `::mock_genesis`
to reflect their actual use as test data generators.

+ Now `BlockInfo::genesis`, `LedgerInfo::genesis`, and
`LedgerInfoWithSigs::genesis` are the "real" way to create genesis
types.

+ Add an assertion that genesis transaction always outputs a
validator_set; i.e., genesis is always an epoch change.

+ Gate `BlockInfo::random` behind test flags.

+ Update usages in various tests.