### PR TITLE
JSON-RPC endpoint

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -390,6 +390,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "buf_redux"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "memchr 2.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "safemem 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "build_const"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1696,6 +1705,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "headers"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "base64 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "bitflags 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "bytes 0.5.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "headers-core 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "http 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "mime 0.3.16 (registry+https://github.com/rust-lang/crates.io-index)",
+ "sha-1 0.8.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "time 0.1.42 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "headers-core"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "http 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "heck"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1905,6 +1937,14 @@ version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "autocfg 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "input_buffer"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "bytes 0.4.12 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -2283,6 +2323,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "libra-json-rpc"
+version = "0.1.0"
+dependencies = [
+ "anyhow 1.0.26 (registry+https://github.com/rust-lang/crates.io-index)",
+ "futures 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "hex 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libra-config 0.1.0",
+ "libra-logger 0.1.0",
+ "libra-metrics 0.1.0",
+ "libra-types 0.1.0",
+ "reqwest 0.10.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_json 1.0.48 (registry+https://github.com/rust-lang/crates.io-index)",
+ "storage-client 0.1.0",
+ "storage-proto 0.1.0",
+ "storage-service 0.1.0",
+ "tokio 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
+ "warp 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "libra-logger"
 version = "0.1.0"
 dependencies = [
@@ -2386,6 +2447,7 @@ dependencies = [
  "jemallocator 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "libra-config 0.1.0",
  "libra-crypto 0.1.0",
+ "libra-json-rpc 0.1.0",
  "libra-logger 0.1.0",
  "libra-mempool 0.1.0",
  "libra-metrics 0.1.0",
@@ -2649,6 +2711,14 @@ dependencies = [
 
 [[package]]
 name = "log"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "log"
 version = "0.4.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
@@ -2727,8 +2797,27 @@ dependencies = [
 
 [[package]]
 name = "mime"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "log 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "mime"
 version = "0.3.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "mime_guess"
+version = "1.8.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "mime 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "phf 0.7.24 (registry+https://github.com/rust-lang/crates.io-index)",
+ "phf_codegen 0.7.24 (registry+https://github.com/rust-lang/crates.io-index)",
+ "unicase 1.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
+]
 
 [[package]]
 name = "mime_guess"
@@ -2859,6 +2948,23 @@ dependencies = [
 name = "multimap"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "multipart"
+version = "0.16.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "buf_redux 0.8.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "httparse 1.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "mime 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "mime_guess 1.8.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "quick-error 1.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "safemem 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tempfile 3.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "twoway 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
+]
 
 [[package]]
 name = "native-tls"
@@ -3324,6 +3430,41 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "fixedbitset 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "indexmap 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "phf"
+version = "0.7.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "phf_shared 0.7.24 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "phf_codegen"
+version = "0.7.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "phf_generator 0.7.24 (registry+https://github.com/rust-lang/crates.io-index)",
+ "phf_shared 0.7.24 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "phf_generator"
+version = "0.7.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "phf_shared 0.7.24 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "phf_shared"
+version = "0.7.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "siphasher 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "unicase 1.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -4255,6 +4396,11 @@ dependencies = [
 ]
 
 [[package]]
+name = "scoped-tls"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
 name = "scopeguard"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4435,6 +4581,11 @@ dependencies = [
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "term 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
+
+[[package]]
+name = "siphasher"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "slab"
@@ -5647,6 +5798,32 @@ dependencies = [
 ]
 
 [[package]]
+name = "tungstenite"
+version = "0.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "base64 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "byteorder 1.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "bytes 0.4.12 (registry+https://github.com/rust-lang/crates.io-index)",
+ "http 0.1.21 (registry+https://github.com/rust-lang/crates.io-index)",
+ "httparse 1.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "input_buffer 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand 0.7.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "sha-1 0.8.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "url 2.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "utf-8 0.7.5 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "twoway"
+version = "0.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "memchr 2.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "typed-arena"
 version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5655,6 +5832,14 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 name = "typenum"
 version = "1.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "unicase"
+version = "1.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "version_check 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
+]
 
 [[package]]
 name = "unicase"
@@ -5746,6 +5931,16 @@ dependencies = [
  "matches 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "percent-encoding 2.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
+
+[[package]]
+name = "urlencoding"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "utf-8"
+version = "0.7.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "utf8parse"
@@ -5945,6 +6140,31 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "try-lock 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "warp"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "bytes 0.5.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "futures 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "headers 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "http 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "hyper 0.13.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "mime 0.3.16 (registry+https://github.com/rust-lang/crates.io-index)",
+ "mime_guess 2.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "multipart 0.16.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "pin-project 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "scoped-tls 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_json 1.0.48 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_urlencoded 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tower-service 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tungstenite 0.9.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "urlencoding 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -6271,6 +6491,7 @@ dependencies = [
 "checksum block-padding 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "fa79dedbb091f449f1f39e53edf88d5dbe95f895dae6135a8d7b881fb5af73f5"
 "checksum bs58 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "b170cd256a3f9fa6b9edae3e44a7dfdfc77e8124dbc3e2612d75f9c3e2396dae"
 "checksum bstr 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)" = "502ae1441a0a5adb8fbd38a5955a6416b9493e92b465de5e4a9bde6a539c2c48"
+"checksum buf_redux 0.8.4 (registry+https://github.com/rust-lang/crates.io-index)" = "b953a6887648bb07a535631f2bc00fbdb2a2216f135552cb3f534ed136b9c07f"
 "checksum build_const 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "39092a32794787acd8525ee150305ff051b0aa6cc2abaf193924f5ab05425f39"
 "checksum bumpalo 3.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "1f359dc14ff8911330a51ef78022d376f25ed00248912803b58f00cb1c27f742"
 "checksum byte-tools 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "e3b5ca7a04898ad4bcd41c90c5285445ff5b791899bb1b0abdd2a2aa791211d7"
@@ -6374,6 +6595,8 @@ dependencies = [
 "checksum goldenfile 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "3f46e6a4d70c06f0b9a70d36dd8eef4fdeaa1ab657e4f1eaff290f69e48145f2"
 "checksum h2 0.1.26 (registry+https://github.com/rust-lang/crates.io-index)" = "a5b34c246847f938a410a03c5458c7fee2274436675e76d8b903c08efc29c462"
 "checksum h2 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "b9433d71e471c1736fd5a61b671fc0b148d7a2992f666c958d03cd8feb3b88d1"
+"checksum headers 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "a72b4bd7cbbf0c22190e82f02517f456a6b9be24c25a6827b5802e478b8c2d70"
+"checksum headers-core 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "e7f66481bfee273957b1f20485a4ff3362987f85b2c236580d81b4eb7a326429"
 "checksum heck 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "20564e78d53d2bb135c343b3f47714a56af2061f1c928fdb541dc7b9fdd94205"
 "checksum hermit-abi 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)" = "1010591b26bbfe835e9faeabeb11866061cc7dcebffd56ad7d0942d0e61aefd8"
 "checksum hex 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)" = "644f9158b2f133fd50f5fb3242878846d9eb792e445c893805ff0e3824006e35"
@@ -6393,6 +6616,7 @@ dependencies = [
 "checksum idna 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "38f09e0f0b1fb55fdee1f17470ad800da77af5186a1a76c026b679358b7e844e"
 "checksum idna 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "02e2673c30ee86b5b96a9cb52ad15718aa1f966f5ab9ad54a8b95d5ca33120a9"
 "checksum indexmap 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)" = "076f042c5b7b98f31d205f1249267e12a6518c1481e9dae9764af19b707d2292"
+"checksum input_buffer 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "8e1b822cc844905551931d6f81608ed5f50a79c1078a4e2b4d42dbc7c1eedfbf"
 "checksum iovec 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)" = "b2b3ea6ff95e175473f8ffe6a7eb7c00d054240321b84c57051175fe3c1e075e"
 "checksum itertools 0.8.2 (registry+https://github.com/rust-lang/crates.io-index)" = "f56a2d0bc861f9165be4eb3442afd3c236d8a98afd426f65d92324ae1091a484"
 "checksum itoa 0.4.5 (registry+https://github.com/rust-lang/crates.io-index)" = "b8b7a7c0c47db5545ed3fef7468ee7bb5b74691498139e4b3f6a20685dc6dd8e"
@@ -6413,6 +6637,7 @@ dependencies = [
 "checksum libz-sys 1.0.25 (registry+https://github.com/rust-lang/crates.io-index)" = "2eb5e43362e38e2bca2fd5f5134c4d4564a23a5c28e9b95411652021a8675ebe"
 "checksum linked-hash-map 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)" = "ae91b68aebc4ddb91978b11a1b02ddd8602a05ec19002801c5666000e05e0f83"
 "checksum lock_api 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "79b2de95ecb4691949fea4716ca53cdbcfccb2c612e19644a8bad05edcf9f47b"
+"checksum log 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)" = "e19e8d5c34a3e0e2223db8e060f9e8264aeeb5c5fc64a4ee9965c062211c024b"
 "checksum log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)" = "14b6052be84e6b71ab17edffc2eeabf5c2c3ae1fdb464aae35ac50c67a44e1f7"
 "checksum lru-cache 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "31e24f1ad8321ca0e8a1e0ac13f23cb668e6f5466c2c57319f6a5cf1cc8e3b1c"
 "checksum lz4-sys 1.8.3 (git+https://github.com/busyjay/lz4-rs.git?branch=adjust-build)" = "<none>"
@@ -6423,7 +6648,9 @@ dependencies = [
 "checksum memchr 2.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "3728d817d99e5ac407411fa471ff9800a778d88a24685968b36824eaf4bee400"
 "checksum memoffset 0.5.3 (registry+https://github.com/rust-lang/crates.io-index)" = "75189eb85871ea5c2e2c15abbdd541185f63b408415e5051f5cac122d8c774b9"
 "checksum memsec 0.5.7 (registry+https://github.com/rust-lang/crates.io-index)" = "0cb9280f8c37546661083aa45eb0318d8469253d31e87649faed25522428398e"
+"checksum mime 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)" = "ba626b8a6de5da682e1caa06bdb42a335aee5a84db8e5046a3e8ab17ba0a3ae0"
 "checksum mime 0.3.16 (registry+https://github.com/rust-lang/crates.io-index)" = "2a60c7ce501c71e03a9c9c0d35b861413ae925bd979cc7a4e30d060069aaac8d"
+"checksum mime_guess 1.8.7 (registry+https://github.com/rust-lang/crates.io-index)" = "0d977de9ee851a0b16e932979515c0f3da82403183879811bc97d50bd9cc50f7"
 "checksum mime_guess 2.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "1a0ed03949aef72dbdf3116a383d7b38b4768e6f960528cd6a6044aa9ed68599"
 "checksum miniz_oxide 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)" = "aa679ff6578b1cddee93d7e82e263b94a575e0bfced07284eb0c037c1d2416a5"
 "checksum mio 0.6.21 (registry+https://github.com/rust-lang/crates.io-index)" = "302dec22bcf6bae6dfb69c647187f4b4d0fb6f535521f7bc022430ce8e12008f"
@@ -6433,6 +6660,7 @@ dependencies = [
 "checksum miow 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "396aa0f2003d7df8395cb93e09871561ccc3e785f0acb369170e8cc74ddf9226"
 "checksum mirai-annotations 1.6.0 (registry+https://github.com/rust-lang/crates.io-index)" = "f12a5b7d83c8fbf058cf1b33d26373763b2d6a0632b6bfecd4b4fa6a0507fea5"
 "checksum multimap 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)" = "a97fbd5d00e0e37bfb10f433af8f5aaf631e739368dc9fc28286ca81ca4948dc"
+"checksum multipart 0.16.1 (registry+https://github.com/rust-lang/crates.io-index)" = "136eed74cadb9edd2651ffba732b19a450316b680e4f48d6c79e905799e19d01"
 "checksum native-tls 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "4b2df1a4c22fd44a62147fd8f13dd0f95c9d8ca7b2610299b2a2f9cf8964274e"
 "checksum net2 0.2.33 (registry+https://github.com/rust-lang/crates.io-index)" = "42550d9fb7b6684a6d404d9fa7250c2eb2646df731d1c06afc06dcee9e1bcf88"
 "checksum nibble_vec 0.0.4 (registry+https://github.com/rust-lang/crates.io-index)" = "c8d77f3db4bce033f4d04db08079b2ef1c3d02b44e86f25d08886fafa7756ffa"
@@ -6475,6 +6703,10 @@ dependencies = [
 "checksum percent-encoding 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "31010dd2e1ac33d5b46a5b413495239882813e0369f8ed8a5e266f173602f831"
 "checksum percent-encoding 2.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "d4fd5641d01c8f18a23da7b6fe29298ff4b55afcccdf78973b24cf3175fee32e"
 "checksum petgraph 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)" = "29c127eea4a29ec6c85d153c59dc1213f33ec74cead30fe4730aecc88cc1fd92"
+"checksum phf 0.7.24 (registry+https://github.com/rust-lang/crates.io-index)" = "b3da44b85f8e8dfaec21adae67f95d93244b2ecf6ad2a692320598dcc8e6dd18"
+"checksum phf_codegen 0.7.24 (registry+https://github.com/rust-lang/crates.io-index)" = "b03e85129e324ad4166b06b2c7491ae27fe3ec353af72e72cd1654c7225d517e"
+"checksum phf_generator 0.7.24 (registry+https://github.com/rust-lang/crates.io-index)" = "09364cc93c159b8b06b1f4dd8a4398984503483891b0c26b867cf431fb132662"
+"checksum phf_shared 0.7.24 (registry+https://github.com/rust-lang/crates.io-index)" = "234f71a15de2288bcb7e3b6515828d22af7ec8598ee6d24c3b526fa0a80b67a0"
 "checksum pin-project 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)" = "7804a463a8d9572f13453c516a5faea534a2403d7ced2f0c7e100eeff072772c"
 "checksum pin-project-internal 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)" = "385322a45f2ecf3410c68d2a549a4a2685e8051d0f278e39743ff4e451cb9b3f"
 "checksum pin-project-lite 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)" = "237844750cfbb86f67afe27eee600dfbbcb6188d734139b534cbfbf4f96792ae"
@@ -6562,6 +6794,7 @@ dependencies = [
 "checksum safemem 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "ef703b7cb59335eae2eb93ceb664c0eb7ea6bf567079d843e09420219668e072"
 "checksum same-file 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)" = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
 "checksum schannel 0.1.17 (registry+https://github.com/rust-lang/crates.io-index)" = "507a9e6e8ffe0a4e0ebb9a10293e62fdf7657c06f1b8bb07a8fcf697d2abf295"
+"checksum scoped-tls 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ea6a9290e3c9cf0f18145ef7ffa62d68ee0bf5fcd651017e586dc7fd5da448c2"
 "checksum scopeguard 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "d29ab0c6d3fc0ee92fe66e2d99f700eab17a8d57d1c1d3b748380fb20baa78cd"
 "checksum sct 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)" = "e3042af939fca8c3453b7af0f1c66e533a15a86169e39de2657310ade8f98d3c"
 "checksum security-framework 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)" = "8ef2429d7cefe5fd28bd1d2ed41c944547d4ff84776f5935b456da44593a16df"
@@ -6580,6 +6813,7 @@ dependencies = [
 "checksum shlex 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "7fdf1b9db47230893d76faad238fd6097fd6d6a9245cd7a4d90dbd639536bbd2"
 "checksum signal-hook-registry 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "94f478ede9f64724c5d173d7bb56099ec3e2d9fc2774aac65d34b8b890405f41"
 "checksum simplelog 0.7.4 (registry+https://github.com/rust-lang/crates.io-index)" = "05a3e303ace6adb0a60a9e9e2fbc6a33e1749d1e43587e2125f7efa9c5e107c5"
+"checksum siphasher 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "0b8de496cf83d4ed58b6be86c3a275b8602f6ffe98d3024a869e124147a9a3ac"
 "checksum slab 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)" = "c111b5bd5695e56cffe5129854aa230b39c93a305372fdbb2668ca2394eea9f8"
 "checksum slog 2.5.2 (registry+https://github.com/rust-lang/crates.io-index)" = "1cc9c640a4adbfbcc11ffb95efe5aa7af7309e002adab54b185507dbf2377b99"
 "checksum slog-async 2.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "78ca925b180da88ccc595cbe4a3d378d79cb49fe5906c2cbc2488eaf700913ee"
@@ -6677,8 +6911,11 @@ dependencies = [
 "checksum tracing-futures 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "58b6233e421bf43203d36a8cd430acd24a75bed39832b0e07bec24541f9759e9"
 "checksum try-lock 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "e604eb7b43c06650e854be16a2a03155743d3752dd1c943f6829e26b7a36e382"
 "checksum ttl_cache 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)" = "4189890526f0168710b6ee65ceaedf1460c48a14318ceec933cb26baa492096a"
+"checksum tungstenite 0.9.2 (registry+https://github.com/rust-lang/crates.io-index)" = "8a0c2bd5aeb7dcd2bb32e472c8872759308495e5eccc942e929a513cd8d36110"
+"checksum twoway 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)" = "59b11b2b5241ba34be09c3cc85a36e56e48f9888862e19cedf23336d35316ed1"
 "checksum typed-arena 2.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "0685c84d5d54d1c26f7d3eb96cd41550adb97baed141a761cf335d3d33bcd0ae"
 "checksum typenum 1.11.2 (registry+https://github.com/rust-lang/crates.io-index)" = "6d2783fe2d6b8c1101136184eb41be8b1ad379e4657050b8aaff0c79ee7575f9"
+"checksum unicase 1.4.2 (registry+https://github.com/rust-lang/crates.io-index)" = "7f4765f83163b74f957c797ad9253caf97f103fb064d3999aea9568d09fc8a33"
 "checksum unicase 2.6.0 (registry+https://github.com/rust-lang/crates.io-index)" = "50f37be617794602aabbeee0be4f259dc1778fabe05e2d67ee8f79326d5cb4f6"
 "checksum unicode-bidi 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)" = "49f2bd0c6468a8230e1db229cff8029217cf623c767ea5d60bfbd42729ea54d5"
 "checksum unicode-normalization 0.1.12 (registry+https://github.com/rust-lang/crates.io-index)" = "5479532badd04e128284890390c1e876ef7a993d0570b3597ae43dfa1d59afa4"
@@ -6691,6 +6928,8 @@ dependencies = [
 "checksum ureq 0.11.4 (registry+https://github.com/rust-lang/crates.io-index)" = "801125e6d1ba6864cf3a5a92cfb2f0b0a3ee73e40602a0cd206ad2f3c040aa96"
 "checksum url 1.7.2 (registry+https://github.com/rust-lang/crates.io-index)" = "dd4e7c0d531266369519a4aa4f399d748bd37043b00bde1e4ff1f60a120b355a"
 "checksum url 2.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "829d4a8476c35c9bf0bbce5a3b23f4106f79728039b726d292bb93bc106787cb"
+"checksum urlencoding 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "3df3561629a8bb4c57e5a2e4c43348d9e29c7c29d9b1c4c1f47166deca8f37ed"
+"checksum utf-8 0.7.5 (registry+https://github.com/rust-lang/crates.io-index)" = "05e42f7c18b8f902290b009cde6d651262f956c98bc51bca4cd1d511c9cd85c7"
 "checksum utf8parse 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "8772a4ccbb4e89959023bc5b7cb8623a795caa7092d99f3aa9501b9484d4557d"
 "checksum vcpkg 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)" = "3fc439f2794e98976c88a2a2dafce96b930fe8010b0a256b3c2199a773933168"
 "checksum vec_map 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)" = "05c78687fb1a80548ae3250346c3db86a80a7cdd77bda190189f2d0a0987c81a"
@@ -6701,6 +6940,7 @@ dependencies = [
 "checksum walkdir 2.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "777182bc735b6424e1a57516d35ed72cb8019d85c8c9bf536dccb3445c1a2f7d"
 "checksum want 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "b6395efa4784b027708f7451087e647ec73cc74f5d9bc2e418404248d679a230"
 "checksum want 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "1ce8a968cb1cd110d136ff8b819a556d6fb6d919363c61534f6860c7eb172ba0"
+"checksum warp 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "ce153bc4ad61ed81c255cad4f1bf2474a1d284b482b20eecaefb152d0675fb1b"
 "checksum wasi 0.9.0+wasi-snapshot-preview1 (registry+https://github.com/rust-lang/crates.io-index)" = "cccddf32554fecc6acb585f82a32a72e28b48f8c4c1883ddfeeeaa96f7d8e519"
 "checksum wasm-bindgen 0.2.58 (registry+https://github.com/rust-lang/crates.io-index)" = "5205e9afdf42282b192e2310a5b463a6d1c1d774e30dc3c791ac37ab42d2616c"
 "checksum wasm-bindgen-backend 0.2.58 (registry+https://github.com/rust-lang/crates.io-index)" = "11cdb95816290b525b32587d76419facd99662a07e59d3cdb560488a819d9a45"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,6 +32,7 @@ members = [
     "crypto/crypto",
     "crypto/crypto-derive",
     "executor",
+    "json-rpc",
     "language/move-lang",
     "language/move-lang/stdlib",
     "language/benchmarks",

--- a/config/src/config/mod.rs
+++ b/config/src/config/mod.rs
@@ -16,6 +16,8 @@ use thiserror::Error;
 
 mod admission_control_config;
 pub use admission_control_config::*;
+mod rpc_config;
+pub use rpc_config::*;
 mod consensus_config;
 pub use consensus_config::*;
 mod debug_interface_config;
@@ -52,6 +54,8 @@ pub use vm_config::*;
 pub struct NodeConfig {
     #[serde(default)]
     pub admission_control: AdmissionControlConfig,
+    #[serde(default)]
+    pub rpc: RpcConfig,
     #[serde(default)]
     pub base: BaseConfig,
     #[serde(default)]
@@ -157,6 +161,7 @@ impl NodeConfig {
     pub fn clone_for_template(&self) -> Self {
         Self {
             admission_control: self.admission_control.clone(),
+            rpc: self.rpc.clone(),
             base: self.base.clone(),
             consensus: self.consensus.clone(),
             debug_interface: self.debug_interface.clone(),
@@ -256,6 +261,7 @@ impl NodeConfig {
         self.admission_control.randomize_ports();
         self.debug_interface.randomize_ports();
         self.storage.randomize_ports();
+        self.rpc.randomize_ports();
     }
 
     pub fn random() -> Self {

--- a/config/src/config/rpc_config.rs
+++ b/config/src/config/rpc_config.rs
@@ -1,0 +1,26 @@
+// Copyright (c) The Libra Core Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::utils;
+use serde::{Deserialize, Serialize};
+use std::net::SocketAddr;
+
+#[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
+#[serde(default, deny_unknown_fields)]
+pub struct RpcConfig {
+    pub address: SocketAddr,
+}
+
+impl Default for RpcConfig {
+    fn default() -> RpcConfig {
+        RpcConfig {
+            address: "0.0.0.0:5000".parse().unwrap(),
+        }
+    }
+}
+
+impl RpcConfig {
+    pub fn randomize_ports(&mut self) {
+        self.address.set_port(utils::get_available_port());
+    }
+}

--- a/json-rpc/Cargo.toml
+++ b/json-rpc/Cargo.toml
@@ -1,0 +1,30 @@
+[package]
+name = "libra-json-rpc"
+version = "0.1.0"
+authors = ["Libra Association <opensource@libra.org>"]
+description = "Libra rpc endpoint"
+repository = "https://github.com/libra/libra"
+homepage = "https://libra.org"
+license = "Apache-2.0"
+publish = false
+edition = "2018"
+
+[dependencies]
+anyhow = "1.0"
+hex = "0.4.2"
+serde_json = "1.0.40"
+serde = { version = "1.0.99", default-features = false }
+warp = "0.2.1"
+futures = "0.3.0"
+tokio = { version = "0.2.8", features = ["full"] }
+
+libra-config = { path = "../config", version = "0.1.0" }
+libra-logger = { path = "../common/logger", version = "0.1.0" }
+libra-metrics = { path = "../common/metrics", version = "0.1.0" }
+libra-types = { path = "../types", version = "0.1.0" }
+storage-client = { path = "../storage/storage-client", version = "0.1.0" }
+storage-proto = { path = "../storage/storage-proto", version = "0.1.0" }
+
+[dev-dependencies]
+reqwest = { version="0.10.1", features=["blocking", "json"], default_features = false }
+storage-service = { path = "../storage/storage-service", version = "0.1.0", features=["testing"] }

--- a/json-rpc/src/lib.rs
+++ b/json-rpc/src/lib.rs
@@ -1,0 +1,27 @@
+// Copyright (c) The Libra Core Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+//! JSON RPC endpoint
+//!
+//! Used as public API interface for interacting with Full Nodes
+//! It serves HTTP API requests from various external clients (such as wallets)
+//!
+//! Protocol specification: https://www.jsonrpc.org/specification
+//!
+//! Module organization:
+//! ├── methods.rs        # contains all available JSON RPC method handlers
+//! ├── views.rs          # custom JSON serializers for Libra data types
+//! ├── runtime.rs        # implementation of JSON RPC protocol over HTTP
+//! ├── tests.rs          # tests
+
+#[macro_use]
+mod util;
+
+mod methods;
+mod runtime;
+mod views;
+
+pub use runtime::bootstrap_from_config;
+
+#[cfg(test)]
+mod tests;

--- a/json-rpc/src/methods.rs
+++ b/json-rpc/src/methods.rs
@@ -1,0 +1,42 @@
+// Copyright (c) The Libra Core Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+//! Module contains RPC method handlers for Full Node JSON-RPC interface
+use crate::views::AccountView;
+use anyhow::{ensure, Result};
+use core::future::Future;
+use libra_types::{account_address::AccountAddress, account_config::AccountResource};
+use serde_json::Value;
+use std::{collections::HashMap, convert::TryFrom, pin::Pin, str::FromStr, sync::Arc};
+use storage_client::StorageRead;
+
+type RpcHandler = Box<
+    fn(Arc<dyn StorageRead>, Vec<Value>) -> Pin<Box<dyn Future<Output = Result<Value>> + Send>>,
+>;
+pub(crate) type RpcRegistry = HashMap<String, RpcHandler>;
+
+/// Returns account state (AccountView) by given address
+async fn get_account_state(
+    client: Arc<dyn StorageRead>,
+    params: Vec<Value>,
+) -> Result<Option<AccountView>> {
+    let address: String = serde_json::from_value(params[0].clone())?;
+
+    let account_address = AccountAddress::from_str(&address)?;
+    let response = client.get_latest_account_state(account_address).await?;
+    if let Some(blob) = response {
+        if let Ok(account) = AccountResource::try_from(&blob) {
+            return Ok(Some(AccountView::new(account)));
+        }
+    }
+    Ok(None)
+}
+
+/// Builds registry of all available RPC methods
+/// To register new RPC method, add it via `register_rpc_method!` macros call
+/// Note that RPC method name will equal to name of function
+pub(crate) fn build_registry() -> RpcRegistry {
+    let mut registry = RpcRegistry::new();
+    register_rpc_method!(registry, get_account_state, 1);
+    registry
+}

--- a/json-rpc/src/runtime.rs
+++ b/json-rpc/src/runtime.rs
@@ -1,0 +1,221 @@
+// Copyright (c) The Libra Core Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::methods::{build_registry, RpcRegistry};
+use futures::future::join_all;
+use libra_config::config::NodeConfig;
+use serde::Serialize;
+use serde_json::{map::Map, Value};
+use std::{net::SocketAddr, sync::Arc};
+use storage_client::{StorageRead, StorageReadServiceClient};
+use tokio::runtime::{Builder, Runtime};
+use warp::Filter;
+
+/// Creates HTTP server (warp-based) that serves JSON RPC requests
+/// Returns handle to corresponding Tokio runtime
+pub fn bootstrap(address: SocketAddr, storage_client: Arc<dyn StorageRead>) -> Runtime {
+    let runtime = Builder::new()
+        .thread_name("rpc-")
+        .threaded_scheduler()
+        .enable_all()
+        .build()
+        .expect("[rpc] failed to create runtime");
+
+    let registry = Arc::new(build_registry());
+
+    let handler = warp::any()
+        .and(warp::path::end())
+        .and(warp::post())
+        .and(warp::header::exact("content-type", "application/json"))
+        .and(warp::body::json())
+        .and(warp::any().map(move || Arc::clone(&storage_client)))
+        .and(warp::any().map(move || Arc::clone(&registry)))
+        .and_then(rpc_endpoint);
+
+    let server = warp::serve(handler).run(address);
+    runtime.handle().spawn(server);
+    runtime
+}
+
+/// Creates JSON RPC endpoint by given node config
+pub fn bootstrap_from_config(config: &NodeConfig) -> Runtime {
+    let storage_client: Arc<dyn StorageRead> =
+        Arc::new(StorageReadServiceClient::new(&config.storage.address));
+
+    bootstrap(config.rpc.address, storage_client)
+}
+
+/// JSON RPC entry point
+/// Handles all incoming rpc requests
+/// Performs routing based on methods defined in `registry`
+async fn rpc_endpoint(
+    data: Value,
+    storage_client: Arc<dyn StorageRead>,
+    registry: Arc<RpcRegistry>,
+) -> Result<Box<dyn warp::Reply>, warp::Rejection> {
+    if let Value::Array(requests) = data {
+        // batch API call
+        let futures = requests.into_iter().map(|req| {
+            rpc_request_handler(req, Arc::clone(&storage_client), Arc::clone(&registry))
+        });
+        let responses = join_all(futures).await;
+        Ok(Box::new(warp::reply::json(&Value::Array(responses))))
+    } else {
+        // single API call
+        let resp = rpc_request_handler(data, storage_client, registry).await;
+        Ok(Box::new(warp::reply::json(&resp)))
+    }
+}
+
+/// Handler of single RPC request
+/// Performs validation and executes corresponding rpc handler
+async fn rpc_request_handler(
+    req: Value,
+    storage_client: Arc<dyn StorageRead>,
+    registry: Arc<RpcRegistry>,
+) -> Value {
+    let request: Map<String, Value>;
+    let mut response = Map::new();
+
+    // set defaults: protocol version to 2.0, request id to null
+    response.insert("jsonrpc".to_string(), Value::String("2.0".to_string()));
+    response.insert("id".to_string(), Value::Null);
+
+    match req {
+        Value::Object(data) => {
+            request = data;
+        }
+        _ => {
+            response.insert(
+                "error".to_string(),
+                JsonRpcError::invalid_request().serialize(),
+            );
+            return Value::Object(response);
+        }
+    }
+
+    // parse request id
+    match parse_request_id(&request) {
+        Ok(request_id) => {
+            response.insert("id".to_string(), request_id);
+        }
+        Err(err) => {
+            response.insert("error".to_string(), err.serialize());
+            return Value::Object(response);
+        }
+    };
+
+    // verify protocol version
+    if let Err(err) = verify_protocol(&request) {
+        response.insert("error".to_string(), err.serialize());
+        return Value::Object(response);
+    }
+
+    // parse parameters
+    let params;
+    match request.get("params") {
+        Some(Value::Array(parameters)) => {
+            params = parameters.to_vec();
+        }
+        _ => {
+            response.insert(
+                "error".to_string(),
+                JsonRpcError::invalid_params().serialize(),
+            );
+            return Value::Object(response);
+        }
+    }
+
+    // get rpc handler
+    match request.get("method") {
+        Some(Value::String(name)) => match registry.get(name) {
+            Some(handler) => match handler(storage_client, params).await {
+                Ok(result) => {
+                    response.insert("result".to_string(), result);
+                }
+                Err(err) => {
+                    response.insert(
+                        "error".to_string(),
+                        JsonRpcError::internal_error(err.to_string()).serialize(),
+                    );
+                }
+            },
+            None => {
+                response.insert(
+                    "error".to_string(),
+                    JsonRpcError::method_not_found().serialize(),
+                );
+            }
+        },
+        _ => {
+            response.insert(
+                "error".to_string(),
+                JsonRpcError::invalid_request().serialize(),
+            );
+        }
+    }
+
+    Value::Object(response)
+}
+
+#[derive(Serialize)]
+struct JsonRpcError {
+    code: i16,
+    message: String,
+}
+
+impl JsonRpcError {
+    fn serialize(self) -> Value {
+        serde_json::to_value(self).unwrap_or(Value::Null)
+    }
+
+    fn invalid_request() -> Self {
+        Self {
+            code: -32600,
+            message: "Invalid Request".to_string(),
+        }
+    }
+
+    fn invalid_params() -> Self {
+        Self {
+            code: -32602,
+            message: "Invalid params".to_string(),
+        }
+    }
+
+    fn method_not_found() -> Self {
+        Self {
+            code: -32601,
+            message: "Method not found".to_string(),
+        }
+    }
+
+    fn internal_error(message: String) -> Self {
+        Self {
+            code: -32000,
+            message: format!("Server error: {}", message),
+        }
+    }
+}
+
+fn parse_request_id(request: &Map<String, Value>) -> Result<Value, JsonRpcError> {
+    match request.get("id") {
+        Some(req_id) => {
+            if req_id.is_string() || req_id.is_number() || req_id.is_null() {
+                Ok(req_id.clone())
+            } else {
+                Err(JsonRpcError::invalid_request())
+            }
+        }
+        None => Ok(Value::Null),
+    }
+}
+
+fn verify_protocol(request: &Map<String, Value>) -> Result<(), JsonRpcError> {
+    if let Some(Value::String(protocol)) = request.get("jsonrpc") {
+        if protocol == "2.0" {
+            return Ok(());
+        }
+    }
+    Err(JsonRpcError::invalid_request())
+}

--- a/json-rpc/src/tests.rs
+++ b/json-rpc/src/tests.rs
@@ -1,0 +1,136 @@
+// Copyright (c) The Libra Core Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::runtime::bootstrap;
+use libra_config::utils;
+use reqwest;
+use serde_json;
+use std::{
+    collections::{HashMap, HashSet},
+    sync::Arc,
+};
+use storage_service::mocks::mock_storage_client::MockStorageReadClient;
+
+type JsonMap = HashMap<String, serde_json::Value>;
+
+#[test]
+fn test_json_rpc_protocol() {
+    let address = format!("0.0.0.0:{}", utils::get_available_port());
+    let _runtime = bootstrap(address.parse().unwrap(), Arc::new(MockStorageReadClient));
+    let client = reqwest::blocking::Client::new();
+
+    // check that only root path is accessible
+    let url = format!("http://{}/fake_path", address);
+    let resp = client.get(&url).send().unwrap();
+    assert_eq!(resp.status(), 404);
+
+    // only post method is allowed
+    let url = format!("http://{}", address);
+    let resp = client.get(&url).send().unwrap();
+    assert_eq!(resp.status(), 405);
+
+    // empty payload is not allowed
+    let resp = client.post(&url).send().unwrap();
+    assert_eq!(resp.status(), 400);
+
+    // non json payload
+    let resp = client.post(&url).body("non json").send().unwrap();
+    assert_eq!(resp.status(), 400);
+
+    // invalid version of protocol
+    let request = serde_json::json!({"jsonrpc": "1.0", "method": "add", "params": [1, 2], "id": 1});
+    let resp = client.post(&url).json(&request).send().unwrap();
+    assert_eq!(resp.status(), 200);
+    assert_eq!(fetch_error(resp), -32600);
+
+    // invalid request id
+    let request =
+        serde_json::json!({"jsonrpc": "2.0", "method": "add", "params": [1, 2], "id": true});
+    let resp = client.post(&url).json(&request).send().unwrap();
+    assert_eq!(resp.status(), 200);
+    assert_eq!(fetch_error(resp), -32600);
+
+    // invalid rpc method
+    let request = serde_json::json!({"jsonrpc": "2.0", "method": "add", "params": [1, 2], "id": 1});
+    let resp = client.post(&url).json(&request).send().unwrap();
+    assert_eq!(resp.status(), 200);
+    assert_eq!(fetch_error(resp), -32601);
+
+    // invalid arguments
+    let request = serde_json::json!({"jsonrpc": "2.0", "method": "get_account_state", "params": [1, 2], "id": 1});
+    let resp = client.post(&url).json(&request).send().unwrap();
+    assert_eq!(resp.status(), 200);
+    assert_eq!(fetch_error(resp), -32000);
+}
+
+#[test]
+fn test_get_account_state() {
+    let address = format!("0.0.0.0:{}", utils::get_available_port());
+    let _runtime = bootstrap(address.parse().unwrap(), Arc::new(MockStorageReadClient));
+    let client = reqwest::blocking::Client::new();
+    let url = format!("http://{}", address);
+
+    // single call
+    let account = "0265b97523d042755f9a290fdc6e9febc9a86bdcd03b70c63a0349274e85e263";
+    let request = serde_json::json!({"jsonrpc": "2.0", "method": "get_account_state", "params": [account], "id": 1});
+    let resp = client.post(&url).json(&request).send().unwrap();
+    assert_eq!(resp.status(), 200);
+    let data = fetch_result(resp.json().unwrap());
+    assert_eq!(data.get("balance").unwrap().as_u64(), Some(100));
+    assert_eq!(data.get("sequence_number").unwrap().as_u64(), Some(0));
+
+    // batching call
+    let accounts = vec![
+        "1ad0e745c00a6ef4a8176ddb1a5e2fdc7bc92f6ac3a7955b3aa0e3211074174a",
+        "f9841c24cf884559e79f20eb9926902eb4a072d1d78d40f11588fbc941d82150",
+        "bc1330c1c4176f50c82c7a1b9e5295eaf1eeec87a627735f4d446a55d5844ead",
+    ];
+    let requests = accounts
+        .iter()
+        .enumerate()
+        .map(|(id, address)|
+            serde_json::json!({"jsonrpc": "2.0", "method": "get_account_state", "params": [address], "id": id})
+        )
+        .collect();
+    let resp = client
+        .post(&url)
+        .json(&serde_json::Value::Array(requests))
+        .send()
+        .unwrap();
+    assert_eq!(resp.status(), 200);
+    match resp.json().unwrap() {
+        serde_json::Value::Array(responses) => {
+            let mut ids = HashSet::new();
+            for response in responses {
+                ids.insert(response.get("id").unwrap().as_u64().unwrap());
+                let result: JsonMap = serde_json::from_value(
+                    response.as_object().unwrap().get("result").unwrap().clone(),
+                )
+                .unwrap();
+                assert_eq!(result.get("balance").unwrap().as_u64(), Some(100));
+            }
+            let ids_expected: HashSet<_> = vec![0, 1, 2].into_iter().collect();
+            assert_eq!(ids, ids_expected);
+        }
+        _ => panic!("invalid server response format"),
+    }
+}
+
+fn fetch_result(data: JsonMap) -> JsonMap {
+    let result: JsonMap = serde_json::from_value(data.get("result").unwrap().clone()).unwrap();
+    assert_eq!(
+        data.get("jsonrpc").unwrap(),
+        &serde_json::Value::String("2.0".to_string())
+    );
+    result
+}
+
+fn fetch_error(resp: reqwest::blocking::Response) -> i16 {
+    let data: JsonMap = resp.json().unwrap();
+    let error: JsonMap = serde_json::from_value(data.get("error").unwrap().clone()).unwrap();
+    assert_eq!(
+        data.get("jsonrpc").unwrap(),
+        &serde_json::Value::String("2.0".to_string())
+    );
+    serde_json::from_value(error.get("code").unwrap().clone()).unwrap()
+}

--- a/json-rpc/src/util.rs
+++ b/json-rpc/src/util.rs
@@ -1,0 +1,20 @@
+// Copyright (c) The Libra Core Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+/// Helper macros. Used to simplify adding new RpcHandler to Registry
+/// `registry` - name of local registry variable
+/// `method` - name of new rpc method
+/// `num_args` - number of method arguments
+macro_rules! register_rpc_method {
+    ($registry:expr, $method: expr, $num_args: expr) => {
+        $registry.insert(
+            stringify!($method).to_string(),
+            Box::new(move |client, parameters| {
+                Box::pin(async move {
+                    ensure!(parameters.len() == $num_args, "Invalid number of arguments");
+                    Ok(serde_json::to_value($method(client, parameters).await?)?)
+                })
+            }),
+        );
+    };
+}

--- a/json-rpc/src/views.rs
+++ b/json-rpc/src/views.rs
@@ -1,0 +1,36 @@
+// Copyright (c) The Libra Core Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+use hex;
+use libra_types::{account_config::AccountResource, byte_array::ByteArray};
+use serde::Serialize;
+
+#[derive(Serialize)]
+pub struct AccountView {
+    balance: u64,
+    sequence_number: u64,
+    authentication_key: BytesView,
+    delegated_key_rotation_capability: bool,
+    delegated_withdrawal_capability: bool,
+}
+
+impl AccountView {
+    pub fn new(account: AccountResource) -> Self {
+        Self {
+            balance: account.balance(),
+            sequence_number: account.sequence_number(),
+            authentication_key: BytesView::from(account.authentication_key()),
+            delegated_key_rotation_capability: account.delegated_key_rotation_capability(),
+            delegated_withdrawal_capability: account.delegated_withdrawal_capability(),
+        }
+    }
+}
+
+#[derive(Serialize)]
+pub struct BytesView(String);
+
+impl From<&ByteArray> for BytesView {
+    fn from(byte_array: &ByteArray) -> Self {
+        Self(hex::encode(byte_array.as_bytes()))
+    }
+}

--- a/libra-node/Cargo.toml
+++ b/libra-node/Cargo.toml
@@ -31,6 +31,7 @@ libra-mempool = { path = "../mempool", version = "0.1.0" }
 libra-metrics = { path = "../common/metrics", version = "0.1.0" }
 libra-crypto = { path = "../crypto/crypto", version = "0.1.0" }
 network = { path = "../network", version = "0.1.0" }
+libra-json-rpc = { path = "../json-rpc", version = "0.1.0" }
 state-synchronizer = { path = "../state-synchronizer", version = "0.1.0" }
 storage-client = { path = "../storage/storage-client", version = "0.1.0" }
 storage-service = { path = "../storage/storage-service", version = "0.1.0" }

--- a/libra-node/src/main_node.rs
+++ b/libra-node/src/main_node.rs
@@ -10,6 +10,7 @@ use debug_interface::{
 use executor::Executor;
 use futures::{channel::mpsc::channel, executor::block_on};
 use libra_config::config::{NetworkConfig, NodeConfig, RoleType};
+use libra_json_rpc::bootstrap_from_config as bootstrap_rpc;
 use libra_logger::prelude::*;
 use libra_metrics::metric_server;
 use network::validator_network::{
@@ -28,6 +29,7 @@ const INTRA_NODE_CHANNEL_BUFFER_SIZE: usize = 1;
 
 pub struct LibraHandle {
     _ac: Runtime,
+    _rpc: Runtime,
     _mempool: Runtime,
     _state_synchronizer: StateSynchronizer,
     _network_runtimes: Vec<Runtime>,
@@ -236,6 +238,8 @@ pub fn setup_environment(node_config: &mut NodeConfig) -> LibraHandle {
     let (ac_sender, client_events) = channel(AC_SMP_CHANNEL_BUFFER_SIZE);
     let admission_control_runtime = AdmissionControlService::bootstrap(&node_config, ac_sender);
 
+    let rpc_runtime = bootstrap_rpc(&node_config);
+
     let mut consensus = None;
     let (consensus_to_mempool_sender, consensus_requests) = channel(INTRA_NODE_CHANNEL_BUFFER_SIZE);
 
@@ -294,6 +298,7 @@ pub fn setup_environment(node_config: &mut NodeConfig) -> LibraHandle {
     LibraHandle {
         _network_runtimes: network_runtimes,
         _ac: admission_control_runtime,
+        _rpc: rpc_runtime,
         _mempool: mempool,
         _state_synchronizer: state_synchronizer,
         consensus,

--- a/storage/storage-service/Cargo.toml
+++ b/storage/storage-service/Cargo.toml
@@ -35,4 +35,5 @@ proptest = "0.9.2"
 
 [features]
 default = []
+testing = ["storage-client", "libradb/fuzzing"]
 fuzzing = ["proptest", "storage-client", "libradb/fuzzing"]

--- a/storage/storage-service/src/lib.rs
+++ b/storage/storage-service/src/lib.rs
@@ -9,7 +9,7 @@
 //! [`storage-client`](../storage-client/index.html) instead of via
 //! [`StorageClient`](../storage-proto/proto/storage_grpc/struct.StorageClient.html) directly.
 
-#[cfg(feature = "fuzzing")]
+#[cfg(any(feature = "testing", feature = "fuzzing"))]
 pub mod mocks;
 
 use anyhow::Result;


### PR DESCRIPTION
adds new HTTP-based JSON-RPC endpoint to node for handling client requests
long term it should replace current AC(admission control)
JSON-RPC protocol specification: https://www.jsonrpc.org/specification

## Motivation
This PR adds minimalistic framework for serving json rpc methods over HTTP.
It's built on top of warp(https://github.com/seanmonstar/warp)
Work is still in progress, some features are not yet supported

PR implements `get_account_state` rpc method as reference implementation.
In order to add new rpc method:
1. add new async rpc method handler in methods.rs (see get_account_state in this PR)
2. define returning user-facing json-serializable struct(if it's not defined yet) in views.py (see AccountView for reference)
3. add it to registry inside of `build_registry` function via `register_rpc_method!` macros call
4. it's ready to go

## Test Plan
added tests for rpc protocol handling and get_account_state rpc method
