### PR TITLE
[language][bytecode verifier] Rename Nonce to RefID

### DIFF
--- a/language/bytecode-verifier/src/lib.rs
+++ b/language/bytecode-verifier/src/lib.rs
@@ -14,7 +14,7 @@ pub mod check_duplication;
 pub mod code_unit_verifier;
 pub mod control_flow_graph;
 pub mod instantiation_loops;
-pub mod nonce;
+pub mod ref_id;
 pub mod resources;
 pub mod signature;
 pub mod stack_usage_verifier;

--- a/language/bytecode-verifier/src/ref_id.rs
+++ b/language/bytecode-verifier/src/ref_id.rs
@@ -1,14 +1,14 @@
 // Copyright (c) The Libra Core Contributors
 // SPDX-License-Identifier: Apache-2.0
 
-//! This module implements the Nonce type used for borrow checking in the abstract interpreter.
-//! A Nonce instance represents an arbitrary reference or access path.
-//! The integer inside a Nonce is meaningless; only equality and borrow relationships are
+//! This module implements the RefID type used for borrow checking in the abstract interpreter.
+//! A RefID instance represents an arbitrary reference or access path.
+//! The integer inside a RefID is meaningless; only equality and borrow relationships are
 //! meaningful.
 #[derive(Clone, Copy, Debug, Default, Hash, PartialEq, Eq, Ord, PartialOrd)]
-pub struct Nonce(usize);
+pub struct RefID(usize);
 
-impl Nonce {
+impl RefID {
     pub fn new(n: usize) -> Self {
         Self(n)
     }


### PR DESCRIPTION
##  Motivation

This PR is part of a two-PR cycle for retargeting the type checker in the bytecode verifier to the borrow graph crate.  This PR makes two changes:
- It renames Nonce to RefID, the name used in the borrow graph crate; variables that used the nonce are instead renamed to use id.
- It drops stale documentation about reference safety.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?

Yes.

## Test Plan

Existing tests.

## Related PRs
