### PR TITLE
[on-chain config] reconfiguration event triggers state sync to notify subscribed components

### DIFF
--- a/consensus/src/state_computer.rs
+++ b/consensus/src/state_computer.rs
@@ -112,11 +112,15 @@ impl StateComputer for ExecutionProxy {
             })
             .collect();
 
-        let committed_txns =
+        let (committed_txns, reconfig_events) =
             self.executor
                 .commit_blocks(committable_blocks, finality_proof, committed_trees)?;
         counters::BLOCK_COMMIT_DURATION_S.observe_duration(pre_commit_instant.elapsed());
-        if let Err(e) = self.synchronizer.commit(committed_txns).await {
+        if let Err(e) = self
+            .synchronizer
+            .commit(committed_txns, reconfig_events)
+            .await
+        {
             error!("failed to notify state synchronizer: {:?}", e);
         }
         Ok(())

--- a/mempool/src/core_mempool/unit_tests/shared_mempool_test.rs
+++ b/mempool/src/core_mempool/unit_tests/shared_mempool_test.rs
@@ -75,6 +75,8 @@ fn init_single_shared_mempool(smp: &mut SharedMempoolNetwork, peer_id: PeerId, c
     let network_handles = vec![(peer_id, network_sender, network_events)];
     let (_consensus_sender, consensus_events) = mpsc::channel(1_024);
     let (_state_sync_sender, state_sync_events) = mpsc::channel(1_024);
+    let (_reconfig_events, reconfig_events_receiver) =
+        libra_channel::new(QueueStyle::LIFO, NonZeroUsize::new(1).unwrap(), None);
 
     let runtime = Builder::new()
         .thread_name("shared-mem-")
@@ -90,6 +92,7 @@ fn init_single_shared_mempool(smp: &mut SharedMempoolNetwork, peer_id: PeerId, c
         ac_endpoint_receiver,
         consensus_events,
         state_sync_events,
+        reconfig_events_receiver,
         Arc::new(MockStorageReadClient),
         Arc::new(MockVMValidator),
         vec![sender],

--- a/mempool/src/lib.rs
+++ b/mempool/src/lib.rs
@@ -63,8 +63,9 @@ extern crate prometheus;
 #[cfg(feature = "fuzzing")]
 pub mod mocks;
 pub use shared_mempool::{
-    bootstrap, CommitNotification, CommitResponse, CommittedTransaction, ConsensusRequest,
-    ConsensusResponse, MempoolClientSender, SubmissionStatus, TransactionExclusion,
+    bootstrap, generate_reconfig_subscription, CommitNotification, CommitResponse,
+    CommittedTransaction, ConsensusRequest, ConsensusResponse, MempoolClientSender,
+    SubmissionStatus, TransactionExclusion,
 };
 
 mod core_mempool;

--- a/mempool/src/mocks/mock_shared_mempool.rs
+++ b/mempool/src/mocks/mock_shared_mempool.rs
@@ -72,6 +72,8 @@ impl MockSharedMempool {
             }
             Some(state_sync) => (None, state_sync),
         };
+        let (_reconfig_event_publisher, reconfig_event_subscriber) =
+            libra_channel::new(QueueStyle::LIFO, NonZeroUsize::new(1).unwrap(), None);
         let network_handles = vec![(peer_id, network_sender, network_events)];
 
         start_shared_mempool(
@@ -82,6 +84,7 @@ impl MockSharedMempool {
             client_events,
             consensus_events,
             state_sync_events,
+            reconfig_event_subscriber,
             Arc::new(MockStorageReadClient),
             Arc::new(MockVMValidator),
             vec![sender],

--- a/state-synchronizer/src/executor_proxy.rs
+++ b/state-synchronizer/src/executor_proxy.rs
@@ -7,6 +7,7 @@ use executor::{ExecutedTrees, Executor};
 use libra_config::config::NodeConfig;
 use libra_types::{
     crypto_proxies::{LedgerInfoWithSignatures, ValidatorChangeProof},
+    event_subscription::EventSubscription,
     transaction::TransactionListWithProof,
 };
 use std::sync::Arc;
@@ -26,6 +27,7 @@ pub trait ExecutorProxyTrait: Sync + Send {
         verified_target_li: LedgerInfoWithSignatures,
         intermediate_end_of_epoch_li: Option<LedgerInfoWithSignatures>,
         synced_trees: &mut ExecutedTrees,
+        reconfig_event_subscriptions: &mut [Box<dyn EventSubscription>],
     ) -> Result<()>;
 
     /// Gets chunk of transactions given the known version, target version and the max limit.
@@ -92,13 +94,22 @@ impl ExecutorProxyTrait for ExecutorProxy {
         verified_target_li: LedgerInfoWithSignatures,
         intermediate_end_of_epoch_li: Option<LedgerInfoWithSignatures>,
         synced_trees: &mut ExecutedTrees,
+        reconfig_event_subscriptions: &mut [Box<dyn EventSubscription>],
     ) -> Result<()> {
-        self.executor.execute_and_commit_chunk(
+        let reconfig_events = self.executor.execute_and_commit_chunk(
             txn_list_with_proof,
             verified_target_li,
             intermediate_end_of_epoch_li,
             synced_trees,
-        )
+        )?;
+
+        // TODO add per-subscription filter logic
+        for event in reconfig_events {
+            for subscription in reconfig_event_subscriptions.iter_mut() {
+                subscription.publish(event.clone());
+            }
+        }
+        Ok(())
     }
 
     async fn get_chunk(

--- a/types/src/event_subscription.rs
+++ b/types/src/event_subscription.rs
@@ -1,0 +1,10 @@
+// Copyright (c) The Libra Core Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::contract_event::ContractEvent;
+
+/// Trait that must be implemented by a subscription to reconfiguration events emitted
+/// by state sync
+pub trait EventSubscription: Send + Sync {
+    fn publish(&mut self, payload: ContractEvent);
+}

--- a/types/src/lib.rs
+++ b/types/src/lib.rs
@@ -16,6 +16,7 @@ pub mod crypto_proxies;
 pub mod discovery_info;
 pub mod discovery_set;
 pub mod event;
+pub mod event_subscription;
 pub mod get_with_proof;
 pub mod identifier;
 pub mod language_storage;


### PR DESCRIPTION
## Summary
With this PR, 
- state synchronizer is responsible for broadcasting reconfiguration events to subscribed components (e.g. mempool, consensus). A component can subscribe itself to state sync's reconfiguration events by adding its own subscription object implementing `ReconfigurationEventSubscription` and adding it to state sync upon node initialization (sampled in this PR by mempool subscribing to state sync)
- On validators, state synchronizer will receive reconfiguration events from consensus upon block commits and notified via the commit notification flow
- On full nodes, state synchronizer will receive reconfiguration events when executing chunks from upstream peers. 

As of now no actual reconfiguration events are being passed around - placeholders exist for the actual emission of reconfiguration event from executor and the processing of the reconfiguration event notification, which will be updated pending Runtian's VM work. 


## Related Issues
https://github.com/libra/libra/issues/2367