### PR TITLE
[k8s][clustertest] Add support for nodes_down experiment

### DIFF
--- a/docker/validator-dynamic/docker-run-dynamic-fullnode.sh
+++ b/docker/validator-dynamic/docker-run-dynamic-fullnode.sh
@@ -39,4 +39,21 @@ fi
 	--output-dir /opt/libra/etc/ \
 	${params[@]}
 
+# Set CFG_OVERRIDES to any values that you want to override in the config
+# Example: CFG_OVERRIDES='grpc_max_receive_len=45,genesis_file_location="genesis2.blob",max_block_size=250'
+# Note: Double quotes are required for string parameters and should be
+# omitted for int parameters.
+# Note: This currently does not work with parameters which are repeated.
+if [ -n "${CFG_OVERRIDES}" ]; then
+  IFS=',' read -ra CFG_OVERRIDES <<< "$CFG_OVERRIDES"
+  for KEY_VAL in "${CFG_OVERRIDES[@]}"; do
+    IFS='=' read -ra KEY_VAL <<< "$KEY_VAL"
+      KEY="${KEY_VAL[0]}"
+      VAL="${KEY_VAL[1]}"
+      echo "Overriding ${KEY} = ${VAL} in node config"
+      sed "s/^${KEY} = .*/${KEY} = ${VAL}/g" /opt/libra/etc/node.config.toml > /tmp/node.config.toml
+      mv /tmp/node.config.toml /opt/libra/etc/node.config.toml
+  done
+fi
+
 exec /opt/libra/bin/libra-node -f /opt/libra/etc/node.config.toml

--- a/testsuite/cluster-test/src/cluster_swarm/mod.rs
+++ b/testsuite/cluster-test/src/cluster_swarm/mod.rs
@@ -3,7 +3,11 @@
 
 pub mod cluster_swarm_kube;
 
-use crate::instance::Instance;
+use crate::instance::{
+    FullnodeConfig, Instance, InstanceConfig,
+    InstanceConfig::{Fullnode, Validator},
+    ValidatorConfig,
+};
 use anyhow::Result;
 use async_trait::async_trait;
 use futures::{future::try_join_all, try_join};
