### PR TITLE
[LBT] set job timeouts

### DIFF
--- a/.github/workflows/land-blocking.yml
+++ b/.github/workflows/land-blocking.yml
@@ -10,6 +10,7 @@ jobs:
   build-images:
     name: Build images
     runs-on: self-hosted
+    timeout-minutes: 15
     steps:
       - uses: actions/checkout@v1
       - name: Setup env
@@ -49,6 +50,7 @@ jobs:
     name: Build images and run cluster test
     needs: build-images
     runs-on: self-hosted
+    timeout-minutes: 20
     steps:
       - uses: actions/checkout@v1
       - name: Setup env
@@ -192,6 +194,7 @@ jobs:
     name: Run cluster test on k8s
     needs: build-images
     runs-on: self-hosted
+    timeout-minutes: 20
     steps:
       - uses: actions/checkout@v1
       - name: Setup env


### PR DESCRIPTION
When cluster test gets stuck in an unknown state in LBT, the landing
queue grinds to a halt. Case in point,
https://github.com/libra/libra/actions/runs/58315619

Set timeout on each job in the LBT workflow so that it doesn't wait for
extended time.
  - The build job is limited to 15 minutes, sufficient for 3 retries.
  - Each of the cluster test job (k8s and ecs) is limited to 20 minutes.