### PR TITLE
[move source language] Fixed dependency order fed to IR

### DIFF
--- a/language/move-ir/types/src/ast.rs
+++ b/language/move-ir/types/src/ast.rs
@@ -1326,7 +1326,7 @@ impl fmt::Display for ImportDefinition {
 
 impl fmt::Display for ModuleDependency {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "Depedency({}, ", &self.name)?;
+        write!(f, "Dependency({}, ", &self.name)?;
         for sdep in &self.structs {
             writeln!(f, "{}, ", sdep)?
         }

--- a/language/move-lang/src/cfgir/ast.rs
+++ b/language/move-lang/src/cfgir/ast.rs
@@ -30,10 +30,9 @@ pub struct Program {
 
 #[derive(Debug)]
 pub struct ModuleDefinition {
-    /// `None` if it is a library dependency
-    /// `Some(order)` if it is a source file. Where `order` is the topological order/rank in the
-    /// depedency graph
-    pub is_source_module: Option<usize>,
+    pub is_source_module: bool,
+    /// `dependency_order` is the topological order/rank in the dependency graph.
+    pub dependency_order: usize,
     pub structs: UniqueMap<StructName, StructDefinition>,
     pub functions: UniqueMap<FunctionName, Function>,
 }
@@ -433,13 +432,16 @@ impl AstDebug for ModuleDefinition {
     fn ast_debug(&self, w: &mut AstWriter) {
         let ModuleDefinition {
             is_source_module,
+            dependency_order,
             structs,
             functions,
         } = self;
-        match is_source_module {
-            None => w.writeln("library module"),
-            Some(ord) => w.writeln(&format!("source moduel #{}", ord)),
+        if *is_source_module {
+            w.writeln("library module")
+        } else {
+            w.writeln("source module")
         }
+        w.writeln(&format!("dependency order #{}", dependency_order));
         for sdef in structs {
             sdef.ast_debug(w);
             w.new_line();

--- a/language/move-lang/src/cfgir/translate.rs
+++ b/language/move-lang/src/cfgir/translate.rs
@@ -105,12 +105,14 @@ fn module(
     mdef: H::ModuleDefinition,
 ) -> (ModuleIdent, G::ModuleDefinition) {
     let is_source_module = mdef.is_source_module;
+    let dependency_order = mdef.dependency_order;
     let structs = mdef.structs.map(|name, s| struct_def(context, name, s));
     let functions = mdef.functions.map(|name, f| function(context, name, f));
     (
         module_ident,
         G::ModuleDefinition {
             is_source_module,
+            dependency_order,
             structs,
             functions,
         },

--- a/language/move-lang/src/hlir/ast.rs
+++ b/language/move-lang/src/hlir/ast.rs
@@ -30,10 +30,9 @@ pub struct Program {
 
 #[derive(Debug)]
 pub struct ModuleDefinition {
-    /// `None` if it is a library dependency
-    /// `Some(order)` if it is a source file. Where `order` is the topological order/rank in the
-    /// depedency graph
-    pub is_source_module: Option<usize>,
+    pub is_source_module: bool,
+    /// `dependency_order` is the topological order/rank in the dependency graph.
+    pub dependency_order: usize,
     pub structs: UniqueMap<StructName, StructDefinition>,
     pub functions: UniqueMap<FunctionName, Function>,
 }
@@ -363,13 +362,16 @@ impl AstDebug for ModuleDefinition {
     fn ast_debug(&self, w: &mut AstWriter) {
         let ModuleDefinition {
             is_source_module,
+            dependency_order,
             structs,
             functions,
         } = self;
-        match is_source_module {
-            None => w.writeln("library module"),
-            Some(ord) => w.writeln(&format!("source moduel #{}", ord)),
+        if *is_source_module {
+            w.writeln("library module")
+        } else {
+            w.writeln("source module")
         }
+        w.writeln(&format!("dependency order #{}", dependency_order));
         for sdef in structs {
             sdef.ast_debug(w);
             w.new_line();

--- a/language/move-lang/src/hlir/translate.rs
+++ b/language/move-lang/src/hlir/translate.rs
@@ -165,6 +165,7 @@ fn module(
     mdef: T::ModuleDefinition,
 ) -> (ModuleIdent, H::ModuleDefinition) {
     let is_source_module = mdef.is_source_module;
+    let dependency_order = mdef.dependency_order;
 
     let structs = mdef.structs.map(|name, s| struct_def(context, name, s));
 
@@ -176,6 +177,7 @@ fn module(
         module_ident,
         H::ModuleDefinition {
             is_source_module,
+            dependency_order,
             structs,
             functions,
         },

--- a/language/move-lang/src/naming/ast.rs
+++ b/language/move-lang/src/naming/ast.rs
@@ -32,10 +32,10 @@ pub struct Program {
 #[derive(Debug)]
 pub struct ModuleDefinition {
     pub uses: BTreeMap<ModuleIdent, Loc>,
-    /// `None` if it is a library dependency
-    /// `Some(order)` if it is a source file. Where `order` is the topological order/rank in the
-    /// depedency graph. `order` is initialized at `0` and set in the uses pass
-    pub is_source_module: Option<usize>,
+    pub is_source_module: bool,
+    /// `dependency_order` is the topological order/rank in the dependency graph.
+    /// `dependency_order` is initialized at `0` and set in the uses pass
+    pub dependency_order: usize,
     pub structs: UniqueMap<StructName, StructDefinition>,
     pub functions: UniqueMap<FunctionName, Function>,
 }
@@ -574,15 +574,18 @@ impl AstDebug for Program {
 impl AstDebug for ModuleDefinition {
     fn ast_debug(&self, w: &mut AstWriter) {
         let ModuleDefinition {
-            uses,
             is_source_module,
+            dependency_order,
+            uses,
             structs,
             functions,
         } = self;
-        match is_source_module {
-            None => w.writeln("library module"),
-            Some(ord) => w.writeln(&format!("source moduel #{}", ord)),
+        if *is_source_module {
+            w.writeln("library module")
+        } else {
+            w.writeln("source module")
         }
+        w.writeln(&format!("dependency order #{}", dependency_order));
         if !uses.is_empty() {
             w.writeln("uses: ");
             w.indent(2, |w| w.comma(uses, |w, (m, _)| w.write(&format!("{}", m))))

--- a/language/move-lang/src/naming/translate.rs
+++ b/language/move-lang/src/naming/translate.rs
@@ -327,7 +327,8 @@ fn module(
     context.restore_unscoped(outer_unscoped);
     N::ModuleDefinition {
         uses,
-        is_source_module: if is_source_module { Some(0) } else { None },
+        is_source_module,
+        dependency_order: 0,
         structs,
         functions,
     }

--- a/language/move-lang/src/naming/uses.rs
+++ b/language/move-lang/src/naming/uses.rs
@@ -28,13 +28,9 @@ pub fn verify(errors: &mut Errors, modules: &mut UniqueMap<ModuleIdent, N::Modul
             report_cycle(context, cycle_ident)
         }
         Ok(ordered_ids) => {
-            let ordering = ordered_ids
-                .into_iter()
-                .filter(|m| imm_modules.get(m).unwrap().is_source_module.is_some())
-                .cloned()
-                .collect::<Vec<_>>();
-            for (order, mident) in ordering.into_iter().rev().enumerate() {
-                modules.get_mut(&mident).unwrap().is_source_module = Some(order)
+            let ordered_ids = ordered_ids.into_iter().cloned().collect::<Vec<_>>();
+            for (order, mident) in ordered_ids.into_iter().rev().enumerate() {
+                modules.get_mut(&mident).unwrap().dependency_order = order
             }
         }
     }

--- a/language/move-lang/src/typing/ast.rs
+++ b/language/move-lang/src/typing/ast.rs
@@ -32,10 +32,9 @@ pub struct Program {
 
 #[derive(Debug)]
 pub struct ModuleDefinition {
-    /// `None` if it is a library dependency
-    /// `Some(order)` if it is a source file. Where `order` is the topological order/rank in the
-    /// depedency graph
-    pub is_source_module: Option<usize>,
+    pub is_source_module: bool,
+    /// `dependency_order` is the topological order/rank in the dependency graph.
+    pub dependency_order: usize,
     pub structs: UniqueMap<StructName, StructDefinition>,
     pub functions: UniqueMap<FunctionName, Function>,
 }
@@ -278,13 +277,16 @@ impl AstDebug for ModuleDefinition {
     fn ast_debug(&self, w: &mut AstWriter) {
         let ModuleDefinition {
             is_source_module,
+            dependency_order,
             structs,
             functions,
         } = self;
-        match is_source_module {
-            None => w.writeln("library module"),
-            Some(ord) => w.writeln(&format!("source moduel #{}", ord)),
+        if *is_source_module {
+            w.writeln("library module")
+        } else {
+            w.writeln("source module")
         }
+        w.writeln(&format!("dependency order #{}", dependency_order));
         for sdef in structs {
             sdef.ast_debug(w);
             w.new_line();

--- a/language/move-lang/src/typing/translate.rs
+++ b/language/move-lang/src/typing/translate.rs
@@ -46,6 +46,7 @@ fn module(
     context.current_module = Some(ident);
     let N::ModuleDefinition {
         is_source_module,
+        dependency_order,
         mut structs,
         functions: n_functions,
         ..
@@ -57,6 +58,7 @@ fn module(
     assert!(context.constraints.is_empty());
     T::ModuleDefinition {
         is_source_module,
+        dependency_order,
         structs,
         functions,
     }

--- a/language/move-lang/tests/functional/dependencies/dependency_order.move
+++ b/language/move-lang/tests/functional/dependencies/dependency_order.move
@@ -1,0 +1,29 @@
+// names used to try to force an ordering of depedencies
+module C {
+    struct T {}
+    public fun foo(): T {
+        T{}
+    }
+}
+
+//! new-transaction
+// names used to try to force an ordering of depedencies
+module B {
+    public fun foo(): {{default}}::C::T {
+        {{default}}::C::foo()
+    }
+}
+
+//! new-transaction
+module A {
+    struct T {
+        t_b: {{default}}::C::T,
+        t_c: {{default}}::C::T,
+    }
+    public fun foo(): T {
+        T {
+            t_c: {{default}}::C::foo(),
+            t_b: {{default}}::B::foo()
+        }
+    }
+}


### PR DESCRIPTION
## Motivation

- Preserved dependency orders for ALL modules (source and lib/deps)
- Sorted explicit_dependency_declarations via module dependency ordering (toposort)
(Write your answer here.)

## Test Plan

- Wrote a test and verified it hit the bug without the sorting in place