### PR TITLE
[crypto, test-only] Extend test coverage for bls12-381

### DIFF
--- a/crypto/crypto/src/unit_tests/bls12381_test.rs
+++ b/crypto/crypto/src/unit_tests/bls12381_test.rs
@@ -3,7 +3,7 @@
 
 use crate::{
     bls12381::{
-        BLS12381PrivateKey, BLS12381PublicKey, BLS12381_PRIVATE_KEY_LENGTH,
+        BLS12381PrivateKey, BLS12381PublicKey, BLS12381Signature, BLS12381_PRIVATE_KEY_LENGTH,
         BLS12381_PUBLIC_KEY_LENGTH, BLS12381_SIGNATURE_LENGTH,
     },
     hash::HashValue,
@@ -13,7 +13,15 @@ use crate::{
 use proptest::prelude::*;
 use std::convert::TryFrom;
 
+#[test]
+fn test_genesis() {
+    let mut zeros = [0u8; 32];
+    zeros[31] = 1;
+    assert_eq!(zeros, BLS12381PrivateKey::genesis().to_bytes()[..]);
+}
+
 proptest! {
+
     #[test]
     fn test_keys_encode(keypair in uniform_keypair_strategy::<BLS12381PrivateKey, BLS12381PublicKey>()) {
         {
@@ -87,5 +95,51 @@ proptest! {
         let serialized = lcs::to_bytes(&signature).unwrap();
         let deserialized = lcs::from_bytes(&serialized).unwrap();
         prop_assert!(keypair.public_key.verify_signature(&hash, &deserialized).is_ok());
+    }
+
+    #[test]
+    fn test_errors(
+        hash in any::<HashValue>(),
+        keypair in uniform_keypair_strategy::<BLS12381PrivateKey, BLS12381PublicKey>()
+    ){
+        {
+            let serialized = keypair.public_key.to_bytes();
+            let truncated = &serialized[..31];
+            let key_error = BLS12381PublicKey::try_from(truncated);
+            prop_assert_eq!(key_error, Err(CryptoMaterialError::WrongLengthError));
+        }
+        {
+            let serialized = keypair.private_key.to_bytes();
+            let truncated = &serialized[..31];
+            let key_error = BLS12381PrivateKey::try_from(truncated);
+            prop_assert_eq!(key_error, Err(CryptoMaterialError::WrongLengthError));
+        }
+        {
+            let signature = keypair.private_key.sign_message(&hash);
+            let truncated = &signature.to_bytes()[..31];
+            let sig_error = BLS12381Signature::try_from(truncated);
+            // errors for short signatures turn up as validation errors
+            prop_assert_eq!(sig_error, Err(CryptoMaterialError::ValidationError));
+            let mut extended: Vec<u8> = signature.to_bytes().to_vec();
+            extended.extend_from_slice(&signature.to_bytes()[..]);
+            let sig_error = BLS12381Signature::try_from(&extended[..]);
+            // errors for short signatures turn up as validation errors
+            prop_assert_eq!(sig_error, Err(CryptoMaterialError::WrongLengthError));
+        }
+    }
+
+    #[test]
+    fn test_user_accessible_string_encodings(
+        keypair in uniform_keypair_strategy::<BLS12381PrivateKey, BLS12381PublicKey>()
+    ){
+        {
+            let encoded = keypair.public_key.to_encoded_string().unwrap();
+            let decoded = BLS12381PublicKey::from_encoded_string(&encoded)?;
+            prop_assert_eq!(decoded, keypair.public_key);
+        }{
+            let encoded = keypair.private_key.to_encoded_string().unwrap();
+            let decoded = BLS12381PrivateKey::from_encoded_string(&encoded)?;
+            prop_assert_eq!(decoded, keypair.private_key);
+        }
     }
 }


### PR DESCRIPTION
- test to_encoded_string,
- test CryptoMaterial::WrongLengthEncoding
- test genesis

The test coverage for bls12381 & slip0010 is largely under-estimated, but this should improve things a little bit nonetheless.


