### PR TITLE
[Serde + move] PoC for format generation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3125,6 +3125,7 @@ dependencies = [
  "once_cell 1.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "proptest 0.9.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.106 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde-reflection 0.1.0",
  "sha2 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "vm 0.1.0",
 ]

--- a/language/move-vm/types/Cargo.toml
+++ b/language/move-vm/types/Cargo.toml
@@ -22,6 +22,7 @@ vm = { path = "../../vm", version = "0.1.0" }
 lcs = { path = "../../../common/lcs", version = "0.1.0", package = "libra-canonical-serialization" }
 libra-crypto = { path = "../../../crypto/crypto", version = "0.1.0" }
 move-core-types = { path = "../../move-core/types", version = "0.1.0" }
+serde-reflection = { path = "../../../common/serde-reflection", version = "0.1.0" }
 
 [dev-dependencies]
 proptest = "0.9.6"

--- a/language/move-vm/types/src/values/values_impl.rs
+++ b/language/move-vm/types/src/values/values_impl.rs
@@ -2174,6 +2174,23 @@ impl Value {
     pub fn simple_serialize(&self, ty: &Type) -> Option<Vec<u8>> {
         lcs::to_bytes(&AnnotatedValue { ty, val: &self.0 }).ok()
     }
+
+    pub fn trace_serialize(
+        &self,
+        tracer: &mut serde_reflection::Tracer,
+        samples: &mut serde_reflection::Samples,
+        ty: &Type,
+    ) -> Result<(serde_reflection::Format, serde_reflection::Value), serde_reflection::Error> {
+        tracer.trace_value(samples, &AnnotatedValue { ty, val: &self.0 })
+    }
+
+    pub fn trace_deserialize(
+        tracer: &mut serde_reflection::Tracer,
+        samples: &serde_reflection::Samples,
+        ty: &Type,
+    ) -> Result<(serde_reflection::Format, Value), serde_reflection::Error> {
+        tracer.trace_type_once_with_seed(samples, ty)
+    }
 }
 
 impl Struct {
@@ -2184,6 +2201,23 @@ impl Struct {
 
     pub fn simple_serialize(&self, ty: &StructType) -> Option<Vec<u8>> {
         lcs::to_bytes(&AnnotatedValue { ty, val: &self.0 }).ok()
+    }
+
+    pub fn trace_serialize(
+        &self,
+        tracer: &mut serde_reflection::Tracer,
+        samples: &mut serde_reflection::Samples,
+        ty: &StructType,
+    ) -> Result<(serde_reflection::Format, serde_reflection::Value), serde_reflection::Error> {
+        tracer.trace_value(samples, &AnnotatedValue { ty, val: &self.0 })
+    }
+
+    pub fn trace_deserialize(
+        tracer: &mut serde_reflection::Tracer,
+        samples: &serde_reflection::Samples,
+        ty: &StructType,
+    ) -> Result<(serde_reflection::Format, Struct), serde_reflection::Error> {
+        tracer.trace_type_once_with_seed(samples, ty)
     }
 }
 


### PR DESCRIPTION
Some temporary sample outputs

```
Struct(StructType { address: 6fd2d30f34f7a77b7762d648db2d0b10, module: Identifier("bQnf6Use_T3LD__H57s4h7__vvev_7"), name: Identifier("_57Zi__q_Rk6f3xAtLG_LUT9p_DJ_QK_C"), ty_args: [U128, U64, Struct(StructType { address: d0e484c3c5149c8dda06fea5e21800ac, module: Identifier("__M1RBWZS__zB_0__G1CuU2__5orM_"), name: Identifier("_Mm_Q_83Z4__2__WJY__0f0Pb_P8y"), ty_args: [U64], layout: [U64, U64, Address, U64, U8] })], layout: [U64, Address, U128, U128, Address, Bool] })
-->
Tuple([U64, TypeName("AccountAddress"), U128, U128, TypeName("AccountAddress"), Bool])

Struct(StructType { address: fde5c4d099d60b81cbb248952684c05e, module: Identifier("_Ygf1e3_0856"), name: Identifier("w__6_Ht"), ty_args: [Bool, U8, Bool], layout: [U64, Struct(StructType { address: c5ce32932254eea7779e9352c56121c1, module: Identifier("__gtW96GH9N9e1aOqPLK_c"), name: Identifier("<SELF>"), ty_args: [Address], layout: [U8] }), Bool, U64, Address, Bool, Bool] })
-->
Tuple([U64, Tuple([U8]), Bool, U64, TypeName("AccountAddress"), Bool, Bool])

Vector(U128)
-->
Seq(U128)
```