### PR TITLE
[json-rpc] update fuzzing logic

### DIFF
--- a/json-rpc/src/fuzzing.rs
+++ b/json-rpc/src/fuzzing.rs
@@ -41,10 +41,15 @@ pub fn fuzzer(data: &[u8]) {
 
     let client = Client::new();
     let url = format!("http://{}", address);
-    let json_request;
-    match serde_json::from_slice::<serde_json::Value>(data) {
-        Err(_) => return, // should not throw error or panic on invalid fuzzer inputs
-        Ok(request) => json_request = request,
+    let json_request = match serde_json::from_slice::<serde_json::Value>(data) {
+        Err(_) => {
+            // should not throw error or panic on invalid fuzzer inputs
+            if cfg!(test) {
+                panic!();
+            }
+            return;
+        }
+        Ok(request) => request,
     };
 
     let response = client
@@ -62,21 +67,35 @@ pub fn fuzzer(data: &[u8]) {
         "JSON RPC response with incorrect protocol: {:?}",
         json_rpc_protocol
     );
-    assert!(
-        response.get("error").is_none(),
-        "expected no error in JSON RPC response",
-    );
-
-    if let Some(result) = response.get("result") {
-        let response_id: u64 = serde_json::from_value(response.get("id").unwrap().clone())
-            .expect("failed to get ID from response");
-        assert_eq!(response_id, 1, "mismatch ID in JSON RPC");
-        assert!(
-            *result == serde_json::Value::Null,
-            "Received unexpected result payload from txn submission: {:?}",
-            result
+    if response.get("error").is_some() && cfg!(test) {
+        panic!(
+            "Unexpected error payload in JSON RPC response: {}",
+            response
         );
-    } else {
-        panic!("Received JSON RPC response with no result payload");
     }
+
+    // only proceed to check successful response for input from `generate_corpus`
+    if !cfg!(test) {
+        return;
+    }
+
+    let result = response.get("result").unwrap_or_else(|| {
+        panic!(
+            "Received JSON RPC response with no result payload. Full response: {}",
+            response
+        )
+    });
+    let response_id: u64 = serde_json::from_value(
+        response
+            .get("id")
+            .unwrap_or_else(|| panic!("failed to get ID from response: {}", response))
+            .clone(),
+    )
+    .unwrap_or_else(|_| panic!("Failed to deserialize ID from: {}", response));
+    assert_eq!(response_id, 1, "mismatch ID in JSON RPC: {}", response);
+    assert!(
+        *result == serde_json::Value::Null,
+        "Received unexpected result payload from txn submission: {:?}",
+        response
+    );
 }


### PR DESCRIPTION
## Summary

Removing invalid assumption in json-rpc fuzzer (don't expect valid JSON RPC responses for invalid inputs)
