### PR TITLE
[network] Implement network handshake protocol

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3229,7 +3229,6 @@ dependencies = [
  "rand 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.106 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_bytes 0.11.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde_repr 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "serial_test 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "socket-bench-server 0.1.0",
  "stream-ratelimiter 0.1.0",
@@ -4611,16 +4610,6 @@ dependencies = [
  "itoa 0.4.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "ryu 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.106 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "serde_repr"
-version = "0.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "proc-macro2 1.0.10 (registry+https://github.com/rust-lang/crates.io-index)",
- "quote 1.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "syn 1.0.17 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -6822,7 +6811,6 @@ dependencies = [
 "checksum serde_bytes 0.11.3 (registry+https://github.com/rust-lang/crates.io-index)" = "325a073952621257820e7a3469f55ba4726d8b28657e7e36653d1c36dc2c84ae"
 "checksum serde_derive 1.0.106 (registry+https://github.com/rust-lang/crates.io-index)" = "9e549e3abf4fb8621bd1609f11dfc9f5e50320802273b12f3811a67e6716ea6c"
 "checksum serde_json 1.0.51 (registry+https://github.com/rust-lang/crates.io-index)" = "da07b57ee2623368351e9a0488bb0b261322a15a6e0ae53e243cbdc0f4208da9"
-"checksum serde_repr 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "cd02c7587ec314570041b2754829f84d873ced14a96d1fd1823531e11db40573"
 "checksum serde_urlencoded 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)" = "9ec5d77e2d4c73717816afac02670d5c4f534ea95ed430442cad02e7a6e32c97"
 "checksum serde_yaml 0.8.11 (registry+https://github.com/rust-lang/crates.io-index)" = "691b17f19fc1ec9d94ec0b5864859290dff279dbd7b03f017afda54eb36c3c35"
 "checksum serial_test 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "fef5f7c7434b2f2c598adc6f9494648a1e41274a75c0ba4056f680ae0c117fd6"

--- a/common/bitvec/src/lib.rs
+++ b/common/bitvec/src/lib.rs
@@ -58,7 +58,7 @@ impl BitVec {
     #[allow(dead_code)]
     /// Sets the bit at position @pos.
     pub fn set(&mut self, pos: u8) {
-        // This is optimised to: let bucket = pos << 3;
+        // This is optimised to: let bucket = pos >> 3;
         let bucket: usize = pos as usize / BUCKET_SIZE;
         if self.inner.len() <= bucket {
             self.inner.resize(bucket + 1, 0);
@@ -72,7 +72,7 @@ impl BitVec {
     #[allow(dead_code)]
     /// Checks if the bit at position @pos is set.
     pub fn is_set(&self, pos: u8) -> bool {
-        // This is optimised to: let bucket = pos << 3;
+        // This is optimised to: let bucket = pos >> 3;
         let bucket: usize = pos as usize / BUCKET_SIZE;
         if self.inner.len() <= bucket {
             return false;

--- a/network/Cargo.toml
+++ b/network/Cargo.toml
@@ -20,7 +20,6 @@ prometheus = { version = "0.8.0", default-features = false }
 rand = "0.6.5"
 serde = { version = "1.0.106", default-features = false }
 serde_bytes = "0.11.3"
-serde_repr = "0.1"
 thiserror = "1.0"
 tokio = { version = "0.2.13", features = ["full"] }
 tokio-util = { version = "0.3", features = ["codec"] }

--- a/network/netcore/src/transport/mod.rs
+++ b/network/netcore/src/transport/mod.rs
@@ -121,7 +121,7 @@ pub trait TransportExt: Transport {
     fn and_then<F, Fut, O>(self, f: F) -> and_then::AndThen<Self, F>
     where
         Self: Sized,
-        F: FnOnce(Self::Output, ConnectionOrigin) -> Fut + Clone,
+        F: FnOnce(Self::Output, Multiaddr, ConnectionOrigin) -> Fut + Clone,
         // Pin the error types to be the same for now
         // TODO don't require the error types to be the same
         Fut: Future<Output = Result<O, Self::Error>>,

--- a/network/netcore/src/transport/tcp.rs
+++ b/network/netcore/src/transport/tcp.rs
@@ -272,8 +272,8 @@ mod test {
 
     #[tokio::test]
     async fn simple_listen_and_dial() -> Result<(), ::std::io::Error> {
-        let t = TcpTransport::default().and_then(|mut out, connection| async move {
-            match connection {
+        let t = TcpTransport::default().and_then(|mut out, _addr, origin| async move {
+            match origin {
                 ConnectionOrigin::Inbound => {
                     out.write_all(b"Earth").await?;
                     let mut buf = [0; 3];

--- a/network/socket-bench-server/src/lib.rs
+++ b/network/socket-bench-server/src/lib.rs
@@ -74,7 +74,7 @@ impl Args {
 
 /// Build a MemorySocket + Noise transport
 pub fn build_memsocket_noise_transport() -> impl Transport<Output = NoiseSocket<MemorySocket>> {
-    MemoryTransport::default().and_then(move |socket, origin| async move {
+    MemoryTransport::default().and_then(move |socket, _addr, origin| async move {
         let noise_config = Arc::new(NoiseConfig::new_random());
         let (_remote_static_key, socket) = noise_config.upgrade_connection(socket, origin).await?;
         Ok(socket)
@@ -83,7 +83,7 @@ pub fn build_memsocket_noise_transport() -> impl Transport<Output = NoiseSocket<
 
 /// Build a Tcp + Noise transport
 pub fn build_tcp_noise_transport() -> impl Transport<Output = NoiseSocket<TcpSocket>> {
-    TcpTransport::default().and_then(move |socket, origin| async move {
+    TcpTransport::default().and_then(move |socket, _addr, origin| async move {
         let noise_config = Arc::new(NoiseConfig::new_random());
         let (_remote_static_key, socket) = noise_config.upgrade_connection(socket, origin).await?;
         Ok(socket)

--- a/network/src/interface/mod.rs
+++ b/network/src/interface/mod.rs
@@ -14,11 +14,12 @@
 use crate::{
     counters,
     peer::{Peer, PeerHandle, PeerNotification},
-    peer_manager::{Connection, ConnectionNotification},
+    peer_manager::ConnectionNotification,
     protocols::{
         direct_send::{DirectSend, DirectSendNotification, DirectSendRequest, Message},
         rpc::{InboundRpcRequest, OutboundRpcRequest, Rpc, RpcNotification},
     },
+    transport::Connection,
     validator_network, ProtocolId,
 };
 use channel::{self, libra_channel, message_queues::QueueStyle};
@@ -72,8 +73,7 @@ where
         libra_channel::Sender<ProtocolId, NetworkRequest>,
         libra_channel::Receiver<ProtocolId, NetworkNotification>,
     ) {
-        let identity = connection.metadata.peer_identity().clone();
-        let peer_id = identity.peer_id();
+        let peer_id = connection.metadata.peer_id();
 
         // Setup and start Peer actor.
         let (peer_reqs_tx, peer_reqs_rx) = channel::new(

--- a/network/src/lib.rs
+++ b/network/src/lib.rs
@@ -28,4 +28,4 @@ mod transport;
 
 pub type DisconnectReason = peer::DisconnectReason;
 pub type ConnectivityRequest = connectivity_manager::ConnectivityRequest;
-pub type ProtocolId = protocols::wire::messaging::v1::ProtocolId;
+pub type ProtocolId = protocols::wire::handshake::v1::ProtocolId;

--- a/network/src/peer/mod.rs
+++ b/network/src/peer/mod.rs
@@ -5,9 +5,11 @@
 //! and opening substreams as well as negotiating particular protocols on those substreams.
 use crate::{
     counters,
-    peer_manager::{Connection, ConnectionMetadata, PeerManagerError},
+    peer_manager::PeerManagerError,
     protocols::wire::messaging::v1::NetworkMessage,
-    transport, ProtocolId,
+    transport,
+    transport::{Connection, ConnectionMetadata},
+    ProtocolId,
 };
 use bytes::BytesMut;
 use channel;
@@ -108,7 +110,7 @@ where
     }
 
     fn peer_id(&self) -> PeerId {
-        self.connection_metadata.peer_identity().peer_id()
+        self.connection_metadata.peer_id()
     }
 
     pub async fn start(mut self) {

--- a/network/src/peer/test.rs
+++ b/network/src/peer/test.rs
@@ -48,7 +48,7 @@ fn build_test_peer(
             Multiaddr::from_str("/ip4/127.0.0.1/tcp/8081").unwrap(),
             origin,
             MessagingProtocolVersion::V1,
-            vec![],
+            [].iter().into(),
         ),
         socket: a,
     };

--- a/network/src/peer_manager/tests.rs
+++ b/network/src/peer_manager/tests.rs
@@ -48,7 +48,7 @@ pub fn build_test_transport(
                     addr,
                     origin,
                     MessagingProtocolVersion::V1,
-                    vec![TEST_PROTOCOL],
+                    [TEST_PROTOCOL].iter().into(),
                 ),
             })
         })
@@ -219,7 +219,7 @@ fn create_connection<TSocket: transport::TSocket>(
             addr,
             origin,
             MessagingProtocolVersion::V1,
-            vec![TEST_PROTOCOL],
+            [TEST_PROTOCOL].iter().into(),
         ),
     }
 }
@@ -543,7 +543,7 @@ fn peer_manager_simultaneous_dial_disconnect_event() {
                 Multiaddr::empty(),
                 ConnectionOrigin::Inbound,
                 MessagingProtocolVersion::V1,
-                vec![TEST_PROTOCOL],
+                [TEST_PROTOCOL].iter().into(),
             ),
             DisconnectReason::ConnectionLost,
         );
@@ -600,7 +600,7 @@ fn test_dial_disconnect() {
                 Multiaddr::empty(),
                 ConnectionOrigin::Outbound,
                 MessagingProtocolVersion::V1,
-                vec![TEST_PROTOCOL],
+                [TEST_PROTOCOL].iter().into(),
             ),
             DisconnectReason::Requested,
         );

--- a/network/src/protocols/identity.rs
+++ b/network/src/protocols/identity.rs
@@ -94,15 +94,19 @@ mod tests {
         let mut server_handshake = HandshakeMsg::new();
         server_handshake.add(
             MessagingProtocolVersion::V1,
-            vec![
+            [
                 ProtocolId::ConsensusDirectSend,
                 ProtocolId::MempoolDirectSend,
-            ],
+            ]
+            .iter()
+            .into(),
         );
         let mut client_handshake = HandshakeMsg::new();
         client_handshake.add(
             MessagingProtocolVersion::V1,
-            vec![ProtocolId::ConsensusRpc, ProtocolId::ConsensusDirectSend],
+            [ProtocolId::ConsensusRpc, ProtocolId::ConsensusDirectSend]
+                .iter()
+                .into(),
         );
 
         let server_handshake_clone = server_handshake.clone();

--- a/network/src/protocols/wire/handshake/v1/mod.rs
+++ b/network/src/protocols/wire/handshake/v1/mod.rs
@@ -82,14 +82,12 @@ impl SupportedProtocols {
 }
 
 impl HandshakeMsg {
-    #[allow(unused)]
     pub fn new() -> Self {
         HandshakeMsg {
             supported_protocols: BTreeMap::default(),
         }
     }
 
-    #[allow(unused)]
     pub fn add(
         &mut self,
         messaging_protocol: MessagingProtocolVersion,
@@ -101,7 +99,6 @@ impl HandshakeMsg {
         );
     }
 
-    #[allow(unused)]
     pub fn find_common_protocols(
         &self,
         other: &HandshakeMsg,

--- a/network/src/protocols/wire/handshake/v1/mod.rs
+++ b/network/src/protocols/wire/handshake/v1/mod.rs
@@ -129,6 +129,6 @@ impl HandshakeMsg {
                 _ => {}
             }
         }
-        return None;
+        None
     }
 }

--- a/network/src/protocols/wire/handshake/v1/mod.rs
+++ b/network/src/protocols/wire/handshake/v1/mod.rs
@@ -11,8 +11,7 @@
 //! intersecting messaging protocol version and use that for the remainder of the session.
 
 use serde::{Deserialize, Serialize};
-use serde_repr::{Deserialize_repr, Serialize_repr};
-use std::collections::HashMap;
+use std::collections::BTreeMap;
 
 #[cfg(test)]
 mod test;
@@ -21,14 +20,13 @@ mod test;
 /// bit-vector specifying application-level protocols supported over that version.
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct HandshakeMsg {
-    pub supported_protocols: HashMap<MessagingProtocolVersion, bitvec::BitVec>,
+    pub supported_protocols: BTreeMap<MessagingProtocolVersion, bitvec::BitVec>,
 }
 
 /// Enum representing different versions of the Libra network protocol. These should be listed from
 /// old to new, old having the smallest value.
 /// We derive `PartialOrd` since nodes need to find highest intersecting protocol version.
-#[repr(u8)]
-#[derive(Eq, PartialEq, PartialOrd, Clone, Debug, Hash, Deserialize_repr, Serialize_repr)]
+#[derive(Eq, PartialEq, Ord, PartialOrd, Clone, Debug, Hash, Deserialize, Serialize)]
 pub enum MessagingProtocolVersion {
     V1 = 0,
 }

--- a/network/src/protocols/wire/handshake/v1/mod.rs
+++ b/network/src/protocols/wire/handshake/v1/mod.rs
@@ -11,7 +11,6 @@
 //! intersecting messaging protocol version and use that for the remainder of the session.
 
 use serde::{Deserialize, Serialize};
-use serde_repr::{Deserialize_repr, Serialize_repr};
 use std::{collections::BTreeMap, convert::TryInto, iter::Iterator};
 
 #[cfg(test)]
@@ -20,7 +19,7 @@ mod test;
 /// Unique identifier associated with each application protocol.
 /// New application protocols can be added without bumping up the MessagingProtocolVersion.
 #[repr(u8)]
-#[derive(Clone, Copy, Debug, Hash, Eq, PartialEq, Deserialize_repr, Serialize_repr)]
+#[derive(Clone, Copy, Debug, Hash, Eq, PartialEq, Deserialize, Serialize)]
 pub enum ProtocolId {
     ConsensusRpc = 0,
     ConsensusDirectSend = 1,

--- a/network/src/protocols/wire/handshake/v1/mod.rs
+++ b/network/src/protocols/wire/handshake/v1/mod.rs
@@ -92,10 +92,8 @@ impl HandshakeMsg {
         messaging_protocol: MessagingProtocolVersion,
         application_protocols: SupportedProtocols,
     ) {
-        self.supported_protocols.insert(
-            messaging_protocol,
-            SupportedProtocols::from(application_protocols),
-        );
+        self.supported_protocols
+            .insert(messaging_protocol, application_protocols);
     }
 
     pub fn find_common_protocols(
@@ -108,11 +106,7 @@ impl HandshakeMsg {
         for (k_outer, _) in self.supported_protocols.iter().rev() {
             // Remove all elements from inner iterator that are larger than the current head of the
             // outer iterator.
-            match inner
-                .by_ref()
-                .filter(|(k_inner, _)| *k_inner <= k_outer)
-                .nth(0)
-            {
+            match inner.by_ref().find(|(k_inner, _)| *k_inner <= k_outer) {
                 None => {
                     return None;
                 }

--- a/network/src/protocols/wire/handshake/v1/mod.rs
+++ b/network/src/protocols/wire/handshake/v1/mod.rs
@@ -11,10 +11,25 @@
 //! intersecting messaging protocol version and use that for the remainder of the session.
 
 use serde::{Deserialize, Serialize};
+use serde_repr::{Deserialize_repr, Serialize_repr};
 use std::collections::BTreeMap;
 
 #[cfg(test)]
 mod test;
+
+/// Unique identifier associated with each application protocol.
+/// New application protocols can be added without bumping up the MessagingProtocolVersion.
+#[repr(u8)]
+#[derive(Clone, Copy, Debug, Hash, Eq, PartialEq, Deserialize_repr, Serialize_repr)]
+pub enum ProtocolId {
+    ConsensusRpc = 0,
+    ConsensusDirectSend = 1,
+    MempoolDirectSend = 2,
+    StateSynchronizerDirectSend = 3,
+    DiscoveryDirectSend = 4,
+    HealthCheckerRpc = 5,
+    IdentityDirectSend = 6,
+}
 
 /// The HandshakeMsg contains a mapping from MessagingProtocolVersion suppported by the node to a
 /// bit-vector specifying application-level protocols supported over that version.

--- a/network/src/protocols/wire/handshake/v1/mod.rs
+++ b/network/src/protocols/wire/handshake/v1/mod.rs
@@ -12,7 +12,7 @@
 
 use serde::{Deserialize, Serialize};
 use serde_repr::{Deserialize_repr, Serialize_repr};
-use std::collections::BTreeMap;
+use std::{collections::BTreeMap, convert::TryInto};
 
 #[cfg(test)]
 mod test;
@@ -31,17 +31,115 @@ pub enum ProtocolId {
     IdentityDirectSend = 6,
 }
 
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
+pub struct SupportedProtocols(bitvec::BitVec);
+
 /// The HandshakeMsg contains a mapping from MessagingProtocolVersion suppported by the node to a
 /// bit-vector specifying application-level protocols supported over that version.
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct HandshakeMsg {
-    pub supported_protocols: BTreeMap<MessagingProtocolVersion, bitvec::BitVec>,
+    pub supported_protocols: BTreeMap<MessagingProtocolVersion, SupportedProtocols>,
 }
 
 /// Enum representing different versions of the Libra network protocol. These should be listed from
 /// old to new, old having the smallest value.
 /// We derive `PartialOrd` since nodes need to find highest intersecting protocol version.
-#[derive(Eq, PartialEq, Ord, PartialOrd, Clone, Debug, Hash, Deserialize, Serialize)]
+#[derive(Eq, PartialEq, Ord, PartialOrd, Clone, Copy, Debug, Hash, Deserialize, Serialize)]
 pub enum MessagingProtocolVersion {
     V1 = 0,
+}
+
+impl TryInto<Vec<ProtocolId>> for SupportedProtocols {
+    type Error = lcs::Error;
+
+    fn try_into(self) -> lcs::Result<Vec<ProtocolId>> {
+        let mut protocols = Vec::with_capacity(self.0.count_ones() as usize);
+        if let Some(last_bit) = self.0.last_set_bit() {
+            for i in 0..=last_bit {
+                if self.0.is_set(i) {
+                    let protocol: ProtocolId = lcs::from_bytes(&[i])?;
+                    protocols.push(protocol);
+                }
+            }
+        }
+        Ok(protocols)
+    }
+}
+
+impl<T: AsRef<[ProtocolId]>> From<T> for SupportedProtocols {
+    fn from(protocols: T) -> Self {
+        let mut bv = bitvec::BitVec::default();
+        protocols.as_ref().iter().for_each(|p| bv.set(*p as u8));
+        Self(bv)
+    }
+}
+
+impl SupportedProtocols {
+    /// Returns a new SupportedProtocols struct that is an intersection.
+    fn intersection(self, other: SupportedProtocols) -> SupportedProtocols {
+        SupportedProtocols(self.0 & other.0)
+    }
+}
+
+impl HandshakeMsg {
+    #[allow(unused)]
+    pub fn new() -> Self {
+        HandshakeMsg {
+            supported_protocols: BTreeMap::default(),
+        }
+    }
+
+    #[allow(unused)]
+    pub fn add(
+        &mut self,
+        messaging_protocol: MessagingProtocolVersion,
+        application_protocols: Vec<ProtocolId>,
+    ) {
+        self.supported_protocols.insert(
+            messaging_protocol,
+            SupportedProtocols::from(application_protocols),
+        );
+    }
+
+    #[allow(unused)]
+    pub fn find_common_protocols(
+        &self,
+        other: &HandshakeMsg,
+    ) -> Option<(MessagingProtocolVersion, Vec<ProtocolId>)> {
+        // First, find the highest MessagingProtocolVersion supported by both nodes.
+        let mut inner = other.supported_protocols.iter().rev().peekable();
+        // Iterate over all supported protocol versions in decreasing order.
+        for (k_outer, _) in self.supported_protocols.iter().rev() {
+            // Remove all elements from inner iterator that are larger than the current head of the
+            // outer iterator.
+            match inner
+                .by_ref()
+                .filter(|(k_inner, _)| *k_inner <= k_outer)
+                .nth(0)
+            {
+                None => {
+                    return None;
+                }
+                Some((k_inner, _)) if k_inner == k_outer => {
+                    // Find all protocols supported by both nodes for the above protocol version.
+                    // Both `self` and `other` shold have entry in map for `key`.
+                    let protocols_self = self.supported_protocols.get(k_inner).unwrap();
+                    let protocols_other = other.supported_protocols.get(k_inner).unwrap();
+                    // Since we are intersecting our `SupportedProtocols` with that of `other`, the
+                    // conversion of intersecting SupportedProtocols to Vec<ProtocolId> is guaranteed to be
+                    // successful.
+                    return Some((
+                        *k_inner,
+                        protocols_self
+                            .clone()
+                            .intersection(protocols_other.clone())
+                            .try_into()
+                            .unwrap(),
+                    ));
+                }
+                _ => {}
+            }
+        }
+        return None;
+    }
 }

--- a/network/src/protocols/wire/handshake/v1/test.rs
+++ b/network/src/protocols/wire/handshake/v1/test.rs
@@ -13,10 +13,17 @@ fn net_protocol() -> lcs::Result<()> {
 
 #[test]
 fn protocols_to_from_vec() {
-    let supported_protocols = vec![ProtocolId::ConsensusRpc, ProtocolId::MempoolDirectSend];
+    let supported_protocols: SupportedProtocols =
+        [ProtocolId::ConsensusRpc, ProtocolId::MempoolDirectSend]
+            .iter()
+            .into();
     assert_eq!(
-        SupportedProtocols::from(&supported_protocols).try_into(),
-        Ok(supported_protocols)
+        SupportedProtocols::from(
+            (supported_protocols.clone().try_into() as Result<Vec<ProtocolId>, _>)
+                .unwrap()
+                .iter()
+        ),
+        supported_protocols
     );
 }
 
@@ -24,7 +31,9 @@ fn protocols_to_from_vec() {
 fn common_protocols() {
     let h1: BTreeMap<_, _> = [(
         MessagingProtocolVersion::V1,
-        SupportedProtocols::from([ProtocolId::ConsensusRpc, ProtocolId::DiscoveryDirectSend]),
+        [ProtocolId::ConsensusRpc, ProtocolId::DiscoveryDirectSend]
+            .iter()
+            .into(),
     )]
     .iter()
     .cloned()
@@ -36,7 +45,9 @@ fn common_protocols() {
     // Case 1: One intersecting protocol is found for common messaging protocol version.
     let h2: BTreeMap<_, _> = [(
         MessagingProtocolVersion::V1,
-        SupportedProtocols::from([ProtocolId::ConsensusRpc, ProtocolId::MempoolDirectSend]),
+        [ProtocolId::ConsensusRpc, ProtocolId::MempoolDirectSend]
+            .iter()
+            .into(),
     )]
     .iter()
     .cloned()
@@ -45,7 +56,10 @@ fn common_protocols() {
         supported_protocols: h2,
     };
     assert_eq!(
-        Some((MessagingProtocolVersion::V1, vec![ProtocolId::ConsensusRpc])),
+        Some((
+            MessagingProtocolVersion::V1,
+            [ProtocolId::ConsensusRpc].iter().into()
+        )),
         h1.find_common_protocols(&h2)
     );
 
@@ -64,7 +78,7 @@ fn common_protocols() {
         supported_protocols: h2,
     };
     assert_eq!(
-        Some((MessagingProtocolVersion::V1, vec![])),
+        Some((MessagingProtocolVersion::V1, [].iter().into())),
         h1.find_common_protocols(&h2)
     );
 }

--- a/network/src/protocols/wire/handshake/v1/test.rs
+++ b/network/src/protocols/wire/handshake/v1/test.rs
@@ -10,3 +10,61 @@ fn net_protocol() -> lcs::Result<()> {
     assert_eq!(lcs::to_bytes(&protocol)?, vec![0x00]);
     Ok(())
 }
+
+#[test]
+fn protocols_to_from_vec() {
+    let supported_protocols = vec![ProtocolId::ConsensusRpc, ProtocolId::MempoolDirectSend];
+    assert_eq!(
+        SupportedProtocols::from(&supported_protocols).try_into(),
+        Ok(supported_protocols)
+    );
+}
+
+#[test]
+fn common_protocols() {
+    let h1: BTreeMap<_, _> = [(
+        MessagingProtocolVersion::V1,
+        SupportedProtocols::from([ProtocolId::ConsensusRpc, ProtocolId::DiscoveryDirectSend]),
+    )]
+    .iter()
+    .cloned()
+    .collect();
+    let h1 = HandshakeMsg {
+        supported_protocols: h1,
+    };
+
+    // Case 1: One intersecting protocol is found for common messaging protocol version.
+    let h2: BTreeMap<_, _> = [(
+        MessagingProtocolVersion::V1,
+        SupportedProtocols::from([ProtocolId::ConsensusRpc, ProtocolId::MempoolDirectSend]),
+    )]
+    .iter()
+    .cloned()
+    .collect();
+    let h2 = HandshakeMsg {
+        supported_protocols: h2,
+    };
+    assert_eq!(
+        Some((MessagingProtocolVersion::V1, vec![ProtocolId::ConsensusRpc])),
+        h1.find_common_protocols(&h2)
+    );
+
+    // Case 2: No intersecting messaging protocol version.
+    let h2 = HandshakeMsg {
+        supported_protocols: BTreeMap::default(),
+    };
+    assert_eq!(None, h1.find_common_protocols(&h2));
+
+    // Case 3: Intersecting messaging protocol version is present, but no intersecting protocols.
+    let h2: BTreeMap<_, _> = [(MessagingProtocolVersion::V1, SupportedProtocols::default())]
+        .iter()
+        .cloned()
+        .collect();
+    let h2 = HandshakeMsg {
+        supported_protocols: h2,
+    };
+    assert_eq!(
+        Some((MessagingProtocolVersion::V1, vec![])),
+        h1.find_common_protocols(&h2)
+    );
+}

--- a/network/src/protocols/wire/messaging/v1/mod.rs
+++ b/network/src/protocols/wire/messaging/v1/mod.rs
@@ -4,9 +4,8 @@
 //! This module defines the structs transported during the network messaging protocol v1.
 //! These should serialize as per [link](TODO: Add ref).
 
-use crate::protocols::wire::handshake::v1::MessagingProtocolVersion;
+use crate::protocols::wire::handshake::v1::{MessagingProtocolVersion, ProtocolId};
 use serde::{Deserialize, Serialize};
-use serde_repr::{Deserialize_repr, Serialize_repr};
 
 #[cfg(test)]
 mod test;
@@ -21,20 +20,6 @@ pub enum NetworkMessage {
     RpcRequest(RpcRequest),
     RpcResponse(RpcResponse),
     DirectSendMsg(DirectSendMsg),
-}
-
-/// Unique identifier associated with each application protocol.
-/// New application protocols can be added without bumping up the MessagingProtocolVersion.
-#[repr(u8)]
-#[derive(Clone, Copy, Debug, Hash, Eq, PartialEq, Deserialize_repr, Serialize_repr)]
-pub enum ProtocolId {
-    ConsensusRpc = 0,
-    ConsensusDirectSend = 1,
-    MempoolDirectSend = 2,
-    StateSynchronizerDirectSend = 3,
-    DiscoveryDirectSend = 4,
-    HealthCheckerRpc = 5,
-    IdentityDirectSend = 6,
 }
 
 /// Enum representing various error codes that can be embedded in NetworkMessage.

--- a/network/src/transport.rs
+++ b/network/src/transport.rs
@@ -3,31 +3,41 @@
 
 use crate::{
     common::NetworkPublicKeys,
-    protocols::identity::{exchange_identity, Identity},
+    protocols::{
+        identity::{exchange_handshake, exchange_peerid},
+        wire::handshake::v1::{HandshakeMsg, MessagingProtocolVersion},
+    },
+    ProtocolId,
 };
 use futures::io::{AsyncRead, AsyncWrite};
 use libra_crypto::{
     x25519::{X25519StaticPrivateKey, X25519StaticPublicKey},
     ValidKey,
 };
+use libra_logger::prelude::*;
 use libra_security_logger::{security_log, SecurityEvent};
 use libra_types::PeerId;
-use netcore::transport::{boxed, memory, tcp, TransportExt};
+use netcore::transport::{boxed, memory, tcp, ConnectionOrigin, TransportExt};
 use noise::NoiseConfig;
+use once_cell::sync::Lazy;
+use parity_multiaddr::Multiaddr;
 use std::{
     collections::HashMap,
     convert::TryFrom,
     fmt::Debug,
     io,
-    sync::{Arc, RwLock},
+    sync::{Arc, Mutex, RwLock},
     time::Duration,
 };
 
-pub trait TSocket: AsyncRead + AsyncWrite + Send + Debug + Unpin + 'static {}
-impl<T> TSocket for T where T: AsyncRead + AsyncWrite + Send + Debug + Unpin + 'static {}
-
 /// A timeout for the connection to open and complete all of the upgrade steps.
 pub const TRANSPORT_TIMEOUT: Duration = Duration::from_secs(30);
+/// Currently supported messaging protocol version.
+/// TODO: Add ability to support more than one messaging protocol.
+pub const SUPPORTED_MESSAGING_PROTOCOL: MessagingProtocolVersion = MessagingProtocolVersion::V1;
+/// Global connection-id generator.
+static CONNECTION_ID_GENERATOR: Lazy<Arc<Mutex<ConnectionIdGenerator>>> =
+    Lazy::new(|| Arc::new(Mutex::new(ConnectionIdGenerator::new())));
 
 const LIBRA_TCP_TRANSPORT: tcp::TcpTransport = tcp::TcpTransport {
     // Use default options.
@@ -38,6 +48,93 @@ const LIBRA_TCP_TRANSPORT: tcp::TcpTransport = tcp::TcpTransport {
     // Use TCP_NODELAY for libra tcp connections.
     nodelay: Some(true),
 };
+
+pub trait TSocket: AsyncRead + AsyncWrite + Send + Debug + Unpin + 'static {}
+impl<T> TSocket for T where T: AsyncRead + AsyncWrite + Send + Debug + Unpin + 'static {}
+
+/// Unique local identifier for a connection.
+#[derive(Clone, Copy, Debug, Default, Eq, PartialEq, Hash)]
+pub struct ConnectionId(u32);
+
+impl From<u32> for ConnectionId {
+    fn from(i: u32) -> ConnectionId {
+        ConnectionId(i)
+    }
+}
+
+/// Generator of unique ConnectionIds.
+struct ConnectionIdGenerator {
+    next: ConnectionId,
+}
+
+impl ConnectionIdGenerator {
+    fn new() -> ConnectionIdGenerator {
+        Self {
+            next: ConnectionId(0),
+        }
+    }
+
+    fn next(&mut self) -> ConnectionId {
+        let ret = self.next;
+        self.next = ConnectionId(ret.0.wrapping_add(1));
+        ret
+    }
+}
+
+/// Metadata associated with an established connection.
+#[derive(Clone, Debug)]
+pub struct ConnectionMetadata {
+    peer_id: PeerId,
+    connection_id: ConnectionId,
+    addr: Multiaddr,
+    origin: ConnectionOrigin,
+    messaging_protocol: MessagingProtocolVersion,
+    application_protocols: Vec<ProtocolId>,
+}
+
+impl ConnectionMetadata {
+    pub fn new(
+        peer_id: PeerId,
+        connection_id: ConnectionId,
+        addr: Multiaddr,
+        origin: ConnectionOrigin,
+        messaging_protocol: MessagingProtocolVersion,
+        application_protocols: Vec<ProtocolId>,
+    ) -> ConnectionMetadata {
+        ConnectionMetadata {
+            peer_id,
+            connection_id,
+            addr,
+            origin,
+            messaging_protocol,
+            application_protocols,
+        }
+    }
+
+    pub fn peer_id(&self) -> PeerId {
+        self.peer_id
+    }
+
+    pub fn connection_id(&self) -> ConnectionId {
+        self.connection_id
+    }
+
+    pub fn addr(&self) -> &Multiaddr {
+        &self.addr
+    }
+
+    pub fn origin(&self) -> ConnectionOrigin {
+        self.origin
+    }
+}
+
+/// The `Connection` struct consists of connection metadata and the actual socket for
+/// communication.
+#[derive(Debug)]
+pub struct Connection<TSocket> {
+    pub socket: TSocket,
+    pub metadata: ConnectionMetadata,
+}
 
 fn identity_key_to_peer_id(
     trusted_peers: &RwLock<HashMap<PeerId, NetworkPublicKeys>>,
@@ -52,37 +149,50 @@ fn identity_key_to_peer_id(
     None
 }
 
-// Ensures that peer id in received identity is same as peer id derived from noise handshake.
-fn match_peer_id(identity: Identity, peer_id: PeerId) -> Result<Identity, io::Error> {
-    if identity.peer_id() != peer_id {
-        security_log(SecurityEvent::InvalidNetworkPeer)
-            .error("InvalidIdentity")
-            .data(&identity)
-            .data(&peer_id)
-            .log();
-        Err(io::Error::new(
+pub async fn perform_handshake<T: TSocket>(
+    peer_id: PeerId,
+    mut socket: T,
+    addr: Multiaddr,
+    origin: ConnectionOrigin,
+    own_handshake: &HandshakeMsg,
+) -> Result<Connection<T>, io::Error> {
+    let handshake_other = exchange_handshake(&own_handshake, &mut socket).await?;
+    let intersecting_protocols = own_handshake.find_common_protocols(&handshake_other);
+    match intersecting_protocols {
+        None => {
+            info!("No matching protocols found for connection with peer: {:?}. Handshake received: {:?}",
+            peer_id.short_str(), handshake_other);
+            Err(io::Error::new(
                 io::ErrorKind::Other,
-                format!(
-                    "PeerId received from Noise Handshake ({}) doesn't match one received from Identity Exchange ({})",
-                    peer_id.short_str(),
-                    identity.peer_id().short_str()
-                )
-        ))
-    } else {
-        Ok(identity)
+                "no matching messaging protocol",
+            ))
+        }
+        Some((messaging_protocol, application_protocols)) => Ok(Connection {
+            socket,
+            metadata: ConnectionMetadata::new(
+                peer_id,
+                CONNECTION_ID_GENERATOR.lock().unwrap().next(),
+                addr,
+                origin,
+                messaging_protocol,
+                application_protocols,
+            ),
+        }),
     }
 }
 
 pub fn build_memory_noise_transport(
-    own_identity: Identity,
     identity_keypair: (X25519StaticPrivateKey, X25519StaticPublicKey),
     trusted_peers: Arc<RwLock<HashMap<PeerId, NetworkPublicKeys>>>,
-) -> boxed::BoxedTransport<(Identity, impl TSocket), impl ::std::error::Error> {
+    application_protocols: Vec<ProtocolId>,
+) -> boxed::BoxedTransport<Connection<impl TSocket>, impl ::std::error::Error> {
     let memory_transport = memory::MemoryTransport::default();
     let noise_config = Arc::new(NoiseConfig::new(identity_keypair));
+    let mut own_handshake = HandshakeMsg::new();
+    own_handshake.add(SUPPORTED_MESSAGING_PROTOCOL, application_protocols);
 
     memory_transport
-        .and_then(move |socket, origin| async move {
+        .and_then(move |socket, _addr, origin| async move {
             let (remote_static_key, socket) =
                 noise_config.upgrade_connection(socket, origin).await?;
             if let Some(peer_id) = identity_key_to_peer_id(&trusted_peers, &remote_static_key) {
@@ -91,22 +201,24 @@ pub fn build_memory_noise_transport(
                 Err(io::Error::new(io::ErrorKind::Other, "Not a trusted peer"))
             }
         })
-        .and_then(move |(peer_id, mut socket), _origin| async move {
-            let identity = exchange_identity(&own_identity, &mut socket).await?;
-            match_peer_id(identity, peer_id).and_then(|identity| Ok((identity, socket)))
+        .and_then(move |(peer_id, socket), addr, origin| async move {
+            perform_handshake(peer_id, socket, addr, origin, &own_handshake).await
         })
         .with_timeout(TRANSPORT_TIMEOUT)
         .boxed()
 }
 
 pub fn build_unauthenticated_memory_noise_transport(
-    own_identity: Identity,
     identity_keypair: (X25519StaticPrivateKey, X25519StaticPublicKey),
-) -> boxed::BoxedTransport<(Identity, impl TSocket), impl ::std::error::Error> {
+    application_protocols: Vec<ProtocolId>,
+) -> boxed::BoxedTransport<Connection<impl TSocket>, impl ::std::error::Error> {
     let memory_transport = memory::MemoryTransport::default();
     let noise_config = Arc::new(NoiseConfig::new(identity_keypair));
+    let mut own_handshake = HandshakeMsg::new();
+    own_handshake.add(SUPPORTED_MESSAGING_PROTOCOL, application_protocols);
+
     memory_transport
-        .and_then(move |socket, origin| {
+        .and_then(move |socket, _addr, origin| {
             async move {
                 let (remote_static_key, socket) =
                     noise_config.upgrade_connection(socket, origin).await?;
@@ -121,21 +233,27 @@ pub fn build_unauthenticated_memory_noise_transport(
                 Ok((peer_id, socket))
             }
         })
-        .and_then(move |(peer_id, mut socket), _origin| async move {
-            let identity = exchange_identity(&own_identity, &mut socket).await?;
-            match_peer_id(identity, peer_id).and_then(|identity| Ok((identity, socket)))
+        .and_then(move |(peer_id, socket), addr, origin| async move {
+            perform_handshake(peer_id, socket, addr, origin, &own_handshake).await
         })
         .with_timeout(TRANSPORT_TIMEOUT)
         .boxed()
 }
 
 pub fn build_memory_transport(
-    own_identity: Identity,
-) -> boxed::BoxedTransport<(Identity, impl TSocket), impl ::std::error::Error> {
+    own_peer_id: PeerId,
+    application_protocols: Vec<ProtocolId>,
+) -> boxed::BoxedTransport<Connection<impl TSocket>, impl ::std::error::Error> {
     let memory_transport = memory::MemoryTransport::default();
+    let mut own_handshake = HandshakeMsg::new();
+    own_handshake.add(SUPPORTED_MESSAGING_PROTOCOL, application_protocols);
+
     memory_transport
-        .and_then(move |mut socket, _origin| async move {
-            Ok((exchange_identity(&own_identity, &mut socket).await?, socket))
+        .and_then(move |mut socket, _addr, _origin| async move {
+            Ok((exchange_peerid(&own_peer_id, &mut socket).await?, socket))
+        })
+        .and_then(move |(peer_id, socket), addr, origin| async move {
+            perform_handshake(peer_id, socket, addr, origin, &own_handshake).await
         })
         .with_timeout(TRANSPORT_TIMEOUT)
         .boxed()
@@ -143,14 +261,16 @@ pub fn build_memory_transport(
 
 //TODO(bmwill) Maybe create an Either Transport so we can merge the building of Memory + Tcp
 pub fn build_tcp_noise_transport(
-    own_identity: Identity,
     identity_keypair: (X25519StaticPrivateKey, X25519StaticPublicKey),
     trusted_peers: Arc<RwLock<HashMap<PeerId, NetworkPublicKeys>>>,
-) -> boxed::BoxedTransport<(Identity, impl TSocket), impl ::std::error::Error> {
+    application_protocols: Vec<ProtocolId>,
+) -> boxed::BoxedTransport<Connection<impl TSocket>, impl ::std::error::Error> {
     let noise_config = Arc::new(NoiseConfig::new(identity_keypair));
+    let mut own_handshake = HandshakeMsg::new();
+    own_handshake.add(SUPPORTED_MESSAGING_PROTOCOL, application_protocols);
 
     LIBRA_TCP_TRANSPORT
-        .and_then(move |socket, origin| async move {
+        .and_then(move |socket, _addr, origin| async move {
             let (remote_static_key, socket) =
                 noise_config.upgrade_connection(socket, origin).await?;
             if let Some(peer_id) = identity_key_to_peer_id(&trusted_peers, &remote_static_key) {
@@ -164,9 +284,8 @@ pub fn build_tcp_noise_transport(
                 Err(io::Error::new(io::ErrorKind::Other, "Not a trusted peer"))
             }
         })
-        .and_then(move |(peer_id, mut socket), _origin| async move {
-            let identity = exchange_identity(&own_identity, &mut socket).await?;
-            match_peer_id(identity, peer_id).and_then(|identity| Ok((identity, socket)))
+        .and_then(move |(peer_id, socket), addr, origin| async move {
+            perform_handshake(peer_id, socket, addr, origin, &own_handshake).await
         })
         .with_timeout(TRANSPORT_TIMEOUT)
         .boxed()
@@ -175,12 +294,15 @@ pub fn build_tcp_noise_transport(
 // Transport based on TCP + Noise, but without remote authentication (i.e., any
 // node is allowed to connect).
 pub fn build_unauthenticated_tcp_noise_transport(
-    own_identity: Identity,
     identity_keypair: (X25519StaticPrivateKey, X25519StaticPublicKey),
-) -> boxed::BoxedTransport<(Identity, impl TSocket), impl ::std::error::Error> {
+    application_protocols: Vec<ProtocolId>,
+) -> boxed::BoxedTransport<Connection<impl TSocket>, impl ::std::error::Error> {
     let noise_config = Arc::new(NoiseConfig::new(identity_keypair));
+    let mut own_handshake = HandshakeMsg::new();
+    own_handshake.add(SUPPORTED_MESSAGING_PROTOCOL, application_protocols);
+
     LIBRA_TCP_TRANSPORT
-        .and_then(move |socket, origin| {
+        .and_then(move |socket, _addr, origin| {
             async move {
                 let (remote_static_key, socket) =
                     noise_config.upgrade_connection(socket, origin).await?;
@@ -195,20 +317,26 @@ pub fn build_unauthenticated_tcp_noise_transport(
                 Ok((peer_id, socket))
             }
         })
-        .and_then(move |(peer_id, mut socket), _origin| async move {
-            let identity = exchange_identity(&own_identity, &mut socket).await?;
-            match_peer_id(identity, peer_id).and_then(|identity| Ok((identity, socket)))
+        .and_then(move |(peer_id, socket), addr, origin| async move {
+            perform_handshake(peer_id, socket, addr, origin, &own_handshake).await
         })
         .with_timeout(TRANSPORT_TIMEOUT)
         .boxed()
 }
 
 pub fn build_tcp_transport(
-    own_identity: Identity,
-) -> boxed::BoxedTransport<(Identity, impl TSocket), impl ::std::error::Error> {
+    own_peer_id: PeerId,
+    application_protocols: Vec<ProtocolId>,
+) -> boxed::BoxedTransport<Connection<impl TSocket>, impl ::std::error::Error> {
+    let mut own_handshake = HandshakeMsg::new();
+    own_handshake.add(SUPPORTED_MESSAGING_PROTOCOL, application_protocols);
+
     LIBRA_TCP_TRANSPORT
-        .and_then(move |mut socket, _origin| async move {
-            Ok((exchange_identity(&own_identity, &mut socket).await?, socket))
+        .and_then(move |mut socket, _addr, _origin| async move {
+            Ok((exchange_peerid(&own_peer_id, &mut socket).await?, socket))
+        })
+        .and_then(move |(peer_id, socket), addr, origin| async move {
+            perform_handshake(peer_id, socket, addr, origin, &own_handshake).await
         })
         .with_timeout(TRANSPORT_TIMEOUT)
         .boxed()

--- a/network/src/transport.rs
+++ b/network/src/transport.rs
@@ -5,9 +5,8 @@ use crate::{
     common::NetworkPublicKeys,
     protocols::{
         identity::{exchange_handshake, exchange_peerid},
-        wire::handshake::v1::{HandshakeMsg, MessagingProtocolVersion},
+        wire::handshake::v1::{HandshakeMsg, MessagingProtocolVersion, SupportedProtocols},
     },
-    ProtocolId,
 };
 use futures::io::{AsyncRead, AsyncWrite};
 use libra_crypto::{
@@ -89,7 +88,7 @@ pub struct ConnectionMetadata {
     addr: Multiaddr,
     origin: ConnectionOrigin,
     messaging_protocol: MessagingProtocolVersion,
-    application_protocols: Vec<ProtocolId>,
+    application_protocols: SupportedProtocols,
 }
 
 impl ConnectionMetadata {
@@ -99,7 +98,7 @@ impl ConnectionMetadata {
         addr: Multiaddr,
         origin: ConnectionOrigin,
         messaging_protocol: MessagingProtocolVersion,
-        application_protocols: Vec<ProtocolId>,
+        application_protocols: SupportedProtocols,
     ) -> ConnectionMetadata {
         ConnectionMetadata {
             peer_id,
@@ -184,7 +183,7 @@ pub async fn perform_handshake<T: TSocket>(
 pub fn build_memory_noise_transport(
     identity_keypair: (X25519StaticPrivateKey, X25519StaticPublicKey),
     trusted_peers: Arc<RwLock<HashMap<PeerId, NetworkPublicKeys>>>,
-    application_protocols: Vec<ProtocolId>,
+    application_protocols: SupportedProtocols,
 ) -> boxed::BoxedTransport<Connection<impl TSocket>, impl ::std::error::Error> {
     let memory_transport = memory::MemoryTransport::default();
     let noise_config = Arc::new(NoiseConfig::new(identity_keypair));
@@ -210,7 +209,7 @@ pub fn build_memory_noise_transport(
 
 pub fn build_unauthenticated_memory_noise_transport(
     identity_keypair: (X25519StaticPrivateKey, X25519StaticPublicKey),
-    application_protocols: Vec<ProtocolId>,
+    application_protocols: SupportedProtocols,
 ) -> boxed::BoxedTransport<Connection<impl TSocket>, impl ::std::error::Error> {
     let memory_transport = memory::MemoryTransport::default();
     let noise_config = Arc::new(NoiseConfig::new(identity_keypair));
@@ -242,7 +241,7 @@ pub fn build_unauthenticated_memory_noise_transport(
 
 pub fn build_memory_transport(
     own_peer_id: PeerId,
-    application_protocols: Vec<ProtocolId>,
+    application_protocols: SupportedProtocols,
 ) -> boxed::BoxedTransport<Connection<impl TSocket>, impl ::std::error::Error> {
     let memory_transport = memory::MemoryTransport::default();
     let mut own_handshake = HandshakeMsg::new();
@@ -263,7 +262,7 @@ pub fn build_memory_transport(
 pub fn build_tcp_noise_transport(
     identity_keypair: (X25519StaticPrivateKey, X25519StaticPublicKey),
     trusted_peers: Arc<RwLock<HashMap<PeerId, NetworkPublicKeys>>>,
-    application_protocols: Vec<ProtocolId>,
+    application_protocols: SupportedProtocols,
 ) -> boxed::BoxedTransport<Connection<impl TSocket>, impl ::std::error::Error> {
     let noise_config = Arc::new(NoiseConfig::new(identity_keypair));
     let mut own_handshake = HandshakeMsg::new();
@@ -295,7 +294,7 @@ pub fn build_tcp_noise_transport(
 // node is allowed to connect).
 pub fn build_unauthenticated_tcp_noise_transport(
     identity_keypair: (X25519StaticPrivateKey, X25519StaticPublicKey),
-    application_protocols: Vec<ProtocolId>,
+    application_protocols: SupportedProtocols,
 ) -> boxed::BoxedTransport<Connection<impl TSocket>, impl ::std::error::Error> {
     let noise_config = Arc::new(NoiseConfig::new(identity_keypair));
     let mut own_handshake = HandshakeMsg::new();
@@ -326,7 +325,7 @@ pub fn build_unauthenticated_tcp_noise_transport(
 
 pub fn build_tcp_transport(
     own_peer_id: PeerId,
-    application_protocols: Vec<ProtocolId>,
+    application_protocols: SupportedProtocols,
 ) -> boxed::BoxedTransport<Connection<impl TSocket>, impl ::std::error::Error> {
     let mut own_handshake = HandshakeMsg::new();
     own_handshake.add(SUPPORTED_MESSAGING_PROTOCOL, application_protocols);

--- a/network/src/validator_network/network_builder.rs
+++ b/network/src/validator_network/network_builder.rs
@@ -20,6 +20,7 @@ use crate::{
     protocols::{
         discovery::{self, Discovery},
         health_checker::{self, HealthChecker},
+        wire::handshake::v1::SupportedProtocols,
     },
     transport,
     transport::*,
@@ -297,12 +298,11 @@ impl NetworkBuilder {
         self.conn_mgr_reqs_tx.clone()
     }
 
-    fn supported_protocols(&self) -> Vec<ProtocolId> {
+    fn supported_protocols(&self) -> SupportedProtocols {
         self.direct_send_protocols
             .iter()
             .chain(&self.rpc_protocols)
-            .cloned()
-            .collect()
+            .into()
     }
 
     /// Add a handler for given protocols using raw bytes.

--- a/network/src/validator_network/network_builder.rs
+++ b/network/src/validator_network/network_builder.rs
@@ -20,7 +20,6 @@ use crate::{
     protocols::{
         discovery::{self, Discovery},
         health_checker::{self, HealthChecker},
-        identity::Identity,
     },
     transport,
     transport::*,
@@ -438,33 +437,46 @@ impl NetworkBuilder {
     /// Create the configured transport and start PeerManager.
     /// Return the actual Multiaddr over which this peer is listening.
     pub fn build(mut self) -> Multiaddr {
-        let identity = Identity::new(self.peer_id, self.supported_protocols());
+        let peer_id = self.peer_id;
+        let supported_protocols = self.supported_protocols();
         // Build network based on the transport type
         let trusted_peers = self.trusted_peers.clone();
         match self.transport {
-            TransportType::Memory => self.build_with_transport(build_memory_transport(identity)),
+            TransportType::Memory => {
+                self.build_with_transport(build_memory_transport(peer_id, supported_protocols))
+            }
             TransportType::MemoryNoise(ref mut keys) => {
                 let keys = keys.take().expect("Identity keys not set");
                 self.build_with_transport(build_memory_noise_transport(
-                    identity,
                     keys,
                     trusted_peers,
+                    supported_protocols,
                 ))
             }
             TransportType::PermissionlessMemoryNoise(ref mut keys) => {
                 let keys = keys.take().expect("Identity keys not set");
                 self.build_with_transport(build_unauthenticated_memory_noise_transport(
-                    identity, keys,
+                    keys,
+                    supported_protocols,
                 ))
             }
-            TransportType::Tcp => self.build_with_transport(build_tcp_transport(identity)),
+            TransportType::Tcp => {
+                self.build_with_transport(build_tcp_transport(peer_id, supported_protocols))
+            }
             TransportType::TcpNoise(ref mut keys) => {
                 let keys = keys.take().expect("Identity keys not set");
-                self.build_with_transport(build_tcp_noise_transport(identity, keys, trusted_peers))
+                self.build_with_transport(build_tcp_noise_transport(
+                    keys,
+                    trusted_peers,
+                    supported_protocols,
+                ))
             }
             TransportType::PermissionlessTcpNoise(ref mut keys) => {
                 let keys = keys.take().expect("Identity keys not set");
-                self.build_with_transport(build_unauthenticated_tcp_noise_transport(identity, keys))
+                self.build_with_transport(build_unauthenticated_tcp_noise_transport(
+                    keys,
+                    supported_protocols,
+                ))
             }
         }
     }
@@ -473,7 +485,7 @@ impl NetworkBuilder {
     /// Return the actual Multiaddr over which this peer is listening.
     fn build_with_transport<TTransport, TSocket>(self, transport: TTransport) -> Multiaddr
     where
-        TTransport: Transport<Output = (Identity, TSocket)> + Send + 'static,
+        TTransport: Transport<Output = Connection<TSocket>> + Send + 'static,
         TSocket: transport::TSocket,
     {
         let peer_mgr = PeerManager::new(


### PR DESCRIPTION
### Motivation
This PR completes our migration to new wire spec (#2878) by replacing the earlier identity exchange protocol with the handshake protocol which is really important for our upgradability story. 

### Details
This commit splits the old identity exchange protocol into 2. For transport using Noise, the Noise exchange is followed by a handshake    message exchange to exchange `wire::handshake::HandshakeMsg`. For    transports not using Noise, we execute a simple PeerId exchange before    doing the HandshakeMsg exchange.
 
### Implementation notes:
  - Pass address in transport AndThen futures
  - We move Connection, ConnectionMetadata and ConnectionId structs from peer_manager to transport sub-modules
  - PeerManager receives a transport whose output is Connection<TSocket>   instead of (Identity, TSocket)
  - All transports execute handshake exchange after noise handshake /peer_id exchange.
  - Identity struct is removed.

#### Cleanup:
  - exchange_handshake and exchange_peerid are still in `identity.rs`. We might want to move them to a better location as part of      https://github.com/libra/libra/issues/3343