### PR TITLE
[CI] move consensus out of the unit test executions in to it's own runner

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -95,7 +95,7 @@ commands:
 jobs:
   build:
     executor: build-executor
-    parallelism: 4
+    parallelism: 5
     steps:
       - build_setup
       - run:
@@ -104,38 +104,42 @@ jobs:
       - run:
           name: Linting
           command: |
-            [[ $CIRCLE_NODE_INDEX =~ [123] ]] || cargo x lint
-            [[ $CIRCLE_NODE_INDEX =~ [123] ]] || cargo xclippy --workspace --all-targets
-            [[ $CIRCLE_NODE_INDEX =~ [123] ]] || cargo xfmt --check
-            [[ $CIRCLE_NODE_INDEX =~ [123] ]] || cargo install cargo-guppy --git http://github.com/calibra/cargo-guppy --rev aa68df82cc3104d72dfb917d3757abc18116d922
-            [[ $CIRCLE_NODE_INDEX =~ [123] ]] || [[ -z $(cargo guppy dups --target x86_64-unknown-linux-gnu --kind directthirdparty) ]]
+            [[ $CIRCLE_NODE_INDEX =~ [1234] ]] || cargo x lint
+            [[ $CIRCLE_NODE_INDEX =~ [1234] ]] || cargo xclippy --workspace --all-targets
+            [[ $CIRCLE_NODE_INDEX =~ [1234] ]] || cargo xfmt --check
+            [[ $CIRCLE_NODE_INDEX =~ [1234] ]] || cargo install cargo-guppy --git http://github.com/calibra/cargo-guppy --rev aa68df82cc3104d72dfb917d3757abc18116d922
+            [[ $CIRCLE_NODE_INDEX =~ [1234] ]] || [[ -z $(cargo guppy dups --target x86_64-unknown-linux-gnu --kind directthirdparty) ]]
       - run:
           name: Build Release
           command: |
-            [[ $CIRCLE_NODE_INDEX =~ [023] ]] || RUST_BACKTRACE=1 cargo build -j 16 --release
+            [[ $CIRCLE_NODE_INDEX =~ [0234] ]] || RUST_BACKTRACE=1 cargo build -j 16 --release
       - run:
           name: Build Dev
           command: |
-            [[ $CIRCLE_NODE_INDEX =~ [012] ]] || RUST_BACKTRACE=1 cargo build -j 16
-            [[ $CIRCLE_NODE_INDEX =~ [012] ]] || RUST_BACKTRACE=1 cargo build -j 16 -p libra-swarm
-            [[ $CIRCLE_NODE_INDEX =~ [012] ]] || RUST_BACKTRACE=1 cargo build -j 16 -p cluster-test
-            [[ $CIRCLE_NODE_INDEX =~ [012] ]] || RUST_BACKTRACE=1 cargo build -j 16 -p libra-fuzzer
-            [[ $CIRCLE_NODE_INDEX =~ [012] ]] || RUST_BACKTRACE=1 cargo build -j 16 -p language_benchmarks
-            [[ $CIRCLE_NODE_INDEX =~ [012] ]] || RUST_BACKTRACE=1 cargo build -j 16 -p bytecode-to-boogie
-            [[ $CIRCLE_NODE_INDEX =~ [012] ]] || RUST_BACKTRACE=1 cargo build -j 16 -p cost-synthesis
-            [[ $CIRCLE_NODE_INDEX =~ [012] ]] || RUST_BACKTRACE=1 cargo build -j 16 -p test-generation
+            [[ $CIRCLE_NODE_INDEX =~ [0124] ]] || RUST_BACKTRACE=1 cargo build -j 16
+            [[ $CIRCLE_NODE_INDEX =~ [0124] ]] || RUST_BACKTRACE=1 cargo build -j 16 -p libra-swarm
+            [[ $CIRCLE_NODE_INDEX =~ [0124] ]] || RUST_BACKTRACE=1 cargo build -j 16 -p cluster-test
+            [[ $CIRCLE_NODE_INDEX =~ [0124] ]] || RUST_BACKTRACE=1 cargo build -j 16 -p libra-fuzzer
+            [[ $CIRCLE_NODE_INDEX =~ [0124] ]] || RUST_BACKTRACE=1 cargo build -j 16 -p language_benchmarks
+            [[ $CIRCLE_NODE_INDEX =~ [0124] ]] || RUST_BACKTRACE=1 cargo build -j 16 -p bytecode-to-boogie
+            [[ $CIRCLE_NODE_INDEX =~ [0124] ]] || RUST_BACKTRACE=1 cargo build -j 16 -p cost-synthesis
+            [[ $CIRCLE_NODE_INDEX =~ [0124] ]] || RUST_BACKTRACE=1 cargo build -j 16 -p test-generation
       - run:
