### PR TITLE
[logging] Capture logs from third-party libraries

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1273,6 +1273,7 @@ dependencies = [
  "libra-metrics 0.1.0",
  "libra-types 0.1.0",
  "slog-scope 4.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "slog-stdlog 4.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -2148,6 +2149,7 @@ dependencies = [
  "slog-async 2.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "slog-envlogger 2.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "slog-scope 4.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "slog-stdlog 4.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "slog-term 2.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "thread-id 3.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]

--- a/common/executable-helpers/Cargo.toml
+++ b/common/executable-helpers/Cargo.toml
@@ -11,6 +11,7 @@ edition = "2018"
 
 [dependencies]
 slog-scope = "4.0"
+slog-stdlog = "4.0.0"
 
 libra-config = { path = "../../config", version = "0.1.0" }
 crash-handler = { path = "../crash-handler", version = "0.1.0" }

--- a/common/executable-helpers/src/helpers.rs
+++ b/common/executable-helpers/src/helpers.rs
@@ -50,6 +50,7 @@ pub fn setup_executable(
     // We need to drop the global logger guard first before resetting it.
     _logger = None;
     let logger = set_default_global_logger(no_logging, &config.logger);
+    slog_stdlog::init().expect("failed to setup slog as log facade back-end");
     for network in &config.full_node_networks {
         setup_metrics(network.peer_id, &config);
     }

--- a/common/logger/Cargo.toml
+++ b/common/logger/Cargo.toml
@@ -24,6 +24,7 @@ slog = { version = "2.5.0", features = ["max_level_trace", "release_max_level_de
 slog-async = "2.3"
 slog-envlogger = "2.1.0"
 slog-scope = "4.0"
+slog-stdlog = "4.0.0"
 slog-term = "2.4.1"
 thread-id = "3.3.0"
 

--- a/common/logger/src/lib.rs
+++ b/common/logger/src/lib.rs
@@ -90,7 +90,9 @@ where
 /// ugly, but it works.
 static TESTING_ENVLOGGER_GUARD: Lazy<GlobalLoggerGuard> = Lazy::new(|| {
     if ::std::env::var("RUST_LOG").is_ok() {
-        set_global_logger(false /* async */, None /* chan_size */)
+        let logger = set_global_logger(false /* async */, None /* chan_size */);
+        slog_stdlog::init().expect("failed to setup slog as log facade back-end");
+        logger
     } else {
         let logger = Logger::root(Discard, o!());
         slog_scope::set_global_logger(logger)


### PR DESCRIPTION
## Motivation

It seems standard practice for Rust libraries to use the `log` [facade](https://docs.rs/log/) library for logging and letting the user of those libraries choose a logging implementation as back-end. In our case, since we use `slog` as our logging implementation, we should set `slog` as the back-end of `log` to capture log messages generated by our libraries.

One risk with doing this is that our log files might become large if a library is too liberal with using `info` or higher log levels. However, it's worth trying this and tuning verbosity of individual libraries as we learn from experience rather than not getting these logs at all.