### PR TITLE
    [x] refactor lint engine to be extensible

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6373,6 +6373,7 @@ dependencies = [
  "chrono 0.4.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "env_logger 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "once_cell 1.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.105 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.50 (registry+https://github.com/rust-lang/crates.io-index)",
  "structopt 0.3.12 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/x/Cargo.toml
+++ b/x/Cargo.toml
@@ -12,6 +12,7 @@ serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0.50"
 structopt = "0.3.12"
 anyhow = "1.0"
+once_cell = "1.3.1"
 toml = "0.5.6"
 env_logger = "0.7.1"
 log = "0.4.8"

--- a/x/src/lint/engine/content.rs
+++ b/x/src/lint/engine/content.rs
@@ -1,0 +1,106 @@
+// Copyright (c) The Libra Core Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::lint::engine::{prelude::*, LintContext};
+use std::str;
+
+/// Represents a linter that checks file contents.
+pub trait ContentLinter: Linter {
+    /// Pre-run step -- avoids loading the contents if possible.
+    ///
+    /// The default implementation returns `Ok(RunStatus::Executed)`; individual lints may configure
+    /// a more restricted set.
+    fn pre_run<'l>(&self, _file_ctx: &FileContext<'l>) -> Result<RunStatus<'l>> {
+        Ok(RunStatus::Executed)
+    }
+
+    /// Executes the lint against the given content context.
+    fn run<'l>(
+        &self,
+        ctx: &ContentContext<'l>,
+        out: &mut LintFormatter<'l, '_>,
+    ) -> Result<RunStatus<'l>>;
+}
+
+#[derive(Debug)]
+pub struct ContentContext<'l> {
+    file_ctx: FileContext<'l>,
+    content: Content,
+}
+
+#[allow(dead_code)]
+impl<'l> ContentContext<'l> {
+    /// The number of bytes that will be searched for null bytes in a file to figure out if it is
+    /// binary.
+    ///
+    /// The value is [the same as Git's](https://stackoverflow.com/a/6134127).
+    pub const BINARY_FILE_CUTOFF: usize = 8000;
+
+    pub(super) fn new(file_ctx: FileContext<'l>, content: Vec<u8>) -> Self {
+        Self {
+            file_ctx,
+            content: Content::new(content),
+        }
+    }
+
+    /// Returns the file context.
+    pub fn file_ctx(&self) -> &FileContext<'l> {
+        &self.file_ctx
+    }
+
+    /// Returns the content, or `None` if this is a non-UTF-8 file.
+    pub fn content(&self) -> Option<&str> {
+        match &self.content {
+            Content::Utf8(text) => Some(text.as_ref()),
+            Content::NonUtf8(_) => None,
+        }
+    }
+
+    /// Returns the raw bytes for the content.
+    pub fn content_bytes(&self) -> &[u8] {
+        match &self.content {
+            Content::Utf8(text) => text.as_bytes(),
+            Content::NonUtf8(bin) => bin.as_ref(),
+        }
+    }
+
+    /// Returns true if this is a binary file.
+    pub fn is_binary(&self) -> bool {
+        match &self.content {
+            Content::Utf8(_) => {
+                // UTF-8 files are not binary by definition.
+                false
+            }
+            Content::NonUtf8(bin) => bin[..Self::BINARY_FILE_CUTOFF].contains(&0),
+        }
+    }
+}
+
+impl<'l> LintContext<'l> for ContentContext<'l> {
+    fn kind(&self) -> LintKind<'l> {
+        LintKind::Content(self.file_ctx.file_path())
+    }
+}
+
+#[derive(Debug)]
+enum Content {
+    Utf8(Box<str>),
+    NonUtf8(Box<[u8]>),
+}
+
+impl Content {
+    fn new(bytes: Vec<u8>) -> Self {
+        match String::from_utf8(bytes) {
+            Ok(s) => Content::Utf8(s.into()),
+            Err(err) => Content::NonUtf8(err.into_bytes().into()),
+        }
+    }
+
+    #[allow(dead_code)]
+    fn len(&self) -> usize {
+        match self {
+            Content::Utf8(text) => text.len(),
+            Content::NonUtf8(bin) => bin.len(),
+        }
+    }
+}

