### PR TITLE
[move-prover] Specification language type checker and translator.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4814,6 +4814,28 @@ version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "spec-lang"
+version = "0.1.0"
+dependencies = [
+ "anyhow 1.0.26 (registry+https://github.com/rust-lang/crates.io-index)",
+ "bytecode-source-map 0.1.0",
+ "bytecode-verifier 0.1.0",
+ "codespan 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "codespan-reporting 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "datatest-stable 0.1.0",
+ "itertools 0.8.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libra-types 0.1.0",
+ "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "move-ir-types 0.1.0",
+ "move-lang 0.0.1",
+ "num 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "regex 1.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "stdlib 0.1.0",
+ "test-utils 0.1.0",
+ "vm 0.1.0",
+]
+
+[[package]]
 name = "spin"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5158,6 +5180,15 @@ dependencies = [
  "utils 0.1.0",
  "vm 0.1.0",
  "vm-runtime 0.1.0",
+]
+
+[[package]]
+name = "test-utils"
+version = "0.1.0"
+dependencies = [
+ "anyhow 1.0.26 (registry+https://github.com/rust-lang/crates.io-index)",
+ "itertools 0.8.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "prettydiff 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -55,6 +55,8 @@ members = [
     "language/compiler/bytecode-source-map",
     "language/move-ir/types",
     "language/move-prover/bytecode-to-boogie",
+    "language/move-prover/spec-lang",
+    "language/move-prover/test-utils",
     "language/move-prover/stackless-bytecode-generator",
     "language/move-vm/cache",
     "language/move-vm/types",

--- a/language/move-lang/src/lib.rs
+++ b/language/move-lang/src/lib.rs
@@ -98,6 +98,26 @@ pub fn move_compile_no_report(
     })
 }
 
+/// Move compile up to expansion phase, returning errors instead of reporting them to stderr
+pub fn move_compile_to_expansion_no_report(
+    targets: &[String],
+    deps: &[String],
+    sender_opt: Option<Address>,
+) -> io::Result<(FilesSourceText, Result<expansion::ast::Program, Errors>)> {
+    let (files, pprog_res) = parse_program(targets, deps)?;
+    Ok(match pprog_res {
+        Ok(pprog) => {
+            let (eprog, errors) = expansion::translate::program(pprog, sender_opt);
+            if errors.is_empty() {
+                (files, Ok(eprog))
+            } else {
+                (files, Err(errors))
+            }
+        }
+        Err(errors) => (files, Err(errors)),
+    })
+}
+
 /// Runs the bytecode verifier on the compiled units
 /// Fails if the bytecode verifier errors
 pub fn sanity_check_compiled_units(

--- a/language/move-prover/spec-lang/Cargo.toml
+++ b/language/move-prover/spec-lang/Cargo.toml
@@ -1,0 +1,33 @@
+[package]
+name = "spec-lang"
+version = "0.1.0"
+authors = ["Libra <oncall+libra@xmail.facebook.com>"]
+publish = false
+edition = "2018"
+
+[dependencies]
+# libra dependencies
+move-lang = { path = "../../move-lang", version = "0.0.1" }
+bytecode-verifier = { path = "../../bytecode-verifier", version = "0.1.0" }
+vm = { path = "../../vm", version = "0.1.0" }
+libra-types = { path = "../../../types", version = "0.1.0" }
+bytecode-source-map = { path = "../../compiler/bytecode-source-map", version = "0.1.0" }
+move-ir-types = { path = "../../move-ir/types", version = "0.1.0" }
+stdlib = { path = "../../stdlib", version = "0.1.0" }
+
+# external dependencies
+codespan = "0.5.0"
+codespan-reporting = "0.5.0"
+itertools = "0.8.0"
+log = "0.4.8"
+num = "0.2.0"
+regex = "1.3.1"
+anyhow = "1.0.*"
+
+[dev-dependencies]
+datatest-stable = { path = "../../../common/datatest-stable", version = "0.1.0" }
+test-utils = { path = "../test-utils", version = "0.1.0" }
+
+[[test]]
+name = "testsuite"
+harness = false

--- a/language/move-prover/spec-lang/src/ast.rs
+++ b/language/move-prover/spec-lang/src/ast.rs
@@ -1,0 +1,274 @@
+// Copyright (c) The Libra Core Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+//! Contains AST definitions for the specification language fragments of the Move language.
+
+use num::{BigUint, Num};
+
+use crate::env::{FieldId, Loc, ModuleId, NodeId, SpecFunId, SpecVarId, StructId};
+use crate::symbol::{Symbol, SymbolPool};
+use crate::ty::Type;
+use std::fmt;
+use std::fmt::{Error, Formatter};
+
+// =================================================================================================
+/// # Declarations
+
+#[derive(Debug)]
+pub struct SpecVarDecl {
+    pub loc: Loc,
+    pub name: Symbol,
+    pub type_: Type,
+}
+
+#[derive(Debug)]
+pub struct SpecFunDecl {
+    pub loc: Loc,
+    pub name: Symbol,
+    pub type_params: Vec<(Symbol, Type)>,
+    pub params: Vec<(Symbol, Type)>,
+    pub result_type: Type,
+    pub body: Option<Exp>,
+}
+
+// =================================================================================================
+/// # Conditions
+
+#[derive(Debug, PartialEq)]
+pub enum ConditionKind {
+    AbortsIf,
+    Ensures,
+}
+
+#[derive(Debug)]
+pub struct Condition {
+    pub kind: ConditionKind,
+    pub exp: Exp,
+}
+
+// =================================================================================================
+/// # Invariants
+
+#[derive(Debug, PartialEq)]
+pub enum InvariantKind {
+    Data,
+    Update,
+    Pack,
+    Unpack,
+}
+
+#[derive(Debug)]
+pub struct Invariant {
+    pub kind: InvariantKind,
+    pub exp: Exp,
+}
+
+// =================================================================================================
+/// # Expressions
+
+#[derive(Debug)]
+pub enum Exp {
+    Error(NodeId),
+    Value(NodeId, Value),
+    LocalVar(NodeId, Symbol),
+    SpecVar(NodeId, ModuleId, SpecVarId),
+    Call(NodeId, Operation, Vec<Exp>),
+    Invoke(NodeId, Box<Exp>, Vec<Exp>),
+    Lambda(NodeId, Vec<LocalVarDecl>, Box<Exp>),
+    Block(NodeId, Vec<LocalVarDecl>, Box<Exp>),
+    IfElse(NodeId, Box<Exp>, Box<Exp>, Box<Exp>),
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub enum Operation {
+    Function(ModuleId, SpecFunId),
+    Pack(ModuleId, StructId),
+    FieldSelect(ModuleId, StructId, FieldId),
+    Result(usize),
+    Index,
+    Slice,
+
+    // Binary operators
+    Range,
+    Add,
+    Sub,
+    Mul,
+    Mod,
+    Div,
+    BitOr,
+    BitAnd,
+    Xor,
+    Shl,
+    Shr,
+    Implies,
+    And,
+    Or,
+    Eq,
+    Neq,
+    Lt,
+    Gt,
+    Le,
+    Ge,
+
+    // Unary operators
+    Not,
+
+    // Builtin functions
+    Len,
+    All,
+    Any,
+    Global,
+    Exists,
+    Old,
+    VectorUpdate,
+}
+
+#[derive(Debug)]
+pub struct LocalVarDecl {
+    pub id: NodeId,
+    pub name: Symbol,
+    pub binding: Option<Exp>,
+}
+
+#[derive(Debug, PartialEq)]
+pub enum Value {
+    Address(BigUint),
+    Number(BigUint),
+    Bool(bool),
+    Bytearray(Vec<u8>),
+}
+
+// =================================================================================================
+/// # Names
+
+/// Represents a module name, consisting of address and name.
+#[derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash, Clone)]
+pub struct ModuleName(BigUint, Symbol);
+
+impl ModuleName {
+    pub fn new(addr: BigUint, name: Symbol) -> ModuleName {
+        ModuleName(addr, name)
+    }
+
+    pub fn from_str(mut addr: &str, name: Symbol) -> ModuleName {
+        if addr.starts_with("0x") {
+            addr = &addr[2..];
+        }
+        let bi = BigUint::from_str_radix(addr, 16).expect("valid hex");
+        ModuleName(bi, name)
+    }
+
+    pub fn addr(&self) -> &BigUint {
+        &self.0
+    }
+
+    pub fn name(&self) -> Symbol {
+        self.1
+    }
+}
+
+impl ModuleName {
+    /// Creates a value implementing the Display trait which shows this name,
+    /// excluding address.
+    pub fn display<'a>(&'a self, pool: &'a SymbolPool) -> ModuleNameDisplay<'a> {
+        ModuleNameDisplay {
+            name: self,
+            pool,
+            with_address: false,
+        }
+    }
+
+    /// Creates a value implementing the Display trait which shows this name,
+    /// including address.
+    pub fn display_full<'a>(&'a self, pool: &'a SymbolPool) -> ModuleNameDisplay<'a> {
+        ModuleNameDisplay {
+            name: self,
+            pool,
+            with_address: true,
+        }
+    }
+}
+
+/// A helper to support module names in formatting.
+pub struct ModuleNameDisplay<'a> {
+    name: &'a ModuleName,
+    pool: &'a SymbolPool,
+    with_address: bool,
+}
+
+impl<'a> fmt::Display for ModuleNameDisplay<'a> {
+    fn fmt(&self, f: &mut Formatter<'_>) -> Result<(), Error> {
+        if self.with_address {
+            write!(f, "0x{}::", self.name.0.to_str_radix(16))?;
+        }
+        write!(f, "{}", self.name.1.display(self.pool))?;
+        Ok(())
+    }
+}
+
+#[derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash, Clone)]
+pub struct QualifiedSymbol {
+    pub module_name: ModuleName,
+    pub symbol: Symbol,
+}
+
+impl QualifiedSymbol {
+    /// Creates a value implementing the Display trait which shows this symbol,
+    /// including module name but excluding address.
+    pub fn display<'a>(&'a self, pool: &'a SymbolPool) -> QualifiedSymbolDisplay<'a> {
+        QualifiedSymbolDisplay {
+            sym: self,
+            pool,
+            with_module: true,
+            with_address: false,
+        }
+    }
+
+    /// Creates a value implementing the Display trait which shows this qualified symbol,
+    /// excluding module name.
+    pub fn display_simple<'a>(&'a self, pool: &'a SymbolPool) -> QualifiedSymbolDisplay<'a> {
+        QualifiedSymbolDisplay {
+            sym: self,
+            pool,
+            with_module: false,
+            with_address: false,
+        }
+    }
+
+    /// Creates a value implementing the Display trait which shows this symbol,
+    /// including module name with address.
+    pub fn display_full<'a>(&'a self, pool: &'a SymbolPool) -> QualifiedSymbolDisplay<'a> {
+        QualifiedSymbolDisplay {
+            sym: self,
+            pool,
+            with_module: true,
+            with_address: true,
+        }
+    }
+}
+
+/// A helper to support qualified symbols in formatting.
+pub struct QualifiedSymbolDisplay<'a> {
+    sym: &'a QualifiedSymbol,
+    pool: &'a SymbolPool,
+    with_module: bool,
+    with_address: bool,
+}
+
+impl<'a> fmt::Display for QualifiedSymbolDisplay<'a> {
+    fn fmt(&self, f: &mut Formatter<'_>) -> Result<(), Error> {
+        if self.with_module {
+            write!(
+                f,
+                "{}::",
+                if self.with_address {
+                    self.sym.module_name.display_full(self.pool)
+                } else {
+                    self.sym.module_name.display(self.pool)
+                }
+            )?;
+        }
+        write!(f, "{}", self.sym.symbol.display(self.pool))?;
+        Ok(())
+    }
+}

