### PR TITLE
[move source language] improve error message for unused resource para…

### DIFF
--- a/language/move-lang/src/cfgir/ast.rs
+++ b/language/move-lang/src/cfgir/ast.rs
@@ -233,6 +233,14 @@ impl std::fmt::Display for Label {
     }
 }
 
+impl FunctionSignature {
+    pub fn is_parameter(&self, v: &Var) -> bool {
+        self.parameters
+            .iter()
+            .any(|(parameter_name, _)| parameter_name == v)
+    }
+}
+
 impl Command_ {
     pub fn is_terminal(&self) -> bool {
         use Command_::*;

--- a/language/move-lang/tests/move_check/locals/reassign_parameter.exp
+++ b/language/move-lang/tests/move_check/locals/reassign_parameter.exp
@@ -1,0 +1,13 @@
+error: 
+
+   ┌── tests/move_check/locals/reassign_parameter.move:7:9 ───
+   │
+ 7 │ ╭         if  (true) {
+ 8 │ │             let R { } = r
+ 9 │ │         }
+   │ ╰─────────^ Invalid return
+   ·
+ 6 │         r = R {};
+   │         - The parameter 'r' might still contain a resource value. The resource must be consumed before the function returns
+   │
+

--- a/language/move-lang/tests/move_check/locals/reassign_parameter.move
+++ b/language/move-lang/tests/move_check/locals/reassign_parameter.move
@@ -1,0 +1,12 @@
+module M {
+    resource struct R {}
+
+    public fun reassign_parameter(r: R) {
+        let R { } = r;
+        r = R {};
+        if  (true) {
+            let R { } = r
+        }
+    }
+
+}

--- a/language/move-lang/tests/move_check/locals/unused_copyable.move
+++ b/language/move-lang/tests/move_check/locals/unused_copyable.move
@@ -1,0 +1,7 @@
+module M {
+    struct S {}
+
+    // this does not currently produce a warning
+    fun unused(i: u64, s: S) {
+    }
+}

--- a/language/move-lang/tests/move_check/locals/unused_resource.exp
+++ b/language/move-lang/tests/move_check/locals/unused_resource.exp
@@ -125,6 +125,6 @@ error:
     │ ╰─────^ Invalid return
     ·
  31 │     fun t6<T>(x: T) {
-    │               - The local 'x' might still contain a resource value due to this assignment. The resource must be consumed before the function returns
+    │               - The parameter 'x' might still contain a resource value. The resource must be consumed before the function returns
     │
 

--- a/language/move-lang/tests/move_check/locals/unused_resource_explicit_return.exp
+++ b/language/move-lang/tests/move_check/locals/unused_resource_explicit_return.exp
@@ -96,6 +96,6 @@ error:
     │         ^^^^^^^^^ Invalid return
     ·
  37 │     fun t6<T>(x: T) {
-    │               - The local 'x' might still contain a resource value due to this assignment. The resource must be consumed before the function returns
+    │               - The parameter 'x' might still contain a resource value. The resource must be consumed before the function returns
     │
 

--- a/language/move-lang/tests/move_check/typing/module_call_explicit_type_arguments.exp
+++ b/language/move-lang/tests/move_check/typing/module_call_explicit_type_arguments.exp
@@ -8,7 +8,7 @@ error:
    │ ╰─────^ Invalid return
    ·
  2 │     fun foo<T, U>(x: T, y: U) {
-   │                   - The local 'x' might still contain a resource value due to this assignment. The resource must be consumed before the function returns
+   │                   - The parameter 'x' might still contain a resource value. The resource must be consumed before the function returns
    │
 
 error: 
@@ -21,6 +21,6 @@ error:
    │ ╰─────^ Invalid return
    ·
  2 │     fun foo<T, U>(x: T, y: U) {
-   │                         - The local 'y' might still contain a resource value due to this assignment. The resource must be consumed before the function returns
+   │                         - The parameter 'y' might still contain a resource value. The resource must be consumed before the function returns
    │
 


### PR DESCRIPTION
…meters

- The error message for an unused resource parameter points to the procedure declaration + says "The local 'x' might still contain a resource value due to this assignment".
- This PR changes it to say "The parameter 'x' might still contain a resource value", which is somewhat clearer.

<!--
Thank you for sending a PR. We appreciate you spending time to help improve the Libra project.

The project is undergoing daily changes. Pull Requests will be reviewed and responded to as time permits.
-->

## Motivation

See above.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?

Y

## Test Plan

New move-check tests.