### PR TITLE
[fuzzing] suppress leak in libc

### DIFF
--- a/testsuite/libra-fuzzer/lsan_suppressions.txt
+++ b/testsuite/libra-fuzzer/lsan_suppressions.txt
@@ -1,2 +1,3 @@
 leak:lazy_static
 leak:backtrace
+leak:libc


### PR DESCRIPTION
## Motivation
CI generates mem leak warnings in libc fast_thread_local that are not
reproducible in dev env or google's oss-fuzz.  Suppress LeakSanitizer
warnings in libc for now.

## Test Plan
Canary in CI.
