### PR TITLE
[language] Clean-up ValidatorConfig and LibraSystem modules

### DIFF
--- a/language/move-lang/tests/functional/translated_ir_tests/validator_set/add_many_validators.move
+++ b/language/move-lang/tests/functional/translated_ir_tests/validator_set/add_many_validators.move
@@ -1,0 +1,251 @@
+// This code adds 6 validators, checks that 2 can be removed safely,
+// but more than 2 cannot be removed.
+// It also checks that only one change can be made per block, i.e.
+// if a transaction adds two validators - this transaction will fail,
+// if the first transaction adds a validator and the second transaction
+// adds a validator in the same block, then the first transaction will succeed
+// and the second will fail.
+// Check that removing a non-existent validator aborts.
+
+//! account: alice
+//! account: bob, 1000000, 0, validator
+//! account: carrol
+//! account: david
+//! account: eve
+//! account: fedor
+
+//! sender: alice
+use 0x0::ValidatorConfig2;
+fun main() {
+    ValidatorConfig2::initialize(x"beefbeef");
+}
+
+// check: EXECUTED
+
+//! new-transaction
+//! sender: bob
+use 0x0::ValidatorConfig2;
+fun main() {
+    ValidatorConfig2::initialize(x"beefbeef");
+}
+
+// check: EXECUTED
+
+//! new-transaction
+//! sender: carrol
+use 0x0::ValidatorConfig2;
+fun main() {
+    ValidatorConfig2::initialize(x"beefbeef");
+}
+
+// check: EXECUTED
+
+//! new-transaction
+//! sender: david
+use 0x0::ValidatorConfig2;
+fun main() {
+    ValidatorConfig2::initialize(x"beefbeef");
+}
+
+// check: EXECUTED
+
+//! new-transaction
+//! sender: eve
+use 0x0::ValidatorConfig2;
+fun main() {
+    ValidatorConfig2::initialize(x"beefbeef");
+}
+
+// check: EXECUTED
+
+//! new-transaction
+//! sender: fedor
+use 0x0::ValidatorConfig2;
+fun main() {
+    ValidatorConfig2::initialize(x"beefbeef");
+}
+
+// check: EXECUTED
+
+//! block-prologue
+//! proposer: bob
+//! block-time: 2
+
+// check: EXECUTED
+
+//! new-transaction
+//! sender: association
+use 0x0::LibraSystem2;
+// add allice to validator set
+fun main() {
+    0x0::Transaction::assert(LibraSystem2::validator_set_size() == 0, 99);
+    LibraSystem2::add_validator(&{{alice}});
+    0x0::Transaction::assert(LibraSystem2::is_validator(&{{alice}}), 100);
+    0x0::Transaction::assert(!LibraSystem2::is_validator(&{{bob}}), 99);
+}
+
+// check: EXECUTED
+
+//! block-prologue
+//! proposer: bob
+//! block-time: 3
+
+// check: EXECUTED
+
+//! new-transaction
+//! sender: association
+use 0x0::LibraSystem2;
+// add bob to validator set
+fun main() {
+    LibraSystem2::add_validator(&{{bob}});
+}
+
+// check: EXECUTED
+
+//! new-transaction
+//! sender: association
+// adding carrol to the validator set in the same block will fail
+use 0x0::LibraSystem2;
+fun main() {
+    LibraSystem2::add_validator(&{{carrol}});
+}
+
+// check: ABORTED
+
+//! block-prologue
+//! proposer: bob
+//! block-time: 4
+
+// check: EXECUTED
+
+//! new-transaction
+//! sender: association
+// test that adding two validators in the same transaction aborts the transaction
+use 0x0::LibraSystem2;
+fun main() {
+    LibraSystem2::add_validator(&{{carrol}});
+    LibraSystem2::add_validator(&{{david}});
+}
+
+// check: ABORTED
+
+//! new-transaction
+//! sender: association
+// add carrol to the validator set
+use 0x0::LibraSystem2;
+fun main() {
+    LibraSystem2::add_validator(&{{carrol}});
+}
+
+// check: EXECUTED
+
+//! block-prologue
+//! proposer: bob
+//! block-time: 5
+
+// check: EXECUTED
+
+//! new-transaction
+//! sender: association
+// add david to the validator set
+use 0x0::LibraSystem2;
+fun main() {
+    0x0::Transaction::assert(!LibraSystem2::is_validator(&{{david}}), 99);
+    LibraSystem2::add_validator(&{{david}});
+    0x0::Transaction::assert(LibraSystem2::is_validator(&{{david}}), 99);
+}
+
+// check: EXECUTED
+
+//! block-prologue
+//! proposer: bob
+//! block-time: 6
+
+// check: EXECUTED
+
+//! new-transaction
+//! sender: association
+// add eve to validator set
+use 0x0::LibraSystem2;
+fun main() {
+    LibraSystem2::add_validator(&{{eve}});
+}
+
+// check: EXECUTED
+//! block-prologue
+//! proposer: bob
+//! block-time: 7
+
+// check: EXECUTED
+
+//! new-transaction
+//! sender: association
+// add fedor to validator set
+use 0x0::LibraSystem2;
+fun main() {
+    LibraSystem2::add_validator(&{{fedor}});
+    0x0::Transaction::assert(LibraSystem2::validator_set_size() == 6, 99);
+}
+
+// check: EXECUTED
+//! block-prologue
+//! proposer: bob
+//! block-time: 8
+
+// check: EXECUTED
+
+//! new-transaction
+//! sender: association
+// remove alice
+use 0x0::LibraSystem2;
+fun main() {
+    LibraSystem2::remove_validator(&{{alice}});
+    0x0::Transaction::assert(LibraSystem2::validator_set_size() == 5, 99);
+}
+
+// check: EXECUTED
+
+//! block-prologue
+//! proposer: bob
+//! block-time: 9
+
+// check: EXECUTED
+
+//! new-transaction
+//! sender: association
+// test deleting a non-existent (or rather already removed) validator aborts
+use 0x0::LibraSystem2;
+fun main() {
+    LibraSystem2::remove_validator(&{{alice}});
+}
+
+// check: ABORTED
+
+//! new-transaction
+//! sender: association
+// remove fedor
+use 0x0::LibraSystem2;
+fun main() {
+    LibraSystem2::remove_validator(&{{fedor}});
+    0x0::Transaction::assert(LibraSystem2::validator_set_size() == 4, 99);
+}
+
+// check: EXECUTED
+
+//! block-prologue
+//! proposer: bob
+//! block-time: 10
+
+// check: EXECUTED
+
+//! new-transaction
+//! sender: association
+// make sure nobody else can be deleted
+// the safe number of validators is 4
+// this test makes sure the number of validators can not go lower
+use 0x0::LibraSystem2;
+fun main() {
+    LibraSystem2::remove_validator(&{{david}});
+}
+
+// check: ABORTED

