### PR TITLE
[JSON RPC] add error support for VM errors & update sequence number in CLI for old txn submission

### DIFF
--- a/json-rpc/src/errors.rs
+++ b/json-rpc/src/errors.rs
@@ -21,7 +21,7 @@ pub enum ServerCode {
 }
 
 #[derive(Clone, Debug, Deserialize, Serialize)]
-pub(crate) struct JsonRpcError {
+pub struct JsonRpcError {
     pub code: i16,
     pub message: String,
     pub data: Option<Value>,
@@ -89,5 +89,14 @@ impl JsonRpcError {
             message: format!("Server error: VM {} error: {:?}", vm_status_type, error),
             data: Some(serde_json::json!(error)),
         }
+    }
+
+    pub fn get_vm_error(&self) -> Option<VMStatus> {
+        if let Some(data) = &self.data {
+            if let Ok(vm_error) = serde_json::from_value::<VMStatus>(data.clone()) {
+                return Some(vm_error);
+            }
+        }
+        None
     }
 }

--- a/json-rpc/src/errors.rs
+++ b/json-rpc/src/errors.rs
@@ -1,0 +1,93 @@
+// Copyright (c) The Libra Core Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+use libra_types::vm_error::{StatusType, VMStatus};
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+
+/// Custom JSON RPC server error codes
+/// Ranges from -32000 to -32099 - see `https://www.jsonrpc.org/specification#error_object` for details
+pub enum ServerCode {
+    DefaultServerError = -32000,
+
+    // expose VM status types as server code
+    VmValidationError = -32001,
+    VmVerificationError = -32002,
+    VmInvariantViolationError = -32003,
+    VmDeserializationError = -32004,
+    VmExecutionError = -32005,
+    VmUnknownError = -32006,
+    // TODO expose Mempool insertion status as server code
+}
+
+#[derive(Clone, Debug, Deserialize, Serialize)]
+pub(crate) struct JsonRpcError {
+    pub code: i16,
+    pub message: String,
+    pub data: Option<Value>,
+}
+
+impl std::error::Error for JsonRpcError {}
+
+impl std::fmt::Display for JsonRpcError {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        write!(f, "{:?}", self)
+    }
+}
+
+impl JsonRpcError {
+    pub(crate) fn serialize(self) -> Value {
+        serde_json::to_value(self).unwrap_or(Value::Null)
+    }
+
+    pub(crate) fn invalid_request() -> Self {
+        Self {
+            code: -32600,
+            message: "Invalid Request".to_string(),
+            data: None,
+        }
+    }
+
+    pub(crate) fn invalid_params() -> Self {
+        Self {
+            code: -32602,
+            message: "Invalid params".to_string(),
+            data: None,
+        }
+    }
+
+    pub(crate) fn method_not_found() -> Self {
+        Self {
+            code: -32601,
+            message: "Method not found".to_string(),
+            data: None,
+        }
+    }
+
+    pub(crate) fn internal_error(message: String) -> Self {
+        Self {
+            code: ServerCode::DefaultServerError as i16,
+            message: format!("Server error: {}", message),
+            data: None,
+        }
+    }
+
+    pub(crate) fn vm_error(error: VMStatus) -> Self {
+        // map VM status to custom server code
+        let vm_status_type = error.status_type();
+        let code = match vm_status_type {
+            StatusType::Validation => ServerCode::VmValidationError,
+            StatusType::Verification => ServerCode::VmVerificationError,
+            StatusType::InvariantViolation => ServerCode::VmInvariantViolationError,
+            StatusType::Deserialization => ServerCode::VmDeserializationError,
+            StatusType::Execution => ServerCode::VmExecutionError,
+            StatusType::Unknown => ServerCode::VmUnknownError,
+        };
+
+        Self {
+            code: code as i16,
+            message: format!("Server error: VM {} error: {:?}", vm_status_type, error),
+            data: Some(serde_json::json!(error)),
+        }
+    }
+}

--- a/json-rpc/src/lib.rs
+++ b/json-rpc/src/lib.rs
@@ -18,6 +18,7 @@
 mod util;
 
 mod client;
+mod errors;
 mod methods;
 mod runtime;
 pub mod views;

--- a/json-rpc/src/lib.rs
+++ b/json-rpc/src/lib.rs
@@ -18,7 +18,7 @@
 mod util;
 
 mod client;
-mod errors;
+pub mod errors;
 mod methods;
 mod runtime;
 pub mod views;

--- a/types/src/vm_error.rs
+++ b/types/src/vm_error.rs
@@ -8,7 +8,7 @@ use anyhow::{Error, Result};
 use proptest::prelude::*;
 #[cfg(any(test, feature = "fuzzing"))]
 use proptest_derive::Arbitrary;
-use serde::{de, ser};
+use serde::{de, ser, Deserialize, Serialize};
 use std::{convert::TryFrom, fmt};
 
 /// The minimum status code for validation statuses
@@ -43,7 +43,7 @@ pub static EXECUTION_STATUS_MAX_CODE: u64 = 4999;
 
 /// A `VMStatus` is represented as a required major status that is semantic coupled with with
 /// an optional sub status and message.
-#[derive(Clone, PartialEq, Eq, PartialOrd, Ord, Debug, Hash)]
+#[derive(Clone, PartialEq, Eq, PartialOrd, Ord, Debug, Hash, Serialize, Deserialize)]
 #[cfg_attr(any(test, feature = "fuzzing"), derive(Arbitrary))]
 #[cfg_attr(any(test, feature = "fuzzing"), proptest(no_params))]
 pub struct VMStatus {


### PR DESCRIPTION
## Motivation

In CLI, add functionality s.t. we reset sequence number when txn with old sequence number is submitted
To do so, this PR also adds support for exposing VM errors as JSON RPC errors

## Test Plan
Tested on local swarm CLI that client can submit more transactions even after submitting txn with old sequence number