### PR TITLE
[clustertest] Downgrade two log points in network to trace!

### DIFF
--- a/network/src/peer/mod.rs
+++ b/network/src/peer/mod.rs
@@ -290,7 +290,7 @@ where
             oneshot::Sender<Result<(), PeerManagerError>>,
         )>,
     ) -> Result<(), PeerManagerError> {
-        debug!("Received message from Peer {}", self.peer_id().short_str(),);
+        trace!("Received message from Peer {}", self.peer_id().short_str(),);
         // Read inbound message from stream.
         let message = message.freeze();
         let message: NetworkMessage = lcs::from_bytes(&message)?;

--- a/network/src/protocols/direct_send/mod.rs
+++ b/network/src/protocols/direct_send/mod.rs
@@ -135,7 +135,7 @@ impl DirectSend {
                 let peer_id = self.peer_handle.peer_id();
                 if let NetworkMessage::DirectSendMsg(message) = message {
                     let protocol = message.protocol_id;
-                    debug!(
+                    trace!(
                         "DirectSend: Received inbound message from peer {} for protocol {:?}",
                         peer_id.short_str(),
                         protocol


### PR DESCRIPTION
## Summary

Recently ElasticSearch started having issues because of log volume. The major source of logs (>90%) seem to be these two log points in network. Donwngrading them from debug! to trace!
