### PR TITLE
[cluster-test] Capture structured logs from validators in cluster test

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2471,6 +2471,7 @@ dependencies = [
  "chrono 0.4.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "env_logger 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "once_cell 1.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.48 (registry+https://github.com/rust-lang/crates.io-index)",
 ]

--- a/common/logger/Cargo.toml
+++ b/common/logger/Cargo.toml
@@ -17,6 +17,7 @@ env_logger = { version = "0.7.1", default-features = false }
 log = "0.4.8"
 serde_json = "1.0.48"
 serde = { version = "1.0.96", features = ["derive"] }
+once_cell = "1.3.1"
 
 [features]
 names_required = []

--- a/consensus/consensus-types/src/block.rs
+++ b/consensus/consensus-types/src/block.rs
@@ -23,7 +23,7 @@ use mirai_annotations::debug_checked_verify_eq;
 use serde::{de::DeserializeOwned, Deserialize, Deserializer, Serialize};
 use std::{
     collections::BTreeMap,
-    fmt::{Display, Formatter},
+    fmt::{self, Display, Formatter},
 };
 
 #[path = "block_test_utils.rs"]
@@ -34,7 +34,7 @@ pub mod block_test_utils;
 #[path = "block_test.rs"]
 pub mod block_test;
 
-#[derive(Serialize, Clone, Debug, PartialEq, Eq)]
+#[derive(Serialize, Clone, PartialEq, Eq)]
 /// Block has the core data of a consensus block that should be persistent when necessary.
 /// Each block must know the id of its parent and keep the QuorurmCertificate to that parent.
 pub struct Block<T> {
@@ -48,7 +48,13 @@ pub struct Block<T> {
     signature: Option<Ed25519Signature>,
 }
 
-impl<T: PartialEq> Display for Block<T> {
+impl<T> fmt::Debug for Block<T> {
+    fn fmt(&self, f: &mut Formatter) -> fmt::Result {
+        write!(f, "{}", self)
+    }
+}
+
+impl<T> Display for Block<T> {
     fn fmt(&self, f: &mut Formatter) -> std::fmt::Result {
         let nil_marker = if self.is_nil_block() { " (NIL)" } else { "" };
         write!(
@@ -124,10 +130,7 @@ impl<T> Block<T> {
     }
 }
 
-impl<T> Block<T>
-where
-    T: PartialEq,
-{
+impl<T> Block<T> {
     pub fn is_genesis_block(&self) -> bool {
         self.block_data.is_genesis_block()
     }

--- a/consensus/consensus-types/src/block_data.rs
+++ b/consensus/consensus-types/src/block_data.rs
@@ -109,16 +109,13 @@ impl<T> BlockData<T> {
     }
 }
 
-impl<T> BlockData<T>
-where
-    T: PartialEq,
-{
+impl<T> BlockData<T> {
     pub fn is_genesis_block(&self) -> bool {
-        self.block_type == BlockType::Genesis
+        matches!(self.block_type, BlockType::Genesis)
     }
 
     pub fn is_nil_block(&self) -> bool {
-        self.block_type == BlockType::NilBlock
+        matches!(self.block_type, BlockType::NilBlock)
     }
 }
 

--- a/consensus/consensus-types/src/executed_block.rs
+++ b/consensus/consensus-types/src/executed_block.rs
@@ -6,14 +6,14 @@ use executor_types::{ExecutedTrees, ProcessedVMOutput, StateComputeResult};
 use libra_crypto::hash::HashValue;
 use libra_types::block_info::BlockInfo;
 use std::{
-    fmt::{Display, Formatter},
+    fmt::{Debug, Display, Formatter},
     sync::Arc,
 };
 
 /// ExecutedBlocks are managed in a speculative tree, the committed blocks form a chain. Besides
 /// block data, each executed block also has other derived meta data which could be regenerated from
 /// blocks.
-#[derive(Clone, Debug)]
+#[derive(Clone)]
 pub struct ExecutedBlock<T> {
     /// Block data that cannot be regenerated.
     block: Block<T>,
@@ -31,9 +31,15 @@ impl<T: PartialEq> PartialEq for ExecutedBlock<T> {
 
 impl<T: Eq> Eq for ExecutedBlock<T> where T: PartialEq {}
 
-impl<T: PartialEq> Display for ExecutedBlock<T> {
+impl<T> Debug for ExecutedBlock<T> {
     fn fmt(&self, f: &mut Formatter) -> std::fmt::Result {
-        self.block().fmt(f)
+        write!(f, "{:?}", self.block())
+    }
+}
+
+impl<T> Display for ExecutedBlock<T> {
+    fn fmt(&self, f: &mut Formatter) -> std::fmt::Result {
+        write!(f, "{}", self.block())
     }
 }
 

--- a/libra-node/src/main.rs
+++ b/libra-node/src/main.rs
@@ -41,6 +41,7 @@ fn main() {
             .is_async(config.logger.is_async)
             .level(config.logger.level)
             .init();
+        libra_logger::init_struct_log_from_env().expect("Failed to initialize structured logging");
     }
 
     if config.metrics.enabled {

--- a/testsuite/cluster-test/src/cluster_swarm/cluster_swarm_kube.rs
+++ b/testsuite/cluster-test/src/cluster_swarm/cluster_swarm_kube.rs
@@ -69,7 +69,7 @@ impl ClusterSwarmKube {
         } else {
             ""
         };
-        let fluentbit_enabled = if index % 10 == 0 { "true" } else { "false" };
+        let fluentbit_enabled = "true";
         let pod_yaml = format!(
             include_str!("validator_spec_template.yaml"),
             index = index,
@@ -100,11 +100,7 @@ impl ClusterSwarmKube {
         cfg_overrides: &str,
         delete_data: bool,
     ) -> Result<Pod> {
-        let fluentbit_enabled = if validator_index % 10 == 0 {
-            "true"
-        } else {
-            "false"
-        };
+        let fluentbit_enabled = "true";
         let pod_yaml = format!(
             include_str!("fullnode_spec_template.yaml"),
             fullnode_index = fullnode_index,

--- a/testsuite/cluster-test/src/cluster_swarm/fullnode_spec_template.yaml
+++ b/testsuite/cluster-test/src/cluster_swarm/fullnode_spec_template.yaml
@@ -35,11 +35,20 @@ spec:
       else
         libra_log_file="non_existent_file"
       fi
-      cat << EOF > /opt/libra/data/fluent-bit.conf
+      mkdir -p /opt/libra/data/fluent-bit/
+      cat << EOF > /opt/libra/data/fluent-bit/parsers.conf
+      [PARSER]
+        Name        events
+        Format      json
+        Time_Key    timestamp
+        Time_Format %Y-%m-%d %H:%M:%S
+      EOF
+      cat << EOF > /opt/libra/data/fluent-bit/fluent-bit.conf
       [SERVICE]
           Flush         5
           Log_Level     info
           Daemon        off
+          Parsers_File  /opt/libra/data/fluent-bit/parsers.conf
 
       [INPUT]
           Name              tail
@@ -48,6 +57,15 @@ spec:
           Mem_Buf_Limit     5MB
           Refresh_Interval  10
           Skip_Long_Lines   On
+
+      [INPUT]
+          Name              tail
+          Tag               validator-events
+          Path              /opt/libra/data/events.log
+          Mem_Buf_Limit     5MB
+          Refresh_Interval  10
+          Skip_Long_Lines   On
+          Parser            events
 
       [FILTER]
           Name record_modifier
@@ -75,7 +93,7 @@ spec:
   - name: fluent-bit
     image: 853397791086.dkr.ecr.us-west-2.amazonaws.com/fluent-bit:1.3.9
     imagePullPolicy: IfNotPresent
-    command: ["/fluent-bit/bin/fluent-bit", "-c", "/opt/libra/data/fluent-bit.conf"]
+    command: ["/fluent-bit/bin/fluent-bit", "-c", "/opt/libra/data/fluent-bit/fluent-bit.conf"]
     volumeMounts:
     - mountPath: /opt/libra/data
       name: data
@@ -106,6 +124,10 @@ spec:
     - name: CFG_FULLNODE_SEED
       value: "{cfg_fullnode_seed}"
     - name: RUST_LOG
+      value: "warn"
+    - name: STRUCT_LOG_FILE
+      value: "/opt/libra/data/events.log"
+    - name: STRUCT_LOG_LEVEL
       value: "debug"
     - name: RUST_BACKTRACE
       value: "1"

--- a/testsuite/cluster-test/src/cluster_swarm/validator_spec_template.yaml
+++ b/testsuite/cluster-test/src/cluster_swarm/validator_spec_template.yaml
@@ -35,11 +35,20 @@ spec:
       else
         libra_log_file="non_existent_file"
       fi
-      cat << EOF > /opt/libra/data/fluent-bit.conf
+      mkdir -p /opt/libra/data/fluent-bit/
+      cat << EOF > /opt/libra/data/fluent-bit/parsers.conf
+      [PARSER]
+        Name        events
+        Format      json
+        Time_Key    timestamp
+        Time_Format %Y-%m-%d %H:%M:%S
+      EOF
+      cat << EOF > /opt/libra/data/fluent-bit/fluent-bit.conf
       [SERVICE]
           Flush         5
           Log_Level     info
           Daemon        off
+          Parsers_File  /opt/libra/data/fluent-bit/parsers.conf
 
       [INPUT]
           Name              tail
@@ -48,6 +57,15 @@ spec:
           Mem_Buf_Limit     5MB
           Refresh_Interval  10
           Skip_Long_Lines   On
+
+      [INPUT]
+          Name              tail
+          Tag               validator-events
+          Path              /opt/libra/data/events.log
+          Mem_Buf_Limit     5MB
+          Refresh_Interval  10
+          Skip_Long_Lines   On
+          Parser            events
 
       [FILTER]
           Name record_modifier
@@ -79,7 +97,7 @@ spec:
   - name: fluent-bit
     image: 853397791086.dkr.ecr.us-west-2.amazonaws.com/fluent-bit:1.3.9
     imagePullPolicy: IfNotPresent
-    command: ["/fluent-bit/bin/fluent-bit", "-c", "/opt/libra/data/fluent-bit.conf"]
+    command: ["/fluent-bit/bin/fluent-bit", "-c", "/opt/libra/data/fluent-bit/fluent-bit.conf"]
     volumeMounts:
     - mountPath: /opt/libra/data
       name: data
@@ -110,6 +128,10 @@ spec:
     - name: CFG_FULLNODE_SEED
       value: "{cfg_fullnode_seed}"
     - name: RUST_LOG
+      value: "warn"
+    - name: STRUCT_LOG_FILE
+      value: "/opt/libra/data/events.log"
+    - name: STRUCT_LOG_LEVEL
       value: "debug"
     - name: RUST_BACKTRACE
       value: "1"


### PR DESCRIPTION
This diff configures fluent bit on cluster test to capture and parse structured logs from validators and full nodes

- Text logs are still collected, but their level set to WARN. We mostly keep this part to collect non-log output, such as panics, setup script messages, etc

- Structured logs are parsed with json parser

This diff also add configurability for structured logger via env variables STRUCT_LOG_FILE and STRUCT_LOG_LEVEL