### PR TITLE
[LCS] faster serialization of maps

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2250,6 +2250,7 @@ dependencies = [
 name = "libra-canonical-serialization"
 version = "0.1.0"
 dependencies = [
+ "criterion 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "proptest 0.9.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "proptest-derive 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.105 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/common/lcs/Cargo.toml
+++ b/common/lcs/Cargo.toml
@@ -14,5 +14,10 @@ thiserror = "1.0"
 serde = { version = "1.0", features = ["derive"] }
 
 [dev-dependencies]
+criterion = "=0.3.1"
 proptest = "0.9"
 proptest-derive = "0.1.1"
+
+[[bench]]
+name = "lcs_bench"
+harness = false

--- a/common/lcs/benches/lcs_bench.rs
+++ b/common/lcs/benches/lcs_bench.rs
@@ -1,0 +1,28 @@
+// Copyright (c) The Libra Core Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+use criterion::{criterion_group, criterion_main, Criterion};
+use libra_canonical_serialization::to_bytes;
+use std::collections::{BTreeMap, HashMap};
+
+pub fn lcs_benchmark(c: &mut Criterion) {
+    let mut btree_map = BTreeMap::new();
+    let mut hash_map = HashMap::new();
+    for i in 0u32..2000u32 {
+        btree_map.insert(i, i);
+        hash_map.insert(i, i);
+    }
+    c.bench_function("serialize btree map", |b| {
+        b.iter(|| {
+            to_bytes(&btree_map).unwrap();
+        })
+    });
+    c.bench_function("serialize hash map", |b| {
+        b.iter(|| {
+            to_bytes(&hash_map).unwrap();
+        })
+    });
+}
+
+criterion_group!(benches, lcs_benchmark);
+criterion_main!(benches);


### PR DESCRIPTION
## Motivation

Inserting N times in a BTreeMap to sort a list of entries does not feel quite right. Let's simply sort of vector instead.

I also compared stable sort v.s. unstable sort. Picking the stable sort because it delivers a better win (-20% time) in the case of `BTreeMap` -- which I expect is our main use case in practice.

## Test Plan

```
$ cargo bench -p libra-canonical-serialization
...
     Running target/release/deps/lcs_bench-5cda580006e59e2b
serialize btree map     time:   [624.22 us 628.37 us 632.84 us]                                
                        change: [-22.655% -21.284% -20.011%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 1 outliers among 100 measurements (1.00%)
  1 (1.00%) high mild

serialize hash map      time:   [708.39 us 715.67 us 724.93 us]                               
                        change: [-16.926% -15.328% -13.683%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 10 outliers among 100 measurements (10.00%)
  2 (2.00%) high mild
  8 (8.00%) high severe
```
