### PR TITLE
[fuzzing] fix README and add instructions for reproducing bugs

### DIFF
--- a/testsuite/libra-fuzzer/README.md
+++ b/testsuite/libra-fuzzer/README.md
@@ -1,7 +1,7 @@
 ## Fuzzing support for Libra
 
-This crate contains support for fuzzing Libra targets. This support
-includes:
+This crate contains support for fuzzing Libra targets. This support sincludes:
+
 * corpus generation with `proptest`
 * automatically running failing examples with `cargo test`
 
@@ -11,8 +11,7 @@ Install [`cargo-fuzz`](https://rust-fuzz.github.io/book/cargo-fuzz.html) if not 
 
 ### Fuzzing a target
 
-First, switch to the directory this README is in: `cd
-testsuite/libra_fuzzer`.
+First, switch to the directory this README is in: `cd testsuite/libra_fuzzer`.
 
 To list out known fuzz targets, run `cargo run --bin libra-fuzzer list`.
 
@@ -57,6 +56,31 @@ Once the deserializer has been fixed, check the artifact into the
 `artifacts/<target>/` directory. The artifact will then act as a
 regression test in `cargo test` runs.
 
+There are two ways to reproduce an issue to investigate a finding:
+
+1. run the harness test (the code the fuzzer runs) directly
+2. run the fuzzer code
+
+The following command (with your own artifact contained in a similar path)
+will run the harness test with your input:
+
+```
+cargo run --bin investigate -- -i artifacts/compiled_module/crash-5d7f403f
+```
+
+The following command will run libfuzzer on the relevant target with your input:
+
+```
+// build single fuzzer for target using instruction in the 'google oss-fuzz integration' section
+./fuzzer input
+```
+
+Note that this should work out of the box for crashes,
+but timeouts might need a `-timeout 25` argument to libfuzzer,
+and out of memory might need a `-rss_limit_mb=2560` argumnent to libfuzzer.
+
+See [Google OSS-Fuzz's documentation on reproducing bugs](https://google.github.io/oss-fuzz/advanced-topics/reproducing/) as well.
+
 ### Fuzzing Coverage
 
 To test coverage of our fuzzers you can run the following command with [tarpaulin](https://crates.io/crates/cargo-tarpaulin):
@@ -64,17 +88,6 @@ To test coverage of our fuzzers you can run the following command with [tarpauli
 ```
 CORPUS_PATH=fuzz/corpus cargo tarpaulin -p libra-fuzzer -- coverage
 ```
-### Investigating an artifact
-
-Running the following command (with your own artifact contained in a similar path)
-will run the fuzzer with your input.
-
-```
-cargo run --bin investigate -- -i artifacts/compiled_module/crash-5d7f403f
-```
-
-This is helpful to investigate and debug a binary in order to find the root cause
-of a bug.
 
 ### Google OSS-Fuzz Integration
 
@@ -84,7 +97,7 @@ For this, build.rs can create a fuzzer binary based on an environement variable.
 Use it as such:
 
 ```sh
-FUZZ_TARGET="consensus_proposal" cargo build --manifest-path fuzz/Cargo.toml --bin fuzzer_builder
+SINGLE_FUZZ_TARGET="consensus_proposal" cargo build --manifest-path fuzz/Cargo.toml --bin fuzzer_builder
 ```
 
 Note that you might want to add more flags [[1]](https://github.com/rust-fuzz/cargo-fuzz/blob/2243de096b15b79b719ce7489f014d7d8ce197ee/src/project.rs#L153)[[2]](https://github.com/rust-fuzz/cargo-fuzz/blob/2243de096b15b79b719ce7489f014d7d8ce197ee/src/project.rs#L174).
@@ -93,7 +106,7 @@ For example for MacOS:
 
 ```sh
 cd fuzz
-ASAN_OPTIONS=detect_odr_violation=0 RUSTC_BOOTSTRAP=1 RUSTFLAGS="--cfg fuzzing -Cpasses=sancov -Cllvm-args=-sanitizer-coverage-level=4 -Cllvm-args=-sanitizer-coverage-trace-compares -Cllvm-args=-sanitizer-coverage-inline-8bit-counters -Cllvm-args=-sanitizer-coverage-trace-geps -Cllvm-args=-sanitizer-coverage-prune-blocks=0 -Cllvm-args=-sanitizer-coverage-pc-table -Clink-dead-code -Zsanitizer=address -Cdebug-assertions" FUZZ_TARGET="vm_value" cargo build --verbose --target x86_64-apple-darwin --bin fuzzer_builder
+SINGLE_FUZZ_TARGET="consensus_proposal" RUSTC_BOOTSTRAP=1 RUSTFLAGS="--cfg fuzzing -Cpasses=sancov -Cllvm-args=-sanitizer-coverage-level=4 -Cllvm-args=-sanitizer-coverage-trace-compares -Cllvm-args=-sanitizer-coverage-inline-8bit-counters -Cllvm-args=-sanitizer-coverage-trace-geps -Cllvm-args=-sanitizer-coverage-prune-blocks=0 -Cllvm-args=-sanitizer-coverage-pc-table -Clink-dead-code -Zsanitizer=address -Cdebug-assertions" FUZZ_TARGET="vm_value" cargo build --verbose --target x86_64-apple-darwin --bin fuzzer_builder
 ```
 
 ### Troubleshooting
@@ -101,3 +114,7 @@ ASAN_OPTIONS=detect_odr_violation=0 RUSTC_BOOTSTRAP=1 RUSTFLAGS="--cfg fuzzing -
 #### linking with CC failed
 
 Are you on MacOS? Have you checked that Xcode is up-to-date?
+
+#### My backtrace does not contain file names and line numbers
+
+You need to use llvm-symbolizer, see https://github.com/rust-fuzz/cargo-fuzz/issues/160


### PR DESCRIPTION
- Fixing the README to build single fuzzer (we changed the env var required for this step)
- add one more step to reproducing bugs and link to google-oss fuzz doc
