### PR TITLE
[vm] Cleanup the logic for loading up gas schedule in VMValidator

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5702,6 +5702,7 @@ dependencies = [
  "async-trait 0.1.24 (registry+https://github.com/rust-lang/crates.io-index)",
  "config-builder 0.1.0",
  "executor 0.1.0",
+ "futures 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "libra-config 0.1.0",
  "libra-crypto 0.1.0",
  "libra-state-view 0.1.0",

--- a/language/e2e-tests/src/executor.rs
+++ b/language/e2e-tests/src/executor.rs
@@ -220,7 +220,8 @@ impl FakeExecutor {
 
     /// Verifies the given transaction by running it through the VM verifier.
     pub fn verify_transaction(&self, txn: SignedTransaction) -> Option<VMStatus> {
-        let vm = LibraVM::new(&self.config);
+        let mut vm = LibraVM::new(&self.config);
+        vm.load_configs(self.get_state_view());
         vm.validate_transaction(txn, &self.data_store)
     }
 

--- a/vm-validator/Cargo.toml
+++ b/vm-validator/Cargo.toml
@@ -12,6 +12,7 @@ edition = "2018"
 [dependencies]
 anyhow = "1.0"
 async-trait = "0.1"
+futures = "0.3.0"
 tokio = { version = "0.2.8", features = ["full"] }
 libra-config = { path = "../config", version = "0.1.0" }
 scratchpad = { path = "../storage/scratchpad", version = "0.1.0" }


### PR DESCRIPTION
<!--
Thank you for sending a PR. We appreciate you spending time to help improve the Libra project.

The project is undergoing daily changes. Pull Requests will be reviewed and responded to as time permits.
-->

## Motivation
Previously there were no initialization phase of LibraVM in the VMValidator. Thus LibraVM was forced to reload the gas schedule on chain during the `validate_transaction` call, which is really inefficient. This PR will utilize the initialization api created in #2636 to load the gas schedule after the VM is created. This also cleaned up a bunch of internal apis in LibraVM as well.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

