### PR TITLE
[move-prover] Refactoring invariant handling, and enabling pack/unpack only model

### DIFF
--- a/language/move-prover/tests/sources/global_vars.exp
+++ b/language/move-prover/tests/sources/global_vars.exp
@@ -1,49 +1,59 @@
 Move prover returns: exiting with boogie verification errors
 error:  A postcondition might not hold on this return path.
 
-    ┌── tests/sources/global_vars.move:30:9 ───
+    ┌── tests/sources/global_vars.move:29:9 ───
     │
- 30 │         ensures sum_of_T == old(sum_of_T) + 1;
+ 29 │         ensures sum_of_T == old(sum_of_T) + 1;
     │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
     │
-    =     at tests/sources/global_vars.move:26:5: pack_invalid (entry)
-    =     at tests/sources/global_vars.move:27:9: pack_invalid
-    =         result = <redacted>
-    =     at tests/sources/global_vars.move:26:5: pack_invalid (exit)
+    =     at tests/sources/global_vars.move:25:5: pack_invalid (entry)
+    =     at tests/sources/global_vars.move:25:5: pack_invalid (exit)
 
 error:  A postcondition might not hold on this return path.
 
-    ┌── tests/sources/global_vars.move:50:9 ───
+    ┌── tests/sources/global_vars.move:49:9 ───
     │
- 50 │         ensures sum_of_T == old(sum_of_T);
+ 49 │         ensures sum_of_T == old(sum_of_T);
     │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
     │
-    =     at tests/sources/global_vars.move:45:5: unpack_invalid (entry)
-    =     at tests/sources/global_vars.move:46:19: unpack_invalid
+    =     at tests/sources/global_vars.move:44:5: unpack_invalid (entry)
+    =     at tests/sources/global_vars.move:45:19: unpack_invalid
     =         t = <redacted>
-    =     at tests/sources/global_vars.move:47:9: unpack_invalid
+    =     at tests/sources/global_vars.move:46:9: unpack_invalid
     =         x = <redacted>
-    =     at tests/sources/global_vars.move:45:5: unpack_invalid (exit)
-    =         result = <redacted>
+    =     at tests/sources/global_vars.move:44:5: unpack_invalid (exit)
 
 error:  A postcondition might not hold on this return path.
 
-    ┌── tests/sources/global_vars.move:81:9 ───
+    ┌── tests/sources/global_vars.move:80:9 ───
     │
- 81 │         ensures sum_of_T == old(sum_of_T);
+ 80 │         ensures sum_of_T == old(sum_of_T);
     │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
     │
-    =     at tests/sources/global_vars.move:74:5: update_invalid (entry)
-    =     at tests/sources/global_vars.move:75:13: update_invalid
-    =     at tests/sources/global_vars.move:76:37: update_invalid
+    =     at tests/sources/global_vars.move:73:5: update_invalid (entry)
+    =     at tests/sources/global_vars.move:74:13: update_invalid
+    =     at tests/sources/global_vars.move:75:37: update_invalid
+    =         t = <redacted>
+    =     at tests/sources/global_vars.move:55:5: update_valid_still_mutating (entry)
+    =     at tests/sources/global_vars.move:56:19: update_valid_still_mutating
     =         t = <redacted>,
     =         t = <redacted>
-    =     at tests/sources/global_vars.move:56:5: update_valid_still_mutating (entry)
-    =     at tests/sources/global_vars.move:57:19: update_valid_still_mutating
-    =         t = <redacted>,
-    =         t = <redacted>
-    =     at tests/sources/global_vars.move:56:5: update_valid_still_mutating (exit)
-    =     at tests/sources/global_vars.move:76:9: update_invalid
-    =     at tests/sources/global_vars.move:77:9: update_invalid
-    =     at tests/sources/global_vars.move:74:5: update_invalid (exit)
-    =         result = <redacted>
+    =     at tests/sources/global_vars.move:55:5: update_valid_still_mutating (exit)
+    =     at tests/sources/global_vars.move:75:9: update_invalid
+    =     at tests/sources/global_vars.move:73:5: update_invalid (exit)
+
+error:  A postcondition might not hold on this return path.
+
+     ┌── tests/sources/global_vars.move:113:9 ───
+     │
+ 113 │         ensures sum_of_S == old(sum_of_S) + 1;
+     │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+     │
+     =     at tests/sources/global_vars.move:106:5: update_invalid_S (entry)
+     =     at tests/sources/global_vars.move:107:13: update_invalid_S
+     =     at tests/sources/global_vars.move:108:17: update_invalid_S
+     =         r = <redacted>,
+     =         s = <redacted>
+     =     at tests/sources/global_vars.move:109:15: update_invalid_S
+     =         r = <redacted>
+     =     at tests/sources/global_vars.move:106:5: update_invalid_S (exit)

