### PR TITLE
[language][prover] Fixed bugs in Prelude

### DIFF
--- a/language/move-prover/src/prelude.bpl
+++ b/language/move-prover/src/prelude.bpl
@@ -88,9 +88,9 @@ type {:datatype} Value;
 const MAX_U8: int;
 axiom MAX_U8 == 255;
 const MAX_U64: int;
-axiom MAX_U64 == 9223372036854775807;
+axiom MAX_U64 == 18446744073709551615;
 const MAX_U128: int;
-axiom MAX_U128 == 340282366920938463463374607431768211456;
+axiom MAX_U128 == 340282366920938463463374607431768211455;
 
 function {:constructor} Boolean(b: bool): Value;
 function {:constructor} Integer(i: int): Value;
@@ -106,14 +106,6 @@ function {:builtin "MapConst"} MapConstValue(v: Value): [int]Value;
 
 function {:inline} $IsValidU8(v: Value): bool {
   is#Integer(v) && i#Integer(v) >= 0 && i#Integer(v) <= MAX_U8
-}
-
-function {:inline} max_u64(): Value {
-  Integer(9223372036854775807)
-}
-
-function {:inline} $IsValidInteger(v: Value): bool {
-  is#Integer(v) && i#Integer(v) >= 0 && i#Integer(v) <= i#Integer(max_u64())
 }
 
 function {:inline} $IsValidU64(v: Value): bool {

--- a/language/move-prover/tests/sources/arithm.exp
+++ b/language/move-prover/tests/sources/arithm.exp
@@ -1,30 +1,84 @@
 Move prover returns: exiting with boogie verification errors
 error:  A postcondition might not hold on this return path.
 
-    ┌── tests/sources/arithm.move:69:6 ───
+    ┌── tests/sources/arithm.move:88:9 ───
     │
- 69 │         aborts_if false;
+ 88 │         aborts_if false;
     │         ^^^^^^^^^^^^^^^^
     │
-    =     at tests/sources/arithm.move:64:5: div_by_zero (entry)
-    =     at tests/sources/arithm.move:66:11: div_by_zero (ABORTED)
+    =     at tests/sources/arithm.move:84:5: div_by_zero_u64_bad (entry)
+    =     at tests/sources/arithm.move:85:11: div_by_zero_u64_bad (ABORTED)
+    =         x = <redacted>,
+    =         y = <redacted>
 
 error:  A postcondition might not hold on this return path.
 
-    ┌── tests/sources/arithm.move:53:6 ───
-    │
- 53 │         aborts_if false;
-    │         ^^^^^^^^^^^^^^^^
-    │
-    =     at tests/sources/arithm.move:48:2: overflow (entry)
-    =     at tests/sources/arithm.move:50:11: overflow (ABORTED)
+     ┌── tests/sources/arithm.move:140:9 ───
+     │
+ 140 │         aborts_if false;
+     │         ^^^^^^^^^^^^^^^^
+     │
+     =     at tests/sources/arithm.move:136:5: overflow_u128_add_bad (entry)
+     =     at tests/sources/arithm.move:137:11: overflow_u128_add_bad (ABORTED)
+     =         x = <redacted>,
+     =         y = <redacted>
 
 error:  A postcondition might not hold on this return path.
 
-    ┌── tests/sources/arithm.move:61:6 ───
-    │
- 61 │         aborts_if false;
-    │         ^^^^^^^^^^^^^^^^
-    │
-    =     at tests/sources/arithm.move:56:5: underflow (entry)
-    =     at tests/sources/arithm.move:58:11: underflow (ABORTED)
+     ┌── tests/sources/arithm.move:193:9 ───
+     │
+ 193 │         aborts_if false;
+     │         ^^^^^^^^^^^^^^^^
+     │
+     =     at tests/sources/arithm.move:189:5: overflow_u128_mul_bad (entry)
+     =     at tests/sources/arithm.move:190:11: overflow_u128_mul_bad (ABORTED)
+     =         x = <redacted>,
+     =         y = <redacted>
+
+error:  A postcondition might not hold on this return path.
+
+     ┌── tests/sources/arithm.move:124:9 ───
+     │
+ 124 │         aborts_if false;
+     │         ^^^^^^^^^^^^^^^^
+     │
+     =     at tests/sources/arithm.move:120:5: overflow_u64_add_bad (entry)
+     =     at tests/sources/arithm.move:121:11: overflow_u64_add_bad (ABORTED)
+     =         x = <redacted>,
+     =         y = <redacted>
+
+error:  A postcondition might not hold on this return path.
+
+     ┌── tests/sources/arithm.move:177:9 ───
+     │
+ 177 │         aborts_if false;
+     │         ^^^^^^^^^^^^^^^^
+     │
+     =     at tests/sources/arithm.move:173:5: overflow_u64_mul_bad (entry)
+     =     at tests/sources/arithm.move:174:11: overflow_u64_mul_bad (ABORTED)
+     =         x = <redacted>,
+     =         y = <redacted>
+
+error:  A postcondition might not hold on this return path.
+
+     ┌── tests/sources/arithm.move:108:9 ───
+     │
+ 108 │         aborts_if false;
+     │         ^^^^^^^^^^^^^^^^
+     │
+     =     at tests/sources/arithm.move:104:5: overflow_u8_add_bad (entry)
+     =     at tests/sources/arithm.move:105:11: overflow_u8_add_bad (ABORTED)
+     =         x = <redacted>,
+     =         y = <redacted>
+
+error:  A postcondition might not hold on this return path.
+
+     ┌── tests/sources/arithm.move:161:9 ───
+     │
+ 161 │         aborts_if false;
+     │         ^^^^^^^^^^^^^^^^
+     │
+     =     at tests/sources/arithm.move:157:5: overflow_u8_mul_bad (entry)
+     =     at tests/sources/arithm.move:158:11: overflow_u8_mul_bad (ABORTED)
+     =         x = <redacted>,
+     =         y = <redacted>

--- a/language/move-prover/tests/sources/arithm.move
+++ b/language/move-prover/tests/sources/arithm.move
@@ -1,19 +1,25 @@
-module TestArithmetic {
+module Arithmetic {
+
+    // --------------------------
+    // Basic arithmetic operation
+    // --------------------------
 
     // Most of the tests here just ensure that what the bytecode operation does is the same as the
     // spec expressions.
 
+    // succeeds.
 	fun add_two_number(x: u64, y: u64): (u64, u64) {
 		let res: u64 = x + y;
 		let z: u64 = 3;
 		(z, res)
 	}
 	spec fun add_two_number {
-	    aborts_if x + y > 9223372036854775807;
+	    aborts_if x + y > 18446744073709551615;
 	    ensures result_1 == 3;
 	    ensures result_2 == x + y;
 	}
 
+    // succeeds.
 	fun multiple_ops(x: u64, y: u64, z: u64): u64 {
 		x + y * z
 	}
@@ -21,6 +27,7 @@ module TestArithmetic {
         ensures result == x + y * z;
     }
 
+    // succeeds.
 	fun bool_ops(a: u64, b: u64): (bool, bool) {
         let c: bool;
         let d: bool;
@@ -34,6 +41,7 @@ module TestArithmetic {
         ensures result_2 == (a < b || a <= b);
     }
 
+    // succeeds.
 	fun arithmetic_ops(a: u64, b: u64): (u64, u64) {
         let c: u64;
         c = (6 + 4 - 1) * 2 / 3 % 4;
@@ -45,27 +53,151 @@ module TestArithmetic {
         ensures result_2 == a;
     }
 
-	fun overflow() : u64 {
-        let x = 9223372036854775807;
-        x + 1
-	}
-	spec fun overflow {
-	    aborts_if false;
-	}
 
+    // ---------
+    // Underflow
+    // ---------
+
+    // succeeds.
     fun underflow(): u64 {
         let x = 0;
         x - 1
     }
 	spec fun underflow {
-	    aborts_if false;
+	    aborts_if true;
 	}
 
-    fun div_by_zero(): u64 {
+
+    // ----------------
+    // Division by zero
+    // ----------------
+
+    // succeeds.
+    fun div_by_zero_ok(): u64 {
         let x = 0;
         1 / x
     }
-	spec fun div_by_zero {
-	    aborts_if false;
+	spec fun div_by_zero_ok {
+	    aborts_if true;
 	}
+
+    fun div_by_zero_u64_bad(x: u64, y: u64): u64 {
+        x / y
+    }
+    spec fun div_by_zero_u64_bad {
+        aborts_if false;
+    }
+
+    fun div_by_zero_u64_ok(x: u64, y: u64): u64 {
+        x / y
+    }
+    spec fun div_by_zero_u64_ok {
+        aborts_if y == 0;
+    }
+
+
+    // --------------------
+    // Overflow by addition
+    // --------------------
+
+    // fails.
+    fun overflow_u8_add_bad(x: u8, y: u8): u8 {
+        x + y
+    }
+    spec fun overflow_u8_add_bad {
+        aborts_if false;
+    }
+
+    // succeeds.
+    fun overflow_u8_add_ok(x: u8, y: u8): u8 {
+        x + y
+    }
+    spec fun overflow_u8_add_ok {
+        aborts_if x + y > 255u8; // U8_MAX
+    }
+
+    // fails.
+    fun overflow_u64_add_bad(x: u64, y: u64): u64 {
+        x + y
+    }
+    spec fun overflow_u64_add_bad {
+        aborts_if false;
+    }
+
+    // succeeds.
+    fun overflow_u64_add_ok(x: u64, y: u64): u64 {
+        x + y
+    }
+    spec fun overflow_u64_add_ok {
+        aborts_if x + y > 18446744073709551615u64; // U64_MAX
+    }
+
+    // fails.
+    fun overflow_u128_add_bad(x: u128, y: u128): u128 {
+        x + y
+    }
+    spec fun overflow_u128_add_bad {
+        aborts_if false;
+    }
+
+    // succeeds.
+    fun overflow_u128_add_ok(x: u128, y: u128): u128 {
+        x + y
+    }
+    spec fun overflow_u128_add_ok {
+        aborts_if x + y > 340282366920938463463374607431768211455u128; // U128_MAX
+    }
+
+
+    // --------------------------
+    // Overflow by multiplication
+    // --------------------------
+
+    // fails.
+    fun overflow_u8_mul_bad(x: u8, y: u8): u8 {
+        x * y
+    }
+    spec fun overflow_u8_mul_bad {
+        aborts_if false;
+    }
+
+    // succeeds.
+    fun overflow_u8_mul_ok(x: u8, y: u8): u8 {
+        x * y
+    }
+    spec fun overflow_u8_mul_ok {
+        aborts_if x * y > 255u8; // U8_MAX
+    }
+
+    // fails.
+    fun overflow_u64_mul_bad(x: u64, y: u64): u64 {
+        x * y
+    }
+    spec fun overflow_u64_mul_bad {
+        aborts_if false;
+    }
+
+    // TODO: Should succeed. JP: Prover seems to give a false counterexample.
+    fun overflow_u64_mul_ok(x: u64, y: u64): u64 {
+        x * y
+    }
+    spec fun overflow_u64_mul_ok {
+        //aborts_if x * y > 18446744073709551615u64; // U64_MAX
+    }
+
+    // fails.
+    fun overflow_u128_mul_bad(x: u128, y: u128): u128 {
+        x * y
+    }
+    spec fun overflow_u128_mul_bad {
+        aborts_if false;
+    }
+
+    // TODO: Should succeed. JP: Prover seems to give a false counterexample.
+    fun overflow_u128_mul_ok(x: u128, y: u128): u128 {
+        x * y
+    }
+    spec fun overflow_u128_mul_ok {
+        //aborts_if x * y > 340282366920938463463374607431768211455u128; // U128_MAX
+    }
 }

--- a/language/move-prover/tests/sources/defines.exp
+++ b/language/move-prover/tests/sources/defines.exp
@@ -1,1 +1,13 @@
-Move prover all good, no errors!
+Move prover returns: exiting with boogie verification errors
+error:  A postcondition might not hold on this return path.
+
+    ┌── tests/sources/defines.move:16:9 ───
+    │
+ 16 │         aborts_if !in_range(x + y, 0, 9223372036854775807);
+    │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    │
+    =     at tests/sources/defines.move:13:5: add (entry)
+    =     at tests/sources/defines.move:13:5: add (exit)
+    =         x = <redacted>,
+    =         y = <redacted>,
+    =         result = <redacted>


### PR DESCRIPTION
- Fixed the bugs in the constants MAX_U64 and MAX_U128 in Prelude
- Removed the (seemingly) deprecated functions: max_u64, and isValidInteger in Prelude
- Ported and added the test cases for arithmetic operations
- Marked two TODO test cases where Prover seems to give false counterexamples.

## Motivation

To fix some bugs in some constants in Prelude
To add tests cases for arithmetic operations

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

cargo test

## Related PRs
