### PR TITLE
[move-prover] Fixing a systematic typo in variable names.

### DIFF
--- a/language/move-prover/spec-lang/src/env.rs
+++ b/language/move-prover/spec-lang/src/env.rs
@@ -1310,7 +1310,7 @@ impl<'env> FunctionEnv<'env> {
     pub fn is_mutating(&self) -> bool {
         self.get_parameters()
             .iter()
-            .any(|Parameter(_, ty)| ty.is_mutual_reference())
+            .any(|Parameter(_, ty)| ty.is_mutable_reference())
     }
 
     /// Returns the type parameters associated with this function.

--- a/language/move-prover/spec-lang/src/ty.rs
+++ b/language/move-prover/spec-lang/src/ty.rs
@@ -76,8 +76,8 @@ impl Type {
         matches!(self, Type::Reference(_, _))
     }
 
-    /// Determines whether this is a mutual reference.
-    pub fn is_mutual_reference(&self) -> bool {
+    /// Determines whether this is a mutable reference.
+    pub fn is_mutable_reference(&self) -> bool {
         if let Type::Reference(true, _) = self {
             true
         } else {

--- a/language/move-prover/tests/sources/stdlib/modules/libra_account.exp
+++ b/language/move-prover/tests/sources/stdlib/modules/libra_account.exp
@@ -1,203 +1,203 @@
 Move prover returns: exiting with boogie verification errors
 bug:  This assertion might not hold.
 
-     ┌── /var/folders/85/dnj3wv151rqgv2jby442x5pm0000gn/T/a949499739cfcafd819475ee3552bdb1/libra_account.bpl:991:6 ───
+     ┌── libra_account.bpl:991:6 ───
      │
  991 │     assert false; // $LibraAccount_write_to_event_store not implemented
      │      ^
      │
-     =     at /var/folders/85/dnj3wv151rqgv2jby442x5pm0000gn/T/a949499739cfcafd819475ee3552bdb1/libra_account.bpl:3412:24: <boogie>: inline$$LibraAccount_deposit$0$Entry
-     =     at /var/folders/85/dnj3wv151rqgv2jby442x5pm0000gn/T/a949499739cfcafd819475ee3552bdb1/libra_account.bpl:3450:6: <boogie>: inline$$LibraAccount_deposit$0$anon11_Else
-     =     at /var/folders/85/dnj3wv151rqgv2jby442x5pm0000gn/T/a949499739cfcafd819475ee3552bdb1/libra_account.bpl:4176:24: <boogie>: inline$$LibraAccount_deposit_with_metadata$0$Entry
-     =     at /var/folders/85/dnj3wv151rqgv2jby442x5pm0000gn/T/a949499739cfcafd819475ee3552bdb1/libra_account.bpl:4245:24: <boogie>: inline$$LibraAccount_deposit_with_sender_and_metadata$0$Entry
-     =     at /var/folders/85/dnj3wv151rqgv2jby442x5pm0000gn/T/a949499739cfcafd819475ee3552bdb1/libra_account.bpl:2629:24: <boogie>: inline$$LibraCoin_value$0$Entry
-     =     at /var/folders/85/dnj3wv151rqgv2jby442x5pm0000gn/T/a949499739cfcafd819475ee3552bdb1/libra_account.bpl:2629:24: <boogie>: inline$$LibraCoin_value$0$Return
-     =     at /var/folders/85/dnj3wv151rqgv2jby442x5pm0000gn/T/a949499739cfcafd819475ee3552bdb1/libra_account.bpl:4317:6: <boogie>: inline$$LibraAccount_deposit_with_sender_and_metadata$0$anon59_Else
-     =     at /var/folders/85/dnj3wv151rqgv2jby442x5pm0000gn/T/a949499739cfcafd819475ee3552bdb1/libra_account.bpl:4331:6: <boogie>: inline$$LibraAccount_deposit_with_sender_and_metadata$0$anon12$1
-     =     at /var/folders/85/dnj3wv151rqgv2jby442x5pm0000gn/T/a949499739cfcafd819475ee3552bdb1/libra_account.bpl:4379:6: <boogie>: inline$$LibraAccount_deposit_with_sender_and_metadata$0$anon64_Else
-     =     at /var/folders/85/dnj3wv151rqgv2jby442x5pm0000gn/T/a949499739cfcafd819475ee3552bdb1/libra_account.bpl:4389:6: <boogie>: inline$$LibraAccount_deposit_with_sender_and_metadata$0$anon22$2
-     =     at /var/folders/85/dnj3wv151rqgv2jby442x5pm0000gn/T/a949499739cfcafd819475ee3552bdb1/libra_account.bpl:4581:24: <boogie>: inline$$LibraAccount_emit_event$0$Entry
-     =     at /var/folders/85/dnj3wv151rqgv2jby442x5pm0000gn/T/a949499739cfcafd819475ee3552bdb1/libra_account.bpl:4635:18: <boogie>: inline$$LibraAccount_emit_event$0$anon15_Then
-     =     at /var/folders/85/dnj3wv151rqgv2jby442x5pm0000gn/T/a949499739cfcafd819475ee3552bdb1/libra_account.bpl:4638:6: <boogie>: inline$$LibraAccount_emit_event$0$anon6$1
+     =     at libra_account.bpl:3659:24: <boogie>: inline$$LibraAccount_deposit$0$Entry
+     =     at libra_account.bpl:3700:6: <boogie>: inline$$LibraAccount_deposit$0$anon11_Else
+     =     at libra_account.bpl:4502:24: <boogie>: inline$$LibraAccount_deposit_with_metadata$0$Entry
+     =     at libra_account.bpl:4577:24: <boogie>: inline$$LibraAccount_deposit_with_sender_and_metadata$0$Entry
+     =     at libra_account.bpl:2829:24: <boogie>: inline$$LibraCoin_value$0$Entry
+     =     at libra_account.bpl:2829:24: <boogie>: inline$$LibraCoin_value$0$Return
+     =     at libra_account.bpl:4651:6: <boogie>: inline$$LibraAccount_deposit_with_sender_and_metadata$0$anon59_Else
+     =     at libra_account.bpl:4667:6: <boogie>: inline$$LibraAccount_deposit_with_sender_and_metadata$0$anon12$1
+     =     at libra_account.bpl:4726:6: <boogie>: inline$$LibraAccount_deposit_with_sender_and_metadata$0$anon64_Else
+     =     at libra_account.bpl:4738:6: <boogie>: inline$$LibraAccount_deposit_with_sender_and_metadata$0$anon22$2
+     =     at libra_account.bpl:4960:24: <boogie>: inline$$LibraAccount_emit_event$0$Entry
+     =     at libra_account.bpl:5018:18: <boogie>: inline$$LibraAccount_emit_event$0$anon15_Then
+     =     at libra_account.bpl:5022:6: <boogie>: inline$$LibraAccount_emit_event$0$anon6$1
 
 bug:  This assertion might not hold.
 
-     ┌── /var/folders/85/dnj3wv151rqgv2jby442x5pm0000gn/T/a949499739cfcafd819475ee3552bdb1/libra_account.bpl:953:6 ───
+     ┌── libra_account.bpl:953:6 ───
      │
  953 │     assert false; // $AddressUtil_address_to_bytes not implemented
      │      ^
      │
-     =     at /var/folders/85/dnj3wv151rqgv2jby442x5pm0000gn/T/a949499739cfcafd819475ee3552bdb1/libra_account.bpl:3667:24: <boogie>: inline$$LibraAccount_create_account$0$Entry
-     =     at /var/folders/85/dnj3wv151rqgv2jby442x5pm0000gn/T/a949499739cfcafd819475ee3552bdb1/libra_account.bpl:3734:18: <boogie>: inline$$LibraAccount_create_account$0$anon31_Then
-     =     at /var/folders/85/dnj3wv151rqgv2jby442x5pm0000gn/T/a949499739cfcafd819475ee3552bdb1/libra_account.bpl:3737:6: <boogie>: inline$$LibraAccount_create_account$0$anon6$1
-     =     at /var/folders/85/dnj3wv151rqgv2jby442x5pm0000gn/T/a949499739cfcafd819475ee3552bdb1/libra_account.bpl:3746:6: <boogie>: inline$$LibraAccount_create_account$0$anon8$1
+     =     at libra_account.bpl:3932:24: <boogie>: inline$$LibraAccount_create_account$0$Entry
+     =     at libra_account.bpl:4002:18: <boogie>: inline$$LibraAccount_create_account$0$anon31_Then
+     =     at libra_account.bpl:4006:6: <boogie>: inline$$LibraAccount_create_account$0$anon6$1
+     =     at libra_account.bpl:4017:6: <boogie>: inline$$LibraAccount_create_account$0$anon8$1
 
 bug:  This assertion might not hold.
 
-     ┌── /var/folders/85/dnj3wv151rqgv2jby442x5pm0000gn/T/a949499739cfcafd819475ee3552bdb1/libra_account.bpl:953:6 ───
+     ┌── libra_account.bpl:953:6 ───
      │
  953 │     assert false; // $AddressUtil_address_to_bytes not implemented
      │      ^
      │
-     =     at /var/folders/85/dnj3wv151rqgv2jby442x5pm0000gn/T/a949499739cfcafd819475ee3552bdb1/libra_account.bpl:3924:24: <boogie>: inline$$LibraAccount_create_new_account$0$Entry
-     =     at /var/folders/85/dnj3wv151rqgv2jby442x5pm0000gn/T/a949499739cfcafd819475ee3552bdb1/libra_account.bpl:3667:24: <boogie>: inline$$LibraAccount_create_account$0$Entry
-     =     at /var/folders/85/dnj3wv151rqgv2jby442x5pm0000gn/T/a949499739cfcafd819475ee3552bdb1/libra_account.bpl:3734:18: <boogie>: inline$$LibraAccount_create_account$0$anon31_Then
-     =     at /var/folders/85/dnj3wv151rqgv2jby442x5pm0000gn/T/a949499739cfcafd819475ee3552bdb1/libra_account.bpl:3737:6: <boogie>: inline$$LibraAccount_create_account$0$anon6$1
-     =     at /var/folders/85/dnj3wv151rqgv2jby442x5pm0000gn/T/a949499739cfcafd819475ee3552bdb1/libra_account.bpl:3746:6: <boogie>: inline$$LibraAccount_create_account$0$anon8$1
+     =     at libra_account.bpl:4226:24: <boogie>: inline$$LibraAccount_create_new_account$0$Entry
+     =     at libra_account.bpl:3932:24: <boogie>: inline$$LibraAccount_create_account$0$Entry
+     =     at libra_account.bpl:4002:18: <boogie>: inline$$LibraAccount_create_account$0$anon31_Then
+     =     at libra_account.bpl:4006:6: <boogie>: inline$$LibraAccount_create_account$0$anon6$1
+     =     at libra_account.bpl:4017:6: <boogie>: inline$$LibraAccount_create_account$0$anon8$1
 
 bug:  This assertion might not hold.
 
-     ┌── /var/folders/85/dnj3wv151rqgv2jby442x5pm0000gn/T/a949499739cfcafd819475ee3552bdb1/libra_account.bpl:991:6 ───
+     ┌── libra_account.bpl:991:6 ───
      │
  991 │     assert false; // $LibraAccount_write_to_event_store not implemented
      │      ^
      │
-     =     at /var/folders/85/dnj3wv151rqgv2jby442x5pm0000gn/T/a949499739cfcafd819475ee3552bdb1/libra_account.bpl:4176:24: <boogie>: inline$$LibraAccount_deposit_with_metadata$0$Entry
-     =     at /var/folders/85/dnj3wv151rqgv2jby442x5pm0000gn/T/a949499739cfcafd819475ee3552bdb1/libra_account.bpl:4245:24: <boogie>: inline$$LibraAccount_deposit_with_sender_and_metadata$0$Entry
-     =     at /var/folders/85/dnj3wv151rqgv2jby442x5pm0000gn/T/a949499739cfcafd819475ee3552bdb1/libra_account.bpl:2629:24: <boogie>: inline$$LibraCoin_value$0$Entry
-     =     at /var/folders/85/dnj3wv151rqgv2jby442x5pm0000gn/T/a949499739cfcafd819475ee3552bdb1/libra_account.bpl:2629:24: <boogie>: inline$$LibraCoin_value$0$Return
-     =     at /var/folders/85/dnj3wv151rqgv2jby442x5pm0000gn/T/a949499739cfcafd819475ee3552bdb1/libra_account.bpl:4317:6: <boogie>: inline$$LibraAccount_deposit_with_sender_and_metadata$0$anon59_Else
-     =     at /var/folders/85/dnj3wv151rqgv2jby442x5pm0000gn/T/a949499739cfcafd819475ee3552bdb1/libra_account.bpl:4331:6: <boogie>: inline$$LibraAccount_deposit_with_sender_and_metadata$0$anon12$1
-     =     at /var/folders/85/dnj3wv151rqgv2jby442x5pm0000gn/T/a949499739cfcafd819475ee3552bdb1/libra_account.bpl:4379:6: <boogie>: inline$$LibraAccount_deposit_with_sender_and_metadata$0$anon64_Else
-     =     at /var/folders/85/dnj3wv151rqgv2jby442x5pm0000gn/T/a949499739cfcafd819475ee3552bdb1/libra_account.bpl:4389:6: <boogie>: inline$$LibraAccount_deposit_with_sender_and_metadata$0$anon22$2
-     =     at /var/folders/85/dnj3wv151rqgv2jby442x5pm0000gn/T/a949499739cfcafd819475ee3552bdb1/libra_account.bpl:4581:24: <boogie>: inline$$LibraAccount_emit_event$0$Entry
-     =     at /var/folders/85/dnj3wv151rqgv2jby442x5pm0000gn/T/a949499739cfcafd819475ee3552bdb1/libra_account.bpl:4635:18: <boogie>: inline$$LibraAccount_emit_event$0$anon15_Then
-     =     at /var/folders/85/dnj3wv151rqgv2jby442x5pm0000gn/T/a949499739cfcafd819475ee3552bdb1/libra_account.bpl:4638:6: <boogie>: inline$$LibraAccount_emit_event$0$anon6$1
+     =     at libra_account.bpl:4502:24: <boogie>: inline$$LibraAccount_deposit_with_metadata$0$Entry
+     =     at libra_account.bpl:4577:24: <boogie>: inline$$LibraAccount_deposit_with_sender_and_metadata$0$Entry
+     =     at libra_account.bpl:2829:24: <boogie>: inline$$LibraCoin_value$0$Entry
+     =     at libra_account.bpl:2829:24: <boogie>: inline$$LibraCoin_value$0$Return
+     =     at libra_account.bpl:4651:6: <boogie>: inline$$LibraAccount_deposit_with_sender_and_metadata$0$anon59_Else
+     =     at libra_account.bpl:4667:6: <boogie>: inline$$LibraAccount_deposit_with_sender_and_metadata$0$anon12$1
+     =     at libra_account.bpl:4726:6: <boogie>: inline$$LibraAccount_deposit_with_sender_and_metadata$0$anon64_Else
+     =     at libra_account.bpl:4738:6: <boogie>: inline$$LibraAccount_deposit_with_sender_and_metadata$0$anon22$2
+     =     at libra_account.bpl:4960:24: <boogie>: inline$$LibraAccount_emit_event$0$Entry
+     =     at libra_account.bpl:5018:18: <boogie>: inline$$LibraAccount_emit_event$0$anon15_Then
+     =     at libra_account.bpl:5022:6: <boogie>: inline$$LibraAccount_emit_event$0$anon6$1
 
 bug:  This assertion might not hold.
 
-     ┌── /var/folders/85/dnj3wv151rqgv2jby442x5pm0000gn/T/a949499739cfcafd819475ee3552bdb1/libra_account.bpl:991:6 ───
+     ┌── libra_account.bpl:991:6 ───
      │
  991 │     assert false; // $LibraAccount_write_to_event_store not implemented
      │      ^
      │
-     =     at /var/folders/85/dnj3wv151rqgv2jby442x5pm0000gn/T/a949499739cfcafd819475ee3552bdb1/libra_account.bpl:4245:24: <boogie>: inline$$LibraAccount_deposit_with_sender_and_metadata$0$Entry
-     =     at /var/folders/85/dnj3wv151rqgv2jby442x5pm0000gn/T/a949499739cfcafd819475ee3552bdb1/libra_account.bpl:2629:24: <boogie>: inline$$LibraCoin_value$0$Entry
-     =     at /var/folders/85/dnj3wv151rqgv2jby442x5pm0000gn/T/a949499739cfcafd819475ee3552bdb1/libra_account.bpl:2629:24: <boogie>: inline$$LibraCoin_value$0$Return
-     =     at /var/folders/85/dnj3wv151rqgv2jby442x5pm0000gn/T/a949499739cfcafd819475ee3552bdb1/libra_account.bpl:4317:6: <boogie>: inline$$LibraAccount_deposit_with_sender_and_metadata$0$anon59_Else
-     =     at /var/folders/85/dnj3wv151rqgv2jby442x5pm0000gn/T/a949499739cfcafd819475ee3552bdb1/libra_account.bpl:4331:6: <boogie>: inline$$LibraAccount_deposit_with_sender_and_metadata$0$anon12$1
-     =     at /var/folders/85/dnj3wv151rqgv2jby442x5pm0000gn/T/a949499739cfcafd819475ee3552bdb1/libra_account.bpl:4379:6: <boogie>: inline$$LibraAccount_deposit_with_sender_and_metadata$0$anon64_Else
-     =     at /var/folders/85/dnj3wv151rqgv2jby442x5pm0000gn/T/a949499739cfcafd819475ee3552bdb1/libra_account.bpl:4389:6: <boogie>: inline$$LibraAccount_deposit_with_sender_and_metadata$0$anon22$2
-     =     at /var/folders/85/dnj3wv151rqgv2jby442x5pm0000gn/T/a949499739cfcafd819475ee3552bdb1/libra_account.bpl:4581:24: <boogie>: inline$$LibraAccount_emit_event$0$Entry
-     =     at /var/folders/85/dnj3wv151rqgv2jby442x5pm0000gn/T/a949499739cfcafd819475ee3552bdb1/libra_account.bpl:4635:18: <boogie>: inline$$LibraAccount_emit_event$0$anon15_Then
-     =     at /var/folders/85/dnj3wv151rqgv2jby442x5pm0000gn/T/a949499739cfcafd819475ee3552bdb1/libra_account.bpl:4638:6: <boogie>: inline$$LibraAccount_emit_event$0$anon6$1
+     =     at libra_account.bpl:4577:24: <boogie>: inline$$LibraAccount_deposit_with_sender_and_metadata$0$Entry
+     =     at libra_account.bpl:2829:24: <boogie>: inline$$LibraCoin_value$0$Entry
+     =     at libra_account.bpl:2829:24: <boogie>: inline$$LibraCoin_value$0$Return
+     =     at libra_account.bpl:4651:6: <boogie>: inline$$LibraAccount_deposit_with_sender_and_metadata$0$anon59_Else
+     =     at libra_account.bpl:4667:6: <boogie>: inline$$LibraAccount_deposit_with_sender_and_metadata$0$anon12$1
+     =     at libra_account.bpl:4726:6: <boogie>: inline$$LibraAccount_deposit_with_sender_and_metadata$0$anon64_Else
+     =     at libra_account.bpl:4738:6: <boogie>: inline$$LibraAccount_deposit_with_sender_and_metadata$0$anon22$2
+     =     at libra_account.bpl:4960:24: <boogie>: inline$$LibraAccount_emit_event$0$Entry
+     =     at libra_account.bpl:5018:18: <boogie>: inline$$LibraAccount_emit_event$0$anon15_Then
+     =     at libra_account.bpl:5022:6: <boogie>: inline$$LibraAccount_emit_event$0$anon6$1
 
 bug:  This assertion might not hold.
 
-     ┌── /var/folders/85/dnj3wv151rqgv2jby442x5pm0000gn/T/a949499739cfcafd819475ee3552bdb1/libra_account.bpl:991:6 ───
+     ┌── libra_account.bpl:991:6 ───
      │
  991 │     assert false; // $LibraAccount_write_to_event_store not implemented
      │      ^
      │
-     =     at /var/folders/85/dnj3wv151rqgv2jby442x5pm0000gn/T/a949499739cfcafd819475ee3552bdb1/libra_account.bpl:4581:24: <boogie>: inline$$LibraAccount_emit_event$0$Entry
-     =     at /var/folders/85/dnj3wv151rqgv2jby442x5pm0000gn/T/a949499739cfcafd819475ee3552bdb1/libra_account.bpl:4635:18: <boogie>: inline$$LibraAccount_emit_event$0$anon15_Then
-     =     at /var/folders/85/dnj3wv151rqgv2jby442x5pm0000gn/T/a949499739cfcafd819475ee3552bdb1/libra_account.bpl:4638:6: <boogie>: inline$$LibraAccount_emit_event$0$anon6$1
+     =     at libra_account.bpl:4960:24: <boogie>: inline$$LibraAccount_emit_event$0$Entry
+     =     at libra_account.bpl:5018:18: <boogie>: inline$$LibraAccount_emit_event$0$anon15_Then
+     =     at libra_account.bpl:5022:6: <boogie>: inline$$LibraAccount_emit_event$0$anon6$1
 
 bug:  This assertion might not hold.
 
-     ┌── /var/folders/85/dnj3wv151rqgv2jby442x5pm0000gn/T/a949499739cfcafd819475ee3552bdb1/libra_account.bpl:953:6 ───
+     ┌── libra_account.bpl:953:6 ───
      │
  953 │     assert false; // $AddressUtil_address_to_bytes not implemented
      │      ^
      │
-     =     at /var/folders/85/dnj3wv151rqgv2jby442x5pm0000gn/T/a949499739cfcafd819475ee3552bdb1/libra_account.bpl:5334:24: <boogie>: inline$$LibraAccount_fresh_guid$0$Entry
+     =     at libra_account.bpl:5828:24: <boogie>: inline$$LibraAccount_fresh_guid$0$Entry
 
 bug:  This assertion might not hold.
 
-     ┌── /var/folders/85/dnj3wv151rqgv2jby442x5pm0000gn/T/a949499739cfcafd819475ee3552bdb1/libra_account.bpl:953:6 ───
+     ┌── libra_account.bpl:953:6 ───
      │
  953 │     assert false; // $AddressUtil_address_to_bytes not implemented
      │      ^
      │
-     =     at /var/folders/85/dnj3wv151rqgv2jby442x5pm0000gn/T/a949499739cfcafd819475ee3552bdb1/libra_account.bpl:5543:24: <boogie>: inline$$LibraAccount_mint_to_address$0$Entry
-     =     at /var/folders/85/dnj3wv151rqgv2jby442x5pm0000gn/T/a949499739cfcafd819475ee3552bdb1/libra_account.bpl:3363:24: <boogie>: inline$$LibraAccount_exists$0$Entry
-     =     at /var/folders/85/dnj3wv151rqgv2jby442x5pm0000gn/T/a949499739cfcafd819475ee3552bdb1/libra_account.bpl:5585:6: <boogie>: inline$$LibraAccount_mint_to_address$0$anon19_Else
-     =     at /var/folders/85/dnj3wv151rqgv2jby442x5pm0000gn/T/a949499739cfcafd819475ee3552bdb1/libra_account.bpl:3667:24: <boogie>: inline$$LibraAccount_create_account$0$Entry
-     =     at /var/folders/85/dnj3wv151rqgv2jby442x5pm0000gn/T/a949499739cfcafd819475ee3552bdb1/libra_account.bpl:3734:18: <boogie>: inline$$LibraAccount_create_account$0$anon31_Then
-     =     at /var/folders/85/dnj3wv151rqgv2jby442x5pm0000gn/T/a949499739cfcafd819475ee3552bdb1/libra_account.bpl:3737:6: <boogie>: inline$$LibraAccount_create_account$0$anon6$1
-     =     at /var/folders/85/dnj3wv151rqgv2jby442x5pm0000gn/T/a949499739cfcafd819475ee3552bdb1/libra_account.bpl:3746:6: <boogie>: inline$$LibraAccount_create_account$0$anon8$1
+     =     at libra_account.bpl:6061:24: <boogie>: inline$$LibraAccount_mint_to_address$0$Entry
+     =     at libra_account.bpl:3607:24: <boogie>: inline$$LibraAccount_exists$0$Entry
+     =     at libra_account.bpl:6105:6: <boogie>: inline$$LibraAccount_mint_to_address$0$anon19_Else
+     =     at libra_account.bpl:3932:24: <boogie>: inline$$LibraAccount_create_account$0$Entry
+     =     at libra_account.bpl:4002:18: <boogie>: inline$$LibraAccount_create_account$0$anon31_Then
+     =     at libra_account.bpl:4006:6: <boogie>: inline$$LibraAccount_create_account$0$anon6$1
+     =     at libra_account.bpl:4017:6: <boogie>: inline$$LibraAccount_create_account$0$anon8$1
 
 bug:  This assertion might not hold.
 
-     ┌── /var/folders/85/dnj3wv151rqgv2jby442x5pm0000gn/T/a949499739cfcafd819475ee3552bdb1/libra_account.bpl:953:6 ───
+     ┌── libra_account.bpl:953:6 ───
      │
  953 │     assert false; // $AddressUtil_address_to_bytes not implemented
      │      ^
      │
-     =     at /var/folders/85/dnj3wv151rqgv2jby442x5pm0000gn/T/a949499739cfcafd819475ee3552bdb1/libra_account.bpl:5660:24: <boogie>: inline$$LibraAccount_new_event_handle$0$Entry
-     =     at /var/folders/85/dnj3wv151rqgv2jby442x5pm0000gn/T/a949499739cfcafd819475ee3552bdb1/libra_account.bpl:5693:6: <boogie>: inline$$LibraAccount_new_event_handle$0$anon9_Else
-     =     at /var/folders/85/dnj3wv151rqgv2jby442x5pm0000gn/T/a949499739cfcafd819475ee3552bdb1/libra_account.bpl:5703:6: <boogie>: inline$$LibraAccount_new_event_handle$0$anon4$2
-     =     at /var/folders/85/dnj3wv151rqgv2jby442x5pm0000gn/T/a949499739cfcafd819475ee3552bdb1/libra_account.bpl:5742:24: <boogie>: inline$$LibraAccount_new_event_handle_impl$0$Entry
-     =     at /var/folders/85/dnj3wv151rqgv2jby442x5pm0000gn/T/a949499739cfcafd819475ee3552bdb1/libra_account.bpl:5334:24: <boogie>: inline$$LibraAccount_fresh_guid$0$Entry
+     =     at libra_account.bpl:6191:24: <boogie>: inline$$LibraAccount_new_event_handle$0$Entry
+     =     at libra_account.bpl:6226:6: <boogie>: inline$$LibraAccount_new_event_handle$0$anon9_Else
+     =     at libra_account.bpl:6238:6: <boogie>: inline$$LibraAccount_new_event_handle$0$anon4$2
+     =     at libra_account.bpl:6281:24: <boogie>: inline$$LibraAccount_new_event_handle_impl$0$Entry
+     =     at libra_account.bpl:5828:24: <boogie>: inline$$LibraAccount_fresh_guid$0$Entry
 
 bug:  This assertion might not hold.
 
-     ┌── /var/folders/85/dnj3wv151rqgv2jby442x5pm0000gn/T/a949499739cfcafd819475ee3552bdb1/libra_account.bpl:953:6 ───
+     ┌── libra_account.bpl:953:6 ───
      │
  953 │     assert false; // $AddressUtil_address_to_bytes not implemented
      │      ^
      │
-     =     at /var/folders/85/dnj3wv151rqgv2jby442x5pm0000gn/T/a949499739cfcafd819475ee3552bdb1/libra_account.bpl:5742:24: <boogie>: inline$$LibraAccount_new_event_handle_impl$0$Entry
-     =     at /var/folders/85/dnj3wv151rqgv2jby442x5pm0000gn/T/a949499739cfcafd819475ee3552bdb1/libra_account.bpl:5334:24: <boogie>: inline$$LibraAccount_fresh_guid$0$Entry
+     =     at libra_account.bpl:6281:24: <boogie>: inline$$LibraAccount_new_event_handle_impl$0$Entry
+     =     at libra_account.bpl:5828:24: <boogie>: inline$$LibraAccount_fresh_guid$0$Entry
 
 bug:  This assertion might not hold.
 
-     ┌── /var/folders/85/dnj3wv151rqgv2jby442x5pm0000gn/T/a949499739cfcafd819475ee3552bdb1/libra_account.bpl:953:6 ───
+     ┌── libra_account.bpl:953:6 ───
      │
  953 │     assert false; // $AddressUtil_address_to_bytes not implemented
      │      ^
      │
-     =     at /var/folders/85/dnj3wv151rqgv2jby442x5pm0000gn/T/a949499739cfcafd819475ee3552bdb1/libra_account.bpl:5814:24: <boogie>: inline$$LibraAccount_pay_from_capability$0$Entry
-     =     at /var/folders/85/dnj3wv151rqgv2jby442x5pm0000gn/T/a949499739cfcafd819475ee3552bdb1/libra_account.bpl:3363:24: <boogie>: inline$$LibraAccount_exists$0$Entry
-     =     at /var/folders/85/dnj3wv151rqgv2jby442x5pm0000gn/T/a949499739cfcafd819475ee3552bdb1/libra_account.bpl:5866:6: <boogie>: inline$$LibraAccount_pay_from_capability$0$anon25_Else
-     =     at /var/folders/85/dnj3wv151rqgv2jby442x5pm0000gn/T/a949499739cfcafd819475ee3552bdb1/libra_account.bpl:3667:24: <boogie>: inline$$LibraAccount_create_account$0$Entry
-     =     at /var/folders/85/dnj3wv151rqgv2jby442x5pm0000gn/T/a949499739cfcafd819475ee3552bdb1/libra_account.bpl:3734:18: <boogie>: inline$$LibraAccount_create_account$0$anon31_Then
-     =     at /var/folders/85/dnj3wv151rqgv2jby442x5pm0000gn/T/a949499739cfcafd819475ee3552bdb1/libra_account.bpl:3737:6: <boogie>: inline$$LibraAccount_create_account$0$anon6$1
-     =     at /var/folders/85/dnj3wv151rqgv2jby442x5pm0000gn/T/a949499739cfcafd819475ee3552bdb1/libra_account.bpl:3746:6: <boogie>: inline$$LibraAccount_create_account$0$anon8$1
+     =     at libra_account.bpl:6359:24: <boogie>: inline$$LibraAccount_pay_from_capability$0$Entry
+     =     at libra_account.bpl:3607:24: <boogie>: inline$$LibraAccount_exists$0$Entry
+     =     at libra_account.bpl:6413:6: <boogie>: inline$$LibraAccount_pay_from_capability$0$anon25_Else
+     =     at libra_account.bpl:3932:24: <boogie>: inline$$LibraAccount_create_account$0$Entry
+     =     at libra_account.bpl:4002:18: <boogie>: inline$$LibraAccount_create_account$0$anon31_Then
+     =     at libra_account.bpl:4006:6: <boogie>: inline$$LibraAccount_create_account$0$anon6$1
+     =     at libra_account.bpl:4017:6: <boogie>: inline$$LibraAccount_create_account$0$anon8$1
 
 bug:  This assertion might not hold.
 
-     ┌── /var/folders/85/dnj3wv151rqgv2jby442x5pm0000gn/T/a949499739cfcafd819475ee3552bdb1/libra_account.bpl:953:6 ───
+     ┌── libra_account.bpl:953:6 ───
      │
  953 │     assert false; // $AddressUtil_address_to_bytes not implemented
      │      ^
      │
-     =     at /var/folders/85/dnj3wv151rqgv2jby442x5pm0000gn/T/a949499739cfcafd819475ee3552bdb1/libra_account.bpl:5960:24: <boogie>: inline$$LibraAccount_pay_from_sender$0$Entry
-     =     at /var/folders/85/dnj3wv151rqgv2jby442x5pm0000gn/T/a949499739cfcafd819475ee3552bdb1/libra_account.bpl:6006:6: <boogie>: inline$$LibraAccount_pay_from_sender$0$anon14_Else
-     =     at /var/folders/85/dnj3wv151rqgv2jby442x5pm0000gn/T/a949499739cfcafd819475ee3552bdb1/libra_account.bpl:6035:24: <boogie>: inline$$LibraAccount_pay_from_sender_with_metadata$0$Entry
-     =     at /var/folders/85/dnj3wv151rqgv2jby442x5pm0000gn/T/a949499739cfcafd819475ee3552bdb1/libra_account.bpl:3363:24: <boogie>: inline$$LibraAccount_exists$0$Entry
-     =     at /var/folders/85/dnj3wv151rqgv2jby442x5pm0000gn/T/a949499739cfcafd819475ee3552bdb1/libra_account.bpl:6081:6: <boogie>: inline$$LibraAccount_pay_from_sender_with_metadata$0$anon22_Else
-     =     at /var/folders/85/dnj3wv151rqgv2jby442x5pm0000gn/T/a949499739cfcafd819475ee3552bdb1/libra_account.bpl:3667:24: <boogie>: inline$$LibraAccount_create_account$0$Entry
-     =     at /var/folders/85/dnj3wv151rqgv2jby442x5pm0000gn/T/a949499739cfcafd819475ee3552bdb1/libra_account.bpl:3734:18: <boogie>: inline$$LibraAccount_create_account$0$anon31_Then
-     =     at /var/folders/85/dnj3wv151rqgv2jby442x5pm0000gn/T/a949499739cfcafd819475ee3552bdb1/libra_account.bpl:3737:6: <boogie>: inline$$LibraAccount_create_account$0$anon6$1
-     =     at /var/folders/85/dnj3wv151rqgv2jby442x5pm0000gn/T/a949499739cfcafd819475ee3552bdb1/libra_account.bpl:3746:6: <boogie>: inline$$LibraAccount_create_account$0$anon8$1
+     =     at libra_account.bpl:6523:24: <boogie>: inline$$LibraAccount_pay_from_sender$0$Entry
+     =     at libra_account.bpl:6573:6: <boogie>: inline$$LibraAccount_pay_from_sender$0$anon14_Else
+     =     at libra_account.bpl:6604:24: <boogie>: inline$$LibraAccount_pay_from_sender_with_metadata$0$Entry
+     =     at libra_account.bpl:3607:24: <boogie>: inline$$LibraAccount_exists$0$Entry
+     =     at libra_account.bpl:6652:6: <boogie>: inline$$LibraAccount_pay_from_sender_with_metadata$0$anon22_Else
+     =     at libra_account.bpl:3932:24: <boogie>: inline$$LibraAccount_create_account$0$Entry
+     =     at libra_account.bpl:4002:18: <boogie>: inline$$LibraAccount_create_account$0$anon31_Then
+     =     at libra_account.bpl:4006:6: <boogie>: inline$$LibraAccount_create_account$0$anon6$1
+     =     at libra_account.bpl:4017:6: <boogie>: inline$$LibraAccount_create_account$0$anon8$1
 
 bug:  This assertion might not hold.
 
-     ┌── /var/folders/85/dnj3wv151rqgv2jby442x5pm0000gn/T/a949499739cfcafd819475ee3552bdb1/libra_account.bpl:953:6 ───
+     ┌── libra_account.bpl:953:6 ───
      │
  953 │     assert false; // $AddressUtil_address_to_bytes not implemented
      │      ^
      │
-     =     at /var/folders/85/dnj3wv151rqgv2jby442x5pm0000gn/T/a949499739cfcafd819475ee3552bdb1/libra_account.bpl:6035:24: <boogie>: inline$$LibraAccount_pay_from_sender_with_metadata$0$Entry
-     =     at /var/folders/85/dnj3wv151rqgv2jby442x5pm0000gn/T/a949499739cfcafd819475ee3552bdb1/libra_account.bpl:3363:24: <boogie>: inline$$LibraAccount_exists$0$Entry
-     =     at /var/folders/85/dnj3wv151rqgv2jby442x5pm0000gn/T/a949499739cfcafd819475ee3552bdb1/libra_account.bpl:6081:6: <boogie>: inline$$LibraAccount_pay_from_sender_with_metadata$0$anon22_Else
-     =     at /var/folders/85/dnj3wv151rqgv2jby442x5pm0000gn/T/a949499739cfcafd819475ee3552bdb1/libra_account.bpl:3667:24: <boogie>: inline$$LibraAccount_create_account$0$Entry
-     =     at /var/folders/85/dnj3wv151rqgv2jby442x5pm0000gn/T/a949499739cfcafd819475ee3552bdb1/libra_account.bpl:3734:18: <boogie>: inline$$LibraAccount_create_account$0$anon31_Then
-     =     at /var/folders/85/dnj3wv151rqgv2jby442x5pm0000gn/T/a949499739cfcafd819475ee3552bdb1/libra_account.bpl:3737:6: <boogie>: inline$$LibraAccount_create_account$0$anon6$1
-     =     at /var/folders/85/dnj3wv151rqgv2jby442x5pm0000gn/T/a949499739cfcafd819475ee3552bdb1/libra_account.bpl:3746:6: <boogie>: inline$$LibraAccount_create_account$0$anon8$1
+     =     at libra_account.bpl:6604:24: <boogie>: inline$$LibraAccount_pay_from_sender_with_metadata$0$Entry
+     =     at libra_account.bpl:3607:24: <boogie>: inline$$LibraAccount_exists$0$Entry
+     =     at libra_account.bpl:6652:6: <boogie>: inline$$LibraAccount_pay_from_sender_with_metadata$0$anon22_Else
+     =     at libra_account.bpl:3932:24: <boogie>: inline$$LibraAccount_create_account$0$Entry
+     =     at libra_account.bpl:4002:18: <boogie>: inline$$LibraAccount_create_account$0$anon31_Then
+     =     at libra_account.bpl:4006:6: <boogie>: inline$$LibraAccount_create_account$0$anon6$1
+     =     at libra_account.bpl:4017:6: <boogie>: inline$$LibraAccount_create_account$0$anon8$1
 
 bug:  This assertion might not hold.
 
-     ┌── /var/folders/85/dnj3wv151rqgv2jby442x5pm0000gn/T/a949499739cfcafd819475ee3552bdb1/libra_account.bpl:978:6 ───
+     ┌── libra_account.bpl:978:6 ───
      │
  978 │     assert false; // $Hash_sha3_256 not implemented
      │      ^
      │
-     =     at /var/folders/85/dnj3wv151rqgv2jby442x5pm0000gn/T/a949499739cfcafd819475ee3552bdb1/libra_account.bpl:6160:24: <boogie>: inline$$LibraAccount_prologue$0$Entry
-     =     at /var/folders/85/dnj3wv151rqgv2jby442x5pm0000gn/T/a949499739cfcafd819475ee3552bdb1/libra_account.bpl:6263:18: <boogie>: inline$$LibraAccount_prologue$0$anon72_Then
-     =     at /var/folders/85/dnj3wv151rqgv2jby442x5pm0000gn/T/a949499739cfcafd819475ee3552bdb1/libra_account.bpl:6266:6: <boogie>: inline$$LibraAccount_prologue$0$anon12$1
-     =     at /var/folders/85/dnj3wv151rqgv2jby442x5pm0000gn/T/a949499739cfcafd819475ee3552bdb1/libra_account.bpl:3363:24: <boogie>: inline$$LibraAccount_exists$0$Entry
-     =     at /var/folders/85/dnj3wv151rqgv2jby442x5pm0000gn/T/a949499739cfcafd819475ee3552bdb1/libra_account.bpl:6271:6: <boogie>: inline$$LibraAccount_prologue$0$anon73_Else
-     =     at /var/folders/85/dnj3wv151rqgv2jby442x5pm0000gn/T/a949499739cfcafd819475ee3552bdb1/libra_account.bpl:6316:6: <boogie>: inline$$LibraAccount_prologue$0$anon77_Else
-     =     at /var/folders/85/dnj3wv151rqgv2jby442x5pm0000gn/T/a949499739cfcafd819475ee3552bdb1/libra_account.bpl:6326:6: <boogie>: inline$$LibraAccount_prologue$0$anon24$1
+     =     at libra_account.bpl:6743:24: <boogie>: inline$$LibraAccount_prologue$0$Entry
+     =     at libra_account.bpl:6848:18: <boogie>: inline$$LibraAccount_prologue$0$anon72_Then
+     =     at libra_account.bpl:6852:6: <boogie>: inline$$LibraAccount_prologue$0$anon12$1
+     =     at libra_account.bpl:3607:24: <boogie>: inline$$LibraAccount_exists$0$Entry
+     =     at libra_account.bpl:6858:6: <boogie>: inline$$LibraAccount_prologue$0$anon73_Else
+     =     at libra_account.bpl:6912:6: <boogie>: inline$$LibraAccount_prologue$0$anon77_Else
+     =     at libra_account.bpl:6924:6: <boogie>: inline$$LibraAccount_prologue$0$anon24$1


### PR DESCRIPTION
I thought this was fixed already in a previous PR, but I must have looked at a different branch instead of the submitted one.

Also fixes an issues with unstable file names in baselines. If we report an error on generated Boogie, the file name in diagnosis with a temporary unstable location. Added a heuristic to baseline test utility to detect this and remove parts of the unstable file name.

## Motivation

Code cleanup.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

None needed

## Related PRs

NA