### PR TITLE
[k8s][cluster-test] Simplify logging of validators/fullnodes

### DIFF
--- a/scripts/cti
+++ b/scripts/cti
@@ -223,11 +223,10 @@ else
   echo "**********"
   echo "${BLUE}Dashboard:${RESTORE} http://grafana.${WORKSPACE}-k8s-testnet.aws.hlw3truzy4ls.com/"
   echo "Dashboard Username: admin. Password: $(kubectl get secret grafana-admin-credentials -o jsonpath="{.data.admin-password}" | base64 --decode)"
-  echo "${BLUE}'validator-0' Logs:${RESTORE} http://kibana.${WORKSPACE}-k8s-testnet.aws.hlw3truzy4ls.com/app/kibana#/discover?_g=(filters:!(),refreshInterval:(pause:!t,value:0),time:(from:now-15m,to:now))&_a=(columns:!(log,kubernetes.pod_name),filters:!(('\$state':(store:appState),meta:(alias:!n,disabled:!f,key:kubernetes.pod_name,negate:!f,params:(query:validator-0),type:phrase),query:(match:(kubernetes.pod_name:(query:validator-0,type:phrase))))),interval:auto,query:(language:kuery,query:''),sort:!(!('@timestamp',desc)))"
+  echo "${BLUE}validator-0 Logs:${RESTORE} http://kibana.${WORKSPACE}-k8s-testnet.aws.hlw3truzy4ls.com/app/kibana#/discover?_g=(filters:!(),refreshInterval:(pause:!t,value:0),time:(from:now-15m,to:now))&_a=(columns:!(log,kubernetes.pod_name),filters:!(('\$state':(store:appState),meta:(alias:!n,disabled:!f,key:kubernetes.pod_name,negate:!f,params:(query:validator-0),type:phrase),query:(match:(kubernetes.pod_name:(query:validator-0,type:phrase))))),interval:auto,query:(language:kuery,query:''),sort:!(!('@timestamp',desc)))"
   echo
-  echo "${BLUE}'fullnode-0-0' Logs:${RESTORE} http://kibana.${WORKSPACE}-k8s-testnet.aws.hlw3truzy4ls.com/app/kibana#/discover?_g=(filters:!(),refreshInterval:(pause:!t,value:0),time:(from:now-15m,to:now))&_a=(columns:!(log,kubernetes.pod_name),filters:!(('\$state':(store:appState),meta:(alias:!n,disabled:!f,key:kubernetes.pod_name,negate:!f,params:(query:fullnode-0-0),type:phrase),query:(match:(kubernetes.pod_name:(query:fullnode-0-0,type:phrase))))),interval:auto,query:(language:kuery,query:''),sort:!(!('@timestamp',desc)))"
+  echo "${BLUE}fullnode-0-0 Logs:${RESTORE} http://kibana.${WORKSPACE}-k8s-testnet.aws.hlw3truzy4ls.com/app/kibana#/discover?_g=(filters:!(),refreshInterval:(pause:!t,value:0),time:(from:now-15m,to:now))&_a=(columns:!(log,kubernetes.pod_name),filters:!(('\$state':(store:appState),meta:(alias:!n,disabled:!f,key:kubernetes.pod_name,negate:!f,params:(query:fullnode-0-0),type:phrase),query:(match:(kubernetes.pod_name:(query:fullnode-0-0,type:phrase))))),interval:auto,query:(language:kuery,query:''),sort:!(!('@timestamp',desc)))"
   echo
-  echo "${BLUE}Note:${RESTORE} Because of log volume, logs for only some of the validators and fullnodes are streamed to Kibana."
   echo "**********"
   kubectl --context=${context} logs -f "${pod_name}" | tee $OUTPUT_TEE
 fi

--- a/testsuite/cluster-test/src/cluster_swarm/cluster_swarm_kube.rs
+++ b/testsuite/cluster-test/src/cluster_swarm/cluster_swarm_kube.rs
@@ -65,7 +65,6 @@ impl ClusterSwarmKube {
         } else {
             ""
         };
