### PR TITLE
[network] Use Vec<u8> in network spec instead of bytes::Bytes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3226,6 +3226,7 @@ dependencies = [
  "proptest 0.9.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.106 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_bytes 0.11.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_repr 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "serial_test 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "socket-bench-server 0.1.0",
@@ -4579,6 +4580,14 @@ version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "ordered-float 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.106 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "serde_bytes"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
  "serde 1.0.106 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -6795,6 +6804,7 @@ dependencies = [
 "checksum semver-parser 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "388a1df253eca08550bef6c72392cfe7c30914bf41df5269b68cbd6ff8f570a3"
 "checksum serde 1.0.106 (registry+https://github.com/rust-lang/crates.io-index)" = "36df6ac6412072f67cf767ebbde4133a5b2e88e76dc6187fa7104cd16f783399"
 "checksum serde-value 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)" = "5a65a7291a8a568adcae4c10a677ebcedbc6c9cec91c054dee2ce40b0e3290eb"
+"checksum serde_bytes 0.11.3 (registry+https://github.com/rust-lang/crates.io-index)" = "325a073952621257820e7a3469f55ba4726d8b28657e7e36653d1c36dc2c84ae"
 "checksum serde_derive 1.0.106 (registry+https://github.com/rust-lang/crates.io-index)" = "9e549e3abf4fb8621bd1609f11dfc9f5e50320802273b12f3811a67e6716ea6c"
 "checksum serde_json 1.0.51 (registry+https://github.com/rust-lang/crates.io-index)" = "da07b57ee2623368351e9a0488bb0b261322a15a6e0ae53e243cbdc0f4208da9"
 "checksum serde_repr 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "cd02c7587ec314570041b2754829f84d873ced14a96d1fd1823531e11db40573"

--- a/network/Cargo.toml
+++ b/network/Cargo.toml
@@ -19,6 +19,7 @@ pin-project = "0.4.2"
 prometheus = { version = "0.8.0", default-features = false }
 rand = "0.6.5"
 serde = { version = "1.0.106", default-features = false }
+serde_bytes = "0.11.3"
 serde_repr = "0.1"
 thiserror = "1.0"
 tokio = { version = "0.2.13", features = ["full"] }

--- a/network/src/peer/test.rs
+++ b/network/src/peer/test.rs
@@ -10,7 +10,6 @@ use crate::{
     },
     ProtocolId,
 };
-use bytes::Bytes;
 use futures::{future::join, io::AsyncWriteExt, stream::StreamExt, SinkExt};
 use libra_types::PeerId;
 use memsocket::MemorySocket;
