### PR TITLE
[mempool] support flexible txn broadcast scheduling

### DIFF
--- a/config/src/config/upstream_config.rs
+++ b/config/src/config/upstream_config.rs
@@ -24,16 +24,12 @@ pub struct UpstreamConfig {
 
 impl UpstreamConfig {
     /// Determines whether a node `peer_id` in network `network_id` is an upstream peer of a node with this NodeConfig.
-    pub fn is_upstream_peer(&self, network_id: NetworkId, peer_id: PeerId) -> bool {
-        self.is_primary_upstream_peer(network_id, peer_id)
-            || self.fallback_networks.contains(&network_id)
+    pub fn is_upstream_peer(&self, peer: PeerNetworkId) -> bool {
+        self.is_primary_upstream_peer(peer) || self.fallback_networks.contains(&peer.network_id())
     }
 
-    pub fn is_primary_upstream_peer(&self, network_id: NetworkId, peer_id: PeerId) -> bool {
-        self.primary_networks.contains(&network_id)
-            || self
-                .upstream_peers
-                .contains(&PeerNetworkId(network_id, peer_id))
+    pub fn is_primary_upstream_peer(&self, peer: PeerNetworkId) -> bool {
+        self.primary_networks.contains(&peer.network_id()) || self.upstream_peers.contains(&peer)
     }
 }
 

--- a/mempool/src/shared_mempool/coordinator.rs
+++ b/mempool/src/shared_mempool/coordinator.rs
@@ -9,7 +9,10 @@ use crate::{
     network::{MempoolNetworkEvents, MempoolSyncMsg},
     shared_mempool::{
         tasks,
-        types::{notify_subscribers, IntervalStream, SharedMempool, SharedMempoolNotification},
+        types::{
+            notify_subscribers, IntervalStream, ScheduledBroadcast, SharedMempool,
+            SharedMempoolNotification,
+        },
     },
     CommitNotification, ConsensusRequest, SubmissionStatus,
 };
@@ -20,53 +23,80 @@ use channel::libra_channel;
 use debug_interface::prelude::*;
 use futures::{
     channel::{mpsc, oneshot},
-    stream::select_all,
+    stream::{select_all, FuturesUnordered},
     StreamExt,
 };
-use libra_config::config::{NodeConfig, PeerNetworkId};
+use libra_config::config::{NetworkId, NodeConfig, PeerNetworkId};
 use libra_logger::prelude::*;
 use libra_security_logger::{security_log, SecurityEvent};
-use libra_types::{on_chain_config::OnChainConfigPayload, transaction::SignedTransaction, PeerId};
+use libra_types::{on_chain_config::OnChainConfigPayload, transaction::SignedTransaction};
 use std::{
     ops::Deref,
     sync::{Arc, Mutex},
-    time::Duration,
+    time::{Duration, Instant},
 };
 use tokio::{runtime::Handle, time::interval};
 use vm_validator::vm_validator::TransactionValidation;
 
 /// Coordinator that handles [`SyncEvent`], which is periodically emitted for us to
 /// broadcast ready to go transactions to peers.
-pub(crate) async fn broadcast_coordinator<V>(smp: SharedMempool<V>, mut interval: IntervalStream)
-where
+pub(crate) async fn broadcast_coordinator<V>(
+    smp: SharedMempool<V>,
+    mut schedule_broadcast_rx: libra_channel::Receiver<PeerNetworkId, PeerNetworkId>,
+    executor: Handle,
+    // A stream that controls the broadcast loop. If provided, a single broadcast will happen when one event is emitted
+    // by `broadcast_ticker`. Should only be used for testing purposes to coordinate broadcast events
+    mut broadcast_ticker: Option<IntervalStream>,
+) where
     V: TransactionValidation,
 {
     let peer_manager = smp.peer_manager;
     let mempool = smp.mempool;
-    let network_senders = smp.network_senders;
+    let mut network_senders = smp.network_senders;
     let batch_size = smp.config.shared_mempool_batch_size;
-    let subscribers = smp.subscribers;
+    let mut scheduled_broadcasts = FuturesUnordered::new();
+    let interval_ms = smp.config.shared_mempool_tick_interval_ms;
 
-    while let Some(sync_event) = interval.next().await {
-        trace!("SyncEvent: {:?}", sync_event);
-        tasks::sync_with_peers(
-            peer_manager.clone(),
-            &mempool,
-            network_senders.clone(),
-            batch_size,
-        )
-        .await;
-        notify_subscribers(SharedMempoolNotification::Sync, &subscribers);
+    loop {
+        tick(&mut broadcast_ticker).await;
+
+        ::futures::select! {
+            new_peer = schedule_broadcast_rx.select_next_some() => {
+                tasks::broadcast_single_peer(new_peer, &peer_manager, &mempool, &mut network_senders, batch_size);
+                schedule_next_broadcast(new_peer, &mut scheduled_broadcasts, interval_ms, executor.clone());
+            }
+            peer = scheduled_broadcasts.select_next_some() => {
+                tasks::broadcast_single_peer(peer, &peer_manager, &mempool, &mut network_senders, batch_size);
+                schedule_next_broadcast(peer, &mut scheduled_broadcasts, interval_ms, executor.clone());
+            }
+        }
     }
+}
 
-    crit!("SharedMempool outbound_sync_task terminated");
+async fn tick(broadcast_ticker: &mut Option<IntervalStream>) {
+    if let Some(ref mut ticker) = broadcast_ticker {
+        while let None = ticker.next().await {}
+    }
+}
+
+fn schedule_next_broadcast(
+    peer: PeerNetworkId,
+    scheduled_broadcasts: &mut FuturesUnordered<ScheduledBroadcast>,
+    interval_ms: u64,
+    executor: Handle,
+) {
+    scheduled_broadcasts.push(ScheduledBroadcast::new(
+        Instant::now() + Duration::from_millis(interval_ms),
+        peer,
+        executor,
+    ))
 }
 
 /// Coordinator that handles inbound network events.
 pub(crate) async fn request_coordinator<V>(
     smp: SharedMempool<V>,
     executor: Handle,
-    network_events: Vec<(PeerId, MempoolNetworkEvents)>,
+    network_events: Vec<(NetworkId, MempoolNetworkEvents)>,
     mut client_events: mpsc::Receiver<(
         SignedTransaction,
         oneshot::Sender<Result<SubmissionStatus>>,
@@ -74,6 +104,7 @@ pub(crate) async fn request_coordinator<V>(
     mut consensus_requests: mpsc::Receiver<ConsensusRequest>,
     mut state_sync_requests: mpsc::Receiver<CommitNotification>,
     mut mempool_reconfig_events: libra_channel::Receiver<(), OnChainConfigPayload>,
+    mut schedule_broadcast_tx: libra_channel::Sender<PeerNetworkId, PeerNetworkId>,
     node_config: NodeConfig,
 ) where
     V: TransactionValidation,
@@ -123,7 +154,14 @@ pub(crate) async fn request_coordinator<V>(
                                 counters::SHARED_MEMPOOL_EVENTS
                                     .with_label_values(&["new_peer".to_string().deref()])
                                     .inc();
-                                peer_manager.add_peer(PeerNetworkId(network_id, peer_id));
+                                let peer = PeerNetworkId(network_id, peer_id);
+                                let is_new_peer = peer_manager.add_peer(peer);
+                                if is_new_peer && peer_manager.is_upstream_peer(peer) {
+                                    // schedule broadcast
+                                    if let Err(e) = schedule_broadcast_tx.push(peer, peer) {
+                                        error!("failed to schedule broadcast for new peer: {}", e);
+                                    }
+                                }
                                 notify_subscribers(SharedMempoolNotification::PeerStateChange, &subscribers);
                             }
                             Event::LostPeer(peer_id) => {
@@ -144,7 +182,9 @@ pub(crate) async fn request_coordinator<V>(
                                             .inc_by(transactions.len() as i64);
                                         let smp_clone = smp.clone();
                                         let peer = PeerNetworkId(network_id, peer_id);
-                                        let timeline_state = match peer_manager.is_upstream_peer(peer) {
+                                        let timeline_state = match peer_manager
+                                            .is_upstream_peer(peer)
+                                        {
                                             true => TimelineState::NonQualified,
                                             false => TimelineState::NotReady,
                                         };

--- a/mempool/src/shared_mempool/peer_manager.rs
+++ b/mempool/src/shared_mempool/peer_manager.rs
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use libra_config::config::{PeerNetworkId, UpstreamConfig};
-use rand::seq::IteratorRandom;
 use std::{collections::HashMap, sync::Mutex};
 
 /// stores only peers that receive txns from this node
@@ -11,7 +10,6 @@ pub(crate) type PeerInfo = HashMap<PeerNetworkId, PeerSyncState>;
 /// state of last sync with peer
 /// `timeline_id` is position in log of ready transactions
 /// `is_alive` - is connection healthy
-/// `network_id` - ID of the mempool network that this peer belongs to
 #[derive(Clone)]
 pub(crate) struct PeerSyncState {
     pub timeline_id: u64,
@@ -26,19 +24,22 @@ pub(crate) struct PeerManager {
 
 impl PeerManager {
     pub fn new(upstream_config: UpstreamConfig, min_broadcast_recipient_count: usize) -> Self {
-        let peer_info = Mutex::new(PeerInfo::new());
         Self {
             upstream_config,
-            peer_info,
+            peer_info: Mutex::new(PeerInfo::new()),
             min_broadcast_recipient_count,
         }
     }
 
-    pub fn add_peer(&self, peer: PeerNetworkId) {
+    // returns true if `peer` is discovered for first time, else false
+    pub fn add_peer(&self, peer: PeerNetworkId) -> bool {
+        let mut peer_info = self
+            .peer_info
+            .lock()
+            .expect("failed to acquire peer_info lock");
+        let is_new_peer = !peer_info.contains_key(&peer);
         if self.is_upstream_peer(peer) {
-            self.peer_info
-                .lock()
-                .expect("failed to acquire peer info lock")
+            peer_info
                 .entry(peer)
                 .or_insert(PeerSyncState {
                     timeline_id: 0,
@@ -46,70 +47,66 @@ impl PeerManager {
                 })
                 .is_alive = true;
         }
+        is_new_peer
     }
 
     pub fn disable_peer(&self, peer: PeerNetworkId) {
         if let Some(state) = self
             .peer_info
             .lock()
-            .expect("failed to acquire peer info lock")
+            .expect("failed to get peer info lock")
             .get_mut(&peer)
         {
             state.is_alive = false;
         }
     }
 
-    // pick_peers
-    // picks peers to broadcast to. Will first try to pick *all* preferred peers (= upstream as defined by config)
-    // if preferred upstream peers < `k = min_broadcast_recipient_count`, pick fallback peers to fill up k
-    pub fn pick_peers(&self) -> PeerInfo {
-        let peer_info = self
-            .peer_info
+    pub fn update_peer_broadcast(&self, peer: PeerNetworkId, timeline_id: u64) {
+        self.peer_info
             .lock()
-            .expect("failed to acquire peer info lock");
-        // pick all preferred peers
-        let mut picked_peers: PeerInfo = peer_info
-            .iter()
-            .filter(|(peer, state)| {
-                state.is_alive && self.upstream_config.is_primary_upstream_peer(**peer)
-            })
-            .map(|(peer, state)| (*peer, state.clone()))
-            .collect();
-
-        let picked_peers_count = picked_peers.len();
-        if picked_peers_count < self.min_broadcast_recipient_count {
-            // randomly select fallback peers
-            // TODO add peer scoring schema to use for selecting fallback peers
-            let fallback_peers: PeerInfo = peer_info
-                .iter()
-                .filter(|(peer, state)| !picked_peers.contains_key(&peer) && state.is_alive)
-                .map(|(peer, state)| (*peer, state.clone()))
-                .choose_multiple(
-                    &mut rand::thread_rng(),
-                    self.min_broadcast_recipient_count - picked_peers_count,
-                )
-                .into_iter()
-                .collect();
-
-            picked_peers.extend(fallback_peers);
-        }
-        picked_peers
-    }
-
-    pub fn update_peer_broadcast(&self, peer_broadcasts: Vec<(PeerNetworkId, u64)>) {
-        let mut peer_info = self
-            .peer_info
-            .lock()
-            .expect("failed to acquire peer_info lock");
-
-        for (peer, new_timeline_id) in peer_broadcasts {
-            peer_info.entry(peer).and_modify(|t| {
-                t.timeline_id = new_timeline_id;
+            .expect("failed to acquire peer_info lock")
+            .entry(peer)
+            .and_modify(|t| {
+                t.timeline_id = timeline_id;
             });
-        }
     }
 
     pub fn is_upstream_peer(&self, peer: PeerNetworkId) -> bool {
         self.upstream_config.is_upstream_peer(peer)
+    }
+
+    fn is_primary_upstream_peer(&self, peer: PeerNetworkId) -> bool {
+        self.upstream_config.is_primary_upstream_peer(peer)
+    }
+
+    pub fn get_peer_state(&self, peer: PeerNetworkId) -> PeerSyncState {
+        self.peer_info
+            .lock()
+            .expect("failed to acquire peer info lock")
+            .get(&peer)
+            .expect("missing peer sync state")
+            .clone()
+    }
+
+    // checks whether a peer is a chosen broadcast recipient:
+    // - all primary peers
+    // - fallback peers, if k-policy is enabled
+    // this does NOT check for whether this peer is alive
+    pub fn is_picked_peer(&self, peer: PeerNetworkId) -> bool {
+        if self.is_primary_upstream_peer(peer) {
+            return true;
+        }
+
+        let no_live_primaries = self
+            .peer_info
+            .lock()
+            .expect("failed to acquire peer info lock")
+            .iter()
+            .find(|(peer, state)| self.is_primary_upstream_peer(**peer) && state.is_alive)
+            .is_none();
+
+        // for fallback peers, broadcast if k-policy is on
+        // TODO change from sending to k fallback peers instead of sending to all fallback peers
+        no_live_primaries && self.min_broadcast_recipient_count > 0
     }
 }

--- a/mempool/src/shared_mempool/tasks.rs
+++ b/mempool/src/shared_mempool/tasks.rs
@@ -16,7 +16,7 @@ use crate::{
 };
 use anyhow::{ensure, format_err, Result};
 use futures::channel::oneshot;
-use libra_config::config::PeerNetworkId;
+use libra_config::config::{NetworkId, PeerNetworkId};
 use libra_logger::prelude::*;
 use libra_types::{
     mempool_status::{MempoolStatus, MempoolStatusCode},
@@ -40,61 +40,64 @@ use vm_validator::vm_validator::{get_account_sequence_number, TransactionValidat
 // ============================== //
 //  broadcast_coordinator tasks  //
 // ============================== //
-/// sync routine
-/// used to periodically broadcast ready to go transactions to peers
-pub(crate) async fn sync_with_peers<'a>(
-    peer_manager: Arc<PeerManager>,
-    mempool: &'a Mutex<CoreMempool>,
-    mut network_senders: HashMap<PeerId, MempoolNetworkSender>,
+
+/// broadcasts txns to `peer` if alive
+/// returns whether the next broadcast should be scheduled
+pub(crate) fn broadcast_single_peer(
+    peer: PeerNetworkId,
+    peer_manager: &PeerManager,
+    mempool: &Mutex<CoreMempool>,
+    network_senders: &mut HashMap<NetworkId, MempoolNetworkSender>,
     batch_size: usize,
 ) {
-    let peers = peer_manager.pick_peers();
-    let mut state_updates = vec![];
-
-    for (peer, peer_state) in peers.into_iter() {
-        if peer_state.is_alive {
-            let timeline_id = peer_state.timeline_id;
-            let (transactions, new_timeline_id) = mempool
-                .lock()
-                .expect("[shared mempool] failed to acquire mempool lock")
-                .read_timeline(timeline_id, batch_size);
-
-            if !transactions.is_empty() {
-                counters::SHARED_MEMPOOL_TRANSACTION_BROADCAST.inc_by(transactions.len() as i64);
-
-                let network_sender = network_senders
-                    .get_mut(&peer.network_id())
-                    .expect("[shared mempool] missign network sender")
-                    .clone();
-
-                let request_id = create_request_id(timeline_id, new_timeline_id);
-                if let Err(e) = send_mempool_sync_msg(
-                    MempoolSyncMsg::BroadcastTransactionsRequest {
-                        request_id,
-                        transactions,
-                    },
-                    peer.peer_id(),
-                    network_sender,
-                ) {
-                    error!(
-                        "[shared mempool] error broadcasting transations to peer {:?}: {}",
-                        peer, e
-                    );
-                } else {
-                    // only update state for successful sends
-                    state_updates.push((peer, new_timeline_id));
-                }
-            }
+    let timeline_id = if peer_manager.is_picked_peer(peer) {
+        let state = peer_manager.get_peer_state(peer);
+        if state.is_alive {
+            state.timeline_id
+        } else {
+            return;
         }
+    } else {
+        return;
+    };
+
+    let (transactions, new_timeline_id) = mempool
+        .lock()
+        .expect("[shared mempool] failed to acquire mempool lock")
+        .read_timeline(timeline_id, batch_size);
+
+    if transactions.is_empty() {
+        return;
     }
 
-    peer_manager.update_peer_broadcast(state_updates);
+    let mut network_sender = network_senders
+        .get_mut(&peer.network_id())
+        .expect("[shared mempool] missing network sender");
+
+    let request_id = create_request_id(timeline_id, new_timeline_id);
+    let txns_ct = transactions.len();
+    if let Err(e) = send_mempool_sync_msg(
+        MempoolSyncMsg::BroadcastTransactionsRequest {
+            request_id,
+            transactions,
+        },
+        peer.peer_id(),
+        &mut network_sender,
+    ) {
+        error!(
+            "[shared mempool] error broadcasting transactions to peer {:?}: {}",
+            peer, e
+        );
+    } else {
+        counters::SHARED_MEMPOOL_TRANSACTION_BROADCAST.inc_by(txns_ct as i64);
+        peer_manager.update_peer_broadcast(peer, new_timeline_id);
+    }
 }
 
 fn send_mempool_sync_msg(
     msg: MempoolSyncMsg,
     recipient: PeerId,
-    mut network_sender: MempoolNetworkSender,
+    network_sender: &mut MempoolNetworkSender,
 ) -> Result<()> {
     // Since this is a direct-send, this will only error if the network
     // module has unexpectedly crashed or shutdown.
@@ -119,8 +122,7 @@ pub(crate) async fn process_client_transaction_submission<V>(
     V: TransactionValidation,
 {
     let mut statuses =
-        process_incoming_transactions(smp.clone(), vec![transaction], TimelineState::NotReady)
-            .await;
+        process_incoming_transactions(&smp, vec![transaction], TimelineState::NotReady).await;
     log_txn_process_results(statuses.clone(), None);
     let status;
     if statuses.is_empty() {
@@ -148,18 +150,17 @@ pub(crate) async fn process_transaction_broadcast<V>(
 ) where
     V: TransactionValidation,
 {
-    let network_sender = smp
-        .network_senders
-        .get_mut(&peer.network_id())
-        .expect("[shared mempool] missing network sender")
-        .clone();
-    let results = process_incoming_transactions(smp, transactions, timeline_state).await;
+    let results = process_incoming_transactions(&smp, transactions, timeline_state).await;
     log_txn_process_results(results, Some(peer.peer_id()));
     // send back ACK
+    let mut network_sender = smp
+        .network_senders
+        .get_mut(&peer.network_id())
+        .expect("[shared mempool] missing network sender");
     if let Err(e) = send_mempool_sync_msg(
         MempoolSyncMsg::BroadcastTransactionsResponse { request_id },
         peer.peer_id(),
-        network_sender,
+        &mut network_sender,
     ) {
         error!(
             "[shared mempool] failed to send ACK back to peer {:?}: {}",
@@ -171,7 +172,7 @@ pub(crate) async fn process_transaction_broadcast<V>(
 /// submits a list of SignedTransaction to the local mempool
 /// and returns a vector containing AdmissionControlStatus
 async fn process_incoming_transactions<V>(
-    smp: SharedMempool<V>,
+    smp: &SharedMempool<V>,
     transactions: Vec<SignedTransaction>,
     timeline_state: TimelineState,
 ) -> Vec<SubmissionStatus>

--- a/state-synchronizer/src/peer_manager.rs
+++ b/state-synchronizer/src/peer_manager.rs
@@ -211,8 +211,7 @@ impl PeerManager {
     }
 
     fn is_upstream_peer(&self, peer: PeerNetworkId) -> bool {
-        self.upstream_config
-            .is_upstream_peer(peer.network_id(), peer.peer_id())
+        self.upstream_config.is_upstream_peer(peer)
     }
 
     #[cfg(test)]


### PR DESCRIPTION
## Motivation

Originally, mempool txn broadcasts followed a rigid schedule - a fixed interval (50 ms) to all peers. There was no flexible scheduling in terms of time or recipient.

With this PR, txn broadcasts can now be scheduled at any time, and each peer can have its own broadcast schedule. 

The current implementation still follows the original protocol of fixed-interval broadcasting, but this framework lays the foundation for later supporting features that require flexible broadcast scheduling such as backpressure and responsive broadcasting

## Test Plan

Refactored and existing tests pass
