### PR TITLE
[compiler] remove unused field: stdlib_address

### DIFF
--- a/language/compiler/src/lib.rs
+++ b/language/compiler/src/lib.rs
@@ -31,8 +31,6 @@ pub struct Compiler {
     pub address: AccountAddress,
     /// Skip stdlib dependencies if true.
     pub skip_stdlib_deps: bool,
-    /// The address to use for stdlib.
-    pub stdlib_address: AccountAddress,
     /// Extra dependencies to compile with.
     pub extra_deps: Vec<VerifiedModule>,
 


### PR DESCRIPTION
<!--
Thank you for sending a PR. We appreciate you spending time to help improve the Libra project.

The project is undergoing daily changes. Pull Requests will be reviewed and responded to as time permits.
-->

## Motivation

Stdlib address is a constant. The `stdlib_address` field is never used.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?

Yes.
## Test Plan

(Share your test plan here. If you changed code, please provide us with clear instructions for verifying that your changes work.)
cargo xtest
## Related PRs

(If this PR adds or changes functionality, please take some time to update the docs at https://github.com/libra/website, and link to your PR here.)
