### PR TITLE
Move the logic of genesis block id generation to block_hash.rs

### DIFF
--- a/consensus/consensus-types/src/block.rs
+++ b/consensus/consensus-types/src/block.rs
@@ -5,25 +5,17 @@ use crate::{
     block_data::{BlockData, BlockType},
     common::{Author, Round},
     quorum_cert::QuorumCert,
-    vote_data::VoteData,
 };
 use anyhow::{bail, ensure, format_err};
 use libra_crypto::{ed25519::Ed25519Signature, hash::CryptoHash, HashValue};
 use libra_types::{
-    block_info::BlockInfo,
-    block_metadata::BlockMetadata,
-    ledger_info::{LedgerInfo, LedgerInfoWithSignatures},
-    transaction::Version,
-    validator_set::ValidatorSet,
-    validator_signer::ValidatorSigner,
+    block_info::BlockInfo, block_metadata::BlockMetadata, ledger_info::LedgerInfo,
+    transaction::Version, validator_set::ValidatorSet, validator_signer::ValidatorSigner,
     validator_verifier::ValidatorVerifier,
 };
 use mirai_annotations::debug_checked_verify_eq;
 use serde::{de::DeserializeOwned, Deserialize, Deserializer, Serialize};
-use std::{
-    collections::BTreeMap,
-    fmt::{self, Display, Formatter},
-};
+use std::fmt::{self, Display, Formatter};
 
 #[path = "block_test_utils.rs"]
 #[cfg(any(test, feature = "fuzzing"))]
@@ -151,29 +143,7 @@ where
     /// Construct new genesis block for next epoch deterministically from the end-epoch LedgerInfo
     /// We carry over most fields except round and block id
     pub fn make_genesis_block_from_ledger_info(ledger_info: &LedgerInfo) -> Self {
-        assert!(ledger_info.next_validator_set().is_some());
-        let ancestor = BlockInfo::new(
-            ledger_info.epoch(),
-            0,
-            HashValue::zero(),
-            ledger_info.transaction_accumulator_hash(),
-            ledger_info.version(),
-            ledger_info.timestamp_usecs(),
-            None,
-        );
-
-        // Genesis carries a placeholder quorum certificate to its parent id with LedgerInfo
-        // carrying information about version from the last LedgerInfo of previous epoch.
-        let genesis_quorum_cert = QuorumCert::new(
-            VoteData::new(ancestor.clone(), ancestor.clone()),
-            LedgerInfoWithSignatures::new(
-                LedgerInfo::new(ancestor, HashValue::zero()),
-                BTreeMap::new(),
-            ),
-        );
-
-        let block_data = BlockData::new_genesis(ledger_info.timestamp_usecs(), genesis_quorum_cert);
-
+        let block_data = BlockData::new_genesis_from_ledger_info(ledger_info);
         Block {
             id: block_data.hash(),
             block_data,

--- a/consensus/consensus-types/src/block_data.rs
+++ b/consensus/consensus-types/src/block_data.rs
@@ -4,11 +4,17 @@
 use crate::{
     common::{Author, Round},
     quorum_cert::QuorumCert,
+    vote_data::VoteData,
 };
 use libra_crypto::hash::{CryptoHash, CryptoHasher, HashValue};
 use libra_crypto_derive::CryptoHasher;
+use libra_types::{
+    block_info::BlockInfo,
+    ledger_info::{LedgerInfo, LedgerInfoWithSignatures},
+};
 use mirai_annotations::*;
 use serde::{Deserialize, Serialize};
+use std::collections::BTreeMap;
 
 #[derive(Deserialize, Serialize, Clone, Debug, PartialEq, Eq)]
 pub enum BlockType<T> {
@@ -123,6 +129,31 @@ impl<T> BlockData<T>
 where
     T: Default + Serialize,
 {
+    pub fn new_genesis_from_ledger_info(ledger_info: &LedgerInfo) -> Self {
+        assert!(ledger_info.next_validator_set().is_some());
+        let ancestor = BlockInfo::new(
+            ledger_info.epoch(),
+            0,                 /* round */
+            HashValue::zero(), /* parent block id */
+            ledger_info.transaction_accumulator_hash(),
+            ledger_info.version(),
+            ledger_info.timestamp_usecs(),
+            None,
+        );
+
+        // Genesis carries a placeholder quorum certificate to its parent id with LedgerInfo
+        // carrying information about version from the last LedgerInfo of previous epoch.
+        let genesis_quorum_cert = QuorumCert::new(
+            VoteData::new(ancestor.clone(), ancestor.clone()),
+            LedgerInfoWithSignatures::new(
+                LedgerInfo::new(ancestor, HashValue::zero()),
+                BTreeMap::new(),
+            ),
+        );
+
+        BlockData::new_genesis(ledger_info.timestamp_usecs(), genesis_quorum_cert)
+    }
+
     pub fn new_genesis(timestamp_usecs: u64, quorum_cert: QuorumCert) -> Self {
         assume!(quorum_cert.certified_block().epoch() < u64::max_value()); // unlikely to be false in this universe
         Self {


### PR DESCRIPTION
## Motivation

The objective of this PR is to move the logic of generating genesis block data from block.rs into block_data.rs, along with all the dependencies necessarily.

The reason is for adding back block tree into LEC (ref: #2519 ). We adopt block_id as the identifier of each block's speculation result inside executor. But to initialize the block tree with a root block, we need a way to cold start from a reconfiguration block (genesis block is a reconfiguration block). However, the block_id is based on block_data, which is needed for execution to start the root block.

`new_genesis_from_ledger_info` will be used by executor.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?
Y

## Test Plan

CI
