### PR TITLE
[Serde reflection] detect format changes + python codegen

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2596,6 +2596,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "libra-serde-codegen"
+version = "0.1.0"
+dependencies = [
+ "libra-serde-reflection 0.1.0",
+ "serde 1.0.105 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_yaml 0.8.11 (registry+https://github.com/rust-lang/crates.io-index)",
+ "structopt 0.3.12 (registry+https://github.com/rust-lang/crates.io-index)",
+ "thiserror 1.0.13 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "libra-serde-reflection"
 version = "0.1.0"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,6 +21,7 @@ members = [
     "common/proptest-helpers",
     "common/prost-ext",
     "common/security-logger",
+    "common/serde-codegen",
     "common/serde-reflection",
     "common/temppath",
     "common/util",

--- a/common/serde-codegen/Cargo.toml
+++ b/common/serde-codegen/Cargo.toml
@@ -1,0 +1,18 @@
+[package]
+name = "libra-serde-codegen"
+version = "0.1.0"
+authors = ["Libra Association <opensource@libra.org>"]
+description = "Libra Serde Codegen"
+repository = "https://github.com/libra/libra"
+homepage = "https://libra.org"
+license = "Apache-2.0"
+publish = false
+edition = "2018"
+
+[dependencies]
+thiserror = "1.0"
+serde = { version = "1.0", features = ["derive"] }
+serde_yaml = "0.8"
+structopt = "0.3.12"
+
+serde_reflection = { path = "../serde-reflection", version = "0.1.0", package = "libra-serde-reflection" }

--- a/common/serde-codegen/src/main.rs
+++ b/common/serde-codegen/src/main.rs
@@ -1,0 +1,174 @@
+// Copyright (c) The Libra Core Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+use serde_reflection::{ContainerFormat, Format, Named, RegistryOwned, VariantFormat};
+use serde_yaml;
+use std::{collections::BTreeMap, path::PathBuf};
+use structopt::StructOpt;
+
+#[derive(Debug, StructOpt)]
+#[structopt(
+    name = "Libra Serde code generator",
+    about = "Generate code for Serde containers"
+)]
+struct Options {
+    #[structopt(parse(from_os_str))]
+    input: PathBuf,
+}
+
+fn main() {
+    let options = Options::from_args();
+    let content =
+        std::fs::read_to_string(options.input.as_os_str()).expect("input file must be readable");
+    let registry = serde_yaml::from_str::<RegistryOwned>(content.as_str()).unwrap();
+
+    println!("{}", python3_preambule());
+    for (name, format) in &registry {
+        println!("{}", python3_container(name, format));
+    }
+}
+
+fn python3_preambule() -> String {
+    r#"
+from dataclasses import dataclass
+import numpy as np
+from typing import *
+"#
+    .into()
+}
+
+fn python3_type(format: &Format) -> String {
+    use Format::*;
+    match format {
+        TypeName(x) => format!("'{}'", x), // Need quotes because of circular dependencies.
+        Unit => "None".into(),
+        Bool => "np.bool".into(),
+        I8 => "np.int8".into(),
+        I16 => "np.int16".into(),
+        I32 => "np.int32".into(),
+        I64 => "np.int64".into(),
+        I128 => "Tuple(np.int64, np.int64)".into(),
+        U8 => "np.uint8".into(),
+        U16 => "np.uint16".into(),
+        U32 => "np.uint32".into(),
+        U64 => "np.uint64".into(),
+        U128 => "Tuple(np.uint64, np.uint64)".into(),
+        F32 => "np.float32".into(),
+        F64 => "np.float64".into(),
+        Char => "char".into(),
+        Str => "str".into(),
+        Bytes => "bytes".into(),
+
+        Option(format) => format!("Optional[{}]", python3_type(format)),
+        Seq(format) => format!("Sequence[{}]", python3_type(format)),
+        Map { key, value } => format!("Dict[{}, {}]", python3_type(key), python3_type(value)),
+        Tuple(formats) => format!("Tuple[{}]", python3_types(formats)),
+        TupleArray { content, size } => format!(
+            "Tuple[{}]",
+            python3_types(&vec![content.as_ref().clone(); *size])
+        ), // Sadly, there are no fixed-size arrays in python.
+
+        _ => panic!("unexpected value"),
+    }
+}
+
+fn python3_types(formats: &[Format]) -> String {
+    formats
+        .iter()
+        .map(python3_type)
+        .collect::<Vec<_>>()
+        .join(", ")
+}
+
+fn python3_fields(indentation: usize, fields: &[Named<Format>]) -> String {
+    let mut result = String::new();
+    let tab = " ".repeat(indentation);
+    for field in fields {
+        result += &format!("{}{}: {}\n", tab, field.name, python3_type(&field.value));
+    }
+    result
+}
+
+fn python3_variant(base: &str, name: &str, index: u32, variant: &VariantFormat) -> String {
+    use VariantFormat::*;
+    match variant {
+        Unit => format!(
+            "@dataclass\nclass _{}_{}({}):\n    INDEX={}\n",
+            base, name, base, index,
+        ),
+        NewType(format) => format!(
+            "@dataclass\nclass _{}_{}({}):\n    INDEX={}\n    value: {}\n",
+            base,
+            name,
+            base,
+            index,
+            python3_type(format)
+        ),
+        Tuple(formats) => format!(
+            "@dataclass\nclass _{}_{}({}):\n    INDEX={}\n    value: Tuple[{}]\n",
+            base,
+            name,
+            base,
+            index,
+            python3_types(formats)
+        ),
+        Struct(fields) => format!(
+            "@dataclass\nclass _{}_{}({}):\n    INDEX={}\n{}",
+            base,
+            name,
+            base,
+            index,
+            python3_fields(4, fields)
+        ),
+        _ => panic!("incorrect value"),
+    }
+}
+
+fn python3_variants(base: &str, variants: &BTreeMap<u32, Named<VariantFormat>>) -> String {
+    let mut result = String::new();
+    for (index, variant) in variants {
+        result += &format!(
+            "{}\n",
+            python3_variant(base, &variant.name, *index, &variant.value)
+        );
+    }
+    result
+}
+
+fn python3_variant_aliases(base: &str, variants: &BTreeMap<u32, Named<VariantFormat>>) -> String {
+    let mut result = String::new();
+    for variant in variants.values() {
+        result += &format!("{}.{} = _{}_{}\n", base, &variant.name, base, &variant.name);
+    }
+    result
+}
+
+fn python3_container(name: &str, format: &ContainerFormat) -> String {
+    use ContainerFormat::*;
+    match format {
+        UnitStruct => format!("@dataclass\nclass {}:\n    pass\n", name,),
+        NewTypeStruct(format) => format!(
+            "@dataclass\nclass {}:\n    value: {}\n",
+            name,
+            python3_type(format)
+        ),
+        TupleStruct(formats) => format!(
+            "@dataclass\nclass {}:\n    value: Tuple[{}]\n",
+            name,
+            python3_types(formats)
+        ),
+        Struct(fields) => format!("@dataclass\nclass {}:\n{}", name, python3_fields(4, fields)),
+        Enum(variants) => format!(
+            "class {}:\n    pass\n\n{}{}{}.VARIANTS = [{}]\n",
+            name,
+            python3_variants(name, variants),
+            python3_variant_aliases(name, variants),
+            name,
+            variants
+                .iter()
+                .map(|(_, v)| format!("{}.{}", name, v.name))
+                .collect::<Vec<_>>()
+                .join(", ")
+        ),
+    }
+}

