### PR TITLE
[executor-type] merge ExecutedState into StateComputeResult

### DIFF
--- a/consensus/consensus-types/src/executed_block.rs
+++ b/consensus/consensus-types/src/executed_block.rs
@@ -98,11 +98,10 @@ impl<T> ExecutedBlock<T> {
     }
 
     pub fn block_info(&self) -> BlockInfo {
-        let executed_state = self.compute_result().executed_state;
         self.block().gen_block_info(
-            executed_state.state_id,
-            executed_state.version,
-            executed_state.validators,
+            self.compute_result().state_id(),
+            self.compute_result().version(),
+            self.compute_result().validators().clone(),
         )
     }
 }

--- a/consensus/src/chained_bft/block_storage/block_store_test.rs
+++ b/consensus/src/chained_bft/block_storage/block_store_test.rs
@@ -262,14 +262,12 @@ fn test_insert_vote() {
 
     assert!(block_store.get_quorum_cert_for_block(block.id()).is_none());
     for (i, voter) in signers.iter().enumerate().take(10).skip(1) {
-        let executed_state = &block.compute_result().executed_state;
-
         let vote = Vote::new(
             VoteData::new(
                 block.block().gen_block_info(
-                    executed_state.state_id,
-                    executed_state.version,
-                    executed_state.validators.clone(),
+                    block.compute_result().state_id(),
+                    block.compute_result().version(),
+                    block.compute_result().validators().clone(),
                 ),
                 block.quorum_cert().certified_block().clone(),
             ),
@@ -291,14 +289,13 @@ fn test_insert_vote() {
     }
 
     // Add the final vote to form a QC
-    let executed_state = &block.compute_result().executed_state;
     let final_voter = &signers[0];
     let vote = Vote::new(
         VoteData::new(
             block.block().gen_block_info(
-                executed_state.state_id,
-                executed_state.version,
-                executed_state.validators.clone(),
+                block.compute_result().state_id(),
+                block.compute_result().version(),
+                block.compute_result().validators().clone(),
             ),
             block.quorum_cert().certified_block().clone(),
         ),

--- a/consensus/src/chained_bft/event_processor.rs
+++ b/consensus/src/chained_bft/event_processor.rs
@@ -765,7 +765,7 @@ impl<T: Payload> EventProcessor<T> {
                 executed_block.transaction_info_hashes(),
             ),
             block.clone(),
-            executed_block.compute_result().executed_state.validators,
+            executed_block.compute_result().validators().clone(),
         );
 
         let vote = self
@@ -956,7 +956,7 @@ impl<T: Payload> EventProcessor<T> {
                     }
                 }
             }
-            for status in block.compute_result().compute_status.iter() {
+            for status in block.compute_result().compute_status().iter() {
                 match status {
                     TransactionStatus::Keep(_) => {
                         counters::COMMITTED_TXNS_COUNT

--- a/consensus/src/chained_bft/event_processor_test.rs
+++ b/consensus/src/chained_bft/event_processor_test.rs
@@ -261,16 +261,14 @@ fn basic_new_rank_event_test() {
         );
         assert_eq!(pending_proposals[0].proposer(), node.signer.author());
 
-        let executed_state = &a1.compute_result().executed_state;
-
         // Simulate a case with a1 receiving enough votes for a QC: a new proposal
         // should be a child of a1 and carry its QC.
         let vote = Vote::new(
             VoteData::new(
                 a1.block().gen_block_info(
-                    executed_state.state_id,
-                    executed_state.version,
-                    executed_state.validators.clone(),
+                    a1.compute_result().state_id(),
+                    a1.compute_result().version(),
+                    a1.compute_result().validators().clone(),
                 ),
                 a1.quorum_cert().certified_block().clone(),
             ),
@@ -281,9 +279,9 @@ fn basic_new_rank_event_test() {
         let vote1 = Vote::new(
             VoteData::new(
                 a1.block().gen_block_info(
-                    executed_state.state_id,
-                    executed_state.version,
-                    executed_state.validators.clone(),
+                    a1.compute_result().state_id(),
+                    a1.compute_result().version(),
+                    a1.compute_result().validators().clone(),
                 ),
                 a1.quorum_cert().certified_block().clone(),
             ),
@@ -643,17 +641,16 @@ fn process_votes_basic_test() {
     let genesis = node.block_store.root();
     let mut inserter = TreeInserter::new_with_store(node.signer.clone(), node.block_store.clone());
     let a1 = inserter.insert_block_with_qc(certificate_for_genesis(), &genesis, 1);
-    let executed_state = &a1.compute_result().executed_state;
 
     let vote_data = VoteData::new(
         BlockInfo::new(
             a1.quorum_cert().certified_block().epoch(),
             a1.round(),
             a1.id(),
-            executed_state.state_id,
-            executed_state.version,
+            a1.compute_result().state_id(),
+            a1.compute_result().version(),
             a1.timestamp_usecs(),
-            executed_state.validators.clone(),
+            a1.compute_result().validators().clone(),
         ),
         a1.quorum_cert().certified_block().clone(),
     );

--- a/consensus/src/chained_bft/test_utils/mock_txn_manager.rs
+++ b/consensus/src/chained_bft/test_utils/mock_txn_manager.rs
@@ -75,13 +75,18 @@ impl TxnManager for MockTransactionManager {
         compute_results: &StateComputeResult,
     ) -> Result<()> {
         if self.mempool_proxy.is_some() {
-            let mut compute_results_clone = compute_results.clone();
-            compute_results_clone.compute_status = mock_transaction_status(txns.len());
+            let mock_compute_result = StateComputeResult::new(
+                compute_results.state_id(),
+                compute_results.frozen_subtree_roots().clone(),
+                compute_results.num_leaves(),
+                compute_results.validators().clone(),
+                mock_transaction_status(txns.len()),
+            );
             assert!(self
                 .mempool_proxy
                 .as_mut()
                 .unwrap()
-                .commit_txns(&vec![], &compute_results_clone)
+                .commit_txns(&vec![], &mock_compute_result)
                 .await
                 .is_ok());
         }

--- a/consensus/src/txn_manager.rs
+++ b/consensus/src/txn_manager.rs
@@ -71,7 +71,7 @@ impl TxnManager for MempoolProxy {
         compute_results: &StateComputeResult,
     ) -> Result<()> {
         let mut rejected_txns = vec![];
-        for (txn, status) in txns.iter().zip(compute_results.compute_status.iter()) {
+        for (txn, status) in txns.iter().zip(compute_results.compute_status().iter()) {
             if let TransactionStatus::Discard(_) = status {
                 rejected_txns.push(CommittedTransaction {
                     sender: txn.sender(),

--- a/execution/executor/src/executor_test.rs
+++ b/execution/executor/src/executor_test.rs
@@ -176,7 +176,7 @@ fn test_executor_status() {
             KEEP_STATUS.clone(),
             DISCARD_STATUS.clone()
         ],
-        *output.state_compute_result().status()
+        *output.state_compute_result().compute_status()
     );
 }
 


### PR DESCRIPTION
## Motivation

`ExecutedState` is no longer necessary to be a standalone struct which could be merged into `StateComputeResult`.

Also add `frozen_subtree_roots` into `StateComputeResult` as it is needed in Consensus, which will facilitate our refactoring of executor to build block_tree in again.

ref: #2519 

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?

Y

## Test Plan

CI
