### PR TITLE
[WIP][on-chain configs] pass reconfig events from consensus to state sync

### DIFF
--- a/consensus/src/state_computer.rs
+++ b/consensus/src/state_computer.rs
@@ -114,11 +114,15 @@ impl StateComputer for ExecutionProxy {
             })
             .collect();
 
-        let committed_txns =
+        let (committed_txns, reconfiguration_events) =
             self.executor
                 .commit_blocks(committable_blocks, finality_proof, committed_trees)?;
         counters::BLOCK_COMMIT_DURATION_S.observe_duration(pre_commit_instant.elapsed());
-        if let Err(e) = self.synchronizer.commit(committed_txns).await {
+        if let Err(e) = self
+            .synchronizer
+            .commit(committed_txns, reconfiguration_events)
+            .await
+        {
             error!("failed to notify state synchronizer: {:?}", e);
         }
         Ok(())

--- a/state-synchronizer/src/tests/integration_tests.rs
+++ b/state-synchronizer/src/tests/integration_tests.rs
@@ -340,7 +340,7 @@ impl SynchronizerEnv {
         // in commit()
         assert!(Runtime::new()
             .unwrap()
-            .block_on(self.clients[peer_id].commit(committed_txns))
+            .block_on(self.clients[peer_id].commit(committed_txns, vec![]))
             .is_ok());
         let mempool_txns = self.mempools[peer_id].read_timeline(0, signed_txns.len());
         for txn in signed_txns.iter() {


### PR DESCRIPTION
## Motivation

First pass/sanity check at piping out how consensus will pass reconfiguration events to state sync

For now this PR sends over the contract events corresponding to reconfig events. The actual payload/representation of reconfiguration events is pending on Runtian's VM work