### PR TITLE
[serde reflection] add test to detect breaking changes in Libra formats

### DIFF
--- a/testsuite/generate-format/Cargo.toml
+++ b/testsuite/generate-format/Cargo.toml
@@ -17,3 +17,8 @@ structopt = "0.3.12"
 libra_types = { path = "../../types", version = "0.1.0", package = "libra-types", features=["fuzzing"] }
 lcs = { path = "../../common/lcs", version = "0.1.0", package = "libra-canonical-serialization" }
 serde_reflection = { path = "../../common/serde-reflection", version = "0.1.0", package = "libra-serde-reflection" }
+
+[[bin]]
+name = "compute"
+path = "src/compute.rs"
+test = false

--- a/testsuite/generate-format/src/compute.rs
+++ b/testsuite/generate-format/src/compute.rs
@@ -1,0 +1,40 @@
+// Copyright (c) The Libra Core Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+use generate_format::{add_deserialization_tracing, add_proptest_serialization_tracing, FILE_PATH};
+use serde_reflection::Tracer;
+use serde_yaml;
+use std::{fs::File, io::Write};
+use structopt::StructOpt;
+
+#[derive(Debug, StructOpt)]
+#[structopt(
+    name = "Libra format generator",
+    about = "Trace serde (de)serialization to generate format descriptions for Libra types"
+)]
+struct Options {
+    #[structopt(short, long)]
+    with_deserialize: bool,
+
+    #[structopt(short, long)]
+    record: bool,
+}
+
+fn main() {
+    let options = Options::from_args();
+
+    let mut tracer = Tracer::new(lcs::is_human_readable());
+    tracer = add_proptest_serialization_tracing(tracer);
+    if options.with_deserialize {
+        tracer = add_deserialization_tracing(tracer);
+    }
+
+    let registry = tracer.registry().unwrap();
+    let content = serde_yaml::to_string(&registry).unwrap();
+    if options.record {
+        let mut f = File::create("testsuite/generate-format/".to_string() + FILE_PATH).unwrap();
+        writeln!(f, "{}", content).unwrap();
+    } else {
+        println!("{}", content);
+    }
+}

--- a/testsuite/generate-format/tests/detect_format_change.rs
+++ b/testsuite/generate-format/tests/detect_format_change.rs
@@ -1,0 +1,81 @@
+// Copyright (c) The Libra Core Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+use generate_format::{add_proptest_serialization_tracing, FILE_PATH};
+use serde_reflection::{RegistryOwned, Tracer};
+use serde_yaml;
+use std::collections::BTreeMap;
+
+static MESSAGE: &str = r#"
+You may run `cargo run -p generate-format -- --record` to refresh the records.
+Please verify the changes to the recorded file(s) and tag your pull-request as `breaking`."#;
+
+#[test]
+fn test_recorded_formats_did_not_change() {
+    let mut tracer = Tracer::new(lcs::is_human_readable());
+    tracer = add_proptest_serialization_tracing(tracer);
+    let registry: BTreeMap<_, _> = tracer
+        .registry()
+        .unwrap()
+        .into_iter()
+        .map(|(k, v)| (k.to_string(), v))
+        .collect();
+
+    let content = std::fs::read_to_string(FILE_PATH).unwrap();
+    let expected = serde_yaml::from_str::<RegistryOwned>(content.as_str()).unwrap();
+
+    for (key, value) in expected.iter() {
+        assert_eq!(
+            Some(value),
+            registry.get(key),
+            r#"
+----
+The recorded format for type `{}` is missing or does not match the recorded value on disk.{}
+----
+"#,
+            key,
+            MESSAGE
+        );
+    }
+
+    for key in registry.keys() {
+        assert!(
+            expected.contains_key(key),
+            r#"
+----
+Type `{}` was added and has no recorded format on disk yet.{}
+----
+"#,
+            key,
+            MESSAGE
+        );
+    }
+}
+
+#[test]
+fn test_we_can_detect_changes_in_yaml() {
+    let yaml1 = r#"---
+Person:
+  ENUM:
+    0:
+      NickName:
+        NEWTYPE:
+          STR
+"#;
+
+    let yaml2 = r#"---
+Person:
+  ENUM:
+    0:
+      NickName:
+        NEWTYPE:
+          STR
+    1:
+      FullName: UNIT
+"#;
+
+    let value1 = serde_yaml::from_str::<RegistryOwned>(yaml1).unwrap();
+    let value2 = serde_yaml::from_str::<RegistryOwned>(yaml2).unwrap();
+    assert_ne!(value1, value2);
+    assert_ne!(value1.get("Person").unwrap(), value2.get("Person").unwrap());
+}

