### PR TITLE
[execution] Remove very large log line

### DIFF
--- a/execution/executor/src/lib.rs
+++ b/execution/executor/src/lib.rs
@@ -391,7 +391,7 @@ where
             .cloned()
             .collect();
         if !status.is_empty() {
-            debug!("Execution status: {:?}", status);
+            trace!("Execution status: {:?}", status);
         }
 
         let (account_to_state, account_to_proof) = state_view.into();


### PR DESCRIPTION
## Summary

This is producing very large log lines (each line is 75KB) which doesn't seem to contain any useful data : https://pastebin.com/raw/NRUWYCWy

This was first introduced in this PR https://github.com/libra/libra/pull/1733/
