### PR TITLE
[tf] fix validator uptime metric

### DIFF
--- a/terraform/templates/ec2_user_data.sh
+++ b/terraform/templates/ec2_user_data.sh
@@ -25,7 +25,7 @@ yum install -y /tmp/node_exporter.rpm
 systemctl start node_exporter
 
 cat > /etc/cron.d/metric_collector <<"EOF"
-* * * * * root   docker container ls -q --filter label=vcs-upstream | xargs docker inspect --format='{{.State.StartedAt}}' | xargs date +"\%s" -d | xargs echo "ecs_start_time_seconds " > /var/lib/node_exporter/textfile_collector/ecs_stats.prom
+* * * * * root   docker container ls -q --filter label=vcs-upstream --filter name=^ecs-dev-validator-.*-validator-.*$ | xargs docker inspect --format='{{.State.StartedAt}}' | xargs date +"\%s" -d | xargs echo "ecs_start_time_seconds " > /var/lib/node_exporter/textfile_collector/ecs_stats.prom
 
 * * * * * root	 docker container ls -q --filter label=com.amazonaws.ecs.container-name | xargs docker inspect --format='{{$tags := .Config.Labels}}build_info{revision="{{index $tags "org.label-schema.vcs-ref"}}", upstream="{{index $tags "vcs-upstream"}}", container_name="{{index $tags "com.amazonaws.ecs.container-name"}}"} 1' > /var/lib/node_exporter/textfile_collector/build_info.prom
 EOF


### PR DESCRIPTION
## Motivation

This fixes the uptime metric on our dashboard, which is currently broken since we now have multiple containers running in the same instance.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?

yes!

## Test Plan

Applied an extra filter for gathering metadata. ssh into validator and verify the filter manually:

```
$ docker container ls -q --filter label=vcs-upstream --filter name=^ecs-dev-validator-.*-validator-.*$ | xargs docker inspect --format='{{.State.StartedAt}}' | xargs date +"\%s" -d | xargs echo "ecs_start_time_seconds "

ecs_start_time_seconds  1584055825
```

