### PR TITLE
[secure-storage] enable use of Vault's transit engine for crypto

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2645,6 +2645,8 @@ dependencies = [
 name = "libra-vault-client"
 version = "0.1.0"
 dependencies = [
+ "base64 0.12.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libra-crypto 0.1.0",
  "serde 1.0.106 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.50 (registry+https://github.com/rust-lang/crates.io-index)",
  "thiserror 1.0.14 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/secure/key-manager/src/lib.rs
+++ b/secure/key-manager/src/lib.rs
@@ -188,7 +188,7 @@ where
         &self,
         new_key: Ed25519PublicKey,
     ) -> Result<Ed25519PublicKey, Error> {
-        let account_prikey = self.storage.get_private_key(ACCOUNT_KEY)?;
+        let account_prikey = self.storage.export_private_key(ACCOUNT_KEY)?;
         let seq_id = self.libra.retrieve_sequence_number(self.account)?;
         let expiration = Duration::from_secs(self.time_service.now() + TXN_EXPIRATION_SECS);
         let txn =

--- a/secure/storage/src/crypto_storage.rs
+++ b/secure/storage/src/crypto_storage.rs
@@ -20,27 +20,27 @@ pub trait CryptoStorage: Send + Sync {
     /// under the given 'policy'. To access or use the key pair (e.g., sign or encrypt data),
     /// subsequent API calls must refer to the key pair by name. As this API call may fail
     /// (e.g., if a key pair with the given name already exists), an error may also be returned.
-    fn generate_new_key(&mut self, name: &str, policy: &Policy) -> Result<Ed25519PublicKey, Error>;
-
-    /// Returns the public key for a given Ed25519 key pair, as identified by the 'name'.
-    /// If the key pair doesn't exist, or the caller doesn't have the
-    /// appropriate permissions to retrieve the public key, this call will fail with an error.
-    fn get_public_key(&self, name: &str) -> Result<PublicKeyResponse, Error>;
+    fn create_key(&mut self, name: &str, policy: &Policy) -> Result<Ed25519PublicKey, Error>;
 
     /// Returns the private key for a given Ed25519 key pair, as identified by the 'name'.
     /// If the key pair doesn't exist, or the caller doesn't have the appropriate permissions to
     /// retrieve the private key, this call will fail with an error.
-    fn get_private_key(&self, name: &str) -> Result<Ed25519PrivateKey, Error>;
+    fn export_private_key(&self, name: &str) -> Result<Ed25519PrivateKey, Error>;
 
     /// Returns the private key for a given Ed25519 key pair version, as identified by the
     /// 'name' and 'version'. If the key pair at the specified version doesn't
     /// exist, or the caller doesn't have the appropriate permissions to retrieve the private key,
     /// this call will fail with an error.
-    fn get_private_key_for_version(
+    fn export_private_key_for_version(
         &self,
         name: &str,
         version: Ed25519PublicKey,
     ) -> Result<Ed25519PrivateKey, Error>;
+
+    /// Returns the public key for a given Ed25519 key pair, as identified by the 'name'.
+    /// If the key pair doesn't exist, or the caller doesn't have the
+    /// appropriate permissions to retrieve the public key, this call will fail with an error.
+    fn get_public_key(&self, name: &str) -> Result<PublicKeyResponse, Error>;
 
     /// Rotates an Ed25519 key pair by generating a new Ed25519 key pair, and updating the
     /// 'name' to reference the freshly generated key. The previous key pair is retained

--- a/secure/storage/src/policy.rs
+++ b/secure/storage/src/policy.rs
@@ -50,6 +50,9 @@ pub enum Identity {
 /// Represents actions
 #[derive(Debug, Deserialize, Serialize)]
 pub enum Capability {
+    Export,
     Read,
+    Rotate,
+    Sign,
     Write,
 }

--- a/secure/storage/src/tests/suite.rs
+++ b/secure/storage/src/tests/suite.rs
@@ -17,7 +17,6 @@ const STORAGE_TESTS: &[fn(&mut dyn Storage)] = &[
     test_create_and_get_non_existent_version,
     test_create_rotate_and_check_key_pair,
     test_create_key_pair_and_perform_rotations,
-    test_create_key_pair_and_perform_get_set_get,
     test_create_sign_rotate_sign,
     test_create_get_and_test_key_pair,
     test_create_get_set_unwrap,
@@ -32,9 +31,9 @@ const STORAGE_TESTS: &[fn(&mut dyn Storage)] = &[
 ];
 
 /// Storage data constants for testing purposes.
-const CRYPTO_KEY: &str = "Private Key";
-const U64_KEY: &str = "U64 Key";
-const CRYPTO_NAME: &str = "Test Key Name";
+const CRYPTO_KEY: &str = "Private_Key";
+const U64_KEY: &str = "U64_Key";
+const CRYPTO_NAME: &str = "Test_Key_Name";
 
 /// Executes all storage tests on a given storage backend.
 pub fn execute_all_storage_tests(storage: &mut dyn Storage) {
@@ -312,48 +311,6 @@ fn test_create_key_pair_and_perform_rotations(storage: &mut dyn Storage) {
         public_key = new_public_key;
         private_key = new_private_key;
     }
-}
-
-/// This test creates a new key pair and performs: (i) a get operation on the key pair name,
-/// to verify the correct key is returned; (ii) a set operation on the key pair name, to update
-/// the key pair directly; and (iii) a get operation to verify the newly stored value.
-/// This test helps ensure consistency between the K/V api and the cryptographic API.
-fn test_create_key_pair_and_perform_get_set_get(storage: &mut dyn Storage) {
-    let _ = storage
-        .create_key(CRYPTO_NAME, &Policy::public())
-        .expect("Failed to create a test Ed25519 key pair!");
-    let private_key = storage
-        .export_private_key(CRYPTO_NAME)
-        .expect("Failed to get the private key for a key pair that should exist!");
-
-    // Verify we can retrieve and unwrap the private key directly, via the K/V api
-    assert_eq!(
-        storage
-            .get(CRYPTO_NAME)
-            .expect("Failed to get the new private key!")
-            .value
-            .ed25519_private_key()
-            .unwrap(),
-        private_key,
-    );
-
-    // Set a new private key directly, and verify the same key is returned for the following get
-    let new_private_key = Ed25519PrivateKey::generate_for_testing();
-    storage
-        .set(
-            CRYPTO_NAME,
-            Value::Ed25519PrivateKey(new_private_key.clone()),
-        )
-        .expect("Failed to set the private key directly");
-    assert_eq!(
-        storage
-            .get(CRYPTO_NAME)
-            .expect("Failed to get the newly set private key!")
-            .value
-            .ed25519_private_key()
-            .unwrap(),
-        new_private_key,
-    );
 }
 
 /// This test creates a new key pair, signs a message using the key pair, rotates the key pair,

--- a/secure/storage/src/tests/suite.rs
+++ b/secure/storage/src/tests/suite.rs
@@ -172,7 +172,7 @@ fn test_create_key_value_twice(storage: &mut dyn Storage) {
 /// retrieval call.
 fn test_create_get_and_test_key_pair(storage: &mut dyn Storage) {
     let public_key = storage
-        .generate_new_key(CRYPTO_NAME, &Policy::public())
+        .create_key(CRYPTO_NAME, &Policy::public())
         .expect("Failed to create a test Ed25519 key pair!");
     let retrieved_public_key_response = storage
         .get_public_key(CRYPTO_NAME)
@@ -185,10 +185,10 @@ fn test_create_get_and_test_key_pair(storage: &mut dyn Storage) {
 fn test_create_key_pair_twice(storage: &mut dyn Storage) {
     let policy = Policy::public();
     let _ = storage
-        .generate_new_key(CRYPTO_NAME, &policy)
+        .create_key(CRYPTO_NAME, &policy)
         .expect("Failed to create a test Ed25519 key pair!");
     assert!(
-        storage.generate_new_key(CRYPTO_NAME, &policy).is_err(),
+        storage.create_key(CRYPTO_NAME, &policy).is_err(),
         "The second call to generate_ed25519_key_pair() should have failed!"
     );
 }
@@ -234,13 +234,13 @@ fn test_ensure_storage_is_available(storage: &mut dyn Storage) {
 fn test_create_and_get_non_existent_version(storage: &mut dyn Storage) {
     // Create new named key pair
     let _ = storage
-        .generate_new_key(CRYPTO_NAME, &Policy::public())
+        .create_key(CRYPTO_NAME, &Policy::public())
         .expect("Failed to create a test Ed25519 key pair!");
 
     // Get a non-existent version of the new key pair and verify failure
     let non_existent_public_key = Ed25519PrivateKey::generate_for_testing().public_key();
     assert!(
-        storage.get_private_key_for_version(CRYPTO_NAME, non_existent_public_key).is_err(),
+        storage.export_private_key_for_version(CRYPTO_NAME, non_existent_public_key).is_err(),
         "We have tried to retrieve a non-existent private key version -- the call should have failed!",
     );
 }
@@ -250,10 +250,10 @@ fn test_create_and_get_non_existent_version(storage: &mut dyn Storage) {
 fn test_create_rotate_and_check_key_pair(storage: &mut dyn Storage) {
     // Create new key pair, fetch both public and private keys and verify relationship
     let public_key = storage
-        .generate_new_key(CRYPTO_NAME, &Policy::public())
+        .create_key(CRYPTO_NAME, &Policy::public())
         .expect("Failed to create a test Ed25519 key pair!");
     let private_key = storage
-        .get_private_key(CRYPTO_NAME)
+        .export_private_key(CRYPTO_NAME)
         .expect("Failed to get the private key for a key pair that should exist!");
     assert_eq!(private_key.public_key(), public_key);
 
@@ -262,7 +262,7 @@ fn test_create_rotate_and_check_key_pair(storage: &mut dyn Storage) {
         .rotate_key(CRYPTO_NAME)
         .expect("Failed to rotate a valid key pair!");
     let new_private_key = storage
-        .get_private_key(CRYPTO_NAME)
+        .export_private_key(CRYPTO_NAME)
         .expect("Failed to get the private key for the rotated key pair!");
     assert_eq!(new_private_key.public_key(), new_public_key);
 
@@ -276,7 +276,7 @@ fn test_create_rotate_and_check_key_pair(storage: &mut dyn Storage) {
     );
     assert_eq!(
         storage
-            .get_private_key_for_version(CRYPTO_NAME, public_key)
+            .export_private_key_for_version(CRYPTO_NAME, public_key)
             .expect("Failed to get the previous private key!"),
         private_key
     );
@@ -288,10 +288,10 @@ fn test_create_key_pair_and_perform_rotations(storage: &mut dyn Storage) {
     let num_rotations = 10;
 
     let mut public_key = storage
-        .generate_new_key(CRYPTO_NAME, &Policy::public())
+        .create_key(CRYPTO_NAME, &Policy::public())
         .expect("Failed to create a test Ed25519 key pair!");
     let mut private_key = storage
-        .get_private_key(CRYPTO_NAME)
+        .export_private_key(CRYPTO_NAME)
         .expect("Failed to get the private key for a key pair that should exist!");
 
     for _ in 0..num_rotations {
@@ -299,12 +299,12 @@ fn test_create_key_pair_and_perform_rotations(storage: &mut dyn Storage) {
             .rotate_key(CRYPTO_NAME)
             .expect("Failed to rotate a valid key pair!");
         let new_private_key = storage
-            .get_private_key(CRYPTO_NAME)
+            .export_private_key(CRYPTO_NAME)
             .expect("Failed to get the private key for the rotated key pair!");
 
         assert_eq!(
             storage
-                .get_private_key_for_version(CRYPTO_NAME, public_key)
+                .export_private_key_for_version(CRYPTO_NAME, public_key)
                 .expect("Failed to get the previous private key!"),
             private_key
         );
@@ -320,10 +320,10 @@ fn test_create_key_pair_and_perform_rotations(storage: &mut dyn Storage) {
 /// This test helps ensure consistency between the K/V api and the cryptographic API.
 fn test_create_key_pair_and_perform_get_set_get(storage: &mut dyn Storage) {
     let _ = storage
-        .generate_new_key(CRYPTO_NAME, &Policy::public())
+        .create_key(CRYPTO_NAME, &Policy::public())
         .expect("Failed to create a test Ed25519 key pair!");
     let private_key = storage
-        .get_private_key(CRYPTO_NAME)
+        .export_private_key(CRYPTO_NAME)
         .expect("Failed to get the private key for a key pair that should exist!");
 
     // Verify we can retrieve and unwrap the private key directly, via the K/V api
@@ -362,7 +362,7 @@ fn test_create_key_pair_and_perform_get_set_get(storage: &mut dyn Storage) {
 fn test_create_sign_rotate_sign(storage: &mut dyn Storage) {
     // Generate new key pair
     let public_key = storage
-        .generate_new_key(CRYPTO_NAME, &Policy::public())
+        .create_key(CRYPTO_NAME, &Policy::public())
         .expect("Failed to create a test Ed25519 key pair!");
 
     // Create then sign message and verify correct signature

--- a/secure/storage/vault/Cargo.toml
+++ b/secure/storage/vault/Cargo.toml
@@ -10,7 +10,9 @@ publish = false
 edition = "2018"
 
 [dependencies]
+base64 = "0.12.0"
 serde = { version = "1.0.99", features = ["derive"], default-features = false }
 serde_json = "1.0.40"
 thiserror = "1.0"
 ureq = { version = "0.12.0", features = ["json"] }
+libra-crypto = { path = "../../../crypto/crypto", version = "0.1.0" }


### PR DESCRIPTION
Transit effectively behaves like an HSM:
* Creates new keys
* Allows versioning
* Retrieval of public keys
* Exporting of private keys
* Signing of messages

(At least these are the functions that we enabled)

This PR also does a couple of other cleanups along the way:
* Renamed a few methods to better match their intents -- this helps once we start defining capabilities that must be matched for these methods to succeed
* Separated the handling of transit basic implementation from the use of capabilities to keep the commits a little more readable and because adding capabilities impacted more than just Vault
* Add the ability to reset vault policies which used to not be the case

I removed one test because it is no longer relevant in a world where not all storage solutions are purely key/value. This brings up an interesting point... maybe we should remove Ed25519 from Values or at least recognize that if they are stored in the KV, that it should be in a different universe than the Crypto. But that's a lot of work for another time.