### PR TITLE
[move-prover] Prevent aliasing of top-level reference parameters.

### DIFF
--- a/language/move-prover/src/boogie_helpers.rs
+++ b/language/move-prover/src/boogie_helpers.rs
@@ -179,10 +179,6 @@ pub fn boogie_well_formed_expr(
                 rtype,
                 mode,
             ));
-            conds.push(format!(
-                "$IsValidReferenceParameter($m, $local_counter, {})",
-                name
-            ));
         }
         // TODO: tuple and functions?
         Type::Fun(_args, _result) => {}

--- a/language/move-prover/tests/sources/marketcap.exp
+++ b/language/move-prover/tests/sources/marketcap.exp
@@ -1,0 +1,16 @@
+Move prover returns: exiting with boogie verification errors
+error:  A postcondition might not hold on this return path.
+
+    ┌── tests/sources/marketcap.move:11:9 ───
+    │
+ 11 │         invariant global<MarketCap>(0xA550C18).total_value == sum_of_coins;
+    │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    │
+    =     at tests/sources/marketcap.move:44:6: deposit_invalid (entry)
+    =     at tests/sources/marketcap.move:45:18: deposit_invalid
+    =         coin_ref = <redacted>,
+    =         check = <redacted>,
+    =         value = <redacted>
+    =     at tests/sources/marketcap.move:46:27: deposit_invalid
+    =         coin_ref = <redacted>
+    =     at tests/sources/marketcap.move:44:6: deposit_invalid (exit)

--- a/language/move-prover/tests/sources/marketcap.move
+++ b/language/move-prover/tests/sources/marketcap.move
@@ -1,0 +1,52 @@
+// A minimized version of the MarketCap verification problem.
+address 0x0:
+
+module TestMarketCap {
+
+    spec module {
+        // SPEC: sum of values of all coins.
+        global sum_of_coins: num;
+
+        // GLOBAL SPEC: MarketCap has correct value
+        invariant global<MarketCap>(0xA550C18).total_value == sum_of_coins;
+    }
+
+    // A resource representing the Libra coin
+    resource struct T {
+        // The value of the coin. May be zero
+        value: u64,
+    }
+    spec struct T {
+        // maintain true sum_of_coins
+        invariant pack sum_of_coins = sum_of_coins + value;
+        invariant unpack sum_of_coins = sum_of_coins - value;
+        invariant update sum_of_coins = sum_of_coins - old(value) + value;
+    }
+
+    resource struct MarketCap {
+        // The sum of the values of all LibraCoin::T resources in the system
+        total_value: u128,
+    }
+
+    // Deposit a check.
+    // The coin passed in by reference will have a value equal to the sum of the two coins
+    // The `check` coin is consumed in the process
+    public fun deposit(coin_ref: &mut T, check: T) {
+        let T { value } = check;
+        coin_ref.value = coin_ref.value + value;
+    }
+    spec fun deposit {
+        aborts_if coin_ref.value + check.value > max_u64();
+        ensures coin_ref.value == old(coin_ref.value) + check.value;
+    }
+
+     // Deposit a check which violates the MarketCap module invariant.
+     public fun deposit_invalid(coin_ref: &mut T, check: T) {
+         let T { value } = check;
+         coin_ref.value = coin_ref.value + value / 2;
+     }
+     spec fun deposit_invalid {
+         aborts_if coin_ref.value + check.value / 2 > max_u64();
+         ensures coin_ref.value == old(coin_ref.value) + check.value / 2;
+     }
+}

--- a/language/move-prover/tests/sources/stdlib/modules/approved_payment.exp
+++ b/language/move-prover/tests/sources/stdlib/modules/approved_payment.exp
@@ -1,136 +1,136 @@
 Move prover returns: exiting with boogie verification errors
 bug:  This assertion might not hold.
 
-      ┌── approved_payment.bpl:1116:6 ───
+      ┌── approved_payment.bpl:1079:6 ───
       │
- 1116 │     assert false; // $LibraAccount_write_to_event_store not implemented
+ 1079 │     assert false; // $LibraAccount_write_to_event_store not implemented
       │      ^
       │
 
 bug:  This assertion might not hold.
 
-      ┌── approved_payment.bpl:1116:6 ───
+      ┌── approved_payment.bpl:1079:6 ───
       │
- 1116 │     assert false; // $LibraAccount_write_to_event_store not implemented
+ 1079 │     assert false; // $LibraAccount_write_to_event_store not implemented
       │      ^
       │
 
 bug:  This assertion might not hold.
 
-      ┌── approved_payment.bpl:1138:6 ───
+      ┌── approved_payment.bpl:1101:6 ───
       │
- 1138 │     assert false; // $LCS_to_bytes not implemented
+ 1101 │     assert false; // $LCS_to_bytes not implemented
       │      ^
       │
 
 bug:  This assertion might not hold.
 
-      ┌── approved_payment.bpl:1138:6 ───
+      ┌── approved_payment.bpl:1101:6 ───
       │
- 1138 │     assert false; // $LCS_to_bytes not implemented
+ 1101 │     assert false; // $LCS_to_bytes not implemented
       │      ^
       │
 
 bug:  This assertion might not hold.
 
-      ┌── approved_payment.bpl:1116:6 ───
+      ┌── approved_payment.bpl:1079:6 ───
       │
- 1116 │     assert false; // $LibraAccount_write_to_event_store not implemented
+ 1079 │     assert false; // $LibraAccount_write_to_event_store not implemented
       │      ^
       │
 
 bug:  This assertion might not hold.
 
-      ┌── approved_payment.bpl:1116:6 ───
+      ┌── approved_payment.bpl:1079:6 ───
       │
- 1116 │     assert false; // $LibraAccount_write_to_event_store not implemented
+ 1079 │     assert false; // $LibraAccount_write_to_event_store not implemented
       │      ^
       │
 
 bug:  This assertion might not hold.
 
-      ┌── approved_payment.bpl:1116:6 ───
+      ┌── approved_payment.bpl:1079:6 ───
       │
- 1116 │     assert false; // $LibraAccount_write_to_event_store not implemented
+ 1079 │     assert false; // $LibraAccount_write_to_event_store not implemented
       │      ^
       │
 
 bug:  This assertion might not hold.
 
-      ┌── approved_payment.bpl:1116:6 ───
+      ┌── approved_payment.bpl:1079:6 ───
       │
- 1116 │     assert false; // $LibraAccount_write_to_event_store not implemented
+ 1079 │     assert false; // $LibraAccount_write_to_event_store not implemented
       │      ^
       │
 
 bug:  This assertion might not hold.
 
-      ┌── approved_payment.bpl:1138:6 ───
+      ┌── approved_payment.bpl:1101:6 ───
       │
- 1138 │     assert false; // $LCS_to_bytes not implemented
+ 1101 │     assert false; // $LCS_to_bytes not implemented
       │      ^
       │
 
 bug:  This assertion might not hold.
 
-      ┌── approved_payment.bpl:1116:6 ───
+      ┌── approved_payment.bpl:1079:6 ───
       │
- 1116 │     assert false; // $LibraAccount_write_to_event_store not implemented
+ 1079 │     assert false; // $LibraAccount_write_to_event_store not implemented
       │      ^
       │
 
 bug:  This assertion might not hold.
 
-      ┌── approved_payment.bpl:1138:6 ───
+      ┌── approved_payment.bpl:1101:6 ───
       │
- 1138 │     assert false; // $LCS_to_bytes not implemented
+ 1101 │     assert false; // $LCS_to_bytes not implemented
       │      ^
       │
 
 bug:  This assertion might not hold.
 
-      ┌── approved_payment.bpl:1138:6 ───
+      ┌── approved_payment.bpl:1101:6 ───
       │
- 1138 │     assert false; // $LCS_to_bytes not implemented
+ 1101 │     assert false; // $LCS_to_bytes not implemented
       │      ^
       │
 
 bug:  This assertion might not hold.
 
-      ┌── approved_payment.bpl:1116:6 ───
+      ┌── approved_payment.bpl:1079:6 ───
       │
- 1116 │     assert false; // $LibraAccount_write_to_event_store not implemented
+ 1079 │     assert false; // $LibraAccount_write_to_event_store not implemented
       │      ^
       │
 
 bug:  This assertion might not hold.
 
-      ┌── approved_payment.bpl:1116:6 ───
+      ┌── approved_payment.bpl:1079:6 ───
       │
- 1116 │     assert false; // $LibraAccount_write_to_event_store not implemented
+ 1079 │     assert false; // $LibraAccount_write_to_event_store not implemented
       │      ^
       │
 
 bug:  This assertion might not hold.
 
-      ┌── approved_payment.bpl:1116:6 ───
+      ┌── approved_payment.bpl:1079:6 ───
       │
