### PR TITLE
[move-prover] Fixing a bug in update invariants in presence of branching

### DIFF
--- a/language/move-prover/src/bytecode_translator.rs
+++ b/language/move-prover/src/bytecode_translator.rs
@@ -64,16 +64,20 @@ struct BytecodeContext<'l> {
     /// over-approximation; however, the execution trace visualizer will remove redundant
     /// entries, so it is more of a performance concern.
     mutable_refs: BTreeSet<usize>,
-    /// A map from local indices  to the before borrow index. Every root which is borrowed in this
+    /// A map from local indices  to the before borrow indices. Every root which is borrowed in this
     /// function has an entry here. For every BorrowLoc(d) | BorrowGlobal(d), we have an entry
     /// d -> i and construct variables $before_borrow_i to remember the value before borrowing,
-    /// and $before_borrow_i_ref to remember the reference. We also track aliasing, i.e. if
-    /// we have MoveLoc(d', d) we add d' -> i as well.
-    borrowed_to_before_index: BTreeMap<usize, usize>,
+    /// $before_borrow_i_ref to remember the reference, and $before_borrow_used to remember whether
+    /// this was very used. We also track aliasing, i.e. if we have MoveLoc(d', d) we add d' -> i
+    /// as well. The aliasing can lead to the same reference in the domain of this map pointing to
+    /// multiple before indices. This results from branches (e.g. `if (b) r = ... else r = ...`).
+    /// We use $before_borrow_i_used to track at execution time which branch has been taken.
+    borrowed_to_before_index: BTreeMap<usize, BTreeSet<usize>>,
     /// A map of mut ref parameter indices to their before index. This works similar as
     /// `borrowed_to_before_index` except that those references are passed into a public function
-    /// and not borrowed.
-    inherited_to_before_index: BTreeMap<usize, usize>,
+    /// and not borrowed. They nevertheless behave similar as if they would have been borrowed
+    /// at function entry and released at function exit.
+    inherited_to_before_index: BTreeMap<usize, BTreeSet<usize>>,
     /// As determined by lifetime analysis, the set of references which become dead
     /// at a given bytecode offset.
     offset_to_dead_refs: BTreeMap<CodeOffset, BTreeSet<TempIndex>>,
@@ -518,7 +522,9 @@ impl<'env> ModuleTranslator<'env> {
                             // Create a new borrow index.
                             context
                                 .borrowed_to_before_index
-                                .insert(*dst, before_borrow_counter);
+                                .entry(*dst)
+                                .or_insert_with(BTreeSet::new)
+                                .insert(before_borrow_counter);
                             before_borrow_counter += 1;
                         }
                     }
@@ -530,28 +536,19 @@ impl<'env> ModuleTranslator<'env> {
                         context.mutable_refs.insert(*dst);
                     }
                 }
