### PR TITLE
[language][prover] Fixed a bug in joining `aborts_if` conditions

### DIFF
--- a/language/move-prover/src/spec_translator.rs
+++ b/language/move-prover/src/spec_translator.rs
@@ -211,7 +211,7 @@ impl<'env> SpecTranslator<'env> {
         if !aborts_if.is_empty() {
             self.writer.set_location(&aborts_if[0].loc);
             emit!(self.writer, "ensures ");
-            self.translate_seq(aborts_if.iter(), " && ", |c| {
+            self.translate_seq(aborts_if.iter(), " || ", |c| {
                 emit!(self.writer, "b#Boolean(old(");
                 self.translate_exp_parenthesised(&c.exp);
                 emit!(self.writer, "))")

--- a/language/move-prover/tests/sources/aborts-if.exp
+++ b/language/move-prover/tests/sources/aborts-if.exp
@@ -1,62 +1,77 @@
 Move prover returns: exiting with boogie verification errors
 error:  A postcondition might not hold on this return path.
 
-    ┌── tests/sources/aborts-if.move:16:9 ───
+    ┌── tests/sources/aborts-if.move:15:9 ───
     │
- 16 │         aborts_if x <= y;
+ 15 │         aborts_if x <= y;
     │         ^^^^^^^^^^^^^^^^^
     │
-    =     at tests/sources/aborts-if.move:12:5: abort2 (entry)
-    =     at tests/sources/aborts-if.move:12:5: abort2 (exit)
+    =     at tests/sources/aborts-if.move:12:5: abort02 (entry)
+    =     at tests/sources/aborts-if.move:12:5: abort02 (exit)
     =         x = <redacted>,
     =         y = <redacted>
 
 error:  A postcondition might not hold on this return path.
 
-    ┌── tests/sources/aborts-if.move:24:9 ───
+    ┌── tests/sources/aborts-if.move:38:9 ───
     │
- 24 │         aborts_if x <= y;
+ 38 │         aborts_if x <= y;
     │         ^^^^^^^^^^^^^^^^^
     │
-    =     at tests/sources/aborts-if.move:20:5: abort3 (entry)
-    =     at tests/sources/aborts-if.move:21:9: abort3
+    =     at tests/sources/aborts-if.move:34:5: abort05 (entry)
+    =     at tests/sources/aborts-if.move:35:9: abort05
     =         x = <redacted>,
     =         y = <redacted>
-    =     at tests/sources/aborts-if.move:20:5: abort3 (exit)
+    =     at tests/sources/aborts-if.move:34:5: abort05 (exit)
 
 error:  A postcondition might not hold on this return path.
 
-    ┌── tests/sources/aborts-if.move:32:9 ───
+    ┌── tests/sources/aborts-if.move:46:9 ───
     │
- 32 │         aborts_if x < y;
+ 46 │         aborts_if x < y;
     │         ^^^^^^^^^^^^^^^^
     │
-    =     at tests/sources/aborts-if.move:28:5: abort4 (entry)
-    =     at tests/sources/aborts-if.move:29:9: abort4
+    =     at tests/sources/aborts-if.move:42:5: abort06 (entry)
+    =     at tests/sources/aborts-if.move:43:9: abort06
     =         x = <redacted>,
     =         y = <redacted>
-    =     at tests/sources/aborts-if.move:28:5: abort4 (exit)
+    =     at tests/sources/aborts-if.move:42:5: abort06 (exit)
 
 error:  A postcondition might not hold on this return path.
 
-    ┌── tests/sources/aborts-if.move:44:9 ───
+    ┌── tests/sources/aborts-if.move:54:9 ───
     │
- 44 │         ensures x == y;
-    │         ^^^^^^^^^^^^^^^
+ 54 │         aborts_if x <= y;
+    │         ^^^^^^^^^^^^^^^^^
     │
-    =     at tests/sources/aborts-if.move:38:5: abort9 (entry)
-    =     at tests/sources/aborts-if.move:39:9: abort9
+    =     at tests/sources/aborts-if.move:50:5: abort07 (entry)
+    =     at tests/sources/aborts-if.move:51:9: abort07
     =         x = <redacted>,
     =         y = <redacted>
-    =     at tests/sources/aborts-if.move:38:5: abort9 (exit)
+    =     at tests/sources/aborts-if.move:50:5: abort07 (exit)
 
 error:  A postcondition might not hold on this return path.
 
-    ┌── tests/sources/aborts-if.move:42:9 ───
+    ┌── tests/sources/aborts-if.move:71:9 ───
     │
- 42 │         aborts_if x > y;
+ 71 │         aborts_if x < y;
     │         ^^^^^^^^^^^^^^^^
     │
-    =     at tests/sources/aborts-if.move:38:5: abort9 (entry)
-    =     at tests/sources/aborts-if.move:39:9: abort9
-    =     at tests/sources/aborts-if.move:38:5: abort9 (exit)
+    =     at tests/sources/aborts-if.move:67:5: abort09 (entry)
+    =     at tests/sources/aborts-if.move:68:9: abort09
+    =         x = <redacted>,
+    =         y = <redacted>
+    =     at tests/sources/aborts-if.move:67:5: abort09 (exit)
+
+error:  A postcondition might not hold on this return path.
+
+    ┌── tests/sources/aborts-if.move:80:9 ───
+    │
+ 80 │         aborts_if x < y;
+    │         ^^^^^^^^^^^^^^^^
+    │
+    =     at tests/sources/aborts-if.move:76:5: abort10 (entry)
+    =     at tests/sources/aborts-if.move:77:9: abort10
+    =         x = <redacted>,
+    =         y = <redacted>
+    =     at tests/sources/aborts-if.move:76:5: abort10 (exit)

--- a/language/move-prover/tests/sources/aborts-if.move
+++ b/language/move-prover/tests/sources/aborts-if.move
@@ -1,46 +1,93 @@
 module AbortsIf {
 
     // succeeds. Very basic test.
-    fun abort1(x: u64, y: u64) {
-        if (!(x > y)) abort 1;
+    fun abort01(x: u64, y: u64) {
+        if (!(x > y)) abort 1
     }
-    spec fun abort1 {
+    spec fun abort01 {
         aborts_if x <= y;
     }
 
-    // fails, because it does not abort when x <= y
-    fun abort2(x: u64, y: u64)
-    {
+    // fails, because it does not abort when x <= y.
+    fun abort02(x: u64, y: u64) {
     }
-    spec fun abort2 {
+    spec fun abort02 {
         aborts_if x <= y;
     }
 
-    // fails, because it aborts when not x<=y
-    fun abort3(x: u64, y: u64) {
-        if (x > y) abort 2;
+    // succeeds, because the specification claims no 'aborts_if' condition.
+    fun abort03(x: u64, y: u64) {
+        abort 1
     }
-    spec fun abort3 {
+    spec fun abort03 {
+    }
+
+    // succeeds.
+    fun abort04(x: u64, y: u64) {
+        abort 1
+    }
+    spec fun abort04 {
+        aborts_if true;
+    }
+
+    // fails, because it does not abort when x <= y.
+    fun abort05(x: u64, y: u64) {
+        if (x > y) abort 1
+    }
+    spec fun abort05 {
         aborts_if x <= y;
     }
 
-    // fails. Violates implicit succeeds_if x >= y when x == y
-    fun abort4(x: u64, y: u64) {
-        if (!(x > y)) abort 1;
+    // fails, because it also aborts when x == y which condition has not been specified.
+    fun abort06(x: u64, y: u64) {
+        if (x <= y) abort 1
     }
-    spec fun abort4 {
+    spec fun abort06 {
         aborts_if x < y;
     }
 
-
-    // fails. It doesn't abort when x > y
-    // Boogie also (correctly) complains because it doesn't SUCCEED on x==y.
-    fun abort9(x: u64, y: u64) {
-        if (!(x > y)) abort 1;
+    // fails, because it does not abort when x == y.
+    fun abort07(x: u64, y: u64) {
+        if (x < y) abort 1
     }
-    spec fun abort9 {
+    spec fun abort07 {
+        aborts_if x <= y;
+    }
+
+    // succeeds. Multiple 'aborts_if' conditions are 'or'ed.
+    fun abort08(x: u64, y: u64) {
+        if (x <= y) abort 1
+    }
+    spec fun abort08 {
+        aborts_if x < y;
+        aborts_if x == y;
+    }
+
+    // fails, because it does not abort when x == y.
+    fun abort09(x: u64, y: u64) {
+        if (x < y) abort 1
+    }
+    spec fun abort09 {
+        aborts_if x < y;
+        aborts_if x == y;
+    }
+
+    // fails, because it also abort when x > y which condition has not been specified.
+    fun abort10(x: u64, y: u64) {
+        abort 1
+    }
+    spec fun abort10 {
+        aborts_if x < y;
+        aborts_if x == y;
+    }
+
+    // succeeds. Aborts all the time.
+    fun abort11(x: u64, y: u64) {
+        abort 1
+    }
+    spec fun abort11 {
+        aborts_if x < y;
+        aborts_if x == y;
         aborts_if x > y;
-        aborts_if x < y;
-        ensures x == y;
     }
 }


### PR DESCRIPTION
- Modified `spec_translator.rs` to correctly join the `aborts_if` conditions using `||` instead of `&&`
- Added tests for multiple `aborts_if` statements

## Motivation

To fix a bug in spec_translator regarding handling multiple `aborts_if` statements

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?

Yes 

## Test Plan

cargo test

## Related PRs

