### PR TITLE
[Move IR] Fixed compilation of generics at borrow/call

### DIFF
--- a/language/ir-testsuite/tests/generics/field_borrow.mvir
+++ b/language/ir-testsuite/tests/generics/field_borrow.mvir
@@ -1,0 +1,9 @@
+module M {
+    struct X { v: u64 }
+    struct S<T> { f: T }
+    t(s: Self.S<Self.X>): u64 {
+        return *(&(&(&s).f).v);
+    }
+}
+
+// check: Success

--- a/language/ir-testsuite/tests/generics/field_borrow_after_call.mvir
+++ b/language/ir-testsuite/tests/generics/field_borrow_after_call.mvir
@@ -1,0 +1,12 @@
+module M {
+    struct X { v: u64 }
+    id<T>(x: &T): &T {
+        return move(x);
+    }
+
+    t(x: Self.X): u64 {
+        return *(&Self.id<Self.X>(&x).v);
+    }
+}
+
+// check: Success

--- a/language/move-ir/types/src/ast.rs
+++ b/language/move-ir/types/src/ast.rs
@@ -634,8 +634,8 @@ pub enum Bytecode_ {
     FreezeRef,
     MutBorrowLoc(Var),
     ImmBorrowLoc(Var),
-    MutBorrowField(StructName, Field),
-    ImmBorrowField(StructName, Field),
+    MutBorrowField(StructName, Vec<Type>, Field),
+    ImmBorrowField(StructName, Vec<Type>, Field),
     MutBorrowGlobal(StructName, Vec<Type>),
     ImmBorrowGlobal(StructName, Vec<Type>),
     Add,
@@ -1783,8 +1783,20 @@ impl fmt::Display for Bytecode_ {
             Bytecode_::FreezeRef => write!(f, "FreezeRef"),
             Bytecode_::MutBorrowLoc(v) => write!(f, "MutBorrowLoc {}", v),
             Bytecode_::ImmBorrowLoc(v) => write!(f, "ImmBorrowLoc {}", v),
-            Bytecode_::MutBorrowField(n, field) => write!(f, "MutBorrowField {}.{}", n, field),
-            Bytecode_::ImmBorrowField(n, field) => write!(f, "ImmBorrowField {}.{}", n, field),
+            Bytecode_::MutBorrowField(n, tys, field) => write!(
+                f,
+                "MutBorrowField {}{}.{}",
+                n,
+                format_type_actuals(tys),
+                field
+            ),
+            Bytecode_::ImmBorrowField(n, tys, field) => write!(
+                f,
+                "ImmBorrowField {}{}.{}",
+                n,
+                format_type_actuals(tys),
+                field
+            ),
             Bytecode_::MutBorrowGlobal(n, tys) => {
                 write!(f, "MutBorrowGlobal {}{}", n, format_type_actuals(tys))
             }

--- a/language/move-lang/src/to_bytecode/translate.rs
+++ b/language/move-lang/src/to_bytecode/translate.rs
@@ -695,12 +695,12 @@ fn exp_(context: &mut Context, code: &mut IR::BytecodeBlock, e: H::Exp) {
         }
 
         E::Borrow(mut_, el, f) => {
-            let (n, _) = struct_definition_name(context, el.ty.clone());
+            let (n, tys) = struct_definition_name(context, el.ty.clone());
             exp(context, code, el);
             let instr = if mut_ {
-                B::MutBorrowField(n, field(f))
+                B::MutBorrowField(n, tys, field(f))
             } else {
-                B::ImmBorrowField(n, field(f))
+                B::ImmBorrowField(n, tys, field(f))
             };
             code.push(sp(loc, instr));
         }


### PR DESCRIPTION
## Motivation

- Field/call did not substitute type arguments
- This meant that any attempt to access the underlying type after the borrow/call could panic
- Added a subst with the type arguments to fix it
- Moved type parameter mappings out of the context for clarity of the two different types of substitutions

## Test Plan

- New tests (verified they were broken on master)