@@ -175,7 +174,7 @@ fn peer_send_message() {
     let send_msg = NetworkMessage::DirectSendMsg(DirectSendMsg {
         protocol_id: PROTOCOL,
         priority: 0,
-        raw_msg: Bytes::from_static(b"hello world"),
+        raw_msg: Vec::from("hello world"),
     });
     let recv_msg = send_msg.clone();
 
@@ -212,7 +211,7 @@ fn peer_recv_message() {
     let send_msg = NetworkMessage::DirectSendMsg(DirectSendMsg {
         protocol_id: PROTOCOL,
         priority: 0,
-        raw_msg: Bytes::from_static(b"hello world"),
+        raw_msg: Vec::from("hello world"),
     });
     let recv_msg = send_msg.clone();
 
@@ -269,12 +268,12 @@ fn peer_open_substream_simultaneous() {
         let msg_a = NetworkMessage::DirectSendMsg(DirectSendMsg {
             protocol_id: PROTOCOL,
             priority: 0,
-            raw_msg: Bytes::from_static(b"hello world"),
+            raw_msg: Vec::from("hello world"),
         });
         let msg_b = NetworkMessage::DirectSendMsg(DirectSendMsg {
             protocol_id: PROTOCOL,
             priority: 0,
-            raw_msg: Bytes::from_static(b"namaste"),
+            raw_msg: Vec::from("namaste"),
         });
 
         // Send open substream requests to both peer_a and peer_b

--- a/network/src/protocols/direct_send/mod.rs
+++ b/network/src/protocols/direct_send/mod.rs
@@ -149,7 +149,7 @@ impl DirectSend {
                         .observe(data.len() as f64);
                     let notif = DirectSendNotification::RecvMessage(Message {
                         protocol,
-                        mdata: data,
+                        mdata: Bytes::from(data),
                     });
                     if let Err(err) = self.ds_notifs_tx.send(notif).await {
                         warn!(
@@ -181,7 +181,7 @@ impl DirectSend {
                             protocol_id,
                             // TODO: Use default priority for now. To be exposed via network API.
                             priority: Priority::default(),
-                            raw_msg: msg.mdata,
+                            raw_msg: Vec::from(msg.mdata.as_ref()),
                         }),
                         protocol_id,
                     )

--- a/network/src/protocols/rpc/fuzzing.rs
+++ b/network/src/protocols/rpc/fuzzing.rs
@@ -9,7 +9,6 @@ use crate::{
     },
     ProtocolId,
 };
-use bytes::Bytes;
 use futures::{
     future::{self, FutureExt},
     stream::StreamExt,
@@ -17,7 +16,7 @@ use futures::{
 use libra_proptest_helpers::ValueGenerator;
 use libra_types::PeerId;
 use proptest::{arbitrary::any, collection::vec, prop_oneof, strategy::Strategy};
-use std::{io, iter::FromIterator};
+use std::io;
 use tokio::runtime;
 use tokio_util::codec::{Encoder, LengthDelimitedCodec};
 
@@ -64,8 +63,7 @@ pub fn generate_corpus(gen: &mut ValueGenerator) -> Vec<u8> {
 pub fn fuzzer(data: &[u8]) {
     let (notification_tx, mut notification_rx) = channel::new_test(8);
     let (peer_reqs_tx, mut peer_reqs_rx) = channel::new_test(8);
-    let data = Vec::from(data);
-    let raw_request = Bytes::from_iter(data.into_iter());
+    let raw_request = Vec::from(data);
     let inbound_request = RpcRequest {
         protocol_id: TEST_PROTOCOL,
         request_id: 0,

--- a/network/src/protocols/rpc/mod.rs
+++ b/network/src/protocols/rpc/mod.rs
@@ -463,7 +463,7 @@ async fn handle_outbound_rpc_inner(
         // TODO: Use default priority for now. To be exposed via network API.
         priority: Priority::default(),
         protocol_id: protocol,
-        raw_request: req_data,
+        raw_request: Vec::from(req_data.as_ref()),
     });
 
     // Start timer to collect RPC latency.
@@ -506,7 +506,7 @@ async fn handle_outbound_rpc_inner(
     counters::LIBRA_NETWORK_RPC_BYTES
         .with_label_values(&["response", "received"])
         .observe(res_data.len() as f64);
-    Ok(res_data)
+    Ok(Bytes::from(res_data))
 }
 
 async fn handle_inbound_request_inner(
@@ -535,7 +535,7 @@ async fn handle_inbound_request_inner(
     let (res_tx, res_rx) = oneshot::channel();
     let notification = RpcNotification::RecvRpc(InboundRpcRequest {
         protocol: request.protocol_id,
-        data: req_data,
+        data: Bytes::from(req_data),
         res_tx,
     });
     notification_tx.send(notification).await?;
@@ -556,7 +556,7 @@ async fn handle_inbound_request_inner(
         peer_id.short_str()
     );
     let response = RpcResponse {
-        raw_response: res_data,
+        raw_response: Vec::from(res_data.as_ref()),
         request_id,
         priority: request.priority,
     };

--- a/network/src/protocols/rpc/test.rs
+++ b/network/src/protocols/rpc/test.rs
@@ -133,7 +133,7 @@ fn create_network_request(
         request_id,
         protocol_id,
         priority: Priority::default(),
-        raw_request,
+        raw_request: Vec::from(raw_request.as_ref()),
     })
 }
 
@@ -141,7 +141,7 @@ fn create_network_response(request_id: RequestId, raw_response: Bytes) -> Networ
     NetworkMessage::RpcResponse(RpcResponse {
         request_id,
         priority: Priority::default(),
-        raw_response,
+        raw_response: Vec::from(raw_response.as_ref()),
     })
 }
 
@@ -299,12 +299,11 @@ fn outbound_rpc_timeout() {
 
     let protocol_id = RPC_PROTOCOL_A;
     let req_data = Bytes::from_static(b"hello");
-    let message = NetworkMessage::RpcRequest(RpcRequest {
-        request_id: 0, // This is the first request.
+    let message = create_network_request(
+        0, // This is the first request.
         protocol_id,
-        priority: Priority::default(),
-        raw_request: req_data.clone(),
-    });
+        req_data.clone(),
+    );
 
     let f_mock_peer = expect_successful_send(&mut peer_reqs_rx, protocol_id, message);
 

--- a/network/src/protocols/wire/messaging/v1/mod.rs
+++ b/network/src/protocols/wire/messaging/v1/mod.rs
@@ -66,6 +66,7 @@ pub struct RpcRequest {
     /// Request priority in the range 0..=255.
     pub priority: Priority,
     /// Request payload. This will be parsed by the application-level handler.
+    #[serde(with = "serde_bytes")]
     pub raw_request: Vec<u8>,
 }
 
@@ -77,6 +78,7 @@ pub struct RpcResponse {
     /// corresponding request.
     pub priority: Priority,
     /// Response payload.
+    #[serde(with = "serde_bytes")]
     pub raw_response: Vec<u8>,
 }
 
@@ -87,5 +89,6 @@ pub struct DirectSendMsg {
     /// Message priority in the range 0..=255.
     pub priority: Priority,
     /// Message payload.
+    #[serde(with = "serde_bytes")]
     pub raw_msg: Vec<u8>,
 }

--- a/network/src/protocols/wire/messaging/v1/mod.rs
+++ b/network/src/protocols/wire/messaging/v1/mod.rs
@@ -5,7 +5,6 @@
 //! These should serialize as per [link](TODO: Add ref).
 
 use crate::protocols::wire::handshake::v1::MessagingProtocolVersion;
-use bytes::Bytes;
 use serde::{Deserialize, Serialize};
 use serde_repr::{Deserialize_repr, Serialize_repr};
 
@@ -67,7 +66,7 @@ pub struct RpcRequest {
     /// Request priority in the range 0..=255.
     pub priority: Priority,
     /// Request payload. This will be parsed by the application-level handler.
-    pub raw_request: Bytes,
+    pub raw_request: Vec<u8>,
 }
 
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
@@ -78,7 +77,7 @@ pub struct RpcResponse {
     /// corresponding request.
     pub priority: Priority,
     /// Response payload.
-    pub raw_response: Bytes,
+    pub raw_response: Vec<u8>,
 }
 
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
@@ -88,5 +87,5 @@ pub struct DirectSendMsg {
     /// Message priority in the range 0..=255.
     pub priority: Priority,
     /// Message payload.
-    pub raw_msg: Bytes,
+    pub raw_msg: Vec<u8>,
 }

--- a/network/src/protocols/wire/messaging/v1/test.rs
+++ b/network/src/protocols/wire/messaging/v1/test.rs
@@ -24,7 +24,7 @@ fn rpc_request() -> lcs::Result<()> {
         request_id: 25,
         protocol_id: ProtocolId::ConsensusRpc,
         priority: 0,
-        raw_request: Bytes::from_static(&[0, 1, 2, 3]),
+        raw_request: [0, 1, 2, 3].to_vec(),
     };
     assert_eq!(
         lcs::to_bytes(&rpc_request)?,


### PR DESCRIPTION
Since we want the spec data-structures to be shared across LSR and validator server/client code, it's important to limit the dependency of the spec to small and safe libraries.

As a side-effect, a new dependency on `serde_bytes` is added. This is because default ser(de) of Vec<u8> treats it as a sequence of elements instead of a byte buffer that can be consumed in one go. This leads to a 40-70% drop in performance. By using `serde_bytes`, we are able to get the same performance as when using the `bytes` crate.