### PR TITLE
[move-prover] Added core contracts as specification tests.

### DIFF
--- a/language/move-prover/test-utils/src/baseline_test.rs
+++ b/language/move-prover/test-utils/src/baseline_test.rs
@@ -28,7 +28,7 @@ pub fn verify_or_update_baseline(baseline_file_name: &Path, text: &str) -> Resul
             .with_context(||
                 format!("Cannot read baseline file at `{}`. To create a new baseline, call this test with env var UPBL=1.", baseline_file_name.to_string_lossy()))?;
         file.read_to_string(&mut contents)?;
-        diff(text, &contents)
+        diff(clean_for_baseline(text).as_ref(), &contents)
     }
 }
 

--- a/language/move-prover/tests/sources/stdlib/modules/address_util.exp
+++ b/language/move-prover/tests/sources/stdlib/modules/address_util.exp
@@ -1,0 +1,1 @@
+Move prover all good, no errors!

--- a/language/move-prover/tests/sources/stdlib/modules/address_util.move
+++ b/language/move-prover/tests/sources/stdlib/modules/address_util.move
@@ -1,0 +1,5 @@
+address 0x0:
+
+module AddressUtil {
+    native public fun address_to_bytes(addr: address): vector<u8>;
+}

--- a/language/move-prover/tests/sources/stdlib/modules/bytearray_util.exp
+++ b/language/move-prover/tests/sources/stdlib/modules/bytearray_util.exp
@@ -1,0 +1,24 @@
+Move prover returns: exiting with checking errors
+error:
+
+   ┌── tests/sources/stdlib/modules/bytearray_util.move:4:47 ───
+   │
+ 4 │     native public fun bytearray_concat(data1: bytearray, data2: bytearray): bytearray;
+   │                                               ^^^^^^^^^ Unbound type 'bytearray' in current scope
+   │
+
+error:
+
+   ┌── tests/sources/stdlib/modules/bytearray_util.move:4:65 ───
+   │
+ 4 │     native public fun bytearray_concat(data1: bytearray, data2: bytearray): bytearray;
+   │                                                                 ^^^^^^^^^ Unbound type 'bytearray' in current scope
+   │
+
+error:
+
+   ┌── tests/sources/stdlib/modules/bytearray_util.move:4:77 ───
+   │
+ 4 │     native public fun bytearray_concat(data1: bytearray, data2: bytearray): bytearray;
+   │                                                                             ^^^^^^^^^ Unbound type 'bytearray' in current scope
+   │

--- a/language/move-prover/tests/sources/stdlib/modules/bytearray_util.move
+++ b/language/move-prover/tests/sources/stdlib/modules/bytearray_util.move
@@ -1,0 +1,5 @@
+address 0x0:
+
+module BytearrayUtil {
+    native public fun bytearray_concat(data1: bytearray, data2: bytearray): bytearray;
+}

--- a/language/move-prover/tests/sources/stdlib/modules/gas_schedule.exp
+++ b/language/move-prover/tests/sources/stdlib/modules/gas_schedule.exp
@@ -1,0 +1,1 @@
+Move prover all good, no errors!

--- a/language/move-prover/tests/sources/stdlib/modules/gas_schedule.move
+++ b/language/move-prover/tests/sources/stdlib/modules/gas_schedule.move
@@ -1,0 +1,49 @@
+// dep: tests/sources/stdlib/modules/transaction.move
+// dep: tests/sources/stdlib/modules/vector.move
+address 0x0:
+
+// The gas schedule keeps two separate schedules for the gas:
+// * The instruction_schedule: This holds the gas for each bytecode instruction.
+// * The native_schedule: This holds the gas for used (per-byte operated over) for each native
+//   function.
+// A couple notes:
+// 1. In the case that an instruction is deleted from the bytecode, that part of the cost schedule
+//    still needs to remain the same; once a slot in the table is taken by an instruction, that is its
+//    slot for the rest of time (since that instruction could already exist in a module on-chain).
+// 2. The initialization of the module will publish the instruction table to the association
+//    address, and will preload the vector with the gas schedule for instructions. The VM will then
+//    load this into memory at the startup of each block.
+module GasSchedule {
+    use 0x0::Vector;
+    use 0x0::Transaction;
+
+    // The gas cost for each instruction is represented using two amounts;
+    // one for the cpu, and the other for storage.
+    struct Cost {
+      cpu: u64,
+      storage: u64,
+    }
+
+    resource struct T {
+        instruction_schedule: vector<Cost>,
+        native_schedule: vector<Cost>,
+    }
+
+    // Initialize the table under the association account
+    fun initialize(gas_schedule: T) {
+        Transaction::assert(Transaction::sender() == 0xA550C18, 0);
+        move_to_sender<T>(gas_schedule);
+    }
+
+    public fun instruction_table_size(): u64 acquires T {
+        let table = borrow_global<T>(0xA550C18);
+        let instruction_table_len = Vector::length(&table.instruction_schedule);
+        instruction_table_len
+    }
+
+    public fun native_table_size(): u64 acquires T {
+        let table = borrow_global<T>(0xA550C18);
+        let native_table_len = Vector::length(&table.native_schedule);
+        native_table_len
+    }
+}

--- a/language/move-prover/tests/sources/stdlib/modules/hash.exp
+++ b/language/move-prover/tests/sources/stdlib/modules/hash.exp
@@ -1,0 +1,1 @@
+Move prover all good, no errors!

--- a/language/move-prover/tests/sources/stdlib/modules/hash.move
+++ b/language/move-prover/tests/sources/stdlib/modules/hash.move
@@ -1,0 +1,6 @@
+address 0x0:
+
+module Hash {
+    native public fun sha2_256(data: vector<u8>): vector<u8>;
+    native public fun sha3_256(data: vector<u8>): vector<u8>;
+}

--- a/language/move-prover/tests/sources/stdlib/modules/libra_account.exp
+++ b/language/move-prover/tests/sources/stdlib/modules/libra_account.exp
@@ -1,0 +1,1 @@
+Move prover all good, no errors!

--- a/language/move-prover/tests/sources/stdlib/modules/libra_account.move
+++ b/language/move-prover/tests/sources/stdlib/modules/libra_account.move
@@ -1,0 +1,543 @@
+// dep: tests/sources/stdlib/modules/libra_coin.move
+// dep: tests/sources/stdlib/modules/vector.move
+// dep: tests/sources/stdlib/modules/transaction.move
+// dep: tests/sources/stdlib/modules/address_util.move
+// dep: tests/sources/stdlib/modules/u64_util.move
+// dep: tests/sources/stdlib/modules/hash.move
+// dep: tests/sources/stdlib/modules/libra_time.move
+// dep: tests/sources/stdlib/modules/libra_transaction_timeout.move
+address 0x0:
+
+// The module for the account resource that governs every Libra account
+module LibraAccount {
+    use 0x0::LibraCoin;
+    use 0x0::Hash;
+    use 0x0::U64Util;
+    use 0x0::AddressUtil;
+    use 0x0::LibraTransactionTimeout;
+    use 0x0::Transaction;
+    use 0x0::Vector;
+
+    // Every Libra account has a LibraAccount::T resource
+    resource struct T {
+        // The current authentication key.
+        // This can be different than the key used to create the account
+        authentication_key: vector<u8>,
+        // If true, the authority to rotate the authentication key of this account resides elsewhere
+        delegated_key_rotation_capability: bool,
+        // If true, the authority to withdraw funds from this account resides elsewhere
+        delegated_withdrawal_capability: bool,
+        // Event handle for received event
+        received_events: EventHandle<ReceivedPaymentEvent>,
+        // Event handle for sent event
+        sent_events: EventHandle<SentPaymentEvent>,
+        // The current sequence number.
+        // Incremented by one each time a transaction is submitted
+        sequence_number: u64,
+        // Generator for event handles
+        event_generator: EventHandleGenerator,
+    }
+
+    // A resource that holds the libra coins stored in this account
+    resource struct Balance {
+        coin: LibraCoin::T,
+    }
+
+    // The holder of WithdrawalCapability for account_address can withdraw Libra from
+    // account_address/LibraAccount::T/balance.
+    // There is at most one WithdrawalCapability in existence for a given address.
+    resource struct WithdrawalCapability {
+        account_address: address,
+    }
+
+    // The holder of KeyRotationCapability for account_address can rotate the authentication key for
+    // account_address (i.e., write to account_address/LibraAccount::T/authentication_key).
+    // There is at most one KeyRotationCapability in existence for a given address.
+    resource struct KeyRotationCapability {
+        account_address: address,
+    }
+
+    // Message for sent events
+    struct SentPaymentEvent {
+        // The amount of LibraCoin::T sent
+        amount: u64,
+        // The address that was paid
+        payee: address,
+        // Metadata associated with the payment
+        metadata: vector<u8>,
+    }
+
+    // Message for received events
+    struct ReceivedPaymentEvent {
+        // The amount of LibraCoin::T received
+        amount: u64,
+        // The address that sent the coin
+        payer: address,
+        // Metadata associated with the payment
+        metadata: vector<u8>,
+    }
+
+    /// Events
+    // A resource representing the counter used to generate uniqueness under each account. There won't be destructor for
+    // this resource to guarantee the uniqueness of the generated handle.
+    resource struct EventHandleGenerator {
+        // A monotonically increasing counter
+        counter: u64,
+    }
+
+    // A handle for an event such that:
+    // 1. Other modules can emit events to this handle.
+    // 2. Storage can use this handle to prove the total number of events that happened in the past.
+    resource struct EventHandle<T: copyable> {
+        // Total number of events emitted to this event stream.
+        counter: u64,
+        // A globally unique ID for this event stream.
+        guid: vector<u8>,
+    }
+
+    // Deposits the `to_deposit` coin into the `payee`'s account balance
+    public fun deposit(payee: address, to_deposit: LibraCoin::T) acquires T, Balance {
+        // Since we don't have vector<u8> literals in the source language at
+        // the moment.
+        // FIXME: Update this once we have vector<u8> literals
+        deposit_with_metadata(payee, to_deposit, Vector::empty());
+    }
+
+    // Deposits the `to_deposit` coin into the `payee`'s account balance with the attached `metadata`
+    public fun deposit_with_metadata(
+        payee: address,
+        to_deposit: LibraCoin::T,
+        metadata: vector<u8>
+    ) acquires T, Balance {
+        deposit_with_sender_and_metadata(
+            payee,
+            Transaction::sender(),
+            to_deposit,
+            metadata
+        );
+    }
+
+    // Deposits the `to_deposit` coin into the `payee`'s account balance with the attached `metadata` and
+    // sender address
+    fun deposit_with_sender_and_metadata(
+        payee: address,
+        sender: address,
+        to_deposit: LibraCoin::T,
+        metadata: vector<u8>
+    ) acquires T, Balance {
+        // Check that the `to_deposit` coin is non-zero
+        let deposit_value = LibraCoin::value(&to_deposit);
+        Transaction::assert(deposit_value > 0, 7);
+
+        // Load the sender's account
+        let sender_account_ref = borrow_global_mut<T>(sender);
+        // Log a sent event
+        emit_event<SentPaymentEvent>(
+            &mut sender_account_ref.sent_events,
+            SentPaymentEvent {
+                amount: deposit_value,
+                payee: payee,
+                metadata: *&metadata
+            },
+        );
+
+        // Load the payee's account
+        let payee_account_ref = borrow_global_mut<T>(payee);
+        let payee_balance = borrow_global_mut<Balance>(payee);
+        // Deposit the `to_deposit` coin
+        LibraCoin::deposit(&mut payee_balance.coin, to_deposit);
+        // Log a received event
+        emit_event<ReceivedPaymentEvent>(
+            &mut payee_account_ref.received_events,
+            ReceivedPaymentEvent {
+                amount: deposit_value,
+                payer: sender,
+                metadata: metadata
+            }
+        );
+    }
+
+    // mint_to_address can only be called by accounts with MintCapability (see Libra)
+    // and those accounts will be charged for gas. If those accounts don't have enough gas to pay
+    // for the transaction cost they will fail minting.
+    // However those account can also mint to themselves so that is a decent workaround
+    public fun mint_to_address(
+        payee: address,
+        auth_key_prefix: vector<u8>,
+        amount: u64
+    ) acquires T, Balance {
+        // Create an account if it does not exist
+        if (!exists(payee)) {
+            create_account(payee, auth_key_prefix);
+        };
+
+        // Mint and deposit the coin
+        deposit(payee, LibraCoin::mint_with_default_capability(amount));
+    }
+
+    // Helper to withdraw `amount` from the given account balance and return the withdrawn LibraCoin::T
+    fun withdraw_from_balance(balance: &mut Balance, amount: u64): LibraCoin::T {
+        LibraCoin::withdraw(&mut balance.coin, amount)
+    }
+
+    // Withdraw `amount` LibraCoin::T from the transaction sender's account balance
+    public fun withdraw_from_sender(amount: u64): LibraCoin::T acquires T, Balance {
+        let sender_account = borrow_global_mut<T>(Transaction::sender());
+        let sender_balance = borrow_global_mut<Balance>(Transaction::sender());
+        // The sender has delegated the privilege to withdraw from her account elsewhere--abort.
+        Transaction::assert(!sender_account.delegated_withdrawal_capability, 11);
+        // The sender has retained her withdrawal privileges--proceed.
+        withdraw_from_balance(sender_balance, amount)
+    }
+
+    // Withdraw `amount` LibraCoin::T from the account under cap.account_address
+    public fun withdraw_with_capability(
+        cap: &WithdrawalCapability, amount: u64
+    ): LibraCoin::T acquires Balance {
+        let balance = borrow_global_mut<Balance>(cap.account_address);
+        withdraw_from_balance(balance , amount)
+    }
+
+    // Return a unique capability granting permission to withdraw from the sender's account balance.
+    public fun extract_sender_withdrawal_capability(): WithdrawalCapability acquires T {
+        let sender = Transaction::sender();
+        let sender_account = borrow_global_mut<T>(sender);
+
+        // Abort if we already extracted the unique withdrawal capability for this account.
+        Transaction::assert(!sender_account.delegated_withdrawal_capability, 11);
+
+        // Ensure the uniqueness of the capability
+        sender_account.delegated_withdrawal_capability = true;
+        WithdrawalCapability { account_address: sender }
+    }
+
+    // Return the withdrawal capability to the account it originally came from
+    public fun restore_withdrawal_capability(cap: WithdrawalCapability) acquires T {
+        // Destroy the capability
+        let WithdrawalCapability { account_address } = cap;
+        let account = borrow_global_mut<T>(account_address);
+        // Update the flag for `account_address` to indicate that the capability has been restored.
+        // The account owner will now be able to call pay_from_sender, withdraw_from_sender, and
+        // extract_sender_withdrawal_capability again.
+        account.delegated_withdrawal_capability = false;
+    }
+
+    // Withdraws `amount` LibraCoin::T using the passed in WithdrawalCapability, and deposits it
+    // into the `payee`'s account balance. Creates the `payee` account if it doesn't exist.
+    public fun pay_from_capability(
+        payee: address,
+        auth_key_prefix: vector<u8>,
+        cap: &WithdrawalCapability,
+        amount: u64,
+        metadata: vector<u8>
+    ) acquires T, Balance {
+        if (!exists(payee)) {
+            create_account(payee, auth_key_prefix);
+        };
+        deposit_with_sender_and_metadata(
+            payee,
+            *&cap.account_address,
+            withdraw_with_capability(cap, amount),
+            metadata,
+        );
+    }
+
+    // Withdraw `amount` LibraCoin::T from the transaction sender's
+    // account balance and send the coin to the `payee` address with the
+    // attached `metadata` Creates the `payee` account if it does not exist
+    public fun pay_from_sender_with_metadata(
+        payee: address,
+        auth_key_prefix: vector<u8>,
+        amount: u64,
+        metadata: vector<u8>
+    ) acquires T, Balance {
+        if (!exists(payee)) {
+            create_account(payee, auth_key_prefix);
+        };
+        deposit_with_metadata(
+            payee,
+            withdraw_from_sender(amount),
+            metadata
+        );
+    }
+
+    // Withdraw `amount` LibraCoin::T from the transaction sender's
+    // account balance  and send the coin to the `payee` address
+    // Creates the `payee` account if it does not exist
+    public fun pay_from_sender(
+        payee: address,
+        auth_key_prefix: vector<u8>,
+        amount: u64
+    ) acquires T, Balance {
+        // FIXME: Update this once we have vector<u8> literals
+        pay_from_sender_with_metadata(payee, auth_key_prefix, amount, Vector::empty());
+    }
+
+    fun rotate_authentication_key_for_account(account: &mut T, new_authentication_key: vector<u8>) {
+      // Don't allow rotating to clearly invalid key
+      Transaction::assert(Vector::length(&new_authentication_key) == 32, 12);
+      account.authentication_key = new_authentication_key;
+    }
+
+    // Rotate the transaction sender's authentication key
+    // The new key will be used for signing future transactions
+    public fun rotate_authentication_key(new_authentication_key: vector<u8>) acquires T {
+        let sender_account = borrow_global_mut<T>(Transaction::sender());
+        // The sender has delegated the privilege to rotate her key elsewhere--abort
+        Transaction::assert(!sender_account.delegated_key_rotation_capability, 11);
+        // The sender has retained her key rotation privileges--proceed.
+        rotate_authentication_key_for_account(
+            sender_account,
+            new_authentication_key
+        );
+    }
+
+    // Rotate the authentication key for the account under cap.account_address
+    public fun rotate_authentication_key_with_capability(
+        cap: &KeyRotationCapability,
+        new_authentication_key: vector<u8>,
+    ) acquires T  {
+        rotate_authentication_key_for_account(
+            borrow_global_mut<T>(*&cap.account_address),
+            new_authentication_key
+        );
+    }
+
+    // Return a unique capability granting permission to rotate the sender's authentication key
+    public fun extract_sender_key_rotation_capability(): KeyRotationCapability acquires T {
+        let sender = Transaction::sender();
+        let sender_account = borrow_global_mut<T>(sender);
+        // Abort if we already extracted the unique key rotation capability for this account.
+        Transaction::assert(!sender_account.delegated_key_rotation_capability, 11);
+        sender_account.delegated_key_rotation_capability = true; // Ensure uniqueness of the capability
+        KeyRotationCapability { account_address: sender }
+    }
+
+    // Return the key rotation capability to the account it originally came from
+    public fun restore_key_rotation_capability(cap: KeyRotationCapability) acquires T {
+        // Destroy the capability
+        let KeyRotationCapability { account_address } = cap;
+        let account = borrow_global_mut<T>(account_address);
+        // Update the flag for `account_address` to indicate that the capability has been restored.
+        // The account owner will now be able to call rotate_authentication_key and
+        // extract_sender_key_rotation_capability again
+        account.delegated_key_rotation_capability = false;
+    }
+
+    // Creates a new account at `fresh_address` with an initial balance of zero and authentication
+    // key `auth_key_prefix` | `fresh_address`
+    // Creating an account at address 0x0 will cause runtime failure as it is a
+    // reserved address for the MoveVM.
+    public fun create_account(fresh_address: address, auth_key_prefix: vector<u8>) {
+        let generator = EventHandleGenerator {counter: 0};
+        let authentication_key = auth_key_prefix;
+        Vector::append(&mut authentication_key, AddressUtil::address_to_bytes(fresh_address));
+        Transaction::assert(Vector::length(&authentication_key) == 32, 12);
+
+        save_account(
+            Balance{
+                coin: LibraCoin::zero()
+            },
+            T {
+                authentication_key,
+                delegated_key_rotation_capability: false,
+                delegated_withdrawal_capability: false,
+                received_events: new_event_handle_impl<ReceivedPaymentEvent>(&mut generator, fresh_address),
+                sent_events: new_event_handle_impl<SentPaymentEvent>(&mut generator, fresh_address),
+                sequence_number: 0,
+                event_generator: generator,
+            },
+            fresh_address,
+        );
+    }
+
+    // Creates a new account at `fresh_address` with the `initial_balance` deducted from the
+    // transaction sender's account
+    public fun create_new_account(
+        fresh_address: address,
+        auth_key_prefix: vector<u8>,
+        initial_balance: u64
+    ) acquires T, Balance {
+        create_account(fresh_address, auth_key_prefix);
+        if (initial_balance > 0) {
+            deposit_with_metadata(
+                fresh_address,
+                withdraw_from_sender(initial_balance),
+                Vector::empty(),
+            );
+        }
+    }
+
+    // Save an account to a given address if the address does not have account resources yet
+    native fun save_account(
+        balance: Balance,
+        account: Self::T,
+        addr: address,
+    );
+
+    // Helper to return the u64 value of the `balance` for `account`
+    fun balance_for(balance: &Balance): u64 {
+        LibraCoin::value(&balance.coin)
+    }
+
+    // Return the current balance of the account at `addr`.
+    public fun balance(addr: address): u64 acquires Balance {
+        balance_for(borrow_global<Balance>(addr))
+    }
+
+    // Helper to return the sequence number field for given `account`
+    fun sequence_number_for_account(account: &T): u64 {
+        account.sequence_number
+    }
+
+    // Return the current sequence number at `addr`
+    public fun sequence_number(addr: address): u64 acquires T {
+        sequence_number_for_account(borrow_global<T>(addr))
+    }
+
+    // Return the authentication key for this account
+    public fun authentication_key(addr: address): vector<u8> acquires T {
+        *&borrow_global<T>(addr).authentication_key
+    }
+
+    // Return true if the account at `addr` has delegated its key rotation capability
+    public fun delegated_key_rotation_capability(addr: address): bool acquires T {
+        borrow_global<T>(addr).delegated_key_rotation_capability
+    }
+
+    // Return true if the account at `addr` has delegated its withdrawal capability
+    public fun delegated_withdrawal_capability(addr: address): bool acquires T {
+        borrow_global<T>(addr).delegated_withdrawal_capability
+    }
+
+    // Return a reference to the address associated with the given withdrawal capability
+    public fun withdrawal_capability_address(cap: &WithdrawalCapability): &address {
+        &cap.account_address
+    }
+
+    // Return a reference to the address associated with the given key rotation capability
+    public fun key_rotation_capability_address(cap: &KeyRotationCapability): &address {
+        &cap.account_address
+    }
+
+    // Checks if an account exists at `check_addr`
+    public fun exists(check_addr: address): bool {
+        ::exists<T>(check_addr)
+    }
+
+    // The prologue is invoked at the beginning of every transaction
+    // It verifies:
+    // - The account's auth key matches the transaction's public key
+    // - That the account has enough balance to pay for all of the gas
+    // - That the sequence number matches the transaction's sequence key
+    fun prologue(
+        txn_sequence_number: u64,
+        txn_public_key: vector<u8>,
+        txn_gas_price: u64,
+        txn_max_gas_units: u64,
+        txn_expiration_time: u64,
+    ) acquires T, Balance {
+        let transaction_sender = Transaction::sender();
+
+        // FUTURE: Make these error codes sequential
+        // Verify that the transaction sender's account exists
+        Transaction::assert(exists(transaction_sender), 5);
+
+        // Load the transaction sender's account
+        let sender_account = borrow_global_mut<T>(transaction_sender);
+
+        // Check that the hash of the transaction's public key matches the account's auth key
+        Transaction::assert(
+            Hash::sha3_256(txn_public_key) == *&sender_account.authentication_key,
+            2
+        );
+
+        // Check that the account has enough balance for all of the gas
+        let max_transaction_fee = txn_gas_price * txn_max_gas_units;
+        let balance_amount = balance(transaction_sender);
+        Transaction::assert(balance_amount >= max_transaction_fee, 6);
+
+        // Check that the transaction sequence number matches the sequence number of the account
+        Transaction::assert(txn_sequence_number >= sender_account.sequence_number, 3);
+        Transaction::assert(txn_sequence_number == sender_account.sequence_number, 4);
+        Transaction::assert(LibraTransactionTimeout::is_valid_transaction_timestamp(txn_expiration_time), 7);
+    }
+
+    // The epilogue is invoked at the end of transactions.
+    // It collects gas and bumps the sequence number
+    fun epilogue(
+        txn_sequence_number: u64,
+        txn_gas_price: u64,
+        txn_max_gas_units: u64,
+        gas_units_remaining: u64
+    ) acquires T, Balance {
+        // Load the transaction sender's account and balance resources
+        let sender_account = borrow_global_mut<T>(Transaction::sender());
+        let sender_balance = borrow_global_mut<Balance>(Transaction::sender());
+
+        // Charge for gas
+        let transaction_fee_amount = txn_gas_price * (txn_max_gas_units - gas_units_remaining);
+        Transaction::assert(
+            balance_for(sender_balance) >= transaction_fee_amount,
+            6
+        );
+        let transaction_fee = withdraw_from_balance(
+                sender_balance,
+                transaction_fee_amount
+            );
+
+        // Bump the sequence number
+        sender_account.sequence_number = txn_sequence_number + 1;
+        // Pay the transaction fee into the transaction fee balance
+        let transaction_fee_balance = borrow_global_mut<Balance>(0xFEE);
+        LibraCoin::deposit(&mut transaction_fee_balance.coin, transaction_fee);
+    }
+
+    /// Events
+    //
+    // Derive a fresh unique id by using sender's EventHandleGenerator. The generated vector<u8> is indeed unique because it
+    // was derived from the hash(sender's EventHandleGenerator || sender_address). This module guarantees that the
+    // EventHandleGenerator is only going to be monotonically increased and there's no way to revert it or destroy it. Thus
+    // such counter is going to give distinct value for each of the new event stream under each sender. And since we
+    // hash it with the sender's address, the result is guaranteed to be globally unique.
+    fun fresh_guid(counter: &mut EventHandleGenerator, sender: address): vector<u8> {
+        let sender_bytes = AddressUtil::address_to_bytes(sender);
+
+        let count_bytes = U64Util::u64_to_bytes(counter.counter);
+        counter.counter = counter.counter + 1;
+
+        // EventHandleGenerator goes first just in case we want to extend address in the future.
+        Vector::append(&mut count_bytes, sender_bytes);
+
+        count_bytes
+    }
+
+    // Use EventHandleGenerator to generate a unique event handle that one can emit an event to.
+    fun new_event_handle_impl<T: copyable>(counter: &mut EventHandleGenerator, sender: address): EventHandle<T> {
+        EventHandle<T> {counter: 0, guid: fresh_guid(counter, sender)}
+    }
+
+    // Use sender's EventHandleGenerator to generate a unique event handle that one can emit an event to.
+    public fun new_event_handle<E: copyable>(): EventHandle<E> acquires T {
+        let sender_account_ref = borrow_global_mut<T>(Transaction::sender());
+        new_event_handle_impl<E>(&mut sender_account_ref.event_generator, Transaction::sender())
+    }
+
+    // Emit an event with payload `msg` by using handle's key and counter. Will change the payload from vector<u8> to a
+    // generic type parameter once we have generics.
+    public fun emit_event<T: copyable>(handle_ref: &mut EventHandle<T>, msg: T) {
+        let guid = *&handle_ref.guid;
+
+        write_to_event_store<T>(guid, handle_ref.counter, msg);
+        handle_ref.counter = handle_ref.counter + 1;
+    }
+
+    // Native procedure that writes to the actual event stream in Event store
+    // This will replace the "native" portion of EmitEvent bytecode
+    native fun write_to_event_store<T: copyable>(guid: vector<u8>, count: u64, msg: T);
+
+    // Destroy a unique handle.
+    public fun destroy_handle<T: copyable>(handle: EventHandle<T>) {
+        EventHandle<T> { counter: _, guid: _ } = handle;
+    }
+}

