### PR TITLE
[JSON RPC] improve mocking events in mock DB

### DIFF
--- a/json-rpc/src/tests/mock_db.rs
+++ b/json-rpc/src/tests/mock_db.rs
@@ -34,14 +34,6 @@ pub(crate) struct MockLibraDB {
     pub account_state_with_proof: Vec<AccountStateWithProof>,
 }
 
-impl MockLibraDB {
-    pub(crate) fn add_event(&mut self, event: ContractEvent) {
-        if self.events.is_empty() {
-            self.events.push((0, event));
-        }
-    }
-}
-
 impl LibraDBTrait for MockLibraDB {
     fn get_latest_account_state(
         &self,


### PR DESCRIPTION
## Motivation

In JSON RPC tests, make `fn mock_db()` handle mocking events in the case where proptest values return no events (replace the clunky `add_event` method)
Also remove dependency on hard-coded values in test

## Testing Plan
Locally tested for proptest values that return no events that tests still pass