### PR TITLE
Refactors the test suite for secure storage backends.

### DIFF
--- a/secure/storage/src/in_memory.rs
+++ b/secure/storage/src/in_memory.rs
@@ -62,4 +62,10 @@ impl Storage for InMemoryStorage {
         self.data.insert(key.to_string(), value);
         Ok(())
     }
+
+    #[cfg(test)]
+    fn reset_and_clear(&mut self) -> Result<(), Error> {
+        self.data.clear();
+        Ok(())
+    }
 }

--- a/secure/storage/src/on_disk.rs
+++ b/secure/storage/src/on_disk.rs
@@ -84,4 +84,9 @@ impl Storage for OnDiskStorage {
         data.insert(key.to_string(), value);
         self.write(&data)
     }
+
+    #[cfg(test)]
+    fn reset_and_clear(&mut self) -> Result<(), Error> {
+        self.write(&HashMap::new())
+    }
 }

--- a/secure/storage/src/storage.rs
+++ b/secure/storage/src/storage.rs
@@ -70,4 +70,10 @@ pub trait Storage: Send + Sync {
             _ => Err(Error::UnexpectedValueType),
         }
     }
+
+    /// Resets and clears all data held in the storage engine.
+    /// Note: this should only be exposed and used for testing. Resetting the storage engine is not
+    /// something that should be supported in production.
+    #[cfg(test)]
+    fn reset_and_clear(&mut self) -> Result<(), Error>;
 }

--- a/secure/storage/src/tests/in_memory.rs
+++ b/secure/storage/src/tests/in_memory.rs
@@ -6,23 +6,5 @@ use crate::{in_memory::InMemoryStorage, tests::suite};
 #[test]
 fn in_memory() {
     let mut storage = Box::new(InMemoryStorage::new());
-    suite::run_test_suite(storage.as_mut(), "InMemoryStorage");
-}
-
-#[test]
-fn crypto_key_create_and_get() {
-    let mut storage = Box::new(InMemoryStorage::new());
-    suite::create_get_and_test_key_pair(storage.as_mut());
-}
-
-#[test]
-fn crypto_key_create_twice() {
-    let mut storage = Box::new(InMemoryStorage::new());
-    suite::create_key_pair_twice(storage.as_mut());
-}
-
-#[test]
-fn crypto_key_get_uncreated() {
-    let mut storage = Box::new(InMemoryStorage::new());
-    suite::get_uncreated_key_pair(storage.as_mut());
+    suite::execute_all_storage_tests(storage.as_mut());
 }

--- a/secure/storage/src/tests/on_disk.rs
+++ b/secure/storage/src/tests/on_disk.rs
@@ -8,26 +8,5 @@ use libra_temppath::TempPath;
 fn on_disk() {
     let temp_path = TempPath::new();
     let mut storage = Box::new(OnDiskStorage::new(temp_path.path().to_path_buf()));
-    suite::run_test_suite(storage.as_mut(), "OnDiskStorage");
-}
-
-#[test]
-fn crypto_key_create_and_get() {
-    let temp_path = TempPath::new();
-    let mut storage = Box::new(OnDiskStorage::new(temp_path.path().to_path_buf()));
-    suite::create_get_and_test_key_pair(storage.as_mut());
-}
-
-#[test]
-fn crypto_key_create_twice() {
-    let temp_path = TempPath::new();
-    let mut storage = Box::new(OnDiskStorage::new(temp_path.path().to_path_buf()));
-    suite::create_key_pair_twice(storage.as_mut());
-}
-
-#[test]
-fn crypto_key_get_uncreated() {
-    let temp_path = TempPath::new();
-    let mut storage = Box::new(OnDiskStorage::new(temp_path.path().to_path_buf()));
-    suite::get_uncreated_key_pair(storage.as_mut());
+    suite::execute_all_storage_tests(storage.as_mut());
 }

