### PR TITLE
[language] Change the IR compiler to emit binary files instead of JSON

### DIFF
--- a/client/cli/src/client_proxy.rs
+++ b/client/cli/src/client_proxy.rs
@@ -753,23 +753,23 @@ impl ClientProxy {
 
     /// Publish move module
     pub fn publish_module(&mut self, space_delim_strings: &[&str]) -> Result<()> {
-        let module_bytes = &fs::read(space_delim_strings[2])?;
+        let module_bytes = fs::read(space_delim_strings[2])?;
         self.submit_program(
             space_delim_strings,
-            TransactionPayload::Module(Module::new(module_bytes.clone())),
+            TransactionPayload::Module(Module::new(module_bytes)),
         )
     }
 
     /// Execute custom script
     pub fn execute_script(&mut self, space_delim_strings: &[&str]) -> Result<()> {
-        let script_bytes = &fs::read(space_delim_strings[2])?;
+        let script_bytes = fs::read(space_delim_strings[2])?;
         let arguments: Vec<_> = space_delim_strings[3..]
             .iter()
             .filter_map(|arg| parse_as_transaction_argument_for_client(arg).ok())
             .collect();
         self.submit_program(
             space_delim_strings,
-            TransactionPayload::Script(Script::new(script_bytes.clone(), arguments)),
+            TransactionPayload::Script(Script::new(script_bytes, arguments)),
         )
     }
 

--- a/client/cli/src/client_proxy.rs
+++ b/client/cli/src/client_proxy.rs
@@ -29,7 +29,7 @@ use libra_types::{
     transaction::{
         authenticator::AuthenticationKey,
         helpers::{create_unsigned_txn, create_user_txn, TransactionSigner},
-        parse_as_transaction_argument, RawTransaction, Script, SignedTransaction,
+        parse_as_transaction_argument, Module, RawTransaction, Script, SignedTransaction,
         TransactionArgument, TransactionPayload, Version,
     },
     waypoint::Waypoint,
@@ -753,21 +753,23 @@ impl ClientProxy {
 
     /// Publish move module
     pub fn publish_module(&mut self, space_delim_strings: &[&str]) -> Result<()> {
-        let module = serde_json::from_slice(&fs::read(space_delim_strings[2])?)?;
-        self.submit_program(space_delim_strings, TransactionPayload::Module(module))
+        let module_bytes = &fs::read(space_delim_strings[2])?;
+        self.submit_program(
+            space_delim_strings,
+            TransactionPayload::Module(Module::new(module_bytes.clone())),
+        )
     }
 
     /// Execute custom script
     pub fn execute_script(&mut self, space_delim_strings: &[&str]) -> Result<()> {
-        let script: Script = serde_json::from_slice(&fs::read(space_delim_strings[2])?)?;
-        let (script_bytes, _) = script.into_inner();
+        let script_bytes = &fs::read(space_delim_strings[2])?;
         let arguments: Vec<_> = space_delim_strings[3..]
             .iter()
             .filter_map(|arg| parse_as_transaction_argument_for_client(arg).ok())
             .collect();
         self.submit_program(
             space_delim_strings,
-            TransactionPayload::Script(Script::new(script_bytes, arguments)),
+            TransactionPayload::Script(Script::new(script_bytes.clone(), arguments)),
         )
     }
 

--- a/language/compiler/src/main.rs
+++ b/language/compiler/src/main.rs
@@ -10,12 +10,7 @@ use bytecode_verifier::{
 };
 use compiler::{util, Compiler};
 use ir_to_bytecode::parser::{parse_module, parse_script};
-use libra_types::{
-    access_path::AccessPath,
-    account_address::AccountAddress,
-    transaction::{Module, Script},
-    vm_error::VMStatus,
-};
+use libra_types::{access_path::AccessPath, account_address::AccountAddress, vm_error::VMStatus};
 use std::{
     convert::TryFrom,
     fs,
@@ -180,9 +175,7 @@ fn main() {
         compiled_script
             .serialize(&mut script)
             .expect("Unable to serialize script");
-        let payload = Script::new(script, vec![]);
-        let payload_bytes = serde_json::to_vec(&payload).expect("Unable to serialize script");
-        write_output(&source_path.with_extension(mv_extension), &payload_bytes);
+        write_output(&source_path.with_extension(mv_extension), &script);
     } else {
         let (compiled_module, source_map) =
             util::do_compile_module(&args.source_path, address, &deps);
@@ -206,8 +199,6 @@ fn main() {
         compiled_module
             .serialize(&mut module)
             .expect("Unable to serialize module");
-        let payload = Module::new(module);
-        let payload_bytes = serde_json::to_vec(&payload).expect("Unable to serialize module");
-        write_output(&source_path.with_extension(mv_extension), &payload_bytes);
+        write_output(&source_path.with_extension(mv_extension), &module);
     }
 }


### PR DESCRIPTION
## Motivation

The disassembler currently only reads binary files so without this, there is no way to examine the output of the IR compiler.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

cargo xtest