### PR TITLE
[language] remove outdated function allows_equality

### DIFF
--- a/language/vm/src/file_format.rs
+++ b/language/vm/src/file_format.rs
@@ -661,23 +661,6 @@ impl SignatureToken {
         }
     }
 
-    /// Checks if the signature token is usable for Eq and Neq.
-    ///
-    /// Currently equality operations are only allowed on:
-    /// - Bool
-    /// - U64
-    /// - ByteArray
-    /// - Address
-    /// - Reference or Mutable reference to these types
-    pub fn allows_equality(&self) -> bool {
-        use SignatureToken::*;
-        match self {
-            Struct(_) | StructInstantiation(_, _) => false,
-            Reference(token) | MutableReference(token) => token.is_primitive(),
-            token => token.is_primitive(),
-        }
-    }
-
     /// Returns true if the `SignatureToken` is any kind of reference (mutable and immutable).
     pub fn is_reference(&self) -> bool {
         use SignatureToken::*;


### PR DESCRIPTION
<!--
Thank you for sending a PR. We appreciate you spending time to help improve the Libra project.

The project is undergoing daily changes. Pull Requests will be reviewed and responded to as time permits.
-->

## Motivation

The function `allows_equality` is outdated and is replaced by `is_copyable` in bytecode_verifier.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?

(Write your answer here.)

## Test Plan

(Share your test plan here. If you changed code, please provide us with clear instructions for verifying that your changes work.)

## Related PRs

(If this PR adds or changes functionality, please take some time to update the docs at https://github.com/libra/website, and link to your PR here.)
