### PR TITLE
[Secure Storage] Added crypto key storage support for in_memory, on_disk and vault implementations.

### DIFF
--- a/secure/storage/Cargo.toml
+++ b/secure/storage/Cargo.toml
@@ -15,6 +15,7 @@ lcs = { path = "../../common/lcs", version = "0.1.0", package = "libra-canonical
 libra-crypto = { path = "../../crypto/crypto", version = "0.1.0" }
 libra-temppath = { path = "../../common/temppath", version = "0.1.0" }
 libra-vault-client = { path = "vault", version = "0.1.0" }
+rand = "0.6.5"
 serde = { version = "1.0.99", features = ["rc"], default-features = false }
 serde_json = "1.0.40"
 thiserror = "1.0"

--- a/secure/storage/src/error.rs
+++ b/secure/storage/src/error.rs
@@ -8,6 +8,8 @@ use toml;
 
 #[derive(Debug, Deserialize, Error, PartialEq, Serialize)]
 pub enum Error {
+    #[error("Entropy error: {0}")]
+    EntropyError(String),
     #[error("Internal error: {0}")]
     InternalError(String),
     #[error("Key not set: {0}")]

--- a/secure/storage/src/storage.rs
+++ b/secure/storage/src/storage.rs
@@ -2,11 +2,17 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::{Error, Policy, Value};
+use libra_crypto::{ed25519::Ed25519PrivateKey, ed25519::Ed25519PublicKey, PrivateKey, Uniform};
+use rand::{rngs::OsRng, Rng, SeedableRng};
 
 /// Libra interface into storage. Create takes a policy that is enforced internally by the actual
 /// backend. The policy contains public identities that the backend can translate into a unique and
 /// private token for another service. Hence get and set internally will pass the current service
 /// private token to the backend to gain its permissions.
+/// Storage also offers support for generating, using and managing cryptographic keys securely.
+/// The API offered here is inspired by the 'Transit Secret Engine' provided by Vault: a
+/// production-ready storage engine for cloud infrastructures (e.g.,
+/// see https://www.vaultproject.io/docs/secrets/transit/index.html).
 pub trait Storage: Send + Sync {
     /// Returns true if the backend service is online and available.
     fn available(&self) -> bool;
@@ -31,4 +37,37 @@ pub trait Storage: Send + Sync {
     fn get(&self, key: &str) -> Result<Value, Error>;
     /// Sets a value in storage and fails if invalid permissions or it does not exist
     fn set(&mut self, key: &str, value: Value) -> Result<(), Error>;
+
+    /// Securely generates a new named Ed25519 key pair and returns the corresponding public key.
+    ///
+    /// The new key pair is named according to the 'key_pair_name' and is held in secure storage
+    /// under the given 'policy'. To access or use the key pair (e.g., sign or encrypt data),
+    /// subsequent API calls must refer to the key pair by name. As this API call may fail
+    /// (e.g., if a key pair with the given name already exists), an error may also be returned.
+    ///
+    /// This default implementation is useful for storage engines that only implement the simple
+    /// Storage interface. More complex engines (e.g., those that support native crypto key
+    /// generation), should override this implementation.
+    fn generate_new_ed25519_key_pair(
+        &mut self,
+        key_pair_name: &str,
+        policy: &Policy,
+    ) -> Result<Ed25519PublicKey, Error> {
+        let mut seed_rng = OsRng::new().map_err(|e| Error::EntropyError(e.to_string()))?;
+        let mut rng = rand::rngs::StdRng::from_seed(seed_rng.gen());
+        let private_key = Ed25519PrivateKey::generate_for_testing(&mut rng);
+        let public_key = private_key.public_key();
+        self.create(key_pair_name, Value::Ed25519PrivateKey(private_key), policy)
+            .map(|_| public_key)
+    }
+
+    /// Returns the corresponding public key for a given Ed25519 key pair, as identified by the
+    /// given 'key_pair_name'. If the key pair doesn't exist, or the caller doesn't have the
+    /// appropriate permissions to retrieve the public key, this call will fail with an error.
+    fn get_public_key_for(&mut self, key_pair_name: &str) -> Result<Ed25519PublicKey, Error> {
+        match self.get(key_pair_name)? {
+            Value::Ed25519PrivateKey(private_key) => Ok(private_key.public_key()),
+            _ => Err(Error::UnexpectedValueType),
+        }
+    }
 }

--- a/secure/storage/src/tests/in_memory.rs
+++ b/secure/storage/src/tests/in_memory.rs
@@ -5,6 +5,24 @@ use crate::{in_memory::InMemoryStorage, tests::suite};
 
 #[test]
 fn in_memory() {
-    let storage = Box::new(InMemoryStorage::new());
-    suite::run_test_suite(storage, "InMemoryStorage");
+    let mut storage = Box::new(InMemoryStorage::new());
+    suite::run_test_suite(storage.as_mut(), "InMemoryStorage");
+}
+
+#[test]
+fn crypto_key_create_and_get() {
+    let mut storage = Box::new(InMemoryStorage::new());
+    suite::create_get_and_test_key_pair(storage.as_mut());
+}
+
+#[test]
+fn crypto_key_create_twice() {
+    let mut storage = Box::new(InMemoryStorage::new());
+    suite::create_key_pair_twice(storage.as_mut());
+}
+
+#[test]
+fn crypto_key_get_uncreated() {
+    let mut storage = Box::new(InMemoryStorage::new());
+    suite::get_uncreated_key_pair(storage.as_mut());
 }

--- a/secure/storage/src/tests/on_disk.rs
+++ b/secure/storage/src/tests/on_disk.rs
@@ -7,6 +7,27 @@ use libra_temppath::TempPath;
 #[test]
 fn on_disk() {
     let temp_path = TempPath::new();
-    let storage = Box::new(OnDiskStorage::new(temp_path.path().to_path_buf()));
-    suite::run_test_suite(storage, "OnDiskStorage");
+    let mut storage = Box::new(OnDiskStorage::new(temp_path.path().to_path_buf()));
+    suite::run_test_suite(storage.as_mut(), "OnDiskStorage");
+}
+
+#[test]
+fn crypto_key_create_and_get() {
+    let temp_path = TempPath::new();
+    let mut storage = Box::new(OnDiskStorage::new(temp_path.path().to_path_buf()));
+    suite::create_get_and_test_key_pair(storage.as_mut());
+}
+
+#[test]
+fn crypto_key_create_twice() {
+    let temp_path = TempPath::new();
+    let mut storage = Box::new(OnDiskStorage::new(temp_path.path().to_path_buf()));
+    suite::create_key_pair_twice(storage.as_mut());
+}
+
+#[test]
+fn crypto_key_get_uncreated() {
+    let temp_path = TempPath::new();
+    let mut storage = Box::new(OnDiskStorage::new(temp_path.path().to_path_buf()));
+    suite::get_uncreated_key_pair(storage.as_mut());
 }


### PR DESCRIPTION
## Motivation

This is the first PR that works towards providing appropriate key management for Validator nodes (as discussed in [Validator Key Management](https://github.com/libra/libra/issues/2332)). The purpose of this PR is to add a secure storage interface for cryptographic keys, so that the Key Manager will ultimately be able to interact with and manage the Validator keys (using this interface).

In this PR, we offer a single commit, that: 
1. Adds two simple API calls that provide a means of secure storage for cryptographic keys. These are: (i) creating a named public/private keypair; and (ii) retrieving the corresponding public key for a given key name.
2. Implements the calls for the in_memory, on_disk and vault secure storage* implementations.
3. Adds appropriate tests for this functionality to the test suite**. To do this, we also add a simple 'reset_vault_storage()' function to allow storage resets between tests (as we only support a single backend for testing at present).

*Note: In this PR, we don't use the vault specific functionalities for handling cryptographic keys (i.e., Vault Transit). Instead, we just leverage the Key/Value support. A future PR will implement the vault specific implementation using Transit.

**Note: In a future PR, I'll refactor the run_test_suite function into multiple separate tests with an appropriate file structure. To avoid blowing this PR up, I'm delegating this to later.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?

Yes.

## Test Plan

All local tests seem to pass.

## Related PRs

None.
