### PR TITLE
[vm-runtime] move gas loading code from Move VM to Libra VM

### DIFF
--- a/language/benchmarks/src/move_vm.rs
+++ b/language/benchmarks/src/move_vm.rs
@@ -23,7 +23,7 @@ use vm_runtime::{
 /// Entry point for the bench, provide a function name to invoke in Module Bench in bench.move.
 pub fn bench(c: &mut Criterion, fun: &str) {
     let module = compile_module();
-    let mut move_vm = MoveVM::new();
+    let move_vm = MoveVM::new();
     move_vm.cache_module(module);
     execute(c, &move_vm, fun);
 }

--- a/language/tools/cost-synthesis/src/main.rs
+++ b/language/tools/cost-synthesis/src/main.rs
@@ -168,7 +168,7 @@ fn stack_instructions(options: &Opt) {
 
     // create a VMRuntime and populate it with generated modules
     let allocator = Arena::new();
-    let mut runtime = VMRuntime::new(&allocator);
+    let runtime = VMRuntime::new(&allocator);
     for m in modules.clone() {
         runtime.cache_module(m);
     }

--- a/language/tools/test-generation/src/lib.rs
+++ b/language/tools/test-generation/src/lib.rs
@@ -21,6 +21,7 @@ use bytecode_verifier::VerifiedModule;
 use crossbeam_channel::{bounded, unbounded, Receiver, Sender};
 use getrandom::getrandom;
 use language_e2e_tests::executor::FakeExecutor;
+use libra_config::config::VMConfig;
 use libra_state_view::StateView;
 use libra_types::{account_address::AccountAddress, byte_array::ByteArray, vm_error::StatusCode};
 use rand::{rngs::StdRng, Rng, SeedableRng};
@@ -32,12 +33,9 @@ use vm::{
     access::ModuleAccess,
     errors::VMResult,
     file_format::{CompiledModule, CompiledModuleMut, FunctionDefinitionIndex, SignatureToken},
-    gas_schedule::MAXIMUM_NUMBER_OF_GAS_UNITS,
     transaction_metadata::TransactionMetadata,
 };
-use vm_runtime::{
-    chain_state::TransactionExecutionContext, data_cache::BlockDataCache, move_vm::MoveVM,
-};
+use vm_runtime::LibraVM;
 use vm_runtime_types::values::Value;
 
 /// This function calls the Bytecode verifier to test it
@@ -89,24 +87,25 @@ fn execute_function_in_module(
         module.identifier_at(entry_name_idx)
     };
     {
-        let runtime = MoveVM::new();
-        runtime.cache_module(module.clone());
+        let mut libra_vm = LibraVM::new(&VMConfig::default());
+        libra_vm.load_configs(state_view);
 
-        let data_cache = BlockDataCache::new(state_view);
-        let mut context =
-            TransactionExecutionContext::new(*MAXIMUM_NUMBER_OF_GAS_UNITS, &data_cache);
-        let gas_schedule = runtime.load_gas_schedule(&mut context, &data_cache)?;
+        let internals = libra_vm.internals();
+        let move_vm = internals.move_vm();
+        move_vm.cache_module(module.clone());
+
+        let gas_schedule = internals.gas_schedule()?;
         let txn_data = TransactionMetadata::default();
-        let mut interpreter_context =
-            TransactionExecutionContext::new(txn_data.max_gas_amount(), &data_cache);
-        runtime.execute_function(
-            &module_id,
-            &entry_name,
-            &gas_schedule,
-            &mut interpreter_context,
-            &txn_data,
-            args,
-        )
+        internals.with_txn_context(&txn_data, state_view, |mut txn_context| {
+            move_vm.execute_function(
+                &module_id,
+                &entry_name,
+                gas_schedule,
+                &mut txn_context,
+                &txn_data,
+                args,
+            )
+        })
     }
 }
 

--- a/language/tools/test-generation/src/lib.rs
+++ b/language/tools/test-generation/src/lib.rs
@@ -89,7 +89,7 @@ fn execute_function_in_module(
         module.identifier_at(entry_name_idx)
     };
     {
-        let mut runtime = MoveVM::new();
+        let runtime = MoveVM::new();
         runtime.cache_module(module.clone());
 
         let data_cache = BlockDataCache::new(state_view);

--- a/language/tools/vm-genesis/src/lib.rs
+++ b/language/tools/vm-genesis/src/lib.rs
@@ -128,7 +128,7 @@ pub fn encode_genesis_transaction_with_validator_and_modules(
     stdlib_modules: &'static [VerifiedModule],
 ) -> SignatureCheckedTransaction {
     // create a MoveVM
-    let mut move_vm = MoveVM::new();
+    let move_vm = MoveVM::new();
 
     // create a data view for move_vm
     let state_view = GenesisStateView;

--- a/language/vm/vm-runtime/src/move_vm.rs
+++ b/language/vm/vm-runtime/src/move_vm.rs
@@ -2,11 +2,11 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::{
-    chain_state::ChainState, data_cache::RemoteCache, loaded_data::loaded_module::LoadedModule,
-    runtime::VMRuntime,
+    chain_state::ChainState, loaded_data::loaded_module::LoadedModule, runtime::VMRuntime,
 };
 use bytecode_verifier::VerifiedModule;
 use libra_types::identifier::Identifier;
+use libra_types::language_storage::StructTag;
 use libra_types::{identifier::IdentStr, language_storage::ModuleId};
 use move_vm_definition::MoveVMImpl;
 use vm::{errors::VMResult, gas_schedule::CostTable, transaction_metadata::TransactionMetadata};
@@ -92,6 +92,16 @@ impl MoveVM {
         self.0.rent(|runtime| runtime.cache_module(module))
     }
 
+    pub fn resolve_struct_tag_by_name<S: ChainState>(
+        &self,
+        module_id: &ModuleId,
+        name: &Identifier,
+        chain_state: &mut S,
+    ) -> VMResult<StructTag> {
+        self.0
+            .rent(|runtime| runtime.resolve_struct_tag_by_name(module_id, name, chain_state))
+    }
+
     pub fn resolve_struct_def_by_name<S: ChainState>(
         &self,
         module_id: &ModuleId,
@@ -100,15 +110,6 @@ impl MoveVM {
     ) -> VMResult<StructDef> {
         self.0
             .rent(|runtime| runtime.resolve_struct_def_by_name(module_id, name, chain_state))
-    }
-
-    pub fn load_gas_schedule<S: ChainState>(
-        &self,
-        chain_state: &mut S,
-        data_view: &dyn RemoteCache,
-    ) -> VMResult<CostTable> {
-        self.0
-            .rent(|runtime| runtime.load_gas_schedule(chain_state, data_view))
     }
 }
 

--- a/language/vm/vm-runtime/src/move_vm.rs
+++ b/language/vm/vm-runtime/src/move_vm.rs
@@ -88,8 +88,8 @@ impl MoveVM {
             .rent(|runtime| runtime.publish_module(module, chain_state, txn_data))
     }
 
-    pub fn cache_module(&mut self, module: VerifiedModule) {
-        self.0.rent_mut(|runtime| runtime.cache_module(module))
+    pub fn cache_module(&self, module: VerifiedModule) {
+        self.0.rent(|runtime| runtime.cache_module(module))
     }
 
     pub fn resolve_struct_def_by_name<S: ChainState>(

--- a/language/vm/vm-runtime/src/runtime.rs
+++ b/language/vm/vm-runtime/src/runtime.rs
@@ -182,7 +182,7 @@ impl<'alloc> VMRuntime<'alloc> {
         )
     }
 
-    pub fn cache_module(&mut self, module: VerifiedModule) {
+    pub fn cache_module(&self, module: VerifiedModule) {
         self.code_cache.cache_module(module);
     }
 


### PR DESCRIPTION
This code is specific to the Libra VM, so it should live here.

Prerequisite for Move/Libra VM separation.