### PR TITLE
[terraform] Add variable to set a permissions boundary

### DIFF
--- a/terraform/auth.tf
+++ b/terraform/auth.tf
@@ -10,9 +10,10 @@ data "aws_iam_policy_document" "instance-assume-role" {
 }
 
 resource "aws_iam_role" "ecsInstanceRole" {
-  name               = "${terraform.workspace}-ecsInstanceRole"
-  path               = var.iam_path
-  assume_role_policy = data.aws_iam_policy_document.instance-assume-role.json
+  name                 = "${terraform.workspace}-ecsInstanceRole"
+  path                 = var.iam_path
+  assume_role_policy   = data.aws_iam_policy_document.instance-assume-role.json
+  permissions_boundary = var.permissions_boundary_policy
 }
 
 resource "aws_iam_role_policy_attachment" "ecsInstanceRole_" {
@@ -53,9 +54,10 @@ data "aws_iam_policy_document" "task-assume-role" {
 }
 
 resource "aws_iam_role" "ecsTaskExecutionRole" {
-  name               = "${terraform.workspace}-ecsTaskExecutionRole"
-  path               = var.iam_path
-  assume_role_policy = data.aws_iam_policy_document.task-assume-role.json
+  name                 = "${terraform.workspace}-ecsTaskExecutionRole"
+  path                 = var.iam_path
+  assume_role_policy   = data.aws_iam_policy_document.task-assume-role.json
+  permissions_boundary = var.permissions_boundary_policy
 }
 
 resource "aws_iam_role_policy_attachment" "ecsTaskExecutionRole_" {

--- a/terraform/cluster-test.tf
+++ b/terraform/cluster-test.tf
@@ -4,9 +4,10 @@ variable "cluster_test" {
 }
 
 resource "aws_iam_role" "cluster-test-runner" {
-  name               = "ClusterTestRunner-Role-${var.region}-${terraform.workspace}"
-  path               = var.iam_path
-  assume_role_policy = data.aws_iam_policy_document.instance-assume-role.json
+  name                 = "ClusterTestRunner-Role-${var.region}-${terraform.workspace}"
+  path                 = var.iam_path
+  assume_role_policy   = data.aws_iam_policy_document.instance-assume-role.json
+  permissions_boundary = var.permissions_boundary_policy
 }
 
 data "aws_caller_identity" "current" {}

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -197,3 +197,8 @@ variable "restore_vol_id" {
   default     = ""
   description = "volume id to restore validator data from"
 }
+
+variable "permissions_boundary_policy" {
+  default     = ""
+  description = "ARN of IAM policy to set as permissions boundary on created roles"
+}


### PR DESCRIPTION
This variable can be set to a policy ARN which will be used as the
permissions boundary on roles created by Terraform. This can be used
to prevent these roles from being used to escalate AWS access.

Test Plan: Created workspace with and without setting permissions
boundary.