### PR TITLE
[storage] add list-accounts option for LibraDB storage inspector

### DIFF
--- a/storage/inspector/src/main.rs
+++ b/storage/inspector/src/main.rs
@@ -10,7 +10,9 @@ use std::path::PathBuf;
 use storage_interface::DbReader;
 use transaction_builder::get_transaction_name;
 
-use libra_types::{account_address::AccountAddress, account_config::AccountResource};
+use libra_types::{
+    account_address::AccountAddress, account_config::AccountResource, account_state::AccountState,
+};
 use std::convert::TryFrom;
 use structopt::StructOpt;
 
@@ -34,6 +36,8 @@ enum Command {
         #[structopt(parse(try_from_str))]
         address: AccountAddress,
     },
+    #[structopt(name = "list-accounts")]
+    ListAccounts,
 }
 
 /// Print out latest information stored in the DB.
@@ -120,6 +124,36 @@ fn list_txns(db: &LibraDB) {
     }
 }
 
+fn list_accounts(db: &LibraDB) {
+    let version = db
+        .get_latest_version()
+        .expect("Unable to get latest version");
+    let backup = db.get_backup_handler();
+    let iter = backup
+        .get_account_iter(version)
+        .expect("Unagle to get account iter");
+    let mut num_account = 0;
+    for res in iter {
+        match res {
+            Ok((_, blob)) => {
+                let accs = AccountState::try_from(&blob).expect("Failed to read AccountState");
+                let addr = accs
+                    .get_account_address()
+                    .expect("Could not get address from state");
+                match addr {
+                    Some(x) => {
+                        num_account += 1;
+                        println!("Address: {:?}", x);
+                    }
+                    None => println!("Skipping: No address for AccountState: {:?}", accs),
+                }
+            }
+            Err(x) => println!("Got err iterating through AccountStateBlobs {:?}", x),
+        }
+    }
+    info!("Total Accounts: {}", num_account);
+}
+
 fn main() {
     ::libra_logger::Logger::new().init();
 
@@ -148,6 +182,9 @@ fn main() {
             }
             Command::PrintAccount { address } => {
                 print_account(&db, address);
+            }
+            Command::ListAccounts => {
+                list_accounts(&db);
             }
         }
     } else {


### PR DESCRIPTION
<!--
Thank you for sending a PR. We appreciate you spending time to help improve the Libra project.

The project is undergoing daily changes. Pull Requests will be reviewed and responded to as time permits.
-->

## Motivation

Add `list-accounts` option for `libra-storage-inspector`. Read AccountStates from disk using backup handler and prints addresses.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

Running libra-swarm with 4 validators, and create account using the CLI (and mint for good measure):

```
libra% a create
>> Creating/retrieving next account from wallet
Created/retrieved account #0 address 285b23268a44747c61dee6ab2bb543ac
libra% account mint 0 110
>> Minting coins
Mint request submitted
libra% query balance 0
Balance is: 110.000000
```

Run list-accounts:

```
$ cargo run -p libra-storage-inspector -- --db ~/libra-tmp/logs/0/libradb/db list-accounts
   Compiling libra-storage-inspector v0.1.0 (/home/rustielin/libra/storage/inspector)
    Finished dev [unoptimized + debuginfo] target(s) in 20.11s
     Running `target/debug/libra-storage-inspector --db /home/rustielin/libra-tmp/logs/0/libradb/db list-accounts`
INFO 2020-04-08 01:47:43 storage/inspector/src/main.rs:166 Opening DB at: "/home/rustielin/libra-tmp/logs/0/libradb/db", log at "/tmp/.tmpah1ORO"
INFO 2020-04-08 01:47:43 storage/libradb/src/lib.rs:183 log stored at "/tmp/.tmpah1ORO"
INFO 2020-04-08 01:47:43 storage/libradb/src/lib.rs:189 Opened LibraDB at "/home/rustielin/libra-tmp/logs/0/libradb/db/libradb" in 115 ms
INFO 2020-04-08 01:47:43 storage/inspector/src/main.rs:169 DB opened successfully.
Address: 140582ca819341f2a1cb1e787d3a81ae
Address: 0000000000000000000000000a550c18
Address: 5707b4b64d213a0f67b07268e307fed4
Address: a8fab1c11fa355845fb6a263acba518c
Address: 51f0a592c41bc9331f76d7df80480fdd
Address: 285b23268a44747c61dee6ab2bb543ac
Address: 00000000000000000000000000000fee
Address: 000000000000000000000000000d15c0
Address: 000000000000000000000000000001d8
Invalid Address: None
INFO 2020-04-08 01:47:43 storage/inspector/src/main.rs:150 Total Accounts: 10
```

We have 9 valid addresses, 4 of which are the validators, and `285b23268a44747c61dee6ab2bb543ac`, which we created above. The rest are faucet or created by libra-swarm for other reasons. 

NOTE: Regarding the invalid address: the count is generated by getting the account state iterator's `count` method from backup, but seems there's an error and it counts a null address that's been persisted to disk. This affects `print_head`'s acc count as well for the same reaosns.

## Related PRs

(If this PR adds or changes functionality, please take some time to update the docs at https://github.com/libra/website, and link to your PR here.)
