### PR TITLE
[types] make some _LENGTH constants be associated with their respective types

### DIFF
--- a/admission_control/admission-control-service/src/unit_tests/admission_control_service_test.rs
+++ b/admission_control/admission-control-service/src/unit_tests/admission_control_service_test.rs
@@ -12,7 +12,7 @@ use anyhow::Result;
 use futures::executor::block_on;
 use libra_crypto::{ed25519::*, test_utils::TEST_SEED};
 use libra_types::{
-    account_address::{AccountAddress, ADDRESS_LENGTH},
+    account_address::AccountAddress,
     mempool_status::MempoolStatusCode,
     proto::types::{
         MempoolStatus, UpdateToLatestLedgerRequest, UpdateToLatestLedgerResponse,
@@ -119,10 +119,10 @@ impl AdmissionControl for MockAdmissionControlService {
             }
             Ok(None) => {
                 let mut status = MempoolStatus::default();
-                let invalid_seq_add = [101_u8; ADDRESS_LENGTH];
-                let sys_error_add = [102_u8; ADDRESS_LENGTH];
-                let accepted_add = [103_u8; ADDRESS_LENGTH];
-                let mempool_full = [104_u8; ADDRESS_LENGTH];
+                let invalid_seq_add = [101_u8; AccountAddress::LENGTH];
+                let sys_error_add = [102_u8; AccountAddress::LENGTH];
+                let accepted_add = [103_u8; AccountAddress::LENGTH];
+                let mempool_full = [104_u8; AccountAddress::LENGTH];
                 let transaction = SignedTransaction::try_from(req.transaction.unwrap()).unwrap();
                 let sender = transaction.sender();
                 let sender_ref = sender.as_ref();
@@ -181,7 +181,7 @@ fn test_submit_txn_inner_vm() {
     ];
     for (sender_id, status, are_keys_valid) in test_cases.into_iter() {
         test_vm_status_submission(
-            AccountAddress::new([sender_id as u8; ADDRESS_LENGTH]),
+            AccountAddress::new([sender_id as u8; AccountAddress::LENGTH]),
             &ac_service,
             status,
             are_keys_valid,
@@ -201,7 +201,7 @@ fn test_submit_txn_inner_mempool() {
     ];
     for (sender_id, status) in test_cases.into_iter() {
         test_mempool_status_submission(
-            AccountAddress::new([sender_id as u8; ADDRESS_LENGTH]),
+            AccountAddress::new([sender_id as u8; AccountAddress::LENGTH]),
             &ac_service,
             status,
         );

--- a/client/cli/src/client_proxy.rs
+++ b/client/cli/src/client_proxy.rs
@@ -26,7 +26,7 @@ use libra_types::{
     account_state::AccountState,
     ledger_info::LedgerInfoWithSignatures,
     transaction::{
-        authenticator::{AuthenticationKey, AUTHENTICATION_KEY_LENGTH},
+        authenticator::AuthenticationKey,
         helpers::{create_unsigned_txn, create_user_txn, TransactionSigner},
         parse_as_transaction_argument, RawTransaction, Script, SignedTransaction,
         TransactionArgument, TransactionPayload, Version,
@@ -1074,7 +1074,7 @@ impl ClientProxy {
     fn authentication_key_from_string(data: &str) -> Result<AuthenticationKey> {
         let bytes_vec: Vec<u8> = hex::decode(data.parse::<String>()?)?;
         ensure!(
-            bytes_vec.len() == AUTHENTICATION_KEY_LENGTH,
+            bytes_vec.len() == AuthenticationKey::LENGTH,
             "The authentication key string {:?} is of invalid length. Authentication keys must be 32-bytes long"
         );
 

--- a/client/cli/src/client_proxy.rs
+++ b/client/cli/src/client_proxy.rs
@@ -18,7 +18,7 @@ use libra_logger::prelude::*;
 use libra_temppath::TempPath;
 use libra_types::{
     access_path::AccessPath,
-    account_address::{AccountAddress, ADDRESS_LENGTH},
+    account_address::AccountAddress,
     account_config::{
         association_address, ACCOUNT_RECEIVED_EVENT_PATH, ACCOUNT_SENT_EVENT_PATH,
         CORE_CODE_ADDRESS,
@@ -1058,7 +1058,7 @@ impl ClientProxy {
     fn address_from_strings(data: &str) -> Result<AccountAddress> {
         let account_vec: Vec<u8> = hex::decode(data.parse::<String>()?)?;
         ensure!(
-            account_vec.len() == ADDRESS_LENGTH,
+            account_vec.len() == AccountAddress::LENGTH,
             "The address {:?} is of invalid length. Addresses must be 16-bytes long"
         );
         let account = AccountAddress::try_from(&account_vec[..]).map_err(|error| {

--- a/client/cli/src/commands.rs
+++ b/client/cli/src/commands.rs
@@ -7,9 +7,7 @@ use crate::{
 };
 use anyhow::Error;
 use libra_metrics::counters::*;
-use libra_types::{
-    account_address::AccountAddress, transaction::authenticator::AUTHENTICATION_KEY_LENGTH,
-};
+use libra_types::{account_address::AccountAddress, transaction::authenticator::AuthenticationKey};
 use std::{collections::HashMap, sync::Arc};
 
 /// Print the error and bump up error counter.
@@ -54,7 +52,7 @@ pub fn is_address(data: &str) -> bool {
 /// Check whether the input string is a valid libra authentication key.
 pub fn is_authentication_key(data: &str) -> bool {
     match hex::decode(data) {
-        Ok(vec) => vec.len() == AUTHENTICATION_KEY_LENGTH,
+        Ok(vec) => vec.len() == AuthenticationKey::LENGTH,
         Err(_) => false,
     }
 }

--- a/client/cli/src/commands.rs
+++ b/client/cli/src/commands.rs
@@ -8,7 +8,7 @@ use crate::{
 use anyhow::Error;
 use libra_metrics::counters::*;
 use libra_types::{
-    account_address::ADDRESS_LENGTH, transaction::authenticator::AUTHENTICATION_KEY_LENGTH,
+    account_address::AccountAddress, transaction::authenticator::AUTHENTICATION_KEY_LENGTH,
 };
 use std::{collections::HashMap, sync::Arc};
 
@@ -46,7 +46,7 @@ pub fn debug_format_cmd(cmd: &str) -> bool {
 /// Check whether the input string is a valid libra address.
 pub fn is_address(data: &str) -> bool {
     match hex::decode(data) {
-        Ok(vec) => vec.len() == ADDRESS_LENGTH,
+        Ok(vec) => vec.len() == AccountAddress::LENGTH,
         Err(_) => false,
     }
 }

--- a/client/libra-dev/src/account.rs
+++ b/client/libra-dev/src/account.rs
@@ -6,7 +6,7 @@ use crate::{
     error::*,
 };
 use libra_crypto::ed25519::*;
-use libra_types::account_address::{AccountAddress, ADDRESS_LENGTH};
+use libra_types::account_address::AccountAddress;
 use std::{convert::TryFrom, slice};
 
 /// Takes in private key in bytes and return the associated public key and address
@@ -34,11 +34,8 @@ pub unsafe extern "C" fn libra_LibraAccountKey_from(
     let public_key: Ed25519PublicKey = (&private_key).into();
     let address = AccountAddress::from_public_key(&public_key);
 
-    let mut address_bytes = [0u8; ADDRESS_LENGTH];
-    address_bytes.copy_from_slice(address.as_ref());
-
     *out = LibraAccountKey {
-        address: address_bytes,
+        address: address.into(),
         private_key: private_key.to_bytes(),
         public_key: public_key.to_bytes(),
     };

--- a/client/libra-dev/src/account_resource.rs
+++ b/client/libra-dev/src/account_resource.rs
@@ -5,9 +5,7 @@ use crate::{
     error::*,
 };
 use libra_crypto::ed25519::ED25519_PUBLIC_KEY_LENGTH;
-use libra_types::{
-    account_state::AccountState, account_state_blob::AccountStateBlob, event::EVENT_KEY_LENGTH,
-};
+use libra_types::{account_state::AccountState, account_state_blob::AccountStateBlob};
 use std::{convert::TryFrom, slice};
 
 pub fn libra_LibraAccountResource_from_safe(
@@ -20,21 +18,13 @@ pub fn libra_LibraAccountResource_from_safe(
                 let mut authentication_key = [0u8; ED25519_PUBLIC_KEY_LENGTH];
                 authentication_key.copy_from_slice(account_resource.authentication_key());
 
-                let mut sent_key_copy = [0u8; EVENT_KEY_LENGTH];
-                sent_key_copy.copy_from_slice(account_resource.sent_events().key().as_bytes());
-
                 let sent_events = LibraEventHandle {
                     count: account_resource.sent_events().count(),
-                    key: sent_key_copy,
+                    key: account_resource.sent_events().key().into(),
                 };
-
-                let mut received_key_copy = [0u8; EVENT_KEY_LENGTH];
-                received_key_copy
-                    .copy_from_slice(account_resource.received_events().key().as_bytes());
-
                 let received_events = LibraEventHandle {
                     count: account_resource.received_events().count(),
-                    key: received_key_copy,
+                    key: account_resource.received_events().key().into(),
                 };
 
                 return Ok(LibraAccountResource {

--- a/client/libra-dev/src/event.rs
+++ b/client/libra-dev/src/event.rs
@@ -9,7 +9,7 @@ use libra_types::{
     account_address::AccountAddress,
     account_config::{ReceivedPaymentEvent, SentPaymentEvent},
     contract_event::ContractEvent,
-    event::{EventKey, EVENT_KEY_LENGTH},
+    event::EventKey,
     language_storage::TypeTag,
 };
 use std::{convert::TryFrom, ffi::CString, ops::Deref, slice};
@@ -44,7 +44,7 @@ pub unsafe extern "C" fn libra_LibraEvent_from(
     let buffer_data: &[u8] = slice::from_raw_parts(buf_data, len_data);
     let buffer_type_tag: &[u8] = slice::from_raw_parts(buf_type_tag, len_type_tag);
 
-    let mut key = [0u8; EVENT_KEY_LENGTH];
+    let mut key = [0u8; EventKey::LENGTH];
     key.copy_from_slice(buffer_key);
 
     let (_salt, event_address) = buffer_key.split_at(8);

--- a/client/libra-dev/src/event.rs
+++ b/client/libra-dev/src/event.rs
@@ -6,7 +6,7 @@ use crate::{
     error::*,
 };
 use libra_types::{
-    account_address::ADDRESS_LENGTH,
+    account_address::AccountAddress,
     account_config::{ReceivedPaymentEvent, SentPaymentEvent},
     contract_event::ContractEvent,
     event::{EventKey, EVENT_KEY_LENGTH},
@@ -48,7 +48,7 @@ pub unsafe extern "C" fn libra_LibraEvent_from(
     key.copy_from_slice(buffer_key);
 
     let (_salt, event_address) = buffer_key.split_at(8);
-    let mut key_address = [0u8; ADDRESS_LENGTH];
+    let mut key_address = [0u8; AccountAddress::LENGTH];
     key_address.copy_from_slice(event_address);
 
     let type_tag: TypeTag = match lcs::from_bytes(buffer_type_tag) {
@@ -101,9 +101,6 @@ pub unsafe extern "C" fn libra_LibraEvent_from(
         Ok(res) => {
             event_enum = LibraEventType::SentPaymentEvent;
 
-            let mut addr = [0u8; ADDRESS_LENGTH];
-            addr.copy_from_slice(res.receiver().as_ref());
-
             let metadata_len = (*res.metadata()).len();
             let metadata_ptr = if metadata_len > 0 {
                 let metadata = res.metadata().clone().into_boxed_slice();
@@ -114,7 +111,7 @@ pub unsafe extern "C" fn libra_LibraEvent_from(
 
             event_data = Some(LibraPaymentEvent {
                 sender_address: key_address,
-                receiver_address: addr,
+                receiver_address: res.receiver().into(),
                 amount: res.amount(),
                 metadata: metadata_ptr,
                 metadata_len,
@@ -130,9 +127,6 @@ pub unsafe extern "C" fn libra_LibraEvent_from(
         Ok(res) => {
             event_enum = LibraEventType::ReceivedPaymentEvent;
 
-            let mut addr = [0u8; ADDRESS_LENGTH];
-            addr.copy_from_slice(res.sender().as_ref());
-
             let metadata_len = (*res.metadata()).len();
             let metadata_ptr = if metadata_len > 0 {
                 let metadata = res.metadata().clone().into_boxed_slice();
@@ -142,7 +136,7 @@ pub unsafe extern "C" fn libra_LibraEvent_from(
             };
 
             event_data = Some(LibraPaymentEvent {
-                sender_address: addr,
+                sender_address: res.sender().into(),
                 receiver_address: key_address,
                 amount: res.amount(),
                 metadata: metadata_ptr,
@@ -201,7 +195,7 @@ fn test_libra_LibraEvent_from() {
     let name = "SentPaymentEvent";
 
     let type_tag = Struct(StructTag {
-        address: AccountAddress::new([0; ADDRESS_LENGTH]),
+        address: AccountAddress::new([0; AccountAddress::LENGTH]),
         module: Identifier::new(module).unwrap(),
         name: Identifier::new(name).unwrap(),
         type_params: [].to_vec(),

--- a/client/libra-dev/src/lib.rs
+++ b/client/libra-dev/src/lib.rs
@@ -17,9 +17,9 @@ use crate::data::{
     LIBRA_ADDRESS_SIZE, LIBRA_EVENT_KEY_SIZE, LIBRA_PRIVKEY_SIZE, LIBRA_PUBKEY_SIZE,
 };
 use libra_crypto::ed25519::{ED25519_PRIVATE_KEY_LENGTH, ED25519_PUBLIC_KEY_LENGTH};
-use libra_types::{account_address::AccountAddress, event::EVENT_KEY_LENGTH};
+use libra_types::{account_address::AccountAddress, event::EventKey};
 
 static_assertions::const_assert_eq!(LIBRA_PUBKEY_SIZE, ED25519_PUBLIC_KEY_LENGTH as u32);
 static_assertions::const_assert_eq!(LIBRA_PRIVKEY_SIZE, ED25519_PRIVATE_KEY_LENGTH as u32);
 static_assertions::const_assert_eq!(LIBRA_ADDRESS_SIZE, AccountAddress::LENGTH as u32);
-static_assertions::const_assert_eq!(LIBRA_EVENT_KEY_SIZE, EVENT_KEY_LENGTH as u32);
+static_assertions::const_assert_eq!(LIBRA_EVENT_KEY_SIZE, EventKey::LENGTH as u32);

--- a/client/libra-dev/src/lib.rs
+++ b/client/libra-dev/src/lib.rs
@@ -17,9 +17,9 @@ use crate::data::{
     LIBRA_ADDRESS_SIZE, LIBRA_EVENT_KEY_SIZE, LIBRA_PRIVKEY_SIZE, LIBRA_PUBKEY_SIZE,
 };
 use libra_crypto::ed25519::{ED25519_PRIVATE_KEY_LENGTH, ED25519_PUBLIC_KEY_LENGTH};
-use libra_types::{account_address::ADDRESS_LENGTH, event::EVENT_KEY_LENGTH};
+use libra_types::{account_address::AccountAddress, event::EVENT_KEY_LENGTH};
 
 static_assertions::const_assert_eq!(LIBRA_PUBKEY_SIZE, ED25519_PUBLIC_KEY_LENGTH as u32);
 static_assertions::const_assert_eq!(LIBRA_PRIVKEY_SIZE, ED25519_PRIVATE_KEY_LENGTH as u32);
-static_assertions::const_assert_eq!(LIBRA_ADDRESS_SIZE, ADDRESS_LENGTH as u32);
+static_assertions::const_assert_eq!(LIBRA_ADDRESS_SIZE, AccountAddress::LENGTH as u32);
 static_assertions::const_assert_eq!(LIBRA_EVENT_KEY_SIZE, EVENT_KEY_LENGTH as u32);

--- a/client/libra-dev/src/transaction.rs
+++ b/client/libra-dev/src/transaction.rs
@@ -14,9 +14,8 @@ use libra_crypto::{ed25519::*, test_utils::KeyPair};
 use libra_types::{
     account_address::AccountAddress,
     transaction::{
-        authenticator::{AuthenticationKey, AUTHENTICATION_KEY_LENGTH},
-        helpers::TransactionSigner,
-        RawTransaction, SignedTransaction, TransactionArgument, TransactionPayload,
+        authenticator::AuthenticationKey, helpers::TransactionSigner, RawTransaction,
+        SignedTransaction, TransactionArgument, TransactionPayload,
     },
 };
 use std::{convert::TryFrom, slice, time::Duration};
@@ -57,7 +56,7 @@ pub unsafe extern "C" fn libra_SignedTransactionBytes_from(
         update_last_error("receiver parameter must not be null.".to_string());
         return LibraStatus::InvalidArgument;
     }
-    let receiver_buf = slice::from_raw_parts(receiver, AUTHENTICATION_KEY_LENGTH);
+    let receiver_buf = slice::from_raw_parts(receiver, AuthenticationKey::LENGTH);
     let receiver_auth_key = match AuthenticationKey::try_from(receiver_buf) {
         Ok(result) => result,
         Err(e) => {
@@ -152,7 +151,7 @@ pub unsafe extern "C" fn libra_RawTransactionBytes_from(
         update_last_error("receiver parameter must not be null.".to_string());
         return LibraStatus::InvalidArgument;
     }
-    let receiver_buf = slice::from_raw_parts(receiver, AUTHENTICATION_KEY_LENGTH);
+    let receiver_buf = slice::from_raw_parts(receiver, AuthenticationKey::LENGTH);
     let receiver_auth_key = match AuthenticationKey::try_from(receiver_buf) {
         Ok(result) => result,
         Err(e) => {
@@ -326,7 +325,7 @@ pub unsafe extern "C" fn libra_LibraSignedTransaction_from(
                     &args[..]
                 {
                     let mut auth_key_prefix_buffer =
-                        [0u8; AUTHENTICATION_KEY_LENGTH - AccountAddress::LENGTH];
+                        [0u8; AuthenticationKey::LENGTH - AccountAddress::LENGTH];
                     auth_key_prefix_buffer.copy_from_slice(auth_key_prefix.as_slice());
 
                     txn_payload = Some(LibraTransactionPayload {

--- a/common/channel/src/libra_channel_test.rs
+++ b/common/channel/src/libra_channel_test.rs
@@ -8,7 +8,7 @@ use futures::{
     future::{join, FutureExt},
     stream::{FusedStream, StreamExt},
 };
-use libra_types::account_address::{AccountAddress, ADDRESS_LENGTH};
+use libra_types::account_address::AccountAddress;
 use std::{num::NonZeroUsize, time::Duration};
 use tokio::{runtime::Runtime, time::delay_for};
 
@@ -103,7 +103,7 @@ fn test_multiple_validators_helper(
         for validator in 0..num_validators {
             sender
                 .push(
-                    AccountAddress::new([validator as u8; ADDRESS_LENGTH]),
+                    AccountAddress::new([validator as u8; AccountAddress::LENGTH]),
                     (validator, message),
                 )
                 .unwrap();

--- a/common/channel/src/message_queues_test.rs
+++ b/common/channel/src/message_queues_test.rs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::message_queues::{PerKeyQueue, QueueStyle};
-use libra_types::account_address::{AccountAddress, ADDRESS_LENGTH};
+use libra_types::account_address::AccountAddress;
 use std::num::NonZeroUsize;
 
 /// This represents a proposal message from a validator
@@ -20,7 +20,7 @@ struct VoteMsg {
 #[test]
 fn test_fifo() {
     let mut q = PerKeyQueue::new(QueueStyle::FIFO, NonZeroUsize::new(3).unwrap(), None);
-    let validator = AccountAddress::new([0u8; ADDRESS_LENGTH]);
+    let validator = AccountAddress::new([0u8; AccountAddress::LENGTH]);
 
     // Test order
     q.push(
@@ -79,7 +79,7 @@ fn test_fifo() {
 #[test]
 fn test_lifo() {
     let mut q = PerKeyQueue::new(QueueStyle::LIFO, NonZeroUsize::new(3).unwrap(), None);
-    let validator = AccountAddress::new([0u8; ADDRESS_LENGTH]);
+    let validator = AccountAddress::new([0u8; AccountAddress::LENGTH]);
 
     // Test order
     q.push(
@@ -138,9 +138,9 @@ fn test_lifo() {
 #[test]
 fn test_fifo_round_robin() {
     let mut q = PerKeyQueue::new(QueueStyle::FIFO, NonZeroUsize::new(3).unwrap(), None);
-    let validator1 = AccountAddress::new([0u8; ADDRESS_LENGTH]);
-    let validator2 = AccountAddress::new([1u8; ADDRESS_LENGTH]);
-    let validator3 = AccountAddress::new([2u8; ADDRESS_LENGTH]);
+    let validator1 = AccountAddress::new([0u8; AccountAddress::LENGTH]);
+    let validator2 = AccountAddress::new([1u8; AccountAddress::LENGTH]);
+    let validator3 = AccountAddress::new([2u8; AccountAddress::LENGTH]);
 
     q.push(
         validator1,
@@ -209,9 +209,9 @@ fn test_fifo_round_robin() {
 #[test]
 fn test_lifo_round_robin() {
     let mut q = PerKeyQueue::new(QueueStyle::LIFO, NonZeroUsize::new(3).unwrap(), None);
-    let validator1 = AccountAddress::new([0u8; ADDRESS_LENGTH]);
-    let validator2 = AccountAddress::new([1u8; ADDRESS_LENGTH]);
-    let validator3 = AccountAddress::new([2u8; ADDRESS_LENGTH]);
+    let validator1 = AccountAddress::new([0u8; AccountAddress::LENGTH]);
+    let validator2 = AccountAddress::new([1u8; AccountAddress::LENGTH]);
+    let validator3 = AccountAddress::new([2u8; AccountAddress::LENGTH]);
 
     q.push(
         validator1,
@@ -280,7 +280,7 @@ fn test_lifo_round_robin() {
 #[test]
 fn test_message_queue_clear() {
     let mut q = PerKeyQueue::new(QueueStyle::LIFO, NonZeroUsize::new(3).unwrap(), None);
-    let validator = AccountAddress::new([0u8; ADDRESS_LENGTH]);
+    let validator = AccountAddress::new([0u8; AccountAddress::LENGTH]);
 
     q.push(
         validator,

--- a/consensus/consensus-types/src/block.rs
+++ b/consensus/consensus-types/src/block.rs
@@ -10,7 +10,6 @@ use crate::{
 use anyhow::{bail, ensure, format_err};
 use libra_crypto::{ed25519::Ed25519Signature, hash::CryptoHash, HashValue};
 use libra_types::{
-    account_address::{AccountAddress, ADDRESS_LENGTH},
     block_info::BlockInfo,
     block_metadata::BlockMetadata,
     ledger_info::{LedgerInfo, LedgerInfoWithSignatures},
@@ -318,9 +317,7 @@ impl<T> From<&Block<T>> for BlockMetadata {
             block.timestamp_usecs(),
             block.quorum_cert().ledger_info().signatures().clone(),
             // For nil block, we use 0x0 which is convention for nil address in move.
-            block
-                .author()
-                .unwrap_or_else(|| AccountAddress::new([0u8; ADDRESS_LENGTH])),
+            block.author().unwrap_or_default(),
         )
     }
 }

--- a/execution/executor/src/executor_test.rs
+++ b/execution/executor/src/executor_test.rs
@@ -12,7 +12,7 @@ use crate::{
 use libra_config::config::NodeConfig;
 use libra_crypto::{hash::PRE_GENESIS_BLOCK_ID, HashValue};
 use libra_types::{
-    account_address::{AccountAddress, ADDRESS_LENGTH},
+    account_address::AccountAddress,
     block_info::BlockInfo,
     ledger_info::{LedgerInfo, LedgerInfoWithSignatures},
     transaction::{Transaction, TransactionListWithProof, Version},
@@ -110,8 +110,8 @@ impl Drop for TestExecutor {
 
 fn gen_address(index: u64) -> AccountAddress {
     let bytes = index.to_be_bytes();
-    let mut buf = [0; ADDRESS_LENGTH];
-    buf[ADDRESS_LENGTH - 8..].copy_from_slice(&bytes);
+    let mut buf = [0; AccountAddress::LENGTH];
+    buf[AccountAddress::LENGTH - 8..].copy_from_slice(&bytes);
     AccountAddress::new(buf)
 }
 

--- a/execution/executor/src/mock_vm/mock_vm_test.rs
+++ b/execution/executor/src/mock_vm/mock_vm_test.rs
@@ -5,15 +5,11 @@ use super::{balance_ap, encode_mint_transaction, encode_transfer_transaction, se
 use anyhow::Result;
 use libra_config::config::VMConfig;
 use libra_state_view::StateView;
-use libra_types::{
-    access_path::AccessPath,
-    account_address::{AccountAddress, ADDRESS_LENGTH},
-    write_set::WriteOp,
-};
+use libra_types::{access_path::AccessPath, account_address::AccountAddress, write_set::WriteOp};
 use libra_vm::VMExecutor;
 
 fn gen_address(index: u8) -> AccountAddress {
-    AccountAddress::new([index; ADDRESS_LENGTH])
+    AccountAddress::new([index; AccountAddress::LENGTH])
 }
 
 struct MockStateView;

--- a/execution/executor/src/mock_vm/mod.rs
+++ b/execution/executor/src/mock_vm/mod.rs
@@ -9,7 +9,7 @@ use libra_crypto::ed25519::compat;
 use libra_state_view::StateView;
 use libra_types::{
     access_path::AccessPath,
-    account_address::{AccountAddress, ADDRESS_LENGTH},
+    account_address::AccountAddress,
     contract_event::ContractEvent,
     event::EventKey,
     language_storage::TypeTag,
@@ -143,7 +143,7 @@ impl VMExecutor for MockVM {
                     ));
                 }
                 MockVMTransaction::Reconfiguration => {
-                    let account = AccountAddress::new([0xff; ADDRESS_LENGTH]);
+                    let account = AccountAddress::new([0xff; AccountAddress::LENGTH]);
                     let balance_access_path = balance_ap(account);
                     read_balance_from_storage(state_view, &balance_access_path);
                     outputs.push(TransactionOutput::new(
@@ -221,7 +221,7 @@ fn seqnum_ap(account: AccountAddress) -> AccessPath {
 }
 
 fn gen_genesis_writeset() -> WriteSet {
-    let address = AccountAddress::new([0xff; ADDRESS_LENGTH]);
+    let address = AccountAddress::new([0xff; AccountAddress::LENGTH]);
     let path = b"hello".to_vec();
     let mut write_set = WriteSetMut::default();
     write_set.push((

--- a/json-rpc/src/tests/unit_tests.rs
+++ b/json-rpc/src/tests/unit_tests.rs
@@ -18,7 +18,7 @@ use libra_config::utils;
 use libra_crypto::{ed25519::*, HashValue};
 use libra_temppath::TempPath;
 use libra_types::{
-    account_address::{AccountAddress, ADDRESS_LENGTH},
+    account_address::AccountAddress,
     account_config::AccountResource,
     account_state::AccountState,
     account_state_blob::{AccountStateBlob, AccountStateWithProof},
@@ -212,11 +212,11 @@ fn test_transaction_submission() {
     };
 
     // check successful submission
-    let sender = AccountAddress::new([9; ADDRESS_LENGTH]);
+    let sender = AccountAddress::new([9; AccountAddress::LENGTH]);
     assert!(txn_submission(sender)[0].as_ref().unwrap() == &JsonRpcResponse::SubmissionResponse);
 
     // check vm error submission
-    let sender = AccountAddress::new([0; ADDRESS_LENGTH]);
+    let sender = AccountAddress::new([0; AccountAddress::LENGTH]);
     let response = &txn_submission(sender)[0];
 
     if let Err(e) = response {

--- a/language/bytecode-verifier/bytecode_verifier_tests/src/unit_tests/signature_tests.rs
+++ b/language/bytecode-verifier/bytecode_verifier_tests/src/unit_tests/signature_tests.rs
@@ -6,10 +6,7 @@ use invalid_mutations::signature::{
     ApplySignatureDoubleRefContext, ApplySignatureFieldRefContext, DoubleRefMutation,
     FieldRefMutation,
 };
-use libra_types::{
-    account_address::{AccountAddress, ADDRESS_LENGTH},
-    vm_error::StatusCode,
-};
+use libra_types::{account_address::AccountAddress, vm_error::StatusCode};
 use move_core_types::identifier::Identifier;
 use proptest::{collection::vec, prelude::*};
 use vm::file_format::{Bytecode::*, CompiledModule, SignatureToken::*, *};
@@ -135,7 +132,7 @@ fn no_verify_locals_good() {
             Identifier::new("foo").unwrap(),
         ],
         byte_array_pool: vec![],
-        address_pool: vec![AccountAddress::new([0; ADDRESS_LENGTH])],
+        address_pool: vec![AccountAddress::new([0; AccountAddress::LENGTH])],
         struct_defs: vec![],
         field_defs: vec![],
         function_defs: vec![
@@ -193,7 +190,7 @@ fn no_verify_locals_bad1() {
             Identifier::new("blah").unwrap(),
         ],
         byte_array_pool: vec![],
-        address_pool: vec![AccountAddress::new([0; ADDRESS_LENGTH])],
+        address_pool: vec![AccountAddress::new([0; AccountAddress::LENGTH])],
         struct_defs: vec![],
         field_defs: vec![],
         function_defs: vec![FunctionDefinition {
@@ -238,7 +235,7 @@ fn no_verify_locals_bad2() {
             Identifier::new("blah").unwrap(),
         ],
         byte_array_pool: vec![],
-        address_pool: vec![AccountAddress::new([0; ADDRESS_LENGTH])],
+        address_pool: vec![AccountAddress::new([0; AccountAddress::LENGTH])],
         struct_defs: vec![],
         field_defs: vec![],
         function_defs: vec![FunctionDefinition {
@@ -284,7 +281,7 @@ fn no_verify_locals_bad3() {
             Identifier::new("blah").unwrap(),
         ],
         byte_array_pool: vec![],
-        address_pool: vec![AccountAddress::new([0; ADDRESS_LENGTH])],
+        address_pool: vec![AccountAddress::new([0; AccountAddress::LENGTH])],
         struct_defs: vec![],
         field_defs: vec![],
         function_defs: vec![FunctionDefinition {
@@ -330,7 +327,7 @@ fn no_verify_locals_bad4() {
             Identifier::new("blah").unwrap(),
         ],
         byte_array_pool: vec![],
-        address_pool: vec![AccountAddress::new([0; ADDRESS_LENGTH])],
+        address_pool: vec![AccountAddress::new([0; AccountAddress::LENGTH])],
         struct_defs: vec![],
         field_defs: vec![],
         function_defs: vec![FunctionDefinition {

--- a/language/e2e-tests/src/tests/scripts.rs
+++ b/language/e2e-tests/src/tests/scripts.rs
@@ -3,10 +3,8 @@
 
 use crate::{account::AccountData, executor::FakeExecutor, gas_costs};
 use libra_types::{
-    account_address::{AccountAddress, ADDRESS_LENGTH},
-    on_chain_config::VMPublishingOption,
-    transaction::TransactionStatus,
-    vm_error::StatusCode,
+    account_address::AccountAddress, on_chain_config::VMPublishingOption,
+    transaction::TransactionStatus, vm_error::StatusCode,
 };
 use move_core_types::identifier::Identifier;
 use vm::file_format::{
@@ -66,7 +64,7 @@ fn script_none_existing_module_dep() {
     // make a non existent external module
     script
         .address_pool
-        .push(AccountAddress::new([1u8; ADDRESS_LENGTH]));
+        .push(AccountAddress::new([1u8; AccountAddress::LENGTH]));
     script.identifiers.push(Identifier::new("module").unwrap());
     let module_handle = ModuleHandle {
         address: AddressPoolIndex((script.address_pool.len() - 1) as u16),
@@ -128,7 +126,7 @@ fn script_non_existing_function_dep() {
     // AddressUtil module
     script
         .address_pool
-        .push(AccountAddress::new([0u8; ADDRESS_LENGTH]));
+        .push(AccountAddress::new([0u8; AccountAddress::LENGTH]));
     script
         .identifiers
         .push(Identifier::new("AddressUtil").unwrap());
@@ -192,7 +190,7 @@ fn script_bad_sig_function_dep() {
     // AddressUtil module
     script
         .address_pool
-        .push(AccountAddress::new([0u8; ADDRESS_LENGTH]));
+        .push(AccountAddress::new([0u8; AccountAddress::LENGTH]));
     script
         .identifiers
         .push(Identifier::new("AddressUtil").unwrap());

--- a/language/move-vm/types/src/values/values_impl.rs
+++ b/language/move-vm/types/src/values/values_impl.rs
@@ -6,7 +6,7 @@ use crate::{
     native_functions::dispatch::{native_gas, NativeResult},
 };
 use libra_types::{
-    account_address::{AccountAddress, ADDRESS_LENGTH},
+    account_address::AccountAddress,
     language_storage::TypeTag,
     vm_error::{sub_status::NFE_VECTOR_ERROR_BASE, StatusCode, VMStatus},
 };
@@ -1631,7 +1631,7 @@ impl ValueImpl {
 
         match self {
             Invalid | U8(_) | U64(_) | U128(_) | Bool(_) => CONST_SIZE,
-            Address(_) => AbstractMemorySize::new(ADDRESS_LENGTH as u64),
+            Address(_) => AbstractMemorySize::new(AccountAddress::LENGTH as u64),
             ContainerRef(r) => r.size(),
             IndexedRef(r) => r.size(),
             // TODO: in case the borrow fails the VM will panic.

--- a/language/tools/cost-synthesis/src/stack_generator.rs
+++ b/language/tools/cost-synthesis/src/stack_generator.rs
@@ -9,10 +9,7 @@ use crate::{
     bytecode_specifications::{frame_transition_info::frame_transitions, stack_transition_info::*},
     common::*,
 };
-use libra_types::{
-    account_address::{AccountAddress, ADDRESS_LENGTH},
-    language_storage::ModuleId,
-};
+use libra_types::{account_address::AccountAddress, language_storage::ModuleId};
 use move_core_types::identifier::Identifier;
 use move_vm_runtime::{
     interpreter::InterpreterForCostSynthesis, loaded_data::loaded_module::LoadedModule, MoveVM,
@@ -386,7 +383,7 @@ impl<'txn> RandomStackGenerator<'txn> {
                 let bytearray_size = self.root_module.byte_array_at(bytearray_idx).len();
                 (LdByteArray(bytearray_idx), bytearray_size)
             }
-            LdAddr(_) => (LdAddr(self.next_address_idx()), ADDRESS_LENGTH),
+            LdAddr(_) => (LdAddr(self.next_address_idx()), AccountAddress::LENGTH),
             _ => (self.op.clone(), 0),
         }
     }

--- a/language/tools/test-generation/src/lib.rs
+++ b/language/tools/test-generation/src/lib.rs
@@ -24,10 +24,7 @@ use language_e2e_tests::executor::FakeExecutor;
 use libra_config::config::VMConfig;
 use libra_logger::{debug, error, info};
 use libra_state_view::StateView;
-use libra_types::{
-    account_address::{AccountAddress, ADDRESS_LENGTH},
-    vm_error::StatusCode,
-};
+use libra_types::{account_address::AccountAddress, vm_error::StatusCode};
 use libra_vm::LibraVM;
 use move_vm_types::values::Value;
 use rand::{rngs::StdRng, Rng, SeedableRng};
@@ -63,7 +60,7 @@ fn run_vm(module: VerifiedModule) -> VMResult<()> {
         .arg_types
         .iter()
         .map(|sig_tok| match sig_tok {
-            SignatureToken::Address => Value::address(AccountAddress::new([0u8; ADDRESS_LENGTH])),
+            SignatureToken::Address => Value::address(AccountAddress::DEFAULT),
             SignatureToken::U64 => Value::u64(0),
             SignatureToken::Bool => Value::bool(true),
             SignatureToken::Vector(inner_tok) if **inner_tok == SignatureToken::U8 => {

--- a/language/transaction-builder/src/lib.rs
+++ b/language/transaction-builder/src/lib.rs
@@ -8,7 +8,7 @@ use libra_types::{
     account_address::AccountAddress,
     block_metadata::BlockMetadata,
     transaction::{
-        authenticator::AUTHENTICATION_KEY_LENGTH, Script, Transaction, TransactionArgument,
+        authenticator::AuthenticationKey, Script, Transaction, TransactionArgument,
         SCRIPT_HASH_LENGTH,
     },
 };
@@ -24,7 +24,7 @@ fn validate_auth_key_prefix(auth_key_prefix: &[u8]) {
     let auth_key_prefix_length = auth_key_prefix.len();
     assert!(
         auth_key_prefix_length == 0
-            || auth_key_prefix_length == AUTHENTICATION_KEY_LENGTH - AccountAddress::LENGTH,
+            || auth_key_prefix_length == AuthenticationKey::LENGTH - AccountAddress::LENGTH,
         "Bad auth key prefix length {}",
         auth_key_prefix_length
     );

--- a/language/transaction-builder/src/lib.rs
+++ b/language/transaction-builder/src/lib.rs
@@ -5,7 +5,7 @@
 
 use libra_crypto::HashValue;
 use libra_types::{
-    account_address::{AccountAddress, ADDRESS_LENGTH},
+    account_address::AccountAddress,
     block_metadata::BlockMetadata,
     transaction::{
         authenticator::AUTHENTICATION_KEY_LENGTH, Script, Transaction, TransactionArgument,
@@ -24,7 +24,7 @@ fn validate_auth_key_prefix(auth_key_prefix: &[u8]) {
     let auth_key_prefix_length = auth_key_prefix.len();
     assert!(
         auth_key_prefix_length == 0
-            || auth_key_prefix_length == AUTHENTICATION_KEY_LENGTH - ADDRESS_LENGTH,
+            || auth_key_prefix_length == AUTHENTICATION_KEY_LENGTH - AccountAddress::LENGTH,
         "Bad auth key prefix length {}",
         auth_key_prefix_length
     );

--- a/language/vm/src/deserializer.rs
+++ b/language/vm/src/deserializer.rs
@@ -4,7 +4,7 @@
 use crate::{errors::*, file_format::*, file_format_common::*};
 use byteorder::{LittleEndian, ReadBytesExt};
 use libra_types::{
-    account_address::ADDRESS_LENGTH,
+    account_address::AccountAddress,
     vm_error::{StatusCode, VMStatus},
 };
 use move_core_types::identifier::Identifier;
@@ -493,11 +493,11 @@ fn load_address_pool(
     addresses: &mut AddressPool,
 ) -> BinaryLoaderResult<()> {
     let mut start = table.offset as usize;
-    if table.count as usize % ADDRESS_LENGTH != 0 {
+    if table.count as usize % AccountAddress::LENGTH != 0 {
         return Err(VMStatus::new(StatusCode::MALFORMED));
     }
-    for _i in 0..table.count as usize / ADDRESS_LENGTH {
-        let end_addr = start + ADDRESS_LENGTH;
+    for _i in 0..table.count as usize / AccountAddress::LENGTH {
+        let end_addr = start + AccountAddress::LENGTH;
         let address = (&binary[start..end_addr]).try_into();
         if address.is_err() {
             return Err(VMStatus::new(StatusCode::MALFORMED));

--- a/language/vm/src/file_format.rs
+++ b/language/vm/src/file_format.rs
@@ -31,7 +31,7 @@ use crate::{
     SignatureTokenKind,
 };
 use libra_types::{
-    account_address::{AccountAddress, ADDRESS_LENGTH},
+    account_address::AccountAddress,
     language_storage::ModuleId,
     vm_error::{StatusCode, VMStatus},
 };
@@ -1830,7 +1830,7 @@ pub fn dummy_procedure_module(code: Vec<Bytecode>) -> CompiledModule {
 
 /// Return a simple script that contains only a return in the main()
 pub fn empty_script() -> CompiledScriptMut {
-    let default_address = AccountAddress::new([3u8; ADDRESS_LENGTH]);
+    let default_address = AccountAddress::new([3u8; AccountAddress::LENGTH]);
     let self_module_name = self_module_name().to_owned();
     let main_name = Identifier::new("main").unwrap();
     let void_void_sig = FunctionSignature {

--- a/network/src/protocols/rpc/fuzzing.rs
+++ b/network/src/protocols/rpc/fuzzing.rs
@@ -13,7 +13,7 @@ use futures::{
     stream::StreamExt,
 };
 use libra_proptest_helpers::ValueGenerator;
-use libra_types::{account_address::ADDRESS_LENGTH, PeerId};
+use libra_types::PeerId;
 use memsocket::MemorySocket;
 use proptest::{arbitrary::any, collection::vec, prop_oneof, strategy::Strategy};
 use std::{io, time::Duration};
@@ -27,7 +27,7 @@ const MAX_UVI_PREFIX_BYTES: usize = 19;
 const MAX_SMALL_MSG_BYTES: usize = 32;
 const MAX_MEDIUM_MSG_BYTES: usize = 280;
 
-const MOCK_PEER_ID: PeerId = PeerId::new([0u8; ADDRESS_LENGTH]);
+const MOCK_PEER_ID: PeerId = PeerId::DEFAULT;
 const INBOUND_RPC_TIMEOUT: Duration = Duration::from_secs(30);
 const TEST_PROTOCOL: ProtocolId = ProtocolId::ConsensusRpc;
 

--- a/storage/libradb/src/pruner/test.rs
+++ b/storage/libradb/src/pruner/test.rs
@@ -5,10 +5,7 @@ use super::*;
 use crate::{change_set::ChangeSet, state_store::StateStore, LibraDB};
 use libra_crypto::HashValue;
 use libra_temppath::TempPath;
-use libra_types::{
-    account_address::{AccountAddress, ADDRESS_LENGTH},
-    account_state_blob::AccountStateBlob,
-};
+use libra_types::{account_address::AccountAddress, account_state_blob::AccountStateBlob};
 use std::collections::HashMap;
 
 fn put_account_state_set(
@@ -44,7 +41,7 @@ fn verify_state_in_store(
 
 #[test]
 fn test_pruner() {
-    let address = AccountAddress::new([1u8; ADDRESS_LENGTH]);
+    let address = AccountAddress::new([1u8; AccountAddress::LENGTH]);
     let value0 = AccountStateBlob::from(vec![0x01]);
     let value1 = AccountStateBlob::from(vec![0x02]);
     let value2 = AccountStateBlob::from(vec![0x03]);
@@ -108,7 +105,7 @@ fn test_pruner() {
 
 #[test]
 fn test_worker_quit_eagerly() {
-    let address = AccountAddress::new([1u8; ADDRESS_LENGTH]);
+    let address = AccountAddress::new([1u8; AccountAddress::LENGTH]);
     let value0 = AccountStateBlob::from(vec![0x01]);
     let value1 = AccountStateBlob::from(vec![0x02]);
     let value2 = AccountStateBlob::from(vec![0x03]);

--- a/storage/libradb/src/schema/transaction_by_account/mod.rs
+++ b/storage/libradb/src/schema/transaction_by_account/mod.rs
@@ -13,10 +13,7 @@
 use crate::schema::{ensure_slice_len_eq, TRANSACTION_BY_ACCOUNT_CF_NAME};
 use anyhow::Result;
 use byteorder::{BigEndian, ReadBytesExt, WriteBytesExt};
-use libra_types::{
-    account_address::{AccountAddress, ADDRESS_LENGTH},
-    transaction::Version,
-};
+use libra_types::{account_address::AccountAddress, transaction::Version};
 use schemadb::{
     define_schema,
     schema::{KeyCodec, ValueCodec},
@@ -46,8 +43,8 @@ impl KeyCodec<TransactionByAccountSchema> for Key {
     fn decode_key(data: &[u8]) -> Result<Self> {
         ensure_slice_len_eq(data, size_of::<Self>())?;
 
-        let address = AccountAddress::try_from(&data[..ADDRESS_LENGTH])?;
-        let seq_num = (&data[ADDRESS_LENGTH..]).read_u64::<BigEndian>()?;
+        let address = AccountAddress::try_from(&data[..AccountAddress::LENGTH])?;
+        let seq_num = (&data[AccountAddress::LENGTH..]).read_u64::<BigEndian>()?;
 
         Ok((address, seq_num))
     }

--- a/storage/libradb/src/state_store/state_store_test.rs
+++ b/storage/libradb/src/state_store/state_store_test.rs
@@ -6,10 +6,7 @@ use crate::{pruner, LibraDB};
 use jellyfish_merkle::restore::JellyfishMerkleRestore;
 use libra_crypto::hash::CryptoHash;
 use libra_temppath::TempPath;
-use libra_types::{
-    account_address::{AccountAddress, ADDRESS_LENGTH},
-    account_state_blob::AccountStateBlob,
-};
+use libra_types::{account_address::AccountAddress, account_state_blob::AccountStateBlob};
 use proptest::{collection::hash_map, prelude::*};
 
 fn put_account_state_set(
@@ -84,7 +81,7 @@ fn test_empty_store() {
     let tmp_dir = TempPath::new();
     let db = LibraDB::new(&tmp_dir);
     let store = &db.state_store;
-    let address = AccountAddress::new([1u8; ADDRESS_LENGTH]);
+    let address = AccountAddress::new([1u8; AccountAddress::LENGTH]);
     assert!(store
         .get_account_state_with_proof_by_version(address, 0)
         .is_err());
@@ -95,9 +92,9 @@ fn test_state_store_reader_writer() {
     let tmp_dir = TempPath::new();
     let db = LibraDB::new(&tmp_dir);
     let store = &db.state_store;
-    let address1 = AccountAddress::new([1u8; ADDRESS_LENGTH]);
-    let address2 = AccountAddress::new([2u8; ADDRESS_LENGTH]);
-    let address3 = AccountAddress::new([3u8; ADDRESS_LENGTH]);
+    let address1 = AccountAddress::new([1u8; AccountAddress::LENGTH]);
+    let address2 = AccountAddress::new([2u8; AccountAddress::LENGTH]);
+    let address3 = AccountAddress::new([3u8; AccountAddress::LENGTH]);
     let value1 = AccountStateBlob::from(vec![0x01]);
     let value1_update = AccountStateBlob::from(vec![0x00]);
     let value2 = AccountStateBlob::from(vec![0x02]);
@@ -137,9 +134,9 @@ fn test_state_store_reader_writer() {
 
 #[test]
 fn test_retired_records() {
-    let address1 = AccountAddress::new([1u8; ADDRESS_LENGTH]);
-    let address2 = AccountAddress::new([2u8; ADDRESS_LENGTH]);
-    let address3 = AccountAddress::new([3u8; ADDRESS_LENGTH]);
+    let address1 = AccountAddress::new([1u8; AccountAddress::LENGTH]);
+    let address2 = AccountAddress::new([2u8; AccountAddress::LENGTH]);
+    let address3 = AccountAddress::new([3u8; AccountAddress::LENGTH]);
     let value1 = AccountStateBlob::from(vec![0x01]);
     let value2 = AccountStateBlob::from(vec![0x02]);
     let value2_update = AccountStateBlob::from(vec![0x12]);

--- a/storage/storage-service/src/mocks/mock_storage_client.rs
+++ b/storage/storage-service/src/mocks/mock_storage_client.rs
@@ -7,7 +7,7 @@ use anyhow::{Error, Result};
 use futures::stream::BoxStream;
 use libra_crypto::{ed25519::*, HashValue};
 use libra_types::{
-    account_address::{AccountAddress, ADDRESS_LENGTH},
+    account_address::AccountAddress,
     account_state::AccountState,
     account_state_blob::AccountStateBlob,
     event::EventHandle,
@@ -207,7 +207,7 @@ fn get_mock_response_item(request_item: &ProtoRequestItem) -> Result<ProtoRespon
             }
             RequestedItems::GetTransactionsRequest(request) => {
                 let mut ret = TransactionListWithProof::default();
-                let sender = AccountAddress::new([1; ADDRESS_LENGTH]);
+                let sender = AccountAddress::new([1; AccountAddress::LENGTH]);
                 if request.limit > 0 {
                     let txns = get_mock_txn_data(sender, 0, request.limit - 1);
                     ret.transactions = txns;

--- a/types/src/event.rs
+++ b/types/src/event.rs
@@ -1,7 +1,7 @@
 // Copyright (c) The Libra Core Contributors
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::account_address::{AccountAddress, ADDRESS_LENGTH};
+use crate::account_address::AccountAddress;
 use anyhow::{ensure, Error, Result};
 #[cfg(feature = "fuzzing")]
 use rand::{rngs::OsRng, RngCore};
@@ -14,7 +14,7 @@ use std::{
 };
 
 /// Size of an event key.
-pub const EVENT_KEY_LENGTH: usize = ADDRESS_LENGTH + 8;
+pub const EVENT_KEY_LENGTH: usize = AccountAddress::LENGTH + 8;
 
 /// A struct that represents a globally unique id for an Event stream that a user can listen to.
 pub struct EventKey([u8; EVENT_KEY_LENGTH]);

--- a/types/src/event.rs
+++ b/types/src/event.rs
@@ -8,17 +8,13 @@ use proptest_derive::Arbitrary;
 #[cfg(feature = "fuzzing")]
 use rand::{rngs::OsRng, RngCore};
 use serde::{de, ser, Deserialize, Serialize};
-use std::{
-    cmp::{Ord, Ordering, PartialOrd},
-    convert::TryFrom,
-    fmt,
-    hash::Hash,
-};
+use std::{convert::TryFrom, fmt};
 
 /// Size of an event key.
 pub const EVENT_KEY_LENGTH: usize = AccountAddress::LENGTH + 8;
 
-/// A struct that represents a globally unique id for an Event stream that a user can listen to.
+/// A struct that represents a globally unique id for an Event stream that a user can listen to.e
+#[derive(Clone, Copy, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
 #[cfg_attr(feature = "fuzzing", derive(Arbitrary))]
 pub struct EventKey([u8; EVENT_KEY_LENGTH]);
 
@@ -56,67 +52,6 @@ impl EventKey {
     }
 }
 
-// Rust doesn't support deriving traits for array size greater than 32. We'll implement those traits
-// by hand for now
-impl PartialEq for EventKey {
-    #[inline]
-    fn eq(&self, other: &EventKey) -> bool {
-        self.as_bytes() == other.as_bytes()
-    }
-}
-
-impl Eq for EventKey {}
-
-impl PartialOrd for EventKey {
-    fn partial_cmp(&self, other: &EventKey) -> Option<Ordering> {
-        PartialOrd::partial_cmp(self.as_bytes(), other.as_bytes())
-    }
-    #[inline]
-    fn lt(&self, other: &EventKey) -> bool {
-        PartialOrd::lt(self.as_bytes(), other.as_bytes())
-    }
-    #[inline]
-    fn le(&self, other: &EventKey) -> bool {
-        PartialOrd::le(self.as_bytes(), other.as_bytes())
-    }
-    #[inline]
-    fn ge(&self, other: &EventKey) -> bool {
-        PartialOrd::ge(self.as_bytes(), other.as_bytes())
-    }
-    #[inline]
-    fn gt(&self, other: &EventKey) -> bool {
-        PartialOrd::gt(self.as_bytes(), other.as_bytes())
-    }
-}
-
-impl Ord for EventKey {
-    #[inline]
-    fn cmp(&self, other: &EventKey) -> Ordering {
-        Ord::cmp(self.as_bytes(), other.as_bytes())
-    }
-}
-
-impl Clone for EventKey {
-    fn clone(&self) -> Self {
-        let mut key = [0; EVENT_KEY_LENGTH];
-        key.copy_from_slice(self.as_bytes());
-        Self(key)
-    }
-}
-
-impl fmt::Debug for EventKey {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "EventKey({:?})", self.as_bytes())
-    }
-}
-
-impl Copy for EventKey {}
-
-impl Hash for EventKey {
-    fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
-        Hash::hash(self.as_bytes(), state)
-    }
-}
 // TODO(#1307)
 impl ser::Serialize for EventKey {
     fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>

--- a/types/src/event.rs
+++ b/types/src/event.rs
@@ -4,6 +4,8 @@
 use crate::account_address::AccountAddress;
 use anyhow::{ensure, Error, Result};
 #[cfg(feature = "fuzzing")]
+use proptest_derive::Arbitrary;
+#[cfg(feature = "fuzzing")]
 use rand::{rngs::OsRng, RngCore};
 use serde::{de, ser, Deserialize, Serialize};
 use std::{
@@ -17,6 +19,7 @@ use std::{
 pub const EVENT_KEY_LENGTH: usize = AccountAddress::LENGTH + 8;
 
 /// A struct that represents a globally unique id for an Event stream that a user can listen to.
+#[cfg_attr(feature = "fuzzing", derive(Arbitrary))]
 pub struct EventKey([u8; EVENT_KEY_LENGTH]);
 
 impl EventKey {

--- a/types/src/proptest_types.rs
+++ b/types/src/proptest_types.rs
@@ -10,7 +10,7 @@ use crate::{
     block_metadata::BlockMetadata,
     contract_event::ContractEvent,
     discovery_info::DiscoveryInfo,
-    event::{EventHandle, EventKey, EVENT_KEY_LENGTH},
+    event::{EventHandle, EventKey},
     get_with_proof::{ResponseItem, UpdateToLatestLedgerResponse},
     language_storage::{StructTag, TypeTag},
     ledger_info::{LedgerInfo, LedgerInfoWithSignatures},
@@ -676,22 +676,6 @@ impl AccountStateBlobGen {
             .materialize(account_index, universe);
         let balance_resource = self.balance_resource_gen.materialize();
         AccountStateBlob::try_from((&account_resource, &balance_resource)).unwrap()
-    }
-}
-
-#[cfg(feature = "fuzzing")]
-impl Arbitrary for EventKey {
-    type Parameters = ();
-    type Strategy = BoxedStrategy<Self>;
-
-    fn arbitrary_with(_args: Self::Parameters) -> Self::Strategy {
-        (vec(any::<u8>(), EVENT_KEY_LENGTH))
-            .prop_map(|v| {
-                let mut bytes = [0; EVENT_KEY_LENGTH];
-                bytes.copy_from_slice(v.as_slice());
-                EventKey::new(bytes)
-            })
-            .boxed()
     }
 }
 

--- a/types/src/transaction/authenticator.rs
+++ b/types/src/transaction/authenticator.rs
@@ -121,19 +121,20 @@ impl TransactionAuthenticator {
     }
 }
 
-pub const AUTHENTICATION_KEY_LENGTH: usize = 32;
-
 /// A struct that represents an account authentication key. An account's address is the last 16
 /// bytes of authentication key used to create it
 #[derive(Debug, Ord, PartialOrd, Eq, PartialEq, Hash, Clone, Copy, CryptoHasher)]
 #[cfg_attr(any(test, feature = "fuzzing"), derive(Arbitrary))]
-pub struct AuthenticationKey([u8; AUTHENTICATION_KEY_LENGTH]);
+pub struct AuthenticationKey([u8; AuthenticationKey::LENGTH]);
 
 impl AuthenticationKey {
     /// Create an authentication key from `bytes`
-    pub const fn new(bytes: [u8; AUTHENTICATION_KEY_LENGTH]) -> Self {
+    pub const fn new(bytes: [u8; Self::LENGTH]) -> Self {
         Self(bytes)
     }
+
+    /// The number of bytes in an authentication key.
+    pub const LENGTH: usize = 32;
 
     /// Create an authentication key from a preimage by taking its sha3 hash
     pub fn from_preimage(preimage: &AuthenticationKeyPreimage) -> AuthenticationKey {
@@ -155,7 +156,7 @@ impl AuthenticationKey {
     pub fn derived_address(&self) -> AccountAddress {
         // keep only last 16 bytes
         let mut array = [0u8; AccountAddress::LENGTH];
-        array.copy_from_slice(&self.0[AUTHENTICATION_KEY_LENGTH - AccountAddress::LENGTH..]);
+        array.copy_from_slice(&self.0[Self::LENGTH - AccountAddress::LENGTH..]);
         AccountAddress::new(array)
     }
 
@@ -179,7 +180,7 @@ impl AuthenticationKey {
     /// Create a random authentication key. For testing only
     pub fn random() -> Self {
         let mut rng = OsRng::new().expect("can't access OsRng");
-        let buf: [u8; AUTHENTICATION_KEY_LENGTH] = rng.gen();
+        let buf: [u8; Self::LENGTH] = rng.gen();
         AuthenticationKey::new(buf)
     }
 }
@@ -232,11 +233,11 @@ impl TryFrom<&[u8]> for AuthenticationKey {
 
     fn try_from(bytes: &[u8]) -> Result<AuthenticationKey> {
         ensure!(
-            bytes.len() == AUTHENTICATION_KEY_LENGTH,
+            bytes.len() == Self::LENGTH,
             "The authentication key {:?} is of invalid length",
             bytes
         );
-        let mut addr = [0u8; AUTHENTICATION_KEY_LENGTH];
+        let mut addr = [0u8; Self::LENGTH];
         addr.copy_from_slice(bytes);
         Ok(AuthenticationKey(addr))
     }

--- a/types/src/transaction/authenticator.rs
+++ b/types/src/transaction/authenticator.rs
@@ -1,7 +1,7 @@
 // Copyright (c) The Libra Core Contributors
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::account_address::{AccountAddress, ADDRESS_LENGTH};
+use crate::account_address::AccountAddress;
 use anyhow::{ensure, Error, Result};
 use libra_crypto::{
     ed25519::{Ed25519PublicKey, Ed25519Signature},
@@ -150,18 +150,19 @@ impl AuthenticationKey {
         Self::from_preimage(&AuthenticationKeyPreimage::multi_ed25519(public_key))
     }
 
-    /// Return an address derived from the last ADDRESS_LENGTH bytes of this authentication key
+    /// Return an address derived from the last `AccountAddress::LENGTH` bytes of this
+    /// authentication key.
     pub fn derived_address(&self) -> AccountAddress {
         // keep only last 16 bytes
-        let mut array = [0u8; ADDRESS_LENGTH];
-        array.copy_from_slice(&self.0[AUTHENTICATION_KEY_LENGTH - ADDRESS_LENGTH..]);
+        let mut array = [0u8; AccountAddress::LENGTH];
+        array.copy_from_slice(&self.0[AUTHENTICATION_KEY_LENGTH - AccountAddress::LENGTH..]);
         AccountAddress::new(array)
     }
 
-    /// Return the first ADDRESS_LENGTH bytes of this authentication key
-    pub fn prefix(&self) -> [u8; ADDRESS_LENGTH] {
-        let mut array = [0u8; ADDRESS_LENGTH];
-        array.copy_from_slice(&self.0[..ADDRESS_LENGTH]);
+    /// Return the first AccountAddress::LENGTH bytes of this authentication key
+    pub fn prefix(&self) -> [u8; AccountAddress::LENGTH] {
+        let mut array = [0u8; AccountAddress::LENGTH];
+        array.copy_from_slice(&self.0[..AccountAddress::LENGTH]);
         array
     }
 

--- a/types/src/transaction/transaction_argument.rs
+++ b/types/src/transaction/transaction_argument.rs
@@ -1,7 +1,7 @@
 // Copyright (c) The Libra Core Contributors
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::account_address::{AccountAddress, ADDRESS_LENGTH};
+use crate::account_address::AccountAddress;
 use anyhow::Result;
 use serde::{Deserialize, Serialize};
 use std::{convert::TryFrom, fmt};
@@ -47,15 +47,15 @@ pub fn parse_as_address(s: &str) -> Result<TransactionArgument> {
         s = format!("0x0{}", &s[2..]);
     }
     let mut addr = hex::decode(&s[2..])?;
-    if addr.len() > ADDRESS_LENGTH {
+    if addr.len() > AccountAddress::LENGTH {
         return Err(ErrorKind::ParseError(format!(
             "address must be {} bytes or less",
-            ADDRESS_LENGTH
+            AccountAddress::LENGTH
         ))
         .into());
     }
-    if addr.len() < ADDRESS_LENGTH {
-        addr = vec![0u8; ADDRESS_LENGTH - addr.len()]
+    if addr.len() < AccountAddress::LENGTH {
+        addr = vec![0u8; AccountAddress::LENGTH - addr.len()]
             .into_iter()
             .chain(addr.into_iter())
             .collect();

--- a/types/src/unit_tests/access_path_test.rs
+++ b/types/src/unit_tests/access_path_test.rs
@@ -1,10 +1,7 @@
 // Copyright (c) The Libra Core Contributors
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::{
-    access_path::AccessPath,
-    account_address::{AccountAddress, ADDRESS_LENGTH},
-};
+use crate::{access_path::AccessPath, account_address::AccountAddress};
 use libra_prost_ext::test_helpers::assert_protobuf_encode_decode;
 use proptest::prelude::*;
 use std::convert::TryFrom;
@@ -12,19 +9,19 @@ use std::convert::TryFrom;
 #[test]
 fn access_path_ord() {
     let ap1 = AccessPath {
-        address: AccountAddress::new([1u8; ADDRESS_LENGTH]),
+        address: AccountAddress::new([1u8; AccountAddress::LENGTH]),
         path: b"/foo/b".to_vec(),
     };
     let ap2 = AccessPath {
-        address: AccountAddress::new([1u8; ADDRESS_LENGTH]),
+        address: AccountAddress::new([1u8; AccountAddress::LENGTH]),
         path: b"/foo/c".to_vec(),
     };
     let ap3 = AccessPath {
-        address: AccountAddress::new([1u8; ADDRESS_LENGTH]),
+        address: AccountAddress::new([1u8; AccountAddress::LENGTH]),
         path: b"/foo/c".to_vec(),
     };
     let ap4 = AccessPath {
-        address: AccountAddress::new([2u8; ADDRESS_LENGTH]),
+        address: AccountAddress::new([2u8; AccountAddress::LENGTH]),
         path: b"/foo/a".to_vec(),
     };
     assert!(ap1 < ap2);
@@ -34,7 +31,7 @@ fn access_path_ord() {
 
 #[test]
 fn test_access_path_protobuf_conversion() {
-    let address = AccountAddress::new([1u8; ADDRESS_LENGTH]);
+    let address = AccountAddress::new([1u8; AccountAddress::LENGTH]);
     let path = b"/foo/bar".to_vec();
     let ap = AccessPath {
         address,

--- a/types/src/unit_tests/address_test.rs
+++ b/types/src/unit_tests/address_test.rs
@@ -1,7 +1,7 @@
 // Copyright (c) The Libra Core Contributors
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::account_address::{AccountAddress, ADDRESS_LENGTH};
+use crate::account_address::AccountAddress;
 use hex::FromHex;
 use libra_crypto::{hash::CryptoHash, HashValue};
 use proptest::prelude::*;
@@ -14,11 +14,11 @@ fn test_address_bytes() {
 
     assert_eq!(
         hex.len(),
-        ADDRESS_LENGTH as usize,
+        AccountAddress::LENGTH as usize,
         "Address {:?} is not {}-bytes long. Addresses must be {} bytes",
         hex,
-        ADDRESS_LENGTH,
-        ADDRESS_LENGTH,
+        AccountAddress::LENGTH,
+        AccountAddress::LENGTH,
     );
     let address = AccountAddress::try_from(&hex[..]).unwrap_or_else(|_| {
         panic!(
@@ -37,11 +37,11 @@ fn test_address() {
 
     assert_eq!(
         hex.len(),
-        ADDRESS_LENGTH as usize,
+        AccountAddress::LENGTH as usize,
         "Address {:?} is not {}-bytes long. Addresses must be {} bytes",
         hex,
-        ADDRESS_LENGTH,
-        ADDRESS_LENGTH,
+        AccountAddress::LENGTH,
+        AccountAddress::LENGTH,
     );
 
     let address: AccountAddress = AccountAddress::try_from(&hex[..]).unwrap_or_else(|_| {
@@ -65,7 +65,7 @@ fn test_address() {
 
 #[test]
 fn test_ref() {
-    let address = AccountAddress::new([1u8; ADDRESS_LENGTH]);
+    let address = AccountAddress::new([1u8; AccountAddress::LENGTH]);
     let _: &[u8] = address.as_ref();
 }
 

--- a/types/src/validator_signer.rs
+++ b/types/src/validator_signer.rs
@@ -1,7 +1,7 @@
 // Copyright (c) The Libra Core Contributors
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::account_address::{AccountAddress, ADDRESS_LENGTH};
+use crate::account_address::AccountAddress;
 use libra_crypto::{
     ed25519::{Ed25519PrivateKey, Ed25519PublicKey, Ed25519Signature},
     test_utils::TEST_SEED,
@@ -66,7 +66,7 @@ impl ValidatorSigner {
     /// For test only - makes signer with nicely looking account address that has specified integer
     /// as fist byte, and rest are zeroes
     pub fn from_int(num: u8) -> Self {
-        let mut address = [0; ADDRESS_LENGTH];
+        let mut address = [0; AccountAddress::LENGTH];
         address[0] = num;
         let mut rng = StdRng::from_seed(TEST_SEED);
         let private_key = Ed25519PrivateKey::generate_for_testing(&mut rng);

--- a/vm-validator/src/mocks/mock_vm_validator.rs
+++ b/vm-validator/src/mocks/mock_vm_validator.rs
@@ -5,7 +5,7 @@ use crate::vm_validator::TransactionValidation;
 use anyhow::Result;
 use libra_state_view::StateView;
 use libra_types::{
-    account_address::{AccountAddress, ADDRESS_LENGTH},
+    account_address::AccountAddress,
     transaction::SignedTransaction,
     vm_error::{StatusCode, VMStatus},
 };
@@ -35,18 +35,20 @@ impl TransactionValidation for MockVMValidator {
         };
 
         let sender = txn.sender();
-        let account_dne_test_add = AccountAddress::try_from(&[0 as u8; ADDRESS_LENGTH]).unwrap();
-        let invalid_sig_test_add = AccountAddress::try_from(&[1 as u8; ADDRESS_LENGTH]).unwrap();
+        let account_dne_test_add =
+            AccountAddress::try_from(&[0 as u8; AccountAddress::LENGTH]).unwrap();
+        let invalid_sig_test_add =
+            AccountAddress::try_from(&[1 as u8; AccountAddress::LENGTH]).unwrap();
         let insufficient_balance_test_add =
-            AccountAddress::try_from(&[2 as u8; ADDRESS_LENGTH]).unwrap();
+            AccountAddress::try_from(&[2 as u8; AccountAddress::LENGTH]).unwrap();
         let seq_number_too_new_test_add =
-            AccountAddress::try_from(&[3 as u8; ADDRESS_LENGTH]).unwrap();
+            AccountAddress::try_from(&[3 as u8; AccountAddress::LENGTH]).unwrap();
         let seq_number_too_old_test_add =
-            AccountAddress::try_from(&[4 as u8; ADDRESS_LENGTH]).unwrap();
+            AccountAddress::try_from(&[4 as u8; AccountAddress::LENGTH]).unwrap();
         let txn_expiration_time_test_add =
-            AccountAddress::try_from(&[5 as u8; ADDRESS_LENGTH]).unwrap();
+            AccountAddress::try_from(&[5 as u8; AccountAddress::LENGTH]).unwrap();
         let invalid_auth_key_test_add =
-            AccountAddress::try_from(&[6 as u8; ADDRESS_LENGTH]).unwrap();
+            AccountAddress::try_from(&[6 as u8; AccountAddress::LENGTH]).unwrap();
         let ret = if sender == account_dne_test_add {
             Some(VMStatus::new(StatusCode::SENDING_ACCOUNT_DOES_NOT_EXIST))
         } else if sender == invalid_sig_test_add {


### PR DESCRIPTION
Simplifies imports quite significantly.

* `ADDRESS_LENGTH` -> `AccountAddress::LENGTH`
* `AUTHENTICATION_KEY_LENGTH` -> `AuthenticationKey::LENGTH`
* `EVENT_KEY_LENGTH` -> `EventKey::LENGTH`.

Also included is some minor cleanup.