--- a/language/move-lang/tests/functional/translated_ir_tests/validator_set/add_one_rotate_by_delegate.move
+++ b/language/move-lang/tests/functional/translated_ir_tests/validator_set/add_one_rotate_by_delegate.move
@@ -1,0 +1,102 @@
+// Make bob a validator, set alice as bob's delegate.
+// Test that alice can rotate bob's key and invoke reconfiguration.
+
+//! account: alice
+//! account: bob, 1000000, 0, validator
+
+//! sender: bob
+use 0x0::ValidatorConfig2;
+fun main() {
+    ValidatorConfig2::initialize(x"beefbeef");
+    // register alice as bob's delegate
+    ValidatorConfig2::set_delegated_account({{alice}});
+}
+
+// check: EXECUTED
+
+//! new-transaction
+//! sender: alice
+use 0x0::ValidatorConfig2;
+// test alice can rotate bob's consensus public key
+fun main() {
+    // check initial key was "beefbeef"
+    let config = ValidatorConfig2::get_config({{bob}});
+    0x0::Transaction::assert(ValidatorConfig2::get_consensus_pubkey(&config) == x"beefbeef", 99);
+
+    0x0::Transaction::assert(ValidatorConfig2::get_validator_operator_account({{bob}}) == {{alice}}, 44);
+    ValidatorConfig2::rotate_consensus_pubkey({{bob}}, x"20", x"10");
+
+    // check new key is "20"
+    config = ValidatorConfig2::get_config({{bob}});
+    0x0::Transaction::assert(ValidatorConfig2::get_consensus_pubkey(&config) == x"20", 99);
+}
+
+// check: EXECUTED
+
+//! new-transaction
+//! sender: bob
+use 0x0::ValidatorConfig2;
+// test bob can not rotate his public key because it delegated
+fun main() {
+    // check initial key was "beefbeef"
+    let config = ValidatorConfig2::get_config({{bob}});
+    0x0::Transaction::assert(ValidatorConfig2::get_consensus_pubkey(&config) == x"20", 99);
+
+    ValidatorConfig2::rotate_consensus_pubkey_of_sender(x"30", x"10");
+}
+
+// check: ABORTED
+
+//! block-prologue
+//! proposer: bob
+//! block-time: 2
+
+// check: EXECUTED
+
+//! new-transaction
+//! sender: association
+use 0x0::LibraSystem2;
+fun main() {
+    // add validator
+    LibraSystem2::add_validator(&{{bob}});
+}
+
+// check: ValidatorSetChangeEvent
+// check: EXECUTED
+
+//! block-prologue
+//! proposer: bob
+//! block-time: 86400000010
+
+// check: EXECUTED
+
+//! new-transaction
+//! sender: alice
+//! expiration-time: 864000000020
+// after >= 24hr has passed since bob was added as a validator with a current
+// consensus pubkey, he can call a force_update to the validator_set (due to
+// rate limits, 24hr = 86_400_000_000us
+// to test that the block-time is set to 24hr + 10us and the expiration time
+// of the transaction is made sufficiently large
+use 0x0::ValidatorConfig2;
+use 0x0::LibraSystem2;
+// test alice can invoke reconfiguration upon successful rotation of bob's consensus public key
+fun main() {
+    // check initial key was "20"
+    let validator_info = LibraSystem2::get_validator_info(&{{bob}});
+    let validator_config = LibraSystem2::get_validator_config(&validator_info);
+    0x0::Transaction::assert(ValidatorConfig2::get_consensus_pubkey(validator_config) == x"20", 99);
+
+    ValidatorConfig2::rotate_consensus_pubkey({{bob}}, x"30", x"10");
+
+    // call force_update to reconfigure
+    LibraSystem2::force_update_validator_info(&{{bob}});
+
+    // check bob's public key is updated
+    validator_info = LibraSystem2::get_validator_info(&{{bob}});
+    validator_config = LibraSystem2::get_validator_config(&validator_info);
+    0x0::Transaction::assert(ValidatorConfig2::get_consensus_pubkey(validator_config) == x"30", 99);
+}
+
+// check: ValidatorSetChangeEvent
+// check: EXECUTED