--- a/testsuite/generate-format/Cargo.toml
+++ b/testsuite/generate-format/Cargo.toml
@@ -17,3 +17,8 @@ structopt = "0.3.12"
 libra_types = { path = "../../types", version = "0.1.0", package = "libra-types", features=["fuzzing"] }
 lcs = { path = "../../common/lcs", version = "0.1.0", package = "libra-canonical-serialization" }
 serde_reflection = { path = "../../common/serde-reflection", version = "0.1.0", package = "libra-serde-reflection" }
+
+[[bin]]
+name = "compute"
+path = "src/compute.rs"
+test = false

--- a/testsuite/generate-format/src/compute.rs
+++ b/testsuite/generate-format/src/compute.rs
@@ -1,0 +1,40 @@
+// Copyright (c) The Libra Core Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+use generate_format::{add_deserialization_tracing, add_proptest_serialization_tracing, FILE_PATH};
+use serde_reflection::Tracer;
+use serde_yaml;
+use std::{fs::File, io::Write};
+use structopt::StructOpt;
+
+#[derive(Debug, StructOpt)]
+#[structopt(
+    name = "Libra format generator",
+    about = "Trace serde (de)serialization to generate format descriptions for Libra types"
+)]
+struct Options {
+    #[structopt(short, long)]
+    with_deserialize: bool,
+
+    #[structopt(short, long)]
+    record: bool,
+}
+
+fn main() {
+    let options = Options::from_args();
+
+    let mut tracer = Tracer::new(lcs::is_human_readable());
+    tracer = add_proptest_serialization_tracing(tracer);
+    if options.with_deserialize {
+        tracer = add_deserialization_tracing(tracer);
+    }
+
+    let registry = tracer.registry().unwrap();
+    let content = serde_yaml::to_string(&registry).unwrap();
+    if options.record {
+        let mut f = File::create("testsuite/generate-format/".to_string() + FILE_PATH).unwrap();
+        writeln!(f, "{}", content).unwrap();
+    } else {
+        println!("{}", content);
+    }
+}

