### PR TITLE
[Secure storage] Updated VaultStorage resets to be namespace specific.

### DIFF
--- a/secure/storage/src/tests/vault.rs
+++ b/secure/storage/src/tests/vault.rs
@@ -6,45 +6,126 @@ use crate::{
     Value,
 };
 
+/// VaultStorage test constants
 const VAULT_HOST: &str = "http://localhost:8200";
 const VAULT_ROOT_TOKEN: &str = "root_token";
+const VAULT_NAMESPACE_1: &str = "namespace_1";
+const VAULT_NAMESPACE_2: &str = "namespace_2";
+const VAULT_NAMESPACE_3: &str = "namespace_3";
 
-/// A test for verifying VaultStorage properly implements the LibraSecureStorage API. This test
-/// depends on running Vault, which can be done by using the provided docker run script in
-/// `docker/vault/run.sh`
-// There can only be one vault test as reset called on one instance can break another test
+/// Storage data constants for testing purposes.
+const U64_KEY_1: &str = "U64 Key 1";
+const U64_KEY_2: &str = "U64 Key 2";
+const U64_VALUE_1: u64 = 10;
+const U64_VALUE_2: u64 = 304;
+
+/// This holds the canonical list of vault storage tests. This is required because vault tests
+/// cannot currently be run in parallel, as each test uses the same vault instance and
+/// storage resets can interfere between tests. To avoid this, we run each test sequentially, and
+/// reset the storage engine only after each test.
+const VAULT_TESTS: &[fn()] = &[
+    test_suite_multiple_namespaces,
+    test_suite_no_namespaces,
+    test_vault_namespace_reset,
+    test_vault_no_namespace_reset,
+    test_vault_tokens_and_basic_ops,
+];
+
+/// A test for verifying VaultStorage properly implements the LibraSecureStorage API and enforces
+/// strict separation between unique namespaces. This test depends on running Vault, which can be
+/// done by using the provided docker run script in `docker/vault/run.sh`
 #[test]
 #[ignore]
 fn execute_storage_tests_vault() {
-    let mut storage = VaultStorage::new(VAULT_HOST.into(), VAULT_ROOT_TOKEN.into(), None);
-    storage.reset_and_clear().unwrap();
+    let mut storage = create_vault_with_namespace(None);
+    storage
+        .reset_and_clear()
+        .expect("Failed to reset VaultStorage after creation!");
 
-    test_vault(&mut storage);
-    suite::execute_all_storage_tests(&mut storage);
-
-    let mut storage0 = VaultStorage::new(
-        VAULT_HOST.into(),
-        VAULT_ROOT_TOKEN.into(),
-        Some("test0".into()),
-    );
-    let mut storage1 = VaultStorage::new(
-        VAULT_HOST.into(),
-        VAULT_ROOT_TOKEN.into(),
-        Some("test1".into()),
-    );
-
-    test_vault(&mut storage0);
-    test_vault(&mut storage1);
-    suite::execute_all_storage_tests(&mut storage0);
-    suite::execute_all_storage_tests(&mut storage1);
-    storage.reset_and_clear().unwrap();
+    for test in VAULT_TESTS.iter() {
+        test();
+        storage
+            .reset_and_clear()
+            .expect("Failed to reset storage engine between tests!");
+    }
 }
 
