### PR TITLE
Remove num_enum

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1187,16 +1187,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "derivative"
-version = "1.0.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "proc-macro2 0.4.30 (registry+https://github.com/rust-lang/crates.io-index)",
- "quote 0.6.13 (registry+https://github.com/rust-lang/crates.io-index)",
- "syn 0.15.44 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
 name = "difference"
 version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2567,7 +2557,6 @@ dependencies = [
  "libra-proptest-helpers 0.1.0",
  "libra-prost-ext 0.1.0",
  "mirai-annotations 1.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "num_enum 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "once_cell 1.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "parity-multiaddr 0.7.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "proptest 0.9.5 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -3214,26 +3203,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "num_enum"
-version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "derivative 1.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "num_enum_derive 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "num_enum_derive"
-version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "proc-macro-crate 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "proc-macro2 1.0.9 (registry+https://github.com/rust-lang/crates.io-index)",
- "quote 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "syn 1.0.16 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
 name = "numtoa"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3577,14 +3546,6 @@ dependencies = [
  "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "term 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "unicode-width 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "proc-macro-crate"
-version = "0.1.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "toml 0.5.6 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -6578,7 +6539,6 @@ dependencies = [
 "checksum curve25519-dalek 2.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "26778518a7f6cffa1d25a44b602b62b979bd88adb9e99ffec546998cf3404839"
 "checksum curve25519-fiat 0.1.4 (git+https://github.com/calibra/rust-curve25519-fiat.git)" = "<none>"
 "checksum data-encoding 2.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "11c0346158a19b3627234e15596f5e465c360fcdb97d817bcb255e0510f5a788"
-"checksum derivative 1.0.3 (registry+https://github.com/rust-lang/crates.io-index)" = "942ca430eef7a3806595a6737bc388bf51adb888d3fc0dd1b50f1c170167ee3a"
 "checksum difference 2.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "524cbf6897b527295dff137cec09ecf3a05f4fddffd7dfcd1585403449e74198"
 "checksum digest 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)" = "f3d0c8c8752312f9713efd397ff63acb9f85585afbf179282e720e7704954dd5"
 "checksum dirs 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)" = "3fd78930633bd1c6e35c4b42b1df7b0cbc6bc191146e512bb3bedf243fcc3901"
@@ -6710,8 +6670,6 @@ dependencies = [
 "checksum num-rational 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "da4dc79f9e6c81bef96148c8f6b8e72ad4541caa4a24373e900a36da07de03a3"
 "checksum num-traits 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)" = "c62be47e61d1842b9170f0fdeec8eba98e60e90e5446449a0545e5152acd7096"
 "checksum num_cpus 1.12.0 (registry+https://github.com/rust-lang/crates.io-index)" = "46203554f085ff89c235cd12f7075f3233af9b11ed7c9e16dfe2560d03313ce6"
-"checksum num_enum 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)" = "be601e38e20a6f3d01049d85801cb9b7a34a8da7a0da70df507bbde7735058c8"
-"checksum num_enum_derive 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)" = "b59f30f6a043f2606adbd0addbf1eef6f2e28e8c4968918b63b7ff97ac0db2a7"
 "checksum numtoa 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "b8f8bdf33df195859076e54ab11ee78a1b208382d3a26ec40d142ffc1ecc49ef"
 "checksum once_cell 1.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "b1c601810575c99596d4afc46f78a678c80105117c379eb3650cf99b8a21ce5b"
 "checksum oorandom 11.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ebcec7c9c2a95cacc7cd0ecb89d8a8454eca13906f6deb55258ffff0adeb9405"
@@ -6751,7 +6709,6 @@ dependencies = [
 "checksum pretty 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)" = "1891757f8427ce41706957fde1fec1b86aee3e335bd50320257705061507a24c"
 "checksum prettydiff 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "5240be0c9ea1bc7887819a36264cb9475eb71c58749808e5b989c8c1fdc67acf"
 "checksum prettytable-rs 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)" = "0fd04b170004fa2daccf418a7f8253aaf033c27760b5f225889024cf66d7ac2e"
-"checksum proc-macro-crate 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)" = "e10d4b51f154c8a7fb96fd6dad097cb74b863943ec010ac94b9fd1be8861fe1e"
 "checksum proc-macro-error 0.4.9 (registry+https://github.com/rust-lang/crates.io-index)" = "052b3c9af39c7e5e94245f820530487d19eb285faedcb40e0c3275132293f242"
 "checksum proc-macro-error-attr 0.4.9 (registry+https://github.com/rust-lang/crates.io-index)" = "d175bef481c7902e63e3165627123fff3502f06ac043d3ef42d08c1246da9253"
 "checksum proc-macro-hack 0.5.11 (registry+https://github.com/rust-lang/crates.io-index)" = "ecd45702f76d6d3c75a80564378ae228a85f0b59d2f3ed43c91b4a69eb2ebfc5"

--- a/types/Cargo.toml
+++ b/types/Cargo.toml
@@ -32,7 +32,6 @@ lcs = { path = "../common/lcs", version = "0.1.0", package = "libra-canonical-se
 libra-crypto = { path = "../crypto/crypto", version = "0.1.0" }
 libra-crypto-derive = { path = "../crypto/crypto-derive", version = "0.1.0" }
 libra-proptest-helpers = { path = "../common/proptest-helpers", version = "0.1.0", optional = true }
-num_enum = "0.4.1"
 
 [build-dependencies]
 prost-build = "0.6"

--- a/types/src/vm_error.rs
+++ b/types/src/vm_error.rs
@@ -4,7 +4,6 @@
 #![allow(clippy::unit_arg)]
 
 use anyhow::{Error, Result};
-use num_enum::{IntoPrimitive, TryFromPrimitive};
 #[cfg(any(test, feature = "fuzzing"))]
 use proptest::prelude::*;
 #[cfg(any(test, feature = "fuzzing"))]
@@ -249,9 +248,7 @@ impl From<VMStatus> for crate::proto::types::VmStatus {
 }
 
 #[allow(non_camel_case_types)]
-#[derive(
-    Clone, Copy, Debug, Eq, Hash, PartialEq, PartialOrd, Ord, IntoPrimitive, TryFromPrimitive,
-)]
+#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq, PartialOrd, Ord)]
 #[repr(u64)]
 /// We don't derive Arbitrary on this enum because it is too large and breaks proptest. It is
 /// written for a subset of these in proptest_types. We test conversion between this and protobuf
@@ -493,6 +490,173 @@ impl<'de> de::Deserialize<'de> for StatusCode {
         }
 
         deserializer.deserialize_u64(StatusCodeVisitor)
+    }
+}
+
+impl TryFrom<u64> for StatusCode {
+    type Error = &'static str;
+
+    fn try_from(value: u64) -> Result<Self, Self::Error> {
+        match value {
+            0 => Ok(StatusCode::UNKNOWN_VALIDATION_STATUS),
+            1 => Ok(StatusCode::INVALID_SIGNATURE),
+            2 => Ok(StatusCode::INVALID_AUTH_KEY),
+            3 => Ok(StatusCode::SEQUENCE_NUMBER_TOO_OLD),
+            4 => Ok(StatusCode::SEQUENCE_NUMBER_TOO_NEW),
+            5 => Ok(StatusCode::INSUFFICIENT_BALANCE_FOR_TRANSACTION_FEE),
+            6 => Ok(StatusCode::TRANSACTION_EXPIRED),
+            7 => Ok(StatusCode::SENDING_ACCOUNT_DOES_NOT_EXIST),
+            8 => Ok(StatusCode::REJECTED_WRITE_SET),
+            9 => Ok(StatusCode::INVALID_WRITE_SET),
+            10 => Ok(StatusCode::EXCEEDED_MAX_TRANSACTION_SIZE),
+            11 => Ok(StatusCode::UNKNOWN_SCRIPT),
+            12 => Ok(StatusCode::UNKNOWN_MODULE),
+            13 => Ok(StatusCode::MAX_GAS_UNITS_EXCEEDS_MAX_GAS_UNITS_BOUND),
+            14 => Ok(StatusCode::MAX_GAS_UNITS_BELOW_MIN_TRANSACTION_GAS_UNITS),
+            15 => Ok(StatusCode::GAS_UNIT_PRICE_BELOW_MIN_BOUND),
+            16 => Ok(StatusCode::GAS_UNIT_PRICE_ABOVE_MAX_BOUND),
+            1000 => Ok(StatusCode::UNKNOWN_VERIFICATION_ERROR),
+            1001 => Ok(StatusCode::INDEX_OUT_OF_BOUNDS),
+            1002 => Ok(StatusCode::RANGE_OUT_OF_BOUNDS),
+            1003 => Ok(StatusCode::INVALID_SIGNATURE_TOKEN),
+            1004 => Ok(StatusCode::INVALID_FIELD_DEF),
+            1005 => Ok(StatusCode::RECURSIVE_STRUCT_DEFINITION),
+            1006 => Ok(StatusCode::INVALID_RESOURCE_FIELD),
+            1007 => Ok(StatusCode::INVALID_FALL_THROUGH),
+            1008 => Ok(StatusCode::JOIN_FAILURE),
+            1009 => Ok(StatusCode::NEGATIVE_STACK_SIZE_WITHIN_BLOCK),
+            1010 => Ok(StatusCode::UNBALANCED_STACK),
+            1011 => Ok(StatusCode::INVALID_MAIN_FUNCTION_SIGNATURE),
+            1012 => Ok(StatusCode::DUPLICATE_ELEMENT),
+            1013 => Ok(StatusCode::INVALID_MODULE_HANDLE),
+            1014 => Ok(StatusCode::UNIMPLEMENTED_HANDLE),
+            1015 => Ok(StatusCode::INCONSISTENT_FIELDS),
+            1016 => Ok(StatusCode::UNUSED_FIELD),
+            1017 => Ok(StatusCode::LOOKUP_FAILED),
+            1018 => Ok(StatusCode::VISIBILITY_MISMATCH),
+            1019 => Ok(StatusCode::TYPE_RESOLUTION_FAILURE),
+            1020 => Ok(StatusCode::TYPE_MISMATCH),
+            1021 => Ok(StatusCode::MISSING_DEPENDENCY),
+            1022 => Ok(StatusCode::POP_REFERENCE_ERROR),
+            1023 => Ok(StatusCode::POP_RESOURCE_ERROR),
+            1024 => Ok(StatusCode::RELEASEREF_TYPE_MISMATCH_ERROR),
+            1025 => Ok(StatusCode::BR_TYPE_MISMATCH_ERROR),
+            1026 => Ok(StatusCode::ABORT_TYPE_MISMATCH_ERROR),
+            1027 => Ok(StatusCode::STLOC_TYPE_MISMATCH_ERROR),
+            1028 => Ok(StatusCode::STLOC_UNSAFE_TO_DESTROY_ERROR),
+            1029 => Ok(StatusCode::RET_UNSAFE_TO_DESTROY_ERROR),
+            1030 => Ok(StatusCode::RET_TYPE_MISMATCH_ERROR),
+            1031 => Ok(StatusCode::RET_BORROWED_MUTABLE_REFERENCE_ERROR),
+            1032 => Ok(StatusCode::FREEZEREF_TYPE_MISMATCH_ERROR),
+            1033 => Ok(StatusCode::FREEZEREF_EXISTS_MUTABLE_BORROW_ERROR),
+            1034 => Ok(StatusCode::BORROWFIELD_TYPE_MISMATCH_ERROR),
+            1035 => Ok(StatusCode::BORROWFIELD_BAD_FIELD_ERROR),
+            1036 => Ok(StatusCode::BORROWFIELD_EXISTS_MUTABLE_BORROW_ERROR),
+            1037 => Ok(StatusCode::COPYLOC_UNAVAILABLE_ERROR),
+            1038 => Ok(StatusCode::COPYLOC_RESOURCE_ERROR),
+            1039 => Ok(StatusCode::COPYLOC_EXISTS_BORROW_ERROR),
+            1040 => Ok(StatusCode::MOVELOC_UNAVAILABLE_ERROR),
+            1041 => Ok(StatusCode::MOVELOC_EXISTS_BORROW_ERROR),
+            1042 => Ok(StatusCode::BORROWLOC_REFERENCE_ERROR),
+            1043 => Ok(StatusCode::BORROWLOC_UNAVAILABLE_ERROR),
+            1044 => Ok(StatusCode::BORROWLOC_EXISTS_BORROW_ERROR),
+            1045 => Ok(StatusCode::CALL_TYPE_MISMATCH_ERROR),
+            1046 => Ok(StatusCode::CALL_BORROWED_MUTABLE_REFERENCE_ERROR),
+            1047 => Ok(StatusCode::PACK_TYPE_MISMATCH_ERROR),
+            1048 => Ok(StatusCode::UNPACK_TYPE_MISMATCH_ERROR),
+            1049 => Ok(StatusCode::READREF_TYPE_MISMATCH_ERROR),
+            1050 => Ok(StatusCode::READREF_RESOURCE_ERROR),
+            1051 => Ok(StatusCode::READREF_EXISTS_MUTABLE_BORROW_ERROR),
+            1052 => Ok(StatusCode::WRITEREF_TYPE_MISMATCH_ERROR),
+            1053 => Ok(StatusCode::WRITEREF_RESOURCE_ERROR),
+            1054 => Ok(StatusCode::WRITEREF_EXISTS_BORROW_ERROR),
+            1055 => Ok(StatusCode::WRITEREF_NO_MUTABLE_REFERENCE_ERROR),
+            1056 => Ok(StatusCode::INTEGER_OP_TYPE_MISMATCH_ERROR),
+            1057 => Ok(StatusCode::BOOLEAN_OP_TYPE_MISMATCH_ERROR),
+            1058 => Ok(StatusCode::EQUALITY_OP_TYPE_MISMATCH_ERROR),
+            1059 => Ok(StatusCode::EXISTS_RESOURCE_TYPE_MISMATCH_ERROR),
+            1060 => Ok(StatusCode::BORROWGLOBAL_TYPE_MISMATCH_ERROR),
+            1061 => Ok(StatusCode::BORROWGLOBAL_NO_RESOURCE_ERROR),
+            1062 => Ok(StatusCode::MOVEFROM_TYPE_MISMATCH_ERROR),
+            1063 => Ok(StatusCode::MOVEFROM_NO_RESOURCE_ERROR),
+            1064 => Ok(StatusCode::MOVETOSENDER_TYPE_MISMATCH_ERROR),
+            1065 => Ok(StatusCode::MOVETOSENDER_NO_RESOURCE_ERROR),
+            1066 => Ok(StatusCode::CREATEACCOUNT_TYPE_MISMATCH_ERROR),
+            1067 => Ok(StatusCode::MODULE_ADDRESS_DOES_NOT_MATCH_SENDER),
+            1068 => Ok(StatusCode::NO_MODULE_HANDLES),
+            1069 => Ok(StatusCode::POSITIVE_STACK_SIZE_AT_BLOCK_END),
+            1070 => Ok(StatusCode::MISSING_ACQUIRES_RESOURCE_ANNOTATION_ERROR),
+            1071 => Ok(StatusCode::EXTRANEOUS_ACQUIRES_RESOURCE_ANNOTATION_ERROR),
+            1072 => Ok(StatusCode::DUPLICATE_ACQUIRES_RESOURCE_ANNOTATION_ERROR),
+            1073 => Ok(StatusCode::INVALID_ACQUIRES_RESOURCE_ANNOTATION_ERROR),
+            1074 => Ok(StatusCode::GLOBAL_REFERENCE_ERROR),
+            1075 => Ok(StatusCode::CONTRAINT_KIND_MISMATCH),
+            1076 => Ok(StatusCode::NUMBER_OF_TYPE_ACTUALS_MISMATCH),
+            1077 => Ok(StatusCode::LOOP_IN_INSTANTIATION_GRAPH),
+            1078 => Ok(StatusCode::UNUSED_LOCALS_SIGNATURE),
+            1079 => Ok(StatusCode::UNUSED_TYPE_SIGNATURE),
+            1080 => Ok(StatusCode::ZERO_SIZED_STRUCT),
+            1081 => Ok(StatusCode::LINKER_ERROR),
+            2000 => Ok(StatusCode::UNKNOWN_INVARIANT_VIOLATION_ERROR),
+            2001 => Ok(StatusCode::OUT_OF_BOUNDS_INDEX),
+            2002 => Ok(StatusCode::OUT_OF_BOUNDS_RANGE),
+            2003 => Ok(StatusCode::EMPTY_VALUE_STACK),
+            2004 => Ok(StatusCode::EMPTY_CALL_STACK),
+            2005 => Ok(StatusCode::PC_OVERFLOW),
+            2006 => Ok(StatusCode::VERIFICATION_ERROR),
+            2007 => Ok(StatusCode::LOCAL_REFERENCE_ERROR),
+            2008 => Ok(StatusCode::STORAGE_ERROR),
+            2009 => Ok(StatusCode::INTERNAL_TYPE_ERROR),
+            2010 => Ok(StatusCode::EVENT_KEY_MISMATCH),
+            2011 => Ok(StatusCode::UNREACHABLE),
+            2012 => Ok(StatusCode::VM_STARTUP_FAILURE),
+            2013 => Ok(StatusCode::NATIVE_FUNCTION_INTERNAL_INCONSISTENCY),
+            3000 => Ok(StatusCode::UNKNOWN_BINARY_ERROR),
+            3001 => Ok(StatusCode::MALFORMED),
+            3002 => Ok(StatusCode::BAD_MAGIC),
+            3003 => Ok(StatusCode::UNKNOWN_VERSION),
+            3004 => Ok(StatusCode::UNKNOWN_TABLE_TYPE),
+            3005 => Ok(StatusCode::UNKNOWN_SIGNATURE_TYPE),
+            3006 => Ok(StatusCode::UNKNOWN_SERIALIZED_TYPE),
+            3007 => Ok(StatusCode::UNKNOWN_OPCODE),
+            3008 => Ok(StatusCode::BAD_HEADER_TABLE),
+            3009 => Ok(StatusCode::UNEXPECTED_SIGNATURE_TYPE),
+            3010 => Ok(StatusCode::DUPLICATE_TABLE),
+            3011 => Ok(StatusCode::VERIFIER_INVARIANT_VIOLATION),
+            4000 => Ok(StatusCode::UNKNOWN_RUNTIME_STATUS),
+            4001 => Ok(StatusCode::EXECUTED),
+            4002 => Ok(StatusCode::OUT_OF_GAS),
+            4003 => Ok(StatusCode::RESOURCE_DOES_NOT_EXIST),
+            4004 => Ok(StatusCode::RESOURCE_ALREADY_EXISTS),
+            4005 => Ok(StatusCode::EVICTED_ACCOUNT_ACCESS),
+            4006 => Ok(StatusCode::ACCOUNT_ADDRESS_ALREADY_EXISTS),
+            4007 => Ok(StatusCode::TYPE_ERROR),
+            4008 => Ok(StatusCode::MISSING_DATA),
+            4009 => Ok(StatusCode::DATA_FORMAT_ERROR),
+            4010 => Ok(StatusCode::INVALID_DATA),
+            4011 => Ok(StatusCode::REMOTE_DATA_ERROR),
+            4012 => Ok(StatusCode::CANNOT_WRITE_EXISTING_RESOURCE),
+            4013 => Ok(StatusCode::VALUE_SERIALIZATION_ERROR),
+            4014 => Ok(StatusCode::VALUE_DESERIALIZATION_ERROR),
+            4015 => Ok(StatusCode::DUPLICATE_MODULE_NAME),
+            4016 => Ok(StatusCode::ABORTED),
+            4017 => Ok(StatusCode::ARITHMETIC_ERROR),
+            4018 => Ok(StatusCode::DYNAMIC_REFERENCE_ERROR),
+            4019 => Ok(StatusCode::CODE_DESERIALIZATION_ERROR),
+            4020 => Ok(StatusCode::EXECUTION_STACK_OVERFLOW),
+            4021 => Ok(StatusCode::CALL_STACK_OVERFLOW),
+            4022 => Ok(StatusCode::NATIVE_FUNCTION_ERROR),
+            4023 => Ok(StatusCode::GAS_SCHEDULE_ERROR),
+            4024 => Ok(StatusCode::CREATE_NULL_ACCOUNT),
+            std::u64::MAX => Ok(StatusCode::UNKNOWN_STATUS),
+            _ => Err("invalid StatusCode"),
+        }
+    }
+}
+
+impl From<StatusCode> for u64 {
+    fn from(status: StatusCode) -> u64 {
+        status as u64
     }
 }
 


### PR DESCRIPTION
num_enum was only used by vm_error::StatusCode and had outdated
dependencies. There didn't seem to be any good, modern alternatives, so this
just replaces it with hand written TryFrom and From impls.
