### PR TITLE
[network] Migrate to using ProtocolId enum from new wire spec

### DIFF
--- a/consensus/src/chained_bft/network_interface.rs
+++ b/consensus/src/chained_bft/network_interface.rs
@@ -152,7 +152,7 @@ impl<T: Payload> ConsensusNetworkSender<T> {
     ) -> Result<ConsensusMsg<T>, RpcError> {
         let protocol = ProtocolId::from_static(CONSENSUS_RPC_PROTOCOL);
         self.peer_mgr_reqs_tx
-            .unary_rpc(recipient, protocol, message, timeout)
+            .send_rpc(recipient, protocol, message, timeout)
             .await
     }
 

--- a/consensus/src/chained_bft/network_interface.rs
+++ b/consensus/src/chained_bft/network_interface.rs
@@ -90,7 +90,7 @@ pub struct ConsensusNetworkSender<T> {
 pub fn add_to_network<T: Payload>(
     network: &mut NetworkBuilder,
 ) -> (ConsensusNetworkSender<T>, ConsensusNetworkEvents<T>) {
-    let (network_sender, network_receiver, control_notifs_rx) = network.add_protocol_handler(
+    let (network_sender, network_receiver, connection_notifs_rx) = network.add_protocol_handler(
         vec![ProtocolId::from_static(CONSENSUS_RPC_PROTOCOL)],
         vec![ProtocolId::from_static(CONSENSUS_DIRECT_SEND_PROTOCOL)],
         QueueStyle::LIFO,
@@ -103,7 +103,7 @@ pub fn add_to_network<T: Payload>(
                 .conn_mgr_reqs_tx()
                 .expect("ConnecitivtyManager not enabled"),
         ),
-        ConsensusNetworkEvents::new(network_receiver, control_notifs_rx),
+        ConsensusNetworkEvents::new(network_receiver, connection_notifs_rx),
     )
 }
 

--- a/consensus/src/chained_bft/network_tests.rs
+++ b/consensus/src/chained_bft/network_tests.rs
@@ -3,10 +3,7 @@
 
 use crate::chained_bft::{
     network::{NetworkReceivers, NetworkSender},
-    network_interface::{
-        ConsensusMsg, ConsensusNetworkEvents, ConsensusNetworkSender,
-        CONSENSUS_DIRECT_SEND_PROTOCOL, CONSENSUS_RPC_PROTOCOL,
-    },
+    network_interface::{ConsensusMsg, ConsensusNetworkEvents, ConsensusNetworkSender},
     test_utils::{self, consensus_runtime, placeholder_ledger_info},
 };
 use channel::{self, libra_channel, message_queues::QueueStyle};
@@ -135,7 +132,7 @@ impl NetworkPlayground {
 
                     node_consensus_tx
                         .push(
-                            (src, ProtocolId::from_static(CONSENSUS_RPC_PROTOCOL)),
+                            (src, ProtocolId::ConsensusRpc),
                             PeerManagerNotification::RecvRpc(src, inbound_req),
                         )
                         .unwrap();
@@ -228,10 +225,7 @@ impl NetworkPlayground {
         };
 
         node_consensus_tx
-            .push(
-                (src, ProtocolId::from_static(CONSENSUS_DIRECT_SEND_PROTOCOL)),
-                msg_notif,
-            )
+            .push((src, ProtocolId::ConsensusDirectSend), msg_notif)
             .unwrap();
         msg_copy
     }

--- a/mempool/src/core_mempool/unit_tests/shared_mempool_test.rs
+++ b/mempool/src/core_mempool/unit_tests/shared_mempool_test.rs
@@ -7,9 +7,7 @@ use crate::{
         CoreMempool, TimelineState,
     },
     mocks::MockSharedMempool,
-    network::{
-        MempoolNetworkEvents, MempoolNetworkSender, MempoolSyncMsg, MEMPOOL_DIRECT_SEND_PROTOCOL,
-    },
+    network::{MempoolNetworkEvents, MempoolNetworkSender, MempoolSyncMsg},
     shared_mempool::{
         start_shared_mempool, ConsensusRequest, SharedMempoolNotification, SyncEvent,
     },
@@ -202,7 +200,7 @@ impl SharedMempoolNetwork {
                 let receiver_network_notif_tx = self.network_notifs_txs.get_mut(&peer_id).unwrap();
                 receiver_network_notif_tx
                     .push(
-                        (*peer, ProtocolId::from_static(MEMPOOL_DIRECT_SEND_PROTOCOL)),
+                        (*peer, ProtocolId::MempoolDirectSend),
                         PeerManagerNotification::RecvMessage(*peer, msg),
                     )
                     .unwrap();
@@ -240,7 +238,7 @@ impl SharedMempoolNetwork {
                 let receiver_network_notif_tx = self.network_notifs_txs.get_mut(&peer_id).unwrap();
                 receiver_network_notif_tx
                     .push(
-                        (*peer, ProtocolId::from_static(MEMPOOL_DIRECT_SEND_PROTOCOL)),
+                        (*peer, ProtocolId::MempoolDirectSend),
                         PeerManagerNotification::RecvMessage(*peer, msg),
                     )
                     .unwrap();

--- a/mempool/src/network.rs
+++ b/mempool/src/network.rs
@@ -65,7 +65,7 @@ pub fn add_to_network(
     let (sender, receiver, connection_reqs_tx, connection_notifs_rx) = network
         .add_protocol_handler(
             vec![],
-            vec![ProtocolId::from_static(MEMPOOL_DIRECT_SEND_PROTOCOL)],
+            vec![ProtocolId::MempoolDirectSend],
             QueueStyle::LIFO,
             Some(&counters::PENDING_MEMPOOL_NETWORK_EVENTS),
         );
@@ -93,7 +93,7 @@ impl MempoolNetworkSender {
         recipient: PeerId,
         message: MempoolSyncMsg,
     ) -> Result<(), NetworkError> {
-        let protocol = ProtocolId::from_static(MEMPOOL_DIRECT_SEND_PROTOCOL);
+        let protocol = ProtocolId::MempoolDirectSend;
         self.inner.send_to(recipient, protocol, message)
     }
 }

--- a/mempool/src/network.rs
+++ b/mempool/src/network.rs
@@ -62,7 +62,7 @@ pub struct MempoolNetworkSender {
 pub fn add_to_network(
     network: &mut NetworkBuilder,
 ) -> (MempoolNetworkSender, MempoolNetworkEvents) {
-    let (sender, receiver, control_notifs_rx) = network.add_protocol_handler(
+    let (sender, receiver, connection_notifs_rx) = network.add_protocol_handler(
         vec![],
         vec![ProtocolId::from_static(MEMPOOL_DIRECT_SEND_PROTOCOL)],
         QueueStyle::LIFO,
@@ -70,7 +70,7 @@ pub fn add_to_network(
     );
     (
         MempoolNetworkSender::new(sender),
-        MempoolNetworkEvents::new(receiver, control_notifs_rx),
+        MempoolNetworkEvents::new(receiver, connection_notifs_rx),
     )
 }
 

--- a/network/src/connectivity_manager/mod.rs
+++ b/network/src/connectivity_manager/mod.rs
@@ -57,7 +57,7 @@ pub struct ConnectivityManager<TTicker, TBackoff> {
     /// Channel to send requests to PeerManager.
     peer_mgr_reqs_tx: PeerManagerRequestSender,
     /// Channel to receive notifications from PeerManager.
-    control_notifs_rx: conn_status_channel::Receiver,
+    connection_notifs_rx: conn_status_channel::Receiver,
     /// Channel over which we receive requests from other actors.
     requests_rx: channel::Receiver<ConnectivityRequest>,
     /// Peers queued to be dialed, potentially with some delay. The dial can be cancelled by
@@ -116,7 +116,7 @@ where
         seed_peers: HashMap<PeerId, Vec<Multiaddr>>,
         ticker: TTicker,
         peer_mgr_reqs_tx: PeerManagerRequestSender,
-        control_notifs_rx: conn_status_channel::Receiver,
+        connection_notifs_rx: conn_status_channel::Receiver,
         requests_rx: channel::Receiver<ConnectivityRequest>,
         backoff_strategy: TBackoff,
         max_delay_ms: u64,
@@ -136,7 +136,7 @@ where
             peer_addresses,
             ticker,
             peer_mgr_reqs_tx,
-            control_notifs_rx,
+            connection_notifs_rx,
             requests_rx,
             dial_queue: HashMap::new(),
             dial_states: HashMap::new(),
@@ -172,7 +172,7 @@ where
                     trace!("Event Id: {}, type: ConnectivityRequest, req: {:?}", self.event_id, req);
                     self.handle_request(req);
                 },
-                notif = self.control_notifs_rx.select_next_some() => {
+                notif = self.connection_notifs_rx.select_next_some() => {
                     trace!("Event Id: {}, type: peer_manager::ConnectionStatusNotification, notif: {:?}", self.event_id, notif);
                     self.handle_control_notification(notif);
                 },

--- a/network/src/lib.rs
+++ b/network/src/lib.rs
@@ -26,7 +26,6 @@ mod peer;
 mod sink;
 mod transport;
 
-/// Type for unique identifier associated with each network protocol
-pub type ProtocolId = bytes::Bytes;
 pub type DisconnectReason = peer::DisconnectReason;
 pub type ConnectivityRequest = connectivity_manager::ConnectivityRequest;
+pub type ProtocolId = protocols::wire::messaging::v1::ProtocolId;

--- a/network/src/peer/mod.rs
+++ b/network/src/peer/mod.rs
@@ -174,7 +174,7 @@ where
     ) {
         match negotiated_subststream {
             Ok(negotiated_substream) => {
-                let protocol = negotiated_substream.protocol.clone();
+                let protocol = negotiated_substream.protocol;
                 let event =
                     PeerNotification::NewSubstream(self.identity.peer_id(), negotiated_substream);
                 if self.rpc_protocols.contains(&protocol) {
@@ -233,7 +233,7 @@ where
         control: TMuxer::Control,
         channel: oneshot::Sender<Result<TMuxer::Substream, PeerManagerError>>,
     ) -> BoxFuture<'static, ()> {
-        let optimistic_negotiation = self.identity.is_protocol_supported(&protocol);
+        let optimistic_negotiation = self.identity.is_protocol_supported(protocol);
         Self::negotiate_outbound_substream(
             self.identity.peer_id(),
             control,

--- a/network/src/peer/mod.rs
+++ b/network/src/peer/mod.rs
@@ -257,14 +257,14 @@ where
                 // substream even though we know for a fact that the Identity struct of this Peer
                 // doesn't include the protocol we're interested in.
                 if optimistic_negotiation {
-                    negotiate_outbound_select(substream, &protocol).await
+                    negotiate_outbound_select(substream, lcs::to_bytes(&protocol).unwrap()).await
                 } else {
                     warn!(
                         "Negotiating outbound substream interactively: Protocol({:?}) PeerId({})",
                         protocol,
                         peer_id.short_str()
                     );
-                    negotiate_outbound_interactive(substream, [&protocol])
+                    negotiate_outbound_interactive(substream, &[lcs::to_bytes(&protocol).unwrap()])
                         .await
                         .map(|(substream, _protocol)| substream)
                 }
@@ -300,9 +300,16 @@ where
         substream: TMuxer::Substream,
         own_supported_protocols: Vec<ProtocolId>,
     ) -> Result<NegotiatedSubstream<TMuxer::Substream>, PeerManagerError> {
-        let (substream, protocol) = negotiate_inbound(substream, own_supported_protocols).await?;
+        let (substream, protocol) = negotiate_inbound(
+            substream,
+            own_supported_protocols
+                .into_iter()
+                .map(|p| lcs::to_bytes(&p).unwrap())
+                .collect::<Vec<_>>(),
+        )
+        .await?;
         Ok(NegotiatedSubstream {
-            protocol,
+            protocol: lcs::from_bytes(&protocol).unwrap(),
             substream,
         })
     }

--- a/network/src/peer_manager/mod.rs
+++ b/network/src/peer_manager/mod.rs
@@ -178,7 +178,7 @@ impl PeerManagerRequestSender {
     }
 
     /// Sends a unary RPC to a remote peer and waits to either receive a response or times out.
-    pub async fn unary_rpc(
+    pub async fn send_rpc(
         &mut self,
         peer_id: PeerId,
         protocol: ProtocolId,

--- a/network/src/peer_manager/tests.rs
+++ b/network/src/peer_manager/tests.rs
@@ -183,7 +183,13 @@ async fn check_correct_connection_is_live(
     }
 
     assert!(open_hello_substream(&mut dropped_connection).await.is_err());
-    assert!(open_hello_substream(&mut live_connection).await.is_ok());
+    if let Err(err) = open_hello_substream(&mut live_connection).await {
+        assert!(
+            false,
+            "Failed to open substream on connection that should be live: {:?}",
+            err
+        );
+    }
 
     live_connection.close().await.unwrap();
     assert_peer_disconnected_event(
@@ -381,6 +387,7 @@ fn peer_manager_simultaneous_dial_outbound_inbound_remote_id_larger() {
 
 #[test]
 fn peer_manager_simultaneous_dial_outbound_inbound_own_id_larger() {
+    ::libra_logger::Logger::new().environment_only(true).init();
     let mut runtime = ::tokio::runtime::Runtime::new().unwrap();
 
     // Create a list of ordered PeerIds so we can ensure how PeerIds will be compared.
@@ -427,6 +434,7 @@ fn peer_manager_simultaneous_dial_outbound_inbound_own_id_larger() {
 
 #[test]
 fn peer_manager_simultaneous_dial_two_outbound() {
+    ::libra_logger::Logger::new().environment_only(true).init();
     let mut runtime = ::tokio::runtime::Runtime::new().unwrap();
 
     // Create a list of ordered PeerIds so we can ensure how PeerIds will be compared.
@@ -465,7 +473,6 @@ fn peer_manager_simultaneous_dial_two_outbound() {
         )
         .await;
     };
-
     runtime.block_on(test);
 }
 
@@ -544,5 +551,6 @@ fn test_dial_disconnect() {
         // Sender of disconnect request should receive acknowledgement once connection is closed.
         disconnect_resp_rx.await.unwrap().unwrap();
     };
+
     runtime.block_on(test);
 }

--- a/network/src/protocols/direct_send/mod.rs
+++ b/network/src/protocols/direct_send/mod.rs
@@ -214,7 +214,7 @@ where
                         .with_label_values(&["received"])
                         .observe(data.len() as f64);
                     let notif = DirectSendNotification::RecvMessage(Message {
-                        protocol: protocol.clone(),
+                        protocol,
                         mdata: data.freeze(),
                     });
                     if let Err(err) = ds_notifs_tx.send(notif).await {
@@ -246,16 +246,13 @@ where
         protocol: ProtocolId,
     ) -> Result<channel::Sender<Bytes>, NetworkError> {
         let peer_id_str = peer_handle.peer_id().short_str();
-        let raw_substream = peer_handle
-            .open_substream(protocol.clone())
-            .await
-            .map_err(|e| {
-                warn!(
-                    "Failed to open substream with peer {} for protocol {:?}",
-                    peer_id_str, protocol
-                );
-                e
-            })?;
+        let raw_substream = peer_handle.open_substream(protocol).await.map_err(|e| {
+            warn!(
+                "Failed to open substream with peer {} for protocol {:?}",
+                peer_id_str, protocol
+            );
+            e
+        })?;
         // Create a channel for the ProtocolId.
         // TODO: Add protocol dimension to metric.
         let (msg_tx, msg_rx) = channel::new::<Bytes>(
@@ -312,14 +309,14 @@ where
     // If the channel is full, simply drop the message on the floor;
     // If the channel is disconnected, remove the message queue from the collection.
     async fn try_send_msg(&mut self, msg: Message) -> Result<(), NetworkError> {
-        let protocol = msg.protocol.clone();
-        let substream_queue_tx = match self.message_queues.entry(protocol.clone()) {
+        let protocol = msg.protocol;
+        let substream_queue_tx = match self.message_queues.entry(protocol) {
             Entry::Occupied(entry) => entry.into_mut(),
             Entry::Vacant(entry) => {
                 let msg_tx = Self::start_message_queue_handler(
                     self.executor.clone(),
                     self.peer_handle.clone(),
-                    protocol.clone(),
+                    protocol,
                 )
                 .await?;
                 entry.insert(msg_tx)

--- a/network/src/protocols/discovery/mod.rs
+++ b/network/src/protocols/discovery/mod.rs
@@ -96,7 +96,7 @@ pub struct DiscoveryNetworkSender {
 pub fn add_to_network(
     network: &mut NetworkBuilder,
 ) -> (DiscoveryNetworkSender, DiscoveryNetworkEvents) {
-    let (sender, receiver, control_notifs_rx) = network.add_protocol_handler(
+    let (sender, receiver, connection_notifs_rx) = network.add_protocol_handler(
         vec![],
         vec![ProtocolId::from_static(DISCOVERY_DIRECT_SEND_PROTOCOL)],
         QueueStyle::LIFO,
@@ -104,7 +104,7 @@ pub fn add_to_network(
     );
     (
         DiscoveryNetworkSender::new(sender),
-        DiscoveryNetworkEvents::new(receiver, control_notifs_rx),
+        DiscoveryNetworkEvents::new(receiver, connection_notifs_rx),
     )
 }
 

--- a/network/src/protocols/discovery/mod.rs
+++ b/network/src/protocols/discovery/mod.rs
@@ -68,8 +68,6 @@ use std::{
 #[cfg(test)]
 mod test;
 
-pub const DISCOVERY_DIRECT_SEND_PROTOCOL: &[u8] = b"/libra/direct-send/0.1.0/discovery/0.1.0";
-
 /// The interface from Network to Discovery module.
 ///
 /// `DiscoveryNetworkEvents` is a `Stream` of `PeerManagerNotification` where the
@@ -99,7 +97,7 @@ pub fn add_to_network(
     let (sender, receiver, connection_reqs_tx, connection_notifs_rx) = network
         .add_protocol_handler(
             vec![],
-            vec![ProtocolId::from_static(DISCOVERY_DIRECT_SEND_PROTOCOL)],
+            vec![ProtocolId::DiscoveryDirectSend],
             QueueStyle::LIFO,
             Some(&counters::PENDING_DISCOVERY_NETWORK_EVENTS),
         );
@@ -122,11 +120,8 @@ impl DiscoveryNetworkSender {
 
     /// Send a DiscoveryMsg to a peer.
     pub fn send_to(&mut self, peer: PeerId, msg: DiscoveryMsg) -> Result<(), NetworkError> {
-        self.inner.send_to(
-            peer,
-            ProtocolId::from_static(DISCOVERY_DIRECT_SEND_PROTOCOL),
-            msg,
-        )
+        self.inner
+            .send_to(peer, ProtocolId::DiscoveryDirectSend, msg)
     }
 }
 

--- a/network/src/protocols/discovery/mod.rs
+++ b/network/src/protocols/discovery/mod.rs
@@ -34,13 +34,13 @@ use crate::{
     connectivity_manager::ConnectivityRequest,
     counters,
     error::{NetworkError, NetworkErrorKind},
-    peer_manager::{PeerManagerRequest, PeerManagerRequestSender},
+    peer_manager::{ConnectionRequestSender, PeerManagerRequestSender},
     protocols::network::{Event, NetworkEvents, NetworkSender},
     validator_network::network_builder::NetworkBuilder,
     NetworkPublicKeys, ProtocolId,
 };
 use bytes::Bytes;
-use channel::{libra_channel, message_queues::QueueStyle};
+use channel::message_queues::QueueStyle;
 use futures::{
     sink::SinkExt,
     stream::{FusedStream, Stream, StreamExt},
@@ -96,23 +96,27 @@ pub struct DiscoveryNetworkSender {
 pub fn add_to_network(
     network: &mut NetworkBuilder,
 ) -> (DiscoveryNetworkSender, DiscoveryNetworkEvents) {
-    let (sender, receiver, connection_notifs_rx) = network.add_protocol_handler(
-        vec![],
-        vec![ProtocolId::from_static(DISCOVERY_DIRECT_SEND_PROTOCOL)],
-        QueueStyle::LIFO,
-        Some(&counters::PENDING_DISCOVERY_NETWORK_EVENTS),
-    );
+    let (sender, receiver, connection_reqs_tx, connection_notifs_rx) = network
+        .add_protocol_handler(
+            vec![],
+            vec![ProtocolId::from_static(DISCOVERY_DIRECT_SEND_PROTOCOL)],
+            QueueStyle::LIFO,
+            Some(&counters::PENDING_DISCOVERY_NETWORK_EVENTS),
+        );
     (
-        DiscoveryNetworkSender::new(sender),
+        DiscoveryNetworkSender::new(sender, connection_reqs_tx),
         DiscoveryNetworkEvents::new(receiver, connection_notifs_rx),
     )
 }
 
 impl DiscoveryNetworkSender {
     /// Create a new Discovery sender
-    pub fn new(inner: libra_channel::Sender<(PeerId, ProtocolId), PeerManagerRequest>) -> Self {
+    pub fn new(
+        peer_mgr_reqs_tx: PeerManagerRequestSender,
+        connection_reqs_tx: ConnectionRequestSender,
+    ) -> Self {
         Self {
-            inner: NetworkSender::new(PeerManagerRequestSender::new(inner)),
+            inner: NetworkSender::new(peer_mgr_reqs_tx, connection_reqs_tx),
         }
     }
 

--- a/network/src/protocols/discovery/test.rs
+++ b/network/src/protocols/discovery/test.rs
@@ -29,13 +29,13 @@ fn gen_peer_info() -> PeerInfo {
 
 fn get_raw_message(msg: DiscoveryMsg) -> Message {
     Message {
-        protocol: ProtocolId::from_static(DISCOVERY_DIRECT_SEND_PROTOCOL),
+        protocol: ProtocolId::DiscoveryDirectSend,
         mdata: lcs::to_bytes(&msg).unwrap().into(),
     }
 }
 
 fn parse_raw_message(msg: Message) -> Result<DiscoveryMsg, NetworkError> {
-    assert_eq!(msg.protocol, DISCOVERY_DIRECT_SEND_PROTOCOL);
+    assert_eq!(msg.protocol, ProtocolId::DiscoveryDirectSend);
     let msg: DiscoveryMsg = lcs::from_bytes(&msg.mdata)
         .map_err(|err| anyhow!(err).context(NetworkErrorKind::ParsingError))?;
     Ok(msg)
@@ -170,10 +170,7 @@ fn inbound() {
         let msg = DiscoveryMsg {
             notes: vec![other_note],
         };
-        let msg_key = (
-            other_peer_id,
-            ProtocolId::from_static(DISCOVERY_DIRECT_SEND_PROTOCOL),
-        );
+        let msg_key = (other_peer_id, ProtocolId::DiscoveryDirectSend);
         let (delivered_tx, delivered_rx) = oneshot::channel();
         network_notifs_tx
             .push_with_feedback(
@@ -357,10 +354,7 @@ fn old_note_higher_epoch() {
         let msg = DiscoveryMsg {
             notes: vec![old_note],
         };
-        let msg_key = (
-            other_peer_id,
-            ProtocolId::from_static(DISCOVERY_DIRECT_SEND_PROTOCOL),
-        );
+        let msg_key = (other_peer_id, ProtocolId::DiscoveryDirectSend);
         let (delivered_tx, delivered_rx) = oneshot::channel();
         network_notifs_tx
             .push_with_feedback(
@@ -446,10 +440,7 @@ fn old_note_max_epoch() {
         let msg = DiscoveryMsg {
             notes: vec![old_note],
         };
-        let msg_key = (
-            other_peer_id,
-            ProtocolId::from_static(DISCOVERY_DIRECT_SEND_PROTOCOL),
-        );
+        let msg_key = (other_peer_id, ProtocolId::DiscoveryDirectSend);
         let (delivered_tx, delivered_rx) = oneshot::channel();
         network_notifs_tx
             .push_with_feedback(

--- a/network/src/protocols/health_checker/mod.rs
+++ b/network/src/protocols/health_checker/mod.rs
@@ -44,9 +44,6 @@ use std::{collections::HashMap, time::Duration};
 #[cfg(test)]
 mod test;
 
-/// Protocol id for HealthChecker RPC calls
-pub const HEALTH_CHECKER_RPC_PROTOCOL: &[u8] = b"/libra/rpc/0.1.0/health-checker/0.1.0";
-
 /// The interface from Network to HealthChecker layer.
 ///
 /// `HealthCheckerNetworkEvents` is a `Stream` of `PeerManagerNotification` where the
@@ -73,7 +70,7 @@ pub fn add_to_network(
 ) -> (HealthCheckerNetworkSender, HealthCheckerNetworkEvents) {
     let (sender, receiver, connection_reqs_tx, connection_notifs_rx) = network
         .add_protocol_handler(
-            vec![ProtocolId::from_static(HEALTH_CHECKER_RPC_PROTOCOL)],
+            vec![ProtocolId::HealthCheckerRpc],
             vec![],
             QueueStyle::LIFO,
             Some(&counters::PENDING_HEALTH_CHECKER_NETWORK_EVENTS),
@@ -105,7 +102,7 @@ impl HealthCheckerNetworkSender {
         req_msg: HealthCheckerMsg,
         timeout: Duration,
     ) -> Result<HealthCheckerMsg, RpcError> {
-        let protocol = ProtocolId::from_static(HEALTH_CHECKER_RPC_PROTOCOL);
+        let protocol = ProtocolId::HealthCheckerRpc;
         self.inner
             .send_rpc(recipient, protocol, req_msg, timeout)
             .await

--- a/network/src/protocols/health_checker/mod.rs
+++ b/network/src/protocols/health_checker/mod.rs
@@ -103,7 +103,7 @@ impl HealthCheckerNetworkSender {
     ) -> Result<HealthCheckerMsg, RpcError> {
         let protocol = ProtocolId::from_static(HEALTH_CHECKER_RPC_PROTOCOL);
         self.inner
-            .unary_rpc(recipient, protocol, req_msg, timeout)
+            .send_rpc(recipient, protocol, req_msg, timeout)
             .await
     }
 

--- a/network/src/protocols/health_checker/mod.rs
+++ b/network/src/protocols/health_checker/mod.rs
@@ -71,7 +71,7 @@ pub struct HealthCheckerNetworkSender {
 pub fn add_to_network(
     network: &mut NetworkBuilder,
 ) -> (HealthCheckerNetworkSender, HealthCheckerNetworkEvents) {
-    let (sender, receiver, control_notifs_rx) = network.add_protocol_handler(
+    let (sender, receiver, connection_notifs_rx) = network.add_protocol_handler(
         vec![ProtocolId::from_static(HEALTH_CHECKER_RPC_PROTOCOL)],
         vec![],
         QueueStyle::LIFO,
@@ -79,7 +79,7 @@ pub fn add_to_network(
     );
     (
         HealthCheckerNetworkSender::new(sender),
-        HealthCheckerNetworkEvents::new(receiver, control_notifs_rx),
+        HealthCheckerNetworkEvents::new(receiver, connection_notifs_rx),
     )
 }
 

--- a/network/src/protocols/health_checker/test.rs
+++ b/network/src/protocols/health_checker/test.rs
@@ -85,10 +85,7 @@ async fn expect_ping(
     let req_data = rpc_req.data;
     let res_tx = rpc_req.res_tx;
 
-    assert_eq!(
-        protocol,
-        ProtocolId::from_static(HEALTH_CHECKER_RPC_PROTOCOL)
-    );
+    assert_eq!(protocol, ProtocolId::HealthCheckerRpc,);
 
     match lcs::from_bytes(&req_data).unwrap() {
         HealthCheckerMsg::Ping(ping) => (ping, res_tx),
@@ -125,7 +122,7 @@ async fn send_inbound_ping(
     ping: u32,
     network_notifs_tx: &mut libra_channel::Sender<(PeerId, ProtocolId), PeerManagerNotification>,
 ) -> oneshot::Receiver<Result<Bytes, RpcError>> {
-    let protocol = ProtocolId::from_static(HEALTH_CHECKER_RPC_PROTOCOL);
+    let protocol = ProtocolId::HealthCheckerRpc;
     let data = lcs::to_bytes(&HealthCheckerMsg::Ping(Ping(ping)))
         .unwrap()
         .into();
@@ -135,10 +132,7 @@ async fn send_inbound_ping(
         data,
         res_tx,
     };
-    let key = (
-        peer_id,
-        ProtocolId::from_static(HEALTH_CHECKER_RPC_PROTOCOL),
-    );
+    let key = (peer_id, ProtocolId::HealthCheckerRpc);
     let (delivered_tx, delivered_rx) = oneshot::channel();
     network_notifs_tx
         .push_with_feedback(

--- a/network/src/protocols/identity.rs
+++ b/network/src/protocols/identity.rs
@@ -111,17 +111,13 @@ mod tests {
         let server_identity = Identity::new(
             PeerId::random(),
             vec![
-                ProtocolId::from_static(b"/proto/1.0.0"),
-                ProtocolId::from_static(b"/proto/2.0.0"),
+                ProtocolId::ConsensusDirectSend,
+                ProtocolId::MempoolDirectSend,
             ],
         );
         let client_identity = Identity::new(
             PeerId::random(),
-            vec![
-                ProtocolId::from_static(b"/proto/1.0.0"),
-                ProtocolId::from_static(b"/proto/2.0.0"),
-                ProtocolId::from_static(b"/proto/3.0.0"),
-            ],
+            vec![ProtocolId::ConsensusRpc, ProtocolId::ConsensusDirectSend],
         );
         let server_identity_config = server_identity.clone();
         let client_identity_config = client_identity.clone();

--- a/network/src/protocols/identity.rs
+++ b/network/src/protocols/identity.rs
@@ -38,10 +38,10 @@ impl Identity {
         self.peer_id
     }
 
-    pub fn is_protocol_supported(&self, protocol: &ProtocolId) -> bool {
+    pub fn is_protocol_supported(&self, protocol: ProtocolId) -> bool {
         self.supported_protocols
             .iter()
-            .any(|proto| proto == protocol)
+            .any(|proto| *proto == protocol)
     }
 
     pub fn supported_protocols(&self) -> &[ProtocolId] {

--- a/network/src/protocols/network/dummy.rs
+++ b/network/src/protocols/network/dummy.rs
@@ -24,17 +24,17 @@ use serde::{Deserialize, Serialize};
 use std::{collections::HashMap, time::Duration};
 use tokio::runtime::Runtime;
 
+const TEST_RPC_PROTOCOL: ProtocolId = ProtocolId::ConsensusRpc;
+const TEST_DIRECT_SEND_PROTOCOL: ProtocolId = ProtocolId::ConsensusDirectSend;
+
 #[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
 pub struct DummyMsg(pub Vec<u8>);
-
-pub const TEST_RPC_PROTOCOL: &[u8] = b"/libra/rpc/0.1.0/test/0.1.0";
-pub const TEST_DIRECT_SENDER_PROTOCOL: &[u8] = b"/libra/ds/0.1.0/test/0.1.0";
 
 fn add_to_network(network: &mut NetworkBuilder) -> (DummyNetworkSender, DummyNetworkEvents) {
     let (sender, receiver, connection_reqs_tx, connection_notifs_rx) = network
         .add_protocol_handler(
-            vec![ProtocolId::from_static(TEST_RPC_PROTOCOL)],
-            vec![ProtocolId::from_static(TEST_DIRECT_SENDER_PROTOCOL)],
+            vec![TEST_RPC_PROTOCOL],
+            vec![TEST_DIRECT_SEND_PROTOCOL],
             QueueStyle::LIFO,
             None,
         );
@@ -64,7 +64,7 @@ impl DummyNetworkSender {
     }
 
     pub fn send_to(&mut self, recipient: PeerId, message: DummyMsg) -> Result<(), NetworkError> {
-        let protocol = ProtocolId::from_static(TEST_DIRECT_SENDER_PROTOCOL);
+        let protocol = TEST_DIRECT_SEND_PROTOCOL;
         self.inner.send_to(recipient, protocol, message)
     }
 
@@ -74,7 +74,7 @@ impl DummyNetworkSender {
         message: DummyMsg,
         timeout: Duration,
     ) -> Result<DummyMsg, RpcError> {
-        let protocol = ProtocolId::from_static(TEST_RPC_PROTOCOL);
+        let protocol = TEST_RPC_PROTOCOL;
         self.inner
             .send_rpc(recipient, protocol, message, timeout)
             .await

--- a/network/src/protocols/network/dummy.rs
+++ b/network/src/protocols/network/dummy.rs
@@ -74,7 +74,7 @@ impl DummyNetworkSender {
     ) -> Result<DummyMsg, RpcError> {
         let protocol = ProtocolId::from_static(TEST_RPC_PROTOCOL);
         self.peer_mgr_reqs_tx
-            .unary_rpc(recipient, protocol, message, timeout)
+            .send_rpc(recipient, protocol, message, timeout)
             .await
     }
 }

--- a/network/src/protocols/network/dummy.rs
+++ b/network/src/protocols/network/dummy.rs
@@ -31,7 +31,7 @@ pub const TEST_RPC_PROTOCOL: &[u8] = b"/libra/rpc/0.1.0/test/0.1.0";
 pub const TEST_DIRECT_SENDER_PROTOCOL: &[u8] = b"/libra/ds/0.1.0/test/0.1.0";
 
 fn add_to_network(network: &mut NetworkBuilder) -> (DummyNetworkSender, DummyNetworkEvents) {
-    let (sender, receiver, control_notifs_rx) = network.add_protocol_handler(
+    let (sender, receiver, connection_notifs_rx) = network.add_protocol_handler(
         vec![ProtocolId::from_static(TEST_RPC_PROTOCOL)],
         vec![ProtocolId::from_static(TEST_DIRECT_SENDER_PROTOCOL)],
         QueueStyle::LIFO,
@@ -39,7 +39,7 @@ fn add_to_network(network: &mut NetworkBuilder) -> (DummyNetworkSender, DummyNet
     );
     (
         DummyNetworkSender::new(sender),
-        DummyNetworkEvents::new(receiver, control_notifs_rx),
+        DummyNetworkEvents::new(receiver, connection_notifs_rx),
     )
 }
 

--- a/network/src/protocols/network/mod.rs
+++ b/network/src/protocols/network/mod.rs
@@ -96,7 +96,7 @@ pub struct NetworkEvents<TMessage> {
 impl<TMessage: Message> NetworkEvents<TMessage> {
     pub fn new(
         peer_mgr_notifs_rx: libra_channel::Receiver<(PeerId, ProtocolId), PeerManagerNotification>,
-        control_notifs_rx: libra_channel::Receiver<
+        connection_notifs_rx: libra_channel::Receiver<
             PeerId,
             peer_manager::ConnectionStatusNotification,
         >,
@@ -105,7 +105,7 @@ impl<TMessage: Message> NetworkEvents<TMessage> {
             peer_mgr_notif_to_event
                 as fn(PeerManagerNotification) -> Result<Event<TMessage>, NetworkError>,
         );
-        let control_event_stream = control_notifs_rx.map(
+        let control_event_stream = connection_notifs_rx.map(
             control_msg_to_event
                 as fn(
                     peer_manager::ConnectionStatusNotification,

--- a/network/src/protocols/network/mod.rs
+++ b/network/src/protocols/network/mod.rs
@@ -245,7 +245,7 @@ impl<TMessage: Message> NetworkSender<TMessage> {
     /// Send a protobuf rpc request to a single recipient while handling
     /// serialization and deserialization of the request and response respectively.
     /// Assumes that the request and response both have the same message type.
-    pub async fn unary_rpc(
+    pub async fn send_rpc(
         &mut self,
         recipient: PeerId,
         protocol: ProtocolId,
@@ -256,7 +256,7 @@ impl<TMessage: Message> NetworkSender<TMessage> {
         let req_data = lcs::to_bytes(&req_msg)?.into();
         let res_data = self
             .inner
-            .unary_rpc(recipient, protocol, req_data, timeout)
+            .send_rpc(recipient, protocol, req_data, timeout)
             .await?;
         let res_msg: TMessage = lcs::from_bytes(&res_data)?;
         Ok(res_msg)

--- a/network/src/protocols/rpc/fuzzing.rs
+++ b/network/src/protocols/rpc/fuzzing.rs
@@ -28,8 +28,8 @@ const MAX_SMALL_MSG_BYTES: usize = 32;
 const MAX_MEDIUM_MSG_BYTES: usize = 280;
 
 const MOCK_PEER_ID: PeerId = PeerId::new([0u8; ADDRESS_LENGTH]);
-const MOCK_PROTOCOL_ID: &[u8] = b"/libra/rpc/1.2.3/consensus/1.2.3";
 const INBOUND_RPC_TIMEOUT: Duration = Duration::from_secs(30);
+const TEST_PROTOCOL: ProtocolId = ProtocolId::ConsensusRpc;
 
 #[test]
 fn test_fuzzer() {
@@ -65,7 +65,7 @@ pub fn fuzzer(data: &[u8]) {
     let (notification_tx, mut notification_rx) = channel::new_test(8);
     let (mut dialer_substream, listener_substream) = MemorySocket::new_pair();
     let listener_substream = NegotiatedSubstream {
-        protocol: ProtocolId::from_static(MOCK_PROTOCOL_ID),
+        protocol: TEST_PROTOCOL,
         substream: listener_substream,
     };
     let peer_notif = PeerNotification::NewSubstream(MOCK_PEER_ID, listener_substream);
@@ -84,7 +84,7 @@ pub fn fuzzer(data: &[u8]) {
                     let protocol = req.protocol;
                     let data = req.data;
                     let res_tx = req.res_tx;
-                    assert_eq!(protocol.as_ref(), MOCK_PROTOCOL_ID);
+                    assert_eq!(protocol, TEST_PROTOCOL);
                     let _ = res_tx.send(Ok(data));
                 }
             }

--- a/network/src/protocols/rpc/test.rs
+++ b/network/src/protocols/rpc/test.rs
@@ -13,6 +13,8 @@ use parity_multiaddr::Multiaddr;
 use std::str::FromStr;
 use tokio::runtime::Runtime;
 
+static RPC_PROTOCOL: ProtocolId = ProtocolId::ConsensusRpc;
+
 async fn do_outbound_rpc_req<TSubstream>(
     peer_tx: PeerHandle<TSubstream>,
     protocol: ProtocolId,
@@ -55,7 +57,7 @@ fn upgrades() {
 
     let listener_peer_id = PeerId::random();
     let dialer_peer_id = PeerId::random();
-    let protocol_id = b"/get_blocks/1.0.0";
+    let protocol_id = RPC_PROTOCOL;
     let req_data = b"hello";
     let res_data = b"goodbye";
 
@@ -76,7 +78,7 @@ fn upgrades() {
         // Handle the inbound rpc request
         match dialer_rpc_notifs_rx.select_next_some().await {
             RpcNotification::RecvRpc(req) => {
-                assert_eq!(req.protocol.as_ref(), protocol_id);
+                assert_eq!(req.protocol, protocol_id);
                 assert_eq!(req.data.as_ref(), req_data);
                 req.res_tx.send(Ok(Bytes::from_static(res_data))).unwrap();
             }
@@ -84,7 +86,7 @@ fn upgrades() {
     };
 
     let substream = NegotiatedSubstream {
-        protocol: ProtocolId::from_static(protocol_id),
+        protocol: protocol_id,
         substream: listener_substream,
     };
     let inbound_notif = PeerNotification::NewSubstream(dialer_peer_id, substream);
@@ -100,7 +102,7 @@ fn upgrades() {
     let f_listener_upgrade = async move {
         let res = do_outbound_rpc_req(
             listener_peer_reqs_tx,
-            ProtocolId::from_static(protocol_id),
+            protocol_id,
             Bytes::from_static(req_data),
             Duration::from_secs(1),
         )
@@ -127,7 +129,7 @@ fn listener_close_before_response() {
     ::libra_logger::Logger::new().environment_only(true).init();
 
     let listener_peer_id = PeerId::random();
-    let protocol_id = b"/get_blocks/1.0.0";
+    let protocol_id = RPC_PROTOCOL;
     let req_data = b"hello";
 
     let (dialer_substream, listener_substream) = MemorySocket::new_pair();
@@ -145,7 +147,7 @@ fn listener_close_before_response() {
     let f_dialer_upgrade = async move {
         let res = do_outbound_rpc_req(
             listener_peer_reqs_tx,
-            ProtocolId::from_static(protocol_id),
+            protocol_id,
             Bytes::from_static(req_data),
             Duration::from_secs(1),
         )
@@ -189,7 +191,7 @@ fn listener_close_before_dialer_send() {
     ::libra_logger::Logger::new().environment_only(true).init();
 
     let listener_peer_id = PeerId::random();
-    let protocol_id = b"/get_blocks/1.0.0";
+    let protocol_id = RPC_PROTOCOL;
     let req_data = b"hello";
 
     let (dialer_substream, listener_substream) = MemorySocket::new_pair();
@@ -210,7 +212,7 @@ fn listener_close_before_dialer_send() {
     let f_listener_upgrade = async move {
         let res = do_outbound_rpc_req(
             listener_peer_reqs_tx,
-            ProtocolId::from_static(protocol_id),
+            protocol_id,
             Bytes::from_static(req_data),
             Duration::from_secs(1),
         )
@@ -234,7 +236,7 @@ fn listener_close_before_dialer_send() {
 fn dialer_close_before_listener_recv() {
     ::libra_logger::Logger::new().environment_only(true).init();
 
-    let protocol_id = b"/get_blocks/1.0.0";
+    let protocol_id = RPC_PROTOCOL;
 
     let (dialer_substream, listener_substream) = MemorySocket::new_pair();
 
@@ -245,12 +247,8 @@ fn dialer_close_before_listener_recv() {
     let f_listener_upgrade = async move {
         let (notification_tx, _notification_rx) = channel::new_test(8);
         // use inner to get Result
-        let res = handle_inbound_substream_inner(
-            notification_tx,
-            ProtocolId::from_static(protocol_id),
-            listener_substream,
-        )
-        .await;
+        let res =
+            handle_inbound_substream_inner(notification_tx, protocol_id, listener_substream).await;
 
         // Check the error
         let err = res.expect_err("Listener's rpc handler should fail");
@@ -269,7 +267,7 @@ fn dialer_close_before_listener_recv() {
 fn dialer_close_before_listener_send() {
     ::libra_logger::Logger::new().environment_only(true).init();
 
-    let protocol_id = b"/get_blocks/1.0.0";
+    let protocol_id = RPC_PROTOCOL;
     let req_data = b"hello";
     let res_data = b"goodbye";
 
@@ -281,7 +279,7 @@ fn dialer_close_before_listener_send() {
         // Handle the inbound rpc request
         match dialer_rpc_notifs_rx.next().await.unwrap() {
             RpcNotification::RecvRpc(req) => {
-                assert_eq!(req.protocol.as_ref(), protocol_id);
+                assert_eq!(req.protocol, protocol_id);
                 assert_eq!(req.data.as_ref(), req_data);
                 req.res_tx.send(Ok(Bytes::from_static(res_data))).unwrap();
             }
@@ -291,12 +289,9 @@ fn dialer_close_before_listener_send() {
     // Listener handles the inbound substream, but should get a broken pipe error
     let f_listener_upgrade = async move {
         // use inner to get Result
-        let res = handle_inbound_substream_inner(
-            dialer_rpc_notifs_tx,
-            ProtocolId::from_static(protocol_id),
-            listener_substream,
-        )
-        .await;
+        let res =
+            handle_inbound_substream_inner(dialer_rpc_notifs_tx, protocol_id, listener_substream)
+                .await;
 
         // Check the error
         let err = res.expect_err("Listener's rpc handler should fail");
@@ -328,7 +323,7 @@ fn dialer_close_before_listener_send() {
 fn dialer_sends_two_requests_err() {
     ::libra_logger::Logger::new().environment_only(true).init();
 
-    let protocol_id = b"/get_blocks/1.0.0";
+    let protocol_id = RPC_PROTOCOL;
     let req_data = b"hello";
 
     let (dialer_substream, listener_substream) = MemorySocket::new_pair();
@@ -337,12 +332,8 @@ fn dialer_sends_two_requests_err() {
     let f_listener_upgrade = async move {
         let (notification_tx, _notification_rx) = channel::new_test(8);
         // use inner to get Result
-        let res = handle_inbound_substream_inner(
-            notification_tx,
-            ProtocolId::from_static(protocol_id),
-            listener_substream,
-        )
-        .await;
+        let res =
+            handle_inbound_substream_inner(notification_tx, protocol_id, listener_substream).await;
 
         // Check the error
         let err = res.expect_err("Listener's rpc handler should fail");
@@ -385,7 +376,7 @@ fn outbound_rpc_timeout() {
     ::libra_logger::Logger::new().environment_only(true).init();
 
     let listener_peer_id = PeerId::random();
-    let protocol_id = b"/get_blocks/1.0.0";
+    let protocol_id = RPC_PROTOCOL;
     let req_data = b"hello";
 
     // Listener hangs after negotiation
@@ -404,7 +395,7 @@ fn outbound_rpc_timeout() {
     let f_dialer_upgrade = async move {
         let res = do_outbound_rpc_req(
             listener_peer_reqs_tx,
-            ProtocolId::from_static(protocol_id),
+            protocol_id,
             Bytes::from_static(req_data),
             Duration::from_millis(100),
         )
@@ -428,7 +419,7 @@ fn inbound_rpc_timeout() {
     ::libra_logger::Logger::new().environment_only(true).init();
 
     let dialer_peer_id = PeerId::random();
-    let protocol_id = b"/get_blocks/1.0.0";
+    let protocol_id = RPC_PROTOCOL;
 
     // Dialer hangs after negotiation
     let (_dialer_substream, listener_substream) = MemorySocket::new_pair();
@@ -436,7 +427,7 @@ fn inbound_rpc_timeout() {
 
     // Handle the inbound substream
     let substream = NegotiatedSubstream {
-        protocol: ProtocolId::from_static(protocol_id),
+        protocol: protocol_id,
         substream: listener_substream,
     };
     let inbound_notif = PeerNotification::NewSubstream(dialer_peer_id, substream);
@@ -457,7 +448,7 @@ fn outbound_cancellation_before_send() {
     ::libra_logger::Logger::new().environment_only(true).init();
 
     let listener_peer_id = PeerId::random();
-    let protocol_id = b"/get_blocks/1.0.0";
+    let protocol_id = RPC_PROTOCOL;
     let req_data = b"hello";
 
     // Fake the dialer NetworkProvider channels
@@ -471,7 +462,7 @@ fn outbound_cancellation_before_send() {
     // build the rpc request future
     let (res_tx, res_rx) = oneshot::channel();
     let outbound_req = OutboundRpcRequest {
-        protocol: ProtocolId::from_static(protocol_id),
+        protocol: protocol_id,
         data: Bytes::from_static(req_data),
         res_tx,
         timeout: Duration::from_secs(1),
@@ -496,7 +487,7 @@ fn outbound_cancellation_recv() {
     let executor = rt.handle().clone();
 
     let listener_peer_id = PeerId::random();
-    let protocol_id = b"/get_blocks/1.0.0";
+    let protocol_id = RPC_PROTOCOL;
     let req_data = b"hello";
     let res_data = b"goodbye";
 
@@ -523,7 +514,7 @@ fn outbound_cancellation_recv() {
         let mut res_rx = res_rx.fuse();
 
         let outbound_req = OutboundRpcRequest {
-            protocol: ProtocolId::from_static(protocol_id),
+            protocol: protocol_id,
             data: Bytes::from_static(req_data),
             res_tx,
             timeout: Duration::from_secs(1),
@@ -590,7 +581,7 @@ fn rpc_protocol() {
 
     let listener_peer_id = PeerId::random();
     let dialer_peer_id = PeerId::random();
-    let protocol_id = b"/get_blocks/1.0.0";
+    let protocol_id = RPC_PROTOCOL;
     let req_data = b"hello";
     let res_data = b"goodbye";
 
@@ -624,7 +615,7 @@ fn rpc_protocol() {
         let (res_tx, res_rx) = oneshot::channel();
 
         let req = OutboundRpcRequest {
-            protocol: ProtocolId::from_static(protocol_id),
+            protocol: protocol_id,
             data: Bytes::from_static(req_data),
             res_tx,
             timeout: Duration::from_secs(1),
@@ -636,7 +627,7 @@ fn rpc_protocol() {
         // Fulfill the open substream request
         match dialer_peer_reqs_rx.next().await.unwrap() {
             PeerRequest::OpenSubstream(protocol, substream_tx) => {
-                assert_eq!(protocol.as_ref(), protocol_id);
+                assert_eq!(protocol, protocol_id);
                 substream_tx.send(Ok(dialer_substream)).unwrap();
             }
             _ => {
@@ -678,7 +669,7 @@ fn rpc_protocol() {
             .send(PeerNotification::NewSubstream(
                 dialer_peer_id,
                 NegotiatedSubstream {
-                    protocol: ProtocolId::from_static(protocol_id),
+                    protocol: protocol_id,
                     substream: listener_substream,
                 },
             ))
@@ -688,7 +679,7 @@ fn rpc_protocol() {
         // Handle the inbound rpc request
         match listener_rpc_notifs_rx.next().await.unwrap() {
             RpcNotification::RecvRpc(req) => {
-                assert_eq!(req.protocol.as_ref(), protocol_id);
+                assert_eq!(req.protocol, protocol_id);
                 assert_eq!(req.data.as_ref(), req_data);
                 req.res_tx.send(Ok(Bytes::from_static(res_data))).unwrap();
             }

--- a/network/src/protocols/wire/messaging.rs
+++ b/network/src/protocols/wire/messaging.rs
@@ -2,4 +2,4 @@
 // SPDX-License-Identifier: Apache-2.0
 
 // v1 of the LibraNet messaging protocol.
-mod v1;
+pub(crate) mod v1;

--- a/network/src/protocols/wire/messaging/v1/mod.rs
+++ b/network/src/protocols/wire/messaging/v1/mod.rs
@@ -27,7 +27,7 @@ pub enum NetworkMessage {
 /// Unique identifier associated with each application protocol.
 /// New application protocols can be added without bumping up the MessagingProtocolVersion.
 #[repr(u8)]
-#[derive(Clone, Debug, Deserialize_repr, Serialize_repr)]
+#[derive(Clone, Copy, Debug, Hash, Eq, PartialEq, Deserialize_repr, Serialize_repr)]
 pub enum ProtocolId {
     ConsensusRpc = 0,
     ConsensusDirectSend = 1,

--- a/network/src/validator_network/network_builder.rs
+++ b/network/src/validator_network/network_builder.rs
@@ -320,13 +320,13 @@ impl NetworkBuilder {
             self.upstream_handlers
                 .insert(protocol, network_notifs_tx.clone());
         }
-        let (control_notifs_tx, control_notifs_rx) = conn_status_channel::new();
+        let (connection_notifs_tx, connection_notifs_rx) = conn_status_channel::new();
         // Auto-subscribe all application level handlers to connection events.
-        self.connection_event_handlers.push(control_notifs_tx);
+        self.connection_event_handlers.push(connection_notifs_tx);
         (
             self.pm_reqs_tx.clone(),
             network_notifs_rx,
-            control_notifs_rx,
+            connection_notifs_rx,
         )
     }
 

--- a/state-synchronizer/src/network.rs
+++ b/state-synchronizer/src/network.rs
@@ -50,7 +50,7 @@ pub struct StateSynchronizerSender {
 pub fn add_to_network(
     network: &mut NetworkBuilder,
 ) -> (StateSynchronizerSender, StateSynchronizerEvents) {
-    let (sender, receiver, control_notifs_rx) = network.add_protocol_handler(
+    let (sender, receiver, connection_notifs_rx) = network.add_protocol_handler(
         vec![],
         vec![ProtocolId::from_static(
             STATE_SYNCHRONIZER_DIRECT_SEND_PROTOCOL,
@@ -60,7 +60,7 @@ pub fn add_to_network(
     );
     (
         StateSynchronizerSender::new(sender),
-        StateSynchronizerEvents::new(receiver, control_notifs_rx),
+        StateSynchronizerEvents::new(receiver, connection_notifs_rx),
     )
 }
 

--- a/state-synchronizer/src/network.rs
+++ b/state-synchronizer/src/network.rs
@@ -22,10 +22,6 @@ pub enum StateSynchronizerMsg {
     GetChunkResponse(Box<GetChunkResponse>),
 }
 
-/// Protocol id for state-synchronizer direct-send calls
-pub const STATE_SYNCHRONIZER_DIRECT_SEND_PROTOCOL: &[u8] =
-    b"/libra/direct-send/0.1.0/state-synchronizer/0.1.0";
-
 /// The interface from Network to StateSynchronizer layer.
 ///
 /// `StateSynchronizerEvents` is a `Stream` of `PeerManagerNotification` where the
@@ -53,9 +49,7 @@ pub fn add_to_network(
     let (sender, receiver, connection_reqs_tx, connection_notifs_rx) = network
         .add_protocol_handler(
             vec![],
-            vec![ProtocolId::from_static(
-                STATE_SYNCHRONIZER_DIRECT_SEND_PROTOCOL,
-            )],
+            vec![ProtocolId::StateSynchronizerDirectSend],
             QueueStyle::FIFO,
             Some(&counters::PENDING_STATE_SYNCHRONIZER_NETWORK_EVENTS),
         );
@@ -80,7 +74,7 @@ impl StateSynchronizerSender {
         recipient: PeerId,
         message: StateSynchronizerMsg,
     ) -> Result<(), NetworkError> {
-        let protocol = ProtocolId::from_static(STATE_SYNCHRONIZER_DIRECT_SEND_PROTOCOL);
+        let protocol = ProtocolId::StateSynchronizerDirectSend;
         self.inner.send_to(recipient, protocol, message)
     }
 }


### PR DESCRIPTION
As a first step in migration to new network wire protocol (#2878), this PR migrates the network module API and internals from `Bytes` based `ProtocolId` to the `ProtocolId` enum defined in #2879. A couple of refactors had to be done to enable this:
1. Removed various ad hoc protocols that were used in tests
2. Removed usage of "DialPeer" and "DisconnectPeer" protocol ids which were introduced as hacks to get around passing DialPeer and DisconnectPeer requests from PeerManager to NetworkProvider.
3. Some small renaming which, though not strictly necessary, makes things look nicer. These are renaming `unary_rpc` to `send_rpc` and `control_notifs_*x` to `connection_notifs_*x`.