### PR TITLE
[move-prover] Dealing with calls from private to public module methods.

### DIFF
--- a/language/move-prover/src/boogie_wrapper.rs
+++ b/language/move-prover/src/boogie_wrapper.rs
@@ -365,7 +365,7 @@ impl<'env> BoogieWrapper<'env> {
         let verification_diag_start =
             Regex::new(r"(?m)^.*\((?P<line>\d+),(?P<col>\d+)\): Error BP\d+:(?P<msg>.*)$").unwrap();
         let verification_diag_related =
-            Regex::new(r"(?m)^.+\((?P<line>\d+),(?P<col>\d+)\): Related.*$").unwrap();
+            Regex::new(r"^\n.+\((?P<line>\d+),(?P<col>\d+)\): Related.*\n").unwrap();
         let verification_diag_trace = Regex::new(r"(?m)^Execution trace:$").unwrap();
         let verification_diag_trace_entry =
             Regex::new(r"(?m)^    .*\((?P<line>\d+),(?P<col>\d+)\): (?P<msg>.*)$").unwrap();

--- a/language/move-prover/tests/sources/mut_ref_accross_modules.exp
+++ b/language/move-prover/tests/sources/mut_ref_accross_modules.exp
@@ -1,11 +1,74 @@
 Move prover returns: exiting with boogie verification errors
 error:  This assertion might not hold.
 
-    ┌── tests/sources/mut_ref_accross_modules.move:19:9 ───
+    ┌── tests/sources/mut_ref_accross_modules.move:16:9 ───
     │
- 19 │         invariant global<TSum>(0x0).sum == spec_sum;
+ 16 │         invariant value > 0;
+    │         ^^^^^^^^^^^^^^^^^^^^
+    │
+    =     at tests/sources/mut_ref_accross_modules.move:59:5: decrement_invalid (entry)
+    =     at tests/sources/mut_ref_accross_modules.move:60:27: decrement_invalid
+    =         x = <redacted>,
+    =         x = <redacted>,
+    =         r = <redacted>
+    =     at tests/sources/mut_ref_accross_modules.move:61:41: decrement_invalid
+    =         r = <redacted>
+    =     at tests/sources/mut_ref_accross_modules.move:62:17: decrement_invalid
+    =         x = <redacted>,
+    =         r = <redacted>
+
+error:  A postcondition might not hold on this return path.
+
+    ┌── tests/sources/mut_ref_accross_modules.move:25:9 ───
+    │
+ 25 │         invariant global<TSum>(0x0).sum == spec_sum;
     │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
     │
-    =     at tests/sources/mut_ref_accross_modules.move:50:5: increment_invalid (entry)
-    =     at tests/sources/mut_ref_accross_modules.move:51:27: increment_invalid
-    =     at tests/sources/mut_ref_accross_modules.move:50:5: increment_invalid (exit)
+    =     at tests/sources/mut_ref_accross_modules.move:53:5: increment_invalid (entry)
+    =     at tests/sources/mut_ref_accross_modules.move:54:27: increment_invalid
+    =         x = <redacted>,
+    =         x = <redacted>
+    =     at tests/sources/mut_ref_accross_modules.move:53:5: increment_invalid (exit)
+
+error:  This assertion might not hold.
+
+    ┌── tests/sources/mut_ref_accross_modules.move:16:9 ───
+    │
+ 16 │         invariant value > 0;
+    │         ^^^^^^^^^^^^^^^^^^^^
+    │
+    =     at tests/sources/mut_ref_accross_modules.move:109:6: private_to_public_caller_invalid_data_invariant (entry)
+    =     at tests/sources/mut_ref_accross_modules.move:29:5: new (entry)
+    =     at tests/sources/mut_ref_accross_modules.move:30:17: new
+    =         x = <redacted>,
+    =         r = <redacted>
+    =     at tests/sources/mut_ref_accross_modules.move:31:17: new
+    =         r = <redacted>
+    =     at tests/sources/mut_ref_accross_modules.move:32:18: new
+    =     at tests/sources/mut_ref_accross_modules.move:29:5: new (exit)
+    =     at tests/sources/mut_ref_accross_modules.move:114:18: private_to_public_caller_invalid_data_invariant
+    =         x = <redacted>
+    =     at tests/sources/mut_ref_accross_modules.move:115:18: private_to_public_caller_invalid_data_invariant
+    =         r = <redacted>
+    =     at tests/sources/mut_ref_accross_modules.move:67:5: private_decrement (entry)
+    =     at tests/sources/mut_ref_accross_modules.move:68:27: private_decrement
+    =         x = <redacted>,
+    =         x = <redacted>,
+    =         r = <redacted>
+    =     at tests/sources/mut_ref_accross_modules.move:69:41: private_decrement
+    =         r = <redacted>
+    =     at tests/sources/mut_ref_accross_modules.move:70:17: private_decrement
+    =         x = <redacted>,
+    =         r = <redacted>
+    =     at tests/sources/mut_ref_accross_modules.move:118:10: private_to_public_caller_invalid_data_invariant
+    =         r = <redacted>
+
+error:  A precondition for this call might not hold.
+
+    ┌── tests/sources/mut_ref_accross_modules.move:25:9 ───
+    │
+ 25 │         invariant global<TSum>(0x0).sum == spec_sum;
+    │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    │
+    =     at tests/sources/mut_ref_accross_modules.move:104:6: private_to_public_caller_invalid_precondition (entry)
+    =     at tests/sources/mut_ref_accross_modules.move:46:5: increment (entry)

--- a/language/move-prover/tests/sources/mut_ref_accross_modules.move
+++ b/language/move-prover/tests/sources/mut_ref_accross_modules.move
@@ -3,53 +3,122 @@ module TestMutRefs {
 
     struct T { value: u64 }
 
+    // Resource to track the sum of values in T
     resource struct TSum {
         sum: u64
     }
 
     spec struct T {
+        // global specification variable tracking sum of values.
         global spec_sum: u64;
 
-        invariant update value > old(value);
+        // Data invariant.
+        invariant value > 0;
+
+        // Pack/unpack invariants updating spec var
         invariant pack spec_sum = spec_sum + value;
         invariant unpack spec_sum = spec_sum - value;
     }
 
     spec module {
+        // Module invariant that the tracked resource sum equals the spec sum
         invariant global<TSum>(0x0).sum == spec_sum;
     }
 
+    // This succeeds because module invariant can be assumed on entry (public function) and is maintained on exit.
     public fun new(x: u64): T acquires TSum {
         let r = borrow_global_mut<TSum>(0x0);
         r.sum = r.sum + x;
         T{value: x}
     }
+    spec fun new {
+        requires x > 0;
+    }
 
+    // This succeeds because module invariant can be assumed on entry (public function) and is maintained on exit.
     public fun delete(x: T) acquires TSum {
         let r = borrow_global_mut<TSum>(0x0);
         let T{value: v} = x;
         r.sum = r.sum - v;
     }
 
+    // This succeeds because module invariant can be assumed on entry (public function) and is maintained on exit.
     public fun increment(x: &mut T) acquires TSum {
         x.value = x.value + 1;
         let r = borrow_global_mut<TSum>(0x0);
         r.sum = r.sum + 1;
     }
 
-    // This should fail because the update invariant requires strict monotonic increase of the value.
-    // TODO: we see this error only when we comment out the next function. Need to determine where this
-    //   comes from, as we usually see Boogie reporting all errors, and not aborting after the first one.
+    // This should fail because we do not update the TSum resource.
+    public fun increment_invalid(x: &mut T) {
+        x.value = x.value + 1;
+    }
+
+    // This should fail because we violate the data invariant (value always > 0). The data invariant is enforced
+    // on exit even though it works on a mut ref since this is a public method.
     public fun decrement_invalid(x: &mut T) acquires TSum {
         x.value = x.value - 1;
         let r = borrow_global_mut<TSum>(0x0);
         r.sum = r.sum - 1;
     }
 
-    // This should fail because we do not update the TSum resource.
-    public fun increment_invalid(x: &mut T) {
-        x.value = x.value + 1;
+    // This one is exactly the same as the previous but succeeds since it is private. The data invariant is not
+    // enforced because the mut ref is manipulated privately.
+    fun private_decrement(x: &mut T) acquires TSum {
+        x.value = x.value - 1;
+        let r = borrow_global_mut<TSum>(0x0);
+        r.sum = r.sum - 1;
     }
+
+    // For a public function, the data invariant for a mut ref is expected to hold.
+    public fun data_invariant(x: &mut T) {
+        spec {
+            assert x.value > 0;
+        }
+    }
+
+    // For a private function, the data invariant for a mut ref is not expected to hold.
+    // TODO: this currently does not fail because of #3076
+    fun private_data_invariant_invalid(x: &mut T) {
+        spec {
+            assert x.value > 0;
+        }
+    }
+
+    // The next function should succeed because calling a public function from a private one maintains module
+    // invariants.
+    fun private_to_public_caller(r: &mut T) acquires TSum {
+        // Before call to public increment, module invariant must hold. Here we specialize it to start with a zero sum.
+        spec {
+            assume spec_sum == 0;
+            assume global<TSum>(0x0).sum == spec_sum;
+        };
+        increment(r);
+        // After call to increment, we expect spec_sum to be incremented.
+        spec {
+            assert spec_sum == 1;
+        };
+    }
+
+     // The next function fails because module invariant doesn't hold before calling public function.
+     fun private_to_public_caller_invalid_precondition(r: &mut T) acquires TSum {
+         increment(r);
+     }
+
+     // The next function fails because the data invariant does not hold.
+     fun private_to_public_caller_invalid_data_invariant() acquires TSum {
+         // Before call to public new(), assume module invariant.
+         spec {
+            assume global<TSum>(0x0).sum == spec_sum;
+         };
+         let x = new(1);
+         let r = &mut x;
+         // The next call will lead to violation of data invariant. However, because it is private, no
+         // problem reported yet.
+         private_decrement(r);
+         // The next call enforces both module and data invariants.
+         increment(r);
+     }
 }
 
 module TestMutRefsUser {


### PR DESCRIPTION
This adds the remaining open piece when dealing with `&mut` parameters. In a previous PR, we added the general functionality that on calls to public functions, data and update invariants of `&mut` parameters can be assumed, and that on exist they are assserted, independent of mutation lifetime. In this PR we treat this also correctly for calls from private to public methods within the same module. In such calls, all parameters which are currently mutated by the caller need to be frozen (update invariants enforced) to match the assumptions of a public entry point. Moreover, after the call returns, we need to unfreeze, and take the current value of the reference as a new 'before' value for the mutation lifetime.

This PR also fixes a bug with analysis of Boogie output in the presence of assertions (i.e. not ensures or requires). Previously, the boogie_wrapper incorrectly parsed such entries, resulting in skipping some and/or merging execution traces of independent errors wrongly into one.

## Motivation

Invariants and global specs.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

Added new tests.

## Related PRs

NA