--- a/language/move-prover/spec-lang/src/env.rs
+++ b/language/move-prover/spec-lang/src/env.rs
@@ -1,0 +1,1133 @@
+// Copyright (c) The Libra Core Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+//! Provides an environment -- global state -- for translation, including helper functions
+//! to interpret metadata about the translation target.
+
+use std::cell::RefCell;
+
+use codespan::{FileId, Files, Location, Span};
+use codespan_reporting::diagnostic::{Diagnostic, Label, Severity};
+use codespan_reporting::term::{emit, termcolor::WriteColor, Config};
+use itertools::Itertools;
+use num::{BigUint, Num};
+
+use bytecode_source_map::source_map::ModuleSourceMap;
+use libra_types::language_storage;
+use vm::access::ModuleAccess;
+use vm::file_format::{
+    AddressPoolIndex, FieldDefinitionIndex, FunctionDefinitionIndex, FunctionHandleIndex, Kind,
+    LocalsSignatureIndex, SignatureToken, StructDefinitionIndex, StructFieldInformation,
+    StructHandleIndex,
+};
+use vm::views::{
+    FieldDefinitionView, FunctionDefinitionView, FunctionHandleView, SignatureTokenView,
+    StructDefinitionView, StructHandleView, ViewInternals,
+};
+
+use crate::ast::{Condition, Invariant, InvariantKind, ModuleName, SpecFunDecl, SpecVarDecl};
+use crate::symbol::{Symbol, SymbolPool};
+use crate::ty::{PrimitiveType, Type};
+use std::collections::BTreeMap;
+use vm::CompiledModule;
+
+// =================================================================================================
+/// # Locations
+
+/// A location, consisting of a FileId and a span in this file.
+#[derive(Debug, PartialEq, Clone)]
+pub struct Loc {
+    pub file_id: FileId,
+    pub span: Span,
+}
+
+// =================================================================================================
+/// # Identifiers
+///
+/// Identifiers are opaque values used to reference entities in the environment.
+///
+/// We have two kinds of ids: those based on an index, and those based on a symbol. We use
+/// the symbol based ids where we do not have control of the definition index order in bytecode
+/// (i.e. we do not know in which order move-lang enters functions and structs into file format),
+/// and index based ids where we do have control (for modules, SpecFun and SpecVar).
+///
+/// In any case, ids are opaque in the sense that if someone has a StructId or similar in hand,
+/// it is known to be defined in the environment, as it has been obtained also from the environment.
+
+/// Raw index type used in ids. 16 bits are sufficient currently.
+type RawIndex = u16;
+
+/// Identifier for a module.
+#[derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash, Clone, Copy)]
+pub struct ModuleId(RawIndex);
+
+/// Identifier for a structure/resource, relative to module.
+#[derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash, Clone, Copy)]
+pub struct StructId(Symbol);
+
+/// Identifier for a field of a structure, relative to struct.
+#[derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash, Clone, Copy)]
+pub struct FieldId(Symbol);
+
+/// Identifier for a Move function, relative to module.
+#[derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash, Clone, Copy)]
+pub struct FunId(Symbol);
+
+/// Identifier for a specification function, relative to module.
+#[derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash, Clone, Copy)]
+pub struct SpecFunId(RawIndex);
+
+/// Identifier for a specification variable, relative to module.
+#[derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash, Clone, Copy)]
+pub struct SpecVarId(RawIndex);
+
+/// Identifier for a node in the AST, relative to a function. This is used to associate attributes
+/// with the node, like source location and type.
+#[derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash, Clone, Copy)]
+pub struct NodeId(RawIndex);
+
+impl FunId {
+    pub fn new(sym: Symbol) -> Self {
+        Self(sym)
+    }
+
+    pub fn symbol(self) -> Symbol {
+        self.0
+    }
+}
+
+impl StructId {
+    pub fn new(sym: Symbol) -> Self {
+        Self(sym)
+    }
+
+    pub fn symbol(self) -> Symbol {
+        self.0
+    }
+}
+
+impl FieldId {
+    pub fn new(sym: Symbol) -> Self {
+        Self(sym)
+    }
+
+    pub fn symbol(self) -> Symbol {
+        self.0
+    }
+}
+
+impl SpecFunId {
+    pub fn new(idx: usize) -> Self {
+        Self(idx as RawIndex)
+    }
+}
+
+impl SpecVarId {
+    pub fn new(idx: usize) -> Self {
+        Self(idx as RawIndex)
+    }
+}
+
+impl NodeId {
+    pub fn new(idx: usize) -> Self {
+        Self(idx as RawIndex)
+    }
+}
+
+impl ModuleId {
+    pub fn new(idx: usize) -> Self {
+        Self(idx as RawIndex)
+    }
+}
+
+// =================================================================================================
+/// # Global Environment
+
+/// Global environment for a set of modules.
+#[derive(Debug)]
+pub struct GlobalEnv {
+    /// A Files database for the codespan crate which supports diagnostics.
+    source_files: Files,
+    /// A mapping from file names to associated FileId. Though this information is
+    /// already in `source_files`, we can't get it out of there so need to book keep here.
+    file_name_map: BTreeMap<String, FileId>,
+    /// Accumulated diagnosis. In a RefCell so we can add to it without needing a mutable GlobalEnv.
+    diags: RefCell<Vec<Diagnostic>>,
+    /// Pool of symbols -- internalized strings.
+    symbol_pool: SymbolPool,
+    /// List of loaded modules, in order they have been provided using `add`.
+    module_data: Vec<ModuleData>,
+}
+
+impl GlobalEnv {
+    /// Creates a new environment.
+    pub fn new() -> Self {
+        GlobalEnv {
+            source_files: Files::new(),
+            file_name_map: BTreeMap::new(),
+            diags: RefCell::new(vec![]),
+            symbol_pool: SymbolPool::new(),
+            module_data: vec![],
+        }
+    }
+
+    /// Returns a reference to the symbol pool owned by this environment.
+    pub fn symbol_pool(&self) -> &SymbolPool {
+        &self.symbol_pool
+    }
+
+    /// Adds a source to this environment, returning a FileId for it.
+    pub fn add_source(&mut self, file_name: &str, source: &str) -> FileId {
+        let file_id = self.source_files.add(file_name, source);
+        self.file_name_map.insert(file_name.to_string(), file_id);
+        file_id
+    }
+
+    /// Adds diagnostic to the environment.
+    pub fn add_diag(&self, diag: Diagnostic) {
+        self.diags.borrow_mut().push(diag);
+    }
+
+    /// Adds an error to this environment, with notes.
+    pub fn error_with_notes(&self, loc: &Loc, msg: &str, notes: Vec<String>) {
+        let diag = Diagnostic::new_error(msg, Label::new(loc.file_id, loc.span, ""));
+        let diag = diag.with_notes(notes);
+        self.add_diag(diag);
+    }
+
+    /// Adds an error to this environment, without notes.
+    pub fn error(&self, loc: &Loc, msg: &str) {
+        self.error_with_notes(loc, msg, vec![]);
+    }
+
+    /// Returns a default location. This is used as location of intrinsics which do not have
+    /// a real source location. This returns a location pointing to a source which has been added
+    /// to the environment with `add_source`. It crashes if no source exists.
+    pub fn default_loc(&self) -> Loc {
+        let (_, file_id) = self
+            .file_name_map
+            .iter()
+            .nth(0)
+            .expect("no source added to the environment");
+        Loc {
+            file_id: *file_id,
+            span: Span::default(),
+        }
+    }
+
+    /// Converts a Loc as used by the move-lang compiler to the one we are using here.
+    /// TODO: move-lang should use FileId as well so we don't need this here. There is already
+    /// a todo in their code to remove the current use of `&'static str` for file names in Loc.
+    pub fn to_loc(&self, loc: &move_lang::shared::Loc) -> Loc {
+        let file_id = self
+            .file_name_map
+            .get(loc.file())
+            .expect("file name undefined");
+        Loc {
+            file_id: *file_id,
+            span: loc.span(),
+        }
+    }
+
+    /// Returns true if diagnostics have error severity or worse.
+    pub fn has_errors(&self) -> bool {
+        self.diags
+            .borrow()
+            .iter()
+            .any(|d| d.severity >= Severity::Error)
+    }
+
+    /// Writes accumulated diagnostics to writer.
+    pub fn report_errors<W: WriteColor>(&self, writer: &mut W) {
+        for diag in self.diags.borrow().iter() {
+            emit(writer, &Config::default(), &self.source_files, diag).expect("emit must not fail");
+        }
+    }
+
+    /// Adds a new module to the environment. StructData and FunctionData need to be provided
+    /// in definition index order. See `create_function_data` and `create_struct_data` for how
+    /// to create them.
+    pub fn add(
+        &mut self,
+        source_file_id: FileId,
+        module: CompiledModule,
+        source_map: ModuleSourceMap<Span>,
+        struct_data: BTreeMap<StructId, StructData>,
+        function_data: BTreeMap<FunId, FunctionData>,
+        spec_vars: Vec<SpecVarDecl>,
+        spec_funs: Vec<SpecFunDecl>,
+        loc_map: BTreeMap<NodeId, Loc>,
+        type_map: BTreeMap<NodeId, Type>,
+    ) {
+        let idx = self.module_data.len();
+        let name = ModuleName::from_str(
+            &module.self_id().address().to_string(),
+            self.symbol_pool.make(module.self_id().name().as_str()),
+        );
+        self.module_data.push(ModuleData {
+            name,
+            id: ModuleId(idx as RawIndex),
+            module,
+            struct_data,
+            function_data,
+            spec_vars,
+            spec_funs,
+            source_map,
+            source_file_id,
+            loc_map,
+            type_map,
+        });
+    }
+
+    /// Creates data for a function, adding any information not contained in bytecode. This is
+    /// a helper for adding a new module to the environment.
+    pub fn create_function_data(
+        &self,
+        module: &CompiledModule,
+        def_idx: FunctionDefinitionIndex,
+        name: Symbol,
+        arg_names: Vec<Symbol>,
+        type_arg_names: Vec<Symbol>,
+        spec: Vec<Condition>,
+    ) -> FunctionData {
+        let handle_idx = module.function_def_at(def_idx).function;
+        FunctionData {
+            name,
+            def_idx,
+            handle_idx,
+            arg_names,
+            type_arg_names,
+            spec,
+        }
+    }
+
+    /// Creates data for a struct. Currently all information is contained in the byte code. This is
+    /// a helper for adding a new module to the environment.
+    pub fn create_struct_data(
+        &self,
+        module: &CompiledModule,
+        def_idx: StructDefinitionIndex,
+        name: Symbol,
+        invariants: Vec<Invariant>,
+    ) -> StructData {
+        let handle_idx = module.struct_def_at(def_idx).struct_handle;
+        let field_data = if let StructFieldInformation::Declared {
+            field_count,
+            fields,
+        } = module.struct_def_at(def_idx).field_information
+        {
+            let mut map = BTreeMap::new();
+            for idx in fields.0..fields.0 + field_count {
+                let def_idx = FieldDefinitionIndex(idx);
+                let def = module.field_def_at(def_idx);
+                let name = self
+                    .symbol_pool
+                    .make(module.identifier_at(def.name).as_str());
+                map.insert(FieldId(name), FieldData { name, def_idx });
+            }
+            map
+        } else {
+            BTreeMap::new()
+        };
+        let mut data_invariants = vec![];
+        let mut update_invariants = vec![];
+        let mut pack_invariants = vec![];
+        let mut unpack_invariants = vec![];
+
+        for inv in invariants {
+            match inv.kind {
+                InvariantKind::Data => data_invariants.push(inv),
+                InvariantKind::Update => update_invariants.push(inv),
+                InvariantKind::Pack => pack_invariants.push(inv),
+                InvariantKind::Unpack => unpack_invariants.push(inv),
+            }
+        }
+        StructData {
+            name,
+            def_idx,
+            handle_idx,
+            field_data,
+            data_invariants,
+            update_invariants,
+            pack_invariants,
+            unpack_invariants,
+        }
+    }
+
+    /// Finds a module by name and returns an environment for it.
+    pub fn find_module(&self, name: &ModuleName) -> Option<ModuleEnv<'_>> {
+        for module_data in &self.module_data {
+            let module_env = ModuleEnv {
+                env: self,
+                data: module_data,
+            };
+            if module_env.get_name() == name {
+                return Some(module_env);
+            }
+        }
+        None
+    }
+
+    /// Finds a module by simple name and returns an environment for it.
+    /// TODO: we may need to disallow this to support modules of the same simple name but with
+    ///    different addresses in one verification session.
+    pub fn find_module_by_name(&self, simple_name: Symbol) -> Option<ModuleEnv<'_>> {
+        self.get_modules()
+            .find(|m| m.get_name().name() == simple_name)
+    }
+
+    // Gets the number of modules in this environment.
+    pub fn get_module_count(&self) -> usize {
+        self.module_data.len()
+    }
+
+    /// Gets a module by id.
+    pub fn get_module(&self, id: ModuleId) -> ModuleEnv<'_> {
+        let module_data = &self.module_data[id.0 as usize];
+        ModuleEnv {
+            env: self,
+            data: module_data,
+        }
+    }
+
+    /// Returns an iterator for all modules in the environment.
+    pub fn get_modules(&self) -> impl Iterator<Item = ModuleEnv<'_>> {
+        self.module_data.iter().map(move |module_data| ModuleEnv {
+            env: self,
+            data: module_data,
+        })
+    }
+
+    /// Returns an iterator for all bytecode modules in the environment.
+    pub fn get_bytecode_modules(&self) -> impl Iterator<Item = &CompiledModule> {
+        self.module_data
+            .iter()
+            .map(|module_data| &module_data.module)
+    }
+
+    /// Returns all structs in all modules which carry invariants.
+    pub fn get_all_structs_with_invariants(&self) -> Vec<Type> {
+        let mut res = vec![];
+        for module_env in self.get_modules() {
+            for struct_env in module_env.get_structs() {
+                if struct_env.has_invariants() {
+                    let formals = struct_env
+                        .get_type_parameters()
+                        .iter()
+                        .enumerate()
+                        .map(|(idx, _)| Type::TypeParameter(idx as u16))
+                        .collect_vec();
+                    res.push(Type::Struct(
+                        module_env.get_id(),
+                        struct_env.get_id(),
+                        formals,
+                    ));
+                }
+            }
+        }
+        res
+    }
+
+    /// Converts a storage module id into an AST module name.
+    fn to_module_name(&self, storage_id: &language_storage::ModuleId) -> ModuleName {
+        ModuleName::from_str(
+            &storage_id.address().to_string(),
+            self.symbol_pool.make(storage_id.name().as_str()),
+        )
+    }
+}
+
+impl Default for GlobalEnv {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+// =================================================================================================
+/// # Module Environment
+
+/// Represents data for a module.
+#[derive(Debug)]
+pub struct ModuleData {
+    /// Module name.
+    pub name: ModuleName,
+
+    /// Id of this module in the global env.
+    pub id: ModuleId,
+
+    /// Module byte code.
+    pub module: CompiledModule,
+
+    /// Struct data.
+    pub struct_data: BTreeMap<StructId, StructData>,
+
+    /// Function data.
+    pub function_data: BTreeMap<FunId, FunctionData>,
+
+    /// Specification variables, in SpecVarId order.
+    pub spec_vars: Vec<SpecVarDecl>,
+
+    /// Specification functions, in SpecFunId order.
+    pub spec_funs: Vec<SpecFunDecl>,
+
+    /// Module source location information.
+    pub source_map: ModuleSourceMap<Span>,
+
+    /// A FileId for the `self.source_files` database.
+    pub source_file_id: FileId,
+
+    /// A map from node id to associated location.
+    pub loc_map: BTreeMap<NodeId, Loc>,
+
+    /// A map from node id to associated type.
+    pub type_map: BTreeMap<NodeId, Type>,
+}
+
+/// Represents a module environment.
+#[derive(Debug, Clone)]
+pub struct ModuleEnv<'env> {
+    /// Reference to the outer env.
+    pub env: &'env GlobalEnv,
+
+    /// Reference to the data of the module.
+    data: &'env ModuleData,
+}
+
+impl<'env> ModuleEnv<'env> {
+    /// Returns the id of this module in the global env.
+    pub fn get_id(&self) -> ModuleId {
+        self.data.id
+    }
+
+    /// Returns the name of this module.
+    pub fn get_name(&'env self) -> &'env ModuleName {
+        &self.data.name
+    }
+
+    /// Returns file name and line/column position for location in this module.
+    pub fn get_position(&self, loc: Span) -> Option<(String, Location)> {
+        self.env
+            .source_files
+            .location(self.data.source_file_id, loc.start())
+            .ok()
+            .map(|location| {
+                (
+                    self.env
+                        .source_files
+                        .name(self.data.source_file_id)
+                        .to_string(),
+                    location,
+                )
+            })
+    }
+
+    /// Gets the underlying bytecode module.
+    pub fn get_verified_module(&'env self) -> &'env CompiledModule {
+        &self.data.module
+    }
+
+    /// Gets a FunctionEnv in this module by name.
+    pub fn find_function(&self, name: Symbol) -> Option<FunctionEnv<'env>> {
+        let id = FunId(name);
+        if let Some(data) = self.data.function_data.get(&id) {
+            Some(FunctionEnv {
+                module_env: self.clone(),
+                data,
+            })
+        } else {
+            None
+        }
+    }
+
+    /// Gets a FunctionEnv by id.
+    pub fn get_function(&'env self, id: FunId) -> FunctionEnv<'env> {
+        let data = self.data.function_data.get(&id).expect("FunId undefined");
+        FunctionEnv {
+            module_env: self.clone(),
+            data,
+        }
+    }
+
+    /// Gets the number of functions in this module.
+    pub fn get_function_count(&self) -> usize {
+        self.data.function_data.len()
+    }
+
+    /// Returns iterator over FunctionEnvs in this module.
+    pub fn get_functions(&'env self) -> impl Iterator<Item = FunctionEnv<'env>> {
+        self.data
+            .function_data
+            .iter()
+            .map(move |(_, data)| FunctionEnv {
+                module_env: self.clone(),
+                data,
+            })
+    }
+
+    /// Returns the FunctionEnv which contains the location. This returns any function
+    /// which location encloses the given one.
+    pub fn get_enclosing_function(&'env self, loc: Span) -> Option<FunctionEnv<'env>> {
+        // Currently we do a brute-force linear search, may need to speed this up if it appears
+        // to be a bottleneck.
+        for func_env in self.get_functions() {
+            let fun_loc = func_env.get_loc();
+            if loc.start() >= fun_loc.start() && loc.end() <= fun_loc.end() {
+                return Some(func_env);
+            }
+        }
+        None
+    }
+
+    /// Get FunctionEnv for a function used in this module, via the FunctionHandleIndex. The
+    /// returned function might be from this or another module.
+    pub fn get_called_function(&self, idx: FunctionHandleIndex) -> FunctionEnv<'_> {
+        let view =
+            FunctionHandleView::new(&self.data.module, self.data.module.function_handle_at(idx));
+        let module_name = self.env.to_module_name(&view.module_id());
+        let module_env = self
+            .env
+            .find_module(&module_name)
+            .expect("unexpected reference to module not found in global env");
+        module_env
+            .find_function(self.env.symbol_pool.make(view.name().as_str()))
+            .expect("unexpected reference to function not found in associated module")
+    }
+
+    /// Gets a StructEnv in this module by name.
+    pub fn find_struct(&self, name: Symbol) -> Option<StructEnv<'_>> {
+        let id = StructId(name);
+        if let Some(data) = self.data.struct_data.get(&id) {
+            Some(StructEnv {
+                module_env: self.clone(),
+                data,
+            })
+        } else {
+            None
+        }
+    }
+
+    /// Gets a StructEnv by id.
+    pub fn get_struct(&self, id: StructId) -> StructEnv<'_> {
+        let data = self.data.struct_data.get(&id).expect("StructId undefined");
+        StructEnv {
+            module_env: self.clone(),
+            data,
+        }
+    }
+
+    /// Gets a StructEnv by id, consuming this module env.
+    pub fn into_get_struct(self, id: StructId) -> StructEnv<'env> {
+        let data = self.data.struct_data.get(&id).expect("StructId undefined");
+        StructEnv {
+            module_env: self,
+            data,
+        }
+    }
+
+    /// Gets the number of structs in this module.
+    pub fn get_struct_count(&self) -> usize {
+        self.data.struct_data.len()
+    }
+
+    /// Gets the struct declaring a field specified by FieldDefinitionIndex,
+    /// as it is globally unique for this module.
+    pub fn get_struct_of_field(&self, idx: &FieldDefinitionIndex) -> StructEnv<'_> {
+        let field_view =
+            FieldDefinitionView::new(&self.data.module, self.data.module.field_def_at(*idx));
+        let struct_name = self
+            .env
+            .symbol_pool
+            .make(field_view.member_of().name().as_str());
+        self.find_struct(struct_name).expect("struct undefined")
+    }
+
+    /// Returns iterator over structs in this module.
+    pub fn get_structs(&'env self) -> impl Iterator<Item = StructEnv<'env>> {
+        self.data
+            .struct_data
+            .iter()
+            .map(move |(_, data)| StructEnv {
+                module_env: self.clone(),
+                data,
+            })
+    }
+
+    /// Globalizes a signature local to this module.
+    pub fn globalize_signature(&self, sig: &SignatureToken) -> Type {
+        match sig {
+            SignatureToken::Bool => Type::Primitive(PrimitiveType::Bool),
+            SignatureToken::U8 => Type::Primitive(PrimitiveType::U8),
+            SignatureToken::U64 => Type::Primitive(PrimitiveType::U64),
+            SignatureToken::U128 => Type::Primitive(PrimitiveType::U128),
+            SignatureToken::ByteArray => Type::Primitive(PrimitiveType::ByteArray),
+            SignatureToken::Address => Type::Primitive(PrimitiveType::Address),
+            SignatureToken::Reference(t) => {
+                Type::Reference(false, Box::new(self.globalize_signature(&*t)))
+            }
+            SignatureToken::MutableReference(t) => {
+                Type::Reference(true, Box::new(self.globalize_signature(&*t)))
+            }
+            SignatureToken::TypeParameter(index) => Type::TypeParameter(*index),
+            SignatureToken::Vector(bt) => Type::Vector(Box::new(self.globalize_signature(&*bt))),
+            SignatureToken::Struct(handle_idx, args) => {
+                let struct_view = StructHandleView::new(
+                    &self.data.module,
+                    self.data.module.struct_handle_at(*handle_idx),
+                );
+                let declaring_module_env = self
+                    .env
+                    .find_module(&self.env.to_module_name(&struct_view.module_id()))
+                    .expect("undefined module");
+                let struct_env = declaring_module_env
+                    .find_struct(self.env.symbol_pool.make(struct_view.name().as_str()))
+                    .expect("undefined struct");
+                Type::Struct(
+                    declaring_module_env.data.id,
+                    struct_env.get_id(),
+                    self.globalize_signatures(args),
+                )
+            }
+        }
+    }
+
+    /// Globalizes a list of signatures.
+    fn globalize_signatures(&self, sigs: &[SignatureToken]) -> Vec<Type> {
+        sigs.iter()
+            .map(|s| self.globalize_signature(s))
+            .collect_vec()
+    }
+
+    /// Gets a list of type actuals associated with the index in the bytecode.
+    pub fn get_type_actuals(&self, idx: LocalsSignatureIndex) -> Vec<Type> {
+        let actuals = &self.data.module.locals_signature_at(idx).0;
+        self.globalize_signatures(actuals)
+    }
+
+    /// Converts an address pool index for this module into a number representing the address.
+    pub fn get_address(&self, idx: AddressPoolIndex) -> BigUint {
+        let addr = &self.data.module.address_pool()[idx.0 as usize];
+        BigUint::from_str_radix(&addr.to_string(), 16).unwrap()
+    }
+
+    /// Returns specification variables of this module.
+    pub fn get_spec_vars(&'env self) -> &'env [SpecVarDecl] {
+        &self.data.spec_vars
+    }
+
+    /// Returns specification functions of this module.
+    pub fn get_spec_funs(&'env self) -> &'env [SpecFunDecl] {
+        &self.data.spec_funs
+    }
+}
+
+// =================================================================================================
+/// # Struct Environment
+
+#[derive(Debug)]
+pub struct StructData {
+    /// The name of this struct.
+    name: Symbol,
+
+    /// The definition index of this struct in its module.
+    def_idx: StructDefinitionIndex,
+
+    /// The handle index of this struct in its module.
+    handle_idx: StructHandleIndex,
+
+    /// Field definitions.
+    field_data: BTreeMap<FieldId, FieldData>,
+
+    // Invariants
+    data_invariants: Vec<Invariant>,
+    update_invariants: Vec<Invariant>,
+    pack_invariants: Vec<Invariant>,
+    unpack_invariants: Vec<Invariant>,
+}
+
+#[derive(Debug, Clone)]
+pub struct StructEnv<'env> {
+    /// Reference to enclosing module.
+    pub module_env: ModuleEnv<'env>,
+
+    /// Reference to the struct data.
+    data: &'env StructData,
+}
+
+impl<'env> StructEnv<'env> {
+    /// Returns the name of this struct.
+    pub fn get_name(&self) -> Symbol {
+        self.data.name
+    }
+
+    /// Returns the location of this struct.
+    pub fn get_loc(&self) -> Span {
+        if let Ok(source_map) = self
+            .module_env
+            .data
+            .source_map
+            .get_struct_source_map(self.data.def_idx)
+        {
+            source_map.decl_location
+        } else {
+            Span::default()
+        }
+    }
+
+    /// Gets the definition index associated with this struct.
+    pub fn get_id(&self) -> StructId {
+        StructId(self.data.name)
+    }
+
+    /// Determines whether this struct is native.
+    pub fn is_native(&self) -> bool {
+        let def = self.module_env.data.module.struct_def_at(self.data.def_idx);
+        def.field_information == StructFieldInformation::Native
+    }
+
+    /// Determines whether this struct is the well-known vector type.
+    pub fn is_vector(&self) -> bool {
+        let name = self
+            .module_env
+            .env
+            .symbol_pool
+            .string(self.module_env.get_name().name());
+        let addr = self.module_env.get_name().addr();
+        name.as_ref() == "Vector" && addr == &BigUint::from(0 as u64)
+    }
+
+    /// Determines whether this struct is a resource type.
+    pub fn is_resource(&self) -> bool {
+        let def = self.module_env.data.module.struct_def_at(self.data.def_idx);
+        let handle = self
+            .module_env
+            .data
+            .module
+            .struct_handle_at(def.struct_handle);
+        handle.is_nominal_resource
+    }
+
+    /// Get an iterator for the fields.
+    pub fn get_fields(&'env self) -> impl Iterator<Item = FieldEnv<'env>> {
+        self.data.field_data.iter().map(move |(_, data)| FieldEnv {
+            struct_env: self.clone(),
+            data,
+        })
+    }
+
+    /// Gets a field by its id.
+    pub fn get_field(&'env self, id: FieldId) -> FieldEnv<'env> {
+        let data = self.data.field_data.get(&id).expect("FieldId undefined");
+        FieldEnv {
+            struct_env: self.clone(),
+            data,
+        }
+    }
+
+    /// Find a field by its name.
+    pub fn find_field(&'env self, name: Symbol) -> Option<FieldEnv<'env>> {
+        let id = FieldId(name);
+        if let Some(data) = self.data.field_data.get(&id) {
+            Some(FieldEnv {
+                struct_env: self.clone(),
+                data,
+            })
+        } else {
+            None
+        }
+    }
+
+    /// Returns the type parameters associated with this struct.
+    pub fn get_type_parameters(&self) -> Vec<TypeParameter> {
+        // TODO: we currently do not know the original names of those formals, so we generate them.
+        let view = StructDefinitionView::new(
+            &self.module_env.data.module,
+            self.module_env.data.module.struct_def_at(self.data.def_idx),
+        );
+        view.type_formals()
+            .iter()
+            .enumerate()
+            .map(|(i, k)| {
+                TypeParameter(
+                    self.module_env.env.symbol_pool.make(&format!("tv{}", i)),
+                    *k,
+                )
+            })
+            .collect_vec()
+    }
+
+    /// Returns true if this struct has invariants.
+    pub fn has_invariants(&self) -> bool {
+        !self.data.data_invariants.is_empty()
+            || !self.data.update_invariants.is_empty()
+            || !self.data.pack_invariants.is_empty()
+            || !self.data.unpack_invariants.is_empty()
+    }
+
+    /// Returns the data invariants associated with this struct.
+    pub fn get_data_invariants(&'env self) -> &'env [Invariant] {
+        &self.data.data_invariants
+    }
+
+    /// Returns the update invariants associated with this struct.
+    pub fn get_update_invariants(&'env self) -> &'env [Invariant] {
+        &self.data.update_invariants
+    }
+
+    /// Returns the pack invariants associated with this struct.
+    pub fn get_pack_invariants(&'env self) -> &'env [Invariant] {
+        &self.data.pack_invariants
+    }
+
+    /// Returns the unpack invariants associated with this struct.
+    pub fn get_unpack_invariants(&'env self) -> &'env [Invariant] {
+        &self.data.unpack_invariants
+    }
+}
+
+// =================================================================================================
+/// # Field Environment
+#[derive(Debug)]
+pub struct FieldData {
+    /// The name of this field.
+    name: Symbol,
+
+    /// The definition index of this field in its module.
+    def_idx: FieldDefinitionIndex,
+}
+
+#[derive(Debug)]
+pub struct FieldEnv<'env> {
+    /// Reference to enclosing struct.
+    pub struct_env: StructEnv<'env>,
+
+    /// Reference to the field data.
+    data: &'env FieldData,
+}
+
+impl<'env> FieldEnv<'env> {
+    /// Gets the name of this field.
+    pub fn get_name(&self) -> Symbol {
+        self.data.name
+    }
+
+    /// Gets the id of this field.
+    pub fn get_id(&self) -> FieldId {
+        FieldId(self.data.name)
+    }
+
+    /// Gets the type of this field.
+    pub fn get_type(&self) -> Type {
+        let view = FieldDefinitionView::new(
+            &self.struct_env.module_env.data.module,
+            self.struct_env
+                .module_env
+                .data
+                .module
+                .field_def_at(self.data.def_idx),
+        );
+        self.struct_env
+            .module_env
+            .globalize_signature(view.type_signature().token().as_inner())
+    }
+}
+
+// =================================================================================================
+/// # Function Environment
+
+/// Represents a type parameter.
+#[derive(Debug, Clone)]
+pub struct TypeParameter(pub Symbol, pub Kind);
+
+/// Represents a parameter.
+#[derive(Debug, Clone)]
+pub struct Parameter(pub Symbol, pub Type);
+
+#[derive(Debug)]
+pub struct FunctionData {
+    /// Name of this function.
+    name: Symbol,
+
+    /// The definition index of this function in its module.
+    def_idx: FunctionDefinitionIndex,
+
+    /// The handle index of this function in its module.
+    handle_idx: FunctionHandleIndex,
+
+    /// List of function argument names. Not in bytecode but obtained from AST.
+    arg_names: Vec<Symbol>,
+
+    /// List of type argument names. Not in bytecode but obtained from AST.
+    type_arg_names: Vec<Symbol>,
+
+    /// List of specification conditions. Not in bytecode but obtained from AST.
+    spec: Vec<Condition>,
+}
+
+#[derive(Debug)]
+pub struct FunctionEnv<'env> {
+    /// Reference to enclosing module.
+    pub module_env: ModuleEnv<'env>,
+
+    /// Reference to the function data.
+    data: &'env FunctionData,
+}
+
+impl<'env> FunctionEnv<'env> {
+    /// Returns the name of this function.
+    pub fn get_name(&self) -> Symbol {
+        self.data.name
+    }
+
+    /// Gets the id of this function.
+    pub fn get_id(&self) -> FunId {
+        FunId(self.data.name)
+    }
+
+    /// Returns the location of this function.
+    pub fn get_loc(&self) -> Span {
+        if let Ok(source_map) = self
+            .module_env
+            .data
+            .source_map
+            .get_function_source_map(self.data.def_idx)
+        {
+            source_map.decl_location
+        } else {
+            Span::default()
+        }
+    }
+
+    /// Returns the location of the bytecode at the given offset.
+    pub fn get_bytecode_loc(&self, offset: u16) -> Span {
+        if let Ok(fmap) = self
+            .module_env
+            .data
+            .source_map
+            .get_function_source_map(self.data.def_idx)
+        {
+            if let Some(loc) = fmap.get_code_location(offset) {
+                return loc;
+            }
+        }
+        self.get_loc()
+    }
+
+    /// Returns true if this function is native.
+    pub fn is_native(&self) -> bool {
+        let view = self.definition_view();
+        view.is_native()
+    }
+
+    /// Returns true if this function mutates any references (i.e. has &mut parameters).
+    pub fn is_mutating(&self) -> bool {
+        self.get_parameters()
+            .iter()
+            .any(|Parameter(_, ty)| ty.is_mutual_reference())
+    }
+
+    /// Returns the type parameters associated with this function.
+    pub fn get_type_parameters(&self) -> Vec<TypeParameter> {
+        // TODO: currently the translation scheme isn't working with using real type
+        //   parameter names, so use indices instead.
+        let view = self.definition_view();
+        view.signature()
+            .type_formals()
+            .iter()
+            .enumerate()
+            .map(|(i, k)| {
+                TypeParameter(
+                    self.module_env.env.symbol_pool.make(&format!("tv{}", i)),
+                    *k,
+                )
+            })
+            .collect_vec()
+    }
+
+    /// Returns the regular parameters associated with this function.
+    pub fn get_parameters(&self) -> Vec<Parameter> {
+        let view = self.definition_view();
+        view.signature()
+            .arg_tokens()
+            .map(|tv: SignatureTokenView<CompiledModule>| {
+                self.module_env.globalize_signature(tv.signature_token())
+            })
+            .zip(self.data.arg_names.iter())
+            .map(|(s, i)| Parameter(*i, s))
+            .collect_vec()
+    }
+
+    /// Returns return types of this function.
+    pub fn get_return_types(&self) -> Vec<Type> {
+        let view = self.definition_view();
+        view.signature()
+            .return_tokens()
+            .map(|tv: SignatureTokenView<CompiledModule>| {
+                self.module_env.globalize_signature(tv.signature_token())
+            })
+            .collect_vec()
+    }
+
+    /// Returns the number of return values of this function.
+    pub fn get_return_count(&self) -> usize {
+        let view = self.definition_view();
+        view.signature().return_count()
+    }
+
+    /// Get the name to be used for a local. If the local is an argument, use that for naming,
+    /// otherwise generate a unique name.
+    pub fn get_local_name(&self, idx: usize) -> Symbol {
+        if idx < self.data.arg_names.len() {
+            return self.data.arg_names[idx as usize];
+        }
+        // Try to obtain name from source map.
+        if let Ok(fmap) = self
+            .module_env
+            .data
+            .source_map
+            .get_function_source_map(self.data.def_idx)
+        {
+            if let Some((ident, _)) = fmap.get_local_name(idx as u64) {
+                return self.module_env.env.symbol_pool.make(ident.as_str());
+            }
+        }
+        self.module_env.env.symbol_pool.make(&format!("__t{}", idx))
+    }
+
+    /// Gets the number of proper locals of this function. Those are locals which are declared
+    /// by the user and also have a user assigned name which can be discovered via `get_local_name`.
+    /// Note we may have more anonymous locals generated e.g by the 'stackless' transformation.
+    pub fn get_local_count(&self) -> usize {
+        let view = self.definition_view();
+        view.locals_signature().len()
+    }
+
+    /// Gets the type of the local at index. This must use an index in the range as determined by
+    /// `get_local_count`.
+    /// TODO: we currently do not have a way to determine type of anonymous locals like those
+    ///   generated by the stackless transformation via the environment. We may want to add a
+    ///   feature to register such types with the environment to better support program
+    ///   transformations.
+    pub fn get_local_type(&self, idx: usize) -> Type {
+        let view = self.definition_view();
+        self.module_env.globalize_signature(
+            view.locals_signature()
+                .token_at(idx as u8)
+                .signature_token(),
+        )
+    }
+
+    /// Returns specification conditions associated with this function.
+    pub fn get_specification(&'env self) -> &'env [Condition] {
+        &self.data.spec
+    }
+
+    fn definition_view(&'env self) -> FunctionDefinitionView<'env, CompiledModule> {
+        FunctionDefinitionView::new(
+            &self.module_env.data.module,
+            self.module_env
+                .data
+                .module
+                .function_def_at(self.data.def_idx),
+        )
+    }
+}

--- a/language/move-prover/spec-lang/src/lib.rs
+++ b/language/move-prover/spec-lang/src/lib.rs
@@ -1,0 +1,132 @@
+// Copyright (c) The Libra Core Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+#![forbid(unsafe_code)]
+
+use crate::ast::ModuleName;
+use crate::env::{GlobalEnv, ModuleId};
+use crate::translate::{ModuleTranslator, Translator};
+use anyhow::anyhow;
+use codespan_reporting::diagnostic::{Diagnostic, Label};
+use itertools::Itertools;
+use move_lang::errors::Errors;
+use move_lang::expansion::ast::Program;
+use move_lang::shared::{Address, Loc};
+use move_lang::to_bytecode::translate::CompiledUnit;
+use move_lang::{move_compile_no_report, move_compile_to_expansion_no_report};
+
+pub mod ast;
+pub mod env;
+pub mod symbol;
+mod translate;
+pub mod ty;
+
+// =================================================================================================
+// Entry Point
+
+pub fn run_spec_lang_compiler(
+    targets: Vec<String>,
+    deps: Vec<String>,
+    address_opt: Option<&str>,
+) -> anyhow::Result<GlobalEnv> {
+    let address_opt = if let Some(s) = address_opt {
+        Some(Address::parse_str(s).map_err(|s| anyhow!(s))?)
+    } else {
+        None
+    };
+
+    let mut env = GlobalEnv::new();
+    // First pass: compile move code.
+    let (files, units_or_errors) = move_compile_no_report(&targets, &deps, address_opt)?;
+    for (fname, fsrc) in files {
+        env.add_source(fname, &fsrc);
+    }
+    match units_or_errors {
+        Err(errors) => {
+            add_move_lang_errors(&mut env, errors);
+        }
+        Ok(units) => {
+            let (verified_units, errors) = move_lang::to_bytecode::translate::verify_units(units);
+            if !errors.is_empty() {
+                add_move_lang_errors(&mut env, errors);
+            } else {
+                // Now compile again, up to expansion phase, to get hand on the expansion AST
+                // which we merge with the verified units. This time we expect no errors.
+                // The alternative to do a second parse and expansion pass is to make the expansion
+                // AST clonable and tee it somehow out of the regular compile chain.
+                let (_, eprog_or_errors) =
+                    move_compile_to_expansion_no_report(&targets, &deps, address_opt)?;
+                let eprog = eprog_or_errors.expect("no compilation errors");
+                // Run the spec checker on verified units plus expanded AST. This will
+                // populate the environment including any errors.
+                run_spec_checker(&mut env, verified_units, eprog)?;
+            }
+        }
+    };
+    Ok(env)
+}
+
+fn add_move_lang_errors(env: &mut GlobalEnv, errors: Errors) {
+    let mk_label = |env: &mut GlobalEnv, err: (Loc, String)| {
+        let loc = env.to_loc(&err.0);
+        Label::new(loc.file_id, loc.span, err.1)
+    };
+    for mut error in errors {
+        let primary = error.remove(0);
+        let diag = Diagnostic::new_error("", mk_label(env, primary))
+            .with_secondary_labels(error.into_iter().map(|e| mk_label(env, e)));
+        env.add_diag(diag);
+    }
+}
+
+fn run_spec_checker(
+    env: &mut GlobalEnv,
+    units: Vec<CompiledUnit>,
+    eprog: Program,
+) -> anyhow::Result<()> {
+    let mut translator = Translator::new(env);
+    let mut module_count = 0;
+    let mut modules = units
+        .into_iter()
+        .filter_map(|u| {
+            if let CompiledUnit::Module(name, compiled_module) = u {
+                Some((name, compiled_module))
+            } else {
+                None
+            }
+        })
+        .collect_vec();
+    for (module_id, expanded_module) in eprog.modules {
+        let loc = translator.to_loc(&module_id.loc());
+        let (pos, _) = modules
+            .iter()
+            .find_position(|(name, _)| name == &module_id.0.value.name)
+            .ok_or_else(|| anyhow!("cannot associate compiled module with expanded"))?;
+        let compiled_module = modules.remove(pos).1;
+        let module_name = ModuleName::from_str(
+            &module_id.0.value.address.to_string(),
+            translator
+                .env
+                .symbol_pool()
+                .make(&module_id.0.value.name.0.value),
+        );
+        let module_id = ModuleId::new(module_count);
+        module_count += 1;
+        let mut module_translator = ModuleTranslator::new(&mut translator, module_id, module_name);
+        module_translator.translate(loc.file_id, expanded_module, compiled_module, None);
+    }
+    Ok(())
+}
+
+// =================================================================================================
+// Crate Helpers
+
+/// Helper to project the 1st element from a vector of pairs.
+pub(crate) fn project_1st<T: Clone, R>(v: &[(T, R)]) -> Vec<T> {
+    v.iter().map(|(x, _)| x.clone()).collect()
+}
+
+/// Helper to project the 2nd element from a vector of pairs.
+pub(crate) fn project_2nd<T, R: Clone>(v: &[(T, R)]) -> Vec<R> {
+    v.iter().map(|(_, x)| x.clone()).collect()
+}

--- a/language/move-prover/spec-lang/src/symbol.rs
+++ b/language/move-prover/spec-lang/src/symbol.rs
@@ -1,0 +1,88 @@
+// Copyright (c) The Libra Core Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+//! Contains definitions of symbols -- internalized strings which support fast hashing and
+//! comparison.
+
+use std::cell::RefCell;
+use std::collections::HashMap;
+use std::fmt;
+use std::fmt::{Error, Formatter};
+use std::rc::Rc;
+
+/// Representation of a symbol.
+#[derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash, Clone, Copy)]
+pub struct Symbol(usize);
+
+impl Symbol {
+    pub fn display<'a>(&'a self, pool: &'a SymbolPool) -> SymbolDisplay<'a> {
+        SymbolDisplay { sym: self, pool }
+    }
+}
+
+/// A helper to support symbols in formatting.
+pub struct SymbolDisplay<'a> {
+    sym: &'a Symbol,
+    pool: &'a SymbolPool,
+}
+
+impl<'a> fmt::Display for SymbolDisplay<'a> {
+    fn fmt(&self, f: &mut Formatter<'_>) -> Result<(), Error> {
+        f.write_str(&self.pool.string(*self.sym))
+    }
+}
+
+/// A pool of symbols. Allows to lookup a symbol by a string representation, and discover
+/// the string representation of an existing symbol. This struct does not need be mutable
+/// for operations on it, which is important so references to it can be freely passed around.
+#[derive(Debug)]
+pub struct SymbolPool {
+    inner: RefCell<InnerPool>,
+}
+
+#[derive(Debug)]
+struct InnerPool {
+    strings: Vec<Rc<String>>,
+    lookup: HashMap<Rc<String>, usize>,
+}
+
+impl SymbolPool {
+    /// Creates a new SymbolPool.
+    pub fn new() -> SymbolPool {
+        SymbolPool {
+            inner: RefCell::new(InnerPool {
+                strings: vec![],
+                lookup: HashMap::new(),
+            }),
+        }
+    }
+
+    /// Looks up a symbol by its string representation. If a symbol with this representation
+    /// already exists, it will be returned, otherwise a new one will be created in the
+    /// pool. The implementation uses internally a RefCell for storing symbols, so the pool
+    /// does not need to be mutable.
+    pub fn make(&self, s: &str) -> Symbol {
+        let mut pool = self.inner.borrow_mut();
+        let key = Rc::new(s.to_string());
+        if let Some(n) = pool.lookup.get(&key) {
+            return Symbol(*n);
+        }
+        let new_sym = pool.strings.len();
+        pool.strings.push(key.clone());
+        pool.lookup.insert(key, new_sym);
+        Symbol(new_sym)
+    }
+
+    /// Returns the string representation of this symbol, as an rc'ed string to avoid copies.
+    /// If the past symbol was not created from this pool, a runtime error may happen (or a wrong
+    /// string will be returned).
+    pub fn string(&self, sym: Symbol) -> Rc<String> {
+        self.inner.borrow().strings[sym.0].clone()
+    }
+}
+
+impl Default for SymbolPool {
+    fn default() -> Self {
+        Self::new()
+    }
+}

--- a/language/move-prover/spec-lang/src/translate.rs
+++ b/language/move-prover/spec-lang/src/translate.rs
@@ -1,0 +1,2161 @@
+// Copyright (c) The Libra Core Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+//! Translates and validates specification language fragments as they are output from the Move
+//! compiler's expansion phase and adds them to the environment (which was initialized from the
+//! byte code). This includes identifying the Move sub-language supported by the specification
+//! system, as well as type checking it and translating it to the spec language ast.
+
+use std::collections::{BTreeMap, BTreeSet, LinkedList};
+
+use codespan::{FileId, Span};
+use itertools::Itertools;
+use num::{BigUint, FromPrimitive, Num};
+
+use bytecode_source_map::source_map::ModuleSourceMap;
+use move_lang::expansion::ast as EA;
+use move_lang::parser::ast as PA;
+use move_lang::shared::Name;
+use vm::access::ModuleAccess;
+use vm::file_format::{FunctionDefinitionIndex, StructDefinitionIndex};
+use vm::views::{FunctionHandleView, StructHandleView};
+use vm::CompiledModule;
+
+use crate::ast::{
+    Condition, ConditionKind, Exp, Invariant, InvariantKind, LocalVarDecl, ModuleName, Operation,
+    QualifiedSymbol, SpecFunDecl, SpecVarDecl, Value,
+};
+use crate::env::{
+    FieldId, FunId, FunctionData, GlobalEnv, Loc, ModuleId, NodeId, SpecFunId, SpecVarId,
+    StructData, StructId,
+};
+use crate::symbol::{Symbol, SymbolPool};
+use crate::ty::{PrimitiveType, Substitution, Type, TypeDisplayContext, BOOL_TYPE};
+use crate::{project_1st, project_2nd};
+
+// =================================================================================================
+/// # Translator
+
+/// A translator. This is used to translate a sequence of modules in acyclic dependency order. The
+/// translator maintains the incremental state of this process, such that the various tables
+/// are extended with each module translated. Each table is a mapping from fully qualified names
+/// (module names plus item name in the module) to the entity.
+#[derive(Debug)]
+pub struct Translator<'env> {
+    /// The global environment we are building.
+    pub env: &'env mut GlobalEnv,
+    /// A symbol table for specification functions. Because of overloading, and entry can
+    /// contain multiple functions.
+    spec_fun_table: BTreeMap<QualifiedSymbol, Vec<SpecFunEntry>>,
+    /// A symbol table for specification variables.
+    spec_var_table: BTreeMap<QualifiedSymbol, SpecVarEntry>,
+    // A symbol table for structs.
+    struct_table: BTreeMap<QualifiedSymbol, StructEntry>,
+    /// A reverse mapping from ModuleId/StructId pairs to QualifiedSymbol. This
+    /// is used for visualization of types in error messages.
+    reverse_struct_table: BTreeMap<(ModuleId, StructId), QualifiedSymbol>,
+    /// A symbol table for functions.
+    fun_table: BTreeMap<QualifiedSymbol, FunEntry>,
+}
+
+/// A declaration of a specification function or operator in the translator state.
+#[derive(Debug, Clone)]
+struct SpecFunEntry {
+    loc: Loc,
+    oper: Operation,
+    type_params: Vec<Type>,
+    arg_types: Vec<Type>,
+    result_type: Type,
+}
+
+/// A declaration of a specification variable in the translator state.
+#[derive(Debug, Clone)]
+struct SpecVarEntry {
+    loc: Loc,
+    module_id: ModuleId,
+    var_id: SpecVarId,
+    type_: Type,
+}
+
+/// A declaration of a struct.
+#[derive(Debug, Clone)]
+struct StructEntry {
+    loc: Loc,
+    module_id: ModuleId,
+    struct_id: StructId,
+    is_resource: bool,
+    type_params: Vec<(Symbol, Type)>,
+    fields: Option<BTreeMap<Symbol, Type>>,
+}
+
+/// A declaration of a function.
+#[derive(Debug, Clone)]
+struct FunEntry {
+    loc: Loc,
+    module_id: ModuleId,
+    fun_id: FunId,
+    type_params: Vec<(Symbol, Type)>,
+    params: Vec<(Symbol, Type)>,
+    result_type: Type,
+}
+
+/// ## General
+
+impl<'env> Translator<'env> {
+    /// Creates a translator.
+    pub fn new(env: &'env mut GlobalEnv) -> Self {
+        let mut translator = Translator {
+            env,
+            spec_fun_table: BTreeMap::new(),
+            spec_var_table: BTreeMap::new(),
+            struct_table: BTreeMap::new(),
+            reverse_struct_table: BTreeMap::new(),
+            fun_table: BTreeMap::new(),
+        };
+        translator.declare_builtins();
+        translator
+    }
+
+    /// Shortcut for translating a Move AST location into ours.
+    pub fn to_loc(&self, loc: &move_lang::shared::Loc) -> Loc {
+        self.env.to_loc(loc)
+    }
+
+    /// Reports a type checking error.
+    fn error(&self, at: &Loc, msg: &str) {
+        self.env.error(at, msg)
+    }
+
+    /// Defines a spec function.
+    fn define_spec_fun(
+        &mut self,
+        loc: &Loc,
+        name: QualifiedSymbol,
+        module_id: ModuleId,
+        fun_id: SpecFunId,
+        type_params: Vec<Type>,
+        arg_types: Vec<Type>,
+        result_type: Type,
+    ) {
+        let entry = SpecFunEntry {
+            loc: loc.clone(),
+            oper: Operation::Function(module_id, fun_id),
+            type_params,
+            arg_types,
+            result_type,
+        };
+        // TODO: check whether overloads are distinguishable
+        self.spec_fun_table
+            .entry(name)
+            .or_insert_with(|| vec![])
+            .push(entry);
+    }
+
+    /// Defines a spec variable.
+    fn define_spec_var(
+        &mut self,
+        loc: &Loc,
+        name: QualifiedSymbol,
+        module_id: ModuleId,
+        var_id: SpecVarId,
+        type_: Type,
+    ) {
+        let entry = SpecVarEntry {
+            loc: loc.clone(),
+            module_id,
+            var_id,
+            type_,
+        };
+        if let Some(old) = self.spec_var_table.insert(name.clone(), entry) {
+            let var_name = name.display(self.env.symbol_pool());
+            self.error(loc, &format!("duplicate declaration of `{}`", var_name));
+            self.error(&old.loc, &format!("previous declaration of `{}`", var_name));
+        }
+    }
+
+    /// Defines a struct type.
+    fn define_struct(
+        &mut self,
+        loc: Loc,
+        name: QualifiedSymbol,
+        module_id: ModuleId,
+        struct_id: StructId,
+        is_resource: bool,
+        type_params: Vec<(Symbol, Type)>,
+        fields: Option<BTreeMap<Symbol, Type>>,
+    ) {
+        let entry = StructEntry {
+            loc,
+            module_id,
+            struct_id,
+            is_resource,
+            type_params,
+            fields,
+        };
+        // Duplicate declarations have been checked by the move compiler.
+        assert!(self.struct_table.insert(name.clone(), entry).is_none());
+        self.reverse_struct_table
+            .insert((module_id, struct_id), name);
+    }
+
+    /// Defines a function.
+    fn define_fun(
+        &mut self,
+        loc: Loc,
+        name: QualifiedSymbol,
+        module_id: ModuleId,
+        fun_id: FunId,
+        type_params: Vec<(Symbol, Type)>,
+        params: Vec<(Symbol, Type)>,
+        result_type: Type,
+    ) {
+        let entry = FunEntry {
+            loc,
+            module_id,
+            fun_id,
+            type_params,
+            params,
+            result_type,
+        };
+        // Duplicate declarations have been checked by the move compiler.
+        assert!(self.fun_table.insert(name, entry).is_none());
+    }
+
+    /// Looks up a type (struct), reporting an error if it is not found.
+    fn lookup_type(&self, loc: &Loc, name: &QualifiedSymbol) -> Type {
+        self.struct_table
+            .get(name)
+            .cloned()
+            .map(|e| Type::Struct(e.module_id, e.struct_id, project_2nd(&e.type_params)))
+            .unwrap_or_else(|| {
+                self.error(
+                    loc,
+                    &format!("undeclared `{}`", name.display(self.env.symbol_pool())),
+                );
+                Type::Error
+            })
+    }
+}
+
+/// # Builtins
+
+impl<'env> Translator<'env> {
+    /// Declares builtins in the translator. This adds functions and operators
+    /// to the translator which will be treated the same as user defined specification functions
+    /// during translation.
+    fn declare_builtins(&mut self) {
+        let loc = self.env.default_loc();
+        let bool_t = &Type::new_prim(PrimitiveType::Bool);
+        let num_t = &Type::new_prim(PrimitiveType::Num);
+        let range_t = &Type::new_prim(PrimitiveType::Range);
+        let address_t = &Type::new_prim(PrimitiveType::Address);
+        let param_t = &Type::TypeParameter(0);
+        let add_builtin = |trans: &mut Translator, name: QualifiedSymbol, entry: SpecFunEntry| {
+            trans
+                .spec_fun_table
+                .entry(name)
+                .or_insert_with(|| vec![])
+                .push(entry);
+        };
+
+        {
+            // Binary operators.
+            let mut declare_bin =
+                |op: PA::BinOp_, oper: Operation, param_type: &Type, result_type: &Type| {
+                    add_builtin(
+                        self,
+                        self.bin_op_symbol(&op),
+                        SpecFunEntry {
+                            loc: loc.clone(),
+                            oper,
+                            type_params: vec![],
+                            arg_types: vec![param_type.clone(), param_type.clone()],
+                            result_type: result_type.clone(),
+                        },
+                    );
+                };
+            use PA::BinOp_::*;
+            declare_bin(Add, Operation::Add, num_t, num_t);
+            declare_bin(Sub, Operation::Sub, num_t, num_t);
+            declare_bin(Mul, Operation::Mul, num_t, num_t);
+            declare_bin(Mod, Operation::Mod, num_t, num_t);
+            declare_bin(Div, Operation::Div, num_t, num_t);
+            declare_bin(BitOr, Operation::BitOr, num_t, num_t);
+            declare_bin(BitAnd, Operation::BitAnd, num_t, num_t);
+            declare_bin(Xor, Operation::Xor, num_t, num_t);
+            declare_bin(Shl, Operation::Shl, num_t, num_t);
+            declare_bin(Shr, Operation::Shr, num_t, num_t);
+
+            declare_bin(Range, Operation::Range, num_t, range_t);
+
+            declare_bin(Implies, Operation::Implies, bool_t, bool_t);
+            declare_bin(And, Operation::And, bool_t, bool_t);
+            declare_bin(Or, Operation::Or, bool_t, bool_t);
+
+            declare_bin(Lt, Operation::Lt, num_t, bool_t);
+            declare_bin(Le, Operation::Le, num_t, bool_t);
+            declare_bin(Gt, Operation::Gt, num_t, bool_t);
+            declare_bin(Ge, Operation::Ge, num_t, bool_t);
+
+            // Eq and Neq have special treatment because they are generic.
+            add_builtin(
+                self,
+                self.bin_op_symbol(&PA::BinOp_::Eq),
+                SpecFunEntry {
+                    loc: loc.clone(),
+                    oper: Operation::Eq,
+                    type_params: vec![param_t.clone()],
+                    arg_types: vec![param_t.clone(), param_t.clone()],
+                    result_type: bool_t.clone(),
+                },
+            );
+            add_builtin(
+                self,
+                self.bin_op_symbol(&PA::BinOp_::Neq),
+                SpecFunEntry {
+                    loc: loc.clone(),
+                    oper: Operation::Neq,
+                    type_params: vec![param_t.clone()],
+                    arg_types: vec![param_t.clone(), param_t.clone()],
+                    result_type: bool_t.clone(),
+                },
+            );
+        }
+
+        {
+            // Unary operators.
+            add_builtin(
+                self,
+                self.unary_op_symbol(&PA::UnaryOp_::Not),
+                SpecFunEntry {
+                    loc: loc.clone(),
+                    oper: Operation::Not,
+                    type_params: vec![],
+                    arg_types: vec![bool_t.clone()],
+                    result_type: bool_t.clone(),
+                },
+            );
+        }
+
+        {
+            // Builtin functions.
+            let vector_t = &Type::Vector(Box::new(param_t.clone()));
+            let pred_t = &Type::Fun(vec![param_t.clone()], Box::new(bool_t.clone()));
+            let pred_num_t = &Type::Fun(vec![num_t.clone()], Box::new(bool_t.clone()));
+
+            // Vectors
+            add_builtin(
+                self,
+                self.builtin_fun_symbol("len"),
+                SpecFunEntry {
+                    loc: loc.clone(),
+                    oper: Operation::Len,
+                    type_params: vec![param_t.clone()],
+                    arg_types: vec![vector_t.clone()],
+                    result_type: num_t.clone(),
+                },
+            );
+            add_builtin(
+                self,
+                self.builtin_fun_symbol("all"),
+                SpecFunEntry {
+                    loc: loc.clone(),
+                    oper: Operation::All,
+                    type_params: vec![param_t.clone()],
+                    arg_types: vec![vector_t.clone(), pred_t.clone()],
+                    result_type: bool_t.clone(),
+                },
+            );
+            add_builtin(
+                self,
+                self.builtin_fun_symbol("any"),
+                SpecFunEntry {
+                    loc: loc.clone(),
+                    oper: Operation::Any,
+                    type_params: vec![param_t.clone()],
+                    arg_types: vec![vector_t.clone(), pred_t.clone()],
+                    result_type: bool_t.clone(),
+                },
+            );
+            add_builtin(
+                self,
+                self.builtin_fun_symbol("update"),
+                SpecFunEntry {
+                    loc: loc.clone(),
+                    oper: Operation::VectorUpdate,
+                    type_params: vec![param_t.clone()],
+                    arg_types: vec![vector_t.clone(), num_t.clone(), param_t.clone()],
+                    result_type: vector_t.clone(),
+                },
+            );
+
+            // Ranges
+            add_builtin(
+                self,
+                self.builtin_fun_symbol("all"),
+                SpecFunEntry {
+                    loc: loc.clone(),
+                    oper: Operation::All,
+                    type_params: vec![],
+                    arg_types: vec![range_t.clone(), pred_num_t.clone()],
+                    result_type: bool_t.clone(),
+                },
+            );
+            add_builtin(
+                self,
+                self.builtin_fun_symbol("any"),
+                SpecFunEntry {
+                    loc: loc.clone(),
+                    oper: Operation::Any,
+                    type_params: vec![],
+                    arg_types: vec![range_t.clone(), pred_num_t.clone()],
+                    result_type: bool_t.clone(),
+                },
+            );
+
+            // Resources.
+            add_builtin(
+                self,
+                self.builtin_fun_symbol("global"),
+                SpecFunEntry {
+                    loc: loc.clone(),
+                    oper: Operation::Global,
+                    type_params: vec![param_t.clone()],
+                    arg_types: vec![address_t.clone()],
+                    result_type: param_t.clone(),
+                },
+            );
+            add_builtin(
+                self,
+                self.builtin_fun_symbol("exists"),
+                SpecFunEntry {
+                    loc: loc.clone(),
+                    oper: Operation::Exists,
+                    type_params: vec![param_t.clone()],
+                    arg_types: vec![address_t.clone()],
+                    result_type: bool_t.clone(),
+                },
+            );
+
+            // Old
+            add_builtin(
+                self,
+                self.builtin_fun_symbol("old"),
+                SpecFunEntry {
+                    loc,
+                    oper: Operation::Old,
+                    type_params: vec![param_t.clone()],
+                    arg_types: vec![param_t.clone()],
+                    result_type: param_t.clone(),
+                },
+            );
+        }
+    }
+
+    /// Returns the qualified symbol for the binary operator.
+    fn bin_op_symbol(&self, op: &PA::BinOp_) -> QualifiedSymbol {
+        QualifiedSymbol {
+            module_name: self.builtin_module(),
+            symbol: self.env.symbol_pool().make(&op.symbol()),
+        }
+    }
+
+    /// Returns the qualified symbol for the unary operator.
+    fn unary_op_symbol(&self, op: &PA::UnaryOp_) -> QualifiedSymbol {
+        QualifiedSymbol {
+            module_name: self.builtin_module(),
+            symbol: self.env.symbol_pool().make(&op.symbol()),
+        }
+    }
+
+    /// Returns the qualified symbol for a builtin function.
+    fn builtin_fun_symbol(&self, name: &str) -> QualifiedSymbol {
+        QualifiedSymbol {
+            module_name: self.builtin_module(),
+            symbol: self.env.symbol_pool().make(name),
+        }
+    }
+
+    /// Returns the symbol for the builtin function `old`.
+    fn old_symbol(&self) -> Symbol {
+        self.env.symbol_pool().make("old")
+    }
+
+    /// Returns the name for the pseudo builtin module.
+    pub fn builtin_module(&self) -> ModuleName {
+        ModuleName::new(BigUint::default(), self.env.symbol_pool().make("$$"))
+    }
+}
+
+// =================================================================================================
+/// # Module Translation
+
+/// A module translator.
+#[derive(Debug)]
+pub struct ModuleTranslator<'env, 'translator> {
+    parent: &'translator mut Translator<'env>,
+    /// Counter for NodeId in this module.
+    node_counter: usize,
+    /// A map from node id to associated location.
+    loc_map: BTreeMap<NodeId, Loc>,
+    /// A map from node id to associated type.
+    type_map: BTreeMap<NodeId, Type>,
+    /// Id of the currently build module.
+    module_id: ModuleId,
+    /// Name of the currently build module.
+    module_name: ModuleName,
+    /// Translated specification functions.
+    spec_funs: Vec<SpecFunDecl>,
+    /// During the definition analysis, the index into `spec_funs` we are currently
+    /// handling
+    spec_fun_index: usize,
+    /// Translated specification variables.
+    spec_vars: Vec<SpecVarDecl>,
+    /// Translated function conditions.
+    fun_conds: BTreeMap<Symbol, Vec<Condition>>,
+    /// Translated struct invariants.
+    struct_invariants: BTreeMap<Symbol, Vec<Invariant>>,
+}
+
+/// # Entry Points
+
+impl<'env, 'translator> ModuleTranslator<'env, 'translator> {
+    pub fn new(
+        parent: &'translator mut Translator<'env>,
+        module_id: ModuleId,
+        module_name: ModuleName,
+    ) -> Self {
+        Self {
+            parent,
+            node_counter: 0,
+            loc_map: BTreeMap::new(),
+            type_map: BTreeMap::new(),
+            module_id,
+            module_name,
+            spec_funs: vec![],
+            spec_fun_index: 0,
+            spec_vars: vec![],
+            fun_conds: BTreeMap::new(),
+            struct_invariants: BTreeMap::new(),
+        }
+    }
+
+    /// Translates the given module definition from the move compiler's expansion phase,
+    /// combined with a compiled module (bytecode) and a source map, and enters it into
+    /// this global environment. Any type check or others errors encountered will be collected
+    /// in the environment for later processing.
+    pub fn translate(
+        &mut self,
+        file_id: FileId,
+        module_def: EA::ModuleDefinition,
+        compiled_module: CompiledModule,
+        source_map: Option<ModuleSourceMap<Span>>,
+    ) {
+        self.decl_ana(&module_def);
+        self.def_ana(&module_def);
+        self.populate_env_from_result(file_id, compiled_module, source_map);
+    }
+}
+
+/// # Basic Helpers
+
+/// A value which we pass in to spec block analyzers, describing the resolved target of the spec
+/// block.
+#[derive(Debug)]
+enum SpecBlockContext {
+    Module,
+    Struct(QualifiedSymbol),
+    Function(QualifiedSymbol),
+}
+
+impl<'env, 'translator> ModuleTranslator<'env, 'translator> {
+    /// Shortcut for accessing the symbol pool.
+    fn symbol_pool(&self) -> &SymbolPool {
+        self.parent.env.symbol_pool()
+    }
+
+    /// Creates a new node id.
+    fn new_node_id(&mut self) -> NodeId {
+        let node_id = NodeId::new(self.node_counter);
+        self.node_counter += 1;
+        node_id
+    }
+
+    /// Qualifies the given symbol by the current module.
+    fn qualified_by_module(&self, sym: Symbol) -> QualifiedSymbol {
+        QualifiedSymbol {
+            module_name: self.module_name.clone(),
+            symbol: sym,
+        }
+    }
+
+    /// Converts a ModuleAccess into its parts, an optional ModuleName and base name.
+    fn module_access_to_parts(&self, access: &EA::ModuleAccess) -> (Option<ModuleName>, Symbol) {
+        match &access.value {
+            EA::ModuleAccess_::Name(n) => (None, self.symbol_pool().make(n.value.as_str())),
+            EA::ModuleAccess_::ModuleAccess(m, n) => {
+                let module_name = ModuleName::from_str(
+                    &m.0.value.address.to_string(),
+                    self.symbol_pool().make(m.0.value.name.0.value.as_str()),
+                );
+                (Some(module_name), self.symbol_pool().make(n.value.as_str()))
+            }
+        }
+    }
+
+    /// Converts a ModuleAccess into a qualified symbol which can be used for lookup of
+    /// types or functions.
+    fn module_access_to_qualified(&self, access: &EA::ModuleAccess) -> QualifiedSymbol {
+        let (module_name_opt, symbol) = self.module_access_to_parts(access);
+        let module_name = module_name_opt.unwrap_or_else(|| self.module_name.clone());
+        QualifiedSymbol {
+            module_name,
+            symbol,
+        }
+    }
+
+    /// Creates a SpecBlockContext from the given SpecBlockTarget
+    fn get_spec_block_context(&self, target: &PA::SpecBlockTarget) -> Option<SpecBlockContext> {
+        match &target.value {
+            PA::SpecBlockTarget_::Function(name) => {
+                let qsym = self.qualified_by_module(self.symbol_pool().make(&name.0.value));
+                if self.parent.fun_table.contains_key(&qsym) {
+                    Some(SpecBlockContext::Function(qsym))
+                } else {
+                    None
+                }
+            }
+            PA::SpecBlockTarget_::Structure(name) => {
+                let qsym = self.qualified_by_module(self.symbol_pool().make(&name.0.value));
+                if self.parent.struct_table.contains_key(&qsym) {
+                    Some(SpecBlockContext::Struct(qsym))
+                } else {
+                    None
+                }
+            }
+            PA::SpecBlockTarget_::Module => Some(SpecBlockContext::Module),
+        }
+    }
+}
+
+/// # Declaration Analysis
+
+impl<'env, 'translator> ModuleTranslator<'env, 'translator> {
+    fn decl_ana(&mut self, module_def: &EA::ModuleDefinition) {
+        for (name, struct_def) in &module_def.structs {
+            self.decl_ana_struct(&name, struct_def);
+        }
+        for (name, fun_def) in &module_def.functions {
+            self.decl_ana_fun(&name, fun_def);
+        }
+        for spec in &module_def.specs {
+            self.decl_ana_spec_block(spec);
+        }
+    }
+
+    fn decl_ana_struct(&mut self, name: &PA::StructName, def: &EA::StructDefinition) {
+        let sym = self.symbol_pool().make(&name.0.value);
+        let qsym = self.qualified_by_module(sym);
+        let mut et = ExpTranslator::new(self, OldExpStatus::NotSupported);
+        let type_params = et.analyze_and_add_type_params(&def.type_parameters);
+        et.parent.parent.define_struct(
+            et.to_loc(&name.0.loc),
+            qsym,
+            et.parent.module_id,
+            StructId::new(sym),
+            def.resource_opt.is_some(),
+            type_params,
+            None, // will be filled in during definition analysis
+        );
+    }
+
+    fn decl_ana_fun(&mut self, name: &PA::FunctionName, def: &EA::Function) {
+        let sym = self.symbol_pool().make(&name.0.value);
+        let qsym = self.qualified_by_module(sym);
+        let mut et = ExpTranslator::new(self, OldExpStatus::NotSupported);
+        et.enter_scope();
+        let type_params = et.analyze_and_add_type_params(&def.signature.type_parameters);
+        et.enter_scope();
+        let params = et.analyze_and_add_params(&def.signature.parameters);
+        let result_type = et.translate_type(&def.signature.return_type);
+        et.parent.parent.define_fun(
+            et.to_loc(&name.0.loc),
+            qsym,
+            et.parent.module_id,
+            FunId::new(sym),
+            type_params,
+            params,
+            result_type,
+        );
+    }
+
+    fn decl_ana_spec_block(&mut self, block: &EA::SpecBlock) {
+        use EA::SpecBlockMember_::*;
+        for member in &block.value.members {
+            let loc = self.parent.env.to_loc(&member.loc);
+            match &member.value {
+                Function {
+                    name, signature, ..
+                } => self.decl_ana_spec_fun(&loc, name, signature),
+                Variable { name, type_ } => self.decl_ana_var(&loc, name, type_),
+                _ => {}
+            }
+        }
+    }
+
+    fn decl_ana_spec_fun(
+        &mut self,
+        loc: &Loc,
+        name: &PA::FunctionName,
+        signature: &EA::FunctionSignature,
+    ) {
+        let name = self.symbol_pool().make(&name.0.value);
+        let (type_params, params, result_type) = {
+            let et = &mut ExpTranslator::new(self, OldExpStatus::NotSupported);
+            let type_params = et.analyze_and_add_type_params(&signature.type_parameters);
+            et.enter_scope();
+            let params = et.analyze_and_add_params(&signature.parameters);
+            let result_type = et.translate_type(&signature.return_type);
+            et.finalize_types();
+            (type_params, params, result_type)
+        };
+
+        // Add the function to the symbol table.
+        let fun_id = SpecFunId::new(self.spec_funs.len());
+        self.parent.define_spec_fun(
+            loc,
+            self.qualified_by_module(name),
+            self.module_id,
+            fun_id,
+            type_params.iter().map(|(_, ty)| ty.clone()).collect(),
+            params.iter().map(|(_, ty)| ty.clone()).collect(),
+            result_type.clone(),
+        );
+        // Add a prototype of the SpecFunDecl to the module translator. This
+        // will for now have an empty body which we fill in during a 2nd pass.
+        let fun_decl = SpecFunDecl {
+            loc: loc.clone(),
+            name,
+            type_params,
+            params,
+            result_type,
+            body: None,
+        };
+        self.spec_funs.push(fun_decl);
+    }
+
+    fn decl_ana_var(&mut self, loc: &Loc, name: &Name, type_: &EA::SingleType) {
+        let name = self.symbol_pool().make(name.value.as_str());
+        let type_ = {
+            let et = &mut ExpTranslator::new(self, OldExpStatus::NotSupported);
+            et.translate_single_type(type_)
+        };
+        // Add the variable to the symbol table.
+        let var_id = SpecVarId::new(self.spec_vars.len());
+        self.parent.define_spec_var(
+            loc,
+            self.qualified_by_module(name),
+            self.module_id,
+            var_id,
+            type_.clone(),
+        );
+        // Add the variable to the module translator.
+        let var_decl = SpecVarDecl {
+            loc: loc.clone(),
+            name,
+            type_,
+        };
+        self.spec_vars.push(var_decl);
+    }
+}
+
+/// # Definition Analysis
+
+impl<'env, 'translator> ModuleTranslator<'env, 'translator> {
+    fn def_ana(&mut self, module_def: &EA::ModuleDefinition) {
+        for (name, def) in &module_def.structs {
+            self.def_ana_struct(&name, def);
+        }
+        for spec in &module_def.specs {
+            if let Some(context) = self.get_spec_block_context(&spec.value.target) {
+                self.def_ana_spec_block(&context, spec);
+            } else {
+                let loc = self.parent.env.to_loc(&spec.value.target.loc);
+                self.parent.error(&loc, "unresolved spec target");
+            }
+        }
+    }
+
+    fn def_ana_struct(&mut self, name: &PA::StructName, def: &EA::StructDefinition) {
+        let sym = self.symbol_pool().make(&name.0.value);
+        let qsym = self.qualified_by_module(sym);
+        let type_params = self
+            .parent
+            .struct_table
+            .get(&qsym)
+            .expect("struct invalid")
+            .type_params
+            .clone();
+        let mut et = ExpTranslator::new(self, OldExpStatus::NotSupported);
+        let loc = et.to_loc(&name.0.loc);
+        for (name, ty) in type_params {
+            et.define_type_param(&loc, name, ty);
+        }
+        let fields = match &def.fields {
+            EA::StructFields::Defined(fields) => {
+                let mut field_map = BTreeMap::new();
+                for (ref field_name, (_, ty)) in fields.iter() {
+                    let field_sym = et.symbol_pool().make(&field_name.0.value);
+                    let field_ty = et.translate_single_type(&ty);
+                    field_map.insert(field_sym, field_ty);
+                }
+                Some(field_map)
+            }
+            EA::StructFields::Native(_) => None,
+        };
+        self.parent
+            .struct_table
+            .get_mut(&qsym)
+            .expect("struct invalid")
+            .fields = fields;
+    }
+
+    fn def_ana_spec_block(&mut self, context: &SpecBlockContext, block: &EA::SpecBlock) {
+        use EA::SpecBlockMember_::*;
+        for member in &block.value.members {
+            let loc = &self.parent.env.to_loc(&member.loc);
+            match &member.value {
+                Condition { kind, exp } => self.def_ana_condition(context, loc, kind, exp),
+                Invariant { kind, exp } => self.def_ana_invariant(context, loc, kind, exp),
+                Function {
+                    signature, body, ..
+                } => self.def_ana_spec_fun(signature, body),
+                Variable { .. } => { /* nothing to do right now */ }
+            }
+        }
+    }
+
+    fn def_ana_condition(
+        &mut self,
+        context: &SpecBlockContext,
+        loc: &Loc,
+        kind: &PA::SpecConditionKind,
+        exp: &EA::Exp,
+    ) {
+        if let SpecBlockContext::Function(name) = context {
+            // We ensured that SpecBlockContext only contains resolvable names.
+            let entry = &self
+                .parent
+                .fun_table
+                .get(name)
+                .expect("invalid spec block context")
+                .clone();
+            let mut et = ExpTranslator::new(self, OldExpStatus::OutsideOld);
+            for (n, ty) in &entry.type_params {
+                et.define_type_param(loc, *n, ty.clone());
+            }
+            et.enter_scope();
+            for (n, ty) in &entry.params {
+                et.define_local(loc, *n, ty.clone(), None);
+            }
+            // Define the placeholders for the result values of a function.
+            et.enter_scope();
+            if let Type::Tuple(ts) = &entry.result_type {
+                for (i, ty) in ts.iter().enumerate() {
+                    let name = et.symbol_pool().make(&format!("result_{}", i + 1));
+                    et.define_local(loc, name, ty.clone(), Some(Operation::Result(i)));
+                }
+            } else {
+                let name = et.symbol_pool().make("result");
+                et.define_local(
+                    loc,
+                    name,
+                    entry.result_type.clone(),
+                    Some(Operation::Result(0)),
+                );
+            }
+            let translated = et.translate_exp(exp, &BOOL_TYPE);
+            et.finalize_types();
+            let kind = match kind {
+                PA::SpecConditionKind::Ensures => ConditionKind::Ensures,
+                PA::SpecConditionKind::AbortsIf => ConditionKind::AbortsIf,
+            };
+            self.fun_conds
+                .entry(name.symbol)
+                .or_insert_with(|| vec![])
+                .push(Condition {
+                    kind,
+                    exp: translated,
+                });
+        } else {
+            self.parent.error(loc, "item only allowed in function spec");
+        }
+    }
+
+    fn def_ana_invariant(
+        &mut self,
+        context: &SpecBlockContext,
+        loc: &Loc,
+        kind: &PA::InvariantKind,
+        exp: &EA::Exp,
+    ) {
+        if let SpecBlockContext::Struct(name) = context {
+            // We ensured that SpecBlockContext only contains resolvable names.
+            let entry = &self
+                .parent
+                .struct_table
+                .get(name)
+                .expect("invalid spec block context")
+                .clone();
+
+            if let Some(fields) = &entry.fields {
+                let (old_status, kind) = match kind {
+                    PA::InvariantKind::Data => (OldExpStatus::NotSupported, InvariantKind::Data),
+                    PA::InvariantKind::Update => (OldExpStatus::OutsideOld, InvariantKind::Update),
+                    PA::InvariantKind::Pack => (OldExpStatus::OutsideOld, InvariantKind::Pack),
+                    PA::InvariantKind::Unpack => (OldExpStatus::OutsideOld, InvariantKind::Unpack),
+                };
+                let mut et = ExpTranslator::new(self, old_status);
+                for (n, ty) in &entry.type_params {
+                    et.define_type_param(loc, *n, ty.clone());
+                }
+                et.enter_scope();
+                for (n, ty) in fields {
+                    et.define_local(
+                        loc,
+                        *n,
+                        ty.clone(),
+                        Some(Operation::FieldSelect(
+                            entry.module_id,
+                            entry.struct_id,
+                            FieldId::new(*n),
+                        )),
+                    );
+                }
+                // Process assignment for a spec var.
+                let (exp, expected_type) = if let EA::Exp_::Assign(list, exp) = &exp.value {
+                    if kind == InvariantKind::Data {
+                        et.error(
+                            loc,
+                            "assignment to spec globals not allowed for data invariants",
+                        );
+                        return;
+                    }
+                    if let Some(name) = et.extract_assign_target(list) {
+                        let var_loc = et.to_loc(&list.loc);
+                        let var_name = et.parent.qualified_by_module(name);
+                        if let Some(spec_var) = et.parent.parent.spec_var_table.get(&var_name) {
+                            (exp.as_ref(), spec_var.type_.clone())
+                        } else {
+                            et.error(
+                                &var_loc,
+                                &format!(
+                                    "spec global `{}` undeclared",
+                                    var_name.display(et.symbol_pool())
+                                ),
+                            );
+                            return;
+                        }
+                    } else {
+                        // Error has been reported.
+                        return;
+                    }
+                } else {
+                    // There is no assignment, but Pack and Unpack need one.
+                    if let InvariantKind::Pack | InvariantKind::Unpack = kind {
+                        et.error(
+                            loc,
+                            "pack/unpack invariants must be assignments to spec globals",
+                        );
+                        return;
+                    }
+                    (exp, BOOL_TYPE.clone())
+                };
+
+                let translated = et.translate_exp(exp, &expected_type);
+                et.finalize_types();
+                if !self.struct_invariants.contains_key(&name.symbol) {
+                    self.struct_invariants.insert(name.symbol.clone(), vec![]);
+                }
+                self.struct_invariants
+                    .entry(name.symbol)
+                    .or_insert_with(|| vec![])
+                    .push(Invariant {
+                        kind,
+                        exp: translated,
+                    });
+            } else {
+                self.parent
+                    .error(loc, "native structs cannot have invariants");
+            }
+        } else {
+            self.parent.error(loc, "item only allowed in struct spec");
+        }
+    }
+
+    fn def_ana_spec_fun(&mut self, _signature: &EA::FunctionSignature, body: &EA::FunctionBody) {
+        if let EA::FunctionBody_::Defined(seq) = &body.value {
+            let entry = &self.spec_funs[self.spec_fun_index];
+            let type_params = entry.type_params.clone();
+            let params = entry.params.clone();
+            let result_type = entry.result_type.clone();
+            let mut et = ExpTranslator::new(self, OldExpStatus::OutsideOld);
+            let loc = et.to_loc(&body.loc);
+            for (n, ty) in type_params {
+                et.define_type_param(&loc, n, ty);
+            }
+            et.enter_scope();
+            for (n, ty) in params {
+                et.define_local(&loc, n, ty, None);
+            }
+            let translated = et.translate_seq(&loc, seq, &result_type);
+            et.finalize_types();
+            // Inject the translated expression body into SpecFunDecl we created in decl analysis.
+            self.spec_funs[self.spec_fun_index].body = Some(translated);
+        }
+        self.spec_fun_index += 1;
+    }
+}
+
+/// # Environment Population
+
+impl<'env, 'translator> ModuleTranslator<'env, 'translator> {
+    fn populate_env_from_result(
+        &mut self,
+        file_id: FileId,
+        module: CompiledModule,
+        source_map: Option<ModuleSourceMap<Span>>,
+    ) {
+        let struct_data: BTreeMap<StructId, StructData> = (0..module.struct_defs().len())
+            .map(|idx| {
+                let def_idx = StructDefinitionIndex(idx as u16);
+                let handle_idx = module.struct_def_at(def_idx).struct_handle;
+                let handle = module.struct_handle_at(handle_idx);
+                let view = StructHandleView::new(&module, handle);
+                let name = self.symbol_pool().make(view.name().as_str());
+                let invariants = self
+                    .struct_invariants
+                    .remove(&name)
+                    .unwrap_or_else(|| vec![]);
+                (
+                    StructId::new(name),
+                    self.parent
+                        .env
+                        .create_struct_data(&module, def_idx, name, invariants),
+                )
+            })
+            .collect();
+        let function_data: BTreeMap<FunId, FunctionData> = (0..module.function_defs().len())
+            .filter_map(|idx| {
+                let def_idx = FunctionDefinitionIndex(idx as u16);
+                let handle_idx = module.function_def_at(def_idx).function;
+                let handle = module.function_handle_at(handle_idx);
+                let view = FunctionHandleView::new(&module, handle);
+                let name = self.symbol_pool().make(view.name().as_str());
+                let conditions = self.fun_conds.remove(&name).unwrap_or_else(|| vec![]);
+                if let Some(entry) = self.parent.fun_table.get(&self.qualified_by_module(name)) {
+                    let arg_names = project_1st(&entry.params);
+                    let type_arg_names = project_1st(&entry.type_params);
+                    Some((FunId::new(name), self.parent.env.create_function_data(
+                        &module,
+                        def_idx,
+                        name,
+                        arg_names,
+                        type_arg_names,
+                        conditions,
+                    )))
+                } else {
+                    self.parent.error(
+                        &self.parent.env.default_loc(),
+                        &format!("[internal] bytecode does not match AST: `{}` in bytecode but not in AST", name.display(self.symbol_pool())));
+                    None
+                }
+            })
+            .collect();
+        let source_map = source_map.unwrap_or_else(|| {
+            ModuleSourceMap::dummy_from_module(&module).expect("cannot create dummy source map")
+        });
+        let spec_vars = std::mem::replace(&mut self.spec_vars, vec![]);
+        let spec_funs = std::mem::replace(&mut self.spec_funs, vec![]);
+        let loc_map = std::mem::replace(&mut self.loc_map, BTreeMap::new());
+        let type_map = std::mem::replace(&mut self.type_map, BTreeMap::new());
+        self.parent.env.add(
+            file_id,
+            module,
+            source_map,
+            struct_data,
+            function_data,
+            spec_vars,
+            spec_funs,
+            loc_map,
+            type_map,
+        );
+    }
+}
+
+// =================================================================================================
+/// # Expression and Type Translation
+#[derive(Debug)]
+pub struct ExpTranslator<'env, 'translator, 'module_translator> {
+    parent: &'module_translator mut ModuleTranslator<'env, 'translator>,
+    /// A symbol table for type parameters.
+    type_params_table: BTreeMap<Symbol, Type>,
+    /// A scoped symbol table for local names. The first element in the list contains the most
+    /// inner scope.
+    local_table: LinkedList<BTreeMap<Symbol, LocalVarEntry>>,
+    /// When compiling a condition, the result type of the function the condition is associated
+    /// with.
+    result_type: Option<Type>,
+    /// Status for the `old(...)` expression form.
+    old_status: OldExpStatus,
+    /// The currently build type substitution.
+    subs: Substitution,
+    /// A counter for generating type variables.
+    type_var_counter: u16,
+    /// A marker to indicate the node_counter start state.
+    node_counter_start: usize,
+}
+
+#[derive(Debug)]
+struct LocalVarEntry {
+    loc: Loc,
+    type_: Type,
+    // If this local is associated with an operation, this is set.
+    operation: Option<Operation>,
+}
+
+#[derive(Debug, PartialEq)]
+enum OldExpStatus {
+    NotSupported,
+    OutsideOld,
+    InsideOld,
+}
+
+/// ## General
+///
+impl<'env, 'translator, 'module_translator> ExpTranslator<'env, 'translator, 'module_translator> {
+    fn new(
+        parent: &'module_translator mut ModuleTranslator<'env, 'translator>,
+        old_status: OldExpStatus,
+    ) -> Self {
+        let node_counter_start = parent.node_counter;
+        Self {
+            parent,
+            type_params_table: BTreeMap::new(),
+            local_table: LinkedList::new(),
+            result_type: None,
+            old_status,
+            subs: Substitution::new(),
+            type_var_counter: 0,
+            node_counter_start,
+        }
+    }
+
+    /// Shortcut for accessing symbol pool.
+    fn symbol_pool(&self) -> &SymbolPool {
+        self.parent.parent.env.symbol_pool()
+    }
+
+    /// Shortcut for translating a Move AST location into ours.
+    fn to_loc(&self, loc: &move_lang::shared::Loc) -> Loc {
+        self.parent.parent.env.to_loc(loc)
+    }
+
+    /// Shortcut for reporting an error.
+    fn error(&self, loc: &Loc, msg: &str) {
+        self.parent.parent.error(loc, msg);
+    }
+
+    /// Creates a fresh type variable.
+    fn fresh_type_var(&mut self) -> Type {
+        let var = Type::Var(self.type_var_counter);
+        self.type_var_counter += 1;
+        var
+    }
+
+    /// Creates a new node id and assigns type and location to it.
+    fn new_node_type_loc(&mut self, ty: &Type, loc: &Loc) -> NodeId {
+        let id = self.parent.new_node_id();
+        self.parent.loc_map.insert(id, loc.clone());
+        self.parent.type_map.insert(id, ty.clone());
+        id
+    }
+
+    /// Finalizes types in this translator, producing errors if some could not be inferred
+    /// and remained incomplete.
+    fn finalize_types(&mut self) {
+        if self.parent.parent.env.has_errors() {
+            // Don't do that check if we already reported errors, as this would produce
+            // useless followup errors.
+            return;
+        }
+        for i in self.node_counter_start..self.parent.node_counter {
+            let id = NodeId::new(i);
+            if let Some(ty) = self.parent.type_map.get_mut(&id) {
+                *ty = self.subs.specialize(ty);
+                if ty.is_incomplete() {
+                    // This type could not be fully inferred.
+                    let loc = if let Some(loc) = self.parent.loc_map.get(&id) {
+                        loc.clone()
+                    } else {
+                        self.parent.parent.env.default_loc()
+                    };
+                    let ty = ty.clone(); // clone to release mut ref to self
+                    self.error(
+                        &loc,
+                        &format!(
+                            "unable to infer type: `{}`",
+                            ty.display(&self.type_display_context())
+                        ),
+                    );
+                };
+            }
+        }
+    }
+
+    /// Constructs a type display context used to visualize types in error messages.
+    fn type_display_context(&self) -> TypeDisplayContext<'_> {
+        TypeDisplayContext {
+            symbol_pool: self.symbol_pool(),
+            reverse_struct_table: &self.parent.parent.reverse_struct_table,
+        }
+    }
+
+    /// Creates an error expression.
+    fn new_error_exp(&mut self) -> Exp {
+        let id = self.new_node_type_loc(&Type::Error, &self.parent.parent.env.default_loc());
+        Exp::Error(id)
+    }
+
+    /// Enters a new scope in the locals table.
+    fn enter_scope(&mut self) {
+        self.local_table.push_front(BTreeMap::new());
+    }
+
+    /// Exists the most inner scope of the locals table.
+    fn exit_scope(&mut self) {
+        self.local_table.pop_front();
+    }
+
+    /// Defines a type parameter.
+    fn define_type_param(&mut self, loc: &Loc, name: Symbol, ty: Type) {
+        if self.type_params_table.insert(name, ty).is_some() {
+            let param_name = name.display(self.symbol_pool());
+            self.parent
+                .parent
+                .error(loc, &format!("duplicate declaration of `{}`", param_name));
+        }
+    }
+
+    /// Defines a local in the most inner scope. This produces an error
+    /// if the name already exists. The invariant option is used for names
+    /// which appear as locals in expressions, but are actually implicit selections
+    /// of fields of an underlying struct.
+    fn define_local(&mut self, loc: &Loc, name: Symbol, type_: Type, operation: Option<Operation>) {
+        let entry = LocalVarEntry {
+            loc: loc.clone(),
+            type_,
+            operation,
+        };
+        if let Some(old) = self
+            .local_table
+            .front_mut()
+            .expect("symbol table empty")
+            .insert(name, entry)
+        {
+            let display = name.display(self.symbol_pool());
+            self.error(loc, &format!("duplicate declaration of `{}`", display));
+            self.error(&old.loc, &format!("previous declaration of `{}`", display));
+        }
+    }
+
+    /// Lookup a local in this translator.
+    fn lookup_local(&mut self, name: Symbol) -> Option<&LocalVarEntry> {
+        for scope in &self.local_table {
+            if let Some(entry) = scope.get(&name) {
+                return Some(entry);
+            }
+        }
+        None
+    }
+
+    /// Analyzes the sequence of type parameters as they are provided via the source AST and enters
+    /// them into the environment. Returns a vector for representing them in the target AST.
+    fn analyze_and_add_type_params(
+        &mut self,
+        type_params: &[(Name, PA::Kind)],
+    ) -> Vec<(Symbol, Type)> {
+        type_params
+            .iter()
+            .enumerate()
+            .map(|(i, (n, _))| {
+                let ty = Type::TypeParameter(i as u16);
+                let sym = self.symbol_pool().make(n.value.as_str());
+                self.define_type_param(&self.to_loc(&n.loc), sym, ty.clone());
+                (sym, ty)
+            })
+            .collect_vec()
+    }
+
+    /// Analyzes the sequence of function parameters as they are provided via the source AST and
+    /// enters them into the environment. Returns a vector for representing them in the target AST.
+    fn analyze_and_add_params(
+        &mut self,
+        params: &[(PA::Var, EA::SingleType)],
+    ) -> Vec<(Symbol, Type)> {
+        params
+            .iter()
+            .map(|(v, ty)| {
+                let ty = self.translate_single_type(ty);
+                let sym = self.symbol_pool().make(v.0.value.as_str());
+                self.define_local(&self.to_loc(&v.0.loc), sym, ty.clone(), None);
+                (sym, ty)
+            })
+            .collect_vec()
+    }
+
+    /// Displays a call target for error messages.
+    fn display_call_target(&mut self, module: &Option<ModuleName>, name: Symbol) -> String {
+        if let Some(m) = module {
+            if m != &self.parent.parent.builtin_module() {
+                // Only print the module name if it is not the pseudo builtin module.
+                return format!(
+                    "{}",
+                    QualifiedSymbol {
+                        module_name: m.clone(),
+                        symbol: name,
+                    }
+                    .display(self.symbol_pool())
+                );
+            }
+        }
+        format!("{}", name.display(self.symbol_pool()))
+    }
+
+    /// Displays a call target candidate for error messages.
+    fn display_call_cand(
+        &mut self,
+        module: &Option<ModuleName>,
+        name: Symbol,
+        entry: &SpecFunEntry,
+    ) -> String {
+        let target = self.display_call_target(module, name);
+        let type_display_context = self.type_display_context();
+        format!(
+            "{}({}): {}",
+            target,
+            entry
+                .arg_types
+                .iter()
+                .map(|ty| ty.display(&type_display_context))
+                .join(", "),
+            entry.result_type.display(&type_display_context)
+        )
+    }
+}
+
+/// ## Type Translation
+
+impl<'env, 'translator, 'module_translator> ExpTranslator<'env, 'translator, 'module_translator> {
+    /// Translates a source AST type into a target AST type.
+    fn translate_type(&mut self, ty: &EA::Type) -> Type {
+        use EA::Type_::*;
+        match &ty.value {
+            Unit => Type::Tuple(vec![]),
+            Single(st) => self.translate_single_type(st),
+            Multiple(vst) => {
+                Type::Tuple(vst.iter().map(|t| self.translate_single_type(t)).collect())
+            }
+        }
+    }
+
+    /// Translates a source AST single-type into a target AST type.
+    fn translate_single_type(&mut self, ty: &EA::SingleType) -> Type {
+        use EA::SingleType_::*;
+        match &ty.value {
+            Apply(access, args) => {
+                if let EA::ModuleAccess_::Name(n) = &access.value {
+                    // Attempt to resolve as primitive type.
+                    match n.value.as_str() {
+                        "bool" => return Type::new_prim(PrimitiveType::Bool),
+                        "u8" => return Type::new_prim(PrimitiveType::U8),
+                        "u64" => return Type::new_prim(PrimitiveType::U64),
+                        "u128" => return Type::new_prim(PrimitiveType::U128),
+                        "num" => return Type::new_prim(PrimitiveType::Num),
+                        "range" => return Type::new_prim(PrimitiveType::Range),
+                        "bytearray" => return Type::new_prim(PrimitiveType::ByteArray),
+                        "address" => return Type::new_prim(PrimitiveType::Address),
+                        "vector" => {
+                            if args.len() != 1 {
+                                self.error(
+                                    &self.to_loc(&ty.loc),
+                                    "expected one type argument for `vector`",
+                                );
+                                return Type::Error;
+                            } else {
+                                return Type::Vector(Box::new(
+                                    self.translate_single_type(&args[0]),
+                                ));
+                            }
+                        }
+                        _ => {}
+                    }
+                    // Attempt to resolve as a type parameter.
+                    let sym = self.symbol_pool().make(n.value.as_str());
+                    if let Some(ty) = self.type_params_table.get(&sym) {
+                        return ty.clone();
+                    }
+                }
+                let loc = self.to_loc(&access.loc);
+                let sym = self.parent.module_access_to_qualified(access);
+                let rty = self.parent.parent.lookup_type(&loc, &sym);
+                if !args.is_empty() {
+                    // Replace type instantiation.
+                    if let Type::Struct(mid, sid, params) = &rty {
+                        if params.len() != args.len() {
+                            self.error(&loc, "type argument count mismatch");
+                            Type::Error
+                        } else {
+                            Type::Struct(*mid, *sid, self.translate_single_types(args))
+                        }
+                    } else {
+                        self.error(&loc, "type cannot have type arguments");
+                        Type::Error
+                    }
+                } else {
+                    rty
+                }
+            }
+            Ref(is_mut, ty) => Type::Reference(*is_mut, Box::new(self.translate_single_type(&*ty))),
+            Fun(args, result) => Type::Fun(
+                self.translate_single_types(args),
+                Box::new(self.translate_type(&*result)),
+            ),
+            UnresolvedError => Type::Error,
+        }
+    }
+
+    /// Translates a slice of single types.
+    fn translate_single_types(&mut self, tys: &[EA::SingleType]) -> Vec<Type> {
+        tys.iter().map(|t| self.translate_single_type(t)).collect()
+    }
+}
+
+/// ## Expression Translation
+
+impl<'env, 'translator, 'module_translator> ExpTranslator<'env, 'translator, 'module_translator> {
+    /// Translates an expression, with given expected type, which might be a type variable.
+    fn translate_exp(&mut self, exp: &EA::Exp, expected_type: &Type) -> Exp {
+        let loc = self.to_loc(&exp.loc);
+        let mut make_value = |val: Value, ty: Type| {
+            let rty = self.check_type(&loc, &ty, expected_type);
+            let id = self.new_node_type_loc(&rty, &loc);
+            Exp::Value(id, val)
+        };
+        match &exp.value {
+            EA::Exp_::Value(v) => match &v.value {
+                PA::Value_::Address(addr) => make_value(
+                    Value::Address(
+                        BigUint::from_str_radix(&format!("{}", addr), 16).expect("valid address"),
+                    ),
+                    Type::new_prim(PrimitiveType::Address),
+                ),
+                PA::Value_::U8(x) => make_value(
+                    Value::Number(BigUint::from_u8(*x).unwrap()),
+                    Type::new_prim(PrimitiveType::U8),
+                ),
+                PA::Value_::U64(x) => make_value(
+                    Value::Number(BigUint::from_u64(*x).unwrap()),
+                    Type::new_prim(PrimitiveType::U64),
+                ),
+                PA::Value_::U128(x) => make_value(
+                    Value::Number(BigUint::from_u128(*x).unwrap()),
+                    Type::new_prim(PrimitiveType::U128),
+                ),
+                PA::Value_::Bool(x) => {
+                    make_value(Value::Bool(*x), Type::new_prim(PrimitiveType::Bool))
+                }
+                PA::Value_::Bytearray(x) => make_value(
+                    Value::Bytearray(x.clone()),
+                    Type::new_prim(PrimitiveType::ByteArray),
+                ),
+            },
+            EA::Exp_::InferredNum(x) => make_value(
+                Value::Number(BigUint::from_u128(*x).unwrap()),
+                Type::new_prim(PrimitiveType::U128),
+            ),
+            EA::Exp_::Name(n) => self.translate_name(&loc, n, expected_type),
+            EA::Exp_::Call(maccess, generics, args) => {
+                // We need the args to be a `&Vec<&Exp>`. This allows us to
+                // construct arg vectors for translate_call on the fly without need to clone
+                // the ast. The below does the trick.
+                let args = (&args.value).iter().collect_vec();
+
+                // First check whether this is an Invoke on a function value.
+                if let EA::ModuleAccess_::Name(n) = &maccess.value {
+                    let sym = self.symbol_pool().make(&n.value);
+                    if let Some(entry) = self.lookup_local(sym) {
+                        // Check whether the local has the expected function type.
+                        let sym_ty = entry.type_.clone();
+                        let (arg_types, args) = self.translate_exp_list(&args);
+                        let fun_t = Type::Fun(arg_types, Box::new(expected_type.clone()));
+                        let sym_ty = self.check_type(&loc, &sym_ty, &fun_t);
+                        let local_id = self.new_node_type_loc(&sym_ty, &self.to_loc(&n.loc));
+                        let local_var = Exp::LocalVar(local_id, sym);
+                        let id = self.new_node_type_loc(expected_type, &loc);
+                        return Exp::Invoke(id, Box::new(local_var), args);
+                    }
+                }
+                // Next treat this as a call to a global function.
+                let (module_name, name) = self.parent.module_access_to_parts(maccess);
+                let is_old = module_name.is_none() && name == self.parent.parent.old_symbol();
+                if is_old {
+                    match self.old_status {
+                        OldExpStatus::NotSupported => {
+                            self.error(&loc, "`old(..)` expression not allowed in this context");
+                        }
+                        OldExpStatus::InsideOld => {
+                            self.error(&loc, "`old(..old(..)..)` not allowed");
+                        }
+                        OldExpStatus::OutsideOld => {
+                            self.old_status = OldExpStatus::InsideOld;
+                        }
+                    }
+                }
+                let result =
+                    self.translate_call(&loc, &module_name, name, generics, &args, expected_type);
+                if is_old && self.old_status == OldExpStatus::InsideOld {
+                    self.old_status = OldExpStatus::OutsideOld;
+                }
+                result
+            }
+            EA::Exp_::Pack(maccess, generics, fields) => {
+                self.translate_pack(&loc, maccess, generics, fields, expected_type)
+            }
+            EA::Exp_::IfElse(cond, then, else_) => {
+                let then = self.translate_exp(&*then, expected_type);
+                let else_ = self.translate_exp(&*else_, expected_type);
+                let cond = self.translate_exp(&*cond, &Type::new_prim(PrimitiveType::Bool));
+                let id = self.new_node_type_loc(expected_type, &loc);
+                Exp::IfElse(id, Box::new(cond), Box::new(then), Box::new(else_))
+            }
+            EA::Exp_::Block(seq) => self.translate_seq(&loc, seq, expected_type),
+            EA::Exp_::Lambda(bindings, exp) => {
+                self.translate_lambda(&loc, bindings, exp, expected_type)
+            }
+            EA::Exp_::BinopExp(l, op, r) => {
+                let args = vec![l.as_ref(), r.as_ref()];
+                let QualifiedSymbol {
+                    module_name,
+                    symbol,
+                } = self.parent.parent.bin_op_symbol(&op.value);
+                self.translate_call(
+                    &loc,
+                    &Some(module_name),
+                    symbol,
+                    &None,
+                    &args,
+                    expected_type,
+                )
+            }
+            EA::Exp_::UnaryExp(op, exp) => {
+                let args = vec![exp.as_ref()];
+                let QualifiedSymbol {
+                    module_name,
+                    symbol,
+                } = self.parent.parent.unary_op_symbol(&op.value);
+                self.translate_call(
+                    &loc,
+                    &Some(module_name),
+                    symbol,
+                    &None,
+                    &args,
+                    expected_type,
+                )
+            }
+            EA::Exp_::ExpDotted(dotted) => self.translate_dotted(dotted, expected_type),
+            EA::Exp_::Index(target, index) => {
+                self.translate_index(&loc, target, index, expected_type)
+            }
+            _ => {
+                self.error(&loc, "expression construct not supported in specifications");
+                self.new_error_exp()
+            }
+        }
+    }
+
+    /// Translates an expression without any known type expectation. This creates a fresh type
+    /// variable and passes this in as expected type, then returns a pair of this type and the
+    /// translated expression.
+    fn translate_exp_free(&mut self, exp: &EA::Exp) -> (Type, Exp) {
+        let tvar = self.fresh_type_var();
+        let exp = self.translate_exp(exp, &tvar);
+        (tvar, exp)
+    }
+
+    /// Translates a sequence expression.
+    fn translate_seq(&mut self, loc: &Loc, seq: &EA::Sequence, expected_type: &Type) -> Exp {
+        let n = seq.len();
+        if n == 0 {
+            self.error(loc, "block sequence cannot be empty");
+            return self.new_error_exp();
+        }
+        // Process all items before the last one, which must be bindings, and accumulate
+        // declarations for them.
+        let mut decls = vec![];
+        let seq = seq.iter().collect_vec();
+        for item in &seq[0..seq.len() - 1] {
+            match &item.value {
+                EA::SequenceItem_::Bind(list, exp) => {
+                    let (t, e) = self.translate_exp_free(exp);
+                    if list.value.len() != 1 {
+                        self.error(
+                            &self.to_loc(&list.loc),
+                            "[current restriction] tuples not supported in let",
+                        );
+                        return Exp::Error(self.parent.new_node_id());
+                    }
+                    let bind_loc = self.to_loc(&list.value[0].loc);
+                    match &list.value[0].value {
+                        EA::Bind_::Var(var) => {
+                            // Declare the variable in the local environment. Currently we mimic
+                            // Rust/ML semantics here, allowing to shadow with each let.
+                            self.enter_scope();
+                            let name = self.symbol_pool().make(&var.0.value);
+                            self.define_local(&bind_loc, name, t.clone(), None);
+                            let id = self.new_node_type_loc(&t, &bind_loc);
+                            decls.push(LocalVarDecl {
+                                id,
+                                name,
+                                binding: Some(e),
+                            });
+                        }
+                        EA::Bind_::Unpack(..) => {
+                            self.error(
+                                &bind_loc,
+                                "[current restriction] unpack not supported in let",
+                            );
+                            return Exp::Error(self.parent.new_node_id());
+                        }
+                    }
+                }
+                _ => self.error(
+                    &self.to_loc(&item.loc),
+                    "only binding `let p = e; ...` allowed here",
+                ),
+            }
+        }
+
+        // Process the last element, which must be an Exp item.
+        let last = match &seq[n - 1].value {
+            EA::SequenceItem_::Seq(e) => self.translate_exp(e, expected_type),
+            _ => {
+                self.error(
+                    &self.to_loc(&seq[n - 1].loc),
+                    "expected an expression as the last element of the block",
+                );
+                self.new_error_exp()
+            }
+        };
+
+        // Exit the scopes for variable bindings
+        for _ in 0..decls.len() {
+            self.exit_scope();
+        }
+
+        let id = self.new_node_type_loc(expected_type, loc);
+        Exp::Block(id, decls, Box::new(last))
+    }
+
+    /// Translates a name. Reports an error if the name is not found.
+    fn translate_name(&mut self, loc: &Loc, name: &Name, expected_type: &Type) -> Exp {
+        let sym = self.symbol_pool().make(name.value.as_str());
+        // First try to find the name in the locals table.
+        if let Some(entry) = self.lookup_local(sym) {
+            let oper_opt = entry.operation.clone();
+            let ty = entry.type_.clone();
+            let ty = self.check_type(loc, &ty, expected_type);
+            let id = self.new_node_type_loc(&ty, loc);
+            if let Some(oper) = oper_opt {
+                return Exp::Call(id, oper, vec![]);
+            } else {
+                return Exp::LocalVar(id, sym);
+            }
+        }
+        // Next try to find the name in the spec var table.
+        let qualified = self.parent.qualified_by_module(sym);
+        if let Some(entry) = self.parent.parent.spec_var_table.get(&qualified) {
+            let var_id = entry.var_id;
+            let module_id = entry.module_id;
+            let ty = entry.type_.clone();
+            let ty = self.check_type(loc, &ty, expected_type);
+            let id = self.new_node_type_loc(&ty, loc);
+            return Exp::SpecVar(id, module_id, var_id);
+        }
+
+        // TODO: the move-lang ast currently does not have a qualified name syntax
+        //   for globals. So we can only lookup spec vars from the same module.
+
+        self.error(loc, &format!("undeclared `{}`", name.value));
+        self.new_error_exp()
+    }
+
+    /// Translate an Index expression.
+    fn translate_index(
+        &mut self,
+        loc: &Loc,
+        target: &EA::Exp,
+        index: &EA::Exp,
+        expected_type: &Type,
+    ) -> Exp {
+        // We must concretize the type of index to decide whether this is a slice
+        // or not. This is not compatible with full type inference, so we may
+        // try to actually represent slicing explicitly in the syntax to fix this.
+        // Alternatively, we could leave it to the backend to figure (after full
+        // type inference) whether this is slice or index.
+        let elem_ty = self.fresh_type_var();
+        let vector_ty = Type::Vector(Box::new(elem_ty.clone()));
+        let vector_exp = self.translate_exp(target, &vector_ty);
+        let (index_ty, ie) = self.translate_exp_free(index);
+        let index_ty = self.subs.specialize(&index_ty);
+        let (result_t, oper) = if let Type::Primitive(PrimitiveType::Range) = &index_ty {
+            (vector_ty, Operation::Slice)
+        } else {
+            // If this is not (known to be) a range, assume its an index.
+            self.check_type(&loc, &index_ty, &Type::new_prim(PrimitiveType::Num));
+            (elem_ty, Operation::Index)
+        };
+        let result_t = self.check_type(loc, &result_t, expected_type);
+        let id = self.new_node_type_loc(&result_t, &loc);
+        Exp::Call(id, oper, vec![vector_exp, ie])
+    }
+
+    /// Extract assign target from assignment list.
+    fn extract_assign_target(&self, list: &EA::AssignList) -> Option<Symbol> {
+        let var_loc = &self.to_loc(&list.loc);
+        if list.value.len() != 1 {
+            self.error(
+                var_loc,
+                "[current restriction] tuples not supported in assignment",
+            );
+            return None;
+        }
+        if let EA::Assign_::Var(var) = &list.value[0].value {
+            Some(self.symbol_pool().make(&var.0.value))
+        } else {
+            self.error(
+                var_loc,
+                "[current restriction] unpack not supported in invariant assignment",
+            );
+            None
+        }
+    }
+
+    /// Translate a Dotted expression.
+    fn translate_dotted(&mut self, dotted: &EA::ExpDotted, expected_type: &Type) -> Exp {
+        // Similar as with Index, we must concretize the type of the expression on which
+        // field selection is performed, violating full type inference rules, so we can actually
+        // check and retrieve the field. To avoid this, we would need to introduce the concept
+        // of a type constraint to type unification, where the constraint would be
+        // 'type var X where X has field F'. This makes unification significant more complex,
+        // so lets see how far we get without this.
+        match &dotted.value {
+            EA::ExpDotted_::Exp(e) => self.translate_exp(e, expected_type),
+            EA::ExpDotted_::Dot(e, n) => {
+                let loc = self.to_loc(&dotted.loc);
+                let field_name = self.symbol_pool().make(&n.value);
+                let ty = self.fresh_type_var();
+                let exp = self.translate_dotted(e.as_ref(), &ty);
+                // Try to concretize the type and check its a struct.
+                let struct_ty = self.subs.specialize(&ty);
+                if let Type::Struct(mid, sid, targs) = &struct_ty {
+                    // Lookup the StructEntry in the translator. It must be defined for valid
+                    // Type::Struct instances.
+                    let struct_name = self
+                        .parent
+                        .parent
+                        .reverse_struct_table
+                        .get(&(*mid, *sid))
+                        .expect("invalid Type::Struct");
+                    let entry = self
+                        .parent
+                        .parent
+                        .struct_table
+                        .get(struct_name)
+                        .expect("invalid Type::Struct")
+                        .clone();
+                    // Lookup the field in the struct.
+                    if let Some(fields) = &entry.fields {
+                        if let Some(field_ty) = fields.get(&field_name) {
+                            // We must instantiate the field type by the provided type args.
+                            let field_ty = field_ty.instantiate(targs);
+                            self.check_type(&loc, &field_ty, expected_type);
+                            let id = self.new_node_type_loc(&field_ty, &loc);
+                            Exp::Call(
+                                id,
+                                Operation::FieldSelect(
+                                    entry.module_id,
+                                    entry.struct_id,
+                                    FieldId::new(field_name),
+                                ),
+                                vec![exp],
+                            )
+                        } else {
+                            self.error(
+                                &loc,
+                                &format!(
+                                    "field `{}` not declared in struct `{}`",
+                                    field_name.display(self.symbol_pool()),
+                                    struct_name.display(self.symbol_pool())
+                                ),
+                            );
+                            self.new_error_exp()
+                        }
+                    } else {
+                        self.error(
+                            &loc,
+                            &format!(
+                                "struct `{}` is native and does not support field selection",
+                                struct_name.display(self.symbol_pool())
+                            ),
+                        );
+                        self.new_error_exp()
+                    }
+                } else {
+                    self.error(
+                        &loc,
+                        &format!(
+                            "type `{}` cannot be resolved as a struct",
+                            struct_ty.display(&self.type_display_context()),
+                        ),
+                    );
+                    self.new_error_exp()
+                }
+            }
+        }
+    }
+
+    /// Translates a call, performing overload resolution. Reports an error if the function cannot be found.
+    /// This is used to resolve both calls to user spec functions and builtin operators.
+    fn translate_call(
+        &mut self,
+        loc: &Loc,
+        module: &Option<ModuleName>,
+        name: Symbol,
+        generics: &Option<Vec<EA::SingleType>>,
+        args: &[&EA::Exp],
+        expected_type: &Type,
+    ) -> Exp {
+        // Translate generic arguments, if any.
+        let generics = if let Some(ts) = generics {
+            Some(self.translate_single_types(&ts))
+        } else {
+            None
+        };
+        // Translate arguments.
+        let (arg_types, args) = self.translate_exp_list(args);
+        // Lookup candidates.
+        let cand_modules = if let Some(m) = module {
+            vec![m.clone()]
+        } else {
+            // For an unqualified name, resolve it both in this and in the builtin pseudo module.
+            vec![
+                self.parent.module_name.clone(),
+                self.parent.parent.builtin_module(),
+            ]
+        };
+        let mut cands = vec![];
+        for module_name in cand_modules {
+            let full_name = QualifiedSymbol {
+                module_name,
+                symbol: name,
+            };
+            if let Some(list) = self.parent.parent.spec_fun_table.get(&full_name) {
+                cands.extend_from_slice(list);
+            }
+        }
+        if cands.is_empty() {
+            let display = self.display_call_target(module, name);
+            self.error(loc, &format!("no function named `{}` found", display));
+            return self.new_error_exp();
+        }
+        // Partition candidates in those which matched and which have been outruled.
+        let mut outruled = vec![];
+        let mut matching = vec![];
+        for cand in &cands {
+            if cand.arg_types.len() != args.len() {
+                outruled.push((
+                    cand,
+                    format!(
+                        "argument count mismatch (expected {} but found {})",
+                        cand.arg_types.len(),
+                        args.len()
+                    ),
+                ));
+                continue;
+            }
+            let (instantiation, diag) =
+                self.make_instantiation(cand.type_params.len(), generics.clone());
+            if let Some(msg) = diag {
+                outruled.push((cand, msg));
+                continue;
+            }
+            // Clone the current substitution, then unify arguments against parameter types.
+            let mut subs = self.subs.clone();
+            let mut success = true;
+            for (i, arg_ty) in arg_types.iter().enumerate() {
+                let instantiated = cand.arg_types[i].instantiate(&instantiation);
+                if let Err(err) = subs.unify(&self.type_display_context(), arg_ty, &instantiated) {
+                    outruled.push((cand, format!("{} for argument {}", err.message, i + 1)));
+                    success = false;
+                    break;
+                }
+            }
+            if success {
+                matching.push((cand, subs, instantiation));
+            }
+        }
+        // Deliver results, reporting errors if there are no or ambiguous matches.
+        match matching.len() {
+            0 => {
+                let display = self.display_call_target(module, name);
+                let notes = outruled
+                    .iter()
+                    .map(|(cand, msg)| {
+                        format!(
+                            "outruled candidate `{}` ({})",
+                            self.display_call_cand(module, name, cand),
+                            msg
+                        )
+                    })
+                    .collect_vec();
+                self.parent.parent.env.error_with_notes(
+                    loc,
+                    &format!("no matching declaration of `{}`", display),
+                    notes,
+                );
+                self.new_error_exp()
+            }
+            1 => {
+                let (cand, subs, instantiation) = matching.remove(0);
+                // Propagate the candidate substitution to this expression translator.
+                self.subs = subs;
+                // Check result type against expected type.
+                let ty = self.check_type(
+                    loc,
+                    &cand.result_type.instantiate(&instantiation),
+                    expected_type,
+                );
+                // Construct result.
+                let id = self.new_node_type_loc(&ty, loc);
+                Exp::Call(id, cand.oper.clone(), args)
+            }
+            _ => {
+                let display = self.display_call_target(module, name);
+                let notes = matching
+                    .iter()
+                    .map(|(cand, _, _)| {
+                        format!(
+                            "matching candidate `{}`",
+                            self.display_call_cand(module, name, cand)
+                        )
+                    })
+                    .collect_vec();
+                self.parent.parent.env.error_with_notes(
+                    loc,
+                    &format!("ambiguous application of `{}`", display),
+                    notes,
+                );
+                self.new_error_exp()
+            }
+        }
+    }
+
+    /// Translate a list of expressions and deliver them together with their types.
+    fn translate_exp_list(&mut self, exps: &[&EA::Exp]) -> (Vec<Type>, Vec<Exp>) {
+        let mut types = vec![];
+        let exps = exps
+            .iter()
+            .map(|e| {
+                let (t, e) = self.translate_exp_free(e);
+                types.push(t);
+                e
+            })
+            .collect_vec();
+        (types, exps)
+    }
+
+    /// Creates a type instantiation based on provided actual type parameters.
+    fn make_instantiation(
+        &mut self,
+        param_count: usize,
+        actuals: Option<Vec<Type>>,
+    ) -> (Vec<Type>, Option<String>) {
+        if let Some(types) = actuals {
+            let n = types.len();
+            if n != param_count {
+                (
+                    types,
+                    Some(format!(
+                        "generic count mismatch (expected {} but found {})",
+                        param_count, n,
+                    )),
+                )
+            } else {
+                (types, None)
+            }
+        } else {
+            // Create fresh type variables.
+            (
+                (0..param_count)
+                    .map(|_| self.fresh_type_var())
+                    .collect_vec(),
+                None,
+            )
+        }
+    }
+
+    fn translate_pack(
+        &mut self,
+        loc: &Loc,
+        maccess: &EA::ModuleAccess,
+        generics: &Option<Vec<EA::SingleType>>,
+        fields: &EA::Fields<EA::Exp>,
+        expected_type: &Type,
+    ) -> Exp {
+        let struct_name = self.parent.module_access_to_qualified(maccess);
+        let struct_name_loc = self.to_loc(&maccess.loc);
+        let generics = if let Some(ts) = generics {
+            Some(self.translate_single_types(&ts))
+        } else {
+            None
+        };
+        if let Some(entry) = self.parent.parent.struct_table.get(&struct_name) {
+            let entry = entry.clone();
+            let (instantiation, diag) = self.make_instantiation(entry.type_params.len(), generics);
+            if let Some(msg) = diag {
+                self.error(loc, &msg);
+                return self.new_error_exp();
+            }
+            if let Some(field_decls) = &entry.fields {
+                let mut fields_not_convered: BTreeSet<Symbol> = BTreeSet::new();
+                fields_not_convered.extend(field_decls.keys());
+                let mut args = BTreeMap::new();
+                for (ref name, (idx, exp)) in fields.iter() {
+                    let field_name = self.symbol_pool().make(&name.0.value);
+                    if let Some(field_ty) = field_decls.get(&field_name) {
+                        let exp = self.translate_exp(exp, &field_ty.instantiate(&instantiation));
+                        fields_not_convered.remove(&field_name);
+                        args.insert(idx, exp);
+                    } else {
+                        self.error(
+                            &self.to_loc(&name.0.loc),
+                            &format!(
+                                "field `{}` not declared in struct `{}`",
+                                field_name.display(self.symbol_pool()),
+                                struct_name.display(self.symbol_pool())
+                            ),
+                        );
+                    }
+                }
+                if !fields_not_convered.is_empty() {
+                    self.error(
+                        loc,
+                        &format!(
+                            "missing fields {}",
+                            fields_not_convered
+                                .iter()
+                                .map(|n| format!("`{}`", n.display(self.symbol_pool())))
+                                .join(", ")
+                        ),
+                    );
+                    self.new_error_exp()
+                } else {
+                    let struct_ty = Type::Struct(entry.module_id, entry.struct_id, instantiation);
+                    let struct_ty = self.check_type(loc, &struct_ty, expected_type);
+                    let args = args
+                        .into_iter()
+                        .sorted_by_key(|(i, _)| *i)
+                        .map(|(_, e)| e)
+                        .collect_vec();
+                    let id = self.new_node_type_loc(&struct_ty, loc);
+                    Exp::Call(id, Operation::Pack(entry.module_id, entry.struct_id), args)
+                }
+            } else {
+                self.error(
+                    &struct_name_loc,
+                    &format!(
+                        "native struct `{}` cannot be packed",
+                        struct_name.display(self.symbol_pool())
+                    ),
+                );
+                self.new_error_exp()
+            }
+        } else {
+            self.error(
+                &struct_name_loc,
+                &format!(
+                    "undeclared struct `{}`",
+                    struct_name.display(self.symbol_pool())
+                ),
+            );
+            self.new_error_exp()
+        }
+    }
+
+    fn translate_lambda(
+        &mut self,
+        loc: &Loc,
+        bindings: &EA::BindList,
+        body: &EA::Exp,
+        expected_type: &Type,
+    ) -> Exp {
+        // Enter the lambda variables into a new local scope and collect their declarations.
+        self.enter_scope();
+        let mut decls = vec![];
+        let mut arg_types = vec![];
+        for bind in &bindings.value {
+            let loc = self.to_loc(&bind.loc);
+            match &bind.value {
+                EA::Bind_::Var(v) => {
+                    let name = self.symbol_pool().make(&v.0.value);
+                    let ty = self.fresh_type_var();
+                    let id = self.new_node_type_loc(&ty, &loc);
+                    self.define_local(&loc, name, ty.clone(), None);
+                    arg_types.push(ty);
+                    decls.push(LocalVarDecl {
+                        id,
+                        name,
+                        binding: None,
+                    });
+                }
+                EA::Bind_::Unpack(..) => {
+                    self.error(&loc, "[current restriction] tuples not supported in lambda")
+                }
+            }
+        }
+        // Translate the body.
+        let ty = self.fresh_type_var();
+        let rbody = self.translate_exp(body, &ty);
+        // Check types and construct result.
+        let rty = self.check_type(loc, &Type::Fun(arg_types, Box::new(ty)), expected_type);
+        let id = self.new_node_type_loc(&rty, loc);
+        Exp::Lambda(id, decls, Box::new(rbody))
+    }
+
+    fn check_type(&mut self, loc: &Loc, ty: &Type, expected: &Type) -> Type {
+        // Because of Rust borrow semantics, we must temporarily detach the substitution from
+        // the translator. This is because we also need to inherently borrow self via the
+        // type_display_context which is passed into unification.
+        let mut subs = std::mem::replace(&mut self.subs, Substitution::new());
+        let result = match subs.unify(&self.type_display_context(), ty, expected) {
+            Ok(t) => t,
+            Err(err) => {
+                self.error(&loc, &err.message);
+                Type::Error
+            }
+        };
+        std::mem::replace(&mut self.subs, subs);
+        result
+    }
+}

--- a/language/move-prover/spec-lang/src/ty.rs
+++ b/language/move-prover/spec-lang/src/ty.rs
@@ -1,0 +1,456 @@
+// Copyright (c) The Libra Core Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+//! Contains types and related functions.
+
+use crate::ast::QualifiedSymbol;
+use crate::env::{ModuleId, StructId};
+use crate::symbol::SymbolPool;
+use std::collections::BTreeMap;
+use std::fmt;
+use std::fmt::Formatter;
+
+/// Represents a type.
+#[derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash, Clone)]
+pub enum Type {
+    Primitive(PrimitiveType),
+    Tuple(Vec<Type>),
+    Vector(Box<Type>),
+    Struct(ModuleId, StructId, Vec<Type>),
+    TypeParameter(u16),
+
+    // Types only appearing in programs.
+    Reference(bool, Box<Type>),
+
+    // Types only appearing in specifications
+    Fun(Vec<Type>, Box<Type>),
+
+    // Temporary types used during type checking
+    Error,
+    Var(u16),
+}
+
+pub const BOOL_TYPE: Type = Type::Primitive(PrimitiveType::Bool);
+
+/// Represents a primitive (builtin) type.
+#[derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash, Clone, Copy)]
+pub enum PrimitiveType {
+    Bool,
+    U8,
+    U64,
+    U128,
+    ByteArray,
+    Address,
+
+    // Types only appearing in specifications
+    Num,
+    Range,
+}
+
+/// A type substitution.
+#[derive(Debug, Clone)]
+pub struct Substitution {
+    subs: BTreeMap<u16, Type>,
+}
+
+/// Represents an type error resulting from unification.
+pub struct TypeError {
+    pub message: String,
+}
+
+impl TypeError {
+    fn new(msg: impl Into<String>) -> Self {
+        TypeError {
+            message: msg.into(),
+        }
+    }
+}
+
+impl Type {
+    pub fn new_prim(p: PrimitiveType) -> Type {
+        Type::Primitive(p)
+    }
+
+    /// Determines whether this is a reference.
+    pub fn is_reference(&self) -> bool {
+        match self {
+            Type::Reference(_, _) => true,
+            _ => false,
+        }
+    }
+
+    /// Determines whether this is a mutual reference.
+    pub fn is_mutual_reference(&self) -> bool {
+        if let Type::Reference(true, _) = self {
+            true
+        } else {
+            false
+        }
+    }
+
+    pub fn is_number(&self) -> bool {
+        if let Type::Primitive(p) = self {
+            if let PrimitiveType::U8
+            | PrimitiveType::U64
+            | PrimitiveType::U128
+            | PrimitiveType::Num = p
+            {
+                return true;
+            }
+        }
+        false
+    }
+
+    pub fn drop_references(&self) -> Type {
+        let mut ty = self.clone();
+        while let Type::Reference(_, bt) = &ty {
+            ty = *bt.clone();
+        }
+        ty
+    }
+
+    /// Instantiates type parameters in this type.
+    pub fn instantiate(&self, params: &[Type]) -> Type {
+        self.replace(Some(params), None)
+    }
+
+    /// A helper function to do replacement of type parameters and/or type variables.
+    fn replace(&self, params: Option<&[Type]>, subs: Option<&Substitution>) -> Type {
+        let replace_vec = |types: &[Type]| types.iter().map(|t| t.replace(params, subs)).collect();
+        match self {
+            Type::TypeParameter(i) => {
+                if let Some(ps) = params {
+                    ps[*i as usize].clone()
+                } else {
+                    self.clone()
+                }
+            }
+            Type::Var(i) => {
+                if let Some(s) = subs {
+                    if let Some(s) = s.subs.get(i) {
+                        // Recursively call replacement again here, in case the substitution s
+                        // refers to type variables.
+                        // TODO: a more efficient approach is to maintain that type assignments
+                        // are always fully specialized w.r.t. to the substitution.
+                        s.replace(params, subs)
+                    } else {
+                        self.clone()
+                    }
+                } else {
+                    self.clone()
+                }
+            }
+            Type::Reference(is_mut, bt) => {
+                Type::Reference(*is_mut, Box::new(bt.replace(params, subs)))
+            }
+            Type::Struct(mid, sid, args) => Type::Struct(*mid, *sid, replace_vec(args)),
+            Type::Fun(args, result) => {
+                Type::Fun(replace_vec(args), Box::new(result.replace(params, subs)))
+            }
+            Type::Tuple(args) => Type::Tuple(replace_vec(args)),
+            Type::Vector(et) => Type::Vector(Box::new(et.replace(params, subs))),
+            _ => self.clone(),
+        }
+    }
+
+    /// Checks whether this type contains a type for which the predicate is true.
+    pub fn contains<P>(&self, p: &P) -> bool
+    where
+        P: Fn(&Type) -> bool,
+    {
+        if p(self) {
+            true
+        } else {
+            let contains_vec = |ts: &[Type]| ts.iter().any(p);
+            match self {
+                Type::Reference(_, bt) => bt.contains(p),
+                Type::Struct(_, _, args) => contains_vec(args),
+                Type::Fun(args, result) => contains_vec(args) || result.contains(p),
+                Type::Tuple(args) => contains_vec(args),
+                Type::Vector(et) => et.contains(p),
+                _ => false,
+            }
+        }
+    }
+
+    /// Returns true if this type is incomplete, i.e. contains any type variables.
+    pub fn is_incomplete(&self) -> bool {
+        use Type::*;
+        match self {
+            Var(_) => true,
+            Tuple(ts) => ts.iter().any(|t| t.is_incomplete()),
+            Fun(ts, r) => ts.iter().any(|t| t.is_incomplete()) || r.is_incomplete(),
+            Struct(_, _, ts) => ts.iter().any(|t| t.is_incomplete()),
+            Vector(et) => et.is_incomplete(),
+            _ => false,
+        }
+    }
+}
+
+impl Substitution {
+    /// Creates a new substitution.
+    pub fn new() -> Self {
+        Self {
+            subs: BTreeMap::new(),
+        }
+    }
+
+    /// Specializes the type, substituting all variables bound in this substitution.
+    pub fn specialize(&self, t: &Type) -> Type {
+        t.replace(None, Some(self))
+    }
+
+    /// Unify two types, returning the unified type.
+    ///
+    /// This currently implements the following notion of type compatibility:
+    ///
+    /// - References are dropped (i.e. &T and T are compatible)
+    /// - All integer types are compatible.
+    ///
+    /// The substitution will be refined by variable assignments as needed to perform
+    /// unification. If unification fails, the substitution will be in some intermediate state;
+    /// to implement transactional unification, the substitution must be cloned before calling
+    /// this.
+    ///
+    /// The passed `display_context` is needed for visualization of types on unification errors.
+    pub fn unify<'a>(
+        &mut self,
+        display_context: &'a TypeDisplayContext<'a>,
+        t1: &Type,
+        t2: &Type,
+    ) -> Result<Type, TypeError> {
+        let t1 = t1.drop_references();
+        let t2 = t2.drop_references();
+
+        // Substitute or assign variables.
+        if let Some(rt) = self.try_substitute_or_assign(display_context, false, &t1, &t2)? {
+            return Ok(rt);
+        }
+        if let Some(rt) = self.try_substitute_or_assign(display_context, true, &t2, &t1)? {
+            return Ok(rt);
+        }
+
+        // Accept any error type.
+        if t1 == Type::Error {
+            return Ok(t2);
+        }
+        if t2 == Type::Error {
+            return Ok(t1);
+        }
+
+        // All number types are currently compatible.
+        if t1.is_number() && t2.is_number() {
+            return Ok(t1);
+        }
+
+        // Unify matching structured types.
+        match (&t1, &t2) {
+            (Type::Primitive(p1), Type::Primitive(p2)) => {
+                if p1 == p2 {
+                    return Ok(t1.clone());
+                }
+            }
+            (Type::TypeParameter(idx1), Type::TypeParameter(idx2)) => {
+                if idx1 == idx2 {
+                    return Ok(t1.clone());
+                }
+            }
+            (Type::Tuple(ts1), Type::Tuple(ts2)) => {
+                return Ok(Type::Tuple(self.unify_vec(
+                    display_context,
+                    ts1,
+                    ts2,
+                    "tuples",
+                )?));
+            }
+            (Type::Fun(ts1, r1), Type::Fun(ts2, r2)) => {
+                return Ok(Type::Fun(
+                    self.unify_vec(display_context, ts1, ts2, "functions")?,
+                    Box::new(self.unify(display_context, &*r1, &*r2)?),
+                ));
+            }
+            (Type::Struct(m1, s1, ts1), Type::Struct(m2, s2, ts2)) => {
+                if m1 == m2 && s1 == s2 {
+                    return Ok(Type::Struct(
+                        *m1,
+                        *s1,
+                        self.unify_vec(display_context, ts1, ts2, "structs")?,
+                    ));
+                }
+            }
+            (Type::Vector(e1), Type::Vector(e2)) => {
+                return self.unify(display_context, &*e1, &*e2);
+            }
+            _ => {}
+        }
+
+        Err(TypeError::new(format!(
+            "expected `{}` but found `{}`",
+            self.specialize(&t2).display(display_context),
+            self.specialize(&t1).display(display_context),
+        )))
+    }
+
+    /// Helper to unify two type vectors.
+    fn unify_vec<'a>(
+        &mut self,
+        display_context: &'a TypeDisplayContext<'a>,
+        ts1: &[Type],
+        ts2: &[Type],
+        item_name: &str,
+    ) -> Result<Vec<Type>, TypeError> {
+        if ts1.len() != ts2.len() {
+            return Err(TypeError::new(format!(
+                "{} have different arity ({} != {})",
+                item_name,
+                ts1.len(),
+                ts2.len()
+            )));
+        }
+        let mut rs = vec![];
+        for i in 0..ts1.len() {
+            rs.push(self.unify(display_context, &ts1[i], &ts2[i])?);
+        }
+        Ok(rs)
+    }
+
+    /// Tries to substitute or assign a variable. Returned option is Some if unification
+    /// was performed, None if not.
+    fn try_substitute_or_assign(
+        &mut self,
+        display_context: &TypeDisplayContext,
+        swapped: bool,
+        t1: &Type,
+        t2: &Type,
+    ) -> Result<Option<Type>, TypeError> {
+        if let Type::Var(v1) = t1 {
+            if let Some(s1) = self.subs.get(&v1).cloned() {
+                if swapped {
+                    // Place the type terms in the right order again, so we
+                    // get the 'expected vs actual' direction right.
+                    return Ok(Some(self.unify(display_context, t2, &s1)?));
+                } else {
+                    return Ok(Some(self.unify(display_context, &s1, t2)?));
+                }
+            }
+            let is_var = |t: &Type| {
+                if let Type::Var(v2) = t {
+                    v1 == v2
+                } else {
+                    false
+                }
+            };
+            if !t2.contains(&is_var) {
+                self.subs.insert(*v1, t2.clone());
+                Ok(Some(t2.clone()))
+            } else {
+                // It is not clear to me whether this can ever occur given we do no global
+                // unification with recursion, but to be on the save side, we have it.
+                Err(TypeError::new(
+                    "[internal] type unification cycle check failed. Try to annotate types.",
+                ))
+            }
+        } else {
+            Ok(None)
+        }
+    }
+}
+
+impl Default for Substitution {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+/// Data providing context for displaying types.
+pub struct TypeDisplayContext<'a> {
+    pub symbol_pool: &'a SymbolPool,
+    pub reverse_struct_table: &'a BTreeMap<(ModuleId, StructId), QualifiedSymbol>,
+}
+
+/// Helper for type displays.
+pub struct TypeDisplay<'a> {
+    type_: &'a Type,
+    context: &'a TypeDisplayContext<'a>,
+}
+
+impl Type {
+    pub fn display<'a>(&'a self, context: &'a TypeDisplayContext<'a>) -> TypeDisplay<'a> {
+        TypeDisplay {
+            type_: self,
+            context,
+        }
+    }
+}
+
+impl<'a> fmt::Display for TypeDisplay<'a> {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        use Type::*;
+        let comma_list = |f: &mut Formatter<'_>, ts: &[Type]| {
+            let mut first = true;
+            for t in ts {
+                if first {
+                    first = false
+                } else {
+                    f.write_str(", ")?;
+                }
+                write!(f, "{}", t.display(self.context))?;
+            }
+            Ok(())
+        };
+        match self.type_ {
+            Primitive(p) => write!(f, "{}", p),
+            Tuple(ts) => {
+                f.write_str("(")?;
+                comma_list(f, ts)?;
+                f.write_str(")")
+            }
+            Vector(t) => write!(f, "vector<{}>", t.display(self.context)),
+            Fun(ts, t) => {
+                f.write_str("|")?;
+                comma_list(f, ts)?;
+                f.write_str("|")?;
+                write!(f, "{}", t.display(self.context))
+            }
+            Struct(mid, sid, ts) => {
+                if let Some(sym) = self.context.reverse_struct_table.get(&(*mid, *sid)) {
+                    write!(f, "{}", sym.display(self.context.symbol_pool))?;
+                } else {
+                    f.write_str("??unknown??")?;
+                }
+                if !ts.is_empty() {
+                    f.write_str("<")?;
+                    comma_list(f, ts)?;
+                    f.write_str(">")?;
+                }
+                Ok(())
+            }
+            Reference(is_mut, t) => {
+                f.write_str("&")?;
+                if *is_mut {
+                    f.write_str("mut ")?;
+                }
+                write!(f, "{}", t.display(self.context))
+            }
+            TypeParameter(idx) => write!(f, "#{}", idx),
+            Var(idx) => write!(f, "?{}", idx),
+            Error => f.write_str("?error"),
+        }
+    }
+}
+
+impl fmt::Display for PrimitiveType {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        use PrimitiveType::*;
+        match self {
+            Bool => f.write_str("bool"),
+            U8 => f.write_str("u8"),
+            U64 => f.write_str("u64"),
+            U128 => f.write_str("u128"),
+            ByteArray => f.write_str("bytearray"),
+            Address => f.write_str("address"),
+            Range => f.write_str("range"),
+            Num => f.write_str("num"),
+        }
+    }
+}

