### PR TITLE
[language/vm-runtime] move gas usage stat recording to Libra VM

### DIFF
--- a/language/vm/vm-runtime/src/interpreter.rs
+++ b/language/vm/vm-runtime/src/interpreter.rs
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::{
-    counters::*,
     execution_context::InterpreterContext,
     gas,
     identifier::{create_access_path, resource_storage_key},
@@ -168,13 +167,8 @@ impl<'txn> Interpreter<'txn> {
         // We count the intrinsic cost of the transaction here, since that needs to also cover the
         // setup of the function.
         let mut interp = Self::new(txn_data, gas_schedule);
-        let starting_gas = context.remaining_gas();
         gas!(consume: context, calculate_intrinsic_gas(txn_size))?;
-        let ret = interp.execute(runtime, context, func, args);
-        record_stats!(
-            observe | TXN_EXECUTION_GAS_USAGE | starting_gas.sub(context.remaining_gas()).get()
-        );
-        ret
+        interp.execute(runtime, context, func, args)
     }
 
     /// Create a new instance of an `Interpreter` in the context of a transaction with a

--- a/language/vm/vm-runtime/src/libra_vm.rs
+++ b/language/vm/vm-runtime/src/libra_vm.rs
@@ -307,13 +307,16 @@ impl LibraVM {
                     Ok(s) => s,
                     Err(e) => return discard_error_output(e),
                 };
-                self.move_vm.execute_script(
+                let ret = self.move_vm.execute_script(
                     s,
                     gas_schedule,
                     &mut ctx,
                     txn_data,
                     convert_txn_args(args),
-                )
+                );
+                let gas_usage = txn_data.max_gas_amount().sub(ctx.gas_left()).get();
+                record_stats!(observe | TXN_EXECUTION_GAS_USAGE | gas_usage);
+                ret
             }
         }
         .map_err(|err| {


### PR DESCRIPTION
Makes the Libra/Move VM separation much easier to do.