### PR TITLE
[cluster-test] Use default port in --swarm if port is not specified

### DIFF
--- a/testsuite/cluster-test/src/main.rs
+++ b/testsuite/cluster-test/src/main.rs
@@ -38,6 +38,7 @@ use futures::{
     future::{join_all, FutureExt, TryFutureExt},
     select,
 };
+use libra_config::config::AdmissionControlConfig;
 use tokio::{
     runtime::{Builder, Runtime},
     time::{delay_for, delay_until, Instant as TokioInstant},
@@ -305,6 +306,10 @@ struct ClusterTestRunner {
 
 fn parse_host_port(s: &str) -> Result<(String, u32)> {
     let v = s.split(':').collect::<Vec<&str>>();
+    if v.len() == 1 {
+        let default_port = AdmissionControlConfig::default().address.port() as u32;
+        return Ok((v[0].to_string(), default_port));
+    }
     if v.len() != 2 {
         return Err(format_err!("Failed to parse {:?} in host:port format", s));
     }


### PR DESCRIPTION
This allows to use `--swarm --peers ip1,ip2,ip3` instead of `--swarm --peers ip1:8000,ip2:8000,ip3:8000`
Custom port can still be specified, for example `--swarm --peers ip1,ip2:6000,ip3` is a valid command
