### PR TITLE
[language][vm] check for overflow when casting from a wider integer type into a narrower one

### DIFF
--- a/language/ir-testsuite/tests/operators/casting_operators.mvir
+++ b/language/ir-testsuite/tests/operators/casting_operators.mvir
@@ -15,15 +15,9 @@ main() {
     assert(to_u8(255u64) == 255u8, 1201);
     assert(to_u8(255u128) == 255u8, 1202);
 
-    // Truncates (wraps) when overflowing.
-    assert(to_u8(256u64) == 0u8, 1300);
-    assert(to_u8(287u128) == 31u8, 1301);
-
-    // Truncating extreme values.
-    assert(to_u8(18446744073709551615u64) == 255u8, 1400);
-    assert(to_u8(340282366920938463463374607431768211455u128) == 255u8, 1400);
     return;
 }
+// check: EXECUTED
 
 // Casting to u64.
 //! new-transaction
@@ -42,15 +36,9 @@ main() {
     assert(to_u64(255u8) == 255u64, 2200);
     assert(to_u64(18446744073709551615u64) == 18446744073709551615u64, 2201);
     assert(to_u64(18446744073709551615u128) == 18446744073709551615u64, 2202);
-
-    // Truncates (wraps) when overflowing.
-    assert(to_u64(18446744073709551616u128) == 0u64, 2300);
-    assert(to_u64(18446744073709551647u128) == 31u64, 2301);
-
-    // Truncating extreme values.
-    assert(to_u64(340282366920938463463374607431768211455u128) == 18446744073709551615u64, 2400);
     return;
 }
+// check: EXECUTED
 
 // Casting to u128.
 //! new-transaction
@@ -71,3 +59,71 @@ main() {
     assert(to_u128(340282366920938463463374607431768211455u128) == 340282366920938463463374607431768211455u128, 3202);
     return;
 }
+// check: EXECUTED
+
+
+// Casting to u8, overflowing.
+//! new-transaction
+main() {
+    _ = to_u8(256u64);
+    return;
+}
+// check: ARITHMETIC_ERROR
+
+//! new-transaction
+main() {
+    _ = to_u8(303u64);
+    return;
+}
+// check: ARITHMETIC_ERROR
+
+//! new-transaction
+main() {
+    _ = to_u8(256u128);
+    return;
+}
+// check: ARITHMETIC_ERROR
+
+//! new-transaction
+main() {
+    _ = to_u8(56432u128);
+    return;
+}
+// check: ARITHMETIC_ERROR
+
+//! new-transaction
+main() {
+    _ = to_u8(18446744073709551615u64);
+    return;
+}
+// check: ARITHMETIC_ERROR
+
+//! new-transaction
+main() {
+    _ = to_u8(340282366920938463463374607431768211455u128);
+    return;
+}
+// check: ARITHMETIC_ERROR
+
+
+// Casting to u64, overflowing.
+//! new-transaction
+main() {
+    _ = to_u64(18446744073709551616u128);
+    return;
+}
+// check: ARITHMETIC_ERROR
+
+//! new-transaction
+main() {
+    _ = to_u64(18446744073709551647u128);
+    return;
+}
+// check: ARITHMETIC_ERROR
+
+//! new-transaction
+main() {
+    _ = to_u64(340282366920938463463374607431768211455u128);
+    return;
+}
+// check: ARITHMETIC_ERROR

--- a/language/move-vm/types/src/values/values_impl.rs
+++ b/language/move-vm/types/src/values/values_impl.rs
@@ -1260,36 +1260,56 @@ impl IntegerValue {
     }
 }
 
-impl From<IntegerValue> for u8 {
-    fn from(value: IntegerValue) -> u8 {
+impl IntegerValue {
+    pub fn cast_u8(self) -> VMResult<u8> {
         use IntegerValue::*;
-        match value {
-            U8(x) => x as u8,
-            U64(x) => x as u8,
-            U128(x) => x as u8,
+
+        match self {
+            U8(x) => Ok(x),
+            U64(x) => {
+                if x > (std::u8::MAX as u64) {
+                    Err(VMStatus::new(StatusCode::ARITHMETIC_ERROR)
+                        .with_message(format!("Cannot cast u64({}) to u8", x)))
+                } else {
+                    Ok(x as u8)
+                }
+            }
+            U128(x) => {
+                if x > (std::u8::MAX as u128) {
+                    Err(VMStatus::new(StatusCode::ARITHMETIC_ERROR)
+                        .with_message(format!("Cannot cast u128({}) to u8", x)))
+                } else {
+                    Ok(x as u8)
+                }
+            }
         }
     }
-}
 
-impl From<IntegerValue> for u64 {
-    fn from(value: IntegerValue) -> u64 {
+    pub fn cast_u64(self) -> VMResult<u64> {
         use IntegerValue::*;
-        match value {
-            U8(x) => x as u64,
-            U64(x) => x as u64,
-            U128(x) => x as u64,
+
+        match self {
+            U8(x) => Ok(x as u64),
+            U64(x) => Ok(x),
+            U128(x) => {
+                if x > (std::u64::MAX as u128) {
+                    Err(VMStatus::new(StatusCode::ARITHMETIC_ERROR)
+                        .with_message(format!("Cannot cast u128({}) to u64", x)))
+                } else {
+                    Ok(x as u64)
+                }
+            }
         }
     }
-}
 
-impl From<IntegerValue> for u128 {
-    fn from(value: IntegerValue) -> u128 {
+    pub fn cast_u128(self) -> VMResult<u128> {
         use IntegerValue::*;
-        match value {
+
+        Ok(match self {
             U8(x) => x as u128,
             U64(x) => x as u128,
-            U128(x) => x as u128,
-        }
+            U128(x) => x,
+        })
     }
 }
 

--- a/language/vm/vm-runtime/src/interpreter.rs
+++ b/language/vm/vm-runtime/src/interpreter.rs
@@ -453,17 +453,20 @@ impl<'txn> Interpreter<'txn> {
                     Bytecode::CastU8 => {
                         gas!(const_instr: context, self, Opcodes::CAST_U8)?;
                         let integer_value = self.operand_stack.pop_as::<IntegerValue>()?;
-                        self.operand_stack.push(Value::u8(integer_value.into()))?;
+                        self.operand_stack
+                            .push(Value::u8(integer_value.cast_u8()?))?;
                     }
                     Bytecode::CastU64 => {
                         gas!(const_instr: context, self, Opcodes::CAST_U64)?;
                         let integer_value = self.operand_stack.pop_as::<IntegerValue>()?;
-                        self.operand_stack.push(Value::u64(integer_value.into()))?;
+                        self.operand_stack
+                            .push(Value::u64(integer_value.cast_u64()?))?;
                     }
                     Bytecode::CastU128 => {
                         gas!(const_instr: context, self, Opcodes::CAST_U128)?;
                         let integer_value = self.operand_stack.pop_as::<IntegerValue>()?;
-                        self.operand_stack.push(Value::u128(integer_value.into()))?;
+                        self.operand_stack
+                            .push(Value::u128(integer_value.cast_u128()?))?;
                     }
                     // Arithmetic Operations
                     Bytecode::Add => {


### PR DESCRIPTION
## Summary
Right now when converting an integer value from a wider integer type into a narrower one, if the value is greater than the maximum representable value of the narrower type, we truncate the value. This can lead to surprising behaviors and does not align with Move's goal to be a secure language.

## Test Plan
cargo test