### PR TITLE
[fuzzing] suppress lazy_static and backtrace in LSAN

### DIFF
--- a/testsuite/libra-fuzzer/lsan_suppressions.txt
+++ b/testsuite/libra-fuzzer/lsan_suppressions.txt
@@ -1,0 +1,2 @@
+leak:lazy_static
+leak:backtrace


### PR DESCRIPTION
Suppress leak until next libbacktrace is released. See details in

https://github.com/rust-lang/rust/issues/69721#issuecomment-595256948
