### PR TITLE
[ghar] Run k8s job in background and print results

### DIFF
--- a/.github/workflows/land-blocking.yml
+++ b/.github/workflows/land-blocking.yml
@@ -18,17 +18,12 @@ jobs:
           echo "::set-env name=TEST_TAG::land_$(git rev-parse --short=8 HEAD)"
       - name: Check kill switch
         id: check_ks
-        run:
+        run: |
           if ${{ secrets.KILL_SWITCH_LAND_BLOCKING_TEST }} ; then
             echo "::set-output name=should_run::false";
           else
             echo "::set-output name=should_run::true";
           fi;
-          if ${{ secrets.ACTIONS_LBT_USE_K8S }} ; then
-            echo "::set-env name=USE_K8S::true";
-          else
-            echo "::set-env name=USE_K8S::false";
-          fi
       - name: Build, tag and push images
         if: steps.check_ks.outputs.should_run == 'true'
         run: |
@@ -39,23 +34,12 @@ jobs:
         run: |
           export CTI_OUTPUT_LOG=$(mktemp)
           echo "::set-env name=CTI_OUTPUT_LOG::$CTI_OUTPUT_LOG"
-          if [[ ${USE_K8S} == true ]]; then
+          JUMPHOST=${{secrets.CLUSTER_TEST_JUMPHOST}} \
             ./scripts/cti \
-              --k8s \
-              --marker land \
-              --tag ${TEST_TAG} \
-              --report report.json \
-              --run bench \
-              --k8s-fullnodes-per-validator=0 \
-              --k8s-num-validators=100
-          else
-            JUMPHOST=${{secrets.CLUSTER_TEST_JUMPHOST}} \
-              ./scripts/cti \
-              --marker land \
-              --tag ${TEST_TAG} \
-              --report report.json \
-              --run bench
-          fi
+            --marker land \
+            --tag ${TEST_TAG} \
+            --report report.json \
+            --run bench
           echo "report.json start"
           cat report.json
           echo "report.json end"
