### PR TITLE
[storage] Run db-bootstrapper on local db

### DIFF
--- a/execution/executor-utils/src/lib.rs
+++ b/execution/executor-utils/src/lib.rs
@@ -7,7 +7,6 @@ pub mod test_helpers;
 use executor::{db_bootstrapper::maybe_bootstrap_db, Executor};
 use libra_config::config::NodeConfig;
 use libra_vm::LibraVM;
-use std::sync::Arc;
 use storage_client::SyncStorageClient;
 use storage_service::start_storage_service;
 use tokio::runtime::Runtime;
@@ -16,9 +15,7 @@ pub fn create_storage_service_and_executor(config: &NodeConfig) -> (Runtime, Exe
     let rt = start_storage_service(config);
     maybe_bootstrap_db::<LibraVM>(config).unwrap();
 
-    let db_reader = Arc::new(SyncStorageClient::new(&config.storage.address));
-    let db_writer = Arc::clone(&db_reader);
-    let executor = Executor::new(db_reader, db_writer);
+    let executor = Executor::new(SyncStorageClient::new(&config.storage.address).into());
 
     (rt, executor)
 }

--- a/execution/executor-utils/src/lib.rs
+++ b/execution/executor-utils/src/lib.rs
@@ -8,13 +8,14 @@ use executor::{db_bootstrapper::maybe_bootstrap_db, Executor};
 use libra_config::config::NodeConfig;
 use libra_vm::LibraVM;
 use storage_client::SyncStorageClient;
