### PR TITLE
[move prover] Add requires preconditions.

### DIFF
--- a/language/move-lang/src/expansion/ast.rs
+++ b/language/move-lang/src/expansion/ast.rs
@@ -420,6 +420,7 @@ impl AstDebug for SpecBlockMember_ {
                     SpecConditionKind::Decreases => w.write("decreases "),
                     SpecConditionKind::AbortsIf => w.write("aborts_if "),
                     SpecConditionKind::Ensures => w.write("ensures "),
+                    SpecConditionKind::Requires => w.write("requires "),
                 }
                 exp.ast_debug(w);
             }

--- a/language/move-lang/src/parser/ast.rs
+++ b/language/move-lang/src/parser/ast.rs
@@ -217,6 +217,7 @@ pub enum SpecConditionKind {
     Decreases,
     AbortsIf,
     Ensures,
+    Requires,
 }
 
 // Specification invaiant kind.
@@ -803,6 +804,7 @@ impl AstDebug for SpecBlockMember_ {
                     SpecConditionKind::Decreases => w.write("decreases "),
                     SpecConditionKind::AbortsIf => w.write("aborts_if "),
                     SpecConditionKind::Ensures => w.write("ensures "),
+                    SpecConditionKind::Requires => w.write("requires "),
                 }
                 exp.ast_debug(w);
             }

--- a/language/move-lang/src/parser/syntax.rs
+++ b/language/move-lang/src/parser/syntax.rs
@@ -1458,11 +1458,13 @@ fn parse_spec_block_member<'input>(tokens: &mut Lexer<'input>) -> Result<SpecBlo
         Tok::Invariant => parse_invariant(tokens),
         Tok::Define | Tok::Native => parse_spec_function(tokens),
         Tok::NameValue => match tokens.content() {
-            "assert" | "assume" | "decreases" | "aborts_if" | "ensures" => parse_condition(tokens),
+            "assert" | "assume" | "decreases" | "aborts_if" | "ensures" | "requires" => {
+                parse_condition(tokens)
+            }
             "global" => parse_spec_variable(tokens),
             _ => Err(unexpected_token_error(
                 tokens,
-                "`assert`, `assume`, `decreases`, `aborts_if`, `ensures`, `global`",
+                "`assert`, `assume`, `decreases`, `aborts_if`, `ensures`, `requires`, `global`",
             )),
         },
         _ => Err(unexpected_token_error(
@@ -1473,7 +1475,7 @@ fn parse_spec_block_member<'input>(tokens: &mut Lexer<'input>) -> Result<SpecBlo
 }
 
 // Parse a specification condition:
-//    SpecCondition = ("assert" | "assume" | "decreases" | "aborts_if" | "ensures") <Exp> ";"
+//    SpecCondition = ("assert" | "assume" | "decreases" | "aborts_if" | "ensures" | "requires" ) <Exp> ";"
 fn parse_condition<'input>(tokens: &mut Lexer<'input>) -> Result<SpecBlockMember, Error> {
     let start_loc = tokens.start_loc();
     let kind = match tokens.content() {
@@ -1482,6 +1484,7 @@ fn parse_condition<'input>(tokens: &mut Lexer<'input>) -> Result<SpecBlockMember
         "decreases" => SpecConditionKind::Decreases,
         "aborts_if" => SpecConditionKind::AbortsIf,
         "ensures" => SpecConditionKind::Ensures,
+        "requires" => SpecConditionKind::Requires,
         _ => unreachable!(),
     };
     tokens.advance()?;

--- a/language/move-prover/spec-lang/src/ast.rs
+++ b/language/move-prover/spec-lang/src/ast.rs
@@ -42,6 +42,7 @@ pub struct SpecFunDecl {
 pub enum ConditionKind {
     AbortsIf,
     Ensures,
+    Requires,
 }
 
 #[derive(Debug)]

--- a/language/move-prover/src/bytecode_translator.rs
+++ b/language/move-prover/src/bytecode_translator.rs
@@ -437,7 +437,7 @@ impl<'env> ModuleTranslator<'env> {
         self.writer.indent();
         emitln!(self.writer, "call $InitVerification();");
         let spec_translator = SpecTranslator::new(self.writer, &func_env.module_env, false);
-        spec_translator.assume_module_invariants(func_env);
+        spec_translator.assume_preconditions(func_env);
         let args = func_env
             .get_type_parameters()
             .iter()

--- a/language/move-prover/tests/sources/module_invariants.move
+++ b/language/move-prover/tests/sources/module_invariants.move
@@ -48,4 +48,13 @@ module TestModuleInvariants {
        let x = new_S();
        x
     }
+
+    // Private function calling a public function with correct precondition.
+    fun private_calls_public(): S acquires SCounter {
+        let x = new_S();
+        x
+    }
+    spec fun private_calls_public {
+        requires global<SCounter>(0x0).n == spec_count;
+    }
 }


### PR DESCRIPTION
We found again use of them for private functions in the presence of module invariants.

This PR is also a small example of a feature extension for the prover which crosscuts all involved code components.


## Motivation

Global specifications.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

Added a new test

## Related PRs

#3037 
