### PR TITLE
[JSON RPC] implement `get_metadata`

### DIFF
--- a/json-rpc/src/methods.rs
+++ b/json-rpc/src/methods.rs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 //! Module contains RPC method handlers for Full Node JSON-RPC interface
-use crate::views::AccountView;
+use crate::views::{AccountView, BlockMetadata};
 use anyhow::{ensure, Result};
 use core::future::Future;
 use libra_types::{account_address::AccountAddress, account_config::AccountResource};
@@ -31,11 +31,20 @@ async fn get_account_state(
     Ok(None)
 }
 
+/// Returns the current blockchain metadata
+/// Can be used to verify that target Full Node is up-to-date
+async fn get_metadata(libra_db: Arc<LibraDB>, _params: Vec<Value>) -> Result<BlockMetadata> {
+    let (version, timestamp) = libra_db.get_latest_commit_metadata()?;
+    Ok(BlockMetadata { version, timestamp })
+}
+
 /// Builds registry of all available RPC methods
 /// To register new RPC method, add it via `register_rpc_method!` macros call
 /// Note that RPC method name will equal to name of function
 pub(crate) fn build_registry() -> RpcRegistry {
     let mut registry = RpcRegistry::new();
     register_rpc_method!(registry, get_account_state, 1);
+    register_rpc_method!(registry, get_metadata, 0);
+
     registry
 }

--- a/json-rpc/src/views.rs
+++ b/json-rpc/src/views.rs
@@ -27,6 +27,12 @@ impl AccountView {
 }
 
 #[derive(Serialize)]
+pub struct BlockMetadata {
+    pub version: u64,
+    pub timestamp: u64,
+}
+
+#[derive(Serialize)]
 pub struct BytesView(String);
 
 impl From<&[u8]> for BytesView {

--- a/storage/libradb/src/lib.rs
+++ b/storage/libradb/src/lib.rs
@@ -355,6 +355,12 @@ impl LibraDB {
             .version())
     }
 
+    pub fn get_latest_commit_metadata(&self) -> Result<(Version, u64)> {
+        let latest_ledger_info = self.ledger_store.get_latest_ledger_info()?;
+        let ledger_info = latest_ledger_info.ledger_info();
+        Ok((ledger_info.version(), ledger_info.timestamp_usecs()))
+    }
+
     /// Returns ledger infos reflecting epoch bumps starting with the given epoch. If there are no
     /// more than `MAX_NUM_EPOCH_CHANGE_LEDGER_INFO` results, this function returns all of them,
     /// otherwise the first `MAX_NUM_EPOCH_CHANGE_LEDGER_INFO` results are returned and a flag


### PR DESCRIPTION
## Motivation

Implementing `get_metadata` JSON RPC method
Also adding `get_latest_commit_metadata` to LibraDB interface, since there is no way to retrieve block timestamp in current interface

## Test Plan

`test_get_metadata`
