### PR TITLE
[move-prover] Assume module invariants for cross-module calls.

### DIFF
--- a/language/move-prover/src/bytecode_translator.rs
+++ b/language/move-prover/src/bytecode_translator.rs
@@ -862,6 +862,15 @@ impl<'env> ModuleTranslator<'env> {
             ),
             Call(dests, callee_index, type_actuals, args) => {
                 let callee_env = self.module_env.get_called_function(*callee_index);
+                // If this is a call to a function from another module, assume the module invariants
+                // if any.
+                if callee_env.module_env.get_id() != func_env.module_env.get_id()
+                    && !callee_env.module_env.get_module_invariants().is_empty()
+                {
+                    let spec_translator =
+                        SpecTranslator::new(self.writer, &callee_env.module_env, false);
+                    spec_translator.assume_module_invariants(&callee_env);
+                }
                 let mut dest_str = String::new();
                 let mut args_str = String::new();
                 let mut dest_type_assumptions = vec![];

--- a/language/move-prover/src/spec_translator.rs
+++ b/language/move-prover/src/spec_translator.rs
@@ -273,7 +273,7 @@ impl<'env> SpecTranslator<'env> {
         }
     }
 
-    /// Assumes module invariants.
+    /// Assumes preconditions for function.
     pub fn assume_preconditions(&self, func_env: &FunctionEnv<'_>) {
         emitln!(self.writer, "assume $ExistsTxnSenderAccount($m, $txn);");
 
@@ -293,7 +293,12 @@ impl<'env> SpecTranslator<'env> {
             emitln!(self.writer);
         }
 
-        // Implicit module invariants.
+        // Implict module invariants.
+        self.assume_module_invariants(func_env);
+    }
+
+    /// Assume module invariants of function.
+    pub fn assume_module_invariants(&self, func_env: &FunctionEnv<'_>) {
         if func_env.is_public() {
             let invariants = func_env.module_env.get_module_invariants();
             if !invariants.is_empty() {

--- a/language/move-prover/tests/sources/module_invariants.exp
+++ b/language/move-prover/tests/sources/module_invariants.exp
@@ -1,21 +1,21 @@
 Move prover returns: exiting with boogie verification errors
 error:  A postcondition might not hold on this return path.
 
-    ┌── tests/sources/module_invariants.move:23:9 ───
+    ┌── tests/sources/module_invariants.move:24:9 ───
     │
- 23 │         invariant global<SCounter>(0x0).n == spec_count;
+ 24 │         invariant global<SCounter>(0x0).n == spec_count;
     │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
     │
-    =     at tests/sources/module_invariants.move:41:5: delete_S_invalid (entry)
-    =     at tests/sources/module_invariants.move:41:5: delete_S_invalid (exit)
+    =     at tests/sources/module_invariants.move:42:5: delete_S_invalid (entry)
+    =     at tests/sources/module_invariants.move:42:5: delete_S_invalid (exit)
     =         x = <redacted>
 
 error:  A precondition for this call might not hold.
 
-    ┌── tests/sources/module_invariants.move:23:9 ───
+    ┌── tests/sources/module_invariants.move:24:9 ───
     │
- 23 │         invariant global<SCounter>(0x0).n == spec_count;
+ 24 │         invariant global<SCounter>(0x0).n == spec_count;
     │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
     │
-    =     at tests/sources/module_invariants.move:47:5: private_calls_public_invalid (entry)
-    =     at tests/sources/module_invariants.move:27:5: new_S (entry)
+    =     at tests/sources/module_invariants.move:48:5: private_calls_public_invalid (entry)
+    =     at tests/sources/module_invariants.move:28:5: new_S (entry)

--- a/language/move-prover/tests/sources/module_invariants.move
+++ b/language/move-prover/tests/sources/module_invariants.move
@@ -1,3 +1,4 @@
+address 0x1:
 module TestModuleInvariants {
 
     // Some structure.
@@ -42,8 +43,8 @@ module TestModuleInvariants {
         let S{} = x;
     }
 
-    // Private function calling a public function and (currently) failing because we can't enforce the pre-condition
-    // of the public function.
+    // Private function calling a public function and failing because the pre-condition of the public function
+    // does not hold.
     fun private_calls_public_invalid(): S acquires SCounter {
        let x = new_S();
        x
@@ -56,5 +57,15 @@ module TestModuleInvariants {
     }
     spec fun private_calls_public {
         requires global<SCounter>(0x0).n == spec_count;
+    }
+}
+
+module TestModuleInvariantsExternal {
+    use 0x1::TestModuleInvariants;
+
+    public fun call_other() {
+        // Module invariant satisfied because we call from other module.
+        let x = TestModuleInvariants::new_S();
+        TestModuleInvariants::delete_S(x);
     }
 }


### PR DESCRIPTION
This assumes module invarians for a call to a function from another module. This was a missing piece in #3037 and (should) complete the implementation.

## Motivation

Global specifications.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

New test case.

## Related PRs

#3037
