### PR TITLE
[logging] Introducing structured log API

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2468,6 +2468,8 @@ dependencies = [
  "chrono 0.4.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "env_logger 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_json 1.0.48 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]

--- a/common/logger/Cargo.toml
+++ b/common/logger/Cargo.toml
@@ -15,3 +15,9 @@ edition = "2018"
 chrono = "0.4.9"
 env_logger = { version = "0.7.1", default-features = false }
 log = "0.4.8"
+serde_json = "1.0.48"
+serde = { version = "1.0.96", features = ["derive"] }
+
+[features]
+names_required = []
+no_struct_log = []

--- a/common/logger/src/struct_log.rs
+++ b/common/logger/src/struct_log.rs
@@ -1,0 +1,220 @@
+// Copyright (c) The Libra Core Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+use chrono::Utc;
+use log;
+use serde_json;
+use std::io::Write as IoWrite;
+
+use serde::Serialize;
+use serde_json::Value;
+use std::{
+    collections::HashMap,
+    fs::{File, OpenOptions},
+    io,
+    sync::{
+        atomic::{AtomicUsize, Ordering},
+        mpsc::{self, Receiver, SyncSender},
+    },
+    thread,
+};
+
+pub trait StructLogSink: Sync {
+    fn send(&self, entry: StructuredLogEntry);
+}
+
+// This is poor's man AtomicReference from crossbeam
+// It have few unsafe lines, but does not require extra dependency
+static NOP: NopStructLog = NopStructLog {};
+static mut STRUCT_LOGGER: &'static dyn StructLogSink = &NOP;
+static STRUCT_LOGGER_STATE: AtomicUsize = AtomicUsize::new(UNINITIALIZED);
+const UNINITIALIZED: usize = 0;
+
+const INITIALIZING: usize = 1;
+const INITIALIZED: usize = 2;
+
+#[derive(Default, Serialize)]
+pub struct StructuredLogEntry {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    text: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pattern: Option<&'static str>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    name: Option<&'static str>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    module: Option<&'static str>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    location: Option<&'static str>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    git_rev: Option<&'static str>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    timestamp: Option<String>,
+    #[serde(skip_serializing_if = "HashMap::is_empty")]
+    data: HashMap<&'static str, Value>,
+}
+
+#[must_use = "use StructuredLogEntry::send to send structured log"]
+impl StructuredLogEntry {
+    pub fn new_unnamed() -> Self {
+        let mut ret = Self::default();
+        ret.timestamp = Some(Utc::now().format("%F %T").to_string());
+        ret
+    }
+
+    pub fn new_named(name: &'static str) -> Self {
+        let mut ret = Self::default();
+        ret.name = Some(name);
+        ret.timestamp = Some(Utc::now().format("%F %T").to_string());
+        ret
+    }
+
+    pub fn text(&mut self, text: String) -> &mut Self {
+        self.text = Some(text);
+        self
+    }
+
+    pub fn pattern(&mut self, pattern: &'static str) -> &mut Self {
+        self.pattern = Some(pattern);
+        self
+    }
+
+    pub fn module(&mut self, module: &'static str) -> &mut Self {
+        self.module = Some(module);
+        self
+    }
+
+    pub fn location(&mut self, location: &'static str) -> &mut Self {
+        self.location = Some(location);
+        self
+    }
+
+    pub fn git_rev(&mut self, git_rev: Option<&'static str>) -> &mut Self {
+        self.git_rev = git_rev;
+        self
+    }
+
+    pub fn timestamp(&mut self, timestamp: String) -> &mut Self {
+        self.timestamp = Some(timestamp);
+        self
+    }
+
+    pub fn json_data(&mut self, key: &'static str, value: Value) -> &mut Self {
+        self.data.insert(key, value);
+        self
+    }
+
+    pub fn data<D: Serialize>(&mut self, key: &'static str, value: D) -> &mut Self {
+        self.data.insert(
+            key,
+            serde_json::to_value(value).expect("Failed to serialize StructuredLogEntry key"),
+        );
+        self
+    }
+
+    // Use send_struct_log! macro instead of this method to populate extra meta information such as git rev and module name
+    #[doc(hidden)]
+    pub fn send(self) {
+        struct_logger().send(self);
+    }
+}
+
+// This is exact copy of similar function in log crate
+/// Sets structured logger
+pub fn set_struct_logger(logger: &'static dyn StructLogSink) -> Result<(), ()> {
+    unsafe {
+        match STRUCT_LOGGER_STATE.compare_and_swap(UNINITIALIZED, INITIALIZING, Ordering::SeqCst) {
+            UNINITIALIZED => {
+                STRUCT_LOGGER = logger;
+                STRUCT_LOGGER_STATE.store(INITIALIZED, Ordering::SeqCst);
+                Ok(())
+            }
+            INITIALIZING => {
+                while STRUCT_LOGGER_STATE.load(Ordering::SeqCst) == INITIALIZING {}
+                Err(())
+            }
+            _ => Err(()),
+        }
+    }
+}
+
+/// Checks if structured logging is enabled
+pub fn struct_logger_enabled() -> bool {
+    STRUCT_LOGGER_STATE.load(Ordering::SeqCst) == INITIALIZED
+}
+
+// This is exact copy of similar function in log crate
+fn struct_logger() -> &'static dyn StructLogSink {
+    unsafe {
+        if STRUCT_LOGGER_STATE.load(Ordering::SeqCst) != INITIALIZED {
+            &NOP
+        } else {
+            STRUCT_LOGGER
+        }
+    }
+}
+
+struct NopStructLog {}
+
+impl StructLogSink for NopStructLog {
+    fn send(&self, _entry: StructuredLogEntry) {}
+}
+
+/// Sink that prints all structured logs to stdout
+pub struct PrintStructLog {}
+
+impl StructLogSink for PrintStructLog {
+    fn send(&self, entry: StructuredLogEntry) {
+        println!("{}", serde_json::to_string(&entry).unwrap());
+    }
+}
+
+/// Sink that prints all structured logs to specified file
+pub struct FileStructLog {
+    sender: SyncSender<StructuredLogEntry>,
+}
+
+impl FileStructLog {
+    /// Creates new FileStructLog and starts async thread to write results
+    pub fn start_new(file_path: String) -> io::Result<Self> {
+        let (sender, receiver) = mpsc::sync_channel(1_024);
+        let file = OpenOptions::new()
+            .append(true)
+            .create(true)
+            .open(file_path)?;
+        let sink_thread = FileStructLogThread { receiver, file };
+        thread::spawn(move || sink_thread.run());
+        Ok(Self { sender })
+    }
+}
+
+impl StructLogSink for FileStructLog {
+    fn send(&self, entry: StructuredLogEntry) {
+        if let Err(e) = self.sender.try_send(entry) {
+            // Use log crate macro to avoid generation of structured log in this case
+            // Otherwise we will have infinite loop
+            log::error!("Failed to send structured log: {}", e);
+        }
+    }
+}
+
+struct FileStructLogThread {
+    receiver: Receiver<StructuredLogEntry>,
+    file: File,
+}
+
+impl FileStructLogThread {
+    pub fn run(mut self) {
+        for entry in self.receiver {
+            let json = match serde_json::to_value(entry) {
+                Err(e) => {
+                    log::error!("Failed to serialize struct log entry: {}", e);
+                    continue;
+                }
+                Ok(json) => json,
+            };
+            if let Err(e) = writeln!(&mut self.file, "{}", json) {
+                log::error!("Failed to write struct log entry: {}", e);
+            }
+        }
+    }
+}

