### PR TITLE
Add annotations and use const where appropriate

### DIFF
--- a/language/compiler/ir-to-bytecode/syntax/src/lexer.rs
+++ b/language/compiler/ir-to-bytecode/syntax/src/lexer.rs
@@ -185,7 +185,7 @@ impl<'input> Lexer<'input> {
         len: usize,
     ) -> Result<(), ParseError<usize, anyhow::Error>> {
         self.token = token;
-        self.cur_end = self.cur_start + len;
+        self.cur_end = self.cur_start.wrapping_add(len); // memory will run out long before this wraps
         Ok(())
     }
 }

--- a/language/move-vm/types/src/values/values_impl.rs
+++ b/language/move-vm/types/src/values/values_impl.rs
@@ -1572,7 +1572,7 @@ impl Container {
         match self {
             Self::General(v) => v
                 .iter()
-                .fold(*STRUCT_SIZE, |acc, v| acc.map2(v.size(), Add::add)),
+                .fold(STRUCT_SIZE, |acc, v| acc.map2(v.size(), Add::add)),
             Self::U8(v) => AbstractMemorySize::new((v.len() * size_of::<u8>()) as u64),
             Self::U64(v) => AbstractMemorySize::new((v.len() * size_of::<u64>()) as u64),
             Self::U128(v) => AbstractMemorySize::new((v.len() * size_of::<u128>()) as u64),
@@ -1583,13 +1583,13 @@ impl Container {
 
 impl ContainerRef {
     fn size(&self) -> AbstractMemorySize<GasCarrier> {
-        words_in(*REFERENCE_SIZE)
+        words_in(REFERENCE_SIZE)
     }
 }
 
 impl IndexedRef {
     fn size(&self) -> AbstractMemorySize<GasCarrier> {
-        words_in(*REFERENCE_SIZE)
+        words_in(REFERENCE_SIZE)
     }
 }
 
@@ -1598,7 +1598,7 @@ impl ValueImpl {
         use ValueImpl::*;
 
         match self {
-            Invalid | U8(_) | U64(_) | U128(_) | Bool(_) => *CONST_SIZE,
+            Invalid | U8(_) | U64(_) | U128(_) | Bool(_) => CONST_SIZE,
             Address(_) => AbstractMemorySize::new(ADDRESS_LENGTH as u64),
             ByteArray(key) => AbstractMemorySize::new(key.len() as u64),
             ContainerRef(r) => r.size(),
@@ -1639,7 +1639,7 @@ impl Reference {
 impl GlobalValue {
     pub fn size(&self) -> AbstractMemorySize<GasCarrier> {
         // TODO: should it be self.container.borrow().size()
-        words_in(*REFERENCE_SIZE)
+        words_in(REFERENCE_SIZE)
     }
 }
 

--- a/language/tools/vm-genesis/src/genesis_gas_schedule.rs
+++ b/language/tools/vm-genesis/src/genesis_gas_schedule.rs
@@ -123,7 +123,7 @@ pub(crate) fn initial_gas_schedule(move_vm: &MoveVM, data_view: &dyn RemoteCache
         .resolve_struct_def_by_name(
             &GAS_SCHEDULE_MODULE,
             &GAS_SCHEDULE_NAME,
-            &mut TransactionExecutionContext::new(*MAXIMUM_NUMBER_OF_GAS_UNITS, data_view),
+            &mut TransactionExecutionContext::new(MAXIMUM_NUMBER_OF_GAS_UNITS, data_view),
         )
         .expect("GasSchedule Module must exist");
     Value::simple_deserialize(&INITIAL_GAS_SCHEDULE, Type::Struct(struct_def)).unwrap()

--- a/language/vm/Cargo.toml
+++ b/language/vm/Cargo.toml
@@ -14,7 +14,7 @@ anyhow = "1.0"
 byteorder = "1.3.2"
 hex = "0.4.2"
 once_cell = "1.3.1"
-mirai-annotations = "1.4.0"
+mirai-annotations = "1.6.0"
 proptest = { version = "0.9", optional = true }
 proptest-derive = { version = "0.1.1", optional = true }
 ref-cast = "1.0"

--- a/language/vm/src/file_format_common.rs
+++ b/language/vm/src/file_format_common.rs
@@ -207,8 +207,6 @@ impl BinaryData {
 
     pub fn push(&mut self, item: u8) -> Result<()> {
         if self.len().checked_add(1).is_some() {
-            // This assumption tells MIRAI the implication of the success of the check
-            assume!(self._binary.len() < usize::max_value());
             self._binary.push(item);
         } else {
             bail!(
@@ -223,8 +221,6 @@ impl BinaryData {
     pub fn extend(&mut self, vec: &[u8]) -> Result<()> {
         let vec_len: usize = vec.len();
         if self.len().checked_add(vec_len).is_some() {
-            // This assumption tells MIRAI the implication of the success of the check
-            assume!(self._binary.len() <= usize::max_value() - vec_len);
             self._binary.extend(vec);
         } else {
             bail!(

--- a/language/vm/src/gas_schedule.rs
+++ b/language/vm/src/gas_schedule.rs
@@ -120,7 +120,7 @@ macro_rules! define_gas_unit {
 define_gas_unit! {
     name: AbstractMemorySize,
     carrier: GasCarrier,
-    doc: "A newtype wrapper that represents the (abstract) memory size that the instruciton will take up."
+    doc: "A newtype wrapper that represents the (abstract) memory size that the instruction will take up."
 }
 
 define_gas_unit! {
@@ -137,59 +137,51 @@ define_gas_unit! {
 
 /// The cost per-byte written to global storage.
 /// TODO: Fill this in with a proper number once it's determined.
-pub static GLOBAL_MEMORY_PER_BYTE_COST: Lazy<GasUnits<GasCarrier>> = Lazy::new(|| GasUnits::new(8));
+pub const GLOBAL_MEMORY_PER_BYTE_COST: GasUnits<GasCarrier> = GasUnits(8);
 
 /// The cost per-byte written to storage.
 /// TODO: Fill this in with a proper number once it's determined.
-pub static GLOBAL_MEMORY_PER_BYTE_WRITE_COST: Lazy<GasUnits<GasCarrier>> =
-    Lazy::new(|| GasUnits::new(8));
+pub const GLOBAL_MEMORY_PER_BYTE_WRITE_COST: GasUnits<GasCarrier> = GasUnits(8);
 
 /// The maximum size representable by AbstractMemorySize
-pub static MAX_ABSTRACT_MEMORY_SIZE: Lazy<AbstractMemorySize<GasCarrier>> =
-    Lazy::new(|| AbstractMemorySize::new(std::u64::MAX));
+pub const MAX_ABSTRACT_MEMORY_SIZE: AbstractMemorySize<GasCarrier> =
+    AbstractMemorySize(std::u64::MAX);
 
 /// The units of gas that should be charged per byte for every transaction.
-pub static INTRINSIC_GAS_PER_BYTE: Lazy<GasUnits<GasCarrier>> = Lazy::new(|| GasUnits::new(8));
+pub const INTRINSIC_GAS_PER_BYTE: GasUnits<GasCarrier> = GasUnits(8);
 
 /// The minimum gas price that a transaction can be submitted with.
-pub static MIN_PRICE_PER_GAS_UNIT: Lazy<GasPrice<GasCarrier>> = Lazy::new(|| GasPrice::new(0));
+pub const MIN_PRICE_PER_GAS_UNIT: GasPrice<GasCarrier> = GasPrice(0);
 
 /// The maximum gas unit price that a transaction can be submitted with.
-pub static MAX_PRICE_PER_GAS_UNIT: Lazy<GasPrice<GasCarrier>> = Lazy::new(|| GasPrice::new(10_000));
+pub const MAX_PRICE_PER_GAS_UNIT: GasPrice<GasCarrier> = GasPrice(10_000);
 
 /// 1 nanosecond should equal one unit of computational gas. We bound the maximum
 /// computational time of any given transaction at 10 milliseconds. We want this number and
 /// `MAX_PRICE_PER_GAS_UNIT` to always satisfy the inequality that
 ///         MAXIMUM_NUMBER_OF_GAS_UNITS * MAX_PRICE_PER_GAS_UNIT < min(u64::MAX, GasUnits<GasCarrier>::MAX)
-pub static MAXIMUM_NUMBER_OF_GAS_UNITS: Lazy<GasUnits<GasCarrier>> =
-    Lazy::new(|| GasUnits::new(1_000_000));
+pub const MAXIMUM_NUMBER_OF_GAS_UNITS: GasUnits<GasCarrier> = GasUnits(1_000_000);
 
 /// We charge one unit of gas per-byte for the first 600 bytes
-pub static MIN_TRANSACTION_GAS_UNITS: Lazy<GasUnits<GasCarrier>> = Lazy::new(|| GasUnits::new(600));
+pub const MIN_TRANSACTION_GAS_UNITS: GasUnits<GasCarrier> = GasUnits(600);
 
 /// The word size that we charge by
-pub static WORD_SIZE: Lazy<AbstractMemorySize<GasCarrier>> =
-    Lazy::new(|| AbstractMemorySize::new(8));
+pub const WORD_SIZE: AbstractMemorySize<GasCarrier> = AbstractMemorySize(8);
 
 /// The size in words for a non-string or address constant on the stack
-pub static CONST_SIZE: Lazy<AbstractMemorySize<GasCarrier>> =
-    Lazy::new(|| AbstractMemorySize::new(1));
+pub const CONST_SIZE: AbstractMemorySize<GasCarrier> = AbstractMemorySize(1);
 
 /// The size in words for a reference on the stack
-pub static REFERENCE_SIZE: Lazy<AbstractMemorySize<GasCarrier>> =
-    Lazy::new(|| AbstractMemorySize::new(8));
+pub const REFERENCE_SIZE: AbstractMemorySize<GasCarrier> = AbstractMemorySize(8);
 
 /// The size of a struct in words
-pub static STRUCT_SIZE: Lazy<AbstractMemorySize<GasCarrier>> =
-    Lazy::new(|| AbstractMemorySize::new(2));
+pub const STRUCT_SIZE: AbstractMemorySize<GasCarrier> = AbstractMemorySize(2);
 
 /// For V1 all accounts will be 32 words
-pub static DEFAULT_ACCOUNT_SIZE: Lazy<AbstractMemorySize<GasCarrier>> =
-    Lazy::new(|| AbstractMemorySize::new(32));
+pub const DEFAULT_ACCOUNT_SIZE: AbstractMemorySize<GasCarrier> = AbstractMemorySize(32);
 
 /// Any transaction over this size will be charged `INTRINSIC_GAS_PER_BYTE` per byte
-pub static LARGE_TRANSACTION_CUTOFF: Lazy<AbstractMemorySize<GasCarrier>> =
-    Lazy::new(|| AbstractMemorySize::new(600));
+pub const LARGE_TRANSACTION_CUTOFF: AbstractMemorySize<GasCarrier> = AbstractMemorySize(600);
 
 pub static GAS_SCHEDULE_NAME: Lazy<Identifier> = Lazy::new(|| Identifier::new("T").unwrap());
 
@@ -300,11 +292,15 @@ impl CostTable {
 
     #[inline]
     pub fn instruction_cost(&self, instr_index: u8) -> &GasCost {
+        precondition!(instr_index > 0 && instr_index <= (self.instruction_table.len() as u8));
         &self.instruction_table[(instr_index - 1) as usize]
     }
 
     #[inline]
     pub fn native_cost(&self, native_index: NativeCostIndex) -> &GasCost {
+        precondition!(
+            native_index as u8 > 0 && native_index as u8 <= (self.instruction_table.len() as u8)
+        );
         &self.native_table[native_index as usize]
     }
 
@@ -462,7 +458,7 @@ impl GasCost {
 pub fn words_in(size: AbstractMemorySize<GasCarrier>) -> AbstractMemorySize<GasCarrier> {
     precondition!(size.get() <= MAX_ABSTRACT_MEMORY_SIZE.get() - (WORD_SIZE.get() + 1));
     // round-up div truncate
-    size.map2(*WORD_SIZE, |size, word_size| {
+    size.map2(WORD_SIZE, |size, word_size| {
         // static invariant
         assume!(word_size > 0);
         // follows from the precondition
@@ -476,10 +472,10 @@ pub fn calculate_intrinsic_gas(
     transaction_size: AbstractMemorySize<GasCarrier>,
 ) -> GasUnits<GasCarrier> {
     precondition!(transaction_size.get() <= MAX_TRANSACTION_SIZE_IN_BYTES as GasCarrier);
-    let min_transaction_fee = *MIN_TRANSACTION_GAS_UNITS;
+    let min_transaction_fee = MIN_TRANSACTION_GAS_UNITS;
 
     if transaction_size.get() > LARGE_TRANSACTION_CUTOFF.get() {
-        let excess = words_in(transaction_size.sub(*LARGE_TRANSACTION_CUTOFF));
+        let excess = words_in(transaction_size.sub(LARGE_TRANSACTION_CUTOFF));
         min_transaction_fee.add(INTRINSIC_GAS_PER_BYTE.mul(excess))
     } else {
         min_transaction_fee.unitary_cast()

--- a/language/vm/src/serializer.rs
+++ b/language/vm/src/serializer.rs
@@ -836,11 +836,13 @@ impl CommonSerializer {
         binary: &mut BinaryData,
         tables: &T,
     ) -> Result<()> {
+        verify!(self.table_count == 0); // Should not be necessary, but it helps MIRAI right now
         self.serialize_module_handles(binary, tables.get_module_handles())?;
         self.serialize_struct_handles(binary, tables.get_struct_handles())?;
         self.serialize_function_handles(binary, tables.get_function_handles())?;
         self.serialize_type_signatures(binary, tables.get_type_signatures())?;
         self.serialize_function_signatures(binary, tables.get_function_signatures())?;
+        verify!(self.table_count < 6); // Should not be necessary, but it helps MIRAI right now
         self.serialize_locals_signatures(binary, tables.get_locals_signatures())?;
         self.serialize_identifiers(binary, tables.get_identifiers())?;
         self.serialize_addresses(binary, tables.get_address_pool())?;

--- a/language/vm/vm-runtime/Cargo.toml
+++ b/language/vm/vm-runtime/Cargo.toml
@@ -14,7 +14,7 @@ hex = "0.4.2"
 once_cell = "1.3.1"
 rayon = "1.1"
 rental = "0.5.4"
-mirai-annotations = "1.4.0"
+mirai-annotations = "1.6.0"
 prometheus = { version = "0.7.0", default-features = false }
 
 bytecode-verifier = { path = "../../bytecode-verifier", version = "0.1.0" }


### PR DESCRIPTION
## Motivation

Lazy static fields are hard for MIRAI to deal with and when used for compile time constants they also seem less than ideal.

Also add a few annotations to resolve MIRAI warnings.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

cargo build
cargo xtest

