### PR TITLE
[language] Add new FixedPoint32 module to stdlib

### DIFF
--- a/language/move-lang/tests/functional/fixedpoint32/create_div_zero.move
+++ b/language/move-lang/tests/functional/fixedpoint32/create_div_zero.move
@@ -1,0 +1,11 @@
+use 0x0::FixedPoint32;
+
+fun main() {
+    // A denominator of zero should cause an arithmetic error.
+    let f1 = FixedPoint32::create_from_rational(2, 0);
+    // The above should fail at runtime so that the following assertion
+    // is never even tested.
+    0x0::Transaction::assert(FixedPoint32::get_raw_value(f1) == 999, 1);
+}
+
+// check: ARITHMETIC_ERROR

--- a/language/move-lang/tests/functional/fixedpoint32/create_overflow.move
+++ b/language/move-lang/tests/functional/fixedpoint32/create_overflow.move
@@ -9,5 +9,4 @@ fun main() {
     0x0::Transaction::assert(FixedPoint32::get_raw_value(f1) == 999, 1);
 }
 
-// check: ABORTED
-// check: 16
+// check: ARITHMETIC_ERROR

--- a/language/move-lang/tests/functional/fixedpoint32/create_overflow.move
+++ b/language/move-lang/tests/functional/fixedpoint32/create_overflow.move
@@ -1,0 +1,13 @@
+use 0x0::FixedPoint32;
+
+fun main() {
+    // The maximum value is 2^32 - 1. Check that anything larger aborts
+    // with an overflow.
+    let f1 = FixedPoint32::create_from_rational(4294967296, 1); // 2^32
+    // The above should fail at runtime so that the following assertion
+    // is never even tested.
+    0x0::Transaction::assert(FixedPoint32::get_raw_value(f1) == 999, 1);
+}
+
+// check: ABORTED
+// check: 16

--- a/language/move-lang/tests/functional/fixedpoint32/create_underflow.move
+++ b/language/move-lang/tests/functional/fixedpoint32/create_underflow.move
@@ -1,0 +1,13 @@
+use 0x0::FixedPoint32;
+
+fun main() {
+    // The minimum non-zero value is 2^-32. Check that anything smaller
+    // aborts.
+    let f1 = FixedPoint32::create_from_rational(1, 8589934592); // 2^-33
+    // The above should fail at runtime so that the following assertion
+    // is never even tested.
+    0x0::Transaction::assert(FixedPoint32::get_raw_value(f1) == 999, 1);
+}
+
+// check: ABORTED
+// check: 16

--- a/language/move-lang/tests/functional/fixedpoint32/divide_by_zero.move
+++ b/language/move-lang/tests/functional/fixedpoint32/divide_by_zero.move
@@ -1,0 +1,12 @@
+use 0x0::FixedPoint32;
+
+fun main() {
+    // Dividing by zero should cause an arithmetic error.
+    let f1 = FixedPoint32::create_from_raw_value(0);
+    let fail = FixedPoint32::divide_u64(1, copy f1);
+    // The above should fail at runtime so that the following assertion
+    // is never even tested.
+    0x0::Transaction::assert(fail == 999, 1);
+}
+
+// check: ARITHMETIC_ERROR

--- a/language/move-lang/tests/functional/fixedpoint32/divide_overflow1.move
+++ b/language/move-lang/tests/functional/fixedpoint32/divide_overflow1.move
@@ -9,5 +9,4 @@ fun main() {
     0x0::Transaction::assert(overflow == 999, 1);
 }
 
-// check: ABORTED
-// check: 16
+// check: ARITHMETIC_ERROR

--- a/language/move-lang/tests/functional/fixedpoint32/divide_overflow1.move
+++ b/language/move-lang/tests/functional/fixedpoint32/divide_overflow1.move
@@ -1,0 +1,13 @@
+use 0x0::FixedPoint32;
+
+fun main() {
+    let f1 = FixedPoint32::create_from_raw_value(1); // 0x0.00000001
+    // Divide 2^32 by the minimum fractional value. This should overflow.
+    let overflow = FixedPoint32::divide_u64(4294967296, copy f1);
+    // The above should fail at runtime so that the following assertion
+    // is never even tested.
+    0x0::Transaction::assert(overflow == 999, 1);
+}
+
+// check: ABORTED
+// check: 16

--- a/language/move-lang/tests/functional/fixedpoint32/divide_overflow2.move
+++ b/language/move-lang/tests/functional/fixedpoint32/divide_overflow2.move
@@ -9,5 +9,4 @@ fun main() {
     0x0::Transaction::assert(overflow == 999, 1);
 }
 
-// check: ABORTED
-// check: 16
+// check: ARITHMETIC_ERROR

