### PR TITLE
[LBT][GHA] combine build and test jobs

### DIFF
--- a/.github/workflows/land-blocking.yml
+++ b/.github/workflows/land-blocking.yml
@@ -7,10 +7,10 @@ on:
       - auto
 
 jobs:
-  build-images:
-    name: Build images
+  build-and-run-cluster-test:
+    name: Build images and run cluster test
     runs-on: self-hosted
-    timeout-minutes: 15
+    timeout-minutes: 20
     steps:
       - uses: actions/checkout@v1
       - name: Setup env
@@ -46,25 +46,6 @@ jobs:
           done
           echo "Build failed after retries"
           exit 1
-  build-and-run-cluster-test:
-    name: Build images and run cluster test
-    needs: build-images
-    runs-on: self-hosted
-    timeout-minutes: 20
-    steps:
-      - uses: actions/checkout@v1
-      - name: Setup env
-        run: |
-          echo "::set-env name=LIBRA_GIT_REV::$(git rev-parse --short=8 HEAD)"
-          echo "::set-env name=TEST_TAG::land_$(git rev-parse --short=8 HEAD)"
-      - name: Check kill switch
-        id: check_ks
-        run: |
-          if ${{ secrets.KILL_SWITCH_LAND_BLOCKING_TEST }} || ! .circleci/should_run_lbt.sh ; then
-            echo "::set-output name=should_run::false";
-          else
-            echo "::set-output name=should_run::true";
-          fi;
       - name: Launch cluster test
         if: steps.check_ks.outputs.should_run == 'true'
         # NOTE Remember to update PR comment payload if cti cmd is updated.


### PR DESCRIPTION
LBT divides the workflow into has two jobs: build and test. Only the
test job will comment on the PR when it fails.  If the build job fails,
the PR owner is left in the dark, pondering why their PR isn't landing.

This commit is a temp fix to combine the jobs to leverage the comment
step.  The proper long term fix, however, is to generalize this comment
step into a standalone action so that it can be reused in other
jobs or workflows.

Case in point,  #3103 is trying to land aaa5819.
- The build failed in https://github.com/libra/libra/runs/538101233?check_suite_focus=true
<img width="1322" alt="image" src="https://user-images.githubusercontent.com/7528420/77709305-d4d1aa80-6f87-11ea-80e7-6f91dd9613f5.png">

- No comment posted in the PR alerting the owner about the breakage
<img width="803" alt="image" src="https://user-images.githubusercontent.com/7528420/77709235-a8b62980-6f87-11ea-9201-3fdb8b373d8d.png">
