### PR TITLE
[move source language] Actually compile && and ||

### DIFF
--- a/language/move-lang/tests/functional/evaluation_order/short_circuiting.move
+++ b/language/move-lang/tests/functional/evaluation_order/short_circuiting.move
@@ -1,0 +1,22 @@
+module X {
+    public fun error(): bool {
+        abort 42
+    }
+}
+
+//! new-transaction
+use {{default}}::X;
+fun main() {
+    let vtrue = true;
+    let vfalse = false;
+
+    true || X::error();
+    vtrue || X::error();
+    vtrue || { let r = X::error(); r };
+    { let x = vtrue; x} || X::error();
+
+    false && X::error();
+    vfalse && X::error();
+    vfalse && { let r = X::error(); r };
+    { let x = vfalse; x} && X::error();
+}

--- a/language/move-lang/tests/functional/evaluation_order/short_circuiting_invalid.move
+++ b/language/move-lang/tests/functional/evaluation_order/short_circuiting_invalid.move
@@ -1,0 +1,33 @@
+module X {
+    public fun error(): bool {
+        abort 42
+    }
+}
+
+//! new-transaction
+use {{default}}::X;
+fun main() {
+    false || X::error();
+}
+// check:"major_status: ABORTED, sub_status: Some(42)"
+
+//! new-transaction
+use {{default}}::X;
+fun main() {
+    true && X::error();
+}
+// check:"major_status: ABORTED, sub_status: Some(42)"
+
+//! new-transaction
+use {{default}}::X;
+fun main() {
+    X::error() && false;
+}
+// check:"major_status: ABORTED, sub_status: Some(42)"
+
+//! new-transaction
+use {{default}}::X;
+fun main() {
+    X::error() || true;
+}
+// check:"major_status: ABORTED, sub_status: Some(42)"


### PR DESCRIPTION
## Motivation

- Compiled && and || to if-else
- Kept the operator if the RHS is a value/local

## Test Plan

new tests