### PR TITLE
[move source language] Fixed last copy to move

### DIFF
--- a/language/move-lang/src/cfgir/mod.rs
+++ b/language/move-lang/src/cfgir/mod.rs
@@ -29,16 +29,11 @@ pub fn refine_inference_and_verify(
     infinite_loop_starts: &BTreeSet<Label>,
 ) {
     remove_no_ops::optimize(cfg);
-    let liveness_states = liveness::refine_inference_and_verify(
-        errors,
-        signature,
-        acquires,
-        locals,
-        cfg,
-        infinite_loop_starts,
-    );
+
+    liveness::last_usage(errors, locals, cfg, infinite_loop_starts);
     let locals_states = locals::verify(errors, signature, acquires, locals, cfg);
-    liveness::release_dead_refs(locals, cfg, &liveness_states, &locals_states);
+
+    liveness::release_dead_refs(&locals_states, locals, cfg, infinite_loop_starts);
     borrows::verify(errors, signature, acquires, locals, cfg);
 }
 

--- a/language/move-lang/tests/move_check/borrows/copy_full_invalid.exp
+++ b/language/move-lang/tests/move_check/borrows/copy_full_invalid.exp
@@ -1,33 +1,22 @@
 error: 
 
-    ┌── tests/move_check/borrows/copy_full_invalid.move:18:17 ───
+    ┌── tests/move_check/borrows/copy_full_invalid.move:12:17 ───
     │
- 19 │         x;
+ 13 │         x;
     │         ^ Invalid copy of local 'x'
     ·
- 18 │         let f = &mut x;
+ 12 │         let f = &mut x;
     │                 ------ It is still being mutably borrowed by this reference
     │
 
 error: 
 
-    ┌── tests/move_check/borrows/copy_full_invalid.move:24:17 ───
+    ┌── tests/move_check/borrows/copy_full_invalid.move:18:17 ───
     │
- 25 │         x;
-    │         ^ Invalid move of local 'x'
-    ·
- 24 │         let f = id(&x);
-    │                 ------ It is still being borrowed by this reference
-    │
-
-error: 
-
-    ┌── tests/move_check/borrows/copy_full_invalid.move:29:17 ───
-    │
- 30 │         x;
+ 19 │         x;
     │         ^ Invalid copy of local 'x'
     ·
- 29 │         let f = id_mut(&mut x);
+ 18 │         let f = id_mut(&mut x);
     │                 -------------- It is still being mutably borrowed by this reference
     │
 

--- a/language/move-lang/tests/move_check/borrows/copy_full_invalid.move
+++ b/language/move-lang/tests/move_check/borrows/copy_full_invalid.move
@@ -9,21 +9,10 @@ module M {
 
     fun t0() {
         let x = 0;
-        let f = &x;
-        x;
-        *f;
-        x;
-
-        let x = 0;
         let f = &mut x;
         x;
         *f;
         x;
-
-        let x = 0;
-        let f = id(&x);
-        x;
-        *f;
 
         let x = 0;
         let f = id_mut(&mut x);

--- a/language/move-lang/tests/move_check/liveness/dead_refs_loop.move
+++ b/language/move-lang/tests/move_check/liveness/dead_refs_loop.move
@@ -24,7 +24,7 @@ module M {
         let x = 0;
         let x_ref = &mut x;
         loop {
-            if (cond) break else  { _ = copy x_ref; }
+            if (cond) break else  { _ = x_ref; }
         };
         _ = x;
         _ = move x;


### PR DESCRIPTION
## Motivation

- Made it so only references get their last copy switched to a move
- This means you should never have to annotate for correctness
- Other primitive values it should not matter much
  - These other copy ~> move need to be aware of the borrow state
    so it will be a bit of work to add this optimization

## Test Plan

- cargo test