### PR TITLE
[libra-wallet] Update some dependencies that were duplicated

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1267,17 +1267,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "ed25519-dalek"
-version = "1.0.0-pre.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "clear_on_drop 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "curve25519-dalek 2.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "rand 0.7.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "sha2 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
 name = "either"
 version = "1.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2645,7 +2634,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow 1.0.26 (registry+https://github.com/rust-lang/crates.io-index)",
  "byteorder 1.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "ed25519-dalek 1.0.0-pre.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ed25519-dalek 1.0.0-pre.1 (git+https://github.com/calibra/ed25519-dalek.git?branch=fiat)",
  "hex 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "hmac 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "libra-crypto 0.1.0",
@@ -2654,7 +2643,6 @@ dependencies = [
  "mirai-annotations 1.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "pbkdf2 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "rand_core 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)",
  "sha2 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "sha3 0.8.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -6645,7 +6633,6 @@ dependencies = [
 "checksum dirs-sys 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)" = "afa0b23de8fd801745c471deffa6e12d248f962c9fd4b4c33787b055599bde7b"
 "checksum dtoa 0.4.5 (registry+https://github.com/rust-lang/crates.io-index)" = "4358a9e11b9a09cf52383b451b49a169e8d797b68aa02301ff586d70d9661ea3"
 "checksum ed25519-dalek 1.0.0-pre.1 (git+https://github.com/calibra/ed25519-dalek.git?branch=fiat)" = "<none>"
-"checksum ed25519-dalek 1.0.0-pre.3 (registry+https://github.com/rust-lang/crates.io-index)" = "978710b352437433c97b2bff193f2fb1dfd58a093f863dd95e225a19baa599a2"
 "checksum either 1.5.3 (registry+https://github.com/rust-lang/crates.io-index)" = "bb1f6b1ce1c140482ea30ddd3335fc0024ac7ee112895426e0a629a6c20adfe3"
 "checksum encode_unicode 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)" = "a357d28ed41a50f9c765dbfe56cbc04a64e53e5fc58ba79fbc34c10ef3df831f"
 "checksum encoding_rs 0.8.22 (registry+https://github.com/rust-lang/crates.io-index)" = "cd8d03faa7fe0c1431609dfad7bbe827af30f82e1e2ae6f7ee4fca6bd764bc28"

--- a/client/libra_wallet/Cargo.toml
+++ b/client/libra_wallet/Cargo.toml
@@ -12,7 +12,6 @@ edition = "2018"
 [dependencies]
 anyhow = "1.0"
 rand = "0.6.5"
-rand_core = "0.4.2"
 hex = "0.4.2"
 hmac = "0.7.1"
 byteorder = "1.3.2"
@@ -21,7 +20,7 @@ serde = "1.0.96"
 sha3 = "0.8.2"
 sha2 = "0.8.0"
 thiserror = "1"
-ed25519-dalek = "1.0.0-pre.1"
+ed25519-dalek = { git = "https://github.com/calibra/ed25519-dalek.git", branch = "fiat", default-features = false }
 libra-crypto = { path = "../../crypto/crypto", version = "0.1.0" }
 libra-temppath = { path = "../../common/temppath/", version = "0.1.0" }
 libra-types = { path = "../../types", version = "0.1.0" }

--- a/client/libra_wallet/src/mnemonic.rs
+++ b/client/libra_wallet/src/mnemonic.rs
@@ -14,7 +14,7 @@ use mirai_annotations::*;
 #[cfg(test)]
 use rand::rngs::EntropyRng;
 #[cfg(test)]
-use rand_core::RngCore;
+use rand::RngCore;
 use sha2::{Digest, Sha256};
 use std::{
     fs::{self, File},


### PR DESCRIPTION
This removes duplicate versions of rand_core and ed25519 by updating them to
the same versions use elsewhere.
