### PR TITLE
[libra db] add ascending as param for get_events

### DIFF
--- a/consensus/src/chained_bft/liveness/leader_reputation.rs
+++ b/consensus/src/chained_bft/liveness/leader_reputation.rs
@@ -44,6 +44,7 @@ impl LibraDBBackend {
         let events = self.libra_db.get_events(
             &new_block_event_key(),
             u64::max_value(),
+            false,
             self.window_size as u64 + buffer,
         )?;
         let mut result = vec![];

--- a/json-rpc/src/methods.rs
+++ b/json-rpc/src/methods.rs
@@ -199,7 +199,7 @@ async fn get_events(service: JsonRpcService, params: Vec<Value>) -> Result<Vec<E
     let limit: u64 = serde_json::from_value(params[2].clone())?;
 
     let event_key = EventKey::try_from(&hex::decode(raw_event_key)?[..])?;
-    let events_with_proof = service.db.get_events(&event_key, start, limit)?;
+    let events_with_proof = service.db.get_events(&event_key, start, true, limit)?;
 
     let mut events = vec![];
     for (version, event) in events_with_proof {

--- a/json-rpc/src/tests/mock_db.rs
+++ b/json-rpc/src/tests/mock_db.rs
@@ -164,6 +164,7 @@ impl LibraDBTrait for MockLibraDB {
         &self,
         key: &EventKey,
         start: u64,
+        _ascending: bool,
         limit: u64,
     ) -> Result<Vec<(u64, ContractEvent)>> {
         let events = self

--- a/storage/libradb/src/lib.rs
+++ b/storage/libradb/src/lib.rs
@@ -162,6 +162,7 @@ pub trait LibraDBTrait: Send + Sync {
         &self,
         event_key: &EventKey,
         start: u64,
+        ascending: bool,
         limit: u64,
     ) -> Result<Vec<(u64, ContractEvent)>>;
 
@@ -890,6 +891,7 @@ impl LibraDBTrait for LibraDB {
         &self,
         event_key: &EventKey,
         start: u64,
+        ascending: bool,
         limit: u64,
     ) -> Result<Vec<(u64, ContractEvent)>> {
         let version = self
@@ -898,7 +900,7 @@ impl LibraDBTrait for LibraDB {
             .ledger_info()
             .version();
         let events = self
-            .get_events_by_event_key(event_key, start, true, limit, version)?
+            .get_events_by_event_key(event_key, start, ascending, limit, version)?
             .into_iter()
             .map(|e| (e.transaction_version, e.event))
             .collect();


### PR DESCRIPTION
<!--
Thank you for sending a PR. We appreciate you spending time to help improve the Libra project.

The project is undergoing daily changes. Pull Requests will be reviewed and responded to as time permits.
-->

## Motivation

To support querying latest events and ascending queries.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?

Y

## Test Plan

Existing tests.

## Related PRs

(If this PR adds or changes functionality, please take some time to update the docs at https://github.com/libra/website, and link to your PR here.)
