### PR TITLE
[move source lang] Added check for instantiation loops

### DIFF
--- a/language/move-lang/src/naming/ast.rs
+++ b/language/move-lang/src/naming/ast.rs
@@ -116,10 +116,10 @@ pub type TypeName = Spanned<TypeName_>;
 #[derive(Debug, Hash, Eq, PartialEq, Ord, PartialOrd, Copy, Clone)]
 pub struct TParamID(pub u64);
 
-#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct TParam {
     pub id: TParamID,
-    pub debug: Name,
+    pub user_specified_name: Name,
     pub kind: Kind,
 }
 
@@ -615,8 +615,12 @@ impl AstDebug for TypeName_ {
 
 impl AstDebug for TParam {
     fn ast_debug(&self, w: &mut AstWriter) {
-        let TParam { id, debug, kind } = self;
-        w.write(&format!("{}#{}", debug, id.0));
+        let TParam {
+            id,
+            user_specified_name,
+            kind,
+        } = self;
+        w.write(&format!("{}#{}", user_specified_name, id.0));
         match &kind.value {
             Kind_::Unknown => (),
             Kind_::Resource => w.write(": resource"),

--- a/language/move-lang/src/naming/translate.rs
+++ b/language/move-lang/src/naming/translate.rs
@@ -560,8 +560,12 @@ fn type_parameters(context: &mut Context, type_parameters: Vec<(Name, Kind)>) ->
         .into_iter()
         .map(|(name, kind)| {
             let id = N::TParamID::next();
-            let debug = name.clone();
-            let tp = N::TParam { id, debug, kind };
+            let user_specified_name = name.clone();
+            let tp = N::TParam {
+                id,
+                user_specified_name,
+                kind,
+            };
             let loc = name.loc;
             context.bind_type(
                 name.value.to_string(),

--- a/language/move-lang/src/parser/ast.rs
+++ b/language/move-lang/src/parser/ast.rs
@@ -245,7 +245,7 @@ pub enum ModuleAccess_ {
 }
 pub type ModuleAccess = Spanned<ModuleAccess_>;
 
-#[derive(Debug, PartialEq, Eq, PartialOrd, Ord, Clone)]
+#[derive(Debug, PartialEq, Eq, PartialOrd, Ord, Clone, Hash)]
 pub enum Kind_ {
     // Kind representing all types
     Unknown,

--- a/language/move-lang/src/test_utils/mod.rs
+++ b/language/move-lang/src/test_utils/mod.rs
@@ -20,7 +20,8 @@ pub const IR_EXTENSION: &str = "mvir";
 
 pub const DEBUG_MODULE_FILE_NAME: &str = "debug.move";
 
-pub const COMPLETED_DIRECTORIES: &[&str; 2] = &["borrow_tests", "commands"];
+pub const COMPLETED_DIRECTORIES: &[&str; 3] =
+    &["borrow_tests", "commands", "generics/instantiation_loops"];
 
 /// We need to replicate the specification of the (non-staged) stdlib files here since we can't
 /// import the stdlib crate: it will create a circular dependency since the stdlib needs the
@@ -76,17 +77,36 @@ pub fn error(s: String) -> datatest_stable::Result<()> {
 pub fn ir_tests() -> impl Iterator<Item = (String, String)> {
     macro_rules! comp_to_string {
         ($comp_opt:expr) => {{
-            $comp_opt.unwrap().as_os_str().to_str()?.to_owned()
+            $comp_opt.as_os_str().to_str()?
         }};
     }
-    datatest_stable::utils::iterate_directory(Path::new(PATH_TO_IR_TESTS)).flat_map(|path| {
+    let num_root_components = Path::new(PATH_TO_IR_TESTS)
+        .canonicalize()
+        .unwrap()
+        .components()
+        .map(|_| 1)
+        .sum();
+    datatest_stable::utils::iterate_directory(Path::new(PATH_TO_IR_TESTS)).flat_map(move |path| {
         if path.extension()?.to_str()? != IR_EXTENSION {
             return None;
         }
         let pathbuf = path.canonicalize().ok()?;
-        let mut components = pathbuf.components().rev();
-        let name = comp_to_string!(components.next());
-        let dir = comp_to_string!(components.next());
+        let mut components = pathbuf.components();
+        // skip over the components pointing to the IR test dir
+        for _ in 0..num_root_components {
+            components.next();
+        }
+        // iterate over the components starting with the file name
+        let mut components = components.rev();
+        let name = comp_to_string!(components.next().unwrap()).to_owned();
+        // Combine the other components into one single string
+        // These components represet the subdir path under the IR test directory. For migration
+        // purposes, consider all of these as a single subdir
+        let mut dir = String::new();
+        for comp in components {
+            let sep = if dir.is_empty() { "" } else { "/" };
+            dir = format!("{}{}{}", comp_to_string!(comp), sep, dir)
+        }
         Some((dir, name))
     })
 }

--- a/language/move-lang/src/to_bytecode/translate.rs
+++ b/language/move-lang/src/to_bytecode/translate.rs
@@ -565,7 +565,7 @@ fn kind(sp!(_, k_): &Kind) -> IR::Kind {
 
 fn type_parameters(tps: Vec<TParam>) -> Vec<(IR::TypeVar, IR::Kind)> {
     tps.into_iter()
-        .map(|tp| (type_var(tp.debug), kind(&tp.kind)))
+        .map(|tp| (type_var(tp.user_specified_name), kind(&tp.kind)))
         .collect()
 }
 
@@ -599,7 +599,10 @@ fn base_type(context: &mut Context, sp!(_, bt_): H::BaseType) -> IR::Type {
             let tys = base_types(context, tys);
             IRT::Struct(n, tys)
         }
-        B::Param(TParam { debug, .. }) => IRT::TypeParameter(type_var(debug).value),
+        B::Param(TParam {
+            user_specified_name,
+            ..
+        }) => IRT::TypeParameter(type_var(user_specified_name).value),
     }
 }
 

--- a/language/move-lang/src/typing/infinite_instantiations.rs
+++ b/language/move-lang/src/typing/infinite_instantiations.rs
@@ -1,0 +1,412 @@
+// Copyright (c) The Libra Core Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+use super::core::{self, Subst, TParamSubst};
+use crate::{
+    errors::*,
+    naming::ast::{self as N, TParam, Type, Type_},
+    parser::ast::{FunctionName, ModuleIdent},
+    shared::unique_map::UniqueMap,
+    typing::ast as T,
+};
+use move_ir_types::location::*;
+use petgraph::{
+    algo::{astar as petgraph_astar, tarjan_scc as petgraph_scc},
+    graphmap::DiGraphMap,
+};
+use std::collections::BTreeMap;
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum Edge {
+    Identity,
+    Nested,
+}
+
+#[derive(Clone, Debug)]
+struct EdgeInfo {
+    name: FunctionName,
+    type_argument: Type,
+    loc: Loc,
+    edge: Edge,
+}
+
+struct Context<'a> {
+    tparams: &'a BTreeMap<ModuleIdent, BTreeMap<FunctionName, &'a Vec<TParam>>>,
+    tparam_type_arguments: BTreeMap<TParam, BTreeMap<TParam, EdgeInfo>>,
+    current_module: ModuleIdent,
+}
+
+impl<'a> Context<'a> {
+    fn new(
+        tparams: &'a BTreeMap<ModuleIdent, BTreeMap<FunctionName, &'a Vec<TParam>>>,
+        current_module: ModuleIdent,
+    ) -> Self {
+        Context {
+            tparams,
+            current_module,
+            tparam_type_arguments: BTreeMap::new(),
+        }
+    }
+
+    fn add_usage(&mut self, loc: Loc, module: &ModuleIdent, fname: &FunctionName, targs: &[Type]) {
+        if &self.current_module != module {
+            return;
+        }
+        self.tparams[module][fname]
+            .iter()
+            .zip(targs)
+            .for_each(|(tparam, targ)| {
+                let info = EdgeInfo {
+                    name: fname.clone(),
+                    type_argument: targ.clone(),
+                    loc,
+                    edge: Edge::Identity,
+                };
+                Self::add_tparam_edges(&mut self.tparam_type_arguments, tparam, info, targ)
+            })
+    }
+
+    fn add_tparam_edges(
+        acc: &mut BTreeMap<TParam, BTreeMap<TParam, EdgeInfo>>,
+        tparam: &TParam,
+        info: EdgeInfo,
+        sp!(_, targ_): &Type,
+    ) {
+        use N::Type_::*;
+        match targ_ {
+            Var(_) => panic!("ICE tvar after expansion"),
+            Unit | Anything | UnresolvedError => (),
+            Ref(_, t) => {
+                let info = EdgeInfo {
+                    edge: Edge::Nested,
+                    ..info
+                };
+                Self::add_tparam_edges(acc, tparam, info, t)
+            }
+            Apply(_, _, tys) => {
+                let info = EdgeInfo {
+                    edge: Edge::Nested,
+                    ..info
+                };
+                tys.iter()
+                    .for_each(|t| Self::add_tparam_edges(acc, tparam, info.clone(), t))
+            }
+            Param(tp) => {
+                let tp_neighbors = acc.entry(tp.clone()).or_insert_with(BTreeMap::new);
+                match tp_neighbors.get(tparam) {
+                    Some(EdgeInfo {
+                        edge: Edge::Nested, ..
+                    }) => (),
+                    None
+                    | Some(EdgeInfo {
+                        edge: Edge::Identity,
+                        ..
+                    }) => {
+                        tp_neighbors.insert(tparam.clone(), info);
+                    }
+                }
+            }
+        }
+    }
+
+    fn instantiation_graph(&self) -> DiGraphMap<&TParam, Edge> {
+        let edges = self
+            .tparam_type_arguments
+            .iter()
+            .flat_map(|(parent, children)| {
+                children
+                    .iter()
+                    .map(move |(child, info)| (parent, child, info.edge))
+            });
+        DiGraphMap::from_edges(edges)
+    }
+}
+
+//**************************************************************************************************
+// Modules
+//**************************************************************************************************
+
+pub fn modules(errors: &mut Errors, modules: &UniqueMap<ModuleIdent, T::ModuleDefinition>) {
+    let tparams = modules
+        .iter()
+        .map(|(mname, mdef)| {
+            let tparams = mdef
+                .functions
+                .iter()
+                .map(|(fname, fdef)| (fname, &fdef.signature.type_parameters))
+                .collect();
+            (mname, tparams)
+        })
+        .collect();
+    modules
+        .iter()
+        .for_each(|(mname, m)| module(errors, &tparams, mname, m))
+}
+
+macro_rules! scc_edges {
+    ($graph:expr, $scc:expr) => {{
+        let g = $graph;
+        let s = $scc;
+        s.iter().flat_map(move |v| {
+            s.iter()
+                .filter_map(move |u| g.edge_weight(v, u).cloned().map(|e| (v, e, u)))
+        })
+    }};
+}
+
+fn module<'a>(
+    errors: &mut Errors,
+    tparams: &'a BTreeMap<ModuleIdent, BTreeMap<FunctionName, &'a Vec<TParam>>>,
+    mname: ModuleIdent,
+    module: &T::ModuleDefinition,
+) {
+    let context = &mut Context::new(tparams, mname);
+    module
+        .functions
+        .iter()
+        .for_each(|(_fname, fdef)| function_body(context, &fdef.body));
+    let graph = context.instantiation_graph();
+    // - get the strongly connected components
+    // - fitler out SCCs that do not contain a 'nested' or 'strong' edge
+    // - report those cycles
+    petgraph_scc(&graph)
+        .into_iter()
+        .filter(|scc| scc_edges!(&graph, scc).any(|(_, e, _)| e == Edge::Nested))
+        .for_each(|scc| errors.push(cycle_error(context, &graph, scc)))
+}
+
+//**************************************************************************************************
+// Functions
+//**************************************************************************************************
+
+fn function_body(context: &mut Context, sp!(_, b_): &T::FunctionBody) {
+    match b_ {
+        T::FunctionBody_::Native => (),
+        T::FunctionBody_::Defined(es) => sequence(context, es),
+    }
+}
+
+//**************************************************************************************************
+// Expressions
+//**************************************************************************************************
+
+fn sequence(context: &mut Context, seq: &T::Sequence) {
+    seq.iter().for_each(|item| sequence_item(context, item))
+}
+
+fn sequence_item(context: &mut Context, item: &T::SequenceItem) {
+    use T::SequenceItem_ as S;
+    match &item.value {
+        S::Bind(_, _, te) | S::Seq(te) => exp(context, te),
+        S::Declare(_) => (),
+    }
+}
+
+fn exp(context: &mut Context, e: &T::Exp) {
+    use T::UnannotatedExp_ as E;
+    match &e.exp.value {
+        E::InferredNum(_) | E::Use(_) => panic!("ICE should have been expanded"),
+
+        E::Unit
+        | E::Value(_)
+        | E::Move { .. }
+        | E::Copy { .. }
+        | E::BorrowLocal(_, _)
+        | E::Break
+        | E::Continue
+        | E::Spec(_, _)
+        | E::UnresolvedError => (),
+
+        E::ModuleCall(call) => {
+            context.add_usage(e.exp.loc, &call.module, &call.name, &call.type_arguments);
+            exp(context, &call.arguments)
+        }
+
+        E::IfElse(eb, et, ef) => {
+            exp(context, eb);
+            exp(context, et);
+            exp(context, ef);
+        }
+        E::While(eb, eloop) => {
+            exp(context, eb);
+            exp(context, eloop);
+        }
+        E::Loop { body: eloop, .. } => exp(context, eloop),
+        E::Block(seq) => sequence(context, seq),
+        E::Assign(_, _, er) => exp(context, er),
+
+        E::Builtin(_, er)
+        | E::Return(er)
+        | E::Abort(er)
+        | E::Dereference(er)
+        | E::UnaryExp(_, er)
+        | E::Borrow(_, er, _)
+        | E::TempBorrow(_, er) => exp(context, er),
+        E::Mutate(el, er) | E::BinopExp(el, _, _, er) => {
+            exp(context, el);
+            exp(context, er)
+        }
+
+        E::Pack(_, _, _, fields) => {
+            for (_, (_, (_, fe))) in fields.iter() {
+                exp(context, fe)
+            }
+        }
+        E::ExpList(el) => exp_list(context, el),
+
+        E::Cast(e, _) | E::Annotate(e, _) => exp(context, e),
+    }
+}
+
+fn exp_list(context: &mut Context, items: &[T::ExpListItem]) {
+    items.iter().for_each(|item| exp_list_item(context, item))
+}
+
+fn exp_list_item(context: &mut Context, item: &T::ExpListItem) {
+    use T::ExpListItem as I;
+    match item {
+        I::Single(e, _) | I::Splat(_, e, _) => {
+            exp(context, e);
+        }
+    }
+}
+
+//**************************************************************************************************
+// Errors
+//**************************************************************************************************
+
+fn cycle_error(context: &Context, graph: &DiGraphMap<&TParam, Edge>, scc: Vec<&TParam>) -> Error {
+    let critical_edge = scc_edges!(graph, &scc).find(|(_, e, _)| e == &Edge::Nested);
+    // tail -> head
+    let (critical_tail, _, critical_head) = critical_edge.unwrap();
+    let (_, cycle_nodes) = petgraph_astar(
+        graph,
+        critical_head,
+        |finish| &finish == critical_tail,
+        |_e| 1,
+        |_| 0,
+    )
+    .unwrap();
+    assert!(!cycle_nodes.is_empty());
+    let next = |i| (i + 1) % cycle_nodes.len();
+    let prev = |i: usize| i.checked_sub(1).unwrap_or_else(|| cycle_nodes.len() - 1);
+
+    assert!(&cycle_nodes[0] == critical_head);
+    let param_info = &context.tparam_type_arguments[cycle_nodes[0]][cycle_nodes[next(0)]];
+    let arg_info = &context.tparam_type_arguments[cycle_nodes[prev(0)]][cycle_nodes[0]];
+
+    let call_loc = arg_info.loc;
+    let call_msg = format!(
+        "Invalid call to '{}::{}'",
+        &context.current_module, &arg_info.name,
+    );
+    let ty_loc = arg_info.type_argument.loc;
+    let ty_str = core::error_format(&arg_info.type_argument, &Subst::empty());
+    let case = match cycle_nodes.len() {
+        1 => "This recursive call",
+        2 => "These mutually recursive calls",
+        _ => "A cycle of recursive calls",
+    };
+    let tparam_msg = format!(
+        "The type parameter '{param_n}::{param_t}' was instantiated with the type {ty}, which \
+        contains the type parameter '{arg_n}::{arg_t}'. {case} causes the instantiation to recurse \
+        infinitely",
+        param_n = &param_info.name,
+        param_t = &critical_head.user_specified_name,
+        ty = ty_str,
+        arg_n = &arg_info.name,
+        arg_t = &critical_tail.user_specified_name,
+        case = case,
+    );
+
+    let mut error = vec![(call_loc, call_msg), (ty_loc, tparam_msg)];
+
+    if cycle_nodes.len() > 1 {
+        let (mut subst, init_call) = {
+            let ftparam = cycle_nodes[0];
+            let prev_tparam = cycle_nodes[prev(0)];
+            let init_state = &context.tparam_type_arguments[prev_tparam][ftparam];
+            let qualified_ = format!("{}::{}", &init_state.name, &ftparam.user_specified_name);
+            let qualified = sp(ftparam.user_specified_name.loc, qualified_);
+            let qualified_tp = TParam {
+                user_specified_name: qualified,
+                ..ftparam.clone()
+            };
+            let ftparam_ty = sp(init_state.loc, Type_::Param(qualified_tp));
+            let init_call = make_call_string(context, init_state, ftparam, &ftparam_ty);
+            let subst = make_subst(context, init_state, ftparam, ftparam_ty);
+            (subst, init_call)
+        };
+
+        let cycle_calls = cycle_nodes
+            .iter()
+            .enumerate()
+            .map(|(i, targ_tparam)| {
+                let tparam = cycle_nodes[next(i)];
+                let cur = &context.tparam_type_arguments[targ_tparam][tparam];
+                let targ = core::subst_tparams(&subst, cur.type_argument.clone());
+                let res = make_call_string(context, cur, tparam, &targ);
+                subst = make_subst(context, cur, tparam, targ);
+                res
+            })
+            .collect::<Vec<_>>();
+        cycle_calls
+            .iter()
+            .enumerate()
+            .for_each(|(i, (loc, next_call))| {
+                let (_, prev_call) = if i == 0 {
+                    &init_call
+                } else {
+                    &cycle_calls[prev(i)]
+                };
+                let msg = format!("'{}' calls '{}'", prev_call, next_call);
+                error.push((*loc, msg))
+            });
+    }
+
+    error
+}
+
+fn make_subst(
+    context: &Context,
+    state: &EdgeInfo,
+    tparam: &TParam,
+    tparam_ty: Type,
+) -> TParamSubst {
+    context.tparams[&context.current_module][&state.name]
+        .iter()
+        .map(|tp| {
+            let ty = if tp == tparam {
+                tparam_ty.clone()
+            } else {
+                sp(tparam_ty.loc, Type_::Anything)
+            };
+            (tp.id, ty)
+        })
+        .collect::<TParamSubst>()
+}
+
+fn make_call_string(
+    context: &Context,
+    cur: &EdgeInfo,
+    tparam: &TParam,
+    targ: &Type,
+) -> (Loc, String) {
+    let targs = context.tparams[&context.current_module][&cur.name]
+        .iter()
+        .map(|tp| {
+            if tp == tparam {
+                core::error_format_nested(&targ, &Subst::empty())
+            } else {
+                "_".to_owned()
+            }
+        })
+        .collect::<Vec<_>>()
+        .join(", ");
+    let targs = if targs.is_empty() {
+        targs
+    } else {
+        format!("<{}>", targs)
+    };
+    (cur.loc, format!("{}{}", &cur.name, targs))
+}

--- a/language/move-lang/src/typing/mod.rs
+++ b/language/move-lang/src/typing/mod.rs
@@ -5,5 +5,6 @@ pub mod ast;
 pub(crate) mod core;
 mod expand;
 mod globals;
+mod infinite_instantiations;
 mod recursive_structs;
 pub(crate) mod translate;

--- a/language/move-lang/src/typing/translate.rs
+++ b/language/move-lang/src/typing/translate.rs
@@ -3,7 +3,7 @@
 
 use super::{
     core::{self, Context, Subst},
-    expand, globals, recursive_structs,
+    expand, globals, infinite_instantiations, recursive_structs,
 };
 use crate::{
     errors::Errors,
@@ -28,6 +28,7 @@ pub fn program(prog: N::Program, errors: Errors) -> (T::Program, Errors) {
     assert!(context.constraints.is_empty());
     let mut errors = context.get_errors();
     recursive_structs::modules(&mut errors, &modules);
+    infinite_instantiations::modules(&mut errors, &modules);
     (T::Program { modules, main }, errors)
 }
 

--- a/language/move-lang/tests/move_check/translated_ir_tests/generics/instantiation_loops/complex_1.exp
+++ b/language/move-lang/tests/move_check/translated_ir_tests/generics/instantiation_loops/complex_1.exp
@@ -1,0 +1,40 @@
+error: 
+
+    ┌── tests/move_check/translated_ir_tests/generics/instantiation_loops/complex_1.move:10:9 ───
+    │
+ 10 │         c<S<T2>, bool>()
+    │         ^^^^^^^^^^^^^^^^ Invalid call to '0x8675309::M::c'
+    ·
+ 10 │         c<S<T2>, bool>()
+    │           ----- The type parameter 'c::T1' was instantiated with the type '0x8675309::M::S<T2>', which contains the type parameter 'c::T2'. A cycle of recursive calls causes the instantiation to recurse infinitely
+    ·
+ 14 │         c<u64, T1>();
+    │         ------------ 'c<c::T1, _>' calls 'c<_, c::T1>'
+    ·
+ 15 │         d<T2>();
+    │         ------- 'c<_, c::T1>' calls 'd<c::T1>'
+    ·
+ 20 │         b<u64, T>()
+    │         ----------- 'd<c::T1>' calls 'b<_, c::T1>'
+    ·
+ 10 │         c<S<T2>, bool>()
+    │         ---------------- 'b<_, c::T1>' calls 'c<0x8675309::M::S<c::T1>, _>'
+    │
+
+error: 
+
+    ┌── tests/move_check/translated_ir_tests/generics/instantiation_loops/complex_1.move:31:9 ───
+    │
+ 31 │         f<S<T>>()
+    │         ^^^^^^^^^ Invalid call to '0x8675309::M::f'
+    ·
+ 31 │         f<S<T>>()
+    │           ---- The type parameter 'g::T' was instantiated with the type '0x8675309::M::S<T>', which contains the type parameter 'f::T'. These mutually recursive calls causes the instantiation to recurse infinitely
+    ·
+ 27 │         g<T>()
+    │         ------ 'f<f::T>' calls 'g<f::T>'
+    ·
+ 31 │         f<S<T>>()
+    │         --------- 'g<f::T>' calls 'f<0x8675309::M::S<f::T>>'
+    │
+

--- a/language/move-lang/tests/move_check/translated_ir_tests/generics/instantiation_loops/complex_1.move
+++ b/language/move-lang/tests/move_check/translated_ir_tests/generics/instantiation_loops/complex_1.move
@@ -1,0 +1,39 @@
+module M {
+    struct S<T> { b: bool }
+
+    fun a<T>() {
+        b<S<T>, u64>()
+    }
+
+    fun b<T1, T2>() {
+        f<T1>();
+        c<S<T2>, bool>()
+    }
+
+    fun c<T1, T2>() {
+        c<u64, T1>();
+        d<T2>();
+        e<T2>()
+    }
+
+    fun d<T>() {
+        b<u64, T>()
+    }
+
+    fun e<T>() {
+    }
+
+    fun f<T>() {
+        g<T>()
+    }
+
+    fun g<T>() {
+        f<S<T>>()
+    }
+}
+
+// There are two disjoint loops in the resulting graph:
+
+// loop 1: f#T --> g#T --S<T>--> f#T
+
+// loop 2: c#T1 --> c#T2 --> d#T --> b#T2 --S<T2>--> c#T1

--- a/language/move-lang/tests/move_check/translated_ir_tests/generics/instantiation_loops/mutually_recursive_just_type_params_ok.move
+++ b/language/move-lang/tests/move_check/translated_ir_tests/generics/instantiation_loops/mutually_recursive_just_type_params_ok.move
@@ -1,0 +1,9 @@
+module M {
+    fun f<T>() {
+        g<T>()
+    }
+
+    fun g<T>() {
+        f<T>()
+    }
+}

--- a/language/move-lang/tests/move_check/translated_ir_tests/generics/instantiation_loops/mutually_recursive_non_generic_type_ok.move
+++ b/language/move-lang/tests/move_check/translated_ir_tests/generics/instantiation_loops/mutually_recursive_non_generic_type_ok.move
@@ -1,0 +1,11 @@
+module M {
+    struct S<T> { b: bool }
+
+    fun f<T>() {
+        g<S<T>>()
+    }
+
+    fun g<T>() {
+        f<u64>()
+    }
+}

--- a/language/move-lang/tests/move_check/translated_ir_tests/generics/instantiation_loops/mutually_recursive_three_args_just_type_params_shitfing_ok.move
+++ b/language/move-lang/tests/move_check/translated_ir_tests/generics/instantiation_loops/mutually_recursive_three_args_just_type_params_shitfing_ok.move
@@ -1,0 +1,13 @@
+module M {
+    fun f<T1, T2, T3>() {
+        g<T2, T3, T1>()
+    }
+
+    fun g<T1, T2, T3>() {
+        h<T1, T2, T3>()
+    }
+
+    fun h<T1, T2, T3>() {
+        f<T1, T2, T3>()
+    }
+}

--- a/language/move-lang/tests/move_check/translated_ir_tests/generics/instantiation_loops/mutually_recursive_three_args_type_con_non_generic_types_ok.move
+++ b/language/move-lang/tests/move_check/translated_ir_tests/generics/instantiation_loops/mutually_recursive_three_args_type_con_non_generic_types_ok.move
@@ -1,0 +1,16 @@
+module M {
+    struct S<T> { b: bool }
+
+    fun f<T1, T2, T3>() {
+        g<T2, T3, T1>()
+    }
+
+    fun g<T1, T2, T3>() {
+        h<T1, T2, S<T3>>()
+    }
+
+    fun h<T1, T2, T3>() {
+        // The bool breaks the chain.
+        f<T1, bool, T3>()
+    }
+}

--- a/language/move-lang/tests/move_check/translated_ir_tests/generics/instantiation_loops/mutually_recursive_three_args_type_con_shifting.exp
+++ b/language/move-lang/tests/move_check/translated_ir_tests/generics/instantiation_loops/mutually_recursive_three_args_type_con_shifting.exp
@@ -1,0 +1,38 @@
+error: 
+
+    ┌── tests/move_check/translated_ir_tests/generics/instantiation_loops/mutually_recursive_three_args_type_con_shifting.move:9:9 ───
+    │
+  9 │         h<T1, T2, S<T3>>()
+    │         ^^^^^^^^^^^^^^^^^^ Invalid call to '0x8675309::M::h'
+    ·
+  9 │         h<T1, T2, S<T3>>()
+    │                   ----- The type parameter 'f::T3' was instantiated with the type '0x8675309::M::S<T3>', which contains the type parameter 'h::T3'. A cycle of recursive calls causes the instantiation to recurse infinitely
+    ·
+ 13 │         f<T1, T2, T3>()
+    │         --------------- 'h<_, _, h::T3>' calls 'f<_, _, h::T3>'
+    ·
+  5 │         g<T2, T3, T1>()
+    │         --------------- 'f<_, _, h::T3>' calls 'g<_, h::T3, _>'
+    ·
+  9 │         h<T1, T2, S<T3>>()
+    │         ------------------ 'g<_, h::T3, _>' calls 'h<_, h::T3, _>'
+    ·
+ 13 │         f<T1, T2, T3>()
+    │         --------------- 'h<_, h::T3, _>' calls 'f<_, h::T3, _>'
+    ·
+  5 │         g<T2, T3, T1>()
+    │         --------------- 'f<_, h::T3, _>' calls 'g<h::T3, _, _>'
+    ·
+  9 │         h<T1, T2, S<T3>>()
+    │         ------------------ 'g<h::T3, _, _>' calls 'h<h::T3, _, _>'
+    ·
+ 13 │         f<T1, T2, T3>()
+    │         --------------- 'h<h::T3, _, _>' calls 'f<h::T3, _, _>'
+    ·
+  5 │         g<T2, T3, T1>()
+    │         --------------- 'f<h::T3, _, _>' calls 'g<_, _, h::T3>'
+    ·
+  9 │         h<T1, T2, S<T3>>()
+    │         ------------------ 'g<_, _, h::T3>' calls 'h<_, _, 0x8675309::M::S<h::T3>>'
+    │
+

--- a/language/move-lang/tests/move_check/translated_ir_tests/generics/instantiation_loops/mutually_recursive_three_args_type_con_shifting.move
+++ b/language/move-lang/tests/move_check/translated_ir_tests/generics/instantiation_loops/mutually_recursive_three_args_type_con_shifting.move
@@ -1,0 +1,15 @@
+module M {
+    struct S<T> { b: bool }
+
+    fun f<T1, T2, T3>() {
+        g<T2, T3, T1>()
+    }
+
+    fun g<T1, T2, T3>() {
+        h<T1, T2, S<T3>>()
+    }
+
+    fun h<T1, T2, T3>() {
+        f<T1, T2, T3>()
+    }
+}

--- a/language/move-lang/tests/move_check/translated_ir_tests/generics/instantiation_loops/mutually_recursive_two_args_non_generic_type_and_type_param_ok.move
+++ b/language/move-lang/tests/move_check/translated_ir_tests/generics/instantiation_loops/mutually_recursive_two_args_non_generic_type_and_type_param_ok.move
@@ -1,0 +1,9 @@
+module M {
+    fun f<T1, T2>() {
+        g<u64, T1>()
+    }
+
+    fun g<T1, T2>() {
+        f<bool, T1>()
+    }
+}

--- a/language/move-lang/tests/move_check/translated_ir_tests/generics/instantiation_loops/mutually_recursive_two_args_swapping_just_type_params_ok.move
+++ b/language/move-lang/tests/move_check/translated_ir_tests/generics/instantiation_loops/mutually_recursive_two_args_swapping_just_type_params_ok.move
@@ -1,0 +1,9 @@
+module M {
+    fun f<T1, T2>() {
+        g<T2, T1>();
+    }
+
+    fun g<T1, T2>() {
+        f<T1, T2>();
+    }
+}

--- a/language/move-lang/tests/move_check/translated_ir_tests/generics/instantiation_loops/mutually_recursive_two_args_swapping_type_con.exp
+++ b/language/move-lang/tests/move_check/translated_ir_tests/generics/instantiation_loops/mutually_recursive_two_args_swapping_type_con.exp
@@ -1,0 +1,23 @@
+error: 
+
+   ┌── tests/move_check/translated_ir_tests/generics/instantiation_loops/mutually_recursive_two_args_swapping_type_con.move:9:9 ───
+   │
+ 9 │         f<T1, S<T2>, u64>()
+   │         ^^^^^^^^^^^^^^^^^^^ Invalid call to '0x8675309::M::f'
+   ·
+ 9 │         f<T1, S<T2>, u64>()
+   │               ----- The type parameter 'g::T2' was instantiated with the type '0x8675309::M::S<T2>', which contains the type parameter 'f::T2'. A cycle of recursive calls causes the instantiation to recurse infinitely
+   ·
+ 5 │         g<T2, T1>()
+   │         ----------- 'f<_, f::T2, _>' calls 'g<f::T2, _>'
+   ·
+ 9 │         f<T1, S<T2>, u64>()
+   │         ------------------- 'g<f::T2, _>' calls 'f<f::T2, _, _>'
+   ·
+ 5 │         g<T2, T1>()
+   │         ----------- 'f<f::T2, _, _>' calls 'g<_, f::T2>'
+   ·
+ 9 │         f<T1, S<T2>, u64>()
+   │         ------------------- 'g<_, f::T2>' calls 'f<_, 0x8675309::M::S<f::T2>, _>'
+   │
+

--- a/language/move-lang/tests/move_check/translated_ir_tests/generics/instantiation_loops/mutually_recursive_two_args_swapping_type_con.move
+++ b/language/move-lang/tests/move_check/translated_ir_tests/generics/instantiation_loops/mutually_recursive_two_args_swapping_type_con.move
@@ -1,0 +1,11 @@
+module M {
+    struct S<T> { b: bool }
+
+    fun f<T1, T2, T3>() {
+        g<T2, T1>()
+    }
+
+    fun g<T1, T2>() {
+        f<T1, S<T2>, u64>()
+    }
+}

--- a/language/move-lang/tests/move_check/translated_ir_tests/generics/instantiation_loops/mutually_recursive_type_con.exp
+++ b/language/move-lang/tests/move_check/translated_ir_tests/generics/instantiation_loops/mutually_recursive_type_con.exp
@@ -1,0 +1,17 @@
+error: 
+
+    ┌── tests/move_check/translated_ir_tests/generics/instantiation_loops/mutually_recursive_type_con.move:8:9 ───
+    │
+  8 │         g<S<T>>()
+    │         ^^^^^^^^^ Invalid call to '0x8675309::M::g'
+    ·
+  8 │         g<S<T>>()
+    │           ---- The type parameter 'f::T' was instantiated with the type '0x8675309::M::S<T>', which contains the type parameter 'g::T'. These mutually recursive calls causes the instantiation to recurse infinitely
+    ·
+ 12 │         f<T>()
+    │         ------ 'g<g::T>' calls 'f<g::T>'
+    ·
+  8 │         g<S<T>>()
+    │         --------- 'f<g::T>' calls 'g<0x8675309::M::S<g::T>>'
+    │
+

--- a/language/move-lang/tests/move_check/translated_ir_tests/generics/instantiation_loops/mutually_recursive_type_con.move
+++ b/language/move-lang/tests/move_check/translated_ir_tests/generics/instantiation_loops/mutually_recursive_type_con.move
@@ -1,0 +1,14 @@
+// Not good: infinitely many types/instances.
+//           f<T>, g<S<T>>, f<S<T>>, g<S<S<T>>>, ...
+
+module M {
+    struct S<T> { b: bool }
+
+    fun f<T>() {
+        g<S<T>>()
+    }
+
+    fun g<T>() {
+        f<T>()
+    }
+}

--- a/language/move-lang/tests/move_check/translated_ir_tests/generics/instantiation_loops/nested_types_1.exp
+++ b/language/move-lang/tests/move_check/translated_ir_tests/generics/instantiation_loops/nested_types_1.exp
@@ -1,0 +1,11 @@
+error: 
+
+   ┌── tests/move_check/translated_ir_tests/generics/instantiation_loops/nested_types_1.move:5:9 ───
+   │
+ 5 │         foo<S<S<T>>>()
+   │         ^^^^^^^^^^^^^^ Invalid call to '0x8675309::M::foo'
+   ·
+ 5 │         foo<S<S<T>>>()
+   │             ------- The type parameter 'foo::T' was instantiated with the type '0x8675309::M::S<0x8675309::M::S<T>>', which contains the type parameter 'foo::T'. This recursive call causes the instantiation to recurse infinitely
+   │
+

--- a/language/move-lang/tests/move_check/translated_ir_tests/generics/instantiation_loops/nested_types_1.move
+++ b/language/move-lang/tests/move_check/translated_ir_tests/generics/instantiation_loops/nested_types_1.move
@@ -1,0 +1,7 @@
+module M {
+    struct S<T> { b: bool }
+
+    fun foo<T>() {
+        foo<S<S<T>>>()
+    }
+}

--- a/language/move-lang/tests/move_check/translated_ir_tests/generics/instantiation_loops/nested_types_2.exp
+++ b/language/move-lang/tests/move_check/translated_ir_tests/generics/instantiation_loops/nested_types_2.exp
@@ -1,0 +1,11 @@
+error: 
+
+   ┌── tests/move_check/translated_ir_tests/generics/instantiation_loops/nested_types_2.move:6:9 ───
+   │
+ 6 │         foo<R<u64, S<S<T>>>>()
+   │         ^^^^^^^^^^^^^^^^^^^^^^ Invalid call to '0x8675309::M::foo'
+   ·
+ 6 │         foo<R<u64, S<S<T>>>>()
+   │             --------------- The type parameter 'foo::T' was instantiated with the type '0x8675309::M::R<u64, 0x8675309::M::S<0x8675309::M::S<T>>>', which contains the type parameter 'foo::T'. This recursive call causes the instantiation to recurse infinitely
+   │
+

--- a/language/move-lang/tests/move_check/translated_ir_tests/generics/instantiation_loops/nested_types_2.move
+++ b/language/move-lang/tests/move_check/translated_ir_tests/generics/instantiation_loops/nested_types_2.move
@@ -1,0 +1,8 @@
+module M {
+    struct S<T> { b: bool }
+    struct R<T1, T2> { b: bool }
+
+    fun foo<T>() {
+        foo<R<u64, S<S<T>>>>()
+    }
+}

--- a/language/move-lang/tests/move_check/translated_ir_tests/generics/instantiation_loops/recursive_infinite_type_terminates.exp
+++ b/language/move-lang/tests/move_check/translated_ir_tests/generics/instantiation_loops/recursive_infinite_type_terminates.exp
@@ -1,0 +1,11 @@
+error: 
+
+    ┌── tests/move_check/translated_ir_tests/generics/instantiation_loops/recursive_infinite_type_terminates.move:11:18 ───
+    │
+ 11 │         unbox<T>(f<Box<T>>(n - 1, Box<T> { x }))
+    │                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Invalid call to '0x8675309::M::f'
+    ·
+ 11 │         unbox<T>(f<Box<T>>(n - 1, Box<T> { x }))
+    │                    ------ The type parameter 'f::T' was instantiated with the type '0x8675309::M::Box<T>', which contains the type parameter 'f::T'. This recursive call causes the instantiation to recurse infinitely
+    │
+

--- a/language/move-lang/tests/move_check/translated_ir_tests/generics/instantiation_loops/recursive_infinite_type_terminates.move
+++ b/language/move-lang/tests/move_check/translated_ir_tests/generics/instantiation_loops/recursive_infinite_type_terminates.move
@@ -1,0 +1,37 @@
+module M {
+    struct Box<T> { x: T }
+
+    fun unbox<T>(b: Box<T>): T {
+        let Box { x } = b;
+        x
+    }
+
+    fun f<T>(n: u64, x: T): T {
+        if (n == 0) return x;
+        unbox<T>(f<Box<T>>(n - 1, Box<T> { x }))
+    }
+}
+
+// Function f calls an instance of itself instantiated with a boxed type, but it does
+// terminate properly if we allow new types to be created on the fly.
+//
+// As reference, the equivalent Haskell code compiles & terminates:
+//
+//   data Boxed a = Box a
+//
+//   unbox (Box a) = a
+//
+//   f :: Integer -> a -> a
+//   f 0 x = x
+//   f n x = unbox (f (n-1) (Box x))
+//
+//    main = do
+//      let x = 42
+//      putStrLn (show (f 5 x))
+//
+// Without the annotation f :: Integer -> a -> a GHC complains about not being able to
+// construct the infinite type a ~ Boxed a.
+//
+// We are taking a conservative approach and forbids such construction in move.
+
+// check: LOOP_IN_INSTANTIATION_GRAPH

--- a/language/move-lang/tests/move_check/translated_ir_tests/generics/instantiation_loops/recursive_one_arg_just_type_params_ok.move
+++ b/language/move-lang/tests/move_check/translated_ir_tests/generics/instantiation_loops/recursive_one_arg_just_type_params_ok.move
@@ -1,0 +1,7 @@
+// This is good as there is only one instance foo<T> for any T::
+
+module M {
+    public fun f<T>(x: T) {
+        f<T>(x)
+    }
+}

--- a/language/move-lang/tests/move_check/translated_ir_tests/generics/instantiation_loops/recursive_one_arg_non_generic_type_ok.move
+++ b/language/move-lang/tests/move_check/translated_ir_tests/generics/instantiation_loops/recursive_one_arg_non_generic_type_ok.move
@@ -1,0 +1,7 @@
+// Good: two instances foo<T> & foo<u64> (if T != u64) for any T::
+
+module M {
+    fun f<T>() {
+        f<u64>()
+    }
+}

--- a/language/move-lang/tests/move_check/translated_ir_tests/generics/instantiation_loops/recursive_one_arg_type_con.exp
+++ b/language/move-lang/tests/move_check/translated_ir_tests/generics/instantiation_loops/recursive_one_arg_type_con.exp
@@ -1,0 +1,11 @@
+error: 
+
+   ┌── tests/move_check/translated_ir_tests/generics/instantiation_loops/recursive_one_arg_type_con.move:7:9 ───
+   │
+ 7 │         f<S<T>>(S<T> { b: true })
+   │         ^^^^^^^^^^^^^^^^^^^^^^^^^ Invalid call to '0x8675309::M::f'
+   ·
+ 7 │         f<S<T>>(S<T> { b: true })
+   │           ---- The type parameter 'f::T' was instantiated with the type '0x8675309::M::S<T>', which contains the type parameter 'f::T'. This recursive call causes the instantiation to recurse infinitely
+   │
+

--- a/language/move-lang/tests/move_check/translated_ir_tests/generics/instantiation_loops/recursive_one_arg_type_con.move
+++ b/language/move-lang/tests/move_check/translated_ir_tests/generics/instantiation_loops/recursive_one_arg_type_con.move
@@ -1,0 +1,9 @@
+// Bad! Can have infinitely many instances: f<T>, f<S<T>>, f<S<S<T>>>, ...
+
+module M {
+    struct S<T> { b: bool }
+
+    fun f<T>(x: T) {
+        f<S<T>>(S<T> { b: true })
+    }
+}

--- a/language/move-lang/tests/move_check/translated_ir_tests/generics/instantiation_loops/recursive_struct.exp
+++ b/language/move-lang/tests/move_check/translated_ir_tests/generics/instantiation_loops/recursive_struct.exp
@@ -1,0 +1,55 @@
+error: 
+
+   ┌── tests/move_check/translated_ir_tests/generics/instantiation_loops/recursive_struct.move:4:21 ───
+   │
+ 4 │     struct Foo { f: Foo }
+   │                     ^^^ Invalid field containing 'Foo' in struct 'Foo'.
+   ·
+ 4 │     struct Foo { f: Foo }
+   │                     --- Using this struct creates a cycle: 'Foo' contains 'Foo'
+   │
+
+error: 
+
+    ┌── tests/move_check/translated_ir_tests/generics/instantiation_loops/recursive_struct.move:10:25 ───
+    │
+ 10 │     struct Foo { f: Cup<Foo> }
+    │                         ^^^ Invalid field containing 'Foo' in struct 'Foo'.
+    ·
+ 10 │     struct Foo { f: Cup<Foo> }
+    │                         --- Using this struct creates a cycle: 'Foo' contains 'Foo'
+    │
+
+error: 
+
+    ┌── tests/move_check/translated_ir_tests/generics/instantiation_loops/recursive_struct.move:20:35 ───
+    │
+ 20 │     resource struct X { y: vector<Y> }
+    │                                   ^ Invalid field containing 'Y' in struct 'X'.
+    ·
+ 20 │     resource struct X { y: vector<Y> }
+    │                                   - Using this struct creates a cycle: 'Y' contains 'X' contains 'Y'
+    │
+
+error: 
+
+    ┌── tests/move_check/translated_ir_tests/generics/instantiation_loops/recursive_struct.move:41:8 ───
+    │
+ 41 │ module M3 {
+    │        ^^ Duplicate definition for module '0x42::M3'
+    ·
+ 34 │ module M3 {
+    │        -- Previously defined here
+    │
+
+error: 
+
+    ┌── tests/move_check/translated_ir_tests/generics/instantiation_loops/recursive_struct.move:46:26 ───
+    │
+ 46 │     struct C { d: vector<D> }
+    │                          ^ Invalid field containing 'D' in struct 'C'.
+    ·
+ 46 │     struct C { d: vector<D> }
+    │                          - Using this struct creates a cycle: 'D' contains 'A' contains 'B' contains 'C' contains 'D'
+    │
+

--- a/language/move-lang/tests/move_check/translated_ir_tests/generics/instantiation_loops/recursive_struct.move
+++ b/language/move-lang/tests/move_check/translated_ir_tests/generics/instantiation_loops/recursive_struct.move
@@ -1,0 +1,49 @@
+address 0x42:
+
+module M0 {
+    struct Foo { f: Foo }
+}
+
+
+module M1 {
+    struct Cup<T> { f: T }
+    struct Foo { f: Cup<Foo> }
+
+    // blows up the stack
+    public fun foo(): Foo {
+        Foo { f: Cup<Foo> { f: foo() }}
+    }
+
+}
+
+module M2 {
+    resource struct X { y: vector<Y> }
+    resource struct Y { x: vector<X> }
+
+    // blows up the vm
+    public fun ex(): bool {
+        exists<X>(0x0::Transaction::sender())
+    }
+
+    // blows up the VM
+    public fun borrow() acquires X {
+        _ = borrow_global<X>(0x0::Transaction::sender())
+    }
+}
+
+module M3 {
+    use 0x42::M1;
+
+    struct Foo { f: M1::Cup<Foo> }
+
+}
+
+module M3 {
+    use 0x42::M1;
+
+    struct A { b: B }
+    struct B { c: C }
+    struct C { d: vector<D> }
+    struct D { x: M1::Cup<M1::Cup<M1::Cup<A>>> }
+
+}

--- a/language/move-lang/tests/move_check/translated_ir_tests/generics/instantiation_loops/recursive_two_args_swapping_type_con.exp
+++ b/language/move-lang/tests/move_check/translated_ir_tests/generics/instantiation_loops/recursive_two_args_swapping_type_con.exp
@@ -1,0 +1,17 @@
+error: 
+
+   ┌── tests/move_check/translated_ir_tests/generics/instantiation_loops/recursive_two_args_swapping_type_con.move:8:9 ───
+   │
+ 8 │         f<S<T2>, T1>(S<T2> { x }, a)
+   │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Invalid call to '0x8675309::M::f'
+   ·
+ 8 │         f<S<T2>, T1>(S<T2> { x }, a)
+   │           ----- The type parameter 'f::T1' was instantiated with the type '0x8675309::M::S<T2>', which contains the type parameter 'f::T2'. These mutually recursive calls causes the instantiation to recurse infinitely
+   ·
+ 8 │         f<S<T2>, T1>(S<T2> { x }, a)
+   │         ---------------------------- 'f<f::T1, _>' calls 'f<_, f::T1>'
+   ·
+ 8 │         f<S<T2>, T1>(S<T2> { x }, a)
+   │         ---------------------------- 'f<_, f::T1>' calls 'f<0x8675309::M::S<f::T1>, _>'
+   │
+

--- a/language/move-lang/tests/move_check/translated_ir_tests/generics/instantiation_loops/recursive_two_args_swapping_type_con.move
+++ b/language/move-lang/tests/move_check/translated_ir_tests/generics/instantiation_loops/recursive_two_args_swapping_type_con.move
@@ -1,0 +1,12 @@
+// Similar to the case with one argument, but swaps the two type parameters.
+// f<T1, T2> => f<S<T2>, T1> => f<S<T1>, S<T2>> => f<S<S<T2>>, S<T1>> => ...
+
+module M {
+    struct S<T> { x: T }
+
+    fun f<T1, T2>(a: T1, x: T2) {
+        f<S<T2>, T1>(S<T2> { x }, a)
+    }
+}
+
+// check: LOOP_IN_INSTANTIATION_GRAPH

--- a/language/move-lang/tests/move_check/translated_ir_tests/generics/instantiation_loops/two_loops.exp
+++ b/language/move-lang/tests/move_check/translated_ir_tests/generics/instantiation_loops/two_loops.exp
@@ -1,0 +1,22 @@
+error: 
+
+   ┌── tests/move_check/translated_ir_tests/generics/instantiation_loops/two_loops.move:8:9 ───
+   │
+ 8 │         f<S<T>>()
+   │         ^^^^^^^^^ Invalid call to '0x8675309::M::f'
+   ·
+ 8 │         f<S<T>>()
+   │           ---- The type parameter 'f::T' was instantiated with the type '0x8675309::M::S<T>', which contains the type parameter 'f::T'. This recursive call causes the instantiation to recurse infinitely
+   │
+
+error: 
+
+    ┌── tests/move_check/translated_ir_tests/generics/instantiation_loops/two_loops.move:12:9 ───
+    │
+ 12 │         g<S<T>>()
+    │         ^^^^^^^^^ Invalid call to '0x8675309::M::g'
+    ·
+ 12 │         g<S<T>>()
+    │           ---- The type parameter 'g::T' was instantiated with the type '0x8675309::M::S<T>', which contains the type parameter 'g::T'. This recursive call causes the instantiation to recurse infinitely
+    │
+

--- a/language/move-lang/tests/move_check/translated_ir_tests/generics/instantiation_loops/two_loops.move
+++ b/language/move-lang/tests/move_check/translated_ir_tests/generics/instantiation_loops/two_loops.move
@@ -1,0 +1,17 @@
+// Two loops in the resulting graph.
+// One error for each loop.
+
+module M {
+    struct S<T> { b: bool }
+
+    fun f<T>() {
+        f<S<T>>()
+    }
+
+    fun g<T>() {
+        g<S<T>>()
+    }
+}
+
+// check: LOOP_IN_INSTANTIATION_GRAPH
+// check: LOOP_IN_INSTANTIATION_GRAPH

--- a/language/move-lang/tests/move_check/typing/infinite_instantiations_invalid.exp
+++ b/language/move-lang/tests/move_check/typing/infinite_instantiations_invalid.exp
@@ -1,0 +1,102 @@
+error: 
+
+   ┌── tests/move_check/typing/infinite_instantiations_invalid.move:7:9 ───
+   │
+ 7 │         t<Box<T>>()
+   │         ^^^^^^^^^^^ Invalid call to '0x42::X::t'
+   ·
+ 7 │         t<Box<T>>()
+   │           ------ The type parameter 't::T' was instantiated with the type '0x42::X::Box<T>', which contains the type parameter 't::T'. This recursive call causes the instantiation to recurse infinitely
+   │
+
+error: 
+
+    ┌── tests/move_check/typing/infinite_instantiations_invalid.move:14:9 ───
+    │
+ 14 │         x<Box<T>>()
+    │         ^^^^^^^^^^^ Invalid call to '0x42::X::x'
+    ·
+ 14 │         x<Box<T>>()
+    │           ------ The type parameter 'y::T' was instantiated with the type '0x42::X::Box<T>', which contains the type parameter 'x::T'. These mutually recursive calls causes the instantiation to recurse infinitely
+    ·
+ 11 │         y<Box<T>>()
+    │         ----------- 'x<x::T>' calls 'y<0x42::X::Box<x::T>>'
+    ·
+ 14 │         x<Box<T>>()
+    │         ----------- 'y<0x42::X::Box<x::T>>' calls 'x<0x42::X::Box<0x42::X::Box<x::T>>>'
+    │
+
+error: 
+
+    ┌── tests/move_check/typing/infinite_instantiations_invalid.move:24:9 ───
+    │
+ 24 │         a<Box<C>>()
+    │         ^^^^^^^^^^^ Invalid call to '0x42::X::a'
+    ·
+ 24 │         a<Box<C>>()
+    │           ------ The type parameter 'b::A' was instantiated with the type '0x42::X::Box<C>', which contains the type parameter 'a::C'. A cycle of recursive calls causes the instantiation to recurse infinitely
+    ·
+ 18 │         b<A>()
+    │         ------ 'a<a::A>' calls 'b<a::A>'
+    ·
+ 21 │         c<B>()
+    │         ------ 'b<a::A>' calls 'c<a::A>'
+    ·
+ 24 │         a<Box<C>>()
+    │         ----------- 'c<a::A>' calls 'a<0x42::X::Box<a::A>>'
+    │
+
+error: 
+
+    ┌── tests/move_check/typing/infinite_instantiations_invalid.move:38:9 ───
+    │
+ 38 │         z<Box<T>>()
+    │         ^^^^^^^^^^^ Invalid call to '0x42::Y::z'
+    ·
+ 38 │         z<Box<T>>()
+    │           ------ The type parameter 'z::T' was instantiated with the type '0x42::Y::Box<T>', which contains the type parameter 'z::T'. This recursive call causes the instantiation to recurse infinitely
+    │
+
+error: 
+
+    ┌── tests/move_check/typing/infinite_instantiations_invalid.move:48:9 ───
+    │
+ 48 │         d<Box<C>>()
+    │         ^^^^^^^^^^^ Invalid call to '0x42::Y::d'
+    ·
+ 48 │         d<Box<C>>()
+    │           ------ The type parameter 'a::D' was instantiated with the type '0x42::Y::Box<C>', which contains the type parameter 'd::C'. A cycle of recursive calls causes the instantiation to recurse infinitely
+    ·
+ 51 │         a<D>()
+    │         ------ 'd<d::D>' calls 'a<d::D>'
+    ·
+ 42 │         b<A>()
+    │         ------ 'a<d::D>' calls 'b<d::D>'
+    ·
+ 45 │         c<B>()
+    │         ------ 'b<d::D>' calls 'c<d::D>'
+    ·
+ 48 │         d<Box<C>>()
+    │         ----------- 'c<d::D>' calls 'd<0x42::Y::Box<d::D>>'
+    │
+
+error: 
+
+    ┌── tests/move_check/typing/infinite_instantiations_invalid.move:62:9 ───
+    │
+ 62 │         bl<Box<TR>>();
+    │         ^^^^^^^^^^^^^ Invalid call to '0x42::Z::bl'
+    ·
+ 62 │         bl<Box<TR>>();
+    │            ------- The type parameter 'tl::BL' was instantiated with the type '0x42::Z::Box<TR>', which contains the type parameter 'bl::TR'. A cycle of recursive calls causes the instantiation to recurse infinitely
+    ·
+ 69 │         tl<BL>()
+    │         -------- 'bl<bl::BL>' calls 'tl<bl::BL>'
+    ·
+ 59 │         tr<TL>()
+    │         -------- 'tl<bl::BL>' calls 'tr<bl::BL>'
+    ·
+ 62 │         bl<Box<TR>>();
+    │         ------------- 'tr<bl::BL>' calls 'bl<0x42::Z::Box<bl::BL>>'
+    │
+

--- a/language/move-lang/tests/move_check/typing/infinite_instantiations_invalid.move
+++ b/language/move-lang/tests/move_check/typing/infinite_instantiations_invalid.move
@@ -1,0 +1,71 @@
+address 0x42:
+
+module X {
+    struct Box<T> {}
+
+    public fun t<T>() {
+        t<Box<T>>()
+    }
+
+    public fun x<T>() {
+        y<Box<T>>()
+    }
+    public fun y<T>() {
+        x<Box<T>>()
+    }
+
+    public fun a<A>() {
+        b<A>()
+    }
+    public fun b<B>() {
+        c<B>()
+    }
+    public fun c<C>() {
+        a<Box<C>>()
+    }
+}
+
+module Y {
+    struct Box<T> {}
+
+    public fun x<T>() {
+        y<Box<T>>()
+    }
+    public fun y<T>() {
+        z<Box<T>>()
+    }
+    public fun z<T>() {
+        z<Box<T>>()
+    }
+
+    public fun a<A>() {
+        b<A>()
+    }
+    public fun b<B>() {
+        c<B>()
+    }
+    public fun c<C>() {
+        d<Box<C>>()
+    }
+    public fun d<D>() {
+        a<D>()
+    }
+}
+
+module Z {
+    struct Box<T> {}
+
+    public fun tl<TL>() {
+        tr<TL>()
+    }
+    public fun tr<TR>() {
+        bl<Box<TR>>();
+        br<TR>()
+    }
+    public fun br<BR>() {
+        bl<BR>()
+    }
+    public fun bl<BL>() {
+        tl<BL>()
+    }
+}

--- a/language/move-lang/tests/move_check/typing/infinite_instantiations_valid.move
+++ b/language/move-lang/tests/move_check/typing/infinite_instantiations_valid.move
@@ -1,0 +1,33 @@
+address 0x42:
+
+module M {
+    struct Box<T> {}
+
+    public fun t0<T>() {
+        t1<T>();
+        t0<T>()
+    }
+
+    public fun t1<T>() {
+        t0<T>();
+        t1<T>()
+    }
+
+    public fun x<T>() {
+        y<Box<T>>()
+    }
+    public fun y<T>() {
+        z<Box<T>>()
+    }
+    public fun z<T>() {
+        z<T>()
+    }
+
+}
+
+module N {
+    use 0x42::M;
+    public fun t<T>() {
+        M::t0<M::Box<T>>()
+    }
+}

--- a/language/move-prover/spec-lang/src/translate.rs
+++ b/language/move-prover/spec-lang/src/translate.rs
@@ -1639,8 +1639,11 @@ impl<'env, 'translator, 'module_translator> ExpTranslator<'env, 'translator, 'mo
             naming::ast::BuiltinTypeName_::*,
         };
         match &ty.value {
-            Param(TParam { debug, .. }) => {
-                let sym = self.symbol_pool().make(debug.value.as_str());
+            Param(TParam {
+                user_specified_name,
+                ..
+            }) => {
+                let sym = self.symbol_pool().make(user_specified_name.value.as_str());
                 self.type_params_table[&sym].clone()
             }
             Apply(_, type_name, args) => {


### PR DESCRIPTION
## Motivation

- Fixed subdir issues with the ir test migration tool
- Added check for instantiation loops
- Error messages are particularly hard for this. They are complicated but hopefully helpful.

## Test Plan

- New test
- Migrated existing (and very well thought out) tests