--- a/language/move-lang/tests/functional/translated_ir_tests/validator_set/add_one_rotate_one.move
+++ b/language/move-lang/tests/functional/translated_ir_tests/validator_set/add_one_rotate_one.move
@@ -1,0 +1,85 @@
+// Add bob as a validator.
+// Make sure bob can rotate his key locally, as
+// well as call force-update to change his
+// key in the validator set and induce reconfiguration.
+
+//! account: alice
+//! account: bob, 1000000, 0, validator
+
+//! sender: bob
+use 0x0::ValidatorConfig2;
+fun main() {
+    ValidatorConfig2::initialize(x"beefbeef");
+}
+
+// check: EXECUTED
+
+//! block-prologue
+//! proposer: bob
+//! block-time: 2
+
+// check: EXECUTED
+
+//! new-transaction
+//! sender: bob
+// rotate bob's key without reconfiguration
+use 0x0::ValidatorConfig2;
+fun main() {
+    let config = ValidatorConfig2::get_config({{bob}});
+    0x0::Transaction::assert(ValidatorConfig2::get_consensus_pubkey(&config) == x"beefbeef", 99);
+    ValidatorConfig2::rotate_consensus_pubkey_of_sender(x"20", x"10");
+    config = ValidatorConfig2::get_config({{bob}});
+    0x0::Transaction::assert(ValidatorConfig2::get_consensus_pubkey(&config) == x"20", 99);
+}
+
+// check: EXECUTED
+
+//! new-transaction
+//! sender: association
+use 0x0::LibraSystem2;
+use 0x0::ValidatorConfig2;
+fun main() {
+    // add validator
+    LibraSystem2::add_validator(&{{bob}});
+
+    // check bob's public key
+    let validator_info = LibraSystem2::get_validator_info(&{{bob}});
+    let validator_config = LibraSystem2::get_validator_config(&validator_info);
+    0x0::Transaction::assert(ValidatorConfig2::get_consensus_pubkey(validator_config) == x"20", 99);
+}
+
+// check: ValidatorSetChangeEvent
+// check: EXECUTED
+
+//! block-prologue
+//! proposer: bob
+//! block-time: 86400000005
+
+// check: EXECUTED
+
+//! new-transaction
+//! sender: bob
+//! expiration-time: 864000000000
+// rotate bob's key with reconfiguration
+use 0x0::ValidatorConfig2;
+use 0x0::LibraSystem2;
+fun main() {
+    // check bob's public key
+    let validator_info = LibraSystem2::get_validator_info(&{{bob}});
+    let validator_config = LibraSystem2::get_validator_config(&validator_info);
+    0x0::Transaction::assert(ValidatorConfig2::get_consensus_pubkey(validator_config) == x"20", 99);
+
+    // bob rotates his public key
+    ValidatorConfig2::rotate_consensus_pubkey_of_sender(x"30", x"10");
+
+    // use the update_token to trigger reconfiguration
+    LibraSystem2::force_update_validator_info(&{{bob}});
+
+    // check bob's public key
+    validator_info = LibraSystem2::get_validator_info(&{{bob}});
+    validator_config = LibraSystem2::get_validator_config(&validator_info);
+    0x0::Transaction::assert(ValidatorConfig2::get_consensus_pubkey(validator_config) == x"30", 99);
+}
+
+// check: ValidatorSetChangeEvent
+// check: EXECUTED