--- a/language/move-prover/spec-lang/tests/sources/conditions_err.exp
+++ b/language/move-prover/spec-lang/tests/sources/conditions_err.exp
@@ -1,0 +1,23 @@
+error: expected `bool` but found `u64`
+
+   ┌── tests/sources/conditions_err.move:7:15 ───
+   │
+ 7 │     aborts_if x;
+   │               ^
+   │
+
+error: expected `bool` but found `num`
+
+   ┌── tests/sources/conditions_err.move:8:13 ───
+   │
+ 8 │     ensures old(x) + x;
+   │             ^^^^^^^^^^
+   │
+
+error: undeclared `result_1`
+
+    ┌── tests/sources/conditions_err.move:10:13 ───
+    │
+ 10 │     ensures result_1 == 0;
+    │             ^^^^^^^^
+    │

--- a/language/move-prover/spec-lang/tests/sources/conditions_err.move
+++ b/language/move-prover/spec-lang/tests/sources/conditions_err.move
@@ -1,0 +1,12 @@
+module M {
+
+  fun add_some(x: &mut u64): u64 { *x = *x + 1; *x }
+
+  spec fun add_some {
+    // Type of condition not bool.
+    aborts_if x;
+    ensures old(x) + x;
+    // Using result which does not exist.
+    ensures result_1 == 0;
+  }
+}

