### PR TITLE
[libratrace] Add --trace to performance benchmark

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2401,6 +2401,7 @@ name = "libra-json-rpc"
 version = "0.1.0"
 dependencies = [
  "anyhow 1.0.26 (registry+https://github.com/rust-lang/crates.io-index)",
+ "debug-interface 0.1.0",
  "futures 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "hex 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "libra-canonical-serialization 0.1.0",

--- a/common/debug-interface/src/json_log.rs
+++ b/common/debug-interface/src/json_log.rs
@@ -11,7 +11,7 @@ pub struct JsonLogEntry {
     pub json: json::Value,
 }
 
-const MAX_EVENTS_IN_QUEUE: usize = 1_000;
+const MAX_EVENTS_IN_QUEUE: usize = 10_000;
 
 /// Writes event to event stream
 /// Example:

--- a/common/debug-interface/src/node_debug_service.rs
+++ b/common/debug-interface/src/node_debug_service.rs
@@ -57,13 +57,16 @@ impl NodeDebugInterface for NodeDebugService {
 pub fn parse_events(events: Vec<Event>) -> Vec<JsonLogEntry> {
     let mut ret = vec![];
     for event in events.into_iter() {
-        let json = serde_json::from_str(&event.json).expect("Failed to parse json");
-        let entry = JsonLogEntry {
-            name: Box::leak(event.name.into_boxed_str()),
-            timestamp: event.timestamp as u128,
-            json,
-        };
-        ret.push(entry);
+        ret.push(parse_event(event));
     }
     ret
+}
+
+pub fn parse_event(event: Event) -> JsonLogEntry {
+    let json = serde_json::from_str(&event.json).expect("Failed to parse json");
+    JsonLogEntry {
+        name: Box::leak(event.name.into_boxed_str()),
+        timestamp: event.timestamp as u128,
+        json,
+    }
 }

--- a/json-rpc/Cargo.toml
+++ b/json-rpc/Cargo.toml
@@ -27,6 +27,7 @@ libra-metrics = { path = "../common/metrics", version = "0.1.0" }
 libra-types = { path = "../types", version = "0.1.0" }
 libradb = { path = "../storage/libradb", version = "0.1.0" }
 transaction-builder = { path = "../language/transaction-builder", version = "0.1.0"}
+debug-interface = { path = "../common/debug-interface", version = "0.1.0" }
 
 [dev-dependencies]
 libra-crypto = { path = "../crypto/crypto", version = "0.1.0" }

--- a/json-rpc/src/methods.rs
+++ b/json-rpc/src/methods.rs
@@ -8,12 +8,13 @@ use crate::views::{
 };
 use anyhow::{ensure, format_err, Result};
 use core::future::Future;
+use debug_interface::prelude::*;
 use futures::{channel::oneshot, SinkExt};
 use hex;
 use libra_mempool::MempoolClientSender;
 use libra_types::{
     account_address::AccountAddress, account_state::AccountState, event::EventKey,
-    mempool_status::MempoolStatusCode,
+    mempool_status::MempoolStatusCode, transaction::SignedTransaction,
 };
 use libradb::LibraDBTrait;
 use serde_json::Value;
@@ -39,7 +40,8 @@ pub(crate) type RpcRegistry = HashMap<String, RpcHandler>;
 /// Submits transaction to full node
 async fn submit(mut service: JsonRpcService, params: Vec<Value>) -> Result<()> {
     let txn_payload: String = serde_json::from_value(params[0].clone())?;
-    let transaction = lcs::from_bytes(&hex::decode(txn_payload)?)?;
+    let transaction: SignedTransaction = lcs::from_bytes(&hex::decode(txn_payload)?)?;
+    trace_code_block!("json-rpc::submit", {"txn", transaction.sender(), transaction.sequence_number()});
 
     let (req_sender, callback) = oneshot::channel();
     service

--- a/testsuite/cluster-test/src/health/debug_interface_log_tail.rs
+++ b/testsuite/cluster-test/src/health/debug_interface_log_tail.rs
@@ -5,7 +5,7 @@
 
 use crate::{
     cluster::Cluster,
-    health::{Commit, Event, LogTail, ValidatorEvent},
+    health::{log_tail::TraceTail, Commit, Event, LogTail, ValidatorEvent},
     instance::Instance,
     util::unix_timestamp_now,
 };
@@ -14,7 +14,10 @@ use libra_logger::*;
 use serde_json::{self, value as json};
 use std::{
     env,
-    sync::{atomic::AtomicI64, mpsc, Arc},
+    sync::{
+        atomic::{AtomicBool, AtomicI64, Ordering},
+        mpsc, Arc, Mutex,
+    },
     thread,
     time::Duration,
 };
@@ -24,13 +27,19 @@ pub struct DebugPortLogThread {
     client: NodeDebugClient,
     event_sender: mpsc::Sender<ValidatorEvent>,
     started_sender: Option<mpsc::Sender<()>>,
+    pending_messages: Arc<AtomicI64>,
+    trace_sender: mpsc::Sender<(String, DebugInterfaceEvent)>,
+    trace_enabled: Arc<AtomicBool>,
 }
 
 impl DebugPortLogThread {
-    pub fn spawn_new(cluster: &Cluster) -> LogTail {
+    pub fn spawn_new(cluster: &Cluster) -> (LogTail, TraceTail) {
         let (event_sender, event_receiver) = mpsc::channel();
         let mut started_receivers = vec![];
-        for instance in cluster.validator_instances() {
+        let pending_messages = Arc::new(AtomicI64::new(0));
+        let (trace_sender, trace_receiver) = mpsc::channel();
+        let trace_enabled = Arc::new(AtomicBool::new(false));
+        for instance in cluster.all_instances() {
             let (started_sender, started_receiver) = mpsc::channel();
             started_receivers.push(started_receiver);
             let client = NodeDebugClient::new(instance.ip(), 6191);
@@ -39,6 +48,9 @@ impl DebugPortLogThread {
                 client,
                 event_sender: event_sender.clone(),
                 started_sender: Some(started_sender),
+                pending_messages: pending_messages.clone(),
+                trace_sender: trace_sender.clone(),
+                trace_enabled: trace_enabled.clone(),
             };
             thread::Builder::new()
                 .name(format!("log-tail-{}", instance.peer_name()))
@@ -50,10 +62,16 @@ impl DebugPortLogThread {
                 panic!("Failed to start one of debug port log threads: {:?}", e);
             }
         }
-        LogTail {
-            event_receiver,
-            pending_messages: Arc::new(AtomicI64::new(0)),
-        }
+        (
+            LogTail {
+                event_receiver,
+                pending_messages,
+            },
+            TraceTail {
+                trace_enabled,
+                trace_receiver: Mutex::new(trace_receiver),
+            },
+        )
     }
 }
 
@@ -69,12 +87,16 @@ impl DebugPortLogThread {
                     thread::sleep(Duration::from_secs(1));
                 }
                 Ok(resp) => {
+                    let mut sent_events = 0i64;
                     for event in resp.events.into_iter() {
                         if let Some(e) = self.parse_event(event) {
                             let _ignore = self.event_sender.send(e);
+                            sent_events += 1;
                         }
                     }
-                    thread::sleep(Duration::from_millis(200));
+                    self.pending_messages
+                        .fetch_add(sent_events, Ordering::Relaxed);
+                    thread::sleep(Duration::from_millis(100));
                 }
             }
             if let Some(started_sender) = self.started_sender.take() {
@@ -92,6 +114,10 @@ impl DebugPortLogThread {
         let e = if event.name == "committed" {
             Self::parse_commit(json)
         } else {
+            if self.trace_enabled.load(Ordering::Relaxed) {
+                let peer = self.instance.peer_name().clone();
+                let _ignore = self.trace_sender.send((peer, event));
+            }
             return None;
         };
         Some(ValidatorEvent {

--- a/testsuite/cluster-test/src/health/log_tail.rs
+++ b/testsuite/cluster-test/src/health/log_tail.rs
@@ -4,11 +4,12 @@
 #![forbid(unsafe_code)]
 
 use crate::{health::ValidatorEvent, util::unix_timestamp_now};
+use debug_interface::proto::Event as DebugInterfaceEvent;
 use libra_logger::*;
 use std::{
     sync::{
-        atomic::{AtomicI64, Ordering},
-        mpsc, Arc,
+        atomic::{AtomicBool, AtomicI64, Ordering},
+        mpsc, Arc, Mutex,
     },
     thread,
     time::{Duration, Instant},
@@ -17,6 +18,11 @@ use std::{
 pub struct LogTail {
     pub event_receiver: mpsc::Receiver<ValidatorEvent>,
     pub pending_messages: Arc<AtomicI64>,
+}
+
+pub struct TraceTail {
+    pub trace_receiver: Mutex<mpsc::Receiver<(String, DebugInterfaceEvent)>>,
+    pub trace_enabled: Arc<AtomicBool>,
 }
 
 impl LogTail {
@@ -54,6 +60,19 @@ impl LogTail {
         let mut events = vec![];
         while let Ok(event) = self.event_receiver.try_recv() {
             self.pending_messages.fetch_sub(1, Ordering::Relaxed);
+            events.push(event);
+        }
+        events
+    }
+}
+
+impl TraceTail {
+    pub async fn capture_trace(&self, duration: Duration) -> Vec<(String, DebugInterfaceEvent)> {
+        self.trace_enabled.store(true, Ordering::Relaxed);
+        tokio::time::delay_for(duration).await;
+        self.trace_enabled.store(false, Ordering::Relaxed);
+        let mut events = vec![];
+        while let Ok(event) = self.trace_receiver.lock().unwrap().try_recv() {
             events.push(event);
         }
         events

--- a/testsuite/cluster-test/src/health/mod.rs
+++ b/testsuite/cluster-test/src/health/mod.rs
@@ -14,7 +14,7 @@ pub use commit_check::CommitHistoryHealthCheck;
 pub use debug_interface_log_tail::DebugPortLogThread;
 use itertools::Itertools;
 pub use liveness_check::LivenessHealthCheck;
-pub use log_tail::LogTail;
+pub use log_tail::{LogTail, TraceTail};
 use std::{
     collections::{HashMap, HashSet},
     env, fmt,

--- a/testsuite/cluster-test/src/suite.rs
+++ b/testsuite/cluster-test/src/suite.rs
@@ -7,7 +7,7 @@ use std::{cmp::min, env};
 use crate::{
     cluster::Cluster,
     experiments::{
-        CpuFlamegraphParams, Experiment, ExperimentParam, PerformanceBenchmarkNodesDownParams,
+        CpuFlamegraphParams, Experiment, ExperimentParam, PerformanceBenchmarkParams,
         PerformanceBenchmarkThreeRegionSimulationParams, RebootRandomValidatorsParams,
         RecoveryTimeParams,
     },
@@ -35,10 +35,10 @@ impl ExperimentSuite {
             experiments.push(b);
         }
         experiments.push(Box::new(
-            PerformanceBenchmarkNodesDownParams::new_nodes_down(0).build(cluster),
+            PerformanceBenchmarkParams::new_nodes_down(0).build(cluster),
         ));
         experiments.push(Box::new(
-            PerformanceBenchmarkNodesDownParams::new_nodes_down(10).build(cluster),
+            PerformanceBenchmarkParams::new_nodes_down(10).build(cluster),
         ));
         experiments.push(Box::new(
             PerformanceBenchmarkThreeRegionSimulationParams {}.build(cluster),
@@ -52,10 +52,10 @@ impl ExperimentSuite {
     pub fn new_perf_suite(cluster: &Cluster) -> Self {
         let mut experiments: Vec<Box<dyn Experiment>> = vec![];
         experiments.push(Box::new(
-            PerformanceBenchmarkNodesDownParams::new_nodes_down(0).build(cluster),
+            PerformanceBenchmarkParams::new_nodes_down(0).build(cluster),
         ));
         experiments.push(Box::new(
-            PerformanceBenchmarkNodesDownParams::new_nodes_down(10).build(cluster),
+            PerformanceBenchmarkParams::new_nodes_down(10).build(cluster),
         ));
         experiments.push(Box::new(
             PerformanceBenchmarkThreeRegionSimulationParams {}.build(cluster),


### PR DESCRIPTION
This PR adds tracing option to benchmark.
Running `cti <...> --run bench -- --trace` will collect trace for short duration and print trace across all validators and full nodes for one transaction