### PR TITLE
[Secure Storage] Added crypto key rotation support for secure storage implementations. 

### DIFF
--- a/secure/storage/src/error.rs
+++ b/secure/storage/src/error.rs
@@ -11,9 +11,9 @@ pub enum Error {
     EntropyError(String),
     #[error("Internal error: {0}")]
     InternalError(String),
-    #[error("Key not set: {0}")]
-    KeyAlreadyExists(String),
     #[error("Key already exists: {0}")]
+    KeyAlreadyExists(String),
+    #[error("Key not set: {0}")]
     KeyNotSet(String),
     #[error("Permission denied")]
     PermissionDenied,
@@ -21,6 +21,8 @@ pub enum Error {
     SerializationError(String),
     #[error("Unexpected value type")]
     UnexpectedValueType,
+    #[error("Key version not found: {0}")]
+    KeyVersionNotFound(String),
 }
 
 impl From<base64::DecodeError> for Error {

--- a/secure/storage/src/storage.rs
+++ b/secure/storage/src/storage.rs
@@ -2,7 +2,10 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::{Error, Policy, Value};
-use libra_crypto::{ed25519::Ed25519PrivateKey, ed25519::Ed25519PublicKey, PrivateKey, Uniform};
+use libra_crypto::{
+    ed25519::{Ed25519PrivateKey, Ed25519PublicKey, Ed25519Signature},
+    HashValue, PrivateKey, SigningKey, Uniform,
+};
 use rand::{rngs::OsRng, Rng, SeedableRng};
 
 /// Libra interface into storage. Create takes a policy that is enforced internally by the actual
@@ -47,28 +50,118 @@ pub trait Storage: Send + Sync {
     ///
     /// This default implementation is useful for storage engines that only implement the simple
     /// Storage interface. More complex engines (e.g., those that support native crypto key
-    /// generation), should override this implementation.
+    /// generation and rotation), should override this implementation.
     fn generate_new_ed25519_key_pair(
         &mut self,
         key_pair_name: &str,
         policy: &Policy,
     ) -> Result<Ed25519PublicKey, Error> {
-        let mut seed_rng = OsRng::new().map_err(|e| Error::EntropyError(e.to_string()))?;
-        let mut rng = rand::rngs::StdRng::from_seed(seed_rng.gen());
-        let private_key = Ed25519PrivateKey::generate_for_testing(&mut rng);
-        let public_key = private_key.public_key();
-        self.create(key_pair_name, Value::Ed25519PrivateKey(private_key), policy)
-            .map(|_| public_key)
+        // Generate and store the new named key pair
+        let (private_key, public_key) = new_ed25519_key_pair()?;
+        self.create(key_pair_name, Value::Ed25519PrivateKey(private_key), policy)?;
+
+        // Set the previous key pair version to be the newly generated key pair. This is useful so
+        // that we can also set the appropriate policy permissions on the previous key pair version
+        // now, and not have to do it later on a rotation.
+        self.create(
+            &get_previous_version_name(key_pair_name),
+            Value::Ed25519PrivateKey(self.get_private_key_for_name(key_pair_name)?),
+            policy,
+        )?;
+
+        Ok(public_key)
     }
 
-    /// Returns the corresponding public key for a given Ed25519 key pair, as identified by the
-    /// given 'key_pair_name'. If the key pair doesn't exist, or the caller doesn't have the
+    /// Returns the public key for a given Ed25519 key pair, as identified by the 'key_pair_name'.
+    /// If the key pair doesn't exist, or the caller doesn't have the
     /// appropriate permissions to retrieve the public key, this call will fail with an error.
-    fn get_public_key_for(&mut self, key_pair_name: &str) -> Result<Ed25519PublicKey, Error> {
+    fn get_public_key_for_name(&self, key_pair_name: &str) -> Result<Ed25519PublicKey, Error> {
+        self.get_private_key_for_name(key_pair_name)
+            .map(|e| e.public_key())
+    }
+
+    /// Returns the private key for a given Ed25519 key pair, as identified by the 'key_pair_name'.
+    /// If the key pair doesn't exist, or the caller doesn't have the appropriate permissions to
+    /// retrieve the private key, this call will fail with an error.
+    fn get_private_key_for_name(&self, key_pair_name: &str) -> Result<Ed25519PrivateKey, Error> {
         match self.get(key_pair_name)? {
-            Value::Ed25519PrivateKey(private_key) => Ok(private_key.public_key()),
+            Value::Ed25519PrivateKey(private_key) => Ok(private_key),
             _ => Err(Error::UnexpectedValueType),
         }
+    }
+
+    /// Returns the private key for a given Ed25519 key pair version, as identified by the
+    /// 'key_pair_name' and 'key_pair_version'. If the key pair at the specified version doesn't
+    /// exist, or the caller doesn't have the appropriate permissions to retrieve the private key,
+    /// this call will fail with an error.
+    fn get_private_key_for_name_and_version(
+        &self,
+        key_pair_name: &str,
+        key_pair_version: Ed25519PublicKey,
+    ) -> Result<Ed25519PrivateKey, Error> {
+        let current_private_key = self.get_private_key_for_name(key_pair_name)?;
+        if current_private_key.public_key().eq(&key_pair_version) {
+            return Ok(current_private_key);
+        }
+
+        let previous_private_key =
+            self.get_private_key_for_name(&get_previous_version_name(key_pair_name))?;
+        if previous_private_key.public_key().eq(&key_pair_version) {
+            return Ok(previous_private_key);
+        }
+
+        Err(Error::KeyVersionNotFound(key_pair_version.to_string()))
+    }
+
+    /// Rotates an Ed25519 key pair by generating a new Ed25519 key pair, and updating the
+    /// 'key_pair_name' to reference the freshly generated key. The previous key pair is retained
+    /// in storage if needed. If multiple key rotations occur over the lifetime of a key pair, only
+    /// two versions of the key pair are maintained (i.e., the current and previous one).
+    /// If the key pair doesn't exist, or the caller doesn't have the appropriate permissions to
+    /// retrieve the public key, this call will fail with an error. Otherwise, the new public
+    /// key for the rotated key pair is returned.
+    fn rotate_key_pair(&mut self, key_pair_name: &str) -> Result<Ed25519PublicKey, Error> {
+        match self.get(key_pair_name)? {
+            Value::Ed25519PrivateKey(private_key) => {
+                let (new_private_key, new_public_key) = new_ed25519_key_pair()?;
+                self.set(
+                    &get_previous_version_name(key_pair_name),
+                    Value::Ed25519PrivateKey(private_key),
+                )?;
+                self.set(key_pair_name, Value::Ed25519PrivateKey(new_private_key))?;
+                Ok(new_public_key)
+            }
+            _ => Err(Error::UnexpectedValueType),
+        }
+    }
+
+    /// Signs the given message using the private key associated with the given 'key_pair_name'.
+    /// If the key pair doesn't exist, or the caller doesn't have the appropriate
+    /// permissions to retrieve and use the public key, this call will fail with an error.
+    fn sign_message(
+        &mut self,
+        key_pair_name: &str,
+        message: &HashValue,
+    ) -> Result<Ed25519Signature, Error> {
+        let private_key = self.get_private_key_for_name(key_pair_name)?;
+        Ok(private_key.sign_message(message))
+    }
+
+    /// Signs the given message using the private key associated with the given 'key_pair_name'
+    /// and 'key_pair_version'. If the key pair doesn't exist, or the caller doesn't have the
+    /// appropriate permissions to perform the operation, this call will fail with an error.
+    /// Note: the 'key_pair_version' is specified using the public key associated with a key pair.
+    /// Only two versions of a key pair are ever maintained at any given time (i.e., the
+    /// current version, and the previous version).
+    fn sign_message_using_version(
+        &mut self,
+        key_pair_name: &str,
+        key_pair_version: Ed25519PublicKey,
+        message: &HashValue,
+    ) -> Result<Ed25519Signature, Error> {
+        let private_key =
+            self.get_private_key_for_name_and_version(key_pair_name, key_pair_version)?;
+        Ok(private_key.sign_message(message))
     }
 
     /// Resets and clears all data held in the storage engine.
@@ -76,4 +169,19 @@ pub trait Storage: Send + Sync {
     /// something that should be supported in production.
     #[cfg(test)]
     fn reset_and_clear(&mut self) -> Result<(), Error>;
+}
+
+/// Helper method to generate a new ed25519 key pair using entropy from the OS.
+fn new_ed25519_key_pair() -> Result<(Ed25519PrivateKey, Ed25519PublicKey), Error> {
+    let mut seed_rng = OsRng::new().map_err(|e| Error::EntropyError(e.to_string()))?;
+    let mut rng = rand::rngs::StdRng::from_seed(seed_rng.gen());
+    let private_key = Ed25519PrivateKey::generate_for_testing(&mut rng);
+    let public_key = private_key.public_key();
+    Ok((private_key, public_key))
+}
+
+/// Helper method to get the name of the previous version of the given key pair, as held in
+/// secure storage.
+fn get_previous_version_name(key_pair_name: &str) -> String {
+    format!("{}_previous", key_pair_name)
 }


### PR DESCRIPTION
## Motivation

This PR works towards providing appropriate key management for Validator nodes (as discussed in [Validator Key Management](https://github.com/libra/libra/issues/2332)). In this PR, we extend the API provided by secure storage to support cryptographic key rotation and signing*.

In this PR, we offer a single commit, that:

1). Adds additional API calls to secure storage. These include: rotate_key_pair(...), sign_message(...), sign_message_with_version(...), and get_private_key_for_name_and_version(...).
2). Adds appropriate tests to test the new API functionality.
3). Renames the API call 'get_public_key_for(...)' to 'get_public_key_for_name(...)' to ensure consistent naming across API calls.

*Note: In this PR, we don't use the vault specific functionalities for handling cryptographic keys (i.e., Vault Transit). Instead, we just leverage the Key/Value support. A future PR will implement the vault specific implementation using Transit.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?

Yes.

## Test Plan

All local tests seem to pass (including those that were added by this PR).

## Related PRs

This PR builds on https://github.com/libra/libra/pull/2641.
