### PR TITLE
[JSON RPC] migrate get_transactions/get_account_transaction CLI functionality to JSON RPC

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5231,6 +5231,7 @@ dependencies = [
  "libra-canonical-serialization 0.1.0",
  "libra-config 0.1.0",
  "libra-crypto 0.1.0",
+ "libra-json-rpc 0.1.0",
  "libra-logger 0.1.0",
  "libra-swarm 0.1.0",
  "libra-temppath 0.1.0",

--- a/client/cli/src/client_proxy.rs
+++ b/client/cli/src/client_proxy.rs
@@ -13,7 +13,7 @@ use libra_crypto::{
     x25519::X25519StaticPublicKey,
     ValidKey, ValidKeyStringExt,
 };
-use libra_json_rpc::views::{AccountView, EventView};
+use libra_json_rpc::views::{AccountView, EventView, TransactionView};
 use libra_logger::prelude::*;
 use libra_temppath::TempPath;
 use libra_types::{
@@ -26,11 +26,10 @@ use libra_types::{
         CORE_CODE_ADDRESS,
     },
     account_state::AccountState,
-    contract_event::ContractEvent,
     crypto_proxies::LedgerInfoWithSignatures,
     transaction::{
         helpers::{create_unsigned_txn, create_user_txn, TransactionSigner},
-        parse_as_transaction_argument, RawTransaction, Script, SignedTransaction, Transaction,
+        parse_as_transaction_argument, RawTransaction, Script, SignedTransaction,
         TransactionArgument, TransactionPayload, Version,
     },
     waypoint::Waypoint,
@@ -423,9 +422,9 @@ impl ClientProxy {
                 .client
                 .get_txn_by_acc_seq(account, sequence_number - 1, true)
             {
-                Ok(Some((_, Some(events)))) => {
+                Ok(Some(txn_view)) => {
                     println!("transaction is stored!");
-                    if events.is_empty() {
+                    if txn_view.events.is_empty() {
                         println!("no events emitted");
                     }
                     break;
@@ -741,7 +740,7 @@ impl ClientProxy {
     pub fn get_committed_txn_by_acc_seq(
         &mut self,
         space_delim_strings: &[&str],
-    ) -> Result<Option<(Transaction, Option<Vec<ContractEvent>>)>> {
+    ) -> Result<Option<TransactionView>> {
         ensure!(
             space_delim_strings.len() == 4,
             "Invalid number of arguments to get transaction by account and sequence number"
@@ -773,7 +772,7 @@ impl ClientProxy {
     pub fn get_committed_txn_by_range(
         &mut self,
         space_delim_strings: &[&str],
-    ) -> Result<Vec<(Transaction, Option<Vec<ContractEvent>>)>> {
+    ) -> Result<Vec<TransactionView>> {
         ensure!(
             space_delim_strings.len() == 4,
             "Invalid number of arguments to get transaction by range"

--- a/testsuite/Cargo.toml
+++ b/testsuite/Cargo.toml
@@ -25,6 +25,7 @@ cli = { path = "../client/cli", version = "0.1.0", features = ["fuzzing"] }
 generate-keypair = { path = "../config/generate-keypair", version = "0.1.0" }
 lcs = { path = "../common/lcs", version = "0.1.0", package = "libra-canonical-serialization" }
 libra-swarm = { path = "../libra-swarm", version = "0.1.0" }
+libra-json-rpc = { path = "../json-rpc", version = "0.1.0" }
 libra-logger = { path = "../common/logger", version = "0.1.0" }
 libra-config = { path = "../config", version = "0.1.0" }
 libra-types = { path = "../types", version = "0.1.0" }


### PR DESCRIPTION
## Summary

Migrate `get_txns` / `get_account_txns` functionality in CLI from gRPC to JSON RPC
Changed existing view implementations to support CLI use cases