--- a/language/move-prover/tests/sources/global_vars.move
+++ b/language/move-prover/tests/sources/global_vars.move
@@ -11,7 +11,6 @@ module GlobalVars {
       invariant pack sum_of_T = sum_of_T + i;
       invariant unpack sum_of_T = sum_of_T - i;
       invariant update sum_of_T = sum_of_T - old(i) + i;
-
     }
 
     // Pack tests
@@ -80,4 +79,41 @@ module GlobalVars {
         // sum should change because we have ended mutating t
         ensures sum_of_T == old(sum_of_T);
     }
+
+
+    // Test with pack/unpack in the absence of update.
+
+    struct S {
+      x: u64
+    }
+    spec struct S {
+        global sum_of_S: u64;
+        // If there are no update invariants, unpack and pack is used during mutation.
+        invariant pack sum_of_S = sum_of_S + x;
+        invariant unpack sum_of_S = sum_of_S - x;
+    }
+
+    fun update_valid_S(): S {
+        let s = S {x: 0};
+        let r = &mut s;
+        r.x = 2;
+        s
+    }
+    spec fun update_valid_S {
+        ensures sum_of_S == old(sum_of_S) + 2;
+    }
+
+    fun update_invalid_S(): S {
+        let s = S {x: 0};
+        let r = &mut s;
+        r.x = 2;
+        s
+    }
+    spec fun update_invalid_S {
+        ensures sum_of_S == old(sum_of_S) + 1;
+    }
+
+
+
+
 }

--- a/language/move-prover/tests/sources/invariants.exp
+++ b/language/move-prover/tests/sources/invariants.exp
@@ -21,7 +21,7 @@ error:  This assertion might not hold.
     =         r = <redacted>,
     =         t = <redacted>
     =     at tests/sources/invariants.move:49:20: invalid_R_update
-    =         t = <redacted>
+    =         r = <redacted>
 
 error:  This assertion might not hold.
 
@@ -33,7 +33,6 @@ error:  This assertion might not hold.
     =     at tests/sources/invariants.move:66:5: invalid_R_update_indirectly (entry)
     =     at tests/sources/invariants.move:67:13: invalid_R_update_indirectly
     =     at tests/sources/invariants.move:68:28: invalid_R_update_indirectly
-    =         t = <redacted>,
     =         t = <redacted>
     =     at tests/sources/invariants.move:71:5: update_helper (entry)
     =     at tests/sources/invariants.move:72:9: update_helper
@@ -54,7 +53,7 @@ error:  This assertion might not hold.
     =         r = <redacted>,
     =         t = <redacted>
     =     at tests/sources/invariants.move:59:14: invalid_R_update_ref
-    =         t = <redacted>
+    =         r = <redacted>
 
 error:  This assertion might not hold.
 
@@ -68,31 +67,33 @@ error:  This assertion might not hold.
     =     at tests/sources/invariants.move:79:21: lifetime_invalid_R
     =         r = <redacted>,
     =         r_ref = <redacted>
-    =     at tests/sources/invariants.move:80:26: lifetime_invalid_R
+    =     at tests/sources/invariants.move:80:13: lifetime_invalid_R
     =         x_ref = <redacted>
     =     at tests/sources/invariants.move:81:18: lifetime_invalid_R
-    =         r = <redacted>
+    =         r_ref = <redacted>,
+    =         x_ref = <redacted>
 
 error:  This assertion might not hold.
 