--- a/common/logger/src/text_log.rs
+++ b/common/logger/src/text_log.rs
@@ -1,0 +1,308 @@
+// Copyright (c) The Libra Core Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+use chrono::Utc;
+use env_logger::filter;
+use log::{self, Level, Log, Metadata, Record};
+
+use std::{
+    env, fmt,
+    fmt::Write,
+    sync::mpsc::{self, Receiver, RecvError, SyncSender, TrySendError},
+    thread,
+};
+
+pub const CHANNEL_SIZE: usize = 256;
+pub const DEFAULT_TARGET: &str = "libra";
+const RUST_LOG: &str = "RUST_LOG";
+
+/// Logging framework for Libra that encapsulates a minimal dependency logger with support for
+/// environmental variable (RUST_LOG) and asynchronous logging.
+/// Note: only a single logger can be instantiated at a time. Repeated instantiates of the loggers
+/// will only adjust the global logging level but will not change the initial filter.
+pub struct Logger {
+    /// Channel size for sending logs to async handler.
+    channel_size: usize,
+    /// Only instantiate a logger if the environment is properly set
+    environment_only: bool,
+    /// Use a dedicated thread for logging.
+    is_async: bool,
+    /// The default logging level.
+    level: Level,
+    /// Override RUST_LOG even if set
+    override_rust_log: bool,
+}
+
+impl Logger {
+    pub fn new() -> Self {
+        Self {
+            channel_size: CHANNEL_SIZE,
+            environment_only: false,
+            is_async: false,
+            level: Level::Info,
+            override_rust_log: false,
+        }
+    }
+
+    pub fn channel_size(&mut self, channel_size: usize) -> &mut Self {
+        self.channel_size = channel_size;
+        self
+    }
+
+    pub fn environment_only(&mut self, environment_only: bool) -> &mut Self {
+        self.environment_only = environment_only;
+        self
+    }
+
+    pub fn is_async(&mut self, is_async: bool) -> &mut Self {
+        self.is_async = is_async;
+        self
+    }
+
+    pub fn level(&mut self, level: Level) -> &mut Self {
+        self.level = level;
+        self
+    }
+
+    pub fn override_rust_log(&mut self, override_rust_log: bool) -> &mut Self {
+        self.override_rust_log = override_rust_log;
+        self
+    }
+
+    pub fn init(&mut self) {
+        self.internal_init(StderrWriter {});
+    }
+
+    fn internal_init<W: 'static + Writer>(&mut self, writer: W) {
+        // Always prefer RUST_LOG
+        let mut use_level = self.override_rust_log;
+        let mut filter_builder = filter::Builder::new();
+
+        if let Ok(s) = env::var(RUST_LOG) {
+            filter_builder.parse(&s);
+        } else if self.environment_only {
+            // Turn off in case there was an active logger
+            log::set_max_level(::log::LevelFilter::Off);
+            return;
+        } else {
+            use_level = true;
+        }
+
+        if use_level {
+            filter_builder.filter(None, self.level.to_level_filter());
+        }
+
+        let filter = filter_builder.build();
+        // Even if there is an existing logger, update the logging level
+        log::set_max_level(filter.filter());
+
+        if self.is_async {
+            let (sender, receiver) = mpsc::sync_channel(self.channel_size);
+
+            let client = AsyncLogClient { filter, sender };
+            if let Err(e) = log::set_boxed_logger(Box::new(client)) {
+                eprintln!("Unable to set logger: {}", e);
+                return;
+            };
+
+            let service = AsyncLogService { receiver, writer };
+
+            thread::spawn(move || service.log_handler());
+        } else {
+            let logger = SyncLogger { filter, writer };
+            if let Err(e) = log::set_boxed_logger(Box::new(logger)) {
+                eprintln!("Unable to set logger: {}", e);
+                return;
+            };
+        }
+    }
+}
+
+impl Default for Logger {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+/// Provies the log::Log for Libra's synchronous logger
+struct SyncLogger<W> {
+    filter: filter::Filter,
+    writer: W,
+}
+
+impl<W: Writer> Log for SyncLogger<W> {
+    /// Determines if a log message with the specified metadata would be logged.
+    fn enabled(&self, metadata: &Metadata) -> bool {
+        self.filter.enabled(metadata)
+    }
+
+    /// Logs the provided record but first evaluates the filters and then writes it.
+    fn log(&self, record: &Record) {
+        // The following filters out everything that does not deal with Libra
+        if record.metadata().target() != DEFAULT_TARGET {
+            return;
+        }
+
+        if !self.filter.matches(record) {
+            return;
+        }
+
+        match format(record) {
+            Ok(formatted) => self.writer.write(formatted),
+            Err(e) => self
+                .writer
+                .write(format!("Unable to format log {:?}: {}", record, e)),
+        };
+    }
+
+    /// In this logger, this doesn't do anything.
+    fn flush(&self) {}
+}
+
+/// Operations between the AsyncLogClient and AsyncLogService
+enum LogOp {
+    /// Send a line to log to the writer.
+    Log(String),
+}
+
+/// Provides the backend to the asynchronous interface for logging. This part actually writes the
+/// log to the writer.
+struct AsyncLogService<W> {
+    receiver: Receiver<LogOp>,
+    writer: W,
+}
+
+impl<W: Writer> AsyncLogService<W> {
+    /// Loop for handling logging
+    fn log_handler(mut self) {
+        loop {
+            if let Err(e) = self.handle_recv() {
+                // TODO write an error record and then exit
+                self.writer.write(format!("Unrecoverable error: {}", e));
+                return;
+            }
+        }
+    }
+
+    fn handle_recv(&mut self) -> Result<(), RecvError> {
+        match self.receiver.recv()? {
+            LogOp::Log(line) => self.writer.write(line),
+        };
+        Ok(())
+    }
+}
+
+/// Provides the log::Log interface for Libra's asynchronous logger
+struct AsyncLogClient {
+    filter: filter::Filter,
+    sender: SyncSender<LogOp>,
+}
+
+impl Log for AsyncLogClient {
+    /// Determines if a log message with the specified metadata would be logged.
+    fn enabled(&self, metadata: &Metadata) -> bool {
+        self.filter.enabled(metadata)
+    }
+
+    /// Logs the provided record but first evaluates the filters and then sending it to the
+    /// AsyncLogService via a SyncSender.
+    fn log(&self, record: &Record) {
+        // The following filters out everything that does not deal with Libra
+        if record.metadata().target() != DEFAULT_TARGET {
+            return;
+        }
+
+        if !self.filter.matches(record) {
+            return;
+        }
+
+        let formatted = match format(record) {
+            Ok(formatted) => formatted,
+            Err(e) => format!("Unable to format log {:?} due to {}", record, e),
+        };
+        if let Err(e) = self.sender.try_send(LogOp::Log(formatted)) {
+            match e {
+                TrySendError::Disconnected(_) => {
+                    eprintln!("Unable to log {:?} due to {}", record, e)
+                }
+                TrySendError::Full(_) => eprintln!("Unable to log, queue full"),
+            }
+        };
+    }
+
+    /// In this logger, this doesn't do anything.
+    fn flush(&self) {}
+}
+
+/// Converts a record into a string representation:
+/// UNIX_TIMESTAMP LOG_LEVEL FILE:LINE MESSAGE
+/// Example:
+/// 2020-03-07 05:03:03 INFO common/libra-logger/src/lib.rs:261 Hello
+fn format(record: &Record) -> Result<String, fmt::Error> {
+    let mut buffer = String::new();
+
+    write!(buffer, "{} ", record.metadata().level())?;
+    write!(buffer, "{} ", Utc::now().format("%F %T"))?;
+
+    if let Some(file) = record.file() {
+        write!(buffer, "{}", file)?;
+        if let Some(line) = record.line() {
+            write!(buffer, ":{}", line)?;
+        }
+        write!(buffer, " ")?;
+    }
+
+    write!(buffer, "{}", record.args())?;
+
+    Ok(buffer)
+}
+
+/// An trait encapsulating the operations required for writing logs.
+trait Writer: Send + Sync {
+    /// Write the log.
+    fn write(&self, log: String);
+}
+
+/// A struct for writing logs to stderr
+struct StderrWriter {}
+
+impl Writer for StderrWriter {
+    /// Write log to stderr
+    fn write(&self, log: String) {
+        eprintln!("{}", log);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::{text_log::*, *};
+    use std::sync::{Arc, RwLock};
+
+    #[derive(Default)]
+    struct VecWriter {
+        logs: Arc<RwLock<Vec<String>>>,
+    }
+
+    impl Writer for VecWriter {
+        fn write(&self, log: String) {
+            self.logs.write().unwrap().push(log)
+        }
+    }
+
+    #[test]
+    fn verify_end_to_end() {
+        let writer = VecWriter::default();
+        let logs = writer.logs.clone();
+        Logger::new().override_rust_log(true).internal_init(writer);
+
+        assert_eq!(logs.read().unwrap().len(), 0);
+        info!("Hello");
+        assert_eq!(logs.read().unwrap().len(), 1);
+        // Ensure that libra target filtering works
+        log::info!("Hello");
+        assert_eq!(logs.read().unwrap().len(), 1);
+        let string = logs.write().unwrap().remove(0);
+        assert!(string.contains("INFO"));
+        assert!(string.ends_with("Hello"));
+    }
+}

--- a/storage/inspector/src/main.rs
+++ b/storage/inspector/src/main.rs
@@ -55,6 +55,7 @@ fn print_head(db: &LibraDB) -> Result<()> {
     info!(
         "Current Validator Set: {}",
         si.latest_validator_set
+            .as_ref()
             .expect("Unable to determine validator set, DB incorrect")
     );
 

--- a/testsuite/cluster-test/Cargo.toml
+++ b/testsuite/cluster-test/Cargo.toml
@@ -39,7 +39,7 @@ config-builder = { path = "../../config/config-builder", version = "0.1.0" }
 generate-keypair = { path = "../../config/generate-keypair", version = "0.1.0" }
 libra-crypto = { path = "../../crypto/crypto", version = "0.1.0" }
 libra-config = { path = "../../config", version = "0.1.0" }
-libra-logger = { path = "../../common/logger", version = "0.1.0" }
+libra-logger = { path = "../../common/logger", version = "0.1.0", features = ["no_struct_log"] }
 libra-types = { path = "../../types", version = "0.1.0", features = ["fuzzing"] }
 transaction-builder = { path = "../../language/transaction-builder", version = "0.1.0" }
 

--- a/testsuite/cluster-test/src/cluster_swarm/cluster_swarm_kube.rs
+++ b/testsuite/cluster-test/src/cluster_swarm/cluster_swarm_kube.rs
@@ -403,8 +403,10 @@ impl ClusterSwarm for ClusterSwarmKube {
                 debug!(
                     "Created {}",
                     o.metadata
+                        .as_ref()
                         .ok_or_else(|| { format_err!("metadata not found for pod {}", pod_name) })?
                         .name
+                        .as_ref()
                         .ok_or_else(|| { format_err!("name not found for pod {}", pod_name) })?
                 );
             }

--- a/testsuite/cluster-test/src/instance.rs
+++ b/testsuite/cluster-test/src/instance.rs
@@ -190,6 +190,12 @@ impl fmt::Display for Instance {
     }
 }
 
+impl fmt::Debug for Instance {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "{:?}", self)
+    }
+}
+
 pub fn instancelist_to_set(instances: &[Instance]) -> HashSet<String> {
     let mut r = HashSet::new();
     for instance in instances {


### PR DESCRIPTION
This PR introduces structured log API for libra.

# Summary

In a nutshell, API introduces two things
1) `StructuredLogEntry` class and `send_struct_log!` macro for directly composing structured log
2) Bridge between traditional log! macro and structured logging API

