### PR TITLE
Tree cache new returns result

### DIFF
--- a/execution/executor-types/src/lib.rs
+++ b/execution/executor-types/src/lib.rs
@@ -291,7 +291,7 @@ impl From<TreeState> for ExecutedTrees {
         ExecutedTrees::new(
             tree_state.account_state_root_hash,
             tree_state.ledger_frozen_subtree_hashes,
-            tree_state.version + 1,
+            tree_state.num_transactions,
         )
     }
 }

--- a/storage/jellyfish-merkle/src/lib.rs
+++ b/storage/jellyfish-merkle/src/lib.rs
@@ -227,7 +227,7 @@ where
         blob_sets: Vec<Vec<(HashValue, AccountStateBlob)>>,
         first_version: Version,
     ) -> Result<(Vec<HashValue>, TreeUpdateBatch)> {
-        let mut tree_cache = TreeCache::new(self.reader, first_version);
+        let mut tree_cache = TreeCache::new(self.reader, first_version)?;
         for (idx, blob_set) in blob_sets.into_iter().enumerate() {
             assert!(
                 !blob_set.is_empty(),

--- a/storage/jellyfish-merkle/src/tree_cache/mod.rs
+++ b/storage/jellyfish-merkle/src/tree_cache/mod.rs
@@ -136,13 +136,11 @@ where
     R: 'a + TreeReader,
 {
     /// Constructs a new `TreeCache` instance.
-    pub fn new(reader: &'a R, next_version: Version) -> Self {
+    pub fn new(reader: &'a R, next_version: Version) -> Result<Self> {
         let mut node_cache = HashMap::new();
         let root_node_key = if next_version == 0 {
             let pre_genesis_root_key = NodeKey::new_empty_path(PRE_GENESIS_VERSION);
-            let pre_genesis_root = reader
-                .get_node_option(&pre_genesis_root_key)
-                .expect("Can't deal with DB read failure on initialization.");
+            let pre_genesis_root = reader.get_node_option(&pre_genesis_root_key)?;
 
             match pre_genesis_root {
                 Some(_) => {
@@ -162,7 +160,7 @@ where
         } else {
             NodeKey::new_empty_path(next_version - 1)
         };
-        Self {
+        Ok(Self {
             node_cache,
             stale_node_index_cache: HashSet::new(),
             frozen_cache: FrozenTreeCache::default(),
@@ -171,7 +169,7 @@ where
             reader,
             num_stale_leaves: 0,
             num_new_leaves: 0,
-        }
+        })
     }
 
     /// Gets a node with given node key. If it doesn't exist in node cache, read from `reader`.

--- a/storage/jellyfish-merkle/src/tree_cache/tree_cache_test.rs
+++ b/storage/jellyfish-merkle/src/tree_cache/tree_cache_test.rs
@@ -20,7 +20,7 @@ fn random_leaf_with_key(next_version: Version) -> (Node, NodeKey) {
 fn test_get_node() {
     let next_version = 0;
     let db = MockTreeStore::default();
-    let cache = TreeCache::new(&db, next_version);
+    let cache = TreeCache::new(&db, next_version).unwrap();
 
     let (node, node_key) = random_leaf_with_key(next_version);
     db.put_node(node_key.clone(), node.clone()).unwrap();
@@ -32,7 +32,7 @@ fn test_get_node() {
 fn test_root_node() {
     let next_version = 0;
     let db = MockTreeStore::default();
-    let mut cache = TreeCache::new(&db, next_version);
+    let mut cache = TreeCache::new(&db, next_version).unwrap();
     assert_eq!(*cache.get_root_node_key(), NodeKey::new_empty_path(0));
 
     let (node, node_key) = random_leaf_with_key(next_version);
@@ -51,7 +51,7 @@ fn test_pre_genesis() {
     db.put_node(pre_genesis_root_key.clone(), pre_genesis_only_node)
         .unwrap();
 
-    let cache = TreeCache::new(&db, next_version);
+    let cache = TreeCache::new(&db, next_version).unwrap();
     assert_eq!(*cache.get_root_node_key(), pre_genesis_root_key);
 }
 
@@ -59,7 +59,7 @@ fn test_pre_genesis() {
 fn test_freeze_with_delete() {
     let next_version = 0;
     let db = MockTreeStore::default();
-    let mut cache = TreeCache::new(&db, next_version);
+    let mut cache = TreeCache::new(&db, next_version).unwrap();
 
     assert_eq!(*cache.get_root_node_key(), NodeKey::new_empty_path(0));
 

--- a/storage/storage-proto/src/lib.rs
+++ b/storage/storage-proto/src/lib.rs
@@ -33,7 +33,7 @@ use libra_types::{
     account_address::AccountAddress,
     account_state_blob::AccountStateBlob,
     ledger_info::LedgerInfoWithSignatures,
-    proof::{SparseMerkleProof, SparseMerkleRangeProof},
+    proof::{definition::LeafCount, SparseMerkleProof, SparseMerkleRangeProof},
     transaction::{
         Transaction, TransactionInfo, TransactionListWithProof, TransactionToCommit, Version,
     },
@@ -493,19 +493,19 @@ impl From<GetTransactionsResponse> for crate::proto::storage::GetTransactionsRes
 #[derive(Clone, Debug, Eq, PartialEq)]
 #[cfg_attr(any(test, feature = "fuzzing"), derive(Arbitrary))]
 pub struct TreeState {
-    pub version: Version,
+    pub num_transactions: LeafCount,
     pub ledger_frozen_subtree_hashes: Vec<HashValue>,
     pub account_state_root_hash: HashValue,
 }
 
 impl TreeState {
     pub fn new(
-        version: Version,
+        num_transactions: LeafCount,
         ledger_frozen_subtree_hashes: Vec<HashValue>,
         account_state_root_hash: HashValue,
     ) -> Self {
         Self {
-            version,
+            num_transactions,
             ledger_frozen_subtree_hashes,
             account_state_root_hash,
         }
@@ -523,10 +523,10 @@ impl TryFrom<crate::proto::storage::TreeState> for TreeState {
             .map(|x| &x[..])
             .map(HashValue::from_slice)
             .collect::<Result<Vec<_>>>()?;
-        let version = proto.version;
+        let num_transactions = proto.num_transactions;
 
         Ok(Self::new(
-            version,
+            num_transactions,
             ledger_frozen_subtree_hashes,
             account_state_root_hash,
         ))
@@ -541,10 +541,10 @@ impl From<TreeState> for crate::proto::storage::TreeState {
             .into_iter()
             .map(|x| x.to_vec())
             .collect();
-        let version = info.version;
+        let num_transactions = info.num_transactions;
 
         Self {
-            version,
+            num_transactions,
             ledger_frozen_subtree_hashes,
             account_state_root_hash,
         }

--- a/storage/storage-proto/src/proto/storage.proto
+++ b/storage/storage-proto/src/proto/storage.proto
@@ -141,8 +141,10 @@ message GetStartupInfoResponse {
 }
 
 message TreeState {
-  // The version of the tree state. All fields below are based on this version.
-  uint64 version = 1;
+  // The number of transactions in the accumulator. "0" means an empty
+  // transaction accumulator, in which case `ledger_frozen_subtree_hashes` must
+  // be empty, but pre-genesis state can exist. All fields below base on this.
+  uint64 num_transactions = 1;
   // From left to right, root hashes of all frozen subtrees.
   repeated bytes ledger_frozen_subtree_hashes = 2;
   // The latest account state root hash.


### PR DESCRIPTION
<!--
Thank you for sending a PR. We appreciate you spending time to help improve the Libra project.

The project is undergoing daily changes. Pull Requests will be reviewed and responded to as time permits.
-->

## Motivation

Realized TreeCache are initialized at runtime frequently, thus should not panic on db error.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?

(Write your answer here.)
yes
## Test Plan
existing coverage
(Share your test plan here. If you changed code, please provide us with clear instructions for verifying that your changes work.)

## Related PRs

(If this PR adds or changes functionality, please take some time to update the docs at https://github.com/libra/website, and link to your PR here.)
