### PR TITLE
[storage] DbReaderWriter to simplify Executor interface

### DIFF
--- a/execution/executor-utils/src/lib.rs
+++ b/execution/executor-utils/src/lib.rs
@@ -7,7 +7,6 @@ pub mod test_helpers;
 use executor::{db_bootstrapper::maybe_bootstrap_db, Executor};
 use libra_config::config::NodeConfig;
 use libra_vm::LibraVM;
-use std::sync::Arc;
 use storage_client::SyncStorageClient;
 use storage_service::start_storage_service;
 use tokio::runtime::Runtime;
@@ -16,9 +15,7 @@ pub fn create_storage_service_and_executor(config: &NodeConfig) -> (Runtime, Exe
     let rt = start_storage_service(config);
     maybe_bootstrap_db::<LibraVM>(config).unwrap();
 
-    let db_reader = Arc::new(SyncStorageClient::new(&config.storage.address));
-    let db_writer = Arc::clone(&db_reader);
-    let executor = Executor::new(db_reader, db_writer);
+    let executor = Executor::new(SyncStorageClient::new(&config.storage.address).into());
 
     (rt, executor)
 }

--- a/execution/executor/src/executor_test.rs
+++ b/execution/executor/src/executor_test.rs
@@ -21,16 +21,14 @@ use libra_types::{
 use proptest::prelude::*;
 use rand::Rng;
 use rusty_fork::{rusty_fork_id, rusty_fork_test, rusty_fork_test_name};
-use std::{collections::BTreeMap, sync::Arc};
+use std::collections::BTreeMap;
 use storage_client::{StorageRead, StorageReadServiceClient, SyncStorageClient};
 use storage_service::start_storage_service;
 use tokio::runtime::Runtime;
 
 fn create_executor(config: &NodeConfig) -> Executor<MockVM> {
     maybe_bootstrap_db::<MockVM>(config).expect("Db-bootstrapper should not fail.");
-    let db_reader = Arc::new(SyncStorageClient::new(&config.storage.address));
-    let db_writer = Arc::clone(&db_reader);
-    Executor::new(db_reader, db_writer)
+    Executor::new(SyncStorageClient::new(&config.storage.address).into())
 }
 
 fn execute_and_commit_block(

--- a/libra-node/src/main_node.rs
+++ b/libra-node/src/main_node.rs
@@ -52,9 +52,9 @@ impl Drop for LibraHandle {
 }
 
 fn setup_executor(config: &NodeConfig) -> Arc<Mutex<Executor<LibraVM>>> {
-    let db_reader = Arc::new(SyncStorageClient::new(&config.storage.address));
-    let db_writer = Arc::clone(&db_reader);
-    Arc::new(Mutex::new(Executor::new(db_reader, db_writer)))
+    Arc::new(Mutex::new(Executor::new(
+        SyncStorageClient::new(&config.storage.address).into(),
+    )))
 }
 
 fn setup_debug_interface(config: &NodeConfig) -> Runtime {

--- a/secure/key-manager/src/tests.rs
+++ b/secure/key-manager/src/tests.rs
@@ -78,9 +78,7 @@ impl Node {
         let storage_service =
             storage_service::start_storage_service_with_db(&config, storage.clone());
         maybe_bootstrap_db::<LibraVM>(config).expect("Db-bootstrapper should not fail.");
-        let db_reader = Arc::new(SyncStorageClient::new(&config.storage.address));
-        let db_writer = Arc::clone(&db_reader);
-        let executor = Executor::new(db_reader, db_writer);
+        let executor = Executor::new(SyncStorageClient::new(&config.storage.address).into());
         let libra = TestLibraInterface {
             queued_transactions: Arc::new(RefCell::new(Vec::new())),
             storage,


### PR DESCRIPTION
## Motivation
With this wrapper type, Executor no longer need to hold db reader and writer separately.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

existing coverage

## Related PRs

(If this PR adds or changes functionality, please take some time to update the docs at https://github.com/libra/website, and link to your PR here.)
