### PR TITLE
Improve consensus unit tests

### DIFF
--- a/consensus/src/chained_bft/event_processor.rs
+++ b/consensus/src/chained_bft/event_processor.rs
@@ -109,7 +109,7 @@ pub enum VerifiedEvent<T> {
 #[path = "event_processor_test.rs"]
 mod event_processor_test;
 
-#[cfg(any(feature = "fuzzing", test))]
+#[cfg(any(test, feature = "fuzzing"))]
 #[path = "event_processor_fuzzing.rs"]
 pub mod event_processor_fuzzing;
 

--- a/consensus/src/chained_bft/event_processor_fuzzing.rs
+++ b/consensus/src/chained_bft/event_processor_fuzzing.rs
@@ -1,6 +1,8 @@
 // Copyright (c) The Libra Core Contributors
 // SPDX-License-Identifier: Apache-2.0
 
+#[allow(unused_imports)] // work around compiler bug which incorrect detects this as unused
+use crate::chained_bft::test_utils::consensus_runtime;
 use crate::{
     chained_bft::{
         block_storage::BlockStore,
@@ -19,7 +21,7 @@ use crate::{
 };
 use channel::{self, libra_channel, message_queues::QueueStyle};
 use consensus_types::proposal_msg::ProposalMsg;
-use futures::{channel::mpsc, executor::block_on};
+use futures::channel::mpsc;
 use libra_types::{
     ledger_info::LedgerInfoWithSignatures, validator_signer::ValidatorSigner,
     validator_verifier::ValidatorVerifier,
@@ -31,19 +33,17 @@ use std::{num::NonZeroUsize, sync::Arc};
 use tokio::runtime::Runtime;
 
 // This generates a proposal for round 1
-pub fn generate_corpus_proposal() -> Vec<u8> {
+pub async fn generate_corpus_proposal() -> Vec<u8> {
     let mut event_processor = create_node_for_fuzzing();
-    block_on(async {
-        let proposal = event_processor
-            .generate_proposal(NewRoundEvent {
-                round: 1,
-                reason: NewRoundReason::QCReady,
-                timeout: std::time::Duration::new(5, 0),
-            })
-            .await;
-        // serialize and return proposal
-        lcs::to_bytes(&proposal.unwrap()).unwrap()
-    })
+    let proposal = event_processor
+        .generate_proposal(NewRoundEvent {
+            round: 1,
+            reason: NewRoundReason::QCReady,
+            timeout: std::time::Duration::new(5, 0),
+        })
+        .await;
+    // serialize and return proposal
+    lcs::to_bytes(&proposal.unwrap()).unwrap()
 }
 
 // optimization for the fuzzer
@@ -151,7 +151,7 @@ fn create_node_for_fuzzing() -> EventProcessor<TestPayload> {
 }
 
 // This functions fuzzes a Proposal protobuffer (not a ConsensusMsg)
-pub fn fuzz_proposal(data: &[u8]) {
+pub async fn fuzz_proposal(data: &[u8]) {
     // create node
     let mut event_processor = create_node_for_fuzzing();
 
@@ -175,18 +175,20 @@ pub fn fuzz_proposal(data: &[u8]) {
         }
     };
 
-    block_on(async move {
-        // TODO: make sure this obtains a vote when testing
-        // TODO: make sure that if this obtains a vote, it's for round 1, etc.
-        event_processor.process_proposal_msg(proposal).await;
-    });
+    // TODO: make sure this obtains a vote when testing
+    // TODO: make sure that if this obtains a vote, it's for round 1, etc.
+    event_processor.process_proposal_msg(proposal).await;
 }
 
 // This test is here so that the fuzzer can be maintained
 #[test]
 fn test_consensus_proposal_fuzzer() {
-    // generate a proposal
-    let proposal = generate_corpus_proposal();
-    // successfully parse it
-    fuzz_proposal(&proposal);
+    let mut runtime = consensus_runtime();
+
+    runtime.block_on(async {
+        // generate a proposal
+        let proposal = generate_corpus_proposal().await;
+        // successfully parse it
+        fuzz_proposal(&proposal).await;
+    });
 }

--- a/consensus/src/chained_bft/event_processor_test.rs
+++ b/consensus/src/chained_bft/event_processor_test.rs
@@ -16,8 +16,8 @@ use crate::{
         network_tests::NetworkPlayground,
         persistent_liveness_storage::RecoveryData,
         test_utils::{
-            self, consensus_runtime, MockStateComputer, MockStorage, MockTransactionManager,
-            TestPayload, TreeInserter,
+            self, consensus_runtime, timed_block_on, MockStateComputer, MockStorage,
+            MockTransactionManager, TestPayload, TreeInserter,
         },
     },
     util::time_service::{ClockTimeService, TimeService},
@@ -223,7 +223,7 @@ impl NodeSetup {
 
 #[test]
 fn basic_new_rank_event_test() {
-    let runtime = consensus_runtime();
+    let mut runtime = consensus_runtime();
     let mut playground = NetworkPlayground::new(runtime.handle().clone());
     let mut nodes = NodeSetup::create_nodes(&mut playground, runtime.handle().clone(), 2);
     let node1 = nodes.pop().unwrap();
@@ -231,7 +231,7 @@ fn basic_new_rank_event_test() {
     let genesis = node.block_store.root();
     let mut inserter = TreeInserter::new_with_store(node.signer.clone(), node.block_store.clone());
     let a1 = inserter.insert_block_with_qc(certificate_for_genesis(), &genesis, 1);
-    block_on(async move {
+    timed_block_on(&mut runtime, async {
         let new_round = 1;
         node.event_processor
             .process_new_round_event(NewRoundEvent {
@@ -328,7 +328,7 @@ fn basic_new_rank_event_test() {
 #[test]
 /// If the proposal is valid, a vote should be sent
 fn process_successful_proposal_test() {
-    let runtime = consensus_runtime();
+    let mut runtime = consensus_runtime();
     let mut playground = NetworkPlayground::new(runtime.handle().clone());
     // In order to observe the votes we're going to check proposal processing on the non-proposer
     // node (which will send the votes to the proposer).
@@ -336,7 +336,7 @@ fn process_successful_proposal_test() {
     let node = &mut nodes[1];
 
     let genesis_qc = certificate_for_genesis();
-    block_on(async move {
+    timed_block_on(&mut runtime, async {
         let proposal = Block::new_proposal(vec![1], 1, 1, genesis_qc.clone(), &node.signer);
         let proposal_id = proposal.id();
         node.event_processor.process_proposed_block(proposal).await;
@@ -376,7 +376,7 @@ fn process_successful_proposal_test() {
 /// If the proposal does not pass voting rules,
 /// No votes are sent, but the block is still added to the block tree.
 fn process_old_proposal_test() {
-    let runtime = consensus_runtime();
+    let mut runtime = consensus_runtime();
     let mut playground = NetworkPlayground::new(runtime.handle().clone());
     // In order to observe the votes we're going to check proposal processing on the non-proposer
     // node (which will send the votes to the proposer).
@@ -387,7 +387,7 @@ fn process_old_proposal_test() {
     let new_block_id = new_block.id();
     let old_block = Block::new_proposal(vec![1], 1, 2, genesis_qc, &node.signer);
     let old_block_id = old_block.id();
-    block_on(async move {
+    timed_block_on(&mut runtime, async {
         node.event_processor.process_proposed_block(new_block).await;
         node.event_processor.process_proposed_block(old_block).await;
         let pending_messages = playground
@@ -422,7 +422,7 @@ fn process_old_proposal_test() {
 /// Basically it checks that adversary can not send proposal and skip rounds violating pacemaker
 /// rules
 fn process_round_mismatch_test() {
-    let runtime = consensus_runtime();
+    let mut runtime = consensus_runtime();
     let mut playground = NetworkPlayground::new(runtime.handle().clone());
     // In order to observe the votes we're going to check proposal processing on the non-proposer
     // node (which will send the votes to the proposer).
@@ -432,7 +432,7 @@ fn process_round_mismatch_test() {
     let genesis_qc = certificate_for_genesis();
     let correct_block = Block::new_proposal(vec![1], 1, 1, genesis_qc.clone(), &node.signer);
     let block_skip_round = Block::new_proposal(vec![1], 2, 2, genesis_qc.clone(), &node.signer);
-    block_on(async move {
+    timed_block_on(&mut runtime, async {
         let bad_proposal = ProposalMsg::<TestPayload>::new(
             block_skip_round,
             SyncInfo::new(genesis_qc.clone(), genesis_qc.clone(), None),
@@ -460,7 +460,7 @@ fn process_round_mismatch_test() {
 /// Ensure that after the vote messages are broadcasted upon timeout, the receivers
 /// have the highest quorum certificate (carried by the SyncInfo of the vote message)
 fn process_vote_timeout_msg_test() {
-    let runtime = consensus_runtime();
+    let mut runtime = consensus_runtime();
     let mut playground = NetworkPlayground::new(runtime.handle().clone());
     let mut nodes = NodeSetup::create_nodes(&mut playground, runtime.handle().clone(), 2);
     let non_proposer = nodes.pop().unwrap();
@@ -527,7 +527,8 @@ fn process_vote_timeout_msg_test() {
         vote_on_timeout,
         SyncInfo::new(block_0_quorum_cert, certificate_for_genesis(), None),
     );
-    block_on(
+    timed_block_on(
+        &mut runtime,
         static_proposer
             .event_processor
             .process_vote(vote_msg_on_timeout),
@@ -546,7 +547,7 @@ fn process_vote_timeout_msg_test() {
 #[test]
 /// We don't vote for proposals that comes from proposers that are not valid proposers for round
 fn process_proposer_mismatch_test() {
-    let runtime = consensus_runtime();
+    let mut runtime = consensus_runtime();
     let mut playground = NetworkPlayground::new(runtime.handle().clone());
     // In order to observe the votes we're going to check proposal processing on the non-proposer
     // node (which will send the votes to the proposer).
@@ -562,7 +563,7 @@ fn process_proposer_mismatch_test() {
         genesis_qc.clone(),
         &incorrect_proposer.signer,
     );
-    block_on(async move {
+    timed_block_on(&mut runtime, async {
         let bad_proposal = ProposalMsg::<TestPayload>::new(
             block_incorrect_proposer,
             SyncInfo::new(genesis_qc.clone(), genesis_qc.clone(), None),
@@ -590,7 +591,7 @@ fn process_proposer_mismatch_test() {
 #[test]
 /// We allow to 'skip' round if proposal carries timeout certificate for next round
 fn process_timeout_certificate_test() {
-    let runtime = consensus_runtime();
+    let mut runtime = consensus_runtime();
     let mut playground = NetworkPlayground::new(runtime.handle().clone());
     // In order to observe the votes we're going to check proposal processing on the non-proposer
     // node (which will send the votes to the proposer).
@@ -606,7 +607,7 @@ fn process_timeout_certificate_test() {
     let mut tc = TimeoutCertificate::new(timeout);
     tc.add_signature(node.signer.author(), timeout_signature);
 
-    block_on(async move {
+    timed_block_on(&mut runtime, async {
         let skip_round_proposal = ProposalMsg::<TestPayload>::new(
             block_skip_round,
             SyncInfo::new(genesis_qc.clone(), genesis_qc.clone(), Some(tc)),
@@ -634,7 +635,7 @@ fn process_timeout_certificate_test() {
 /// Happy path for vote processing:
 /// 1) if a new QC is formed and a block is present send a PM event
 fn process_votes_basic_test() {
-    let runtime = consensus_runtime();
+    let mut runtime = consensus_runtime();
     let mut playground = NetworkPlayground::new(runtime.handle().clone());
     let mut node = NodeSetup::create_nodes(&mut playground, runtime.handle().clone(), 1)
         .pop()
@@ -666,7 +667,7 @@ fn process_votes_basic_test() {
         test_utils::placeholder_sync_info(),
     );
 
-    block_on(async move {
+    timed_block_on(&mut runtime, async {
         node.event_processor.process_vote(vote_msg).await;
         // The new QC is aggregated
         assert_eq!(
@@ -681,7 +682,7 @@ fn process_votes_basic_test() {
 
 #[test]
 fn process_block_retrieval() {
-    let runtime = consensus_runtime();
+    let mut runtime = consensus_runtime();
     let mut playground = NetworkPlayground::new(runtime.handle().clone());
     let mut node = NodeSetup::create_nodes(&mut playground, runtime.handle().clone(), 1)
         .pop()
@@ -691,7 +692,7 @@ fn process_block_retrieval() {
     let block = Block::new_proposal(vec![1], 1, 1, genesis_qc, &node.signer);
     let block_id = block.id();
 
-    block_on(async move {
+    timed_block_on(&mut runtime, async {
         node.event_processor
             .process_certificates(block.quorum_cert(), None)
             .await
@@ -771,7 +772,7 @@ fn process_block_retrieval() {
 #[test]
 /// rebuild a node from previous storage without violating safety guarantees.
 fn basic_restart_test() {
-    let runtime = consensus_runtime();
+    let mut runtime = consensus_runtime();
     let mut playground = NetworkPlayground::new(runtime.handle().clone());
     let mut node = NodeSetup::create_nodes(&mut playground, runtime.handle().clone(), 1)
         .pop()
@@ -791,13 +792,15 @@ fn basic_restart_test() {
         proposals.push(proposal);
     }
     for proposal in &proposals {
-        block_on(
+        timed_block_on(
+            &mut runtime,
             node_mut
                 .event_processor
                 .process_certificates(proposal.quorum_cert(), None),
         )
         .expect("Failed to process certificates");
-        block_on(
+        timed_block_on(
+            &mut runtime,
             node_mut
                 .event_processor
                 .process_proposed_block(proposal.block().clone()),
@@ -817,12 +820,12 @@ fn basic_restart_test() {
 #[test]
 /// Generate a NIL vote extending HQC upon timeout if no votes have been sent in the round.
 fn nil_vote_on_timeout() {
-    let runtime = consensus_runtime();
+    let mut runtime = consensus_runtime();
     let mut playground = NetworkPlayground::new(runtime.handle().clone());
     // It needs 2 nodes to test network message.
     let mut nodes = NodeSetup::create_nodes(&mut playground, runtime.handle().clone(), 2);
     let node = &mut nodes[0];
-    block_on(async move {
+    timed_block_on(&mut runtime, async {
         // Process the outgoing vote message and verify that it contains a round signature
         // and that the vote extends genesis.
         node.event_processor.process_local_timeout(1).await;

--- a/consensus/src/chained_bft/liveness/pacemaker_test.rs
+++ b/consensus/src/chained_bft/liveness/pacemaker_test.rs
@@ -2,14 +2,18 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::{
-    chained_bft::liveness::pacemaker::{
-        ExponentialTimeInterval, NewRoundEvent, NewRoundReason, Pacemaker, PacemakerTimeInterval,
+    chained_bft::{
+        liveness::pacemaker::{
+            ExponentialTimeInterval, NewRoundEvent, NewRoundReason, Pacemaker,
+            PacemakerTimeInterval,
+        },
+        test_utils::consensus_runtime,
     },
     util::mock_time_service::SimulatedTimeService,
 };
 
 use consensus_types::common::Round;
-use futures::{executor::block_on, StreamExt};
+use futures::StreamExt;
 use std::{sync::Arc, time::Duration};
 
 #[test]
@@ -28,12 +32,13 @@ fn test_pacemaker_time_interval() {
 #[test]
 /// Verify that Pacemaker properly outputs local timeout events upon timeout
 fn test_basic_timeout() {
+    let mut runtime = consensus_runtime();
     let (mut pm, mut timeout_rx) = make_pacemaker();
 
     // jump start the pacemaker
     pm.process_certificates(Some(0), None, None);
     for _ in 0..2 {
-        let round = block_on(timeout_rx.next()).unwrap();
+        let round = runtime.block_on(timeout_rx.next()).unwrap();
         // Here we just test timeout send retry,
         // round for timeout is not changed as no timeout certificate was gathered at this point
         assert_eq!(1, round);

--- a/consensus/src/chained_bft/liveness/pacemaker_test.rs
+++ b/consensus/src/chained_bft/liveness/pacemaker_test.rs
@@ -2,12 +2,8 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::{
-    chained_bft::{
-        liveness::pacemaker::{
-            ExponentialTimeInterval, NewRoundEvent, NewRoundReason, Pacemaker,
-            PacemakerTimeInterval,
-        },
-        test_utils::consensus_runtime,
+    chained_bft::liveness::pacemaker::{
+        ExponentialTimeInterval, NewRoundEvent, NewRoundReason, Pacemaker, PacemakerTimeInterval,
     },
     util::mock_time_service::SimulatedTimeService,
 };
@@ -29,16 +25,15 @@ fn test_pacemaker_time_interval() {
     assert_eq!(6750, interval.get_round_duration(1000).as_millis());
 }
 
-#[test]
+#[tokio::test]
 /// Verify that Pacemaker properly outputs local timeout events upon timeout
-fn test_basic_timeout() {
-    let mut runtime = consensus_runtime();
+async fn test_basic_timeout() {
     let (mut pm, mut timeout_rx) = make_pacemaker();
 
     // jump start the pacemaker
     pm.process_certificates(Some(0), None, None);
     for _ in 0..2 {
-        let round = runtime.block_on(timeout_rx.next()).unwrap();
+        let round = timeout_rx.next().await.unwrap();
         // Here we just test timeout send retry,
         // round for timeout is not changed as no timeout certificate was gathered at this point
         assert_eq!(1, round);

--- a/consensus/src/chained_bft/liveness/proposal_generator_test.rs
+++ b/consensus/src/chained_bft/liveness/proposal_generator_test.rs
@@ -5,7 +5,7 @@ use crate::{
     chained_bft::{
         block_storage::BlockReader,
         liveness::proposal_generator::ProposalGenerator,
-        test_utils::{build_empty_tree, MockTransactionManager, TreeInserter},
+        test_utils::{build_empty_tree, consensus_runtime, MockTransactionManager, TreeInserter},
     },
     util::mock_time_service::SimulatedTimeService,
 };
@@ -13,7 +13,6 @@ use consensus_types::block::{
     block_test_utils::{certificate_for_genesis, gen_test_certificate},
     Block,
 };
-use futures::executor::block_on;
 use libra_types::validator_signer::ValidatorSigner;
 use std::{
     sync::Arc,
@@ -26,6 +25,7 @@ fn minute_from_now() -> Instant {
 
 #[test]
 fn test_proposal_generation_empty_tree() {
+    let mut runtime = consensus_runtime();
     let signer = ValidatorSigner::random(None);
     let block_store = build_empty_tree();
     let mut proposal_generator = ProposalGenerator::new(
@@ -38,20 +38,24 @@ fn test_proposal_generation_empty_tree() {
     let genesis = block_store.root();
 
     // Generate proposals for an empty tree.
-    let proposal_data =
-        block_on(proposal_generator.generate_proposal(1, minute_from_now())).unwrap();
+    let proposal_data = runtime
+        .block_on(proposal_generator.generate_proposal(1, minute_from_now()))
+        .unwrap();
     let proposal = Block::new_proposal_from_block_data(proposal_data, &signer);
     assert_eq!(proposal.parent_id(), genesis.id());
     assert_eq!(proposal.round(), 1);
     assert_eq!(proposal.quorum_cert().certified_block().id(), genesis.id());
 
     // Duplicate proposals on the same round are not allowed
-    let proposal_err = block_on(proposal_generator.generate_proposal(1, minute_from_now())).err();
+    let proposal_err = runtime
+        .block_on(proposal_generator.generate_proposal(1, minute_from_now()))
+        .err();
     assert!(proposal_err.is_some());
 }
 
 #[test]
 fn test_proposal_generation_parent() {
+    let mut runtime = consensus_runtime();
     let mut inserter = TreeInserter::default();
     let block_store = inserter.block_store();
     let mut proposal_generator = ProposalGenerator::new(
@@ -68,7 +72,8 @@ fn test_proposal_generation_parent() {
     // With no certifications the parent is genesis
     // generate proposals for an empty tree.
     assert_eq!(
-        block_on(proposal_generator.generate_proposal(10, minute_from_now()))
+        runtime
+            .block_on(proposal_generator.generate_proposal(10, minute_from_now()))
             .unwrap()
             .parent_id(),
         genesis.id()
@@ -76,16 +81,18 @@ fn test_proposal_generation_parent() {
 
     // Once a1 is certified, it should be the one to choose from
     inserter.insert_qc_for_block(a1.as_ref(), None);
-    let a1_child_res =
-        block_on(proposal_generator.generate_proposal(11, minute_from_now())).unwrap();
+    let a1_child_res = runtime
+        .block_on(proposal_generator.generate_proposal(11, minute_from_now()))
+        .unwrap();
     assert_eq!(a1_child_res.parent_id(), a1.id());
     assert_eq!(a1_child_res.round(), 11);
     assert_eq!(a1_child_res.quorum_cert().certified_block().id(), a1.id());
 
     // Once b1 is certified, it should be the one to choose from
     inserter.insert_qc_for_block(b1.as_ref(), None);
-    let b1_child_res =
-        block_on(proposal_generator.generate_proposal(12, minute_from_now())).unwrap();
+    let b1_child_res = runtime
+        .block_on(proposal_generator.generate_proposal(12, minute_from_now()))
+        .unwrap();
     assert_eq!(b1_child_res.parent_id(), b1.id());
     assert_eq!(b1_child_res.round(), 12);
     assert_eq!(b1_child_res.quorum_cert().certified_block().id(), b1.id());
@@ -93,6 +100,7 @@ fn test_proposal_generation_parent() {
 
 #[test]
 fn test_old_proposal_generation() {
+    let mut runtime = consensus_runtime();
     let mut inserter = TreeInserter::default();
     let block_store = inserter.block_store();
     let mut proposal_generator = ProposalGenerator::new(
@@ -106,12 +114,15 @@ fn test_old_proposal_generation() {
     let a1 = inserter.insert_block_with_qc(certificate_for_genesis(), &genesis, 1);
     inserter.insert_qc_for_block(a1.as_ref(), None);
 
-    let proposal_err = block_on(proposal_generator.generate_proposal(1, minute_from_now())).err();
+    let proposal_err = runtime
+        .block_on(proposal_generator.generate_proposal(1, minute_from_now()))
+        .err();
     assert!(proposal_err.is_some());
 }
 
 #[test]
 fn test_empty_proposal_after_reconfiguration() {
+    let mut runtime = consensus_runtime();
     let mut inserter = TreeInserter::default();
     let block_store = inserter.block_store();
     let mut proposal_generator = ProposalGenerator::new(
@@ -124,14 +135,16 @@ fn test_empty_proposal_after_reconfiguration() {
     let genesis = block_store.root();
     let a1 = inserter.insert_block_with_qc(certificate_for_genesis(), &genesis, 1);
     // Normal proposal is not empty
-    let normal_proposal_1 =
-        block_on(proposal_generator.generate_proposal(42, minute_from_now())).unwrap();
+    let normal_proposal_1 = runtime
+        .block_on(proposal_generator.generate_proposal(42, minute_from_now()))
+        .unwrap();
     assert!(!normal_proposal_1.payload().unwrap().is_empty());
     let a2 = inserter.insert_reconfiguration_block(&a1, 2);
     inserter.insert_qc_for_block(a2.as_ref(), None);
     // The direct child is empty
-    let empty_proposal_1 =
-        block_on(proposal_generator.generate_proposal(43, minute_from_now())).unwrap();
+    let empty_proposal_1 = runtime
+        .block_on(proposal_generator.generate_proposal(43, minute_from_now()))
+        .unwrap();
     assert!(empty_proposal_1.payload().unwrap().is_empty());
     // insert one more block after reconfiguration
     let a3 = inserter.create_block_with_qc(
@@ -143,8 +156,9 @@ fn test_empty_proposal_after_reconfiguration() {
     let a3 = block_store.execute_and_insert_block(a3).unwrap();
     inserter.insert_qc_for_block(a3.as_ref(), None);
     // Indirect child is empty too
-    let empty_proposal_2 =
-        block_on(proposal_generator.generate_proposal(44, minute_from_now())).unwrap();
+    let empty_proposal_2 = runtime
+        .block_on(proposal_generator.generate_proposal(44, minute_from_now()))
+        .unwrap();
     assert!(empty_proposal_2.payload().unwrap().is_empty());
     // if reconfiguration is committed, not allow to generate proposal
     let a4 = inserter.create_block_with_qc(
@@ -161,6 +175,7 @@ fn test_empty_proposal_after_reconfiguration() {
         Some(a2.block_info()),
     );
     block_store.insert_single_quorum_cert(li).unwrap();
-    let err_proposal = block_on(proposal_generator.generate_proposal(45, minute_from_now()));
+    let err_proposal =
+        runtime.block_on(proposal_generator.generate_proposal(45, minute_from_now()));
     assert!(err_proposal.is_err());
 }

--- a/consensus/src/chained_bft/mod.rs
+++ b/consensus/src/chained_bft/mod.rs
@@ -23,5 +23,5 @@ mod liveness;
 
 mod event_processor;
 
-#[cfg(feature = "fuzzing")]
+#[cfg(any(test, feature = "fuzzing"))]
 pub use event_processor::event_processor_fuzzing;


### PR DESCRIPTION
Consensus is built on the Tokio executor for futures, but currently uses `futures::executor` all over the place. This was discovered by trying to improve the test timeout behavior and realizing that the futures were not executing in a Tokio runtime.

This PR does the following:
- Changes tests using `futures::executor::block_on` to use `tokio::runtime::Runtime::block_on` instead.
- Uses `async` blocks instead of `async move` blocks, as the `Runtime` must be dropped from outside a future as it calls block_on in the drop logic. The `async move` was moving the `Runtime` inside the block, which was then dropped inside the block, causing a panic for invoking runtime functions inside a runtime (similar to a double borrow).
- Removes the crash handler, which force exited the process on panic, which is not the behavior the test harness is designed for.
- Replaces the timeout panic with `tokio::time::timeout` for more graceful timeout handling.

This PR does not remove all instances of `futures::executor`, but that should be done eventually.