### PR TITLE
[Storage] SchemaDB: remove use of set_db_log_dir

### DIFF
--- a/storage/inspector/src/main.rs
+++ b/storage/inspector/src/main.rs
@@ -169,7 +169,8 @@ fn main() {
     let log_dir = tempfile::tempdir().expect("Unable to get temp dir");
     info!("Opening DB at: {:?}, log at {:?}", p, log_dir.path());
 
-    let db = LibraDB::open(p, true, Some(log_dir.path())).expect("Unable to open LibraDB");
+    let read_only = true;
+    let db = LibraDB::open(p, read_only).expect("Unable to open LibraDB");
     info!("DB opened successfully.");
 
     if let Some(cmd) = opt.cmd {

--- a/storage/schemadb/src/lib.rs
+++ b/storage/schemadb/src/lib.rs
@@ -17,7 +17,7 @@
 pub mod schema;
 
 use crate::schema::{KeyCodec, Schema, SeekKeyCodec, ValueCodec};
-use anyhow::{bail, format_err, Result};
+use anyhow::{format_err, Result};
 use libra_metrics::OpMetrics;
 use once_cell::sync::Lazy;
 use rocksdb::{
@@ -228,22 +228,8 @@ impl DB {
     pub fn open_readonly<P: AsRef<Path>>(
         path: P,
         cf_opts_map: ColumnFamilyOptionsMap,
-        db_log_dir: P,
     ) -> Result<Self> {
-        if !db_exists(path.as_ref()) {
-            bail!("DB doesn't exists.");
-        }
-
-        let mut db_opts = DBOptions::new();
-
-        db_opts.create_if_missing(false);
-        db_opts.set_db_log_dir(db_log_dir.as_ref().to_str().ok_or_else(|| {
-            format_err!(
-                "db_log_dir {:?} can not be converted to string.",
-                db_log_dir.as_ref()
-            )
-        })?);
-
+        let db_opts = DBOptions::new();
         DB::open_cf_readonly(db_opts, &path, cf_opts_map.into_iter().collect())
     }
 


### PR DESCRIPTION
https://github.com/rust-rocksdb/rust-rocksdb currently does not support this right now. I don't feel it is strictly necessary, as having the `LOG` files would be okay, maybe even better for keeping track of what has happened.
