### PR TITLE
[tf] Add variable to set number of validators in genesis blob

### DIFF
--- a/docker/validator-dynamic/docker-run-dynamic.sh
+++ b/docker/validator-dynamic/docker-run-dynamic.sh
@@ -20,6 +20,9 @@ fi
 if [ -n "${CFG_NUM_VALIDATORS}" ]; then # Total number of nodes in this network
 	    params+="-n ${CFG_NUM_VALIDATORS} "
 fi
+if [ -n "${CFG_NUM_VALIDATORS_IN_GENESIS}" ]; then # Total number of nodes in genesis
+	    params+="-g ${CFG_NUM_VALIDATORS_IN_GENESIS} "
+fi
 if [ -n "${CFG_SEED}" ]; then # Random seed to use
 	    params+="-s ${CFG_SEED} "
 fi

--- a/terraform/templates/validator.json
+++ b/terraform/templates/validator.json
@@ -40,6 +40,7 @@
             {"name": "CFG_LISTEN_ADDR", "value": "${cfg_listen_addr}"},
             {"name": "CFG_NODE_INDEX", "value": "${cfg_node_index}"},
             {"name": "CFG_NUM_VALIDATORS", "value": "${cfg_num_validators}"},
+            {"name": "CFG_NUM_VALIDATORS_IN_GENESIS", "value": "${cfg_num_validators_in_genesis}"},
             {"name": "CFG_SEED", "value": "${cfg_seed}"},
             {"name": "CFG_SEED_PEER_IP", "value": "${cfg_seed_peer_ip}"},
             {"name": "RUST_LOG", "value": "${log_level}"}

--- a/terraform/validators.tf
+++ b/terraform/validators.tf
@@ -135,7 +135,7 @@ locals {
 }
 
 resource "aws_ebs_snapshot" "restore_snapshot" {
-  count = var.restore_vol_id == "" ? 0 : 1
+  count     = var.restore_vol_id == "" ? 0 : 1
   volume_id = var.restore_vol_id
 
   tags = {
@@ -193,16 +193,17 @@ data "template_file" "ecs_task_definition" {
   template = file("templates/validator.json")
 
   vars = {
-    image              = local.image_repo
-    image_version      = local.image_version
-    cpu                = (var.enable_logstash ? local.cpu_by_instance[var.validator_type] - 584 : local.cpu_by_instance[var.validator_type]) - 512
-    mem                = (var.enable_logstash ? local.mem_by_instance[var.validator_type] - 1024 : local.mem_by_instance[var.validator_type]) - 256
-    cfg_base_config    = jsonencode(data.template_file.validator_config.rendered)
-    cfg_listen_addr    = var.validator_use_public_ip == true ? element(aws_instance.validator.*.public_ip, count.index) : element(aws_instance.validator.*.private_ip, count.index)
-    cfg_node_index     = count.index
-    cfg_num_validators = var.cfg_num_validators_override == 0 ? var.num_validators : var.cfg_num_validators_override
-    cfg_seed           = var.config_seed
-    cfg_seed_peer_ip   = local.seed_peer_ip
+    image                         = local.image_repo
+    image_version                 = local.image_version
+    cpu                           = (var.enable_logstash ? local.cpu_by_instance[var.validator_type] - 584 : local.cpu_by_instance[var.validator_type]) - 512
+    mem                           = (var.enable_logstash ? local.mem_by_instance[var.validator_type] - 1024 : local.mem_by_instance[var.validator_type]) - 256
+    cfg_base_config               = jsonencode(data.template_file.validator_config.rendered)
+    cfg_listen_addr               = var.validator_use_public_ip == true ? element(aws_instance.validator.*.public_ip, count.index) : element(aws_instance.validator.*.private_ip, count.index)
+    cfg_node_index                = count.index
+    cfg_num_validators            = var.cfg_num_validators_override == 0 ? var.num_validators : var.cfg_num_validators_override
+    cfg_num_validators_in_genesis = var.num_validators_in_genesis
+    cfg_seed                      = var.config_seed
+    cfg_seed_peer_ip              = local.seed_peer_ip
 
     cfg_fullnode_seed = count.index < var.num_fullnode_networks ? var.fullnode_seed : ""
     cfg_num_fullnodes = var.num_fullnodes

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -50,6 +50,11 @@ variable "num_validators" {
   description = "Number of validator nodes to run on this network"
 }
 
+variable "num_validators_in_genesis" {
+  default     = 4
+  description = "Number of validator nodes to include in genesis blob"
+}
+
 # This allows you to use a override number of validators for config generation
 variable "cfg_num_validators_override" {
   default     = 0


### PR DESCRIPTION
<!--
Thank you for sending a PR. We appreciate you spending time to help improve the Libra project.

The project is undergoing daily changes. Pull Requests will be reviewed and responded to as time permits.
-->

## Motivation

This add a variable for us to define number of validators in genesis so that we can test reconfiguration

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

Built a new docker image with changes
Applied changes to sherryxiao workspace, started the workspace with 3 nodes in genesis
http://prometheus.sherryxiao.aws.hlw3truzy4ls.com:9091/d/overview10/overview?orgId=1&from=now-3h&to=now

```
Start EventProcessor with epoch 1 with genesis [id: 0ed22672, epoch: 1, round: 00, parent_id: 00000000], validators ValidatorSet: [8fd104dc: 1, 916dcbd2: 1, dca65d55: 1, ]
```
## Related PRs

(If this PR adds or changes functionality, please take some time to update the docs at https://github.com/libra/website, and link to your PR here.)
