### PR TITLE
[secure-storage] Start bringing the framework online

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2569,6 +2569,7 @@ name = "libra-secure-storage"
 version = "0.1.0"
 dependencies = [
  "base64 0.12.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "chrono 0.4.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "libra-canonical-serialization 0.1.0",
  "libra-config 0.1.0",
  "libra-crypto 0.1.0",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2409,6 +2409,7 @@ dependencies = [
 name = "libra-key-manager"
 version = "0.1.0"
 dependencies = [
+ "anyhow 1.0.27 (registry+https://github.com/rust-lang/crates.io-index)",
  "config-builder 0.1.0",
  "executor 0.1.0",
  "executor-types 0.1.0",
@@ -2423,6 +2424,7 @@ dependencies = [
  "rand 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "storage-client 0.1.0",
  "storage-service 0.1.0",
+ "thiserror 1.0.13 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio 0.2.13 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 

--- a/consensus/safety-rules/src/persistent_safety_storage.rs
+++ b/consensus/safety-rules/src/persistent_safety_storage.rs
@@ -58,7 +58,7 @@ impl PersistentSafetyStorage {
         Ok(self
             .internal_store
             .get(CONSENSUS_KEY)
-            .and_then(|value| value.ed25519_private_key())?)
+            .and_then(|r| r.value.ed25519_private_key())?)
     }
 
     pub fn set_consensus_key(&mut self, consensus_key: Ed25519PrivateKey) -> Result<()> {
@@ -68,10 +68,7 @@ impl PersistentSafetyStorage {
     }
 
     pub fn epoch(&self) -> Result<u64> {
-        Ok(self
-            .internal_store
-            .get(EPOCH)
-            .and_then(|value| value.u64())?)
+        Ok(self.internal_store.get(EPOCH).and_then(|r| r.value.u64())?)
     }
 
     pub fn set_epoch(&mut self, epoch: u64) -> Result<()> {
@@ -83,7 +80,7 @@ impl PersistentSafetyStorage {
         Ok(self
             .internal_store
             .get(LAST_VOTED_ROUND)
-            .and_then(|value| value.u64())?)
+            .and_then(|r| r.value.u64())?)
     }
 
     pub fn set_last_voted_round(&mut self, last_voted_round: Round) -> Result<()> {
@@ -96,7 +93,7 @@ impl PersistentSafetyStorage {
         Ok(self
             .internal_store
             .get(PREFERRED_ROUND)
-            .and_then(|value| value.u64())?)
+            .and_then(|r| r.value.u64())?)
     }
 
     pub fn set_preferred_round(&mut self, preferred_round: Round) -> Result<()> {

--- a/secure/key-manager/Cargo.toml
+++ b/secure/key-manager/Cargo.toml
@@ -15,8 +15,10 @@ libra-logger = { path = "../../common/logger", version = "0.1.0" }
 libra-secure-storage = { path = "../../secure/storage", version = "0.1.0" }
 libra-transaction-scripts = { path = "../transaction-scripts", version = "0.1.0" }
 libra-types = { path = "../../types", version = "0.1.0" }
+thiserror = "1.0"
 
 [dev-dependencies]
+anyhow = "1.0"
 rand = "0.6.5"
 tokio = { version = "0.2.12", features = ["full"] }
 
@@ -24,7 +26,7 @@ config-builder = { path = "../../config/config-builder", version = "0.1.0" }
 executor = { path = "../../execution/executor", version = "0.1.0" }
 executor-types = { path = "../../execution/executor-types", version = "0.1.0" }
 libradb = { path = "../../storage/libradb", version = "0.1.0" }
-libra-config = { path = "../../config", version = "0.1.0" }
+libra-config = { path = "../../config", version = "0.1.0", features = ["fuzzing"]}
 libra-vm = { path = "../../language/libra-vm", version = "0.1.0" }
 storage-client = { path = "../../storage/storage-client", version = "0.1.0" }
 storage-service = { path = "../../storage/storage-service", version = "0.1.0" }

--- a/secure/key-manager/src/lib.rs
+++ b/secure/key-manager/src/lib.rs
@@ -1,6 +1,22 @@
 // Copyright (c) The Libra Core Contributors
 // SPDX-License-Identifier: Apache-2.0
 
+//! The purpose of KeyManager is to rotate consensus key and eventually the network key. It is not
+//! responsible for generating the first key and fails if the stores have not been properly setup.
+//! During rotation, it first updates the local store, then submits a transaction to rotate to the
+//! new key. After some period of time and upon restarts of the process, it will evaluate the
+//! current status of the system including:
+//! * last rotation time, and rotate if it is too long ago
+//! * if the latest key in the store matches the latest key in the ValidatorConfig, upon mismatch
+//! it will try to submit a transaction to update the ValidatorConfig to the current key in the
+//! store.
+//! * if the current key in the ValidatorConfig matches the ValidatorSet, if it does not it
+//! evaluates the current time from the last reconfiguration and logs that delta with greater
+//! levels of severity depending on the delta.
+//!
+//! KeyManager talks to Libra via the LibraInterface that may either be a direct link into
+//! `LibraDB`/`Executor`, JSON-RPC, or some other concoction.
+//! KeyManager talks to its own storage through the `LibraSecureStorage::Storage1 trait.
 #![forbid(unsafe_code)]
 
 use libra_crypto::{
@@ -13,13 +29,113 @@ use libra_types::{
     transaction::{RawTransaction, Script, Transaction, TransactionArgument},
 };
 use std::time::{Duration, SystemTime};
+use thiserror::Error;
+
+#[cfg(test)]
+use libra_secure_storage::Storage;
+#[cfg(test)]
+use libra_types::{validator_config::ValidatorConfig, validator_info::ValidatorInfo};
 
 #[cfg(test)]
 mod tests;
 
+pub const CONSENSUS_KEY: &str = "consensus_key";
 const GAS_UNIT_PRICE: u64 = 0;
 const MAX_GAS_AMOUNT: u64 = 400_000;
 const TXN_EXPIRATION: u64 = 100;
+
+#[allow(clippy::large_enum_variant)]
+#[derive(Debug, Error, PartialEq)]
+pub enum Error {
+    #[error("Unknown error: {0}")]
+    UnknownError(String),
+    #[error("Key mismatch, config: {0}, info: {0}")]
+    ConfigInfoKeyMismatch(Ed25519PublicKey, Ed25519PublicKey),
+    #[error("Key mismatch, config: {0}, storage: {0}")]
+    ConfigStorageKeyMismatch(Ed25519PublicKey, Ed25519PublicKey),
+    #[error("Data does not exist: {0}")]
+    DataDoesNotExist(&'static str),
+    #[error("Internal storage error")]
+    SecureStorageError(#[from] libra_secure_storage::Error),
+    #[error("ValidatorInfo not found in ValidatorConfig: {0}")]
+    ValidatorInfoNotFound(AccountAddress),
+}
+
+#[cfg(test)]
+impl From<anyhow::Error> for Error {
+    fn from(error: anyhow::Error) -> Self {
+        Error::UnknownError(format!("{}", error))
+    }
+}
+
+/// This defines a generic trait used to interact with the Libra blockchain. In production, this
+/// will be talking to a JSON-RPC service. For tests, this may be an executor and storage directly.
+#[cfg(test)]
+trait LibraInterface {
+    /// Retrieve current sequence id for the provided account
+    fn retrieve_sequence_id(&self, account: AccountAddress) -> Result<u64, Error>;
+
+    /// Submits a transaction to the block chain and returns successfully if the transaction was
+    /// successfully submitted. It does not necessarily mean the transaction successfully executed.
+    fn submit_transaction(&self, transaction: Transaction) -> Result<(), Error>;
+
+    /// Retrieves the ValidatorConfig at the specified AccountAddress if one exists.
+    fn retrieve_validator_config(&self, account: AccountAddress) -> Result<ValidatorConfig, Error>;
+
+    /// Retrieves the ValidatorInfo for the specified account from the current ValidatorSet if one exists.
+    fn retrieve_validator_info(&self, account: AccountAddress) -> Result<ValidatorInfo, Error>;
+}
+
+#[cfg(test)]
+struct KeyManager<LI, S> {
+    account: AccountAddress,
+    key_name: String,
+    libra: LI,
+    storage: S,
+}
+
+#[cfg(test)]
+impl<LI, S> KeyManager<LI, S>
+where
+    LI: LibraInterface,
+    S: Storage,
+{
+    pub fn new(account: AccountAddress, key_name: String, libra: LI, storage: S) -> Self {
+        Self {
+            account,
+            key_name,
+            libra,
+            storage,
+        }
+    }
+
+    pub fn last_rotation(&self) -> Result<u64, Error> {
+        Ok(self.storage.get_public_key(&self.key_name)?.last_update)
+    }
+
+    pub fn compare_storage_to_config(&self) -> Result<(), Error> {
+        let storage_key = self.storage.get_public_key(&self.key_name)?.public_key;
+        let validator_config = self.libra.retrieve_validator_config(self.account)?;
+        let config_key = validator_config.consensus_pubkey;
+
+        if storage_key == config_key {
+            return Ok(());
+        }
+        Err(Error::ConfigStorageKeyMismatch(config_key, storage_key))
+    }
+
+    pub fn compare_info_to_config(&self) -> Result<(), Error> {
+        let validator_info = self.libra.retrieve_validator_info(self.account)?;
+        let info_key = validator_info.consensus_public_key();
+        let validator_config = self.libra.retrieve_validator_config(self.account)?;
+        let config_key = validator_config.consensus_pubkey;
+
+        if &config_key == info_key {
+            return Ok(());
+        }
+        Err(Error::ConfigInfoKeyMismatch(config_key, info_key.clone()))
+    }
+}
 
 fn expiration_time(until: u64) -> Duration {
     let now = SystemTime::now()

--- a/secure/key-manager/src/lib.rs
+++ b/secure/key-manager/src/lib.rs
@@ -73,6 +73,10 @@ impl From<anyhow::Error> for Error {
 #[cfg(test)]
 trait LibraInterface {
     /// Retrieves the current time from the blockchain, this is returned as microseconds.
+    fn libra_timestamp(&self) -> Result<u64, Error>;
+
+    /// Retrieves the last reconfiguration time from the blockchain, this is returned as
+    /// microseconds.
     fn last_reconfiguration(&self) -> Result<u64, Error>;
 
     /// Retrieve current sequence id for the provided account.
@@ -119,6 +123,11 @@ where
 
     pub fn last_rotation(&self) -> Result<u64, Error> {
         Ok(self.storage.get_public_key(&self.key_name)?.last_update)
+    }
+
+    pub fn libra_timestamp(&self) -> Result<u64, Error> {
+        // Convert the time to seconds
+        Ok(self.libra.last_reconfiguration()? / 1_000_000)
     }
 
     pub fn compare_storage_to_config(&self) -> Result<(), Error> {

--- a/secure/key-manager/src/lib.rs
+++ b/secure/key-manager/src/lib.rs
@@ -72,7 +72,10 @@ impl From<anyhow::Error> for Error {
 /// will be talking to a JSON-RPC service. For tests, this may be an executor and storage directly.
 #[cfg(test)]
 trait LibraInterface {
-    /// Retrieve current sequence id for the provided account
+    /// Retrieves the current time from the blockchain, this is returned as microseconds.
+    fn last_reconfiguration(&self) -> Result<u64, Error>;
+
+    /// Retrieve current sequence id for the provided account.
     fn retrieve_sequence_id(&self, account: AccountAddress) -> Result<u64, Error>;
 
     /// Submits a transaction to the block chain and returns successfully if the transaction was
@@ -107,6 +110,11 @@ where
             libra,
             storage,
         }
+    }
+
+    pub fn last_reconfiguration(&self) -> Result<u64, Error> {
+        // Convert the time to seconds
+        Ok(self.libra.last_reconfiguration()? / 1_000_000)
     }
 
     pub fn last_rotation(&self) -> Result<u64, Error> {

--- a/secure/storage/Cargo.toml
+++ b/secure/storage/Cargo.toml
@@ -11,6 +11,7 @@ edition = "2018"
 
 [dependencies]
 base64 = "0.12.0"
+chrono = "0.4.9"
 lcs = { path = "../../common/lcs", version = "0.1.0", package = "libra-canonical-serialization" }
 libra-crypto = { path = "../../crypto/crypto", version = "0.1.0" }
 libra-temppath = { path = "../../common/temppath", version = "0.1.0" }

--- a/secure/storage/src/crypto_kv_storage.rs
+++ b/secure/storage/src/crypto_kv_storage.rs
@@ -41,7 +41,7 @@ impl<T: CryptoKVStorage> CryptoStorage for T {
     }
 
     fn get_private_key_for_name(&self, key_pair_name: &str) -> Result<Ed25519PrivateKey, Error> {
-        match self.get(key_pair_name)? {
+        match self.get(key_pair_name)?.value {
             Value::Ed25519PrivateKey(private_key) => Ok(private_key),
             _ => Err(Error::UnexpectedValueType),
         }
@@ -67,7 +67,7 @@ impl<T: CryptoKVStorage> CryptoStorage for T {
     }
 
     fn rotate_key_pair(&mut self, key_pair_name: &str) -> Result<Ed25519PublicKey, Error> {
-        match self.get(key_pair_name)? {
+        match self.get(key_pair_name)?.value {
             Value::Ed25519PrivateKey(private_key) => {
                 let (new_private_key, new_public_key) = new_ed25519_key_pair()?;
                 self.set(

--- a/secure/storage/src/crypto_storage.rs
+++ b/secure/storage/src/crypto_storage.rs
@@ -6,6 +6,8 @@ use libra_crypto::{
     ed25519::{Ed25519PrivateKey, Ed25519PublicKey, Ed25519Signature},
     HashValue,
 };
+use serde::{Deserialize, Serialize};
+use std::time::{Duration, SystemTime};
 
 /// CryptoStorage offers a secure storage engine for generating, using and managing cryptographic
 /// keys securely. The API offered here is inspired by the 'Transit Secret Engine' provided by
@@ -14,64 +16,82 @@ use libra_crypto::{
 pub trait CryptoStorage: Send + Sync {
     /// Securely generates a new named Ed25519 key pair and returns the corresponding public key.
     ///
-    /// The new key pair is named according to the 'key_pair_name' and is held in secure storage
+    /// The new key pair is named according to the 'name' and is held in secure storage
     /// under the given 'policy'. To access or use the key pair (e.g., sign or encrypt data),
     /// subsequent API calls must refer to the key pair by name. As this API call may fail
     /// (e.g., if a key pair with the given name already exists), an error may also be returned.
-    fn generate_new_ed25519_key_pair(
-        &mut self,
-        key_pair_name: &str,
-        policy: &Policy,
-    ) -> Result<Ed25519PublicKey, Error>;
+    fn generate_new_key(&mut self, name: &str, policy: &Policy) -> Result<Ed25519PublicKey, Error>;
 
-    /// Returns the public key for a given Ed25519 key pair, as identified by the 'key_pair_name'.
+    /// Returns the public key for a given Ed25519 key pair, as identified by the 'name'.
     /// If the key pair doesn't exist, or the caller doesn't have the
     /// appropriate permissions to retrieve the public key, this call will fail with an error.
-    fn get_public_key_for_name(&self, key_pair_name: &str) -> Result<Ed25519PublicKey, Error>;
+    fn get_public_key(&self, name: &str) -> Result<PublicKeyResponse, Error>;
 
-    /// Returns the private key for a given Ed25519 key pair, as identified by the 'key_pair_name'.
+    /// Returns the private key for a given Ed25519 key pair, as identified by the 'name'.
     /// If the key pair doesn't exist, or the caller doesn't have the appropriate permissions to
     /// retrieve the private key, this call will fail with an error.
-    fn get_private_key_for_name(&self, key_pair_name: &str) -> Result<Ed25519PrivateKey, Error>;
+    fn get_private_key(&self, name: &str) -> Result<Ed25519PrivateKey, Error>;
 
     /// Returns the private key for a given Ed25519 key pair version, as identified by the
-    /// 'key_pair_name' and 'key_pair_version'. If the key pair at the specified version doesn't
+    /// 'name' and 'version'. If the key pair at the specified version doesn't
     /// exist, or the caller doesn't have the appropriate permissions to retrieve the private key,
     /// this call will fail with an error.
-    fn get_private_key_for_name_and_version(
+    fn get_private_key_for_version(
         &self,
-        key_pair_name: &str,
-        key_pair_version: Ed25519PublicKey,
+        name: &str,
+        version: Ed25519PublicKey,
     ) -> Result<Ed25519PrivateKey, Error>;
 
     /// Rotates an Ed25519 key pair by generating a new Ed25519 key pair, and updating the
-    /// 'key_pair_name' to reference the freshly generated key. The previous key pair is retained
+    /// 'name' to reference the freshly generated key. The previous key pair is retained
     /// in storage if needed. If multiple key rotations occur over the lifetime of a key pair, only
     /// two versions of the key pair are maintained (i.e., the current and previous one).
     /// If the key pair doesn't exist, or the caller doesn't have the appropriate permissions to
     /// retrieve the public key, this call will fail with an error. Otherwise, the new public
     /// key for the rotated key pair is returned.
-    fn rotate_key_pair(&mut self, key_pair_name: &str) -> Result<Ed25519PublicKey, Error>;
+    fn rotate_key_pair(&mut self, name: &str) -> Result<Ed25519PublicKey, Error>;
 
-    /// Signs the given message using the private key associated with the given 'key_pair_name'.
+    /// Signs the given message using the private key associated with the given 'name'.
     /// If the key pair doesn't exist, or the caller doesn't have the appropriate
     /// permissions to retrieve and use the public key, this call will fail with an error.
-    fn sign_message(
-        &mut self,
-        key_pair_name: &str,
-        message: &HashValue,
-    ) -> Result<Ed25519Signature, Error>;
+    fn sign_message(&mut self, name: &str, message: &HashValue) -> Result<Ed25519Signature, Error>;
 
-    /// Signs the given message using the private key associated with the given 'key_pair_name'
-    /// and 'key_pair_version'. If the key pair doesn't exist, or the caller doesn't have the
+    /// Signs the given message using the private key associated with the given 'name'
+    /// and 'version'. If the key pair doesn't exist, or the caller doesn't have the
     /// appropriate permissions to perform the operation, this call will fail with an error.
-    /// Note: the 'key_pair_version' is specified using the public key associated with a key pair.
+    /// Note: the 'version' is specified using the public key associated with a key pair.
     /// Only two versions of a key pair are ever maintained at any given time (i.e., the
     /// current version, and the previous version).
     fn sign_message_using_version(
         &mut self,
-        key_pair_name: &str,
-        key_pair_version: Ed25519PublicKey,
+        name: &str,
+        version: Ed25519PublicKey,
         message: &HashValue,
     ) -> Result<Ed25519Signature, Error>;
+}
+
+#[derive(Debug, Deserialize, PartialEq, Serialize)]
+#[serde(tag = "data")]
+pub struct PublicKeyResponse {
+    /// Time since Unix Epoch in seconds.
+    pub last_update: u64,
+    /// Ed25519PublicKey stored at the provided key
+    pub public_key: Ed25519PublicKey,
+}
+
+impl PublicKeyResponse {
+    /// Creates a PublicKeyResponse using the current time for the timestamp
+    pub fn new(public_key: Ed25519PublicKey) -> Self {
+        Self {
+            public_key,
+            last_update: Self::now().as_secs(),
+        }
+    }
+
+    /// Returns back a Duration encompassing the current system time less the Unix Epoch
+    fn now() -> Duration {
+        SystemTime::now()
+            .duration_since(SystemTime::UNIX_EPOCH)
+            .unwrap()
+    }
 }

--- a/secure/storage/src/error.rs
+++ b/secure/storage/src/error.rs
@@ -31,6 +31,12 @@ impl From<base64::DecodeError> for Error {
     }
 }
 
+impl From<chrono::format::ParseError> for Error {
+    fn from(error: chrono::format::ParseError) -> Self {
+        Self::SerializationError(format!("{}", error))
+    }
+}
+
 impl From<io::Error> for Error {
     fn from(error: io::Error) -> Self {
         Self::InternalError(format!("{}", error))

--- a/secure/storage/src/in_memory.rs
+++ b/secure/storage/src/in_memory.rs
@@ -1,9 +1,7 @@
 // Copyright (c) The Libra Core Contributors
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::{
-    error::Error, kv_storage::KVStorage, policy::Policy, value::Value, CryptoKVStorage, Storage,
-};
+use crate::{CryptoKVStorage, Error, GetResponse, KVStorage, Policy, Storage, Value};
 use std::collections::HashMap;
 
 /// InMemoryStorage represents a key value store that is purely in memory and intended for single
@@ -14,7 +12,7 @@ use std::collections::HashMap;
 /// securely handle key material. This should not be used in production.
 #[derive(Default)]
 pub struct InMemoryStorage {
-    data: HashMap<String, Value>,
+    data: HashMap<String, GetResponse>,
 }
 
 impl InMemoryStorage {
@@ -39,20 +37,20 @@ impl KVStorage for InMemoryStorage {
         if self.data.contains_key(key) {
             return Err(Error::KeyAlreadyExists(key.to_string()));
         }
-        self.data.insert(key.to_string(), value);
+        self.data.insert(key.to_string(), GetResponse::new(value));
         Ok(())
     }
 
-    fn get(&self, key: &str) -> Result<Value, Error> {
-        let value = self
+    fn get(&self, key: &str) -> Result<GetResponse, Error> {
+        let response = self
             .data
             .get(key)
             .ok_or_else(|| Error::KeyNotSet(key.to_string()))?;
 
-        let value = match value {
+        let value = match &response.value {
             Value::Ed25519PrivateKey(value) => {
                 // Hack because Ed25519PrivateKey does not support clone / copy
-                let bytes = lcs::to_bytes(value)?;
+                let bytes = lcs::to_bytes(&value)?;
                 let key = lcs::from_bytes(&bytes)?;
                 Value::Ed25519PrivateKey(key)
             }
@@ -60,14 +58,15 @@ impl KVStorage for InMemoryStorage {
             Value::U64(value) => Value::U64(*value),
         };
 
-        Ok(value)
+        let last_update = response.last_update;
+        Ok(GetResponse { value, last_update })
     }
 
     fn set(&mut self, key: &str, value: Value) -> Result<(), Error> {
         if !self.data.contains_key(key) {
             return Err(Error::KeyNotSet(key.to_string()));
         }
-        self.data.insert(key.to_string(), value);
+        self.data.insert(key.to_string(), GetResponse::new(value));
         Ok(())
     }
 

--- a/secure/storage/src/lib.rs
+++ b/secure/storage/src/lib.rs
@@ -16,7 +16,7 @@ mod vault;
 
 pub use crate::{
     crypto_kv_storage::CryptoKVStorage,
-    crypto_storage::CryptoStorage,
+    crypto_storage::{CryptoStorage, PublicKeyResponse},
     error::Error,
     in_memory::InMemoryStorage,
     kv_storage::{GetResponse, KVStorage},

--- a/secure/storage/src/lib.rs
+++ b/secure/storage/src/lib.rs
@@ -19,7 +19,7 @@ pub use crate::{
     crypto_storage::CryptoStorage,
     error::Error,
     in_memory::InMemoryStorage,
-    kv_storage::KVStorage,
+    kv_storage::{GetResponse, KVStorage},
     on_disk::OnDiskStorage,
     policy::{Capability, Identity, Permission, Policy},
     storage::Storage,

--- a/secure/storage/src/tests/vault.rs
+++ b/secure/storage/src/tests/vault.rs
@@ -77,24 +77,24 @@ pub fn test_vault(storage: &mut VaultStorage) {
 
     // Verify initial reading works correctly
 
-    assert_eq!(storage.get("anyone"), Ok(Value::U64(1)));
-    assert_eq!(storage.get("root"), Ok(Value::U64(2)));
-    assert_eq!(storage.get("partial"), Ok(Value::U64(3)));
-    assert_eq!(storage.get("full"), Ok(Value::U64(4)));
+    assert_eq!(storage.get("anyone").unwrap().value, Value::U64(1));
+    assert_eq!(storage.get("root").unwrap().value, Value::U64(2));
+    assert_eq!(storage.get("partial").unwrap().value, Value::U64(3));
+    assert_eq!(storage.get("full").unwrap().value, Value::U64(4));
 
     let writer_token = storage.create_token(vec![&writer]).unwrap();
     let mut writer = VaultStorage::new(VAULT_HOST.into(), writer_token, storage.namespace());
-    assert_eq!(writer.get("anyone"), Ok(Value::U64(1)));
+    assert_eq!(writer.get("anyone").unwrap().value, Value::U64(1));
     assert_eq!(writer.get("root"), Err(Error::PermissionDenied));
-    assert_eq!(writer.get("partial"), Ok(Value::U64(3)));
-    assert_eq!(writer.get("full"), Ok(Value::U64(4)));
+    assert_eq!(writer.get("partial").unwrap().value, Value::U64(3));
+    assert_eq!(writer.get("full").unwrap().value, Value::U64(4));
 
     let reader_token = storage.create_token(vec![&reader]).unwrap();
     let mut reader = VaultStorage::new(VAULT_HOST.into(), reader_token, storage.namespace());
-    assert_eq!(reader.get("anyone"), Ok(Value::U64(1)));
+    assert_eq!(reader.get("anyone").unwrap().value, Value::U64(1));
     assert_eq!(reader.get("root"), Err(Error::PermissionDenied));
-    assert_eq!(reader.get("partial"), Ok(Value::U64(3)));
-    assert_eq!(reader.get("full"), Ok(Value::U64(4)));
+    assert_eq!(reader.get("partial").unwrap().value, Value::U64(3));
+    assert_eq!(reader.get("full").unwrap().value, Value::U64(4));
 
     // Attempt writes followed by reads for correctness
 
@@ -106,10 +106,10 @@ pub fn test_vault(storage: &mut VaultStorage) {
     writer.set("partial", Value::U64(7)).unwrap();
     writer.set("full", Value::U64(8)).unwrap();
 
-    assert_eq!(storage.get("anyone"), Ok(Value::U64(5)));
-    assert_eq!(storage.get("root"), Ok(Value::U64(2)));
-    assert_eq!(storage.get("partial"), Ok(Value::U64(7)));
-    assert_eq!(storage.get("full"), Ok(Value::U64(8)));
+    assert_eq!(storage.get("anyone").unwrap().value, Value::U64(5));
+    assert_eq!(storage.get("root").unwrap().value, Value::U64(2));
+    assert_eq!(storage.get("partial").unwrap().value, Value::U64(7));
+    assert_eq!(storage.get("full").unwrap().value, Value::U64(8));
 
     reader.set("anyone", Value::U64(9)).unwrap();
     assert_eq!(
@@ -122,8 +122,8 @@ pub fn test_vault(storage: &mut VaultStorage) {
     );
     reader.set("full", Value::U64(12)).unwrap();
 
-    assert_eq!(storage.get("anyone"), Ok(Value::U64(9)));
-    assert_eq!(storage.get("root"), Ok(Value::U64(2)));
-    assert_eq!(storage.get("partial"), Ok(Value::U64(7)));
-    assert_eq!(storage.get("full"), Ok(Value::U64(12)));
+    assert_eq!(storage.get("anyone").unwrap().value, Value::U64(9));
+    assert_eq!(storage.get("root").unwrap().value, Value::U64(2));
+    assert_eq!(storage.get("partial").unwrap().value, Value::U64(7));
+    assert_eq!(storage.get("full").unwrap().value, Value::U64(12));
 }

--- a/secure/storage/src/tests/vault.rs
+++ b/secure/storage/src/tests/vault.rs
@@ -12,6 +12,7 @@ const VAULT_ROOT_TOKEN: &str = "root_token";
 /// A test for verifying VaultStorage properly implements the LibraSecureStorage API. This test
 /// depends on running Vault, which can be done by using the provided docker run script in
 /// `docker/vault/run.sh`
+// There can only be one vault test as reset called on one instance can break another test
 #[test]
 #[ignore]
 fn execute_storage_tests_vault() {
@@ -20,27 +21,21 @@ fn execute_storage_tests_vault() {
 
     test_vault(&mut storage);
     suite::execute_all_storage_tests(&mut storage);
-    storage.reset_and_clear().unwrap();
-}
 
-#[test]
-#[ignore]
-fn execute_storage_tests_vault_with_namespace() {
-    let mut storage = VaultStorage::new(
+    let mut storage0 = VaultStorage::new(
         VAULT_HOST.into(),
         VAULT_ROOT_TOKEN.into(),
-        Some("test".into()),
+        Some("test0".into()),
     );
     let mut storage1 = VaultStorage::new(
         VAULT_HOST.into(),
         VAULT_ROOT_TOKEN.into(),
         Some("test1".into()),
     );
-    storage.reset_and_clear().unwrap();
 
-    test_vault(&mut storage);
+    test_vault(&mut storage0);
     test_vault(&mut storage1);
-    suite::execute_all_storage_tests(&mut storage);
+    suite::execute_all_storage_tests(&mut storage0);
     suite::execute_all_storage_tests(&mut storage1);
     storage.reset_and_clear().unwrap();
 }

--- a/types/src/account_state.rs
+++ b/types/src/account_state.rs
@@ -10,6 +10,7 @@ use crate::{
         DiscoverySetResource, DISCOVERY_SET_CHANGE_EVENT_PATH, DISCOVERY_SET_RESOURCE_PATH,
     },
     event::EventHandle,
+    libra_timestamp::{LibraTimestampResource, LIBRA_TIMESTAMP_RESOURCE_PATH},
     validator_config::{ValidatorConfigResource, VALIDATOR_CONFIG_RESOURCE_PATH},
     validator_set::{
         ValidatorSetResource, VALIDATOR_SET_CHANGE_EVENT_PATH, VALIDATOR_SET_RESOURCE_PATH,
@@ -33,6 +34,10 @@ impl AccountState {
 
     pub fn get_discovery_set_resource(&self) -> Result<Option<DiscoverySetResource>> {
         self.get_resource(&*DISCOVERY_SET_RESOURCE_PATH)
+    }
+
+    pub fn get_libra_timestamp_resource(&self) -> Result<Option<LibraTimestampResource>> {
+        self.get_resource(&*LIBRA_TIMESTAMP_RESOURCE_PATH)
     }
 
     pub fn get_validator_config_resource(&self) -> Result<Option<ValidatorConfigResource>> {
@@ -101,6 +106,11 @@ impl fmt::Debug for AccountState {
             .map(|discovery_set_opt| format!("{:#?}", discovery_set_opt))
             .unwrap_or_else(|e| format!("parse error: {:#?}", e));
 
+        let libra_timestamp_str = self
+            .get_libra_timestamp_resource()
+            .map(|libra_timestamp_opt| format!("{:#?}", libra_timestamp_opt))
+            .unwrap_or_else(|e| format!("parse: {:#?}", e));
+
         let validator_config_str = self
             .get_validator_config_resource()
             .map(|validator_config_opt| format!("{:#?}", validator_config_opt))
@@ -116,10 +126,15 @@ impl fmt::Debug for AccountState {
             "{{ \n \
              AccountResource {{ {} }} \n \
              DiscoverySet {{ {} }} \n \
+             LibraTimestamp {{ {} }} \n \
              ValidatorConfig {{ {} }} \n \
              ValidatorSet {{ {} }} \n \
              }}",
-            account_resource_str, discovery_set_str, validator_config_str, validator_set_str,
+            account_resource_str,
+            discovery_set_str,
+            libra_timestamp_str,
+            validator_config_str,
+            validator_set_str,
         )
     }
 }

--- a/types/src/lib.rs
+++ b/types/src/lib.rs
@@ -19,6 +19,7 @@ pub mod event_subscription;
 pub mod get_with_proof;
 pub mod language_storage;
 pub mod ledger_info;
+pub mod libra_timestamp;
 pub mod mempool_status;
 pub mod on_chain_config;
 pub mod proof;

--- a/types/src/libra_timestamp.rs
+++ b/types/src/libra_timestamp.rs
@@ -1,0 +1,47 @@
+// Copyright (c) The Libra Core Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::{
+    access_path::{AccessPath, Accesses},
+    account_config,
+    language_storage::StructTag,
+};
+use move_core_types::identifier::{IdentStr, Identifier};
+use once_cell::sync::Lazy;
+use serde::{Deserialize, Serialize};
+
+static LIBRA_TIMESTAMP_MODULE_NAME: Lazy<Identifier> =
+    Lazy::new(|| Identifier::new("LibraTimestamp").unwrap());
+static LIBRA_TIMESTAMP_STRUCT_NAME: Lazy<Identifier> =
+    Lazy::new(|| Identifier::new("CurrentTimeMicroseconds").unwrap());
+
+pub fn libra_timestamp_module_name() -> &'static IdentStr {
+    &*LIBRA_TIMESTAMP_MODULE_NAME
+}
+
+pub fn libra_timestamp_struct_name() -> &'static IdentStr {
+    &*LIBRA_TIMESTAMP_STRUCT_NAME
+}
+
+pub fn libra_timestamp_tag() -> StructTag {
+    StructTag {
+        address: account_config::CORE_CODE_ADDRESS,
+        name: libra_timestamp_struct_name().to_owned(),
+        module: libra_timestamp_module_name().to_owned(),
+        type_params: vec![],
+    }
+}
+
+/// The access path where the Validator Set resource is stored.
+pub static LIBRA_TIMESTAMP_RESOURCE_PATH: Lazy<Vec<u8>> =
+    Lazy::new(|| AccessPath::resource_access_vec(&libra_timestamp_tag(), &Accesses::empty()));
+
+#[derive(Debug, Deserialize, Serialize)]
+pub struct LibraTimestampResource {
+    pub libra_timestamp: LibraTimestamp,
+}
+
+#[derive(Clone, Debug, Deserialize, Serialize)]
+pub struct LibraTimestamp {
+    pub microseconds: u64,
+}

--- a/types/src/validator_set.rs
+++ b/types/src/validator_set.rs
@@ -67,6 +67,10 @@ impl ValidatorSetResource {
         &self.change_events
     }
 
+    pub fn last_reconfiguration_time(&self) -> u64 {
+        self.last_reconfiguration_time
+    }
+
     pub fn validator_set(&self) -> &ValidatorSet {
         &self.validator_set
     }


### PR DESCRIPTION
This PR instantiates the first few components of secure storage:
* an interface for talking to libra
* a container for key management code
* access to the libra blockchain timestamp
* access to the timestamps to the last time data was written to secure storage
* a fix to testing vault from multiple integration tests

There's a lot more work to be done, we haven't even begun submitting transactions within the key manager or evaluating whether or not it is appropriate to be submitting a rotation and of course logging and counters (@ankushagarwal, looking forward to your counter PR landing). Even after we get all that done, we still need to do all the work to talk to the JSON-RPC interface, but these are essential building blocks.