### PR TITLE
[language] disallow uppercase "0X" prefix for address values

### DIFF
--- a/language/move-lang/src/parser/lexer.rs
+++ b/language/move-lang/src/parser/lexer.rs
@@ -238,7 +238,7 @@ fn find_token(file: &'static str, text: &str, start_offset: usize) -> Result<(To
     };
     let (tok, len) = match c {
         '0'..='9' => {
-            if (text.starts_with("0x") || text.starts_with("0X")) && text.len() > 2 {
+            if text.starts_with("0x") && text.len() > 2 {
                 let hex_len = get_hex_digits_len(&text[2..]);
                 if hex_len == 0 {
                     // Fall back to treating this as a "0" token.

--- a/language/move-lang/tests/move_check/parser/use_with_main.exp
+++ b/language/move-lang/tests/move_check/parser/use_with_main.exp
@@ -18,7 +18,7 @@ error:
 
    ┌── tests/move_check/parser/use_with_main.move:3:5 ───
    │
- 3 │ use 0XaBcD::Module as M;
+ 3 │ use 0xaBcD::Module as M;
    │     ^^^^^^^^^^^^^^ Invalid 'use'. Unbound module: '0xabcd::Module'
    │
 
@@ -26,7 +26,7 @@ error:
 
    ┌── tests/move_check/parser/use_with_main.move:3:23 ───
    │
- 3 │ use 0XaBcD::Module as M;
+ 3 │ use 0xaBcD::Module as M;
    │                       ^ Unused 'use' of alias 'M'. Consider removing it
    │
 

--- a/language/move-lang/tests/move_check/parser/use_with_main.move
+++ b/language/move-lang/tests/move_check/parser/use_with_main.move
@@ -1,6 +1,6 @@
 // Test various "use" declarations at the file level.
 use 0x0::Module;
-use 0XaBcD::Module as M;
+use 0xaBcD::Module as M;
 use 0x0000::Z;
 fun main() {
 }


### PR DESCRIPTION
C and C++ allow either "0x" (lowercase) or "0X" (uppercase) prefixes for hex numbers, but Rust only supports the lowercase version. After discussion in #3131, it seems like there is a consensus that Move should follow the Rust approach.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

Updated tests that were using the uppercase "0X" prefix.