--- a/language/move-prover/tests/sources/stdlib/modules/libra_block.exp
+++ b/language/move-prover/tests/sources/stdlib/modules/libra_block.exp
@@ -1,0 +1,448 @@
+Move prover returns: exiting with boogie verification errors
+error:  A precondition for this call might not hold.
+
+    ┌── tests/sources/stdlib/modules/validator_config.move:93:5 ───
+    │
+ 93 │ ╭     public fun rotate_consensus_pubkey(consensus_pubkey: vector<u8>) acquires T {
+ 94 │ │         let t_ref = borrow_global_mut<T>(Transaction::sender());
+ 95 │ │         let key_ref = &mut t_ref.config.consensus_pubkey;
+ 96 │ │         *key_ref = consensus_pubkey;
+ 97 │ │     }
+    │ ╰─────^
+    │
+    =     at tests/sources/stdlib/modules/libra_system.move:289:4: rotate_consensus_pubkey (entry)
+    =     at tests/sources/stdlib/modules/libra_system.move:290:32: rotate_consensus_pubkey
+    =         consensus_pubkey = <redacted>,
+    =         validator_set_ref = <redacted>
+    =     at tests/sources/stdlib/modules/libra_system.move:291:43: rotate_consensus_pubkey
+    =         account_address = <redacted>
+    =     at tests/sources/stdlib/modules/libra_system.move:140:4: is_validator_ (entry)
+    =     at tests/sources/stdlib/modules/libra_system.move:141:28: is_validator_
+    =         addr = <redacted>,
+    =         validators_vec_ref = <redacted>,
+    =         size = <redacted>
+    =     at tests/sources/stdlib/modules/libra_system.move:142:13: is_validator_
+    =     at tests/sources/stdlib/modules/libra_system.move:146:13: is_validator_
+    =     at tests/sources/stdlib/modules/libra_system.move:148:49: is_validator_
+    =         i = <redacted>,
+    =         validator_info_ref = <redacted>
+    =     at tests/sources/stdlib/modules/libra_system.move:150:18: is_validator_
+    =     at tests/sources/stdlib/modules/libra_system.move:295:12: rotate_consensus_pubkey
+    =     at tests/sources/stdlib/modules/libra_system.move:294:8: rotate_consensus_pubkey
+    =     at tests/sources/stdlib/modules/validator_config.move:93:5: rotate_consensus_pubkey (entry)
+
+error:  A precondition for this call might not hold.
+
+     ┌── tests/sources/stdlib/modules/libra_system.move:115:5 ───
+     │
+ 115 │ ╭     public fun get_discovery_address(d: &DiscoveryInfo): &address {
+ 116 │ │         &d.addr
+ 117 │ │     }
+     │ ╰─────^
+     │
+     =     at tests/sources/stdlib/modules/libra_system.move:329:4: rotate_validator_network_address (entry)
+     =     at tests/sources/stdlib/modules/libra_system.move:332:32: rotate_validator_network_address
+     =         validator_network_address = <redacted>,
+     =         discovery_set_ref = <redacted>
+     =     at tests/sources/stdlib/modules/libra_system.move:335:58: rotate_validator_network_address
+     =     at tests/sources/stdlib/modules/validator_config.move:113:5: rotate_validator_network_address (entry)
+     =     at tests/sources/stdlib/modules/validator_config.move:116:21: rotate_validator_network_address
+     =         validator_network_address = <redacted>,
+     =         t_ref = <redacted>
+     =     at tests/sources/stdlib/modules/validator_config.move:117:13: rotate_validator_network_address
+     =         key_ref = <redacted>
+     =     at tests/sources/stdlib/modules/validator_config.move:118:20: rotate_validator_network_address
+     =         key_ref = <redacted>,
+     =         t_ref = <redacted>
+     =     at tests/sources/stdlib/modules/libra_system.move:335:25: rotate_validator_network_address
+     =     at tests/sources/stdlib/modules/libra_system.move:207:5: get_discovery_index (entry)
+     =     at tests/sources/stdlib/modules/libra_system.move:208:27: get_discovery_index
+     =         discovery_set = <redacted>,
+     =         addr = <redacted>,
+     =         len = <redacted>
+     =     at tests/sources/stdlib/modules/libra_system.move:209:17: get_discovery_index
+     =         i = <redacted>
+     =     at tests/sources/stdlib/modules/libra_system.move:211:54: get_discovery_index
+     =     at tests/sources/stdlib/modules/libra_system.move:115:5: get_discovery_address (entry)
+
+error:  A precondition for this call might not hold.
+
+     ┌── tests/sources/stdlib/modules/libra_system.move:115:5 ───
+     │
+ 115 │ ╭     public fun get_discovery_address(d: &DiscoveryInfo): &address {
+ 116 │ │         &d.addr
+ 117 │ │     }
+     │ ╰─────^
+     │
+     =     at tests/sources/stdlib/modules/libra_system.move:311:4: rotate_validator_network_identity_pubkey (entry)
+     =     at tests/sources/stdlib/modules/libra_system.move:314:32: rotate_validator_network_identity_pubkey
+     =         validator_network_identity_pubkey = <redacted>,
+     =         discovery_set_ref = <redacted>
+     =     at tests/sources/stdlib/modules/libra_system.move:317:66: rotate_validator_network_identity_pubkey
+     =     at tests/sources/stdlib/modules/validator_config.move:103:5: rotate_validator_network_identity_pubkey (entry)
+     =     at tests/sources/stdlib/modules/validator_config.move:106:21: rotate_validator_network_identity_pubkey
+     =         validator_network_identity_pubkey = <redacted>,
+     =         t_ref = <redacted>
+     =     at tests/sources/stdlib/modules/validator_config.move:107:13: rotate_validator_network_identity_pubkey
+     =         key_ref = <redacted>
+     =     at tests/sources/stdlib/modules/validator_config.move:108:20: rotate_validator_network_identity_pubkey
+     =         key_ref = <redacted>,
+     =         t_ref = <redacted>
+     =     at tests/sources/stdlib/modules/libra_system.move:317:25: rotate_validator_network_identity_pubkey
+     =     at tests/sources/stdlib/modules/libra_system.move:207:5: get_discovery_index (entry)
+     =     at tests/sources/stdlib/modules/libra_system.move:208:27: get_discovery_index
+     =         discovery_set = <redacted>,
+     =         addr = <redacted>,
+     =         len = <redacted>
+     =     at tests/sources/stdlib/modules/libra_system.move:209:17: get_discovery_index
+     =         i = <redacted>
+     =     at tests/sources/stdlib/modules/libra_system.move:211:54: get_discovery_index
+     =     at tests/sources/stdlib/modules/libra_system.move:115:5: get_discovery_address (entry)
+
+error:  A precondition for this call might not hold.
+
+     ┌── tests/sources/stdlib/modules/libra_system.move:412:4 ───
+     │
+ 412 │ ╭    fun make_validator_info(addr: address): ValidatorInfo {
+ 413 │ │        let config = ValidatorConfig::config(addr);
+ 414 │ │
+ 415 │ │       ValidatorInfo {
+ 416 │ │           addr: addr,
+ 417 │ │           consensus_pubkey: ValidatorConfig::consensus_pubkey(&config),
+ 418 │ │           consensus_voting_power: 1,
+ 419 │ │           network_signing_pubkey: ValidatorConfig::validator_network_signing_pubkey(&config),
+ 420 │ │           network_identity_pubkey: ValidatorConfig::validator_network_identity_pubkey(&config),
+ 421 │ │       }
+ 422 │ │    }
+     │ ╰────^
+     │
+     =     at tests/sources/stdlib/modules/libra_system.move:227:5: add_validator (entry)
+     =     at tests/sources/stdlib/modules/libra_system.move:233:4: add_validator_ (entry)
+     =     at tests/sources/stdlib/modules/libra_system.move:235:8: add_validator_
+     =         account_address = <redacted>
+     =     at tests/sources/stdlib/modules/validator_config.move:24:5: has (entry)
+     =     at tests/sources/stdlib/modules/libra_system.move:237:45: add_validator_
+     =     at tests/sources/stdlib/modules/libra_system.move:239:32: add_validator_
+     =         validator_set_ref = <redacted>
+     =     at tests/sources/stdlib/modules/libra_system.move:240:64: add_validator_
+     =         discovery_set_ref = <redacted>
+     =     at tests/sources/stdlib/modules/libra_system.move:140:4: is_validator_ (entry)
+     =     at tests/sources/stdlib/modules/libra_system.move:141:28: is_validator_
+     =         addr = <redacted>,
+     =         validators_vec_ref = <redacted>,
+     =         size = <redacted>
+     =     at tests/sources/stdlib/modules/libra_system.move:142:13: is_validator_
+     =     at tests/sources/stdlib/modules/libra_system.move:146:13: is_validator_
+     =     at tests/sources/stdlib/modules/libra_system.move:148:49: is_validator_
+     =         i = <redacted>,
+     =         validator_info_ref = <redacted>
+     =     at tests/sources/stdlib/modules/libra_system.move:150:18: is_validator_
+     =     at tests/sources/stdlib/modules/libra_system.move:153:19: is_validator_
+     =         i = <redacted>
+     =     at tests/sources/stdlib/modules/libra_system.move:154:17: is_validator_
+     =     at tests/sources/stdlib/modules/libra_system.move:244:13: add_validator_
+     =     at tests/sources/stdlib/modules/libra_system.move:243:8: add_validator_
+     =     at tests/sources/stdlib/modules/libra_system.move:412:4: make_validator_info (entry)
+
+error:  A precondition for this call might not hold.
+
+     ┌── tests/sources/stdlib/modules/libra_system.move:412:4 ───
+     │
+ 412 │ ╭    fun make_validator_info(addr: address): ValidatorInfo {
+ 413 │ │        let config = ValidatorConfig::config(addr);
+ 414 │ │
+ 415 │ │       ValidatorInfo {
+ 416 │ │           addr: addr,
+ 417 │ │           consensus_pubkey: ValidatorConfig::consensus_pubkey(&config),
+ 418 │ │           consensus_voting_power: 1,
+ 419 │ │           network_signing_pubkey: ValidatorConfig::validator_network_signing_pubkey(&config),
+ 420 │ │           network_identity_pubkey: ValidatorConfig::validator_network_identity_pubkey(&config),
+ 421 │ │       }
+ 422 │ │    }
+     │ ╰────^
+     │
+     =     at tests/sources/stdlib/modules/libra_system.move:233:4: add_validator_ (entry)
+     =     at tests/sources/stdlib/modules/libra_system.move:235:8: add_validator_
+     =         account_address = <redacted>
+     =     at tests/sources/stdlib/modules/validator_config.move:24:5: has (entry)
+     =     at tests/sources/stdlib/modules/libra_system.move:237:45: add_validator_
+     =     at tests/sources/stdlib/modules/libra_system.move:239:32: add_validator_
+     =         validator_set_ref = <redacted>
+     =     at tests/sources/stdlib/modules/libra_system.move:240:64: add_validator_
+     =         discovery_set_ref = <redacted>
+     =     at tests/sources/stdlib/modules/libra_system.move:140:4: is_validator_ (entry)
+     =     at tests/sources/stdlib/modules/libra_system.move:141:28: is_validator_
+     =         addr = <redacted>,
+     =         validators_vec_ref = <redacted>,
+     =         size = <redacted>
+     =     at tests/sources/stdlib/modules/libra_system.move:142:13: is_validator_
+     =     at tests/sources/stdlib/modules/libra_system.move:146:13: is_validator_
+     =     at tests/sources/stdlib/modules/libra_system.move:148:49: is_validator_
+     =         i = <redacted>,
+     =         validator_info_ref = <redacted>
+     =     at tests/sources/stdlib/modules/libra_system.move:150:18: is_validator_
+     =     at tests/sources/stdlib/modules/libra_system.move:153:19: is_validator_
+     =         i = <redacted>
+     =     at tests/sources/stdlib/modules/libra_system.move:154:17: is_validator_
+     =     at tests/sources/stdlib/modules/libra_system.move:244:13: add_validator_
+     =     at tests/sources/stdlib/modules/libra_system.move:243:8: add_validator_
+     =     at tests/sources/stdlib/modules/libra_system.move:412:4: make_validator_info (entry)
+
+error:  A precondition for this call might not hold.
+
+     ┌── tests/sources/stdlib/modules/libra_system.move:115:5 ───
+     │
+ 115 │ ╭     public fun get_discovery_address(d: &DiscoveryInfo): &address {
+ 116 │ │         &d.addr
+ 117 │ │     }
+     │ ╰─────^
+     │
+     =     at tests/sources/stdlib/modules/libra_system.move:207:5: get_discovery_index (entry)
+     =     at tests/sources/stdlib/modules/libra_system.move:208:27: get_discovery_index
+     =         discovery_set = <redacted>,
+     =         addr = <redacted>,
+     =         len = <redacted>
+     =     at tests/sources/stdlib/modules/libra_system.move:209:17: get_discovery_index
+     =         i = <redacted>
+     =     at tests/sources/stdlib/modules/libra_system.move:211:54: get_discovery_index
+     =     at tests/sources/stdlib/modules/libra_system.move:115:5: get_discovery_address (entry)
+
+error:  A precondition for this call might not hold.
+
+    ┌── tests/sources/stdlib/modules/libra_system.move:93:5 ───
+    │
+ 93 │ ╭     public fun get_validator_address(v: &ValidatorInfo): &address {
+ 94 │ │       &v.addr
+ 95 │ │     }
+    │ ╰─────^
+    │
+    =     at tests/sources/stdlib/modules/libra_system.move:190:5: get_validator_index (entry)
+    =     at tests/sources/stdlib/modules/libra_system.move:191:27: get_validator_index
+    =         validators = <redacted>,
+    =         addr = <redacted>,
+    =         len = <redacted>
+    =     at tests/sources/stdlib/modules/libra_system.move:192:17: get_validator_index
+    =         i = <redacted>
+    =     at tests/sources/stdlib/modules/libra_system.move:194:54: get_validator_index
+    =     at tests/sources/stdlib/modules/libra_system.move:93:5: get_validator_address (entry)
+
+error:  A precondition for this call might not hold.
+
+    ┌── tests/sources/stdlib/modules/libra_system.move:93:5 ───
+    │
+ 93 │ ╭     public fun get_validator_address(v: &ValidatorInfo): &address {
+ 94 │ │       &v.addr
+ 95 │ │     }
+    │ ╰─────^
+    │
+    =     at tests/sources/stdlib/modules/libra_system.move:258:4: remove_validator (entry)
+    =     at tests/sources/stdlib/modules/libra_system.move:260:8: remove_validator
+    =         account_address = <redacted>
+    =     at tests/sources/stdlib/modules/libra_system.move:262:32: remove_validator
+    =         validator_set_ref = <redacted>
+    =     at tests/sources/stdlib/modules/libra_system.move:263:64: remove_validator
+    =         discovery_set_ref = <redacted>
+    =     at tests/sources/stdlib/modules/libra_system.move:140:4: is_validator_ (entry)
+    =     at tests/sources/stdlib/modules/libra_system.move:141:28: is_validator_
+    =         addr = <redacted>,
+    =         validators_vec_ref = <redacted>,
+    =         size = <redacted>
+    =     at tests/sources/stdlib/modules/libra_system.move:142:13: is_validator_
+    =     at tests/sources/stdlib/modules/libra_system.move:146:13: is_validator_
+    =     at tests/sources/stdlib/modules/libra_system.move:148:49: is_validator_
+    =         i = <redacted>,
+    =         validator_info_ref = <redacted>
+    =     at tests/sources/stdlib/modules/libra_system.move:150:18: is_validator_
+    =     at tests/sources/stdlib/modules/libra_system.move:266:12: remove_validator
+    =     at tests/sources/stdlib/modules/libra_system.move:265:8: remove_validator
+    =     at tests/sources/stdlib/modules/libra_system.move:190:5: get_validator_index (entry)
+    =     at tests/sources/stdlib/modules/libra_system.move:191:27: get_validator_index
+    =     at tests/sources/stdlib/modules/libra_system.move:192:17: get_validator_index
+    =     at tests/sources/stdlib/modules/libra_system.move:194:54: get_validator_index
+    =     at tests/sources/stdlib/modules/libra_system.move:93:5: get_validator_address (entry)
+
+error:  A precondition for this call might not hold.
+
+     ┌── tests/sources/stdlib/modules/libra_system.move:174:5 ───
+     │
+ 174 │ ╭     public fun get_ith_validator_address(i: u64): address acquires ValidatorSet {
+ 175 │ │       let validator_set = borrow_global<ValidatorSet>(0x1D8);
+ 176 │ │       let len = Vector::length(&validator_set.validators);
+ 177 │ │       Transaction::assert(i < len, 3);
+ 178 │ │       Vector::borrow(&validator_set.validators, i).addr
+ 179 │ │     }
+     │ ╰─────^
+     │
+     =     at tests/sources/stdlib/modules/transaction_fee.move:51:5: distribute_transaction_fees (entry)
+     =     at tests/sources/stdlib/modules/transaction_fee.move:53:7: distribute_transaction_fees
+     =     at tests/sources/stdlib/modules/libra_system.move:136:5: validator_set_size (entry)
+     =     at tests/sources/stdlib/modules/libra_system.move:137:25: validator_set_size
+     =     at tests/sources/stdlib/modules/transaction_fee.move:55:41: distribute_transaction_fees
+     =         num_validators = <redacted>
+     =     at tests/sources/stdlib/modules/transaction_fee.move:56:52: distribute_transaction_fees
+     =         amount_collected = <redacted>
+     =     at tests/sources/stdlib/modules/libra_account.move:384:5: balance (entry)
+     =     at tests/sources/stdlib/modules/libra_account.move:385:21: balance
+     =         addr = <redacted>
+     =     at tests/sources/stdlib/modules/libra_account.move:379:5: balance_for (entry)
+     =     at tests/sources/stdlib/modules/libra_coin.move:105:5: value (entry)
+     =     at tests/sources/stdlib/modules/libra_coin.move:105:5: value (exit)
+     =         coin_ref = <redacted>
+     =     at tests/sources/stdlib/modules/libra_account.move:380:20: balance_for
+     =         balance = <redacted>
+     =     at tests/sources/stdlib/modules/libra_account.move:385:9: balance
+     =     at tests/sources/stdlib/modules/transaction_fee.move:56:44: distribute_transaction_fees
+     =     at tests/sources/stdlib/modules/transaction_fee.move:59:11: distribute_transaction_fees
+     =     at tests/sources/stdlib/modules/transaction_fee.move:108:5: per_validator_distribution_amount (entry)
+     =     at tests/sources/stdlib/modules/transaction_fee.move:109:9: per_validator_distribution_amount
+     =         amount_collected = <redacted>,
+     =         num_validators = <redacted>
+     =     at tests/sources/stdlib/modules/transaction_fee.move:110:49: per_validator_distribution_amount
+     =         validator_payout = <redacted>
+     =     at tests/sources/stdlib/modules/transaction_fee.move:111:29: per_validator_distribution_amount
+     =     at tests/sources/stdlib/modules/transaction_fee.move:62:48: distribute_transaction_fees
+     =         amount_to_distribute_per_validator = <redacted>
+     =     at tests/sources/stdlib/modules/transaction_fee.move:69:11: distribute_transaction_fees
+     =     at tests/sources/stdlib/modules/transaction_fee.move:79:5: distribute_transaction_fees_internal (entry)
+     =     at tests/sources/stdlib/modules/transaction_fee.move:83:37: distribute_transaction_fees_internal
+     =         amount_to_distribute_per_validator = <redacted>,
+     =         num_validators = <redacted>,
+     =         distribution_resource = <redacted>
+     =     at tests/sources/stdlib/modules/transaction_fee.move:84:21: distribute_transaction_fees_internal
+     =         index = <redacted>
+     =     at tests/sources/stdlib/modules/transaction_fee.move:86:16: distribute_transaction_fees_internal
+     =     at tests/sources/stdlib/modules/libra_system.move:174:5: get_ith_validator_address (entry)
+
+error:  A precondition for this call might not hold.
+
+     ┌── tests/sources/stdlib/modules/libra_system.move:174:5 ───
+     │
+ 174 │ ╭     public fun get_ith_validator_address(i: u64): address acquires ValidatorSet {
+ 175 │ │       let validator_set = borrow_global<ValidatorSet>(0x1D8);
+ 176 │ │       let len = Vector::length(&validator_set.validators);
+ 177 │ │       Transaction::assert(i < len, 3);
+ 178 │ │       Vector::borrow(&validator_set.validators, i).addr
+ 179 │ │     }
+     │ ╰─────^
+     │
+     =     at tests/sources/stdlib/modules/transaction_fee.move:79:5: distribute_transaction_fees_internal (entry)
+     =     at tests/sources/stdlib/modules/transaction_fee.move:83:37: distribute_transaction_fees_internal
+     =         amount_to_distribute_per_validator = <redacted>,
+     =         num_validators = <redacted>,
+     =         distribution_resource = <redacted>
+     =     at tests/sources/stdlib/modules/transaction_fee.move:84:21: distribute_transaction_fees_internal
+     =         index = <redacted>
+     =     at tests/sources/stdlib/modules/transaction_fee.move:86:16: distribute_transaction_fees_internal
+     =     at tests/sources/stdlib/modules/libra_system.move:174:5: get_ith_validator_address (entry)
+
+error:  A precondition for this call might not hold.
+
+     ┌── tests/sources/stdlib/modules/libra_system.move:174:5 ───
+     │
+ 174 │ ╭     public fun get_ith_validator_address(i: u64): address acquires ValidatorSet {
+ 175 │ │       let validator_set = borrow_global<ValidatorSet>(0x1D8);
+ 176 │ │       let len = Vector::length(&validator_set.validators);
+ 177 │ │       Transaction::assert(i < len, 3);
+ 178 │ │       Vector::borrow(&validator_set.validators, i).addr
+ 179 │ │     }
+     │ ╰─────^
+     │
+     =     at tests/sources/stdlib/modules/libra_block.move:57:5: block_prologue (entry)
+     =     at tests/sources/stdlib/modules/libra_block.move:64:7: block_prologue
+     =         timestamp = <redacted>,
+     =         new_block_hash = <redacted>,
+     =         previous_block_votes = <redacted>,
+     =         proposer = <redacted>
+     =     at tests/sources/stdlib/modules/libra_block.move:74:5: process_block_prologue (entry)
+     =     at tests/sources/stdlib/modules/libra_block.move:80:34: process_block_prologue
+     =         timestamp = <redacted>,
+     =         new_block_hash = <redacted>,
+     =         previous_block_votes = <redacted>,
+     =         proposer = <redacted>,
+     =         block_metadata_ref = <redacted>
+     =     at tests/sources/stdlib/modules/libra_block.move:83:12: process_block_prologue
+     =     at tests/sources/stdlib/modules/libra_block.move:84:44: process_block_prologue
+     =     at tests/sources/stdlib/modules/libra_time.move:24:5: update_global_time (entry)
+     =     at tests/sources/stdlib/modules/libra_time.move:26:9: update_global_time
+     =     at tests/sources/stdlib/modules/libra_time.move:28:28: update_global_time
+     =     at tests/sources/stdlib/modules/libra_time.move:29:13: update_global_time
+     =     at tests/sources/stdlib/modules/libra_time.move:31:13: update_global_time
+     =     at tests/sources/stdlib/modules/libra_time.move:36:37: update_global_time
+     =     at tests/sources/stdlib/modules/libra_block.move:84:25: process_block_prologue
+     =     at tests/sources/stdlib/modules/libra_block.move:86:9: process_block_prologue
+     =     at tests/sources/stdlib/modules/libra_block.move:87:39: process_block_prologue
+     =     at tests/sources/stdlib/modules/libra_block.move:88:37: process_block_prologue
+     =     at tests/sources/stdlib/modules/libra_block.move:66:7: block_prologue
+     =     at tests/sources/stdlib/modules/transaction_fee.move:51:5: distribute_transaction_fees (entry)
+     =     at tests/sources/stdlib/modules/transaction_fee.move:53:7: distribute_transaction_fees
+     =     at tests/sources/stdlib/modules/libra_system.move:136:5: validator_set_size (entry)
+     =     at tests/sources/stdlib/modules/libra_system.move:137:25: validator_set_size
+     =     at tests/sources/stdlib/modules/transaction_fee.move:55:41: distribute_transaction_fees
+     =     at tests/sources/stdlib/modules/transaction_fee.move:56:52: distribute_transaction_fees
+     =     at tests/sources/stdlib/modules/libra_account.move:384:5: balance (entry)
+     =     at tests/sources/stdlib/modules/libra_account.move:385:21: balance
+     =     at tests/sources/stdlib/modules/libra_account.move:379:5: balance_for (entry)
+     =     at tests/sources/stdlib/modules/libra_coin.move:105:5: value (entry)
+     =     at tests/sources/stdlib/modules/libra_coin.move:105:5: value (exit)
+     =     at tests/sources/stdlib/modules/libra_account.move:380:20: balance_for
+     =     at tests/sources/stdlib/modules/libra_account.move:385:9: balance
+     =     at tests/sources/stdlib/modules/transaction_fee.move:56:44: distribute_transaction_fees
+     =     at tests/sources/stdlib/modules/transaction_fee.move:59:11: distribute_transaction_fees
+     =     at tests/sources/stdlib/modules/transaction_fee.move:108:5: per_validator_distribution_amount (entry)
+     =     at tests/sources/stdlib/modules/transaction_fee.move:109:9: per_validator_distribution_amount
+     =     at tests/sources/stdlib/modules/transaction_fee.move:110:49: per_validator_distribution_amount
+     =     at tests/sources/stdlib/modules/transaction_fee.move:111:29: per_validator_distribution_amount
+     =     at tests/sources/stdlib/modules/transaction_fee.move:62:48: distribute_transaction_fees
+     =     at tests/sources/stdlib/modules/transaction_fee.move:69:11: distribute_transaction_fees
+     =     at tests/sources/stdlib/modules/transaction_fee.move:79:5: distribute_transaction_fees_internal (entry)
+     =     at tests/sources/stdlib/modules/transaction_fee.move:83:37: distribute_transaction_fees_internal
+     =     at tests/sources/stdlib/modules/transaction_fee.move:84:21: distribute_transaction_fees_internal
+     =     at tests/sources/stdlib/modules/transaction_fee.move:86:16: distribute_transaction_fees_internal
+     =     at tests/sources/stdlib/modules/libra_system.move:174:5: get_ith_validator_address (entry)
+
+error:  A precondition for this call might not hold.
+
+    ┌── tests/sources/stdlib/modules/libra_time.move:24:5 ───
+    │
+ 24 │ ╭     public fun update_global_time(proposer: address, timestamp: u64) acquires CurrentTimeMicroseconds {
+ 25 │ │
+ 26 │ │         Transaction::assert(Transaction::sender() == 0x0, 33);
+ 27 │ │
+ 28 │ │         let global_timer = borrow_global_mut<CurrentTimeMicroseconds>(0xA550C18);
+ 29 │ │         if (proposer == 0x0) {
+ 30 │ │
+ 31 │ │             Transaction::assert(timestamp == global_timer.microseconds, 5001);
+ 32 │ │         } else {
+ 33 │ │
+ 34 │ │             Transaction::assert(global_timer.microseconds < timestamp, 5001);
+ 35 │ │         };
+ 36 │ │         global_timer.microseconds = timestamp;
+ 37 │ │     }
+    │ ╰─────^
+    │
+    =     at tests/sources/stdlib/modules/libra_block.move:74:5: process_block_prologue (entry)
+    =     at tests/sources/stdlib/modules/libra_block.move:80:34: process_block_prologue
+    =         timestamp = <redacted>,
+    =         new_block_hash = <redacted>,
+    =         previous_block_votes = <redacted>,
+    =         proposer = <redacted>,
+    =         block_metadata_ref = <redacted>
+    =     at tests/sources/stdlib/modules/libra_block.move:83:12: process_block_prologue
+    =     at tests/sources/stdlib/modules/libra_system.move:162:5: is_validator (entry)
+    =     at tests/sources/stdlib/modules/libra_system.move:163:31: is_validator
+    =         addr = <redacted>
+    =     at tests/sources/stdlib/modules/libra_system.move:140:4: is_validator_ (entry)
+    =     at tests/sources/stdlib/modules/libra_system.move:141:28: is_validator_
+    =         addr = <redacted>,
+    =         validators_vec_ref = <redacted>,
+    =         size = <redacted>
+    =     at tests/sources/stdlib/modules/libra_system.move:142:13: is_validator_
+    =     at tests/sources/stdlib/modules/libra_system.move:146:13: is_validator_
+    =     at tests/sources/stdlib/modules/libra_system.move:148:49: is_validator_
+    =         i = <redacted>,
+    =         validator_info_ref = <redacted>
+    =     at tests/sources/stdlib/modules/libra_system.move:150:18: is_validator_
+    =     at tests/sources/stdlib/modules/libra_system.move:163:9: is_validator
+    =     at tests/sources/stdlib/modules/libra_block.move:83:62: process_block_prologue
+    =     at tests/sources/stdlib/modules/libra_block.move:84:44: process_block_prologue
+    =     at tests/sources/stdlib/modules/libra_time.move:24:5: update_global_time (entry)