-/// Creates and returns a new VaultStorage instance for testing purposes.
-pub fn test_vault(storage: &mut VaultStorage) {
+/// Verifies that when calling reset on a VaultStorage instance, if the instance was created with
+/// a namespace, only the secrets within the namespace are removed. This helps to ensure operations
+/// across namespaces do not interfere.
+fn test_vault_namespace_reset() {
+    let mut storage_1 = create_vault_with_namespace(Some(VAULT_NAMESPACE_1.into()));
+    let mut storage_2 = create_vault_with_namespace(Some(VAULT_NAMESPACE_2.into()));
+    storage_1
+        .create(U64_KEY_1, Value::U64(U64_VALUE_1), &Policy::public())
+        .unwrap();
+    storage_2
+        .create(U64_KEY_1, Value::U64(U64_VALUE_1), &Policy::public())
+        .unwrap();
+
+    // Verify resets do not occur across namespaces
+    storage_1
+        .reset_and_clear()
+        .expect("Failed to reset VaultStorage with namespace!");
+    assert!(storage_1.get(U64_KEY_1).is_err());
+    assert_eq!(
+        storage_2.get(U64_KEY_1).unwrap().value.u64().unwrap(),
+        U64_VALUE_1
+    );
+}
+
+/// Verifies that when calling reset on a VaultStorage instance, if the instance was created without
+/// a namespace, all data in the storage engine will be cleared
+fn test_vault_no_namespace_reset() {
+    let mut storage_1 = create_vault_with_namespace(Some(VAULT_NAMESPACE_1.into()));
+    let mut storage_2 = create_vault_with_namespace(Some(VAULT_NAMESPACE_2.into()));
+    storage_1
+        .create(U64_KEY_1, Value::U64(U64_VALUE_1), &Policy::public())
+        .unwrap();
+    storage_2
+        .create(U64_KEY_2, Value::U64(U64_VALUE_2), &Policy::public())
+        .unwrap();
+
+    // Create a VaultStorage without a namespace, reset the instance, and ensure all data is cleared
+    // regardless of namespaces.
+    create_vault_with_namespace(None)
+        .reset_and_clear()
+        .expect("Failed to reset VaultStorage without namespace!");
+    assert!(storage_1.get(U64_KEY_1).is_err());
+    assert!(storage_2.get(U64_KEY_2).is_err());
+}
+
+/// Runs the test suite on a VaultStorage instance that does not use distinct namespaces
+fn test_suite_no_namespaces() {
+    let mut storage = create_vault_with_namespace(None);
+    suite::execute_all_storage_tests(&mut storage);
+}
+
+/// Runs the test suite on a VaultStorage instance that supports multiple distinct namespaces.
+/// Tests should be able to run across namespaces without interfering.
+fn test_suite_multiple_namespaces() {
+    let mut storage_1 = create_vault_with_namespace(Some(VAULT_NAMESPACE_1.into()));
+    let mut storage_2 = create_vault_with_namespace(Some(VAULT_NAMESPACE_2.into()));
+    let mut storage_3 = create_vault_with_namespace(Some(VAULT_NAMESPACE_3.into()));
+
+    suite::execute_all_storage_tests(&mut storage_1);
+    suite::execute_all_storage_tests(&mut storage_2);
+    suite::execute_all_storage_tests(&mut storage_3);
+}
+
+/// Creates and initializes a VaultStorage instance for testing. If a namespace is specified, the
+/// instance will perform all storage operations under that namespace.
+fn create_vault_with_namespace(namespace: Option<String>) -> VaultStorage {
+    VaultStorage::new(VAULT_HOST.into(), VAULT_ROOT_TOKEN.into(), namespace)
+}
+
+/// Initializes test policies for a VaultStorage instance and checks the instance is
+/// accessible (e.g., by ensuring subsequent read and write operations complete successfully).
+fn test_vault_tokens_and_basic_ops() {
     // TODO(davidiw,joshlind): evaluate other systems and determine if create_token can be on the
     // Storage / KV interface. And then refactor this method to make it cleaner and easier to reason
     // about.
+    let mut storage = create_vault_with_namespace(None);
     let reader: String = "reader".into();
     let writer: String = "writer".into();
 

--- a/secure/storage/src/vault.rs
+++ b/secure/storage/src/vault.rs
@@ -31,9 +31,15 @@ impl VaultStorage {
         self.namespace.clone()
     }
 
-    /// Erase all secrets and keys from the vault storage. Use with caution.
+    /// Erase all secrets and keys from the vault storage. If a namespace was specified on vault
+    /// storage creation, only the secrets associated with that namespace are removed. Use with
+    /// caution.
     pub fn reset(&self) -> Result<(), Error> {
-        self.reset_helper("")
+        if let Some(namespace) = &self.namespace {
+            self.reset_helper(&format!("{}/", namespace))
+        } else {
+            self.reset_helper("")
+        }
     }
 
     fn reset_helper(&self, path: &str) -> Result<(), Error> {

--- a/secure/storage/vault/src/lib.rs
+++ b/secure/storage/vault/src/lib.rs
@@ -95,7 +95,7 @@ impl Client {
     }
 
     /// Creates a new token or identity for accessing Vault. The token will have access to anything
-    /// under the default policy and any perscribed policies.
+    /// under the default policy and any prescribed policies.
     pub fn create_token(&self, policies: Vec<&str>) -> Result<String, Error> {
         let response = ureq::post(&format!("{}/v1/auth/token/create", self.host))
             .set("X-Vault-Token", &self.token)


### PR DESCRIPTION
## Motivation

At present, calling 'reset_and_clear()' on a VaultStorage client will reset the entire storage engine (i.e., delete all data in the storage engine). This is true regardless of if the VaultStorage client was created with access to only a specific namespace in mind (e.g., all secrets under a specific folder). The result of this is that we cannot currently verify that operations within a namespace are actually unique (as between each test, the entire storage engine is wiped clean...). This means that our tests don't actually do what we'd like them to.

To overcome this, this PR ensures that 'reset_and_clear()' only deletes storage data under a specific namespace if the VaultStorage client was created with that namespace in mind. This allows us to add and modify appropriate tests to verify that operations within each namespace are unique.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?

Yes.

## Test Plan

All local tests pass (including when run with the vault storage docker container).

## Related PRs

No.
