### PR TITLE
[executor] compare local compute result with chunk before comparing w…

### DIFF
--- a/types/src/transaction/mod.rs
+++ b/types/src/transaction/mod.rs
@@ -30,6 +30,7 @@ use std::{
     collections::HashMap,
     convert::{TryFrom, TryInto},
     fmt,
+    fmt::{Display, Formatter},
     time::Duration,
 };
 
@@ -717,7 +718,7 @@ impl From<TransactionInfo> for crate::proto::types::TransactionInfo {
 
 /// `TransactionInfo` is the object we store in the transaction accumulator. It consists of the
 /// transaction as well as the execution result of this transaction.
-#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize, CryptoHasher)]
+#[derive(Clone, CryptoHasher, Debug, Eq, PartialEq, Serialize, Deserialize)]
 #[cfg_attr(any(test, feature = "fuzzing"), derive(Arbitrary))]
 pub struct TransactionInfo {
     /// The hash of this transaction.
@@ -792,6 +793,16 @@ impl CryptoHash for TransactionInfo {
         let mut state = Self::Hasher::default();
         state.write(&lcs::to_bytes(self).expect("Serialization should work."));
         state.finish()
+    }
+}
+
+impl Display for TransactionInfo {
+    fn fmt(&self, f: &mut Formatter) -> std::fmt::Result {
+        write!(
+            f,
+            "TransactionInfo: [txn_hash: {}, state_root_hash: {}, event_root_hash: {}, gas_used: {}, major_status: {:?}]",
+            self.transaction_hash(), self.state_root_hash(), self.event_root_hash(), self.gas_used(), self.major_status(),
+        )
     }
 }
 


### PR DESCRIPTION
…ith the final ledger_info

## Motivation

there's a problem in `execute_and_commit_chunk`
let's say we're at version 100, receive a sync request to 600, first chunk comes with TransactionListWithProof[101-350] with LedgerInfo[version:600],
we verify the TransactionListWithProof matches LedgerInfo[version:600]
execute txns [101-350]
commit txns [101-350]
But we never verify the local execute result matches TransactionListWithProof

This PR fixes the problem to find out the unmatched results before reaching the final ledger info to be committed.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?

Y
## Test Plan

CI
