### PR TITLE
Clippy cleanups

### DIFF
--- a/admission_control/admission-control-service/src/admission_control_fuzzing.rs
+++ b/admission_control/admission-control-service/src/admission_control_fuzzing.rs
@@ -10,7 +10,6 @@ use libra_mempool::mocks::MockSharedMempool;
 use libra_proptest_helpers::ValueGenerator;
 use libra_prost_ext::MessageExt;
 use libra_types::transaction::SignedTransaction;
-use proptest;
 use prost::Message;
 use std::sync::Arc;
 use storage_service::mocks::mock_storage_client::MockStorageReadClient;

--- a/client/cli/src/main.rs
+++ b/client/cli/src/main.rs
@@ -20,7 +20,6 @@ use std::{
     time::{Duration, UNIX_EPOCH},
 };
 use structopt::StructOpt;
-use ureq;
 
 #[derive(Debug, StructOpt)]
 #[structopt(

--- a/common/logger/src/glog_format.rs
+++ b/common/logger/src/glog_format.rs
@@ -7,12 +7,10 @@ use crate::{
     collector_serializer::CollectorSerializer,
     kv_categorizer::{KVCategorizer, KVCategory},
 };
-use chrono;
 use itertools::{Either, Itertools};
 use slog::{Drain, Key, Level, OwnedKVList, Record, KV};
 use slog_term::{Decorator, RecordDecorator};
 use std::{io, str};