--- a/language/move-prover/spec-lang/tests/sources/conditions_ok.exp
+++ b/language/move-prover/spec-lang/tests/sources/conditions_ok.exp
@@ -1,0 +1,1 @@
+All good, no errors!

--- a/language/move-prover/spec-lang/tests/sources/conditions_ok.move
+++ b/language/move-prover/spec-lang/tests/sources/conditions_ok.move
@@ -1,0 +1,18 @@
+module M {
+
+  fun add_some(x: &mut u64): u64 { *x = *x + 1; *x }
+
+  spec fun add_some {
+    global some_global: u64;
+    aborts_if x == 0 || some_global == 0;
+    ensures old(x) > x;
+    ensures result == x;
+  }
+
+  fun multiple_results(x: u64): (u64, bool) { (x, true) }
+
+  spec fun multiple_results {
+    ensures x == result_1 && result_2 == true;
+  }
+
+}

--- a/language/move-prover/spec-lang/tests/sources/expressions_err.exp
+++ b/language/move-prover/spec-lang/tests/sources/expressions_err.exp
@@ -1,0 +1,77 @@
+error: undeclared `x`
+
+    ┌── tests/sources/expressions_err.move:12:7 ───
+    │
+ 12 │       x
+    │       ^
+    │
+
+error: no function named `not_declared` found
+
+    ┌── tests/sources/expressions_err.move:17:7 ───
+    │
+ 17 │       not_declared()
+    │       ^^^^^^^^^^^^^^
+    │
+
+error: expected `num` but found `bool`
+
+    ┌── tests/sources/expressions_err.move:22:7 ───
+    │
+ 22 │       false
+    │       ^^^^^
+    │
+
+error: no matching declaration of `>`
+
+    ┌── tests/sources/expressions_err.move:27:7 ───
+    │
+ 27 │       x > y
+    │       ^^^^^
+    │
+    = outruled candidate `>(num, num): bool` (expected `num` but found `vector<num>` for argument 1)
+
+error: expected `(num, bool)` but found `bool`
+
+    ┌── tests/sources/expressions_err.move:32:7 ───
+    │
+ 32 │       false
+    │       ^^^^^
+    │
+
+error: no matching declaration of `wrongly_typed_callee`
+
+    ┌── tests/sources/expressions_err.move:37:42 ───
+    │
+ 37 │     define wrongly_typed_caller(): num { wrongly_typed_callee(1, 1) }
+    │                                          ^^^^^^^^^^^^^^^^^^^^^^^^^^
+    │
+    = outruled candidate `wrongly_typed_callee(num, bool): num` (expected `bool` but found `u128` for argument 2)
+
+error: no matching declaration of `wrongly_typed_fun_arg_callee`
+
+    ┌── tests/sources/expressions_err.move:41:50 ───
+    │
+ 41 │     define wrongly_typed_fun_arg_caller(): num { wrongly_typed_fun_arg_callee(|x| false) }
+    │                                                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    │
+    = outruled candidate `wrongly_typed_fun_arg_callee(|num|num): num` (expected `num` but found `bool` for argument 1)
+
+error: ambiguous application of `ambigous_callee`
+
+    ┌── tests/sources/expressions_err.move:48:7 ───
+    │
+ 48 │       ambigous_callee()
+    │       ^^^^^^^^^^^^^^^^^
+    │
+    = matching candidate `ambigous_callee(): num`
+    = matching candidate `ambigous_callee(): num`
+
+error: no matching declaration of `wrong_instantiation`
+
+    ┌── tests/sources/expressions_err.move:54:7 ───
+    │
+ 54 │       wrong_instantiation<u64>(x)
+    │       ^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    │
+    = outruled candidate `wrong_instantiation(#0): #0` (generic count mismatch (expected 2 but found 1))

