### PR TITLE
[clustertest] Support 30val+30fn setup for run-ci-suite experiments

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -706,6 +706,7 @@ dependencies = [
  "libra-types 0.1.0",
  "libra-util 0.1.0",
  "num_cpus 1.12.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "once_cell 1.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "regex 1.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "reqwest 0.10.4 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/testsuite/cluster-test/Cargo.toml
+++ b/testsuite/cluster-test/Cargo.toml
@@ -14,6 +14,7 @@ anyhow = "1.0"
 flate2 = { version = "1.0", features = ["rust_backend"], default-features = false }
 hex = "0.4.2"
 itertools = "0.9.0"
+once_cell = "1.3.1"
 rand = "0.6.5"
 regex = { version = "1.3.6", default-features = false, features = ["std", "perf"] }
 reqwest = { version="0.10.4", features=["blocking", "json", "rustls-tls"], default_features = false }

--- a/testsuite/cluster-test/src/main.rs
+++ b/testsuite/cluster-test/src/main.rs
@@ -101,7 +101,7 @@ struct Args {
     changelog: Option<Vec<String>>,
 
     // emit_tx options
-    #[structopt(long, default_value = "10")]
+    #[structopt(long, default_value = "15")]
     accounts_per_client: usize,
     #[structopt(long)]
     workers_per_ac: Option<usize>,
@@ -750,10 +750,12 @@ impl ClusterTestRunner {
 
     pub fn cleanup_and_run(&mut self, experiment: Box<dyn Experiment>) -> Result<()> {
         self.cleanup();
-        self.run_single_experiment(experiment, Some(self.global_emit_job_request.clone()))?;
+        let result =
+            self.run_single_experiment(experiment, Some(self.global_emit_job_request.clone()));
         if let Some(cluster_swarm) = self.cluster_swarm.as_ref() {
             self.runtime.block_on(cluster_swarm.delete_all())?;
         }
+        result?;
         self.print_report();
         Ok(())
     }

--- a/testsuite/cluster-test/src/tx_emitter.rs
+++ b/testsuite/cluster-test/src/tx_emitter.rs
@@ -101,7 +101,7 @@ impl EmitJobRequest {
             },
             None => Self {
                 instances,
-                accounts_per_client: 10,
+                accounts_per_client: 15,
                 workers_per_ac: None,
                 thread_params: EmitThreadParams::default(),
             },


### PR DESCRIPTION
## Summary

* Update PerformanceBenchmark, PerformanceBenchmarkThreeRegionSimulation to support fullnodes
* Update accounts_per_client default value to 15
* Reorder the experiments in run-ci-suite so that 10% down experiment is run at last