--- a/x/src/lint/engine/file.rs
+++ b/x/src/lint/engine/file.rs
@@ -1,0 +1,52 @@
+// Copyright (c) The Libra Core Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::lint::engine::{prelude::*, LintContext};
+use std::{ffi::OsStr, fs, path::Path};
+
+/// Contains information for a single file.
+#[derive(Clone, Debug)]
+pub struct FileContext<'l> {
+    project_ctx: ProjectContext<'l>,
+    file_path: &'l Path,
+}
+
+#[allow(dead_code)]
+impl<'l> FileContext<'l> {
+    pub fn new(project_ctx: ProjectContext<'l>, file_path: &'l Path) -> Self {
+        Self {
+            project_ctx,
+            file_path,
+        }
+    }
+
+    /// Returns the project context.
+    pub fn project_ctx(&self) -> ProjectContext<'l> {
+        self.project_ctx
+    }
+
+    pub fn file_path(&self) -> &'l Path {
+        &self.file_path
+    }
+
+    /// Returns the extension of the file. Returns `None` if there's no extension or if the
+    /// extension isn't valid UTF-8.
+    pub fn extension(&self) -> Option<&'l str> {
+        self.file_path.extension().map(OsStr::to_str).flatten()
+    }
+
+    /// Loads this file and turns it into a `ContentContext`.
+    ///
+    /// `pub(super)` is to dissuade individual linters from loading file contexts.
+    pub(super) fn load(self) -> Result<ContentContext<'l>> {
+        let full_path = self.project_ctx.full_path(self.file_path);
+        let content = fs::read(&full_path)?;
+        Ok(ContentContext::new(self, content))
+    }
+}
+
+impl<'l> LintContext<'l> for FileContext<'l> {
+    fn kind(&self) -> LintKind<'l> {
+        LintKind::File(self.file_path)
+    }
+}

