### PR TITLE
[json-rpc] add `submit` rpc method

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2310,8 +2310,11 @@ dependencies = [
  "anyhow 1.0.26 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "hex 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libra-canonical-serialization 0.1.0",
  "libra-config 0.1.0",
+ "libra-crypto 0.1.0",
  "libra-logger 0.1.0",
+ "libra-mempool 0.1.0",
  "libra-metrics 0.1.0",
  "libra-temppath 0.1.0",
  "libra-types 0.1.0",
@@ -2321,6 +2324,7 @@ dependencies = [
  "serde 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.48 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio 0.2.13 (registry+https://github.com/rust-lang/crates.io-index)",
+ "vm-validator 0.1.0",
  "warp 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 

--- a/json-rpc/Cargo.toml
+++ b/json-rpc/Cargo.toml
@@ -18,16 +18,20 @@ warp = "0.2.2"
 futures = "0.3.0"
 tokio = { version = "0.2.13", features = ["full"] }
 
+lcs = { path = "../common/lcs", version = "0.1.0", package = "libra-canonical-serialization" }
 libra-config = { path = "../config", version = "0.1.0" }
 libra-logger = { path = "../common/logger", version = "0.1.0" }
+libra-mempool = { path = "../mempool", version = "0.1.0" }
 libra-metrics = { path = "../common/metrics", version = "0.1.0" }
 libra-types = { path = "../types", version = "0.1.0" }
 libradb = { path = "../storage/libradb", version = "0.1.0" }
 
 [dev-dependencies]
+libra-crypto = { path = "../crypto/crypto", version = "0.1.0" }
 libra-temppath = { path = "../common/temppath", version = "0.1.0" }
 proptest = "0.9.2"
 reqwest = { version = "0.10.4", features = ["blocking", "json"], default_features = false }
+vm-validator = { path = "../vm-validator", version = "0.1.0" }
 
 [features]
 fuzzing = ["libradb/fuzzing"]

--- a/json-rpc/src/util.rs
+++ b/json-rpc/src/util.rs
@@ -9,10 +9,10 @@ macro_rules! register_rpc_method {
     ($registry:expr, $method: expr, $num_args: expr) => {
         $registry.insert(
             stringify!($method).to_string(),
-            Box::new(move |libra_db, parameters| {
+            Box::new(move |service, parameters| {
                 Box::pin(async move {
                     ensure!(parameters.len() == $num_args, "Invalid number of arguments");
-                    Ok(serde_json::to_value($method(libra_db, parameters).await?)?)
+                    Ok(serde_json::to_value($method(service, parameters).await?)?)
                 })
             }),
         );


### PR DESCRIPTION
adds new `submit` rpc method
used to submit new hex encoded signed transactions to full node via json-rpc API
