### PR TITLE
[move source language] Change "move" and "copy" to be unary expressions

### DIFF
--- a/language/move-lang/src/parser/ast.rs
+++ b/language/move-lang/src/parser/ast.rs
@@ -311,7 +311,7 @@ pub enum Exp_ {
     Copy(Var),
     // n
     Name(Name),
-    // .n(e)
+    // ::n(e)
     GlobalCall(Name, Option<Vec<SingleType>>, Spanned<Vec<Exp>>),
 
     // f(earg,*)

--- a/language/move-lang/src/parser/syntax.rs
+++ b/language/move-lang/src/parser/syntax.rs
@@ -488,9 +488,7 @@ fn parse_sequence<'input>(tokens: &mut Lexer<'input>) -> Result<Sequence, Error>
 
 // Parse an expression term:
 //      Term =
-//          "move" <Var>
-//          | "copy" <Var>
-//          | "break"
+//          "break"
 //          | "continue"
 //          | <Name>
 //          | <Value>
@@ -503,16 +501,6 @@ fn parse_sequence<'input>(tokens: &mut Lexer<'input>) -> Result<Sequence, Error>
 fn parse_term<'input>(tokens: &mut Lexer<'input>) -> Result<Exp, Error> {
     let start_loc = tokens.start_loc();
     let term = match tokens.peek() {
-        Tok::Move => {
-            tokens.advance()?;
-            Exp_::Move(parse_var(tokens)?)
-        }
-
-        Tok::Copy => {
-            tokens.advance()?;
-            Exp_::Copy(parse_var(tokens)?)
-        }
-
         Tok::Break => {
             tokens.advance()?;
             Exp_::Break
@@ -713,10 +701,10 @@ fn parse_call_args<'input>(tokens: &mut Lexer<'input>) -> Result<Spanned<Vec<Exp
 //          "if" "(" <Exp> ")" <Exp> ("else" <Exp>)?
 //          | "while" "(" <Exp> ")" <Exp>
 //          | "loop" <Exp>
-//          | <UnaryExp> "=" <Exp>
 //          | "return" <Exp>
 //          | "abort" <Exp>
 //          | <BinOpExp>
+//          | <UnaryExp> "=" <Exp>
 fn parse_exp<'input>(tokens: &mut Lexer<'input>) -> Result<Exp, Error> {
     let start_loc = tokens.start_loc();
     let exp = match tokens.peek() {
@@ -802,7 +790,8 @@ fn get_precedence(token: Tok) -> u32 {
 
 // Parse a binary operator expression:
 //      BinOpExp =
-//          <UnaryExp> <BinOp> <BinOpExp>
+//          <BinOpExp> <BinOp> <BinOpExp>
+//          | <UnaryExp>
 //      BinOp = (listed from lowest to highest precedence)
 //          "||"
 //          | "&&"
@@ -879,6 +868,8 @@ fn parse_binop_exp<'input>(
 //          | "&mut" <UnaryExp>
 //          | "&" <UnaryExp>
 //          | "*" <UnaryExp>
+//          | "move" <Var>
+//          | "copy" <Var>
 //          | <DotChain>
 fn parse_unary_exp<'input>(tokens: &mut Lexer<'input>) -> Result<Exp, Error> {
     let start_loc = tokens.start_loc();
@@ -911,6 +902,14 @@ fn parse_unary_exp<'input>(tokens: &mut Lexer<'input>) -> Result<Exp, Error> {
             tokens.advance()?;
             let e = parse_unary_exp(tokens)?;
             Exp_::Dereference(Box::new(e))
+        }
+        Tok::Move => {
+            tokens.advance()?;
+            Exp_::Move(parse_var(tokens)?)
+        }
+        Tok::Copy => {
+            tokens.advance()?;
+            Exp_::Copy(parse_var(tokens)?)
         }
         _ => {
             return parse_dot_chain(tokens);

--- a/language/move-lang/tests/functional/translated_ir_tests/borrow_tests/borrow_move_ok.move
+++ b/language/move-lang/tests/functional/translated_ir_tests/borrow_tests/borrow_move_ok.move
@@ -7,7 +7,7 @@ module M {
 
     public fun value(this: &T) : u64 {
         //borrow of move
-        let f = move this.v;
+        let f = (move this).v;
         f
     }
 }

--- a/language/move-lang/tests/move_check/translated_ir_tests/borrow_tests/ref_moved_one_branch.move
+++ b/language/move-lang/tests/move_check/translated_ir_tests/borrow_tests/ref_moved_one_branch.move
@@ -3,7 +3,7 @@ module A {
 
     public fun t(changed: bool, s: &mut S) {
         if (changed) {
-            foo(&mut move s.value);
+            foo(&mut (move s).value);
         }
     }
 


### PR DESCRIPTION
The previous Move grammar allowed "move" and "copy" expressions to be "Terms" used with field references, e.g., "move x.field". This was misleading and could result in confusing error messages from the compiler. It does not matter so much with "copy" but for "move" you have to move the entire value before you access the fields. This changes them to be unary expressions so that they need to be wrapped in parenthesis before accessing fields, e.g., "(move x).field".

## Motivation

Improving clarity of Move expressions

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

Updated some tests that needed to have parens.