### PR TITLE
[Serde reflection] New experimental tracer based on Deserialization

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1594,6 +1594,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 name = "generate-format"
 version = "0.1.0"
 dependencies = [
+ "clap 2.33.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "libra-canonical-serialization 0.1.0",
  "libra-serde-reflection 0.1.0",
  "libra-types 0.1.0",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1594,12 +1594,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 name = "generate-format"
 version = "0.1.0"
 dependencies = [
- "clap 2.33.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "libra-canonical-serialization 0.1.0",
  "libra-serde-reflection 0.1.0",
  "libra-types 0.1.0",
  "proptest 0.9.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_yaml 0.8.11 (registry+https://github.com/rust-lang/crates.io-index)",
+ "structopt 0.3.12 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]

--- a/common/serde-reflection/src/de.rs
+++ b/common/serde-reflection/src/de.rs
@@ -1,0 +1,596 @@
+// Copyright (c) The Libra Core Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::{
+    error::{Error, Result},
+    format::{Format, FormatHolder, Named, VariantFormat},
+    trace::Tracer,
+};
+use serde::de::{self, DeserializeSeed, IntoDeserializer, Visitor};
+use std::collections::BTreeMap;
+
+pub(crate) struct Deserializer<'a> {
+    tracer: &'a mut Tracer,
+    format: &'a mut Format,
+}
+
+impl<'a> Deserializer<'a> {
+    pub(crate) fn new(tracer: &'a mut Tracer, format: &'a mut Format) -> Self {
+        Deserializer { tracer, format }
+    }
+}
+
+impl<'de, 'a> de::Deserializer<'de> for Deserializer<'a> {
+    type Error = Error;
+
+    fn deserialize_any<V>(self, _visitor: V) -> Result<V::Value>
+    where
+        V: Visitor<'de>,
+    {
+        Err(Error::NotSupported("deserialize_any"))
+    }
+
+    fn deserialize_bool<V>(self, visitor: V) -> Result<V::Value>
+    where
+        V: Visitor<'de>,
+    {
+        self.format.merge(Format::Bool)?;
+        visitor.visit_bool(false)
+    }
+
+    fn deserialize_i8<V>(self, visitor: V) -> Result<V::Value>
+    where
+        V: Visitor<'de>,
+    {
+        self.format.merge(Format::I8)?;
+        visitor.visit_i8(0)
+    }
+
+    fn deserialize_i16<V>(self, visitor: V) -> Result<V::Value>
+    where
+        V: Visitor<'de>,
+    {
+        self.format.merge(Format::I16)?;
+        visitor.visit_i16(0)
+    }
+
+    fn deserialize_i32<V>(self, visitor: V) -> Result<V::Value>
+    where
+        V: Visitor<'de>,
+    {
+        self.format.merge(Format::I32)?;
+        visitor.visit_i32(0)
+    }
+
+    fn deserialize_i64<V>(self, visitor: V) -> Result<V::Value>
+    where
+        V: Visitor<'de>,
+    {
+        self.format.merge(Format::I64)?;
+        visitor.visit_i64(0)
+    }
+
+    fn deserialize_i128<V>(self, visitor: V) -> Result<V::Value>
+    where
+        V: Visitor<'de>,
+    {
+        self.format.merge(Format::I128)?;
+        visitor.visit_i128(0)
+    }
+
+    fn deserialize_u8<V>(self, visitor: V) -> Result<V::Value>
+    where
+        V: Visitor<'de>,
+    {
+        self.format.merge(Format::U8)?;
+        visitor.visit_u8(0)
+    }
+
+    fn deserialize_u16<V>(self, visitor: V) -> Result<V::Value>
+    where
+        V: Visitor<'de>,
+    {
+        self.format.merge(Format::U16)?;
+        visitor.visit_u16(0)
+    }
+
+    fn deserialize_u32<V>(self, visitor: V) -> Result<V::Value>
+    where
+        V: Visitor<'de>,
+    {
+        self.format.merge(Format::U32)?;
+        visitor.visit_u32(0)
+    }
+
+    fn deserialize_u64<V>(self, visitor: V) -> Result<V::Value>
+    where
+        V: Visitor<'de>,
+    {
+        self.format.merge(Format::U64)?;
+        visitor.visit_u64(0)
+    }
+
+    fn deserialize_u128<V>(self, visitor: V) -> Result<V::Value>
+    where
+        V: Visitor<'de>,
+    {
+        self.format.merge(Format::U128)?;
+        visitor.visit_u128(0)
+    }
+
+    fn deserialize_f32<V>(self, visitor: V) -> Result<V::Value>
+    where
+        V: Visitor<'de>,
+    {
+        self.format.merge(Format::F32)?;
+        visitor.visit_f32(0.0)
+    }
+
+    fn deserialize_f64<V>(self, visitor: V) -> Result<V::Value>
+    where
+        V: Visitor<'de>,
+    {
+        self.format.merge(Format::F64)?;
+        visitor.visit_f64(0.0)
+    }
+
+    fn deserialize_char<V>(self, visitor: V) -> Result<V::Value>
+    where
+        V: Visitor<'de>,
+    {
+        self.format.merge(Format::Char)?;
+        visitor.visit_char('A')
+    }
+
+    fn deserialize_str<V>(self, visitor: V) -> Result<V::Value>
+    where
+        V: Visitor<'de>,
+    {
+        self.format.merge(Format::Str)?;
+        visitor.visit_borrowed_str("")
+    }
+
+    fn deserialize_string<V>(self, visitor: V) -> Result<V::Value>
+    where
+        V: Visitor<'de>,
+    {
+        self.format.merge(Format::Str)?;
+        visitor.visit_string("".into())
+    }
+
+    fn deserialize_bytes<V>(self, visitor: V) -> Result<V::Value>
+    where
+        V: Visitor<'de>,
+    {
+        self.format.merge(Format::Bytes)?;
+        visitor.visit_borrowed_bytes(b"")
+    }
+
+    fn deserialize_byte_buf<V>(self, visitor: V) -> Result<V::Value>
+    where
+        V: Visitor<'de>,
+    {
+        self.deserialize_bytes(visitor)
+    }
+
+    fn deserialize_option<V>(mut self, visitor: V) -> Result<V::Value>
+    where
+        V: Visitor<'de>,
+    {
+        self.format
+            .merge(Format::Option(Box::new(Format::Unknown)))?;
+        let format = match &mut self.format {
+            Format::Option(x) => x,
+            _ => unreachable!(),
+        };
+        if **format == Format::Unknown {
+            let inner = Deserializer::new(self.tracer, format.as_mut());
+            visitor.visit_some(inner)
+        } else {
+            // Cut exploration.
+            visitor.visit_none()
+        }
+    }
+
+    fn deserialize_unit<V>(self, visitor: V) -> Result<V::Value>
+    where
+        V: Visitor<'de>,
+    {
+        self.format.merge(Format::Unit)?;
+        visitor.visit_unit()
+    }
+
+    fn deserialize_unit_struct<V>(self, name: &'static str, visitor: V) -> Result<V::Value>
+    where
+        V: Visitor<'de>,
+    {
+        self.format.merge(Format::TypeName(name.into()))?;
+        self.tracer
+            .registry
+            .entry(name)
+            .or_insert(Format::Unknown)
+            .merge(Format::UnitStruct)?;
+        visitor.visit_unit()
+    }
+
+    fn deserialize_newtype_struct<V>(self, name: &'static str, visitor: V) -> Result<V::Value>
+    where
+        V: Visitor<'de>,
+    {
+        // If a newtype struct was visited by the serialization tracer, use the recorded value.
+        if let Some(hint) = self.tracer.get_value(name) {
+            return visitor.visit_newtype_struct(hint.clone().into_deserializer());
+        }
+        self.format.merge(Format::TypeName(name.into()))?;
+        let entry = self.tracer.registry.entry(name).or_insert(Format::Unknown);
+        entry.merge(Format::NewTypeStruct(Box::new(Format::Unknown)))?;
+
+        let mut format = Format::Unknown;
+        let inner = Deserializer::new(self.tracer, &mut format);
+        let value = visitor.visit_newtype_struct(inner)?;
+        match self.tracer.registry.get_mut(name) {
+            Some(Format::NewTypeStruct(x)) => {
+                *x = Box::new(format);
+            }
+            _ => unreachable!(),
+        };
+        Ok(value)
+    }
+
+    fn deserialize_seq<V>(mut self, visitor: V) -> Result<V::Value>
+    where
+        V: Visitor<'de>,
+    {
+        self.format.merge(Format::Seq(Box::new(Format::Unknown)))?;
+        let format = match &mut self.format {
+            Format::Seq(x) => x,
+            _ => unreachable!(),
+        };
+        if **format == Format::Unknown {
+            // Simulate vector of size 1.
+            let inner = SeqDeserializer::new(self.tracer, std::iter::once(format.as_mut()));
+            visitor.visit_seq(inner)
+        } else {
+            // Cut exploration with a vector of size 0.
+            let inner = SeqDeserializer::new(self.tracer, std::iter::empty());
+            visitor.visit_seq(inner)
+        }
+    }
+
+    fn deserialize_tuple<V>(mut self, len: usize, visitor: V) -> Result<V::Value>
+    where
+        V: Visitor<'de>,
+    {
+        self.format
+            .merge(Format::Tuple(vec![Format::Unknown; len]))?;
+        let formats = match &mut self.format {
+            Format::Tuple(x) => x,
+            _ => unreachable!(),
+        };
+        let inner = SeqDeserializer::new(self.tracer, formats.iter_mut());
+        visitor.visit_seq(inner)
+    }
+
+    fn deserialize_tuple_struct<V>(
+        self,
+        name: &'static str,
+        len: usize,
+        visitor: V,
+    ) -> Result<V::Value>
+    where
+        V: Visitor<'de>,
+    {
+        self.format.merge(Format::TypeName(name.into()))?;
+        let entry = self.tracer.registry.entry(name).or_insert(Format::Unknown);
+        let mut formats = vec![Format::Unknown; len];
+        // Update the registry with an intermediate result to stop recursion.
+        entry.merge(Format::TupleStruct(formats.clone()))?;
+        // Compute the formats.
+        let inner = SeqDeserializer::new(self.tracer, formats.iter_mut());
+        let value = visitor.visit_seq(inner)?;
+        // Finally, update the registry.
+        match self.tracer.registry.get_mut(name) {
+            Some(Format::TupleStruct(x)) => {
+                *x = formats;
+            }
+            _ => unreachable!(),
+        };
+        Ok(value)
+    }
+
+    fn deserialize_map<V>(mut self, visitor: V) -> Result<V::Value>
+    where
+        V: Visitor<'de>,
+    {
+        self.format.merge(Format::Map {
+            key: Box::new(Format::Unknown),
+            value: Box::new(Format::Unknown),
+        })?;
+        let formats = match &mut self.format {
+            Format::Map { key, value } => vec![key.as_mut(), value.as_mut()],
+            _ => unreachable!(),
+        };
+        if *formats[0] == Format::Unknown || *formats[1] == Format::Unknown {
+            // Simulate a map with one entry.
+            let inner = SeqDeserializer::new(self.tracer, formats.into_iter());
+            visitor.visit_map(inner)
+        } else {
+            // Stop exploration.
+            let inner = SeqDeserializer::new(self.tracer, std::iter::empty());
+            visitor.visit_map(inner)
+        }
+    }
+
+    fn deserialize_struct<V>(
+        self,
+        name: &'static str,
+        fields: &'static [&'static str],
+        visitor: V,
+    ) -> Result<V::Value>
+    where
+        V: Visitor<'de>,
+    {
+        self.format.merge(Format::TypeName(name.into()))?;
+        let entry = self.tracer.registry.entry(name).or_insert(Format::Unknown);
+        let mut formats: Vec<_> = fields
+            .iter()
+            .map(|&name| Named {
+                name: name.into(),
+                value: Format::Unknown,
+            })
+            .collect();
+        // Update the registry with an intermediate result to stop recursion.
+        entry.merge(Format::Struct(formats.clone()))?;
+        // Compute the formats.
+        let inner = SeqDeserializer::new(
+            self.tracer,
+            formats.iter_mut().map(|named| &mut named.value),
+        );
+        let value = visitor.visit_seq(inner)?;
+        // Finally, update the registry.
+        match self.tracer.registry.get_mut(name) {
+            Some(Format::Struct(x)) => {
+                *x = formats;
+            }
+            _ => unreachable!(),
+        };
+        Ok(value)
+    }
+
+    // Assumption: The first variant(s) should be "base cases", i.e. not cause infinite recursion
+    // while constructing sample values.
+    fn deserialize_enum<V>(
+        self,
+        name: &'static str,
+        variants: &'static [&'static str],
+        visitor: V,
+    ) -> Result<V::Value>
+    where
+        V: Visitor<'de>,
+    {
+        assert!(
+            !variants.is_empty(),
+            "Enums should have at least one variant."
+        );
+        self.format.merge(Format::TypeName(name.into()))?;
+        let entry = self.tracer.registry.entry(name).or_insert(Format::Unknown);
+        // Update the registry with an intermediate result to stop recursion.
+        entry.merge(Format::Variant(BTreeMap::new()))?;
+        let current_variants = match entry {
+            Format::Variant(x) => x,
+            _ => unreachable!(),
+        };
+        let (index, mut variant) = if current_variants.len() == variants.len()
+            || self.tracer.incomplete_enums.contains(name)
+        {
+            // If we have found all the variants OR if the enum is marked as
+            // incomplete already, pick the first variant.
+            (0, current_variants[&0].clone())
+        } else {
+            assert!(
+                current_variants.len() < variants.len(),
+                "Current variants cannot exceed the entire list."
+            );
+            // Otherwise, create a new variant format.
+            let index = current_variants.len() as u32;
+            let variant = Named {
+                name: variants[index as usize].into(),
+                value: VariantFormat::Unknown,
+            };
+            (index, variant)
+        };
+
+        // Compute the formats.
+        let inner = EnumDeserializer::new(self.tracer, index, &mut variant.value);
+        let value = visitor.visit_enum(inner)?;
+        // Finally, update the registry.
+        let current_variants = match self.tracer.registry.get_mut(name) {
+            Some(Format::Variant(x)) => x,
+            _ => unreachable!(),
+        };
+        current_variants.insert(index, variant);
+        if current_variants.len() != variants.len() {
+            self.tracer.incomplete_enums.insert(name.into());
+        }
+        Ok(value)
+    }
+
+    // Not needed since we always deserialize structs as sequences.
+    fn deserialize_identifier<V>(self, _visitor: V) -> Result<V::Value>
+    where
+        V: Visitor<'de>,
+    {
+        Err(Error::NotSupported("deserialize_identifier"))
+    }
+
+    fn deserialize_ignored_any<V>(self, _visitor: V) -> Result<V::Value>
+    where
+        V: Visitor<'de>,
+    {
+        Err(Error::NotSupported("deserialize_ignored_any"))
+    }
+
+    fn is_human_readable(&self) -> bool {
+        self.tracer.is_human_readable
+    }
+}
+
+struct SeqDeserializer<'a, I> {
+    tracer: &'a mut Tracer,
+    formats: I,
+}
+
+impl<'a, I> SeqDeserializer<'a, I> {
+    fn new(tracer: &'a mut Tracer, formats: I) -> Self {
+        Self { tracer, formats }
+    }
+}
+
+impl<'de, 'a, I> de::SeqAccess<'de> for SeqDeserializer<'a, I>
+where
+    I: Iterator<Item = &'a mut Format>,
+{
+    type Error = Error;
+
+    fn next_element_seed<T>(&mut self, seed: T) -> Result<Option<T::Value>>
+    where
+        T: DeserializeSeed<'de>,
+    {
+        let format = match self.formats.next() {
+            Some(x) => x,
+            None => return Ok(None),
+        };
+        let inner = Deserializer::new(self.tracer, format);
+        seed.deserialize(inner).map(Some)
+    }
+
+    fn size_hint(&self) -> Option<usize> {
+        self.formats.size_hint().1
+    }
+}
+
+impl<'de, 'a, I> de::MapAccess<'de> for SeqDeserializer<'a, I>
+where
+    // Must have an even number of elements
+    I: Iterator<Item = &'a mut Format>,
+{
+    type Error = Error;
+
+    fn next_key_seed<K>(&mut self, seed: K) -> Result<Option<K::Value>>
+    where
+        K: DeserializeSeed<'de>,
+    {
+        let format = match self.formats.next() {
+            Some(x) => x,
+            None => return Ok(None),
+        };
+        let inner = Deserializer::new(self.tracer, format);
+        seed.deserialize(inner).map(Some)
+    }
+
+    fn next_value_seed<V>(&mut self, seed: V) -> Result<V::Value>
+    where
+        V: DeserializeSeed<'de>,
+    {
+        let format = match self.formats.next() {
+            Some(x) => x,
+            None => unreachable!(),
+        };
+        let inner = Deserializer::new(self.tracer, format);
+        seed.deserialize(inner)
+    }
+
+    fn size_hint(&self) -> Option<usize> {
+        self.formats.size_hint().1.map(|x| x / 2)
+    }
+}
+
+struct EnumDeserializer<'a> {
+    tracer: &'a mut Tracer,
+    index: u32,
+    format: &'a mut VariantFormat,
+}
+
+impl<'a> EnumDeserializer<'a> {
+    fn new(tracer: &'a mut Tracer, index: u32, format: &'a mut VariantFormat) -> Self {
+        Self {
+            tracer,
+            index,
+            format,
+        }
+    }
+}
+
+impl<'de, 'a> de::EnumAccess<'de> for EnumDeserializer<'a> {
+    type Error = Error;
+    type Variant = Self;
+
+    fn variant_seed<V>(self, seed: V) -> Result<(V::Value, Self::Variant)>
+    where
+        V: DeserializeSeed<'de>,
+    {
+        let index = self.index;
+        let value = seed.deserialize(index.into_deserializer())?;
+        Ok((value, self))
+    }
+}
+
+impl<'de, 'a> de::VariantAccess<'de> for EnumDeserializer<'a> {
+    type Error = Error;
+
+    fn unit_variant(self) -> Result<()> {
+        self.format.merge(VariantFormat::Unit)
+    }
+
+    fn newtype_variant_seed<T>(mut self, seed: T) -> Result<T::Value>
+    where
+        T: DeserializeSeed<'de>,
+    {
+        self.format
+            .merge(VariantFormat::NewType(Box::new(Format::Unknown)))?;
+        let format = match &mut self.format {
+            VariantFormat::NewType(x) => x.as_mut(),
+            _ => unreachable!(),
+        };
+        let inner = Deserializer::new(self.tracer, format);
+        seed.deserialize(inner)
+    }
+
+    fn tuple_variant<V>(mut self, len: usize, visitor: V) -> Result<V::Value>
+    where
+        V: Visitor<'de>,
+    {
+        self.format
+            .merge(VariantFormat::Tuple(vec![Format::Unknown; len]))?;
+        let formats = match &mut self.format {
+            VariantFormat::Tuple(x) => x,
+            _ => unreachable!(),
+        };
+        let inner = SeqDeserializer::new(self.tracer, formats.iter_mut());
+        visitor.visit_seq(inner)
+    }
+
+    fn struct_variant<V>(mut self, fields: &'static [&'static str], visitor: V) -> Result<V::Value>
+    where
+        V: Visitor<'de>,
+    {
+        let formats: Vec<_> = fields
+            .iter()
+            .map(|&name| Named {
+                name: name.into(),
+                value: Format::Unknown,
+            })
+            .collect();
+        self.format.merge(VariantFormat::Struct(formats))?;
+
+        let formats = match &mut self.format {
+            VariantFormat::Struct(x) => x,
+            _ => unreachable!(),
+        };
+        let inner = SeqDeserializer::new(
+            self.tracer,
+            formats.iter_mut().map(|named| &mut named.value),
+        );
+        visitor.visit_seq(inner)
+    }
+}

