### PR TITLE
[onchain-discovery] initial version of onchain discovery protocol

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3430,7 +3430,7 @@ dependencies = [
  "network 0.1.0",
  "once_cell 1.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "parity-multiaddr 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "rand 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand 0.7.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.106 (registry+https://github.com/rust-lang/crates.io-index)",
  "storage-client 0.1.0",
  "storage-interface 0.1.0",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2452,6 +2452,7 @@ dependencies = [
  "libra-vm 0.1.0",
  "libra-workspace-hack 0.1.0",
  "network 0.1.0",
+ "onchain-discovery 0.1.0",
  "parity-multiaddr 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "rayon 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "state-synchronizer 0.1.0",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3426,6 +3426,7 @@ dependencies = [
  "libra-logger 0.1.0",
  "libra-types 0.1.0",
  "libra-vm 0.1.0",
+ "libra-workspace-hack 0.1.0",
  "network 0.1.0",
  "once_cell 1.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "parity-multiaddr 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3409,6 +3409,35 @@ version = "1.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "onchain-discovery"
+version = "0.1.0"
+dependencies = [
+ "anyhow 1.0.28 (registry+https://github.com/rust-lang/crates.io-index)",
+ "bounded-executor 0.1.0",
+ "bytes 0.5.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "channel 0.1.0",
+ "config-builder 0.1.0",
+ "executor 0.1.0",
+ "futures 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libra-canonical-serialization 0.1.0",
+ "libra-config 0.1.0",
+ "libra-crypto 0.1.0",
+ "libra-logger 0.1.0",
+ "libra-types 0.1.0",
+ "libra-vm 0.1.0",
+ "network 0.1.0",
+ "once_cell 1.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "parity-multiaddr 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.106 (registry+https://github.com/rust-lang/crates.io-index)",
+ "storage-client 0.1.0",
+ "storage-interface 0.1.0",
+ "storage-service 0.1.0",
+ "tokio 0.2.13 (registry+https://github.com/rust-lang/crates.io-index)",
+ "vm-genesis 0.1.0",
+]
+
+[[package]]
 name = "oorandom"
 version = "11.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -83,6 +83,7 @@ members = [
     "network/memsocket",
     "network/netcore",
     "network/noise",
+    "network/onchain-discovery",
     "network/socket-bench-server",
     "mempool",
     "secure/json-rpc",

--- a/config/src/config/network_config.rs
+++ b/config/src/config/network_config.rs
@@ -38,6 +38,8 @@ pub struct NetworkConfig {
     // Otherwise, any node can connect. If this flag is set to true, `enable_noise` must
     // also be set to true.
     pub enable_remote_authentication: bool,
+    // Enable this network to use either gossip discovery or onchain discovery.
+    pub discovery_method: DiscoveryMethod,
     // network peers are the nodes allowed to connect when the network is started in authenticated
     // mode.
     #[serde(skip)]
@@ -60,6 +62,7 @@ impl Default for NetworkConfig {
             connectivity_check_interval_ms: 5000,
             enable_noise: true,
             enable_remote_authentication: true,
+            discovery_method: DiscoveryMethod::Gossip,
             network_keypairs: None,
             network_peers_file: PathBuf::new(),
             network_peers: NetworkPeersConfig::default(),
@@ -81,6 +84,7 @@ impl NetworkConfig {
             connectivity_check_interval_ms: self.connectivity_check_interval_ms,
             enable_noise: self.enable_noise,
             enable_remote_authentication: self.enable_remote_authentication,
+            discovery_method: self.discovery_method,
             network_keypairs: None,
             network_peers_file: self.network_peers_file.clone(),
             network_peers: self.network_peers.clone(),
@@ -253,6 +257,15 @@ pub struct NetworkPeerInfo {
     pub signing_public_key: Ed25519PublicKey,
     #[serde(rename = "ni")]
     pub identity_public_key: x25519::PublicKey,
+}
+
+#[derive(Clone, Copy, Debug, Deserialize, Eq, PartialEq, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum DiscoveryMethod {
+    // default until we can deprecate
+    Gossip,
+    Onchain,
+    None,
 }
 
 #[cfg(test)]

--- a/libra-node/Cargo.toml
+++ b/libra-node/Cargo.toml
@@ -30,6 +30,7 @@ libra-mempool = { path = "../mempool", version = "0.1.0" }
 libra-metrics = { path = "../common/metrics", version = "0.1.0" }
 libra-crypto = { path = "../crypto/crypto", version = "0.1.0" }
 network = { path = "../network", version = "0.1.0" }
+onchain-discovery = { path = "../network/onchain-discovery", version = "0.1.0" }
 libra-json-rpc = { path = "../json-rpc", version = "0.1.0" }
 state-synchronizer = { path = "../state-synchronizer", version = "0.1.0" }
 storage-client = { path = "../storage/storage-client", version = "0.1.0" }

--- a/network/onchain-discovery/Cargo.toml
+++ b/network/onchain-discovery/Cargo.toml
@@ -1,0 +1,38 @@
+[package]
+name = "onchain-discovery"
+version = "0.1.0"
+authors = ["Libra Association <opensource@libra.org>"]
+description = "Libra Onchain Discovery Protocol"
+repository = "https://github.com/libra/libra"
+homepage = "https://libra.org"
+license = "Apache-2.0"
+publish = false
+edition = "2018"
+
+[dependencies]
+anyhow = "1.0"
+bytes = "0.5.4"
+futures = "0.3.4"
+once_cell = "1.3.1"
+parity-multiaddr = "0.8.0"
+rand = "0.6.5"
+serde = { version = "1.0.106", features = ["derive"] }
+tokio = { version = "0.2.13", features = ["full"] }
+
+bounded-executor = { path = "../../common/bounded-executor", version = "0.1.0" }
+channel = { path = "../../common/channel", version = "0.1.0" }
+lcs = { path = "../../common/lcs", version = "0.1.0", package = "libra-canonical-serialization" }
+libra-config = { path = "../../config", version = "0.1.0" }
+libra-crypto = { path = "../../crypto/crypto", version = "0.1.0" }
+libra-logger = { path = "../../common/logger", version = "0.1.0" }
+libra-types = { path = "../../types", version = "0.1.0" }
+network = { path = "../", version = "0.1.0" }
+storage-client = { path = "../../storage/storage-client", version = "0.1.0" }
+
+[dev-dependencies]
+config-builder = { path = "../../config/config-builder", version = "0.1.0" }
+executor = { path = "../../execution/executor", version = "0.1.0" }
+libra-vm = { path = "../../language/libra-vm", version = "0.1.0" }
+storage-interface = { path = "../../storage/storage-interface", version = "0.1.0" }
+storage-service = { path = "../../storage/storage-service", version = "0.1.0" }
+vm-genesis = { path = "../../language/tools/vm-genesis", version = "0.1.0" }

--- a/network/onchain-discovery/Cargo.toml
+++ b/network/onchain-discovery/Cargo.toml
@@ -26,6 +26,7 @@ libra-config = { path = "../../config", version = "0.1.0" }
 libra-crypto = { path = "../../crypto/crypto", version = "0.1.0" }
 libra-logger = { path = "../../common/logger", version = "0.1.0" }
 libra-types = { path = "../../types", version = "0.1.0" }
+libra-workspace-hack = { path = "../../common/workspace-hack", version = "0.1.0" }
 network = { path = "../", version = "0.1.0" }
 storage-client = { path = "../../storage/storage-client", version = "0.1.0" }
 

--- a/network/onchain-discovery/Cargo.toml
+++ b/network/onchain-discovery/Cargo.toml
@@ -15,7 +15,7 @@ bytes = "0.5.4"
 futures = "0.3.4"
 once_cell = "1.3.1"
 parity-multiaddr = "0.8.0"
-rand = "0.6.5"
+rand = "0.7.3"
 serde = { version = "1.0.106", features = ["derive"] }
 tokio = { version = "0.2.13", features = ["full"] }
 

--- a/network/onchain-discovery/src/lib.rs
+++ b/network/onchain-discovery/src/lib.rs
@@ -79,7 +79,7 @@ use network::{
     error::NetworkError,
     protocols::{network::Event, rpc::error::RpcError},
 };
-use rand::{rngs::SmallRng, FromEntropy, Rng};
+use rand::{rngs::SmallRng, Rng, SeedableRng};
 use std::{
     collections::HashSet,
     convert::{TryFrom, TryInto},

--- a/network/onchain-discovery/src/lib.rs
+++ b/network/onchain-discovery/src/lib.rs
@@ -51,6 +51,9 @@ use std::{
 use storage_client::StorageRead;
 use tokio::runtime::Handle;
 
+#[cfg(test)]
+mod test;
+
 pub mod network_interface;
 pub mod types;
 

--- a/network/onchain-discovery/src/lib.rs
+++ b/network/onchain-discovery/src/lib.rs
@@ -1,0 +1,699 @@
+// Copyright (c) The Libra Core Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+// <Black magic>
+// Increase recursion limit to allow for use of select! macro.
+#![recursion_limit = "1024"]
+// </Black magic>
+
+use crate::{
+    network_interface::{OnchainDiscoveryNetworkEvents, OnchainDiscoveryNetworkSender},
+    types::{
+        DiscoveryInfoInternal, DiscoverySetInternal, OnchainDiscoveryMsg, QueryDiscoverySetRequest,
+        QueryDiscoverySetResponse, QueryDiscoverySetResponseWithEvent,
+    },
+};
+use anyhow::{Context as AnyhowContext, Result};
+use bounded_executor::BoundedExecutor;
+use bytes::Bytes;
+use futures::{
+    channel::oneshot,
+    future,
+    future::{FusedFuture, Future, FutureExt},
+    ready,
+    stream::{FusedStream, Stream, StreamExt},
+    task::Poll,
+};
+use libra_config::config::RoleType;
+use libra_logger::prelude::*;
+use libra_types::{
+    discovery_set::DiscoverySetChangeEvent,
+    get_with_proof::{UpdateToLatestLedgerRequest, UpdateToLatestLedgerResponse},
+    trusted_state::{TrustedState, TrustedStateChange},
+    waypoint::Waypoint,
+    PeerId,
+};
+use network::{
+    connectivity_manager::{ConnectivityRequest, DiscoverySource},
+    error::NetworkError,
+    protocols::{network::Event, rpc::error::RpcError},
+};
+use rand::{rngs::SmallRng, FromEntropy, Rng};
+use std::{
+    collections::HashSet,
+    convert::{TryFrom, TryInto},
+    mem,
+    pin::Pin,
+    sync::Arc,
+    task::Context,
+    time::Duration,
+};
+use storage_client::StorageRead;
+use tokio::runtime::Handle;
+
+pub mod network_interface;
+pub mod types;
+
+pub struct OnchainDiscovery<TTicker> {
+    /// A bounded executor for handling inbound discovery set queries.
+    inbound_rpc_executor: BoundedExecutor,
+    /// Our node's PeerId.
+    peer_id: PeerId,
+    /// Our node's role (validator || fullnode).
+    role: RoleType,
+    /// The current trusted state, which keeps track of the latest verified
+    /// ledger version and validator set. This version can be ahead of other
+    /// components (e.g., state sync) since we only rely on syncing epoch change
+    /// LedgerInfo's and don't need to do tx replay.
+    trusted_state: TrustedState,
+    /// The sequence number of the most recent discovery set change event we've
+    /// processed.
+    latest_event_seq_num: u64,
+    /// An internal representation of the most recent discovery set.
+    latest_discovery_set: DiscoverySetInternal,
+    /// The set of peers we're connected to.
+    connected_peers: HashSet<PeerId>,
+    /// A channel to send requests to the network instance.
+    network_tx: OnchainDiscoveryNetworkSender,
+    /// A channel to recevie notifications from the network.
+    network_rx: OnchainDiscoveryNetworkEvents,
+    /// internal gRPC client to send read requests to Libra Storage.
+    // TODO(philiphayes): use the new storage DbReader interface.
+    storage_read_client: Arc<dyn StorageRead>,
+    /// Ticker to periodically query our peers for the latest discovery set.
+    // TODO(philiphayes): once we do a bunch of initial queries on startup, we
+    // can probably reduce the frequency.
+    peer_query_ticker: TTicker,
+    /// Ticker to query our own storage for the latest discovery set.
+    // TODO(philiphayes): we should only need to query our own storage on startup
+    // and after that rely on state-sync's reconfig notifications.
+    storage_query_ticker: TTicker,
+    /// The timeout for the whole rpc request when querying one of our peers for
+    /// their latest discovery set.
+    outbound_rpc_timeout: Duration,
+    /// Random number generator. Used to sample the next peer to query.
+    rng: SmallRng,
+    /// A local counter incremented on receiving an incoming message. Printing this in debugging
+    /// allows for easy debugging.
+    event_id: u32,
+}
+
+impl<TTicker> OnchainDiscovery<TTicker>
+where
+    TTicker: Stream + FusedStream + Unpin,
+{
+    pub fn new(
+        executor: Handle,
+        self_peer_id: PeerId,
+        role: RoleType,
+        // TODO(philiphayes): make Waypoint non-optional
+        waypoint: Option<Waypoint>,
+        network_tx: OnchainDiscoveryNetworkSender,
+        network_rx: OnchainDiscoveryNetworkEvents,
+        storage_read_client: Arc<dyn StorageRead>,
+        peer_query_ticker: TTicker,
+        storage_query_ticker: TTicker,
+        outbound_rpc_timeout: Duration,
+        max_concurrent_inbound_queries: usize,
+    ) -> Self {
+        // This initial trusted state will trust any genesis presented to us.
+        // Since we are querying from our own storage, this will just get us
+        // up-to-speed on our last known ledger state from storage, ratcheting
+        // our trusted state in the process.
+        // TODO(philiphayes): always start from at least genesis _waypoint_.
+        // TODO(philiphayes): we could also start from storage.get_startup_info's
+        // latest ledger info?
+        // TODO(philiphayes): this is probably unsafe currently, since the
+        // storage query could race with the peer query below and we might
+        // accidently trust whatever the peer's genesis is.
+        let trusted_state = waypoint
+            .map(TrustedState::from_waypoint)
+            .unwrap_or(TrustedState::new_trust_any_genesis_WARNING_UNSAFE());
+
+        Self {
+            inbound_rpc_executor: BoundedExecutor::new(max_concurrent_inbound_queries, executor),
+            peer_id: self_peer_id,
+            role,
+            trusted_state,
+            latest_event_seq_num: 0,
+            latest_discovery_set: DiscoverySetInternal::empty(),
+            connected_peers: HashSet::new(),
+            network_tx,
+            network_rx,
+            storage_read_client,
+            peer_query_ticker,
+            storage_query_ticker,
+            outbound_rpc_timeout,
+            rng: SmallRng::from_entropy(),
+            event_id: 0,
+        }
+    }
+
+    pub async fn start(mut self) {
+        // A slot that can hold at-most-one pending outbound discovery set query
+        // to another peer.
+        let mut pending_outbound_rpc = OptionFuture::new(None);
+
+        // On startup, we want to first query our local storage state to see if
+        // we have an up-to-date discovery set to connect with.
+        let f_query_storage = self.handle_storage_query_tick().boxed();
+        let mut pending_storage_query = OptionFuture::new(Some(f_query_storage));
+
+        debug!("starting onchain discovery");
+        loop {
+            self.event_id = self.event_id.wrapping_add(1);
+            futures::select! {
+                event = self.network_rx.select_next_some() => {
+                    trace!("event id: {}, type: NetworkEvent", self.event_id);
+                    self.handle_network_event(event);
+                },
+                _ = self.peer_query_ticker.select_next_some() => {
+                    trace!("event id: {}, type: PeerQueryTick", self.event_id);
+                    pending_outbound_rpc
+                        .or_insert_with(|| {
+                            self.handle_peer_query_tick()
+                                .map(|f_query| f_query.boxed())
+                        });
+                },
+                query_res = pending_outbound_rpc => {
+                    trace!("event id: {}, type: QueryResponse", self.event_id);
+                    self.handle_outbound_query_res(query_res).await;
+                },
+                _ = self.storage_query_ticker.select_next_some() => {
+                    trace!("event id: {}, type: StorageQueryTick", self.event_id);
+                    pending_storage_query
+                        .or_insert_with(|| Some(self.handle_storage_query_tick().boxed()));
+                },
+                query_res = pending_storage_query => {
+                    trace!("event id: {}, type: QueryResponse", self.event_id);
+                    self.handle_outbound_query_res(query_res).await;
+                }
+                complete => {
+                    crit!("onchain discovery terminated");
+                    break;
+                }
+            }
+        }
+    }
+
+    fn handle_network_event(&mut self, event: Result<Event<OnchainDiscoveryMsg>, NetworkError>) {
+        match event {
+            Ok(event) => match event {
+                Event::NewPeer(peer_id) => {
+                    trace!("connected to new peer: {}", peer_id.short_str());
+                    // Add peer to connected peer list.
+                    self.connected_peers.insert(peer_id);
+                }
+                Event::LostPeer(peer_id) => {
+                    trace!("disconnected from peer: {}", peer_id.short_str());
+                    // Remove peer from connected peer list.
+                    self.connected_peers.remove(&peer_id);
+                }
+                Event::Message(msg) => {
+                    warn!("unexpected direct-send message from network: {:?}", msg);
+                    debug_assert!(false);
+                }
+                Event::RpcRequest((peer_id, msg, res_tx)) => match msg.try_into() {
+                    Ok(OnchainDiscoveryMsg::QueryDiscoverySetRequest(req_msg)) => {
+                        debug!(
+                            "recevied query discovery set request: peer: {}, \
+                             version: {}, seq_num: {}",
+                            peer_id.short_str(),
+                            req_msg.client_known_version,
+                            req_msg.client_known_seq_num,
+                        );
+
+                        let res = self.inbound_rpc_executor.try_spawn(
+                            handle_query_discovery_set_request(
+                                Arc::clone(&self.storage_read_client),
+                                peer_id,
+                                req_msg,
+                                res_tx,
+                            ),
+                        );
+
+                        if res.is_err() {
+                            warn!(
+                                "discovery set query executor at capacity; dropped \
+                                 rpc request: peer: {}",
+                                peer_id.short_str()
+                            );
+                        }
+                    }
+                    Ok(msg) => {
+                        warn!("unexpected rpc from peer: {}, msg: {:?}", peer_id, msg);
+                        debug_assert!(false);
+                    }
+                    Err(err) => {
+                        warn!(
+                            "failed to deserialize rpc from peer: {}, err: {:?}",
+                            peer_id, err
+                        );
+                        debug_assert!(false);
+                    }
+                },
+            },
+            Err(err) => error!("network event error: {:?}", err),
+        }
+    }
+
+    fn handle_peer_query_tick(
+        &mut self,
+    ) -> Option<
+        impl Future<
+            Output = Result<(
+                PeerId,
+                QueryDiscoverySetRequest,
+                QueryDiscoverySetResponseWithEvent,
+            )>,
+        >,
+    > {
+        self.sample_peer().map(|peer_id| {
+            let req_msg = QueryDiscoverySetRequest {
+                client_known_version: self.trusted_state.latest_version(),
+                client_known_seq_num: 0,
+            };
+
+            let peer_id_short = peer_id.short_str();
+
+            trace!(
+                "handle_peer_query_tick: querying peer: {}, trusted version: {}",
+                peer_id_short,
+                req_msg.client_known_version
+            );
+
+            peer_query_discovery_set(
+                peer_id,
+                req_msg,
+                self.outbound_rpc_timeout,
+                self.network_tx.clone(),
+            )
+        })
+    }
+
+    async fn handle_outbound_query_res(
+        &mut self,
+        query_res: Result<(
+            PeerId,
+            QueryDiscoverySetRequest,
+            QueryDiscoverySetResponseWithEvent,
+        )>,
+    ) {
+        match query_res {
+            Ok((peer_id, req_msg, res_msg)) => {
+                debug!(
+                    "received query response: peer: {}, their version: {}",
+                    peer_id.short_str(),
+                    res_msg
+                        .update_to_latest_ledger_response
+                        .ledger_info_with_sigs
+                        .ledger_info()
+                        .version(),
+                );
+                self.handle_query_response(peer_id, req_msg, res_msg).await;
+            }
+            Err(err) => warn!("query to remote peer failed: {:?}", err),
+        }
+    }
+
+    fn handle_storage_query_tick(
+        &self,
+    ) -> impl Future<
+        Output = Result<(
+            PeerId,
+            QueryDiscoverySetRequest,
+            QueryDiscoverySetResponseWithEvent,
+        )>,
+    > {
+        let trusted_version = self.trusted_state.latest_version();
+        trace!(
+            "handle_storage_query_tick: querying self storage, trusted version: {}",
+            trusted_version,
+        );
+        let req_msg = QueryDiscoverySetRequest {
+            client_known_version: trusted_version,
+            client_known_seq_num: self.latest_event_seq_num,
+        };
+        let self_peer_id = self.peer_id;
+        storage_query_discovery_set(self.storage_read_client.clone(), req_msg)
+            .map(move |res| res.map(move |(req_msg, res_msg)| (self_peer_id, req_msg, res_msg)))
+    }
+
+    async fn handle_query_response(
+        &mut self,
+        peer_id: PeerId,
+        req_msg: QueryDiscoverySetRequest,
+        res_msg: QueryDiscoverySetResponseWithEvent,
+    ) {
+        let latest_version = self.trusted_state.latest_version();
+
+        let trusted_state_change = match res_msg
+            .update_to_latest_ledger_response
+            .verify(&self.trusted_state, &req_msg.into())
+        {
+            Ok(trusted_state_change) => trusted_state_change,
+            Err(err) => {
+                warn!(
+                    "invalid query response: failed to ratchet state: \
+                     peer: {}, err: {:?}",
+                    peer_id.short_str(),
+                    err
+                );
+                return;
+            }
+        };
+
+        let new_state = match trusted_state_change {
+            TrustedStateChange::Epoch {
+                new_state,
+                latest_epoch_change_li,
+                ..
+            } => {
+                info!(
+                    "successfully ratcheted to new epoch: \
+                     peer: {}, epoch: {}, version: {}",
+                    peer_id.short_str(),
+                    latest_epoch_change_li.ledger_info().epoch(),
+                    new_state.latest_version(),
+                );
+                new_state
+            }
+            TrustedStateChange::Version { new_state, .. } => {
+                debug!(
+                    "successfully ratcheted to new version: \
+                     peer: {}, version: {}",
+                    peer_id.short_str(),
+                    new_state.latest_version(),
+                );
+                new_state
+            }
+        };
+
+        // swap in our newly ratcheted trusted state
+        self.trusted_state = new_state;
+
+        if let Some(discovery_set_event) = res_msg.event {
+            self.handle_new_discovery_set_event(discovery_set_event)
+                .await;
+        } else {
+            debug!(
+                "no new discovery set event since latest version, peer: {}, latest_version: {}",
+                peer_id.short_str(),
+                latest_version,
+            );
+        }
+    }
+
+    async fn handle_new_discovery_set_event(
+        &mut self,
+        discovery_set_event: DiscoverySetChangeEvent,
+    ) {
+        let our_seq_num = self.latest_event_seq_num;
+        let new_seq_num = discovery_set_event.event_seq_num;
+
+        debug!(
+            "handle_new_discovery_set_event: our_seq_num: {}, new_seq_num: {}",
+            our_seq_num, new_seq_num
+        );
+
+        assert!(
+            new_seq_num >= our_seq_num,
+            "somehow we successfully ratcheted to a new trusted state (fresher \
+             version) but the discovery set event seqnum is older! This should \
+             never happen.",
+        );
+
+        // We should update if there is a newer discovery set event or we're just
+        // starting up.
+        let should_update = new_seq_num > our_seq_num || self.latest_discovery_set.is_empty();
+        if !should_update {
+            debug!("no new discovery set event; ignoring response");
+            return;
+        }
+
+        // event is actually newer; update connectivity manager about any
+        // modified peer infos.
+
+        info!(
+            "observed newer discovery set; updating connectivity manager: \
+             our seq num: {}, new seq num: {}",
+            our_seq_num, new_seq_num
+        );
+
+        let latest_discovery_set =
+            DiscoverySetInternal::from_discovery_set(self.role, discovery_set_event.discovery_set);
+
+        let mut prev_discovery_set =
+            mem::replace(&mut self.latest_discovery_set, latest_discovery_set.clone());
+
+        // TODO(philiphayes): send UpdateEligibleNodes if identity pubkeys change
+
+        // TODO(philiphayes): ConnectivityManager supports multiple identity pubkeys per
+        // peer (will accept connections from any in set, and do { pubkeys } x { addrs }
+        // when attempting to dial).
+
+        // TODO(philiphayes): consensus sends reconfig notification to on-chain
+        // discovery instead of network?
+
+        // pull out here to satisfy borrow checker
+        let self_peer_id = self.peer_id;
+
+        // Compare the latest and previous discovery sets to determine if
+        // we need to update the connectivity manager that a peer is
+        // advertising new addresses. In an effort to maintain
+        // connectivity, we will also merge in the previous advertised
+        // addresses.
+        let update_addr_reqs = latest_discovery_set
+            .0
+            .into_iter()
+            .filter(|(peer_id, _discovery_info)| &self_peer_id != peer_id)
+            .filter_map(|(peer_id, DiscoveryInfoInternal(_id_pubkey, addrs))| {
+                let prev_discovery_info_opt = prev_discovery_set.0.remove(&peer_id);
+
+                let mut addrs = addrs;
+
+                match prev_discovery_info_opt {
+                    // if there's a change between prev and new discovery set,
+                    // send an update request with duplicate addresses removed.
+                    Some(DiscoveryInfoInternal(_prev_id_pubkey, prev_addrs))
+                        if addrs != prev_addrs =>
+                    {
+                        for addr in prev_addrs.into_iter() {
+                            if !addrs.contains(&addr) {
+                                addrs.push(addr);
+                            }
+                        }
+                        Some(ConnectivityRequest::UpdateAddresses(
+                            DiscoverySource::OnChain,
+                            peer_id,
+                            addrs,
+                        ))
+                    }
+                    // no change, don't send an update request
+                    Some(_) => None,
+                    // a validator has been added or we're starting up; always
+                    // send an update request.
+                    None => Some(ConnectivityRequest::UpdateAddresses(
+                        DiscoverySource::OnChain,
+                        peer_id,
+                        addrs,
+                    )),
+                }
+            });
+
+        for update_addr_req in update_addr_reqs {
+            self.network_tx
+                .send_connectivity_request(update_addr_req)
+                .await
+                .unwrap();
+        }
+
+        // TODO(philiphayes): check for updated list of accepted (id key + sign key)
+    }
+
+    /// Sample iid a PeerId of one of the connected peers.
+    fn sample_peer(&mut self) -> Option<PeerId> {
+        let num_peers = self.connected_peers.len();
+        if num_peers > 0 {
+            // The particular index is not important, just the probability of
+            // sampling any of the current peers is equal.
+            let idx = self.rng.gen_range(0, num_peers);
+            self.connected_peers.iter().skip(idx).next().copied()
+        } else {
+            None
+        }
+    }
+}
+
+async fn handle_query_discovery_set_request(
+    storage_read_client: Arc<dyn StorageRead>,
+    peer_id: PeerId,
+    req_msg: QueryDiscoverySetRequest,
+    mut res_tx: oneshot::Sender<Result<Bytes, RpcError>>,
+) {
+    // TODO(philiphayes): verify that there is a timeout here...
+    let mut f_rpc_cancel = future::poll_fn(|cx: &mut Context<'_>| res_tx.poll_canceled(cx)).fuse();
+
+    // TODO(philiphayes): remove?
+    let peer_id_short = peer_id.short_str();
+
+    // cancel the internal storage rpc request early if the external rpc request
+    // is cancelled.
+    futures::select! {
+        res = storage_query_discovery_set(storage_read_client, req_msg).fuse() => {
+            let (_req_msg, res_msg) = match res {
+                Ok(res) => res,
+                Err(err) => {
+                    warn!("error querying storage discovery set: peer: {}, err: {:?}", peer_id_short, err);
+                    return;
+                },
+            };
+
+            let res_msg = QueryDiscoverySetResponse::from(res_msg);
+            let res_msg = OnchainDiscoveryMsg::QueryDiscoverySetResponse(res_msg);
+            let res_bytes = match lcs::to_bytes(&res_msg) {
+                Ok(res_bytes) => res_bytes,
+                Err(err) => {
+                    error!("failed to serialize response message: err: {:?}, res_msg: {:?}", err, res_msg);
+                    return;
+                }
+            };
+
+            if res_tx.send(Ok(res_bytes.into())).is_err() {
+                debug!("remote peer canceled discovery set query: peer: {}", peer_id_short);
+            }
+        },
+        _ = f_rpc_cancel => {
+            debug!("remote peer canceled discovery set query: peer: {}", peer_id_short);
+        },
+    }
+}
+
+/// Query our own storage for the latest discovery set and validator change proof.
+async fn storage_query_discovery_set(
+    storage_read_client: Arc<dyn StorageRead>,
+    req_msg: QueryDiscoverySetRequest,
+) -> Result<(QueryDiscoverySetRequest, QueryDiscoverySetResponseWithEvent)> {
+    let storage_req_msg = Into::<UpdateToLatestLedgerRequest>::into(req_msg.clone());
+
+    let res_msg = storage_read_client
+        .update_to_latest_ledger(
+            storage_req_msg.client_known_version,
+            storage_req_msg.requested_items,
+        )
+        .await
+        .with_context(|| {
+            format!(
+                "error forwarding discovery query to storage: client version: {}",
+                req_msg.client_known_version,
+            )
+        })?;
+
+    let (response_items, ledger_info_with_sigs, validator_change_proof, ledger_consistency_proof) =
+        res_msg;
+
+    let res_msg = UpdateToLatestLedgerResponse::new(
+        response_items,
+        ledger_info_with_sigs,
+        validator_change_proof,
+        ledger_consistency_proof,
+    );
+    let res_msg = QueryDiscoverySetResponse::from(res_msg);
+    let res_msg = QueryDiscoverySetResponseWithEvent::try_from(res_msg).with_context(|| {
+        format!(
+            "failed to verify storage's response: client version: {}",
+            req_msg.client_known_version
+        )
+    })?;
+
+    Ok((req_msg, res_msg))
+}
+
+/// Query a remote peer for their latest discovery set and a validator change
+/// proof.
+async fn peer_query_discovery_set(
+    peer_id: PeerId,
+    req_msg: QueryDiscoverySetRequest,
+    outbound_rpc_timeout: Duration,
+    mut network_tx: OnchainDiscoveryNetworkSender,
+) -> Result<(
+    PeerId,
+    QueryDiscoverySetRequest,
+    QueryDiscoverySetResponseWithEvent,
+)> {
+    let our_latest_version = req_msg.client_known_version;
+    let res_msg = network_tx
+        .query_discovery_set(peer_id, req_msg.clone(), outbound_rpc_timeout)
+        .await
+        .with_context(|| {
+            format!(
+                "failed to query peer discovery set: peer: {}, latest_version: {}",
+                peer_id.short_str(),
+                our_latest_version,
+            )
+        })?;
+
+    Ok((peer_id, req_msg, res_msg))
+}
+
+/// Effectively a size=1 future queue, or a slot with at-most-one future inside.
+///
+/// For now, we require `F: Unpin` which mandates boxing of `async fn` futures
+/// but simplifies the `OptionFuture` implementation.
+// TODO(philiphayes): extract this into libra/common
+pub struct OptionFuture<F> {
+    inner: Option<F>,
+}
+
+impl<F> OptionFuture<F>
+where
+    F: Future + Unpin,
+{
+    pub fn new(inner: Option<F>) -> Self {
+        Self { inner }
+    }
+
+    pub fn or_insert_with<G>(&mut self, fun: G)
+    where
+        G: FnOnce() -> Option<F>,
+    {
+        if let None = self.inner {
+            self.inner = fun();
+        }
+    }
+}
+
+impl<F> Unpin for OptionFuture<F> where F: Unpin {}
+
+impl<F> Future for OptionFuture<F>
+where
+    F: Future + Unpin,
+{
+    type Output = <F as Future>::Output;
+
+    fn poll(mut self: Pin<&mut Self>, cx: &mut Context) -> Poll<Self::Output> {
+        // try to poll whatever future is in the inner slot, if there is one.
+        let out = match Pin::new(&mut self.as_mut().get_mut().inner).as_pin_mut() {
+            Some(f) => ready!(f.poll(cx)),
+            None => return Poll::Pending,
+        };
+
+        // the inner future is complete so we can drop it now and just return the
+        // results.
+        self.set(OptionFuture { inner: None });
+
+        Poll::Ready(out)
+    }
+}
+
+impl<F> FusedFuture for OptionFuture<F>
+where
+    F: Future + Unpin,
+{
+    fn is_terminated(&self) -> bool {
+        match self.inner {
+            Some(_) => false,
+            None => true,
+        }
+    }
+}

--- a/network/onchain-discovery/src/network_interface.rs
+++ b/network/onchain-discovery/src/network_interface.rs
@@ -1,0 +1,116 @@
+// Copyright (c) The Libra Core Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+//! Protobuf based interface between OnchainDiscovery and Network layers.
+use crate::types::{
+    OnchainDiscoveryMsg, QueryDiscoverySetRequest, QueryDiscoverySetResponseWithEvent,
+};
+use channel::message_queues::QueueStyle;
+use futures::{channel::mpsc, sink::SinkExt};
+use libra_types::PeerId;
+use network::{
+    connectivity_manager::ConnectivityRequest,
+    peer_manager::{ConnectionRequestSender, PeerManagerRequestSender},
+    protocols::{
+        network::{NetworkEvents, NetworkSender},
+        rpc::error::RpcError,
+    },
+    validator_network::network_builder::NetworkBuilder,
+    ProtocolId,
+};
+use std::{convert::TryFrom, time::Duration};
+
+/// The interface from Network to OnchainDiscovery module.
+///
+/// `OnchainDiscoveryNetworkEvents` is a `Stream` of `NetworkNotification` where
+/// the raw `Bytes` rpc messages are deserialized into `OnchainDiscoveryMsg`
+/// types. `OnchainDiscoveryNetworkEvents` is a thin wrapper around a
+/// `channel::Receiver<NetworkNotification>`.
+pub type OnchainDiscoveryNetworkEvents = NetworkEvents<OnchainDiscoveryMsg>;
+
+/// The interface from OnchainDiscovery to Networking layer.
+///
+/// This is a thin wrapper around a `NetworkSender<OnchainDiscoveryMsg>`, which
+/// is in turn a thin wrapper around a `channel::Sender<NetworkRequest>`, so it
+/// is easy to clone and send off to a separate task. For example, the rpc
+/// requests return Futures that encapsulate the whole flow, from sending the
+/// request to remote, to finally receiving the response and deserializing. It
+/// therefore makes the most sense to make the rpc call on a separate async
+/// task, which requires the `OnchainDiscoveryNetworkSender` to be `Clone` and
+/// `Send`.
+#[derive(Clone)]
+pub struct OnchainDiscoveryNetworkSender {
+    network_sender: NetworkSender<OnchainDiscoveryMsg>,
+    conn_mgr_reqs_tx: channel::Sender<ConnectivityRequest>,
+}
+
+impl OnchainDiscoveryNetworkSender {
+    pub fn new(
+        peer_mgr_reqs_tx: PeerManagerRequestSender,
+        conn_reqs_tx: ConnectionRequestSender,
+        conn_mgr_reqs_tx: channel::Sender<ConnectivityRequest>,
+    ) -> Self {
+        Self {
+            network_sender: NetworkSender::new(peer_mgr_reqs_tx, conn_reqs_tx),
+            conn_mgr_reqs_tx,
+        }
+    }
+
+    pub async fn query_discovery_set(
+        &mut self,
+        recipient: PeerId,
+        req_msg: QueryDiscoverySetRequest,
+        timeout: Duration,
+    ) -> Result<QueryDiscoverySetResponseWithEvent, RpcError> {
+        let protocol = ProtocolId::OnchainDiscoveryRpc;
+        let req_msg_enum = OnchainDiscoveryMsg::QueryDiscoverySetRequest(req_msg);
+
+        let res_msg_enum = self
+            .network_sender
+            .send_rpc(recipient, protocol, req_msg_enum, timeout)
+            .await?;
+
+        let res_msg = match res_msg_enum {
+            OnchainDiscoveryMsg::QueryDiscoverySetResponse(res_msg) => res_msg,
+            OnchainDiscoveryMsg::QueryDiscoverySetRequest(_) => {
+                return Err(RpcError::InvalidRpcResponse);
+            }
+        };
+        let res_msg = QueryDiscoverySetResponseWithEvent::try_from(res_msg)
+            .map_err(RpcError::ApplicationError)?;
+        Ok(res_msg)
+    }
+
+    pub async fn send_connectivity_request(
+        &mut self,
+        req: ConnectivityRequest,
+    ) -> Result<(), mpsc::SendError> {
+        self.conn_mgr_reqs_tx.send(req).await
+    }
+}
+
+/// Construct OnchainDiscoveryNetworkSender/Events and register them with the
+/// given network builder.
+pub fn add_to_network(
+    network: &mut NetworkBuilder,
+) -> (OnchainDiscoveryNetworkSender, OnchainDiscoveryNetworkEvents) {
+    let (network_sender, network_receiver, conn_reqs_tx, conn_notifs_rx) = network
+        .add_protocol_handler(
+            vec![ProtocolId::OnchainDiscoveryRpc],
+            vec![],
+            QueueStyle::LIFO,
+            // Some(&counters::PENDING_CONSENSUS_NETWORK_EVENTS),
+            // TODO(philiphayes): add a counter for onchain discovery
+            None,
+        );
+    (
+        OnchainDiscoveryNetworkSender::new(
+            network_sender,
+            conn_reqs_tx,
+            network
+                .conn_mgr_reqs_tx()
+                .expect("ConnecitivtyManager not enabled"),
+        ),
+        OnchainDiscoveryNetworkEvents::new(network_receiver, conn_notifs_rx),
+    )
+}

--- a/network/onchain-discovery/src/test.rs
+++ b/network/onchain-discovery/src/test.rs
@@ -90,8 +90,7 @@ impl MockOnchainDiscoveryNetworkSender {
                 panic!("Unexpected request msg, expected response msg")
             }
         };
-        let res_msg = QueryDiscoverySetResponseWithEvent::try_from(res_msg).unwrap();
-        res_msg
+        QueryDiscoverySetResponseWithEvent::try_from(res_msg).unwrap()
     }
 
     async fn new_peer(&mut self, peer_id: PeerId) {
@@ -123,7 +122,7 @@ impl MockOnchainDiscoveryNetworkSender {
                     ..
                 },
             ) => (
-                protocol.clone(),
+                protocol,
                 PeerManagerNotification::RecvRpc(
                     peer_id,
                     InboundRpcRequest {
@@ -156,7 +155,7 @@ impl MockOnchainDiscoveryNetworkSender {
 fn gen_configs(count: usize) -> (Vec<NodeConfig>, ValidatorSet, DiscoverySet) {
     let config_template = NodeConfig::default();
     let config_seed = [42; 32];
-    let randomize_service_ports = false;
+    let randomize_service_ports = true;
     let randomize_libranet_ports = false;
 
     let ValidatorSwarm {
@@ -299,11 +298,12 @@ fn handles_remote_query() {
 
     let other_peer_id = PeerId::random();
     let query_res =
-        rt.block_on(mock_network_tx.query_discovery_set(other_peer_id, query_req.clone().into()));
+        rt.block_on(mock_network_tx.query_discovery_set(other_peer_id, query_req.clone()));
 
     // verify response and ratchet epoch_info
     let trusted_state = TrustedState::new_trust_any_genesis_WARNING_UNSAFE();
     query_res
+        .query_res
         .update_to_latest_ledger_response
         .verify(&trusted_state, &query_req.into())
         .unwrap();

--- a/network/onchain-discovery/src/test.rs
+++ b/network/onchain-discovery/src/test.rs
@@ -368,7 +368,7 @@ fn queries_storage_on_tick() {
     let update_reqs = update_reqs
         .into_iter()
         .map(|req| match req {
-            ConnectivityRequest::UpdateAddresses(peer_id, addrs) => (peer_id, addrs),
+            ConnectivityRequest::UpdateAddresses(_src, peer_id, addrs) => (peer_id, addrs),
             _ => panic!(
                 "Unexpected ConnectivityRequest, expected UpdateAddresses: {:?}",
                 req
@@ -466,7 +466,7 @@ fn queries_peers_on_tick() {
     let update_reqs = update_reqs
         .into_iter()
         .map(|req| match req {
-            ConnectivityRequest::UpdateAddresses(peer_id, addrs) => (peer_id, addrs),
+            ConnectivityRequest::UpdateAddresses(_src, peer_id, addrs) => (peer_id, addrs),
             _ => panic!(
                 "Unexpected ConnectivityRequest, expected UpdateAddresses: {:?}",
                 req

--- a/network/onchain-discovery/src/test.rs
+++ b/network/onchain-discovery/src/test.rs
@@ -1,0 +1,488 @@
+// Copyright (c) The Libra Core Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+use super::{
+    network_interface::{OnchainDiscoveryNetworkEvents, OnchainDiscoveryNetworkSender},
+    types::{
+        DiscoveryInfoInternal, DiscoverySetInternal, OnchainDiscoveryMsg, QueryDiscoverySetRequest,
+        QueryDiscoverySetResponseWithEvent,
+    },
+    OnchainDiscovery,
+};
+use channel::{libra_channel, message_queues::QueueStyle};
+use executor::{db_bootstrapper::maybe_bootstrap_db, Executor};
+use futures::{channel::oneshot, sink::SinkExt, stream::StreamExt};
+use libra_config::{
+    config::{NodeConfig, RoleType},
+    generator::{self, ValidatorSwarm},
+};
+use libra_types::{
+    discovery_set::DiscoverySet, trusted_state::TrustedState, validator_set::ValidatorSet, PeerId,
+};
+use libra_vm::LibraVM;
+use network::{
+    connectivity_manager::ConnectivityRequest,
+    peer_manager::{
+        ConnectionRequestSender, ConnectionStatusNotification, PeerManagerNotification,
+        PeerManagerRequest, PeerManagerRequestSender,
+    },
+    protocols::rpc::{InboundRpcRequest, OutboundRpcRequest},
+    ProtocolId,
+};
+use parity_multiaddr::Multiaddr;
+use std::{
+    collections::HashMap, convert::TryFrom, num::NonZeroUsize, str::FromStr, sync::Arc,
+    time::Duration,
+};
+use storage_client::{StorageRead, StorageReadServiceClient, SyncStorageClient};
+use storage_service::{init_libra_db, start_storage_service_with_db};
+use tokio::{
+    runtime::{Handle, Runtime},
+    task::JoinHandle,
+};
+use vm_genesis::{encode_genesis_transaction_with_validator, GENESIS_KEYPAIR};
+
+struct MockOnchainDiscoveryNetworkSender {
+    peer_mgr_notifs_tx: libra_channel::Sender<(PeerId, ProtocolId), PeerManagerNotification>,
+    conn_notifs_tx: libra_channel::Sender<PeerId, ConnectionStatusNotification>,
+}
+
+impl MockOnchainDiscoveryNetworkSender {
+    fn new(
+        peer_mgr_notifs_tx: libra_channel::Sender<(PeerId, ProtocolId), PeerManagerNotification>,
+        conn_notifs_tx: libra_channel::Sender<PeerId, ConnectionStatusNotification>,
+    ) -> Self {
+        Self {
+            peer_mgr_notifs_tx,
+            conn_notifs_tx,
+        }
+    }
+
+    async fn query_discovery_set(
+        &mut self,
+        recipient: PeerId,
+        req_msg: QueryDiscoverySetRequest,
+    ) -> QueryDiscoverySetResponseWithEvent {
+        let req_msg = OnchainDiscoveryMsg::QueryDiscoverySetRequest(req_msg);
+        let req_bytes = lcs::to_bytes(&req_msg).unwrap();
+        let (res_tx, res_rx) = oneshot::channel();
+        let inbound_rpc_req = InboundRpcRequest {
+            protocol: ProtocolId::OnchainDiscoveryRpc,
+            data: req_bytes.into(),
+            res_tx,
+        };
+
+        let (delivered_tx, delivered_rx) = oneshot::channel();
+        self.peer_mgr_notifs_tx
+            .push_with_feedback(
+                (recipient, ProtocolId::OnchainDiscoveryRpc),
+                PeerManagerNotification::RecvRpc(recipient, inbound_rpc_req),
+                Some(delivered_tx),
+            )
+            .unwrap();
+        delivered_rx.await.unwrap();
+
+        let res_bytes = res_rx.await.unwrap().unwrap();
+        let res_msg: OnchainDiscoveryMsg = lcs::from_bytes(&res_bytes).unwrap();
+        let res_msg = match res_msg {
+            OnchainDiscoveryMsg::QueryDiscoverySetResponse(res_msg) => res_msg,
+            OnchainDiscoveryMsg::QueryDiscoverySetRequest(_) => {
+                panic!("Unexpected request msg, expected response msg")
+            }
+        };
+        let res_msg = QueryDiscoverySetResponseWithEvent::try_from(res_msg).unwrap();
+        res_msg
+    }
+
+    async fn new_peer(&mut self, peer_id: PeerId) {
+        let addr = Multiaddr::from_str("/ip4/127.0.0.1/tcp/1234").unwrap();
+        let notif = ConnectionStatusNotification::NewPeer(peer_id, addr);
+        self.send_connection_notif(peer_id, notif).await;
+    }
+
+    async fn send_connection_notif(
+        &mut self,
+        peer_id: PeerId,
+        notif: ConnectionStatusNotification,
+    ) {
+        let (delivered_tx, delivered_rx) = oneshot::channel();
+        self.conn_notifs_tx
+            .push_with_feedback(peer_id, notif, Some(delivered_tx))
+            .unwrap();
+        delivered_rx.await.unwrap();
+    }
+
+    async fn forward_outbound_rpc(&mut self, peer_id: PeerId, outbound_req: PeerManagerRequest) {
+        let (protocol, inbound_req) = match outbound_req {
+            PeerManagerRequest::SendRpc(
+                _peer_id,
+                OutboundRpcRequest {
+                    protocol,
+                    data,
+                    res_tx,
+                    ..
+                },
+            ) => (
+                protocol.clone(),
+                PeerManagerNotification::RecvRpc(
+                    peer_id,
+                    InboundRpcRequest {
+                        protocol,
+                        data,
+                        res_tx,
+                    },
+                ),
+            ),
+            _ => panic!("Unexpected request, expected SendRpc: {:?}", outbound_req),
+        };
+        self.send_peer_mgr_notif(peer_id, protocol, inbound_req)
+            .await;
+    }
+
+    async fn send_peer_mgr_notif(
+        &mut self,
+        peer_id: PeerId,
+        protocol: ProtocolId,
+        notif: PeerManagerNotification,
+    ) {
+        let (delivered_tx, delivered_rx) = oneshot::channel();
+        self.peer_mgr_notifs_tx
+            .push_with_feedback((peer_id, protocol), notif, Some(delivered_tx))
+            .unwrap();
+        delivered_rx.await.unwrap();
+    }
+}
+
+fn gen_configs(count: usize) -> (Vec<NodeConfig>, ValidatorSet, DiscoverySet) {
+    let config_template = NodeConfig::default();
+    let config_seed = [42; 32];
+    let randomize_service_ports = false;
+    let randomize_libranet_ports = false;
+
+    let ValidatorSwarm {
+        mut nodes,
+        validator_set,
+        discovery_set,
+    } = generator::validator_swarm(
+        &config_template,
+        count,
+        config_seed,
+        randomize_service_ports,
+        randomize_libranet_ports,
+    );
+
+    let vm_publishing_option = None;
+    let genesis = encode_genesis_transaction_with_validator(
+        &GENESIS_KEYPAIR.0,
+        GENESIS_KEYPAIR.1.clone(),
+        &nodes[..],
+        validator_set.clone(),
+        discovery_set.clone(),
+        vm_publishing_option,
+    );
+
+    for node in &mut nodes {
+        node.execution.genesis = Some(genesis.clone());
+    }
+
+    (nodes, validator_set, discovery_set)
+}
+
+fn gen_single_config(count: usize) -> (NodeConfig, ValidatorSet, DiscoverySet) {
+    let (mut nodes, validator_set, discovery_set) = gen_configs(count);
+    let node = nodes.swap_remove(0);
+    (node, validator_set, discovery_set)
+}
+
+fn setup_storage_service_and_executor(
+    config: &NodeConfig,
+) -> (Runtime, Arc<dyn StorageRead>, Executor<LibraVM>) {
+    let (arc_db, db_reader_writer) = init_libra_db(config);
+    maybe_bootstrap_db::<LibraVM>(db_reader_writer, config)
+        .expect("Db-bootstrapper should not fail.");
+    let storage_runtime = start_storage_service_with_db(config, arc_db);
+
+    let storage_read_client = Arc::new(StorageReadServiceClient::new(&config.storage.address));
+    let executor = Executor::new(SyncStorageClient::new(&config.storage.address).into());
+
+    (storage_runtime, storage_read_client, executor)
+}
+
+fn setup_onchain_discovery(
+    executor: Handle,
+    peer_id: PeerId,
+    role: RoleType,
+    storage_read_client: Arc<dyn StorageRead>,
+) -> (
+    JoinHandle<()>,
+    MockOnchainDiscoveryNetworkSender,
+    channel::Sender<()>,
+    channel::Sender<()>,
+    libra_channel::Receiver<(PeerId, ProtocolId), PeerManagerRequest>,
+    channel::Receiver<ConnectivityRequest>,
+) {
+    let (peer_mgr_reqs_tx, peer_mgr_reqs_rx) =
+        libra_channel::new(QueueStyle::FIFO, NonZeroUsize::new(8).unwrap(), None);
+    let peer_mgr_reqs_tx = PeerManagerRequestSender::new(peer_mgr_reqs_tx);
+    let (peer_mgr_notifs_tx, peer_mgr_notifs_rx) =
+        libra_channel::new(QueueStyle::FIFO, NonZeroUsize::new(8).unwrap(), None);
+    let (conn_notifs_tx, conn_notifs_rx) =
+        libra_channel::new(QueueStyle::FIFO, NonZeroUsize::new(8).unwrap(), None);
+    let (conn_mgr_reqs_tx, conn_mgr_reqs_rx) = channel::new_test(8);
+    let (conn_reqs_tx, _) =
+        libra_channel::new(QueueStyle::FIFO, NonZeroUsize::new(8).unwrap(), None);
+    let conn_reqs_tx = ConnectionRequestSender::new(conn_reqs_tx);
+    let network_reqs_tx =
+        OnchainDiscoveryNetworkSender::new(peer_mgr_reqs_tx, conn_reqs_tx, conn_mgr_reqs_tx);
+    let network_notifs_rx = OnchainDiscoveryNetworkEvents::new(peer_mgr_notifs_rx, conn_notifs_rx);
+    let (peer_query_ticker_tx, peer_query_ticker_rx) = channel::new_test::<()>(1);
+    let (storage_query_ticker_tx, storage_query_ticker_rx) = channel::new_test::<()>(1);
+
+    let waypoint = None;
+    let outbound_rpc_timeout = Duration::from_secs(30);
+    let max_concurrent_inbound_rpcs = 8;
+
+    let onchain_discovery = OnchainDiscovery::new(
+        executor.clone(),
+        peer_id,
+        role,
+        waypoint,
+        network_reqs_tx,
+        network_notifs_rx,
+        storage_read_client,
+        peer_query_ticker_rx,
+        storage_query_ticker_rx,
+        outbound_rpc_timeout,
+        max_concurrent_inbound_rpcs,
+    );
+
+    let f_onchain_discovery = executor.spawn(onchain_discovery.start());
+
+    let mock_network_sender =
+        MockOnchainDiscoveryNetworkSender::new(peer_mgr_notifs_tx, conn_notifs_tx);
+
+    (
+        f_onchain_discovery,
+        mock_network_sender,
+        peer_query_ticker_tx,
+        storage_query_ticker_tx,
+        peer_mgr_reqs_rx,
+        conn_mgr_reqs_rx,
+    )
+}
+
+#[test]
+fn handles_remote_query() {
+    ::libra_logger::Logger::new().environment_only(true).init();
+    let mut rt = Runtime::new().unwrap();
+    let (config, _, discovery_set) = gen_single_config(5);
+    let self_peer_id = config.validator_network.as_ref().unwrap().peer_id;
+    let role = config.base.role;
+
+    let (_storage_runtime, storage_read_client, _executor) =
+        setup_storage_service_and_executor(&config);
+
+    let (
+        f_onchain_discovery,
+        mut mock_network_tx,
+        peer_query_ticker_tx,
+        storage_query_ticker_tx,
+        _peer_mgr_reqs_rx,
+        _conn_mgr_reqs_rx,
+    ) = setup_onchain_discovery(rt.handle().clone(), self_peer_id, role, storage_read_client);
+
+    // query the onchain discovery actor
+    let query_req = QueryDiscoverySetRequest {
+        client_known_version: 0,
+        client_known_seq_num: 0,
+    };
+
+    let other_peer_id = PeerId::random();
+    let query_res =
+        rt.block_on(mock_network_tx.query_discovery_set(other_peer_id, query_req.clone().into()));
+
+    // verify response and ratchet epoch_info
+    let trusted_state = TrustedState::new_trust_any_genesis_WARNING_UNSAFE();
+    query_res
+        .update_to_latest_ledger_response
+        .verify(&trusted_state, &query_req.into())
+        .unwrap();
+
+    // verify discovery set is the same as genesis discovery set
+    let discovery_set_event = query_res.event.unwrap();
+    assert_eq!(0, discovery_set_event.event_seq_num);
+
+    let expected_discovery_set = DiscoverySetInternal::from_discovery_set(role, discovery_set);
+    let actual_discovery_set =
+        DiscoverySetInternal::from_discovery_set(role, discovery_set_event.discovery_set);
+    assert_eq!(expected_discovery_set, actual_discovery_set);
+
+    // shutdown
+    drop(mock_network_tx);
+    drop(peer_query_ticker_tx);
+    drop(storage_query_ticker_tx);
+
+    rt.block_on(f_onchain_discovery).unwrap();
+}
+
+#[test]
+fn queries_storage_on_tick() {
+    ::libra_logger::Logger::new().environment_only(true).init();
+    let mut rt = Runtime::new().unwrap();
+    let (config, _, discovery_set) = gen_single_config(5);
+    let self_peer_id = config.validator_network.as_ref().unwrap().peer_id;
+    let role = config.base.role;
+
+    let (_storage_runtime, storage_read_client, _executor) =
+        setup_storage_service_and_executor(&config);
+
+    let (
+        f_onchain_discovery,
+        mock_network_tx,
+        peer_query_ticker_tx,
+        mut storage_query_ticker_tx,
+        _peer_mgr_reqs_rx,
+        conn_mgr_reqs_rx,
+    ) = setup_onchain_discovery(rt.handle().clone(), self_peer_id, role, storage_read_client);
+
+    // trigger storage tick so onchain discovery queries its own storage
+    rt.block_on(storage_query_ticker_tx.send(())).unwrap();
+
+    // shutdown all channels so onchain discovery will drop conn_mgr_reqs_tx
+    // when its done sending updates
+    drop(mock_network_tx);
+    drop(peer_query_ticker_tx);
+    drop(storage_query_ticker_tx);
+
+    // expect updates for all other nodes except ourselves
+    let discovery_set = DiscoverySetInternal::from_discovery_set(role, discovery_set);
+    let expected_update_reqs = discovery_set
+        .0
+        .into_iter()
+        .filter(|(peer_id, _discovery_info)| &self_peer_id != peer_id)
+        .map(|(peer_id, DiscoveryInfoInternal(_id_pubkey, addrs))| (peer_id, addrs))
+        .collect::<HashMap<_, _>>();
+
+    // onchain discovery should notify connectivity manager about new peer infos
+    let update_reqs = rt.block_on(conn_mgr_reqs_rx.collect::<Vec<_>>());
+    let update_reqs = update_reqs
+        .into_iter()
+        .map(|req| match req {
+            ConnectivityRequest::UpdateAddresses(peer_id, addrs) => (peer_id, addrs),
+            _ => panic!(
+                "Unexpected ConnectivityRequest, expected UpdateAddresses: {:?}",
+                req
+            ),
+        })
+        .collect::<HashMap<_, _>>();
+
+    assert_eq!(expected_update_reqs, update_reqs);
+
+    // onchain discovery actor should terminate
+    rt.block_on(f_onchain_discovery).unwrap();
+}
+
+#[test]
+fn queries_peers_on_tick() {
+    ::libra_logger::Logger::new().environment_only(true).init();
+    let mut rt = Runtime::new().unwrap();
+    let (mut configs, _, discovery_set) = gen_configs(5);
+
+    // server setup
+
+    let server_config = configs.swap_remove(0);
+    let server_peer_id = server_config.validator_network.as_ref().unwrap().peer_id;
+    let server_role = server_config.base.role;
+
+    let (_server_storage_runtime, server_storage_read_client, _server_executor) =
+        setup_storage_service_and_executor(&server_config);
+
+    let (
+        f_server_onchain_discovery,
+        mut server_network_tx,
+        server_peer_query_ticker_tx,
+        server_storage_query_ticker_tx,
+        _server_peer_mgr_reqs_rx,
+        _server_conn_mgr_reqs_rx,
+    ) = setup_onchain_discovery(
+        rt.handle().clone(),
+        server_peer_id,
+        server_role,
+        server_storage_read_client,
+    );
+
+    // client setup
+
+    let client_config = configs.swap_remove(0);
+    let client_peer_id = client_config.validator_network.as_ref().unwrap().peer_id;
+    let client_role = client_config.base.role;
+
+    let (_storage_runtime, storage_read_client, _executor) =
+        setup_storage_service_and_executor(&client_config);
+
+    let (
+        f_client_onchain_discovery,
+        mut client_network_tx,
+        mut client_peer_query_ticker_tx,
+        client_storage_query_ticker_tx,
+        mut client_peer_mgr_reqs_rx,
+        client_conn_mgr_reqs_rx,
+    ) = setup_onchain_discovery(
+        rt.handle().clone(),
+        client_peer_id,
+        client_role,
+        storage_read_client,
+    );
+
+    // notify client of new connection to server
+    rt.block_on(client_network_tx.new_peer(server_peer_id));
+
+    // trigger peer tick so client queries server peer
+    rt.block_on(client_peer_query_ticker_tx.send(())).unwrap();
+
+    // client should send a query discovery set request
+    let outbound_req = rt.block_on(client_peer_mgr_reqs_rx.next()).unwrap();
+
+    // forward the rpc request to the server
+    rt.block_on(server_network_tx.forward_outbound_rpc(client_peer_id, outbound_req));
+
+    // shutdown all channels so client onchain discovery will drop
+    // conn_mgr_reqs_tx when its done sending updates
+    drop(client_network_tx);
+    drop(client_peer_query_ticker_tx);
+    drop(client_storage_query_ticker_tx);
+
+    // expect updates for all other nodes except ourselves
+    let discovery_set = DiscoverySetInternal::from_discovery_set(client_role, discovery_set);
+    let expected_update_reqs = discovery_set
+        .0
+        .into_iter()
+        .filter(|(peer_id, _discovery_info)| &client_peer_id != peer_id)
+        .map(|(peer_id, DiscoveryInfoInternal(_id_pubkey, addrs))| (peer_id, addrs))
+        .collect::<HashMap<_, _>>();
+
+    // client should notify its connectivity manager about new peer infos
+    let update_reqs = rt.block_on(client_conn_mgr_reqs_rx.collect::<Vec<_>>());
+    let update_reqs = update_reqs
+        .into_iter()
+        .map(|req| match req {
+            ConnectivityRequest::UpdateAddresses(peer_id, addrs) => (peer_id, addrs),
+            _ => panic!(
+                "Unexpected ConnectivityRequest, expected UpdateAddresses: {:?}",
+                req
+            ),
+        })
+        .collect::<HashMap<_, _>>();
+
+    assert_eq!(expected_update_reqs, update_reqs);
+
+    // client should shutdown completely
+    rt.block_on(f_client_onchain_discovery).unwrap();
+
+    // server shutdown
+    drop(server_network_tx);
+    drop(server_peer_query_ticker_tx);
+    drop(server_storage_query_ticker_tx);
+
+    rt.block_on(f_server_onchain_discovery).unwrap();
+}

--- a/network/onchain-discovery/src/types.rs
+++ b/network/onchain-discovery/src/types.rs
@@ -1,0 +1,180 @@
+// Copyright (c) The Libra Core Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+use anyhow::{bail, ensure, Error, Result};
+use libra_config::config::RoleType;
+use libra_crypto::x25519;
+use libra_types::{
+    discovery_info::DiscoveryInfo,
+    discovery_set::{
+        DiscoverySet, DiscoverySetChangeEvent, GLOBAL_DISCOVERY_SET_CHANGE_EVENT_PATH,
+    },
+    get_with_proof::{
+        RequestItem, ResponseItem, UpdateToLatestLedgerRequest, UpdateToLatestLedgerResponse,
+    },
+    PeerId,
+};
+use parity_multiaddr::Multiaddr;
+use serde::{Deserialize, Serialize};
+use std::{collections::HashMap, convert::TryFrom};
+
+/// OnchainDiscovery LibraNet message types. These are sent over-the-wire.
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub enum OnchainDiscoveryMsg {
+    QueryDiscoverySetRequest(QueryDiscoverySetRequest),
+    QueryDiscoverySetResponse(QueryDiscoverySetResponse),
+}
+
+/// A request for another peer's latest discovery set and (if needed) a validator
+/// change proof.
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct QueryDiscoverySetRequest {
+    pub client_known_version: u64,
+    // TODO(philiphayes): actually use this sequence number.
+    pub client_known_seq_num: u64,
+}
+
+impl Into<UpdateToLatestLedgerRequest> for QueryDiscoverySetRequest {
+    fn into(self) -> UpdateToLatestLedgerRequest {
+        let req_items = vec![RequestItem::GetEventsByEventAccessPath {
+            access_path: GLOBAL_DISCOVERY_SET_CHANGE_EVENT_PATH.clone(),
+            // u64::MAX means query the latest event
+            start_event_seq_num: ::std::u64::MAX,
+            // to query latest, ascending needs to be false
+            ascending: false,
+            // just query the last event
+            limit: 1,
+        }];
+
+        UpdateToLatestLedgerRequest::new(self.client_known_version, req_items)
+    }
+}
+
+/// A response to a QueryDiscoverySetRequest with the latest discovery set change
+/// event and (if needed) a validator change proof.
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct QueryDiscoverySetResponse {
+    pub update_to_latest_ledger_response: UpdateToLatestLedgerResponse,
+}
+
+impl From<UpdateToLatestLedgerResponse> for QueryDiscoverySetResponse {
+    fn from(res: UpdateToLatestLedgerResponse) -> Self {
+        Self {
+            update_to_latest_ledger_response: res,
+        }
+    }
+}
+
+impl From<QueryDiscoverySetResponseWithEvent> for QueryDiscoverySetResponse {
+    fn from(res: QueryDiscoverySetResponseWithEvent) -> Self {
+        Self {
+            update_to_latest_ledger_response: res.update_to_latest_ledger_response,
+        }
+    }
+}
+
+/// A QueryDiscoverySetResponse with the event validated, deserialized, and pulled
+/// out to reduce unnecessary double validation.
+#[derive(Clone, Debug)]
+pub struct QueryDiscoverySetResponseWithEvent {
+    pub update_to_latest_ledger_response: UpdateToLatestLedgerResponse,
+    pub event: Option<DiscoverySetChangeEvent>,
+}
+
+impl TryFrom<QueryDiscoverySetResponse> for QueryDiscoverySetResponseWithEvent {
+    type Error = Error;
+
+    fn try_from(res: QueryDiscoverySetResponse) -> Result<Self> {
+        // TODO(philiphayes): validate event access path etc
+
+        let res = res.update_to_latest_ledger_response;
+
+        let res_len = res.response_items.len();
+        ensure!(
+            res_len <= 1,
+            "Should only contain at most one response item. response_items.len(): {}",
+            res_len
+        );
+
+        let maybe_event = res.response_items.get(0)
+            .map(|res_item| {
+                match res_item {
+                    ResponseItem::GetEventsByEventAccessPath {
+                        events_with_proof,
+                        ..
+                    } => {
+                        let events_len = events_with_proof.len();
+                        ensure!(
+                            events_len <= 1,
+                            "Should only contain at most one event response. events_with_proof.len(): {}",
+                            events_len
+                        );
+
+                        Ok(events_with_proof.get(0).map(|event_with_proof| &event_with_proof.event))
+                    },
+                    res_item => bail!("Unexpected response item type: res_item: {:?}, expected GetEventsByEventAccessPath", res_item),
+                }
+            })
+            .transpose()?
+            .flatten();
+
+        let event = maybe_event
+            .map(|event| DiscoverySetChangeEvent::try_from(event))
+            .transpose()?;
+
+        Ok(Self {
+            update_to_latest_ledger_response: res,
+            event,
+        })
+    }
+}
+
+/// An internal representation of the DiscoverySet.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct DiscoverySetInternal(pub HashMap<PeerId, DiscoveryInfoInternal>);
+
+impl DiscoverySetInternal {
+    pub fn from_discovery_set(role_filter: RoleType, discovery_set: DiscoverySet) -> Self {
+        Self(
+            discovery_set
+                .into_iter()
+                .map(|discovery_info| {
+                    (
+                        discovery_info.account_address,
+                        DiscoveryInfoInternal::from_discovery_info(role_filter, discovery_info),
+                    )
+                })
+                .collect::<HashMap<_, _>>(),
+        )
+    }
+
+    pub fn empty() -> Self {
+        Self(HashMap::new())
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.0.is_empty()
+    }
+
+    pub fn len(&self) -> usize {
+        self.0.len()
+    }
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct DiscoveryInfoInternal(pub x25519::PublicKey, pub Vec<Multiaddr>);
+
+impl DiscoveryInfoInternal {
+    pub fn from_discovery_info(role_filter: RoleType, discovery_info: DiscoveryInfo) -> Self {
+        match role_filter {
+            RoleType::Validator => Self(
+                discovery_info.validator_network_identity_pubkey,
+                vec![discovery_info.validator_network_address],
+            ),
+            RoleType::FullNode => Self(
+                discovery_info.fullnodes_network_identity_pubkey,
+                vec![discovery_info.fullnodes_network_address],
+            ),
+        }
+    }
+}

--- a/network/src/connectivity_manager/mod.rs
+++ b/network/src/connectivity_manager/mod.rs
@@ -190,7 +190,7 @@ where
 
         trace!("Starting connection manager");
         loop {
-            self.event_id += 1;
+            self.event_id = self.event_id.wrapping_add(1);
             ::futures::select! {
                 _ = self.ticker.select_next_some() => {
                     trace!("Event Id: {}, type: Tick", self.event_id);

--- a/network/src/protocols/network/dummy.rs
+++ b/network/src/protocols/network/dummy.rs
@@ -147,7 +147,8 @@ pub fn setup_network() -> DummyNetwork {
         .trusted_peers(trusted_peers.clone())
         .signing_keypair((listener_signing_private_key, listener_signing_public_key))
         .discovery_interval_ms(HOUR_IN_MS)
-        .add_discovery();
+        .add_connectivity_manager()
+        .add_gossip_discovery();
     let (listener_sender, mut listener_events) = add_to_network(&mut network_builder);
     let listen_addr = network_builder.build();
 
@@ -169,7 +170,8 @@ pub fn setup_network() -> DummyNetwork {
                 .collect(),
         )
         .discovery_interval_ms(HOUR_IN_MS)
-        .add_discovery();
+        .add_connectivity_manager()
+        .add_gossip_discovery();
     let (dialer_sender, mut dialer_events) = add_to_network(&mut network_builder);
     let _dialer_addr = network_builder.build();
 

--- a/network/src/protocols/wire/handshake/v1/mod.rs
+++ b/network/src/protocols/wire/handshake/v1/mod.rs
@@ -28,6 +28,7 @@ pub enum ProtocolId {
     DiscoveryDirectSend = 4,
     HealthCheckerRpc = 5,
     IdentityDirectSend = 6,
+    OnchainDiscoveryRpc = 7,
 }
 
 #[derive(Clone, Debug, Default, PartialEq, Deserialize, Serialize)]

--- a/state-synchronizer/src/tests/integration_tests.rs
+++ b/state-synchronizer/src/tests/integration_tests.rs
@@ -259,7 +259,8 @@ impl SynchronizerEnv {
             .trusted_peers(trusted_peers)
             .seed_peers(seed_peers)
             .transport(TransportType::Memory)
-            .add_discovery();
+            .add_connectivity_manager()
+            .add_gossip_discovery();
 
         let (sender, events) = crate::network::add_to_network(&mut network_builder);
         let peer_addr = network_builder.build();


### PR DESCRIPTION
note: this does not actually enable onchain discovery yet. when used instead of gossip discovery, the smoke tests all pass, which is nice : )

still todo:

1. use new DbReader storage trait instead of old gRPC service
2. integrate DiscoverySet into ValidatorSet onchain config
3. integrate state-sync reconfig notifications
4. use discovery set as source-of-truth for elligible peers set
5. full protocol stack in discovery info instead of separate pubkey and address field
6. fullnodes using onchain discovery
7. ...