### PR TITLE
[KS][GHA] add land-blocking test kill switch

### DIFF
--- a/.github/workflows/land-blocking.yml
+++ b/.github/workflows/land-blocking.yml
@@ -15,10 +15,20 @@ jobs:
       - name: Setup env
         run: |
           echo "::set-env name=LIBRA_GIT_REV::$(git rev-parse --short=8 HEAD)"
+      - name: Check kill switch
+        id: check_ks
+        run:
+          if ${{ secrets.KILL_SWITCH_LAND_BLOCKING_TEST }} ; then
+            echo "::set-output name=should_run::false";
+          else
+            echo "::set-output name=should_run::true";
+          fi
       - name: Build, tag and push images
+        if: steps.check_ks.outputs.should_run == 'true'
         run: |
           docker/build-aws.sh --build-all --version $LIBRA_GIT_REV --addl_tags canary
       - name: Launch cluster test
+        if: steps.check_ks.outputs.should_run == 'true'
         run: |
           JUMPHOST=${{secrets.CLUSTER_TEST_JUMPHOST}} \
           ./scripts/cti \
@@ -32,6 +42,11 @@ jobs:
         with:
           github-token: ${{secrets.GITHUB_TOKEN}}
           script: |
+            // Check kill switch
+            if (${{secrets.KILL_SWITCH_LAND_BLOCKING_TEST}}) {
+              console.log('Kill switch is set. Will skip this step.');
+              return;
+            }
             // Find the number of the pull request that trigggers this push
             let pr_num = 0;
             let commit_message = context.payload.head_commit.message;


### PR DESCRIPTION
## Motivation
The land-blocking test workflow depends on the cluster test in this repo
and the infra backing in another.  Before we turn it on, we need a KS to
bypass the workflow for ninja land or breaking the inherent dep loop.
Consider this scenario where the cluster test itself breaks, no PRs can
land as they all fail the test, including the PR that fixes the breakage
in cluster test.

The cluster test has kill switch mechanism built in. That depends on
actions behind the scene in AWS. Here we perform the bypass at the
source.  GitHub Secrets is used as a SV to toggle the swtich.

Note that bors will be listening for the check status from the
land-blocking flow. We will let the workflow run but terminate early
with success exit status.


## Test Plan
- KS is set - canary with 8ff8077 in https://github.com/sausagee/libra/runs/459406928?check_suite_focus=true
The build and test steps are skipped.  
<img width="1373" alt="image" src="https://user-images.githubusercontent.com/7528420/75003488-c807e700-541c-11ea-92be-abdd15db5fd9.png">

- KS is not set - canary with f8bbfd6 in https://github.com/sausagee/libra/runs/459413889?check_suite_focus=true

<img width="1368" alt="image" src="https://user-images.githubusercontent.com/7528420/75003506-e241c500-541c-11ea-9594-22caeb4b9140.png">
