### PR TITLE
[GHAR][LBT] log error to console

### DIFF
--- a/.github/workflows/land-blocking.yml
+++ b/.github/workflows/land-blocking.yml
@@ -123,6 +123,7 @@ jobs:
                 }
               } else {
                 body = "Cluster Test failed - test report processing failed.";
+                console.error(err);
               }
               body += " See https://github.com/libra/libra/actions/runs/${{github.run_id}}";
               // Post comment on PR then fail this workflow


### PR DESCRIPTION
When the land-blocking test fails to process the JSON report, log the
error to the runner console.