- 1116 │     assert false; // $LibraAccount_write_to_event_store not implemented
+ 1079 │     assert false; // $LibraAccount_write_to_event_store not implemented
       │      ^
       │
 
 bug:  This assertion might not hold.
 
-      ┌── approved_payment.bpl:1125:6 ───
+      ┌── approved_payment.bpl:1088:6 ───
       │
- 1125 │     assert false; // $Signature_ed25519_verify not implemented
+ 1088 │     assert false; // $Signature_ed25519_verify not implemented
       │      ^
       │
 
 bug:  This assertion might not hold.
 
-      ┌── approved_payment.bpl:1125:6 ───
+      ┌── approved_payment.bpl:1088:6 ───
       │
- 1125 │     assert false; // $Signature_ed25519_verify not implemented
+ 1088 │     assert false; // $Signature_ed25519_verify not implemented
       │      ^
       │

--- a/language/move-prover/tests/sources/stdlib/modules/libra_account.exp
+++ b/language/move-prover/tests/sources/stdlib/modules/libra_account.exp
@@ -1,128 +1,128 @@
 Move prover returns: exiting with boogie verification errors
 bug:  This assertion might not hold.
 
-      ┌── libra_account.bpl:1116:6 ───
+      ┌── libra_account.bpl:1079:6 ───
       │
- 1116 │     assert false; // $LibraAccount_write_to_event_store not implemented
+ 1079 │     assert false; // $LibraAccount_write_to_event_store not implemented
       │      ^
       │
 
 bug:  This assertion might not hold.
 
-      ┌── libra_account.bpl:1116:6 ───
+      ┌── libra_account.bpl:1079:6 ───
       │
- 1116 │     assert false; // $LibraAccount_write_to_event_store not implemented
+ 1079 │     assert false; // $LibraAccount_write_to_event_store not implemented
       │      ^
       │
 
 bug:  This assertion might not hold.
 
-      ┌── libra_account.bpl:1138:6 ───
+      ┌── libra_account.bpl:1101:6 ───
       │
- 1138 │     assert false; // $LCS_to_bytes not implemented
+ 1101 │     assert false; // $LCS_to_bytes not implemented
       │      ^
       │
 
 bug:  This assertion might not hold.
 
-      ┌── libra_account.bpl:1138:6 ───
+      ┌── libra_account.bpl:1101:6 ───
       │
- 1138 │     assert false; // $LCS_to_bytes not implemented
+ 1101 │     assert false; // $LCS_to_bytes not implemented
       │      ^
       │
 
 bug:  This assertion might not hold.
 
-      ┌── libra_account.bpl:1116:6 ───
+      ┌── libra_account.bpl:1079:6 ───
       │
- 1116 │     assert false; // $LibraAccount_write_to_event_store not implemented
+ 1079 │     assert false; // $LibraAccount_write_to_event_store not implemented
       │      ^
       │
 
 bug:  This assertion might not hold.
 
-      ┌── libra_account.bpl:1116:6 ───
+      ┌── libra_account.bpl:1079:6 ───
       │
- 1116 │     assert false; // $LibraAccount_write_to_event_store not implemented
+ 1079 │     assert false; // $LibraAccount_write_to_event_store not implemented
       │      ^
       │
 
 bug:  This assertion might not hold.
 
-      ┌── libra_account.bpl:1116:6 ───
+      ┌── libra_account.bpl:1079:6 ───
       │
- 1116 │     assert false; // $LibraAccount_write_to_event_store not implemented
+ 1079 │     assert false; // $LibraAccount_write_to_event_store not implemented
       │      ^
       │
 
 bug:  This assertion might not hold.
 
-      ┌── libra_account.bpl:1116:6 ───
+      ┌── libra_account.bpl:1079:6 ───
       │
- 1116 │     assert false; // $LibraAccount_write_to_event_store not implemented
+ 1079 │     assert false; // $LibraAccount_write_to_event_store not implemented
       │      ^
       │
 
 bug:  This assertion might not hold.
 
-      ┌── libra_account.bpl:1138:6 ───
+      ┌── libra_account.bpl:1101:6 ───
       │
- 1138 │     assert false; // $LCS_to_bytes not implemented
+ 1101 │     assert false; // $LCS_to_bytes not implemented
       │      ^
       │
 
 bug:  This assertion might not hold.
 
-      ┌── libra_account.bpl:1116:6 ───
+      ┌── libra_account.bpl:1079:6 ───
       │
- 1116 │     assert false; // $LibraAccount_write_to_event_store not implemented
+ 1079 │     assert false; // $LibraAccount_write_to_event_store not implemented
       │      ^
       │
 
 bug:  This assertion might not hold.
 
-      ┌── libra_account.bpl:1138:6 ───
+      ┌── libra_account.bpl:1101:6 ───
       │
- 1138 │     assert false; // $LCS_to_bytes not implemented
+ 1101 │     assert false; // $LCS_to_bytes not implemented
       │      ^
       │
 
 bug:  This assertion might not hold.
 
-      ┌── libra_account.bpl:1138:6 ───
+      ┌── libra_account.bpl:1101:6 ───
       │
- 1138 │     assert false; // $LCS_to_bytes not implemented
+ 1101 │     assert false; // $LCS_to_bytes not implemented
       │      ^
       │
 
 bug:  This assertion might not hold.
 
-      ┌── libra_account.bpl:1116:6 ───
+      ┌── libra_account.bpl:1079:6 ───
       │
- 1116 │     assert false; // $LibraAccount_write_to_event_store not implemented
+ 1079 │     assert false; // $LibraAccount_write_to_event_store not implemented
       │      ^
       │
 
 bug:  This assertion might not hold.
 
-      ┌── libra_account.bpl:1116:6 ───
+      ┌── libra_account.bpl:1079:6 ───
       │
- 1116 │     assert false; // $LibraAccount_write_to_event_store not implemented
+ 1079 │     assert false; // $LibraAccount_write_to_event_store not implemented
       │      ^
       │
 
 bug:  This assertion might not hold.
 
-      ┌── libra_account.bpl:1116:6 ───
+      ┌── libra_account.bpl:1079:6 ───
       │
- 1116 │     assert false; // $LibraAccount_write_to_event_store not implemented
+ 1079 │     assert false; // $LibraAccount_write_to_event_store not implemented
       │      ^
       │
 
 bug:  This assertion might not hold.
 
-      ┌── libra_account.bpl:1138:6 ───
+      ┌── libra_account.bpl:1101:6 ───
       │
- 1138 │     assert false; // $LCS_to_bytes not implemented
+ 1101 │     assert false; // $LCS_to_bytes not implemented
       │      ^
       │

--- a/language/move-prover/tests/sources/stdlib/modules/libra_block.exp
+++ b/language/move-prover/tests/sources/stdlib/modules/libra_block.exp
@@ -1,153 +1,153 @@
 Move prover returns: exiting with boogie verification errors
 bug:  This assertion might not hold.
 
-      ┌── libra_block.bpl:1116:6 ───
+      ┌── libra_block.bpl:1079:6 ───
       │
- 1116 │     assert false; // $LibraAccount_write_to_event_store not implemented
+ 1079 │     assert false; // $LibraAccount_write_to_event_store not implemented
       │      ^
       │
 
 bug:  This assertion might not hold.
 
-      ┌── libra_block.bpl:1116:6 ───
+      ┌── libra_block.bpl:1079:6 ───
       │
- 1116 │     assert false; // $LibraAccount_write_to_event_store not implemented
+ 1079 │     assert false; // $LibraAccount_write_to_event_store not implemented
       │      ^
       │
 
 bug:  This assertion might not hold.
 
-      ┌── libra_block.bpl:1138:6 ───
+      ┌── libra_block.bpl:1101:6 ───
       │
- 1138 │     assert false; // $LCS_to_bytes not implemented
+ 1101 │     assert false; // $LCS_to_bytes not implemented
       │      ^
       │
 
 bug:  This assertion might not hold.
 
-      ┌── libra_block.bpl:1138:6 ───
+      ┌── libra_block.bpl:1101:6 ───
       │
- 1138 │     assert false; // $LCS_to_bytes not implemented
+ 1101 │     assert false; // $LCS_to_bytes not implemented
       │      ^
       │
 
 bug:  This assertion might not hold.
 
-      ┌── libra_block.bpl:1116:6 ───
+      ┌── libra_block.bpl:1079:6 ───
       │
- 1116 │     assert false; // $LibraAccount_write_to_event_store not implemented
+ 1079 │     assert false; // $LibraAccount_write_to_event_store not implemented
       │      ^
       │
 
 bug:  This assertion might not hold.
 
-      ┌── libra_block.bpl:1116:6 ───
+      ┌── libra_block.bpl:1079:6 ───
       │
