### PR TITLE
[faucet] update API to use auth key instead of address

### DIFF
--- a/client/cli/src/client_proxy.rs
+++ b/client/cli/src/client_proxy.rs
@@ -321,7 +321,7 @@ impl ClientProxy {
                 ),
                 is_blocking,
             ),
-            None => self.mint_coins_with_faucet_service(&receiver, num_coins, is_blocking),
+            None => self.mint_coins_with_faucet_service(receiver_auth_key, num_coins, is_blocking),
         }
     }
 
@@ -1109,7 +1109,7 @@ impl ClientProxy {
 
     fn mint_coins_with_faucet_service(
         &mut self,
-        receiver: &AccountAddress,
+        receiver: AuthenticationKey,
         num_coins: u64,
         is_blocking: bool,
     ) -> Result<()> {
@@ -1119,7 +1119,7 @@ impl ClientProxy {
             format!("http://{}", self.faucet_server).as_str(),
             &[
                 ("amount", num_coins.to_string().as_str()),
-                ("address", format!("{:?}", receiver).as_str()),
+                ("auth_key", &hex::encode(receiver)),
             ],
         )?;
 

--- a/docker/mint/server.py
+++ b/docker/mint/server.py
@@ -42,11 +42,11 @@ create_client()
 
 @application.route("/", methods=('POST',))
 def send_transaction():
-    address = flask.request.args['address']
+    auth_key = flask.request.args['auth_key']
 
-    # Return immediately if address is invalid
-    if re.match('^[a-f0-9]{32}$', address) is None:
-        return 'Malformed address', 400
+    # Return immediately if auth_key is invalid
+    if re.match('^[a-f0-9]{64}$', auth_key) is None:
+        return 'Malformed auth_key', 400
 
     try:
         amount = decimal.Decimal(flask.request.args['amount'])
@@ -59,7 +59,7 @@ def send_transaction():
     try:
         create_client()
         application.client.sendline(
-            "a m {} {}".format(address, amount / (10 ** 6)))
+            "a m {} {}".format(auth_key, amount / (10 ** 6)))
         application.client.expect("Mint request submitted", timeout=2)
 
         application.client.sendline("a la")


### PR DESCRIPTION
creating new account by minting now requires to pass original auth key
so switching API to use that instead of address