### PR TITLE
[types+client] Add `TrustedState` for ratcheting latest verified state. Integrate into client.

### DIFF
--- a/client/cli/src/client_proxy.rs
+++ b/client/cli/src/client_proxy.rs
@@ -193,7 +193,7 @@ impl ClientProxy {
 
     /// Returns the ledger info corresonding to the latest epoch change
     /// (could further be used for e.g., generating a waypoint)
-    pub fn latest_epoch_change_li(&self) -> Option<LedgerInfoWithSignatures> {
+    pub fn latest_epoch_change_li(&self) -> Option<&LedgerInfoWithSignatures> {
         self.client.latest_epoch_change_li()
     }
 

--- a/execution/executor/tests/storage_integration_test.rs
+++ b/execution/executor/tests/storage_integration_test.rs
@@ -12,13 +12,12 @@ use libra_types::{
     account_state_blob::AccountStateWithProof,
     block_info::BlockInfo,
     block_metadata::BlockMetadata,
-    crypto_proxies::{EpochInfo, ValidatorVerifier},
     discovery_set::{DISCOVERY_SET_CHANGE_EVENT_PATH, GLOBAL_DISCOVERY_SET_CHANGE_EVENT_PATH},
     get_with_proof::{verify_update_to_latest_ledger_response, RequestItem},
     ledger_info::{LedgerInfo, LedgerInfoWithSignatures},
     test_helpers::transaction_test_helpers::get_test_signed_txn,
     transaction::{Script, Transaction, TransactionListWithProof, TransactionWithProof},
-    validator_change::VerifierType,
+    trusted_state::TrustedState,
 };
 use rand::SeedableRng;
 use std::{collections::BTreeMap, convert::TryFrom, sync::Arc};
@@ -106,11 +105,9 @@ fn test_genesis() {
         )
         .unwrap();
 
+    let trusted_state = TrustedState::new_trust_any_genesis_WARNING_UNSAFE();
     verify_update_to_latest_ledger_response(
-        &VerifierType::TrustedVerifier(EpochInfo {
-            epoch: 0,
-            verifier: Arc::new(ValidatorVerifier::new(BTreeMap::new())),
-        }),
+        &trusted_state,
         0,
         &request_items,
         &response_items,
@@ -438,11 +435,9 @@ fn test_execution_with_storage() {
             ),
         )
         .unwrap();
+    let trusted_state = TrustedState::new_trust_any_genesis_WARNING_UNSAFE();
     verify_update_to_latest_ledger_response(
-        &VerifierType::TrustedVerifier(EpochInfo {
-            epoch: 0,
-            verifier: Arc::new(ValidatorVerifier::new(BTreeMap::new())),
-        }),
+        &trusted_state,
         0,
         &request_items,
         &response_items,
@@ -668,11 +663,9 @@ fn test_execution_with_storage() {
             ),
         )
         .unwrap();
+    let trusted_state = TrustedState::new_trust_any_genesis_WARNING_UNSAFE();
     verify_update_to_latest_ledger_response(
-        &&VerifierType::TrustedVerifier(EpochInfo {
-            epoch: 0,
-            verifier: Arc::new(ValidatorVerifier::new(BTreeMap::new())),
-        }),
+        &trusted_state,
         0,
         &request_items,
         &response_items,

--- a/types/src/crypto_proxies.rs
+++ b/types/src/crypto_proxies.rs
@@ -96,7 +96,7 @@ pub type ValidatorSet = RawValidatorSet<Ed25519PublicKey>;
 pub use crate::validator_change::ValidatorChangeProof;
 use std::sync::Arc;
 
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 /// EpochInfo represents a trusted validator set to validate messages from the specific epoch,
 /// it could be updated with ValidatorChangeProof.
 pub struct EpochInfo {

--- a/types/src/lib.rs
+++ b/types/src/lib.rs
@@ -28,6 +28,7 @@ pub mod proto;
 #[cfg(any(test, feature = "fuzzing"))]
 pub mod test_helpers;
 pub mod transaction;
+pub mod trusted_state;
 pub mod validator_change;
 pub mod validator_public_keys;
 pub mod validator_set;

--- a/types/src/trusted_state.rs
+++ b/types/src/trusted_state.rs
@@ -1,0 +1,208 @@
+// Copyright (c) The Libra Core Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::{
+    crypto_proxies::{EpochInfo, LedgerInfoWithSignatures, ValidatorSet},
+    get_with_proof::{UpdateToLatestLedgerRequest, UpdateToLatestLedgerResponse},
+    ledger_info::LedgerInfo,
+    transaction::Version,
+    validator_change::VerifierType,
+    waypoint::Waypoint,
+};
+use anyhow::{format_err, Context as _, Result};
+use std::sync::Arc;
+
+/// `TrustedState` keeps track of our latest trusted state, including the latest
+/// verified version and the latest verified validator set.
+#[derive(Clone, Debug)]
+pub struct TrustedState {
+    /// The latest verified version of either a waypoint or a ledger info, either
+    /// inside an epoch or the epoch change ledger info. If the TrustedState is
+    /// generated from an initial waypoint, the latest_version is coincidentally
+    /// the same as the waypoint version.
+    latest_version: Version,
+    /// The current verifier. If we're starting up fresh, this is probably a
+    /// waypoint from our config. Otherwise, this is probably generated from the
+    /// validator set in the last known epoch change ledger info.
+    verifier: VerifierType,
+}
+
+/// `TrustedStateChange` is the result of attempting to ratchet to a new trusted
+/// state. In order to reduce redundant error checking, `TrustedStateChange` also
+/// contains references to relevant items used to ratchet us.
+#[derive(Clone, Debug)]
+pub enum TrustedStateChange<'a> {
+    /// We have a newer `TrustedState` but it's still in the same epoch, so only
+    /// the latest trusted version changed.
+    Version {
+        new_state: TrustedState,
+        latest_li: &'a LedgerInfoWithSignatures,
+    },
+    /// We have a newer `TrustedState` and there was at least one epoch change,
+    /// so we have a newer trusted version and a newer trusted validator set.
+    Epoch {
+        new_state: TrustedState,
+        latest_li: &'a LedgerInfoWithSignatures,
+        latest_epoch_change_li: &'a LedgerInfoWithSignatures,
+        latest_validator_set: &'a ValidatorSet,
+    },
+    /// Our current `TrustedState` is more recent.
+    Stale,
+}
+
+impl TrustedState {
+    /// Create an initial trusted state from a waypoint.
+    pub fn from_waypoint(waypoint: Waypoint) -> Self {
+        Self {
+            latest_version: waypoint.version(),
+            verifier: VerifierType::Waypoint(waypoint),
+        }
+    }
+
+    /// Create an initial trusted state that will trust the first genesis
+    /// presented to it.
+    ///
+    /// WARNING: this is obviously unsafe, as a malicious peer could present any
+    /// arbitrary genesis and this TrustedState would gladly accept it.
+    // TODO(philiphayes/dmitrip): remove this when waypoints are completely
+    // integrated with client code.
+    #[allow(non_snake_case)]
+    pub fn new_trust_any_genesis_WARNING_UNSAFE() -> Self {
+        Self {
+            latest_version: 0,
+            verifier: VerifierType::TrustedVerifier(EpochInfo::empty()),
+        }
+    }
+
+    /// Create an initial trusted state from an epoch change ledger info.
+    pub fn from_epoch_change_ledger_info(epoch_change_li: &LedgerInfo) -> Result<Self> {
+        // Generate the EpochInfo from the new validator set.
+        let epoch_info = EpochInfo {
+            epoch: epoch_change_li.epoch() + 1,
+            verifier: Arc::new(
+                epoch_change_li
+                    .next_validator_set()
+                    .ok_or_else(|| {
+                        format_err!(
+                            "No ValidatorSet in LedgerInfo; it must not be on an epoch boundary"
+                        )
+                    })?
+                    .into(),
+            ),
+        };
+        let latest_version = epoch_change_li.version();
+        let verifier = VerifierType::TrustedVerifier(epoch_info);
+
+        Ok(Self {
+            latest_version,
+            verifier,
+        })
+    }
+
+    /// Verify and ratchet forward our trusted state from an UpdateToLatestLedger
+    /// request/response.
+    ///
+    /// For example, a client sends an `UpdateToLatestLedgerRequest` to a
+    /// FullNode and receive some validator change proof along with a latest
+    /// ledger info inside the `UpdateToLatestLedgerResponse`. This function
+    /// verifies the response, the change proof, and ratchets the trusted state
+    /// version forward if the response successfully moves us into a new epoch
+    /// or a new latest ledger info within our current epoch.
+    ///
+    /// + If there was a validation error, e.g., the epoch change proof was
+    /// invalid, we return an `Err`.
+    ///
+    /// + If the message was well formed but stale (i.e., the returned latest
+    /// ledger is behind our trusted version), we return
+    /// `Ok(TrustedStateChange::Stale)`.
+    ///
+    /// + If the response is fresh and there is no epoch change, we just ratchet
+    /// our trusted version to the latest ledger info and return
+    /// `Ok(TrustedStateChange::Version { .. })`.
+    ///
+    /// + If there is a new epoch and the server provides a correct proof, we
+    /// ratchet our trusted version forward, update our verifier to contain
+    /// the new validator set, and return `Ok(TrustedStateChange::Epoch { .. })`.
+    pub fn verify_and_ratchet_response<'a>(
+        &self,
+        req: &UpdateToLatestLedgerRequest,
+        res: &'a UpdateToLatestLedgerResponse,
+    ) -> Result<TrustedStateChange<'a>> {
+        let res_version = res.ledger_info_with_sigs.ledger_info().version();
+        if res_version < self.latest_version {
+            // The response is stale, so we don't need to update our trusted
+            // state.
+            return Ok(TrustedStateChange::Stale);
+        }
+
+        let maybe_epoch_info = res
+            .verify(&self.verifier, req)
+            .context("Error verifying UpdateToLatestLedgerResponse")?;
+
+        let trusted_state_change = match maybe_epoch_info {
+            // After processing this UpdateToLatestLedgerResponse, we're able to
+            // enter a new epoch. Move to the latest validator set and ratchet
+            // our version.
+            Some(epoch_info) => {
+                // ratchet our latest version
+
+                let verifier = VerifierType::TrustedVerifier(epoch_info);
+                let latest_li = &res.ledger_info_with_sigs;
+
+                let latest_epoch_change_li = res
+                    .validator_change_proof
+                    .ledger_info_with_sigs
+                    .last()
+                    // TODO(philiphayes): Should this panic? We cannot have moved
+                    // to a new epoch with an empty ValidatorChangeProof.
+                    .ok_or_else(|| format_err!("A valid ValidatorChangeProof cannot be empty"))?;
+
+                let latest_validator_set = latest_epoch_change_li
+                    .ledger_info()
+                    .next_validator_set()
+                    // TODO(philiphayes): Should this panic? We cannot have a
+                    // valid ValidatorChangeProof where an epoch change ledger
+                    // info does not have a new validator set.
+                    .ok_or_else(|| {
+                        format_err!("Epoch change ledger info without a new validator set")
+                    })?;
+
+                let new_state = TrustedState {
+                    latest_version: res_version,
+                    verifier,
+                };
+
+                TrustedStateChange::Epoch {
+                    new_state,
+                    latest_li,
+                    latest_epoch_change_li,
+                    latest_validator_set,
+                }
+            }
+            // We're still in the same epoch, just ratchet the version.
+            None => {
+                let latest_li = &res.ledger_info_with_sigs;
+
+                let new_state = TrustedState {
+                    latest_version: res_version,
+                    verifier: self.verifier.clone(),
+                };
+
+                TrustedStateChange::Version {
+                    new_state,
+                    latest_li,
+                }
+            }
+        };
+
+        Ok(trusted_state_change)
+    }
+
+    pub fn latest_version(&self) -> Version {
+        self.latest_version
+    }
+
+    pub fn verifier(&self) -> &VerifierType {
+        &self.verifier
+    }
+}