--- a/language/move-prover/spec-lang/tests/sources/expressions_err.move
+++ b/language/move-prover/spec-lang/tests/sources/expressions_err.move
@@ -1,0 +1,57 @@
+module M {
+
+  struct S {
+    x: u64,
+    y: bool,
+  }
+
+  spec module {
+
+    // Undeclared simple name.
+    define undeclared_name() : num {
+      x
+    }
+
+    // Undeclared spec function.
+    define undeclared_fun(): num {
+      not_declared()
+    }
+
+    // Wrong result type.
+    define wrong_result_type(): num {
+      false
+    }
+
+    // No matching overload.
+    define no_overload(x: vector<num>, y: vector<num>): bool {
+      x > y
+    }
+
+    // Wrong result type tuple.
+    define wrong_result_type(): (num, bool) {
+      false
+    }
+
+    // Wrongly typed function application.
+    define wrongly_typed_callee(x: num, y: bool): num { x }
+    define wrongly_typed_caller(): num { wrongly_typed_callee(1, 1) }
+
+    // Wrongly typed function argument.
+    define wrongly_typed_fun_arg_callee(f: |num|num): num { 0 }
+    define wrongly_typed_fun_arg_caller(): num { wrongly_typed_fun_arg_callee(|x| false) }
+
+    // Ambiguous application
+    // TODO: we actually want to see the error at the declaration, but currently we see it at the call.
+    define ambigous_callee(): num { 0 }
+    define ambigous_callee(): num { 0 }
+    define amdbigous_caller(): num {
+      ambigous_callee()
+    }
+
+    // Wrong instantiation
+    define wrong_instantiation<T1, T2>(x: T1): T1 { x }
+    define wrong_instantiation_caller(x: u64): u64 {
+      wrong_instantiation<u64>(x)
+    }
+  }
+}