@@ -135,15 +119,9 @@ jobs:
             // Add repro cmd to message
             try {
               body += "\nRepro cmd:\n";
-              if (${{secrets.ACTIONS_LBT_USE_K8S}}) {
-                body += `
-                  ./scripts/cti --k8s --tag ${env_vars.TEST_TAG} --run bench --k8s-fullnodes-per-validator=0 --k8s-num-validators=100
-                `;
-              } else {
-                body += `
-                  ./scripts/cti --tag ${env_vars.TEST_TAG} --run bench
-                `;
-              }
+              body += `
+                ./scripts/cti --tag ${env_vars.TEST_TAG} --run bench
+              `;
             } catch (err) {
               if (err.code === 'ReferenceError') {
                 console.error("env var $LIBRA_GIT_REV is not set.");
@@ -174,4 +152,71 @@ jobs:
             // Fail the workflow if test fails or perf regresses
             if (should_fail) {
               throw "Land-blocking test failed";
+            }
+  build-and-run-cluster-test-k8s:
+    name: Run cluster test on k8s
+    needs: build-and-run-cluster-test
+    runs-on: self-hosted
+    steps:
+      - uses: actions/checkout@v1
+      - name: Setup env
+        run: |
+          echo "::set-env name=LIBRA_GIT_REV::$(git rev-parse --short=8 HEAD)"
+          echo "::set-env name=TEST_TAG::land_$(git rev-parse --short=8 HEAD)"
+      - name: Check kill switch
+        id: check_ks
+        run: |
+          if ${{ secrets.KILL_SWITCH_LAND_BLOCKING_TEST }} ; then
+            echo "::set-output name=should_run::false";
+          else
+            echo "::set-output name=should_run::true";
+          fi;
+      - name: Launch cluster test
+        if: steps.check_ks.outputs.should_run == 'true'
+        # NOTE Remember to update PR comment payload if cti cmd is updated.
+        run: |
+          export CTI_OUTPUT_LOG=$(mktemp)
+          ./scripts/cti \
+            --k8s \
+            --tag ${TEST_TAG} \
+            --report report-k8s.json \
+            --run bench \
+            --k8s-fullnodes-per-validator=0 \
+            --k8s-num-validators=100
+
+          echo "::set-env name=CTI_OUTPUT_LOG::$CTI_OUTPUT_LOG"
+          echo "report-k8s.json start"
+          cat report-k8s.json
+          echo "report-k8s.json end"
+      - name: Verify TPS Nubmers
+        if: always()
+        uses: actions/github-script@0.4.0
+        with:
+          github-token: ${{secrets.GITHUB_TOKEN}}
+          script: |
+            // Check kill switch
+            if (${{secrets.KILL_SWITCH_LAND_BLOCKING_TEST}}) {
+              console.log('Kill switch is set. Will skip this step.');
+              return;
+            }
+            // Read and check cluster test results
+            let should_fail = false;
+            let msg = "";
+            const fsp = require('fs').promises;
+            try {
+              data = await fsp.readFile('report-k8s.json', 'utf-8');
+              var result = JSON.parse(data);
+              let tps = result.metrics.find(m => m.experiment == "all up" && m.metric == "avg_tps").value;
+              let min_tps = 900;
+              if (tps < min_tps) {
+                should_fail = true;
+                msg = "Land-blocking test failed because of perf regression. TPS : " + tps;
+              }
+            } catch (err) {
+              console.error(err);
+              should_fail = true;
+              msg = "Land-blocking test failed because failure to parse output.";
+            }
+            if (should_fail) {
+              throw msg;
             }

--- a/scripts/cti
+++ b/scripts/cti
@@ -55,7 +55,10 @@ kube_select_cluster () {
     for ((i = 0; i < ${K8S_POOL_SIZE}; i++)); do
       local context=${K8S_CONTEXT_PATTERN/CLUSTERNAME/ct-${i}}
       local running_pods=$(kubectl --context="${context}" get pods -l app=cluster-test --field-selector=status.phase==Running 2> /dev/null | wc -l)
-      if [[ $running_pods -eq 0 ]]; then
+      local prometheus_healthy_containers=$(kubectl --context="${context}" get pod/libra-testnet-prometheus-server-0 | grep 'libra-testnet-prometheus-server-0' | awk '{print $2}')
+      if [[ ${prometheus_healthy_containers} != "2/2" ]]; then
+        echo "prometheus is not healthy for ct-${i}"
+      elif [[ $running_pods -eq 0 ]] && [[ ${prometheus_healthy_containers} == "2/2" ]]; then
         retval_kube_select_cluster="ct-${i}"
         return
       fi
@@ -223,7 +226,6 @@ else
   kube_wait_pod ${pod_name} ${context}
   echo "**********"
   echo "${BLUE}Dashboard:${RESTORE} http://grafana.${WORKSPACE}-k8s-testnet.aws.hlw3truzy4ls.com/"
-  echo "Dashboard Username: admin. Password: $(kubectl get secret grafana-admin-credentials -o jsonpath="{.data.admin-password}" | base64 --decode)"
   echo "${BLUE}'validator-0' Logs:${RESTORE} http://kibana.${WORKSPACE}-k8s-testnet.aws.hlw3truzy4ls.com/app/kibana#/discover?_g=(filters:!(),refreshInterval:(pause:!t,value:0),time:(from:now-15m,to:now))&_a=(columns:!(log,kubernetes.pod_name),filters:!(('\$state':(store:appState),meta:(alias:!n,disabled:!f,key:kubernetes.pod_name,negate:!f,params:(query:validator-0),type:phrase),query:(match:(kubernetes.pod_name:(query:validator-0,type:phrase))))),interval:auto,query:(language:kuery,query:''),sort:!(!('@timestamp',desc)))"
   echo
   echo "${BLUE}'fullnode-0-0' Logs:${RESTORE} http://kibana.${WORKSPACE}-k8s-testnet.aws.hlw3truzy4ls.com/app/kibana#/discover?_g=(filters:!(),refreshInterval:(pause:!t,value:0),time:(from:now-15m,to:now))&_a=(columns:!(log,kubernetes.pod_name),filters:!(('\$state':(store:appState),meta:(alias:!n,disabled:!f,key:kubernetes.pod_name,negate:!f,params:(query:fullnode-0-0),type:phrase),query:(match:(kubernetes.pod_name:(query:fullnode-0-0,type:phrase))))),interval:auto,query:(language:kuery,query:''),sort:!(!('@timestamp',desc)))"


### PR DESCRIPTION
## Summary

* Run the k8s version of cti command in background
* Run the regular version of cti command in the foreground
* Print the results from the k8s run (even if incomplete)
* Exit with the return code of regular version of cti

We can evaluate the k8s runs after a week and switch to it if things look good