### PR TITLE
Create libra-secure-push-metrics crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2558,6 +2558,14 @@ dependencies = [
 ]
 
 [[package]]
+name = "libra-secure-push-metrics"
+version = "0.1.0"
+dependencies = [
+ "libra-logger 0.1.0",
+ "ureq 0.11.4 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "libra-secure-storage"
 version = "0.1.0"
 dependencies = [
@@ -4549,11 +4557,13 @@ dependencies = [
  "anyhow 1.0.27 (registry+https://github.com/rust-lang/crates.io-index)",
  "consensus-types 0.1.0",
  "criterion 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "libra-canonical-serialization 0.1.0",
  "libra-config 0.1.0",
  "libra-crypto 0.1.0",
  "libra-logger 0.1.0",
  "libra-secure-net 0.1.0",
+ "libra-secure-push-metrics 0.1.0",
  "libra-secure-storage 0.1.0",
  "libra-temppath 0.1.0",
  "libra-types 0.1.0",

--- a/consensus/safety-rules/Cargo.toml
+++ b/consensus/safety-rules/Cargo.toml
@@ -8,12 +8,15 @@ edition = "2018"
 
 [dependencies]
 anyhow = "1.0"
+lazy_static = "1.4.0"
+
 consensus-types = { path = "../consensus-types", version = "0.1.0" }
 lcs = { path = "../../common/lcs", version = "0.1.0", package = "libra-canonical-serialization" }
 libra-config = { path = "../../config", version = "0.1.0" }
 libra-crypto = { path = "../../crypto/crypto", version = "0.1.0" }
 libra-logger = { path = "../../common/logger", version = "0.1.0" }
 libra-secure-net = { path = "../../secure/net", version = "0.1.0" }
+libra-secure-push-metrics = { path = "../../secure/push-metrics", version = "0.1.0" }
 libra-secure-storage = { path = "../../secure/storage", version = "0.1.0" }
 libra-temppath = { path = "../../common/temppath", version = "0.1.0" }
 libra-types = { path = "../../types", version = "0.1.0" }

--- a/consensus/safety-rules/src/counters.rs
+++ b/consensus/safety-rules/src/counters.rs
@@ -1,0 +1,25 @@
+// Copyright (c) The Libra Core Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+use lazy_static::lazy_static;
+use libra_secure_push_metrics::{define_counters, Counter, Gauge};
+use std::sync::Arc;
+
+// @TODO This is still Work in Progress and not ready for production
+// Use the libra_safety_rules prefix for all counters
+define_counters![
+    "libra_safety_rules",
+    (
+        sign_proposal: Counter,
+        "sign_proposal counter counts sign_proposals"
+    ),
+    (
+        sign_timeout: Counter,
+        "sign_timeout counter counts sign_timeouts"
+    ),
+    (some_gauge_counter: Gauge, "example help for a gauge metric"),
+];
+
+lazy_static! {
+    pub static ref COUNTERS: Arc<Counters> = Arc::new(Counters::new());
+}

--- a/consensus/safety-rules/src/lib.rs
+++ b/consensus/safety-rules/src/lib.rs
@@ -4,6 +4,7 @@
 #![forbid(unsafe_code)]
 
 mod consensus_state;
+mod counters;
 mod error;
 mod local_client;
 mod persistent_safety_storage;
@@ -17,7 +18,7 @@ mod t_safety_rules;
 mod thread;
 
 pub use crate::{
-    consensus_state::ConsensusState, error::Error,
+    consensus_state::ConsensusState, counters::COUNTERS, error::Error,
     persistent_safety_storage::PersistentSafetyStorage, process::Process,
     safety_rules::SafetyRules, safety_rules_manager::SafetyRulesManager,
     t_safety_rules::TSafetyRules,

--- a/consensus/safety-rules/src/main.rs
+++ b/consensus/safety-rules/src/main.rs
@@ -6,7 +6,8 @@
 #![forbid(unsafe_code)]
 
 use libra_config::config::NodeConfig;
-use safety_rules::Process;
+use libra_secure_push_metrics::MetricsPusher;
+use safety_rules::{Process, COUNTERS};
 use std::{env, process};
 
 fn main() {
@@ -27,7 +28,7 @@ fn main() {
         .is_async(config.logger.is_async)
         .level(config.logger.level)
         .init();
-
+    MetricsPusher::new(COUNTERS.clone()).start();
     let mut service = Process::new(config);
     service.start();
 }

--- a/consensus/safety-rules/src/safety_rules.rs
+++ b/consensus/safety-rules/src/safety_rules.rs
@@ -3,7 +3,7 @@
 
 use crate::{
     consensus_state::ConsensusState, error::Error,
-    persistent_safety_storage::PersistentSafetyStorage, t_safety_rules::TSafetyRules,
+    persistent_safety_storage::PersistentSafetyStorage, t_safety_rules::TSafetyRules, COUNTERS,
 };
 use consensus_types::{
     block::Block,
@@ -182,6 +182,7 @@ impl<T: Payload> TSafetyRules<T> for SafetyRules<T> {
     /// @TODO verify QC matches preferred round
     fn sign_proposal(&mut self, block_data: BlockData<T>) -> Result<Block<T>, Error> {
         debug!("Incoming proposal to sign.");
+        COUNTERS.sign_proposal.inc();
         Ok(Block::new_proposal_from_block_data(
             block_data,
             &self.validator_signer,
@@ -191,6 +192,7 @@ impl<T: Payload> TSafetyRules<T> for SafetyRules<T> {
     /// @TODO only sign a timeout if it matches last_voted_round or last_voted_round + 1
     /// @TODO update last_voted_round
     fn sign_timeout(&mut self, timeout: &Timeout) -> Result<Ed25519Signature, Error> {
+        COUNTERS.sign_timeout.inc();
         debug!("Incoming timeout message to sign.");
         Ok(timeout.sign(&self.validator_signer))
     }

--- a/secure/push-metrics/Cargo.toml
+++ b/secure/push-metrics/Cargo.toml
@@ -1,0 +1,14 @@
+[package]
+name = "libra-secure-push-metrics"
+version = "0.1.0"
+authors = ["Libra Association <opensource@libra.org>"]
+description = "Libra libra-util"
+repository = "https://github.com/libra/libra"
+homepage = "https://libra.org"
+license = "Apache-2.0"
+publish = false
+edition = "2018"
+
+[dependencies]
+ureq = { version = "0.11.3", features = ["json"] }
+libra-logger = { path = "../../common/logger", version = "0.1.0" }

--- a/secure/push-metrics/src/counters.rs
+++ b/secure/push-metrics/src/counters.rs
@@ -1,0 +1,119 @@
+// Copyright (c) The Libra Core Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+use std::sync::atomic::{AtomicBool, AtomicI64, Ordering};
+
+/// BaseMetric is a struct used by `Counter` and `Gauge`
+struct BaseMetric {
+    counter_name: String,
+    counter_help: String,
+    counter: AtomicI64,
+}
+
+impl BaseMetric {
+    pub fn new(counter_name: String, counter_help: String) -> Self {
+        Self {
+            counter_name,
+            counter_help,
+            counter: std::sync::atomic::AtomicI64::new(0),
+        }
+    }
+
+    pub fn inc_by(&self, i: i64) {
+        self.counter.fetch_add(i, Ordering::Relaxed);
+    }
+
+    pub fn inc(&self) {
+        self.inc_by(1);
+    }
+
+    pub fn set(&self, i: i64) {
+        self.counter.store(i, Ordering::Relaxed);
+    }
+}
+
+/// PushMetricFormat contains a single function which converts the
+/// metric into a string format which can be pushed to Prometheus
+pub trait PushMetricFormat {
+    fn get_push_metric_format(&self) -> String;
+}
+
+/// A Counter is a cumulative metric that represents a single
+/// monotonically increasing counter whose value can only
+/// increase or be reset to zero on restart.
+pub struct Counter {
+    base_counter: BaseMetric,
+}
+
+impl Counter {
+    pub fn new(counter_name: String, counter_help: String) -> Self {
+        Self {
+            base_counter: BaseMetric::new(counter_name, counter_help),
+        }
+    }
+
+    pub fn inc_by(&self, i: i64) {
+        self.base_counter.inc_by(i);
+    }
+
+    pub fn inc(&self) {
+        self.base_counter.inc();
+    }
+}
+
+impl PushMetricFormat for Counter {
+    fn get_push_metric_format(&self) -> String {
+        format!(
+            "# HELP {} {}\n# TYPE {} {}\n{} {}\n",
+            self.base_counter.counter_name,
+            self.base_counter.counter_help,
+            self.base_counter.counter_name,
+            "counter",
+            self.base_counter.counter_name,
+            self.base_counter.counter.load(Ordering::Relaxed)
+        )
+    }
+}
+
+/// A Gauge is a metric that represents a single
+/// numerical value that can arbitrarily go up and down.
+pub struct Gauge {
+    base_counter: BaseMetric,
+    has_been_set: AtomicBool,
+}
+
+impl Gauge {
+    pub fn new(counter_name: String, counter_help: String) -> Self {
+        Self {
+            base_counter: BaseMetric::new(counter_name, counter_help),
+            has_been_set: AtomicBool::new(false),
+        }
+    }
+
+    pub fn set(&self, i: i64) {
+        self.has_been_set.store(true, Ordering::Relaxed);
+        self.base_counter.set(i);
+    }
+}
+
+impl PushMetricFormat for Gauge {
+    fn get_push_metric_format(&self) -> String {
+        if self.has_been_set.load(Ordering::Relaxed) {
+            format!(
+                "# HELP {} {}\n# TYPE {} {}\n{} {}\n",
+                self.base_counter.counter_name,
+                self.base_counter.counter_help,
+                self.base_counter.counter_name,
+                "gauge",
+                self.base_counter.counter_name,
+                self.base_counter.counter.load(Ordering::Relaxed)
+            )
+        } else {
+            String::new()
+        }
+    }
+}
+
+pub trait Metrics {
+    fn get_metrics(&self) -> Vec<&dyn PushMetricFormat>;
+}

--- a/secure/push-metrics/src/lib.rs
+++ b/secure/push-metrics/src/lib.rs
@@ -1,0 +1,74 @@
+// Copyright (c) The Libra Core Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+#![forbid(unsafe_code)]
+
+mod counters;
+mod pusher;
+
+pub use crate::{
+    counters::{Counter, Gauge, Metrics, PushMetricFormat},
+    pusher::MetricsPusher,
+};
+
+/// Defines a list of counters with help messages
+/// Additionally, requires a prefix which will be prepended to all counters
+///
+/// # Example of defining two counters and using the prefix libra_safety_rules for counter names
+/// # Also defines a static COUNTERS which contains a reference to all the defined counters
+///
+/// ```ignore
+/// define_counters![
+///     "libra_safety_rules",
+///     (
+///         sign_proposal: Counter,
+///         "sign_proposal counter counts sign_proposals"
+///     ),
+///     (
+///         sign_timeout: Counter,
+///         "sign_timeout counter counts sign_timeouts"
+///     ),
+///     (some_gauge: Gauge, "example help for a gauge metric"),
+/// ];
+///
+/// lazy_static! {
+///     pub static ref COUNTERS: Arc<Counters> = Arc::new(Counters::new());
+/// }
+/// ```
+///
+/// # Example of setting them in code
+///
+/// ```ignore
+/// COUNTERS.some_gauge.set(42)
+/// COUNTERS.some_counter.inc()
+/// ```
+///
+#[macro_export]
+macro_rules! define_counters {
+    [
+        $prefix:expr,$(($counter:ident: $countertype:ty, $help: expr)),* $(,)?
+    ] => {
+        pub struct Counters {
+            $( pub $counter: $countertype, )*
+        }
+
+        impl Counters {
+            pub fn new() -> Self {
+                Self {
+                $(
+                    $counter: <$ countertype>::new(
+                      format!("{}_{}", $prefix, stringify!($counter)),
+                      ($help).to_string(),
+                    ),
+                )*
+                }
+            }
+        }
+
+        impl $crate::Metrics for Counters {
+            fn get_metrics(&self) -> Vec<&dyn $crate::PushMetricFormat> {
+                vec![$( &self.$counter, )*]
+            }
+        }
+    };
+}

--- a/secure/push-metrics/src/pusher.rs
+++ b/secure/push-metrics/src/pusher.rs
@@ -1,0 +1,70 @@
+// Copyright (c) The Libra Core Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::counters::Metrics;
+use libra_logger::{debug, error, info};
+use std::{env, sync::Arc, thread, thread::JoinHandle, time::Duration};
+
+const DEFAULT_PUSH_FREQUENCY_SECS: u64 = 15;
+
+/// MetricsPusher provides a function to push a list of Metrics to a configurable
+/// pushgateway endpoint.
+pub struct MetricsPusher {
+    metrics: Arc<dyn Metrics + Send + Sync>,
+}
+
+impl MetricsPusher {
+    pub fn new(metrics: Arc<dyn Metrics + Send + Sync>) -> Self {
+        Self { metrics }
+    }
+
+    fn run(self, push_metrics_endpoint: String, push_metrics_frequency_secs: u64) {
+        loop {
+            let mut data = String::new();
+            for metric in self.metrics.get_metrics() {
+                let metric_data = metric.get_push_metric_format();
+                data.push_str(&metric_data);
+            }
+            debug!("Metrics sent to server:\n{}", data);
+            let response = ureq::post(&push_metrics_endpoint)
+                .timeout_connect(10_000)
+                .send_string(&data);
+            if let Some(error) = response.synthetic_error() {
+                error!(
+                    "Failed to push metrics to {}. Error: {}",
+                    push_metrics_endpoint, error
+                );
+            }
+            thread::sleep(Duration::from_secs(push_metrics_frequency_secs));
+        }
+    }
+
+    /// start starts a new thread and periodically pushes the metrics to a pushgateway endpoint
+    pub fn start(self) -> Option<JoinHandle<()>> {
+        // eg value for PUSH_METRICS_ENDPOINT: "http://pushgatewar.server.com:9091/metrics/job/safety_rules"
+        let push_metrics_endpoint = match env::var("PUSH_METRICS_ENDPOINT") {
+            Ok(s) => s,
+            Err(_) => {
+                info!("PUSH_METRICS_ENDPOINT env var is not set. Skipping sending metrics.");
+                return None;
+            }
+        };
+        let push_metrics_frequency_secs = match env::var("PUSH_METRICS_FREQUENCY_SECS") {
+            Ok(s) => match s.parse::<u64>() {
+                Ok(i) => i,
+                Err(_) => {
+                    error!("Invalid value for PUSH_METRICS_FREQUENCY_SECS: {}", s);
+                    return None;
+                }
+            },
+            Err(_) => DEFAULT_PUSH_FREQUENCY_SECS,
+        };
+        info!(
+            "Starting push metrics loop. Sending metrics to {} with a frequency of {} seconds",
+            push_metrics_endpoint, push_metrics_frequency_secs
+        );
+        Some(thread::spawn(move || {
+            self.run(push_metrics_endpoint, push_metrics_frequency_secs)
+        }))
+    }
+}


### PR DESCRIPTION
## Summary

* `safety-push-metrics` is a crate intended to be used by safety rules servers to define and push metrics to Prometheus
* We defined our own crate instead of using prometheus to avoid taking any new dependencies for safety-rules
  * With this, the only deps we are taking are `ureq` as a HTTP client for pushing metrics and `lazy_static` for defining counters
* Since the metrics are push based, we don't need to open up a port in safety rules servers
* `safety-rules/src/counters.rs` contains the counter definitions used across the crate
* `safety-rules/src/main.rs` starts the thread for pushing metrics in a loop
* `safety-rules/src/safety_rules.rs` contains an example of how the counters can be incremented from code
* Use `libra_safety_rules_` prefix for all counters in safety rules server

## Testing

* Ran safety rules server locally against prometheus pushgateway and verified that metrics show up