### PR TITLE
[terraform] Add vault instance and container

### DIFF
--- a/terraform/auth.tf
+++ b/terraform/auth.tf
@@ -28,6 +28,10 @@ data "aws_iam_policy_document" "ecs_extra" {
       "arn:aws:s3:::${aws_s3_bucket.config.id}/*",
     ]
   }
+  statement {
+    actions   = ["kms:Encrypt", "kms:Decrypt", "kms:DescribeKey"]
+    resources = [aws_kms_key.vault.arn]
+  }
 }
 
 resource "aws_iam_role_policy" "ecs_extra" {

--- a/terraform/monitoring.tf
+++ b/terraform/monitoring.tf
@@ -5,7 +5,7 @@ data "template_file" "prometheus_yml" {
     workspace             = terraform.workspace
     validators            = join(",", formatlist("%s:%s", aws_instance.validator.*.private_ip, range(var.num_validators)))
     fullnodes             = join(",", formatlist("%s:%s", aws_instance.fullnode.*.private_ip, range(var.num_fullnodes)))
-    other_nodes           = join(",", ["${aws_instance.monitoring.private_ip}:monitoring", "${aws_instance.faucet.private_ip}:faucet"])
+    other_nodes           = join(",", ["${aws_instance.monitoring.private_ip}:monitoring", "${aws_instance.faucet.private_ip}:faucet", "${aws_instance.vault.private_ip}:vault"])
     monitoring_private_ip = aws_instance.monitoring.private_ip
   }
 }

--- a/terraform/network.tf
+++ b/terraform/network.tf
@@ -256,3 +256,47 @@ resource "aws_security_group_rule" "faucet-lb-application" {
   protocol          = "tcp"
   cidr_blocks       = var.api_sources_ipv4
 }
+
+resource "aws_security_group" "vault" {
+  name        = "${terraform.workspace}-vault"
+  description = "Vault secrets manager"
+  vpc_id      = aws_vpc.testnet.id
+}
+
+resource "aws_security_group_rule" "vault-validator" {
+  security_group_id        = aws_security_group.vault.id
+  type                     = "ingress"
+  from_port                = 8200
+  to_port                  = 8200
+  protocol                 = "tcp"
+  source_security_group_id = aws_security_group.validator.id
+}
+
+resource "aws_security_group_rule" "vault-ssh" {
+  security_group_id = aws_security_group.vault.id
+  type              = "ingress"
+  from_port         = 22
+  to_port           = 22
+  protocol          = "tcp"
+  cidr_blocks       = var.ssh_sources_ipv4
+  ipv6_cidr_blocks  = var.ssh_sources_ipv6
+}
+
+resource "aws_security_group_rule" "vault-mon" {
+  security_group_id        = aws_security_group.vault.id
+  type                     = "ingress"
+  from_port                = 9100
+  to_port                  = 9101
+  protocol                 = "tcp"
+  source_security_group_id = aws_security_group.monitoring.id
+}
+
+resource "aws_security_group_rule" "vault-egress" {
+  security_group_id = aws_security_group.vault.id
+  type              = "egress"
+  from_port         = 0
+  to_port           = 0
+  protocol          = -1
+  cidr_blocks       = ["0.0.0.0/0"]
+  ipv6_cidr_blocks  = ["::/0"]
+}

--- a/terraform/templates/ec2_user_data.sh
+++ b/terraform/templates/ec2_user_data.sh
@@ -15,7 +15,7 @@ if [ -e /dev/nvme1n1 ]; then
 	mount /data
 fi
 
-mkdir -p /opt/libra
+mkdir -p /opt/libra /vault
 
 echo ECS_CLUSTER=${ecs_cluster} >> /etc/ecs/ecs.config
 systemctl try-restart ecs --no-block

