### PR TITLE
[move-prover] Made stubs for unimplemented procedures in prelude safer

### DIFF
--- a/language/move-prover/src/prelude.bpl
+++ b/language/move-prover/src/prelude.bpl
@@ -932,12 +932,12 @@ procedure {:inline 1} $Vector_set(ta: TypeValue, src: Reference, i: Value, e: Va
 
 procedure {:inline 1} $Vector_contains(ta: TypeValue, vr: Reference, er: Reference) returns (res: Value)  {
     res := DefaultValue;
-    $abort_flag := true;
+    assert false; // $Vector_contains not implemented
 }
 
 procedure {:inline 1} $Vector_swap_remove(ta: TypeValue, vr: Reference, idx: Value) returns (res: Value)  {
     res := DefaultValue;
-    $abort_flag := true;
+    assert false; // $Vector_swap_remove not implemented
 }
 
 // ==================================================================================
@@ -947,7 +947,7 @@ procedure {:inline 1} $Vector_swap_remove(ta: TypeValue, vr: Reference, idx: Val
 
 procedure {:inline 1} $AddressUtil_address_to_bytes(addr: Value) returns (res: Value)  {
     res := DefaultValue;
-    $abort_flag := true;
+    assert false; // $AddressUtil_address_to_bytes not implemented
 }
 
 // ==================================================================================
@@ -957,7 +957,7 @@ procedure {:inline 1} $AddressUtil_address_to_bytes(addr: Value) returns (res: V
 
 procedure {:inline 1} $U64Util_u64_to_bytes(val: Value) returns (res: Value)  {
     res := DefaultValue;
-    $abort_flag := true;
+    assert false; // $U64Util_u64_to_bytes not implemented
 }
 
 // ==================================================================================
@@ -967,12 +967,12 @@ procedure {:inline 1} $U64Util_u64_to_bytes(val: Value) returns (res: Value)  {
 
 procedure {:inline 1} $Hash_sha2_256(val: Value) returns (res: Value)  {
     res := DefaultValue;
-    $abort_flag := true;
+    assert false; // $Hash_sha2_256 not implemented
 }
 
 procedure {:inline 1} $Hash_sha3_256(val: Value) returns (res: Value)  {
     res := DefaultValue;
-    $abort_flag := true;
+    assert false; // $Hash_sha3_256 not implemented
 }
 
 // ==================================================================================
@@ -981,9 +981,9 @@ procedure {:inline 1} $Hash_sha3_256(val: Value) returns (res: Value)  {
 // TODO: implement the below methods
 
 procedure {:inline 1} $LibraAccount_save_account(balance: Value, account: Value, addr: Value) {
-    $abort_flag := true;
+    assert false; // $LibraAccount_save_account
 }
 
 procedure {:inline 1} $LibraAccount_write_to_event_store(ta: TypeValue, guid: Value, count: Value, msg: Value) {
-    $abort_flag := true;
+    assert false; // $LibraAccount_write_to_event_store not implemented
 }

--- a/language/move-prover/tests/sources/stdlib/modules/libra_account.exp
+++ b/language/move-prover/tests/sources/stdlib/modules/libra_account.exp
@@ -1,1 +1,203 @@
-Move prover all good, no errors!
+Move prover returns: exiting with boogie verification errors
+bug:  This assertion might not hold.
+
+     ┌── /var/folders/85/dnj3wv151rqgv2jby442x5pm0000gn/T/a949499739cfcafd819475ee3552bdb1/libra_account.bpl:991:6 ───
+     │
+ 991 │     assert false; // $LibraAccount_write_to_event_store not implemented
+     │      ^
+     │
+     =     at /var/folders/85/dnj3wv151rqgv2jby442x5pm0000gn/T/a949499739cfcafd819475ee3552bdb1/libra_account.bpl:3412:24: <boogie>: inline$$LibraAccount_deposit$0$Entry
+     =     at /var/folders/85/dnj3wv151rqgv2jby442x5pm0000gn/T/a949499739cfcafd819475ee3552bdb1/libra_account.bpl:3450:6: <boogie>: inline$$LibraAccount_deposit$0$anon11_Else
+     =     at /var/folders/85/dnj3wv151rqgv2jby442x5pm0000gn/T/a949499739cfcafd819475ee3552bdb1/libra_account.bpl:4176:24: <boogie>: inline$$LibraAccount_deposit_with_metadata$0$Entry
+     =     at /var/folders/85/dnj3wv151rqgv2jby442x5pm0000gn/T/a949499739cfcafd819475ee3552bdb1/libra_account.bpl:4245:24: <boogie>: inline$$LibraAccount_deposit_with_sender_and_metadata$0$Entry
+     =     at /var/folders/85/dnj3wv151rqgv2jby442x5pm0000gn/T/a949499739cfcafd819475ee3552bdb1/libra_account.bpl:2629:24: <boogie>: inline$$LibraCoin_value$0$Entry
+     =     at /var/folders/85/dnj3wv151rqgv2jby442x5pm0000gn/T/a949499739cfcafd819475ee3552bdb1/libra_account.bpl:2629:24: <boogie>: inline$$LibraCoin_value$0$Return
+     =     at /var/folders/85/dnj3wv151rqgv2jby442x5pm0000gn/T/a949499739cfcafd819475ee3552bdb1/libra_account.bpl:4317:6: <boogie>: inline$$LibraAccount_deposit_with_sender_and_metadata$0$anon59_Else
+     =     at /var/folders/85/dnj3wv151rqgv2jby442x5pm0000gn/T/a949499739cfcafd819475ee3552bdb1/libra_account.bpl:4331:6: <boogie>: inline$$LibraAccount_deposit_with_sender_and_metadata$0$anon12$1
+     =     at /var/folders/85/dnj3wv151rqgv2jby442x5pm0000gn/T/a949499739cfcafd819475ee3552bdb1/libra_account.bpl:4379:6: <boogie>: inline$$LibraAccount_deposit_with_sender_and_metadata$0$anon64_Else
+     =     at /var/folders/85/dnj3wv151rqgv2jby442x5pm0000gn/T/a949499739cfcafd819475ee3552bdb1/libra_account.bpl:4389:6: <boogie>: inline$$LibraAccount_deposit_with_sender_and_metadata$0$anon22$2
+     =     at /var/folders/85/dnj3wv151rqgv2jby442x5pm0000gn/T/a949499739cfcafd819475ee3552bdb1/libra_account.bpl:4581:24: <boogie>: inline$$LibraAccount_emit_event$0$Entry
+     =     at /var/folders/85/dnj3wv151rqgv2jby442x5pm0000gn/T/a949499739cfcafd819475ee3552bdb1/libra_account.bpl:4635:18: <boogie>: inline$$LibraAccount_emit_event$0$anon15_Then
+     =     at /var/folders/85/dnj3wv151rqgv2jby442x5pm0000gn/T/a949499739cfcafd819475ee3552bdb1/libra_account.bpl:4638:6: <boogie>: inline$$LibraAccount_emit_event$0$anon6$1
+
+bug:  This assertion might not hold.
+
+     ┌── /var/folders/85/dnj3wv151rqgv2jby442x5pm0000gn/T/a949499739cfcafd819475ee3552bdb1/libra_account.bpl:953:6 ───
+     │
+ 953 │     assert false; // $AddressUtil_address_to_bytes not implemented
+     │      ^
+     │
+     =     at /var/folders/85/dnj3wv151rqgv2jby442x5pm0000gn/T/a949499739cfcafd819475ee3552bdb1/libra_account.bpl:3667:24: <boogie>: inline$$LibraAccount_create_account$0$Entry
+     =     at /var/folders/85/dnj3wv151rqgv2jby442x5pm0000gn/T/a949499739cfcafd819475ee3552bdb1/libra_account.bpl:3734:18: <boogie>: inline$$LibraAccount_create_account$0$anon31_Then
+     =     at /var/folders/85/dnj3wv151rqgv2jby442x5pm0000gn/T/a949499739cfcafd819475ee3552bdb1/libra_account.bpl:3737:6: <boogie>: inline$$LibraAccount_create_account$0$anon6$1
+     =     at /var/folders/85/dnj3wv151rqgv2jby442x5pm0000gn/T/a949499739cfcafd819475ee3552bdb1/libra_account.bpl:3746:6: <boogie>: inline$$LibraAccount_create_account$0$anon8$1
+
+bug:  This assertion might not hold.
+
+     ┌── /var/folders/85/dnj3wv151rqgv2jby442x5pm0000gn/T/a949499739cfcafd819475ee3552bdb1/libra_account.bpl:953:6 ───
+     │
+ 953 │     assert false; // $AddressUtil_address_to_bytes not implemented
+     │      ^
+     │
+     =     at /var/folders/85/dnj3wv151rqgv2jby442x5pm0000gn/T/a949499739cfcafd819475ee3552bdb1/libra_account.bpl:3924:24: <boogie>: inline$$LibraAccount_create_new_account$0$Entry
+     =     at /var/folders/85/dnj3wv151rqgv2jby442x5pm0000gn/T/a949499739cfcafd819475ee3552bdb1/libra_account.bpl:3667:24: <boogie>: inline$$LibraAccount_create_account$0$Entry
+     =     at /var/folders/85/dnj3wv151rqgv2jby442x5pm0000gn/T/a949499739cfcafd819475ee3552bdb1/libra_account.bpl:3734:18: <boogie>: inline$$LibraAccount_create_account$0$anon31_Then
+     =     at /var/folders/85/dnj3wv151rqgv2jby442x5pm0000gn/T/a949499739cfcafd819475ee3552bdb1/libra_account.bpl:3737:6: <boogie>: inline$$LibraAccount_create_account$0$anon6$1
+     =     at /var/folders/85/dnj3wv151rqgv2jby442x5pm0000gn/T/a949499739cfcafd819475ee3552bdb1/libra_account.bpl:3746:6: <boogie>: inline$$LibraAccount_create_account$0$anon8$1
+
+bug:  This assertion might not hold.
+
+     ┌── /var/folders/85/dnj3wv151rqgv2jby442x5pm0000gn/T/a949499739cfcafd819475ee3552bdb1/libra_account.bpl:991:6 ───
+     │
+ 991 │     assert false; // $LibraAccount_write_to_event_store not implemented
+     │      ^
+     │
+     =     at /var/folders/85/dnj3wv151rqgv2jby442x5pm0000gn/T/a949499739cfcafd819475ee3552bdb1/libra_account.bpl:4176:24: <boogie>: inline$$LibraAccount_deposit_with_metadata$0$Entry
+     =     at /var/folders/85/dnj3wv151rqgv2jby442x5pm0000gn/T/a949499739cfcafd819475ee3552bdb1/libra_account.bpl:4245:24: <boogie>: inline$$LibraAccount_deposit_with_sender_and_metadata$0$Entry
+     =     at /var/folders/85/dnj3wv151rqgv2jby442x5pm0000gn/T/a949499739cfcafd819475ee3552bdb1/libra_account.bpl:2629:24: <boogie>: inline$$LibraCoin_value$0$Entry
+     =     at /var/folders/85/dnj3wv151rqgv2jby442x5pm0000gn/T/a949499739cfcafd819475ee3552bdb1/libra_account.bpl:2629:24: <boogie>: inline$$LibraCoin_value$0$Return
+     =     at /var/folders/85/dnj3wv151rqgv2jby442x5pm0000gn/T/a949499739cfcafd819475ee3552bdb1/libra_account.bpl:4317:6: <boogie>: inline$$LibraAccount_deposit_with_sender_and_metadata$0$anon59_Else
+     =     at /var/folders/85/dnj3wv151rqgv2jby442x5pm0000gn/T/a949499739cfcafd819475ee3552bdb1/libra_account.bpl:4331:6: <boogie>: inline$$LibraAccount_deposit_with_sender_and_metadata$0$anon12$1
+     =     at /var/folders/85/dnj3wv151rqgv2jby442x5pm0000gn/T/a949499739cfcafd819475ee3552bdb1/libra_account.bpl:4379:6: <boogie>: inline$$LibraAccount_deposit_with_sender_and_metadata$0$anon64_Else
+     =     at /var/folders/85/dnj3wv151rqgv2jby442x5pm0000gn/T/a949499739cfcafd819475ee3552bdb1/libra_account.bpl:4389:6: <boogie>: inline$$LibraAccount_deposit_with_sender_and_metadata$0$anon22$2
+     =     at /var/folders/85/dnj3wv151rqgv2jby442x5pm0000gn/T/a949499739cfcafd819475ee3552bdb1/libra_account.bpl:4581:24: <boogie>: inline$$LibraAccount_emit_event$0$Entry
+     =     at /var/folders/85/dnj3wv151rqgv2jby442x5pm0000gn/T/a949499739cfcafd819475ee3552bdb1/libra_account.bpl:4635:18: <boogie>: inline$$LibraAccount_emit_event$0$anon15_Then
+     =     at /var/folders/85/dnj3wv151rqgv2jby442x5pm0000gn/T/a949499739cfcafd819475ee3552bdb1/libra_account.bpl:4638:6: <boogie>: inline$$LibraAccount_emit_event$0$anon6$1
+
+bug:  This assertion might not hold.
+
+     ┌── /var/folders/85/dnj3wv151rqgv2jby442x5pm0000gn/T/a949499739cfcafd819475ee3552bdb1/libra_account.bpl:991:6 ───
+     │
+ 991 │     assert false; // $LibraAccount_write_to_event_store not implemented
+     │      ^
+     │
+     =     at /var/folders/85/dnj3wv151rqgv2jby442x5pm0000gn/T/a949499739cfcafd819475ee3552bdb1/libra_account.bpl:4245:24: <boogie>: inline$$LibraAccount_deposit_with_sender_and_metadata$0$Entry
+     =     at /var/folders/85/dnj3wv151rqgv2jby442x5pm0000gn/T/a949499739cfcafd819475ee3552bdb1/libra_account.bpl:2629:24: <boogie>: inline$$LibraCoin_value$0$Entry
+     =     at /var/folders/85/dnj3wv151rqgv2jby442x5pm0000gn/T/a949499739cfcafd819475ee3552bdb1/libra_account.bpl:2629:24: <boogie>: inline$$LibraCoin_value$0$Return
+     =     at /var/folders/85/dnj3wv151rqgv2jby442x5pm0000gn/T/a949499739cfcafd819475ee3552bdb1/libra_account.bpl:4317:6: <boogie>: inline$$LibraAccount_deposit_with_sender_and_metadata$0$anon59_Else
+     =     at /var/folders/85/dnj3wv151rqgv2jby442x5pm0000gn/T/a949499739cfcafd819475ee3552bdb1/libra_account.bpl:4331:6: <boogie>: inline$$LibraAccount_deposit_with_sender_and_metadata$0$anon12$1
+     =     at /var/folders/85/dnj3wv151rqgv2jby442x5pm0000gn/T/a949499739cfcafd819475ee3552bdb1/libra_account.bpl:4379:6: <boogie>: inline$$LibraAccount_deposit_with_sender_and_metadata$0$anon64_Else
+     =     at /var/folders/85/dnj3wv151rqgv2jby442x5pm0000gn/T/a949499739cfcafd819475ee3552bdb1/libra_account.bpl:4389:6: <boogie>: inline$$LibraAccount_deposit_with_sender_and_metadata$0$anon22$2
+     =     at /var/folders/85/dnj3wv151rqgv2jby442x5pm0000gn/T/a949499739cfcafd819475ee3552bdb1/libra_account.bpl:4581:24: <boogie>: inline$$LibraAccount_emit_event$0$Entry
+     =     at /var/folders/85/dnj3wv151rqgv2jby442x5pm0000gn/T/a949499739cfcafd819475ee3552bdb1/libra_account.bpl:4635:18: <boogie>: inline$$LibraAccount_emit_event$0$anon15_Then
+     =     at /var/folders/85/dnj3wv151rqgv2jby442x5pm0000gn/T/a949499739cfcafd819475ee3552bdb1/libra_account.bpl:4638:6: <boogie>: inline$$LibraAccount_emit_event$0$anon6$1
+
+bug:  This assertion might not hold.
+
+     ┌── /var/folders/85/dnj3wv151rqgv2jby442x5pm0000gn/T/a949499739cfcafd819475ee3552bdb1/libra_account.bpl:991:6 ───
+     │
+ 991 │     assert false; // $LibraAccount_write_to_event_store not implemented
+     │      ^
+     │
+     =     at /var/folders/85/dnj3wv151rqgv2jby442x5pm0000gn/T/a949499739cfcafd819475ee3552bdb1/libra_account.bpl:4581:24: <boogie>: inline$$LibraAccount_emit_event$0$Entry
+     =     at /var/folders/85/dnj3wv151rqgv2jby442x5pm0000gn/T/a949499739cfcafd819475ee3552bdb1/libra_account.bpl:4635:18: <boogie>: inline$$LibraAccount_emit_event$0$anon15_Then
+     =     at /var/folders/85/dnj3wv151rqgv2jby442x5pm0000gn/T/a949499739cfcafd819475ee3552bdb1/libra_account.bpl:4638:6: <boogie>: inline$$LibraAccount_emit_event$0$anon6$1
+
+bug:  This assertion might not hold.
+
+     ┌── /var/folders/85/dnj3wv151rqgv2jby442x5pm0000gn/T/a949499739cfcafd819475ee3552bdb1/libra_account.bpl:953:6 ───
+     │
+ 953 │     assert false; // $AddressUtil_address_to_bytes not implemented
+     │      ^
+     │
+     =     at /var/folders/85/dnj3wv151rqgv2jby442x5pm0000gn/T/a949499739cfcafd819475ee3552bdb1/libra_account.bpl:5334:24: <boogie>: inline$$LibraAccount_fresh_guid$0$Entry
+
+bug:  This assertion might not hold.
+
+     ┌── /var/folders/85/dnj3wv151rqgv2jby442x5pm0000gn/T/a949499739cfcafd819475ee3552bdb1/libra_account.bpl:953:6 ───
+     │
+ 953 │     assert false; // $AddressUtil_address_to_bytes not implemented
+     │      ^
+     │
+     =     at /var/folders/85/dnj3wv151rqgv2jby442x5pm0000gn/T/a949499739cfcafd819475ee3552bdb1/libra_account.bpl:5543:24: <boogie>: inline$$LibraAccount_mint_to_address$0$Entry
+     =     at /var/folders/85/dnj3wv151rqgv2jby442x5pm0000gn/T/a949499739cfcafd819475ee3552bdb1/libra_account.bpl:3363:24: <boogie>: inline$$LibraAccount_exists$0$Entry
+     =     at /var/folders/85/dnj3wv151rqgv2jby442x5pm0000gn/T/a949499739cfcafd819475ee3552bdb1/libra_account.bpl:5585:6: <boogie>: inline$$LibraAccount_mint_to_address$0$anon19_Else
+     =     at /var/folders/85/dnj3wv151rqgv2jby442x5pm0000gn/T/a949499739cfcafd819475ee3552bdb1/libra_account.bpl:3667:24: <boogie>: inline$$LibraAccount_create_account$0$Entry
+     =     at /var/folders/85/dnj3wv151rqgv2jby442x5pm0000gn/T/a949499739cfcafd819475ee3552bdb1/libra_account.bpl:3734:18: <boogie>: inline$$LibraAccount_create_account$0$anon31_Then
+     =     at /var/folders/85/dnj3wv151rqgv2jby442x5pm0000gn/T/a949499739cfcafd819475ee3552bdb1/libra_account.bpl:3737:6: <boogie>: inline$$LibraAccount_create_account$0$anon6$1
+     =     at /var/folders/85/dnj3wv151rqgv2jby442x5pm0000gn/T/a949499739cfcafd819475ee3552bdb1/libra_account.bpl:3746:6: <boogie>: inline$$LibraAccount_create_account$0$anon8$1
+
+bug:  This assertion might not hold.
+
+     ┌── /var/folders/85/dnj3wv151rqgv2jby442x5pm0000gn/T/a949499739cfcafd819475ee3552bdb1/libra_account.bpl:953:6 ───
+     │
+ 953 │     assert false; // $AddressUtil_address_to_bytes not implemented
+     │      ^
+     │
+     =     at /var/folders/85/dnj3wv151rqgv2jby442x5pm0000gn/T/a949499739cfcafd819475ee3552bdb1/libra_account.bpl:5660:24: <boogie>: inline$$LibraAccount_new_event_handle$0$Entry
+     =     at /var/folders/85/dnj3wv151rqgv2jby442x5pm0000gn/T/a949499739cfcafd819475ee3552bdb1/libra_account.bpl:5693:6: <boogie>: inline$$LibraAccount_new_event_handle$0$anon9_Else
+     =     at /var/folders/85/dnj3wv151rqgv2jby442x5pm0000gn/T/a949499739cfcafd819475ee3552bdb1/libra_account.bpl:5703:6: <boogie>: inline$$LibraAccount_new_event_handle$0$anon4$2
+     =     at /var/folders/85/dnj3wv151rqgv2jby442x5pm0000gn/T/a949499739cfcafd819475ee3552bdb1/libra_account.bpl:5742:24: <boogie>: inline$$LibraAccount_new_event_handle_impl$0$Entry
+     =     at /var/folders/85/dnj3wv151rqgv2jby442x5pm0000gn/T/a949499739cfcafd819475ee3552bdb1/libra_account.bpl:5334:24: <boogie>: inline$$LibraAccount_fresh_guid$0$Entry
+
+bug:  This assertion might not hold.
+
+     ┌── /var/folders/85/dnj3wv151rqgv2jby442x5pm0000gn/T/a949499739cfcafd819475ee3552bdb1/libra_account.bpl:953:6 ───
+     │
+ 953 │     assert false; // $AddressUtil_address_to_bytes not implemented
+     │      ^
+     │
+     =     at /var/folders/85/dnj3wv151rqgv2jby442x5pm0000gn/T/a949499739cfcafd819475ee3552bdb1/libra_account.bpl:5742:24: <boogie>: inline$$LibraAccount_new_event_handle_impl$0$Entry
+     =     at /var/folders/85/dnj3wv151rqgv2jby442x5pm0000gn/T/a949499739cfcafd819475ee3552bdb1/libra_account.bpl:5334:24: <boogie>: inline$$LibraAccount_fresh_guid$0$Entry
+
+bug:  This assertion might not hold.
+
+     ┌── /var/folders/85/dnj3wv151rqgv2jby442x5pm0000gn/T/a949499739cfcafd819475ee3552bdb1/libra_account.bpl:953:6 ───
+     │
+ 953 │     assert false; // $AddressUtil_address_to_bytes not implemented
+     │      ^
+     │
+     =     at /var/folders/85/dnj3wv151rqgv2jby442x5pm0000gn/T/a949499739cfcafd819475ee3552bdb1/libra_account.bpl:5814:24: <boogie>: inline$$LibraAccount_pay_from_capability$0$Entry
+     =     at /var/folders/85/dnj3wv151rqgv2jby442x5pm0000gn/T/a949499739cfcafd819475ee3552bdb1/libra_account.bpl:3363:24: <boogie>: inline$$LibraAccount_exists$0$Entry
+     =     at /var/folders/85/dnj3wv151rqgv2jby442x5pm0000gn/T/a949499739cfcafd819475ee3552bdb1/libra_account.bpl:5866:6: <boogie>: inline$$LibraAccount_pay_from_capability$0$anon25_Else
+     =     at /var/folders/85/dnj3wv151rqgv2jby442x5pm0000gn/T/a949499739cfcafd819475ee3552bdb1/libra_account.bpl:3667:24: <boogie>: inline$$LibraAccount_create_account$0$Entry
+     =     at /var/folders/85/dnj3wv151rqgv2jby442x5pm0000gn/T/a949499739cfcafd819475ee3552bdb1/libra_account.bpl:3734:18: <boogie>: inline$$LibraAccount_create_account$0$anon31_Then
+     =     at /var/folders/85/dnj3wv151rqgv2jby442x5pm0000gn/T/a949499739cfcafd819475ee3552bdb1/libra_account.bpl:3737:6: <boogie>: inline$$LibraAccount_create_account$0$anon6$1
+     =     at /var/folders/85/dnj3wv151rqgv2jby442x5pm0000gn/T/a949499739cfcafd819475ee3552bdb1/libra_account.bpl:3746:6: <boogie>: inline$$LibraAccount_create_account$0$anon8$1
+
+bug:  This assertion might not hold.
+
+     ┌── /var/folders/85/dnj3wv151rqgv2jby442x5pm0000gn/T/a949499739cfcafd819475ee3552bdb1/libra_account.bpl:953:6 ───
+     │
+ 953 │     assert false; // $AddressUtil_address_to_bytes not implemented
+     │      ^
+     │
+     =     at /var/folders/85/dnj3wv151rqgv2jby442x5pm0000gn/T/a949499739cfcafd819475ee3552bdb1/libra_account.bpl:5960:24: <boogie>: inline$$LibraAccount_pay_from_sender$0$Entry
+     =     at /var/folders/85/dnj3wv151rqgv2jby442x5pm0000gn/T/a949499739cfcafd819475ee3552bdb1/libra_account.bpl:6006:6: <boogie>: inline$$LibraAccount_pay_from_sender$0$anon14_Else
+     =     at /var/folders/85/dnj3wv151rqgv2jby442x5pm0000gn/T/a949499739cfcafd819475ee3552bdb1/libra_account.bpl:6035:24: <boogie>: inline$$LibraAccount_pay_from_sender_with_metadata$0$Entry
+     =     at /var/folders/85/dnj3wv151rqgv2jby442x5pm0000gn/T/a949499739cfcafd819475ee3552bdb1/libra_account.bpl:3363:24: <boogie>: inline$$LibraAccount_exists$0$Entry
+     =     at /var/folders/85/dnj3wv151rqgv2jby442x5pm0000gn/T/a949499739cfcafd819475ee3552bdb1/libra_account.bpl:6081:6: <boogie>: inline$$LibraAccount_pay_from_sender_with_metadata$0$anon22_Else
+     =     at /var/folders/85/dnj3wv151rqgv2jby442x5pm0000gn/T/a949499739cfcafd819475ee3552bdb1/libra_account.bpl:3667:24: <boogie>: inline$$LibraAccount_create_account$0$Entry
+     =     at /var/folders/85/dnj3wv151rqgv2jby442x5pm0000gn/T/a949499739cfcafd819475ee3552bdb1/libra_account.bpl:3734:18: <boogie>: inline$$LibraAccount_create_account$0$anon31_Then
+     =     at /var/folders/85/dnj3wv151rqgv2jby442x5pm0000gn/T/a949499739cfcafd819475ee3552bdb1/libra_account.bpl:3737:6: <boogie>: inline$$LibraAccount_create_account$0$anon6$1
+     =     at /var/folders/85/dnj3wv151rqgv2jby442x5pm0000gn/T/a949499739cfcafd819475ee3552bdb1/libra_account.bpl:3746:6: <boogie>: inline$$LibraAccount_create_account$0$anon8$1
+
+bug:  This assertion might not hold.
+
+     ┌── /var/folders/85/dnj3wv151rqgv2jby442x5pm0000gn/T/a949499739cfcafd819475ee3552bdb1/libra_account.bpl:953:6 ───
+     │
+ 953 │     assert false; // $AddressUtil_address_to_bytes not implemented
+     │      ^
+     │
+     =     at /var/folders/85/dnj3wv151rqgv2jby442x5pm0000gn/T/a949499739cfcafd819475ee3552bdb1/libra_account.bpl:6035:24: <boogie>: inline$$LibraAccount_pay_from_sender_with_metadata$0$Entry
+     =     at /var/folders/85/dnj3wv151rqgv2jby442x5pm0000gn/T/a949499739cfcafd819475ee3552bdb1/libra_account.bpl:3363:24: <boogie>: inline$$LibraAccount_exists$0$Entry
+     =     at /var/folders/85/dnj3wv151rqgv2jby442x5pm0000gn/T/a949499739cfcafd819475ee3552bdb1/libra_account.bpl:6081:6: <boogie>: inline$$LibraAccount_pay_from_sender_with_metadata$0$anon22_Else
+     =     at /var/folders/85/dnj3wv151rqgv2jby442x5pm0000gn/T/a949499739cfcafd819475ee3552bdb1/libra_account.bpl:3667:24: <boogie>: inline$$LibraAccount_create_account$0$Entry
+     =     at /var/folders/85/dnj3wv151rqgv2jby442x5pm0000gn/T/a949499739cfcafd819475ee3552bdb1/libra_account.bpl:3734:18: <boogie>: inline$$LibraAccount_create_account$0$anon31_Then
+     =     at /var/folders/85/dnj3wv151rqgv2jby442x5pm0000gn/T/a949499739cfcafd819475ee3552bdb1/libra_account.bpl:3737:6: <boogie>: inline$$LibraAccount_create_account$0$anon6$1
+     =     at /var/folders/85/dnj3wv151rqgv2jby442x5pm0000gn/T/a949499739cfcafd819475ee3552bdb1/libra_account.bpl:3746:6: <boogie>: inline$$LibraAccount_create_account$0$anon8$1
+
+bug:  This assertion might not hold.
+
+     ┌── /var/folders/85/dnj3wv151rqgv2jby442x5pm0000gn/T/a949499739cfcafd819475ee3552bdb1/libra_account.bpl:978:6 ───
+     │
+ 978 │     assert false; // $Hash_sha3_256 not implemented
+     │      ^
+     │
+     =     at /var/folders/85/dnj3wv151rqgv2jby442x5pm0000gn/T/a949499739cfcafd819475ee3552bdb1/libra_account.bpl:6160:24: <boogie>: inline$$LibraAccount_prologue$0$Entry
+     =     at /var/folders/85/dnj3wv151rqgv2jby442x5pm0000gn/T/a949499739cfcafd819475ee3552bdb1/libra_account.bpl:6263:18: <boogie>: inline$$LibraAccount_prologue$0$anon72_Then
+     =     at /var/folders/85/dnj3wv151rqgv2jby442x5pm0000gn/T/a949499739cfcafd819475ee3552bdb1/libra_account.bpl:6266:6: <boogie>: inline$$LibraAccount_prologue$0$anon12$1
+     =     at /var/folders/85/dnj3wv151rqgv2jby442x5pm0000gn/T/a949499739cfcafd819475ee3552bdb1/libra_account.bpl:3363:24: <boogie>: inline$$LibraAccount_exists$0$Entry
+     =     at /var/folders/85/dnj3wv151rqgv2jby442x5pm0000gn/T/a949499739cfcafd819475ee3552bdb1/libra_account.bpl:6271:6: <boogie>: inline$$LibraAccount_prologue$0$anon73_Else
+     =     at /var/folders/85/dnj3wv151rqgv2jby442x5pm0000gn/T/a949499739cfcafd819475ee3552bdb1/libra_account.bpl:6316:6: <boogie>: inline$$LibraAccount_prologue$0$anon77_Else
+     =     at /var/folders/85/dnj3wv151rqgv2jby442x5pm0000gn/T/a949499739cfcafd819475ee3552bdb1/libra_account.bpl:6326:6: <boogie>: inline$$LibraAccount_prologue$0$anon24$1


### PR DESCRIPTION
Previously, some unimplemented functions in move-prover/src/prelude.bpl had as a body:

$abort_flag := true;

An unsuspecting user who does not specify and "aborts_if" and does specify an "ensures" property of a procedure that calls such a stub, directly or indirectly, will find that every such property happily verifies, because the property is only required to hold when the specified procedure does not abort, and a procedure that calls one of these stubs will always abort. (As you can probably guess, I was the user who ran into this issue.)

I changed the body of several functions to something like:

assert false;  // $foo_bar not implemented.

With causes Boogie to report an error. It has the nice property that Move Prover prints an error message with the failing line, including "$foo_bar not implemented," which is very helpful for the user.

<!--
Thank you for sending a PR. We appreciate you spending time to help improve the Libra project.

The project is undergoing daily changes. Pull Requests will be reviewed and responded to as time permits.
-->

## Motivation

(Write your motivation for proposed changes here.)

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?

(Write your answer here.)

## Test Plan

(Share your test plan here. If you changed code, please provide us with clear instructions for verifying that your changes work.)

## Related PRs

(If this PR adds or changes functionality, please take some time to update the docs at https://github.com/libra/website, and link to your PR here.)