--- a/language/move-prover/tests/sources/stdlib/modules/libra_block.move
+++ b/language/move-prover/tests/sources/stdlib/modules/libra_block.move
@@ -1,0 +1,105 @@
+// dep: tests/sources/stdlib/modules/libra_time.move
+// dep: tests/sources/stdlib/modules/libra_transaction_timeout.move
+// dep: tests/sources/stdlib/modules/transaction.move
+// dep: tests/sources/stdlib/modules/transaction_fee.move
+// dep: tests/sources/stdlib/modules/u64_util.move
+// dep: tests/sources/stdlib/modules/libra_system.move
+// dep: tests/sources/stdlib/modules/hash.move
+// dep: tests/sources/stdlib/modules/vector.move
+// dep: tests/sources/stdlib/modules/libra_coin.move
+// dep: tests/sources/stdlib/modules/libra_account.move
+// dep: tests/sources/stdlib/modules/validator_config.move
+// dep: tests/sources/stdlib/modules/address_util.move
+
+address 0x0:
+
+module LibraBlock {
+    use 0x0::LibraTimestamp;
+    use 0x0::Transaction;
+    use 0x0::TransactionFee;
+    use 0x0::U64Util;
+    use 0x0::LibraSystem;
+
+    resource struct BlockMetadata {
+      // Height of the current block
+      // TODO: Should we keep the height?
+      height: u64,
+
+      // Hash of the current block of transactions.
+      id: vector<u8>,
+
+      // Proposer of the current block.
+      proposer: address,
+    }
+
+    // This can only be invoked by the Association address, and only a single time.
+    // Currently, it is invoked in the genesis transaction
+    public fun initialize_block_metadata() {
+      // Only callable by the Association address
+      Transaction::assert(Transaction::sender() == 0xA550C18, 1);
+
+      // TODO: How should we get the default block metadata? Should it be set in the first block prologue transaction or
+      //       in the genesis?
+      move_to_sender<BlockMetadata>(BlockMetadata {
+        height: 0,
+        // FIXME: Update this once we have byte vector literals
+        id: U64Util::u64_to_bytes(0),
+        proposer: 0xA550C18,
+      });
+      LibraTimestamp::initialize_timer();
+    }
+
+    // Set the metadata for the current block.
+    // The runtime always runs this before executing the transactions in a block.
+    // TODO: 1. Make this private, support other metadata
+    //       2. Should the previous block votes be provided from BlockMetadata or should it come from the ValidatorSet
+    //          Resource?
+    public fun block_prologue(
+        timestamp: u64,
+        new_block_hash: vector<u8>,
+        previous_block_votes: vector<u8>,
+        proposer: address
+    ) acquires BlockMetadata {
+      // Can only be invoked by LibraVM privilege.
+      Transaction::assert(Transaction::sender() == 0x0, 33);
+
+      process_block_prologue(timestamp, new_block_hash, previous_block_votes, proposer);
+
+      // Currently distribute once per-block.
+      // TODO: Once we have a better on-chain representation of epochs we will make this per-epoch.
+      TransactionFee::distribute_transaction_fees();
+    }
+
+    // Update the BlockMetadata resource with the new blockmetada coming from the consensus.
+    fun process_block_prologue(
+        timestamp: u64,
+        new_block_hash: vector<u8>,
+        previous_block_votes: vector<u8>,
+        proposer: address
+    ) acquires BlockMetadata {
+        let block_metadata_ref = borrow_global_mut<BlockMetadata>(0xA550C18);
+
+        // TODO: Figure out a story for errors in the system transactions.
+        if(proposer != 0x0) Transaction::assert(LibraSystem::is_validator(proposer), 5002);
+        LibraTimestamp::update_global_time(proposer, timestamp);
+
+        block_metadata_ref.id = new_block_hash;
+        block_metadata_ref.proposer = proposer;
+        block_metadata_ref.height = block_metadata_ref.height + 1;
+    }
+
+    // Get the current block height
+    public fun get_current_block_height(): u64 acquires BlockMetadata {
+      borrow_global<BlockMetadata>(0xA550C18).height
+    }
+
+    // Get the current block id
+    public fun get_current_block_id(): vector<u8> acquires BlockMetadata {
+      *&borrow_global<BlockMetadata>(0xA550C18).id
+    }
+
+    // Gets the address of the proposer of the current block
+    public fun get_current_proposer(): address acquires BlockMetadata {
+      borrow_global<BlockMetadata>(0xA550C18).proposer
+    }
+}

