### PR TITLE
[k8s][cti] Add ct-k8s-status.sh

### DIFF
--- a/scripts/ct-k8s-status.sh
+++ b/scripts/ct-k8s-status.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+
+# Copyright (c) The Libra Core Contributors
+# SPDX-License-Identifier: Apache-2.0
+
+set -euo pipefail
+
+DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
+
+source "${DIR}/ct.vars"
+
+for ((i = 0; i < ${K8S_POOL_SIZE}; i++)); do
+  ws="ct-${i}"
+  echo "Workspace: $ws"
+  echo "Cluster test pods:"
+  context="arn:aws:eks:us-west-2:853397791086:cluster/${ws}-k8s-testnet"
+  kubectl get pods --context="${context}" -l app=cluster-test --sort-by=.status.startTime
+  echo
+done

--- a/scripts/ct.vars
+++ b/scripts/ct.vars
@@ -1,0 +1,1 @@
+K8S_POOL_SIZE="3"

--- a/scripts/cti
+++ b/scripts/cti
@@ -14,8 +14,11 @@ MARKER=$(whoami)
 DEPLOY=yes
 
 K8S=""
-K8S_POOL_SIZE="3"
 K8S_CONTEXT_PATTERN='arn:aws:eks:us-west-2:853397791086:cluster/CLUSTERNAME-k8s-testnet'
+
+DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
+
+source "${DIR}/ct.vars"
 
 # Colorize Output
 RESTORE=$(echo -en '\001\033[0m\002')


### PR DESCRIPTION
## Summary

This script prints out all the cluster-test pods from the various cluster-test k8s clusters

## Test Plan

`./scripts/ct-k8s-status.sh`