### PR TITLE
[docker] add storage inspector binary to validator

### DIFF
--- a/docker/validator/Dockerfile
+++ b/docker/validator/Dockerfile
@@ -16,7 +16,7 @@ FROM toolchain AS builder
 
 COPY . /libra
 
-RUN cargo build --release -p libra-node -p cli -p config-builder -p safety-rules && cd target/release && rm -r build deps incremental
+RUN cargo build --release -p libra-node -p cli -p config-builder -p safety-rules -p libra-storage-inspector && cd target/release && rm -r build deps incremental
 RUN strip /libra/target/release/config-builder
 
 ### Production Image ###
@@ -28,6 +28,7 @@ RUN mkdir -p /opt/libra/bin /opt/libra/etc
 COPY docker/install-tools.sh /root
 COPY --from=builder /libra/target/release/libra-node /opt/libra/bin
 COPY --from=builder /libra/target/release/config-builder /opt/libra/bin
+COPY --from=builder /libra/target/release/libra-storage-inspector /opt/libra/bin
 
 # Admission control
 EXPOSE 8000


### PR DESCRIPTION
<!--
Thank you for sending a PR. We appreciate you spending time to help improve the Libra project.

The project is undergoing daily changes. Pull Requests will be reviewed and responded to as time permits.
-->

## Motivation

Adds libra-storage-inspector to validator Docker image for debugging purposes.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan



## Related PRs

(If this PR adds or changes functionality, please take some time to update the docs at https://github.com/libra/website, and link to your PR here.)
