### PR TITLE
[JSON RPC] migrate CLI submit_transaction from gRPC to JSON RPC

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -684,6 +684,7 @@ dependencies = [
  "num-traits 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "parity-multiaddr 0.7.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "proptest 0.9.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "reqwest 0.10.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "rust_decimal 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "rustyline 6.0.0 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/client/cli/Cargo.toml
+++ b/client/cli/Cargo.toml
@@ -20,7 +20,8 @@ rustyline = "6.0.0"
 rust_decimal = "1.3.0"
 num-traits = "0.2"
 parity-multiaddr = { version = "0.7.2", default-features = false }
-reqwest = { version = "0.10.4", features = ["blocking"], default-features = false }
+rand = "0.6.5"
+reqwest = { version = "0.10.4", features = ["blocking", "json"], default-features = false }
 serde = { version = "1.0.96", features = ["derive"] }
 serde_json = "1.0.48"
 structopt = "0.3.2"

--- a/client/cli/src/lib.rs
+++ b/client/cli/src/lib.rs
@@ -23,8 +23,8 @@ pub mod client_proxy;
 /// Command struct to interact with client.
 pub mod commands;
 mod dev_commands;
-/// gRPC client wrapper to connect to validator.
-mod grpc_client;
+/// Client wrapper to connect to validator.
+mod libra_client;
 mod query_commands;
 mod transfer_commands;
 

--- a/client/cli/src/main.rs
+++ b/client/cli/src/main.rs
@@ -29,8 +29,12 @@ use structopt::StructOpt;
 )]
 struct Args {
     /// Admission Control port to connect to.
+    /// TODO deprecate this completely once migration to JSON RPC is complete
     #[structopt(short = "p", long, default_value = "8000")]
     pub port: NonZeroU16,
+    /// JSON RPC port to connect to.
+    #[structopt(short = "j", long, default_value = "5000")]
+    pub json_rpc_port: NonZeroU16,
     /// Host address/name to connect to.
     #[structopt(short = "a", long)]
     pub host: String,
@@ -97,6 +101,7 @@ fn main() {
     let mut client_proxy = ClientProxy::new(
         &args.host,
         args.port.get(),
+        args.json_rpc_port.get(),
         &faucet_account_file,
         args.sync,
         args.faucet_server.clone(),

--- a/json-rpc/src/views.rs
+++ b/json-rpc/src/views.rs
@@ -35,7 +35,6 @@ impl AccountView {
             authentication_key: BytesView::from(account.authentication_key()),
             sent_events_key: BytesView::from(account.sent_events().key().as_bytes()),
             received_events_key: BytesView::from(account.received_events().key().as_bytes()),
-
             delegated_key_rotation_capability: account.delegated_key_rotation_capability(),
             delegated_withdrawal_capability: account.delegated_withdrawal_capability(),
         }

--- a/libra-swarm/src/client.rs
+++ b/libra-swarm/src/client.rs
@@ -39,7 +39,8 @@ impl Drop for InteractiveClient {
 
 impl InteractiveClient {
     pub fn new_with_inherit_io(
-        port: u16,
+        ac_port: u16,
+        json_rpc_port: u16,
         faucet_key_file_path: &Path,
         mnemonic_file_path: &Path,
     ) -> Self {
@@ -52,7 +53,9 @@ impl InteractiveClient {
                 Command::new(workspace_builder::get_bin("cli"))
                     .current_dir(workspace_builder::workspace_root())
                     .arg("-p")
-                    .arg(port.to_string())
+                    .arg(ac_port.to_string())
+                    .arg("-j")
+                    .arg(json_rpc_port.to_string())
                     .arg("-m")
                     .arg(
                         faucet_key_file_path
@@ -141,12 +144,18 @@ pub struct InProcessTestClient {
 }
 
 impl InProcessTestClient {
-    pub fn new(port: u16, faucet_key_file_path: &Path, mnemonic_file_path: &str) -> Self {
+    pub fn new(
+        ac_port: u16,
+        json_rpc_port: u16,
+        faucet_key_file_path: &Path,
+        mnemonic_file_path: &str,
+    ) -> Self {
         let (_, alias_to_cmd) = commands::get_commands(true);
         Self {
             client: ClientProxy::new(
                 "localhost",
-                port,
+                ac_port,
+                json_rpc_port,
                 faucet_key_file_path
                     .canonicalize()
                     .expect("Unable to get canonical path of faucet key file")

--- a/libra-swarm/src/main.rs
+++ b/libra-swarm/src/main.rs
@@ -84,8 +84,9 @@ fn main() {
     let validator_config = NodeConfig::load(&validator_swarm.config.config_files[0]).unwrap();
     println!("To run the Libra CLI client in a separate process and connect to the validator nodes you just spawned, use this command:");
     println!(
-        "\tcargo run --bin cli -- -a localhost -p {} -m {:?}",
+        "\tcargo run --bin cli -- -a localhost -p {} -j {} -m {:?}",
         validator_config.admission_control.address.port(),
+        validator_config.rpc.address.port(),
         faucet_key_file_path,
     );
     let node_address_list = validator_swarm
@@ -111,8 +112,9 @@ fn main() {
         let full_node_config = NodeConfig::load(&swarm.config.config_files[0]).unwrap();
         println!("To connect to the full nodes you just spawned, use this command:");
         println!(
-            "\tcargo run --bin cli -- -a localhost -p {} -m {:?}",
+            "\tcargo run --bin cli -- -a localhost -p {} - j {} -m {:?}",
             full_node_config.admission_control.address.port(),
+            full_node_config.rpc.address.port(),
             faucet_key_file_path,
         );
     }
@@ -120,8 +122,10 @@ fn main() {
     let tmp_mnemonic_file = TempPath::new();
     tmp_mnemonic_file.create_as_file().unwrap();
     if args.start_client {
+        let (ac_port, json_rpc_port) = validator_swarm.get_client_ports(0);
         let client = client::InteractiveClient::new_with_inherit_io(
-            validator_swarm.get_ac_port(0),
+            ac_port,
+            json_rpc_port,
             Path::new(&faucet_key_file_path),
             &tmp_mnemonic_file.path(),
         );

--- a/libra-swarm/src/swarm.rs
+++ b/libra-swarm/src/swarm.rs
@@ -28,6 +28,7 @@ pub struct LibraNode {
     role: RoleType,
     debug_client: NodeDebugClient,
     ac_port: u16,
+    json_rpc_port: u16,
     log: PathBuf,
 }
 
@@ -93,6 +94,7 @@ impl LibraNode {
             role,
             debug_client,
             ac_port: config.admission_control.address.port(),
+            json_rpc_port: config.rpc.address.port(),
             log: log_path,
         })
     }
@@ -103,6 +105,10 @@ impl LibraNode {
 
     pub fn ac_port(&self) -> u16 {
         self.ac_port
+    }
+
+    pub fn json_rpc_port(&self) -> u16 {
+        self.json_rpc_port
     }
 
     pub fn get_log_contents(&self) -> Result<String> {
@@ -504,10 +510,14 @@ impl LibraSwarm {
         false
     }
 
-    /// A specific public AC port of a validator or a full node.
-    pub fn get_ac_port(&self, index: usize) -> u16 {
+    /// A specific public ports of a validator or a full node.
+    /// Returns (AC port, JSON RPC port)
+    pub fn get_client_ports(&self, index: usize) -> (u16, u16) {
         let node_id = format!("{}", index);
-        self.nodes.get(&node_id).map(|node| node.ac_port()).unwrap()
+        self.nodes
+            .get(&node_id)
+            .map(|node| (node.ac_port(), node.json_rpc_port()))
+            .unwrap()
     }
 
     /// Vector with the peer ids of the validators in the swarm.

--- a/scripts/cli/start_cli_testnet.sh
+++ b/scripts/cli/start_cli_testnet.sh
@@ -13,7 +13,7 @@ source "$HOME/.cargo/env"
 
 SCRIPT_PATH="$(dirname $0)"
 
-RUN_PARAMS="--host ac.testnet.libra.org --port 8000 "
+RUN_PARAMS="--host ac.testnet.libra.org --port 8000 --json_rpc_port 5000 "
 RELEASE=""
 
 while [[ ! -z "$1" ]]; do

--- a/testsuite/tests/libratest/smoke_test.rs
+++ b/testsuite/tests/libratest/smoke_test.rs
@@ -112,7 +112,12 @@ impl TestEnvironment {
         panic!("Max out {} attempts to launch test swarm", num_attempts);
     }
 
-    fn get_ac_client(&self, port: u16, waypoint: Option<Waypoint>) -> ClientProxy {
+    fn get_ac_client(
+        &self,
+        ac_port: u16,
+        json_rpc_port: u16,
+        waypoint: Option<Waypoint>,
+    ) -> ClientProxy {
         let mnemonic_file_path = self
             .mnemonic_file
             .path()
@@ -125,7 +130,8 @@ impl TestEnvironment {
 
         ClientProxy::new(
             "localhost",
-            port,
+            ac_port,
+            json_rpc_port,
             &self.faucet_key.1,
             false,
             /* faucet server */ None,
@@ -140,8 +146,8 @@ impl TestEnvironment {
         node_index: usize,
         waypoint: Option<Waypoint>,
     ) -> ClientProxy {
-        let port = self.validator_swarm.get_ac_port(node_index);
-        self.get_ac_client(port, waypoint)
+        let (ac_port, json_rpc_port) = self.validator_swarm.get_client_ports(node_index);
+        self.get_ac_client(ac_port, json_rpc_port, waypoint)
     }
 
     fn get_full_node_ac_client(
@@ -151,8 +157,8 @@ impl TestEnvironment {
     ) -> ClientProxy {
         match &self.full_node_swarm {
             Some(swarm) => {
-                let port = swarm.get_ac_port(node_index);
-                self.get_ac_client(port, waypoint)
+                let (ac_port, json_rpc_port) = swarm.get_client_ports(node_index);
+                self.get_ac_client(ac_port, json_rpc_port, waypoint)
             }
             None => {
                 panic!("Full Node swarm is not initialized");


### PR DESCRIPTION
## Summary

As a first step in migrating from gRPC to JSON RPC in Libra Client CLI, migrating `submit_transaction` functionality to use JSON RPC
- add new `JsonRpcClientBlocking` analogous to `AdmissionControlClientBlocking`
- updated CLI and `libra-swarm` initialization to support both AC and JSON RPC to temporarily support transition

## Test Plan

Tested on local Libra swarm CLI
