### PR TITLE
[GHA][LBT] Fix regex in parsing commit message

### DIFF
--- a/.github/workflows/land-blocking.yml
+++ b/.github/workflows/land-blocking.yml
@@ -50,7 +50,7 @@ jobs:
             // Find the number of the pull request that trigggers this push
             let pr_num = 0;
             let commit_message = context.payload.head_commit.message;
-            let re = /.*[^]Closes:\s\#(\d+)[^]Approved\sby:\s\w+$/;
+            let re = /.*[^]Closes:\s\#(\d+)[^]Approved\sby:\s[A-Za-z0-9_-]+$/;
             if (re.test(commit_message)) {
               let match = re.exec(commit_message);
               pr_num = match[1];


### PR DESCRIPTION
## Motivation
There is an issue with the regex parser in the current LBT workflow Actions.  The original regex used \w and missed the "-".

## Test Plan
Canary with parent commit and verify parsing issue https://github.com/sausagee/libra/runs/465949511?check_suite_focus=true

Canary with this commit and verify no issue https://github.com/sausagee/libra/runs/465950770?check_suite_focus=true