### PR TITLE
[Secure Storage] Fixes the create() method for the Vault secure storage implementation and adds an appropriate test.

### DIFF
--- a/secure/storage/src/tests/suite.rs
+++ b/secure/storage/src/tests/suite.rs
@@ -90,4 +90,9 @@ pub fn run_test_suite(mut storage: Box<dyn Storage>, name: &str) {
         storage.get(KEY_KEY).unwrap().u64().unwrap_err(),
         Error::UnexpectedValueType
     );
+
+    // Attempt to perform a u64_key creation twice (i.e., for a key that already exists!)
+    assert!(storage
+        .create(U64_KEY, Value::U64(u64_value_1), &public)
+        .is_err());
 }


### PR DESCRIPTION

## Motivation

This PR fixes an implementation error for create() in the vault backend and adds an explicit test to verify the previously broken behaviour.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?

Yes.

## Test Plan

The updated tests works (as well as all previous tests)

## Related PRs

None.