### PR TITLE
[executor] Depend on DbReader instead of StorageRead

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1279,6 +1279,7 @@ dependencies = [
  "serde_json 1.0.51 (registry+https://github.com/rust-lang/crates.io-index)",
  "stdlib 0.1.0",
  "storage-client 0.1.0",
+ "storage-interface 0.1.0",
  "storage-proto 0.1.0",
  "storage-service 0.1.0",
  "tokio 0.2.13 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/execution/executor-utils/src/lib.rs
+++ b/execution/executor-utils/src/lib.rs
@@ -8,7 +8,9 @@ use executor::{db_bootstrapper::maybe_bootstrap_db, Executor};
 use libra_config::config::NodeConfig;
 use libra_vm::LibraVM;
 use std::sync::Arc;
-use storage_client::{StorageReadServiceClient, StorageWriteServiceClient};
+use storage_client::{
+    StorageReadServiceClient, StorageReaderWithRuntimeHandle, StorageWriteServiceClient,
+};
 use storage_service::start_storage_service;
 use tokio::runtime::Runtime;
 
@@ -17,8 +19,13 @@ pub fn create_storage_service_and_executor(config: &NodeConfig) -> (Runtime, Exe
     maybe_bootstrap_db::<LibraVM>(config).unwrap();
 
     let storage_read_client = Arc::new(StorageReadServiceClient::new(&config.storage.address));
+    let exec_rt = Executor::<LibraVM>::create_runtime();
+    let db_reader = Arc::new(StorageReaderWithRuntimeHandle::new(
+        storage_read_client,
+        exec_rt.handle().clone(),
+    ));
     let storage_write_client = Arc::new(StorageWriteServiceClient::new(&config.storage.address));
-    let executor = Executor::new(storage_read_client, storage_write_client);
+    let executor = Executor::new(exec_rt, db_reader, storage_write_client);
 
     (rt, executor)
 }

--- a/execution/executor/Cargo.toml
+++ b/execution/executor/Cargo.toml
@@ -32,6 +32,7 @@ libra-types = { path = "../../types", version = "0.1.0" }
 scratchpad = { path = "../../storage/scratchpad", version = "0.1.0" }
 serde_json = "1.0"
 storage-client = { path = "../../storage/storage-client", version = "0.1.0" }
+storage-interface = { path = "../../storage/storage-interface", version = "0.1.0" }
 storage-proto = { path = "../../storage/storage-proto", version = "0.1.0" }
 libra-vm = { path = "../../language/libra-vm", version = "0.1.0" }
 

--- a/execution/executor/src/executor_test.rs
+++ b/execution/executor/src/executor_test.rs
@@ -22,15 +22,23 @@ use proptest::prelude::*;
 use rand::Rng;
 use rusty_fork::{rusty_fork_id, rusty_fork_test, rusty_fork_test_name};
 use std::{collections::BTreeMap, sync::Arc};
-use storage_client::{StorageRead, StorageReadServiceClient, StorageWriteServiceClient};
+use storage_client::{
+    StorageRead, StorageReadServiceClient, StorageReaderWithRuntimeHandle,
+    StorageWriteServiceClient,
+};
 use storage_service::start_storage_service;
 use tokio::runtime::Runtime;
 
 fn create_executor(config: &NodeConfig) -> Executor<MockVM> {
     maybe_bootstrap_db::<MockVM>(config).expect("Db-bootstrapper should not fail.");
+    let rt = Executor::<MockVM>::create_runtime();
     let read_client = Arc::new(StorageReadServiceClient::new(&config.storage.address));
+    let db_reader = Arc::new(StorageReaderWithRuntimeHandle::new(
+        read_client,
+        rt.handle().clone(),
+    ));
     let write_client = Arc::new(StorageWriteServiceClient::new(&config.storage.address));
-    Executor::new(read_client, write_client)
+    Executor::new(rt, db_reader, write_client)
 }
 
 fn execute_and_commit_block(

--- a/storage/storage-client/src/lib.rs
+++ b/storage/storage-client/src/lib.rs
@@ -559,7 +559,11 @@ impl DbReader for StorageReaderWithRuntimeHandle {
     }
 
     fn get_startup_info(&self) -> Result<Option<StartupInfo>> {
-        unimplemented!()
+        let reader = Arc::clone(&self.reader);
+        block_on(
+            self.rt_handle
+                .spawn(async move { reader.get_startup_info().await }),
+        )?
     }
 
     fn get_txn_by_account(


### PR DESCRIPTION
<!--
Thank you for sending a PR. We appreciate you spending time to help improve the Libra project.

The project is undergoing daily changes. Pull Requests will be reviewed and responded to as time permits.
-->

## Motivation


So that it's possible to run the Executor against a local LibraDB.
We will also move away from the grpc- based remote db solution, this is another step to decouple the Executor with the grpc related traits.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?


yes

## Test Plan
existing coverage

## Related PRs

(If this PR adds or changes functionality, please take some time to update the docs at https://github.com/libra/website, and link to your PR here.)