--- a/types/src/unit_tests/mod.rs
+++ b/types/src/unit_tests/mod.rs
@@ -14,6 +14,7 @@ mod language_storage_test;
 mod ledger_info_proto_conversion_test;
 mod multiaddr_test;
 mod transaction_test;
+mod trusted_state_test;
 mod validator_change_proto_conversion_test;
 mod validator_set_test;
 mod vm_error_proto_conversion_test;

--- a/types/src/unit_tests/trusted_state_test.rs
+++ b/types/src/unit_tests/trusted_state_test.rs
@@ -1,0 +1,526 @@
+// Copyright (c) The Libra Core Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::{
+    account_address::AccountAddress,
+    block_info::BlockInfo,
+    crypto_proxies::{
+        random_validator_verifier, LedgerInfoWithSignatures, ValidatorPublicKeys, ValidatorSet,
+        ValidatorSigner,
+    },
+    get_with_proof::{UpdateToLatestLedgerRequest, UpdateToLatestLedgerResponse},
+    ledger_info::LedgerInfo,
+    proof::definition::AccumulatorConsistencyProof,
+    transaction::Version,
+    trusted_state::{TrustedState, TrustedStateChange},
+    validator_change::ValidatorChangeProof,
+    waypoint::Waypoint,
+};
+use libra_crypto::{
+    ed25519::Ed25519Signature,
+    hash::{CryptoHash, HashValue},
+};
+use proptest::{
+    collection::{size_range, vec, SizeRange},
+    prelude::*,
+    sample::Index,
+};
+use std::collections::BTreeMap;
+
+// hack strategy to generate a length from `impl Into<SizeRange>`
+fn arb_length(size_range: impl Into<SizeRange>) -> impl Strategy<Value = usize> {
+    vec(Just(()), size_range).prop_map(|vec| vec.len())
+}
+
+/// For `n` epoch changes, we sample `n+1` validator sets of variable size
+/// `validators_per_epoch`. The `+1` is for the initial validator set in the first
+/// epoch.
+fn arb_validator_sets(
+    epoch_changes: impl Into<SizeRange>,
+    validators_per_epoch: impl Into<SizeRange>,
+) -> impl Strategy<Value = Vec<Vec<ValidatorSigner>>> {
+    vec(arb_length(validators_per_epoch), epoch_changes.into() + 1).prop_map(
+        |validators_per_epoch_vec| {
+            validators_per_epoch_vec
+                .into_iter()
+                .map(|num_validators| {
+                    // all uniform voting power
+                    let voting_power = None;
+                    // human readable incrementing account addresses
+                    let int_account_addrs = true;
+                    let (signers, _verifier) =
+                        random_validator_verifier(num_validators, voting_power, int_account_addrs);
+                    signers
+                })
+                .collect::<Vec<_>>()
+        },
+    )
+}
+
+/// Convert a slice of `ValidatorSigner` (includes the private signing key) into
+/// the public-facing `ValidatorSet` type (just the public key).
+fn into_validator_set(signers: &[ValidatorSigner]) -> ValidatorSet {
+    ValidatorSet::new(
+        signers
+            .iter()
+            .map(|signer| {
+                ValidatorPublicKeys::new_with_random_network_keys(
+                    signer.author(),
+                    signer.public_key(),
+                    1, /* voting power */
+                )
+            })
+            .collect::<Vec<_>>(),
+    )
+}
+
+/// Create all signatures for a `LedgerInfoWithSignatures` given a set of signers
+/// and a `LedgerInfo`.
+fn sign_ledger_info(
+    signers: &[ValidatorSigner],
+    ledger_info: &LedgerInfo,
+) -> BTreeMap<AccountAddress, Ed25519Signature> {
+    signers
+        .iter()
+        .map(|s| (s.author(), s.sign_message(ledger_info.hash()).unwrap()))
+        .collect()
+}
+
+fn new_mock_ledger_info(
+    epoch: u64,
+    version: Version,
+    next_validator_set: Option<ValidatorSet>,
+) -> LedgerInfo {
+    LedgerInfo::new(
+        BlockInfo::new(
+            epoch,
+            0,                 /* round */
+            HashValue::zero(), /* id */
+            HashValue::zero(), /* executed_state_id */
+            version,
+            0, /* timestamp_usecs */
+            next_validator_set,
+        ),
+        HashValue::zero(),
+    )
+}
+
+fn new_mock_accumulator_proof() -> AccumulatorConsistencyProof {
+    AccumulatorConsistencyProof::new(vec![])
+}
+
+// A strategy for generating components of an UpdateToLatestLedgerResponse with
+// a correct ValidatorChangeProof.
+fn arb_update_proof(
+    // the epoch of the first LedgerInfoWithSignatures
+    start_epoch: u64,
+    // the version of the first LedgerInfoWithSignatures
+    start_version: Version,
+    // the distribution of versions changes between LedgerInfoWithSignatures
+    version_delta: impl Into<SizeRange>,
+    // the distribution for the number of epoch changes to generate
+    epoch_changes: impl Into<SizeRange>,
+    // the distribution for the number of validators in each epoch
+    validators_per_epoch: impl Into<SizeRange>,
+) -> impl Strategy<
+    Value = (
+        // The validator sets for each epoch
+        Vec<Vec<ValidatorSigner>>,
+        // The epoch change ledger infos
+        Vec<LedgerInfoWithSignatures>,
+        // The latest ledger info inside the last epoch
+        LedgerInfoWithSignatures,
+    ),
+> {
+    // helpful diagram:
+    //
+    // input:
+    //   num epoch changes
+    //
+    // output:
+    //   vsets: [S_1 .. S_n+1],
+    //   epoch changes: [L_1, .., L_n],
+    //   latest ledger_info: L_n+1
+    //
+    // let S_i = ith set of validators
+    // let L_i = ith ledger info
+    // S_i -> L_i => ith validators sign ith ledger info
+    // L_i -> S_i+1 => ith ledger info contains i+1'th validators for epoch change
+    // L_n+1 = a ledger info inside the nth epoch (contains S = None)
+    //
+    // base case: n = 0 => no epoch changes
+    //
+    // [ S_1 ] (None)
+    //     \   __^
+    //      v /
+    //    [ L_1 ]
+    //
+    // otherwise, for n > 0:
+    //
+    // [ S_1, S_2, ..., S_n+1 ] (None)
+    //    \    ^ \       ^ \   __^
+    //     v  /   v     /   v /
+    //    [ L_1, L_2, ..., L_n+1 ]
+    //
+
+    let version_delta = size_range(version_delta);
+    let epoch_changes = size_range(epoch_changes);
+    let validators_per_epoch = size_range(validators_per_epoch);
+
+    // sample n, the number of epoch changes
+    arb_length(epoch_changes).prop_flat_map(move |epoch_changes| {
+        (
+            // sample the validator sets, including the signers for the first epoch
+            arb_validator_sets(epoch_changes, validators_per_epoch.clone()),
+            // generate n version deltas
+            vec(arb_length(version_delta.clone()), epoch_changes),
+        )
+            .prop_map(move |(mut vsets, version_deltas)| {
+                // if generating from genesis, then there is no validator set to
+                // sign the genesis block.
+                if start_epoch == 0 {
+                    // this will always succeed, since
+                    // n >= 0, |vsets| = n + 1 ==> |vsets| >= 1
+                    let pre_genesis_vset = vsets.first_mut().unwrap();
+                    *pre_genesis_vset = vec![];
+                }
+
+                let mut epoch = start_epoch;
+                let mut version = start_version;
+                let num_epoch_changes = vsets.len() - 1;
+
+                let signers = vsets.iter().take(num_epoch_changes);
+                let next_sets = vsets.iter().skip(1);
+
+                let ledger_infos_with_sigs = signers
+                    .zip(next_sets)
+                    .zip(version_deltas)
+                    .map(|((curr_vset, next_vset), version_delta)| {
+                        let next_vset = into_validator_set(next_vset);
+                        let ledger_info = new_mock_ledger_info(epoch, version, Some(next_vset));
+                        let signatures = sign_ledger_info(&curr_vset[..], &ledger_info);
+
+                        epoch += 1;
+                        version += version_delta as u64;
+
+                        LedgerInfoWithSignatures::new(ledger_info, signatures)
+                    })
+                    .collect::<Vec<_>>();
+
+                // this will always succeed, since
+                // n >= 0, |vsets| = n + 1 ==> |vsets| >= 1
+                let last_vset = vsets.last().unwrap();
+                let latest_ledger_info = new_mock_ledger_info(epoch, version, None);
+                let signatures = sign_ledger_info(&last_vset[..], &latest_ledger_info);
+                let latest_ledger_info_with_sigs =
+                    LedgerInfoWithSignatures::new(latest_ledger_info, signatures);
+
+                (vsets, ledger_infos_with_sigs, latest_ledger_info_with_sigs)
+            })
+    })
+}
+
+proptest! {
+    #![proptest_config(ProptestConfig::with_cases(100))]
+
+    #[test]
+    fn test_pre_genesis_trusted_state_always_ratchets_from_any_genesis(
+        (_vsets, lis_with_sigs, latest_li) in arb_update_proof(
+            0    /* start epoch */,
+            0    /* start version */,
+            1..3 /* version delta */,
+            1..3 /* epoch changes */,
+            1..5 /* validators per epoch */,
+        )
+    ) {
+        let trusted_state = TrustedState::new_trust_any_genesis_WARNING_UNSAFE();
+
+        let expected_latest_version = latest_li.ledger_info().version();
+        let expected_latest_li = latest_li.clone();
+        let expected_latest_epoch_change_li = lis_with_sigs.last().cloned();
+        let expected_validator_set = expected_latest_epoch_change_li
+            .as_ref()
+            .and_then(|li_with_sigs| li_with_sigs.ledger_info().next_validator_set());
+
+        let change_proof = ValidatorChangeProof::new(lis_with_sigs, false /* more */);
+        let req = UpdateToLatestLedgerRequest::new(trusted_state.latest_version(), vec![]);
+        let res = UpdateToLatestLedgerResponse::new(vec![], latest_li, change_proof, new_mock_accumulator_proof());
+
+        let trusted_state_change = trusted_state
+            .verify_and_ratchet_response(&req, &res)
+            .expect("Should never error when ratcheting from pre-genesis with valid proofs");
+
+        match trusted_state_change {
+            TrustedStateChange::Epoch {
+                new_state,
+                latest_li,
+                latest_epoch_change_li,
+                latest_validator_set,
+            } => {
+                assert_eq!(new_state.latest_version(), expected_latest_version);
+                assert_eq!(latest_li, &expected_latest_li);
+                assert_eq!(Some(latest_epoch_change_li), expected_latest_epoch_change_li.as_ref());
+                assert_eq!(Some(latest_validator_set), expected_validator_set);
+            }
+            TrustedStateChange::Version {
+                new_state,
+                latest_li,
+            } => {
+                assert_eq!(new_state.latest_version(), expected_latest_version);
+                assert_eq!(latest_li, &expected_latest_li);
+            }
+            TrustedStateChange::Stale =>
+                panic!("Should never be stale since we're ratcheting from pre-genesis"),
+        };
+    }
+
+    #[test]
+    fn test_ratchet_from_waypoint(
+        (_vsets, lis_with_sigs, latest_li) in arb_update_proof(
+            10,   /* start epoch */
+            123,  /* start version */
+            1..3, /* version delta */
+            1..3, /* epoch changes */
+            1..5, /* validators per epoch */
+        )
+    ) {
+        let first_epoch_change_li = lis_with_sigs.first().map(LedgerInfoWithSignatures::ledger_info).unwrap();
+        let waypoint = Waypoint::new(first_epoch_change_li)
+            .expect("Generating waypoint failed even though we passed an epoch change ledger info");
+        let trusted_state = TrustedState::from_waypoint(waypoint);
+
+        let expected_latest_version = latest_li.ledger_info().version();
+        let expected_latest_li = latest_li.clone();
+        let expected_latest_epoch_change_li = lis_with_sigs.last().cloned();
+        let expected_validator_set = expected_latest_epoch_change_li
+            .as_ref()
+            .and_then(|li_with_sigs| li_with_sigs.ledger_info().next_validator_set());
+
+        let change_proof = ValidatorChangeProof::new(lis_with_sigs, false /* more */);
+        let req = UpdateToLatestLedgerRequest::new(trusted_state.latest_version(), vec![]);
+        let res = UpdateToLatestLedgerResponse::new(vec![], latest_li, change_proof, new_mock_accumulator_proof());
+
+        let trusted_state_change = trusted_state
+            .verify_and_ratchet_response(&req, &res)
+            .expect("Should never error when ratcheting from waypoint with valid proofs");
+
+        match trusted_state_change {
+            TrustedStateChange::Epoch {
+                new_state,
+                latest_li,
+                latest_epoch_change_li,
+                latest_validator_set,
+            } => {
+                assert_eq!(new_state.latest_version(), expected_latest_version);
+                assert_eq!(latest_li, &expected_latest_li);
+                assert_eq!(Some(latest_epoch_change_li), expected_latest_epoch_change_li.as_ref());
+                assert_eq!(Some(latest_validator_set), expected_validator_set);
+            }
+            TrustedStateChange::Version { .. } =>
+                panic!("Ratcheting from a waypoint should always provide the epoch for that waypoint"),
+            TrustedStateChange::Stale =>
+                panic!("Should never be stale since we're ratcheting into a fresh ledger info"),
+        };
+    }
+
+    #[test]
+    fn test_ratchet_version_only(
+        (_vsets, mut lis_with_sigs, latest_li) in arb_update_proof(
+            1,    /* start epoch */
+            1,    /* start version */
+            1..3, /* version delta */
+            1,    /* epoch changes */
+            1..5, /* validators per epoch */
+        )
+    ) {
+        // Assume we have already ratcheted into this epoch
+        let epoch_change_li = lis_with_sigs.remove(0);
+        let trusted_state = TrustedState::from_epoch_change_ledger_info(
+            epoch_change_li.ledger_info()
+        ).unwrap();
+
+        let expected_latest_version = latest_li.ledger_info().version();
+        let expected_latest_li = latest_li.clone();
+
+        // Use an empty epoch change proof
+        let change_proof = ValidatorChangeProof::new(vec![], false /* more */);
+        let req = UpdateToLatestLedgerRequest::new(trusted_state.latest_version(), vec![]);
+        let res = UpdateToLatestLedgerResponse::new(vec![], latest_li, change_proof, new_mock_accumulator_proof());
+
+        let trusted_state_change = trusted_state
+            .verify_and_ratchet_response(&req, &res)
+            .expect("Should never error when ratcheting from waypoint with valid proofs");
+
+        match trusted_state_change {
+            TrustedStateChange::Epoch { ..  } =>
+                panic!("Empty change proof so we should not change epoch"),
+            TrustedStateChange::Version {
+                new_state,
+                latest_li,
+            } => {
+                assert_eq!(new_state.latest_version(), expected_latest_version);
+                assert_eq!(latest_li, &expected_latest_li);
+            }
+            TrustedStateChange::Stale =>
+                panic!("Should never be stale since we're ratcheting into a fresh ledger info"),
+        };
+    }
+
+    #[test]
+    fn test_ratchet_with_partial_trusted_prefix(
+        (_vsets, lis_with_sigs, latest_li) in arb_update_proof(
+            1,    /* start epoch */
+            1,    /* start version */
+            1..3, /* version delta */
+            1..5, /* epoch changes */
+            1..5, /* validators per epoch */
+        ),
+        trusted_prefix_end_idx in any::<Index>(),
+    ) {
+        let initial_version = lis_with_sigs[0].ledger_info().version();
+
+        // Let's say we ratcheted to an intermediate epoch concurrently while this
+        // update request was fulfilled. If the response still has a fresher state,
+        // we should be able to use that and just skip the already trusted prefix.
+        let idx = trusted_prefix_end_idx.index(lis_with_sigs.len());
+        let intermediate_ledger_info = lis_with_sigs[idx].ledger_info();
+        let trusted_state = TrustedState::from_epoch_change_ledger_info(intermediate_ledger_info).unwrap();
+
+        let expected_latest_version = latest_li.ledger_info().version();
+        let expected_latest_li = latest_li.clone();
+        let expected_latest_epoch_change_li = lis_with_sigs.last().cloned();
+        let expected_validator_set = expected_latest_epoch_change_li
+            .as_ref()
+            .and_then(|li_with_sigs| li_with_sigs.ledger_info().next_validator_set());
+
+        let change_proof = ValidatorChangeProof::new(lis_with_sigs, false /* more */);
+        let req = UpdateToLatestLedgerRequest::new(initial_version, vec![]);
+        let res = UpdateToLatestLedgerResponse::new(vec![], latest_li, change_proof, new_mock_accumulator_proof());
+
+        let trusted_state_change = trusted_state
+            .verify_and_ratchet_response(&req, &res)
+            .expect("Should never error when ratcheting from waypoint with valid proofs");
+
+        match trusted_state_change {
+            TrustedStateChange::Epoch {
+                new_state,
+                latest_li,
+                latest_epoch_change_li,
+                latest_validator_set,
+            } => {
+                assert_eq!(new_state.latest_version(), expected_latest_version);
+                assert_eq!(latest_li, &expected_latest_li);
+                assert_eq!(Some(latest_epoch_change_li), expected_latest_epoch_change_li.as_ref());
+                assert_eq!(Some(latest_validator_set), expected_validator_set);
+            }
+            TrustedStateChange::Version {
+                new_state,
+                latest_li,
+            } => {
+                assert_eq!(new_state.latest_version(), expected_latest_version);
+                assert_eq!(latest_li, &expected_latest_li);
+            }
+            TrustedStateChange::Stale =>
+                panic!("Should never be stale since we're ratcheting into a fresh ledger info"),
+        };
+    }
+
+    #[test]
+    fn test_ratchet_fails_with_gap_in_proof(
+        (_vsets, mut lis_with_sigs, latest_li) in arb_update_proof(
+            1,    /* start epoch */
+            1,    /* start version */
+            3,    /* version delta */
+            2..5, /* epoch changes */
+            1..3, /* validators per epoch */
+        ),
+        li_gap_idx in any::<Index>(),
+    ) {
+        let initial_li_with_sigs = lis_with_sigs.remove(0);
+        let initial_version = initial_li_with_sigs.ledger_info().version();
+        let trusted_state = TrustedState::from_epoch_change_ledger_info(
+            initial_li_with_sigs.ledger_info(),
+        ).unwrap();
+
+        // materialize index and remove an epoch change in the proof to add a gap
+        let li_gap_idx = li_gap_idx.index(lis_with_sigs.len());
+        lis_with_sigs.remove(li_gap_idx);
+
+        let change_proof = ValidatorChangeProof::new(lis_with_sigs, false /* more */);
+        let req = UpdateToLatestLedgerRequest::new(initial_version, vec![]);
+        let res = UpdateToLatestLedgerResponse::new(vec![], latest_li, change_proof, new_mock_accumulator_proof());
+
+        trusted_state
+            .verify_and_ratchet_response(&req, &res)
+            .expect_err("Should always return Err with an invalid change proof");
+    }
+
+    #[test]
+    fn test_ratchet_fails_with_invalid_signature(
+        (_vsets, mut lis_with_sigs, latest_li) in arb_update_proof(
+            1,    /* start epoch */
+            1,    /* start version */
+            1,    /* version delta */
+            2..5, /* epoch changes */
+            1..5, /* validators per epoch */
+        ),
+        bad_li_idx in any::<Index>(),
+    ) {
+        let initial_li_with_sigs = lis_with_sigs.remove(0);
+        let initial_version = initial_li_with_sigs.ledger_info().version();
+        let trusted_state = TrustedState::from_epoch_change_ledger_info(
+            initial_li_with_sigs.ledger_info(),
+        ).unwrap();
+
+        // Swap in a bad ledger info without signatures
+        let li_with_sigs = bad_li_idx.get(&lis_with_sigs);
+        let bad_li_with_sigs = LedgerInfoWithSignatures::new(
+            li_with_sigs.ledger_info().clone(),
+            BTreeMap::new(), /* empty signatures */
+        );
+        ::std::mem::replace(bad_li_idx.get_mut(&mut lis_with_sigs), bad_li_with_sigs);
+
+        let change_proof = ValidatorChangeProof::new(lis_with_sigs, false /* more */);
+        let req = UpdateToLatestLedgerRequest::new(initial_version, vec![]);
+        let res = UpdateToLatestLedgerResponse::new(vec![], latest_li, change_proof, new_mock_accumulator_proof());
+
+        trusted_state
+            .verify_and_ratchet_response(&req, &res)
+            .expect_err("Should always return Err with an invalid change proof");
+    }
+}
+
+proptest! {
+    #![proptest_config(ProptestConfig::with_cases(1))]
+
+    #[test]
+    fn test_stale_ratchet(
+        (_vsets, lis_with_sigs, latest_li) in arb_update_proof(
+            1,    /* start epoch */
+            1,    /* start version */
+            1..3, /* version delta */
+            1,    /* epoch changes */
+            1..5, /* validators per epoch */
+        ),
+    ) {
+        let initial_version = lis_with_sigs[0].ledger_info().version();
+
+        // We've ratched beyond the response change proof, so attempting to ratchet
+        // that change proof should just return `TrustedStateChange::Stale`.
+        let epoch_change_li = new_mock_ledger_info(123 /* epoch */, 456 /* version */, Some(ValidatorSet::empty()));
+        let trusted_state = TrustedState::from_epoch_change_ledger_info(&epoch_change_li).unwrap();
+
+        let change_proof = ValidatorChangeProof::new(lis_with_sigs, false /* more */);
+        let req = UpdateToLatestLedgerRequest::new(initial_version, vec![]);
+        let res = UpdateToLatestLedgerResponse::new(vec![], latest_li, change_proof, new_mock_accumulator_proof());
+
+        let trusted_state_change = trusted_state
+            .verify_and_ratchet_response(&req, &res)
+            .expect("Should never error when ratcheting from waypoint with valid proofs");
+
+        match trusted_state_change {
+            TrustedStateChange::Stale => {},
+            _ => panic!("Unexpected state change, expected Stale, got: {:?}", trusted_state_change),
+        }
+    }
+}