@@ -25,19 +29,12 @@ pub trait ClusterSwarm {
 
     async fn fullnode_instances(&self) -> Vec<Instance>;
 
-    /// Inserts a validator into the ClusterSwarm if it doesn't exist. If it
-    /// exists, then updates the validator.
-    async fn upsert_validator(
-        &self,
-        index: u32,
-        num_validators: u32,
-        num_fullnodes: u32,
-        image_tag: &str,
-        delete_data: bool,
-    ) -> Result<()>;
+    /// Inserts an into the ClusterSwarm if it doesn't exist. If it
+    /// exists, then updates the instance.
+    async fn upsert_node(&self, instance_config: InstanceConfig, delete_data: bool) -> Result<()>;
 
-    /// Deletes a validator from the ClusterSwarm
-    async fn delete_validator(&self, index: u32) -> Result<()>;
+    /// Deletes a node from the ClusterSwarm
+    async fn delete_node(&self, instance_config: InstanceConfig) -> Result<()>;
 
     /// Creates a set of validators with the given `image_tag`
     async fn create_validator_set(
@@ -45,42 +42,22 @@ pub trait ClusterSwarm {
         num_validators: u32,
         num_fullnodes_per_validator: u32,
         image_tag: &str,
+        config_overrides: Vec<String>,
         delete_data: bool,
     ) -> Result<()> {
         let validators = (0..num_validators).map(|i| {
-            self.upsert_validator(
-                i,
+            let validator_config = ValidatorConfig {
+                index: i,
                 num_validators,
-                num_fullnodes_per_validator,
-                image_tag,
-                delete_data,
-            )
+                num_fullnodes: num_fullnodes_per_validator,
+                image_tag: image_tag.to_string(),
+                config_overrides: config_overrides.clone(),
+            };
+            self.upsert_node(Validator(validator_config), delete_data)
         });
         try_join_all(validators).await?;
         Ok(())
     }
-
-    /// Deletes a set of validators
-    async fn delete_validator_set(&self, num_validators: u32) -> Result<()> {
-        let validators = (0..num_validators).map(|i| self.delete_validator(i));
-        try_join_all(validators).await?;
-        Ok(())
-    }
-
-    /// Inserts a fullnode into the ClusterSwarm if it doesn't exist. If it
-    /// exists, then updates the fullnode.
-    async fn upsert_fullnode(
-        &self,
-        fullnode_index: u32,
-        num_fullnodes_per_validator: u32,
-        validator_index: u32,
-        num_validators: u32,
-        image_tag: &str,
-        delete_data: bool,
-    ) -> Result<()>;
-
-    /// Deletes a fullnode from the ClusterSwarm
-    async fn delete_fullnode(&self, fullnode_index: u32, validator_index: u32) -> Result<()>;
 
     /// Creates a set of fullnodes with the given `image_tag`
     async fn create_fullnode_set(
@@ -88,33 +65,22 @@ pub trait ClusterSwarm {
         num_validators: u32,
         num_fullnodes_per_validator: u32,
         image_tag: &str,
+        config_overrides: Vec<String>,
         delete_data: bool,
     ) -> Result<()> {
         let fullnodes = (0..num_validators).flat_map(move |validator_index| {
+            let config_overrides = config_overrides.clone();
             (0..num_fullnodes_per_validator).map(move |fullnode_index| {
-                self.upsert_fullnode(
+                let fullnode_config = FullnodeConfig {
                     fullnode_index,
                     num_fullnodes_per_validator,
                     validator_index,
                     num_validators,
-                    image_tag,
-                    delete_data,
-                )
+                    image_tag: image_tag.to_string(),
+                    config_overrides: config_overrides.clone(),
+                };
+                self.upsert_node(Fullnode(fullnode_config), delete_data)
             })
-        });
-        try_join_all(fullnodes).await?;
-        Ok(())
-    }
-
-    /// Deletes a set of fullnodes
-    async fn delete_fullnode_set(
-        &self,
-        num_validators: u32,
-        num_fullnodes_per_validator: u32,
-    ) -> Result<()> {
-        let fullnodes = (0..num_validators).flat_map(move |validator_index| {
-            (0..num_fullnodes_per_validator)
-                .map(move |fullnode_index| self.delete_fullnode(fullnode_index, validator_index))
         });
         try_join_all(fullnodes).await?;
         Ok(())
@@ -133,26 +99,16 @@ pub trait ClusterSwarm {
                 num_validators,
                 num_fullnodes_per_validator,
                 image_tag,
+                vec![],
                 delete_data
             ),
             self.create_fullnode_set(
                 num_validators,
                 num_fullnodes_per_validator,
                 image_tag,
+                vec![],
                 delete_data
             ),
-        )
-    }
-
-    /// Deletes a set of validators and fullnodes with the given parameters
-    async fn delete_validator_and_fullnode_set(
-        &self,
-        num_validators: u32,
-        num_fullnodes_per_validator: u32,
-    ) -> Result<((), ())> {
-        try_join!(
-            self.delete_validator_set(num_validators),
-            self.delete_fullnode_set(num_validators, num_fullnodes_per_validator),
         )
     }
 

--- a/testsuite/cluster-test/src/experiments/reboot_random_validator.rs
+++ b/testsuite/cluster-test/src/experiments/reboot_random_validator.rs
@@ -11,13 +11,14 @@ use anyhow::{bail, Result};
 
 use crate::{
     cluster::Cluster,
+    cluster_swarm::ClusterSwarm,
     effects::{Action, Reboot},
     experiments::{Context, Experiment, ExperimentParam},
     instance,
     instance::Instance,
 };
 use async_trait::async_trait;
-use futures::future::join_all;
+use futures::future::{join_all, try_join_all};
 use libra_logger::warn;
 use structopt::StructOpt;
 
@@ -58,17 +59,32 @@ impl Experiment for RebootRandomValidators {
         instance::instancelist_to_set(&self.instances)
     }
 
-    async fn run(&mut self, _context: &mut Context<'_>) -> anyhow::Result<()> {
-        let futures = self.instances.iter().map(|instance| async move {
-            let reboot = Reboot::new(instance.clone());
-            reboot
-                .apply()
-                .await
-                .map_err(|e| warn!("Failed to reboot {}: {}", instance, e))
-        });
-        let results = join_all(futures).await;
-        if results.iter().any(Result::is_err) {
-            bail!("Failed to reboot one of nodes");
+    async fn run(&mut self, context: &mut Context<'_>) -> anyhow::Result<()> {
+        if let Some(cluster_swarm) = context.cluster_swarm {
+            let instance_configs = instance::instance_configs(&self.instances)?;
+            let futures: Vec<_> = instance_configs
+                .clone()
+                .into_iter()
+                .map(|ic| cluster_swarm.delete_node(ic.clone()))
+                .collect();
+            try_join_all(futures).await?;
+            let futures: Vec<_> = instance_configs
+                .into_iter()
+                .map(|ic| cluster_swarm.upsert_node(ic.clone(), false))
+                .collect();
+            try_join_all(futures).await?;
+        } else {
+            let futures = self.instances.iter().map(|instance| async move {
+                let reboot = Reboot::new(instance.clone());
+                reboot
+                    .apply()
+                    .await
+                    .map_err(|e| warn!("Failed to reboot {}: {}", instance, e))
+            });
+            let results = join_all(futures).await;
+            if results.iter().any(Result::is_err) {
+                bail!("Failed to reboot one of nodes");
+            }
         }
         Ok(())
     }


### PR DESCRIPTION
## Summary

* Create ValidatorConfig and FullnodeConfig structs
* Updates to trait ClusterSwarm to support trait ClusterSwarm
* Update PerformanceBenchmark k8s version to support down nodes

## Test Plan
```
====json-report-begin===
{
  "metrics": [
    {
      "experiment": "10% down",
      "metric": "submitted_txn",
      "value": 211890.0
    },
    {
      "experiment": "10% down",
      "metric": "expired_txn",
      "value": 0.0
    },
    {
      "experiment": "10% down",
      "metric": "avg_txns_per_block",
      "value": 648.1848320272743
    },
    {
      "experiment": "10% down",
      "metric": "avg_tps",
      "value": 888.9571425332344
    },
    {
      "experiment": "10% down",
      "metric": "avg_latency",
      "value": 2933.330649348292
    }
  ],
  "text": "10% down : 889 TPS, 2933.3 ms latency, no expired txns"
}
====json-report-end===
```