### PR TITLE
[move-lang] Inject file name into error messages about file open errors.

### DIFF
--- a/language/move-lang/src/lib.rs
+++ b/language/move-lang/src/lib.rs
@@ -239,7 +239,8 @@ fn parse_file(
     fname: &'static str,
 ) -> io::Result<(Option<parser::ast::FileDefinition>, Errors)> {
     let mut errors: Errors = Vec::new();
-    let mut f = File::open(fname)?;
+    let mut f = File::open(fname)
+        .map_err(|err| std::io::Error::new(err.kind(), format!("{}: {}", err, fname)))?;
     let mut source_buffer = String::new();
     f.read_to_string(&mut source_buffer)?;
     let no_comments_buffer = match strip_comments_and_verify(fname, &source_buffer) {


### PR DESCRIPTION
This injects the name of the file which could not be opened by the move-lang parser. Where we got:

```
Error: No such file or directory (os error 2)
```

... before, we now get:

```
Error: No such file or directory (os error 2): not_existing.move
```

## Motivation

DevX

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

Manual

## Related PRs

NA
