### PR TITLE
[move-prover] Fix some type and other problems in boogie prelude, generated boogie

### DIFF
--- a/language/move-prover/src/spec_translator.rs
+++ b/language/move-prover/src/spec_translator.rs
@@ -586,7 +586,7 @@ impl<'env> SpecTranslator<'env> {
     fn translate_resource_access(&self, node_id: NodeId, args: &[Exp]) {
         let rty = &self.module_env.get_node_instantiation(node_id)[0];
         let type_value = boogie_type_value(self.module_env.env, rty);
-        emit!(self.writer, "$ResourceExists($m, {}, ", type_value);
+        emit!(self.writer, "$ResourceValue($m, {}, ", type_value);
         self.translate_exp(&args[0]);
         emit!(self.writer, ")");
     }
@@ -594,7 +594,7 @@ impl<'env> SpecTranslator<'env> {
     fn translate_resource_exists(&self, node_id: NodeId, args: &[Exp]) {
         let rty = &self.module_env.get_node_instantiation(node_id)[0];
         let type_value = boogie_type_value(self.module_env.env, rty);
-        emit!(self.writer, "$ResourceValue($m, {}, ", type_value);
+        emit!(self.writer, "$ResourceExists($m, {}, ", type_value);
         self.translate_exp(&args[0]);
         emit!(self.writer, ")");
     }


### PR DESCRIPTION
  
I fixed some problems that I ran into when trying to port the specs for libra_coin.move.
    
    1. Address was defined redundantly as type int and as a constructor of values.
    
    2. Fixing that exposed some other problems where int Addresses and Value Address were getting mixed up.  Fixed those (I think).
    
    3. Fixed a few random problems:  $ExistsResource vs. $ResourceExists,
    typo: $ResoureValue, calling $ResourceExists instead of $ResourceValue and
    vice-versa.
    
    4. Commented out apparently unused function InitTransaction, instead of fixing
    a type error.

## Motivation

Debugging Move Prover

### Have you read the [Contributing Guidelines on pull requests]

Yes

## Test Plan

(Share your test plan here. If you changed code, please provide us with clear instructions for verifying that your changes work.)

cargo test

## Related PRs

(If this PR adds or changes functionality, please take some time to update the docs at https://github.com/libra/website, and link to your PR here.)
