### PR TITLE
[move source language] Add implicit freezing for eq/neq

### DIFF
--- a/language/move-lang/src/cfgir/borrows/mod.rs
+++ b/language/move-lang/src/cfgir/borrows/mod.rs
@@ -6,7 +6,7 @@ mod state;
 use super::{absint::*, ast::*};
 use crate::{
     errors::*,
-    parser::ast::{StructName, Var},
+    parser::ast::{BinOp_, StructName, Var},
     shared::unique_map::UniqueMap,
 };
 use state::*;
@@ -152,7 +152,9 @@ fn lvalue(context: &mut Context, sp!(loc, l_): &LValue, value: Value) {
         }
         L::Unpack(_, _, fields) => {
             assert!(!value.is_ref());
-            fields.iter().for_each(|(_, l)| lvalue(context, l, value))
+            fields
+                .iter()
+                .for_each(|(_, l)| lvalue(context, l, Value::NonRef))
         }
     }
 }
@@ -243,11 +245,24 @@ fn exp(context: &mut Context, parent_e: &Exp) -> Values {
             assert!(!assert_single_value(v).is_ref());
             svalue()
         }
+        E::BinopExp(e1, sp!(_, BinOp_::Eq), e2) | E::BinopExp(e1, sp!(_, BinOp_::Neq), e2) => {
+            let v1 = assert_single_value(exp(context, e1));
+            let v2 = assert_single_value(exp(context, e2));
+            if v1.is_ref() {
+                // derefrence releases the id and checks that it is readable
+                assert!(v2.is_ref());
+                let (errors, _) = context.borrow_state.dereference(e1.exp.loc, v1);
+                assert!(errors.is_empty(), "ICE eq freezing failed");
+                let (errors, _) = context.borrow_state.dereference(e1.exp.loc, v2);
+                assert!(errors.is_empty(), "ICE eq freezing failed");
+            }
+            svalue()
+        }
         E::BinopExp(e1, _, e2) => {
-            let v1 = exp(context, e1);
-            let v2 = exp(context, e2);
-            context.borrow_state.release_values(v1);
-            context.borrow_state.release_values(v2);
+            let v1 = assert_single_value(exp(context, e1));
+            let v2 = assert_single_value(exp(context, e2));
+            assert!(!v1.is_ref());
+            assert!(!v2.is_ref());
             svalue()
         }
         E::Pack(_, _, fields) => {

--- a/language/move-lang/src/cfgir/borrows/state.rs
+++ b/language/move-lang/src/cfgir/borrows/state.rs
@@ -28,7 +28,7 @@ enum Label {
 
 type BorrowGraph = borrow_graph::graph::BorrowGraph<Loc, Label>;
 
-#[derive(Copy, Clone, Debug, Eq, PartialEq)]
+#[derive(Clone, Debug, Eq, PartialEq)]
 pub enum Value {
     NonRef,
     Ref(RefID),

--- a/language/move-lang/src/hlir/translate.rs
+++ b/language/move-lang/src/hlir/translate.rs
@@ -870,7 +870,8 @@ fn exp_impl(context: &mut Context, result: &mut Block, e: T::Exp) -> H::Exp {
         | TE::BinopExp(tl, op @ sp!(_, BinOp_::Neq), toperand_ty, tr) => {
             let operand_ty = type_(context, *toperand_ty);
             let (el, er) = {
-                let tes = vec![(*tl, Some(operand_ty.clone())), (*tr, Some(operand_ty))];
+                let frozen_ty = freeze_ty(operand_ty);
+                let tes = vec![(*tl, Some(frozen_ty.clone())), (*tr, Some(frozen_ty))];
                 let mut es = exp_evaluation_order(context, result, tes);
                 assert!(es.len() == 2, "ICE exp_evaluation_order changed arity");
                 let er = es.pop().unwrap();
@@ -1264,7 +1265,7 @@ fn freeze_ty(sp!(tloc, t): H::Type) -> H::Type {
     use H::Type_ as T;
     match t {
         T::Single(s) => sp(tloc, T::Single(freeze_single(s))),
-        t => panic!("ICE MULTIPLE freezing anything but a mutable ref: {:#?}", t),
+        t => sp(tloc, t),
     }
 }
 
@@ -1272,6 +1273,6 @@ fn freeze_single(sp!(sloc, s): H::SingleType) -> H::SingleType {
     use H::SingleType_ as S;
     match s {
         S::Ref(true, inner) => sp(sloc, S::Ref(false, inner)),
-        t => panic!("ICE SINGLE freezing anything but a mutable ref: {:#?}", t),
+        s => sp(sloc, s),
     }
 }

--- a/language/move-lang/tests/move_check/typing/mutable_eq_and_neq.move
+++ b/language/move-lang/tests/move_check/typing/mutable_eq_and_neq.move
@@ -1,0 +1,37 @@
+module M {
+    struct S { f: u64, g: u64 }
+    struct B { f: bool }
+    struct P { b1: B, b2: B }
+
+    fun t(r1: &mut u64, r2: &mut u64, s: &mut S) {
+        r1 == r1;
+        r1 == r2;
+        r2 == r2;
+        r2 == r2;
+
+        r1 != r1;
+        r1 != r2;
+        r2 != r2;
+        r2 != r2;
+
+        (&mut s.f) == (&mut s.f);
+        (&mut s.f) == (&mut s.g);
+        (&mut s.g) == (&mut s.f);
+        (&mut s.g) == (&mut s.g);
+
+        (&mut s.f) != (&mut s.f);
+        (&mut s.f) != (&mut s.g);
+        (&mut s.g) != (&mut s.f);
+        (&mut s.g) != (&mut s.g);
+    }
+
+    fun t1(p: &mut P) {
+        let comp = (&mut p.b1) == (&mut p.b2);
+        p.b1.f = comp
+    }
+
+    fun t2(p: &mut P) {
+        let comp = (&mut p.b1) != (&mut p.b2);
+        p.b1.f = comp
+    }
+}

--- a/language/move-lang/tests/move_check/typing/mutable_eq_and_neq_invalid.exp
+++ b/language/move-lang/tests/move_check/typing/mutable_eq_and_neq_invalid.exp
@@ -1,0 +1,22 @@
+error: 
+
+   ┌── tests/move_check/typing/mutable_eq_and_neq_invalid.move:7:20 ───
+   │
+ 7 │         let comp = (&mut p.b1) == (&mut p.b2);
+   │                    ^^^^^^^^^^^ Invalid freeze.
+   ·
+ 6 │         let f = &mut p.b1.f;
+   │                 ----------- Field 'f' is still being mutably borrowed by this reference
+   │
+
+error: 
+
+    ┌── tests/move_check/typing/mutable_eq_and_neq_invalid.move:13:20 ───
+    │
+ 13 │         let comp = (&mut p.b1) != (&mut p.b2);
+    │                    ^^^^^^^^^^^ Invalid freeze.
+    ·
+ 12 │         let f = &mut p.b1.f;
+    │                 ----------- Field 'f' is still being mutably borrowed by this reference
+    │
+

--- a/language/move-lang/tests/move_check/typing/mutable_eq_and_neq_invalid.move
+++ b/language/move-lang/tests/move_check/typing/mutable_eq_and_neq_invalid.move
@@ -1,0 +1,16 @@
+module M {
+    struct B { f: bool }
+    struct P { b1: B, b2: B }
+
+    fun t0(p: &mut P) {
+        let f = &mut p.b1.f;
+        let comp = (&mut p.b1) == (&mut p.b2);
+        *f = comp
+    }
+
+    fun t1(p: &mut P) {
+        let f = &mut p.b1.f;
+        let comp = (&mut p.b1) != (&mut p.b2);
+        *f = comp
+    }
+}


### PR DESCRIPTION
## Motivation

- Added implicit freezing to references before invoking ==/!=
  - If the references are mutable, they might not be readable. It will only be freezable if it is readable
  - By adding a freeze here, it allows cases that would otherwise have to be banned, i.e. (x == x, where x is an unborrowed mutable reference). 

## Test Plan

- new tests