### PR TITLE
Add workspace-hack crate to unify third party dependency features

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -16,6 +16,7 @@ dependencies = [
  "anyhow 1.0.28 (registry+https://github.com/rust-lang/crates.io-index)",
  "libra-crypto 0.1.0",
  "libra-types 0.1.0",
+ "libra-workspace-hack 0.1.0",
  "mirai-annotations 1.6.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "proptest 0.9.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -33,6 +34,7 @@ dependencies = [
  "anyhow 1.0.28 (registry+https://github.com/rust-lang/crates.io-index)",
  "libra-logger 0.1.0",
  "libra-types 0.1.0",
+ "libra-workspace-hack 0.1.0",
  "prost 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio 0.2.13 (registry+https://github.com/rust-lang/crates.io-index)",
  "tonic 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -53,6 +55,7 @@ dependencies = [
  "libra-logger 0.1.0",
  "libra-mempool 0.1.0",
  "libra-types 0.1.0",
+ "libra-workspace-hack 0.1.0",
  "once_cell 1.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "prometheus 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "prost 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -223,6 +226,7 @@ dependencies = [
  "libra-canonical-serialization 0.1.0",
  "libra-crypto 0.1.0",
  "libra-types 0.1.0",
+ "libra-workspace-hack 0.1.0",
  "libradb 0.1.0",
  "proptest 0.9.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -397,6 +401,7 @@ dependencies = [
 name = "borrow-graph"
 version = "0.0.1"
 dependencies = [
+ "libra-workspace-hack 0.1.0",
  "mirai-annotations 1.6.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -406,6 +411,7 @@ version = "0.1.0"
 dependencies = [
  "futures 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures-semaphore 0.1.0",
+ "libra-workspace-hack 0.1.0",
  "tokio 0.2.13 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -452,6 +458,7 @@ dependencies = [
  "codespan 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "codespan-reporting 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "libra-types 0.1.0",
+ "libra-workspace-hack 0.1.0",
  "move-core-types 0.1.0",
  "move-ir-types 0.1.0",
  "serde 1.0.106 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -467,6 +474,7 @@ dependencies = [
  "borrow-graph 0.0.1",
  "invalid-mutations 0.1.0",
  "libra-types 0.1.0",
+ "libra-workspace-hack 0.1.0",
  "mirai-annotations 1.6.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "move-core-types 0.1.0",
  "move-vm-types 0.1.0",
@@ -481,6 +489,7 @@ dependencies = [
  "bytecode-verifier 0.1.0",
  "invalid-mutations 0.1.0",
  "libra-types 0.1.0",
+ "libra-workspace-hack 0.1.0",
  "move-core-types 0.1.0",
  "petgraph 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "proptest 0.9.6 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -605,6 +614,7 @@ dependencies = [
  "libra-logger 0.1.0",
  "libra-metrics 0.1.0",
  "libra-types 0.1.0",
+ "libra-workspace-hack 0.1.0",
  "once_cell 1.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "rusty-fork 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio 0.2.13 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -677,6 +687,7 @@ dependencies = [
  "libra-temppath 0.1.0",
  "libra-types 0.1.0",
  "libra-wallet 0.1.0",
+ "libra-workspace-hack 0.1.0",
  "num-traits 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "parity-multiaddr 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "proptest 0.9.6 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -724,6 +735,7 @@ dependencies = [
  "libra-logger 0.1.0",
  "libra-types 0.1.0",
  "libra-util 0.1.0",
+ "libra-workspace-hack 0.1.0",
  "num_cpus 1.12.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "once_cell 1.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -779,6 +791,7 @@ dependencies = [
  "bytecode-verifier 0.1.0",
  "ir-to-bytecode 0.1.0",
  "libra-types 0.1.0",
+ "libra-workspace-hack 0.1.0",
  "move-ir-types 0.1.0",
  "serde_json 1.0.51 (registry+https://github.com/rust-lang/crates.io-index)",
  "stdlib 0.1.0",
@@ -797,6 +810,7 @@ dependencies = [
  "libra-crypto 0.1.0",
  "libra-logger 0.1.0",
  "libra-types 0.1.0",
+ "libra-workspace-hack 0.1.0",
  "parity-multiaddr 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "structopt 0.3.13 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -830,6 +844,7 @@ dependencies = [
  "libra-temppath 0.1.0",
  "libra-types 0.1.0",
  "libra-vm 0.1.0",
+ "libra-workspace-hack 0.1.0",
  "libradb 0.1.0",
  "mirai-annotations 1.6.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "network 0.1.0",
@@ -864,6 +879,7 @@ dependencies = [
  "libra-crypto 0.1.0",
  "libra-crypto-derive 0.1.0",
  "libra-types 0.1.0",
+ "libra-workspace-hack 0.1.0",
  "mirai-annotations 1.6.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "proptest 0.9.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.106 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -903,6 +919,7 @@ version = "0.1.0"
 dependencies = [
  "backtrace 0.3.46 (registry+https://github.com/rust-lang/crates.io-index)",
  "libra-logger 0.1.0",
+ "libra-workspace-hack 0.1.0",
  "serde 1.0.106 (registry+https://github.com/rust-lang/crates.io-index)",
  "toml 0.5.6 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -1123,6 +1140,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 name = "datatest-stable"
 version = "0.1.0"
 dependencies = [
+ "libra-workspace-hack 0.1.0",
  "regex 1.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "structopt 0.3.13 (registry+https://github.com/rust-lang/crates.io-index)",
  "termcolor 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1136,6 +1154,7 @@ dependencies = [
  "anyhow 1.0.28 (registry+https://github.com/rust-lang/crates.io-index)",
  "libra-logger 0.1.0",
  "libra-metrics 0.1.0",
+ "libra-workspace-hack 0.1.0",
  "once_cell 1.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "prost 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.51 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1196,6 +1215,7 @@ dependencies = [
  "bytecode-verifier 0.1.0",
  "ir-to-bytecode-syntax 0.1.0",
  "libra-types 0.1.0",
+ "libra-workspace-hack 0.1.0",
  "move-core-types 0.1.0",
  "move-ir-types 0.1.0",
  "serde 1.0.106 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1289,6 +1309,7 @@ dependencies = [
  "libra-state-view 0.1.0",
  "libra-types 0.1.0",
  "libra-vm 0.1.0",
+ "libra-workspace-hack 0.1.0",
  "once_cell 1.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "proptest 0.9.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1321,6 +1342,7 @@ dependencies = [
  "libra-logger 0.1.0",
  "libra-types 0.1.0",
  "libra-vm 0.1.0",
+ "libra-workspace-hack 0.1.0",
  "rand 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "rayon 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "storage-client 0.1.0",
@@ -1335,6 +1357,7 @@ version = "0.1.0"
 dependencies = [
  "libra-crypto 0.1.0",
  "libra-types 0.1.0",
+ "libra-workspace-hack 0.1.0",
  "scratchpad 0.1.0",
  "serde 1.0.106 (registry+https://github.com/rust-lang/crates.io-index)",
  "storage-proto 0.1.0",
@@ -1349,6 +1372,7 @@ dependencies = [
  "libra-crypto 0.1.0",
  "libra-types 0.1.0",
  "libra-vm 0.1.0",
+ "libra-workspace-hack 0.1.0",
  "storage-client 0.1.0",
  "storage-service 0.1.0",
  "tokio 0.2.13 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1451,6 +1475,7 @@ dependencies = [
  "libra-state-view 0.1.0",
  "libra-types 0.1.0",
  "libra-vm 0.1.0",
+ "libra-workspace-hack 0.1.0",
  "mirai-annotations 1.6.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "move-core-types 0.1.0",
  "once_cell 1.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1534,6 +1559,7 @@ name = "futures-semaphore"
 version = "0.1.0"
 dependencies = [
  "futures 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libra-workspace-hack 0.1.0",
  "tokio 0.2.13 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -1576,6 +1602,7 @@ version = "0.1.0"
 dependencies = [
  "libra-canonical-serialization 0.1.0",
  "libra-types 0.1.0",
+ "libra-workspace-hack 0.1.0",
  "proptest 0.9.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde-reflection 0.1.0",
  "serde_yaml 0.8.11 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1590,6 +1617,7 @@ dependencies = [
  "libra-canonical-serialization 0.1.0",
  "libra-crypto 0.1.0",
  "libra-temppath 0.1.0",
+ "libra-workspace-hack 0.1.0",
  "rand 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "structopt 0.3.13 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -1608,6 +1636,7 @@ version = "0.1.0"
 dependencies = [
  "libra-canonical-serialization 0.1.0",
  "libra-types 0.1.0",
+ "libra-workspace-hack 0.1.0",
  "structopt 0.3.13 (registry+https://github.com/rust-lang/crates.io-index)",
  "vm 0.1.0",
 ]
@@ -1956,6 +1985,7 @@ version = "0.1.0"
 dependencies = [
  "libra-proptest-helpers 0.1.0",
  "libra-types 0.1.0",
+ "libra-workspace-hack 0.1.0",
  "proptest 0.9.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "vm 0.1.0",
 ]
@@ -1978,6 +2008,7 @@ dependencies = [
  "functional-tests 0.1.0",
  "ir-to-bytecode 0.1.0",
  "libra-types 0.1.0",
+ "libra-workspace-hack 0.1.0",
  "move-ir-types 0.1.0",
  "stdlib 0.1.0",
  "vm 0.1.0",
@@ -1993,6 +2024,7 @@ dependencies = [
  "codespan-reporting 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "ir-to-bytecode-syntax 0.1.0",
  "libra-types 0.1.0",
+ "libra-workspace-hack 0.1.0",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "move-core-types 0.1.0",
  "move-ir-types 0.1.0",
@@ -2008,6 +2040,7 @@ dependencies = [
  "codespan 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "hex 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "libra-types 0.1.0",
+ "libra-workspace-hack 0.1.0",
  "move-core-types 0.1.0",
  "move-ir-types 0.1.0",
 ]
@@ -2044,6 +2077,7 @@ dependencies = [
  "libra-crypto-derive 0.1.0",
  "libra-nibble 0.1.0",
  "libra-types 0.1.0",
+ "libra-workspace-hack 0.1.0",
  "mirai-annotations 1.6.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "num-derive 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "num-traits 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2159,6 +2193,7 @@ dependencies = [
  "libra-state-view 0.1.0",
  "libra-types 0.1.0",
  "libra-vm 0.1.0",
+ "libra-workspace-hack 0.1.0",
  "move-core-types 0.1.0",
  "move-lang 0.0.1",
  "move-vm-runtime 0.1.0",
@@ -2182,6 +2217,7 @@ dependencies = [
  "libra-state-view 0.1.0",
  "libra-types 0.1.0",
  "libra-vm 0.1.0",
+ "libra-workspace-hack 0.1.0",
  "move-core-types 0.1.0",
  "move-vm-cache 0.1.0",
  "move-vm-state 0.1.0",
@@ -2235,6 +2271,7 @@ version = "0.1.0"
 dependencies = [
  "libra-canonical-serialization 0.1.0",
  "libra-proptest-helpers 0.1.0",
+ "libra-workspace-hack 0.1.0",
  "proptest 0.9.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.106 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -2244,6 +2281,7 @@ name = "libra-canonical-serialization"
 version = "0.1.0"
 dependencies = [
  "criterion 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libra-workspace-hack 0.1.0",
  "proptest 0.9.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "proptest-derive 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.106 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2263,6 +2301,7 @@ dependencies = [
  "libra-logger 0.1.0",
  "libra-temppath 0.1.0",
  "libra-types 0.1.0",
+ "libra-workspace-hack 0.1.0",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "mirai-annotations 1.6.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "parity-multiaddr 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2289,6 +2328,7 @@ dependencies = [
  "libra-canonical-serialization 0.1.0",
  "libra-crypto-derive 0.1.0",
  "libra-nibble 0.1.0",
+ "libra-workspace-hack 0.1.0",
  "mirai-annotations 1.6.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "once_cell 1.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "proptest 0.9.6 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2309,6 +2349,7 @@ name = "libra-crypto-derive"
 version = "0.1.0"
 dependencies = [
  "anyhow 1.0.28 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libra-workspace-hack 0.1.0",
  "proc-macro2 1.0.10 (registry+https://github.com/rust-lang/crates.io-index)",
  "quote 1.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "syn 1.0.17 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2323,6 +2364,7 @@ dependencies = [
  "libra-canonical-serialization 0.1.0",
  "libra-crypto 0.1.0",
  "libra-types 0.1.0",
+ "libra-workspace-hack 0.1.0",
  "move-core-types 0.1.0",
  "once_cell 1.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2336,6 +2378,7 @@ version = "0.1.0"
 dependencies = [
  "libfuzzer-sys 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "libra-fuzzer 0.1.0",
+ "libra-workspace-hack 0.1.0",
  "once_cell 1.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -2354,6 +2397,7 @@ dependencies = [
  "libra-proptest-helpers 0.1.0",
  "libra-prost-ext 0.1.0",
  "libra-types 0.1.0",
+ "libra-workspace-hack 0.1.0",
  "move-vm-types 0.1.0",
  "network 0.1.0",
  "noise 0.1.0",
@@ -2384,6 +2428,7 @@ dependencies = [
  "libra-proptest-helpers 0.1.0",
  "libra-temppath 0.1.0",
  "libra-types 0.1.0",
+ "libra-workspace-hack 0.1.0",
  "libradb 0.1.0",
  "once_cell 1.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "prometheus 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2415,6 +2460,7 @@ dependencies = [
  "libra-transaction-scripts 0.1.0",
  "libra-types 0.1.0",
  "libra-vm 0.1.0",
+ "libra-workspace-hack 0.1.0",
  "libradb 0.1.0",
  "rand 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "storage-interface 0.1.0",
@@ -2427,6 +2473,7 @@ version = "0.1.0"
 dependencies = [
  "chrono 0.4.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "env_logger 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libra-workspace-hack 0.1.0",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "once_cell 1.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.106 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2451,6 +2498,7 @@ dependencies = [
  "libra-proptest-helpers 0.1.0",
  "libra-security-logger 0.1.0",
  "libra-types 0.1.0",
+ "libra-workspace-hack 0.1.0",
  "lru-cache 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "mirai-annotations 1.6.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "network 0.1.0",
@@ -2479,6 +2527,7 @@ dependencies = [
  "futures 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "hyper 0.13.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "libra-logger 0.1.0",
+ "libra-workspace-hack 0.1.0",
  "once_cell 1.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "prometheus 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "rusty-fork 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2490,6 +2539,7 @@ dependencies = [
 name = "libra-nibble"
 version = "0.1.0"
 dependencies = [
+ "libra-workspace-hack 0.1.0",
  "proptest 0.9.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.106 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -2514,6 +2564,7 @@ dependencies = [
  "libra-metrics 0.1.0",
  "libra-types 0.1.0",
  "libra-vm 0.1.0",
+ "libra-workspace-hack 0.1.0",
  "network 0.1.0",
  "parity-multiaddr 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "rayon 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2531,6 +2582,7 @@ name = "libra-proptest-helpers"
 version = "0.1.0"
 dependencies = [
  "crossbeam 0.7.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libra-workspace-hack 0.1.0",
  "proptest 0.9.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "proptest-derive 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -2540,6 +2592,7 @@ name = "libra-prost-ext"
 version = "0.1.0"
 dependencies = [
  "bytes 0.5.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libra-workspace-hack 0.1.0",
  "prost 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -2549,6 +2602,7 @@ version = "0.1.0"
 dependencies = [
  "libra-config 0.1.0",
  "libra-logger 0.1.0",
+ "libra-workspace-hack 0.1.0",
  "thiserror 1.0.15 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -2557,6 +2611,7 @@ name = "libra-secure-push-metrics"
 version = "0.1.0"
 dependencies = [
  "libra-logger 0.1.0",
+ "libra-workspace-hack 0.1.0",
  "ureq 0.12.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -2572,6 +2627,7 @@ dependencies = [
  "libra-secure-time 0.1.0",
  "libra-temppath 0.1.0",
  "libra-vault-client 0.1.0",
+ "libra-workspace-hack 0.1.0",
  "rand 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.106 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.51 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2589,6 +2645,7 @@ version = "0.1.0"
 dependencies = [
  "backtrace 0.3.46 (registry+https://github.com/rust-lang/crates.io-index)",
  "libra-logger 0.1.0",
+ "libra-workspace-hack 0.1.0",
  "rand 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.106 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.51 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2600,6 +2657,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow 1.0.28 (registry+https://github.com/rust-lang/crates.io-index)",
  "libra-types 0.1.0",
+ "libra-workspace-hack 0.1.0",
 ]
 
 [[package]]
@@ -2610,6 +2668,7 @@ dependencies = [
  "libra-crypto 0.1.0",
  "libra-logger 0.1.0",
  "libra-types 0.1.0",
+ "libra-workspace-hack 0.1.0",
  "libradb 0.1.0",
  "storage-interface 0.1.0",
  "structopt 0.3.13 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2632,6 +2691,7 @@ dependencies = [
  "libra-logger 0.1.0",
  "libra-temppath 0.1.0",
  "libra-types 0.1.0",
+ "libra-workspace-hack 0.1.0",
  "structopt 0.3.13 (registry+https://github.com/rust-lang/crates.io-index)",
  "thiserror 1.0.15 (registry+https://github.com/rust-lang/crates.io-index)",
  "workspace-builder 0.1.0",
@@ -2642,6 +2702,7 @@ name = "libra-temppath"
 version = "0.1.0"
 dependencies = [
  "hex 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libra-workspace-hack 0.1.0",
  "rand 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -2650,6 +2711,7 @@ name = "libra-transaction-scripts"
 version = "0.1.0"
 dependencies = [
  "include_dir 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libra-workspace-hack 0.1.0",
  "once_cell 1.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -2667,6 +2729,7 @@ dependencies = [
  "libra-crypto-derive 0.1.0",
  "libra-proptest-helpers 0.1.0",
  "libra-prost-ext 0.1.0",
+ "libra-workspace-hack 0.1.0",
  "mirai-annotations 1.6.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "move-core-types 0.1.0",
  "once_cell 1.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2687,6 +2750,7 @@ dependencies = [
 name = "libra-util"
 version = "0.1.0"
 dependencies = [
+ "libra-workspace-hack 0.1.0",
  "tokio 0.2.13 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -2696,6 +2760,7 @@ version = "0.1.0"
 dependencies = [
  "base64 0.12.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "libra-crypto 0.1.0",
+ "libra-workspace-hack 0.1.0",
  "serde 1.0.106 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.51 (registry+https://github.com/rust-lang/crates.io-index)",
  "thiserror 1.0.15 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2716,6 +2781,7 @@ dependencies = [
  "libra-metrics 0.1.0",
  "libra-state-view 0.1.0",
  "libra-types 0.1.0",
+ "libra-workspace-hack 0.1.0",
  "mirai-annotations 1.6.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "move-core-types 0.1.0",
  "move-vm-cache 0.1.0",
@@ -2743,6 +2809,7 @@ dependencies = [
  "libra-crypto 0.1.0",
  "libra-temppath 0.1.0",
  "libra-types 0.1.0",
+ "libra-workspace-hack 0.1.0",
  "mirai-annotations 1.6.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "pbkdf2 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2750,6 +2817,22 @@ dependencies = [
  "sha2 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "sha3 0.8.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "thiserror 1.0.15 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "libra-workspace-hack"
+version = "0.1.0"
+dependencies = [
+ "bytes 0.5.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cc 1.0.50 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "memchr 2.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "num-traits 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
+ "petgraph 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.106 (registry+https://github.com/rust-lang/crates.io-index)",
+ "sha-1 0.8.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "subtle 2.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 1.0.17 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -2769,6 +2852,7 @@ dependencies = [
  "libra-proptest-helpers 0.1.0",
  "libra-temppath 0.1.0",
  "libra-types 0.1.0",
+ "libra-workspace-hack 0.1.0",
  "num-derive 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "num-traits 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "num-variants 0.1.0",
@@ -2908,6 +2992,7 @@ version = "0.1.0"
 dependencies = [
  "bytes 0.5.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libra-workspace-hack 0.1.0",
  "once_cell 1.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -3022,6 +3107,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow 1.0.28 (registry+https://github.com/rust-lang/crates.io-index)",
  "libra-canonical-serialization 0.1.0",
+ "libra-workspace-hack 0.1.0",
  "once_cell 1.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "proptest 0.9.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "proptest-derive 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -3039,6 +3125,7 @@ dependencies = [
  "codespan 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "hex 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "libra-types 0.1.0",
+ "libra-workspace-hack 0.1.0",
  "move-core-types 0.1.0",
  "once_cell 1.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.106 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -3060,6 +3147,7 @@ dependencies = [
  "hex 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "ir-to-bytecode 0.1.0",
  "libra-types 0.1.0",
+ "libra-workspace-hack 0.1.0",
  "move-ir-types 0.1.0",
  "petgraph 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "regex 1.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -3081,6 +3169,7 @@ dependencies = [
  "itertools 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "libra-temppath 0.1.0",
  "libra-types 0.1.0",
+ "libra-workspace-hack 0.1.0",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "move-ir-types 0.1.0",
  "move-lang 0.0.1",
@@ -3100,6 +3189,7 @@ name = "move-vm-cache"
 version = "0.1.0"
 dependencies = [
  "crossbeam 0.7.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libra-workspace-hack 0.1.0",
  "proptest 0.9.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "typed-arena 2.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -3117,6 +3207,7 @@ dependencies = [
  "libra-logger 0.1.0",
  "libra-state-view 0.1.0",
  "libra-types 0.1.0",
+ "libra-workspace-hack 0.1.0",
  "mirai-annotations 1.6.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "move-core-types 0.1.0",
  "move-vm-cache 0.1.0",
@@ -3136,6 +3227,7 @@ dependencies = [
  "libra-logger 0.1.0",
  "libra-state-view 0.1.0",
  "libra-types 0.1.0",
+ "libra-workspace-hack 0.1.0",
  "move-vm-types 0.1.0",
  "vm 0.1.0",
 ]
@@ -3148,6 +3240,7 @@ dependencies = [
  "libra-canonical-serialization 0.1.0",
  "libra-crypto 0.1.0",
  "libra-types 0.1.0",
+ "libra-workspace-hack 0.1.0",
  "move-core-types 0.1.0",
  "once_cell 1.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "proptest 0.9.6 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -3232,6 +3325,7 @@ dependencies = [
  "bytes 0.5.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "libra-logger 0.1.0",
+ "libra-workspace-hack 0.1.0",
  "memsocket 0.1.0",
  "parity-multiaddr 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "pin-project 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -3256,6 +3350,7 @@ dependencies = [
  "libra-proptest-helpers 0.1.0",
  "libra-security-logger 0.1.0",
  "libra-types 0.1.0",
+ "libra-workspace-hack 0.1.0",
  "memsocket 0.1.0",
  "netcore 0.1.0",
  "noise 0.1.0",
@@ -3307,6 +3402,7 @@ dependencies = [
  "libra-crypto 0.1.0",
  "libra-logger 0.1.0",
  "libra-proptest-helpers 0.1.0",
+ "libra-workspace-hack 0.1.0",
  "memsocket 0.1.0",
  "netcore 0.1.0",
  "once_cell 1.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -3408,6 +3504,7 @@ dependencies = [
 name = "num-variants"
 version = "0.1.0"
 dependencies = [
+ "libra-workspace-hack 0.1.0",
  "proc-macro2 1.0.10 (registry+https://github.com/rust-lang/crates.io-index)",
  "quote 1.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "syn 1.0.17 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -4494,6 +4591,7 @@ dependencies = [
  "libra-secure-storage 0.1.0",
  "libra-temppath 0.1.0",
  "libra-types 0.1.0",
+ "libra-workspace-hack 0.1.0",
  "once_cell 1.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.106 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -4527,6 +4625,7 @@ dependencies = [
  "byteorder 1.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "libra-metrics 0.1.0",
  "libra-temppath 0.1.0",
+ "libra-workspace-hack 0.1.0",
  "once_cell 1.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "proptest 0.9.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "rocksdb 0.3.0 (git+https://github.com/tikv/rust-rocksdb.git?rev=72e45c3f3283302c825d53c3cd7154f4cd9e8f5b)",
@@ -4550,6 +4649,7 @@ dependencies = [
  "itertools 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "libra-crypto 0.1.0",
  "libra-types 0.1.0",
+ "libra-workspace-hack 0.1.0",
  "proptest 0.9.6 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -4609,6 +4709,7 @@ name = "serde-reflection"
 version = "0.1.0"
 dependencies = [
  "bincode 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libra-workspace-hack 0.1.0",
  "serde 1.0.106 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.51 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_yaml 0.8.11 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -4698,6 +4799,7 @@ dependencies = [
 name = "serializer-tests"
 version = "0.1.0"
 dependencies = [
+ "libra-workspace-hack 0.1.0",
  "proptest 0.9.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "proptest-derive 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "vm 0.1.0",
@@ -4817,6 +4919,7 @@ version = "0.1.0"
 dependencies = [
  "futures 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "libra-logger 0.1.0",
+ "libra-workspace-hack 0.1.0",
  "memsocket 0.1.0",
  "netcore 0.1.0",
  "noise 0.1.0",
@@ -4848,6 +4951,7 @@ dependencies = [
  "datatest-stable 0.1.0",
  "itertools 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "libra-types 0.1.0",
+ "libra-workspace-hack 0.1.0",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "move-ir-types 0.1.0",
  "move-lang 0.0.1",
@@ -4875,6 +4979,7 @@ dependencies = [
  "bytecode-verifier 0.1.0",
  "ir-to-bytecode 0.1.0",
  "libra-types 0.1.0",
+ "libra-workspace-hack 0.1.0",
  "num 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "proptest 0.9.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "spec-lang 0.0.1",
@@ -4904,6 +5009,7 @@ dependencies = [
  "libra-metrics 0.1.0",
  "libra-types 0.1.0",
  "libra-vm 0.1.0",
+ "libra-workspace-hack 0.1.0",
  "network 0.1.0",
  "once_cell 1.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "parity-multiaddr 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -4948,6 +5054,7 @@ dependencies = [
  "libra-canonical-serialization 0.1.0",
  "libra-crypto 0.1.0",
  "libra-types 0.1.0",
+ "libra-workspace-hack 0.1.0",
  "move-lang 0.0.1",
  "once_cell 1.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "vm 0.1.0",
@@ -4963,6 +5070,7 @@ dependencies = [
  "libra-crypto 0.1.0",
  "libra-state-view 0.1.0",
  "libra-types 0.1.0",
+ "libra-workspace-hack 0.1.0",
  "scratchpad 0.1.0",
  "storage-interface 0.1.0",
  "storage-proto 0.1.0",
@@ -4977,6 +5085,7 @@ dependencies = [
  "anyhow 1.0.28 (registry+https://github.com/rust-lang/crates.io-index)",
  "libra-crypto 0.1.0",
  "libra-types 0.1.0",
+ "libra-workspace-hack 0.1.0",
  "serde 1.0.106 (registry+https://github.com/rust-lang/crates.io-index)",
  "storage-proto 0.1.0",
 ]
@@ -4989,6 +5098,7 @@ dependencies = [
  "libra-crypto 0.1.0",
  "libra-prost-ext 0.1.0",
  "libra-types 0.1.0",
+ "libra-workspace-hack 0.1.0",
  "proptest 0.9.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "proptest-derive 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "prost 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -5011,6 +5121,7 @@ dependencies = [
  "libra-metrics 0.1.0",
  "libra-temppath 0.1.0",
  "libra-types 0.1.0",
+ "libra-workspace-hack 0.1.0",
  "libradb 0.1.0",
  "proptest 0.9.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -5027,6 +5138,7 @@ version = "0.1.0"
 dependencies = [
  "futures 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures-semaphore 0.1.0",
+ "libra-workspace-hack 0.1.0",
  "pin-project 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio 0.2.13 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -5093,6 +5205,7 @@ dependencies = [
  "anyhow 1.0.28 (registry+https://github.com/rust-lang/crates.io-index)",
  "channel 0.1.0",
  "libra-types 0.1.0",
+ "libra-workspace-hack 0.1.0",
 ]
 
 [[package]]
@@ -5220,6 +5333,7 @@ dependencies = [
  "libra-state-view 0.1.0",
  "libra-types 0.1.0",
  "libra-vm 0.1.0",
+ "libra-workspace-hack 0.1.0",
  "mirai-annotations 1.6.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "move-core-types 0.1.0",
  "move-vm-cache 0.1.0",
@@ -5238,6 +5352,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow 1.0.28 (registry+https://github.com/rust-lang/crates.io-index)",
  "itertools 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libra-workspace-hack 0.1.0",
  "prettydiff 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "regex 1.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -5257,6 +5372,7 @@ dependencies = [
  "libra-swarm 0.1.0",
  "libra-temppath 0.1.0",
  "libra-types 0.1.0",
+ "libra-workspace-hack 0.1.0",
  "num 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "num-traits 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "rust_decimal 1.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -5938,6 +6054,7 @@ dependencies = [
  "libra-canonical-serialization 0.1.0",
  "libra-config 0.1.0",
  "libra-types 0.1.0",
+ "libra-workspace-hack 0.1.0",
  "mirai-annotations 1.6.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "stdlib 0.1.0",
  "vm 0.1.0",
@@ -6103,6 +6220,7 @@ dependencies = [
  "bytecode-verifier 0.1.0",
  "ir-to-bytecode 0.1.0",
  "libra-types 0.1.0",
+ "libra-workspace-hack 0.1.0",
  "move-core-types 0.1.0",
  "move-ir-types 0.1.0",
  "rand 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -6140,6 +6258,7 @@ dependencies = [
  "libra-crypto 0.1.0",
  "libra-proptest-helpers 0.1.0",
  "libra-types 0.1.0",
+ "libra-workspace-hack 0.1.0",
  "mirai-annotations 1.6.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "move-core-types 0.1.0",
  "num-variants 0.1.0",
@@ -6164,6 +6283,7 @@ dependencies = [
  "libra-state-view 0.1.0",
  "libra-types 0.1.0",
  "libra-vm 0.1.0",
+ "libra-workspace-hack 0.1.0",
  "move-core-types 0.1.0",
  "move-vm-cache 0.1.0",
  "move-vm-runtime 0.1.0",
@@ -6193,6 +6313,7 @@ dependencies = [
  "libra-state-view 0.1.0",
  "libra-types 0.1.0",
  "libra-vm 0.1.0",
+ "libra-workspace-hack 0.1.0",
  "rand 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "scratchpad 0.1.0",
  "storage-client 0.1.0",
@@ -6436,6 +6557,7 @@ name = "workspace-builder"
 version = "0.1.0"
 dependencies = [
  "libra-logger 0.1.0",
+ "libra-workspace-hack 0.1.0",
  "once_cell 1.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -6455,6 +6577,7 @@ dependencies = [
  "anyhow 1.0.28 (registry+https://github.com/rust-lang/crates.io-index)",
  "chrono 0.4.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "env_logger 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libra-workspace-hack 0.1.0",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.106 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.51 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -6470,6 +6593,7 @@ version = "0.1.0"
 dependencies = [
  "cargo_metadata 0.9.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "guppy 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libra-workspace-hack 0.1.0",
  "once_cell 1.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -6478,6 +6602,7 @@ name = "x-lint"
 version = "0.1.0"
 dependencies = [
  "guppy 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libra-workspace-hack 0.1.0",
  "once_cell 1.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "x-core 0.1.0",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,6 +27,7 @@ members = [
     "common/temppath",
     "common/util",
     "common/workspace-builder",
+    "common/workspace-hack",
     "config",
     "config/config-builder",
     "config/generate-keypair",

--- a/admission-control/admission-control-proto/Cargo.toml
+++ b/admission-control/admission-control-proto/Cargo.toml
@@ -17,6 +17,7 @@ prost = "0.6"
 
 libra-logger = { path = "../../common/logger", version = "0.1.0" }
 libra-types = { path = "../../types", version = "0.1.0" }
+libra-workspace-hack = { path = "../../common/workspace-hack", version = "0.1.0" }
 
 [build-dependencies]
 tonic-build = "0.2"

--- a/admission-control/admission-control-service/Cargo.toml
+++ b/admission-control/admission-control-service/Cargo.toml
@@ -15,6 +15,7 @@ prost = "0.6"
 futures = "0.3.0"
 once_cell = "1.3.1"
 rand = "0.6.5"
+serde_json = "1.0"
 tokio = { version = "0.2.13", features = ["full"] }
 tonic = "0.2"
 prometheus = { version = "0.8.0", default-features = false }
@@ -23,12 +24,11 @@ admission-control-proto = { path = "../admission-control-proto", version = "0.1.
 libra-config = { path = "../../config", version = "0.1.0" }
 libra-crypto = { path = "../../crypto/crypto", version = "0.1.0" }
 libra-logger = { path = "../../common/logger", version = "0.1.0" }
-libra-types = { path = "../../types", version = "0.1.0" }
-storage-client = { path = "../../storage/storage-client", version = "0.1.0" }
-
 libra-mempool = { path = "../../mempool", version = "0.1.0"}
+libra-types = { path = "../../types", version = "0.1.0" }
+libra-workspace-hack = { path = "../../common/workspace-hack", version = "0.1.0" }
 debug-interface = { path = "../../common/debug-interface", version = "0.1.0" }
-serde_json = "1.0"
+storage-client = { path = "../../storage/storage-client", version = "0.1.0" }
 
 [dev-dependencies]
 assert_matches = "1.3.0"

--- a/client/cli/Cargo.toml
+++ b/client/cli/Cargo.toml
@@ -38,6 +38,7 @@ libra-logger =  { path = "../../common/logger", version = "0.1.0" }
 libra-metrics = { path = "../../common/metrics", version = "0.1.0" }
 libra-types = { path = "../../types", version = "0.1.0" }
 libra-temppath = { path = "../../common/temppath/", version = "0.1.0" }
+libra-workspace-hack = { path = "../../common/workspace-hack", version = "0.1.0" }
 stdlib = { path = "../../language/stdlib", version = "0.1.0" }
 transaction-builder = { path = "../../language/transaction-builder", version = "0.1.0" }
 

--- a/client/libra-dev/Cargo.toml
+++ b/client/libra-dev/Cargo.toml
@@ -18,6 +18,7 @@ libc = "0.2.68"
 move-core-types = { path = "../../language/move-core/types", version = "0.1.0" }
 once_cell = "1.3.1"
 static_assertions = "1.0.0"
+libra-workspace-hack = { path = "../../common/workspace-hack", version = "0.1.0" }
 
 [dev-dependencies]
 rand = "0.6.5"

--- a/client/libra-wallet/Cargo.toml
+++ b/client/libra-wallet/Cargo.toml
@@ -24,6 +24,7 @@ ed25519-dalek = { git = "https://github.com/calibra/ed25519-dalek.git", branch =
 libra-crypto = { path = "../../crypto/crypto", version = "0.1.0" }
 libra-temppath = { path = "../../common/temppath/", version = "0.1.0" }
 libra-types = { path = "../../types", version = "0.1.0" }
+libra-workspace-hack = { path = "../../common/workspace-hack", version = "0.1.0" }
 mirai-annotations = "1.5.0"
 
 [features]

--- a/common/bitvec/Cargo.toml
+++ b/common/bitvec/Cargo.toml
@@ -9,9 +9,8 @@ license = "Apache-2.0"
 publish = false
 edition = "2018"
 
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
-
 [dependencies]
+libra-workspace-hack = { path = "../workspace-hack", version = "0.1.0" }
 serde = { version = "1.0.106", features = ["derive"] }
 
 [dev-dependencies]

--- a/common/bounded-executor/Cargo.toml
+++ b/common/bounded-executor/Cargo.toml
@@ -12,4 +12,5 @@ edition = "2018"
 [dependencies]
 futures = "0.3.0"
 futures-semaphore = { path = "../futures-semaphore" }
+libra-workspace-hack = { path = "../workspace-hack", version = "0.1.0" }
 tokio = { version = "0.2.13", features = ["full"] }

--- a/common/channel/Cargo.toml
+++ b/common/channel/Cargo.toml
@@ -15,6 +15,7 @@ futures = "0.3.0"
 once_cell = "1.3.1"
 libra-logger = { path = "../logger", version = "0.1.0" }
 libra-metrics = { path = "../metrics", version = "0.1.0" }
+libra-workspace-hack = { path = "../workspace-hack", version = "0.1.0" }
 
 [dev-dependencies]
 libra-types = { path = "../../types", version = "0.1.0"  }

--- a/common/crash-handler/Cargo.toml
+++ b/common/crash-handler/Cargo.toml
@@ -14,4 +14,5 @@ backtrace = "0.3.46"
 toml = "0.5.3"
 
 libra-logger = { path = "../logger", version = "0.1.0" }
+libra-workspace-hack = { path = "../workspace-hack", version = "0.1.0" }
 serde = { version = "1.0.106", features = ["derive"] }

--- a/common/datatest-stable/Cargo.toml
+++ b/common/datatest-stable/Cargo.toml
@@ -16,6 +16,7 @@ regex = "1.3.6"
 walkdir = "2.2.9"
 structopt = "0.3.13"
 termcolor = "1.0.5"
+libra-workspace-hack = { path = "../workspace-hack", version = "0.1.0" }
 
 [[test]]
 name = "example"

--- a/common/debug-interface/Cargo.toml
+++ b/common/debug-interface/Cargo.toml
@@ -19,6 +19,7 @@ once_cell = "1.3.1"
 
 libra-logger = { path = "../logger", version = "0.1.0" }
 libra-metrics = { path = "../metrics", version = "0.1.0" }
+libra-workspace-hack = { path = "../workspace-hack", version = "0.1.0" }
 
 [build-dependencies]
 tonic-build = "0.2"

--- a/common/futures-semaphore/Cargo.toml
+++ b/common/futures-semaphore/Cargo.toml
@@ -10,6 +10,7 @@ publish = false
 edition = "2018"
 
 [dependencies]
+libra-workspace-hack = { path = "../workspace-hack", version = "0.1.0" }
 tokio = { version = "0.2.13", features = ["sync"] }
 
 [dev-dependencies]

--- a/common/lcs/Cargo.toml
+++ b/common/lcs/Cargo.toml
@@ -10,6 +10,7 @@ publish = false
 edition = "2018"
 
 [dependencies]
+libra-workspace-hack = { path = "../workspace-hack", version = "0.1.0" }
 thiserror = "1.0"
 serde = { version = "1.0", features = ["derive"] }
 

--- a/common/logger/Cargo.toml
+++ b/common/logger/Cargo.toml
@@ -14,6 +14,7 @@ edition = "2018"
 [dependencies]
 chrono = "0.4.9"
 env_logger = { version = "0.7.1", default-features = false }
+libra-workspace-hack = { path = "../workspace-hack", version = "0.1.0" }
 log = "0.4.8"
 serde_json = "1.0.51"
 serde = { version = "1.0.106", features = ["derive"] }

--- a/common/metrics/Cargo.toml
+++ b/common/metrics/Cargo.toml
@@ -13,12 +13,12 @@ edition = "2018"
 anyhow = "1.0"
 futures = "0.3.0"
 hyper = "0.13"
+libra-logger = { path = "../logger", version = "0.1.0" }
+libra-workspace-hack = { path = "../workspace-hack", version = "0.1.0" }
 once_cell = "1.3.1"
+prometheus = { version = "0.8.0", default-features = false }
 serde_json = "1.0.51"
 tokio = "0.2"
-prometheus = { version = "0.8.0", default-features = false }
-
-libra-logger = { path = "../logger", version = "0.1.0" }
 
 [dev-dependencies]
 rusty-fork = "0.2.1"

--- a/common/nibble/Cargo.toml
+++ b/common/nibble/Cargo.toml
@@ -10,6 +10,7 @@ publish = false
 edition = "2018"
 
 [dependencies]
+libra-workspace-hack = { path = "../workspace-hack", version = "0.1.0" }
 proptest = { version = "0.9.6", optional = true }
 serde = { version = "1.0.106", features = ["derive"] }
 

--- a/common/num-variants/Cargo.toml
+++ b/common/num-variants/Cargo.toml
@@ -9,9 +9,8 @@ license = "Apache-2.0"
 [lib]
 proc-macro = true
 
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
-
 [dependencies]
 syn = "1.0.17"
 quote = "1.0.3"
 proc-macro2 = "1.0.10"
+libra-workspace-hack = { path = "../workspace-hack", version = "0.1.0" }

--- a/common/proptest-helpers/Cargo.toml
+++ b/common/proptest-helpers/Cargo.toml
@@ -11,5 +11,6 @@ edition = "2018"
 
 [dependencies]
 crossbeam = "0.7.2"
+libra-workspace-hack = { path = "../workspace-hack", version = "0.1.0" }
 proptest = "0.9.6"
 proptest-derive = "0.1.2"

--- a/common/prost-ext/Cargo.toml
+++ b/common/prost-ext/Cargo.toml
@@ -9,8 +9,7 @@ license = "Apache-2.0"
 publish = false
 edition = "2018"
 
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
-
 [dependencies]
 bytes = "0.5.4"
+libra-workspace-hack = { path = "../workspace-hack", version = "0.1.0" }
 prost = "0.6"

--- a/common/security-logger/Cargo.toml
+++ b/common/security-logger/Cargo.toml
@@ -16,3 +16,4 @@ serde = { version = "1.0.106", features = ["derive"] }
 serde_json = "1.0.51"
 
 libra-logger = { path = "../logger", version = "0.1.0" }
+libra-workspace-hack = { path = "../workspace-hack", version = "0.1.0" }

--- a/common/serde-reflection/Cargo.toml
+++ b/common/serde-reflection/Cargo.toml
@@ -10,6 +10,7 @@ publish = false
 edition = "2018"
 
 [dependencies]
+libra-workspace-hack = { path = "../workspace-hack", version = "0.1.0" }
 thiserror = "1.0"
 serde = { version = "1.0", features = ["derive"] }
 

--- a/common/stream-ratelimiter/Cargo.toml
+++ b/common/stream-ratelimiter/Cargo.toml
@@ -9,13 +9,12 @@ license = "Apache-2.0"
 publish = false
 edition = "2018"
 
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
-
 [dependencies]
 futures = "0.3.0"
 tokio = { version = "0.2.13", features = ["time", "stream"] }
 pin-project = "0.4.2"
 futures-semaphore = { path = "../futures-semaphore" }
+libra-workspace-hack = { path = "../../common/workspace-hack", version = "0.1.0" }
 
 [dev-dependencies]
 tokio = { version = "0.2.13", features = ["full"] }

--- a/common/subscription-service/Cargo.toml
+++ b/common/subscription-service/Cargo.toml
@@ -13,4 +13,5 @@ edition = "2018"
 anyhow = "1.0"
 
 libra-types = { path = "../../types", version = "0.1.0" }
+libra-workspace-hack = { path = "../../common/workspace-hack", version = "0.1.0" }
 channel = { path = "..//channel", version = "0.1.0" }

--- a/common/temppath/Cargo.toml
+++ b/common/temppath/Cargo.toml
@@ -11,4 +11,5 @@ edition = "2018"
 
 [dependencies]
 hex = "0.4.2"
+libra-workspace-hack = { path = "../workspace-hack", version = "0.1.0" }
 rand = "0.6.5"

--- a/common/util/Cargo.toml
+++ b/common/util/Cargo.toml
@@ -10,4 +10,5 @@ publish = false
 edition = "2018"
 
 [dependencies]
+libra-workspace-hack = { path = "..//workspace-hack", version = "0.1.0" }
 tokio = { version = "0.2.13", features = ["time"] }

--- a/common/workspace-builder/Cargo.toml
+++ b/common/workspace-builder/Cargo.toml
@@ -12,3 +12,4 @@ edition = "2018"
 [dependencies]
 once_cell = "1.3.1"
 libra-logger = { path = "../logger", version = "0.1.0" }
+libra-workspace-hack = { path = "../workspace-hack", version = "0.1.0" }

--- a/common/workspace-hack/Cargo.toml
+++ b/common/workspace-hack/Cargo.toml
@@ -1,0 +1,22 @@
+[package]
+name = "libra-workspace-hack"
+version = "0.1.0"
+authors = ["Libra Association <opensource@libra.org>"]
+description = "Libra workspace hack"
+repository = "https://github.com/libra/libra"
+homepage = "https://libra.org"
+license = "Apache-2.0"
+publish = false
+edition = "2018"
+
+[dependencies]
+bytes = { version = "0.5.4", features = ["serde", "std"] }
+cc = { version = "1.0.50", features = ["jobserver", "parallel"] }
+log = { version = "0.4.8", features = ["serde", "std"] }
+memchr = { version = "2.3.3", features = ["std", "use_std"] }
+num-traits = { version = "0.2.11", features = ["std"] }
+petgraph = { version = "0.5.0", features = ["graphmap", "matrix_graph", "stable_graph"] }
+serde = { version = "1.0.96", features = ["derive", "rc"] }
+sha-1 = { version = "0.8.2", features = ["std"] }
+subtle = { version = "2.2.2", features = ["i128", "std"] }
+syn = { version = "1.0.16", features = ["clone-impls", "derive", "extra-traits", "fold", "full", "parsing", "printing", "proc-macro", "quote", "visit", "visit-mut"] }

--- a/common/workspace-hack/README.md
+++ b/common/workspace-hack/README.md
@@ -1,0 +1,13 @@
+# libra-workspace-hack
+
+This crate is hack to unify 3rd party dependency crate features in order to
+have better compilation caching. Each time cargo is invoked, it computes
+features, so across multi invocations it may resolve differently and therefore
+find things are cached.
+
+The downside is that all code is compiled with the features needed for any
+invocation.
+
+See the
+[rustc-workspace-hack](https://github.com/rust-lang/rust/tree/master/src/tools/rustc-workspace-hack)
+for further details.

--- a/common/workspace-hack/src/lib.rs
+++ b/common/workspace-hack/src/lib.rs
@@ -1,0 +1,4 @@
+// Copyright (c) The Libra Core Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+// intentionally left blank

--- a/config/Cargo.toml
+++ b/config/Cargo.toml
@@ -25,9 +25,9 @@ lcs = { path = "../common/lcs", version = "0.1.0", package = "libra-canonical-se
 libra-crypto = { path = "../crypto/crypto", version = "0.1.0" }
 libra-crypto-derive = { path = "../crypto/crypto-derive", version = "0.1.0" }
 libra-logger = { path = "../common/logger", version = "0.1.0" }
-
 libra-temppath = { path = "../common/temppath", version = "0.1.0" }
 libra-types = { path = "../types", version = "0.1.0" }
+libra-workspace-hack = { path = "../common/workspace-hack", version = "0.1.0" }
 
 [features]
 default = []

--- a/config/config-builder/Cargo.toml
+++ b/config/config-builder/Cargo.toml
@@ -22,4 +22,5 @@ libra-crypto = { path = "../../crypto/crypto", version = "0.1.0" }
 lcs = { path = "../../common/lcs", version = "0.1.0", package = "libra-canonical-serialization" }
 libra-logger = { path = "../../common/logger", version = "0.1.0" }
 libra-types = { path = "../../types", version = "0.1.0" }
+libra-workspace-hack = { path = "../../common/workspace-hack", version = "0.1.0" }
 vm-genesis = { path = "../../language/tools/vm-genesis", version = "0.1.0" }

--- a/config/generate-keypair/Cargo.toml
+++ b/config/generate-keypair/Cargo.toml
@@ -17,3 +17,4 @@ structopt = "0.3.13"
 lcs = { path = "../../common/lcs", version = "0.1.0", package = "libra-canonical-serialization" }
 libra-crypto = { path = "../../crypto/crypto/", version = "0.1.0"}
 libra-temppath = { path = "../../common/temppath", version = "0.1.0" }
+libra-workspace-hack = { path = "../../common/workspace-hack", version = "0.1.0" }

--- a/consensus/Cargo.toml
+++ b/consensus/Cargo.toml
@@ -43,6 +43,7 @@ libra-metrics = { path = "../common/metrics", version = "0.1.0" }
 libra-security-logger = { path = "../common/security-logger", version = "0.1.0" }
 libra-temppath = { path = "../common/temppath", version = "0.1.0" }
 libra-types = { path = "../types", version = "0.1.0" }
+libra-workspace-hack = { path = "../common/workspace-hack", version = "0.1.0" }
 network = { path = "../network", version = "0.1.0" }
 safety-rules = { path = "safety-rules", version = "0.1.0" }
 state-synchronizer = { path = "../state-synchronizer", version = "0.1.0" }

--- a/consensus/consensus-types/Cargo.toml
+++ b/consensus/consensus-types/Cargo.toml
@@ -18,6 +18,7 @@ libra-crypto = { path = "../../crypto/crypto", version = "0.1.0" }
 libra-crypto-derive = { path = "../../crypto/crypto-derive", version = "0.1.0" }
 executor-types = { path = "../../execution/executor-types", version = "0.1.0" }
 libra-types = { path = "../../types", version = "0.1.0" }
+libra-workspace-hack = { path = "../../common/workspace-hack", version = "0.1.0" }
 
 [dev-dependencies]
 proptest = "0.9.6"

--- a/consensus/safety-rules/Cargo.toml
+++ b/consensus/safety-rules/Cargo.toml
@@ -20,6 +20,7 @@ libra-secure-push-metrics = { path = "../../secure/push-metrics", version = "0.1
 libra-secure-storage = { path = "../../secure/storage", version = "0.1.0" }
 libra-temppath = { path = "../../common/temppath", version = "0.1.0" }
 libra-types = { path = "../../types", version = "0.1.0" }
+libra-workspace-hack = { path = "../../common/workspace-hack", version = "0.1.0" }
 serde = { version = "1.0.106", default-features = false }
 thiserror = "1.0"
 workspace-builder = { path = "../../common/workspace-builder", version = "0.1.0" }

--- a/crypto/crypto-derive/Cargo.toml
+++ b/crypto/crypto-derive/Cargo.toml
@@ -12,6 +12,7 @@ edition = "2018"
 proc_macro = true
 
 [dependencies]
+libra-workspace-hack = { path = "../../common/workspace-hack", version = "0.1.0" }
 syn = { version = "1.0.17", features = ["derive"] }
 quote = "1.0.3"
 proc-macro2 = "1.0.10"

--- a/crypto/crypto/Cargo.toml
+++ b/crypto/crypto/Cargo.toml
@@ -32,6 +32,7 @@ x25519-dalek = { git = "https://github.com/calibra/x25519-dalek.git", branch = "
 libra-crypto-derive = { path = "../crypto-derive", version = "0.1.0" }
 lcs = { path = "../../common/lcs", version = "0.1.0", package = "libra-canonical-serialization" }
 libra-nibble = { path = "../../common/nibble", version = "0.1.0" }
+libra-workspace-hack = { path = "../../common/workspace-hack", version = "0.1.0" }
 
 [dev-dependencies]
 bitvec = "0.17.3"

--- a/devtools/x-core/Cargo.toml
+++ b/devtools/x-core/Cargo.toml
@@ -7,9 +7,8 @@ edition = "2018"
 publish = false
 license = "Apache-2.0"
 
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
-
 [dependencies]
 cargo_metadata = "0.9.1"
 guppy = "0.1.8"
+libra-workspace-hack = { path = "../../common/workspace-hack", version = "0.1.0" }
 once_cell = "1.3.1"

--- a/devtools/x-lint/Cargo.toml
+++ b/devtools/x-lint/Cargo.toml
@@ -7,9 +7,8 @@ edition = "2018"
 publish = false
 license = "Apache-2.0"
 
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
-
 [dependencies]
 guppy = "0.1.8"
+libra-workspace-hack = { path = "../../common/workspace-hack", version = "0.1.0" }
 once_cell = "1.3.1"
 x-core = { version = "0.1.0", path = "../x-core" }

--- a/devtools/x-lint/src/package.rs
+++ b/devtools/x-lint/src/package.rs
@@ -39,6 +39,11 @@ impl<'l> PackageContext<'l> {
         }
     }
 
+    /// Returns the project context
+    pub fn project_ctx(&self) -> &ProjectContext<'l> {
+        &self.project_ctx
+    }
+
     /// Returns the relative path for this package in the workspace.
     pub fn workspace_path(&self) -> &'l Path {
         self.workspace_path

--- a/devtools/x/Cargo.toml
+++ b/devtools/x/Cargo.toml
@@ -18,3 +18,4 @@ log = "0.4.8"
 chrono = "0.4.11"
 x-core = { version = "0.1.0", path = "../x-core" }
 x-lint = { version = "0.1.0", path = "../x-lint" }
+libra-workspace-hack = { path = "../../common/workspace-hack", version = "0.1.0" }

--- a/devtools/x/src/lint/mod.rs
+++ b/devtools/x/src/lint/mod.rs
@@ -26,6 +26,7 @@ pub fn run(args: Args, xctx: XContext) -> crate::Result<()> {
     let package_linters: &[&dyn PackageLinter] = &[
         &guppy::EnforcedAttributes::new(&workspace_config.enforced_attributes),
         &guppy::CrateNamesPaths,
+        &guppy::WorkspaceHack,
     ];
 
     let content_linters: &[&dyn ContentLinter] = &[

--- a/execution/executor-benchmark/Cargo.toml
+++ b/execution/executor-benchmark/Cargo.toml
@@ -28,6 +28,7 @@ libra-types = { path = "../../types", version = "0.1.0" }
 storage-client = { path = "../../storage/storage-client", version = "0.1.0" }
 transaction-builder = { path = "../../language/transaction-builder", version = "0.1.0" }
 libra-vm= { path = "../../language/libra-vm", version = "0.1.0" }
+libra-workspace-hack = { path = "../../common/workspace-hack", version = "0.1.0" }
 
 [features]
 default = []

--- a/execution/executor-types/Cargo.toml
+++ b/execution/executor-types/Cargo.toml
@@ -14,6 +14,7 @@ serde = { version = "1.0.106", default-features = false }
 
 libra-crypto = { path = "../../crypto/crypto", version = "0.1.0" }
 libra-types = { path = "../../types", version = "0.1.0" }
+libra-workspace-hack = { path = "../../common/workspace-hack", version = "0.1.0" }
 scratchpad = { path = "../../storage/scratchpad", version = "0.1.0" }
 storage-proto = { path = "../../storage/storage-proto", version = "0.1.0" }
 

--- a/execution/executor-utils/Cargo.toml
+++ b/execution/executor-utils/Cargo.toml
@@ -17,6 +17,7 @@ libra-config = { path = "../../config", version = "0.1.0" }
 storage-client = { path = "../../storage/storage-client", version = "0.1.0" }
 storage-service = { path = "../../storage/storage-service", version = "0.1.0" }
 libra-vm = { path = "../../language/libra-vm", version = "0.1.0" }
+libra-workspace-hack = { path = "../../common/workspace-hack", version = "0.1.0" }
 
 #[dev-dependencies]
 libra-crypto = { path = "../../crypto/crypto", version = "0.1.0" }

--- a/execution/executor/Cargo.toml
+++ b/execution/executor/Cargo.toml
@@ -29,6 +29,7 @@ libra-logger = { path = "../../common/logger", version = "0.1.0" }
 libra-metrics = { path = "../../common/metrics", version = "0.1.0" }
 libra-state-view = { path = "../../storage/state-view", version = "0.1.0" }
 libra-types = { path = "../../types", version = "0.1.0" }
+libra-workspace-hack = { path = "../../common/workspace-hack", version = "0.1.0" }
 scratchpad = { path = "../../storage/scratchpad", version = "0.1.0" }
 serde_json = "1.0"
 storage-client = { path = "../../storage/storage-client", version = "0.1.0" }

--- a/json-rpc/Cargo.toml
+++ b/json-rpc/Cargo.toml
@@ -30,6 +30,7 @@ libra-mempool = { path = "../mempool", version = "0.1.0" }
 libra-metrics = { path = "../common/metrics", version = "0.1.0" }
 libra-proptest-helpers = { path = "../common/proptest-helpers", optional = true }
 libra-types = { path = "../types", version = "0.1.0" }
+libra-workspace-hack = { path = "../common/workspace-hack", version = "0.1.0" }
 libradb = { path = "../storage/libradb", version = "0.1.0" }
 storage-interface = { path = "../storage/storage-interface", version = "0.1.0" }
 transaction-builder = { path = "../language/transaction-builder", version = "0.1.0"}

--- a/language/benchmarks/Cargo.toml
+++ b/language/benchmarks/Cargo.toml
@@ -19,6 +19,7 @@ language-e2e-tests = { path = "../e2e-tests", version = "0.1.0" }
 libra-proptest-helpers = { path = "../../common/proptest-helpers", version = "0.1.0" }
 libra-state-view = { path = "../../storage/state-view", version = "0.1.0" }
 libra-types = { path = "../../types", version = "0.1.0", features = ["fuzzing"] }
+libra-workspace-hack = { path = "../../common/workspace-hack", version = "0.1.0" }
 move-core-types = { path = "../move-core/types", version = "0.1.0" }
 move-lang = { path = "../move-lang", version = "0.0.1" }
 move-vm-runtime = { path = "../move-vm/runtime", version = "0.1.0" }

--- a/language/borrow-graph/Cargo.toml
+++ b/language/borrow-graph/Cargo.toml
@@ -7,4 +7,5 @@ edition = "2018"
 license = "Apache-2.0"
 
 [dependencies]
+libra-workspace-hack = { path = "../../common/workspace-hack", version = "0.1.0" }
 mirai-annotations = "1.4.0"

--- a/language/bytecode-verifier/Cargo.toml
+++ b/language/bytecode-verifier/Cargo.toml
@@ -17,6 +17,7 @@ petgraph = "0.5.0"
 borrow-graph = { path = "../borrow-graph", version = "0.0.1" }
 vm = { path = "../vm", version = "0.1.0" }
 libra-types = { path = "../../types", version = "0.1.0" }
+libra-workspace-hack = { path = "../../common/workspace-hack", version = "0.1.0" }
 move-core-types = { path = "../move-core/types", version = "0.1.0" }
 move-vm-types = { path = "../move-vm/types", version = "0.1.0" }
 

--- a/language/bytecode-verifier/bytecode-verifier-tests/Cargo.toml
+++ b/language/bytecode-verifier/bytecode-verifier-tests/Cargo.toml
@@ -15,6 +15,7 @@ proptest = "0.9.6"
 
 bytecode-verifier = { path = "../", version = "0.1.0" }
 libra-types = { path = "../../../types", version = "0.1.0", features = ["fuzzing"] }
+libra-workspace-hack = { path = "../../../common/workspace-hack", version = "0.1.0" }
 invalid-mutations = { path = "../invalid-mutations", version = "0.1.0" }
 move-core-types = { path = "../../move-core/types", version = "0.1.0" }
 vm = { path = "../../vm", version = "0.1.0", features = ["fuzzing"] }

--- a/language/bytecode-verifier/invalid-mutations/Cargo.toml
+++ b/language/bytecode-verifier/invalid-mutations/Cargo.toml
@@ -14,6 +14,7 @@ vm = { path = "../../vm", version = "0.1.0" }
 libra-types = { path = "../../../types", version = "0.1.0" }
 proptest = "0.9"
 libra-proptest-helpers = { path = "../../../common/proptest-helpers", version = "0.1.0" }
+libra-workspace-hack = { path = "../../../common/workspace-hack", version = "0.1.0" }
 
 [features]
 default = []

--- a/language/compiler/Cargo.toml
+++ b/language/compiler/Cargo.toml
@@ -16,6 +16,7 @@ ir-to-bytecode = { path = "ir-to-bytecode", version = "0.1.0" }
 bytecode-source-map = { path = "bytecode-source-map", version = "0.1.0" }
 stdlib = { path = "../stdlib", version = "0.1.0" }
 libra-types = { path = "../../types", version = "0.1.0" }
+libra-workspace-hack = { path = "../../common/workspace-hack", version = "0.1.0" }
 move-ir-types = { path = "../move-ir/types", version = "0.1.0" }
 vm = { path = "../vm", version = "0.1.0" }
 structopt = "0.3.13"

--- a/language/compiler/bytecode-source-map/Cargo.toml
+++ b/language/compiler/bytecode-source-map/Cargo.toml
@@ -9,6 +9,7 @@ edition = "2018"
 [dependencies]
 anyhow = "1.0"
 libra-types = { path = "../../../types", version = "0.1.0" }
+libra-workspace-hack = { path = "../../../common/workspace-hack", version = "0.1.0" }
 move-core-types = { path = "../../move-core/types", version = "0.1.0" }
 move-ir-types = { path = "../../move-ir/types", version = "0.1.0" }
 vm = { path = "../../vm", version = "0.1.0" }

--- a/language/compiler/ir-to-bytecode/Cargo.toml
+++ b/language/compiler/ir-to-bytecode/Cargo.toml
@@ -13,6 +13,7 @@ edition = "2018"
 anyhow = "1.0"
 ir-to-bytecode-syntax = { path = "syntax", version = "0.1.0" }
 libra-types = { path = "../../../types", version = "0.1.0" }
+libra-workspace-hack = { path = "../../../common/workspace-hack", version = "0.1.0" }
 move-core-types = { path = "../../move-core/types", version = "0.1.0" }
 move-ir-types = { path = "../../move-ir/types", version = "0.1.0" }
 vm = { path = "../../vm", version = "0.1.0" }

--- a/language/compiler/ir-to-bytecode/syntax/Cargo.toml
+++ b/language/compiler/ir-to-bytecode/syntax/Cargo.toml
@@ -16,6 +16,7 @@ hex = "0.4.2"
 move-ir-types = { path = "../../../move-ir/types", version = "0.1.0" }
 move-core-types = { path = "../../../move-core/types", version = "0.1.0" }
 libra-types = { path = "../../../../types", version = "0.1.0" }
+libra-workspace-hack = { path = "../../../../common/workspace-hack", version = "0.1.0" }
 
 [features]
 default = []

--- a/language/e2e-tests/Cargo.toml
+++ b/language/e2e-tests/Cargo.toml
@@ -19,6 +19,7 @@ libra-crypto = { path = "../../crypto/crypto", version = "0.1.0", features = ["f
 rand = "0.6.5"
 libra-state-view = { path = "../../storage/state-view", version = "0.1.0" }
 libra-types = { path = "../../types", version = "0.1.0", features = ["fuzzing"] }
+libra-workspace-hack = { path = "../../common/workspace-hack", version = "0.1.0" }
 move-core-types = { path = "../move-core/types", version = "0.1.0" }
 move-vm-cache = { path = "../move-vm/cache", version = "0.1.0" }
 move-vm-state = { path = "../move-vm/state", version = "0.1.0" }

--- a/language/functional-tests/Cargo.toml
+++ b/language/functional-tests/Cargo.toml
@@ -18,6 +18,7 @@ bytecode-verifier = { path = "../bytecode-verifier", version = "0.1.0" }
 language-e2e-tests = { path = "../e2e-tests", version = "0.1.0" }
 libra-config = { path = "../../config", version = "0.1.0" }
 libra-crypto = { path = "../../crypto/crypto", version = "0.1.0" }
+libra-workspace-hack = { path = "../../common/workspace-hack", version = "0.1.0" }
 once_cell = "1.3.1"
 regex = { version = "1.3.6", default-features = false, features = ["std", "perf"] }
 thiserror = "1.0"

--- a/language/ir-testsuite/Cargo.toml
+++ b/language/ir-testsuite/Cargo.toml
@@ -15,6 +15,7 @@ datatest-stable = { path = "../../common/datatest-stable", version = "0.1.0" }
 functional-tests = { path = "../functional-tests", version = "0.1.0" }
 ir-to-bytecode = { path = "../compiler/ir-to-bytecode", version = "0.1.0" }
 libra-types = { path = "../../types", version = "0.1.0" }
+libra-workspace-hack = { path = "../../common/workspace-hack", version = "0.1.0" }
 move-ir-types = { path = "../move-ir/types", version = "0.1.0" }
 stdlib = { path = "../stdlib", version = "0.1.0" }
 vm = { path = "../vm", version = "0.1.0" }

--- a/language/libra-vm/Cargo.toml
+++ b/language/libra-vm/Cargo.toml
@@ -24,6 +24,7 @@ libra-logger = { path = "../../common/logger", version = "0.1.0" }
 libra-metrics = { path = "../../common/metrics", version = "0.1.0" }
 libra-state-view = { path = "../../storage/state-view", version = "0.1.0" }
 libra-types = { path = "../../types", version = "0.1.0" }
+libra-workspace-hack = { path = "../../common/workspace-hack", version = "0.1.0" }
 move-core-types = { path = "../move-core/types", version = "0.1.0" }
 move-vm-cache = { path = "../move-vm/cache", version = "0.1.0" }
 move-vm-runtime = { path = "../move-vm/runtime", version = "0.1.0" }

--- a/language/move-core/types/Cargo.toml
+++ b/language/move-core/types/Cargo.toml
@@ -17,6 +17,7 @@ ref-cast = "1.0"
 serde = { version = "1.0.106", default-features = false }
 
 lcs = { path = "../../../common/lcs", version = "0.1.0", package = "libra-canonical-serialization" }
+libra-workspace-hack = { path = "../../../common/workspace-hack", version = "0.1.0" }
 
 [dev-dependencies]
 once_cell = "1.3.1"

--- a/language/move-ir/types/Cargo.toml
+++ b/language/move-ir/types/Cargo.toml
@@ -18,4 +18,5 @@ hex = "0.4.2"
 once_cell = "1.3.1"
 
 libra-types = { path = "../../../types", version = "0.1.0" }
+libra-workspace-hack = { path = "../../../common/workspace-hack", version = "0.1.0" }
 move-core-types = { path = "../../move-core/types", version = "0.1.0" }

--- a/language/move-lang/Cargo.toml
+++ b/language/move-lang/Cargo.toml
@@ -19,6 +19,7 @@ datatest-stable = { path = "../../common/datatest-stable", version = "0.1.0" }
 move-vm = { path = "../vm", package = "vm" }
 move-bytecode-verifier = { path = "../bytecode-verifier", package = "bytecode-verifier" }
 libra-types = { path = "../../types" }
+libra-workspace-hack = { path = "../../common/workspace-hack", version = "0.1.0" }
 move-ir-types = {path = "../move-ir/types" }
 ir-to-bytecode = {path = "../compiler/ir-to-bytecode" }
 borrow-graph = { path = "../borrow-graph" }

--- a/language/move-prover/Cargo.toml
+++ b/language/move-prover/Cargo.toml
@@ -14,6 +14,7 @@ stackless-bytecode-generator = { path = "stackless-bytecode-generator", version 
 vm = { path = "../vm", version = "0.1.0" }
 libra-types = { path = "../../types", version = "0.1.0" }
 libra-temppath = { path = "../../common/temppath", version = "0.1.0" }
+libra-workspace-hack = { path = "../../common/workspace-hack", version = "0.1.0" }
 bytecode-source-map = { path = "../compiler/bytecode-source-map", version = "0.1.0" }
 move-ir-types = { path = "../move-ir/types", version = "0.1.0" }
 stdlib = { path = "../stdlib", version = "0.1.0" }

--- a/language/move-prover/spec-lang/Cargo.toml
+++ b/language/move-prover/spec-lang/Cargo.toml
@@ -12,6 +12,7 @@ move-lang = { path = "../../move-lang", version = "0.0.1" }
 bytecode-verifier = { path = "../../bytecode-verifier", version = "0.1.0" }
 vm = { path = "../../vm", version = "0.1.0" }
 libra-types = { path = "../../../types", version = "0.1.0" }
+libra-workspace-hack = { path = "../../../common/workspace-hack", version = "0.1.0" }
 bytecode-source-map = { path = "../../compiler/bytecode-source-map", version = "0.1.0" }
 move-ir-types = { path = "../../move-ir/types", version = "0.1.0" }
 stdlib = { path = "../../stdlib", version = "0.1.0" }

--- a/language/move-prover/stackless-bytecode-generator/Cargo.toml
+++ b/language/move-prover/stackless-bytecode-generator/Cargo.toml
@@ -14,6 +14,7 @@ spec-lang = { path = "../spec-lang", version = "0.0.1" }
 vm = { path = "../../vm", version = "0.1.0" }
 bytecode-verifier = { path = "../../bytecode-verifier", version = "0.1.0" }
 ir-to-bytecode = { path = "../../compiler/ir-to-bytecode", version = "0.1.0" }
+libra-workspace-hack = { path = "../../../common/workspace-hack", version = "0.1.0" }
 stdlib = { path = "../../stdlib", version = "0.1.0" }
 num = "0.2.0"
 

--- a/language/move-prover/test-utils/Cargo.toml
+++ b/language/move-prover/test-utils/Cargo.toml
@@ -10,3 +10,4 @@ prettydiff = "0.3.1"
 itertools = "0.9.0"
 anyhow = "1.0.*"
 regex = "1.3.6"
+libra-workspace-hack = { path = "../../../common/workspace-hack", version = "0.1.0" }

--- a/language/move-vm/cache/Cargo.toml
+++ b/language/move-vm/cache/Cargo.toml
@@ -10,6 +10,7 @@ publish = false
 edition = "2018"
 
 [dependencies]
+libra-workspace-hack = { path = "../../../common/workspace-hack", version = "0.1.0" }
 typed-arena = "2.0.1"
 
 [dev-dependencies]

--- a/language/move-vm/runtime/Cargo.toml
+++ b/language/move-vm/runtime/Cargo.toml
@@ -20,6 +20,7 @@ bytecode-verifier = { path = "../../bytecode-verifier", version = "0.1.0" }
 libra-crypto = { path = "../../../crypto/crypto", version = "0.1.0" }
 libra-logger = { path = "../../../common/logger", version = "0.1.0" }
 libra-types = { path = "../../../types", version = "0.1.0" }
+libra-workspace-hack = { path = "../../../common/workspace-hack", version = "0.1.0" }
 move-core-types = { path = "../../move-core/types", version = "0.1.0" }
 move-vm-cache = { path = "../cache", version = "0.1.0" }
 move-vm-types = { path = "../types", version = "0.1.0" }

--- a/language/move-vm/state/Cargo.toml
+++ b/language/move-vm/state/Cargo.toml
@@ -17,5 +17,6 @@ lcs = { path = "../../../common/lcs", version = "0.1.0", package = "libra-canoni
 libra-logger = { path = "../../../common/logger", version = "0.1.0" }
 libra-state-view = { path = "../../../storage/state-view", version = "0.1.0" }
 libra-types = { path = "../../../types", version = "0.1.0" }
+libra-workspace-hack = { path = "../../../common/workspace-hack", version = "0.1.0" }
 move-vm-types = { path = "../types", version = "0.1.0" }
 vm = { path = "../../vm", version = "0.1.0" }

--- a/language/move-vm/types/Cargo.toml
+++ b/language/move-vm/types/Cargo.toml
@@ -17,6 +17,7 @@ sha2 = "0.8.0"
 serde = { version = "1.0", features = ["derive", "rc"] }
 
 libra-types = { path = "../../../types", version = "0.1.0" }
+libra-workspace-hack = { path = "../../../common/workspace-hack", version = "0.1.0" }
 vm = { path = "../../vm", version = "0.1.0" }
 lcs = { path = "../../../common/lcs", version = "0.1.0", package = "libra-canonical-serialization" }
 libra-crypto = { path = "../../../crypto/crypto", version = "0.1.0" }

--- a/language/stdlib/Cargo.toml
+++ b/language/stdlib/Cargo.toml
@@ -15,6 +15,7 @@ bytecode-verifier = { path = "../bytecode-verifier", version = "0.1.0" }
 move-lang = { path = "../move-lang" }
 libra-crypto = { path = "../../crypto/crypto", version = "0.1.0" }
 libra-types = { path = "../../types", version = "0.1.0" }
+libra-workspace-hack = { path = "../../common/workspace-hack", version = "0.1.0" }
 datatest-stable = { path = "../../common/datatest-stable", version = "0.1.0" }
 lcs = { path = "../../common/lcs", version = "0.1.0", package = "libra-canonical-serialization" }
 vm = { path = "../vm", version = "0.1.0" }

--- a/language/tools/disassembler/Cargo.toml
+++ b/language/tools/disassembler/Cargo.toml
@@ -12,6 +12,7 @@ bytecode-verifier = { path = "../../bytecode-verifier", version = "0.1.0" }
 bytecode-source-map = { path = "../../compiler/bytecode-source-map", version = "0.1.0" }
 ir-to-bytecode-syntax = { path = "../../compiler/ir-to-bytecode/syntax", version = "0.1.0" }
 libra-types = { path = "../../../types", version = "0.1.0" }
+libra-workspace-hack = { path = "../../../common/workspace-hack", version = "0.1.0" }
 move-core-types = { path = "../../move-core/types", version = "0.1.0" }
 move-ir-types = { path = "../../move-ir/types", version = "0.1.0" }
 vm = { path = "../../vm", version = "0.1.0" }

--- a/language/tools/genesis-viewer/Cargo.toml
+++ b/language/tools/genesis-viewer/Cargo.toml
@@ -12,6 +12,7 @@ edition = "2018"
 [dependencies]
 lcs = { path = "../../../common/lcs", version = "0.1.0", package = "libra-canonical-serialization" }
 libra-types = { path = "../../../types", version = "0.1.0" }
+libra-workspace-hack = { path = "../../../common/workspace-hack", version = "0.1.0" }
 vm = { path = "../../vm", version = "0.1.0" }
 
 structopt = "0.3.13"

--- a/language/tools/test-generation/Cargo.toml
+++ b/language/tools/test-generation/Cargo.toml
@@ -23,6 +23,7 @@ bytecode-verifier = { path = "../../bytecode-verifier", version = "0.1.0" }
 libra-config = { path = "../../../config", version = "0.1.0" }
 libra-logger = { path = "../../../common/logger", version = "0.1.0" }
 libra-state-view = { path = "../../../storage/state-view", version = "0.1.0" }
+libra-workspace-hack = { path = "../../../common/workspace-hack", version = "0.1.0" }
 move-core-types = { path = "../../move-core/types", version = "0.1.0" }
 move-vm-cache = { path = "../../move-vm/cache", version = "0.1.0" }
 move-vm-types = { path = "../../move-vm/types", version = "0.1.0" }

--- a/language/tools/utils/Cargo.toml
+++ b/language/tools/utils/Cargo.toml
@@ -17,6 +17,7 @@ ir-to-bytecode = { path = "../../compiler/ir-to-bytecode", version = "0.1.0" }
 move-core-types = { path = "../../move-core/types", version = "0.1.0" }
 move-ir-types = { path = "../../move-ir/types", version = "0.1.0" }
 libra-types = { path = "../../../types", version = "0.1.0" }
+libra-workspace-hack = { path = "../../../common/workspace-hack", version = "0.1.0" }
 vm = { path = "../../vm", version = "0.1.0" }
 
 [features]

--- a/language/tools/vm-genesis/Cargo.toml
+++ b/language/tools/vm-genesis/Cargo.toml
@@ -20,6 +20,7 @@ libra-config = { path = "../../../config", version = "0.1.0" }
 libra-crypto = { path = "../../../crypto/crypto", version = "0.1.0" }
 libra-state-view = { path = "../../../storage/state-view", version = "0.1.0" }
 libra-types = { path = "../../../types", version = "0.1.0" }
+libra-workspace-hack = { path = "../../../common/workspace-hack", version = "0.1.0" }
 move-core-types = { path = "../../move-core/types", version = "0.1.0" }
 move-vm-cache = { path = "../../move-vm/cache", version = "0.1.0" }
 move-vm-runtime = { path = "../../move-vm/runtime", version = "0.1.0"}

--- a/language/transaction-builder/Cargo.toml
+++ b/language/transaction-builder/Cargo.toml
@@ -14,6 +14,7 @@ mirai-annotations = "1.6.1"
 libra-config = { path = "../../config", version = "0.1.0" }
 stdlib = { path = "../stdlib", version = "0.1.0" }
 libra-types = { path = "../../types", version = "0.1.0" }
+libra-workspace-hack = { path = "../../common/workspace-hack", version = "0.1.0" }
 vm = { path = "../vm", version = "0.1.0" }
 lcs = { path = "../../common/lcs", version = "0.1.0", package = "libra-canonical-serialization" }
 

--- a/language/vm/Cargo.toml
+++ b/language/vm/Cargo.toml
@@ -24,6 +24,7 @@ lcs = { path = "../../common/lcs", version = "0.1.0", package = "libra-canonical
 libra-crypto = { path = "../../crypto/crypto", version = "0.1.0" }
 libra-proptest-helpers = { path = "../../common/proptest-helpers", version = "0.1.0", optional = true }
 libra-types = { path = "../../types", version = "0.1.0" }
+libra-workspace-hack = { path = "../../common/workspace-hack", version = "0.1.0" }
 move-core-types = { path = "../move-core/types", version = "0.1.0" }
 num-variants = { path = "../../common/num-variants", version = "0.1.0" }
 

--- a/language/vm/serializer-tests/Cargo.toml
+++ b/language/vm/serializer-tests/Cargo.toml
@@ -10,6 +10,7 @@ publish = false
 edition = "2018"
 
 [dev-dependencies]
+libra-workspace-hack = { path = "../../../common/workspace-hack", version = "0.1.0" }
 proptest = "0.9"
 proptest-derive = "0.1.1"
 vm = { path = "../", version = "0.1.0", features = ["fuzzing"] }

--- a/libra-node/Cargo.toml
+++ b/libra-node/Cargo.toml
@@ -37,6 +37,7 @@ storage-service = { path = "../storage/storage-service", version = "0.1.0" }
 subscription-service = { path = "../common/subscription-service", version = "0.1.0" }
 libra-types = { path = "../types", version = "0.1.0" }
 libra-vm = { path = "../language/libra-vm", version = "0.1.0" }
+libra-workspace-hack = { path = "../common/workspace-hack", version = "0.1.0" }
 
 [features]
 default = []

--- a/libra-swarm/Cargo.toml
+++ b/libra-swarm/Cargo.toml
@@ -24,4 +24,5 @@ libra-logger = { path = "../common/logger", version = "0.1.0" }
 libra-crypto = { path = "../crypto/crypto", version = "0.1.0", features = ["cloneable-private-keys"] }
 libra-temppath = { path = "../common/temppath", version = "0.1.0" }
 libra-types = { path = "../types", version = "0.1.0" }
+libra-workspace-hack = { path = "../common/workspace-hack", version = "0.1.0" }
 workspace-builder = { path = "../common/workspace-builder", version = "0.1.0" }

--- a/mempool/Cargo.toml
+++ b/mempool/Cargo.toml
@@ -29,6 +29,7 @@ libra-logger = { path = "../common/logger", version = "0.1.0" }
 libra-metrics = { path = "../common/metrics", version = "0.1.0" }
 libra-security-logger = { path = "../common/security-logger", version = "0.1.0" }
 libra-types = { path = "../types", version = "0.1.0" }
+libra-workspace-hack = { path = "../common/workspace-hack", version = "0.1.0" }
 mirai-annotations = "1.5.0"
 network = { path = "../network", version = "0.1.0" }
 prometheus = { version = "0.8.0", default-features = false }

--- a/network/Cargo.toml
+++ b/network/Cargo.toml
@@ -34,6 +34,7 @@ libra-types = { path = "../types", version = "0.1.0" }
 libra-logger = { path = "../common/logger", version = "0.1.0" }
 libra-metrics = { path = "../common/metrics", version = "0.1.0" }
 libra-security-logger = { path = "../common/security-logger", version = "0.1.0" }
+libra-workspace-hack = { path = "../common/workspace-hack", version = "0.1.0" }
 memsocket = { path = "memsocket", version = "0.1.0" }
 netcore = { path = "netcore", version = "0.1.0" }
 noise = { path = "noise", version = "0.1.0" }

--- a/network/memsocket/Cargo.toml
+++ b/network/memsocket/Cargo.toml
@@ -13,3 +13,4 @@ publish = false
 futures = "0.3.0"
 bytes = "0.5.4"
 once_cell = "1.3.1"
+libra-workspace-hack = { path = "../../common/workspace-hack", version = "0.1.0" }

--- a/network/netcore/Cargo.toml
+++ b/network/netcore/Cargo.toml
@@ -13,6 +13,7 @@ edition = "2018"
 async-trait = "0.1"
 bytes = "0.5.4"
 futures = { version = "0.3.4"  }
+libra-workspace-hack = { path = "../../common/workspace-hack", version = "0.1.0" }
 memsocket = { path = "../memsocket", version = "0.1.0" }
 parity-multiaddr = { version = "0.8.0", default-features = false }
 pin-project = "0.4.2"

--- a/network/noise/Cargo.toml
+++ b/network/noise/Cargo.toml
@@ -15,6 +15,7 @@ snow = { version = "0.6.1", features=["ring-accelerated"]}
 libra-crypto = { path = "../../crypto/crypto", version = "0.1.0" }
 netcore = { path = "../netcore", version = "0.1.0" }
 libra-logger = { path = "../../common/logger", version = "0.1.0" }
+libra-workspace-hack = { path = "../../common/workspace-hack", version = "0.1.0" }
 
 # used by fuzzing
 libra-proptest-helpers = { path = "../../common/proptest-helpers", optional = true }

--- a/network/socket-bench-server/Cargo.toml
+++ b/network/socket-bench-server/Cargo.toml
@@ -16,6 +16,7 @@ tokio = { version = "0.2.13", features = ["full"] }
 tokio-util = { version = "0.3", features = ["codec"] }
 
 libra-logger = { path = "../../common/logger", version = "0.1.0" }
+libra-workspace-hack = { path = "../../common/workspace-hack", version = "0.1.0" }
 memsocket = { path = "../memsocket", version = "0.1.0" }
 netcore = { path = "../netcore", version = "0.1.0" }
 noise = { path = "../noise", version = "0.1.0", features = ["testing"] }

--- a/secure/key-manager/Cargo.toml
+++ b/secure/key-manager/Cargo.toml
@@ -16,6 +16,7 @@ libra-secure-storage = { path = "../../secure/storage", version = "0.1.0" }
 libra-secure-time = { path = "../../secure/time", version = "0.1.0" }
 libra-transaction-scripts = { path = "../transaction-scripts", version = "0.1.0" }
 libra-types = { path = "../../types", version = "0.1.0" }
+libra-workspace-hack = { path = "../../common/workspace-hack", version = "0.1.0" }
 thiserror = "1.0"
 
 [dev-dependencies]

--- a/secure/net/Cargo.toml
+++ b/secure/net/Cargo.toml
@@ -11,6 +11,7 @@ edition = "2018"
 
 [dependencies]
 libra-logger = { path = "../../common/logger", version = "0.1.0" }
+libra-workspace-hack = { path = "../../common/workspace-hack", version = "0.1.0" }
 thiserror = "1.0"
 
 [dev-dependencies]

--- a/secure/push-metrics/Cargo.toml
+++ b/secure/push-metrics/Cargo.toml
@@ -12,3 +12,4 @@ edition = "2018"
 [dependencies]
 ureq = { version = "0.12.0", features = ["json"] }
 libra-logger = { path = "../../common/logger", version = "0.1.0" }
+libra-workspace-hack = { path = "../../common/workspace-hack", version = "0.1.0" }

--- a/secure/storage/Cargo.toml
+++ b/secure/storage/Cargo.toml
@@ -17,6 +17,7 @@ libra-crypto = { path = "../../crypto/crypto", version = "0.1.0" }
 libra-secure-time = { path = "../time", version = "0.1.0" }
 libra-temppath = { path = "../../common/temppath", version = "0.1.0" }
 libra-vault-client = { path = "vault", version = "0.1.0" }
+libra-workspace-hack = { path = "../../common/workspace-hack", version = "0.1.0" }
 rand = "0.6.5"
 serde = { version = "1.0.106", features = ["rc"], default-features = false }
 serde_json = "1.0.51"

--- a/secure/storage/vault/Cargo.toml
+++ b/secure/storage/vault/Cargo.toml
@@ -16,3 +16,4 @@ serde_json = "1.0.40"
 thiserror = "1.0"
 ureq = { version = "0.12.0", features = ["json"] }
 libra-crypto = { path = "../../../crypto/crypto", version = "0.1.0" }
+libra-workspace-hack = { path = "../../../common/workspace-hack", version = "0.1.0" }

--- a/secure/transaction-scripts/Cargo.toml
+++ b/secure/transaction-scripts/Cargo.toml
@@ -12,3 +12,4 @@ publish = false
 [dependencies]
 once_cell = "1.3.1"
 include_dir = "0.5.0"
+libra-workspace-hack = { path = "../../common/workspace-hack", version = "0.1.0" }

--- a/state-synchronizer/Cargo.toml
+++ b/state-synchronizer/Cargo.toml
@@ -30,6 +30,7 @@ libra-logger = { path = "../common/logger", version = "0.1.0" }
 libra-mempool = { path = "../mempool", version = "0.1.0"}
 libra-metrics = { path = "../common/metrics", version = "0.1.0" }
 libra-types = { path = "../types", version = "0.1.0" }
+libra-workspace-hack = { path = "../common/workspace-hack", version = "0.1.0" }
 network = { path = "../network", version = "0.1.0" }
 storage-client = { path = "../storage/storage-client", version = "0.1.0" }
 subscription-service = { path = "../common/subscription-service", version = "0.1.0" }

--- a/storage/accumulator/Cargo.toml
+++ b/storage/accumulator/Cargo.toml
@@ -14,6 +14,7 @@ anyhow = "1.0"
 libra-crypto = { path = "../../crypto/crypto", version = "0.1.0" }
 mirai-annotations = "1.5.0"
 libra-types = { path = "../../types", version = "0.1.0" }
+libra-workspace-hack = { path = "../../common/workspace-hack", version = "0.1.0" }
 
 [dev-dependencies]
 rand = "0.6.5"

--- a/storage/backup-restore/Cargo.toml
+++ b/storage/backup-restore/Cargo.toml
@@ -23,6 +23,7 @@ lcs = { path = "../../common/lcs", package = "libra-canonical-serialization", ve
 libradb = { path = "../libradb", version = "0.1.0" }
 libra-crypto = { path = "../../crypto/crypto", version = "0.1.0" }
 libra-types = { path = "../../types", version = "0.1.0" }
+libra-workspace-hack = { path = "../../common/workspace-hack", version = "0.1.0" }
 storage-client = { path = "../storage-client", version = "0.1.0" }
 
 [dev-dependencies]

--- a/storage/inspector/Cargo.toml
+++ b/storage/inspector/Cargo.toml
@@ -17,5 +17,6 @@ libradb = { path = "../libradb", version = "0.1.0" }
 libra-crypto = { path = "../../crypto/crypto", version = "0.1.0" }
 libra-types = { path = "../../types", version = "0.1.0" }
 libra-logger = { path = "../../common/logger", version = "0.1.0" }
+libra-workspace-hack = { path = "../../common/workspace-hack", version = "0.1.0" }
 storage-interface = { path = "../storage-interface", version = "0.1.0" }
 transaction-builder = { path = "../../language/transaction-builder", version = "0.1.0" }

--- a/storage/jellyfish-merkle/Cargo.toml
+++ b/storage/jellyfish-merkle/Cargo.toml
@@ -25,6 +25,7 @@ libra-crypto = { path = "../../crypto/crypto", version = "0.1.0" }
 libra-crypto-derive = { path = "../../crypto/crypto-derive", version = "0.1.0" }
 libra-nibble = { path = "../../common/nibble", version = "0.1.0" }
 libra-types = { path = "../../types", version = "0.1.0" }
+libra-workspace-hack = { path = "../../common/workspace-hack", version = "0.1.0" }
 
 [dev-dependencies]
 rand = "0.6.5"

--- a/storage/libradb/Cargo.toml
+++ b/storage/libradb/Cargo.toml
@@ -35,6 +35,7 @@ storage-proto = { path = "../storage-proto", version = "0.1.0" }
 libra-types = { path = "../../types", version = "0.1.0" }
 libra-proptest-helpers = { path = "../../common/proptest-helpers", version = "0.1.0", optional = true }
 libra-temppath = { path = "../../common/temppath", version = "0.1.0", optional = true }
+libra-workspace-hack = { path = "../../common/workspace-hack", version = "0.1.0" }
 num-variants = { path = "../../common/num-variants", version = "0.1.0" }
 
 [dev-dependencies]

--- a/storage/schemadb/Cargo.toml
+++ b/storage/schemadb/Cargo.toml
@@ -13,6 +13,7 @@ edition = "2018"
 anyhow = "1.0"
 once_cell = "1.3.1"
 libra-metrics = { path = "../../common/metrics", version = "0.1.0" }
+libra-workspace-hack = { path = "../../common/workspace-hack", version = "0.1.0" }
 rocksdb = {git = "https://github.com/tikv/rust-rocksdb.git", rev="72e45c3f3283302c825d53c3cd7154f4cd9e8f5b"}
 
 [dev-dependencies]

--- a/storage/scratchpad/Cargo.toml
+++ b/storage/scratchpad/Cargo.toml
@@ -14,6 +14,7 @@ itertools = "0.9.0"
 
 libra-crypto = { path = "../../crypto/crypto", version = "0.1.0" }
 libra-types = { path = "../../types", version = "0.1.0" }
+libra-workspace-hack = { path = "../../common/workspace-hack", version = "0.1.0" }
 
 [dev-dependencies]
 proptest = "0.9.6"

--- a/storage/state-view/Cargo.toml
+++ b/storage/state-view/Cargo.toml
@@ -12,6 +12,7 @@ edition = "2018"
 [dependencies]
 anyhow = "1.0"
 libra-types = { path = "../../types", version = "0.1.0" }
+libra-workspace-hack = { path = "../../common/workspace-hack", version = "0.1.0" }
 
 [features]
 default = []

--- a/storage/storage-client/Cargo.toml
+++ b/storage/storage-client/Cargo.toml
@@ -20,6 +20,7 @@ libra-state-view = { path = "../state-view", version = "0.1.0" }
 storage-interface = { path = "../storage-interface", version = "0.1.0" }
 storage-proto = { path = "../storage-proto", version = "0.1.0" }
 libra-types = { path = "../../types", version = "0.1.0" }
+libra-workspace-hack = { path = "../../common/workspace-hack", version = "0.1.0" }
 tokio = { version = "0.2.13", features = ["full"] }
 
 [features]

--- a/storage/storage-interface/Cargo.toml
+++ b/storage/storage-interface/Cargo.toml
@@ -16,3 +16,4 @@ serde = { version = "1.0.106", default-features = false }
 libra-crypto = { path = "../../crypto/crypto", version = "0.1.0" }
 storage-proto = { path = "../storage-proto", version = "0.1.0" }
 libra-types = { path = "../../types", version = "0.1.0" }
+libra-workspace-hack = { path = "../../common/workspace-hack", version = "0.1.0" }

--- a/storage/storage-proto/Cargo.toml
+++ b/storage/storage-proto/Cargo.toml
@@ -18,6 +18,7 @@ prost = "0.6"
 
 libra-crypto = { path = "../../crypto/crypto", version = "0.1.0" }
 libra-types = { path = "../../types", version = "0.1.0" }
+libra-workspace-hack = { path = "../../common/workspace-hack", version = "0.1.0" }
 
 [build-dependencies]
 tonic-build = "0.2"

--- a/storage/storage-service/Cargo.toml
+++ b/storage/storage-service/Cargo.toml
@@ -25,6 +25,7 @@ libra-metrics = { path = "../../common/metrics", version = "0.1.0" }
 storage-interface = { path = "../storage-interface", version = "0.1.0" }
 storage-proto = { path = "../storage-proto", version = "0.1.0" }
 libra-types = { path = "../../types", version = "0.1.0" }
+libra-workspace-hack = { path = "../../common/workspace-hack", version = "0.1.0" }
 rand = { version = "0.6.5", optional = true }
 proptest = { version = "0.9.6", optional = true }
 storage-client = { path = "../storage-client", version = "0.1.0", optional = true }

--- a/testsuite/Cargo.toml
+++ b/testsuite/Cargo.toml
@@ -30,3 +30,4 @@ libra-config = { path = "../config", version = "0.1.0" }
 libra-types = { path = "../types", version = "0.1.0" }
 libra-temppath = { path = "../common/temppath", version = "0.1.0" }
 libra-crypto = { path = "../crypto/crypto", version = "0.1.0", features = ["fuzzing"] }
+libra-workspace-hack = { path = "../common/workspace-hack", version = "0.1.0" }

--- a/testsuite/cluster-test/Cargo.toml
+++ b/testsuite/cluster-test/Cargo.toml
@@ -42,6 +42,7 @@ libra-crypto = { path = "../../crypto/crypto", version = "0.1.0" }
 libra-config = { path = "../../config", version = "0.1.0" }
 libra-logger = { path = "../../common/logger", version = "0.1.0", features = ["no_struct_log"] }
 libra-types = { path = "../../types", version = "0.1.0", features = ["fuzzing"] }
+libra-workspace-hack = { path = "../../common/workspace-hack", version = "0.1.0" }
 transaction-builder = { path = "../../language/transaction-builder", version = "0.1.0" }
 
 futures = "0.3.0"

--- a/testsuite/generate-format/Cargo.toml
+++ b/testsuite/generate-format/Cargo.toml
@@ -14,8 +14,9 @@ proptest = "0.9.6"
 serde_yaml = "0.8"
 structopt = "0.3.13"
 
-libra-types = { path = "../../types", version = "0.1.0", features=["fuzzing"] }
 lcs = { path = "../../common/lcs", version = "0.1.0", package = "libra-canonical-serialization" }
+libra-types = { path = "../../types", version = "0.1.0", features=["fuzzing"] }
+libra-workspace-hack = { path = "../../common/workspace-hack", version = "0.1.0" }
 serde-reflection = { path = "../../common/serde-reflection", version = "0.1.0" }
 
 [[bin]]

--- a/testsuite/libra-fuzzer/Cargo.toml
+++ b/testsuite/libra-fuzzer/Cargo.toml
@@ -18,6 +18,7 @@ once_cell = "1.3.1"
 proptest = { version = "0.9.6", default-features = false }
 libra-proptest-helpers = { path = "../../common/proptest-helpers", version = "0.1.0" }
 libra-prost-ext = { path = "../../common/prost-ext", version = "0.1.0" }
+libra-workspace-hack = { path = "../../common/workspace-hack", version = "0.1.0" }
 prost = "0.6"
 rusty-fork = { version = "0.2.2", default-features = false }
 sha-1 = { version = "0.8.1", default-features = false }

--- a/testsuite/libra-fuzzer/fuzz/Cargo.toml
+++ b/testsuite/libra-fuzzer/fuzz/Cargo.toml
@@ -15,6 +15,7 @@ cargo-fuzz = true
 [dependencies]
 libfuzzer-sys = "0.3.2"
 libra-fuzzer = { path = "..", version = "0.1.0" }
+libra-workspace-hack = { path = "../../../common/workspace-hack", version = "0.1.0" }
 once_cell = "1.3.1"
 
 # Prevent this from interfering with workspaces

--- a/types/Cargo.toml
+++ b/types/Cargo.toml
@@ -31,6 +31,7 @@ lcs = { path = "../common/lcs", version = "0.1.0", package = "libra-canonical-se
 libra-crypto = { path = "../crypto/crypto", version = "0.1.0" }
 libra-crypto-derive = { path = "../crypto/crypto-derive", version = "0.1.0" }
 libra-proptest-helpers = { path = "../common/proptest-helpers", version = "0.1.0", optional = true }
+libra-workspace-hack = { path = "../common/workspace-hack", version = "0.1.0" }
 move-core-types = { path = "../language/move-core/types", version = "0.1.0" }
 
 [build-dependencies]

--- a/vm-validator/Cargo.toml
+++ b/vm-validator/Cargo.toml
@@ -21,6 +21,7 @@ storage-client = { path = "../storage/storage-client", version = "0.1.0" }
 storage-interface = { path = "../storage/storage-interface", version = "0.1.0" }
 libra-types = { path = "../types", version = "0.1.0" }
 libra-vm = { path = "../language/libra-vm", version = "0.1.0" }
+libra-workspace-hack = { path = "../common/workspace-hack", version = "0.1.0" }
 
 [dev-dependencies]
 rand = "0.6.5"


### PR DESCRIPTION
By unifying the features requested in third party dependencies, this crate
improves caching and should speed up build/test time. Each time cargo is
invoked, it resolves features for its targets, but since the targets change
every invocation potentially, the resolved features for third party crates
might also change, causing those third party crates to be recompiled. This
unifies the features among third party crates so that every feature resolution
is the same for third party crates.

The downside is we have dependencies to libra-workspace-hack from every first
party crate, and we create new, unused dependency edges from some crates to
third party dependencies. Both downsides can be mitigated by using cargo-guppy
with the `--omit-edges-into libra-workspace-hack`.

This solution is modeled on the one in the rust compiler, which is at
https://github.com/rust-lang/rust/tree/master/src/tools/rustc-workspace-hack