### PR TITLE
[types] Make core code address cosntant

### DIFF
--- a/client/cli/src/client_proxy.rs
+++ b/client/cli/src/client_proxy.rs
@@ -17,8 +17,8 @@ use libra_types::{
     access_path::AccessPath,
     account_address::{AccountAddress, ADDRESS_LENGTH},
     account_config::{
-        association_address, core_code_address, AccountResource, ACCOUNT_RECEIVED_EVENT_PATH,
-        ACCOUNT_SENT_EVENT_PATH,
+        association_address, AccountResource, ACCOUNT_RECEIVED_EVENT_PATH, ACCOUNT_SENT_EVENT_PATH,
+        CORE_CODE_ADDRESS,
     },
     account_state_blob::{AccountStateBlob, AccountStateWithProof},
     contract_event::{ContractEvent, EventWithProof},
@@ -566,7 +566,7 @@ impl ClientProxy {
         let paths: Vec<AccessPath> = serde_json::from_str(str::from_utf8(&output.stdout)?)?;
         let mut dependencies = vec![];
         for path in paths {
-            if path.address != core_code_address() {
+            if path.address != CORE_CODE_ADDRESS {
                 if let (Some(blob), _) = self.client.get_account_blob(path.address)? {
                     let account_state = AccountState::try_from(&blob)?;
                     if let Some(code) = account_state.get(&path.path) {

--- a/language/e2e-tests/src/tests/verify_txn.rs
+++ b/language/e2e-tests/src/tests/verify_txn.rs
@@ -14,7 +14,7 @@ use compiler::Compiler;
 use libra_config::config::{NodeConfig, VMPublishingOption};
 use libra_crypto::ed25519::*;
 use libra_types::{
-    account_config::core_code_address,
+    account_config::CORE_CODE_ADDRESS,
     test_helpers::transaction_test_helpers,
     transaction::{
         Script, TransactionArgument, TransactionPayload, TransactionStatus,
@@ -58,7 +58,7 @@ fn verify_reserved_sender() {
         let (private_key, public_key) = compat::generate_keypair(None);
         let program = encode_transfer_script(sender.address(), 100);
         let signed_txn = transaction_test_helpers::get_test_signed_txn(
-            core_code_address(),
+            CORE_CODE_ADDRESS,
             0,
             &private_key,
             public_key,

--- a/language/stdlib/src/lib.rs
+++ b/language/stdlib/src/lib.rs
@@ -14,10 +14,10 @@ use move_ir_types::ast::Loc;
 use once_cell::sync::Lazy;
 
 static ANNOTATED_STDLIB: Lazy<(Vec<VerifiedModule>, SourceMap<Loc>)> =
-    Lazy::new(|| build_stdlib(account_config::core_code_address()));
+    Lazy::new(|| build_stdlib(account_config::CORE_CODE_ADDRESS));
 
 /// Returns a reference to the standard library, compiled with the
-/// [default address](account_config::core_code_address).
+/// [default address](account_config::CORE_CODE_ADDRESS).
 ///
 /// The order the modules are presented in is important: later modules depend on earlier ones.
 pub fn stdlib_modules() -> &'static [VerifiedModule] {
@@ -34,7 +34,7 @@ pub fn stdlib_source_map() -> &'static [ModuleSourceMap<Loc>] {
 
 /// Builds and returns a copy of the standard library with this address as the self address.
 ///
-/// A copy of the stdlib built with the [default address](account_config::core_code_address) is
+/// A copy of the stdlib built with the [default address](account_config::CORE_CODE_ADDRESS) is
 /// available through [`stdlib_modules`].
 pub fn build_stdlib(address: AccountAddress) -> (Vec<VerifiedModule>, SourceMap<Loc>) {
     let mut stdlib_modules = vec![];

--- a/language/vm/vm-runtime/src/interpreter.rs
+++ b/language/vm/vm-runtime/src/interpreter.rs
@@ -19,7 +19,7 @@ use libra_logger::prelude::*;
 use libra_types::{
     access_path::AccessPath,
     account_address::AccountAddress,
-    account_config::core_code_address,
+    account_config::CORE_CODE_ADDRESS,
     byte_array::ByteArray,
     contract_event::ContractEvent,
     event::EventKey,
@@ -791,7 +791,7 @@ impl<'txn> Interpreter<'txn> {
         let account_module = runtime.get_loaded_module(&ACCOUNT_MODULE, context)?;
         let account_resource = self.operand_stack.pop_as::<Struct>()?;
         let address = self.operand_stack.pop_as::<AccountAddress>()?;
-        if address == core_code_address() {
+        if address == CORE_CODE_ADDRESS {
             return Err(VMStatus::new(StatusCode::CREATE_NULL_ACCOUNT));
         }
         self.save_account(runtime, context, account_module, address, account_resource)

--- a/language/vm/vm-runtime/src/system_module_names.rs
+++ b/language/vm/vm-runtime/src/system_module_names.rs
@@ -9,49 +9,49 @@ use once_cell::sync::Lazy;
 /// The ModuleId for the Account module
 pub static ACCOUNT_MODULE: Lazy<ModuleId> = Lazy::new(|| {
     ModuleId::new(
-        account_config::core_code_address(),
+        account_config::CORE_CODE_ADDRESS,
         Identifier::new("LibraAccount").unwrap(),
     )
 });
 /// The ModuleId for the LibraTransactionTimeout module
 pub static LIBRA_TRANSACTION_TIMEOUT: Lazy<ModuleId> = Lazy::new(|| {
     ModuleId::new(
-        account_config::core_code_address(),
+        account_config::CORE_CODE_ADDRESS,
         Identifier::new("LibraTransactionTimeout").unwrap(),
     )
 });
 /// The ModuleId for the LibraCoin module
 pub static COIN_MODULE: Lazy<ModuleId> = Lazy::new(|| {
     ModuleId::new(
-        account_config::core_code_address(),
+        account_config::CORE_CODE_ADDRESS,
         Identifier::new("LibraCoin").unwrap(),
     )
 });
 /// The ModuleId for the Event
 pub static EVENT_MODULE: Lazy<ModuleId> = Lazy::new(|| {
     ModuleId::new(
-        account_config::core_code_address(),
+        account_config::CORE_CODE_ADDRESS,
         Identifier::new("Event").unwrap(),
     )
 });
 /// The ModuleId for the validator config
 pub static VALIDATOR_CONFIG_MODULE: Lazy<ModuleId> = Lazy::new(|| {
     ModuleId::new(
-        account_config::core_code_address(),
+        account_config::CORE_CODE_ADDRESS,
         Identifier::new("ValidatorConfig").unwrap(),
     )
 });
 /// The ModuleId for the libra system module
 pub static LIBRA_SYSTEM_MODULE: Lazy<ModuleId> = Lazy::new(|| {
     ModuleId::new(
-        account_config::core_code_address(),
+        account_config::CORE_CODE_ADDRESS,
         Identifier::new("LibraSystem").unwrap(),
     )
 });
 /// The ModuleId for the gas schedule module
 pub static GAS_SCHEDULE_MODULE: Lazy<ModuleId> = Lazy::new(|| {
     ModuleId::new(
-        account_config::core_code_address(),
+        account_config::CORE_CODE_ADDRESS,
         Identifier::new("GasSchedule").unwrap(),
     )
 });

--- a/language/vm/vm-runtime/src/system_txn/block_metadata_processor.rs
+++ b/language/vm/vm-runtime/src/system_txn/block_metadata_processor.rs
@@ -8,7 +8,7 @@ use crate::{
 };
 use libra_types::transaction::TransactionStatus;
 use libra_types::{
-    account_config::core_code_address,
+    account_config::CORE_CODE_ADDRESS,
     block_metadata::BlockMetadata,
     identifier::Identifier,
     transaction::TransactionOutput,
@@ -36,7 +36,7 @@ pub(crate) fn process_block_metadata(
     //    might be useful here.
     // 3. We set the max gas to a big number just to get rid of the potential out of gas error.
     let mut txn_data = TransactionMetadata::default();
-    txn_data.sender = core_code_address();
+    txn_data.sender = CORE_CODE_ADDRESS;
     txn_data.max_gas_amount = GasUnits::new(std::u64::MAX);
 
     let mut interpreter_context =

--- a/language/vm/vm-runtime/vm-runtime-types/src/native_functions/dispatch.rs
+++ b/language/vm/vm-runtime/vm-runtime-types/src/native_functions/dispatch.rs
@@ -134,7 +134,7 @@ type NativeFunctionMap = HashMap<ModuleId, HashMap<Identifier, NativeFunction>>;
 static NATIVE_FUNCTION_MAP: Lazy<NativeFunctionMap> = Lazy::new(|| {
     use SignatureToken::*;
     let mut m: NativeFunctionMap = HashMap::new();
-    let addr = account_config::core_code_address();
+    let addr = account_config::CORE_CODE_ADDRESS;
     // Hash
     add!(
         m,

--- a/language/vm/vm-runtime/vm-runtime-types/src/native_structs/dispatch.rs
+++ b/language/vm/vm-runtime/vm-runtime-types/src/native_structs/dispatch.rs
@@ -62,7 +62,7 @@ type NativeStructMap = HashMap<ModuleId, HashMap<Identifier, NativeStruct>>;
 
 static NATIVE_STRUCT_MAP: Lazy<NativeStructMap> = Lazy::new(|| {
     let mut m: NativeStructMap = HashMap::new();
-    let addr = account_config::core_code_address();
+    let addr = account_config::CORE_CODE_ADDRESS;
     add!(
         m,
         addr,

--- a/types/src/account_address.rs
+++ b/types/src/account_address.rs
@@ -21,7 +21,7 @@ const SHORT_STRING_LENGTH: usize = 4;
 
 /// A struct that represents an account address.
 /// Currently Public Key is used.
-#[derive(Ord, PartialOrd, Eq, PartialEq, Hash, Default, Clone, Copy, CryptoHasher)]
+#[derive(Ord, PartialOrd, Eq, PartialEq, Hash, Clone, Copy, CryptoHasher)]
 #[cfg_attr(any(test, feature = "fuzzing"), derive(Arbitrary))]
 pub struct AccountAddress([u8; ADDRESS_LENGTH]);
 
@@ -29,6 +29,11 @@ impl AccountAddress {
     pub const fn new(address: [u8; ADDRESS_LENGTH]) -> Self {
         AccountAddress(address)
     }
+
+    pub const DEFAULT: Self = Self([
+        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 0,
+    ]);
 
     pub fn random() -> Self {
         let mut rng = OsRng::new().expect("can't access OsRng");
@@ -74,6 +79,12 @@ impl AccountAddress {
         };
 
         AccountAddress::try_from(padded_result)
+    }
+}
+
+impl Default for AccountAddress {
+    fn default() -> AccountAddress {
+        AccountAddress::DEFAULT
     }
 }
 

--- a/types/src/account_config.rs
+++ b/types/src/account_config.rs
@@ -54,9 +54,7 @@ pub fn received_event_name() -> &'static IdentStr {
     &*RECEIVED_EVENT_NAME
 }
 
-pub fn core_code_address() -> AccountAddress {
-    AccountAddress::default()
-}
+pub const CORE_CODE_ADDRESS: AccountAddress = AccountAddress::DEFAULT;
 
 pub fn association_address() -> AccountAddress {
     AccountAddress::from_hex_literal("0xA550C18")
@@ -80,7 +78,7 @@ pub fn discovery_set_address() -> AccountAddress {
 
 pub fn account_struct_tag() -> StructTag {
     StructTag {
-        address: core_code_address(),
+        address: CORE_CODE_ADDRESS,
         module: account_module_name().to_owned(),
         name: account_struct_name().to_owned(),
         type_params: vec![],
@@ -89,7 +87,7 @@ pub fn account_struct_tag() -> StructTag {
 
 pub fn sent_payment_tag() -> StructTag {
     StructTag {
-        address: core_code_address(),
+        address: CORE_CODE_ADDRESS,
         module: account_module_name().to_owned(),
         name: sent_event_name().to_owned(),
         type_params: vec![],
@@ -98,7 +96,7 @@ pub fn sent_payment_tag() -> StructTag {
 
 pub fn received_payment_tag() -> StructTag {
     StructTag {
-        address: core_code_address(),
+        address: CORE_CODE_ADDRESS,
         module: account_module_name().to_owned(),
         name: received_event_name().to_owned(),
         type_params: vec![],

--- a/types/src/discovery_set.rs
+++ b/types/src/discovery_set.rs
@@ -31,7 +31,7 @@ pub fn discovery_set_struct_name() -> &'static IdentStr {
 pub fn discovery_set_tag() -> StructTag {
     StructTag {
         name: discovery_set_struct_name().to_owned(),
-        address: account_config::core_code_address(),
+        address: account_config::CORE_CODE_ADDRESS,
         module: discovery_set_module_name().to_owned(),
         type_params: vec![],
     }

--- a/types/src/validator_set.rs
+++ b/types/src/validator_set.rs
@@ -39,7 +39,7 @@ pub fn validator_set_struct_name() -> &'static IdentStr {
 pub fn validator_set_tag() -> StructTag {
     StructTag {
         name: validator_set_struct_name().to_owned(),
-        address: account_config::core_code_address(),
+        address: account_config::CORE_CODE_ADDRESS,
         module: validator_set_module_name().to_owned(),
         type_params: vec![],
     }


### PR DESCRIPTION
## Motivation

- Made account_config::core_code_address() a constant
- Makes the address more explicit, instead of relying on the derived default (formatting is a bit long and funny though)
- This allows for pattern matching against the CORE_CODE_ADDRESS 

## Test Plan

- cargo test