-use thread_id;
 
 /// A slog `Drain` for glog-formatted logs.
 pub struct GlogFormat<D: Decorator, C: KVCategorizer> {
@@ -163,7 +161,6 @@ mod tests {
     use regex::{Captures, Regex};
     use slog::{info, o, Drain, Logger};
     use slog_term::PlainSyncDecorator;
-    use thread_id;
 
     // Create a regex that matches log lines.
     static LOG_REGEX: Lazy<Regex> = Lazy::new(|| {

--- a/common/logger/src/security.rs
+++ b/common/logger/src/security.rs
@@ -5,7 +5,7 @@ use super::error;
 use backtrace::Backtrace;
 use rand::{rngs::SmallRng, FromEntropy, Rng};
 use serde::Serialize;
-use std::fmt::Debug;
+use std::fmt::{self, Debug};
 
 #[derive(Serialize)]
 pub enum SecurityEvent {
@@ -160,13 +160,15 @@ impl SecurityLog {
         self
     }
 
-    pub(crate) fn to_string(&self) -> String {
-        serde_json::to_string(&self).unwrap_or_else(|e| e.to_string())
-    }
-
     /// Prints the `SecurityEvent` struct.
     pub fn log(self) {
         error!("[security] {}", self.to_string());
+    }
+}
+
+impl fmt::Display for SecurityLog {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}", serde_json::to_string(&self).unwrap_or_else(|e| e.to_string()))
     }
 }
 

--- a/common/logger/src/security.rs
+++ b/common/logger/src/security.rs
@@ -168,7 +168,11 @@ impl SecurityLog {
 
 impl fmt::Display for SecurityLog {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "{}", serde_json::to_string(&self).unwrap_or_else(|e| e.to_string()))
+        write!(
+            f,
+            "{}",
+            serde_json::to_string(&self).unwrap_or_else(|e| e.to_string())
+        )
     }
 }
 

--- a/common/proptest-helpers/src/unit_tests/repeat_vec_tests.rs
+++ b/common/proptest-helpers/src/unit_tests/repeat_vec_tests.rs
@@ -248,7 +248,7 @@ fn repeat_vec_proptest_impl(
 
     prop_assert_eq!(test_vec.len(), naive_vec.len());
 
-    fn scaled_index(index: &PropIndex, len: usize) -> usize {
+    fn scaled_index(index: PropIndex, len: usize) -> usize {
         // Go roughly 10% beyond the end of the list to also check negative cases.
         let scaled_len = len + (len / 10);
         if scaled_len == 0 {
@@ -264,7 +264,7 @@ fn repeat_vec_proptest_impl(
         match op {
             RepeatVecOp::Get(query) => {
                 // Go beyond the end of the list to also check negative cases.
-                let at = scaled_index(&query, test_vec.len());
+                let at = scaled_index(query, test_vec.len());
                 let test_get = test_vec.get(at);
                 prop_assert_eq!(test_get, naive_vec.get(at));
                 if at >= test_vec.len() {
@@ -278,7 +278,7 @@ fn repeat_vec_proptest_impl(
                 naive_vec.extend(counter.clone(), size);
             }
             RepeatVecOp::Remove(prop_index) => {
-                let logical_index = scaled_index(&prop_index, test_vec.len());
+                let logical_index = scaled_index(prop_index, test_vec.len());
                 test_vec.remove(logical_index);
                 naive_vec.remove(logical_index);
             }
@@ -287,7 +287,7 @@ fn repeat_vec_proptest_impl(
                     .into_iter()
                     .map(|prop_index| {
                         // Go beyond the end of the list to also check out of bounds cases.
-                        scaled_index(&prop_index, test_vec.len())
+                        scaled_index(prop_index, test_vec.len())
                     })
                     .collect();
 

--- a/common/proptest-helpers/src/value_generator.rs
+++ b/common/proptest-helpers/src/value_generator.rs
@@ -3,7 +3,7 @@
 
 use proptest::{
     strategy::{Strategy, ValueTree},
-    test_runner::{Config, TestRunner},
+    test_runner::TestRunner,
 };
 
 /// Context for generating single values out of strategies.
@@ -11,6 +11,7 @@ use proptest::{
 /// Proptest is designed to be built around "value trees", which represent a spectrum from complex
 /// values to simpler ones. But in some contexts, like benchmarking or generating corpuses, one just
 /// wants a single value. This is a convenience struct for that.
+#[derive(Default)]
 pub struct ValueGenerator {
     runner: TestRunner,
 }
@@ -18,9 +19,7 @@ pub struct ValueGenerator {
 impl ValueGenerator {
     /// Creates a new value generator with the default RNG.
     pub fn new() -> Self {
-        Self {
-            runner: TestRunner::new(Config::default()),
-        }
+        Default::default()
     }
 
     /// Creates a new value generator with a deterministic RNG.

--- a/common/temppath/src/lib.rs
+++ b/common/temppath/src/lib.rs
@@ -76,3 +76,9 @@ impl std::convert::AsRef<Path> for TempPath {
         self.path()
     }
 }
+
+impl Default for TempPath {
+    fn default() -> Self {
+        Self::new()
+    }
+}

--- a/config/config-builder/src/validator_config.rs
+++ b/config/config-builder/src/validator_config.rs
@@ -15,7 +15,6 @@ use libra_types::transaction::Transaction;
 use parity_multiaddr::Multiaddr;
 use rand::{rngs::StdRng, Rng, SeedableRng};
 use std::{collections::HashMap, net::SocketAddr};
-use vm_genesis;
 
 const DEFAULT_SEED: [u8; 32] = [13u8; 32];
 const DEFAULT_ADVERTISED: &str = "/ip4/127.0.0.1/tcp/6180";

--- a/config/src/config/logger_config.rs
+++ b/config/src/config/logger_config.rs
@@ -28,6 +28,7 @@ impl Default for LoggerConfig {
     }
 }
 
+#[allow(clippy::trivially_copy_pass_by_ref)]
 fn serialize_filter_level<S>(filter_level: &FilterLevel, serializer: S) -> Result<S::Ok, S::Error>
 where
     S: Serializer,

--- a/config/src/config/mod.rs
+++ b/config/src/config/mod.rs
@@ -107,11 +107,11 @@ pub enum RoleType {
 }
 
 impl RoleType {
-    pub fn is_validator(&self) -> bool {
-        *self == RoleType::Validator
+    pub fn is_validator(self) -> bool {
+        self == RoleType::Validator
     }
 
-    pub fn as_str(&self) -> &'static str {
+    pub fn as_str(self) -> &'static str {
         match self {
             RoleType::Validator => "validator",
             RoleType::FullNode => "full_node",

--- a/config/src/config/mod.rs
+++ b/config/src/config/mod.rs
@@ -13,7 +13,6 @@ use std::{
     str::FromStr,
 };
 use thiserror::Error;
-use toml;
 
 mod admission_control_config;
 pub use admission_control_config::*;

--- a/consensus/Cargo.toml
+++ b/consensus/Cargo.toml
@@ -55,7 +55,6 @@ vm-runtime = { path = "../language/vm/vm-runtime", version = "0.1.0" }
 
 [dev-dependencies]
 cached = "0.11.0"
-parity-multiaddr = "0.7.2"
 proptest = "0.9.4"
 tempfile = "3.1.0"
 

--- a/consensus/safety-rules/src/error.rs
+++ b/consensus/safety-rules/src/error.rs
@@ -1,7 +1,6 @@
 // Copyright (c) The Libra Core Contributors
 // SPDX-License-Identifier: Apache-2.0
 
-use anyhow;
 use consensus_types::common::Round;
 use serde::{Deserialize, Serialize};
 use thiserror::Error;

--- a/consensus/safety-rules/src/spawned_process.rs
+++ b/consensus/safety-rules/src/spawned_process.rs
@@ -10,7 +10,6 @@ use std::{
     net::SocketAddr,
     process::{Child, Command, Stdio},
 };
-use workspace_builder;
 
 const BINARY: &str = "safety-rules";
 

--- a/consensus/src/chained_bft/block_storage/sync_manager.rs
+++ b/consensus/src/chained_bft/block_storage/sync_manager.rs
@@ -322,6 +322,7 @@ const RETRIEVAL_MAX_EXP: u32 = 4;
 
 /// Returns exponentially increasing timeout with
 /// limit of RETRIEVAL_INITIAL_TIMEOUT*(2^RETRIEVAL_MAX_EXP)
+#[allow(clippy::trivially_copy_pass_by_ref)]
 fn retrieval_timeout(deadline: &Instant, attempt: u32) -> Option<Duration> {
     assert!(attempt > 0, "retrieval_timeout attempt can't be 0");
     let exp = RETRIEVAL_MAX_EXP.min(attempt - 1); // [0..RETRIEVAL_MAX_EXP]

--- a/consensus/src/chained_bft/chained_bft_smr.rs
+++ b/consensus/src/chained_bft/chained_bft_smr.rs
@@ -15,7 +15,6 @@ use crate::{
     util::time_service::ClockTimeService,
 };
 use anyhow::Result;
-use channel;
 use consensus_types::common::{Author, Payload, Round};
 use futures::{select, stream::StreamExt};
 use libra_config::config::{ConsensusConfig, NodeConfig};

--- a/consensus/src/chained_bft/liveness/pacemaker.rs
+++ b/consensus/src/chained_bft/liveness/pacemaker.rs
@@ -5,7 +5,6 @@ use crate::{
     counters,
     util::time_service::{SendTask, TimeService},
 };
-use channel;
 use consensus_types::common::Round;
 use libra_logger::prelude::*;
 use std::{

--- a/consensus/src/chained_bft/liveness/pacemaker_test.rs
+++ b/consensus/src/chained_bft/liveness/pacemaker_test.rs
@@ -8,7 +8,6 @@ use crate::{
     util::mock_time_service::SimulatedTimeService,
 };
 
-use channel;
 use consensus_types::common::Round;
 use futures::{executor::block_on, StreamExt};
 use std::{sync::Arc, time::Duration};

--- a/consensus/src/util/time_service.rs
+++ b/consensus/src/util/time_service.rs
@@ -1,7 +1,6 @@
 // Copyright (c) The Libra Core Contributors
 // SPDX-License-Identifier: Apache-2.0
 
-use channel;
 use futures::{Future, FutureExt, SinkExt};
 use libra_logger::prelude::*;
 use std::{

--- a/crypto/crypto/src/ed25519.rs
+++ b/crypto/crypto/src/ed25519.rs
@@ -32,7 +32,6 @@
 use crate::{traits::*, HashValue};
 use anyhow::{anyhow, Result};
 use core::convert::TryFrom;
-use ed25519_dalek;
 use libra_crypto_derive::{DeserializeKey, SerializeKey, SilentDebug, SilentDisplay};
 use std::cmp::Ordering;
 

--- a/crypto/crypto/src/unit_tests/ed25519_test.rs
+++ b/crypto/crypto/src/unit_tests/ed25519_test.rs
@@ -13,7 +13,6 @@ use core::{
 };
 
 use crate::hash::HashValue;
-use ed25519_dalek;
 use proptest::prelude::*;
 
 proptest! {

--- a/crypto/crypto/src/x25519.rs
+++ b/crypto/crypto/src/x25519.rs
@@ -61,7 +61,6 @@ use libra_crypto_derive::{Deref, DeserializeKey, SerializeKey, SilentDebug, Sile
 use rand::{rngs::EntropyRng, RngCore};
 use sha2::Sha256;
 use std::{convert::TryFrom, ops::Deref};
-use x25519_dalek;
 
 /// TODO: move traits to the right file (possibly traits.rs)
 

--- a/executor/src/executor_test.rs
+++ b/executor/src/executor_test.rs
@@ -8,7 +8,6 @@ use crate::{
     },
     Executor, OP_COUNTERS,
 };
-use config_builder;
 use libra_config::config::NodeConfig;
 use libra_crypto::{hash::PRE_GENESIS_BLOCK_ID, HashValue};
 use libra_types::block_info::BlockInfo;

--- a/executor/tests/storage_integration_test.rs
+++ b/executor/tests/storage_integration_test.rs
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use anyhow::{ensure, format_err, Result};
-use config_builder;
 use executor::utils::create_storage_service_and_executor;
 use libra_config::config::{VMConfig, VMPublishingOption};
 use libra_crypto::{ed25519::*, test_utils::TEST_SEED, HashValue, PrivateKey};

--- a/language/bytecode-verifier/src/absint.rs
+++ b/language/bytecode-verifier/src/absint.rs
@@ -118,7 +118,7 @@ pub trait AbstractInterpreter: TransferFunctions {
                 }
             };
             // propagate postcondition of this block to successor blocks
-            for next_block_id in cfg.successors(&block_id) {
+            for next_block_id in cfg.successors(block_id) {
                 match inv_map.get_mut(next_block_id) {
                     Some(next_block_invariant) => {
                         let join_result = match &mut next_block_invariant.pre {
@@ -168,8 +168,8 @@ pub trait AbstractInterpreter: TransferFunctions {
         function_view: &FunctionDefinitionView<CompiledModule>,
         cfg: &dyn ControlFlowGraph,
     ) -> Result<(), Self::AnalysisError> {
-        let block_end = cfg.block_end(&block_id);
-        for offset in cfg.instr_indexes(&block_id) {
+        let block_end = cfg.block_end(block_id);
+        for offset in cfg.instr_indexes(block_id) {
             let instr = &function_view.code().code[offset as usize];
             self.execute(state, instr, offset as usize, block_end as usize)?
         }

--- a/language/bytecode-verifier/src/control_flow_graph.rs
+++ b/language/bytecode-verifier/src/control_flow_graph.rs
@@ -14,16 +14,16 @@ pub type BlockId = CodeOffset;
 /// A trait that specifies the basic requirements for a CFG
 pub trait ControlFlowGraph {
     /// Start index of the block ID in the bytecode vector
-    fn block_start(&self, block_id: &BlockId) -> CodeOffset;
+    fn block_start(&self, block_id: BlockId) -> CodeOffset;
 
     /// End index of the block ID in the bytecode vector
-    fn block_end(&self, block_id: &BlockId) -> CodeOffset;
+    fn block_end(&self, block_id: BlockId) -> CodeOffset;
 
     /// Successors of the block ID in the bytecode vector
-    fn successors(&self, block_id: &BlockId) -> &Vec<BlockId>;
+    fn successors(&self, block_id: BlockId) -> &Vec<BlockId>;
 
     /// Iterator over the indexes of instructions in this block
-    fn instr_indexes(&self, block_id: &BlockId) -> Box<dyn Iterator<Item = CodeOffset>>;
+    fn instr_indexes(&self, block_id: BlockId) -> Box<dyn Iterator<Item = CodeOffset>>;
 
     /// Return an iterator over the blocks of the CFG
     fn blocks(&self) -> Vec<BlockId>;
@@ -132,7 +132,7 @@ impl VMControlFlowGraph {
         while index < ret.len() {
             let block_id = ret[index];
             index += 1;
-            let successors = self.successors(&block_id);
+            let successors = self.successors(block_id);
             for block_id in successors.iter() {
                 if !seen.contains(&block_id) {
                     ret.push(*block_id);
@@ -157,23 +157,23 @@ impl ControlFlowGraph for VMControlFlowGraph {
     // Note: it is still possible to get a BlockId from one CFG and use it in another CFG where it
     // is not valid. The design does not attempt to prevent this abuse of the API.
 
-    fn block_start(&self, block_id: &BlockId) -> CodeOffset {
-        self.blocks[block_id].entry
+    fn block_start(&self, block_id: BlockId) -> CodeOffset {
+        self.blocks[&block_id].entry
     }
 
-    fn block_end(&self, block_id: &BlockId) -> CodeOffset {
-        self.blocks[block_id].exit
+    fn block_end(&self, block_id: BlockId) -> CodeOffset {
+        self.blocks[&block_id].exit
     }
 
-    fn successors(&self, block_id: &BlockId) -> &Vec<BlockId> {
-        &self.blocks[block_id].successors
+    fn successors(&self, block_id: BlockId) -> &Vec<BlockId> {
+        &self.blocks[&block_id].successors
     }
 
     fn blocks(&self) -> Vec<BlockId> {
         self.blocks.keys().cloned().collect()
     }
 
-    fn instr_indexes(&self, block_id: &BlockId) -> Box<dyn Iterator<Item = CodeOffset>> {
+    fn instr_indexes(&self, block_id: BlockId) -> Box<dyn Iterator<Item = CodeOffset>> {
         Box::new(self.block_start(block_id)..=self.block_end(block_id))
     }
 

--- a/language/bytecode-verifier/src/nonce.rs
+++ b/language/bytecode-verifier/src/nonce.rs
@@ -13,11 +13,11 @@ impl Nonce {
         Self(n)
     }
 
-    pub fn is(&self, n: usize) -> bool {
+    pub fn is(self, n: usize) -> bool {
         self.0 == n
     }
 
-    pub fn inner(&self) -> usize {
+    pub fn inner(self) -> usize {
         self.0
     }
 }

--- a/language/bytecode-verifier/src/stack_usage_verifier.rs
+++ b/language/bytecode-verifier/src/stack_usage_verifier.rs
@@ -36,12 +36,12 @@ impl<'a> StackUsageVerifier<'a> {
 
         let mut errors = vec![];
         for block_id in cfg.blocks() {
-            errors.append(&mut verifier.verify_block(&block_id, cfg));
+            errors.append(&mut verifier.verify_block(block_id, cfg));
         }
         errors
     }
 
-    fn verify_block(&self, block_id: &BlockId, cfg: &dyn ControlFlowGraph) -> Vec<VMStatus> {
+    fn verify_block(&self, block_id: BlockId, cfg: &dyn ControlFlowGraph) -> Vec<VMStatus> {
         let code = &self.function_definition_view.code().code;
         let mut stack_size_increment = 0;
         let block_start = cfg.block_start(block_id);

--- a/language/compiler/ir-to-bytecode/src/parser.rs
+++ b/language/compiler/ir-to-bytecode/src/parser.rs
@@ -114,9 +114,9 @@ pub fn parse_cmd_(cmd_str: &str, _sender_address: AccountAddress) -> Result<ast:
     syntax::parse_cmd_string(stripped_string).or_else(|e| handle_error(e, stripped_string))
 }
 
-fn handle_error<'input, T>(
+fn handle_error<T>(
     e: syntax::ParseError<usize, anyhow::Error>,
-    code_str: &'input str,
+    code_str: &str,
 ) -> Result<T> {
     let mut s = DefaultHasher::new();
     code_str.hash(&mut s);

--- a/language/compiler/ir-to-bytecode/src/parser.rs
+++ b/language/compiler/ir-to-bytecode/src/parser.rs
@@ -114,10 +114,7 @@ pub fn parse_cmd_(cmd_str: &str, _sender_address: AccountAddress) -> Result<ast:
     syntax::parse_cmd_string(stripped_string).or_else(|e| handle_error(e, stripped_string))
 }
 
-fn handle_error<T>(
-    e: syntax::ParseError<usize, anyhow::Error>,
-    code_str: &str,
-) -> Result<T> {
+fn handle_error<T>(e: syntax::ParseError<usize, anyhow::Error>, code_str: &str) -> Result<T> {
     let mut s = DefaultHasher::new();
     code_str.hash(&mut s);
     let mut code = CodeMap::new();

--- a/language/compiler/ir-to-bytecode/syntax/src/lexer.rs
+++ b/language/compiler/ir-to-bytecode/syntax/src/lexer.rs
@@ -116,7 +116,7 @@ pub enum Tok {
 impl Tok {
     /// Return true if the given token is the beginning of a specification directive for the Move
     /// prover
-    pub fn is_spec_directive(&self) -> bool {
+    pub fn is_spec_directive(self) -> bool {
         match self {
             Tok::Ensures | Tok::Requires | Tok::SucceedsIf | Tok::AbortsIf => true,
             _ => false,

--- a/language/compiler/ir-to-bytecode/syntax/src/syntax.rs
+++ b/language/compiler/ir-to-bytecode/syntax/src/syntax.rs
@@ -7,7 +7,6 @@ use std::fmt;
 use std::str::FromStr;
 
 use crate::lexer::*;
-use hex;
 use libra_types::identifier::Identifier;
 use libra_types::{account_address::AccountAddress, byte_array::ByteArray};
 use move_ir_types::{ast::*, spec_language_ast::*};

--- a/language/compiler/ir-to-bytecode/syntax/src/syntax.rs
+++ b/language/compiler/ir-to-bytecode/syntax/src/syntax.rs
@@ -2088,40 +2088,40 @@ fn parse_script_or_module<'input>(
     }
 }
 
-pub fn parse_cmd_string<'input>(
-    input: &'input str,
+pub fn parse_cmd_string(
+    input: &str,
 ) -> Result<Cmd_, ParseError<usize, anyhow::Error>> {
     let mut tokens = Lexer::new(input);
     tokens.advance()?;
     parse_cmd_(&mut tokens)
 }
 
-pub fn parse_module_string<'input>(
-    input: &'input str,
+pub fn parse_module_string(
+    input: &str,
 ) -> Result<ModuleDefinition, ParseError<usize, anyhow::Error>> {
     let mut tokens = Lexer::new(input);
     tokens.advance()?;
     parse_module(&mut tokens)
 }
 
-pub fn parse_program_string<'input>(
-    input: &'input str,
+pub fn parse_program_string(
+    input: &str,
 ) -> Result<Program, ParseError<usize, anyhow::Error>> {
     let mut tokens = Lexer::new(input);
     tokens.advance()?;
     parse_program(&mut tokens)
 }
 
-pub fn parse_script_string<'input>(
-    input: &'input str,
+pub fn parse_script_string(
+    input: &str,
 ) -> Result<Script, ParseError<usize, anyhow::Error>> {
     let mut tokens = Lexer::new(input);
     tokens.advance()?;
     parse_script(&mut tokens)
 }
 
-pub fn parse_script_or_module_string<'input>(
-    input: &'input str,
+pub fn parse_script_or_module_string(
+    input: &str,
 ) -> Result<ScriptOrModule, ParseError<usize, anyhow::Error>> {
     let mut tokens = Lexer::new(input);
     tokens.advance()?;

--- a/language/compiler/ir-to-bytecode/syntax/src/syntax.rs
+++ b/language/compiler/ir-to-bytecode/syntax/src/syntax.rs
@@ -272,7 +272,7 @@ fn parse_copyable_val<'input>(
 // for the code in parse_rhs_of_binary_exp.
 // Precedences are not sequential to make it easier to add new binops without
 // renumbering everything.
-fn get_precedence(token: &Tok) -> u32 {
+fn get_precedence(token: Tok) -> u32 {
     match token {
         // Reserved minimum precedence value is 1 (specified in parse_exp_)
         // TODO
@@ -315,7 +315,7 @@ fn parse_rhs_of_binary_exp<'input>(
     min_prec: u32,
 ) -> Result<Exp, ParseError<usize, anyhow::Error>> {
     let mut result = lhs;
-    let mut next_tok_prec = get_precedence(&tokens.peek());
+    let mut next_tok_prec = get_precedence(tokens.peek());
 
     // Continue parsing binary expressions as long as they have they
     // specified minimum precedence.
@@ -328,10 +328,10 @@ fn parse_rhs_of_binary_exp<'input>(
         // If the next token is another binary operator with a higher
         // precedence, then recursively parse that expression as the RHS.
         let this_prec = next_tok_prec;
-        next_tok_prec = get_precedence(&tokens.peek());
+        next_tok_prec = get_precedence(tokens.peek());
         if this_prec < next_tok_prec {
             rhs = parse_rhs_of_binary_exp(tokens, rhs, this_prec + 1)?;
-            next_tok_prec = get_precedence(&tokens.peek());
+            next_tok_prec = get_precedence(tokens.peek());
         }
 
         let op = match op_token {
@@ -1516,7 +1516,7 @@ fn parse_rhs_of_spec_exp<'input>(
     min_prec: u32,
 ) -> Result<SpecExp, ParseError<usize, anyhow::Error>> {
     let mut result = lhs;
-    let mut next_tok_prec = get_precedence(&tokens.peek());
+    let mut next_tok_prec = get_precedence(tokens.peek());
 
     // Continue parsing binary expressions as long as they have they
     // specified minimum precedence.
@@ -1529,10 +1529,10 @@ fn parse_rhs_of_spec_exp<'input>(
         // If the next token is another binary operator with a higher
         // precedence, then recursively parse that expression as the RHS.
         let this_prec = next_tok_prec;
-        next_tok_prec = get_precedence(&tokens.peek());
+        next_tok_prec = get_precedence(tokens.peek());
         if this_prec < next_tok_prec {
             rhs = parse_rhs_of_spec_exp(tokens, rhs, this_prec + 1)?;
-            next_tok_prec = get_precedence(&tokens.peek());
+            next_tok_prec = get_precedence(tokens.peek());
         }
         // TODO: Should we treat ==> like a normal BinOp?
         // TODO: Implement IFF

--- a/language/compiler/ir-to-bytecode/syntax/src/syntax.rs
+++ b/language/compiler/ir-to-bytecode/syntax/src/syntax.rs
@@ -2087,9 +2087,7 @@ fn parse_script_or_module<'input>(
     }
 }
 
-pub fn parse_cmd_string(
-    input: &str,
-) -> Result<Cmd_, ParseError<usize, anyhow::Error>> {
+pub fn parse_cmd_string(input: &str) -> Result<Cmd_, ParseError<usize, anyhow::Error>> {
     let mut tokens = Lexer::new(input);
     tokens.advance()?;
     parse_cmd_(&mut tokens)
@@ -2103,17 +2101,13 @@ pub fn parse_module_string(
     parse_module(&mut tokens)
 }
 
-pub fn parse_program_string(
-    input: &str,
-) -> Result<Program, ParseError<usize, anyhow::Error>> {
+pub fn parse_program_string(input: &str) -> Result<Program, ParseError<usize, anyhow::Error>> {
     let mut tokens = Lexer::new(input);
     tokens.advance()?;
     parse_program(&mut tokens)
 }
 
-pub fn parse_script_string(
-    input: &str,
-) -> Result<Script, ParseError<usize, anyhow::Error>> {
+pub fn parse_script_string(input: &str) -> Result<Script, ParseError<usize, anyhow::Error>> {
     let mut tokens = Lexer::new(input);
     tokens.advance()?;
     parse_script(&mut tokens)

--- a/language/compiler/src/main.rs
+++ b/language/compiler/src/main.rs
@@ -16,7 +16,6 @@ use libra_types::{
     transaction::{Module, Script},
     vm_error::VMStatus,
 };
-use serde_json;
 use std::{
     convert::TryFrom,
     fs,

--- a/language/e2e-tests/src/account_universe/create_account.rs
+++ b/language/e2e-tests/src/account_universe/create_account.rs
@@ -34,7 +34,7 @@ impl AUTransactionGen for CreateAccountGen {
         &self,
         universe: &mut AccountUniverse,
     ) -> (SignedTransaction, (TransactionStatus, u64)) {
-        let sender = universe.pick(&self.sender).1;
+        let sender = universe.pick(self.sender).1;
 
         let txn = create_account_txn(
             sender.account(),

--- a/language/e2e-tests/src/account_universe/peer_to_peer.rs
+++ b/language/e2e-tests/src/account_universe/peer_to_peer.rs
@@ -125,7 +125,7 @@ impl AUTransactionGen for P2PNewReceiverGen {
         &self,
         universe: &mut AccountUniverse,
     ) -> (SignedTransaction, (TransactionStatus, u64)) {
-        let sender = universe.pick(&self.sender).1;
+        let sender = universe.pick(self.sender).1;
 
         // Create a new, nonexistent account for the receiver.
         let txn = peer_to_peer_txn(

--- a/language/e2e-tests/src/account_universe/rotate_key.rs
+++ b/language/e2e-tests/src/account_universe/rotate_key.rs
@@ -30,7 +30,7 @@ impl AUTransactionGen for RotateKeyGen {
         &self,
         universe: &mut AccountUniverse,
     ) -> (SignedTransaction, (TransactionStatus, u64)) {
-        let sender = universe.pick(&self.sender).1;
+        let sender = universe.pick(self.sender).1;
 
         let new_key_hash = AccountAddress::from_public_key(&self.new_key.1);
         let txn = rotate_key_txn(sender.account(), new_key_hash, sender.sequence_number);

--- a/language/e2e-tests/src/account_universe/universe.rs
+++ b/language/e2e-tests/src/account_universe/universe.rs
@@ -160,7 +160,7 @@ impl AccountUniverse {
     }
 
     /// Picks an account using the provided `Index` as a source of randomness.
-    pub fn pick(&mut self, index: &Index) -> (usize, &mut AccountCurrent) {
+    pub fn pick(&mut self, index: Index) -> (usize, &mut AccountCurrent) {
         let idx = self.picker.pick(index);
         (idx, &mut self.accounts[idx])
     }
@@ -185,7 +185,7 @@ impl AccountPicker {
         }
     }
 
-    fn pick(&mut self, index: &Index) -> usize {
+    fn pick(&mut self, index: Index) -> usize {
         match self {
             AccountPicker::Unlimited(num_accounts) => index.index(*num_accounts),
             AccountPicker::Limited(remaining) => {

--- a/language/functional-tests/src/evaluator.rs
+++ b/language/functional-tests/src/evaluator.rs
@@ -109,7 +109,7 @@ impl EvaluationOutput {
 
 /// A log consisting of outputs from all stages and the final status.
 /// This is checked against the directives.
-#[derive(Debug)]
+#[derive(Debug, Default)]
 pub struct EvaluationLog {
     pub outputs: Vec<EvaluationOutput>,
 }

--- a/language/move-lang/src/cfgir/cfg.rs
+++ b/language/move-lang/src/cfgir/cfg.rs
@@ -323,7 +323,7 @@ impl AstDebug for BlockCFG<'_> {
         w.writeln("--BlockCFG--");
         ast_debug_cfg(
             w,
-            start,
+            *start,
             blocks,
             successor_map.iter(),
             predecessor_map.iter(),
@@ -342,7 +342,7 @@ impl AstDebug for ReverseBlockCFG<'_> {
         w.writeln("--ReverseBlockCFG--");
         ast_debug_cfg(
             w,
-            start,
+            *start,
             blocks,
             successor_map.iter(),
             predecessor_map.iter(),
@@ -352,7 +352,7 @@ impl AstDebug for ReverseBlockCFG<'_> {
 
 fn ast_debug_cfg<'a>(
     w: &mut AstWriter,
-    start: &Label,
+    start: Label,
     blocks: &Blocks,
     successor_map: impl Iterator<Item = (&'a Label, &'a BTreeSet<Label>)>,
     predecessor_map: impl Iterator<Item = (&'a Label, &'a BTreeSet<Label>)>,

--- a/language/move-lang/src/shared/mod.rs
+++ b/language/move-lang/src/shared/mod.rs
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use codespan::Span;
-use hex;
 use std::{
     cmp::Ordering,
     convert::TryFrom,

--- a/language/move-lang/tests/move_check_testsuite.rs
+++ b/language/move-lang/tests/move_check_testsuite.rs
@@ -1,7 +1,6 @@
 // Copyright (c) The Libra Core Contributors
 // SPDX-License-Identifier: Apache-2.0
 
-use difference;
 use move_lang::{move_compile_no_report, shared::Address};
 use std::{fs, path::Path};
 

--- a/language/move-prover/bytecode-to-boogie/src/boogie_helpers.rs
+++ b/language/move-prover/bytecode-to-boogie/src/boogie_helpers.rs
@@ -39,7 +39,7 @@ pub fn boogie_type_value(env: &GlobalEnv, sig: &GlobalType) -> String {
         }
         GlobalType::TypeParameter(index) => format!("tv{}", index),
         GlobalType::Struct(module_idx, struct_idx, args) => {
-            boogie_struct_type_value(env, *module_idx, struct_idx, args)
+            boogie_struct_type_value(env, *module_idx, *struct_idx, args)
         }
         // TODO: Need a boogie type for subrange?
         GlobalType::Subrange => "Unimplemented boogie subrange".to_string(),
@@ -50,7 +50,7 @@ pub fn boogie_type_value(env: &GlobalEnv, sig: &GlobalType) -> String {
 pub fn boogie_struct_type_value(
     env: &GlobalEnv,
     module_idx: usize,
-    struct_idx: &StructDefinitionIndex,
+    struct_idx: StructDefinitionIndex,
     args: &[GlobalType],
 ) -> String {
     let module_env = env.get_module(module_idx);
@@ -91,7 +91,7 @@ pub fn boogie_type_check_expr(env: &GlobalEnv, name: &str, sig: &GlobalType) -> 
         GlobalType::Address => conds.push(format!("is#Address({})", name)),
         GlobalType::ByteArray => conds.push(format!("is#ByteArray({})", name)),
         GlobalType::Struct(module_idx, struct_idx, _) => {
-            let struct_env = env.get_module(*module_idx).into_get_struct(struct_idx);
+            let struct_env = env.get_module(*module_idx).into_get_struct(*struct_idx);
             conds.push(format!(
                 "${}_is_well_formed({})",
                 boogie_struct_name(&struct_env),

--- a/language/move-prover/bytecode-to-boogie/src/boogie_wrapper.rs
+++ b/language/move-prover/bytecode-to-boogie/src/boogie_wrapper.rs
@@ -62,7 +62,7 @@ pub enum BoogieErrorKind {
 }
 
 impl BoogieErrorKind {
-    fn from_verification(self) -> bool {
+    fn is_from_verification(self) -> bool {
         self == BoogieErrorKind::Assertion || self == BoogieErrorKind::Postcondition
     }
 }
@@ -159,7 +159,7 @@ impl<'env> BoogieWrapper<'env> {
 
         // Determine whether we report this error on the source
         let on_source =
-            error.kind.from_verification() && self.to_proper_source_location(location).is_some();
+            error.kind.is_from_verification() && self.to_proper_source_location(location).is_some();
 
         // Create label (position information) for main error.
         let label = Label::new_primary(if on_source {
@@ -193,7 +193,7 @@ impl<'env> BoogieWrapper<'env> {
         );
 
         // Now add trace diagnostics.
-        if error.kind.from_verification() && !error.execution_trace.is_empty() {
+        if error.kind.is_from_verification() && !error.execution_trace.is_empty() {
             // Add trace information.
             let mut locals_shown = BTreeSet::new();
             let mut aborted = false;

--- a/language/move-prover/bytecode-to-boogie/src/boogie_wrapper.rs
+++ b/language/move-prover/bytecode-to-boogie/src/boogie_wrapper.rs
@@ -62,8 +62,8 @@ pub enum BoogieErrorKind {
 }
 
 impl BoogieErrorKind {
-    fn from_verification(&self) -> bool {
-        self == &BoogieErrorKind::Assertion || self == &BoogieErrorKind::Postcondition
+    fn from_verification(self) -> bool {
+        self == BoogieErrorKind::Assertion || self == BoogieErrorKind::Postcondition
     }
 }
 
@@ -641,7 +641,7 @@ impl Model {
                 .extract_number()
                 .ok_or_else(Self::invalid_track_info)
                 .and_then(Self::index_range_check(module_env.get_function_count()))?;
-            let func_env = module_env.get_function(&FunctionDefinitionIndex(func_idx as u16));
+            let func_env = module_env.get_function(FunctionDefinitionIndex(func_idx as u16));
             let var_idx = args[2]
                 .extract_number()
                 .ok_or_else(Self::invalid_track_info)
@@ -936,7 +936,7 @@ impl ModelValue {
     ) -> Option<PrettyDoc> {
         let error = ModelValue::error();
         let module_env = env.get_module(module_idx);
-        let struct_env = module_env.get_struct(&struct_idx);
+        let struct_env = module_env.get_struct(struct_idx);
         let values = self.extract_vector(model)?;
         let entries = if struct_env.is_vector() {
             values

--- a/language/move-prover/bytecode-to-boogie/src/bytecode_translator.rs
+++ b/language/move-prover/bytecode-to-boogie/src/bytecode_translator.rs
@@ -426,7 +426,7 @@ impl<'env> ModuleTranslator<'env> {
                         .module_env
                         .env
                         .get_module(*module_idx)
-                        .into_get_struct(struct_idx);
+                        .into_get_struct(*struct_idx);
                     emitln!(
                         self.writer,
                         "call ${}_update_inv({}, Dereference(__m, {}_ref));",
@@ -567,8 +567,8 @@ impl<'env> ModuleTranslator<'env> {
             FreezeRef(dest, src) => emitln!(self.writer, "call __t{} := FreezeRef(__t{});", dest, src),
             Call(dests, callee_index, type_actuals, args) => {
                 let (callee_module_env, callee_def_idx) =
-                    self.module_env.get_callee_info(callee_index);
-                let callee_env = callee_module_env.get_function(&callee_def_idx);
+                    self.module_env.get_callee_info(*callee_index);
+                let callee_env = callee_module_env.get_function(callee_def_idx);
                 let mut dest_str = String::new();
                 let mut args_str = String::new();
                 let mut dest_type_assumptions = vec![];
@@ -645,7 +645,7 @@ impl<'env> ModuleTranslator<'env> {
                 }
             }
             Pack(dest, struct_def_index, type_actuals, fields) => {
-                let struct_env = func_env.module_env.get_struct(struct_def_index);
+                let struct_env = func_env.module_env.get_struct(*struct_def_index);
                 let effective_dest = effective_dest_func(*dest);
                 let track_args =
                     if effective_dest < func_env.get_local_count() {
@@ -678,7 +678,7 @@ impl<'env> ModuleTranslator<'env> {
                 );
             }
             Unpack(dests, struct_def_index, _, src) => {
-                let struct_env = &func_env.module_env.get_struct(struct_def_index);
+                let struct_env = &func_env.module_env.get_struct(*struct_def_index);
                 let mut dests_str = String::new();
                 let mut tmp_assignments = vec![];
                 for dest in dests.iter() {
@@ -706,8 +706,8 @@ impl<'env> ModuleTranslator<'env> {
                 }
             }
             BorrowField(dest, src, field_def_index) => {
-                let struct_env = self.module_env.get_struct_of_field(field_def_index);
-                let field_env = &struct_env.get_field(field_def_index);
+                let struct_env = self.module_env.get_struct_of_field(*field_def_index);
+                let field_env = &struct_env.get_field(*field_def_index);
                 emitln!(
                     self.writer,
                     "call __t{} := BorrowField(__t{}, {});",
@@ -721,7 +721,7 @@ impl<'env> ModuleTranslator<'env> {
                 let resource_type = boogie_struct_type_value(
                     self.module_env.env,
                     self.module_env.get_module_idx(),
-                    struct_def_index,
+                    *struct_def_index,
                     &self.module_env.get_type_actuals(*type_actuals),
                 );
                 emitln!(
@@ -736,7 +736,7 @@ impl<'env> ModuleTranslator<'env> {
                 let resource_type = boogie_struct_type_value(
                     self.module_env.env,
                     self.module_env.get_module_idx(),
-                    struct_def_index,
+                    *struct_def_index,
                     &self.module_env.get_type_actuals(*type_actuals),
                 );
                 emitln!(
@@ -753,7 +753,7 @@ impl<'env> ModuleTranslator<'env> {
                 let resource_type = boogie_struct_type_value(
                     self.module_env.env,
                     self.module_env.get_module_idx(),
-                    struct_def_index,
+                    *struct_def_index,
                     &self.module_env.get_type_actuals(*type_actuals),
                 );
                 emitln!(
@@ -768,7 +768,7 @@ impl<'env> ModuleTranslator<'env> {
                 let resource_type = boogie_struct_type_value(
                     self.module_env.env,
                     self.module_env.get_module_idx(),
-                    struct_def_index,
+                    *struct_def_index,
                     &self.module_env.get_type_actuals(*type_actuals),
                 );
                 emitln!(
@@ -855,7 +855,7 @@ impl<'env> ModuleTranslator<'env> {
                 emitln!(self.writer, &update_and_track_local(*dest, "__tmp"));
             }
             LdAddr(idx, addr_idx) => {
-                let addr_int = self.module_env.get_address(addr_idx);
+                let addr_int = self.module_env.get_address(*addr_idx);
                 emitln!(self.writer, "call __tmp := LdAddr({});", addr_int);
                 emitln!(self.writer, &update_and_track_local(*idx, "__tmp"));
             }
@@ -1346,7 +1346,7 @@ impl<'env> ModuleTranslator<'env> {
                         .module_env
                         .env
                         .get_module(*module_idx)
-                        .into_get_struct(struct_idx);
+                        .into_get_struct(*struct_idx);
                     if !struct_env.get_data_invariants().is_empty()
                         || !struct_env.get_update_invariants().is_empty()
                     {

--- a/language/move-prover/bytecode-to-boogie/src/driver.rs
+++ b/language/move-prover/bytecode-to-boogie/src/driver.rs
@@ -261,7 +261,7 @@ impl Driver {
     }
 
     /// Creates a BoogieWrapper which allows to call boogie and analyze results.
-    pub fn new_boogie_wrapper<'env>(&'env self) -> BoogieWrapper<'env> {
+    pub fn new_boogie_wrapper(&self) -> BoogieWrapper<'_> {
         BoogieWrapper {
             env: &self.env,
             writer: &self.writer,

--- a/language/move-prover/bytecode-to-boogie/src/env.rs
+++ b/language/move-prover/bytecode-to-boogie/src/env.rs
@@ -259,7 +259,7 @@ impl GlobalEnv {
     }
 
     /// Gets a module by index.
-    pub fn get_module<'env>(&'env self, idx: usize) -> ModuleEnv<'env> {
+    pub fn get_module(&self, idx: usize) -> ModuleEnv<'_> {
         let module_data = &self.module_data[idx];
         ModuleEnv {
             env: self,
@@ -268,7 +268,7 @@ impl GlobalEnv {
     }
 
     /// Returns an iterator for all modules in the environment.
-    pub fn get_modules<'env>(&'env self) -> impl Iterator<Item = ModuleEnv<'env>> {
+    pub fn get_modules(&self) -> impl Iterator<Item = ModuleEnv<'_>> {
         self.module_data.iter().map(move |module_data| ModuleEnv {
             env: self,
             data: module_data,
@@ -276,7 +276,7 @@ impl GlobalEnv {
     }
 
     /// Returns an iterator for all bytecode modules in the environment.
-    pub fn get_bytecode_modules<'env>(&'env self) -> impl Iterator<Item = &'env VerifiedModule> {
+    pub fn get_bytecode_modules(&self) -> impl Iterator<Item = &VerifiedModule> {
         self.module_data
             .iter()
             .map(|module_data| &module_data.module)

--- a/language/move-prover/bytecode-to-boogie/src/env.rs
+++ b/language/move-prover/bytecode-to-boogie/src/env.rs
@@ -437,7 +437,7 @@ impl<'env> ModuleEnv<'env> {
     }
 
     /// Gets a FunctionEnv by index.
-    pub fn get_function(&'env self, idx: &FunctionDefinitionIndex) -> FunctionEnv<'env> {
+    pub fn get_function(&'env self, idx: FunctionDefinitionIndex) -> FunctionEnv<'env> {
         let data = &self.data.function_data[idx.0 as usize];
         FunctionEnv {
             module_env: self.clone(),
@@ -485,10 +485,10 @@ impl<'env> ModuleEnv<'env> {
     /// for which the `func_env` contains a reference.
     pub fn get_callee_info(
         &'env self,
-        idx: &FunctionHandleIndex,
+        idx: FunctionHandleIndex,
     ) -> (ModuleEnv<'env>, FunctionDefinitionIndex) {
         let view =
-            FunctionHandleView::new(&self.data.module, self.data.module.function_handle_at(*idx));
+            FunctionHandleView::new(&self.data.module, self.data.module.function_handle_at(idx));
         let module_env = self
             .env
             .find_module(&view.module_id())
@@ -516,7 +516,7 @@ impl<'env> ModuleEnv<'env> {
     }
 
     /// Gets a StructEnv by index.
-    pub fn get_struct(&'env self, idx: &StructDefinitionIndex) -> StructEnv<'env> {
+    pub fn get_struct(&'env self, idx: StructDefinitionIndex) -> StructEnv<'env> {
         let data = &self.data.struct_data[idx.0 as usize];
         StructEnv {
             module_env: self.clone(),
@@ -525,7 +525,7 @@ impl<'env> ModuleEnv<'env> {
     }
 
     /// Gets a StructEnv by index.
-    pub fn into_get_struct(self, idx: &StructDefinitionIndex) -> StructEnv<'env> {
+    pub fn into_get_struct(self, idx: StructDefinitionIndex) -> StructEnv<'env> {
         let data = &self.data.struct_data[idx.0 as usize];
         StructEnv {
             module_env: self,
@@ -540,9 +540,9 @@ impl<'env> ModuleEnv<'env> {
 
     /// Gets the struct declaring a field specified by FieldDefinitionIndex,
     /// as it is globally unique for this module.
-    pub fn get_struct_of_field(&'env self, idx: &FieldDefinitionIndex) -> StructEnv<'env> {
+    pub fn get_struct_of_field(&'env self, idx: FieldDefinitionIndex) -> StructEnv<'env> {
         let field_view =
-            FieldDefinitionView::new(&self.data.module, self.data.module.field_def_at(*idx));
+            FieldDefinitionView::new(&self.data.module, self.data.module.field_def_at(idx));
         let struct_name = field_view.member_of().name();
         self.find_struct(struct_name).expect("struct undefined")
     }
@@ -606,7 +606,7 @@ impl<'env> ModuleEnv<'env> {
     }
 
     /// Converts an address pool index for this module into a number representing the address.
-    pub fn get_address(&self, idx: &AddressPoolIndex) -> BigInt {
+    pub fn get_address(&self, idx: AddressPoolIndex) -> BigInt {
         let addr = &self.data.module.address_pool()[idx.0 as usize];
         BigInt::from_str_radix(&addr.to_string(), 16).unwrap()
     }
@@ -840,9 +840,9 @@ impl<'env> StructEnv<'env> {
     }
 
     /// Gets a field by its definition index.
-    pub fn get_field(&'env self, idx: &FieldDefinitionIndex) -> FieldEnv<'env> {
+    pub fn get_field(&'env self, idx: FieldDefinitionIndex) -> FieldEnv<'env> {
         for data in &self.data.field_data {
-            if data.def_idx == *idx {
+            if data.def_idx == idx {
                 return FieldEnv {
                     struct_env: self.clone(),
                     data,

--- a/language/move-prover/bytecode-to-boogie/src/spec_translator.rs
+++ b/language/move-prover/bytecode-to-boogie/src/spec_translator.rs
@@ -525,7 +525,7 @@ impl<'env> SpecTranslator<'env> {
             let boogie_type = boogie_struct_type_value(
                 self.module_env.env,
                 struct_env.module_env.get_module_idx(),
-                &struct_env.get_def_idx(),
+                struct_env.get_def_idx(),
                 &[],
             );
             emitln!(
@@ -569,7 +569,7 @@ impl<'env> SpecTranslator<'env> {
                         .module_env
                         .env
                         .get_module(*module_idx)
-                        .into_get_struct(struct_idx);
+                        .into_get_struct(*struct_idx);
                     if p(&struct_env) {
                         Some(struct_env)
                     } else {
@@ -1004,7 +1004,7 @@ impl<'env> SpecTranslator<'env> {
         // Verify the type is actually a resource.
         if let GlobalType::Struct(module_idx, struct_idx, _) = &resource_type {
             let module_env = self.module_env.env.get_module(*module_idx);
-            let struct_env = module_env.get_struct(struct_idx);
+            let struct_env = module_env.get_struct(*struct_idx);
             if !struct_env.is_resource() {
                 self.error(
                     &format!("type `{}` is not a resource", struct_env.get_name()),
@@ -1040,7 +1040,7 @@ impl<'env> SpecTranslator<'env> {
         }
         if let GlobalType::Struct(module_index, struct_index, _actuals) = sig {
             let module_env = self.module_env.env.get_module(*module_index);
-            let struct_env = module_env.get_struct(&struct_index);
+            let struct_env = module_env.get_struct(*struct_index);
             if let Some(field_env) = struct_env.find_field(field.name()) {
                 (
                     boogie_field_name(&field_env),

--- a/language/move-prover/bytecode-to-boogie/tests/driver/mod.rs
+++ b/language/move-prover/bytecode-to-boogie/tests/driver/mod.rs
@@ -4,7 +4,6 @@
 use bytecode_to_boogie::boogie_wrapper::BoogieOutput;
 use bytecode_to_boogie::cli::Options;
 use bytecode_to_boogie::driver::Driver;
-use goldenfile;
 use itertools::Itertools;
 use libra_temppath::TempPath;
 use log::info;

--- a/language/tools/cost-synthesis/src/main.rs
+++ b/language/tools/cost-synthesis/src/main.rs
@@ -14,7 +14,6 @@ use cost_synthesis::{
     natives::StackAccessorMocker,
     stack_generator::RandomStackGenerator,
 };
-use csv;
 use language_e2e_tests::data_store::FakeDataStore;
 use libra_types::vm_error::StatusCode;
 use std::{

--- a/language/tools/disassembler/src/disassembler.rs
+++ b/language/tools/disassembler/src/disassembler.rs
@@ -147,15 +147,15 @@ impl<Location: Clone + Eq + Default> Disassembler<Location> {
 
     fn struct_type_info(
         &self,
-        struct_idx: &StructDefinitionIndex,
-        types_idx: &LocalsSignatureIndex,
+        struct_idx: StructDefinitionIndex,
+        types_idx: LocalsSignatureIndex,
     ) -> Result<(String, String)> {
-        let struct_definition = self.get_struct_def(*struct_idx)?;
+        let struct_definition = self.get_struct_def(struct_idx)?;
         let struct_source_map = self
             .source_mapper
             .source_map
-            .get_struct_source_map(*struct_idx)?;
-        let locals_signature = self.source_mapper.bytecode.locals_signature_at(*types_idx);
+            .get_struct_source_map(struct_idx)?;
+        let locals_signature = self.source_mapper.bytecode.locals_signature_at(types_idx);
         let type_arguments = locals_signature
             .0
             .iter()
@@ -352,37 +352,37 @@ impl<Location: Clone + Eq + Default> Disassembler<Location> {
                 Ok(format!("ImmBorrowField[{}]({}: {})", field_idx, name, ty))
             }
             Bytecode::Pack(struct_idx, types_idx) => {
-                let (name, ty_params) = self.struct_type_info(struct_idx, types_idx)?;
+                let (name, ty_params) = self.struct_type_info(*struct_idx, *types_idx)?;
                 Ok(format!("Pack[{}]({}{})", struct_idx, name, ty_params))
             }
             Bytecode::Unpack(struct_idx, types_idx) => {
-                let (name, ty_params) = self.struct_type_info(struct_idx, types_idx)?;
+                let (name, ty_params) = self.struct_type_info(*struct_idx, *types_idx)?;
                 Ok(format!("Unpack[{}]({}{})", struct_idx, name, ty_params))
             }
             Bytecode::Exists(struct_idx, types_idx) => {
-                let (name, ty_params) = self.struct_type_info(struct_idx, types_idx)?;
+                let (name, ty_params) = self.struct_type_info(*struct_idx, *types_idx)?;
                 Ok(format!("Exists[{}]({}{})", struct_idx, name, ty_params))
             }
             Bytecode::MutBorrowGlobal(struct_idx, types_idx) => {
-                let (name, ty_params) = self.struct_type_info(struct_idx, types_idx)?;
+                let (name, ty_params) = self.struct_type_info(*struct_idx, *types_idx)?;
                 Ok(format!(
                     "MutBorrowGlobal[{}]({}{})",
                     struct_idx, name, ty_params
                 ))
             }
             Bytecode::ImmBorrowGlobal(struct_idx, types_idx) => {
-                let (name, ty_params) = self.struct_type_info(struct_idx, types_idx)?;
+                let (name, ty_params) = self.struct_type_info(*struct_idx, *types_idx)?;
                 Ok(format!(
                     "ImmBorrowGlobal[{}]({}{})",
                     struct_idx, name, ty_params
                 ))
             }
             Bytecode::MoveFrom(struct_idx, types_idx) => {
-                let (name, ty_params) = self.struct_type_info(struct_idx, types_idx)?;
+                let (name, ty_params) = self.struct_type_info(*struct_idx, *types_idx)?;
                 Ok(format!("MoveFrom[{}]({}{})", struct_idx, name, ty_params))
             }
             Bytecode::MoveToSender(struct_idx, types_idx) => {
-                let (name, ty_params) = self.struct_type_info(struct_idx, types_idx)?;
+                let (name, ty_params) = self.struct_type_info(*struct_idx, *types_idx)?;
                 Ok(format!(
                     "MoveToSender[{}]({}{})",
                     struct_idx, name, ty_params

--- a/language/tools/disassembler/src/main.rs
+++ b/language/tools/disassembler/src/main.rs
@@ -9,7 +9,6 @@ use bytecode_source_map::{
 use disassembler::disassembler::{Disassembler, DisassemblerOptions};
 use libra_types::transaction::Module;
 use move_ir_types::ast::Loc;
-use serde_json;
 use std::fs;
 use std::path::Path;
 use structopt::StructOpt;

--- a/language/tools/test-generation/src/abstract_state.rs
+++ b/language/tools/test-generation/src/abstract_state.rs
@@ -561,6 +561,12 @@ impl fmt::Display for AbstractState {
     }
 }
 
+impl Default for AbstractState {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 impl fmt::Display for AbstractValue {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "({:?}: {:?})", self.token, self.kind)

--- a/language/tools/test-generation/src/control_flow_graph.rs
+++ b/language/tools/test-generation/src/control_flow_graph.rs
@@ -14,7 +14,7 @@ type BlockIDSize = u16;
 type BlockLocals = HashMap<usize, (AbstractValue, BorrowState)>;
 
 /// This represents a basic block in a control flow graph
-#[derive(Debug, Clone)]
+#[derive(Debug, Default, Clone)]
 pub struct BasicBlock {
     /// The starting locals
     locals_in: BlockLocals,

--- a/language/tools/test-generation/src/transitions.rs
+++ b/language/tools/test-generation/src/transitions.rs
@@ -23,15 +23,14 @@ use std::collections::HashMap;
 
 /// A substitution is a mapping from type formal index to the `SignatureToken` representing the
 /// type instantiation for that index.
+#[derive(Default)]
 pub struct Subst {
     pub subst: HashMap<usize, SignatureToken>,
 }
 
 impl Subst {
     pub fn new() -> Self {
-        Self {
-            subst: HashMap::new(),
-        }
+        Default::default()
     }
 
     /// NB that the position of arguments here matters. We can build a substitution if the `instr_sig`

--- a/language/tools/vm-genesis/src/genesis_gas_schedule.rs
+++ b/language/tools/vm-genesis/src/genesis_gas_schedule.rs
@@ -3,7 +3,6 @@
 
 //! This file contains the starting gas schedule published at genesis.
 
-use lcs;
 use once_cell::sync::Lazy;
 use vm::{
     file_format::{

--- a/language/vm/src/file_format.rs
+++ b/language/vm/src/file_format.rs
@@ -472,7 +472,7 @@ impl Kind {
 
     /// Helper function to determine the kind of a struct instance by taking the kind of a type
     /// actual and join it with the existing partial result.
-    pub fn join(self, other: &Kind) -> Kind {
+    pub fn join(self, other: Kind) -> Kind {
         match (self, other) {
             (Kind::All, _) | (_, Kind::All) => Kind::All,
             (Kind::Resource, _) | (_, Kind::Resource) => Kind::Resource,
@@ -766,7 +766,7 @@ impl SignatureToken {
                 //       whole, and thus `all`.
                 //   - If none of the type actuals is `all`, then the struct is a resource if
                 //     and only if one of the type actuals is `resource`.
-                kinds.iter().fold(Kind::Unrestricted, Kind::join)
+                kinds.iter().cloned().fold(Kind::Unrestricted, Kind::join)
             }
         }
     }

--- a/language/vm/src/file_format_common.rs
+++ b/language/vm/src/file_format_common.rs
@@ -183,6 +183,7 @@ pub enum Opcodes {
 pub const BINARY_SIZE_LIMIT: usize = usize::max_value();
 
 /// A wrapper for the binary vector
+#[derive(Default)]
 pub struct BinaryData {
     _binary: Vec<u8>,
 }

--- a/language/vm/src/foreign_contracts.rs
+++ b/language/vm/src/foreign_contracts.rs
@@ -10,7 +10,7 @@ pub mod types {
     pub mod byte_array {
         pub struct ByteArray(Vec<u8>);
         impl ByteArray {
-            pub fn as_bytes<'a>(_self: &'a ByteArray) -> &'a [u8] {
+            pub fn as_bytes(_self: &ByteArray) -> &[u8] {
                 &_self.0
             }
             pub fn new(buf: Vec<u8>) -> Self {

--- a/language/vm/src/printers.rs
+++ b/language/vm/src/printers.rs
@@ -3,7 +3,6 @@
 
 use crate::file_format::*;
 use anyhow::{bail, format_err, Result};
-use hex;
 use libra_types::{account_address::AccountAddress, byte_array::ByteArray, identifier::IdentStr};
 use std::{collections::VecDeque, fmt};
 

--- a/language/vm/vm-runtime/src/move_vm.rs
+++ b/language/vm/vm-runtime/src/move_vm.rs
@@ -111,3 +111,9 @@ impl MoveVM {
             .rent(|runtime| runtime.load_gas_schedule(chain_state, data_view))
     }
 }
+
+impl Default for MoveVM {
+    fn default() -> Self {
+        Self::new()
+    }
+}

--- a/language/vm/vm-runtime/vm-runtime-types/src/native_functions/dispatch.rs
+++ b/language/vm/vm-runtime/vm-runtime-types/src/native_functions/dispatch.rs
@@ -110,7 +110,7 @@ decl_native_function_enum! {
 impl NativeFunction {
     /// Given the vector of aguments, it executes the native function.
     pub fn dispatch(
-        &self,
+        self,
         t: Vec<TypeTag>,
         v: VecDeque<Value>,
         c: &CostTable,
@@ -143,7 +143,7 @@ impl NativeFunction {
 
     /// The number of arguments to the native function,
     /// It is checked at publishing of the module that this matches the expected signature.
-    pub fn num_args(&self) -> usize {
+    pub fn num_args(self) -> usize {
         match self {
             Self::HashSha2_256 => 1,
             Self::HashSha3_256 => 1,
@@ -169,7 +169,7 @@ impl NativeFunction {
     /// It should NOT be generally inspected outside of it's declaring module as the various
     /// struct handle indexes are not remapped into the local context.
     pub fn signature<T: ModuleAccess>(
-        &self,
+        self,
         m: Option<&ModuleView<T>>,
     ) -> Option<FunctionSignature> {
         let res = self.signature_(m)?;
@@ -181,7 +181,7 @@ impl NativeFunction {
         Some(res)
     }
 
-    fn signature_<T: ModuleAccess>(&self, m: Option<&ModuleView<T>>) -> Option<FunctionSignature> {
+    fn signature_<T: ModuleAccess>(self, m: Option<&ModuleView<T>>) -> Option<FunctionSignature> {
         use SignatureToken::*;
         macro_rules! simple {
             ($args:expr, $ret:expr) => {{

--- a/libra-node/src/main.rs
+++ b/libra-node/src/main.rs
@@ -31,7 +31,7 @@ fn main() {
     let args = Args::from_args();
 
     let (mut config, _logger) =
-        setup_executable(args.config.as_ref().map(PathBuf::as_path), args.no_logging);
+        setup_executable(args.config.as_deref(), args.no_logging);
 
     let _node_handle = libra_node::main_node::setup_environment(&mut config);
 

--- a/libra-node/src/main.rs
+++ b/libra-node/src/main.rs
@@ -30,8 +30,7 @@ static ALLOC: jemallocator::Jemalloc = jemallocator::Jemalloc;
 fn main() {
     let args = Args::from_args();
 
-    let (mut config, _logger) =
-        setup_executable(args.config.as_deref(), args.no_logging);
+    let (mut config, _logger) = setup_executable(args.config.as_deref(), args.no_logging);
 
     let _node_handle = libra_node::main_node::setup_environment(&mut config);
 

--- a/libra-swarm/src/client.rs
+++ b/libra-swarm/src/client.rs
@@ -9,7 +9,6 @@ use std::{
     process::{Child, Command, Output, Stdio},
     sync::Arc,
 };
-use workspace_builder;
 
 pub struct InteractiveClient {
     client: Option<Child>,

--- a/libra-swarm/src/swarm.rs
+++ b/libra-swarm/src/swarm.rs
@@ -18,7 +18,6 @@ use std::{
     str::FromStr,
 };
 use thiserror::Error;
-use workspace_builder;
 
 const LIBRA_NODE_BIN: &str = "libra-node";
 

--- a/network/netcore/src/multiplexing/yamux.rs
+++ b/network/netcore/src/multiplexing/yamux.rs
@@ -26,7 +26,6 @@ use std::{
     sync::Arc,
     task::{Context, Poll},
 };
-use yamux;
 
 /// Re-export `Mode` and `Stream` from the yamux crate
 pub use yamux::Mode;

--- a/network/src/peer/test.rs
+++ b/network/src/peer/test.rs
@@ -6,7 +6,6 @@ use crate::{
     protocols::identity::Identity,
     ProtocolId,
 };
-use channel;
 use futures::{
     executor::block_on,
     future::join,

--- a/network/src/peer_manager/tests.rs
+++ b/network/src/peer_manager/tests.rs
@@ -9,7 +9,6 @@ use crate::{
     protocols::identity::{exchange_identity, Identity},
     ProtocolId,
 };
-use channel;
 use channel::libra_channel;
 use channel::message_queues::QueueStyle;
 use futures::{channel::oneshot, stream::StreamExt};

--- a/network/src/protocols/direct_send/mod.rs
+++ b/network/src/protocols/direct_send/mod.rs
@@ -50,7 +50,6 @@ use crate::{
     ProtocolId,
 };
 use bytes::Bytes;
-use channel;
 use futures::{
     io::{AsyncRead, AsyncWrite},
     sink::SinkExt,

--- a/network/src/protocols/direct_send/test.rs
+++ b/network/src/protocols/direct_send/test.rs
@@ -9,7 +9,6 @@ use crate::{
     ProtocolId,
 };
 use bytes::Bytes;
-use channel;
 use futures::{sink::SinkExt, stream::StreamExt};
 use libra_logger::prelude::*;
 use libra_types::PeerId;

--- a/network/src/protocols/discovery/mod.rs
+++ b/network/src/protocols/discovery/mod.rs
@@ -222,10 +222,7 @@ where
         }
     }
 
-    async fn handle_network_event(
-        &mut self,
-        event: Result<Event<DiscoveryMsg>, NetworkError>,
-    ) {
+    async fn handle_network_event(&mut self, event: Result<Event<DiscoveryMsg>, NetworkError>) {
         trace!("Network event::{:?}", event);
         match event {
             Ok(e) => {

--- a/network/src/protocols/discovery/mod.rs
+++ b/network/src/protocols/discovery/mod.rs
@@ -223,8 +223,8 @@ where
         }
     }
 
-    async fn handle_network_event<'a>(
-        &'a mut self,
+    async fn handle_network_event(
+        &mut self,
         event: Result<Event<DiscoveryMsg>, NetworkError>,
     ) {
         trace!("Network event::{:?}", event);

--- a/network/src/protocols/discovery/mod.rs
+++ b/network/src/protocols/discovery/mod.rs
@@ -41,7 +41,6 @@ use crate::{
 };
 use anyhow::anyhow;
 use bytes::Bytes;
-use channel;
 use futures::{
     sink::SinkExt,
     stream::{FusedStream, Stream, StreamExt},

--- a/network/src/protocols/rpc/fuzzing.rs
+++ b/network/src/protocols/rpc/fuzzing.rs
@@ -7,7 +7,6 @@ use crate::{
     protocols::rpc::{self, RpcNotification},
     ProtocolId,
 };
-use channel;
 use futures::{
     future::{self, FutureExt},
     io::{AsyncReadExt, AsyncWriteExt},

--- a/network/src/protocols/rpc/mod.rs
+++ b/network/src/protocols/rpc/mod.rs
@@ -62,7 +62,6 @@ use crate::{
     ProtocolId,
 };
 use bytes::Bytes;
-use channel;
 use error::RpcError;
 use futures::{
     channel::oneshot,

--- a/secure/storage/src/error.rs
+++ b/secure/storage/src/error.rs
@@ -4,7 +4,6 @@
 use serde::{Deserialize, Serialize};
 use std::io;
 use thiserror::Error;
-use toml;
 
 #[derive(Debug, Deserialize, Error, PartialEq, Serialize)]
 pub enum Error {

--- a/secure/storage/src/in_memory.rs
+++ b/secure/storage/src/in_memory.rs
@@ -10,6 +10,7 @@ use std::collections::HashMap;
 /// Internally, it retains all data, which means that it must make copies of all key material which
 /// violates the Libra code base. It violates it because the anticipation is that data stores would
 /// securely handle key material. This should not be used in production.
+#[derive(Default)]
 pub struct InMemoryStorage {
     data: HashMap<String, Value>,
 }

--- a/secure/storage/src/on_disk.rs
+++ b/secure/storage/src/on_disk.rs
@@ -9,7 +9,6 @@ use std::{
     io::{Read, Write},
     path::PathBuf,
 };
-use toml;
 
 /// InMemoryStorage represents a key value store that is purely in memory and intended for single
 /// threads (or must be wrapped by a Arc<RwLock<>>). This provides no permission checks and simply

--- a/secure/storage/src/value.rs
+++ b/secure/storage/src/value.rs
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::error::Error;
-use base64;
 use libra_crypto::ed25519::Ed25519PrivateKey;
 use serde::{Deserialize, Serialize};
 

--- a/secure/storage/vault/src/lib.rs
+++ b/secure/storage/vault/src/lib.rs
@@ -10,7 +10,6 @@ use std::{
     convert::{TryFrom, TryInto},
 };
 use thiserror::Error;
-use ureq;
 
 #[derive(Debug, Error, PartialEq)]
 pub enum Error {

--- a/state-synchronizer/src/synchronizer.rs
+++ b/state-synchronizer/src/synchronizer.rs
@@ -146,14 +146,11 @@ impl StateSyncClient {
                     Err(format_err!("[state sync client] failed to receive commit ACK from state synchronizer on time"))
                 }
                 Ok(resp) => {
-                    match resp?? {
-                        CommitResponse { msg } => {
-                            if msg != "" {
-                                Err(format_err!("[state sync client] commit failed: {:?}", msg))
-                            } else {
-                                Ok(())
-                            }
-                        }
+                    let CommitResponse { msg } = resp??;
+                    if msg != "" {
+                        Err(format_err!("[state sync client] commit failed: {:?}", msg))
+                    } else {
+                        Ok(())
                     }
                 }
             }

--- a/state-synchronizer/src/tests/integration_tests.rs
+++ b/state-synchronizer/src/tests/integration_tests.rs
@@ -6,7 +6,6 @@ use crate::{
     StateSynchronizer, SynchronizerState,
 };
 use anyhow::{bail, Result};
-use config_builder;
 use executor::ExecutedTrees;
 use futures::executor::block_on;
 use libra_config::config::RoleType;

--- a/testsuite/cluster-test/src/aws.rs
+++ b/testsuite/cluster-test/src/aws.rs
@@ -56,6 +56,12 @@ impl Aws {
     }
 }
 
+impl Default for Aws {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 fn discover_workspace(ec2: &Ec2Client) -> String {
     let instance_id = current_instance_id();
     let mut attempt = 0;

--- a/testsuite/cluster-test/src/github.rs
+++ b/testsuite/cluster-test/src/github.rs
@@ -53,3 +53,9 @@ impl GitHub {
         Ok(response)
     }
 }
+
+impl Default for GitHub {
+    fn default() -> Self {
+        Self::new()
+    }
+}

--- a/testsuite/cluster-test/src/health/commit_check.rs
+++ b/testsuite/cluster-test/src/health/commit_check.rs
@@ -9,6 +9,7 @@ use std::collections::{hash_map::Entry, HashMap, HashSet};
 /// Verifies that commit history produced by validators is 'lineariazble'
 /// This means that validators can be behind each other, but commits that they are producing
 /// do not contradict each other
+#[derive(Default)]
 pub struct CommitHistoryHealthCheck {
     round_to_commit: HashMap<u64, CommitAndValidators>,
     latest_committed_round: HashMap<String, u64>,
@@ -21,10 +22,7 @@ struct CommitAndValidators {
 
 impl CommitHistoryHealthCheck {
     pub fn new() -> Self {
-        Self {
-            round_to_commit: HashMap::new(),
-            latest_committed_round: HashMap::new(),
-        }
+        Default::default()
     }
 }
 

--- a/testsuite/cluster-test/src/health/mod.rs
+++ b/testsuite/cluster-test/src/health/mod.rs
@@ -234,3 +234,9 @@ impl HealthCheckContext {
         self.err_acc.push(HealthCheckError { validator, message })
     }
 }
+
+impl Default for HealthCheckContext {
+    fn default() -> Self {
+        Self::new()
+    }
+}

--- a/testsuite/cluster-test/src/instance.rs
+++ b/testsuite/cluster-test/src/instance.rs
@@ -7,7 +7,6 @@ use anyhow::{ensure, format_err, Result};
 use serde_json::Value;
 use std::collections::HashSet;
 use std::{ffi::OsStr, fmt, process::Stdio};
-use tokio;
 
 #[derive(Clone)]
 pub struct Instance {

--- a/testsuite/cluster-test/src/report.rs
+++ b/testsuite/cluster-test/src/report.rs
@@ -4,7 +4,7 @@
 use serde::Serialize;
 use std::fmt;
 
-#[derive(Serialize)]
+#[derive(Default, Serialize)]
 pub struct SuiteReport {
     metrics: Vec<ReportedMetric>,
     text: String,
@@ -19,10 +19,7 @@ pub struct ReportedMetric {
 
 impl SuiteReport {
     pub fn new() -> Self {
-        SuiteReport {
-            metrics: vec![],
-            text: String::new(),
-        }
+        Default::default()
     }
 
     pub fn report_metric<E: ToString, M: ToString>(

--- a/testsuite/cluster-test/src/slack.rs
+++ b/testsuite/cluster-test/src/slack.rs
@@ -31,3 +31,9 @@ impl SlackClient {
         Ok(())
     }
 }
+
+impl Default for SlackClient {
+    fn default() -> Self {
+        Self::new()
+    }
+}

--- a/testsuite/tests/libratest/smoke_test.rs
+++ b/testsuite/tests/libratest/smoke_test.rs
@@ -22,7 +22,6 @@ use std::fs::{self, File};
 use std::io::Read;
 use std::str::FromStr;
 use std::{thread, time};
-use workspace_builder;
 
 struct TestEnvironment {
     validator_swarm: LibraSwarm,

--- a/types/src/account_address.rs
+++ b/types/src/account_address.rs
@@ -3,7 +3,6 @@
 
 use anyhow::{ensure, Error, Result};
 use bytes::Bytes;
-use hex;
 use libra_crypto::{
     hash::{CryptoHash, CryptoHasher},
     HashValue, VerifyingKey,

--- a/types/src/byte_array.rs
+++ b/types/src/byte_array.rs
@@ -1,7 +1,6 @@
 // Copyright (c) The Libra Core Contributors
 // SPDX-License-Identifier: Apache-2.0
 
-use hex;
 use serde::{Deserialize, Serialize};
 
 #[derive(Ord, PartialOrd, Eq, PartialEq, Hash, Default, Clone, Serialize, Deserialize)]

--- a/types/src/event.rs
+++ b/types/src/event.rs
@@ -3,7 +3,6 @@
 
 use crate::account_address::AccountAddress;
 use anyhow::{ensure, Error, Result};
-use hex;
 #[cfg(feature = "fuzzing")]
 use rand::{rngs::OsRng, RngCore};
 use serde::{de, ser, Deserialize, Serialize};

--- a/types/src/unit_tests/identifier_test.rs
+++ b/types/src/unit_tests/identifier_test.rs
@@ -6,7 +6,6 @@ use crate::test_helpers::assert_canonical_encode_decode;
 use once_cell::sync::Lazy;
 use proptest::prelude::*;
 use regex::Regex;
-use serde_json;
 use std::borrow::Borrow;
 
 #[test]

--- a/types/src/write_set.rs
+++ b/types/src/write_set.rs
@@ -58,7 +58,7 @@ impl WriteSet {
     }
 
     #[inline]
-    pub fn iter<'a>(&'a self) -> ::std::slice::Iter<'a, (AccessPath, WriteOp)> {
+    pub fn iter(&self) -> ::std::slice::Iter<'_, (AccessPath, WriteOp)> {
         self.into_iter()
     }
 

--- a/vm-validator/src/unit_tests/vm_validator_test.rs
+++ b/vm-validator/src/unit_tests/vm_validator_test.rs
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::vm_validator::{TransactionValidation, VMValidator};
-use config_builder;
 use executor::Executor;
 use libra_config::config::NodeConfig;
 use libra_crypto::{ed25519::*, PrivateKey};

--- a/x.toml
+++ b/x.toml
@@ -5,7 +5,6 @@ testsuite = { path = "testsuite", system = true }
 
 [clippy]
 allowed = [
-    "clippy::get_unwrap",
     "clippy::new_without_default",
     # Deriving Arbitrary often causes this warning to show up.
     "clippy::unit_arg",

--- a/x.toml
+++ b/x.toml
@@ -8,6 +8,4 @@ allowed = [
     "clippy::new_without_default",
     # Deriving Arbitrary often causes this warning to show up.
     "clippy::unit_arg",
-    # Whitelist for now since it seems like the futures::select! macro has an issue with this
-    "clippy::unnecessary-mut-passed",
 ]

--- a/x.toml
+++ b/x.toml
@@ -8,8 +8,6 @@ allowed = [
     "clippy::new_without_default",
     # Deriving Arbitrary often causes this warning to show up.
     "clippy::unit_arg",
-    # This ends up being platform dependent, e.g. the Instant type
-    "clippy::trivially-copy-pass-by-ref",
     # Whitelist for now since it seems like the futures::select! macro has an issue with this
     "clippy::unnecessary-mut-passed",
 ]

--- a/x.toml
+++ b/x.toml
@@ -5,7 +5,6 @@ testsuite = { path = "testsuite", system = true }
 
 [clippy]
 allowed = [
-    "clippy::new_without_default",
     # Deriving Arbitrary often causes this warning to show up.
     "clippy::unit_arg",
 ]

--- a/x.toml
+++ b/x.toml
@@ -8,8 +8,6 @@ allowed = [
     "clippy::new_without_default",
     # Deriving Arbitrary often causes this warning to show up.
     "clippy::unit_arg",
-    # Clippy seems to complain about async functions
-    "clippy::needless_lifetimes",
     # This ends up being platform dependent, e.g. the Instant type
     "clippy::trivially-copy-pass-by-ref",
     # Whitelist for now since it seems like the futures::select! macro has an issue with this

--- a/x.toml
+++ b/x.toml
@@ -13,10 +13,6 @@ allowed = [
     "clippy::needless_lifetimes",
     # This ends up being platform dependent, e.g. the Instant type
     "clippy::trivially-copy-pass-by-ref",
-    # Temporarily allow the `clippy::inheret-to-string` lint to avoid having to
-    # fix all violations in our codebase during the compiler bump to 1.39.0
-    # beta where it was changed to be on-by-default.
-    "clippy::inherent-to-string",
     # Whitelist for now since it seems like the futures::select! macro has an issue with this
     "clippy::unnecessary-mut-passed",
 ]


### PR DESCRIPTION
Re-enable clippy lints that were disabled during Rust toolchain upgrades. This also fixes some of the issues found with new nightly lints.