### PR TITLE
[language] fix is_script flag of disassembler

### DIFF
--- a/language/tools/disassembler/src/main.rs
+++ b/language/tools/disassembler/src/main.rs
@@ -36,13 +36,13 @@ struct Args {
     #[structopt(long = "skip-basic-blocks")]
     pub skip_basic_blocks: bool,
 
-    /// The path to the bytecode file to disassemble; let's call it file.mv. We assume that two
-    /// other files reside under the same directory: a source map file.mvsm (possibly) and the Move
-    /// source code file.move.
+    /// Treat input file as a script (default is to treat file as a module)
     #[structopt(short = "s", long = "script")]
     pub is_script: bool,
 
-    /// The path to the bytecode file.
+    /// The path to the bytecode file to disassemble; let's call it file.mv. We assume that two
+    /// other files reside under the same directory: a source map file.mvsm (possibly) and the Move
+    /// source code file.move.
     #[structopt(short = "b", long = "bytecode")]
     pub bytecode_file_path: String,
 }


### PR DESCRIPTION

## Motivation

The `is_script` flag in disassembler means the input file is a script and uses the ` CompiledScript::deserialize` method to deserialize it. 

Without the `is_script` flag, the input file will be deserialized by `CompiledModule::deserialize` method.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?

Yes.

## Test Plan

(Share your test plan here. If you changed code, please provide us with clear instructions for verifying that your changes work.)

Run `cargo run -p disassembler -- --help`, 

> USAGE:
>     disassembler [FLAGS] --bytecode <bytecode-file-path>
> 
> FLAGS:
>     -h, --help                 Prints help information
>     -s, --script               Treat input file as a script (default is to treat file as a module)
>         --skip-basic-blocks    Do not print the basic blocks of each function
>         --skip-code            Do not print the disassembled bytecodes of each function
>         --skip-locals          Do not print locals of each function
>         --skip-private         Skip printing of private functions
>     -V, --version              Prints version information
> 
> OPTIONS:
>     -b, --bytecode <bytecode-file-path>    The path to the bytecode file to disassemble; let's call it file.mv. We
>                                            assume that two other files reside under the same directory: a source map
>                                            file.mvsm (possibly) and the Move source code file.move

then check the `-s, --script ` section and `-b, --bytecode` section.



## Related PRs

(If this PR adds or changes functionality, please take some time to update the docs at https://github.com/libra/website, and link to your PR here.)
