### PR TITLE
[CLI] replace host/port CLI args with full URL

### DIFF
--- a/client/cli/src/main.rs
+++ b/client/cli/src/main.rs
@@ -14,7 +14,6 @@ use cli::{
 use libra_types::waypoint::Waypoint;
 use rustyline::{config::CompletionType, error::ReadlineError, Config, Editor};
 use std::{
-    num::NonZeroU16,
     str::FromStr,
     time::{Duration, UNIX_EPOCH},
 };
@@ -27,14 +26,9 @@ use structopt::StructOpt;
     about = "Libra client to connect to a specific validator"
 )]
 struct Args {
-    /// JSON RPC port to connect to.
-    #[structopt(short = "p", long, default_value = "8080")]
-    pub port: NonZeroU16,
-    /// Host address/name to connect to. Default protocol is http
-    /// To specify http protocol (e.g. https), must pass in base URL with full prefix,
-    /// and URL should not include trailing `/` or port number)
-    #[structopt(short = "a", long)]
-    pub host: String,
+    /// Full URL address to connect to - should include port number, if applicable
+    #[structopt(short = "u", long)]
+    pub url: String,
     /// Path to the generated keypair for the faucet account. The faucet account can be used to
     /// mint coins. If not passed, a new keypair will be generated for
     /// you and placed in a temporary directory.
@@ -96,8 +90,7 @@ fn main() {
         })
     });
     let mut client_proxy = ClientProxy::new(
-        &args.host,
-        args.port.get(),
+        &args.url,
         &faucet_account_file,
         args.sync,
         args.faucet_server.clone(),
@@ -111,8 +104,8 @@ fn main() {
         .test_validator_connection()
         .unwrap_or_else(|e| {
             panic!(
-                "Not able to connect to validator at {}:{}. Error: {}",
-                args.host, args.port, e,
+                "Not able to connect to validator at {}. Error: {}",
+                args.url, e,
             )
         });
     let ledger_info_str = format!(
@@ -123,8 +116,8 @@ fn main() {
         )
     );
     let cli_info = format!(
-        "Connected to validator at: {}:{}, {}",
-        args.host, args.port, ledger_info_str
+        "Connected to validator at: {}, {}",
+        args.url, ledger_info_str
     );
     if args.mnemonic_file.is_some() {
         match client_proxy.recover_accounts_in_wallet() {
@@ -219,37 +212,5 @@ fn retrieve_waypoint(url_str: &str) -> anyhow::Result<Waypoint> {
             url_str,
             response.status_line()
         )),
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn test_args_port() {
-        let args = Args::from_iter(&["test", "--host=h"]);
-        assert_eq!(args.port.get(), 8080);
-        assert_eq!(format!("{}:{}", args.host, args.port.get()), "h:8080");
-        let args = Args::from_iter(&["test", "--port=65535", "--host=h"]);
-        assert_eq!(args.port.get(), 65535);
-    }
-
-    #[test]
-    fn test_args_port_too_large() {
-        let result = Args::from_iter_safe(&["test", "--port=65536", "--host=h"]);
-        assert_eq!(result.is_ok(), false);
-    }
-
-    #[test]
-    fn test_args_port_invalid() {
-        let result = Args::from_iter_safe(&["test", "--port=abc", "--host=h"]);
-        assert_eq!(result.is_ok(), false);
-    }
-
-    #[test]
-    fn test_args_port_zero() {
-        let result = Args::from_iter_safe(&["test", "--port=0", "--host=h"]);
-        assert_eq!(result.is_ok(), false);
     }
 }

--- a/docker/README.md
+++ b/docker/README.md
@@ -10,4 +10,4 @@ This directory contains [Docker](https://www.docker.com/) configuration and scri
 4. To test the validator image locally, run `docker/validator/run.sh`
 5. To test the faucet server image locally, run `docker/mint/run.sh`
 6. Run the client as follows:
-   `cargo run -p cli --bin cli -- -a localhost -p 8000 -f localhost:8080`
+   `cargo run -p cli --bin cli -- -u http://localhost:8000 -f localhost:8080`

--- a/docker/client/client.Dockerfile
+++ b/docker/client/client.Dockerfile
@@ -26,7 +26,7 @@ RUN mkdir -p /opt/libra/bin /opt/libra/etc
 COPY --from=builder /libra/target/release/cli /opt/libra/bin/libra_client
 
 ENTRYPOINT ["/opt/libra/bin/libra_client"]
-CMD ["--host", "ac.testnet.libra.org", "--port", "8000"]
+CMD ["--url", "http://client.testnet.libra.org"]
 
 ARG BUILD_DATE
 ARG GIT_REV

--- a/docker/mint/server.py
+++ b/docker/mint/server.py
@@ -22,11 +22,11 @@ def create_client():
         ac_hosts = os.environ['AC_HOST'].split(',')
         ac_host = random.choice(ac_hosts)
         ac_port = os.environ['AC_PORT']
+        url = "http://{}:{}".format(ac_host, ac_port)
 
-        print("Connecting to ac on: {}:{}".format(ac_host, ac_port))
-        cmd = "/opt/libra/bin/cli --host {} --port {} -m {}".format(
-            ac_host,
-            ac_port,
+        print("Connecting to ac on: {}".format(url))
+        cmd = "/opt/libra/bin/cli --url {} -m {}".format(
+            url,
             "/opt/libra/etc/mint.key")
 
         application.client = pexpect.spawn(cmd)

--- a/libra-swarm/src/client.rs
+++ b/libra-swarm/src/client.rs
@@ -51,8 +51,8 @@ impl InteractiveClient {
             client: Some(
                 Command::new(workspace_builder::get_bin("cli"))
                     .current_dir(workspace_builder::workspace_root())
-                    .arg("-p")
-                    .arg(port.to_string())
+                    .arg("-u")
+                    .arg(format!("http://localhost:{}", port))
                     .arg("-m")
                     .arg(
                         faucet_key_file_path
@@ -69,8 +69,6 @@ impl InteractiveClient {
                             .to_str()
                             .unwrap(),
                     )
-                    .arg("-a")
-                    .arg("localhost")
                     .stdin(Stdio::inherit())
                     .stdout(Stdio::inherit())
                     .stderr(Stdio::inherit())
@@ -92,8 +90,8 @@ impl InteractiveClient {
             client: Some(
                 Command::new(workspace_builder::get_bin("cli"))
                     .current_dir(workspace_builder::workspace_root())
-                    .arg("-p")
-                    .arg(port.to_string())
+                    .arg("-u")
+                    .arg(format!("http://localhost:{}", port))
                     .arg("-m")
                     .arg(
                         faucet_key_file_path
@@ -110,8 +108,6 @@ impl InteractiveClient {
                             .to_str()
                             .unwrap(),
                     )
-                    .arg("-a")
-                    .arg("localhost")
                     .stdin(Stdio::piped())
                     .stdout(Stdio::piped())
                     .stderr(Stdio::piped())
@@ -145,8 +141,7 @@ impl InProcessTestClient {
         let (_, alias_to_cmd) = commands::get_commands(true);
         Self {
             client: ClientProxy::new(
-                "localhost",
-                port,
+                &format!("http://localhost:{}", port),
                 faucet_key_file_path
                     .canonicalize()
                     .expect("Unable to get canonical path of faucet key file")

--- a/libra-swarm/src/main.rs
+++ b/libra-swarm/src/main.rs
@@ -89,8 +89,8 @@ fn main() {
     let validator_config = NodeConfig::load(&validator_swarm.config.config_files[0]).unwrap();
     println!("To run the Libra CLI client in a separate process and connect to the validator nodes you just spawned, use this command:");
     println!(
-        "\tcargo run --bin cli -- -a localhost -p {} -m {:?}",
-        validator_config.rpc.address.port(),
+        "\tcargo run --bin cli -- -u {} -m {:?}",
+        format!("http://localhost:{}", validator_config.rpc.address.port()),
         faucet_key_file_path,
     );
     let node_address_list = validator_swarm
@@ -112,8 +112,8 @@ fn main() {
         let full_node_config = NodeConfig::load(&swarm.config.config_files[0]).unwrap();
         println!("To connect to the full nodes you just spawned, use this command:");
         println!(
-            "\tcargo run --bin cli -- -a localhost -p {} -m {:?}",
-            full_node_config.rpc.address.port(),
+            "\tcargo run --bin cli -- -u {} -m {:?}",
+            format!("http://localhost:{}", full_node_config.rpc.address.port()),
             faucet_key_file_path,
         );
     }

--- a/scripts/cli/start_cli_testnet.sh
+++ b/scripts/cli/start_cli_testnet.sh
@@ -13,7 +13,7 @@ source "$HOME/.cargo/env"
 
 SCRIPT_PATH="$(dirname $0)"
 
-RUN_PARAMS="--host https://client.testnet.libra.org --port 443 "
+RUN_PARAMS="--url https://client.testnet.libra.org "
 RELEASE=""
 
 while [[ ! -z "$1" ]]; do

--- a/testsuite/tests/libratest/smoke_test.rs
+++ b/testsuite/tests/libratest/smoke_test.rs
@@ -123,8 +123,7 @@ impl TestEnvironment {
             .to_string();
 
         ClientProxy::new(
-            "localhost",
-            port,
+            &format!("http://localhost:{}", port),
             &self.faucet_key.1,
             false,
             /* faucet server */ None,


### PR DESCRIPTION
## Motivation

In CLI, fully replace host/port args with passing in full URL, to give user full customizability of URL options (e.g. http protocol type, using paths vs ports)

## Test Plan

Tested on local swarm CLI and devnet
