### PR TITLE
[JSON RPC] make CLI client independent of AC/gRPC

### DIFF
--- a/client/cli/src/client_proxy.rs
+++ b/client/cli/src/client_proxy.rs
@@ -117,15 +117,14 @@ impl ClientProxy {
     /// Construct a new TestClient.
     pub fn new(
         host: &str,
-        ac_port: u16,
-        json_rpc_port: u16,
+        port: u16,
         faucet_account_file: &str,
         sync_on_wallet_recovery: bool,
         faucet_server: Option<String>,
         mnemonic_file: Option<String>,
         waypoint: Option<Waypoint>,
     ) -> Result<Self> {
-        let mut client = LibraClient::new(host, ac_port, json_rpc_port, waypoint)?;
+        let mut client = LibraClient::new(host, port, waypoint)?;
 
         let accounts = vec![];
 
@@ -943,9 +942,7 @@ impl ClientProxy {
 
     /// Test gRPC client connection with validator.
     pub fn test_validator_connection(&mut self) -> Result<LedgerInfoWithSignatures> {
-        self.client
-            .get_with_proof_sync(vec![])
-            .map(|res| res.ledger_info_with_sigs)
+        self.client.get_state_proof()
     }
 
     /// Get account state from validator and update status of account if it is cached locally.
@@ -1268,8 +1265,7 @@ mod tests {
         // generate random accounts
         let mut client_proxy = ClientProxy::new(
             "", /* host */
-            0,  /* Admission Control (gRPC) port */
-            1,  /* JSON RPC port*/
+            0,  /* JSON RPC port*/
             &"",
             false,
             None,

--- a/client/cli/src/client_proxy.rs
+++ b/client/cli/src/client_proxy.rs
@@ -646,7 +646,7 @@ impl ClientProxy {
         let mut dependencies = vec![];
         for path in paths {
             if path.address != CORE_CODE_ADDRESS {
-                if let (Some(blob), _) = self.client.get_account_blob(path.address)? {
+                if let Some(blob) = self.client.get_account_blob(path.address)? {
                     let account_state = AccountState::try_from(&blob)?;
                     if let Some(code) = account_state.get(&path.path) {
                         dependencies.push(code.clone());

--- a/client/cli/src/main.rs
+++ b/client/cli/src/main.rs
@@ -28,7 +28,7 @@ use structopt::StructOpt;
 )]
 struct Args {
     /// JSON RPC port to connect to.
-    #[structopt(short = "p", long, default_value = "5000")]
+    #[structopt(short = "p", long, default_value = "8080")]
     pub port: NonZeroU16,
     /// Host address/name to connect to.
     #[structopt(short = "a", long)]
@@ -227,8 +227,8 @@ mod tests {
     #[test]
     fn test_args_port() {
         let args = Args::from_iter(&["test", "--host=h"]);
-        assert_eq!(args.port.get(), 8000);
-        assert_eq!(format!("{}:{}", args.host, args.port.get()), "h:8000");
+        assert_eq!(args.port.get(), 8080);
+        assert_eq!(format!("{}:{}", args.host, args.port.get()), "h:8080");
         let args = Args::from_iter(&["test", "--port=65535", "--host=h"]);
         assert_eq!(args.port.get(), 65535);
     }

--- a/client/cli/src/main.rs
+++ b/client/cli/src/main.rs
@@ -27,13 +27,9 @@ use structopt::StructOpt;
     about = "Libra client to connect to a specific validator"
 )]
 struct Args {
-    /// Admission Control port to connect to.
-    /// TODO deprecate this completely once migration to JSON RPC is complete
-    #[structopt(short = "p", long, default_value = "8000")]
-    pub port: NonZeroU16,
     /// JSON RPC port to connect to.
-    #[structopt(short = "j", long, default_value = "5000")]
-    pub json_rpc_port: NonZeroU16,
+    #[structopt(short = "p", long, default_value = "5000")]
+    pub port: NonZeroU16,
     /// Host address/name to connect to.
     #[structopt(short = "a", long)]
     pub host: String,
@@ -100,7 +96,6 @@ fn main() {
     let mut client_proxy = ClientProxy::new(
         &args.host,
         args.port.get(),
-        args.json_rpc_port.get(),
         &faucet_account_file,
         args.sync,
         args.faucet_server.clone(),

--- a/config/src/config/rpc_config.rs
+++ b/config/src/config/rpc_config.rs
@@ -11,7 +11,7 @@ pub struct RpcConfig {
     pub address: SocketAddr,
 }
 
-pub const DEFAULT_JSON_RPC_PORT: u16 = 5000;
+pub const DEFAULT_JSON_RPC_PORT: u16 = 8080;
 
 impl Default for RpcConfig {
     fn default() -> RpcConfig {

--- a/json-rpc/src/views.rs
+++ b/json-rpc/src/views.rs
@@ -113,7 +113,7 @@ pub struct BlockMetadata {
     pub timestamp: u64,
 }
 
-#[derive(Serialize, Deserialize, Debug, PartialEq)]
+#[derive(Clone, Serialize, Deserialize, Debug, PartialEq)]
 pub struct BytesView(pub String);
 
 impl BytesView {

--- a/libra-swarm/src/client.rs
+++ b/libra-swarm/src/client.rs
@@ -39,8 +39,7 @@ impl Drop for InteractiveClient {
 
 impl InteractiveClient {
     pub fn new_with_inherit_io(
-        ac_port: u16,
-        json_rpc_port: u16,
+        port: u16,
         faucet_key_file_path: &Path,
         mnemonic_file_path: &Path,
     ) -> Self {
@@ -53,9 +52,7 @@ impl InteractiveClient {
                 Command::new(workspace_builder::get_bin("cli"))
                     .current_dir(workspace_builder::workspace_root())
                     .arg("-p")
-                    .arg(ac_port.to_string())
-                    .arg("-j")
-                    .arg(json_rpc_port.to_string())
+                    .arg(port.to_string())
                     .arg("-m")
                     .arg(
                         faucet_key_file_path
@@ -144,18 +141,12 @@ pub struct InProcessTestClient {
 }
 
 impl InProcessTestClient {
-    pub fn new(
-        ac_port: u16,
-        json_rpc_port: u16,
-        faucet_key_file_path: &Path,
-        mnemonic_file_path: &str,
-    ) -> Self {
+    pub fn new(port: u16, faucet_key_file_path: &Path, mnemonic_file_path: &str) -> Self {
         let (_, alias_to_cmd) = commands::get_commands(true);
         Self {
             client: ClientProxy::new(
                 "localhost",
-                ac_port,
-                json_rpc_port,
+                port,
                 faucet_key_file_path
                     .canonicalize()
                     .expect("Unable to get canonical path of faucet key file")

--- a/libra-swarm/src/main.rs
+++ b/libra-swarm/src/main.rs
@@ -84,8 +84,7 @@ fn main() {
     let validator_config = NodeConfig::load(&validator_swarm.config.config_files[0]).unwrap();
     println!("To run the Libra CLI client in a separate process and connect to the validator nodes you just spawned, use this command:");
     println!(
-        "\tcargo run --bin cli -- -a localhost -p {} -j {} -m {:?}",
-        validator_config.admission_control.address.port(),
+        "\tcargo run --bin cli -- -a localhost -p {} -m {:?}",
         validator_config.rpc.address.port(),
         faucet_key_file_path,
     );
@@ -108,8 +107,7 @@ fn main() {
         let full_node_config = NodeConfig::load(&swarm.config.config_files[0]).unwrap();
         println!("To connect to the full nodes you just spawned, use this command:");
         println!(
-            "\tcargo run --bin cli -- -a localhost -p {} - j {} -m {:?}",
-            full_node_config.admission_control.address.port(),
+            "\tcargo run --bin cli -- -a localhost -p {} -m {:?}",
             full_node_config.rpc.address.port(),
             faucet_key_file_path,
         );
@@ -118,10 +116,9 @@ fn main() {
     let tmp_mnemonic_file = TempPath::new();
     tmp_mnemonic_file.create_as_file().unwrap();
     if args.start_client {
-        let (ac_port, json_rpc_port) = validator_swarm.get_client_ports(0);
+        let port = validator_swarm.get_client_port(0);
         let client = client::InteractiveClient::new_with_inherit_io(
-            ac_port,
-            json_rpc_port,
+            port,
             Path::new(&faucet_key_file_path),
             &tmp_mnemonic_file.path(),
         );

--- a/libra-swarm/src/swarm.rs
+++ b/libra-swarm/src/swarm.rs
@@ -27,8 +27,7 @@ pub struct LibraNode {
     validator_peer_id: Option<AccountAddress>,
     role: RoleType,
     debug_client: NodeDebugClient,
-    ac_port: u16,
-    json_rpc_port: u16,
+    port: u16,
     log: PathBuf,
 }
 
@@ -93,8 +92,7 @@ impl LibraNode {
             validator_peer_id,
             role,
             debug_client,
-            ac_port: config.admission_control.address.port(),
-            json_rpc_port: config.rpc.address.port(),
+            port: config.rpc.address.port(),
             log: log_path,
         })
     }
@@ -103,12 +101,8 @@ impl LibraNode {
         self.validator_peer_id
     }
 
-    pub fn ac_port(&self) -> u16 {
-        self.ac_port
-    }
-
-    pub fn json_rpc_port(&self) -> u16 {
-        self.json_rpc_port
+    pub fn port(&self) -> u16 {
+        self.port
     }
 
     pub fn get_log_contents(&self) -> Result<String> {
@@ -510,14 +504,10 @@ impl LibraSwarm {
         false
     }
 
-    /// A specific public ports of a validator or a full node.
-    /// Returns (AC port, JSON RPC port)
-    pub fn get_client_ports(&self, index: usize) -> (u16, u16) {
+    /// A specific public JSON RPC port of a validator or a full node.
+    pub fn get_client_port(&self, index: usize) -> u16 {
         let node_id = format!("{}", index);
-        self.nodes
-            .get(&node_id)
-            .map(|node| (node.ac_port(), node.json_rpc_port()))
-            .unwrap()
+        self.nodes.get(&node_id).map(|node| node.port()).unwrap()
     }
 
     /// Vector with the peer ids of the validators in the swarm.

--- a/scripts/cli/start_cli_testnet.sh
+++ b/scripts/cli/start_cli_testnet.sh
@@ -13,7 +13,7 @@ source "$HOME/.cargo/env"
 
 SCRIPT_PATH="$(dirname $0)"
 
-RUN_PARAMS="--host ac.testnet.libra.org --port 8000 --json-rpc-port 5000 "
+RUN_PARAMS="--host ac.testnet.libra.org --port 5000 "
 RELEASE=""
 
 while [[ ! -z "$1" ]]; do

--- a/scripts/cli/start_cli_testnet.sh
+++ b/scripts/cli/start_cli_testnet.sh
@@ -13,7 +13,7 @@ source "$HOME/.cargo/env"
 
 SCRIPT_PATH="$(dirname $0)"
 
-RUN_PARAMS="--host ac.testnet.libra.org --port 5000 "
+RUN_PARAMS="--host ac.testnet.libra.org --port 8080 "
 RELEASE=""
 
 while [[ ! -z "$1" ]]; do

--- a/testsuite/tests/libratest/smoke_test.rs
+++ b/testsuite/tests/libratest/smoke_test.rs
@@ -114,12 +114,7 @@ impl TestEnvironment {
         panic!("Max out {} attempts to launch test swarm", num_attempts);
     }
 
-    fn get_ac_client(
-        &self,
-        ac_port: u16,
-        json_rpc_port: u16,
-        waypoint: Option<Waypoint>,
-    ) -> ClientProxy {
+    fn get_json_rpc_client(&self, port: u16, waypoint: Option<Waypoint>) -> ClientProxy {
         let mnemonic_file_path = self
             .mnemonic_file
             .path()
@@ -132,8 +127,7 @@ impl TestEnvironment {
 
         ClientProxy::new(
             "localhost",
-            ac_port,
-            json_rpc_port,
+            port,
             &self.faucet_key.1,
             false,
             /* faucet server */ None,
@@ -148,8 +142,8 @@ impl TestEnvironment {
         node_index: usize,
         waypoint: Option<Waypoint>,
     ) -> ClientProxy {
-        let (ac_port, json_rpc_port) = self.validator_swarm.get_client_ports(node_index);
-        self.get_ac_client(ac_port, json_rpc_port, waypoint)
+        let port = self.validator_swarm.get_client_port(node_index);
+        self.get_json_rpc_client(port, waypoint)
     }
 
     fn get_validator_debug_interface_client(&self, node_index: usize) -> NodeDebugClient {
@@ -173,8 +167,8 @@ impl TestEnvironment {
     ) -> ClientProxy {
         match &self.full_node_swarm {
             Some(swarm) => {
-                let (ac_port, json_rpc_port) = swarm.get_client_ports(node_index);
-                self.get_ac_client(ac_port, json_rpc_port, waypoint)
+                let port = swarm.get_client_port(node_index);
+                self.get_json_rpc_client(port, waypoint)
             }
             None => {
                 panic!("Full Node swarm is not initialized");


### PR DESCRIPTION
## Summary

Last step in completely migrating CLI over from AC/gRPC to JSON RPC protocol!
- removed last gRPC endpoint in CLI client (replaced with `get_state_proof`)
- removed all AC dependencies in CLI client

## Test Plan

Locally ran CLI
Currently `start_cli_testnet.sh` breaks on failing to connect to JSON RPC port - this should be resolved once JSON RPC port is opened on testnet. 