--- a/x/src/lint/engine/mod.rs
+++ b/x/src/lint/engine/mod.rs
@@ -1,0 +1,206 @@
+// Copyright (c) The Libra Core Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+//! Lint engine.
+//!
+//! The overall design is generally inspired by
+//! [Arcanist](https://secure.phabricator.com/book/phabricator/article/arcanist_lint)'s lint engine.
+
+pub mod content;
+pub mod file;
+pub mod project;
+mod runner;
+
+pub use runner::*;
+
+use std::{borrow::Cow, error, fmt, io, path::Path, process::ExitStatus, result};
+
+/// Represents a linter.
+pub trait Linter: Send + Sync + fmt::Debug {
+    /// Returns the name of the linter.
+    fn name(&self) -> &'static str;
+}
+
+/// Represents common functionality among various `Context` instances.
+pub(super) trait LintContext<'l> {
+    /// Returns the kind of this lint context.
+    fn kind(&self) -> LintKind<'l>;
+
+    /// Returns a `LintSource` for this lint context.
+    fn source(&self, name: &'static str) -> LintSource<'l> {
+        LintSource::new(name, self.kind())
+    }
+}
+
+/// A lint formatter.
+///
+/// Lints write `LintMessage` instances to this.
+pub struct LintFormatter<'l, 'a> {
+    source: LintSource<'l>,
+    messages: &'a mut Vec<(LintSource<'l>, LintMessage)>,
+}
+
+impl<'l, 'a> LintFormatter<'l, 'a> {
+    pub fn new(
+        source: LintSource<'l>,
+        messages: &'a mut Vec<(LintSource<'l>, LintMessage)>,
+    ) -> Self {
+        Self { source, messages }
+    }
+
+    /// Writes a new lint message to this formatter.
+    pub fn write(&mut self, message: LintMessage) {
+        self.messages.push((self.source, message));
+    }
+}
+
+/// The run status of a lint.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub enum RunStatus<'l> {
+    /// This lint run was successful, with messages possibly written into the `LintFormatter`.
+    Executed,
+    /// This lint was skipped.
+    Skipped(SkipReason<'l>),
+}
+
+/// The reason for why this lint was skipped.
+#[derive(Clone, Debug, Eq, PartialEq)]
+#[non_exhaustive]
+pub enum SkipReason<'l> {
+    /// This file was not valid UTF-8.
+    NonUtf8,
+    /// This extension was unsupported.
+    UnsupportedExtension(Option<&'l str>),
+    // TODO: Add more reasons.
+}
+
+/// A message raised by a lint.
+#[derive(Debug)]
+pub struct LintMessage {
+    level: LintLevel,
+    message: Cow<'static, str>,
+}
+
+impl LintMessage {
+    pub fn new(level: LintLevel, message: impl Into<Cow<'static, str>>) -> Self {
+        Self {
+            level,
+            message: message.into(),
+        }
+    }
+
+    pub fn level(&self) -> LintLevel {
+        self.level
+    }
+
+    pub fn message(&self) -> &str {
+        &self.message
+    }
+}
+
+#[derive(Copy, Clone, Debug, Eq, PartialEq)]
+#[allow(dead_code)]
+#[non_exhaustive]
+pub enum LintLevel {
+    Error,
+    Warning,
+    // TODO: add more levels?
+}
+
+impl fmt::Display for LintLevel {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match self {
+            LintLevel::Error => write!(f, "ERROR"),
+            LintLevel::Warning => write!(f, "WARNING"),
+        }
+    }
+}
+
+/// Message source for lints.
+#[derive(Copy, Clone, Debug)]
+pub struct LintSource<'l> {
+    name: &'static str,
+    kind: LintKind<'l>,
+}
+
+impl<'l> LintSource<'l> {
+    pub(super) fn new(name: &'static str, kind: LintKind<'l>) -> Self {
+        Self { name, kind }
+    }
+
+    pub fn name(&self) -> &'static str {
+        self.name
+    }
+
+    pub fn kind(&self) -> LintKind<'l> {
+        self.kind
+    }
+}
+
+#[derive(Copy, Clone, Debug, Eq, PartialEq)]
+pub enum LintKind<'l> {
+    Project,
+    File(&'l Path),
+    Content(&'l Path),
+}
+
+impl<'l> fmt::Display for LintKind<'l> {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match self {
+            LintKind::Project => write!(f, "project"),
+            LintKind::File(path) => write!(f, "file {}", path.display()),
+            LintKind::Content(path) => write!(f, "content {}", path.display()),
+        }
+    }
+}
+
+/// Type alias for the return type for `run` methods.
+pub type Result<T, E = SystemError> = result::Result<T, E>;
+
+/// A system error that happened while running a lint.
+#[derive(Debug)]
+#[non_exhaustive]
+pub enum SystemError {
+    Exec {
+        cmd: &'static str,
+        status: ExitStatus,
+    },
+    Io(io::Error),
+}
+
+impl fmt::Display for SystemError {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match self {
+            SystemError::Exec { cmd, status } => match status.code() {
+                Some(code) => write!(f, "'{}' failed with exit code {}", cmd, code),
+                None => write!(f, "'{}' terminated by signal", cmd),
+            },
+            SystemError::Io(err) => write!(f, "IO error: {}", err),
+        }
+    }
+}
+
+impl error::Error for SystemError {
+    fn source(&self) -> Option<&(dyn error::Error + 'static)> {
+        match self {
+            SystemError::Exec { .. } => None,
+            SystemError::Io(err) => Some(err),
+        }
+    }
+}
+
+impl From<io::Error> for SystemError {
+    fn from(err: io::Error) -> Self {
+        SystemError::Io(err)
+    }
+}
+
+pub mod prelude {
+    pub use super::{
+        content::{ContentContext, ContentLinter},
+        file::FileContext,
+        project::ProjectContext,
+        LintFormatter, LintKind, LintLevel, LintMessage, LintSource, Linter, Result, RunStatus,
+        SkipReason, SystemError,
+    };
+}

