### PR TITLE
[Import Fix] Merge imports in the Libra codebase using the nightly cargo build.

### DIFF
--- a/client/cli/src/client_proxy.rs
+++ b/client/cli/src/client_proxy.rs
@@ -4,10 +4,10 @@
 use crate::{commands::is_address, grpc_client::GRPCClient, AccountData, AccountStatus};
 use admission_control_proto::proto::admission_control::SubmitTransactionRequest;
 use anyhow::{bail, ensure, format_err, Error, Result};
-use libra_crypto::x25519::X25519StaticPublicKey;
 use libra_crypto::{
     ed25519::{Ed25519PrivateKey, Ed25519PublicKey, Ed25519Signature},
     test_utils::KeyPair,
+    x25519::X25519StaticPublicKey,
     ValidKey, ValidKeyStringExt,
 };
 use libra_logger::prelude::*;

--- a/config/config-builder/src/validator_config.rs
+++ b/config/config-builder/src/validator_config.rs
@@ -11,8 +11,7 @@ use libra_config::{
     generator,
 };
 use libra_crypto::{ed25519::Ed25519PrivateKey, PrivateKey, Uniform};
-use libra_types::crypto_proxies::ValidatorSet;
-use libra_types::transaction::Transaction;
+use libra_types::{crypto_proxies::ValidatorSet, transaction::Transaction};
 use parity_multiaddr::Multiaddr;
 use rand::{rngs::StdRng, Rng, SeedableRng};
 use std::{collections::HashMap, net::SocketAddr};

--- a/config/src/generator.rs
+++ b/config/src/generator.rs
@@ -4,10 +4,10 @@
 //! Convenience structs and functions for generating a random set of Libra ndoes without the
 //! genesis.blob.
 
-use crate::config::SafetyRulesService;
 use crate::{
     config::{
-        NodeConfig, OnDiskStorageConfig, SafetyRulesBackend, SeedPeersConfig, VMPublishingOption,
+        NodeConfig, OnDiskStorageConfig, SafetyRulesBackend, SafetyRulesService, SeedPeersConfig,
+        VMPublishingOption,
     },
     utils,
 };

--- a/consensus/src/chained_bft/event_processor.rs
+++ b/consensus/src/chained_bft/event_processor.rs
@@ -18,8 +18,7 @@ use crate::{
         },
     },
     counters,
-    state_replication::StateComputer,
-    state_replication::TxnManager,
+    state_replication::{StateComputer, TxnManager},
     util::time_service::{
         duration_since_epoch, wait_if_possible, TimeService, WaitingError, WaitingSuccess,
     },

--- a/language/compiler/bytecode-source-map/src/utils.rs
+++ b/language/compiler/bytecode-source-map/src/utils.rs
@@ -6,8 +6,7 @@ use crate::{
     source_map::{ModuleSourceMap, SourceMap},
 };
 use anyhow::{format_err, Result};
-use codespan::Span;
-use codespan::{FileId, Files};
+use codespan::{FileId, Files, Span};
 use codespan_reporting::{
     diagnostic::{Diagnostic, Label},
     term::{
@@ -17,10 +16,7 @@ use codespan_reporting::{
     },
 };
 use move_ir_types::location::Loc;
-use serde::{
-    de::DeserializeOwned,
-    {Deserialize, Serialize},
-};
+use serde::{de::DeserializeOwned, Deserialize, Serialize};
 use std::{collections::HashMap, fs::File, path::Path};
 
 pub type Error = (Loc, String);

--- a/language/e2e-tests/src/account.rs
+++ b/language/e2e-tests/src/account.rs
@@ -13,8 +13,8 @@ use libra_types::{
         RawTransaction, Script, SignedTransaction, TransactionArgument, TransactionPayload,
     },
 };
-use move_vm_types::identifier::create_access_path;
 use move_vm_types::{
+    identifier::create_access_path,
     loaded_data::{struct_def::StructDef, types::Type},
     values::{Struct, Value},
 };

--- a/language/libra-vm/src/libra_vm.rs
+++ b/language/libra-vm/src/libra_vm.rs
@@ -22,8 +22,7 @@ use move_vm_state::{
     data_cache::{BlockDataCache, RemoteCache, RemoteStorage},
     execution_context::{ExecutionContext, SystemExecutionContext, TransactionExecutionContext},
 };
