### PR TITLE
[storage][executor] Executor depend on synchronized storage interfaces

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6135,6 +6135,7 @@ dependencies = [
  "rand 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "scratchpad 0.1.0",
  "storage-client 0.1.0",
+ "storage-interface 0.1.0",
  "storage-service 0.1.0",
  "tokio 0.2.13 (registry+https://github.com/rust-lang/crates.io-index)",
  "transaction-builder 0.1.0",

--- a/execution/executor-utils/src/lib.rs
+++ b/execution/executor-utils/src/lib.rs
@@ -8,9 +8,7 @@ use executor::{db_bootstrapper::maybe_bootstrap_db, Executor};
 use libra_config::config::NodeConfig;
 use libra_vm::LibraVM;
 use std::sync::Arc;
-use storage_client::{
-    StorageReadServiceClient, StorageReaderWithRuntimeHandle, StorageWriteServiceClient,
-};
+use storage_client::{StorageReadServiceClient, StorageWriteServiceClient, SyncStorageClient};
 use storage_service::start_storage_service;
 use tokio::runtime::Runtime;
 
@@ -20,7 +18,7 @@ pub fn create_storage_service_and_executor(config: &NodeConfig) -> (Runtime, Exe
 
     let storage_read_client = Arc::new(StorageReadServiceClient::new(&config.storage.address));
     let exec_rt = Executor::<LibraVM>::create_runtime();
-    let db_reader = Arc::new(StorageReaderWithRuntimeHandle::new(
+    let db_reader = Arc::new(SyncStorageClient::new(
         storage_read_client,
         exec_rt.handle().clone(),
     ));

--- a/execution/executor-utils/src/lib.rs
+++ b/execution/executor-utils/src/lib.rs
@@ -8,7 +8,7 @@ use executor::{db_bootstrapper::maybe_bootstrap_db, Executor};
 use libra_config::config::NodeConfig;
 use libra_vm::LibraVM;
 use std::sync::Arc;
-use storage_client::{StorageReadServiceClient, StorageWriteServiceClient, SyncStorageClient};
+use storage_client::SyncStorageClient;
 use storage_service::start_storage_service;
 use tokio::runtime::Runtime;
 
@@ -16,14 +16,9 @@ pub fn create_storage_service_and_executor(config: &NodeConfig) -> (Runtime, Exe
     let rt = start_storage_service(config);
     maybe_bootstrap_db::<LibraVM>(config).unwrap();
 
-    let storage_read_client = Arc::new(StorageReadServiceClient::new(&config.storage.address));
-    let exec_rt = Executor::<LibraVM>::create_runtime();
-    let db_reader = Arc::new(SyncStorageClient::new(
-        storage_read_client,
-        exec_rt.handle().clone(),
-    ));
-    let storage_write_client = Arc::new(StorageWriteServiceClient::new(&config.storage.address));
-    let executor = Executor::new(exec_rt, db_reader, storage_write_client);
+    let db_reader = Arc::new(SyncStorageClient::new(&config.storage.address));
+    let db_writer = Arc::clone(&db_reader);
+    let executor = Executor::new(db_reader, db_writer);
 
     (rt, executor)
 }

--- a/execution/executor/src/db_bootstrapper.rs
+++ b/execution/executor/src/db_bootstrapper.rs
@@ -11,15 +11,13 @@ use libra_logger::prelude::*;
 use libra_types::ledger_info::LedgerInfoWithSignatures;
 use libra_vm::VMExecutor;
 use std::sync::Arc;
-use storage_client::{
-    StorageReadServiceClient, StorageReaderWithRuntimeHandle, StorageWriteServiceClient,
-};
+use storage_client::{StorageReadServiceClient, StorageWriteServiceClient, SyncStorageClient};
 use storage_interface::DbReader;
 
 pub fn maybe_bootstrap_db<V: VMExecutor>(config: &NodeConfig) -> Result<()> {
     let rt = Executor::<V>::create_runtime();
     let storage_read_client = Arc::new(StorageReadServiceClient::new(&config.storage.address));
-    let db_reader = Arc::new(StorageReaderWithRuntimeHandle::new(
+    let db_reader = Arc::new(SyncStorageClient::new(
         storage_read_client,
         rt.handle().clone(),
     ));

--- a/execution/executor/src/executor_test.rs
+++ b/execution/executor/src/executor_test.rs
@@ -23,8 +23,7 @@ use rand::Rng;
 use rusty_fork::{rusty_fork_id, rusty_fork_test, rusty_fork_test_name};
 use std::{collections::BTreeMap, sync::Arc};
 use storage_client::{
-    StorageRead, StorageReadServiceClient, StorageReaderWithRuntimeHandle,
-    StorageWriteServiceClient,
+    StorageRead, StorageReadServiceClient, StorageWriteServiceClient, SyncStorageClient,
 };
 use storage_service::start_storage_service;
 use tokio::runtime::Runtime;
@@ -33,10 +32,7 @@ fn create_executor(config: &NodeConfig) -> Executor<MockVM> {
     maybe_bootstrap_db::<MockVM>(config).expect("Db-bootstrapper should not fail.");
     let rt = Executor::<MockVM>::create_runtime();
     let read_client = Arc::new(StorageReadServiceClient::new(&config.storage.address));
-    let db_reader = Arc::new(StorageReaderWithRuntimeHandle::new(
-        read_client,
-        rt.handle().clone(),
-    ));
+    let db_reader = Arc::new(SyncStorageClient::new(read_client, rt.handle().clone()));
     let write_client = Arc::new(StorageWriteServiceClient::new(&config.storage.address));
     Executor::new(rt, db_reader, write_client)
 }

--- a/json-rpc/src/tests/mock_db.rs
+++ b/json-rpc/src/tests/mock_db.rs
@@ -227,4 +227,8 @@ impl DbReader for MockLibraDB {
     ) -> Result<(Option<AccountStateBlob>, SparseMerkleProof)> {
         unimplemented!()
     }
+
+    fn get_latest_state_root(&self) -> Result<(u64, HashValue)> {
+        unimplemented!()
+    }
 }

--- a/libra-node/src/main_node.rs
+++ b/libra-node/src/main_node.rs
@@ -25,9 +25,7 @@ use std::{
     thread,
     time::Instant,
 };
-use storage_client::{
-    StorageReadServiceClient, StorageReaderWithRuntimeHandle, StorageWriteServiceClient,
-};
+use storage_client::{StorageReadServiceClient, StorageWriteServiceClient, SyncStorageClient};
 use storage_service::{init_libra_db, start_storage_service_with_db};
 use tokio::runtime::{Builder, Runtime};
 
@@ -56,7 +54,7 @@ impl Drop for LibraHandle {
 fn setup_executor(config: &NodeConfig) -> Arc<Mutex<Executor<LibraVM>>> {
     let rt = Executor::<LibraVM>::create_runtime();
     let storage_read_client = Arc::new(StorageReadServiceClient::new(&config.storage.address));
-    let db_reader = Arc::new(StorageReaderWithRuntimeHandle::new(
+    let db_reader = Arc::new(SyncStorageClient::new(
         storage_read_client,
         rt.handle().clone(),
     ));

--- a/secure/key-manager/src/tests.rs
+++ b/secure/key-manager/src/tests.rs
@@ -24,9 +24,7 @@ use libra_vm::LibraVM;
 use libradb::LibraDB;
 use rand::{rngs::StdRng, SeedableRng};
 use std::{cell::RefCell, collections::BTreeMap, convert::TryFrom, sync::Arc, time::Duration};
-use storage_client::{
-    StorageReadServiceClient, StorageReaderWithRuntimeHandle, StorageWriteServiceClient,
-};
+use storage_client::{StorageReadServiceClient, StorageWriteServiceClient, SyncStorageClient};
 use storage_interface::DbReader;
 use tokio::runtime::Runtime;
 
@@ -81,7 +79,7 @@ impl Node {
             storage_service::start_storage_service_with_db(&config, storage.clone());
         maybe_bootstrap_db::<LibraVM>(config).expect("Db-bootstrapper should not fail.");
         let rt = Executor::<LibraVM>::create_runtime();
-        let db_reader = Arc::new(StorageReaderWithRuntimeHandle::new(
+        let db_reader = Arc::new(SyncStorageClient::new(
             Arc::new(StorageReadServiceClient::new(&config.storage.address)),
             rt.handle().clone(),
         ));

--- a/storage/libradb/src/lib.rs
+++ b/storage/libradb/src/lib.rs
@@ -474,12 +474,6 @@ impl LibraDB {
 
     // =========================== Libra Core Internal APIs ========================================
 
-    /// Gets the latest state root hash together with its version.
-    pub fn get_latest_state_root(&self) -> Result<(Version, HashValue)> {
-        let (version, txn_info) = self.ledger_store.get_latest_transaction_info()?;
-        Ok((version, txn_info.state_root_hash()))
-    }
-
     /// Gets the latest TreeState no matter if db has been bootstrapped.
     /// Used by the Db-bootstrapper.
     pub fn get_latest_tree_state(&self) -> Result<TreeState> {
@@ -916,6 +910,11 @@ impl DbReader for LibraDB {
     ) -> Result<(Option<AccountStateBlob>, SparseMerkleProof)> {
         self.state_store
             .get_account_state_with_proof_by_version(address, version)
+    }
+
+    fn get_latest_state_root(&self) -> Result<(Version, HashValue)> {
+        let (version, txn_info) = self.ledger_store.get_latest_transaction_info()?;
+        Ok((version, txn_info.state_root_hash()))
     }
 }
 

--- a/storage/storage-client/src/lib.rs
+++ b/storage/storage-client/src/lib.rs
@@ -515,18 +515,18 @@ pub trait StorageWrite: Send + Sync {
     ) -> Result<()>;
 }
 
-pub struct StorageReaderWithRuntimeHandle {
+pub struct SyncStorageClient {
     reader: Arc<dyn StorageRead>,
     rt_handle: Handle,
 }
 
-impl StorageReaderWithRuntimeHandle {
+impl SyncStorageClient {
     pub fn new(reader: Arc<dyn StorageRead>, rt_handle: Handle) -> Self {
         Self { reader, rt_handle }
     }
 }
 
-impl DbReader for StorageReaderWithRuntimeHandle {
+impl DbReader for SyncStorageClient {
     fn get_transactions(
         &self,
         _start_version: u64,

--- a/vm-validator/Cargo.toml
+++ b/vm-validator/Cargo.toml
@@ -18,6 +18,7 @@ libra-config = { path = "../config", version = "0.1.0" }
 scratchpad = { path = "../storage/scratchpad", version = "0.1.0" }
 libra-state-view = { path = "../storage/state-view", version = "0.1.0" }
 storage-client = { path = "../storage/storage-client", version = "0.1.0" }
+storage-interface = { path = "../storage/storage-interface", version = "0.1.0" }
 libra-types = { path = "../types", version = "0.1.0" }
 libra-vm = { path = "../language/libra-vm", version = "0.1.0" }
 

--- a/vm-validator/src/unit_tests/vm_validator_test.rs
+++ b/vm-validator/src/unit_tests/vm_validator_test.rs
@@ -15,7 +15,7 @@ use libra_types::{
 use libra_vm::LibraVM;
 use rand::SeedableRng;
 use std::{sync::Arc, u64};
-use storage_client::{StorageRead, StorageReadServiceClient};
+use storage_client::SyncStorageClient;
 use storage_service::start_storage_service;
 use tokio::runtime::Runtime;
 use transaction_builder::encode_transfer_script;
@@ -33,10 +33,8 @@ impl TestValidator {
 
         // Create another client for the vm_validator since the one used for the executor will be
         // run on another runtime which will be dropped before this function returns.
-        let read_client: Arc<dyn StorageRead> =
-            Arc::new(StorageReadServiceClient::new(&config.storage.address));
-        let vm_validator = VMValidator::new(read_client, rt.handle().clone());
-
+        let db_reader = Arc::new(SyncStorageClient::new(&config.storage.address));
+        let vm_validator = VMValidator::new(db_reader);
         (
             TestValidator {
                 _storage: storage,

--- a/vm-validator/src/vm_validator.rs
+++ b/vm-validator/src/vm_validator.rs
@@ -11,7 +11,7 @@ use libra_types::{
 use libra_vm::{LibraVM, VMVerifier};
 use scratchpad::SparseMerkleTree;
 use std::{convert::TryFrom, sync::Arc};
-use storage_client::{StorageRead, StorageReaderWithRuntimeHandle, VerifiedStateView};
+use storage_client::{StorageRead, SyncStorageClient, VerifiedStateView};
 use tokio::runtime::Handle;
 
 #[cfg(test)]
@@ -42,7 +42,7 @@ impl VMValidator {
                 .expect("Failed to get the latest state");
         let smt = SparseMerkleTree::new(state_root);
         let state_view = VerifiedStateView::new(
-            Arc::new(StorageReaderWithRuntimeHandle::new(
+            Arc::new(SyncStorageClient::new(
                 storage_read_client.clone(),
                 rt_handle.clone(),
             )),
@@ -84,7 +84,7 @@ impl TransactionValidation for VMValidator {
         tokio::task::spawn_blocking(move || {
             let smt = SparseMerkleTree::new(state_root);
             let state_view = VerifiedStateView::new(
-                Arc::new(StorageReaderWithRuntimeHandle::new(client, rt_handle)),
+                Arc::new(SyncStorageClient::new(client, rt_handle)),
                 Some(version),
                 state_root,
                 &smt,


### PR DESCRIPTION

## Motivation

After this I will be able to use an Executor with an local LibraDB.

Also we can substitute StorageClient with then new storage rpc interface without changing Executor.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?
yes
## Test Plan
existing coverage.

## Related PRs

(If this PR adds or changes functionality, please take some time to update the docs at https://github.com/libra/website, and link to your PR here.)
