### PR TITLE
[mempool] remove balance check

### DIFF
--- a/admission_control/admission-control-service/src/unit_tests/admission_control_service_test.rs
+++ b/admission_control/admission-control-service/src/unit_tests/admission_control_service_test.rs
@@ -119,7 +119,6 @@ impl AdmissionControl for MockAdmissionControlService {
             }
             Ok(None) => {
                 let mut status = MempoolStatus::default();
-                let insufficient_balance_add = [100_u8; ADDRESS_LENGTH];
                 let invalid_seq_add = [101_u8; ADDRESS_LENGTH];
                 let sys_error_add = [102_u8; ADDRESS_LENGTH];
                 let accepted_add = [103_u8; ADDRESS_LENGTH];
@@ -129,8 +128,6 @@ impl AdmissionControl for MockAdmissionControlService {
                 let sender_ref = sender.as_ref();
                 if sender_ref == accepted_add {
                     status.code = MempoolStatusCode::Accepted.into();
-                } else if sender_ref == insufficient_balance_add {
-                    status.code = MempoolStatusCode::InsufficientBalance.into();
                 } else if sender_ref == invalid_seq_add {
                     status.code = MempoolStatusCode::InvalidSeqNumber.into();
                 } else if sender_ref == sys_error_add {
@@ -197,7 +194,6 @@ fn test_submit_txn_inner_mempool() {
     let ac_service = MockAdmissionControlService::new();
 
     let test_cases = vec![
-        (100, Some(MempoolStatusCode::InsufficientBalance)),
         (101, Some(MempoolStatusCode::InvalidSeqNumber)),
         (102, Some(MempoolStatusCode::InvalidUpdate)),
         (103, None),

--- a/mempool/src/core_mempool/transaction_store.rs
+++ b/mempool/src/core_mempool/transaction_store.rs
@@ -19,7 +19,6 @@ use libra_types::{
     mempool_status::{MempoolStatus, MempoolStatusCode},
     transaction::SignedTransaction,
 };
-use mirai_annotations::*;
 use std::{
     collections::HashMap,
     ops::Bound,
@@ -268,18 +267,6 @@ impl TransactionStore {
         self.timeline_index.remove(&txn);
         self.parking_lot_index.remove(&txn);
         self.track_indices();
-    }
-
-    /// returns gas amount required to process all transactions for given account
-    pub(crate) fn get_required_balance(&mut self, address: &AccountAddress) -> u64 {
-        self.transactions.get_mut(&address).map_or(0, |txns| {
-            txns.iter().fold(0, |acc, (_, txn)| {
-                assume!(txn.gas_amount < u32::max_value() as u64); // seems more than reasonable
-                assume!(txn.txn.gas_unit_price() < u32::max_value() as u64);
-                assume!(acc <= u64::max_value() - txn.txn.gas_unit_price() * txn.gas_amount);
-                acc + txn.txn.gas_unit_price() * txn.gas_amount
-            })
-        })
     }
 
     /// Read `count` transactions from timeline since `timeline_id`

--- a/mempool/src/core_mempool/unit_tests/common.rs
+++ b/mempool/src/core_mempool/unit_tests/common.rs
@@ -97,7 +97,7 @@ pub(crate) fn add_txns_to_mempool(
     let mut transactions = vec![];
     for transaction in txns {
         let txn = transaction.make_signed_transaction();
-        pool.add_txn(txn.clone(), 0, 0, 1000, TimelineState::NotReady);
+        pool.add_txn(txn.clone(), 0, 0, TimelineState::NotReady);
         transactions.push(txn);
     }
     transactions
@@ -109,7 +109,7 @@ pub(crate) fn add_txn(pool: &mut CoreMempool, transaction: TestTransaction) -> R
 
 pub(crate) fn add_signed_txn(pool: &mut CoreMempool, transaction: SignedTransaction) -> Result<()> {
     match pool
-        .add_txn(transaction, 0, 0, 1000, TimelineState::NotReady)
+        .add_txn(transaction, 0, 0, TimelineState::NotReady)
         .code
     {
         MempoolStatusCode::Accepted => Ok(()),

--- a/mempool/src/core_mempool/unit_tests/shared_mempool_test.rs
+++ b/mempool/src/core_mempool/unit_tests/shared_mempool_test.rs
@@ -155,7 +155,7 @@ impl SharedMempoolNetwork {
         let mut mempool = self.mempools.get(peer_id).unwrap().lock().unwrap();
         for txn in txns {
             let transaction = txn.make_signed_transaction_with_max_gas_amount(5);
-            mempool.add_txn(transaction, 0, 0, 10, TimelineState::NotReady);
+            mempool.add_txn(transaction, 0, 0, TimelineState::NotReady);
         }
     }
 

--- a/mempool/src/mocks/mock_shared_mempool.rs
+++ b/mempool/src/mocks/mock_shared_mempool.rs
@@ -105,7 +105,7 @@ impl MockSharedMempool {
                 .lock()
                 .expect("[mock shared mempool] failed to acquire mempool lock");
             for txn in txns {
-                if pool.add_txn(txn, 0, 0, 1000, TimelineState::NotReady).code
+                if pool.add_txn(txn, 0, 0, TimelineState::NotReady).code
                     != MempoolStatusCode::Accepted
                 {
                     return Err(format_err!("failed to insert into mock mempool"));

--- a/types/src/mempool_status.rs
+++ b/types/src/mempool_status.rs
@@ -42,19 +42,17 @@ impl MempoolStatus {
 pub enum MempoolStatusCode {
     // Transaction was accepted by Mempool
     Accepted = 0,
-    // The sender does not have enough balance for the transaction.
-    InsufficientBalance = 1,
     // Sequence number is old, etc.
-    InvalidSeqNumber = 2,
+    InvalidSeqNumber = 1,
     // Mempool is full (reached max global capacity)
-    MempoolIsFull = 3,
+    MempoolIsFull = 2,
     // Account reached max capacity per account
-    TooManyTransactions = 4,
+    TooManyTransactions = 3,
     // Invalid update. Only gas price increase is allowed
-    InvalidUpdate = 5,
+    InvalidUpdate = 4,
     // transaction didn't pass vm_validation
-    VmError = 6,
-    UnknownStatus = 7,
+    VmError = 5,
+    UnknownStatus = 6,
 }
 
 impl TryFrom<u64> for MempoolStatusCode {
@@ -63,13 +61,12 @@ impl TryFrom<u64> for MempoolStatusCode {
     fn try_from(value: u64) -> Result<Self, Self::Error> {
         match value {
             0 => Ok(MempoolStatusCode::Accepted),
-            1 => Ok(MempoolStatusCode::InsufficientBalance),
-            2 => Ok(MempoolStatusCode::InvalidSeqNumber),
-            3 => Ok(MempoolStatusCode::MempoolIsFull),
-            4 => Ok(MempoolStatusCode::TooManyTransactions),
-            5 => Ok(MempoolStatusCode::InvalidUpdate),
-            6 => Ok(MempoolStatusCode::VmError),
-            7 => Ok(MempoolStatusCode::UnknownStatus),
+            1 => Ok(MempoolStatusCode::InvalidSeqNumber),
+            2 => Ok(MempoolStatusCode::MempoolIsFull),
+            3 => Ok(MempoolStatusCode::TooManyTransactions),
+            4 => Ok(MempoolStatusCode::InvalidUpdate),
+            5 => Ok(MempoolStatusCode::VmError),
+            6 => Ok(MempoolStatusCode::UnknownStatus),
             _ => Err("invalid StatusCode"),
         }
     }

--- a/vm-validator/src/vm_validator.rs
+++ b/vm-validator/src/vm_validator.rs
@@ -95,21 +95,16 @@ impl TransactionValidation for VMValidator {
     }
 }
 
-/// read account state
-/// returns account's current sequence number and balance
-pub async fn get_account_state(
+/// returns account's sequence number from storage
+pub async fn get_account_sequence_number(
     storage_read_client: Arc<dyn StorageRead>,
     address: AccountAddress,
-) -> Result<(u64, u64)> {
-    let account_state = storage_read_client
+) -> Result<u64> {
+    match storage_read_client
         .get_latest_account_state(address)
-        .await?;
-    Ok(if let Some(blob) = account_state {
-        let account_resource = AccountResource::try_from(&blob)?;
-        let sequence_number = account_resource.sequence_number();
-        let balance = account_resource.balance();
-        (sequence_number, balance)
-    } else {
-        (0, 0)
-    })
+        .await?
+    {
+        Some(blob) => Ok(AccountResource::try_from(&blob)?.sequence_number()),
+        None => Ok(0),
+    }
 }


### PR DESCRIPTION
this check used to verify that account has sufficient balance to pay for gas for all txns in local mempool
it was best effort attempt. It's still possible to easily craft txns and send to different validators to bypass it
Also it doesn't really check internal script of txn
