### PR TITLE
[libra-dev] Correctly decoding mint/p2p transfer argument

### DIFF
--- a/client/libra-dev/include/data.h
+++ b/client/libra-dev/include/data.h
@@ -39,6 +39,7 @@ struct LibraAccountResource {
 struct LibraP2PTransferTransactionArgument {
     uint64_t value;
     uint8_t address[LIBRA_ADDRESS_SIZE];
+    uint8_t auth_key_prefix[LIBRA_PUBKEY_SIZE - LIBRA_ADDRESS_SIZE];
 };
 
 enum TransactionType {


### PR DESCRIPTION
Unblocks pylibra library to work with new shorter address.