### PR TITLE
[consensus] implement LeaderReputation

### DIFF
--- a/consensus/src/chained_bft/liveness/leader_reputation.rs
+++ b/consensus/src/chained_bft/liveness/leader_reputation.rs
@@ -1,0 +1,135 @@
+// Copyright (c) The Libra Core Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::chained_bft::liveness::proposer_election::{next, ProposerElection};
+use consensus_types::{
+    block::Block,
+    common::{Author, Round},
+};
+use libra_types::block_metadata::BlockMetadata;
+use serde::export::PhantomData;
+use std::{cmp::Ordering, collections::HashSet, sync::Arc};
+
+/// Interface to query committed BlockMetadata.
+pub trait MetadataBackend {
+    /// Return a window_size contiguous BlockMetadata window in which last one is at target_round or
+    /// latest committed, return all previous one if not enough.
+    fn get_block_metadata(&self, window_size: u64, target_round: Round) -> &[BlockMetadata];
+}
+
+/// Interface to calculate weights for proposers based on history.
+pub trait ReputationHeuristic {
+    /// Return the weights of all candidates based on the history.
+    fn get_weights(&self, candidates: &[Author], history: &[BlockMetadata]) -> Vec<u64>;
+}
+
+/// If candidate appear in the history, it's assigned active_weight otherwise inactive weight.
+pub struct ActiveInactiveHeuristic {
+    active_weight: u64,
+    inactive_weight: u64,
+}
+
+#[allow(dead_code)]
+impl ActiveInactiveHeuristic {
+    pub fn new(active_weight: u64, inactive_weight: u64) -> Self {
+        Self {
+            active_weight,
+            inactive_weight,
+        }
+    }
+}
+
+impl ReputationHeuristic for ActiveInactiveHeuristic {
+    fn get_weights(&self, candidates: &[Author], history: &[BlockMetadata]) -> Vec<u64> {
+        let set = history.iter().fold(HashSet::new(), |mut set, meta| {
+            set.insert(meta.proposer());
+            set.extend(meta.voters().into_iter());
+            set
+        });
+        candidates
+            .iter()
+            .map(|author| {
+                if set.contains(&author) {
+                    self.active_weight
+                } else {
+                    self.inactive_weight
+                }
+            })
+            .collect()
+    }
+}
+
+/// Committed history based proposer election implementation that could help bias towards
+/// successful leaders to help improve performance.
+pub struct LeaderReputation<T> {
+    proposers: Vec<Author>,
+    backend: Arc<dyn MetadataBackend>,
+    window_size: u64,
+    heuristic: Box<dyn ReputationHeuristic>,
+    phantom: PhantomData<T>,
+}
+
+#[allow(dead_code)]
+impl<T> LeaderReputation<T> {
+    pub fn new(
+        proposers: Vec<Author>,
+        backend: Arc<dyn MetadataBackend>,
+        window_size: u64,
+        heuristic: Box<dyn ReputationHeuristic>,
+    ) -> Self {
+        Self {
+            proposers,
+            backend,
+            window_size,
+            heuristic,
+            phantom: PhantomData,
+        }
+    }
+}
+
+impl<T> ProposerElection<T> for LeaderReputation<T> {
+    fn is_valid_proposer(&self, author: Author, round: Round) -> Option<Author> {
+        if self.get_valid_proposers(round).contains(&author) {
+            Some(author)
+        } else {
+            None
+        }
+    }
+
+    fn get_valid_proposers(&self, round: Round) -> Vec<Author> {
+        // TODO: configure the round gap
+        let sliding_window = self.backend.get_block_metadata(self.window_size, round - 4);
+        let mut weights = self.heuristic.get_weights(&self.proposers, sliding_window);
+        assert_eq!(weights.len(), self.proposers.len());
+        let mut total_weight = 0;
+        for w in &mut weights {
+            total_weight += *w;
+            *w = total_weight;
+        }
+        let mut state = round.to_le_bytes().to_vec();
+        let chosen_weight = next(&mut state) % total_weight;
+        let chosen_index = weights
+            .binary_search_by(|w| {
+                if *w <= chosen_weight {
+                    Ordering::Less
+                } else {
+                    Ordering::Greater
+                }
+            })
+            .unwrap_err();
+        vec![self.proposers[chosen_index]]
+    }
+
+    fn process_proposal(&mut self, proposal: Block<T>) -> Option<Block<T>> {
+        let author = proposal.author()?;
+        if self.get_valid_proposers(proposal.round()).contains(&author) {
+            Some(proposal)
+        } else {
+            None
+        }
+    }
+
+    fn take_backup_proposal(&mut self, _round: Round) -> Option<Block<T>> {
+        None
+    }
+}