-          name: Run All Unit Tests
+          name: Run All Non Flaky Unit Tests
           command: |
-            [[ $CIRCLE_NODE_INDEX =~ [013] ]] || RUST_BACKTRACE=1 $CI_TIMEOUT cargo x test --unit
+            [[ $CIRCLE_NODE_INDEX =~ [0134] ]] || RUST_BACKTRACE=1 $CI_TIMEOUT cargo test --all-features --workspace --exclude libra-node --exclude libra-crypto --exclude testsuite --exclude consensus
       - run:
           name: Run Cryptography Unit Tests with the formally verified backend
           command: |
-            [[ $CIRCLE_NODE_INDEX =~ [013] ]] || ( RUST_BACKTRACE=1 cd crypto/crypto && $CI_TIMEOUT cargo test --features='std fiat_u64_backend fuzzing' --no-default-features )
+            [[ $CIRCLE_NODE_INDEX =~ [0134] ]] || ( RUST_BACKTRACE=1 cd crypto/crypto && $CI_TIMEOUT cargo test --features='std fiat_u64_backend fuzzing' --no-default-features )
       - run:
           name: Run All End to End Tests
           command: |
-            [[ $CIRCLE_NODE_INDEX =~ [012] ]] || RUST_BACKTRACE=1 $CI_TIMEOUT cargo x test --package testsuite -- --test-threads 1
+            [[ $CIRCLE_NODE_INDEX =~ [0124] ]] || RUST_BACKTRACE=1 $CI_TIMEOUT cargo x test --package testsuite -- --test-threads 1
+      - run:
+          name: Run Quarantined Unit Tests 3 (consensus) times
+          command: |
+            [[ $CIRCLE_NODE_INDEX =~ [0123] ]] || timeout 20m ./scripts/run_quarantined.sh -c consensus -r 3 -f
       - build_teardown
   validate-cluster-test-dockerfile:
     description: Validate that committed docker files for cluster test are up to date

--- a/scripts/run_quarantined.sh
+++ b/scripts/run_quarantined.sh
@@ -1,0 +1,54 @@
+#!/bin/bash
+# Copyright (c) The Libra Core Contributors
+# SPDX-License-Identifier: Apache-2.0
+
+crate=
+retries=
+shouldfail=false
+
+usage() {
+  echo -r number of times to retry
+  echo -f fail of the script does not succeed at least once
+  echo -c crates to run
+}
+
+while getopts 'fr:c:' OPTION; do
+  case "$OPTION" in
+    f)
+      shouldfail=true
+      ;;
+    r)
+      retries=$OPTARG
+      ;;
+    c)
+      crate="$OPTARG"
+      ;;
+    ?)
+      usage
+      exit 1
+      ;;
+  esac
+done
+
+if ! [[ "$retries" =~ ^[0-9]+$ ]]; then usage; exit 1; fi
+
+if [ -z "$crate" ]; then usage; exti 1; fi
+
+if [[ "$shouldfail" == false ]]; then echo command will never fail; fi
+
+count=0
+success=-1
+RUST_BACKTRACE=1
+while [ $count -lt $retries ] && [ $success -ne 0 ]
+do
+  cargo xtest --package $crate && success=0
+  count=$(( $count + 1 ))
+done
+
+if [ "$success" -eq "0" ] || [ "$shouldfail" == false ]; then
+   echo Crates: $crate succeeded after $count executions.
+   exit 0;
+else
+   echo Crates: $crate failed after $count executions.
+   exit 1;
+fi


### PR DESCRIPTION
<!--
Thank you for sending a PR. We appreciate you spending time to help improve the Libra project.

The project is undergoing daily changes. Pull Requests will be reviewed and responded to as time permits.
-->

## Motivation

Move flaky tests out of the way -- run them in their own basket 3 times.   Right now just consensus.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?

yes

## Test Plan

tested cargo test commands locally. 
Now watching CI's behavior.

## Related PRs

None