### PR TITLE
[move-prover] Making update invariants on nested data structures work.

### DIFF
--- a/language/move-prover/spec-lang/src/env.rs
+++ b/language/move-prover/spec-lang/src/env.rs
@@ -1079,12 +1079,16 @@ impl<'env> StructEnv<'env> {
         handle.is_nominal_resource
     }
 
-    /// Get an iterator for the fields.
+    /// Get an iterator for the fields, ordered by offset.
     pub fn get_fields(&'env self) -> impl Iterator<Item = FieldEnv<'env>> {
-        self.data.field_data.values().map(move |data| FieldEnv {
-            struct_env: self.clone(),
-            data,
-        })
+        self.data
+            .field_data
+            .values()
+            .sorted_by_key(|data| data.offset)
+            .map(move |data| FieldEnv {
+                struct_env: self.clone(),
+                data,
+            })
     }
 
     /// Gets a field by its id.
@@ -1105,7 +1109,7 @@ impl<'env> StructEnv<'env> {
         })
     }
 
-    /// Gets a field by its id.
+    /// Gets a field by its offset.
     pub fn get_field_by_offset(&'env self, offset: usize) -> FieldEnv<'env> {
         for data in self.data.field_data.values() {
             if data.offset == offset {
@@ -1175,6 +1179,8 @@ pub struct FieldData {
 
     /// The struct definition index of this field in its module.
     def_idx: StructDefinitionIndex,
+
+    /// The offset of this field.
     offset: usize,
 }
 

--- a/language/move-prover/spec-lang/src/ty.rs
+++ b/language/move-prover/spec-lang/src/ty.rs
@@ -5,7 +5,7 @@
 
 use crate::{
     ast::QualifiedSymbol,
-    env::{ModuleId, StructId},
+    env::{GlobalEnv, ModuleId, StructEnv, StructId},
     symbol::SymbolPool,
 };
 use std::{collections::BTreeMap, fmt, fmt::Formatter};
@@ -85,6 +85,7 @@ impl Type {
         }
     }
 
+    /// Returns true if this is any number type.
     pub fn is_number(&self) -> bool {
         if let Type::Primitive(p) = self {
             if let PrimitiveType::U8
@@ -96,6 +97,18 @@ impl Type {
             }
         }
         false
+    }
+
+    /// If this is a struct type, return the associated struct env and type parameters.
+    pub fn get_struct<'env>(
+        &'env self,
+        env: &'env GlobalEnv,
+    ) -> Option<(StructEnv<'env>, &'env [Type])> {
+        if let Type::Struct(module_idx, struct_idx, params) = self {
+            Some((env.get_module(*module_idx).into_struct(*struct_idx), params))
+        } else {
+            None
+        }
     }
 
     /// Instantiates type parameters in this type.

--- a/language/move-prover/tests/sources/mut_ref_accross_modules.exp
+++ b/language/move-prover/tests/sources/mut_ref_accross_modules.exp
@@ -64,7 +64,7 @@ error:  This assertion might not hold.
     =         r = <redacted>
     =     at tests/sources/mut_ref_accross_modules.move:32:18: new
     =     at tests/sources/mut_ref_accross_modules.move:29:5: new (exit)
-    =     at tests/sources/mut_ref_accross_modules.move:115:18: private_to_public_caller_invalid_data_invariant
+    =     at tests/sources/mut_ref_accross_modules.move:115:22: private_to_public_caller_invalid_data_invariant
     =         x = <redacted>
     =     at tests/sources/mut_ref_accross_modules.move:116:18: private_to_public_caller_invalid_data_invariant
     =         r = <redacted>
@@ -78,8 +78,7 @@ error:  This assertion might not hold.
     =     at tests/sources/mut_ref_accross_modules.move:70:17: private_decrement
     =         x = <redacted>,
     =         r = <redacted>
-    =     at tests/sources/mut_ref_accross_modules.move:119:10: private_to_public_caller_invalid_data_invariant
-    =         r = <redacted>
+    =     at tests/sources/mut_ref_accross_modules.move:119:28: private_to_public_caller_invalid_data_invariant
 
 error:  A precondition for this call might not hold.
 

--- a/language/move-prover/tests/sources/nested_invariants.exp
+++ b/language/move-prover/tests/sources/nested_invariants.exp
@@ -1,0 +1,48 @@
+Move prover returns: exiting with boogie verification errors
+error:  This assertion might not hold.
+
+    ┌── tests/sources/nested_invariants.move:11:9 ───
+    │
+ 11 │         invariant x > 0;
+    │         ^^^^^^^^^^^^^^^^
+    │
+    =     at tests/sources/nested_invariants.move:58:5: mutate_inner_data_invariant_invalid (entry)
+    =     at tests/sources/nested_invariants.move:59:13: mutate_inner_data_invariant_invalid
+    =     at tests/sources/nested_invariants.move:60:17: mutate_inner_data_invariant_invalid
+    =         o = <redacted>,
+    =         r = <redacted>
+    =     at tests/sources/nested_invariants.move:61:17: mutate_inner_data_invariant_invalid
+    =         r = <redacted>
+
+error:  This assertion might not hold.
+
+    ┌── tests/sources/nested_invariants.move:27:9 ───
+    │
+ 27 │         invariant n.x < y;
+    │         ^^^^^^^^^^^^^^^^^^
+    │
+    =     at tests/sources/nested_invariants.move:52:5: mutate_outer_data_invariant_invalid (entry)
+    =     at tests/sources/nested_invariants.move:53:13: mutate_outer_data_invariant_invalid
+    =     at tests/sources/nested_invariants.move:54:17: mutate_outer_data_invariant_invalid
+    =         o = <redacted>,
+    =         r = <redacted>
+    =     at tests/sources/nested_invariants.move:55:15: mutate_outer_data_invariant_invalid
+    =         r = <redacted>
+
+error:  This assertion might not hold.
+
+    ┌── tests/sources/nested_invariants.move:11:9 ───
+    │
+ 11 │         invariant x > 0;
+    │         ^^^^^^^^^^^^^^^^
+    │
+    =     at tests/sources/nested_invariants.move:41:5: new_inner_data_invariant_invalid (entry)
+
+error:  This assertion might not hold.
+
+    ┌── tests/sources/nested_invariants.move:27:9 ───
+    │
+ 27 │         invariant n.x < y;
+    │         ^^^^^^^^^^^^^^^^^^
+    │
+    =     at tests/sources/nested_invariants.move:37:5: new_outer_data_invariant_invalid (entry)

--- a/language/move-prover/tests/sources/nested_invariants.move
+++ b/language/move-prover/tests/sources/nested_invariants.move
@@ -1,0 +1,63 @@
+module TestNestedInvariants {
+
+    // Tests scenarios for invariants with nested structs
+
+    struct Nested {
+        x: u64
+    }
+
+    spec struct Nested {
+        // We must always have a value greater one.
+        invariant x > 0;
+
+        // When we update via a reference, the new value must be smaller or equal the old one.
+        invariant update x <= old(x);
+    }
+
+    struct Outer {
+        y: u64,
+        n: Nested
+    }
+
+    spec struct Outer {
+        // Invariant for own field.
+        invariant y < 4;
+
+        // Invariant for field of aggregated struct in relation to own field.
+        invariant n.x < y;
+
+        // Update invariant for own field.
+        invariant update y <= old(y);
+    }
+
+    fun new(): Outer {
+        Outer{y: 3, n: Nested{x: 2}}
+    }
+
+    fun new_outer_data_invariant_invalid(): Outer {
+        Outer{y: 2, n: Nested{x: 2}}
+    }
+
+    fun new_inner_data_invariant_invalid(): Outer {
+        Outer{y: 2, n: Nested{x: 0}}
+    }
+
+    fun mutate() {
+        let o = Outer{y: 3, n: Nested{x: 2}};
+        let r = &mut o;
+        r.y = 2;
+        r.n.x = 1;
+    }
+
+    fun mutate_outer_data_invariant_invalid() {
+        let o = Outer{y: 3, n: Nested{x: 2}};
+        let r = &mut o;
+        r.y = 2;
+    }
+
+    fun mutate_inner_data_invariant_invalid() {
+        let o = Outer{y: 3, n: Nested{x: 2}};
+        let r = &mut o;
+        r.n.x = 0;
+    }
+}


### PR DESCRIPTION
Update invariants (and pack/unpack) on nested data structures haven't been correctly implemented before. This PR fixes some holes to this end. There is still an open problems with `Vector<StructWithInvariant>` which need to be fixed in a subsequent PR.

This also repairs field ordering in pack instructions. Shaz fixed this a couple of days ago, but it was accidentally reverted by the large file format PR which went in afterwards. We did not had a test with multiple fields to catch this. This PR also indirectly adds test for this use case.

## Motivation

Global specs.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

Added new tests.

## Related PRs

NA
