### PR TITLE
[move-prover] Modeled hash.move native library.

### DIFF
--- a/language/move-prover/tests/sources/hash_model.exp
+++ b/language/move-prover/tests/sources/hash_model.exp
@@ -1,0 +1,1 @@
+Move prover all good, no errors!

--- a/language/move-prover/tests/sources/hash_model.move
+++ b/language/move-prover/tests/sources/hash_model.move
@@ -1,0 +1,61 @@
+// dep: tests/sources/stdlib/modules/hash.move
+
+module TestHash {
+
+    use 0x0::Hash;
+
+    // sha2 tests
+
+    fun hash_test1(v1: vector<u8>, v2: vector<u8>): (vector<u8>, vector<u8>)
+    {
+        let h1 = Hash::sha2_256(v1);
+        let h2 = Hash::sha2_256(v2);
+        (h1, h2)
+    }
+    spec fun hash_test1 {
+        aborts_if false;
+        ensures result_1 == result_2 ==> v1 == v2;
+        ensures v1 == v2 ==> result_1 == result_2;
+        ensures len(result_1) == 32;
+        // it knows result is vector<u8>
+        ensures len(result_1) > 0 ==> result_1[0] <= max_u8();
+    }
+
+    fun hash_test2(v1: vector<u8>, v2: vector<u8>): bool
+    {
+        let h1 = Hash::sha2_256(v1);
+        let h2 = Hash::sha2_256(v2);
+        h1 == h2
+    }
+    spec fun hash_test2 {
+        aborts_if false;
+        ensures result == (v1 == v2);
+    }
+
+    // sha3 tests
+    fun hash_test3(v1: vector<u8>, v2: vector<u8>): (vector<u8>, vector<u8>)
+    {
+        let h1 = Hash::sha3_256(v1);
+        let h2 = Hash::sha3_256(v2);
+        (h1, h2)
+    }
+    spec fun hash_test3 {
+        aborts_if false;
+        ensures result_1 == result_2 ==> v1 == v2;
+        ensures v1 == v2 ==> result_1 == result_2;
+        ensures len(result_1) == 32;
+        // it knows result is vector<u8>
+        ensures len(result_1) > 0 ==> result_1[0] <= max_u8();
+    }
+
+    fun hash_test4(v1: vector<u8>, v2: vector<u8>): bool
+    {
+        let h1 = Hash::sha3_256(v1);
+        let h2 = Hash::sha3_256(v2);
+        h1 == h2
+    }
+    spec fun hash_test4 {
+        aborts_if false;
+        ensures result == (v1 == v2);
+    }
+}

--- a/language/move-prover/tests/sources/hash_model_invalid.exp
+++ b/language/move-prover/tests/sources/hash_model_invalid.exp
@@ -1,0 +1,47 @@
+Move prover returns: exiting with boogie verification errors
+error:  A postcondition might not hold on this return path.
+
+    ┌── tests/sources/hash_model_invalid.move:16:9 ───
+    │
+ 16 │         ensures result_1 == result_2;
+    │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    │
+    =     at tests/sources/hash_model_invalid.move:8:5: hash_test1 (entry)
+    =     at tests/sources/hash_model_invalid.move:10:24: hash_test1
+    =         v1 = <redacted>,
+    =         v2 = <redacted>,
+    =         h1 = <redacted>
+    =     at tests/sources/hash_model_invalid.move:11:33: hash_test1
+    =         h2 = <redacted>
+    =     at tests/sources/hash_model_invalid.move:12:10: hash_test1
+    =     at tests/sources/hash_model_invalid.move:8:5: hash_test1 (exit)
+
+error:  A postcondition might not hold on this return path.
+
+    ┌── tests/sources/hash_model_invalid.move:29:9 ───
+    │
+ 29 │         ensures result_1 == result_2;
+    │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    │
+    =     at tests/sources/hash_model_invalid.move:21:5: hash_test2 (entry)
+    =     at tests/sources/hash_model_invalid.move:23:24: hash_test2
+    =         v1 = <redacted>,
+    =         v2 = <redacted>,
+    =         h1 = <redacted>
+    =     at tests/sources/hash_model_invalid.move:24:33: hash_test2
+    =         h2 = <redacted>
+    =     at tests/sources/hash_model_invalid.move:25:10: hash_test2
+    =     at tests/sources/hash_model_invalid.move:21:5: hash_test2 (exit)
+
+error:  A postcondition might not hold on this return path.
+
+    ┌── tests/sources/hash_model_invalid.move:30:9 ───
+    │
+ 30 │         ensures len(result_1) > 0 ==> result_1[0] < max_u8();
+    │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    │
+    =     at tests/sources/hash_model_invalid.move:21:5: hash_test2 (entry)
+    =     at tests/sources/hash_model_invalid.move:23:24: hash_test2
+    =     at tests/sources/hash_model_invalid.move:24:33: hash_test2
+    =     at tests/sources/hash_model_invalid.move:25:10: hash_test2
+    =     at tests/sources/hash_model_invalid.move:21:5: hash_test2 (exit)

