### PR TITLE
[language] rename ModuleSourceMap to SourceMap

### DIFF
--- a/language/compiler/bytecode-source-map/src/mapping.rs
+++ b/language/compiler/bytecode-source-map/src/mapping.rs
@@ -1,7 +1,7 @@
 // Copyright (c) The Libra Core Contributors
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::{marking::MarkedSourceMapping, source_map::ModuleSourceMap};
+use crate::{marking::MarkedSourceMapping, source_map::SourceMap};
 use vm::file_format::{CompiledModule, CompiledScript};
 
 /// An object that associates source code with compiled bytecode and source map.
@@ -11,7 +11,7 @@ pub struct SourceMapping<Location: Clone + Eq> {
     pub bytecode: CompiledModule,
 
     // The source map for the bytecode made w.r.t. to the `source_code`
-    pub source_map: ModuleSourceMap<Location>,
+    pub source_map: SourceMap<Location>,
 
     // The source code for the bytecode. This is not required for disassembly, but it is required
     // for being able to print out corresponding source code for marked functions and structs.
@@ -24,7 +24,7 @@ pub struct SourceMapping<Location: Clone + Eq> {
 }
 
 impl<Location: Clone + Eq> SourceMapping<Location> {
-    pub fn new(source_map: ModuleSourceMap<Location>, bytecode: CompiledModule) -> Self {
+    pub fn new(source_map: SourceMap<Location>, bytecode: CompiledModule) -> Self {
         Self {
             source_map,
             bytecode,
@@ -33,10 +33,7 @@ impl<Location: Clone + Eq> SourceMapping<Location> {
         }
     }
 
-    pub fn new_from_script(
-        source_map: ModuleSourceMap<Location>,
-        bytecode: CompiledScript,
-    ) -> Self {
+    pub fn new_from_script(source_map: SourceMap<Location>, bytecode: CompiledScript) -> Self {
         Self::new(source_map, bytecode.into_module())
     }
 

--- a/language/compiler/bytecode-source-map/src/source_map.rs
+++ b/language/compiler/bytecode-source-map/src/source_map.rs
@@ -59,8 +59,8 @@ pub struct FunctionSourceMap<Location: Clone + Eq> {
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone)]
-pub struct ModuleSourceMap<Location: Clone + Eq> {
-    /// The name <address.module_name> for module that this source map is for
+pub struct SourceMap<Location: Clone + Eq> {
+    /// The name <address.module_name> for module/script that this source map is for
     pub module_name: (AccountAddress, Identifier),
 
     // A mapping of StructDefinitionIndex to source map for each struct/resource
@@ -78,9 +78,9 @@ pub fn remap_locations_source_name<Location: Clone + Eq, Other: Clone + Eq>(
 }
 
 pub fn remap_locations_source_map<Location: Clone + Eq, Other: Clone + Eq>(
-    map: Vec<ModuleSourceMap<Location>>,
+    map: Vec<SourceMap<Location>>,
     f: &mut impl FnMut(Location) -> Other,
-) -> Vec<ModuleSourceMap<Other>> {
+) -> Vec<SourceMap<Other>> {
     map.into_iter().map(|m| m.remap_locations(f)).collect()
 }
 
@@ -281,7 +281,7 @@ impl<Location: Clone + Eq> FunctionSourceMap<Location> {
     }
 }
 
-impl<Location: Clone + Eq> ModuleSourceMap<Location> {
+impl<Location: Clone + Eq> SourceMap<Location> {
     pub fn new(module_name: QualifiedModuleIdent) -> Self {
         let ident = Identifier::new(module_name.name.into_inner()).unwrap();
         Self {
@@ -511,8 +511,8 @@ impl<Location: Clone + Eq> ModuleSourceMap<Location> {
     pub fn remap_locations<Other: Clone + Eq>(
         self,
         f: &mut impl FnMut(Location) -> Other,
-    ) -> ModuleSourceMap<Other> {
-        let ModuleSourceMap {
+    ) -> SourceMap<Other> {
+        let SourceMap {
             module_name,
             struct_map,
             function_map,
@@ -525,7 +525,7 @@ impl<Location: Clone + Eq> ModuleSourceMap<Location> {
             .into_iter()
             .map(|(n, m)| (n, m.remap_locations(f)))
             .collect();
-        ModuleSourceMap {
+        SourceMap {
             module_name,
             struct_map,
             function_map,

--- a/language/compiler/bytecode-source-map/src/source_map.rs
+++ b/language/compiler/bytecode-source-map/src/source_map.rs
@@ -21,7 +21,6 @@ use vm::{
 // Source location mapping
 //***************************************************************************
 
-pub type SourceMap<Location> = Vec<ModuleSourceMap<Location>>;
 pub type SourceName<Location> = (String, Location);
 
 #[derive(Debug, Serialize, Deserialize, Clone)]
@@ -79,9 +78,9 @@ pub fn remap_locations_source_name<Location: Clone + Eq, Other: Clone + Eq>(
 }
 
 pub fn remap_locations_source_map<Location: Clone + Eq, Other: Clone + Eq>(
-    map: SourceMap<Location>,
+    map: Vec<ModuleSourceMap<Location>>,
     f: &mut impl FnMut(Location) -> Other,
-) -> SourceMap<Other> {
+) -> Vec<ModuleSourceMap<Other>> {
     map.into_iter().map(|m| m.remap_locations(f)).collect()
 }
 

--- a/language/compiler/bytecode-source-map/src/utils.rs
+++ b/language/compiler/bytecode-source-map/src/utils.rs
@@ -19,7 +19,7 @@ use std::{collections::HashMap, fs::File, path::Path};
 pub type Error = (Loc, String);
 pub type Errors = Vec<Error>;
 
-pub fn module_source_map_from_file<Location>(file_path: &Path) -> Result<SourceMap<Location>>
+pub fn source_map_from_file<Location>(file_path: &Path) -> Result<SourceMap<Location>>
 where
     Location: Clone + Eq + Default + DeserializeOwned,
 {

--- a/language/compiler/bytecode-source-map/src/utils.rs
+++ b/language/compiler/bytecode-source-map/src/utils.rs
@@ -3,7 +3,7 @@
 
 use crate::{
     mapping::SourceMapping,
-    source_map::{ModuleSourceMap, SourceMap},
+    source_map::ModuleSourceMap,
 };
 use anyhow::{format_err, Result};
 use codespan::{FileId, Files, Span};
@@ -23,16 +23,6 @@ pub type Error = (Loc, String);
 pub type Errors = Vec<Error>;
 
 pub fn module_source_map_from_file<Location>(file_path: &Path) -> Result<ModuleSourceMap<Location>>
-where
-    Location: Clone + Eq + Default + DeserializeOwned,
-{
-    File::open(file_path)
-        .ok()
-        .and_then(|file| serde_json::from_reader(file).ok())
-        .ok_or_else(|| format_err!("Error while reading in source map information"))
-}
-
-pub fn source_map_from_file<Location>(file_path: &Path) -> Result<SourceMap<Location>>
 where
     Location: Clone + Eq + Default + DeserializeOwned,
 {

--- a/language/compiler/bytecode-source-map/src/utils.rs
+++ b/language/compiler/bytecode-source-map/src/utils.rs
@@ -1,10 +1,7 @@
 // Copyright (c) The Libra Core Contributors
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::{
-    mapping::SourceMapping,
-    source_map::ModuleSourceMap,
-};
+use crate::{mapping::SourceMapping, source_map::SourceMap};
 use anyhow::{format_err, Result};
 use codespan::{FileId, Files, Span};
 use codespan_reporting::{
@@ -22,7 +19,7 @@ use std::{collections::HashMap, fs::File, path::Path};
 pub type Error = (Loc, String);
 pub type Errors = Vec<Error>;
 
-pub fn module_source_map_from_file<Location>(file_path: &Path) -> Result<ModuleSourceMap<Location>>
+pub fn module_source_map_from_file<Location>(file_path: &Path) -> Result<SourceMap<Location>>
 where
     Location: Clone + Eq + Default + DeserializeOwned,
 {
@@ -63,7 +60,7 @@ pub struct OwnedLoc {
     span: Span,
 }
 
-pub fn remap_owned_loc_to_loc(m: ModuleSourceMap<OwnedLoc>) -> ModuleSourceMap<Loc> {
+pub fn remap_owned_loc_to_loc(m: SourceMap<OwnedLoc>) -> SourceMap<Loc> {
     let mut table: HashMap<String, &'static str> = HashMap::new();
     let mut f = |owned| {
         let OwnedLoc { file, span } = owned;

--- a/language/compiler/ir-to-bytecode/src/compiler.rs
+++ b/language/compiler/ir-to-bytecode/src/compiler.rs
@@ -7,7 +7,7 @@ use crate::{
 };
 
 use anyhow::{bail, format_err, Result};
-use bytecode_source_map::source_map::ModuleSourceMap;
+use bytecode_source_map::source_map::SourceMap;
 use libra_types::account_address::AccountAddress;
 use move_ir_types::{
     ast::{self, Bytecode as IRBytecode, Bytecode_ as IRBytecode_, *},
@@ -321,7 +321,7 @@ pub fn compile_script<'a, T: 'a + ModuleAccess>(
     address: AccountAddress,
     script: Script,
     dependencies: impl IntoIterator<Item = &'a T>,
-) -> Result<(CompiledScript, ModuleSourceMap<Loc>)> {
+) -> Result<(CompiledScript, SourceMap<Loc>)> {
     let current_module = QualifiedModuleIdent {
         address,
         name: ModuleName::new(file_format::self_module_name().to_string()),
@@ -378,7 +378,7 @@ pub fn compile_module<'a, T: 'a + ModuleAccess>(
     address: AccountAddress,
     module: ModuleDefinition,
     dependencies: impl IntoIterator<Item = &'a T>,
-) -> Result<(CompiledModule, ModuleSourceMap<Loc>)> {
+) -> Result<(CompiledModule, SourceMap<Loc>)> {
     let current_module = QualifiedModuleIdent {
         address,
         name: module.name,

--- a/language/compiler/ir-to-bytecode/src/context.rs
+++ b/language/compiler/ir-to-bytecode/src/context.rs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use anyhow::{bail, format_err, Result};
-use bytecode_source_map::source_map::ModuleSourceMap;
+use bytecode_source_map::source_map::SourceMap;
 use libra_types::account_address::AccountAddress;
 use move_core_types::identifier::{IdentStr, Identifier};
 use move_ir_types::{ast::*, location::*};
@@ -197,7 +197,7 @@ pub struct Context<'a> {
     current_function_index: FunctionDefinitionIndex,
 
     // Source location mapping for this module
-    pub source_map: ModuleSourceMap<Loc>,
+    pub source_map: SourceMap<Loc>,
 }
 
 impl<'a> Context<'a> {
@@ -238,7 +238,7 @@ impl<'a> Context<'a> {
             address_pool: HashMap::new(),
             type_formals: HashMap::new(),
             current_function_index: FunctionDefinitionIndex(0),
-            source_map: ModuleSourceMap::new(current_module.clone()),
+            source_map: SourceMap::new(current_module.clone()),
         };
         let self_name = ModuleName::new(ModuleName::self_name().into());
         context.declare_import(current_module, self_name)?;
@@ -263,7 +263,7 @@ impl<'a> Context<'a> {
     }
 
     /// Finish compilation, and materialize the pools for file format.
-    pub fn materialize_pools(self) -> (MaterializedPools, ModuleSourceMap<Loc>) {
+    pub fn materialize_pools(self) -> (MaterializedPools, SourceMap<Loc>) {
         let num_functions = self.function_handles.len();
         assert!(num_functions == self.function_signatures.len());
         let function_handles = Self::materialize_pool(

--- a/language/compiler/src/lib.rs
+++ b/language/compiler/src/lib.rs
@@ -9,7 +9,7 @@ pub mod util;
 mod unit_tests;
 
 use anyhow::Result;
-use bytecode_source_map::source_map::ModuleSourceMap;
+use bytecode_source_map::source_map::SourceMap;
 use bytecode_verifier::VerifiedModule;
 use ir_to_bytecode::{
     compiler::{compile_module, compile_script},
@@ -49,7 +49,7 @@ impl Compiler {
         mut self,
         file_name: &str,
         code: &str,
-    ) -> Result<(CompiledScript, ModuleSourceMap<Loc>)> {
+    ) -> Result<(CompiledScript, SourceMap<Loc>)> {
         let (compiled_script, source_map, _) = self.compile_script(file_name, code)?;
         Ok((compiled_script, source_map))
     }
@@ -81,7 +81,7 @@ impl Compiler {
         &mut self,
         file_name: &str,
         code: &str,
-    ) -> Result<(CompiledScript, ModuleSourceMap<Loc>, Vec<VerifiedModule>)> {
+    ) -> Result<(CompiledScript, SourceMap<Loc>, Vec<VerifiedModule>)> {
         let parsed_script = parse_script(file_name, code)?;
         let deps = self.deps();
         let (compiled_script, source_map) = compile_script(self.address, parsed_script, &deps)?;
@@ -92,7 +92,7 @@ impl Compiler {
         &mut self,
         file_name: &str,
         code: &str,
-    ) -> Result<(CompiledModule, ModuleSourceMap<Loc>, Vec<VerifiedModule>)> {
+    ) -> Result<(CompiledModule, SourceMap<Loc>, Vec<VerifiedModule>)> {
         let parsed_module = parse_module(file_name, code)?;
         let deps = self.deps();
         let (compiled_module, source_map) = compile_module(self.address, parsed_module, &deps)?;

--- a/language/compiler/src/util.rs
+++ b/language/compiler/src/util.rs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use anyhow::Context;
-use bytecode_source_map::source_map::ModuleSourceMap;
+use bytecode_source_map::source_map::SourceMap;
 use ir_to_bytecode::{compiler::compile_module, parser::parse_module};
 use libra_types::account_address::AccountAddress;
 use move_ir_types::location::Loc;
@@ -13,7 +13,7 @@ pub fn do_compile_module<T: ModuleAccess>(
     source_path: &Path,
     address: AccountAddress,
     dependencies: &[T],
-) -> (CompiledModule, ModuleSourceMap<Loc>) {
+) -> (CompiledModule, SourceMap<Loc>) {
     let source = fs::read_to_string(source_path)
         .with_context(|| format!("Unable to read file: {:?}", source_path))
         .unwrap();

--- a/language/move-lang/src/compiled_unit.rs
+++ b/language/move-lang/src/compiled_unit.rs
@@ -7,7 +7,7 @@ use crate::{
     parser::ast::{FunctionName, ModuleIdent},
     shared::unique_map::UniqueMap,
 };
-use bytecode_source_map::source_map::ModuleSourceMap;
+use bytecode_source_map::source_map::SourceMap;
 use move_ir_types::location::*;
 use move_vm::file_format as F;
 use std::collections::BTreeMap;
@@ -21,13 +21,13 @@ pub enum CompiledUnit {
     Module {
         ident: ModuleIdent,
         module: F::CompiledModule,
-        source_map: ModuleSourceMap<Loc>,
+        source_map: SourceMap<Loc>,
         spec_id_offsets: UniqueMap<FunctionName, BTreeMap<SpecId, F::CodeOffset>>,
     },
     Script {
         loc: Loc,
         script: F::CompiledScript,
-        source_map: ModuleSourceMap<Loc>,
+        source_map: SourceMap<Loc>,
         spec_id_offsets: BTreeMap<SpecId, F::CodeOffset>,
     },
 }

--- a/language/move-lang/src/to_bytecode/translate.rs
+++ b/language/move-lang/src/to_bytecode/translate.rs
@@ -15,7 +15,7 @@ use crate::{
     },
     shared::{unique_map::UniqueMap, *},
 };
-use bytecode_source_map::source_map::ModuleSourceMap;
+use bytecode_source_map::source_map::SourceMap;
 use libra_types::account_address::AccountAddress as LibraAddress;
 use move_ir_types::{ast as IR, location::*};
 use move_vm::file_format as F;
@@ -176,7 +176,7 @@ fn main(
 
 fn function_spec_id_map(
     compile_module: &F::CompiledModule,
-    source_map: &ModuleSourceMap<Loc>,
+    source_map: &SourceMap<Loc>,
     function_nop_labels: &UniqueMap<FunctionName, BTreeMap<SpecId, IR::NopLabel>>,
     idx: F::FunctionDefinitionIndex,
 ) -> (FunctionName, BTreeMap<SpecId, F::CodeOffset>) {
@@ -201,7 +201,7 @@ fn function_spec_id_map(
 }
 
 fn main_spec_id_map(
-    source_map: &ModuleSourceMap<Loc>,
+    source_map: &SourceMap<Loc>,
     nop_labels: BTreeMap<SpecId, IR::NopLabel>,
 ) -> BTreeMap<SpecId, F::CodeOffset> {
     let idx = F::FunctionDefinitionIndex(0);

--- a/language/move-prover/spec-lang/src/env.rs
+++ b/language/move-prover/spec-lang/src/env.rs
@@ -17,7 +17,7 @@ use codespan_reporting::{
 use itertools::Itertools;
 use num::{BigUint, Num};
 
-use bytecode_source_map::source_map::ModuleSourceMap;
+use bytecode_source_map::source_map::SourceMap;
 use libra_types::language_storage;
 use vm::{
     access::ModuleAccess,
@@ -380,7 +380,7 @@ impl GlobalEnv {
         &mut self,
         loc: Loc,
         module: CompiledModule,
-        source_map: ModuleSourceMap<MoveIrLoc>,
+        source_map: SourceMap<MoveIrLoc>,
         struct_data: BTreeMap<StructId, StructData>,
         function_data: BTreeMap<FunId, FunctionData>,
         spec_vars: Vec<SpecVarDecl>,
@@ -684,7 +684,7 @@ pub struct ModuleData {
     pub module_invariants: Vec<Invariant>,
 
     /// Module source location information.
-    pub source_map: ModuleSourceMap<MoveIrLoc>,
+    pub source_map: SourceMap<MoveIrLoc>,
 
     /// The location of this module.
     pub loc: Loc,

--- a/language/move-prover/spec-lang/src/translate.rs
+++ b/language/move-prover/spec-lang/src/translate.rs
@@ -11,7 +11,7 @@ use std::collections::{BTreeMap, BTreeSet, LinkedList};
 use itertools::Itertools;
 use num::{BigUint, FromPrimitive, Num};
 
-use bytecode_source_map::source_map::ModuleSourceMap;
+use bytecode_source_map::source_map::SourceMap;
 use move_lang::{
     expansion::ast as EA,
     parser::ast as PA,
@@ -621,7 +621,7 @@ impl<'env, 'translator> ModuleTranslator<'env, 'translator> {
         loc: Loc,
         module_def: EA::ModuleDefinition,
         compiled_module: CompiledModule,
-        source_map: ModuleSourceMap<MoveIrLoc>,
+        source_map: SourceMap<MoveIrLoc>,
         spec_id_offsets: UniqueMap<FunctionName, BTreeMap<SpecId, CodeOffset>>,
     ) {
         self.decl_ana(&module_def);
@@ -1189,7 +1189,7 @@ impl<'env, 'translator> ModuleTranslator<'env, 'translator> {
         &mut self,
         loc: Loc,
         module: CompiledModule,
-        source_map: ModuleSourceMap<MoveIrLoc>,
+        source_map: SourceMap<MoveIrLoc>,
     ) {
         let struct_data: BTreeMap<StructId, StructData> = (0..module.struct_defs().len())
             .filter_map(|idx| {

--- a/language/tools/disassembler/src/main.rs
+++ b/language/tools/disassembler/src/main.rs
@@ -5,7 +5,7 @@
 
 use bytecode_source_map::{
     mapping::SourceMapping,
-    source_map::ModuleSourceMap,
+    source_map::SourceMap,
     utils::{module_source_map_from_file, remap_owned_loc_to_loc, OwnedLoc},
 };
 use disassembler::disassembler::{Disassembler, DisassemblerOptions};
@@ -87,14 +87,14 @@ fn main() {
         let compiled_script = CompiledScript::deserialize(&bytecode_bytes)
             .expect("Script blob can't be deserialized");
         source_map
-            .or_else(|_| ModuleSourceMap::dummy_from_script(&compiled_script, no_loc))
+            .or_else(|_| SourceMap::dummy_from_script(&compiled_script, no_loc))
             .and_then(|source_map| Ok(SourceMapping::new_from_script(source_map, compiled_script)))
             .expect("Unable to build source mapping for compiled script")
     } else {
         let compiled_module = CompiledModule::deserialize(&bytecode_bytes)
             .expect("Module blob can't be deserialized");
         source_map
-            .or_else(|_| ModuleSourceMap::dummy_from_module(&compiled_module, no_loc))
+            .or_else(|_| SourceMap::dummy_from_module(&compiled_module, no_loc))
             .and_then(|source_map| Ok(SourceMapping::new(source_map, compiled_module)))
             .expect("Unable to build source mapping for compiled module")
     };

--- a/language/tools/disassembler/src/main.rs
+++ b/language/tools/disassembler/src/main.rs
@@ -6,7 +6,7 @@
 use bytecode_source_map::{
     mapping::SourceMapping,
     source_map::SourceMap,
-    utils::{module_source_map_from_file, remap_owned_loc_to_loc, OwnedLoc},
+    utils::{remap_owned_loc_to_loc, source_map_from_file, OwnedLoc},
 };
 use disassembler::disassembler::{Disassembler, DisassemblerOptions};
 use move_ir_types::location::Spanned;
@@ -70,7 +70,7 @@ fn main() {
 
     let source_path = Path::new(&args.bytecode_file_path).with_extension(move_extension);
     let source = fs::read_to_string(&source_path).ok();
-    let source_map = module_source_map_from_file::<OwnedLoc>(
+    let source_map = source_map_from_file::<OwnedLoc>(
         &Path::new(&args.bytecode_file_path).with_extension(source_map_extension),
     )
     .map(remap_owned_loc_to_loc);


### PR DESCRIPTION
The previous SourceMap type was barely used and since it is just a vector of ModuleSourceMaps, it can be replaced by that when needed. With that out of the way, we can rename ModuleSourceMap to the shorter "SourceMap". We use this for both modules and scripts, so it was a little confusing to use the name ModuleSourceMap.

## Motivation

Simplicity and clarity

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

No functional changes here