# Direct API

```rust
pub struct StructuredLogEntry {
    text: Option<String>,
    pattern: Option<&'static str>,
    name: Option<&'static str>,
    module: Option<&'static str>,
    location: Option<&'static str>,
    git_rev: Option<&'static str>,
    data: HashMap<&'static str, Value>,
}

impl StructuredLogEntry {
    pub fn new_unnamed() -> Self { /* ... */ }
    pub fn new_named(name: &'static str) -> Self { /* ... */ }
    /* ..Bunch of builder style setters for chained initialization such as
        entry.data(a, b).data(x, y).. */
}

// Usage:
send_struct_log!(StructuredLogEntry::new_named("Committed")
   .data("block", &block)
   .data("autor", &author))
```

Arguments passed to `.data` will be serialized into json, and as such should implement `Serialize`.
Only static strings are allowed as field names.

`send_struct_log!` should be used to send structured log entry.
This macro populates metadata such as git_rev, location and module, and also skips evaluation of StructuredLogEntry entirely, if structured logging is disabled

# Log macro bridge

Crate owners are not required to rewrite their code right away to support new structured logging.
Importing logger crate will automatically emit structured logging on every log(debug!, info!, etc) macro invocation, unless `no_struct_log` feature was enabled on this crate.

*Note*: Only enable 'no_struct_log' on leaf binary crates, never on library, as it might disable structured logging for other crates, due to how cargo handles features at this moment.

