### PR TITLE
[move-prover] Implemented quantification over ranges

### DIFF
--- a/language/move-prover/src/prelude.bpl
+++ b/language/move-prover/src/prelude.bpl
@@ -98,6 +98,7 @@ function {:constructor} Address(a: Address): Value;
 function {:constructor} ByteArray(b: ByteArray): Value;
 function {:constructor} Str(a: String): Value;
 function {:constructor} Vector(v: ValueArray): Value; // used to both represent move Struct and Vector
+function {:constructor} $Range(lb: Value, ub: Value): Value;
 function {:constructor} Error(): Value;
 const DefaultValue: Value;
 axiom DefaultValue == Error();
@@ -281,6 +282,10 @@ function {:inline} $vmap(v: Value): [int]Value {
 function {:inline} $vlen(v: Value): int {
     l#ValueArray(v#Vector(v))
 }
+// Sometimes, we need the length as a Value, not an int.
+function {:inline} $vlen_value(v: Value): Value {
+    Integer($vlen(v))
+}
 function {:inline} mk_vector(): Value {
     Vector(EmptyValueArray)
 }
@@ -302,6 +307,10 @@ function {:inline} $update_vector(v: Value, i: int, elem: Value): Value {
 function {:inline} $select_vector(v: Value, i: int) : Value {
     $vmap(v)[i]
 }
+// $select_vector_by_value requires index to be a Value, not int.
+function {:inline} $select_vector_by_value(v: Value, i: Value) : Value {
+    $vmap(v)[i#Integer(i)]
+}
 function {:inline} swap_vector(v: Value, i: int, j: int): Value {
     Vector(SwapValueArray(v#Vector(v), i, j))
 }
@@ -312,6 +321,10 @@ function {:inline} $slice_vector(v: Value, i: int, j: int) : Value {
 function {:inline} $InVectorRange(v: Value, i: int): bool {
     i >= 0 && i < $vlen(v)
 }
+function {:inline} $InRange(r: Value, i: int): bool {
+   i#Integer(lb#$Range(r)) <= i && i < i#Integer(ub#$Range(r))
+}
+
 
 // ============================================================================================
 // Memory

--- a/language/move-prover/tests/sources/vector.move
+++ b/language/move-prover/tests/sources/vector.move
@@ -36,5 +36,6 @@ module TestVector {
 
     spec fun vector_of_proper_positives {
       ensures all(result, |n| n > 0);
+      ensures all(0..len(result), (|i| all(0..len(result), (|j| result[i] == result[j] ==> i == j))));
     }
 }


### PR DESCRIPTION
Filled in missing support for quantification over ranges in the specification language.

There were some issues in generated boogie code with Value and int types getting mixed up.

This caused Boogie to get type errors, which were typically reported by the Move Prover like this:

bug: output.bpl(1208,438): Error: invalid type for argument 1 in application of IsEqual: int (expected: Value)

To address this, I added to the prelude $vlen_value, which returns the length of a vector as a Value, not as an int, and $select_vector_by_value, which indexes into a vector using a Value (Integer) for the index instead of an int. I am not yet confident that we have nailed all such problems, or that
my fixes are consistent.

I changed spec_translator.rs:translate_call to generate calls to these functions for "len" and "index" nodes.

There was also an issue with nested quantified expressions.  The generated Boogie code used constant names for the range and quantified variable which clashed when there was a nested quantified expression. I added a new function fresh_var_name(&str) that generates a string
for a unique variable name, and used those names in the generated Boogie code.

<!--
Thank you for sending a PR. We appreciate you spending time to help improve the Libra project.

The project is undergoing daily changes. Pull Requests will be reviewed and responded to as time permits.
-->

## Motivation

Add functionality to the Move Prover.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?

Yes.

## Test Plan

Added an assertion to vector.move test, cargo test

## Related PRs

#2831

(If this PR adds or changes functionality, please take some time to update the docs at https://github.com/libra/website, and link to your PR here.)
