### PR TITLE
[tf] Separate JSON-RPC security group and update port

### DIFF
--- a/terraform/load-balancing.tf
+++ b/terraform/load-balancing.tf
@@ -49,7 +49,7 @@ resource "aws_lb" "json-rpc" {
   ip_address_type                  = "dualstack"
   enable_cross_zone_load_balancing = true
   subnets                          = aws_subnet.testnet.*.id
-  security_groups                  = [aws_security_group.validator.id]
+  security_groups                  = [aws_security_group.jsonrpc-lb.id]
 }
 
 resource "aws_lb_target_group" "json-rpc" {

--- a/terraform/network.tf
+++ b/terraform/network.tf
@@ -124,13 +124,47 @@ resource "aws_security_group_rule" "validator-ac" {
   cidr_blocks       = concat(var.api_sources_ipv4, [aws_vpc.testnet.cidr_block])
 }
 
+resource "aws_security_group_rule" "validator-jsonrpc" {
+  security_group_id        = aws_security_group.validator.id
+  type                     = "ingress"
+  from_port                = 8080
+  to_port                  = 8080
+  protocol                 = "tcp"
+  source_security_group_id = aws_security_group.jsonrpc-lb.id
+}
+
+resource "aws_security_group" "jsonrpc-lb" {
+  name        = "${terraform.workspace}-jsonrpc-lb"
+  description = "jsonrpc-lb"
+  vpc_id      = aws_vpc.testnet.id
+}
+
 resource "aws_security_group_rule" "json-rpc" {
-  security_group_id = aws_security_group.validator.id
+  security_group_id = aws_security_group.jsonrpc-lb.id
   type              = "ingress"
-  from_port         = 8080
-  to_port           = 8080
+  from_port         = 80
+  to_port           = 80
   protocol          = "tcp"
   cidr_blocks       = concat(var.api_sources_ipv4, [aws_vpc.testnet.cidr_block])
+}
+
+resource "aws_security_group_rule" "json-rpc-https" {
+  security_group_id = aws_security_group.jsonrpc-lb.id
+  type              = "ingress"
+  from_port         = 443
+  to_port           = 443
+  protocol          = "tcp"
+  cidr_blocks       = concat(var.api_sources_ipv4, [aws_vpc.testnet.cidr_block])
+}
+
+resource "aws_security_group_rule" "jsonrpc-lb-egress" {
+  security_group_id = aws_security_group.jsonrpc-lb.id
+  type              = "egress"
+  from_port         = 0
+  to_port           = 0
+  protocol          = "-1"
+  cidr_blocks       = ["0.0.0.0/0"]
+  ipv6_cidr_blocks  = ["::/0"]
 }
 
 resource "aws_security_group_rule" "validator-host-mon" {


### PR DESCRIPTION
<!--
Thank you for sending a PR. We appreciate you spending time to help improve the Libra project.

The project is undergoing daily changes. Pull Requests will be reviewed and responded to as time permits.
-->

## Motivation

- Separate security group for JSON-RPC
- Allow traffic to port 80
- Allow traffic to port 443 (for https)

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?

Yes
## Test Plan

terraform apply on sherryxiao workspace...will update with test result later
## Related PRs

(If this PR adds or changes functionality, please take some time to update the docs at https://github.com/libra/website, and link to your PR here.)
