### PR TITLE
[VM] Don't load on-chain configs when executing direct write set transactions

### DIFF
--- a/language/e2e-tests/src/tests/genesis.rs
+++ b/language/e2e-tests/src/tests/genesis.rs
@@ -2,7 +2,8 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::{
-    assert_prologue_parity, assert_status_eq, executor::FakeExecutor, transaction_status_eq,
+    assert_prologue_parity, assert_status_eq, data_store::GENESIS_WRITE_SET,
+    executor::FakeExecutor, keygen::KeyGen, transaction_status_eq,
 };
 use libra_crypto::ed25519::*;
 use libra_types::{
@@ -35,4 +36,25 @@ fn invalid_genesis_write_set() {
         executor.execute_transaction(txn).status(),
         VMStatus::new(StatusCode::INVALID_WRITE_SET)
     );
+}
+
+#[test]
+fn execute_genesis_write_set() {
+    let executor = FakeExecutor::no_genesis();
+    let write_set = GENESIS_WRITE_SET.clone();
+    let address = account_config::association_address();
+    let mut keygen = KeyGen::from_seed([9u8; 32]);
+
+    let (private_key, public_key) = keygen.generate_keypair();
+    let txn = transaction_test_helpers::get_write_set_txn(
+        address,
+        0,
+        &private_key,
+        public_key,
+        Some(write_set),
+    )
+    .into_inner();
+
+    // Executing the genesis transaction should success.
+    assert!(!executor.execute_transaction(txn).status().is_discarded());
 }

--- a/language/libra-vm/src/libra_vm.rs
+++ b/language/libra-vm/src/libra_vm.rs
@@ -535,7 +535,6 @@ impl LibraVM {
         let mut result = vec![];
         let blocks = chunk_block_transactions(transactions);
         let mut data_cache = BlockDataCache::new(state_view);
-        self.load_configs_impl(&data_cache);
         let mut execute_block_trace_guard = vec![];
         let mut current_block_id = HashValue::zero();
         for block in blocks {
@@ -573,6 +572,7 @@ impl LibraVM {
         data_cache: &mut BlockDataCache<'_>,
         state_view: &dyn StateView,
     ) -> VMResult<Vec<TransactionOutput>> {
+        self.load_configs_impl(data_cache);
         let signature_verified_block: Vec<Result<SignatureCheckedTransaction, VMStatus>>;
         {
             trace_code_block!("libra_vm::verify_signatures", {"block", block_id});


### PR DESCRIPTION
<!--
Thank you for sending a PR. We appreciate you spending time to help improve the Libra project.

The project is undergoing daily changes. Pull Requests will be reviewed and responded to as time permits.
-->

## Motivation
This PR aims to fix the unneeded load of gas schedule when processing the genesis by postponing the load to the user transaction execution time. This should fix the `crit!` [error](https://github.com/libra/libra/blob/c630349b2eb6d9afe58a03d2102f1eb1cf2973ea/language/move-vm/runtime/src/code_cache/module_cache.rs#L267)  in the testnet.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

Added a test for loading genesis in VM and manually change that `crit!` error to `panic!` locally to make sure the error didn't occur.

## Related PRs

(If this PR adds or changes functionality, please take some time to update the docs at https://github.com/libra/website, and link to your PR here.)
