### PR TITLE
[storage] trivial: move all get_startup_info() logic to the ledger store

### DIFF
--- a/storage/libradb/src/ledger_store/ledger_info_test.rs
+++ b/storage/libradb/src/ledger_store/ledger_info_test.rs
@@ -132,13 +132,13 @@ proptest! {
         let tmp_dir = TempPath::new();
         let db = set_up(&tmp_dir, &ledger_infos_with_sigs);
 
-        let (actual_latest_li, actual_vs_opt) = db.ledger_store.get_startup_info().unwrap().unwrap();
+        let startup_info = db.ledger_store.get_startup_info().unwrap().unwrap();
 
         let expected_latest_li = ledger_infos_with_sigs.last().unwrap();
-        prop_assert_eq!(&actual_latest_li, expected_latest_li);
+        prop_assert_eq!(&startup_info.latest_ledger_info, expected_latest_li);
 
         if expected_latest_li.ledger_info().next_validator_set().is_some() {
-            prop_assert_eq!(actual_vs_opt, None);
+            prop_assert_eq!(startup_info.latest_validator_set, None);
         } else {
             let expected_vs_opt = ledger_infos_with_sigs
                 .iter()
@@ -146,7 +146,7 @@ proptest! {
                 .filter_map(|x| x.ledger_info().next_validator_set().cloned())
                 .next()
                 .unwrap();
-            prop_assert_eq!(actual_vs_opt.unwrap(), expected_vs_opt);
+            prop_assert_eq!(startup_info.latest_validator_set.unwrap(), expected_vs_opt);
         }
     }
 }

--- a/types/src/transaction/mod.rs
+++ b/types/src/transaction/mod.rs
@@ -49,6 +49,8 @@ use std::ops::Deref;
 pub use transaction_argument::{parse_as_transaction_argument, TransactionArgument};
 
 pub type Version = u64; // Height - also used for MVCC in StateDB
+                        // In StateDB, things readable by the genesis transaction are under this version.
+pub const PRE_GENESIS_VERSION: Version = u64::max_value();
 
 // In StateDB, things readable by the genesis transaction are under this version.
 pub const PRE_GENESIS_VERSION: Version = u64::max_value();

--- a/types/src/transaction/mod.rs
+++ b/types/src/transaction/mod.rs
@@ -49,7 +49,8 @@ use std::ops::Deref;
 pub use transaction_argument::{parse_as_transaction_argument, TransactionArgument};
 
 pub type Version = u64; // Height - also used for MVCC in StateDB
-                        // In StateDB, things readable by the genesis transaction are under this version.
+
+// In StateDB, things readable by the genesis transaction are under this version.
 pub const PRE_GENESIS_VERSION: Version = u64::max_value();
 
 // In StateDB, things readable by the genesis transaction are under this version.

--- a/types/src/transaction/mod.rs
+++ b/types/src/transaction/mod.rs
@@ -53,9 +53,6 @@ pub type Version = u64; // Height - also used for MVCC in StateDB
 // In StateDB, things readable by the genesis transaction are under this version.
 pub const PRE_GENESIS_VERSION: Version = u64::max_value();
 
-// In StateDB, things readable by the genesis transaction are under this version.
-pub const PRE_GENESIS_VERSION: Version = u64::max_value();
-
 pub const MAX_TRANSACTION_SIZE_IN_BYTES: usize = 4096;
 
 /// RawTransaction is the portion of a transaction that a client signs


### PR DESCRIPTION

## Motivation
Because it belongs there and it makes little sense to split it between the store and the LibraDB.
It's more readable this way.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?

(Write your answer here.)
Yes

## Test Plan

(Share your test plan here. If you changed code, please provide us with clear instructions for verifying that your changes work.)
existing coverage.
## Related PRs

(If this PR adds or changes functionality, please take some time to update the docs at https://github.com/libra/website, and link to your PR here.)