--- a/language/move-prover/spec-lang/tests/sources/expressions_inference_err.exp
+++ b/language/move-prover/spec-lang/tests/sources/expressions_inference_err.exp
@@ -1,0 +1,31 @@
+error: unable to infer type: `?2`
+
+   ┌── tests/sources/expressions_inference_err.move:7:16 ───
+   │
+ 7 │       let f = |x|x;
+   │                ^
+   │
+
+error: unable to infer type: `?2`
+
+   ┌── tests/sources/expressions_inference_err.move:7:18 ───
+   │
+ 7 │       let f = |x|x;
+   │                  ^
+   │
+
+error: unable to infer type: `|?2|?2`
+
+   ┌── tests/sources/expressions_inference_err.move:7:15 ───
+   │
+ 7 │       let f = |x|x;
+   │               ^^^^
+   │
+
+error: unable to infer type: `|?2|?2`
+
+   ┌── tests/sources/expressions_inference_err.move:7:11 ───
+   │
+ 7 │       let f = |x|x;
+   │           ^
+   │

--- a/language/move-prover/spec-lang/tests/sources/expressions_inference_err.move
+++ b/language/move-prover/spec-lang/tests/sources/expressions_inference_err.move
@@ -1,0 +1,11 @@
+// Inference errors may only be reported if all else succeeds, so we put them in a different file.
+
+module M {
+  spec module {
+    // Incomplete types.
+    define incomplete_types(): u64 {
+      let f = |x|x;
+      0
+    }
+  }
+}

