### PR TITLE
[client] add support for registering validator

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -652,6 +652,7 @@ dependencies = [
  "libra-types 0.1.0",
  "libra-wallet 0.1.0",
  "num-traits 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
+ "parity-multiaddr 0.7.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "proptest 0.9.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "reqwest 0.10.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "rust_decimal 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/client/cli/Cargo.toml
+++ b/client/cli/Cargo.toml
@@ -19,6 +19,7 @@ proptest = { version = "0.9.2", optional = true }
 rustyline = "6.0.0"
 rust_decimal = "1.3.0"
 num-traits = "0.2"
+parity-multiaddr = { version = "0.7.2", default-features = false }
 reqwest = { version = "0.10.4", features = ["blocking"], default-features = false }
 serde = { version = "1.0.96", features = ["derive"] }
 serde_json = "1.0.48"

--- a/client/cli/src/dev_commands.rs
+++ b/client/cli/src/dev_commands.rs
@@ -27,6 +27,7 @@ impl Command for DevCommand {
             Box::new(DevCommandAddValidator {}),
             Box::new(DevCommandRemoveValidator {}),
             Box::new(DevCommandGenWaypoint {}),
+            Box::new(DevCommandRegisterValidator {}),
         ];
         subcommand_execute(&params[0], commands, client, &params[1..]);
     }
@@ -213,6 +214,32 @@ impl Command for DevCommandGenWaypoint {
                 li_time_str,
                 waypoint
             ),
+        }
+    }
+}
+
+pub struct DevCommandRegisterValidator {}
+
+impl Command for DevCommandRegisterValidator {
+    fn get_aliases(&self) -> Vec<&'static str> {
+        vec!["register_validator"]
+    }
+    fn get_params_help(&self) -> &'static str {
+        "<validator_account_address> <validator_account_private_key> <consensus_public_key> <network_signing_key> <network_identity_key> <network_address> <fullnode_identity_key> <fullnode_network_address>"
+    }
+
+    fn get_description(&self) -> &'static str {
+        "Register an account address as validator candidate with necessary data, it's up to association to add them to the network"
+    }
+
+    fn execute(&self, client: &mut ClientProxy, params: &[&str]) {
+        if params.len() != 9 {
+            println!("Invalid number of arguments to register validator");
+            return;
+        }
+        match client.register_validator(params, true) {
+            Ok(_) => println!("Successfully finished execution"),
+            Err(e) => println!("{}", e),
         }
     }
 }


### PR DESCRIPTION
<!--
Thank you for sending a PR. We appreciate you spending time to help improve the Libra project.

The project is undergoing daily changes. Pull Requests will be reviewed and responded to as time permits.
-->

## Motivation

Support registering validator script in client. It's gated by mint_key now, but wonder if we should open this script the same as transfer.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?

Y

## Test Plan

test in dev net, register a validator not in genesis and add it to the network. will follow up with a smoke test.

## Related PRs

(If this PR adds or changes functionality, please take some time to update the docs at https://github.com/libra/website, and link to your PR here.)
