### PR TITLE
[cluster-test] Setup DNS for every libra node

### DIFF
--- a/testsuite/cluster-test/src/cluster_swarm/fullnode_spec_template.yaml
+++ b/testsuite/cluster-test/src/cluster_swarm/fullnode_spec_template.yaml
@@ -5,6 +5,7 @@ metadata:
   labels:
     app: libra-fullnode
     libra-node: "true"
+    peer_id: fn-{validator_index}-{fullnode_index}
   annotations:
     prometheus.io/should_be_scraped: "true"
 spec:

--- a/testsuite/cluster-test/src/cluster_swarm/libra_node_service_template.yaml
+++ b/testsuite/cluster-test/src/cluster_swarm/libra_node_service_template.yaml
@@ -1,0 +1,30 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {peer_id}
+  labels:
+    app: libra-validator
+    libra-node: "true"
+    peer_id: {peer_id}
+spec:
+  type: ClusterIP
+  selector:
+    app: libra-validator
+    libra-node: "true"
+    peer_id: {peer_id}
+  ports:
+    - name: "port6180"
+      protocol: TCP
+      port: 6180
+    - name: "port6181"
+      protocol: TCP
+      port: 6181
+    - name: "port8000"
+      protocol: TCP
+      port: 8000
+    - name: "port9101"
+      protocol: TCP
+      port: 9101
+    - name: "port6191"
+      protocol: TCP
+      port: 6191

--- a/testsuite/cluster-test/src/cluster_swarm/validator_spec_template.yaml
+++ b/testsuite/cluster-test/src/cluster_swarm/validator_spec_template.yaml
@@ -5,6 +5,7 @@ metadata:
   labels:
     app: libra-validator
     libra-node: "true"
+    peer_id: val-{index}
   annotations:
     prometheus.io/should_be_scraped: "true"
 spec:


### PR DESCRIPTION
## Summary

* This gives each libra-node a dns hostname which is the same as its peer_id. Eg: `val-0`, `fn-2-0`
* These dns hostnames will be later used in genesis for referring to libra-nodes
