### PR TITLE
Revert merged imports option which is still unstable

### DIFF
--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,3 +1,2 @@
 edition = "2018"
 use_field_init_shorthand = true
-merge_imports=true


### PR DESCRIPTION
This was introduced in #2707, but causes spurious warnings for those on the
stable toolchain.