- 1116 │     assert false; // $LibraAccount_write_to_event_store not implemented
+ 1079 │     assert false; // $LibraAccount_write_to_event_store not implemented
       │      ^
       │
 
 bug:  This assertion might not hold.
 
-      ┌── libra_block.bpl:1116:6 ───
+      ┌── libra_block.bpl:1079:6 ───
       │
- 1116 │     assert false; // $LibraAccount_write_to_event_store not implemented
+ 1079 │     assert false; // $LibraAccount_write_to_event_store not implemented
       │      ^
       │
 
 bug:  This assertion might not hold.
 
-      ┌── libra_block.bpl:1116:6 ───
+      ┌── libra_block.bpl:1079:6 ───
       │
- 1116 │     assert false; // $LibraAccount_write_to_event_store not implemented
+ 1079 │     assert false; // $LibraAccount_write_to_event_store not implemented
       │      ^
       │
 
 bug:  This assertion might not hold.
 
-      ┌── libra_block.bpl:1138:6 ───
+      ┌── libra_block.bpl:1101:6 ───
       │
- 1138 │     assert false; // $LCS_to_bytes not implemented
+ 1101 │     assert false; // $LCS_to_bytes not implemented
       │      ^
       │
 
 bug:  This assertion might not hold.
 
-      ┌── libra_block.bpl:1116:6 ───
+      ┌── libra_block.bpl:1079:6 ───
       │
- 1116 │     assert false; // $LibraAccount_write_to_event_store not implemented
+ 1079 │     assert false; // $LibraAccount_write_to_event_store not implemented
       │      ^
       │
 
 bug:  This assertion might not hold.
 
-      ┌── libra_block.bpl:1138:6 ───
+      ┌── libra_block.bpl:1101:6 ───
       │
- 1138 │     assert false; // $LCS_to_bytes not implemented
+ 1101 │     assert false; // $LCS_to_bytes not implemented
       │      ^
       │
 
 bug:  This assertion might not hold.
 
-      ┌── libra_block.bpl:1138:6 ───
+      ┌── libra_block.bpl:1101:6 ───
       │
- 1138 │     assert false; // $LCS_to_bytes not implemented
+ 1101 │     assert false; // $LCS_to_bytes not implemented
       │      ^
       │
 
 bug:  This assertion might not hold.
 
-      ┌── libra_block.bpl:1116:6 ───
+      ┌── libra_block.bpl:1079:6 ───
       │
- 1116 │     assert false; // $LibraAccount_write_to_event_store not implemented
+ 1079 │     assert false; // $LibraAccount_write_to_event_store not implemented
       │      ^
       │
 
 bug:  This assertion might not hold.
 
-      ┌── libra_block.bpl:1116:6 ───
+      ┌── libra_block.bpl:1079:6 ───
       │
- 1116 │     assert false; // $LibraAccount_write_to_event_store not implemented
+ 1079 │     assert false; // $LibraAccount_write_to_event_store not implemented
       │      ^
       │
 
 bug:  This assertion might not hold.
 
-      ┌── libra_block.bpl:1116:6 ───
+      ┌── libra_block.bpl:1079:6 ───
       │
- 1116 │     assert false; // $LibraAccount_write_to_event_store not implemented
+ 1079 │     assert false; // $LibraAccount_write_to_event_store not implemented
       │      ^
       │
 
 bug:  This assertion might not hold.
 
-      ┌── libra_block.bpl:1116:6 ───
+      ┌── libra_block.bpl:1079:6 ───
       │
- 1116 │     assert false; // $LibraAccount_write_to_event_store not implemented
+ 1079 │     assert false; // $LibraAccount_write_to_event_store not implemented
       │      ^
       │
 
 bug:  This assertion might not hold.
 
-      ┌── libra_block.bpl:1116:6 ───
+      ┌── libra_block.bpl:1079:6 ───
       │
- 1116 │     assert false; // $LibraAccount_write_to_event_store not implemented
+ 1079 │     assert false; // $LibraAccount_write_to_event_store not implemented
       │      ^
       │
 
 bug:  This assertion might not hold.
 
-      ┌── libra_block.bpl:1116:6 ───
+      ┌── libra_block.bpl:1079:6 ───
       │
- 1116 │     assert false; // $LibraAccount_write_to_event_store not implemented
+ 1079 │     assert false; // $LibraAccount_write_to_event_store not implemented
       │      ^
       │
 
 bug:  This assertion might not hold.
 
-      ┌── libra_block.bpl:1116:6 ───
+      ┌── libra_block.bpl:1079:6 ───
       │
- 1116 │     assert false; // $LibraAccount_write_to_event_store not implemented
+ 1079 │     assert false; // $LibraAccount_write_to_event_store not implemented
       │      ^
       │
 
@@ -198,17 +198,17 @@ error:  A precondition for this call might not hold.
 
 bug:  This assertion might not hold.
 
-      ┌── libra_block.bpl:1116:6 ───
+      ┌── libra_block.bpl:1079:6 ───
       │
- 1116 │     assert false; // $LibraAccount_write_to_event_store not implemented
+ 1079 │     assert false; // $LibraAccount_write_to_event_store not implemented
       │      ^
       │
 
 bug:  This assertion might not hold.
 
-      ┌── libra_block.bpl:1116:6 ───
+      ┌── libra_block.bpl:1079:6 ───
       │
- 1116 │     assert false; // $LibraAccount_write_to_event_store not implemented
+ 1079 │     assert false; // $LibraAccount_write_to_event_store not implemented
       │      ^
       │
 
@@ -252,81 +252,81 @@ error:  A precondition for this call might not hold.
 
 bug:  This assertion might not hold.
 
-      ┌── libra_block.bpl:1138:6 ───
+      ┌── libra_block.bpl:1101:6 ───
       │
- 1138 │     assert false; // $LCS_to_bytes not implemented
+ 1101 │     assert false; // $LCS_to_bytes not implemented
       │      ^
       │
 
 bug:  This assertion might not hold.
 
-      ┌── libra_block.bpl:1138:6 ───
+      ┌── libra_block.bpl:1101:6 ───
       │
- 1138 │     assert false; // $LCS_to_bytes not implemented
+ 1101 │     assert false; // $LCS_to_bytes not implemented
       │      ^
       │
 
 bug:  This assertion might not hold.
 
-      ┌── libra_block.bpl:1116:6 ───
+      ┌── libra_block.bpl:1079:6 ───
       │
- 1116 │     assert false; // $LibraAccount_write_to_event_store not implemented
+ 1079 │     assert false; // $LibraAccount_write_to_event_store not implemented
       │      ^
       │
 
 bug:  This assertion might not hold.
 
-      ┌── libra_block.bpl:1116:6 ───
+      ┌── libra_block.bpl:1079:6 ───
       │
- 1116 │     assert false; // $LibraAccount_write_to_event_store not implemented
+ 1079 │     assert false; // $LibraAccount_write_to_event_store not implemented
       │      ^
       │
 
 bug:  This assertion might not hold.
 
-      ┌── libra_block.bpl:1116:6 ───
+      ┌── libra_block.bpl:1079:6 ───
       │
- 1116 │     assert false; // $LibraAccount_write_to_event_store not implemented
+ 1079 │     assert false; // $LibraAccount_write_to_event_store not implemented
       │      ^
       │
 
 bug:  This assertion might not hold.
 
-      ┌── libra_block.bpl:1116:6 ───
+      ┌── libra_block.bpl:1079:6 ───
       │
- 1116 │     assert false; // $LibraAccount_write_to_event_store not implemented
+ 1079 │     assert false; // $LibraAccount_write_to_event_store not implemented
       │      ^
       │
 
 bug:  This assertion might not hold.
 
-      ┌── libra_block.bpl:1116:6 ───
+      ┌── libra_block.bpl:1079:6 ───
       │
- 1116 │     assert false; // $LibraAccount_write_to_event_store not implemented
+ 1079 │     assert false; // $LibraAccount_write_to_event_store not implemented
       │      ^
       │
 
 bug:  This assertion might not hold.
 
-      ┌── libra_block.bpl:1116:6 ───
+      ┌── libra_block.bpl:1079:6 ───
       │
- 1116 │     assert false; // $LibraAccount_write_to_event_store not implemented
+ 1079 │     assert false; // $LibraAccount_write_to_event_store not implemented
       │      ^
       │
 
 bug:  This assertion might not hold.
 
-      ┌── libra_block.bpl:1138:6 ───
+      ┌── libra_block.bpl:1101:6 ───
       │
- 1138 │     assert false; // $LCS_to_bytes not implemented
+ 1101 │     assert false; // $LCS_to_bytes not implemented
       │      ^
       │
 
 bug:  This assertion might not hold.
 
