### PR TITLE
[JSON RPC] update JSON RPC port command line arg in `start_cli_testnet.sh`

### DIFF
--- a/scripts/cli/start_cli_testnet.sh
+++ b/scripts/cli/start_cli_testnet.sh
@@ -13,7 +13,7 @@ source "$HOME/.cargo/env"
 
 SCRIPT_PATH="$(dirname $0)"
 
-RUN_PARAMS="--host ac.testnet.libra.org --port 8000 --json_rpc_port 5000 "
+RUN_PARAMS="--host ac.testnet.libra.org --port 8000 --json-rpc-port 5000 "
 RELEASE=""
 
 while [[ ! -z "$1" ]]; do


### PR DESCRIPTION
## Summary

Fix json-rpc-port arg in command line for `./scripts/cli/start_cli_testnet.sh`

## Test Plan

ran `./scripts/cli/start_cli_testnet.sh` locally
