### PR TITLE
[Secure storage] Fix test for timestamps: ensure timestamps are increasing.

### DIFF
--- a/secure/storage/src/tests/suite.rs
+++ b/secure/storage/src/tests/suite.rs
@@ -28,7 +28,7 @@ const STORAGE_TESTS: &[fn(&mut dyn Storage)] = &[
     test_get_set_non_existent,
     test_get_uncreated_key_pair,
     test_hash_value,
-    test_timestamp,
+    test_incremental_timestamp,
     test_verify_incorrect_value_types_unwrap,
 ];
 
@@ -387,7 +387,7 @@ fn create_ed25519_key_for_testing() -> Ed25519PrivateKey {
 }
 
 /// This test verifies that timestamps increase with successive writes
-fn test_timestamp(storage: &mut dyn Storage) {
+fn test_incremental_timestamp(storage: &mut dyn Storage) {
     let key = "timestamp_u64";
     let value0 = 442;
     let value1 = 450;
@@ -399,6 +399,6 @@ fn test_timestamp(storage: &mut dyn Storage) {
     storage.set(key, Value::U64(value1)).unwrap();
     let second = storage.get(key).unwrap();
 
-    assert!(first.value != second.value);
-    assert!(first.last_update != second.last_update);
+    assert_ne!(first.value, second.value);
+    assert!(first.last_update < second.last_update);
 }


### PR DESCRIPTION
## Motivation

This small PR updates the timestamp test for secure storage: (i) it avoids using 'assert!(X != Y)', which should be replaced by 'assert_ne!(X, Y)'; and (ii) it ensures that timestamp1 is less than timestamp2 (instead of just checking that the timestamps are not equal).

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?

Yes.

## Test Plan

Running the test locally passes.

## Related PRs

None.