-      ┌── libra_block.bpl:1116:6 ───
+      ┌── libra_block.bpl:1079:6 ───
       │
- 1116 │     assert false; // $LibraAccount_write_to_event_store not implemented
+ 1079 │     assert false; // $LibraAccount_write_to_event_store not implemented
       │      ^
       │
 

--- a/language/move-prover/tests/sources/stdlib/modules/libra_configs.exp
+++ b/language/move-prover/tests/sources/stdlib/modules/libra_configs.exp
@@ -1,153 +1,153 @@
 Move prover returns: exiting with boogie verification errors
 bug:  This assertion might not hold.
 
-      ┌── libra_configs.bpl:1116:6 ───
+      ┌── libra_configs.bpl:1079:6 ───
       │
- 1116 │     assert false; // $LibraAccount_write_to_event_store not implemented
+ 1079 │     assert false; // $LibraAccount_write_to_event_store not implemented
       │      ^
       │
 
 bug:  This assertion might not hold.
 
-      ┌── libra_configs.bpl:1116:6 ───
+      ┌── libra_configs.bpl:1079:6 ───
       │
- 1116 │     assert false; // $LibraAccount_write_to_event_store not implemented
+ 1079 │     assert false; // $LibraAccount_write_to_event_store not implemented
       │      ^
       │
 
 bug:  This assertion might not hold.
 
-      ┌── libra_configs.bpl:1138:6 ───
+      ┌── libra_configs.bpl:1101:6 ───
       │
- 1138 │     assert false; // $LCS_to_bytes not implemented
+ 1101 │     assert false; // $LCS_to_bytes not implemented
       │      ^
       │
 
 bug:  This assertion might not hold.
 
-      ┌── libra_configs.bpl:1138:6 ───
+      ┌── libra_configs.bpl:1101:6 ───
       │
- 1138 │     assert false; // $LCS_to_bytes not implemented
+ 1101 │     assert false; // $LCS_to_bytes not implemented
       │      ^
       │
 
 bug:  This assertion might not hold.
 
-      ┌── libra_configs.bpl:1116:6 ───
+      ┌── libra_configs.bpl:1079:6 ───
       │
- 1116 │     assert false; // $LibraAccount_write_to_event_store not implemented
+ 1079 │     assert false; // $LibraAccount_write_to_event_store not implemented
       │      ^
       │
 
 bug:  This assertion might not hold.
 
-      ┌── libra_configs.bpl:1116:6 ───
+      ┌── libra_configs.bpl:1079:6 ───
       │
- 1116 │     assert false; // $LibraAccount_write_to_event_store not implemented
+ 1079 │     assert false; // $LibraAccount_write_to_event_store not implemented
       │      ^
       │
 
 bug:  This assertion might not hold.
 
-      ┌── libra_configs.bpl:1116:6 ───
+      ┌── libra_configs.bpl:1079:6 ───
       │
- 1116 │     assert false; // $LibraAccount_write_to_event_store not implemented
+ 1079 │     assert false; // $LibraAccount_write_to_event_store not implemented
       │      ^
       │
 
 bug:  This assertion might not hold.
 
-      ┌── libra_configs.bpl:1116:6 ───
+      ┌── libra_configs.bpl:1079:6 ───
       │
- 1116 │     assert false; // $LibraAccount_write_to_event_store not implemented
+ 1079 │     assert false; // $LibraAccount_write_to_event_store not implemented
       │      ^
       │
 
 bug:  This assertion might not hold.
 
-      ┌── libra_configs.bpl:1138:6 ───
+      ┌── libra_configs.bpl:1101:6 ───
       │
- 1138 │     assert false; // $LCS_to_bytes not implemented
+ 1101 │     assert false; // $LCS_to_bytes not implemented
       │      ^
       │
 
 bug:  This assertion might not hold.
 
-      ┌── libra_configs.bpl:1116:6 ───
+      ┌── libra_configs.bpl:1079:6 ───
       │
- 1116 │     assert false; // $LibraAccount_write_to_event_store not implemented
+ 1079 │     assert false; // $LibraAccount_write_to_event_store not implemented
       │      ^
       │
 
 bug:  This assertion might not hold.
 
-      ┌── libra_configs.bpl:1138:6 ───
+      ┌── libra_configs.bpl:1101:6 ───
       │
- 1138 │     assert false; // $LCS_to_bytes not implemented
+ 1101 │     assert false; // $LCS_to_bytes not implemented
       │      ^
       │
 
 bug:  This assertion might not hold.
 
-      ┌── libra_configs.bpl:1138:6 ───
+      ┌── libra_configs.bpl:1101:6 ───
       │
- 1138 │     assert false; // $LCS_to_bytes not implemented
+ 1101 │     assert false; // $LCS_to_bytes not implemented
       │      ^
       │
 
 bug:  This assertion might not hold.
 
-      ┌── libra_configs.bpl:1116:6 ───
+      ┌── libra_configs.bpl:1079:6 ───
       │
- 1116 │     assert false; // $LibraAccount_write_to_event_store not implemented
+ 1079 │     assert false; // $LibraAccount_write_to_event_store not implemented
       │      ^
       │
 
 bug:  This assertion might not hold.
 
-      ┌── libra_configs.bpl:1116:6 ───
+      ┌── libra_configs.bpl:1079:6 ───
       │
- 1116 │     assert false; // $LibraAccount_write_to_event_store not implemented
+ 1079 │     assert false; // $LibraAccount_write_to_event_store not implemented
       │      ^
       │
 
 bug:  This assertion might not hold.
 
-      ┌── libra_configs.bpl:1116:6 ───
+      ┌── libra_configs.bpl:1079:6 ───
       │
- 1116 │     assert false; // $LibraAccount_write_to_event_store not implemented
+ 1079 │     assert false; // $LibraAccount_write_to_event_store not implemented
       │      ^
       │
 
 bug:  This assertion might not hold.
 
-      ┌── libra_configs.bpl:1116:6 ───
+      ┌── libra_configs.bpl:1079:6 ───
       │
- 1116 │     assert false; // $LibraAccount_write_to_event_store not implemented
+ 1079 │     assert false; // $LibraAccount_write_to_event_store not implemented
       │      ^
       │
 
 bug:  This assertion might not hold.
 
-      ┌── libra_configs.bpl:1116:6 ───
+      ┌── libra_configs.bpl:1079:6 ───
       │
- 1116 │     assert false; // $LibraAccount_write_to_event_store not implemented
+ 1079 │     assert false; // $LibraAccount_write_to_event_store not implemented
       │      ^
       │
 
 bug:  This assertion might not hold.
 
-      ┌── libra_configs.bpl:1116:6 ───
+      ┌── libra_configs.bpl:1079:6 ───
       │
- 1116 │     assert false; // $LibraAccount_write_to_event_store not implemented
+ 1079 │     assert false; // $LibraAccount_write_to_event_store not implemented
       │      ^
       │
 
 bug:  This assertion might not hold.
 
-      ┌── libra_configs.bpl:1116:6 ───
+      ┌── libra_configs.bpl:1079:6 ───
       │
- 1116 │     assert false; // $LibraAccount_write_to_event_store not implemented
+ 1079 │     assert false; // $LibraAccount_write_to_event_store not implemented
       │      ^
       │
 
@@ -198,17 +198,17 @@ error:  A precondition for this call might not hold.
 
 bug:  This assertion might not hold.
 
-      ┌── libra_configs.bpl:1116:6 ───
+      ┌── libra_configs.bpl:1079:6 ───
       │
- 1116 │     assert false; // $LibraAccount_write_to_event_store not implemented
+ 1079 │     assert false; // $LibraAccount_write_to_event_store not implemented
       │      ^
       │
 
 bug:  This assertion might not hold.
 
-      ┌── libra_configs.bpl:1116:6 ───
+      ┌── libra_configs.bpl:1079:6 ───
       │
- 1116 │     assert false; // $LibraAccount_write_to_event_store not implemented
+ 1079 │     assert false; // $LibraAccount_write_to_event_store not implemented
       │      ^
       │
 
@@ -252,56 +252,56 @@ error:  A precondition for this call might not hold.
 
 bug:  This assertion might not hold.
 
-      ┌── libra_configs.bpl:1138:6 ───
+      ┌── libra_configs.bpl:1101:6 ───
       │
- 1138 │     assert false; // $LCS_to_bytes not implemented
+ 1101 │     assert false; // $LCS_to_bytes not implemented
       │      ^
       │
 
 bug:  This assertion might not hold.
 
-      ┌── libra_configs.bpl:1138:6 ───
+      ┌── libra_configs.bpl:1101:6 ───
       │
