### PR TITLE
[JSON RPC] extract out JSON RPC payload handling logic as generic helpers

### DIFF
--- a/client/cli/src/client_proxy.rs
+++ b/client/cli/src/client_proxy.rs
@@ -13,7 +13,7 @@ use libra_crypto::{
     x25519::X25519StaticPublicKey,
     ValidKey, ValidKeyStringExt,
 };
-use libra_json_rpc::views::{AccountView, EventView, TransactionView};
+use libra_json_rpc::views::{AccountView, BlockMetadata, EventView, TransactionView};
 use libra_logger::prelude::*;
 use libra_temppath::TempPath;
 use libra_types::{
@@ -994,8 +994,13 @@ impl ClientProxy {
         }
     }
 
-    /// Test gRPC client connection with validator.
-    pub fn test_validator_connection(&mut self) -> Result<LedgerInfoWithSignatures> {
+    /// Test JSON RPC client connection with validator.
+    pub fn test_validator_connection(&mut self) -> Result<BlockMetadata> {
+        self.client.get_metadata()
+    }
+
+    /// Test client's connection to validator with proof.
+    pub fn test_trusted_connection(&mut self) -> Result<()> {
         self.client.get_state_proof()
     }
 

--- a/client/cli/src/main.rs
+++ b/client/cli/src/main.rs
@@ -100,7 +100,7 @@ fn main() {
     .expect("Failed to construct client.");
 
     // Test connection to validator
-    let latest_li = client_proxy
+    let block_metadata = client_proxy
         .test_validator_connection()
         .unwrap_or_else(|e| {
             panic!(
@@ -110,10 +110,8 @@ fn main() {
         });
     let ledger_info_str = format!(
         "latest version = {}, timestamp = {}",
-        latest_li.ledger_info().version(),
-        DateTime::<Utc>::from(
-            UNIX_EPOCH + Duration::from_micros(latest_li.ledger_info().timestamp_usecs())
-        )
+        block_metadata.version,
+        DateTime::<Utc>::from(UNIX_EPOCH + Duration::from_micros(block_metadata.timestamp))
     );
     let cli_info = format!(
         "Connected to validator at: {}, {}",

--- a/json-rpc/src/lib.rs
+++ b/json-rpc/src/lib.rs
@@ -27,7 +27,10 @@ mod methods;
 mod runtime;
 pub mod views;
 
-pub use client::{JsonRpcAsyncClient, JsonRpcBatch};
+pub use client::{
+    get_response_from_batch, process_batch_response, JsonRpcAsyncClient, JsonRpcBatch,
+    JsonRpcResponse,
+};
 pub use runtime::bootstrap_from_config;
 
 #[cfg(any(feature = "fuzzing", test))]

--- a/json-rpc/src/methods.rs
+++ b/json-rpc/src/methods.rs
@@ -221,11 +221,12 @@ async fn get_account_state_with_proof(
     let address: String = serde_json::from_value(params[0].clone())?;
     let account_address = AccountAddress::from_str(&address)?;
     let version: u64 = serde_json::from_value(params[1].clone())?;
+    let ledger_version: u64 = serde_json::from_value(params[2].clone())?;
 
     let account_state_with_proof =
         service
             .db
-            .get_account_state_with_proof(account_address, version, version)?;
+            .get_account_state_with_proof(account_address, version, ledger_version)?;
     Ok(AccountStateWithProofView::try_from(
         account_state_with_proof,
     )?)

--- a/json-rpc/src/tests/unit_tests.rs
+++ b/json-rpc/src/tests/unit_tests.rs
@@ -261,6 +261,7 @@ proptest! {
         let result = rt.block_on(client.execute(batch)).unwrap().remove(0).unwrap();
         match result {
             JsonRpcResponse::AccountResponse(account) => {
+                let account = account.expect("account does not exist");
                 assert_eq!(account.balance, expected_resource.get_balance_resource().unwrap().unwrap().coin());
                 assert_eq!(account.sequence_number, expected_resource.get_account_resource().unwrap().unwrap().sequence_number());
             }
@@ -285,6 +286,7 @@ proptest! {
         for (idx, response) in responses.into_iter().enumerate() {
             match response.unwrap() {
                 JsonRpcResponse::AccountResponse(account) => {
+                    let account = account.expect("account does not exist");
                     assert_eq!(account.balance, states[idx].get_balance_resource().unwrap().unwrap().coin());
                     assert_eq!(account.sequence_number, states[idx].get_account_resource().unwrap().unwrap().sequence_number());
                 }

--- a/json-rpc/src/views.rs
+++ b/json-rpc/src/views.rs
@@ -1,7 +1,8 @@
 // Copyright (c) The Libra Core Contributors
 // SPDX-License-Identifier: Apache-2.0
 
-use anyhow::{format_err, Error};
+use crate::JsonRpcResponse;
+use anyhow::{format_err, Error, Result};
 use hex;
 use libra_crypto::HashValue;
 use libra_types::{
@@ -22,7 +23,27 @@ use serde::{Deserialize, Serialize};
 use std::convert::TryFrom;
 use transaction_builder::get_transaction_name;
 
-#[derive(Serialize, Deserialize, Debug, PartialEq)]
+/// For JSON RPC views that are returned as part of a `JsonRpcResponse` instance, this trait
+/// can be used to extract the view from a `JsonRpcResponse` instance when applicable
+pub trait ResponseAsView: Sized {
+    fn unexpected_response_error<T>(response: JsonRpcResponse) -> Result<T> {
+        Err(format_err!("did not receive expected view: {:?}", response))
+    }
+
+    fn from_response(_response: JsonRpcResponse) -> Result<Self> {
+        unimplemented!()
+    }
+
+    fn optional_from_response(_response: JsonRpcResponse) -> Result<Option<Self>> {
+        unimplemented!()
+    }
+
+    fn vec_from_response(_response: JsonRpcResponse) -> Result<Vec<Self>> {
+        unimplemented!()
+    }
+}
+
+#[derive(Clone, Serialize, Deserialize, Debug, PartialEq)]
 pub struct AccountView {
     pub balance: u64,
     pub sequence_number: u64,
@@ -47,7 +68,17 @@ impl AccountView {
     }
 }
 
-#[derive(Debug, Serialize, Deserialize)]
+impl ResponseAsView for AccountView {
+    fn optional_from_response(response: JsonRpcResponse) -> Result<Option<Self>> {
+        if let JsonRpcResponse::AccountResponse(view) = response {
+            Ok(view)
+        } else {
+            Self::unexpected_response_error::<Option<Self>>(response)
+        }
+    }
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq)]
 pub struct EventView {
     pub key: BytesView,
     pub sequence_number: u64,
@@ -55,7 +86,17 @@ pub struct EventView {
     pub data: EventDataView,
 }
 
-#[derive(Debug, Serialize, Deserialize)]
+impl ResponseAsView for EventView {
+    fn vec_from_response(response: JsonRpcResponse) -> Result<Vec<Self>> {
+        if let JsonRpcResponse::EventsResponse(events) = response {
+            Ok(events)
+        } else {
+            Self::unexpected_response_error::<Vec<Self>>(response)
+        }
+    }
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq)]
 #[serde(tag = "type")]
 pub enum EventDataView {
     #[serde(rename = "receivedpayment")]
@@ -110,10 +151,20 @@ impl From<(u64, ContractEvent)> for EventView {
     }
 }
 
-#[derive(Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, PartialEq)]
 pub struct BlockMetadata {
     pub version: u64,
     pub timestamp: u64,
+}
+
+impl ResponseAsView for BlockMetadata {
+    fn from_response(response: JsonRpcResponse) -> Result<Self> {
+        if let JsonRpcResponse::BlockMetadataResponse(metadata) = response {
+            Ok(metadata)
+        } else {
+            Self::unexpected_response_error::<Self>(response)
+        }
+    }
 }
 
 #[derive(Clone, Serialize, Deserialize, Debug, PartialEq)]
@@ -137,7 +188,7 @@ impl From<&Vec<u8>> for BytesView {
     }
 }
 
-#[derive(Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, PartialEq)]
 pub struct TransactionView {
     pub version: u64,
     pub transaction: TransactionDataView,
@@ -147,7 +198,7 @@ pub struct TransactionView {
 }
 
 #[allow(clippy::large_enum_variant)]
-#[derive(Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, PartialEq)]
 #[serde(tag = "type")]
 pub enum TransactionDataView {
     #[serde(rename = "blockmetadata")]
@@ -181,7 +232,25 @@ impl TransactionView {
     }
 }
 
-#[derive(Debug, Deserialize, Serialize)]
+impl ResponseAsView for TransactionView {
+    fn optional_from_response(response: JsonRpcResponse) -> Result<Option<Self>> {
+        if let JsonRpcResponse::AccountTransactionResponse(view) = response {
+            Ok(view)
+        } else {
+            Self::unexpected_response_error::<Option<Self>>(response)
+        }
+    }
+
+    fn vec_from_response(response: JsonRpcResponse) -> Result<Vec<Self>> {
+        if let JsonRpcResponse::TransactionsResponse(txns) = response {
+            Ok(txns)
+        } else {
+            Self::unexpected_response_error::<Vec<Self>>(response)
+        }
+    }
+}
+
+#[derive(Clone, Debug, Deserialize, Serialize, PartialEq)]
 #[serde(tag = "type")]
 // TODO cover all script types
 pub enum ScriptView {
@@ -309,7 +378,7 @@ impl From<TransactionPayload> for ScriptView {
     }
 }
 
-#[derive(Serialize, Deserialize)]
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq)]
 pub struct StateProofView {
     pub ledger_info_with_signatures: BytesView,
     pub validator_change_proof: BytesView,
@@ -342,11 +411,31 @@ impl
     }
 }
 
-#[derive(Serialize, Deserialize)]
+impl ResponseAsView for StateProofView {
+    fn from_response(response: JsonRpcResponse) -> Result<Self> {
+        if let JsonRpcResponse::StateProofResponse(view) = response {
+            Ok(view)
+        } else {
+            Self::unexpected_response_error::<Self>(response)
+        }
+    }
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq)]
 pub struct AccountStateWithProofView {
     pub version: u64,
     pub blob: Option<BytesView>,
     pub proof: AccountStateProofView,
+}
+
+impl ResponseAsView for AccountStateWithProofView {
+    fn from_response(response: JsonRpcResponse) -> Result<Self> {
+        if let JsonRpcResponse::AccountStateWithProofResponse(resp) = response {
+            Ok(resp)
+        } else {
+            Self::unexpected_response_error::<Self>(response)
+        }
+    }
 }
 
 impl TryFrom<AccountStateWithProof> for AccountStateWithProofView {
@@ -368,7 +457,7 @@ impl TryFrom<AccountStateWithProof> for AccountStateWithProofView {
     }
 }
 
-#[derive(Serialize, Deserialize)]
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq)]
 pub struct AccountStateProofView {
     pub ledger_info_to_transaction_info_proof: BytesView,
     pub transaction_info: BytesView,

--- a/testsuite/cluster-test/src/tx_emitter.rs
+++ b/testsuite/cluster-test/src/tx_emitter.rs
@@ -333,7 +333,10 @@ impl TxEmitter {
             .get_accounts_state(slice::from_ref(address))
             .await
             .map_err(|e| format_err!("[{:?}] get_accounts_state failed: {:?} ", client, e))?;
-        Ok(resp[0].sequence_number)
+        Ok(resp[0]
+            .as_ref()
+            .ok_or_else(|| format_err!("account does not exist"))?
+            .sequence_number)
     }
 }
 
@@ -468,7 +471,10 @@ async fn query_sequence_numbers(
             .map_err(|e| format_err!("[{:?}] get_accounts_state failed: {:?} ", client, e))?;
 
         for item in resp.into_iter() {
-            result.push(item.sequence_number);
+            result.push(
+                item.ok_or_else(|| format_err!("account does not exist"))?
+                    .sequence_number,
+            );
         }
     }
     Ok(result)

--- a/testsuite/tests/libratest/smoke_test.rs
+++ b/testsuite/tests/libratest/smoke_test.rs
@@ -1022,7 +1022,7 @@ fn test_client_waypoints() {
 
     // Start another client with the genesis waypoint and make sure it successfully connects
     let mut client_with_waypoint = env.get_validator_ac_client(0, Some(genesis_waypoint));
-    client_with_waypoint.test_validator_connection().unwrap();
+    client_with_waypoint.test_trusted_connection().unwrap();
     assert_eq!(
         client_with_waypoint.latest_epoch_change_li().unwrap(),
         genesis_li
@@ -1055,7 +1055,7 @@ fn test_client_waypoints() {
 
     // Start a client with the waypoint for end of epoch 1 and make sure it successfully connects
     client_with_waypoint = env.get_validator_ac_client(1, Some(epoch_1_waypoint));
-    client_with_waypoint.test_validator_connection().unwrap();
+    client_with_waypoint.test_trusted_connection().unwrap();
     assert_eq!(
         client_with_waypoint.latest_epoch_change_li().unwrap(),
         epoch_1_li
@@ -1065,9 +1065,7 @@ fn test_client_waypoints() {
     let bad_li = LedgerInfo::mock_genesis();
     let bad_waypoint = Waypoint::new(&bad_li).unwrap();
     let mut client_with_bad_waypoint = env.get_validator_ac_client(1, Some(bad_waypoint));
-    assert!(client_with_bad_waypoint
-        .test_validator_connection()
-        .is_err());
+    assert!(client_with_bad_waypoint.test_trusted_connection().is_err());
 }
 
 #[test]


### PR DESCRIPTION
## Motivation

- Extract out generic JSON RPC payload handling logic into shared code used by CLI and JSON RPC async client
- use get_block_metadata instead of get_state_proof in CLI `test_validator_connection`

Will refactor for json-rpc unit tests in later PR