### PR TITLE
[types] move AuthenticationKey to TransactionAuthenticator

### DIFF
--- a/client/cli/src/client_proxy.rs
+++ b/client/cli/src/client_proxy.rs
@@ -18,9 +18,7 @@ use libra_logger::prelude::*;
 use libra_temppath::TempPath;
 use libra_types::{
     access_path::AccessPath,
-    account_address::{
-        AccountAddress, AuthenticationKey, ADDRESS_LENGTH, AUTHENTICATION_KEY_LENGTH,
-    },
+    account_address::{AccountAddress, ADDRESS_LENGTH},
     account_config::{
         association_address, ACCOUNT_RECEIVED_EVENT_PATH, ACCOUNT_SENT_EVENT_PATH,
         CORE_CODE_ADDRESS,
@@ -28,6 +26,7 @@ use libra_types::{
     account_state::AccountState,
     ledger_info::LedgerInfoWithSignatures,
     transaction::{
+        authenticator::{AuthenticationKey, AUTHENTICATION_KEY_LENGTH},
         helpers::{create_unsigned_txn, create_user_txn, TransactionSigner},
         parse_as_transaction_argument, RawTransaction, Script, SignedTransaction,
         TransactionArgument, TransactionPayload, Version,

--- a/client/cli/src/commands.rs
+++ b/client/cli/src/commands.rs
@@ -7,7 +7,9 @@ use crate::{
 };
 use anyhow::Error;
 use libra_metrics::counters::*;
-use libra_types::account_address::{ADDRESS_LENGTH, AUTHENTICATION_KEY_LENGTH};
+use libra_types::{
+    account_address::ADDRESS_LENGTH, transaction::authenticator::AUTHENTICATION_KEY_LENGTH,
+};
 use std::{collections::HashMap, sync::Arc};
 
 /// Print the error and bump up error counter.

--- a/client/libra-dev/src/account_resource.rs
+++ b/client/libra-dev/src/account_resource.rs
@@ -88,11 +88,11 @@ mod tests {
     fn test_get_accountresource() {
         use libra_crypto::ed25519::compat;
         use libra_types::{
-            account_address::AuthenticationKey,
             account_config::{
                 AccountResource, BalanceResource, ACCOUNT_RESOURCE_PATH, BALANCE_RESOURCE_PATH,
             },
             event::{EventHandle, EventKey},
+            transaction::authenticator::AuthenticationKey,
         };
         use std::collections::BTreeMap;
 
@@ -100,7 +100,7 @@ mod tests {
 
         // Figure out how to use Libra code to generate AccountStateBlob directly, not involving btreemap directly
         let mut map: BTreeMap<Vec<u8>, Vec<u8>> = BTreeMap::new();
-        let auth_key = AuthenticationKey::from_public_key(&keypair.1);
+        let auth_key = AuthenticationKey::ed25519(&keypair.1);
         let addr = auth_key.derived_address();
         let ar = AccountResource::new(
             123_456_789,

--- a/client/libra-dev/src/transaction.rs
+++ b/client/libra-dev/src/transaction.rs
@@ -12,12 +12,11 @@ use crate::{
 use lcs::to_bytes;
 use libra_crypto::{ed25519::*, test_utils::KeyPair};
 use libra_types::{
-    account_address::{
-        AccountAddress, AuthenticationKey, ADDRESS_LENGTH, AUTHENTICATION_KEY_LENGTH,
-    },
+    account_address::{AccountAddress, ADDRESS_LENGTH},
     transaction::{
-        helpers::TransactionSigner, RawTransaction, SignedTransaction, TransactionArgument,
-        TransactionPayload,
+        authenticator::{AuthenticationKey, AUTHENTICATION_KEY_LENGTH},
+        helpers::TransactionSigner,
+        RawTransaction, SignedTransaction, TransactionArgument, TransactionPayload,
     },
 };
 use std::{convert::TryFrom, slice, time::Duration};

--- a/client/libra_wallet/src/key_factory.rs
+++ b/client/libra_wallet/src/key_factory.rs
@@ -25,7 +25,7 @@ use libra_crypto::{
     hkdf::Hkdf,
     traits::SigningKey,
 };
-use libra_types::account_address::{AccountAddress, AuthenticationKey};
+use libra_types::{account_address::AccountAddress, transaction::authenticator::AuthenticationKey};
 use mirai_annotations::*;
 use pbkdf2::pbkdf2;
 use serde::{Deserialize, Serialize};
@@ -106,7 +106,7 @@ impl ExtendedPrivKey {
 
     /// Compute the authentication key for this account's public key
     pub fn get_authentication_key(&self) -> AuthenticationKey {
-        AuthenticationKey::from_public_key(&self.get_public())
+        AuthenticationKey::ed25519(&self.get_public())
     }
 
     /// Libra specific sign function that is capable of signing an arbitrary HashValue

--- a/client/libra_wallet/src/wallet_library.rs
+++ b/client/libra_wallet/src/wallet_library.rs
@@ -20,8 +20,11 @@ use crate::{
 use anyhow::Result;
 use libra_crypto::hash::CryptoHash;
 use libra_types::{
-    account_address::{AccountAddress, AuthenticationKey},
-    transaction::{helpers::TransactionSigner, RawTransaction, SignedTransaction},
+    account_address::AccountAddress,
+    transaction::{
+        authenticator::AuthenticationKey, helpers::TransactionSigner, RawTransaction,
+        SignedTransaction,
+    },
 };
 use rand::{rngs::EntropyRng, Rng};
 use std::{collections::HashMap, path::Path};

--- a/config/src/config/network_config.rs
+++ b/config/src/config/network_config.rs
@@ -12,7 +12,7 @@ use libra_crypto::{
     x25519::{X25519StaticPrivateKey, X25519StaticPublicKey},
     Uniform, ValidKey,
 };
-use libra_types::{account_address::AuthenticationKey, PeerId};
+use libra_types::{transaction::authenticator::AuthenticationKey, PeerId};
 use parity_multiaddr::Multiaddr;
 use rand::rngs::StdRng;
 use serde::{Deserialize, Serialize};

--- a/execution/executor-benchmark/src/lib.rs
+++ b/execution/executor-benchmark/src/lib.rs
@@ -11,11 +11,13 @@ use libra_crypto::{
 };
 use libra_logger::prelude::*;
 use libra_types::{
-    account_address::{AccountAddress, AuthenticationKey},
+    account_address::AccountAddress,
     account_config::{association_address, AccountResource},
     block_info::BlockInfo,
     ledger_info::{LedgerInfo, LedgerInfoWithSignatures},
-    transaction::{RawTransaction, Script, SignedTransaction, Transaction},
+    transaction::{
+        authenticator::AuthenticationKey, RawTransaction, Script, SignedTransaction, Transaction,
+    },
 };
 use libra_vm::LibraVM;
 use rand::{rngs::StdRng, SeedableRng};
@@ -37,7 +39,7 @@ struct AccountData {
 
 impl AccountData {
     pub fn auth_key_prefix(&self) -> Vec<u8> {
-        AuthenticationKey::from_public_key(&self.public_key)
+        AuthenticationKey::ed25519(&self.public_key)
             .prefix()
             .to_vec()
     }

--- a/execution/executor/tests/storage_integration_test.rs
+++ b/execution/executor/tests/storage_integration_test.rs
@@ -7,7 +7,7 @@ use libra_config::config::{VMConfig, VMPublishingOption};
 use libra_crypto::{ed25519::*, test_utils::TEST_SEED, HashValue, PrivateKey};
 use libra_types::{
     access_path::AccessPath,
-    account_address::{AccountAddress, AuthenticationKey},
+    account_address::AccountAddress,
     account_config::{association_address, AccountResource},
     account_state::AccountState,
     account_state_blob::AccountStateWithProof,
@@ -17,7 +17,10 @@ use libra_types::{
     get_with_proof::{verify_update_to_latest_ledger_response, RequestItem},
     ledger_info::{LedgerInfo, LedgerInfoWithSignatures},
     test_helpers::transaction_test_helpers::get_test_signed_txn,
-    transaction::{Script, Transaction, TransactionListWithProof, TransactionWithProof},
+    transaction::{
+        authenticator::AuthenticationKey, Script, Transaction, TransactionListWithProof,
+        TransactionWithProof,
+    },
     trusted_state::TrustedState,
 };
 use rand::SeedableRng;
@@ -157,7 +160,7 @@ fn test_reconfiguration() {
         .unwrap();
     let validator_privkey = keys.take_private().unwrap();
     let validator_pubkey = keys.public().clone();
-    let auth_key = AuthenticationKey::from_public_key(&validator_pubkey);
+    let auth_key = AuthenticationKey::ed25519(&validator_pubkey);
     let validator_auth_key_prefix = auth_key.prefix().to_vec();
     assert!(
         auth_key.derived_address() == validator_account,
@@ -253,16 +256,16 @@ fn test_execution_with_storage() {
     assert!(seed != TEST_SEED);
     let mut rng = ::rand::rngs::StdRng::from_seed(seed);
     let (privkey1, pubkey1) = compat::generate_keypair(&mut rng);
-    let account1_auth_key = AuthenticationKey::from_public_key(&pubkey1);
+    let account1_auth_key = AuthenticationKey::ed25519(&pubkey1);
     let account1 = account1_auth_key.derived_address();
     let (privkey2, pubkey2) = compat::generate_keypair(&mut rng);
-    let account2_auth_key = AuthenticationKey::from_public_key(&pubkey2);
+    let account2_auth_key = AuthenticationKey::ed25519(&pubkey2);
     let account2 = account2_auth_key.derived_address();
     let (_privkey3, pubkey3) = compat::generate_keypair(&mut rng);
-    let account3_auth_key = AuthenticationKey::from_public_key(&pubkey3);
+    let account3_auth_key = AuthenticationKey::ed25519(&pubkey3);
     let account3 = account3_auth_key.derived_address();
     let (_privkey4, pubkey4) = compat::generate_keypair(&mut rng);
-    let account4_auth_key = AuthenticationKey::from_public_key(&pubkey4); // non-existent account
+    let account4_auth_key = AuthenticationKey::ed25519(&pubkey4); // non-existent account
     let account4 = account4_auth_key.derived_address();
     let genesis_account = association_address();
 

--- a/language/e2e-tests/src/account.rs
+++ b/language/e2e-tests/src/account.rs
@@ -7,12 +7,13 @@ use crate::keygen::KeyGen;
 use libra_crypto::ed25519::*;
 use libra_types::{
     access_path::AccessPath,
-    account_address::{AccountAddress, AuthenticationKey},
+    account_address::AccountAddress,
     account_config,
     event::EventHandle,
     language_storage::StructTag,
     transaction::{
-        RawTransaction, Script, SignedTransaction, TransactionArgument, TransactionPayload,
+        authenticator::AuthenticationKey, RawTransaction, Script, SignedTransaction,
+        TransactionArgument, TransactionPayload,
     },
 };
 use move_vm_types::{
@@ -123,14 +124,12 @@ impl Account {
     ///
     /// This is the same as the account's address if the keys have never been rotated.
     pub fn auth_key(&self) -> Vec<u8> {
-        AuthenticationKey::from_public_key(&self.pubkey).to_vec()
+        AuthenticationKey::ed25519(&self.pubkey).to_vec()
     }
 
     /// Return the first 16 bytes of the account's auth key
     pub fn auth_key_prefix(&self) -> Vec<u8> {
-        AuthenticationKey::from_public_key(&self.pubkey)
-            .prefix()
-            .to_vec()
+        AuthenticationKey::ed25519(&self.pubkey).prefix().to_vec()
     }
 
     //

--- a/language/e2e-tests/src/tests/rotate_key.rs
+++ b/language/e2e-tests/src/tests/rotate_key.rs
@@ -15,7 +15,7 @@ use libra_crypto::{
 };
 use libra_types::{
     account_address::AccountAddress,
-    transaction::{authenticator::TransactionAuthenticator, SignedTransaction, TransactionStatus},
+    transaction::{authenticator::AuthenticationKey, SignedTransaction, TransactionStatus},
     vm_error::{StatusCode, VMStatus},
 };
 
@@ -85,8 +85,7 @@ fn rotate_ed25519_multisig_key() {
         let threshold = 1;
         let multi_ed_public_key =
             MultiEd25519PublicKey::new(vec![pubkey1, pubkey2], threshold).unwrap();
-        let new_auth_key =
-            TransactionAuthenticator::multi_ed25519_authentication_key(&multi_ed_public_key);
+        let new_auth_key = AuthenticationKey::multi_ed25519(&multi_ed_public_key);
 
         // (1) rotate key to multisig
         let output = &executor.execute_transaction(rotate_key_txn(

--- a/language/tools/vm-genesis/src/lib.rs
+++ b/language/tools/vm-genesis/src/lib.rs
@@ -17,13 +17,15 @@ use libra_crypto::{
 use libra_state_view::StateView;
 use libra_types::{
     access_path::AccessPath,
-    account_address::{AccountAddress, AuthenticationKey},
+    account_address::AccountAddress,
     account_config,
     contract_event::ContractEvent,
     crypto_proxies::ValidatorSet,
     discovery_info::DiscoveryInfo,
     discovery_set::DiscoverySet,
-    transaction::{ChangeSet, RawTransaction, SignatureCheckedTransaction},
+    transaction::{
+        authenticator::AuthenticationKey, ChangeSet, RawTransaction, SignatureCheckedTransaction,
+    },
 };
 use libra_vm::system_module_names::*;
 use move_core_types::identifier::Identifier;
@@ -298,7 +300,7 @@ fn create_and_initialize_main_accounts(
         )
         .expect("Failure minting to association");
 
-    let genesis_auth_key = AuthenticationKey::from_public_key(public_key).to_vec();
+    let genesis_auth_key = AuthenticationKey::ed25519(public_key).to_vec();
     move_vm
         .execute_function(
             &account_config::ACCOUNT_MODULE,
@@ -462,7 +464,7 @@ fn get_validator_authentication_key(
             .as_ref()
             .unwrap()
             .public();
-        let validator_authentication_key = AuthenticationKey::from_public_key(public_key);
+        let validator_authentication_key = AuthenticationKey::ed25519(public_key);
         let derived_address = validator_authentication_key.derived_address();
         if derived_address == *address {
             return Some(validator_authentication_key);

--- a/language/transaction-builder/src/lib.rs
+++ b/language/transaction-builder/src/lib.rs
@@ -6,9 +6,12 @@
 use libra_config::config::{VMConfig, VMPublishingOption};
 use libra_crypto::HashValue;
 use libra_types::{
-    account_address::{AccountAddress, ADDRESS_LENGTH, AUTHENTICATION_KEY_LENGTH},
+    account_address::{AccountAddress, ADDRESS_LENGTH},
     block_metadata::BlockMetadata,
-    transaction::{Script, Transaction, TransactionArgument, SCRIPT_HASH_LENGTH},
+    transaction::{
+        authenticator::AUTHENTICATION_KEY_LENGTH, Script, Transaction, TransactionArgument,
+        SCRIPT_HASH_LENGTH,
+    },
 };
 use std::{collections::HashSet, iter::FromIterator};
 use stdlib::transaction_scripts::{

--- a/language/vm/src/transaction_metadata.rs
+++ b/language/vm/src/transaction_metadata.rs
@@ -5,7 +5,7 @@ use crate::gas_schedule::{AbstractMemorySize, GasAlgebra, GasCarrier, GasPrice, 
 use libra_crypto::ed25519::compat;
 use libra_types::{
     account_address::AccountAddress,
-    transaction::{authenticator::TransactionAuthenticator, SignedTransaction},
+    transaction::{authenticator::AuthenticationKeyPreimage, SignedTransaction},
 };
 use std::time::Duration;
 
@@ -23,7 +23,10 @@ impl TransactionMetadata {
     pub fn new(txn: &SignedTransaction) -> Self {
         Self {
             sender: txn.sender(),
-            authentication_key_preimage: txn.authenticator().authentication_key_preimage().0,
+            authentication_key_preimage: txn
+                .authenticator()
+                .authentication_key_preimage()
+                .into_vec(),
             sequence_number: txn.sequence_number(),
             max_gas_amount: GasUnits::new(txn.max_gas_amount()),
             gas_unit_price: GasPrice::new(txn.gas_unit_price()),
@@ -66,8 +69,7 @@ impl Default for TransactionMetadata {
         let (_, public_key) = compat::generate_genesis_keypair();
         TransactionMetadata {
             sender: AccountAddress::default(),
-            authentication_key_preimage:
-                TransactionAuthenticator::ed25519_authentication_key_preimage(&public_key).0,
+            authentication_key_preimage: AuthenticationKeyPreimage::ed25519(&public_key).into_vec(),
             sequence_number: 0,
             max_gas_amount: GasUnits::new(100_000_000),
             gas_unit_price: GasPrice::new(0),

--- a/state-synchronizer/src/tests/mock_storage.rs
+++ b/state-synchronizer/src/tests/mock_storage.rs
@@ -6,12 +6,12 @@ use anyhow::{bail, Result};
 use executor_types::ExecutedTrees;
 use libra_crypto::{hash::CryptoHash, HashValue};
 use libra_types::{
-    account_address::{AccountAddress, AuthenticationKey},
+    account_address::AccountAddress,
     block_info::BlockInfo,
     crypto_proxies::{ValidatorChangeProof, ValidatorSet, ValidatorSigner, ValidatorVerifier},
     ledger_info::{LedgerInfo, LedgerInfoWithSignatures},
     test_helpers::transaction_test_helpers::get_test_signed_txn,
-    transaction::{SignedTransaction, Transaction},
+    transaction::{authenticator::AuthenticationKey, SignedTransaction, Transaction},
 };
 use std::collections::{BTreeMap, HashMap};
 use transaction_builder::encode_transfer_script;

--- a/testsuite/cluster-test/src/tx_emitter.rs
+++ b/testsuite/cluster-test/src/tx_emitter.rs
@@ -20,9 +20,11 @@ use libra_crypto::{
 };
 use libra_logger::*;
 use libra_types::{
-    account_address::{AccountAddress, AuthenticationKey},
+    account_address::AccountAddress,
     account_config::association_address,
-    transaction::{helpers::create_user_txn, Script, TransactionPayload},
+    transaction::{
+        authenticator::AuthenticationKey, helpers::create_user_txn, Script, TransactionPayload,
+    },
 };
 use rand::{
     prelude::ThreadRng,
@@ -605,7 +607,7 @@ struct AccountData {
 
 impl AccountData {
     pub fn auth_key_prefix(&self) -> Vec<u8> {
-        AuthenticationKey::from_public_key(&self.key_pair.public_key)
+        AuthenticationKey::ed25519(&self.key_pair.public_key)
             .prefix()
             .to_vec()
     }

--- a/testsuite/tests/libratest/smoke_test.rs
+++ b/testsuite/tests/libratest/smoke_test.rs
@@ -10,10 +10,8 @@ use libra_logger::prelude::*;
 use libra_swarm::swarm::{LibraNode, LibraSwarm};
 use libra_temppath::TempPath;
 use libra_types::{
-    account_address::{AccountAddress, AuthenticationKey},
-    account_config::association_address,
-    ledger_info::LedgerInfo,
-    waypoint::Waypoint,
+    account_address::AccountAddress, account_config::association_address, ledger_info::LedgerInfo,
+    transaction::authenticator::AuthenticationKey, waypoint::Waypoint,
 };
 use num_traits::cast::FromPrimitive;
 use rust_decimal::Decimal;
@@ -651,7 +649,7 @@ fn test_external_transaction_signer() {
     let public_key = key_pair.1;
 
     // create transfer parameters
-    let sender_auth_key = AuthenticationKey::from_public_key(&public_key);
+    let sender_auth_key = AuthenticationKey::ed25519(&public_key);
     let sender_address = sender_auth_key.derived_address();
     let (receiver_address, receiver_auth_key_opt) = client_proxy
         .get_account_address_from_parameter(

--- a/types/src/account_address.rs
+++ b/types/src/account_address.rs
@@ -1,7 +1,7 @@
 // Copyright (c) The Libra Core Contributors
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::transaction::authenticator::TransactionAuthenticator;
+use crate::transaction::authenticator::AuthenticationKey;
 use anyhow::{ensure, Error, Result};
 use bytes::Bytes;
 use libra_crypto::{
@@ -17,7 +17,6 @@ use serde::{de::Error as _, Deserialize, Deserializer, Serialize, Serializer};
 use std::{convert::TryFrom, fmt, str::FromStr};
 
 pub const ADDRESS_LENGTH: usize = 16;
-pub const AUTHENTICATION_KEY_LENGTH: usize = ADDRESS_LENGTH * 2;
 
 const SHORT_STRING_LENGTH: usize = 4;
 
@@ -49,7 +48,7 @@ impl AccountAddress {
     }
 
     pub fn authentication_key(public_key: &Ed25519PublicKey) -> AuthenticationKey {
-        AuthenticationKey::from_public_key(public_key)
+        AuthenticationKey::ed25519(public_key)
     }
 
     pub fn from_public_key(public_key: &Ed25519PublicKey) -> Self {
@@ -80,53 +79,6 @@ impl AccountAddress {
         };
 
         AccountAddress::try_from(padded_result)
-    }
-}
-
-/// A struct that represents an account authentication key. An account's address is the last 16
-/// bytes of authentication key used to create it
-#[derive(Debug, Ord, PartialOrd, Eq, PartialEq, Hash, Clone, Copy, CryptoHasher)]
-#[cfg_attr(any(test, feature = "fuzzing"), derive(Arbitrary))]
-pub struct AuthenticationKey([u8; AUTHENTICATION_KEY_LENGTH]);
-
-impl AuthenticationKey {
-    pub const fn new(bytes: [u8; AUTHENTICATION_KEY_LENGTH]) -> Self {
-        Self(bytes)
-    }
-
-    pub fn random() -> Self {
-        let mut rng = OsRng::new().expect("can't access OsRng");
-        let buf: [u8; AUTHENTICATION_KEY_LENGTH] = rng.gen();
-        AuthenticationKey::new(buf)
-    }
-
-    /// Create an authentication key from a public key by taking its sha3 hash
-    pub fn from_public_key(public_key: &Ed25519PublicKey) -> Self {
-        let preimage = TransactionAuthenticator::ed25519_authentication_key_preimage(&public_key).0;
-        Self(*HashValue::from_sha3_256(&preimage).as_ref())
-    }
-
-    /// Return an address derived from the last ADDRESS_LENGTH bytes of this authentication key
-    pub fn derived_address(&self) -> AccountAddress {
-        // keep only last 16 bytes
-        let mut array = [0u8; ADDRESS_LENGTH];
-        array.copy_from_slice(&self.0[AUTHENTICATION_KEY_LENGTH - ADDRESS_LENGTH..]);
-        AccountAddress::new(array)
-    }
-
-    /// Return the first ADDRESS_LENGTH bytes of this authentication key
-    pub fn prefix(&self) -> [u8; ADDRESS_LENGTH] {
-        let mut array = [0u8; ADDRESS_LENGTH];
-        array.copy_from_slice(&self.0[..ADDRESS_LENGTH]);
-        array
-    }
-
-    pub fn short_str(&self) -> String {
-        hex::encode(&self.0[..SHORT_STRING_LENGTH])
-    }
-
-    pub fn to_vec(&self) -> Vec<u8> {
-        self.0.to_vec()
     }
 }
 
@@ -283,57 +235,5 @@ impl Serialize for AccountAddress {
         } else {
             self.0.serialize(serializer)
         }
-    }
-}
-
-impl TryFrom<&[u8]> for AuthenticationKey {
-    type Error = Error;
-
-    fn try_from(bytes: &[u8]) -> Result<AuthenticationKey> {
-        ensure!(
-            bytes.len() == AUTHENTICATION_KEY_LENGTH,
-            "The authentication key {:?} is of invalid length",
-            bytes
-        );
-        let mut addr = [0u8; AUTHENTICATION_KEY_LENGTH];
-        addr.copy_from_slice(bytes);
-        Ok(AuthenticationKey(addr))
-    }
-}
-
-impl TryFrom<Vec<u8>> for AuthenticationKey {
-    type Error = Error;
-
-    fn try_from(bytes: Vec<u8>) -> Result<AuthenticationKey> {
-        AuthenticationKey::try_from(&bytes[..])
-    }
-}
-
-impl FromStr for AuthenticationKey {
-    type Err = Error;
-
-    fn from_str(s: &str) -> Result<Self> {
-        assert!(!s.is_empty());
-        let bytes_out = ::hex::decode(s)?;
-        AuthenticationKey::try_from(bytes_out.as_slice())
-    }
-}
-
-impl AsRef<[u8]> for AuthenticationKey {
-    fn as_ref(&self) -> &[u8] {
-        &self.0
-    }
-}
-
-impl fmt::LowerHex for AuthenticationKey {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "{}", hex::encode(&self.0))
-    }
-}
-
-impl fmt::Display for AuthenticationKey {
-    fn fmt(&self, f: &mut fmt::Formatter) -> std::fmt::Result {
-        // Forward to the LowerHex impl with a "0x" prepended (the # flag).
-        write!(f, "{:#x}", self)
     }
 }

--- a/types/src/transaction/authenticator.rs
+++ b/types/src/transaction/authenticator.rs
@@ -1,23 +1,41 @@
 // Copyright (c) The Libra Core Contributors
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::account_address::AuthenticationKey;
+use crate::account_address::{AccountAddress, ADDRESS_LENGTH};
+use anyhow::{ensure, Error, Result};
 use libra_crypto::{
     ed25519::{Ed25519PublicKey, Ed25519Signature},
     multi_ed25519::{MultiEd25519PublicKey, MultiEd25519Signature},
     traits::Signature,
     HashValue,
 };
-
-use anyhow::Result;
+use libra_crypto_derive::CryptoHasher;
+#[cfg(any(test, feature = "fuzzing"))]
+use proptest_derive::Arbitrary;
+use rand::{rngs::OsRng, Rng};
 use serde::{Deserialize, Serialize};
-use std::{convert::TryFrom, fmt};
+use std::{convert::TryFrom, fmt, str::FromStr};
 
-// TODO: in the future, can tie these to the enum with https://github.com/rust-lang/rust/issues/60553
-const ED25519_SCHEME: u8 = 0;
-const MULTI_ED25519_SCHEME: u8 = 1;
+/// A `TransactionAuthenticator` is an an abstraction of a signature scheme. It must know:
+/// (1) How to check its signature against a message and public key
+/// (2) How to convert its public key into an `AuthenticationKeyPreimage` structured as
+/// (public_key | signaure_scheme_id).
+/// Each on-chain `LibraAccount` must store an `AuthenticationKey` (computed via a sha3 hash of an
+/// `AuthenticationKeyPreimage`).
+/// Each transaction submitted to the Libra blockchain contains a `TransactionAuthenticator`. During
+/// transaction execution, the executor will check if the `TransactionAuthenticator`'s signature on
+/// the transaction hash is well-formed (1) and whether the sha3 hash of the
+/// `TransactionAuthenticator`'s `AuthenticationKeyPreimage` matches the `AuthenticationKey` stored
+/// under the transaction's sender account address (2).
 
-pub struct AuthenticationKeyPreimage(pub Vec<u8>);
+// TODO: in the future, can tie these to the TransactionAuthenticator enum directly with https://github.com/rust-lang/rust/issues/60553
+#[derive(Debug)]
+#[repr(u8)]
+pub enum Scheme {
+    Ed25519 = 0,
+    MultiEd25519 = 1,
+    // ... add more schemes here
+}
 
 #[derive(Clone, Debug, Eq, PartialEq, Hash, Serialize, Deserialize)]
 pub enum TransactionAuthenticator {
@@ -36,10 +54,10 @@ pub enum TransactionAuthenticator {
 
 impl TransactionAuthenticator {
     /// Unique identifier for the signature scheme
-    pub fn scheme_id(&self) -> u8 {
+    pub fn scheme(&self) -> Scheme {
         match self {
-            Self::Ed25519 { .. } => ED25519_SCHEME,
-            Self::MultiEd25519 { .. } => MULTI_ED25519_SCHEME,
+            Self::Ed25519 { .. } => Scheme::Ed25519,
+            Self::MultiEd25519 { .. } => Scheme::MultiEd25519,
         }
     }
 
@@ -76,6 +94,7 @@ impl TransactionAuthenticator {
         }
     }
 
+    /// Return the raw bytes of `self.public_key`
     pub fn public_key_bytes(&self) -> Vec<u8> {
         match self {
             Self::Ed25519 { public_key, .. } => public_key.to_bytes().to_vec(),
@@ -83,6 +102,7 @@ impl TransactionAuthenticator {
         }
     }
 
+    /// Return the raw bytes of `self.signature`
     pub fn signature_bytes(&self) -> Vec<u8> {
         match self {
             Self::Ed25519 { signature, .. } => signature.to_bytes().to_vec(),
@@ -90,59 +110,107 @@ impl TransactionAuthenticator {
         }
     }
 
-    /// Return bytes for (self.public_key | self.scheme_id). To create an account authentication
-    /// key, sha3 these bytes
-    // TODO: move AuthenticationKey to this file and make this private
-    pub fn compute_authentication_key_preimage(
-        mut public_key_bytes: Vec<u8>,
-        scheme_id: u8,
-    ) -> AuthenticationKeyPreimage {
-        public_key_bytes.push(scheme_id);
-        AuthenticationKeyPreimage(public_key_bytes)
-    }
-
-    // TODO: move AuthenticationKey to this file to avoid try_from
-    fn preimage_to_authentication_key(preimage: &AuthenticationKeyPreimage) -> AuthenticationKey {
-        AuthenticationKey::try_from(HashValue::from_sha3_256(&preimage.0).to_vec()).unwrap()
-    }
-
+    /// Return an authentication key preimage derived from `self`'s public key and scheme id
     pub fn authentication_key_preimage(&self) -> AuthenticationKeyPreimage {
-        Self::compute_authentication_key_preimage(
-            self.public_key_bytes().to_vec(),
-            self.scheme_id(),
-        )
+        AuthenticationKeyPreimage::new(self.public_key_bytes(), self.scheme())
     }
 
-    /// Return bytes for (self.public_key | self.scheme_id)
-    pub fn ed25519_authentication_key_preimage(
-        public_key: &Ed25519PublicKey,
-    ) -> AuthenticationKeyPreimage {
-        Self::compute_authentication_key_preimage(public_key.to_bytes().to_vec(), ED25519_SCHEME)
+    /// Return an authentication key derived from `self`'s public key and scheme id
+    pub fn authentication_key(&self) -> AuthenticationKey {
+        AuthenticationKey::from_preimage(&self.authentication_key_preimage())
+    }
+}
+
+pub const AUTHENTICATION_KEY_LENGTH: usize = 32;
+
+/// A struct that represents an account authentication key. An account's address is the last 16
+/// bytes of authentication key used to create it
+#[derive(Debug, Ord, PartialOrd, Eq, PartialEq, Hash, Clone, Copy, CryptoHasher)]
+#[cfg_attr(any(test, feature = "fuzzing"), derive(Arbitrary))]
+pub struct AuthenticationKey([u8; AUTHENTICATION_KEY_LENGTH]);
+
+impl AuthenticationKey {
+    /// Create an authentication key from `bytes`
+    pub const fn new(bytes: [u8; AUTHENTICATION_KEY_LENGTH]) -> Self {
+        Self(bytes)
     }
 
-    /// Return bytes for (self.public_key | self.scheme_id)
-    pub fn multi_ed25519_authentication_key_preimage(
-        public_key: &MultiEd25519PublicKey,
-    ) -> AuthenticationKeyPreimage {
-        Self::compute_authentication_key_preimage(public_key.to_bytes(), MULTI_ED25519_SCHEME)
+    /// Create an authentication key from a preimage by taking its sha3 hash
+    pub fn from_preimage(preimage: &AuthenticationKeyPreimage) -> AuthenticationKey {
+        AuthenticationKey::new(*HashValue::from_sha3_256(&preimage.0).as_ref())
     }
 
-    /// Return an authentication derived from this public key
-    pub fn ed25519_authentication_key(public_key: &Ed25519PublicKey) -> AuthenticationKey {
-        Self::preimage_to_authentication_key(&Self::compute_authentication_key_preimage(
-            public_key.to_bytes().to_vec(),
-            ED25519_SCHEME,
-        ))
+    /// Create an authentication key from an Ed25519 public key
+    pub fn ed25519(public_key: &Ed25519PublicKey) -> AuthenticationKey {
+        Self::from_preimage(&AuthenticationKeyPreimage::ed25519(public_key))
     }
 
-    /// Return an authentication derived from this public key
-    pub fn multi_ed25519_authentication_key(
-        public_key: &MultiEd25519PublicKey,
-    ) -> AuthenticationKey {
-        Self::preimage_to_authentication_key(&Self::compute_authentication_key_preimage(
-            public_key.to_bytes(),
-            MULTI_ED25519_SCHEME,
-        ))
+    /// Create an authentication key from a MultiEd25519 public key
+    pub fn multi_ed25519(public_key: &MultiEd25519PublicKey) -> Self {
+        Self::from_preimage(&AuthenticationKeyPreimage::multi_ed25519(public_key))
+    }
+
+    /// Return an address derived from the last ADDRESS_LENGTH bytes of this authentication key
+    pub fn derived_address(&self) -> AccountAddress {
+        // keep only last 16 bytes
+        let mut array = [0u8; ADDRESS_LENGTH];
+        array.copy_from_slice(&self.0[AUTHENTICATION_KEY_LENGTH - ADDRESS_LENGTH..]);
+        AccountAddress::new(array)
+    }
+
+    /// Return the first ADDRESS_LENGTH bytes of this authentication key
+    pub fn prefix(&self) -> [u8; ADDRESS_LENGTH] {
+        let mut array = [0u8; ADDRESS_LENGTH];
+        array.copy_from_slice(&self.0[..ADDRESS_LENGTH]);
+        array
+    }
+
+    /// Return an abbreviated representation of this authentication key
+    pub fn short_str(&self) -> String {
+        hex::encode(&self.0[..4])
+    }
+
+    /// Construct a vector from this authentication key
+    pub fn to_vec(&self) -> Vec<u8> {
+        self.0.to_vec()
+    }
+
+    /// Create a random authentication key. For testing only
+    pub fn random() -> Self {
+        let mut rng = OsRng::new().expect("can't access OsRng");
+        let buf: [u8; AUTHENTICATION_KEY_LENGTH] = rng.gen();
+        AuthenticationKey::new(buf)
+    }
+}
+
+/// A value that can be hashed to produce an authentication key
+pub struct AuthenticationKeyPreimage(Vec<u8>);
+
+impl AuthenticationKeyPreimage {
+    /// Return bytes for (public_key | scheme_id)
+    fn new(mut public_key_bytes: Vec<u8>, scheme: Scheme) -> Self {
+        public_key_bytes.push(scheme as u8);
+        Self(public_key_bytes)
+    }
+
+    /// Construct a preimage from an Ed25519 public key
+    pub fn ed25519(public_key: &Ed25519PublicKey) -> AuthenticationKeyPreimage {
+        Self::new(public_key.to_bytes().to_vec(), Scheme::Ed25519)
+    }
+
+    /// Construct a preimage from a MultiEd25519 public key
+    pub fn multi_ed25519(public_key: &MultiEd25519PublicKey) -> AuthenticationKeyPreimage {
+        Self::new(public_key.to_bytes(), Scheme::MultiEd25519)
+    }
+
+    /// Construct a slice from this authentication key
+    pub fn to_bytes(&self) -> &[u8] {
+        &self.0
+    }
+
+    /// Construct a vector from this authentication key
+    pub fn into_vec(self) -> Vec<u8> {
+        self.0
     }
 }
 
@@ -150,10 +218,62 @@ impl fmt::Display for TransactionAuthenticator {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(
             f,
-            "TransactionAuthenticator[scheme id: {}, public key: {}, signature: {}]",
-            self.scheme_id(),
+            "TransactionAuthenticator[scheme id: {:?}, public key: {}, signature: {}]",
+            self.scheme(),
             hex::encode(&self.public_key_bytes()),
             hex::encode(&self.signature_bytes())
         )
+    }
+}
+
+impl TryFrom<&[u8]> for AuthenticationKey {
+    type Error = Error;
+
+    fn try_from(bytes: &[u8]) -> Result<AuthenticationKey> {
+        ensure!(
+            bytes.len() == AUTHENTICATION_KEY_LENGTH,
+            "The authentication key {:?} is of invalid length",
+            bytes
+        );
+        let mut addr = [0u8; AUTHENTICATION_KEY_LENGTH];
+        addr.copy_from_slice(bytes);
+        Ok(AuthenticationKey(addr))
+    }
+}
+
+impl TryFrom<Vec<u8>> for AuthenticationKey {
+    type Error = Error;
+
+    fn try_from(bytes: Vec<u8>) -> Result<AuthenticationKey> {
+        AuthenticationKey::try_from(&bytes[..])
+    }
+}
+
+impl FromStr for AuthenticationKey {
+    type Err = Error;
+
+    fn from_str(s: &str) -> Result<Self> {
+        assert!(!s.is_empty());
+        let bytes_out = ::hex::decode(s)?;
+        AuthenticationKey::try_from(bytes_out.as_slice())
+    }
+}
+
+impl AsRef<[u8]> for AuthenticationKey {
+    fn as_ref(&self) -> &[u8] {
+        &self.0
+    }
+}
+
+impl fmt::LowerHex for AuthenticationKey {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}", hex::encode(&self.0))
+    }
+}
+
+impl fmt::Display for AuthenticationKey {
+    fn fmt(&self, f: &mut fmt::Formatter) -> std::fmt::Result {
+        // Forward to the LowerHex impl with a "0x" prepended (the # flag).
+        write!(f, "{:#x}", self)
     }
 }


### PR DESCRIPTION
plus associated refactoring/simplifications:
- add separate type for `AuthenticationKeyPreimage`
- use an enum for signature scheme

<!--
Thank you for sending a PR. We appreciate you spending time to help improve the Libra project.

The project is undergoing daily changes. Pull Requests will be reviewed and responded to as time permits.
-->

## Motivation

Cleanup promised in 24f1673da36d9562711222de4747163ead29c7bf

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?

Y

## Test Plan

Should be pure refactoring
