### PR TITLE
[CI] update docker build trigger

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -80,7 +80,7 @@ commands:
           command: |
             echo 'export CHANGED_DOCKER_FILES=$(
               for commit in $(git rev-list origin/master..HEAD) ; do
-                git diff-tree --no-commit-id --name-only -r "$commit" -- "*.Dockerfile";
+                git diff-tree --no-commit-id --name-only -r "$commit" -- "*Dockerfile";
               done
             )' >> $BASH_ENV
   save_cargo_package_cache:

--- a/.circleci/should_build_docker.sh
+++ b/.circleci/should_build_docker.sh
@@ -15,7 +15,7 @@ cd "$PROJECT_DIR"
 COMMITS=$(git rev-list $oldrev..$newrev)
 DOCKER_FILES=$(
   for commit in $COMMITS; do
-    git diff-tree --no-commit-id --name-only -r "$commit" -- "*.Dockerfile";
+    git diff-tree --no-commit-id --name-only -r "$commit" -- "*Dockerfile";
   done
 )
 


### PR DESCRIPTION
## Motivation
Update the path matching logic in the docker build trigger to account
for different patterns in file name.

## Test Plan
Tested locally by rebasing 5c474c8b on top.
```
[youngyl@youngyl-mbp:libra davidiw/docker]$ git log -2
commit 5c474c8b5546c8d941c11e3102751127fcec6ec3 (HEAD -> davidiw/docker)
Author: David Wolinsky <davidiw@fb.com>
Date:   Sat Apr 4 21:38:51 2020 -0700

    [docker] Make local running work

    * Remove the old pre-config-builder faucet key from mint
    * Have it connect to the first node in the validator set, since it will
    always exist so long as there is one validator
    * Move Mint port since it overlapped with JSON-RPC
    * Merged build-dynamic.sh into build.sh from validator-dynamic since every other build was build.sh
    * Expose validator-dyanmic JSON-RPC from docker
    * Update readme to note all historical changes

commit 667e95caca7afd19fde4db3a63ddfa4bb5d070cc (ci_docker_trigger)
Author: Young Yang Liauw <youngyl@fb.com>
Date:   Mon Apr 6 09:56:47 2020 -0700

    [CI] update docker build trigger

    Update the path matching logic in the docker build trigger to account
    for different patterns in file name.
[youngyl@youngyl-mbp:libra davidiw/docker]$ .circleci/should_build_docker.sh
Will build docker containers.
[youngyl@youngyl-mbp:libra davidiw/docker]$
```