### PR TITLE
[monitoring] alert on dev when low txn throughput

### DIFF
--- a/terraform/templates/prometheus.yml
+++ b/terraform/templates/prometheus.yml
@@ -13,8 +13,8 @@ alerting:
 
 # Load rules once and periodically evaluate them according to the global 'evaluation_interval'.
 rule_files:
-  - "rules/blockchain_alerts.yml"
   - "rules/recording_rules.yml"
+  - "rules/blockchain_alerts.yml"
 
 # A scrape configuration containing exactly one endpoint to scrape:
 # Here it's Prometheus itself.

--- a/terraform/templates/prometheus/rules/blockchain_alerts.yml
+++ b/terraform/templates/prometheus/rules/blockchain_alerts.yml
@@ -7,6 +7,12 @@ groups:
     labels:
       severity: high
       summary: "Node {{ $labels.peer_id }} is not producing consensus commits"
+  - alert: Low Transaction Commit Rate
+    expr: absent(avg(rate(libra_consensus_committed_txns_count{role="validator"}[1m])) > 1)
+    for: 20m
+    labels:
+      severity: high
+      summary: "Node {{ $labels.peer_id }} is not reporting committed txns"
   - alert: HighCpuUsage
     expr: (1 - avg by(peer_id)(irate(node_cpu_seconds_total{role='validator',mode='idle'}[5m]))) * 100 > 90
     for: 5m


### PR DESCRIPTION
<!--
Thank you for sending a PR. We appreciate you spending time to help improve the Libra project.

The project is undergoing daily changes. Pull Requests will be reviewed and responded to as time permits.
-->

## Motivation

Dev keeps breaking, and we need an automated way to check its status. This PR adds alerts for oncall when dev txns drop to zero. Also, adds a switch to select the appropriate prometheus alerts rule depending on your terraform workspace (e.g. `dev` or not).

Note: for alerting to oncall to work, terraform expects `prometheus_pagerduty_key` 

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan



## Related PRs

