### PR TITLE
[GHA][LBT] handle expired GH token

### DIFF
--- a/.github/workflows/land-blocking.yml
+++ b/.github/workflows/land-blocking.yml
@@ -83,14 +83,24 @@ jobs:
               should_fail = true;
             }
             // Post test result on original pull request
-            await github.issues.createComment(
-                {
-                  issue_number: pr_num,
-                  owner: context.repo.owner,
-                  repo: context.repo.repo,
-                  body: body,
-                }
-            );
+            try {
+              await github.issues.createComment(
+                  {
+                    issue_number: pr_num,
+                    owner: context.repo.owner,
+                    repo: context.repo.repo,
+                    body: body,
+                  }
+              );
+            } catch (err) {
+              if (err.status === 401) {
+                // Fail silently for auth but log to console.
+                console.warn("GH token has expired when trying to POST\n", err);
+              } else {
+                console.error("HttpError other than 401 is not bypassed");
+                throw err;
+              }
+            }
             // Fail the workflow if test fails or perf regresses
             if (should_fail) {
               throw "Land-blocking test failed";


### PR DESCRIPTION
## Motivation
We saw sporadic http error when LBT tries to post the cluster test
result on the PR. The error was about invalid GH token.  It turns out
the token expires after 60 minutes. If the workflow is queued up, the
token may have expired even before the job begins. In this case, LBT
needs to handle the http error.

## Test Plan
Canary result
![image](https://user-images.githubusercontent.com/7528420/75181910-1c001d80-56f4-11ea-9530-a751fa8f3881.png)
