### PR TITLE
[JSON RPC] add multisig support for 'TransactionDataView::UserTransaction'

### DIFF
--- a/json-rpc/src/views.rs
+++ b/json-rpc/src/views.rs
@@ -143,6 +143,7 @@ pub struct TransactionView {
     pub events: Vec<EventView>,
 }
 
+#[allow(clippy::large_enum_variant)]
 #[derive(Debug, Deserialize, Serialize)]
 #[serde(tag = "type")]
 pub enum TransactionDataView {
@@ -153,7 +154,9 @@ pub enum TransactionDataView {
     #[serde(rename = "user")]
     UserTransaction {
         sender: String,
-        authenticator: String,
+        signature_scheme: String,
+        signature: String,
+        public_key: String,
         sequence_number: u64,
         max_gas_amount: u64,
         gas_unit_price: u64,
@@ -218,7 +221,9 @@ impl From<Transaction> for TransactionDataView {
 
                 Ok(TransactionDataView::UserTransaction {
                     sender: t.sender().to_string(),
-                    authenticator: t.authenticator().to_string(),
+                    signature_scheme: t.authenticator().scheme().to_string(),
+                    signature: hex::encode(t.authenticator().signature_bytes()),
+                    public_key: hex::encode(t.authenticator().public_key_bytes()),
                     sequence_number: t.sequence_number(),
                     max_gas_amount: t.max_gas_amount(),
                     gas_unit_price: t.gas_unit_price(),

--- a/types/src/transaction/authenticator.rs
+++ b/types/src/transaction/authenticator.rs
@@ -37,6 +37,16 @@ pub enum Scheme {
     // ... add more schemes here
 }
 
+impl fmt::Display for Scheme {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let display = match self {
+            Scheme::Ed25519 => "Ed25519",
+            Scheme::MultiEd25519 => "MultiEd25519",
+        };
+        write!(f, "Scheme::{}", display)
+    }
+}
+
 #[derive(Clone, Debug, Eq, PartialEq, Hash, Serialize, Deserialize)]
 pub enum TransactionAuthenticator {
     /// Single signature


### PR DESCRIPTION
## Summary

adding `signature_scheme` field to `TransactionDataView::UserTransaction` to support multiple signature schemes in user txns