### PR TITLE
[storage] LibraDB::get_latest_tree_state()

### DIFF
--- a/execution/executor-types/src/lib.rs
+++ b/execution/executor-types/src/lib.rs
@@ -291,7 +291,7 @@ impl From<TreeState> for ExecutedTrees {
         ExecutedTrees::new(
             tree_state.account_state_root_hash,
             tree_state.ledger_frozen_subtree_hashes,
-            tree_state.version + 1,
+            tree_state.num_transactions,
         )
     }
 }

--- a/storage/jellyfish-merkle/src/lib.rs
+++ b/storage/jellyfish-merkle/src/lib.rs
@@ -599,8 +599,15 @@ where
 
     #[cfg(any(test, feature = "fuzzing"))]
     pub fn get_root_hash(&self, version: Version) -> Result<HashValue> {
+        self.get_root_hash_option(version)?
+            .ok_or_else(|| format_err!("State root hash for version {}", version))
+    }
+
+    pub fn get_root_hash_option(&self, version: Version) -> Result<Option<HashValue>> {
         let root_node_key = NodeKey::new_empty_path(version);
-        let root_node = self.reader.get_node(&root_node_key)?;
-        Ok(root_node.hash())
+        Ok(self
+            .reader
+            .get_node_option(&root_node_key)?
+            .map(|root_node| root_node.hash()))
     }
 }

