### PR TITLE
[GHA][LBT] Find PR number in commit message

### DIFF
--- a/.github/workflows/land-blocking.yml
+++ b/.github/workflows/land-blocking.yml
@@ -33,23 +33,14 @@ jobs:
           github-token: ${{secrets.GITHUB_TOKEN}}
           script: |
             // Find the number of the pull request that trigggers this push
-            const pulls = await github.pulls.list(
-              {
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                state: "open",
-                sort: "updated",
-              }
-            );
             let pr_num = 0;
-            for (const pull of pulls.data) {
-              if (pull.head.sha === context.sha) {
-                pr_num = pull.number;
-                break;
-                }
-            }
-            if (pr_num === 0) {
-              console.warn("Did not find original pull request. -\\_(O_o)_/-");
+            let commit_message = context.payload.head_commit.message;
+            let re = /.*[^]Closes:\s\#(\d+)[^]Approved\sby:\s\w+$/;
+            if (re.test(commit_message)) {
+              let match = re.exec(commit_message);
+              pr_num = match[1];
+            } else {
+              console.warn("Did not find pull request num in commit message. -\\_(O_o)_/-");
               return;
             }
             // Read and check cluster test results


### PR DESCRIPTION
## Motivation
When we run land-blocking test in GitHub Actions, we want to post the
test results in the original PR. At land time, bors rebases the PR on
top of master and pushes it to the auto branch for verification work.
The head commit in the push event doesn't correspond to any PR, so we
cannot use it to look up the original PR, as it is currently done.

Thanks to metajack brilliant idea, we can however look up the original
PR number in the commit message. This is the trace bors appends to the
commit message in the land workflow.

## Test Plan
Canary with 639055b in https://github.com/sausagee/libra/pull/8 
- Verified the triggered workflow completes
![image](https://user-images.githubusercontent.com/7528420/74869239-77a16400-530c-11ea-991a-402bc8b77dd7.png)

- Verified the comment step in the workflow should look up the PR number from the last two lines in the message

![image](https://user-images.githubusercontent.com/7528420/74868869-cc90aa80-530b-11ea-8b4c-46e86d4a75ee.png)

- Verified the results is not sent to the spurious PR mentioned in the canary commit 
![image](https://user-images.githubusercontent.com/7528420/74868801-aff47280-530b-11ea-811a-8bffc4f46e3f.png)
