### PR TITLE
[move-prover] Reactivate invariant tests and improve error reporting.

### DIFF
--- a/language/move-prover/spec-lang/src/lib.rs
+++ b/language/move-prover/spec-lang/src/lib.rs
@@ -21,6 +21,9 @@ pub mod symbol;
 mod translate;
 pub mod ty;
 
+#[allow(unused_imports)]
+use log::{info, warn};
+
 // =================================================================================================
 // Entry Point
 
@@ -100,6 +103,10 @@ fn run_spec_checker(
                     let expanded_module = eprog.modules.remove(&module_id).unwrap();
                     Some((module_id, expanded_module, compiled_module, source_map))
                 } else {
+                    warn!(
+                        "[internal] cannot associate bytecode module `{}` with AST",
+                        name.0.value
+                    );
                     None
                 }
             } else {

--- a/language/move-prover/src/boogie_helpers.rs
+++ b/language/move-prover/src/boogie_helpers.rs
@@ -188,15 +188,6 @@ pub fn boogie_declare_global(env: &GlobalEnv, name: &str, ty: &Type) -> String {
     )
 }
 
-/// Returns the name of the invariant target value.
-pub fn boogie_invariant_target(for_old: bool) -> String {
-    if for_old {
-        "$inv_target_old".to_string()
-    } else {
-        "$inv_target".to_string()
-    }
-}
-
 pub fn boogie_var_before_borrow(idx: usize) -> String {
     format!("$before_borrow_{}", idx)
 }

--- a/language/move-prover/src/prelude.bpl
+++ b/language/move-prover/src/prelude.bpl
@@ -321,16 +321,8 @@ function {:constructor} Global(t: TypeValue, a: Address): Location;
 function {:constructor} Local(i: int): Location;
 
 type {:datatype} Reference;
-function {:constructor} Reference(l: Location, t: TypeValue, p: Path): Reference;
+function {:constructor} Reference(l: Location, p: Path): Reference;
 const DefaultReference: Reference;