--- a/language/move-prover/tests/sources/hash_model_invalid.move
+++ b/language/move-prover/tests/sources/hash_model_invalid.move
@@ -1,0 +1,32 @@
+// dep: tests/sources/stdlib/modules/hash.move
+
+module TestHash {
+
+    use 0x0::Hash;
+
+    // sha2 test
+    fun hash_test1(v1: vector<u8>, v2: vector<u8>): (vector<u8>, vector<u8>)
+    {
+        let h1 = Hash::sha2_256(v1);
+        let h2 = Hash::sha2_256(v2);
+        (h1, h2)
+    }
+    spec fun hash_test1 {
+        aborts_if false;
+        ensures result_1 == result_2;  // embarrassingly, this caught a bug.
+        ensures len(result_1) > 0 ==> result_1[0] < max_u8(); // should be <=
+    }
+
+    // sha3 test
+    fun hash_test2(v1: vector<u8>, v2: vector<u8>): (vector<u8>, vector<u8>)
+    {
+        let h1 = Hash::sha3_256(v1);
+        let h2 = Hash::sha3_256(v2);
+        (h1, h2)
+    }
+    spec fun hash_test2 {
+        aborts_if false;
+        ensures result_1 == result_2;
+        ensures len(result_1) > 0 ==> result_1[0] < max_u8();
+    }
+}

--- a/language/move-prover/tests/sources/mut_ref_accross_modules.exp
+++ b/language/move-prover/tests/sources/mut_ref_accross_modules.exp
@@ -1,6 +1,15 @@
 Move prover returns: exiting with boogie verification errors
 error:  This assertion might not hold.
 
+    ┌── tests/sources/mut_ref_accross_modules.move:76:13 ───
+    │
+ 76 │             assert x.value > 0;
+    │             ^^^^^^^^^^^^^^^^^^^
+    │
+    =     at tests/sources/mut_ref_accross_modules.move:74:5: data_invariant (entry)
+
+error:  This assertion might not hold.
+
     ┌── tests/sources/mut_ref_accross_modules.move:16:9 ───
     │
  16 │         invariant value > 0;

--- a/language/move-prover/tests/sources/stdlib/modules/libra_account.exp
+++ b/language/move-prover/tests/sources/stdlib/modules/libra_account.exp
@@ -1,112 +1,112 @@
 Move prover returns: exiting with boogie verification errors
 bug:  This assertion might not hold.
 
-      ┌── libra_account.bpl:1052:6 ───
+      ┌── libra_account.bpl:1116:6 ───
       │
- 1052 │     assert false; // $LibraAccount_write_to_event_store not implemented
+ 1116 │     assert false; // $LibraAccount_write_to_event_store not implemented
       │      ^
       │
 
 bug:  This assertion might not hold.
 
-      ┌── libra_account.bpl:1014:6 ───
+      ┌── libra_account.bpl:1044:6 ───
       │
- 1014 │     assert false; // $AddressUtil_address_to_bytes not implemented
+ 1044 │     assert false; // $AddressUtil_address_to_bytes not implemented
       │      ^
       │
 
 bug:  This assertion might not hold.
 
-      ┌── libra_account.bpl:1014:6 ───
+      ┌── libra_account.bpl:1044:6 ───
       │
- 1014 │     assert false; // $AddressUtil_address_to_bytes not implemented
+ 1044 │     assert false; // $AddressUtil_address_to_bytes not implemented
       │      ^
       │
 
 bug:  This assertion might not hold.
 
-      ┌── libra_account.bpl:1052:6 ───
+      ┌── libra_account.bpl:1116:6 ───
       │
- 1052 │     assert false; // $LibraAccount_write_to_event_store not implemented
+ 1116 │     assert false; // $LibraAccount_write_to_event_store not implemented
       │      ^
       │
 
 bug:  This assertion might not hold.
 
-      ┌── libra_account.bpl:1052:6 ───
+      ┌── libra_account.bpl:1116:6 ───
       │
- 1052 │     assert false; // $LibraAccount_write_to_event_store not implemented
+ 1116 │     assert false; // $LibraAccount_write_to_event_store not implemented
       │      ^
       │
 
 bug:  This assertion might not hold.
 
-      ┌── libra_account.bpl:1052:6 ───
+      ┌── libra_account.bpl:1116:6 ───
       │