--- a/language/move-lang/tests/functional/translated_ir_tests/validator_set/add_two_rotate_by_delegate.move
+++ b/language/move-lang/tests/functional/translated_ir_tests/validator_set/add_two_rotate_by_delegate.move
@@ -1,0 +1,136 @@
+// Add bob and alice as validators
+// Register alice as bob's delegate,
+// test all possible key rotations:
+// bob's key by bob - aborts
+// bob's key by alice - executes
+// alice's key by bob - aborts
+// alice's key by alice - executes
+
+//! account: alice
+//! account: bob, 1000000, 0, validator
+
+//! sender: bob
+use 0x0::ValidatorConfig2;
+// initialize bob as validator
+fun main() {
+    ValidatorConfig2::initialize(x"beefbeef");
+    // set alice to change bob's key
+    ValidatorConfig2::set_delegated_account({{alice}});
+}
+
+// check: EXECUTED
+
+//! new-transaction
+//! sender: alice
+use 0x0::ValidatorConfig2;
+// initialize alice as validator
+fun main() {
+    ValidatorConfig2::initialize(x"beefbeef");
+}
+
+// check: EXECUTED
+
+//! block-prologue
+//! proposer: bob
+//! block-time: 2
+
+// check: EXECUTED
+
+//! new-transaction
+//! sender: association
+use 0x0::LibraSystem2;
+fun main() {
+    // add validator
+    LibraSystem2::add_validator(&{{bob}});
+}
+
+// check: ValidatorSetChangeEvent
+// check: EXECUTED
+
+//! block-prologue
+//! proposer: bob
+//! block-time: 3
+
+// check: EXECUTED
+
+//! new-transaction
+//! sender: association
+use 0x0::LibraSystem2;
+fun main() {
+    // add validator
+    LibraSystem2::add_validator(&{{alice}});
+}
+
+// check: ValidatorSetChangeEvent
+// check: EXECUTED
+
+//! block-prologue
+//! proposer: bob
+//! block-time: 4
+
+// check: EXECUTED
+
+//! new-transaction
+//! sender: bob
+// check bob can not rotate his consensus key
+use 0x0::ValidatorConfig2;
+fun main() {
+    ValidatorConfig2::rotate_consensus_pubkey_of_sender(x"30", x"10");
+}
+
+// check: ABORTED
+
+//! new-transaction
+//! sender: bob
+// check bob can not rotate his consensus key
+use 0x0::ValidatorConfig2;
+fun main() {
+    ValidatorConfig2::rotate_consensus_pubkey({{bob}}, x"30", x"10");
+}
+
+// check: ABORTED
+
+//! new-transaction
+//! sender: bob
+// check bob can not rotate alice's consensus key
+use 0x0::ValidatorConfig2;
+fun main() {
+    ValidatorConfig2::rotate_consensus_pubkey({{alice}}, x"30", x"10");
+}
+
+// check: ABORTED
+
+//! new-transaction
+//! sender: alice
+// check alice can rotate bob's consensus key
+use 0x0::ValidatorConfig2;
+fun main() {
+    0x0::Transaction::assert(ValidatorConfig2::get_consensus_pubkey(&ValidatorConfig2::get_config({{bob}})) == x"beefbeef", 99);
+    ValidatorConfig2::rotate_consensus_pubkey({{bob}}, x"30", x"10");
+    0x0::Transaction::assert(ValidatorConfig2::get_consensus_pubkey(&ValidatorConfig2::get_config({{bob}})) == x"30", 99);
+}
+
+// check: EXECUTED
+
+//! new-transaction
+//! sender: alice
+// check alice can rotate her consensus key
+use 0x0::ValidatorConfig2;
+fun main() {
+    0x0::Transaction::assert(ValidatorConfig2::get_consensus_pubkey(&ValidatorConfig2::get_config({{alice}})) == x"beefbeef", 99);
+    ValidatorConfig2::rotate_consensus_pubkey({{alice}}, x"20", x"10");
+    0x0::Transaction::assert(ValidatorConfig2::get_consensus_pubkey(&ValidatorConfig2::get_config({{alice}})) == x"20", 99);
+}
+
+// check: EXECUTED
+
+//! new-transaction
+//! sender: alice
+// check alice can rotate her consensus key
+use 0x0::ValidatorConfig2;
+fun main() {
+    ValidatorConfig2::rotate_consensus_pubkey_of_sender(x"30", x"10");
+    0x0::Transaction::assert(ValidatorConfig2::get_consensus_pubkey(&ValidatorConfig2::get_config({{alice}})) == x"30", 99);
+}
+
+// check: EXECUTED

--- a/language/move-lang/tests/functional/translated_ir_tests/validator_set/add_validator.move
+++ b/language/move-lang/tests/functional/translated_ir_tests/validator_set/add_validator.move
@@ -1,0 +1,35 @@
+// Add simple validator to LibraSystem's validator set.
+
+//! account: alice
+//! account: bob, 1000000, 0, validator
+
+//! sender: bob
+use 0x0::ValidatorConfig2;
+fun main() {
+    ValidatorConfig2::initialize(x"beefbeef");
+    let config = ValidatorConfig2::get_config({{bob}});
+    let consensus_pk = ValidatorConfig2::get_consensus_pubkey(&config);
+    let expected_pk = x"beefbeef";
+    0x0::Transaction::assert(&consensus_pk == &expected_pk, 98);
+}
+
+// check: EXECUTED
+
+//! block-prologue
+//! proposer: bob
+//! block-time: 2
+
+// check: EXECUTED
+
+//! new-transaction
+//! sender: association
+use 0x0::LibraSystem2;
+fun main() {
+    let validator_size = LibraSystem2::validator_set_size();
+    0x0::Transaction::assert(validator_size == 0, 99);
+    LibraSystem2::add_validator(&{{bob}});
+    validator_size = LibraSystem2::validator_set_size();
+    0x0::Transaction::assert(validator_size == 1, 99);
+}
+
+// check: EXECUTED

