### PR TITLE
[consensus] [state sync] Export counter with highest committed timestamp

### DIFF
--- a/consensus/src/counters.rs
+++ b/consensus/src/counters.rs
@@ -37,6 +37,15 @@ pub static LAST_COMMITTED_VERSION: Lazy<IntGauge> = Lazy::new(|| {
     .unwrap()
 });
 
+/// The counter corresponds to the version of the last committed ledger info.
+pub static LAST_COMMITTED_TIMESTAMP: Lazy<IntGauge> = Lazy::new(|| {
+    register_int_gauge!(
+        "libra_consensus_last_committed_timestamp",
+        "The counter corresponds to the timestamp of the last committed ledger info."
+    )
+    .unwrap()
+});
+
 /// This counter is set to the round of the highest voted block.
 pub static LAST_VOTE_ROUND: Lazy<IntGauge> = Lazy::new(|| {
     register_int_gauge!(

--- a/consensus/src/state_computer.rs
+++ b/consensus/src/state_computer.rs
@@ -101,6 +101,8 @@ impl StateComputer for ExecutionProxy {
     ) -> Result<()> {
         let version = finality_proof.ledger_info().version();
         counters::LAST_COMMITTED_VERSION.set(version as i64);
+        let timestamp = finality_proof.ledger_info().timestamp_usecs();
+        counters::LAST_COMMITTED_TIMESTAMP.set(timestamp as i64);
 
         let pre_commit_instant = Instant::now();
 

--- a/state-synchronizer/src/coordinator.rs
+++ b/state-synchronizer/src/coordinator.rs
@@ -340,6 +340,8 @@ impl<T: ExecutorProxyTrait> SyncCoordinator<T> {
         self.sync_state_with_local_storage().await?;
         let local_version = self.local_state.highest_version_in_local_storage();
         counters::COMMITTED_VERSION.set(local_version as i64);
+        let local_timestamp = self.local_state.highest_local_timestamp();
+        counters::COMMITTED_TIMESTAMP.set(local_timestamp as i64);
         let block_timestamp_usecs = self
             .local_state
             .highest_local_li

--- a/state-synchronizer/src/counters.rs
+++ b/state-synchronizer/src/counters.rs
@@ -86,6 +86,15 @@ pub static COMMITTED_VERSION: Lazy<IntGauge> = Lazy::new(|| {
     .unwrap()
 });
 
+/// Most recent version that has been committed
+pub static COMMITTED_TIMESTAMP: Lazy<IntGauge> = Lazy::new(|| {
+    register_int_gauge!(
+        "libra_state_sync_committed_timestamp",
+        "Most recent timestamp that has been committed"
+    )
+    .unwrap()
+});
+
 /// How long it takes to make progress, from requesting a chunk to processing the response and
 /// committing the block
 pub static SYNC_PROGRESS_DURATION: Lazy<DurationHistogram> = Lazy::new(|| {

--- a/state-synchronizer/src/lib.rs
+++ b/state-synchronizer/src/lib.rs
@@ -69,6 +69,10 @@ impl SynchronizerState {
         }
     }
 
+    pub fn highest_local_timestamp(&self) -> u64 {
+        self.highest_local_li.timestamp_usecs()
+    }
+
     /// The highest available version in the local storage (even if it's not covered by the LI).
     pub fn highest_version_in_local_storage(&self) -> u64 {
         self.synced_trees.version().unwrap_or(0)


### PR DESCRIPTION
Analyzing this counter will help understanding timestamp lag between different validators and between validator and fullnode
