### PR TITLE
[move prover]integrate lifetime analysis into bytecode translator

### DIFF
--- a/language/move-prover/bytecode-to-boogie/src/spec_translator.rs
+++ b/language/move-prover/bytecode-to-boogie/src/spec_translator.rs
@@ -347,7 +347,9 @@ impl<'env> SpecTranslator<'env> {
     /// Generates a procedure which asserts the update invariants of the struct.
     ///
     pub fn translate_update_invariant(&self, struct_env: &StructEnv<'env>) {
-        if struct_env.get_update_invariants().is_empty() {
+        if struct_env.get_update_invariants().is_empty()
+            && struct_env.get_data_invariants().is_empty()
+        {
             return;
         }
         emitln!(

--- a/language/move-prover/bytecode-to-boogie/test_mvir/verify-lifetime.mvir
+++ b/language/move-prover/bytecode-to-boogie/test_mvir/verify-lifetime.mvir
@@ -1,0 +1,54 @@
+module TestLifetime {
+    resource S {
+        x: u64,
+        invariant {data} x > 1, //! This assertion might not hold.
+    }
+
+    resource T {
+        x: u64,
+        invariant {data} x > 1, //! This assertion might not hold.
+    }
+
+    public invalid_S() : Self.S {
+        let s: Self.S;
+        let s_ref: &mut Self.S;
+        let x_ref: &mut u64;
+
+        s = S{x:3};
+        s_ref = &mut s;
+        x_ref = &mut move(s_ref).x;
+        *move(x_ref) = 0; // s_ref goes out of scope here
+
+        s_ref = &mut s;
+        x_ref = &mut move(s_ref).x;
+        *move(x_ref) = 2;
+
+        return move(s);
+    }
+
+    public invalid_bool(cond: bool) : Self.S * Self.T {
+        let s_ref: &mut Self.S;
+        let s: Self.S;
+        let t_ref: &mut Self.T;
+        let t: Self.T;
+        let x_ref: &mut u64;
+
+        s = S{x:3};
+        t = T{x:4};
+        s_ref = &mut s;
+        t_ref = &mut t;
+
+        if (copy(cond)) {
+            x_ref = &mut move(s_ref).x;
+        } else {
+            x_ref = &mut move(t_ref).x;
+        }
+
+        if (move(cond)) {
+            *move(x_ref) = 10;
+        } else {
+            *move(x_ref) = 0; // only T's invariant should fail
+        }
+        return move(s), move(t);
+    }
+}

--- a/language/move-prover/bytecode-to-boogie/tests/goldenfiles/libra_account.bpl
+++ b/language/move-prover/bytecode-to-boogie/tests/goldenfiles/libra_account.bpl
@@ -263,7 +263,7 @@ ensures old(b#Boolean(Boolean(!(b#Boolean(ExistsResource(__m, LibraCoin_MarketCa
     // bytecode translation starts here
     call __t4 := CopyOrMoveRef(capability);
 
-    // unimplemented instruction: NoOp
+    // unimplemented instruction: Pop(4)
 
     call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 0));
     __m := UpdateLocal(__m, __frame + 5, __tmp);

--- a/language/move-prover/bytecode-to-boogie/tests/goldenfiles/libra_coin.bpl
+++ b/language/move-prover/bytecode-to-boogie/tests/goldenfiles/libra_coin.bpl
@@ -207,7 +207,7 @@ ensures old(b#Boolean(Boolean(!(b#Boolean(ExistsResource(__m, LibraCoin_MarketCa
     // bytecode translation starts here
     call __t4 := CopyOrMoveRef(capability);
 
-    // unimplemented instruction: NoOp
+    // unimplemented instruction: Pop(4)
 
     call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 0));
     __m := UpdateLocal(__m, __frame + 5, __tmp);

--- a/language/move-prover/bytecode-to-boogie/tests/goldenfiles/test-struct.bpl
+++ b/language/move-prover/bytecode-to-boogie/tests/goldenfiles/test-struct.bpl
@@ -262,7 +262,7 @@ Label_8:
 
     call __t12 := CopyOrMoveRef(t_ref1);
 
-    // unimplemented instruction: NoOp
+    // unimplemented instruction: Pop(12)
 
     call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 0));
     __m := UpdateLocal(__m, __frame + 13, __tmp);
@@ -279,7 +279,7 @@ Label_8:
 
     call __t15 := CopyOrMoveRef(t_ref2);
 
-    // unimplemented instruction: NoOp
+    // unimplemented instruction: Pop(15)
 
     call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 0));
     __m := UpdateLocal(__m, __frame + 16, __tmp);

--- a/language/move-prover/bytecode-to-boogie/tests/goldenfiles/verify-invariants.bpl
+++ b/language/move-prover/bytecode-to-boogie/tests/goldenfiles/verify-invariants.bpl
@@ -208,12 +208,12 @@ ensures b#Boolean(Boolean(IsEqual(SelectField(__ret0, TestInvariants_T_i), Integ
     call WriteRef(__t7, GetLocal(__m, __frame + 6));
     assume $DebugTrackLocal(0, 2, 0, 1005, GetLocal(__m, __frame + 0));
 
+    call $TestInvariants_T_update_inv(__before_borrow_0, Dereference(__m, __before_borrow_0_ref));
     call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 0));
     __m := UpdateLocal(__m, __frame + 8, __tmp);
 
     __ret0 := GetLocal(__m, __frame + 8);
     assume $DebugTrackLocal(0, 2, 2, 1030, __ret0);
-    call $TestInvariants_T_update_inv(__before_borrow_0, Dereference(__m, __before_borrow_0_ref));
     return;
 
 Label_Abort:
@@ -288,12 +288,12 @@ ensures b#Boolean(Boolean(IsEqual(SelectField(__ret0, TestInvariants_T_i), Integ
     call WriteRef(__t7, GetLocal(__m, __frame + 6));
     assume $DebugTrackLocal(0, 3, 0, 1209, GetLocal(__m, __frame + 0));
 
+    call $TestInvariants_T_update_inv(__before_borrow_0, Dereference(__m, __before_borrow_0_ref));
     call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 0));
     __m := UpdateLocal(__m, __frame + 8, __tmp);
 
     __ret0 := GetLocal(__m, __frame + 8);
     assume $DebugTrackLocal(0, 3, 2, 1234, __ret0);
-    call $TestInvariants_T_update_inv(__before_borrow_0, Dereference(__m, __before_borrow_0_ref));
     return;
 
 Label_Abort:
@@ -367,12 +367,12 @@ ensures b#Boolean(Boolean(IsEqual(SelectField(__ret0, TestInvariants_T_i), Integ
     call WriteRef(__t7, GetLocal(__m, __frame + 5));
     assume $DebugTrackLocal(0, 4, 0, 1424, GetLocal(__m, __frame + 0));
 
+    call $TestInvariants_T_update_inv(__before_borrow_0, Dereference(__m, __before_borrow_0_ref));
     call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 0));
     __m := UpdateLocal(__m, __frame + 8, __tmp);
 
     __ret0 := GetLocal(__m, __frame + 8);
     assume $DebugTrackLocal(0, 4, 2, 1451, __ret0);
-    call $TestInvariants_T_update_inv(__before_borrow_0, Dereference(__m, __before_borrow_0_ref));
     return;
 
 Label_Abort:

