### PR TITLE
[move source language] Added help to ir_test_coverage

### DIFF
--- a/language/move-lang/tests/ir_test_coverage.rs
+++ b/language/move-lang/tests/ir_test_coverage.rs
@@ -25,10 +25,27 @@ fn test_ir_test_coverage() {
         .map(|(subdir, name)| format!("{}/{}/{}", PATH_TO_IR_TESTS, subdir, name))
         .collect::<Vec<_>>();
     if !not_migrated.is_empty() {
-        let mut msg = "\nThe following tests have not been migrated:\n".to_owned();
+        let mut msg = "\n\nThe following tests have not been migrated:\n".to_owned();
         for path in not_migrated {
             msg.push_str(&format!("{}\n", path));
         }
+        msg.push_str("\nA corresponding test needs to be added:\n");
+        msg.push_str(&format!(
+            "    {}/{}/<dir name>/<test name>.{}\n",
+            MOVE_CHECK_DIR, STD_LIB_TRANSACTION_SCRIPTS_DIR, MOVE_EXTENSION
+        ));
+        msg.push_str("  or\n");
+        msg.push_str(&format!(
+            "    {}/{}/<dir name>/<test name>.{}\n",
+            FUNCTIONAL_TEST_DIR, STD_LIB_TRANSACTION_SCRIPTS_DIR, MOVE_EXTENSION
+        ));
+        msg.push_str(&format!(
+            "Replace the extension '.{}' with '.{}' to mark the test as present, but it will not \
+            be run.\n\n",
+            MOVE_EXTENSION, TODO_EXTENSION
+        ));
+        msg.push_str("Running the following tool may help with the migration:\n");
+        msg.push_str("  cargo run -p move-lang --bin ir-test-translation -- -d <dir_name>\n\n");
         panic!(msg)
     }
 }


### PR DESCRIPTION
## Motivation

- Added directions for the ir_test_coverage test on failure

Example output: 
```
The following tests have not been migrated:
../ir-testsuite/tests/borrow_tests/example.mvir

A corresponding test needs to be added:
    tests/move_check/../stdlib/transaction_scripts/<dir name>/<test name>.move
  or
    tests/functional/../stdlib/transaction_scripts/<dir name>/<test name>.move
Replace the extension '.move' with '.move_TODO' to mark the test as present, but it will not be run.

Running the following tool may help with the migration:
  cargo run -p move-lang --bin ir-test-translation -- -d <dir_name>
```

## Test Plan

Ran it
