### PR TITLE
[storage] db-bootstraper

### DIFF
--- a/execution/executor-utils/src/lib.rs
+++ b/execution/executor-utils/src/lib.rs
@@ -4,7 +4,7 @@
 #[cfg(any(test, feature = "testing"))]
 pub mod test_helpers;
 
-use executor::Executor;
+use executor::{db_bootstrapper::maybe_bootstrap_db, Executor};
 use libra_config::config::NodeConfig;
 use libra_vm::LibraVM;
 use std::sync::Arc;
@@ -14,11 +14,11 @@ use tokio::runtime::Runtime;
 
 pub fn create_storage_service_and_executor(config: &NodeConfig) -> (Runtime, Executor<LibraVM>) {
     let rt = start_storage_service(config);
+    maybe_bootstrap_db::<LibraVM>(config).unwrap();
 
     let storage_read_client = Arc::new(StorageReadServiceClient::new(&config.storage.address));
     let storage_write_client = Arc::new(StorageWriteServiceClient::new(&config.storage.address));
-
-    let executor = Executor::new(storage_read_client, storage_write_client, config);
+    let executor = Executor::new(storage_read_client, storage_write_client);
 
     (rt, executor)
 }

--- a/execution/executor/src/db_bootstrapper.rs
+++ b/execution/executor/src/db_bootstrapper.rs
@@ -1,0 +1,77 @@
+// Copyright (c) The Libra Core Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+#![forbid(unsafe_code)]
+
+use crate::Executor;
+use anyhow::Result;
+use futures::executor::block_on;
+use libra_config::config::NodeConfig;
+use libra_crypto::{hash::PRE_GENESIS_BLOCK_ID, HashValue};
+use libra_logger::prelude::*;
+use libra_types::ledger_info::LedgerInfoWithSignatures;
+use libra_vm::VMExecutor;
+use std::sync::Arc;
+use storage_client::{StorageRead, StorageReadServiceClient, StorageWriteServiceClient};
+use storage_proto::StartupInfo;
+
+fn get_startup_info(storage_read_client: Arc<dyn StorageRead>) -> Result<Option<StartupInfo>> {
+    let read_client_clone = Arc::clone(&storage_read_client);
+
+    // TODO(aldenhu): remove once we switch to blocking Storage interface.
+    let rt = tokio::runtime::Builder::new()
+        .threaded_scheduler()
+        .enable_all()
+        .thread_name("tokio-executor")
+        .build()
+        .unwrap();
+    Ok(block_on(rt.spawn(async move {
+        read_client_clone
+            .get_startup_info()
+            .await
+            .expect("Shouldn't fail")
+    }))?)
+}
+
+pub fn maybe_bootstrap_db<V: VMExecutor>(config: &NodeConfig) -> Result<()> {
+    let storage_read_client = Arc::new(StorageReadServiceClient::new(&config.storage.address));
+
+    let startup_info_opt = get_startup_info(storage_read_client.clone())?;
+    if startup_info_opt.is_some() {
+        return Ok(());
+    }
+
+    let genesis_txn = config
+        .execution
+        .genesis
+        .as_ref()
+        .expect("failed to load genesis transaction!")
+        .clone();
+    let storage_write_client = Arc::new(StorageWriteServiceClient::new(&config.storage.address));
+    let mut executor =
+        Executor::<V>::new_on_unbootstrapped_db(storage_read_client, storage_write_client);
+
+    // Create a block with genesis_txn being the only transaction. Execute it then commit it
+    // immediately.
+    let result = executor.execute_block(
+        (
+            HashValue::zero(), // match with the id in BlockInfo::genesis(...)
+            vec![genesis_txn],
+        ),
+        *PRE_GENESIS_BLOCK_ID,
+    )?;
+
+    let root_hash = result.root_hash();
+    let validator_set = result
+        .validators()
+        .clone()
+        .expect("Genesis transaction must emit a validator set.");
+
+    let ledger_info_with_sigs = LedgerInfoWithSignatures::genesis(root_hash, validator_set.clone());
+    executor.commit_blocks(vec![HashValue::zero()], ledger_info_with_sigs)?;
+    info!(
+        "GENESIS transaction is committed with state_id {} and ValidatorSet {}.",
+        root_hash, validator_set
+    );
+    Ok(())
+}

--- a/execution/executor/src/db_bootstrapper.rs
+++ b/execution/executor/src/db_bootstrapper.rs
@@ -16,8 +16,6 @@ use storage_client::{StorageRead, StorageReadServiceClient, StorageWriteServiceC
 use storage_proto::StartupInfo;
 
 fn get_startup_info(storage_read_client: Arc<dyn StorageRead>) -> Result<Option<StartupInfo>> {
-    let read_client_clone = Arc::clone(&storage_read_client);
-
     // TODO(aldenhu): remove once we switch to blocking Storage interface.
     let rt = tokio::runtime::Builder::new()
         .threaded_scheduler()
@@ -26,7 +24,7 @@ fn get_startup_info(storage_read_client: Arc<dyn StorageRead>) -> Result<Option<
         .build()
         .unwrap();
     Ok(block_on(rt.spawn(async move {
-        read_client_clone
+        storage_read_client
             .get_startup_info()
             .await
             .expect("Shouldn't fail")

--- a/secure/key-manager/src/tests.rs
+++ b/secure/key-manager/src/tests.rs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::{Action, Error, KeyManager, LibraInterface};
-use executor::Executor;
+use executor::{db_bootstrapper::maybe_bootstrap_db, Executor};
 use libra_config::config::NodeConfig;
 use libra_crypto::{ed25519::Ed25519PrivateKey, HashValue, PrivateKey, Uniform};
 use libra_secure_storage::{InMemoryStorageInternal, KVStorage, Policy, Value};
@@ -76,6 +76,7 @@ impl Node {
         let storage = storage_service::init_libra_db(config);
         let storage_service =
             storage_service::start_storage_service_with_db(&config, storage.clone());
+        maybe_bootstrap_db::<LibraVM>(config).expect("Db-bootstrapper should not fail.");
         let executor = Executor::new(
             Arc::new(StorageReadServiceClient::new(&config.storage.address)),
             Arc::new(StorageWriteServiceClient::new(&config.storage.address)),

--- a/secure/key-manager/src/tests.rs
+++ b/secure/key-manager/src/tests.rs
@@ -79,7 +79,6 @@ impl Node {
         let executor = Executor::new(
             Arc::new(StorageReadServiceClient::new(&config.storage.address)),
             Arc::new(StorageWriteServiceClient::new(&config.storage.address)),
-            config,
         );
         let libra = TestLibraInterface {
             queued_transactions: Arc::new(RefCell::new(Vec::new())),


### PR DESCRIPTION

## Motivation

Extract genesis transaction applying logic out of executor and make sure executor won't start without bootstrapping db. The new file will evolve so that it's capable of applying genesis txn not only on top of an empty db but any db state. 

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?

(Write your answer here.)
yes
## Test Plan

(Share your test plan here. If you changed code, please provide us with clear instructions for verifying that your changes work.)
existing coverage

## Related PRs

(If this PR adds or changes functionality, please take some time to update the docs at https://github.com/libra/website, and link to your PR here.)
