### PR TITLE
[github config] Use Rust syntax highlighting for Move

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -10,3 +10,7 @@
 *.toml text
 *.txt text
 *.yml text
+
+# Use Rust syntax highlighter for Move and Move IR code
+*.move linguist-language=Rust
+*.mvir linguist-language=Rust


### PR DESCRIPTION
We haven't built Linguist syntax highlighting for Move yet. Using Rust syntax highlighting will be more readable than no highlighting at all.

<!--
Thank you for sending a PR. We appreciate you spending time to help improve the Libra project.

The project is undergoing daily changes. Pull Requests will be reviewed and responded to as time permits.
-->

## Motivation

Making it easier to review/browse Move code.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?

Y

## Test Plan

I don't know how to test this without committing it, but would be more than open to suggestions