--- a/language/move-prover/tests/sources/stdlib/modules/libra_coin.exp
+++ b/language/move-prover/tests/sources/stdlib/modules/libra_coin.exp
@@ -1,0 +1,1 @@
+Move prover all good, no errors!

--- a/language/move-prover/tests/sources/stdlib/modules/libra_coin.move
+++ b/language/move-prover/tests/sources/stdlib/modules/libra_coin.move
@@ -1,0 +1,175 @@
+// dep: tests/sources/stdlib/modules/transaction.move
+address 0x0:
+
+// global spec ideas
+// SPEC TODO: total value global spec
+// SPEC TODO: Number of coins global spec.
+// SPEC TODO: who/what functions can mint.
+
+module LibraCoin {
+    use 0x0::Transaction;
+
+    // A resource representing the Libra coin
+    resource struct T {
+        // The value of the coin. May be zero
+        value: u64,
+    }
+
+    // A singleton resource that grants access to `LibraCoin::mint`. Only the Association has one.
+    resource struct MintCapability { }
+
+    resource struct MarketCap {
+        // The sum of the values of all LibraCoin::T resources in the system
+        total_value: u128,
+    }
+
+    // Return a reference to the MintCapability published under the sender's account. Fails if the
+    // sender does not have a MintCapability.
+    // Since only the Association account has a mint capability, this will only succeed if it is
+    // invoked by  a transaction sent by that account.
+    public fun mint_with_default_capability(amount: u64): T acquires MintCapability, MarketCap {
+        mint(amount, borrow_global<MintCapability>(Transaction::sender()))
+    }
+
+    spec fun mint_with_default_capability {
+	aborts_if !exists<MintCapability>(sender());
+        aborts_if !exists<MarketCap>(0xA550C18);
+        // Over mint-able amount
+        aborts_if amount > 1000000000000000;
+        // MarketCap overflow
+        aborts_if amount + global<MarketCap>(0xA550C18).total_value > max_u128();
+        ensures result.value == amount;
+    }
+
+    // Mint a new LibraCoin::T worth `value`. The caller must have a reference to a MintCapability.
+    // Only the Association account can acquire such a reference, and it can do so only via
+    // `borrow_sender_mint_capability`
+    public fun mint(value: u64, capability: &MintCapability): T acquires MarketCap {
+        // TODO: temporary measure for testnet only: limit minting to 1B Libra at a time.
+        // this is to prevent the market cap's total value from hitting u64_max due to excessive
+        // minting. This will not be a problem in the production Libra system because coins will
+        // be backed with real-world assets, and thus minting will be correspondingly rarer.
+        Transaction::assert(value <= 1000000000 * 1000000, 11); // * 1000000 because the unit is microlibra
+        // update market cap resource to reflect minting
+        let market_cap = borrow_global_mut<MarketCap>(0xA550C18);
+        market_cap.total_value = market_cap.total_value + (value as u128);
+
+        T{ value: value }
+    }
+    spec fun mint {
+        aborts_if !exists<MarketCap>(0xA550C18);
+        // Over mint-able amount
+        aborts_if value > 1000000000000000;
+        // MarketCap overflow
+        aborts_if value + global<MarketCap>(0xA550C18).total_value > max_u128();
+        ensures global<MarketCap>(0xA550C18).total_value == old(global<MarketCap>(0xA550C18).total_value) + value;
+        ensures result.value == value;
+    }
+
+    // This can only be invoked by the Association address, and only a single time.
+    // Currently, it is invoked in the genesis transaction
+    public fun initialize() {
+        // Only callable by the Association address
+        Transaction::assert(Transaction::sender() == 0xA550C18, 1);
+        move_to_sender<MintCapability>(MintCapability{ });
+        move_to_sender<MarketCap>(MarketCap { total_value: 0u128 });
+    }
+    spec fun initialize {
+        aborts_if sender() != 0xA550C18;
+        aborts_if exists<MintCapability>(sender());
+        aborts_if exists<MarketCap>(sender());
+        ensures exists<MintCapability>(sender());
+        ensures exists<MarketCap>(sender());
+        ensures global<MarketCap>(sender()).total_value == 0;
+        // I'm not going to specify _dummy == true because I don't think we care.
+    }
+
+    // Return the total value of all Libra in the system
+    public fun market_cap(): u128 acquires MarketCap {
+        borrow_global<MarketCap>(0xA550C18).total_value
+    }
+    spec fun market_cap {
+        aborts_if !exists<MarketCap>(0xA550C18);
+        ensures result == global<MarketCap>(0xA550C18).total_value;
+    }
+
+    // Create a new LibraCoin::T with a value of 0
+    public fun zero(): T {
+        T{value: 0}
+    }
+    spec fun zero {
+        ensures result.value == 0;
+    }
+
+    // Public accessor for the value of a coin
+    public fun value(coin_ref: &T): u64 {
+        coin_ref.value
+    }
+    spec fun value {
+        ensures result == coin_ref.value;
+    }
+
+    // Splits the given coin into two and returns them both
+    // It leverages `withdraw` for any verifications of the values
+    public fun split(coin: T, amount: u64): (T, T) {
+        let other = withdraw(&mut coin, amount);
+        (coin, other)
+    }
+    spec fun split {
+        aborts_if coin.value < amount;
+        ensures result_2.value == amount && result_1.value == old(coin.value) - amount;
+    }
+
+    // "Divides" the given coin into two, where original coin is modified in place
+    // The original coin will have value = original value - `amount`
+    // The new coin will have a value = `amount`
+    // Fails if the coins value is less than `amount`
+    public fun withdraw(coin_ref: &mut T, amount: u64): T {
+        // Check that `amount` is less than the coin's value
+        Transaction::assert(coin_ref.value >= amount, 10);
+
+        // Split the coin
+        coin_ref.value = coin_ref.value - amount;
+        T{ value: amount }
+    }
+    spec fun withdraw {
+        aborts_if coin_ref.value < amount;
+        ensures coin_ref.value == old(coin_ref.value) - amount;
+        ensures result.value == amount;
+    }
+
+    // Merges two coins and returns a new coin whose value is equal to the sum of the two inputs
+    public fun join(coin1: T, coin2: T): T  {
+        deposit(&mut coin1, coin2);
+        coin1
+    }
+    spec fun join {
+        aborts_if coin1.value + coin2.value > max_u64();
+        ensures result.value == old(coin1.value) + old(coin2.value);
+    }
+
+    // "Merges" the two coins
+    // The coin passed in by reference will have a value equal to the sum of the two coins
+    // The `check` coin is consumed in the process
+    public fun deposit(coin_ref: &mut T, check: T) {
+        let T { value } = check;
+        coin_ref.value= coin_ref.value + value;
+    }
+    spec fun deposit {
+        aborts_if coin_ref.value + check.value > max_u64();
+        ensures coin_ref.value == old(coin_ref.value) + old(check.value);
+    }
+
+    // Destroy a coin
+    // Fails if the value is non-zero
+    // The amount of LibraCoin::T in the system is a tightly controlled property,
+    // so you cannot "burn" any non-zero amount of LibraCoin::T
+    // SPEC TODO: Number of coins reduced by 1.
+    public fun destroy_zero(coin: T) {
+        let T { value } = coin;
+        Transaction::assert(value == 0, 11);
+    }
+    spec fun destroy_zero {
+        aborts_if coin.value != 0;
+    }
+}

