### PR TITLE
[terraform] Setup push gateway for stats from safety-rules

### DIFF
--- a/terraform/monitoring.tf
+++ b/terraform/monitoring.tf
@@ -186,6 +186,7 @@ data "template_file" "ecs_monitoring_definition" {
 
   vars = {
     prometheus_image   = "prom/prometheus:v2.9.2"
+    pushgateway_image  = "prom/pushgateway:v1.2.0"
     alertmanager_image = "prom/alertmanager:v0.17.0"
     grafana_image      = "grafana/grafana:latest"
   }

--- a/terraform/network.tf
+++ b/terraform/network.tf
@@ -79,6 +79,15 @@ resource "aws_security_group_rule" "monitoring-prometheus" {
   ipv6_cidr_blocks  = var.ssh_sources_ipv6
 }
 
+resource "aws_security_group_rule" "monitoring-pushgateway" {
+  security_group_id        = aws_security_group.monitoring.id
+  type                     = "ingress"
+  from_port                = 9092
+  to_port                  = 9092
+  protocol                 = "tcp"
+  source_security_group_id = aws_security_group.validator.id
+}
+
 resource "aws_security_group_rule" "monitoring-egress" {
   security_group_id = aws_security_group.monitoring.id
   type              = "egress"

--- a/terraform/templates/monitoring.json
+++ b/terraform/templates/monitoring.json
@@ -2,8 +2,8 @@
     {
         "name": "prometheus",
         "image": "${prometheus_image}",
-        "cpu": 1280,
-        "memory": 2088,
+        "cpu": 1024,
+        "memory": 2048,
         "essential": true,
         "portMappings": [
             {"containerPort": 9090, "hostPort": 9090}
@@ -21,10 +21,20 @@
         ]
     },
     {
+        "name": "pushgateway",
+        "image": "${pushgateway_image}",
+        "cpu": 256,
+        "memory": 256,
+        "essential": true,
+        "portMappings": [
+            {"containerPort": 9091, "hostPort": 9092}
+        ]
+    },
+    {
         "name": "alertmanager",
         "image": "${alertmanager_image}",
-        "cpu": 384,
-        "memory": 768,
+        "cpu": 256,
+        "memory": 512,
         "essential": true,
         "portMappings": [
             {"containerPort": 9093, "hostPort": 9093}
@@ -41,7 +51,7 @@
     {
         "name": "grafana",
         "image": "${grafana_image}",
-        "cpu": 384,
+        "cpu": 512,
         "memory": 1024,
         "essential": true,
         "portMappings": [

--- a/terraform/templates/prometheus.yml
+++ b/terraform/templates/prometheus.yml
@@ -21,15 +21,18 @@ rule_files:
 scrape_configs:
   # The job name is added as a label `job=<job_name>` to any timeseries scraped from this config.
   - job_name: 'prometheus'
-
-    # metrics_path defaults to '/metrics'
-    # scheme defaults to 'http'.
-
     static_configs:
       - targets: ['localhost:9090']
         labels:
           workspace: '${workspace}'
           role: 'prometheus'
+
+  - job_name: 'pushgateway'
+    honor_labels: true
+    static_configs:
+      - targets: ['${monitoring_private_ip}:9092']
+        labels:
+          workspace: '${workspace}'
 
   - job_name: 'other_nodes'
     static_configs:

--- a/terraform/templates/validator.json
+++ b/terraform/templates/validator.json
@@ -85,6 +85,7 @@
             {"sourceVolume": "libra-data", "containerPath": "/opt/libra/data"}
         ],
         "environment": [
+            {"name": "PUSH_METRICS_ENDPOINT", "value": "${push_metrics_endpoint}"},
             {"name": "CFG_NODE_INDEX", "value": "${cfg_node_index}"},
             {"name": "CFG_NUM_VALIDATORS", "value": "${cfg_num_validators}"},
             {"name": "CFG_SEED", "value": "${cfg_seed}"},

--- a/terraform/validators.tf
+++ b/terraform/validators.tf
@@ -218,6 +218,7 @@ data "template_file" "ecs_task_definition" {
     logstash_config            = local.logstash_config
     safety_rules_image         = local.safety_rules_image_repo
     safety_rules_image_version = local.safety_rules_image_version
+    push_metrics_endpoint      = "http://${aws_instance.monitoring.private_ip}:9092/metrics/job/safety_rules/role/validator/peer_id/val-${count.index}"
     cfg_vault_addr             = "http://${aws_instance.vault.private_ip}:8200"
     cfg_vault_namespace        = "val-${count.index}"
     use_vault                  = var.safety_rules_use_vault


### PR DESCRIPTION
Run push gateway in the monitoring service, and configure safety-rules
to send metrics to it.

Test Plan: Deployed to my workspace, checked that safety-rules metrics
were in prometheus.