### PR TITLE
[consensus] refactor consensus network messages processing

### DIFF
--- a/consensus/consensus-types/src/epoch_retrieval.rs
+++ b/consensus/consensus-types/src/epoch_retrieval.rs
@@ -4,7 +4,7 @@
 use serde::{Deserialize, Serialize};
 
 /// Request to get a ValidatorChangeProof from current_epoch to target_epoch
-#[derive(Serialize, Deserialize)]
+#[derive(Debug, Deserialize, Serialize)]
 pub struct EpochRetrievalRequest {
     pub start_epoch: u64,
     pub end_epoch: u64,

--- a/consensus/src/chained_bft/chained_bft_smr.rs
+++ b/consensus/src/chained_bft/chained_bft_smr.rs
@@ -4,8 +4,7 @@
 use crate::{
     chained_bft::{
         block_storage::BlockStore,
-        epoch_manager::{EpochManager, LivenessStorageData, Processor},
-        event_processor::EventProcessor,
+        epoch_manager::{EpochManager, LivenessStorageData},
         network::{NetworkReceivers, NetworkTask},
         network_interface::{ConsensusNetworkEvents, ConsensusNetworkSender},
         persistent_liveness_storage::PersistentLivenessStorage,
@@ -21,10 +20,7 @@ use futures::{select, stream::StreamExt};
 use libra_config::config::{ConsensusConfig, NodeConfig};
 use libra_logger::prelude::*;
 use safety_rules::SafetyRulesManager;
-use std::{
-    sync::{Arc, RwLock},
-    time::Instant,
-};
+use std::{sync::Arc, time::Instant};
 use tokio::runtime::{self, Handle, Runtime};
 
 /// All these structures need to be moved into EpochManager. Rather than make each one an option
@@ -86,117 +82,29 @@ impl<T: Payload> ChainedBftSMR<T> {
         self.block_store.clone()
     }
 
-    // Depending on what data we can extract from consensusdb, we may or may not have an
-    // event processor at startup. If we need to sync up with peers for blocks to construct
-    // a valid block store, which is required to construct an event processor, we will take
-    // care of the sync up here. If we already have an event processor, it will just simply
-    // be extracted out of the enum and returned
-    async fn gen_event_processor(
-        processor: Processor<T>,
-        epoch_manager: &mut EpochManager<T>,
-        network_receivers: &mut NetworkReceivers<T>,
-    ) -> EventProcessor<T> {
-        match processor {
-            Processor::StartupSyncProcessor(mut startup_sync_processor) => {
-                loop {
-                    let pre_select_instant = Instant::now();
-                    let idle_duration;
-                    select! {
-                        proposal_msg = network_receivers.proposals.select_next_some() => {
-                            idle_duration = pre_select_instant.elapsed();
-                            if let Ok(initial_data) = startup_sync_processor.process_proposal_msg(proposal_msg).await {
-                                break epoch_manager.start_epoch_with_recovery_data(initial_data);
-                            }
-                        }
-                        vote_msg = network_receivers.votes.select_next_some() => {
-                            idle_duration = pre_select_instant.elapsed();
-                            if let Ok(initial_data) = startup_sync_processor.process_vote(vote_msg).await {
-                                break epoch_manager.start_epoch_with_recovery_data(initial_data);
-                            }
-                        }
-                        sync_info_msg = network_receivers.sync_info_msgs.select_next_some() => {
-                            idle_duration = pre_select_instant.elapsed();
-                            if let Ok(initial_data) = startup_sync_processor.process_sync_info_msg(sync_info_msg.0, sync_info_msg.1).await {
-                                break epoch_manager.start_epoch_with_recovery_data(initial_data);
-                            }
-                        }
-                        ledger_info = network_receivers.epoch_change.select_next_some() => {
-                            idle_duration = pre_select_instant.elapsed();
-                            if epoch_manager.epoch() <= ledger_info.ledger_info().epoch() {
-                                let event_processor = epoch_manager.start_new_epoch(ledger_info).await;
-                                // clean up all the previous messages from the old epochs
-                                network_receivers.clear_prev_epoch_msgs();
-                                break event_processor;
-                            }
-                        }
-                        different_epoch_and_peer = network_receivers.different_epoch.select_next_some() => {
-                            idle_duration = pre_select_instant.elapsed();
-                            epoch_manager.process_different_epoch(different_epoch_and_peer.0, different_epoch_and_peer.1).await
-                        }
-                    }
-                    counters::STARTUP_SYNC_LOOP_BUSY_DURATION_S
-                        .observe_duration(pre_select_instant.elapsed() - idle_duration);
-                    counters::STARTUP_SYNC_LOOP_IDLE_DURATION_S.observe_duration(idle_duration);
-                }
-            }
-            Processor::EventProcessor(event_processor) => event_processor,
-        }
-    }
-
     fn start_event_processing(
         executor: Handle,
         mut epoch_manager: EpochManager<T>,
-        processor: Processor<T>,
         mut pacemaker_timeout_sender_rx: channel::Receiver<Round>,
         network_task: NetworkTask<T>,
         mut network_receivers: NetworkReceivers<T>,
     ) {
         let fut = async move {
-            // TODO: Event loop logic need to get cleaned up(#2518)
-            let mut event_processor =
-                Self::gen_event_processor(processor, &mut epoch_manager, &mut network_receivers)
-                    .await;
-            event_processor.start().await;
             loop {
                 let pre_select_instant = Instant::now();
                 let idle_duration;
                 select! {
-                    proposal_msg = network_receivers.proposals.select_next_some() => {
+                    msg = network_receivers.consensus_messages.select_next_some() => {
                         idle_duration = pre_select_instant.elapsed();
-                        event_processor.process_proposal_msg(proposal_msg).await;
+                        epoch_manager.process_message(msg.0, msg.1).await
                     }
                     block_retrieval = network_receivers.block_retrieval.select_next_some() => {
                         idle_duration = pre_select_instant.elapsed();
-                        event_processor.process_block_retrieval(block_retrieval).await;
+                        epoch_manager.process_block_retrieval(block_retrieval).await
                     }
-                    vote_msg = network_receivers.votes.select_next_some() => {
+                    round = pacemaker_timeout_sender_rx.select_next_some() => {
                         idle_duration = pre_select_instant.elapsed();
-                        event_processor.process_vote(vote_msg).await;
-                    }
-                    local_timeout_round = pacemaker_timeout_sender_rx.select_next_some() => {
-                        idle_duration = pre_select_instant.elapsed();
-                        event_processor.process_local_timeout(local_timeout_round).await;
-                    }
-                    sync_info_msg = network_receivers.sync_info_msgs.select_next_some() => {
-                        idle_duration = pre_select_instant.elapsed();
-                        event_processor.process_sync_info_msg(sync_info_msg.0, sync_info_msg.1).await;
-                    }
-                    ledger_info = network_receivers.epoch_change.select_next_some() => {
-                        idle_duration = pre_select_instant.elapsed();
-                        if epoch_manager.epoch() <= ledger_info.ledger_info().epoch() {
-                            event_processor = epoch_manager.start_new_epoch(ledger_info).await;
-                            // clean up all the previous messages from the old epochs
-                            network_receivers.clear_prev_epoch_msgs();
-                            event_processor.start().await;
-                        }
-                    }
-                    different_epoch_and_peer = network_receivers.different_epoch.select_next_some() => {
-                        idle_duration = pre_select_instant.elapsed();
-                        epoch_manager.process_different_epoch(different_epoch_and_peer.0, different_epoch_and_peer.1).await
-                    }
-                    epoch_retrieval_and_peer = network_receivers.epoch_retrieval.select_next_some() => {
-                        idle_duration = pre_select_instant.elapsed();
-                        epoch_manager.process_epoch_retrieval(epoch_retrieval_and_peer.0, epoch_retrieval_and_peer.1).await
+                        epoch_manager.process_local_timeout(round).await
                     }
                 }
                 counters::EVENT_PROCESSING_LOOP_BUSY_DURATION_S
@@ -232,11 +140,11 @@ impl<T: Payload> ConsensusProvider for ChainedBftSMR<T> {
 
         let liveness_storage_data: LivenessStorageData<T> = runtime.block_on(self.storage.start());
 
-        let epoch_info = Arc::new(RwLock::new(liveness_storage_data.epoch_info()));
+        let epoch_info = liveness_storage_data.epoch_info();
 
         let mut epoch_mgr = EpochManager::new(
             self.author,
-            Arc::clone(&epoch_info),
+            epoch_info,
             input.config,
             time_service,
             self_sender,
@@ -249,18 +157,16 @@ impl<T: Payload> ConsensusProvider for ChainedBftSMR<T> {
         );
 
         let (network_task, network_receiver) =
-            NetworkTask::new(epoch_info, input.network_events, self_receiver);
+            NetworkTask::new(input.network_events, self_receiver);
 
-        let processor = epoch_mgr.start(liveness_storage_data);
+        runtime.block_on(epoch_mgr.start(liveness_storage_data));
 
-        if let Processor::EventProcessor(p) = &processor {
-            self.block_store = Some(p.block_store());
-        }
+        // TODO: this is for testing, remove
+        self.block_store = epoch_mgr.block_store();
 
         Self::start_event_processing(
             executor,
             epoch_mgr,
-            processor,
             timeout_receiver,
             network_task,
             network_receiver,

--- a/consensus/src/chained_bft/event_processor_fuzzing.rs
+++ b/consensus/src/chained_bft/event_processor_fuzzing.rs
@@ -156,7 +156,7 @@ pub fn fuzz_proposal(data: &[u8]) {
     };
 
     let proposal = match proposal.verify_well_formed() {
-        Ok(xx) => xx,
+        Ok(_) => proposal,
         Err(_) => {
             if cfg!(test) {
                 panic!();

--- a/consensus/src/chained_bft/event_processor_test.rs
+++ b/consensus/src/chained_bft/event_processor_test.rs
@@ -48,20 +48,13 @@ use libra_crypto::HashValue;
 use libra_types::{
     block_info::BlockInfo,
     crypto_proxies::{
-        random_validator_verifier, EpochInfo, LedgerInfoWithSignatures, ValidatorSigner,
-        ValidatorVerifier,
+        random_validator_verifier, LedgerInfoWithSignatures, ValidatorSigner, ValidatorVerifier,
     },
 };
 use network::{peer_manager::conn_status_channel, proto::ConsensusMsg};
 use prost::Message as _;
 use safety_rules::{ConsensusState, PersistentSafetyStorage as SafetyStorage, SafetyRulesManager};
-use std::{
-    collections::HashMap,
-    convert::TryFrom,
-    num::NonZeroUsize,
-    sync::{Arc, RwLock},
-    time::Duration,
-};
+use std::{collections::HashMap, convert::TryFrom, num::NonZeroUsize, sync::Arc, time::Duration};
 use tokio::runtime::Handle;
 
 /// Auxiliary struct that is setting up node environment for the test.
@@ -149,14 +142,7 @@ impl NodeSetup {
             initial_data.validators(),
         );
 
-        let (task, _receiver) = NetworkTask::<TestPayload>::new(
-            Arc::new(RwLock::new(EpochInfo {
-                epoch: 0,
-                verifier: initial_data.validators(),
-            })),
-            network_events,
-            self_receiver,
-        );
+        let (task, _receiver) = NetworkTask::<TestPayload>::new(network_events, self_receiver);
 
         executor.spawn(task.start());
         let last_vote_sent = initial_data.last_vote();

--- a/consensus/src/counters.rs
+++ b/consensus/src/counters.rs
@@ -84,28 +84,6 @@ pub static COMMITTED_TXNS_COUNT: Lazy<IntCounterVec> = Lazy::new(|| {
 });
 
 /// Histogram of idle time of spent in event processing loop
-pub static STARTUP_SYNC_LOOP_IDLE_DURATION_S: Lazy<DurationHistogram> = Lazy::new(|| {
-    DurationHistogram::new(
-        register_histogram!(
-            "libra_consensus_startup_sync_loop_idle_duration_s",
-            "Histogram of idle time of spent in startup sync loop"
-        )
-        .unwrap(),
-    )
-});
-
-/// Histogram of idle time of spent in event processing loop
-pub static STARTUP_SYNC_LOOP_BUSY_DURATION_S: Lazy<DurationHistogram> = Lazy::new(|| {
-    DurationHistogram::new(
-        register_histogram!(
-            "libra_consensus_startup_sync_loop_busy_duration_s",
-            "Histogram of busy time of spent in startup sync loop"
-        )
-        .unwrap(),
-    )
-});
-
-/// Histogram of idle time of spent in event processing loop
 pub static EVENT_PROCESSING_LOOP_IDLE_DURATION_S: Lazy<DurationHistogram> = Lazy::new(|| {
     DurationHistogram::new(
         register_histogram!(
@@ -127,21 +105,11 @@ pub static EVENT_PROCESSING_LOOP_BUSY_DURATION_S: Lazy<DurationHistogram> = Lazy
     )
 });
 
-/// Counters(queued,dequeued,dropped) related to proposals channel
-pub static PROPOSAL_CHANNEL_MSGS: Lazy<IntCounterVec> = Lazy::new(|| {
+/// Counters(queued,dequeued,dropped) related to consensus channel
+pub static CONSENSUS_CHANNEL_MSGS: Lazy<IntCounterVec> = Lazy::new(|| {
     register_int_counter_vec!(
-        "libra_consensus_proposal_channel_msgs_count",
-        "Counters(queued,dequeued,dropped) related to proposals channel",
-        &["state"]
-    )
-    .unwrap()
-});
-
-/// Counters(queued,dequeued,dropped) related to votes channel
-pub static VOTES_CHANNEL_MSGS: Lazy<IntCounterVec> = Lazy::new(|| {
-    register_int_counter_vec!(
-        "libra_consensus_votes_channel_msgs_count",
-        "Counters(queued,dequeued,dropped) related to votes channel",
+        "libra_consensus_channel_msgs_count",
+        "Counters(queued,dequeued,dropped) related to consensus channel",
         &["state"]
     )
     .unwrap()
@@ -152,26 +120,6 @@ pub static BLOCK_RETRIEVAL_CHANNEL_MSGS: Lazy<IntCounterVec> = Lazy::new(|| {
     register_int_counter_vec!(
         "libra_consensus_block_retrieval_channel_msgs_count",
         "Counters(queued,dequeued,dropped) related to block retrieval channel",
-        &["state"]
-    )
-    .unwrap()
-});
-
-/// Counters(queued,dequeued,dropped) related to sync info channel
-pub static SYNC_INFO_CHANNEL_MSGS: Lazy<IntCounterVec> = Lazy::new(|| {
-    register_int_counter_vec!(
-        "libra_consensus_sync_info_dropped_channel_msgs_count",
-        "Counters(queued,dequeued,dropped) related to sync info channel",
-        &["state"]
-    )
-    .unwrap()
-});
-
-/// Counters(queued,dequeued,dropped) related to epoch change channel
-pub static EPOCH_CHANGE_CHANNEL_MSGS: Lazy<IntCounterVec> = Lazy::new(|| {
-    register_int_counter_vec!(
-        "libra_consensus_epoch_change_dropped_channel_msgs_count",
-        "Counters(queued,dequeued,dropped) related to epoch change channel",
         &["state"]
     )
     .unwrap()

--- a/libra-node/src/main_node.rs
+++ b/libra-node/src/main_node.rs
@@ -240,6 +240,16 @@ pub fn setup_environment(node_config: &mut NodeConfig) -> LibraHandle {
     let mut consensus = None;
     let (consensus_to_mempool_sender, consensus_requests) = channel(INTRA_NODE_CHANNEL_BUFFER_SIZE);
 
+    instant = Instant::now();
+    let mempool = libra_mempool::bootstrap(
+        node_config,
+        mempool_network_handles,
+        client_events,
+        consensus_requests,
+        state_sync_requests,
+    );
+    debug!("Mempool started in {} ms", instant.elapsed().as_millis());
+
     if let Some((peer_id, runtime, mut network_builder)) = validator_network_provider {
         // Note: We need to start network provider before consensus, because the consensus
         // initialization is blocked on state synchronizer to sync to the initial root ledger
@@ -281,16 +291,6 @@ pub fn setup_environment(node_config: &mut NodeConfig) -> LibraHandle {
         consensus = Some(consensus_provider);
         debug!("Consensus started in {} ms", instant.elapsed().as_millis());
     }
-
-    instant = Instant::now();
-    let mempool = libra_mempool::bootstrap(
-        node_config,
-        mempool_network_handles,
-        client_events,
-        consensus_requests,
-        state_sync_requests,
-    );
-    debug!("Mempool started in {} ms", instant.elapsed().as_millis());
 
     LibraHandle {
         _network_runtimes: network_runtimes,


### PR DESCRIPTION
<!--
Thank you for sending a PR. We appreciate you spending time to help improve the Libra project.

The project is undergoing daily changes. Pull Requests will be reviewed and responded to as time permits.
-->

## Motivation

This is my attempt to tackle https://github.com/libra/libra/issues/2518 and https://github.com/libra/libra/issues/1671 and inspired by https://github.com/libra/libra/pull/2402

High level this commit does the following:
- Delay verification from network to EpochManager
- Add (Un)VerifiedEvent to serve the same purpose as network layer before
- Message pass through EpochManager to EventProcessor following the logic: process_epoch -> verify -> process_event
- single channel in network for messages per validator

Some of them are inter-related so it's quite a big PR.

Also there's more we can do but I'd rather leave them to following PR.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?

Y

## Test Plan

Existing tests.

## Related PRs

(If this PR adds or changes functionality, please take some time to update the docs at https://github.com/libra/website, and link to your PR here.)
