### PR TITLE
[crypto] [u8; 4] as bitmap in multi-sigs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2329,7 +2329,6 @@ name = "libra-crypto"
 version = "0.1.0"
 dependencies = [
  "anyhow 1.0.27 (registry+https://github.com/rust-lang/crates.io-index)",
- "bit-vec 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "bitvec 0.17.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "byteorder 1.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "bytes 0.5.4 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/crypto/crypto/Cargo.toml
+++ b/crypto/crypto/Cargo.toml
@@ -11,7 +11,6 @@ edition = "2018"
 
 [dependencies]
 anyhow = "1.0"
-bit-vec = "0.6.1"
 byteorder = "1.3.2"
 bytes = "0.5.4"
 curve25519-dalek = { git = "https://github.com/calibra/curve25519-dalek.git", branch = "fiat", default-features = false }


### PR DESCRIPTION
## Motivation

Multi-sigs support up to 32 keys. This PR allows for using a `[u8; 4]` as bitmap to link signatures with their corresponding keys. Major benefits:
- No sanity checks for bitmap size; a `[u8; 4]` can support up to 32 indexes, which is exactly what we want.
- Get rid of the `bit-vec` external dependency.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?

YES

## Test Plan

`multi_ed25519_test.rs`