--- a/language/move-prover/spec-lang/tests/sources/expressions_ok.exp
+++ b/language/move-prover/spec-lang/tests/sources/expressions_ok.exp
@@ -1,0 +1,1 @@
+All good, no errors!

--- a/language/move-prover/spec-lang/tests/sources/expressions_ok.move
+++ b/language/move-prover/spec-lang/tests/sources/expressions_ok.move
@@ -1,0 +1,79 @@
+module M {
+
+  spec module {
+
+    define add1(x: num): num { x + 1 }
+
+    define call_other(x: num): num {
+      add1(x)
+    }
+
+    define call_other_self(x: num): num {
+      Self::add1(x)
+    }
+
+    define add_any_unsigned(x: u64, y: u8): num {
+      x + y
+    }
+
+    define compare_any_unsigned(x: u64, y: u128, z: num): bool {
+      x == y && y == z ==> x == z
+    }
+
+    define some_range(upper: num): range {
+      0..upper
+    }
+
+    define add_with_let(x: num, y: num): num {
+      let r = x + y;
+      r
+    }
+
+    define let_shadows(): num {
+      let x = true;
+      let b = !x;
+      let x = 1;
+      x
+    }
+
+    define lambdas(p1: |num|bool, p2: |num|bool): |num|bool {
+      |x| p1(x) && p2(x)
+    }
+
+    define call_lambdas(x: num): bool {
+      let f = lambdas(|x| x > 0, |x| x < 10);
+      f(x)
+    }
+
+    define if_else(x: num, y: num): num {
+      if (x > 0) { x } else { y }
+    }
+
+    define vector_builtins(v: vector<num>): bool {
+      len(v) > 2 && all(v, |x| x > 0) && any(v, |x| x > 10) && update(v, 2, 23)[2] == 23
+    }
+
+    define range_builtins(v: vector<num>): bool {
+      all(1..10, |x| x > 0) && any(5..10, |x| x > 7)
+    }
+
+    define vector_index(v: vector<num>): num {
+      v[2]
+    }
+
+    define vector_slice(v: vector<num>): vector<num> {
+      v[2..3]
+    }
+
+    define generic_function<T>(x: T, y: T): bool {
+      x == y
+    }
+    define generic_function_call(): bool {
+      generic_function(1, 2)
+    }
+    define generic_function_instantiated_call(): bool {
+      generic_function<num>(3, 3)
+    }
+
+  }
+}