--- a/language/stdlib/modules/libra_block.move
+++ b/language/stdlib/modules/libra_block.move
@@ -48,14 +48,16 @@ module LibraBlock {
         previous_block_votes: vector<address>,
         proposer: address
     ) acquires BlockMetadata {
-      // Can only be invoked by LibraVM privilege.
-      Transaction::assert(Transaction::sender() == 0x0, 33);
+        // Can only be invoked by LibraVM privilege.
+        Transaction::assert(Transaction::sender() == 0x0, 33);
 
-      process_block_prologue(round, timestamp, previous_block_votes, proposer);
+        process_block_prologue(round, timestamp, previous_block_votes, proposer);
 
-      // Currently distribute once per-block.
-      // TODO: Once we have a better on-chain representation of epochs we will make this per-epoch.
-      TransactionFee::distribute_transaction_fees<LBR::T>();
+        // Currently distribute once per-block.
+        // TODO: Once we have a better on-chain representation of epochs we will make this per-epoch.
+        TransactionFee::distribute_transaction_fees<LBR::T>();
+
+        // TODO(valerini): call regular reconfiguration here LibraSystem2::update_all_validator_info()
     }
 
     // Update the BlockMetadata resource with the new blockmetada coming from the consensus.

--- a/language/stdlib/modules/libra_system.move
+++ b/language/stdlib/modules/libra_system.move
@@ -2,10 +2,11 @@ address 0x0:
 
 module LibraSystem {
     use 0x0::LibraAccount;
+    use 0x0::LibraConfig;
+    use 0x0::LibraSystem2;
+    use 0x0::Transaction;
     use 0x0::ValidatorConfig;
     use 0x0::Vector;
-    use 0x0::Transaction;
-    use 0x0::LibraConfig;
 
     struct ValidatorInfo {
         addr: address,
@@ -51,6 +52,7 @@ module LibraSystem {
             scheme: 0,
             validators: Vector::empty(),
         });
+        LibraSystem2::initialize_validator_set();
     }
 
     // This returns a copy of the current validator set.