--- a/consensus/src/chained_bft/liveness/leader_reputation_test.rs
+++ b/consensus/src/chained_bft/liveness/leader_reputation_test.rs
@@ -1,0 +1,160 @@
+// Copyright (c) The Libra Core Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::chained_bft::{
+    liveness::{
+        leader_reputation::{
+            ActiveInactiveHeuristic, LeaderReputation, MetadataBackend, ReputationHeuristic,
+        },
+        proposer_election::{next, ProposerElection},
+    },
+    test_utils::TestPayload,
+};
+use consensus_types::{
+    block::{block_test_utils::certificate_for_genesis, Block},
+    common::{Author, Round},
+};
+use libra_crypto::HashValue;
+use libra_types::{block_metadata::BlockMetadata, validator_signer::ValidatorSigner};
+use std::{collections::BTreeMap, sync::Arc};
+
+struct MockHistory {
+    data: Vec<BlockMetadata>,
+}
+
+impl MockHistory {
+    fn new(data: Vec<BlockMetadata>) -> Self {
+        Self { data }
+    }
+}
+
+impl MetadataBackend for MockHistory {
+    fn get_block_metadata(&self, window_size: u64, _target_round: Round) -> &[BlockMetadata] {
+        let start = if self.data.len() > window_size as usize {
+            self.data.len() - window_size as usize
+        } else {
+            0
+        };
+        &self.data[start..]
+    }
+}
+
+fn create_block(proposer: Author, voters: Vec<&ValidatorSigner>) -> BlockMetadata {
+    let mut votes = BTreeMap::new();
+    for v in voters {
+        votes.insert(v.author(), v.sign_message(HashValue::zero()));
+    }
+    BlockMetadata::new(HashValue::zero(), 0, votes, proposer)
+}
+
+#[test]
+fn test_simple_heuristic() {
+    let active_weight = 9;
+    let inactive_weight = 1;
+    let mut proposers = vec![];
+    let mut signers = vec![];
+    for i in 0..8 {
+        let signer = ValidatorSigner::random([i; 32]);
+        proposers.push(signer.author());
+        signers.push(signer);
+    }
+    let heuristic = ActiveInactiveHeuristic::new(active_weight, inactive_weight);
+    // 1. Window size not enough
+    let weights = heuristic.get_weights(&proposers, &[]);
+    assert_eq!(weights.len(), proposers.len());
+    for w in weights {
+        assert_eq!(w, inactive_weight);
+    }
+    // 2. Sliding window with [proposer 0, voters 1, 2], [proposer 0, voters 3]
+    let weights = heuristic.get_weights(
+        &proposers,
+        &[
+            create_block(proposers[0], vec![&signers[1], &signers[2]]),
+            create_block(proposers[0], vec![&signers[3]]),
+        ],
+    );
+    assert_eq!(weights.len(), proposers.len());
+    for (i, w) in weights.iter().enumerate() {
+        let expected = if i < 4 {
+            active_weight
+        } else {
+            inactive_weight
+        };
+        assert_eq!(*w, expected);
+    }
+}
+
+#[test]
+fn test_api() {
+    let window_size = 1;
+    let active_weight = 9;
+    let inactive_weight = 1;
+    let mut proposers = vec![];
+    let mut signers = vec![];
+    for i in 0..5 {
+        let signer = ValidatorSigner::random([i; 32]);
+        proposers.push(signer.author());
+        signers.push(signer);
+    }
+    let history = vec![
+        create_block(proposers[0], vec![&signers[1], &signers[2]]),
+        create_block(proposers[0], vec![&signers[3]]),
+    ];
+    let leader_reputation = LeaderReputation::<TestPayload>::new(
+        proposers.clone(),
+        Arc::new(MockHistory::new(history)),
+        window_size,
+        Box::new(ActiveInactiveHeuristic::new(active_weight, inactive_weight)),
+    );
+    let round = 42u64;
+    // first metadata is ignored because of window size 1
+    let expected_weights = vec![
+        active_weight,
+        inactive_weight,
+        inactive_weight,
+        active_weight,
+        inactive_weight,
+    ];
+    let sum = expected_weights.iter().fold(0, |mut s, w| {
+        s += *w;
+        s
+    });
+    let mut state = round.to_le_bytes().to_vec();
+    let chosen_weight = next(&mut state) % sum;
+    let mut expected_index = 0usize;
+    let mut accu = 0u64;
+    for (i, w) in expected_weights.iter().enumerate() {
+        accu += *w;
+        if accu >= chosen_weight {
+            expected_index = i;
+        }
+    }
+    let unexpected_index = (expected_index + 1) % proposers.len();
+    let mut proposer_election: Box<dyn ProposerElection<TestPayload>> = Box::new(leader_reputation);
+    let output = proposer_election.get_valid_proposers(round);
+    assert_eq!(output.len(), 1);
+    assert_eq!(output[0], proposers[expected_index]);
+    assert!(proposer_election
+        .is_valid_proposer(proposers[expected_index], 42)
+        .is_some());
+    assert!(proposer_election
+        .is_valid_proposer(proposers[unexpected_index], 42)
+        .is_none());
+    let good_proposal = Block::new_proposal(
+        vec![1],
+        round,
+        1,
+        certificate_for_genesis(),
+        &signers[expected_index],
+    );
+    assert!(proposer_election.process_proposal(good_proposal).is_some());
+    let bad_proposal = Block::new_proposal(
+        vec![1],
+        round,
+        1,
+        certificate_for_genesis(),
+        &signers[unexpected_index],
+    );
+    assert!(proposer_election.process_proposal(bad_proposal).is_none());
+    assert!(proposer_election.take_backup_proposal(round).is_none());
+}

