### PR TITLE
[docker] Add yet another param to docker run script

### DIFF
--- a/docker/safety-rules/docker-run-dynamic.sh
+++ b/docker/safety-rules/docker-run-dynamic.sh
@@ -29,6 +29,9 @@ fi
 if [ -n "${CFG_SAFETY_RULES_TOKEN}" ]; then
     params+="--safety-rules-token ${CFG_SAFETY_RULES_TOKEN} "
 fi
+if [ -n "${CFG_SAFETY_RULES_NAMESPACE}" ]; then
+    params+="--safety-rules-namespace ${CFG_SAFETY_RULES_NAMESPACE} "
+fi
 
 /opt/libra/bin/config-builder safety-rules \
     --data-dir /opt/libra/data/common \


### PR DESCRIPTION
## Motivation

`config-builder safety-rules` doesn't support a template (#3136) so everything needs to be passed through explicitly.

## Test Plan

*eyes*