### PR TITLE
HashValue for secure storage

### DIFF
--- a/secure/storage/src/in_memory.rs
+++ b/secure/storage/src/in_memory.rs
@@ -49,6 +49,7 @@ impl Storage for InMemoryStorage {
                 let key = lcs::from_bytes(&bytes)?;
                 Value::Ed25519PrivateKey(key)
             }
+            Value::HashValue(value) => Value::HashValue(*value),
             Value::U64(value) => Value::U64(*value),
         };
 

--- a/secure/storage/src/tests/suite.rs
+++ b/secure/storage/src/tests/suite.rs
@@ -15,19 +15,20 @@ use rand::{rngs::StdRng, SeedableRng};
 /// tests rely on first running the vault docker script in `docker/vault/run.sh`); and (ii) vault
 /// tests cannot currently be run in parallel, as each test uses the same vault instance.
 const STORAGE_TESTS: &[fn(&mut dyn Storage)] = &[
-    test_ensure_storage_is_available,
-    test_create_get_set_unwrap,
-    test_create_key_value_twice,
-    test_get_set_non_existent,
-    test_verify_incorrect_value_types_unwrap,
-    test_create_get_and_test_key_pair,
-    test_create_key_pair_twice,
-    test_get_uncreated_key_pair,
     test_create_and_get_non_existent_version,
     test_create_rotate_and_check_key_pair,
     test_create_key_pair_and_perform_rotations,
     test_create_key_pair_and_perform_get_set_get,
     test_create_sign_rotate_sign,
+    test_create_get_and_test_key_pair,
+    test_create_get_set_unwrap,
+    test_create_key_pair_twice,
+    test_create_key_value_twice,
+    test_ensure_storage_is_available,
+    test_get_set_non_existent,
+    test_get_uncreated_key_pair,
+    test_hash_value,
+    test_verify_incorrect_value_types_unwrap,
 ];
 
 /// Storage data constants for testing purposes.
@@ -198,6 +199,19 @@ fn test_get_uncreated_key_pair(storage: &mut dyn Storage) {
         storage.get_public_key_for_name(key_pair_name).is_err(),
         "Accessing a key that has not yet been created should have failed!"
     );
+}
+
+/// Verify HashValues work correctly
+fn test_hash_value(storage: &mut dyn Storage) {
+    let hash_value_key = "HashValue";
+    let hash_value_value = HashValue::random();
+    let policy = Policy::public();
+
+    storage
+        .create(hash_value_key, Value::HashValue(hash_value_value), &policy)
+        .unwrap();
+    let out_value = storage.get(hash_value_key).unwrap().hash_value().unwrap();
+    assert_eq!(hash_value_value, out_value);
 }
 
 /// This test verifies the storage engine is up and running.

--- a/secure/storage/src/value.rs
+++ b/secure/storage/src/value.rs
@@ -2,27 +2,36 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::error::Error;
-use libra_crypto::ed25519::Ed25519PrivateKey;
+use libra_crypto::{ed25519::Ed25519PrivateKey, hash::HashValue};
 use serde::{Deserialize, Serialize};
 
 #[derive(Debug, Deserialize, PartialEq, Serialize)]
 #[serde(content = "value", rename_all = "snake_case", tag = "type")]
 pub enum Value {
     Ed25519PrivateKey(Ed25519PrivateKey),
+    HashValue(HashValue),
     U64(u64),
 }
 
 impl Value {
-    pub fn u64(self) -> Result<u64, Error> {
-        if let Value::U64(value) = self {
+    pub fn ed25519_private_key(self) -> Result<Ed25519PrivateKey, Error> {
+        if let Value::Ed25519PrivateKey(value) = self {
             Ok(value)
         } else {
             Err(Error::UnexpectedValueType)
         }
     }
 
-    pub fn ed25519_private_key(self) -> Result<Ed25519PrivateKey, Error> {
-        if let Value::Ed25519PrivateKey(value) = self {
+    pub fn hash_value(self) -> Result<HashValue, Error> {
+        if let Value::HashValue(value) = self {
+            Ok(value)
+        } else {
+            Err(Error::UnexpectedValueType)
+        }
+    }
+
+    pub fn u64(self) -> Result<u64, Error> {
+        if let Value::U64(value) = self {
             Ok(value)
         } else {
             Err(Error::UnexpectedValueType)
@@ -48,18 +57,26 @@ mod tests {
     use rand::{rngs::StdRng, SeedableRng};
 
     #[test]
-    fn u64() {
-        let value = Value::U64(12341);
+    fn ed25519_private_key() {
+        let mut rng = StdRng::from_seed([13u8; 32]);
+        let value = Ed25519PrivateKey::generate_for_testing(&mut rng);
+        let value = Value::Ed25519PrivateKey(value);
         let base64 = value.to_base64().unwrap();
         let out_value = Value::from_base64(&base64).unwrap();
         assert_eq!(value, out_value);
     }
 
     #[test]
-    fn ed25519_private_key() {
-        let mut rng = StdRng::from_seed([13u8; 32]);
-        let value = Ed25519PrivateKey::generate_for_testing(&mut rng);
-        let value = Value::Ed25519PrivateKey(value);
+    fn hash_value() {
+        let value = Value::HashValue(HashValue::random());
+        let base64 = value.to_base64().unwrap();
+        let out_value = Value::from_base64(&base64).unwrap();
+        assert_eq!(value, out_value);
+    }
+
+    #[test]
+    fn u64() {
+        let value = Value::U64(12341);
         let base64 = value.to_base64().unwrap();
         let out_value = Value::from_base64(&base64).unwrap();
         assert_eq!(value, out_value);


### PR DESCRIPTION
Add human serializable form for HashValue and subsequently add it to secure-storage. We'll need to store a couple of HashValues as part of the safety rules, this makes it elegant to do so.