--- a/consensus/src/chained_bft/liveness/mod.rs
+++ b/consensus/src/chained_bft/liveness/mod.rs
@@ -1,12 +1,15 @@
 // Copyright (c) The Libra Core Contributors
 // SPDX-License-Identifier: Apache-2.0
 
+pub(crate) mod leader_reputation;
 pub(crate) mod multi_proposer_election;
 pub(crate) mod pacemaker;
 pub(crate) mod proposal_generator;
 pub(crate) mod proposer_election;
 pub(crate) mod rotating_proposer_election;
 
+#[cfg(test)]
+mod leader_reputation_test;
 #[cfg(test)]
 mod multi_proposer_test;
 #[cfg(test)]

--- a/consensus/src/chained_bft/liveness/multi_proposer_election.rs
+++ b/consensus/src/chained_bft/liveness/multi_proposer_election.rs
@@ -1,25 +1,12 @@
 // Copyright (c) The Libra Core Contributors
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::chained_bft::liveness::proposer_election::ProposerElection;
+use crate::chained_bft::liveness::proposer_election::{next, ProposerElection};
 use consensus_types::{
     block::Block,
     common::{Author, Payload, Round},
 };
 use libra_logger::prelude::*;
-
-// next continuously mutates a state and returns a u64-index
-pub fn next(state: &mut Vec<u8>) -> u64 {
-    // state = SHA-3-256(state)
-    std::mem::replace(
-        state,
-        libra_crypto::HashValue::from_sha3_256(state).to_vec(),
-    );
-    let mut temp = [0u8; 8];
-    temp.copy_from_slice(&state[..8]);
-    // return state[0..8]
-    u64::from_le_bytes(temp)
-}
 
 /// The MultiProposer maps a round to an ordered list of authors.
 /// The primary proposer is determined by an index of hash(round) % num_proposers.

