### PR TITLE
[vm] Removed assert from native functions

### DIFF
--- a/language/bytecode-verifier/src/verifier.rs
+++ b/language/bytecode-verifier/src/verifier.rs
@@ -383,8 +383,16 @@ fn verify_native_functions(module_view: &ModuleView<VerifiedModule>) -> Vec<VMSt
             Some(vm_native_function) => {
                 let declared_function_signature =
                     native_function_definition_view.signature().as_inner();
-                let expected_function_signature = vm_native_function.signature(Some(module_view));
-                let matching_signatures = expected_function_signature
+                let expected_function_signature_res =
+                    vm_native_function.signature(Some(module_view));
+                let expected_function_signature_opt = match expected_function_signature_res {
+                    Ok(opt) => opt,
+                    Err(e) => {
+                        errors.push(e);
+                        continue;
+                    }
+                };
+                let matching_signatures = expected_function_signature_opt
                     .map(|e| &e == declared_function_signature)
                     .unwrap_or(false);
                 if !matching_signatures {

--- a/types/src/vm_error.rs
+++ b/types/src/vm_error.rs
@@ -405,6 +405,7 @@ pub enum StatusCode {
     EVENT_KEY_MISMATCH = 2010,
     UNREACHABLE = 2011,
     VM_STARTUP_FAILURE = 2012,
+    NATIVE_FUNCTION_INTERNAL_INCONSISTENCY = 2013,
 
     // Errors that can arise from binary decoding (deserialization)
     // Deserializtion Errors: 3000-3999


### PR DESCRIPTION
## Motivation

- Replaced assert with a new vm invariant violation

## Test Plan

- cargo test