--- a/x/src/lint/engine/project.rs
+++ b/x/src/lint/engine/project.rs
@@ -1,0 +1,34 @@
+// Copyright (c) The Libra Core Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::lint::engine::{LintContext, LintKind};
+use std::path::{Path, PathBuf};
+
+/// Overall linter context for a project.
+#[derive(Copy, Clone, Debug)]
+pub struct ProjectContext<'l> {
+    project_root: &'l Path,
+}
+
+#[allow(dead_code)]
+impl<'l> ProjectContext<'l> {
+    pub fn new(project_root: &'l Path) -> Self {
+        Self { project_root }
+    }
+
+    /// Returns the project root.
+    pub fn project_root(&self) -> &'l Path {
+        self.project_root
+    }
+
+    /// Returns the absolute path from the project root.
+    pub fn full_path(&self, path: impl AsRef<Path>) -> PathBuf {
+        self.project_root.join(path.as_ref())
+    }
+}
+
+impl<'l> LintContext<'l> for ProjectContext<'l> {
+    fn kind(&self) -> LintKind<'l> {
+        LintKind::Project
+    }
+}

--- a/x/src/lint/engine/runner.rs
+++ b/x/src/lint/engine/runner.rs
@@ -1,0 +1,196 @@
+// Copyright (c) The Libra Core Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::lint::engine::{prelude::*, LintContext};
+use once_cell::sync::OnceCell;
+use std::{
+    ffi::OsStr,
+    path::Path,
+    process::{Command, Stdio},
+};
+
+/// Configuration for the lint engine.
+#[derive(Clone, Debug)]
+pub struct LintEngineConfig<'cfg> {
+    project_root: &'cfg Path,
+    content_linters: &'cfg [&'cfg (dyn ContentLinter + 'cfg)],
+    fail_fast: bool,
+}
+
+impl<'cfg> LintEngineConfig<'cfg> {
+    pub fn new(project_root: &'cfg Path) -> Self {
+        Self {
+            project_root,
+            content_linters: &[],
+            fail_fast: false,
+        }
+    }
+
+    pub fn with_content_linters(
+        &mut self,
+        content_linters: &'cfg [&'cfg (dyn ContentLinter + 'cfg)],
+    ) -> &mut Self {
+        self.content_linters = content_linters;
+        self
+    }
+
+    pub fn fail_fast(&mut self, fail_fast: bool) -> &mut Self {
+        self.fail_fast = fail_fast;
+        self
+    }
+
+    pub fn build(&self) -> LintEngine<'cfg> {
+        LintEngine::new(self.clone())
+    }
+}
+
+/// Executor for linters.
+#[derive(Debug)]
+pub struct LintEngine<'cfg> {
+    config: LintEngineConfig<'cfg>,
+
+    // Caches to allow results to live as long as the engine itself.
+    files_stdout: OnceCell<Vec<u8>>,
+}
+
+impl<'cfg> LintEngine<'cfg> {
+    pub fn new(config: LintEngineConfig<'cfg>) -> Self {
+        Self {
+            config,
+            files_stdout: OnceCell::new(),
+        }
+    }
+
+    pub fn run(&self) -> Result<LintResults> {
+        let mut skipped = vec![];
+        let mut messages = vec![];
+
+        // TODO: add support for project and file lints.
+
+        let project_ctx = ProjectContext::new(self.config.project_root);
+
+        if !self.config.content_linters.is_empty() {
+            let file_list = self.get_file_list()?;
+
+            // TODO: This should probably be a worker queue with a thread pool or something.
+
+            let file_ctxs = file_list
+                .iter()
+                .map(|path| FileContext::new(project_ctx, path));
+
+            'outer: for file_ctx in file_ctxs {
+                let linters_to_run = self
+                    .config
+                    .content_linters
+                    .iter()
+                    .copied()
+                    .filter_map(|linter| match linter.pre_run(&file_ctx) {
+                        Ok(RunStatus::Executed) => Some(Ok(linter)),
+                        Ok(RunStatus::Skipped(reason)) => {
+                            let source = file_ctx.source(linter.name());
+                            skipped.push((source, reason));
+                            None
+                        }
+                        Err(err) => Some(Err(err)),
+                    })
+                    .collect::<Result<Vec<_>>>()?;
+
+                if linters_to_run.is_empty() {
+                    // No linters to run for this file -- no point loading it.
+                    continue;
+                }
+
+                // Load up the content for this file.
+                let content_ctx = file_ctx.load()?;
+
+                for linter in linters_to_run {
+                    let source = content_ctx.source(linter.name());
+                    let mut formatter = LintFormatter::new(source, &mut messages);
+
+                    match linter.run(&content_ctx, &mut formatter)? {
+                        RunStatus::Executed => {
+                            // Yay! Lint ran successfully.
+                        }
+                        RunStatus::Skipped(reason) => {
+                            skipped.push((source, reason));
+                        }
+                    }
+
+                    if self.config.fail_fast && !messages.is_empty() {
+                        // At least one issue was found.
+                        break 'outer;
+                    }
+                }
+            }
+        }
+
+        Ok(LintResults { skipped, messages })
+    }
+
+    // ---
+    // Helper methods
+    // ---
+
+    fn get_file_list(&self) -> Result<Vec<&Path>> {
+        // TODO: It'd be pretty cool to be able to cache the `&Path` instances as well. The options
+        // are:
+        // 1. Cache them as `PathBuf` instances. That would involve lots of allocations.
+        // 2. Store the `&Path` instances alongside `files_stdout`. That would be a self-referential
+        //    struct (so would require the use of something like
+        //    [`rental`](https://docs.rs/rental/).
+        // 3. Reorganize the code to use some sort of arena allocator which is passed into the lint
+        //    context (and/or stored alongside with `rental`.)
+        let stdout = self.files_stdout()?;
+
+        Ok(stdout
+            .split(|b| b == &0)
+            .filter_map(|s| {
+                // TODO: make global exclusions configurable.
+                if !s.is_empty() && !s.starts_with(b"testsuite/libra-fuzzer/artifacts/") {
+                    // `OsStr::from_bytes` only works on Unix, since "OS strings" on Windows are
+                    // actually UTF-16ish. Would be cool to get it working on Windows at some point
+                    // too, but it needs to be done with some care.
+                    //
+                    // For more, see:
+                    // * https://doc.rust-lang.org/std/ffi/index.html#conversions
+                    // * https://www.mercurial-scm.org/wiki/EncodingStrategy and
+                    // * https://en.wikipedia.org/wiki/Mojibake.
+                    use std::os::unix::ffi::OsStrExt;
+
+                    let s = OsStr::from_bytes(s);
+                    Some(Path::new(s))
+                } else {
+                    None
+                }
+            })
+            .collect())
+    }
+
+    fn files_stdout(&self) -> Result<&[u8]> {
+        self.files_stdout
+            .get_or_try_init(|| {
+                // TODO: abstract out SCM and command-running functionality.
+                let output = Command::new("git")
+                    .current_dir(self.config.project_root)
+                    // The -z causes files to not be quoted, and to be separated by \0.
+                    .args(&["ls-files", "-z"])
+                    .stderr(Stdio::inherit())
+                    .output()?;
+                if !output.status.success() {
+                    return Err(SystemError::Exec {
+                        cmd: "git ls-files",
+                        status: output.status,
+                    });
+                }
+                Ok(output.stdout)
+            })
+            .map(|stdout| stdout.as_slice())
+    }
+}
+
+#[derive(Debug)]
+#[non_exhaustive]
+pub struct LintResults<'l> {
+    pub skipped: Vec<(LintSource<'l>, SkipReason<'l>)>,
+    pub messages: Vec<(LintSource<'l>, LintMessage)>,
+}

