### PR TITLE
[libra types] start serving balance value from BalanceResource

### DIFF
--- a/execution/executor/tests/storage_integration_test.rs
+++ b/execution/executor/tests/storage_integration_test.rs
@@ -5,6 +5,7 @@ use anyhow::{ensure, format_err, Result};
 use executor_utils::create_storage_service_and_executor;
 use libra_config::config::{VMConfig, VMPublishingOption};
 use libra_crypto::{ed25519::*, test_utils::TEST_SEED, HashValue, PrivateKey};
+use libra_types::account_state::AccountState;
 use libra_types::{
     access_path::AccessPath,
     account_address::{AccountAddress, AuthenticationKey},
@@ -815,7 +816,10 @@ where
     F: Fn(u64) -> bool,
 {
     let balance = if let Some(blob) = &account_state_with_proof.blob {
-        AccountResource::try_from(blob)?.balance()
+        AccountState::try_from(blob)?
+            .get_balance_resource()?
+            .map(|b| b.coin())
+            .unwrap_or(0)
     } else {
         0
     };

--- a/json-rpc/src/views.rs
+++ b/json-rpc/src/views.rs
@@ -5,8 +5,8 @@ use anyhow::{format_err, Error};
 use hex;
 use libra_types::{
     account_config::{
-        received_payment_tag, sent_payment_tag, AccountResource, ReceivedPaymentEvent,
-        SentPaymentEvent,
+        received_payment_tag, sent_payment_tag, AccountResource, BalanceResource,
+        ReceivedPaymentEvent, SentPaymentEvent,
     },
     contract_event::ContractEvent,
     crypto_proxies::{LedgerInfoWithSignatures, ValidatorChangeProof},
@@ -30,9 +30,9 @@ pub struct AccountView {
 }
 
 impl AccountView {
-    pub fn new(account: &AccountResource) -> Self {
+    pub fn new(account: &AccountResource, balance: &BalanceResource) -> Self {
         Self {
-            balance: account.balance(),
+            balance: balance.coin(),
             sequence_number: account.sequence_number(),
             authentication_key: BytesView::from(account.authentication_key()),
             sent_events_key: BytesView::from(account.sent_events().key().as_bytes()),

--- a/storage/storage-service/src/mocks/mock_storage_client.rs
+++ b/storage/storage-service/src/mocks/mock_storage_client.rs
@@ -224,7 +224,6 @@ fn get_mock_response_item(request_item: &ProtoRequestItem) -> Result<ProtoRespon
 
 fn get_mock_account_state_blob() -> AccountStateBlob {
     let account_resource = libra_types::account_config::AccountResource::new(
-        100,
         0,
         vec![],
         false,

--- a/types/src/account_config.rs
+++ b/types/src/account_config.rs
@@ -132,9 +132,8 @@ pub fn received_payment_tag() -> StructTag {
 #[cfg_attr(any(test, feature = "fuzzing"), derive(Arbitrary))]
 pub struct AccountResource {
     authentication_key: Vec<u8>,
-    // TODO: remove this field from the account resource, and depend upon the [`BalanceResource`]
-    // defined in this file for this information.
-    balance: u64,
+    // TODO: should be unused by now
+    _deprecated_balance: u64,
     delegated_key_rotation_capability: bool,
     delegated_withdrawal_capability: bool,
     received_events: EventHandle,
@@ -146,7 +145,6 @@ pub struct AccountResource {
 impl AccountResource {
     /// Constructs an Account resource.
     pub fn new(
-        balance: u64,
         sequence_number: u64,
         authentication_key: Vec<u8>,
         delegated_key_rotation_capability: bool,
@@ -156,8 +154,8 @@ impl AccountResource {
         event_generator: u64,
     ) -> Self {
         AccountResource {
-            balance,
             sequence_number,
+            _deprecated_balance: 0,
             authentication_key,
             delegated_key_rotation_capability,
             delegated_withdrawal_capability,
@@ -170,11 +168,6 @@ impl AccountResource {
     /// Return the sequence_number field for the given AccountResource
     pub fn sequence_number(&self) -> u64 {
         self.sequence_number
-    }
-
-    /// Return the balance field for the given AccountResource
-    pub fn balance(&self) -> u64 {
-        self.balance
     }
 
     /// Return the authentication_key field for the given AccountResource
@@ -224,6 +217,11 @@ impl BalanceResource {
 /// It can be used to create an AccessPath for an Account resource.
 pub static ACCOUNT_RESOURCE_PATH: Lazy<Vec<u8>> =
     Lazy::new(|| AccessPath::resource_access_vec(&account_struct_tag(), &Accesses::empty()));
+
+/// Path to the Balance resource
+pub static BALANCE_RESOURCE_PATH: Lazy<Vec<u8>> = Lazy::new(|| {
+    AccessPath::resource_access_vec(&account_balance_struct_tag(), &Accesses::empty())
+});
 
 /// The path to the sent event counter for an Account resource.
 /// It can be used to query the event DB for the given event.

--- a/types/src/account_state_blob/mod.rs
+++ b/types/src/account_state_blob/mod.rs
@@ -2,8 +2,13 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::{
-    account_address::AccountAddress, account_config::AccountResource, account_state::AccountState,
-    event::EventKey, ledger_info::LedgerInfo, proof::AccountStateProof, transaction::Version,
+    account_address::AccountAddress,
+    account_config::{AccountResource, BalanceResource},
+    account_state::AccountState,
+    event::EventKey,
+    ledger_info::LedgerInfo,
+    proof::AccountStateProof,
+    transaction::Version,
 };
 use anyhow::{anyhow, ensure, format_err, Error, Result};
 use libra_crypto::{
@@ -94,11 +99,16 @@ impl TryFrom<&AccountStateBlob> for AccountState {
     }
 }
 
-impl TryFrom<&AccountResource> for AccountStateBlob {
+impl TryFrom<(&AccountResource, &BalanceResource)> for AccountStateBlob {
     type Error = Error;
 
-    fn try_from(account_resource: &AccountResource) -> Result<Self> {
-        Self::try_from(&AccountState::try_from(account_resource)?)
+    fn try_from(
+        (account_resource, balance_resource): (&AccountResource, &BalanceResource),
+    ) -> Result<Self> {
+        Self::try_from(&AccountState::try_from((
+            account_resource,
+            balance_resource,
+        ))?)
     }
 }
 
@@ -124,8 +134,8 @@ impl CryptoHash for AccountStateBlob {
 
 #[cfg(any(test, feature = "fuzzing"))]
 prop_compose! {
-    fn account_state_blob_strategy()(account_resource in any::<AccountResource>()) -> AccountStateBlob {
-        AccountStateBlob::try_from(&account_resource).unwrap()
+    fn account_state_blob_strategy()(account_resource in any::<AccountResource>(), balance_resource in any::<BalanceResource>()) -> AccountStateBlob {
+        AccountStateBlob::try_from((&account_resource, &balance_resource)).unwrap()
     }
 }
 

--- a/types/src/proptest_types.rs
+++ b/types/src/proptest_types.rs
@@ -4,7 +4,7 @@
 use crate::{
     access_path::AccessPath,
     account_address::AccountAddress,
-    account_config::AccountResource,
+    account_config::{AccountResource, BalanceResource},
     account_state_blob::AccountStateBlob,
     block_info::{BlockInfo, Round},
     block_metadata::BlockMetadata,
@@ -639,7 +639,6 @@ impl ContractEventGen {
 
 #[derive(Arbitrary, Debug)]
 struct AccountResourceGen {
-    balance: u64,
     delegated_key_rotation_capability: bool,
     delegated_withdrawal_capability: bool,
 }
@@ -653,7 +652,6 @@ impl AccountResourceGen {
         let account_info = universe.get_account_info(account_index);
 
         AccountResource::new(
-            self.balance,
             account_info.sequence_number,
             account_info.public_key.to_bytes().to_vec(),
             self.delegated_key_rotation_capability,
@@ -666,8 +664,20 @@ impl AccountResourceGen {
 }
 
 #[derive(Arbitrary, Debug)]
+struct BalanceResourceGen {
+    coin: u64,
+}
+
+impl BalanceResourceGen {
+    pub fn materialize(self) -> BalanceResource {
+        BalanceResource::new(self.coin)
+    }
+}
+
+#[derive(Arbitrary, Debug)]
 struct AccountStateBlobGen {
     account_resource_gen: AccountResourceGen,
+    balance_resource_gen: BalanceResourceGen,
 }
 
 impl AccountStateBlobGen {
@@ -679,7 +689,8 @@ impl AccountStateBlobGen {
         let account_resource = self
             .account_resource_gen
             .materialize(account_index, universe);
-        AccountStateBlob::try_from(&account_resource).unwrap()
+        let balance_resource = self.balance_resource_gen.materialize();
+        AccountStateBlob::try_from((&account_resource, &balance_resource)).unwrap()
     }
 }
 


### PR DESCRIPTION
after https://github.com/libra/libra/pull/2871, we double write balance value for field inside of AccountResource and  into separate BalanceResource
this PR switches serving value from BalanceResource instead of balance field(previous implementation)