--- a/common/serde-reflection/src/de.rs
+++ b/common/serde-reflection/src/de.rs
@@ -216,11 +216,12 @@ impl<'de, 'a> de::Deserializer<'de> for Deserializer<'a> {
     where
         V: Visitor<'de>,
     {
+        self.format.merge(Format::TypeName(name.into()))?;
         // If a newtype struct was visited by the serialization tracer, use the recorded value.
         if let Some(hint) = self.tracer.get_value(name) {
+            // Hints are recorded during serialization-tracing therefore the registry is already accurate.
             return visitor.visit_newtype_struct(hint.clone().into_deserializer());
         }
-        self.format.merge(Format::TypeName(name.into()))?;
         self.tracer
             .registry
             .entry(name)

--- a/common/serde-reflection/src/error.rs
+++ b/common/serde-reflection/src/error.rs
@@ -5,8 +5,10 @@ use serde::{de, ser};
 use std::fmt;
 use thiserror::Error;
 
+/// Result type used in this crate.
 pub type Result<T, E = Error> = std::result::Result<T, E>;
 
+/// Error type used in this crate.
 #[derive(Clone, Debug, Error, PartialEq)]
 pub enum Error {
     #[error("{0}")]
@@ -19,6 +21,8 @@ pub enum Error {
     Incompatible(String, String),
     #[error("Incomplete tracing detected")]
     UnknownFormat,
+    #[error("Incomplete tracing detected inside container: {0}")]
+    UnknownFormatInContainer(&'static str),
     #[error("Missing variants detected for specific enums")]
     MissingVariants(Vec<String>),
 }

--- a/common/serde-reflection/src/error.rs
+++ b/common/serde-reflection/src/error.rs
@@ -11,10 +11,16 @@ pub type Result<T, E = Error> = std::result::Result<T, E>;
 pub enum Error {
     #[error("{0}")]
     Custom(String),
+    #[error("{0}")]
+    NotSupported(&'static str),
+    #[error("Failed to deserialize {0}")]
+    DeserializationError(&'static str),
     #[error("Incompatible formats detected: {0} {1}")]
     Incompatible(String, String),
     #[error("Incomplete tracing detected")]
     UnknownFormat,
+    #[error("Missing variants detected for specific enums")]
+    MissingVariants(Vec<String>),
 }
 
 impl ser::Error for Error {

--- a/common/serde-reflection/src/format.rs
+++ b/common/serde-reflection/src/format.rs
@@ -9,8 +9,7 @@ use serde::{
 };
 use std::collections::{btree_map::Entry, BTreeMap};
 
-/// Description of a Serde-based serialization format.
-/// First, the formats of anonymous "value" types.
+/// Serde-based serialization format for anonymous "value" types.
 #[derive(Serialize, Deserialize, Debug, Eq, Clone, PartialEq)]
 #[serde(rename_all = "UPPERCASE")]
 pub enum Format {
@@ -60,7 +59,7 @@ pub enum Format {
     },
 }
 
-/// Second, the formats of named "container" types.
+/// Serde-based serialization format for named "container" types.
 /// In Rust, those are enums and structs.
 #[derive(Serialize, Deserialize, Debug, Eq, Clone, PartialEq)]
 #[serde(rename_all = "UPPERCASE")]
@@ -80,7 +79,7 @@ pub enum ContainerFormat {
 
 #[derive(Debug, Clone, Default, Eq, PartialEq)]
 /// A named value.
-/// Used for named parameters or variant cases.
+/// Used for named parameters or variants.
 pub struct Named<T> {
     pub name: String,
     pub value: T,

--- a/common/serde-reflection/src/format.rs
+++ b/common/serde-reflection/src/format.rs
@@ -10,12 +10,13 @@ use serde::{
 use std::collections::{btree_map::Entry, BTreeMap};
 
 /// Description of a Serde-based serialization format.
+/// First, the formats of anonymous "value" types.
 #[derive(Serialize, Deserialize, Debug, Eq, Clone, PartialEq)]
 #[serde(rename_all = "UPPERCASE")]
 pub enum Format {
-    /// Placeholder for an unknown format (e.g. after tracing `None` value)
+    /// Placeholder for an unknown format (e.g. after tracing `None` value).
     Unknown,
-    /// The name of a container
+    /// The name of a container.
     TypeName(String),
 
     // The formats of primitive types
@@ -37,42 +38,49 @@ pub enum Format {
     Str,
     Bytes,
 
-    /// The format of Option<T>
+    /// The format of `Option<T>`.
     Option(Box<Format>),
-    /// E.g. the format of Vec<Foo>
+    /// A sequence, e.g. the format of `Vec<Foo>`.
     Seq(Box<Format>),
-    /// E.g. the format of BTreeMap<K, V>
+    /// A map, e.g. the format of `BTreeMap<K, V>`.
     #[serde(rename_all = "UPPERCASE")]
     Map {
         key: Box<Format>,
         value: Box<Format>,
     },
 
-    /// E.g. the format of (Foo, Bar)
+    /// A tuple, e.g. the format of `(Foo, Bar)`.
     Tuple(Vec<Format>),
-    /// Alias for (Foo, .... Foo)
-    /// E.g. the format of [Foo; N]
+    /// Alias for `(Foo, ... Foo)`.
+    /// E.g. the format of `[Foo; N]`.
     #[serde(rename_all = "UPPERCASE")]
     TupleArray {
         content: Box<Format>,
         size: usize,
     },
+}
 
-    /// The format of an empty struct
+/// Second, the formats of named "container" types.
+/// In Rust, those are enums and structs.
+#[derive(Serialize, Deserialize, Debug, Eq, Clone, PartialEq)]
+#[serde(rename_all = "UPPERCASE")]
+pub enum ContainerFormat {
+    /// An empty struct, e.g. `struct A`.
     UnitStruct,
-    /// The format of a struct with a unique unnamed field, e.g. struct A (u16)
+    /// A struct with a single unnamed parameter, e.g. `struct A(u16)`
     NewTypeStruct(Box<Format>),
-    /// The format of a struct with several unnamed fields, e.g. struct A (u16, u32)
+    /// A struct with several unnamed parameters, e.g. `struct A(u16, u32)`
     TupleStruct(Vec<Format>),
-    /// The format of a struct with named fields, e.g. struct A { a: Foo }
+    /// A struct with named parameters, e.g. `struct A { a: Foo }`.
     Struct(Vec<Named<Format>>),
-    /// The format of enum containers
-    Variant(BTreeMap<u32, Named<VariantFormat>>),
+    /// An enum, that is, an enumeration of variants.
+    /// Each variant has a unique name and index within the enum.
+    Enum(BTreeMap<u32, Named<VariantFormat>>),
 }
 
 #[derive(Debug, Clone, Default, Eq, PartialEq)]
 /// A named value.
-/// Used for named fields or variant cases.
+/// Used for named parameters or variant cases.
 pub struct Named<T> {
     pub name: String,
     pub value: T,
@@ -80,12 +88,17 @@ pub struct Named<T> {
 
 #[derive(Serialize, Deserialize, Debug, Clone, Eq, PartialEq)]
 #[serde(rename_all = "UPPERCASE")]
-/// Description of a variant case.
+/// Description of a variant in an enum.
 pub enum VariantFormat {
+    /// A variant whose format is yet unknown.
     Unknown,
+    /// A variant without parameters, e.g. `A` in `enum X { A }`
     Unit,
+    /// A variant with a single unnamed parameter, e.g. `A` in `enum X { A(u16) }`
     NewType(Box<Format>),
+    /// A struct with several unnamed parameters, e.g. `A` in `enum X { A(u16, u32) }`
     Tuple(Vec<Format>),
+    /// A struct with named parameters, e.g. `A` in `enum X { A { a: Foo } }`
     Struct(Vec<Named<Format>>),
 }
 
@@ -190,6 +203,108 @@ where
     }
 }
 
+pub(crate) trait ContainerFormatEntry {
+    fn merge(self, format: ContainerFormat) -> Result<()>;
+}
+
+impl<'a> ContainerFormatEntry for Entry<'a, &'static str, ContainerFormat> {
+    fn merge(self, format: ContainerFormat) -> Result<()> {
+        match self {
+            Entry::Vacant(e) => {
+                e.insert(format);
+                Ok(())
+            }
+            Entry::Occupied(e) => e.into_mut().merge(format),
+        }
+    }
+}
+
+impl FormatHolder for ContainerFormat {
+    fn merge(&mut self, mut format: ContainerFormat) -> Result<()> {
+        // Matching `&mut format` instead of `format` because of
+        // "error[E0009]: cannot bind by-move and by-ref in the same pattern"
+        match (&mut *self, &mut format) {
+            (Self::UnitStruct, Self::UnitStruct) => (),
+
+            (Self::NewTypeStruct(format1), Self::NewTypeStruct(format2)) => {
+                let format2 = std::mem::take(format2.as_mut());
+                format1.as_mut().merge(format2)?;
+            }
+
+            (Self::TupleStruct(formats1), Self::TupleStruct(formats2)) => {
+                if formats1.len() != formats2.len() {
+                    return Err(merge_error(self, &mut format));
+                }
+                let mut formats2 = formats2.iter_mut();
+                for format1 in formats1 {
+                    let format2 = std::mem::take(formats2.next().unwrap());
+                    format1.merge(format2)?;
+                }
+            }
+
+            (Self::Struct(named_formats1), Self::Struct(named_formats2)) => {
+                if named_formats1.len() != named_formats2.len() {
+                    return Err(merge_error(self, &mut format));
+                }
+                let mut named_formats2 = named_formats2.iter_mut();
+                for format1 in named_formats1 {
+                    let format2 = std::mem::take(named_formats2.next().unwrap());
+                    format1.merge(format2)?;
+                }
+            }
+
+            (Self::Enum(variants1), Self::Enum(variants2)) => {
+                for (index2, variant2) in variants2.iter_mut() {
+                    let variant2 = std::mem::take(variant2);
+                    match variants1.entry(*index2) {
+                        Entry::Vacant(e) => {
+                            // Note that we do not check for name collisions.
+                            e.insert(variant2);
+                        }
+                        Entry::Occupied(mut e) => {
+                            e.get_mut().merge(variant2)?;
+                        }
+                    }
+                }
+            }
+
+            _ => {
+                return Err(merge_error(self, &mut format));
+            }
+        }
+        Ok(())
+    }
+
+    fn normalize(&mut self) -> Result<()> {
+        match &mut *self {
+            Self::UnitStruct => Ok(()),
+
+            Self::NewTypeStruct(format) => format.normalize(),
+
+            Self::TupleStruct(formats) => {
+                for format in formats {
+                    format.normalize()?;
+                }
+                Ok(())
+            }
+
+            Self::Struct(named_formats) => {
+                for format in named_formats {
+                    format.normalize()?;
+                }
+                Ok(())
+            }
+
+            Self::Enum(variants) => {
+                for variant in variants.values_mut() {
+                    variant.normalize()?;
+                }
+                Ok(())
+            }
+        }
+    }
+}
+
 impl FormatHolder for Format {
     /// Merge the newly "traced" value `format` into the current format.
     /// Note that there should be no `TupleArray`s at this point.
@@ -217,8 +332,7 @@ impl FormatHolder for Format {
             | (Self::F64, Self::F64)
             | (Self::Char, Self::Char)
             | (Self::Str, Self::Str)
-            | (Self::Bytes, Self::Bytes)
-            | (Self::UnitStruct, Self::UnitStruct) => (),
+            | (Self::Bytes, Self::Bytes) => (),
 
             (Self::TypeName(name1), Self::TypeName(name2)) => {
                 if name1 != name2 {
@@ -227,31 +341,18 @@ impl FormatHolder for Format {
             }
 
             (Self::Option(format1), Self::Option(format2))
-            | (Self::Seq(format1), Self::Seq(format2))
-            | (Self::NewTypeStruct(format1), Self::NewTypeStruct(format2)) => {
+            | (Self::Seq(format1), Self::Seq(format2)) => {
                 let format2 = std::mem::take(format2.as_mut());
                 format1.as_mut().merge(format2)?;
             }
 
-            (Self::Tuple(formats1), Self::Tuple(formats2))
-            | (Self::TupleStruct(formats1), Self::TupleStruct(formats2)) => {
+            (Self::Tuple(formats1), Self::Tuple(formats2)) => {
                 if formats1.len() != formats2.len() {
                     return Err(merge_error(self, &mut format));
                 }
                 let mut formats2 = formats2.iter_mut();
                 for format1 in formats1 {
                     let format2 = std::mem::take(formats2.next().unwrap());
-                    format1.merge(format2)?;
-                }
-            }
-
-            (Self::Struct(named_formats1), Self::Struct(named_formats2)) => {
-                if named_formats1.len() != named_formats2.len() {
-                    return Err(merge_error(self, &mut format));
-                }
-                let mut named_formats2 = named_formats2.iter_mut();
-                for format1 in named_formats1 {
-                    let format2 = std::mem::take(named_formats2.next().unwrap());
                     format1.merge(format2)?;
                 }
             }
@@ -270,21 +371,6 @@ impl FormatHolder for Format {
                 let value2 = std::mem::take(value2.as_mut());
                 key1.as_mut().merge(key2)?;
                 value1.as_mut().merge(value2)?;
-            }
-
-            (Self::Variant(variants1), Self::Variant(variants2)) => {
-                for (index2, variant2) in variants2.iter_mut() {
-                    let variant2 = std::mem::take(variant2);
-                    match variants1.entry(*index2) {
-                        Entry::Vacant(e) => {
-                            // Note that we do not check for name collisions.
-                            e.insert(variant2);
-                        }
-                        Entry::Occupied(mut e) => {
-                            e.get_mut().merge(variant2)?;
-                        }
-                    }
-                }
             }
 
             _ => {
@@ -314,8 +400,7 @@ impl FormatHolder for Format {
             | Self::F64
             | Self::Char
             | Self::Str
-            | Self::Bytes
-            | Self::UnitStruct => {
+            | Self::Bytes => {
                 return Ok(());
             }
 
@@ -325,7 +410,6 @@ impl FormatHolder for Format {
 
             Self::Option(format)
             | Self::Seq(format)
-            | Self::NewTypeStruct(format)
             | Self::TupleArray {
                 content: format, ..
             } => {
@@ -335,27 +419,6 @@ impl FormatHolder for Format {
             Self::Map { key, value } => {
                 key.normalize()?;
                 return value.normalize();
-            }
-
-            Self::TupleStruct(formats) => {
-                for format in formats {
-                    format.normalize()?;
-                }
-                return Ok(());
-            }
-
-            Self::Struct(named_formats) => {
-                for format in named_formats {
-                    format.normalize()?;
-                }
-                return Ok(());
-            }
-
-            Self::Variant(variants) => {
-                for variant in variants.values_mut() {
-                    variant.normalize()?;
-                }
-                return Ok(());
             }
 
             // The only case where compression happens.

--- a/common/serde-reflection/src/format.rs
+++ b/common/serde-reflection/src/format.rs
@@ -10,7 +10,7 @@ use serde::{
 use std::collections::{btree_map::Entry, BTreeMap};
 
 /// Description of a Serde-based serialization format.
-#[derive(Serialize, Deserialize, Debug, Eq, PartialEq)]
+#[derive(Serialize, Deserialize, Debug, Eq, Clone, PartialEq)]
 #[serde(rename_all = "UPPERCASE")]
 pub enum Format {
     /// Placeholder for an unknown format (e.g. after tracing `None` value)
@@ -70,7 +70,7 @@ pub enum Format {
     Variant(BTreeMap<u32, Named<VariantFormat>>),
 }
 
-#[derive(Debug, Default, Eq, PartialEq)]
+#[derive(Debug, Clone, Default, Eq, PartialEq)]
 /// A named value.
 /// Used for named fields or variant cases.
 pub struct Named<T> {
@@ -78,10 +78,11 @@ pub struct Named<T> {
     pub value: T,
 }
 
-#[derive(Serialize, Deserialize, Debug, Eq, PartialEq)]
+#[derive(Serialize, Deserialize, Debug, Clone, Eq, PartialEq)]
 #[serde(rename_all = "UPPERCASE")]
 /// Description of a variant case.
 pub enum VariantFormat {
+    Unknown,
     Unit,
     NewType(Box<Format>),
     Tuple(Vec<Format>),
@@ -111,7 +112,12 @@ impl FormatHolder for VariantFormat {
         // See also https://github.com/rust-lang/rust/issues/68354
         // We make it work using std::mem::take (and the Default trait).
         match (&mut *self, &mut format) {
-            (Self::Unit, Self::Unit) => (),
+            (format1 @ Self::Unknown, format2) => {
+                let format2 = std::mem::take(format2);
+                *format1 = format2;
+            }
+
+            (_, Self::Unknown) | (Self::Unit, Self::Unit) => (),
 
             (Self::NewType(format1), Self::NewType(format2)) => {
                 let format2 = std::mem::take(format2.as_mut());
@@ -149,6 +155,7 @@ impl FormatHolder for VariantFormat {
 
     fn normalize(&mut self) -> Result<()> {
         match self {
+            Self::Unknown => Err(Error::UnknownFormat),
             Self::Unit => Ok(()),
             Self::NewType(format) => format.normalize(),
             Self::Tuple(formats) => {
@@ -386,7 +393,7 @@ impl Default for Format {
 
 impl Default for VariantFormat {
     fn default() -> Self {
-        Self::Unit
+        Self::Unknown
     }
 }
 

--- a/common/serde-reflection/src/lib.rs
+++ b/common/serde-reflection/src/lib.rs
@@ -8,11 +8,19 @@
 //! This crate provides a way to extract IDL-like format descriptions for Rust containers
 //! that implement the Serialize and/or Deserialize trait(s) of Serde.
 //!
+//! # Overview
+//!
+//! In the following example, we extract the Serde-generated data-format of two containers
+//! `Name` and `Person`. We also demonstrate how to handle a custom
+//! implementation of `ser::de::Deserialize` that would enforce user-defined invariants
+//! for `Name` values.
+//!
 //! ```rust
 //! # use libra_serde_reflection::*;
 //! # use serde::{Deserialize, Serialize};
-//! # #[derive(Serialize, PartialEq, Eq, Debug, Clone)]
+//! #[derive(Serialize, PartialEq, Eq, Debug, Clone)]
 //! struct Name(String);
+//! // impl<'de> Deserialize<'de> for Name { ... }
 //! #
 //! # impl<'de> Deserialize<'de> for Name {
 //! #     fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
@@ -38,7 +46,7 @@
 //! #     }
 //! # }
 //!
-//! # #[derive(Serialize, Deserialize, PartialEq, Eq, Debug, Clone)]
+//! #[derive(Serialize, Deserialize, PartialEq, Eq, Debug, Clone)]
 //! enum Person {
 //!     NickName(Name),
 //!     FullName { first: Name, last: Name },
@@ -48,24 +56,24 @@
 //! // Start a session to trace formats.
 //! let mut tracer = Tracer::new(/* is_human_readable */ false);
 //!
-//! // For every type (here `Name`), if a user-defined implementation of `Deserialize`
-//! // exists that performs custom validation checks, start by tracing the serialization
-//! // of a valid value of this type.
+//! // For every type (here `Name`), if a user-defined implementation of `Deserialize` exists and
+//! // is known to perform custom validation checks, start by tracing the serialization of
+//! // a valid value of this type.
 //! let bob = Name("Bob".into());
 //! tracer.trace_value(&bob)?;
 //!
-//! // Then, we may trace deserialization for top-level types (here `Person`) and their
-//! // dependencies as follows. This phase will use Rust values previously recorded
-//! // during serialization in order to pass custom checks.
-//! // TODO: Currently, recorded values are only used for `NewTypeStruct`s.
-//! let format = tracer.trace_type::<Person>()?;
+//! // Now, let's trace deserialization for the top-level type `Person`.
+//! let (format, values) = tracer.trace_type::<Person>()?;
 //! assert_eq!(format, Format::TypeName("Person".into()));
 //!
-//! // We may also request a sample value of type `Person`.
-//! let (person, _) = tracer.sample_type_once::<Person>()?;
-//! assert_eq!(person, Person::NickName(bob.clone()));
+//! // As a byproduct, we have also obtained sample values of type `Person`.
+//! // We can see that the user-provided value `bob` was used consistently to pass
+//! // validation checks for `Name`.
+//! assert_eq!(values[0], Person::NickName(bob.clone()));
+//! assert_eq!(values[1], Person::FullName { first: bob.clone(), last: bob.clone() });
 //!
-//! // Stop the tracing session and obtain a final registry of containers (i.e. structs and enums).
+//! // We have no more top-level types to trace, so let's stop the tracing session and obtain
+//! // a final registry of containers.
 //! let registry = tracer.registry()?;
 //!
 //! // We have successfully extracted a format description of all Serde containers under `Person`.
@@ -74,7 +82,7 @@
 //!     &ContainerFormat::NewTypeStruct(Box::new(Format::Str)),
 //! );
 //! match registry.get("Person").unwrap() {
-//!     ContainerFormat::Enum(_) => (),
+//!     ContainerFormat::Enum(variants) => assert_eq!(variants.len(), 2),
 //!      _ => panic!(),
 //! };
 //!
@@ -100,6 +108,117 @@
 //! # Ok(())
 //! # }
 //! ```
+//!
+//! # Tracing Serialization with `trace_value(v)`
+//!
+//! Tracing the serialization of a Rust value `v` consists of visiting the structural
+//! components of `v` in depth and recording Serde formats for all the visited types.
+//!
+//! ```rust
+//! # use libra_serde_reflection::*;
+//! # use serde::Serialize;
+//! #[derive(Serialize)]
+//! struct FullName<'a> {
+//!   first: &'a str,
+//!   middle: Option<&'a str>,
+//!   last: &'a str,
+//! }
+//!
+//! # fn main() -> Result<(), Error> {
+//! let mut tracer = Tracer::new(/* is_human_readable */ false);
+//! tracer.trace_value(&FullName { first: "", middle: Some(""), last: "" })?;
+//! let registry = tracer.registry()?;
+//! match registry.get("FullName").unwrap() {
+//!     ContainerFormat::Struct(fields) => assert_eq!(fields.len(), 3),
+//!     _ => panic!(),
+//! };
+//! # Ok(())
+//! # }
+//! ```
+//!
+//! This approach works well but it can only recover the formats of datatypes for which
+//! nontrivial samples have been provided:
+//!
+//! * In enums, only the variants explicitly covered by user samples will be recorded.
+//!
+//! * Providing a `None` value or an empty vector `[]` within a sample may result in
+//! formats that are partially unknown.
+//!
+//! ```rust
+//! # use libra_serde_reflection::*;
+//! # use serde::Serialize;
+//! # #[derive(Serialize)]
+//! # struct FullName<'a> {
+//! #   first: &'a str,
+//! #   middle: Option<&'a str>,
+//! #   last: &'a str,
+//! # }
+//! # fn main() -> Result<(), Error> {
+//! let mut tracer = Tracer::new(/* is_human_readable */ false);
+//! tracer.trace_value(&FullName { first: "", middle: None, last: "" })?;
+//! assert_eq!(tracer.registry().unwrap_err(), Error::UnknownFormatInContainer("FullName"));
+//! # Ok(())
+//! # }
+//! ```
+//!
+//! For this reason, we introduce a complementary set of APIs to trace deserialization of types.
+//!
+//! # Tracing Deserialization with `trace_type<T>()`
+//!
+//! Deserialization-tracing APIs take the current tracing state `&mut self` and a type `T`
+//! as input.
+//!
+//! ## Core Algorithm and High-Level API
+//!
+//! The core algorithm `trace_type_once<T>()`
+//! attempts to reconstruct a witness value of type `T` by exploring the graph of all the types
+//! occurring in the definition of `T`. At the same time, the algorithm records the
+//! formats of all the visited structs and enum variants.
+//!
+//! For the exploration to be able to terminate, the core algorithm `trace_type_once` explores
+//! possible recursion points only once (see definition below).
+//! In particular, if `T` is an enum, `trace_type_once` discovers only one variant at a time.
+//!
+//! For this reason, the high-level API `trace_type<T>()`
+//! will repeat calls to `trace_type_once` until all the variants of `T` are known.
+//! Variant cases of `T` are explored in sequential order, starting with index `0`.
+//!
+//! ## Coverage Guarantees
+//!
+//! Under the assumptions listed below, a single call to `trace_type<T>()` is guaranteed to
+//! record the formats of all the types that `T` depends on.
+//!
+//! (0) Container names must not collide. (TODO: handle this using `std::any::type_name`?)
+//!
+//! (1) The first variants of mutually recursive enums must be a "base case". That is,
+//! defaulting to the first variant for every enum type (along with `None` for option values
+//! and `[]` for sequences) must guarantee termination of depth-first traversals of the graph of type
+//! declarations.
+//!
+//! (2) If a type runs custom validation checks during deserialization, sample values must have been provided
+//! previously by calling `trace_value`. Besides, the corresponding registered formats
+//! must not contain `Unknown` parts.
+//!
+//! ## Design Considerations
+//!
+//! Whenever we traverse the graph of type declarations using deserialization callbacks, the type
+//! system requires us to return valid Rust values of type `V::Value`, where `V` is the type of
+//! a given `visitor`. This contraint limits the way we can stop graph traversal to only a few cases.
+//!
+//! The first 3 cases are what we have called *possible recursion points* above:
+//!
+//! * while visiting an `Option<T>` for the second time, we choose to return the value `None` to stop;
+//! * while visiting an `Seq<T>` for the second time, we choose to return the empty sequence `[]`;
+//! * while visiting an `enum T` for the second time, we choose to return the first variant, i.e.
+//! a "base case" by assumption (1) above.
+//!
+//! In addition to these 3 cases,
+//!
+//! * while visiting a container (one of the 5 types), if the container's name is mapped to a recorded value,
+//! we MAY decide to use it.
+//!
+//! Currently, we always pick the recorded value for a NewTypeStruct and never do in the other cases.
+//! (TODO: decide what to do)
 
 mod de;
 mod error;

--- a/common/serde-reflection/src/lib.rs
+++ b/common/serde-reflection/src/lib.rs
@@ -5,8 +5,101 @@
 
 //! # Serde Reflection (experimental)
 //!
-//! This crate provides a way to extract IDL-like format descriptions for values
-//! that implement the Serialize trait of Serde.
+//! This crate provides a way to extract IDL-like format descriptions for Rust containers
+//! that implement the Serialize and/or Deserialize trait(s) of Serde.
+//!
+//! ```rust
+//! # use libra_serde_reflection::*;
+//! # use serde::{Deserialize, Serialize};
+//! # #[derive(Serialize, PartialEq, Eq, Debug, Clone)]
+//! struct Name(String);
+//! #
+//! # impl<'de> Deserialize<'de> for Name {
+//! #     fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+//! #     where
+//! #         D: ::serde::Deserializer<'de>,
+//! #     {
+//! #         // Make sure to wrap our value in a container with the same name
+//! #         // as the original type.
+//! #         # [derive(Deserialize)]
+//! #         # [serde(rename = "Name")]
+//! #         struct InternalValue(String);
+//! #
+//! #         let value = InternalValue::deserialize(deserializer)?.0;
+//! #         // Enforce some custom invariant
+//! #         if value.len() >= 2 && value.chars().all(char::is_alphabetic) {
+//! #             Ok(Name(value))
+//! #         } else {
+//! #             Err(<D::Error as ::serde::de::Error>::custom(format!(
+//! #                 "Invalid name {}",
+//! #                 value
+//! #             )))
+//! #         }
+//! #     }
+//! # }
+//!
+//! # #[derive(Serialize, Deserialize, PartialEq, Eq, Debug, Clone)]
+//! enum Person {
+//!     NickName(Name),
+//!     FullName { first: Name, last: Name },
+//! }
+//!
+//! # fn main() -> Result<(), Error> {
+//! // Start a session to trace formats.
+//! let mut tracer = Tracer::new(/* is_human_readable */ false);
+//!
+//! // For every type (here `Name`), if a user-defined implementation of `Deserialize`
+//! // exists that performs custom validation checks, start by tracing the serialization
+//! // of a valid value of this type.
+//! let bob = Name("Bob".into());
+//! tracer.trace_value(&bob)?;
+//!
+//! // Then, we may trace deserialization for top-level types (here `Person`) and their
+//! // dependencies as follows. This phase will use Rust values previously recorded
+//! // during serialization in order to pass custom checks.
+//! // TODO: Currently, recorded values are only used for `NewTypeStruct`s.
+//! let format = tracer.trace_type::<Person>()?;
+//! assert_eq!(format, Format::TypeName("Person".into()));
+//!
+//! // We may also request a sample value of type `Person`.
+//! let (person, _) = tracer.sample_type_once::<Person>()?;
+//! assert_eq!(person, Person::NickName(bob.clone()));
+//!
+//! // Stop the tracing session and obtain a final registry of containers (i.e. structs and enums).
+//! let registry = tracer.registry()?;
+//!
+//! // We have successfully extracted a format description of all Serde containers under `Person`.
+//! assert_eq!(
+//!     registry.get("Name").unwrap(),
+//!     &ContainerFormat::NewTypeStruct(Box::new(Format::Str)),
+//! );
+//! match registry.get("Person").unwrap() {
+//!     ContainerFormat::Enum(_) => (),
+//!      _ => panic!(),
+//! };
+//!
+//! // Export the registry in YAML.
+//! let data = serde_yaml::to_string(&registry).unwrap() + "\n";
+//! assert_eq!(&data, r#"---
+//! Name:
+//!   NEWTYPESTRUCT: STR
+//! Person:
+//!   ENUM:
+//!     0:
+//!       NickName:
+//!         NEWTYPE:
+//!           TYPENAME: Name
+//!     1:
+//!       FullName:
+//!         STRUCT:
+//!           - first:
+//!               TYPENAME: Name
+//!           - last:
+//!               TYPENAME: Name
+//! "#);
+//! # Ok(())
+//! # }
+//! ```
 
 mod de;
 mod error;

--- a/common/serde-reflection/src/lib.rs
+++ b/common/serde-reflection/src/lib.rs
@@ -8,10 +8,14 @@
 //! This crate provides a way to extract IDL-like format descriptions for values
 //! that implement the Serialize trait of Serde.
 
+mod de;
 mod error;
 mod format;
+mod ser;
 mod trace;
+mod value;
 
 pub use error::{Error, Result};
 pub use format::{Format, Named, VariantFormat};
 pub use trace::Tracer;
+pub use value::Value;

--- a/common/serde-reflection/src/lib.rs
+++ b/common/serde-reflection/src/lib.rs
@@ -21,8 +21,8 @@
 //! #     {
 //! #         // Make sure to wrap our value in a container with the same name
 //! #         // as the original type.
-//! #         # [derive(Deserialize)]
-//! #         # [serde(rename = "Name")]
+//! #         #[derive(Deserialize)]
+//! #         #[serde(rename = "Name")]
 //! #         struct InternalValue(String);
 //! #
 //! #         let value = InternalValue::deserialize(deserializer)?.0;

--- a/common/serde-reflection/src/lib.rs
+++ b/common/serde-reflection/src/lib.rs
@@ -16,6 +16,6 @@ mod trace;
 mod value;
 
 pub use error::{Error, Result};
-pub use format::{Format, Named, VariantFormat};
-pub use trace::Tracer;
+pub use format::{ContainerFormat, Format, Named, VariantFormat};
+pub use trace::{Registry, RegistryOwned, Tracer};
 pub use value::Value;

--- a/common/serde-reflection/src/ser.rs
+++ b/common/serde-reflection/src/ser.rs
@@ -114,7 +114,8 @@ impl<'a> ser::Serializer for Serializer<'a> {
     }
 
     fn serialize_unit_struct(self, name: &'static str) -> Result<(Format, Value)> {
-        self.tracer.record(name, Format::UnitStruct, Value::Unit)
+        self.tracer
+            .record(name, ContainerFormat::UnitStruct, Value::Unit)
     }
 
     fn serialize_unit_variant(
@@ -141,8 +142,11 @@ impl<'a> ser::Serializer for Serializer<'a> {
         T: ?Sized + Serialize,
     {
         let (format, value) = value.serialize(Serializer::new(&mut self.tracer))?;
-        self.tracer
-            .record(name, Format::NewTypeStruct(Box::new(format)), value)
+        self.tracer.record(
+            name,
+            ContainerFormat::NewTypeStruct(Box::new(format)),
+            value,
+        )
     }
 
     fn serialize_newtype_variant<T>(
@@ -323,7 +327,7 @@ impl<'a> ser::SerializeTupleStruct for TupleStructSerializer<'a> {
     }
 
     fn end(self) -> Result<(Format, Value)> {
-        let format = Format::TupleStruct(self.formats);
+        let format = ContainerFormat::TupleStruct(self.formats);
         let value = Value::Seq(self.values);
         self.tracer.record(self.name, format, value)
     }
@@ -431,7 +435,7 @@ impl<'a> ser::SerializeStruct for StructSerializer<'a> {
     }
 
     fn end(self) -> Result<(Format, Value)> {
-        let format = Format::Struct(self.fields);
+        let format = ContainerFormat::Struct(self.fields);
         let value = Value::Seq(self.values);
         self.tracer.record(self.name, format, value)
     }

--- a/common/serde-reflection/src/ser.rs
+++ b/common/serde-reflection/src/ser.rs
@@ -1,0 +1,477 @@
+// Copyright (c) The Libra Core Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::{
+    error::{Error, Result},
+    format::*,
+    trace::Tracer,
+    value::Value,
+};
+use serde::{ser, Serialize};
+
+pub(crate) struct Serializer<'a> {
+    tracer: &'a mut Tracer,
+}
+
+impl<'a> Serializer<'a> {
+    pub(crate) fn new(tracer: &'a mut Tracer) -> Self {
+        Self { tracer }
+    }
+}
+
+impl<'a> ser::Serializer for Serializer<'a> {
+    type Ok = (Format, Value);
+    type Error = Error;
+    type SerializeSeq = SeqSerializer<'a>;
+    type SerializeTuple = TupleSerializer<'a>;
+    type SerializeTupleStruct = TupleStructSerializer<'a>;
+    type SerializeTupleVariant = TupleVariantSerializer<'a>;
+    type SerializeMap = MapSerializer<'a>;
+    type SerializeStruct = StructSerializer<'a>;
+    type SerializeStructVariant = StructVariantSerializer<'a>;
+
+    fn serialize_bool(self, v: bool) -> Result<(Format, Value)> {
+        Ok((Format::Bool, Value::Bool(v)))
+    }
+
+    fn serialize_i8(self, v: i8) -> Result<(Format, Value)> {
+        Ok((Format::I8, Value::I8(v)))
+    }
+
+    fn serialize_i16(self, v: i16) -> Result<(Format, Value)> {
+        Ok((Format::I16, Value::I16(v)))
+    }
+
+    fn serialize_i32(self, v: i32) -> Result<(Format, Value)> {
+        Ok((Format::I32, Value::I32(v)))
+    }
+
+    fn serialize_i64(self, v: i64) -> Result<(Format, Value)> {
+        Ok((Format::I64, Value::I64(v)))
+    }
+
+    fn serialize_i128(self, v: i128) -> Result<(Format, Value)> {
+        Ok((Format::I128, Value::I128(v)))
+    }
+
+    fn serialize_u8(self, v: u8) -> Result<(Format, Value)> {
+        Ok((Format::U8, Value::U8(v)))
+    }
+
+    fn serialize_u16(self, v: u16) -> Result<(Format, Value)> {
+        Ok((Format::U16, Value::U16(v)))
+    }
+
+    fn serialize_u32(self, v: u32) -> Result<(Format, Value)> {
+        Ok((Format::U32, Value::U32(v)))
+    }
+
+    fn serialize_u64(self, v: u64) -> Result<(Format, Value)> {
+        Ok((Format::U64, Value::U64(v)))
+    }
+
+    fn serialize_u128(self, v: u128) -> Result<(Format, Value)> {
+        Ok((Format::U128, Value::U128(v)))
+    }
+
+    fn serialize_f32(self, v: f32) -> Result<(Format, Value)> {
+        Ok((Format::F32, Value::F32(v)))
+    }
+
+    fn serialize_f64(self, v: f64) -> Result<(Format, Value)> {
+        Ok((Format::F64, Value::F64(v)))
+    }
+
+    fn serialize_char(self, v: char) -> Result<(Format, Value)> {
+        Ok((Format::Char, Value::Char(v)))
+    }
+
+    fn serialize_str(self, v: &str) -> Result<(Format, Value)> {
+        Ok((Format::Str, Value::Str(v.into())))
+    }
+
+    fn serialize_bytes(self, v: &[u8]) -> Result<(Format, Value)> {
+        Ok((Format::Bytes, Value::Bytes(v.into())))
+    }
+
+    fn serialize_none(self) -> Result<(Format, Value)> {
+        Ok((Format::Unknown, Value::Option(None)))
+    }
+
+    fn serialize_some<T>(self, v: &T) -> Result<(Format, Value)>
+    where
+        T: ?Sized + Serialize,
+    {
+        let (format, value) = v.serialize(self)?;
+        Ok((
+            Format::Option(Box::new(format)),
+            Value::Option(Some(Box::new(value))),
+        ))
+    }
+
+    fn serialize_unit(self) -> Result<(Format, Value)> {
+        Ok((Format::Unit, Value::Unit))
+    }
+
+    fn serialize_unit_struct(self, name: &'static str) -> Result<(Format, Value)> {
+        self.tracer.record(name, Format::UnitStruct, Value::Unit)
+    }
+
+    fn serialize_unit_variant(
+        self,
+        name: &'static str,
+        variant_index: u32,
+        variant_name: &'static str,
+    ) -> Result<(Format, Value)> {
+        self.tracer.record_variant(
+            name,
+            variant_index,
+            variant_name,
+            VariantFormat::Unit,
+            Value::Unit,
+        )
+    }
+
+    fn serialize_newtype_struct<T>(
+        mut self,
+        name: &'static str,
+        value: &T,
+    ) -> Result<(Format, Value)>
+    where
+        T: ?Sized + Serialize,
+    {
+        let (format, value) = value.serialize(Serializer::new(&mut self.tracer))?;
+        self.tracer
+            .record(name, Format::NewTypeStruct(Box::new(format)), value)
+    }
+
+    fn serialize_newtype_variant<T>(
+        mut self,
+        name: &'static str,
+        variant_index: u32,
+        variant_name: &'static str,
+        value: &T,
+    ) -> Result<(Format, Value)>
+    where
+        T: ?Sized + Serialize,
+    {
+        let (format, value) = value.serialize(Serializer::new(&mut self.tracer))?;
+        self.tracer.record_variant(
+            name,
+            variant_index,
+            variant_name,
+            VariantFormat::NewType(Box::new(format)),
+            value,
+        )
+    }
+
+    fn serialize_seq(self, _len: Option<usize>) -> Result<Self::SerializeSeq> {
+        Ok(SeqSerializer {
+            tracer: &mut *self.tracer,
+            format: Format::Unknown,
+            values: Vec::new(),
+        })
+    }
+
+    fn serialize_tuple(self, _len: usize) -> Result<Self::SerializeTuple> {
+        Ok(TupleSerializer {
+            tracer: &mut *self.tracer,
+            formats: Vec::new(),
+            values: Vec::new(),
+        })
+    }
+
+    fn serialize_tuple_struct(
+        self,
+        name: &'static str,
+        _len: usize,
+    ) -> Result<Self::SerializeTupleStruct> {
+        Ok(TupleStructSerializer {
+            tracer: &mut *self.tracer,
+            name,
+            formats: Vec::new(),
+            values: Vec::new(),
+        })
+    }
+
+    fn serialize_tuple_variant(
+        self,
+        name: &'static str,
+        variant_index: u32,
+        variant_name: &'static str,
+        _len: usize,
+    ) -> Result<Self::SerializeTupleVariant> {
+        Ok(TupleVariantSerializer {
+            tracer: &mut *self.tracer,
+            name,
+            variant_index,
+            variant_name,
+            formats: Vec::new(),
+            values: Vec::new(),
+        })
+    }
+
+    fn serialize_map(self, _len: Option<usize>) -> Result<Self::SerializeMap> {
+        Ok(MapSerializer {
+            tracer: &mut *self.tracer,
+            key_format: Format::Unknown,
+            value_format: Format::Unknown,
+            values: Vec::new(),
+        })
+    }
+
+    fn serialize_struct(self, name: &'static str, _len: usize) -> Result<Self::SerializeStruct> {
+        Ok(StructSerializer {
+            tracer: &mut *self.tracer,
+            name,
+            fields: Vec::new(),
+            values: Vec::new(),
+        })
+    }
+
+    fn serialize_struct_variant(
+        self,
+        name: &'static str,
+        variant_index: u32,
+        variant_name: &'static str,
+        _len: usize,
+    ) -> Result<Self::SerializeStructVariant> {
+        Ok(StructVariantSerializer {
+            tracer: &mut *self.tracer,
+            name,
+            variant_index,
+            variant_name,
+            fields: Vec::new(),
+            values: Vec::new(),
+        })
+    }
+
+    fn is_human_readable(&self) -> bool {
+        self.tracer.is_human_readable
+    }
+}
+
+pub struct SeqSerializer<'a> {
+    tracer: &'a mut Tracer,
+    format: Format,
+    values: Vec<Value>,
+}
+
+impl<'a> ser::SerializeSeq for SeqSerializer<'a> {
+    type Ok = (Format, Value);
+    type Error = Error;
+
+    fn serialize_element<T>(&mut self, value: &T) -> Result<()>
+    where
+        T: ?Sized + Serialize,
+    {
+        let (format, value) = value.serialize(Serializer::new(&mut self.tracer))?;
+        self.format.merge(format)?;
+        self.values.push(value);
+        Ok(())
+    }
+
+    fn end(self) -> Result<(Format, Value)> {
+        Ok((Format::Seq(Box::new(self.format)), Value::Seq(self.values)))
+    }
+}
+
+pub struct TupleSerializer<'a> {
+    tracer: &'a mut Tracer,
+    formats: Vec<Format>,
+    values: Vec<Value>,
+}
+
+impl<'a> ser::SerializeTuple for TupleSerializer<'a> {
+    type Ok = (Format, Value);
+    type Error = Error;
+
+    fn serialize_element<T>(&mut self, value: &T) -> Result<()>
+    where
+        T: ?Sized + Serialize,
+    {
+        let (format, value) = value.serialize(Serializer::new(&mut self.tracer))?;
+        self.formats.push(format);
+        self.values.push(value);
+        Ok(())
+    }
+
+    fn end(self) -> Result<(Format, Value)> {
+        Ok((Format::Tuple(self.formats), Value::Seq(self.values)))
+    }
+}
+
+pub struct TupleStructSerializer<'a> {
+    tracer: &'a mut Tracer,
+    name: &'static str,
+    formats: Vec<Format>,
+    values: Vec<Value>,
+}
+
+impl<'a> ser::SerializeTupleStruct for TupleStructSerializer<'a> {
+    type Ok = (Format, Value);
+    type Error = Error;
+
+    fn serialize_field<T>(&mut self, value: &T) -> Result<()>
+    where
+        T: ?Sized + Serialize,
+    {
+        let (format, value) = value.serialize(Serializer::new(&mut self.tracer))?;
+        self.formats.push(format);
+        self.values.push(value);
+        Ok(())
+    }
+
+    fn end(self) -> Result<(Format, Value)> {
+        let format = Format::TupleStruct(self.formats);
+        let value = Value::Seq(self.values);
+        self.tracer.record(self.name, format, value)
+    }
+}
+
+pub struct TupleVariantSerializer<'a> {
+    tracer: &'a mut Tracer,
+    name: &'static str,
+    variant_index: u32,
+    variant_name: &'static str,
+    formats: Vec<Format>,
+    values: Vec<Value>,
+}
+
+impl<'a> ser::SerializeTupleVariant for TupleVariantSerializer<'a> {
+    type Ok = (Format, Value);
+    type Error = Error;
+
+    fn serialize_field<T>(&mut self, v: &T) -> Result<()>
+    where
+        T: ?Sized + Serialize,
+    {
+        let (format, value) = v.serialize(Serializer::new(&mut self.tracer))?;
+        self.formats.push(format);
+        self.values.push(value);
+        Ok(())
+    }
+
+    fn end(self) -> Result<(Format, Value)> {
+        let variant = VariantFormat::Tuple(self.formats);
+        let value = Value::Seq(self.values);
+        self.tracer.record_variant(
+            self.name,
+            self.variant_index,
+            self.variant_name,
+            variant,
+            value,
+        )
+    }
+}
+
+pub struct MapSerializer<'a> {
+    tracer: &'a mut Tracer,
+    key_format: Format,
+    value_format: Format,
+    values: Vec<Value>,
+}
+
+impl<'a> ser::SerializeMap for MapSerializer<'a> {
+    type Ok = (Format, Value);
+    type Error = Error;
+
+    fn serialize_key<T>(&mut self, key: &T) -> Result<()>
+    where
+        T: ?Sized + Serialize,
+    {
+        let (format, value) = key.serialize(Serializer::new(&mut self.tracer))?;
+        self.key_format.merge(format)?;
+        self.values.push(value);
+        Ok(())
+    }
+
+    fn serialize_value<T>(&mut self, value: &T) -> Result<()>
+    where
+        T: ?Sized + Serialize,
+    {
+        let (format, value) = value.serialize(Serializer::new(&mut self.tracer))?;
+        self.value_format.merge(format)?;
+        self.values.push(value);
+        Ok(())
+    }
+
+    fn end(self) -> Result<(Format, Value)> {
+        let format = Format::Map {
+            key: Box::new(self.key_format),
+            value: Box::new(self.value_format),
+        };
+        let value = Value::Seq(self.values);
+        Ok((format, value))
+    }
+}
+
+pub struct StructSerializer<'a> {
+    tracer: &'a mut Tracer,
+    name: &'static str,
+    fields: Vec<Named<Format>>,
+    values: Vec<Value>,
+}
+
+impl<'a> ser::SerializeStruct for StructSerializer<'a> {
+    type Ok = (Format, Value);
+    type Error = Error;
+
+    fn serialize_field<T>(&mut self, name: &'static str, value: &T) -> Result<()>
+    where
+        T: ?Sized + Serialize,
+    {
+        let (format, value) = value.serialize(Serializer::new(&mut self.tracer))?;
+        self.fields.push(Named {
+            name: name.into(),
+            value: format,
+        });
+        self.values.push(value);
+        Ok(())
+    }
+
+    fn end(self) -> Result<(Format, Value)> {
+        let format = Format::Struct(self.fields);
+        let value = Value::Seq(self.values);
+        self.tracer.record(self.name, format, value)
+    }
+}
+
+pub struct StructVariantSerializer<'a> {
+    tracer: &'a mut Tracer,
+    name: &'static str,
+    variant_index: u32,
+    variant_name: &'static str,
+    fields: Vec<Named<Format>>,
+    values: Vec<Value>,
+}
+
+impl<'a> ser::SerializeStructVariant for StructVariantSerializer<'a> {
+    type Ok = (Format, Value);
+    type Error = Error;
+
+    fn serialize_field<T>(&mut self, name: &'static str, value: &T) -> Result<()>
+    where
+        T: ?Sized + Serialize,
+    {
+        let (format, value) = value.serialize(Serializer::new(&mut self.tracer))?;
+        self.fields.push(Named {
+            name: name.into(),
+            value: format,
+        });
+        self.values.push(value);
+        Ok(())
+    }
+
+    fn end(self) -> Result<(Format, Value)> {
+        let variant = VariantFormat::Struct(self.fields);
+        let value = Value::Seq(self.values);
+        self.tracer.record_variant(
+            self.name,
+            self.variant_index,
+            self.variant_name,
+            variant,
+            value,
+        )
+    }
+}

--- a/common/serde-reflection/src/trace.rs
+++ b/common/serde-reflection/src/trace.rs
@@ -2,37 +2,152 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::{
+    de::Deserializer,
     error::{Error, Result},
     format::*,
+    ser::Serializer,
+    value::Value,
 };
-use serde::{ser, Serialize};
-use std::collections::BTreeMap;
+use serde::{de::DeserializeSeed, Deserialize, Serialize};
+use std::collections::{BTreeMap, BTreeSet};
 
 #[derive(Debug)]
 pub struct Tracer {
-    /// Whether to trace the human readable variant of the Serialize trait.
-    is_human_readable: bool,
-    /// Formats of all named containers that we have traced so far.
-    registry: BTreeMap<&'static str, Format>,
+    /// Whether to trace the human readable variant of the (De)Serialize traits.
+    pub(crate) is_human_readable: bool,
+
+    /// Formats of the named containers discovered so far, while tracing
+    /// serialization and/or deserialization.
+    pub(crate) registry: BTreeMap<&'static str, Format>,
+
+    /// Value samples recorded during serialization.
+    /// This will help passing user-defined checks during deserialization.
+    values: BTreeMap<&'static str, Value>,
+
+    /// Enums that have detected to be yet incomplete (i.e. missing variants)
+    /// while tracing deserialization.
+    pub(crate) incomplete_enums: BTreeSet<String>,
 }
 
 impl Tracer {
-    /// Start tracing serialization.
+    /// Start tracing deserialization.
     pub fn new(is_human_readable: bool) -> Self {
         Self {
             is_human_readable,
             registry: BTreeMap::new(),
+            values: BTreeMap::new(),
+            incomplete_enums: BTreeSet::new(),
         }
     }
 
     /// Trace the serialization of a particular value.
     /// Nested containers will be added to the global registry, indexed by
     /// their (non-qualified) name.
-    pub fn trace<T>(&mut self, value: &T) -> Result<Format>
+    pub fn trace_value<T>(&mut self, value: &T) -> Result<(Format, Value)>
     where
         T: ?Sized + Serialize,
     {
-        value.serialize(self)
+        let serializer = Serializer::new(self);
+        value.serialize(serializer)
+    }
+
+    /// Trace a single deserialization of a particular type.
+    /// Nested containers will be added to the global registry, indexed by
+    /// their (non-qualified) name.
+    pub fn trace_type_once<'de, T>(&mut self) -> Result<Format>
+    where
+        T: Deserialize<'de>,
+    {
+        let mut format = Format::Unknown;
+        let deserializer = Deserializer::new(&mut *self, &mut format);
+        T::deserialize(deserializer)?;
+        Ok(format)
+    }
+
+    /// Same as trace_type_once for seeded deserialization.
+    pub fn trace_type_once_with_seed<'de, T>(&mut self, seed: T) -> Result<Format>
+    where
+        T: DeserializeSeed<'de>,
+    {
+        let mut format = Format::Unknown;
+        let deserializer = Deserializer::new(&mut *self, &mut format);
+        seed.deserialize(deserializer)?;
+        Ok(format)
+    }
+
+    /// Same as trace_type_once but if `T` is an enum, we repeat the process
+    /// until all variants are covered.
+    pub fn trace_type<'de, T>(&mut self) -> Result<Format>
+    where
+        T: Deserialize<'de>,
+    {
+        loop {
+            let format = self.trace_type_once::<T>()?;
+            if let Format::TypeName(name) = &format {
+                if self.incomplete_enums.contains(name) {
+                    self.incomplete_enums.remove(name);
+                    continue;
+                }
+            }
+            return Ok(format);
+        }
+    }
+
+    /// Same as `trace` for seeded deserialization.
+    pub fn trace_type_with_seed<'de, T>(&'de mut self, seed: T) -> Result<Format>
+    where
+        T: DeserializeSeed<'de> + Clone,
+    {
+        loop {
+            let format = self.trace_type_once_with_seed(seed.clone())?;
+            if let Format::TypeName(name) = &format {
+                if self.incomplete_enums.contains(name) {
+                    self.incomplete_enums.remove(name);
+                    continue;
+                }
+            }
+            return Ok(format);
+        }
+    }
+
+    /// Compute a default value for `T`.
+    /// Return true if `T` is an enum and more values are needed to cover
+    /// all variant cases.
+    pub fn sample_type_once<'de, T>(&mut self) -> Result<(T, bool)>
+    where
+        T: Deserialize<'de>,
+    {
+        let mut format = Format::Unknown;
+        let deserializer = Deserializer::new(&mut *self, &mut format);
+        let value = T::deserialize(deserializer)?;
+        let has_more = match &format {
+            Format::TypeName(name) => {
+                if self.incomplete_enums.contains(name) {
+                    self.incomplete_enums.remove(name);
+                    true
+                } else {
+                    false
+                }
+            }
+            _ => false,
+        };
+        Ok((value, has_more))
+    }
+
+    /// Same as sample_type_once but if `T` is an enum, we repeat the process
+    /// until all variants are covered.
+    pub fn sample_type<'de, T>(&mut self) -> Result<Vec<T>>
+    where
+        T: Deserialize<'de>,
+    {
+        let mut values = Vec::new();
+        loop {
+            let (value, has_more) = self.sample_type_once::<T>()?;
+            values.push(value);
+            if !has_more {
+                return Ok(values);
+            }
+        }
     }
 
     /// Finish tracing and recover a map of normalized formats.
@@ -41,25 +156,47 @@ impl Tracer {
         for format in registry.values_mut() {
             format.normalize()?;
         }
+        if self.incomplete_enums.is_empty() {
+            Ok(registry)
+        } else {
+            Err(Error::MissingVariants(
+                self.incomplete_enums.into_iter().collect(),
+            ))
+        }
+    }
+
+    /// Same as registry but always return a value, even if we detected issues.
+    /// This should only be use for debugging.
+    pub fn registry_unchecked(self) -> Result<BTreeMap<&'static str, Format>> {
+        let mut registry = self.registry;
+        for format in registry.values_mut() {
+            format.normalize().unwrap_or(());
+        }
         Ok(registry)
     }
 }
 
 impl Tracer {
-    fn record(&mut self, name: &'static str, format: Format) -> Result<Format> {
-        // Note that we assume unqualified names to be unique.
+    pub(crate) fn record(
+        &mut self,
+        name: &'static str,
+        format: Format,
+        value: Value,
+    ) -> Result<(Format, Value)> {
         let entry = self.registry.entry(name).or_insert(Format::Unknown);
         entry.merge(format)?;
-        Ok(Format::TypeName(name.into()))
+        self.values.insert(name, value.clone());
+        Ok((Format::TypeName(name.into()), value))
     }
 
-    fn record_variant(
+    pub(crate) fn record_variant(
         &mut self,
         name: &'static str,
         variant_index: u32,
         variant_name: &'static str,
         variant: VariantFormat,
-    ) -> Result<Format> {
+        variant_value: Value,
+    ) -> Result<(Format, Value)> {
         let mut variants = BTreeMap::new();
         variants.insert(
             variant_index,
@@ -68,407 +205,12 @@ impl Tracer {
                 value: variant,
             },
         );
-        self.record(name, Format::Variant(variants))
-    }
-}
-
-impl<'a> ser::Serializer for &'a mut Tracer {
-    type Ok = Format;
-    type Error = Error;
-    type SerializeSeq = SeqTracer<'a>;
-    type SerializeTuple = TupleTracer<'a>;
-    type SerializeTupleStruct = TupleStructTracer<'a>;
-    type SerializeTupleVariant = TupleVariantTracer<'a>;
-    type SerializeMap = MapTracer<'a>;
-    type SerializeStruct = StructTracer<'a>;
-    type SerializeStructVariant = StructVariantTracer<'a>;
-
-    fn serialize_bool(self, _v: bool) -> Result<Format> {
-        Ok(Format::Bool)
+        let format = Format::Variant(variants);
+        let value = Value::Variant(variant_index, Box::new(variant_value));
+        self.record(name, format, value)
     }
 
-    fn serialize_i8(self, _v: i8) -> Result<Format> {
-        Ok(Format::I8)
-    }
-
-    fn serialize_i16(self, _v: i16) -> Result<Format> {
-        Ok(Format::I16)
-    }
-
-    fn serialize_i32(self, _v: i32) -> Result<Format> {
-        Ok(Format::I32)
-    }
-
-    fn serialize_i64(self, _v: i64) -> Result<Format> {
-        Ok(Format::I64)
-    }
-
-    fn serialize_i128(self, _v: i128) -> Result<Format> {
-        Ok(Format::I128)
-    }
-
-    fn serialize_u8(self, _v: u8) -> Result<Format> {
-        Ok(Format::U8)
-    }
-
-    fn serialize_u16(self, _v: u16) -> Result<Format> {
-        Ok(Format::U16)
-    }
-
-    fn serialize_u32(self, _v: u32) -> Result<Format> {
-        Ok(Format::U32)
-    }
-
-    fn serialize_u64(self, _v: u64) -> Result<Format> {
-        Ok(Format::U64)
-    }
-
-    fn serialize_u128(self, _v: u128) -> Result<Format> {
-        Ok(Format::U128)
-    }
-
-    fn serialize_f32(self, _v: f32) -> Result<Format> {
-        Ok(Format::F32)
-    }
-
-    fn serialize_f64(self, _v: f64) -> Result<Format> {
-        Ok(Format::F64)
-    }
-
-    fn serialize_char(self, _v: char) -> Result<Format> {
-        Ok(Format::Char)
-    }
-
-    fn serialize_str(self, _v: &str) -> Result<Format> {
-        Ok(Format::Str)
-    }
-
-    fn serialize_bytes(self, _v: &[u8]) -> Result<Format> {
-        Ok(Format::Bytes)
-    }
-
-    fn serialize_none(self) -> Result<Format> {
-        Ok(Format::Unknown)
-    }
-
-    fn serialize_some<T>(self, value: &T) -> Result<Format>
-    where
-        T: ?Sized + Serialize,
-    {
-        let format = value.serialize(self)?;
-        Ok(Format::Option(Box::new(format)))
-    }
-
-    fn serialize_unit(self) -> Result<Format> {
-        Ok(Format::Unit)
-    }
-
-    fn serialize_unit_struct(self, name: &'static str) -> Result<Format> {
-        self.record(name, Format::UnitStruct)
-    }
-
-    fn serialize_unit_variant(
-        self,
-        name: &'static str,
-        variant_index: u32,
-        variant_name: &'static str,
-    ) -> Result<Format> {
-        self.record_variant(name, variant_index, variant_name, VariantFormat::Unit)
-    }
-
-    fn serialize_newtype_struct<T>(self, name: &'static str, value: &T) -> Result<Format>
-    where
-        T: ?Sized + Serialize,
-    {
-        let format = Box::new(value.serialize(&mut *self)?);
-        self.record(name, Format::NewTypeStruct(format))
-    }
-
-    fn serialize_newtype_variant<T>(
-        self,
-        name: &'static str,
-        variant_index: u32,
-        variant_name: &'static str,
-        value: &T,
-    ) -> Result<Format>
-    where
-        T: ?Sized + Serialize,
-    {
-        let format = Box::new(value.serialize(&mut *self)?);
-        self.record_variant(
-            name,
-            variant_index,
-            variant_name,
-            VariantFormat::NewType(format),
-        )
-    }
-
-    fn serialize_seq(self, _len: Option<usize>) -> Result<Self::SerializeSeq> {
-        Ok(SeqTracer {
-            tracer: self,
-            value: Format::Unknown,
-        })
-    }
-
-    fn serialize_tuple(self, _len: usize) -> Result<Self::SerializeTuple> {
-        Ok(TupleTracer {
-            tracer: self,
-            values: Vec::new(),
-        })
-    }
-
-    fn serialize_tuple_struct(
-        self,
-        name: &'static str,
-        _len: usize,
-    ) -> Result<Self::SerializeTupleStruct> {
-        Ok(TupleStructTracer {
-            tracer: self,
-            name,
-            fields: Vec::new(),
-        })
-    }
-
-    fn serialize_tuple_variant(
-        self,
-        name: &'static str,
-        variant_index: u32,
-        variant_name: &'static str,
-        _len: usize,
-    ) -> Result<Self::SerializeTupleVariant> {
-        Ok(TupleVariantTracer {
-            tracer: self,
-            name,
-            variant_index,
-            variant_name,
-            fields: Vec::new(),
-        })
-    }
-
-    fn serialize_map(self, _len: Option<usize>) -> Result<Self::SerializeMap> {
-        Ok(MapTracer {
-            tracer: self,
-            key: Format::Unknown,
-            value: Format::Unknown,
-        })
-    }
-
-    fn serialize_struct(self, name: &'static str, _len: usize) -> Result<Self::SerializeStruct> {
-        Ok(StructTracer {
-            tracer: self,
-            name,
-            fields: Vec::new(),
-        })
-    }
-
-    fn serialize_struct_variant(
-        self,
-        name: &'static str,
-        variant_index: u32,
-        variant_name: &'static str,
-        _len: usize,
-    ) -> Result<Self::SerializeStructVariant> {
-        Ok(StructVariantTracer {
-            tracer: self,
-            name,
-            variant_index,
-            variant_name,
-            fields: Vec::new(),
-        })
-    }
-
-    fn is_human_readable(&self) -> bool {
-        self.is_human_readable
-    }
-}
-
-pub struct SeqTracer<'a> {
-    tracer: &'a mut Tracer,
-    value: Format,
-}
-
-impl<'a> ser::SerializeSeq for SeqTracer<'a> {
-    type Ok = Format;
-    type Error = Error;
-
-    fn serialize_element<T>(&mut self, value: &T) -> Result<()>
-    where
-        T: ?Sized + Serialize,
-    {
-        let format = value.serialize(&mut *self.tracer)?;
-        self.value.merge(format)
-    }
-
-    fn end(self) -> Result<Format> {
-        Ok(Format::Seq(Box::new(self.value)))
-    }
-}
-
-pub struct TupleTracer<'a> {
-    tracer: &'a mut Tracer,
-    values: Vec<Format>,
-}
-
-impl<'a> ser::SerializeTuple for TupleTracer<'a> {
-    type Ok = Format;
-    type Error = Error;
-
-    fn serialize_element<T>(&mut self, value: &T) -> Result<()>
-    where
-        T: ?Sized + Serialize,
-    {
-        let format = value.serialize(&mut *self.tracer)?;
-        self.values.push(format);
-        Ok(())
-    }
-
-    fn end(self) -> Result<Format> {
-        Ok(Format::Tuple(self.values))
-    }
-}
-
-pub struct TupleStructTracer<'a> {
-    tracer: &'a mut Tracer,
-    name: &'static str,
-    fields: Vec<Format>,
-}
-
-impl<'a> ser::SerializeTupleStruct for TupleStructTracer<'a> {
-    type Ok = Format;
-    type Error = Error;
-
-    fn serialize_field<T>(&mut self, value: &T) -> Result<()>
-    where
-        T: ?Sized + Serialize,
-    {
-        let format = value.serialize(&mut *self.tracer)?;
-        self.fields.push(format);
-        Ok(())
-    }
-
-    fn end(self) -> Result<Format> {
-        let format = Format::TupleStruct(self.fields);
-        self.tracer.record(self.name, format)
-    }
-}
-
-pub struct TupleVariantTracer<'a> {
-    tracer: &'a mut Tracer,
-    name: &'static str,
-    variant_index: u32,
-    variant_name: &'static str,
-    fields: Vec<Format>,
-}
-
-impl<'a> ser::SerializeTupleVariant for TupleVariantTracer<'a> {
-    type Ok = Format;
-    type Error = Error;
-
-    fn serialize_field<T>(&mut self, value: &T) -> Result<()>
-    where
-        T: ?Sized + Serialize,
-    {
-        let format = value.serialize(&mut *self.tracer)?;
-        self.fields.push(format);
-        Ok(())
-    }
-
-    fn end(self) -> Result<Format> {
-        let variant = VariantFormat::Tuple(self.fields);
-        self.tracer
-            .record_variant(self.name, self.variant_index, self.variant_name, variant)
-    }
-}
-
-pub struct MapTracer<'a> {
-    tracer: &'a mut Tracer,
-    key: Format,
-    value: Format,
-}
-
-impl<'a> ser::SerializeMap for MapTracer<'a> {
-    type Ok = Format;
-    type Error = Error;
-
-    fn serialize_key<T>(&mut self, key: &T) -> Result<()>
-    where
-        T: ?Sized + Serialize,
-    {
-        let format = key.serialize(&mut *self.tracer)?;
-        self.key.merge(format)
-    }
-
-    fn serialize_value<T>(&mut self, value: &T) -> Result<()>
-    where
-        T: ?Sized + Serialize,
-    {
-        let format = value.serialize(&mut *self.tracer)?;
-        self.value.merge(format)
-    }
-
-    fn end(self) -> Result<Format> {
-        Ok(Format::Map {
-            key: Box::new(self.key),
-            value: Box::new(self.value),
-        })
-    }
-}
-
-pub struct StructTracer<'a> {
-    tracer: &'a mut Tracer,
-    name: &'static str,
-    fields: Vec<Named<Format>>,
-}
-
-impl<'a> ser::SerializeStruct for StructTracer<'a> {
-    type Ok = Format;
-    type Error = Error;
-
-    fn serialize_field<T>(&mut self, name: &'static str, value: &T) -> Result<()>
-    where
-        T: ?Sized + Serialize,
-    {
-        let format = value.serialize(&mut *self.tracer)?;
-        self.fields.push(Named {
-            name: name.into(),
-            value: format,
-        });
-        Ok(())
-    }
-
-    fn end(self) -> Result<Format> {
-        let format = Format::Struct(self.fields);
-        self.tracer.record(self.name, format)
-    }
-}
-
-pub struct StructVariantTracer<'a> {
-    tracer: &'a mut Tracer,
-    name: &'static str,
-    variant_index: u32,
-    variant_name: &'static str,
-    fields: Vec<Named<Format>>,
-}
-
-impl<'a> ser::SerializeStructVariant for StructVariantTracer<'a> {
-    type Ok = Format;
-    type Error = Error;
-
-    fn serialize_field<T>(&mut self, name: &'static str, value: &T) -> Result<()>
-    where
-        T: ?Sized + Serialize,
-    {
-        let format = value.serialize(&mut *self.tracer)?;
-        self.fields.push(Named {
-            name: name.into(),
-            value: format,
-        });
-        Ok(())
-    }
-
-    fn end(self) -> Result<Format> {
-        let variant = VariantFormat::Struct(self.fields);
-        self.tracer
-            .record_variant(self.name, self.variant_index, self.variant_name, variant)
+    pub(crate) fn get_value(&mut self, name: &'static str) -> Option<&Value> {
+        self.values.get(name)
     }
 }

--- a/common/serde-reflection/src/value.rs
+++ b/common/serde-reflection/src/value.rs
@@ -4,6 +4,8 @@
 use crate::error::{Error, Result};
 use serde::de::{self, DeserializeSeed, IntoDeserializer, Visitor};
 
+/// A structured Serde value.
+/// Meant to be easily recorded while tracing serialization and easily used while tracing deserialization.
 #[derive(Debug, Clone, PartialEq)]
 pub enum Value {
     Unit,
@@ -33,6 +35,7 @@ pub enum Value {
     Seq(Vec<Value>),
 }
 
+/// Deserializer meant to reconstruct the Rust value behind a particular Serde value.
 pub struct Deserializer {
     value: Value,
 }

--- a/common/serde-reflection/src/value.rs
+++ b/common/serde-reflection/src/value.rs
@@ -1,0 +1,373 @@
+// Copyright (c) The Libra Core Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::error::{Error, Result};
+use serde::de::{self, DeserializeSeed, IntoDeserializer, Visitor};
+
+#[derive(Debug, Clone, PartialEq)]
+pub enum Value {
+    Unit,
+    Bool(bool),
+
+    I8(i8),
+    I16(i16),
+    I32(i32),
+    I64(i64),
+    I128(i128),
+
+    U8(u8),
+    U16(u16),
+    U32(u32),
+    U64(u64),
+    U128(u128),
+
+    F32(f32),
+    F64(f64),
+
+    Char(char),
+    Str(String),
+    Bytes(Vec<u8>),
+
+    Option(Option<Box<Value>>),
+    Variant(u32, Box<Value>),
+    Seq(Vec<Value>),
+}
+
+pub struct Deserializer {
+    value: Value,
+}
+
+impl Deserializer {
+    pub fn new(value: Value) -> Self {
+        Self { value }
+    }
+}
+
+impl<'de> IntoDeserializer<'de, Error> for Value {
+    type Deserializer = Deserializer;
+
+    fn into_deserializer(self) -> Self::Deserializer {
+        Deserializer::new(self)
+    }
+}
+
+macro_rules! declare_deserialize {
+    ($method:ident, $token:ident, $visit:ident, $str:expr) => {
+        fn $method<V>(self, visitor: V) -> Result<V::Value>
+        where
+            V: Visitor<'de>,
+        {
+            match self.value {
+                Value::$token(x) => visitor.$visit(x),
+                _ => Err(Error::DeserializationError($str)),
+            }
+        }
+    }
+}
+
+impl<'de> de::Deserializer<'de> for Deserializer {
+    type Error = Error;
+
+    fn deserialize_any<V>(self, _visitor: V) -> Result<V::Value>
+    where
+        V: Visitor<'de>,
+    {
+        Err(Error::NotSupported("deserialize_any"))
+    }
+
+    declare_deserialize!(deserialize_bool, Bool, visit_bool, "bool");
+
+    declare_deserialize!(deserialize_i8, I8, visit_i8, "i8");
+    declare_deserialize!(deserialize_i16, I16, visit_i16, "i16");
+    declare_deserialize!(deserialize_i32, I32, visit_i32, "i32");
+    declare_deserialize!(deserialize_i64, I64, visit_i64, "i64");
+    declare_deserialize!(deserialize_i128, I128, visit_i128, "i128");
+
+    declare_deserialize!(deserialize_u8, U8, visit_u8, "u8");
+    declare_deserialize!(deserialize_u16, U16, visit_u16, "u16");
+    declare_deserialize!(deserialize_u32, U32, visit_u32, "u32");
+    declare_deserialize!(deserialize_u64, U64, visit_u64, "u64");
+    declare_deserialize!(deserialize_u128, U128, visit_u128, "u128");
+
+    declare_deserialize!(deserialize_f32, F32, visit_f32, "f32");
+    declare_deserialize!(deserialize_f64, F64, visit_f64, "f64");
+
+    declare_deserialize!(deserialize_char, Char, visit_char, "char");
+    declare_deserialize!(deserialize_string, Str, visit_string, "string");
+    declare_deserialize!(deserialize_str, Str, visit_string, "str");
+    declare_deserialize!(deserialize_byte_buf, Bytes, visit_byte_buf, "byte_buf");
+    declare_deserialize!(deserialize_bytes, Bytes, visit_byte_buf, "bytes");
+
+    fn deserialize_option<V>(self, visitor: V) -> Result<V::Value>
+    where
+        V: Visitor<'de>,
+    {
+        match self.value {
+            Value::Option(None) => visitor.visit_none(),
+            Value::Option(Some(x)) => visitor.visit_some(x.into_deserializer()),
+            _ => Err(Error::DeserializationError("option")),
+        }
+    }
+
+    fn deserialize_unit<V>(self, visitor: V) -> Result<V::Value>
+    where
+        V: Visitor<'de>,
+    {
+        match self.value {
+            Value::Unit => visitor.visit_unit(),
+            _ => Err(Error::DeserializationError("unit")),
+        }
+    }
+
+    fn deserialize_unit_struct<V>(self, _name: &'static str, visitor: V) -> Result<V::Value>
+    where
+        V: Visitor<'de>,
+    {
+        match self.value {
+            Value::Unit => visitor.visit_unit(),
+            _ => Err(Error::DeserializationError("unit struct")),
+        }
+    }
+
+    fn deserialize_newtype_struct<V>(self, _name: &'static str, visitor: V) -> Result<V::Value>
+    where
+        V: Visitor<'de>,
+    {
+        visitor.visit_newtype_struct(self)
+    }
+
+    fn deserialize_seq<V>(self, visitor: V) -> Result<V::Value>
+    where
+        V: Visitor<'de>,
+    {
+        match self.value {
+            Value::Seq(x) => visitor.visit_seq(x.into_seq_deserializer()),
+            _ => Err(Error::DeserializationError("seq")),
+        }
+    }
+
+    fn deserialize_tuple<V>(self, _len: usize, visitor: V) -> Result<V::Value>
+    where
+        V: Visitor<'de>,
+    {
+        match self.value {
+            Value::Seq(x) => visitor.visit_seq(x.into_seq_deserializer()),
+            _ => Err(Error::DeserializationError("tuple")),
+        }
+    }
+
+    fn deserialize_tuple_struct<V>(
+        self,
+        _name: &'static str,
+        _len: usize,
+        visitor: V,
+    ) -> Result<V::Value>
+    where
+        V: Visitor<'de>,
+    {
+        match self.value {
+            Value::Seq(x) => visitor.visit_seq(x.into_seq_deserializer()),
+            _ => Err(Error::DeserializationError("tuple struct")),
+        }
+    }
+
+    fn deserialize_map<V>(self, visitor: V) -> Result<V::Value>
+    where
+        V: Visitor<'de>,
+    {
+        match self.value {
+            Value::Seq(x) => visitor.visit_seq(x.into_seq_deserializer()),
+            _ => Err(Error::DeserializationError("map")),
+        }
+    }
+
+    fn deserialize_struct<V>(
+        self,
+        _name: &'static str,
+        _fields: &'static [&'static str],
+        visitor: V,
+    ) -> Result<V::Value>
+    where
+        V: Visitor<'de>,
+    {
+        match self.value {
+            Value::Seq(x) => visitor.visit_seq(x.into_seq_deserializer()),
+            _ => Err(Error::DeserializationError("tuple struct")),
+        }
+    }
+
+    fn deserialize_enum<V>(
+        self,
+        _name: &'static str,
+        _variants: &'static [&'static str],
+        visitor: V,
+    ) -> Result<V::Value>
+    where
+        V: Visitor<'de>,
+    {
+        match self.value {
+            Value::Variant(index, variant) => {
+                let inner = EnumDeserializer::new(index, *variant);
+                visitor.visit_enum(inner)
+            }
+            _ => Err(Error::DeserializationError("enum")),
+        }
+    }
+
+    // Not needed since we always deserialize structs as sequences.
+    fn deserialize_identifier<V>(self, _visitor: V) -> Result<V::Value>
+    where
+        V: Visitor<'de>,
+    {
+        Err(Error::NotSupported("deserialize_identifier"))
+    }
+
+    fn deserialize_ignored_any<V>(self, _visitor: V) -> Result<V::Value>
+    where
+        V: Visitor<'de>,
+    {
+        Err(Error::NotSupported("deserialize_ignored_any"))
+    }
+
+    fn is_human_readable(&self) -> bool {
+        false
+    }
+}
+
+struct SeqDeserializer<I> {
+    values: I,
+}
+
+trait IntoSeqDeserializer {
+    type SeqDeserializer;
+
+    fn into_seq_deserializer(self) -> Self::SeqDeserializer;
+}
+
+impl<I> SeqDeserializer<I> {
+    fn new(values: I) -> Self {
+        Self { values }
+    }
+}
+
+impl IntoSeqDeserializer for Vec<Value> {
+    type SeqDeserializer = SeqDeserializer<std::vec::IntoIter<Value>>;
+
+    fn into_seq_deserializer(self) -> Self::SeqDeserializer {
+        SeqDeserializer::new(self.into_iter())
+    }
+}
+
+impl<'de, I> de::SeqAccess<'de> for SeqDeserializer<I>
+where
+    I: Iterator<Item = Value>,
+{
+    type Error = Error;
+
+    fn next_element_seed<T>(&mut self, seed: T) -> Result<Option<T::Value>>
+    where
+        T: DeserializeSeed<'de>,
+    {
+        match self.values.next() {
+            Some(x) => seed.deserialize(x.into_deserializer()).map(Some),
+            None => Ok(None),
+        }
+    }
+
+    fn size_hint(&self) -> Option<usize> {
+        self.values.size_hint().1
+    }
+}
+
+impl<'de, I> de::MapAccess<'de> for SeqDeserializer<I>
+where
+    I: Iterator<Item = Value>,
+{
+    type Error = Error;
+
+    fn next_key_seed<K>(&mut self, seed: K) -> Result<Option<K::Value>>
+    where
+        K: DeserializeSeed<'de>,
+    {
+        match self.values.next() {
+            Some(x) => seed.deserialize(x.into_deserializer()).map(Some),
+            None => Ok(None),
+        }
+    }
+
+    fn next_value_seed<V>(&mut self, seed: V) -> Result<V::Value>
+    where
+        V: DeserializeSeed<'de>,
+    {
+        match self.values.next() {
+            Some(x) => seed.deserialize(x.into_deserializer()),
+            None => Err(Error::DeserializationError("map (invalid sequence)")),
+        }
+    }
+
+    fn size_hint(&self) -> Option<usize> {
+        self.values.size_hint().1.map(|x| x / 2)
+    }
+}
+
+struct EnumDeserializer {
+    index: u32,
+    value: Value,
+}
+
+impl EnumDeserializer {
+    fn new(index: u32, value: Value) -> Self {
+        Self { index, value }
+    }
+}
+
+impl<'de> de::EnumAccess<'de> for EnumDeserializer {
+    type Error = Error;
+    type Variant = Self;
+
+    fn variant_seed<V>(self, seed: V) -> Result<(V::Value, Self::Variant)>
+    where
+        V: DeserializeSeed<'de>,
+    {
+        let value = seed.deserialize(self.index.into_deserializer())?;
+        Ok((value, self))
+    }
+}
+
+impl<'de> de::VariantAccess<'de> for EnumDeserializer {
+    type Error = Error;
+
+    fn unit_variant(self) -> Result<()> {
+        match self.value {
+            Value::Unit => Ok(()),
+            _ => Err(Error::DeserializationError("unit variant")),
+        }
+    }
+
+    fn newtype_variant_seed<T>(self, seed: T) -> Result<T::Value>
+    where
+        T: DeserializeSeed<'de>,
+    {
+        seed.deserialize(self.value.into_deserializer())
+    }
+
+    fn tuple_variant<V>(self, _len: usize, visitor: V) -> Result<V::Value>
+    where
+        V: Visitor<'de>,
+    {
+        match self.value {
+            Value::Seq(x) => visitor.visit_seq(x.into_seq_deserializer()),
+            _ => Err(Error::DeserializationError("tuple variant")),
+        }
+    }
+
+    fn struct_variant<V>(self, _fields: &'static [&'static str], visitor: V) -> Result<V::Value>
+    where
+        V: Visitor<'de>,
+    {
+        match self.value {
+            Value::Seq(x) => visitor.visit_seq(x.into_seq_deserializer()),
+            _ => Err(Error::DeserializationError("struct variant")),
+        }
+    }
+}

--- a/common/serde-reflection/tests/serde.rs
+++ b/common/serde-reflection/tests/serde.rs
@@ -260,3 +260,23 @@ fn test_type_deserialization_with_custom_invariants() {
         &ContainerFormat::Enum(variants)
     );
 }
+
+mod foo {
+    #[derive(super::Serialize)]
+    pub struct A;
+}
+
+mod bar {
+    #[derive(super::Serialize)]
+    pub struct A(pub u32);
+}
+
+#[test]
+fn test_name_clash_not_suported() {
+    let mut tracer = Tracer::new(/* is_human_readable */ false);
+    tracer.trace_value(&foo::A).unwrap();
+    // Repeating names is fine.
+    assert!(tracer.trace_value(&foo::A).is_ok());
+    // but format have to match.
+    assert!(tracer.trace_value(&bar::A(0)).is_err());
+}

--- a/common/serde-reflection/tests/serde.rs
+++ b/common/serde-reflection/tests/serde.rs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use bincode;
-use libra_serde_reflection::{Format, Named, Tracer, Value, VariantFormat};
+use libra_serde_reflection::{ContainerFormat, Format, Named, Tracer, Value, VariantFormat};
 use serde::{de::IntoDeserializer, Deserialize, Serialize};
 use serde_json;
 use serde_yaml;
@@ -71,7 +71,7 @@ fn test_tracers() {
     let registry = tracer.registry().unwrap();
     let format = registry.get("E").unwrap();
     let variants = match format {
-        Format::Variant(variants) => variants,
+        ContainerFormat::Enum(variants) => variants,
         _ => {
             unreachable!();
         }
@@ -113,12 +113,12 @@ fn test_tracers() {
     // Format values can serialize and deserialize in text and binary encodings.
     let data = serde_json::to_string_pretty(format).unwrap();
     println!("{}\n", data);
-    let format2 = serde_json::from_str::<Format>(&data).unwrap();
+    let format2 = serde_json::from_str::<ContainerFormat>(&data).unwrap();
     assert_eq!(*format, format2);
 
     let data = serde_yaml::to_string(format).unwrap();
     println!("{}\n", data);
-    let format3 = serde_yaml::from_str::<Format>(&data).unwrap();
+    let format3 = serde_yaml::from_str::<ContainerFormat>(&data).unwrap();
     assert_eq!(*format, format3);
 
     let data = bincode::serialize(format).unwrap();

--- a/common/serde-reflection/tests/serde.rs
+++ b/common/serde-reflection/tests/serde.rs
@@ -128,15 +128,9 @@ fn test_tracers() {
 
     // Tracing deserialization
     let mut tracer = Tracer::new(/* is_human_readable */ false);
-    assert_eq!(
-        tracer.trace_type::<E>().unwrap(),
-        Format::TypeName("E".into())
-    );
+    let (ident, values) = tracer.trace_type::<E>().unwrap();
+    assert_eq!(ident, Format::TypeName("E".into()));
     assert_eq!(tracer.registry().unwrap().get("E").unwrap(), format);
-
-    // Sampling values with DTracer
-    let mut tracer = Tracer::new(/* is_human_readable */ false);
-    let values = tracer.sample_type::<E>().unwrap();
     assert_eq!(
         values,
         vec![
@@ -198,24 +192,10 @@ fn test_type_deserialization_with_custom_invariants() {
     assert_eq!(value, Value::Str("Bob".into()));
 
     // Now try again.
-    let format = tracer.trace_type::<Person>().unwrap();
+    let (format, values) = tracer.trace_type::<Person>().unwrap();
     assert_eq!(format, Format::TypeName("Person".into()));
-
-    // We can request a value for `Person`.
-    let (person, has_more) = tracer.sample_type_once::<Person>().unwrap();
-    assert_eq!(person, Person::NickName(bob.clone()));
-    assert!(!has_more);
-
-    // We cannot sample all values with this tracer any more.
-    let persons = tracer.sample_type::<Person>().unwrap();
-    assert_eq!(persons.len(), 1);
-
-    // .. but it would work if start from scratch.
-    let mut tracer = Tracer::new(/* is_human_readable */ false);
-    tracer.trace_value(&bob).unwrap();
-    let persons = tracer.sample_type::<Person>().unwrap();
     assert_eq!(
-        persons,
+        values,
         vec![
             Person::NickName(bob.clone()),
             Person::FullName {

--- a/common/serde-reflection/tests/serde.rs
+++ b/common/serde-reflection/tests/serde.rs
@@ -2,39 +2,71 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use bincode;
-use libra_serde_reflection::{Format, Named, Tracer, VariantFormat};
-use serde::Serialize;
+use libra_serde_reflection::{Format, Named, Tracer, Value, VariantFormat};
+use serde::{de::IntoDeserializer, Deserialize, Serialize};
 use serde_json;
 use serde_yaml;
 
-#[derive(Serialize)]
+#[derive(Serialize, Deserialize, PartialEq, Eq, Debug)]
 enum E {
     Unit,
     Newtype(u16),
-    Tuple(u16, u16),
+    Tuple(u16, Option<bool>),
     Struct { a: u32 },
     NewTupleArray((u16, u16, u16)),
 }
 
+fn test_variant(tracer: &mut Tracer, expr: E, expected_value: Value) {
+    let (format, value) = tracer.trace_value(&expr).unwrap();
+    // Check the local result of tracing.
+    assert_eq!(format, Format::TypeName("E".into()));
+    assert_eq!(value, expected_value);
+    // Check that the value deserializes back into the Rust value `expr`.
+    assert_eq!(expr, E::deserialize(value.into_deserializer()).unwrap());
+}
+
 #[test]
-fn test_tracer() {
+fn test_tracers() {
     let mut tracer = Tracer::new(/* is_human_readable */ false);
-    let ident = Format::TypeName("E".into());
 
-    let u = E::Unit;
-    assert_eq!(tracer.trace(&u).unwrap(), ident);
-
-    let n = E::Newtype(1);
-    assert_eq!(tracer.trace(&n).unwrap(), ident);
-
-    let t = E::Tuple(1, 2);
-    assert_eq!(tracer.trace(&t).unwrap(), ident);
-
-    let s = E::Struct { a: 1 };
-    assert_eq!(tracer.trace(&s).unwrap(), ident);
-
-    let r = E::NewTupleArray((1, 2, 3));
-    assert_eq!(tracer.trace(&r).unwrap(), ident);
+    test_variant(
+        &mut tracer,
+        E::Unit,
+        Value::Variant(0, Box::new(Value::Unit)),
+    );
+    test_variant(
+        &mut tracer,
+        E::Newtype(1),
+        Value::Variant(1, Box::new(Value::U16(1))),
+    );
+    test_variant(
+        &mut tracer,
+        E::Tuple(1, Some(true)),
+        Value::Variant(
+            2,
+            Box::new(Value::Seq(vec![
+                Value::U16(1),
+                Value::Option(Some(Box::new(Value::Bool(true)))),
+            ])),
+        ),
+    );
+    test_variant(
+        &mut tracer,
+        E::Struct { a: 1 },
+        Value::Variant(3, Box::new(Value::Seq(vec![Value::U32(1)]))),
+    );
+    test_variant(
+        &mut tracer,
+        E::NewTupleArray((1, 2, 3)),
+        Value::Variant(
+            4,
+            Box::new(Value::Seq(vec![
+                Value::U16(1),
+                Value::U16(2),
+                Value::U16(3),
+            ])),
+        ),
+    );
 
     let registry = tracer.registry().unwrap();
     let format = registry.get("E").unwrap();
@@ -61,7 +93,7 @@ fn test_tracer() {
     );
     assert_eq!(
         variants.get(&2).unwrap().value,
-        VariantFormat::Tuple(vec![Format::U16, Format::U16])
+        VariantFormat::Tuple(vec![Format::U16, Format::Option(Box::new(Format::Bool))])
     );
     assert_eq!(
         variants.get(&3).unwrap().value,
@@ -92,4 +124,26 @@ fn test_tracer() {
     let data = bincode::serialize(format).unwrap();
     let format4 = bincode::deserialize(&data).unwrap();
     assert_eq!(*format, format4);
+
+    // Tracing deserialization
+    let mut tracer = Tracer::new(/* is_human_readable */ false);
+    assert_eq!(
+        tracer.trace_type::<E>().unwrap(),
+        Format::TypeName("E".into())
+    );
+    assert_eq!(tracer.registry().unwrap().get("E").unwrap(), format);
+
+    // Sampling values with DTracer
+    let mut tracer = Tracer::new(/* is_human_readable */ false);
+    let values = tracer.sample_type::<E>().unwrap();
+    assert_eq!(
+        values,
+        vec![
+            E::Unit,
+            E::Newtype(0),
+            E::Tuple(0, Some(false)),
+            E::Struct { a: 0 },
+            E::NewTupleArray((0, 0, 0))
+        ]
+    );
 }

--- a/testsuite/generate-format/Cargo.toml
+++ b/testsuite/generate-format/Cargo.toml
@@ -12,7 +12,7 @@ edition = "2018"
 [dependencies]
 proptest = "0.9.4"
 serde_yaml = "0.8"
-clap = "2.33"
+structopt = "0.3.12"
 
 libra_types = { path = "../../types", version = "0.1.0", package = "libra-types", features=["fuzzing"] }
 lcs = { path = "../../common/lcs", version = "0.1.0", package = "libra-canonical-serialization" }

--- a/testsuite/generate-format/Cargo.toml
+++ b/testsuite/generate-format/Cargo.toml
@@ -12,6 +12,7 @@ edition = "2018"
 [dependencies]
 proptest = "0.9.4"
 serde_yaml = "0.8"
+clap = "2.33"
 
 libra_types = { path = "../../types", version = "0.1.0", package = "libra-types", features=["fuzzing"] }
 lcs = { path = "../../common/lcs", version = "0.1.0", package = "libra-canonical-serialization" }

--- a/testsuite/generate-format/src/main.rs
+++ b/testsuite/generate-format/src/main.rs
@@ -1,24 +1,24 @@
 // Copyright (c) The Libra Core Contributors
 // SPDX-License-Identifier: Apache-2.0
 
-use lcs;
+use clap::{App, Arg};
 use libra_types::{contract_event, transaction};
-use serde_reflection::Tracer;
-
 use proptest::{
     prelude::*,
     test_runner::{Config, FileFailurePersistence, TestRunner},
 };
+use serde_reflection::Tracer;
 use serde_yaml;
 use std::sync::{Arc, Mutex};
 
-fn main() {
+fn add_proptest_serialization_tracing(tracer: Tracer) -> Tracer {
     let mut runner = TestRunner::new(Config {
         failure_persistence: Some(Box::new(FileFailurePersistence::Off)),
         ..Config::default()
     });
 
-    let tracer = Arc::new(Mutex::new(Tracer::new(lcs::is_human_readable())));
+    // Wrap the tracer for (hypothetical) concurrent accesses.
+    let tracer = Arc::new(Mutex::new(tracer));
 
     runner
         .run(&any::<transaction::Transaction>(), |v| {
@@ -34,13 +34,36 @@ fn main() {
         })
         .unwrap();
 
-    // Pull a finalized registry out of the Arc-mutex-ed tracer.
-    let registry = Arc::try_unwrap(tracer)
-        .unwrap()
-        .into_inner()
-        .unwrap()
-        .registry()
+    // Recover the Arc-mutex-ed tracer.
+    Arc::try_unwrap(tracer).unwrap().into_inner().unwrap()
+}
+
+fn add_deserialization_tracing(mut tracer: Tracer) -> Tracer {
+    tracer.trace_type::<transaction::Transaction>().unwrap();
+    tracer
+        .trace_type::<contract_event::ContractEvent>()
         .unwrap();
+    tracer
+}
+
+fn main() {
+    let matches = App::new("Libra format generator")
+        .about("Trace serde (de)serialization to generate format descriptions for Libra types")
+        .arg(
+            Arg::with_name("with_deserialize")
+                .long("with_deserialize")
+                .help("Trace deserialization instead of serialization"),
+        )
+        .get_matches();
+
+    let mut tracer = Tracer::new(lcs::is_human_readable());
+
+    tracer = add_proptest_serialization_tracing(tracer);
+    if matches.is_present("with_deserialize") {
+        tracer = add_deserialization_tracing(tracer);
+    }
+
+    let registry = tracer.registry().unwrap();
     let output = serde_yaml::to_string(&registry).unwrap();
     println!("{}", output);
 }

--- a/testsuite/generate-format/src/main.rs
+++ b/testsuite/generate-format/src/main.rs
@@ -22,14 +22,14 @@ fn main() {
 
     runner
         .run(&any::<transaction::Transaction>(), |v| {
-            tracer.lock().unwrap().trace(&v)?;
+            tracer.lock().unwrap().trace_value(&v)?;
             Ok(())
         })
         .unwrap();
 
     runner
         .run(&any::<contract_event::ContractEvent>(), |v| {
-            tracer.lock().unwrap().trace(&v)?;
+            tracer.lock().unwrap().trace_value(&v)?;
             Ok(())
         })
         .unwrap();


### PR DESCRIPTION
## Motivation

Make it possible to generate an IDL-like format based on the serde Deserialize trait in addition to the Serialize trait.

## Test Plan
```
cargo x test -p libra-serde-reflection
cargo run -p generate-format
cargo run -p generate-format -- --with_deserialize   # currently crashing due to handwritten checks in deserializers
```

## Related PRs

https://github.com/libra/libra/pull/2867