--- a/consensus/src/chained_bft/liveness/multi_proposer_test.rs
+++ b/consensus/src/chained_bft/liveness/multi_proposer_test.rs
@@ -2,8 +2,8 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::chained_bft::liveness::{
-    multi_proposer_election::{self, MultiProposer},
-    proposer_election::ProposerElection,
+    multi_proposer_election::MultiProposer,
+    proposer_election::{next, ProposerElection},
 };
 use consensus_types::block::{block_test_utils::certificate_for_genesis, Block};
 use libra_types::validator_signer::ValidatorSigner;
@@ -23,9 +23,9 @@ fn test_multi_proposer() {
     let round = 1u64;
     let mut state = epoch.to_le_bytes().to_vec();
     state.extend_from_slice(&round.to_le_bytes());
-    let primary_idx = multi_proposer_election::next(&mut state);
+    let primary_idx = next(&mut state);
     let primary_idx = (primary_idx % 8) as usize;
-    let secondary_idx = multi_proposer_election::next(&mut state);
+    let secondary_idx = next(&mut state);
     let secondary_idx = (secondary_idx % 7) as usize; // assuming no collisions in this case
 
     let primary_proposer = proposers[primary_idx];
@@ -95,7 +95,7 @@ fn test_multi_proposer_hash() {
     for round in 0..10000 {
         let mut state = epoch.to_le_bytes().to_vec();
         state.extend_from_slice(&(round as u64).to_le_bytes());
-        let idx = multi_proposer_election::next(&mut state) % (counts.len() as u64);
+        let idx = next(&mut state) % (counts.len() as u64);
         counts[idx as usize] += 1;
     }
     for c in counts {

--- a/consensus/src/chained_bft/liveness/proposer_election.rs
+++ b/consensus/src/chained_bft/liveness/proposer_election.rs
@@ -34,3 +34,16 @@ pub trait ProposerElection<T> {
     /// following take requests are going to return None.
     fn take_backup_proposal(&mut self, round: Round) -> Option<Block<T>>;
 }
+
+// next continuously mutates a state and returns a u64-index
+pub(crate) fn next(state: &mut Vec<u8>) -> u64 {
+    // state = SHA-3-256(state)
+    std::mem::replace(
+        state,
+        libra_crypto::HashValue::from_sha3_256(state).to_vec(),
+    );
+    let mut temp = [0u8; 8];
+    temp.copy_from_slice(&state[..8]);
+    // return state[0..8]
+    u64::from_le_bytes(temp)
+}

--- a/types/src/block_metadata.rs
+++ b/types/src/block_metadata.rs
@@ -55,6 +55,14 @@ impl BlockMetadata {
         let vote_maps = lcs::to_bytes(&self.previous_block_votes)?;
         Ok((id, self.timestamp_usecs, vote_maps, self.proposer))
     }
+
+    pub fn proposer(&self) -> AccountAddress {
+        self.proposer
+    }
+
+    pub fn voters(&self) -> Vec<AccountAddress> {
+        self.previous_block_votes.keys().cloned().collect()
+    }
 }
 
 pub fn new_block_event_key() -> EventKey {


### PR DESCRIPTION
<!--
Thank you for sending a PR. We appreciate you spending time to help improve the Libra project.

The project is undergoing daily changes. Pull Requests will be reviewed and responded to as time permits.
-->

## Motivation

We introduce a committed history based leader election implementation in this pr,
the heuristic is simple - if a author is active in the past a few
blocks, it gets higher chance to be elected again.

In case validators don't agree on the committed history, they'll timeout
and trigger a synchronization across board.

This PR only lays foundation of the impl without integrating with the
rest of consensus.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?

Y

## Test Plan

Added tests.

## Related PRs

(If this PR adds or changes functionality, please take some time to update the docs at https://github.com/libra/website, and link to your PR here.)
