### PR TITLE
[move-prover] Fix for inline attribute on Boogie function

### DIFF
--- a/language/move-prover/src/spec_translator.rs
+++ b/language/move-prover/src/spec_translator.rs
@@ -333,7 +333,7 @@ impl<'env> SpecTranslator<'env> {
     fn translate_assume_well_formed(&self, struct_env: &StructEnv<'env>) {
         emitln!(
             self.writer,
-            "function {{:inline 1}} ${}_is_well_formed($this: Value): bool {{",
+            "function {{:inline}} ${}_is_well_formed($this: Value): bool {{",
             boogie_struct_name(struct_env),
         );
         self.writer.indent();


### PR DESCRIPTION
## Motivation

Inlined Boogie function should have attribute {:inline}. Closes #2898 .

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

Existing tests

## Related PRs

