### PR TITLE
[GHA] fix trigger typo in LBT workflow

### DIFF
--- a/.github/workflows/land-blocking.yml
+++ b/.github/workflows/land-blocking.yml
@@ -87,7 +87,7 @@ jobs:
           github-token: ${{secrets.GITHUB_TOKEN}}
           script: |
             // Check kill switch
-            if (${{secrets.KILL_SWITCH_LAND_BLOCKING_TEST}} || ${{steps.check_ks.outputs.should_run}} != 'true') {
+            if (${{secrets.KILL_SWITCH_LAND_BLOCKING_TEST}} || ${{steps.check_ks.outputs.should_run}} == 'false') {
               console.log('Kill switch is set. Will skip this step.');
               return;
             }
@@ -233,7 +233,7 @@ jobs:
           github-token: ${{secrets.GITHUB_TOKEN}}
           script: |
             // Check kill switch
-            if (${{secrets.KILL_SWITCH_LAND_BLOCKING_TEST}} || ${{steps.check_ks.outputs.should_run}} != 'true') {
+            if (${{secrets.KILL_SWITCH_LAND_BLOCKING_TEST}} || ${{steps.check_ks.outputs.should_run}} == 'false') {
               console.log('Kill switch is set. Will skip this step.');
               return;
             }


### PR DESCRIPTION
## Motivation
This commit fixes a logic typo in the comment step of the LBT workflow,
where the Cluster Test results are not posted on the original PR.

## Test Plan
Canary result
<img width="790" alt="image" src="https://user-images.githubusercontent.com/7528420/77115706-0547a080-69ec-11ea-9300-a86dcdfbc613.png">

Verify comment step works
<img width="775" alt="image" src="https://user-images.githubusercontent.com/7528420/77115744-17294380-69ec-11ea-86f0-1a1bd285c460.png">