-
-function {:inline} RootReferenceType(r: Reference): TypeValue {
-  t#Reference(r)
-}
-
-function {:inline} RootReference(r: Reference): Reference {
-  Reference(l#Reference(r), t#Reference(r), EmptyPath)
-}
 
 function {:inline} $IsValidReferenceParameter(m: Memory, local_counter: int, r: Reference): bool {
   // If the reference parameter is for a local, its index must be less than the current
@@ -400,7 +392,7 @@ function {:inline} $ExistsResource(m: Memory, resource: TypeValue, addr: Address
 
 // Obtains reference to the given resource.
 function {:inline} $GetResourceReference(resource: TypeValue, addr: Address): Reference {
-    Reference(Global(resource, addr), resource, EmptyPath)
+    Reference(Global(resource, addr), EmptyPath)
 }
 
 // Obtains value of given resource.
@@ -483,12 +475,12 @@ procedure {:inline 1} BorrowGlobal(address: Value, ta: TypeValue) returns (dst: 
         $abort_flag := true;
         return;
     }
-    dst := Reference(l, ta, EmptyPath);
+    dst := Reference(l, EmptyPath);
 }
 
-procedure {:inline 1} BorrowLoc(l: int, t: TypeValue) returns (dst: Reference)
+procedure {:inline 1} BorrowLoc(l: int) returns (dst: Reference)
 {
-    dst := Reference(Local(l), t, EmptyPath);
+    dst := Reference(Local(l), EmptyPath);
 }
 
 procedure {:inline 1} BorrowField(src: Reference, f: FieldName) returns (dst: Reference)
@@ -499,7 +491,7 @@ procedure {:inline 1} BorrowField(src: Reference, f: FieldName) returns (dst: Re
     p := p#Reference(src);
     size := size#Path(p);
 	p := Path(p#Path(p)[size := f], size+1);
-    dst := Reference(l#Reference(src), t#Reference(src), p);
+    dst := Reference(l#Reference(src), p);
 }
 
 procedure {:inline 1} WriteRef(to: Reference, new_v: Value)
@@ -867,7 +859,7 @@ procedure {:inline 1} $Vector_borrow_mut(ta: TypeValue, src: Reference, index: V
     p := p#Reference(src);
     size := size#Path(p);
 	p := Path(p#Path(p)[size := i_ind], size+1);
-    dst := Reference(l#Reference(src), t#Reference(src), p);
+    dst := Reference(l#Reference(src), p);
 }
 
 procedure {:inline 1} $Vector_destroy_empty(ta: TypeValue, v: Value) {

--- a/language/move-prover/src/spec_translator.rs
+++ b/language/move-prover/src/spec_translator.rs
@@ -278,7 +278,7 @@ impl<'env> SpecTranslator<'env> {
         }
         emitln!(
             self.writer,
-            "procedure {{:inline 1}} ${}_update_inv($before: Value, $after: Value) {{",
+            "procedure {{:inline 1}} {}_update_inv($before: Value, $after: Value) {{",
             boogie_struct_name(struct_env)
         );
         self.writer.indent();
@@ -303,7 +303,7 @@ impl<'env> SpecTranslator<'env> {
     }
 
     pub fn emit_pack_invariants(&self, struct_env: &StructEnv<'env>, target: &str) {
-        self.emit_invariants_assume_or_assert(target, "", true, struct_env.get_data_invariants());
+        self.emit_invariants_assume_or_assert(target, "", false, struct_env.get_data_invariants());
         self.emit_spec_var_updates(target, "", struct_env.get_pack_invariants());
     }
 
@@ -322,6 +322,7 @@ impl<'env> SpecTranslator<'env> {
     ) {
         for inv in invariants {
             if inv.target.is_none() {
+                self.writer.set_location(&inv.loc);
                 if assume {
                     emit!(self.writer, "assume b#Boolean(");
                 } else {
@@ -337,6 +338,7 @@ impl<'env> SpecTranslator<'env> {
     fn emit_spec_var_updates(&self, target: &str, old_target: &str, invariants: &[Invariant]) {
         for inv in invariants {
             if let Some((module_id, spec_var_id)) = &inv.target {
+                self.writer.set_location(&inv.loc);
                 let module_env = self.module_env.env.get_module(*module_id);
                 let spec_var = module_env.get_spec_var(*spec_var_id);
                 emit!(

--- a/language/move-prover/tests/sources/aborts-if.exp
+++ b/language/move-prover/tests/sources/aborts-if.exp
@@ -8,8 +8,8 @@ error:  A postcondition might not hold on this return path.
     │
     =     at tests/sources/aborts-if.move:12:5: abort2 (entry)
     =     at tests/sources/aborts-if.move:12:5: abort2 (exit)
-    =         x = 281,
-    =         y = 281
+    =         x = <redacted>,
+    =         y = <redacted>
 
 error:  A postcondition might not hold on this return path.
 
@@ -20,8 +20,8 @@ error:  A postcondition might not hold on this return path.
     │
     =     at tests/sources/aborts-if.move:20:5: abort3 (entry)
     =     at tests/sources/aborts-if.move:21:9: abort3
-    =         x = 1323,
-    =         y = 1323
+    =         x = <redacted>,
+    =         y = <redacted>
     =     at tests/sources/aborts-if.move:20:5: abort3 (exit)
 
 error:  A postcondition might not hold on this return path.
@@ -33,9 +33,8 @@ error:  A postcondition might not hold on this return path.
     │
     =     at tests/sources/aborts-if.move:28:5: abort4 (entry)
     =     at tests/sources/aborts-if.move:29:9: abort4
-    =         x = 8879,
-    =         y = 8879
-    =     at tests/sources/aborts-if.move:29:23: abort4
+    =         x = <redacted>,
+    =         y = <redacted>
     =     at tests/sources/aborts-if.move:28:5: abort4 (exit)
 
 error:  A postcondition might not hold on this return path.
@@ -47,8 +46,8 @@ error:  A postcondition might not hold on this return path.
     │
     =     at tests/sources/aborts-if.move:38:5: abort9 (entry)
     =     at tests/sources/aborts-if.move:39:9: abort9
-    =         x = 854,
-    =         y = 853
+    =         x = <redacted>,
+    =         y = <redacted>
     =     at tests/sources/aborts-if.move:38:5: abort9 (exit)
 
 error:  A postcondition might not hold on this return path.
@@ -60,5 +59,4 @@ error:  A postcondition might not hold on this return path.
     │
     =     at tests/sources/aborts-if.move:38:5: abort9 (entry)
     =     at tests/sources/aborts-if.move:39:9: abort9
-    =     at tests/sources/aborts-if.move:39:23: abort9
     =     at tests/sources/aborts-if.move:38:5: abort9 (exit)

--- a/language/move-prover/tests/sources/global_vars.exp
+++ b/language/move-prover/tests/sources/global_vars.exp
@@ -1,0 +1,49 @@
+Move prover returns: exiting with boogie verification errors
+error:  A postcondition might not hold on this return path.
+
+    ┌── tests/sources/global_vars.move:30:9 ───
+    │
+ 30 │         ensures sum_of_T == old(sum_of_T) + 1;
+    │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    │
+    =     at tests/sources/global_vars.move:26:5: pack_invalid (entry)
+    =     at tests/sources/global_vars.move:27:9: pack_invalid
+    =         result = <redacted>
+    =     at tests/sources/global_vars.move:26:5: pack_invalid (exit)
+
+error:  A postcondition might not hold on this return path.
+
+    ┌── tests/sources/global_vars.move:50:9 ───
+    │
+ 50 │         ensures sum_of_T == old(sum_of_T);
+    │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    │
+    =     at tests/sources/global_vars.move:45:5: unpack_invalid (entry)
+    =     at tests/sources/global_vars.move:46:19: unpack_invalid
+    =         t = <redacted>
+    =     at tests/sources/global_vars.move:47:9: unpack_invalid
+    =         x = <redacted>
+    =     at tests/sources/global_vars.move:45:5: unpack_invalid (exit)
+    =         result = <redacted>
+
+error:  A postcondition might not hold on this return path.
+
+    ┌── tests/sources/global_vars.move:81:9 ───
+    │
+ 81 │         ensures sum_of_T == old(sum_of_T);
+    │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    │
+    =     at tests/sources/global_vars.move:74:5: update_invalid (entry)
+    =     at tests/sources/global_vars.move:75:13: update_invalid
+    =     at tests/sources/global_vars.move:76:37: update_invalid
+    =         t = <redacted>,
+    =         t = <redacted>
+    =     at tests/sources/global_vars.move:56:5: update_valid_still_mutating (entry)
+    =     at tests/sources/global_vars.move:57:19: update_valid_still_mutating
+    =         t = <redacted>,
+    =         t = <redacted>
+    =     at tests/sources/global_vars.move:56:5: update_valid_still_mutating (exit)
+    =     at tests/sources/global_vars.move:76:9: update_invalid
+    =     at tests/sources/global_vars.move:77:9: update_invalid
+    =     at tests/sources/global_vars.move:74:5: update_invalid (exit)
+    =         result = <redacted>

--- a/language/move-prover/tests/sources/global_vars.move
+++ b/language/move-prover/tests/sources/global_vars.move
@@ -1,0 +1,83 @@
+module GlobalVars {
+
+    spec module {
+        global sum_of_T: u64;
+    }
+
+    struct T {
+      i: u64,
+    }
+    spec struct T {
+      invariant pack sum_of_T = sum_of_T + i;
+      invariant unpack sum_of_T = sum_of_T - i;
+      invariant update sum_of_T = sum_of_T - old(i) + i;
+
+    }
+
+    // Pack tests
+
+    fun pack_valid(): T {
+        T {i: 2}
+    }
+    spec fun pack_valid {
+        ensures sum_of_T == old(sum_of_T) + 2;
+    }
+
+    fun pack_invalid(): T {
+        T {i: 2}
+    }
+    spec fun pack_invalid {
+        ensures sum_of_T == old(sum_of_T) + 1;
+        ensures result.i == 2;
+    }
+
+    // Unpack tests
+
+    fun unpack_valid(t: T): u64 {
+        let T {i: x} = t;
+        x
+    }
+    spec fun unpack_valid {
+        ensures sum_of_T == old(sum_of_T) - old(t.i);
+        ensures result == old(t.i);
+    }
+
+    fun unpack_invalid(t: T): u64 {
+        let T {i: x} = t;
+        x
+    }
+    spec fun unpack_invalid {
+        ensures sum_of_T == old(sum_of_T);
+        ensures result == old(t.i);
+    }
+
+    // Update tests.
+
+    fun update_valid_still_mutating(t: &mut T) {
+        t.i = t.i + 3;
+    }
+    spec fun update_valid_still_mutating {
+        // sum should not change because we have not ended mutating t
+        ensures sum_of_T == old(sum_of_T);
+    }
+
+    fun update_valid(): T {
+        let t = T {i: 0};
+        update_valid_still_mutating(&mut t);
+        t
+    }
+    spec fun update_valid {
+        // sum should change because we have ended mutating t
+        ensures sum_of_T == old(sum_of_T) + 3;
+    }
+
+    fun update_invalid(): T {
+        let t = T {i: 0};
+        update_valid_still_mutating(&mut t);
+        t
+    }
+    spec fun update_invalid {
+        // sum should change because we have ended mutating t
+        ensures sum_of_T == old(sum_of_T);
+    }
+}

--- a/language/move-prover/tests/sources/invariants.exp
+++ b/language/move-prover/tests/sources/invariants.exp
@@ -1,0 +1,98 @@
+Move prover returns: exiting with boogie verification errors
+error:  This assertion might not hold.
+
+    ┌── tests/sources/invariants.move:11:7 ───
+    │
+ 11 │       invariant x > 1;
+    │       ^^^^^^^^^^^^^^^^
+    │
+    =     at tests/sources/invariants.move:27:5: invalid_R_pack (entry)
+
+error:  This assertion might not hold.
+
+    ┌── tests/sources/invariants.move:14:7 ───
+    │
+ 14 │       invariant update x <= old(x);
+    │       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    │
+    =     at tests/sources/invariants.move:46:5: invalid_R_update (entry)
+    =     at tests/sources/invariants.move:47:13: invalid_R_update
+    =     at tests/sources/invariants.move:48:17: invalid_R_update
+    =         r = <redacted>,
+    =         t = <redacted>
+    =     at tests/sources/invariants.move:49:20: invalid_R_update
+    =         t = <redacted>
+
+error:  This assertion might not hold.
+
+    ┌── tests/sources/invariants.move:14:7 ───
+    │
+ 14 │       invariant update x <= old(x);
+    │       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    │
+    =     at tests/sources/invariants.move:66:5: invalid_R_update_indirectly (entry)
+    =     at tests/sources/invariants.move:67:13: invalid_R_update_indirectly
+    =     at tests/sources/invariants.move:68:28: invalid_R_update_indirectly
+    =         t = <redacted>,
+    =         t = <redacted>
+    =     at tests/sources/invariants.move:71:5: update_helper (entry)
+    =     at tests/sources/invariants.move:72:9: update_helper
+    =         r = <redacted>,
+    =         r = <redacted>
+    =     at tests/sources/invariants.move:68:9: invalid_R_update_indirectly
+
+error:  This assertion might not hold.
+
+    ┌── tests/sources/invariants.move:14:7 ───
+    │
+ 14 │       invariant update x <= old(x);
+    │       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    │
+    =     at tests/sources/invariants.move:56:5: invalid_R_update_ref (entry)
+    =     at tests/sources/invariants.move:57:13: invalid_R_update_ref
+    =     at tests/sources/invariants.move:58:22: invalid_R_update_ref
+    =         r = <redacted>,
+    =         t = <redacted>
+    =     at tests/sources/invariants.move:59:14: invalid_R_update_ref
+    =         t = <redacted>
+
+error:  This assertion might not hold.
+
+    ┌── tests/sources/invariants.move:11:7 ───
+    │
+ 11 │       invariant x > 1;
+    │       ^^^^^^^^^^^^^^^^
+    │
+    =     at tests/sources/invariants.move:77:5: lifetime_invalid_R (entry)
+    =     at tests/sources/invariants.move:78:13: lifetime_invalid_R
+    =     at tests/sources/invariants.move:79:21: lifetime_invalid_R
+    =         r = <redacted>,
+    =         r_ref = <redacted>
+    =     at tests/sources/invariants.move:80:26: lifetime_invalid_R
+    =         x_ref = <redacted>
+    =     at tests/sources/invariants.move:81:18: lifetime_invalid_R
+    =         r = <redacted>
+
+error:  This assertion might not hold.
+
+    ┌── tests/sources/invariants.move:94:9 ───
+    │
+ 94 │         invariant y > 1;
+    │         ^^^^^^^^^^^^^^^^
+    │
+    =     at tests/sources/invariants.move:97:5: lifetime_invalid_S_branching (entry)
+    =     at tests/sources/invariants.move:98:11: lifetime_invalid_S_branching
+    =         cond = <redacted>
+    =     at tests/sources/invariants.move:99:21: lifetime_invalid_S_branching
+    =         a = <redacted>,
+    =         b = <redacted>
+    =     at tests/sources/invariants.move:100:19: lifetime_invalid_S_branching
+    =         a_ref = <redacted>
+    =     at tests/sources/invariants.move:101:19: lifetime_invalid_S_branching
+    =         b_ref = <redacted>
+    =     at tests/sources/invariants.move:102:23: lifetime_invalid_S_branching
+    =         x_ref = <redacted>
+    =     at tests/sources/invariants.move:104:11: lifetime_invalid_S_branching
+    =     at tests/sources/invariants.move:107:11: lifetime_invalid_S_branching
+    =         a = <redacted>,
+    =         b = <redacted>

--- a/language/move-prover/tests/sources/invariants.move
+++ b/language/move-prover/tests/sources/invariants.move
@@ -1,0 +1,112 @@
+module Invariants {
+
+    // General invariant checking.
+
+    struct R {
+        x: u64
+    }
+
+    spec struct R {
+      // We must always have a value greater one.
+      invariant x > 1;
+
+      // When we update via a reference, the new value must be smaller or equal the old one.
+      invariant update x <= old(x);
+    }
+
+
+    // Pack tests
+
+    fun valid_R_pack(): R {
+        R {x: 2}
+    }
+    spec fun valid_R_pack {
+        ensures result.x == 2;
+    }
+
+    fun invalid_R_pack(): R {
+        R {x: 1}
+    }
+    spec fun invalid_R_pack {
+        ensures result.x == 1;
+    }
+
+    // Update tests
+
+    fun valid_R_update(): R {
+        let t = R {x: 3};
+        let r = &mut t;
+        *r = R {x: 2};
+        t
+    }
+    spec fun valid_R_update {
+        ensures result.x == 2;
+    }
+
+    fun invalid_R_update(): R {
+        let t = R {x: 3};
+        let r = &mut t;
+        *r = R {x: 4};
+        t
+    }
+    spec fun invalid_R_update {
+        ensures result.x == 4;
+    }
+
+    fun invalid_R_update_ref(): R {
+        let t = R{x:3};
+        let r = &mut t.x;
+        *r = 4;
+        t
+    }
+    spec fun invalid_R_update_ref {
+        ensures result.x == 4;
+    }
+
+    fun invalid_R_update_indirectly(): R {
+        let t = R{x:3};
+        update_helper(&mut t.x);
+        t
+    }
+    fun update_helper(r: &mut u64) {
+        *r = 4;
+    }
+
+    // Lifetime analysis tests
+
+    fun lifetime_invalid_R() : R {
+        let r = R {x: 3};
+        let r_ref = &mut r;
+        let x_ref = &mut r_ref.x;
+        *x_ref = 0; // r_ref goes out of scope here
+
+        r_ref = &mut r;
+        x_ref = &mut r_ref.x;
+        *x_ref = 2;
+
+        r
+    }
+
+    struct S {
+        y: u64
+    }
+    spec struct S {
+        invariant y > 1;
+    }
+
+    fun lifetime_invalid_S_branching(cond: bool): (R, S) {
+      let a = R {x: 3};
+      let b = S {y: 4};
+      let a_ref = &mut a;
+      let b_ref = &mut b;
+      let x_ref = if (cond) { &mut a_ref.x } else { &mut b_ref.y };
+
+      if (cond) {
+          *x_ref = 2;
+      } else {
+          *x_ref = 0;  // only S's invariant should fail
+      }; // <-- TODO: file a parser bug that the semicolon here is needed
+
+      (a, b)
+    }
+}

--- a/language/move-prover/tests/testsuite.rs
+++ b/language/move-prover/tests/testsuite.rs
@@ -17,7 +17,8 @@ fn test_runner(path: &Path) -> datatest_stable::Result<()> {
         !no_boogie || !extract_test_directives(path, "// no-boogie-test")?.is_empty();
     let mut sources = extract_test_directives(path, "// dep:")?;
     sources.push(path.to_string_lossy().to_string());
-    let mut args = vec!["-v=debug".to_string()];
+    // The first argument in the args list is interpreted as program name, so set something here.
+    let mut args = vec!["mvp_test".to_string()];
     args.extend_from_slice(&sources);
     let mut options = Options::default();
     options.initialize_from_args(&args);
@@ -25,6 +26,7 @@ fn test_runner(path: &Path) -> datatest_stable::Result<()> {
     if no_boogie {
         options.generate_only = true;
     }
+    options.stable_test_output = true;
 
     let temp_path = TempPath::new();
     temp_path.create_as_dir()?;


### PR DESCRIPTION
This ports the mvir tests `verify-invariants.mvir`, `verify-synthetics.mvir`, and `verify-lifetime.mvir`, and fixes a few smaller bugs around this feature. The 'WriteRef` invariant model where invariants are enforced at write time has been removed in favor of the lifetime model.  The PR also refines error reporting in the presence of invariant verification errors. The results aren't ideal yet (specifically we cannot see the global var values), but good enough for now.

## Motivation

Moving Move Prover to new Move Lang.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

New tests.

## Related PRs

This is based on a commit from unmerged PR #2842, which needs to go in first. Please focus on the second commit only, and check the other PR for the first one.