### PR TITLE
[move-prover] Enforce update invariants for mutable-ref parameters of public functions

### DIFF
--- a/language/move-prover/tests/sources/module_invariants.exp
+++ b/language/move-prover/tests/sources/module_invariants.exp
@@ -6,8 +6,8 @@ error:  A postcondition might not hold on this return path.
  24 │         invariant global<SCounter>(0x0).n == spec_count;
     │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
     │
-    =     at tests/sources/module_invariants.move:42:5: delete_S_invalid (entry)
-    =     at tests/sources/module_invariants.move:42:5: delete_S_invalid (exit)
+    =     at tests/sources/module_invariants.move:46:5: delete_S_invalid (entry)
+    =     at tests/sources/module_invariants.move:46:5: delete_S_invalid (exit)
     =         x = <redacted>
 
 error:  A precondition for this call might not hold.
@@ -17,5 +17,5 @@ error:  A precondition for this call might not hold.
  24 │         invariant global<SCounter>(0x0).n == spec_count;
     │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
     │
-    =     at tests/sources/module_invariants.move:48:5: private_calls_public_invalid (entry)
-    =     at tests/sources/module_invariants.move:28:5: new_S (entry)
+    =     at tests/sources/module_invariants.move:55:5: private_calls_public_invalid (entry)
+    =     at tests/sources/module_invariants.move:31:5: new_S (entry)

--- a/language/move-prover/tests/sources/module_invariants.move
+++ b/language/move-prover/tests/sources/module_invariants.move
@@ -24,6 +24,9 @@ module TestModuleInvariants {
         invariant global<SCounter>(0x0).n == spec_count;
     }
 
+    // Creating and Deleting Resource
+    // -------------------------------
+
     // Function creating an S instance. Since its public, we expect the module invariant to be satisfied.
     public fun new_S(): S acquires SCounter {
         let counter = borrow_global_mut<SCounter>(0x0);
@@ -38,10 +41,14 @@ module TestModuleInvariants {
         counter.n = counter.n - 1;
     }
 
-    // Function destroying an S instance but not tracking it.
+    // Function destroying an S instance but not tracking it. The module invariant will catch this when the function
+    // exits.
     public fun delete_S_invalid(x: S) {
         let S{} = x;
     }
+
+    // Private Calling Public
+    // -----------------------
 
     // Private function calling a public function and failing because the pre-condition of the public function
     // does not hold.

--- a/language/move-prover/tests/sources/mut_ref_accross_modules.exp
+++ b/language/move-prover/tests/sources/mut_ref_accross_modules.exp
@@ -1,0 +1,11 @@
+Move prover returns: exiting with boogie verification errors
+error:  This assertion might not hold.
+
+    ┌── tests/sources/mut_ref_accross_modules.move:19:9 ───
+    │
+ 19 │         invariant global<TSum>(0x0).sum == spec_sum;
+    │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    │
+    =     at tests/sources/mut_ref_accross_modules.move:50:5: increment_invalid (entry)
+    =     at tests/sources/mut_ref_accross_modules.move:51:27: increment_invalid
+    =     at tests/sources/mut_ref_accross_modules.move:50:5: increment_invalid (exit)

--- a/language/move-prover/tests/sources/mut_ref_accross_modules.move
+++ b/language/move-prover/tests/sources/mut_ref_accross_modules.move
@@ -1,0 +1,63 @@
+address 0x1:
+module TestMutRefs {
+
+    struct T { value: u64 }
+
+    resource struct TSum {
+        sum: u64
+    }
+
+    spec struct T {
+        global spec_sum: u64;
+
+        invariant update value > old(value);
+        invariant pack spec_sum = spec_sum + value;
+        invariant unpack spec_sum = spec_sum - value;
+    }
+
+    spec module {
+        invariant global<TSum>(0x0).sum == spec_sum;
+    }
+
+    public fun new(x: u64): T acquires TSum {
+        let r = borrow_global_mut<TSum>(0x0);
+        r.sum = r.sum + x;
+        T{value: x}
+    }
+
+    public fun delete(x: T) acquires TSum {
+        let r = borrow_global_mut<TSum>(0x0);
+        let T{value: v} = x;
+        r.sum = r.sum - v;
+    }
+
+    public fun increment(x: &mut T) acquires TSum {
+        x.value = x.value + 1;
+        let r = borrow_global_mut<TSum>(0x0);
+        r.sum = r.sum + 1;
+    }
+
+    // This should fail because the update invariant requires strict monotonic increase of the value.
+    // TODO: we see this error only when we comment out the next function. Need to determine where this
+    //   comes from, as we usually see Boogie reporting all errors, and not aborting after the first one.
+    public fun decrement_invalid(x: &mut T) acquires TSum {
+        x.value = x.value - 1;
+        let r = borrow_global_mut<TSum>(0x0);
+        r.sum = r.sum - 1;
+    }
+
+    // This should fail because we do not update the TSum resource.
+    public fun increment_invalid(x: &mut T) {
+        x.value = x.value + 1;
+    }
+}
+
+module TestMutRefsUser {
+    use 0x1::TestMutRefs;
+
+    public fun valid() {
+        let x = TestMutRefs::new(4);
+        TestMutRefs::increment(&mut x);
+        TestMutRefs::delete(x);
+    }
+}


### PR DESCRIPTION
This enforces update (and pack/unpack) invariants for mutable ref parameters of a public function on exit. To make this happen, on entry to the public function we save the before-value behind the reference and compare it with the after-value on exit. As with borrowing, this mechanism is extended to pack/unpack. Most of the code is similar with lifetime based invariant enforcement, only that the scope of the mutation is now shortened to execution of the function. This treatment is logically consistent because as long as the mut ref is passed around outside of the module, it can't be mutated unless calling a public function of the module again.

The treatment of calling public functions from local functions isn't yet totally clear and left out in this PR.

A test case which pretty much resembles the MarketCap use case has been added as `mut_ref_accross_modules.move`.

## Motivation

Global specifications.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

New test.

## Related PRs

NA
