### PR TITLE
[cluster-test] Integrate ClusterSwarmKube into cluster-test

### DIFF
--- a/testsuite/cluster-test/src/aws.rs
+++ b/testsuite/cluster-test/src/aws.rs
@@ -22,9 +22,13 @@ pub struct Aws {
 }
 
 impl Aws {
-    pub fn new() -> Self {
+    pub fn new(k8s: bool) -> Self {
         let ec2 = Ec2Client::new(Region::UsWest2);
-        let workspace = discover_workspace(&ec2);
+        let workspace = if k8s {
+            "k8s".to_string()
+        } else {
+            discover_workspace(&ec2)
+        };
         Self {
             workspace,
             ec2,
@@ -56,7 +60,7 @@ impl Aws {
 
 impl Default for Aws {
     fn default() -> Self {
-        Self::new()
+        Self::new(false)
     }
 }
 

--- a/testsuite/cluster-test/src/cluster.rs
+++ b/testsuite/cluster-test/src/cluster.rs
@@ -48,6 +48,26 @@ impl Cluster {
         }
     }
 
+    fn get_mint_key_pair() -> KeyPair<Ed25519PrivateKey, Ed25519PublicKey> {
+        let seed = "1337133713371337133713371337133713371337133713371337133713371337";
+        let seed = hex::decode(seed).expect("Invalid hex in seed.");
+        let seed = seed[..32].try_into().expect("Invalid seed");
+        let mint_key = ValidatorConfig::new().seed(seed).build_faucet_client();
+        KeyPair::from(mint_key)
+    }
+
+    pub fn new_k8s(
+        validator_instances: Vec<Instance>,
+        fullnode_instances: Vec<Instance>,
+    ) -> Result<Self> {
+        Ok(Self {
+            validator_instances,
+            fullnode_instances,
+            prometheus_ip: None,
+            mint_key_pair: Self::get_mint_key_pair(),
+        })
+    }
+
     pub fn discover(aws: &Aws) -> Result<Self> {
         let mut validator_instances = vec![];
         let mut fullnode_instances = vec![];
@@ -123,11 +143,7 @@ impl Cluster {
         );
         let prometheus_ip =
             prometheus_ip.ok_or_else(|| format_err!("Prometheus was not found in workspace"))?;
-        let seed = "1337133713371337133713371337133713371337133713371337133713371337";
-        let seed = hex::decode(seed).expect("Invalid hex in seed.");
-        let seed = seed[..32].try_into().expect("Invalid seed");
-        let mint_key = ValidatorConfig::new().seed(seed).build_faucet_client();
-        let mint_key_pair = KeyPair::from(mint_key);
+        let mint_key_pair = Self::get_mint_key_pair();
         Ok(Self {
             validator_instances,
             fullnode_instances,

--- a/testsuite/cluster-test/src/cluster_swarm/fullnode_spec_template.yaml
+++ b/testsuite/cluster-test/src/cluster_swarm/fullnode_spec_template.yaml
@@ -9,13 +9,14 @@ metadata:
     prometheus.io/should_be_scraped: "true"
 spec:
   hostNetwork: true
+  dnsPolicy: ClusterFirstWithHostNet
   serviceAccountName: fullnode
   nodeSelector:
     nodeType: validators
   nodeName: "{node_name}"
   initContainers:
   - name: init
-    image: bitnami/kubectl:1.17
+    image: 853397791086.dkr.ecr.us-west-2.amazonaws.com/libra_init:{image_tag}
     volumeMounts:
     - mountPath: /opt/libra/data
       name: data
@@ -60,9 +61,9 @@ spec:
     - name: CFG_FULLNODE_INDEX
       value: "{fullnode_index}"
     - name: CFG_SEED
-      value: "1337133713371337133713371337133713371337133713371337133713371337"
+      value: "{cfg_seed}"
     - name: CFG_FULLNODE_SEED
-      value: "2674267426742674267426742674267426742674267426742674267426742674"
+      value: "{cfg_fullnode_seed}"
     - name: RUST_LOG
       value: "debug"
     - name: RUST_BACKTRACE
@@ -80,7 +81,7 @@ spec:
         set -x;
         export CFG_LISTEN_ADDR=$MY_POD_IP;
         export CFG_SEED_PEER_IP=$(cat /opt/libra/data/seed_peer_ip);
-        exec bash /docker-run-dynamic-fullnode.sh
+        exec bash /docker-run-dynamic-fullnode.sh &> /opt/libra/data/libra.log
   volumes:
   - name: data
     hostPath:

--- a/testsuite/cluster-test/src/cluster_swarm/mod.rs
+++ b/testsuite/cluster-test/src/cluster_swarm/mod.rs
@@ -3,12 +3,17 @@
 
 pub mod cluster_swarm_kube;
 
+use crate::instance::Instance;
 use anyhow::Result;
 use async_trait::async_trait;
 use futures::{future::try_join_all, try_join};
 
 #[async_trait]
 pub trait ClusterSwarm {
+    async fn validator_instances(&self) -> Vec<Instance>;
+
+    async fn fullnode_instances(&self) -> Vec<Instance>;
+
     /// Inserts a validator into the ClusterSwarm if it doesn't exist. If it
     /// exists, then updates the validator.
     async fn upsert_validator(
@@ -142,4 +147,6 @@ pub trait ClusterSwarm {
 
     /// Deletes all validators and fullnodes in this cluster
     async fn delete_all(&self) -> Result<()>;
+
+    async fn get_grafana_baseurl(&self) -> Result<String>;
 }

--- a/testsuite/cluster-test/src/cluster_swarm/validator_spec_template.yaml
+++ b/testsuite/cluster-test/src/cluster_swarm/validator_spec_template.yaml
@@ -9,13 +9,14 @@ metadata:
     prometheus.io/should_be_scraped: "true"
 spec:
   hostNetwork: true
+  dnsPolicy: ClusterFirstWithHostNet
   serviceAccountName: validator
   nodeSelector:
     nodeType: validators
   nodeName: "{node_name}"
   initContainers:
   - name: init
-    image: bitnami/kubectl:1.17
+    image: 853397791086.dkr.ecr.us-west-2.amazonaws.com/libra_init:{image_tag}
     volumeMounts:
     - mountPath: /opt/libra/data
       name: data
@@ -64,9 +65,9 @@ spec:
     - name: CFG_NUM_FULLNODES
       value: "{num_fullnodes}"
     - name: CFG_SEED
-      value: "1337133713371337133713371337133713371337133713371337133713371337"
+      value: "{cfg_seed}"
     - name: CFG_FULLNODE_SEED
-      value: "2674267426742674267426742674267426742674267426742674267426742674"
+      value: "{cfg_fullnode_seed}"
     - name: RUST_LOG
       value: "debug"
     - name: RUST_BACKTRACE
@@ -84,7 +85,7 @@ spec:
         set -x;
         export CFG_LISTEN_ADDR=$MY_POD_IP;
         export CFG_SEED_PEER_IP=$(cat /opt/libra/data/seed_peer_ip);
-        exec bash /docker-run-dynamic.sh
+        exec bash /docker-run-dynamic.sh &> /opt/libra/data/libra.log
   volumes:
   - name: data
     hostPath:

--- a/testsuite/cluster-test/src/main.rs
+++ b/testsuite/cluster-test/src/main.rs
@@ -19,6 +19,7 @@ use anyhow::{bail, format_err, Result};
 use cluster_test::{
     aws::Aws,
     cluster::Cluster,
+    cluster_swarm::{cluster_swarm_kube::ClusterSwarmKube, ClusterSwarm},
     deployment::DeploymentManager,
     effects::{Action, Effect, Reboot, RemoveNetworkEffects, StopContainer},
     experiments::{get_experiment, Context, Experiment},
@@ -122,6 +123,11 @@ struct Args {
         help = "Whether transactions should be submitted to validators or full nodes"
     )]
     pub emit_to_validator: Option<bool>,
+
+    #[structopt(long, default_value = "1")]
+    pub k8s_fullnodes_per_validator: u32,
+    #[structopt(long, parse(try_from_str), default_value = "30")]
+    pub k8s_num_validators: u32,
 }
 
 pub fn main() {
@@ -172,12 +178,14 @@ pub fn main() {
     let mut runner = ClusterTestRunner::setup(&args);
 
     if let Some(ref hash_or_tag) = args.deploy {
-        // Deploy deploy_hash before running whatever command
-        let hash = runner
-            .deployment_manager
-            .resolve(hash_or_tag)
-            .expect("Failed to resolve tag");
-        exit_on_error(runner.redeploy(&hash));
+        if runner.cluster_swarm.is_none() {
+            // Deploy deploy_hash before running whatever command
+            let hash = runner
+                .deployment_manager
+                .resolve(hash_or_tag)
+                .expect("Failed to resolve tag");
+            exit_on_error(runner.redeploy(&hash));
+        }
     }
 
     let mut perf_msg = None;
@@ -274,6 +282,7 @@ struct ClusterUtil {
     cluster: Cluster,
     aws: Aws,
     prometheus: Prometheus,
+    cluster_swarm: Option<ClusterSwarmKube>,
 }
 
 struct ClusterTestRunner {
@@ -291,6 +300,7 @@ struct ClusterTestRunner {
     report: SuiteReport,
     global_emit_job_request: EmitJobRequest,
     emit_to_validator: bool,
+    cluster_swarm: Option<ClusterSwarmKube>,
 }
 
 fn parse_host_port(s: &str) -> Result<(String, u32)> {
@@ -342,30 +352,80 @@ impl BasicSwarmUtil {
 
 impl ClusterUtil {
     pub fn setup(args: &Args) -> Self {
-        let aws = Aws::new();
-        let cluster = Cluster::discover(&aws).expect("Failed to discover cluster");
-        let cluster = if args.peers.is_empty() {
-            cluster
-        } else {
-            cluster.validator_sub_cluster(args.peers.clone())
-        };
-        let prometheus = Prometheus::new(
-            cluster
-                .prometheus_ip()
-                .expect("Failed to discover prometheus ip in aws"),
-            aws.workspace(),
-        );
-        info!(
-            "Discovered {} validators and {} fns in {} workspace",
-            cluster.validator_instances().len(),
-            cluster.fullnode_instances().len(),
-            aws.workspace()
-        );
-        Self {
-            cluster,
-            aws,
-            prometheus,
-        }
+        Runtime::new().unwrap().block_on(async move {
+            let k8s = env::var("KUBERNETES_SERVICE_HOST").is_ok();
+            let aws = Aws::new(k8s);
+            let cluster_swarm = if k8s {
+                Some(
+                    ClusterSwarmKube::new()
+                        .await
+                        .expect("Failed to initialize ClusterSwarmKube"),
+                )
+            } else {
+                None
+            };
+            let cluster = if let Some(cluster_swarm) = cluster_swarm.as_ref() {
+                cluster_swarm.delete_all().await.expect("delete_all failed");
+                let image_tag = args.deploy.as_ref().map(|x| x.as_str()).unwrap_or("master");
+                info!(
+                    "Deploying with {} tag for validators and fullnodes",
+                    image_tag
+                );
+                cluster_swarm
+                    .create_validator_and_fullnode_set(
+                        args.k8s_num_validators,
+                        args.k8s_fullnodes_per_validator,
+                        &image_tag,
+                        true,
+                    )
+                    .await
+                    .expect("Failed to create_validator_and_fullnode_set");
+                info!("Deployment complete");
+                Cluster::new_k8s(
+                    cluster_swarm.validator_instances().await,
+                    cluster_swarm.fullnode_instances().await,
+                )
+                .unwrap()
+            } else {
+                Cluster::discover(&aws).expect("Failed to discover cluster")
+            };
+            let cluster = if args.peers.is_empty() {
+                cluster
+            } else {
+                cluster.validator_sub_cluster(args.peers.clone())
+            };
+            let prometheus_ip = if cluster_swarm.is_some() {
+                "libra-testnet-prometheus-server.default.svc.cluster.local"
+            } else {
+                cluster
+                    .prometheus_ip()
+                    .expect("Failed to discover prometheus ip in aws")
+            };
+            let grafana_base_url = if let Some(cluster_swarm) = cluster_swarm.as_ref() {
+                cluster_swarm
+                    .get_grafana_baseurl()
+                    .await
+                    .expect("Failed to discover grafana url in k8s")
+            } else {
+                format!(
+                    "http://prometheus.{}.aws.hlw3truzy4ls.com:9091",
+                    aws.workspace()
+                )
+            };
+            let prometheus = Prometheus::new(prometheus_ip, grafana_base_url, k8s);
+            info!(
+                "Discovered {} validators and {} fns in {} workspace",
+                cluster.validator_instances().len(),
+                cluster.fullnode_instances().len(),
+                aws.workspace()
+            );
+            Self {
+                cluster,
+                aws,
+                prometheus,
+                cluster_swarm,
+            }
+        })
     }
 
     pub fn discovery(&self) {
@@ -432,6 +492,7 @@ impl ClusterTestRunner {
         let util = ClusterUtil::setup(args);
         let cluster = util.cluster;
         let aws = util.aws;
+        let cluster_swarm = util.cluster_swarm;
         let log_tail_started = Instant::now();
         let logs = DebugPortLogThread::spawn_new(&cluster);
         let log_tail_startup_time = Instant::now() - log_tail_started;
@@ -445,19 +506,13 @@ impl ClusterTestRunner {
             Err(..) => 15,
         };
         let experiment_interval = Duration::from_secs(experiment_interval_sec);
-        let workspace = aws.workspace().clone();
         let deployment_manager = DeploymentManager::new(aws, cluster.clone());
         let slack = SlackClient::new();
         let slack_changelog_url = env::var("SLACK_CHANGELOG_URL")
             .map(|u| u.parse().expect("Failed to parse SLACK_CHANGELOG_URL"))
             .ok();
         let tx_emitter = TxEmitter::new(&cluster);
-        let prometheus = Prometheus::new(
-            cluster
-                .prometheus_ip()
-                .expect("Failed to discover prometheus ip in aws"),
-            &workspace,
-        );
+        let prometheus = util.prometheus;
         let github = GitHub::new();
         let report = SuiteReport::new();
         let runtime = Builder::new()
@@ -497,6 +552,7 @@ impl ClusterTestRunner {
             report,
             global_emit_job_request,
             emit_to_validator,
+            cluster_swarm,
         }
     }
 
@@ -566,7 +622,6 @@ impl ClusterTestRunner {
         self.health_check_runner.clear();
         self.tx_emitter.clear();
         self.start();
-        info!("Waiting until all validators healthy after deployment");
         self.wait_until_all_healthy()?;
         Ok(())
     }
@@ -607,6 +662,9 @@ impl ClusterTestRunner {
     pub fn cleanup_and_run(&mut self, experiment: Box<dyn Experiment>) -> Result<()> {
         self.cleanup();
         self.run_single_experiment(experiment, Some(self.global_emit_job_request.clone()))?;
+        if let Some(cluster_swarm) = self.cluster_swarm.as_ref() {
+            self.runtime.block_on(cluster_swarm.delete_all())?;
+        }
         self.print_report();
         Ok(())
     }
@@ -616,6 +674,7 @@ impl ClusterTestRunner {
         mut experiment: Box<dyn Experiment>,
         mut global_emit_job_request: Option<EmitJobRequest>,
     ) -> Result<()> {
+        self.wait_until_all_healthy()?;
         let events = self.logs.recv_all();
         if let Err(s) =
             self.health_check_runner
@@ -786,6 +845,7 @@ impl ClusterTestRunner {
     }
 
     fn wait_until_all_healthy(&mut self) -> Result<()> {
+        info!("Waiting for all validators to be healthy");
         let wait_deadline = Instant::now() + Duration::from_secs(20 * 60);
         for instance in self.cluster.validator_instances() {
             self.health_check_runner.invalidate(instance.peer_name());
@@ -806,6 +866,7 @@ impl ClusterTestRunner {
                 }
             }
         }
+        info!("All validators are now healthy");
         Ok(())
     }
 
@@ -887,18 +948,20 @@ impl ClusterTestRunner {
     }
 
     fn cleanup(&mut self) {
-        let futures = self.cluster.all_instances().map(|instance| async move {
-            RemoveNetworkEffects::new(instance.clone())
-                .apply()
-                .await
-                .map_err(|e| {
-                    info!(
-                        "Failed to remove network effects for {}. Error: {}",
-                        instance, e
-                    );
-                })
-        });
-        self.runtime.block_on(join_all(futures));
+        if self.cluster_swarm.is_none() {
+            let futures = self.cluster.all_instances().map(|instance| async move {
+                RemoveNetworkEffects::new(instance.clone())
+                    .apply()
+                    .await
+                    .map_err(|e| {
+                        info!(
+                            "Failed to remove network effects for {}. Error: {}",
+                            instance, e
+                        );
+                    })
+            });
+            self.runtime.block_on(join_all(futures));
+        }
     }
 
     pub fn stop(&mut self) {


### PR DESCRIPTION
## Summary

* Use `ClusterSwarm#create_validator_and_fullnode_set` in setup() to setup the cluster
* Create a sample pod spec for launching cluster-test `cluster_test_pod_sample.yaml`
* Add `validator_instances` and `fullnode_instances` methods to `ClusterSwarm`
* Use `libra_init` image for init container
* Add flags `k8s_num_validators`, `k8s_fullnodes_per_validator` to main
* Update prometheus so that it works in k8s cluster
* Replace `thread::sleep` with `tokio::time::delay_for` in tx_emitter

## Test Plan

Ran cluster-test