### PR TITLE
[CI] retry and flag flaky E2E tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -196,8 +196,8 @@ jobs:
       - run:
           name: Find all e2e tests
           command: |
-            cargo x test --package testsuite -- --list | grep "::" | \
-              sed 's/: .*$//' > e2e_tests
+            RUST_BACKTRACE=1 cargo x test --package testsuite -- --list | \
+              grep "::" | sed 's/: .*$//' > e2e_tests
             cat e2e_tests
       - persist_to_workspace:
           root: /home/circleci/project
@@ -209,6 +209,8 @@ jobs:
     parallelism: 8
     description: Run E2E tests in parallel. Each container runs a subset of
       test targets.
+    environment:
+      E2E_RETRIES: 3
     steps:
       - build_setup
       - restore_cargo_package_cache
@@ -227,17 +229,28 @@ jobs:
       - run:
           name: Run E2E tests
           command: |
-            set -x
+            set -x +e
             libratest=$(find target/debug/deps/ -name "libratest*" -executable)
+            num_fails=0
             for target in $(cat /tmp/tests_to_run) ; do
-              if [ ! -z "$libratest" ]; then
-                RUST_BACKTRACE=1 $CI_TIMEOUT $libratest $target \
-                  --test-threads 1 --exact --nocapture
-              else
-                RUST_BACKTRACE=1 $CI_TIMEOUT cargo x test $target \
-                  --package testsuite -- --test-threads 1 --exact --nocapture
+              cmd="$libratest $target --test-threads 1 --exact --nocapture"
+              retry=0
+              status=1
+              failed_tests=
+              while [[ $status != 0 && $retry < ${E2E_RETRIES} ]]; do
+                RUST_BACKTRACE=1 timeout --kill-after=370 --preserve-status 360 $cmd
+                status=$?
+                retry=$((retry + 1))
+              done
+              if [[ $status != 0 ]] ; then
+                num_fails=$((num_fails + 1))
+                failed_tests="$target\n$failed_tests"
               fi
             done
+            if [[ $num_fails != 0 ]]; then
+              echo -e "$num_fails test(s) failed:$failed_tests"
+            fi
+            exit $num_fails
   run-unit-test:
     executor: build-executor
     description: Run all unit tests, excluding E2E and flaky tests that are

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -103,6 +103,49 @@ commands:
           command: |
             ls -all /usr/local/cargo
             du -ssh /usr/local/cargo
+  send_message:
+    description: Send message to the specified webhook.
+    parameters:
+      payload_file:
+        description: File containing the message payload
+        type: string
+        default: ""
+      build_url:
+        description: This build's URL in Circle
+        type: string
+        default: "${CIRCLE_BUILD_URL}"
+      webhook:
+        description: Webhook for the message
+        type: string
+        default: ""
+    steps:
+      - run:
+          name: Send job status
+          command: |
+            set -x
+            if [ -e <<parameters.payload_file>> ]; then
+              jq -n \
+                --arg msg "$(cat <<parameters.payload_file>>)" \
+                --arg url "<<parameters.build_url>>" \
+                '{
+                  attachments: [
+                    {
+                      text: $msg,
+                      actions: [
+                        {
+                          "type": "button",
+                          "text": "Visit Job",
+                          "url": $url
+                        }
+                      ],
+                    }
+                  ]
+                }' > /tmp/payload
+              cat /tmp/payload
+              curl -X POST -H 'Content-type: application/json' -d @/tmp/payload \
+                <<parameters.webhook>>
+            fi
+          when: always
   build_setup:
     steps:
       - checkout
@@ -211,6 +254,8 @@ jobs:
       test targets.
     environment:
       E2E_RETRIES: 3
+      FLAKY_TESTS_FILE: "/tmp/flaky_tests"
+      MESSAGE_PAYLOAD_FILE: "/tmp/message_payload"
     steps:
       - build_setup
       - restore_cargo_package_cache