--- a/secure/storage/src/tests/suite.rs
+++ b/secure/storage/src/tests/suite.rs
@@ -5,80 +5,126 @@ use crate::{Error, Policy, Storage, Value};
 use libra_crypto::{ed25519::Ed25519PrivateKey, Uniform};
 use rand::{rngs::StdRng, SeedableRng};
 
-const KEY_KEY: &str = "key";
-const U64_KEY: &str = "u64";
+/// This suite contains tests for secure storage backends. We test the correct functionality
+/// of both key/value and cryptographic operations for storage implementations. All storage backend
+/// implementations should be tested using the tests in this suite.
 
-/// This helper function checks various features of the secure storage behaviour relating to K/V
-/// support, e.g., ensuring errors are returned when attempting to retrieve missing keys, and
-/// verifying sets and gets are implemented correctly.
-pub fn run_test_suite(storage: &mut dyn Storage, name: &str) {
-    assert!(
-        storage.available(),
-        eprintln!("Backend storage, {}, is not available", name)
-    );
+/// This holds the canonical list of secure storage tests. It allows different callers
+/// of the test suite to ensure they're executing all tests.
+/// Note: this is required because: (i) vault tests cannot be run in the usual fashion (i.e., vault
+/// tests rely on first running the vault docker script in `docker/vault/run.sh`); and (ii) vault
+/// tests cannot currently be run in parallel, as each test uses the same vault instance.
+const STORAGE_TESTS: &[fn(&mut dyn Storage)] = &[
+    test_ensure_storage_is_available,
+    test_create_get_set_unwrap,
+    test_create_key_value_twice,
+    test_get_set_non_existent,
+    test_verify_incorrect_value_types_unwrap,
+    test_create_get_and_test_key_pair,
+    test_create_key_pair_twice,
+    test_get_uncreated_key_pair,
+];
 
-    let public = Policy::public();
-    let u64_value_0 = 5;
-    let u64_value_1 = 2322;
+/// Storage data constants for testing purposes.
+const CRYPTO_KEY: &str = "Private Key";
+const U64_KEY: &str = "U64 Key";
+const CRYPTO_KEYPAIR_NAME: &str = "Test Key Name";
 
-    let mut rng = StdRng::from_seed([13u8; 32]);
-    let key_value_0 = Ed25519PrivateKey::generate_for_testing(&mut rng);
-    let key_value_1 = Ed25519PrivateKey::generate_for_testing(&mut rng);
+/// Executes all storage tests on a given storage backend.
+pub fn execute_all_storage_tests(storage: &mut dyn Storage) {
+    for test in STORAGE_TESTS.iter() {
+        test(storage);
+        storage
+            .reset_and_clear()
+            .expect("Failed to reset storage engine between tests!");
+    }
+}
+
+/// This test tries to get and set non-existent keys in storage and asserts that the correct
+/// errors are returned on these operations.
+fn test_get_set_non_existent(storage: &mut dyn Storage) {
+    let crypto_value = Value::Ed25519PrivateKey(create_ed25519_key_for_testing());
+    let u64_value = Value::U64(10);
 
     assert_eq!(
-        storage.get(KEY_KEY).unwrap_err(),
-        Error::KeyNotSet(KEY_KEY.to_string())
+        storage.get(CRYPTO_KEY).unwrap_err(),
+        Error::KeyNotSet(CRYPTO_KEY.to_string())
     );
     assert_eq!(
         storage.get(U64_KEY).unwrap_err(),
         Error::KeyNotSet(U64_KEY.to_string())
     );
-
     assert_eq!(
-        storage
-            .set(KEY_KEY, Value::Ed25519PrivateKey(key_value_0.clone()))
-            .unwrap_err(),
-        Error::KeyNotSet(KEY_KEY.to_string())
+        storage.set(CRYPTO_KEY, crypto_value).unwrap_err(),
+        Error::KeyNotSet(CRYPTO_KEY.to_string())
     );
     assert_eq!(
-        storage.set(U64_KEY, Value::U64(u64_value_0)).unwrap_err(),
+        storage.set(U64_KEY, u64_value).unwrap_err(),
         Error::KeyNotSet(U64_KEY.to_string())
     );
+}
+
+/// This test stores various key/value pairs in storage, updates them, retrieves the values and
+/// unwraps them to ensure the correct value types are returned.
+fn test_create_get_set_unwrap(storage: &mut dyn Storage) {
+    let crypto_private_1 = create_ed25519_key_for_testing();
+    let crypto_private_2 = create_ed25519_key_for_testing();
+    let u64_1 = 10;
+    let u64_2 = 647;
+    let policy = Policy::public();
 
     storage
-        .create_if_not_exists(U64_KEY, Value::U64(u64_value_1), &public)
+        .create_if_not_exists(U64_KEY, Value::U64(u64_1), &policy)
         .unwrap();
     storage
         .create(
-            KEY_KEY,
-            Value::Ed25519PrivateKey(key_value_1.clone()),
-            &public,
+            CRYPTO_KEY,
+            Value::Ed25519PrivateKey(crypto_private_1.clone()),
+            &policy,
         )
         .unwrap();
 
-    assert_eq!(storage.get(U64_KEY).unwrap().u64().unwrap(), u64_value_1);
+    assert_eq!(storage.get(U64_KEY).unwrap().u64().unwrap(), u64_1);
     assert_eq!(
-        &storage.get(KEY_KEY).unwrap().ed25519_private_key().unwrap(),
-        &key_value_1
+        &storage
+            .get(CRYPTO_KEY)
+            .unwrap()
+            .ed25519_private_key()
+            .unwrap(),
+        &crypto_private_1
     );
 
-    storage.set(U64_KEY, Value::U64(u64_value_0)).unwrap();
+    storage.set(U64_KEY, Value::U64(u64_2)).unwrap();
     storage
-        .set(KEY_KEY, Value::Ed25519PrivateKey(key_value_0.clone()))
+        .set(
+            CRYPTO_KEY,
+            Value::Ed25519PrivateKey(crypto_private_2.clone()),
+        )
         .unwrap();
 
-    assert_eq!(&storage.get(U64_KEY).unwrap().u64().unwrap(), &u64_value_0);
+    assert_eq!(storage.get(U64_KEY).unwrap().u64().unwrap(), u64_2);
     assert_eq!(
-        &storage.get(KEY_KEY).unwrap().ed25519_private_key().unwrap(),
-        &key_value_0
+        &storage
+            .get(CRYPTO_KEY)
+            .unwrap()
+            .ed25519_private_key()
+            .unwrap(),
+        &crypto_private_2
     );
+}
 
-    // Should not affect the above computation
+/// This test stores different types of values into storage, retrieves them, and asserts
+/// that the value unwrap functions return an unexpected type error on an incorrect unwrap.
+fn test_verify_incorrect_value_types_unwrap(storage: &mut dyn Storage) {
+    let crypto_value = Value::Ed25519PrivateKey(create_ed25519_key_for_testing());
+    let u64_value = Value::U64(10);
+    let policy = Policy::public();
+
     storage
-        .create_if_not_exists(U64_KEY, Value::U64(u64_value_1), &public)
+        .create_if_not_exists(U64_KEY, u64_value, &policy)
         .unwrap();
     storage
-        .create_if_not_exists(KEY_KEY, Value::Ed25519PrivateKey(key_value_1), &public)
+        .create_if_not_exists(CRYPTO_KEY, crypto_value, &policy)
         .unwrap();
 
     assert_eq!(
@@ -90,51 +136,74 @@ pub fn run_test_suite(storage: &mut dyn Storage, name: &str) {
         Error::UnexpectedValueType
     );
     assert_eq!(
-        storage.get(KEY_KEY).unwrap().u64().unwrap_err(),
+        storage.get(CRYPTO_KEY).unwrap().u64().unwrap_err(),
         Error::UnexpectedValueType
     );
-
-    // Attempt to perform a u64_key creation twice (i.e., for a key that already exists!)
-    assert!(storage
-        .create(U64_KEY, Value::U64(u64_value_1), &public)
-        .is_err());
 }
 
-/// This helper function: (i) creates a new named test key pair; (ii) retrieves the public key for
+/// This test attempts to create a key/value pair twice, asserting that the second
+/// creation attempt fails and returns a key exists error.
+fn test_create_key_value_twice(storage: &mut dyn Storage) {
+    let u64_value = 10;
+    let policy = Policy::public();
+
+    assert_eq!(
+        storage.create(U64_KEY, Value::U64(u64_value), &policy),
+        Ok(())
+    );
+    match storage.create(U64_KEY, Value::U64(u64_value), &policy) {
+        Err(Error::KeyAlreadyExists(_)) => (/* Expected error code */),
+        _ => panic!("The second call to create() should have failed!"),
+    }
+}
+
+/// This test: (i) creates a new named test key pair; (ii) retrieves the public key for
 /// the created key pair; (iii) compares the public keys returned by the create call and the
 /// retrieval call.
-pub fn create_get_and_test_key_pair(storage: &mut dyn Storage) {
-    let key_pair_name = "Test Key";
+fn test_create_get_and_test_key_pair(storage: &mut dyn Storage) {
     let public_key = storage
-        .generate_new_ed25519_key_pair(key_pair_name, &Policy::public())
+        .generate_new_ed25519_key_pair(CRYPTO_KEYPAIR_NAME, &Policy::public())
         .expect("Failed to create a test Ed25519 key pair!");
     let retrieved_public_key = storage
-        .get_public_key_for(key_pair_name)
+        .get_public_key_for(CRYPTO_KEYPAIR_NAME)
         .expect("Failed to fetch the test key pair!");
     assert_eq!(public_key, retrieved_public_key);
 }
 
-/// This helper function attempts to create two named key pairs using the same name, and asserts
+/// This test attempts to create two named key pairs using the same name, and asserts
 /// that the second creation call (i.e., the duplicate), fails.
-pub fn create_key_pair_twice(storage: &mut dyn Storage) {
-    let key_pair_name = "Test Key";
+fn test_create_key_pair_twice(storage: &mut dyn Storage) {
     let policy = Policy::public();
     let _ = storage
-        .generate_new_ed25519_key_pair(key_pair_name, &policy)
+        .generate_new_ed25519_key_pair(CRYPTO_KEYPAIR_NAME, &policy)
         .expect("Failed to create a test Ed25519 key pair!");
     assert!(
         storage
-            .generate_new_ed25519_key_pair(key_pair_name, &policy)
+            .generate_new_ed25519_key_pair(CRYPTO_KEYPAIR_NAME, &policy)
             .is_err(),
         "The second call to generate_ed25519_key_pair() should have failed!"
     );
 }
 
-/// This helper function tries to get the public key of a key pair that has not yet been created. As
+/// This test tries to get the public key of a key pair that has not yet been created. As
 /// such, it asserts that this attempt fails.
-pub fn get_uncreated_key_pair(storage: &mut dyn Storage) {
+fn test_get_uncreated_key_pair(storage: &mut dyn Storage) {
+    let key_pair_name = "Non-existent Key";
     assert!(
-        storage.get_public_key_for("Non-existent key").is_err(),
+        storage.get_public_key_for(key_pair_name).is_err(),
         "Accessing a key that has not yet been created should have failed!"
     );
+}
+
+/// This test verifies the storage engine is up and running.
+fn test_ensure_storage_is_available(storage: &mut dyn Storage) {
+    assert!(
+        storage.available(),
+        eprintln!("Backend storage is not available")
+    );
+}
+
+fn create_ed25519_key_for_testing() -> Ed25519PrivateKey {
+    let mut rng = StdRng::from_seed([13u8; 32]);
+    Ed25519PrivateKey::generate_for_testing(&mut rng)
 }

--- a/secure/storage/src/tests/vault.rs
+++ b/secure/storage/src/tests/vault.rs
@@ -9,37 +9,20 @@ use crate::{
 /// A test for verifying VaultStorage properly implements the LibraSecureStorage API. This test
 /// depends on running Vault, which can be done by using the provided docker run script in
 /// `docker/vault/run.sh`
-/// Note: because we only run a single vault backend for testing, we execute all tests sequentially
-/// using the method below.
-///
-/// TODO(joshlind): see how we can refactor this to run each test individually. This would better
-/// separate the testing of individual behaviours and help make failures easier to reason about.
-/// It would also be good to avoid having to call reset_vault_storage between tests..
-#[ignore]
 #[test]
-fn all_tests() {
+#[ignore]
+fn execute_storage_tests_vault() {
     let mut storage = Box::new(setup_vault());
-
-    // Test key/value related operations
-    suite::run_test_suite(storage.as_mut(), "VaultStorage");
-    reset_vault_storage(storage.as_mut());
-
-    // Test cryptographic key related operations
-    suite::create_get_and_test_key_pair(storage.as_mut());
-    reset_vault_storage(storage.as_mut());
-
-    suite::create_key_pair_twice(storage.as_mut());
-    reset_vault_storage(storage.as_mut());
-
-    suite::get_uncreated_key_pair(storage.as_mut());
-    reset_vault_storage(storage.as_mut());
+    suite::execute_all_storage_tests(storage.as_mut());
 }
 
-fn setup_vault() -> VaultStorage {
+/// Creates and returns a new VaultStorage instance for testing purposes.
+// TODO(joshlind): refactor this method to make it cleaner and easier to reason about.
+pub fn setup_vault() -> VaultStorage {
     let host = "http://localhost:8200".to_string();
     let token = "root_token".to_string();
     let mut storage = VaultStorage::new(host.clone(), token);
-    reset_vault_storage(&mut storage);
+    storage.reset_and_clear().unwrap();
 
     // @TODO davidiw, the following needs to be made generic but right now the creation of a token
     // / service is very backend specific.
@@ -125,13 +108,6 @@ fn setup_vault() -> VaultStorage {
     assert_eq!(storage.get("partial"), Ok(Value::U64(7)));
     assert_eq!(storage.get("full"), Ok(Value::U64(12)));
 
-    reset_vault_storage(&mut storage);
+    storage.reset_and_clear().unwrap();
     storage
-}
-
-/// Resets the internal state of vault for testing purposes (i.e., clears all stored data).
-fn reset_vault_storage(storage: &mut VaultStorage) {
-    storage
-        .reset()
-        .expect("Failed to reset vault storage state!");
 }

--- a/secure/storage/src/vault.rs
+++ b/secure/storage/src/vault.rs
@@ -105,4 +105,9 @@ impl Storage for VaultStorage {
         self.set_secret(&key, value)?;
         Ok(())
     }
+
+    #[cfg(test)]
+    fn reset_and_clear(&mut self) -> Result<(), Error> {
+        self.reset()
+    }
 }


### PR DESCRIPTION
## Motivation

This PR refactors the test suite for secure storage backends. Currently the test suite is not structured in a very modular way (e.g. the long run_test_suite() method). As a result, it's: (i) unclear exactly what tests and behaviours are being checked; and (ii) difficult to reason about test failures.

To address this, we split the run_test_suite() method into multiple different tests, and help unify the testing of all backends into a single location. This will make the test suite easier to extend when we add more storage functionality.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?

Yes.

## Test Plan

All new and old tests pass (including the tests for vault, run with the docker image and "--ignored" flag).

## Related PRs

None.
