### PR TITLE
Use a fixed 8 character hash for canonical image tag

### DIFF
--- a/.github/workflows/land-blocking.yml
+++ b/.github/workflows/land-blocking.yml
@@ -15,6 +15,7 @@ jobs:
       - name: Setup env
         run: |
           echo "::set-env name=LIBRA_GIT_REV::$(git rev-parse --short=8 HEAD)"
+          echo "::set-env name=TEST_TAG::land_$(git rev-parse --short=8 HEAD)"
       - name: Check kill switch
         id: check_ks
         run:
@@ -26,7 +27,7 @@ jobs:
       - name: Build, tag and push images
         if: steps.check_ks.outputs.should_run == 'true'
         run: |
-          docker/build-aws.sh --build-all --version $LIBRA_GIT_REV --addl_tags canary
+          docker/build-aws.sh --build-all --version $LIBRA_GIT_REV --addl_tags canary,${TEST_TAG}
       - name: Launch cluster test
         if: steps.check_ks.outputs.should_run == 'true'
         # NOTE Remember to update PR comment payload if cti cmd is updated.
@@ -36,7 +37,7 @@ jobs:
           JUMPHOST=${{secrets.CLUSTER_TEST_JUMPHOST}} \
           ./scripts/cti \
             --marker land \
-            --tag dev_$LIBRA_GIT_REV \
+            --tag ${TEST_TAG} \
             --report report.json \
             --run bench
       - name: Post test results on PR
@@ -115,7 +116,7 @@ jobs:
             try {
               body += "\nRepro cmd:\n";
               body += `
-                ./scripts/cti --tag dev_${env_vars.LIBRA_GIT_REV} --run bench
+                ./scripts/cti --tag ${env_vars.TEST_TAG} --run bench
               `;
             } catch (err) {
               if (err.code === 'ReferenceError') {

--- a/docker/build-aws.sh
+++ b/docker/build-aws.sh
@@ -15,6 +15,7 @@ function print_usage() {
   exit 1
 }
 
+USER=$(whoami)
 BUILD_PROJECTS=()
 
 while [[ "$1" =~ ^- ]]; do case $1 in

--- a/docker/cluster-test/buildspec.yaml
+++ b/docker/cluster-test/buildspec.yaml
@@ -18,4 +18,4 @@ phases:
     commands:
       - echo Build completed on `date`
       # Tag and push the docker images
-      - SOURCE=cluster-test:latest TARGET_REPO=$LIBRA_CLUSTER_TEST_REPO TARGET_TAGS="${TAGS}:dev_$(git rev-parse --short HEAD)" docker/tag-and-push.sh
+      - SOURCE=cluster-test:latest TARGET_REPO=$LIBRA_CLUSTER_TEST_REPO TARGET_TAGS="${TAGS}:dev_$(git rev-parse --short=8  HEAD)" docker/tag-and-push.sh

--- a/docker/validator-dynamic/buildspec.yaml
+++ b/docker/validator-dynamic/buildspec.yaml
@@ -19,5 +19,5 @@ phases:
     commands:
       - echo Build completed on `date`
       # Tag and push the docker images
-      - SOURCE=libra_e2e:latest TARGET_REPO=$LIBRA_E2E_REPO TARGET_TAGS="${TAGS}:dev_$(git rev-parse --short HEAD)" docker/tag-and-push.sh
+      - SOURCE=libra_e2e:latest TARGET_REPO=$LIBRA_E2E_REPO TARGET_TAGS="${TAGS}:dev_$(git rev-parse --short=8  HEAD)" docker/tag-and-push.sh
       - SOURCE=libra_validator_dynamic:latest TARGET_REPO=$LIBRA_VALIDATOR_REPO TARGET_TAGS="${TAGS}:dev_$(git rev-parse --short HEAD)" docker/tag-and-push.sh


### PR DESCRIPTION
## Summary

* `git rev-parse --short` can produce variable length tags. This fixes the canonical tag to length of 8 characters.
* Also update GHAR to explicitly specify tag rather than implicitly deriving it.