@@ -233,24 +278,35 @@ jobs:
             libratest=$(find target/debug/deps/ -name "libratest*" -executable)
             num_fails=0
             for target in $(cat /tmp/tests_to_run) ; do
-              cmd="$libratest $target --test-threads 1 --exact --nocapture"
               retry=0
               status=1
               failed_tests=
               while [[ $status != 0 && $retry < ${E2E_RETRIES} ]]; do
-                RUST_BACKTRACE=1 timeout --kill-after=370 --preserve-status 360 $cmd
+                RUST_BACKTRACE=1 timeout --kill-after=370 --preserve-status 360 \
+                  $libratest $target --test-threads 1 --exact --nocapture
                 status=$?
                 retry=$((retry + 1))
               done
               if [[ $status != 0 ]] ; then
                 num_fails=$((num_fails + 1))
                 failed_tests="$target\n$failed_tests"
+              elif [[ $retry > 1 ]]; then
+                echo "$target passed after $retry tries" >> ${FLAKY_TESTS_FILE}
               fi
             done
+            if [ -e ${FLAKY_TESTS_FILE} ]; then
+              msg="Found flaky tests\n$(cat ${FLAKY_TESTS_FILE})"
+              echo -e $msg
+              echo -e $msg > ${MESSAGE_PAYLOAD_FILE}
+            fi
             if [[ $num_fails != 0 ]]; then
-              echo -e "$num_fails test(s) failed:$failed_tests"
+              echo -e "$num_fails test(s) failed:\n$failed_tests"
             fi
             exit $num_fails
+      - send_message:
+          payload_file: "${MESSAGE_PAYLOAD_FILE}"
+          build_url: "${CIRCLE_BUILD_URL}#tests/containers/${CIRCLE_NODE_INDEX}"
+          webhook: "${WEBHOOK_FLAKY_TESTS}"
   run-unit-test:
     executor: build-executor
     description: Run all unit tests, excluding E2E and flaky tests that are


### PR DESCRIPTION
## Motivation
We had two flaky e2e tests last week `smoke_test_single_node_block_metadata` and `basic_state_synchronization`.  They were fixed, however, we have couple more this week, `test_basic_restartability` (https://circleci.com/gh/libra/libra/63762#tests/containers/4), `test_startup_sync_state_with_empty_consensus_db` (https://circleci.com/gh/libra/libra/63425#tests/containers/7), `test_basic_state_synchronization` (https://circleci.com/gh/libra/libra/63083#tests/containers/5). These tests seem to pass if they are run again.

CI can retry these tests locally to unblock the land and alleviate developer frustration. The flaky tests are then flagged to test owners so that they can look into the underlying issue.

Summary of changes:
- Add a retry loop to the run-e2e-test step
- Use a 6-minute timeout when each test is run.  This is to catch and kill stuck libra-swarm. For example, https://circleci.com/gh/libra/libra/62777
- Use a file to pass message payload between commands in yaml. yaml doesn't support arg passing at runtime, circumventing it via Circle's bash env var between container layers results loss in message formatting (no space, newline).  

## Test Plan
Canary with 3f0e30c in https://circleci.com/workflow-run/1e778b6b-ccf4-4d2a-9063-d0ae4ba73f2f. Jobs unrelated to e2e tests in the regular commit verify workflow are stripped.

Testcases
- Intentionally fail `smoke_test::test_basic_restartability`. Verify the retry logic works with known-fail tests in https://circleci.com/gh/libra/libra/63816#tests/containers/4
- Reduce test timeout to 180sec.  Verify some tests would pass in second try: https://circleci.com/gh/libra/libra/63816#tests/containers/4, https://circleci.com/gh/libra/libra/63816#tests/containers/5
- Verify the flaky tests are posted to #flaky-test
- Verify the embedded link in the message points to the specific container node in Circle where the flaky test ran. The test owner can examine the log and diagnosis the issue. 