### PR TITLE
[JSON RPC] fix flaky test_get_events

### DIFF
--- a/json-rpc/src/tests/mock_db.rs
+++ b/json-rpc/src/tests/mock_db.rs
@@ -34,6 +34,14 @@ pub(crate) struct MockLibraDB {
     pub account_state_with_proof: Vec<AccountStateWithProof>,
 }
 
+impl MockLibraDB {
+    pub(crate) fn add_event(&mut self, event: ContractEvent) {
+        if self.events.is_empty() {
+            self.events.push((0, event));
+        }
+    }
+}
+
 impl LibraDBTrait for MockLibraDB {
     fn get_latest_account_state(
         &self,

--- a/json-rpc/src/tests/unit_tests.rs
+++ b/json-rpc/src/tests/unit_tests.rs
@@ -21,6 +21,7 @@ use libra_types::{
     account_config::AccountResource,
     account_state::AccountState,
     account_state_blob::{AccountStateBlob, AccountStateWithProof},
+    contract_event::ContractEvent,
     crypto_proxies::LedgerInfoWithSignatures,
     mempool_status::{MempoolStatus, MempoolStatusCode},
     proof::{SparseMerkleProof, TransactionAccumulatorProof},
@@ -291,9 +292,10 @@ proptest! {
 
 
     #[test]
-    fn test_get_events(blocks in arb_blocks_to_commit()) {
+    fn test_get_events(blocks in arb_blocks_to_commit(), event in any::<ContractEvent>(),) {
         // set up MockLibraDB
-        let mock_db = mock_db(blocks, None);
+        let mut mock_db = mock_db(blocks, None);
+        mock_db.add_event(event);
 
         // set up JSON RPC
         let address = format!("0.0.0.0:{}", utils::get_available_port());


### PR DESCRIPTION
## Motivation

`test_get_events` was flaky because proptest data used to populate the mock db was not guaranteed to contain events, so test_get_events failed where no events were available in the mock DB. We fix this by ensuring mock DB has events for `test_get_events`