- 1138 │     assert false; // $LCS_to_bytes not implemented
+ 1101 │     assert false; // $LCS_to_bytes not implemented
       │      ^
       │
 
 bug:  This assertion might not hold.
 
-      ┌── libra_configs.bpl:1116:6 ───
+      ┌── libra_configs.bpl:1079:6 ───
       │
- 1116 │     assert false; // $LibraAccount_write_to_event_store not implemented
+ 1079 │     assert false; // $LibraAccount_write_to_event_store not implemented
       │      ^
       │
 
 bug:  This assertion might not hold.
 
-      ┌── libra_configs.bpl:1116:6 ───
+      ┌── libra_configs.bpl:1079:6 ───
       │
- 1116 │     assert false; // $LibraAccount_write_to_event_store not implemented
+ 1079 │     assert false; // $LibraAccount_write_to_event_store not implemented
       │      ^
       │
 
 bug:  This assertion might not hold.
 
-      ┌── libra_configs.bpl:1116:6 ───
+      ┌── libra_configs.bpl:1079:6 ───
       │
- 1116 │     assert false; // $LibraAccount_write_to_event_store not implemented
+ 1079 │     assert false; // $LibraAccount_write_to_event_store not implemented
       │      ^
       │
 
 bug:  This assertion might not hold.
 
-      ┌── libra_configs.bpl:1116:6 ───
+      ┌── libra_configs.bpl:1079:6 ───
       │
- 1116 │     assert false; // $LibraAccount_write_to_event_store not implemented
+ 1079 │     assert false; // $LibraAccount_write_to_event_store not implemented
       │      ^
       │
 
 bug:  This assertion might not hold.
 
-      ┌── libra_configs.bpl:1116:6 ───
+      ┌── libra_configs.bpl:1079:6 ───
       │
- 1116 │     assert false; // $LibraAccount_write_to_event_store not implemented
+ 1079 │     assert false; // $LibraAccount_write_to_event_store not implemented
       │      ^
       │

--- a/language/move-prover/tests/sources/stdlib/modules/libra_system.exp
+++ b/language/move-prover/tests/sources/stdlib/modules/libra_system.exp
@@ -1,153 +1,153 @@
 Move prover returns: exiting with boogie verification errors
 bug:  This assertion might not hold.
 
-      ┌── libra_system.bpl:1116:6 ───
+      ┌── libra_system.bpl:1079:6 ───
       │
- 1116 │     assert false; // $LibraAccount_write_to_event_store not implemented
+ 1079 │     assert false; // $LibraAccount_write_to_event_store not implemented
       │      ^
       │
 
 bug:  This assertion might not hold.
 
-      ┌── libra_system.bpl:1116:6 ───
+      ┌── libra_system.bpl:1079:6 ───
       │
- 1116 │     assert false; // $LibraAccount_write_to_event_store not implemented
+ 1079 │     assert false; // $LibraAccount_write_to_event_store not implemented
       │      ^
       │
 
 bug:  This assertion might not hold.
 
-      ┌── libra_system.bpl:1138:6 ───
+      ┌── libra_system.bpl:1101:6 ───
       │
- 1138 │     assert false; // $LCS_to_bytes not implemented
+ 1101 │     assert false; // $LCS_to_bytes not implemented
       │      ^
       │
 
 bug:  This assertion might not hold.
 
-      ┌── libra_system.bpl:1138:6 ───
+      ┌── libra_system.bpl:1101:6 ───
       │
- 1138 │     assert false; // $LCS_to_bytes not implemented
+ 1101 │     assert false; // $LCS_to_bytes not implemented
       │      ^
       │
 
 bug:  This assertion might not hold.
 
-      ┌── libra_system.bpl:1116:6 ───
+      ┌── libra_system.bpl:1079:6 ───
       │
- 1116 │     assert false; // $LibraAccount_write_to_event_store not implemented
+ 1079 │     assert false; // $LibraAccount_write_to_event_store not implemented
       │      ^
       │
 
 bug:  This assertion might not hold.
 
-      ┌── libra_system.bpl:1116:6 ───
+      ┌── libra_system.bpl:1079:6 ───
       │
- 1116 │     assert false; // $LibraAccount_write_to_event_store not implemented
+ 1079 │     assert false; // $LibraAccount_write_to_event_store not implemented
       │      ^
       │
 
 bug:  This assertion might not hold.
 
-      ┌── libra_system.bpl:1116:6 ───
+      ┌── libra_system.bpl:1079:6 ───
       │
- 1116 │     assert false; // $LibraAccount_write_to_event_store not implemented
+ 1079 │     assert false; // $LibraAccount_write_to_event_store not implemented
       │      ^
       │
 
 bug:  This assertion might not hold.
 
-      ┌── libra_system.bpl:1116:6 ───
+      ┌── libra_system.bpl:1079:6 ───
       │
- 1116 │     assert false; // $LibraAccount_write_to_event_store not implemented
+ 1079 │     assert false; // $LibraAccount_write_to_event_store not implemented
       │      ^
       │
 
 bug:  This assertion might not hold.
 
-      ┌── libra_system.bpl:1138:6 ───
+      ┌── libra_system.bpl:1101:6 ───
       │
- 1138 │     assert false; // $LCS_to_bytes not implemented
+ 1101 │     assert false; // $LCS_to_bytes not implemented
       │      ^
       │
 
 bug:  This assertion might not hold.
 
-      ┌── libra_system.bpl:1116:6 ───
+      ┌── libra_system.bpl:1079:6 ───
       │
- 1116 │     assert false; // $LibraAccount_write_to_event_store not implemented
+ 1079 │     assert false; // $LibraAccount_write_to_event_store not implemented
       │      ^
       │
 
 bug:  This assertion might not hold.
 
-      ┌── libra_system.bpl:1138:6 ───
+      ┌── libra_system.bpl:1101:6 ───
       │
- 1138 │     assert false; // $LCS_to_bytes not implemented
+ 1101 │     assert false; // $LCS_to_bytes not implemented
       │      ^
       │
 
 bug:  This assertion might not hold.
 
-      ┌── libra_system.bpl:1138:6 ───
+      ┌── libra_system.bpl:1101:6 ───
       │
- 1138 │     assert false; // $LCS_to_bytes not implemented
+ 1101 │     assert false; // $LCS_to_bytes not implemented
       │      ^
       │
 
 bug:  This assertion might not hold.
 
-      ┌── libra_system.bpl:1116:6 ───
+      ┌── libra_system.bpl:1079:6 ───
       │
- 1116 │     assert false; // $LibraAccount_write_to_event_store not implemented
+ 1079 │     assert false; // $LibraAccount_write_to_event_store not implemented
       │      ^
       │
 
 bug:  This assertion might not hold.
 
-      ┌── libra_system.bpl:1116:6 ───
+      ┌── libra_system.bpl:1079:6 ───
       │
- 1116 │     assert false; // $LibraAccount_write_to_event_store not implemented
+ 1079 │     assert false; // $LibraAccount_write_to_event_store not implemented
       │      ^
       │
 
 bug:  This assertion might not hold.
 
-      ┌── libra_system.bpl:1116:6 ───
+      ┌── libra_system.bpl:1079:6 ───
       │
- 1116 │     assert false; // $LibraAccount_write_to_event_store not implemented
+ 1079 │     assert false; // $LibraAccount_write_to_event_store not implemented
       │      ^
       │
 
 bug:  This assertion might not hold.
 
-      ┌── libra_system.bpl:1116:6 ───
+      ┌── libra_system.bpl:1079:6 ───
       │
- 1116 │     assert false; // $LibraAccount_write_to_event_store not implemented
+ 1079 │     assert false; // $LibraAccount_write_to_event_store not implemented
       │      ^
       │
 
 bug:  This assertion might not hold.
 
-      ┌── libra_system.bpl:1116:6 ───
+      ┌── libra_system.bpl:1079:6 ───
       │
- 1116 │     assert false; // $LibraAccount_write_to_event_store not implemented
+ 1079 │     assert false; // $LibraAccount_write_to_event_store not implemented
       │      ^
       │
 
 bug:  This assertion might not hold.
 
-      ┌── libra_system.bpl:1116:6 ───
+      ┌── libra_system.bpl:1079:6 ───
       │
- 1116 │     assert false; // $LibraAccount_write_to_event_store not implemented
+ 1079 │     assert false; // $LibraAccount_write_to_event_store not implemented
       │      ^
       │
 
 bug:  This assertion might not hold.
 
-      ┌── libra_system.bpl:1116:6 ───
+      ┌── libra_system.bpl:1079:6 ───
       │
- 1116 │     assert false; // $LibraAccount_write_to_event_store not implemented
+ 1079 │     assert false; // $LibraAccount_write_to_event_store not implemented
       │      ^
       │
 
