### PR TITLE
[move-prover] Re-enables execution traces in verification errors.

### DIFF
--- a/language/move-lang/src/expansion/ast.rs
+++ b/language/move-lang/src/expansion/ast.rs
@@ -31,6 +31,7 @@ pub struct Program {
 
 #[derive(Debug)]
 pub struct ModuleDefinition {
+    pub loc: Loc,
     pub uses: BTreeMap<ModuleIdent, Loc>,
     pub unused_aliases: Vec<ModuleIdent>,
     pub is_source_module: bool,
@@ -47,6 +48,7 @@ pub type Fields<T> = UniqueMap<Field, (usize, T)>;
 
 #[derive(Debug, PartialEq)]
 pub struct StructDefinition {
+    pub loc: Loc,
     pub resource_opt: ResourceLoc,
     pub type_parameters: Vec<(Name, Kind)>,
     pub fields: StructFields,
@@ -79,6 +81,7 @@ pub type FunctionBody = Spanned<FunctionBody_>;
 
 #[derive(PartialEq, Debug)]
 pub struct Function {
+    pub loc: Loc,
     pub visibility: FunctionVisibility,
     pub signature: FunctionSignature,
     pub acquires: Vec<ModuleAccess>,
@@ -311,6 +314,7 @@ impl AstDebug for Program {
 impl AstDebug for ModuleDefinition {
     fn ast_debug(&self, w: &mut AstWriter) {
         let ModuleDefinition {
+            loc: _loc,
             uses,
             unused_aliases,
             is_source_module,
@@ -361,6 +365,7 @@ impl AstDebug for (StructName, &StructDefinition) {
         let (
             name,
             StructDefinition {
+                loc: _loc,
                 resource_opt,
                 type_parameters,
                 fields,
@@ -447,6 +452,7 @@ impl AstDebug for (FunctionName, &Function) {
         let (
             name,
             Function {
+                loc: _loc,
                 visibility,
                 signature,
                 acquires,

--- a/language/move-lang/src/expansion/translate.rs
+++ b/language/move-lang/src/expansion/translate.rs
@@ -222,6 +222,7 @@ fn module(
 ) -> (ModuleIdent, E::ModuleDefinition) {
     assert!(context.aliases.is_empty());
     let P::ModuleDefinition {
+        loc,
         uses,
         name,
         structs: pstructs,
@@ -251,6 +252,7 @@ fn module(
     let (uses, unused_aliases) = check_aliases(context, used_aliases, alias_map);
     let is_source_module = is_source_module && !fake_natives::is_fake_native(&current_module);
     let def = E::ModuleDefinition {
+        loc,
         uses,
         unused_aliases,
         is_source_module,
@@ -397,6 +399,7 @@ fn struct_def(
     pstruct: P::StructDefinition,
 ) -> (StructName, E::StructDefinition) {
     let P::StructDefinition {
+        loc,
         name,
         resource_opt,
         type_parameters: pty_params,
@@ -405,6 +408,7 @@ fn struct_def(
     let type_parameters = type_parameters(context, pty_params);
     let fields = struct_fields(context, &name, pfields);
     let sdef = E::StructDefinition {
+        loc,
         resource_opt,
         type_parameters,
         fields,
@@ -470,6 +474,7 @@ fn functions(
 
 fn function_def(context: &mut Context, pfunction: P::Function) -> (FunctionName, E::Function) {
     let P::Function {
+        loc,
         name,
         visibility,
         signature: psignature,
@@ -483,6 +488,7 @@ fn function_def(context: &mut Context, pfunction: P::Function) -> (FunctionName,
         .collect();
     let body = function_body(context, pbody);
     let fdef = E::Function {
+        loc,
         visibility,
         signature,
         acquires,

--- a/language/move-lang/src/parser/ast.rs
+++ b/language/move-lang/src/parser/ast.rs
@@ -89,6 +89,7 @@ pub struct ModuleIdent(pub Spanned<ModuleIdent_>);
 
 #[derive(Debug)]
 pub struct ModuleDefinition {
+    pub loc: Loc,
     pub uses: Vec<(ModuleIdent, Option<ModuleName>)>,
     pub name: ModuleName,
     pub structs: Vec<StructDefinition>,
@@ -107,6 +108,7 @@ pub type ResourceLoc = Option<Loc>;
 
 #[derive(Debug, PartialEq)]
 pub struct StructDefinition {
+    pub loc: Loc,
     pub resource_opt: ResourceLoc,
     pub name: StructName,
     pub type_parameters: Vec<(Name, Kind)>,
@@ -151,6 +153,7 @@ pub type FunctionBody = Spanned<FunctionBody_>;
 //  }
 // (public?) native foo<T1(: copyable?), ..., TN(: copyable?)>(x1: t1, ..., xn: tn): t1 * ... * tn;
 pub struct Function {
+    pub loc: Loc,
     pub visibility: FunctionVisibility,
     pub signature: FunctionSignature,
     pub acquires: Vec<ModuleAccess>,
@@ -701,6 +704,7 @@ impl AstDebug for ModuleOrAddress {
 impl AstDebug for ModuleDefinition {
     fn ast_debug(&self, w: &mut AstWriter) {
         let ModuleDefinition {
+            loc: _loc,
             uses,
             name,
             structs,
@@ -747,6 +751,7 @@ impl AstDebug for (ModuleIdent, Option<ModuleName>) {
 impl AstDebug for StructDefinition {
     fn ast_debug(&self, w: &mut AstWriter) {
         let StructDefinition {
+            loc: _loc,
             resource_opt,
             name,
             type_parameters,
@@ -839,6 +844,7 @@ impl AstDebug for SpecBlockMember_ {
 impl AstDebug for Function {
     fn ast_debug(&self, w: &mut AstWriter) {
         let Function {
+            loc: _loc,
             visibility,
             signature,
             acquires,

--- a/language/move-lang/src/parser/syntax.rs
+++ b/language/move-lang/src/parser/syntax.rs
@@ -1147,6 +1147,7 @@ fn parse_function_decl<'input>(
     tokens: &mut Lexer<'input>,
     allow_native: bool,
 ) -> Result<Function, Error> {
+    let start_loc = tokens.start_loc();
     // Record the source location of the "native" keyword (if there is one).
     let native_opt = if allow_native {
         consume_optional_token_with_loc(tokens, Tok::Native)?
@@ -1244,7 +1245,9 @@ fn parse_function_decl<'input>(
         return_type,
     };
 
+    let loc = make_loc(tokens.file_name(), start_loc, tokens.previous_end_loc());
     Ok(Function {
+        loc,
         visibility,
         signature,
         acquires,
@@ -1274,6 +1277,8 @@ fn parse_parameter<'input>(tokens: &mut Lexer<'input>) -> Result<(Var, SingleTyp
 //          <Name>
 //          | <Name> "<" Comma<TypeParameter> ">"
 fn parse_struct_definition<'input>(tokens: &mut Lexer<'input>) -> Result<StructDefinition, Error> {
+    let start_loc = tokens.start_loc();
+
     // Record the source location of the "native" keyword (if there is one).
     let native_opt = consume_optional_token_with_loc(tokens, Tok::Native)?;
 
@@ -1313,7 +1318,9 @@ fn parse_struct_definition<'input>(tokens: &mut Lexer<'input>) -> Result<StructD
         }
     };
 
+    let loc = make_loc(tokens.file_name(), start_loc, tokens.previous_end_loc());
     Ok(StructDefinition {
+        loc,
         resource_opt,
         name,
         type_parameters,
@@ -1366,6 +1373,8 @@ fn is_struct_definition<'input>(tokens: &mut Lexer<'input>) -> Result<bool, Erro
 //              ( <StructDefinition> | <FunctionDecl> | <Spec> )*
 //          "}"
 fn parse_module<'input>(tokens: &mut Lexer<'input>) -> Result<ModuleDefinition, Error> {
+    let start_loc = tokens.start_loc();
+
     consume_token(tokens, Tok::Module)?;
     let name = parse_module_name(tokens)?;
     consume_token(tokens, Tok::LBrace)?;
@@ -1389,7 +1398,9 @@ fn parse_module<'input>(tokens: &mut Lexer<'input>) -> Result<ModuleDefinition, 
     }
     tokens.advance()?; // consume the RBrace
 
+    let loc = make_loc(tokens.file_name(), start_loc, tokens.previous_end_loc());
     Ok(ModuleDefinition {
+        loc,
         uses,
         name,
         structs,

--- a/language/move-prover/src/boogie_helpers.rs
+++ b/language/move-prover/src/boogie_helpers.rs
@@ -139,7 +139,7 @@ pub fn boogie_type_check_expr(env: &GlobalEnv, name: &str, ty: &Type) -> String 
         },
         Type::Vector(_) => conds.push(format!("$Vector_is_well_formed({})", name)),
         Type::Struct(module_idx, struct_idx, _) => {
-            let struct_env = env.get_module(*module_idx).into_get_struct(*struct_idx);
+            let struct_env = env.get_module(*module_idx).into_struct(*struct_idx);
             conds.push(format!(
                 "${}_is_well_formed({})",
                 boogie_struct_name(&struct_env),

--- a/language/move-prover/src/prelude.bpl
+++ b/language/move-prover/src/prelude.bpl
@@ -7,14 +7,14 @@
 // Debug tracking is used to inject information used for model analysis. The generated code emits statements
 // like this:
 //
-//     assume $DebugTrackLocal(module_idx, func_idx, var_idx, code_position, value);
+//     assume $DebugTrackLocal(file_id, byte_index, var_idx, value);
 //
 // While those tracking assumptions are trivially true for the provers logic, the solver (at least Z3)
 // will construct a function mapping which appears in the model, e.g.:
 //
 //     $DebugTrackLocal -> {
-//         1 1 0 440 (Vector (ValueArray |T@[Int]Value!val!0| 0)) -> true
-//         1 1 2 533 (Integer 1) -> true
+//         1 440 0 (Vector (ValueArray |T@[Int]Value!val!0| 0)) -> true
+//         1 533 1 (Integer 1) -> true
 //         ...
 //         else -> true
 //     }
@@ -24,12 +24,12 @@
 
 // Tracks debug information for a parameter, local or a return parameter. Return parameter indices start at
 // the overall number of locals (including parameters).
-function $DebugTrackLocal(module_idx: int, func_idx: int, var_idx: int, code_index: int, value: Value) : bool {
+function $DebugTrackLocal(file_id: int, byte_index:  int, var_idx: int, value: Value) : bool {
   true
 }
 
 // Tracks at which location a function was aborted.
-function $DebugTrackAbort(module_idx: int, func_idx: int, code_index: int) : bool {
+function $DebugTrackAbort(file_id: int, byte_index: int) : bool {
   true
 }
 

--- a/language/move-prover/tests/sources/aborts-if.exp
+++ b/language/move-prover/tests/sources/aborts-if.exp
@@ -6,6 +6,10 @@ error:  A postcondition might not hold on this return path.
  16 │         aborts_if x <= y;
     │         ^^^^^^^^^^^^^^^^^
     │
+    =     at tests/sources/aborts-if.move:12:5: abort2 (entry)
+    =     at tests/sources/aborts-if.move:12:5: abort2 (exit)
+    =         x = 281,
+    =         y = 281
 
 error:  A postcondition might not hold on this return path.
 
@@ -14,6 +18,11 @@ error:  A postcondition might not hold on this return path.
  24 │         aborts_if x <= y;
     │         ^^^^^^^^^^^^^^^^^
     │
+    =     at tests/sources/aborts-if.move:20:5: abort3 (entry)
+    =     at tests/sources/aborts-if.move:21:9: abort3
+    =         x = 1323,
+    =         y = 1323
+    =     at tests/sources/aborts-if.move:20:5: abort3 (exit)
 
 error:  A postcondition might not hold on this return path.
 
@@ -22,6 +31,12 @@ error:  A postcondition might not hold on this return path.
  32 │         aborts_if x < y;
     │         ^^^^^^^^^^^^^^^^
     │
+    =     at tests/sources/aborts-if.move:28:5: abort4 (entry)
+    =     at tests/sources/aborts-if.move:29:9: abort4
+    =         x = 8879,
+    =         y = 8879
+    =     at tests/sources/aborts-if.move:29:23: abort4
+    =     at tests/sources/aborts-if.move:28:5: abort4 (exit)
 
 error:  A postcondition might not hold on this return path.
 
@@ -30,6 +45,11 @@ error:  A postcondition might not hold on this return path.
  44 │         ensures x == y;
     │         ^^^^^^^^^^^^^^^
     │
+    =     at tests/sources/aborts-if.move:38:5: abort9 (entry)
+    =     at tests/sources/aborts-if.move:39:9: abort9
+    =         x = 854,
+    =         y = 853
+    =     at tests/sources/aborts-if.move:38:5: abort9 (exit)
 
 error:  A postcondition might not hold on this return path.
 
@@ -38,3 +58,7 @@ error:  A postcondition might not hold on this return path.
  42 │         aborts_if x > y;
     │         ^^^^^^^^^^^^^^^^
     │
+    =     at tests/sources/aborts-if.move:38:5: abort9 (entry)
+    =     at tests/sources/aborts-if.move:39:9: abort9
+    =     at tests/sources/aborts-if.move:39:23: abort9
+    =     at tests/sources/aborts-if.move:38:5: abort9 (exit)

--- a/language/move-prover/tests/sources/arithm.exp
+++ b/language/move-prover/tests/sources/arithm.exp
@@ -6,6 +6,8 @@ error:  A postcondition might not hold on this return path.
  69 │         aborts_if false;
     │         ^^^^^^^^^^^^^^^^
     │
+    =     at tests/sources/arithm.move:64:5: div_by_zero (entry)
+    =     at tests/sources/arithm.move:66:11: div_by_zero (ABORTED)
 
 error:  A postcondition might not hold on this return path.
 
@@ -14,6 +16,8 @@ error:  A postcondition might not hold on this return path.
  53 │         aborts_if false;
     │         ^^^^^^^^^^^^^^^^
     │
+    =     at tests/sources/arithm.move:48:2: overflow (entry)
+    =     at tests/sources/arithm.move:50:11: overflow (ABORTED)
 
 error:  A postcondition might not hold on this return path.
 
@@ -22,3 +26,5 @@ error:  A postcondition might not hold on this return path.
  61 │         aborts_if false;
     │         ^^^^^^^^^^^^^^^^
     │
+    =     at tests/sources/arithm.move:56:5: underflow (entry)
+    =     at tests/sources/arithm.move:58:11: underflow (ABORTED)


### PR DESCRIPTION
With SourceMap now working for Move Lang (thanks Todd and Tim!), we can re-enable execution traces.

- Adds location info to ModuleDefinition, StructDefinition, and Function in Move parser and expansion phases. Those span over the entire definition and not just the declared name, which is important for the reverse mapping.
- Refactors boogie_wrapper and supporting env data structure to properly work with the new (file, span) location model.

<!--
Thank you for sending a PR. We appreciate you spending time to help improve the Libra project.

The project is undergoing daily changes. Pull Requests will be reviewed and responded to as time permits.
-->

## Motivation

Restore functionality available before refactoring.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

Existing baseline tests now capture execution traces.

## Related PRs

NA

