### PR TITLE
[terraform] Create IAM objects under a path

### DIFF
--- a/terraform/auth.tf
+++ b/terraform/auth.tf
@@ -11,10 +11,11 @@ data "aws_iam_policy_document" "instance-assume-role" {
 
 resource "aws_iam_role" "ecsInstanceRole" {
   name               = "${terraform.workspace}-ecsInstanceRole"
+  path               = var.iam_path
   assume_role_policy = data.aws_iam_policy_document.instance-assume-role.json
 }
 
-resource "aws_iam_role_policy_attachment" "ecsInstanceRole" {
+resource "aws_iam_role_policy_attachment" "ecsInstanceRole_" {
   role       = aws_iam_role.ecsInstanceRole.name
   policy_arn = "arn:aws:iam::aws:policy/service-role/AmazonEC2ContainerServiceforEC2Role"
 }
@@ -28,18 +29,15 @@ data "aws_iam_policy_document" "ecs_extra" {
   }
 }
 
-resource "aws_iam_policy" "ecs_extra" {
-  name   = "${terraform.workspace}-ECS-extra"
+resource "aws_iam_role_policy" "ecs_extra" {
+  name   = "Config-S3"
+  role   = aws_iam_role.ecsInstanceRole.name
   policy = data.aws_iam_policy_document.ecs_extra.json
-}
-
-resource "aws_iam_role_policy_attachment" "ecs_extra" {
-  role       = aws_iam_role.ecsInstanceRole.name
-  policy_arn = aws_iam_policy.ecs_extra.arn
 }
 
 resource "aws_iam_instance_profile" "ecsInstanceRole" {
   name = "${terraform.workspace}-ecsInstanceRole"
+  path = var.iam_path
   role = aws_iam_role.ecsInstanceRole.name
 }
 
@@ -56,10 +54,11 @@ data "aws_iam_policy_document" "task-assume-role" {
 
 resource "aws_iam_role" "ecsTaskExecutionRole" {
   name               = "${terraform.workspace}-ecsTaskExecutionRole"
+  path               = var.iam_path
   assume_role_policy = data.aws_iam_policy_document.task-assume-role.json
 }
 
-resource "aws_iam_role_policy_attachment" "ecsTaskExecutionRole" {
+resource "aws_iam_role_policy_attachment" "ecsTaskExecutionRole_" {
   role       = aws_iam_role.ecsTaskExecutionRole.name
   policy_arn = "arn:aws:iam::aws:policy/service-role/AmazonECSTaskExecutionRolePolicy"
 }

--- a/terraform/cluster-test.tf
+++ b/terraform/cluster-test.tf
@@ -5,6 +5,7 @@ variable "cluster_test" {
 
 resource "aws_iam_role" "cluster-test-runner" {
   name               = "ClusterTestRunner-Role-${var.region}-${terraform.workspace}"
+  path               = var.iam_path
   assume_role_policy = data.aws_iam_policy_document.instance-assume-role.json
 }
 
@@ -22,14 +23,15 @@ data "aws_iam_policy_document" "cluster-test-runner" {
 }
 
 resource "aws_iam_role_policy" "cluster-test-runner" {
-  name   = "ClusterTestRunner-Policy-${var.region}-${terraform.workspace}"
-  role   = "${aws_iam_role.cluster-test-runner.name}"
+  name   = "ClusterTest-EC2-ECR-ECS"
+  role   = aws_iam_role.cluster-test-runner.name
   policy = data.aws_iam_policy_document.cluster-test-runner.json
 }
 
 resource "aws_iam_instance_profile" "cluster-test-runner" {
   name = "ClusterTestRunner-IamProfile-${var.region}-${terraform.workspace}"
-  role = "${aws_iam_role.cluster-test-runner.name}"
+  path = var.iam_path
+  role = aws_iam_role.cluster-test-runner.name
 }
 
 data "template_file" "cluster_test_user_data" {
@@ -56,7 +58,7 @@ resource "aws_instance" "cluster-test-runner" {
     Role      = "cluster-test-runner"
     Workspace = terraform.workspace
   }
-  iam_instance_profile = "${aws_iam_instance_profile.cluster-test-runner.name}"
+  iam_instance_profile = aws_iam_instance_profile.cluster-test-runner.name
 
   root_block_device {
     volume_type = "gp2"

--- a/terraform/fullnodes.tf
+++ b/terraform/fullnodes.tf
@@ -11,7 +11,7 @@ resource "aws_instance" "fullnode" {
     aws_subnet.testnet.*.id,
     count.index % length(data.aws_availability_zones.available.names),
   )
-  depends_on                  = [aws_main_route_table_association.testnet, aws_iam_role_policy_attachment.ecs_extra]
+  depends_on                  = [aws_main_route_table_association.testnet, aws_iam_role_policy.ecs_extra]
   vpc_security_group_ids      = [aws_security_group.validator.id]
   associate_public_ip_address = local.instance_public_ip
   key_name                    = aws_key_pair.libra.key_name

--- a/terraform/validators.tf
+++ b/terraform/validators.tf
@@ -135,7 +135,7 @@ locals {
 }
 
 resource "aws_ebs_snapshot" "restore_snapshot" {
-  count = var.restore_vol_id == "" ? 0 : 1
+  count     = var.restore_vol_id == "" ? 0 : 1
   volume_id = var.restore_vol_id
 
   tags = {
@@ -151,7 +151,7 @@ resource "aws_instance" "validator" {
     aws_subnet.testnet.*.id,
     count.index % length(data.aws_availability_zones.available.names),
   )
-  depends_on                  = [aws_main_route_table_association.testnet, aws_iam_role_policy_attachment.ecs_extra]
+  depends_on                  = [aws_main_route_table_association.testnet, aws_iam_role_policy.ecs_extra]
   vpc_security_group_ids      = [aws_security_group.validator.id]
   associate_public_ip_address = local.instance_public_ip
   key_name                    = aws_key_pair.libra.key_name

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -2,6 +2,11 @@ variable "region" {
   default = "us-west-2"
 }
 
+variable "iam_path" {
+  default     = "/testnet/"
+  description = "Path to use when naming IAM objects"
+}
+
 variable "ssh_pub_key" {
   type        = string
   description = "SSH public key for EC2 instance access"


### PR DESCRIPTION
Set a configurable path for IAM objects:
https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_identifiers.html

This will allow AWS permissions to be scoped to these IAM objects to
better separation from global IAM objects.

Test Plan: Applied to my workspace