### PR TITLE
[storage] Downgrade GRPC logs to trace

### DIFF
--- a/storage/storage-service/src/lib.rs
+++ b/storage/storage-service/src/lib.rs
@@ -230,7 +230,7 @@ impl Storage for StorageService {
         &self,
         request: tonic::Request<SaveTransactionsRequest>,
     ) -> Result<tonic::Response<SaveTransactionsResponse>, tonic::Status> {
-        debug!("[GRPC] Storage::save_transactions");
+        trace!("[GRPC] Storage::save_transactions");
         let req = request.into_inner();
         let resp = self
             .save_transactions_inner(req)
@@ -242,7 +242,7 @@ impl Storage for StorageService {
         &self,
         request: tonic::Request<UpdateToLatestLedgerRequest>,
     ) -> Result<tonic::Response<UpdateToLatestLedgerResponse>, tonic::Status> {
-        debug!("[GRPC] Storage::update_to_latest_ledger");
+        trace!("[GRPC] Storage::update_to_latest_ledger");
         let req = request.into_inner();
         let resp = self
             .update_to_latest_ledger_inner(req)
@@ -254,7 +254,7 @@ impl Storage for StorageService {
         &self,
         request: tonic::Request<GetTransactionsRequest>,
     ) -> Result<tonic::Response<GetTransactionsResponse>, tonic::Status> {
-        debug!("[GRPC] Storage::get_transactions");
+        trace!("[GRPC] Storage::get_transactions");
         let req = request.into_inner();
         let resp = self
             .get_transactions_inner(req)
@@ -266,7 +266,7 @@ impl Storage for StorageService {
         &self,
         request: tonic::Request<GetLatestStateRootRequest>,
     ) -> Result<tonic::Response<GetLatestStateRootResponse>, tonic::Status> {
-        debug!("[GRPC] Storage::get_latest_state_root");
+        trace!("[GRPC] Storage::get_latest_state_root");
         let req = request.into_inner();
         let resp = self
             .get_latest_state_root_inner(req)
@@ -278,7 +278,7 @@ impl Storage for StorageService {
         &self,
         request: tonic::Request<GetLatestAccountStateRequest>,
     ) -> Result<tonic::Response<GetLatestAccountStateResponse>, tonic::Status> {
-        debug!("[GRPC] Storage::get_latest_account_state");
+        trace!("[GRPC] Storage::get_latest_account_state");
         let req = request.into_inner();
         let resp = self
             .get_latest_account_state_inner(req)
@@ -290,7 +290,7 @@ impl Storage for StorageService {
         &self,
         request: tonic::Request<GetAccountStateWithProofByVersionRequest>,
     ) -> Result<tonic::Response<GetAccountStateWithProofByVersionResponse>, tonic::Status> {
-        debug!("[GRPC] Storage::get_account_state_with_proof_by_version");
+        trace!("[GRPC] Storage::get_account_state_with_proof_by_version");
         let req = request.into_inner();
         let resp = self
             .get_account_state_with_proof_by_version_inner(req)
@@ -302,7 +302,7 @@ impl Storage for StorageService {
         &self,
         _request: tonic::Request<GetStartupInfoRequest>,
     ) -> Result<tonic::Response<GetStartupInfoResponse>, tonic::Status> {
-        debug!("[GRPC] Storage::get_startup_info");
+        trace!("[GRPC] Storage::get_startup_info");
         let resp = self
             .get_startup_info_inner()
             .map_err(|e| tonic::Status::new(tonic::Code::InvalidArgument, e.to_string()))?;
@@ -313,7 +313,7 @@ impl Storage for StorageService {
         &self,
         request: tonic::Request<GetEpochChangeLedgerInfosRequest>,
     ) -> Result<tonic::Response<ValidatorChangeProof>, tonic::Status> {
-        debug!("[GRPC] Storage::get_epoch_change_ledger_infos");
+        trace!("[GRPC] Storage::get_epoch_change_ledger_infos");
         let req = request.into_inner();
         let resp = self
             .get_epoch_change_ledger_infos_inner(req)
@@ -328,7 +328,7 @@ impl Storage for StorageService {
         &self,
         request: tonic::Request<BackupAccountStateRequest>,
     ) -> Result<tonic::Response<Self::BackupAccountStateStream>, tonic::Status> {
-        debug!("[GRPC] Storage::backup_account_state");
+        trace!("[GRPC] Storage::backup_account_state");
         let req = request.into_inner();
         let iter = self
             .db
@@ -361,7 +361,7 @@ impl Storage for StorageService {
         &self,
         request: tonic::Request<GetAccountStateRangeProofRequest>,
     ) -> Result<tonic::Response<GetAccountStateRangeProofResponse>, tonic::Status> {
-        debug!("[GRPC] Storage::get_account_state_range_proof");
+        trace!("[GRPC] Storage::get_account_state_range_proof");
         let req = request.into_inner();
         let resp = self
             .get_account_state_range_proof_inner(req)
@@ -375,7 +375,7 @@ impl Storage for StorageService {
         &self,
         request: tonic::Request<BackupTransactionRequest>,
     ) -> Result<tonic::Response<Self::BackupTransactionStream>, tonic::Status> {
-        debug!("[GRPC] Storage::backup_transaction");
+        trace!("[GRPC] Storage::backup_transaction");
         let req = request.into_inner();
 
         let backup_handler = self.db.get_backup_handler();
@@ -421,7 +421,7 @@ impl Storage for StorageService {
         &self,
         request: tonic::Request<BackupTransactionInfoRequest>,
     ) -> Result<tonic::Response<Self::BackupTransactionInfoStream>, tonic::Status> {
-        debug!("[GRPC] Storage::backup_transaction_info");
+        trace!("[GRPC] Storage::backup_transaction_info");
         let req = request.into_inner();
 
         let backup_handler = self.db.get_backup_handler();


### PR DESCRIPTION
## Summary

In our current setup, we log at debug level and the storage GRPC log messages are extremely noisy. We have noticed perf issues before when we were logging too much. Fewer logs also helps debugging.