### PR TITLE
[k8s][clustertest] Add network effects

### DIFF
--- a/testsuite/cluster-test/src/cluster_swarm/job_template.yaml
+++ b/testsuite/cluster-test/src/cluster_swarm/job_template.yaml
@@ -1,0 +1,25 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: {name}
+  labels:
+    app: {label}
+spec:
+  template:
+    metadata:
+      labels:
+        app: {label}
+    spec:
+      nodeName: {node_name}
+      hostNetwork: true
+      dnsPolicy: ClusterFirstWithHostNet
+      containers:
+      - name: main
+        image: {image}
+        command: ["sh",  "-c", "{command}"]
+        securityContext:
+          privileged: true
+          capabilities:
+            add: ["SYS_ADMIN"]
+      restartPolicy: Never
+  backoffLimit: {back_off_limit}

--- a/testsuite/cluster-test/src/cluster_swarm/mod.rs
+++ b/testsuite/cluster-test/src/cluster_swarm/mod.rs
@@ -10,6 +10,17 @@ use futures::{future::try_join_all, try_join};
 
 #[async_trait]
 pub trait ClusterSwarm {
+    async fn remove_all_network_effects(&self) -> Result<()>;
+
+    /// Runs the given command in a container against the given Instance
+    async fn run(
+        &self,
+        instance: &Instance,
+        docker_image: &str,
+        command: String,
+        job_name: &str,
+    ) -> Result<()>;
+
     async fn validator_instances(&self) -> Vec<Instance>;
 
     async fn fullnode_instances(&self) -> Vec<Instance>;

--- a/testsuite/cluster-test/src/experiments/mod.rs
+++ b/testsuite/cluster-test/src/experiments/mod.rs
@@ -31,7 +31,7 @@ use crate::{
     tx_emitter::{EmitJobRequest, TxEmitter},
 };
 
-use crate::health::TraceTail;
+use crate::{cluster_swarm::cluster_swarm_kube::ClusterSwarmKube, health::TraceTail};
 use async_trait::async_trait;
 pub use cpu_flamegraph::{CpuFlamegraph, CpuFlamegraphParams};
 use std::collections::HashMap;
@@ -59,6 +59,7 @@ pub struct Context<'a> {
     pub report: &'a mut SuiteReport,
     pub global_emit_job_request: &'a mut Option<EmitJobRequest>,
     pub emit_to_validator: bool,
+    pub cluster_swarm: &'a Option<ClusterSwarmKube>,
 }
 
 impl<'a> Context<'a> {
@@ -70,6 +71,7 @@ impl<'a> Context<'a> {
         report: &'a mut SuiteReport,
         emit_job_request: &'a mut Option<EmitJobRequest>,
         emit_to_validator: bool,
+        cluster_swarm: &'a Option<ClusterSwarmKube>,
     ) -> Self {
         Context {
             tx_emitter,
@@ -79,6 +81,7 @@ impl<'a> Context<'a> {
             report,
             global_emit_job_request: emit_job_request,
             emit_to_validator,
+            cluster_swarm,
         }
     }
 }

--- a/testsuite/cluster-test/src/experiments/performance_benchmark_three_region_simulation.rs
+++ b/testsuite/cluster-test/src/experiments/performance_benchmark_three_region_simulation.rs
@@ -3,14 +3,18 @@
 
 use crate::{
     cluster::Cluster,
+    cluster_swarm::{cluster_swarm_kube::ClusterSwarmKube, ClusterSwarm},
     effects::{three_region_simulation_effects, Effect},
     experiments::{Context, Experiment, ExperimentParam},
+    instance::Instance,
     stats,
     tx_emitter::EmitJobRequest,
     util::unix_timestamp_now,
 };
+use anyhow::Result;
 use async_trait::async_trait;
-use futures::future::join_all;
+use futures::future::{join_all, try_join_all};
+use libra_logger::*;
 use std::{
     fmt::{Display, Error, Formatter},
     time::Duration,
@@ -53,7 +57,26 @@ impl Experiment for PerformanceBenchmarkThreeRegionSimulation {
                 Duration::from_millis(40), // us_west<->us_east one way delay
             ),
         );
-        join_all(network_effects.iter().map(|e| e.activate())).await;
+        if let Some(cluster_swarm) = context.cluster_swarm {
+            three_region_simulation_effects_k8s(
+                (
+                    us_west.validator_instances().to_vec(),
+                    us_east.validator_instances().to_vec(),
+                    euro.validator_instances().to_vec(),
+                ),
+                (
+                    Duration::from_millis(60), // us_east<->eu one way delay
+                    Duration::from_millis(95), // us_west<->eu one way delay
+                    Duration::from_millis(40), // us_west<->us_east one way delay
+                ),
+                cluster_swarm,
+            )
+            .await?;
+        } else {
+            info!("cluster_swarm is not set");
+            join_all(network_effects.iter().map(|e| e.activate())).await;
+        }
+
         let window = Duration::from_secs(240);
         let emit_job_request = if context.emit_to_validator {
             EmitJobRequest::for_instances(
@@ -74,7 +97,11 @@ impl Experiment for PerformanceBenchmarkThreeRegionSimulation {
         let end = unix_timestamp_now() - buffer;
         let start = end - window + 2 * buffer;
         let (avg_tps, avg_latency) = stats::txn_stats(&context.prometheus, start, end)?;
-        join_all(network_effects.iter().map(|e| e.deactivate())).await;
+        if let Some(cluster_swarm) = context.cluster_swarm {
+            cluster_swarm.remove_all_network_effects().await?;
+        } else {
+            join_all(network_effects.iter().map(|e| e.deactivate())).await;
+        }
         context.report.report_metric(&self, "avg_tps", avg_tps);
         context
             .report
@@ -95,4 +122,91 @@ impl Display for PerformanceBenchmarkThreeRegionSimulation {
     fn fmt(&self, f: &mut Formatter<'_>) -> Result<(), Error> {
         write!(f, "3 Region Simulation")
     }
+}
+
+async fn add_network_delay_k8s(
+    instance: Instance,
+    configuration: Vec<(Vec<Instance>, Duration)>,
+    cluster_swarm: &ClusterSwarmKube,
+) -> Result<()> {
+    let mut command = "".to_string();
+    command += "tc qdisc delete dev eth0 root; ";
+    // Create a HTB https://linux.die.net/man/8/tc-htb
+    command += "tc qdisc add dev eth0 root handle 1: htb; ";
+    for i in 0..configuration.len() {
+        // Create a class within the HTB https://linux.die.net/man/8/tc
+        command += format!(
+            "tc class add dev eth0 parent 1: classid 1:{} htb rate 1tbit; ",
+            i + 1
+        )
+        .as_str();
+    }
+    for (i, config) in configuration.iter().enumerate() {
+        // Create u32 filters so that all the target instances are classified as class 1:(i+1)
+        // http://man7.org/linux/man-pages/man8/tc-u32.8.html
+        for target_instance in &config.0 {
+            command += format!("tc filter add dev eth0 parent 1: protocol ip prio 1 u32 flowid 1:{} match ip dst {}; ", i+1, target_instance.ip()).as_str();
+        }
+    }
+    for (i, config) in configuration.iter().enumerate() {
+        // Use netem to delay packets to this class
+        command += format!(
+            "tc qdisc add dev eth0 parent 1:{} handle {}0: netem delay {}ms; ",
+            i + 1,
+            i + 1,
+            config.1.as_millis(),
+        )
+        .as_str();
+    }
+
+    cluster_swarm
+        .run(
+            &instance,
+            "853397791086.dkr.ecr.us-west-2.amazonaws.com/iproute2:latest",
+            command,
+            "add-network-delay",
+        )
+        .await
+}
+
+async fn three_region_simulation_effects_k8s(
+    regions: (Vec<Instance>, Vec<Instance>, Vec<Instance>),
+    delays_bw_regions: (Duration, Duration, Duration),
+    cluster_swarm: &ClusterSwarmKube,
+) -> Result<()> {
+    let mut futures = vec![];
+    for instance in &regions.0 {
+        let configuration = vec![
+            (regions.1.clone(), delays_bw_regions.2),
+            (regions.2.clone(), delays_bw_regions.1),
+        ];
+        futures.push(add_network_delay_k8s(
+            instance.clone(),
+            configuration,
+            cluster_swarm,
+        ));
+    }
+    for instance in &regions.1 {
+        let configuration = vec![
+            (regions.0.clone(), delays_bw_regions.2),
+            (regions.2.clone(), delays_bw_regions.0),
+        ];
+        futures.push(add_network_delay_k8s(
+            instance.clone(),
+            configuration,
+            cluster_swarm,
+        ));
+    }
+    for instance in &regions.2 {
+        let configuration = vec![
+            (regions.1.clone(), delays_bw_regions.0),
+            (regions.0.clone(), delays_bw_regions.1),
+        ];
+        futures.push(add_network_delay_k8s(
+            instance.clone(),
+            configuration,
+            cluster_swarm,
+        ));
+    }
+    try_join_all(futures).await.map(|_| ())
 }


### PR DESCRIPTION
## Summary

Add `add_network_delay` and `remove_all_network_effects` functions to cluster swarm

Update `performance_benchmark_three_region_simulation.rs` to support k8s

Perform cleanup when cluster starts



## Test Plan

```
====json-report-begin===
{
  "metrics": [
    {
      "experiment": "3 Region Simulation",
      "metric": "avg_tps",
      "value": 849.3701091666841
    },
    {
      "experiment": "3 Region Simulation",
      "metric": "avg_latency",
      "value": 3484.6653925600763
    }
  ],
  "text": "3 Region Simulation : 849 TPS, 3484.7 ms latency"
}
====json-report-end===
INFO 2020-03-16 23:23:28 testsuite/cluster-test/src/main.rs:226 Experiment Result: 3 Region Simulation : 849 TPS, 3484.7 ms latency
```