### PR TITLE
Key manager

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2446,6 +2446,7 @@ version = "0.1.0"
 dependencies = [
  "config-builder 0.1.0",
  "executor 0.1.0",
+ "executor-types 0.1.0",
  "libra-config 0.1.0",
  "libra-crypto 0.1.0",
  "libra-logger 0.1.0",
@@ -2454,6 +2455,7 @@ dependencies = [
  "libra-types 0.1.0",
  "libra-vm 0.1.0",
  "libradb 0.1.0",
+ "rand 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "storage-client 0.1.0",
  "storage-service 0.1.0",
  "tokio 0.2.13 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2441,6 +2441,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "libra-key-manager"
+version = "0.1.0"
+dependencies = [
+ "config-builder 0.1.0",
+ "executor 0.1.0",
+ "libra-config 0.1.0",
+ "libra-crypto 0.1.0",
+ "libra-logger 0.1.0",
+ "libra-secure-storage 0.1.0",
+ "libra-transaction-scripts 0.1.0",
+ "libra-types 0.1.0",
+ "libra-vm 0.1.0",
+ "libradb 0.1.0",
+ "storage-client 0.1.0",
+ "storage-service 0.1.0",
+ "tokio 0.2.13 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "libra-logger"
 version = "0.1.0"
 dependencies = [

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2657,6 +2657,14 @@ dependencies = [
 ]
 
 [[package]]
+name = "libra-transaction-scripts"
+version = "0.1.0"
+dependencies = [
+ "include_dir 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "once_cell 1.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "libra-types"
 version = "0.1.0"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -83,6 +83,7 @@ members = [
     "mempool",
     "secure/net",
     "secure/storage",
+    "secure/transaction-scripts",
     "state-synchronizer",
     "storage/accumulator",
     "storage/backup-restore",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -81,6 +81,7 @@ members = [
     "network/noise",
     "network/socket-bench-server",
     "mempool",
+    "secure/key-manager",
     "secure/net",
     "secure/storage",
     "secure/transaction-scripts",

--- a/config/src/config/test_config.rs
+++ b/config/src/config/test_config.rs
@@ -14,9 +14,9 @@ type ConsensusKeyPair = KeyPair<Ed25519PrivateKey>;
 #[derive(Debug, Default, Deserialize, Serialize)]
 pub struct TestConfig {
     pub account_keypair: Option<AccountKeyPair>,
+    pub consensus_keypair: Option<ConsensusKeyPair>,
     // Used only to prevent a potentially temporary data_dir from being deleted. This should
     // eventually be moved to be owned by something outside the config.
-    pub consensus_keypair: Option<ConsensusKeyPair>,
     #[serde(skip)]
     temp_dir: Option<TempPath>,
 }

--- a/secure/key-manager/Cargo.toml
+++ b/secure/key-manager/Cargo.toml
@@ -17,10 +17,12 @@ libra-transaction-scripts = { path = "../transaction-scripts", version = "0.1.0"
 libra-types = { path = "../../types", version = "0.1.0" }
 
 [dev-dependencies]
+rand = "0.6.5"
 tokio = { version = "0.2.12", features = ["full"] }
 
 config-builder = { path = "../../config/config-builder", version = "0.1.0" }
 executor = { path = "../../execution/executor", version = "0.1.0" }
+executor-types = { path = "../../execution/executor-types", version = "0.1.0" }
 libradb = { path = "../../storage/libradb", version = "0.1.0" }
 libra-config = { path = "../../config", version = "0.1.0" }
 libra-vm = { path = "../../language/libra-vm", version = "0.1.0" }

--- a/secure/key-manager/Cargo.toml
+++ b/secure/key-manager/Cargo.toml
@@ -1,0 +1,28 @@
+[package]
+name = "libra-key-manager"
+version = "0.1.0"
+edition = "2018"
+authors = ["Libra Association <opensource@libra.org>"]
+description = "Libra Key Manager"
+repository = "https://github.com/libra/libra"
+homepage = "https://libra.org"
+license = "Apache-2.0"
+publish = false
+
+[dependencies]
+libra-crypto = { path = "../../crypto/crypto", version = "0.1.0" }
+libra-logger = { path = "../../common/logger", version = "0.1.0" }
+libra-secure-storage = { path = "../../secure/storage", version = "0.1.0" }
+libra-transaction-scripts = { path = "../transaction-scripts", version = "0.1.0" }
+libra-types = { path = "../../types", version = "0.1.0" }
+
+[dev-dependencies]
+tokio = { version = "0.2.12", features = ["full"] }
+
+config-builder = { path = "../../config/config-builder", version = "0.1.0" }
+executor = { path = "../../execution/executor", version = "0.1.0" }
+libradb = { path = "../../storage/libradb", version = "0.1.0" }
+libra-config = { path = "../../config", version = "0.1.0" }
+libra-vm = { path = "../../language/libra-vm", version = "0.1.0" }
+storage-client = { path = "../../storage/storage-client", version = "0.1.0" }
+storage-service = { path = "../../storage/storage-service", version = "0.1.0" }

--- a/secure/key-manager/src/lib.rs
+++ b/secure/key-manager/src/lib.rs
@@ -3,5 +3,50 @@
 
 #![forbid(unsafe_code)]
 
+use libra_crypto::{
+    ed25519::{Ed25519PrivateKey, Ed25519PublicKey},
+    PrivateKey,
+};
+use libra_transaction_scripts;
+use libra_types::{
+    account_address::AccountAddress,
+    transaction::{RawTransaction, Script, Transaction, TransactionArgument},
+};
+use std::time::{Duration, SystemTime};
+
 #[cfg(test)]
 mod tests;
+
+const GAS_UNIT_PRICE: u64 = 0;
+const MAX_GAS_AMOUNT: u64 = 400_000;
+const TXN_EXPIRATION: u64 = 100;
+
+fn expiration_time(until: u64) -> Duration {
+    let now = SystemTime::now()
+        .duration_since(SystemTime::UNIX_EPOCH)
+        .unwrap()
+        .as_secs();
+    std::time::Duration::from_secs(now + until)
+}
+
+pub fn build_transaction(
+    sender: AccountAddress,
+    seq_id: u64,
+    signing_key: &Ed25519PrivateKey,
+    new_key: &Ed25519PublicKey,
+) -> Transaction {
+    let script = Script::new(
+        libra_transaction_scripts::ROTATE_CONSENSUS_PUBKEY_TXN.clone(),
+        vec![TransactionArgument::U8Vector(new_key.to_bytes().to_vec())],
+    );
+    let raw_txn = RawTransaction::new_script(
+        sender,
+        seq_id,
+        script,
+        MAX_GAS_AMOUNT,
+        GAS_UNIT_PRICE,
+        expiration_time(TXN_EXPIRATION),
+    );
+    let signed_txn = raw_txn.sign(signing_key, signing_key.public_key()).unwrap();
+    Transaction::UserTransaction(signed_txn.into_inner())
+}

--- a/secure/key-manager/src/lib.rs
+++ b/secure/key-manager/src/lib.rs
@@ -1,0 +1,7 @@
+// Copyright (c) The Libra Core Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+#![forbid(unsafe_code)]
+
+#[cfg(test)]
+mod tests;

--- a/secure/key-manager/src/tests.rs
+++ b/secure/key-manager/src/tests.rs
@@ -1,0 +1,84 @@
+// Copyright (c) The Libra Core Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+use executor::Executor;
+use libra_config::config::NodeConfig;
+use libra_crypto::ed25519::Ed25519PublicKey;
+use libra_types::{
+    account_address::AccountAddress, account_config, account_state::AccountState,
+    discovery_set::DiscoverySet, validator_config::ValidatorConfig, validator_set::ValidatorSet,
+};
+use libra_vm::LibraVM;
+use libradb::{LibraDB, LibraDBTrait};
+use std::{convert::TryFrom, sync::Arc};
+use storage_client::{StorageReadServiceClient, StorageWriteServiceClient};
+use tokio::runtime::Runtime;
+
+struct Node {
+    _executor: Arc<Executor<LibraVM>>,
+    storage: Arc<LibraDB>,
+    _storage_service: Runtime,
+}
+
+fn setup(config: &NodeConfig) -> Node {
+    let storage = storage_service::init_libra_db(config);
+    let storage_service = storage_service::start_storage_service_with_db(&config, storage.clone());
+    let executor = Arc::new(Executor::new(
+        Arc::new(StorageReadServiceClient::new(&config.storage.address)),
+        Arc::new(StorageWriteServiceClient::new(&config.storage.address)),
+        config,
+    ));
+
+    Node {
+        _executor: executor,
+        storage,
+        _storage_service: storage_service,
+    }
+}
+
+fn get_discovery_set(storage: &Arc<LibraDB>) -> DiscoverySet {
+    let account = account_config::discovery_set_address();
+    let blob = storage.get_latest_account_state(account).unwrap().unwrap();
+    let account_state = AccountState::try_from(&blob).unwrap();
+    account_state
+        .get_discovery_set_resource()
+        .unwrap()
+        .unwrap()
+        .discovery_set()
+        .clone()
+}
+
+fn get_validator_config(storage: &Arc<LibraDB>, account: AccountAddress) -> ValidatorConfig {
+    let blob = storage.get_latest_account_state(account).unwrap().unwrap();
+    let account_state: AccountState = AccountState::try_from(&blob).unwrap();
+    account_state
+        .get_validator_config_resource()
+        .unwrap()
+        .unwrap()
+        .validator_config
+}
+
+fn get_validator_set(storage: &Arc<LibraDB>) -> ValidatorSet<Ed25519PublicKey> {
+    let account = account_config::validator_set_address();
+    let blob = storage.get_latest_account_state(account).unwrap().unwrap();
+    let account_state = AccountState::try_from(&blob).unwrap();
+    account_state
+        .get_validator_set_resource()
+        .unwrap()
+        .unwrap()
+        .validator_set()
+        .clone()
+}
+
+#[test]
+// This simple test just proves that genesis took effect and the values are in storage
+fn test() {
+    let (config, _genesis_key) = config_builder::test_config();
+    let node = setup(&config);
+
+    let validator_address = config.validator_network.unwrap().peer_id;
+
+    get_discovery_set(&node.storage);
+    get_validator_config(&node.storage, validator_address);
+    get_validator_set(&node.storage);
+}

--- a/secure/key-manager/src/tests.rs
+++ b/secure/key-manager/src/tests.rs
@@ -2,20 +2,34 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use executor::Executor;
+use executor_types::ExecutedTrees;
 use libra_config::config::NodeConfig;
-use libra_crypto::ed25519::Ed25519PublicKey;
+use libra_crypto::{
+    ed25519::{Ed25519PrivateKey, Ed25519PublicKey},
+    HashValue, PrivateKey, Uniform,
+};
 use libra_types::{
-    account_address::AccountAddress, account_config, account_state::AccountState,
-    discovery_set::DiscoverySet, validator_config::ValidatorConfig, validator_set::ValidatorSet,
+    account_address::AccountAddress,
+    account_config,
+    account_state::AccountState,
+    block_info::BlockInfo,
+    block_metadata::BlockMetadata,
+    discovery_set::DiscoverySet,
+    ledger_info::{LedgerInfo, LedgerInfoWithSignatures},
+    transaction::Transaction,
+    validator_config::ValidatorConfig,
+    validator_set::ValidatorSet,
 };
 use libra_vm::LibraVM;
 use libradb::{LibraDB, LibraDBTrait};
-use std::{convert::TryFrom, sync::Arc};
+use rand::{rngs::StdRng, SeedableRng};
+use std::{collections::BTreeMap, convert::TryFrom, sync::Arc};
 use storage_client::{StorageReadServiceClient, StorageWriteServiceClient};
 use tokio::runtime::Runtime;
 
 struct Node {
-    _executor: Arc<Executor<LibraVM>>,
+    account: AccountAddress,
+    executor: Arc<Executor<LibraVM>>,
     storage: Arc<LibraDB>,
     _storage_service: Runtime,
 }
@@ -30,7 +44,8 @@ fn setup(config: &NodeConfig) -> Node {
     ));
 
     Node {
-        _executor: executor,
+        account: config.validator_network.as_ref().unwrap().peer_id,
+        executor,
         storage,
         _storage_service: storage_service,
     }
@@ -50,7 +65,7 @@ fn get_discovery_set(storage: &Arc<LibraDB>) -> DiscoverySet {
 
 fn get_validator_config(storage: &Arc<LibraDB>, account: AccountAddress) -> ValidatorConfig {
     let blob = storage.get_latest_account_state(account).unwrap().unwrap();
-    let account_state: AccountState = AccountState::try_from(&blob).unwrap();
+    let account_state = AccountState::try_from(&blob).unwrap();
     account_state
         .get_validator_config_resource()
         .unwrap()
@@ -70,15 +85,80 @@ fn get_validator_set(storage: &Arc<LibraDB>) -> ValidatorSet<Ed25519PublicKey> {
         .clone()
 }
 
+fn execute_and_commit(node: &Node, mut block: Vec<Transaction>) {
+    let block_id = HashValue::zero();
+    let startup_info = node.storage.get_startup_info().unwrap().unwrap();
+    let clock = startup_info.committed_tree_state.version + 1;
+    let committed_trees = ExecutedTrees::from(startup_info.committed_tree_state);
+
+    // This will set the current clock to be equal to the current version + 1, this guarantees that
+    // the clock is always refreshed for this set of transactions.
+    let block_metadata = BlockMetadata::new(block_id, clock, BTreeMap::new(), node.account);
+    let prologue = Transaction::BlockMetadata(block_metadata);
+    block.insert(0, prologue);
+
+    let output = node
+        .executor
+        .execute_block(block_id, block.clone(), &committed_trees, &committed_trees)
+        .unwrap();
+
+    let root_hash = output.accu_root();
+    let version = output.version().unwrap();
+    let ledger_info = LedgerInfo::new(
+        BlockInfo::new(0, 0, block_id, root_hash, version, 0, None),
+        HashValue::zero(),
+    );
+    let ledger_info_with_sigs = LedgerInfoWithSignatures::new(ledger_info, BTreeMap::new());
+    let executed_block = vec![(block, Arc::new(output))];
+
+    node.executor
+        .commit_blocks(executed_block, ledger_info_with_sigs, &committed_trees)
+        .unwrap();
+}
+
 #[test]
 // This simple test just proves that genesis took effect and the values are in storage
 fn test() {
     let (config, _genesis_key) = config_builder::test_config();
     let node = setup(&config);
 
-    let validator_address = config.validator_network.unwrap().peer_id;
-
     get_discovery_set(&node.storage);
-    get_validator_config(&node.storage, validator_address);
+    get_validator_config(&node.storage, node.account);
     get_validator_set(&node.storage);
+}
+
+#[test]
+// This test verifies that a node can rotate its key and it results in a new validator set
+fn test_consensus_rotation() {
+    let (config, _genesis_key) = config_builder::test_config();
+    let node = setup(&config);
+
+    let test_config = config.test.unwrap();
+    let mut keypair = test_config.consensus_keypair.unwrap();
+
+    let genesis_prikey = keypair.take_private().unwrap();
+    let genesis_pubkey = genesis_prikey.public_key();
+    let account_prikey = test_config.account_keypair.unwrap().take_private().unwrap();
+
+    let genesis_config = get_validator_config(&node.storage, node.account);
+    let genesis_set = get_validator_set(&node.storage);
+
+    assert_eq!(genesis_pubkey, genesis_config.consensus_pubkey);
+    assert_eq!(&genesis_pubkey, genesis_set[0].consensus_public_key());
+    assert_eq!(&node.account, genesis_set[0].account_address());
+
+    let mut rng = StdRng::from_seed([44u8; 32]);
+    let new_prikey = Ed25519PrivateKey::generate_for_testing(&mut rng);
+    let new_pubkey = new_prikey.public_key();
+
+    let txn = crate::build_transaction(node.account, 0, &account_prikey, &new_pubkey);
+
+    execute_and_commit(&node, vec![txn]);
+
+    let new_config = get_validator_config(&node.storage, node.account);
+    let new_set = get_validator_set(&node.storage);
+
+    assert!(new_pubkey != genesis_pubkey);
+    assert_eq!(new_pubkey, new_config.consensus_pubkey);
+    assert_eq!(&new_pubkey, new_set[0].consensus_public_key());
 }

--- a/secure/transaction-scripts/Cargo.toml
+++ b/secure/transaction-scripts/Cargo.toml
@@ -1,0 +1,14 @@
+[package]
+name = "libra-transaction-scripts"
+version = "0.1.0"
+edition = "2018"
+authors = ["Libra Association <opensource@libra.org>"]
+description = "Libra transaction scripts"
+repository = "https://github.com/libra/libra"
+homepage = "https://libra.org"
+license = "Apache-2.0"
+publish = false
+
+[dependencies]
+once_cell = "1.3.1"
+include_dir = "0.5.0"

--- a/secure/transaction-scripts/src/lib.rs
+++ b/secure/transaction-scripts/src/lib.rs
@@ -1,0 +1,74 @@
+// Copyright (c) The Libra Core Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+//! This crates includes the compiled transactions scripts to mitigate issues around binary /
+//! transaction script versions and to simplify deployment.
+
+use include_dir::{include_dir, Dir};
+use once_cell::sync::Lazy;
+use std::path::PathBuf;
+
+const STAGED_EXTENSION: &str = "mv";
+const STAGED_TXN_SCRIPTS_DIR: Dir =
+    include_dir!("../../language/stdlib/staged/transaction_scripts");
+
+fn script(script_name: &str) -> Vec<u8> {
+    let mut path = PathBuf::from(script_name);
+    path.set_extension(STAGED_EXTENSION);
+    STAGED_TXN_SCRIPTS_DIR
+        .get_file(path)
+        .unwrap()
+        .contents()
+        .to_vec()
+}
+
+pub static ADD_VALIDATOR_TXN: Lazy<Vec<u8>> = Lazy::new(|| script("add_validator"));
+
+pub static PEER_TO_PEER_TRANSFER_TXN: Lazy<Vec<u8>> = Lazy::new(|| script("peer_to_peer_transfer"));
+
+pub static PEER_TO_PEER_TRANSFER_WITH_METADATA_TXN: Lazy<Vec<u8>> =
+    Lazy::new(|| script("peer_to_peer_transfer_with_metadata"));
+
+pub static CREATE_ACCOUNT_TXN: Lazy<Vec<u8>> = Lazy::new(|| script("create_account"));
+
+pub static REGISTER_VALIDATOR_TXN: Lazy<Vec<u8>> = Lazy::new(|| script("register_validator"));
+
+pub static REMOVE_VALIDATOR_TXN: Lazy<Vec<u8>> = Lazy::new(|| script("remove_validator"));
+
+pub static ROTATE_CONSENSUS_PUBKEY_TXN: Lazy<Vec<u8>> =
+    Lazy::new(|| script("rotate_consensus_pubkey"));
+
+pub static ROTATE_AUTHENTICATION_KEY_TXN: Lazy<Vec<u8>> =
+    Lazy::new(|| script("rotate_authentication_key"));
+
+pub static MINT_TXN: Lazy<Vec<u8>> = Lazy::new(|| script("mint"));
+
+pub static BLOCK_PROLOGUE_TXN: Lazy<Vec<u8>> = Lazy::new(|| script("block_prologue"));
+
+pub static EMPTY_TXN: Lazy<Vec<u8>> = Lazy::new(|| script("empty_script"));
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn verify_txn_scripts() {
+        let txn_scripts = &[
+            &ADD_VALIDATOR_TXN,
+            &PEER_TO_PEER_TRANSFER_TXN,
+            &PEER_TO_PEER_TRANSFER_WITH_METADATA_TXN,
+            &CREATE_ACCOUNT_TXN,
+            &REGISTER_VALIDATOR_TXN,
+            &REMOVE_VALIDATOR_TXN,
+            &ROTATE_CONSENSUS_PUBKEY_TXN,
+            &ROTATE_AUTHENTICATION_KEY_TXN,
+            &MINT_TXN,
+            &BLOCK_PROLOGUE_TXN,
+            &EMPTY_TXN,
+        ];
+
+        for txn_script in txn_scripts.iter() {
+            assert!(txn_script.len() > 0);
+        }
+    }
+}

--- a/types/src/discovery_set.rs
+++ b/types/src/discovery_set.rs
@@ -68,6 +68,10 @@ impl DiscoverySetResource {
     pub fn change_events(&self) -> &EventHandle {
         &self.change_events
     }
+
+    pub fn discovery_set(&self) -> &DiscoverySet {
+        &self.discovery_set
+    }
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]

--- a/types/src/validator_set.rs
+++ b/types/src/validator_set.rs
@@ -67,6 +67,10 @@ impl<PublicKey> ValidatorSetResource<PublicKey> {
     pub fn change_events(&self) -> &EventHandle {
         &self.change_events
     }
+
+    pub fn validator_set(&self) -> &ValidatorSet<PublicKey> {
+        &self.validator_set
+    }
 }
 
 #[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]


### PR DESCRIPTION
This PR begins with [secure] minimal transaction set

It introduces the beginning of a key-manager focusing first and foremost on the most critical blocks enabling key rotation within a running system. The goal is to build on top of this with a library that can handle most functions, then the json-rpc interaction, and finally the main and docker components. This is very early in the game.

I have a long winded comment in the last commit likely targeting @lightmark and @wqfish:

"The one thing I wonder about writing this is that there are a lot of
places in the code that want executor and/or storage but none of them
have them as conveniently as this. For example, executor tests heavily
depend on the grpc interface, yuck. JSON-RPC built a compatible storage
engine rather than use LibraDB which is really cool but won't work with
executor as it currently stands -- at least not in an easy way. So here
we have yet another approach. I guess once we start cleaning up
executor, we could drag the JSON-RPC storage into that code base and
really simplify testing of these things"

It might be crazy, but I found that creating this test was a lot more work than I anticipated -- but it makes sense in retrospect.