--- a/language/move-lang/tests/functional/fixedpoint32/divide_overflow2.move
+++ b/language/move-lang/tests/functional/fixedpoint32/divide_overflow2.move
@@ -1,0 +1,13 @@
+use 0x0::FixedPoint32;
+
+fun main() {
+    let f1 = FixedPoint32::create_from_rational(1, 2); // 0.5
+    // Divide the maximum u64 value by 0.5. This should overflow.
+    let overflow = FixedPoint32::divide_u64(18446744073709551615, copy f1);
+    // The above should fail at runtime so that the following assertion
+    // is never even tested.
+    0x0::Transaction::assert(overflow == 999, 1);
+}
+
+// check: ABORTED
+// check: 16

--- a/language/move-lang/tests/functional/fixedpoint32/multiply_overflow1.move
+++ b/language/move-lang/tests/functional/fixedpoint32/multiply_overflow1.move
@@ -1,0 +1,13 @@
+use 0x0::FixedPoint32;
+
+fun main() {
+    let f1 = FixedPoint32::create_from_rational(3, 2); // 1.5
+    // Multiply the maximum u64 value by 1.5. This should overflow.
+    let overflow = FixedPoint32::multiply_u64(18446744073709551615, copy f1);
+    // The above should fail at runtime so that the following assertion
+    // is never even tested.
+    0x0::Transaction::assert(overflow == 999, 1);
+}
+
+// check: ABORTED
+// check: 16

--- a/language/move-lang/tests/functional/fixedpoint32/multiply_overflow1.move
+++ b/language/move-lang/tests/functional/fixedpoint32/multiply_overflow1.move
@@ -9,5 +9,4 @@ fun main() {
     0x0::Transaction::assert(overflow == 999, 1);
 }
 
-// check: ABORTED
-// check: 16
+// check: ARITHMETIC_ERROR

--- a/language/move-lang/tests/functional/fixedpoint32/multiply_overflow2.move
+++ b/language/move-lang/tests/functional/fixedpoint32/multiply_overflow2.move
@@ -1,0 +1,13 @@
+use 0x0::FixedPoint32;
+
+fun main() {
+    let f1 = FixedPoint32::create_from_raw_value(18446744073709551615);
+    // Multiply 2^33 by the maximum fixed-point value. This should overflow.
+    let overflow = FixedPoint32::multiply_u64(8589934592, copy f1);
+    // The above should fail at runtime so that the following assertion
+    // is never even tested.
+    0x0::Transaction::assert(overflow == 999, 1);
+}
+
+// check: ABORTED
+// check: 16

--- a/language/move-lang/tests/functional/fixedpoint32/multiply_overflow2.move
+++ b/language/move-lang/tests/functional/fixedpoint32/multiply_overflow2.move
@@ -9,5 +9,4 @@ fun main() {
     0x0::Transaction::assert(overflow == 999, 1);
 }
 
-// check: ABORTED
-// check: 16
+// check: ARITHMETIC_ERROR

--- a/language/move-lang/tests/functional/fixedpoint32/test.move
+++ b/language/move-lang/tests/functional/fixedpoint32/test.move
@@ -1,0 +1,25 @@
+use 0x0::FixedPoint32;
+
+fun main() {
+    let f1 = FixedPoint32::create_from_rational(3, 4); // 0.75
+    let nine = FixedPoint32::multiply_u64(12, copy f1); // 12 * 0.75
+    0x0::Transaction::assert(nine == 9, nine);
+    let twelve = FixedPoint32::divide_u64(9, copy f1); // 9 / 0.75
+    0x0::Transaction::assert(twelve == 12, twelve);
+
+    let f2 = FixedPoint32::create_from_rational(1, 3); // 0.333...
+    let not_three = FixedPoint32::multiply_u64(9, copy f2); // 9 * 0.333...
+    // multiply_u64 does NOT round -- it truncates -- so values that
+    // are not perfectly representable in binary may be off by one.
+    0x0::Transaction::assert(not_three == 2, not_three);
+
+    // Try again with a fraction slightly larger than 1/3.
+    let f3 = FixedPoint32::create_from_raw_value(FixedPoint32::get_raw_value(copy f2) + 1);
+    let three = FixedPoint32::multiply_u64(9, copy f3);
+    0x0::Transaction::assert(three == 3, three);
+
+    // Test creating a 1.0 fraction from the maximum u64 value.
+    let f4 = FixedPoint32::create_from_rational(18446744073709551615, 18446744073709551615);
+    let one = FixedPoint32::get_raw_value(copy f4);
+    0x0::Transaction::assert(one == 4294967296, 4); // 0x1.00000000
+}

--- a/language/stdlib/modules/fixedpoint32.move
+++ b/language/stdlib/modules/fixedpoint32.move
@@ -19,8 +19,9 @@ module FixedPoint32 {
         // The unscaled product has 32 fractional bits (from the multiplier)
         // so rescale it by shifting away the low bits.
         let product = unscaled_product >> 32;
-        // If the multiplier is larger than 1.0, this can overflow; check that.
-        Transaction::assert((product >> 64) == 0, 16);
+        // Convert back to u64. If the multiplier is larger than 1.0,
+        // the value may be too large, which will cause the cast to fail
+        // with an arithmetic error.
         (product as u64)
     }
 