-use storage_service::start_storage_service;
+use storage_service::{init_libra_db, start_storage_service_with_db};
 use tokio::runtime::Runtime;
 
 pub fn create_storage_service_and_executor(config: &NodeConfig) -> (Runtime, Executor<LibraVM>) {
-    let rt = start_storage_service(config);
-    maybe_bootstrap_db::<LibraVM>(config).unwrap();
+    let (arc_db, db_reader_writer) = init_libra_db(config);
+    maybe_bootstrap_db::<LibraVM>(db_reader_writer, config).unwrap();
 
+    let rt = start_storage_service_with_db(config, arc_db);
     let executor = Executor::new(SyncStorageClient::new(&config.storage.address).into());
 
     (rt, executor)

--- a/execution/executor/src/executor_test.rs
+++ b/execution/executor/src/executor_test.rs
@@ -21,16 +21,14 @@ use libra_types::{
 use proptest::prelude::*;
 use rand::Rng;
 use rusty_fork::{rusty_fork_id, rusty_fork_test, rusty_fork_test_name};
-use std::{collections::BTreeMap, sync::Arc};
+use std::collections::BTreeMap;
 use storage_client::{StorageRead, StorageReadServiceClient, SyncStorageClient};
 use storage_service::start_storage_service;
 use tokio::runtime::Runtime;
 
 fn create_executor(config: &NodeConfig) -> Executor<MockVM> {
     maybe_bootstrap_db::<MockVM>(config).expect("Db-bootstrapper should not fail.");
-    let db_reader = Arc::new(SyncStorageClient::new(&config.storage.address));
-    let db_writer = Arc::clone(&db_reader);
-    Executor::new(db_reader, db_writer)
+    Executor::new(SyncStorageClient::new(&config.storage.address).into())
 }
 
 fn execute_and_commit_block(

--- a/libra-node/src/main_node.rs
+++ b/libra-node/src/main_node.rs
@@ -167,9 +167,10 @@ pub fn setup_environment(node_config: &mut NodeConfig) -> LibraHandle {
         .expect("Building rayon global thread pool should work.");
 
     let mut instant = Instant::now();
-    let libra_db = init_libra_db(&node_config);
+    let (libra_db, db_reader_writer) = init_libra_db(&node_config);
     let storage = start_storage_service_with_db(&node_config, Arc::clone(&libra_db));
-    maybe_bootstrap_db::<LibraVM>(node_config).expect("Db-bootstrapper should not fail.");
+    maybe_bootstrap_db::<LibraVM>(db_reader_writer, node_config)
+        .expect("Db-bootstrapper should not fail.");
 
     debug!(
         "Storage service started in {} ms",

--- a/libra-node/src/main_node.rs
+++ b/libra-node/src/main_node.rs
@@ -52,9 +52,9 @@ impl Drop for LibraHandle {
 }
 
 fn setup_executor(config: &NodeConfig) -> Arc<Mutex<Executor<LibraVM>>> {
-    let db_reader = Arc::new(SyncStorageClient::new(&config.storage.address));
-    let db_writer = Arc::clone(&db_reader);
-    Arc::new(Mutex::new(Executor::new(db_reader, db_writer)))
+    Arc::new(Mutex::new(Executor::new(
+        SyncStorageClient::new(&config.storage.address).into(),
+    )))
 }
 
 fn setup_debug_interface(config: &NodeConfig) -> Runtime {

--- a/secure/key-manager/src/tests.rs
+++ b/secure/key-manager/src/tests.rs
@@ -78,9 +78,7 @@ impl Node {
         let storage_service =
             storage_service::start_storage_service_with_db(&config, storage.clone());
         maybe_bootstrap_db::<LibraVM>(config).expect("Db-bootstrapper should not fail.");
-        let db_reader = Arc::new(SyncStorageClient::new(&config.storage.address));
-        let db_writer = Arc::clone(&db_reader);
-        let executor = Executor::new(db_reader, db_writer);
+        let executor = Executor::new(SyncStorageClient::new(&config.storage.address).into());
         let libra = TestLibraInterface {
             queued_transactions: Arc::new(RefCell::new(Vec::new())),
             storage,

--- a/secure/key-manager/src/tests.rs
+++ b/secure/key-manager/src/tests.rs
@@ -74,10 +74,11 @@ fn setup_secure_storage(
 
 impl Node {
     fn setup(config: &NodeConfig) -> Self {
-        let storage = storage_service::init_libra_db(config);
+        let (storage, db_reader_writer) = storage_service::init_libra_db(config);
         let storage_service =
             storage_service::start_storage_service_with_db(&config, storage.clone());
-        maybe_bootstrap_db::<LibraVM>(config).expect("Db-bootstrapper should not fail.");
+        maybe_bootstrap_db::<LibraVM>(db_reader_writer, config)
+            .expect("Db-bootstrapper should not fail.");
         let executor = Executor::new(SyncStorageClient::new(&config.storage.address).into());
         let libra = TestLibraInterface {
             queued_transactions: Arc::new(RefCell::new(Vec::new())),

--- a/storage/libradb/src/backup/test.rs
+++ b/storage/libradb/src/backup/test.rs
@@ -5,6 +5,7 @@ use crate::{test_helper::arb_blocks_to_commit, LibraDB};
 use anyhow::Result;
 use libra_temppath::TempPath;
 use proptest::prelude::*;
+use storage_interface::DbWriter;
 
 proptest! {
     #![proptest_config(ProptestConfig::with_cases(10))]

--- a/storage/storage-interface/src/lib.rs
+++ b/storage/storage-interface/src/lib.rs
@@ -139,6 +139,14 @@ impl DbReaderWriter {
 
         Self { reader, writer }
     }
+
+    pub fn wrap<D: 'static + DbReader + DbWriter>(db: D) -> (Arc<D>, Self) {
+        let arc_db = Arc::new(db);
+        let reader = Arc::clone(&arc_db);
+        let writer = Arc::clone(&arc_db);
+
+        (arc_db, Self { reader, writer })
+    }
 }
 
 impl<D> From<D> for DbReaderWriter

--- a/storage/storage-service/src/lib.rs
+++ b/storage/storage-service/src/lib.rs
@@ -21,7 +21,7 @@ use libra_types::proto::types::{
 };
 use libradb::LibraDB;
 use std::{convert::TryFrom, path::Path, sync::Arc};
-use storage_interface::DbReader;
+use storage_interface::{DbReader, DbReaderWriter, DbWriter};
 use storage_proto::proto::storage::{
     storage_server::{Storage, StorageServer},
     BackupAccountStateRequest, BackupAccountStateResponse, BackupTransactionInfoRequest,
@@ -35,8 +35,8 @@ use storage_proto::proto::storage::{
 };
 use tokio::runtime::Runtime;
 
-pub fn init_libra_db(config: &NodeConfig) -> Arc<LibraDB> {
-    Arc::new(LibraDB::new(&config.storage.dir()))
+pub fn init_libra_db(config: &NodeConfig) -> (Arc<LibraDB>, DbReaderWriter) {
+    DbReaderWriter::wrap(LibraDB::new(&config.storage.dir()))
 }
 
 /// Starts storage service with a given LibraDB


### PR DESCRIPTION
Introduced `DbReaderWriter` to use in place of `Arc<DbReader + DbWriter>`, because there's a catch in Rust that you can't cast `Arc<DbReader + DbWriter>` to `Arc<DbReader>`.

Used that in Executor / Db-bootstrapper interfaces, so that they can work with both local and remote DB.
 
## Motivation

It makes more sense to bootstrap the db locally instead of remotely. Plus I don't need to implement the new interfaces I needed in the storage service.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?

yes

## Test Plan

existing coverage

## Related PRs

(If this PR adds or changes functionality, please take some time to update the docs at https://github.com/libra/website, and link to your PR here.)