--- a/language/stdlib/modules/libra_system_2.move
+++ b/language/stdlib/modules/libra_system_2.move
@@ -1,0 +1,257 @@
+address 0x0:
+
+// These modules only change resources stored under the three addresses:
+// LibraAssociation's account address: 0xA550C18
+// ValidatorSet resource address: 0x1D8
+// DiscoverySet resource address: 0xD15C0
+// ValidatorSet and DiscoverySet are stored under different addresses in order to facilitate
+// cheaper reads of these sets from storage.
+module LibraSystem2 {
+    use 0x0::LibraAccount;
+    use 0x0::LibraTimestamp;
+    use 0x0::Transaction;
+    use 0x0::ValidatorConfig2;
+    use 0x0::Vector;
+
+    struct ValidatorInfo {
+        addr: address,
+        consensus_voting_power: u64,
+        config: ValidatorConfig2::Config,
+        // To protect against DDoS, the force updates are allowed only if the time passed
+        // since the last force update is larger than a threshold (24hr).
+        last_force_update_time: u64,
+    }
+
+    struct ValidatorSetChangeEvent {
+        new_validator_set: vector<ValidatorInfo>,
+    }
+
+    resource struct ValidatorSet {
+        validators: vector<ValidatorInfo>,
+        last_reconfiguration_time: u64,
+        change_events: LibraAccount::EventHandle<ValidatorSetChangeEvent>,
+    }
+
+    // ValidatorInfo public accessors
+
+    // Get validator's address from ValidatorInfo
+    public fun get_validator_address(v: &ValidatorInfo): &address {
+        &v.addr
+    }
+
+    // Get validator's config from ValidatorInfo
+    public fun get_validator_config(v: &ValidatorInfo): &ValidatorConfig2::Config {
+        &v.config
+    }
+
+    // Get validator's voting power from ValidatorInfo
+    public fun get_validator_voting_power(v: &ValidatorInfo): &u64 {
+        &v.consensus_voting_power
+    }
+
+    // Get last forced update time
+    public fun get_last_force_update_time(v: &ValidatorInfo): &u64 {
+        &v.last_force_update_time
+    }
+
+    // This can only be invoked by the ValidatorSet address to instantiate the resource under that address.
+    // It can only be called a single time. Currently, it is invoked in the genesis transaction.
+    public fun initialize_validator_set() {
+        Transaction::assert(Transaction::sender() == 0x1D8, 1);
+        move_to_sender<ValidatorSet>(ValidatorSet {
+            validators: Vector::empty(),
+            last_reconfiguration_time: 0,
+            change_events: LibraAccount::new_event_handle<ValidatorSetChangeEvent>(),
+        });
+    }
+
+    // Adds a new validator, only callable by the LibraAssociation address
+    // TODO(valerini): allow the Association to add multiple validators in a single block
+    public fun add_validator(account_address: &address) acquires ValidatorSet {
+        Transaction::assert(Transaction::sender() == 0xA550C18, 1);
+        // A prospective validator must have a validator config resource
+        Transaction::assert(ValidatorConfig2::has(*account_address), 17);
+
+        let validator_set_ref = borrow_global_mut<ValidatorSet>(0x1D8);
+        // Ensure that this address is not already a validator
+        Transaction::assert(!is_validator_(account_address, &validator_set_ref.validators), 18);
+
+        let config = ValidatorConfig2::get_config(*account_address);
+        let current_block_time = LibraTimestamp::now_microseconds();
+        Vector::push_back(&mut validator_set_ref.validators, ValidatorInfo {
+            addr: *account_address,
+            config: config, // copy the config over to ValidatorSet
+            consensus_voting_power: 1,
+            last_force_update_time: current_block_time,
+        });
+
+        emit_reconfiguration_event();
+    }
+
+    // Removes a validator, only callable by the LibraAssociation address
+    public fun remove_validator(account_address: &address) acquires ValidatorSet {
+        Transaction::assert(Transaction::sender() == 0xA550C18, 1);
+        let validator_set_ref = borrow_global_mut<ValidatorSet>(0x1D8);
+        let size = Vector::length(&validator_set_ref.validators);
+        // Make sure the size of validator set does not go beyond 4, which is the minimum safe number of validators
+        Transaction::assert(size > 4, 22);
+
+        // Ensure that this address is an active validator
+        let to_remove_index_vec = get_validator_index_(&validator_set_ref.validators, account_address);
+        Transaction::assert(!Vector::is_empty(&to_remove_index_vec), 21);
+        // Remove corresponding ValidatorInfo from the validator set
+        _  = Vector::swap_remove(&mut validator_set_ref.validators, *Vector::borrow(&to_remove_index_vec, 0));
+
+        emit_reconfiguration_event();
+    }
+
+    // Copies validator's config to ValidatorSet
+    // Callable by the LibraAssociation address only.
+    // Aborts if there are no changes to the config.
+    public fun update_validator_info(addr: &address) acquires ValidatorSet {
+        Transaction::assert(Transaction::sender() == 0xA550C18, 1);
+        let validator_set_ref = borrow_global_mut<ValidatorSet>(0x1D8);
+
+        let validator_index_vec = get_validator_index_(&validator_set_ref.validators, addr);
+        Transaction::assert(!Vector::is_empty(&validator_index_vec), 19);
+        Transaction::assert(update_ith_validator_info_(&mut validator_set_ref.validators, *Vector::borrow(&validator_index_vec, 0)), 42);
+        emit_reconfiguration_event();
+    }
+
+    // This function can be called by the validator's operator,
+    // which is either the validator itself or the validator's delegate account.
+    // Aborts if there are no changes to the config.
+    public fun force_update_validator_info(validator_address: &address) acquires ValidatorSet {
+        // Check the sender
+        Transaction::assert(ValidatorConfig2::get_validator_operator_account(*validator_address) == Transaction::sender(), 1);
+
+        let validator_vec_ref = borrow_global_mut<ValidatorSet>(0x1D8);
+        let validator_index_vec = get_validator_index_(&validator_vec_ref.validators, validator_address);
+        Transaction::assert(!Vector::is_empty(&validator_index_vec), 19);
+        let validator_index = *Vector::borrow(&validator_index_vec, 0);
+
+        // Update force update timer to enforce rate-limits
+        let validator_info_ref = Vector::borrow(&mut validator_vec_ref.validators, validator_index);
+
+        // If less than 24hr has passed since the last forced update, abort.
+        // Note that validators can always ask LibraAssocition offchain to invoke update.
+        let current_block_time = LibraTimestamp::now_microseconds();
+        Transaction::assert(current_block_time - validator_info_ref.last_force_update_time >= 86400000000, 11);
+
+        // Copy validator config from validator's account and assert that there are changes to the config
+        Transaction::assert(update_ith_validator_info_(&mut validator_vec_ref.validators, validator_index), 42);
+        let validator_info = Vector::borrow_mut(&mut validator_vec_ref.validators, validator_index);
+        *&mut validator_info.last_force_update_time = current_block_time;
+        emit_reconfiguration_event();
+    }
+
+    // This function can be invoked by the LibraAssociation or by the 0x0 LibraVM address in
+    // block_prologue to facilitate reconfigurations at regular intervals.
+    // Here for all of the validators the information from ValidatorConfig2 will get copied into the ValidatorSet,
+    // if any components of the configs have changed, appropriate events will be fired.
+    public fun update_all_validator_info() acquires ValidatorSet {
+        Transaction::assert(Transaction::sender() == 0xA550C18 || Transaction::sender() == 0x0, 1);
+        let validators = &mut borrow_global_mut<ValidatorSet>(0x1D8).validators;
+
+        let size = Vector::length(validators);
+        if (size == 0) {
+            return
+        };
+
+        let i = 0;
+        let configs_changed = false;
+        configs_changed = configs_changed || update_ith_validator_info_(validators, i);
+        loop {
+            i = i + 1;
+            if (i >= size) { break };
+            configs_changed = configs_changed || update_ith_validator_info_(validators, i);
+        };
+        Transaction::assert(configs_changed, 42);
+        emit_reconfiguration_event();
+    }
+
+    // Public getters
+
+    // Return true if addr is a current validator
+    public fun is_validator(addr: &address): bool acquires ValidatorSet { is_validator_(addr, &borrow_global<ValidatorSet>(0x1D8).validators) }
+
+    // Returns validator info
+    // If the address is not a validator, abort
+    public fun get_validator_info(addr: &address): ValidatorInfo acquires ValidatorSet {
+        let validator_set_ref = borrow_global<ValidatorSet>(0x1D8);
+        let validator_index_vec = get_validator_index_(&validator_set_ref.validators, addr);
+        Transaction::assert(!Vector::is_empty(&validator_index_vec), 19);
+
+        *Vector::borrow(&validator_set_ref.validators, *Vector::borrow(&validator_index_vec, 0))
+    }
+
+    // Return the size of the current validator set
+    public fun validator_set_size(): u64 acquires ValidatorSet {
+        Vector::length(&borrow_global<ValidatorSet>(0x1D8).validators)
+    }
+
+    // Private helper functions
+
+    // Emit a reconfiguration event. This function will be invoked by the genesis to generate the very first
+    // reconfiguration event.
+    fun emit_reconfiguration_event() acquires ValidatorSet {
+        let validator_set_ref = borrow_global_mut<ValidatorSet>(0x1D8);
+
+        // Ensure only one reconfiguration event is emitted per block
+        let current_block_time = LibraTimestamp::now_microseconds();
+
+        // Abort the transaction if reconfiguration was already called within the same block
+        Transaction::assert(current_block_time > validator_set_ref.last_reconfiguration_time, 14);
+
+        validator_set_ref.last_reconfiguration_time = current_block_time;
+        LibraAccount::emit_event<ValidatorSetChangeEvent>(
+            &mut validator_set_ref.change_events,
+            ValidatorSetChangeEvent {
+                new_validator_set: *&validator_set_ref.validators,
+            });
+    }
+
+    // Get the index of the validator by address in the `validators` vector
+    fun get_validator_index_(validators: &vector<ValidatorInfo>, addr: &address): vector<u64> {
+        let size = Vector::length(validators);
+        let result: vector<u64> = Vector::empty();
+        if (size == 0) {
+            return result
+        };
+
+        let i = 0;
+        let validator_info_ref = Vector::borrow(validators, i);
+        loop {
+            if (&validator_info_ref.addr == addr) {
+                Vector::push_back(&mut result, i);
+                return result
+            };
+            i = i + 1;
+            if (i >= size) { break };
+            validator_info_ref = Vector::borrow(validators, i);
+        };
+
+        result
+    }
+
+    // Updates ith validator info, if nothing changed, return false
+    fun update_ith_validator_info_(validators: &mut vector<ValidatorInfo>, i: u64): bool {
+        let size = Vector::length(validators);
+        if (i >= size) {
+            return false
+        };
+        let validator_info = Vector::borrow(validators, i);
+        let new_validator_config = ValidatorConfig2::get_config(validator_info.addr);
+        // check if information is the same
+        let config_ref = &mut Vector::borrow_mut(validators, i).config;
+        if (config_ref == &new_validator_config) {
+            return false
+        };
+        *config_ref = *&new_validator_config;
+        true
+    }
+
+    fun is_validator_(addr: &address, validators_vec_ref: &vector<ValidatorInfo>): bool {
+        !Vector::is_empty(&get_validator_index_(validators_vec_ref, addr))
+    }
+}

