### PR TITLE
[move source language] Fix check for invalid field access from a script

### DIFF
--- a/language/move-lang/src/typing/translate.rs
+++ b/language/move-lang/src/typing/translate.rs
@@ -1331,8 +1331,7 @@ fn resolve_field(context: &mut Context, loc: Loc, ty: BaseType, field: &Field) -
             BaseType_::anything(loc)
         }
         sp!(_, Apply(_, sp!(_, ModuleType(m, n)), targs)) => {
-            let current_module = context.current_module.clone().unwrap();
-            if m != current_module {
+            if !context.is_current_module(&m) {
                 let msg = format!(
                     "Invalid access of field '{}' on '{}::{}'. \
                      Fields can only be accessed inside the struct's module",


### PR DESCRIPTION
The check for the current module in the resolve_field function was unwrapping an Option that is None in the context of a transaction script, causing a compiler crash instead of an error message.

## Motivation

Fix compiler crash

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

I don't know how to test this. The functional tests don't expect compiler errors and the move_check tests don't handle separate modules and scripts.