### PR TITLE
[json-rpc] use same DB version for batched requests

### DIFF
--- a/json-rpc/src/util.rs
+++ b/json-rpc/src/util.rs
@@ -9,10 +9,12 @@ macro_rules! register_rpc_method {
     ($registry:expr, $method: expr, $num_args: expr) => {
         $registry.insert(
             stringify!($method).to_string(),
-            Box::new(move |service, parameters| {
+            Box::new(move |service, parameters, ledger_info| {
                 Box::pin(async move {
                     ensure!(parameters.len() == $num_args, "Invalid number of arguments");
-                    Ok(serde_json::to_value($method(service, parameters).await?)?)
+                    Ok(serde_json::to_value(
+                        $method(service, parameters, ledger_info).await?,
+                    )?)
                 })
             }),
         );

--- a/json-rpc/src/util.rs
+++ b/json-rpc/src/util.rs
@@ -9,12 +9,13 @@ macro_rules! register_rpc_method {
     ($registry:expr, $method: expr, $num_args: expr) => {
         $registry.insert(
             stringify!($method).to_string(),
-            Box::new(move |service, parameters, ledger_info| {
+            Box::new(move |service, request| {
                 Box::pin(async move {
-                    ensure!(parameters.len() == $num_args, "Invalid number of arguments");
-                    Ok(serde_json::to_value(
-                        $method(service, parameters, ledger_info).await?,
-                    )?)
+                    ensure!(
+                        request.params.len() == $num_args,
+                        "Invalid number of arguments"
+                    );
+                    Ok(serde_json::to_value($method(service, request).await?)?)
                 })
             }),
         );

--- a/storage/libradb/src/lib.rs
+++ b/storage/libradb/src/lib.rs
@@ -758,15 +758,11 @@ impl DbReader for LibraDB {
         Ok(events)
     }
 
-    fn get_state_proof(
+    fn get_state_proof_with_ledger_info(
         &self,
         known_version: u64,
-    ) -> Result<(
-        LedgerInfoWithSignatures,
-        ValidatorChangeProof,
-        AccumulatorConsistencyProof,
-    )> {
-        let ledger_info_with_sigs = self.ledger_store.get_latest_ledger_info()?;
+        ledger_info_with_sigs: LedgerInfoWithSignatures,
+    ) -> Result<(ValidatorChangeProof, AccumulatorConsistencyProof)> {
         let ledger_info = ledger_info_with_sigs.ledger_info();
         let known_epoch = self.ledger_store.get_epoch(known_version)?;
         let validator_change_proof = if known_epoch < ledger_info.epoch() {
@@ -782,6 +778,20 @@ impl DbReader for LibraDB {
         let ledger_consistency_proof = self
             .ledger_store
             .get_consistency_proof(known_version, ledger_info.version())?;
+        Ok((validator_change_proof, ledger_consistency_proof))
+    }
+
+    fn get_state_proof(
+        &self,
+        known_version: u64,
+    ) -> Result<(
+        LedgerInfoWithSignatures,
+        ValidatorChangeProof,
+        AccumulatorConsistencyProof,
+    )> {
+        let ledger_info_with_sigs = self.ledger_store.get_latest_ledger_info()?;
+        let (validator_change_proof, ledger_consistency_proof) =
+            self.get_state_proof_with_ledger_info(known_version, ledger_info_with_sigs.clone())?;
         Ok((
             ledger_info_with_sigs,
             validator_change_proof,

--- a/storage/storage-client/src/lib.rs
+++ b/storage/storage-client/src/lib.rs
@@ -587,6 +587,14 @@ impl DbReader for SyncStorageClient {
         unimplemented!()
     }
 
+    fn get_state_proof_with_ledger_info(
+        &self,
+        _known_version: u64,
+        _ledger_info_with_sigs: LedgerInfoWithSignatures,
+    ) -> Result<(ValidatorChangeProof, AccumulatorConsistencyProof)> {
+        unimplemented!()
+    }
+
     fn get_state_proof(
         &self,
         _known_version: u64,

--- a/storage/storage-interface/src/lib.rs
+++ b/storage/storage-interface/src/lib.rs
@@ -77,6 +77,14 @@ pub trait DbReader: Send + Sync {
         fetch_events: bool,
     ) -> Result<Option<TransactionWithProof>>;
 
+    /// Returns proof of new state for a given ledger info with signatures relative to version known
+    /// to client
+    fn get_state_proof_with_ledger_info(
+        &self,
+        known_version: u64,
+        ledger_info: LedgerInfoWithSignatures,
+    ) -> Result<(ValidatorChangeProof, AccumulatorConsistencyProof)>;
+
     /// Returns proof of new state relative to version known to client
     fn get_state_proof(
         &self,


### PR DESCRIPTION
## Summary

Batched JSON RPC requests should be handled by the same version of the DB. To ensure this consistency, with this PR, the JSON RPC server takes a version checkpoint of the DB (latest ledger info at that point) upon receiving requests and uses that same version for handling individual requests in a batch
