### PR TITLE
[language] beginning of a Debug module

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1436,6 +1436,7 @@ dependencies = [
  "move-core-types 0.1.0",
  "once_cell 1.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "regex 1.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "stdlib 0.1.0",
  "termcolor 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "thiserror 1.0.14 (registry+https://github.com/rust-lang/crates.io-index)",
  "vm 0.1.0",

--- a/language/e2e-tests/Cargo.toml
+++ b/language/e2e-tests/Cargo.toml
@@ -22,7 +22,7 @@ libra-types = { path = "../../types", version = "0.1.0", features = ["fuzzing"] 
 move-core-types = { path = "../move-core/types", version = "0.1.0" }
 move-vm-cache = { path = "../move-vm/cache", version = "0.1.0" }
 move-vm-state = { path = "../move-vm/state", version = "0.1.0" }
-move-vm-types = { path = "../move-vm/types", version = "0.1.0" }
+move-vm-types = { path = "../move-vm/types", version = "0.1.0", features = ["debug_module"] }
 transaction-builder = { path = "../transaction-builder", version = "0.1.0", features = ["fuzzing"]}
 vm = { path = "../vm", version = "0.1.0" }
 vm-genesis = { path = "../tools/vm-genesis", version = "0.1.0" }

--- a/language/e2e-tests/src/data_store.rs
+++ b/language/e2e-tests/src/data_store.rs
@@ -15,12 +15,16 @@ use libra_types::{
 use move_vm_state::data_cache::RemoteCache;
 use once_cell::sync::Lazy;
 use std::collections::HashMap;
+use stdlib::StdLibOptions;
 use vm::{errors::*, CompiledModule};
-use vm_genesis;
+use vm_genesis::generate_genesis_change_set_for_testing;
 
 /// Dummy genesis ChangeSet for testing
 pub static GENESIS_CHANGE_SET: Lazy<ChangeSet> =
-    Lazy::new(vm_genesis::generate_genesis_change_set_for_testing);
+    Lazy::new(|| generate_genesis_change_set_for_testing(StdLibOptions::Staged));
+
+pub static GENESIS_CHANGE_SET_FRESH: Lazy<ChangeSet> =
+    Lazy::new(|| generate_genesis_change_set_for_testing(StdLibOptions::Fresh));
 
 /// An in-memory implementation of [`StateView`] and [`RemoteCache`] for the VM.
 ///

--- a/language/e2e-tests/src/executor.rs
+++ b/language/e2e-tests/src/executor.rs
@@ -5,7 +5,7 @@
 
 use crate::{
     account::{Account, AccountData},
-    data_store::{FakeDataStore, GENESIS_CHANGE_SET},
+    data_store::{FakeDataStore, GENESIS_CHANGE_SET, GENESIS_CHANGE_SET_FRESH},
 };
 use bytecode_verifier::VerifiedModule;
 use libra_config::generator;
@@ -55,9 +55,14 @@ impl FakeExecutor {
         Self::from_genesis(GENESIS_CHANGE_SET.clone().write_set())
     }
 
+    /// Creates an executor using the standard genesis.
+    pub fn from_fresh_genesis() -> Self {
+        Self::from_genesis(GENESIS_CHANGE_SET_FRESH.clone().write_set())
+    }
+
     pub fn whitelist_genesis() -> Self {
         Self::custom_genesis(
-            Some(stdlib_modules(StdLibOptions::Staged).to_vec()),
+            stdlib_modules(StdLibOptions::Staged).to_vec(),
             None,
             VMPublishingOption::Locked(StdlibScript::whitelist()),
         )
@@ -72,7 +77,7 @@ impl FakeExecutor {
         }
 
         Self::custom_genesis(
-            Some(stdlib_modules(StdLibOptions::Staged).to_vec()),
+            stdlib_modules(StdLibOptions::Staged).to_vec(),
             None,
             publishing_options,
         )
@@ -86,28 +91,23 @@ impl FakeExecutor {
         }
     }
 
-    /// Creates fresh genesis from the stdlib modules passed in. If none are passed in the staged
-    /// genesis write set is used.
+    /// Creates fresh genesis from the stdlib modules passed in.
     pub fn custom_genesis(
-        genesis_modules: Option<Vec<VerifiedModule>>,
+        genesis_modules: Vec<VerifiedModule>,
         validator_set: Option<ValidatorSet>,
         publishing_options: VMPublishingOption,
     ) -> Self {
-        let genesis_change_set = if genesis_modules.is_none() && validator_set.is_none() {
-            GENESIS_CHANGE_SET.clone()
-        } else {
+        let genesis_change_set = {
             let validator_set_len: usize = validator_set.as_ref().map_or(10, |s| s.payload().len());
             let swarm = generator::validator_swarm_for_testing(validator_set_len);
             let validator_set = validator_set.unwrap_or(swarm.validator_set);
             let discovery_set = mock_discovery_set(&validator_set);
-            let stdlib_modules =
-                genesis_modules.unwrap_or_else(|| stdlib_modules(StdLibOptions::Staged).to_vec());
             vm_genesis::encode_genesis_change_set(
                 &GENESIS_KEYPAIR.1,
                 &swarm.nodes,
                 validator_set,
                 discovery_set,
-                &stdlib_modules,
+                &genesis_modules,
                 publishing_options,
             )
         };

--- a/language/functional-tests/Cargo.toml
+++ b/language/functional-tests/Cargo.toml
@@ -26,3 +26,4 @@ termcolor = "1.0.5"
 datatest-stable = { path = "../../common/datatest-stable", version = "0.1.0" }
 mirai-annotations = "1.6.0"
 move-core-types = { path = "../move-core/types", version = "0.1.0" }
+stdlib = { path = "../stdlib", version = "0.1.0" }

--- a/language/functional-tests/src/compiler.rs
+++ b/language/functional-tests/src/compiler.rs
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use anyhow::Result;
-use bytecode_verifier::VerifiedModule;
 use libra_types::account_address::AccountAddress;
 use vm::file_format::{CompiledModule, CompiledScript};
 
@@ -14,10 +13,6 @@ pub trait Compiler {
         address: AccountAddress,
         input: &str,
     ) -> Result<ScriptOrModule>;
-
-    /// Return the (ordered) list of modules to be used for genesis. If None is returned the staged
-    /// version of the stdlib is used.
-    fn stdlib() -> Option<Vec<VerifiedModule>>;
 }
 
 pub enum ScriptOrModule {

--- a/language/functional-tests/src/evaluator.rs
+++ b/language/functional-tests/src/evaluator.rs
@@ -31,6 +31,7 @@ use std::{
     str::FromStr,
     time::Duration,
 };
+use stdlib::{stdlib_modules, StdLibOptions};
 use vm::{
     file_format::{CompiledModule, CompiledScript},
     gas_schedule::{GasAlgebra, MAXIMUM_NUMBER_OF_GAS_UNITS},
@@ -557,13 +558,12 @@ pub fn eval<TComp: Compiler>(
 
     // Set up a fake executor with the genesis block and create the accounts.
     let mut exec = if config.validator_set.payload().is_empty() {
-        // use the default validator set. this uses a precomputed validator set and is cheap
-        FakeExecutor::custom_genesis(TComp::stdlib(), None, VMPublishingOption::Open)
+        FakeExecutor::from_fresh_genesis()
     } else {
         // use custom validator set. this requires dynamically generating a new genesis tx and
         // is thus more expensive.
         FakeExecutor::custom_genesis(
-            TComp::stdlib(),
+            stdlib_modules(StdLibOptions::Fresh).to_vec(),
             Some(config.validator_set.clone()),
             VMPublishingOption::Open,
         )

--- a/language/ir-testsuite/tests/debug/simple.mvir
+++ b/language/ir-testsuite/tests/debug/simple.mvir
@@ -1,0 +1,48 @@
+//! debug
+
+module M {
+    import 0x0.Debug;
+    import 0x0.Vector;
+
+    struct Foo { x: bool }
+    struct Bar { x: u128, y: Self.Foo, z: bool }
+    struct Box<T> { x: T }
+
+    public test() {
+        let x: u64;
+        let v: vector<u64>;
+        let foo: Self.Foo;
+        let bar: Self.Bar;
+        let box: Self.Box<Self.Foo>;
+
+        x = 42;
+        Debug.print<u64>(&x);
+
+        v = Vector.empty<u64>();
+        Vector.push_back<u64>(&mut v, 100);
+        Vector.push_back<u64>(&mut v, 200);
+        Vector.push_back<u64>(&mut v, 300);
+        Debug.print<vector<u64>>(&v);
+
+        foo = Foo { x: false };
+        Debug.print<Self.Foo>(&foo);
+
+        bar = Bar { x: 404u128, y: Foo { x: false }, z: true };
+        Debug.print<Self.Bar>(&bar);
+
+        box = Box<Self.Foo> { x: Foo { x: false } };
+        Debug.print<Self.Box<Self.Foo>>(&box);
+
+        return;
+    }
+}
+// check: EXECUTED
+
+//! new-transaction
+import {{default}}.M;
+
+main() {
+    M.test();
+    return;
+}
+// check: EXECUTED

--- a/language/ir-testsuite/tests/testsuite.rs
+++ b/language/ir-testsuite/tests/testsuite.rs
@@ -14,7 +14,7 @@ use ir_to_bytecode::{
 use libra_types::account_address::AccountAddress;
 use move_ir_types::ast;
 use std::path::Path;
-use stdlib::{env_stdlib_modules, stdlib_modules, use_staged, StdLibOptions};
+use stdlib::{stdlib_modules, StdLibOptions};
 
 struct IRCompiler {
     deps: Vec<VerifiedModule>,
@@ -51,23 +51,13 @@ impl Compiler for IRCompiler {
             }
         })
     }
-
-    // Use the staged genesis/stdlib unless the the
-    // MOVE_NO_USE_STAGED environment variable is set.
-    fn stdlib() -> Option<Vec<VerifiedModule>> {
-        if !use_staged() {
-            Some(env_stdlib_modules().to_vec())
-        } else {
-            None
-        }
-    }
 }
 
 fn run_test(path: &Path) -> datatest_stable::Result<()> {
-    // The IR tests always run with the staged stdlib
-    let stdlib = stdlib_modules(StdLibOptions::Staged);
-    let compiler = IRCompiler::new(stdlib.to_vec());
-    testsuite::functional_tests(compiler, path)
+    testsuite::functional_tests(
+        IRCompiler::new(stdlib_modules(StdLibOptions::Fresh).to_vec()),
+        path,
+    )
 }
 
 datatest_stable::harness!(run_test, "tests", r".*\.mvir");

--- a/language/move-lang/src/test_utils/mod.rs
+++ b/language/move-lang/src/test_utils/mod.rs
@@ -18,6 +18,8 @@ pub const TODO_EXTENSION: &str = "move_TODO";
 pub const MOVE_EXTENSION: &str = "move";
 pub const IR_EXTENSION: &str = "mvir";
 
+pub const DEBUG_MODULE_FILE_NAME: &str = "debug.move";
+
 pub const COMPLETED_DIRECTORIES: &[&str; 2] = &["borrow_tests", "commands"];
 
 /// We need to replicate the specification of the (non-staged) stdlib files here since we can't

--- a/language/move-lang/tests/functional/debug/simple.move
+++ b/language/move-lang/tests/functional/debug/simple.move
@@ -1,0 +1,39 @@
+//! debug
+
+module M {
+    use 0x0::Debug;
+    use 0x0::Vector;
+
+    struct Foo {}
+    struct Bar { x: u128, y: Foo, z: bool }
+    struct Box<T> { x: T }
+
+    public fun test()  {
+        let x = 42;
+        Debug::print(&x);
+
+        let v = Vector::empty();
+        Vector::push_back(&mut v, 100);
+        Vector::push_back(&mut v, 200);
+        Vector::push_back(&mut v, 300);
+        Debug::print(&v);
+
+        let foo = Foo {};
+        Debug::print(&foo);
+
+        let bar = Bar { x: 404, y: Foo {}, z: true };
+        Debug::print(&bar);
+
+        let box = Box { x: Foo {} };
+        Debug::print(&box);
+    }
+}
+// check: EXECUTED
+
+//! new-transaction
+use {{default}}::M;
+
+fun main() {
+    M::test();
+}
+// check: EXECUTED

--- a/language/move-lang/tests/functional_testsuite.rs
+++ b/language/move-lang/tests/functional_testsuite.rs
@@ -7,10 +7,9 @@ use functional_tests::{
     testsuite,
 };
 use libra_types::account_address::AccountAddress as LibraAddress;
-use move_bytecode_verifier::{batch_verify_modules, VerifiedModule};
 use move_lang::{
     compiled_unit::CompiledUnit,
-    move_compile, move_compile_no_report,
+    move_compile_no_report,
     shared::Address,
     test_utils::{read_bool_var, stdlib_files, FUNCTIONAL_TEST_DIR},
 };
@@ -89,25 +88,10 @@ impl Compiler for MoveSourceCompiler {
             }
         })
     }
-
-    fn stdlib() -> Option<Vec<VerifiedModule>> {
-        let (_, compiled_units) =
-            move_compile(&stdlib_files(), &[], Some(Address::LIBRA_CORE)).unwrap();
-        Some(batch_verify_modules(
-            compiled_units
-                .into_iter()
-                .map(|compiled_unit| match compiled_unit {
-                    CompiledUnit::Module { module, .. } => module,
-                    CompiledUnit::Script { .. } => panic!("Unexpected Script in stdlib"),
-                })
-                .collect(),
-        ))
-    }
 }
 
 fn functional_testsuite(path: &Path) -> datatest_stable::Result<()> {
-    let compiler = MoveSourceCompiler::new(stdlib_files());
-    testsuite::functional_tests(compiler, path)
+    testsuite::functional_tests(MoveSourceCompiler::new(stdlib_files()), path)
 }
 
 datatest_stable::harness!(functional_testsuite, FUNCTIONAL_TEST_DIR, r".*\.move");

--- a/language/move-vm/types/Cargo.toml
+++ b/language/move-vm/types/Cargo.toml
@@ -28,3 +28,4 @@ proptest = "0.9"
 [features]
 default = []
 fuzzing = ["proptest", "libra-types/fuzzing", "vm/fuzzing"]
+debug_module = []

--- a/language/stdlib/modules/debug.move
+++ b/language/stdlib/modules/debug.move
@@ -1,0 +1,5 @@
+address 0x0:
+
+module Debug {
+    native public fun print<T>(x: &T);
+}

--- a/language/stdlib/src/main.rs
+++ b/language/stdlib/src/main.rs
@@ -40,7 +40,8 @@ fn main() {
 
     let txn_source_files =
         datatest_stable::utils::iterate_directory(Path::new(TRANSACTION_SCRIPTS));
-    let transaction_files = filter_move_files(txn_source_files);
+    let transaction_files = filter_move_files(txn_source_files)
+        .flat_map(|path| path.into_os_string().into_string().ok());
     for txn_file in transaction_files {
         let compiled_script = compile_script(txn_file.clone());
         let mut txn_path = PathBuf::from(STAGED_OUTPUT_PATH);

--- a/language/tools/vm-genesis/src/lib.rs
+++ b/language/tools/vm-genesis/src/lib.rs
@@ -779,8 +779,8 @@ fn verify_genesis_write_set(events: &[ContractEvent], discovery_set: &DiscoveryS
 }
 
 /// Generate an artificial genesis `ChangeSet` for testing
-pub fn generate_genesis_change_set_for_testing() -> ChangeSet {
-    let stdlib_modules = stdlib_modules(StdLibOptions::Staged);
+pub fn generate_genesis_change_set_for_testing(stdlib_options: StdLibOptions) -> ChangeSet {
+    let stdlib_modules = stdlib_modules(stdlib_options);
     let swarm = generator::validator_swarm_for_testing(10);
 
     encode_genesis_change_set(

--- a/language/vm/src/gas_schedule.rs
+++ b/language/vm/src/gas_schedule.rs
@@ -137,6 +137,9 @@ define_gas_unit! {
     doc: "A newtype wrapper around the gas price for each unit of gas consumed."
 }
 
+/// Zero cost.
+pub const ZERO_GAS_UNITS: GasUnits<GasCarrier> = GasUnits(0);
+
 /// The cost per-byte written to global storage.
 /// TODO: Fill this in with a proper number once it's determined.
 pub const GLOBAL_MEMORY_PER_BYTE_COST: GasUnits<GasCarrier> = GasUnits(8);


### PR DESCRIPTION
## Summary
This adds a module `Debug` with a native function `print`. `print` takes a reference to a value of any type and prints out the value in stdout. 

Highlights:
- Implementation of the native function `print` is behind a feature flag
  - No-op if feature flag is not present
- IR tests now use freshly generated genesis
- Move-lang functional tests now run faster

## Test Plan
Run `cargo test -p move-lang debug/simple.move` manually and you should see
```
[debug] 42u64
[debug] [100u64, 200u64, 300u64]
[debug] M::Foo {false}
[debug] M::Bar {404u128, M::Foo {false}, true}
[debug] M::Box {M::Foo {false}}
```

## Progress Tracker
- [x] Basic Functionalities
- [x] Documentation
- [x] Conditional Compilation
- [x] Debug/Prod Genesis & Tests
- [x] Code Cleanup