- 1052 │     assert false; // $LibraAccount_write_to_event_store not implemented
+ 1116 │     assert false; // $LibraAccount_write_to_event_store not implemented
       │      ^
       │
 
 bug:  This assertion might not hold.
 
-      ┌── libra_account.bpl:1014:6 ───
+      ┌── libra_account.bpl:1044:6 ───
       │
- 1014 │     assert false; // $AddressUtil_address_to_bytes not implemented
+ 1044 │     assert false; // $AddressUtil_address_to_bytes not implemented
       │      ^
       │
 
 bug:  This assertion might not hold.
 
-      ┌── libra_account.bpl:1014:6 ───
+      ┌── libra_account.bpl:1044:6 ───
       │
- 1014 │     assert false; // $AddressUtil_address_to_bytes not implemented
+ 1044 │     assert false; // $AddressUtil_address_to_bytes not implemented
       │      ^
       │
 
 bug:  This assertion might not hold.
 
-      ┌── libra_account.bpl:1014:6 ───
+      ┌── libra_account.bpl:1044:6 ───
       │
- 1014 │     assert false; // $AddressUtil_address_to_bytes not implemented
+ 1044 │     assert false; // $AddressUtil_address_to_bytes not implemented
       │      ^
       │
 
 bug:  This assertion might not hold.
 
-      ┌── libra_account.bpl:1014:6 ───
+      ┌── libra_account.bpl:1044:6 ───
       │
- 1014 │     assert false; // $AddressUtil_address_to_bytes not implemented
+ 1044 │     assert false; // $AddressUtil_address_to_bytes not implemented
       │      ^
       │
 
 bug:  This assertion might not hold.
 
-      ┌── libra_account.bpl:1014:6 ───
+      ┌── libra_account.bpl:1044:6 ───
       │
- 1014 │     assert false; // $AddressUtil_address_to_bytes not implemented
+ 1044 │     assert false; // $AddressUtil_address_to_bytes not implemented
       │      ^
       │
 
 bug:  This assertion might not hold.
 
-      ┌── libra_account.bpl:1014:6 ───
+      ┌── libra_account.bpl:1044:6 ───
       │
- 1014 │     assert false; // $AddressUtil_address_to_bytes not implemented
+ 1044 │     assert false; // $AddressUtil_address_to_bytes not implemented
       │      ^
       │
 
 bug:  This assertion might not hold.
 
-      ┌── libra_account.bpl:1014:6 ───
+      ┌── libra_account.bpl:1044:6 ───
       │
- 1014 │     assert false; // $AddressUtil_address_to_bytes not implemented
+ 1044 │     assert false; // $AddressUtil_address_to_bytes not implemented
       │      ^
       │
 
 bug:  This assertion might not hold.
 
-      ┌── libra_account.bpl:1039:6 ───
+      ┌── libra_account.bpl:1116:6 ───
       │
- 1039 │     assert false; // $Hash_sha3_256 not implemented
+ 1116 │     assert false; // $LibraAccount_write_to_event_store not implemented
       │      ^
       │


### PR DESCRIPTION
This PR is a model for hash.move, which is a native library.

src/prelude.bpl

sha2 and sha3 are modeled  abstractly in boogie as a function that takes an arbitrary vector and returns a 32-byte (256-bit) vector<u8>. The return value is arbitrary, except that there is an axiom requiring hash to be injective: if v1 != v2, then hash(v1) != hash(v2).  This axiom is actually false and even unsound, because there are infinitely many possible input vectors and only 2^256 possible outputs, so there MUST be collisions.  Fortunately, Boogie, Z3, and CVC4 are not smart enough to detect this, and the prover can use this convenient fiction without proving other things that aren't true.

Trying to reason about a bit-accurate implementation of hash with an SMT solver would be terrible, and I believe that the model is sufficient for almost all uses of sha2 and sha3 in practice.  On the other hand, lots of code depends on the fact that there is negligible probability of *ever* seeing a hash collision, so we want to be able to specify and verify conditions as though hash collisions were impossible.

There are two test cases:
tests/sources/hash_model.move, and
tests/sources/hash_model_invalid.move

The first tests that hash(v1) == hash(v2) iff v1 == v2 in several ways,
that the result is of length 32 and it's elements are u8s.

The second checks some invalid properties.

<!--
Thank you for sending a PR. We appreciate you spending time to help improve the Libra project.

The project is undergoing daily changes. Pull Requests will be reviewed and responded to as time permits.
-->

## Motivation

We want to verify Move modules that use sha2 and sha3.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?

yes

## Test Plan

See test cases.

## Related PRs

(If this PR adds or changes functionality, please take some time to update the docs at https://github.com/libra/website, and link to your PR here.)
