### PR TITLE
Update to latest Boogie

### DIFF
--- a/language/move-prover/scripts/install-boogie.sh
+++ b/language/move-prover/scripts/install-boogie.sh
@@ -3,4 +3,5 @@
 # Copyright (c) The Libra Core Contributors
 # SPDX-License-Identifier: Apache-2.0
 
+dotnet tool uninstall --global Boogie
 dotnet tool install --global Boogie

--- a/language/move-prover/scripts/install-z3.sh
+++ b/language/move-prover/scripts/install-z3.sh
@@ -3,8 +3,8 @@
 # Copyright (c) The Libra Core Contributors
 # SPDX-License-Identifier: Apache-2.0
 
-curl -LO https://github.com/Z3Prover/z3/releases/download/z3-4.8.6/z3-4.8.6-x64-osx-10.14.6.zip
-unzip z3-4.8.6-x64-osx-10.14.6.zip
-sudo cp z3-4.8.6-x64-osx-10.14.6/bin/z3 /usr/local/bin/
-rm -rf z3-4.8.6-x64-osx-10.14.6
-rm -rf z3-4.8.6-x64-osx-10.14.6.zip
+curl -LO https://github.com/Z3Prover/z3/releases/download/z3-4.8.7/z3-4.8.7-x64-osx-10.14.6.zip
+unzip z3-4.8.7-x64-osx-10.14.6.zip
+sudo cp z3-4.8.7-x64-osx-10.14.6/bin/z3 /usr/local/bin/
+rm -rf z3-4.8.7-x64-osx-10.14.6
+rm -rf z3-4.8.7-x64-osx-10.14.6.zip


### PR DESCRIPTION
##  Motivation

This PR does a few things:
- updates Move Prover to the latest version of Boogie (v2.5 and above); changes are required because command-line options have changed.
- made install-boogie.sh more robust by uninstalling the existing installation first.
- updated install-z3.sh to 4.8.7.
- added -use-array-theory flag to cli; the tests verify with and without this option.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

Existing tests

## Related PRs

None