-use move_vm_types::identifier::create_access_path;
-use move_vm_types::{chain_state::ChainState, values::Value};
+use move_vm_types::{chain_state::ChainState, identifier::create_access_path, values::Value};
 use rayon::prelude::*;
 use std::sync::Arc;
 use vm::{

--- a/language/move-lang/src/expansion/ast.rs
+++ b/language/move-lang/src/expansion/ast.rs
@@ -1,11 +1,11 @@
 // Copyright (c) The Libra Core Contributors
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::parser::ast::{InvariantKind, SpecBlockTarget, SpecConditionKind};
 use crate::{
     parser::ast::{
-        BinOp, Field, FunctionName, FunctionVisibility, Kind, ModuleIdent, ModuleName, ResourceLoc,
-        StructName, UnaryOp, Value, Var,
+        BinOp, Field, FunctionName, FunctionVisibility, InvariantKind, Kind, ModuleIdent,
+        ModuleName, ResourceLoc, SpecBlockTarget, SpecConditionKind, StructName, UnaryOp, Value,
+        Var,
     },
     shared::{ast_debug::*, unique_map::UniqueMap, *},
 };

--- a/language/move-prover/spec-lang/src/ast.rs
+++ b/language/move-prover/spec-lang/src/ast.rs
@@ -5,11 +5,15 @@
 
 use num::{BigUint, Num};
 
-use crate::env::{FieldId, Loc, ModuleId, NodeId, SpecFunId, SpecVarId, StructId};
-use crate::symbol::{Symbol, SymbolPool};
-use crate::ty::Type;
-use std::fmt;
-use std::fmt::{Error, Formatter};
+use crate::{
+    env::{FieldId, Loc, ModuleId, NodeId, SpecFunId, SpecVarId, StructId},
+    symbol::{Symbol, SymbolPool},
+    ty::Type,
+};
+use std::{
+    fmt,
+    fmt::{Error, Formatter},
+};
 
 // =================================================================================================
 /// # Declarations

--- a/language/move-prover/spec-lang/src/env.rs
+++ b/language/move-prover/spec-lang/src/env.rs
@@ -7,27 +7,33 @@
 use std::cell::RefCell;
 
 use codespan::{FileId, Files, Location, Span};
-use codespan_reporting::diagnostic::{Diagnostic, Label, Severity};
-use codespan_reporting::term::{emit, termcolor::WriteColor, Config};
+use codespan_reporting::{
+    diagnostic::{Diagnostic, Label, Severity},
+    term::{emit, termcolor::WriteColor, Config},
+};
 use itertools::Itertools;
 use num::{BigUint, Num};
 
 use bytecode_source_map::source_map::ModuleSourceMap;
 use libra_types::language_storage;
-use vm::access::ModuleAccess;
-use vm::file_format::{
-    AddressPoolIndex, FieldDefinitionIndex, FunctionDefinitionIndex, FunctionHandleIndex, Kind,
-    LocalsSignatureIndex, SignatureToken, StructDefinitionIndex, StructFieldInformation,
-    StructHandleIndex,
-};
-use vm::views::{
-    FieldDefinitionView, FunctionDefinitionView, FunctionHandleView, SignatureTokenView,
-    StructDefinitionView, StructHandleView, ViewInternals,
+use vm::{
+    access::ModuleAccess,
+    file_format::{
+        AddressPoolIndex, FieldDefinitionIndex, FunctionDefinitionIndex, FunctionHandleIndex, Kind,
+        LocalsSignatureIndex, SignatureToken, StructDefinitionIndex, StructFieldInformation,
+        StructHandleIndex,
+    },
+    views::{
+        FieldDefinitionView, FunctionDefinitionView, FunctionHandleView, SignatureTokenView,
+        StructDefinitionView, StructHandleView, ViewInternals,
+    },
 };
 
-use crate::ast::{Condition, Invariant, InvariantKind, ModuleName, SpecFunDecl, SpecVarDecl};
-use crate::symbol::{Symbol, SymbolPool};
-use crate::ty::{PrimitiveType, Type};
+use crate::{
+    ast::{Condition, Invariant, InvariantKind, ModuleName, SpecFunDecl, SpecVarDecl},
+    symbol::{Symbol, SymbolPool},
+    ty::{PrimitiveType, Type},
+};
 use std::collections::BTreeMap;
 use vm::CompiledModule;
 

--- a/language/move-prover/spec-lang/src/lib.rs
+++ b/language/move-prover/spec-lang/src/lib.rs
@@ -3,18 +3,19 @@
 
 #![forbid(unsafe_code)]
 
-use crate::ast::ModuleName;
-use crate::env::{GlobalEnv, ModuleId};
-use crate::translate::{ModuleTranslator, Translator};
+use crate::{
+    ast::ModuleName,
+    env::{GlobalEnv, ModuleId},
+    translate::{ModuleTranslator, Translator},
+};
 use anyhow::anyhow;
 use codespan_reporting::diagnostic::{Diagnostic, Label};
 use itertools::Itertools;
 use move_ir_types::location::Loc;
-use move_lang::errors::Errors;
-use move_lang::expansion::ast::Program;
-use move_lang::shared::Address;
-use move_lang::to_bytecode::translate::CompiledUnit;
-use move_lang::{move_compile_no_report, move_compile_to_expansion_no_report};
+use move_lang::{
+    errors::Errors, expansion::ast::Program, move_compile_no_report,
+    move_compile_to_expansion_no_report, shared::Address, to_bytecode::translate::CompiledUnit,
+};
 
 pub mod ast;
 pub mod env;

--- a/language/move-prover/spec-lang/src/symbol.rs
+++ b/language/move-prover/spec-lang/src/symbol.rs
@@ -4,11 +4,13 @@
 //! Contains definitions of symbols -- internalized strings which support fast hashing and
 //! comparison.
 
-use std::cell::RefCell;
-use std::collections::HashMap;
-use std::fmt;
-use std::fmt::{Error, Formatter};
-use std::rc::Rc;
+use std::{
+    cell::RefCell,
+    collections::HashMap,
+    fmt,
+    fmt::{Error, Formatter},
+    rc::Rc,
+};
 
 /// Representation of a symbol.
 #[derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash, Clone, Copy)]

--- a/language/move-prover/spec-lang/src/translate.rs
+++ b/language/move-prover/spec-lang/src/translate.rs
@@ -13,25 +13,27 @@ use itertools::Itertools;
 use num::{BigUint, FromPrimitive, Num};
 
 use bytecode_source_map::source_map::ModuleSourceMap;
-use move_lang::expansion::ast as EA;
-use move_lang::parser::ast as PA;
-use move_lang::shared::Name;
-use vm::access::ModuleAccess;
-use vm::file_format::{FunctionDefinitionIndex, StructDefinitionIndex};
-use vm::views::{FunctionHandleView, StructHandleView};
-use vm::CompiledModule;
+use move_lang::{expansion::ast as EA, parser::ast as PA, shared::Name};
+use vm::{
+    access::ModuleAccess,
+    file_format::{FunctionDefinitionIndex, StructDefinitionIndex},
+    views::{FunctionHandleView, StructHandleView},
+    CompiledModule,
+};
 
-use crate::ast::{
-    Condition, ConditionKind, Exp, Invariant, InvariantKind, LocalVarDecl, ModuleName, Operation,
-    QualifiedSymbol, SpecFunDecl, SpecVarDecl, Value,
+use crate::{
+    ast::{
+        Condition, ConditionKind, Exp, Invariant, InvariantKind, LocalVarDecl, ModuleName,
+        Operation, QualifiedSymbol, SpecFunDecl, SpecVarDecl, Value,
+    },
+    env::{
+        FieldId, FunId, FunctionData, GlobalEnv, Loc, ModuleId, NodeId, SpecFunId, SpecVarId,
+        StructData, StructId,
+    },
+    project_1st, project_2nd,
+    symbol::{Symbol, SymbolPool},
+    ty::{PrimitiveType, Substitution, Type, TypeDisplayContext, BOOL_TYPE},
 };
-use crate::env::{
-    FieldId, FunId, FunctionData, GlobalEnv, Loc, ModuleId, NodeId, SpecFunId, SpecVarId,
-    StructData, StructId,
-};
-use crate::symbol::{Symbol, SymbolPool};
-use crate::ty::{PrimitiveType, Substitution, Type, TypeDisplayContext, BOOL_TYPE};
-use crate::{project_1st, project_2nd};
 
 // =================================================================================================
 /// # Translator

--- a/language/move-prover/spec-lang/src/ty.rs
+++ b/language/move-prover/spec-lang/src/ty.rs
@@ -3,12 +3,12 @@
 
 //! Contains types and related functions.
 
-use crate::ast::QualifiedSymbol;
-use crate::env::{ModuleId, StructId};
-use crate::symbol::SymbolPool;
-use std::collections::BTreeMap;
-use std::fmt;
-use std::fmt::Formatter;
+use crate::{
+    ast::QualifiedSymbol,
+    env::{ModuleId, StructId},
+    symbol::SymbolPool,
+};
+use std::{collections::BTreeMap, fmt, fmt::Formatter};
 
 /// Represents a type.
 #[derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash, Clone)]

--- a/language/move-prover/spec-lang/tests/testsuite.rs
+++ b/language/move-prover/spec-lang/tests/testsuite.rs
@@ -6,8 +6,7 @@ use std::path::Path;
 use codespan_reporting::term::termcolor::Buffer;
 
 use spec_lang::run_spec_lang_compiler;
-use test_utils::baseline_test::verify_or_update_baseline;
-use test_utils::DEFAULT_SENDER;
+use test_utils::{baseline_test::verify_or_update_baseline, DEFAULT_SENDER};
 
 fn test_runner(path: &Path) -> datatest_stable::Result<()> {
     let targets = vec![path.to_str().unwrap().to_string()];

--- a/language/move-prover/test-utils/src/baseline_test.rs
+++ b/language/move-prover/test-utils/src/baseline_test.rs
@@ -5,11 +5,12 @@
 
 use crate::read_bool_env_var;
 use anyhow::{anyhow, Context, Result};
-use prettydiff::basic::DiffOp;
-use prettydiff::diff_lines;
-use std::fs::File;
-use std::io::{Read, Write};
-use std::path::Path;
+use prettydiff::{basic::DiffOp, diff_lines};
+use std::{
+    fs::File,
+    io::{Read, Write},
+    path::Path,
+};
 
 /// Verifies or updates baseline file for the given generated text.
 pub fn verify_or_update_baseline(baseline_file_name: &Path, text: &str) -> Result<()> {

--- a/language/move-vm/runtime/src/interpreter.rs
+++ b/language/move-vm/runtime/src/interpreter.rs
@@ -25,8 +25,8 @@ use libra_types::{
     transaction::MAX_TRANSACTION_SIZE_IN_BYTES,
     vm_error::{StatusCode, StatusType, VMStatus},
 };
-use move_vm_types::identifier::{create_access_path, resource_storage_key};
 use move_vm_types::{
+    identifier::{create_access_path, resource_storage_key},
     loaded_data::{struct_def::StructDef, types::Type},
     native_functions::dispatch::NativeFunction,
     type_context::TypeContext,

--- a/language/move-vm/runtime/src/runtime.rs
+++ b/language/move-vm/runtime/src/runtime.rs
@@ -1,12 +1,14 @@
 // Copyright (c) The Libra Core Contributors
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::loaded_data::function::FunctionRef;
 use crate::{
     code_cache::{module_cache::VMModuleCache, script_cache::ScriptCache},
     interpreter::Interpreter,
     interpreter_context::InterpreterContext,
-    loaded_data::{function::FunctionReference, loaded_module::LoadedModule},
+    loaded_data::{
+        function::{FunctionRef, FunctionReference},
+        loaded_module::LoadedModule,
+    },
 };
 use bytecode_verifier::VerifiedModule;
 use libra_logger::prelude::*;
@@ -16,8 +18,8 @@ use libra_types::{
     vm_error::{StatusCode, VMStatus},
 };
 use move_vm_cache::Arena;
-use move_vm_types::identifier::resource_storage_key;
 use move_vm_types::{
+    identifier::resource_storage_key,
     loaded_data::{struct_def::StructDef, types::Type},
     type_context::TypeContext,
     values::Value,

--- a/language/stdlib/src/main.rs
+++ b/language/stdlib/src/main.rs
@@ -3,9 +3,11 @@
 
 #![forbid(unsafe_code)]
 
-use std::fs::File;
-use std::io::Write;
-use std::path::{Path, PathBuf};
+use std::{
+    fs::File,
+    io::Write,
+    path::{Path, PathBuf},
+};
 use stdlib::{
     build_stdlib, compile_script, filter_move_files, STAGED_EXTENSION, STAGED_OUTPUT_PATH,
     STAGED_STDLIB_NAME, TRANSACTION_SCRIPTS,

--- a/language/tools/cost-synthesis/src/global_state/account.rs
+++ b/language/tools/cost-synthesis/src/global_state/account.rs
@@ -9,8 +9,7 @@ use libra_types::{
 };
 use move_vm_types::{
     identifier::{create_access_path, resource_storage_key},
-    loaded_data::struct_def::StructDef,
-    loaded_data::types::Type,
+    loaded_data::{struct_def::StructDef, types::Type},
     values::{Struct, Value},
 };
 use rand::{

--- a/language/tools/cost-synthesis/src/global_state/inhabitor.rs
+++ b/language/tools/cost-synthesis/src/global_state/inhabitor.rs
@@ -9,7 +9,10 @@ use libra_types::{
 };
 use move_vm_runtime::{loaded_data::loaded_module::LoadedModule, MoveVM};
 use move_vm_state::execution_context::SystemExecutionContext;
-use move_vm_types::{loaded_data::struct_def::StructDef, loaded_data::types::Type, values::*};
+use move_vm_types::{
+    loaded_data::{struct_def::StructDef, types::Type},
+    values::*,
+};
 use rand::{rngs::StdRng, Rng, SeedableRng};
 use std::collections::HashMap;
 use vm::{

--- a/mempool/src/network.rs
+++ b/mempool/src/network.rs
@@ -5,8 +5,7 @@
 
 use crate::counters;
 use channel::{libra_channel, message_queues::QueueStyle};
-use libra_types::transaction::SignedTransaction;
-use libra_types::PeerId;
+use libra_types::{transaction::SignedTransaction, PeerId};
 use network::{
     error::NetworkError,
     peer_manager::{PeerManagerRequest, PeerManagerRequestSender},

--- a/secure/storage/src/storage.rs
+++ b/secure/storage/src/storage.rs
@@ -2,7 +2,10 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::{Error, Policy, Value};
-use libra_crypto::{ed25519::Ed25519PrivateKey, ed25519::Ed25519PublicKey, PrivateKey, Uniform};
+use libra_crypto::{
+    ed25519::{Ed25519PrivateKey, Ed25519PublicKey},
+    PrivateKey, Uniform,
+};
 use rand::{rngs::OsRng, Rng, SeedableRng};
 
 /// Libra interface into storage. Create takes a policy that is enforced internally by the actual

--- a/testsuite/cluster-test/src/deployment.rs
+++ b/testsuite/cluster-test/src/deployment.rs
@@ -3,8 +3,7 @@
 
 #![forbid(unsafe_code)]
 
-use crate::instance::Instance;
-use crate::{aws::Aws, cluster::Cluster};
+use crate::{aws::Aws, cluster::Cluster, instance::Instance};
 use anyhow::{bail, format_err, Result};
 use rusoto_core::RusotoError;
 use rusoto_ecr::{

--- a/types/src/account_config.rs
+++ b/types/src/account_config.rs
@@ -1,13 +1,12 @@
 // Copyright (c) The Libra Core Contributors
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::language_storage::ModuleId;
 use crate::{
     access_path::{AccessPath, Accesses},
     account_address::AccountAddress,
     event::EventHandle,
     identifier::{IdentStr, Identifier},
-    language_storage::StructTag,
+    language_storage::{ModuleId, StructTag},
 };
 use anyhow::Result;
 use once_cell::sync::Lazy;


### PR DESCRIPTION
## Motivation

At present, 'cargo fmt' doesn't automatically merge imports for rust files. While this feature is available in the nightly build of cargo, the general consensus is that we shouldn't enforce this requirement until it is accepted in stable. Moreover, it seems that people are reluctant to include a lint rule that checks this property (although, consensus has yet to be achieved here)... Until then, I figure I may as well submit periodic PRs that clean up the imports.

Is this PR useful? Personally, I think so. Looking at the changes below, it's clear that imports can easily become messy, and this PR took me less than a minute to generate, write, and submit.

Note: this PR was generated by running: 'cargo +nightly fmt -- --config merge_imports=true'. This does not affect import lines in a file that are separated by several newlines (e.g., imports at the top of a file are not automatically merged with those declared later on).

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?

Yes.

## Test Plan

All local tests pass.

## Related PRs

None.
