### PR TITLE
[secure-storage] Add namespace ability to vault

### DIFF
--- a/config/config-builder/src/main.rs
+++ b/config/config-builder/src/main.rs
@@ -151,6 +151,9 @@ struct ValidatorCommonArgs {
     /// Specifies the token for secure storages that use credentials
     #[structopt(long)]
     safety_rules_token: Option<String>,
+    /// Specifies a unique namespace for the secure storage
+    #[structopt(long)]
+    safety_rules_namespace: Option<String>,
     #[structopt(short = "s", long)]
     /// Use the provided seed for generating keys for each of the validators
     seed: Option<String>,
@@ -266,19 +269,7 @@ fn build_safety_rules(args: SafetyRulesArgs) {
         return;
     }
 
-    let mut config_builder = ValidatorConfig::new();
-    config_builder
-        .index(args.validator_common.index)
-        .nodes(args.validator_common.nodes)
-        .safety_rules_addr(args.validator_common.safety_rules_addr)
-        .safety_rules_backend(args.validator_common.safety_rules_backend)
-        .safety_rules_host(args.validator_common.safety_rules_host)
-        .safety_rules_token(args.validator_common.safety_rules_token);
-
-    if let Some(seed) = args.validator_common.seed.as_ref() {
-        config_builder.seed(parse_seed(seed));
-    }
-
+    let config_builder = safety_rules_common(&args.validator_common);
     let mut node_config = config_builder.build().expect("ConfigBuilder failed");
     node_config.set_data_dir(args.validator_common.data_dir);
     save_config(node_config, &args.validator_common.output_dir);
@@ -290,7 +281,7 @@ fn build_validator(args: ValidatorArgs) {
         return;
     }
 
-    let mut config_builder = ValidatorConfig::new();
+    let mut config_builder = safety_rules_common(&args.validator_common);
     config_builder
         .advertised(args.advertised)
         .bootstrap(args.bootstrap)
@@ -301,6 +292,7 @@ fn build_validator(args: ValidatorArgs) {
         .safety_rules_addr(args.validator_common.safety_rules_addr)
         .safety_rules_backend(args.validator_common.safety_rules_backend)
         .safety_rules_host(args.validator_common.safety_rules_host)
+        .safety_rules_namespace(args.validator_common.safety_rules_namespace)
         .safety_rules_token(args.validator_common.safety_rules_token)
         .template(load_template(args.template));
 
@@ -311,6 +303,25 @@ fn build_validator(args: ValidatorArgs) {
     let mut node_config = config_builder.build().expect("ConfigBuilder failed");
     node_config.set_data_dir(args.validator_common.data_dir);
     save_config(node_config, &args.validator_common.output_dir);
+}
+
+fn safety_rules_common(args: &ValidatorCommonArgs) -> ValidatorConfig {
+    let mut config_builder = ValidatorConfig::new();
+
+    config_builder
+        .index(args.index)
+        .nodes(args.nodes)
+        .safety_rules_addr(args.safety_rules_addr.clone())
+        .safety_rules_backend(args.safety_rules_backend.clone())
+        .safety_rules_host(args.safety_rules_host.clone())
+        .safety_rules_namespace(args.safety_rules_namespace.clone())
+        .safety_rules_token(args.safety_rules_token.clone());
+
+    if let Some(seed) = args.seed.as_ref() {
+        config_builder.seed(parse_seed(seed));
+    }
+
+    config_builder
 }
 
 fn node_config_exists(output_dir: &PathBuf) -> bool {

--- a/config/config-builder/src/validator_config.rs
+++ b/config/config-builder/src/validator_config.rs
@@ -30,6 +30,7 @@ pub struct ValidatorConfig {
     safety_rules_addr: Option<SocketAddr>,
     safety_rules_backend: Option<String>,
     safety_rules_host: Option<String>,
+    safety_rules_namespace: Option<String>,
     safety_rules_token: Option<String>,
     seed: [u8; 32],
     template: NodeConfig,
@@ -47,6 +48,7 @@ impl Default for ValidatorConfig {
             safety_rules_addr: None,
             safety_rules_backend: None,
             safety_rules_host: None,
+            safety_rules_namespace: None,
             safety_rules_token: None,
             seed: DEFAULT_SEED,
             template: NodeConfig::default(),
@@ -101,6 +103,11 @@ impl ValidatorConfig {
 
     pub fn safety_rules_host(&mut self, safety_rules_host: Option<String>) -> &mut Self {
         self.safety_rules_host = safety_rules_host;
+        self
+    }
+
+    pub fn safety_rules_namespace(&mut self, safety_rules_namespace: Option<String>) -> &mut Self {
+        self.safety_rules_namespace = safety_rules_namespace;
         self
     }
 
@@ -227,6 +234,7 @@ impl ValidatorConfig {
                 "on-disk" => safety_rules_config.backend.clone(),
                 "vault" => SafetyRulesBackend::Vault(VaultConfig {
                     default: true,
+                    namespace: self.safety_rules_namespace.clone(),
                     server: self
                         .safety_rules_host
                         .as_ref()

--- a/config/src/config/safety_rules_config.rs
+++ b/config/src/config/safety_rules_config.rs
@@ -77,6 +77,10 @@ pub struct VaultConfig {
     /// In testing scenarios this will install baseline data if it is not specified. Note: this can
     /// only be used if the token provided has root or sudo access.
     pub default: bool,
+    /// A namespace is an optional portion of the path to a key stored within Vault. For example,
+    /// a secret, S, without a namespace would be available in secret/data/S, with a namespace, N, it
+    /// would be in secret/data/N/S.
+    pub namespace: Option<String>,
     /// Vault's URL, note: only HTTP is currently supported.
     pub server: String,
     /// The authorization token for access secrets

--- a/consensus/safety-rules/benches/safety_rules.rs
+++ b/consensus/safety-rules/benches/safety_rules.rs
@@ -55,7 +55,7 @@ fn lsr(mut safety_rules: Box<dyn TSafetyRules<Vec<u8>>>, signer: ValidatorSigner
 fn in_memory(n: u64) {
     let signer = ValidatorSigner::from_int(0);
     let storage = PersistentSafetyStorage::initialize(
-        InMemoryStorage::new_boxed_in_memory_storage(),
+        InMemoryStorage::new_storage(),
         signer.private_key().clone(),
     );
     let safety_rules_manager = SafetyRulesManager::new_local(signer.author(), storage);
@@ -66,7 +66,7 @@ fn on_disk(n: u64) {
     let signer = ValidatorSigner::from_int(0);
     let file_path = NamedTempFile::new().unwrap().into_temp_path().to_path_buf();
     let storage = PersistentSafetyStorage::initialize(
-        OnDiskStorage::new_boxed_on_disk_storage(file_path),
+        OnDiskStorage::new_storage(file_path),
         signer.private_key().clone(),
     );
     let safety_rules_manager = SafetyRulesManager::new_local(signer.author(), storage);
@@ -77,7 +77,7 @@ fn serializer(n: u64) {
     let signer = ValidatorSigner::from_int(0);
     let file_path = NamedTempFile::new().unwrap().into_temp_path().to_path_buf();
     let storage = PersistentSafetyStorage::initialize(
-        OnDiskStorage::new_boxed_on_disk_storage(file_path),
+        OnDiskStorage::new_storage(file_path),
         signer.private_key().clone(),
     );
     let safety_rules_manager = SafetyRulesManager::new_serializer(signer.author(), storage);
@@ -88,7 +88,7 @@ fn thread(n: u64) {
     let signer = ValidatorSigner::from_int(0);
     let file_path = NamedTempFile::new().unwrap().into_temp_path().to_path_buf();
     let storage = PersistentSafetyStorage::initialize(
-        OnDiskStorage::new_boxed_on_disk_storage(file_path),
+        OnDiskStorage::new_storage(file_path),
         signer.private_key().clone(),
     );
     let safety_rules_manager = SafetyRulesManager::new_thread(signer.author(), storage);

--- a/consensus/safety-rules/src/persistent_safety_storage.rs
+++ b/consensus/safety-rules/src/persistent_safety_storage.rs
@@ -22,7 +22,7 @@ const PREFERRED_ROUND: &str = "preferred_round";
 
 impl PersistentSafetyStorage {
     pub fn in_memory(private_key: Ed25519PrivateKey) -> Self {
-        let storage = InMemoryStorage::new_boxed_in_memory_storage();
+        let storage = InMemoryStorage::new_storage();
         Self::initialize(storage, private_key)
     }
 
@@ -114,7 +114,7 @@ mod tests {
     #[test]
     fn test() {
         let private_key = ValidatorSigner::from_int(0).private_key().clone();
-        let internal = InMemoryStorage::new_boxed_in_memory_storage();
+        let internal = InMemoryStorage::new_storage();
         let mut storage = PersistentSafetyStorage::initialize(internal, private_key);
         assert_eq!(storage.epoch().unwrap(), 1);
         assert_eq!(storage.last_voted_round().unwrap(), 0);

--- a/consensus/safety-rules/src/safety_rules_manager.rs
+++ b/consensus/safety-rules/src/safety_rules_manager.rs
@@ -28,16 +28,17 @@ pub fn extract_service_inputs(config: &mut NodeConfig) -> (Author, PersistentSaf
 
     let backend = &config.consensus.safety_rules.backend;
     let (initialize, internal_storage): (bool, Box<dyn Storage>) = match backend {
-        SafetyRulesBackend::InMemoryStorage => {
-            (true, InMemoryStorage::new_boxed_in_memory_storage())
+        SafetyRulesBackend::InMemoryStorage => (true, InMemoryStorage::new_storage()),
+        SafetyRulesBackend::OnDiskStorage(config) => {
+            (config.default, OnDiskStorage::new_storage(config.path()))
         }
-        SafetyRulesBackend::OnDiskStorage(config) => (
-            config.default,
-            OnDiskStorage::new_boxed_on_disk_storage(config.path()),
-        ),
         SafetyRulesBackend::Vault(config) => (
             config.default,
-            VaultStorage::new_boxed_vault_storage(config.server.clone(), config.token.clone()),
+            VaultStorage::new_storage(
+                config.server.clone(),
+                config.token.clone(),
+                config.namespace.clone(),
+            ),
         ),
     };
 

--- a/consensus/safety-rules/src/tests/vault.rs
+++ b/consensus/safety-rules/src/tests/vault.rs
@@ -19,11 +19,10 @@ fn safety_rules<T: Payload>() -> (Box<dyn TSafetyRules<T>>, ValidatorSigner) {
     let signer = ValidatorSigner::from_int(0);
     let host = "http://localhost:8200".to_string();
     let token = "root_token".to_string();
+    let mut storage = VaultStorage::new_storage(host, token, None);
+    storage.reset_and_clear().unwrap();
 
-    let storage = PersistentSafetyStorage::initialize(
-        VaultStorage::new_boxed_vault_storage(host, token),
-        signer.private_key().clone(),
-    );
+    let storage = PersistentSafetyStorage::initialize(storage, signer.private_key().clone());
     let safety_rules_manager = SafetyRulesManager::new_local(signer.author(), storage);
     let safety_rules = safety_rules_manager.client();
     (safety_rules, signer)

--- a/secure/storage/src/in_memory.rs
+++ b/secure/storage/src/in_memory.rs
@@ -25,7 +25,7 @@ impl InMemoryStorage {
     }
 
     /// Public convenience function to return a new InMemoryStorage based Storage.
-    pub fn new_boxed_in_memory_storage() -> Box<dyn Storage> {
+    pub fn new_storage() -> Box<dyn Storage> {
         Box::new(InMemoryStorage::new())
     }
 }
@@ -71,7 +71,6 @@ impl KVStorage for InMemoryStorage {
         Ok(())
     }
 
-    #[cfg(test)]
     fn reset_and_clear(&mut self) -> Result<(), Error> {
         self.data.clear();
         Ok(())

--- a/secure/storage/src/kv_storage.rs
+++ b/secure/storage/src/kv_storage.rs
@@ -36,9 +36,9 @@ pub trait KVStorage: Send + Sync {
     /// Sets a value in storage and fails if invalid permissions or it does not exist
     fn set(&mut self, key: &str, value: Value) -> Result<(), Error>;
 
+    // @TODO(davidiw): Make this accessible only to tests.
     /// Resets and clears all data held in the storage engine.
     /// Note: this should only be exposed and used for testing. Resetting the storage engine is not
     /// something that should be supported in production.
-    #[cfg(test)]
     fn reset_and_clear(&mut self) -> Result<(), Error>;
 }

--- a/secure/storage/src/on_disk.rs
+++ b/secure/storage/src/on_disk.rs
@@ -59,7 +59,7 @@ impl OnDiskStorage {
     }
 
     /// Public convenience function to return a new OnDiskStorage based Storage.
-    pub fn new_boxed_on_disk_storage(path_buf: PathBuf) -> Box<dyn Storage> {
+    pub fn new_storage(path_buf: PathBuf) -> Box<dyn Storage> {
         Box::new(OnDiskStorage::new(path_buf))
     }
 }
@@ -93,7 +93,6 @@ impl KVStorage for OnDiskStorage {
         self.write(&data)
     }
 
-    #[cfg(test)]
     fn reset_and_clear(&mut self) -> Result<(), Error> {
         self.write(&HashMap::new())
     }

--- a/secure/storage/src/tests/in_memory.rs
+++ b/secure/storage/src/tests/in_memory.rs
@@ -5,6 +5,6 @@ use crate::{tests::suite, InMemoryStorage};
 
 #[test]
 fn in_memory() {
-    let mut storage = InMemoryStorage::new_boxed_in_memory_storage();
+    let mut storage = InMemoryStorage::new_storage();
     suite::execute_all_storage_tests(storage.as_mut());
 }

--- a/secure/storage/src/tests/on_disk.rs
+++ b/secure/storage/src/tests/on_disk.rs
@@ -7,6 +7,6 @@ use libra_temppath::TempPath;
 #[test]
 fn on_disk() {
     let path_buf = TempPath::new().path().to_path_buf();
-    let mut storage = OnDiskStorage::new_boxed_on_disk_storage(path_buf);
+    let mut storage = OnDiskStorage::new_storage(path_buf);
     suite::execute_all_storage_tests(storage.as_mut());
 }

--- a/secure/storage/src/vault.rs
+++ b/secure/storage/src/vault.rs
@@ -19,19 +19,11 @@ pub struct VaultStorage {
 }
 
 impl VaultStorage {
-    pub fn new(host: String, token: String) -> Self {
+    pub fn new(host: String, token: String, namespace: Option<String>) -> Self {
         Self {
             client: Client::new(host, token),
-            namespace: None,
+            namespace,
         }
-    }
-
-    /// A namespace is an optional portion of the path to a key stored within Vault. For example,
-    /// a secret, S, without a namespace would be available in secret/data/S, with a namespace, N, it
-    /// would be in secret/data/N/S.
-    pub fn set_namespace(mut self, namespace: Option<String>) -> Self {
-        self.namespace = namespace;
-        self
     }
 
     pub fn namespace(&self) -> Option<String> {
@@ -127,8 +119,8 @@ impl VaultStorage {
     }
 
     /// Public convenience function to return a new Vault based Storage.
-    pub fn new_boxed_vault_storage(host: String, token: String) -> Box<dyn Storage> {
-        Box::new(VaultStorage::new(host, token))
+    pub fn new_storage(host: String, token: String, namespace: Option<String>) -> Box<dyn Storage> {
+        Box::new(VaultStorage::new(host, token, namespace))
     }
 }
 
@@ -169,7 +161,6 @@ impl KVStorage for VaultStorage {
         Ok(())
     }
 
-    #[cfg(test)]
     fn reset_and_clear(&mut self) -> Result<(), Error> {
         self.reset()
     }

--- a/secure/storage/src/vault.rs
+++ b/secure/storage/src/vault.rs
@@ -14,7 +14,7 @@ use libra_vault_client::{self as vault, Client};
 /// calls pointers to data keys, Vault has actually a secret that contains multiple key value
 /// pairs.
 pub struct VaultStorage {
-    pub client: Client,
+    pub(crate) client: Client,
 }
 
 impl VaultStorage {


### PR DESCRIPTION
This allows multiple frameworks to use vault with the same common names but under different namespaces, think of 10 instances of safety rules all accessing their preferred_round but instead of reading and writing to /preferred_round, they do it to nX/preferred_round

Wonderful...

This also adds in the configuration to config-builder

Closes: https://github.com/libra/libra/issues/2803