--- a/language/stdlib/modules/validator_config_2.move
+++ b/language/stdlib/modules/validator_config_2.move
@@ -1,0 +1,105 @@
+address 0x0:
+
+module ValidatorConfig2 {
+    use 0x0::LibraAccount;
+    use 0x0::Transaction;
+
+    struct Config {
+        consensus_pubkey: vector<u8>,
+    }
+
+    // A current or prospective validator should publish one of these under their accounts.
+    // If delegation is enabled, only the delegated_account can change the config.
+    // If delegation is disabled, only the owner of this resource can change the config.
+    // The entity that can change the config is called a "validator operator".
+    // The owner of this resource can enable delegation and set delegated account.
+    // The owner can also disable delegation at any time.
+    resource struct T {
+        config: Config,
+        delegation_enabled: bool,
+        delegated_account: address,
+    }
+
+    // TODO(valerini): add events here
+
+    // Returns true if addr has a published ValidatorConfig::T resource
+    public fun has(addr: address): bool {
+        exists<T>(addr)
+    }
+
+    // Get Config
+    public fun get_config(addr: address): Config acquires T {
+        *&borrow_global<T>(addr).config
+    }
+
+    // Get consensus_pubkey from Config
+    public fun get_consensus_pubkey(config_ref: &Config): vector<u8> {
+        *&config_ref.consensus_pubkey
+    }
+
+    // Returns the address of the entity who is now in charge of managing the config.
+    public fun get_validator_operator_account(addr: address): address acquires T {
+        let t_ref = borrow_global<T>(addr);
+        if (t_ref.delegation_enabled) {
+            return *&t_ref.delegated_account
+        } else {
+            return addr
+        }
+    }
+
+    // Register the transaction sender as a candidate validator by creating a ValidatorConfig
+    // resource under their account. Note that only one such resource can be instantiated under an account.
+    public fun initialize(
+        consensus_pubkey: vector<u8>,) {
+
+        move_to_sender<T>(
+            T {
+                config: Config {
+                    consensus_pubkey: consensus_pubkey,
+                },
+                delegation_enabled: false,
+                delegated_account: 0x0
+            }
+        );
+    }
+
+    // If the sender of the transaction has a ValidatorConfig::T resource,
+    // this function will delegate management of the ValidatorConfig::T resource to a delegated_account.
+    public fun set_delegated_account(delegated_account: address) acquires T {
+        Transaction::assert(LibraAccount::exists(delegated_account), 5);
+        // check delegated address is different from transaction's sender
+        Transaction::assert(delegated_account != Transaction::sender(), 6);
+        let t_ref = borrow_global_mut<T>(Transaction::sender());
+        *(&mut t_ref.delegation_enabled) = true;
+        *(&mut t_ref.delegated_account) = delegated_account;
+    }
+
+    // If the sender of the transaction has a ValidatorConfig::T resource,
+    // this function will revoke management capabilities from the delegated_account account.
+    public fun remove_delegated_account() acquires T {
+        let t_ref = borrow_global_mut<T>(Transaction::sender());
+        *(&mut t_ref.delegation_enabled) = false;
+        *(&mut t_ref.delegated_account) = 0x0;
+    }
+
+    // Rotate validator's config.
+    // Here validator_account - is the account of the validator whose consensus_pubkey is going to be rotated.
+    public fun rotate_consensus_pubkey(validator_account: address, new_consensus_pubkey: vector<u8>, proof: vector<u8>) acquires T {
+        let addr = get_validator_operator_account(validator_account);
+        Transaction::assert(Transaction::sender() == addr, 1);
+
+        // TODO(valerini): verify the proof of posession of new_consensus_secretkey
+
+        let t_ref = borrow_global_mut<T>(validator_account);
+        // Assert that the new key is different from the old key
+        Transaction::assert(&t_ref.config.consensus_pubkey != &new_consensus_pubkey, 15);
+        // Set the new key
+        let key_ref = &mut t_ref.config.consensus_pubkey;
+        *key_ref = new_consensus_pubkey;
+    }
+
+    // Simplified arguments when the sender is the validators itself
+    public fun rotate_consensus_pubkey_of_sender(new_consensus_pubkey: vector<u8>, proof: vector<u8>) acquires T {
+        rotate_consensus_pubkey(Transaction::sender(), new_consensus_pubkey, proof);
+    }
+}


