### PR TITLE
[monitoring] fix dashboard revision info

### DIFF
--- a/terraform/templates/ec2_user_data.sh
+++ b/terraform/templates/ec2_user_data.sh
@@ -25,9 +25,9 @@ yum install -y /tmp/node_exporter.rpm
 systemctl start node_exporter
 
 cat > /etc/cron.d/metric_collector <<"EOF"
-* * * * * root   docker container ls -q --filter label=com.amazonaws.ecs.container-name | xargs docker inspect --format='{{.State.StartedAt}}' | xargs date +"\%s" -d | xargs echo "ecs_start_time_seconds " > /var/lib/node_exporter/textfile_collector/ecs_stats.prom
+* * * * * root   docker container ls -q --filter label=vcs-upstream | xargs docker inspect --format='{{.State.StartedAt}}' | xargs date +"\%s" -d | xargs echo "ecs_start_time_seconds " > /var/lib/node_exporter/textfile_collector/ecs_stats.prom
 
-* * * * * root	 docker container ls -q --filter label=com.amazonaws.ecs.container-name | xargs docker inspect --format='{{$tags := .Config.Labels}}build_info{revision="{{index $tags "org.label-schema.vcs-ref"}}", upstream="{{index $tags "vcs-upstream"}}"} 1' > /var/lib/node_exporter/textfile_collector/build_info.prom
+* * * * * root	 docker container ls -q --filter label=vcs-upstream | xargs docker inspect --format='{{$tags := .Config.Labels}}build_info{revision="{{index $tags "org.label-schema.vcs-ref"}}", upstream="{{index $tags "vcs-upstream"}}"} 1' > /var/lib/node_exporter/textfile_collector/build_info.prom
 EOF
 
 cat > /etc/profile.d/libra_prompt.sh <<EOF


### PR DESCRIPTION
<!--
Thank you for sending a PR. We appreciate you spending time to help improve the Libra project.

The project is undergoing daily changes. Pull Requests will be reviewed and responded to as time permits.
-->

## Motivation

Fix revision info and uptime on Grafana dashboard, currently the query result contains two set of data (logstash got into the query), this failed to render on dashboard cause "Only queries that return single series/table is supported"

- Compare the docker image info:
```
"Labels": {
                "com.amazonaws.ecs.cluster": "dev",
                "com.amazonaws.ecs.container-name": "logstash",
                "com.amazonaws.ecs.task-arn": "arn:aws:ecs:us-west-2:853397791086:task/dev/330532c22e2f4bb88ff550c771f4d042",
                "com.amazonaws.ecs.task-definition-family": "dev-validator-2",
                "com.amazonaws.ecs.task-definition-version": "239",
                "license": "Elastic License",
                "org.label-schema.build-date": "20191001",
                "org.label-schema.license": "GPLv2",
                "org.label-schema.name": "logstash",
                "org.label-schema.schema-version": "1.0",
                "org.label-schema.url": "https://www.elastic.co/products/logstash",
                "org.label-schema.vcs-url": "https://github.com/elastic/logstash",
                "org.label-schema.vendor": "Elastic",
                "org.label-schema.version": "7.5.1"
            }
        },
```
and for validator / fullnode:

```
"Labels": {
                "com.amazonaws.ecs.cluster": "dev",
                "com.amazonaws.ecs.container-name": "fullnode",
                "com.amazonaws.ecs.task-arn": "arn:aws:ecs:us-west-2:853397791086:task/dev/6954487c9b89481593cd0cf1a922f318",
                "com.amazonaws.ecs.task-definition-family": "dev-fullnode-0",
                "com.amazonaws.ecs.task-definition-version": "135",
                "org.label-schema.build-date": "2020-02-25T19:42:39Z",
                "org.label-schema.schema-version": "1.0",
                "org.label-schema.vcs-ref": "2ba2cf00cdd19a10361d03a72b861a31db936281",
                "vcs-upstream": "2ba2cf00cdd19a10361d03a72b861a31db936281"
            }
        },
```

Pick `vcs-upstream` as the unique identifier for validator and fullnode.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan
Before the change, we got two container hash:
```
[root:validator@ip-10-0-11-123 /home/ec2-user]$ docker container ls -q --filter label=com.amazonaws.ecs.container-name
8b956b0627bf
e67fa1c52562
```
after the change, only validator hash returned:
```
[root:validator@ip-10-0-11-123 /home/ec2-user]$ docker container ls -q --filter label=vcs-upstream
8b956b0627bf
```

- Apply changes to devnet

