### PR TITLE
[tf] add mix_validators and mix_image_tags vars for roar

### DIFF
--- a/terraform/roar_variables.tf
+++ b/terraform/roar_variables.tf
@@ -1,0 +1,11 @@
+variable "mix_validators" {
+  type    = bool
+  default = false
+  description = "Mix validator images for record and replay test"
+}
+
+variable "mix_image_tags" {
+  type        = list(string)
+  default     = ["latest_dynamic"]
+  description = "List of Docker image tags to be used in record and replay test"
+}

--- a/terraform/validators.tf
+++ b/terraform/validators.tf
@@ -129,6 +129,7 @@ data "template_file" "user_data" {
 locals {
   image_repo                 = var.image_repo
   image_version              = substr(var.image_tag, 0, 6) == "sha256" ? "@${var.image_tag}" : ":${var.image_tag}"
+  mix_image_versions         = [for img in var.mix_image_tags: substr(img, 0, 6) == "sha256" ? "@${img}" : ":${img}"]
   safety_rules_image_repo    = var.safety_rules_image_repo
   safety_rules_image_version = substr(var.safety_rules_image_tag, 0, 6) == "sha256" ? "@${var.safety_rules_image_tag}" : ":${var.safety_rules_image_tag}"
   instance_public_ip         = true
@@ -195,7 +196,7 @@ data "template_file" "ecs_task_definition" {
 
   vars = {
     image                         = local.image_repo
-    image_version                 = local.image_version
+    image_version                 = var.mix_validators ? local.mix_image_versions[count.index % length(local.mix_image_versions)] : local.image_version
     cpu                           = (var.enable_logstash ? local.cpu_by_instance[var.validator_type] - 584 : local.cpu_by_instance[var.validator_type]) - 512
     mem                           = (var.enable_logstash ? local.mem_by_instance[var.validator_type] - 1024 : local.mem_by_instance[var.validator_type]) - 256
     cfg_base_config               = jsonencode(data.template_file.validator_config.rendered)


### PR DESCRIPTION
<!--
Thank you for sending a PR. We appreciate you spending time to help improve the Libra project.

The project is undergoing daily changes. Pull Requests will be reviewed and responded to as time permits.
-->

## Motivation

Adds the ability to specify mixed-version validators for the network. This change is backwards compatible,  and relies on `override_image_tags` list. This will allow us to more easily set up Record and Replay tests for backwards compatibility.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

http://prometheus.rustielin.aws.hlw3truzy4ls.com:9091/d/overview10/overview?orgId=1

Launched network with 4 validators, mixed with 2 adjacent versions. Validators 0 and 2 have different revision numbers than validators 1 and 3.

## Related PRs

Blocks https://github.com/calibra/libra-ops/pull/458