-    ┌── tests/sources/invariants.move:94:9 ───
-    │
- 94 │         invariant y > 1;
-    │         ^^^^^^^^^^^^^^^^
-    │
-    =     at tests/sources/invariants.move:97:5: lifetime_invalid_S_branching (entry)
-    =     at tests/sources/invariants.move:98:11: lifetime_invalid_S_branching
-    =         cond = <redacted>
-    =     at tests/sources/invariants.move:99:21: lifetime_invalid_S_branching
-    =         a = <redacted>,
-    =         b = <redacted>
-    =     at tests/sources/invariants.move:100:19: lifetime_invalid_S_branching
-    =         a_ref = <redacted>
-    =     at tests/sources/invariants.move:101:19: lifetime_invalid_S_branching
-    =         b_ref = <redacted>
-    =     at tests/sources/invariants.move:102:23: lifetime_invalid_S_branching
-    =         x_ref = <redacted>
-    =     at tests/sources/invariants.move:104:11: lifetime_invalid_S_branching
-    =     at tests/sources/invariants.move:107:11: lifetime_invalid_S_branching
-    =         a = <redacted>,
-    =         b = <redacted>
+     ┌── tests/sources/invariants.move:101:9 ───
+     │
+ 101 │         invariant y > 1;
+     │         ^^^^^^^^^^^^^^^^
+     │
+     =     at tests/sources/invariants.move:104:5: lifetime_invalid_S_branching (entry)
+     =     at tests/sources/invariants.move:105:11: lifetime_invalid_S_branching
+     =         cond = <redacted>
+     =     at tests/sources/invariants.move:106:21: lifetime_invalid_S_branching
+     =         a = <redacted>,
+     =         b = <redacted>
+     =     at tests/sources/invariants.move:107:19: lifetime_invalid_S_branching
+     =         a_ref = <redacted>
+     =     at tests/sources/invariants.move:108:19: lifetime_invalid_S_branching
+     =         b_ref = <redacted>
+     =     at tests/sources/invariants.move:109:23: lifetime_invalid_S_branching
+     =         x_ref = <redacted>
+     =     at tests/sources/invariants.move:111:11: lifetime_invalid_S_branching
+     =     at tests/sources/invariants.move:114:11: lifetime_invalid_S_branching
+     =         a_ref = <redacted>,
+     =         b_ref = <redacted>,
+     =         x_ref = <redacted>

--- a/language/move-prover/tests/sources/invariants.move
+++ b/language/move-prover/tests/sources/invariants.move
@@ -87,6 +87,13 @@ module Invariants {
         r
     }
 
+    struct T {
+        x: u64
+    }
+    spec struct T {
+        invariant x > 1;
+    }
+
     struct S {
         y: u64
     }
@@ -94,8 +101,8 @@ module Invariants {
         invariant y > 1;
     }
 
-    fun lifetime_invalid_S_branching(cond: bool): (R, S) {
-      let a = R {x: 3};
+    fun lifetime_invalid_S_branching(cond: bool): (T, S) {
+      let a = T {x: 3};
       let b = S {y: 4};
       let a_ref = &mut a;
       let b_ref = &mut b;
@@ -105,7 +112,7 @@ module Invariants {
           *x_ref = 2;
       } else {
           *x_ref = 0;  // only S's invariant should fail
-      }; // <-- TODO: file a parser bug that the semicolon here is needed
+      };
 
       (a, b)
     }


### PR DESCRIPTION
This PR adds a new feature allowing global spec vars to be updated just via pack/unpack invariants and without the update invariant. If a struct spec has no update invariants, then we are "synthesizing" one from the pack/unpacks s.t. if mutation starts, we treat this as unpack, and if mutation ends as pack.

The PR also cleans up invariant handling in bytecode_translator.rs which had become quite unwieldy:

- New data structure `BytecodeContext` which contains the various data which is tracked across bytecode translation of a function. More complete documentation of what is used for what.
- Factoring out some functions to reduce extensive code size of single functions (they are still too large)
- Fixed a bug in integration of lifetime analysis and simplified the handling of return. Branches and Return are special because we need to handle dead references _before_ the instruction itself, whereas for other instructions they are handled _after_. E.g. `S; goto L; <<process dead refs at S` vs `S; <<process dead refs at S>>; goto L` (later the correct one).

I have a bit more trust now that we are doing things right but it's still a complex piece  of code which we need to further improve.

## Motivation

New feature and cleanup.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

Existing tests plus new one.

## Related PRs

NA
