### PR TITLE
[Move VM] enforce canonical ULEB encodings

### DIFF
--- a/language/vm/src/file_format_common.rs
+++ b/language/vm/src/file_format_common.rs
@@ -302,13 +302,16 @@ pub fn write_u128(binary: &mut BinaryData, value: u128) -> Result<()> {
 ///
 /// Return an error on an invalid representation.
 pub fn read_uleb128_as_u16(cursor: &mut Cursor<&[u8]>) -> Result<u16> {
-    let mut value: u16 = 0;
+    let mut value: u32 = 0;
     let mut shift: u8 = 0;
     while let Ok(byte) = cursor.read_u8() {
         let val = byte & 0x7f;
-        value |= u16::from(val) << shift;
+        value |= u32::from(val) << shift;
         if val == byte {
-            return Ok(value);
+            if (shift > 0 && val == 0) || value > std::u16::MAX.into() {
+                bail!("invalid ULEB128 representation for u16");
+            }
+            return Ok(value as u16);
         }
         shift += 7;
         if shift > 14 {
@@ -326,13 +329,16 @@ pub fn read_uleb128_as_u16(cursor: &mut Cursor<&[u8]>) -> Result<u16> {
 ///
 /// Return an error on an invalid representation.
 pub fn read_uleb128_as_u32(cursor: &mut Cursor<&[u8]>) -> Result<u32> {
-    let mut value: u32 = 0;
+    let mut value: u64 = 0;
     let mut shift: u8 = 0;
     while let Ok(byte) = cursor.read_u8() {
         let val = byte & 0x7f;
-        value |= u32::from(val) << shift;
+        value |= u64::from(val) << shift;
         if val == byte {
-            return Ok(value);
+            if (shift > 0 && val == 0) || value > std::u32::MAX.into() {
+                bail!("invalid ULEB128 representation for u32");
+            }
+            return Ok(value as u32);
         }
         shift += 7;
         if shift > 28 {

--- a/language/vm/src/unit_tests/number_tests.rs
+++ b/language/vm/src/unit_tests/number_tests.rs
@@ -44,7 +44,7 @@ fn test_u32(value: u32, expected_bytes: usize) {
 }
 
 #[test]
-fn lab128_u16_test() {
+fn uleb128_u16_test() {
     test_u16(0, 1);
     test_u16(16, 1);
     test_u16(2u16.pow(7) - 1, 1);
@@ -59,7 +59,7 @@ fn lab128_u16_test() {
 }
 
 #[test]
-fn lab128_u32_test() {
+fn uleb128_u32_test() {
     test_u32(0, 1);
     test_u32(16, 1);
     test_u32(2u32.pow(7) - 1, 1);
@@ -80,7 +80,7 @@ fn lab128_u32_test() {
 }
 
 #[test]
-fn lab128_malformed_test() {
+fn uleb128_malformed_test() {
     assert!(read_uleb128_as_u16(&mut Cursor::new(&[])).is_err());
     assert!(read_uleb128_as_u16(&mut Cursor::new(&[0x80])).is_err());
     assert!(read_uleb128_as_u16(&mut Cursor::new(&[0x80, 0x80])).is_err());
@@ -92,6 +92,17 @@ fn lab128_malformed_test() {
     assert!(read_uleb128_as_u32(&mut Cursor::new(&[0x80, 0x80])).is_err());
     assert!(read_uleb128_as_u32(&mut Cursor::new(&[0x80, 0x80, 0x80, 0x80])).is_err());
     assert!(read_uleb128_as_u32(&mut Cursor::new(&[0x80, 0x80, 0x80, 0x80, 0x80, 0x2])).is_err());
+}
+
+#[test]
+fn uleb128_canonicity_test() {
+    assert!(read_uleb128_as_u16(&mut Cursor::new(&[0x80, 0x00])).is_err());
+    assert!(read_uleb128_as_u16(&mut Cursor::new(&[0x80, 0x80, 0x02])).is_ok());
+    assert!(read_uleb128_as_u16(&mut Cursor::new(&[0x80, 0x80, 0x04])).is_err());
+
+    assert!(read_uleb128_as_u32(&mut Cursor::new(&[0x80, 0x00])).is_err());
+    assert!(read_uleb128_as_u32(&mut Cursor::new(&[0x80, 0x80, 0x80, 0x80, 0x0f])).is_ok());
+    assert!(read_uleb128_as_u32(&mut Cursor::new(&[0x80, 0x80, 0x80, 0x80, 0x10])).is_err());
 }
 
 proptest! {


### PR DESCRIPTION
## Motivation

Make sure that our ULEB encoding of u32 and u16 integers in Move VM are unique.

## Test Plan

```
cargo x test -p vm number_tests
```

## Related PRs

Initially, I made these observations while working on #2987 