--- a/x/src/lint/license.rs
+++ b/x/src/lint/license.rs
@@ -1,54 +1,89 @@
 // Copyright (c) The Libra Core Contributors
 // SPDX-License-Identifier: Apache-2.0
 
-use std::{borrow::Cow, convert, ffi::OsStr, path::Path};
+use crate::lint::engine::prelude::*;
 
 static LICENSE_HEADER: &str = "Copyright (c) The Libra Core Contributors\n\
                                SPDX-License-Identifier: Apache-2.0\n\
                                ";
 
-pub(super) fn has_license_header(file: &Path, contents: &str) -> Result<(), Cow<'static, str>> {
-    enum FileType {
-        Rust,
-        Shell,
-        Proto,
+#[derive(Copy, Clone, Debug)]
+pub(super) struct LicenseHeader;
+
+impl Linter for LicenseHeader {
+    fn name(&self) -> &'static str {
+        "license-header"
+    }
+}
+
+impl ContentLinter for LicenseHeader {
+    fn pre_run<'l>(&self, file_ctx: &FileContext<'l>) -> Result<RunStatus<'l>> {
+        // TODO: Add a way to pass around state between pre_run and run, so that this computation
+        // only needs to be done once.
+        match FileType::new(file_ctx) {
+            Some(_) => Ok(RunStatus::Executed),
+            None => Ok(RunStatus::Skipped(SkipReason::UnsupportedExtension(
+                file_ctx.extension(),
+            ))),
+        }
     }
 
