### PR TITLE
[perf] Block PR on performance regression

### DIFF
--- a/.github/workflows/land-blocking.yml
+++ b/.github/workflows/land-blocking.yml
@@ -72,6 +72,13 @@ jobs:
             ${result.text}
             \`\`\`
             `;
+              let tps = result.metrics.find(m => m.experiment == "all up" && m.metric == "avg_tps").value;
+              let min_tps = 900;
+              if (tps < min_tps) {
+                body += "\n :exclamation: Performance regression is detected on this PR";
+                body += "\n TPS with PR: " + tps + ", this is lower then minimum allowed " + min_tps + " TPS.";
+                should_fail = true;
+              }
             } catch (err) {
               if (err.code === 'ENOENT') {
                 body = "Cluster Test failed - no test report found.";


### PR DESCRIPTION
This is very simple diff that will block PR if performance falls below hardcoded limit

Expectation that for now we going to update this limit manually, until better tooling comes in place

We want this to avoid more painful revert process that we have right now when regression is detected.
