### PR TITLE
[move-prover] Added Boogie model for serialize to prelude.bpl

### DIFF
--- a/language/move-prover/tests/sources/hash_model.move
+++ b/language/move-prover/tests/sources/hash_model.move
@@ -79,8 +79,8 @@ module TestHash {
 
     fun hash_test2_incorrect(v1: vector<u8>, v2: vector<u8>): (vector<u8>, vector<u8>)
     {
-        let h1 = Hash::sha3_256(v1);
-        let h2 = Hash::sha3_256(v2);
+        let h1 = Hash::sha2_256(v1);
+        let h2 = Hash::sha2_256(v2);
         (h1, h2)
     }
     spec fun hash_test2_incorrect {

--- a/language/move-prover/tests/sources/serialize_model.exp
+++ b/language/move-prover/tests/sources/serialize_model.exp
@@ -1,0 +1,30 @@
+Move prover returns: exiting with boogie verification errors
+error:  A postcondition might not hold on this return path.
+
+    ┌── tests/sources/serialize_model.move:31:9 ───
+    │
+ 31 │         ensures result_1 == result_2;
+    │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    │
+    =     at tests/sources/serialize_model.move:23:5: lcs_test1_incorrect (entry)
+    =     at tests/sources/serialize_model.move:25:23: lcs_test1_incorrect
+    =         v1 = <redacted>,
+    =         v2 = <redacted>,
+    =         s1 = <redacted>
+    =     at tests/sources/serialize_model.move:26:32: lcs_test1_incorrect
+    =         s2 = <redacted>
+    =     at tests/sources/serialize_model.move:27:10: lcs_test1_incorrect
+    =     at tests/sources/serialize_model.move:23:5: lcs_test1_incorrect (exit)
+
+error:  A postcondition might not hold on this return path.
+
+    ┌── tests/sources/serialize_model.move:34:9 ───
+    │
+ 34 │         ensures result_1[0] < max_u8();
+    │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    │
+    =     at tests/sources/serialize_model.move:23:5: lcs_test1_incorrect (entry)
+    =     at tests/sources/serialize_model.move:25:23: lcs_test1_incorrect
+    =     at tests/sources/serialize_model.move:26:32: lcs_test1_incorrect
+    =     at tests/sources/serialize_model.move:27:10: lcs_test1_incorrect
+    =     at tests/sources/serialize_model.move:23:5: lcs_test1_incorrect (exit)

--- a/language/move-prover/tests/sources/serialize_model.move
+++ b/language/move-prover/tests/sources/serialize_model.move
@@ -1,0 +1,37 @@
+// dep: tests/sources/stdlib/modules/lcs.move
+
+module TestLCS {
+
+    use 0x0::LCS;
+
+    fun lcs_test1<Thing>(v1: &Thing, v2: &Thing): (vector<u8>, vector<u8>)
+    {
+        let s1 = LCS::to_bytes(v1);
+        let s2 = LCS::to_bytes(v2);
+        (s1, s2)
+    }
+    spec fun lcs_test1 {
+        aborts_if false;
+        ensures result_1 == result_2 ==> v1 == v2;
+        ensures v1 == v2 ==> result_1 == result_2;
+        // it knows result is vector<u8>
+        ensures len(result_1) > 0 ==> result_1[0] <= max_u8();
+    }
+
+    // serialize tests
+
+    fun lcs_test1_incorrect<Thing>(v1: &Thing, v2: &Thing): (vector<u8>, vector<u8>)
+    {
+        let s1 = LCS::to_bytes(v1);
+        let s2 = LCS::to_bytes(v2);
+        (s1, s2)
+    }
+    spec fun lcs_test1_incorrect {
+        aborts_if false;
+        ensures result_1 == result_2;
+        ensures len(result_1) > 0;
+        // it knows result is vector<u8>
+        ensures result_1[0] < max_u8();
+    }
+
+}

--- a/language/move-prover/tests/sources/stdlib/modules/approved_payment.exp
+++ b/language/move-prover/tests/sources/stdlib/modules/approved_payment.exp
@@ -1,136 +1,112 @@
 Move prover returns: exiting with boogie verification errors
 bug:  This assertion might not hold.
 
-      ┌── approved_payment.bpl:1079:6 ───
+      ┌── approved_payment.bpl:1054:6 ───
       │
- 1079 │     assert false; // $LibraAccount_write_to_event_store not implemented
+ 1054 │     assert false; // $LibraAccount_write_to_event_store not implemented
       │      ^
       │
 
 bug:  This assertion might not hold.
 
-      ┌── approved_payment.bpl:1079:6 ───
+      ┌── approved_payment.bpl:1054:6 ───
       │
- 1079 │     assert false; // $LibraAccount_write_to_event_store not implemented
+ 1054 │     assert false; // $LibraAccount_write_to_event_store not implemented
       │      ^
       │
 
 bug:  This assertion might not hold.
 
-      ┌── approved_payment.bpl:1101:6 ───
+      ┌── approved_payment.bpl:1050:6 ───
       │
- 1101 │     assert false; // $LCS_to_bytes not implemented
+ 1050 │     assert false; // $LibraAccount_save_account not implemented
       │      ^
       │
 
 bug:  This assertion might not hold.
 
-      ┌── approved_payment.bpl:1101:6 ───
+      ┌── approved_payment.bpl:1050:6 ───
       │
- 1101 │     assert false; // $LCS_to_bytes not implemented
+ 1050 │     assert false; // $LibraAccount_save_account not implemented
       │      ^
       │
 
 bug:  This assertion might not hold.
 
-      ┌── approved_payment.bpl:1079:6 ───
+      ┌── approved_payment.bpl:1054:6 ───
       │
- 1079 │     assert false; // $LibraAccount_write_to_event_store not implemented
+ 1054 │     assert false; // $LibraAccount_write_to_event_store not implemented
       │      ^
       │
 
 bug:  This assertion might not hold.
 
-      ┌── approved_payment.bpl:1079:6 ───
+      ┌── approved_payment.bpl:1054:6 ───
       │
- 1079 │     assert false; // $LibraAccount_write_to_event_store not implemented
+ 1054 │     assert false; // $LibraAccount_write_to_event_store not implemented
       │      ^
       │
 
 bug:  This assertion might not hold.
 
-      ┌── approved_payment.bpl:1079:6 ───
+      ┌── approved_payment.bpl:1054:6 ───
       │
- 1079 │     assert false; // $LibraAccount_write_to_event_store not implemented
+ 1054 │     assert false; // $LibraAccount_write_to_event_store not implemented
       │      ^
       │
 
 bug:  This assertion might not hold.
 
-      ┌── approved_payment.bpl:1079:6 ───
+      ┌── approved_payment.bpl:1054:6 ───
       │
- 1079 │     assert false; // $LibraAccount_write_to_event_store not implemented
+ 1054 │     assert false; // $LibraAccount_write_to_event_store not implemented
       │      ^
       │
 
 bug:  This assertion might not hold.
 
-      ┌── approved_payment.bpl:1101:6 ───
+      ┌── approved_payment.bpl:1050:6 ───
       │
- 1101 │     assert false; // $LCS_to_bytes not implemented
+ 1050 │     assert false; // $LibraAccount_save_account not implemented
       │      ^
       │
 
 bug:  This assertion might not hold.
 
-      ┌── approved_payment.bpl:1079:6 ───
+      ┌── approved_payment.bpl:1050:6 ───
       │
- 1079 │     assert false; // $LibraAccount_write_to_event_store not implemented
+ 1050 │     assert false; // $LibraAccount_save_account not implemented
       │      ^
       │
 
 bug:  This assertion might not hold.
 
-      ┌── approved_payment.bpl:1101:6 ───
+      ┌── approved_payment.bpl:1050:6 ───
       │
- 1101 │     assert false; // $LCS_to_bytes not implemented
+ 1050 │     assert false; // $LibraAccount_save_account not implemented
       │      ^
       │
 
 bug:  This assertion might not hold.
 
-      ┌── approved_payment.bpl:1101:6 ───
+      ┌── approved_payment.bpl:1050:6 ───
       │
- 1101 │     assert false; // $LCS_to_bytes not implemented
+ 1050 │     assert false; // $LibraAccount_save_account not implemented
       │      ^
       │
 
 bug:  This assertion might not hold.
 
-      ┌── approved_payment.bpl:1079:6 ───
+      ┌── approved_payment.bpl:1063:6 ───
       │
- 1079 │     assert false; // $LibraAccount_write_to_event_store not implemented
+ 1063 │     assert false; // $Signature_ed25519_verify not implemented
       │      ^
       │
 
 bug:  This assertion might not hold.
 
-      ┌── approved_payment.bpl:1079:6 ───
+      ┌── approved_payment.bpl:1063:6 ───
       │
- 1079 │     assert false; // $LibraAccount_write_to_event_store not implemented
-      │      ^
-      │
-
-bug:  This assertion might not hold.
-
-      ┌── approved_payment.bpl:1079:6 ───
-      │
- 1079 │     assert false; // $LibraAccount_write_to_event_store not implemented
-      │      ^
-      │
-
-bug:  This assertion might not hold.
-
-      ┌── approved_payment.bpl:1088:6 ───
-      │
- 1088 │     assert false; // $Signature_ed25519_verify not implemented
-      │      ^
-      │
-
-bug:  This assertion might not hold.
-
-      ┌── approved_payment.bpl:1088:6 ───
-      │
- 1088 │     assert false; // $Signature_ed25519_verify not implemented
+ 1063 │     assert false; // $Signature_ed25519_verify not implemented
       │      ^
       │

--- a/language/move-prover/tests/sources/stdlib/modules/libra_account.exp
+++ b/language/move-prover/tests/sources/stdlib/modules/libra_account.exp
@@ -1,128 +1,104 @@
 Move prover returns: exiting with boogie verification errors
 bug:  This assertion might not hold.
 
-      ┌── libra_account.bpl:1079:6 ───
+      ┌── libra_account.bpl:1054:6 ───
       │
- 1079 │     assert false; // $LibraAccount_write_to_event_store not implemented
+ 1054 │     assert false; // $LibraAccount_write_to_event_store not implemented
       │      ^
       │
 
 bug:  This assertion might not hold.
 
-      ┌── libra_account.bpl:1079:6 ───
+      ┌── libra_account.bpl:1054:6 ───
       │
- 1079 │     assert false; // $LibraAccount_write_to_event_store not implemented
+ 1054 │     assert false; // $LibraAccount_write_to_event_store not implemented
       │      ^
       │
 
 bug:  This assertion might not hold.
 
-      ┌── libra_account.bpl:1101:6 ───
+      ┌── libra_account.bpl:1050:6 ───
       │
- 1101 │     assert false; // $LCS_to_bytes not implemented
+ 1050 │     assert false; // $LibraAccount_save_account not implemented
       │      ^
       │
 
 bug:  This assertion might not hold.
 
-      ┌── libra_account.bpl:1101:6 ───
+      ┌── libra_account.bpl:1050:6 ───
       │
- 1101 │     assert false; // $LCS_to_bytes not implemented
+ 1050 │     assert false; // $LibraAccount_save_account not implemented
       │      ^
       │
 
 bug:  This assertion might not hold.
 
-      ┌── libra_account.bpl:1079:6 ───
+      ┌── libra_account.bpl:1054:6 ───
       │
- 1079 │     assert false; // $LibraAccount_write_to_event_store not implemented
+ 1054 │     assert false; // $LibraAccount_write_to_event_store not implemented
       │      ^
       │
 
 bug:  This assertion might not hold.
 
-      ┌── libra_account.bpl:1079:6 ───
+      ┌── libra_account.bpl:1054:6 ───
       │
- 1079 │     assert false; // $LibraAccount_write_to_event_store not implemented
+ 1054 │     assert false; // $LibraAccount_write_to_event_store not implemented
       │      ^
       │
 
 bug:  This assertion might not hold.
 
-      ┌── libra_account.bpl:1079:6 ───
+      ┌── libra_account.bpl:1054:6 ───
       │
- 1079 │     assert false; // $LibraAccount_write_to_event_store not implemented
+ 1054 │     assert false; // $LibraAccount_write_to_event_store not implemented
       │      ^
       │
 
 bug:  This assertion might not hold.
 
-      ┌── libra_account.bpl:1079:6 ───
+      ┌── libra_account.bpl:1054:6 ───
       │
- 1079 │     assert false; // $LibraAccount_write_to_event_store not implemented
+ 1054 │     assert false; // $LibraAccount_write_to_event_store not implemented
       │      ^
       │
 
 bug:  This assertion might not hold.
 
-      ┌── libra_account.bpl:1101:6 ───
+      ┌── libra_account.bpl:1050:6 ───
       │
- 1101 │     assert false; // $LCS_to_bytes not implemented
+ 1050 │     assert false; // $LibraAccount_save_account not implemented
       │      ^
       │
 
 bug:  This assertion might not hold.
 
-      ┌── libra_account.bpl:1079:6 ───
+      ┌── libra_account.bpl:1050:6 ───
       │
- 1079 │     assert false; // $LibraAccount_write_to_event_store not implemented
+ 1050 │     assert false; // $LibraAccount_save_account not implemented
       │      ^
       │
 
 bug:  This assertion might not hold.
 
-      ┌── libra_account.bpl:1101:6 ───
+      ┌── libra_account.bpl:1050:6 ───
       │
- 1101 │     assert false; // $LCS_to_bytes not implemented
+ 1050 │     assert false; // $LibraAccount_save_account not implemented
       │      ^
       │
 
 bug:  This assertion might not hold.
 
-      ┌── libra_account.bpl:1101:6 ───
+      ┌── libra_account.bpl:1050:6 ───
       │
- 1101 │     assert false; // $LCS_to_bytes not implemented
+ 1050 │     assert false; // $LibraAccount_save_account not implemented
       │      ^
       │
 
 bug:  This assertion might not hold.
 
-      ┌── libra_account.bpl:1079:6 ───
+      ┌── libra_account.bpl:1054:6 ───
       │
- 1079 │     assert false; // $LibraAccount_write_to_event_store not implemented
-      │      ^
-      │
-
-bug:  This assertion might not hold.
-
-      ┌── libra_account.bpl:1079:6 ───
-      │
- 1079 │     assert false; // $LibraAccount_write_to_event_store not implemented
-      │      ^
-      │
-
-bug:  This assertion might not hold.
-
-      ┌── libra_account.bpl:1079:6 ───
-      │
- 1079 │     assert false; // $LibraAccount_write_to_event_store not implemented
-      │      ^
-      │
-
-bug:  This assertion might not hold.
-
-      ┌── libra_account.bpl:1101:6 ───
-      │
- 1101 │     assert false; // $LCS_to_bytes not implemented
+ 1054 │     assert false; // $LibraAccount_write_to_event_store not implemented
       │      ^
       │

--- a/language/move-prover/tests/sources/stdlib/modules/libra_block.exp
+++ b/language/move-prover/tests/sources/stdlib/modules/libra_block.exp
@@ -1,153 +1,129 @@
 Move prover returns: exiting with boogie verification errors
 bug:  This assertion might not hold.
 
-      ┌── libra_block.bpl:1079:6 ───
+      ┌── libra_block.bpl:1054:6 ───
       │
- 1079 │     assert false; // $LibraAccount_write_to_event_store not implemented
+ 1054 │     assert false; // $LibraAccount_write_to_event_store not implemented
       │      ^
       │
 
 bug:  This assertion might not hold.
 
-      ┌── libra_block.bpl:1079:6 ───
+      ┌── libra_block.bpl:1054:6 ───
       │
- 1079 │     assert false; // $LibraAccount_write_to_event_store not implemented
+ 1054 │     assert false; // $LibraAccount_write_to_event_store not implemented
       │      ^
       │
 
 bug:  This assertion might not hold.
 
-      ┌── libra_block.bpl:1101:6 ───
+      ┌── libra_block.bpl:1050:6 ───
       │
- 1101 │     assert false; // $LCS_to_bytes not implemented
+ 1050 │     assert false; // $LibraAccount_save_account not implemented
       │      ^
       │
 
 bug:  This assertion might not hold.
 
-      ┌── libra_block.bpl:1101:6 ───
+      ┌── libra_block.bpl:1050:6 ───
       │
- 1101 │     assert false; // $LCS_to_bytes not implemented
+ 1050 │     assert false; // $LibraAccount_save_account not implemented
       │      ^
       │
 
 bug:  This assertion might not hold.
 
-      ┌── libra_block.bpl:1079:6 ───
+      ┌── libra_block.bpl:1054:6 ───
       │
- 1079 │     assert false; // $LibraAccount_write_to_event_store not implemented
+ 1054 │     assert false; // $LibraAccount_write_to_event_store not implemented
       │      ^
       │
 
 bug:  This assertion might not hold.
 
-      ┌── libra_block.bpl:1079:6 ───
+      ┌── libra_block.bpl:1054:6 ───
       │
- 1079 │     assert false; // $LibraAccount_write_to_event_store not implemented
+ 1054 │     assert false; // $LibraAccount_write_to_event_store not implemented
       │      ^
       │
 
 bug:  This assertion might not hold.
 
-      ┌── libra_block.bpl:1079:6 ───
+      ┌── libra_block.bpl:1054:6 ───
       │
- 1079 │     assert false; // $LibraAccount_write_to_event_store not implemented
+ 1054 │     assert false; // $LibraAccount_write_to_event_store not implemented
       │      ^
       │
 
 bug:  This assertion might not hold.
 
-      ┌── libra_block.bpl:1079:6 ───
+      ┌── libra_block.bpl:1054:6 ───
       │
- 1079 │     assert false; // $LibraAccount_write_to_event_store not implemented
+ 1054 │     assert false; // $LibraAccount_write_to_event_store not implemented
       │      ^
       │
 
 bug:  This assertion might not hold.
 
-      ┌── libra_block.bpl:1101:6 ───
+      ┌── libra_block.bpl:1050:6 ───
       │
- 1101 │     assert false; // $LCS_to_bytes not implemented
+ 1050 │     assert false; // $LibraAccount_save_account not implemented
       │      ^
       │
 
 bug:  This assertion might not hold.
 
-      ┌── libra_block.bpl:1079:6 ───
+      ┌── libra_block.bpl:1050:6 ───
       │
- 1079 │     assert false; // $LibraAccount_write_to_event_store not implemented
+ 1050 │     assert false; // $LibraAccount_save_account not implemented
       │      ^
       │
 
 bug:  This assertion might not hold.
 
-      ┌── libra_block.bpl:1101:6 ───
+      ┌── libra_block.bpl:1050:6 ───
       │
- 1101 │     assert false; // $LCS_to_bytes not implemented
+ 1050 │     assert false; // $LibraAccount_save_account not implemented
       │      ^
       │
 
 bug:  This assertion might not hold.
 
-      ┌── libra_block.bpl:1101:6 ───
+      ┌── libra_block.bpl:1050:6 ───
       │
- 1101 │     assert false; // $LCS_to_bytes not implemented
+ 1050 │     assert false; // $LibraAccount_save_account not implemented
       │      ^
       │
 
 bug:  This assertion might not hold.
 
-      ┌── libra_block.bpl:1079:6 ───
+      ┌── libra_block.bpl:1054:6 ───
       │
- 1079 │     assert false; // $LibraAccount_write_to_event_store not implemented
+ 1054 │     assert false; // $LibraAccount_write_to_event_store not implemented
       │      ^
       │
 
 bug:  This assertion might not hold.
 
-      ┌── libra_block.bpl:1079:6 ───
+      ┌── libra_block.bpl:1054:6 ───
       │
- 1079 │     assert false; // $LibraAccount_write_to_event_store not implemented
+ 1054 │     assert false; // $LibraAccount_write_to_event_store not implemented
       │      ^
       │
 
 bug:  This assertion might not hold.
 
-      ┌── libra_block.bpl:1079:6 ───
+      ┌── libra_block.bpl:1054:6 ───
       │
- 1079 │     assert false; // $LibraAccount_write_to_event_store not implemented
+ 1054 │     assert false; // $LibraAccount_write_to_event_store not implemented
       │      ^
       │
 
 bug:  This assertion might not hold.
 
-      ┌── libra_block.bpl:1079:6 ───
+      ┌── libra_block.bpl:1054:6 ───
       │
- 1079 │     assert false; // $LibraAccount_write_to_event_store not implemented
-      │      ^
-      │
-
-bug:  This assertion might not hold.
-
-      ┌── libra_block.bpl:1079:6 ───
-      │
- 1079 │     assert false; // $LibraAccount_write_to_event_store not implemented
-      │      ^
-      │
-
-bug:  This assertion might not hold.
-
-      ┌── libra_block.bpl:1079:6 ───
-      │
- 1079 │     assert false; // $LibraAccount_write_to_event_store not implemented
-      │      ^
-      │
-
-bug:  This assertion might not hold.
-
-      ┌── libra_block.bpl:1079:6 ───
-      │
- 1079 │     assert false; // $LibraAccount_write_to_event_store not implemented
+ 1054 │     assert false; // $LibraAccount_write_to_event_store not implemented
       │      ^
       │
 
@@ -198,17 +174,17 @@ error:  A precondition for this call might not hold.
 
 bug:  This assertion might not hold.
 
-      ┌── libra_block.bpl:1079:6 ───
+      ┌── libra_block.bpl:1054:6 ───
       │
- 1079 │     assert false; // $LibraAccount_write_to_event_store not implemented
+ 1054 │     assert false; // $LibraAccount_write_to_event_store not implemented
       │      ^
       │
 
 bug:  This assertion might not hold.
 
-      ┌── libra_block.bpl:1079:6 ───
+      ┌── libra_block.bpl:1054:6 ───
       │
- 1079 │     assert false; // $LibraAccount_write_to_event_store not implemented
+ 1054 │     assert false; // $LibraAccount_write_to_event_store not implemented
       │      ^
       │
 
@@ -252,81 +228,57 @@ error:  A precondition for this call might not hold.
 
 bug:  This assertion might not hold.
 
-      ┌── libra_block.bpl:1101:6 ───
+      ┌── libra_block.bpl:1054:6 ───
       │
- 1101 │     assert false; // $LCS_to_bytes not implemented
+ 1054 │     assert false; // $LibraAccount_write_to_event_store not implemented
       │      ^
       │
 
 bug:  This assertion might not hold.
 
-      ┌── libra_block.bpl:1101:6 ───
+      ┌── libra_block.bpl:1054:6 ───
       │
- 1101 │     assert false; // $LCS_to_bytes not implemented
+ 1054 │     assert false; // $LibraAccount_write_to_event_store not implemented
       │      ^
       │
 
 bug:  This assertion might not hold.
 
-      ┌── libra_block.bpl:1079:6 ───
+      ┌── libra_block.bpl:1054:6 ───
       │
- 1079 │     assert false; // $LibraAccount_write_to_event_store not implemented
+ 1054 │     assert false; // $LibraAccount_write_to_event_store not implemented
       │      ^
       │
 
 bug:  This assertion might not hold.
 
-      ┌── libra_block.bpl:1079:6 ───
+      ┌── libra_block.bpl:1050:6 ───
       │
- 1079 │     assert false; // $LibraAccount_write_to_event_store not implemented
+ 1050 │     assert false; // $LibraAccount_save_account not implemented
       │      ^
       │
 
 bug:  This assertion might not hold.
 
-      ┌── libra_block.bpl:1079:6 ───
+      ┌── libra_block.bpl:1050:6 ───
       │
- 1079 │     assert false; // $LibraAccount_write_to_event_store not implemented
+ 1050 │     assert false; // $LibraAccount_save_account not implemented
       │      ^
       │
 
 bug:  This assertion might not hold.
 
-      ┌── libra_block.bpl:1079:6 ───
+      ┌── libra_block.bpl:1054:6 ───
       │
- 1079 │     assert false; // $LibraAccount_write_to_event_store not implemented
+ 1054 │     assert false; // $LibraAccount_write_to_event_store not implemented
       │      ^
       │
 
 bug:  This assertion might not hold.
 
-      ┌── libra_block.bpl:1079:6 ───
+      ┌── libra_block.bpl:1054:6 ───
       │
- 1079 │     assert false; // $LibraAccount_write_to_event_store not implemented
-      │      ^
-      │
-
-bug:  This assertion might not hold.
-
-      ┌── libra_block.bpl:1079:6 ───
-      │
- 1079 │     assert false; // $LibraAccount_write_to_event_store not implemented
-      │      ^
-      │
-
-bug:  This assertion might not hold.
-
-      ┌── libra_block.bpl:1101:6 ───
-      │
- 1101 │     assert false; // $LCS_to_bytes not implemented
-      │      ^
-      │
-
-bug:  This assertion might not hold.
-
-      ┌── libra_block.bpl:1079:6 ───
-      │
- 1079 │     assert false; // $LibraAccount_write_to_event_store not implemented
+ 1054 │     assert false; // $LibraAccount_write_to_event_store not implemented
       │      ^
       │
 

--- a/language/move-prover/tests/sources/stdlib/modules/libra_configs.exp
+++ b/language/move-prover/tests/sources/stdlib/modules/libra_configs.exp
@@ -1,153 +1,129 @@
 Move prover returns: exiting with boogie verification errors
 bug:  This assertion might not hold.
 
-      ┌── libra_configs.bpl:1079:6 ───
+      ┌── libra_configs.bpl:1054:6 ───
       │
- 1079 │     assert false; // $LibraAccount_write_to_event_store not implemented
+ 1054 │     assert false; // $LibraAccount_write_to_event_store not implemented
       │      ^
       │
 
 bug:  This assertion might not hold.
 
-      ┌── libra_configs.bpl:1079:6 ───
+      ┌── libra_configs.bpl:1054:6 ───
       │
- 1079 │     assert false; // $LibraAccount_write_to_event_store not implemented
+ 1054 │     assert false; // $LibraAccount_write_to_event_store not implemented
       │      ^
       │
 
 bug:  This assertion might not hold.
 
-      ┌── libra_configs.bpl:1101:6 ───
+      ┌── libra_configs.bpl:1050:6 ───
       │
- 1101 │     assert false; // $LCS_to_bytes not implemented
+ 1050 │     assert false; // $LibraAccount_save_account not implemented
       │      ^
       │
 
 bug:  This assertion might not hold.
 
-      ┌── libra_configs.bpl:1101:6 ───
+      ┌── libra_configs.bpl:1050:6 ───
       │
- 1101 │     assert false; // $LCS_to_bytes not implemented
+ 1050 │     assert false; // $LibraAccount_save_account not implemented
       │      ^
       │
 
 bug:  This assertion might not hold.
 
-      ┌── libra_configs.bpl:1079:6 ───
+      ┌── libra_configs.bpl:1054:6 ───
       │
- 1079 │     assert false; // $LibraAccount_write_to_event_store not implemented
+ 1054 │     assert false; // $LibraAccount_write_to_event_store not implemented
       │      ^
       │
 
 bug:  This assertion might not hold.
 
-      ┌── libra_configs.bpl:1079:6 ───
+      ┌── libra_configs.bpl:1054:6 ───
       │
- 1079 │     assert false; // $LibraAccount_write_to_event_store not implemented
+ 1054 │     assert false; // $LibraAccount_write_to_event_store not implemented
       │      ^
       │
 
 bug:  This assertion might not hold.
 
-      ┌── libra_configs.bpl:1079:6 ───
+      ┌── libra_configs.bpl:1054:6 ───
       │
- 1079 │     assert false; // $LibraAccount_write_to_event_store not implemented
+ 1054 │     assert false; // $LibraAccount_write_to_event_store not implemented
       │      ^
       │
 
 bug:  This assertion might not hold.
 
-      ┌── libra_configs.bpl:1079:6 ───
+      ┌── libra_configs.bpl:1054:6 ───
       │
- 1079 │     assert false; // $LibraAccount_write_to_event_store not implemented
+ 1054 │     assert false; // $LibraAccount_write_to_event_store not implemented
       │      ^
       │
 
 bug:  This assertion might not hold.
 
-      ┌── libra_configs.bpl:1101:6 ───
+      ┌── libra_configs.bpl:1050:6 ───
       │
- 1101 │     assert false; // $LCS_to_bytes not implemented
+ 1050 │     assert false; // $LibraAccount_save_account not implemented
       │      ^
       │
 
 bug:  This assertion might not hold.
 
-      ┌── libra_configs.bpl:1079:6 ───
+      ┌── libra_configs.bpl:1050:6 ───
       │
- 1079 │     assert false; // $LibraAccount_write_to_event_store not implemented
+ 1050 │     assert false; // $LibraAccount_save_account not implemented
       │      ^
       │
 
 bug:  This assertion might not hold.
 
-      ┌── libra_configs.bpl:1101:6 ───
+      ┌── libra_configs.bpl:1050:6 ───
       │
- 1101 │     assert false; // $LCS_to_bytes not implemented
+ 1050 │     assert false; // $LibraAccount_save_account not implemented
       │      ^
       │
 
 bug:  This assertion might not hold.
 
-      ┌── libra_configs.bpl:1101:6 ───
+      ┌── libra_configs.bpl:1050:6 ───
       │
- 1101 │     assert false; // $LCS_to_bytes not implemented
+ 1050 │     assert false; // $LibraAccount_save_account not implemented
       │      ^
       │
 
 bug:  This assertion might not hold.
 
-      ┌── libra_configs.bpl:1079:6 ───
+      ┌── libra_configs.bpl:1054:6 ───
       │
- 1079 │     assert false; // $LibraAccount_write_to_event_store not implemented
+ 1054 │     assert false; // $LibraAccount_write_to_event_store not implemented
       │      ^
       │
 
 bug:  This assertion might not hold.
 
-      ┌── libra_configs.bpl:1079:6 ───
+      ┌── libra_configs.bpl:1054:6 ───
       │
- 1079 │     assert false; // $LibraAccount_write_to_event_store not implemented
+ 1054 │     assert false; // $LibraAccount_write_to_event_store not implemented
       │      ^
       │
 
 bug:  This assertion might not hold.
 
-      ┌── libra_configs.bpl:1079:6 ───
+      ┌── libra_configs.bpl:1054:6 ───
       │
- 1079 │     assert false; // $LibraAccount_write_to_event_store not implemented
+ 1054 │     assert false; // $LibraAccount_write_to_event_store not implemented
       │      ^
       │
 
 bug:  This assertion might not hold.
 
-      ┌── libra_configs.bpl:1079:6 ───
+      ┌── libra_configs.bpl:1054:6 ───
       │
- 1079 │     assert false; // $LibraAccount_write_to_event_store not implemented
-      │      ^
-      │
-
-bug:  This assertion might not hold.
-
-      ┌── libra_configs.bpl:1079:6 ───
-      │
- 1079 │     assert false; // $LibraAccount_write_to_event_store not implemented
-      │      ^
-      │
-
-bug:  This assertion might not hold.
-
-      ┌── libra_configs.bpl:1079:6 ───
-      │
- 1079 │     assert false; // $LibraAccount_write_to_event_store not implemented
-      │      ^
-      │
-
-bug:  This assertion might not hold.
-
-      ┌── libra_configs.bpl:1079:6 ───
-      │
- 1079 │     assert false; // $LibraAccount_write_to_event_store not implemented
+ 1054 │     assert false; // $LibraAccount_write_to_event_store not implemented
       │      ^
       │
 
@@ -198,17 +174,17 @@ error:  A precondition for this call might not hold.
 
 bug:  This assertion might not hold.
 
-      ┌── libra_configs.bpl:1079:6 ───
+      ┌── libra_configs.bpl:1054:6 ───
       │
- 1079 │     assert false; // $LibraAccount_write_to_event_store not implemented
+ 1054 │     assert false; // $LibraAccount_write_to_event_store not implemented
       │      ^
       │
 
 bug:  This assertion might not hold.
 
-      ┌── libra_configs.bpl:1079:6 ───
+      ┌── libra_configs.bpl:1054:6 ───
       │
- 1079 │     assert false; // $LibraAccount_write_to_event_store not implemented
+ 1054 │     assert false; // $LibraAccount_write_to_event_store not implemented
       │      ^
       │
 
@@ -252,56 +228,40 @@ error:  A precondition for this call might not hold.
 
 bug:  This assertion might not hold.
 
-      ┌── libra_configs.bpl:1101:6 ───
+      ┌── libra_configs.bpl:1054:6 ───
       │
- 1101 │     assert false; // $LCS_to_bytes not implemented
+ 1054 │     assert false; // $LibraAccount_write_to_event_store not implemented
       │      ^
       │
 
 bug:  This assertion might not hold.
 
-      ┌── libra_configs.bpl:1101:6 ───
+      ┌── libra_configs.bpl:1054:6 ───
       │
- 1101 │     assert false; // $LCS_to_bytes not implemented
+ 1054 │     assert false; // $LibraAccount_write_to_event_store not implemented
       │      ^
       │
 
 bug:  This assertion might not hold.
 
-      ┌── libra_configs.bpl:1079:6 ───
+      ┌── libra_configs.bpl:1054:6 ───
       │
- 1079 │     assert false; // $LibraAccount_write_to_event_store not implemented
+ 1054 │     assert false; // $LibraAccount_write_to_event_store not implemented
       │      ^
       │
 
 bug:  This assertion might not hold.
 
-      ┌── libra_configs.bpl:1079:6 ───
+      ┌── libra_configs.bpl:1054:6 ───
       │
- 1079 │     assert false; // $LibraAccount_write_to_event_store not implemented
+ 1054 │     assert false; // $LibraAccount_write_to_event_store not implemented
       │      ^
       │
 
 bug:  This assertion might not hold.
 
-      ┌── libra_configs.bpl:1079:6 ───
+      ┌── libra_configs.bpl:1054:6 ───
       │
- 1079 │     assert false; // $LibraAccount_write_to_event_store not implemented
-      │      ^
-      │
-
-bug:  This assertion might not hold.
-
-      ┌── libra_configs.bpl:1079:6 ───
-      │
- 1079 │     assert false; // $LibraAccount_write_to_event_store not implemented
-      │      ^
-      │
-
-bug:  This assertion might not hold.
-
-      ┌── libra_configs.bpl:1079:6 ───
-      │
- 1079 │     assert false; // $LibraAccount_write_to_event_store not implemented
+ 1054 │     assert false; // $LibraAccount_write_to_event_store not implemented
       │      ^
       │

--- a/language/move-prover/tests/sources/stdlib/modules/libra_system.exp
+++ b/language/move-prover/tests/sources/stdlib/modules/libra_system.exp
@@ -1,153 +1,129 @@
 Move prover returns: exiting with boogie verification errors
 bug:  This assertion might not hold.
 
-      ┌── libra_system.bpl:1079:6 ───
+      ┌── libra_system.bpl:1054:6 ───
       │
- 1079 │     assert false; // $LibraAccount_write_to_event_store not implemented
+ 1054 │     assert false; // $LibraAccount_write_to_event_store not implemented
       │      ^
       │
 
 bug:  This assertion might not hold.
 
-      ┌── libra_system.bpl:1079:6 ───
+      ┌── libra_system.bpl:1054:6 ───
       │
- 1079 │     assert false; // $LibraAccount_write_to_event_store not implemented
+ 1054 │     assert false; // $LibraAccount_write_to_event_store not implemented
       │      ^
       │
 
 bug:  This assertion might not hold.
 
-      ┌── libra_system.bpl:1101:6 ───
+      ┌── libra_system.bpl:1050:6 ───
       │
- 1101 │     assert false; // $LCS_to_bytes not implemented
+ 1050 │     assert false; // $LibraAccount_save_account not implemented
       │      ^
       │
 
 bug:  This assertion might not hold.
 
-      ┌── libra_system.bpl:1101:6 ───
+      ┌── libra_system.bpl:1050:6 ───
       │
- 1101 │     assert false; // $LCS_to_bytes not implemented
+ 1050 │     assert false; // $LibraAccount_save_account not implemented
       │      ^
       │
 
 bug:  This assertion might not hold.
 
-      ┌── libra_system.bpl:1079:6 ───
+      ┌── libra_system.bpl:1054:6 ───
       │
- 1079 │     assert false; // $LibraAccount_write_to_event_store not implemented
+ 1054 │     assert false; // $LibraAccount_write_to_event_store not implemented
       │      ^
       │
 
 bug:  This assertion might not hold.
 
-      ┌── libra_system.bpl:1079:6 ───
+      ┌── libra_system.bpl:1054:6 ───
       │
- 1079 │     assert false; // $LibraAccount_write_to_event_store not implemented
+ 1054 │     assert false; // $LibraAccount_write_to_event_store not implemented
       │      ^
       │
 
 bug:  This assertion might not hold.
 
-      ┌── libra_system.bpl:1079:6 ───
+      ┌── libra_system.bpl:1054:6 ───
       │
- 1079 │     assert false; // $LibraAccount_write_to_event_store not implemented
+ 1054 │     assert false; // $LibraAccount_write_to_event_store not implemented
       │      ^
       │
 
 bug:  This assertion might not hold.
 
-      ┌── libra_system.bpl:1079:6 ───
+      ┌── libra_system.bpl:1054:6 ───
       │
- 1079 │     assert false; // $LibraAccount_write_to_event_store not implemented
+ 1054 │     assert false; // $LibraAccount_write_to_event_store not implemented
       │      ^
       │
 
 bug:  This assertion might not hold.
 
-      ┌── libra_system.bpl:1101:6 ───
+      ┌── libra_system.bpl:1050:6 ───
       │
- 1101 │     assert false; // $LCS_to_bytes not implemented
+ 1050 │     assert false; // $LibraAccount_save_account not implemented
       │      ^
       │
 
 bug:  This assertion might not hold.
 
-      ┌── libra_system.bpl:1079:6 ───
+      ┌── libra_system.bpl:1050:6 ───
       │
- 1079 │     assert false; // $LibraAccount_write_to_event_store not implemented
+ 1050 │     assert false; // $LibraAccount_save_account not implemented
       │      ^
       │
 
 bug:  This assertion might not hold.
 
-      ┌── libra_system.bpl:1101:6 ───
+      ┌── libra_system.bpl:1050:6 ───
       │
- 1101 │     assert false; // $LCS_to_bytes not implemented
+ 1050 │     assert false; // $LibraAccount_save_account not implemented
       │      ^
       │
 
 bug:  This assertion might not hold.
 
-      ┌── libra_system.bpl:1101:6 ───
+      ┌── libra_system.bpl:1050:6 ───
       │
- 1101 │     assert false; // $LCS_to_bytes not implemented
+ 1050 │     assert false; // $LibraAccount_save_account not implemented
       │      ^
       │
 
 bug:  This assertion might not hold.
 
-      ┌── libra_system.bpl:1079:6 ───
+      ┌── libra_system.bpl:1054:6 ───
       │
- 1079 │     assert false; // $LibraAccount_write_to_event_store not implemented
+ 1054 │     assert false; // $LibraAccount_write_to_event_store not implemented
       │      ^
       │
 
 bug:  This assertion might not hold.
 
-      ┌── libra_system.bpl:1079:6 ───
+      ┌── libra_system.bpl:1054:6 ───
       │
- 1079 │     assert false; // $LibraAccount_write_to_event_store not implemented
+ 1054 │     assert false; // $LibraAccount_write_to_event_store not implemented
       │      ^
       │
 
 bug:  This assertion might not hold.
 
-      ┌── libra_system.bpl:1079:6 ───
+      ┌── libra_system.bpl:1054:6 ───
       │
- 1079 │     assert false; // $LibraAccount_write_to_event_store not implemented
+ 1054 │     assert false; // $LibraAccount_write_to_event_store not implemented
       │      ^
       │
 
 bug:  This assertion might not hold.
 
-      ┌── libra_system.bpl:1079:6 ───
+      ┌── libra_system.bpl:1054:6 ───
       │
- 1079 │     assert false; // $LibraAccount_write_to_event_store not implemented
-      │      ^
-      │
-
-bug:  This assertion might not hold.
-
-      ┌── libra_system.bpl:1079:6 ───
-      │
- 1079 │     assert false; // $LibraAccount_write_to_event_store not implemented
-      │      ^
-      │
-
-bug:  This assertion might not hold.
-
-      ┌── libra_system.bpl:1079:6 ───
-      │
- 1079 │     assert false; // $LibraAccount_write_to_event_store not implemented
-      │      ^
-      │
-
-bug:  This assertion might not hold.
-
-      ┌── libra_system.bpl:1079:6 ───
-      │
- 1079 │     assert false; // $LibraAccount_write_to_event_store not implemented
+ 1054 │     assert false; // $LibraAccount_write_to_event_store not implemented
       │      ^
       │
 
@@ -198,17 +174,17 @@ error:  A precondition for this call might not hold.
 
 bug:  This assertion might not hold.
 
-      ┌── libra_system.bpl:1079:6 ───
+      ┌── libra_system.bpl:1054:6 ───
       │
- 1079 │     assert false; // $LibraAccount_write_to_event_store not implemented
+ 1054 │     assert false; // $LibraAccount_write_to_event_store not implemented
       │      ^
       │
 
 bug:  This assertion might not hold.
 
-      ┌── libra_system.bpl:1079:6 ───
+      ┌── libra_system.bpl:1054:6 ───
       │
- 1079 │     assert false; // $LibraAccount_write_to_event_store not implemented
+ 1054 │     assert false; // $LibraAccount_write_to_event_store not implemented
       │      ^
       │
 
@@ -252,49 +228,33 @@ error:  A precondition for this call might not hold.
 
 bug:  This assertion might not hold.
 
-      ┌── libra_system.bpl:1101:6 ───
+      ┌── libra_system.bpl:1054:6 ───
       │
- 1101 │     assert false; // $LCS_to_bytes not implemented
+ 1054 │     assert false; // $LibraAccount_write_to_event_store not implemented
       │      ^
       │
 
 bug:  This assertion might not hold.
 
-      ┌── libra_system.bpl:1101:6 ───
+      ┌── libra_system.bpl:1054:6 ───
       │
- 1101 │     assert false; // $LCS_to_bytes not implemented
+ 1054 │     assert false; // $LibraAccount_write_to_event_store not implemented
       │      ^
       │
 
 bug:  This assertion might not hold.
 
-      ┌── libra_system.bpl:1079:6 ───
+      ┌── libra_system.bpl:1054:6 ───
       │
- 1079 │     assert false; // $LibraAccount_write_to_event_store not implemented
+ 1054 │     assert false; // $LibraAccount_write_to_event_store not implemented
       │      ^
       │
 
 bug:  This assertion might not hold.
 
-      ┌── libra_system.bpl:1079:6 ───
+      ┌── libra_system.bpl:1054:6 ───
       │
- 1079 │     assert false; // $LibraAccount_write_to_event_store not implemented
-      │      ^
-      │
-
-bug:  This assertion might not hold.
-
-      ┌── libra_system.bpl:1079:6 ───
-      │
- 1079 │     assert false; // $LibraAccount_write_to_event_store not implemented
-      │      ^
-      │
-
-bug:  This assertion might not hold.
-
-      ┌── libra_system.bpl:1079:6 ───
-      │
- 1079 │     assert false; // $LibraAccount_write_to_event_store not implemented
+ 1054 │     assert false; // $LibraAccount_write_to_event_store not implemented
       │      ^
       │
 

--- a/language/move-prover/tests/sources/stdlib/modules/script_whitelist.exp
+++ b/language/move-prover/tests/sources/stdlib/modules/script_whitelist.exp
@@ -1,153 +1,129 @@
 Move prover returns: exiting with boogie verification errors
 bug:  This assertion might not hold.
 
-      ┌── script_whitelist.bpl:1079:6 ───
+      ┌── script_whitelist.bpl:1054:6 ───
       │
- 1079 │     assert false; // $LibraAccount_write_to_event_store not implemented
+ 1054 │     assert false; // $LibraAccount_write_to_event_store not implemented
       │      ^
       │
 
 bug:  This assertion might not hold.
 
-      ┌── script_whitelist.bpl:1079:6 ───
+      ┌── script_whitelist.bpl:1054:6 ───
       │
- 1079 │     assert false; // $LibraAccount_write_to_event_store not implemented
+ 1054 │     assert false; // $LibraAccount_write_to_event_store not implemented
       │      ^
       │
 
 bug:  This assertion might not hold.
 
-      ┌── script_whitelist.bpl:1101:6 ───
+      ┌── script_whitelist.bpl:1050:6 ───
       │
- 1101 │     assert false; // $LCS_to_bytes not implemented
+ 1050 │     assert false; // $LibraAccount_save_account not implemented
       │      ^
       │
 
 bug:  This assertion might not hold.
 
-      ┌── script_whitelist.bpl:1101:6 ───
+      ┌── script_whitelist.bpl:1050:6 ───
       │
- 1101 │     assert false; // $LCS_to_bytes not implemented
+ 1050 │     assert false; // $LibraAccount_save_account not implemented
       │      ^
       │
 
 bug:  This assertion might not hold.
 
-      ┌── script_whitelist.bpl:1079:6 ───
+      ┌── script_whitelist.bpl:1054:6 ───
       │
- 1079 │     assert false; // $LibraAccount_write_to_event_store not implemented
+ 1054 │     assert false; // $LibraAccount_write_to_event_store not implemented
       │      ^
       │
 
 bug:  This assertion might not hold.
 
-      ┌── script_whitelist.bpl:1079:6 ───
+      ┌── script_whitelist.bpl:1054:6 ───
       │
- 1079 │     assert false; // $LibraAccount_write_to_event_store not implemented
+ 1054 │     assert false; // $LibraAccount_write_to_event_store not implemented
       │      ^
       │
 
 bug:  This assertion might not hold.
 
-      ┌── script_whitelist.bpl:1079:6 ───
+      ┌── script_whitelist.bpl:1054:6 ───
       │
- 1079 │     assert false; // $LibraAccount_write_to_event_store not implemented
+ 1054 │     assert false; // $LibraAccount_write_to_event_store not implemented
       │      ^
       │
 
 bug:  This assertion might not hold.
 
-      ┌── script_whitelist.bpl:1079:6 ───
+      ┌── script_whitelist.bpl:1054:6 ───
       │
- 1079 │     assert false; // $LibraAccount_write_to_event_store not implemented
+ 1054 │     assert false; // $LibraAccount_write_to_event_store not implemented
       │      ^
       │
 
 bug:  This assertion might not hold.
 
-      ┌── script_whitelist.bpl:1101:6 ───
+      ┌── script_whitelist.bpl:1050:6 ───
       │
- 1101 │     assert false; // $LCS_to_bytes not implemented
+ 1050 │     assert false; // $LibraAccount_save_account not implemented
       │      ^
       │
 
 bug:  This assertion might not hold.
 
-      ┌── script_whitelist.bpl:1079:6 ───
+      ┌── script_whitelist.bpl:1050:6 ───
       │
- 1079 │     assert false; // $LibraAccount_write_to_event_store not implemented
+ 1050 │     assert false; // $LibraAccount_save_account not implemented
       │      ^
       │
 
 bug:  This assertion might not hold.
 
-      ┌── script_whitelist.bpl:1101:6 ───
+      ┌── script_whitelist.bpl:1050:6 ───
       │
- 1101 │     assert false; // $LCS_to_bytes not implemented
+ 1050 │     assert false; // $LibraAccount_save_account not implemented
       │      ^
       │
 
 bug:  This assertion might not hold.
 
-      ┌── script_whitelist.bpl:1101:6 ───
+      ┌── script_whitelist.bpl:1050:6 ───
       │
- 1101 │     assert false; // $LCS_to_bytes not implemented
+ 1050 │     assert false; // $LibraAccount_save_account not implemented
       │      ^
       │
 
 bug:  This assertion might not hold.
 
-      ┌── script_whitelist.bpl:1079:6 ───
+      ┌── script_whitelist.bpl:1054:6 ───
       │
- 1079 │     assert false; // $LibraAccount_write_to_event_store not implemented
+ 1054 │     assert false; // $LibraAccount_write_to_event_store not implemented
       │      ^
       │
 
 bug:  This assertion might not hold.
 
-      ┌── script_whitelist.bpl:1079:6 ───
+      ┌── script_whitelist.bpl:1054:6 ───
       │
- 1079 │     assert false; // $LibraAccount_write_to_event_store not implemented
+ 1054 │     assert false; // $LibraAccount_write_to_event_store not implemented
       │      ^
       │
 
 bug:  This assertion might not hold.
 
-      ┌── script_whitelist.bpl:1079:6 ───
+      ┌── script_whitelist.bpl:1054:6 ───
       │
- 1079 │     assert false; // $LibraAccount_write_to_event_store not implemented
+ 1054 │     assert false; // $LibraAccount_write_to_event_store not implemented
       │      ^
       │
 
 bug:  This assertion might not hold.
 
-      ┌── script_whitelist.bpl:1079:6 ───
+      ┌── script_whitelist.bpl:1054:6 ───
       │
- 1079 │     assert false; // $LibraAccount_write_to_event_store not implemented
-      │      ^
-      │
-
-bug:  This assertion might not hold.
-
-      ┌── script_whitelist.bpl:1079:6 ───
-      │
- 1079 │     assert false; // $LibraAccount_write_to_event_store not implemented
-      │      ^
-      │
-
-bug:  This assertion might not hold.
-
-      ┌── script_whitelist.bpl:1079:6 ───
-      │
- 1079 │     assert false; // $LibraAccount_write_to_event_store not implemented
-      │      ^
-      │
-
-bug:  This assertion might not hold.
-
-      ┌── script_whitelist.bpl:1079:6 ───
-      │
- 1079 │     assert false; // $LibraAccount_write_to_event_store not implemented
+ 1054 │     assert false; // $LibraAccount_write_to_event_store not implemented
       │      ^
       │
 
@@ -198,17 +174,17 @@ error:  A precondition for this call might not hold.
 
 bug:  This assertion might not hold.
 
-      ┌── script_whitelist.bpl:1079:6 ───
+      ┌── script_whitelist.bpl:1054:6 ───
       │
- 1079 │     assert false; // $LibraAccount_write_to_event_store not implemented
+ 1054 │     assert false; // $LibraAccount_write_to_event_store not implemented
       │      ^
       │
 
 bug:  This assertion might not hold.
 
-      ┌── script_whitelist.bpl:1079:6 ───
+      ┌── script_whitelist.bpl:1054:6 ───
       │
- 1079 │     assert false; // $LibraAccount_write_to_event_store not implemented
+ 1054 │     assert false; // $LibraAccount_write_to_event_store not implemented
       │      ^
       │
 
@@ -252,72 +228,56 @@ error:  A precondition for this call might not hold.
 
 bug:  This assertion might not hold.
 
-      ┌── script_whitelist.bpl:1101:6 ───
+      ┌── script_whitelist.bpl:1054:6 ───
       │
- 1101 │     assert false; // $LCS_to_bytes not implemented
+ 1054 │     assert false; // $LibraAccount_write_to_event_store not implemented
       │      ^
       │
 
 bug:  This assertion might not hold.
 
-      ┌── script_whitelist.bpl:1101:6 ───
+      ┌── script_whitelist.bpl:1054:6 ───
       │
- 1101 │     assert false; // $LCS_to_bytes not implemented
+ 1054 │     assert false; // $LibraAccount_write_to_event_store not implemented
       │      ^
       │
 
 bug:  This assertion might not hold.
 
-      ┌── script_whitelist.bpl:1079:6 ───
+      ┌── script_whitelist.bpl:1054:6 ───
       │
- 1079 │     assert false; // $LibraAccount_write_to_event_store not implemented
+ 1054 │     assert false; // $LibraAccount_write_to_event_store not implemented
       │      ^
       │
 
 bug:  This assertion might not hold.
 
-      ┌── script_whitelist.bpl:1079:6 ───
+      ┌── script_whitelist.bpl:1054:6 ───
       │
- 1079 │     assert false; // $LibraAccount_write_to_event_store not implemented
+ 1054 │     assert false; // $LibraAccount_write_to_event_store not implemented
       │      ^
       │
 
 bug:  This assertion might not hold.
 
-      ┌── script_whitelist.bpl:1079:6 ───
+      ┌── script_whitelist.bpl:1054:6 ───
       │
- 1079 │     assert false; // $LibraAccount_write_to_event_store not implemented
+ 1054 │     assert false; // $LibraAccount_write_to_event_store not implemented
       │      ^
       │
 
 bug:  This assertion might not hold.
 
-      ┌── script_whitelist.bpl:1079:6 ───
+      ┌── script_whitelist.bpl:1054:6 ───
       │
- 1079 │     assert false; // $LibraAccount_write_to_event_store not implemented
+ 1054 │     assert false; // $LibraAccount_write_to_event_store not implemented
       │      ^
       │
 
 bug:  This assertion might not hold.
 
-      ┌── script_whitelist.bpl:1079:6 ───
+      ┌── script_whitelist.bpl:1054:6 ───
       │
- 1079 │     assert false; // $LibraAccount_write_to_event_store not implemented
-      │      ^
-      │
-
-bug:  This assertion might not hold.
-
-      ┌── script_whitelist.bpl:1079:6 ───
-      │
- 1079 │     assert false; // $LibraAccount_write_to_event_store not implemented
-      │      ^
-      │
-
-bug:  This assertion might not hold.
-
-      ┌── script_whitelist.bpl:1079:6 ───
-      │
- 1079 │     assert false; // $LibraAccount_write_to_event_store not implemented
+ 1054 │     assert false; // $LibraAccount_write_to_event_store not implemented
       │      ^
       │

--- a/language/move-prover/tests/sources/stdlib/modules/transaction_fee.exp
+++ b/language/move-prover/tests/sources/stdlib/modules/transaction_fee.exp
@@ -1,153 +1,129 @@
 Move prover returns: exiting with boogie verification errors
 bug:  This assertion might not hold.
 
-      ┌── transaction_fee.bpl:1079:6 ───
+      ┌── transaction_fee.bpl:1054:6 ───
       │
- 1079 │     assert false; // $LibraAccount_write_to_event_store not implemented
+ 1054 │     assert false; // $LibraAccount_write_to_event_store not implemented
       │      ^
       │
 
 bug:  This assertion might not hold.
 
-      ┌── transaction_fee.bpl:1079:6 ───
+      ┌── transaction_fee.bpl:1054:6 ───
       │
- 1079 │     assert false; // $LibraAccount_write_to_event_store not implemented
+ 1054 │     assert false; // $LibraAccount_write_to_event_store not implemented
       │      ^
       │
 
 bug:  This assertion might not hold.
 
-      ┌── transaction_fee.bpl:1101:6 ───
+      ┌── transaction_fee.bpl:1050:6 ───
       │
- 1101 │     assert false; // $LCS_to_bytes not implemented
+ 1050 │     assert false; // $LibraAccount_save_account not implemented
       │      ^
       │
 
 bug:  This assertion might not hold.
 
-      ┌── transaction_fee.bpl:1101:6 ───
+      ┌── transaction_fee.bpl:1050:6 ───
       │
- 1101 │     assert false; // $LCS_to_bytes not implemented
+ 1050 │     assert false; // $LibraAccount_save_account not implemented
       │      ^
       │
 
 bug:  This assertion might not hold.
 
-      ┌── transaction_fee.bpl:1079:6 ───
+      ┌── transaction_fee.bpl:1054:6 ───
       │
- 1079 │     assert false; // $LibraAccount_write_to_event_store not implemented
+ 1054 │     assert false; // $LibraAccount_write_to_event_store not implemented
       │      ^
       │
 
 bug:  This assertion might not hold.
 
-      ┌── transaction_fee.bpl:1079:6 ───
+      ┌── transaction_fee.bpl:1054:6 ───
       │
- 1079 │     assert false; // $LibraAccount_write_to_event_store not implemented
+ 1054 │     assert false; // $LibraAccount_write_to_event_store not implemented
       │      ^
       │
 
 bug:  This assertion might not hold.
 
-      ┌── transaction_fee.bpl:1079:6 ───
+      ┌── transaction_fee.bpl:1054:6 ───
       │
- 1079 │     assert false; // $LibraAccount_write_to_event_store not implemented
+ 1054 │     assert false; // $LibraAccount_write_to_event_store not implemented
       │      ^
       │
 
 bug:  This assertion might not hold.
 
-      ┌── transaction_fee.bpl:1079:6 ───
+      ┌── transaction_fee.bpl:1054:6 ───
       │
- 1079 │     assert false; // $LibraAccount_write_to_event_store not implemented
+ 1054 │     assert false; // $LibraAccount_write_to_event_store not implemented
       │      ^
       │
 
 bug:  This assertion might not hold.
 
-      ┌── transaction_fee.bpl:1101:6 ───
+      ┌── transaction_fee.bpl:1050:6 ───
       │
- 1101 │     assert false; // $LCS_to_bytes not implemented
+ 1050 │     assert false; // $LibraAccount_save_account not implemented
       │      ^
       │
 
 bug:  This assertion might not hold.
 
-      ┌── transaction_fee.bpl:1079:6 ───
+      ┌── transaction_fee.bpl:1050:6 ───
       │
- 1079 │     assert false; // $LibraAccount_write_to_event_store not implemented
+ 1050 │     assert false; // $LibraAccount_save_account not implemented
       │      ^
       │
 
 bug:  This assertion might not hold.
 
-      ┌── transaction_fee.bpl:1101:6 ───
+      ┌── transaction_fee.bpl:1050:6 ───
       │
- 1101 │     assert false; // $LCS_to_bytes not implemented
+ 1050 │     assert false; // $LibraAccount_save_account not implemented
       │      ^
       │
 
 bug:  This assertion might not hold.
 
-      ┌── transaction_fee.bpl:1101:6 ───
+      ┌── transaction_fee.bpl:1050:6 ───
       │
- 1101 │     assert false; // $LCS_to_bytes not implemented
+ 1050 │     assert false; // $LibraAccount_save_account not implemented
       │      ^
       │
 
 bug:  This assertion might not hold.
 
-      ┌── transaction_fee.bpl:1079:6 ───
+      ┌── transaction_fee.bpl:1054:6 ───
       │
- 1079 │     assert false; // $LibraAccount_write_to_event_store not implemented
+ 1054 │     assert false; // $LibraAccount_write_to_event_store not implemented
       │      ^
       │
 
 bug:  This assertion might not hold.
 
-      ┌── transaction_fee.bpl:1079:6 ───
+      ┌── transaction_fee.bpl:1054:6 ───
       │
- 1079 │     assert false; // $LibraAccount_write_to_event_store not implemented
+ 1054 │     assert false; // $LibraAccount_write_to_event_store not implemented
       │      ^
       │
 
 bug:  This assertion might not hold.
 
-      ┌── transaction_fee.bpl:1079:6 ───
+      ┌── transaction_fee.bpl:1054:6 ───
       │
- 1079 │     assert false; // $LibraAccount_write_to_event_store not implemented
+ 1054 │     assert false; // $LibraAccount_write_to_event_store not implemented
       │      ^
       │
 
 bug:  This assertion might not hold.
 
-      ┌── transaction_fee.bpl:1079:6 ───
+      ┌── transaction_fee.bpl:1054:6 ───
       │
- 1079 │     assert false; // $LibraAccount_write_to_event_store not implemented
-      │      ^
-      │
-
-bug:  This assertion might not hold.
-
-      ┌── transaction_fee.bpl:1079:6 ───
-      │
- 1079 │     assert false; // $LibraAccount_write_to_event_store not implemented
-      │      ^
-      │
-
-bug:  This assertion might not hold.
-
-      ┌── transaction_fee.bpl:1079:6 ───
-      │
- 1079 │     assert false; // $LibraAccount_write_to_event_store not implemented
-      │      ^
-      │
-
-bug:  This assertion might not hold.
-
-      ┌── transaction_fee.bpl:1079:6 ───
-      │
- 1079 │     assert false; // $LibraAccount_write_to_event_store not implemented
+ 1054 │     assert false; // $LibraAccount_write_to_event_store not implemented
       │      ^
       │
 
@@ -198,17 +174,17 @@ error:  A precondition for this call might not hold.
 
 bug:  This assertion might not hold.
 
-      ┌── transaction_fee.bpl:1079:6 ───
+      ┌── transaction_fee.bpl:1054:6 ───
       │
- 1079 │     assert false; // $LibraAccount_write_to_event_store not implemented
+ 1054 │     assert false; // $LibraAccount_write_to_event_store not implemented
       │      ^
       │
 
 bug:  This assertion might not hold.
 
-      ┌── transaction_fee.bpl:1079:6 ───
+      ┌── transaction_fee.bpl:1054:6 ───
       │
- 1079 │     assert false; // $LibraAccount_write_to_event_store not implemented
+ 1054 │     assert false; // $LibraAccount_write_to_event_store not implemented
       │      ^
       │
 
@@ -252,65 +228,49 @@ error:  A precondition for this call might not hold.
 
 bug:  This assertion might not hold.
 
-      ┌── transaction_fee.bpl:1101:6 ───
+      ┌── transaction_fee.bpl:1054:6 ───
       │
- 1101 │     assert false; // $LCS_to_bytes not implemented
+ 1054 │     assert false; // $LibraAccount_write_to_event_store not implemented
       │      ^
       │
 
 bug:  This assertion might not hold.
 
-      ┌── transaction_fee.bpl:1101:6 ───
+      ┌── transaction_fee.bpl:1054:6 ───
       │
- 1101 │     assert false; // $LCS_to_bytes not implemented
+ 1054 │     assert false; // $LibraAccount_write_to_event_store not implemented
       │      ^
       │
 
 bug:  This assertion might not hold.
 
-      ┌── transaction_fee.bpl:1079:6 ───
+      ┌── transaction_fee.bpl:1054:6 ───
       │
- 1079 │     assert false; // $LibraAccount_write_to_event_store not implemented
+ 1054 │     assert false; // $LibraAccount_write_to_event_store not implemented
       │      ^
       │
 
 bug:  This assertion might not hold.
 
-      ┌── transaction_fee.bpl:1079:6 ───
+      ┌── transaction_fee.bpl:1050:6 ───
       │
- 1079 │     assert false; // $LibraAccount_write_to_event_store not implemented
+ 1050 │     assert false; // $LibraAccount_save_account not implemented
       │      ^
       │
 
 bug:  This assertion might not hold.
 
-      ┌── transaction_fee.bpl:1079:6 ───
+      ┌── transaction_fee.bpl:1050:6 ───
       │
- 1079 │     assert false; // $LibraAccount_write_to_event_store not implemented
+ 1050 │     assert false; // $LibraAccount_save_account not implemented
       │      ^
       │
 
 bug:  This assertion might not hold.
 
-      ┌── transaction_fee.bpl:1079:6 ───
+      ┌── transaction_fee.bpl:1054:6 ───
       │
- 1079 │     assert false; // $LibraAccount_write_to_event_store not implemented
-      │      ^
-      │
-
-bug:  This assertion might not hold.
-
-      ┌── transaction_fee.bpl:1079:6 ───
-      │
- 1079 │     assert false; // $LibraAccount_write_to_event_store not implemented
-      │      ^
-      │
-
-bug:  This assertion might not hold.
-
-      ┌── transaction_fee.bpl:1101:6 ───
-      │
- 1101 │     assert false; // $LCS_to_bytes not implemented
+ 1054 │     assert false; // $LibraAccount_write_to_event_store not implemented
       │      ^
       │
 


### PR DESCRIPTION
Move datastructures are converted to vector<u8> for sha2/3, crypto and other purposes by a native library called "serialize".  There is no "deserialize" in Move and no plans to create one.

The new Boogie code for serialize maps a Move value to an arbitrary non-empty vector<8>.  There is a an additional axiom that constrains serialize to be an injection, because (I believe) the correctness of Move modules will sometimes depend on this property. However, the model is a conservative approximation of the actual function because it does not guarantee that the bytes in the serialized value correspond to what the native serialize function does, or even that the length of the result is the same as the actual serialize.

We should be able to verify properties that require serialize to be an injection, but won't be able to verify code that accesses and manipulates bytes from a serialized value or, for example, code that depends on the length of serialized values.

There are test cases serialize-model.move and serialize-model-invalid.move, also. Some new .exp files were created for stdlib files that use lcs.move.

<!--
Thank you for sending a PR. We appreciate you spending time to help improve the Libra project.

The project is undergoing daily changes. Pull Requests will be reviewed and responded to as time permits.
-->

## Motivation

(Write your motivation for proposed changes here.)

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?

(Write your answer here.)

## Test Plan

(Share your test plan here. If you changed code, please provide us with clear instructions for verifying that your changes work.)

## Related PRs

(If this PR adds or changes functionality, please take some time to update the docs at https://github.com/libra/website, and link to your PR here.)
