### PR TITLE
[crypto] remove compat and update Uniform

### DIFF
--- a/admission_control/admission-control-service/Cargo.toml
+++ b/admission_control/admission-control-service/Cargo.toml
@@ -32,6 +32,7 @@ serde_json = "1.0"
 
 [dev-dependencies]
 assert_matches = "1.3.0"
+libra-types = { path = "../../types", version = "0.1.0", features = ["fuzzing"] }
 vm-validator = { path = "../../vm-validator", version = "0.1.0" }
 
 [features]

--- a/admission_control/admission-control-service/src/unit_tests/admission_control_service_test.rs
+++ b/admission_control/admission-control-service/src/unit_tests/admission_control_service_test.rs
@@ -10,7 +10,7 @@ use admission_control_proto::{
 };
 use anyhow::Result;
 use futures::executor::block_on;
-use libra_crypto::{ed25519::*, test_utils::TEST_SEED};
+use libra_crypto::{ed25519::Ed25519PrivateKey, test_utils::TEST_SEED, PrivateKey, Uniform};
 use libra_types::{
     account_address::AccountAddress,
     mempool_status::MempoolStatusCode,
@@ -34,16 +34,15 @@ fn submit_transaction(
     ac_service: &MockAdmissionControlService,
     are_keys_valid: bool,
 ) -> SubmitTransactionResponse {
-    let keypair = compat::generate_keypair(None);
+    let mut rng = ::rand::rngs::StdRng::from_seed(TEST_SEED);
+    let private_key = Ed25519PrivateKey::generate(&mut rng);
     let public_key = if are_keys_valid {
-        keypair.1
+        private_key.public_key()
     } else {
-        let mut rng = ::rand::rngs::StdRng::from_seed(TEST_SEED);
-        let test_key = compat::generate_keypair(&mut rng);
-        test_key.1
+        Ed25519PrivateKey::generate(&mut rng).public_key()
     };
     let mut req = SubmitTransactionRequest::default();
-    req.transaction = Some(get_test_signed_txn(sender, 0, &keypair.0, public_key, None).into());
+    req.transaction = Some(get_test_signed_txn(sender, 0, &private_key, public_key, None).into());
     SubmitTransactionResponse::try_from(
         block_on(ac_service.submit_transaction(Request::new(req)))
             .unwrap()

--- a/client/libra-dev/src/account.rs
+++ b/client/libra-dev/src/account.rs
@@ -5,7 +5,7 @@ use crate::{
     data::{LibraAccountKey, LibraStatus},
     error::*,
 };
-use libra_crypto::ed25519::*;
+use libra_crypto::{ed25519::Ed25519PrivateKey, PrivateKey};
 use libra_types::account_address::AccountAddress;
 use std::{convert::TryFrom, slice};
 
@@ -22,7 +22,7 @@ pub unsafe extern "C" fn libra_LibraAccountKey_from(
     }
 
     let private_key_buf: &[u8] =
-        slice::from_raw_parts(private_key_bytes, ED25519_PRIVATE_KEY_LENGTH);
+        slice::from_raw_parts(private_key_bytes, Ed25519PrivateKey::LENGTH);
 
     let private_key = match Ed25519PrivateKey::try_from(private_key_buf) {
         Ok(result) => result,
@@ -31,7 +31,7 @@ pub unsafe extern "C" fn libra_LibraAccountKey_from(
             return LibraStatus::InvalidArgument;
         }
     };
-    let public_key: Ed25519PublicKey = (&private_key).into();
+    let public_key = private_key.public_key();
     let address = AccountAddress::from_public_key(&public_key);
 
     *out = LibraAccountKey {
@@ -46,20 +46,15 @@ pub unsafe extern "C" fn libra_LibraAccountKey_from(
 /// Generate a private key, then get LibraAccount
 #[test]
 fn test_libra_account_from() {
-    use libra_crypto::test_utils::TEST_SEED;
-    use rand::{rngs::StdRng, SeedableRng};
+    use libra_crypto::Uniform;
 
-    // generate key pair
-    let mut rng = StdRng::from_seed(TEST_SEED);
-    let key_pair = compat::generate_keypair(&mut rng);
-    let private_key = key_pair.0;
-
+    let private_key = Ed25519PrivateKey::generate_for_testing();
     let mut libra_account = LibraAccountKey::default();
     let result =
         unsafe { libra_LibraAccountKey_from(private_key.to_bytes().as_ptr(), &mut libra_account) };
     assert_eq!(result, LibraStatus::Ok);
 
-    let public_key = key_pair.1;
+    let public_key = private_key.public_key();
     let address = AccountAddress::from_public_key(&public_key);
 
     assert_eq!(libra_account.public_key, public_key.to_bytes());

--- a/client/libra-dev/src/account_resource.rs
+++ b/client/libra-dev/src/account_resource.rs
@@ -76,7 +76,7 @@ mod tests {
     /// Generate an AccountBlob and verify we can parse it
     #[test]
     fn test_get_accountresource() {
-        use libra_crypto::ed25519::compat;
+        use libra_crypto::{ed25519::Ed25519PrivateKey, PrivateKey, Uniform};
         use libra_types::{
             account_config::{
                 AccountResource, BalanceResource, ACCOUNT_RESOURCE_PATH, BALANCE_RESOURCE_PATH,
@@ -86,11 +86,11 @@ mod tests {
         };
         use std::collections::BTreeMap;
 
-        let keypair = compat::generate_keypair(None);
+        let pubkey = Ed25519PrivateKey::generate_for_testing().public_key();
 
         // Figure out how to use Libra code to generate AccountStateBlob directly, not involving btreemap directly
         let mut map: BTreeMap<Vec<u8>, Vec<u8>> = BTreeMap::new();
-        let auth_key = AuthenticationKey::ed25519(&keypair.1);
+        let auth_key = AuthenticationKey::ed25519(&pubkey);
         let addr = auth_key.derived_address();
         let ar = AccountResource::new(
             123_456_789,

--- a/client/libra-dev/src/event.rs
+++ b/client/libra-dev/src/event.rs
@@ -174,7 +174,7 @@ pub unsafe extern "C" fn libra_LibraEvent_free(ptr: *mut LibraEvent) {
 
 #[test]
 fn test_libra_LibraEvent_from() {
-    use libra_crypto::ed25519::compat;
+    use libra_crypto::{ed25519::Ed25519PrivateKey, PrivateKey, Uniform};
     use libra_types::{
         account_address::AccountAddress,
         account_config::SentPaymentEvent,
@@ -185,8 +185,7 @@ fn test_libra_LibraEvent_from() {
     use move_core_types::identifier::Identifier;
     use std::ffi::CStr;
 
-    let keypair = compat::generate_keypair(None);
-    let public_key = keypair.1;
+    let public_key = Ed25519PrivateKey::generate_for_testing().public_key();
     let sender_address = AccountAddress::from_public_key(&public_key);
     let sent_event_handle = EventHandle::new(EventKey::new_from_address(&sender_address, 0), 0);
     let sequence_number = sent_event_handle.count();

--- a/config/config-builder/src/validator_config.rs
+++ b/config/config-builder/src/validator_config.rs
@@ -218,7 +218,7 @@ impl ValidatorConfig {
 
     fn build_faucet(&self) -> (Ed25519PrivateKey, [u8; 32]) {
         let mut faucet_rng = StdRng::from_seed(self.seed);
-        let faucet_key = Ed25519PrivateKey::generate_for_testing(&mut faucet_rng);
+        let faucet_key = Ed25519PrivateKey::generate(&mut faucet_rng);
         let config_seed: [u8; 32] = faucet_rng.gen();
         (faucet_key, config_seed)
     }

--- a/config/generate-keypair/src/lib.rs
+++ b/config/generate-keypair/src/lib.rs
@@ -4,7 +4,11 @@
 #![forbid(unsafe_code)]
 
 use anyhow::Result;
-use libra_crypto::{ed25519::*, test_utils::KeyPair};
+use libra_crypto::{
+    ed25519::{Ed25519PrivateKey, Ed25519PublicKey},
+    test_utils::KeyPair,
+    Uniform,
+};
 use libra_temppath::TempPath;
 use rand::{rngs::OsRng, Rng, SeedableRng};
 use std::{
@@ -23,7 +27,7 @@ pub fn create_faucet_key_file(output_file: &str) -> KeyPair<Ed25519PrivateKey, E
     let mut seed_rng = OsRng::new().expect("can't access OsRng");
     let mut rng = rand::rngs::StdRng::from_seed(seed_rng.gen());
 
-    let (private_key, _) = compat::generate_keypair(&mut rng);
+    let private_key = Ed25519PrivateKey::generate(&mut rng);
     let keypair = KeyPair::from(private_key);
 
     // Write to disk

--- a/config/src/config/network_config.rs
+++ b/config/src/config/network_config.rs
@@ -175,8 +175,8 @@ impl NetworkConfig {
     }
 
     pub fn random_with_peer_id(&mut self, rng: &mut StdRng, peer_id: Option<PeerId>) {
-        let signing_key = Ed25519PrivateKey::generate_for_testing(rng);
-        let identity_key = X25519StaticPrivateKey::generate_for_testing(rng);
+        let signing_key = Ed25519PrivateKey::generate(rng);
+        let identity_key = X25519StaticPrivateKey::generate(rng);
         let network_keypairs = NetworkKeyPairs::load(signing_key, identity_key);
         self.peer_id = if let Some(peer_id) = peer_id {
             peer_id

--- a/config/src/config/test_config.rs
+++ b/config/src/config/test_config.rs
@@ -65,12 +65,12 @@ impl TestConfig {
     }
 
     pub fn random_account_key(&mut self, rng: &mut StdRng) {
-        let privkey = Ed25519PrivateKey::generate_for_testing(rng);
+        let privkey = Ed25519PrivateKey::generate(rng);
         self.account_keypair = Some(AccountKeyPair::load(privkey));
     }
 
     pub fn random_consensus_key(&mut self, rng: &mut StdRng) {
-        let privkey = Ed25519PrivateKey::generate_for_testing(rng);
+        let privkey = Ed25519PrivateKey::generate(rng);
         self.consensus_keypair = Some(ConsensusKeyPair::load(privkey));
     }
 

--- a/config/src/keys.rs
+++ b/config/src/keys.rs
@@ -1,9 +1,8 @@
 // Copyright (c) The Libra Core Contributors
 // SPDX-License-Identifier: Apache-2.0
 
-use libra_crypto::{test_utils::TEST_SEED, PrivateKey, Uniform, ValidKeyStringExt};
+use libra_crypto::{PrivateKey, Uniform, ValidKeyStringExt};
 use mirai_annotations::verify_unreachable;
-use rand::{rngs::StdRng, SeedableRng};
 use serde::{de::DeserializeOwned, Deserialize, Deserializer, Serialize, Serializer};
 
 #[derive(Debug, PartialEq)]
@@ -81,8 +80,7 @@ where
     T::PublicKeyMaterial: DeserializeOwned + 'static + Serialize + ValidKeyStringExt,
 {
     fn default() -> Self {
-        let mut rng = StdRng::from_seed(TEST_SEED);
-        let private_key = T::generate(&mut rng);
+        let private_key = T::generate_for_testing();
         let public_key = private_key.public_key();
         Self {
             private_key: PrivateKeyContainer::Present(private_key),

--- a/config/src/keys.rs
+++ b/config/src/keys.rs
@@ -82,7 +82,7 @@ where
 {
     fn default() -> Self {
         let mut rng = StdRng::from_seed(TEST_SEED);
-        let private_key = T::generate_for_testing(&mut rng);
+        let private_key = T::generate(&mut rng);
         let public_key = private_key.public_key();
         Self {
             private_key: PrivateKeyContainer::Present(private_key),

--- a/crypto/crypto/src/ed25519.rs
+++ b/crypto/crypto/src/ed25519.rs
@@ -21,7 +21,7 @@
 //! let hashed_message = hasher.finish();
 //!
 //! let mut rng: StdRng = SeedableRng::from_seed([0; 32]);
-//! let private_key = Ed25519PrivateKey::generate_for_testing(&mut rng);
+//! let private_key = Ed25519PrivateKey::generate(&mut rng);
 //! let public_key: Ed25519PublicKey = (&private_key).into();
 //! let signature = private_key.sign_message(&hashed_message);
 //! assert!(signature.verify(&hashed_message, &public_key).is_ok());
@@ -165,7 +165,7 @@ impl SigningKey for Ed25519PrivateKey {
 }
 
 impl Uniform for Ed25519PrivateKey {
-    fn generate_for_testing<R>(rng: &mut R) -> Self
+    fn generate<R>(rng: &mut R) -> Self
     where
         R: ::rand::SeedableRng + ::rand::RngCore + ::rand::CryptoRng,
     {
@@ -467,10 +467,10 @@ pub mod compat {
         T: Into<Option<&'a mut StdRng>> + Sized,
     {
         if let Some(rng_mut_ref) = opt_rng.into() {
-            <(Ed25519PrivateKey, Ed25519PublicKey)>::generate_for_testing(rng_mut_ref)
+            <(Ed25519PrivateKey, Ed25519PublicKey)>::generate(rng_mut_ref)
         } else {
             let mut rng = StdRng::from_seed(crate::test_utils::TEST_SEED);
-            <(Ed25519PrivateKey, Ed25519PublicKey)>::generate_for_testing(&mut rng)
+            <(Ed25519PrivateKey, Ed25519PublicKey)>::generate(&mut rng)
         }
     }
 

--- a/crypto/crypto/src/lib.rs
+++ b/crypto/crypto/src/lib.rs
@@ -11,13 +11,12 @@ pub mod error;
 pub mod hash;
 pub mod hkdf;
 pub mod multi_ed25519;
+pub mod test_utils;
 pub mod traits;
 pub mod x25519;
 
 #[cfg(test)]
 mod unit_tests;
-
-pub mod test_utils;
 
 pub use self::traits::*;
 pub use hash::HashValue;

--- a/crypto/crypto/src/multi_ed25519.rs
+++ b/crypto/crypto/src/multi_ed25519.rs
@@ -157,7 +157,7 @@ impl SigningKey for MultiEd25519PrivateKey {
 
 // Generating a random K out-of N key for testing.
 impl Uniform for MultiEd25519PrivateKey {
-    fn generate_for_testing<R>(rng: &mut R) -> Self
+    fn generate<R>(rng: &mut R) -> Self
     where
         R: ::rand::SeedableRng + ::rand::RngCore + ::rand::CryptoRng,
     {

--- a/crypto/crypto/src/test_utils.rs
+++ b/crypto/crypto/src/test_utils.rs
@@ -75,3 +75,25 @@ where
         write!(f, "{}", hex::encode(&v[..]))
     }
 }
+
+#[cfg(any(test, feature = "fuzzing"))]
+use rand::{rngs::StdRng, SeedableRng};
+#[cfg(any(test, feature = "fuzzing"))]
+use proptest::prelude::*;
+
+/// Produces a uniformly random keypair from a seed
+#[cfg(any(test, feature = "fuzzing"))]
+pub fn uniform_keypair_strategy<Priv, Pub>() -> impl Strategy<Value = KeyPair<Priv, Pub>>
+where
+    Pub: Serialize + for<'a> From<&'a Priv>,
+    Priv: Serialize + Uniform,
+{
+    // The no_shrink is because keypairs should be fixed -- shrinking would cause a different
+    // keypair to be generated, which appears to not be very useful.
+    any::<[u8; 32]>()
+        .prop_map(|seed| {
+            let mut rng = StdRng::from_seed(seed);
+            KeyPair::<Priv, Pub>::generate_for_testing(&mut rng)
+        })
+        .no_shrink()
+}

--- a/crypto/crypto/src/test_utils.rs
+++ b/crypto/crypto/src/test_utils.rs
@@ -39,11 +39,11 @@ where
     S: Uniform,
     for<'a> P: From<&'a S>,
 {
-    fn generate_for_testing<R>(rng: &mut R) -> Self
+    fn generate<R>(rng: &mut R) -> Self
     where
         R: ::rand::SeedableRng + ::rand::RngCore + ::rand::CryptoRng,
     {
-        let private_key = S::generate_for_testing(rng);
+        let private_key = S::generate(rng);
         private_key.into()
     }
 }
@@ -54,11 +54,11 @@ where
     S: Uniform,
     for<'a> P: From<&'a S>,
 {
-    fn generate_for_testing<R>(rng: &mut R) -> Self
+    fn generate<R>(rng: &mut R) -> Self
     where
         R: ::rand::SeedableRng + ::rand::RngCore + ::rand::CryptoRng,
     {
-        let private_key = S::generate_for_testing(rng);
+        let private_key = S::generate(rng);
         let public_key = (&private_key).into();
         (private_key, public_key)
     }
@@ -77,9 +77,9 @@ where
 }
 
 #[cfg(any(test, feature = "fuzzing"))]
-use rand::{rngs::StdRng, SeedableRng};
-#[cfg(any(test, feature = "fuzzing"))]
 use proptest::prelude::*;
+#[cfg(any(test, feature = "fuzzing"))]
+use rand::{rngs::StdRng, SeedableRng};
 
 /// Produces a uniformly random keypair from a seed
 #[cfg(any(test, feature = "fuzzing"))]
@@ -93,7 +93,7 @@ where
     any::<[u8; 32]>()
         .prop_map(|seed| {
             let mut rng = StdRng::from_seed(seed);
-            KeyPair::<Priv, Pub>::generate_for_testing(&mut rng)
+            KeyPair::<Priv, Pub>::generate(&mut rng)
         })
         .no_shrink()
 }

--- a/crypto/crypto/src/traits.rs
+++ b/crypto/crypto/src/traits.rs
@@ -9,6 +9,7 @@
 use crate::HashValue;
 use anyhow::Result;
 use core::convert::{From, TryFrom};
+use rand::{rngs::StdRng, CryptoRng, RngCore, SeedableRng};
 use serde::{de::DeserializeOwned, Serialize};
 use std::{fmt::Debug, hash::Hash};
 use thiserror::Error;
@@ -229,7 +230,16 @@ pub trait Uniform {
     /// store private keys.
     fn generate<R>(rng: &mut R) -> Self
     where
-        R: ::rand::SeedableRng + ::rand::RngCore + ::rand::CryptoRng;
+        R: SeedableRng + RngCore + CryptoRng;
+
+    /// Generate a random key using the shared TEST_SEED
+    fn generate_for_testing() -> Self
+    where
+        Self: Sized,
+    {
+        let mut rng: StdRng = SeedableRng::from_seed(crate::test_utils::TEST_SEED);
+        Self::generate(&mut rng)
+    }
 }
 
 /// A type family with a by-convention notion of genesis private key.

--- a/crypto/crypto/src/traits.rs
+++ b/crypto/crypto/src/traits.rs
@@ -224,8 +224,10 @@ pub trait Signature:
 /// A type family for schemes which know how to generate key material from
 /// a cryptographically-secure [`CryptoRng`][::rand::CryptoRng].
 pub trait Uniform {
-    /// Generate key material from an RNG for testing purposes.
-    fn generate_for_testing<R>(rng: &mut R) -> Self
+    /// Generate key material from an RNG. This should generally not be used for production
+    /// purposes even with a good source of randomness. When possible use hardware crypto to generate and
+    /// store private keys.
+    fn generate<R>(rng: &mut R) -> Self
     where
         R: ::rand::SeedableRng + ::rand::RngCore + ::rand::CryptoRng;
 }

--- a/crypto/crypto/src/unit_tests/cross_test.rs
+++ b/crypto/crypto/src/unit_tests/cross_test.rs
@@ -7,8 +7,8 @@ use crate as libra_crypto;
 use crate::{
     ed25519::{Ed25519PrivateKey, Ed25519PublicKey, Ed25519Signature},
     multi_ed25519::{MultiEd25519PrivateKey, MultiEd25519PublicKey, MultiEd25519Signature},
-    traits::*,
     test_utils::uniform_keypair_strategy,
+    traits::*,
 };
 
 use crate::hash::HashValue;

--- a/crypto/crypto/src/unit_tests/cross_test.rs
+++ b/crypto/crypto/src/unit_tests/cross_test.rs
@@ -8,7 +8,7 @@ use crate::{
     ed25519::{Ed25519PrivateKey, Ed25519PublicKey, Ed25519Signature},
     multi_ed25519::{MultiEd25519PrivateKey, MultiEd25519PublicKey, MultiEd25519Signature},
     traits::*,
-    unit_tests::uniform_keypair_strategy,
+    test_utils::uniform_keypair_strategy,
 };
 
 use crate::hash::HashValue;

--- a/crypto/crypto/src/unit_tests/ed25519_test.rs
+++ b/crypto/crypto/src/unit_tests/ed25519_test.rs
@@ -7,7 +7,7 @@ use crate::{
         ED25519_PUBLIC_KEY_LENGTH, ED25519_SIGNATURE_LENGTH,
     },
     traits::*,
-    unit_tests::uniform_keypair_strategy,
+    test_utils::uniform_keypair_strategy,
 };
 
 use core::{

--- a/crypto/crypto/src/unit_tests/ed25519_test.rs
+++ b/crypto/crypto/src/unit_tests/ed25519_test.rs
@@ -6,8 +6,8 @@ use crate::{
         Ed25519PrivateKey, Ed25519PublicKey, Ed25519Signature, ED25519_PRIVATE_KEY_LENGTH,
         ED25519_PUBLIC_KEY_LENGTH, ED25519_SIGNATURE_LENGTH,
     },
-    traits::*,
     test_utils::uniform_keypair_strategy,
+    traits::*,
 };
 
 use core::{

--- a/crypto/crypto/src/unit_tests/mod.rs
+++ b/crypto/crypto/src/unit_tests/mod.rs
@@ -6,24 +6,3 @@ mod ed25519_test;
 mod hkdf_test;
 mod multi_ed25519_test;
 mod x25519_test;
-
-use crate::{test_utils::KeyPair, traits::Uniform};
-use proptest::prelude::*;
-use rand::{rngs::StdRng, SeedableRng};
-use serde::Serialize;
-
-/// Produces a uniformly random keypair from a seed
-pub(super) fn uniform_keypair_strategy<Priv, Pub>() -> impl Strategy<Value = KeyPair<Priv, Pub>>
-where
-    Pub: Serialize + for<'a> From<&'a Priv>,
-    Priv: Serialize + Uniform,
-{
-    // The no_shrink is because keypairs should be fixed -- shrinking would cause a different
-    // keypair to be generated, which appears to not be very useful.
-    any::<[u8; 32]>()
-        .prop_map(|seed| {
-            let mut rng = StdRng::from_seed(seed);
-            KeyPair::<Priv, Pub>::generate_for_testing(&mut rng)
-        })
-        .no_shrink()
-}

--- a/crypto/crypto/src/unit_tests/x25519_test.rs
+++ b/crypto/crypto/src/unit_tests/x25519_test.rs
@@ -12,12 +12,12 @@ fn test_default_key_pair() {
     let public_key2: X25519StaticPublicKey;
     {
         let mut rng: StdRng = SeedableRng::from_seed(seed);
-        let private_key1 = X25519StaticPrivateKey::generate_for_testing(&mut rng);
+        let private_key1 = X25519StaticPrivateKey::generate(&mut rng);
         public_key1 = (&private_key1).into();
     }
     {
         let mut rng: StdRng = SeedableRng::from_seed(seed);
-        let private_key2 = X25519StaticPrivateKey::generate_for_testing(&mut rng);
+        let private_key2 = X25519StaticPrivateKey::generate(&mut rng);
         public_key2 = (&private_key2).into();
     }
     assert_eq!(public_key1, public_key2);
@@ -66,7 +66,7 @@ fn test_generate_key_pair_with_seed() {
 fn test_serialize_deserialize() {
     let seed: [u8; 32] = [0u8; 32];
     let mut rng: StdRng = SeedableRng::from_seed(seed);
-    let private_key = X25519StaticPrivateKey::generate_for_testing(&mut rng);
+    let private_key = X25519StaticPrivateKey::generate(&mut rng);
     let public_key: X25519StaticPublicKey = (&private_key).into();
 
     let serialized = lcs::to_bytes(&private_key).unwrap();

--- a/crypto/crypto/src/x25519.rs
+++ b/crypto/crypto/src/x25519.rs
@@ -325,61 +325,16 @@ impl std::fmt::Debug for X25519StaticPublicKey {
     }
 }
 
-//////////////////////////
-// Compatibility Traits //
-//////////////////////////
+#[cfg(any(test, feature = "fuzzing"))]
+use proptest::prelude::*;
 
-/// Those transitory traits are meant to help with the progressive
-/// migration of the code base to the crypto module and will
-/// disappear after.
-pub mod compat {
-    use crate::traits::*;
-    #[cfg(any(test, feature = "fuzzing"))]
-    use proptest::strategy::LazyJust;
-    #[cfg(any(test, feature = "fuzzing"))]
-    use proptest::{prelude::*, strategy::Strategy};
+#[cfg(any(test, feature = "fuzzing"))]
+impl proptest::arbitrary::Arbitrary for X25519StaticPublicKey {
+    type Parameters = ();
+    type Strategy = BoxedStrategy<Self>;
 
-    use crate::x25519::{X25519StaticPrivateKey, X25519StaticPublicKey};
-    use rand::{rngs::StdRng, SeedableRng};
-
-    /// Generate an arbitrary key pair, with possible Rng input
-    ///
-    /// Warning: if you pass in None, this will not return distinct
-    /// results every time! Should you want to write non-deterministic
-    /// tests, look at libra_config::config_builder::util::get_test_config
-    pub fn generate_keypair<'a, T>(opt_rng: T) -> (X25519StaticPrivateKey, X25519StaticPublicKey)
-    where
-        T: Into<Option<&'a mut StdRng>> + Sized,
-    {
-        if let Some(rng_mut_ref) = opt_rng.into() {
-            <(X25519StaticPrivateKey, X25519StaticPublicKey)>::generate(rng_mut_ref)
-        } else {
-            let mut rng = StdRng::from_seed(crate::test_utils::TEST_SEED);
-            <(X25519StaticPrivateKey, X25519StaticPublicKey)>::generate(&mut rng)
-        }
-    }
-
-    /// Used to produce keypairs from a seed for testing purposes
-    #[cfg(any(test, feature = "fuzzing"))]
-    pub fn keypair_strategy(
-    ) -> impl Strategy<Value = (X25519StaticPrivateKey, X25519StaticPublicKey)> {
-        // The no_shrink is because keypairs should be fixed -- shrinking would cause a different
-        // keypair to be generated, which appears to not be very useful.
-        any::<[u8; 32]>()
-            .prop_map(|seed| {
-                let mut rng: StdRng = SeedableRng::from_seed(seed);
-                let (private_key, public_key) = generate_keypair(&mut rng);
-                (private_key, public_key)
-            })
-            .no_shrink()
-    }
-
-    #[cfg(any(test, feature = "fuzzing"))]
-    impl Arbitrary for X25519StaticPublicKey {
-        type Parameters = ();
-        fn arbitrary_with(_args: Self::Parameters) -> Self::Strategy {
-            LazyJust::new(|| generate_keypair(None).1).boxed()
-        }
-        type Strategy = BoxedStrategy<Self>;
+    fn arbitrary_with(_args: Self::Parameters) -> Self::Strategy {
+        crate::test_utils::uniform_keypair_strategy::<X25519StaticPrivateKey, X25519StaticPublicKey>()
+            .prop_map(|v| v.public_key).boxed()
     }
 }

--- a/crypto/crypto/src/x25519.rs
+++ b/crypto/crypto/src/x25519.rs
@@ -43,7 +43,7 @@
 //! use libra_crypto::Uniform;
 //! let seed = [1u8; 32];
 //! let mut rng: StdRng = SeedableRng::from_seed(seed);
-//! let private_key = X25519StaticPrivateKey::generate_for_testing(&mut rng);
+//! let private_key = X25519StaticPrivateKey::generate(&mut rng);
 //! let public_key: X25519StaticPublicKey = (&private_key).into();
 //!
 //! // Generate an X25519 key pair from an RNG and a user-provided seed.
@@ -100,7 +100,7 @@ pub struct X25519SharedKey(x25519_dalek::SharedSecret);
 /////////////////////////
 
 impl Uniform for X25519EphemeralPrivateKey {
-    fn generate_for_testing<R>(rng: &mut R) -> Self
+    fn generate<R>(rng: &mut R) -> Self
     where
         R: ::rand::SeedableRng + ::rand::RngCore + ::rand::CryptoRng,
     {
@@ -181,7 +181,7 @@ impl X25519StaticPrivateKey {
 }
 
 impl Uniform for X25519StaticPrivateKey {
-    fn generate_for_testing<R>(rng: &mut R) -> Self
+    fn generate<R>(rng: &mut R) -> Self
     where
         R: ::rand::SeedableRng + ::rand::RngCore + ::rand::CryptoRng,
     {
@@ -352,10 +352,10 @@ pub mod compat {
         T: Into<Option<&'a mut StdRng>> + Sized,
     {
         if let Some(rng_mut_ref) = opt_rng.into() {
-            <(X25519StaticPrivateKey, X25519StaticPublicKey)>::generate_for_testing(rng_mut_ref)
+            <(X25519StaticPrivateKey, X25519StaticPublicKey)>::generate(rng_mut_ref)
         } else {
             let mut rng = StdRng::from_seed(crate::test_utils::TEST_SEED);
-            <(X25519StaticPrivateKey, X25519StaticPublicKey)>::generate_for_testing(&mut rng)
+            <(X25519StaticPrivateKey, X25519StaticPublicKey)>::generate(&mut rng)
         }
     }
 

--- a/execution/executor-benchmark/src/lib.rs
+++ b/execution/executor-benchmark/src/lib.rs
@@ -4,9 +4,9 @@
 use executor::Executor;
 use executor_utils::create_storage_service_and_executor;
 use libra_crypto::{
-    ed25519::{self, Ed25519PrivateKey, Ed25519PublicKey},
+    ed25519::{Ed25519PrivateKey, Ed25519PublicKey},
     hash::{CryptoHash, HashValue},
-    traits::{PrivateKey, SigningKey},
+    PrivateKey, SigningKey, Uniform,
 };
 use libra_logger::prelude::*;
 use libra_types::{
@@ -70,7 +70,8 @@ impl TransactionGenerator {
 
         let mut accounts = Vec::with_capacity(num_accounts);
         for _i in 0..num_accounts {
-            let (private_key, public_key) = ed25519::compat::generate_keypair(&mut rng);
+            let private_key = Ed25519PrivateKey::generate(&mut rng);
+            let public_key = private_key.public_key();
             let address = AccountAddress::from_public_key(&public_key);
             let account = AccountData {
                 private_key,

--- a/execution/executor/src/mock_vm/mod.rs
+++ b/execution/executor/src/mock_vm/mod.rs
@@ -4,7 +4,7 @@
 #[cfg(test)]
 mod mock_vm_test;
 
-use libra_crypto::ed25519::compat;
+use libra_crypto::{ed25519::Ed25519PrivateKey, PrivateKey, Uniform};
 use libra_state_view::StateView;
 use libra_types::{
     access_path::AccessPath,
@@ -313,10 +313,10 @@ fn encode_transaction(sender: AccountAddress, program: Script) -> Transaction {
         std::time::Duration::from_secs(0),
     );
 
-    let (privkey, pubkey) = compat::generate_keypair(None);
+    let privkey = Ed25519PrivateKey::generate_for_testing();
     Transaction::UserTransaction(
         raw_transaction
-            .sign(&privkey, pubkey)
+            .sign(&privkey, privkey.public_key())
             .expect("Failed to sign raw transaction.")
             .into_inner(),
     )
@@ -325,10 +325,10 @@ fn encode_transaction(sender: AccountAddress, program: Script) -> Transaction {
 pub fn encode_reconfiguration_transaction(sender: AccountAddress) -> Transaction {
     let raw_transaction = RawTransaction::new_write_set(sender, 0, WriteSet::default());
 
-    let (privkey, pubkey) = compat::generate_keypair(None);
+    let privkey = Ed25519PrivateKey::generate_for_testing();
     Transaction::UserTransaction(
         raw_transaction
-            .sign(&privkey, pubkey)
+            .sign(&privkey, privkey.public_key())
             .expect("Failed to sign raw transaction.")
             .into_inner(),
     )

--- a/execution/executor/tests/storage_integration_test.rs
+++ b/execution/executor/tests/storage_integration_test.rs
@@ -3,7 +3,11 @@
 
 use anyhow::{ensure, format_err, Result};
 use executor_utils::create_storage_service_and_executor;
-use libra_crypto::{ed25519::*, test_utils::TEST_SEED, HashValue, PrivateKey};
+use libra_crypto::{
+    ed25519::{Ed25519PrivateKey, Ed25519PublicKey},
+    test_utils::TEST_SEED,
+    HashValue, PrivateKey, Uniform,
+};
 use libra_types::{
     access_path::AccessPath,
     account_address::AccountAddress,
@@ -190,8 +194,7 @@ fn test_reconfiguration() {
     let txn2 = encode_block_prologue_script(gen_block_metadata(1, validator_account));
 
     // rotate the validator's connsensus pubkey to trigger a reconfiguration
-    let mut rng = ::rand::rngs::StdRng::from_seed(TEST_SEED);
-    let (_, new_pubkey) = compat::generate_keypair(&mut rng);
+    let new_pubkey = Ed25519PrivateKey::generate_for_testing().public_key();
     let txn3 = get_test_signed_transaction(
         validator_account,
         /* sequence_number = */ 0,
@@ -724,16 +727,22 @@ fn test_execution_with_storage() {
     // account3} already exists in genesis, the code below will fail.
     assert!(seed != TEST_SEED);
     let mut rng = ::rand::rngs::StdRng::from_seed(seed);
-    let (privkey1, pubkey1) = compat::generate_keypair(&mut rng);
+
+    let privkey1 = Ed25519PrivateKey::generate(&mut rng);
+    let pubkey1 = privkey1.public_key();
     let account1_auth_key = AuthenticationKey::ed25519(&pubkey1);
     let account1 = account1_auth_key.derived_address();
-    let (privkey2, pubkey2) = compat::generate_keypair(&mut rng);
+
+    let privkey2 = Ed25519PrivateKey::generate(&mut rng);
+    let pubkey2 = privkey2.public_key();
     let account2_auth_key = AuthenticationKey::ed25519(&pubkey2);
     let account2 = account2_auth_key.derived_address();
-    let (_privkey3, pubkey3) = compat::generate_keypair(&mut rng);
+
+    let pubkey3 = Ed25519PrivateKey::generate(&mut rng).public_key();
     let account3_auth_key = AuthenticationKey::ed25519(&pubkey3);
     let account3 = account3_auth_key.derived_address();
-    let (_privkey4, pubkey4) = compat::generate_keypair(&mut rng);
+
+    let pubkey4 = Ed25519PrivateKey::generate(&mut rng).public_key();
     let account4_auth_key = AuthenticationKey::ed25519(&pubkey4); // non-existent account
     let account4 = account4_auth_key.derived_address();
     let genesis_account = association_address();

--- a/json-rpc/src/tests/unit_tests.rs
+++ b/json-rpc/src/tests/unit_tests.rs
@@ -15,7 +15,7 @@ use anyhow::format_err;
 use futures::{channel::mpsc::channel, StreamExt};
 use hex;
 use libra_config::utils;
-use libra_crypto::{ed25519::*, HashValue};
+use libra_crypto::{ed25519::Ed25519PrivateKey, HashValue, PrivateKey, Uniform};
 use libra_temppath::TempPath;
 use libra_types::{
     account_address::AccountAddress,
@@ -205,8 +205,8 @@ fn test_transaction_submission() {
 
     // closure that checks transaction submission for given account
     let mut txn_submission = move |sender| {
-        let keypair = compat::generate_keypair(None);
-        let txn = get_test_signed_txn(sender, 0, &keypair.0, keypair.1, None);
+        let privkey = Ed25519PrivateKey::generate_for_testing();
+        let txn = get_test_signed_txn(sender, 0, &privkey, privkey.public_key(), None);
         let mut batch = JsonRpcBatch::default();
         batch.add_submit_request(txn).unwrap();
         runtime.block_on(client.execute(batch)).unwrap()

--- a/language/e2e-tests/src/account_universe/rotate_key.rs
+++ b/language/e2e-tests/src/account_universe/rotate_key.rs
@@ -6,7 +6,10 @@ use crate::{
     common_transactions::rotate_key_txn,
     gas_costs,
 };
-use libra_crypto::ed25519::{compat::keypair_strategy, *};
+use libra_crypto::{
+    ed25519::{self, Ed25519PrivateKey, Ed25519PublicKey},
+    test_utils::KeyPair,
+};
 use libra_proptest_helpers::Index;
 use libra_types::{
     account_address::AccountAddress,
@@ -21,8 +24,8 @@ use proptest_derive::Arbitrary;
 #[proptest(no_params)]
 pub struct RotateKeyGen {
     sender: Index,
-    #[proptest(strategy = "keypair_strategy()")]
-    new_key: (Ed25519PrivateKey, Ed25519PublicKey),
+    #[proptest(strategy = "ed25519::keypair_strategy()")]
+    new_keypair: KeyPair<Ed25519PrivateKey, Ed25519PublicKey>,
 }
 
 impl AUTransactionGen for RotateKeyGen {
@@ -32,8 +35,8 @@ impl AUTransactionGen for RotateKeyGen {
     ) -> (SignedTransaction, (TransactionStatus, u64)) {
         let sender = universe.pick(self.sender).1;
 
-        let new_key_hash = AccountAddress::authentication_key(&self.new_key.1).to_vec();
-        let txn = rotate_key_txn(sender.account(), new_key_hash, sender.sequence_number);
+        let key_hash = AccountAddress::authentication_key(&self.new_keypair.public_key).to_vec();
+        let txn = rotate_key_txn(sender.account(), key_hash, sender.sequence_number);
 
         // This should work all the time except for if the balance is too low for gas.
         let mut gas_cost = 0;
@@ -42,8 +45,10 @@ impl AUTransactionGen for RotateKeyGen {
             sender.sequence_number += 1;
             gas_cost = sender.rotate_key_gas_cost();
             sender.balance -= gas_cost;
-            let (privkey, pubkey) = (self.new_key.0.clone(), self.new_key.1.clone());
-            sender.rotate_key(privkey, pubkey);
+            sender.rotate_key(
+                self.new_keypair.private_key.clone(),
+                self.new_keypair.public_key.clone(),
+            );
 
             TransactionStatus::Keep(VMStatus::new(StatusCode::EXECUTED))
         } else {

--- a/language/e2e-tests/src/gas_costs.rs
+++ b/language/e2e-tests/src/gas_costs.rs
@@ -8,7 +8,7 @@ use crate::{
     common_transactions::{create_account_txn, peer_to_peer_txn, rotate_key_txn},
     executor::FakeExecutor,
 };
-use libra_crypto::ed25519::compat;
+use libra_crypto::{ed25519::Ed25519PrivateKey, PrivateKey, Uniform};
 use libra_types::{account_address::AccountAddress, transaction::SignedTransaction};
 use once_cell::sync::Lazy;
 
@@ -244,7 +244,7 @@ pub static ROTATE_KEY: Lazy<u64> = Lazy::new(|| {
     let mut executor = FakeExecutor::from_genesis_file();
     let sender = AccountData::new(1_000_000, 10);
     executor.add_account_data(&sender);
-    let (_privkey, pubkey) = compat::generate_keypair(None);
+    let pubkey = Ed25519PrivateKey::generate_for_testing().public_key();
     let new_key_hash = AccountAddress::authentication_key(&pubkey).to_vec();
 
     let txn = rotate_key_txn(sender.account(), new_key_hash, 10);

--- a/language/e2e-tests/src/keygen.rs
+++ b/language/e2e-tests/src/keygen.rs
@@ -1,7 +1,10 @@
 // Copyright (c) The Libra Core Contributors
 // SPDX-License-Identifier: Apache-2.0
 
-use libra_crypto::ed25519::{compat::generate_keypair, Ed25519PrivateKey, Ed25519PublicKey};
+use libra_crypto::{
+    ed25519::{Ed25519PrivateKey, Ed25519PublicKey},
+    PrivateKey, Uniform,
+};
 use rand::{
     rngs::{OsRng, StdRng},
     Rng, SeedableRng,
@@ -26,6 +29,8 @@ impl KeyGen {
 
     /// Generate an Ed25519 key pair.
     pub fn generate_keypair(&mut self) -> (Ed25519PrivateKey, Ed25519PublicKey) {
-        generate_keypair(&mut self.0)
+        let private_key = Ed25519PrivateKey::generate(&mut self.0);
+        let public_key = private_key.public_key();
+        (private_key, public_key)
     }
 }

--- a/language/e2e-tests/src/tests/genesis.rs
+++ b/language/e2e-tests/src/tests/genesis.rs
@@ -3,9 +3,9 @@
 
 use crate::{
     assert_prologue_parity, assert_status_eq, data_store::GENESIS_WRITE_SET,
-    executor::FakeExecutor, keygen::KeyGen, transaction_status_eq,
+    executor::FakeExecutor, transaction_status_eq,
 };
-use libra_crypto::ed25519::*;
+use libra_crypto::{ed25519::Ed25519PrivateKey, PrivateKey, Uniform};
 use libra_types::{
     access_path::AccessPath,
     account_config,
@@ -22,12 +22,12 @@ fn invalid_genesis_write_set() {
     let write_op = (AccessPath::default(), WriteOp::Deletion);
     let write_set = WriteSetMut::new(vec![write_op]).freeze().unwrap();
     let address = account_config::association_address();
-    let (private_key, public_key) = compat::generate_keypair(None);
+    let private_key = Ed25519PrivateKey::generate_for_testing();
     let txn = transaction_test_helpers::get_write_set_txn(
         address,
         0,
         &private_key,
-        public_key,
+        private_key.public_key(),
         Some(write_set),
     )
     .into_inner();
@@ -43,14 +43,13 @@ fn execute_genesis_write_set() {
     let executor = FakeExecutor::no_genesis();
     let write_set = GENESIS_WRITE_SET.clone();
     let address = account_config::association_address();
-    let mut keygen = KeyGen::from_seed([9u8; 32]);
 
-    let (private_key, public_key) = keygen.generate_keypair();
+    let private_key = Ed25519PrivateKey::generate_for_testing();
     let txn = transaction_test_helpers::get_write_set_txn(
         address,
         0,
         &private_key,
-        public_key,
+        private_key.public_key(),
         Some(write_set),
     )
     .into_inner();

--- a/language/e2e-tests/src/tests/rotate_key.rs
+++ b/language/e2e-tests/src/tests/rotate_key.rs
@@ -8,10 +8,10 @@ use crate::{
     keygen::KeyGen,
 };
 use libra_crypto::{
-    ed25519::compat,
+    ed25519::Ed25519PrivateKey,
     hash::CryptoHash,
     multi_ed25519::{MultiEd25519PublicKey, MultiEd25519Signature},
-    traits::SigningKey,
+    PrivateKey, SigningKey, Uniform,
 };
 use libra_types::{
     account_address::AccountAddress,
@@ -26,7 +26,8 @@ fn rotate_ed25519_key() {
     let mut sender = AccountData::new(1_000_000, 10);
     executor.add_account_data(&sender);
 
-    let (privkey, pubkey) = compat::generate_keypair(None);
+    let privkey = Ed25519PrivateKey::generate_for_testing();
+    let pubkey = privkey.public_key();
     let new_key_hash = AccountAddress::authentication_key(&pubkey).to_vec();
     let txn = rotate_key_txn(sender.account(), new_key_hash.clone(), 10);
 

--- a/language/e2e-tests/src/tests/verify_txn.rs
+++ b/language/e2e-tests/src/tests/verify_txn.rs
@@ -7,7 +7,7 @@ use crate::{
 };
 use bytecode_verifier::VerifiedModule;
 use compiler::Compiler;
-use libra_crypto::ed25519::*;
+use libra_crypto::{ed25519::Ed25519PrivateKey, PrivateKey, Uniform};
 use libra_types::{
     account_config::{lbr_type_tag, CORE_CODE_ADDRESS},
     on_chain_config::VMPublishingOption,
@@ -28,7 +28,7 @@ fn verify_signature() {
     let sender = AccountData::new(900_000, 10);
     executor.add_account_data(&sender);
     // Generate a new key pair to try and sign things with.
-    let (private_key, _public_key) = compat::generate_keypair(None);
+    let private_key = Ed25519PrivateKey::generate_for_testing();
     let program = encode_transfer_script(sender.address(), vec![], 100);
     let signed_txn = transaction_test_helpers::get_test_unchecked_txn(
         *sender.address(),
@@ -51,13 +51,13 @@ fn verify_reserved_sender() {
     let sender = AccountData::new(900_000, 10);
     executor.add_account_data(&sender);
     // Generate a new key pair to try and sign things with.
-    let (private_key, public_key) = compat::generate_keypair(None);
+    let private_key = Ed25519PrivateKey::generate_for_testing();
     let program = encode_transfer_script(sender.address(), vec![], 100);
     let signed_txn = transaction_test_helpers::get_test_signed_txn(
         CORE_CODE_ADDRESS,
         0,
         &private_key,
-        public_key,
+        private_key.public_key(),
         Some(program),
     );
 

--- a/language/tools/cost-synthesis/src/global_state/account.rs
+++ b/language/tools/cost-synthesis/src/global_state/account.rs
@@ -3,7 +3,10 @@
 
 use crate::global_state::inhabitor::RandomInhabitor;
 use bytecode_verifier::VerifiedModule;
-use libra_crypto::ed25519::{compat, Ed25519PrivateKey, Ed25519PublicKey};
+use libra_crypto::{
+    ed25519::{Ed25519PrivateKey, Ed25519PublicKey},
+    PrivateKey, Uniform,
+};
 use libra_types::{access_path::AccessPath, account_address::AccountAddress, account_config};
 use move_vm_types::{
     identifier::create_access_path,
@@ -36,7 +39,8 @@ impl Account {
         let mut seed_rng = OsRng::new().expect("can't access OsRng");
         let seed_buf: [u8; 32] = seed_rng.gen();
         let mut rng = StdRng::from_seed(seed_buf);
-        let (privkey, pubkey) = compat::generate_keypair(&mut rng);
+        let privkey = Ed25519PrivateKey::generate(&mut rng);
+        let pubkey = privkey.public_key();
         let addr = AccountAddress::from_public_key(&pubkey);
         Account {
             addr,

--- a/language/tools/vm-genesis/src/lib.rs
+++ b/language/tools/vm-genesis/src/lib.rs
@@ -10,9 +10,9 @@ use anyhow::Result;
 use bytecode_verifier::VerifiedModule;
 use libra_config::config::NodeConfig;
 use libra_crypto::{
-    ed25519::*,
-    traits::ValidKey,
+    ed25519::{Ed25519PrivateKey, Ed25519PublicKey},
     x25519::{X25519StaticPrivateKey, X25519StaticPublicKey},
+    PrivateKey, Uniform, ValidKey,
 };
 use libra_state_view::StateView;
 use libra_types::{
@@ -56,7 +56,9 @@ pub const ASSOCIATION_INIT_BALANCE: u64 = 1_000_000_000_000_000;
 
 pub static GENESIS_KEYPAIR: Lazy<(Ed25519PrivateKey, Ed25519PublicKey)> = Lazy::new(|| {
     let mut rng = StdRng::from_seed(GENESIS_SEED);
-    compat::generate_keypair(&mut rng)
+    let private_key = Ed25519PrivateKey::generate(&mut rng);
+    let public_key = private_key.public_key();
+    (private_key, public_key)
 });
 // TODO(philiphayes): remove this when we add discovery set to genesis config.
 static PLACEHOLDER_PUBKEY: Lazy<X25519StaticPublicKey> = Lazy::new(|| {

--- a/language/vm/src/transaction_metadata.rs
+++ b/language/vm/src/transaction_metadata.rs
@@ -2,12 +2,12 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::gas_schedule::{AbstractMemorySize, GasAlgebra, GasCarrier, GasPrice, GasUnits};
-use libra_crypto::ed25519::compat;
+use libra_crypto::{ed25519::Ed25519PrivateKey, PrivateKey};
 use libra_types::{
     account_address::AccountAddress,
     transaction::{authenticator::AuthenticationKeyPreimage, SignedTransaction},
 };
-use std::time::Duration;
+use std::{convert::TryFrom, time::Duration};
 
 pub struct TransactionMetadata {
     pub sender: AccountAddress,
@@ -66,7 +66,9 @@ impl TransactionMetadata {
 
 impl Default for TransactionMetadata {
     fn default() -> Self {
-        let (_, public_key) = compat::generate_genesis_keypair();
+        let mut buf = [0u8; Ed25519PrivateKey::LENGTH];
+        buf[Ed25519PrivateKey::LENGTH - 1] = 1;
+        let public_key = Ed25519PrivateKey::try_from(&buf[..]).unwrap().public_key();
         TransactionMetadata {
             sender: AccountAddress::default(),
             authentication_key_preimage: AuthenticationKeyPreimage::ed25519(&public_key).into_vec(),

--- a/mempool/src/core_mempool/unit_tests/common.rs
+++ b/mempool/src/core_mempool/unit_tests/common.rs
@@ -4,7 +4,7 @@
 use crate::core_mempool::{CoreMempool, TimelineState, TxnPointer};
 use anyhow::{format_err, Result};
 use libra_config::config::NodeConfig;
-use libra_crypto::ed25519::*;
+use libra_crypto::{ed25519::Ed25519PrivateKey, PrivateKey, Uniform};
 use libra_types::{
     account_address::AccountAddress,
     account_config::lbr_type_tag,
@@ -79,9 +79,9 @@ impl TestTransaction {
         let mut seed: [u8; 32] = [0u8; 32];
         seed[..4].copy_from_slice(&[1, 2, 3, 4]);
         let mut rng: StdRng = StdRng::from_seed(seed);
-        let (privkey, pubkey) = compat::generate_keypair(&mut rng);
+        let privkey = Ed25519PrivateKey::generate(&mut rng);
         raw_txn
-            .sign(&privkey, pubkey)
+            .sign(&privkey, privkey.public_key())
             .expect("Failed to sign raw transaction.")
             .into_inner()
     }

--- a/network/src/connectivity_manager/test.rs
+++ b/network/src/connectivity_manager/test.rs
@@ -9,7 +9,9 @@ use crate::{
 use channel::{libra_channel, message_queues::QueueStyle};
 use core::str::FromStr;
 use futures::SinkExt;
-use libra_crypto::{ed25519::compat, test_utils::TEST_SEED, x25519};
+use libra_crypto::{
+    ed25519::compat, test_utils::TEST_SEED, x25519::X25519StaticPrivateKey, PrivateKey, Uniform,
+};
 use libra_logger::info;
 use rand::{rngs::StdRng, SeedableRng};
 use std::{io, num::NonZeroUsize};
@@ -38,7 +40,7 @@ fn setup_conn_mgr(
         .into_iter()
         .map(|peer_id| {
             let (_, signing_public_key) = compat::generate_keypair(&mut rng);
-            let (_, identity_public_key) = x25519::compat::generate_keypair(&mut rng);
+            let identity_public_key = X25519StaticPrivateKey::generate(&mut rng).public_key();
             let pubkeys = NetworkPublicKeys {
                 identity_public_key,
                 signing_public_key,
@@ -73,7 +75,7 @@ fn gen_peer() -> (PeerId, NetworkPublicKeys) {
     let peer_id = PeerId::random();
     let mut rng = StdRng::from_seed(TEST_SEED);
     let (_, signing_public_key) = compat::generate_keypair(&mut rng);
-    let (_, identity_public_key) = x25519::compat::generate_keypair(&mut rng);
+    let identity_public_key = X25519StaticPrivateKey::generate(&mut rng).public_key();
     (
         peer_id,
         NetworkPublicKeys {

--- a/network/src/connectivity_manager/test.rs
+++ b/network/src/connectivity_manager/test.rs
@@ -10,7 +10,8 @@ use channel::{libra_channel, message_queues::QueueStyle};
 use core::str::FromStr;
 use futures::SinkExt;
 use libra_crypto::{
-    ed25519::compat, test_utils::TEST_SEED, x25519::X25519StaticPrivateKey, PrivateKey, Uniform,
+    ed25519::Ed25519PrivateKey, test_utils::TEST_SEED, x25519::X25519StaticPrivateKey, PrivateKey,
+    Uniform,
 };
 use libra_logger::info;
 use rand::{rngs::StdRng, SeedableRng};
@@ -39,7 +40,7 @@ fn setup_conn_mgr(
     let eligible_peers = eligible_peers
         .into_iter()
         .map(|peer_id| {
-            let (_, signing_public_key) = compat::generate_keypair(&mut rng);
+            let signing_public_key = Ed25519PrivateKey::generate(&mut rng).public_key();
             let identity_public_key = X25519StaticPrivateKey::generate(&mut rng).public_key();
             let pubkeys = NetworkPublicKeys {
                 identity_public_key,
@@ -74,7 +75,7 @@ fn setup_conn_mgr(
 fn gen_peer() -> (PeerId, NetworkPublicKeys) {
     let peer_id = PeerId::random();
     let mut rng = StdRng::from_seed(TEST_SEED);
-    let (_, signing_public_key) = compat::generate_keypair(&mut rng);
+    let signing_public_key = Ed25519PrivateKey::generate(&mut rng).public_key();
     let identity_public_key = X25519StaticPrivateKey::generate(&mut rng).public_key();
     (
         peer_id,

--- a/network/src/protocols/discovery/test.rs
+++ b/network/src/protocols/discovery/test.rs
@@ -108,7 +108,7 @@ async fn expect_address_update(
 
 fn generate_network_pub_keys_and_signer() -> (NetworkPublicKeys, Ed25519PrivateKey) {
     let mut rng = StdRng::from_seed(TEST_SEED);
-    let signing_priv_key = Ed25519PrivateKey::generate_for_testing(&mut rng);
+    let signing_priv_key = Ed25519PrivateKey::generate(&mut rng);
     let (_, identity_pub_key) = x25519::compat::generate_keypair(&mut rng);
     (
         NetworkPublicKeys {

--- a/network/src/protocols/discovery/test.rs
+++ b/network/src/protocols/discovery/test.rs
@@ -16,10 +16,8 @@ use core::str::FromStr;
 use futures::channel::oneshot;
 use libra_config::config::RoleType;
 use libra_crypto::{
-    ed25519::Ed25519PrivateKey, test_utils::TEST_SEED, x25519::X25519StaticPrivateKey, PrivateKey,
-    Uniform,
+    ed25519::Ed25519PrivateKey, x25519::X25519StaticPrivateKey, PrivateKey, Uniform,
 };
-use rand::{rngs::StdRng, SeedableRng};
 use std::num::NonZeroUsize;
 use tokio::runtime::Runtime;
 
@@ -110,9 +108,8 @@ async fn expect_address_update(
 }
 
 fn generate_network_pub_keys_and_signer() -> (NetworkPublicKeys, Ed25519PrivateKey) {
-    let mut rng = StdRng::from_seed(TEST_SEED);
-    let signing_priv_key = Ed25519PrivateKey::generate(&mut rng);
-    let identity_pub_key = X25519StaticPrivateKey::generate(&mut rng).public_key();
+    let signing_priv_key = Ed25519PrivateKey::generate_for_testing();
+    let identity_pub_key = X25519StaticPrivateKey::generate_for_testing().public_key();
     (
         NetworkPublicKeys {
             signing_public_key: signing_priv_key.public_key(),

--- a/network/src/protocols/discovery/test.rs
+++ b/network/src/protocols/discovery/test.rs
@@ -15,7 +15,10 @@ use channel::{libra_channel, message_queues::QueueStyle};
 use core::str::FromStr;
 use futures::channel::oneshot;
 use libra_config::config::RoleType;
-use libra_crypto::{test_utils::TEST_SEED, *};
+use libra_crypto::{
+    ed25519::Ed25519PrivateKey, test_utils::TEST_SEED, x25519::X25519StaticPrivateKey, PrivateKey,
+    Uniform,
+};
 use rand::{rngs::StdRng, SeedableRng};
 use std::num::NonZeroUsize;
 use tokio::runtime::Runtime;
@@ -109,7 +112,7 @@ async fn expect_address_update(
 fn generate_network_pub_keys_and_signer() -> (NetworkPublicKeys, Ed25519PrivateKey) {
     let mut rng = StdRng::from_seed(TEST_SEED);
     let signing_priv_key = Ed25519PrivateKey::generate(&mut rng);
-    let (_, identity_pub_key) = x25519::compat::generate_keypair(&mut rng);
+    let identity_pub_key = X25519StaticPrivateKey::generate(&mut rng).public_key();
     (
         NetworkPublicKeys {
             signing_public_key: signing_priv_key.public_key(),

--- a/network/src/protocols/network/dummy.rs
+++ b/network/src/protocols/network/dummy.rs
@@ -16,7 +16,9 @@ use crate::{
 use channel::message_queues::QueueStyle;
 use futures::{executor::block_on, StreamExt};
 use libra_config::config::RoleType;
-use libra_crypto::{ed25519::compat, test_utils::TEST_SEED, x25519};
+use libra_crypto::{
+    ed25519::compat, test_utils::TEST_SEED, x25519::X25519StaticPrivateKey, PrivateKey, Uniform,
+};
 use libra_types::PeerId;
 use parity_multiaddr::Multiaddr;
 use rand::{rngs::StdRng, SeedableRng};
@@ -104,14 +106,14 @@ pub fn setup_network() -> DummyNetwork {
     let mut rng = StdRng::from_seed(TEST_SEED);
     let (dialer_signing_private_key, dialer_signing_public_key) =
         compat::generate_keypair(&mut rng);
-    let (dialer_identity_private_key, dialer_identity_public_key) =
-        x25519::compat::generate_keypair(&mut rng);
+    let dialer_identity_private_key = X25519StaticPrivateKey::generate(&mut rng);
+    let dialer_identity_public_key = dialer_identity_private_key.public_key();
 
     // Setup keys for listener.
     let (listener_signing_private_key, listener_signing_public_key) =
         compat::generate_keypair(&mut rng);
-    let (listener_identity_private_key, listener_identity_public_key) =
-        x25519::compat::generate_keypair(&mut rng);
+    let listener_identity_private_key = X25519StaticPrivateKey::generate(&mut rng);
+    let listener_identity_public_key = listener_identity_private_key.public_key();
 
     // Setup trusted peers.
     let trusted_peers: HashMap<_, _> = vec![

--- a/network/src/protocols/network/dummy.rs
+++ b/network/src/protocols/network/dummy.rs
@@ -17,7 +17,8 @@ use channel::message_queues::QueueStyle;
 use futures::{executor::block_on, StreamExt};
 use libra_config::config::RoleType;
 use libra_crypto::{
-    ed25519::compat, test_utils::TEST_SEED, x25519::X25519StaticPrivateKey, PrivateKey, Uniform,
+    ed25519::Ed25519PrivateKey, test_utils::TEST_SEED, x25519::X25519StaticPrivateKey, PrivateKey,
+    Uniform,
 };
 use libra_types::PeerId;
 use parity_multiaddr::Multiaddr;
@@ -104,14 +105,14 @@ pub fn setup_network() -> DummyNetwork {
 
     // Setup keys for dialer.
     let mut rng = StdRng::from_seed(TEST_SEED);
-    let (dialer_signing_private_key, dialer_signing_public_key) =
-        compat::generate_keypair(&mut rng);
+    let dialer_signing_private_key = Ed25519PrivateKey::generate(&mut rng);
+    let dialer_signing_public_key = dialer_signing_private_key.public_key();
     let dialer_identity_private_key = X25519StaticPrivateKey::generate(&mut rng);
     let dialer_identity_public_key = dialer_identity_private_key.public_key();
 
     // Setup keys for listener.
-    let (listener_signing_private_key, listener_signing_public_key) =
-        compat::generate_keypair(&mut rng);
+    let listener_signing_private_key = Ed25519PrivateKey::generate(&mut rng);
+    let listener_signing_public_key = listener_signing_private_key.public_key();
     let listener_identity_private_key = X25519StaticPrivateKey::generate(&mut rng);
     let listener_identity_public_key = listener_identity_private_key.public_key();
 

--- a/secure/key-manager/src/tests.rs
+++ b/secure/key-manager/src/tests.rs
@@ -284,7 +284,7 @@ fn test_consensus_rotation() {
     assert_eq!(&node.account, genesis_info.account_address());
 
     let mut rng = StdRng::from_seed([44u8; 32]);
-    let new_prikey = Ed25519PrivateKey::generate_for_testing(&mut rng);
+    let new_prikey = Ed25519PrivateKey::generate(&mut rng);
     let new_pubkey = new_prikey.public_key();
 
     let txn = crate::build_transaction(

--- a/secure/storage/src/crypto_kv_storage.rs
+++ b/secure/storage/src/crypto_kv_storage.rs
@@ -105,7 +105,7 @@ impl<T: CryptoKVStorage> CryptoStorage for T {
 fn new_ed25519_key_pair() -> Result<(Ed25519PrivateKey, Ed25519PublicKey), Error> {
     let mut seed_rng = OsRng::new().map_err(|e| Error::EntropyError(e.to_string()))?;
     let mut rng = rand::rngs::StdRng::from_seed(seed_rng.gen());
-    let private_key = Ed25519PrivateKey::generate_for_testing(&mut rng);
+    let private_key = Ed25519PrivateKey::generate(&mut rng);
     let public_key = private_key.public_key();
     Ok((private_key, public_key))
 }

--- a/secure/storage/src/tests/suite.rs
+++ b/secure/storage/src/tests/suite.rs
@@ -3,7 +3,6 @@
 
 use crate::{Error, Policy, Storage, Value};
 use libra_crypto::{ed25519::Ed25519PrivateKey, HashValue, PrivateKey, Signature, Uniform};
-use rand::{rngs::StdRng, SeedableRng};
 
 /// This suite contains tests for secure storage backends. We test the correct functionality
 /// of both key/value and cryptographic operations for storage implementations. All storage backend
@@ -50,7 +49,7 @@ pub fn execute_all_storage_tests(storage: &mut dyn Storage) {
 /// This test tries to get and set non-existent keys in storage and asserts that the correct
 /// errors are returned on these operations.
 fn test_get_set_non_existent(storage: &mut dyn Storage) {
-    let crypto_value = Value::Ed25519PrivateKey(create_ed25519_key_for_testing());
+    let crypto_value = Value::Ed25519PrivateKey(Ed25519PrivateKey::generate_for_testing());
     let u64_value = Value::U64(10);
 
     assert_eq!(
@@ -74,8 +73,8 @@ fn test_get_set_non_existent(storage: &mut dyn Storage) {
 /// This test stores various key/value pairs in storage, updates them, retrieves the values and
 /// unwraps them to ensure the correct value types are returned.
 fn test_create_get_set_unwrap(storage: &mut dyn Storage) {
-    let crypto_private_1 = create_ed25519_key_for_testing();
-    let crypto_private_2 = create_ed25519_key_for_testing();
+    let crypto_private_1 = Ed25519PrivateKey::generate_for_testing();
+    let crypto_private_2 = Ed25519PrivateKey::generate_for_testing();
     let u64_1 = 10;
     let u64_2 = 647;
     let policy = Policy::public();
@@ -126,7 +125,7 @@ fn test_create_get_set_unwrap(storage: &mut dyn Storage) {
 /// This test stores different types of values into storage, retrieves them, and asserts
 /// that the value unwrap functions return an unexpected type error on an incorrect unwrap.
 fn test_verify_incorrect_value_types_unwrap(storage: &mut dyn Storage) {
-    let crypto_value = Value::Ed25519PrivateKey(create_ed25519_key_for_testing());
+    let crypto_value = Value::Ed25519PrivateKey(Ed25519PrivateKey::generate_for_testing());
     let u64_value = Value::U64(10);
     let policy = Policy::public();
 
@@ -239,7 +238,7 @@ fn test_create_and_get_non_existent_version(storage: &mut dyn Storage) {
         .expect("Failed to create a test Ed25519 key pair!");
 
     // Get a non-existent version of the new key pair and verify failure
-    let non_existent_public_key = create_ed25519_key_for_testing().public_key();
+    let non_existent_public_key = Ed25519PrivateKey::generate_for_testing().public_key();
     assert!(
         storage.get_private_key_for_version(CRYPTO_NAME, non_existent_public_key).is_err(),
         "We have tried to retrieve a non-existent private key version -- the call should have failed!",
@@ -339,7 +338,7 @@ fn test_create_key_pair_and_perform_get_set_get(storage: &mut dyn Storage) {
     );
 
     // Set a new private key directly, and verify the same key is returned for the following get
-    let new_private_key = create_ed25519_key_for_testing();
+    let new_private_key = Ed25519PrivateKey::generate_for_testing();
     storage
         .set(
             CRYPTO_NAME,
@@ -379,11 +378,6 @@ fn test_create_sign_rotate_sign(storage: &mut dyn Storage) {
 
     // Verify signatures match and are valid
     assert_eq!(message_signature, message_signature_previous);
-}
-
-fn create_ed25519_key_for_testing() -> Ed25519PrivateKey {
-    let mut rng = StdRng::from_seed([13u8; 32]);
-    Ed25519PrivateKey::generate(&mut rng)
 }
 
 /// This test verifies that timestamps increase with successive writes

--- a/secure/storage/src/tests/suite.rs
+++ b/secure/storage/src/tests/suite.rs
@@ -383,7 +383,7 @@ fn test_create_sign_rotate_sign(storage: &mut dyn Storage) {
 
 fn create_ed25519_key_for_testing() -> Ed25519PrivateKey {
     let mut rng = StdRng::from_seed([13u8; 32]);
-    Ed25519PrivateKey::generate_for_testing(&mut rng)
+    Ed25519PrivateKey::generate(&mut rng)
 }
 
 /// This test verifies that timestamps increase with successive writes

--- a/secure/storage/src/value.rs
+++ b/secure/storage/src/value.rs
@@ -59,7 +59,7 @@ mod tests {
     #[test]
     fn ed25519_private_key() {
         let mut rng = StdRng::from_seed([13u8; 32]);
-        let value = Ed25519PrivateKey::generate_for_testing(&mut rng);
+        let value = Ed25519PrivateKey::generate(&mut rng);
         let value = Value::Ed25519PrivateKey(value);
         let base64 = value.to_base64().unwrap();
         let out_value = Value::from_base64(&base64).unwrap();

--- a/secure/storage/src/value.rs
+++ b/secure/storage/src/value.rs
@@ -54,12 +54,10 @@ impl Value {
 mod tests {
     use super::*;
     use libra_crypto::Uniform;
-    use rand::{rngs::StdRng, SeedableRng};
 
     #[test]
     fn ed25519_private_key() {
-        let mut rng = StdRng::from_seed([13u8; 32]);
-        let value = Ed25519PrivateKey::generate(&mut rng);
+        let value = Ed25519PrivateKey::generate_for_testing();
         let value = Value::Ed25519PrivateKey(value);
         let base64 = value.to_base64().unwrap();
         let out_value = Value::from_base64(&base64).unwrap();

--- a/state-synchronizer/src/tests/integration_tests.rs
+++ b/state-synchronizer/src/tests/integration_tests.rs
@@ -10,11 +10,8 @@ use executor_types::ExecutedTrees;
 use futures::executor::block_on;
 use libra_config::config::RoleType;
 use libra_crypto::{
-    ed25519::*,
-    hash::ACCUMULATOR_PLACEHOLDER_HASH,
-    test_utils::TEST_SEED,
-    x25519,
-    x25519::{X25519StaticPrivateKey, X25519StaticPublicKey},
+    ed25519::*, hash::ACCUMULATOR_PLACEHOLDER_HASH, test_utils::TEST_SEED,
+    x25519::X25519StaticPrivateKey, PrivateKey, Uniform,
 };
 use libra_mempool::mocks::MockSharedMempool;
 use libra_types::{
@@ -140,9 +137,9 @@ impl SynchronizerEnv {
             .map(|_| compat::generate_keypair(&mut rng))
             .collect::<Vec<(Ed25519PrivateKey, Ed25519PublicKey)>>();
         // Setup identity public keys.
-        let identity_keys = (0..count)
-            .map(|_| x25519::compat::generate_keypair(&mut rng))
-            .collect::<Vec<(X25519StaticPrivateKey, X25519StaticPublicKey)>>();
+        let identity_keys: Vec<_> = (0..count)
+            .map(|_| X25519StaticPrivateKey::generate(&mut rng))
+            .collect();
 
         let mut validators_keys = vec![];
         // The voting power of peer 0 is enough to generate an LI that passes validation.
@@ -153,7 +150,7 @@ impl SynchronizerEnv {
                 signer.public_key(),
                 voting_power,
                 signing_keys[idx].1.clone(),
-                identity_keys[idx].1.clone(),
+                identity_keys[idx].public_key(),
             );
             validators_keys.push(validator_info);
         }

--- a/storage/storage-service/src/mocks/mock_storage_client.rs
+++ b/storage/storage-service/src/mocks/mock_storage_client.rs
@@ -5,7 +5,7 @@
 
 use anyhow::{Error, Result};
 use futures::stream::BoxStream;
-use libra_crypto::{ed25519::*, HashValue};
+use libra_crypto::{ed25519::Ed25519PrivateKey, HashValue, PrivateKey, Uniform};
 use libra_types::{
     account_address::AccountAddress,
     account_state::AccountState,
@@ -251,14 +251,14 @@ fn get_mock_txn_data(
     let mut seed_rng = OsRng::new().expect("can't access OsRng");
     let seed_buf: [u8; 32] = seed_rng.gen();
     let mut rng = StdRng::from_seed(seed_buf);
-    let (priv_key, pub_key) = compat::generate_keypair(&mut rng);
+    let priv_key = Ed25519PrivateKey::generate(&mut rng);
     let mut txns = vec![];
     for i in start_seq..=end_seq {
         let txn = Transaction::UserTransaction(get_test_signed_txn(
             address,
             i,
             &priv_key,
-            pub_key.clone(),
+            priv_key.public_key(),
             None,
         ));
         txns.push(txn.into());

--- a/testsuite/cluster-test/src/tx_emitter.rs
+++ b/testsuite/cluster-test/src/tx_emitter.rs
@@ -521,7 +521,7 @@ fn gen_transfer_txn_request(
 }
 
 fn gen_random_account(rng: &mut StdRng) -> AccountData {
-    let key_pair = KeyPair::generate_for_testing(rng);
+    let key_pair = KeyPair::generate(rng);
     AccountData {
         address: AccountAddress::from_public_key(&key_pair.public_key),
         key_pair,

--- a/testsuite/tests/libratest/smoke_test.rs
+++ b/testsuite/tests/libratest/smoke_test.rs
@@ -4,7 +4,12 @@
 use cli::client_proxy::ClientProxy;
 use debug_interface::{libra_trace, node_debug_service::parse_events, NodeDebugClient};
 use libra_config::config::{NodeConfig, RoleType, TestConfig};
-use libra_crypto::{ed25519::*, hash::CryptoHash, test_utils::KeyPair, SigningKey};
+use libra_crypto::{
+    ed25519::{Ed25519PrivateKey, Ed25519PublicKey},
+    hash::CryptoHash,
+    test_utils::KeyPair,
+    PrivateKey, SigningKey, Uniform,
+};
 use libra_json_rpc::views::{ScriptView, TransactionDataView};
 use libra_logger::prelude::*;
 use libra_swarm::swarm::{LibraNode, LibraSwarm};
@@ -640,11 +645,8 @@ fn test_external_transaction_signer() {
     let (_swarm, mut client_proxy) = setup_swarm_and_client_proxy(1, 0);
 
     // generate key pair
-    let mut seed: [u8; 32] = [0u8; 32];
-    seed[..4].copy_from_slice(&[1, 2, 3, 4]);
-    let key_pair = compat::generate_keypair(None);
-    let private_key = key_pair.0;
-    let public_key = key_pair.1;
+    let private_key = Ed25519PrivateKey::generate_for_testing();
+    let public_key = private_key.public_key();
 
     // create transfer parameters
     let sender_auth_key = AuthenticationKey::ed25519(&public_key);

--- a/types/src/proof/unit_tests/proof_test.rs
+++ b/types/src/proof/unit_tests/proof_test.rs
@@ -17,12 +17,12 @@ use crate::{
     vm_error::StatusCode,
 };
 use libra_crypto::{
-    ed25519::*,
+    ed25519::Ed25519PrivateKey,
     hash::{
         CryptoHash, TestOnlyHash, ACCUMULATOR_PLACEHOLDER_HASH, GENESIS_BLOCK_ID,
         SPARSE_MERKLE_PLACEHOLDER_HASH,
     },
-    HashValue,
+    HashValue, PrivateKey, Uniform,
 };
 
 #[test]
@@ -336,7 +336,8 @@ fn test_verify_account_state_and_event() {
     let txn_info0_hash = b"hellohello".test_only_hash();
     let txn_info1_hash = b"worldworld".test_only_hash();
 
-    let (privkey, pubkey) = compat::generate_keypair(None);
+    let privkey = Ed25519PrivateKey::generate_for_testing();
+    let pubkey = privkey.public_key();
     let txn2_hash = Transaction::UserTransaction(
         RawTransaction::new_script(
             AccountAddress::from_public_key(&pubkey),

--- a/types/src/proptest_types.rs
+++ b/types/src/proptest_types.rs
@@ -26,8 +26,9 @@ use crate::{
     write_set::{WriteOp, WriteSet, WriteSetMut},
 };
 use libra_crypto::{
-    ed25519::{compat::keypair_strategy, *},
+    ed25519::{self, Ed25519PrivateKey, Ed25519PublicKey, Ed25519Signature},
     hash::CryptoHash,
+    test_utils::KeyPair,
     traits::*,
     x25519::X25519StaticPublicKey,
     HashValue,
@@ -193,11 +194,14 @@ impl AccountInfoUniverse {
 impl Arbitrary for AccountInfoUniverse {
     type Parameters = usize;
     fn arbitrary_with(num_accounts: Self::Parameters) -> Self::Strategy {
-        vec(keypair_strategy(), num_accounts)
-            .prop_map(|keypairs| {
+        vec(ed25519::keypair_strategy(), num_accounts)
+            .prop_map(|kps| {
+                let kps: Vec<_> = kps
+                    .into_iter()
+                    .map(|k| (k.private_key, k.public_key))
+                    .collect();
                 AccountInfoUniverse::new(
-                    keypairs, /* epoch = */ 0, /* round = */ 0,
-                    /* next_version = */ 0,
+                    kps, /* epoch = */ 0, /* round = */ 0, /* next_version = */ 0,
                 )
             })
             .boxed()
@@ -345,7 +349,7 @@ impl SignatureCheckedTransaction {
     // This isn't an Arbitrary impl because this doesn't generate *any* possible SignedTransaction,
     // just one kind of them.
     pub fn script_strategy(
-        keypair_strategy: impl Strategy<Value = (Ed25519PrivateKey, Ed25519PublicKey)>,
+        keypair_strategy: impl Strategy<Value = KeyPair<Ed25519PrivateKey, Ed25519PublicKey>>,
         gas_specifier_strategy: impl Strategy<Value = TypeTag>,
     ) -> impl Strategy<Value = Self> {
         Self::strategy_impl(
@@ -356,7 +360,7 @@ impl SignatureCheckedTransaction {
     }
 
     pub fn module_strategy(
-        keypair_strategy: impl Strategy<Value = (Ed25519PrivateKey, Ed25519PublicKey)>,
+        keypair_strategy: impl Strategy<Value = KeyPair<Ed25519PrivateKey, Ed25519PublicKey>>,
         gas_specifier_strategy: impl Strategy<Value = TypeTag>,
     ) -> impl Strategy<Value = Self> {
         Self::strategy_impl(
@@ -367,7 +371,7 @@ impl SignatureCheckedTransaction {
     }
 
     pub fn write_set_strategy(
-        keypair_strategy: impl Strategy<Value = (Ed25519PrivateKey, Ed25519PublicKey)>,
+        keypair_strategy: impl Strategy<Value = KeyPair<Ed25519PrivateKey, Ed25519PublicKey>>,
         gas_specifier_strategy: impl Strategy<Value = TypeTag>,
     ) -> impl Strategy<Value = Self> {
         Self::strategy_impl(
@@ -378,7 +382,7 @@ impl SignatureCheckedTransaction {
     }
 
     pub fn genesis_strategy(
-        keypair_strategy: impl Strategy<Value = (Ed25519PrivateKey, Ed25519PublicKey)>,
+        keypair_strategy: impl Strategy<Value = KeyPair<Ed25519PrivateKey, Ed25519PublicKey>>,
         gas_specifier_strategy: impl Strategy<Value = TypeTag>,
     ) -> impl Strategy<Value = Self> {
         Self::strategy_impl(
@@ -389,13 +393,13 @@ impl SignatureCheckedTransaction {
     }
 
     fn strategy_impl(
-        keypair_strategy: impl Strategy<Value = (Ed25519PrivateKey, Ed25519PublicKey)>,
+        keypair_strategy: impl Strategy<Value = KeyPair<Ed25519PrivateKey, Ed25519PublicKey>>,
         payload_strategy: impl Strategy<Value = TransactionPayload>,
         gas_specifier_strategy: impl Strategy<Value = TypeTag>,
     ) -> impl Strategy<Value = Self> {
         (keypair_strategy, payload_strategy, gas_specifier_strategy)
             .prop_flat_map(|(keypair, payload, gas_specifier)| {
-                let address = AccountAddress::from_public_key(&keypair.1);
+                let address = AccountAddress::from_public_key(&keypair.public_key);
                 (
                     Just(keypair),
                     RawTransaction::strategy_impl(
@@ -405,9 +409,9 @@ impl SignatureCheckedTransaction {
                     ),
                 )
             })
-            .prop_map(|((private_key, public_key), raw_txn)| {
+            .prop_map(|(keypair, raw_txn)| {
                 raw_txn
-                    .sign(&private_key, public_key)
+                    .sign(&keypair.private_key, keypair.public_key)
                     .expect("signing should always work")
             })
     }
@@ -436,7 +440,7 @@ impl Arbitrary for SignatureCheckedTransaction {
     type Parameters = ();
     fn arbitrary_with(_args: ()) -> Self::Strategy {
         Self::strategy_impl(
-            keypair_strategy(),
+            ed25519::keypair_strategy(),
             any::<TransactionPayload>(),
             any::<TypeTag>(),
         )
@@ -585,10 +589,10 @@ impl Arbitrary for TransactionArgument {
 prop_compose! {
     fn arb_validator_signature_for_hash(hash: HashValue)(
         hash in Just(hash),
-        (private_key, public_key) in keypair_strategy(),
+        keypair in ed25519::keypair_strategy(),
     ) -> (AccountAddress, Ed25519Signature) {
-        let signature = private_key.sign_message(&hash);
-        (AccountAddress::from_public_key(&public_key), signature)
+        let signature = keypair.private_key.sign_message(&hash);
+        (AccountAddress::from_public_key(&keypair.public_key), signature)
     }
 }
 

--- a/types/src/unit_tests/transaction_test.rs
+++ b/types/src/unit_tests/transaction_test.rs
@@ -10,14 +10,16 @@ use crate::{
     },
 };
 use lcs::test_helpers::assert_canonical_encode_decode;
-use libra_crypto::ed25519::*;
+use libra_crypto::{
+    ed25519::{self, Ed25519PrivateKey, Ed25519Signature},
+    PrivateKey, Uniform,
+};
 use libra_prost_ext::test_helpers::assert_protobuf_encode_decode;
 use proptest::prelude::*;
 use std::convert::TryFrom;
 
 #[test]
 fn test_invalid_signature() {
-    let keypair = compat::generate_keypair(None);
     let proto_txn: crate::proto::types::SignedTransaction = SignedTransaction::new(
         RawTransaction::new_script(
             AccountAddress::random(),
@@ -28,7 +30,7 @@ fn test_invalid_signature() {
             lbr_type_tag(),
             std::time::Duration::new(0, 0),
         ),
-        keypair.1,
+        Ed25519PrivateKey::generate_for_testing().public_key(),
         Ed25519Signature::try_from(&[1u8; 64][..]).unwrap(),
     )
     .into();
@@ -40,8 +42,8 @@ fn test_invalid_signature() {
 
 proptest! {
     #[test]
-    fn test_sign_raw_transaction(raw_txn in any::<RawTransaction>(), (sk1, pk1) in compat::keypair_strategy()) {
-        let txn = raw_txn.sign(&sk1, pk1).unwrap();
+    fn test_sign_raw_transaction(raw_txn in any::<RawTransaction>(), keypair in ed25519::keypair_strategy()) {
+        let txn = raw_txn.sign(&keypair.private_key, keypair.public_key).unwrap();
         let signed_txn = txn.into_inner();
         assert!(signed_txn.check_signature().is_ok());
     }

--- a/types/src/validator_info.rs
+++ b/types/src/validator_info.rs
@@ -5,9 +5,9 @@ use crate::account_address::AccountAddress;
 use anyhow::{Error, Result};
 #[cfg(any(test, feature = "fuzzing"))]
 use libra_crypto::ed25519::compat::generate_keypair as generate_ed25519_keypair;
+use libra_crypto::{ed25519::Ed25519PublicKey, x25519::X25519StaticPublicKey, ValidKey};
 #[cfg(any(test, feature = "fuzzing"))]
-use libra_crypto::x25519::compat::generate_keypair as generate_x25519_keypair;
-use libra_crypto::{ed25519::*, x25519::X25519StaticPublicKey, ValidKey};
+use libra_crypto::{x25519::X25519StaticPrivateKey, PrivateKey, Uniform};
 #[cfg(any(test, feature = "fuzzing"))]
 use proptest_derive::Arbitrary;
 use serde::{Deserialize, Serialize};
@@ -66,7 +66,8 @@ impl ValidatorInfo {
         consensus_voting_power: u64,
     ) -> Self {
         let (_, network_signing_public_key) = generate_ed25519_keypair(None);
-        let (_, network_identity_public_key) = generate_x25519_keypair(None);
+        let network_identity_public_key =
+            X25519StaticPrivateKey::generate_for_testing().public_key();
         ValidatorInfo {
             account_address,
             consensus_public_key,

--- a/types/src/validator_info.rs
+++ b/types/src/validator_info.rs
@@ -4,10 +4,10 @@
 use crate::account_address::AccountAddress;
 use anyhow::{Error, Result};
 #[cfg(any(test, feature = "fuzzing"))]
-use libra_crypto::ed25519::compat::generate_keypair as generate_ed25519_keypair;
+use libra_crypto::{
+    ed25519::Ed25519PrivateKey, x25519::X25519StaticPrivateKey, PrivateKey, Uniform,
+};
 use libra_crypto::{ed25519::Ed25519PublicKey, x25519::X25519StaticPublicKey, ValidKey};
-#[cfg(any(test, feature = "fuzzing"))]
-use libra_crypto::{x25519::X25519StaticPrivateKey, PrivateKey, Uniform};
 #[cfg(any(test, feature = "fuzzing"))]
 use proptest_derive::Arbitrary;
 use serde::{Deserialize, Serialize};
@@ -65,7 +65,7 @@ impl ValidatorInfo {
         consensus_public_key: Ed25519PublicKey,
         consensus_voting_power: u64,
     ) -> Self {
-        let (_, network_signing_public_key) = generate_ed25519_keypair(None);
+        let network_signing_public_key = Ed25519PrivateKey::generate_for_testing().public_key();
         let network_identity_public_key =
             X25519StaticPrivateKey::generate_for_testing().public_key();
         ValidatorInfo {

--- a/types/src/validator_signer.rs
+++ b/types/src/validator_signer.rs
@@ -85,9 +85,7 @@ pub mod proptests {
         prop_oneof![
             // The no_shrink here reflects that particular keypair choices out
             // of random options are irrelevant.
-            LazyJust::new(
-                || Ed25519PrivateKey::generate(&mut StdRng::from_seed(TEST_SEED))
-            ),
+            LazyJust::new(|| Ed25519PrivateKey::generate(&mut StdRng::from_seed(TEST_SEED))),
             LazyJust::new(|| Ed25519PrivateKey::genesis()),
         ]
     }

--- a/types/src/validator_signer.rs
+++ b/types/src/validator_signer.rs
@@ -68,8 +68,7 @@ impl ValidatorSigner {
     pub fn from_int(num: u8) -> Self {
         let mut address = [0; AccountAddress::LENGTH];
         address[0] = num;
-        let mut rng = StdRng::from_seed(TEST_SEED);
-        let private_key = Ed25519PrivateKey::generate(&mut rng);
+        let private_key = Ed25519PrivateKey::generate_for_testing();
         Self::new(AccountAddress::try_from(&address[..]).unwrap(), private_key)
     }
 }
@@ -85,7 +84,7 @@ pub mod proptests {
         prop_oneof![
             // The no_shrink here reflects that particular keypair choices out
             // of random options are irrelevant.
-            LazyJust::new(|| Ed25519PrivateKey::generate(&mut StdRng::from_seed(TEST_SEED))),
+            LazyJust::new(|| Ed25519PrivateKey::generate_for_testing()),
             LazyJust::new(|| Ed25519PrivateKey::genesis()),
         ]
     }

--- a/types/src/validator_signer.rs
+++ b/types/src/validator_signer.rs
@@ -59,7 +59,7 @@ impl ValidatorSigner {
         let mut rng = StdRng::from_seed(opt_rng_seed.into().unwrap_or(TEST_SEED));
         Self::new(
             AccountAddress::random(),
-            Ed25519PrivateKey::generate_for_testing(&mut rng),
+            Ed25519PrivateKey::generate(&mut rng),
         )
     }
 
@@ -69,7 +69,7 @@ impl ValidatorSigner {
         let mut address = [0; AccountAddress::LENGTH];
         address[0] = num;
         let mut rng = StdRng::from_seed(TEST_SEED);
-        let private_key = Ed25519PrivateKey::generate_for_testing(&mut rng);
+        let private_key = Ed25519PrivateKey::generate(&mut rng);
         Self::new(AccountAddress::try_from(&address[..]).unwrap(), private_key)
     }
 }
@@ -86,7 +86,7 @@ pub mod proptests {
             // The no_shrink here reflects that particular keypair choices out
             // of random options are irrelevant.
             LazyJust::new(
-                || Ed25519PrivateKey::generate_for_testing(&mut StdRng::from_seed(TEST_SEED))
+                || Ed25519PrivateKey::generate(&mut StdRng::from_seed(TEST_SEED))
             ),
             LazyJust::new(|| Ed25519PrivateKey::genesis()),
         ]

--- a/vm-validator/src/unit_tests/vm_validator_test.rs
+++ b/vm-validator/src/unit_tests/vm_validator_test.rs
@@ -4,7 +4,7 @@
 use crate::vm_validator::{TransactionValidation, VMValidator};
 use executor::Executor;
 use libra_config::config::NodeConfig;
-use libra_crypto::{ed25519::*, PrivateKey};
+use libra_crypto::{ed25519::Ed25519PrivateKey, PrivateKey, Uniform};
 use libra_types::{
     account_address, account_config,
     account_config::lbr_type_tag,
@@ -107,7 +107,7 @@ fn test_validate_invalid_signature() {
     let (vm_validator, mut rt) = TestValidator::new(&config);
 
     let mut rng = ::rand::rngs::StdRng::from_seed([1u8; 32]);
-    let (other_private_key, _) = compat::generate_keypair(&mut rng);
+    let other_private_key = Ed25519PrivateKey::generate(&mut rng);
     // Submit with an account using an different private/public keypair
 
     let address = account_config::association_address();
@@ -311,7 +311,7 @@ fn test_validate_invalid_auth_key() {
     let (vm_validator, mut rt) = TestValidator::new(&config);
 
     let mut rng = ::rand::rngs::StdRng::from_seed([1u8; 32]);
-    let (other_private_key, other_public_key) = compat::generate_keypair(&mut rng);
+    let other_private_key = Ed25519PrivateKey::generate(&mut rng);
     // Submit with an account using an different private/public keypair
 
     let address = account_config::association_address();
@@ -320,7 +320,7 @@ fn test_validate_invalid_auth_key() {
         address,
         1,
         &other_private_key,
-        other_public_key,
+        other_private_key.public_key(),
         Some(program),
     );
     let ret = rt


### PR DESCRIPTION
compat was the last part of the legacy API, this removes it from both ed25519 and x25519
I also tweaked Uniform to rename generate_for_testing to generate and introduced a generate_for_testing for convenience (it uses the TEST_SEED). I also added a very clear note on the lack of safety involving generate, but it may very well be used in a couple production cases, and we cannot leave it named as is...
moved proptest code out as it was a clean replacement for the compat interfaces