### PR TITLE
Expose AccountAddress for AccountState through EventKey

### DIFF
--- a/types/src/account_state.rs
+++ b/types/src/account_state.rs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::{
+    account_address::AccountAddress,
     account_config::{
         AccountResource, BalanceResource, ACCOUNT_RECEIVED_EVENT_PATH, ACCOUNT_RESOURCE_PATH,
         ACCOUNT_SENT_EVENT_PATH, BALANCE_RESOURCE_PATH,
@@ -25,6 +26,12 @@ use std::{collections::btree_map::BTreeMap, convert::TryFrom, fmt};
 pub struct AccountState(BTreeMap<Vec<u8>, Vec<u8>>);
 
 impl AccountState {
+    // By design and do not remove
+    pub fn get_account_address(&self) -> Result<Option<AccountAddress>> {
+        self.get_account_resource()
+            .map(|opt_ar| opt_ar.map(|ar| ar.sent_events().key().get_creator_address()))
+    }
+
     pub fn get_account_resource(&self) -> Result<Option<AccountResource>> {
         self.get_resource(&*ACCOUNT_RESOURCE_PATH)
     }

--- a/types/src/event.rs
+++ b/types/src/event.rs
@@ -10,7 +10,8 @@ use rand::{rngs::OsRng, RngCore};
 use serde::{de, ser, Deserialize, Serialize};
 use std::{convert::TryFrom, fmt};
 
-/// A struct that represents a globally unique id for an Event stream that a user can listen to.e
+/// A struct that represents a globally unique id for an Event stream that a user can listen to.
+/// By design, the lower part of EventKey is the same as account address.
 #[derive(Clone, Copy, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
 #[cfg_attr(feature = "fuzzing", derive(Arbitrary))]
 pub struct EventKey([u8; EventKey::LENGTH]);
@@ -32,6 +33,14 @@ impl EventKey {
     /// Convert event key into a byte array.
     pub fn to_vec(&self) -> Vec<u8> {
         self.0.to_vec()
+    }
+
+    /// Get the account address part in this event key
+    pub fn get_creator_address(&self) -> AccountAddress {
+        let mut arr_bytes = [0u8; AccountAddress::LENGTH];
+        arr_bytes.copy_from_slice(&self.0[EventKey::LENGTH - AccountAddress::LENGTH..]);
+
+        AccountAddress::new(arr_bytes)
     }
 
     #[cfg(feature = "fuzzing")]


### PR DESCRIPTION
Per previous discussion, as implemented in this PR, we will expose AccountAddress through EventKey for AccountState . 