-        let fluentbit_enabled = if index % 10 == 0 { "true" } else { "false" };
         let pod_yaml = format!(
             include_str!("validator_spec_template.yaml"),
             index = index,
@@ -77,7 +76,6 @@ impl ClusterSwarmKube {
             delete_data = delete_data,
             cfg_seed = CFG_SEED,
             cfg_fullnode_seed = cfg_fullnode_seed,
-            fluentbit_enabled = fluentbit_enabled,
         );
         let pod_spec: serde_yaml::Value = serde_yaml::from_str(&pod_yaml)?;
         serde_json::to_vec(&pod_spec).map_err(|e| format_err!("serde_json::to_vec failed: {}", e))
@@ -93,11 +91,6 @@ impl ClusterSwarmKube {
         image_tag: &str,
         delete_data: bool,
     ) -> Result<Vec<u8>> {
-        let fluentbit_enabled = if validator_index % 10 == 0 {
-            "true"
-        } else {
-            "false"
-        };
         let pod_yaml = format!(
             include_str!("fullnode_spec_template.yaml"),
             fullnode_index = fullnode_index,
@@ -110,7 +103,6 @@ impl ClusterSwarmKube {
             delete_data = delete_data,
             cfg_seed = CFG_SEED,
             cfg_fullnode_seed = CFG_FULLNODE_SEED,
-            fluentbit_enabled = fluentbit_enabled,
         );
         let pod_spec: serde_yaml::Value = serde_yaml::from_str(&pod_yaml)?;
         serde_json::to_vec(&pod_spec).map_err(|e| format_err!("serde_json::to_vec failed: {}", e))

--- a/testsuite/cluster-test/src/cluster_swarm/fullnode_spec_template.yaml
+++ b/testsuite/cluster-test/src/cluster_swarm/fullnode_spec_template.yaml
@@ -30,40 +30,6 @@ spec:
       if [[ {delete_data} = true ]]; then
         rm -rf /opt/libra/data/*
       fi
-      if [[ {fluentbit_enabled} = true ]]; then
-        libra_log_file="libra.log"
-      else
-        libra_log_file="non_existent_file"
-      fi
-      cat << EOF > /opt/libra/data/fluent-bit.conf
-      [SERVICE]
-          Flush         5
-          Log_Level     info
-          Daemon        off
-
-      [INPUT]
-          Name              tail
-          Tag               validator
-          Path              /opt/libra/data/${{libra_log_file}}
-          Mem_Buf_Limit     5MB
-          Refresh_Interval  10
-          Skip_Long_Lines   On
-
-      [FILTER]
-          Name record_modifier
-          Match *
-          Record kubernetes.pod_name fullnode-{validator_index}-{fullnode_index}
-
-      [OUTPUT]
-          Name            es
-          Match           *
-          Host            elasticsearch-master
-          Port            9200
-          Logstash_Format On
-          Replace_Dots    Off
-          Retry_Limit     False
-          Logstash_Prefix kubernetes_cluster
-      EOF
       CFG_SEED_PEER_IP=$(kubectl get pod/validator-{validator_index} -o=jsonpath='{{.status.podIP}}');
       while [ -z "${{CFG_SEED_PEER_IP}}" ]; do
         sleep 5;
@@ -72,13 +38,6 @@ spec:
       done;
       echo -n "${{CFG_SEED_PEER_IP}}" > /opt/libra/data/seed_peer_ip
   containers:
-  - name: fluent-bit
-    image: 853397791086.dkr.ecr.us-west-2.amazonaws.com/fluent-bit:1.3.9
-    imagePullPolicy: IfNotPresent
-    command: ["/fluent-bit/bin/fluent-bit", "-c", "/opt/libra/data/fluent-bit.conf"]
-    volumeMounts:
-    - mountPath: /opt/libra/data
-      name: data
   - name: main
     image: 853397791086.dkr.ecr.us-west-2.amazonaws.com/libra_validator:{image_tag}
     imagePullPolicy: Always
@@ -122,7 +81,7 @@ spec:
         set -x;
         export CFG_LISTEN_ADDR=$MY_POD_IP;
         export CFG_SEED_PEER_IP=$(cat /opt/libra/data/seed_peer_ip);
-        exec bash /docker-run-dynamic-fullnode.sh &> /opt/libra/data/libra.log
+        exec bash /docker-run-dynamic-fullnode.sh
   volumes:
   - name: data
     hostPath:

--- a/testsuite/cluster-test/src/cluster_swarm/validator_spec_template.yaml
+++ b/testsuite/cluster-test/src/cluster_swarm/validator_spec_template.yaml
@@ -30,40 +30,6 @@ spec:
       if [[ {delete_data} = true ]]; then
         rm -rf /opt/libra/data/*
       fi
-      if [[ {fluentbit_enabled} = true ]]; then
-        libra_log_file="libra.log"
-      else
-        libra_log_file="non_existent_file"
-      fi
-      cat << EOF > /opt/libra/data/fluent-bit.conf
-      [SERVICE]
-          Flush         5
-          Log_Level     info
-          Daemon        off
-
-      [INPUT]
-          Name              tail
-          Tag               validator
-          Path              /opt/libra/data/${{libra_log_file}}
-          Mem_Buf_Limit     5MB
-          Refresh_Interval  10
-          Skip_Long_Lines   On
-
-      [FILTER]
-          Name record_modifier
-          Match *
-          Record kubernetes.pod_name validator-{index}
-
-      [OUTPUT]
-          Name            es
-          Match           *
-          Host            elasticsearch-master
-          Port            9200
-          Logstash_Format On
-          Replace_Dots    Off
-          Retry_Limit     False
-          Logstash_Prefix kubernetes_cluster
-      EOF
       CFG_SEED_PEER_IP=$(kubectl get pod/validator-0 -o=jsonpath='{{.status.podIP}}');
       while [ -z "${{CFG_SEED_PEER_IP}}" ]; do
         sleep 5;
@@ -76,13 +42,6 @@ spec:
         echo "Waiting for all validator pods to be scheduled";
       done
   containers:
-  - name: fluent-bit
-    image: 853397791086.dkr.ecr.us-west-2.amazonaws.com/fluent-bit:1.3.9
-    imagePullPolicy: IfNotPresent
-    command: ["/fluent-bit/bin/fluent-bit", "-c", "/opt/libra/data/fluent-bit.conf"]
-    volumeMounts:
-    - mountPath: /opt/libra/data
-      name: data
   - name: main
     image: 853397791086.dkr.ecr.us-west-2.amazonaws.com/libra_validator:{image_tag}
     imagePullPolicy: Always
@@ -126,7 +85,7 @@ spec:
         set -x;
         export CFG_LISTEN_ADDR=$MY_POD_IP;
         export CFG_SEED_PEER_IP=$(cat /opt/libra/data/seed_peer_ip);
-        exec bash /docker-run-dynamic.sh &> /opt/libra/data/libra.log
+        exec bash /docker-run-dynamic.sh
   volumes:
   - name: data
     hostPath:


### PR DESCRIPTION
## Summary

* We no longer need to sample logs from validators because of reduced volume
* We no longer need a separate agent as we are writing to stdout

## Test Plan

Ran cluster-test
