### PR TITLE
[move-prover] Add support for locals in spec blocks inside functions

### DIFF
--- a/language/move-prover/spec-lang/src/ast.rs
+++ b/language/move-prover/spec-lang/src/ast.rs
@@ -17,6 +17,8 @@ use std::{
 };
 use vm::file_format::CodeOffset;
 
+use move_lang::parser::ast::{self as PA};
+
 // =================================================================================================
 /// # Declarations
 
@@ -41,7 +43,7 @@ pub struct SpecFunDecl {
 /// # Conditions
 
 #[derive(Debug, PartialEq)]
-pub enum ConditionKind {
+pub enum SpecConditionKind {
     Assert,
     Assume,
     Decreases,
@@ -50,9 +52,21 @@ pub enum ConditionKind {
     Requires,
 }
 
-impl ConditionKind {
+impl SpecConditionKind {
+    pub fn new(kind: &PA::SpecConditionKind) -> Self {
+        use SpecConditionKind::*;
+        match kind {
+            PA::SpecConditionKind::Assert => Assert,
+            PA::SpecConditionKind::Assume => Assume,
+            PA::SpecConditionKind::Decreases => Decreases,
+            PA::SpecConditionKind::Ensures => Ensures,
+            PA::SpecConditionKind::Requires => Requires,
+            PA::SpecConditionKind::AbortsIf => AbortsIf,
+        }
+    }
+
     pub fn on_decl(&self) -> bool {
-        use ConditionKind::*;
+        use SpecConditionKind::*;
         match self {
             AbortsIf | Ensures | Requires => true,
             _ => false,
@@ -60,7 +74,7 @@ impl ConditionKind {
     }
 
     pub fn on_impl(&self) -> bool {
-        use ConditionKind::*;
+        use SpecConditionKind::*;
         match self {
             Assert | Assume | Decreases => true,
             _ => false,
@@ -71,7 +85,7 @@ impl ConditionKind {
 #[derive(Debug)]
 pub struct Condition {
     pub loc: Loc,
-    pub kind: ConditionKind,
+    pub kind: SpecConditionKind,
     pub exp: Exp,
 }
 
@@ -141,6 +155,7 @@ pub enum Operation {
     Pack(ModuleId, StructId),
     Tuple,
     Select(ModuleId, StructId, FieldId),
+    Local(Symbol),
     Result(usize),
     Index,
     Slice,

--- a/language/move-prover/src/bytecode_translator.rs
+++ b/language/move-prover/src/bytecode_translator.rs
@@ -438,7 +438,7 @@ impl<'env> ModuleTranslator<'env> {
     /// Return string for spec inside function implementation.
     fn generate_function_spec_inside_impl(&self, func_env: &FunctionEnv<'_>, offset: CodeOffset) {
         emitln!(self.writer);
-        SpecTranslator::new(self.writer, &func_env.module_env, true)
+        SpecTranslator::new_for_spec_in_impl(self.writer, func_env, true)
             .translate_conditions_inside_impl(func_env, offset);
     }
 

--- a/language/move-prover/src/spec_translator.rs
+++ b/language/move-prover/src/spec_translator.rs
@@ -3,7 +3,7 @@
 
 //! This module translates specification conditions to Boogie code.
 
-use std::cell::RefCell;
+use std::{cell::RefCell, collections::BTreeMap};
 
 use spec_lang::{
     env::{FieldId, FunctionEnv, Loc, ModuleEnv, ModuleId, NodeId, SpecFunId, StructEnv, StructId},
@@ -19,7 +19,7 @@ use crate::{
 };
 use itertools::Itertools;
 use spec_lang::{
-    ast::{ConditionKind, Exp, Invariant, LocalVarDecl, Operation, Value},
+    ast::{Exp, Invariant, LocalVarDecl, Operation, SpecConditionKind, Value},
     symbol::Symbol,
 };
 use vm::file_format::CodeOffset;
@@ -38,6 +38,8 @@ pub struct SpecTranslator<'env> {
     /// Counter for generating fresh variables.  It's a RefCell so we can increment it without
     /// making a ton of &self arguments mutable.
     fresh_var_count: RefCell<u64>,
+    /// Local variable name to local index in bytecode
+    name_to_idx_map: BTreeMap<Symbol, usize>,
 }
 
 // General
@@ -57,6 +59,26 @@ impl<'env> SpecTranslator<'env> {
             in_old: RefCell::new(false),
             invariant_target: RefCell::new(("".to_string(), "".to_string())),
             fresh_var_count: RefCell::new(0),
+            name_to_idx_map: BTreeMap::new(),
+        }
+    }
+
+    /// Creates a translator for use in translating spec blocks inside function implementation
+    pub fn new_for_spec_in_impl(
+        writer: &'env CodeWriter,
+        func_env: &'env FunctionEnv<'env>,
+        supports_native_old: bool,
+    ) -> SpecTranslator<'env> {
+        SpecTranslator {
+            module_env: &func_env.module_env,
+            writer,
+            supports_native_old,
+            in_old: RefCell::new(false),
+            invariant_target: RefCell::new(("".to_string(), "".to_string())),
+            fresh_var_count: RefCell::new(0),
+            name_to_idx_map: (0..func_env.get_local_count())
+                .map(|idx| (func_env.get_local_name(idx), idx))
+                .collect(),
         }
     }
 
@@ -206,7 +228,7 @@ impl<'env> SpecTranslator<'env> {
                     self.writer.set_location(&cond.loc);
                     emit!(
                         self.writer,
-                        if cond.kind == ConditionKind::Assert {
+                        if cond.kind == SpecConditionKind::Assert {
                             "assert "
                         } else {
                             "assume "
@@ -235,7 +257,7 @@ impl<'env> SpecTranslator<'env> {
         // Generate requires.
         let requires = conds
             .iter()
-            .filter(|c| c.kind == ConditionKind::Requires)
+            .filter(|c| c.kind == SpecConditionKind::Requires)
             .collect_vec();
         if !requires.is_empty() {
             self.translate_seq(requires.iter(), "\n", |cond| {
@@ -252,7 +274,7 @@ impl<'env> SpecTranslator<'env> {
         // multiple abort_if conditions are "or"ed. If no condition holds, function does not abort.
         let aborts_if = conds
             .iter()
-            .filter(|c| c.kind == ConditionKind::AbortsIf)
+            .filter(|c| c.kind == SpecConditionKind::AbortsIf)
             .collect_vec();
         if !aborts_if.is_empty() {
             self.writer.set_location(&aborts_if[0].loc);
@@ -268,7 +290,7 @@ impl<'env> SpecTranslator<'env> {
         // Generate ensures
         let ensures = conds
             .iter()
-            .filter(|c| c.kind == ConditionKind::Ensures)
+            .filter(|c| c.kind == SpecConditionKind::Ensures)
             .collect_vec();
         if !ensures.is_empty() {
             self.translate_seq(ensures.iter(), "\n", |cond| {
@@ -310,7 +332,7 @@ impl<'env> SpecTranslator<'env> {
         let requires = func_env
             .get_specification_on_decl()
             .iter()
-            .filter(|cond| cond.kind == ConditionKind::Requires)
+            .filter(|cond| cond.kind == SpecConditionKind::Requires)
             .collect_vec();
         if !requires.is_empty() {
             self.translate_seq(requires.iter(), "\n", |cond| {
@@ -641,6 +663,13 @@ impl<'env> SpecTranslator<'env> {
             Operation::Tuple => self.error(&loc, "Tuple not yet supported"),
             Operation::Select(module_id, struct_id, field_id) => {
                 self.translate_select(*module_id, *struct_id, *field_id, args)
+            }
+            Operation::Local(sym) => {
+                emit!(
+                    self.writer,
+                    "$GetLocal($m, $frame + {})",
+                    self.name_to_idx_map[sym],
+                );
             }
             Operation::Result(pos) => self.auto_dref(node_id, || {
                 emit!(self.writer, "$ret{}", pos);

--- a/language/move-prover/tests/sources/specs-in-fun.exp
+++ b/language/move-prover/tests/sources/specs-in-fun.exp
@@ -1,21 +1,48 @@
 Move prover returns: exiting with boogie verification errors
 error:  This assertion might not hold.
 
-    ┌── tests/sources/specs-in-fun.move:14:13 ───
+    ┌── tests/sources/specs-in-fun.move:40:13 ───
     │
- 14 │             assert x == y;
+ 40 │             assert x == y;
     │             ^^^^^^^^^^^^^^
     │
-    =     at tests/sources/specs-in-fun.move:11:5: simple2 (entry)
-    =     at tests/sources/specs-in-fun.move:12:9: simple2
+    =     at tests/sources/specs-in-fun.move:37:5: simple1_invalid (entry)
+    =     at tests/sources/specs-in-fun.move:38:9: simple1_invalid
     =         x = <redacted>,
     =         y = <redacted>
 
 error:  This assertion might not hold.
 
-    ┌── tests/sources/specs-in-fun.move:30:13 ───
+    ┌── tests/sources/specs-in-fun.move:48:13 ───
     │
- 30 │             assert x > y;
+ 48 │             assert x == y;
+    │             ^^^^^^^^^^^^^^
+    │
+    =     at tests/sources/specs-in-fun.move:44:5: simple2_invalid (entry)
+    =     at tests/sources/specs-in-fun.move:46:15: simple2_invalid
+    =         x = <redacted>,
+    =         y = <redacted>
+    =     at tests/sources/specs-in-fun.move:48:13: simple2_invalid
+
+error:  This assertion might not hold.
+
+    ┌── tests/sources/specs-in-fun.move:55:13 ───
+    │
+ 55 │             assert x > y;
     │             ^^^^^^^^^^^^^
     │
-    =     at tests/sources/specs-in-fun.move:27:5: simple4 (entry)
+    =     at tests/sources/specs-in-fun.move:52:5: simple3_invalid (entry)
+
+error:  This assertion might not hold.
+
+    ┌── tests/sources/specs-in-fun.move:64:13 ───
+    │
+ 64 │             assert z > 2*x;
+    │             ^^^^^^^^^^^^^^^
+    │
+    =     at tests/sources/specs-in-fun.move:59:5: simple4_invalid (entry)
+    =     at tests/sources/specs-in-fun.move:61:15: simple4_invalid
+    =         x = <redacted>,
+    =         y = <redacted>,
+    =         z = <redacted>
+    =     at tests/sources/specs-in-fun.move:63:13: simple4_invalid

--- a/language/move-prover/tests/sources/specs-in-fun.move
+++ b/language/move-prover/tests/sources/specs-in-fun.move
@@ -1,5 +1,6 @@
 module TestAssertAndAssume {
-    // succeeds
+    // Tests that should verify
+
     fun simple1(x: u64, y: u64) {
         if (!(x > y)) abort 1;
         spec {
@@ -7,15 +8,14 @@ module TestAssertAndAssume {
         }
     }
 
-    // fails
-    fun simple2(x: u64, y: u64) {
-        if (!(x > y)) abort 1;
+    fun simple2(x: u64) {
+        let y: u64;
+        y = x + 1;
         spec {
-            assert x == y;
+            assert x == y - 1;
         }
     }
 
-    // succeeds
     fun simple3(x: u64, y: u64) {
         spec {
             assume x > y;
@@ -23,11 +23,45 @@ module TestAssertAndAssume {
         }
     }
 
-    // fails
     fun simple4(x: u64, y: u64) {
+        let z: u64;
+        z = x + y;
+        spec {
+            assume x > y;
+            assert z > 2*y;
+        }
+    }
+
+    // Tests that should not verify
+
+    fun simple1_invalid(x: u64, y: u64) {
+        if (!(x > y)) abort 1;
+        spec {
+            assert x == y;
+        }
+    }
+
+    fun simple2_invalid(x: u64) {
+        let y: u64;
+        y = x + 1;
+        spec {
+            assert x == y;
+        }
+    }
+
+    fun simple3_invalid(x: u64, y: u64) {
         spec {
             assume x >= y;
             assert x > y;
+        }
+    }
+
+    fun simple4_invalid(x: u64, y: u64) {
+        let z: u64;
+        z = x + y;
+        spec {
+            assume x > y;
+            assert z > 2*x;
         }
     }
 }


### PR DESCRIPTION
## Motivation

This PR adds the capability to refer to locals in spec blocks inside functions.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

More tests and existing tests

## Related PRs
