### PR TITLE
[consensus] de-asyncify mainloop

### DIFF
--- a/common/channel/src/libra_channel.rs
+++ b/common/channel/src/libra_channel.rs
@@ -133,6 +133,18 @@ impl<K: Eq + Hash + Clone, M> Receiver<K, M> {
         let mut shared_state = self.shared_state.lock().unwrap();
         shared_state.internal_queue.clear();
     }
+
+    pub fn try_recv(&mut self) -> Option<M> {
+        let mut shared_state = self.shared_state.lock().unwrap();
+        if let Some((val, status_ch)) = shared_state.internal_queue.pop() {
+            if let Some(status_ch) = status_ch {
+                let _err = status_ch.send(ElementStatus::Dequeued);
+            }
+            Some(val)
+        } else {
+            None
+        }
+    }
 }
 
 impl<K: Eq + Hash + Clone, M> Drop for Receiver<K, M> {

--- a/consensus/src/chained_bft/block_storage/block_store.rs
+++ b/consensus/src/chained_bft/block_storage/block_store.rs
@@ -164,7 +164,7 @@ impl<T: Payload> BlockStore<T> {
     }
 
     /// Commit the given block id with the proof, returns the path from current root or error
-    pub async fn commit(
+    pub fn commit(
         &self,
         finality_proof: LedgerInfoWithSignatures,
     ) -> anyhow::Result<Vec<Arc<ExecutedBlock<T>>>> {
@@ -188,7 +188,6 @@ impl<T: Payload> BlockStore<T> {
                 blocks_to_commit.iter().map(|b| b.id()).collect(),
                 finality_proof,
             )
-            .await
             .expect("Failed to persist commit");
         counters::LAST_COMMITTED_ROUND.set(block_to_commit.round() as i64);
         debug!("{}Committed{} {}", Fg(Blue), Fg(Reset), *block_to_commit);
@@ -201,7 +200,7 @@ impl<T: Payload> BlockStore<T> {
         Ok(blocks_to_commit)
     }
 
-    pub async fn rebuild(
+    pub fn rebuild(
         &self,
         root: RootInfo<T>,
         root_metadata: RootMetadata,
@@ -233,7 +232,7 @@ impl<T: Payload> BlockStore<T> {
         // Here we commit up to the highest_commit_cert to maintain highest_commit_cert == state_computer.committed_trees.
         if self.highest_commit_cert().commit_info().round() > self.root().round() {
             let finality_proof = self.highest_commit_cert().ledger_info().clone();
-            if let Err(e) = self.commit(finality_proof).await {
+            if let Err(e) = self.commit(finality_proof) {
                 warn!("{:?}", e);
             }
         }

--- a/consensus/src/chained_bft/block_storage/sync_manager.rs
+++ b/consensus/src/chained_bft/block_storage/sync_manager.rs
@@ -192,7 +192,7 @@ impl<T: Payload> BlockStore<T> {
 
         // If a node restarts in the middle of state synchronization, it is going to try to catch up
         // to the stored quorum certs as the new root.
-        storage.save_tree(blocks.clone(), quorum_certs.clone())?;
+        storage.save_tree(blocks, quorum_certs)?;
         let pre_sync_instance = Instant::now();
         state_computer.sync_to(highest_commit_cert.ledger_info().clone())?;
         counters::STATE_SYNC_DURATION_S.observe_duration(pre_sync_instance.elapsed());

--- a/consensus/src/chained_bft/block_storage/sync_manager.rs
+++ b/consensus/src/chained_bft/block_storage/sync_manager.rs
@@ -151,8 +151,7 @@ impl<T: Payload> BlockStore<T> {
         .await?
         .take();
         debug!("{}Sync to{} {}", Fg(Blue), Fg(Reset), root.0);
-        self.rebuild(root, root_metadata, blocks, quorum_certs)
-            .await;
+        self.rebuild(root, root_metadata, blocks, quorum_certs);
 
         if highest_commit_cert.ends_epoch() {
             retriever
@@ -201,9 +200,7 @@ impl<T: Payload> BlockStore<T> {
         // to the stored quorum certs as the new root.
         storage.save_tree(blocks.clone(), quorum_certs.clone())?;
         let pre_sync_instance = Instant::now();
-        state_computer
-            .sync_to(highest_commit_cert.ledger_info().clone())
-            .await?;
+        state_computer.sync_to(highest_commit_cert.ledger_info().clone())?;
         counters::STATE_SYNC_DURATION_S.observe_duration(pre_sync_instance.elapsed());
         let recovery_data = storage
             .start()

--- a/consensus/src/chained_bft/chained_bft_smr.rs
+++ b/consensus/src/chained_bft/chained_bft_smr.rs
@@ -96,15 +96,15 @@ impl<T: Payload> ChainedBftSMR<T> {
                 select! {
                     msg = network_receivers.consensus_messages.select_next_some() => {
                         idle_duration = pre_select_instant.elapsed();
-                        epoch_manager.process_message(msg.0, msg.1).await
+                        epoch_manager.process_message(msg.0, msg.1)
                     }
                     block_retrieval = network_receivers.block_retrieval.select_next_some() => {
                         idle_duration = pre_select_instant.elapsed();
-                        epoch_manager.process_block_retrieval(block_retrieval).await
+                        epoch_manager.process_block_retrieval(block_retrieval)
                     }
                     round = pacemaker_timeout_sender_rx.select_next_some() => {
                         idle_duration = pre_select_instant.elapsed();
-                        epoch_manager.process_local_timeout(round).await
+                        epoch_manager.process_local_timeout(round)
                     }
                 }
                 counters::EVENT_PROCESSING_LOOP_BUSY_DURATION_S
@@ -123,7 +123,7 @@ impl<T: Payload> ConsensusProvider for ChainedBftSMR<T> {
     /// 2. Construct per-epoch component with the fixed Validators provided by EpochManager including
     /// ProposerElection, Pacemaker, SafetyRules, Network(Populate with known validators), EventProcessor
     fn start(&mut self) -> Result<()> {
-        let mut runtime = runtime::Builder::new()
+        let runtime = runtime::Builder::new()
             .thread_name("consensus-")
             .threaded_scheduler()
             .enable_all()
@@ -154,7 +154,7 @@ impl<T: Payload> ConsensusProvider for ChainedBftSMR<T> {
         let (network_task, network_receiver) =
             NetworkTask::new(input.network_events, self_receiver);
 
-        runtime.block_on(epoch_mgr.start_processor());
+        epoch_mgr.start_processor();
 
         // TODO: this is for testing, remove
         self.block_store = epoch_mgr.block_store();

--- a/consensus/src/chained_bft/chained_bft_smr.rs
+++ b/consensus/src/chained_bft/chained_bft_smr.rs
@@ -132,7 +132,7 @@ impl<T: Payload> ConsensusProvider for ChainedBftSMR<T> {
         let input = self.input.take().expect("already started, input is None");
 
         let executor = runtime.handle().clone();
-        let time_service = Arc::new(ClockTimeService::new(executor.clone()));
+        let time_service = Arc::new(ClockTimeService::new());
 
         let (timeout_sender, timeout_receiver) =
             channel::new(1_024, &counters::PENDING_PACEMAKER_TIMEOUTS);

--- a/consensus/src/chained_bft/epoch_manager.rs
+++ b/consensus/src/chained_bft/epoch_manager.rs
@@ -21,7 +21,7 @@ use crate::{
     },
     counters,
     state_replication::{StateComputer, TxnManager},
-    util::time_service::{ClockTimeService, TimeService},
+    util::time_service::TimeService,
 };
 use anyhow::anyhow;
 use consensus_types::{
@@ -69,7 +69,7 @@ impl<T: Payload> LivenessStorageData<T> {
 pub struct EpochManager<T> {
     author: Author,
     config: ConsensusConfig,
-    time_service: Arc<ClockTimeService>,
+    time_service: Arc<dyn TimeService>,
     self_sender: channel::Sender<anyhow::Result<Event<ConsensusMsg<T>>>>,
     network_sender: ConsensusNetworkSender<T>,
     timeout_sender: channel::Sender<Round>,
@@ -84,7 +84,7 @@ impl<T: Payload> EpochManager<T> {
     pub fn new(
         author: Author,
         config: ConsensusConfig,
-        time_service: Arc<ClockTimeService>,
+        time_service: Arc<dyn TimeService>,
         self_sender: channel::Sender<anyhow::Result<Event<ConsensusMsg<T>>>>,
         network_sender: ConsensusNetworkSender<T>,
         timeout_sender: channel::Sender<Round>,

--- a/consensus/src/chained_bft/event_processor.rs
+++ b/consensus/src/chained_bft/event_processor.rs
@@ -895,7 +895,7 @@ impl<T: Payload> EventProcessor<T> {
 
     /// Upon (potentially) new commit, commit the blocks via block store.
     async fn process_commit(&mut self, finality_proof: LedgerInfoWithSignatures) {
-        let blocks_to_commit = match self.block_store.commit(finality_proof.clone()).await {
+        let blocks_to_commit = match self.block_store.commit(finality_proof.clone()) {
             Ok(blocks) => blocks,
             Err(e) => {
                 error!("{:?}", e);

--- a/consensus/src/chained_bft/event_processor.rs
+++ b/consensus/src/chained_bft/event_processor.rs
@@ -650,9 +650,7 @@ impl<T: Payload> EventProcessor<T> {
             self.time_service.as_ref(),
             Duration::from_micros(block_timestamp_us),
             current_round_deadline,
-        )
-        .await
-        {
+        ) {
             Ok(waiting_success) => {
                 debug!("Success with {:?} for being able to vote", waiting_success);
 

--- a/consensus/src/chained_bft/event_processor_fuzzing.rs
+++ b/consensus/src/chained_bft/event_processor_fuzzing.rs
@@ -65,7 +65,7 @@ fn build_empty_store(
 fn create_pacemaker() -> Pacemaker {
     let base_timeout = std::time::Duration::new(60, 0);
     let time_interval = Box::new(ExponentialTimeInterval::fixed(base_timeout));
-    let (pacemaker_timeout_sender, _) = channel::new_test(1_024);
+    let (pacemaker_timeout_sender, _) = std::sync::mpsc::channel();
     let time_service = Arc::new(SimulatedTimeService::new());
     Pacemaker::new(time_interval, time_service, pacemaker_timeout_sender)
 }

--- a/consensus/src/chained_bft/event_processor_fuzzing.rs
+++ b/consensus/src/chained_bft/event_processor_fuzzing.rs
@@ -33,17 +33,13 @@ use tokio::runtime::Runtime;
 // This generates a proposal for round 1
 pub fn generate_corpus_proposal() -> Vec<u8> {
     let mut event_processor = create_node_for_fuzzing();
-    block_on(async {
-        let proposal = event_processor
-            .generate_proposal(NewRoundEvent {
-                round: 1,
-                reason: NewRoundReason::QCReady,
-                timeout: std::time::Duration::new(5, 0),
-            })
-            .await;
-        // serialize and return proposal
-        lcs::to_bytes(&proposal.unwrap()).unwrap()
-    })
+    let proposal = event_processor.generate_proposal(NewRoundEvent {
+        round: 1,
+        reason: NewRoundReason::QCReady,
+        timeout: std::time::Duration::new(5, 0),
+    });
+    // serialize and return proposal
+    lcs::to_bytes(&proposal.unwrap()).unwrap()
 }
 
 // optimization for the fuzzer

--- a/consensus/src/chained_bft/event_processor_fuzzing.rs
+++ b/consensus/src/chained_bft/event_processor_fuzzing.rs
@@ -19,7 +19,7 @@ use crate::{
 };
 use channel::{self, libra_channel, message_queues::QueueStyle};
 use consensus_types::proposal_msg::ProposalMsg;
-use futures::{channel::mpsc, executor::block_on};
+use futures::channel::mpsc;
 use libra_types::{
     ledger_info::LedgerInfoWithSignatures, validator_signer::ValidatorSigner,
     validator_verifier::ValidatorVerifier,
@@ -171,11 +171,9 @@ pub fn fuzz_proposal(data: &[u8]) {
         }
     };
 
-    block_on(async move {
-        // TODO: make sure this obtains a vote when testing
-        // TODO: make sure that if this obtains a vote, it's for round 1, etc.
-        event_processor.process_proposal_msg(proposal).await;
-    });
+    // TODO: make sure this obtains a vote when testing
+    // TODO: make sure that if this obtains a vote, it's for round 1, etc.
+    event_processor.process_proposal_msg(proposal);
 }
 
 // This test is here so that the fuzzer can be maintained

--- a/consensus/src/chained_bft/event_processor_test.rs
+++ b/consensus/src/chained_bft/event_processor_test.rs
@@ -165,7 +165,7 @@ impl NodeSetup {
             10, // max pruned blocks in mem
         ));
 
-        let time_service = Arc::new(ClockTimeService::new(executor));
+        let time_service = Arc::new(ClockTimeService::new());
 
         let proposal_generator = ProposalGenerator::new(
             author,

--- a/consensus/src/chained_bft/liveness/pacemaker.rs
+++ b/consensus/src/chained_bft/liveness/pacemaker.rs
@@ -9,7 +9,7 @@ use consensus_types::common::Round;
 use libra_logger::prelude::*;
 use std::{
     fmt,
-    sync::Arc,
+    sync::{mpsc, Arc},
     time::{Duration, Instant},
 };
 
@@ -145,7 +145,7 @@ pub struct Pacemaker {
     // Service for timer
     time_service: Arc<dyn TimeService>,
     // To send local timeout events to the subscriber (e.g., SMR)
-    timeout_sender: channel::Sender<Round>,
+    timeout_sender: mpsc::Sender<Round>,
 }
 
 #[allow(dead_code)]
@@ -153,7 +153,7 @@ impl Pacemaker {
     pub fn new(
         time_interval: Box<dyn PacemakerTimeInterval>,
         time_service: Arc<dyn TimeService>,
-        timeout_sender: channel::Sender<Round>,
+        timeout_sender: mpsc::Sender<Round>,
     ) -> Self {
         // Our counters are initialized lazily, so they're not going to appear in
         // Prometheus if some conditions never happen. Invoking get() function enforces creation.

--- a/consensus/src/chained_bft/liveness/proposal_generator.rs
+++ b/consensus/src/chained_bft/liveness/proposal_generator.rs
@@ -100,7 +100,7 @@ impl<T: Payload> ProposalGenerator<T> {
     /// 2. The round is provided by the caller.
     /// 3. In case a given round is not greater than the calculated parent, return an OldRound
     /// error.
-    pub async fn generate_proposal(
+    pub fn generate_proposal(
         &mut self,
         round: Round,
         round_deadline: Instant,
@@ -204,7 +204,6 @@ impl<T: Payload> ProposalGenerator<T> {
         let txns = self
             .txn_manager
             .pull_txns(self.max_block_size, exclude_payload)
-            .await
             .context("Fail to retrieve txn")?;
 
         Ok(BlockData::new_proposal(

--- a/consensus/src/chained_bft/liveness/proposal_generator.rs
+++ b/consensus/src/chained_bft/liveness/proposal_generator.rs
@@ -140,9 +140,7 @@ impl<T: Payload> ProposalGenerator<T> {
                 self.time_service.as_ref(),
                 Duration::from_micros(hqc.certified_block().timestamp_usecs()),
                 round_deadline,
-            )
-            .await
-            {
+            ) {
                 Ok(waiting_success) => {
                     debug!(
                         "Success with {:?} for getting a valid timestamp for the next proposal",

--- a/consensus/src/chained_bft/liveness/proposal_generator_test.rs
+++ b/consensus/src/chained_bft/liveness/proposal_generator_test.rs
@@ -23,8 +23,7 @@ fn minute_from_now() -> Instant {
     Instant::now() + Duration::new(60, 0)
 }
 
-#[tokio::test]
-async fn test_proposal_generation_empty_tree() {
+fn test_proposal_generation_empty_tree() {
     let signer = ValidatorSigner::random(None);
     let block_store = build_empty_tree();
     let mut proposal_generator = ProposalGenerator::new(
@@ -39,7 +38,6 @@ async fn test_proposal_generation_empty_tree() {
     // Generate proposals for an empty tree.
     let proposal_data = proposal_generator
         .generate_proposal(1, minute_from_now())
-        .await
         .unwrap();
     let proposal = Block::new_proposal_from_block_data(proposal_data, &signer);
     assert_eq!(proposal.parent_id(), genesis.id());
@@ -49,13 +47,11 @@ async fn test_proposal_generation_empty_tree() {
     // Duplicate proposals on the same round are not allowed
     let proposal_err = proposal_generator
         .generate_proposal(1, minute_from_now())
-        .await
         .err();
     assert!(proposal_err.is_some());
 }
 
-#[tokio::test]
-async fn test_proposal_generation_parent() {
+fn test_proposal_generation_parent() {
     let mut inserter = TreeInserter::default();
     let block_store = inserter.block_store();
     let mut proposal_generator = ProposalGenerator::new(
@@ -74,7 +70,6 @@ async fn test_proposal_generation_parent() {
     assert_eq!(
         proposal_generator
             .generate_proposal(10, minute_from_now())
-            .await
             .unwrap()
             .parent_id(),
         genesis.id()
@@ -84,7 +79,6 @@ async fn test_proposal_generation_parent() {
     inserter.insert_qc_for_block(a1.as_ref(), None);
     let a1_child_res = proposal_generator
         .generate_proposal(11, minute_from_now())
-        .await
         .unwrap();
     assert_eq!(a1_child_res.parent_id(), a1.id());
     assert_eq!(a1_child_res.round(), 11);
@@ -94,15 +88,13 @@ async fn test_proposal_generation_parent() {
     inserter.insert_qc_for_block(b1.as_ref(), None);
     let b1_child_res = proposal_generator
         .generate_proposal(12, minute_from_now())
-        .await
         .unwrap();
     assert_eq!(b1_child_res.parent_id(), b1.id());
     assert_eq!(b1_child_res.round(), 12);
     assert_eq!(b1_child_res.quorum_cert().certified_block().id(), b1.id());
 }
 
-#[tokio::test]
-async fn test_old_proposal_generation() {
+fn test_old_proposal_generation() {
     let mut inserter = TreeInserter::default();
     let block_store = inserter.block_store();
     let mut proposal_generator = ProposalGenerator::new(
@@ -118,13 +110,11 @@ async fn test_old_proposal_generation() {
 
     let proposal_err = proposal_generator
         .generate_proposal(1, minute_from_now())
-        .await
         .err();
     assert!(proposal_err.is_some());
 }
 
-#[tokio::test]
-async fn test_empty_proposal_after_reconfiguration() {
+fn test_empty_proposal_after_reconfiguration() {
     let mut inserter = TreeInserter::default();
     let block_store = inserter.block_store();
     let mut proposal_generator = ProposalGenerator::new(
@@ -139,7 +129,6 @@ async fn test_empty_proposal_after_reconfiguration() {
     // Normal proposal is not empty
     let normal_proposal_1 = proposal_generator
         .generate_proposal(42, minute_from_now())
-        .await
         .unwrap();
     assert!(!normal_proposal_1.payload().unwrap().is_empty());
     let a2 = inserter.insert_reconfiguration_block(&a1, 2);
@@ -147,7 +136,6 @@ async fn test_empty_proposal_after_reconfiguration() {
     // The direct child is empty
     let empty_proposal_1 = proposal_generator
         .generate_proposal(43, minute_from_now())
-        .await
         .unwrap();
     assert!(empty_proposal_1.payload().unwrap().is_empty());
     // insert one more block after reconfiguration
@@ -162,7 +150,6 @@ async fn test_empty_proposal_after_reconfiguration() {
     // Indirect child is empty too
     let empty_proposal_2 = proposal_generator
         .generate_proposal(44, minute_from_now())
-        .await
         .unwrap();
     assert!(empty_proposal_2.payload().unwrap().is_empty());
     // if reconfiguration is committed, not allow to generate proposal
@@ -180,8 +167,6 @@ async fn test_empty_proposal_after_reconfiguration() {
         Some(a2.block_info()),
     );
     block_store.insert_single_quorum_cert(li).unwrap();
-    let err_proposal = proposal_generator
-        .generate_proposal(45, minute_from_now())
-        .await;
+    let err_proposal = proposal_generator.generate_proposal(45, minute_from_now());
     assert!(err_proposal.is_err());
 }

--- a/consensus/src/chained_bft/network.rs
+++ b/consensus/src/chained_bft/network.rs
@@ -17,8 +17,9 @@ use consensus_types::{
     sync_info::SyncInfo,
     vote_msg::VoteMsg,
 };
-use futures::executor::block_on;
-use futures::{channel::oneshot, stream::select, SinkExt, Stream, StreamExt, TryStreamExt};
+use futures::{
+    channel::oneshot, executor::block_on, stream::select, SinkExt, Stream, StreamExt, TryStreamExt,
+};
 use libra_logger::prelude::*;
 use libra_security_logger::{security_log, SecurityEvent};
 use libra_types::{

--- a/consensus/src/chained_bft/network_tests.rs
+++ b/consensus/src/chained_bft/network_tests.rs
@@ -400,9 +400,7 @@ mod tests {
             SyncInfo::new(previous_qc.clone(), previous_qc, None),
         );
         timed_block_on(&mut runtime, async {
-            nodes[0]
-                .send_vote(vote_msg.clone(), peers[2..5].to_vec())
-                .await;
+            nodes[0].send_vote(vote_msg.clone(), peers[2..5].to_vec());
             playground
                 .wait_for_messages(3, NetworkPlayground::take_all::<TestPayload>)
                 .await;
@@ -413,7 +411,7 @@ mod tests {
                     _ => panic!("unexpected messages"),
                 }
             }
-            nodes[0].broadcast_proposal(proposal.clone()).await;
+            nodes[0].broadcast_proposal(proposal.clone());
             playground
                 .wait_for_messages(4, NetworkPlayground::take_all::<TestPayload>)
                 .await;
@@ -488,8 +486,8 @@ mod tests {
                 // make sure the network task is not blocked during RPC
                 // we limit the network notification queue size to 1 so if it's blocked,
                 // we can not process 2 votes and the test will timeout
-                node0.send_vote(vote_msg.clone(), vec![peer1]).await;
-                node0.send_vote(vote_msg.clone(), vec![peer1]).await;
+                node0.send_vote(vote_msg.clone(), vec![peer1]);
+                node0.send_vote(vote_msg.clone(), vec![peer1]);
                 playground
                     .wait_for_messages(2, NetworkPlayground::votes_only::<TestPayload>)
                     .await;
@@ -511,7 +509,6 @@ mod tests {
                     peer,
                     Duration::from_secs(5),
                 )
-                .await
                 .unwrap();
             assert_eq!(response.status(), BlockRetrievalStatus::IdNotFound);
         });

--- a/consensus/src/chained_bft/test_utils/mock_state_computer.rs
+++ b/consensus/src/chained_bft/test_utils/mock_state_computer.rs
@@ -46,7 +46,6 @@ impl MockStateComputer {
     }
 }
 
-#[async_trait::async_trait]
 impl StateComputer for MockStateComputer {
     type Payload = Vec<usize>;
     fn compute(
@@ -68,11 +67,7 @@ impl StateComputer for MockStateComputer {
         ))
     }
 
-    async fn commit(
-        &self,
-        block_ids: Vec<HashValue>,
-        commit: LedgerInfoWithSignatures,
-    ) -> Result<()> {
+    fn commit(&self, block_ids: Vec<HashValue>, commit: LedgerInfoWithSignatures) -> Result<()> {
         self.consensus_db
             .commit_to_storage(commit.ledger_info().clone());
 
@@ -97,7 +92,7 @@ impl StateComputer for MockStateComputer {
         Ok(())
     }
 
-    async fn sync_to(&self, commit: LedgerInfoWithSignatures) -> Result<()> {
+    fn sync_to(&self, commit: LedgerInfoWithSignatures) -> Result<()> {
         debug!(
             "{}Fake sync{} to block id {}",
             Fg(Blue),
@@ -112,11 +107,7 @@ impl StateComputer for MockStateComputer {
         Ok(())
     }
 
-    async fn get_epoch_proof(
-        &self,
-        _start_epoch: u64,
-        _end_epoch: u64,
-    ) -> Result<ValidatorChangeProof> {
+    fn get_epoch_proof(&self, _start_epoch: u64, _end_epoch: u64) -> Result<ValidatorChangeProof> {
         Err(format_err!(
             "epoch proof not supported in mock state computer"
         ))
@@ -125,7 +116,6 @@ impl StateComputer for MockStateComputer {
 
 pub struct EmptyStateComputer;
 
-#[async_trait::async_trait]
 impl StateComputer for EmptyStateComputer {
     type Payload = TestPayload;
     fn compute(
@@ -143,23 +133,15 @@ impl StateComputer for EmptyStateComputer {
         ))
     }
 
-    async fn commit(
-        &self,
-        _block_ids: Vec<HashValue>,
-        _commit: LedgerInfoWithSignatures,
-    ) -> Result<()> {
+    fn commit(&self, _block_ids: Vec<HashValue>, _commit: LedgerInfoWithSignatures) -> Result<()> {
         Ok(())
     }
 
-    async fn sync_to(&self, _commit: LedgerInfoWithSignatures) -> Result<()> {
+    fn sync_to(&self, _commit: LedgerInfoWithSignatures) -> Result<()> {
         Ok(())
     }
 
-    async fn get_epoch_proof(
-        &self,
-        _start_epoch: u64,
-        _end_epoch: u64,
-    ) -> Result<ValidatorChangeProof> {
+    fn get_epoch_proof(&self, _start_epoch: u64, _end_epoch: u64) -> Result<ValidatorChangeProof> {
         Err(format_err!(
             "epoch proof not supported in empty state computer"
         ))

--- a/consensus/src/chained_bft/test_utils/mock_state_computer.rs
+++ b/consensus/src/chained_bft/test_utils/mock_state_computer.rs
@@ -82,13 +82,13 @@ impl StateComputer for MockStateComputer {
                 .ok_or_else(|| format_err!("Cannot find block"))?;
             txns.append(&mut payload);
         }
-        self.state_sync_client
-            .unbounded_send(txns)
-            .expect("Fail to notify state sync about commit");
+        if let Err(e) = self.state_sync_client.unbounded_send(txns) {
+            debug!("Fail to notify state sync about commit: {:?}", e);
+        }
 
-        self.commit_callback
-            .unbounded_send(commit)
-            .expect("Fail to notify about commit.");
+        if let Err(e) = self.commit_callback.unbounded_send(commit) {
+            debug!("Failed to notify about commit: {:?}", e);
+        }
         Ok(())
     }
 
@@ -101,9 +101,9 @@ impl StateComputer for MockStateComputer {
         );
         self.consensus_db
             .commit_to_storage(commit.ledger_info().clone());
-        self.commit_callback
-            .unbounded_send(commit)
-            .expect("Fail to notify about sync");
+        if let Err(e) = self.commit_callback.unbounded_send(commit) {
+            debug!("Failed to notify about commit: {:?}", e);
+        }
         Ok(())
     }
 

--- a/consensus/src/chained_bft/test_utils/mock_txn_manager.rs
+++ b/consensus/src/chained_bft/test_utils/mock_txn_manager.rs
@@ -52,12 +52,11 @@ fn mock_transaction_status(count: usize) -> Vec<TransactionStatus> {
     statuses
 }
 
-#[async_trait::async_trait]
 impl TxnManager for MockTransactionManager {
     type Payload = Vec<MockTransaction>;
 
     /// The returned future is fulfilled with the vector of SignedTransactions
-    async fn pull_txns(
+    fn pull_txns(
         &mut self,
         max_size: u64,
         _exclude_txns: Vec<&Self::Payload>,
@@ -69,7 +68,7 @@ impl TxnManager for MockTransactionManager {
         Ok(res)
     }
 
-    async fn commit_txns(
+    fn commit_txns(
         &mut self,
         txns: &Self::Payload,
         compute_results: &StateComputeResult,
@@ -88,7 +87,6 @@ impl TxnManager for MockTransactionManager {
                 .as_mut()
                 .unwrap()
                 .commit_txns(&vec![], &mock_compute_result)
-                .await
                 .is_ok());
         }
         Ok(())

--- a/consensus/src/counters.rs
+++ b/consensus/src/counters.rs
@@ -415,12 +415,3 @@ pub static PENDING_SELF_MESSAGES: Lazy<IntGauge> = Lazy::new(|| {
     )
     .unwrap()
 });
-
-/// Count of the pending outbound pacemaker timeouts
-pub static PENDING_PACEMAKER_TIMEOUTS: Lazy<IntGauge> = Lazy::new(|| {
-    register_int_gauge!(
-        "libra_consensus_pending_pacemaker_timeouts",
-        "Count of the pending outbound pacemaker timeouts"
-    )
-    .unwrap()
-});

--- a/consensus/src/state_replication.rs
+++ b/consensus/src/state_replication.rs
@@ -8,14 +8,13 @@ use libra_crypto::HashValue;
 use libra_types::{ledger_info::LedgerInfoWithSignatures, validator_change::ValidatorChangeProof};
 
 /// Retrieves and updates the status of transactions on demand (e.g., via talking with Mempool)
-#[async_trait::async_trait]
 pub trait TxnManager: Send + Sync {
     type Payload;
 
     /// Brings new transactions to be applied.
     /// The `exclude_txns` list includes the transactions that are already pending in the
     /// branch of blocks consensus is trying to extend.
-    async fn pull_txns(
+    fn pull_txns(
         &mut self,
         max_size: u64,
         exclude_txns: Vec<&Self::Payload>,
@@ -23,7 +22,7 @@ pub trait TxnManager: Send + Sync {
 
     /// Notifies TxnManager about the payload of the committed block including the state compute
     /// result, which includes the specifics of what transactions succeeded and failed.
-    async fn commit_txns(
+    fn commit_txns(
         &mut self,
         txns: &Self::Payload,
         compute_result: &StateComputeResult,

--- a/consensus/src/state_replication.rs
+++ b/consensus/src/state_replication.rs
@@ -45,7 +45,6 @@ impl<T> Clone for Box<dyn TxnManager<Payload = T>> {
 /// While Consensus is managing proposed blocks, `StateComputer` is managing the results of the
 /// (speculative) execution of their payload.
 /// StateComputer is using proposed block ids for identifying the transactions.
-#[async_trait::async_trait]
 pub trait StateComputer: Send + Sync {
     type Payload;
 
@@ -61,7 +60,7 @@ pub trait StateComputer: Send + Sync {
     ) -> Result<StateComputeResult>;
 
     /// Send a successful commit. A future is fulfilled when the state is finalized.
-    async fn commit(
+    fn commit(
         &self,
         block_ids: Vec<HashValue>,
         finality_proof: LedgerInfoWithSignatures,
@@ -71,12 +70,8 @@ pub trait StateComputer: Send + Sync {
     /// In case of success (`Result::Ok`) the LI of storage is at the given target.
     /// In case of failure (`Result::Error`) the LI of storage remains unchanged, and the validator
     /// can assume there were no modifications to the storage made.
-    async fn sync_to(&self, target: LedgerInfoWithSignatures) -> Result<()>;
+    fn sync_to(&self, target: LedgerInfoWithSignatures) -> Result<()>;
 
     /// Generate the epoch change proof from start_epoch to the latest epoch.
-    async fn get_epoch_proof(
-        &self,
-        start_epoch: u64,
-        end_epoch: u64,
-    ) -> Result<ValidatorChangeProof>;
+    fn get_epoch_proof(&self, start_epoch: u64, end_epoch: u64) -> Result<ValidatorChangeProof>;
 }

--- a/consensus/src/txn_manager.rs
+++ b/consensus/src/txn_manager.rs
@@ -5,8 +5,10 @@ use crate::state_replication::TxnManager;
 use anyhow::{format_err, Result};
 use debug_interface::prelude::*;
 use executor_types::StateComputeResult;
-use futures::channel::{mpsc, oneshot};
-use futures::executor::block_on;
+use futures::{
+    channel::{mpsc, oneshot},
+    executor::block_on,
+};
 use libra_crypto::HashValue;
 use libra_mempool::{
     CommittedTransaction, ConsensusRequest, ConsensusResponse, TransactionExclusion,

--- a/consensus/src/util/mock_time_service.rs
+++ b/consensus/src/util/mock_time_service.rs
@@ -2,10 +2,8 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::util::time_service::{ScheduledTask, TimeService};
-use futures::{Future, FutureExt};
 use libra_logger::prelude::*;
 use std::{
-    pin::Pin,
     sync::{Arc, Mutex},
     time::Duration,
 };
@@ -62,16 +60,13 @@ impl TimeService for SimulatedTimeService {
         self.inner.lock().unwrap().now
     }
 
-    fn sleep(&self, t: Duration) -> Pin<Box<dyn Future<Output = ()> + Send>> {
+    fn sleep(&self, t: Duration) {
         let inner = self.inner.clone();
-        let fut = async move {
-            let mut inner = inner.lock().unwrap();
-            inner.now += t;
-            if inner.now > inner.max {
-                inner.now = inner.max;
-            }
-        };
-        fut.boxed()
+        let mut inner = inner.lock().unwrap();
+        inner.now += t;
+        if inner.now > inner.max {
+            inner.now = inner.max;
+        }
     }
 }
 

--- a/consensus/src/util/mock_time_service.rs
+++ b/consensus/src/util/mock_time_service.rs
@@ -51,8 +51,7 @@ impl TimeService for SimulatedTimeService {
             if inner.now > inner.max {
                 inner.now = inner.max;
             }
-            // Perhaps this could be done better, but I think its good enough for tests...
-            futures::executor::block_on(t.run());
+            t.run();
         }
     }
 
@@ -126,7 +125,7 @@ impl SimulatedTimeService {
         }
         for (_, mut t) in drain {
             // probably could be done better then that, but for now I feel its good enough for tests
-            futures::executor::block_on(t.run());
+            t.run();
         }
     }
 }

--- a/consensus/src/util/time_service_test.rs
+++ b/consensus/src/util/time_service_test.rs
@@ -5,7 +5,6 @@ use crate::util::{
     mock_time_service::SimulatedTimeService,
     time_service::{wait_if_possible, TimeService, WaitingError, WaitingSuccess},
 };
-use futures::executor::block_on;
 use std::time::{Duration, Instant};
 
 #[test]
@@ -13,11 +12,7 @@ fn wait_if_possible_test_waiting_required() {
     let simulated_time = SimulatedTimeService::new();
     let min_duration_since_epoch = Duration::from_secs(1);
     let max_instant = Instant::now() + Duration::from_secs(2);
-    let result = block_on(wait_if_possible(
-        &simulated_time,
-        min_duration_since_epoch,
-        max_instant,
-    ));
+    let result = wait_if_possible(&simulated_time, min_duration_since_epoch, max_instant);
 
     assert_eq!(
         result.ok().unwrap(),
@@ -31,14 +26,10 @@ fn wait_if_possible_test_waiting_required() {
 #[test]
 fn wait_if_possible_test_no_wait_required() {
     let simulated_time = SimulatedTimeService::new();
-    block_on(simulated_time.sleep(Duration::from_secs(3)));
+    simulated_time.sleep(Duration::from_secs(3));
     let min_duration_since_epoch = Duration::from_secs(1);
     let max_instant = Instant::now() + Duration::from_secs(5);
-    let result = block_on(wait_if_possible(
-        &simulated_time,
-        min_duration_since_epoch,
-        max_instant,
-    ));
+    let result = wait_if_possible(&simulated_time, min_duration_since_epoch, max_instant);
 
     assert_eq!(
         result.ok().unwrap(),
@@ -54,11 +45,7 @@ fn wait_if_possible_test_max_duration_exceeded() {
     let simulated_time = SimulatedTimeService::new();
     let min_duration_since_epoch = Duration::from_secs(3);
     let max_instant = Instant::now() + Duration::from_secs(2);
-    let result = block_on(wait_if_possible(
-        &simulated_time,
-        min_duration_since_epoch,
-        max_instant,
-    ));
+    let result = wait_if_possible(&simulated_time, min_duration_since_epoch, max_instant);
 
     assert_eq!(result.err().unwrap(), WaitingError::MaxWaitExceeded);
 }
@@ -68,11 +55,7 @@ fn wait_if_possible_test_sleep_failed() {
     let simulated_time = SimulatedTimeService::max(Duration::from_secs(1));
     let min_duration_since_epoch = Duration::from_secs(2);
     let max_instant = Instant::now() + Duration::from_secs(3);
-    let result = block_on(wait_if_possible(
-        &simulated_time,
-        min_duration_since_epoch,
-        max_instant,
-    ));
+    let result = wait_if_possible(&simulated_time, min_duration_since_epoch, max_instant);
 
     assert_eq!(
         result.err().unwrap(),

--- a/network/src/peer_manager/mod.rs
+++ b/network/src/peer_manager/mod.rs
@@ -170,12 +170,10 @@ impl PeerManagerRequestSender {
             res_tx,
             timeout,
         };
-        self.inner
-            .push(
-                (peer_id, protocol),
-                PeerManagerRequest::SendRpc(peer_id, request),
-            )
-            .unwrap();
+        self.inner.push(
+            (peer_id, protocol),
+            PeerManagerRequest::SendRpc(peer_id, request),
+        )?;
         res_rx.await?
     }
 }

--- a/state-synchronizer/src/synchronizer.rs
+++ b/state-synchronizer/src/synchronizer.rs
@@ -21,14 +21,8 @@ use libra_types::{
     validator_change::ValidatorChangeProof, waypoint::Waypoint,
 };
 use libra_vm::LibraVM;
-use std::{
-    sync::{Arc, Mutex},
-    time::Duration,
-};
-use tokio::{
-    runtime::{Builder, Runtime},
-    time::timeout,
-};
+use std::sync::{Arc, Mutex};
+use tokio::runtime::{Builder, Runtime};
 
 pub struct StateSynchronizer {
     _runtime: Runtime,
@@ -155,12 +149,13 @@ impl StateSyncClient {
                 ))
                 .await?;
 
-            match timeout(Duration::from_secs(1), callback_rcv).await {
+            // TODO: add timeout support
+            match callback_rcv.await {
                 Err(_) => {
                     Err(format_err!("[state sync client] failed to receive commit ACK from state synchronizer on time"))
                 }
                 Ok(resp) => {
-                    let CommitResponse { msg } = resp??;
+                    let CommitResponse { msg } = resp?;
                     if msg != "" {
                         Err(format_err!("[state sync client] commit failed: {:?}", msg))
                     } else {


### PR DESCRIPTION
<!--
Thank you for sending a PR. We appreciate you spending time to help improve the Libra project.

The project is undergoing daily changes. Pull Requests will be reviewed and responded to as time permits.
-->

## Motivation

We decide to get rid of async in consensus given it's hard to debug and the algorithm isn't really parallelizable.

This is the first half of the work, another half would be migrating the network interface. 

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?

Y

## Test Plan

Existing tests.

## Related PRs

(If this PR adds or changes functionality, please take some time to update the docs at https://github.com/libra/website, and link to your PR here.)
