### PR TITLE
[logging] Downgrade high frequency log lines to trace

### DIFF
--- a/admission_control/admission-control-service/src/admission_control_service.rs
+++ b/admission_control/admission-control-service/src/admission_control_service.rs
@@ -105,7 +105,7 @@ impl AdmissionControl for AdmissionControlService {
         &self,
         request: tonic::Request<SubmitTransactionRequest>,
     ) -> Result<tonic::Response<SubmitTransactionResponse>, tonic::Status> {
-        debug!("[GRPC] AdmissionControl::submit_transaction");
+        trace!("[GRPC] AdmissionControl::submit_transaction");
         counters::REQUESTS
             .with_label_values(&["submit_transaction"])
             .inc();
@@ -177,7 +177,7 @@ impl AdmissionControl for AdmissionControlService {
         &self,
         request: tonic::Request<UpdateToLatestLedgerRequest>,
     ) -> Result<tonic::Response<UpdateToLatestLedgerResponse>, tonic::Status> {
-        debug!("[GRPC] AdmissionControl::update_to_latest_ledger");
+        trace!("[GRPC] AdmissionControl::update_to_latest_ledger");
         counters::REQUESTS
             .with_label_values(&["update_to_latest_ledger"])
             .inc();

--- a/mempool/src/core_mempool/mempool.rs
+++ b/mempool/src/core_mempool/mempool.rs
@@ -57,9 +57,11 @@ impl Mempool {
         sequence_number: u64,
         is_rejected: bool,
     ) {
-        debug!(
+        trace!(
             "[Mempool] Removing transaction from mempool: {}:{}:{}",
-            sender, sequence_number, is_rejected
+            sender,
+            sequence_number,
+            is_rejected
         );
         self.log_latency(sender.clone(), sequence_number, "e2e.latency");
         self.metrics_cache.remove(&(*sender, sequence_number));
@@ -107,7 +109,7 @@ impl Mempool {
         db_sequence_number: u64,
         timeline_state: TimelineState,
     ) -> MempoolStatus {
-        debug!(
+        trace!(
             "[Mempool] Adding transaction to mempool: {}:{}:{}",
             &txn.sender(),
             txn.sequence_number(),

--- a/mempool/src/core_mempool/transaction_store.rs
+++ b/mempool/src/core_mempool/transaction_store.rs
@@ -216,7 +216,7 @@ impl TransactionStore {
                     }
                 }
             }
-            debug!("[Mempool] txns for account {:?}. Current sequence_number: {}, length: {}, parking lot: {}",
+            trace!("[Mempool] txns for account {:?}. Current sequence_number: {}, length: {}, parking lot: {}",
                 address, current_sequence_number, txns.len(), parking_lot_txns,
             );
         }


### PR DESCRIPTION
## Summary

Based on a sample of logs from the validator, these were the most frequently logged points. The fourth one is slog complaining that it is dropping log lines (`slog-async: logger dropped messages due to channel overflow`).

```
136403 mempool/src/core_mempool/transaction_store.rs:219]
111527 mempool/src/core_mempool/mempool.rs:110]
24936 mempool/src/core_mempool/mempool.rs:60]
14924 /root/.cargo/registry/src/github.com-1ecc6299db9ec823/slog-async-2.4.0/lib.rs:686]
2974 admission_control/admission-control-service/src/admission_control_service.rs:180]
```

Downgrading these log levels to `trace!` so that we have a sustainable logging system at the debug level.