--- a/language/move-prover/tests/sources/stdlib/modules/libra_system.exp
+++ b/language/move-prover/tests/sources/stdlib/modules/libra_system.exp
@@ -1,0 +1,296 @@
+Move prover returns: exiting with boogie verification errors
+error:  A precondition for this call might not hold.
+
+    ┌── tests/sources/stdlib/modules/validator_config.move:93:5 ───
+    │
+ 93 │ ╭     public fun rotate_consensus_pubkey(consensus_pubkey: vector<u8>) acquires T {
+ 94 │ │         let t_ref = borrow_global_mut<T>(Transaction::sender());
+ 95 │ │         let key_ref = &mut t_ref.config.consensus_pubkey;
+ 96 │ │         *key_ref = consensus_pubkey;
+ 97 │ │     }
+    │ ╰─────^
+    │
+    =     at tests/sources/stdlib/modules/libra_system.move:289:4: rotate_consensus_pubkey (entry)
+    =     at tests/sources/stdlib/modules/libra_system.move:290:32: rotate_consensus_pubkey
+    =         consensus_pubkey = <redacted>,
+    =         validator_set_ref = <redacted>
+    =     at tests/sources/stdlib/modules/libra_system.move:291:43: rotate_consensus_pubkey
+    =         account_address = <redacted>
+    =     at tests/sources/stdlib/modules/libra_system.move:140:4: is_validator_ (entry)
+    =     at tests/sources/stdlib/modules/libra_system.move:141:28: is_validator_
+    =         addr = <redacted>,
+    =         validators_vec_ref = <redacted>,
+    =         size = <redacted>
+    =     at tests/sources/stdlib/modules/libra_system.move:142:13: is_validator_
+    =     at tests/sources/stdlib/modules/libra_system.move:146:13: is_validator_
+    =     at tests/sources/stdlib/modules/libra_system.move:148:49: is_validator_
+    =         i = <redacted>,
+    =         validator_info_ref = <redacted>
+    =     at tests/sources/stdlib/modules/libra_system.move:150:18: is_validator_
+    =     at tests/sources/stdlib/modules/libra_system.move:295:12: rotate_consensus_pubkey
+    =     at tests/sources/stdlib/modules/libra_system.move:294:8: rotate_consensus_pubkey
+    =     at tests/sources/stdlib/modules/validator_config.move:93:5: rotate_consensus_pubkey (entry)
+
+error:  A precondition for this call might not hold.
+
+     ┌── tests/sources/stdlib/modules/libra_system.move:115:5 ───
+     │
+ 115 │ ╭     public fun get_discovery_address(d: &DiscoveryInfo): &address {
+ 116 │ │         &d.addr
+ 117 │ │     }
+     │ ╰─────^
+     │
+     =     at tests/sources/stdlib/modules/libra_system.move:329:4: rotate_validator_network_address (entry)
+     =     at tests/sources/stdlib/modules/libra_system.move:332:32: rotate_validator_network_address
+     =         validator_network_address = <redacted>,
+     =         discovery_set_ref = <redacted>
+     =     at tests/sources/stdlib/modules/libra_system.move:335:58: rotate_validator_network_address
+     =     at tests/sources/stdlib/modules/validator_config.move:113:5: rotate_validator_network_address (entry)
+     =     at tests/sources/stdlib/modules/validator_config.move:116:21: rotate_validator_network_address
+     =         validator_network_address = <redacted>,
+     =         t_ref = <redacted>
+     =     at tests/sources/stdlib/modules/validator_config.move:117:13: rotate_validator_network_address
+     =         key_ref = <redacted>
+     =     at tests/sources/stdlib/modules/validator_config.move:118:20: rotate_validator_network_address
+     =         key_ref = <redacted>,
+     =         t_ref = <redacted>
+     =     at tests/sources/stdlib/modules/libra_system.move:335:25: rotate_validator_network_address
+     =     at tests/sources/stdlib/modules/libra_system.move:207:5: get_discovery_index (entry)
+     =     at tests/sources/stdlib/modules/libra_system.move:208:27: get_discovery_index
+     =         discovery_set = <redacted>,
+     =         addr = <redacted>,
+     =         len = <redacted>
+     =     at tests/sources/stdlib/modules/libra_system.move:209:17: get_discovery_index
+     =         i = <redacted>
+     =     at tests/sources/stdlib/modules/libra_system.move:211:54: get_discovery_index
+     =     at tests/sources/stdlib/modules/libra_system.move:115:5: get_discovery_address (entry)
+
+error:  A precondition for this call might not hold.
+
+     ┌── tests/sources/stdlib/modules/libra_system.move:115:5 ───
+     │
+ 115 │ ╭     public fun get_discovery_address(d: &DiscoveryInfo): &address {
+ 116 │ │         &d.addr
+ 117 │ │     }
+     │ ╰─────^
+     │
+     =     at tests/sources/stdlib/modules/libra_system.move:311:4: rotate_validator_network_identity_pubkey (entry)
+     =     at tests/sources/stdlib/modules/libra_system.move:314:32: rotate_validator_network_identity_pubkey
+     =         validator_network_identity_pubkey = <redacted>,
+     =         discovery_set_ref = <redacted>
+     =     at tests/sources/stdlib/modules/libra_system.move:317:66: rotate_validator_network_identity_pubkey
+     =     at tests/sources/stdlib/modules/validator_config.move:103:5: rotate_validator_network_identity_pubkey (entry)
+     =     at tests/sources/stdlib/modules/validator_config.move:106:21: rotate_validator_network_identity_pubkey
+     =         validator_network_identity_pubkey = <redacted>,
+     =         t_ref = <redacted>
+     =     at tests/sources/stdlib/modules/validator_config.move:107:13: rotate_validator_network_identity_pubkey
+     =         key_ref = <redacted>
+     =     at tests/sources/stdlib/modules/validator_config.move:108:20: rotate_validator_network_identity_pubkey
+     =         key_ref = <redacted>,
+     =         t_ref = <redacted>
+     =     at tests/sources/stdlib/modules/libra_system.move:317:25: rotate_validator_network_identity_pubkey
+     =     at tests/sources/stdlib/modules/libra_system.move:207:5: get_discovery_index (entry)
+     =     at tests/sources/stdlib/modules/libra_system.move:208:27: get_discovery_index
+     =         discovery_set = <redacted>,
+     =         addr = <redacted>,
+     =         len = <redacted>
+     =     at tests/sources/stdlib/modules/libra_system.move:209:17: get_discovery_index
+     =         i = <redacted>
+     =     at tests/sources/stdlib/modules/libra_system.move:211:54: get_discovery_index
+     =     at tests/sources/stdlib/modules/libra_system.move:115:5: get_discovery_address (entry)
+
+error:  A precondition for this call might not hold.
+
+     ┌── tests/sources/stdlib/modules/libra_system.move:412:4 ───
+     │
+ 412 │ ╭    fun make_validator_info(addr: address): ValidatorInfo {
+ 413 │ │        let config = ValidatorConfig::config(addr);
+ 414 │ │
+ 415 │ │       ValidatorInfo {
+ 416 │ │           addr: addr,
+ 417 │ │           consensus_pubkey: ValidatorConfig::consensus_pubkey(&config),
+ 418 │ │           consensus_voting_power: 1,
+ 419 │ │           network_signing_pubkey: ValidatorConfig::validator_network_signing_pubkey(&config),
+ 420 │ │           network_identity_pubkey: ValidatorConfig::validator_network_identity_pubkey(&config),
+ 421 │ │       }
+ 422 │ │    }
+     │ ╰────^
+     │
+     =     at tests/sources/stdlib/modules/libra_system.move:227:5: add_validator (entry)
+     =     at tests/sources/stdlib/modules/libra_system.move:233:4: add_validator_ (entry)
+     =     at tests/sources/stdlib/modules/libra_system.move:235:8: add_validator_
+     =         account_address = <redacted>
+     =     at tests/sources/stdlib/modules/validator_config.move:24:5: has (entry)
+     =     at tests/sources/stdlib/modules/libra_system.move:237:45: add_validator_
+     =     at tests/sources/stdlib/modules/libra_system.move:239:32: add_validator_
+     =         validator_set_ref = <redacted>
+     =     at tests/sources/stdlib/modules/libra_system.move:240:64: add_validator_
+     =         discovery_set_ref = <redacted>
+     =     at tests/sources/stdlib/modules/libra_system.move:140:4: is_validator_ (entry)
+     =     at tests/sources/stdlib/modules/libra_system.move:141:28: is_validator_
+     =         addr = <redacted>,
+     =         validators_vec_ref = <redacted>,
+     =         size = <redacted>
+     =     at tests/sources/stdlib/modules/libra_system.move:142:13: is_validator_
+     =     at tests/sources/stdlib/modules/libra_system.move:146:13: is_validator_
+     =     at tests/sources/stdlib/modules/libra_system.move:148:49: is_validator_
+     =         i = <redacted>,
+     =         validator_info_ref = <redacted>
+     =     at tests/sources/stdlib/modules/libra_system.move:150:18: is_validator_
+     =     at tests/sources/stdlib/modules/libra_system.move:153:19: is_validator_
+     =         i = <redacted>
+     =     at tests/sources/stdlib/modules/libra_system.move:154:17: is_validator_
+     =     at tests/sources/stdlib/modules/libra_system.move:244:13: add_validator_
+     =     at tests/sources/stdlib/modules/libra_system.move:243:8: add_validator_
+     =     at tests/sources/stdlib/modules/libra_system.move:412:4: make_validator_info (entry)
+
+error:  A precondition for this call might not hold.
+
+     ┌── tests/sources/stdlib/modules/libra_system.move:412:4 ───
+     │
+ 412 │ ╭    fun make_validator_info(addr: address): ValidatorInfo {
+ 413 │ │        let config = ValidatorConfig::config(addr);
+ 414 │ │
+ 415 │ │       ValidatorInfo {
+ 416 │ │           addr: addr,
+ 417 │ │           consensus_pubkey: ValidatorConfig::consensus_pubkey(&config),
+ 418 │ │           consensus_voting_power: 1,
+ 419 │ │           network_signing_pubkey: ValidatorConfig::validator_network_signing_pubkey(&config),
+ 420 │ │           network_identity_pubkey: ValidatorConfig::validator_network_identity_pubkey(&config),
+ 421 │ │       }
+ 422 │ │    }
+     │ ╰────^
+     │
+     =     at tests/sources/stdlib/modules/libra_system.move:233:4: add_validator_ (entry)
+     =     at tests/sources/stdlib/modules/libra_system.move:235:8: add_validator_
+     =         account_address = <redacted>
+     =     at tests/sources/stdlib/modules/validator_config.move:24:5: has (entry)
+     =     at tests/sources/stdlib/modules/libra_system.move:237:45: add_validator_
+     =     at tests/sources/stdlib/modules/libra_system.move:239:32: add_validator_
+     =         validator_set_ref = <redacted>
+     =     at tests/sources/stdlib/modules/libra_system.move:240:64: add_validator_
+     =         discovery_set_ref = <redacted>
+     =     at tests/sources/stdlib/modules/libra_system.move:140:4: is_validator_ (entry)
+     =     at tests/sources/stdlib/modules/libra_system.move:141:28: is_validator_
+     =         addr = <redacted>,
+     =         validators_vec_ref = <redacted>,
+     =         size = <redacted>
+     =     at tests/sources/stdlib/modules/libra_system.move:142:13: is_validator_
+     =     at tests/sources/stdlib/modules/libra_system.move:146:13: is_validator_
+     =     at tests/sources/stdlib/modules/libra_system.move:148:49: is_validator_
+     =         i = <redacted>,
+     =         validator_info_ref = <redacted>
+     =     at tests/sources/stdlib/modules/libra_system.move:150:18: is_validator_
+     =     at tests/sources/stdlib/modules/libra_system.move:153:19: is_validator_
+     =         i = <redacted>
+     =     at tests/sources/stdlib/modules/libra_system.move:154:17: is_validator_
+     =     at tests/sources/stdlib/modules/libra_system.move:244:13: add_validator_
+     =     at tests/sources/stdlib/modules/libra_system.move:243:8: add_validator_
+     =     at tests/sources/stdlib/modules/libra_system.move:412:4: make_validator_info (entry)
+
+error:  A precondition for this call might not hold.
+
+     ┌── tests/sources/stdlib/modules/libra_system.move:115:5 ───
+     │
+ 115 │ ╭     public fun get_discovery_address(d: &DiscoveryInfo): &address {
+ 116 │ │         &d.addr
+ 117 │ │     }
+     │ ╰─────^
+     │
+     =     at tests/sources/stdlib/modules/libra_system.move:207:5: get_discovery_index (entry)
+     =     at tests/sources/stdlib/modules/libra_system.move:208:27: get_discovery_index
+     =         discovery_set = <redacted>,
+     =         addr = <redacted>,
+     =         len = <redacted>
+     =     at tests/sources/stdlib/modules/libra_system.move:209:17: get_discovery_index
+     =         i = <redacted>
+     =     at tests/sources/stdlib/modules/libra_system.move:211:54: get_discovery_index
+     =     at tests/sources/stdlib/modules/libra_system.move:115:5: get_discovery_address (entry)
+
+error:  A precondition for this call might not hold.
+
+    ┌── tests/sources/stdlib/modules/libra_system.move:93:5 ───
+    │
+ 93 │ ╭     public fun get_validator_address(v: &ValidatorInfo): &address {
+ 94 │ │       &v.addr
+ 95 │ │     }
+    │ ╰─────^
+    │
+    =     at tests/sources/stdlib/modules/libra_system.move:190:5: get_validator_index (entry)
+    =     at tests/sources/stdlib/modules/libra_system.move:191:27: get_validator_index
+    =         validators = <redacted>,
+    =         addr = <redacted>,
+    =         len = <redacted>
+    =     at tests/sources/stdlib/modules/libra_system.move:192:17: get_validator_index
+    =         i = <redacted>
+    =     at tests/sources/stdlib/modules/libra_system.move:194:54: get_validator_index
+    =     at tests/sources/stdlib/modules/libra_system.move:93:5: get_validator_address (entry)
+
+error:  A precondition for this call might not hold.
+
+    ┌── tests/sources/stdlib/modules/libra_system.move:93:5 ───
+    │
+ 93 │ ╭     public fun get_validator_address(v: &ValidatorInfo): &address {
+ 94 │ │       &v.addr
+ 95 │ │     }
+    │ ╰─────^
+    │
+    =     at tests/sources/stdlib/modules/libra_system.move:258:4: remove_validator (entry)
+    =     at tests/sources/stdlib/modules/libra_system.move:260:8: remove_validator
+    =         account_address = <redacted>
+    =     at tests/sources/stdlib/modules/libra_system.move:262:32: remove_validator
+    =         validator_set_ref = <redacted>
+    =     at tests/sources/stdlib/modules/libra_system.move:263:64: remove_validator
+    =         discovery_set_ref = <redacted>
+    =     at tests/sources/stdlib/modules/libra_system.move:140:4: is_validator_ (entry)
+    =     at tests/sources/stdlib/modules/libra_system.move:141:28: is_validator_
+    =         addr = <redacted>,
+    =         validators_vec_ref = <redacted>,
+    =         size = <redacted>
+    =     at tests/sources/stdlib/modules/libra_system.move:142:13: is_validator_
+    =     at tests/sources/stdlib/modules/libra_system.move:146:13: is_validator_
+    =     at tests/sources/stdlib/modules/libra_system.move:148:49: is_validator_
+    =         i = <redacted>,
+    =         validator_info_ref = <redacted>
+    =     at tests/sources/stdlib/modules/libra_system.move:150:18: is_validator_
+    =     at tests/sources/stdlib/modules/libra_system.move:266:12: remove_validator
+    =     at tests/sources/stdlib/modules/libra_system.move:265:8: remove_validator
+    =     at tests/sources/stdlib/modules/libra_system.move:190:5: get_validator_index (entry)
+    =     at tests/sources/stdlib/modules/libra_system.move:191:27: get_validator_index
+    =     at tests/sources/stdlib/modules/libra_system.move:192:17: get_validator_index
+    =     at tests/sources/stdlib/modules/libra_system.move:194:54: get_validator_index
+    =     at tests/sources/stdlib/modules/libra_system.move:93:5: get_validator_address (entry)
+
+error:  A precondition for this call might not hold.
+
+     ┌── tests/sources/stdlib/modules/libra_system.move:190:5 ───
+     │
+ 190 │ ╭     public fun get_validator_index(validators: &vector<ValidatorInfo>, addr: address): u64 {
+ 191 │ │         let len = Vector::length(validators);
+ 192 │ │         let i = 0;
+ 193 │ │         loop {
+ 194 │ │             if (get_validator_address(Vector::borrow(validators, i)) == &addr) {
+ 195 │ │                 return i
+ 196 │ │             };
+ 197 │ │
+ 198 │ │             i = i + 1;
+ 199 │ │             if (i >= len) { break };
+ 200 │ │         };
+ 201 │ │
+ 202 │ │         abort 99
+ 203 │ │     }
+     │ ╰─────^
+     │
+     =     at tests/sources/stdlib/modules/libra_system.move:258:4: remove_validator (entry)
+     =     at tests/sources/stdlib/modules/libra_system.move:260:8: remove_validator
+     =     at tests/sources/stdlib/modules/libra_system.move:262:32: remove_validator
+     =     at tests/sources/stdlib/modules/libra_system.move:263:64: remove_validator
+     =     at tests/sources/stdlib/modules/libra_system.move:140:4: is_validator_ (entry)
+     =     at tests/sources/stdlib/modules/libra_system.move:141:28: is_validator_
+     =     at tests/sources/stdlib/modules/libra_system.move:142:13: is_validator_
+     =     at tests/sources/stdlib/modules/libra_system.move:146:13: is_validator_
+     =     at tests/sources/stdlib/modules/libra_system.move:148:49: is_validator_
+     =     at tests/sources/stdlib/modules/libra_system.move:150:18: is_validator_
+     =     at tests/sources/stdlib/modules/libra_system.move:266:12: remove_validator
+     =     at tests/sources/stdlib/modules/libra_system.move:265:8: remove_validator
+     =     at tests/sources/stdlib/modules/libra_system.move:190:5: get_validator_index (entry)

