### PR TITLE
[language][function tests] use fixed seed for key generation

### DIFF
--- a/language/e2e-tests/src/account.rs
+++ b/language/e2e-tests/src/account.rs
@@ -3,6 +3,7 @@
 
 //! Test infrastructure for modeling Libra accounts.
 
+use crate::keygen::KeyGen;
 use libra_crypto::ed25519::*;
 use libra_types::{
     access_path::AccessPath,
@@ -19,7 +20,6 @@ use move_vm_types::{
     loaded_data::{struct_def::StructDef, types::Type},
     values::{Struct, Value},
 };
-use rand::{Rng, SeedableRng};
 use std::time::Duration;
 use vm_genesis::GENESIS_KEYPAIR;
 
@@ -48,13 +48,7 @@ impl Account {
     /// [`FakeExecutor::add_account_data`][crate::executor::FakeExecutor::add_account_data].
     /// This function returns distinct values upon every call.
     pub fn new() -> Self {
-        let mut seed_rng = rand::rngs::OsRng::new().expect("can't access OsRng");
-        let seed_buf: [u8; 32] = seed_rng.gen();
-        let mut rng = rand::rngs::StdRng::from_seed(seed_buf);
-
-        // replace `&mut rng` by None (making the function deterministic) and watch the
-        // functional_tests fail!
-        let (privkey, pubkey) = compat::generate_keypair(&mut rng);
+        let (privkey, pubkey) = KeyGen::from_os_rng().generate_keypair();
         Self::with_keypair(privkey, pubkey)
     }
 

--- a/language/e2e-tests/src/keygen.rs
+++ b/language/e2e-tests/src/keygen.rs
@@ -1,0 +1,31 @@
+// Copyright (c) The Libra Core Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+use libra_crypto::ed25519::{compat::generate_keypair, Ed25519PrivateKey, Ed25519PublicKey};
+use rand::{
+    rngs::{OsRng, StdRng},
+    Rng, SeedableRng,
+};
+
+/// Ed25519 key generator.
+pub struct KeyGen(StdRng);
+
+impl KeyGen {
+    /// Constructs a key generator with a specific seed.
+    pub fn from_seed(seed: [u8; 32]) -> Self {
+        Self(StdRng::from_seed(seed))
+    }
+
+    /// Constructs a key generator with a random seed.
+    /// The random seed itself is generated using the OS rng.
+    pub fn from_os_rng() -> Self {
+        let mut seed_rng = OsRng::new().expect("can't access OsRng");
+        let seed: [u8; 32] = seed_rng.gen();
+        Self::from_seed(seed)
+    }
+
+    /// Generate an Ed25519 key pair.
+    pub fn generate_keypair(&mut self) -> (Ed25519PrivateKey, Ed25519PublicKey) {
+        generate_keypair(&mut self.0)
+    }
+}

--- a/language/e2e-tests/src/lib.rs
+++ b/language/e2e-tests/src/lib.rs
@@ -19,6 +19,7 @@ pub mod compile;
 pub mod data_store;
 pub mod executor;
 pub mod gas_costs;
+pub mod keygen;
 mod proptest_types;
 
 pub fn assert_status_eq(s1: &VMStatus, s2: &VMStatus) -> bool {

--- a/language/functional-tests/src/config/global.rs
+++ b/language/functional-tests/src/config/global.rs
@@ -5,7 +5,10 @@
 // A config entry starts with "//!", differentiating it from a directive.
 
 use crate::{common::strip, errors::*, genesis_accounts::make_genesis_accounts};
-use language_e2e_tests::account::{Account, AccountData};
+use language_e2e_tests::{
+    account::{Account, AccountData},
+    keygen::KeyGen,
+};
 use libra_config::generator;
 use libra_crypto::PrivateKey;
 use libra_types::crypto_proxies::ValidatorSet;
@@ -134,6 +137,10 @@ impl Config {
             (BTreeMap::new(), ValidatorSet::new(vec![]))
         };
 
+        // key generator with a fixed seed
+        // this is important as it ensures the tests are deterministic
+        let mut keygen = KeyGen::from_seed([0x1f; 32]);
+
         // initialize the keys of validator entries with the validator set
         // enhance type of config to contain a validator set, use it to initialize genesis
         for entry in entries {
@@ -149,7 +156,10 @@ impl Config {
                             def.sequence_number.unwrap_or(0),
                         )
                     } else {
-                        AccountData::new(
+                        let (privkey, pubkey) = keygen.generate_keypair();
+                        AccountData::with_keypair(
+                            privkey,
+                            pubkey,
                             def.balance.unwrap_or(DEFAULT_BALANCE),
                             def.sequence_number.unwrap_or(0),
                         )
@@ -173,7 +183,10 @@ impl Config {
         }
 
         if let btree_map::Entry::Vacant(entry) = accounts.entry("default".to_string()) {
-            entry.insert(AccountData::new(
+            let (privkey, pubkey) = keygen.generate_keypair();
+            entry.insert(AccountData::with_keypair(
+                privkey,
+                pubkey,
                 DEFAULT_BALANCE,
                 /* sequence_number */ 0,
             ));


### PR DESCRIPTION
## Summary
Functional tests used be non-deterministic due to different seeds use across runs. This gets it fixed.

## Test Plan
Write a failed test and observe the addresses in the log. 