### PR TITLE
Implement an LibraDB inspector to inspect local storage without running node

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2385,6 +2385,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "libra-storage-inspector"
+version = "0.1.0"
+dependencies = [
+ "anyhow 1.0.26 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libra-crypto 0.1.0",
+ "libra-logger 0.1.0",
+ "libradb 0.1.0",
+ "structopt 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tempfile 3.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "transaction-builder 0.1.0",
+]
+
+[[package]]
 name = "libra-swarm"
 version = "0.1.0"
 dependencies = [

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2391,6 +2391,7 @@ dependencies = [
  "anyhow 1.0.26 (registry+https://github.com/rust-lang/crates.io-index)",
  "libra-crypto 0.1.0",
  "libra-logger 0.1.0",
+ "libra-types 0.1.0",
  "libradb 0.1.0",
  "structopt 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "tempfile 3.1.0 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -77,6 +77,7 @@ members = [
     "storage/backup-restore",
     "storage/libradb",
     "storage/jellyfish-merkle",
+    "storage/inspector",
     "storage/schemadb",
     "storage/scratchpad",
     "storage/storage-client",

--- a/storage/inspector/Cargo.toml
+++ b/storage/inspector/Cargo.toml
@@ -10,9 +10,11 @@ edition = "2018"
 
 [dependencies]
 anyhow = "1.0"
-libradb = { path = "../libradb", version = "0.1.0" }
-libra-logger = { path = "../../common/logger", version = "0.1.0" }
 structopt = "0.3.2"
 tempfile = "3.1.0"
-transaction-builder = { path = "../../language/transaction-builder", version = "0.1.0" }
+
+libradb = { path = "../libradb", version = "0.1.0" }
 libra-crypto = { path = "../../crypto/crypto", version = "0.1.0" }
+libra-types = { path = "../../types", version = "0.1.0" }
+libra-logger = { path = "../../common/logger", version = "0.1.0" }
+transaction-builder = { path = "../../language/transaction-builder", version = "0.1.0" }

--- a/storage/inspector/Cargo.toml
+++ b/storage/inspector/Cargo.toml
@@ -1,0 +1,18 @@
+[package]
+name = "libra-storage-inspector"
+version = "0.1.0"
+authors = ["Libra Association <opensource@libra.org>"]
+repository = "https://github.com/libra/libra"
+homepage = "https://libra.org"
+license = "Apache-2.0"
+publish = false
+edition = "2018"
+
+[dependencies]
+anyhow = "1.0"
+libradb = { path = "../libradb", version = "0.1.0" }
+libra-logger = { path = "../../common/logger", version = "0.1.0" }
+structopt = "0.3.2"
+tempfile = "3.1.0"
+transaction-builder = { path = "../../language/transaction-builder", version = "0.1.0" }
+libra-crypto = { path = "../../crypto/crypto", version = "0.1.0" }

--- a/storage/inspector/src/main.rs
+++ b/storage/inspector/src/main.rs
@@ -1,0 +1,127 @@
+use anyhow::{ensure, Result};
+use libra_logger::prelude::*;
+use libradb::LibraDB;
+use std::path::PathBuf;
+use transaction_builder::get_transaction_name;
+
+use libra_crypto::hash::CryptoHash;
+use libra_crypto::HashValue;
+use structopt::StructOpt;
+
+#[derive(Debug, StructOpt)]
+struct Opt {
+    #[structopt(long, parse(from_os_str))]
+    db: PathBuf,
+}
+
+// Print out latest information stored in the DB.
+fn print_head(db: &LibraDB) {
+    let version = db
+        .get_latest_version()
+        .expect("get_latest_version throw error");
+
+    info!("Latest Version: {}", version);
+
+    let si = db
+        .get_startup_info()
+        .expect("Can't get startup info")
+        .expect("StartupInfo is empty, database is empty.");
+
+    info!(
+        "The latest ledger info: {}",
+        si.latest_ledger_info.ledger_info()
+    );
+
+    info!("Signatures: {:?}", si.latest_ledger_info.signatures());
+
+    info!(
+        "Current Validator Set: {}",
+        si.latest_validator_set
+            .expect("Unable to determine validator set, DB incorrect")
+    );
+
+    let tx = db
+        .get_transaction_with_proof(version, version, false)
+        .expect("Unable to load latest TXN");
+    info!(
+        "Current Transaction: {}",
+        tx.transaction.format_for_client(get_transaction_name)
+    );
+}
+
+// List all TXs from DB and verify their proofs
+fn verify_txs(db: &LibraDB) -> Result<()> {
+    let si = db
+        .get_startup_info()
+        .expect("Can't get startup info")
+        .expect("StartupInfo is empty, database is empty.");
+    let ledger_info = si.latest_ledger_info.ledger_info();
+
+    let latest_version = ledger_info.version();
+
+    for n in (1..latest_version).rev() {
+        let tx = db.get_transaction_with_proof(n, latest_version, true)?;
+
+        let tx_info = tx.proof.transaction_info();
+
+        let events_root_hash = tx.events.as_ref().map(|events| {
+            let event_hashes: Vec<_> = events.iter().map(ContractEvent::hash).collect();
+            InMemoryAccumulator::<EventAccumulatorHasher>::from_leaves(&event_hashes).root_hash()
+        });
+
+        // verify TX proof
+        tx.proof
+            .verify(ledger_info, tx.transaction.hash(), events_root_hash, n)?;
+    }
+    info!("Total TX verified: {}", latest_version);
+
+    Ok(())
+}
+
+// Verify the last accounts state tree by iterating through all accounts
+fn verify_latest_account_state(db: &LibraDB) -> Result<()> {
+    let version = db.get_latest_version()?;
+    let backup = db.get_backup_handler();
+
+    let iter = backup.get_account_iter(version)?;
+
+    let mut total = 0;
+    for i in iter {
+        let (addr_hash, blob) = i?;
+        ensure!(addr_hash != HashValue::zero(), "Invalid address hash!");
+        ensure!(blob.hash() != HashValue::zero(), "Invalid blob!");
+        total += 1;
+    }
+    info!("Total account verified: {}", total);
+
+    // TODO: verify the root hash is correct
+
+    Ok(())
+}
+
+fn main() {
+    let _logger = libra_logger::set_global_logger(false, None);
+
+    let opt = Opt::from_args();
+
+    let p = opt.db.as_path();
+
+    if !p.is_dir() {
+        info!("Invalid Directory {:?}!", p);
+        std::process::exit(-1);
+    }
+
+    let log_dir = tempfile::tempdir().expect("Unable to get temp dir");
+    info!("Opening DB at: {:?}, log at {:?}", p, log_dir.path());
+
+    let db = LibraDB::open(p, true, Some(log_dir.path())).expect("Unable to open LibraDB");
+    info!("DB opened successfully.");
+
+    print_head(&db);
+
+    verify_txs(&db).expect("Unable to verify all TXs");
+
+    verify_latest_account_state(&db).expect("Unable to verify account state");
+
+    info!("Successfully verified database.");
+}

--- a/storage/inspector/src/main.rs
+++ b/storage/inspector/src/main.rs
@@ -1,3 +1,8 @@
+// Copyright (c) The Libra Core Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+#![forbid(unsafe_code)]
+
 use anyhow::{ensure, Result};
 use libra_logger::prelude::*;
 use libradb::LibraDB;
@@ -14,7 +19,7 @@ struct Opt {
     db: PathBuf,
 }
 
-// Print out latest information stored in the DB.
+/// Print out latest information stored in the DB.
 fn print_head(db: &LibraDB) {
     let version = db
         .get_latest_version()
@@ -49,8 +54,8 @@ fn print_head(db: &LibraDB) {
     );
 }
 
-// List all TXs from DB and verify their proofs
-fn verify_txs(db: &LibraDB) -> Result<()> {
+/// List all TXNs from DB and verify their proofs
+fn verify_txns(db: &LibraDB) -> Result<()> {
     let si = db
         .get_startup_info()
         .expect("Can't get startup info")
@@ -73,7 +78,7 @@ fn verify_txs(db: &LibraDB) -> Result<()> {
         tx.proof
             .verify(ledger_info, tx.transaction.hash(), events_root_hash, n)?;
     }
-    info!("Total TX verified: {}", latest_version);
+    info!("Total TXNs verified: {}", latest_version);
 
     Ok(())
 }
@@ -119,7 +124,7 @@ fn main() {
 
     print_head(&db);
 
-    verify_txs(&db).expect("Unable to verify all TXs");
+    verify_txns(&db).expect("Unable to verify all TXNs");
 
     verify_latest_account_state(&db).expect("Unable to verify account state");
 

--- a/storage/libradb/src/lib.rs
+++ b/storage/libradb/src/lib.rs
@@ -172,18 +172,17 @@ impl LibraDB {
         let path = db_root_path.as_ref().join("libradb");
         let instant = Instant::now();
 
-        let db = Arc::new(match readonly {
-            true => {
-                ensure!(path.as_path().is_dir(), "libradb directory is not found.");
-                ensure!(
-                    log_dir.is_some(),
-                    "Must provide log_dir if opening in readonly mode."
-                );
-                let db_log_dir = log_dir.unwrap().to_str().expect("Invalid directory");
-                info!("log stored at {}", db_log_dir);
-                DB::open_readonly(path.clone(), cf_opts_map, db_log_dir)?
-            }
-            false => DB::open(path.clone(), cf_opts_map)?,
+        let db = Arc::new(if readonly {
+            ensure!(path.as_path().is_dir(), "libradb directory is not found.");
+            ensure!(
+                log_dir.is_some(),
+                "Must provide log_dir if opening in readonly mode."
+            );
+            let db_log_dir = log_dir.unwrap().to_str().expect("Invalid directory");
+            info!("log stored at {}", db_log_dir);
+            DB::open_readonly(path.clone(), cf_opts_map, db_log_dir)?
+        } else {
+            DB::open(path.clone(), cf_opts_map)?
         });
 
         info!(

--- a/storage/libradb/src/lib.rs
+++ b/storage/libradb/src/lib.rs
@@ -134,8 +134,11 @@ impl LibraDB {
     /// Config parameter for the pruner.
     const NUM_HISTORICAL_VERSIONS_TO_KEEP: u64 = 1_000_000;
 
-    /// This creates an empty LibraDB instance on disk or opens one if it already exists.
-    pub fn new<P: AsRef<Path> + Clone>(db_root_path: P) -> Self {
+    pub fn open<P: AsRef<Path> + Clone>(
+        db_root_path: P,
+        readonly: bool,
+        log_dir: Option<&Path>,
+    ) -> Result<Self> {
         let cf_opts_map: ColumnFamilyOptionsMap = [
             (
                 /* LedgerInfo CF = */ DEFAULT_CF_NAME,
@@ -168,7 +171,20 @@ impl LibraDB {
 
         let path = db_root_path.as_ref().join("libradb");
         let instant = Instant::now();
-        let db = Arc::new(DB::open(path.clone(), cf_opts_map).expect("LibraDB open failed"));
+
+        let db = Arc::new(match readonly {
+            true => {
+                ensure!(path.as_path().is_dir(), "libradb directory is not found.");
+                ensure!(
+                    log_dir.is_some(),
+                    "Must provide log_dir if opening in readonly mode."
+                );
+                let db_log_dir = log_dir.unwrap().to_str().expect("Invalid directory");
+                info!("log stored at {}", db_log_dir);
+                DB::open_readonly(path.clone(), cf_opts_map, db_log_dir)?
+            }
+            false => DB::open(path.clone(), cf_opts_map)?,
+        });
 
         info!(
             "Opened LibraDB at {:?} in {} ms",
@@ -176,7 +192,7 @@ impl LibraDB {
             instant.elapsed().as_millis()
         );
 
-        LibraDB {
+        Ok(LibraDB {
             db: Arc::clone(&db),
             event_store: EventStore::new(Arc::clone(&db)),
             ledger_store: Arc::new(LedgerStore::new(Arc::clone(&db))),
@@ -184,7 +200,12 @@ impl LibraDB {
             transaction_store: Arc::new(TransactionStore::new(Arc::clone(&db))),
             system_store: SystemStore::new(Arc::clone(&db)),
             pruner: Pruner::new(Arc::clone(&db), Self::NUM_HISTORICAL_VERSIONS_TO_KEEP),
-        }
+        })
+    }
+
+    /// This creates an empty LibraDB instance on disk or opens one if it already exists.
+    pub fn new<P: AsRef<Path> + Clone>(db_root_path: P) -> Self {
+        Self::open(db_root_path, false, None).expect("Unable to open LibraDB")
     }
 
     // ================================== Public API ==================================
@@ -329,7 +350,7 @@ impl LibraDB {
     }
 
     /// Gets the latest version number available in the ledger.
-    fn get_latest_version(&self) -> Result<Version> {
+    pub fn get_latest_version(&self) -> Result<Version> {
         Ok(self
             .ledger_store
             .get_latest_ledger_info()?
@@ -844,7 +865,7 @@ impl LibraDB {
         Ok(())
     }
 
-    fn get_transaction_with_proof(
+    pub fn get_transaction_with_proof(
         &self,
         version: Version,
         ledger_version: Version,

--- a/storage/libradb/src/lib.rs
+++ b/storage/libradb/src/lib.rs
@@ -44,7 +44,7 @@ use crate::{
     system_store::SystemStore,
     transaction_store::TransactionStore,
 };
-use anyhow::{ensure, Result};
+use anyhow::{ensure, format_err, Result};
 use itertools::{izip, zip_eq};
 use jellyfish_merkle::restore::JellyfishMerkleRestore;
 use libra_crypto::hash::{CryptoHash, HashValue};
@@ -137,7 +137,7 @@ impl LibraDB {
     pub fn open<P: AsRef<Path> + Clone>(
         db_root_path: P,
         readonly: bool,
-        log_dir: Option<&Path>,
+        log_dir: Option<P>,
     ) -> Result<Self> {
         let cf_opts_map: ColumnFamilyOptionsMap = [
             (
@@ -174,13 +174,10 @@ impl LibraDB {
 
         let db = Arc::new(if readonly {
             ensure!(path.as_path().is_dir(), "libradb directory is not found.");
-            ensure!(
-                log_dir.is_some(),
-                "Must provide log_dir if opening in readonly mode."
-            );
-            let db_log_dir = log_dir.unwrap().to_str().expect("Invalid directory");
-            info!("log stored at {}", db_log_dir);
-            DB::open_readonly(path.clone(), cf_opts_map, db_log_dir)?
+            let db_log_dir = log_dir
+                .ok_or_else(|| format_err!("Must provide log_dir if opening in readonly mode."))?;
+            info!("log stored at {:?}", db_log_dir.as_ref());
+            DB::open_readonly(path.clone(), cf_opts_map, db_log_dir.as_ref().to_path_buf())?
         } else {
             DB::open(path.clone(), cf_opts_map)?
         });

--- a/storage/schemadb/src/lib.rs
+++ b/storage/schemadb/src/lib.rs
@@ -228,10 +228,7 @@ impl DB {
     ) -> Result<Self> {
         let mut db_opts = DBOptions::new();
 
-        // do not create if not exists
         db_opts.create_if_missing(false);
-
-        // Put LOG file somewhere else
         db_opts.set_db_log_dir(db_log_dir);
 
         return DB::open_cf_readonly(db_opts, &path, cf_opts_map.into_iter().collect());

--- a/storage/schemadb/src/lib.rs
+++ b/storage/schemadb/src/lib.rs
@@ -231,7 +231,7 @@ impl DB {
         db_opts.create_if_missing(false);
         db_opts.set_db_log_dir(db_log_dir);
 
-        return DB::open_cf_readonly(db_opts, &path, cf_opts_map.into_iter().collect());
+        DB::open_cf_readonly(db_opts, &path, cf_opts_map.into_iter().collect())
     }
 
     fn open_cf<'a, P, T>(opts: DBOptions, path: P, cfds: Vec<T>) -> Result<DB>

--- a/storage/schemadb/src/lib.rs
+++ b/storage/schemadb/src/lib.rs
@@ -203,7 +203,7 @@ impl DB {
             return DB::open_cf(db_opts, &path, cf_opts_map.into_iter().collect());
         }
 
-        // If db doesn't exist, create one with all column families if requested.
+        // If db doesn't exist, create a db first with all column families.
         db_opts.create_if_missing(true);
 
         let mut db = DB::open_cf(

--- a/storage/schemadb/src/lib.rs
+++ b/storage/schemadb/src/lib.rs
@@ -224,12 +224,17 @@ impl DB {
     pub fn open_readonly<P: AsRef<Path>>(
         path: P,
         cf_opts_map: ColumnFamilyOptionsMap,
-        db_log_dir: &str,
+        db_log_dir: P,
     ) -> Result<Self> {
         let mut db_opts = DBOptions::new();
 
         db_opts.create_if_missing(false);
-        db_opts.set_db_log_dir(db_log_dir);
+        db_opts.set_db_log_dir(db_log_dir.as_ref().to_str().ok_or_else(|| {
+            format_err!(
+                "db_log_dir {:?} can not be converted to string.",
+                db_log_dir.as_ref()
+            )
+        })?);
 
         DB::open_cf_readonly(db_opts, &path, cf_opts_map.into_iter().collect())
     }

--- a/storage/schemadb/src/lib.rs
+++ b/storage/schemadb/src/lib.rs
@@ -17,7 +17,7 @@
 pub mod schema;
 
 use crate::schema::{KeyCodec, Schema, SeekKeyCodec, ValueCodec};
-use anyhow::{format_err, Result};
+use anyhow::{bail, format_err, Result};
 use libra_metrics::OpMetrics;
 use once_cell::sync::Lazy;
 use rocksdb::{
@@ -226,6 +226,10 @@ impl DB {
         cf_opts_map: ColumnFamilyOptionsMap,
         db_log_dir: P,
     ) -> Result<Self> {
+        if !db_exists(path.as_ref()) {
+            bail!("DB doesn't exists.");
+        }
+
         let mut db_opts = DBOptions::new();
 
         db_opts.create_if_missing(false);


### PR DESCRIPTION
A naive implementation to inspect and verify some DB information.  


```$ RUST_BACKTRACE=1 cargo run -p libra-storage-inspector -- --db /tmp/libra/
    Finished dev [unoptimized + debuginfo] target(s) in 0.37s
     Running `target/debug/libra-storage-inspector --db /tmp/libra/`
I0225 14:46:32.318460 4694003136 storage/inspector/src/main.rs:134] Opening DB at: "/tmp/libra/", log at "/var/folders/ml/kgz_nqm17zncq4rnkty4s40h0000gn/T/.tmpD4M53V"
I0225 14:46:32.319634 4694003136 storage/libradb/src/lib.rs:182] log stored at /var/folders/ml/kgz_nqm17zncq4rnkty4s40h0000gn/T/.tmpD4M53V
I0225 14:46:32.331778 4694003136 storage/libradb/src/lib.rs:188] Opened LibraDB at "/tmp/libra/libradb" in 12 ms
I0225 14:46:32.332337 4694003136 storage/inspector/src/main.rs:137] DB opened successfully.
I0225 14:46:32.333968 4694003136 storage/inspector/src/main.rs:46] Version: 120
I0225 14:46:32.334023 4694003136 storage/inspector/src/main.rs:48] The latest ledger info: LedgerInfo: [commit_info: BlockInfo: [epoch: 1, round: 114, id: ce417afd, version: 120, timestamp (us): 1582666782133797, next_validator_set: None]]
I0225 14:46:32.334107 4694003136 storage/inspector/src/main.rs:53] Signatures: {3203fb165486ec1a985a01acacb6303d023beb16655f5ff683ad680a86166dd8: Ed25519Signature(Signature( R: CompressedEdwardsY: [182, 224, 89, 238, 120, 33, 199, 24, 230, 44, 2, 67, 226, 91, 12, 217, 195, 117, 236, 175, 98, 33, 215, 151, 83, 181, 66, 54, 106, 127, 1, 90], s: Scalar{
        bytes: [22, 225, 0, 243, 155, 67, 195, 240, 142, 59, 152, 151, 158, 155, 27, 255, 121, 45, 113, 156, 65, 34, 76, 85, 234, 77, 248, 37, 231, 212, 202, 11],
} )), 78633fc6c6133e0a865d69d3f7a9a65f16a3cd91ec583d4eb3e2735e4c849536: Ed25519Signature(Signature( R: CompressedEdwardsY: [6, 175, 171, 41, 196, 178, 166, 171, 4, 127, 73, 206, 255, 29, 248, 255, 90, 41, 49, 122, 144, 223, 48, 170, 40, 161, 152, 23, 71, 196, 143, 87], s: Scalar{
        bytes: [80, 13, 151, 42, 48, 177, 229, 204, 64, 144, 157, 207, 247, 63, 81, 120, 238, 145, 32, 79, 122, 0, 129, 158, 117, 69, 202, 110, 28, 74, 141, 7],
} )), f3616cc079c0be423d52a6eb5de329515698e540405c309b50bbe3c613fdea5e: Ed25519Signature(Signature( R: CompressedEdwardsY: [14, 49, 9, 203, 202, 225, 81, 72, 115, 156, 188, 84, 71, 19, 69, 8, 14, 37, 7, 181, 248, 157, 161, 171, 49, 227, 220, 211, 77, 0, 159, 64], s: Scalar{
        bytes: [121, 210, 177, 96, 92, 191, 0, 150, 42, 47, 123, 24, 75, 111, 212, 131, 245, 216, 141, 202, 15, 147, 72, 60, 37, 102, 136, 192, 129, 168, 82, 7],
} ))}
I0225 14:46:32.334654 4694003136 storage/inspector/src/main.rs:55] Current Validator Set: [account_address: 3203fb16 account_address: 78633fc6 account_address: f3616cc0 account_address: fd6ab820 ]
I0225 14:46:32.338758 4694003136 storage/inspector/src/main.rs:64] Total Accounts: 14
Transaction 120: SignedTransaction { 
 raw_txn: RawTransaction { 
        sender: 042efa66e4e03efd34612c627c91f7080d463e067a3213e0092ea0f541222955, 
        sequence_number: 0, 
        payload: {, 
                transaction: peer_to_peer_transaction, 
                args: [ 
                        {ADDRESS: 866968dd61f95f5578a2ec120e68f62b14192539348606e33236b7ef1c808330},
                        {U64: 10000000}, 
                ]
        }, 
        max_gas_amount: 140000, 
        gas_unit_price: 0, 
        expiration_time: 1582666881s, 
}, 
 public_key: Ed25519PublicKey(c9ebb9f82f0d9c6f75262232a7bed008f449aad11df4deac6d822b7487d4e40b), 
 signature: Ed25519Signature(
    Signature( R: CompressedEdwardsY: [212, 128, 178, 103, 104, 128, 171, 228, 106, 229, 212, 213, 139, 137, 30, 170, 100, 212, 31, 41, 73, 94, 95, 138, 172, 198, 102, 76, 160, 52, 92, 223], s: Scalar{
        bytes: [160, 52, 181, 33, 144, 165, 57, 237, 208, 232, 35, 20, 34, 107, 250, 1, 233, 35, 71, 30, 170, 128, 247, 203, 107, 247, 232, 31, 154, 221, 246, 1],
    } ),
), 
 }
libra-storage-inspector 0.1.0

USAGE:
    libra-storage-inspector --db <db> [SUBCOMMAND]

FLAGS:
    -h, --help       Prints help information
    -V, --version    Prints version information

OPTIONS:
        --db <db>    

SUBCOMMANDS:
    help             Prints this message or the help of the given subcommand(s)
    list-txns        
    print-account    
    print-txn        

```