### PR TITLE
[JSON RPC] make views deserializable

### DIFF
--- a/json-rpc/src/methods.rs
+++ b/json-rpc/src/methods.rs
@@ -67,7 +67,7 @@ async fn get_account_state(
     let response = service.db.get_latest_account_state(account_address)?;
     if let Some(blob) = response {
         if let Ok(account) = AccountResource::try_from(&blob) {
-            return Ok(Some(AccountView::new(account)));
+            return Ok(Some(AccountView::new(&account)));
         }
     }
     Ok(None)

--- a/json-rpc/src/views.rs
+++ b/json-rpc/src/views.rs
@@ -3,9 +3,9 @@
 
 use hex;
 use libra_types::account_config::AccountResource;
-use serde::Serialize;
+use serde::{Deserialize, Serialize};
 
-#[derive(Serialize)]
+#[derive(Serialize, Deserialize, Debug, PartialEq)]
 pub struct AccountView {
     balance: u64,
     sequence_number: u64,
@@ -15,7 +15,7 @@ pub struct AccountView {
 }
 
 impl AccountView {
-    pub fn new(account: AccountResource) -> Self {
+    pub fn new(account: &AccountResource) -> Self {
         Self {
             balance: account.balance(),
             sequence_number: account.sequence_number(),
@@ -24,15 +24,21 @@ impl AccountView {
             delegated_withdrawal_capability: account.delegated_withdrawal_capability(),
         }
     }
+
+    // TODO remove test tag once used by CLI client
+    #[cfg(test)]
+    pub(crate) fn balance(&self) -> u64 {
+        self.balance
+    }
 }
 
-#[derive(Serialize)]
+#[derive(Serialize, Deserialize)]
 pub struct BlockMetadata {
     pub version: u64,
     pub timestamp: u64,
 }
 
-#[derive(Serialize)]
+#[derive(Serialize, Deserialize, Debug, PartialEq)]
 pub struct BytesView(String);
 
 impl From<&[u8]> for BytesView {


### PR DESCRIPTION
## Summary

Make `View` types deserializable

Also changed signature in `AccountAddress::new` to reduce cloning