### PR TITLE
[tf] nonpersistent storage option for dev

### DIFF
--- a/terraform/fullnodes.tf
+++ b/terraform/fullnodes.tf
@@ -78,7 +78,7 @@ resource "aws_ecs_task_definition" "fullnode" {
 
   volume {
     name      = "libra-data"
-    host_path = "/data/libra"
+    host_path = var.persist_libra_data ? "/data/libra" : ""
   }
 
   placement_constraints {

--- a/terraform/templates/ec2_user_data.sh
+++ b/terraform/templates/ec2_user_data.sh
@@ -10,9 +10,24 @@ if [ -e /dev/nvme1n1 ]; then
 	cat >> /etc/fstab <<-EOF
 	/dev/nvme1n1  /data  ext4  defaults,noatime,nofail  0  2
 	EOF
-
 	mkdir /data
 	mount /data
+
+	# non-persistent storage is managed by Docker under data-root
+	if ! ${persistent} ; then
+		cat >> /etc/fstab <<-EOF
+		/dev/nvme1n1  /var/lib/docker/volumes  ext4  defaults,noatime,nofail  0  2
+		EOF
+		mkdir -p /var/lib/docker/volumes
+		mount /var/lib/docker/volumes
+
+		# give some helptul tips
+		cat > /data/README <<-EOF
+		In non-persistent mode -- data is not persisted between ECS updates. Showing Docker volumes instead. To find the currently mounted Docker volume:
+		\$ docker container ls -q --filter label=com.amazonaws.ecs.container-name=validator | xargs docker inspect -f '{{ .Mounts }}' | awk '{print \$3}'
+		EOF
+	fi
+
 fi
 
 mkdir -p /opt/libra /vault

--- a/terraform/validators.tf
+++ b/terraform/validators.tf
@@ -236,7 +236,7 @@ resource "aws_ecs_task_definition" "validator" {
 
   volume {
     name      = "libra-data"
-    host_path = "/data/libra"
+    host_path = var.persist_libra_data ? "/data/libra" : ""
   }
 
   placement_constraints {

--- a/terraform/validators.tf
+++ b/terraform/validators.tf
@@ -119,6 +119,7 @@ data "template_file" "user_data" {
   template = file("templates/ec2_user_data.sh")
 
   vars = {
+    persistent       = var.persist_libra_data
     ecs_cluster      = aws_ecs_cluster.testnet.name
     host_log_path    = "/data/libra/libra.log"
     host_structlog_path   = "/data/libra/libra_structlog.log"

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -224,3 +224,9 @@ variable "safety_rules_use_vault" {
   description = "Configure safety-rules to use Vault as the backend"
   default     = false
 }
+
+variable "persist_libra_data" {
+  type        = bool
+  default     = true
+  description = "Whether to persist libra data on validator and fullnode"
+}

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -228,5 +228,5 @@ variable "safety_rules_use_vault" {
 variable "persist_libra_data" {
   type        = bool
   default     = true
-  description = "Whether to persist libra data on validator and fullnode"
+  description = "Whether to persist libra data on validator and fullnode between restarts"
 }


### PR DESCRIPTION
<!--
Thank you for sending a PR. We appreciate you spending time to help improve the Libra project.

The project is undergoing daily changes. Pull Requests will be reviewed and responded to as time permits.
-->

## Motivation

Devnet breaks occasionally and requires an operator to go in and manually wipe validator and fullnode state (eg. `nuke-all`). This PR adds terraform variable `persist_libra_data` that controls whether validator and fullnode state is reset on restart. 

NOTE: To make volumes non-persistent, we hand control to Docker, which by default creates the volume in its own data-root directory. As a workaround, we have to mount the libra-data filesystem at /var/lib/docker/volumes. To keep this backwards compatible with our old metrics, we have to mount again at /data. 

```
[ec2-user:validator@ip-10-0-10-26 /data]$ df -a | grep nvme1n1
/dev/nvme1n1    30832548  382680  28860620   2% /data
/dev/nvme1n1    30832548  382680  28860620   2% /var/lib/docker/volumes
```

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

http://prometheus.rustietest.aws.hlw3truzy4ls.com:9091/d/overview10/overview?orgId=1

/data Util and / Util metrics are functioning as expected, and there is no performance regression since the Docker volume directory is mounted on io1 disk type.

Before update ECS services

![image](https://user-images.githubusercontent.com/12578616/77965567-1e770980-7296-11ea-8200-496da59245be.png)

After restarting ECS services, new docker volume is used. Old volumes and exited containers are cleaned up by ECS Agent after 3 hrs by default. See drop in total stored txns.

![image](https://user-images.githubusercontent.com/12578616/77965554-174ffb80-7296-11ea-9e2e-faf7c687a8e0.png)


## Related PRs

(If this PR adds or changes functionality, please take some time to update the docs at https://github.com/libra/website, and link to your PR here.)
