### PR TITLE
[libra-trace] Introducing libra-trace

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -46,6 +46,7 @@ dependencies = [
  "admission-control-proto 0.1.0",
  "anyhow 1.0.26 (registry+https://github.com/rust-lang/crates.io-index)",
  "assert_matches 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "debug-interface 0.1.0",
  "futures 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "libra-config 0.1.0",
  "libra-crypto 0.1.0",
@@ -59,6 +60,7 @@ dependencies = [
  "proptest 0.9.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "prost 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_json 1.0.48 (registry+https://github.com/rust-lang/crates.io-index)",
  "storage-client 0.1.0",
  "storage-service 0.1.0",
  "tokio 0.2.13 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1334,6 +1336,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow 1.0.26 (registry+https://github.com/rust-lang/crates.io-index)",
  "config-builder 0.1.0",
+ "debug-interface 0.1.0",
  "executor-types 0.1.0",
  "executor-utils 0.1.0",
  "futures 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1352,6 +1355,7 @@ dependencies = [
  "rusty-fork 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "scratchpad 0.1.0",
  "serde 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_json 1.0.48 (registry+https://github.com/rust-lang/crates.io-index)",
  "storage-client 0.1.0",
  "storage-proto 0.1.0",
  "storage-service 0.1.0",
@@ -2443,6 +2447,7 @@ dependencies = [
  "bounded-executor 0.1.0",
  "channel 0.1.0",
  "chrono 0.4.11 (registry+https://github.com/rust-lang/crates.io-index)",
+ "debug-interface 0.1.0",
  "futures 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "libra-canonical-serialization 0.1.0",
  "libra-config 0.1.0",
@@ -2462,6 +2467,7 @@ dependencies = [
  "prost 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_json 1.0.48 (registry+https://github.com/rust-lang/crates.io-index)",
  "storage-client 0.1.0",
  "storage-service 0.1.0",
  "tokio 0.2.13 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2683,6 +2689,7 @@ name = "libra-vm"
 version = "0.1.0"
 dependencies = [
  "bytecode-verifier 0.1.0",
+ "debug-interface 0.1.0",
  "hex 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "libra-canonical-serialization 0.1.0",
  "libra-config 0.1.0",
@@ -2701,6 +2708,7 @@ dependencies = [
  "prometheus 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "proptest 0.9.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "rayon 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_json 1.0.48 (registry+https://github.com/rust-lang/crates.io-index)",
  "vm 0.1.0",
 ]
 
@@ -5229,6 +5237,7 @@ name = "testsuite"
 version = "0.1.0"
 dependencies = [
  "cli 0.1.0",
+ "debug-interface 0.1.0",
  "generate-keypair 0.1.0",
  "libra-canonical-serialization 0.1.0",
  "libra-config 0.1.0",

--- a/admission_control/admission-control-service/Cargo.toml
+++ b/admission_control/admission-control-service/Cargo.toml
@@ -31,6 +31,8 @@ libra-mempool = { path = "../../mempool", version = "0.1.0"}
 libra-proptest-helpers = { path = "../../common/proptest-helpers", optional = true }
 libra-prost-ext = { path = "../../common/prost-ext", version = "0.1.0", optional = true }
 storage-service = { path = "../../storage/storage-service", optional = true }
+debug-interface = { path = "../../common/debug-interface", version = "0.1.0" }
+serde_json = "1.0"
 
 [dev-dependencies]
 assert_matches = "1.3.0"

--- a/admission_control/admission-control-service/src/admission_control_service.rs
+++ b/admission_control/admission-control-service/src/admission_control_service.rs
@@ -15,6 +15,7 @@ use admission_control_proto::{
     AdmissionControlStatus,
 };
 use anyhow::Result;
+use debug_interface::prelude::*;
 use futures::{channel::oneshot, SinkExt};
 use libra_config::config::NodeConfig;
 use libra_logger::prelude::*;
@@ -124,6 +125,7 @@ impl AdmissionControl for AdmissionControlService {
             )
         })?;
 
+        trace_code_block!("admission_control_service::submit_transaction", {"txn", txn.sender(), txn.sequence_number()});
         let (req_sender, res_receiver) = oneshot::channel();
         self.ac_sender
             .clone()

--- a/client/cli/src/libra_client.rs
+++ b/client/cli/src/libra_client.rs
@@ -255,7 +255,7 @@ impl LibraClient {
         let req =
             UpdateToLatestLedgerRequest::new(self.trusted_state.latest_version(), requested_items);
 
-        debug!("get_with_proof with request: {:?}", req);
+        trace!("get_with_proof with request: {:?}", req);
         let proto_req = req.clone().into();
         let resp = self.client.update_to_latest_ledger(proto_req)?;
         let resp = UpdateToLatestLedgerResponse::try_from(resp)?;

--- a/common/debug-interface/src/lib.rs
+++ b/common/debug-interface/src/lib.rs
@@ -14,9 +14,13 @@ use tokio::runtime::{Builder, Runtime};
 // Generated
 pub mod proto;
 
-pub mod node_debug_service;
-#[macro_use]
 pub mod json_log;
+pub mod libra_trace;
+pub mod node_debug_service;
+
+pub mod prelude {
+    pub use crate::{end_trace, event, trace_code_block, trace_edge, trace_event};
+}
 
 /// Implement default utility client for NodeDebugInterface
 pub struct NodeDebugClient {

--- a/common/debug-interface/src/libra_trace.rs
+++ b/common/debug-interface/src/libra_trace.rs
@@ -1,0 +1,297 @@
+// Copyright (c) The Libra Core Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::json_log::JsonLogEntry;
+use once_cell::sync::Lazy;
+use std::time::Instant;
+
+pub const TRACE_EVENT: &str = "trace_event";
+pub const TRACE_EDGE: &str = "trace_edge";
+
+pub static TRACE_START: Lazy<Instant> = Lazy::new(Instant::now);
+
+#[macro_export]
+macro_rules! trace_event {
+    ($stage:expr, $node:tt) => {
+        trace_event!($stage; {$crate::format_node!($node), module_path!(), Option::<u64>::None})
+    };
+    ($stage:expr; {$node:expr, $path:expr, $duration:expr}) => {
+        let trace_start = *$crate::libra_trace::TRACE_START;
+        $crate::json_log::send_json_log($crate::json_log::JsonLogEntry::new(
+            $crate::libra_trace::TRACE_EVENT,
+            serde_json::json!({
+               "path": $path,
+               "reltime": std::time::Instant::now().duration_since(trace_start).as_micros() as u64,
+               "node": $node,
+               "stage": $stage,
+               "duration": $duration,
+            }),
+        ));
+    }
+}
+
+#[macro_export]
+macro_rules! trace_code_block {
+    ($stage:expr, $node:tt) => {
+        let trace_guard = $crate::libra_trace::TraceBlockGuard::new_entered(
+            concat!($stage, "::done"),
+            $crate::format_node!($node),
+            module_path!(),
+        );
+        trace_event!($stage, $node);
+    };
+    ($stage:expr, $node:tt, $guard_vec:tt) => {
+        let trace_guard = $crate::libra_trace::TraceBlockGuard::new_entered(
+            concat!($stage, "::done"),
+            $crate::format_node!($node),
+            module_path!(),
+        );
+        trace_event!($stage, $node);
+        $guard_vec.push(trace_guard);
+    };
+}
+
+pub struct TraceBlockGuard {
+    stage: &'static str,
+    node: String,
+    module_path: &'static str,
+    started: Instant,
+}
+
+impl TraceBlockGuard {
+    pub fn new_entered(
+        stage: &'static str,
+        node: String,
+        module_path: &'static str,
+    ) -> TraceBlockGuard {
+        let started = Instant::now();
+        TraceBlockGuard {
+            stage,
+            node,
+            module_path,
+            started,
+        }
+    }
+}
+
+impl Drop for TraceBlockGuard {
+    fn drop(&mut self) {
+        let duration = format!("{:.0?}", Instant::now().duration_since(self.started));
+        trace_event!(self.stage; {self.node, self.module_path, duration});
+    }
+}
+
+#[macro_export]
+macro_rules! end_trace {
+    ($stage:expr, $node:tt) => {
+        let trace_start = *$crate::libra_trace::TRACE_START;
+        $crate::json_log::send_json_log($crate::json_log::JsonLogEntry::new(
+            $crate::libra_trace::TRACE_EVENT,
+            serde_json::json!({
+               "path": module_path!(),
+               "reltime": std::time::Instant::now().duration_since(trace_start).as_micros() as u64,
+               "node": $crate::format_node!($node),
+               "stage": $stage,
+               "end": true,
+            }),
+        ));
+    };
+}
+
+#[macro_export]
+macro_rules! trace_edge {
+    ($stage:expr, $node_from:tt, $node_to:tt) => {
+        let trace_start = *$crate::libra_trace::TRACE_START;
+        $crate::json_log::send_json_log($crate::json_log::JsonLogEntry::new(
+            $crate::libra_trace::TRACE_EDGE,
+            serde_json::json!({
+               "path": module_path!(),
+               "reltime": std::time::Instant::now().duration_since(trace_start).as_micros() as u64,
+               "node": $crate::format_node!($node_from),
+               "node_to": $crate::format_node!($node_to),
+               "stage": $stage,
+            }),
+        ));
+    };
+}
+
+#[macro_export]
+macro_rules! format_node {
+    ({$($node_part:expr),+}) => {
+        format!($crate::__trace_fmt_gen!($($node_part),+), $($node_part),+)
+    }
+}
+
+// Internal helper macro
+// Transforms (expr, expr, ...) into "{}::{}::..."
+#[macro_export]
+macro_rules! __trace_fmt_gen {
+    ($p:expr) => {"{}"};
+    ($p:expr, $($par:expr),+) => {concat!("{}::", $crate::__trace_fmt_gen!($($par),+))}
+}
+
+pub fn random_node(entries: &[JsonLogEntry], prefix: &str) -> Option<String> {
+    for entry in entries {
+        if entry.name != TRACE_EVENT {
+            continue;
+        }
+        let node = entry
+            .json
+            .get("node")
+            .expect("TRACE_EVENT::node not found")
+            .as_str()
+            .expect("TRACE_EVENT::node is not a string");
+        if node.starts_with(prefix) {
+            return Some(node.to_string());
+        }
+    }
+    None
+}
+
+pub fn trace_node(entries: &[JsonLogEntry], node_name: &str) {
+    let mut nodes = vec![];
+    nodes.push(node_name);
+    for entry in entries {
+        if entry.name != TRACE_EDGE {
+            continue;
+        }
+        let node_from = entry
+            .json
+            .get("node")
+            .expect("TRACE_EDGE::node not found")
+            .as_str()
+            .expect("TRACE_EDGE::node is not a string");
+        if nodes.contains(&node_from) {
+            let node_to = entry
+                .json
+                .get("node_to")
+                .expect("TRACE_EDGE::node_to not found")
+                .as_str()
+                .expect("TRACE_EDGE::node_to is not a string");
+            nodes.push(node_to);
+        }
+    }
+    let mut start_time = None;
+    for entry in entries {
+        if !entry.name.starts_with("trace_") {
+            continue;
+        }
+        let node = entry
+            .json
+            .get("node")
+            .expect("TRACE_EVENT::node not found")
+            .as_str()
+            .expect("TRACE_EVENT::node is not a string");
+        if !nodes.contains(&node) {
+            continue;
+        }
+        let reltime = entry
+            .json
+            .get("reltime")
+            .expect("::reltime not found")
+            .as_u64()
+            .expect("::reltime is not an u64");
+        if start_time.is_none() {
+            start_time = Some(reltime);
+        }
+        let trace_time = (reltime - start_time.unwrap()) / 1000; // micros -> ms
+        let stage = entry
+            .json
+            .get("stage")
+            .expect("::stage not found")
+            .as_str()
+            .expect("::stage is not a string");
+        let path = entry
+            .json
+            .get("path")
+            .expect("::path not found")
+            .as_str()
+            .expect("::path is not a string");
+        let duration = entry.json.get("duration").and_then(|v| v.as_str());
+        let crate_name = crate_name(path);
+        match entry.name {
+            TRACE_EVENT => {
+                let node = entry
+                    .json
+                    .get("node")
+                    .expect("TRACE_EVENT::node not found")
+                    .as_str()
+                    .expect("TRACE_EVENT::node is not a string");
+                if nodes.contains(&node) {
+                    let end = entry.json.get("end").and_then(|m| m.as_bool());
+                    let end_str = end.map_or("", |f| if f { " *end" } else { "" });
+                    let duration_str = duration.map_or("".to_string(), |d| format!(" [{}]", d));
+
+                    println!(
+                        "{}[{:^11}] +{:05} {} {}{}{}{}",
+                        crate_color(crate_name),
+                        crate_name,
+                        trace_time,
+                        node,
+                        stage,
+                        duration_str,
+                        end_str,
+                        reset_color()
+                    );
+                    if end == Some(true) {
+                        return;
+                    }
+                }
+            }
+            TRACE_EDGE => {
+                let node_to = entry
+                    .json
+                    .get("node_to")
+                    .expect("TRACE_EDGE::node_to not found")
+                    .as_str()
+                    .expect("TRACE_EDGE::node_to is not a string");
+                println!(
+                    "{}[{:^11}] +{:05} {}->{} {}{}",
+                    crate_color(crate_name),
+                    crate_name,
+                    trace_time,
+                    node,
+                    node_to,
+                    stage,
+                    reset_color()
+                );
+            }
+            _ => {}
+        }
+    }
+}
+
+fn reset_color() -> &'static str {
+    "\x1B[K\x1B[49m"
+}
+
+fn crate_color(path: &str) -> &'static str {
+    match path {
+        "consensus" => "\x1B[43m",
+        "mempool" => "\x1B[46m",
+        "executor" => "\x1B[104m",
+        "ac" => "\x1B[103m",
+        "vm" => "\x1B[45m",
+        _ => "\x1B[49m",
+    }
+}
+
+fn crate_name(path: &str) -> &str {
+    let name = match path.find("::") {
+        Some(pos) => &path[0..pos],
+        None => path,
+    };
+    let name = if name.starts_with("libra_") {
+        &name["libra_".len()..]
+    } else {
+        name
+    };
+    abbreviate_crate(name)
+}
+
+fn abbreviate_crate(name: &str) -> &str {
+    match name {
+        "admission_control_service" => "ac",
+        _ => name,
+    }
+}

--- a/common/debug-interface/src/node_debug_service.rs
+++ b/common/debug-interface/src/node_debug_service.rs
@@ -3,6 +3,7 @@
 
 //! Debug interface to access information in a specific node.
 
+use crate::json_log::JsonLogEntry;
 use crate::{
     json_log,
     proto::{
@@ -51,4 +52,18 @@ impl NodeDebugInterface for NodeDebugService {
         }
         Ok(Response::new(response))
     }
+}
+
+pub fn parse_events(events: Vec<Event>) -> Vec<JsonLogEntry> {
+    let mut ret = vec![];
+    for event in events.into_iter() {
+        let json = serde_json::from_str(&event.json).expect("Failed to parse json");
+        let entry = JsonLogEntry {
+            name: Box::leak(event.name.into_boxed_str()),
+            timestamp: event.timestamp as u128,
+            json,
+        };
+        ret.push(entry);
+    }
+    ret
 }

--- a/consensus/consensus-types/src/vote_msg.rs
+++ b/consensus/consensus-types/src/vote_msg.rs
@@ -3,6 +3,7 @@
 
 use crate::{sync_info::SyncInfo, vote::Vote};
 use anyhow::ensure;
+use libra_crypto::HashValue;
 use libra_types::crypto_proxies::ValidatorVerifier;
 use serde::{Deserialize, Serialize};
 use std::fmt::{Display, Formatter};
@@ -42,6 +43,10 @@ impl VoteMsg {
 
     pub fn epoch(&self) -> u64 {
         self.vote.epoch()
+    }
+
+    pub fn proposed_block_id(&self) -> HashValue {
+        self.vote.vote_data().proposed().id()
     }
 
     pub fn verify(&self, validator: &ValidatorVerifier) -> anyhow::Result<()> {

--- a/consensus/src/chained_bft/block_storage/block_store.rs
+++ b/consensus/src/chained_bft/block_storage/block_store.rs
@@ -14,7 +14,7 @@ use consensus_types::{
     block::Block, common::Payload, executed_block::ExecutedBlock, quorum_cert::QuorumCert,
     timeout_certificate::TimeoutCertificate,
 };
-use debug_interface::event;
+use debug_interface::prelude::*;
 use executor_types::{ExecutedTrees, ProcessedVMOutput};
 use libra_crypto::HashValue;
 use libra_logger::prelude::*;
@@ -254,6 +254,7 @@ impl<T: Payload> BlockStore<T> {
     }
 
     fn execute_block(&self, block: Block<T>) -> anyhow::Result<ExecutedBlock<T>> {
+        trace_code_block!("block_store::execute_block", {"block", block.id()});
         ensure!(
             self.inner.read().unwrap().root().round() < block.round(),
             "Block with old round"

--- a/consensus/src/chained_bft/persistent_liveness_storage.rs
+++ b/consensus/src/chained_bft/persistent_liveness_storage.rs
@@ -10,6 +10,7 @@ use consensus_types::{
     block::Block, common::Payload, quorum_cert::QuorumCert,
     timeout_certificate::TimeoutCertificate, vote::Vote,
 };
+use debug_interface::prelude::*;
 use executor_types::ExecutedTrees;
 use libra_config::config::NodeConfig;
 use libra_crypto::HashValue;
@@ -312,6 +313,10 @@ impl StorageWriteProxy {
 #[async_trait::async_trait]
 impl<T: Payload> PersistentLivenessStorage<T> for StorageWriteProxy {
     fn save_tree(&self, blocks: Vec<Block<T>>, quorum_certs: Vec<QuorumCert>) -> Result<()> {
+        let mut trace_batch = vec![];
+        for block in blocks.iter() {
+            trace_code_block!("consensusdb::save_tree", {"block", block.id()}, trace_batch);
+        }
         self.db
             .save_blocks_and_quorum_certificates(blocks, quorum_certs)
     }

--- a/consensus/src/state_computer.rs
+++ b/consensus/src/state_computer.rs
@@ -70,6 +70,7 @@ impl StateComputer for ExecutionProxy {
         // TODO: figure out error handling for the prologue txn
         self.executor
             .execute_block(
+                block.id(),
                 Self::transactions_from_block(block),
                 parent_executed_trees,
                 committed_trees,

--- a/consensus/src/state_replication.rs
+++ b/consensus/src/state_replication.rs
@@ -4,6 +4,7 @@
 use anyhow::Result;
 use consensus_types::{block::Block, executed_block::ExecutedBlock};
 use executor_types::{ExecutedTrees, ProcessedVMOutput, StateComputeResult};
+use libra_crypto::HashValue;
 use libra_types::crypto_proxies::{LedgerInfoWithSignatures, ValidatorChangeProof};
 
 /// Retrieves and updates the status of transactions on demand (e.g., via talking with Mempool)
@@ -30,6 +31,9 @@ pub trait TxnManager: Send + Sync {
 
     /// Bypass the trait object non-clonable limit.
     fn _clone_box(&self) -> Box<dyn TxnManager<Payload = Self::Payload>>;
+
+    // Helper to trace transactions after block is generated
+    fn trace_transactions(&self, _txns: &Self::Payload, _block_id: HashValue) {}
 }
 
 impl<T> Clone for Box<dyn TxnManager<Payload = T>> {

--- a/consensus/src/txn_manager.rs
+++ b/consensus/src/txn_manager.rs
@@ -3,8 +3,10 @@
 
 use crate::state_replication::TxnManager;
 use anyhow::{format_err, Result};
+use debug_interface::prelude::*;
 use executor_types::StateComputeResult;
 use futures::channel::{mpsc, oneshot};
+use libra_crypto::HashValue;
 use libra_mempool::{
     CommittedTransaction, ConsensusRequest, ConsensusResponse, TransactionExclusion,
 };
@@ -97,5 +99,11 @@ impl TxnManager for MempoolProxy {
 
     fn _clone_box(&self) -> Box<dyn TxnManager<Payload = Self::Payload>> {
         Box::new(self.clone())
+    }
+
+    fn trace_transactions(&self, txns: &Self::Payload, block_id: HashValue) {
+        for txn in txns.iter() {
+            trace_edge!("pull_txns", {"txn", txn.sender(), txn.sequence_number()}, {"block", block_id});
+        }
     }
 }

--- a/execution/executor-benchmark/src/lib.rs
+++ b/execution/executor-benchmark/src/lib.rs
@@ -215,6 +215,7 @@ impl TransactionExecutor {
             let output = self
                 .executor
                 .execute_block(
+                    HashValue::zero(),
                     transactions.clone(),
                     &self.committed_trees,
                     &self.committed_trees,

--- a/execution/executor/Cargo.toml
+++ b/execution/executor/Cargo.toml
@@ -19,6 +19,7 @@ serde = { version = "1.0.99", default-features = false }
 tokio = { version = "0.2.12", features = ["full"] }
 
 config-builder = { path = "../../config/config-builder", version = "0.1.0" }
+debug-interface = { path = "../../common/debug-interface", version = "0.1.0" }
 executor-types = { path = "../executor-types", version = "0.1.0" }
 lcs = { path = "../../common/lcs", version = "0.1.0", package = "libra-canonical-serialization" }
 libra-config = { path = "../../config", version = "0.1.0" }
@@ -28,6 +29,7 @@ libra-metrics = { path = "../../common/metrics", version = "0.1.0" }
 libra-state-view = { path = "../../storage/state-view", version = "0.1.0" }
 libra-types = { path = "../../types", version = "0.1.0" }
 scratchpad = { path = "../../storage/scratchpad", version = "0.1.0" }
+serde_json = "1.0"
 storage-client = { path = "../../storage/storage-client", version = "0.1.0" }
 storage-proto = { path = "../../storage/storage-proto", version = "0.1.0" }
 transaction-builder = { path = "../../language/transaction-builder", version = "0.1.0" }

--- a/execution/executor/tests/storage_integration_test.rs
+++ b/execution/executor/tests/storage_integration_test.rs
@@ -191,7 +191,12 @@ fn test_reconfiguration() {
     let txn3 = encode_block_prologue_script(gen_block_metadata(1, validator_account));
     let txn_block = vec![txn1, txn2, txn3];
     let vm_output = executor
-        .execute_block(txn_block, &committed_trees, &committed_trees)
+        .execute_block(
+            HashValue::zero(),
+            txn_block,
+            &committed_trees,
+            &committed_trees,
+        )
         .unwrap();
 
     // Make sure the execution result sees the reconfiguration
@@ -213,7 +218,12 @@ fn test_reconfiguration() {
     let txn5 = encode_block_prologue_script(gen_block_metadata(2, validator_account));
     let txn_block = vec![txn4, txn5];
     let output = executor
-        .execute_block(txn_block, &committed_trees, &committed_trees)
+        .execute_block(
+            HashValue::zero(),
+            txn_block,
+            &committed_trees,
+            &committed_trees,
+        )
         .unwrap();
 
     assert!(
@@ -357,7 +367,12 @@ fn test_execution_with_storage() {
     }
 
     let output1 = executor
-        .execute_block(block1.clone(), &committed_trees, &committed_trees)
+        .execute_block(
+            HashValue::zero(),
+            block1.clone(),
+            &committed_trees,
+            &committed_trees,
+        )
         .unwrap();
     let ledger_info_with_sigs = gen_ledger_info_with_sigs(6, output1.accu_root(), block1_id);
     let committed_trees_copy = committed_trees.clone();
@@ -638,7 +653,12 @@ fn test_execution_with_storage() {
 
     // Execution the 2nd block.
     let output2 = executor
-        .execute_block(block2.clone(), &committed_trees, &committed_trees)
+        .execute_block(
+            HashValue::zero(),
+            block2.clone(),
+            &committed_trees,
+            &committed_trees,
+        )
         .unwrap();
     let ledger_info_with_sigs = gen_ledger_info_with_sigs(20, output2.accu_root(), block2_id);
     executor

--- a/language/libra-vm/Cargo.toml
+++ b/language/libra-vm/Cargo.toml
@@ -30,6 +30,8 @@ move-vm-runtime = { path = "../move-vm/runtime", version = "0.1.0" }
 move-vm-state = { path = "../move-vm/state", version = "0.1.0" }
 move-vm-types = { path = "../move-vm/types", version = "0.1.0" }
 vm = { path = "../vm", version = "0.1.0" }
+debug-interface = { path = "../../common/debug-interface", version = "0.1.0" }
+serde_json = "1.0"
 
 [dev-dependencies]
 proptest = "0.9"

--- a/mempool/Cargo.toml
+++ b/mempool/Cargo.toml
@@ -34,6 +34,8 @@ network = { path = "../network", version = "0.1.0" }
 prometheus = { version = "0.8.0", default-features = false }
 storage-client = { path = "../storage/storage-client", version = "0.1.0" }
 vm-validator = { path = "../vm-validator", version = "0.1.0" }
+debug-interface = { path = "../common/debug-interface", version = "0.1.0" }
+serde_json = "1.0"
 
 libra-proptest-helpers = { path = "../common/proptest-helpers", optional = true }
 proptest = { version = "0.9.4", optional = true }

--- a/mempool/src/core_mempool/mempool.rs
+++ b/mempool/src/core_mempool/mempool.rs
@@ -14,6 +14,7 @@ use crate::{
     OP_COUNTERS,
 };
 use chrono::Utc;
+use debug_interface::prelude::*;
 use libra_config::config::NodeConfig;
 use libra_logger::prelude::*;
 use libra_types::{
@@ -57,6 +58,7 @@ impl Mempool {
         sequence_number: u64,
         is_rejected: bool,
     ) {
+        trace_event!("mempool:remove_transaction", {"txn", sender, sequence_number});
         trace!(
             "[Mempool] Removing transaction from mempool: {}:{}:{}",
             sender,
@@ -109,6 +111,7 @@ impl Mempool {
         db_sequence_number: u64,
         timeline_state: TimelineState,
     ) -> MempoolStatus {
+        trace_event!("mempool::add_txn", {"txn", txn.sender(), txn.sequence_number()});
         trace!(
             "[Mempool] Adding transaction to mempool: {}:{}:{}",
             &txn.sender(),
@@ -183,6 +186,7 @@ impl Mempool {
             if seen_previous || account_sequence_number == Some(&mut seq) {
                 let ptr = TxnPointer::from(txn);
                 seen.insert(ptr);
+                trace_event!("mempool::get_block", {"txn", txn.address, txn.sequence_number});
                 result.push(ptr);
                 if (result.len() as u64) == batch_size {
                     break;

--- a/mempool/src/shared_mempool.rs
+++ b/mempool/src/shared_mempool.rs
@@ -9,6 +9,7 @@ use crate::{
 use anyhow::{format_err, Result};
 use bounded_executor::BoundedExecutor;
 use channel::{libra_channel, message_queues::QueueStyle};
+use debug_interface::prelude::*;
 use futures::{
     channel::{
         mpsc::{self, Receiver, UnboundedSender},
@@ -632,6 +633,7 @@ async fn inbound_network_task<V>(
     loop {
         ::futures::select! {
             (mut msg, callback) = client_events.select_next_some() => {
+                trace_event!("mempool::client_event", {"txn", msg.sender(), msg.sequence_number()});
                 bounded_executor
                 .spawn(process_client_transaction_submission(
                     smp.clone(),

--- a/testsuite/Cargo.toml
+++ b/testsuite/Cargo.toml
@@ -16,6 +16,7 @@ rust_decimal = "1.3.0"
 statistical = "1"
 rusty-fork = "0.2.1"
 workspace-builder = { path = "../common/workspace-builder", version = "0.1.0" }
+debug-interface = { path = "../common/debug-interface", version = "0.1.0" }
 
 # In order to limit the potential waiting time for binaries to be built while
 # running tests all binaries which are being tested under this testsuite

--- a/testsuite/cluster-test/src/health/debug_interface_log_tail.rs
+++ b/testsuite/cluster-test/src/health/debug_interface_log_tail.rs
@@ -92,7 +92,6 @@ impl DebugPortLogThread {
         let e = if event.name == "committed" {
             Self::parse_commit(json)
         } else {
-            warn!("Unknown event: {} from {}", event.name, self.instance);
             return None;
         };
         Some(ValidatorEvent {

--- a/types/src/block_metadata.rs
+++ b/types/src/block_metadata.rs
@@ -44,6 +44,10 @@ impl BlockMetadata {
         }
     }
 
+    pub fn id(&self) -> HashValue {
+        self.id
+    }
+
     pub fn into_inner(self) -> Result<(Vec<u8>, u64, Vec<u8>, AccountAddress)> {
         let id = self.id.to_vec();
         let vote_maps = lcs::to_bytes(&self.previous_block_votes)?;


### PR DESCRIPTION
We currently don't have a good tool to understand where does transaction spend it's time between being submitted to full node by client, and being committed into block chain.

Libra trace aims to solve this problem by providing tracing capability into libra code.

# Concept

While goal of libra trace is to track transaction finality time, it is written in a such way that framework does not know details about transactions, blocks, etc.
Instead, framework operates in terms of abstract tree, where data being traced is represented as a `point`, and transition from one data representation to another is represented as an `edge`.

For example, transaction and block would be independent points, and generating proposal would create trace edge between transaction and the block where it is included.

If user runs command to trace specific transaction, libra_trace is able to figure out that since there is edge between this transaction and certain block, this block needs to be traced as well.

# API

Libra trace provides few `trace_` macros, that can be placed in code to track specific events.

* `trace_event` records single event, such as mempool receiving transaction.
* `trace_code_block` traces block of code and records both execution start and end time as separate events.
> Both `trace_event` and `trace_code_block` take `trace_point` as an argument
* `trace_edge` connects different tracing points, for example it signals that a transaction was included into some block

# Architecture

Trace macros in libra are leveraging `event!` macro to produce structured data points. Trace macros do not interact with each other, and are designed to do minimal job possible.
Events generated with trace macro are then accessible through debug interface, and trace code can fetch those events and perform more expensive processing (like connecting points and edges) outside of libra_node machine.

Trace code can then use information about edges and points to paint full picture of lifetime of a trace point.

# Comparing to other technologies
We've been looking into `tokio::trace` that provide somewhat similar interface.
There are few difference between how this framework is written and tokio::trace.
In a nutshell, tokio trace is good to tracing nested calls, as it provides powerful mechanism to pass context between calls and support both sync and async methods.
In libra codebase context inside nested calls is usually easy to get, and most interested thing to see when tracing transaction is not breakdown by nested calls, but rather bigger picture as transaction travels between different tasks, runtimes and nodes.
While this is still possible to do with tokio trace, benefit of using it becomes less obvious, and since we are trying to minimize external dependencies used, we are going to avoid it for now.

# TODO

This RFC shows some preview of what tracing API for user look like and what kind of output we can generate.
There is still work in progress on getting all the features done

* Aggregating data from multiple nodes(both validators and full nodes) to show global txn time breakdown
* Integrating into cluster test and generating regular reports
* Integrating with structured logging so same tracing could be use to get same perf breakdown in pre-main net
* Better configuration, runtime disabling and/or compiling out tracing when not used
* Tracing inside more components: libranet, statesync, storage