--- a/language/move-prover/bytecode-to-boogie/tests/goldenfiles/verify-lifetime.bpl
+++ b/language/move-prover/bytecode-to-boogie/tests/goldenfiles/verify-lifetime.bpl
@@ -1,0 +1,359 @@
+
+
+// ** synthetics of module TestLifetime
+
+
+
+// ** structs of module TestLifetime
+
+const unique TestLifetime_S: TypeName;
+const TestLifetime_S_x: FieldName;
+axiom TestLifetime_S_x == 0;
+function TestLifetime_S_type_value(): TypeValue {
+    StructType(TestLifetime_S, ExtendTypeValueArray(EmptyTypeValueArray, IntegerType()))
+}
+function {:inline 1} $TestLifetime_S_is_well_formed(__this: Value): bool {
+    is#Vector(__this)
+        && IsValidU64(SelectField(__this, TestLifetime_S_x))
+        && b#Boolean(Boolean(i#Integer(SelectField(__this, TestLifetime_S_x)) > i#Integer(Integer(1))))
+}
+
+procedure {:inline 1} $TestLifetime_S_update_inv(__before: Value, __after: Value) {
+    assert b#Boolean(Boolean(i#Integer(SelectField(__after, TestLifetime_S_x)) > i#Integer(Integer(1))));
+}
+
+procedure {:inline 1} Pack_TestLifetime_S(module_idx: int, func_idx: int, var_idx: int, code_idx: int, x: Value) returns (_struct: Value)
+{
+    assume IsValidU64(x);
+    _struct := Vector(ExtendValueArray(EmptyValueArray, x));
+    if (code_idx > 0) { assume $DebugTrackLocal(module_idx, func_idx, var_idx, code_idx, _struct); }
+    assert b#Boolean(Boolean(i#Integer(SelectField(_struct, TestLifetime_S_x)) > i#Integer(Integer(1))));
+}
+
+procedure {:inline 1} Unpack_TestLifetime_S(_struct: Value) returns (x: Value)
+{
+    assume is#Vector(_struct);
+    x := SelectField(_struct, TestLifetime_S_x);
+    assume IsValidU64(x);
+}
+
+const unique TestLifetime_T: TypeName;
+const TestLifetime_T_x: FieldName;
+axiom TestLifetime_T_x == 0;
+function TestLifetime_T_type_value(): TypeValue {
+    StructType(TestLifetime_T, ExtendTypeValueArray(EmptyTypeValueArray, IntegerType()))
+}
+function {:inline 1} $TestLifetime_T_is_well_formed(__this: Value): bool {
+    is#Vector(__this)
+        && IsValidU64(SelectField(__this, TestLifetime_T_x))
+        && b#Boolean(Boolean(i#Integer(SelectField(__this, TestLifetime_T_x)) > i#Integer(Integer(1))))
+}
+
+procedure {:inline 1} $TestLifetime_T_update_inv(__before: Value, __after: Value) {
+    assert b#Boolean(Boolean(i#Integer(SelectField(__after, TestLifetime_T_x)) > i#Integer(Integer(1))));
+}
+
+procedure {:inline 1} Pack_TestLifetime_T(module_idx: int, func_idx: int, var_idx: int, code_idx: int, x: Value) returns (_struct: Value)
+{
+    assume IsValidU64(x);
+    _struct := Vector(ExtendValueArray(EmptyValueArray, x));
+    if (code_idx > 0) { assume $DebugTrackLocal(module_idx, func_idx, var_idx, code_idx, _struct); }
+    assert b#Boolean(Boolean(i#Integer(SelectField(_struct, TestLifetime_T_x)) > i#Integer(Integer(1))));
+}
+
+procedure {:inline 1} Unpack_TestLifetime_T(_struct: Value) returns (x: Value)
+{
+    assume is#Vector(_struct);
+    x := SelectField(_struct, TestLifetime_T_x);
+    assume IsValidU64(x);
+}
+
+
+
+// ** functions of module TestLifetime
+
+procedure {:inline 1} TestLifetime_invalid_S () returns (__ret0: Value)
+requires ExistsTxnSenderAccount(__m, __txn);
+{
+    // declare local variables
+    var s: Value; // TestLifetime_S_type_value()
+    var s_ref: Reference; // ReferenceType(TestLifetime_S_type_value())
+    var x_ref: Reference; // ReferenceType(IntegerType())
+    var __t3: Value; // IntegerType()
+    var __t4: Value; // TestLifetime_S_type_value()
+    var __t5: Reference; // ReferenceType(TestLifetime_S_type_value())
+    var __t6: Reference; // ReferenceType(TestLifetime_S_type_value())
+    var __t7: Reference; // ReferenceType(IntegerType())
+    var __t8: Value; // IntegerType()
+    var __t9: Reference; // ReferenceType(IntegerType())
+    var __t10: Reference; // ReferenceType(TestLifetime_S_type_value())
+    var __t11: Reference; // ReferenceType(TestLifetime_S_type_value())
+    var __t12: Reference; // ReferenceType(IntegerType())
+    var __t13: Value; // IntegerType()
+    var __t14: Reference; // ReferenceType(IntegerType())
+    var __t15: Value; // TestLifetime_S_type_value()
+    var __tmp: Value;
+    var __frame: int;
+    var __saved_m: Memory;
+    var __before_borrow_0: Value;
+    var __before_borrow_0_ref: Reference;
+    var __before_borrow_1: Value;
+    var __before_borrow_1_ref: Reference;
+
+    // initialize function execution
+    assume !__abort_flag;
+    __saved_m := __m;
+    __frame := __local_counter;
+
+    // process and type check arguments
+
+    // increase the local counter
+    __local_counter := __local_counter + 16;
+
+    // bytecode translation starts here
+    call __tmp := LdConst(3);
+    __m := UpdateLocal(__m, __frame + 3, __tmp);
+
+    call __tmp := Pack_TestLifetime_S(0, 0, 0, 367, GetLocal(__m, __frame + 3));
+    __m := UpdateLocal(__m, __frame + 4, __tmp);
+
+    call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 4));
+    __m := UpdateLocal(__m, __frame + 0, __tmp);
+    assume $DebugTrackLocal(0, 0, 0, 363, __tmp);
+
+    call __t5 := BorrowLoc(__frame + 0, TestLifetime_S_type_value());
+    __before_borrow_0 := Dereference(__m, __t5);
+    __before_borrow_0_ref := __t5;
+
+    call s_ref := CopyOrMoveRef(__t5);
+    assume $TestLifetime_S_is_well_formed(Dereference(__m, s_ref));
+    assume $DebugTrackLocal(0, 0, 1, 383, Dereference(__m, s_ref));
+
+    call __t6 := CopyOrMoveRef(s_ref);
+
+    call __t7 := BorrowField(__t6, TestLifetime_S_x);
+
+    call x_ref := CopyOrMoveRef(__t7);
+    assume IsValidU64(Dereference(__m, x_ref));
+    assume $DebugTrackLocal(0, 0, 2, 407, Dereference(__m, x_ref));
+
+    call __tmp := LdConst(0);
+    __m := UpdateLocal(__m, __frame + 8, __tmp);
+
+    call __t9 := CopyOrMoveRef(x_ref);
+
+    call WriteRef(__t9, GetLocal(__m, __frame + 8));
+    assume $DebugTrackLocal(0, 0, 0, 443, GetLocal(__m, __frame + 0));
+
+    call $TestLifetime_S_update_inv(__before_borrow_0, Dereference(__m, __before_borrow_0_ref));
+    call __t10 := BorrowLoc(__frame + 0, TestLifetime_S_type_value());
+    __before_borrow_1 := Dereference(__m, __t10);
+    __before_borrow_1_ref := __t10;
+
+    call s_ref := CopyOrMoveRef(__t10);
+    assume $TestLifetime_S_is_well_formed(Dereference(__m, s_ref));
+    assume $DebugTrackLocal(0, 0, 1, 502, Dereference(__m, s_ref));
+
+    call __t11 := CopyOrMoveRef(s_ref);
+
+    call __t12 := BorrowField(__t11, TestLifetime_S_x);
+
+    call x_ref := CopyOrMoveRef(__t12);
+    assume IsValidU64(Dereference(__m, x_ref));
+    assume $DebugTrackLocal(0, 0, 2, 526, Dereference(__m, x_ref));
+
+    call __tmp := LdConst(2);
+    __m := UpdateLocal(__m, __frame + 13, __tmp);
+
+    call __t14 := CopyOrMoveRef(x_ref);
+
+    call WriteRef(__t14, GetLocal(__m, __frame + 13));
+    assume $DebugTrackLocal(0, 0, 0, 562, GetLocal(__m, __frame + 0));
+
+    call $TestLifetime_S_update_inv(__before_borrow_1, Dereference(__m, __before_borrow_1_ref));
+    call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 0));
+    __m := UpdateLocal(__m, __frame + 15, __tmp);
+
+    __ret0 := GetLocal(__m, __frame + 15);
+    assume $DebugTrackLocal(0, 0, 3, 589, __ret0);
+    return;
+
+Label_Abort:
+    __abort_flag := true;
+    __m := __saved_m;
+    __ret0 := DefaultValue;
+}
+
+procedure TestLifetime_invalid_S_verify () returns (__ret0: Value)
+{
+    call InitVerification();
+    call __ret0 := TestLifetime_invalid_S();
+}
+
+procedure {:inline 1} TestLifetime_invalid_bool (cond: Value) returns (__ret0: Value, __ret1: Value)
+requires ExistsTxnSenderAccount(__m, __txn);
+{
+    // declare local variables
+    var s_ref: Reference; // ReferenceType(TestLifetime_S_type_value())
+    var s: Value; // TestLifetime_S_type_value()
+    var t_ref: Reference; // ReferenceType(TestLifetime_T_type_value())
+    var t: Value; // TestLifetime_T_type_value()
+    var x_ref: Reference; // ReferenceType(IntegerType())
+    var __t6: Value; // IntegerType()
+    var __t7: Value; // TestLifetime_S_type_value()
+    var __t8: Value; // IntegerType()
+    var __t9: Value; // TestLifetime_T_type_value()
+    var __t10: Reference; // ReferenceType(TestLifetime_S_type_value())
+    var __t11: Reference; // ReferenceType(TestLifetime_T_type_value())
+    var __t12: Value; // BooleanType()
+    var __t13: Reference; // ReferenceType(TestLifetime_S_type_value())
+    var __t14: Reference; // ReferenceType(IntegerType())
+    var __t15: Reference; // ReferenceType(TestLifetime_T_type_value())
+    var __t16: Reference; // ReferenceType(IntegerType())
+    var __t17: Value; // BooleanType()
+    var __t18: Value; // IntegerType()
+    var __t19: Reference; // ReferenceType(IntegerType())
+    var __t20: Value; // IntegerType()
+    var __t21: Reference; // ReferenceType(IntegerType())
+    var __t22: Value; // TestLifetime_S_type_value()
+    var __t23: Value; // TestLifetime_T_type_value()
+    var __tmp: Value;
+    var __frame: int;
+    var __saved_m: Memory;
+    var __before_borrow_0: Value;
+    var __before_borrow_0_ref: Reference;
+    var __before_borrow_1: Value;
+    var __before_borrow_1_ref: Reference;
+
+    // initialize function execution
+    assume !__abort_flag;
+    __saved_m := __m;
+    __frame := __local_counter;
+
+    // process and type check arguments
+    assume is#Boolean(cond);
+    __m := UpdateLocal(__m, __frame + 0, cond);
+    assume $DebugTrackLocal(0, 1, 0, 616, cond);
+
+    // increase the local counter
+    __local_counter := __local_counter + 24;
+
+    // bytecode translation starts here
+    call __tmp := LdConst(3);
+    __m := UpdateLocal(__m, __frame + 6, __tmp);
+
+    call __tmp := Pack_TestLifetime_S(0, 1, 2, 820, GetLocal(__m, __frame + 6));
+    __m := UpdateLocal(__m, __frame + 7, __tmp);
+
+    call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 7));
+    __m := UpdateLocal(__m, __frame + 2, __tmp);
+    assume $DebugTrackLocal(0, 1, 2, 816, __tmp);
+
+    call __tmp := LdConst(4);
+    __m := UpdateLocal(__m, __frame + 8, __tmp);
+
+    call __tmp := Pack_TestLifetime_T(0, 1, 4, 840, GetLocal(__m, __frame + 8));
+    __m := UpdateLocal(__m, __frame + 9, __tmp);
+
+    call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 9));
+    __m := UpdateLocal(__m, __frame + 4, __tmp);
+    assume $DebugTrackLocal(0, 1, 4, 836, __tmp);
+
+    call __t10 := BorrowLoc(__frame + 2, TestLifetime_S_type_value());
+    __before_borrow_0 := Dereference(__m, __t10);
+    __before_borrow_0_ref := __t10;
+
+    call s_ref := CopyOrMoveRef(__t10);
+    assume $TestLifetime_S_is_well_formed(Dereference(__m, s_ref));
+    assume $DebugTrackLocal(0, 1, 1, 856, Dereference(__m, s_ref));
+
+    call __t11 := BorrowLoc(__frame + 4, TestLifetime_T_type_value());
+    __before_borrow_1 := Dereference(__m, __t11);
+    __before_borrow_1_ref := __t11;
+
+    call t_ref := CopyOrMoveRef(__t11);
+    assume $TestLifetime_T_is_well_formed(Dereference(__m, t_ref));
+    assume $DebugTrackLocal(0, 1, 3, 880, Dereference(__m, t_ref));
+
+    call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 0));
+    __m := UpdateLocal(__m, __frame + 12, __tmp);
+
+    __tmp := GetLocal(__m, __frame + 12);
+    if (!b#Boolean(__tmp)) { goto Label_16; }
+
+    call __t13 := CopyOrMoveRef(s_ref);
+
+    call __t14 := BorrowField(__t13, TestLifetime_S_x);
+
+    call x_ref := CopyOrMoveRef(__t14);
+    assume IsValidU64(Dereference(__m, x_ref));
+    assume $DebugTrackLocal(0, 1, 5, 935, Dereference(__m, x_ref));
+
+    goto Label_19;
+
+Label_16:
+    call __t15 := CopyOrMoveRef(t_ref);
+
+    call __t16 := BorrowField(__t15, TestLifetime_T_x);
+
+    call x_ref := CopyOrMoveRef(__t16);
+    assume IsValidU64(Dereference(__m, x_ref));
+    assume $DebugTrackLocal(0, 1, 5, 992, Dereference(__m, x_ref));
+
+Label_19:
+    call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 0));
+    __m := UpdateLocal(__m, __frame + 17, __tmp);
+
+    __tmp := GetLocal(__m, __frame + 17);
+    if (!b#Boolean(__tmp)) { goto Label_25; }
+
+    call __tmp := LdConst(10);
+    __m := UpdateLocal(__m, __frame + 18, __tmp);
+
+    call __t19 := CopyOrMoveRef(x_ref);
+
+    call WriteRef(__t19, GetLocal(__m, __frame + 18));
+    assume $DebugTrackLocal(0, 1, 2, 1069, GetLocal(__m, __frame + 2));
+    assume $DebugTrackLocal(0, 1, 4, 1069, GetLocal(__m, __frame + 4));
+
+    call $TestLifetime_S_update_inv(__before_borrow_0, Dereference(__m, __before_borrow_0_ref));
+    call $TestLifetime_T_update_inv(__before_borrow_1, Dereference(__m, __before_borrow_1_ref));
+    goto Label_28;
+
+Label_25:
+    call __tmp := LdConst(0);
+    __m := UpdateLocal(__m, __frame + 20, __tmp);
+
+    call __t21 := CopyOrMoveRef(x_ref);
+
+    call WriteRef(__t21, GetLocal(__m, __frame + 20));
+    assume $DebugTrackLocal(0, 1, 2, 1117, GetLocal(__m, __frame + 2));
+    assume $DebugTrackLocal(0, 1, 4, 1117, GetLocal(__m, __frame + 4));
+
+    call $TestLifetime_S_update_inv(__before_borrow_0, Dereference(__m, __before_borrow_0_ref));
+    call $TestLifetime_T_update_inv(__before_borrow_1, Dereference(__m, __before_borrow_1_ref));
+Label_28:
+    call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 2));
+    __m := UpdateLocal(__m, __frame + 22, __tmp);
+
+    call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 4));
+    __m := UpdateLocal(__m, __frame + 23, __tmp);
+
+    __ret0 := GetLocal(__m, __frame + 22);
+    assume $DebugTrackLocal(0, 1, 6, 1187, __ret0);
+    __ret1 := GetLocal(__m, __frame + 23);
+    assume $DebugTrackLocal(0, 1, 7, 1187, __ret1);
+    return;
+
+Label_Abort:
+    __abort_flag := true;
+    __m := __saved_m;
+    __ret0 := DefaultValue;
+    __ret1 := DefaultValue;
+}
+
+procedure TestLifetime_invalid_bool_verify (cond: Value) returns (__ret0: Value, __ret1: Value)
+{
+    call InitVerification();
+    call __ret0, __ret1 := TestLifetime_invalid_bool(cond);
+}