--- a/language/move-prover/tests/sources/stdlib/modules/libra_system.move
+++ b/language/move-prover/tests/sources/stdlib/modules/libra_system.move
@@ -1,0 +1,473 @@
+// dep: tests/sources/stdlib/modules/libra_account.move
+// dep: tests/sources/stdlib/modules/validator_config.move
+// dep: tests/sources/stdlib/modules/vector.move
+// dep: tests/sources/stdlib/modules/transaction.move
+// dep: tests/sources/stdlib/modules/libra_time.move
+// dep: tests/sources/stdlib/modules/libra_coin.move
+// dep: tests/sources/stdlib/modules/address_util.move
+// dep: tests/sources/stdlib/modules/u64_util.move
+// dep: tests/sources/stdlib/modules/hash.move
+// dep: tests/sources/stdlib/modules/libra_transaction_timeout.move
+address 0x0:
+
+module LibraSystem {
+    use 0x0::LibraAccount;
+    use 0x0::ValidatorConfig;
+    use 0x0::Vector;
+    use 0x0::Transaction;
+    use 0x0::LibraTimestamp;
+
+    struct ValidatorInfo {
+        addr: address,
+        consensus_pubkey: vector<u8>,
+        consensus_voting_power: u64,
+        network_signing_pubkey: vector<u8>,
+        network_identity_pubkey: vector<u8>,
+    }
+
+    struct ValidatorSetChangeEvent {
+        new_validator_set: vector<ValidatorInfo>,
+    }
+
+    resource struct ValidatorSet {
+        // The current validator set. Updated only at epoch boundaries via reconfiguration.
+        validators: vector<ValidatorInfo>,
+        // Last time when a reconfiguration happened.
+        last_reconfiguration_time: u64,
+        // Handle where validator set change events are emitted
+        change_events: LibraAccount::EventHandle<ValidatorSetChangeEvent>,
+    }
+
+    struct DiscoveryInfo {
+        addr: address,
+        validator_network_identity_pubkey: vector<u8>,
+        validator_network_address: vector<u8>,
+        fullnodes_network_identity_pubkey: vector<u8>,
+        fullnodes_network_address: vector<u8>,
+    }
+
+    struct DiscoverySetChangeEvent {
+        new_discovery_set: vector<DiscoveryInfo>,
+    }
+
+    resource struct DiscoverySet {
+        // The current discovery set. Updated only at epoch boundaries via reconfiguration.
+        discovery_set: vector<DiscoveryInfo>,
+        // Handle where discovery set change events are emitted
+        change_events: LibraAccount::EventHandle<DiscoverySetChangeEvent>,
+    }
+
+    // This can only be invoked by the Association address, and only a single time.
+    // Currently, it is invoked in the genesis transaction
+    public fun initialize_validator_set() {
+      // Only callable by the validator set address
+      Transaction::assert(Transaction::sender() == 0x1D8, 1);
+
+      move_to_sender<ValidatorSet>(ValidatorSet {
+          validators: Vector::empty(),
+          last_reconfiguration_time: 0,
+          change_events: LibraAccount::new_event_handle<ValidatorSetChangeEvent>(),
+      });
+    }
+
+    public fun initialize_discovery_set() {
+        // Only callable by the discovery set address
+        Transaction::assert(Transaction::sender() == 0xD15C0, 1);
+
+        move_to_sender<DiscoverySet>(DiscoverySet {
+            discovery_set: Vector::empty(),
+            change_events: LibraAccount::new_event_handle<DiscoverySetChangeEvent>(),
+        });
+    }
+
+    public fun reconfigure() acquires ValidatorSet {
+        // TODO: Transform this method to user capability pattern.
+        // Only the Association can emit reconfiguration event for now
+        Transaction::assert(Transaction::sender() == 0xA550C18, 1);
+
+        reconfigure_()
+    }
+
+    // ValidatorInfo public accessors
+
+    public fun get_validator_address(v: &ValidatorInfo): &address {
+      &v.addr
+    }
+
+    public fun get_consensus_pubkey(v: &ValidatorInfo): &vector<u8> {
+      &v.consensus_pubkey
+    }
+
+    public fun get_consensus_voting_power(v: &ValidatorInfo): &u64 {
+      &v.consensus_voting_power
+    }
+
+    public fun get_network_signing_pubkey(v: &ValidatorInfo): &vector<u8> {
+      &v.network_signing_pubkey
+    }
+
+    public fun get_network_identity_pubkey(v: &ValidatorInfo): &vector<u8> {
+      &v.network_identity_pubkey
+    }
+
+    // DiscoveryInfo public accessors
+
+    public fun get_discovery_address(d: &DiscoveryInfo): &address {
+        &d.addr
+    }
+
+    public fun get_validator_network_identity_pubkey(d: &DiscoveryInfo): &vector<u8> {
+        &d.validator_network_identity_pubkey
+    }
+
+    public fun get_validator_network_address(d: &DiscoveryInfo): &vector<u8> {
+        &d.validator_network_address
+    }
+
+    public fun get_fullnodes_network_identity_pubkey(d: &DiscoveryInfo): &vector<u8> {
+        &d.fullnodes_network_identity_pubkey
+    }
+
+    public fun get_fullnodes_network_address(d: &DiscoveryInfo): &vector<u8> {
+        &d.fullnodes_network_address
+    }
+
+    // Return the size of the current validator set
+    public fun validator_set_size(): u64 acquires ValidatorSet {
+        Vector::length(&borrow_global<ValidatorSet>(0x1D8).validators)
+    }
+
+   fun is_validator_(addr: &address, validators_vec_ref: &vector<ValidatorInfo>): bool {
+        let size = Vector::length(validators_vec_ref);
+        if (size == 0) {
+            return false
+        };
+
+        let i = 0;
+        // this is only needed to make the bytecode verifier happy
+        let validator_info_ref = Vector::borrow(validators_vec_ref, i);
+        loop {
+            if (&validator_info_ref.addr == addr) {
+                return true
+            };
+            i = i + 1;
+            if (i >= size) { break };
+            validator_info_ref = Vector::borrow(validators_vec_ref, i);
+        };
+
+        false
+    }
+
+    // Return true if addr is a current validator
+    public fun is_validator(addr: address): bool acquires ValidatorSet {
+        is_validator_(&addr, &borrow_global<ValidatorSet>(0x1D8).validators)
+    }
+
+    // Get the ValidatorInfo for the ith validator
+    public fun get_ith_validator_info(i: u64): ValidatorInfo acquires ValidatorSet {
+      let validators_vec_ref = &borrow_global<ValidatorSet>(0x1D8).validators;
+      Transaction::assert(i < Vector::length(validators_vec_ref), 3);
+      *Vector::borrow(validators_vec_ref, i)
+    }
+
+    // Get the address of the i'th validator.
+    public fun get_ith_validator_address(i: u64): address acquires ValidatorSet {
+      let validator_set = borrow_global<ValidatorSet>(0x1D8);
+      let len = Vector::length(&validator_set.validators);
+      Transaction::assert(i < len, 3);
+      Vector::borrow(&validator_set.validators, i).addr
+    }
+
+    // Get the DiscoveryInfo for the ith validator
+    public fun get_ith_discovery_info(i: u64): DiscoveryInfo acquires DiscoverySet {
+        let discovery_vec_ref = &borrow_global<DiscoverySet>(0xD15C0).discovery_set;
+        Transaction::assert(i < Vector::length(discovery_vec_ref), 4);
+        *Vector::borrow(discovery_vec_ref, i)
+    }
+
+    // Get the index of the validator with address `addr` in `validators`.
+    // Aborts if `addr` is not the address of any validator
+    public fun get_validator_index(validators: &vector<ValidatorInfo>, addr: address): u64 {
+        let len = Vector::length(validators);
+        let i = 0;
+        loop {
+            if (get_validator_address(Vector::borrow(validators, i)) == &addr) {
+                return i
+            };
+
+            i = i + 1;
+            if (i >= len) { break };
+        };
+
+        abort 99
+    }
+
+    // Get the index of the discovery info with address `addr` in `discovery_set`.
+    // Aborts if `addr` is not in discovery set.
+    public fun get_discovery_index(discovery_set: &vector<DiscoveryInfo>, addr: address): u64 {
+        let len = Vector::length(discovery_set);
+        let i = 0;
+        loop {
+            if (get_discovery_address(Vector::borrow(discovery_set, i)) == &addr) {
+                return i
+            };
+
+            i = i + 1;
+            if (i >= len) { break };
+        };
+
+        abort 99
+    }
+
+    // Adds a validator to the addition buffer, which will cause it to be added to the validator
+    // set in the next epoch.
+    // Fails if `account_address` is already a validator or has already been added to the addition
+    // buffer.
+    // Only callable by the Association address
+    public fun add_validator(account_address: address) acquires ValidatorSet, DiscoverySet {
+        add_validator_(account_address);
+        reconfigure_();
+        emit_discovery_set_change();
+    }
+
+   fun add_validator_(account_address: address) acquires ValidatorSet, DiscoverySet {
+       // Only the Association can add new validators
+       Transaction::assert(Transaction::sender() == 0xA550C18, 1);
+       // A prospective validator must have a validator config resource
+       Transaction::assert(ValidatorConfig::has(account_address), 17);
+
+       let validator_set_ref = borrow_global_mut<ValidatorSet>(0x1D8);
+       let discovery_set_ref = borrow_global_mut<DiscoverySet>(0xD15C0);
+
+       // Ensure that this address is not already a validator
+       Transaction::assert(
+           !is_validator_(&account_address, &validator_set_ref.validators),
+           18
+       );
+
+       Vector::push_back(
+           &mut validator_set_ref.validators,
+           make_validator_info(account_address)
+       );
+       Vector::push_back(
+           &mut discovery_set_ref.discovery_set,
+           make_discovery_info(account_address)
+       );
+   }
+
+   public fun remove_validator(account_address: address) acquires ValidatorSet, DiscoverySet {
+       // Only the Association can remove validators
+       Transaction::assert(Transaction::sender() == 0xA550C18, 1);
+
+       let validator_set_ref = borrow_global_mut<ValidatorSet>(0x1D8);
+       let discovery_set_ref = borrow_global_mut<DiscoverySet>(0xD15C0);
+       // Ensure that this address is already a validator
+       Transaction::assert(
+           is_validator_(&account_address, &validator_set_ref.validators),
+           21
+       );
+
+       let to_remove_index = get_validator_index(
+           &validator_set_ref.validators,
+           account_address
+       );
+
+       // remove corresponding ValidatorInfo from the validator set
+       _  = Vector::swap_remove(
+            &mut validator_set_ref.validators,
+           to_remove_index
+       );
+       _  = Vector::swap_remove(
+           &mut discovery_set_ref.discovery_set,
+           to_remove_index
+       );
+
+       reconfigure_();
+       emit_discovery_set_change();
+   }
+
+   public fun rotate_consensus_pubkey(consensus_pubkey: vector<u8>) acquires ValidatorSet {
+       let validator_set_ref = borrow_global_mut<ValidatorSet>(0x1D8);
+       let account_address = Transaction::sender();
+
+       // Ensure that this address is already a validator
+       Transaction::assert(
+           is_validator_(&account_address, &validator_set_ref.validators),
+           21
+       );
+
+       ValidatorConfig::rotate_consensus_pubkey(consensus_pubkey);
+
+       let validator_index = get_validator_index(
+           &validator_set_ref.validators,
+           account_address
+       );
+
+       if(copy_validator_info(Vector::borrow_mut(&mut validator_set_ref.validators, validator_index))) {
+           reconfigure_();
+       }
+   }
+
+   public fun rotate_validator_network_identity_pubkey(
+       validator_network_identity_pubkey: vector<u8>
+   ) acquires DiscoverySet {
+       let discovery_set_ref = borrow_global_mut<DiscoverySet>(0xD15C0);
+       let account_address = Transaction::sender();
+
+       ValidatorConfig::rotate_validator_network_identity_pubkey(validator_network_identity_pubkey);
+
+       let validator_index = get_discovery_index(
+           &discovery_set_ref.discovery_set,
+           account_address
+       );
+
+       if(copy_discovery_info(Vector::borrow_mut(&mut discovery_set_ref.discovery_set, validator_index))) {
+           emit_discovery_set_change();
+       }
+   }
+
+   public fun rotate_validator_network_address(
+       validator_network_address: vector<u8>
+   ) acquires DiscoverySet {
+       let discovery_set_ref = borrow_global_mut<DiscoverySet>(0xD15C0);
+       let account_address = Transaction::sender();
+
+       ValidatorConfig::rotate_validator_network_address(validator_network_address);
+
+       let validator_index = get_discovery_index(
+           &discovery_set_ref.discovery_set,
+           account_address
+       );
+
+       if(copy_discovery_info(Vector::borrow_mut(&mut discovery_set_ref.discovery_set, validator_index))) {
+           emit_discovery_set_change();
+       }
+   }
+
+   fun reconfigure_() acquires ValidatorSet {
+       let validator_set_ref = borrow_global_mut<ValidatorSet>(0x1D8);
+       let current_block_time = LibraTimestamp::now_microseconds();
+
+       // Ensure that there is at most one reconfiguration per transaction. This ensures that there is a 1-1
+       // correspondence between system reconfigurations and emitted ReconfigurationEvents.
+       Transaction::assert(current_block_time > validator_set_ref.last_reconfiguration_time, 23);
+
+       validator_set_ref.last_reconfiguration_time = current_block_time;
+       emit_reconfiguration_event();
+   }
+
+   // Emit a reconfiguration event. This function will be invoked by the genesis to generate the very first
+   // reconfiguration event.
+   fun emit_reconfiguration_event() acquires ValidatorSet {
+       let validator_set_ref = borrow_global_mut<ValidatorSet>(0x1D8);
+
+       LibraAccount::emit_event<ValidatorSetChangeEvent>(
+           &mut validator_set_ref.change_events,
+           ValidatorSetChangeEvent {
+               new_validator_set: *&validator_set_ref.validators,
+           },
+       );
+   }
+
+   fun emit_discovery_set_change() acquires DiscoverySet {
+       let discovery_set_ref = borrow_global_mut<DiscoverySet>(0xD15C0);
+       LibraAccount::emit_event<DiscoverySetChangeEvent>(
+           &mut discovery_set_ref.change_events,
+           DiscoverySetChangeEvent {
+               new_discovery_set: *&discovery_set_ref.discovery_set,
+           },
+       );
+   }
+
+   // Return true if the ValidatorInfo given as input is different than the one
+   // derived from the ValidatorConfig published at validator_info.addr + copies
+   // the differing fields. Aborts if there is no ValidatorConfig at
+
+   // validator_info.addr
+   public fun copy_validator_info(validator_info: &mut ValidatorInfo): bool {
+
+       let config = ValidatorConfig::config(validator_info.addr);
+       let consensus_pubkey = ValidatorConfig::consensus_pubkey(&config);
+       let network_signing_pubkey = ValidatorConfig::validator_network_signing_pubkey(&config);
+       let network_identity_pubkey = ValidatorConfig::validator_network_identity_pubkey(&config);
+
+       let changed = false;
+       if (&consensus_pubkey != &validator_info.consensus_pubkey) {
+           *&mut validator_info.consensus_pubkey = consensus_pubkey;
+           changed = true;
+       };
+       if (&network_signing_pubkey != &validator_info.network_signing_pubkey) {
+           *&mut validator_info.network_signing_pubkey = network_signing_pubkey;
+           changed = true;
+       };
+       if (&network_identity_pubkey != &validator_info.network_identity_pubkey) {
+           *&mut validator_info.network_identity_pubkey = network_identity_pubkey;
+           changed = true;
+       };
+       changed
+   }
+
+   // Create a ValidatorInfo from the ValidatorConfig stored at addr.
+   // Aborts if addr does not have a ValidatorConfig
+   fun make_validator_info(addr: address): ValidatorInfo {
+       let config = ValidatorConfig::config(addr);
+
+      ValidatorInfo {
+          addr: addr,
+          consensus_pubkey: ValidatorConfig::consensus_pubkey(&config),
+          consensus_voting_power: 1,
+          network_signing_pubkey: ValidatorConfig::validator_network_signing_pubkey(&config),
+          network_identity_pubkey: ValidatorConfig::validator_network_identity_pubkey(&config),
+      }
+   }
+
+   // Return true if the DiscoveryInfo given as input is different than the one
+   // derived from the ValidatorConfig published at discovery_info.addr + copies
+   // the differing fields. Aborts if there is no ValidatorConfig at
+   // discovery_info.addr
+   public fun copy_discovery_info(discovery_info: &mut DiscoveryInfo): bool {
+       let config = ValidatorConfig::config(*&discovery_info.addr);
+       let validator_network_identity_pubkey = ValidatorConfig::validator_network_identity_pubkey(&config);
+       let validator_network_address = ValidatorConfig::validator_network_address(&config);
+       let fullnodes_network_identity_pubkey = ValidatorConfig::fullnodes_network_identity_pubkey(&config);
+       let fullnodes_network_address = ValidatorConfig::fullnodes_network_address(&config);
+
+       let changed = false;
+       if (&validator_network_identity_pubkey != &discovery_info.validator_network_identity_pubkey) {
+           *&mut discovery_info.validator_network_identity_pubkey = validator_network_identity_pubkey;
+           changed = true;
+       };
+       if (&validator_network_address != &discovery_info.validator_network_address) {
+           *&mut discovery_info.validator_network_address = validator_network_address;
+           changed = true;
+       };
+       if (&fullnodes_network_identity_pubkey != &discovery_info.fullnodes_network_identity_pubkey) {
+           *&mut discovery_info.fullnodes_network_identity_pubkey = fullnodes_network_identity_pubkey;
+           changed = true;
+       };
+       if (&fullnodes_network_address != &discovery_info.fullnodes_network_address) {
+           *&mut discovery_info.fullnodes_network_address = fullnodes_network_address;
+           changed = true;
+       };
+
+       changed
+   }
+
+   // Create a DiscoveryInfo from the ValidatorConfig stored at addr.
+   // Aborts if addr does not have a ValidatorConfig
+   fun make_discovery_info(addr: address): DiscoveryInfo {
+      let config = ValidatorConfig::config(addr);
+
+      DiscoveryInfo {
+          addr: addr,
+          validator_network_identity_pubkey:
+              ValidatorConfig::validator_network_identity_pubkey(&config),
+          validator_network_address:
+              ValidatorConfig::validator_network_address(&config),
+          fullnodes_network_identity_pubkey:
+              ValidatorConfig::fullnodes_network_identity_pubkey(&config),
+          fullnodes_network_address:
+              ValidatorConfig::fullnodes_network_address(&config),
+      }
+   }
+}

--- a/language/move-prover/tests/sources/stdlib/modules/libra_time.exp
+++ b/language/move-prover/tests/sources/stdlib/modules/libra_time.exp
@@ -1,0 +1,1 @@
+Move prover all good, no errors!

--- a/language/move-prover/tests/sources/stdlib/modules/libra_time.move
+++ b/language/move-prover/tests/sources/stdlib/modules/libra_time.move
@@ -1,0 +1,43 @@
+// dep: tests/sources/stdlib/modules/transaction.move
+address 0x0:
+
+module LibraTimestamp {
+    use 0x0::Transaction;
+
+    // A singleton resource holding the current Unix time in microseconds
+    resource struct CurrentTimeMicroseconds {
+        microseconds: u64,
+    }
+
+    // Initialize the global wall clock time resource.
+    public fun initialize_timer() {
+
+        // Only callable by the Association address
+        Transaction::assert(Transaction::sender() == 0xA550C18, 1);
+
+        // TODO: Should the initialized value be passed in to genesis?
+        let timer = CurrentTimeMicroseconds {microseconds: 0};
+        move_to_sender<CurrentTimeMicroseconds>(timer);
+    }
+
+    // Update the wall clock time by consensus. Requires VM privilege and will be invoked during block prologue.
+    public fun update_global_time(proposer: address, timestamp: u64) acquires CurrentTimeMicroseconds {
+        // Can only be invoked by LibraVM privilege.
+        Transaction::assert(Transaction::sender() == 0x0, 33);
+
+        let global_timer = borrow_global_mut<CurrentTimeMicroseconds>(0xA550C18);
+        if (proposer == 0x0) {
+            // NIL block with null address as proposer. Timestamp must be equal.
+            Transaction::assert(timestamp == global_timer.microseconds, 5001);
+        } else {
+            // Normal block. Time must advance
+            Transaction::assert(global_timer.microseconds < timestamp, 5001);
+        };
+        global_timer.microseconds = timestamp;
+    }
+
+    // Get the timestamp representing `now` in microseconds.
+    public fun now_microseconds(): u64 acquires CurrentTimeMicroseconds {
+        borrow_global<CurrentTimeMicroseconds>(0xA550C18).microseconds
+    }
+}

--- a/language/move-prover/tests/sources/stdlib/modules/libra_transaction_timeout.exp
+++ b/language/move-prover/tests/sources/stdlib/modules/libra_transaction_timeout.exp
@@ -1,0 +1,1 @@
+Move prover all good, no errors!

--- a/language/move-prover/tests/sources/stdlib/modules/libra_transaction_timeout.move
+++ b/language/move-prover/tests/sources/stdlib/modules/libra_transaction_timeout.move
@@ -1,0 +1,48 @@
+// dep: tests/sources/stdlib/modules/transaction.move
+// dep: tests/sources/stdlib/modules/libra_time.move
+
+address 0x0:
+
+module LibraTransactionTimeout {
+  use 0x0::Transaction;
+  use 0x0::LibraTimestamp;
+
+  resource struct TTL {
+    // Only transactions with timestamp in between block time and block time + duration would be accepted.
+    duration_microseconds: u64,
+  }
+
+  public fun initialize() {
+
+    // Only callable by the Association address
+    Transaction::assert(Transaction::sender() == 0xA550C18, 1);
+    // Currently set to 1day.
+    move_to_sender<TTL>(TTL {duration_microseconds: 86400000000});
+  }
+
+  public fun set_timeout(new_duration: u64) acquires TTL {
+    // Only callable by the Association address
+    Transaction::assert(Transaction::sender() == 0xA550C18, 1);
+
+    let timeout = borrow_global_mut<TTL>(0xA550C18);
+    timeout.duration_microseconds = new_duration;
+  }
+
+  public fun is_valid_transaction_timestamp(timestamp: u64): bool acquires TTL {
+    // Reject timestamp greater than u64::MAX / 1_000_000;
+    if(timestamp > 9223372036854) {
+      return false
+    };
+
+    let current_block_time = LibraTimestamp::now_microseconds();
+    let timeout = borrow_global<TTL>(0xA550C18).duration_microseconds;
+    let _max_txn_time = current_block_time + timeout;
+
+    let txn_time_microseconds = timestamp * 1000000;
+    // TODO: Add LibraTimestamp::is_before_exclusive(&txn_time_microseconds, &max_txn_time)
+    //       This is causing flaky test right now. The reason is that we will use this logic for AC, where its wall
+    //       clock time might be out of sync with the real block time stored in StateStore.
+    //       See details in issue #2346.
+    current_block_time < txn_time_microseconds
+  }
+}

--- a/language/move-prover/tests/sources/stdlib/modules/offer.exp
+++ b/language/move-prover/tests/sources/stdlib/modules/offer.exp
@@ -1,0 +1,1 @@
+Move prover all good, no errors!

--- a/language/move-prover/tests/sources/stdlib/modules/offer.move
+++ b/language/move-prover/tests/sources/stdlib/modules/offer.move
@@ -1,0 +1,38 @@
+// dep: tests/sources/stdlib/modules/transaction.move
+address 0x0:
+
+// TODO: add optional timeout for reclaiming by original publisher once we have implemented time
+module Offer {
+  use 0x0::Transaction;
+  // A wrapper around value `offered` that can be claimed by the address stored in `for`.
+  resource struct T<Offered> { offered: Offered, for: address }
+
+  // Publish a value of type `Offered` under the sender's account. The value can be claimed by
+  // either the `for` address or the transaction sender.
+  public fun create<Offered>(offered: Offered, for: address) {
+    move_to_sender<T<Offered>>(T<Offered> { offered: offered, for: for });
+  }
+
+  // Claim the value of type `Offered` published at `offer_address`.
+  // Only succeeds if the sender is the intended recipient stored in `for` or the original
+  // publisher `offer_address`.
+  // Also fails if no such value exists.
+  public fun redeem<Offered>(offer_address: address): Offered acquires T {
+    let T<Offered> { offered, for } = move_from<T<Offered>>(offer_address);
+    let sender = Transaction::sender();
+    // fail with INSUFFICIENT_PRIVILEGES
+    Transaction::assert(sender == for || sender == offer_address, 11);
+    offered
+  }
+
+  // Returns true if an offer of type `Offered` exists at `offer_address`.
+  public fun exists_at<Offered>(offer_address: address): bool {
+    exists<T<Offered>>(offer_address)
+  }
+
+  // Returns the address of the `Offered` type stored at `offer_address.
+  // Fails if no such `Offer` exists.
+  public fun address_of<Offered>(offer_address: address): address acquires T {
+    borrow_global<T<Offered>>(offer_address).for
+  }
+}

--- a/language/move-prover/tests/sources/stdlib/modules/signature.exp
+++ b/language/move-prover/tests/sources/stdlib/modules/signature.exp
@@ -1,0 +1,1 @@
+Move prover all good, no errors!

--- a/language/move-prover/tests/sources/stdlib/modules/signature.move
+++ b/language/move-prover/tests/sources/stdlib/modules/signature.move
@@ -1,0 +1,6 @@
+address 0x0:
+
+module Signature {
+    native public fun ed25519_verify(signature: vector<u8>, public_key: vector<u8>, message: vector<u8>): bool;
+    native public fun ed25519_threshold_verify(bitmap: vector<u8>, signature: vector<u8>, public_key: vector<u8>, message: vector<u8>): u64;
+}

