### PR TITLE
[cluster-test][k8s] Stream validator/fullnode logs to elasticsearch

### DIFF
--- a/scripts/cti
+++ b/scripts/cti
@@ -16,6 +16,10 @@ K8S=""
 K8S_POOL_SIZE="3"
 K8S_CONTEXT_PATTERN='arn:aws:eks:us-west-2:853397791086:cluster/CLUSTERNAME-k8s-testnet'
 
+# Colorize Output
+RESTORE=$(echo -en '\001\033[0m\002')
+BLUE=$(echo -en '\001\033[01;34m\002')
+
 join_args() {
   retval_join_args=""
   for var in $*
@@ -217,10 +221,13 @@ else
   kubectl --context=${context} apply -f ${specfile} || (echo "Failed to create cluster-test pod"; exit 1)
   kube_wait_pod ${pod_name} ${context}
   echo "**********"
-  echo "Copy of this output: $OUTPUT_TEE"
-  echo "Dashboard: http://grafana.${WORKSPACE}-k8s-testnet.aws.hlw3truzy4ls.com/"
+  echo "${BLUE}Dashboard:${RESTORE} http://grafana.${WORKSPACE}-k8s-testnet.aws.hlw3truzy4ls.com/"
   echo "Dashboard Username: admin. Password: $(kubectl get secret grafana-admin-credentials -o jsonpath="{.data.admin-password}" | base64 --decode)"
-  echo "Kibana: http://kibana.${WORKSPACE}-k8s-testnet.aws.hlw3truzy4ls.com/"
+  echo "${BLUE}'validator-0' Logs:${RESTORE} http://kibana.${WORKSPACE}-k8s-testnet.aws.hlw3truzy4ls.com/app/kibana#/discover?_g=(filters:!(),refreshInterval:(pause:!t,value:0),time:(from:now-15m,to:now))&_a=(columns:!(log,kubernetes.pod_name),filters:!(('\$state':(store:appState),meta:(alias:!n,disabled:!f,key:kubernetes.pod_name,negate:!f,params:(query:validator-0),type:phrase),query:(match:(kubernetes.pod_name:(query:validator-0,type:phrase))))),interval:auto,query:(language:kuery,query:''),sort:!(!('@timestamp',desc)))"
+  echo
+  echo "${BLUE}'fullnode-0-0' Logs:${RESTORE} http://kibana.${WORKSPACE}-k8s-testnet.aws.hlw3truzy4ls.com/app/kibana#/discover?_g=(filters:!(),refreshInterval:(pause:!t,value:0),time:(from:now-15m,to:now))&_a=(columns:!(log,kubernetes.pod_name),filters:!(('\$state':(store:appState),meta:(alias:!n,disabled:!f,key:kubernetes.pod_name,negate:!f,params:(query:fullnode-0-0),type:phrase),query:(match:(kubernetes.pod_name:(query:fullnode-0-0,type:phrase))))),interval:auto,query:(language:kuery,query:''),sort:!(!('@timestamp',desc)))"
+  echo
+  echo "${BLUE}Note:${RESTORE} Because of log volume, logs for only some of the validators and fullnodes are streamed to Kibana."
   echo "**********"
   kubectl --context=${context} logs -f "${pod_name}" | tee $OUTPUT_TEE
 fi

--- a/testsuite/cluster-test/src/cluster_swarm/cluster_swarm_kube.rs
+++ b/testsuite/cluster-test/src/cluster_swarm/cluster_swarm_kube.rs
@@ -65,6 +65,7 @@ impl ClusterSwarmKube {
         } else {
             ""
         };
+        let fluentbit_enabled = if index % 10 == 0 { "true" } else { "false" };
         let pod_yaml = format!(
             include_str!("validator_spec_template.yaml"),
             index = index,
@@ -76,6 +77,7 @@ impl ClusterSwarmKube {
             delete_data = delete_data,
             cfg_seed = CFG_SEED,
             cfg_fullnode_seed = cfg_fullnode_seed,
+            fluentbit_enabled = fluentbit_enabled,
         );
         let pod_spec: serde_yaml::Value = serde_yaml::from_str(&pod_yaml)?;
         serde_json::to_vec(&pod_spec).map_err(|e| format_err!("serde_json::to_vec failed: {}", e))
@@ -91,6 +93,11 @@ impl ClusterSwarmKube {
         image_tag: &str,
         delete_data: bool,
     ) -> Result<Vec<u8>> {
+        let fluentbit_enabled = if validator_index % 10 == 0 {
+            "true"
+        } else {
+            "false"
+        };
         let pod_yaml = format!(
             include_str!("fullnode_spec_template.yaml"),
             fullnode_index = fullnode_index,
@@ -103,6 +110,7 @@ impl ClusterSwarmKube {
             delete_data = delete_data,
             cfg_seed = CFG_SEED,
             cfg_fullnode_seed = CFG_FULLNODE_SEED,
+            fluentbit_enabled = fluentbit_enabled,
         );
         let pod_spec: serde_yaml::Value = serde_yaml::from_str(&pod_yaml)?;
         serde_json::to_vec(&pod_spec).map_err(|e| format_err!("serde_json::to_vec failed: {}", e))

--- a/testsuite/cluster-test/src/cluster_swarm/fullnode_spec_template.yaml
+++ b/testsuite/cluster-test/src/cluster_swarm/fullnode_spec_template.yaml
@@ -30,6 +30,40 @@ spec:
       if [[ {delete_data} = true ]]; then
         rm -rf /opt/libra/data/*
       fi
+      if [[ {fluentbit_enabled} = true ]]; then
+        libra_log_file="libra.log"
+      else
+        libra_log_file="non_existent_file"
+      fi
+      cat << EOF > /opt/libra/data/fluent-bit.conf
+      [SERVICE]
+          Flush         5
+          Log_Level     info
+          Daemon        off
+
+      [INPUT]
+          Name              tail
+          Tag               validator
+          Path              /opt/libra/data/${{libra_log_file}}
+          Mem_Buf_Limit     5MB
+          Refresh_Interval  10
+          Skip_Long_Lines   On
+
+      [FILTER]
+          Name record_modifier
+          Match *
+          Record kubernetes.pod_name fullnode-{validator_index}-{fullnode_index}
+
+      [OUTPUT]
+          Name            es
+          Match           *
+          Host            elasticsearch-master
+          Port            9200
+          Logstash_Format On
+          Replace_Dots    Off
+          Retry_Limit     False
+          Logstash_Prefix kubernetes_cluster
+      EOF
       CFG_SEED_PEER_IP=$(kubectl get pod/validator-{validator_index} -o=jsonpath='{{.status.podIP}}');
       while [ -z "${{CFG_SEED_PEER_IP}}" ]; do
         sleep 5;
@@ -38,6 +72,13 @@ spec:
       done;
       echo -n "${{CFG_SEED_PEER_IP}}" > /opt/libra/data/seed_peer_ip
   containers:
+  - name: fluent-bit
+    image: 853397791086.dkr.ecr.us-west-2.amazonaws.com/fluent-bit:1.3.9
+    imagePullPolicy: IfNotPresent
+    command: ["/fluent-bit/bin/fluent-bit", "-c", "/opt/libra/data/fluent-bit.conf"]
+    volumeMounts:
+    - mountPath: /opt/libra/data
+      name: data
   - name: main
     image: 853397791086.dkr.ecr.us-west-2.amazonaws.com/libra_validator:{image_tag}
     imagePullPolicy: Always

--- a/testsuite/cluster-test/src/cluster_swarm/validator_spec_template.yaml
+++ b/testsuite/cluster-test/src/cluster_swarm/validator_spec_template.yaml
@@ -30,6 +30,40 @@ spec:
       if [[ {delete_data} = true ]]; then
         rm -rf /opt/libra/data/*
       fi
+      if [[ {fluentbit_enabled} = true ]]; then
+        libra_log_file="libra.log"
+      else
+        libra_log_file="non_existent_file"
+      fi
+      cat << EOF > /opt/libra/data/fluent-bit.conf
+      [SERVICE]
+          Flush         5
+          Log_Level     info
+          Daemon        off
+
+      [INPUT]
+          Name              tail
+          Tag               validator
+          Path              /opt/libra/data/${{libra_log_file}}
+          Mem_Buf_Limit     5MB
+          Refresh_Interval  10
+          Skip_Long_Lines   On
+
+      [FILTER]
+          Name record_modifier
+          Match *
+          Record kubernetes.pod_name validator-{index}
+
+      [OUTPUT]
+          Name            es
+          Match           *
+          Host            elasticsearch-master
+          Port            9200
+          Logstash_Format On
+          Replace_Dots    Off
+          Retry_Limit     False
+          Logstash_Prefix kubernetes_cluster
+      EOF
       CFG_SEED_PEER_IP=$(kubectl get pod/validator-0 -o=jsonpath='{{.status.podIP}}');
       while [ -z "${{CFG_SEED_PEER_IP}}" ]; do
         sleep 5;
@@ -42,6 +76,13 @@ spec:
         echo "Waiting for all validator pods to be scheduled";
       done
   containers:
+  - name: fluent-bit
+    image: 853397791086.dkr.ecr.us-west-2.amazonaws.com/fluent-bit:1.3.9
+    imagePullPolicy: IfNotPresent
+    command: ["/fluent-bit/bin/fluent-bit", "-c", "/opt/libra/data/fluent-bit.conf"]
+    volumeMounts:
+    - mountPath: /opt/libra/data
+      name: data
   - name: main
     image: 853397791086.dkr.ecr.us-west-2.amazonaws.com/libra_validator:{image_tag}
     imagePullPolicy: Always


### PR DESCRIPTION
## Summary

* Stream logs from validator/fullnode to elasticsearch
* Use sampling to reduce log volume - we only send logs from 10% of the validator and fullnode instances (validator-0 , validator-10, validator-20, etc.)
  * Without sampling, elasticsearch setup gets overloaded and starts rate limiting the agents. Right now we use a 3 node elastic search cluster per cluster-test environment. Without sampling we would need about 15 node elastic search cluster per cluster-test environment to handle the log volume produced by a 100 node libra cluster.
* Print link to validator and fullnode logs in cti command