### PR TITLE
[types] Rename Transaction::WriteSet to WaypointWriteSet.

### DIFF
--- a/config/config-builder/src/validator_config.rs
+++ b/config/config-builder/src/validator_config.rs
@@ -11,7 +11,7 @@ use libra_config::{
     generator,
 };
 use libra_crypto::{ed25519::Ed25519PrivateKey, PrivateKey, Uniform};
-use libra_types::{transaction::Transaction, validator_set::ValidatorSet};
+use libra_types::validator_set::ValidatorSet;
 use parity_multiaddr::Multiaddr;
 use rand::{rngs::StdRng, Rng, SeedableRng};
 use std::{collections::HashMap, net::SocketAddr};
@@ -194,19 +194,16 @@ impl ValidatorConfig {
         );
         let discovery_set = vm_genesis::make_placeholder_discovery_set(&validator_set);
 
-        let genesis = Some(Transaction::UserTransaction(
-            vm_genesis::encode_genesis_transaction_with_validator(
-                &faucet_key,
-                faucet_key.public_key(),
-                &validator_swarm.nodes,
-                validator_set,
-                discovery_set,
-                self.template
-                    .test
-                    .as_ref()
-                    .and_then(|config| config.publishing_option.clone()),
-            )
-            .into_inner(),
+        let genesis = Some(vm_genesis::encode_genesis_transaction_with_validator(
+            &faucet_key,
+            faucet_key.public_key(),
+            &validator_swarm.nodes,
+            validator_set,
+            discovery_set,
+            self.template
+                .test
+                .as_ref()
+                .and_then(|config| config.publishing_option.clone()),
         ));
 
         for node in &mut validator_swarm.nodes {

--- a/config/src/config/execution_config.rs
+++ b/config/src/config/execution_config.rs
@@ -93,7 +93,7 @@ mod test {
 
     #[test]
     fn test_some_and_load_genesis() {
-        let fake_genesis = Transaction::AuthenticatedWriteSet(ChangeSet::new(
+        let fake_genesis = Transaction::WaypointWriteSet(ChangeSet::new(
             WriteSetMut::new(vec![]).freeze().unwrap(),
             vec![],
         ));

--- a/config/src/config/execution_config.rs
+++ b/config/src/config/execution_config.rs
@@ -53,7 +53,6 @@ impl ExecutionConfig {
             let mut file = File::open(&path)?;
             let mut buffer = vec![];
             file.read_to_end(&mut buffer)?;
-            // TODO: update to use `Transaction::WriteSet` variant when ready.
             self.genesis = Some(lcs::from_bytes(&buffer)?);
         }
 
@@ -94,7 +93,7 @@ mod test {
 
     #[test]
     fn test_some_and_load_genesis() {
-        let fake_genesis = Transaction::WriteSet(ChangeSet::new(
+        let fake_genesis = Transaction::AuthenticatedWriteSet(ChangeSet::new(
             WriteSetMut::new(vec![]).freeze().unwrap(),
             vec![],
         ));

--- a/execution/executor/src/lib.rs
+++ b/execution/executor/src/lib.rs
@@ -730,7 +730,7 @@ where
                     // should not reach this code path. The exception is genesis transaction (and
                     // maybe other writeset transactions).
                     match transaction {
-                        Transaction::AuthenticatedWriteSet(_) => (),
+                        Transaction::WaypointWriteSet(_) => (),
                         Transaction::BlockMetadata(_) => {
                             bail!("Write set should be a subset of read set.")
                         }

--- a/execution/executor/src/lib.rs
+++ b/execution/executor/src/lib.rs
@@ -731,8 +731,9 @@ where
                     // maybe other writeset transactions).
                     match transaction {
                         Transaction::AuthenticatedWriteSet(_) => (),
-                        Transaction::BlockMetadata(_) =>
-                            bail!("Write set should be a subset of read set."),
+                        Transaction::BlockMetadata(_) => {
+                            bail!("Write set should be a subset of read set.")
+                        }
                         Transaction::UserTransaction(txn) => match txn.payload() {
                             TransactionPayload::Program
                             | TransactionPayload::Module(_)
@@ -740,7 +741,7 @@ where
                                 bail!("Write set should be a subset of read set.")
                             }
                             TransactionPayload::WriteSet(_) => (),
-                        }
+                        },
                     }
 
                     let mut account_state = Default::default();

--- a/execution/executor/src/lib.rs
+++ b/execution/executor/src/lib.rs
@@ -728,14 +728,19 @@ where
                 hash_map::Entry::Vacant(entry) => {
                     // Before writing to an account, VM should always read that account. So we
                     // should not reach this code path. The exception is genesis transaction (and
-                    // maybe other FTVM transactions).
-                    match transaction.as_signed_user_txn()?.payload() {
-                        TransactionPayload::Program
-                        | TransactionPayload::Module(_)
-                        | TransactionPayload::Script(_) => {
-                            bail!("Write set should be a subset of read set.")
+                    // maybe other writeset transactions).
+                    match transaction {
+                        Transaction::AuthenticatedWriteSet(_) => (),
+                        Transaction::BlockMetadata(_) =>
+                            bail!("Write set should be a subset of read set."),
+                        Transaction::UserTransaction(txn) => match txn.payload() {
+                            TransactionPayload::Program
+                            | TransactionPayload::Module(_)
+                            | TransactionPayload::Script(_) => {
+                                bail!("Write set should be a subset of read set.")
+                            }
+                            TransactionPayload::WriteSet(_) => (),
                         }
-                        TransactionPayload::WriteSet(_) => (),
                     }
 
                     let mut account_state = Default::default();

--- a/json-rpc/src/tests/unit_tests.rs
+++ b/json-rpc/src/tests/unit_tests.rs
@@ -435,7 +435,7 @@ fn test_get_transactions_impl(blocks: Vec<(Vec<TransactionToCommit>, LedgerInfoW
                             }
                             _ => panic!("Returned value doesn't match!"),
                         },
-                        Transaction::WriteSet(_) => match view.transaction {
+                        Transaction::AuthenticatedWriteSet(_) => match view.transaction {
                             TransactionDataView::WriteSet { .. } => {}
                             _ => panic!("Returned value doesn't match!"),
                         },

--- a/json-rpc/src/tests/unit_tests.rs
+++ b/json-rpc/src/tests/unit_tests.rs
@@ -435,7 +435,7 @@ fn test_get_transactions_impl(blocks: Vec<(Vec<TransactionToCommit>, LedgerInfoW
                             }
                             _ => panic!("Returned value doesn't match!"),
                         },
-                        Transaction::AuthenticatedWriteSet(_) => match view.transaction {
+                        Transaction::WaypointWriteSet(_) => match view.transaction {
                             TransactionDataView::WriteSet { .. } => {}
                             _ => panic!("Returned value doesn't match!"),
                         },

--- a/json-rpc/src/views.rs
+++ b/json-rpc/src/views.rs
@@ -221,7 +221,7 @@ impl From<Transaction> for TransactionDataView {
                     timestamp_usecs: x.1,
                 })
             }
-            Transaction::AuthenticatedWriteSet(_) => Ok(TransactionDataView::WriteSet {}),
+            Transaction::WaypointWriteSet(_) => Ok(TransactionDataView::WriteSet {}),
             Transaction::UserTransaction(t) => {
                 let script_hash = match t.payload() {
                     TransactionPayload::Script(s) => HashValue::from_sha3_256(s.code()),

--- a/json-rpc/src/views.rs
+++ b/json-rpc/src/views.rs
@@ -221,7 +221,7 @@ impl From<Transaction> for TransactionDataView {
                     timestamp_usecs: x.1,
                 })
             }
-            Transaction::WriteSet(_) => Ok(TransactionDataView::WriteSet {}),
+            Transaction::AuthenticatedWriteSet(_) => Ok(TransactionDataView::WriteSet {}),
             Transaction::UserTransaction(t) => {
                 let script_hash = match t.payload() {
                     TransactionPayload::Script(s) => HashValue::from_sha3_256(s.code()),

--- a/language/libra-vm/src/libra_vm.rs
+++ b/language/libra-vm/src/libra_vm.rs
@@ -764,7 +764,7 @@ pub fn chunk_block_transactions(txns: Vec<Transaction>) -> Vec<TransactionBlock>
                 }
                 blocks.push(TransactionBlock::BlockPrologue(data));
             }
-            Transaction::AuthenticatedWriteSet(cs) => {
+            Transaction::WaypointWriteSet(cs) => {
                 if !buf.is_empty() {
                     blocks.push(TransactionBlock::UserTransaction(buf));
                     buf = vec![];

--- a/language/libra-vm/src/libra_vm.rs
+++ b/language/libra-vm/src/libra_vm.rs
@@ -764,7 +764,7 @@ pub fn chunk_block_transactions(txns: Vec<Transaction>) -> Vec<TransactionBlock>
                 }
                 blocks.push(TransactionBlock::BlockPrologue(data));
             }
-            Transaction::WriteSet(cs) => {
+            Transaction::AuthenticatedWriteSet(cs) => {
                 if !buf.is_empty() {
                     blocks.push(TransactionBlock::UserTransaction(buf));
                     buf = vec![];

--- a/language/libra-vm/src/unit_tests/block_chunking_test.rs
+++ b/language/libra-vm/src/unit_tests/block_chunking_test.rs
@@ -9,7 +9,7 @@ fn reconstruct_transaction_vec(blocks: Vec<TransactionBlock>) -> Vec<Transaction
     let mut txns = vec![];
     for block in blocks {
         match block {
-            TransactionBlock::WriteSet(ws) => txns.push(Transaction::AuthenticatedWriteSet(ws)),
+            TransactionBlock::WriteSet(ws) => txns.push(Transaction::WaypointWriteSet(ws)),
             TransactionBlock::BlockPrologue(ws) => txns.push(Transaction::BlockMetadata(ws)),
             TransactionBlock::UserTransaction(user_txns) => {
                 assert!(!user_txns.is_empty());
@@ -33,7 +33,7 @@ proptest! {
         let check = txns.iter().zip(result.iter()).all(|(l, r)| {
             if let Transaction::UserTransaction(txn) = l {
                 if let TransactionPayload::WriteSet(ws_l) = txn.payload() {
-                    return matches!(r, Transaction::AuthenticatedWriteSet(ws_r) if ws_l == ws_r);
+                    return matches!(r, Transaction::WaypointWriteSet(ws_r) if ws_l == ws_r);
                 }
             }
             l == r

--- a/language/libra-vm/src/unit_tests/block_chunking_test.rs
+++ b/language/libra-vm/src/unit_tests/block_chunking_test.rs
@@ -9,7 +9,7 @@ fn reconstruct_transaction_vec(blocks: Vec<TransactionBlock>) -> Vec<Transaction
     let mut txns = vec![];
     for block in blocks {
         match block {
-            TransactionBlock::WriteSet(ws) => txns.push(Transaction::WriteSet(ws)),
+            TransactionBlock::WriteSet(ws) => txns.push(Transaction::AuthenticatedWriteSet(ws)),
             TransactionBlock::BlockPrologue(ws) => txns.push(Transaction::BlockMetadata(ws)),
             TransactionBlock::UserTransaction(user_txns) => {
                 assert!(!user_txns.is_empty());
@@ -33,7 +33,7 @@ proptest! {
         let check = txns.iter().zip(result.iter()).all(|(l, r)| {
             if let Transaction::UserTransaction(txn) = l {
                 if let TransactionPayload::WriteSet(ws_l) = txn.payload() {
-                    return matches!(r, Transaction::WriteSet(ws_r) if ws_l == ws_r);
+                    return matches!(r, Transaction::AuthenticatedWriteSet(ws_r) if ws_l == ws_r);
                 }
             }
             l == r

--- a/language/tools/vm-genesis/src/lib.rs
+++ b/language/tools/vm-genesis/src/lib.rs
@@ -214,7 +214,7 @@ pub fn encode_genesis_transaction(
     stdlib_modules: &[VerifiedModule],
     vm_publishing_option: VMPublishingOption,
 ) -> Transaction {
-    Transaction::AuthenticatedWriteSet(encode_genesis_change_set(
+    Transaction::WaypointWriteSet(encode_genesis_change_set(
         &public_key,
         nodes,
         validator_set,

--- a/language/tools/vm-genesis/src/lib.rs
+++ b/language/tools/vm-genesis/src/lib.rs
@@ -24,9 +24,7 @@ use libra_types::{
     discovery_set::DiscoverySet,
     language_storage::ModuleId,
     on_chain_config::VMPublishingOption,
-    transaction::{
-        authenticator::AuthenticationKey, ChangeSet, RawTransaction, SignatureCheckedTransaction,
-    },
+    transaction::{authenticator::AuthenticationKey, ChangeSet, Transaction},
     validator_set::ValidatorSet,
 };
 use libra_vm::system_module_names::*;
@@ -132,7 +130,7 @@ pub fn encode_genesis_transaction_with_validator(
     validator_set: ValidatorSet,
     discovery_set: DiscoverySet,
     vm_publishing_option: Option<VMPublishingOption>,
-) -> SignatureCheckedTransaction {
+) -> Transaction {
     encode_genesis_transaction(
         private_key,
         public_key,
@@ -208,28 +206,22 @@ pub fn encode_genesis_change_set(
 }
 
 pub fn encode_genesis_transaction(
-    private_key: &Ed25519PrivateKey,
+    _private_key: &Ed25519PrivateKey,
     public_key: Ed25519PublicKey,
     nodes: &[NodeConfig],
     validator_set: ValidatorSet,
     discovery_set: DiscoverySet,
     stdlib_modules: &[VerifiedModule],
     vm_publishing_option: VMPublishingOption,
-) -> SignatureCheckedTransaction {
-    let genesis_change_set = encode_genesis_change_set(
+) -> Transaction {
+    Transaction::AuthenticatedWriteSet(encode_genesis_change_set(
         &public_key,
         nodes,
         validator_set,
         discovery_set,
         stdlib_modules,
         vm_publishing_option,
-    );
-    let transaction = RawTransaction::new_change_set(
-        account_config::association_address(),
-        0,
-        genesis_change_set,
-    );
-    transaction.sign(private_key, public_key).unwrap()
+    ))
 }
 
 /// Create an initialize Association, Transaction Fee and Core Code accounts.

--- a/testsuite/generate-format/tests/staged/libra.yaml
+++ b/testsuite/generate-format/tests/staged/libra.yaml
@@ -101,7 +101,7 @@ Transaction:
         NEWTYPE:
           TYPENAME: SignedTransaction
     1:
-      WriteSet:
+      AuthenticatedWriteSet:
         NEWTYPE:
           TYPENAME: ChangeSet
     2:

--- a/testsuite/generate-format/tests/staged/libra.yaml
+++ b/testsuite/generate-format/tests/staged/libra.yaml
@@ -101,7 +101,7 @@ Transaction:
         NEWTYPE:
           TYPENAME: SignedTransaction
     1:
-      AuthenticatedWriteSet:
+      WaypointWriteSet:
         NEWTYPE:
           TYPENAME: ChangeSet
     2:

--- a/types/src/transaction/mod.rs
+++ b/types/src/transaction/mod.rs
@@ -1127,7 +1127,7 @@ pub enum Transaction {
 
     /// Transaction that applies a WriteSet to the current storage. This should be used for ONLY for
     /// genesis right now.
-    AuthenticatedWriteSet(ChangeSet),
+    WaypointWriteSet(ChangeSet),
 
     /// Transaction to update the block metadata resource at the beginning of a block.
     BlockMetadata(BlockMetadata),
@@ -1147,7 +1147,7 @@ impl Transaction {
                 user_txn.format_for_client(get_transaction_name)
             }
             // TODO: display proper information for client
-            Transaction::AuthenticatedWriteSet(_write_set) => String::from("genesis"),
+            Transaction::WaypointWriteSet(_write_set) => String::from("genesis"),
             // TODO: display proper information for client
             Transaction::BlockMetadata(_block_metadata) => String::from("block_metadata"),
         }

--- a/types/src/transaction/mod.rs
+++ b/types/src/transaction/mod.rs
@@ -1127,7 +1127,7 @@ pub enum Transaction {
 
     /// Transaction that applies a WriteSet to the current storage. This should be used for ONLY for
     /// genesis right now.
-    WriteSet(ChangeSet),
+    AuthenticatedWriteSet(ChangeSet),
 
     /// Transaction to update the block metadata resource at the beginning of a block.
     BlockMetadata(BlockMetadata),
@@ -1147,7 +1147,7 @@ impl Transaction {
                 user_txn.format_for_client(get_transaction_name)
             }
             // TODO: display proper information for client
-            Transaction::WriteSet(_write_set) => String::from("genesis"),
+            Transaction::AuthenticatedWriteSet(_write_set) => String::from("genesis"),
             // TODO: display proper information for client
             Transaction::BlockMetadata(_block_metadata) => String::from("block_metadata"),
         }


### PR DESCRIPTION
<!--
Thank you for sending a PR. We appreciate you spending time to help improve the Libra project.

The project is undergoing daily changes. Pull Requests will be reviewed and responded to as time permits.
-->

## Motivation

Rename  `Transaction::WriteSet` to `WaypointWriteSet`. In the future, `WaypointWriteSet` will be the entry point for applying writesets manually after waypoint. Genesis transaction will be the very first example of this mechanism.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?

Yes
