### PR TITLE
[crypto] MultiEd25519 support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2278,6 +2278,7 @@ name = "libra-crypto"
 version = "0.1.0"
 dependencies = [
  "anyhow 1.0.26 (registry+https://github.com/rust-lang/crates.io-index)",
+ "bit-vec 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "bitvec 0.17.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "byteorder 1.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "bytes 0.5.4 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/crypto/crypto/Cargo.toml
+++ b/crypto/crypto/Cargo.toml
@@ -11,6 +11,7 @@ edition = "2018"
 
 [dependencies]
 anyhow = "1.0"
+bit-vec = "0.6.1"
 byteorder = "1.3.2"
 bytes = "0.5.4"
 curve25519-dalek = { git = "https://github.com/calibra/curve25519-dalek.git", branch = "fiat", default-features = false }

--- a/crypto/crypto/src/ed25519.rs
+++ b/crypto/crypto/src/ed25519.rs
@@ -198,7 +198,9 @@ impl TryFrom<&[u8]> for Ed25519PrivateKey {
 }
 
 impl Length for Ed25519PrivateKey {
-    const LENGTH: usize = ed25519_dalek::SECRET_KEY_LENGTH;
+    fn length(&self) -> usize {
+        ED25519_PRIVATE_KEY_LENGTH
+    }
 }
 
 impl ValidKey for Ed25519PrivateKey {
@@ -221,8 +223,8 @@ impl Genesis for Ed25519PrivateKey {
 
 // Implementing From<&PrivateKey<...>> allows to derive a public key in a more elegant fashion
 impl From<&Ed25519PrivateKey> for Ed25519PublicKey {
-    fn from(secret_key: &Ed25519PrivateKey) -> Self {
-        let secret: &ed25519_dalek::SecretKey = &secret_key.0;
+    fn from(private_key: &Ed25519PrivateKey) -> Self {
+        let secret: &ed25519_dalek::SecretKey = &private_key.0;
         let public: ed25519_dalek::PublicKey = secret.into();
         Ed25519PublicKey(public)
     }
@@ -302,7 +304,9 @@ impl TryFrom<&[u8]> for Ed25519PublicKey {
 }
 
 impl Length for Ed25519PublicKey {
-    const LENGTH: usize = ed25519_dalek::PUBLIC_KEY_LENGTH;
+    fn length(&self) -> usize {
+        ED25519_PUBLIC_KEY_LENGTH
+    }
 }
 
 impl ValidKey for Ed25519PublicKey {
@@ -367,7 +371,9 @@ impl Signature for Ed25519Signature {
 }
 
 impl Length for Ed25519Signature {
-    const LENGTH: usize = ED25519_SIGNATURE_LENGTH;
+    fn length(&self) -> usize {
+        ED25519_SIGNATURE_LENGTH
+    }
 }
 
 impl ValidKey for Ed25519Signature {
@@ -378,8 +384,8 @@ impl ValidKey for Ed25519Signature {
 
 impl std::hash::Hash for Ed25519Signature {
     fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
-        let encoded_pubkey = self.to_bytes();
-        state.write(&encoded_pubkey);
+        let encoded_signature = self.to_bytes();
+        state.write(&encoded_signature);
     }
 }
 

--- a/crypto/crypto/src/lib.rs
+++ b/crypto/crypto/src/lib.rs
@@ -11,6 +11,7 @@ pub mod ed25519;
 pub mod error;
 pub mod hash;
 pub mod hkdf;
+pub mod multi_ed25519;
 pub mod slip0010;
 pub mod traits;
 pub mod vrf;

--- a/crypto/crypto/src/multi_ed25519.rs
+++ b/crypto/crypto/src/multi_ed25519.rs
@@ -303,7 +303,7 @@ impl MultiEd25519Signature {
             return Err(CryptoMaterialError::WrongLengthError);
         }
 
-        let mut sorted_signatures = signatures.clone();
+        let mut sorted_signatures = signatures;
         sorted_signatures.sort_by(|a, b| a.1.cmp(&b.1));
 
         let mut sigvec: Vec<Ed25519Signature> = Vec::with_capacity(num_of_sigs);
@@ -315,13 +315,13 @@ impl MultiEd25519Signature {
             if item.1 < MAX_NUM_OF_KEYS as u8 {
                 // if an index has been set already (thus, there is a duplicate).
                 if bitvec[i] {
-                    return Err(CryptoMaterialError::FormatError);
+                    return Err(CryptoMaterialError::BitVecError);
                 } else {
                     sigvec[i] = item.0.clone();
                     bitvec.set(i, true);
                 }
             } else {
-                return Err(CryptoMaterialError::FormatError);
+                return Err(CryptoMaterialError::BitVecError);
             }
         }
         Ok(MultiEd25519Signature(sigvec, bitvec))

--- a/crypto/crypto/src/multi_ed25519.rs
+++ b/crypto/crypto/src/multi_ed25519.rs
@@ -1,0 +1,547 @@
+// Copyright (c) The Libra Core Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+//! This module provides an API for the accountable threshold multi-sig PureEdDSA signature scheme
+//! over the ed25519 twisted Edwards curve as defined in [RFC8032](https://tools.ietf.org/html/rfc8032).
+//!
+//! Signature verification also checks and rejects non-canonical signatures.
+
+use crate::ed25519::{
+    Ed25519PrivateKey, Ed25519PublicKey, Ed25519Signature, ED25519_PRIVATE_KEY_LENGTH,
+    ED25519_PUBLIC_KEY_LENGTH, ED25519_SIGNATURE_LENGTH,
+};
+use crate::{traits::*, HashValue};
+use anyhow::{anyhow, Result};
+use bit_vec::BitVec;
+use core::convert::TryFrom;
+use libra_crypto_derive::{DeserializeKey, SerializeKey, SilentDebug, SilentDisplay};
+use once_cell::sync::Lazy;
+use std::fmt;
+
+const MAX_NUM_OF_KEYS: usize = 32;
+const BITVEC_NUM_OF_BYTES: usize = MAX_NUM_OF_KEYS / 8;
+static BITVEC_FIRST_KEY_SET: Lazy<BitVec> =
+    Lazy::new(|| BitVec::from_bytes(&[0b1000_0000, 0b0000_0000, 0b0000_0000, 0b0000_0000]));
+
+/// Vector of private keys in the multi-key Ed25519 structure along with the threshold.
+#[derive(DeserializeKey, SilentDisplay, SilentDebug, SerializeKey)]
+pub struct MultiEd25519PrivateKey(Vec<Ed25519PrivateKey>, u8);
+
+#[cfg(feature = "assert-private-keys-not-cloneable")]
+static_assertions::assert_not_impl_any!(MultiEd25519PrivateKey: Clone);
+
+/// Vector of public keys in the multi-key Ed25519 structure along with the threshold.
+#[derive(DeserializeKey, Clone, SerializeKey)]
+pub struct MultiEd25519PublicKey(pub(crate) Vec<Ed25519PublicKey>, pub(crate) u8);
+
+/// Vector of the multi-key signatures along with their index required to map signatures with
+/// their corresponding public keys.
+#[derive(DeserializeKey, Clone, SerializeKey)]
+pub struct MultiEd25519Signature(pub(crate) Vec<Ed25519Signature>, pub(crate) BitVec);
+
+impl MultiEd25519PrivateKey {
+    /// Construct a new MultiEd25519PrivateKey.
+    pub fn new(
+        private_keys: Vec<Ed25519PrivateKey>,
+        threshold: u8,
+    ) -> std::result::Result<Self, CryptoMaterialError> {
+        let num_of_keys = private_keys.len();
+        if threshold != 0 && num_of_keys >= threshold as usize && num_of_keys <= MAX_NUM_OF_KEYS {
+            Ok(MultiEd25519PrivateKey(private_keys, threshold))
+        } else {
+            Err(CryptoMaterialError::WrongLengthError)
+        }
+    }
+
+    /// Serialize a MultiEd25519PrivateKey.
+    pub fn to_bytes(&self) -> Vec<u8> {
+        to_bytes(&self.0, self.1)
+    }
+}
+
+impl MultiEd25519PublicKey {
+    /// Construct a new MultiEd25519PublicKey.
+    /// --- Rules ---
+    /// a) threshold cannot be zero.
+    /// b) public_keys.len() should be equal to or larger than threshold.
+    /// c) support up to MAX_NUM_OF_KEYS public keys.
+    pub fn new(
+        public_keys: Vec<Ed25519PublicKey>,
+        threshold: u8,
+    ) -> std::result::Result<Self, CryptoMaterialError> {
+        let num_of_keys = public_keys.len();
+        if threshold != 0 && num_of_keys >= threshold as usize && num_of_keys <= MAX_NUM_OF_KEYS {
+            Ok(MultiEd25519PublicKey(public_keys, threshold))
+        } else {
+            Err(CryptoMaterialError::WrongLengthError)
+        }
+    }
+
+    /// Serialize a MultiEd25519PublicKey.
+    pub fn to_bytes(&self) -> Vec<u8> {
+        to_bytes(&self.0, self.1)
+    }
+}
+
+///////////////////////
+// PrivateKey Traits //
+///////////////////////
+
+impl PrivateKey for MultiEd25519PrivateKey {
+    type PublicKeyMaterial = MultiEd25519PublicKey;
+}
+
+impl SigningKey for MultiEd25519PrivateKey {
+    type VerifyingKeyMaterial = MultiEd25519PublicKey;
+    type SignatureMaterial = MultiEd25519Signature;
+
+    // Sign a message with the minimum amount of keys to meet threshold (starting from left-most keys).
+    fn sign_message(&self, message: &HashValue) -> MultiEd25519Signature {
+        let mut ed25519_signatures: Vec<Ed25519Signature> = Vec::with_capacity(self.1 as usize);
+        let mut bitvec = BitVec::from_elem(MAX_NUM_OF_KEYS, false);
+
+        for (i, item) in self.0.iter().enumerate() {
+            if i < self.1 as usize {
+                ed25519_signatures.push(item.sign_message(message));
+                bitvec.set(i, true);
+            } else {
+                break;
+            }
+        }
+        MultiEd25519Signature(ed25519_signatures, bitvec)
+    }
+}
+
+// Generating a random 2 out-of 3 key for testing.
+impl Uniform for MultiEd25519PrivateKey {
+    fn generate_for_testing<R>(rng: &mut R) -> Self
+    where
+        R: ::rand::SeedableRng + ::rand::RngCore + ::rand::CryptoRng,
+    {
+        let mut private_keys: Vec<Ed25519PrivateKey> = Vec::with_capacity(3);
+        for _ in 0..3 {
+            private_keys.push(
+                Ed25519PrivateKey::try_from(
+                    &ed25519_dalek::SecretKey::generate(rng).to_bytes()[..],
+                )
+                .unwrap(),
+            );
+        }
+        MultiEd25519PrivateKey(private_keys, 2)
+    }
+}
+
+impl PartialEq<Self> for MultiEd25519PrivateKey {
+    fn eq(&self, other: &Self) -> bool {
+        self.to_bytes() == other.to_bytes()
+    }
+}
+
+impl Eq for MultiEd25519PrivateKey {}
+
+// We could have a distinct kind of validation for the PrivateKey, for
+// ex. checking the derived PublicKey is valid?
+impl TryFrom<&[u8]> for MultiEd25519PrivateKey {
+    type Error = CryptoMaterialError;
+
+    /// Deserialize an Ed25519PrivateKey. This method will also check for key and threshold validity.
+    fn try_from(bytes: &[u8]) -> std::result::Result<MultiEd25519PrivateKey, CryptoMaterialError> {
+        let payload_length = bytes.len();
+        // Special case for single keys to speed up deserialization.
+        if payload_length == ED25519_PRIVATE_KEY_LENGTH {
+            return Ed25519PrivateKey::try_from(bytes)
+                .map(|private_key| MultiEd25519PrivateKey(vec![private_key], 1u8));
+        }
+
+        let threshold = get_threshold(
+            payload_length,
+            ED25519_PRIVATE_KEY_LENGTH,
+            bytes[payload_length - 1],
+        )?;
+
+        let mut private_keys: Vec<Ed25519PrivateKey> = vec![];
+        let multi_key = bytes
+            .chunks(ED25519_PRIVATE_KEY_LENGTH)
+            .filter(|chunk| chunk.len() == ED25519_PRIVATE_KEY_LENGTH)
+            .try_for_each(|key_bytes| deserialize_and_push(key_bytes, &mut private_keys));
+
+        multi_key.map(|_| MultiEd25519PrivateKey(private_keys, threshold))
+    }
+}
+
+impl Length for MultiEd25519PrivateKey {
+    fn length(&self) -> usize {
+        self.to_bytes().len()
+    }
+}
+
+impl ValidKey for MultiEd25519PrivateKey {
+    fn to_bytes(&self) -> Vec<u8> {
+        self.to_bytes()
+    }
+}
+
+impl Genesis for MultiEd25519PrivateKey {
+    fn genesis() -> Self {
+        let mut buf = [0u8; ED25519_PRIVATE_KEY_LENGTH];
+        buf[ED25519_PRIVATE_KEY_LENGTH - 1] = 1;
+        MultiEd25519PrivateKey(vec![Ed25519PrivateKey::try_from(buf.as_ref()).unwrap()], 1)
+    }
+}
+
+//////////////////////
+// PublicKey Traits //
+//////////////////////
+
+/// Convenient method to create a MultiEd25519PublicKey from a single Ed25519PublicKey.
+impl From<&Ed25519PublicKey> for MultiEd25519PublicKey {
+    fn from(ed_public_key: &Ed25519PublicKey) -> Self {
+        MultiEd25519PublicKey(vec![ed_public_key.clone()], 1u8)
+    }
+}
+
+/// Implementing From<&PrivateKey<...>> allows to derive a public key in a more elegant fashion.
+impl From<&MultiEd25519PrivateKey> for MultiEd25519PublicKey {
+    fn from(private_key: &MultiEd25519PrivateKey) -> Self {
+        let public_key = private_key
+            .0
+            .iter()
+            .map(|ed_private_key| ed_private_key.public_key())
+            .collect();
+        MultiEd25519PublicKey(public_key, private_key.1)
+    }
+}
+
+/// We deduce PublicKey from this.
+impl PublicKey for MultiEd25519PublicKey {
+    type PrivateKeyMaterial = MultiEd25519PrivateKey;
+}
+
+/// Get the hash output of the serialized MultiEd25519PublicKey.
+impl std::hash::Hash for MultiEd25519PublicKey {
+    fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
+        let encoded_pubkey = self.to_bytes();
+        state.write(&encoded_pubkey);
+    }
+}
+
+// Those are required by the implementation of hash above.
+impl PartialEq for MultiEd25519PublicKey {
+    fn eq(&self, other: &MultiEd25519PublicKey) -> bool {
+        self.to_bytes() == other.to_bytes()
+    }
+}
+
+impl Eq for MultiEd25519PublicKey {}
+
+impl TryFrom<&[u8]> for MultiEd25519PublicKey {
+    type Error = CryptoMaterialError;
+
+    /// Deserialize a MultiEd25519PublicKey. This method will also check for key and threshold
+    /// validity, and will only deserialize keys that are safe against small subgroup attacks.
+    fn try_from(bytes: &[u8]) -> std::result::Result<MultiEd25519PublicKey, CryptoMaterialError> {
+        let payload_length = bytes.len();
+        // Special case for single keys to speed up deserialization.
+        if payload_length == ED25519_PUBLIC_KEY_LENGTH {
+            return Ed25519PublicKey::try_from(bytes)
+                .map(|public_key| MultiEd25519PublicKey(vec![public_key], 1u8));
+        }
+        let threshold = get_threshold(
+            payload_length,
+            ED25519_PRIVATE_KEY_LENGTH,
+            bytes[payload_length - 1],
+        )?;
+
+        let mut public_keys: Vec<Ed25519PublicKey> = vec![];
+        let multi_key = bytes
+            .chunks(ED25519_PUBLIC_KEY_LENGTH)
+            .filter(|chunk| chunk.len() == ED25519_PUBLIC_KEY_LENGTH)
+            .try_for_each(|key_bytes| deserialize_and_push(key_bytes, &mut public_keys));
+
+        multi_key.map(|_| MultiEd25519PublicKey(public_keys, threshold))
+    }
+}
+
+/// We deduce VerifyingKey from pointing to the signature material
+/// we get the ability to do `pubkey.validate(msg, signature)`
+impl VerifyingKey for MultiEd25519PublicKey {
+    type SigningKeyMaterial = MultiEd25519PrivateKey;
+    type SignatureMaterial = MultiEd25519Signature;
+}
+
+impl fmt::Display for MultiEd25519PublicKey {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}", hex::encode(&self.to_bytes()))
+    }
+}
+
+impl fmt::Debug for MultiEd25519PublicKey {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "MultiEd25519PublicKey({})", self)
+    }
+}
+
+impl Length for MultiEd25519PublicKey {
+    fn length(&self) -> usize {
+        self.to_bytes().len()
+    }
+}
+
+impl ValidKey for MultiEd25519PublicKey {
+    fn to_bytes(&self) -> Vec<u8> {
+        self.to_bytes()
+    }
+}
+
+impl MultiEd25519Signature {
+    /// This method will also sort signatures based on index.
+    pub fn new(
+        signatures: Vec<(Ed25519Signature, u8)>,
+    ) -> std::result::Result<Self, CryptoMaterialError> {
+        let num_of_sigs = signatures.len();
+        if num_of_sigs == 0 || num_of_sigs > MAX_NUM_OF_KEYS {
+            return Err(CryptoMaterialError::WrongLengthError);
+        }
+
+        let mut sorted_signatures = signatures.clone();
+        sorted_signatures.sort_by(|a, b| a.1.cmp(&b.1));
+
+        let mut sigvec: Vec<Ed25519Signature> = Vec::with_capacity(num_of_sigs);
+        let mut bitvec = BitVec::from_elem(MAX_NUM_OF_KEYS, false);
+
+        // Check if all indexes are unique and < MAX_NUM_OF_KEYS
+        for (i, item) in sorted_signatures.iter().enumerate() {
+            // If an index is out of range.
+            if item.1 < MAX_NUM_OF_KEYS as u8 {
+                // if an index has been set already (thus, there is a duplicate).
+                if bitvec[i] {
+                    return Err(CryptoMaterialError::FormatError);
+                } else {
+                    sigvec[i] = item.0.clone();
+                    bitvec.set(i, true);
+                }
+            } else {
+                return Err(CryptoMaterialError::FormatError);
+            }
+        }
+        Ok(MultiEd25519Signature(sigvec, bitvec))
+    }
+
+    /// Serialize a MultiEd25519Signature in the form of sig0||sig1||..sigN||bitvec.
+    /// Note that we omit bitvec if all bits from index = zero to index = signatures.len() - 1
+    /// are set.
+    pub fn to_bytes(&self) -> Vec<u8> {
+        let mut bytes: Vec<u8> = vec![];
+        self.0.iter().for_each(|signature| {
+            bytes.extend(signature.to_bytes().to_vec());
+        });
+        // TODO compress even more, i.e., we don't always need up to 4bytes for bitvec.
+        // No need to attach the bitvector when there is no gap between the indexes.
+        if (0..self.0.len()).any(|i| !self.1[i]) {
+            bytes.extend(self.1.to_bytes());
+        }
+        bytes
+    }
+}
+
+impl TryFrom<&[u8]> for MultiEd25519Signature {
+    type Error = CryptoMaterialError;
+
+    /// Deserialize a MultiEd25519Signature. This method will also check for bitvec validity.
+    fn try_from(bytes: &[u8]) -> std::result::Result<MultiEd25519Signature, CryptoMaterialError> {
+        let length = bytes.len();
+        // Special case for single signatures to speed up deserialization.
+        if length == ED25519_SIGNATURE_LENGTH {
+            return Ed25519Signature::try_from(bytes).map(|signature| {
+                MultiEd25519Signature(vec![signature], BITVEC_FIRST_KEY_SET.clone())
+            });
+        }
+        let bitvec_num_of_bytes = length % ED25519_SIGNATURE_LENGTH;
+        let num_of_sigs = length / ED25519_SIGNATURE_LENGTH;
+
+        if num_of_sigs == 0
+            || num_of_sigs > MAX_NUM_OF_KEYS
+            || (bitvec_num_of_bytes != 0 && bitvec_num_of_bytes != BITVEC_NUM_OF_BYTES)
+        {
+            return Err(CryptoMaterialError::WrongLengthError);
+        }
+
+        let bitvec: BitVec = if bitvec_num_of_bytes == BITVEC_NUM_OF_BYTES {
+            let temp = BitVec::from_bytes(&bytes[length - 4..length]);
+            let count_set_bits = count_set_bits(&temp);
+            if count_set_bits != num_of_sigs || count_set_bits != 0 {
+                return Err(CryptoMaterialError::DeserializationError);
+            }
+            temp
+        } else {
+            let mut temp = BitVec::from_elem(MAX_NUM_OF_KEYS, false);
+            for i in 0..num_of_sigs {
+                temp.set(i, true);
+            }
+            temp
+        };
+
+        let mut signatures: Vec<Ed25519Signature> = vec![];
+        let multi_signature = bytes
+            .chunks(ED25519_SIGNATURE_LENGTH)
+            .filter(|chunk| chunk.len() == ED25519_SIGNATURE_LENGTH)
+            .try_for_each(|sig_bytes| deserialize_and_push(sig_bytes, &mut signatures));
+
+        multi_signature.map(|_| MultiEd25519Signature(signatures, bitvec))
+    }
+}
+
+impl Length for MultiEd25519Signature {
+    fn length(&self) -> usize {
+        self.to_bytes().len()
+    }
+}
+
+impl std::hash::Hash for MultiEd25519Signature {
+    fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
+        let encoded_signature = self.to_bytes();
+        state.write(&encoded_signature);
+    }
+}
+
+// Those are required by the implementation of hash above.
+impl PartialEq for MultiEd25519Signature {
+    fn eq(&self, other: &MultiEd25519Signature) -> bool {
+        self.to_bytes() == other.to_bytes()
+    }
+}
+
+impl Eq for MultiEd25519Signature {}
+
+impl fmt::Display for MultiEd25519Signature {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}", hex::encode(&self.to_bytes()[..]))
+    }
+}
+
+impl fmt::Debug for MultiEd25519Signature {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "MultiEd25519Signature({})", self)
+    }
+}
+
+impl ValidKey for MultiEd25519Signature {
+    fn to_bytes(&self) -> Vec<u8> {
+        self.to_bytes()
+    }
+}
+
+//////////////////////
+// Signature Traits //
+//////////////////////
+
+impl Signature for MultiEd25519Signature {
+    type VerifyingKeyMaterial = MultiEd25519PublicKey;
+    type SigningKeyMaterial = MultiEd25519PrivateKey;
+
+    /// Checks that `self` is valid for `message` using `public_key`.
+    fn verify(&self, message: &HashValue, public_key: &MultiEd25519PublicKey) -> Result<()> {
+        self.verify_arbitrary_msg(message.as_ref(), public_key)
+    }
+
+    /// Checks that `self` is valid for an arbitrary &[u8] `message` using `public_key`.
+    /// Outside of this crate, this particular function should only be used for native signature
+    /// verification in Move.
+    fn verify_arbitrary_msg(
+        &self,
+        message: &[u8],
+        public_key: &MultiEd25519PublicKey,
+    ) -> Result<()> {
+        if last_bit_set(&self.1) > public_key.length()
+            || count_set_bits(&self.1) < public_key.1 as usize
+        {
+            return Err(anyhow!("{}", CryptoMaterialError::ValidationError));
+        }
+        let mut bitvec_index = 0;
+        // TODO use deterministic batch verification
+        for sig in &self.0 {
+            while !self.1[bitvec_index] {
+                bitvec_index += 1;
+            }
+            sig.verify_arbitrary_msg(message, &public_key.0[bitvec_index])?;
+            bitvec_index += 1;
+        }
+        Ok(())
+    }
+
+    fn to_bytes(&self) -> Vec<u8> {
+        self.to_bytes()
+    }
+}
+
+//////////////////////
+// Helper functions //
+//////////////////////
+
+// Helper function required to MultiEd25519 keys to_bytes to add or omit the threshold.
+fn to_bytes<T: ValidKey>(keys: &[T], threshold: u8) -> Vec<u8> {
+    let mut bytes: Vec<u8> = vec![];
+    keys.iter().for_each(|key| {
+        bytes.extend(key.to_bytes());
+    });
+    // No need to attach the threshold in N out-of N.
+    if keys.len() > threshold as usize {
+        bytes.push(threshold);
+    }
+    bytes
+}
+
+// Helper method to count bitvec's set bits in MultiEd25519 signatures.
+fn count_set_bits(bitvec: &BitVec) -> usize {
+    let mut count: usize = 0;
+    for bit in bitvec.iter() {
+        if bit {
+            count += 1;
+        }
+    }
+    count
+}
+
+fn last_bit_set(bitvec: &BitVec) -> usize {
+    let mut last_bit: usize = 0; // This is fine as we expect at least one set bit.
+    for (i, bit) in bitvec.iter().enumerate() {
+        if bit {
+            last_bit = i;
+        }
+    }
+    last_bit
+}
+
+// Helper method to get threshold from a serialized MultiEd25519 key payload.
+fn get_threshold(
+    payload_length: usize,
+    key_size: usize,
+    byte: u8,
+) -> std::result::Result<u8, CryptoMaterialError> {
+    let threshold_num_of_bytes = payload_length % key_size;
+    let num_of_keys = payload_length / key_size;
+
+    if num_of_keys == 0 || num_of_keys > MAX_NUM_OF_KEYS || threshold_num_of_bytes > 1 {
+        return Err(CryptoMaterialError::WrongLengthError);
+    }
+
+    if threshold_num_of_bytes == 1 {
+        // We don't attach the threshold on N out-of N as well.
+        if byte >= num_of_keys as u8 {
+            return Err(CryptoMaterialError::WrongLengthError);
+        }
+        Ok(byte)
+    } else {
+        Ok(num_of_keys as u8)
+    }
+}
+
+// Helper function required to MultiEd25519 keys and signature try_from.
+fn deserialize_and_push<'a, T: TryFrom<&'a [u8], Error = CryptoMaterialError>>(
+    bytes: &'a [u8],
+    keys: &mut Vec<T>,
+) -> std::result::Result<(), CryptoMaterialError> {
+    T::try_from(bytes).map(|key| {
+        keys.push(key);
+    })
+}

