### PR TITLE
[scripts] Fix code coverage problems due to inlining

### DIFF
--- a/scripts/coverage_report.sh
+++ b/scripts/coverage_report.sh
@@ -72,7 +72,7 @@ then
 fi
 
 # Set the flags necessary for coverage output
-export RUSTFLAGS="-Zprofile -Ccodegen-units=1 -Cinline-threshold=0 -Coverflow-checks=off -Zno-landing-pads"
+export RUSTFLAGS="-Zprofile -Ccodegen-units=1 -Coverflow-checks=off -Zno-landing-pads"
 export RUSTC_BOOTSTRAP=1
 export CARGO_INCREMENTAL=0
 


### PR DESCRIPTION
Libra's script to report code coverage has been passing "-Cinline-threshold=0" in an attempt to forcibly disable inlining. We run coverage with a debug build, so that shouldn't have been strictly necessary but at some time in the past that worked fine. But, LLVM's inliner has gotten smarter and a threshold of zero just means that inlining should never increase code size. Now adding that option actually has the effect of enabling inlining, and for functions with a single call site and many arguments, it is often a code size win to inline. That's great for perf but it totally messes up the coverage data, because all the counts for an inlined function go to the line(s) where it is called and you can't tell what is covered within the function. With our current version of Rust (1.42), dropping the "-Cinline-threshold=0" option solves this problem, and that option shouldn't be necessary in the future, either.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

I don't know of a good way to test this automatically, but it would be great if we had something to make sure this does not regress. Suggestions welcome!
