### PR TITLE
[crypto] add compact `Display`+`Debug` impl for `Ed25519Signature`

### DIFF
--- a/crypto/crypto/src/ed25519.rs
+++ b/crypto/crypto/src/ed25519.rs
@@ -33,7 +33,7 @@ use crate::{traits::*, HashValue};
 use anyhow::{anyhow, Result};
 use core::convert::TryFrom;
 use libra_crypto_derive::{DeserializeKey, SerializeKey, SilentDebug, SilentDisplay};
-use std::cmp::Ordering;
+use std::{cmp::Ordering, fmt};
 
 /// The length of the Ed25519PrivateKey
 pub const ED25519_PRIVATE_KEY_LENGTH: usize = ed25519_dalek::SECRET_KEY_LENGTH;
@@ -60,7 +60,7 @@ static_assertions::assert_not_impl_any!(Ed25519PrivateKey: Clone);
 pub struct Ed25519PublicKey(ed25519_dalek::PublicKey);
 
 /// An Ed25519 signature
-#[derive(DeserializeKey, Clone, Debug, SerializeKey)]
+#[derive(DeserializeKey, Clone, SerializeKey)]
 pub struct Ed25519Signature(ed25519_dalek::Signature);
 
 impl Ed25519PrivateKey {
@@ -256,14 +256,14 @@ impl VerifyingKey for Ed25519PublicKey {
     type SignatureMaterial = Ed25519Signature;
 }
 
-impl std::fmt::Display for Ed25519PublicKey {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+impl fmt::Display for Ed25519PublicKey {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "{}", hex::encode(&self.0.as_bytes()))
     }
 }
 
-impl std::fmt::Debug for Ed25519PublicKey {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+impl fmt::Debug for Ed25519PublicKey {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "Ed25519PublicKey({})", self)
     }
 }
@@ -400,6 +400,18 @@ impl PartialEq for Ed25519Signature {
 }
 
 impl Eq for Ed25519Signature {}
+
+impl fmt::Display for Ed25519Signature {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}", hex::encode(&self.0.to_bytes()[..]))
+    }
+}
+
+impl fmt::Debug for Ed25519Signature {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "Ed25519Signature({})", self)
+    }
+}
 
 /// Check if S < L to capture invalid signatures.
 fn check_s_lt_l(s: &[u8]) -> bool {


### PR DESCRIPTION
This diff makes the `Display` and `Debug` outputs for ed25519 signatures
much more compact than the default derives. For example, the `Debug`
output

before:

```
Ed25519Signature(
    Signature(
        R: CompressedEdwardsY: [120, 32, 181, 228, 44, 88, 200, 210, 189, 137, 47, 255, 232, 196, 171, 229, 51, 213, 146, 245, 243, 130, 182, 139, 94, 48, 14, 161, 89, 185, 221, 76],
        s: Scalar { bytes: [176, 123, 45, 105, 161, 159, 223, 60, 191, 3, 21, 199, 240, 134, 72, 13, 249, 100, 241, 44, 129, 89, 110, 111, 174, 217, 150, 164, 60, 159, 56, 4], }
    )
)
```

after:

```
Ed25519Signature(7820b5e42c58c8d2bd892fffe8c4abe533d592f5f382b68b5e300ea159b9dd4cb07b2d69a19fdf3cbf0315c7f086480df964f12c81596e6faed996a43c9f3804)
```