### PR TITLE
[on-chain config] add fetch_config method to OnChainConfig trait

### DIFF
--- a/language/libra-vm/src/on_chain_configs.rs
+++ b/language/libra-vm/src/on_chain_configs.rs
@@ -1,9 +1,8 @@
 // Copyright (c) The Libra Core Contributors
 // SPDX-License-Identifier: Apache-2.0
 
-use libra_types::on_chain_config::{
-    ConfigStorage, LibraVersion, OnChainConfig, VMPublishingOption,
-};
+use libra_logger::prelude::*;
+use libra_types::on_chain_config::{LibraVersion, OnChainConfig, VMPublishingOption};
 use move_vm_state::data_cache::RemoteCache;
 
 #[derive(Debug, Clone)]
@@ -14,15 +13,16 @@ pub(crate) struct VMConfig {
 
 impl VMConfig {
     pub fn load_on_chain_config(state_view: &dyn RemoteCache) -> Option<Self> {
-        let publishing_options = state_view
-            .fetch_config(VMPublishingOption::CONFIG_ID.access_path())
-            .and_then(|bytes| VMPublishingOption::deserialize_into_config(&bytes).ok())?;
-        let version = state_view
-            .fetch_config(LibraVersion::CONFIG_ID.access_path())
-            .and_then(|bytes| LibraVersion::deserialize_into_config(&bytes).ok())?;
-        Some(VMConfig {
-            version,
-            publishing_options,
-        })
+        let publishing_options = VMPublishingOption::fetch_config(state_view);
+        let version = LibraVersion::fetch_config(state_view);
+        if publishing_options.is_some() && version.is_some() {
+            Some(VMConfig {
+                publishing_options: publishing_options?,
+                version: version?,
+            })
+        } else {
+            error!("Failed to fetch VM config");
+            None
+        }
     }
 }

--- a/types/src/on_chain_config.rs
+++ b/types/src/on_chain_config.rs
@@ -78,6 +78,15 @@ pub trait OnChainConfig: Send + Sync + DeserializeOwned {
     fn deserialize_into_config(bytes: &[u8]) -> Result<Self> {
         Self::deserialize_default_impl(bytes)
     }
+
+    fn fetch_config<T>(storage: T) -> Option<Self>
+    where
+        T: ConfigStorage,
+    {
+        storage
+            .fetch_config(Self::CONFIG_ID.access_path())
+            .and_then(|bytes| Self::deserialize_into_config(&bytes).ok())
+    }
 }
 
 pub fn access_path_for_config(config_name: Identifier) -> AccessPath {


### PR DESCRIPTION
## Motivation

Adding `fetch_config` method to reduce repeated code in loading VM config 
