### PR TITLE
[consensus] cleanup EpochManager, RecoveryData 

### DIFF
--- a/consensus/src/chained_bft/event_processor.rs
+++ b/consensus/src/chained_bft/event_processor.rs
@@ -117,7 +117,7 @@ pub mod event_processor_fuzzing;
 
 /// During the event of the node can't recover from local data, StartupSyncProcessor is responsible
 /// for processing the events carrying sync info and use the info to retrieve blocks from peers
-pub struct StartupSyncProcessor<T> {
+pub struct SyncProcessor<T> {
     epoch_info: EpochInfo,
     network: NetworkSender<T>,
     storage: Arc<dyn PersistentLivenessStorage<T>>,
@@ -125,7 +125,7 @@ pub struct StartupSyncProcessor<T> {
     ledger_recovery_data: LedgerRecoveryData,
 }
 
-impl<T: Payload> StartupSyncProcessor<T> {
+impl<T: Payload> SyncProcessor<T> {
     pub fn new(
         epoch_info: EpochInfo,
         network: NetworkSender<T>,
@@ -133,7 +133,7 @@ impl<T: Payload> StartupSyncProcessor<T> {
         state_computer: Arc<dyn StateComputer<Payload = T>>,
         ledger_recovery_data: LedgerRecoveryData,
     ) -> Self {
-        StartupSyncProcessor {
+        SyncProcessor {
             epoch_info,
             network,
             storage,
@@ -158,6 +158,7 @@ impl<T: Payload> StartupSyncProcessor<T> {
     }
 
     async fn sync_up(&mut self, sync_info: &SyncInfo, peer: Author) -> Result<RecoveryData<T>> {
+        sync_info.verify(&self.epoch_info.verifier)?;
         ensure!(
             sync_info.highest_round() > self.ledger_recovery_data.commit_round(),
             "Received sync info has lower round number than committed block"

--- a/consensus/src/chained_bft/event_processor.rs
+++ b/consensus/src/chained_bft/event_processor.rs
@@ -122,7 +122,7 @@ pub struct StartupSyncProcessor<T> {
     network: NetworkSender<T>,
     storage: Arc<dyn PersistentLivenessStorage<T>>,
     state_computer: Arc<dyn StateComputer<Payload = T>>,
-    ledger_recovery_data: LedgerRecoveryData<T>,
+    ledger_recovery_data: LedgerRecoveryData,
 }
 
 impl<T: Payload> StartupSyncProcessor<T> {
@@ -131,7 +131,7 @@ impl<T: Payload> StartupSyncProcessor<T> {
         network: NetworkSender<T>,
         storage: Arc<dyn PersistentLivenessStorage<T>>,
         state_computer: Arc<dyn StateComputer<Payload = T>>,
-        ledger_recovery_data: LedgerRecoveryData<T>,
+        ledger_recovery_data: LedgerRecoveryData,
     ) -> Self {
         StartupSyncProcessor {
             epoch_info,
@@ -163,7 +163,7 @@ impl<T: Payload> StartupSyncProcessor<T> {
             "Received sync info has lower round number than committed block"
         );
         ensure!(
-            sync_info.epoch() == self.ledger_recovery_data.epoch(),
+            sync_info.epoch() == self.epoch_info.epoch,
             "Received sync info is in different epoch than committed block"
         );
         let mut retriever = BlockRetriever::new(

--- a/consensus/src/chained_bft/event_processor_fuzzing.rs
+++ b/consensus/src/chained_bft/event_processor_fuzzing.rs
@@ -21,7 +21,7 @@ use channel::{self, libra_channel, message_queues::QueueStyle};
 use consensus_types::proposal_msg::ProposalMsg;
 use futures::{channel::mpsc, executor::block_on};
 use libra_types::crypto_proxies::{
-    EpochInfo, LedgerInfoWithSignatures, ValidatorSigner, ValidatorVerifier,
+    LedgerInfoWithSignatures, ValidatorSigner, ValidatorVerifier,
 };
 use network::peer_manager::{ConnectionRequestSender, PeerManagerRequestSender};
 use once_cell::sync::Lazy;
@@ -103,18 +103,14 @@ fn create_node_for_fuzzing() -> EventProcessor<TestPayload> {
         conn_mgr_reqs_tx,
     );
     let (self_sender, _self_receiver) = channel::new_test(8);
+
+    let epoch_info = initial_data.epoch_info();
     let network = NetworkSender::new(
         signer.author(),
         network_sender,
         self_sender,
-        initial_data.validators(),
+        epoch_info.verifier.clone(),
     );
-
-    let validators = initial_data.validators();
-    let epoch_info = EpochInfo {
-        epoch: initial_data.epoch(),
-        verifier: validators,
-    };
 
     // TODO: mock
     let block_store = build_empty_store(storage.clone(), initial_data);

--- a/consensus/src/chained_bft/event_processor_fuzzing.rs
+++ b/consensus/src/chained_bft/event_processor_fuzzing.rs
@@ -20,9 +20,7 @@ use crate::{
 use channel::{self, libra_channel, message_queues::QueueStyle};
 use consensus_types::proposal_msg::ProposalMsg;
 use futures::{channel::mpsc, executor::block_on};
-use libra_types::crypto_proxies::{
-    LedgerInfoWithSignatures, ValidatorSigner, ValidatorVerifier,
-};
+use libra_types::crypto_proxies::{LedgerInfoWithSignatures, ValidatorSigner, ValidatorVerifier};
 use network::peer_manager::{ConnectionRequestSender, PeerManagerRequestSender};
 use once_cell::sync::Lazy;
 use safety_rules::{PersistentSafetyStorage, SafetyRules};

--- a/consensus/src/chained_bft/event_processor_fuzzing.rs
+++ b/consensus/src/chained_bft/event_processor_fuzzing.rs
@@ -20,7 +20,9 @@ use crate::{
 use channel::{self, libra_channel, message_queues::QueueStyle};
 use consensus_types::proposal_msg::ProposalMsg;
 use futures::{channel::mpsc, executor::block_on};
-use libra_types::crypto_proxies::{LedgerInfoWithSignatures, ValidatorSigner, ValidatorVerifier};
+use libra_types::crypto_proxies::{
+    EpochInfo, LedgerInfoWithSignatures, ValidatorSigner, ValidatorVerifier,
+};
 use network::peer_manager::{ConnectionRequestSender, PeerManagerRequestSender};
 use once_cell::sync::Lazy;
 use safety_rules::{PersistentSafetyStorage, SafetyRules};
@@ -109,6 +111,10 @@ fn create_node_for_fuzzing() -> EventProcessor<TestPayload> {
     );
 
     let validators = initial_data.validators();
+    let epoch_info = EpochInfo {
+        epoch: initial_data.epoch(),
+        verifier: validators,
+    };
 
     // TODO: mock
     let block_store = build_empty_store(storage.clone(), initial_data);
@@ -133,6 +139,7 @@ fn create_node_for_fuzzing() -> EventProcessor<TestPayload> {
 
     // event processor
     EventProcessor::new(
+        epoch_info,
         Arc::clone(&block_store),
         None,
         pacemaker,
@@ -143,7 +150,6 @@ fn create_node_for_fuzzing() -> EventProcessor<TestPayload> {
         Box::new(MockTransactionManager::new(None)),
         storage,
         time_service,
-        validators,
     )
 }
 

--- a/consensus/src/chained_bft/persistent_liveness_storage.rs
+++ b/consensus/src/chained_bft/persistent_liveness_storage.rs
@@ -15,10 +15,9 @@ use executor_types::ExecutedTrees;
 use libra_config::config::NodeConfig;
 use libra_crypto::HashValue;
 use libra_logger::prelude::*;
-use libra_types::crypto_proxies::EpochInfo;
 use libra_types::{
     block_info::Round,
-    crypto_proxies::{ValidatorPublicKeys, ValidatorSet, ValidatorVerifier},
+    crypto_proxies::{EpochInfo, ValidatorPublicKeys, ValidatorSet, ValidatorVerifier},
     ledger_info::LedgerInfo,
 };
 use std::{collections::HashSet, sync::Arc};

--- a/consensus/src/chained_bft/test_utils/mock_storage.rs
+++ b/consensus/src/chained_bft/test_utils/mock_storage.rs
@@ -15,9 +15,9 @@ use executor_types::ExecutedTrees;
 use futures::executor::block_on;
 use libra_crypto::HashValue;
 use libra_types::{crypto_proxies::ValidatorSet, ledger_info::LedgerInfo};
-use std::marker::PhantomData;
 use std::{
     collections::HashMap,
+    marker::PhantomData,
     sync::{Arc, Mutex},
 };
 


### PR DESCRIPTION
<!--
Thank you for sending a PR. We appreciate you spending time to help improve the Libra project.

The project is undergoing daily changes. Pull Requests will be reviewed and responded to as time permits.
-->

## Motivation

Three commits inside:
1. unify EpochManager initial start path with epoch start path
2. unify LedgerRecoveryData with RecoveryData
3. fix the unverified SyncInfo in SyncProcessor

It's preparation for leader reputation work as we want to start a new EventProcessor upon state sync to propagate the latest commit info to ProposerElection.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?

Y

## Test Plan
Existing tests.

## Related PRs

(If this PR adds or changes functionality, please take some time to update the docs at https://github.com/libra/website, and link to your PR here.)