--- a/storage/jellyfish-merkle/src/lib.rs
+++ b/storage/jellyfish-merkle/src/lib.rs
@@ -600,7 +600,7 @@ where
     #[cfg(any(test, feature = "fuzzing"))]
     pub fn get_root_hash(&self, version: Version) -> Result<HashValue> {
         self.get_root_hash_option(version)?
-            .ok_or_else(|| format_err!("State root hash for version {}", version))
+            .ok_or_else(|| format_err!("Root node not found for version {}.", version))
     }
 
     pub fn get_root_hash_option(&self, version: Version) -> Result<Option<HashValue>> {

--- a/storage/libradb/src/ledger_store/mod.rs
+++ b/storage/libradb/src/ledger_store/mod.rs
@@ -168,7 +168,7 @@ impl LedgerStore {
         Ok(latest_validator_set.clone())
     }
 
-    fn get_tree_state(
+    pub fn get_tree_state(
         &self,
         num_transactions: LeafCount,
         transaction_info: TransactionInfo,

--- a/storage/libradb/src/libradb_test.rs
+++ b/storage/libradb/src/libradb_test.rs
@@ -2,12 +2,17 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use super::*;
-use crate::test_helper::{arb_blocks_to_commit, arb_mock_genesis};
+use crate::{
+    schema::jellyfish_merkle_node::JellyfishMerkleNodeSchema,
+    test_helper::{arb_blocks_to_commit, arb_mock_genesis},
+};
+use jellyfish_merkle::node_type::{Node, NodeKey};
 use libra_crypto::hash::CryptoHash;
 use libra_temppath::TempPath;
 use libra_types::{
     account_config::AccountResource, contract_event::ContractEvent,
     discovery_set::DISCOVERY_SET_CHANGE_EVENT_PATH, ledger_info::LedgerInfo,
+    proof::SparseMerkleLeafNode, vm_error::StatusCode,
 };
 use proptest::prelude::*;
 use std::{collections::HashMap, convert::TryFrom};
@@ -488,4 +493,53 @@ proptest! {
         assert!(account_state_with_proof.blob.is_some());
         assert!(events.is_empty());
     }
+}
+
+#[test]
+fn test_get_latest_tree_state() {
+    let tmp_dir = TempPath::new();
+    let db = LibraDB::new(&tmp_dir);
+
+    // entirely emtpy db
+    let empty = db.get_latest_tree_state().unwrap();
+    assert_eq!(
+        empty,
+        TreeState::new(0, vec![], *SPARSE_MERKLE_PLACEHOLDER_HASH,)
+    );
+
+    // unbootstrapped db with pre-genesis state
+    let address = AccountAddress::new([0; 16]);
+    let blob = AccountStateBlob::from(vec![1]);
+    db.db
+        .put::<JellyfishMerkleNodeSchema>(
+            &NodeKey::new_empty_path(PRE_GENESIS_VERSION),
+            &Node::new_leaf(address.hash(), blob.clone()),
+        )
+        .unwrap();
+    let hash = SparseMerkleLeafNode::new(address.hash(), blob.hash()).hash();
+    let pre_genesis = db.get_latest_tree_state().unwrap();
+    assert_eq!(pre_genesis, TreeState::new(0, vec![], hash,));
+
+    // bootstrapped db (any transaction info is in)
+    let txn_info = TransactionInfo::new(
+        HashValue::random(),
+        HashValue::random(),
+        HashValue::random(),
+        0,
+        StatusCode::UNKNOWN_STATUS,
+    );
+    put_transaction_info(&db, 0, &txn_info);
+    let bootstrapped = db.get_latest_tree_state().unwrap();
+    assert_eq!(
+        bootstrapped,
+        TreeState::new(1, vec![txn_info.hash()], txn_info.state_root_hash())
+    );
+}
+
+fn put_transaction_info(db: &LibraDB, version: Version, txn_info: &TransactionInfo) {
+    let mut cs = ChangeSet::new();
+    db.ledger_store
+        .put_transaction_infos(version, &[txn_info.clone()], &mut cs)
+        .unwrap();
+    db.db.write_schemas(cs.batch).unwrap();
 }

--- a/storage/libradb/src/libradb_test.rs
+++ b/storage/libradb/src/libradb_test.rs
@@ -508,7 +508,7 @@ fn test_get_latest_tree_state() {
     );
 
     // unbootstrapped db with pre-genesis state
-    let address = AccountAddress::new([0; 16]);
+    let address = AccountAddress::default();
     let blob = AccountStateBlob::from(vec![1]);
     db.db
         .put::<JellyfishMerkleNodeSchema>(
@@ -518,7 +518,7 @@ fn test_get_latest_tree_state() {
         .unwrap();
     let hash = SparseMerkleLeafNode::new(address.hash(), blob.hash()).hash();
     let pre_genesis = db.get_latest_tree_state().unwrap();
-    assert_eq!(pre_genesis, TreeState::new(0, vec![], hash,));
+    assert_eq!(pre_genesis, TreeState::new(0, vec![], hash));
 
     // bootstrapped db (any transaction info is in)
     let txn_info = TransactionInfo::new(

--- a/storage/libradb/src/state_store/mod.rs
+++ b/storage/libradb/src/state_store/mod.rs
@@ -110,6 +110,10 @@ impl StateStore {
         JellyfishMerkleTree::new(self).get_root_hash(version)
     }
 
+    pub fn get_root_hash_option(&self, version: Version) -> Result<Option<HashValue>> {
+        JellyfishMerkleTree::new(self).get_root_hash_option(version)
+    }
+
     /// Finds the rightmost leaf by scanning the entire DB.
     #[cfg(test)]
     pub fn get_rightmost_leaf_naive(&self) -> Result<Option<(NodeKey, LeafNode)>> {

--- a/storage/storage-proto/src/lib.rs
+++ b/storage/storage-proto/src/lib.rs
@@ -33,7 +33,7 @@ use libra_types::{
     account_address::AccountAddress,
     account_state_blob::AccountStateBlob,
     ledger_info::LedgerInfoWithSignatures,
-    proof::{SparseMerkleProof, SparseMerkleRangeProof},
+    proof::{definition::LeafCount, SparseMerkleProof, SparseMerkleRangeProof},
     transaction::{
         Transaction, TransactionInfo, TransactionListWithProof, TransactionToCommit, Version,
     },
@@ -493,19 +493,19 @@ impl From<GetTransactionsResponse> for crate::proto::storage::GetTransactionsRes
 #[derive(Clone, Debug, Eq, PartialEq)]
 #[cfg_attr(any(test, feature = "fuzzing"), derive(Arbitrary))]
 pub struct TreeState {
-    pub version: Version,
+    pub num_transactions: LeafCount,
     pub ledger_frozen_subtree_hashes: Vec<HashValue>,
     pub account_state_root_hash: HashValue,
 }
 
 impl TreeState {
     pub fn new(
-        version: Version,
+        num_transactions: LeafCount,
         ledger_frozen_subtree_hashes: Vec<HashValue>,
         account_state_root_hash: HashValue,
     ) -> Self {
         Self {
-            version,
+            num_transactions,
             ledger_frozen_subtree_hashes,
             account_state_root_hash,
         }
@@ -523,10 +523,10 @@ impl TryFrom<crate::proto::storage::TreeState> for TreeState {
             .map(|x| &x[..])
             .map(HashValue::from_slice)
             .collect::<Result<Vec<_>>>()?;
-        let version = proto.version;
+        let num_transactions = proto.num_transactions;
 
         Ok(Self::new(
-            version,
+            num_transactions,
             ledger_frozen_subtree_hashes,
             account_state_root_hash,
         ))
@@ -541,10 +541,10 @@ impl From<TreeState> for crate::proto::storage::TreeState {
             .into_iter()
             .map(|x| x.to_vec())
             .collect();
-        let version = info.version;
+        let num_transactions = info.num_transactions;
 
         Self {
-            version,
+            num_transactions,
             ledger_frozen_subtree_hashes,
             account_state_root_hash,
         }

--- a/storage/storage-proto/src/proto/storage.proto
+++ b/storage/storage-proto/src/proto/storage.proto
@@ -141,8 +141,10 @@ message GetStartupInfoResponse {
 }
 
 message TreeState {
-  // The version of the tree state. All fields below are based on this version.
-  uint64 version = 1;
+  // The number of transactions in the accumulator. "0" means an empty
+  // transaction accumulator, in which case `ledger_frozen_subtree_hashes` must
+  // be empty, but pre-genesis state can exist. All fields below base on this.
+  uint64 num_transactions = 1;
   // From left to right, root hashes of all frozen subtrees.
   repeated bytes ledger_frozen_subtree_hashes = 2;
   // The latest account state root hash.


### PR DESCRIPTION

## Motivation

expose latest tree state, even when db is not bootstrapped, to be used by the db-bootstrapper

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?

(Write your answer here.)
yes
## Test Plan
unit tests added
(Share your test plan here. If you changed code, please provide us with clear instructions for verifying that your changes work.)

## Related PRs

(If this PR adds or changes functionality, please take some time to update the docs at https://github.com/libra/website, and link to your PR here.)