--- a/testsuite/generate-format/tests/detect_format_change.rs
+++ b/testsuite/generate-format/tests/detect_format_change.rs
@@ -1,0 +1,51 @@
+// Copyright (c) The Libra Core Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+use generate_format::{add_proptest_serialization_tracing, FILE_PATH};
+use serde_reflection::{RegistryOwned, Tracer};
+use serde_yaml;
+use std::collections::BTreeMap;
+
+static MESSAGE: &str = "Run `cargo run -p generate-format -- --record` to refresh the records and `git diff` to study the changes before amending your commit.";
+
+#[test]
+fn test_format_change() {
+    let mut tracer = Tracer::new(lcs::is_human_readable());
+    tracer = add_proptest_serialization_tracing(tracer);
+    let registry: BTreeMap<_, _> = tracer
+        .registry()
+        .unwrap()
+        .into_iter()
+        .map(|(k, v)| (k.to_string(), v))
+        .collect();
+
+    let content = std::fs::read_to_string(FILE_PATH).unwrap();
+    let expected = serde_yaml::from_str::<RegistryOwned>(content.as_str()).unwrap();
+
+    for (key, value) in expected.iter() {
+        assert_eq!(
+            Some(value),
+            registry.get(key),
+            r#"
+----
+The extracted Serde format for type {} is missing or does not match the recorded value on disk. {}
+----
+"#,
+            key,
+            MESSAGE
+        );
+    }
+
+    for key in registry.keys() {
+        assert!(
+            expected.contains_key(key),
+            r#"
+----
+Type {} was added and has no recorded Serde format on disk yet. {}
+----
+"#,
+            key,
+            MESSAGE
+        );
+    }
+}

