### PR TITLE
[generate-format] improve tracing of Serde serialization

### DIFF
--- a/types/src/account_address.rs
+++ b/types/src/account_address.rs
@@ -215,12 +215,16 @@ impl<'de> Deserialize<'de> for AccountAddress {
     where
         D: Deserializer<'de>,
     {
+        #[derive(::serde::Deserialize)]
+        #[serde(rename = "AccountAddress")]
+        struct _Value([u8; ADDRESS_LENGTH]);
+
         if deserializer.is_human_readable() {
             let s = <&str>::deserialize(deserializer)?;
             AccountAddress::from_str(s).map_err(D::Error::custom)
         } else {
-            let b = <[u8; ADDRESS_LENGTH]>::deserialize(deserializer)?;
-            Ok(AccountAddress::new(b))
+            let value = <_Value>::deserialize(deserializer)?;
+            Ok(AccountAddress::new(value.0))
         }
     }
 }
@@ -233,7 +237,7 @@ impl Serialize for AccountAddress {
         if serializer.is_human_readable() {
             self.to_string().serialize(serializer)
         } else {
-            self.0.serialize(serializer)
+            serializer.serialize_newtype_struct("AccountAddress", &self.0)
         }
     }
 }


### PR DESCRIPTION
## Motivation

We now have a tool to trace Serde (de)serialization and extract formats (#2867).

This PR makes our handwritten (de)serializers follow the Serde data model more closely, making sure to report the name of containers before serializing a payload.

This makes no difference for LCS but greatly improves the output of `generate-format`.

* Before
```
BlockMetadata:
  STRUCT:
    - id: BYTES
    - timestamp_usecs: U64
    - previous_block_votes:
        MAP:
          KEY:
            TUPLEARRAY:
              CONTENT: U8
              SIZE: 16
          VALUE: BYTES
    - proposer:
        TUPLEARRAY:
          CONTENT: U8
          SIZE: 16
```
* After
```
BlockMetadata:
  STRUCT:
    - id:
        TYPENAME: HashValue
    - timestamp_usecs: U64
    - previous_block_votes:
        MAP:
          KEY:
            TYPENAME: AccountAddress
          VALUE:
            TYPENAME: Ed25519Signature
    - proposer:
        TYPENAME: AccountAddress
```

Note that the problem of serializing `HashValue` as a fixed size array rather than bytes is a separate issue (#1307).

## Test Plan
```
cargo x test -p libra-types
cargo run -p generate-format
```

Also tested with #3008 (DRAFT)