### PR TITLE
[CLI] change CLI arg to accept base URL instead of host

### DIFF
--- a/client/cli/Cargo.toml
+++ b/client/cli/Cargo.toml
@@ -21,7 +21,7 @@ rust_decimal = "1.3.0"
 num-traits = "0.2"
 parity-multiaddr = { version = "0.7.2", default-features = false }
 rand = "0.6.5"
-reqwest = { version = "0.10.4", features = ["blocking", "json"], default-features = false }
+reqwest = { version = "0.10.4", features = ["blocking", "json", "rustls-tls"], default-features = false }
 serde = { version = "1.0.96", features = ["derive"] }
 serde_json = "1.0.48"
 structopt = "0.3.2"

--- a/client/cli/src/client_proxy.rs
+++ b/client/cli/src/client_proxy.rs
@@ -148,7 +148,10 @@ impl ClientProxy {
 
         let faucet_server = match faucet_server {
             Some(server) => server,
-            None => host.replace("client", "faucet"),
+            None => host
+                .replace("http://", "")
+                .replace("https://", "")
+                .replace("client", "faucet"),
         };
 
         let address_to_ref_id = accounts

--- a/client/cli/src/main.rs
+++ b/client/cli/src/main.rs
@@ -30,7 +30,9 @@ struct Args {
     /// JSON RPC port to connect to.
     #[structopt(short = "p", long, default_value = "8080")]
     pub port: NonZeroU16,
-    /// Host address/name to connect to.
+    /// Host address/name to connect to. Default protocol is http
+    /// To specify http protocol (e.g. https), must pass in base URL with full prefix,
+    /// and URL should not include trailing `/` or port number)
     #[structopt(short = "a", long)]
     pub host: String,
     /// Path to the generated keypair for the faucet account. The faucet account can be used to

--- a/scripts/cli/start_cli_testnet.sh
+++ b/scripts/cli/start_cli_testnet.sh
@@ -13,7 +13,7 @@ source "$HOME/.cargo/env"
 
 SCRIPT_PATH="$(dirname $0)"
 
-RUN_PARAMS="--host client.testnet.libra.org --port 80 "
+RUN_PARAMS="--host https://client.testnet.libra.org --port 443 "
 RELEASE=""
 
 while [[ ! -z "$1" ]]; do


### PR DESCRIPTION
## Summary

Changed CLI arg to accept base URL instead of host for address of node to connect to
This is to support both http connections (for local/internal usage) and https connection (for testnet)

## Test Plan

Tested on local swarm CLI (spawned by both swarm and by command line in separate process) using http
Tested https connection on devnet CLI