--- a/testsuite/generate-format/tests/staged/libra.yaml
+++ b/testsuite/generate-format/tests/staged/libra.yaml
@@ -1,0 +1,186 @@
+---
+AccessPath:
+  STRUCT:
+    - address:
+        TYPENAME: AccountAddress
+    - path:
+        SEQ: U8
+AccountAddress:
+  NEWTYPESTRUCT:
+    TUPLEARRAY:
+      CONTENT: U8
+      SIZE: 16
+BlockMetadata:
+  STRUCT:
+    - id:
+        TYPENAME: HashValue
+    - round: U64
+    - timestamp_usecs: U64
+    - previous_block_votes:
+        SEQ:
+          TYPENAME: AccountAddress
+    - proposer:
+        TYPENAME: AccountAddress
+ChangeSet:
+  STRUCT:
+    - write_set:
+        TYPENAME: WriteSet
+    - events:
+        SEQ:
+          TYPENAME: ContractEvent
+ContractEvent:
+  STRUCT:
+    - key:
+        TYPENAME: EventKey
+    - sequence_number: U64
+    - type_tag:
+        TYPENAME: TypeTag
+    - event_data:
+        SEQ: U8
+Ed25519PublicKey:
+  NEWTYPESTRUCT:
+    SEQ: U8
+Ed25519Signature:
+  NEWTYPESTRUCT:
+    SEQ: U8
+EventKey:
+  NEWTYPESTRUCT:
+    SEQ: U8
+HashValue:
+  NEWTYPESTRUCT:
+    SEQ: U8
+Identifier:
+  NEWTYPESTRUCT: STR
+Module:
+  STRUCT:
+    - code:
+        SEQ: U8
+RawTransaction:
+  STRUCT:
+    - sender:
+        TYPENAME: AccountAddress
+    - sequence_number: U64
+    - payload:
+        TYPENAME: TransactionPayload
+    - max_gas_amount: U64
+    - gas_unit_price: U64
+    - gas_specifier:
+        TYPENAME: TypeTag
+    - expiration_time: U64
+Script:
+  STRUCT:
+    - code:
+        SEQ: U8
+    - args:
+        SEQ:
+          TYPENAME: TransactionArgument
+SignedTransaction:
+  STRUCT:
+    - raw_txn:
+        TYPENAME: RawTransaction
+    - authenticator:
+        TYPENAME: TransactionAuthenticator
+StructTag:
+  STRUCT:
+    - address:
+        TYPENAME: AccountAddress
+    - module:
+        TYPENAME: Identifier
+    - name:
+        TYPENAME: Identifier
+    - type_params:
+        SEQ:
+          TYPENAME: TypeTag
+Transaction:
+  ENUM:
+    0:
+      UserTransaction:
+        NEWTYPE:
+          TYPENAME: SignedTransaction
+    1:
+      WriteSet:
+        NEWTYPE:
+          TYPENAME: ChangeSet
+    2:
+      BlockMetadata:
+        NEWTYPE:
+          TYPENAME: BlockMetadata
+TransactionArgument:
+  ENUM:
+    0:
+      U64:
+        NEWTYPE: U64
+    1:
+      Address:
+        NEWTYPE:
+          TYPENAME: AccountAddress
+    2:
+      U8Vector:
+        NEWTYPE:
+          SEQ: U8
+    3:
+      Bool:
+        NEWTYPE: BOOL
+TransactionAuthenticator:
+  ENUM:
+    0:
+      Ed25519:
+        STRUCT:
+          - public_key:
+              TYPENAME: Ed25519PublicKey
+          - signature:
+              TYPENAME: Ed25519Signature
+TransactionPayload:
+  ENUM:
+    0:
+      Program: UNIT
+    1:
+      WriteSet:
+        NEWTYPE:
+          TYPENAME: ChangeSet
+    2:
+      Script:
+        NEWTYPE:
+          TYPENAME: Script
+    3:
+      Module:
+        NEWTYPE:
+          TYPENAME: Module
+TypeTag:
+  ENUM:
+    0:
+      Bool: UNIT
+    1:
+      U8: UNIT
+    2:
+      U64: UNIT
+    3:
+      U128: UNIT
+    4:
+      Address: UNIT
+    5:
+      Vector:
+        NEWTYPE:
+          TYPENAME: TypeTag
+    6:
+      Struct:
+        NEWTYPE:
+          TYPENAME: StructTag
+WriteOp:
+  ENUM:
+    0:
+      Deletion: UNIT
+    1:
+      Value:
+        NEWTYPE:
+          SEQ: U8
+WriteSet:
+  NEWTYPESTRUCT:
+    TYPENAME: WriteSetMut
+WriteSetMut:
+  STRUCT:
+    - write_set:
+        SEQ:
+          TUPLE:
+            - TYPENAME: AccessPath
+            - TYPENAME: WriteOp


### PR DESCRIPTION
## Motivation

Put all the previous Serde reflection PRs into use:
* Add a non-regression test to track (breaking) changes to the Libra formats
* Demo of python codegenerator

## Test Plan

```
cargo x test -p libra-serde-reflection

cargo x test -p generate-format
cargo run -p generate-format -- --record   # to modify recorded file on disk

cargo run -p libra-serde-codegen -- testsuite/generate-format/tests/staged/libra.yaml
```

## Related PRs

https://github.com/libra/libra/pull/3060