### PR TITLE
[dependency update] Bitvec 0.17.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -312,8 +312,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "bitvec"
-version = "0.10.2"
+version = "0.17.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "either 1.5.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "radium 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
 
 [[package]]
 name = "blake2"
@@ -2221,7 +2225,7 @@ name = "libra-crypto"
 version = "0.1.0"
 dependencies = [
  "anyhow 1.0.26 (registry+https://github.com/rust-lang/crates.io-index)",
- "bitvec 0.10.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "bitvec 0.17.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "byteorder 1.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "bytes 0.5.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "criterion 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -3706,6 +3710,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "proc-macro2 1.0.9 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
+
+[[package]]
+name = "radium"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "radix_trie"
@@ -6491,7 +6500,7 @@ dependencies = [
 "checksum bit-vec 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)" = "f59bbe95d4e52a6398ec21238d31577f2b28a9d86807f06ca59d191d8440d0bb"
 "checksum bit-vec 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)" = "a4523a10839ffae575fb08aa3423026c8cb4687eef43952afb956229d4f246f7"
 "checksum bitflags 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "cf1de2fe8c75bc145a2f577add951f8134889b4795d47466a54a5c846d691693"
-"checksum bitvec 0.10.2 (registry+https://github.com/rust-lang/crates.io-index)" = "284495959f63520b015b41f8e2a0627af935345ea558ae779b354e8f98c966fa"
+"checksum bitvec 0.17.2 (registry+https://github.com/rust-lang/crates.io-index)" = "1fe4300c1d7a9ea6f3e3f39c10b39862bb79e1175c0572b6b49539a30e5562f5"
 "checksum blake2 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)" = "94cb07b0da6a73955f8fb85d24c466778e70cda767a568229b104f0264089330"
 "checksum blake2-rfc 0.2.18 (registry+https://github.com/rust-lang/crates.io-index)" = "5d6d530bdd2d52966a6d03b7a964add7ae1a288d25214066fd4b600f0f796400"
 "checksum blake2b_simd 0.5.10 (registry+https://github.com/rust-lang/crates.io-index)" = "d8fb2d74254a3a0b5cac33ac9f8ed0e44aa50378d9dbb2e5d83bd21ed1dc2c8a"
@@ -6736,6 +6745,7 @@ dependencies = [
 "checksum quick-error 1.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "a1d01941d82fa2ab50be1e79e6714289dd7cde78eba4c074bc5a4374f650dfe0"
 "checksum quote 0.6.13 (registry+https://github.com/rust-lang/crates.io-index)" = "6ce23b6b870e8f94f81fb0a363d65d86675884b34a09043c81e5562f11c1f8e1"
 "checksum quote 1.0.3 (registry+https://github.com/rust-lang/crates.io-index)" = "2bdc6c187c65bca4260c9011c9e3132efe4909da44726bad24cf7572ae338d7f"
+"checksum radium 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "def50a86306165861203e7f84ecffbbdfdea79f0e51039b33de1e952358c47ac"
 "checksum radix_trie 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)" = "3d3681b28cd95acfb0560ea9441f82d6a4504fa3b15b97bd7b6e952131820e95"
 "checksum rand 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)" = "552840b97013b1a26992c11eac34bdd778e464601a4c2054b5f0bff7c6761293"
 "checksum rand 0.5.6 (registry+https://github.com/rust-lang/crates.io-index)" = "c618c47cd3ebd209790115ab837de41425723956ad3ce2e6a7f09890947cacb9"

--- a/crypto/crypto/Cargo.toml
+++ b/crypto/crypto/Cargo.toml
@@ -37,7 +37,7 @@ lcs = { path = "../../common/lcs", version = "0.1.0", package = "libra-canonical
 libra-nibble = { path = "../../common/nibble", version = "0.1.0" }
 
 [dev-dependencies]
-bitvec = "0.10.2"
+bitvec = "0.17.2"
 byteorder = "1.3.2"
 proptest = "0.9.1"
 proptest-derive = "0.1.0"

--- a/crypto/crypto/src/unit_tests/hash_test.rs
+++ b/crypto/crypto/src/unit_tests/hash_test.rs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::hash::*;
-use bitvec::BitVec;
+use bitvec::prelude::*;
 use byteorder::{LittleEndian, WriteBytesExt};
 use proptest::{collection::vec, prelude::*};
 use rand::{rngs::StdRng, SeedableRng};
@@ -222,7 +222,7 @@ fn test_common_prefix_nibbles_len() {
 proptest! {
     #[test]
     fn test_hashvalue_to_bits_roundtrip(hash in any::<HashValue>()) {
-        let bitvec: BitVec = hash.iter_bits().collect();
+        let bitvec: BitVec<Msb0, u8>  = hash.iter_bits().collect();
         let bytes: Vec<u8> = bitvec.into();
         let hash2 = HashValue::from_slice(&bytes).unwrap();
         prop_assert_eq!(hash, hash2);
@@ -230,7 +230,7 @@ proptest! {
 
     #[test]
     fn test_hashvalue_to_bits_inverse_roundtrip(bits in vec(any::<bool>(), HashValue::LENGTH_IN_BITS)) {
-        let bitvec: BitVec = bits.iter().cloned().collect();
+        let bitvec: BitVec<Msb0, u8> = bits.iter().cloned().collect();
         let bytes: Vec<u8> = bitvec.into();
         let hash = HashValue::from_slice(&bytes).unwrap();
         let bits2: Vec<bool> = hash.iter_bits().collect();
@@ -247,7 +247,7 @@ proptest! {
 
     #[test]
     fn test_hashvalue_to_rev_bits_roundtrip(hash in any::<HashValue>()) {
-        let bitvec: BitVec<bitvec::LittleEndian> = hash.iter_bits().rev().collect();
+        let bitvec: BitVec<Lsb0, u8> = hash.iter_bits().rev().collect();
         let mut bytes: Vec<u8> = bitvec.into();
         bytes.reverse();
         let hash2 = HashValue::from_slice(&bytes).unwrap();


### PR DESCRIPTION
## Motivation

Latest deps before locking down (though this is test only).
Learning rust.

### Have you read the [Contributing Guidelines on pull requests]\

Yes

## Test Plan

build, test, lint

## Related PRs

https://github.com/libra/libra/pull/2587
Bitvec-0.17.2 which this extends, and will be closed by dependabot once this lands.