@@ -34,8 +35,9 @@ module FixedPoint32 {
         // Divide and convert the quotient to 64 bits. If the divisor is zero,
         // this will fail with a divide-by-zero error.
         let quotient = scaled_value / (divisor.value as u128);
-        // If the divisor is less than 1.0, this can overflow; check that.
-        Transaction::assert((quotient >> 64) == 0, 16);
+        // Convert back to u64. If the divisor is less than 1.0,
+        // the value may be too large, which will cause the cast to fail
+        // with an arithmetic error.
         (quotient as u64)
     }
 
@@ -57,9 +59,8 @@ module FixedPoint32 {
         // but if you really want a ratio of zero, it is easy to create that
         // from a raw value.
         Transaction::assert(quotient != 0 || numerator == 0, 16);
-        // This can overflow because the non-fractional part of the quotient
-        // only has 32 bits; check that.
-        Transaction::assert((quotient >> 64) == 0, 16);
+        // Return the quotient as a fixed-point number. The cast will fail
+        // with an arithmetic error if the number is too large.
         T { value: (quotient as u64) }
     }
 

--- a/language/stdlib/modules/fixedpoint32.move
+++ b/language/stdlib/modules/fixedpoint32.move
@@ -1,0 +1,76 @@
+address 0x0:
+
+module FixedPoint32 {
+    use 0x0::Transaction;
+
+    // Define a fixed-point numeric type with 32 fractional bits.
+    // This is just a u64 integer but it is wrapped in a struct to
+    // make a unique type.
+    struct T { value: u64 }
+
+    // Multiply a u64 integer by a fixed-point number, truncating any
+    // fractional part of the product. This will abort if the product
+    // overflows.
+    public fun multiply_u64(num: u64, multiplier: T): u64 {
+        // The product of two 64 bit values has 128 bits, so perform the
+        // multiplication with u128 types and keep the full 128 bit product
+        // to avoid losing accuracy.
+        let unscaled_product = (num as u128) * (multiplier.value as u128);
+        // The unscaled product has 32 fractional bits (from the multiplier)
+        // so rescale it by shifting away the low bits.
+        let product = unscaled_product >> 32;
+        // If the multiplier is larger than 1.0, this can overflow; check that.
+        Transaction::assert((product >> 64) == 0, 16);
+        (product as u64)
+    }
+
+    // Divide a u64 integer by a fixed-point number, truncating any
+    // fractional part of the quotient. This will abort if the divisor
+    // is zero or if the quotient overflows.
+    public fun divide_u64(num: u64, divisor: T): u64 {
+        // First convert to 128 bits and then shift left to
+        // add 32 fractional zero bits to the dividend.
+        let scaled_value = (num as u128) << 32;
+        // Divide and convert the quotient to 64 bits. If the divisor is zero,
+        // this will fail with a divide-by-zero error.
+        let quotient = scaled_value / (divisor.value as u128);
+        // If the divisor is less than 1.0, this can overflow; check that.
+        Transaction::assert((quotient >> 64) == 0, 16);
+        (quotient as u64)
+    }
+
+    // Create a fixed-point value from a rational number specified by its
+    // numerator and denominator. This function is for convenience; it is also
+    // perfectly fine to create a fixed-point value by directly specifying the
+    // raw value. This will abort if the denominator is zero or if the ratio is
+    // not in the range 2^-32 .. 2^32-1.
+    public fun create_from_rational(numerator: u64, denominator: u64): T {
+        // Scale the numerator to have 64 fractional bits and the denominator
+        // to have 32 fractional bits, so that the quotient will have 32
+        // fractional bits.
+        let scaled_numerator = (numerator as u128) << 64;
+        let scaled_denominator = (denominator as u128) << 32;
+        // If the denominator is zero, this will fail with a divide-by-zero
+        // error.
+        let quotient = scaled_numerator / scaled_denominator;
+        // Check for underflow. Truncating to zero might be the desired result,
+        // but if you really want a ratio of zero, it is easy to create that
+        // from a raw value.
+        Transaction::assert(quotient != 0 || numerator == 0, 16);
+        // This can overflow because the non-fractional part of the quotient
+        // only has 32 bits; check that.
+        Transaction::assert((quotient >> 64) == 0, 16);
+        T { value: (quotient as u64) }
+    }
+
+    public fun create_from_raw_value(value: u64): T {
+        T { value }
+    }
+
+    // Accessor for the raw u64 value. Other less common operations, such as
+    // adding or subtracting FixedPoint32 values, can be done using the raw
+    // values directly.
+    public fun get_raw_value(num: T): u64 {
+        num.value
+    }
+}


### PR DESCRIPTION
This adds a fixed-point numeric type with 32 fractional bits. This can be used for things like interest rates, conversion rates, etc. Besides functions to create these fixed-point values, this provides basic truncating multiply and divide functions.

## Motivation

Add support for non-integer values in a fixed-point representation.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

Added some new tests for this module, including all the interesting corner cases that I could think of.