### PR TITLE
[mempool] add LibraVersion config subscription

### DIFF
--- a/mempool/src/shared_mempool.rs
+++ b/mempool/src/shared_mempool.rs
@@ -25,7 +25,9 @@ use libra_security_logger::{security_log, SecurityEvent};
 use libra_types::{
     account_address::AccountAddress,
     mempool_status::{MempoolStatus, MempoolStatusCode},
-    on_chain_config::{ConfigID, OnChainConfig, OnChainConfigPayload, VMPublishingOption},
+    on_chain_config::{
+        ConfigID, LibraVersion, OnChainConfig, OnChainConfigPayload, VMPublishingOption,
+    },
     transaction::SignedTransaction,
     vm_error::{
         StatusCode::{RESOURCE_DOES_NOT_EXIST, SEQUENCE_NUMBER_TOO_OLD},
@@ -861,4 +863,5 @@ pub fn bootstrap(
 }
 
 /// On-chain configs that mempool subscribes to for reconfiguration
-pub const MEMPOOL_SUBSCRIBED_CONFIGS: &[ConfigID] = &[VMPublishingOption::CONFIG_ID];
+pub const MEMPOOL_SUBSCRIBED_CONFIGS: &[ConfigID] =
+    &[LibraVersion::CONFIG_ID, VMPublishingOption::CONFIG_ID];

--- a/types/src/on_chain_config.rs
+++ b/types/src/on_chain_config.rs
@@ -27,7 +27,8 @@ impl ConfigID {
 }
 
 /// State sync will panic if the value of any config in this registry is uninitialized
-pub const ON_CHAIN_CONFIG_REGISTRY: &[ConfigID] = &[VMPublishingOption::CONFIG_ID];
+pub const ON_CHAIN_CONFIG_REGISTRY: &[ConfigID] =
+    &[VMPublishingOption::CONFIG_ID, LibraVersion::CONFIG_ID];
 
 #[derive(Clone, Debug, PartialEq)]
 pub struct OnChainConfigPayload {

--- a/vm-validator/src/vm_validator.rs
+++ b/vm-validator/src/vm_validator.rs
@@ -5,7 +5,7 @@ use anyhow::Result;
 use libra_types::{
     account_address::AccountAddress,
     account_config::AccountResource,
-    on_chain_config::{OnChainConfigPayload, VMPublishingOption},
+    on_chain_config::{LibraVersion, OnChainConfigPayload, VMPublishingOption},
     transaction::{SignedTransaction, VMValidatorResult},
 };
 use libra_vm::{on_chain_configs::VMConfig, LibraVM, VMVerifier};
@@ -81,7 +81,7 @@ impl TransactionValidation for VMValidator {
     fn restart(&mut self, config: OnChainConfigPayload) -> Result<()> {
         let gas_schedule = self.vm.get_gas_schedule()?;
         let publishing_options = config.get::<VMPublishingOption>()?;
-        let version = self.vm.get_libra_version()?;
+        let version = config.get::<LibraVersion>()?;
         let vm_config = VMConfig {
             publishing_options,
             version,


### PR DESCRIPTION
## Summary

- Add `LibraVersion` config to `ON_CHAIN_CONFIG_REGISTRY` for state sync to read
- Add `LibraVersion` config subscription to mempool 
- Make VM Validator restart with reading `LibraVersion` from on-chain config payload 