--- a/types/src/validator_change.rs
+++ b/types/src/validator_change.rs
@@ -25,7 +25,7 @@ pub struct ValidatorChangeProof {
     pub more: bool,
 }
 
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 /// The verification of the validator change proof starts with some verifier that is trusted by the
 /// client: could be either a waypoint (upon startup) or a known validator verifier.
 pub enum VerifierType {

--- a/types/src/validator_change.rs
+++ b/types/src/validator_change.rs
@@ -98,7 +98,7 @@ impl ValidatorChangeProof {
     /// pass a waypoint in case it's not needed).
     ///
     /// We will also skip any stale ledger info's in the [`ValidatorChangeProof`].
-    pub fn verify(&self, verifier: &VerifierType) -> Result<LedgerInfoWithSignatures> {
+    pub fn verify(&self, verifier: &VerifierType) -> Result<&LedgerInfoWithSignatures> {
         ensure!(
             !self.ledger_info_with_sigs.is_empty(),
             "The ValidatorChangeProof is empty"
@@ -153,7 +153,7 @@ impl ValidatorChangeProof {
                     .ok_or_else(|| format_err!("LedgerInfo doesn't carry a ValidatorSet"))
             })?;
 
-        Ok(self.ledger_info_with_sigs.last().unwrap().clone())
+        Ok(self.ledger_info_with_sigs.last().unwrap())
     }
 }
 

--- a/types/src/validator_verifier.rs
+++ b/types/src/validator_verifier.rs
@@ -38,7 +38,7 @@ pub enum VerifyError {
 }
 
 /// Helper struct to manage validator information for validation
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 pub struct ValidatorInfo<PublicKey> {
     public_key: PublicKey,
     voting_power: u64,
@@ -64,7 +64,7 @@ impl<PublicKey: VerifyingKey> ValidatorInfo<PublicKey> {
 /// Supports validation of signatures for known authors with individual voting powers. This struct
 /// can be used for all signature verification operations including block and network signature
 /// verification, respectively.
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 pub struct ValidatorVerifier<PublicKey> {
     /// An ordered map of each validator's on-chain account address to its pubkeys
     /// and voting power.


### PR DESCRIPTION
+ `TrustedState` keeps track of our latest trusted state, including the latest verified version and the latest verified validator set or epoch change waypoint.

+ `TrustedState` ratchets this latest trusted state forward when verifying a `UpdateToLatestLedgerRequest/Response` pair. In other words, it keeps track of our current epoch, lets us safely transition to new epochs, and ensures that we never go backwards to a previous epoch or version.

+ Similar logic exists in the current libra client code; since onchain discovery needs this logic as well, this common logic can be extracted into a single place.