### PR TITLE
[executor] change all subsequent txn statuses to RETRY after a valida…

### DIFF
--- a/consensus/src/chained_bft/event_processor.rs
+++ b/consensus/src/chained_bft/event_processor.rs
@@ -947,6 +947,8 @@ impl<T: Payload> EventProcessor<T> {
                             .with_label_values(&["failed"])
                             .inc();
                     }
+                    // TODO(zekunli): add counter
+                    TransactionStatus::Retry => (),
                 }
             }
         }

--- a/execution/executor/src/executor_test.rs
+++ b/execution/executor/src/executor_test.rs
@@ -630,7 +630,7 @@ proptest! {
             block.txns[reconfig_txn_index as usize] = encode_reconfiguration_transaction(gen_address(reconfig_txn_index));
             let (executor, committed_trees) = TestExecutor::new();
             let output = executor.execute_block(
-                block.txns.clone(), &committed_trees, &committed_trees,
+                block.txns, &committed_trees, &committed_trees,
             ).unwrap();
         let retry_iter = output.transaction_data().iter().map(TransactionData::status)
             .skip_while(|status| match *status {

--- a/execution/executor/src/executor_test.rs
+++ b/execution/executor/src/executor_test.rs
@@ -626,7 +626,7 @@ proptest! {
                 0..num_txns
             )
         })) {
-            let mut block = TestBlock::new(0..num_txns, 10, *PRE_GENESIS_BLOCK_ID, gen_block_id(1));
+            let mut block = TestBlock::new(0..num_txns, 10, gen_block_id(1));
             block.txns[reconfig_txn_index as usize] = encode_reconfiguration_transaction(gen_address(reconfig_txn_index));
             let (executor, committed_trees) = TestExecutor::new();
             let output = executor.execute_block(

--- a/execution/executor/src/lib.rs
+++ b/execution/executor/src/lib.rs
@@ -523,72 +523,91 @@ where
         let mut next_validator_set = None;
 
         let proof_reader = ProofReader::new(account_to_proof);
+        let mut validator_set_change_seen = false;
         for (vm_output, txn) in itertools::zip_eq(vm_outputs.into_iter(), transactions.iter()) {
-            let (blobs, state_tree, num_accounts_created) = Self::process_write_set(
-                txn,
-                &mut account_to_state,
-                &proof_reader,
-                vm_output.write_set().clone(),
-                &current_state_tree,
-            )?;
+            if validator_set_change_seen {
+                txn_data.push(TransactionData::new(
+                    HashMap::new(),
+                    vec![],
+                    TransactionStatus::Retry,
+                    Arc::clone(&current_state_tree),
+                    Arc::new(InMemoryAccumulator::<EventAccumulatorHasher>::default()),
+                    0,
+                    0,
+                    None,
+                ));
+            } else {
+                let (blobs, state_tree, num_accounts_created) = Self::process_write_set(
+                    txn,
+                    &mut account_to_state,
+                    &proof_reader,
+                    vm_output.write_set().clone(),
+                    &current_state_tree,
+                )?;
 
-            let event_tree = {
-                let event_hashes: Vec<_> =
-                    vm_output.events().iter().map(CryptoHash::hash).collect();
-                InMemoryAccumulator::<EventAccumulatorHasher>::from_leaves(&event_hashes)
-            };
-            let mut txn_info_hash = None;
+                let event_tree = {
+                    let event_hashes: Vec<_> =
+                        vm_output.events().iter().map(CryptoHash::hash).collect();
+                    InMemoryAccumulator::<EventAccumulatorHasher>::from_leaves(&event_hashes)
+                };
+                let mut txn_info_hash = None;
 
-            match vm_output.status() {
-                TransactionStatus::Keep(status) => {
-                    ensure!(
-                        !vm_output.write_set().is_empty(),
-                        "Transaction with empty write set should be discarded.",
-                    );
-                    // Compute hash for the TransactionInfo object. We need the hash of the
-                    // transaction itself, the state root hash as well as the event root hash.
-                    let txn_info = TransactionInfo::new(
-                        txn.hash(),
-                        state_tree.root_hash(),
-                        event_tree.root_hash(),
-                        vm_output.gas_used(),
-                        status.major_status,
-                    );
-
-                    let real_txn_info_hash = txn_info.hash();
-                    txn_info_hashes.push(real_txn_info_hash);
-                    txn_info_hash = Some(real_txn_info_hash);
-                }
-                TransactionStatus::Discard(status) => {
-                    if !vm_output.write_set().is_empty() || !vm_output.events().is_empty() {
-                        crit!(
-                            "Discarded transaction has non-empty write set or events. \
-                             Transaction: {:?}. Status: {}.",
-                            txn,
-                            status,
+                match vm_output.status() {
+                    TransactionStatus::Keep(status) => {
+                        ensure!(
+                            !vm_output.write_set().is_empty(),
+                            "Transaction with empty write set should be discarded.",
                         );
+                        // Compute hash for the TransactionInfo object. We need the hash of the
+                        // transaction itself, the state root hash as well as the event root hash.
+                        let txn_info = TransactionInfo::new(
+                            txn.hash(),
+                            state_tree.root_hash(),
+                            event_tree.root_hash(),
+                            vm_output.gas_used(),
+                            status.major_status,
+                        );
+
+                        let real_txn_info_hash = txn_info.hash();
+                        txn_info_hashes.push(real_txn_info_hash);
+                        txn_info_hash = Some(real_txn_info_hash);
+                    }
+                    TransactionStatus::Discard(status) => {
+                        if !vm_output.write_set().is_empty() || !vm_output.events().is_empty() {
+                            crit!(
+                                "Discarded transaction has non-empty write set or events. \
+                                 Transaction: {:?}. Status: {}.",
+                                txn,
+                                status,
+                            );
+                        }
+                    }
+                    TransactionStatus::Retry => (),
+                }
+
+                txn_data.push(TransactionData::new(
+                    blobs,
+                    vm_output.events().to_vec(),
+                    vm_output.status().clone(),
+                    Arc::clone(&state_tree),
+                    Arc::new(event_tree),
+                    vm_output.gas_used(),
+                    num_accounts_created,
+                    txn_info_hash,
+                ));
+                current_state_tree = state_tree;
+
+                // check for change in validator set
+                let validator_set_change_event_key = ValidatorSet::change_event_key();
+                for event in vm_output.events() {
+                    if *event.key() == validator_set_change_event_key {
+                        next_validator_set = Some(ValidatorSet::from_bytes(event.event_data())?);
+                        break;
                     }
                 }
-            }
 
-            txn_data.push(TransactionData::new(
-                blobs,
-                vm_output.events().to_vec(),
-                vm_output.status().clone(),
-                Arc::clone(&state_tree),
-                Arc::new(event_tree),
-                vm_output.gas_used(),
-                num_accounts_created,
-                txn_info_hash,
-            ));
-            current_state_tree = state_tree;
-
-            // check for change in validator set
-            let validator_set_change_event_key = ValidatorSet::change_event_key();
-            for event in vm_output.events() {
-                if *event.key() == validator_set_change_event_key {
-                    next_validator_set = Some(ValidatorSet::from_bytes(event.event_data())?);
-                    break;
+                if next_validator_set.is_some() {
+                    validator_set_change_seen = true;
                 }
             }
         }

--- a/language/e2e-tests/src/executor.rs
+++ b/language/e2e-tests/src/executor.rs
@@ -218,6 +218,7 @@ impl FakeExecutor {
                 output
             }
             TransactionStatus::Discard(status) => panic!("transaction discarded with {:?}", status),
+            TransactionStatus::Retry => panic!("transaction status is retry"),
         }
     }
 

--- a/language/functional-tests/src/evaluator.rs
+++ b/language/functional-tests/src/evaluator.rs
@@ -360,7 +360,7 @@ fn run_transaction(
                     Err(ErrorKind::VMExecutionFailure(output).into())
                 }
             }
-            TransactionStatus::Discard(_) => {
+            TransactionStatus::Discard(_) | TransactionStatus::Retry => {
                 checked_verify!(output.write_set().is_empty());
                 Err(ErrorKind::DiscardedTransaction(output).into())
             }

--- a/language/libra-vm/src/counters.rs
+++ b/language/libra-vm/src/counters.rs
@@ -101,6 +101,7 @@ pub fn report_execution_status(status: &TransactionStatus) {
     match status {
         TransactionStatus::Keep(vm_status) => inc_counter(TXN_EXECUTION_KEEP, vm_status),
         TransactionStatus::Discard(vm_status) => inc_counter(TXN_EXECUTION_DISCARD, vm_status),
+        TransactionStatus::Retry => (),
     }
 }
 

--- a/language/libra-vm/src/libra_vm.rs
+++ b/language/libra-vm/src/libra_vm.rs
@@ -353,6 +353,8 @@ impl LibraVM {
                 .and_then(|_| get_transaction_output(&mut gas_free_ctx, txn_data, status))
                 .unwrap_or_else(discard_error_output),
             TransactionStatus::Discard(status) => discard_error_output(status),
+            // impossible to reach here
+            TransactionStatus::Retry => unreachable!(),
         }
     }
 

--- a/language/libra-vm/src/libra_vm.rs
+++ b/language/libra-vm/src/libra_vm.rs
@@ -353,7 +353,6 @@ impl LibraVM {
                 .and_then(|_| get_transaction_output(&mut gas_free_ctx, txn_data, status))
                 .unwrap_or_else(discard_error_output),
             TransactionStatus::Discard(status) => discard_error_output(status),
-            // impossible to reach here
             TransactionStatus::Retry => unreachable!(),
         }
     }

--- a/types/src/transaction/mod.rs
+++ b/types/src/transaction/mod.rs
@@ -588,7 +588,7 @@ impl TransactionStatus {
         match self {
             TransactionStatus::Discard(_) => true,
             TransactionStatus::Keep(_) => false,
-            TransactionStatus::Retry => false,
+            TransactionStatus::Retry => true,
         }
     }
 }

--- a/types/src/transaction/mod.rs
+++ b/types/src/transaction/mod.rs
@@ -569,12 +569,18 @@ pub enum TransactionStatus {
 
     /// Keep the transaction output
     Keep(VMStatus),
+
+    /// Retry the transaction because it is after a ValidatorSetChange txn
+    Retry,
 }
 
 impl TransactionStatus {
-    pub fn vm_status(&self) -> &VMStatus {
+    pub fn vm_status(&self) -> VMStatus {
         match self {
-            TransactionStatus::Discard(vm_status) | TransactionStatus::Keep(vm_status) => vm_status,
+            TransactionStatus::Discard(vm_status) | TransactionStatus::Keep(vm_status) => {
+                vm_status.clone()
+            }
+            TransactionStatus::Retry => VMStatus::new(StatusCode::UNKNOWN_VALIDATION_STATUS),
         }
     }
 
@@ -582,6 +588,7 @@ impl TransactionStatus {
         match self {
             TransactionStatus::Discard(_) => true,
             TransactionStatus::Keep(_) => false,
+            TransactionStatus::Retry => false,
         }
     }
 }


### PR DESCRIPTION
…tor set change txn

## Motivation

@zekun000 's request to set all the txns in a block after a validator-set-change-txn with a new
transaction status `Retry`.  https://github.com/libra/libra/issues/2485

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?

Y

## Test Plan

Existing tests