### PR TITLE
[on-chain config] make reconfig subscription from trait to struct

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2610,6 +2610,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow 1.0.28 (registry+https://github.com/rust-lang/crates.io-index)",
  "bytes 0.5.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "channel 0.1.0",
  "chrono 0.4.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "hex 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "itertools 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/language/vm/src/file_format_common.rs
+++ b/language/vm/src/file_format_common.rs
@@ -309,7 +309,7 @@ pub fn read_uleb128_as_u16(cursor: &mut Cursor<&[u8]>) -> Result<u16> {
         let val = byte & 0x7f;
         value |= u32::from(val) << shift;
         if val == byte {
-            if (shift > 0 && val == 0) || value > std::u16::MAX.into() {
+            if (shift > 0 && val == 0) || value > u32::from(std::u16::MAX) {
                 bail!("invalid ULEB128 representation for u16");
             }
             return Ok(value as u16);

--- a/libra-node/src/main_node.rs
+++ b/libra-node/src/main_node.rs
@@ -12,7 +12,9 @@ use futures::{channel::mpsc::channel, executor::block_on};
 use libra_config::config::{NetworkConfig, NodeConfig, RoleType};
 use libra_json_rpc::bootstrap_from_config as bootstrap_rpc;
 use libra_logger::prelude::*;
+use libra_mempool::MEMPOOL_SUBSCRIBED_CONFIGS;
 use libra_metrics::metric_server;
+use libra_types::event_subscription::ReconfigSubscription;
 use libra_vm::LibraVM;
 use network::validator_network::network_builder::{NetworkBuilder, TransportType};
 use state_synchronizer::StateSynchronizer;
@@ -184,10 +186,11 @@ pub fn setup_environment(node_config: &mut NodeConfig) -> LibraHandle {
     let mut state_sync_network_handles = vec![];
     let mut mempool_network_handles = vec![];
     let mut validator_network_provider = None;
-    let mut reconfig_event_subscriptions = vec![];
+    let mut reconfig_subscriptions = vec![];
+
     let (mempool_reconfig_subscription, mempool_reconfig_events) =
-        libra_mempool::generate_reconfig_subscription();
-    reconfig_event_subscriptions.push(mempool_reconfig_subscription);
+        ReconfigSubscription::subscribe(MEMPOOL_SUBSCRIBED_CONFIGS);
+    reconfig_subscriptions.push(mempool_reconfig_subscription);
 
     if let Some(network) = node_config.validator_network.as_mut() {
         let (runtime, mut network_builder) = setup_network(network, RoleType::Validator);
@@ -226,7 +229,7 @@ pub fn setup_environment(node_config: &mut NodeConfig) -> LibraHandle {
         state_sync_to_mempool_sender,
         Arc::clone(&executor),
         &node_config,
-        reconfig_event_subscriptions,
+        reconfig_subscriptions,
     );
     let (mp_client_sender, mp_client_events) = channel(AC_SMP_CHANNEL_BUFFER_SIZE);
 

--- a/mempool/src/lib.rs
+++ b/mempool/src/lib.rs
@@ -63,9 +63,9 @@ extern crate prometheus;
 #[cfg(feature = "fuzzing")]
 pub mod mocks;
 pub use shared_mempool::{
-    bootstrap, generate_reconfig_subscription, CommitNotification, CommitResponse,
-    CommittedTransaction, ConsensusRequest, ConsensusResponse, MempoolClientSender,
-    SubmissionStatus, TransactionExclusion,
+    bootstrap, CommitNotification, CommitResponse, CommittedTransaction, ConsensusRequest,
+    ConsensusResponse, MempoolClientSender, SubmissionStatus, TransactionExclusion,
+    MEMPOOL_SUBSCRIBED_CONFIGS,
 };
 
 mod core_mempool;

--- a/state-synchronizer/src/synchronizer.rs
+++ b/state-synchronizer/src/synchronizer.rs
@@ -16,7 +16,7 @@ use futures::{
 use libra_config::config::{NodeConfig, RoleType, StateSyncConfig};
 use libra_mempool::{CommitNotification, CommitResponse};
 use libra_types::{
-    contract_event::ContractEvent, event_subscription::EventSubscription,
+    contract_event::ContractEvent, event_subscription::ReconfigSubscription,
     ledger_info::LedgerInfoWithSignatures, transaction::Transaction,
     validator_change::ValidatorChangeProof, waypoint::Waypoint,
 };
@@ -42,7 +42,7 @@ impl StateSynchronizer {
         state_sync_to_mempool_sender: mpsc::Sender<CommitNotification>,
         executor: Arc<Mutex<Executor<LibraVM>>>,
         config: &NodeConfig,
-        reconfig_event_subscriptions: Vec<Box<dyn EventSubscription>>,
+        reconfig_event_subscriptions: Vec<ReconfigSubscription>,
     ) -> Self {
         let executor_proxy = ExecutorProxy::new(executor, config, reconfig_event_subscriptions);
         Self::bootstrap_with_executor_proxy(

--- a/types/Cargo.toml
+++ b/types/Cargo.toml
@@ -27,6 +27,7 @@ serde = { version = "1.0.106", default-features = false }
 thiserror = "1.0"
 tiny-keccak = { version = "2.0.2", default-features = false, features = ["sha3"] }
 
+channel = { path = "../common/channel", version = "0.1.0" }
 lcs = { path = "../common/lcs", version = "0.1.0", package = "libra-canonical-serialization" }
 libra-crypto = { path = "../crypto/crypto", version = "0.1.0" }
 libra-crypto-derive = { path = "../crypto/crypto-derive", version = "0.1.0" }

--- a/types/src/event_subscription.rs
+++ b/types/src/event_subscription.rs
@@ -2,11 +2,44 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::on_chain_config::{ConfigID, OnChainConfigPayload};
-use std::collections::HashSet;
+use anyhow::Result;
+use channel::{
+    libra_channel::{self, Receiver, Sender},
+    message_queues::QueueStyle,
+};
+use std::{collections::HashSet, num::NonZeroUsize};
 
-/// Trait that must be implemented by a subscription to reconfiguration events emitted
-/// by state sync
-pub trait EventSubscription: Send + Sync {
-    fn subscribed_configs(&self) -> HashSet<ConfigID>;
-    fn publish(&mut self, payload: OnChainConfigPayload);
+/// A subscription to on-chain reconfiguration notifications from state sync
+pub struct ReconfigSubscription {
+    sender: Sender<(), OnChainConfigPayload>,
+    subscribed_configs: HashSet<ConfigID>,
+}
+
+impl ReconfigSubscription {
+    /// Constructs an reconfig subscription object for a set of configs `subscribed_configs`
+    /// Returns the subscription object, and the receiving end of a channel that reconfig notifications
+    /// will be sent to
+    pub fn subscribe(
+        subscribed_configs: &[ConfigID],
+    ) -> (Self, Receiver<(), OnChainConfigPayload>) {
+        let (sender, receiver) =
+            libra_channel::new(QueueStyle::LIFO, NonZeroUsize::new(1).unwrap(), None);
+        let subscribed_configs = subscribed_configs.iter().cloned().collect::<HashSet<_>>();
+        (
+            Self {
+                sender,
+                subscribed_configs,
+            },
+            receiver,
+        )
+    }
+
+    /// Function used by reconfiguration notification publisher to send notification to subscriber
+    pub fn publish(&mut self, payload: OnChainConfigPayload) -> Result<()> {
+        self.sender.push((), payload)
+    }
+
+    pub fn subscribed_configs(&self) -> HashSet<ConfigID> {
+        self.subscribed_configs.clone()
+    }
 }

--- a/types/src/on_chain_config.rs
+++ b/types/src/on_chain_config.rs
@@ -17,7 +17,7 @@ use std::{collections::HashMap, sync::Arc};
 /// 1. Implement the `OnChainConfig` trait for the Rust representation of the config
 /// 2. Add the config's `ConfigID` to `ON_CHAIN_CONFIG_REGISTRY`
 
-#[derive(Copy, Clone, Eq, Hash, PartialEq)]
+#[derive(Copy, Clone, Debug, Eq, Hash, PartialEq)]
 pub struct ConfigID(&'static str);
 
 impl ConfigID {
@@ -29,7 +29,7 @@ impl ConfigID {
 /// State sync will panic if the value of any config in this registry is uninitialized
 pub const ON_CHAIN_CONFIG_REGISTRY: &[ConfigID] = &[VMPublishingOption::CONFIG_ID];
 
-#[derive(Clone)]
+#[derive(Clone, Debug, PartialEq)]
 pub struct OnChainConfigPayload {
     configs: Arc<HashMap<ConfigID, Vec<u8>>>,
 }


### PR DESCRIPTION
## Summary

Make `EventSubscription` trait to `ReconfigSubscription` struct, since mechanism for publishing reconfig notification will be pretty uniform
Also had to change u32 conversion in `language/vm/src/file_format_common.rs` due to clippy complaint
