### PR TITLE
[mempool] restart VM when VM publishing option changes

### DIFF
--- a/language/libra-vm/src/libra_vm.rs
+++ b/language/libra-vm/src/libra_vm.rs
@@ -60,6 +60,15 @@ impl LibraVM {
         }
     }
 
+    pub fn init_with_config(gas_schedule: CostTable, on_chain_config: OnlineConfig) -> Self {
+        let inner = MoveVM::new();
+        Self {
+            move_vm: Arc::new(inner),
+            gas_schedule: Some(gas_schedule),
+            on_chain_config: Some(on_chain_config),
+        }
+    }
+
     /// Provides access to some internal APIs of the Libra VM.
     pub fn internals(&self) -> LibraVMInternals {
         LibraVMInternals(self)
@@ -111,14 +120,14 @@ impl LibraVM {
         Ok(table)
     }
 
-    fn get_gas_schedule(&self) -> VMResult<&CostTable> {
+    pub fn get_gas_schedule(&self) -> VMResult<&CostTable> {
         self.gas_schedule.as_ref().ok_or_else(|| {
             VMStatus::new(StatusCode::VM_STARTUP_FAILURE)
                 .with_sub_status(sub_status::VSF_GAS_SCHEDULE_NOT_FOUND)
         })
     }
 
-    fn get_libra_version(&self) -> VMResult<LibraVersion> {
+    pub fn get_libra_version(&self) -> VMResult<LibraVersion> {
         Ok(self.on_chain_config()?.version.clone())
     }
 

--- a/language/libra-vm/src/on_chain_configs.rs
+++ b/language/libra-vm/src/on_chain_configs.rs
@@ -7,7 +7,7 @@ use libra_types::on_chain_config::{
 use move_vm_state::data_cache::RemoteCache;
 
 #[derive(Debug, Clone)]
-pub(crate) struct VMConfig {
+pub struct VMConfig {
     pub publishing_options: VMPublishingOption,
     pub version: LibraVersion,
 }

--- a/mempool/src/core_mempool/unit_tests/shared_mempool_test.rs
+++ b/mempool/src/core_mempool/unit_tests/shared_mempool_test.rs
@@ -40,7 +40,10 @@ use std::{
     time::Duration,
 };
 use storage_service::mocks::mock_storage_client::MockStorageReadClient;
-use tokio::runtime::{Builder, Runtime};
+use tokio::{
+    runtime::{Builder, Runtime},
+    sync::RwLock,
+};
 use vm_validator::mocks::mock_vm_validator::MockVMValidator;
 
 #[derive(Default)]
@@ -97,7 +100,7 @@ fn init_single_shared_mempool(smp: &mut SharedMempoolNetwork, peer_id: PeerId, c
         state_sync_events,
         reconfig_events_receiver,
         Arc::new(MockStorageReadClient),
-        Arc::new(MockVMValidator),
+        Arc::new(RwLock::new(MockVMValidator)),
         vec![sender],
         Some(timer_receiver.map(|_| SyncEvent).boxed()),
     );

--- a/mempool/src/mocks/mock_shared_mempool.rs
+++ b/mempool/src/mocks/mock_shared_mempool.rs
@@ -22,7 +22,10 @@ use std::{
     sync::{Arc, Mutex},
 };
 use storage_service::mocks::mock_storage_client::MockStorageReadClient;
-use tokio::runtime::{Builder, Runtime};
+use tokio::{
+    runtime::{Builder, Runtime},
+    sync::RwLock,
+};
 use vm_validator::mocks::mock_vm_validator::MockVMValidator;
 
 /// Mock of a running instance of shared mempool
@@ -93,7 +96,7 @@ impl MockSharedMempool {
             state_sync_events,
             reconfig_event_subscriber,
             Arc::new(MockStorageReadClient),
-            Arc::new(MockVMValidator),
+            Arc::new(RwLock::new(MockVMValidator)),
             vec![sender],
             None,
         );

--- a/mempool/src/shared_mempool.rs
+++ b/mempool/src/shared_mempool.rs
@@ -602,15 +602,12 @@ async fn process_config_update<V>(config_update: OnChainConfigPayload, validator
 where
     V: TransactionValidation,
 {
-    if config_update.get::<VMPublishingOption>().is_ok() {
-        // restart VM validator
-        validator
-            .write()
-            .await
-            .restart()
-            .await
-            .expect("failed to restart VM validator");
-    }
+    // restart VM validator
+    validator
+        .write()
+        .await
+        .restart(config_update)
+        .expect("failed to restart VM validator");
 }
 
 /// This task handles inbound network events.

--- a/testsuite/tests/libratest/smoke_test.rs
+++ b/testsuite/tests/libratest/smoke_test.rs
@@ -933,7 +933,7 @@ fn test_e2e_reconfiguration() {
 
 #[test]
 fn test_e2e_modify_publishing_option() {
-    let (mut env, mut client_proxy) = setup_swarm_and_client_proxy(1, 0);
+    let (_env, mut client_proxy) = setup_swarm_and_client_proxy(1, 0);
     client_proxy.create_next_account(false).unwrap();
 
     client_proxy
@@ -965,16 +965,6 @@ fn test_e2e_modify_publishing_option() {
     client_proxy
         .disable_custom_script(&["disallow_custom_script"], true)
         .unwrap();
-
-    // TODO: Currently VMValidator didn't restart after reconfiguration. We will manually restart
-    //       the node so that VMValidator is using the new config.
-    let peer_to_restart = 0;
-    // restart node
-    env.validator_swarm.kill_node(peer_to_restart);
-    assert!(env
-        .validator_swarm
-        .add_node(peer_to_restart, RoleType::Validator, false)
-        .is_ok());
 
     // mint another 10 coins after restart
     client_proxy

--- a/vm-validator/Cargo.toml
+++ b/vm-validator/Cargo.toml
@@ -15,7 +15,6 @@ async-trait = "0.1"
 futures = "0.3.0"
 tokio = { version = "0.2.13", features = ["full"] }
 libra-config = { path = "../config", version = "0.1.0" }
-libra-crypto = { path = "../crypto/crypto", version = "0.1.0" }
 scratchpad = { path = "../storage/scratchpad", version = "0.1.0" }
 libra-state-view = { path = "../storage/state-view", version = "0.1.0" }
 storage-client = { path = "../storage/storage-client", version = "0.1.0" }

--- a/vm-validator/Cargo.toml
+++ b/vm-validator/Cargo.toml
@@ -15,6 +15,7 @@ async-trait = "0.1"
 futures = "0.3.0"
 tokio = { version = "0.2.13", features = ["full"] }
 libra-config = { path = "../config", version = "0.1.0" }
+libra-crypto = { path = "../crypto/crypto", version = "0.1.0" }
 scratchpad = { path = "../storage/scratchpad", version = "0.1.0" }
 libra-state-view = { path = "../storage/state-view", version = "0.1.0" }
 storage-client = { path = "../storage/storage-client", version = "0.1.0" }

--- a/vm-validator/src/mocks/mock_vm_validator.rs
+++ b/vm-validator/src/mocks/mock_vm_validator.rs
@@ -75,4 +75,8 @@ impl TransactionValidation for MockVMValidator {
         };
         Ok(VMValidatorResult::new(ret, 0))
     }
+
+    async fn restart(&mut self) -> Result<()> {
+        unimplemented!();
+    }
 }

--- a/vm-validator/src/mocks/mock_vm_validator.rs
+++ b/vm-validator/src/mocks/mock_vm_validator.rs
@@ -6,6 +6,7 @@ use anyhow::Result;
 use libra_state_view::StateView;
 use libra_types::{
     account_address::AccountAddress,
+    on_chain_config::OnChainConfigPayload,
     transaction::{SignedTransaction, VMValidatorResult},
     vm_error::{StatusCode, VMStatus},
 };
@@ -76,7 +77,7 @@ impl TransactionValidation for MockVMValidator {
         Ok(VMValidatorResult::new(ret, 0))
     }
 
-    async fn restart(&mut self) -> Result<()> {
+    fn restart(&mut self, _config: OnChainConfigPayload) -> Result<()> {
         unimplemented!();
     }
 }


### PR DESCRIPTION
## Motivation

Mempool should restart VM validator when VM publishing options change, since this changes how mempool decides which submitted txns to accept

## Test Plan
Updated the smoke test `test_e2e_modify_publishing_option` to remove the hard-coded forced node restart to simulate vm restart, and test passes without restarting node