### PR TITLE
[move-prover] Added some builtin functions to specification language

### DIFF
--- a/language/move-prover/spec-lang/src/ast.rs
+++ b/language/move-prover/spec-lang/src/ast.rs
@@ -147,6 +147,10 @@ pub enum Operation {
     Exists,
     Old,
     Update,
+    Sender,
+    MaxU8,
+    MaxU64,
+    MaxU128,
 }
 
 #[derive(Debug)]

--- a/language/move-prover/spec-lang/src/translate.rs
+++ b/language/move-prover/spec-lang/src/translate.rs
@@ -353,6 +353,56 @@ impl<'env> Translator<'env> {
             let pred_t = &Type::Fun(vec![param_t.clone()], Box::new(bool_t.clone()));
             let pred_num_t = &Type::Fun(vec![num_t.clone()], Box::new(bool_t.clone()));
 
+            // Transaction metadata
+            add_builtin(
+                self,
+                self.builtin_fun_symbol("sender"),
+                SpecFunEntry {
+                    loc: loc.clone(),
+                    oper: Operation::Sender,
+                    type_params: vec![],
+                    arg_types: vec![],
+                    result_type: address_t.clone(),
+                },
+            );
+
+            // constants (max_u8(), etc.)
+            add_builtin(
+                self,
+                self.builtin_fun_symbol("max_u8"),
+                SpecFunEntry {
+                    loc: loc.clone(),
+                    oper: Operation::MaxU8,
+                    type_params: vec![],
+                    arg_types: vec![],
+                    result_type: num_t.clone(),
+                },
+            );
+
+            add_builtin(
+                self,
+                self.builtin_fun_symbol("max_u64"),
+                SpecFunEntry {
+                    loc: loc.clone(),
+                    oper: Operation::MaxU64,
+                    type_params: vec![],
+                    arg_types: vec![],
+                    result_type: num_t.clone(),
+                },
+            );
+
+            add_builtin(
+                self,
+                self.builtin_fun_symbol("max_u128"),
+                SpecFunEntry {
+                    loc: loc.clone(),
+                    oper: Operation::MaxU128,
+                    type_params: vec![],
+                    arg_types: vec![],
+                    result_type: num_t.clone(),
+                },
+            );
+
             // Vectors
             add_builtin(
                 self,

--- a/language/move-prover/src/prelude.bpl
+++ b/language/move-prover/src/prelude.bpl
@@ -419,6 +419,10 @@ function {:inline} $ExistsTxnSenderAccount(m: Memory, txn: Transaction): bool {
    domain#Memory(m)[Global(LibraAccount_T_type_value(), sender#Transaction(txn))]
 }
 
+function {:inline} $TxnSender(txn: Transaction): Value {
+    Address(sender#Transaction(txn))
+}
+
 // Forward declaration of type value of LibraAccount. This is declared so we can define
 // ExistsTxnSenderAccount.
 function LibraAccount_T_type_value(): TypeValue;
@@ -470,7 +474,6 @@ procedure {:inline 1} MoveFrom(address: Value, ta: TypeValue) returns (dst: Valu
 procedure {:inline 1} BorrowGlobal(address: Value, ta: TypeValue) returns (dst: Reference)
 {
     var a: int;
-    var v: Value;
     var l: Location;
     assume is#Address(address);
     a := a#Address(address);
@@ -757,7 +760,7 @@ procedure {:inline 1} GetTxnPublicKey() returns (ret_public_key: Value)
 
 procedure {:inline 1} GetTxnSenderAddress() returns (ret_sender: Value)
 {
-  ret_sender := Address(sender#Transaction($txn));
+  ret_sender := $TxnSender($txn);
 }
 
 procedure {:inline 1} GetTxnMaxGasUnits() returns (ret_max_gas_units: Value)

--- a/language/move-prover/src/spec_translator.rs
+++ b/language/move-prover/src/spec_translator.rs
@@ -575,10 +575,14 @@ impl<'env> SpecTranslator<'env> {
             Operation::Global => self.translate_resource_access(node_id, args),
             Operation::Exists => self.translate_resource_exists(node_id, args),
             Operation::Len => self.translate_primitive_call("$vlen_value", args),
+            Operation::Sender => emit!(self.writer, "$TxnSender($txn)"),
             Operation::All => self.translate_all_or_exists(&loc, true, args),
             Operation::Any => self.translate_all_or_exists(&loc, false, args),
             Operation::Update => self.translate_primitive_call("$update_vector", args),
             Operation::Old => self.translate_old(args),
+            Operation::MaxU8 => emit!(self.writer, "Integer(MAX_U8)"),
+            Operation::MaxU64 => emit!(self.writer, "Integer(MAX_U64)"),
+            Operation::MaxU128 => emit!(self.writer, "Integer(MAX_U128)"),
         }
     }
 

--- a/language/move-prover/tests/sources/arithm.move
+++ b/language/move-prover/tests/sources/arithm.move
@@ -14,7 +14,7 @@ module Arithmetic {
 		(z, res)
 	}
 	spec fun add_two_number {
-	    aborts_if x + y > 18446744073709551615;
+	    aborts_if x + y > max_u64();
 	    ensures result_1 == 3;
 	    ensures result_2 == x + y;
 	}
@@ -113,7 +113,7 @@ module Arithmetic {
         x + y
     }
     spec fun overflow_u8_add_ok {
-        aborts_if x + y > 255u8; // U8_MAX
+        aborts_if x + y > max_u8();
     }
 
     // fails.
@@ -129,7 +129,7 @@ module Arithmetic {
         x + y
     }
     spec fun overflow_u64_add_ok {
-        aborts_if x + y > 18446744073709551615u64; // U64_MAX
+        aborts_if x + y > max_u64();
     }
 
     // fails.
@@ -145,7 +145,7 @@ module Arithmetic {
         x + y
     }
     spec fun overflow_u128_add_ok {
-        aborts_if x + y > 340282366920938463463374607431768211455u128; // U128_MAX
+        aborts_if x + y > max_u128();
     }
 
 
@@ -166,7 +166,7 @@ module Arithmetic {
         x * y
     }
     spec fun overflow_u8_mul_ok {
-        aborts_if x * y > 255u8; // U8_MAX
+        aborts_if x * y > max_u8();
     }
 
     // fails.
@@ -182,7 +182,7 @@ module Arithmetic {
         x * y
     }
     spec fun overflow_u64_mul_ok {
-        //aborts_if x * y > 18446744073709551615u64; // U64_MAX
+        //aborts_if x * y > max_u64();
     }
 
     // fails.
@@ -198,6 +198,6 @@ module Arithmetic {
         x * y
     }
     spec fun overflow_u128_mul_ok {
-        //aborts_if x * y > 340282366920938463463374607431768211455u128; // U128_MAX
+        //aborts_if x * y > max_u128(); // U128_MAX
     }
 }

--- a/language/move-prover/tests/sources/defines.exp
+++ b/language/move-prover/tests/sources/defines.exp
@@ -9,5 +9,4 @@ error:  A postcondition might not hold on this return path.
     =     at tests/sources/defines.move:13:5: add (entry)
     =     at tests/sources/defines.move:13:5: add (exit)
     =         x = <redacted>,
-    =         y = <redacted>,
-    =         result = <redacted>
+    =         y = <redacted>

--- a/language/move-prover/tests/sources/txn.exp
+++ b/language/move-prover/tests/sources/txn.exp
@@ -1,0 +1,1 @@
+Move prover all good, no errors!

--- a/language/move-prover/tests/sources/txn.move
+++ b/language/move-prover/tests/sources/txn.move
@@ -1,0 +1,25 @@
+// dep: ../stdlib/modules/transaction.move
+address 0x0:
+
+module Txn {
+    use 0x0::Transaction;
+
+    resource struct T {
+        value: u128,
+    }
+
+    fun check_sender1() {
+        Transaction::assert(Transaction::sender() == 0xdeadbeef, 1);
+    }
+    spec fun check_sender1 {
+        aborts_if sender() != 0xdeadbeef;
+    }
+
+
+    fun check_sender2() acquires T {
+	borrow_global<T>(Transaction::sender());
+    }
+    spec fun check_sender2 {
+        aborts_if !exists<T>(sender());
+    }
+}


### PR DESCRIPTION
Added "sender()", which returns the transaction sender address.

Added "max_u8()", "max_u64()", "max_u128()", which return the maximum values for each integer length.

Changed tests/sources/arithm.m to use the new MAX functions.

Added tests/sources/txn.m to test sender().

<!--
Thank you for sending a PR. We appreciate you spending time to help improve the Libra project.

The project is undergoing daily changes. Pull Requests will be reviewed and responded to as time permits.
-->

## Motivation

(Write your motivation for proposed changes here.)

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?

(Write your answer here.)

## Test Plan

(Share your test plan here. If you changed code, please provide us with clear instructions for verifying that your changes work.)

## Related PRs

(If this PR adds or changes functionality, please take some time to update the docs at https://github.com/libra/website, and link to your PR here.)
