### PR TITLE
Update ac endpoint for client to use JSON-RPC

### DIFF
--- a/scripts/cli/start_cli_testnet.sh
+++ b/scripts/cli/start_cli_testnet.sh
@@ -13,7 +13,7 @@ source "$HOME/.cargo/env"
 
 SCRIPT_PATH="$(dirname $0)"
 
-RUN_PARAMS="--host ac.testnet.libra.org --port 8080 "
+RUN_PARAMS="--host client.testnet.libra.org --port 80 "
 RELEASE=""
 
 while [[ ! -z "$1" ]]; do


### PR DESCRIPTION
<!--
Thank you for sending a PR. We appreciate you spending time to help improve the Libra project.

The project is undergoing daily changes. Pull Requests will be reviewed and responded to as time permits.
-->

## Motivation

Connecting cli through ac won't be supported anymore
### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?

Yes
## Test Plan

run command and make sure it can connect to devnet.
`cargo run -p cli -- --host client.dev.aws.hlw3truzy4ls.com --port 80`

## Related PRs

(If this PR adds or changes functionality, please take some time to update the docs at https://github.com/libra/website, and link to your PR here.)
