### PR TITLE
[client] Added a smoke test for changing publishing option

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -667,6 +667,7 @@ dependencies = [
  "rustyline 6.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.105 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.48 (registry+https://github.com/rust-lang/crates.io-index)",
+ "stdlib 0.1.0",
  "structopt 0.3.12 (registry+https://github.com/rust-lang/crates.io-index)",
  "tonic 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "transaction-builder 0.1.0",

--- a/client/cli/Cargo.toml
+++ b/client/cli/Cargo.toml
@@ -38,6 +38,7 @@ libra-logger =  { path = "../../common/logger", version = "0.1.0" }
 libra-metrics = { path = "../../common/metrics", version = "0.1.0" }
 libra-types = { path = "../../types", version = "0.1.0" }
 libra-temppath = { path = "../../common/temppath/", version = "0.1.0" }
+stdlib = { path = "../../language/stdlib", version = "0.1.0" }
 transaction-builder = { path = "../../language/transaction-builder", version = "0.1.0" }
 
 [dev-dependencies]

--- a/client/cli/src/client_proxy.rs
+++ b/client/cli/src/client_proxy.rs
@@ -332,7 +332,7 @@ impl ClientProxy {
     }
 
     /// Allow executing arbitrary script in the network.
-    pub fn allow_custom_script(
+    pub fn enable_custom_script(
         &mut self,
         space_delim_strings: &[&str],
         is_blocking: bool,
@@ -352,8 +352,8 @@ impl ClientProxy {
         }
     }
 
-    /// Only allow executing predefined script in the network.
-    pub fn disallow_custom_script(
+    /// Only allow executing predefined script in the move standard library in the network.
+    pub fn disable_custom_script(
         &mut self,
         space_delim_strings: &[&str],
         is_blocking: bool,
@@ -478,7 +478,6 @@ impl ClientProxy {
                 }
                 Err(e) => {
                     println!("Response with error: {:?}", e);
-                    break;
                 }
                 _ => {
                     print!(".");

--- a/client/cli/src/dev_commands.rs
+++ b/client/cli/src/dev_commands.rs
@@ -115,6 +115,60 @@ impl Command for DevCommandExecute {
     }
 }
 
+pub struct DevCommandAllowCustomScript {}
+
+impl Command for DevCommandAllowCustomScript {
+    fn get_aliases(&self) -> Vec<&'static str> {
+        vec!["allow_custom_script"]
+    }
+
+    fn get_params_help(&self) -> &'static str {
+        ""
+    }
+
+    fn get_description(&self) -> &'static str {
+        "Allow executing arbitrary script in the network."
+    }
+
+    fn execute(&self, client: &mut ClientProxy, params: &[&str]) {
+        if params.len() != 1 {
+            println!("Invalid number of arguments");
+            return;
+        }
+        match client.allow_custom_script(params, true) {
+            Ok(_) => println!("Successfully finished execution"),
+            Err(e) => println!("{}", e),
+        }
+    }
+}
+
+pub struct DevCommandDisallowCustomScript {}
+
+impl Command for DevCommandDisallowCustomScript {
+    fn get_aliases(&self) -> Vec<&'static str> {
+        vec!["disallow_custom_script"]
+    }
+
+    fn get_params_help(&self) -> &'static str {
+        ""
+    }
+
+    fn get_description(&self) -> &'static str {
+        "Only allow executing predefined script in the network."
+    }
+
+    fn execute(&self, client: &mut ClientProxy, params: &[&str]) {
+        if params.len() != 1 {
+            println!("Invalid number of arguments");
+            return;
+        }
+        match client.disallow_custom_script(params, true) {
+            Ok(_) => println!("Successfully finished execution"),
+            Err(e) => println!("{}", e),
+        }
+    }
+}
+
 pub struct DevCommandAddValidator {}
 
 impl Command for DevCommandAddValidator {

--- a/client/cli/src/dev_commands.rs
+++ b/client/cli/src/dev_commands.rs
@@ -135,7 +135,7 @@ impl Command for DevCommandAllowCustomScript {
             println!("Invalid number of arguments");
             return;
         }
-        match client.allow_custom_script(params, true) {
+        match client.enable_custom_script(params, true) {
             Ok(_) => println!("Successfully finished execution"),
             Err(e) => println!("{}", e),
         }
@@ -162,7 +162,7 @@ impl Command for DevCommandDisallowCustomScript {
             println!("Invalid number of arguments");
             return;
         }
-        match client.disallow_custom_script(params, true) {
+        match client.disable_custom_script(params, true) {
             Ok(_) => println!("Successfully finished execution"),
             Err(e) => println!("{}", e),
         }

--- a/client/cli/src/dev_commands.rs
+++ b/client/cli/src/dev_commands.rs
@@ -115,11 +115,11 @@ impl Command for DevCommandExecute {
     }
 }
 
-pub struct DevCommandAllowCustomScript {}
+pub struct DevCommandEnableCustomScript {}
 
-impl Command for DevCommandAllowCustomScript {
+impl Command for DevCommandEnableCustomScript {
     fn get_aliases(&self) -> Vec<&'static str> {
-        vec!["allow_custom_script"]
+        vec!["enable_custom_script"]
     }
 
     fn get_params_help(&self) -> &'static str {
@@ -142,11 +142,11 @@ impl Command for DevCommandAllowCustomScript {
     }
 }
 
-pub struct DevCommandDisallowCustomScript {}
+pub struct DevCommandDisableCustomScript {}
 
-impl Command for DevCommandDisallowCustomScript {
+impl Command for DevCommandDisableCustomScript {
     fn get_aliases(&self) -> Vec<&'static str> {
-        vec!["disallow_custom_script"]
+        vec!["disable_custom_script"]
     }
 
     fn get_params_help(&self) -> &'static str {
@@ -154,7 +154,7 @@ impl Command for DevCommandDisallowCustomScript {
     }
 
     fn get_description(&self) -> &'static str {
-        "Only allow executing predefined script in the network."
+        "Only allow executing predefined stdlib script in the network."
     }
 
     fn execute(&self, client: &mut ClientProxy, params: &[&str]) {

--- a/testsuite/tests/libratest/smoke_test.rs
+++ b/testsuite/tests/libratest/smoke_test.rs
@@ -931,6 +931,72 @@ fn test_e2e_reconfiguration() {
 }
 
 #[test]
+fn test_e2e_modify_publishing_option() {
+    let (mut env, mut client_proxy) = setup_swarm_and_client_proxy(1, 0);
+    client_proxy.create_next_account(false).unwrap();
+
+    client_proxy
+        .mint_coins(&["mintb", "0", "10"], true)
+        .unwrap();
+    assert_eq!(
+        Decimal::from_f64(10.0),
+        Decimal::from_str(&client_proxy.get_balance(&["b", "0"]).unwrap()).ok()
+    );
+    let script_path = workspace_builder::workspace_root()
+        .join("testsuite/tests/libratest/dev_modules/test_script.mvir");
+    let unwrapped_script_path = script_path.to_str().unwrap();
+    let script_params = &["execute", "0", unwrapped_script_path, "script"];
+    let script_compiled_path = client_proxy.compile_program(script_params).unwrap();
+
+    // Initially publishing option was set to CustomScript, this transaction should be executed.
+    client_proxy
+        .execute_script(&["execute", "0", &script_compiled_path[..], "10", "0x0"])
+        .unwrap();
+
+    assert_eq!(
+        client_proxy
+            .get_sequence_number(&["sequence", "0", "true"])
+            .unwrap(),
+        1
+    );
+
+    client_proxy
+        .disallow_custom_script(&["disallow_custom_script"], true)
+        .unwrap();
+
+    // TODO: Currently VMValidator didn't restart after reconfiguration. We will manually restart
+    //       the node so that VMValidator is using the new config.
+    let peer_to_restart = 0;
+    // restart node
+    env.validator_swarm.kill_node(peer_to_restart);
+    assert!(env
+        .validator_swarm
+        .add_node(peer_to_restart, RoleType::Validator, false)
+        .is_ok());
+
+    // mint another 10 coins after remove node 0
+    client_proxy
+        .mint_coins(&["mintb", "0", "10"], true)
+        .unwrap();
+    assert_eq!(
+        Decimal::from_f64(20.0),
+        Decimal::from_str(&client_proxy.get_balance(&["b", "0"]).unwrap()).ok()
+    );
+
+    // Now that publishing option was changed to locked, this transaction will be rejected.
+    client_proxy
+        .execute_script(&["execute", "0", &script_compiled_path[..], "10", "0x0"])
+        .unwrap_err();
+
+    assert_eq!(
+        client_proxy
+            .get_sequence_number(&["sequence", "0", "true"])
+            .unwrap(),
+        1
+    );
+}
+
+#[test]
 fn test_client_waypoints() {
     let (env, mut client_proxy) = setup_swarm_and_client_proxy(3, 1);
     // Make sure some txns are committed


### PR DESCRIPTION
<!--
Thank you for sending a PR. We appreciate you spending time to help improve the Libra project.

The project is undergoing daily changes. Pull Requests will be reviewed and responded to as time permits.
-->

## Motivation
Added a bunch of helper functions in client to generate transaction to change VMPublishingOption.

Added a smoke test for changing publishing option. Currently VMValidator didn't restart on epoch change, thus we need to manually restart the node to have a new VMValidator instance with the new modified config.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

## Related PRs

#2932 