### PR TITLE
[storage] VerifiedStateView depends on DbReader trait instead of Stor…

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4919,6 +4919,7 @@ dependencies = [
  "libra-state-view 0.1.0",
  "libra-types 0.1.0",
  "scratchpad 0.1.0",
+ "storage-interface 0.1.0",
  "storage-proto 0.1.0",
  "tokio 0.2.13 (registry+https://github.com/rust-lang/crates.io-index)",
  "tonic 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/execution/executor/src/lib.rs
+++ b/execution/executor/src/lib.rs
@@ -47,7 +47,9 @@ use std::{
     marker::PhantomData,
     sync::Arc,
 };
-use storage_client::{StorageRead, StorageWrite, VerifiedStateView};
+use storage_client::{
+    StorageRead, StorageReaderWithRuntimeHandle, StorageWrite, VerifiedStateView,
+};
 use tokio::runtime::Runtime;
 
 static OP_COUNTERS: Lazy<libra_metrics::OpMetrics> =
@@ -142,8 +144,10 @@ where
         let _timer = OP_COUNTERS.timer("block_execute_time_s");
         // Construct a StateView and pass the transactions to VM.
         let state_view = VerifiedStateView::new(
-            Arc::clone(&self.storage_read_client),
-            self.rt.handle().clone(),
+            Arc::new(StorageReaderWithRuntimeHandle::new(
+                self.storage_read_client.clone(),
+                self.rt.handle().clone(),
+            )),
             self.cache.committed_trees().version(),
             self.cache.committed_trees().state_root(),
             parent_block_executed_trees.state_tree(),
@@ -400,8 +404,10 @@ where
 
         // Construct a StateView and pass the transactions to VM.
         let state_view = VerifiedStateView::new(
-            Arc::clone(&self.storage_read_client),
-            self.rt.handle().clone(),
+            Arc::new(StorageReaderWithRuntimeHandle::new(
+                self.storage_read_client.clone(),
+                self.rt.handle().clone(),
+            )),
             self.cache.synced_trees().version(),
             self.cache.synced_trees().state_root(),
             self.cache.synced_trees().state_tree(),

--- a/execution/executor/src/lib.rs
+++ b/execution/executor/src/lib.rs
@@ -145,7 +145,7 @@ where
         // Construct a StateView and pass the transactions to VM.
         let state_view = VerifiedStateView::new(
             Arc::new(StorageReaderWithRuntimeHandle::new(
-                self.storage_read_client.clone(),
+                Arc::clone(&self.storage_read_client),
                 self.rt.handle().clone(),
             )),
             self.cache.committed_trees().version(),
@@ -405,7 +405,7 @@ where
         // Construct a StateView and pass the transactions to VM.
         let state_view = VerifiedStateView::new(
             Arc::new(StorageReaderWithRuntimeHandle::new(
-                self.storage_read_client.clone(),
+                Arc::clone(&self.storage_read_client),
                 self.rt.handle().clone(),
             )),
             self.cache.synced_trees().version(),

--- a/json-rpc/src/tests/mock_db.rs
+++ b/json-rpc/src/tests/mock_db.rs
@@ -11,8 +11,8 @@ use libra_types::{
     event::EventKey,
     ledger_info::{LedgerInfo, LedgerInfoWithSignatures},
     proof::{
-        AccumulatorConsistencyProof, AccumulatorRangeProof, TransactionAccumulatorProof,
-        TransactionListProof, TransactionProof,
+        AccumulatorConsistencyProof, AccumulatorRangeProof, SparseMerkleProof,
+        TransactionAccumulatorProof, TransactionListProof, TransactionProof,
     },
     transaction::{
         Transaction, TransactionInfo, TransactionListWithProof, TransactionWithProof, Version,
@@ -217,6 +217,14 @@ impl DbReader for MockLibraDB {
     }
 
     fn get_startup_info(&self) -> Result<Option<StartupInfo>> {
+        unimplemented!()
+    }
+
+    fn get_account_state_with_proof_by_version(
+        &self,
+        address: AccountAddress,
+        version: u64,
+    ) -> Result<(Option<AccountStateBlob>, SparseMerkleProof)> {
         unimplemented!()
     }
 }

--- a/json-rpc/src/tests/mock_db.rs
+++ b/json-rpc/src/tests/mock_db.rs
@@ -222,8 +222,8 @@ impl DbReader for MockLibraDB {
 
     fn get_account_state_with_proof_by_version(
         &self,
-        address: AccountAddress,
-        version: u64,
+        _address: AccountAddress,
+        _version: u64,
     ) -> Result<(Option<AccountStateBlob>, SparseMerkleProof)> {
         unimplemented!()
     }

--- a/storage/libradb/src/lib.rs
+++ b/storage/libradb/src/lib.rs
@@ -480,19 +480,6 @@ impl LibraDB {
         Ok((version, txn_info.state_root_hash()))
     }
 
-    /// Gets an account state by account address, out of the ledger state indicated by the state
-    /// Merkle tree root hash.
-    ///
-    /// This is used by libra core (executor) internally.
-    pub fn get_account_state_with_proof_by_version(
-        &self,
-        address: AccountAddress,
-        version: Version,
-    ) -> Result<(Option<AccountStateBlob>, SparseMerkleProof)> {
-        self.state_store
-            .get_account_state_with_proof_by_version(address, version)
-    }
-
     /// Gets the latest TreeState no matter if db has been bootstrapped.
     /// Used by the Db-bootstrapper.
     pub fn get_latest_tree_state(&self) -> Result<TreeState> {
@@ -920,6 +907,15 @@ impl DbReader for LibraDB {
 
     fn get_startup_info(&self) -> Result<Option<StartupInfo>> {
         self.ledger_store.get_startup_info()
+    }
+
+    fn get_account_state_with_proof_by_version(
+        &self,
+        address: AccountAddress,
+        version: Version,
+    ) -> Result<(Option<AccountStateBlob>, SparseMerkleProof)> {
+        self.state_store
+            .get_account_state_with_proof_by_version(address, version)
     }
 }
 

--- a/storage/storage-client/Cargo.toml
+++ b/storage/storage-client/Cargo.toml
@@ -17,6 +17,7 @@ tonic = "0.2"
 libra-crypto = { path = "../../crypto/crypto", version = "0.1.0" }
 scratchpad = { path = "../scratchpad", version = "0.1.0" }
 libra-state-view = { path = "../state-view", version = "0.1.0" }
+storage-interface = { path = "../storage-interface", version = "0.1.0" }
 storage-proto = { path = "../storage-proto", version = "0.1.0" }
 libra-types = { path = "../../types", version = "0.1.0" }
 tokio = { version = "0.2.13", features = ["full"] }

--- a/storage/storage-client/src/state_view.rs
+++ b/storage/storage-client/src/state_view.rs
@@ -1,9 +1,7 @@
 // Copyright (c) The Libra Core Contributors
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::StorageRead;
 use anyhow::{format_err, Result};
-use futures::executor::block_on;
 use libra_crypto::{hash::CryptoHash, HashValue};
 use libra_state_view::StateView;
 use libra_types::{
@@ -17,15 +15,14 @@ use std::{
     convert::TryInto,
     sync::Arc,
 };
-use tokio::runtime::Handle;
+use storage_interface::DbReader;
 
 /// `VerifiedStateView` is like a snapshot of the global state comprised of state view at two
 /// levels, persistent storage and memory.
 pub struct VerifiedStateView<'a> {
     /// A gateway implementing persistent storage interface, which can be a RPC client or direct
     /// accessor.
-    reader: Arc<dyn StorageRead>,
-    rt_handle: Handle,
+    reader: Arc<dyn DbReader>,
 
     /// The most recent version in persistent storage.
     latest_persistent_version: Option<Version>,
@@ -81,15 +78,13 @@ impl<'a> VerifiedStateView<'a> {
     /// `latest_persistent_state_root` plus a storage reader, and the in-memory speculative state
     /// on top of it represented by `speculative_state`.
     pub fn new(
-        reader: Arc<dyn StorageRead>,
-        rt_handle: Handle,
+        reader: Arc<dyn DbReader>,
         latest_persistent_version: Option<Version>,
         latest_persistent_state_root: HashValue,
         speculative_state: &'a SparseMerkleTree,
     ) -> Self {
         Self {
             reader,
-            rt_handle,
             latest_persistent_version,
             latest_persistent_state_root,
             speculative_state,
@@ -133,15 +128,9 @@ impl<'a> StateView for VerifiedStateView<'a> {
                     // former case, we don't have the blob data but only its hash.
                     AccountStatus::ExistsInDB | AccountStatus::Unknown => {
                         let (blob, proof) = match self.latest_persistent_version {
-                            Some(version) => {
-                                let reader = self.reader.clone();
-                                block_on(self.rt_handle.spawn(async move {
-                                    reader
-                                        .get_account_state_with_proof_by_version(address, version)
-                                        .await
-                                }))
-                                .unwrap()?
-                            }
+                            Some(version) => self
+                                .reader
+                                .get_account_state_with_proof_by_version(address, version)?,
                             None => (None, SparseMerkleProof::new(None, vec![])),
                         };
                         proof

--- a/storage/storage-interface/src/lib.rs
+++ b/storage/storage-interface/src/lib.rs
@@ -8,7 +8,7 @@ use libra_types::{
     contract_event::ContractEvent,
     event::EventKey,
     ledger_info::LedgerInfoWithSignatures,
-    proof::AccumulatorConsistencyProof,
+    proof::{AccumulatorConsistencyProof, SparseMerkleProof},
     transaction::{TransactionListWithProof, TransactionWithProof, Version},
     validator_change::ValidatorChangeProof,
 };
@@ -92,4 +92,14 @@ pub trait DbReader: Send + Sync {
         version: Version,
         ledger_version: Version,
     ) -> Result<AccountStateWithProof>;
+
+    /// Gets an account state by account address, out of the ledger state indicated by the state
+    /// Merkle tree root hash.
+    ///
+    /// This is used by libra core (executor) internally.
+    fn get_account_state_with_proof_by_version(
+        &self,
+        address: AccountAddress,
+        version: Version,
+    ) -> Result<(Option<AccountStateBlob>, SparseMerkleProof)>;
 }


### PR DESCRIPTION
…ageRead


## Motivation

So that it's possible to run the VerifiedStateView against a local LibraDB.
We will also move away from the grpc- based remote db solution, this is the first step to decouple the Executor with the grpc related traits.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?
yes
(Write your answer here.)

## Test Plan
existing coverage
(Share your test plan here. If you changed code, please provide us with clear instructions for verifying that your changes work.)

## Related PRs

(If this PR adds or changes functionality, please take some time to update the docs at https://github.com/libra/website, and link to your PR here.)
