### PR TITLE
[JSON RPC] migrate CLI 'get_events' functionality from gRPC to JSON RPC

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -681,6 +681,7 @@ dependencies = [
  "libra-canonical-serialization 0.1.0",
  "libra-config 0.1.0",
  "libra-crypto 0.1.0",
+ "libra-json-rpc 0.1.0",
  "libra-logger 0.1.0",
  "libra-metrics 0.1.0",
  "libra-temppath 0.1.0",

--- a/client/cli/Cargo.toml
+++ b/client/cli/Cargo.toml
@@ -33,6 +33,7 @@ crash-handler = { path = "../../common/crash-handler", version = "0.1.0" }
 libra-crypto = { path = "../../crypto/crypto", version = "0.1.0" }
 lcs = { path = "../../common/lcs", version = "0.1.0", package = "libra-canonical-serialization" }
 libra-wallet = { path = "../libra_wallet", version = "0.1.0" }
+libra-json-rpc = { path = "../../json-rpc", version = "0.1.0" }
 libra-logger =  { path = "../../common/logger", version = "0.1.0" }
 libra-metrics = { path = "../../common/metrics", version = "0.1.0" }
 libra-types = { path = "../../types", version = "0.1.0" }

--- a/client/cli/src/client_proxy.rs
+++ b/client/cli/src/client_proxy.rs
@@ -9,6 +9,7 @@ use libra_crypto::{
     x25519::X25519StaticPublicKey,
     ValidKey, ValidKeyStringExt,
 };
+use libra_json_rpc::views::{AccountView, EventView};
 use libra_logger::prelude::*;
 use libra_temppath::TempPath;
 use libra_types::{
@@ -19,8 +20,8 @@ use libra_types::{
         CORE_CODE_ADDRESS,
     },
     account_state::AccountState,
-    account_state_blob::{AccountStateBlob, AccountStateWithProof},
-    contract_event::{ContractEvent, EventWithProof},
+    account_state_blob::AccountStateBlob,
+    contract_event::ContractEvent,
     crypto_proxies::LedgerInfoWithSignatures,
     transaction::{
         helpers::{create_unsigned_txn, create_user_txn, TransactionSigner},
@@ -803,7 +804,7 @@ impl ClientProxy {
     pub fn get_events_by_account_and_type(
         &mut self,
         space_delim_strings: &[&str],
-    ) -> Result<(Vec<EventWithProof>, AccountStateWithProof)> {
+    ) -> Result<(Vec<EventView>, AccountView)> {
         ensure!(
             space_delim_strings.len() == 6,
             "Invalid number of arguments to get events by access path"
@@ -826,9 +827,6 @@ impl ClientProxy {
                 error,
             )
         })?;
-        let ascending = parse_bool(space_delim_strings[4]).map_err(|error| {
-            format_parse_data_error("ascending", InputType::Bool, space_delim_strings[4], error)
-        })?;
         let limit = space_delim_strings[5].parse::<u64>().map_err(|error| {
             format_parse_data_error(
                 "start_seq_number",
@@ -838,7 +836,7 @@ impl ClientProxy {
             )
         })?;
         self.client
-            .get_events_by_access_path(access_path, start_seq_number, ascending, limit)
+            .get_events_by_access_path(access_path, start_seq_number, limit)
     }
 
     /// Write mnemonic recover to the file specified.

--- a/client/cli/src/query_commands.rs
+++ b/client/cli/src/query_commands.rs
@@ -205,7 +205,7 @@ impl Command for QueryCommandGetEvent {
         vec!["event", "ev"]
     }
     fn get_params_help(&self) -> &'static str {
-        "<account_ref_id>|<account_address> <sent|received> <start_sequence_number> <ascending=true|false> <limit>"
+        "<account_ref_id>|<account_address> <sent|received> <start_sequence_number> <limit>"
     }
     fn get_description(&self) -> &'static str {
         "Get events by account and event type (sent|received)."
@@ -218,7 +218,7 @@ impl Command for QueryCommandGetEvent {
                     println!("No events returned");
                 } else {
                     for event in events {
-                        println!("{}", event);
+                        println!("{:?}", event);
                     }
                 }
                 println!("Last event state: {:#?}", last_event_state);

--- a/json-rpc/src/lib.rs
+++ b/json-rpc/src/lib.rs
@@ -19,7 +19,7 @@ mod util;
 
 mod methods;
 mod runtime;
-mod views;
+pub mod views;
 
 pub use runtime::bootstrap_from_config;
 

--- a/json-rpc/src/views.rs
+++ b/json-rpc/src/views.rs
@@ -47,7 +47,7 @@ impl AccountView {
     }
 }
 
-#[derive(Serialize, Deserialize)]
+#[derive(Debug, Serialize, Deserialize)]
 pub struct EventView {
     pub key: BytesView,
     pub sequence_number: u64,
@@ -55,7 +55,7 @@ pub struct EventView {
     pub data: EventDataView,
 }
 
-#[derive(Serialize, Deserialize)]
+#[derive(Debug, Serialize, Deserialize)]
 #[serde(tag = "type")]
 pub enum EventDataView {
     ReceivedPayment {
@@ -109,7 +109,7 @@ pub struct BlockMetadata {
 }
 
 #[derive(Serialize, Deserialize, Debug, PartialEq)]
-pub struct BytesView(String);
+pub struct BytesView(pub String);
 
 impl From<&[u8]> for BytesView {
     fn from(bytes: &[u8]) -> Self {


### PR DESCRIPTION
## Summary

Migrate Libra CLI's `get_events` functionality to use JSON RPC instead of gRPC. This PR also: 
- removes proofs from the events and account states returned
- removes `ascending` parameter in `get_events`
- implicitly implement `get_events` and `get_account_state` for `LibraClient`