--- a/language/move-prover/tests/sources/stdlib/modules/transaction.exp
+++ b/language/move-prover/tests/sources/stdlib/modules/transaction.exp
@@ -1,0 +1,1 @@
+Move prover all good, no errors!

--- a/language/move-prover/tests/sources/stdlib/modules/transaction.move
+++ b/language/move-prover/tests/sources/stdlib/modules/transaction.move
@@ -1,0 +1,15 @@
+address 0x0:
+
+module Transaction {
+    native public fun gas_unit_price(): u64;
+    native public fun max_gas_units(): u64;
+    native public fun gas_remaining(): u64;
+    native public fun sender(): address;
+    native public fun sequence_number(): u64;
+    native public fun public_key(): vector<u8>;
+
+    // inlined
+    public fun assert(check: bool, code: u64) {
+        if (check) () else abort code
+    }
+}

--- a/language/move-prover/tests/sources/stdlib/modules/transaction_fee.exp
+++ b/language/move-prover/tests/sources/stdlib/modules/transaction_fee.exp
@@ -1,0 +1,336 @@
+Move prover returns: exiting with boogie verification errors
+error:  A precondition for this call might not hold.
+
+    ┌── tests/sources/stdlib/modules/validator_config.move:93:5 ───
+    │
+ 93 │ ╭     public fun rotate_consensus_pubkey(consensus_pubkey: vector<u8>) acquires T {
+ 94 │ │         let t_ref = borrow_global_mut<T>(Transaction::sender());
+ 95 │ │         let key_ref = &mut t_ref.config.consensus_pubkey;
+ 96 │ │         *key_ref = consensus_pubkey;
+ 97 │ │     }
+    │ ╰─────^
+    │
+    =     at tests/sources/stdlib/modules/libra_system.move:289:4: rotate_consensus_pubkey (entry)
+    =     at tests/sources/stdlib/modules/libra_system.move:290:32: rotate_consensus_pubkey
+    =         consensus_pubkey = <redacted>,
+    =         validator_set_ref = <redacted>
+    =     at tests/sources/stdlib/modules/libra_system.move:291:43: rotate_consensus_pubkey
+    =         account_address = <redacted>
+    =     at tests/sources/stdlib/modules/libra_system.move:140:4: is_validator_ (entry)
+    =     at tests/sources/stdlib/modules/libra_system.move:141:28: is_validator_
+    =         addr = <redacted>,
+    =         validators_vec_ref = <redacted>,
+    =         size = <redacted>
+    =     at tests/sources/stdlib/modules/libra_system.move:142:13: is_validator_
+    =     at tests/sources/stdlib/modules/libra_system.move:146:13: is_validator_
+    =     at tests/sources/stdlib/modules/libra_system.move:148:49: is_validator_
+    =         i = <redacted>,
+    =         validator_info_ref = <redacted>
+    =     at tests/sources/stdlib/modules/libra_system.move:150:18: is_validator_
+    =     at tests/sources/stdlib/modules/libra_system.move:295:12: rotate_consensus_pubkey
+    =     at tests/sources/stdlib/modules/libra_system.move:294:8: rotate_consensus_pubkey
+    =     at tests/sources/stdlib/modules/validator_config.move:93:5: rotate_consensus_pubkey (entry)
+
+error:  A precondition for this call might not hold.
+
+     ┌── tests/sources/stdlib/modules/libra_system.move:115:5 ───
+     │
+ 115 │ ╭     public fun get_discovery_address(d: &DiscoveryInfo): &address {
+ 116 │ │         &d.addr
+ 117 │ │     }
+     │ ╰─────^
+     │
+     =     at tests/sources/stdlib/modules/libra_system.move:329:4: rotate_validator_network_address (entry)
+     =     at tests/sources/stdlib/modules/libra_system.move:332:32: rotate_validator_network_address
+     =         validator_network_address = <redacted>,
+     =         discovery_set_ref = <redacted>
+     =     at tests/sources/stdlib/modules/libra_system.move:335:58: rotate_validator_network_address
+     =     at tests/sources/stdlib/modules/validator_config.move:113:5: rotate_validator_network_address (entry)
+     =     at tests/sources/stdlib/modules/validator_config.move:116:21: rotate_validator_network_address
+     =         validator_network_address = <redacted>,
+     =         t_ref = <redacted>
+     =     at tests/sources/stdlib/modules/validator_config.move:117:13: rotate_validator_network_address
+     =         key_ref = <redacted>
+     =     at tests/sources/stdlib/modules/validator_config.move:118:20: rotate_validator_network_address
+     =         key_ref = <redacted>,
+     =         t_ref = <redacted>
+     =     at tests/sources/stdlib/modules/libra_system.move:335:25: rotate_validator_network_address
+     =     at tests/sources/stdlib/modules/libra_system.move:207:5: get_discovery_index (entry)
+     =     at tests/sources/stdlib/modules/libra_system.move:208:27: get_discovery_index
+     =         discovery_set = <redacted>,
+     =         addr = <redacted>,
+     =         len = <redacted>
+     =     at tests/sources/stdlib/modules/libra_system.move:209:17: get_discovery_index
+     =         i = <redacted>
+     =     at tests/sources/stdlib/modules/libra_system.move:211:54: get_discovery_index
+     =     at tests/sources/stdlib/modules/libra_system.move:115:5: get_discovery_address (entry)
+
+error:  A precondition for this call might not hold.
+
+     ┌── tests/sources/stdlib/modules/libra_system.move:115:5 ───
+     │
+ 115 │ ╭     public fun get_discovery_address(d: &DiscoveryInfo): &address {
+ 116 │ │         &d.addr
+ 117 │ │     }
+     │ ╰─────^
+     │
+     =     at tests/sources/stdlib/modules/libra_system.move:311:4: rotate_validator_network_identity_pubkey (entry)
+     =     at tests/sources/stdlib/modules/libra_system.move:314:32: rotate_validator_network_identity_pubkey
+     =         validator_network_identity_pubkey = <redacted>,
+     =         discovery_set_ref = <redacted>
+     =     at tests/sources/stdlib/modules/libra_system.move:317:66: rotate_validator_network_identity_pubkey
+     =     at tests/sources/stdlib/modules/validator_config.move:103:5: rotate_validator_network_identity_pubkey (entry)
+     =     at tests/sources/stdlib/modules/validator_config.move:106:21: rotate_validator_network_identity_pubkey
+     =         validator_network_identity_pubkey = <redacted>,
+     =         t_ref = <redacted>
+     =     at tests/sources/stdlib/modules/validator_config.move:107:13: rotate_validator_network_identity_pubkey
+     =         key_ref = <redacted>
+     =     at tests/sources/stdlib/modules/validator_config.move:108:20: rotate_validator_network_identity_pubkey
+     =         key_ref = <redacted>,
+     =         t_ref = <redacted>
+     =     at tests/sources/stdlib/modules/libra_system.move:317:25: rotate_validator_network_identity_pubkey
+     =     at tests/sources/stdlib/modules/libra_system.move:207:5: get_discovery_index (entry)
+     =     at tests/sources/stdlib/modules/libra_system.move:208:27: get_discovery_index
+     =         discovery_set = <redacted>,
+     =         addr = <redacted>,
+     =         len = <redacted>
+     =     at tests/sources/stdlib/modules/libra_system.move:209:17: get_discovery_index
+     =         i = <redacted>
+     =     at tests/sources/stdlib/modules/libra_system.move:211:54: get_discovery_index
+     =     at tests/sources/stdlib/modules/libra_system.move:115:5: get_discovery_address (entry)
+
+error:  A precondition for this call might not hold.
+
+     ┌── tests/sources/stdlib/modules/libra_system.move:412:4 ───
+     │
+ 412 │ ╭    fun make_validator_info(addr: address): ValidatorInfo {
+ 413 │ │        let config = ValidatorConfig::config(addr);
+ 414 │ │
+ 415 │ │       ValidatorInfo {
+ 416 │ │           addr: addr,
+ 417 │ │           consensus_pubkey: ValidatorConfig::consensus_pubkey(&config),
+ 418 │ │           consensus_voting_power: 1,
+ 419 │ │           network_signing_pubkey: ValidatorConfig::validator_network_signing_pubkey(&config),
+ 420 │ │           network_identity_pubkey: ValidatorConfig::validator_network_identity_pubkey(&config),
+ 421 │ │       }
+ 422 │ │    }
+     │ ╰────^
+     │
+     =     at tests/sources/stdlib/modules/libra_system.move:227:5: add_validator (entry)
+     =     at tests/sources/stdlib/modules/libra_system.move:233:4: add_validator_ (entry)
+     =     at tests/sources/stdlib/modules/libra_system.move:235:8: add_validator_
+     =         account_address = <redacted>
+     =     at tests/sources/stdlib/modules/validator_config.move:24:5: has (entry)
+     =     at tests/sources/stdlib/modules/libra_system.move:237:45: add_validator_
+     =     at tests/sources/stdlib/modules/libra_system.move:239:32: add_validator_
+     =         validator_set_ref = <redacted>
+     =     at tests/sources/stdlib/modules/libra_system.move:240:64: add_validator_
+     =         discovery_set_ref = <redacted>
+     =     at tests/sources/stdlib/modules/libra_system.move:140:4: is_validator_ (entry)
+     =     at tests/sources/stdlib/modules/libra_system.move:141:28: is_validator_
+     =         addr = <redacted>,
+     =         validators_vec_ref = <redacted>,
+     =         size = <redacted>
+     =     at tests/sources/stdlib/modules/libra_system.move:142:13: is_validator_
+     =     at tests/sources/stdlib/modules/libra_system.move:146:13: is_validator_
+     =     at tests/sources/stdlib/modules/libra_system.move:148:49: is_validator_
+     =         i = <redacted>,
+     =         validator_info_ref = <redacted>
+     =     at tests/sources/stdlib/modules/libra_system.move:150:18: is_validator_
+     =     at tests/sources/stdlib/modules/libra_system.move:153:19: is_validator_
+     =         i = <redacted>
+     =     at tests/sources/stdlib/modules/libra_system.move:154:17: is_validator_
+     =     at tests/sources/stdlib/modules/libra_system.move:244:13: add_validator_
+     =     at tests/sources/stdlib/modules/libra_system.move:243:8: add_validator_
+     =     at tests/sources/stdlib/modules/libra_system.move:412:4: make_validator_info (entry)
+
+error:  A precondition for this call might not hold.
+
+     ┌── tests/sources/stdlib/modules/libra_system.move:412:4 ───
+     │
+ 412 │ ╭    fun make_validator_info(addr: address): ValidatorInfo {
+ 413 │ │        let config = ValidatorConfig::config(addr);
+ 414 │ │
+ 415 │ │       ValidatorInfo {
+ 416 │ │           addr: addr,
+ 417 │ │           consensus_pubkey: ValidatorConfig::consensus_pubkey(&config),
+ 418 │ │           consensus_voting_power: 1,
+ 419 │ │           network_signing_pubkey: ValidatorConfig::validator_network_signing_pubkey(&config),
+ 420 │ │           network_identity_pubkey: ValidatorConfig::validator_network_identity_pubkey(&config),
+ 421 │ │       }
+ 422 │ │    }
+     │ ╰────^
+     │
+     =     at tests/sources/stdlib/modules/libra_system.move:233:4: add_validator_ (entry)
+     =     at tests/sources/stdlib/modules/libra_system.move:235:8: add_validator_
+     =         account_address = <redacted>
+     =     at tests/sources/stdlib/modules/validator_config.move:24:5: has (entry)
+     =     at tests/sources/stdlib/modules/libra_system.move:237:45: add_validator_
+     =     at tests/sources/stdlib/modules/libra_system.move:239:32: add_validator_
+     =         validator_set_ref = <redacted>
+     =     at tests/sources/stdlib/modules/libra_system.move:240:64: add_validator_
+     =         discovery_set_ref = <redacted>
+     =     at tests/sources/stdlib/modules/libra_system.move:140:4: is_validator_ (entry)
+     =     at tests/sources/stdlib/modules/libra_system.move:141:28: is_validator_
+     =         addr = <redacted>,
+     =         validators_vec_ref = <redacted>,
+     =         size = <redacted>
+     =     at tests/sources/stdlib/modules/libra_system.move:142:13: is_validator_
+     =     at tests/sources/stdlib/modules/libra_system.move:146:13: is_validator_
+     =     at tests/sources/stdlib/modules/libra_system.move:148:49: is_validator_
+     =         i = <redacted>,
+     =         validator_info_ref = <redacted>
+     =     at tests/sources/stdlib/modules/libra_system.move:150:18: is_validator_
+     =     at tests/sources/stdlib/modules/libra_system.move:153:19: is_validator_
+     =         i = <redacted>
+     =     at tests/sources/stdlib/modules/libra_system.move:154:17: is_validator_
+     =     at tests/sources/stdlib/modules/libra_system.move:244:13: add_validator_
+     =     at tests/sources/stdlib/modules/libra_system.move:243:8: add_validator_
+     =     at tests/sources/stdlib/modules/libra_system.move:412:4: make_validator_info (entry)
+
+error:  A precondition for this call might not hold.
+
+     ┌── tests/sources/stdlib/modules/libra_system.move:115:5 ───
+     │
+ 115 │ ╭     public fun get_discovery_address(d: &DiscoveryInfo): &address {
+ 116 │ │         &d.addr
+ 117 │ │     }
+     │ ╰─────^
+     │
+     =     at tests/sources/stdlib/modules/libra_system.move:207:5: get_discovery_index (entry)
+     =     at tests/sources/stdlib/modules/libra_system.move:208:27: get_discovery_index
+     =         discovery_set = <redacted>,
+     =         addr = <redacted>,
+     =         len = <redacted>
+     =     at tests/sources/stdlib/modules/libra_system.move:209:17: get_discovery_index
+     =         i = <redacted>
+     =     at tests/sources/stdlib/modules/libra_system.move:211:54: get_discovery_index
+     =     at tests/sources/stdlib/modules/libra_system.move:115:5: get_discovery_address (entry)
+
+error:  A precondition for this call might not hold.
+
+    ┌── tests/sources/stdlib/modules/libra_system.move:93:5 ───
+    │
+ 93 │ ╭     public fun get_validator_address(v: &ValidatorInfo): &address {
+ 94 │ │       &v.addr
+ 95 │ │     }
+    │ ╰─────^
+    │
+    =     at tests/sources/stdlib/modules/libra_system.move:190:5: get_validator_index (entry)
+    =     at tests/sources/stdlib/modules/libra_system.move:191:27: get_validator_index
+    =         validators = <redacted>,
+    =         addr = <redacted>,
+    =         len = <redacted>
+    =     at tests/sources/stdlib/modules/libra_system.move:192:17: get_validator_index
+    =         i = <redacted>
+    =     at tests/sources/stdlib/modules/libra_system.move:194:54: get_validator_index
+    =     at tests/sources/stdlib/modules/libra_system.move:93:5: get_validator_address (entry)
+
+error:  A precondition for this call might not hold.
+
+    ┌── tests/sources/stdlib/modules/libra_system.move:93:5 ───
+    │
+ 93 │ ╭     public fun get_validator_address(v: &ValidatorInfo): &address {
+ 94 │ │       &v.addr
+ 95 │ │     }
+    │ ╰─────^
+    │
+    =     at tests/sources/stdlib/modules/libra_system.move:258:4: remove_validator (entry)
+    =     at tests/sources/stdlib/modules/libra_system.move:260:8: remove_validator
+    =         account_address = <redacted>
+    =     at tests/sources/stdlib/modules/libra_system.move:262:32: remove_validator
+    =         validator_set_ref = <redacted>
+    =     at tests/sources/stdlib/modules/libra_system.move:263:64: remove_validator
+    =         discovery_set_ref = <redacted>
+    =     at tests/sources/stdlib/modules/libra_system.move:140:4: is_validator_ (entry)
+    =     at tests/sources/stdlib/modules/libra_system.move:141:28: is_validator_
+    =         addr = <redacted>,
+    =         validators_vec_ref = <redacted>,
+    =         size = <redacted>
+    =     at tests/sources/stdlib/modules/libra_system.move:142:13: is_validator_
+    =     at tests/sources/stdlib/modules/libra_system.move:146:13: is_validator_
+    =     at tests/sources/stdlib/modules/libra_system.move:148:49: is_validator_
+    =         i = <redacted>,
+    =         validator_info_ref = <redacted>
+    =     at tests/sources/stdlib/modules/libra_system.move:150:18: is_validator_
+    =     at tests/sources/stdlib/modules/libra_system.move:266:12: remove_validator
+    =     at tests/sources/stdlib/modules/libra_system.move:265:8: remove_validator
+    =     at tests/sources/stdlib/modules/libra_system.move:190:5: get_validator_index (entry)
+    =     at tests/sources/stdlib/modules/libra_system.move:191:27: get_validator_index
+    =     at tests/sources/stdlib/modules/libra_system.move:192:17: get_validator_index
+    =     at tests/sources/stdlib/modules/libra_system.move:194:54: get_validator_index
+    =     at tests/sources/stdlib/modules/libra_system.move:93:5: get_validator_address (entry)
+
+error:  A precondition for this call might not hold.
+
+     ┌── tests/sources/stdlib/modules/libra_system.move:174:5 ───
+     │
+ 174 │ ╭     public fun get_ith_validator_address(i: u64): address acquires ValidatorSet {
+ 175 │ │       let validator_set = borrow_global<ValidatorSet>(0x1D8);
+ 176 │ │       let len = Vector::length(&validator_set.validators);
+ 177 │ │       Transaction::assert(i < len, 3);
+ 178 │ │       Vector::borrow(&validator_set.validators, i).addr
+ 179 │ │     }
+     │ ╰─────^
+     │
+     =     at tests/sources/stdlib/modules/transaction_fee.move:51:5: distribute_transaction_fees (entry)
+     =     at tests/sources/stdlib/modules/transaction_fee.move:53:7: distribute_transaction_fees
+     =     at tests/sources/stdlib/modules/libra_system.move:136:5: validator_set_size (entry)
+     =     at tests/sources/stdlib/modules/libra_system.move:137:25: validator_set_size
+     =     at tests/sources/stdlib/modules/transaction_fee.move:55:41: distribute_transaction_fees
+     =         num_validators = <redacted>
+     =     at tests/sources/stdlib/modules/transaction_fee.move:56:52: distribute_transaction_fees
+     =         amount_collected = <redacted>
+     =     at tests/sources/stdlib/modules/libra_account.move:384:5: balance (entry)
+     =     at tests/sources/stdlib/modules/libra_account.move:385:21: balance
+     =         addr = <redacted>
+     =     at tests/sources/stdlib/modules/libra_account.move:379:5: balance_for (entry)
+     =     at tests/sources/stdlib/modules/libra_coin.move:105:5: value (entry)
+     =     at tests/sources/stdlib/modules/libra_coin.move:105:5: value (exit)
+     =         coin_ref = <redacted>
+     =     at tests/sources/stdlib/modules/libra_account.move:380:20: balance_for
+     =         balance = <redacted>
+     =     at tests/sources/stdlib/modules/libra_account.move:385:9: balance
+     =     at tests/sources/stdlib/modules/transaction_fee.move:56:44: distribute_transaction_fees
+     =     at tests/sources/stdlib/modules/transaction_fee.move:59:11: distribute_transaction_fees
+     =     at tests/sources/stdlib/modules/transaction_fee.move:108:5: per_validator_distribution_amount (entry)
+     =     at tests/sources/stdlib/modules/transaction_fee.move:109:9: per_validator_distribution_amount
+     =         amount_collected = <redacted>,
+     =         num_validators = <redacted>
+     =     at tests/sources/stdlib/modules/transaction_fee.move:110:49: per_validator_distribution_amount
+     =         validator_payout = <redacted>
+     =     at tests/sources/stdlib/modules/transaction_fee.move:111:29: per_validator_distribution_amount
+     =     at tests/sources/stdlib/modules/transaction_fee.move:62:48: distribute_transaction_fees
+     =         amount_to_distribute_per_validator = <redacted>
+     =     at tests/sources/stdlib/modules/transaction_fee.move:69:11: distribute_transaction_fees
+     =     at tests/sources/stdlib/modules/transaction_fee.move:79:5: distribute_transaction_fees_internal (entry)
+     =     at tests/sources/stdlib/modules/transaction_fee.move:83:37: distribute_transaction_fees_internal
+     =         amount_to_distribute_per_validator = <redacted>,
+     =         num_validators = <redacted>,
+     =         distribution_resource = <redacted>
+     =     at tests/sources/stdlib/modules/transaction_fee.move:84:21: distribute_transaction_fees_internal
+     =         index = <redacted>
+     =     at tests/sources/stdlib/modules/transaction_fee.move:86:16: distribute_transaction_fees_internal
+     =     at tests/sources/stdlib/modules/libra_system.move:174:5: get_ith_validator_address (entry)
+
+error:  A precondition for this call might not hold.
+
+     ┌── tests/sources/stdlib/modules/libra_system.move:174:5 ───
+     │
+ 174 │ ╭     public fun get_ith_validator_address(i: u64): address acquires ValidatorSet {
+ 175 │ │       let validator_set = borrow_global<ValidatorSet>(0x1D8);
+ 176 │ │       let len = Vector::length(&validator_set.validators);
+ 177 │ │       Transaction::assert(i < len, 3);
+ 178 │ │       Vector::borrow(&validator_set.validators, i).addr
+ 179 │ │     }
+     │ ╰─────^
+     │
+     =     at tests/sources/stdlib/modules/transaction_fee.move:79:5: distribute_transaction_fees_internal (entry)
+     =     at tests/sources/stdlib/modules/transaction_fee.move:83:37: distribute_transaction_fees_internal
+     =         amount_to_distribute_per_validator = <redacted>,
+     =         num_validators = <redacted>,
+     =         distribution_resource = <redacted>
+     =     at tests/sources/stdlib/modules/transaction_fee.move:84:21: distribute_transaction_fees_internal
+     =         index = <redacted>
+     =     at tests/sources/stdlib/modules/transaction_fee.move:86:16: distribute_transaction_fees_internal
+     =     at tests/sources/stdlib/modules/libra_system.move:174:5: get_ith_validator_address (entry)