-                MoveLoc(dst, src) => {
+                MoveLoc(dst, src) | StLoc(dst, src) => {
                     // Propagate information from src to dst.
-                    let src = &(*src as usize);
                     if context.mutable_refs.contains(src) {
                         context.mutable_refs.insert(*dst);
                     }
-                    if let Some(idx) = context.borrowed_to_before_index.get(src) {
+                    if let Some(idx_set) = context.borrowed_to_before_index.get(src) {
                         // dst becomes an alias for src
-                        let idx = *idx;
-                        context.borrowed_to_before_index.insert(*dst, idx);
-                    }
-                }
-                StLoc(dst, src) => {
-                    // Propagate information from src to dst.
-                    let dst = &(*dst as usize);
-                    if context.mutable_refs.contains(src) {
-                        context.mutable_refs.insert(*dst);
-                    }
-                    if let Some(idx) = context.borrowed_to_before_index.get(src) {
-                        // dst becomes an alias for src
-                        let idx = *idx;
-                        context.borrowed_to_before_index.insert(*dst, idx);
+                        let mut idx_set = idx_set.clone();
+                        context
+                            .borrowed_to_before_index
+                            .entry(*dst)
+                            .or_insert_with(BTreeSet::new)
+                            .append(&mut idx_set);
                     }
                 }
                 _ => {}
@@ -563,7 +560,9 @@ impl<'env> ModuleTranslator<'env> {
                 if ty.is_mutable_reference() && self.has_after_update_invariant(ty) {
                     context
                         .inherited_to_before_index
-                        .insert(i, before_borrow_counter);
+                        .entry(i)
+                        .or_insert_with(BTreeSet::new)
+                        .insert(before_borrow_counter);
                     before_borrow_counter += 1;
                 }
             }
@@ -593,17 +592,20 @@ impl<'env> ModuleTranslator<'env> {
         emitln!(self.writer, "var $tmp: Value;");
         emitln!(self.writer, "var $frame: int;");
         emitln!(self.writer, "var $saved_m: Memory;");
-        for idx in context
+        let all_before_borrow_indices = context
             .borrowed_to_before_index
             .values()
             .chain(context.inherited_to_before_index.values())
+            .flatten()
             .unique()
             .sorted()
-        {
+            .collect_vec();
+        for idx in &all_before_borrow_indices {
             // Declare before borrow variables.
-            let name = boogie_var_before_borrow(*idx);
+            let name = boogie_var_before_borrow(**idx);
             emitln!(self.writer, "var {}: Value;", name);
             emitln!(self.writer, "var {}_ref: Reference;", name);
+            emitln!(self.writer, "var {}_used: bool;", name);
         }
 
         emitln!(self.writer, "\n// initialize function execution");
@@ -639,13 +641,19 @@ impl<'env> ModuleTranslator<'env> {
             }
         }
 
+        // Initialize before_borrow_used variables to false.
+        for idx in &all_before_borrow_indices {
+            let name = boogie_var_before_borrow(**idx);
+            emitln!(self.writer, "{}_used := false;", name);
+        }
+
         if !context.inherited_to_before_index.is_empty() {
             emitln!(
                 self.writer,
                 "\n// save values and references for mutable ref parameters with invariants"
             );
-            for (param_idx, before_idx) in context.inherited_to_before_index.iter() {
-                self.save_and_enforce_before_update(&func_env, *param_idx, *before_idx);
+            for (param_idx, before_idx_set) in context.inherited_to_before_index.iter() {
+                self.save_and_enforce_before_update_set(&func_env, *param_idx, before_idx_set);
             }
         }
 
@@ -750,11 +758,11 @@ impl<'env> ModuleTranslator<'env> {
 
         // Helper to save a borrowed value before mutation starts.
         let save_borrowed_value = |ctx: &BytecodeContext<'_>, dest: &usize| {
-            if let Some(idx) = ctx.borrowed_to_before_index.get(dest) {
+            if let Some(idx_set) = ctx.borrowed_to_before_index.get(dest) {
                 // Save the value before mutation happens. We also need to save the reference,
                 // because the bytecode may reuse it for some other purpose, so we can construct
                 // the after-value from it when the update invariant is executed.
-                self.save_and_enforce_before_update(&func_env, *dest, *idx);
+                self.save_and_enforce_before_update_set(&func_env, *dest, idx_set);
             }
         };
 
@@ -916,7 +924,7 @@ impl<'env> ModuleTranslator<'env> {
                     spec_translator.assume_module_invariants(&callee_env);
                 }
                 // If this is a call to a public function within the same module,
-                // and it contains parameters which are mutated currently, we end mutating now,
+                // and it has parameters which are mutated currently, we end mutating now,
                 // enforcing the update invariant. At the end of the call, we restart mutating,
                 // re-initializing the before value. This is reflecting the fact that mutable
                 // reference parameters to public functions are consider frozen when passed
@@ -927,11 +935,12 @@ impl<'env> ModuleTranslator<'env> {
                 {
                     args.iter()
                         .filter_map(|arg| {
-                            if let Some(before_idx) = ctx.borrowed_to_before_index.get(arg) {
-                                Some((*arg, *before_idx))
-                            } else if let Some(before_idx) = ctx.inherited_to_before_index.get(arg)
+                            if let Some(before_idx_set) = ctx.borrowed_to_before_index.get(arg) {
+                                Some((*arg, before_idx_set))
+                            } else if let Some(before_idx_set) =
+                                ctx.inherited_to_before_index.get(arg)
                             {
-                                Some((*arg, *before_idx))
+                                Some((*arg, before_idx_set))
                             } else {
                                 None
                             }
@@ -941,9 +950,9 @@ impl<'env> ModuleTranslator<'env> {
                     BTreeMap::new()
                 };
                 // Now that we have calculated the frozen refs, enforce update invariants.
-                for (idx, before_idx) in &frozen_ref_params {
+                for (idx, before_idx_set) in &frozen_ref_params {
                     let ty = self.get_local_type(func_env, *idx);
-                    self.enforce_after_update_invariant(func_env, &ty, *before_idx);
+                    self.enforce_after_update_invariant_set(func_env, &ty, before_idx_set);
                 }
 
                 let mut dest_str = String::new();
@@ -1018,8 +1027,8 @@ impl<'env> ModuleTranslator<'env> {
                     track_mutable_refs(ctx);
                 }
                 // After the call, save current value as before value and enforce before invariants.
-                for (idx, before_idx) in &frozen_ref_params {
-                    self.save_and_enforce_before_update(func_env, *idx, *before_idx);
+                for (idx, before_idx_set) in &frozen_ref_params {
+                    self.save_and_enforce_before_update_set(func_env, *idx, *before_idx_set);
                 }
             }
             Pack(dest, struct_def_index, type_actuals, fields) => {
@@ -1473,12 +1482,25 @@ impl<'env> ModuleTranslator<'env> {
             ref_name,
         );
         emitln!(self.writer, "{}_ref := {};", before_name, ref_name);
+        emitln!(self.writer, "{}_used := true;", before_name);
         // Enforce the before update invariant (if any).
         self.enforce_before_update_invariant(
             func_env,
             &self.get_local_type(func_env, ref_idx),
             before_idx,
         );
+    }
+
+    /// Call `save_and_enforce_before_update` for a set.
+    fn save_and_enforce_before_update_set(
+        &'env self,
+        func_env: &FunctionEnv,
+        ref_idx: usize,
+        before_idx_set: &BTreeSet<usize>,
+    ) {
+        for before_idx in before_idx_set {
+            self.save_and_enforce_before_update(func_env, ref_idx, *before_idx);
+        }
     }
 
     // Enforce invariants on references going out of scope
@@ -1499,9 +1521,9 @@ impl<'env> ModuleTranslator<'env> {
             }
             for ref_idx in dead_refs {
                 let ref_idx = *ref_idx as usize;
-                if let Some(idx) = context.borrowed_to_before_index.get(&ref_idx) {
+                if let Some(idx_set) = context.borrowed_to_before_index.get(&ref_idx) {
                     let ty = self.get_local_type(func_env, ref_idx);
-                    self.enforce_after_update_invariant(func_env, &ty, *idx);
+                    self.enforce_after_update_invariant_set(func_env, &ty, idx_set);
                 }
             }
         }
@@ -1513,9 +1535,9 @@ impl<'env> ModuleTranslator<'env> {
         func_env: &FunctionEnv,
         context: &BytecodeContext,
     ) {
-        for (ref_idx, before_idx) in &context.inherited_to_before_index {
+        for (ref_idx, before_idx_set) in &context.inherited_to_before_index {
             let ty = self.get_local_type(func_env, *ref_idx);
-            self.enforce_after_update_invariant(func_env, &ty, *before_idx);
+            self.enforce_after_update_invariant_set(func_env, &ty, before_idx_set);
         }
     }
 
@@ -1582,8 +1604,8 @@ impl<'env> ModuleTranslator<'env> {
         None
     }
 
-    // Enforce the invariant of an updated value before mutation starts. Does nothing if there
-    // is no before-update invariant.
+    /// Enforce the invariant of an updated value before mutation starts. Does nothing if there
+    /// is no before-update invariant.
     fn enforce_before_update_invariant(&self, _func_env: &FunctionEnv<'_>, ty: &Type, idx: usize) {
         if let Some(struct_env) = self.get_referred_struct(ty) {
             if SpecTranslator::has_before_update_invariant(&struct_env) {
@@ -1597,20 +1619,37 @@ impl<'env> ModuleTranslator<'env> {
         }
     }
 
-    // Enforce the invariant of an updated value after mutation ended. Does nothing if there is
-    // no after-update invariant.
+    /// Enforce the invariant of an updated value after mutation ended. Does nothing if there is
+    /// no after-update invariant.
     fn enforce_after_update_invariant(&self, _func_env: &FunctionEnv<'_>, ty: &Type, idx: usize) {
         if let Some(struct_env) = self.get_referred_struct(ty) {
             if SpecTranslator::has_after_update_invariant(&struct_env) {
                 let name = &boogie_var_before_borrow(idx);
+                emitln!(self.writer, "if ({}_used) {{", name);
+                self.writer.indent();
                 emitln!(
                     self.writer,
                     "call {}_after_update_inv({}, $Dereference($m, {}_ref));",
                     boogie_struct_name(&struct_env),
                     name,
-                    name
+                    name,
                 );
+                emitln!(self.writer, "{}_used := false;", name);
+                self.writer.unindent();
+                emitln!(self.writer, "}");
             }
+        }
+    }
+
+    /// Calls enforce_after_update_invariant on a set of before-borrow indices.
+    fn enforce_after_update_invariant_set(
+        &self,
+        func_env: &FunctionEnv<'_>,
+        ty: &Type,
+        idx_set: &BTreeSet<usize>,
+    ) {
+        for idx in idx_set {
+            self.enforce_after_update_invariant(func_env, ty, *idx);
         }
     }
 

--- a/language/move-prover/tests/sources/global_vars.exp
+++ b/language/move-prover/tests/sources/global_vars.exp
@@ -13,6 +13,7 @@ error:  A postcondition might not hold on this return path.
      =         s = <redacted>
      =     at tests/sources/global_vars.move:112:15: combi_incorrect
      =         s = <redacted>
+     =     at tests/sources/global_vars.move:109:21: combi_incorrect
      =     at tests/sources/global_vars.move:108:5: combi_incorrect (exit)
 
 error:  A postcondition might not hold on this return path.
@@ -53,6 +54,7 @@ error:  A postcondition might not hold on this return path.
      =         s = <redacted>
      =     at tests/sources/global_vars.move:147:15: update_S_incorrect
      =         r = <redacted>
+     =     at tests/sources/global_vars.move:148:9: update_S_incorrect
      =     at tests/sources/global_vars.move:144:5: update_S_incorrect (exit)
 
 error:  A postcondition might not hold on this return path.
@@ -72,4 +74,5 @@ error:  A postcondition might not hold on this return path.
     =         t = <redacted>
     =     at tests/sources/global_vars.move:64:5: update_valid_still_mutating (exit)
     =     at tests/sources/global_vars.move:84:9: update_incorrect
+    =     at tests/sources/global_vars.move:85:9: update_incorrect
     =     at tests/sources/global_vars.move:82:5: update_incorrect (exit)

--- a/language/move-prover/tests/sources/hash_model_invalid.exp
+++ b/language/move-prover/tests/sources/hash_model_invalid.exp
@@ -1,0 +1,34 @@
+Move prover returns: exiting with boogie verification errors
+error:  A postcondition might not hold on this return path.
+
+    ┌── tests/sources/hash_model_invalid.move:19:9 ───
+    │
+ 19 │         ensures len(result_1) > 0 ==> result_1[0] < max_u8();
+    │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    │
+    =     at tests/sources/hash_model_invalid.move:8:5: hash_test1 (entry)
+    =     at tests/sources/hash_model_invalid.move:10:24: hash_test1
+    =         v1 = <redacted>,
+    =         v2 = <redacted>,
+    =         h1 = <redacted>
+    =     at tests/sources/hash_model_invalid.move:11:33: hash_test1
+    =         h2 = <redacted>
+    =     at tests/sources/hash_model_invalid.move:12:10: hash_test1
+    =     at tests/sources/hash_model_invalid.move:8:5: hash_test1 (exit)
+
+error:  A postcondition might not hold on this return path.
+
+    ┌── tests/sources/hash_model_invalid.move:32:9 ───
+    │
+ 32 │         ensures len(result_1) > 0 ==> result_1[0] < max_u8();
+    │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    │
+    =     at tests/sources/hash_model_invalid.move:23:5: hash_test2 (entry)
+    =     at tests/sources/hash_model_invalid.move:25:24: hash_test2
+    =         v1 = <redacted>,
+    =         v2 = <redacted>,
+    =         h1 = <redacted>
+    =     at tests/sources/hash_model_invalid.move:26:33: hash_test2
+    =         h2 = <redacted>
+    =     at tests/sources/hash_model_invalid.move:27:10: hash_test2
+    =     at tests/sources/hash_model_invalid.move:23:5: hash_test2 (exit)

--- a/language/move-prover/tests/sources/hash_model_invalid.move
+++ b/language/move-prover/tests/sources/hash_model_invalid.move
@@ -1,0 +1,34 @@
+// dep: tests/sources/stdlib/modules/hash.move
+
+module TestHash {
+
+    use 0x0::Hash;
+
+    // sha2 test
+    fun hash_test1(v1: vector<u8>, v2: vector<u8>): (vector<u8>, vector<u8>)
+    {
+        let h1 = Hash::sha2_256(v1);
+        let h2 = Hash::sha2_256(v2);
+        (h1, h2)
+    }
+    spec fun hash_test1 {
+        aborts_if false;
+        // TODO: two failing ensures seem to create non-determinism; one time the first, the next the
+        // second is reported. Investigate whether this is caused by boogie_wrapper or by inherent to boogie.
+        // ensures result_1 == result_2;
+        ensures len(result_1) > 0 ==> result_1[0] < max_u8(); // should be <=
+    }
+
+    // sha3 test
+    fun hash_test2(v1: vector<u8>, v2: vector<u8>): (vector<u8>, vector<u8>)
+    {
+        let h1 = Hash::sha3_256(v1);
+        let h2 = Hash::sha3_256(v2);
+        (h1, h2)
+    }
+    spec fun hash_test2 {
+        aborts_if false;
+        // ensures result_1 == result_2;
+        ensures len(result_1) > 0 ==> result_1[0] < max_u8();
+    }
+}

--- a/language/move-prover/tests/sources/invariants.exp
+++ b/language/move-prover/tests/sources/invariants.exp
@@ -30,6 +30,27 @@ error:  This assertion might not hold.
  14 │         invariant update x <= old(x);
     │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
     │
+    =     at tests/sources/invariants.move:80:5: invalid_R_update_branching (entry)
+    =     at tests/sources/invariants.move:81:13: invalid_R_update_branching
+    =         b = <redacted>,
+    =         t1 = <redacted>
+    =     at tests/sources/invariants.move:82:24: invalid_R_update_branching
+    =         t1 = <redacted>,
+    =         t2 = <redacted>
+    =     at tests/sources/invariants.move:84:13: invalid_R_update_branching
+    =     at tests/sources/invariants.move:89:13: invalid_R_update_branching
+    =     at tests/sources/invariants.move:91:20: invalid_R_update_branching
+    =         r = <redacted>,
+    =         r = <redacted>
+    =     at tests/sources/invariants.move:92:10: invalid_R_update_branching
+
+error:  This assertion might not hold.
+
+    ┌── tests/sources/invariants.move:14:9 ───
+    │
+ 14 │         invariant update x <= old(x);
+    │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    │
     =     at tests/sources/invariants.move:71:5: invalid_R_update_indirectly (entry)
     =     at tests/sources/invariants.move:72:13: invalid_R_update_indirectly
     =     at tests/sources/invariants.move:73:28: invalid_R_update_indirectly
@@ -62,14 +83,14 @@ error:  This assertion might not hold.
  11 │         invariant x > 1;
     │         ^^^^^^^^^^^^^^^^
     │
-    =     at tests/sources/invariants.move:85:5: lifetime_invalid_R (entry)
-    =     at tests/sources/invariants.move:86:13: lifetime_invalid_R
-    =     at tests/sources/invariants.move:87:21: lifetime_invalid_R
+    =     at tests/sources/invariants.move:99:5: lifetime_invalid_R (entry)
+    =     at tests/sources/invariants.move:100:13: lifetime_invalid_R
+    =     at tests/sources/invariants.move:101:21: lifetime_invalid_R
     =         r = <redacted>,
     =         r_ref = <redacted>
-    =     at tests/sources/invariants.move:88:26: lifetime_invalid_R
+    =     at tests/sources/invariants.move:102:26: lifetime_invalid_R
     =         x_ref = <redacted>
-    =     at tests/sources/invariants.move:89:18: lifetime_invalid_R
+    =     at tests/sources/invariants.move:103:18: lifetime_invalid_R
     =         r_ref = <redacted>,
     =         x_ref = <redacted>
 
@@ -80,48 +101,48 @@ error:  This assertion might not hold.
  14 │         invariant update x <= old(x);
     │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
     │
-    =     at tests/sources/invariants.move:98:5: lifetime_invalid_R_2 (entry)
-    =     at tests/sources/invariants.move:99:13: lifetime_invalid_R_2
-    =     at tests/sources/invariants.move:100:21: lifetime_invalid_R_2
+    =     at tests/sources/invariants.move:112:5: lifetime_invalid_R_2 (entry)
+    =     at tests/sources/invariants.move:113:13: lifetime_invalid_R_2
+    =     at tests/sources/invariants.move:114:21: lifetime_invalid_R_2
     =         r = <redacted>,
     =         r_ref = <redacted>
-    =     at tests/sources/invariants.move:101:26: lifetime_invalid_R_2
+    =     at tests/sources/invariants.move:115:26: lifetime_invalid_R_2
     =         x_ref = <redacted>
-    =     at tests/sources/invariants.move:102:18: lifetime_invalid_R_2
+    =     at tests/sources/invariants.move:116:18: lifetime_invalid_R_2
     =         r_ref = <redacted>,
     =         x_ref = <redacted>
-    =     at tests/sources/invariants.move:103:18: lifetime_invalid_R_2
+    =     at tests/sources/invariants.move:117:18: lifetime_invalid_R_2
     =         r_ref = <redacted>,
     =         x_ref = <redacted>
-    =     at tests/sources/invariants.move:105:9: lifetime_invalid_R_2
+    =     at tests/sources/invariants.move:119:17: lifetime_invalid_R_2
     =         r_ref = <redacted>
-    =     at tests/sources/invariants.move:106:22: lifetime_invalid_R_2
+    =     at tests/sources/invariants.move:120:22: lifetime_invalid_R_2
     =         x_ref = <redacted>
-    =     at tests/sources/invariants.move:107:18: lifetime_invalid_R_2
+    =     at tests/sources/invariants.move:121:18: lifetime_invalid_R_2
     =         r_ref = <redacted>,
     =         x_ref = <redacted>
 
 error:  This assertion might not hold.
 
-     ┌── tests/sources/invariants.move:123:9 ───
+     ┌── tests/sources/invariants.move:137:9 ───
      │
- 123 │         invariant y > 1;
+ 137 │         invariant y > 1;
      │         ^^^^^^^^^^^^^^^^
      │
-     =     at tests/sources/invariants.move:126:5: lifetime_invalid_S_branching (entry)
-     =     at tests/sources/invariants.move:127:11: lifetime_invalid_S_branching
+     =     at tests/sources/invariants.move:140:5: lifetime_invalid_S_branching (entry)
+     =     at tests/sources/invariants.move:141:11: lifetime_invalid_S_branching
      =         cond = <redacted>
-     =     at tests/sources/invariants.move:128:21: lifetime_invalid_S_branching
+     =     at tests/sources/invariants.move:142:21: lifetime_invalid_S_branching
      =         a = <redacted>,
      =         b = <redacted>
-     =     at tests/sources/invariants.move:129:19: lifetime_invalid_S_branching
+     =     at tests/sources/invariants.move:143:19: lifetime_invalid_S_branching
      =         a_ref = <redacted>
-     =     at tests/sources/invariants.move:130:19: lifetime_invalid_S_branching
+     =     at tests/sources/invariants.move:144:19: lifetime_invalid_S_branching
      =         b_ref = <redacted>
-     =     at tests/sources/invariants.move:131:23: lifetime_invalid_S_branching
+     =     at tests/sources/invariants.move:145:23: lifetime_invalid_S_branching
      =         x_ref = <redacted>
-     =     at tests/sources/invariants.move:133:11: lifetime_invalid_S_branching
-     =     at tests/sources/invariants.move:136:11: lifetime_invalid_S_branching
+     =     at tests/sources/invariants.move:147:11: lifetime_invalid_S_branching
+     =     at tests/sources/invariants.move:150:11: lifetime_invalid_S_branching
      =         a_ref = <redacted>,
      =         b_ref = <redacted>,
      =         x_ref = <redacted>

--- a/language/move-prover/tests/sources/invariants.move
+++ b/language/move-prover/tests/sources/invariants.move
@@ -77,6 +77,20 @@ module TestInvariants {
         *r = 4;
     }
 
+    fun invalid_R_update_branching(b: bool): R {
+        let t1 = R {x: 5};
+        let t2 = R {x: 3};
+        let r: &mut R;
+        if (b) {
+            // this branch is fine because we can go from x = 5 to x = 4
+            r = &mut t1
+        } else {
+            // this branch leads to update invariant violation as we cannot go from x = 3 to x = 4
+            r = &mut t2
+        };
+        *r = R {x: 4};
+        *r
+    }
 
     // -----------------------
     // Lifetime analysis tests

--- a/language/move-prover/tests/sources/mut_ref_accross_modules.exp
+++ b/language/move-prover/tests/sources/mut_ref_accross_modules.exp
@@ -79,6 +79,8 @@ error:  This assertion might not hold.
     =         x = <redacted>,
     =         r = <redacted>
     =     at tests/sources/mut_ref_accross_modules.move:119:28: private_to_public_caller_invalid_data_invariant
+    =     at tests/sources/mut_ref_accross_modules.move:121:20: private_to_public_caller_invalid_data_invariant
+    =         r = <redacted>
 
 error:  A precondition for this call might not hold.
 


### PR DESCRIPTION
Until now, we had wrongly assumed that a mut ref can only have exactly one before-borrow snapshot associated. However, due to branching this is not the case. Consider e.g.:

```
let r: &mut R;
if (b) r = &mut t1 else r = &mut t2;
```

Here `r` can represent either `&mut t1` or `&mut t2`, depending on the value of `b`.

In this PR, we extend the tracking of before-update index from a single value per reference to a set of indices. In the example above, the reference `r` will have assigned both the before-borrow indices of `&mut t1` and `&mut t2`. In order to decide which invariant has to be enforced when `r` dies, we use a new boolean variable `$before_borrow_N_used` which is managed at runtime and set to `true` once the associated borrow instruction is executed.

This also fixes a bunch of related issues, like incorrectly asserting invariants for borrows which are never executed because of branching. There are likely more issues with this if it comes to loops, and we eventually will need to move the current ad-hoc analysis we do on the bytecode to the DFA framework and peform it in a better principled way.

## Motivation

Refine invariants.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?

Yes.

## Test Plan

Add a new function `invalid_R_update_branching` to `invariants.move` based on the example which @shazqadeer wrote and which discovered the issue.

Some baselines of other tests have changed caused by different generated boogie code but the changes look good.

## Related PRs

NA
