### PR TITLE
[LEC] Executor cache: keep block speculation result inside executor

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1295,6 +1295,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow 1.0.27 (registry+https://github.com/rust-lang/crates.io-index)",
  "config-builder 0.1.0",
+ "consensus-types 0.1.0",
  "debug-interface 0.1.0",
  "executor-types 0.1.0",
  "executor-utils 0.1.0",
@@ -1363,7 +1364,6 @@ name = "executor-utils"
 version = "0.1.0"
 dependencies = [
  "executor 0.1.0",
- "executor-types 0.1.0",
  "libra-config 0.1.0",
  "libra-vm 0.1.0",
  "storage-client 0.1.0",

--- a/consensus/src/chained_bft/block_storage/block_store_test.rs
+++ b/consensus/src/chained_bft/block_storage/block_store_test.rs
@@ -265,7 +265,7 @@ fn test_insert_vote() {
         let vote = Vote::new(
             VoteData::new(
                 block.block().gen_block_info(
-                    block.compute_result().state_id(),
+                    block.compute_result().root_hash(),
                     block.compute_result().version(),
                     block.compute_result().validators().clone(),
                 ),
@@ -293,7 +293,7 @@ fn test_insert_vote() {
     let vote = Vote::new(
         VoteData::new(
             block.block().gen_block_info(
-                block.compute_result().state_id(),
+                block.compute_result().root_hash(),
                 block.compute_result().version(),
                 block.compute_result().validators().clone(),
             ),

--- a/consensus/src/chained_bft/block_storage/sync_manager.rs
+++ b/consensus/src/chained_bft/block_storage/sync_manager.rs
@@ -142,7 +142,7 @@ impl<T: Payload> BlockStore<T> {
         if !self.need_sync_for_quorum_cert(&highest_commit_cert) {
             return Ok(());
         }
-        let (root, root_executed_trees, blocks, quorum_certs) = Self::fast_forward_sync(
+        let (root, root_metadata, blocks, quorum_certs) = Self::fast_forward_sync(
             &highest_commit_cert,
             retriever,
             self.storage.clone(),
@@ -151,7 +151,7 @@ impl<T: Payload> BlockStore<T> {
         .await?
         .take();
         debug!("{}Sync to{} {}", Fg(Blue), Fg(Reset), root.0);
-        self.rebuild(root, root_executed_trees, blocks, quorum_certs)
+        self.rebuild(root, root_metadata, blocks, quorum_certs)
             .await;
 
         if highest_commit_cert.ends_epoch() {

--- a/consensus/src/chained_bft/event_processor.rs
+++ b/consensus/src/chained_bft/event_processor.rs
@@ -755,13 +755,12 @@ impl<T: Payload> EventProcessor<T> {
 
         let vote_proposal = VoteProposal::new(
             AccumulatorExtensionProof::<TransactionAccumulatorHasher>::new(
-                parent_block
-                    .executed_trees()
-                    .txn_accumulator()
-                    .frozen_subtree_roots()
+                parent_block.compute_result().frozen_subtree_roots().clone(),
+                parent_block.compute_result().num_leaves(),
+                executed_block
+                    .compute_result()
+                    .transaction_info_hashes()
                     .clone(),
-                parent_block.executed_trees().txn_accumulator().num_leaves(),
-                executed_block.transaction_info_hashes(),
             ),
             block.clone(),
             executed_block.compute_result().validators().clone(),
@@ -938,24 +937,10 @@ impl<T: Payload> EventProcessor<T> {
                 counters::CREATION_TO_COMMIT_S.observe_duration(time_to_commit);
             }
             counters::COMMITTED_BLOCKS_COUNT.inc();
-            let block_txns = block.output().transaction_data();
-            counters::NUM_TXNS_PER_BLOCK.observe(block_txns.len() as f64);
+            let txn_status = block.compute_result().compute_status();
+            counters::NUM_TXNS_PER_BLOCK.observe(txn_status.len() as f64);
 
-            for txn in block_txns.iter() {
-                match txn.txn_info_hash() {
-                    Some(_) => {
-                        counters::COMMITTED_TXNS_COUNT
-                            .with_label_values(&["success"])
-                            .inc();
-                    }
-                    None => {
-                        counters::COMMITTED_TXNS_COUNT
-                            .with_label_values(&["failed"])
-                            .inc();
-                    }
-                }
-            }
-            for status in block.compute_result().compute_status().iter() {
+            for status in txn_status.iter() {
                 match status {
                     TransactionStatus::Keep(_) => {
                         counters::COMMITTED_TXNS_COUNT

--- a/consensus/src/chained_bft/event_processor_test.rs
+++ b/consensus/src/chained_bft/event_processor_test.rs
@@ -267,7 +267,7 @@ fn basic_new_rank_event_test() {
         let vote = Vote::new(
             VoteData::new(
                 a1.block().gen_block_info(
-                    a1.compute_result().state_id(),
+                    a1.compute_result().root_hash(),
                     a1.compute_result().version(),
                     a1.compute_result().validators().clone(),
                 ),
@@ -280,7 +280,7 @@ fn basic_new_rank_event_test() {
         let vote1 = Vote::new(
             VoteData::new(
                 a1.block().gen_block_info(
-                    a1.compute_result().state_id(),
+                    a1.compute_result().root_hash(),
                     a1.compute_result().version(),
                     a1.compute_result().validators().clone(),
                 ),
@@ -481,6 +481,7 @@ fn process_vote_timeout_msg_test() {
     // Populate block_0 and a quorum certificate for block_0 on non_proposer
     let block_0_quorum_cert = gen_test_certificate(
         vec![&static_proposer.signer, &non_proposer.signer],
+        // Follow MockStateComputer implementation
         block_0.gen_block_info(
             parent_block_info.executed_state_id(),
             parent_block_info.version(),
@@ -649,7 +650,7 @@ fn process_votes_basic_test() {
             a1.quorum_cert().certified_block().epoch(),
             a1.round(),
             a1.id(),
-            a1.compute_result().state_id(),
+            a1.compute_result().root_hash(),
             a1.compute_result().version(),
             a1.timestamp_usecs(),
             a1.compute_result().validators().clone(),

--- a/consensus/src/chained_bft/persistent_liveness_storage.rs
+++ b/consensus/src/chained_bft/persistent_liveness_storage.rs
@@ -13,12 +13,12 @@ use libra_config::config::NodeConfig;
 use libra_crypto::HashValue;
 use libra_logger::prelude::*;
 use libra_types::{
-    block_info::Round, epoch_info::EpochInfo, ledger_info::LedgerInfo,
+    block_info::Round, epoch_info::EpochInfo, ledger_info::LedgerInfo, transaction::Version,
     validator_info::ValidatorInfo, validator_set::ValidatorSet,
     validator_verifier::ValidatorVerifier,
 };
 use libradb::LibraDBTrait;
-use std::{collections::HashSet, sync::Arc};
+use std::{cmp::max, collections::HashSet, sync::Arc};
 
 /// PersistentLivenessStorage is essential for maintaining liveness when a node crashes.  Specifically,
 /// upon a restart, a correct node will recover.  Even if all nodes crash, liveness is
@@ -143,6 +143,31 @@ impl LedgerRecoveryData {
     }
 }
 
+pub struct RootMetadata {
+    pub accu_hash: HashValue,
+    pub frozen_root_hashes: Vec<HashValue>,
+    pub num_leaves: Version,
+}
+
+impl RootMetadata {
+    pub fn new(num_leaves: u64, accu_hash: HashValue, frozen_root_hashes: Vec<HashValue>) -> Self {
+        Self {
+            num_leaves,
+            accu_hash,
+            frozen_root_hashes,
+        }
+    }
+
+    pub fn version(&self) -> Version {
+        max(self.num_leaves, 1) - 1
+    }
+
+    #[cfg(any(test, feature = "fuzzing"))]
+    pub fn new_empty() -> Self {
+        Self::new(0, *libra_crypto::hash::ACCUMULATOR_PLACEHOLDER_HASH, vec![])
+    }
+}
+
 /// The recovery data constructed from raw consensusdb data, it'll find the root value and
 /// blocks that need cleanup or return error if the input data is inconsistent.
 pub struct RecoveryData<T> {
@@ -150,7 +175,7 @@ pub struct RecoveryData<T> {
     // The last vote message sent by this validator.
     last_vote: Option<Vote>,
     root: RootInfo<T>,
-    root_executed_trees: ExecutedTrees,
+    root_metadata: RootMetadata,
     // 1. the blocks guarantee the topological ordering - parent <- child.
     // 2. all blocks are children of the root.
     blocks: Vec<Block<T>>,
@@ -166,8 +191,8 @@ impl<T: Payload> RecoveryData<T> {
         last_vote: Option<Vote>,
         ledger_recovery_data: LedgerRecoveryData,
         mut blocks: Vec<Block<T>>,
+        root_metadata: RootMetadata,
         mut quorum_certs: Vec<QuorumCert>,
-        root_executed_trees: ExecutedTrees,
         highest_timeout_certificate: Option<TimeoutCertificate>,
     ) -> Result<Self> {
         let root = ledger_recovery_data
@@ -204,7 +229,7 @@ impl<T: Payload> RecoveryData<T> {
                 _ => None,
             },
             root,
-            root_executed_trees,
+            root_metadata,
             blocks,
             quorum_certs,
             blocks_to_prune,
@@ -227,10 +252,10 @@ impl<T: Payload> RecoveryData<T> {
         self.last_vote.clone()
     }
 
-    pub fn take(self) -> (RootInfo<T>, ExecutedTrees, Vec<Block<T>>, Vec<QuorumCert>) {
+    pub fn take(self) -> (RootInfo<T>, RootMetadata, Vec<Block<T>>, Vec<QuorumCert>) {
         (
             self.root,
-            self.root_executed_trees,
+            self.root_metadata,
             self.blocks,
             self.quorum_certs,
         )
@@ -364,13 +389,21 @@ impl<T: Payload> PersistentLivenessStorage<T> for StorageWriteProxy {
             startup_info.latest_ledger_info.ledger_info().clone(),
             validator_set,
         );
+        let frozen_root_hashes = startup_info
+            .committed_tree_state
+            .ledger_frozen_subtree_hashes
+            .clone();
         let root_executed_trees = ExecutedTrees::from(startup_info.committed_tree_state);
         match RecoveryData::new(
             last_vote,
             ledger_recovery_data.clone(),
             blocks,
+            RootMetadata::new(
+                root_executed_trees.txn_accumulator().num_leaves(),
+                root_executed_trees.state_id(),
+                frozen_root_hashes,
+            ),
             quorum_certs,
-            root_executed_trees,
             highest_timeout_certificate,
         ) {
             Ok(mut initial_data) => {

--- a/consensus/src/chained_bft/test_utils/mock_storage.rs
+++ b/consensus/src/chained_bft/test_utils/mock_storage.rs
@@ -1,17 +1,17 @@
 // Copyright (c) The Libra Core Contributors
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::chained_bft::persistent_liveness_storage::{
-    LedgerRecoveryData, PersistentLivenessStorage, RecoveryData,
+use crate::chained_bft::{
+    epoch_manager::LivenessStorageData,
+    persistent_liveness_storage::{
+        LedgerRecoveryData, PersistentLivenessStorage, RecoveryData, RootMetadata,
+    },
 };
-
-use crate::chained_bft::epoch_manager::LivenessStorageData;
 use anyhow::Result;
 use consensus_types::{
     block::Block, common::Payload, quorum_cert::QuorumCert,
     timeout_certificate::TimeoutCertificate, vote::Vote,
 };
-use executor_types::ExecutedTrees;
 use libra_crypto::HashValue;
 use libra_types::{ledger_info::LedgerInfo, validator_set::ValidatorSet};
 use std::{
@@ -112,8 +112,8 @@ impl<T: Payload> MockStorage<T> {
             self.shared_storage.last_vote.lock().unwrap().clone(),
             ledger_recovery_data,
             blocks,
+            RootMetadata::new_empty(),
             quorum_certs,
-            ExecutedTrees::new_empty(),
             self.shared_storage
                 .highest_timeout_certificate
                 .lock()
@@ -262,8 +262,8 @@ impl<T: Payload> PersistentLivenessStorage<T> for EmptyStorage<T> {
             None,
             self.recover_from_ledger(),
             vec![],
+            RootMetadata::new_empty(),
             vec![],
-            ExecutedTrees::new_empty(),
             None,
         ) {
             Ok(recovery_data) => LivenessStorageData::RecoveryData(recovery_data),

--- a/consensus/src/chained_bft/test_utils/mock_txn_manager.rs
+++ b/consensus/src/chained_bft/test_utils/mock_txn_manager.rs
@@ -76,11 +76,12 @@ impl TxnManager for MockTransactionManager {
     ) -> Result<()> {
         if self.mempool_proxy.is_some() {
             let mock_compute_result = StateComputeResult::new(
-                compute_results.state_id(),
+                compute_results.root_hash(),
                 compute_results.frozen_subtree_roots().clone(),
                 compute_results.num_leaves(),
                 compute_results.validators().clone(),
                 mock_transaction_status(txns.len()),
+                compute_results.transaction_info_hashes().clone(),
             );
             assert!(self
                 .mempool_proxy

--- a/consensus/src/consensus_provider.rs
+++ b/consensus/src/consensus_provider.rs
@@ -19,7 +19,7 @@ use libra_types::transaction::SignedTransaction;
 use libra_vm::LibraVM;
 use libradb::LibraDBTrait;
 use state_synchronizer::StateSyncClient;
-use std::sync::Arc;
+use std::sync::{Arc, Mutex};
 
 /// Public interface to a consensus protocol.
 pub trait ConsensusProvider {
@@ -39,7 +39,7 @@ pub fn make_consensus_provider(
     node_config: &mut NodeConfig,
     network_sender: ConsensusNetworkSender<Vec<SignedTransaction>>,
     network_receiver: ConsensusNetworkEvents<Vec<SignedTransaction>>,
-    executor: Arc<Executor<LibraVM>>,
+    executor: Arc<Mutex<Executor<LibraVM>>>,
     state_sync_client: Arc<StateSyncClient>,
     consensus_to_mempool_sender: mpsc::Sender<ConsensusRequest>,
     libra_db: Arc<dyn LibraDBTrait>,

--- a/consensus/src/state_replication.rs
+++ b/consensus/src/state_replication.rs
@@ -2,8 +2,8 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use anyhow::Result;
-use consensus_types::{block::Block, executed_block::ExecutedBlock};
-use executor_types::{ExecutedTrees, ProcessedVMOutput, StateComputeResult};
+use consensus_types::block::Block;
+use executor_types::StateComputeResult;
 use libra_crypto::HashValue;
 use libra_types::{ledger_info::LedgerInfoWithSignatures, validator_change::ValidatorChangeProof};
 
@@ -56,18 +56,15 @@ pub trait StateComputer: Send + Sync {
         &self,
         // The block that will be computed.
         block: &Block<Self::Payload>,
-        // The executed trees of parent block.
-        parent_executed_trees: &ExecutedTrees,
-        // The last committed trees.
-        committed_trees: &ExecutedTrees,
-    ) -> Result<ProcessedVMOutput>;
+        // The parent block root hash.
+        parent_block_id: HashValue,
+    ) -> Result<StateComputeResult>;
 
     /// Send a successful commit. A future is fulfilled when the state is finalized.
     async fn commit(
         &self,
-        blocks: Vec<&ExecutedBlock<Self::Payload>>,
+        block_ids: Vec<HashValue>,
         finality_proof: LedgerInfoWithSignatures,
-        synced_trees: &ExecutedTrees,
     ) -> Result<()>;
 
     /// Best effort state synchronization to the given target LedgerInfo.

--- a/execution/executor-utils/Cargo.toml
+++ b/execution/executor-utils/Cargo.toml
@@ -13,7 +13,6 @@ edition = "2018"
 tokio = { version = "0.2.12", features = ["full"] }
 
 executor = { path = "../executor", version = "0.1.0" }
-executor-types = { path = "../executor-types", version = "0.1.0" }
 libra-config = { path = "../../config", version = "0.1.0" }
 storage-client = { path = "../../storage/storage-client", version = "0.1.0" }
 storage-service = { path = "../../storage/storage-service", version = "0.1.0" }

--- a/execution/executor-utils/src/lib.rs
+++ b/execution/executor-utils/src/lib.rs
@@ -2,30 +2,20 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use executor::Executor;
-use executor_types::ExecutedTrees;
 use libra_config::config::NodeConfig;
 use libra_vm::LibraVM;
 use std::sync::Arc;
-use storage_client::{StorageRead, StorageReadServiceClient, StorageWriteServiceClient};
+use storage_client::{StorageReadServiceClient, StorageWriteServiceClient};
 use storage_service::start_storage_service;
 use tokio::runtime::Runtime;
 
-pub fn create_storage_service_and_executor(
-    config: &NodeConfig,
-) -> (Runtime, Executor<LibraVM>, ExecutedTrees) {
-    let mut rt = start_storage_service(config);
+pub fn create_storage_service_and_executor(config: &NodeConfig) -> (Runtime, Executor<LibraVM>) {
+    let rt = start_storage_service(config);
 
     let storage_read_client = Arc::new(StorageReadServiceClient::new(&config.storage.address));
     let storage_write_client = Arc::new(StorageWriteServiceClient::new(&config.storage.address));
 
     let executor = Executor::new(storage_read_client, storage_write_client, config);
 
-    let storage_read_client = Arc::new(StorageReadServiceClient::new(&config.storage.address));
-
-    let startup_info = rt
-        .block_on(storage_read_client.get_startup_info())
-        .expect("unable to read ledger info from storage")
-        .expect("startup info is None");
-    let committed_trees = ExecutedTrees::from(startup_info.committed_tree_state);
-    (rt, executor, committed_trees)
+    (rt, executor)
 }

--- a/execution/executor/Cargo.toml
+++ b/execution/executor/Cargo.toml
@@ -19,6 +19,7 @@ serde = { version = "1.0.105", default-features = false }
 tokio = { version = "0.2.12", features = ["full"] }
 
 config-builder = { path = "../../config/config-builder", version = "0.1.0" }
+consensus-types = { path = "../../consensus/consensus-types", version = "0.1.0"}
 debug-interface = { path = "../../common/debug-interface", version = "0.1.0" }
 executor-types = { path = "../executor-types", version = "0.1.0" }
 lcs = { path = "../../common/lcs", version = "0.1.0", package = "libra-canonical-serialization" }
@@ -47,4 +48,4 @@ vm-genesis = { path = "../../language/tools/vm-genesis", version = "0.1.0" }
 
 [features]
 default = []
-fuzzing = ["libra-config/fuzzing", "libra-crypto/fuzzing", "libra-types/fuzzing"]
+fuzzing = ["consensus-types/fuzzing", "libra-config/fuzzing", "libra-crypto/fuzzing", "libra-types/fuzzing"]

--- a/execution/executor/src/executor_test.rs
+++ b/execution/executor/src/executor_test.rs
@@ -10,7 +10,7 @@ use crate::{
     Executor, OP_COUNTERS,
 };
 use libra_config::config::NodeConfig;
-use libra_crypto::{hash::PRE_GENESIS_BLOCK_ID, HashValue};
+use libra_crypto::HashValue;
 use libra_types::{
     account_address::AccountAddress,
     block_info::BlockInfo,
@@ -24,48 +24,28 @@ use storage_client::{StorageRead, StorageReadServiceClient, StorageWriteServiceC
 use storage_service::start_storage_service;
 use tokio::runtime::Runtime;
 
-fn create_executor(config: &NodeConfig) -> (Executor<MockVM>, ExecutedTrees) {
-    let mut rt = Runtime::new().unwrap();
+fn create_executor(config: &NodeConfig) -> Executor<MockVM> {
     let read_client = Arc::new(StorageReadServiceClient::new(&config.storage.address));
     let write_client = Arc::new(StorageWriteServiceClient::new(&config.storage.address));
-    let executor = Executor::new(read_client, write_client, config);
-    let read_client = Arc::new(StorageReadServiceClient::new(&config.storage.address));
-    let startup_info = rt
-        .block_on(read_client.get_startup_info())
-        .expect("unable to read ledger info from storage")
-        .expect("startup info is None");
-    let root_executed_trees = ExecutedTrees::from(startup_info.committed_tree_state);
-    (executor, root_executed_trees)
+    Executor::new(read_client, write_client, config)
 }
 
 fn execute_and_commit_block(
-    executor: &TestExecutor,
-    committed_trees: &mut ExecutedTrees,
+    executor: &mut TestExecutor,
+    parent_block_id: HashValue,
     txn_index: u64,
-) {
+) -> HashValue {
     let txn = encode_mint_transaction(gen_address(txn_index), 100);
     let id = gen_block_id(txn_index + 1);
 
     let output = executor
-        .execute_block(
-            HashValue::zero(),
-            vec![txn.clone()],
-            &committed_trees,
-            &committed_trees,
-        )
+        .execute_block((id, vec![txn]), parent_block_id)
         .unwrap();
-    assert_eq!(output.version().unwrap(), txn_index + 1);
+    assert_eq!(output.version(), txn_index + 1);
 
-    let ledger_info = gen_ledger_info(txn_index + 1, output.accu_root(), id, txn_index + 1);
-    let new_trees = output.executed_trees().clone();
-    executor
-        .commit_blocks(
-            vec![(vec![txn], Arc::new(output))],
-            ledger_info,
-            &committed_trees,
-        )
-        .unwrap();
-    *committed_trees = new_trees;
+    let ledger_info = gen_ledger_info(txn_index + 1, output.root_hash(), id, txn_index + 1);
+    executor.commit_blocks(vec![id], ledger_info).unwrap();
+    id
 }
 
 struct TestExecutor {
@@ -76,19 +56,16 @@ struct TestExecutor {
 }
 
 impl TestExecutor {
-    fn new() -> (TestExecutor, ExecutedTrees) {
+    fn new() -> TestExecutor {
         let (config, _) = config_builder::test_config();
         let storage_server = start_storage_service(&config);
-        let (executor, committed_trees) = create_executor(&config);
+        let executor = create_executor(&config);
 
-        (
-            TestExecutor {
-                _config: config,
-                storage_server: Some(storage_server),
-                executor,
-            },
-            committed_trees,
-        )
+        TestExecutor {
+            _config: config,
+            storage_server: Some(storage_server),
+            executor,
+        }
     }
 }
 
@@ -97,6 +74,12 @@ impl std::ops::Deref for TestExecutor {
 
     fn deref(&self) -> &Self::Target {
         &self.executor
+    }
+}
+
+impl std::ops::DerefMut for TestExecutor {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.executor
     }
 }
 
@@ -145,75 +128,68 @@ fn gen_ledger_info(
 
 #[test]
 fn test_executor_status() {
-    let (executor, committed_trees) = TestExecutor::new();
+    let mut executor = TestExecutor::new();
+    let parent_block_id = executor.committed_block_id();
+    let block_id = gen_block_id(1);
 
     let txn0 = encode_mint_transaction(gen_address(0), 100);
     let txn1 = encode_mint_transaction(gen_address(1), 100);
     let txn2 = encode_transfer_transaction(gen_address(0), gen_address(1), 500);
 
     let output = executor
-        .execute_block(
-            HashValue::zero(),
-            vec![txn0, txn1, txn2],
-            &committed_trees,
-            &committed_trees,
-        )
+        .execute_block((block_id, vec![txn0, txn1, txn2]), parent_block_id)
         .unwrap();
 
     assert_eq!(
-        vec![
+        &vec![
             KEEP_STATUS.clone(),
             KEEP_STATUS.clone(),
             DISCARD_STATUS.clone()
         ],
-        *output.state_compute_result().compute_status()
+        output.compute_status()
     );
 }
 
 #[test]
 fn test_executor_one_block() {
-    let (executor, committed_trees) = TestExecutor::new();
-
+    let mut executor = TestExecutor::new();
+    let parent_block_id = executor.committed_block_id();
+    println!("{:?}", parent_block_id);
     let block_id = gen_block_id(1);
+
     let version = 100;
 
     let txns = (0..version)
         .map(|i| encode_mint_transaction(gen_address(i), 100))
         .collect::<Vec<_>>();
     let output = executor
-        .execute_block(
-            HashValue::zero(),
-            txns.clone(),
-            &committed_trees,
-            &committed_trees,
-        )
+        .execute_block((block_id, txns), parent_block_id)
         .unwrap();
-    assert_eq!(output.version().unwrap(), 100);
+    assert_eq!(output.version(), 100);
+    let block_root_hash = output.root_hash();
 
-    let ledger_info = gen_ledger_info(version, output.accu_root(), block_id, 1);
-    executor
-        .commit_blocks(
-            vec![(txns, Arc::new(output))],
-            ledger_info,
-            &committed_trees,
-        )
-        .unwrap();
+    let ledger_info = gen_ledger_info(version, block_root_hash, block_id, 1);
+    executor.commit_blocks(vec![block_id], ledger_info).unwrap();
 }
 
 #[test]
 fn test_executor_multiple_blocks() {
-    let (executor, mut committed_trees) = TestExecutor::new();
+    let mut executor = TestExecutor::new();
+    let mut parent_block_id = executor.committed_block_id();
 
     for i in 0..100 {
-        execute_and_commit_block(&executor, &mut committed_trees, i)
+        parent_block_id = execute_and_commit_block(&mut executor, parent_block_id, i);
     }
 }
 
 #[test]
 fn test_executor_two_blocks_with_failed_txns() {
-    let (executor, committed_trees) = TestExecutor::new();
+    let mut executor = TestExecutor::new();
+    let parent_block_id = executor.committed_block_id();
 
+    let block1_id = gen_block_id(1);
     let block2_id = gen_block_id(2);
+
     let block1_txns = (0..50)
         .map(|i| encode_mint_transaction(gen_address(i), 100))
         .collect::<Vec<_>>();
@@ -226,55 +202,35 @@ fn test_executor_two_blocks_with_failed_txns() {
             }
         })
         .collect::<Vec<_>>();
-    let output1 = executor
-        .execute_block(
-            HashValue::zero(),
-            block1_txns.clone(),
-            &committed_trees,
-            &committed_trees,
-        )
+    let _output1 = executor
+        .execute_block((block1_id, block1_txns), parent_block_id)
         .unwrap();
     let output2 = executor
-        .execute_block(
-            HashValue::zero(),
-            block2_txns.clone(),
-            output1.executed_trees(),
-            &committed_trees,
-        )
+        .execute_block((block2_id, block2_txns), block1_id)
         .unwrap();
-    let ledger_info = gen_ledger_info(75, output2.accu_root(), block2_id, 1);
+    let ledger_info = gen_ledger_info(75, output2.root_hash(), block2_id, 1);
     executor
-        .commit_blocks(
-            vec![
-                (block1_txns, Arc::new(output1)),
-                (block2_txns, Arc::new(output2)),
-            ],
-            ledger_info,
-            &committed_trees,
-        )
+        .commit_blocks(vec![block1_id, block2_id], ledger_info)
         .unwrap();
 }
 
 #[test]
 fn test_executor_execute_same_block_multiple_times() {
+    let mut executor = TestExecutor::new();
+    let parent_block_id = executor.committed_block_id();
+    let block_id = gen_block_id(1);
     let version = 100;
 
     let txns: Vec<_> = (0..version)
         .map(|i| encode_mint_transaction(gen_address(i), 100))
         .collect();
 
-    let (executor, committed_trees) = TestExecutor::new();
     let mut responses = vec![];
     for _i in 0..100 {
         let output = executor
-            .execute_block(
-                HashValue::zero(),
-                txns.clone(),
-                &committed_trees,
-                &committed_trees,
-            )
+            .execute_block((block_id, txns.clone()), parent_block_id)
             .unwrap();
-        responses.push(output.state_compute_result());
+        responses.push(output);
     }
     responses.dedup();
     assert_eq!(responses.len(), 1);
@@ -283,9 +239,10 @@ fn test_executor_execute_same_block_multiple_times() {
 rusty_fork_test! {
     #[test]
     fn test_num_accounts_created_counter() {
-        let (executor, mut committed_trees) = TestExecutor::new();
+        let mut executor = TestExecutor::new();
+        let mut parent_block_id = executor.committed_block_id();
         for i in 0..20 {
-            execute_and_commit_block(&executor, &mut committed_trees, i);
+            parent_block_id = execute_and_commit_block(&mut executor, parent_block_id, i);
             assert_eq!(OP_COUNTERS.counter("num_accounts").get() as u64, i + 1);
         }
     }
@@ -310,7 +267,7 @@ fn create_transaction_chunks(
     // separate DB. Then we call get_transactions to retrieve them.
     let (config, _) = config_builder::test_config();
     let storage_server = start_storage_service(&config);
-    let (executor, root_trees) = create_executor(&config);
+    let mut executor = create_executor(&config);
 
     let mut txns = vec![];
     for i in 1..chunk_ranges.last().unwrap().end {
@@ -320,16 +277,12 @@ fn create_transaction_chunks(
     let id = gen_block_id(1);
 
     let output = executor
-        .execute_block(HashValue::zero(), txns.clone(), &root_trees, &root_trees)
+        .execute_block((id, txns.clone()), executor.committed_block_id())
         .unwrap();
     let ledger_version = txns.len() as u64;
-    let ledger_info = gen_ledger_info(ledger_version, output.accu_root(), id, 1);
+    let ledger_info = gen_ledger_info(ledger_version, output.root_hash(), id, 1);
     executor
-        .commit_blocks(
-            vec![(txns, Arc::new(output))],
-            ledger_info.clone(),
-            &root_trees,
-        )
+        .commit_blocks(vec![id], ledger_info.clone())
         .unwrap();
 
     let storage_client = StorageReadServiceClient::new(&config.storage.address);
@@ -374,38 +327,28 @@ fn test_executor_execute_and_commit_chunk() {
     // Now we execute these two chunks of transactions.
     let (config, _) = config_builder::test_config();
     let storage_server = start_storage_service(&config);
-    let (executor, mut committed_trees) = create_executor(&config);
+    let mut executor = create_executor(&config);
     let storage_client = StorageReadServiceClient::new(&config.storage.address);
 
     // Execute the first chunk. After that we should still get the genesis ledger info from DB.
     executor
-        .execute_and_commit_chunk(
-            chunks[0].clone(),
-            ledger_info.clone(),
-            None,
-            &mut committed_trees,
-        )
+        .execute_and_commit_chunk(chunks[0].clone(), ledger_info.clone(), None)
         .unwrap();
     let (_, li, _, _) = rt
         .block_on(storage_client.update_to_latest_ledger(0, vec![]))
         .unwrap();
     assert_eq!(li.ledger_info().version(), 0);
-    assert_eq!(li.ledger_info().consensus_block_id(), *PRE_GENESIS_BLOCK_ID);
+    assert_eq!(li.ledger_info().consensus_block_id(), HashValue::zero());
 
     // Execute the second chunk. After that we should still get the genesis ledger info from DB.
     executor
-        .execute_and_commit_chunk(
-            chunks[1].clone(),
-            ledger_info.clone(),
-            None,
-            &mut committed_trees,
-        )
+        .execute_and_commit_chunk(chunks[1].clone(), ledger_info.clone(), None)
         .unwrap();
     let (_, li, _, _) = rt
         .block_on(storage_client.update_to_latest_ledger(0, vec![]))
         .unwrap();
     assert_eq!(li.ledger_info().version(), 0);
-    assert_eq!(li.ledger_info().consensus_block_id(), *PRE_GENESIS_BLOCK_ID);
+    assert_eq!(li.ledger_info().consensus_block_id(), HashValue::zero());
 
     // Execute an empty chunk. After that we should still get the genesis ledger info from DB.
     executor
@@ -413,38 +356,27 @@ fn test_executor_execute_and_commit_chunk() {
             TransactionListWithProof::new_empty(),
             ledger_info.clone(),
             None,
-            &mut committed_trees,
         )
         .unwrap();
     let (_, li, _, _) = rt
         .block_on(storage_client.update_to_latest_ledger(0, vec![]))
         .unwrap();
     assert_eq!(li.ledger_info().version(), 0);
-    assert_eq!(li.ledger_info().consensus_block_id(), *PRE_GENESIS_BLOCK_ID);
+    assert_eq!(li.ledger_info().consensus_block_id(), HashValue::zero());
 
     // Execute the second chunk again. After that we should still get the same thing.
     executor
-        .execute_and_commit_chunk(
-            chunks[1].clone(),
-            ledger_info.clone(),
-            None,
-            &mut committed_trees,
-        )
+        .execute_and_commit_chunk(chunks[1].clone(), ledger_info.clone(), None)
         .unwrap();
     let (_, li, _, _) = rt
         .block_on(storage_client.update_to_latest_ledger(0, vec![]))
         .unwrap();
     assert_eq!(li.ledger_info().version(), 0);
-    assert_eq!(li.ledger_info().consensus_block_id(), *PRE_GENESIS_BLOCK_ID);
+    assert_eq!(li.ledger_info().consensus_block_id(), HashValue::zero());
 
     // Execute the third chunk. After that we should get the new ledger info.
     executor
-        .execute_and_commit_chunk(
-            chunks[2].clone(),
-            ledger_info.clone(),
-            None,
-            &mut committed_trees,
-        )
+        .execute_and_commit_chunk(chunks[2].clone(), ledger_info.clone(), None)
         .unwrap();
     let (_, li, _, _) = rt
         .block_on(storage_client.update_to_latest_ledger(0, vec![]))
@@ -471,41 +403,29 @@ fn test_executor_execute_and_commit_chunk_restart() {
 
     let (config, _) = config_builder::test_config();
     let storage_server = start_storage_service(&config);
-    let mut synced_trees;
 
     // First we simulate syncing the first chunk of transactions.
     {
-        let (executor, mut committed_trees) = create_executor(&config);
+        let mut executor = create_executor(&config);
         let storage_client = StorageReadServiceClient::new(&config.storage.address);
 
         executor
-            .execute_and_commit_chunk(
-                chunks[0].clone(),
-                ledger_info.clone(),
-                None,
-                &mut committed_trees,
-            )
+            .execute_and_commit_chunk(chunks[0].clone(), ledger_info.clone(), None)
             .unwrap();
-        synced_trees = committed_trees;
         let (_, li, _, _) = rt
             .block_on(storage_client.update_to_latest_ledger(0, vec![]))
             .unwrap();
         assert_eq!(li.ledger_info().version(), 0);
-        assert_eq!(li.ledger_info().consensus_block_id(), *PRE_GENESIS_BLOCK_ID);
+        assert_eq!(li.ledger_info().consensus_block_id(), HashValue::zero());
     }
 
     // Then we restart executor and resume to the next chunk.
     {
-        let (executor, _) = create_executor(&config);
+        let mut executor = create_executor(&config);
         let storage_client = StorageReadServiceClient::new(&config.storage.address);
 
         executor
-            .execute_and_commit_chunk(
-                chunks[1].clone(),
-                ledger_info.clone(),
-                None,
-                &mut synced_trees,
-            )
+            .execute_and_commit_chunk(chunks[1].clone(), ledger_info.clone(), None)
             .unwrap();
         let (_, li, _, _) = rt
             .block_on(storage_client.update_to_latest_ledger(0, vec![]))
@@ -535,53 +455,33 @@ impl TestBlock {
 // Executes a list of transactions by executing and immediately commtting one at a time. Returns
 // the root hash after all transactions are committed.
 fn run_transactions_naive(transactions: Vec<Transaction>) -> HashValue {
-    let (executor, mut committed_trees) = TestExecutor::new();
+    let mut executor = TestExecutor::new();
+    let mut parent_block_id = executor.committed_block_id();
+
     let mut iter = transactions.into_iter();
     let first_txn = iter.next().map_or(vec![], |txn| vec![txn]);
-    let first_id = gen_block_id(1);
-    let mut output = executor
-        .execute_block(
-            HashValue::zero(),
-            first_txn.clone(),
-            &committed_trees,
-            &committed_trees,
-        )
-        .unwrap();
-    let mut root_hash = output.accu_root();
-    let ledger_info = gen_ledger_info(first_txn.len() as u64, root_hash, first_id, 0);
-    let new_trees = output.executed_trees().clone();
+    let first_block_id = gen_block_id(1);
+    let mut root_hash = executor
+        .execute_block((first_block_id, first_txn.clone()), parent_block_id)
+        .unwrap()
+        .root_hash();
+    let ledger_info = gen_ledger_info(first_txn.len() as u64, root_hash, first_block_id, 0);
     executor
-        .commit_blocks(
-            vec![(first_txn, Arc::new(output))],
-            ledger_info,
-            &committed_trees,
-        )
+        .commit_blocks(vec![first_block_id], ledger_info)
         .unwrap();
-    committed_trees = new_trees;
+    parent_block_id = first_block_id;
 
     for (i, txn) in iter.enumerate() {
         // when i = 0, id should be 2.
         let id = gen_block_id(i as u64 + 2);
-        output = executor
-            .execute_block(
-                HashValue::zero(),
-                vec![txn.clone()],
-                &committed_trees,
-                &committed_trees,
-            )
-            .unwrap();
+        root_hash = executor
+            .execute_block((id, vec![txn.clone()]), parent_block_id)
+            .unwrap()
+            .root_hash();
 
-        root_hash = output.accu_root();
         let ledger_info = gen_ledger_info(i as u64 + 2, root_hash, id, i as u64 + 1);
-        let new_trees = output.executed_trees().clone();
-        executor
-            .commit_blocks(
-                vec![(vec![txn], Arc::new(output))],
-                ledger_info,
-                &committed_trees,
-            )
-            .unwrap();
-        committed_trees = new_trees;
+        executor.commit_blocks(vec![id], ledger_info).unwrap();
+        parent_block_id = id;
     }
     root_hash
 }
@@ -603,24 +503,21 @@ proptest! {
         let block_b = TestBlock::new(0..b_size, amount, gen_block_id(2));
         let block_c = TestBlock::new(0..c_size, amount, gen_block_id(3));
         // Execute block A, B and C. Hold all results in memory.
-        let (executor, committed_trees) = TestExecutor::new();
+        let mut executor = TestExecutor::new();
+        let parent_block_id = executor.committed_block_id();
 
         let output_a = executor.execute_block(
-            HashValue::zero(), block_a.txns.clone(), &committed_trees, &committed_trees,
+            (block_a.id, block_a.txns.clone()), parent_block_id
         ).unwrap();
-        prop_assert_eq!(output_a.version().unwrap(), a_size);
-        let output_b = executor.execute_block(
-            HashValue::zero(), block_b.txns.clone(), output_a.executed_trees(), &committed_trees,
-        ).unwrap();
-        prop_assert_eq!(output_b.version().unwrap(), a_size + b_size);
-        let output_c = executor.execute_block(
-            HashValue::zero(), block_c.txns.clone(), output_a.executed_trees(), &committed_trees,
-        ).unwrap();
-        prop_assert_eq!(output_c.version().unwrap(), a_size + c_size);
+        let root_hash_a = output_a.root_hash();
+        prop_assert_eq!(output_a.version(), a_size);
+        let output_b = executor.execute_block((block_b.id, block_b.txns.clone()), block_a.id).unwrap();
+        prop_assert_eq!(output_b.version(), a_size + b_size);
+        let output_c = executor.execute_block((block_c.id, block_c.txns.clone()), block_a.id).unwrap();
+        prop_assert_eq!(output_c.version(), a_size + c_size);
 
-        let root_hash_a = output_a.accu_root();
-        let root_hash_b = output_b.accu_root();
-        let root_hash_c = output_c.accu_root();
+        let root_hash_b = output_b.root_hash();
+        let root_hash_c = output_c.root_hash();
 
         // Execute block A and B. Execute and commit one transaction at a time.
         let expected_root_hash_a = run_transactions_naive(block_a.txns.clone());
@@ -653,11 +550,13 @@ proptest! {
         })) {
             let mut block = TestBlock::new(0..num_txns, 10, gen_block_id(1));
             block.txns[reconfig_txn_index as usize] = encode_reconfiguration_transaction(gen_address(reconfig_txn_index));
-            let (executor, committed_trees) = TestExecutor::new();
+            let mut executor = TestExecutor::new();
+            let parent_block_id = executor.committed_block_id();
+
             let output = executor.execute_block(
-                HashValue::zero(), block.txns, &committed_trees, &committed_trees,
+                (block.id, block.txns), parent_block_id
             ).unwrap();
-        let retry_iter = output.transaction_data().iter().map(TransactionData::status)
+        let retry_iter = output.compute_status().iter()
             .skip_while(|status| matches!(*status, TransactionStatus::Keep(_)));
             prop_assert_eq!(retry_iter.take_while(|status| matches!(*status,TransactionStatus::Retry)).count() as u64, num_txns - reconfig_txn_index - 1);
         }
@@ -669,39 +568,34 @@ proptest! {
 
         let (config, _) = config_builder::test_config();
         let storage_server = start_storage_service(&config);
+        let mut parent_block_id;
+        let mut root_hash;
 
         // First execute and commit one block, then destroy executor.
         {
-            let (executor, committed_trees) = create_executor(&config);
+            let mut executor = create_executor(&config);
+            parent_block_id = executor.committed_block_id();
             let output_a = executor.execute_block(
-                HashValue::zero(), block_a.txns.clone(), &committed_trees, &committed_trees,
+                (block_a.id, block_a.txns.clone()), parent_block_id
             ).unwrap();
-            let root_hash = output_a.accu_root();
+            root_hash = output_a.root_hash();
             let ledger_info = gen_ledger_info(block_a.txns.len() as u64, root_hash, block_a.id, 1);
-            executor.commit_blocks(vec![(block_a.txns.clone(), Arc::new(output_a))],
-                                   ledger_info,
-                                   &committed_trees)
-                .unwrap();
+            executor.commit_blocks(vec![block_a.id], ledger_info).unwrap();
+            parent_block_id = block_a.id;
         }
 
         // Now we construct a new executor and run one more block.
-        let root_hash = {
-            let (executor, committed_trees) = create_executor(&config);
-            let output_b = executor.execute_block(
-                HashValue::zero(), block_b.txns.clone(), &committed_trees, &committed_trees,
-            ).unwrap();
-            let root_hash = output_b.accu_root();
+        {
+            let mut executor = create_executor(&config);
+            let output_b = executor.execute_block((block_b.id, block_b.txns.clone()), parent_block_id).unwrap();
+            root_hash = output_b.root_hash();
             let ledger_info = gen_ledger_info(
                 (block_a.txns.len() + block_b.txns.len()) as u64,
                 root_hash,
                 block_b.id,
                 2,
             );
-            executor.commit_blocks(vec![(block_b.txns.clone(), Arc::new(output_b))],
-                                   ledger_info,
-                                   &committed_trees)
-                .unwrap();
-            root_hash
+            executor.commit_blocks(vec![block_b.id], ledger_info).unwrap();
         };
 
         let expected_root_hash = run_transactions_naive({
@@ -727,43 +621,40 @@ proptest! {
 
         let (config, _) = config_builder::test_config();
         let storage_server = start_storage_service(&config);
-        let (executor, committed_trees) = create_executor(&config);
+        let mut executor = create_executor(&config);
+        let parent_block_id = executor.committed_block_id();
 
         let overlap_txn_list_with_proof = chunks.pop().unwrap();
         let txn_list_with_proof_to_commit = chunks.pop().unwrap();
         let mut first_block_txns = txn_list_with_proof_to_commit.transactions.clone();
 
-        let mut synced_trees = committed_trees.clone();
         // Commit the first chunk without committing the ledger info.
-        executor.execute_and_commit_chunk(txn_list_with_proof_to_commit, ledger_info, None, &mut synced_trees)
-            .unwrap();
+        executor.
+            execute_and_commit_chunk(txn_list_with_proof_to_commit, ledger_info, None).unwrap();
 
         first_block_txns.extend(overlap_txn_list_with_proof.transactions);
         let second_block_txns = ((chunk_size + overlap_size + 1..=chunk_size + overlap_size + num_new_txns)
                              .map(|i| encode_mint_transaction(gen_address(i), 100))).collect::<Vec<_>>();
 
-        let output1 = executor.execute_block(HashValue::zero(),
-            first_block_txns.clone(),
-            &committed_trees,
-            &committed_trees,
+        let first_block_id = gen_block_id(1);
+        let _output1 = executor.execute_block(
+            (first_block_id, first_block_txns),
+            parent_block_id
         ).unwrap();
 
         let second_block_id = gen_block_id(2);
-        let output2 = executor.execute_block(HashValue::zero(),
-            second_block_txns.clone(),
-            output1.executed_trees(),
-            &committed_trees,
+        let output2 = executor.execute_block(
+            (second_block_id, second_block_txns),
+            first_block_id,
         ).unwrap();
 
         let version = chunk_size + overlap_size + num_new_txns;
-        prop_assert_eq!(output2.version().unwrap(), version);
+        prop_assert_eq!(output2.version(), version);
 
-        let ledger_info = gen_ledger_info(version, output2.accu_root(), second_block_id, 1);
+        let ledger_info = gen_ledger_info(version, output2.root_hash(), second_block_id, 1);
         executor.commit_blocks(
-            vec![(first_block_txns, Arc::new(output1)),
-                 (second_block_txns, Arc::new(output2))],
+            vec![first_block_id, second_block_id],
             ledger_info,
-            &synced_trees,
         ).unwrap();
 
         drop(storage_server);

--- a/execution/executor/src/speculation_cache/mod.rs
+++ b/execution/executor/src/speculation_cache/mod.rs
@@ -1,0 +1,244 @@
+// Copyright (c) The Libra Core Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+//! In a leader based consensus algorithm, each participant maintains a block tree that looks like
+//! the following in the executor:
+//! ```text
+//!  Height      5      6      7      ...
+//!
+//! Committed -> B5  -> B6  -> B7
+//!         |
+//!         └--> B5' -> B6' -> B7'
+//!                     |
+//!                     └----> B7"
+//! ```
+//! This module implements `SpeculationCache` that is an in-memory representation of this tree.
+
+#[cfg(test)]
+mod test;
+
+use anyhow::{format_err, Result};
+use consensus_types::block::Block;
+use executor_types::{ExecutedTrees, ProcessedVMOutput};
+use libra_crypto::{hash::PRE_GENESIS_BLOCK_ID, HashValue};
+use libra_logger::prelude::*;
+use libra_types::{ledger_info::LedgerInfo, transaction::Transaction};
+use std::{
+    collections::HashMap,
+    sync::{Arc, Mutex, Weak},
+};
+use storage_proto::StartupInfo;
+
+/// The struct that stores all speculation result of its counterpart in consensus.
+pub(crate) struct SpeculationBlock {
+    // The block id of which the output is computed from.
+    id: HashValue,
+    // The transactions in the block.
+    transactions: Vec<Transaction>,
+    // The pointers to all the children blocks.
+    children: Vec<Arc<Mutex<SpeculationBlock>>>,
+    // The speculative execution result.
+    output: ProcessedVMOutput,
+    // A pointer to the global block map keyed by id to achieve O(1) lookup time complexity.
+    block_map: Arc<Mutex<HashMap<HashValue, Weak<Mutex<SpeculationBlock>>>>>,
+}
+
+impl SpeculationBlock {
+    pub fn new(
+        id: HashValue,
+        transactions: Vec<Transaction>,
+        output: ProcessedVMOutput,
+        block_map: Arc<Mutex<HashMap<HashValue, Weak<Mutex<SpeculationBlock>>>>>,
+    ) -> Self {
+        Self {
+            id,
+            transactions,
+            children: vec![],
+            output,
+            block_map,
+        }
+    }
+
+    pub fn id(&self) -> HashValue {
+        self.id
+    }
+
+    pub fn transactions(&self) -> &Vec<Transaction> {
+        &self.transactions
+    }
+
+    pub fn add_child(&mut self, child: Arc<Mutex<SpeculationBlock>>) {
+        self.children.push(child)
+    }
+
+    pub fn output(&self) -> &ProcessedVMOutput {
+        &self.output
+    }
+}
+
+/// drop() will clean the current block entry from the global map.
+impl Drop for SpeculationBlock {
+    fn drop(&mut self) {
+        self.block_map
+            .lock()
+            .unwrap()
+            .remove(&self.id())
+            .expect("Speculation block must exist in block_map before being dropped.");
+        debug!("Speculation block {} is dropped.", self.id())
+    }
+}
+
+/// SpeculationCache implements the block tree structrue. The tree is reprensented by a root block id,
+/// all the children of root and a global block map. Each block is an Arc<Mutx<SpeculationBlock>>
+/// with ref_count = 1. For the chidren of the root, the sole owner is `heads`. For the rest, the sole
+/// owner is their parent block. So when a block is dropped, all its descendants will be dropped
+/// recursively. In the meanwhile, wheir entries in the block map will be removed by each block's drop().
+pub(crate) struct SpeculationCache {
+    synced_trees: ExecutedTrees,
+    committed_trees: ExecutedTrees,
+    // The id of root block.
+    committed_block_id: HashValue,
+    // The chidren of root block.
+    heads: Vec<Arc<Mutex<SpeculationBlock>>>,
+    // A pointer to the global block map keyed by id to achieve O(1) lookup time complexity.
+    // It is optional but an optimization.
+    block_map: Arc<Mutex<HashMap<HashValue, Weak<Mutex<SpeculationBlock>>>>>,
+}
+
+impl SpeculationCache {
+    pub fn new() -> Self {
+        Self {
+            synced_trees: ExecutedTrees::new_empty(),
+            committed_trees: ExecutedTrees::new_empty(),
+            heads: vec![],
+            block_map: Arc::new(Mutex::new(HashMap::new())),
+            committed_block_id: *PRE_GENESIS_BLOCK_ID,
+        }
+    }
+
+    pub fn new_with_startup_info(startup_info: StartupInfo) -> Self {
+        let mut cache = Self::new();
+        let ledger_info = startup_info.latest_ledger_info.ledger_info();
+        let committed_trees = ExecutedTrees::from(startup_info.committed_tree_state);
+        cache.update_block_tree_root(committed_trees, ledger_info);
+        if let Some(synced_tree_state) = startup_info.synced_tree_state {
+            cache.update_synced_trees(ExecutedTrees::from(synced_tree_state));
+        }
+        cache
+    }
+
+    pub fn committed_block_id(&self) -> HashValue {
+        self.committed_block_id
+    }
+
+    pub fn committed_trees(&self) -> &ExecutedTrees {
+        &self.committed_trees
+    }
+
+    pub fn synced_trees(&self) -> &ExecutedTrees {
+        &self.synced_trees
+    }
+
+    pub fn update_block_tree_root(
+        &mut self,
+        committed_trees: ExecutedTrees,
+        committed_ledger_info: &LedgerInfo,
+    ) {
+        let new_root_block_id = if committed_ledger_info.next_validator_set().is_some() {
+            // Update the root block id with reconfig virtual block id, to be consistent
+            // with the logic of Consensus.
+            let id = Block::<()>::make_genesis_block_from_ledger_info(committed_ledger_info).id();
+            debug!(
+                "Updated with a new root block {} as a virtual block of reconfiguration block {}",
+                id,
+                committed_ledger_info.consensus_block_id()
+            );
+            id
+        } else {
+            let id = committed_ledger_info.consensus_block_id();
+            debug!("updated with a new root block {}", id);
+            id
+        };
+        self.committed_block_id = new_root_block_id;
+        self.committed_trees = committed_trees.clone();
+        self.synced_trees = committed_trees;
+    }
+
+    pub fn update_synced_trees(&mut self, new_trees: ExecutedTrees) {
+        self.synced_trees = new_trees;
+    }
+
+    pub fn reset(&mut self) {
+        self.heads = vec![];
+        *self.block_map.lock().unwrap() = HashMap::new();
+    }
+
+    pub fn add_block(
+        &mut self,
+        parent_block_id: HashValue,
+        block: (
+            HashValue,         /* block id */
+            Vec<Transaction>,  /* block transactions */
+            ProcessedVMOutput, /* block execution output */
+        ),
+    ) -> Result<()> {
+        // 0. Check existence first
+        let (block_id, txns, output) = block;
+        if self.block_map.lock().unwrap().contains_key(&block_id) {
+            return Ok(());
+        }
+
+        let block = Arc::new(Mutex::new(SpeculationBlock::new(
+            block_id,
+            txns,
+            output,
+            Arc::clone(&self.block_map),
+        )));
+        // 1. Add to the map
+        self.block_map
+            .lock()
+            .unwrap()
+            .insert(block_id, Arc::downgrade(&block));
+        // 2. Add to the tree
+        if parent_block_id == self.committed_block_id() {
+            self.heads.push(block);
+            return Ok(());
+        } else {
+            self.get_block(&parent_block_id)?
+                .lock()
+                .unwrap()
+                .add_child(block);
+        }
+        Ok(())
+    }
+
+    pub fn prune(&mut self, committed_ledger_info: &LedgerInfo) -> Result<()> {
+        let arc_latest_committed_block =
+            self.get_block(&committed_ledger_info.consensus_block_id())?;
+        let latest_committed_block = arc_latest_committed_block.lock().unwrap();
+        self.heads = latest_committed_block.children.clone();
+        self.update_block_tree_root(
+            latest_committed_block.output().executed_trees().clone(),
+            committed_ledger_info,
+        );
+        Ok(())
+    }
+
+    // This function is intended to be called internally.
+    pub fn get_block(&self, block_id: &HashValue) -> Result<Arc<Mutex<SpeculationBlock>>> {
+        self.block_map
+            .lock()
+            .unwrap()
+            .get(&block_id)
+            .ok_or_else(|| {
+                format_err!("Cannot find speculation result for block id {:x}", block_id)
+            })?
+            .upgrade()
+            .ok_or_else(|| {
+                format_err!(
+                    "block {:x} has been deallocated. Something went wrong.",
+                    block_id
+                )
+            })
+    }
+}

--- a/execution/executor/src/speculation_cache/test.rs
+++ b/execution/executor/src/speculation_cache/test.rs
@@ -1,0 +1,107 @@
+// Copyright (c) The Libra Core Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+use super::*;
+use libra_types::{block_info::BlockInfo, validator_set::ValidatorSet};
+
+fn id(index: u64) -> HashValue {
+    let bytes = index.to_be_bytes();
+    let mut buf = [0; HashValue::LENGTH];
+    buf[HashValue::LENGTH - 8..].copy_from_slice(&bytes);
+    HashValue::new(buf)
+}
+
+fn gen_block(id: HashValue) -> (HashValue, Vec<Transaction>, ProcessedVMOutput) {
+    (
+        id,
+        vec![],
+        ProcessedVMOutput::new(vec![], ExecutedTrees::new_empty(), None),
+    )
+}
+
+fn gen_ledger_info(block_id: HashValue, reconfig: bool) -> LedgerInfo {
+    LedgerInfo::new(
+        BlockInfo::new(
+            1,
+            0,
+            block_id,
+            HashValue::zero(),
+            0,
+            0,
+            if reconfig {
+                Some(ValidatorSet::empty())
+            } else {
+                None
+            },
+        ),
+        HashValue::zero(),
+    )
+}
+
+fn create_cache() -> SpeculationCache {
+    //    * ---> 1 ---> 2
+    //    |      |
+    //    |      └----> 3 ---> 4
+    //    |             |
+    //    |             └----> 5
+    //    |
+    //    └----> 6 ---> 7 ---> 8
+    //           |
+    //           └----> 9 ---> 10
+    //                  |
+    //                  └----> 11
+    // *: PRE_GENESIS_BLOCK_ID
+    let mut cache = SpeculationCache::new();
+
+    cache
+        .add_block(*PRE_GENESIS_BLOCK_ID, gen_block(id(1)))
+        .unwrap();
+    cache.add_block(id(1), gen_block(id(2))).unwrap();
+    cache.add_block(id(1), gen_block(id(3))).unwrap();
+    cache.add_block(id(3), gen_block(id(4))).unwrap();
+    cache.add_block(id(3), gen_block(id(5))).unwrap();
+    cache
+        .add_block(*PRE_GENESIS_BLOCK_ID, gen_block(id(6)))
+        .unwrap();
+    cache.add_block(id(6), gen_block(id(7))).unwrap();
+    cache.add_block(id(7), gen_block(id(8))).unwrap();
+    cache.add_block(id(6), gen_block(id(9))).unwrap();
+    cache.add_block(id(9), gen_block(id(10))).unwrap();
+    cache.add_block(id(9), gen_block(id(11))).unwrap();
+    cache
+}
+
+#[test]
+fn test_branch() {
+    let mut cache = create_cache();
+    // put counting blocks as a separate line to avoid core dump
+    // if assertion fails.
+    let mut num_blocks = cache.block_map.lock().unwrap().len();
+    assert_eq!(num_blocks, 11);
+    cache.prune(&gen_ledger_info(id(9), false)).unwrap();
+    num_blocks = cache.block_map.lock().unwrap().len();
+    assert_eq!(num_blocks, 2);
+    assert_eq!(cache.committed_block_id, id(9));
+}
+
+#[test]
+fn test_reconfig_id_update() {
+    let mut cache = create_cache();
+    cache.prune(&gen_ledger_info(id(1), true)).unwrap();
+    let num_blocks = cache.block_map.lock().unwrap().len();
+    assert_eq!(num_blocks, 4);
+    assert_ne!(cache.committed_block_id, id(1));
+}
+
+#[test]
+fn test_add_duplicate_block() {
+    let mut cache = create_cache();
+    cache.add_block(id(1), gen_block(id(7))).unwrap();
+    cache.add_block(id(1), gen_block(id(7))).unwrap();
+}
+
+#[test]
+fn test_add_block_missing_parent() {
+    let mut cache = create_cache();
+    assert!(cache.add_block(id(99), gen_block(id(100))).is_err());
+}

--- a/libra-node/src/main_node.rs
+++ b/libra-node/src/main_node.rs
@@ -16,7 +16,13 @@ use libra_metrics::metric_server;
 use libra_vm::LibraVM;
 use network::validator_network::network_builder::{NetworkBuilder, TransportType};
 use state_synchronizer::StateSynchronizer;
-use std::{collections::HashMap, net::ToSocketAddrs, sync::Arc, thread, time::Instant};
+use std::{
+    collections::HashMap,
+    net::ToSocketAddrs,
+    sync::{Arc, Mutex},
+    thread,
+    time::Instant,
+};
 use storage_client::{StorageReadServiceClient, StorageWriteServiceClient};
 use storage_service::{init_libra_db, start_storage_service_with_db};
 use tokio::runtime::{Builder, Runtime};
@@ -43,15 +49,15 @@ impl Drop for LibraHandle {
     }
 }
 
-fn setup_executor(config: &NodeConfig) -> Arc<Executor<LibraVM>> {
+fn setup_executor(config: &NodeConfig) -> Arc<Mutex<Executor<LibraVM>>> {
     let storage_read_client = Arc::new(StorageReadServiceClient::new(&config.storage.address));
     let storage_write_client = Arc::new(StorageWriteServiceClient::new(&config.storage.address));
 
-    Arc::new(Executor::new(
+    Arc::new(Mutex::new(Executor::new(
         storage_read_client,
         storage_write_client,
         config,
-    ))
+    )))
 }
 
 fn setup_debug_interface(config: &NodeConfig) -> Runtime {

--- a/state-synchronizer/src/synchronizer.rs
+++ b/state-synchronizer/src/synchronizer.rs
@@ -21,7 +21,10 @@ use libra_types::{
     validator_change::ValidatorChangeProof, waypoint::Waypoint,
 };
 use libra_vm::LibraVM;
-use std::{sync::Arc, time::Duration};
+use std::{
+    sync::{Arc, Mutex},
+    time::Duration,
+};
 use tokio::{
     runtime::{Builder, Runtime},
     time::timeout,
@@ -37,7 +40,7 @@ impl StateSynchronizer {
     pub fn bootstrap(
         network: Vec<(StateSynchronizerSender, StateSynchronizerEvents)>,
         state_sync_to_mempool_sender: mpsc::Sender<CommitNotification>,
-        executor: Arc<Executor<LibraVM>>,
+        executor: Arc<Mutex<Executor<LibraVM>>>,
         config: &NodeConfig,
         reconfig_event_subscriptions: Vec<Box<dyn EventSubscription>>,
     ) -> Self {

--- a/state-synchronizer/src/tests/integration_tests.rs
+++ b/state-synchronizer/src/tests/integration_tests.rs
@@ -61,7 +61,7 @@ impl ExecutorProxyTrait for MockExecutorProxy {
     }
 
     async fn execute_chunk(
-        &self,
+        &mut self,
         txn_list_with_proof: TransactionListWithProof,
         ledger_info_with_sigs: LedgerInfoWithSignatures,
         intermediate_end_of_epoch_li: Option<LedgerInfoWithSignatures>,

--- a/types/src/block_info.rs
+++ b/types/src/block_info.rs
@@ -2,9 +2,9 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::{transaction::Version, validator_set::ValidatorSet};
+use libra_crypto::hash::HashValue;
 #[cfg(any(test, feature = "fuzzing"))]
 use libra_crypto::hash::ACCUMULATOR_PLACEHOLDER_HASH;
-use libra_crypto::hash::{HashValue, PRE_GENESIS_BLOCK_ID};
 #[cfg(any(test, feature = "fuzzing"))]
 use proptest_derive::Arbitrary;
 use serde::{Deserialize, Serialize};
@@ -102,8 +102,7 @@ impl BlockInfo {
         Self {
             epoch: GENESIS_EPOCH,
             round: GENESIS_ROUND,
-            // We use `PRE_GENESIS_BLOCK_ID` as the parent of the genesis block.
-            id: *PRE_GENESIS_BLOCK_ID,
+            id: HashValue::zero(),
             executed_state_id: genesis_state_root_hash,
             version: GENESIS_VERSION,
             timestamp_usecs: GENESIS_TIMESTAMP_USECS,
@@ -155,10 +154,11 @@ impl Display for BlockInfo {
     fn fmt(&self, f: &mut Formatter) -> std::fmt::Result {
         write!(
             f,
-            "BlockInfo: [epoch: {}, round: {}, id: {}, version: {}, timestamp (us): {}, next_validator_set: {}]",
+            "BlockInfo: [epoch: {}, round: {}, id: {}, executed_state_id: {}, version: {}, timestamp (us): {}, next_validator_set: {}]",
             self.epoch(),
             self.round(),
             self.id(),
+            self.executed_state_id(),
             self.version(),
             self.timestamp_usecs(),
             self.next_validator_set.as_ref().map_or("None".to_string(), |validator_set| format!("{}", validator_set)),


### PR DESCRIPTION
## Motivation

This PR made a huge refactoring to `Executor` to cache speculation result inside executor instead of returning back to consensus cached inside the block_tree maintained by consensus, required by #2519 as the first milestone.

The reason for this refactoring was explained in #2519 . In short, some speculation result is unserializable so can not be sent over wire. Since `Executor` will be a standalone service in a container, all the current API will become RPC API called via messages over wire. The only option for us is to keep unserializable speculation results inside.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?

Y

## Test Plan

CI

