### PR TITLE
Rename LibraDBTrait to DbReader

### DIFF
--- a/consensus/src/chained_bft/liveness/leader_reputation.rs
+++ b/consensus/src/chained_bft/liveness/leader_reputation.rs
@@ -8,7 +8,7 @@ use consensus_types::{
 };
 use libra_logger::prelude::*;
 use libra_types::block_metadata::{new_block_event_key, NewBlockEvent};
-use libradb::LibraDBTrait;
+use libradb::DbReader;
 use serde::export::PhantomData;
 use std::{
     cmp::Ordering,
@@ -25,12 +25,12 @@ pub trait MetadataBackend: Send + Sync {
 
 pub struct LibraDBBackend {
     window_size: usize,
-    libra_db: Arc<dyn LibraDBTrait>,
+    libra_db: Arc<dyn DbReader>,
     window: Mutex<Vec<(u64, NewBlockEvent)>>,
 }
 
 impl LibraDBBackend {
-    pub fn new(window_size: usize, libra_db: Arc<dyn LibraDBTrait>) -> Self {
+    pub fn new(window_size: usize, libra_db: Arc<dyn DbReader>) -> Self {
         Self {
             window_size,
             libra_db,

--- a/consensus/src/chained_bft/test_utils/mock_storage.rs
+++ b/consensus/src/chained_bft/test_utils/mock_storage.rs
@@ -14,7 +14,7 @@ use consensus_types::{
 };
 use libra_crypto::HashValue;
 use libra_types::{ledger_info::LedgerInfo, validator_set::ValidatorSet};
-use libradb::LibraDBTrait;
+use libradb::DbReader;
 use std::{
     collections::HashMap,
     marker::PhantomData,
@@ -219,7 +219,7 @@ impl<T: Payload> PersistentLivenessStorage<T> for MockStorage<T> {
         Ok(())
     }
 
-    fn libra_db(&self) -> Arc<dyn LibraDBTrait> {
+    fn libra_db(&self) -> Arc<dyn DbReader> {
         unimplemented!()
     }
 }
@@ -283,7 +283,7 @@ impl<T: Payload> PersistentLivenessStorage<T> for EmptyStorage<T> {
         Ok(())
     }
 
-    fn libra_db(&self) -> Arc<dyn LibraDBTrait> {
+    fn libra_db(&self) -> Arc<dyn DbReader> {
         unimplemented!()
     }
 }

--- a/consensus/src/consensus_provider.rs
+++ b/consensus/src/consensus_provider.rs
@@ -17,7 +17,7 @@ use libra_config::config::NodeConfig;
 use libra_mempool::ConsensusRequest;
 use libra_types::transaction::SignedTransaction;
 use libra_vm::LibraVM;
-use libradb::LibraDBTrait;
+use libradb::DbReader;
 use state_synchronizer::StateSyncClient;
 use std::sync::{Arc, Mutex};
 
@@ -42,7 +42,7 @@ pub fn make_consensus_provider(
     executor: Arc<Mutex<Executor<LibraVM>>>,
     state_sync_client: Arc<StateSyncClient>,
     consensus_to_mempool_sender: mpsc::Sender<ConsensusRequest>,
-    libra_db: Arc<dyn LibraDBTrait>,
+    libra_db: Arc<dyn DbReader>,
 ) -> Box<dyn ConsensusProvider> {
     let storage = Arc::new(StorageWriteProxy::new(node_config, libra_db));
     let txn_manager = Box::new(MempoolProxy::new(consensus_to_mempool_sender));

--- a/json-rpc/src/methods.rs
+++ b/json-rpc/src/methods.rs
@@ -19,18 +19,18 @@ use libra_types::{
     account_address::AccountAddress, account_state::AccountState, event::EventKey,
     mempool_status::MempoolStatusCode, transaction::SignedTransaction,
 };
-use libradb::LibraDBTrait;
+use libradb::DbReader;
 use serde_json::Value;
 use std::{collections::HashMap, convert::TryFrom, pin::Pin, str::FromStr, sync::Arc};
 
 #[derive(Clone)]
 pub(crate) struct JsonRpcService {
-    db: Arc<dyn LibraDBTrait>,
+    db: Arc<dyn DbReader>,
     mempool_sender: MempoolClientSender,
 }
 
 impl JsonRpcService {
-    pub fn new(db: Arc<dyn LibraDBTrait>, mempool_sender: MempoolClientSender) -> Self {
+    pub fn new(db: Arc<dyn DbReader>, mempool_sender: MempoolClientSender) -> Self {
         Self { db, mempool_sender }
     }
 }

--- a/json-rpc/src/runtime.rs
+++ b/json-rpc/src/runtime.rs
@@ -9,7 +9,7 @@ use crate::{
 use futures::future::join_all;
 use libra_config::config::NodeConfig;
 use libra_mempool::MempoolClientSender;
-use libradb::LibraDBTrait;
+use libradb::DbReader;
 use serde_json::{map::Map, Value};
 use std::{net::SocketAddr, sync::Arc};
 use tokio::runtime::{Builder, Runtime};
@@ -19,7 +19,7 @@ use warp::Filter;
 /// Returns handle to corresponding Tokio runtime
 pub fn bootstrap(
     address: SocketAddr,
-    libra_db: Arc<dyn LibraDBTrait>,
+    libra_db: Arc<dyn DbReader>,
     mp_sender: MempoolClientSender,
 ) -> Runtime {
     let runtime = Builder::new()
@@ -56,7 +56,7 @@ pub fn bootstrap(
 /// Creates JSON RPC endpoint by given node config
 pub fn bootstrap_from_config(
     config: &NodeConfig,
-    libra_db: Arc<dyn LibraDBTrait>,
+    libra_db: Arc<dyn DbReader>,
     mp_sender: MempoolClientSender,
 ) -> Runtime {
     bootstrap(config.rpc.address, libra_db, mp_sender)

--- a/json-rpc/src/tests/mock_db.rs
+++ b/json-rpc/src/tests/mock_db.rs
@@ -20,7 +20,7 @@ use libra_types::{
     validator_change::ValidatorChangeProof,
     vm_error::StatusCode,
 };
-use libradb::LibraDBTrait;
+use libradb::DbReader;
 use std::collections::BTreeMap;
 use storage_proto::StartupInfo;
 
@@ -35,7 +35,7 @@ pub(crate) struct MockLibraDB {
     pub account_state_with_proof: Vec<AccountStateWithProof>,
 }
 
-impl LibraDBTrait for MockLibraDB {
+impl DbReader for MockLibraDB {
     fn get_latest_account_state(
         &self,
         address: AccountAddress,

--- a/json-rpc/src/tests/unit_tests.rs
+++ b/json-rpc/src/tests/unit_tests.rs
@@ -32,7 +32,7 @@ use libra_types::{
     transaction::{Transaction, TransactionInfo, TransactionPayload, TransactionToCommit},
     vm_error::{StatusCode, VMStatus},
 };
-use libradb::{test_helper::arb_blocks_to_commit, LibraDB, LibraDBTrait};
+use libradb::{test_helper::arb_blocks_to_commit, DbReader, LibraDB};
 use proptest::prelude::*;
 use reqwest;
 use serde_json::{self, Value};

--- a/secure/key-manager/src/tests.rs
+++ b/secure/key-manager/src/tests.rs
@@ -21,7 +21,7 @@ use libra_types::{
     validator_set::ValidatorSetResource,
 };
 use libra_vm::LibraVM;
-use libradb::{LibraDB, LibraDBTrait};
+use libradb::{DbReader, LibraDB};
 use rand::{rngs::StdRng, SeedableRng};
 use std::{cell::RefCell, collections::BTreeMap, convert::TryFrom, sync::Arc, time::Duration};
 use storage_client::{StorageReadServiceClient, StorageWriteServiceClient};

--- a/state-synchronizer/src/executor_proxy.rs
+++ b/state-synchronizer/src/executor_proxy.rs
@@ -91,7 +91,7 @@ impl ExecutorProxy {
     }
 
     // TODO make this into more general trait method in `on_chain_config.rs`
-    // once `StorageRead` trait is replaced with `LibraDBTrait` and `batch_fetch_config` method is no longer async
+    // once `StorageRead` trait is replaced with `DbReader` and `batch_fetch_config` method is no longer async
     async fn fetch_all_configs(&self) -> Result<HashMap<ConfigID, Vec<u8>>> {
         let access_paths = ON_CHAIN_CONFIG_REGISTRY
             .iter()

--- a/storage/inspector/src/main.rs
+++ b/storage/inspector/src/main.rs
@@ -5,7 +5,7 @@
 
 use anyhow::Result;
 use libra_logger::info;
-use libradb::{LibraDB, LibraDBTrait};
+use libradb::{DbReader, LibraDB};
 use std::path::PathBuf;
 use transaction_builder::get_transaction_name;
 

--- a/storage/libradb/src/lib.rs
+++ b/storage/libradb/src/lib.rs
@@ -121,7 +121,7 @@ fn error_if_too_many_requested(num_requested: u64, max_allowed: u64) -> Result<(
 
 /// Trait that is implemented by a DB that supports certain public (to client) read APIs
 /// expected of a Libra DB
-pub trait LibraDBTrait: Send + Sync {
+pub trait DbReader: Send + Sync {
     /// Given an account address, returns the latest account state. `None` if the account does not
     /// exist.
     fn get_latest_account_state(&self, address: AccountAddress)
@@ -804,7 +804,7 @@ impl LibraDB {
     }
 }
 
-impl LibraDBTrait for LibraDB {
+impl DbReader for LibraDB {
     fn get_latest_account_state(
         &self,
         address: AccountAddress,

--- a/storage/storage-client/src/lib.rs
+++ b/storage/storage-client/src/lib.rs
@@ -284,7 +284,7 @@ impl StorageRead for StorageReadServiceClient {
     }
 
     // TODO migrate this to `ConfigStorage` trait as non-async
-    // and implement for LibraDBTrait once `StorageRead` is deprecated
+    // and implement for DbReader once `StorageRead` is deprecated
     async fn batch_fetch_config(&self, access_paths: Vec<AccessPath>) -> Result<Vec<Vec<u8>>> {
         // some access paths can have the same address, so don't duplicate requests for them
         let addresses: Vec<AccountAddress> = access_paths

--- a/storage/storage-service/src/lib.rs
+++ b/storage/storage-service/src/lib.rs
@@ -19,7 +19,7 @@ use libra_logger::prelude::*;
 use libra_types::proto::types::{
     UpdateToLatestLedgerRequest, UpdateToLatestLedgerResponse, ValidatorChangeProof,
 };
-use libradb::{LibraDB, LibraDBTrait};
+use libradb::{DbReader, LibraDB};
 use std::{convert::TryFrom, path::Path, sync::Arc};
 use storage_proto::proto::storage::{
     storage_server::{Storage, StorageServer},


### PR DESCRIPTION
## Motivation

We will use this trait for read access control.

The current name is not self-explainable and "Trait" itself is not suitable to be part of a trait name.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?

Y

## Test Plan

CI


