### PR TITLE
[network] Add structs for new network wire protocol

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3242,6 +3242,7 @@ dependencies = [
  "proptest 0.9.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_repr 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "socket-bench-server 0.1.0",
  "thiserror 1.0.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio 0.2.13 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -4682,6 +4683,16 @@ dependencies = [
  "itoa 0.4.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "ryu 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "serde_repr"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "proc-macro2 1.0.9 (registry+https://github.com/rust-lang/crates.io-index)",
+ "quote 1.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 1.0.16 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -6893,6 +6904,7 @@ dependencies = [
 "checksum serde-value 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)" = "5a65a7291a8a568adcae4c10a677ebcedbc6c9cec91c054dee2ce40b0e3290eb"
 "checksum serde_derive 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)" = "128f9e303a5a29922045a830221b8f78ec74a5f544944f3d5984f8ec3895ef64"
 "checksum serde_json 1.0.48 (registry+https://github.com/rust-lang/crates.io-index)" = "9371ade75d4c2d6cb154141b9752cf3781ec9c05e0e5cf35060e1e70ee7b9c25"
+"checksum serde_repr 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "cd02c7587ec314570041b2754829f84d873ced14a96d1fd1823531e11db40573"
 "checksum serde_urlencoded 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)" = "9ec5d77e2d4c73717816afac02670d5c4f534ea95ed430442cad02e7a6e32c97"
 "checksum serde_yaml 0.8.11 (registry+https://github.com/rust-lang/crates.io-index)" = "691b17f19fc1ec9d94ec0b5864859290dff279dbd7b03f017afda54eb36c3c35"
 "checksum sha-1 0.8.2 (registry+https://github.com/rust-lang/crates.io-index)" = "f7d94d0bede923b3cea61f3f1ff57ff8cdfd77b400fb8f9998949e0cf04163df"

--- a/common/lcs/src/lib.rs
+++ b/common/lcs/src/lib.rs
@@ -143,7 +143,7 @@
 //! Structures are fixed length sequences consisting of fields with potentially different types.
 //! Each field within a struct is serialized in the order specified by the canonical structure
 //! definition. Structs can exist within other structs and as such, LCS recurses into each struct
-//! ans serializes them in order. There are no labels in the serialized format, the struct ordering
+//! and serializes them in order. There are no labels in the serialized format, the struct ordering
 //! defines the organization within the serialization stream.
 //!
 //! ```rust

--- a/network/Cargo.toml
+++ b/network/Cargo.toml
@@ -19,6 +19,7 @@ pin-project = "0.4.2"
 prometheus = { version = "0.8.0", default-features = false }
 rand = "0.6.5"
 serde = { version = "1.0.99", default-features = false }
+serde_repr = "0.1"
 thiserror = "1.0"
 tokio = { version = "0.2.13", features = ["full"] }
 tokio-util = { version = "0.3", features = ["codec"] }
@@ -35,9 +36,8 @@ libra-security-logger = { path = "../common/security-logger", version = "0.1.0" 
 memsocket = { path = "memsocket", version = "0.1.0" }
 netcore = { path = "netcore", version = "0.1.0" }
 noise = { path = "noise", version = "0.1.0" }
-
 libra-proptest-helpers = { path = "../common/proptest-helpers", version = "0.1.0", optional = true }
-proptest = { version = "0.9.4", default-features = false, optional = true }
+proptest = { version = "0.9.4", default-features = true, optional = true }
 
 [dev-dependencies]
 criterion = "=0.3.1"

--- a/network/src/protocols/mod.rs
+++ b/network/src/protocols/mod.rs
@@ -11,3 +11,4 @@ pub mod rpc;
 pub(crate) mod discovery;
 pub(crate) mod health_checker;
 pub(crate) mod identity;
+pub(crate) mod wire;

--- a/network/src/protocols/wire/handshake.rs
+++ b/network/src/protocols/wire/handshake.rs
@@ -1,0 +1,5 @@
+// Copyright (c) The Libra Core Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+// v1 of the LibraNet handshake protocol.
+pub(crate) mod v1;

--- a/network/src/protocols/wire/handshake/v1/bitvec.rs
+++ b/network/src/protocols/wire/handshake/v1/bitvec.rs
@@ -1,0 +1,200 @@
+// Copyright (c) The Libra Core Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+//! This library defines a BitVec struct that represents a bit vector.
+
+use bytes::{BufMut, BytesMut};
+use serde::{de::Error, Deserialize, Deserializer, Serialize};
+use std::ops::BitAnd;
+
+// Every u8 is used as a bucket of 8 bits. Total max buckets = 256 / 8 = 32.
+const BUCKET_SIZE: usize = 8;
+const MAX_BUCKETS: usize = 32;
+
+/// BitVec represents a bit vector that upports only 2 operations:
+/// 1. Marking a position as set, and
+/// 2. Checking if a position is set.
+/// Internally, it stores a vector of u8's (as Bytes).
+/// * The first 8 positions of the bit vector are encoded in the first element of the vector, the
+///   next 8 are encoded in the second element, and so on.
+/// * Each bit of a u8 is set to 1 if the position is set and to 0 if it's not.
+/// * We only allow setting positions upto u8::MAX. As a result, the size of the inner vector is
+///   limited to 32 (= 256 / 8).
+/// * Once a bit has been set, it cannot be unset. As a result, the inner vector cannot shrink.
+/// * The positions can be set in any order.
+/// * A position can set more than once -- it remains set after the first time.
+///
+/// # Examples:
+/// ```ignore
+/// let mut bv = BitVec::default();
+/// bv.set(2);
+/// bv.set(5);
+/// assert!(bv.is_set(2));
+/// assert!(bv.is_set(5));
+/// assert_eq!(false, bv.is_set(0));
+///
+/// // A bitwise AND of BitVec can be performed by using the `&` operator.
+/// let bv1 = BitVec::default();
+/// bv1.set(2);
+/// bv1.set(3);
+/// let bv2 = BitVec::default();
+/// bv2.set(2);
+/// let intersection = bv1 & bv2;
+/// assert!(intersection.is_set(2));
+/// assert_eq!(false, intersection.is_set(3));
+/// ```
+#[derive(Clone, Default, Debug, PartialEq, Serialize)]
+pub struct BitVec {
+    inner: BytesMut,
+}
+
+impl BitVec {
+    // TODO(abhayb): Remove after migration to new wire format.
+    #[allow(dead_code)]
+    /// Sets the bit at position @pos.
+    pub fn set(&mut self, pos: u8) {
+        // This is optimised to: let bucket = pos << 3;
+        let bucket: usize = pos as usize / BUCKET_SIZE;
+        if self.inner.len() <= bucket {
+            self.inner.resize(bucket + 1, 0);
+        }
+        // This is optimized to: let bucket_pos = pos | 0x07;
+        let bucket_pos = pos as usize - (bucket * BUCKET_SIZE);
+        self.inner[bucket] |= 0x01 << bucket_pos;
+    }
+
+    // TODO(abhayb): Remove after migration to new wire format.
+    #[allow(dead_code)]
+    /// Checks if the bit at position @pos is set.
+    pub fn is_set(&self, pos: u8) -> bool {
+        // This is optimised to: let bucket = pos << 3;
+        let bucket: usize = pos as usize / BUCKET_SIZE;
+        if self.inner.len() <= bucket {
+            return false;
+        }
+        // This is optimized to: let bucket_pos = pos | 0x07;
+        let bucket_pos = pos as usize - (bucket * BUCKET_SIZE);
+        (self.inner[bucket] & (0x01 << bucket_pos)) != 0
+    }
+}
+
+impl BitAnd for BitVec {
+    type Output = BitVec;
+
+    /// Returns a new BitVec that is a bitwise AND of two BitVecs.
+    fn bitand(self, other: Self) -> Self {
+        let len = std::cmp::min(self.inner.len(), other.inner.len());
+        let mut ret = BitVec {
+            inner: BytesMut::with_capacity(len),
+        };
+        for i in 0..len {
+            ret.inner.put_u8(self.inner[i] & other.inner[i]);
+        }
+        ret
+    }
+}
+
+// We impl custom deseriazation to ensure that the length of inner vector does not exceed 32 (=
+// 256 / 8).
+impl<'de> Deserialize<'de> for BitVec {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let v = <BytesMut>::deserialize(deserializer)?;
+        if v.len() > MAX_BUCKETS {
+            return Err(D::Error::custom(format!("BitVec too long: {}", v.len())));
+        }
+        Ok(BitVec { inner: v })
+    }
+}
+
+#[cfg(test)]
+mod test {
+
+    use super::*;
+    use proptest::prelude::*;
+    use proptest::{arbitrary::any, collection::vec};
+
+    #[test]
+    fn test_empty() {
+        let p = BitVec::default();
+        for i in 0..std::u8::MAX {
+            assert_eq!(false, p.is_set(i));
+        }
+    }
+
+    #[test]
+    fn test_extremes() {
+        let mut p = BitVec::default();
+        p.set(std::u8::MAX);
+        p.set(0);
+        assert!(p.is_set(std::u8::MAX));
+        assert!(p.is_set(0));
+        for i in 1..std::u8::MAX {
+            assert_eq!(false, p.is_set(i));
+        }
+    }
+
+    #[test]
+    fn test_deserialization() {
+        // First 4 bytes represent length.
+        let mut bytes = [0u8; 50];
+        bytes[0] = 46;
+        assert!(lcs::from_bytes::<BitVec>(&bytes).is_err());
+        let mut bytes = [0u8; 36];
+        bytes[0] = 32;
+        let bv = BitVec {
+            inner: BytesMut::from([0u8; 32].as_ref()),
+        };
+        assert_eq!(Ok(bv), lcs::from_bytes::<BitVec>(&bytes));
+    }
+
+    // Constructs a bit vector by setting the positions specified in the argument vector. The
+    // vector can have duplicates and need not be sorted.
+    fn construct_bitvec(posns: &[u8]) -> BitVec {
+        let mut bv = BitVec::default();
+        posns.iter().for_each(|x| bv.set(*x));
+        bv
+    }
+
+    // Proptest for ensuring is_set returns true iff corresponding position was set.
+    proptest! {
+        #[test]
+        fn test_arbitrary(mut v in vec(any::<u8>(), 0..256)) {
+            let bv = construct_bitvec(&v);
+            // Sort and dedup the vector so we can iterate over its elements from smallest to largest.
+            v.sort_unstable();
+            v.dedup();
+            let mut viter = v.into_iter().peekable();
+            // Positions in bv should be set iff they are in v.
+            for i in 0..std::u8::MAX {
+                if viter.peek() == Some(&i) {
+                    prop_assert!(bv.is_set(i));
+                    viter.next();
+                } else {
+                    prop_assert_eq!(false, bv.is_set(i));
+                }
+            }
+
+        }
+    }
+
+    // Test for bitwise AND operation on 2 bitvecs.
+    proptest! {
+        #[test]
+        fn test_and(v1 in vec(any::<u8>(), 0..256), v2 in vec(any::<u8>(), 0..256)) {
+            let bv1 = construct_bitvec(&v1);
+            let bv2 = construct_bitvec(&v2);
+            let intersection = bv1.clone() & bv2.clone();
+            for i in 0..std::u8::MAX {
+                if bv1.is_set(i) && bv2.is_set(i) {
+                    prop_assert!(intersection.is_set(i));
+                } else {
+                    prop_assert_eq!(false, intersection.is_set(i));
+                }
+            }
+
+        }
+    }
+}

--- a/network/src/protocols/wire/handshake/v1/mod.rs
+++ b/network/src/protocols/wire/handshake/v1/mod.rs
@@ -1,0 +1,35 @@
+// Copyright (c) The Libra Core Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+//! This module defines the structs transported during the network handshake protocol v1.
+//! These should serialize as per [link](TODO: Add ref).
+//!
+//! During the v1 Handshake protocol, both end-points of a connection send a serialized and
+//! length-prefixed `HandshakeMsg` to each other. The handshake message contains a map from
+//! supported messaging protocol versions to a bit vector representing application protocols
+//! supported over that messaging protocol. On receipt, both ends will determine the highest
+//! intersecting messaging protocol version and use that for the remainder of the session.
+
+use serde::{Deserialize, Serialize};
+use serde_repr::{Deserialize_repr, Serialize_repr};
+use std::collections::HashMap;
+
+mod bitvec;
+#[cfg(test)]
+mod test;
+
+/// The HandshakeMsg contains a mapping from MessagingProtocolVersion suppported by the node to a
+/// bit-vector specifying application-level protocols supported over that version.
+#[derive(Clone, Debug, Deserialize, Serialize)]
+pub struct HandshakeMsg {
+    pub supported_protocols: HashMap<MessagingProtocolVersion, bitvec::BitVec>,
+}
+
+/// Enum representing different versions of the Libra network protocol. These should be listed from
+/// old to new, old having the smallest value.
+/// We derive `PartialOrd` since nodes need to find highest intersecting protocol version.
+#[repr(u8)]
+#[derive(Eq, PartialEq, PartialOrd, Clone, Debug, Hash, Deserialize_repr, Serialize_repr)]
+pub enum MessagingProtocolVersion {
+    V1 = 0,
+}

--- a/network/src/protocols/wire/handshake/v1/test.rs
+++ b/network/src/protocols/wire/handshake/v1/test.rs
@@ -1,0 +1,12 @@
+// Copyright (c) The Libra Core Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+use super::*;
+
+// Ensure serialization of MessagingProtocolVersion enum takes 1 byte.
+#[test]
+fn net_protocol() -> lcs::Result<()> {
+    let protocol = MessagingProtocolVersion::V1;
+    assert_eq!(lcs::to_bytes(&protocol)?, vec![0x00]);
+    Ok(())
+}

--- a/network/src/protocols/wire/messaging.rs
+++ b/network/src/protocols/wire/messaging.rs
@@ -1,0 +1,5 @@
+// Copyright (c) The Libra Core Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+// v1 of the LibraNet messaging protocol.
+mod v1;

--- a/network/src/protocols/wire/messaging/v1/mod.rs
+++ b/network/src/protocols/wire/messaging/v1/mod.rs
@@ -1,0 +1,86 @@
+// Copyright (c) The Libra Core Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+//! This module defines the structs transported during the network messaging protocol v1.
+//! These should serialize as per [link](TODO: Add ref).
+
+use crate::protocols::wire::handshake::v1::MessagingProtocolVersion;
+use bytes::Bytes;
+use serde::{Deserialize, Serialize};
+use serde_repr::{Deserialize_repr, Serialize_repr};
+
+#[cfg(test)]
+mod test;
+
+/// Message variants that are sent on the wire.
+/// New variants cannot be added without bumping up the MessagingProtocolVersion.
+#[derive(Clone, Debug, Deserialize, Serialize)]
+pub enum NetworkMessage {
+    Error(ErrorCode),
+    Ping(Nonce),
+    Pong(Nonce),
+    RpcRequest(RpcRequest),
+    RpcResponse(RpcResponse),
+    DirectSendMsg(DirectSendMsg),
+}
+
+/// Unique identifier associated with each application protocol.
+/// New application protocols can be added without bumping up the MessagingProtocolVersion.
+#[repr(u8)]
+#[derive(Clone, Debug, Deserialize_repr, Serialize_repr)]
+pub enum ProtocolId {
+    ConsensusRpc = 0,
+    ConsensusDirectSend = 1,
+    MempoolDirectSend = 2,
+    StateSynchronizerDirectSend = 3,
+    DiscoveryDirectSend = 4,
+    HealthCheckerRpc = 5,
+    IdentityDirectSend = 6,
+}
+
+/// Enum representing various error codes that can be embedded in NetworkMessage.
+/// New variants cannot be added without bumping up the MessagingProtocolVersion.
+#[derive(Clone, Debug, Deserialize, Serialize)]
+pub enum ErrorCode {
+    /// Failed to parse NetworkMessage when interpreting according to provided protocol version.
+    ParsingError(MessagingProtocolVersion, Box<NetworkMessage>),
+    /// Ping timed out.
+    TimedOut,
+}
+
+/// Nonces used by Ping and Pong message types.
+#[derive(Clone, Debug, Deserialize, Serialize)]
+pub struct Nonce(u32);
+
+#[derive(Clone, Debug, Deserialize, Serialize)]
+pub struct RpcRequest {
+    /// RequestId for the RPC Request.
+    pub request_id: u32,
+    /// `protocol_id` is a variant of the ProtocolId enum.
+    pub protocol_id: ProtocolId,
+    /// Request priority in the range 0..=255.
+    pub priority: u8,
+    /// Request payload. This will be parsed by the application-level handler.
+    pub raw_request: Bytes,
+}
+
+#[derive(Clone, Debug, Deserialize, Serialize)]
+pub struct RpcResponse {
+    /// RequestId for corresponding request. This is copied as is from the RpcRequest.
+    pub request_id: u32,
+    /// Response priority in the range 0..=255. This will likely be same as the priority of
+    /// corresponding request.
+    pub priority: u8,
+    /// Response payload.
+    pub raw_response: Bytes,
+}
+
+#[derive(Clone, Debug, Deserialize, Serialize)]
+pub struct DirectSendMsg {
+    /// `protocol_id` is a variant of the ProtocolId enum.
+    pub protocol_id: ProtocolId,
+    /// Message priority in the range 0..=255.
+    pub priority: u8,
+    /// Message payload.
+    pub raw_msg: Bytes,
+}

--- a/network/src/protocols/wire/messaging/v1/test.rs
+++ b/network/src/protocols/wire/messaging/v1/test.rs
@@ -1,0 +1,39 @@
+// Copyright (c) The Libra Core Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+use super::*;
+
+// Ensure serialization of ProtocolId enum takes 1 byte.
+#[test]
+fn protocol_id_serialization() -> lcs::Result<()> {
+    let protocol = ProtocolId::ConsensusRpc;
+    assert_eq!(lcs::to_bytes(&protocol)?, vec![0x00]);
+    Ok(())
+}
+
+#[test]
+fn error_code() -> lcs::Result<()> {
+    let error_code = ErrorCode::TimedOut;
+    assert_eq!(lcs::to_bytes(&error_code)?, vec![0x01, 0, 0, 0]);
+    Ok(())
+}
+
+#[test]
+fn rpc_request() -> lcs::Result<()> {
+    let rpc_request = RpcRequest {
+        request_id: 25,
+        protocol_id: ProtocolId::ConsensusRpc,
+        priority: 0,
+        raw_request: Bytes::from_static(&[0, 1, 2, 3]),
+    };
+    assert_eq!(
+        lcs::to_bytes(&rpc_request)?,
+        // [25, 0, 0, 0] -> request_id
+        // [0] -> protocol_idx
+        // [0] -> priority
+        // [4, 0, 0, 0] -> length of raw_request
+        // [0, 1, 2, 3] -> raw_request bytes
+        vec![25, 0, 0, 0, 0, 0, 4, 0, 0, 0, 0, 1, 2, 3]
+    );
+    Ok(())
+}

--- a/network/src/protocols/wire/mod.rs
+++ b/network/src/protocols/wire/mod.rs
@@ -1,0 +1,11 @@
+// Copyright (c) The Libra Core Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+//! This module defines the structs transported during the LibraNet handshake protocol and
+//! the LibraNet messaging protocol.
+//! The handshake protocol is executed prior to executing the messaging protocol, and is used to
+//! determine the version of messaging protocol to use. Each node only supports one version of the
+//! handshake protocol on an end-point, and that is advertised as part of its discovery Multiaddr.
+
+pub mod handshake;
+pub mod messaging;


### PR DESCRIPTION
GitHub Issue: https://github.com/libra/libra/issues/2878

Implementation:
We divide the wire spec directory structure into two subdirectories:
1. handshake - for the LibraNet handshake protocol. This contains the
   structs exchanged during the handshake phase, before any messages are
   sent.
2. messaging - for the LibraNet messaging protocol. This contains
   structs exchanged after handshake has been performed.

For the handshake protocol, we need to send the remote peer a bit vector
signalling the application protocols we support over certain LibraNet
messaging protocol version. To represent the bit vector, we create a new
BitVec struct which wraps a `Vec<u8>`, where each each bit of a u8 is
set to 0 or 1 depending on whether that position is set or not.