### PR TITLE
[safety-rules] Add logging init to main

### DIFF
--- a/consensus/safety-rules/src/main.rs
+++ b/consensus/safety-rules/src/main.rs
@@ -22,6 +22,12 @@ fn main() {
         process::exit(1);
     });
 
+    libra_logger::Logger::new()
+        .channel_size(config.logger.chan_size)
+        .is_async(config.logger.is_async)
+        .level(config.logger.level)
+        .init();
+
     let mut service = Process::new(config);
     service.start();
 }


### PR DESCRIPTION
Verified by placing a hello, world statement after init and using a
default generated node.config from the node.config builder.