### PR TITLE
[network] Fix how disconnects are handled

### DIFF
--- a/network/src/protocols/direct_send/test.rs
+++ b/network/src/protocols/direct_send/test.rs
@@ -15,9 +15,7 @@ use bytes::Bytes;
 use futures::{sink::SinkExt, stream::StreamExt};
 use libra_logger::debug;
 use libra_types::PeerId;
-use parity_multiaddr::Multiaddr;
 use serial_test::serial;
-use std::str::FromStr;
 use tokio::runtime::{Handle, Runtime};
 
 const PROTOCOL_1: ProtocolId = ProtocolId::ConsensusDirectSend;
@@ -48,11 +46,7 @@ fn start_direct_send_actor(
     // Reset counters before starting actor.
     reset_counters();
     let direct_send = DirectSend::new(
-        PeerHandle::new(
-            PeerId::random(),
-            Multiaddr::from_str("/ip4/127.0.0.1/tcp/8081").unwrap(),
-            peer_reqs_tx,
-        ),
+        PeerHandle::new(PeerId::random(), peer_reqs_tx),
         ds_requests_rx,
         ds_notifs_tx,
         peer_notifs_rx,

--- a/network/src/protocols/rpc/fuzzing.rs
+++ b/network/src/protocols/rpc/fuzzing.rs
@@ -16,9 +16,8 @@ use futures::{
 };
 use libra_proptest_helpers::ValueGenerator;
 use libra_types::PeerId;
-use parity_multiaddr::Multiaddr;
 use proptest::{arbitrary::any, collection::vec, prop_oneof, strategy::Strategy};
-use std::{io, iter::FromIterator, str::FromStr};
+use std::{io, iter::FromIterator};
 use tokio::runtime;
 use tokio_util::codec::{Encoder, LengthDelimitedCodec};
 
@@ -78,11 +77,7 @@ pub fn fuzzer(data: &[u8]) {
     let f_handle_inbound = rpc::handle_inbound_request_inner(
         notification_tx,
         inbound_request,
-        PeerHandle::new(
-            MOCK_PEER_ID,
-            Multiaddr::from_str("/ip4/127.0.0.1/tcp/8081").unwrap(),
-            peer_reqs_tx,
-        ),
+        PeerHandle::new(MOCK_PEER_ID, peer_reqs_tx),
     )
     .map(|_| io::Result::Ok(()));
 

--- a/network/src/protocols/rpc/test.rs
+++ b/network/src/protocols/rpc/test.rs
@@ -14,9 +14,7 @@ use crate::{
 use anyhow::anyhow;
 use futures::future::join;
 use libra_types::PeerId;
-use parity_multiaddr::Multiaddr;
 use serial_test::serial;
-use std::str::FromStr;
 use tokio::runtime::{Handle, Runtime};
 
 static RPC_PROTOCOL_A: ProtocolId = ProtocolId::ConsensusRpc;
@@ -42,11 +40,7 @@ fn start_rpc_actor(
     // Reset counters before starting actor.
     reset_counters();
     let rpc = Rpc::new(
-        PeerHandle::new(
-            PeerId::random(),
-            Multiaddr::from_str("/ip4/127.0.0.1/tcp/8081").unwrap(),
-            peer_reqs_tx,
-        ),
+        PeerHandle::new(PeerId::random(), peer_reqs_tx),
         rpc_requests_rx,
         peer_notifs_rx,
         rpc_notifs_tx,


### PR DESCRIPTION
A notion of `connection_id` is introduced. ConnectionId is a unique local identifier assigned to each connection by the ConnectionHandler. The ConnectionId is part of the ConnectionMetadata struct that is passed from PeerManager to Peer when we start the downstream modules to handle IO over the connection. The metadata is passed back from Peer to PeerManager on disconnect. This allows PeerManager to uniquely determine which connection was lost. This is unlike earlier, when we had a (buggy) heurisitic to determine this using connection origin.

**Design decisions:**
* We increment the LIBRA_NETWORK_PEERS counter on any new connection. Similarly, decrement the counter on any lost connection. This means that LIBRA_NETWORK_PEERS may temporarily double-count a peer if there are 2 connections with it. However, in steady state the counter should reflect the number of unique peers we are connected to.
* Duplicate LostPeer notifications: It is possible that we send many duplicate LostPeer notifications for a peer to the upstream client. However, this does not affect correctness, since the notification is only sent when there are no active connections.

Closes: #3128 