### PR TITLE
[language][move-lang] support pretty printing errors

### DIFF
--- a/language/functional-tests/src/testsuite.rs
+++ b/language/functional-tests/src/testsuite.rs
@@ -5,7 +5,7 @@ use crate::{
     checker::*,
     compiler::Compiler,
     config::global::Config as GlobalConfig,
-    evaluator::eval,
+    evaluator::{eval, EvaluationOutput},
     preprocessor::{build_transactions, split_input},
 };
 use std::{env, fs::read_to_string, io::Write, iter, path::Path};
@@ -142,7 +142,18 @@ pub fn functional_tests<TComp: Compiler>(
         writeln!(
             output,
             "{}",
-            format!("{}", log)
+            log.outputs
+                .iter()
+                .enumerate()
+                .map(|(id, entry)| {
+                    match entry {
+                        EvaluationOutput::Error(err) => {
+                            format!("[{}] Error: {}\n", id, err.root_cause())
+                        }
+                        _ => format!("[{}] {}\n", id, entry),
+                    }
+                })
+                .collect::<String>()
                 .lines()
                 .map(|line| format!("    {}\n", line))
                 .collect::<String>()


### PR DESCRIPTION
## Summary
This adds support for pretty printing errors when running the move-lang functional tests.

Before:
```
    [0] Transaction(0)
    [1] Stage(Compiler)
    [2] "error: \n\n   ┌── /var/folders/hd/zt73s2xj5gb2csy_9nhdwq7w1qz8wg/T/.tmp3ha6BX:2:9 ───\n   │\n 2 │ let x = 1 + true;\n   │             ^^^^ Incompatible arguments to \'+\'\n   ·\n 2 │ let x = 1 + true;\n   │         - The type: integer\n   ·\n 2 │ let x = 1 + true;\n   │             ---- Is not compatible with: \'bool\'\n   │\n\n"
    [3] Status(Failure)
```
After:
```
    [0] Transaction 0
    [1] Stage: Compiler
    [2] Error: 
    
    error: 
    
       ┌── /var/folders/hd/zt73s2xj5gb2csy_9nhdwq7w1qz8wg/T/.tmpaflJZx:2:9 ───
       │
     2 │ let x = 1 + true;
       │             ^^^^ Incompatible arguments to '+'
       ·
     2 │ let x = 1 + true;
       │         - The type: integer
       ·
     2 │ let x = 1 + true;
       │             ---- Is not compatible with: 'bool'
       │
    
    
    
    [3] Status: Failure
```

## Test Plan
Manually test with a file with compile errors.