-    let file_type = match file
-        .extension()
-        .map(OsStr::to_str)
-        .and_then(convert::identity)
-    {
-        Some("rs") => FileType::Rust,
-        Some("sh") => FileType::Shell,
-        Some("proto") => FileType::Proto,
-        _ => return Ok(()),
-    };
+    fn run<'l>(
+        &self,
+        ctx: &ContentContext<'l>,
+        out: &mut LintFormatter<'l, '_>,
+    ) -> Result<RunStatus<'l>> {
+        let content = match ctx.content() {
+            Some(content) => content,
+            None => {
+                // This is not a UTF-8 file -- don't analyze it.
+                return Ok(RunStatus::Skipped(SkipReason::NonUtf8));
+            }
+        };
 
-    // Determine if the file is missing the license header
-    let missing_header = match file_type {
-        FileType::Rust | FileType::Proto => {
-            let maybe_license = contents
-                .lines()
-                .skip_while(|line| line.is_empty())
-                .take(2)
-                .map(|s| s.trim_start_matches("// "));
-            !LICENSE_HEADER.lines().eq(maybe_license)
-        }
-        FileType::Shell => {
-            let maybe_license = contents
-                .lines()
-                .skip_while(|line| line.starts_with("#!"))
-                .skip_while(|line| line.is_empty())
-                .take(2)
-                .map(|s| s.trim_start_matches("# "));
-            !LICENSE_HEADER.lines().eq(maybe_license)
-        }
-    };
+        let file_type = FileType::new(ctx.file_ctx()).expect("None filtered out in pre_run");
+        // Determine if the file is missing the license header
+        let missing_header = match file_type {
+            FileType::Rust | FileType::Proto => {
+                let maybe_license = content
+                    .lines()
+                    .skip_while(|line| line.is_empty())
+                    .take(2)
+                    .map(|s| s.trim_start_matches("// "));
+                !LICENSE_HEADER.lines().eq(maybe_license)
+            }
+            FileType::Shell => {
+                let maybe_license = content
+                    .lines()
+                    .skip_while(|line| line.starts_with("#!"))
+                    .skip_while(|line| line.is_empty())
+                    .take(2)
+                    .map(|s| s.trim_start_matches("# "));
+                !LICENSE_HEADER.lines().eq(maybe_license)
+            }
+        };
 
-    if missing_header {
-        return Err("missing a license header".into());
+        if missing_header {
+            out.write(LintMessage::new(LintLevel::Error, "missing license header"));
+        }
+
+        Ok(RunStatus::Executed)
     }
+}
 
-    Ok(())
+enum FileType {
+    Rust,
+    Shell,
+    Proto,
+}
+
+impl FileType {
+    fn new(ctx: &FileContext<'_>) -> Option<Self> {
+        match ctx.extension() {
+            Some("rs") => Some(FileType::Rust),
+            Some("sh") => Some(FileType::Shell),
+            Some("proto") => Some(FileType::Proto),
+            _ => None,
+        }
+    }
 }

