### PR TITLE
[ghar][land-blocking] Update GHAR to use Kubernetes cluster

### DIFF
--- a/.github/workflows/land-blocking.yml
+++ b/.github/workflows/land-blocking.yml
@@ -23,6 +23,11 @@ jobs:
             echo "::set-output name=should_run::false";
           else
             echo "::set-output name=should_run::true";
+          fi;
+          if ${{ secrets.ACTIONS_LBT_USE_K8S }} ; then
+            echo "::set-env name=USE_K8S::true";
+          else
+            echo "::set-env name=USE_K8S::false";
           fi
       - name: Build, tag and push images
         if: steps.check_ks.outputs.should_run == 'true'
@@ -34,12 +39,23 @@ jobs:
         run: |
           export CTI_OUTPUT_LOG=$(mktemp)
           echo "::set-env name=CTI_OUTPUT_LOG::$CTI_OUTPUT_LOG"
-          JUMPHOST=${{secrets.CLUSTER_TEST_JUMPHOST}} \
-          ./scripts/cti \
-            --marker land \
-            --tag ${TEST_TAG} \
-            --report report.json \
-            --run bench
+          if [[ ${USE_K8S} == true ]]; then
+            ./scripts/cti \
+              --k8s \
+              --marker land \
+              --tag ${TEST_TAG} \
+              --report report.json \
+              --run bench \
+              --k8s-fullnodes-per-validator=0 \
+              --k8s-num-validators=100
+          else
+            JUMPHOST=${{secrets.CLUSTER_TEST_JUMPHOST}} \
+              ./scripts/cti \
+              --marker land \
+              --tag ${TEST_TAG} \
+              --report report.json \
+              --run bench
+          fi
       - name: Post test results on PR
         if: always()
         uses: actions/github-script@0.4.0
@@ -115,9 +131,15 @@ jobs:
             // Add repro cmd to message
             try {
               body += "\nRepro cmd:\n";
-              body += `
-                ./scripts/cti --tag ${env_vars.TEST_TAG} --run bench
-              `;
+              if (${{secrets.ACTIONS_LBT_USE_K8S}}) {
+                body += `
+                  ./scripts/cti --k8s --tag ${env_vars.TEST_TAG} --run bench --k8s-fullnodes-per-validator=0 --k8s-num-validators=100
+                `;
+              } else {
+                body += `
+                  ./scripts/cti --tag ${env_vars.TEST_TAG} --run bench
+                `;
+              }
             } catch (err) {
               if (err.code === 'ReferenceError') {
                 console.error("env var $LIBRA_GIT_REV is not set.");

--- a/scripts/cti
+++ b/scripts/cti
@@ -38,7 +38,7 @@ join_env_vars() {
 }
 
 kube_init_context () {
-  aws eks --region us-west-2 list-clusters &> /dev/null || (echo "Failed to access codebuild, try awsmfa?"; exit 1)
+  aws eks --region us-west-2 describe-cluster --name ct-0-k8s-testnet &>/dev/null || (echo "Failed to access EKS, try awsmfa?"; exit 1)
   local highest_pool_index=$(($K8S_POOL_SIZE - 1))
   local context=${K8S_CONTEXT_PATTERN/CLUSTERNAME/ct-${highest_pool_index}}
   if kubectl config get-contexts ${context} &> /dev/null; then
@@ -202,6 +202,7 @@ else
   echo "Running cluster-test on Kubernetes"
   kube_init_context
   pod_name="cluster-test-$(whoami)-$(date +%s)"
+  pod_name=${pod_name/_/-} #underscore not allowed in pod name
   specfile=$(mktemp)
   echo "Pod Spec : ${specfile}"
   join_args $*

--- a/testsuite/cluster-test/src/main.rs
+++ b/testsuite/cluster-test/src/main.rs
@@ -646,9 +646,10 @@ impl ClusterTestRunner {
     pub fn print_report(&self) {
         let json_report =
             serde_json::to_string_pretty(&self.report).expect("Failed to serialize report to json");
-        println!("====json-report-begin===");
-        println!("{}", json_report);
-        println!("====json-report-end===");
+        info!(
+            "\n====json-report-begin===\n{}\n====json-report-end===",
+            json_report
+        );
     }
 
     pub fn perf_run(&mut self) -> String {


### PR DESCRIPTION
## Summary

* This migrates the land blocking workflow from the static 100 node cluster to a pool of Kubernetes clusters.
* Advantages of this should be 
  * speedup in the land blocking workflow by a few minutes 
  * should not be blocked by other developers or nightly runs on the cluster

I earlier decided to run both workflows in parallel, but that seemed complicated. I have been testing the Kubernetes clusters for a week and I haven't seen any hiccups so far, so making a hard switch here.

## Test Plan

Verified that this workflow works : https://github.com/libra/libra/actions/runs/53090561