### PR TITLE
[tf] Open http port for json-rpc

### DIFF
--- a/terraform/load-balancing.tf
+++ b/terraform/load-balancing.tf
@@ -43,6 +43,51 @@ resource "aws_lb_listener" "validator-ac" {
   }
 }
 
+resource "aws_lb" "json-rpc" {
+  name                             = "${terraform.workspace}-jsonrpc"
+  load_balancer_type               = "application"
+  enable_cross_zone_load_balancing = true
+  subnets                          = aws_subnet.testnet.*.id
+  security_groups                  = [aws_security_group.validator.id]
+}
+
+resource "aws_lb_target_group" "json-rpc" {
+  name     = "${terraform.workspace}-jsonrpc"
+  protocol = "HTTP"
+  port     = 8080
+  vpc_id   = aws_vpc.testnet.id
+}
+
+resource "aws_lb_target_group_attachment" "json-rpc" {
+  count            = var.num_fullnodes
+  target_group_arn = aws_lb_target_group.json-rpc.arn
+  target_id        = element(aws_instance.fullnode.*.id, count.index)
+}
+
+resource "aws_lb_listener" "json-rpc" {
+  load_balancer_arn = aws_lb.json-rpc.arn
+  port              = 80
+  protocol          = "HTTP"
+
+  default_action {
+    type             = "forward"
+    target_group_arn = aws_lb_target_group.json-rpc.arn
+  }
+}
+
+resource "aws_lb_listener" "json-rpc-https" {
+  count             = local.zone_id == "" ? 0 : 1
+  load_balancer_arn = aws_lb.json-rpc.arn
+  certificate_arn   = aws_acm_certificate_validation.json-rpc[count.index].certificate_arn
+  port              = 443
+  protocol          = "HTTPS"
+
+  default_action {
+    type             = "forward"
+    target_group_arn = aws_lb_target_group.json-rpc.arn
+  }
+}
+
 resource "aws_lb_target_group" "fullnode-ac" {
   name     = "${terraform.workspace}-fullnode"
   protocol = "TCP"
@@ -78,6 +123,46 @@ resource "aws_route53_record" "validator-ac" {
     zone_id                = aws_lb.validator-ac.zone_id
     evaluate_target_health = true
   }
+}
+
+resource "aws_route53_record" "json-rpc" {
+  count   = local.zone_id == "" ? 0 : 1
+  zone_id = local.zone_id
+  name    = "client${local.dns_suffix}"
+  type    = "A"
+
+  alias {
+    name                   = aws_lb.json-rpc.dns_name
+    zone_id                = aws_lb.json-rpc.zone_id
+    evaluate_target_health = true
+  }
+}
+
+resource "aws_acm_certificate" "json-rpc" {
+  count = local.zone_id == "" ? 0 : 1
+
+  domain_name       = aws_route53_record.json-rpc[count.index].fqdn
+  validation_method = "DNS"
+
+  lifecycle {
+    create_before_destroy = true
+  }
+}
+resource "aws_route53_record" "json-rpc-cert-validation" {
+  count = local.zone_id == "" ? 0 : 1
+
+  name    = aws_acm_certificate.json-rpc[count.index].domain_validation_options[0].resource_record_name
+  type    = aws_acm_certificate.json-rpc[count.index].domain_validation_options[0].resource_record_type
+  zone_id = local.zone_id
+  records = [aws_acm_certificate.json-rpc[count.index].domain_validation_options[0].resource_record_value]
+  ttl     = 60
+}
+
+resource "aws_acm_certificate_validation" "json-rpc" {
+  count = local.zone_id == "" ? 0 : 1
+
+  certificate_arn         = aws_acm_certificate.json-rpc[count.index].arn
+  validation_record_fqdns = [aws_route53_record.json-rpc-cert-validation[count.index].fqdn]
 }
 
 # FAUCET #

--- a/terraform/network.tf
+++ b/terraform/network.tf
@@ -124,6 +124,15 @@ resource "aws_security_group_rule" "validator-ac" {
   cidr_blocks       = concat(var.api_sources_ipv4, [aws_vpc.testnet.cidr_block])
 }
 
+resource "aws_security_group_rule" "json-rpc" {
+  security_group_id = aws_security_group.validator.id
+  type              = "ingress"
+  from_port         = 8080
+  to_port           = 8080
+  protocol          = "tcp"
+  cidr_blocks       = concat(var.api_sources_ipv4, [aws_vpc.testnet.cidr_block])
+}
+
 resource "aws_security_group_rule" "validator-host-mon" {
   security_group_id        = aws_security_group.validator.id
   type                     = "ingress"

--- a/terraform/templates/fullnode.json
+++ b/terraform/templates/fullnode.json
@@ -12,6 +12,7 @@
             {"containerPort": 6180, "hostPort": 6180},
             {"containerPort": 6181, "hostPort": 6181},
             {"containerPort": 8000, "hostPort": 8000},
+            {"containerPort": 8080, "hostPort": 8080},
             {"containerPort": 9101, "hostPort": 9101},
             {"containerPort": 6191, "hostPort": 6191}
         ],


### PR DESCRIPTION
<!--
Thank you for sending a PR. We appreciate you spending time to help improve the Libra project.

The project is undergoing daily changes. Pull Requests will be reviewed and responded to as time permits.
-->

## Motivation

Open port 8080 for json-rpc, create a new load balancer for it. Add listeners on http 80 and 443 for https.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

Apply changes to sherryxiao workspace.
new load balancer created: https://us-west-2.console.aws.amazon.com/ec2/v2/home?region=us-west-2#LoadBalancers:search=jsonrpc;sort=loadBalancerName

## Related PRs

(If this PR adds or changes functionality, please take some time to update the docs at https://github.com/libra/website, and link to your PR here.)
