### PR TITLE
[cti] Allow a different tag for clustertest

### DIFF
--- a/scripts/cluster_test_pod_template.yaml
+++ b/scripts/cluster_test_pod_template.yaml
@@ -15,7 +15,7 @@ spec:
     effect: "NoSchedule"
   containers:
   - name: main
-    image: 853397791086.dkr.ecr.us-west-2.amazonaws.com/libra_cluster_test:{image_tag}
+    image: 853397791086.dkr.ecr.us-west-2.amazonaws.com/libra_cluster_test:{cluster_test_image_tag}
     imagePullPolicy: Always
     env: [{env_variables}]
     command: [cluster-test, --deploy={image_tag} {extra_args}]

--- a/scripts/cti
+++ b/scripts/cti
@@ -5,6 +5,7 @@ set -e
 set -o pipefail
 
 TAG=""
+CLUSTER_TEST_TAG=""
 PR=""
 WORKSPACE=""
 ENV=""
@@ -117,6 +118,10 @@ while (( "$#" )); do
       TAG=$2
       shift 2
       ;;
+    --cluster-test-tag)
+      CLUSTER_TEST_TAG=$2
+      shift 2
+      ;;
     -D|--no-deploy)
       DEPLOY=no
       shift 1
@@ -148,6 +153,7 @@ then
       echo "--pr <PR>: Build image from pull request #<PR>"
       echo "-M|--master: Use latest image available in CI"
       echo "-T|--tag <TAG>: Use image with tag TAG"
+      echo "--cluster-test-tag <TAG>: Use this tag for cluster test"
       echo "-W|--workspace <WORKSPACE>: Use custom workplace <WORKSPACE>"
       echo "-E|--env <ENV>: Set environment variable, ex. -E RUST_LOG=debug. Can be repeated, e.g. -E A=B -E C=D"
       echo "-R|--report file.json: Generate json report into file.json"
@@ -168,6 +174,8 @@ if [ -z "$TAG" ]; then
     TAG=dev_${USER}_pull_${PR}
     echo "**TIP Use cti -T $TAG <...> to restart this run with same tag without rebuilding it"
 fi
+
+CLUSTER_TEST_TAG=${CLUSTER_TEST_TAG:-${TAG}}
 
 OUTPUT_TEE=${CTI_OUTPUT_LOG:-$(mktemp)}
 
@@ -195,7 +203,7 @@ if [[ -z "${K8S}" ]]; then
       DEPLOY_CMD=""
   fi
 
-  ssh -t $JUMPHOST ssh -i /libra_rsa ec2-user@ct.priv.${WORKSPACE}.aws.hlw3truzy4ls.com env $ENV CTI_MARKER=$MARKER REMOTE_USER=$MARKER ct -c cluster-test-ci --image "853397791086.dkr.ecr.us-west-2.amazonaws.com/libra_cluster_test:$TAG" $DEPLOY_CMD $* 2>&1 | tee $OUTPUT_TEE
+  ssh -t $JUMPHOST ssh -i /libra_rsa ec2-user@ct.priv.${WORKSPACE}.aws.hlw3truzy4ls.com env $ENV CTI_MARKER=$MARKER REMOTE_USER=$MARKER ct -c cluster-test-ci --image "853397791086.dkr.ecr.us-west-2.amazonaws.com/libra_cluster_test:$CLUSTER_TEST_TAG" $DEPLOY_CMD $* 2>&1 | tee $OUTPUT_TEE
 
 else
   if ! which kubectl &>/dev/null; then
@@ -213,6 +221,7 @@ else
   DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
   sed -e "s/{pod_name}/${pod_name}/g" \
       -e "s/{image_tag}/${TAG}/g" \
+      -e "s/{cluster_test_image_tag}/${CLUSTER_TEST_TAG}/g" \
       -e "s/{env_variables}/${retval_join_env_vars}/g" \
       -e "s/{extra_args}/${retval_join_args}/g" \
       ${DIR}/cluster_test_pod_template.yaml > ${specfile}


### PR DESCRIPTION
## Summary

Allow a different tag for clustertest

When I develop cluster test, I am only building cluster-test images and not validator images, so I need to run cti with different images.

## Test Plan

Ran cti with k8s