### PR TITLE
[faucet] migrate faucet service to json-rpc

### DIFF
--- a/client/cli/src/client_proxy.rs
+++ b/client/cli/src/client_proxy.rs
@@ -149,7 +149,7 @@ impl ClientProxy {
 
         let faucet_server = match faucet_server {
             Some(server) => server,
-            None => host.replace("ac", "faucet"),
+            None => host.replace("client", "faucet"),
         };
 
         let address_to_ref_id = accounts

--- a/docker/mint/mint.Dockerfile
+++ b/docker/mint/mint.Dockerfile
@@ -44,7 +44,7 @@ RUN apt-get update && apt-get install -y procps
 
 # TEST docker-run.sh
 #   GIVEN necessary environment arguments to run docker-run.sh
-ARG AC_PORT="8000"
+ARG AC_PORT="8080"
 ARG AC_HOST="172.18.0.13"
 ARG LOG_LEVEL="info"
 

--- a/docker/mint/run.sh
+++ b/docker/mint/run.sh
@@ -10,7 +10,7 @@ set -ex
 
 IMAGE="${1:-libra_mint:latest}"
 AC_HOST="${2:-172.18.0.13}"
-AC_PORT="${3:-8000}"
+AC_PORT="${3:-8080}"
 LOG_LEVEL="${4:-info}"
 CONFIGDIR="$(dirname "$0")/../../terraform/validator-sets/dev"
 

--- a/docker/mint/server.py
+++ b/docker/mint/server.py
@@ -45,7 +45,7 @@ def send_transaction():
     address = flask.request.args['address']
 
     # Return immediately if address is invalid
-    if re.match('^[a-f0-9]{64}$', address) is None:
+    if re.match('^[a-f0-9]{32}$', address) is None:
         return 'Malformed address', 400
 
     try:


### PR DESCRIPTION
fixes required so far
- point CLI from client to faucet
- change client port for faucet
- update account address verification format to 32 bytes  