### PR TITLE
[generate-format] improve tracing of Serde serialization

### DIFF
--- a/crypto/crypto-derive/src/lib.rs
+++ b/crypto/crypto-derive/src/lib.rs
@@ -145,6 +145,7 @@ pub fn silent_debug(source: TokenStream) -> TokenStream {
 pub fn deserialize_key(source: TokenStream) -> TokenStream {
     let ast: DeriveInput = syn::parse(source).expect("Incorrect macro input");
     let name = &ast.ident;
+    let name_string = name.to_string();
     let gen = quote! {
         impl<'de> ::serde::Deserialize<'de> for #name {
             fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
@@ -152,12 +153,21 @@ pub fn deserialize_key(source: TokenStream) -> TokenStream {
                 D: ::serde::Deserializer<'de>,
             {
                 if deserializer.is_human_readable() {
-                    let encoded_key: &str = ::serde::Deserialize::deserialize(deserializer)?;
+                    let encoded_key = <&str>::deserialize(deserializer)?;
                     ValidKeyStringExt::from_encoded_string(encoded_key)
                         .map_err(<D::Error as ::serde::de::Error>::custom)
                 } else {
-                    let b = <&[u8]>::deserialize(deserializer)?;
-                    #name::try_from(b).map_err(<D::Error as ::serde::de::Error>::custom)
+                    // In order to preserve the Serde data model and help analysis tools,
+                    // make sure to wrap our value in a container with the same name
+                    // as the original type.
+                    #[derive(::serde::Deserialize)]
+                    #[serde(rename = #name_string)]
+                    struct Value<'a>(&'a[u8]);
+
+                    let value = Value::deserialize(deserializer)?;
+                    #name::try_from(value.0).map_err(|s| {
+                        <D::Error as ::serde::de::Error>::custom(format!("{} with {}", s, #name_string))
+                    })
                 }
             }
         }
@@ -170,6 +180,7 @@ pub fn deserialize_key(source: TokenStream) -> TokenStream {
 pub fn serialize_key(source: TokenStream) -> TokenStream {
     let ast: DeriveInput = syn::parse(source).expect("Incorrect macro input");
     let name = &ast.ident;
+    let name_string = name.to_string();
     let gen = quote! {
         impl ::serde::Serialize for #name {
             fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
@@ -181,7 +192,8 @@ pub fn serialize_key(source: TokenStream) -> TokenStream {
                         .map_err(<S::Error as ::serde::ser::Error>::custom)
                         .and_then(|str| serializer.serialize_str(&str[..]))
                 } else {
-                    serializer.serialize_bytes(&ValidKey::to_bytes(self))
+                    // See comment in deserialize_key.
+                    serializer.serialize_newtype_struct(#name_string, &ValidKey::to_bytes(self))
                 }
             }
         }


### PR DESCRIPTION
## Motivation

We now have a tool to trace Serde (de)serialization and extract formats (#2867).

This PR makes our handwritten (de)serializers follow the Serde data model more closely, making sure to report Rust containers (e.g. `HashValue`) before serializing their content (e.g. as bytes).

This makes no difference for LCS but greatly improves the output of `generate-format`.

* Before
```
BlockMetadata:
  STRUCT:
    - id: BYTES
    - timestamp_usecs: U64
    - previous_block_votes:
        MAP:
          KEY:
            TUPLEARRAY:
              CONTENT: U8
              SIZE: 16
          VALUE: BYTES
    - proposer:
        TUPLEARRAY:
          CONTENT: U8
          SIZE: 16
```
* After
```
BlockMetadata:
  STRUCT:
    - id:
        TYPENAME: HashValue
    - timestamp_usecs: U64
    - previous_block_votes:
        MAP:
          KEY:
            TYPENAME: AccountAddress
          VALUE:
            TYPENAME: Ed25519Signature
    - proposer:
        TYPENAME: AccountAddress
...
HashValue:
  NEWTYPESTRUCT:
    SEQ: U8
```

Incidentally, I switched `HashValue` from `Bytes` to a sequence `[u8]`. This is the same representation in LCS anyway.

Note that the problem of serializing `HashValue` as a fixed size array rather than a sequence is a separate issue (#1307).

## Test Plan
```
cargo x test -p libra-types
cargo run -p generate-format
```

Also tested with #3008 (DRAFT)