### PR TITLE
[move-prover] Ensure that references are dreferenced in spec expressions

### DIFF
--- a/language/move-prover/src/prelude.bpl
+++ b/language/move-prover/src/prelude.bpl
@@ -985,7 +985,7 @@ procedure {:inline 1} $Hash_sha3_256(val: Value) returns (res: Value)  {
 
 // TODO: implement the below methods
 
-procedure {:inline 1} $LibraAccount_save_account(addr: Value, account: Value) {
+procedure {:inline 1} $LibraAccount_save_account(balance: Value, account: Value, addr: Value) {
     $abort_flag := true;
 }
 

--- a/language/move-prover/tests/sources/references.exp
+++ b/language/move-prover/tests/sources/references.exp
@@ -1,0 +1,1 @@
+Move prover all good, no errors!

--- a/language/move-prover/tests/sources/references.move
+++ b/language/move-prover/tests/sources/references.move
@@ -1,0 +1,29 @@
+// dep: ../stdlib/modules/vector.move
+module References {
+    use 0x0::Vector;
+
+    struct T {
+        a: u64
+    }
+
+    fun ref_param(r: &T): u64 {
+        r.a
+    }
+    spec fun ref_param {
+        ensures result == r.a;
+    }
+
+    fun ref_param_vec(r: &vector<T>): u64 {
+        Vector::length(r)
+    }
+    spec fun ref_param_vec {
+        ensures result == len(r);
+    }
+
+    fun ref_return(r: &vector<T>, i: u64): &T {
+        Vector::borrow(r, i)
+    }
+    spec fun ref_return {
+        ensures result == r[i];
+    }
+}


### PR DESCRIPTION
The problem was that the type checker eliminated reference type information during type unification. This info is now preserved and passed on to the boogie translator. Moreover, the boogie translator didn't implement dereferencing of return values, which is now fixed as well.

This also fixes a failure in boogie compilation of the standard library. The signature of the native function `LibraAccount::save_account` had changed (by lang team), and our tests did not caught it because they aren't running in Ci.

## Motivation

Build an awesome Move prover.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

Added new test for references.

## Related PRs

NA
