### PR TITLE
[cluster-test] Increase TXN_MAX_WAIT by 20 seconds

### DIFF
--- a/testsuite/cluster-test/src/tx_emitter.rs
+++ b/testsuite/cluster-test/src/tx_emitter.rs
@@ -475,7 +475,7 @@ async fn query_sequence_numbers(
 const MAX_GAS_AMOUNT: u64 = 1_000_000;
 const GAS_UNIT_PRICE: u64 = 0;
 const TXN_EXPIRATION_SECONDS: i64 = 50;
-const TXN_MAX_WAIT: Duration = Duration::from_secs(TXN_EXPIRATION_SECONDS as u64 + 10);
+const TXN_MAX_WAIT: Duration = Duration::from_secs(TXN_EXPIRATION_SECONDS as u64 + 30);
 const LIBRA_PER_NEW_ACCOUNT: u64 = 1_000_000;
 
 fn gen_submit_transaction_request(


### PR DESCRIPTION
## Summary

We are seeing `SEQUENCE_NUMBER_TOO_OLD` errors in 3 Region Simulation https://github.com/libra/libra/issues/2682. The hypothesis is that sometimes transactions take longer to commit. Increasing TXN_MAX_WAIT should hopefully help alleviate the issue.