So
```
info!("Committing {}", block);
```
Will emit(in addition to regular text log) structured log such as
```
{
  pattern: "Committing {}",
  data: {
    block: "<id>"
  },
  ...metadata...
}
```

There are few caveats to automatic structured logging generation

1) Argument values for structured logging will be serialized with `Debug` implementation(vs proper json serialization if `send_struct_log!` macro is used), regardless of what formatter is used for textual log. As a consequence, this means, that every log argument must implement `Debug`. In theory, this is extra limitation, but in practice currently in libra node crate and it's dependencies there was no single log argument that would not satisfy this criteria.

2) Field names will be automatically evaluated if expression is a single identifier, as in example above field `block` will get human readable name in json. However, if more complex expression is passed, structured log field name will be based on position of argument: "_0", "_1", etc:
```
info!("Committing {}", block.id());
//->
{
  data: {
    "_0": "<id>"
  },
  ...metadata...
}
```

3) Another way to set proper name to json fields is to use named format arguments:
```
info!("Committing {id}", id=block.id());
//->
{
  data: {
    "id": "<id>"
  },
  ...metadata...
}
```

# Structured log sink

Application must define implementation of `StructLogSink` interface in order to direct structured logs emitted by `send_struct_log` and other macros. This sink can be only initialized once, by calling `set_struct_logger` function.

Currently 3 implementations for `StructLogSink` exist:

1) `NopStructLog` ignores structured logs
2) `PrintStructLog` immediately prints structured logs to stdout
3) `FileStructLog` prints structured logs into provided file. Using this logger creates separate thread for writing files and structured logging itself is asynchronous in this case.
