### PR TITLE
[storage] TreeCache supports bootstraping from PRE_GENESIS_VERSION

### DIFF
--- a/storage/jellyfish-merkle/src/jellyfish_merkle_test.rs
+++ b/storage/jellyfish-merkle/src/jellyfish_merkle_test.rs
@@ -5,6 +5,7 @@ use super::*;
 use libra_crypto::{hash::SPARSE_MERKLE_PLACEHOLDER_HASH, HashValue};
 use libra_nibble::Nibble;
 use libra_types::proof::SparseMerkleInternalNode;
+use libra_types::transaction::PRE_GENESIS_VERSION;
 use mock_tree_store::MockTreeStore;
 use proptest::{
     collection::{btree_map, hash_map, vec},
@@ -42,6 +43,36 @@ fn test_insert_to_empty_tree() {
     db.write_tree_update_batch(batch).unwrap();
 
     assert_eq!(tree.get(key, 0).unwrap().unwrap(), value);
+}
+
+#[test]
+fn test_insert_to_pre_genesis() {
+    // Set up DB with pre-genesis state (one single leaf node).
+    let db = MockTreeStore::default();
+    let key1 = HashValue::new([0x00u8; HashValue::LENGTH]);
+    let value1 = AccountStateBlob::from(vec![1u8, 2u8]);
+    let pre_genesis_root_key = NodeKey::new_empty_path(PRE_GENESIS_VERSION);
+    db.put_node(pre_genesis_root_key, Node::new_leaf(key1, value1.clone()))
+        .unwrap();
+
+    // Genesis inserts one more leaf.
+    let tree = JellyfishMerkleTree::new(&db);
+    let key2 = update_nibble(&key1, 0, 15);
+    let value2 = AccountStateBlob::from(vec![3u8, 4u8]);
+    let (_root_hash, batch) = tree
+        .put_blob_set(vec![(key2, value2.clone())], 0 /* version */)
+        .unwrap();
+
+    // Check pre-genesis node prunes okay.
+    assert_eq!(batch.stale_node_index_batch.len(), 1);
+    db.write_tree_update_batch(batch).unwrap();
+    assert_eq!(db.num_nodes(), 4);
+    db.purge_stale_nodes(0).unwrap();
+    assert_eq!(db.num_nodes(), 3);
+
+    // Check mixed state reads okay.
+    assert_eq!(tree.get(key1, 0).unwrap().unwrap(), value1);
+    assert_eq!(tree.get(key2, 0).unwrap().unwrap(), value2);
 }
 
 #[test]

--- a/storage/jellyfish-merkle/src/jellyfish_merkle_test.rs
+++ b/storage/jellyfish-merkle/src/jellyfish_merkle_test.rs
@@ -4,8 +4,7 @@
 use super::*;
 use libra_crypto::{hash::SPARSE_MERKLE_PLACEHOLDER_HASH, HashValue};
 use libra_nibble::Nibble;
-use libra_types::proof::SparseMerkleInternalNode;
-use libra_types::transaction::PRE_GENESIS_VERSION;
+use libra_types::{proof::SparseMerkleInternalNode, transaction::PRE_GENESIS_VERSION};
 use mock_tree_store::MockTreeStore;
 use proptest::{
     collection::{btree_map, hash_map, vec},

--- a/storage/jellyfish-merkle/src/tree_cache/tree_cache_test.rs
+++ b/storage/jellyfish-merkle/src/tree_cache/tree_cache_test.rs
@@ -43,6 +43,19 @@ fn test_root_node() {
 }
 
 #[test]
+fn test_pre_genesis() {
+    let next_version = 0;
+    let db = MockTreeStore::default();
+    let pre_genesis_root_key = NodeKey::new_empty_path(PRE_GENESIS_VERSION);
+    let (pre_genesis_only_node, _) = random_leaf_with_key(PRE_GENESIS_VERSION);
+    db.put_node(pre_genesis_root_key.clone(), pre_genesis_only_node)
+        .unwrap();
+
+    let cache = TreeCache::new(&db, next_version);
+    assert_eq!(*cache.get_root_node_key(), pre_genesis_root_key);
+}
+
+#[test]
 fn test_freeze_with_delete() {
     let next_version = 0;
     let db = MockTreeStore::default();

--- a/types/src/transaction/mod.rs
+++ b/types/src/transaction/mod.rs
@@ -49,6 +49,7 @@ use std::ops::Deref;
 pub use transaction_argument::{parse_as_transaction_argument, TransactionArgument};
 
 pub type Version = u64; // Height - also used for MVCC in StateDB
+
 // In StateDB, things readable by the genesis transaction are under this version.
 pub const PRE_GENESIS_VERSION: Version = u64::max_value();
 

--- a/types/src/transaction/mod.rs
+++ b/types/src/transaction/mod.rs
@@ -49,6 +49,8 @@ use std::ops::Deref;
 pub use transaction_argument::{parse_as_transaction_argument, TransactionArgument};
 
 pub type Version = u64; // Height - also used for MVCC in StateDB
+// In StateDB, things readable by the genesis transaction are under this version.
+pub const PRE_GENESIS_VERSION: Version = u64::max_value();
 
 pub const MAX_TRANSACTION_SIZE_IN_BYTES: usize = 4096;
 


### PR DESCRIPTION
To support #2439 we need the state to be readable before geneiss version.
I'm defining PRE_GENESIS_VERSION = std::u64::max_value() and in progress of making our state tree capable of reaading from it.
This commit specifically tweeks the TreeCache so that it detects whether a pre genesis state is present when initialized with next_version == 0.

<!--
Thank you for sending a PR. We appreciate you spending time to help improve the Libra project.

The project is undergoing daily changes. Pull Requests will be reviewed and responded to as time permits.
-->

## Motivation

(Write your motivation for proposed changes here.)

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?
Yes.
(Write your answer here.)

## Test Plan

Existing coverage and new unit test.

## Related PRs

(If this PR adds or changes functionality, please take some time to update the docs at https://github.com/libra/website, and link to your PR here.)
