### PR TITLE
[ci] Forbid direct third-party duplicate dependencies

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -107,6 +107,8 @@ jobs:
             [[ $CIRCLE_NODE_INDEX =~ [123] ]] || cargo x lint
             [[ $CIRCLE_NODE_INDEX =~ [123] ]] || cargo xclippy --workspace --all-targets
             [[ $CIRCLE_NODE_INDEX =~ [123] ]] || cargo fmt -- --check
+            [[ $CIRCLE_NODE_INDEX =~ [123] ]] || cargo install cargo-guppy --git http://github.com/calibra/cargo-guppy --rev aa68df82cc3104d72dfb917d3757abc18116d922
+            [[ $CIRCLE_NODE_INDEX =~ [123] ]] || [[ -z $(cargo guppy dups --target x86_64-unknown-linux-gnu --kind directthirdparty) ]]
       - run:
           name: Build Release
           command: |

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1364,7 +1364,7 @@ dependencies = [
  "executor 0.1.0",
  "executor-types 0.1.0",
  "executor-utils 0.1.0",
- "itertools 0.8.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "itertools 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "libra-config 0.1.0",
  "libra-crypto 0.1.0",
  "libra-logger 0.1.0",

--- a/execution/executor-benchmark/Cargo.toml
+++ b/execution/executor-benchmark/Cargo.toml
@@ -11,7 +11,7 @@ edition = "2018"
 
 [dependencies]
 anyhow = "1.0"
-itertools = { version = "0.8.0", default-features = false }
+itertools = { version = "0.9.0", default-features = false }
 rand = "0.6.5"
 rayon = "1"
 structopt = "0.3"


### PR DESCRIPTION
This installs and uses cargo-guppy to detect direct duplication of third-party dependencies, failing the build if any are present.

## Test Plan

This should fail as I think we are not currently clean. I'll investigate and fix, and this can land once it is then clean.