### PR TITLE
[LCS] enforce canonical encoding for BTreeMaps (but not BTreeSets)

### DIFF
--- a/common/lcs/src/error.rs
+++ b/common/lcs/src/error.rs
@@ -19,6 +19,8 @@ pub enum Error {
     ExpectedMapKey,
     #[error("expected map value")]
     ExpectedMapValue,
+    #[error("keys of serialized maps must be unique and in increasing order")]
+    NonCanonicalMap,
     #[error("expected option type")]
     ExpectedOption,
     #[error("{0}")]


### PR DESCRIPTION
## Motivation

The LCS serializer makes sure to sort keys (by bitstring) before outputting the serialization of a map but we forgot to implement the corresponding validation check in the LCS deserializer. This PR enforces the right behavior.

Note that by default, Serde derive macros currently deserialize `BTreeSet`s as sequences [1].
This is a bit unfortunate for us but perhaps it make sense for performance. (Need to ask DT)

This is an additional motivation for tracking the data formats resulting from Serde macros in a text file [2].

## Test Plan

```
cargo x test -p libra-canonical-serialization
```

## Related Links

[1] https://docs.serde.rs/src/serde/de/impls.rs.html
[2] https://github.com/libra/libra/pull/3104