### PR TITLE
[compiler] fix error message of struct map and unify param names

### DIFF
--- a/language/compiler/bytecode-source-map/src/source_map.rs
+++ b/language/compiler/bytecode-source-map/src/source_map.rs
@@ -317,13 +317,13 @@ impl<Location: Clone + Eq> ModuleSourceMap<Location> {
 
     pub fn add_code_mapping(
         &mut self,
-        function_definition_index: FunctionDefinitionIndex,
+        fdef_idx: FunctionDefinitionIndex,
         start_offset: CodeOffset,
         location: Location,
     ) -> Result<()> {
         let func_entry = self
             .function_map
-            .get_mut(&function_definition_index.0)
+            .get_mut(&fdef_idx.0)
             .ok_or_else(|| format_err!("Tried to add code mapping to undefined function index"))?;
         func_entry.add_code_mapping(start_offset, location);
         Ok(())
@@ -333,11 +333,11 @@ impl<Location: Clone + Eq> ModuleSourceMap<Location> {
     /// the location in the source code associated with the instruction at that offset.
     pub fn get_code_location(
         &self,
-        function_definition_index: FunctionDefinitionIndex,
+        fdef_idx: FunctionDefinitionIndex,
         offset: CodeOffset,
     ) -> Result<Location> {
         self.function_map
-            .get(&function_definition_index.0)
+            .get(&fdef_idx.0)
             .and_then(|function_source_map| function_source_map.get_code_location(offset))
             .ok_or_else(|| format_err!("Tried to get code location from undefined function index"))
     }
@@ -401,11 +401,11 @@ impl<Location: Clone + Eq> ModuleSourceMap<Location> {
 
     pub fn add_struct_type_parameter_mapping(
         &mut self,
-        fdef_idx: StructDefinitionIndex,
+        struct_def_idx: StructDefinitionIndex,
         name: SourceName<Location>,
     ) -> Result<()> {
-        let struct_entry = self.struct_map.get_mut(&fdef_idx.0).ok_or_else(|| {
-            format_err!("Tried to add function type parameter mapping to undefined function index")
+        let struct_entry = self.struct_map.get_mut(&struct_def_idx.0).ok_or_else(|| {
+            format_err!("Tried to add struct type parameter mapping to undefined struct index")
         })?;
         struct_entry.add_type_parameter(name);
         Ok(())
@@ -413,15 +413,15 @@ impl<Location: Clone + Eq> ModuleSourceMap<Location> {
 
     pub fn get_struct_type_parameter_name(
         &self,
-        fdef_idx: StructDefinitionIndex,
+        struct_def_idx: StructDefinitionIndex,
         type_parameter_idx: usize,
     ) -> Result<SourceName<Location>> {
         self.struct_map
-            .get(&fdef_idx.0)
+            .get(&struct_def_idx.0)
             .and_then(|struct_source_map| {
                 struct_source_map.get_type_parameter_name(type_parameter_idx)
             })
-            .ok_or_else(|| format_err!("Unable to get function type parameter name"))
+            .ok_or_else(|| format_err!("Unable to get struct type parameter name"))
     }
 
     pub fn get_function_source_map(
@@ -435,10 +435,10 @@ impl<Location: Clone + Eq> ModuleSourceMap<Location> {
 
     pub fn get_struct_source_map(
         &self,
-        fdef_idx: StructDefinitionIndex,
+        struct_def_idx: StructDefinitionIndex,
     ) -> Result<&StructSourceMap<Location>> {
         self.struct_map
-            .get(&fdef_idx.0)
+            .get(&struct_def_idx.0)
             .ok_or_else(|| format_err!("Unable to get struct source map"))
     }
 


### PR DESCRIPTION
<!--
Thank you for sending a PR. We appreciate you spending time to help improve the Libra project.

The project is undergoing daily changes. Pull Requests will be reviewed and responded to as time permits.
-->

## Motivation

(Write your motivation for proposed changes here.)
 fix error message of struct map and unify param names

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?

Yes.

## Test Plan

(Share your test plan here. If you changed code, please provide us with clear instructions for verifying that your changes work.)
cargo xtest

## Related PRs

(If this PR adds or changes functionality, please take some time to update the docs at https://github.com/libra/website, and link to your PR here.)