--- a/x/src/lint/mod.rs
+++ b/x/src/lint/mod.rs
@@ -1,17 +1,15 @@
 // Copyright (c) The Libra Core Contributors
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::{config::Config, utils::project_root};
-use anyhow::anyhow;
-use std::{
-    borrow::Cow,
-    fs,
-    path::{Path, PathBuf},
-    process::{Command, Stdio},
-    str,
+use crate::{
+    config::Config,
+    lint::engine::{prelude::*, LintEngineConfig},
+    utils::project_root,
 };
+use anyhow::anyhow;
 use structopt::StructOpt;
 
+mod engine;
 mod license;
 mod whitespace;
 
@@ -21,64 +19,35 @@ pub struct Args {
     fail_fast: bool,
 }
 
-/// List of lints to run
-static LINTS: &[fn(&Path, &str) -> Result<(), Cow<'static, str>>] = &[
-    license::has_license_header,
-    whitespace::has_newline_at_eof,
-    whitespace::has_trailing_whitespace,
-];
-
 pub fn run(args: Args, _config: Config) -> crate::Result<()> {
-    let mut errors = false;
-    let project_root = project_root();
-    let mut full_file_path = PathBuf::new();
+    let content_linters: &[&dyn ContentLinter] = &[
+        &license::LicenseHeader,
+        &whitespace::EofNewline,
+        &whitespace::TrailingWhitespace,
+    ];
 
-    for file in get_file_listing()? {
-        full_file_path.push(&project_root);
-        full_file_path.push(&file);
+    let engine = LintEngineConfig::new(project_root())
+        .with_content_linters(content_linters)
+        .fail_fast(args.fail_fast)
+        .build();
 
-        let contents = match fs::read_to_string(&full_file_path) {
-            Ok(s) => s,
-            // Skip non utf8 files
-            Err(_) => continue,
-        };
+    let results = engine.run()?;
 
-        // Run each lint on the file
-        for lint in LINTS {
-            if let Err(e) = lint(&file, &contents) {
-                errors = true;
-                let msg = format!("{}: {}", file.display(), e);
-                if args.fail_fast {
-                    return Err(anyhow!(msg));
-                } else {
-                    println!("{}", msg);
-                }
-            }
-        }
+    // TODO: handle skipped results
+
+    for (source, message) in &results.messages {
+        println!(
+            "[{}] [{}] [{}]: {}",
+            message.level(),
+            source.name(),
+            source.kind(),
+            message.message()
+        );
     }
 
-    if errors {
+    if !results.messages.is_empty() {
         Err(anyhow!("there were lint errors"))
     } else {
         Ok(())
     }
-}
-
-fn get_file_listing() -> crate::Result<Vec<PathBuf>> {
-    let project_root = project_root();
-    let output = Command::new("git")
-        .current_dir(&project_root)
-        .arg("ls-files")
-        .stderr(Stdio::inherit())
-        .output()?;
-    if !output.status.success() {
-        return Err(anyhow!("failed to run git command"));
-    }
-
-    Ok(str::from_utf8(&output.stdout)?
-        .split('\n')
-        .filter(|s| !s.is_empty() && !s.starts_with("testsuite/libra-fuzzer/artifacts/"))
-        .map(Path::new)
-        .map(Path::to_path_buf)
-        .collect())
 }

--- a/x/src/lint/whitespace.rs
+++ b/x/src/lint/whitespace.rs
@@ -1,55 +1,91 @@
 // Copyright (c) The Libra Core Contributors
 // SPDX-License-Identifier: Apache-2.0
 
-use std::{borrow::Cow, convert, ffi::OsStr, path::Path, str};
+use crate::lint::engine::prelude::*;
 
-pub(super) fn has_newline_at_eof(file: &Path, contents: &str) -> Result<(), Cow<'static, str>> {
-    if skip_whitespace_checks(file) {
-        return Ok(());
-    }
+#[derive(Clone, Copy, Debug)]
+pub(super) struct EofNewline;
 
-    if !contents.ends_with('\n') {
-        Err("missing a newline at EOF".into())
-    } else {
-        Ok(())
+impl Linter for EofNewline {
+    fn name(&self) -> &'static str {
+        "eof-newline"
     }
 }
 
-pub(super) fn has_trailing_whitespace(
-    file: &Path,
-    contents: &str,
-) -> Result<(), Cow<'static, str>> {
-    if skip_whitespace_checks(file) {
-        return Ok(());
+impl ContentLinter for EofNewline {
+    fn pre_run<'l>(&self, file_ctx: &FileContext<'l>) -> Result<RunStatus<'l>> {
+        Ok(skip_whitespace_checks(file_ctx.extension()))
     }
 
-    for (ln, line) in contents
-        .lines()
-        .enumerate()
-        .map(|(ln, line)| (ln + 1, line))
-    {
-        if line.trim_end() != line {
-            return Err(Cow::Owned(format!("trailing whitespace on line {}", ln)));
+    fn run<'l>(
+        &self,
+        ctx: &ContentContext<'l>,
+        out: &mut LintFormatter<'l, '_>,
+    ) -> Result<RunStatus<'l>> {
+        let content = match ctx.content() {
+            Some(text) => text,
+            None => return Ok(RunStatus::Skipped(SkipReason::NonUtf8)),
+        };
+        if !content.ends_with('\n') {
+            out.write(LintMessage::new(LintLevel::Error, "missing newline at EOF"));
         }
+        Ok(RunStatus::Executed)
     }
-
-    if contents
-        .lines()
-        .rev()
-        .take_while(|line| line.is_empty())
-        .count()
-        > 0
-    {
-        return Err("trailing whitespace at EOF".into());
-    }
-
-    Ok(())
 }
 
-fn skip_whitespace_checks(file: &Path) -> bool {
-    let ext = file
-        .extension()
-        .map(OsStr::to_str)
-        .and_then(convert::identity);
-    matches!(ext, Some("exp"))
+#[derive(Clone, Copy, Debug)]
+pub(super) struct TrailingWhitespace;
+
+impl Linter for TrailingWhitespace {
+    fn name(&self) -> &'static str {
+        "trailing-whitespace"
+    }
+}
+
+impl ContentLinter for TrailingWhitespace {
+    fn pre_run<'l>(&self, file_ctx: &FileContext<'l>) -> Result<RunStatus<'l>> {
+        Ok(skip_whitespace_checks(file_ctx.extension()))
+    }
+
+    fn run<'l>(
+        &self,
+        ctx: &ContentContext<'l>,
+        out: &mut LintFormatter<'l, '_>,
+    ) -> Result<RunStatus<'l>> {
+        let content = match ctx.content() {
+            Some(text) => text,
+            None => return Ok(RunStatus::Skipped(SkipReason::NonUtf8)),
+        };
+
+        for (ln, line) in content.lines().enumerate().map(|(ln, line)| (ln + 1, line)) {
+            if line.trim_end() != line {
+                out.write(LintMessage::new(
+                    LintLevel::Error,
+                    format!("trailing whitespace at line {}", ln),
+                ));
+            }
+        }
+
+        if content
+            .lines()
+            .rev()
+            .take_while(|line| line.is_empty())
+            .count()
+            > 0
+        {
+            out.write(LintMessage::new(
+                LintLevel::Error,
+                "trailing whitespace at EOF",
+            ));
+        }
+
+        Ok(RunStatus::Executed)
+    }
+}
+
+fn skip_whitespace_checks(ext: Option<&str>) -> RunStatus {
+    match ext {
+        Some("exp") => RunStatus::Skipped(SkipReason::UnsupportedExtension(ext)),
+        _ => RunStatus::Executed,
+    }
 }

--- a/x/src/utils.rs
+++ b/x/src/utils.rs
@@ -5,12 +5,11 @@ use crate::{cargo::Cargo, Result};
 use serde::Deserialize;
 use std::path::{Path, PathBuf};
 
-pub fn project_root() -> PathBuf {
+pub fn project_root() -> &'static Path {
     Path::new(&env!("CARGO_MANIFEST_DIR"))
         .ancestors()
         .nth(1)
         .unwrap()
-        .to_path_buf()
 }
 
 pub fn locate_project() -> Result<PathBuf> {


### PR DESCRIPTION
I'd like to start adding file name and global lints. Build out a simple framework to allow the lint engine to be extensible.

The framework is generally inspired by Arcanist, but it has several tweaks based on my experiences dealing with the lint engine there. For example, there's now a clear separation between project, file and content linters.