--- a/language/move-prover/tests/sources/stdlib/modules/transaction_fee.move
+++ b/language/move-prover/tests/sources/stdlib/modules/transaction_fee.move
@@ -1,0 +1,114 @@
+// dep: tests/sources/stdlib/modules/libra_account.move
+// dep: tests/sources/stdlib/modules/libra_system.move
+// dep: tests/sources/stdlib/modules/address_util.move
+// dep: tests/sources/stdlib/modules/transaction.move
+// dep: tests/sources/stdlib/modules/vector.move
+// dep: tests/sources/stdlib/modules/libra_coin.move
+// dep: tests/sources/stdlib/modules/validator_config.move
+// dep: tests/sources/stdlib/modules/u64_util.move
+// dep: tests/sources/stdlib/modules/hash.move
+// dep: tests/sources/stdlib/modules/libra_time.move
+// dep: tests/sources/stdlib/modules/libra_transaction_timeout.move
+address 0x0:
+
+module TransactionFee {
+    use 0x0::LibraAccount;
+    use 0x0::LibraSystem;
+    use 0x0::AddressUtil;
+    use 0x0::Transaction;
+    use 0x0::Vector;
+
+    ///////////////////////////////////////////////////////////////////////////
+    // Transaction Fee Distribution
+    ///////////////////////////////////////////////////////////////////////////
+    // Implements a basic transaction fee distribution logic.
+    //
+    // We have made a couple design decisions here that are worth noting:
+    //  * We pay out once per-block for now.
+    //    TODO: Once we have a better on-chain representation of
+    //          epochs this should be changed over to be once per-epoch.
+    //  * Sometimes the number of validators does not evenly divide the transaction fees to be
+    //    distributed. In such cases the remainder ("dust") is left in the transaction fees pot and
+    //    these remaining fees will be included in the calculations for the transaction fee
+    //    distribution in the next epoch. This distribution strategy is meant to in part minimize the
+    //    benefit of being the first validator in the validator set.
+
+    resource struct TransactionFees {
+        fee_withdrawal_capability: LibraAccount::WithdrawalCapability,
+    }
+
+    // Initialize the transaction fee distribution module. We keep track of the last paid block
+    // height in order to ensure that we don't try to pay more than once per-block. We also
+    // encapsulate the withdrawal capability to the transaction fee account so that we can withdraw
+    // the fees from this account from block metadata transactions.
+    fun initialize_transaction_fees() {
+        Transaction::assert(Transaction::sender() == 0xFEE, 0);
+        move_to_sender<TransactionFees>(TransactionFees {
+            fee_withdrawal_capability: LibraAccount::extract_sender_withdrawal_capability(),
+        });
+    }
+
+    public fun distribute_transaction_fees() acquires TransactionFees {
+      // Can only be invoked by LibraVM privilege.
+      Transaction::assert(Transaction::sender() == 0x0, 33);
+
+      let num_validators = LibraSystem::validator_set_size();
+      let amount_collected = LibraAccount::balance(0xFEE);
+
+      // If amount_collected == 0, this will also return early
+      if (amount_collected < num_validators) return ();
+
+      // Calculate the amount of money to be dispursed, along with the remainder.
+      let amount_to_distribute_per_validator = per_validator_distribution_amount(
+          amount_collected,
+          num_validators
+      );
+
+      // Iterate through the validators distributing fees equally
+      distribute_transaction_fees_internal(
+          amount_to_distribute_per_validator,
+          num_validators,
+      );
+    }
+
+    // After the book keeping has been performed, this then distributes the
+    // transaction fees equally to all validators with the exception that
+    // any remainder (in the case that the number of validators does not
+    // evenly divide the transaction fee pot) is distributed to the first
+    // validator.
+    fun distribute_transaction_fees_internal(
+        amount_to_distribute_per_validator: u64,
+        num_validators: u64
+    ) acquires TransactionFees {
+        let distribution_resource = borrow_global<TransactionFees>(0xFEE);
+        let index = 0;
+
+        while (index < num_validators) {
+
+            let addr = LibraSystem::get_ith_validator_address(index);
+            // Increment the index into the validator set.
+            index = index + 1;
+
+            LibraAccount::pay_from_capability(
+                addr,
+                Vector::empty(),
+                &distribution_resource.fee_withdrawal_capability,
+                amount_to_distribute_per_validator,
+                // FIXME: Update this once we have bytearray literals
+                AddressUtil::address_to_bytes(0xFEE),
+            );
+           }
+    }
+
+    // This calculates the amount to be distributed to each validator equally. We do this by calculating
+    // the integer division of the transaction fees collected by the number of validators. In
+    // particular, this means that if the number of validators does not evenly divide the
+    // transaction fees collected, then there will be a remainder that is left in the transaction
+    // fees pot to be distributed later.
+    fun per_validator_distribution_amount(amount_collected: u64, num_validators: u64): u64 {
+        Transaction::assert(num_validators != 0, 0);
+        let validator_payout = amount_collected / num_validators;
+        Transaction::assert(validator_payout * num_validators <= amount_collected, 1);
+        validator_payout
+    }
+}

--- a/language/move-prover/tests/sources/stdlib/modules/u64_util.exp
+++ b/language/move-prover/tests/sources/stdlib/modules/u64_util.exp
@@ -1,0 +1,1 @@
+Move prover all good, no errors!

--- a/language/move-prover/tests/sources/stdlib/modules/u64_util.move
+++ b/language/move-prover/tests/sources/stdlib/modules/u64_util.move
@@ -1,0 +1,5 @@
+address 0x0:
+
+module U64Util {
+    native public fun u64_to_bytes(i: u64): vector<u8>;
+}

--- a/language/move-prover/tests/sources/stdlib/modules/validator_config.exp
+++ b/language/move-prover/tests/sources/stdlib/modules/validator_config.exp
@@ -1,0 +1,1 @@
+Move prover all good, no errors!

--- a/language/move-prover/tests/sources/stdlib/modules/validator_config.move
+++ b/language/move-prover/tests/sources/stdlib/modules/validator_config.move
@@ -1,0 +1,120 @@
+// dep: tests/sources/stdlib/modules/transaction.move
+address 0x0:
+
+module ValidatorConfig {
+
+    use 0x0::Transaction;
+    // TODO(philiphayes): We should probably enforce a max length for these fields
+
+    struct Config {
+        consensus_pubkey: vector<u8>,
+        validator_network_signing_pubkey: vector<u8>,
+        validator_network_identity_pubkey: vector<u8>,
+        validator_network_address: vector<u8>,
+        fullnodes_network_identity_pubkey: vector<u8>,
+        fullnodes_network_address: vector<u8>,
+    }
+
+    // A current or prospective validator should publish one of these under their address
+    resource struct T {
+        config: Config,
+    }
+
+    // Returns true if addr has a published ValidatorConfig::T resource
+    public fun has(addr: address): bool {
+        exists<T>(addr)
+    }
+
+    // The following are public accessors for retrieving config information about Validators
+
+    // Retrieve a read-only instance of a specific accounts ValidatorConfig::T.config
+    public fun config(addr: address): Config acquires T {
+      *&borrow_global<T>(addr).config
+    }
+
+    // Public accessor for consensus_pubkey
+    public fun consensus_pubkey(config_ref: &Config): vector<u8> {
+        *&config_ref.consensus_pubkey
+    }
+
+    // Public accessor for validator_network_signing_pubkey
+    public fun validator_network_signing_pubkey(config_ref: &Config): vector<u8> {
+        *&config_ref.validator_network_signing_pubkey
+    }
+
+    // Public accessor for validator_network_identity_pubkey
+    public fun validator_network_identity_pubkey(config_ref: &Config): vector<u8> {
+        *&config_ref.validator_network_identity_pubkey
+    }
+
+    // Public accessor for validator_network_address
+    public fun validator_network_address(config_ref: &Config): vector<u8> {
+        *&config_ref.validator_network_address
+    }
+
+    // Public accessor for fullnodes_network_identity_pubkey
+    public fun fullnodes_network_identity_pubkey(config_ref: &Config): vector<u8> {
+        *&config_ref.fullnodes_network_identity_pubkey
+    }
+
+    // Public accessor for fullnodes_network_address
+    public fun fullnodes_network_address(config_ref: &Config): vector<u8> {
+        *&config_ref.fullnodes_network_address
+    }
+
+    // The following are self methods for initializing and maintaining a Validator's config
+
+    // Register the transaction sender as a candidate validator by creating a ValidatorConfig
+    // resource under their account
+    public fun register_candidate_validator(
+        consensus_pubkey: vector<u8>,
+        validator_network_signing_pubkey: vector<u8>,
+        validator_network_identity_pubkey: vector<u8>,
+        validator_network_address: vector<u8>,
+        fullnodes_network_identity_pubkey: vector<u8>,
+        fullnodes_network_address: vector<u8>) {
+
+        move_to_sender<T>(
+            T {
+                config: Config {
+                     consensus_pubkey,
+                     validator_network_signing_pubkey,
+                     validator_network_identity_pubkey,
+                     validator_network_address,
+                     fullnodes_network_identity_pubkey,
+                     fullnodes_network_address,
+                }
+            }
+        );
+    }
+
+    // Rotate a validator candidate's consensus public key. The change will not take effect until
+    // the next reconfiguration.
+    public fun rotate_consensus_pubkey(consensus_pubkey: vector<u8>) acquires T {
+        let t_ref = borrow_global_mut<T>(Transaction::sender());
+        let key_ref = &mut t_ref.config.consensus_pubkey;
+        *key_ref = consensus_pubkey;
+    }
+
+    // TODO(philiphayes): fill out the rest of the rotate methods
+
+    // Rotate the network public key for validator discovery. This change will be
+    // committed in the next reconfiguration.
+    public fun rotate_validator_network_identity_pubkey(
+        validator_network_identity_pubkey: vector<u8>
+    ) acquires T {
+        let t_ref = borrow_global_mut<T>(Transaction::sender());
+        let key_ref = &mut t_ref.config.validator_network_identity_pubkey;
+        *key_ref = validator_network_identity_pubkey;
+    }
+
+    // Rotate the network address for validator discovery. This change will be
+    // committed in the next reconfiguration.
+    public fun rotate_validator_network_address(
+        validator_network_address: vector<u8>
+    ) acquires T {
+        let t_ref = borrow_global_mut<T>(Transaction::sender());
+        let key_ref = &mut t_ref.config.validator_network_address;
+        *key_ref = validator_network_address;
+    }
+}

--- a/language/move-prover/tests/sources/stdlib/modules/vector.exp
+++ b/language/move-prover/tests/sources/stdlib/modules/vector.exp
@@ -1,0 +1,1 @@
+Move prover all good, no errors!

--- a/language/move-prover/tests/sources/stdlib/modules/vector.move
+++ b/language/move-prover/tests/sources/stdlib/modules/vector.move
@@ -1,0 +1,85 @@
+address 0x0:
+
+// A variable-sized container that can hold both unrestricted types and resources.
+module Vector {
+    native public fun empty<Element>(): vector<Element>;
+
+    // Return the length of the vector.
+    native public fun length<Element>(v: &vector<Element>): u64;
+
+    // Acquire an immutable reference to the ith element of the vector.
+    native public fun borrow<Element>(v: &vector<Element>, i: u64): &Element;
+
+    // Add an element to the end of the vector.
+    native public fun push_back<Element>(v: &mut vector<Element>, e: Element);
+
+    // Get mutable reference to the ith element in the vector, abort if out of bound.
+    native public fun borrow_mut<Element>(v: &mut vector<Element>, idx: u64): &mut Element;
+
+    // Pop an element from the end of vector, abort if the vector is empty.
+    native public fun pop_back<Element>(v: &mut vector<Element>): Element;
+
+    // Destroy the vector, abort if not empty.
+    native public fun destroy_empty<Element>(v: vector<Element>);
+
+    // Swaps the elements at the i'th and j'th indices in the vector.
+    native public fun swap<Element>(v: &mut vector<Element>, i: u64, j: u64);
+
+    // Reverses the order of the elements in the vector in place.
+    public fun reverse<Element>(v: &mut vector<Element>) {
+        let len = length(v);
+        if (len == 0) return ();
+
+        let front_index = 0;
+        let back_index = len -1;
+        while (front_index < back_index) {
+            swap(v, front_index, back_index);
+            front_index = front_index + 1;
+            back_index = back_index - 1;
+        }
+    }
+
+    // Moves all of the elements of the `other` vector into the `lhs` vector.
+    public fun append<Element>(lhs: &mut vector<Element>, other: vector<Element>) {
+        reverse(&mut other);
+        while (!is_empty(&other)) push_back(lhs, pop_back(&mut other));
+        destroy_empty(other);
+    }
+
+    // Return true if the vector has no elements
+    public fun is_empty<Element>(v: &vector<Element>): bool {
+        length(v) == 0
+    }
+
+    // Return true if `e` is in the vector `v`
+    public fun contains<Element>(v: &vector<Element>, e: &Element): bool {
+        let i = 0;
+        let len = length(v);
+        while (i < len) {
+            if (borrow(v, i) == e) return true;
+            i = i + 1;
+        };
+        false
+    }
+
+    // Remove the `i`th element E of the vector, shifting all subsequent elements
+    // It is O(n) and preserves ordering
+    public fun remove<Element>(v: &mut vector<Element>, i: u64): Element {
+        let len = length(v);
+        // i out of bounds; abort
+        if (i >= len) abort 10;
+
+        len = len - 1;
+        while (i < len) swap(v, i, { i = i + 1; i });
+        pop_back(v)
+    }
+
+    // Remove the `i`th element E of the vector by swapping it with the last element,
+    // and then popping it off
+    // It is O(1), but does not preserve ordering
+    public fun swap_remove<Element>(v: &mut vector<Element>, i: u64): Element {
+        let last_idx = length(v) - 1;
+        swap(v, i, last_idx);
+        pop_back(v)
+    }
+}


### PR DESCRIPTION
There was a bug in baseline_tests.rs::verify_or_update_baseline where it failed tests because of whitespace. The problem turned out to be that the .exp file (reference output) was stripped of trailing whitespace to make github happy, but the output file it was compared with was not stripped.  I wrapped a call to clean_for_baseline around the "text" arg to diff.

Copied core contracts from language/stdlib to move-prover/tests/sources/stdlib.  I kept the modules and transaction_scripts directories.

Only the modules/libra_coin.move module is specified. I copied the
others so we can add specifications to them.

libra_coin.move has updated versions of the specs for the .mvir version. I.e., aborts_if and ensures for individual functions.  There are interesting global properties to be specified, but I haven't tried doing that yet.

I also added dependency comments at the beginnings of the .move files so the prover can find them during "cargo test".

Three files have no Move specifications but still can't make it through the Move prover: libra_system.move, libra_block.move, and transaction_fee.move. I have not investigated this problem yet.  The tests all pass because the ".exp" files have the erroneous messages in them.

<!--
Thank you for sending a PR. We appreciate you spending time to help improve the Libra project.

The project is undergoing daily changes. Pull Requests will be reviewed and responded to as time permits.
-->

## Motivation

Added specified contract libra_coin.move for testing, set up files to add specs for more contracts, fixed a bug in test framework.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

cargo test

## Related PRs

(If this PR adds or changes functionality, please take some time to update the docs at https://github.com/libra/website, and link to your PR here.)
