### PR TITLE
[on-chain config] on-chain config Rust interface + pub/sub e2e flow

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3159,6 +3159,7 @@ dependencies = [
 name = "move-vm-state"
 version = "0.1.0"
 dependencies = [
+ "libra-canonical-serialization 0.1.0",
  "libra-logger 0.1.0",
  "libra-state-view 0.1.0",
  "libra-types 0.1.0",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4930,6 +4930,7 @@ dependencies = [
  "executor 0.1.0",
  "executor-types 0.1.0",
  "futures 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "itertools 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "libra-canonical-serialization 0.1.0",
  "libra-config 0.1.0",
  "libra-crypto 0.1.0",

--- a/language/libra-vm/src/on_chain_configs.rs
+++ b/language/libra-vm/src/on_chain_configs.rs
@@ -1,10 +1,8 @@
 // Copyright (c) The Libra Core Contributors
 // SPDX-License-Identifier: Apache-2.0
 
-use libra_types::on_chain_config::{access_path_for_config, VMPublishingOption};
-use move_core_types::identifier::Identifier;
+use libra_types::on_chain_config::{OnChainConfig, VMPublishingOption};
 use move_vm_state::data_cache::RemoteCache;
-use once_cell::sync::Lazy;
 
 #[derive(Debug, Clone)]
 pub(crate) struct VMConfig {
@@ -13,20 +11,10 @@ pub(crate) struct VMConfig {
 
 impl VMConfig {
     pub fn load_on_chain_config(state_view: &dyn RemoteCache) -> Option<Self> {
-        Some(VMConfig {
-            publishing_options: load_script_whitelist(state_view)?,
-        })
+        if let Ok(publishing_options) = VMPublishingOption::fetch_config(&Box::new(state_view)) {
+            Some(VMConfig { publishing_options })
+        } else {
+            None
+        }
     }
-}
-
-static SCRIPT_WHITELIST: Lazy<Identifier> =
-    Lazy::new(|| Identifier::new("ScriptWhitelist").unwrap());
-
-fn load_script_whitelist(state_view: &dyn RemoteCache) -> Option<VMPublishingOption> {
-    let access_path = access_path_for_config(SCRIPT_WHITELIST.clone());
-    state_view
-        .get(&access_path)
-        .ok()?
-        .and_then(|bytes| lcs::from_bytes::<Vec<u8>>(&bytes).ok())
-        .and_then(|bytes| lcs::from_bytes::<VMPublishingOption>(&bytes).ok())
 }

--- a/language/move-vm/state/Cargo.toml
+++ b/language/move-vm/state/Cargo.toml
@@ -12,6 +12,7 @@ edition = "2018"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
+lcs = { path = "../../../common/lcs", version = "0.1.0", package = "libra-canonical-serialization" }
 # TODO: Move may want to have its own logger infra independent of libra_logger
 libra-logger = { path = "../../../common/logger", version = "0.1.0" }
 libra-state-view = { path = "../../../storage/state-view", version = "0.1.0" }

--- a/language/move-vm/state/src/data_cache.rs
+++ b/language/move-vm/state/src/data_cache.rs
@@ -75,11 +75,9 @@ pub trait RemoteCache {
     fn get(&self, access_path: &AccessPath) -> VMResult<Option<Vec<u8>>>;
 }
 
-impl ConfigStorage for Box<&dyn RemoteCache> {
+impl ConfigStorage for &dyn RemoteCache {
     fn fetch_config(&self, access_path: AccessPath) -> Option<Vec<u8>> {
-        self.get(&access_path)
-            .ok()?
-            .and_then(|bytes| lcs::from_bytes::<Vec<u8>>(&bytes).ok())
+        self.get(&access_path).ok()?
     }
 }
 

--- a/mempool/src/shared_mempool.rs
+++ b/mempool/src/shared_mempool.rs
@@ -24,9 +24,9 @@ use libra_logger::prelude::*;
 use libra_security_logger::{security_log, SecurityEvent};
 use libra_types::{
     account_address::AccountAddress,
-    contract_event::ContractEvent,
     event_subscription::EventSubscription,
     mempool_status::{MempoolStatus, MempoolStatusCode},
+    on_chain_config::{ConfigID, OnChainConfig, OnChainConfigPayload, VMPublishingOption},
     transaction::SignedTransaction,
     vm_error::{
         StatusCode::{RESOURCE_DOES_NOT_EXIST, SEQUENCE_NUMBER_TOO_OLD},
@@ -168,11 +168,17 @@ pub struct TransactionExclusion {
 
 /// Mempool's subscription to reconfiguration events
 pub struct MempoolReconfigSubscription {
-    sender: libra_channel::Sender<(), ContractEvent>,
+    sender: libra_channel::Sender<(), OnChainConfigPayload>,
 }
 
 impl EventSubscription for MempoolReconfigSubscription {
-    fn publish(&mut self, payload: ContractEvent) {
+    fn subscribed_configs(&self) -> HashSet<ConfigID> {
+        let mut subscribed_configs = HashSet::new();
+        subscribed_configs.insert(VMPublishingOption::CONFIG_ID);
+        subscribed_configs
+    }
+
+    fn publish(&mut self, payload: OnChainConfigPayload) {
         if let Err(e) = self.sender.push((), payload) {
             debug!(
                 "[shared mempool] failed to publish reconfiguration event to mempool: {}",
@@ -600,6 +606,14 @@ where
     }
 }
 
+fn process_config_update(config_update: OnChainConfigPayload) {
+    // check for VM update
+    if let Ok(_vm_publishing_option) = config_update.get::<VMPublishingOption>() {
+        // TODO restart VM validator
+    }
+    // potentially check for other configs here
+}
+
 /// This task handles inbound network events.
 async fn inbound_network_task<V>(
     smp: SharedMempool<V>,
@@ -611,7 +625,7 @@ async fn inbound_network_task<V>(
     )>,
     mut consensus_requests: mpsc::Receiver<ConsensusRequest>,
     mut state_sync_requests: mpsc::Receiver<CommitNotification>,
-    mut mempool_reconfig_events: libra_channel::Receiver<(), ContractEvent>,
+    mut mempool_reconfig_events: libra_channel::Receiver<(), OnChainConfigPayload>,
     node_config: NodeConfig,
 ) where
     V: TransactionValidation,
@@ -648,8 +662,8 @@ async fn inbound_network_task<V>(
             msg = state_sync_requests.select_next_some() => {
                 tokio::spawn(process_state_sync_request(smp.clone(), msg));
             }
-            reconfig_event = mempool_reconfig_events.select_next_some() => {
-                // TODO actually process reconfig event
+            config_update = mempool_reconfig_events.select_next_some() => {
+                process_config_update(config_update);
             },
             (network_id, event) = events.select_next_some() => {
                 match event {
@@ -755,7 +769,7 @@ pub(crate) fn start_shared_mempool<V>(
     client_events: mpsc::Receiver<(SignedTransaction, oneshot::Sender<Result<SubmissionStatus>>)>,
     consensus_requests: mpsc::Receiver<ConsensusRequest>,
     state_sync_requests: mpsc::Receiver<CommitNotification>,
-    mempool_reconfig_events: libra_channel::Receiver<(), ContractEvent>,
+    mempool_reconfig_events: libra_channel::Receiver<(), OnChainConfigPayload>,
     storage_read_client: Arc<dyn StorageRead>,
     validator: Arc<V>,
     subscribers: Vec<UnboundedSender<SharedMempoolNotification>>,
@@ -818,7 +832,7 @@ pub fn bootstrap(
     client_events: Receiver<(SignedTransaction, oneshot::Sender<Result<SubmissionStatus>>)>,
     consensus_requests: Receiver<ConsensusRequest>,
     state_sync_requests: Receiver<CommitNotification>,
-    mempool_reconfig_events: libra_channel::Receiver<(), ContractEvent>,
+    mempool_reconfig_events: libra_channel::Receiver<(), OnChainConfigPayload>,
 ) -> Runtime {
     let runtime = Builder::new()
         .thread_name("shared-mem-")
@@ -855,7 +869,7 @@ pub fn bootstrap(
 /// events will be published
 pub fn generate_reconfig_subscription() -> (
     Box<dyn EventSubscription>,
-    libra_channel::Receiver<(), ContractEvent>,
+    libra_channel::Receiver<(), OnChainConfigPayload>,
 ) {
     let (reconfig_event_publisher, reconfig_event_subscriber) =
         libra_channel::new(QueueStyle::LIFO, NonZeroUsize::new(1).unwrap(), None);

--- a/mempool/src/shared_mempool.rs
+++ b/mempool/src/shared_mempool.rs
@@ -173,9 +173,9 @@ pub struct MempoolReconfigSubscription {
 
 impl EventSubscription for MempoolReconfigSubscription {
     fn subscribed_configs(&self) -> HashSet<ConfigID> {
-        let mut subscribed_configs = HashSet::new();
-        subscribed_configs.insert(VMPublishingOption::CONFIG_ID);
-        subscribed_configs
+        vec![VMPublishingOption::CONFIG_ID]
+            .into_iter()
+            .collect::<HashSet<_>>()
     }
 
     fn publish(&mut self, payload: OnChainConfigPayload) {

--- a/state-synchronizer/Cargo.toml
+++ b/state-synchronizer/Cargo.toml
@@ -19,6 +19,7 @@ once_cell = "1.3.1"
 rand = "0.6.5"
 tokio = { version = "0.2.13", features = ["full"] }
 prometheus = { version = "0.8.0", default-features = false }
+itertools = { version = "0.9.0", default-features = false }
 
 channel = { path = "../common/channel", version = "0.1.0" }
 executor = { path = "../execution/executor", version = "0.1.0" }

--- a/state-synchronizer/src/synchronizer.rs
+++ b/state-synchronizer/src/synchronizer.rs
@@ -44,7 +44,7 @@ impl StateSynchronizer {
         config: &NodeConfig,
         reconfig_event_subscriptions: Vec<Box<dyn EventSubscription>>,
     ) -> Self {
-        let executor_proxy = ExecutorProxy::new(executor, config);
+        let executor_proxy = ExecutorProxy::new(executor, config, reconfig_event_subscriptions);
         Self::bootstrap_with_executor_proxy(
             network,
             state_sync_to_mempool_sender,
@@ -52,7 +52,6 @@ impl StateSynchronizer {
             config.base.waypoint,
             &config.state_sync,
             executor_proxy,
-            reconfig_event_subscriptions,
         )
     }
 
@@ -63,7 +62,6 @@ impl StateSynchronizer {
         waypoint: Option<Waypoint>,
         state_sync_config: &StateSyncConfig,
         executor_proxy: E,
-        reconfig_event_subscriptions: Vec<Box<dyn EventSubscription>>,
     ) -> Self {
         let mut runtime = Builder::new()
             .thread_name("state-sync-")
@@ -85,7 +83,6 @@ impl StateSynchronizer {
             state_sync_config.clone(),
             executor_proxy,
             initial_state,
-            reconfig_event_subscriptions,
         );
         runtime.spawn(coordinator.start(network));
 

--- a/state-synchronizer/src/synchronizer.rs
+++ b/state-synchronizer/src/synchronizer.rs
@@ -61,7 +61,7 @@ impl StateSynchronizer {
         role: RoleType,
         waypoint: Option<Waypoint>,
         state_sync_config: &StateSyncConfig,
-        executor_proxy: E,
+        mut executor_proxy: E,
     ) -> Self {
         let mut runtime = Builder::new()
             .thread_name("state-sync-")
@@ -75,6 +75,12 @@ impl StateSynchronizer {
         let initial_state = runtime
             .block_on(executor_proxy.get_local_storage_state())
             .expect("[state sync] Start failure: cannot sync with storage.");
+
+        // initial read of on-chain configs
+        runtime
+            .block_on(executor_proxy.load_on_chain_configs())
+            .expect("[state sync] Failed initial read of on-chain configs");
+
         let coordinator = SyncCoordinator::new(
             coordinator_receiver,
             state_sync_to_mempool_sender,

--- a/state-synchronizer/src/tests/integration_tests.rs
+++ b/state-synchronizer/src/tests/integration_tests.rs
@@ -108,6 +108,10 @@ impl ExecutorProxyTrait for MockExecutorProxy {
         self.storage.read().unwrap().get_ledger_info(version)
     }
 
+    async fn load_on_chain_configs(&mut self) -> Result<()> {
+        Ok(())
+    }
+
     async fn publish_on_chain_config_updates(&mut self, _events: Vec<ContractEvent>) -> Result<()> {
         Ok(())
     }

--- a/state-synchronizer/src/tests/integration_tests.rs
+++ b/state-synchronizer/src/tests/integration_tests.rs
@@ -18,7 +18,7 @@ use libra_crypto::{
 };
 use libra_mempool::mocks::MockSharedMempool;
 use libra_types::{
-    event_subscription::EventSubscription, ledger_info::LedgerInfoWithSignatures,
+    contract_event::ContractEvent, ledger_info::LedgerInfoWithSignatures,
     proof::TransactionListProof, transaction::TransactionListWithProof,
     validator_change::ValidatorChangeProof, validator_info::ValidatorInfo,
     validator_set::ValidatorSet, validator_signer::ValidatorSigner,
@@ -66,7 +66,6 @@ impl ExecutorProxyTrait for MockExecutorProxy {
         ledger_info_with_sigs: LedgerInfoWithSignatures,
         intermediate_end_of_epoch_li: Option<LedgerInfoWithSignatures>,
         _synced_trees: &mut ExecutedTrees,
-        _reconfig_event_subscriptions: &mut [Box<dyn EventSubscription>],
     ) -> Result<()> {
         self.storage.write().unwrap().add_txns_with_li(
             txn_list_with_proof.transactions,
@@ -107,6 +106,10 @@ impl ExecutorProxyTrait for MockExecutorProxy {
 
     async fn get_ledger_info(&self, version: u64) -> Result<LedgerInfoWithSignatures> {
         self.storage.read().unwrap().get_ledger_info(version)
+    }
+
+    async fn publish_on_chain_config_updates(&mut self, _events: Vec<ContractEvent>) -> Result<()> {
+        Ok(())
     }
 }
 
@@ -302,7 +305,6 @@ impl SynchronizerEnv {
             waypoint,
             &config.state_sync,
             MockExecutorProxy::new(handler, storage_proxy.clone()),
-            vec![],
         );
         self.mempools
             .push(MockSharedMempool::new(Some(mempool_requests)));

--- a/storage/storage-service/src/mocks/mock_storage_client.rs
+++ b/storage/storage-service/src/mocks/mock_storage_client.rs
@@ -7,6 +7,7 @@ use anyhow::{Error, Result};
 use futures::stream::BoxStream;
 use libra_crypto::{ed25519::*, HashValue};
 use libra_types::{
+    access_path::AccessPath,
     account_address::AccountAddress,
     account_state::AccountState,
     account_state_blob::AccountStateBlob,
@@ -143,6 +144,10 @@ impl StorageRead for MockStorageReadClient {
         _start_version: Version,
         _num_transaction_infos: u64,
     ) -> Result<BoxStream<'_, Result<BackupTransactionInfoResponse, Error>>> {
+        unimplemented!()
+    }
+
+    async fn batch_fetch_config(&self, _access_paths: Vec<AccessPath>) -> Vec<Option<Vec<u8>>> {
         unimplemented!()
     }
 }

--- a/storage/storage-service/src/mocks/mock_storage_client.rs
+++ b/storage/storage-service/src/mocks/mock_storage_client.rs
@@ -147,7 +147,7 @@ impl StorageRead for MockStorageReadClient {
         unimplemented!()
     }
 
-    async fn batch_fetch_config(&self, _access_paths: Vec<AccessPath>) -> Vec<Option<Vec<u8>>> {
+    async fn batch_fetch_config(&self, _access_paths: Vec<AccessPath>) -> Result<Vec<Vec<u8>>> {
         unimplemented!()
     }
 }

--- a/types/src/event_subscription.rs
+++ b/types/src/event_subscription.rs
@@ -1,10 +1,12 @@
 // Copyright (c) The Libra Core Contributors
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::contract_event::ContractEvent;
+use crate::on_chain_config::{ConfigID, OnChainConfigPayload};
+use std::collections::HashSet;
 
 /// Trait that must be implemented by a subscription to reconfiguration events emitted
 /// by state sync
 pub trait EventSubscription: Send + Sync {
-    fn publish(&mut self, payload: ContractEvent);
+    fn subscribed_configs(&self) -> HashSet<ConfigID>;
+    fn publish(&mut self, payload: OnChainConfigPayload);
 }

--- a/types/src/on_chain_config.rs
+++ b/types/src/on_chain_config.rs
@@ -26,28 +26,25 @@ impl ConfigID {
     }
 }
 
+/// State sync will panic if the value of any config in this registry is uninitialized
 pub const ON_CHAIN_CONFIG_REGISTRY: &[ConfigID] = &[VMPublishingOption::CONFIG_ID];
 
 #[derive(Clone)]
 pub struct OnChainConfigPayload {
-    configs: Arc<HashMap<ConfigID, Option<Vec<u8>>>>,
+    configs: Arc<HashMap<ConfigID, Vec<u8>>>,
 }
 
 impl OnChainConfigPayload {
-    pub fn new(configs: Arc<HashMap<ConfigID, Option<Vec<u8>>>>) -> Self {
+    pub fn new(configs: Arc<HashMap<ConfigID, Vec<u8>>>) -> Self {
         Self { configs }
     }
 
     pub fn get<T: OnChainConfig>(&self) -> Result<T> {
-        if let Some(bytes) = self
+        let bytes = self
             .configs
             .get(&T::CONFIG_ID)
-            .ok_or_else(|| format_err!("[on-chain-cfg] config not in payload"))?
-        {
-            T::deserialize_into_config(bytes)
-        } else {
-            Err(format_err!("[on-chain-cfg] missing byte array in payload, potentially caused be failed storage read"))
-        }
+            .ok_or_else(|| format_err!("[on-chain cfg] config not in payload"))?;
+        T::deserialize_into_config(bytes)
     }
 }
 

--- a/types/src/on_chain_config.rs
+++ b/types/src/on_chain_config.rs
@@ -64,8 +64,8 @@ pub trait OnChainConfig: Send + Sync + DeserializeOwned {
 
     // Single-round LCS deserialization from bytes to `Self`
     // This is the expected deserialization pattern for most Rust representations,
-    // but sometimes `deserialize_into_config` may need to be customized
-    // (e.g. `VMPublishingOption` needs an extra round of deserialization)
+    // but sometimes `deserialize_into_config` may need an extra customized round of deserialization
+    // (e.g. enums like `VMPublishingOption`)
     // In the override, we can reuse this default logic via this function
     // Note: we cannot directly call the default `deserialize_into_config` implementation
     // in its override - this will just refer to the override implementation itself

--- a/types/src/on_chain_config.rs
+++ b/types/src/on_chain_config.rs
@@ -7,9 +7,45 @@ use crate::{
     language_storage::{StructTag, TypeTag},
     transaction::SCRIPT_HASH_LENGTH,
 };
+use anyhow::Result;
 use libra_crypto::HashValue;
 use move_core_types::identifier::Identifier;
-use serde::{Deserialize, Serialize};
+use serde::{de::DeserializeOwned, Deserialize, Serialize};
+
+/// Trait to be implemented by a storage type from which to read on-chain configs
+pub trait ConfigStorage {
+    fn fetch_config(&self, access_path: AccessPath) -> Option<Vec<u8>>;
+}
+
+/// Trait to be implemented by a Rust struct representation of an on-chain config
+/// that is stored in storage as a deserialized byte array
+pub trait OnChainConfig {
+    const IDENTIFIER: &'static str;
+
+    fn deserialize_into_config(bytes: &[u8]) -> Result<Self>
+    where
+        Self: DeserializeOwned,
+    {
+        let result = lcs::from_bytes::<Self>(&bytes).map_err(|e| {
+            anyhow::format_err!(
+                "Failed to serialize account blob bytes to on-chain config: {}",
+                e
+            )
+        })?;
+        Ok(result)
+    }
+
+    fn fetch_config<U: ConfigStorage>(storage: &U) -> Result<Self>
+    where
+        Self: DeserializeOwned,
+    {
+        let access_path = access_path_for_config(Identifier::new(Self::IDENTIFIER).unwrap());
+        let bytes = storage
+            .fetch_config(access_path)
+            .ok_or_else(|| anyhow::format_err!("no config found"))?;
+        Self::deserialize_into_config(&bytes)
+    }
+}
 
 pub fn access_path_for_config(config_name: Identifier) -> AccessPath {
     AccessPath::new(
@@ -45,6 +81,10 @@ pub enum VMPublishingOption {
     CustomScripts,
     /// Allow both custom scripts and custom module publishing
     Open,
+}
+
+impl OnChainConfig for VMPublishingOption {
+    const IDENTIFIER: &'static str = "ScriptWhitelist";
 }
 
 impl VMPublishingOption {


### PR DESCRIPTION
## Summary

This PR does mainly two things: 
- Adding Rust interface(i.e. traits) to support representing and reading on-chain configs in Rust/Libra node. Specifically:
      - `ConfigStorage`: trait for storage to read on-chain configs from
      - `OnChainConfig`: trait for Rust representation of on-chain configs
      Refactored existing VM whitelist config as POC for new interface
- impl e2e flow for reconfig notification pub/sub (mempool subscription to VMPublishingOption)


