### PR TITLE
[language] Fix error handling for non-ASCII input

### DIFF
--- a/language/move-lang/src/lib.rs
+++ b/language/move-lang/src/lib.rs
@@ -245,6 +245,7 @@ fn parse_file(
     let no_comments_buffer = match strip_comments_and_verify(fname, &source_buffer) {
         Err(err) => {
             errors.push(err);
+            files.insert(fname, source_buffer);
             return Ok((None, errors));
         }
         Ok(no_comments_buffer) => no_comments_buffer,
@@ -303,8 +304,9 @@ fn verify_string(fname: &'static str, string: &str) -> Result<(), Error> {
             let span = Span::new(ByteIndex(idx as u32), ByteIndex(idx as u32));
             let loc = Loc::new(fname, span);
             let msg = format!(
-                "Parser Error: invalid character {} found when reading file.\
-                 Only ascii printable, tabs (\\t), and \\n line ending characters are permitted.",
+                "Invalid character '{}' found when reading file. \
+                 Only ASCII printable characters, tabs (\\t), and line endings (\\n) \
+                 are permitted.",
                 chr
             );
             Err(vec![(loc, msg)])

--- a/language/move-lang/tests/move_check/parser/invalid_character_comment.exp
+++ b/language/move-lang/tests/move_check/parser/invalid_character_comment.exp
@@ -1,0 +1,8 @@
+error: 
+
+   ┌── tests/move_check/parser/invalid_character_comment.move:3:44 ───
+   │
+ 3 │ // Non-ASCII characters in comments (e.g., ф) are also not allowed.
+   │                                            ^ Invalid character 'ф' found when reading file. Only ASCII printable characters, tabs (\t), and line endings (\n) are permitted.
+   │
+

--- a/language/move-lang/tests/move_check/parser/invalid_character_comment.move
+++ b/language/move-lang/tests/move_check/parser/invalid_character_comment.move
@@ -1,0 +1,5 @@
+address 0x0:
+
+// Non-ASCII characters in comments (e.g., ф) are also not allowed.
+module Temp {
+}

--- a/language/move-lang/tests/move_check/parser/invalid_character_non_ascii.exp
+++ b/language/move-lang/tests/move_check/parser/invalid_character_non_ascii.exp
@@ -1,0 +1,8 @@
+error: 
+
+   ┌── tests/move_check/parser/invalid_character_non_ascii.move:5:4 ───
+   │
+ 5 │    ф
+   │    ^ Invalid character 'ф' found when reading file. Only ASCII printable characters, tabs (\t), and line endings (\n) are permitted.
+   │
+

--- a/language/move-lang/tests/move_check/parser/invalid_character_non_ascii.move
+++ b/language/move-lang/tests/move_check/parser/invalid_character_non_ascii.move
@@ -1,0 +1,6 @@
+address 0x0:
+
+// Check that we provide good error messages for non-ASCII characters.
+module Temp {
+   ф
+}


### PR DESCRIPTION
The compiler was previously crashing when trying to handle the error loc because the list of source files was not updated when the input contains non-ASCII characters. Also tweak the error message.

## Motivation

Fix compiler crash

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

Added a new test for this.