### PR DESCRIPTION
This PR updates `ValidatorConfig` and `LibraSystem` modules. To gradually roll out this change, the PR introduces the modules `ValidatorConfig2` and `LibraSystem2` alongside their older versions. For this first PR, the new modules only deal with consensus public key. The follow-up PR will expand same logic to the full config comprised of consensus public key as well as network information.

### ValidatorConfig
`ValidatorConfig2` now allows to set the `delegated_address`, such that the owner of the `delegated_address` can rotate validator's consensus public key. Therefore `ValidatorConfig2` has two ways to rotate consensus public key: by itself, if delegated_address **is not set** and by delegate, if delegated_address **is set**.
If the key was updated a function on LibraSystem2 module can be called to trigger the update of the validator set and the reconfiguration event to be emitted: `LibraSystem2::force_update_validator_info`.
The force update has rate-limits: no validator can run it more frequently than once in 24hr. Force update should only be called to recover from a suspected compromise, it should not be invoked after regular scheduled key rotations.

### LibraSystem
The Association can invoke `LibraSystem2::update_all_validator_info` to copy configs of all validators from their accounts into the ValidatorSet resource. If any part of the config for at least one validator has changed, the reconfiguration event will be emitted. In the future this function will get called regularly in block_prologue. The Association may also update config for a particular validator with `LibraSystem2::update_validator_info`, if it changed, the reconfiguration event will be emitted. These functions have no rate-limits.

As before: only one reconfiguration is allowed per block, so at the moment if the Libra Association needs to add multiple validators at once, it needs to do so in different blocks.

Validator's removal (`LibraSystem2::remove_validator`) can only be called when the current number of validators more than 4 as a safe-guard (lower number of validators may crash the system).

## Motivation

Motivation for this change is to improve overall key management as discussed here:
[Issue3161](https://github.com/libra/libra/issues/3161)
[Issue2332](https://github.com/libra/libra/issues/2332)

### Future work and TODOs
1) Regular reconfiguration (`LibraSystem2::update_all_validator_info`) should be invoked on a regular basis (once every X blocks, where X is to be determined) in `LibraBlock::block_prologue`.
2) Allow the Association add/remove multiple validators in a single block and make a call to reconfiguration explicit (it is implicit now in the update_*_config functions).
3) Add events to ValidatorConfig2 to be emitted on key rotations.
4) Verify the proof of possession of the corresponding secret key on every call to rotate_consensus_pubkey function. The most viable option for the proof seems to be the following. The proof of knowledge of Ed25519's secret key `sk` that corresponds to the public key `pk` is a signature generated with `sk` over the hash (with a proper domain-separation tag) of `pk`: `GenerateProof(sk, pk): outputs proof = Ed25519-Sign(sk, HKDF-SHA3("domain_separation_tag", pk))`, `VerifyProof(proof, pk): outputs 1 iff Ed25519-Verify(pk, HKDF-SHA3("domain_separation_tag", pk)) == 1`. Similar approach is taken in the [RFC of BLS signatures](https://tools.ietf.org/html/draft-irtf-cfrg-bls-signature-02#section-3.3) where the proof of possession is required for secure non-interactive aggregation of BLS signatures.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

From language/move-lang run
> cargo test functional_testsuite::translated_ir_tests/validator_set

