### PR TITLE
[move-prover] Assuming invariants only on immutable or frozen refs.

### DIFF
--- a/language/move-prover/src/boogie_helpers.rs
+++ b/language/move-prover/src/boogie_helpers.rs
@@ -122,8 +122,25 @@ pub fn boogie_local_type(ty: &Type) -> String {
     }
 }
 
-/// Create boogie type check boolean expression.
-pub fn boogie_type_check_expr(env: &GlobalEnv, name: &str, ty: &Type) -> String {
+/// A value indicating how to perform well-formed checks.
+#[derive(Clone, Copy, PartialEq)]
+pub enum WellFormedMode {
+    /// Assume types and invariants in auto mode. If the type is a mutable reference, invariants
+    /// will not be assumed.
+    Default,
+    /// Assume types and invariants.
+    WithInvariant,
+    /// Assume types only.
+    WithoutInvariant,
+}
+
+/// Create boogie well-formed boolean expression.
+pub fn boogie_well_formed_expr(
+    env: &GlobalEnv,
+    name: &str,
+    ty: &Type,
+    mode: WellFormedMode,
+) -> String {
     let mut conds = vec![];
     match ty {
         Type::Primitive(p) => match p {
@@ -138,17 +155,29 @@ pub fn boogie_type_check_expr(env: &GlobalEnv, name: &str, ty: &Type) -> String 
         Type::Vector(_) => conds.push(format!("$Vector_is_well_formed({})", name)),
         Type::Struct(module_idx, struct_idx, _) => {
             let struct_env = env.get_module(*module_idx).into_struct(*struct_idx);
+            let well_formed_name = if mode == WellFormedMode::WithoutInvariant {
+                "is_well_formed_types"
+            } else {
+                "is_well_formed"
+            };
             conds.push(format!(
-                "${}_is_well_formed({})",
+                "{}_{}({})",
                 boogie_struct_name(&struct_env),
+                well_formed_name,
                 name
             ))
         }
-        Type::Reference(_is_mut, rtype) => {
-            conds.push(boogie_type_check_expr(
+        Type::Reference(is_mut, rtype) => {
+            let mode = if *is_mut && mode == WellFormedMode::Default {
+                WellFormedMode::WithoutInvariant
+            } else {
+                mode
+            };
+            conds.push(boogie_well_formed_expr(
                 env,
                 &format!("$Dereference($m, {})", name),
                 rtype,
+                mode,
             ));
             conds.push(format!(
                 "$IsValidReferenceParameter($m, $local_counter, {})",
@@ -165,10 +194,15 @@ pub fn boogie_type_check_expr(env: &GlobalEnv, name: &str, ty: &Type) -> String 
     conds.iter().filter(|s| !s.is_empty()).join(" && ")
 }
 
-/// Create boogie type check assumption. The result will be either an empty string or a
+/// Create boogie well-formed check. The result will be either an empty string or a
 /// newline-terminated assume statement.
-pub fn boogie_type_check(env: &GlobalEnv, name: &str, ty: &Type) -> String {
-    let expr = boogie_type_check_expr(env, name, ty);
+pub fn boogie_well_formed_check(
+    env: &GlobalEnv,
+    name: &str,
+    ty: &Type,
+    mode: WellFormedMode,
+) -> String {
+    let expr = boogie_well_formed_expr(env, name, ty, mode);
     if !expr.is_empty() {
         format!("assume {};\n", expr)
     } else {
@@ -182,7 +216,7 @@ pub fn boogie_declare_global(env: &GlobalEnv, name: &str, ty: &Type) -> String {
     format!(
         "var {} : Value where {};",
         name,
-        boogie_type_check_expr(env, name, ty)
+        boogie_well_formed_expr(env, name, ty, WellFormedMode::Default)
     )
 }
 

--- a/language/move-prover/src/boogie_wrapper.rs
+++ b/language/move-prover/src/boogie_wrapper.rs
@@ -153,7 +153,12 @@ impl<'env> BoogieWrapper<'env> {
         );
 
         // Now add trace diagnostics.
-        if error.kind.is_from_verification() && !error.execution_trace.is_empty() {
+        if error.kind.is_from_verification()
+            && !error.execution_trace.is_empty()
+            // Reporting errors on boogie source seems to have some non-determinism, so skip
+            // this if stable output is required
+            && (on_source || !self.options.stable_test_output)
+        {
             let mut locals_shown = BTreeSet::new();
             let mut aborted = false;
             let cleaned_trace = error

--- a/language/move-prover/tests/sources/mut_ref_accross_modules.exp
+++ b/language/move-prover/tests/sources/mut_ref_accross_modules.exp
@@ -32,12 +32,21 @@ error:  A postcondition might not hold on this return path.
 
 error:  This assertion might not hold.
 
+    ┌── tests/sources/mut_ref_accross_modules.move:83:13 ───
+    │
+ 83 │             assert x.value > 0;
+    │             ^^^^^^^^^^^^^^^^^^^
+    │
+    =     at tests/sources/mut_ref_accross_modules.move:81:5: private_data_invariant_invalid (entry)
+
+error:  This assertion might not hold.
+
     ┌── tests/sources/mut_ref_accross_modules.move:16:9 ───
     │
  16 │         invariant value > 0;
     │         ^^^^^^^^^^^^^^^^^^^^
     │
-    =     at tests/sources/mut_ref_accross_modules.move:109:6: private_to_public_caller_invalid_data_invariant (entry)
+    =     at tests/sources/mut_ref_accross_modules.move:110:6: private_to_public_caller_invalid_data_invariant (entry)
     =     at tests/sources/mut_ref_accross_modules.move:29:5: new (entry)
     =     at tests/sources/mut_ref_accross_modules.move:30:17: new
     =         x = <redacted>,
@@ -46,9 +55,9 @@ error:  This assertion might not hold.
     =         r = <redacted>
     =     at tests/sources/mut_ref_accross_modules.move:32:18: new
     =     at tests/sources/mut_ref_accross_modules.move:29:5: new (exit)
-    =     at tests/sources/mut_ref_accross_modules.move:114:18: private_to_public_caller_invalid_data_invariant
-    =         x = <redacted>
     =     at tests/sources/mut_ref_accross_modules.move:115:18: private_to_public_caller_invalid_data_invariant
+    =         x = <redacted>
+    =     at tests/sources/mut_ref_accross_modules.move:116:18: private_to_public_caller_invalid_data_invariant
     =         r = <redacted>
     =     at tests/sources/mut_ref_accross_modules.move:67:5: private_decrement (entry)
     =     at tests/sources/mut_ref_accross_modules.move:68:27: private_decrement
@@ -60,7 +69,7 @@ error:  This assertion might not hold.
     =     at tests/sources/mut_ref_accross_modules.move:70:17: private_decrement
     =         x = <redacted>,
     =         r = <redacted>
-    =     at tests/sources/mut_ref_accross_modules.move:118:10: private_to_public_caller_invalid_data_invariant
+    =     at tests/sources/mut_ref_accross_modules.move:119:10: private_to_public_caller_invalid_data_invariant
     =         r = <redacted>
 
 error:  A precondition for this call might not hold.
@@ -70,5 +79,5 @@ error:  A precondition for this call might not hold.
  25 │         invariant global<TSum>(0x0).sum == spec_sum;
     │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
     │
-    =     at tests/sources/mut_ref_accross_modules.move:104:6: private_to_public_caller_invalid_precondition (entry)
+    =     at tests/sources/mut_ref_accross_modules.move:105:6: private_to_public_caller_invalid_precondition (entry)
     =     at tests/sources/mut_ref_accross_modules.move:46:5: increment (entry)

--- a/language/move-prover/tests/sources/mut_ref_accross_modules.move
+++ b/language/move-prover/tests/sources/mut_ref_accross_modules.move
@@ -78,7 +78,6 @@ module TestMutRefs {
     }
 
     // For a private function, the data invariant for a mut ref is not expected to hold.
-    // TODO: this currently does not fail because of #3076
     fun private_data_invariant_invalid(x: &mut T) {
         spec {
             assert x.value > 0;
@@ -88,9 +87,11 @@ module TestMutRefs {
     // The next function should succeed because calling a public function from a private one maintains module
     // invariants.
     fun private_to_public_caller(r: &mut T) acquires TSum {
-        // Before call to public increment, module invariant must hold. Here we specialize it to start with a zero sum.
+        // Before call to public increment, data invariants and module invariant must hold.
+        // Here we assume them, and force spec_sum to start with a zero value.
         spec {
             assume spec_sum == 0;
+            assume r.value > 0;
             assume global<TSum>(0x0).sum == spec_sum;
         };
         increment(r);

--- a/language/move-prover/tests/sources/stdlib/modules/libra_account.exp
+++ b/language/move-prover/tests/sources/stdlib/modules/libra_account.exp
@@ -6,19 +6,6 @@ bug:  This assertion might not hold.
  1052 │     assert false; // $LibraAccount_write_to_event_store not implemented
       │      ^
       │
-      =     at libra_account.bpl:3720:24: <boogie>: inline$$LibraAccount_deposit$0$Entry
-      =     at libra_account.bpl:3761:6: <boogie>: inline$$LibraAccount_deposit$0$anon11_Else
-      =     at libra_account.bpl:4563:24: <boogie>: inline$$LibraAccount_deposit_with_metadata$0$Entry
-      =     at libra_account.bpl:4638:24: <boogie>: inline$$LibraAccount_deposit_with_sender_and_metadata$0$Entry
-      =     at libra_account.bpl:2890:24: <boogie>: inline$$LibraCoin_value$0$Entry
-      =     at libra_account.bpl:2890:24: <boogie>: inline$$LibraCoin_value$0$Return
-      =     at libra_account.bpl:4712:6: <boogie>: inline$$LibraAccount_deposit_with_sender_and_metadata$0$anon59_Else
-      =     at libra_account.bpl:4728:6: <boogie>: inline$$LibraAccount_deposit_with_sender_and_metadata$0$anon12$1
-      =     at libra_account.bpl:4787:6: <boogie>: inline$$LibraAccount_deposit_with_sender_and_metadata$0$anon64_Else
-      =     at libra_account.bpl:4799:6: <boogie>: inline$$LibraAccount_deposit_with_sender_and_metadata$0$anon22$2
-      =     at libra_account.bpl:5021:24: <boogie>: inline$$LibraAccount_emit_event$0$Entry
-      =     at libra_account.bpl:5080:18: <boogie>: inline$$LibraAccount_emit_event$0$anon15_Then
-      =     at libra_account.bpl:5084:6: <boogie>: inline$$LibraAccount_emit_event$0$anon6$1
 
 bug:  This assertion might not hold.
 
@@ -27,10 +14,6 @@ bug:  This assertion might not hold.
  1014 │     assert false; // $AddressUtil_address_to_bytes not implemented
       │      ^
       │
-      =     at libra_account.bpl:3993:24: <boogie>: inline$$LibraAccount_create_account$0$Entry
-      =     at libra_account.bpl:4063:18: <boogie>: inline$$LibraAccount_create_account$0$anon31_Then
-      =     at libra_account.bpl:4067:6: <boogie>: inline$$LibraAccount_create_account$0$anon6$1
-      =     at libra_account.bpl:4078:6: <boogie>: inline$$LibraAccount_create_account$0$anon8$1
 
 bug:  This assertion might not hold.
 
@@ -39,11 +22,6 @@ bug:  This assertion might not hold.
  1014 │     assert false; // $AddressUtil_address_to_bytes not implemented
       │      ^
       │
-      =     at libra_account.bpl:4287:24: <boogie>: inline$$LibraAccount_create_new_account$0$Entry
-      =     at libra_account.bpl:3993:24: <boogie>: inline$$LibraAccount_create_account$0$Entry
-      =     at libra_account.bpl:4063:18: <boogie>: inline$$LibraAccount_create_account$0$anon31_Then
-      =     at libra_account.bpl:4067:6: <boogie>: inline$$LibraAccount_create_account$0$anon6$1
-      =     at libra_account.bpl:4078:6: <boogie>: inline$$LibraAccount_create_account$0$anon8$1
 
 bug:  This assertion might not hold.
 
@@ -52,17 +30,6 @@ bug:  This assertion might not hold.
  1052 │     assert false; // $LibraAccount_write_to_event_store not implemented
       │      ^
       │
-      =     at libra_account.bpl:4563:24: <boogie>: inline$$LibraAccount_deposit_with_metadata$0$Entry
-      =     at libra_account.bpl:4638:24: <boogie>: inline$$LibraAccount_deposit_with_sender_and_metadata$0$Entry
-      =     at libra_account.bpl:2890:24: <boogie>: inline$$LibraCoin_value$0$Entry
-      =     at libra_account.bpl:2890:24: <boogie>: inline$$LibraCoin_value$0$Return
-      =     at libra_account.bpl:4712:6: <boogie>: inline$$LibraAccount_deposit_with_sender_and_metadata$0$anon59_Else
-      =     at libra_account.bpl:4728:6: <boogie>: inline$$LibraAccount_deposit_with_sender_and_metadata$0$anon12$1
-      =     at libra_account.bpl:4787:6: <boogie>: inline$$LibraAccount_deposit_with_sender_and_metadata$0$anon64_Else
-      =     at libra_account.bpl:4799:6: <boogie>: inline$$LibraAccount_deposit_with_sender_and_metadata$0$anon22$2
-      =     at libra_account.bpl:5021:24: <boogie>: inline$$LibraAccount_emit_event$0$Entry
-      =     at libra_account.bpl:5080:18: <boogie>: inline$$LibraAccount_emit_event$0$anon15_Then
-      =     at libra_account.bpl:5084:6: <boogie>: inline$$LibraAccount_emit_event$0$anon6$1
 
 bug:  This assertion might not hold.
 
@@ -71,16 +38,6 @@ bug:  This assertion might not hold.
  1052 │     assert false; // $LibraAccount_write_to_event_store not implemented
       │      ^
       │
-      =     at libra_account.bpl:4638:24: <boogie>: inline$$LibraAccount_deposit_with_sender_and_metadata$0$Entry
-      =     at libra_account.bpl:2890:24: <boogie>: inline$$LibraCoin_value$0$Entry
-      =     at libra_account.bpl:2890:24: <boogie>: inline$$LibraCoin_value$0$Return
-      =     at libra_account.bpl:4712:6: <boogie>: inline$$LibraAccount_deposit_with_sender_and_metadata$0$anon59_Else
-      =     at libra_account.bpl:4728:6: <boogie>: inline$$LibraAccount_deposit_with_sender_and_metadata$0$anon12$1
-      =     at libra_account.bpl:4787:6: <boogie>: inline$$LibraAccount_deposit_with_sender_and_metadata$0$anon64_Else
-      =     at libra_account.bpl:4799:6: <boogie>: inline$$LibraAccount_deposit_with_sender_and_metadata$0$anon22$2
-      =     at libra_account.bpl:5021:24: <boogie>: inline$$LibraAccount_emit_event$0$Entry
-      =     at libra_account.bpl:5080:18: <boogie>: inline$$LibraAccount_emit_event$0$anon15_Then
-      =     at libra_account.bpl:5084:6: <boogie>: inline$$LibraAccount_emit_event$0$anon6$1
 
 bug:  This assertion might not hold.
 
@@ -89,9 +46,6 @@ bug:  This assertion might not hold.
  1052 │     assert false; // $LibraAccount_write_to_event_store not implemented
       │      ^
       │
-      =     at libra_account.bpl:5021:24: <boogie>: inline$$LibraAccount_emit_event$0$Entry
-      =     at libra_account.bpl:5080:18: <boogie>: inline$$LibraAccount_emit_event$0$anon15_Then
-      =     at libra_account.bpl:5084:6: <boogie>: inline$$LibraAccount_emit_event$0$anon6$1
 
 bug:  This assertion might not hold.
 
@@ -100,7 +54,6 @@ bug:  This assertion might not hold.
  1014 │     assert false; // $AddressUtil_address_to_bytes not implemented
       │      ^
       │
-      =     at libra_account.bpl:5892:24: <boogie>: inline$$LibraAccount_fresh_guid$0$Entry
 
 bug:  This assertion might not hold.
 
@@ -109,13 +62,6 @@ bug:  This assertion might not hold.
  1014 │     assert false; // $AddressUtil_address_to_bytes not implemented
       │      ^
       │
-      =     at libra_account.bpl:6125:24: <boogie>: inline$$LibraAccount_mint_to_address$0$Entry
-      =     at libra_account.bpl:3668:24: <boogie>: inline$$LibraAccount_exists$0$Entry
-      =     at libra_account.bpl:6169:6: <boogie>: inline$$LibraAccount_mint_to_address$0$anon19_Else
-      =     at libra_account.bpl:3993:24: <boogie>: inline$$LibraAccount_create_account$0$Entry
-      =     at libra_account.bpl:4063:18: <boogie>: inline$$LibraAccount_create_account$0$anon31_Then
-      =     at libra_account.bpl:4067:6: <boogie>: inline$$LibraAccount_create_account$0$anon6$1
-      =     at libra_account.bpl:4078:6: <boogie>: inline$$LibraAccount_create_account$0$anon8$1
 
 bug:  This assertion might not hold.
 
@@ -124,11 +70,6 @@ bug:  This assertion might not hold.
  1014 │     assert false; // $AddressUtil_address_to_bytes not implemented
       │      ^
       │
-      =     at libra_account.bpl:6255:24: <boogie>: inline$$LibraAccount_new_event_handle$0$Entry
-      =     at libra_account.bpl:6290:6: <boogie>: inline$$LibraAccount_new_event_handle$0$anon9_Else
-      =     at libra_account.bpl:6302:6: <boogie>: inline$$LibraAccount_new_event_handle$0$anon4$2
-      =     at libra_account.bpl:6345:24: <boogie>: inline$$LibraAccount_new_event_handle_impl$0$Entry
-      =     at libra_account.bpl:5892:24: <boogie>: inline$$LibraAccount_fresh_guid$0$Entry
 
 bug:  This assertion might not hold.
 
@@ -137,8 +78,6 @@ bug:  This assertion might not hold.
  1014 │     assert false; // $AddressUtil_address_to_bytes not implemented
       │      ^
       │
-      =     at libra_account.bpl:6345:24: <boogie>: inline$$LibraAccount_new_event_handle_impl$0$Entry
-      =     at libra_account.bpl:5892:24: <boogie>: inline$$LibraAccount_fresh_guid$0$Entry
 
 bug:  This assertion might not hold.
 
@@ -147,13 +86,6 @@ bug:  This assertion might not hold.
  1014 │     assert false; // $AddressUtil_address_to_bytes not implemented
       │      ^
       │
-      =     at libra_account.bpl:6423:24: <boogie>: inline$$LibraAccount_pay_from_capability$0$Entry
-      =     at libra_account.bpl:3668:24: <boogie>: inline$$LibraAccount_exists$0$Entry
-      =     at libra_account.bpl:6477:6: <boogie>: inline$$LibraAccount_pay_from_capability$0$anon25_Else
-      =     at libra_account.bpl:3993:24: <boogie>: inline$$LibraAccount_create_account$0$Entry
-      =     at libra_account.bpl:4063:18: <boogie>: inline$$LibraAccount_create_account$0$anon31_Then
-      =     at libra_account.bpl:4067:6: <boogie>: inline$$LibraAccount_create_account$0$anon6$1
-      =     at libra_account.bpl:4078:6: <boogie>: inline$$LibraAccount_create_account$0$anon8$1
 
 bug:  This assertion might not hold.
 
@@ -162,15 +94,6 @@ bug:  This assertion might not hold.
  1014 │     assert false; // $AddressUtil_address_to_bytes not implemented
       │      ^
       │
-      =     at libra_account.bpl:6587:24: <boogie>: inline$$LibraAccount_pay_from_sender$0$Entry
-      =     at libra_account.bpl:6637:6: <boogie>: inline$$LibraAccount_pay_from_sender$0$anon14_Else
-      =     at libra_account.bpl:6668:24: <boogie>: inline$$LibraAccount_pay_from_sender_with_metadata$0$Entry
-      =     at libra_account.bpl:3668:24: <boogie>: inline$$LibraAccount_exists$0$Entry
-      =     at libra_account.bpl:6716:6: <boogie>: inline$$LibraAccount_pay_from_sender_with_metadata$0$anon22_Else
-      =     at libra_account.bpl:3993:24: <boogie>: inline$$LibraAccount_create_account$0$Entry
-      =     at libra_account.bpl:4063:18: <boogie>: inline$$LibraAccount_create_account$0$anon31_Then
-      =     at libra_account.bpl:4067:6: <boogie>: inline$$LibraAccount_create_account$0$anon6$1
-      =     at libra_account.bpl:4078:6: <boogie>: inline$$LibraAccount_create_account$0$anon8$1
 
 bug:  This assertion might not hold.
 
@@ -179,13 +102,6 @@ bug:  This assertion might not hold.
  1014 │     assert false; // $AddressUtil_address_to_bytes not implemented
       │      ^
       │
-      =     at libra_account.bpl:6668:24: <boogie>: inline$$LibraAccount_pay_from_sender_with_metadata$0$Entry
-      =     at libra_account.bpl:3668:24: <boogie>: inline$$LibraAccount_exists$0$Entry
-      =     at libra_account.bpl:6716:6: <boogie>: inline$$LibraAccount_pay_from_sender_with_metadata$0$anon22_Else
-      =     at libra_account.bpl:3993:24: <boogie>: inline$$LibraAccount_create_account$0$Entry
-      =     at libra_account.bpl:4063:18: <boogie>: inline$$LibraAccount_create_account$0$anon31_Then
-      =     at libra_account.bpl:4067:6: <boogie>: inline$$LibraAccount_create_account$0$anon6$1
-      =     at libra_account.bpl:4078:6: <boogie>: inline$$LibraAccount_create_account$0$anon8$1
 
 bug:  This assertion might not hold.
 
@@ -194,10 +110,3 @@ bug:  This assertion might not hold.
  1039 │     assert false; // $Hash_sha3_256 not implemented
       │      ^
       │
-      =     at libra_account.bpl:6807:24: <boogie>: inline$$LibraAccount_prologue$0$Entry
-      =     at libra_account.bpl:6912:18: <boogie>: inline$$LibraAccount_prologue$0$anon72_Then
-      =     at libra_account.bpl:6916:6: <boogie>: inline$$LibraAccount_prologue$0$anon12$1
-      =     at libra_account.bpl:3668:24: <boogie>: inline$$LibraAccount_exists$0$Entry
-      =     at libra_account.bpl:6922:6: <boogie>: inline$$LibraAccount_prologue$0$anon73_Else
-      =     at libra_account.bpl:6976:6: <boogie>: inline$$LibraAccount_prologue$0$anon77_Else
-      =     at libra_account.bpl:6988:6: <boogie>: inline$$LibraAccount_prologue$0$anon24$1


### PR DESCRIPTION
This fixes #3076.

In addition, this PR removes execution traces on .bpl for baseline files, as they appear to be not stable over multiple runs.

## Motivation

Invariants

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

Existing tests now behaves as expected.

## Related PRs

NA