--- a/terraform/templates/validator.json
+++ b/terraform/templates/validator.json
@@ -32,7 +32,6 @@
             {"sourceVolume": "libra-data", "containerPath": "/opt/libra/data"}
         ],
         "environment": [
-            {"name": "CFG_BASE_CONFIG", "value": ${cfg_base_config}},
         %{ if cfg_fullnode_seed != "" }
             {"name": "CFG_FULLNODE_SEED", "value": "${cfg_fullnode_seed}"},
             {"name": "CFG_NUM_FULLNODES", "value": "${cfg_num_fullnodes}"},
@@ -43,6 +42,7 @@
             {"name": "CFG_NUM_VALIDATORS_IN_GENESIS", "value": "${cfg_num_validators_in_genesis}"},
             {"name": "CFG_SEED", "value": "${cfg_seed}"},
             {"name": "CFG_SEED_PEER_IP", "value": "${cfg_seed_peer_ip}"},
+            {"name": "CFG_SAFETY_RULES_ADDR", "value": "127.0.0.1:6185"},
         %{ if structlog_path != "" }
             {"name": "STRUCT_LOG_FILE", "value": "${structlog_path}"},
         %{ endif }
@@ -89,6 +89,12 @@
             {"name": "CFG_NUM_VALIDATORS", "value": "${cfg_num_validators}"},
             {"name": "CFG_SEED", "value": "${cfg_seed}"},
             {"name": "CFG_SAFETY_RULES_LISTEN_ADDR", "value": "127.0.0.1:6185"},
+%{ if use_vault }
+            {"name": "CFG_SAFETY_RULES_BACKEND", "value": "vault"},
+            {"name": "CFG_SAFETY_RULES_HOST", "value": "${cfg_vault_addr}"},
+            {"name": "CFG_SAFETY_RULES_TOKEN", "value": "root"},
+            {"name": "CFG_SAFETY_RULES_NAMESPACE", "value": "${cfg_vault_namespace}"},
+%{ endif }
             {"name": "RUST_LOG", "value": "${log_level}"}
         ]
     }

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -162,8 +162,8 @@ variable "log_path" {
 
 variable "structlog_path" {
   description = "Structured log path"
-  type    = string
-  default = "/opt/libra/data/libra_structlog.log"
+  type        = string
+  default     = "/opt/libra/data/libra_structlog.log"
 }
 
 variable "enable_logstash" {
@@ -213,4 +213,14 @@ variable "override_image_tags" {
   type        = list(string)
   default     = []
   description = "List of Docker image tags to be used in record and replay test, overrides image_tag"
+}
+
+variable "vault_type" {
+  description = "EC2 instance type of Vault instances"
+  default     = "c5.large"
+}
+
+variable "safety_rules_use_vault" {
+  description = "Configure safety-rules to use Vault as the backend"
+  default     = false
 }

--- a/terraform/vault.tf
+++ b/terraform/vault.tf
@@ -1,0 +1,109 @@
+resource "aws_kms_key" "vault" {
+  description             = "Vault unseal key"
+  deletion_window_in_days = 7
+
+  tags = {
+    Name = "${terraform.workspace}-vault"
+  }
+}
+
+resource "aws_instance" "vault" {
+  ami                         = local.aws_ecs_ami
+  instance_type               = var.vault_type
+  subnet_id                   = aws_subnet.testnet[0].id
+  depends_on                  = [aws_main_route_table_association.testnet, aws_iam_role_policy.ecs_extra]
+  vpc_security_group_ids      = [aws_security_group.vault.id]
+  associate_public_ip_address = local.instance_public_ip
+  key_name                    = aws_key_pair.libra.key_name
+  iam_instance_profile        = aws_iam_instance_profile.ecsInstanceRole.name
+  user_data                   = local.user_data
+
+  tags = {
+    Name      = "${terraform.workspace}-vault"
+    Role      = "vault"
+    Workspace = terraform.workspace
+  }
+}
+
+resource "aws_ecs_task_definition" "vault" {
+  family             = "${terraform.workspace}-vault"
+  execution_role_arn = aws_iam_role.ecsTaskExecutionRole.arn
+  network_mode       = "host"
+
+  container_definitions = jsonencode([
+    {
+      name      = "vault",
+      image     = "vault:latest",
+      command   = ["server"],
+      cpu       = 2000,
+      memory    = 2048,
+      essential = true,
+      portMappings = [
+        { containerPort = 8200, hostPort = 8200 },
+      ],
+      mountPoints = [
+        { sourceVolume = "vault-data", containerPath = "/vault/file" },
+      ],
+      environment = [
+        { name = "VAULT_LOCAL_CONFIG", value = jsonencode({
+          backend = {
+            file = { path = "/vault/file" }
+          },
+          listener = {
+            tcp = {
+              address     = "0.0.0.0:8200",
+              tls_disable = "true",
+            },
+          },
+          seal = {
+            awskms = { kms_key_id = aws_kms_key.vault.id }
+          },
+        }) },
+      ],
+      linuxParameters = {
+        capabilities = {
+          add = ["IPC_LOCK"],
+        },
+      },
+    }, {
+      name       = "vault-init",
+      image      = "vault:latest",
+      entryPoint = ["sh"],
+      command    = ["-c", "sleep 5s && TOKEN=$(vault operator init | grep 'Root Token' | cut -d: -f2) && vault login $TOKEN && vault token create -id=root -policy=root && vault secrets enable -path=secret kv-v2"],
+      cpu        = 40,
+      memory     = 128,
+      essential  = false,
+      environment = [
+        { name = "VAULT_ADDR", value = "http://localhost:8200" },
+      ],
+    },
+  ])
+
+  volume {
+    name      = "vault-data"
+    host_path = "/vault"
+  }
+
+  placement_constraints {
+    type       = "memberOf"
+    expression = "ec2InstanceId == ${aws_instance.vault.id}"
+  }
+
+  tags = {
+    Role      = "vault"
+    Workspace = terraform.workspace
+  }
+}
+
+resource "aws_ecs_service" "vault" {
+  name                               = "${terraform.workspace}-vault"
+  cluster                            = aws_ecs_cluster.testnet.id
+  task_definition                    = aws_ecs_task_definition.vault.arn
+  desired_count                      = 1
+  deployment_minimum_healthy_percent = 0
+
+  tags = {
+    Role      = "vault"
+    Workspace = terraform.workspace
+  }
+}


### PR DESCRIPTION
Add new EC2 instance and ECS container to run Hashicorp Vault. Vault is
automatically initialised and a hardcoded root token "root" created.
Vault storage is local disk for now. The variable `safety_rules_use_vault`
enables actual use of Vault.

Test Plan: Deployed to my workspace, with and without
`safety_rules_use_vault` set.