### PR TITLE
[move-prover] Fixed bug in address parsing

### DIFF
--- a/language/move-prover/spec-lang/src/translate.rs
+++ b/language/move-prover/spec-lang/src/translate.rs
@@ -1525,12 +1525,21 @@ impl<'env, 'translator, 'module_translator> ExpTranslator<'env, 'translator, 'mo
         };
         match &exp.value {
             EA::Exp_::Value(v) => match &v.value {
-                PA::Value_::Address(addr) => make_value(
-                    Value::Address(
-                        BigUint::from_str_radix(&format!("{}", addr), 16).expect("valid address"),
-                    ),
-                    Type::new_prim(PrimitiveType::Address),
-                ),
+                PA::Value_::Address(addr) => {
+                    let addr_str = &format!("{}", addr);
+                    if &addr_str[0..2] == "0x" {
+                        let digits_only = &addr_str[2..];
+                        make_value(
+                            Value::Address(
+                                BigUint::from_str_radix(digits_only, 16).expect("valid address"),
+                            ),
+                            Type::new_prim(PrimitiveType::Address),
+                        )
+                    } else {
+                        self.error(&loc, "address string does not begin with '0x'");
+                        self.new_error_exp()
+                    }
+                }
                 PA::Value_::U8(x) => make_value(
                     Value::Number(BigUint::from_u8(*x).unwrap()),
                     Type::new_prim(PrimitiveType::U8),


### PR DESCRIPTION
Fixed a bug in the specification language translate.rs function that was parsing a hex address, but didn't remove "0x" first.

<!--
Thank you for sending a PR. We appreciate you spending time to help improve the Libra project.

The project is undergoing daily changes. Pull Requests will be reviewed and responded to as time permits.
-->

## Motivation

(Write your motivation for proposed changes here.)

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?

(Write your answer here.)

## Test Plan

(Share your test plan here. If you changed code, please provide us with clear instructions for verifying that your changes work.)

## Related PRs

(If this PR adds or changes functionality, please take some time to update the docs at https://github.com/libra/website, and link to your PR here.)