@@ -198,17 +198,17 @@ error:  A precondition for this call might not hold.
 
 bug:  This assertion might not hold.
 
-      ┌── libra_system.bpl:1116:6 ───
+      ┌── libra_system.bpl:1079:6 ───
       │
- 1116 │     assert false; // $LibraAccount_write_to_event_store not implemented
+ 1079 │     assert false; // $LibraAccount_write_to_event_store not implemented
       │      ^
       │
 
 bug:  This assertion might not hold.
 
-      ┌── libra_system.bpl:1116:6 ───
+      ┌── libra_system.bpl:1079:6 ───
       │
- 1116 │     assert false; // $LibraAccount_write_to_event_store not implemented
+ 1079 │     assert false; // $LibraAccount_write_to_event_store not implemented
       │      ^
       │
 
@@ -252,49 +252,49 @@ error:  A precondition for this call might not hold.
 
 bug:  This assertion might not hold.
 
-      ┌── libra_system.bpl:1138:6 ───
+      ┌── libra_system.bpl:1101:6 ───
       │
- 1138 │     assert false; // $LCS_to_bytes not implemented
+ 1101 │     assert false; // $LCS_to_bytes not implemented
       │      ^
       │
 
 bug:  This assertion might not hold.
 
-      ┌── libra_system.bpl:1138:6 ───
+      ┌── libra_system.bpl:1101:6 ───
       │
- 1138 │     assert false; // $LCS_to_bytes not implemented
+ 1101 │     assert false; // $LCS_to_bytes not implemented
       │      ^
       │
 
 bug:  This assertion might not hold.
 
-      ┌── libra_system.bpl:1116:6 ───
+      ┌── libra_system.bpl:1079:6 ───
       │
- 1116 │     assert false; // $LibraAccount_write_to_event_store not implemented
+ 1079 │     assert false; // $LibraAccount_write_to_event_store not implemented
       │      ^
       │
 
 bug:  This assertion might not hold.
 
-      ┌── libra_system.bpl:1116:6 ───
+      ┌── libra_system.bpl:1079:6 ───
       │
- 1116 │     assert false; // $LibraAccount_write_to_event_store not implemented
+ 1079 │     assert false; // $LibraAccount_write_to_event_store not implemented
       │      ^
       │
 
 bug:  This assertion might not hold.
 
-      ┌── libra_system.bpl:1116:6 ───
+      ┌── libra_system.bpl:1079:6 ───
       │
- 1116 │     assert false; // $LibraAccount_write_to_event_store not implemented
+ 1079 │     assert false; // $LibraAccount_write_to_event_store not implemented
       │      ^
       │
 
 bug:  This assertion might not hold.
 
-      ┌── libra_system.bpl:1116:6 ───
+      ┌── libra_system.bpl:1079:6 ───
       │
- 1116 │     assert false; // $LibraAccount_write_to_event_store not implemented
+ 1079 │     assert false; // $LibraAccount_write_to_event_store not implemented
       │      ^
       │
 

--- a/language/move-prover/tests/sources/stdlib/modules/script_whitelist.exp
+++ b/language/move-prover/tests/sources/stdlib/modules/script_whitelist.exp
@@ -1,153 +1,153 @@
 Move prover returns: exiting with boogie verification errors
 bug:  This assertion might not hold.
 
-      ┌── script_whitelist.bpl:1116:6 ───
+      ┌── script_whitelist.bpl:1079:6 ───
       │
- 1116 │     assert false; // $LibraAccount_write_to_event_store not implemented
+ 1079 │     assert false; // $LibraAccount_write_to_event_store not implemented
       │      ^
       │
 
 bug:  This assertion might not hold.
 
-      ┌── script_whitelist.bpl:1116:6 ───
+      ┌── script_whitelist.bpl:1079:6 ───
       │
- 1116 │     assert false; // $LibraAccount_write_to_event_store not implemented
+ 1079 │     assert false; // $LibraAccount_write_to_event_store not implemented
       │      ^
       │
 
 bug:  This assertion might not hold.
 
-      ┌── script_whitelist.bpl:1138:6 ───
+      ┌── script_whitelist.bpl:1101:6 ───
       │
- 1138 │     assert false; // $LCS_to_bytes not implemented
+ 1101 │     assert false; // $LCS_to_bytes not implemented
       │      ^
       │
 
 bug:  This assertion might not hold.
 
-      ┌── script_whitelist.bpl:1138:6 ───
+      ┌── script_whitelist.bpl:1101:6 ───
       │
- 1138 │     assert false; // $LCS_to_bytes not implemented
+ 1101 │     assert false; // $LCS_to_bytes not implemented
       │      ^
       │
 
 bug:  This assertion might not hold.
 
-      ┌── script_whitelist.bpl:1116:6 ───
+      ┌── script_whitelist.bpl:1079:6 ───
       │
- 1116 │     assert false; // $LibraAccount_write_to_event_store not implemented
+ 1079 │     assert false; // $LibraAccount_write_to_event_store not implemented
       │      ^
       │
 
 bug:  This assertion might not hold.
 
-      ┌── script_whitelist.bpl:1116:6 ───
+      ┌── script_whitelist.bpl:1079:6 ───
       │
- 1116 │     assert false; // $LibraAccount_write_to_event_store not implemented
+ 1079 │     assert false; // $LibraAccount_write_to_event_store not implemented
       │      ^
       │
 
 bug:  This assertion might not hold.
 
-      ┌── script_whitelist.bpl:1116:6 ───
+      ┌── script_whitelist.bpl:1079:6 ───
       │
- 1116 │     assert false; // $LibraAccount_write_to_event_store not implemented
+ 1079 │     assert false; // $LibraAccount_write_to_event_store not implemented
       │      ^
       │
 
 bug:  This assertion might not hold.
 
-      ┌── script_whitelist.bpl:1116:6 ───
+      ┌── script_whitelist.bpl:1079:6 ───
       │
- 1116 │     assert false; // $LibraAccount_write_to_event_store not implemented
+ 1079 │     assert false; // $LibraAccount_write_to_event_store not implemented
       │      ^
       │
 
 bug:  This assertion might not hold.
 
-      ┌── script_whitelist.bpl:1138:6 ───
+      ┌── script_whitelist.bpl:1101:6 ───
       │
- 1138 │     assert false; // $LCS_to_bytes not implemented
+ 1101 │     assert false; // $LCS_to_bytes not implemented
       │      ^
       │
 
 bug:  This assertion might not hold.
 
-      ┌── script_whitelist.bpl:1116:6 ───
+      ┌── script_whitelist.bpl:1079:6 ───
       │
- 1116 │     assert false; // $LibraAccount_write_to_event_store not implemented
+ 1079 │     assert false; // $LibraAccount_write_to_event_store not implemented
       │      ^
       │
 
 bug:  This assertion might not hold.
 
-      ┌── script_whitelist.bpl:1138:6 ───
+      ┌── script_whitelist.bpl:1101:6 ───
       │
- 1138 │     assert false; // $LCS_to_bytes not implemented
+ 1101 │     assert false; // $LCS_to_bytes not implemented
       │      ^
       │
 
 bug:  This assertion might not hold.
 
-      ┌── script_whitelist.bpl:1138:6 ───
+      ┌── script_whitelist.bpl:1101:6 ───
       │
- 1138 │     assert false; // $LCS_to_bytes not implemented
+ 1101 │     assert false; // $LCS_to_bytes not implemented
       │      ^
       │
 
 bug:  This assertion might not hold.
 
-      ┌── script_whitelist.bpl:1116:6 ───
+      ┌── script_whitelist.bpl:1079:6 ───
       │
- 1116 │     assert false; // $LibraAccount_write_to_event_store not implemented
+ 1079 │     assert false; // $LibraAccount_write_to_event_store not implemented
       │      ^
       │
 
 bug:  This assertion might not hold.
 
-      ┌── script_whitelist.bpl:1116:6 ───
+      ┌── script_whitelist.bpl:1079:6 ───
       │
- 1116 │     assert false; // $LibraAccount_write_to_event_store not implemented
+ 1079 │     assert false; // $LibraAccount_write_to_event_store not implemented
       │      ^
       │
 
 bug:  This assertion might not hold.
 
-      ┌── script_whitelist.bpl:1116:6 ───
+      ┌── script_whitelist.bpl:1079:6 ───
       │
- 1116 │     assert false; // $LibraAccount_write_to_event_store not implemented
+ 1079 │     assert false; // $LibraAccount_write_to_event_store not implemented
       │      ^
       │
 
 bug:  This assertion might not hold.
 
-      ┌── script_whitelist.bpl:1116:6 ───
+      ┌── script_whitelist.bpl:1079:6 ───
       │
