### PR TITLE
[cluster-test] Tune cluster-test params to improve benchmark throughput

### DIFF
--- a/config/src/config/consensus_config.rs
+++ b/config/src/config/consensus_config.rs
@@ -19,7 +19,7 @@ pub struct ConsensusConfig {
 impl Default for ConsensusConfig {
     fn default() -> ConsensusConfig {
         ConsensusConfig {
-            max_block_size: 1000,
+            max_block_size: 2000,
             proposer_type: ConsensusProposerType::MultipleOrderedProposers,
             contiguous_rounds: 2,
             max_pruned_blocks_in_mem: 10000,

--- a/config/src/config/test_data/random.complete.node.config.toml
+++ b/config/src/config/test_data/random.complete.node.config.toml
@@ -12,7 +12,7 @@ data_dir = "/opt/libra/data/common"
 role = "validator"
 
 [consensus]
-max_block_size = 1000
+max_block_size = 2000
 max_pruned_blocks_in_mem = 10000
 pacemaker_initial_timeout_ms = 1000
 proposer_type = "multiple_ordered_proposers"

--- a/config/src/config/test_data/single.node.config.toml
+++ b/config/src/config/test_data/single.node.config.toml
@@ -48,7 +48,7 @@ network_peers_file = ""
 seed_peers_file = ""
 
 [consensus]
-max_block_size = 1000
+max_block_size = 2000
 max_pruned_blocks_in_mem = 10000
 pacemaker_initial_timeout_ms = 1000
 proposer_type = "multiple_ordered_proposers"

--- a/testsuite/cluster-test/src/main.rs
+++ b/testsuite/cluster-test/src/main.rs
@@ -100,13 +100,13 @@ struct Args {
     changelog: Option<Vec<String>>,
 
     // emit_tx options
-    #[structopt(long, default_value = "16")]
+    #[structopt(long, default_value = "10")]
     accounts_per_client: usize,
-    #[structopt(long)]
-    threads_per_ac: Option<usize>,
-    #[structopt(long, default_value = "0")]
+    #[structopt(long, default_value = "1")]
+    threads_per_ac: usize,
+    #[structopt(long, default_value = "75")]
     wait_millis: u64,
-    #[structopt(long)]
+    #[structopt(long, parse(try_from_str), default_value = "true")]
     burst: bool,
     #[structopt(long, default_value = "mint.key")]
     mint_file: String,
@@ -148,7 +148,7 @@ pub fn main() {
             let util = BasicSwarmUtil::setup(&args);
             rt.block_on(util.emit_tx(
                 args.accounts_per_client,
-                args.threads_per_ac,
+                Some(args.threads_per_ac),
                 thread_params,
                 duration,
             ));
@@ -157,7 +157,7 @@ pub fn main() {
             let util = ClusterUtil::setup(&args);
             rt.block_on(util.emit_tx(
                 args.accounts_per_client,
-                args.threads_per_ac,
+                Some(args.threads_per_ac),
                 thread_params,
                 duration,
             ));
@@ -468,7 +468,7 @@ impl ClusterTestRunner {
         let global_emit_job_request = EmitJobRequest {
             instances: vec![],
             accounts_per_client: args.accounts_per_client,
-            threads_per_ac: args.threads_per_ac,
+            threads_per_ac: Some(args.threads_per_ac),
             thread_params: EmitThreadParams {
                 wait_millis: args.wait_millis,
                 wait_committed: !args.burst,

--- a/testsuite/cluster-test/src/tx_emitter.rs
+++ b/testsuite/cluster-test/src/tx_emitter.rs
@@ -79,8 +79,8 @@ pub struct EmitThreadParams {
 impl Default for EmitThreadParams {
     fn default() -> Self {
         Self {
-            wait_millis: 0,
-            wait_committed: true,
+            wait_millis: 75,
+            wait_committed: false,
         }
     }
 }
@@ -105,7 +105,7 @@ impl EmitJobRequest {
             },
             None => Self {
                 instances,
-                accounts_per_client: 16,
+                accounts_per_client: 10,
                 threads_per_ac: None,
                 thread_params: EmitThreadParams::default(),
             },
@@ -141,7 +141,7 @@ impl TxEmitter {
                 // We want to have equal numbers of threads for each AC, so that they are equally loaded
                 // Otherwise things like flamegrap/perf going to show different numbers depending on which AC is chosen
                 // Also limiting number of threads as max 10 per AC for use cases with very small number of nodes or use --peers
-                min(10, max(1, 200 / req.instances.len()))
+                min(10, max(1, 100 / req.instances.len()))
             }
         };
         let num_clients = req.instances.len() * threads_per_ac;


### PR DESCRIPTION
## Summary

* Use burst mode to send transactions continously to validators
* Tweak accounts_per_client, threads_per_ac, wait_millis to maximize throughput
* Set max_block_size to 2000

## Test Plan

http://prometheus.cluster-test-ci.aws.hlw3truzy4ls.com:9091/d/lDnunt7Zk/consensus?orgId=1&from=1582166545503&to=1582166999103