### PR TITLE
[types] Ensure we always use VerifierType to check ledger info

### DIFF
--- a/consensus/consensus-types/src/quorum_cert.rs
+++ b/consensus/consensus-types/src/quorum_cert.rs
@@ -121,7 +121,7 @@ impl QuorumCert {
             return Ok(());
         }
         self.ledger_info()
-            .verify(validator)
+            .verify_signatures(validator)
             .context("Fail to verify QuorumCert")?;
         Ok(())
     }

--- a/state-synchronizer/src/coordinator.rs
+++ b/state-synchronizer/src/coordinator.rs
@@ -22,6 +22,7 @@ use libra_mempool::{CommitNotification, CommitResponse, CommittedTransaction};
 use libra_types::{
     crypto_proxies::{LedgerInfoWithSignatures, ValidatorChangeProof},
     transaction::{Transaction, TransactionListWithProof, Version},
+    validator_change::VerifierType,
     waypoint::Waypoint,
 };
 use network::protocols::network::Event;
@@ -762,8 +763,8 @@ impl<T: ExecutorProxyTrait> SyncCoordinator<T> {
             None => response_li.ledger_info().epoch(),
         };
         self.send_chunk_request(new_version, new_epoch).await?;
-
-        response_li.verify(self.local_state.verifier())?;
+        let verifier = VerifierType::TrustedVerifier(self.local_state.trusted_epoch.clone());
+        verifier.verify(&response_li)?;
         self.validate_and_store_chunk(txn_list_with_proof, response_li, None)
             .await
     }

--- a/types/src/get_with_proof.rs
+++ b/types/src/get_with_proof.rs
@@ -217,7 +217,8 @@ pub fn verify_update_to_latest_ledger_response(
                     .into(),
             ),
         };
-        ledger_info_with_sigs.verify(&new_epoch_info.verifier)?;
+        let new_verifier = VerifierType::TrustedVerifier(new_epoch_info.clone());
+        new_verifier.verify(ledger_info_with_sigs)?;
         Ok(Some(new_epoch_info))
     } else {
         verifier.verify(ledger_info_with_sigs)?;

--- a/types/src/ledger_info.rs
+++ b/types/src/ledger_info.rs
@@ -239,7 +239,7 @@ impl<Sig: Signature> LedgerInfoWithSignatures<Sig> {
         &self.signatures
     }
 
-    pub fn verify(
+    pub fn verify_signatures(
         &self,
         validator: &ValidatorVerifier<Sig::VerifyingKeyMaterial>,
     ) -> ::std::result::Result<(), VerifyError> {

--- a/types/src/validator_change.rs
+++ b/types/src/validator_change.rs
@@ -42,7 +42,7 @@ impl VerifierType {
                     epoch_info.epoch == ledger_info.ledger_info().epoch(),
                     "LedgerInfo has unexpected epoch"
                 );
-                ledger_info.verify(epoch_info.verifier.as_ref())?;
+                ledger_info.verify_signatures(epoch_info.verifier.as_ref())?;
                 Ok(())
             }
         }


### PR DESCRIPTION
+ By consistently using `VerifierType`, we ensure that the ledger info
we're checking is actually in the next epoch and not just signed by the
current validator set (which could be the same in different epochs).

+ Rename `LedgerInfoWithSignatures::verify` to `verify_signatures` to
make it more obvious that this is just checking signatures. 

+ Without this fix, the test case `test_ratchet_fails_with_gap_in_proof`
in another PR #2700 fails. I will leave the regression test to that PR.

+ Are the any other properties we should be checking? It looks like all
we're currently check (this diff included) is the epoch number and the
validators' signatures. Should we check that the version number is
monotonically increasing? That the timestamp is monotonically increasing?

+ Our verification infrastructure is pretty convoluted at this point. We
should think about doing some further refactoring to make this less
error prone.
