### PR TITLE
[structured_log] Write structured logs in libra swarm

### DIFF
--- a/common/logger/src/lib.rs
+++ b/common/logger/src/lib.rs
@@ -118,7 +118,7 @@
 pub use log;
 
 pub mod prelude {
-    pub use crate::{crit, debug, error, info, trace, warn};
+    pub use crate::{crit, debug, error, info, send_struct_log, trace, warn};
 }
 
 mod struct_log;

--- a/common/workspace-builder/src/lib.rs
+++ b/common/workspace-builder/src/lib.rs
@@ -8,14 +8,15 @@ use std::{env, path::PathBuf, process::Command};
 const WORKSPACE_BUILD_ERROR_MSG: &str = r#"
     Unable to build all workspace binaries. Cannot continue running tests.
 
-    Try running 'cargo build --all --bins' yourself.
+    Try running 'cargo build --all --bins --exclude cluster-test' yourself.
 "#;
 
 // Global flag indicating if all binaries in the workspace have been built.
 static WORKSPACE_BUILT: Lazy<bool> = Lazy::new(|| {
     info!("Building project binaries");
     let args = if cfg!(debug_assertions) {
-        vec!["build", "--all", "--bins"]
+        // special case: excluding cluster-test as it exports no-struct-opt feature that poisons everything
+        vec!["build", "--all", "--bins", "--exclude", "cluster-test"]
     } else {
         vec!["build", "--all", "--bins", "--release"]
     };


### PR DESCRIPTION
Engineers want an easy way to check structured logs that their code produce, without running cluster test or other complex environments, so adding support for it into libra swarm. They are enabled by default and disabled only if logs are disabled.

Structured logs for each validator are placed in separate file, similarly to regular logs