--- a/language/move-prover/bytecode-to-boogie/tests/goldenfiles/verify-synthetics.bpl
+++ b/language/move-prover/bytecode-to-boogie/tests/goldenfiles/verify-synthetics.bpl
@@ -116,6 +116,7 @@ ensures b#Boolean(Boolean(IsEqual(__TestInvariants_syn, Integer(i#Integer(Intege
     call WriteRef(__t11, GetLocal(__m, __frame + 9));
     assume $DebugTrackLocal(0, 0, 1, 658, GetLocal(__m, __frame + 1));
 
+    call $TestInvariants_T_update_inv(__before_borrow_0, Dereference(__m, __before_borrow_0_ref));
     call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 0));
     __m := UpdateLocal(__m, __frame + 12, __tmp);
 
@@ -126,7 +127,6 @@ ensures b#Boolean(Boolean(IsEqual(__TestInvariants_syn, Integer(i#Integer(Intege
     __m := UpdateLocal(__m, __frame + 3, __tmp);
     assume $DebugTrackLocal(0, 0, 3, 687, __tmp);
 
-    call $TestInvariants_T_update_inv(__before_borrow_0, Dereference(__m, __before_borrow_0_ref));
     return;
 
 Label_Abort:
@@ -214,6 +214,7 @@ ensures b#Boolean(Boolean(IsEqual(__TestInvariants_syn, Integer(i#Integer(old(__
     call WriteRef(__t11, GetLocal(__m, __frame + 9));
     assume $DebugTrackLocal(0, 1, 1, 963, GetLocal(__m, __frame + 1));
 
+    call $TestInvariants_T_update_inv(__before_borrow_0, Dereference(__m, __before_borrow_0_ref));
     call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 0));
     __m := UpdateLocal(__m, __frame + 12, __tmp);
 
@@ -224,7 +225,6 @@ ensures b#Boolean(Boolean(IsEqual(__TestInvariants_syn, Integer(i#Integer(old(__
     __m := UpdateLocal(__m, __frame + 3, __tmp);
     assume $DebugTrackLocal(0, 1, 3, 992, __tmp);
 
-    call $TestInvariants_T_update_inv(__before_borrow_0, Dereference(__m, __before_borrow_0_ref));
     return;
 
 Label_Abort:

--- a/language/move-prover/bytecode-to-boogie/tests/goldenfiles/verify-vector.bpl
+++ b/language/move-prover/bytecode-to-boogie/tests/goldenfiles/verify-vector.bpl
@@ -2462,7 +2462,7 @@ ensures b#Boolean(Boolean(IsEqual(Integer(vlen(v)), __ret0)));
 
     call __t2 := Vector_length(IntegerType(), __t1);
     if (__abort_flag) {
-      assume $DebugTrackAbort(1, 23, 9014);
+      assume $DebugTrackAbort(1, 23, 9013);
       goto Label_Abort;
     }
     assume IsValidU64(__t2);