--- a/language/move-prover/spec-lang/tests/sources/invariants_err.exp
+++ b/language/move-prover/spec-lang/tests/sources/invariants_err.exp
@@ -1,0 +1,23 @@
+error: expected `bool` but found `num`
+
+   ┌── tests/sources/invariants_err.move:9:15 ───
+   │
+ 9 │     invariant x + 1;
+   │               ^^^^^
+   │
+
+error: `old(..)` expression not allowed in this context
+
+    ┌── tests/sources/invariants_err.move:11:15 ───
+    │
+ 11 │     invariant old(x) > 0;
+    │               ^^^^^^
+    │
+
+error: `old(..old(..)..)` not allowed
+
+    ┌── tests/sources/invariants_err.move:13:26 ───
+    │
+ 13 │     invariant update old(old(x)) > 0;
+    │                          ^^^^^^
+    │

--- a/language/move-prover/spec-lang/tests/sources/invariants_err.move
+++ b/language/move-prover/spec-lang/tests/sources/invariants_err.move
@@ -1,0 +1,15 @@
+module M {
+
+  struct S {
+    x: u64,
+  }
+
+  spec struct S {
+    // Expression not a bool
+    invariant x + 1;
+    // Old expression in data invariant
+    invariant old(x) > 0;
+    // Nested old expression.
+    invariant update old(old(x)) > 0;
+  }
+}

--- a/language/move-prover/spec-lang/tests/sources/invariants_ok.exp
+++ b/language/move-prover/spec-lang/tests/sources/invariants_ok.exp
@@ -1,0 +1,1 @@
+All good, no errors!

--- a/language/move-prover/spec-lang/tests/sources/invariants_ok.move
+++ b/language/move-prover/spec-lang/tests/sources/invariants_ok.move
@@ -1,0 +1,20 @@
+module M {
+
+  struct S {
+    x: u64,
+    y: bool
+  }
+
+  struct R {
+    s: S,
+  }
+
+  spec struct S {
+    invariant x > 0 == y;
+    invariant update old(x) < x;
+  }
+
+  spec struct R {
+    invariant s.x < 10;
+  }
+}

--- a/language/move-prover/spec-lang/tests/sources/structs_err.exp
+++ b/language/move-prover/spec-lang/tests/sources/structs_err.exp
@@ -1,0 +1,47 @@
+error: field `xx` not declared in struct `M::S`
+
+    ┌── tests/sources/structs_err.move:26:7 ───
+    │
+ 26 │       s.xx
+    │       ^^^^
+    │
+
+error: expected `bool` but found `u64`
+
+    ┌── tests/sources/structs_err.move:31:7 ───
+    │
+ 31 │       s.x
+    │       ^^^
+    │
+
+error: expected `bool` but found `u64`
+
+    ┌── tests/sources/structs_err.move:36:18 ───
+    │
+ 36 │       S{x: x, y: y, z: z}
+    │                  ^
+    │
+
+error: missing fields `y`, `z`
+
+    ┌── tests/sources/structs_err.move:40:7 ───
+    │
+ 40 │       S{x: x}
+    │       ^^^^^^^
+    │
+
+error: expected `bool` but found `u64`
+
+    ┌── tests/sources/structs_err.move:45:7 ───
+    │
+ 45 │       G{x: x, y: y}
+    │       ^^^^^^^^^^^^^
+    │
+
+error: generic count mismatch (expected 1 but found 2)
+
+    ┌── tests/sources/structs_err.move:50:7 ───
+    │
+ 50 │       G<u64, bool>{x: x, y: y}
+    │       ^^^^^^^^^^^^^^^^^^^^^^^^
+    │

--- a/language/move-prover/spec-lang/tests/sources/structs_err.move
+++ b/language/move-prover/spec-lang/tests/sources/structs_err.move
@@ -1,0 +1,53 @@
+module M {
+
+  struct S {
+    x: u64,
+    y: bool,
+    z: vector<u64>,
+  }
+
+  struct R {
+    s: S
+  }
+
+  struct G<T> {
+    x: T,
+    y: bool,
+  }
+
+  resource struct T {
+    x: u64
+  }
+
+  spec module {
+
+    // Field undeclared
+    define field_undeclared(s: S): u64 {
+      s.xx
+    }
+
+    // Field wrongly typed
+    define field_wrongly_typed(s: S): bool {
+      s.x
+    }
+
+    // Pack wrongly typed
+    define pack_wrongly_typed(x: u64, y: u64, z: vector<u64>): S {
+      S{x: x, y: y, z: z}
+    }
+
+    define pack_misses_fields(x: u64): S {
+      S{x: x}
+    }
+
+    // Generic pack wrongly typed
+    define generic_pack_wrongly_typed(x: u64, y: bool): G<bool> {
+      G{x: x, y: y}
+    }
+
+    // Wrong number of generics
+    define wrong_number_generics(x: u64, y: bool): G<u64> {
+      G<u64, bool>{x: x, y: y}
+    }
+  }
+}

--- a/language/move-prover/spec-lang/tests/sources/structs_ok.exp
+++ b/language/move-prover/spec-lang/tests/sources/structs_ok.exp
@@ -1,0 +1,1 @@
+All good, no errors!

--- a/language/move-prover/spec-lang/tests/sources/structs_ok.move
+++ b/language/move-prover/spec-lang/tests/sources/structs_ok.move
@@ -1,0 +1,53 @@
+module M {
+
+  struct S {
+    x: u64,
+    y: bool,
+    z: vector<u64>,
+  }
+
+  struct R {
+    s: S
+  }
+
+  struct G<T> {
+    x: T,
+    y: bool,
+  }
+
+  resource struct T {
+    x: u64
+  }
+
+  spec module {
+
+    define struct_access(s: S): u64 {
+      s.x
+    }
+
+    define nested_struct_access(r: R): bool {
+      r.s.y
+    }
+
+    define struct_pack(x: u64, y: bool, z: vector<u64>): S {
+      S{x: x, y: y, z: z}
+    }
+
+    define generic_struct_pack(x: u64, y: bool): G<u64> {
+      G{x: x, y: y}
+    }
+
+    define generic_struct_pack_instantiated(x: u64, y: bool): G<u64> {
+      G<u64>{x: x, y: y}
+    }
+
+    define resource_global(addr: address): T {
+      global<T>(addr)
+    }
+
+    define resource_global_exists(addr: address): bool {
+      exists<T>(addr)
+    }
+
+  }
+}

--- a/language/move-prover/spec-lang/tests/sources/variables_err.exp
+++ b/language/move-prover/spec-lang/tests/sources/variables_err.exp
@@ -1,0 +1,39 @@
+error: spec global `M::ticks` undeclared
+
+    ┌── tests/sources/variables_err.move:11:22 ───
+    │
+ 11 │     invariant update ticks = tick + 1;
+    │                      ^^^^^
+    │
+
+error: expected `num` but found `bool`
+
+    ┌── tests/sources/variables_err.move:14:29 ───
+    │
+ 14 │     invariant update tick = false;
+    │                             ^^^^^
+    │
+
+error: assignment to spec globals not allowed for data invariants
+
+    ┌── tests/sources/variables_err.move:17:5 ───
+    │
+ 17 │     invariant tick = x;
+    │     ^^^^^^^^^^^^^^^^^^^
+    │
+
+error: pack/unpack invariants must be assignments to spec globals
+
+    ┌── tests/sources/variables_err.move:20:5 ───
+    │
+ 20 │     invariant pack x == 0;
+    │     ^^^^^^^^^^^^^^^^^^^^^^
+    │
+
+error: pack/unpack invariants must be assignments to spec globals
+
+    ┌── tests/sources/variables_err.move:21:5 ───
+    │
+ 21 │     invariant unpack x == 0;
+    │     ^^^^^^^^^^^^^^^^^^^^^^^^
+    │

--- a/language/move-prover/spec-lang/tests/sources/variables_err.move
+++ b/language/move-prover/spec-lang/tests/sources/variables_err.move
@@ -1,0 +1,23 @@
+module M {
+
+  struct S {
+    x: u64,
+  }
+
+  spec struct S {
+    global tick: num;
+
+    // Undeclared
+    invariant update ticks = tick + 1;
+
+    // Wrong type
+    invariant update tick = false;
+
+    // Cannot have assignment
+    invariant tick = x;
+
+    // Must have assignment
+    invariant pack x == 0;
+    invariant unpack x == 0;
+  }
+}

--- a/language/move-prover/spec-lang/tests/sources/variables_ok.exp
+++ b/language/move-prover/spec-lang/tests/sources/variables_ok.exp
@@ -1,0 +1,1 @@
+All good, no errors!

--- a/language/move-prover/spec-lang/tests/sources/variables_ok.move
+++ b/language/move-prover/spec-lang/tests/sources/variables_ok.move
@@ -1,0 +1,13 @@
+module M {
+
+  struct S {
+    x: u64,
+  }
+
+  spec struct S {
+    global sum: num;
+    invariant update sum = sum - old(x) + x;
+    invariant pack sum = sum + x;
+    invariant unpack sum = sum - x;
+  }
+}

--- a/language/move-prover/spec-lang/tests/testsuite.rs
+++ b/language/move-prover/spec-lang/tests/testsuite.rs
@@ -1,0 +1,30 @@
+// Copyright (c) The Libra Core Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+use std::path::Path;
+
+use codespan_reporting::term::termcolor::Buffer;
+
+use spec_lang::run_spec_lang_compiler;
+use test_utils::baseline_test::verify_or_update_baseline;
+use test_utils::DEFAULT_SENDER;
+
+fn test_runner(path: &Path) -> datatest_stable::Result<()> {
+    let targets = vec![path.to_str().unwrap().to_string()];
+    let deps = vec![];
+    let address_opt = Some(DEFAULT_SENDER);
+
+    let env = run_spec_lang_compiler(targets, deps, address_opt)?;
+    let diags = if env.has_errors() {
+        let mut writer = Buffer::no_color();
+        env.report_errors(&mut writer);
+        String::from_utf8_lossy(&writer.into_inner()).to_string()
+    } else {
+        "All good, no errors!".to_string()
+    };
+    let baseline_path = path.with_extension("exp");
+    verify_or_update_baseline(baseline_path.as_path(), &diags)?;
+    Ok(())
+}
+
+datatest_stable::harness!(test_runner, "tests/sources", r".*\.move");

--- a/language/move-prover/test-utils/Cargo.toml
+++ b/language/move-prover/test-utils/Cargo.toml
@@ -1,0 +1,10 @@
+[package]
+name = "test-utils"
+version = "0.1.0"
+authors = ["Libra <oncall+libra@xmail.facebook.com>"]
+edition = "2018"
+
+[dependencies]
+prettydiff = "0.3.1"
+itertools = "0.8.0"
+anyhow = "1.0.*"

--- a/language/move-prover/test-utils/src/baseline_test.rs
+++ b/language/move-prover/test-utils/src/baseline_test.rs
@@ -1,0 +1,93 @@
+// Copyright (c) The Libra Core Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+//! A module supporting baseline (golden) tests.
+
+use crate::read_bool_env_var;
+use anyhow::{anyhow, Context, Result};
+use prettydiff::basic::DiffOp;
+use prettydiff::diff_lines;
+use std::fs::File;
+use std::io::{Read, Write};
+use std::path::Path;
+
+/// Verifies or updates baseline file for the given generated text.
+pub fn verify_or_update_baseline(baseline_file_name: &Path, text: &str) -> Result<()> {
+    let update_baseline = read_bool_env_var("UPBL");
+
+    if update_baseline {
+        // Just update the baseline file.
+        let mut file = File::create(baseline_file_name)?;
+        write!(file, "{}", clean_for_baseline(text))?;
+        Ok(())
+    } else {
+        // Read the baseline and diff it.
+        let mut contents = String::new();
+        let mut file = File::open(baseline_file_name)
+            .with_context(||
+                format!("Cannot read baseline file at `{}`. To create a new baseline, call this test with env var UPBL=1.", baseline_file_name.to_string_lossy()))?;
+        file.read_to_string(&mut contents)?;
+        diff(text, &contents)
+    }
+}
+
+/// Clean a content to be usable as a baseline file. Currently, we ensure there are no
+/// trailing whitespaces and no empty last line, because this is required by git-checks.sh.
+fn clean_for_baseline(content: &str) -> String {
+    let mut res = String::new();
+    for line in content.lines() {
+        res.push_str(line.trim_end());
+        res.push_str("\n");
+    }
+    res = res.trim_end().to_string(); // removes empty lines at end
+    res.push_str("\n"); // adds back a single newline
+    res
+}
+
+/// Diffs old and new content.
+fn diff(old_content: &str, new_content: &str) -> Result<()> {
+    if old_content.trim() == new_content.trim() {
+        return Ok(());
+    }
+
+    let print_lines = |result: &mut Vec<String>, lines: &[&str], prefix: &str| {
+        for line in lines {
+            result.push(format!("{}{}", prefix, line));
+        }
+    };
+
+    let print_context = |result: &mut Vec<String>, lines: &[&str]| {
+        if lines.len() <= 3 {
+            print_lines(result, lines, "= ");
+        } else {
+            print_lines(result, &lines[..1], "= ");
+            result.push(format!("= ... ({} lines)", lines.len() - 2));
+            print_lines(result, &lines[lines.len() - 1..], "= ");
+        }
+    };
+
+    let diff = diff_lines(&new_content, &old_content);
+    let mut result = vec![];
+    result.push(
+        "
+New output differs from baseline!
+Call this test with env variable UPBL=1 to regenerate baseline files.
+Then use your favorite changelist diff tool to verify you are good with the changes.
+
+Or check the rudimentary diff below:
+"
+        .to_string(),
+    );
+    for d in diff.diff() {
+        match d {
+            DiffOp::Equal(lines) => print_context(&mut result, lines),
+            DiffOp::Insert(lines) => print_lines(&mut result, lines, "+ "),
+            DiffOp::Remove(lines) => print_lines(&mut result, lines, "- "),
+            DiffOp::Replace(old, new) => {
+                print_lines(&mut result, old, "- ");
+                print_lines(&mut result, new, "+ ");
+            }
+        }
+    }
+    Err(anyhow!(result.join("\n")))
+}

--- a/language/move-prover/test-utils/src/lib.rs
+++ b/language/move-prover/test-utils/src/lib.rs
@@ -1,0 +1,21 @@
+// Copyright (c) The Libra Core Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+pub mod baseline_test;
+
+// =================================================================================================
+// Constants
+
+pub const DEFAULT_SENDER: &str = "0x8675309";
+
+// =================================================================================================
+// Env vars
+
+pub fn read_env_var(v: &str) -> String {
+    std::env::var(v).unwrap_or_else(|_| "".into())
+}
+
+pub fn read_bool_env_var(v: &str) -> bool {
+    let val = read_env_var(v);
+    val == "1" || val == "true"
+}


### PR DESCRIPTION
This implements type checking of specifications as they come out of the move compilers expansion phase. The expansion AST is translated into a new AST and integrated into the prover's environment abstraction.

The checker and AST is in a new crate `move-prover/spec-lang`. The `env.rs` from bytecode-to-boogie has been copied and adapted for the new design (unfortunately, we can't see the diff). Test infra for golden (baseline) tests has also been copied and put into a new create `move-prover/test-utils`.

The type checker implements type inference and is fairly complete (no known feature gaps). It uses a unified approach to binary and unary operators and specification function resolution. Tests are in `spec-lang/tests/sources` and are likely the best starting point to read this PR.

This PR doesn't finalize the ingestion of the checked and translated ast into the prover environment, but uses the environment only as far as needed for the type checking problem. A subsequent PR will deal with this problem, as well as adapting the new environment and ast for translation to Boogie.

## Motivation

Integrate specifications into Move Lang.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

Added new tests

## Related PRs

NA