--- a/testsuite/generate-format/tests/staged/libra.yaml
+++ b/testsuite/generate-format/tests/staged/libra.yaml
@@ -1,0 +1,186 @@
+---
+AccessPath:
+  STRUCT:
+    - address:
+        TYPENAME: AccountAddress
+    - path:
+        SEQ: U8
+AccountAddress:
+  NEWTYPESTRUCT:
+    TUPLEARRAY:
+      CONTENT: U8
+      SIZE: 16
+BlockMetadata:
+  STRUCT:
+    - id:
+        TYPENAME: HashValue
+    - round: U64
+    - timestamp_usecs: U64
+    - previous_block_votes:
+        SEQ:
+          TYPENAME: AccountAddress
+    - proposer:
+        TYPENAME: AccountAddress
+ChangeSet:
+  STRUCT:
+    - write_set:
+        TYPENAME: WriteSet
+    - events:
+        SEQ:
+          TYPENAME: ContractEvent
+ContractEvent:
+  STRUCT:
+    - key:
+        TYPENAME: EventKey
+    - sequence_number: U64
+    - type_tag:
+        TYPENAME: TypeTag
+    - event_data:
+        SEQ: U8
+Ed25519PublicKey:
+  NEWTYPESTRUCT:
+    SEQ: U8
+Ed25519Signature:
+  NEWTYPESTRUCT:
+    SEQ: U8
+EventKey:
+  NEWTYPESTRUCT:
+    SEQ: U8
+HashValue:
+  NEWTYPESTRUCT:
+    SEQ: U8
+Identifier:
+  NEWTYPESTRUCT: STR
+Module:
+  STRUCT:
+    - code:
+        SEQ: U8
+RawTransaction:
+  STRUCT:
+    - sender:
+        TYPENAME: AccountAddress
+    - sequence_number: U64
+    - payload:
+        TYPENAME: TransactionPayload
+    - max_gas_amount: U64
+    - gas_unit_price: U64
+    - gas_specifier:
+        TYPENAME: TypeTag
+    - expiration_time: U64
+Script:
+  STRUCT:
+    - code:
+        SEQ: U8
+    - args:
+        SEQ:
+          TYPENAME: TransactionArgument
+SignedTransaction:
+  STRUCT:
+    - raw_txn:
+        TYPENAME: RawTransaction
+    - authenticator:
+        TYPENAME: TransactionAuthenticator
+StructTag:
+  STRUCT:
+    - address:
+        TYPENAME: AccountAddress
+    - module:
+        TYPENAME: Identifier
+    - name:
+        TYPENAME: Identifier
+    - type_params:
+        SEQ:
+          TYPENAME: TypeTag
+Transaction:
+  ENUM:
+    0:
+      UserTransaction:
+        NEWTYPE:
+          TYPENAME: SignedTransaction
+    1:
+      WriteSet:
+        NEWTYPE:
+          TYPENAME: ChangeSet
+    2:
+      BlockMetadata:
+        NEWTYPE:
+          TYPENAME: BlockMetadata
+TransactionArgument:
+  ENUM:
+    0:
+      U64:
+        NEWTYPE: U64
+    1:
+      Address:
+        NEWTYPE:
+          TYPENAME: AccountAddress
+    2:
+      U8Vector:
+        NEWTYPE:
+          SEQ: U8
+    3:
+      Bool:
+        NEWTYPE: BOOL
+TransactionAuthenticator:
+  ENUM:
+    0:
+      Ed25519:
+        STRUCT:
+          - public_key:
+              TYPENAME: Ed25519PublicKey
+          - signature:
+              TYPENAME: Ed25519Signature
+TransactionPayload:
+  ENUM:
+    0:
+      Program: UNIT
+    1:
+      WriteSet:
+        NEWTYPE:
+          TYPENAME: ChangeSet
+    2:
+      Script:
+        NEWTYPE:
+          TYPENAME: Script
+    3:
+      Module:
+        NEWTYPE:
+          TYPENAME: Module
+TypeTag:
+  ENUM:
+    0:
+      Bool: UNIT
+    1:
+      U8: UNIT
+    2:
+      U64: UNIT
+    3:
+      U128: UNIT
+    4:
+      Address: UNIT
+    5:
+      Vector:
+        NEWTYPE:
+          TYPENAME: TypeTag
+    6:
+      Struct:
+        NEWTYPE:
+          TYPENAME: StructTag
+WriteOp:
+  ENUM:
+    0:
+      Deletion: UNIT
+    1:
+      Value:
+        NEWTYPE:
+          SEQ: U8
+WriteSet:
+  NEWTYPESTRUCT:
+    TYPENAME: WriteSetMut
+WriteSetMut:
+  STRUCT:
+    - write_set:
+        SEQ:
+          TUPLE:
+            - TYPENAME: AccessPath
+            - TYPENAME: WriteOp


### PR DESCRIPTION
## Motivation

Use the recent Serde reflection library to add a non-regression test to track (breaking) changes to the Libra formats.

This does not include all Libra types just yet but we will get there!

## Test Plan

Manually changed the recorded YAML file to create mismatch then run:
```
cargo x test -p generate-format                   # fails due to manual change 
cargo run -p generate-format -- --record   # modify recorded file on disk
cargo x test -p generate-format                   # works again
```

## Related PRs

https://github.com/libra/libra/pull/3104 (replaced by this one)
https://github.com/libra/libra/pull/3060