### PR TITLE
[consensus] Remove unused dependency on parity-multiaddr

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -818,7 +818,6 @@ dependencies = [
  "num-derive 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "num-traits 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "once_cell 1.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "parity-multiaddr 0.7.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "prometheus 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "proptest 0.9.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/consensus/Cargo.toml
+++ b/consensus/Cargo.toml
@@ -19,7 +19,6 @@ once_cell = "1.3.1"
 mirai-annotations = { version = "1.4.0", default-features = false }
 num-derive = { version = "0.3.0", default-features = false }
 num-traits = { version = "0.2.8", default-features = false }
-parity-multiaddr = { version = "0.7.2", default-features = false }
 rand = { version = "0.6.5", default-features = false }
 serde = { version = "1.0.105", default-features = false }
 serde_json = "1.0"


### PR DESCRIPTION
During dependency triage we realized this dep was unused.