### PR TITLE
Make the ChainState APIs nicer to implement

### DIFF
--- a/language/vm/vm-runtime/src/execution_context.rs
+++ b/language/vm/vm-runtime/src/execution_context.rs
@@ -36,7 +36,7 @@ pub trait InterpreterContext {
         def: StructDef,
     ) -> VMResult<(bool, AbstractMemorySize<GasCarrier>)>;
 
-    fn borrow_global(&mut self, ap: &AccessPath, def: StructDef) -> VMResult<&mut GlobalValue>;
+    fn borrow_global(&mut self, ap: &AccessPath, def: StructDef) -> VMResult<&GlobalValue>;
 
     fn push_event(&mut self, event: ContractEvent);
 
@@ -110,7 +110,7 @@ impl<T: ChainState> InterpreterContext for T {
         })
     }
 
-    fn borrow_global(&mut self, ap: &AccessPath, def: StructDef) -> VMResult<&mut GlobalValue> {
+    fn borrow_global(&mut self, ap: &AccessPath, def: StructDef) -> VMResult<&GlobalValue> {
         match self.load_data(ap, def) {
             Ok(Some((_, g))) => Ok(g),
             Ok(None) => Err(

--- a/language/vm/vm-runtime/vm-runtime-types/src/values/values_impl.rs
+++ b/language/vm/vm-runtime/vm-runtime-types/src/values/values_impl.rs
@@ -158,9 +158,18 @@ pub enum IntegerValue {
 #[derive(Debug)]
 pub struct Struct(Container);
 
-/// A special value that lives in the global storage which you are allowed to take global
-/// references from. A global value also contains an internal flag, indicating whether
-/// the value has potentially been modified or not.
+/// A special value that lives in global storage.
+///
+/// Callers are allowed to take global references from a `GlobalValue`. A global value also contains
+/// an internal flag, indicating whether the value has potentially been modified or not.
+///
+/// For any given value in storage, only one `GlobalValue` may exist to represent it at any time.
+/// This means that:
+/// * `GlobalValue` **does not** and **cannot** implement `Clone`!
+/// * a borrowed reference through `borrow_global` is represented through a `&GlobalValue`.
+/// * `borrow_global_mut` is also represented through a `&GlobalValue` -- the bytecode verifier
+///   enforces mutability restrictions.
+/// * `move_from` is represented through an owned `GlobalValue`.
 #[derive(Debug)]
 pub struct GlobalValue {
     status: Rc<RefCell<GlobalDataStatus>>,


### PR DESCRIPTION
See commit messages for details. Add some comments and make the API nicer to use.

This is a precursor to splitting the Move VM out of vm-runtime so that it can be used by third parties.