### PR TITLE
[json-rpc] JsonRpcAsyncClient

### DIFF
--- a/json-rpc/Cargo.toml
+++ b/json-rpc/Cargo.toml
@@ -16,6 +16,7 @@ serde_json = "1.0.40"
 serde = { version = "1.0.99", default-features = false }
 warp = "0.2.2"
 futures = "0.3.0"
+reqwest = { version = "0.10.4", features = ["blocking", "json"], default_features = false }
 tokio = { version = "0.2.13", features = ["full"] }
 
 lcs = { path = "../common/lcs", version = "0.1.0", package = "libra-canonical-serialization" }
@@ -31,7 +32,6 @@ transaction-builder = { path = "../language/transaction-builder", version = "0.1
 libra-crypto = { path = "../crypto/crypto", version = "0.1.0" }
 libra-temppath = { path = "../common/temppath", version = "0.1.0" }
 proptest = "0.9.2"
-reqwest = { version = "0.10.4", features = ["blocking", "json"], default_features = false }
 vm-validator = { path = "../vm-validator", version = "0.1.0" }
 
 [features]

--- a/json-rpc/src/client.rs
+++ b/json-rpc/src/client.rs
@@ -1,0 +1,121 @@
+// Copyright (c) The Libra Core Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::views::AccountView;
+use anyhow::{ensure, format_err, Error, Result};
+use libra_types::{account_address::AccountAddress, transaction::SignedTransaction};
+use reqwest::Client;
+use serde_json::Value;
+use std::convert::TryFrom;
+
+#[derive(Default)]
+pub struct JsonRpcBatch {
+    pub requests: Vec<(String, Vec<Value>)>,
+}
+
+impl JsonRpcBatch {
+    pub fn add_request(&mut self, method_name: String, parameters: Vec<Value>) {
+        self.requests.push((method_name, parameters));
+    }
+
+    pub fn add_submit_request(&mut self, transaction: SignedTransaction) -> Result<()> {
+        let txn_payload = hex::encode(lcs::to_bytes(&transaction)?);
+        self.add_request("submit".to_string(), vec![Value::String(txn_payload)]);
+        Ok(())
+    }
+
+    pub fn add_get_account_state_request(&mut self, address: AccountAddress) {
+        self.add_request(
+            "get_account_state".to_string(),
+            vec![Value::String(address.to_string())],
+        );
+    }
+}
+
+pub struct JsonRpcAsyncClient {
+    address: String,
+    client: Client,
+}
+
+impl JsonRpcAsyncClient {
+    pub fn new(host: &str, port: u16) -> Self {
+        let address = format!("http://{}:{}", host, port);
+        let client = Client::new();
+        Self { address, client }
+    }
+
+    pub async fn execute(&self, batch: JsonRpcBatch) -> Result<Vec<Result<JsonRpcResponse>>> {
+        let requests = batch
+            .requests
+            .iter()
+            .enumerate()
+            .map(|(id, (method, params))| {
+                serde_json::json!({"jsonrpc": "2.0", "method": method, "params": params, "id": id})
+            })
+            .collect();
+
+        let resp = self
+            .client
+            .post(&self.address)
+            .json(&serde_json::Value::Array(requests))
+            .send()
+            .await?;
+
+        ensure!(
+            resp.status() == 200,
+            format!("Http error code {}", resp.status())
+        );
+
+        let responses: Vec<Value> = resp.json().await?;
+        let mut result = vec![];
+        for _ in batch.requests.iter() {
+            result.push(Err(format_err!("response is missing")));
+        }
+
+        for response in responses {
+            if let Ok(req_id) = self.fetch_id(&response) {
+                if req_id < result.len() {
+                    if let Some(err_data) = response.get("error") {
+                        result[req_id] =
+                            Err(format_err!("JSON-RPC error {:?}", err_data.get("message")));
+                        continue;
+                    }
+                    if let Some(data) = response.get("result") {
+                        let method = batch.requests[req_id].0.clone();
+                        result[req_id] = Ok(JsonRpcResponse::try_from((method, data.clone()))?);
+                    }
+                }
+            }
+        }
+        Ok(result)
+    }
+
+    fn fetch_id(&self, response: &Value) -> Result<usize> {
+        match response.get("id") {
+            Some(id) => Ok(serde_json::from_value::<usize>(id.clone())?),
+            None => Err(format_err!("request id is missing")),
+        }
+    }
+}
+
+#[derive(PartialEq)]
+pub enum JsonRpcResponse {
+    SubmissionResponse,
+    AccountResponse(AccountView),
+    UnknownResponse,
+}
+
+impl TryFrom<(String, Value)> for JsonRpcResponse {
+    type Error = Error;
+
+    fn try_from((method, value): (String, Value)) -> Result<JsonRpcResponse> {
+        if method == "submit" {
+            Ok(JsonRpcResponse::SubmissionResponse)
+        } else if method == "get_account_state" {
+            let account: AccountView = serde_json::from_value(value)?;
+            Ok(JsonRpcResponse::AccountResponse(account))
+        } else {
+            Ok(JsonRpcResponse::UnknownResponse)
+        }
+    }
+}

--- a/json-rpc/src/lib.rs
+++ b/json-rpc/src/lib.rs
@@ -17,11 +17,15 @@
 #[macro_use]
 mod util;
 
+mod client;
 mod methods;
 mod runtime;
 pub mod views;
 
-pub use runtime::bootstrap_from_config;
+pub use {
+    client::{JsonRpcAsyncClient, JsonRpcBatch},
+    runtime::bootstrap_from_config,
+};
 
 #[cfg(test)]
 mod tests;

--- a/json-rpc/src/views.rs
+++ b/json-rpc/src/views.rs
@@ -20,13 +20,13 @@ use transaction_builder::get_transaction_name;
 
 #[derive(Serialize, Deserialize, Debug, PartialEq)]
 pub struct AccountView {
-    balance: u64,
-    sequence_number: u64,
-    authentication_key: BytesView,
+    pub balance: u64,
+    pub sequence_number: u64,
+    pub authentication_key: BytesView,
     pub sent_events_key: BytesView,
     pub received_events_key: BytesView,
-    delegated_key_rotation_capability: bool,
-    delegated_withdrawal_capability: bool,
+    pub delegated_key_rotation_capability: bool,
+    pub delegated_withdrawal_capability: bool,
 }
 
 impl AccountView {
@@ -40,12 +40,6 @@ impl AccountView {
             delegated_key_rotation_capability: account.delegated_key_rotation_capability(),
             delegated_withdrawal_capability: account.delegated_withdrawal_capability(),
         }
-    }
-
-    // TODO remove test tag once used by CLI client
-    #[cfg(test)]
-    pub(crate) fn balance(&self) -> u64 {
-        self.balance
     }
 }
 


### PR DESCRIPTION
adding thin async client to communicate with JSON RPC endpoint
should be potentially used by CLI, integration tests, cluster test and local unit tests
in this diff only submit and get_account_state support is added

