### PR TITLE
[network] Remove role from identity exchange protocol

### DIFF
--- a/network/src/peer_manager/tests.rs
+++ b/network/src/peer_manager/tests.rs
@@ -64,7 +64,7 @@ fn build_test_connection() -> (Yamux<MemorySocket>, Yamux<MemorySocket>) {
 }
 
 fn build_test_identity(peer_id: PeerId) -> Identity {
-    Identity::new(peer_id, Vec::new(), RoleType::Validator)
+    Identity::new(peer_id, Vec::new())
 }
 
 fn ordered_peer_ids(num: usize) -> Vec<PeerId> {
@@ -98,8 +98,9 @@ fn build_test_peer_manager(
 
     let peer_manager = PeerManager::new(
         executor,
-        build_test_transport(Identity::new(peer_id, vec![], RoleType::Validator)),
+        build_test_transport(Identity::new(peer_id, vec![])),
         peer_id,
+        RoleType::Validator,
         "/memory/0".parse().unwrap(),
         peer_manager_request_rx,
         HashSet::from_iter([hello_protocol.clone()].iter().cloned()), /* rpc protocols */

--- a/network/src/protocols/identity.rs
+++ b/network/src/protocols/identity.rs
@@ -8,7 +8,6 @@
 use crate::ProtocolId;
 use bytes::BytesMut;
 use futures::io::{AsyncRead, AsyncWrite, AsyncWriteExt};
-use libra_config::config::RoleType;
 use libra_types::PeerId;
 use netcore::{
     framing::{read_u16frame, write_u16frame},
@@ -24,25 +23,19 @@ const IDENTITY_PROTOCOL_NAME: &[u8] = b"/identity/0.1.0";
 #[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
 pub struct Identity {
     peer_id: PeerId,
-    role: RoleType,
     supported_protocols: Vec<ProtocolId>,
 }
 
 impl Identity {
-    pub fn new(peer_id: PeerId, supported_protocols: Vec<ProtocolId>, role: RoleType) -> Self {
+    pub fn new(peer_id: PeerId, supported_protocols: Vec<ProtocolId>) -> Self {
         Self {
             peer_id,
-            role,
             supported_protocols,
         }
     }
 
     pub fn peer_id(&self) -> PeerId {
         self.peer_id
-    }
-
-    pub fn role(&self) -> RoleType {
-        self.role
     }
 
     pub fn is_protocol_supported(&self, protocol: &ProtocolId) -> bool {
@@ -104,7 +97,6 @@ mod tests {
         ProtocolId,
     };
     use futures::{executor::block_on, future::join};
-    use libra_config::config::RoleType;
     use libra_types::PeerId;
     use memsocket::MemorySocket;
     use netcore::transport::ConnectionOrigin;
@@ -122,7 +114,6 @@ mod tests {
                 ProtocolId::from_static(b"/proto/1.0.0"),
                 ProtocolId::from_static(b"/proto/2.0.0"),
             ],
-            RoleType::Validator,
         );
         let client_identity = Identity::new(
             PeerId::random(),
@@ -131,7 +122,6 @@ mod tests {
                 ProtocolId::from_static(b"/proto/2.0.0"),
                 ProtocolId::from_static(b"/proto/3.0.0"),
             ],
-            RoleType::Validator,
         );
         let server_identity_config = server_identity.clone();
         let client_identity_config = client_identity.clone();

--- a/network/src/validator_network/network_builder.rs
+++ b/network/src/validator_network/network_builder.rs
@@ -432,7 +432,7 @@ impl NetworkBuilder {
     /// Create the configured transport and start PeerManager.
     /// Return the actual Multiaddr over which this peer is listening.
     pub fn build(mut self) -> Multiaddr {
-        let identity = Identity::new(self.peer_id, self.supported_protocols(), self.role);
+        let identity = Identity::new(self.peer_id, self.supported_protocols());
         // Build network based on the transport type
         let trusted_peers = self.trusted_peers.clone();
         match self.transport {
@@ -474,6 +474,7 @@ impl NetworkBuilder {
             self.executor.clone(),
             transport,
             self.peer_id,
+            self.role,
             self.addr,
             self.pm_reqs_rx,
             HashSet::from_iter(self.rpc_protocols.into_iter()),


### PR DESCRIPTION
## Motivation

The role declared by a remote is non-verifiable anyway, so the listener
assumes that the role of the dialer is same as itself.