- 1116 │     assert false; // $LibraAccount_write_to_event_store not implemented
+ 1079 │     assert false; // $LibraAccount_write_to_event_store not implemented
       │      ^
       │
 
 bug:  This assertion might not hold.
 
-      ┌── script_whitelist.bpl:1116:6 ───
+      ┌── script_whitelist.bpl:1079:6 ───
       │
- 1116 │     assert false; // $LibraAccount_write_to_event_store not implemented
+ 1079 │     assert false; // $LibraAccount_write_to_event_store not implemented
       │      ^
       │
 
 bug:  This assertion might not hold.
 
-      ┌── script_whitelist.bpl:1116:6 ───
+      ┌── script_whitelist.bpl:1079:6 ───
       │
- 1116 │     assert false; // $LibraAccount_write_to_event_store not implemented
+ 1079 │     assert false; // $LibraAccount_write_to_event_store not implemented
       │      ^
       │
 
 bug:  This assertion might not hold.
 
-      ┌── script_whitelist.bpl:1116:6 ───
+      ┌── script_whitelist.bpl:1079:6 ───
       │
- 1116 │     assert false; // $LibraAccount_write_to_event_store not implemented
+ 1079 │     assert false; // $LibraAccount_write_to_event_store not implemented
       │      ^
       │
 
@@ -198,17 +198,17 @@ error:  A precondition for this call might not hold.
 
 bug:  This assertion might not hold.
 
-      ┌── script_whitelist.bpl:1116:6 ───
+      ┌── script_whitelist.bpl:1079:6 ───
       │
- 1116 │     assert false; // $LibraAccount_write_to_event_store not implemented
+ 1079 │     assert false; // $LibraAccount_write_to_event_store not implemented
       │      ^
       │
 
 bug:  This assertion might not hold.
 
-      ┌── script_whitelist.bpl:1116:6 ───
+      ┌── script_whitelist.bpl:1079:6 ───
       │
- 1116 │     assert false; // $LibraAccount_write_to_event_store not implemented
+ 1079 │     assert false; // $LibraAccount_write_to_event_store not implemented
       │      ^
       │
 
@@ -252,72 +252,72 @@ error:  A precondition for this call might not hold.
 
 bug:  This assertion might not hold.
 
-      ┌── script_whitelist.bpl:1138:6 ───
+      ┌── script_whitelist.bpl:1101:6 ───
       │
- 1138 │     assert false; // $LCS_to_bytes not implemented
+ 1101 │     assert false; // $LCS_to_bytes not implemented
       │      ^
       │
 
 bug:  This assertion might not hold.
 
-      ┌── script_whitelist.bpl:1138:6 ───
+      ┌── script_whitelist.bpl:1101:6 ───
       │
- 1138 │     assert false; // $LCS_to_bytes not implemented
+ 1101 │     assert false; // $LCS_to_bytes not implemented
       │      ^
       │
 
 bug:  This assertion might not hold.
 
-      ┌── script_whitelist.bpl:1116:6 ───
+      ┌── script_whitelist.bpl:1079:6 ───
       │
- 1116 │     assert false; // $LibraAccount_write_to_event_store not implemented
+ 1079 │     assert false; // $LibraAccount_write_to_event_store not implemented
       │      ^
       │
 
 bug:  This assertion might not hold.
 
-      ┌── script_whitelist.bpl:1116:6 ───
+      ┌── script_whitelist.bpl:1079:6 ───
       │
- 1116 │     assert false; // $LibraAccount_write_to_event_store not implemented
+ 1079 │     assert false; // $LibraAccount_write_to_event_store not implemented
       │      ^
       │
 
 bug:  This assertion might not hold.
 
-      ┌── script_whitelist.bpl:1116:6 ───
+      ┌── script_whitelist.bpl:1079:6 ───
       │
- 1116 │     assert false; // $LibraAccount_write_to_event_store not implemented
+ 1079 │     assert false; // $LibraAccount_write_to_event_store not implemented
       │      ^
       │
 
 bug:  This assertion might not hold.
 
-      ┌── script_whitelist.bpl:1116:6 ───
+      ┌── script_whitelist.bpl:1079:6 ───
       │
- 1116 │     assert false; // $LibraAccount_write_to_event_store not implemented
+ 1079 │     assert false; // $LibraAccount_write_to_event_store not implemented
       │      ^
       │
 
 bug:  This assertion might not hold.
 
-      ┌── script_whitelist.bpl:1116:6 ───
+      ┌── script_whitelist.bpl:1079:6 ───
       │
- 1116 │     assert false; // $LibraAccount_write_to_event_store not implemented
+ 1079 │     assert false; // $LibraAccount_write_to_event_store not implemented
       │      ^
       │
 
 bug:  This assertion might not hold.
 
-      ┌── script_whitelist.bpl:1116:6 ───
+      ┌── script_whitelist.bpl:1079:6 ───
       │
- 1116 │     assert false; // $LibraAccount_write_to_event_store not implemented
+ 1079 │     assert false; // $LibraAccount_write_to_event_store not implemented
       │      ^
       │
 
 bug:  This assertion might not hold.
 
-      ┌── script_whitelist.bpl:1116:6 ───
+      ┌── script_whitelist.bpl:1079:6 ───
       │
- 1116 │     assert false; // $LibraAccount_write_to_event_store not implemented
+ 1079 │     assert false; // $LibraAccount_write_to_event_store not implemented
       │      ^
       │

--- a/language/move-prover/tests/sources/stdlib/modules/transaction_fee.exp
+++ b/language/move-prover/tests/sources/stdlib/modules/transaction_fee.exp
@@ -1,153 +1,153 @@
 Move prover returns: exiting with boogie verification errors
 bug:  This assertion might not hold.
 
-      ┌── transaction_fee.bpl:1116:6 ───
+      ┌── transaction_fee.bpl:1079:6 ───
       │
- 1116 │     assert false; // $LibraAccount_write_to_event_store not implemented
+ 1079 │     assert false; // $LibraAccount_write_to_event_store not implemented
       │      ^
       │
 
 bug:  This assertion might not hold.
 
-      ┌── transaction_fee.bpl:1116:6 ───
+      ┌── transaction_fee.bpl:1079:6 ───
       │
- 1116 │     assert false; // $LibraAccount_write_to_event_store not implemented
+ 1079 │     assert false; // $LibraAccount_write_to_event_store not implemented
       │      ^
       │
 
 bug:  This assertion might not hold.
 
-      ┌── transaction_fee.bpl:1138:6 ───
+      ┌── transaction_fee.bpl:1101:6 ───
       │
- 1138 │     assert false; // $LCS_to_bytes not implemented
+ 1101 │     assert false; // $LCS_to_bytes not implemented
       │      ^
       │
 
 bug:  This assertion might not hold.
 
-      ┌── transaction_fee.bpl:1138:6 ───
+      ┌── transaction_fee.bpl:1101:6 ───
       │
- 1138 │     assert false; // $LCS_to_bytes not implemented
+ 1101 │     assert false; // $LCS_to_bytes not implemented
       │      ^
       │
 
 bug:  This assertion might not hold.
 
-      ┌── transaction_fee.bpl:1116:6 ───
+      ┌── transaction_fee.bpl:1079:6 ───
       │
- 1116 │     assert false; // $LibraAccount_write_to_event_store not implemented
+ 1079 │     assert false; // $LibraAccount_write_to_event_store not implemented
       │      ^
       │
 
 bug:  This assertion might not hold.
 
-      ┌── transaction_fee.bpl:1116:6 ───
+      ┌── transaction_fee.bpl:1079:6 ───
       │
- 1116 │     assert false; // $LibraAccount_write_to_event_store not implemented
+ 1079 │     assert false; // $LibraAccount_write_to_event_store not implemented
       │      ^
       │
 
 bug:  This assertion might not hold.
 
-      ┌── transaction_fee.bpl:1116:6 ───
+      ┌── transaction_fee.bpl:1079:6 ───
       │
- 1116 │     assert false; // $LibraAccount_write_to_event_store not implemented
+ 1079 │     assert false; // $LibraAccount_write_to_event_store not implemented
       │      ^
       │
 
 bug:  This assertion might not hold.
 
-      ┌── transaction_fee.bpl:1116:6 ───
+      ┌── transaction_fee.bpl:1079:6 ───
       │
- 1116 │     assert false; // $LibraAccount_write_to_event_store not implemented
+ 1079 │     assert false; // $LibraAccount_write_to_event_store not implemented
       │      ^
       │
 
 bug:  This assertion might not hold.
 
-      ┌── transaction_fee.bpl:1138:6 ───
+      ┌── transaction_fee.bpl:1101:6 ───
       │
- 1138 │     assert false; // $LCS_to_bytes not implemented
+ 1101 │     assert false; // $LCS_to_bytes not implemented
       │      ^
       │
 
 bug:  This assertion might not hold.
 