--- a/crypto/crypto/src/traits.rs
+++ b/crypto/crypto/src/traits.rs
@@ -35,10 +35,8 @@ pub enum CryptoMaterialError {
     SmallSubgroupError,
     /// A curve point (i.e., a public key) does not satisfy the curve equation.
     PointNotOnCurveError,
-    /// BitVec mismatch error in accountable multi-sig schemes.
-    WrongBitVecError,
-    /// Key or signature material is not in the correct format.
-    FormatError,
+    /// BitVec errors in accountable multi-sig schemes.
+    BitVecError,
 }
 
 /// The serialized length of the data that enables macro derived serialization and deserialization.

--- a/crypto/crypto/src/traits.rs
+++ b/crypto/crypto/src/traits.rs
@@ -36,7 +36,7 @@ pub enum CryptoMaterialError {
     /// A curve point (i.e., a public key) does not satisfy the curve equation.
     PointNotOnCurveError,
     /// BitVec errors in accountable multi-sig schemes.
-    BitVecError,
+    BitVecError(String),
 }
 
 /// The serialized length of the data that enables macro derived serialization and deserialization.

--- a/crypto/crypto/src/traits.rs
+++ b/crypto/crypto/src/traits.rs
@@ -27,7 +27,7 @@ pub enum CryptoMaterialError {
     DeserializationError,
     /// Key or signature material deserializes, but is otherwise not valid.
     ValidationError,
-    /// Key or signature material does not have the expected size.
+    /// Key, threshold or signature material does not have the expected size.
     WrongLengthError,
     /// Part of the signature or key is not canonical resulting to malleability issues.
     CanonicalRepresentationError,
@@ -35,12 +35,16 @@ pub enum CryptoMaterialError {
     SmallSubgroupError,
     /// A curve point (i.e., a public key) does not satisfy the curve equation.
     PointNotOnCurveError,
+    /// BitVec mismatch error in accountable multi-sig schemes.
+    WrongBitVecError,
+    /// Key or signature material is not in the correct format.
+    FormatError,
 }
 
 /// The serialized length of the data that enables macro derived serialization and deserialization.
 pub trait Length {
     /// The serialized length of the data
-    const LENGTH: usize;
+    fn length(&self) -> usize;
 }
 
 /// Key or more generally crypto material with a notion of byte validation.

--- a/crypto/crypto/src/unit_tests/ed25519_test.rs
+++ b/crypto/crypto/src/unit_tests/ed25519_test.rs
@@ -2,7 +2,10 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::{
-    ed25519::{Ed25519PrivateKey, Ed25519PublicKey, Ed25519Signature},
+    ed25519::{
+        Ed25519PrivateKey, Ed25519PublicKey, Ed25519Signature, ED25519_PRIVATE_KEY_LENGTH,
+        ED25519_PUBLIC_KEY_LENGTH, ED25519_SIGNATURE_LENGTH,
+    },
     traits::*,
     unit_tests::uniform_keypair_strategy,
 };
@@ -21,14 +24,14 @@ proptest! {
         {
             let encoded = keypair.private_key.to_encoded_string().unwrap();
              // Hex encoding of a 32-bytes key is 64 (2 x 32) characters.
-            prop_assert_eq!(2 * ed25519_dalek::SECRET_KEY_LENGTH, encoded.len());
+            prop_assert_eq!(2 * ED25519_PRIVATE_KEY_LENGTH, encoded.len());
             let decoded = Ed25519PrivateKey::from_encoded_string(&encoded);
             prop_assert_eq!(Some(keypair.private_key), decoded.ok());
         }
         {
             let encoded = keypair.public_key.to_encoded_string().unwrap();
             // Hex encoding of a 32-bytes key is 64 (2 x 32) characters.
-            prop_assert_eq!(2 * ed25519_dalek::PUBLIC_KEY_LENGTH, encoded.len());
+            prop_assert_eq!(2 * ED25519_PUBLIC_KEY_LENGTH, encoded.len());
             let decoded = Ed25519PublicKey::from_encoded_string(&encoded);
             prop_assert_eq!(Some(keypair.public_key), decoded.ok());
         }
@@ -56,13 +59,13 @@ proptest! {
     ) {
         {
             let serialized: &[u8] = &(keypair.private_key.to_bytes());
-            prop_assert_eq!(ed25519_dalek::SECRET_KEY_LENGTH, serialized.len());
+            prop_assert_eq!(ED25519_PRIVATE_KEY_LENGTH, serialized.len());
             let deserialized = Ed25519PrivateKey::try_from(serialized);
             prop_assert_eq!(Some(keypair.private_key), deserialized.ok());
         }
         {
             let serialized: &[u8] = &(keypair.public_key.to_bytes());
-            prop_assert_eq!(ed25519_dalek::PUBLIC_KEY_LENGTH, serialized.len());
+            prop_assert_eq!(ED25519_PUBLIC_KEY_LENGTH, serialized.len());
             let deserialized = Ed25519PublicKey::try_from(serialized);
             prop_assert_eq!(Some(keypair.public_key), deserialized.ok());
         }
@@ -75,7 +78,7 @@ proptest! {
     ) {
         let signature = keypair.private_key.sign_message(&hash);
         let serialized: &[u8] = &(signature.to_bytes());
-        prop_assert_eq!(ed25519_dalek::SIGNATURE_LENGTH, serialized.len());
+        prop_assert_eq!(ED25519_SIGNATURE_LENGTH, serialized.len());
         let deserialized = Ed25519Signature::try_from(serialized).unwrap();
         prop_assert!(keypair.public_key.verify_signature(&hash, &deserialized).is_ok());
     }
@@ -232,7 +235,7 @@ impl Scalar52 {
         let mut words = [0u64; 4];
         for i in 0..4 {
             for j in 0..8 {
-                words[i] |= u64::from(bytes[(i * 8) + j]) << (j * 8);
+                words[i] |= u64::from(bytes[(i * 8) + j]) << (j * 8) as u64;
             }
         }
 

--- a/crypto/crypto/src/unit_tests/mod.rs
+++ b/crypto/crypto/src/unit_tests/mod.rs
@@ -5,6 +5,7 @@ mod bls12381_test;
 mod cross_test;
 mod ed25519_test;
 mod hkdf_test;
+mod multi_ed25519_test;
 mod slip0010_test;
 mod x25519_test;
 

--- a/crypto/crypto/src/unit_tests/multi_ed25519_test.rs
+++ b/crypto/crypto/src/unit_tests/multi_ed25519_test.rs
@@ -13,120 +13,189 @@ use crate::ed25519::{compat, ED25519_PUBLIC_KEY_LENGTH};
 use crate::hash::HashValue;
 use crate::multi_ed25519::{MultiEd25519PrivateKey, MultiEd25519PublicKey};
 use crate::test_utils::TEST_SEED;
+use crate::CryptoMaterialError::{ValidationError, WrongLengthError};
 
-// Test multi-sig Ed25519 serialization.
+// Helper function to generate N key pairs.
+fn generate_key_pairs(n: usize) -> Vec<(Ed25519PrivateKey, Ed25519PublicKey)> {
+    let mut rng = StdRng::from_seed(TEST_SEED);
+    (0..n).map(|_| compat::generate_keypair(&mut rng)).collect()
+}
+
+// Reused assertions in our tests.
+fn test_successful_public_key_serialization(original_keys: &[Ed25519PublicKey], threshold: u8) {
+    let n = original_keys.len();
+    let public_key: MultiEd25519PublicKey =
+        MultiEd25519PublicKey::new(original_keys.to_vec(), threshold).unwrap();
+    assert_eq!(public_key.threshold(), &threshold);
+    assert_eq!(public_key.public_keys().len(), n);
+    assert_eq!(public_key.public_keys(), &original_keys.to_vec());
+    let serialized = public_key.to_bytes();
+    assert_eq!(serialized.len(), n * ED25519_PUBLIC_KEY_LENGTH + 1);
+    let reserialized = MultiEd25519PublicKey::try_from(&serialized[..]);
+    assert!(reserialized.is_ok());
+    assert_eq!(public_key, reserialized.unwrap());
+}
+
+fn test_failed_public_key_serialization(
+    result: std::result::Result<MultiEd25519PublicKey, CryptoMaterialError>,
+    expected_error: CryptoMaterialError,
+) {
+    assert!(result.is_err());
+    assert_eq!(result.err().unwrap(), expected_error);
+}
+
+// Test multi-sig Ed25519 public key serialization.
+#[allow(clippy::redundant_clone)]
 #[test]
 fn test_multi_ed25519_public_key_serialization() {
-    let mut rng = StdRng::from_seed(TEST_SEED);
+    let pub_keys_1: Vec<Ed25519PublicKey> =
+        generate_key_pairs(1).iter().map(|x| x.1.clone()).collect();
+    let pub_keys_10: Vec<Ed25519PublicKey> =
+        generate_key_pairs(10).iter().map(|x| x.1.clone()).collect();
+    let pub_keys_32: Vec<Ed25519PublicKey> =
+        generate_key_pairs(32).iter().map(|x| x.1.clone()).collect();
+    let pub_keys_33: Vec<Ed25519PublicKey> =
+        generate_key_pairs(33).iter().map(|x| x.1.clone()).collect();
 
-    let mut pub_keys: Vec<Ed25519PublicKey> = vec![];
-    for _ in 0..10 {
-        pub_keys.push(compat::generate_keypair(&mut rng).1);
-    }
+    // Test 1-of-1
+    test_successful_public_key_serialization(&pub_keys_1, 1);
+    // Test 1-of-10
+    test_successful_public_key_serialization(&pub_keys_10, 1);
+    // Test 7-of-10
+    test_successful_public_key_serialization(&pub_keys_10, 7);
+    // Test 10-of-10
+    test_successful_public_key_serialization(&pub_keys_10, 10);
+    // Test 2-of-32
+    test_successful_public_key_serialization(&pub_keys_32, 2);
+    // Test 32-of-32
+    test_successful_public_key_serialization(&pub_keys_32, 32);
 
-    #[allow(clippy::redundant_clone)]
-    let multi_key_1of10 = MultiEd25519PublicKey::new(pub_keys.clone(), 1);
-    let serialized_1of10 = MultiEd25519PublicKey::to_bytes(&multi_key_1of10.unwrap());
-    assert_eq!(serialized_1of10.len(), 10 * ED25519_PUBLIC_KEY_LENGTH + 1);
+    // Test 11-of-10 (should fail).
+    let multi_key_11of10 = MultiEd25519PublicKey::new(pub_keys_10.clone(), 11);
+    test_failed_public_key_serialization(multi_key_11of10, ValidationError);
 
-    #[allow(clippy::redundant_clone)]
-    let multi_key_10of10 = MultiEd25519PublicKey::new(pub_keys.clone(), 10);
-    let mut serialized_10of10 = MultiEd25519PublicKey::to_bytes(&multi_key_10of10.unwrap());
-    assert_eq!(serialized_10of10.len(), 10 * ED25519_PUBLIC_KEY_LENGTH);
+    // Test 0-of-10 (should fail).
+    let multi_key_0of10 = MultiEd25519PublicKey::new(pub_keys_10.clone(), 0);
+    test_failed_public_key_serialization(multi_key_0of10, ValidationError);
 
-    let multi_key_1of10_new = MultiEd25519PublicKey::try_from(serialized_1of10.as_slice());
-    let multi_key_10of10_new = MultiEd25519PublicKey::try_from(serialized_10of10.as_slice());
+    // Test 1-of-33 (should fail).
+    let multi_key_1of33 = MultiEd25519PublicKey::new(pub_keys_33.clone(), 1);
+    test_failed_public_key_serialization(multi_key_1of33, WrongLengthError);
 
-    assert!(&multi_key_1of10_new.is_ok());
-    assert!(&multi_key_10of10_new.is_ok());
+    // Test try_from empty bytes (should fail).
+    let multi_key_empty_bytes = MultiEd25519PublicKey::try_from(&[] as &[u8]);
+    test_failed_public_key_serialization(multi_key_empty_bytes, WrongLengthError);
 
-    let multi_key_1of10_new = multi_key_1of10_new.unwrap();
-    let multi_key_10of10_new = multi_key_10of10_new.unwrap();
+    // Test try_from 1 byte (should fail).
+    let multi_key_1_byte = MultiEd25519PublicKey::try_from(&[0u8][..]);
+    test_failed_public_key_serialization(multi_key_1_byte, WrongLengthError);
 
-    for (index, pk) in pub_keys.iter().enumerate() {
-        assert_eq!(pk, &multi_key_1of10_new.0[index]);
-        assert_eq!(pk, &multi_key_10of10_new.0[index]);
-    }
-    assert_eq!(multi_key_1of10_new.1, 1);
-    assert_eq!(multi_key_10of10_new.1, 10);
+    // Test try_from 31 bytes (should fail).
+    let multi_key_31_bytes =
+        MultiEd25519PublicKey::try_from(&[0u8; ED25519_PUBLIC_KEY_LENGTH - 1][..]);
+    test_failed_public_key_serialization(multi_key_31_bytes, WrongLengthError);
 
-    // Add threshold at the end of 10of10.
-    serialized_10of10.push(10u8);
-    let multi_key_10of10_new = MultiEd25519PublicKey::try_from(serialized_10of10.as_slice());
-    assert!(&multi_key_10of10_new.is_err());
+    // Test try_from 32 bytes (should fail) because we always need ED25519_PUBLIC_KEY_LENGTH * N + 1
+    // bytes (thus 32N + 1).
+    let multi_key_32_bytes = MultiEd25519PublicKey::try_from(&[0u8; ED25519_PUBLIC_KEY_LENGTH][..]);
+    test_failed_public_key_serialization(multi_key_32_bytes, WrongLengthError);
+
+    // Test try_from 34 bytes (should fail).
+    let multi_key_34_bytes =
+        MultiEd25519PublicKey::try_from(&[0u8; ED25519_PUBLIC_KEY_LENGTH + 2][..]);
+    test_failed_public_key_serialization(multi_key_34_bytes, WrongLengthError);
+
+    // Test try_from 33 all zero bytes (size is fine, but it should fail due to
+    // validation issues).
+    let multi_key_33_zero_bytes =
+        MultiEd25519PublicKey::try_from(&[0u8; ED25519_PUBLIC_KEY_LENGTH + 1][..]);
+    test_failed_public_key_serialization(multi_key_33_zero_bytes, ValidationError);
+
+    let keypairs_10 = generate_key_pairs(10);
+    let priv_keys_10: Vec<Ed25519PrivateKey> = keypairs_10.iter().map(|x| x.0.clone()).collect();
+    let pub_keys_10: Vec<Ed25519PublicKey> = keypairs_10.iter().map(|x| x.1.clone()).collect();
+
+    let multi_private_key_7of10 = MultiEd25519PrivateKey::new(priv_keys_10.clone(), 7).unwrap();
+    let multi_public_key_7of10 = MultiEd25519PublicKey::new(pub_keys_10.clone(), 7).unwrap();
+
+    // Check that MultiEd25519PublicKey::from MultiEd25519PrivateKey works as expected.
+    let multi_public_key_7of10_from_multi_private_key =
+        MultiEd25519PublicKey::from(&multi_private_key_7of10);
     assert_eq!(
-        multi_key_10of10_new.err().unwrap(),
-        CryptoMaterialError::WrongLengthError
+        multi_public_key_7of10_from_multi_private_key,
+        multi_public_key_7of10
     );
 
-    serialized_10of10.pop();
-    serialized_10of10.push(11u8);
-    let multi_key_10of10_new = MultiEd25519PublicKey::try_from(serialized_10of10.as_slice());
-    assert!(&multi_key_10of10_new.is_err());
-    assert_eq!(
-        multi_key_10of10_new.err().unwrap(),
-        CryptoMaterialError::WrongLengthError
+    // Check that MultiEd25519PublicKey::from Ed25519PublicKey works as expected.
+    let multi_public_key_from_ed25519 = MultiEd25519PublicKey::from(
+        &multi_public_key_7of10_from_multi_private_key.public_keys()[0],
     );
-
-    // Cannot add zero threshold.
-    #[allow(clippy::redundant_clone)]
-    let multi_key_0of10 = MultiEd25519PublicKey::new(pub_keys.clone(), 0);
-    assert!(multi_key_0of10.is_err());
+    assert_eq!(multi_public_key_from_ed25519.public_keys().len(), 1);
     assert_eq!(
-        multi_key_0of10.err().unwrap(),
-        CryptoMaterialError::WrongLengthError
+        &multi_public_key_from_ed25519.public_keys()[0],
+        &multi_public_key_7of10_from_multi_private_key.public_keys()[0]
     );
+    assert_eq!(multi_public_key_from_ed25519.threshold(), &1u8);
+}
 
-    // Cannot add bigger than N threshold.
-    #[allow(clippy::redundant_clone)]
-    let multi_key_11of10 = MultiEd25519PublicKey::new(pub_keys.clone(), 11);
-    assert!(multi_key_11of10.is_err());
+// Test against known small subgroup public key.
+#[test]
+fn test_publickey_smallorder() {
+    // A small group point with threshold 1 (last byte).
+    // See EIGHT_TORSION in ed25519_test.rs for more about small group points.
+    let torsion_point_with_threshold_1: [u8; 33] = [
+        1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 0, 1,
+    ];
+
+    let torsion_key = MultiEd25519PublicKey::try_from(&torsion_point_with_threshold_1[..]);
+    assert!(torsion_key.is_err());
     assert_eq!(
-        multi_key_11of10.err().unwrap(),
-        CryptoMaterialError::WrongLengthError
+        torsion_key.err().unwrap(),
+        CryptoMaterialError::SmallSubgroupError
     );
 }
 
 // Test multi-sig Ed25519 signature verification.
+#[allow(clippy::redundant_clone)]
 #[test]
 fn test_multi_ed25519_signature_verification() {
-    let mut rng = StdRng::from_seed(TEST_SEED);
+    let keypairs_10 = generate_key_pairs(10);
+    let priv_keys_10: Vec<Ed25519PrivateKey> = keypairs_10.iter().map(|x| x.0.clone()).collect();
+    let pub_keys_10: Vec<Ed25519PublicKey> = keypairs_10.iter().map(|x| x.1.clone()).collect();
 
-    let mut private_keys: Vec<Ed25519PrivateKey> = vec![];
-    let mut public_keys: Vec<Ed25519PublicKey> = vec![];
-    for _ in 0..10 {
-        let (private_key, public_key) = compat::generate_keypair(&mut rng);
-        private_keys.push(private_key);
-        public_keys.push(public_key);
-    }
-    #[allow(clippy::redundant_clone)]
-    let multi_private_key_7of10 = MultiEd25519PrivateKey::new(private_keys.clone(), 7).unwrap();
+    let multi_private_key_7of10 = MultiEd25519PrivateKey::new(priv_keys_10.clone(), 7).unwrap();
     let multi_public_key_7of10 = MultiEd25519PublicKey::from(&multi_private_key_7of10);
 
-    // Check if MultiEd25519PublicKey::from works as expected.
-    #[allow(clippy::redundant_clone)]
-    let multi_public_key_7of10_construct =
-        MultiEd25519PublicKey::new(public_keys.clone(), 7).unwrap();
-    assert_eq!(multi_public_key_7of10, multi_public_key_7of10_construct);
-    let message = b"Hello";
+    let message = b"Test Message";
     let message_hash = HashValue::from_sha3_256(message);
 
+    // Verifying a 7-of-10 signature against a public key with the same threshold should pass.
     let multi_signature_7of10 = multi_private_key_7of10.sign_message(&message_hash);
     assert!(multi_signature_7of10
         .verify(&message_hash, &multi_public_key_7of10)
         .is_ok());
 
-    // A Public key with bigger threshold should fail.
-    #[allow(clippy::redundant_clone)]
-    let multi_public_key_8of10 = MultiEd25519PublicKey::new(public_keys.clone(), 8).unwrap();
+    // Verifying a 7-of-10 signature against a public key with bigger threshold (i.e., 8) should fail.
+    let multi_public_key_8of10 = MultiEd25519PublicKey::new(pub_keys_10.clone(), 8).unwrap();
     assert!(multi_signature_7of10
         .verify(&message_hash, &multi_public_key_8of10)
         .is_err());
 
-    // A Public key with smaller threshold should pass.
-    #[allow(clippy::redundant_clone)]
-    let multi_public_key_6of10 = MultiEd25519PublicKey::new(public_keys.clone(), 6).unwrap();
+    // Verifying a 7-of-10 signature against a public key with smaller threshold (i.e., 6) should pass.
+    let multi_public_key_6of10 = MultiEd25519PublicKey::new(pub_keys_10.clone(), 6).unwrap();
     assert!(multi_signature_7of10
         .verify(&message_hash, &multi_public_key_6of10)
         .is_ok());
+
+    // Verifying a 7-of-10 signature against a reordered MultiEd25519PublicKey should fail.
+    // To deterministically simulate reshuffling, we use a reversed vector of 10 keys.
+    // Note that because 10 is an even number, all of they keys will change position.
+    let mut pub_keys_10_reversed = pub_keys_10.clone();
+    pub_keys_10_reversed.reverse();
+    let multi_public_key_7of10_reversed =
+        MultiEd25519PublicKey::new(pub_keys_10_reversed, 7).unwrap();
+    assert!(multi_signature_7of10
+        .verify(&message_hash, &multi_public_key_7of10_reversed)
+        .is_err());
 }

--- a/crypto/crypto/src/unit_tests/multi_ed25519_test.rs
+++ b/crypto/crypto/src/unit_tests/multi_ed25519_test.rs
@@ -1,0 +1,132 @@
+// Copyright (c) The Libra Core Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::{
+    ed25519::{Ed25519PrivateKey, Ed25519PublicKey},
+    traits::*,
+};
+
+use core::convert::TryFrom;
+use rand::{rngs::StdRng, SeedableRng};
+
+use crate::ed25519::{compat, ED25519_PUBLIC_KEY_LENGTH};
+use crate::hash::HashValue;
+use crate::multi_ed25519::{MultiEd25519PrivateKey, MultiEd25519PublicKey};
+use crate::test_utils::TEST_SEED;
+
+// Test multi-sig Ed25519 serialization.
+#[test]
+fn test_multi_ed25519_public_key_serialization() {
+    let mut rng = StdRng::from_seed(TEST_SEED);
+
+    let mut pub_keys: Vec<Ed25519PublicKey> = vec![];
+    for _ in 0..10 {
+        pub_keys.push(compat::generate_keypair(&mut rng).1);
+    }
+
+    #[allow(clippy::all)]
+    let multi_key_1of10 = MultiEd25519PublicKey::new(pub_keys.clone(), 1);
+    let serialized_1of10 = MultiEd25519PublicKey::to_bytes(&multi_key_1of10.unwrap());
+    assert_eq!(serialized_1of10.len(), 10 * ED25519_PUBLIC_KEY_LENGTH + 1);
+
+    #[allow(clippy::all)]
+    let multi_key_10of10 = MultiEd25519PublicKey::new(pub_keys.clone(), 10);
+    let mut serialized_10of10 = MultiEd25519PublicKey::to_bytes(&multi_key_10of10.unwrap());
+    assert_eq!(serialized_10of10.len(), 10 * ED25519_PUBLIC_KEY_LENGTH);
+
+    let multi_key_1of10_new = MultiEd25519PublicKey::try_from(serialized_1of10.as_slice());
+    let multi_key_10of10_new = MultiEd25519PublicKey::try_from(serialized_10of10.as_slice());
+
+    assert!(&multi_key_1of10_new.is_ok());
+    assert!(&multi_key_10of10_new.is_ok());
+
+    let multi_key_1of10_new = multi_key_1of10_new.unwrap();
+    let multi_key_10of10_new = multi_key_10of10_new.unwrap();
+
+    for (index, pk) in pub_keys.iter().enumerate() {
+        assert_eq!(pk, &multi_key_1of10_new.0[index]);
+        assert_eq!(pk, &multi_key_10of10_new.0[index]);
+    }
+    assert_eq!(multi_key_1of10_new.1, 1);
+    assert_eq!(multi_key_10of10_new.1, 10);
+
+    // Add threshold at the end of 10of10.
+    serialized_10of10.push(10u8);
+    let multi_key_10of10_new = MultiEd25519PublicKey::try_from(serialized_10of10.as_slice());
+    assert!(&multi_key_10of10_new.is_err());
+    assert_eq!(
+        multi_key_10of10_new.err().unwrap(),
+        CryptoMaterialError::WrongLengthError
+    );
+
+    serialized_10of10.pop();
+    serialized_10of10.push(11u8);
+    let multi_key_10of10_new = MultiEd25519PublicKey::try_from(serialized_10of10.as_slice());
+    assert!(&multi_key_10of10_new.is_err());
+    assert_eq!(
+        multi_key_10of10_new.err().unwrap(),
+        CryptoMaterialError::WrongLengthError
+    );
+
+    // Cannot add zero threshold.
+    #[allow(clippy::all)]
+    let multi_key_0of10 = MultiEd25519PublicKey::new(pub_keys.clone(), 0);
+    assert!(multi_key_0of10.is_err());
+    assert_eq!(
+        multi_key_0of10.err().unwrap(),
+        CryptoMaterialError::WrongLengthError
+    );
+
+    // Cannot add bigger than N threshold.
+    #[allow(clippy::all)]
+    let multi_key_11of10 = MultiEd25519PublicKey::new(pub_keys.clone(), 11);
+    assert!(multi_key_11of10.is_err());
+    assert_eq!(
+        multi_key_11of10.err().unwrap(),
+        CryptoMaterialError::WrongLengthError
+    );
+}
+
+// Test multi-sig Ed25519 signature verification.
+#[test]
+fn test_multi_ed25519_signature_verification() {
+    let mut rng = StdRng::from_seed(TEST_SEED);
+
+    let mut private_keys: Vec<Ed25519PrivateKey> = vec![];
+    let mut public_keys: Vec<Ed25519PublicKey> = vec![];
+    for _ in 0..10 {
+        let (private_key, public_key) = compat::generate_keypair(&mut rng);
+        private_keys.push(private_key);
+        public_keys.push(public_key);
+    }
+    #[allow(clippy::all)]
+    let multi_private_key_7of10 = MultiEd25519PrivateKey::new(private_keys.clone(), 7).unwrap();
+    let multi_public_key_7of10 = MultiEd25519PublicKey::from(&multi_private_key_7of10);
+
+    // Check if MultiEd25519PublicKey::from works as expected.
+    #[allow(clippy::all)]
+    let multi_public_key_7of10_construct =
+        MultiEd25519PublicKey::new(public_keys.clone(), 7).unwrap();
+    assert_eq!(multi_public_key_7of10, multi_public_key_7of10_construct);
+    let message = b"Hello";
+    let message_hash = HashValue::from_sha3_256(message);
+
+    let multi_signature_7of10 = multi_private_key_7of10.sign_message(&message_hash);
+    assert!(multi_signature_7of10
+        .verify(&message_hash, &multi_public_key_7of10)
+        .is_ok());
+
+    // A Public key with bigger threshold should fail.
+    #[allow(clippy::all)]
+    let multi_public_key_8of10 = MultiEd25519PublicKey::new(public_keys.clone(), 8).unwrap();
+    assert!(multi_signature_7of10
+        .verify(&message_hash, &multi_public_key_8of10)
+        .is_err());
+
+    // A Public key with smaller threshold should pass.
+    #[allow(clippy::all)]
+    let multi_public_key_6of10 = MultiEd25519PublicKey::new(public_keys.clone(), 6).unwrap();
+    assert!(multi_signature_7of10
+        .verify(&message_hash, &multi_public_key_6of10)
+        .is_ok());
+}

--- a/crypto/crypto/src/unit_tests/multi_ed25519_test.rs
+++ b/crypto/crypto/src/unit_tests/multi_ed25519_test.rs
@@ -24,12 +24,12 @@ fn test_multi_ed25519_public_key_serialization() {
         pub_keys.push(compat::generate_keypair(&mut rng).1);
     }
 
-    #[allow(clippy::all)]
+    #[allow(clippy::redundant_clone)]
     let multi_key_1of10 = MultiEd25519PublicKey::new(pub_keys.clone(), 1);
     let serialized_1of10 = MultiEd25519PublicKey::to_bytes(&multi_key_1of10.unwrap());
     assert_eq!(serialized_1of10.len(), 10 * ED25519_PUBLIC_KEY_LENGTH + 1);
 
-    #[allow(clippy::all)]
+    #[allow(clippy::redundant_clone)]
     let multi_key_10of10 = MultiEd25519PublicKey::new(pub_keys.clone(), 10);
     let mut serialized_10of10 = MultiEd25519PublicKey::to_bytes(&multi_key_10of10.unwrap());
     assert_eq!(serialized_10of10.len(), 10 * ED25519_PUBLIC_KEY_LENGTH);
@@ -69,7 +69,7 @@ fn test_multi_ed25519_public_key_serialization() {
     );
 
     // Cannot add zero threshold.
-    #[allow(clippy::all)]
+    #[allow(clippy::redundant_clone)]
     let multi_key_0of10 = MultiEd25519PublicKey::new(pub_keys.clone(), 0);
     assert!(multi_key_0of10.is_err());
     assert_eq!(
@@ -78,7 +78,7 @@ fn test_multi_ed25519_public_key_serialization() {
     );
 
     // Cannot add bigger than N threshold.
-    #[allow(clippy::all)]
+    #[allow(clippy::redundant_clone)]
     let multi_key_11of10 = MultiEd25519PublicKey::new(pub_keys.clone(), 11);
     assert!(multi_key_11of10.is_err());
     assert_eq!(
@@ -99,12 +99,12 @@ fn test_multi_ed25519_signature_verification() {
         private_keys.push(private_key);
         public_keys.push(public_key);
     }
-    #[allow(clippy::all)]
+    #[allow(clippy::redundant_clone)]
     let multi_private_key_7of10 = MultiEd25519PrivateKey::new(private_keys.clone(), 7).unwrap();
     let multi_public_key_7of10 = MultiEd25519PublicKey::from(&multi_private_key_7of10);
 
     // Check if MultiEd25519PublicKey::from works as expected.
-    #[allow(clippy::all)]
+    #[allow(clippy::redundant_clone)]
     let multi_public_key_7of10_construct =
         MultiEd25519PublicKey::new(public_keys.clone(), 7).unwrap();
     assert_eq!(multi_public_key_7of10, multi_public_key_7of10_construct);
@@ -117,14 +117,14 @@ fn test_multi_ed25519_signature_verification() {
         .is_ok());
 
     // A Public key with bigger threshold should fail.
-    #[allow(clippy::all)]
+    #[allow(clippy::redundant_clone)]
     let multi_public_key_8of10 = MultiEd25519PublicKey::new(public_keys.clone(), 8).unwrap();
     assert!(multi_signature_7of10
         .verify(&message_hash, &multi_public_key_8of10)
         .is_err());
 
     // A Public key with smaller threshold should pass.
-    #[allow(clippy::all)]
+    #[allow(clippy::redundant_clone)]
     let multi_public_key_6of10 = MultiEd25519PublicKey::new(public_keys.clone(), 6).unwrap();
     assert!(multi_signature_7of10
         .verify(&message_hash, &multi_public_key_6of10)

--- a/crypto/crypto/src/x25519.rs
+++ b/crypto/crypto/src/x25519.rs
@@ -225,7 +225,9 @@ impl TryFrom<&[u8]> for X25519StaticPrivateKey {
 }
 
 impl Length for X25519StaticPrivateKey {
-    const LENGTH: usize = X25519_PRIVATE_KEY_LENGTH;
+    fn length(&self) -> usize {
+        X25519_PRIVATE_KEY_LENGTH
+    }
 }
 
 impl ValidKey for X25519StaticPrivateKey {
@@ -288,7 +290,9 @@ impl TryFrom<&[u8]> for X25519StaticPublicKey {
 }
 
 impl Length for X25519StaticPublicKey {
-    const LENGTH: usize = X25519_PUBLIC_KEY_LENGTH;
+    fn length(&self) -> usize {
+        X25519_PUBLIC_KEY_LENGTH
+    }
 }
 
 impl ValidKey for X25519StaticPublicKey {


### PR DESCRIPTION
## Motivation

This is WIP, do not fully review it yet, but feel free to provide feedback. Testing is not exhaustive, more PRs will follow on this, but feel free to suggest a list of edge cases. 

Implementation of the Threshold Multi-sig On-chain Accountable Pure Ed25519 signatures.
Current scheme can support concatenated _K out-of N_ for _K <= N_ and _N <= 32_

The goal is to eventually use it as Libra's main signature scheme, that will natively support multi-sig similarly to Bitcoin.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?

YES

## Test Plan

multi_ed25519_test