### PR TITLE
[cluster-test] Retry flaky update_service AWS call

### DIFF
--- a/testsuite/cluster-test/src/deployment.rs
+++ b/testsuite/cluster-test/src/deployment.rs
@@ -3,6 +3,7 @@
 
 #![forbid(unsafe_code)]
 
+use crate::instance::Instance;
 use crate::{aws::Aws, cluster::Cluster};
 use anyhow::{bail, format_err, Result};
 use rusoto_core::RusotoError;
@@ -64,19 +65,30 @@ impl DeploymentManager {
 
     pub fn update_all_services(&self) -> Result<()> {
         for instance in self.cluster.all_instances() {
+            self.update_service(instance)?;
+            thread::sleep(Duration::from_millis(200));
+        }
+        Ok(())
+    }
+
+    fn update_service(&self, instance: &Instance) -> Result<()> {
+        for _ in 0..10 {
             let mut request = UpdateServiceRequest::default();
             request.cluster = Some(self.aws.workspace().clone());
             request.force_new_deployment = Some(true);
             request.service = instance.peer_name().to_string();
 
-            self.aws
-                .ecs()
-                .update_service(request)
-                .sync()
-                .map_err(|e| format_err!("Failed to update {}: {:?}", instance, e))?;
-            thread::sleep(Duration::from_millis(200));
+            let res = self.aws.ecs().update_service(request).sync();
+            match res {
+                Ok(..) => return Ok(()),
+                Err(e) => println!("Failed to update {}: {}, retrying", instance, e),
+            }
+            thread::sleep(Duration::from_millis(1000));
         }
-        Ok(())
+        Err(format_err!(
+            "Failed to update {}: no more retries",
+            instance
+        ))
     }
 
     fn image_digest_by_tag(&self, tag: &str) -> Result<String> {


### PR DESCRIPTION
In general we should retry any aws call, and we do already for most of them
update_service was not retried before, and it was flaky lately and we were failing ct jobs because of this

This diff will retry failed update_service call, instead of failing entire build