@@ -2470,7 +2470,7 @@ ensures b#Boolean(Boolean(IsEqual(Integer(vlen(v)), __ret0)));
     __m := UpdateLocal(__m, __frame + 2, __t2);
 
     __ret0 := GetLocal(__m, __frame + 2);
-    assume $DebugTrackLocal(1, 23, 1, 9007, __ret0);
+    assume $DebugTrackLocal(1, 23, 1, 9006, __ret0);
     return;
 
 Label_Abort:
@@ -2504,7 +2504,7 @@ ensures b#Boolean(Boolean(IsEqual(Integer(vlen(Dereference(__m, v))), __ret0)));
     // process and type check arguments
     assume $Vector_T_is_well_formed(Dereference(__m, v)) && IsValidReferenceParameter(__m, __local_counter, v);
     assume $Vector_T_is_well_formed(Dereference(__m, v));
-    assume $DebugTrackLocal(1, 24, 0, 9115, Dereference(__m, v));
+    assume $DebugTrackLocal(1, 24, 0, 9114, Dereference(__m, v));
 
     // increase the local counter
     __local_counter := __local_counter + 3;
@@ -2514,7 +2514,7 @@ ensures b#Boolean(Boolean(IsEqual(Integer(vlen(Dereference(__m, v))), __ret0)));
 
     call __t2 := Vector_length(IntegerType(), __t1);
     if (__abort_flag) {
-      assume $DebugTrackAbort(1, 24, 9209);
+      assume $DebugTrackAbort(1, 24, 9208);
       goto Label_Abort;
     }
     assume IsValidU64(__t2);
@@ -2522,7 +2522,7 @@ ensures b#Boolean(Boolean(IsEqual(Integer(vlen(Dereference(__m, v))), __ret0)));
     __m := UpdateLocal(__m, __frame + 2, __t2);
 
     __ret0 := GetLocal(__m, __frame + 2);
-    assume $DebugTrackLocal(1, 24, 1, 9202, __ret0);
+    assume $DebugTrackLocal(1, 24, 1, 9201, __ret0);
     return;
 
 Label_Abort:
@@ -2556,7 +2556,7 @@ ensures b#Boolean(Boolean(IsEqual(Integer(vlen(Dereference(__m, v))), __ret0)));
     // process and type check arguments
     assume $Vector_T_is_well_formed(Dereference(__m, v)) && IsValidReferenceParameter(__m, __local_counter, v);
     assume $Vector_T_is_well_formed(Dereference(__m, v));
-    assume $DebugTrackLocal(1, 25, 0, 9290, Dereference(__m, v));
+    assume $DebugTrackLocal(1, 25, 0, 9289, Dereference(__m, v));
 
     // increase the local counter
     __local_counter := __local_counter + 3;
@@ -2566,7 +2566,7 @@ ensures b#Boolean(Boolean(IsEqual(Integer(vlen(Dereference(__m, v))), __ret0)));
 
     call __t2 := Vector_length(tv0, __t1);
     if (__abort_flag) {
-      assume $DebugTrackAbort(1, 25, 9397);
+      assume $DebugTrackAbort(1, 25, 9396);
       goto Label_Abort;
     }
     assume IsValidU64(__t2);
@@ -2574,7 +2574,7 @@ ensures b#Boolean(Boolean(IsEqual(Integer(vlen(Dereference(__m, v))), __ret0)));
     __m := UpdateLocal(__m, __frame + 2, __t2);
 
     __ret0 := GetLocal(__m, __frame + 2);
-    assume $DebugTrackLocal(1, 25, 1, 9390, __ret0);
+    assume $DebugTrackLocal(1, 25, 1, 9389, __ret0);
     return;
 
 Label_Abort:
@@ -2613,10 +2613,10 @@ ensures old(b#Boolean(Boolean(i#Integer(i) >= i#Integer(Integer(vlen(v)))))) ==>
     // process and type check arguments
     assume $Vector_T_is_well_formed(v);
     __m := UpdateLocal(__m, __frame + 0, v);
-    assume $DebugTrackLocal(1, 26, 0, 9458, v);
+    assume $DebugTrackLocal(1, 26, 0, 9457, v);
     assume IsValidU64(i);
     __m := UpdateLocal(__m, __frame + 1, i);
-    assume $DebugTrackLocal(1, 26, 1, 9458, i);
+    assume $DebugTrackLocal(1, 26, 1, 9457, i);
 
     // increase the local counter
     __local_counter := __local_counter + 6;
@@ -2629,7 +2629,7 @@ ensures old(b#Boolean(Boolean(i#Integer(i) >= i#Integer(Integer(vlen(v)))))) ==>
 
     call __t4 := Vector_borrow(IntegerType(), __t2, GetLocal(__m, __frame + 3));
     if (__abort_flag) {
-      assume $DebugTrackAbort(1, 26, 9620);
+      assume $DebugTrackAbort(1, 26, 9619);
       goto Label_Abort;
     }
     assume IsValidU64(Dereference(__m, __t4)) && IsValidReferenceParameter(__m, __local_counter, __t4);
@@ -2641,7 +2641,7 @@ ensures old(b#Boolean(Boolean(i#Integer(i) >= i#Integer(Integer(vlen(v)))))) ==>
     __m := UpdateLocal(__m, __frame + 5, __tmp);
 
     __ret0 := GetLocal(__m, __frame + 5);
-    assume $DebugTrackLocal(1, 26, 2, 9612, __ret0);
+    assume $DebugTrackLocal(1, 26, 2, 9611, __ret0);
     return;
 
 Label_Abort:
@@ -2680,10 +2680,10 @@ ensures old(b#Boolean(Boolean(i#Integer(i) >= i#Integer(Integer(vlen(Dereference
     // process and type check arguments
     assume $Vector_T_is_well_formed(Dereference(__m, v)) && IsValidReferenceParameter(__m, __local_counter, v);
     assume $Vector_T_is_well_formed(Dereference(__m, v));
-    assume $DebugTrackLocal(1, 27, 0, 9730, Dereference(__m, v));
+    assume $DebugTrackLocal(1, 27, 0, 9729, Dereference(__m, v));
     assume IsValidU64(i);
     __m := UpdateLocal(__m, __frame + 1, i);
-    assume $DebugTrackLocal(1, 27, 1, 9730, i);
+    assume $DebugTrackLocal(1, 27, 1, 9729, i);
 
     // increase the local counter
     __local_counter := __local_counter + 6;
@@ -2696,7 +2696,7 @@ ensures old(b#Boolean(Boolean(i#Integer(i) >= i#Integer(Integer(vlen(Dereference
 
     call __t4 := Vector_borrow(IntegerType(), __t2, GetLocal(__m, __frame + 3));
     if (__abort_flag) {
-      assume $DebugTrackAbort(1, 27, 9895);
+      assume $DebugTrackAbort(1, 27, 9894);
       goto Label_Abort;
     }
     assume IsValidU64(Dereference(__m, __t4)) && IsValidReferenceParameter(__m, __local_counter, __t4);
@@ -2708,7 +2708,7 @@ ensures old(b#Boolean(Boolean(i#Integer(i) >= i#Integer(Integer(vlen(Dereference
     __m := UpdateLocal(__m, __frame + 5, __tmp);
 
     __ret0 := GetLocal(__m, __frame + 5);
-    assume $DebugTrackLocal(1, 27, 2, 9887, __ret0);
+    assume $DebugTrackLocal(1, 27, 2, 9886, __ret0);
     return;
 
 Label_Abort:
@@ -2749,10 +2749,10 @@ ensures old(b#Boolean(Boolean(i#Integer(i) >= i#Integer(Integer(vlen(Dereference
     // process and type check arguments
     assume $Vector_T_is_well_formed(Dereference(__m, v)) && IsValidReferenceParameter(__m, __local_counter, v);
     assume $Vector_T_is_well_formed(Dereference(__m, v));
-    assume $DebugTrackLocal(1, 28, 0, 9961, Dereference(__m, v));
+    assume $DebugTrackLocal(1, 28, 0, 9960, Dereference(__m, v));
     assume IsValidU64(i);
     __m := UpdateLocal(__m, __frame + 1, i);
-    assume $DebugTrackLocal(1, 28, 1, 9961, i);
+    assume $DebugTrackLocal(1, 28, 1, 9960, i);
 
     // increase the local counter
     __local_counter := __local_counter + 8;
@@ -2765,7 +2765,7 @@ ensures old(b#Boolean(Boolean(i#Integer(i) >= i#Integer(Integer(vlen(Dereference
 
     call __t4 := Vector_borrow(IntegerType(), __t2, GetLocal(__m, __frame + 3));
     if (__abort_flag) {
-      assume $DebugTrackAbort(1, 28, 10151);
+      assume $DebugTrackAbort(1, 28, 10150);
       goto Label_Abort;
     }
     assume IsValidU64(Dereference(__m, __t4)) && IsValidReferenceParameter(__m, __local_counter, __t4);
@@ -2781,13 +2781,13 @@ ensures old(b#Boolean(Boolean(i#Integer(i) >= i#Integer(Integer(vlen(Dereference
 
     call __tmp := Sub(GetLocal(__m, __frame + 5), GetLocal(__m, __frame + 6));
     if (__abort_flag) {
-      assume $DebugTrackAbort(1, 28, 10150);
+      assume $DebugTrackAbort(1, 28, 10149);
       goto Label_Abort;
     }
     __m := UpdateLocal(__m, __frame + 7, __tmp);
 
     __ret0 := GetLocal(__m, __frame + 7);
-    assume $DebugTrackLocal(1, 28, 2, 10143, __ret0);
+    assume $DebugTrackLocal(1, 28, 2, 10142, __ret0);
     return;
 
 Label_Abort:
@@ -2826,10 +2826,10 @@ ensures old(b#Boolean(Boolean(i#Integer(i) >= i#Integer(Integer(vlen(Dereference
     // process and type check arguments
     assume $Vector_T_is_well_formed(Dereference(__m, v)) && IsValidReferenceParameter(__m, __local_counter, v);
     assume $Vector_T_is_well_formed(Dereference(__m, v));
-    assume $DebugTrackLocal(1, 29, 0, 10245, Dereference(__m, v));
+    assume $DebugTrackLocal(1, 29, 0, 10244, Dereference(__m, v));
     assume IsValidU64(i);
     __m := UpdateLocal(__m, __frame + 1, i);
-    assume $DebugTrackLocal(1, 29, 1, 10245, i);
+    assume $DebugTrackLocal(1, 29, 1, 10244, i);
 
     // increase the local counter
     __local_counter := __local_counter + 6;
@@ -2842,7 +2842,7 @@ ensures old(b#Boolean(Boolean(i#Integer(i) >= i#Integer(Integer(vlen(Dereference
 
     call __t4 := Vector_borrow(tv0, __t2, GetLocal(__m, __frame + 3));
     if (__abort_flag) {
-      assume $DebugTrackAbort(1, 29, 10441);
+      assume $DebugTrackAbort(1, 29, 10440);
       goto Label_Abort;
     }
     assume IsValidReferenceParameter(__m, __local_counter, __t4);
@@ -2853,7 +2853,7 @@ ensures old(b#Boolean(Boolean(i#Integer(i) >= i#Integer(Integer(vlen(Dereference
     __m := UpdateLocal(__m, __frame + 5, __tmp);
 
     __ret0 := GetLocal(__m, __frame + 5);
-    assume $DebugTrackLocal(1, 29, 2, 10433, __ret0);
+    assume $DebugTrackLocal(1, 29, 2, 10432, __ret0);
     return;
 
 Label_Abort:
@@ -2893,13 +2893,13 @@ ensures old(b#Boolean(Boolean(i#Integer(i) >= i#Integer(Integer(vlen(v)))))) ==>
     // process and type check arguments
     assume $Vector_T_is_well_formed(v);
     __m := UpdateLocal(__m, __frame + 0, v);
-    assume $DebugTrackLocal(1, 30, 0, 10511, v);
+    assume $DebugTrackLocal(1, 30, 0, 10510, v);
     assume IsValidU64(i);
     __m := UpdateLocal(__m, __frame + 1, i);
-    assume $DebugTrackLocal(1, 30, 1, 10511, i);
+    assume $DebugTrackLocal(1, 30, 1, 10510, i);
     assume IsValidU64(e);
     __m := UpdateLocal(__m, __frame + 2, e);
-    assume $DebugTrackLocal(1, 30, 2, 10511, e);
+    assume $DebugTrackLocal(1, 30, 2, 10510, e);
 
     // increase the local counter
     __local_counter := __local_counter + 8;
@@ -2915,22 +2915,22 @@ ensures old(b#Boolean(Boolean(i#Integer(i) >= i#Integer(Integer(vlen(v)))))) ==>
 
     call __t6 := Vector_borrow_mut(IntegerType(), __t4, GetLocal(__m, __frame + 5));
     if (__abort_flag) {
-      assume $DebugTrackAbort(1, 30, 10650);
+      assume $DebugTrackAbort(1, 30, 10649);
       goto Label_Abort;
     }
     assume IsValidU64(Dereference(__m, __t6)) && IsValidReferenceParameter(__m, __local_counter, __t6);
 
 
-    assume $DebugTrackLocal(1, 30, 0, 10650, GetLocal(__m, __frame + 0));
+    assume $DebugTrackLocal(1, 30, 0, 10649, GetLocal(__m, __frame + 0));
 
     call WriteRef(__t6, GetLocal(__m, __frame + 3));
-    assume $DebugTrackLocal(1, 30, 0, 10648, GetLocal(__m, __frame + 0));
+    assume $DebugTrackLocal(1, 30, 0, 10647, GetLocal(__m, __frame + 0));
 
     call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 0));
     __m := UpdateLocal(__m, __frame + 7, __tmp);
 
     __ret0 := GetLocal(__m, __frame + 7);
-    assume $DebugTrackLocal(1, 30, 3, 10710, __ret0);
+    assume $DebugTrackLocal(1, 30, 3, 10709, __ret0);
     return;
 
 Label_Abort:
@@ -2969,13 +2969,13 @@ ensures old(b#Boolean(Boolean(i#Integer(i) >= i#Integer(Integer(vlen(Dereference
     // process and type check arguments
     assume $Vector_T_is_well_formed(Dereference(__m, v)) && IsValidReferenceParameter(__m, __local_counter, v);
     assume $Vector_T_is_well_formed(Dereference(__m, v));
-    assume $DebugTrackLocal(1, 31, 0, 10803, Dereference(__m, v));
+    assume $DebugTrackLocal(1, 31, 0, 10802, Dereference(__m, v));
     assume IsValidU64(i);
     __m := UpdateLocal(__m, __frame + 1, i);
-    assume $DebugTrackLocal(1, 31, 1, 10803, i);
+    assume $DebugTrackLocal(1, 31, 1, 10802, i);
     assume IsValidU64(e);
     __m := UpdateLocal(__m, __frame + 2, e);
-    assume $DebugTrackLocal(1, 31, 2, 10803, e);
+    assume $DebugTrackLocal(1, 31, 2, 10802, e);
 
     // increase the local counter
     __local_counter := __local_counter + 7;
@@ -2991,18 +2991,18 @@ ensures old(b#Boolean(Boolean(i#Integer(i) >= i#Integer(Integer(vlen(Dereference
 
     call __t6 := Vector_borrow_mut(IntegerType(), __t4, GetLocal(__m, __frame + 5));
     if (__abort_flag) {
-      assume $DebugTrackAbort(1, 31, 10931);
+      assume $DebugTrackAbort(1, 31, 10930);
       goto Label_Abort;
     }
     assume IsValidU64(Dereference(__m, __t6)) && IsValidReferenceParameter(__m, __local_counter, __t6);
 
 
     assume $Vector_T_is_well_formed(Dereference(__m, v));
-    assume $DebugTrackLocal(1, 31, 0, 10931, Dereference(__m, v));
+    assume $DebugTrackLocal(1, 31, 0, 10930, Dereference(__m, v));
 
     call WriteRef(__t6, GetLocal(__m, __frame + 3));
     assume $Vector_T_is_well_formed(Dereference(__m, v));
-    assume $DebugTrackLocal(1, 31, 0, 10929, Dereference(__m, v));
+    assume $DebugTrackLocal(1, 31, 0, 10928, Dereference(__m, v));
 
     return;
 
@@ -3041,12 +3041,12 @@ ensures old(b#Boolean(Boolean(i#Integer(i) >= i#Integer(Integer(vlen(Dereference
     // process and type check arguments
     assume $Vector_T_is_well_formed(Dereference(__m, v)) && IsValidReferenceParameter(__m, __local_counter, v);
     assume $Vector_T_is_well_formed(Dereference(__m, v));
-    assume $DebugTrackLocal(1, 32, 0, 11052, Dereference(__m, v));
+    assume $DebugTrackLocal(1, 32, 0, 11051, Dereference(__m, v));
     assume IsValidU64(i);
     __m := UpdateLocal(__m, __frame + 1, i);
-    assume $DebugTrackLocal(1, 32, 1, 11052, i);
+    assume $DebugTrackLocal(1, 32, 1, 11051, i);
     __m := UpdateLocal(__m, __frame + 2, e);
-    assume $DebugTrackLocal(1, 32, 2, 11052, e);
+    assume $DebugTrackLocal(1, 32, 2, 11051, e);
 
     // increase the local counter
     __local_counter := __local_counter + 7;
@@ -3062,18 +3062,18 @@ ensures old(b#Boolean(Boolean(i#Integer(i) >= i#Integer(Integer(vlen(Dereference
 
     call __t6 := Vector_borrow_mut(tv0, __t4, GetLocal(__m, __frame + 5));
     if (__abort_flag) {
-      assume $DebugTrackAbort(1, 32, 11305);
+      assume $DebugTrackAbort(1, 32, 11304);
       goto Label_Abort;
     }
     assume IsValidReferenceParameter(__m, __local_counter, __t6);
 
 
     assume $Vector_T_is_well_formed(Dereference(__m, v));
-    assume $DebugTrackLocal(1, 32, 0, 11305, Dereference(__m, v));
+    assume $DebugTrackLocal(1, 32, 0, 11304, Dereference(__m, v));
 
     call WriteRef(__t6, GetLocal(__m, __frame + 3));
     assume $Vector_T_is_well_formed(Dereference(__m, v));
-    assume $DebugTrackLocal(1, 32, 0, 11303, Dereference(__m, v));
+    assume $DebugTrackLocal(1, 32, 0, 11302, Dereference(__m, v));
 
     return;
 
@@ -3108,7 +3108,7 @@ requires ExistsTxnSenderAccount(__m, __txn);
     // process and type check arguments
     assume $Vector_T_is_well_formed(Dereference(__m, v)) && IsValidReferenceParameter(__m, __local_counter, v);
     assume $Vector_T_is_well_formed(Dereference(__m, v));
-    assume $DebugTrackLocal(1, 33, 0, 11445, Dereference(__m, v));
+    assume $DebugTrackLocal(1, 33, 0, 11444, Dereference(__m, v));
 
     // increase the local counter
     __local_counter := __local_counter + 5;
@@ -3118,7 +3118,7 @@ requires ExistsTxnSenderAccount(__m, __txn);
 
     call __t2 := Vector_length(IntegerType(), __t1);
     if (__abort_flag) {
-      assume $DebugTrackAbort(1, 33, 11677);
+      assume $DebugTrackAbort(1, 33, 11676);
       goto Label_Abort;
     }
     assume IsValidU64(__t2);
@@ -3132,7 +3132,7 @@ requires ExistsTxnSenderAccount(__m, __txn);
     __m := UpdateLocal(__m, __frame + 4, __tmp);
 
     __ret0 := GetLocal(__m, __frame + 4);
-    assume $DebugTrackLocal(1, 33, 1, 11670, __ret0);
+    assume $DebugTrackLocal(1, 33, 1, 11669, __ret0);
     return;
 
 Label_Abort:
@@ -3196,7 +3196,7 @@ ensures b#Boolean(Boolean(IsEqual(slice_vector(__ret1, i#Integer(Integer(1)), i#
     // bytecode translation starts here
     call __t2 := Vector_empty(IntegerType());
     if (__abort_flag) {
-      assume $DebugTrackAbort(1, 34, 12087);
+      assume $DebugTrackAbort(1, 34, 12086);
       goto Label_Abort;
     }
     assume $Vector_T_is_well_formed(__t2);
@@ -3205,11 +3205,11 @@ ensures b#Boolean(Boolean(IsEqual(slice_vector(__ret1, i#Integer(Integer(1)), i#
 
     call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 2));
     __m := UpdateLocal(__m, __frame + 0, __tmp);
-    assume $DebugTrackLocal(1, 34, 0, 12081, __tmp);
+    assume $DebugTrackLocal(1, 34, 0, 12080, __tmp);
 
     call __t3 := Vector_empty(IntegerType());
     if (__abort_flag) {
-      assume $DebugTrackAbort(1, 34, 12122);
+      assume $DebugTrackAbort(1, 34, 12121);
       goto Label_Abort;
     }
     assume $Vector_T_is_well_formed(__t3);
@@ -3218,7 +3218,7 @@ ensures b#Boolean(Boolean(IsEqual(slice_vector(__ret1, i#Integer(Integer(1)), i#
 
     call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 3));
     __m := UpdateLocal(__m, __frame + 1, __tmp);
-    assume $DebugTrackLocal(1, 34, 1, 12116, __tmp);
+    assume $DebugTrackLocal(1, 34, 1, 12115, __tmp);
 
     call __t4 := BorrowLoc(__frame + 0, Vector_T_type_value(IntegerType()));
 
@@ -3227,11 +3227,11 @@ ensures b#Boolean(Boolean(IsEqual(slice_vector(__ret1, i#Integer(Integer(1)), i#
 
     call Vector_push_back(IntegerType(), __t4, GetLocal(__m, __frame + 5));
     if (__abort_flag) {
-      assume $DebugTrackAbort(1, 34, 12151);
+      assume $DebugTrackAbort(1, 34, 12150);
       goto Label_Abort;
     }
-    assume $DebugTrackLocal(1, 34, 0, 12151, GetLocal(__m, __frame + 0));
-    assume $DebugTrackLocal(1, 34, 1, 12151, GetLocal(__m, __frame + 1));
+    assume $DebugTrackLocal(1, 34, 0, 12150, GetLocal(__m, __frame + 0));
+    assume $DebugTrackLocal(1, 34, 1, 12150, GetLocal(__m, __frame + 1));
 
     call __t6 := BorrowLoc(__frame + 0, Vector_T_type_value(IntegerType()));
 
@@ -3240,11 +3240,11 @@ ensures b#Boolean(Boolean(IsEqual(slice_vector(__ret1, i#Integer(Integer(1)), i#
 
     call Vector_push_back(IntegerType(), __t6, GetLocal(__m, __frame + 7));
     if (__abort_flag) {
-      assume $DebugTrackAbort(1, 34, 12195);
+      assume $DebugTrackAbort(1, 34, 12194);
       goto Label_Abort;
     }
-    assume $DebugTrackLocal(1, 34, 0, 12195, GetLocal(__m, __frame + 0));
-    assume $DebugTrackLocal(1, 34, 1, 12195, GetLocal(__m, __frame + 1));
+    assume $DebugTrackLocal(1, 34, 0, 12194, GetLocal(__m, __frame + 0));
+    assume $DebugTrackLocal(1, 34, 1, 12194, GetLocal(__m, __frame + 1));
 
     call __t8 := BorrowLoc(__frame + 1, Vector_T_type_value(IntegerType()));
 
@@ -3253,11 +3253,11 @@ ensures b#Boolean(Boolean(IsEqual(slice_vector(__ret1, i#Integer(Integer(1)), i#
 
     call Vector_push_back(IntegerType(), __t8, GetLocal(__m, __frame + 9));
     if (__abort_flag) {
-      assume $DebugTrackAbort(1, 34, 12240);
+      assume $DebugTrackAbort(1, 34, 12239);
       goto Label_Abort;
     }
-    assume $DebugTrackLocal(1, 34, 0, 12240, GetLocal(__m, __frame + 0));
-    assume $DebugTrackLocal(1, 34, 1, 12240, GetLocal(__m, __frame + 1));
+    assume $DebugTrackLocal(1, 34, 0, 12239, GetLocal(__m, __frame + 0));
+    assume $DebugTrackLocal(1, 34, 1, 12239, GetLocal(__m, __frame + 1));
 
     call __t10 := BorrowLoc(__frame + 1, Vector_T_type_value(IntegerType()));
 
@@ -3266,11 +3266,11 @@ ensures b#Boolean(Boolean(IsEqual(slice_vector(__ret1, i#Integer(Integer(1)), i#
 
     call Vector_push_back(IntegerType(), __t10, GetLocal(__m, __frame + 11));
     if (__abort_flag) {
-      assume $DebugTrackAbort(1, 34, 12284);
+      assume $DebugTrackAbort(1, 34, 12283);
       goto Label_Abort;
     }
-    assume $DebugTrackLocal(1, 34, 0, 12284, GetLocal(__m, __frame + 0));
-    assume $DebugTrackLocal(1, 34, 1, 12284, GetLocal(__m, __frame + 1));
+    assume $DebugTrackLocal(1, 34, 0, 12283, GetLocal(__m, __frame + 0));
+    assume $DebugTrackLocal(1, 34, 1, 12283, GetLocal(__m, __frame + 1));
 
     call __t12 := BorrowLoc(__frame + 1, Vector_T_type_value(IntegerType()));
 
@@ -3279,11 +3279,11 @@ ensures b#Boolean(Boolean(IsEqual(slice_vector(__ret1, i#Integer(Integer(1)), i#
 
     call Vector_push_back(IntegerType(), __t12, GetLocal(__m, __frame + 13));
     if (__abort_flag) {
-      assume $DebugTrackAbort(1, 34, 12328);
+      assume $DebugTrackAbort(1, 34, 12327);
       goto Label_Abort;
     }
-    assume $DebugTrackLocal(1, 34, 0, 12328, GetLocal(__m, __frame + 0));
-    assume $DebugTrackLocal(1, 34, 1, 12328, GetLocal(__m, __frame + 1));
+    assume $DebugTrackLocal(1, 34, 0, 12327, GetLocal(__m, __frame + 0));
+    assume $DebugTrackLocal(1, 34, 1, 12327, GetLocal(__m, __frame + 1));
 
     call __t14 := BorrowLoc(__frame + 1, Vector_T_type_value(IntegerType()));
 
@@ -3292,11 +3292,11 @@ ensures b#Boolean(Boolean(IsEqual(slice_vector(__ret1, i#Integer(Integer(1)), i#
 
     call Vector_push_back(IntegerType(), __t14, GetLocal(__m, __frame + 15));
     if (__abort_flag) {
-      assume $DebugTrackAbort(1, 34, 12372);
+      assume $DebugTrackAbort(1, 34, 12371);
       goto Label_Abort;
     }
-    assume $DebugTrackLocal(1, 34, 0, 12372, GetLocal(__m, __frame + 0));
-    assume $DebugTrackLocal(1, 34, 1, 12372, GetLocal(__m, __frame + 1));
+    assume $DebugTrackLocal(1, 34, 0, 12371, GetLocal(__m, __frame + 0));
+    assume $DebugTrackLocal(1, 34, 1, 12371, GetLocal(__m, __frame + 1));
 
     call __t16 := BorrowLoc(__frame + 1, Vector_T_type_value(IntegerType()));
 
@@ -3305,11 +3305,11 @@ ensures b#Boolean(Boolean(IsEqual(slice_vector(__ret1, i#Integer(Integer(1)), i#
 
     call Vector_push_back(IntegerType(), __t16, GetLocal(__m, __frame + 17));
     if (__abort_flag) {
-      assume $DebugTrackAbort(1, 34, 12416);
+      assume $DebugTrackAbort(1, 34, 12415);
       goto Label_Abort;
     }
-    assume $DebugTrackLocal(1, 34, 0, 12416, GetLocal(__m, __frame + 0));
-    assume $DebugTrackLocal(1, 34, 1, 12416, GetLocal(__m, __frame + 1));
+    assume $DebugTrackLocal(1, 34, 0, 12415, GetLocal(__m, __frame + 0));
+    assume $DebugTrackLocal(1, 34, 1, 12415, GetLocal(__m, __frame + 1));
 
     call __t18 := BorrowLoc(__frame + 1, Vector_T_type_value(IntegerType()));
 
@@ -3318,11 +3318,11 @@ ensures b#Boolean(Boolean(IsEqual(slice_vector(__ret1, i#Integer(Integer(1)), i#
 
     call Vector_push_back(IntegerType(), __t18, GetLocal(__m, __frame + 19));
     if (__abort_flag) {
-      assume $DebugTrackAbort(1, 34, 12460);
+      assume $DebugTrackAbort(1, 34, 12459);
       goto Label_Abort;
     }
-    assume $DebugTrackLocal(1, 34, 0, 12460, GetLocal(__m, __frame + 0));
-    assume $DebugTrackLocal(1, 34, 1, 12460, GetLocal(__m, __frame + 1));
+    assume $DebugTrackLocal(1, 34, 0, 12459, GetLocal(__m, __frame + 0));
+    assume $DebugTrackLocal(1, 34, 1, 12459, GetLocal(__m, __frame + 1));
 
     call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 0));
     __m := UpdateLocal(__m, __frame + 20, __tmp);
@@ -3331,9 +3331,9 @@ ensures b#Boolean(Boolean(IsEqual(slice_vector(__ret1, i#Integer(Integer(1)), i#
     __m := UpdateLocal(__m, __frame + 21, __tmp);
 
     __ret0 := GetLocal(__m, __frame + 20);
-    assume $DebugTrackLocal(1, 34, 2, 12504, __ret0);
+    assume $DebugTrackLocal(1, 34, 2, 12503, __ret0);
     __ret1 := GetLocal(__m, __frame + 21);
-    assume $DebugTrackLocal(1, 34, 3, 12504, __ret1);
+    assume $DebugTrackLocal(1, 34, 3, 12503, __ret1);
     return;
 
 Label_Abort:
@@ -3376,10 +3376,10 @@ ensures old(b#Boolean(Boolean(IsEqual(e, Integer(9223372036854775807))))) ==> __
     // process and type check arguments
     assume $Vector_T_is_well_formed(Dereference(__m, v)) && IsValidReferenceParameter(__m, __local_counter, v);
     assume $Vector_T_is_well_formed(Dereference(__m, v));
-    assume $DebugTrackLocal(1, 35, 0, 12594, Dereference(__m, v));
+    assume $DebugTrackLocal(1, 35, 0, 12593, Dereference(__m, v));
     assume IsValidU64(e);
     __m := UpdateLocal(__m, __frame + 1, e);
-    assume $DebugTrackLocal(1, 35, 1, 12594, e);
+    assume $DebugTrackLocal(1, 35, 1, 12593, e);
 
     // increase the local counter
     __local_counter := __local_counter + 8;
@@ -3393,14 +3393,14 @@ ensures old(b#Boolean(Boolean(IsEqual(e, Integer(9223372036854775807))))) ==> __
 
     call __tmp := AddU64(GetLocal(__m, __frame + 3), GetLocal(__m, __frame + 4));
     if (__abort_flag) {
-      assume $DebugTrackAbort(1, 35, 12798);
+      assume $DebugTrackAbort(1, 35, 12797);
       goto Label_Abort;
     }
     __m := UpdateLocal(__m, __frame + 5, __tmp);
 
     call __tmp := CopyOrMoveValue(GetLocal(__m, __frame + 5));
     __m := UpdateLocal(__m, __frame + 2, __tmp);
-    assume $DebugTrackLocal(1, 35, 2, 12794, __tmp);
+    assume $DebugTrackLocal(1, 35, 2, 12793, __tmp);
 
     call __t6 := CopyOrMoveRef(v);
 
@@ -3409,11 +3409,11 @@ ensures old(b#Boolean(Boolean(IsEqual(e, Integer(9223372036854775807))))) ==> __
 
     call Vector_push_back(IntegerType(), __t6, GetLocal(__m, __frame + 7));
     if (__abort_flag) {
-      assume $DebugTrackAbort(1, 35, 12819);
+      assume $DebugTrackAbort(1, 35, 12818);
       goto Label_Abort;
     }
     assume $Vector_T_is_well_formed(Dereference(__m, v));
-    assume $DebugTrackLocal(1, 35, 0, 12819, Dereference(__m, v));
+    assume $DebugTrackLocal(1, 35, 0, 12818, Dereference(__m, v));
 
     return;
 
@@ -3457,10 +3457,10 @@ ensures old(b#Boolean(Boolean(IsEqual(e, Integer(9223372036854775807))))) ==> __
     // process and type check arguments
     assume $Vector_T_is_well_formed(Dereference(__m, v)) && IsValidReferenceParameter(__m, __local_counter, v);
     assume $Vector_T_is_well_formed(Dereference(__m, v));
-    assume $DebugTrackLocal(1, 36, 0, 12904, Dereference(__m, v));
+    assume $DebugTrackLocal(1, 36, 0, 12903, Dereference(__m, v));
     assume IsValidU64(e);
     __m := UpdateLocal(__m, __frame + 1, e);
-    assume $DebugTrackLocal(1, 36, 1, 12904, e);
+    assume $DebugTrackLocal(1, 36, 1, 12903, e);
 
     // increase the local counter
     __local_counter := __local_counter + 8;
@@ -3476,18 +3476,18 @@ ensures old(b#Boolean(Boolean(IsEqual(e, Integer(9223372036854775807))))) ==> __
 
     call __tmp := AddU64(GetLocal(__m, __frame + 3), GetLocal(__m, __frame + 4));
     if (__abort_flag) {
-      assume $DebugTrackAbort(1, 36, 13181);
+      assume $DebugTrackAbort(1, 36, 13180);
       goto Label_Abort;
     }
     __m := UpdateLocal(__m, __frame + 5, __tmp);
 
     call Vector_push_back(IntegerType(), __t2, GetLocal(__m, __frame + 5));
     if (__abort_flag) {
-      assume $DebugTrackAbort(1, 36, 13150);
+      assume $DebugTrackAbort(1, 36, 13149);
       goto Label_Abort;
     }
     assume $Vector_T_is_well_formed(Dereference(__m, v));
-    assume $DebugTrackLocal(1, 36, 0, 13150, Dereference(__m, v));
+    assume $DebugTrackLocal(1, 36, 0, 13149, Dereference(__m, v));
 
     call __t6 := CopyOrMoveRef(v);
 
@@ -3496,11 +3496,11 @@ ensures old(b#Boolean(Boolean(IsEqual(e, Integer(9223372036854775807))))) ==> __
 
     call Vector_push_back(IntegerType(), __t6, GetLocal(__m, __frame + 7));
     if (__abort_flag) {
-      assume $DebugTrackAbort(1, 36, 13201);
+      assume $DebugTrackAbort(1, 36, 13200);
       goto Label_Abort;
     }
     assume $Vector_T_is_well_formed(Dereference(__m, v));
-    assume $DebugTrackLocal(1, 36, 0, 13201, Dereference(__m, v));
+    assume $DebugTrackLocal(1, 36, 0, 13200, Dereference(__m, v));
 
     return;
 
@@ -3536,10 +3536,10 @@ ensures b#Boolean(Boolean(IsEqual(old(Dereference(__m, v)), slice_vector(Derefer
     // process and type check arguments
     assume $Vector_T_is_well_formed(Dereference(__m, v)) && IsValidReferenceParameter(__m, __local_counter, v);
     assume $Vector_T_is_well_formed(Dereference(__m, v));
-    assume $DebugTrackLocal(1, 37, 0, 13335, Dereference(__m, v));
+    assume $DebugTrackLocal(1, 37, 0, 13334, Dereference(__m, v));
     assume IsValidU64(e);
     __m := UpdateLocal(__m, __frame + 1, e);
-    assume $DebugTrackLocal(1, 37, 1, 13335, e);
+    assume $DebugTrackLocal(1, 37, 1, 13334, e);
 
     // increase the local counter
     __local_counter := __local_counter + 4;
@@ -3552,11 +3552,11 @@ ensures b#Boolean(Boolean(IsEqual(old(Dereference(__m, v)), slice_vector(Derefer
 
     call Vector_push_back(IntegerType(), __t2, GetLocal(__m, __frame + 3));
     if (__abort_flag) {
-      assume $DebugTrackAbort(1, 37, 13510);
+      assume $DebugTrackAbort(1, 37, 13509);
       goto Label_Abort;
     }
     assume $Vector_T_is_well_formed(Dereference(__m, v));
-    assume $DebugTrackLocal(1, 37, 0, 13510, Dereference(__m, v));
+    assume $DebugTrackLocal(1, 37, 0, 13509, Dereference(__m, v));
 
     return;
 
@@ -3592,9 +3592,9 @@ ensures b#Boolean(Boolean(IsEqual(old(Dereference(__m, v)), slice_vector(Derefer
     // process and type check arguments
     assume $Vector_T_is_well_formed(Dereference(__m, v)) && IsValidReferenceParameter(__m, __local_counter, v);
     assume $Vector_T_is_well_formed(Dereference(__m, v));
-    assume $DebugTrackLocal(1, 38, 0, 13619, Dereference(__m, v));
+    assume $DebugTrackLocal(1, 38, 0, 13618, Dereference(__m, v));
     __m := UpdateLocal(__m, __frame + 1, e);
-    assume $DebugTrackLocal(1, 38, 1, 13619, e);
+    assume $DebugTrackLocal(1, 38, 1, 13618, e);
 
     // increase the local counter
     __local_counter := __local_counter + 4;
@@ -3607,11 +3607,11 @@ ensures b#Boolean(Boolean(IsEqual(old(Dereference(__m, v)), slice_vector(Derefer
 
     call Vector_push_back(tv0, __t2, GetLocal(__m, __frame + 3));
     if (__abort_flag) {
-      assume $DebugTrackAbort(1, 38, 13811);
+      assume $DebugTrackAbort(1, 38, 13810);
       goto Label_Abort;
     }
     assume $Vector_T_is_well_formed(Dereference(__m, v));
-    assume $DebugTrackLocal(1, 38, 0, 13811, Dereference(__m, v));
+    assume $DebugTrackLocal(1, 38, 0, 13810, Dereference(__m, v));
 
     return;
 
@@ -3650,7 +3650,7 @@ ensures old(b#Boolean(Boolean(IsEqual(Integer(vlen(Dereference(__m, v))), Intege
     // process and type check arguments
     assume $Vector_T_is_well_formed(Dereference(__m, v)) && IsValidReferenceParameter(__m, __local_counter, v);
     assume $Vector_T_is_well_formed(Dereference(__m, v));
-    assume $DebugTrackLocal(1, 39, 0, 13949, Dereference(__m, v));
+    assume $DebugTrackLocal(1, 39, 0, 13948, Dereference(__m, v));
 
     // increase the local counter
     __local_counter := __local_counter + 3;
@@ -3660,17 +3660,17 @@ ensures old(b#Boolean(Boolean(IsEqual(Integer(vlen(Dereference(__m, v))), Intege
 
     call __t2 := Vector_pop_back(IntegerType(), __t1);
     if (__abort_flag) {
-      assume $DebugTrackAbort(1, 39, 14161);
+      assume $DebugTrackAbort(1, 39, 14160);
       goto Label_Abort;
     }
     assume IsValidU64(__t2);
 
     __m := UpdateLocal(__m, __frame + 2, __t2);
     assume $Vector_T_is_well_formed(Dereference(__m, v));
-    assume $DebugTrackLocal(1, 39, 0, 14161, Dereference(__m, v));
+    assume $DebugTrackLocal(1, 39, 0, 14160, Dereference(__m, v));
 
     __ret0 := GetLocal(__m, __frame + 2);
-    assume $DebugTrackLocal(1, 39, 1, 14154, __ret0);
+    assume $DebugTrackLocal(1, 39, 1, 14153, __ret0);
     return;
 
 Label_Abort:
@@ -3709,7 +3709,7 @@ ensures old(b#Boolean(Boolean(IsEqual(Integer(vlen(Dereference(__m, v))), Intege
     // process and type check arguments
     assume $Vector_T_is_well_formed(Dereference(__m, v)) && IsValidReferenceParameter(__m, __local_counter, v);
     assume $Vector_T_is_well_formed(Dereference(__m, v));
-    assume $DebugTrackLocal(1, 40, 0, 14244, Dereference(__m, v));
+    assume $DebugTrackLocal(1, 40, 0, 14243, Dereference(__m, v));
 
     // increase the local counter
     __local_counter := __local_counter + 3;
@@ -3719,16 +3719,16 @@ ensures old(b#Boolean(Boolean(IsEqual(Integer(vlen(Dereference(__m, v))), Intege
 
     call __t2 := Vector_pop_back(tv0, __t1);
     if (__abort_flag) {
-      assume $DebugTrackAbort(1, 40, 14474);
+      assume $DebugTrackAbort(1, 40, 14472);
       goto Label_Abort;
     }
 
     __m := UpdateLocal(__m, __frame + 2, __t2);
     assume $Vector_T_is_well_formed(Dereference(__m, v));
-    assume $DebugTrackLocal(1, 40, 0, 14474, Dereference(__m, v));
+    assume $DebugTrackLocal(1, 40, 0, 14472, Dereference(__m, v));
 
     __ret0 := GetLocal(__m, __frame + 2);
-    assume $DebugTrackLocal(1, 40, 1, 14467, __ret0);
+    assume $DebugTrackLocal(1, 40, 1, 14465, __ret0);
     return;
 
 Label_Abort:

--- a/language/move-prover/bytecode-to-boogie/tests/prover_tests.rs
+++ b/language/move-prover/bytecode-to-boogie/tests/prover_tests.rs
@@ -84,3 +84,8 @@ fn verify_invariants() {
 fn verify_synthetics() {
     test(VERIFY, &["test_mvir/verify-synthetics.mvir"]);
 }
+
+#[test]
+fn verify_lifetime() {
+    test(VERIFY, &["test_mvir/verify-lifetime.mvir"]);
+}

--- a/language/move-prover/stackless-bytecode-generator/src/stackless_bytecode.rs
+++ b/language/move-prover/stackless-bytecode-generator/src/stackless_bytecode.rs
@@ -106,7 +106,7 @@ pub enum StacklessBytecode {
     BrFalse(CodeOffset, TempIndex), // if(!t) goto code_offset
 
     Abort(TempIndex), // abort t
-    NoOp,
+    Pop(TempIndex),
 }
 
 impl StacklessBytecode {

--- a/language/move-prover/stackless-bytecode-generator/src/stackless_bytecode_generator.rs
+++ b/language/move-prover/stackless-bytecode-generator/src/stackless_bytecode_generator.rs
@@ -130,8 +130,8 @@ impl<'a> StacklessBytecodeGenerator<'a> {
     pub fn generate_bytecode(&mut self, bytecode: &Bytecode) {
         match bytecode {
             Bytecode::Pop => {
-                self.temp_stack.pop();
-                self.code.push(StacklessBytecode::NoOp);
+                let temp_index = self.temp_stack.pop().unwrap();
+                self.code.push(StacklessBytecode::Pop(temp_index));
             }
             Bytecode::BrTrue(code_offset) => {
                 let temp_index = self.temp_stack.pop().unwrap();

--- a/language/move-prover/stackless-bytecode-generator/tests/stack_elim_tests.rs
+++ b/language/move-prover/stackless-bytecode-generator/tests/stack_elim_tests.rs
@@ -45,7 +45,7 @@ fn transform_code_with_refs() {
         FreezeRef(10, 9),
         StLoc(4, 10),
         MoveLoc(11, 4),
-        NoOp,
+        Pop(11),
         MoveLoc(12, 3),
         ReadRef(13, 12),
         Ret(vec![13]),
@@ -578,7 +578,7 @@ fn transform_program_with_generics() {
         BorrowField(5, 4, FieldDefinitionIndex::new(0)),
         StLoc(2, 5),
         MoveLoc(6, 2),
-        NoOp,
+        Pop(6),
         MoveLoc(7, 0),
         Unpack(
             vec![8],


### PR DESCRIPTION
<!--
Thank you for sending a PR. We appreciate you spending time to help improve the Libra project.

The project is undergoing daily changes. Pull Requests will be reviewed and responded to as time permits.
-->

## Motivation

This PR integrates the result of lifetime analysis into bytecode to boogie translator.
At the end of each bytecode instruction, we query the analysis result to see if any mutable references become 'dead' at that point. If so, we check that the invariants on the structs/resources these references point to still hold after the mutation is done.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?

Yes.

## Test Plan

Added a test file `verify-lifetime.mvir`.

## Related PRs

https://github.com/libra/libra/pull/2664
