### PR TITLE
[cluster-test] Migrate debug_interface_log_tail to async api

### DIFF
--- a/testsuite/cluster-test/src/health/debug_interface_log_tail.rs
+++ b/testsuite/cluster-test/src/health/debug_interface_log_tail.rs
@@ -11,6 +11,7 @@ use crate::{
 };
 use debug_interface::{proto::Event as DebugInterfaceEvent, NodeDebugClient};
 use libra_logger::*;
+use futures::future::FutureExt;
 use serde_json::{self, value as json};
 use std::{
     env,
@@ -21,8 +22,9 @@ use std::{
     thread,
     time::Duration,
 };
+use tokio::time;
 
-pub struct DebugPortLogThread {
+pub struct DebugPortLogWorker {
     instance: Instance,
     client: NodeDebugClient,
     event_sender: mpsc::Sender<ValidatorEvent>,
@@ -32,8 +34,8 @@ pub struct DebugPortLogThread {
     trace_enabled: Arc<AtomicBool>,
 }
 
-impl DebugPortLogThread {
-    pub fn spawn_new(cluster: &Cluster) -> (LogTail, TraceTail) {
+impl DebugPortLogWorker {
+    pub fn spawn_new(cluster: &Cluster, runtime: &tokio::runtime::Runtime) -> (LogTail, TraceTail) {
         let (event_sender, event_receiver) = mpsc::channel();
         let mut started_receivers = vec![];
         let pending_messages = Arc::new(AtomicI64::new(0));
@@ -43,7 +45,7 @@ impl DebugPortLogThread {
             let (started_sender, started_receiver) = mpsc::channel();
             started_receivers.push(started_receiver);
             let client = NodeDebugClient::new(instance.ip(), 6191);
-            let debug_port_log_thread = DebugPortLogThread {
+            let debug_port_log_worker = DebugPortLogWorker {
                 instance: instance.clone(),
                 client,
                 event_sender: event_sender.clone(),
@@ -52,10 +54,7 @@ impl DebugPortLogThread {
                 trace_sender: trace_sender.clone(),
                 trace_enabled: trace_enabled.clone(),
             };
-            thread::Builder::new()
-                .name(format!("log-tail-{}", instance.peer_name()))
-                .spawn(move || debug_port_log_thread.run())
-                .expect("Failed to spawn log tail thread");
+            runtime.spawn(debug_port_log_worker.run().boxed());
         }
         for r in started_receivers {
             if let Err(e) = r.recv() {
@@ -75,8 +74,8 @@ impl DebugPortLogThread {
     }
 }
 
-impl DebugPortLogThread {
-    pub fn run(mut self) {
+impl DebugPortLogWorker {
+    pub async fn run(mut self) {
         let print_failures = env::var("VERBOSE").is_ok();
         loop {
             match self.client.get_events() {
@@ -84,7 +83,7 @@ impl DebugPortLogThread {
                     if print_failures {
                         info!("Failed to get events from {}: {:?}", self.instance, e);
                     }
-                    thread::sleep(Duration::from_secs(1));
+                    time::delay_for(Duration::from_secs(1)).await;
                 }
                 Ok(resp) => {
                     let mut sent_events = 0i64;
@@ -96,7 +95,7 @@ impl DebugPortLogThread {
                     }
                     self.pending_messages
                         .fetch_add(sent_events, Ordering::Relaxed);
-                    thread::sleep(Duration::from_millis(100));
+                    time::delay_for(Duration::from_millis(200)).await;
                 }
             }
             if let Some(started_sender) = self.started_sender.take() {

--- a/testsuite/cluster-test/src/health/mod.rs
+++ b/testsuite/cluster-test/src/health/mod.rs
@@ -11,7 +11,7 @@ mod log_tail;
 use crate::{cluster::Cluster, util::unix_timestamp_now};
 use anyhow::{bail, Result};
 pub use commit_check::CommitHistoryHealthCheck;
-pub use debug_interface_log_tail::DebugPortLogThread;
+pub use debug_interface_log_tail::DebugPortLogWorker;
 use itertools::Itertools;
 pub use liveness_check::LivenessHealthCheck;
 pub use log_tail::{LogTail, TraceTail};


### PR DESCRIPTION
<!--
Thank you for sending a PR. We appreciate you spending time to help improve the Libra project.

The project is undergoing daily changes. Pull Requests will be reviewed and responded to as time permits.
-->

## Motivation
See issue [1863](https://github.com/libra/libra/issues/1863)
Currently DebugPortLogThread spawns a dedicated thread for each node
this change is for switching to the async api and use the tokio runtime
instead ot std::threads

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

Just ran the entire test suite and linters, not sure if any other test is needed.

## Related PRs

None
