### PR TITLE
[tf] set default num_validators_in_genesis same as num_validators

### DIFF
--- a/terraform/validators.tf
+++ b/terraform/validators.tf
@@ -203,7 +203,7 @@ data "template_file" "ecs_task_definition" {
     cfg_listen_addr               = var.validator_use_public_ip == true ? element(aws_instance.validator.*.public_ip, count.index) : element(aws_instance.validator.*.private_ip, count.index)
     cfg_node_index                = count.index
     cfg_num_validators            = var.cfg_num_validators_override == 0 ? var.num_validators : var.cfg_num_validators_override
-    cfg_num_validators_in_genesis = var.num_validators_in_genesis
+    cfg_num_validators_in_genesis = var.num_validators_in_genesis == 0? var.num_validators : var.num_validators_in_genesis
     cfg_seed                      = var.config_seed
     cfg_seed_peer_ip              = local.seed_peer_ip
 

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -56,8 +56,8 @@ variable "num_validators" {
 }
 
 variable "num_validators_in_genesis" {
-  default     = 4
-  description = "Number of validator nodes to include in genesis blob"
+  default     = 0
+  description = "Number of validator nodes to include in genesis blob, 0 will default to using num_validators"
 }
 
 # This allows you to use a override number of validators for config generation


### PR DESCRIPTION
<!--
Thank you for sending a PR. We appreciate you spending time to help improve the Libra project.

The project is undergoing daily changes. Pull Requests will be reviewed and responded to as time permits.
-->

## Motivation

Use num_validators as default for num_validators_in_genesis

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

terraform apply to sherryxiao workspace

## Related PRs

(If this PR adds or changes functionality, please take some time to update the docs at https://github.com/libra/website, and link to your PR here.)
