### PR TITLE
rustfmt: merge imports and enforce in CI

### DIFF
--- a/.cargo/config
+++ b/.cargo/config
@@ -2,4 +2,5 @@
 x = "run --package x --bin x --"
 xcheck = "run --package x --bin x -- check"
 xclippy = "run --package x --bin x -- clippy"
+xfmt = "run --package x --bin x -- fmt"
 xtest = "run --package x --bin x -- test"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -106,7 +106,7 @@ jobs:
           command: |
             [[ $CIRCLE_NODE_INDEX =~ [123] ]] || cargo x lint
             [[ $CIRCLE_NODE_INDEX =~ [123] ]] || cargo xclippy --workspace --all-targets
-            [[ $CIRCLE_NODE_INDEX =~ [123] ]] || cargo fmt -- --check
+            [[ $CIRCLE_NODE_INDEX =~ [123] ]] || cargo xfmt --check
             [[ $CIRCLE_NODE_INDEX =~ [123] ]] || cargo install cargo-guppy --git http://github.com/calibra/cargo-guppy --rev aa68df82cc3104d72dfb917d3757abc18116d922
             [[ $CIRCLE_NODE_INDEX =~ [123] ]] || [[ -z $(cargo guppy dups --target x86_64-unknown-linux-gnu --kind directthirdparty) ]]
       - run:

--- a/common/debug-interface/src/node_debug_service.rs
+++ b/common/debug-interface/src/node_debug_service.rs
@@ -3,9 +3,9 @@
 
 //! Debug interface to access information in a specific node.
 
