### PR TITLE
Prototype for safety rules counters

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4533,6 +4533,7 @@ dependencies = [
  "serde 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)",
  "tempfile 3.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "thiserror 1.0.11 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ureq 0.11.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "workspace-builder 0.1.0",
 ]
 

--- a/consensus/safety-rules/Cargo.toml
+++ b/consensus/safety-rules/Cargo.toml
@@ -20,6 +20,7 @@ libra-types = { path = "../../types", version = "0.1.0" }
 serde = { version = "1.0.99", default-features = false }
 thiserror = "1.0"
 workspace-builder = { path = "../../common/workspace-builder", version = "0.1.0" }
+ureq = { version = "0.11.3", features = ["json"] }
 
 [dev-dependencies]
 criterion = "0.3"

--- a/consensus/safety-rules/src/counters.rs
+++ b/consensus/safety-rules/src/counters.rs
@@ -1,0 +1,28 @@
+use crate::simple_push_metrics::{Counter, Metrics, SerCounter};
+use std::sync::atomic::{AtomicI64, Ordering};
+
+pub struct SafetyRulesMetrics {
+    pub num_requests_received: Counter,
+    pub num_responses_sent: Counter,
+}
+
+impl SafetyRulesMetrics {
+    pub fn new() -> Self {
+        Self {
+            num_requests_received: Counter {
+                counter_name: "num_requests_received".to_string(),
+                counter: AtomicI64::new(0),
+            },
+            num_responses_sent: Counter {
+                counter_name: "num_responses_sent".to_string(),
+                counter: AtomicI64::new(0),
+            },
+        }
+    }
+}
+
+impl Metrics for SafetyRulesMetrics {
+    fn get_metrics(&self) -> Vec<&Counter> {
+        vec![&self.num_requests_received, &self.num_responses_sent]
+    }
+}

--- a/consensus/safety-rules/src/lib.rs
+++ b/consensus/safety-rules/src/lib.rs
@@ -4,6 +4,7 @@
 #![forbid(unsafe_code)]
 
 mod consensus_state;
+pub mod counters;
 mod error;
 mod local_client;
 mod persistent_safety_storage;
@@ -12,6 +13,7 @@ mod remote_service;
 mod safety_rules;
 mod safety_rules_manager;
 mod serializer;
+pub mod simple_push_metrics;
 mod spawned_process;
 mod t_safety_rules;
 mod thread;

--- a/consensus/safety-rules/src/simple_push_metrics.rs
+++ b/consensus/safety-rules/src/simple_push_metrics.rs
@@ -1,0 +1,50 @@
+use std::{
+    sync::{
+        atomic::{AtomicI64, Ordering},
+        Arc, Mutex,
+    },
+    thread,
+    thread::JoinHandle,
+    time::Duration,
+};
+
+pub struct Counter {
+    pub counter_name: String,
+    pub counter: AtomicI64,
+}
+
+pub struct SerCounter {
+    pub counter_name: String,
+    pub counter: i64,
+}
+
+pub trait Metrics {
+    fn get_metrics(&self) -> Vec<&Counter>;
+}
+
+pub struct CountersPusher {}
+
+impl CountersPusher {
+    pub fn start(&self, metrics: Arc<dyn Metrics + Send + Sync>) -> JoinHandle<()> {
+        thread::spawn(move || loop {
+            let mut data = "".to_string();
+            for metric in metrics.get_metrics() {
+                let metric_data = format!(
+                    "{} {}\n",
+                    metric.counter_name,
+                    metric.counter.load(Ordering::SeqCst)
+                );
+                data.push_str(&metric_data);
+            }
+            let response = ureq::post("http://pushgateway.example.org:9091/metrics/job/safety_rules")
+              .timeout_connect(10_000)
+              .send_string(&data);
+            if response.ok() {
+                println!("Ok")
+            } else {
+                println!("Error")
+            }
+            thread::sleep(Duration::from_secs(10));
+        })
+    }
+}


### PR DESCRIPTION
## Summary

`safety-rules/src/counters.rs` defines counters tracked by safety rules

`consensus/safety-rules/src/simple_push_metrics.rs` is a general push metrics client which pushes metrics to a prometheus pushgateway

This is a very quick prototype of one way on how we can have counters in safety rules servers. Counters are pushed to Prometheus every 10 seconds 

PR Only intended for discussion. Not planning to land.