### PR TITLE
[move-prover] added plumbing for translating specs inside functions into Boogie

### DIFF
--- a/language/move-prover/spec-lang/src/ast.rs
+++ b/language/move-prover/spec-lang/src/ast.rs
@@ -50,6 +50,24 @@ pub enum ConditionKind {
     Requires,
 }
 
+impl ConditionKind {
+    pub fn on_decl(&self) -> bool {
+        use ConditionKind::*;
+        match self {
+            AbortsIf | Ensures | Requires => true,
+            _ => false,
+        }
+    }
+
+    pub fn on_impl(&self) -> bool {
+        use ConditionKind::*;
+        match self {
+            Assert | Assume | Decreases => true,
+            _ => false,
+        }
+    }
+}
+
 #[derive(Debug)]
 pub struct Condition {
     pub loc: Loc,

--- a/language/move-prover/spec-lang/src/env.rs
+++ b/language/move-prover/spec-lang/src/env.rs
@@ -22,9 +22,9 @@ use libra_types::language_storage;
 use vm::{
     access::ModuleAccess,
     file_format::{
-        AddressPoolIndex, FieldDefinitionIndex, FunctionDefinitionIndex, FunctionHandleIndex, Kind,
-        LocalsSignatureIndex, SignatureToken, StructDefinitionIndex, StructFieldInformation,
-        StructHandleIndex,
+        AddressPoolIndex, CodeOffset, FieldDefinitionIndex, FunctionDefinitionIndex,
+        FunctionHandleIndex, Kind, LocalsSignatureIndex, SignatureToken, StructDefinitionIndex,
+        StructFieldInformation, StructHandleIndex,
     },
     views::{
         FieldDefinitionView, FunctionDefinitionView, FunctionHandleView, SignatureTokenView,
@@ -1408,8 +1408,13 @@ impl<'env> FunctionEnv<'env> {
     }
 
     /// Returns specification conditions associated with this function.
-    pub fn get_specification(&'env self) -> &'env [Condition] {
+    pub fn get_specification_on_decl(&'env self) -> &'env [Condition] {
         &self.data.spec.on_decl
+    }
+
+    /// Returns specification conditions associated with this function at bytecode offset.
+    pub fn get_specification_on_impl(&'env self, offset: CodeOffset) -> Option<&'env [Condition]> {
+        self.data.spec.on_impl.get(&offset).map(|x| x.as_slice())
     }
 
     fn definition_view(&'env self) -> FunctionDefinitionView<'env, CompiledModule> {

--- a/language/move-prover/src/bytecode_translator.rs
+++ b/language/move-prover/src/bytecode_translator.rs
@@ -331,7 +331,7 @@ impl<'env> ModuleTranslator<'env> {
             if !func_env.is_native() {
                 num_fun += 1;
             }
-            if !func_env.get_specification().is_empty() && !func_env.is_native() {
+            if !func_env.get_specification_on_decl().is_empty() && !func_env.is_native() {
                 num_fun_specified += 1;
             }
             self.writer.set_location(&func_env.get_loc());
@@ -428,6 +428,13 @@ impl<'env> ModuleTranslator<'env> {
     fn generate_function_spec(&self, func_env: &FunctionEnv<'_>) {
         emitln!(self.writer);
         SpecTranslator::new(self.writer, &func_env.module_env, true).translate_conditions(func_env);
+    }
+
+    /// Return string for spec inside function implementation.
+    fn generate_function_spec_inside_impl(&self, func_env: &FunctionEnv<'_>, offset: CodeOffset) {
+        emitln!(self.writer);
+        SpecTranslator::new(self.writer, &func_env.module_env, true)
+            .translate_conditions_inside_impl(func_env, offset);
     }
 
     /// Return string for body of verify function, which is just a call to the
@@ -738,6 +745,9 @@ impl<'env> ModuleTranslator<'env> {
             emitln!(self.writer, "Label_{}:", offset);
             self.writer.indent();
         }
+
+        // Insert any specs at this bytecode offset
+        self.generate_function_spec_inside_impl(func_env, offset);
 
         // Translate the bytecode instruction.
         match bytecode {

--- a/language/move-prover/tests/sources/specs-in-fun.exp
+++ b/language/move-prover/tests/sources/specs-in-fun.exp
@@ -1,0 +1,21 @@
+Move prover returns: exiting with boogie verification errors
+error:  This assertion might not hold.
+
+    ┌── tests/sources/specs-in-fun.move:14:13 ───
+    │
+ 14 │             assert x == y;
+    │             ^^^^^^^^^^^^^^
+    │
+    =     at tests/sources/specs-in-fun.move:11:5: simple2 (entry)
+    =     at tests/sources/specs-in-fun.move:12:9: simple2
+    =         x = <redacted>,
+    =         y = <redacted>
+
+error:  This assertion might not hold.
+
+    ┌── tests/sources/specs-in-fun.move:30:13 ───
+    │
+ 30 │             assert x > y;
+    │             ^^^^^^^^^^^^^
+    │
+    =     at tests/sources/specs-in-fun.move:27:5: simple4 (entry)

--- a/language/move-prover/tests/sources/specs-in-fun.move
+++ b/language/move-prover/tests/sources/specs-in-fun.move
@@ -1,0 +1,33 @@
+module TestAssertAndAssume {
+    // succeeds
+    fun simple1(x: u64, y: u64) {
+        if (!(x > y)) abort 1;
+        spec {
+            assert x > y;
+        }
+    }
+
+    // fails
+    fun simple2(x: u64, y: u64) {
+        if (!(x > y)) abort 1;
+        spec {
+            assert x == y;
+        }
+    }
+
+    // succeeds
+    fun simple3(x: u64, y: u64) {
+        spec {
+            assume x > y;
+            assert x >= y;
+        }
+    }
+
+    // fails
+    fun simple4(x: u64, y: u64) {
+        spec {
+            assume x >= y;
+            assert x > y;
+        }
+    }
+}


### PR DESCRIPTION
## Motivation

This PR adds plumbing to translate asserts and assumes inside spec blocks.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

Added a test

## Related PRs