-      ┌── transaction_fee.bpl:1116:6 ───
+      ┌── transaction_fee.bpl:1079:6 ───
       │
- 1116 │     assert false; // $LibraAccount_write_to_event_store not implemented
+ 1079 │     assert false; // $LibraAccount_write_to_event_store not implemented
       │      ^
       │
 
 bug:  This assertion might not hold.
 
-      ┌── transaction_fee.bpl:1138:6 ───
+      ┌── transaction_fee.bpl:1101:6 ───
       │
- 1138 │     assert false; // $LCS_to_bytes not implemented
+ 1101 │     assert false; // $LCS_to_bytes not implemented
       │      ^
       │
 
 bug:  This assertion might not hold.
 
-      ┌── transaction_fee.bpl:1138:6 ───
+      ┌── transaction_fee.bpl:1101:6 ───
       │
- 1138 │     assert false; // $LCS_to_bytes not implemented
+ 1101 │     assert false; // $LCS_to_bytes not implemented
       │      ^
       │
 
 bug:  This assertion might not hold.
 
-      ┌── transaction_fee.bpl:1116:6 ───
+      ┌── transaction_fee.bpl:1079:6 ───
       │
- 1116 │     assert false; // $LibraAccount_write_to_event_store not implemented
+ 1079 │     assert false; // $LibraAccount_write_to_event_store not implemented
       │      ^
       │
 
 bug:  This assertion might not hold.
 
-      ┌── transaction_fee.bpl:1116:6 ───
+      ┌── transaction_fee.bpl:1079:6 ───
       │
- 1116 │     assert false; // $LibraAccount_write_to_event_store not implemented
+ 1079 │     assert false; // $LibraAccount_write_to_event_store not implemented
       │      ^
       │
 
 bug:  This assertion might not hold.
 
-      ┌── transaction_fee.bpl:1116:6 ───
+      ┌── transaction_fee.bpl:1079:6 ───
       │
- 1116 │     assert false; // $LibraAccount_write_to_event_store not implemented
+ 1079 │     assert false; // $LibraAccount_write_to_event_store not implemented
       │      ^
       │
 
 bug:  This assertion might not hold.
 
-      ┌── transaction_fee.bpl:1116:6 ───
+      ┌── transaction_fee.bpl:1079:6 ───
       │
- 1116 │     assert false; // $LibraAccount_write_to_event_store not implemented
+ 1079 │     assert false; // $LibraAccount_write_to_event_store not implemented
       │      ^
       │
 
 bug:  This assertion might not hold.
 
-      ┌── transaction_fee.bpl:1116:6 ───
+      ┌── transaction_fee.bpl:1079:6 ───
       │
- 1116 │     assert false; // $LibraAccount_write_to_event_store not implemented
+ 1079 │     assert false; // $LibraAccount_write_to_event_store not implemented
       │      ^
       │
 
 bug:  This assertion might not hold.
 
-      ┌── transaction_fee.bpl:1116:6 ───
+      ┌── transaction_fee.bpl:1079:6 ───
       │
- 1116 │     assert false; // $LibraAccount_write_to_event_store not implemented
+ 1079 │     assert false; // $LibraAccount_write_to_event_store not implemented
       │      ^
       │
 
 bug:  This assertion might not hold.
 
-      ┌── transaction_fee.bpl:1116:6 ───
+      ┌── transaction_fee.bpl:1079:6 ───
       │
- 1116 │     assert false; // $LibraAccount_write_to_event_store not implemented
+ 1079 │     assert false; // $LibraAccount_write_to_event_store not implemented
       │      ^
       │
 
@@ -198,17 +198,17 @@ error:  A precondition for this call might not hold.
 
 bug:  This assertion might not hold.
 
-      ┌── transaction_fee.bpl:1116:6 ───
+      ┌── transaction_fee.bpl:1079:6 ───
       │
- 1116 │     assert false; // $LibraAccount_write_to_event_store not implemented
+ 1079 │     assert false; // $LibraAccount_write_to_event_store not implemented
       │      ^
       │
 
 bug:  This assertion might not hold.
 
-      ┌── transaction_fee.bpl:1116:6 ───
+      ┌── transaction_fee.bpl:1079:6 ───
       │
- 1116 │     assert false; // $LibraAccount_write_to_event_store not implemented
+ 1079 │     assert false; // $LibraAccount_write_to_event_store not implemented
       │      ^
       │
 
@@ -252,65 +252,65 @@ error:  A precondition for this call might not hold.
 
 bug:  This assertion might not hold.
 
-      ┌── transaction_fee.bpl:1138:6 ───
+      ┌── transaction_fee.bpl:1101:6 ───
       │
- 1138 │     assert false; // $LCS_to_bytes not implemented
+ 1101 │     assert false; // $LCS_to_bytes not implemented
       │      ^
       │
 
 bug:  This assertion might not hold.
 
-      ┌── transaction_fee.bpl:1138:6 ───
+      ┌── transaction_fee.bpl:1101:6 ───
       │
- 1138 │     assert false; // $LCS_to_bytes not implemented
+ 1101 │     assert false; // $LCS_to_bytes not implemented
       │      ^
       │
 
 bug:  This assertion might not hold.
 
-      ┌── transaction_fee.bpl:1116:6 ───
+      ┌── transaction_fee.bpl:1079:6 ───
       │
- 1116 │     assert false; // $LibraAccount_write_to_event_store not implemented
+ 1079 │     assert false; // $LibraAccount_write_to_event_store not implemented
       │      ^
       │
 
 bug:  This assertion might not hold.
 
-      ┌── transaction_fee.bpl:1116:6 ───
+      ┌── transaction_fee.bpl:1079:6 ───
       │
- 1116 │     assert false; // $LibraAccount_write_to_event_store not implemented
+ 1079 │     assert false; // $LibraAccount_write_to_event_store not implemented
       │      ^
       │
 
 bug:  This assertion might not hold.
 
-      ┌── transaction_fee.bpl:1116:6 ───
+      ┌── transaction_fee.bpl:1079:6 ───
       │
- 1116 │     assert false; // $LibraAccount_write_to_event_store not implemented
+ 1079 │     assert false; // $LibraAccount_write_to_event_store not implemented
       │      ^
       │
 
 bug:  This assertion might not hold.
 
-      ┌── transaction_fee.bpl:1116:6 ───
+      ┌── transaction_fee.bpl:1079:6 ───
       │
- 1116 │     assert false; // $LibraAccount_write_to_event_store not implemented
+ 1079 │     assert false; // $LibraAccount_write_to_event_store not implemented
       │      ^
       │
 
 bug:  This assertion might not hold.
 
-      ┌── transaction_fee.bpl:1116:6 ───
+      ┌── transaction_fee.bpl:1079:6 ───
       │
- 1116 │     assert false; // $LibraAccount_write_to_event_store not implemented
+ 1079 │     assert false; // $LibraAccount_write_to_event_store not implemented
       │      ^
       │
 
 bug:  This assertion might not hold.
 
-      ┌── transaction_fee.bpl:1138:6 ───
+      ┌── transaction_fee.bpl:1101:6 ───
       │
- 1138 │     assert false; // $LCS_to_bytes not implemented
+ 1101 │     assert false; // $LCS_to_bytes not implemented
       │      ^
       │
 


### PR DESCRIPTION
This implements a simpler regime for ensuring exclusiveness of top-level reference parameters (those which are passed into a top-level `foo_verify` boogie procedure). For each such parameter, we ensure that the Reference is disjoint from any other reference, based on the following properties:

- A mutable reference is by Move borrow semantics always exclusive from every other reference.
- An immutable reference behaves like a value and that it is a reference is irrelevant, so we can choose an arbitray reference for it (we happen to chose one which is disjoint from others)

Previously, we had a more complicated mechanism to deal with reference aliasing based on the stratified function `$IsValidReferenceParameter`, which is removed in this PR. The previous mechanism was also only preventing aliasing for locals on the stack, not for globals.

The new implementation simply defines a new location type `Param(i: int): Location` which we assign to top-level references, where `i` is the parameter position. We generate code as such:

```
procedure foo_verify(ref1: Reference, ref2: Reference) {
  assume l#Reference(ref1) == Param(0);
  assume size#Path(p#Reference(ref1)) == 0;
  assume l#Reference(ref2) == Param(1);
  assume size#Path(p#Reference(ref2)) == 0;
  call foo(ref1, ref2);
}
```

All existing tests pass, and a new test has been added for the case of aliasing global mut refs.

## Motivation

Fix a bug which was discovered trying to specify MarketCap

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

Passes existing tests, added new test `marketcap.move`.

## Related PRs

NA