-use crate::json_log::JsonLogEntry;
 use crate::{
     json_log,
+    json_log::JsonLogEntry,
     proto::{
         node_debug_interface_server::NodeDebugInterface, Event, GetEventsRequest,
         GetEventsResponse, GetNodeDetailsRequest, GetNodeDetailsResponse,

--- a/config/src/generator.rs
+++ b/config/src/generator.rs
@@ -4,10 +4,10 @@
 //! Convenience structs and functions for generating a random set of Libra ndoes without the
 //! genesis.blob.
 
-use crate::config::SafetyRulesService;
 use crate::{
     config::{
-        NodeConfig, OnDiskStorageConfig, SafetyRulesBackend, SeedPeersConfig, VMPublishingOption,
+        NodeConfig, OnDiskStorageConfig, SafetyRulesBackend, SafetyRulesService, SeedPeersConfig,
+        VMPublishingOption,
     },
     utils,
 };

--- a/consensus/src/chained_bft/event_processor.rs
+++ b/consensus/src/chained_bft/event_processor.rs
@@ -18,8 +18,7 @@ use crate::{
         },
     },
     counters,
-    state_replication::StateComputer,
-    state_replication::TxnManager,
+    state_replication::{StateComputer, TxnManager},
     util::time_service::{
         duration_since_epoch, wait_if_possible, TimeService, WaitingError, WaitingSuccess,
     },

--- a/crypto/crypto/src/multi_ed25519.rs
+++ b/crypto/crypto/src/multi_ed25519.rs
@@ -6,11 +6,14 @@
 //!
 //! Signature verification also checks and rejects non-canonical signatures.
 
-use crate::ed25519::{
-    Ed25519PrivateKey, Ed25519PublicKey, Ed25519Signature, ED25519_PRIVATE_KEY_LENGTH,
-    ED25519_PUBLIC_KEY_LENGTH, ED25519_SIGNATURE_LENGTH,
+use crate::{
+    ed25519::{
+        Ed25519PrivateKey, Ed25519PublicKey, Ed25519Signature, ED25519_PRIVATE_KEY_LENGTH,
+        ED25519_PUBLIC_KEY_LENGTH, ED25519_SIGNATURE_LENGTH,
+    },
+    traits::*,
+    HashValue,
 };
-use crate::{traits::*, HashValue};
 use anyhow::{anyhow, Result};
 use bit_vec::BitVec;
 use core::convert::TryFrom;

--- a/crypto/crypto/src/unit_tests/multi_ed25519_test.rs
+++ b/crypto/crypto/src/unit_tests/multi_ed25519_test.rs
@@ -9,11 +9,13 @@ use crate::{
 use core::convert::TryFrom;
 use rand::{rngs::StdRng, SeedableRng};
 
-use crate::ed25519::{compat, ED25519_PUBLIC_KEY_LENGTH};
-use crate::hash::HashValue;
-use crate::multi_ed25519::{MultiEd25519PrivateKey, MultiEd25519PublicKey};
-use crate::test_utils::TEST_SEED;
-use crate::CryptoMaterialError::{ValidationError, WrongLengthError};
+use crate::{
+    ed25519::{compat, ED25519_PUBLIC_KEY_LENGTH},
+    hash::HashValue,
+    multi_ed25519::{MultiEd25519PrivateKey, MultiEd25519PublicKey},
+    test_utils::TEST_SEED,
+    CryptoMaterialError::{ValidationError, WrongLengthError},
+};
 
 // Helper function to generate N key pairs.
 fn generate_key_pairs(n: usize) -> Vec<(Ed25519PrivateKey, Ed25519PublicKey)> {

--- a/execution/executor/src/lib.rs
+++ b/execution/executor/src/lib.rs
@@ -14,9 +14,8 @@ use debug_interface::prelude::*;
 use executor_types::{ExecutedTrees, ProcessedVMOutput, ProofReader, TransactionData};
 use futures::executor::block_on;
 use libra_config::config::{NodeConfig, VMConfig};
-use libra_crypto::hash::GENESIS_BLOCK_ID;
 use libra_crypto::{
-    hash::{CryptoHash, EventAccumulatorHasher},
+    hash::{CryptoHash, EventAccumulatorHasher, GENESIS_BLOCK_ID},
     HashValue,
 };
 use libra_logger::prelude::*;

--- a/execution/executor/tests/storage_integration_test.rs
+++ b/execution/executor/tests/storage_integration_test.rs
@@ -5,11 +5,11 @@ use anyhow::{ensure, format_err, Result};
 use executor_utils::create_storage_service_and_executor;
 use libra_config::config::{VMConfig, VMPublishingOption};
 use libra_crypto::{ed25519::*, test_utils::TEST_SEED, HashValue, PrivateKey};
-use libra_types::account_state::AccountState;
 use libra_types::{
     access_path::AccessPath,
     account_address::{AccountAddress, AuthenticationKey},
     account_config::{association_address, AccountResource},
+    account_state::AccountState,
     account_state_blob::AccountStateWithProof,
     block_info::BlockInfo,
     block_metadata::BlockMetadata,

--- a/json-rpc/src/client.rs
+++ b/json-rpc/src/client.rs
@@ -6,8 +6,7 @@ use anyhow::{ensure, format_err, Error, Result};
 use libra_types::{account_address::AccountAddress, transaction::SignedTransaction};
 use reqwest::Client;
 use serde_json::Value;
-use std::convert::TryFrom;
-use std::fmt;
+use std::{convert::TryFrom, fmt};
 
 #[derive(Default)]
 pub struct JsonRpcBatch {

--- a/json-rpc/src/lib.rs
+++ b/json-rpc/src/lib.rs
@@ -22,10 +22,8 @@ mod methods;
 mod runtime;
 pub mod views;
 
-pub use {
-    client::{JsonRpcAsyncClient, JsonRpcBatch},
-    runtime::bootstrap_from_config,
-};
+pub use client::{JsonRpcAsyncClient, JsonRpcBatch};
+pub use runtime::bootstrap_from_config;
 
 #[cfg(test)]
 mod tests;

--- a/language/compiler/bytecode-source-map/src/utils.rs
+++ b/language/compiler/bytecode-source-map/src/utils.rs
@@ -6,8 +6,7 @@ use crate::{
     source_map::{ModuleSourceMap, SourceMap},
 };
 use anyhow::{format_err, Result};
-use codespan::Span;
-use codespan::{FileId, Files};
+use codespan::{FileId, Files, Span};
 use codespan_reporting::{
     diagnostic::{Diagnostic, Label},
     term::{
@@ -17,10 +16,7 @@ use codespan_reporting::{
     },
 };
 use move_ir_types::location::Loc;
-use serde::{
-    de::DeserializeOwned,
-    {Deserialize, Serialize},
-};
+use serde::{de::DeserializeOwned, Deserialize, Serialize};
 use std::{collections::HashMap, fs::File, path::Path};
 
 pub type Error = (Loc, String);

--- a/language/e2e-tests/src/account.rs
+++ b/language/e2e-tests/src/account.rs
@@ -14,8 +14,8 @@ use libra_types::{
         RawTransaction, Script, SignedTransaction, TransactionArgument, TransactionPayload,
     },
 };
-use move_vm_types::identifier::create_access_path;
 use move_vm_types::{
+    identifier::create_access_path,
     loaded_data::{struct_def::StructDef, types::Type},
     values::{Struct, Value},
 };

--- a/language/e2e-tests/src/tests/scripts.rs
+++ b/language/e2e-tests/src/tests/scripts.rs
@@ -4,8 +4,9 @@
 use crate::{account::AccountData, executor::test_all_genesis, gas_costs};
 use libra_config::config::VMPublishingOption;
 use libra_types::{
-    account_address::AccountAddress, account_address::ADDRESS_LENGTH,
-    transaction::TransactionStatus, vm_error::StatusCode,
+    account_address::{AccountAddress, ADDRESS_LENGTH},
+    transaction::TransactionStatus,
+    vm_error::StatusCode,
 };
 use move_core_types::identifier::Identifier;
 use vm::file_format::{

--- a/language/libra-vm/src/libra_vm.rs
+++ b/language/libra-vm/src/libra_vm.rs
@@ -23,8 +23,7 @@ use move_vm_state::{
     data_cache::{BlockDataCache, RemoteCache, RemoteStorage},
     execution_context::{ExecutionContext, SystemExecutionContext, TransactionExecutionContext},
 };
-use move_vm_types::identifier::create_access_path;
-use move_vm_types::{chain_state::ChainState, values::Value};
+use move_vm_types::{chain_state::ChainState, identifier::create_access_path, values::Value};
 use rayon::prelude::*;
 use std::sync::Arc;
 use vm::{

--- a/language/move-lang/src/expansion/ast.rs
+++ b/language/move-lang/src/expansion/ast.rs
@@ -1,11 +1,11 @@
 // Copyright (c) The Libra Core Contributors
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::parser::ast::{InvariantKind, SpecBlockTarget, SpecConditionKind};
 use crate::{
     parser::ast::{
-        BinOp, Field, FunctionName, FunctionVisibility, Kind, ModuleIdent, ModuleName, ResourceLoc,
-        StructName, UnaryOp, Value, Var,
+        BinOp, Field, FunctionName, FunctionVisibility, InvariantKind, Kind, ModuleIdent,
+        ModuleName, ResourceLoc, SpecBlockTarget, SpecConditionKind, StructName, UnaryOp, Value,
+        Var,
     },
     shared::{ast_debug::*, unique_map::UniqueMap, *},
 };

--- a/language/move-lang/tests/ir_test_coverage.rs
+++ b/language/move-lang/tests/ir_test_coverage.rs
@@ -41,7 +41,7 @@ fn test_ir_test_coverage() {
         ));
         msg.push_str(&format!(
             "Replace the extension '.{}' with '.{}' to mark the test as present, but it will not \
-            be run.\n\n",
+             be run.\n\n",
             MOVE_EXTENSION, TODO_EXTENSION
         ));
         msg.push_str("Running the following tool may help with the migration:\n");

--- a/language/move-prover/spec-lang/src/ast.rs
+++ b/language/move-prover/spec-lang/src/ast.rs
@@ -5,11 +5,15 @@
 
 use num::{BigUint, Num};
 
-use crate::env::{FieldId, Loc, ModuleId, NodeId, SpecFunId, SpecVarId, StructId};
-use crate::symbol::{Symbol, SymbolPool};
-use crate::ty::Type;
-use std::fmt;
-use std::fmt::{Error, Formatter};
+use crate::{
+    env::{FieldId, Loc, ModuleId, NodeId, SpecFunId, SpecVarId, StructId},
+    symbol::{Symbol, SymbolPool},
+    ty::Type,
+};
+use std::{
+    fmt,
+    fmt::{Error, Formatter},
+};
 
 // =================================================================================================
 /// # Declarations

--- a/language/move-prover/spec-lang/src/env.rs
+++ b/language/move-prover/spec-lang/src/env.rs
@@ -10,27 +10,33 @@ use log::info;
 use std::cell::RefCell;
 
 use codespan::{ByteIndex, ByteOffset, FileId, Files, Location, Span};
-use codespan_reporting::diagnostic::{Diagnostic, Label, Severity};
-use codespan_reporting::term::{emit, termcolor::WriteColor, Config};
+use codespan_reporting::{
+    diagnostic::{Diagnostic, Label, Severity},
+    term::{emit, termcolor::WriteColor, Config},
+};
 use itertools::Itertools;
 use num::{BigUint, Num};
 
 use bytecode_source_map::source_map::ModuleSourceMap;
 use libra_types::language_storage;
-use vm::access::ModuleAccess;
-use vm::file_format::{
-    AddressPoolIndex, FieldDefinitionIndex, FunctionDefinitionIndex, FunctionHandleIndex, Kind,
-    LocalsSignatureIndex, SignatureToken, StructDefinitionIndex, StructFieldInformation,
-    StructHandleIndex,
-};
-use vm::views::{
-    FieldDefinitionView, FunctionDefinitionView, FunctionHandleView, SignatureTokenView,
-    StructDefinitionView, StructHandleView, ViewInternals,
+use vm::{
+    access::ModuleAccess,
+    file_format::{
+        AddressPoolIndex, FieldDefinitionIndex, FunctionDefinitionIndex, FunctionHandleIndex, Kind,
+        LocalsSignatureIndex, SignatureToken, StructDefinitionIndex, StructFieldInformation,
+        StructHandleIndex,
+    },
+    views::{
+        FieldDefinitionView, FunctionDefinitionView, FunctionHandleView, SignatureTokenView,
+        StructDefinitionView, StructHandleView, ViewInternals,
+    },
 };
 
-use crate::ast::{Condition, Invariant, InvariantKind, ModuleName, SpecFunDecl, SpecVarDecl};
-use crate::symbol::{Symbol, SymbolPool};
-use crate::ty::{PrimitiveType, Type};
+use crate::{
+    ast::{Condition, Invariant, InvariantKind, ModuleName, SpecFunDecl, SpecVarDecl},
+    symbol::{Symbol, SymbolPool},
+    ty::{PrimitiveType, Type},
+};
 use std::collections::BTreeMap;
 use vm::CompiledModule;
 

--- a/language/move-prover/spec-lang/src/lib.rs
+++ b/language/move-prover/spec-lang/src/lib.rs
@@ -3,17 +3,18 @@
 
 #![forbid(unsafe_code)]
 
-use crate::ast::ModuleName;
-use crate::env::{GlobalEnv, ModuleId};
-use crate::translate::{ModuleTranslator, Translator};
+use crate::{
+    ast::ModuleName,
+    env::{GlobalEnv, ModuleId},
+    translate::{ModuleTranslator, Translator},
+};
 use anyhow::anyhow;
 use codespan_reporting::diagnostic::{Diagnostic, Label};
 use itertools::Itertools;
-use move_lang::errors::Errors;
-use move_lang::expansion::ast::Program;
-use move_lang::shared::Address;
-use move_lang::to_bytecode::translate::CompiledUnit;
-use move_lang::{move_compile_no_report, move_compile_to_expansion_no_report};
+use move_lang::{
+    errors::Errors, expansion::ast::Program, move_compile_no_report,
+    move_compile_to_expansion_no_report, shared::Address, to_bytecode::translate::CompiledUnit,
+};
 
 pub mod ast;
 pub mod env;

--- a/language/move-prover/spec-lang/src/symbol.rs
+++ b/language/move-prover/spec-lang/src/symbol.rs
@@ -4,11 +4,13 @@
 //! Contains definitions of symbols -- internalized strings which support fast hashing and
 //! comparison.
 
-use std::cell::RefCell;
-use std::collections::HashMap;
-use std::fmt;
-use std::fmt::{Error, Formatter};
-use std::rc::Rc;
+use std::{
+    cell::RefCell,
+    collections::HashMap,
+    fmt,
+    fmt::{Error, Formatter},
+    rc::Rc,
+};
 
 /// Representation of a symbol.
 #[derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash, Clone, Copy)]

--- a/language/move-prover/spec-lang/src/translate.rs
+++ b/language/move-prover/spec-lang/src/translate.rs
@@ -12,25 +12,27 @@ use itertools::Itertools;
 use num::{BigUint, FromPrimitive, Num};
 
 use bytecode_source_map::source_map::ModuleSourceMap;
-use move_lang::expansion::ast as EA;
-use move_lang::parser::ast as PA;
-use move_lang::shared::Name;
-use vm::access::ModuleAccess;
-use vm::file_format::{FunctionDefinitionIndex, StructDefinitionIndex};
-use vm::views::{FunctionHandleView, StructHandleView};
-use vm::CompiledModule;
+use move_lang::{expansion::ast as EA, parser::ast as PA, shared::Name};
+use vm::{
+    access::ModuleAccess,
+    file_format::{FunctionDefinitionIndex, StructDefinitionIndex},
+    views::{FunctionHandleView, StructHandleView},
+    CompiledModule,
+};
 
-use crate::ast::{
-    Condition, ConditionKind, Exp, Invariant, InvariantKind, LocalVarDecl, ModuleName, Operation,
-    QualifiedSymbol, SpecFunDecl, SpecVarDecl, Value,
+use crate::{
+    ast::{
+        Condition, ConditionKind, Exp, Invariant, InvariantKind, LocalVarDecl, ModuleName,
+        Operation, QualifiedSymbol, SpecFunDecl, SpecVarDecl, Value,
+    },
+    env::{
+        FieldId, FunId, FunctionData, GlobalEnv, Loc, ModuleId, MoveIrLoc, NodeId, SpecFunId,
+        SpecVarId, StructData, StructId,
+    },
+    project_1st, project_2nd,
+    symbol::{Symbol, SymbolPool},
+    ty::{PrimitiveType, Substitution, Type, TypeDisplayContext, BOOL_TYPE},
 };
-use crate::env::{
-    FieldId, FunId, FunctionData, GlobalEnv, Loc, ModuleId, MoveIrLoc, NodeId, SpecFunId,
-    SpecVarId, StructData, StructId,
-};
-use crate::symbol::{Symbol, SymbolPool};
-use crate::ty::{PrimitiveType, Substitution, Type, TypeDisplayContext, BOOL_TYPE};
-use crate::{project_1st, project_2nd};
 
 // =================================================================================================
 /// # Translator

--- a/language/move-prover/spec-lang/src/ty.rs
+++ b/language/move-prover/spec-lang/src/ty.rs
@@ -3,12 +3,12 @@
 
 //! Contains types and related functions.
 
-use crate::ast::QualifiedSymbol;
-use crate::env::{ModuleId, StructId};
-use crate::symbol::SymbolPool;
-use std::collections::BTreeMap;
-use std::fmt;
-use std::fmt::Formatter;
+use crate::{
+    ast::QualifiedSymbol,
+    env::{ModuleId, StructId},
+    symbol::SymbolPool,
+};
+use std::{collections::BTreeMap, fmt, fmt::Formatter};
 
 /// Represents a type.
 #[derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash, Clone)]

--- a/language/move-prover/spec-lang/tests/testsuite.rs
+++ b/language/move-prover/spec-lang/tests/testsuite.rs
@@ -6,8 +6,7 @@ use std::path::Path;
 use codespan_reporting::term::termcolor::Buffer;
 
 use spec_lang::run_spec_lang_compiler;
-use test_utils::baseline_test::verify_or_update_baseline;
-use test_utils::DEFAULT_SENDER;
+use test_utils::{baseline_test::verify_or_update_baseline, DEFAULT_SENDER};
 
 fn test_runner(path: &Path) -> datatest_stable::Result<()> {
     let targets = vec![path.to_str().unwrap().to_string()];

--- a/language/move-prover/src/boogie_helpers.rs
+++ b/language/move-prover/src/boogie_helpers.rs
@@ -4,11 +4,11 @@
 //! Helpers for emitting Boogie code.
 
 use itertools::Itertools;
-use spec_lang::env::{
-    FieldEnv, FunctionEnv, GlobalEnv, ModuleEnv, ModuleId, SpecFunId, StructEnv, StructId,
+use spec_lang::{
+    env::{FieldEnv, FunctionEnv, GlobalEnv, ModuleEnv, ModuleId, SpecFunId, StructEnv, StructId},
+    symbol::Symbol,
+    ty::{PrimitiveType, Type},
 };
-use spec_lang::symbol::Symbol;
-use spec_lang::ty::{PrimitiveType, Type};
 
 /// Return boogie name of given structure.
 pub fn boogie_struct_name(env: &StructEnv<'_>) -> String {

--- a/language/move-prover/src/boogie_wrapper.rs
+++ b/language/move-prover/src/boogie_wrapper.rs
@@ -20,11 +20,12 @@ use num::BigInt;
 use pretty::RcDoc;
 use regex::Regex;
 
-use spec_lang::env::{FunId, FunctionEnv, GlobalEnv, Loc, ModuleId, StructId};
-use spec_lang::ty::{PrimitiveType, Type};
+use spec_lang::{
+    env::{FunId, FunctionEnv, GlobalEnv, Loc, ModuleId, StructId},
+    ty::{PrimitiveType, Type},
+};
 
-use crate::cli::Options;
-use crate::code_writer::CodeWriter;
+use crate::{cli::Options, code_writer::CodeWriter};
 
 /// A type alias for the way how we use crate `pretty`'s document type. `pretty` is a
 /// Wadler-style pretty printer. Our simple usage doesn't require any lifetime management.

--- a/language/move-prover/src/bytecode_translator.rs
+++ b/language/move-prover/src/bytecode_translator.rs
@@ -9,25 +9,28 @@ use itertools::Itertools;
 #[allow(unused_imports)]
 use log::{debug, info};
 
-use spec_lang::env::{FunctionEnv, GlobalEnv, Loc, ModuleEnv, Parameter, StructEnv, TypeParameter};
-use spec_lang::ty::{PrimitiveType, Type};
+use spec_lang::{
+    env::{FunctionEnv, GlobalEnv, Loc, ModuleEnv, Parameter, StructEnv, TypeParameter},
+    ty::{PrimitiveType, Type},
+};
 use stackless_bytecode_generator::{
     stackless_bytecode::StacklessBytecode::{self, *},
     stackless_bytecode_generator::{StacklessFunction, StacklessModuleGenerator},
 };
 
-use crate::cli::Options;
-use crate::spec_translator::SpecTranslator;
 use crate::{
     boogie_helpers::{
         boogie_field_name, boogie_function_name, boogie_local_type, boogie_struct_name,
         boogie_struct_type_value, boogie_type_check, boogie_type_value, boogie_type_values,
         boogie_var_before_borrow,
     },
+    cli::Options,
     code_writer::CodeWriter,
+    spec_translator::SpecTranslator,
 };
-use bytecode_to_boogie::lifetime_analysis::LifetimeAnalysis;
-use bytecode_to_boogie::stackless_control_flow_graph::StacklessControlFlowGraph;
+use bytecode_to_boogie::{
+    lifetime_analysis::LifetimeAnalysis, stackless_control_flow_graph::StacklessControlFlowGraph,
+};
 use num::Zero;
 
 pub struct BoogieTranslator<'env> {

--- a/language/move-prover/src/lib.rs
+++ b/language/move-prover/src/lib.rs
@@ -3,15 +3,16 @@
 
 #![forbid(unsafe_code)]
 
-use crate::boogie_wrapper::BoogieWrapper;
-use crate::bytecode_translator::BoogieTranslator;
-use crate::cli::{Options, INLINE_PRELUDE};
-use crate::code_writer::CodeWriter;
+use crate::{
+    boogie_wrapper::BoogieWrapper,
+    bytecode_translator::BoogieTranslator,
+    cli::{Options, INLINE_PRELUDE},
+    code_writer::CodeWriter,
+};
 use anyhow::anyhow;
 use codespan_reporting::term::termcolor::WriteColor;
 use log::info;
-use spec_lang::env::GlobalEnv;
-use spec_lang::run_spec_lang_compiler;
+use spec_lang::{env::GlobalEnv, run_spec_lang_compiler};
 use std::fs;
 
 // TODO: remove pub below. Having it for now to supress warnings.

--- a/language/move-prover/src/main.rs
+++ b/language/move-prover/src/main.rs
@@ -5,8 +5,7 @@
 
 use codespan_reporting::term::termcolor::{ColorChoice, StandardStream};
 
-use move_prover::cli::Options;
-use move_prover::run_move_prover;
+use move_prover::{cli::Options, run_move_prover};
 use std::env;
 
 fn main() -> anyhow::Result<()> {

--- a/language/move-prover/src/spec_translator.rs
+++ b/language/move-prover/src/spec_translator.rs
@@ -5,10 +5,10 @@
 
 use std::cell::RefCell;
 
-use spec_lang::env::{
-    FieldId, FunctionEnv, Loc, ModuleEnv, ModuleId, NodeId, SpecFunId, StructEnv, StructId,
+use spec_lang::{
+    env::{FieldId, FunctionEnv, Loc, ModuleEnv, ModuleId, NodeId, SpecFunId, StructEnv, StructId},
+    ty::{PrimitiveType, Type},
 };
-use spec_lang::ty::{PrimitiveType, Type};
 
 use crate::{
     boogie_helpers::{
@@ -18,8 +18,10 @@ use crate::{
     code_writer::CodeWriter,
 };
 use itertools::Itertools;
-use spec_lang::ast::{ConditionKind, Exp, Invariant, LocalVarDecl, Operation, Value};
-use spec_lang::symbol::Symbol;
+use spec_lang::{
+    ast::{ConditionKind, Exp, Invariant, LocalVarDecl, Operation, Value},
+    symbol::Symbol,
+};
 
 pub struct SpecTranslator<'env> {
     /// The module in which context translation happens.

--- a/language/move-prover/test-utils/src/baseline_test.rs
+++ b/language/move-prover/test-utils/src/baseline_test.rs
@@ -5,11 +5,12 @@
 
 use crate::read_bool_env_var;
 use anyhow::{anyhow, Context, Result};
-use prettydiff::basic::DiffOp;
-use prettydiff::diff_lines;
-use std::fs::File;
-use std::io::{Read, Write};
-use std::path::Path;
+use prettydiff::{basic::DiffOp, diff_lines};
+use std::{
+    fs::File,
+    io::{Read, Write},
+    path::Path,
+};
 
 /// Verifies or updates baseline file for the given generated text.
 pub fn verify_or_update_baseline(baseline_file_name: &Path, text: &str) -> Result<()> {

--- a/language/move-prover/test-utils/src/lib.rs
+++ b/language/move-prover/test-utils/src/lib.rs
@@ -2,9 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use regex::Regex;
-use std::fs::File;
-use std::io::Read;
-use std::path::Path;
+use std::{fs::File, io::Read, path::Path};
 
 pub mod baseline_test;
 

--- a/language/move-prover/tests/testsuite.rs
+++ b/language/move-prover/tests/testsuite.rs
@@ -6,10 +6,8 @@ use std::path::Path;
 use codespan_reporting::term::termcolor::Buffer;
 
 use libra_temppath::TempPath;
-use move_prover::cli::Options;
-use move_prover::run_move_prover;
-use test_utils::baseline_test::verify_or_update_baseline;
-use test_utils::{extract_test_directives, read_env_var};
+use move_prover::{cli::Options, run_move_prover};
+use test_utils::{baseline_test::verify_or_update_baseline, extract_test_directives, read_env_var};
 
 fn test_runner(path: &Path) -> datatest_stable::Result<()> {
     let no_boogie = read_env_var("BOOGIE_EXE").is_empty() || read_env_var("Z3_EXE").is_empty();

--- a/language/move-vm/runtime/src/interpreter.rs
+++ b/language/move-vm/runtime/src/interpreter.rs
@@ -25,8 +25,8 @@ use libra_types::{
     vm_error::{StatusCode, StatusType, VMStatus},
 };
 use move_core_types::identifier::IdentStr;
-use move_vm_types::identifier::{create_access_path, resource_storage_key};
 use move_vm_types::{
+    identifier::{create_access_path, resource_storage_key},
     loaded_data::{struct_def::StructDef, types::Type},
     native_functions::dispatch::NativeFunction,
     type_context::TypeContext,

--- a/language/move-vm/runtime/src/runtime.rs
+++ b/language/move-vm/runtime/src/runtime.rs
@@ -1,12 +1,14 @@
 // Copyright (c) The Libra Core Contributors
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::loaded_data::function::FunctionRef;
 use crate::{
     code_cache::{module_cache::VMModuleCache, script_cache::ScriptCache},
     interpreter::Interpreter,
     interpreter_context::InterpreterContext,
-    loaded_data::{function::FunctionReference, loaded_module::LoadedModule},
+    loaded_data::{
+        function::{FunctionRef, FunctionReference},
+        loaded_module::LoadedModule,
+    },
 };
 use bytecode_verifier::VerifiedModule;
 use libra_logger::prelude::*;
@@ -16,8 +18,8 @@ use libra_types::{
 };
 use move_core_types::identifier::{IdentStr, Identifier};
 use move_vm_cache::Arena;
-use move_vm_types::identifier::resource_storage_key;
 use move_vm_types::{
+    identifier::resource_storage_key,
     loaded_data::{struct_def::StructDef, types::Type},
     type_context::TypeContext,
     values::Value,

--- a/language/stdlib/src/main.rs
+++ b/language/stdlib/src/main.rs
@@ -3,9 +3,11 @@
 
 #![forbid(unsafe_code)]
 
-use std::fs::File;
-use std::io::Write;
-use std::path::{Path, PathBuf};
+use std::{
+    fs::File,
+    io::Write,
+    path::{Path, PathBuf},
+};
 use stdlib::{
     build_stdlib, compile_script, filter_move_files, STAGED_EXTENSION, STAGED_OUTPUT_PATH,
     STAGED_STDLIB_NAME, TRANSACTION_SCRIPTS,

--- a/language/tools/cost-synthesis/src/global_state/account.rs
+++ b/language/tools/cost-synthesis/src/global_state/account.rs
@@ -9,8 +9,7 @@ use libra_types::{
 };
 use move_vm_types::{
     identifier::{create_access_path, resource_storage_key},
-    loaded_data::struct_def::StructDef,
-    loaded_data::types::Type,
+    loaded_data::{struct_def::StructDef, types::Type},
     values::{Struct, Value},
 };
 use rand::{

--- a/language/tools/cost-synthesis/src/global_state/inhabitor.rs
+++ b/language/tools/cost-synthesis/src/global_state/inhabitor.rs
@@ -9,7 +9,10 @@ use libra_types::{
 use move_core_types::identifier::Identifier;
 use move_vm_runtime::{loaded_data::loaded_module::LoadedModule, MoveVM};
 use move_vm_state::execution_context::SystemExecutionContext;
-use move_vm_types::{loaded_data::struct_def::StructDef, loaded_data::types::Type, values::*};
+use move_vm_types::{
+    loaded_data::{struct_def::StructDef, types::Type},
+    values::*,
+};
 use rand::{rngs::StdRng, Rng, SeedableRng};
 use std::collections::HashMap;
 use vm::{

--- a/language/tools/test-generation/src/lib.rs
+++ b/language/tools/test-generation/src/lib.rs
@@ -25,7 +25,8 @@ use libra_config::config::VMConfig;
 use libra_logger::{debug, error, info};
 use libra_state_view::StateView;
 use libra_types::{
-    account_address::AccountAddress, account_address::ADDRESS_LENGTH, byte_array::ByteArray,
+    account_address::{AccountAddress, ADDRESS_LENGTH},
+    byte_array::ByteArray,
     vm_error::StatusCode,
 };
 use libra_vm::LibraVM;

--- a/mempool/src/network.rs
+++ b/mempool/src/network.rs
@@ -5,8 +5,7 @@
 
 use crate::counters;
 use channel::{libra_channel, message_queues::QueueStyle};
-use libra_types::transaction::SignedTransaction;
-use libra_types::PeerId;
+use libra_types::{transaction::SignedTransaction, PeerId};
 use network::{
     error::NetworkError,
     peer_manager::{PeerManagerRequest, PeerManagerRequestSender},

--- a/network/src/protocols/wire/handshake/v1/bitvec.rs
+++ b/network/src/protocols/wire/handshake/v1/bitvec.rs
@@ -113,8 +113,7 @@ impl<'de> Deserialize<'de> for BitVec {
 mod test {
 
     use super::*;
-    use proptest::prelude::*;
-    use proptest::{arbitrary::any, collection::vec};
+    use proptest::{arbitrary::any, collection::vec, prelude::*};
 
     #[test]
     fn test_empty() {

--- a/testsuite/cluster-test/src/deployment.rs
+++ b/testsuite/cluster-test/src/deployment.rs
@@ -3,8 +3,7 @@
 
 #![forbid(unsafe_code)]
 
-use crate::instance::Instance;
-use crate::{aws::Aws, cluster::Cluster};
+use crate::{aws::Aws, cluster::Cluster, instance::Instance};
 use anyhow::{bail, format_err, Result};
 use libra_logger::{info, warn};
 use rusoto_core::RusotoError;

--- a/testsuite/tests/libratest/smoke_test.rs
+++ b/testsuite/tests/libratest/smoke_test.rs
@@ -2,8 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use cli::client_proxy::ClientProxy;
-use debug_interface::node_debug_service::parse_events;
-use debug_interface::{libra_trace, NodeDebugClient};
+use debug_interface::{libra_trace, node_debug_service::parse_events, NodeDebugClient};
 use libra_config::config::{NodeConfig, RoleType, VMPublishingOption};
 use libra_crypto::{ed25519::*, hash::CryptoHash, test_utils::KeyPair, SigningKey};
 use libra_json_rpc::views::{ScriptView, TransactionDataView};

--- a/types/src/account_config.rs
+++ b/types/src/account_config.rs
@@ -1,12 +1,11 @@
 // Copyright (c) The Libra Core Contributors
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::language_storage::ModuleId;
 use crate::{
     access_path::{AccessPath, Accesses},
     account_address::AccountAddress,
     event::EventHandle,
-    language_storage::StructTag,
+    language_storage::{ModuleId, StructTag},
 };
 use anyhow::Result;
 use move_core_types::identifier::{IdentStr, Identifier};

--- a/types/src/transaction/transaction_argument.rs
+++ b/types/src/transaction/transaction_argument.rs
@@ -1,7 +1,7 @@
 // Copyright (c) The Libra Core Contributors
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::{account_address::AccountAddress, account_address::ADDRESS_LENGTH};
+use crate::account_address::{AccountAddress, ADDRESS_LENGTH};
 use anyhow::Result;
 use serde::{Deserialize, Serialize};
 use std::{convert::TryFrom, fmt};

--- a/x/src/cargo.rs
+++ b/x/src/cargo.rs
@@ -24,6 +24,11 @@ impl Cargo {
         }
     }
 
+    pub fn all(&mut self) -> &mut Self {
+        self.inner.arg("--all");
+        self
+    }
+
     pub fn workspace(&mut self) -> &mut Self {
         self.inner.arg("--workspace");
         self

--- a/x/src/fmt.rs
+++ b/x/src/fmt.rs
@@ -1,0 +1,44 @@
+// Copyright (c) The Libra Core Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::{cargo::Cargo, config::Config, Result};
+use std::ffi::OsString;
+use structopt::StructOpt;
+
+#[derive(Debug, StructOpt)]
+pub struct Args {
+    #[structopt(long)]
+    /// Run in 'check' mode. Exits with 0 if input is
+    /// formatted correctly. Exits with 1 and prints a diff if
+    /// formatting is required.
+    check: bool,
+
+    #[structopt(long)]
+    /// Run check on all packages in the workspace
+    workspace: bool,
+
+    #[structopt(name = "ARGS", parse(from_os_str), last = true)]
+    /// Pass through args to rustfmt
+    args: Vec<OsString>,
+}
+
+pub fn run(args: Args, _config: Config) -> Result<()> {
+    // Hardcode that we want imports merged
+    let mut pass_through_args = vec!["--config".into(), "merge_imports=true".into()];
+
+    if args.check {
+        pass_through_args.push("--check".into());
+    }
+
+    pass_through_args.extend(args.args);
+
+    let mut cmd = Cargo::new("fmt");
+
+    if args.workspace {
+        // cargo fmt doesn't have a --workspace flag, instead it uses the
+        // old --all flag
+        cmd.all();
+    }
+
+    cmd.pass_through(&pass_through_args).run()
+}

--- a/x/src/main.rs
+++ b/x/src/main.rs
@@ -10,6 +10,7 @@ mod cargo;
 mod check;
 mod clippy;
 mod config;
+mod fmt;
 mod lint;
 mod test;
 mod utils;
@@ -33,6 +34,9 @@ enum Command {
     #[structopt(name = "clippy")]
     /// Run `cargo clippy`
     Clippy(clippy::Args),
+    #[structopt(name = "fmt")]
+    /// Run `cargo fmt`
+    Fmt(fmt::Args),
     #[structopt(name = "test")]
     /// Run tests
     Test(test::Args),
@@ -49,6 +53,7 @@ fn main() -> Result<()> {
         Command::Test(args) => test::run(args, config),
         Command::Check(args) => check::run(args, config),
         Command::Clippy(args) => clippy::run(args, config),
+        Command::Fmt(args) => fmt::run(args, config),
         Command::Bench(args) => bench::run(args, config),
         Command::Lint(args) => lint::run(args, config),
     }


### PR DESCRIPTION
    Introduce 'xfmt', a wrapper around 'cargo fmt' which works around the
    issue that the 'merge_imports' config of rustfmt isn't stable.
    
    If you place an unstable config in a rustfmt.toml config file and run
    using a stable version of rustfmt the config is ignored and you get the
    following:
    
        $ cargo fmt
        Warning: can't set `merge_imports = true`, unstable features are only available in nightly channel.
    
    But if you instead pass the config using the '--config' option rustfmt
    happily applies and uses the unstable config:
    
        $ cargo fmt -- --config merge_imports=true
    
    Since there are enough people on the project that would like to see
    imports merged the new 'xfmt' wrapper uses the abbove workaround to
    ensure that imports are merged when running 'cargo xfmt'.
    
    If you also want to have the following behavior with your favorite
    editor (assuming your editor lets you pass additional flags to rustfmt)
    you can simply add '--config merge_imports=true' to the list of options
    your editor passes rustfmt when formatting rust code. For example with
    vim and the rust.vim plugin you would just need to add the following to
    your vimrc to have imports merged when rust.vim is used to format your
    code:
    
        let g:rustfmt_options = '--config merge_imports=true'

Closes: #1587