### PR TITLE
[cluster-test][k8s] Create cluster_swarm with libra_swarm like API

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -127,6 +127,18 @@ version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "async-compression"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "bytes 0.5.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "flate2 1.0.13 (registry+https://github.com/rust-lang/crates.io-index)",
+ "futures-core 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "memchr 2.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "pin-project-lite 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "async-stream"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -677,6 +689,8 @@ dependencies = [
  "generate-keypair 0.1.0",
  "hex 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "itertools 0.8.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "k8s-openapi 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "kube 0.25.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "libra-config 0.1.0",
  "libra-crypto 0.1.0",
  "libra-types 0.1.0",
@@ -691,6 +705,7 @@ dependencies = [
  "rusoto_s3 0.42.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.48 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_yaml 0.8.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "slog 2.5.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "slog-envlogger 2.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "slog-scope 4.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1414,6 +1429,19 @@ version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "foreign-types"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "foreign-types-shared 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "foreign-types-shared"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
 name = "fs_extra"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1543,6 +1571,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 [[package]]
 name = "futures-task"
 version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "futures-timer"
+version = "3.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -1852,6 +1885,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "hyper-tls"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "bytes 0.5.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "hyper 0.13.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "native-tls 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio-tls 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "idna"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2010,6 +2055,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "k8s-openapi"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "base64 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "bytes 0.5.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "chrono 0.4.10 (registry+https://github.com/rust-lang/crates.io-index)",
+ "http 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "percent-encoding 2.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde-value 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_json 1.0.48 (registry+https://github.com/rust-lang/crates.io-index)",
+ "url 2.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "keccak"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2021,6 +2082,33 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "winapi 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "winapi-build 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "kube"
+version = "0.25.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "base64 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "bytes 0.5.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "chrono 0.4.10 (registry+https://github.com/rust-lang/crates.io-index)",
+ "dirs 2.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "either 1.5.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "futures 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "futures-timer 3.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "futures-util 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "http 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "k8s-openapi 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "openssl 0.10.28 (registry+https://github.com/rust-lang/crates.io-index)",
+ "reqwest 0.10.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_derive 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_json 1.0.48 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_yaml 0.8.11 (registry+https://github.com/rust-lang/crates.io-index)",
+ "thiserror 1.0.11 (registry+https://github.com/rust-lang/crates.io-index)",
+ "time 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "url 2.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -2452,6 +2540,9 @@ dependencies = [
 [[package]]
 name = "libra-util"
 version = "0.1.0"
+dependencies = [
+ "tokio 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
+]
 
 [[package]]
 name = "libra-vault-client"
@@ -2798,6 +2889,23 @@ version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "native-tls"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.67 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "openssl 0.10.28 (registry+https://github.com/rust-lang/crates.io-index)",
+ "openssl-probe 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "openssl-sys 0.9.54 (registry+https://github.com/rust-lang/crates.io-index)",
+ "schannel 0.1.17 (registry+https://github.com/rust-lang/crates.io-index)",
+ "security-framework 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "security-framework-sys 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tempfile 3.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "net2"
 version = "0.2.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3058,9 +3166,42 @@ version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "openssl"
+version = "0.10.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "bitflags 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cfg-if 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)",
+ "foreign-types 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.67 (registry+https://github.com/rust-lang/crates.io-index)",
+ "openssl-sys 0.9.54 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "openssl-probe"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "openssl-sys"
+version = "0.9.54"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "autocfg 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cc 1.0.50 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.67 (registry+https://github.com/rust-lang/crates.io-index)",
+ "pkg-config 0.3.17 (registry+https://github.com/rust-lang/crates.io-index)",
+ "vcpkg 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "ordered-float"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "num-traits 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
+]
 
 [[package]]
 name = "owning_ref"
@@ -3794,6 +3935,7 @@ name = "reqwest"
 version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
+ "async-compression 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "base64 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "bytes 0.5.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "encoding_rs 0.8.22 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -3803,11 +3945,13 @@ dependencies = [
  "http-body 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "hyper 0.13.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "hyper-rustls 0.19.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "hyper-tls 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "js-sys 0.3.35 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "mime 0.3.16 (registry+https://github.com/rust-lang/crates.io-index)",
  "mime_guess 2.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "native-tls 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "percent-encoding 2.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "pin-project-lite 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "rustls 0.16.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -3817,6 +3961,7 @@ dependencies = [
  "time 0.1.42 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-rustls 0.12.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio-tls 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "url 2.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "wasm-bindgen 0.2.58 (registry+https://github.com/rust-lang/crates.io-index)",
  "wasm-bindgen-futures 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -4203,6 +4348,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde-value"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "ordered-float 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "serde_derive"
 version = "1.0.104"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4231,6 +4385,17 @@ dependencies = [
  "itoa 0.4.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)",
  "url 2.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "serde_yaml"
+version = "0.8.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "dtoa 0.4.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "linked-hash-map 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)",
+ "yaml-rust 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -4882,6 +5047,35 @@ dependencies = [
 ]
 
 [[package]]
+name = "time"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "rustversion 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "time-macros 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "time-macros"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "proc-macro-hack 0.5.11 (registry+https://github.com/rust-lang/crates.io-index)",
+ "time-macros-impl 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "time-macros-impl"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "proc-macro-hack 0.5.11 (registry+https://github.com/rust-lang/crates.io-index)",
+ "proc-macro2 1.0.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "quote 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 1.0.14 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "tiny-keccak"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5153,6 +5347,15 @@ dependencies = [
  "futures 0.1.29 (registry+https://github.com/rust-lang/crates.io-index)",
  "slab 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-executor 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "tokio-tls"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "native-tls 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -6008,6 +6211,14 @@ version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "yaml-rust"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "linked-hash-map 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "yamux"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6064,6 +6275,7 @@ dependencies = [
 "checksum arrayvec 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)" = "cff77d8686867eceff3105329d4698d96c2391c176d5d03adc90c7389162b5b8"
 "checksum assert_approx_eq 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "3c07dab4369547dbe5114677b33fbbf724971019f3818172d59a97a61c774ffd"
 "checksum assert_matches 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "7deb0a829ca7bcfaf5da70b073a8d128619259a7be8216a355e23f00763059e5"
+"checksum async-compression 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "2c5c52622726d68ec35fec88edfb4ccb862d4f3b3bfa4af2f45142e69ef9b220"
 "checksum async-stream 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "22068c0c19514942eefcfd4daf8976ef1aad84e61539f95cd200c35202f80af5"
 "checksum async-stream-impl 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "25f9db3b38af870bf7e5cc649167533b493928e50744e2c30ae350230b414670"
 "checksum async-trait 0.1.24 (registry+https://github.com/rust-lang/crates.io-index)" = "750b1c38a1dfadd108da0f01c08f4cdc7ff1bb39b325f9c82cc972361780a6e1"
@@ -6166,6 +6378,8 @@ dependencies = [
 "checksum fixedbitset 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "37ab347416e802de484e4d03c7316c48f1ecb56574dfd4a46a80f173ce1de04d"
 "checksum flate2 1.0.13 (registry+https://github.com/rust-lang/crates.io-index)" = "6bd6d6f4752952feb71363cffc9ebac9411b75b87c6ab6058c40c8900cf43c0f"
 "checksum fnv 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)" = "2fad85553e09a6f881f739c29f0b00b0f01357c743266d478b68951ce23285f3"
+"checksum foreign-types 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)" = "f6f339eb8adc052cd2ca78910fda869aefa38d22d5cb648e6485e4d3fc06f3b1"
+"checksum foreign-types-shared 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
 "checksum fs_extra 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "5f2a4a2034423744d2cc7ca2068453168dcdb82c438419e639a26bd87839c674"
 "checksum fuchsia-cprng 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "a06f77d526c1a601b7c4cdd98f54b5eaabffc14d5f2f0296febdc7f357c6d3ba"
 "checksum fuchsia-zircon 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "2e9763c69ebaae630ba35f74888db465e49e259ba1bc0eda7d06f4a067615d82"
@@ -6180,6 +6394,7 @@ dependencies = [
 "checksum futures-macro 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)" = "9a5081aa3de1f7542a794a397cde100ed903b0630152d0973479018fd85423a7"
 "checksum futures-sink 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)" = "3466821b4bc114d95b087b850a724c6f83115e929bc88f1fa98a3304a944c8a6"
 "checksum futures-task 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)" = "7b0a34e53cf6cdcd0178aa573aed466b646eb3db769570841fda0c7ede375a27"
+"checksum futures-timer 3.0.2 (registry+https://github.com/rust-lang/crates.io-index)" = "e64b03909df88034c26dc1547e8970b91f98bdb65165d6a4e9110d94263dbb2c"
 "checksum futures-util 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)" = "22766cf25d64306bedf0384da004d05c9974ab104fcc4528f1236181c18004c5"
 "checksum gcc 0.3.55 (registry+https://github.com/rust-lang/crates.io-index)" = "8f5f3913fa0bfe7ee1fd8248b6b9f42a5af4b9d65ec2dd2c3c26132b950ecfc2"
 "checksum generic-array 0.12.3 (registry+https://github.com/rust-lang/crates.io-index)" = "c68f0274ae0e023facc3c97b2e00f076be70e254bc851d972503b328db79b2ec"
@@ -6205,6 +6420,7 @@ dependencies = [
 "checksum hyper 0.13.2 (registry+https://github.com/rust-lang/crates.io-index)" = "fa1c527bbc634be72aa7ba31e4e4def9bbb020f5416916279b7c705cd838893e"
 "checksum hyper-rustls 0.17.1 (registry+https://github.com/rust-lang/crates.io-index)" = "719d85c7df4a7f309a77d145340a063ea929dcb2e025bae46a80345cffec2952"
 "checksum hyper-rustls 0.19.1 (registry+https://github.com/rust-lang/crates.io-index)" = "f6ea6215c7314d450ee45970ab8b3851ab447a0e6bafdd19e31b20a42dbb7faf"
+"checksum hyper-tls 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)" = "3adcd308402b9553630734e9c36b77a7e48b3821251ca2493e8cd596763aafaa"
 "checksum idna 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "38f09e0f0b1fb55fdee1f17470ad800da77af5186a1a76c026b679358b7e844e"
 "checksum idna 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "02e2673c30ee86b5b96a9cb52ad15718aa1f966f5ab9ad54a8b95d5ca33120a9"
 "checksum indexmap 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)" = "076f042c5b7b98f31d205f1249267e12a6518c1481e9dae9764af19b707d2292"
@@ -6215,8 +6431,10 @@ dependencies = [
 "checksum jemallocator 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)" = "43ae63fcfc45e99ab3d1b29a46782ad679e98436c3169d15a167a1108a724b69"
 "checksum jobserver 0.1.21 (registry+https://github.com/rust-lang/crates.io-index)" = "5c71313ebb9439f74b00d9d2dcec36440beaf57a6aa0623068441dd7cd81a7f2"
 "checksum js-sys 0.3.35 (registry+https://github.com/rust-lang/crates.io-index)" = "7889c7c36282151f6bf465be4700359318aef36baa951462382eae49e9577cf9"
+"checksum k8s-openapi 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)" = "96affb18356fc998baa692c2185d198095ffdf6e6fff3bc9efb4927952f86851"
 "checksum keccak 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "67c21572b4949434e4fc1e1978b99c5f77064153c59d998bf13ecd96fb5ecba7"
 "checksum kernel32-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "7507624b29483431c0ba2d82aece8ca6cdba9382bff4ddd0f7490560c056098d"
+"checksum kube 0.25.0 (registry+https://github.com/rust-lang/crates.io-index)" = "38433a71ab9de436861e0ba3bccd3422bd6d41cd1203cdeaf59240fe54666a6a"
 "checksum lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 "checksum libc 0.2.67 (registry+https://github.com/rust-lang/crates.io-index)" = "eb147597cdf94ed43ab7a9038716637d2d1bf2bc571da995d0028dec06bd3018"
 "checksum libfuzzer-sys 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "c103ca347f75325d3d3ee31702bd6c09b7744e71883b7a8da9562b0c5dcdaead"
@@ -6246,6 +6464,7 @@ dependencies = [
 "checksum miow 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "396aa0f2003d7df8395cb93e09871561ccc3e785f0acb369170e8cc74ddf9226"
 "checksum mirai-annotations 1.6.0 (registry+https://github.com/rust-lang/crates.io-index)" = "f12a5b7d83c8fbf058cf1b33d26373763b2d6a0632b6bfecd4b4fa6a0507fea5"
 "checksum multimap 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)" = "a97fbd5d00e0e37bfb10f433af8f5aaf631e739368dc9fc28286ca81ca4948dc"
+"checksum native-tls 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "4b2df1a4c22fd44a62147fd8f13dd0f95c9d8ca7b2610299b2a2f9cf8964274e"
 "checksum net2 0.2.33 (registry+https://github.com/rust-lang/crates.io-index)" = "42550d9fb7b6684a6d404d9fa7250c2eb2646df731d1c06afc06dcee9e1bcf88"
 "checksum nibble_vec 0.0.4 (registry+https://github.com/rust-lang/crates.io-index)" = "c8d77f3db4bce033f4d04db08079b2ef1c3d02b44e86f25d08886fafa7756ffa"
 "checksum nix 0.14.1 (registry+https://github.com/rust-lang/crates.io-index)" = "6c722bee1037d430d0f8e687bbdbf222f27cc6e4e68d5caf630857bb2b6dbdce"
@@ -6268,7 +6487,10 @@ dependencies = [
 "checksum once_cell 1.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "b1c601810575c99596d4afc46f78a678c80105117c379eb3650cf99b8a21ce5b"
 "checksum oorandom 11.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ebcec7c9c2a95cacc7cd0ecb89d8a8454eca13906f6deb55258ffff0adeb9405"
 "checksum opaque-debug 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "2839e79665f131bdb5782e51f2c6c9599c133c6098982a54c794358bf432529c"
+"checksum openssl 0.10.28 (registry+https://github.com/rust-lang/crates.io-index)" = "973293749822d7dd6370d6da1e523b0d1db19f06c459134c658b2a4261378b52"
 "checksum openssl-probe 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "77af24da69f9d9341038eba93a073b1fdaaa1b788221b00a69bce9e762cb32de"
+"checksum openssl-sys 0.9.54 (registry+https://github.com/rust-lang/crates.io-index)" = "1024c0a59774200a555087a6da3f253a9095a5f344e353b212ac4c8b8e450986"
+"checksum ordered-float 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)" = "18869315e81473c951eb56ad5558bbc56978562d3ecfb87abb7a1e944cea4518"
 "checksum owning_ref 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "cdf84f41639e037b484f93433aa3897863b561ed65c6e59c7073d7c561710f37"
 "checksum pairing 0.14.2 (registry+https://github.com/rust-lang/crates.io-index)" = "ceda21136251c6d5a422d3d798d8ac22515a6e8d3521bb60c59a8349d36d0d57"
 "checksum parity-multiaddr 0.7.2 (registry+https://github.com/rust-lang/crates.io-index)" = "26df883298bc3f4e92528b4c5cc9f806b791955b136da3e5e939ed9de0fd958b"
@@ -6378,9 +6600,11 @@ dependencies = [
 "checksum semver 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)" = "1d7eb9ef2c18661902cc47e535f9bc51b78acd254da71d375c2f6720d9a40403"
 "checksum semver-parser 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "388a1df253eca08550bef6c72392cfe7c30914bf41df5269b68cbd6ff8f570a3"
 "checksum serde 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)" = "414115f25f818d7dfccec8ee535d76949ae78584fc4f79a6f45a904bf8ab4449"
+"checksum serde-value 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)" = "5a65a7291a8a568adcae4c10a677ebcedbc6c9cec91c054dee2ce40b0e3290eb"
 "checksum serde_derive 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)" = "128f9e303a5a29922045a830221b8f78ec74a5f544944f3d5984f8ec3895ef64"
 "checksum serde_json 1.0.48 (registry+https://github.com/rust-lang/crates.io-index)" = "9371ade75d4c2d6cb154141b9752cf3781ec9c05e0e5cf35060e1e70ee7b9c25"
 "checksum serde_urlencoded 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)" = "9ec5d77e2d4c73717816afac02670d5c4f534ea95ed430442cad02e7a6e32c97"
+"checksum serde_yaml 0.8.11 (registry+https://github.com/rust-lang/crates.io-index)" = "691b17f19fc1ec9d94ec0b5864859290dff279dbd7b03f017afda54eb36c3c35"
 "checksum sha-1 0.8.2 (registry+https://github.com/rust-lang/crates.io-index)" = "f7d94d0bede923b3cea61f3f1ff57ff8cdfd77b400fb8f9998949e0cf04163df"
 "checksum sha2 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)" = "27044adfd2e1f077f649f59deb9490d3941d674002f7d062870a60ebe9bd47a0"
 "checksum sha3 0.8.2 (registry+https://github.com/rust-lang/crates.io-index)" = "dd26bc0e7a2e3a7c959bc494caf58b72ee0c71d67704e9520f736ca7e4853ecf"
@@ -6432,6 +6656,9 @@ dependencies = [
 "checksum thread_local 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "d40c6d1b69745a6ec6fb1ca717914848da4b44ae29d9b3080cbee91d72a69b14"
 "checksum threshold_crypto 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)" = "95be1032c63011f20b01c5edb64930e2b51512782b43b458b1e3449613d70f87"
 "checksum time 0.1.42 (registry+https://github.com/rust-lang/crates.io-index)" = "db8dcfca086c1143c9270ac42a2bbd8a7ee477b78ac8e45b19abfb0cbede4b6f"
+"checksum time 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)" = "bcb8742444475438c500d017736dd7cf3d9c9dd1f0153cfa4af428692484e3ef"
+"checksum time-macros 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "9ae9b6e9f095bc105e183e3cd493d72579be3181ad4004fceb01adbe9eecab2d"
+"checksum time-macros-impl 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "e987cfe0537f575b5fc99909de6185f6c19c3ad8889e2275e686a873d0869ba1"
 "checksum tiny-keccak 1.5.0 (registry+https://github.com/rust-lang/crates.io-index)" = "1d8a021c69bb74a44ccedb824a046447e2c84a01df9e5c20779750acb38e11b2"
 "checksum tiny-keccak 2.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "2953ca5148619bc99695c1274cb54c5275bbb913c6adad87e72eaf8db9787f69"
 "checksum tinytemplate 1.0.3 (registry+https://github.com/rust-lang/crates.io-index)" = "57a3c6667d3e65eb1bc3aed6fd14011c6cbc3a0665218ab7f5daf040b9ec371a"
@@ -6454,6 +6681,7 @@ dependencies = [
 "checksum tokio-tcp 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)" = "98df18ed66e3b72e742f185882a9e201892407957e45fbff8da17ae7a7c51f72"
 "checksum tokio-threadpool 0.1.18 (registry+https://github.com/rust-lang/crates.io-index)" = "df720b6581784c118f0eb4310796b12b1d242a7eb95f716a8367855325c25f89"
 "checksum tokio-timer 0.2.13 (registry+https://github.com/rust-lang/crates.io-index)" = "93044f2d313c95ff1cb7809ce9a7a05735b012288a888b62d4434fd58c94f296"
+"checksum tokio-tls 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "7bde02a3a5291395f59b06ec6945a3077602fac2b07eeeaf0dee2122f3619828"
 "checksum tokio-udp 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)" = "e2a0b10e610b39c38b031a2fcab08e4b82f16ece36504988dcbd81dbba650d82"
 "checksum tokio-uds 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)" = "5076db410d6fdc6523df7595447629099a1fdc47b3d9f896220780fa48faf798"
 "checksum tokio-util 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "571da51182ec208780505a32528fc5512a8fe1443ab960b3f2f3ef093cd16930"
@@ -6529,6 +6757,7 @@ dependencies = [
 "checksum x25519-dalek 0.5.2 (git+https://github.com/calibra/x25519-dalek.git?branch=fiat)" = "<none>"
 "checksum x25519-dalek 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)" = "637ff90c9540fa3073bb577e65033069e4bae7c79d49d74aa3ffdf5342a53217"
 "checksum xml-rs 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)" = "541b12c998c5b56aa2b4e6f18f03664eef9a4fd0a246a55594efae6cc2d964b5"
+"checksum yaml-rust 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)" = "65923dd1784f44da1d2c3dbbc5e822045628c590ba72123e1c73d3c230c4434d"
 "checksum yamux 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)" = "d73295bc9d9acf89dd9336b3b5f5b57731ee72b587857dd4312721a0196b48e5"
 "checksum zeroize 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "3cbac2ed2ba24cc90f5e06485ac8c7c1e5449fe8911aef4d8877218af021a5b8"
 "checksum zeroize_derive 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "de251eec69fc7c1bc3923403d18ececb929380e016afe103da75f396704f8ca2"

--- a/common/util/Cargo.toml
+++ b/common/util/Cargo.toml
@@ -8,3 +8,6 @@ homepage = "https://libra.org"
 license = "Apache-2.0"
 publish = false
 edition = "2018"
+
+[dependencies]
+tokio = { version = "0.2.8", features = ["time"] }

--- a/common/util/src/retry.rs
+++ b/common/util/src/retry.rs
@@ -36,7 +36,7 @@ where
             Ok(value) => return Ok(value),
             Err(err) => {
                 if let Some(delay) = iterator.next() {
-                    thread::sleep(delay);
+                    tokio::time::delay_for(delay).await;
                 } else {
                     return Err(err);
                 }

--- a/docker/cluster-test/cluster-test.Dockerfile
+++ b/docker/cluster-test/cluster-test.Dockerfile
@@ -9,7 +9,7 @@
 FROM debian:buster AS builder
 ## To use http/https proxy while building, use:
 ## docker build --build-arg https_proxy=http:
-RUN apt-get update && apt-get install -y cmake curl clang git
+RUN apt-get update && apt-get install -y cmake curl clang git libssl-dev pkg-config
 RUN curl --proto '=https' --tlsv1.2 -sSf "https://sh.rustup.rs" | sh -s -- -y --default-toolchain none
 ENV PATH "$PATH:/root/.cargo/bin"
 WORKDIR /libra
@@ -18,7 +18,7 @@ RUN rustup install $(cat rust-toolchain)
 COPY . /libra
 RUN docker/cluster-test/compile.sh
 FROM debian:buster
-RUN apt-get update && apt-get install -y openssh-client
+RUN apt-get update && apt-get install -y openssh-client curl && curl -L "https://storage.googleapis.com/kubernetes-release/release/`curl -s https://storage.googleapis.com/kubernetes-release/release/stable.txt`/bin/linux/amd64/kubectl" -o /usr/local/bin/kubectl && chmod +x /usr/local/bin/kubectl
 RUN mkdir /etc/cluster-test
 WORKDIR /etc/cluster-test
 COPY --from=builder /target/release/cluster-test /usr/local/bin/cluster-test

--- a/docker/cluster-test/cluster-test.Dockerfile.template
+++ b/docker/cluster-test/cluster-test.Dockerfile.template
@@ -17,7 +17,8 @@ RUN docker/cluster-test/compile.sh
 
 FROM debian:buster
 
-RUN apt-get update && apt-get install -y openssh-client
+RUN apt-get update && apt-get install -y openssh-client curl && curl -L "https://storage.googleapis.com/kubernetes-release/release/`curl -s https://storage.googleapis.com/kubernetes-release/release/stable.txt`/bin/linux/amd64/kubectl" -o /usr/local/bin/kubectl && chmod +x /usr/local/bin/kubectl
+
 RUN mkdir /etc/cluster-test
 WORKDIR /etc/cluster-test
 

--- a/docker/cluster-test/cluster-test.builder.Dockerfile
+++ b/docker/cluster-test/cluster-test.builder.Dockerfile
@@ -3,7 +3,7 @@ FROM debian:buster AS builder
 ## To use http/https proxy while building, use:
 ## docker build --build-arg https_proxy=http://fwdproxy:8080 --build-arg http_proxy=http://fwdproxy:8080
 
-RUN apt-get update && apt-get install -y cmake curl clang git
+RUN apt-get update && apt-get install -y cmake curl clang git libssl-dev pkg-config
 
 RUN curl --proto '=https' --tlsv1.2 -sSf "https://sh.rustup.rs" | sh -s -- -y --default-toolchain none
 ENV PATH "$PATH:/root/.cargo/bin"

--- a/docker/cluster-test/cluster-test.container.Dockerfile
+++ b/docker/cluster-test/cluster-test.container.Dockerfile
@@ -7,7 +7,7 @@
 ## - To comment must use double ##, single # will be treated as pre-processor command
 ## -
 FROM debian:buster
-RUN apt-get update && apt-get install -y openssh-client
+RUN apt-get update && apt-get install -y openssh-client curl && curl -L "https://storage.googleapis.com/kubernetes-release/release/`curl -s https://storage.googleapis.com/kubernetes-release/release/stable.txt`/bin/linux/amd64/kubectl" -o /usr/local/bin/kubectl && chmod +x /usr/local/bin/kubectl
 RUN mkdir /etc/cluster-test
 WORKDIR /etc/cluster-test
 COPY cluster_test_docker_builder_cluster_test /usr/local/bin/cluster-test

--- a/testsuite/cluster-test/Cargo.toml
+++ b/testsuite/cluster-test/Cargo.toml
@@ -22,6 +22,7 @@ rusoto_ecr = {version = "0.42.0", features=["rustls"], default_features = false}
 rusoto_ecs = {version = "0.42.0", features=["rustls"], default_features = false}
 rusoto_s3 = {version = "0.42.0", features=["rustls"], default_features = false}
 serde_json = "1.0"
+serde_yaml = "0.8.11"
 termion = "1.5.3"
 serde = { version = "1.0.89", features = ["derive"] }
 structopt = "0.3.2"
@@ -47,3 +48,6 @@ hex = "0.4.2"
 futures = "0.3.0"
 tokio = { version = "0.2.8", features = ["full"] }
 async-trait = "0.1.24"
+
+kube = { version = "0.25.0", features = ["openapi"] }
+k8s-openapi = { version = "0.7.1", default-features = false, features = ["v1_15"] }

--- a/testsuite/cluster-test/src/cluster_swarm/cluster_swarm_kube.rs
+++ b/testsuite/cluster-test/src/cluster_swarm/cluster_swarm_kube.rs
@@ -1,0 +1,300 @@
+// Copyright (c) The Libra Core Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+#![forbid(unsafe_code)]
+
+use std::collections::HashMap;
+use std::sync::Arc;
+
+use anyhow::{bail, format_err, Result};
+use async_trait::async_trait;
+
+use futures::future::try_join_all;
+use futures::lock::Mutex;
+use kube::{
+    api::{Api, PostParams},
+    client::APIClient,
+    config,
+};
+use slog_scope::*;
+use util::retry;
+
+use crate::cluster_swarm::ClusterSwarm;
+use crate::instance::Instance;
+use kube::api::ListParams;
+use libra_config::config::AdmissionControlConfig;
+
+const DEFAULT_NAMESPACE: &str = "default";
+
+const ERROR_NOT_FOUND: u16 = 404;
+
+pub struct ClusterSwarmKube {
+    client: APIClient,
+    validator_to_node: Arc<Mutex<HashMap<u32, Instance>>>,
+    fullnode_to_node: Arc<Mutex<HashMap<(u32, u32), Instance>>>,
+}
+
+impl ClusterSwarmKube {
+    pub async fn new() -> Result<Self> {
+        let mut config = config::load_kube_config().await;
+        if config.is_err() {
+            config = config::incluster_config();
+        }
+        let config = config.map_err(|e| format_err!("Failed to load config: {:?}", e))?;
+        let client = APIClient::new(config);
+        let validator_to_node = Arc::new(Mutex::new(HashMap::new()));
+        let fullnode_to_node = Arc::new(Mutex::new(HashMap::new()));
+        Ok(Self {
+            client,
+            validator_to_node,
+            fullnode_to_node,
+        })
+    }
+
+    fn validator_spec(
+        &self,
+        index: u32,
+        num_validators: u32,
+        num_fullnodes: u32,
+        node_name: &str,
+        image_tag: &str,
+        delete_data: bool,
+    ) -> Result<Vec<u8>> {
+        let pod_yaml = format!(
+            include_str!("validator_spec_template.yaml"),
+            index = index,
+            num_validators = num_validators,
+            num_fullnodes = num_fullnodes,
+            image_tag = image_tag,
+            node_name = node_name,
+            cfg_overrides = "",
+            delete_data = delete_data,
+        );
+        let pod_spec: serde_yaml::Value = serde_yaml::from_str(&pod_yaml)?;
+        serde_json::to_vec(&pod_spec).map_err(|e| format_err!("serde_json::to_vec failed: {}", e))
+    }
+
+    fn fullnode_spec(
+        &self,
+        fullnode_index: u32,
+        num_fullnodes: u32,
+        validator_index: u32,
+        num_validators: u32,
+        node_name: &str,
+        image_tag: &str,
+        delete_data: bool,
+    ) -> Result<Vec<u8>> {
+        let pod_yaml = format!(
+            include_str!("fullnode_spec_template.yaml"),
+            fullnode_index = fullnode_index,
+            num_fullnodes = num_fullnodes,
+            validator_index = validator_index,
+            num_validators = num_validators,
+            node_name = node_name,
+            image_tag = image_tag,
+            cfg_overrides = "",
+            delete_data = delete_data,
+        );
+        let pod_spec: serde_yaml::Value = serde_yaml::from_str(&pod_yaml)?;
+        serde_json::to_vec(&pod_spec).map_err(|e| format_err!("serde_json::to_vec failed: {}", e))
+    }
+
+    async fn get_pod_node_and_ip(&self, pod_name: &str) -> Result<(String, String)> {
+        retry::retry_async(retry::fixed_retry_strategy(5000, 60), || {
+            let pod_api = Api::v1Pod(self.client.clone()).within(DEFAULT_NAMESPACE);
+            let pod_name = pod_name.to_string();
+            Box::pin(async move {
+                match pod_api.get(&pod_name).await {
+                    Ok(o) => {
+                        let node_name = o.spec.node_name.ok_or_else(|| {
+                            format_err!("node_name not found for pod {}", pod_name)
+                        })?;
+                        let pod_ip = o
+                            .status
+                            .ok_or_else(|| format_err!("status not found for pod {}", pod_name))?
+                            .pod_ip
+                            .ok_or_else(|| format_err!("pod_ip not found for pod {}", pod_name))?;
+                        if node_name.is_empty() || pod_ip.is_empty() {
+                            bail!(
+                                "Either node_name or pod_ip was empty string for pod {}",
+                                pod_name
+                            )
+                        } else {
+                            Ok((node_name, pod_ip))
+                        }
+                    }
+                    Err(e) => bail!("pod_api.get failed for pod {} : {:?}", pod_name, e),
+                }
+            })
+        })
+        .await
+    }
+
+    async fn delete_pod(&self, name: &str) -> Result<()> {
+        debug!("Deleting Pod {}", name);
+        let pod_api = Api::v1Pod(self.client.clone()).within(DEFAULT_NAMESPACE);
+        pod_api.delete(name, &Default::default()).await?;
+        retry::retry_async(retry::fixed_retry_strategy(2000, 30), || {
+            let pod_api = pod_api.clone();
+            let name = name.to_string();
+            Box::pin(async move {
+                match pod_api.get(&name).await {
+                    Ok(_) => {
+                        bail!("Waiting for pod {} to be deleted..", name);
+                    }
+                    Err(kube::Error::Api(ae)) => {
+                        if ae.code == ERROR_NOT_FOUND {
+                            Ok(())
+                        } else {
+                            bail!("Waiting for pod to be deleted..")
+                        }
+                    }
+                    Err(_) => bail!("Waiting for pod {} to be deleted..", name),
+                }
+            })
+        })
+        .await
+        .map_err(|e| format_err!("Failed to delete pod {}: {:?}", name, e))
+    }
+}
+
+#[async_trait]
+impl ClusterSwarm for ClusterSwarmKube {
+    async fn upsert_validator(
+        &self,
+        index: u32,
+        num_validators: u32,
+        num_fullnodes: u32,
+        image_tag: &str,
+        delete_data: bool,
+    ) -> Result<()> {
+        let pod_name = format!("validator-{}", index);
+        let pod_api = Api::v1Pod(self.client.clone()).within(DEFAULT_NAMESPACE);
+        if pod_api.get(&pod_name).await.is_ok() {
+            self.delete_pod(&pod_name).await?;
+        }
+        let node_name = if let Some(instance) = self.validator_to_node.lock().await.get(&index) {
+            if let Some(k8s_node) = instance.k8s_node() {
+                k8s_node.to_string()
+            } else {
+                "".to_string()
+            }
+        } else {
+            "".to_string()
+        };
+        debug!("Creating pod {} on node {:?}", pod_name, node_name);
+        match pod_api
+            .create(
+                &PostParams::default(),
+                self.validator_spec(
+                    index,
+                    num_validators,
+                    num_fullnodes,
+                    &node_name,
+                    image_tag,
+                    delete_data,
+                )?,
+            )
+            .await
+        {
+            Ok(o) => {
+                debug!("Created {}", o.metadata.name);
+            }
+            Err(e) => bail!("Failed to create pod {} : {}", pod_name, e),
+        }
+        if node_name.is_empty() {
+            let (node_name, pod_ip) = self.get_pod_node_and_ip(&pod_name).await?;
+            let ac_port = AdmissionControlConfig::default().address.port() as u32;
+            let instance = Instance::new_k8s(pod_name, pod_ip, ac_port, Some(node_name));
+            self.validator_to_node.lock().await.insert(index, instance);
+        }
+        Ok(())
+    }
+
+    async fn delete_validator(&self, index: u32) -> Result<()> {
+        let pod_name = format!("validator-{}", index);
+        self.delete_pod(&pod_name).await
+    }
+
+    async fn upsert_fullnode(
+        &self,
+        fullnode_index: u32,
+        num_fullnodes_per_validator: u32,
+        validator_index: u32,
+        num_validators: u32,
+        image_tag: &str,
+        delete_data: bool,
+    ) -> Result<()> {
+        let pod_name = format!("fullnode-{}-{}", validator_index, fullnode_index);
+        let pod_api = Api::v1Pod(self.client.clone()).within(DEFAULT_NAMESPACE);
+        if pod_api.get(&pod_name).await.is_ok() {
+            self.delete_pod(&pod_name).await?;
+        }
+        let node_name = if let Some(instance) = self
+            .fullnode_to_node
+            .lock()
+            .await
+            .get(&(validator_index, fullnode_index))
+        {
+            if let Some(k8s_node) = instance.k8s_node() {
+                k8s_node.to_string()
+            } else {
+                "".to_string()
+            }
+        } else {
+            "".to_string()
+        };
+        debug!("Creating pod {} on node {:?}", pod_name, node_name);
+        match pod_api
+            .create(
+                &PostParams::default(),
+                self.fullnode_spec(
+                    fullnode_index,
+                    num_fullnodes_per_validator,
+                    validator_index,
+                    num_validators,
+                    &node_name,
+                    image_tag,
+                    delete_data,
+                )?,
+            )
+            .await
+        {
+            Ok(o) => {
+                debug!("Created {}", o.metadata.name);
+            }
+            Err(e) => bail!("Failed to create pod {} : {}", pod_name, e),
+        }
+        if node_name.is_empty() {
+            let (node_name, pod_ip) = self.get_pod_node_and_ip(&pod_name).await?;
+            let ac_port = AdmissionControlConfig::default().address.port() as u32;
+            let instance = Instance::new_k8s(pod_name, pod_ip, ac_port, Some(node_name));
+            self.fullnode_to_node
+                .lock()
+                .await
+                .insert((validator_index, fullnode_index), instance);
+        }
+        Ok(())
+    }
+
+    async fn delete_fullnode(&self, fullnode_index: u32, validator_index: u32) -> Result<()> {
+        let pod_name = format!("fullnode-{}-{}", validator_index, fullnode_index);
+        self.delete_pod(&pod_name).await
+    }
+
+    async fn delete_all(&self) -> Result<()> {
+        let pod_api = Api::v1Pod(self.client.clone()).within(DEFAULT_NAMESPACE);
+        let pod_names: Vec<_> = pod_api
+            .list(&ListParams {
+                label_selector: Some("libra-node=true".to_string()),
+                ..Default::default()
+            })
+            .await?
+            .iter()
+            .map(|pod| pod.metadata.name.clone())
+            .collect();
+        let delete_futures = pod_names.iter().map(|pod_name| self.delete_pod(pod_name));
+        try_join_all(delete_futures).await?;
+        Ok(())
+    }
+}

--- a/testsuite/cluster-test/src/cluster_swarm/fullnode_spec_template.yaml
+++ b/testsuite/cluster-test/src/cluster_swarm/fullnode_spec_template.yaml
@@ -1,0 +1,101 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: fullnode-{validator_index}-{fullnode_index}
+  labels:
+    app: libra-fullnode
+    libra-node: "true"
+  annotations:
+    prometheus.io/should_be_scraped: "true"
+spec:
+  hostNetwork: true
+  serviceAccountName: fullnode
+  nodeSelector:
+    nodeType: validators
+  nodeName: "{node_name}"
+  initContainers:
+  - name: init
+    image: bitnami/kubectl:1.17
+    volumeMounts:
+    - mountPath: /opt/libra/data
+      name: data
+    securityContext:
+      runAsUser: 0 # To get permissions to write to /opt/libra/data
+    command:
+    - "bash"
+    - "-c"
+    - |
+      set -x;
+      if [[ {delete_data} = true ]]; then
+        rm -rf /opt/libra/data/*
+      fi
+      CFG_SEED_PEER_IP=$(kubectl get pod/validator-{validator_index} -o=jsonpath='{{.status.podIP}}');
+      while [ -z "${{CFG_SEED_PEER_IP}}" ]; do
+        sleep 5;
+        CFG_SEED_PEER_IP=$(kubectl get pod/validator-{validator_index} -o=jsonpath='{{.status.podIP}}');
+        echo "Waiting for pod/validator-{validator_index} IP Address";
+      done;
+      echo -n "${{CFG_SEED_PEER_IP}}" > /opt/libra/data/seed_peer_ip
+  containers:
+  - name: main
+    image: 853397791086.dkr.ecr.us-west-2.amazonaws.com/libra_validator:{image_tag}
+    imagePullPolicy: Always
+    resources:
+      requests:
+        cpu: 7800m
+    ports:
+    - containerPort: 6180
+    - containerPort: 6181
+    - containerPort: 8000
+    - containerPort: 9101
+    - containerPort: 6191
+    volumeMounts:
+    - mountPath: /opt/libra/data
+      name: data
+    env:
+    - name: CFG_NUM_VALIDATORS
+      value: "{num_validators}"
+    - name: CFG_NUM_FULLNODES
+      value: "{num_fullnodes}"
+    - name: CFG_FULLNODE_INDEX
+      value: "{fullnode_index}"
+    - name: CFG_SEED
+      value: "1337133713371337133713371337133713371337133713371337133713371337"
+    - name: CFG_FULLNODE_SEED
+      value: "2674267426742674267426742674267426742674267426742674267426742674"
+    - name: RUST_LOG
+      value: "debug"
+    - name: RUST_BACKTRACE
+      value: "1"
+    - name: CFG_OVERRIDES
+      value: "{cfg_overrides}"
+    - name: MY_POD_IP
+      valueFrom:
+        fieldRef:
+          fieldPath: status.podIP
+    command:
+      - "bash"
+      - "-c"
+      - |
+        set -x;
+        export CFG_LISTEN_ADDR=$MY_POD_IP;
+        export CFG_SEED_PEER_IP=$(cat /opt/libra/data/seed_peer_ip);
+        exec bash /docker-run-dynamic-fullnode.sh
+  volumes:
+  - name: data
+    hostPath:
+      path: /data
+      type: Directory
+  affinity:
+    podAntiAffinity:
+      requiredDuringSchedulingIgnoredDuringExecution:
+      - labelSelector:
+          matchExpressions:
+          - key: libra-node
+            operator: Exists
+        topologyKey: "kubernetes.io/hostname"
+  terminationGracePeriodSeconds: 5
+  tolerations:
+  - key: "validators"
+    operator: "Exists"
+    effect: "NoSchedule"

--- a/testsuite/cluster-test/src/cluster_swarm/mod.rs
+++ b/testsuite/cluster-test/src/cluster_swarm/mod.rs
@@ -1,0 +1,146 @@
+// Copyright (c) The Libra Core Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+pub mod cluster_swarm_kube;
+
+use anyhow::Result;
+use async_trait::async_trait;
+use futures::future::try_join_all;
+use futures::try_join;
+
+#[async_trait]
+pub trait ClusterSwarm {
+    /// Inserts a validator into the ClusterSwarm if it doesn't exist. If it
+    /// exists, then updates the validator.
+    async fn upsert_validator(
+        &self,
+        index: u32,
+        num_validators: u32,
+        num_fullnodes: u32,
+        image_tag: &str,
+        delete_data: bool,
+    ) -> Result<()>;
+
+    /// Deletes a validator from the ClusterSwarm
+    async fn delete_validator(&self, index: u32) -> Result<()>;
+
+    /// Creates a set of validators with the given `image_tag`
+    async fn create_validator_set(
+        &self,
+        num_validators: u32,
+        num_fullnodes_per_validator: u32,
+        image_tag: &str,
+        delete_data: bool,
+    ) -> Result<()> {
+        let validators = (0..num_validators).map(|i| {
+            self.upsert_validator(
+                i,
+                num_validators,
+                num_fullnodes_per_validator,
+                image_tag,
+                delete_data,
+            )
+        });
+        try_join_all(validators).await?;
+        Ok(())
+    }
+
+    /// Deletes a set of validators
+    async fn delete_validator_set(&self, num_validators: u32) -> Result<()> {
+        let validators = (0..num_validators).map(|i| self.delete_validator(i));
+        try_join_all(validators).await?;
+        Ok(())
+    }
+
+    /// Inserts a fullnode into the ClusterSwarm if it doesn't exist. If it
+    /// exists, then updates the fullnode.
+    async fn upsert_fullnode(
+        &self,
+        fullnode_index: u32,
+        num_fullnodes_per_validator: u32,
+        validator_index: u32,
+        num_validators: u32,
+        image_tag: &str,
+        delete_data: bool,
+    ) -> Result<()>;
+
+    /// Deletes a fullnode from the ClusterSwarm
+    async fn delete_fullnode(&self, fullnode_index: u32, validator_index: u32) -> Result<()>;
+
+    /// Creates a set of fullnodes with the given `image_tag`
+    async fn create_fullnode_set(
+        &self,
+        num_validators: u32,
+        num_fullnodes_per_validator: u32,
+        image_tag: &str,
+        delete_data: bool,
+    ) -> Result<()> {
+        let fullnodes = (0..num_validators).flat_map(move |validator_index| {
+            (0..num_fullnodes_per_validator).map(move |fullnode_index| {
+                self.upsert_fullnode(
+                    fullnode_index,
+                    num_fullnodes_per_validator,
+                    validator_index,
+                    num_validators,
+                    image_tag,
+                    delete_data,
+                )
+            })
+        });
+        try_join_all(fullnodes).await?;
+        Ok(())
+    }
+
+    /// Deletes a set of fullnodes
+    async fn delete_fullnode_set(
+        &self,
+        num_validators: u32,
+        num_fullnodes_per_validator: u32,
+    ) -> Result<()> {
+        let fullnodes = (0..num_validators).flat_map(move |validator_index| {
+            (0..num_fullnodes_per_validator)
+                .map(move |fullnode_index| self.delete_fullnode(fullnode_index, validator_index))
+        });
+        try_join_all(fullnodes).await?;
+        Ok(())
+    }
+
+    /// Creates a set of validators and fullnodes with the given parameters
+    async fn create_validator_and_fullnode_set(
+        &self,
+        num_validators: u32,
+        num_fullnodes_per_validator: u32,
+        image_tag: &str,
+        delete_data: bool,
+    ) -> Result<((), ())> {
+        try_join!(
+            self.create_validator_set(
+                num_validators,
+                num_fullnodes_per_validator,
+                image_tag,
+                delete_data
+            ),
+            self.create_fullnode_set(
+                num_validators,
+                num_fullnodes_per_validator,
+                image_tag,
+                delete_data
+            ),
+        )
+    }
+
+    /// Deletes a set of validators and fullnodes with the given parameters
+    async fn delete_validator_and_fullnode_set(
+        &self,
+        num_validators: u32,
+        num_fullnodes_per_validator: u32,
+    ) -> Result<((), ())> {
+        try_join!(
+            self.delete_validator_set(num_validators),
+            self.delete_fullnode_set(num_validators, num_fullnodes_per_validator),
+        )
+    }
+
+    /// Deletes all validators and fullnodes in this cluster
+    async fn delete_all(&self) -> Result<()>;
+}

--- a/testsuite/cluster-test/src/cluster_swarm/validator_spec_template.yaml
+++ b/testsuite/cluster-test/src/cluster_swarm/validator_spec_template.yaml
@@ -1,0 +1,105 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: validator-{index}
+  labels:
+    app: libra-validator
+    libra-node: "true"
+  annotations:
+    prometheus.io/should_be_scraped: "true"
+spec:
+  hostNetwork: true
+  serviceAccountName: validator
+  nodeSelector:
+    nodeType: validators
+  nodeName: "{node_name}"
+  initContainers:
+  - name: init
+    image: bitnami/kubectl:1.17
+    volumeMounts:
+    - mountPath: /opt/libra/data
+      name: data
+    securityContext:
+      runAsUser: 0 # To get permissions to write to /opt/libra/data
+    command:
+    - "bash"
+    - "-c"
+    - |
+      set -x;
+      if [[ {delete_data} = true ]]; then
+        rm -rf /opt/libra/data/*
+      fi
+      CFG_SEED_PEER_IP=$(kubectl get pod/validator-0 -o=jsonpath='{{.status.podIP}}');
+      while [ -z "${{CFG_SEED_PEER_IP}}" ]; do
+        sleep 5;
+        CFG_SEED_PEER_IP=$(kubectl get pod/validator-0 -o=jsonpath='{{.status.podIP}}');
+        echo "Waiting for pod/validator-0 IP Address";
+      done;
+      echo -n "${{CFG_SEED_PEER_IP}}" > /opt/libra/data/seed_peer_ip
+      until [ $(kubectl get pods -l app=libra-validator | grep ^validator | grep -e Init -e Running | wc -l) = "{num_validators}" ]; do
+        sleep 3;
+        echo "Waiting for all validator pods to be scheduled";
+      done
+  containers:
+  - name: main
+    image: 853397791086.dkr.ecr.us-west-2.amazonaws.com/libra_validator:{image_tag}
+    imagePullPolicy: Always
+    resources:
+      requests:
+        cpu: 7800m
+    ports:
+    - containerPort: 6180
+    - containerPort: 6181
+    - containerPort: 8000
+    - containerPort: 9101
+    - containerPort: 6191
+    volumeMounts:
+    - mountPath: /opt/libra/data
+      name: data
+    env:
+    - name: CFG_NODE_INDEX
+      value: "{index}"
+    - name: CFG_NUM_VALIDATORS
+      value: "{num_validators}"
+    - name: CFG_NUM_FULLNODES
+      value: "{num_fullnodes}"
+    - name: CFG_SEED
+      value: "1337133713371337133713371337133713371337133713371337133713371337"
+    - name: CFG_FULLNODE_SEED
+      value: "2674267426742674267426742674267426742674267426742674267426742674"
+    - name: RUST_LOG
+      value: "debug"
+    - name: RUST_BACKTRACE
+      value: "1"
+    - name: CFG_OVERRIDES
+      value: "{cfg_overrides}"
+    - name: MY_POD_IP
+      valueFrom:
+        fieldRef:
+          fieldPath: status.podIP
+    command:
+      - "bash"
+      - "-c"
+      - |
+        set -x;
+        export CFG_LISTEN_ADDR=$MY_POD_IP;
+        export CFG_SEED_PEER_IP=$(cat /opt/libra/data/seed_peer_ip);
+        exec bash /docker-run-dynamic.sh
+  volumes:
+  - name: data
+    hostPath:
+      path: /data
+      type: Directory
+  affinity:
+    podAntiAffinity:
+      requiredDuringSchedulingIgnoredDuringExecution:
+      - labelSelector:
+          matchExpressions:
+          - key: libra-node
+            operator: Exists
+        topologyKey: "kubernetes.io/hostname"
+  terminationGracePeriodSeconds: 5
+  tolerations:
+  - key: "validators"
+    operator: "Exists"
+    effect: "NoSchedule"

--- a/testsuite/cluster-test/src/instance.rs
+++ b/testsuite/cluster-test/src/instance.rs
@@ -13,6 +13,7 @@ pub struct Instance {
     peer_name: String,
     ip: String,
     ac_port: u32,
+    k8s_node: Option<String>,
 }
 
 impl Instance {
@@ -21,6 +22,21 @@ impl Instance {
             peer_name,
             ip,
             ac_port,
+            k8s_node: None,
+        }
+    }
+
+    pub fn new_k8s(
+        peer_name: String,
+        ip: String,
+        ac_port: u32,
+        k8s_node: Option<String>,
+    ) -> Instance {
+        Instance {
+            peer_name,
+            ip,
+            ac_port,
+            k8s_node,
         }
     }
 
@@ -129,6 +145,10 @@ impl Instance {
 
     pub fn ac_port(&self) -> u32 {
         self.ac_port
+    }
+
+    pub fn k8s_node(&self) -> Option<&String> {
+        self.k8s_node.as_ref()
     }
 }
 

--- a/testsuite/cluster-test/src/lib.rs
+++ b/testsuite/cluster-test/src/lib.rs
@@ -3,6 +3,7 @@
 
 pub mod aws;
 pub mod cluster;
+pub mod cluster_swarm;
 pub mod deployment;
 pub mod effects;
 pub mod experiments;


### PR DESCRIPTION
## Summary

* Create a trait `ClusterSwarm` which provider a LibraSwarm like API
  * Add an implementation of the trait `ClusterSwarmKube` for Kubernetes
  * This supports creating, deleting validators and fullnode instances
  * Add a bunch of default trait methods to the `ClusterSwarm` trait, eg: `create_fullnode_set`, `create_validator_set`, `create_fullnode_set`

## Other

* Fix minor bug in `common/util/src/retry.rs`
* Add kube, k8s-openapi crate deps to cluster-test
  * Update cluster-test Dockerfiles to add the required packages


## Testing

* Tested on my cluster
