### PR TITLE
[subscription-service] generalize ReconfigSubscription to generic subscription service crate in common

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2479,6 +2479,7 @@ dependencies = [
  "storage-client 0.1.0",
  "storage-service 0.1.0",
  "structopt 0.3.13 (registry+https://github.com/rust-lang/crates.io-index)",
+ "subscription-service 0.1.0",
  "tokio 0.2.13 (registry+https://github.com/rust-lang/crates.io-index)",
  "tonic 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -2616,7 +2617,6 @@ version = "0.1.0"
 dependencies = [
  "anyhow 1.0.28 (registry+https://github.com/rust-lang/crates.io-index)",
  "bytes 0.5.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "channel 0.1.0",
  "chrono 0.4.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "hex 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "itertools 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -4883,6 +4883,7 @@ dependencies = [
  "serde 1.0.106 (registry+https://github.com/rust-lang/crates.io-index)",
  "stdlib 0.1.0",
  "storage-client 0.1.0",
+ "subscription-service 0.1.0",
  "tokio 0.2.13 (registry+https://github.com/rust-lang/crates.io-index)",
  "transaction-builder 0.1.0",
  "vm-genesis 0.1.0",
@@ -5054,6 +5055,15 @@ dependencies = [
  "proc-macro2 1.0.10 (registry+https://github.com/rust-lang/crates.io-index)",
  "quote 1.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "syn 1.0.17 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "subscription-service"
+version = "0.1.0"
+dependencies = [
+ "anyhow 1.0.28 (registry+https://github.com/rust-lang/crates.io-index)",
+ "channel 0.1.0",
+ "libra-types 0.1.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,6 +23,7 @@ members = [
     "common/security-logger",
     "common/serde-reflection",
     "common/stream-ratelimiter",
+    "common/subscription-service",
     "common/temppath",
     "common/util",
     "common/workspace-builder",

--- a/common/subscription-service/Cargo.toml
+++ b/common/subscription-service/Cargo.toml
@@ -1,0 +1,16 @@
+[package]
+name = "subscription-service"
+version = "0.1.0"
+authors = ["Libra Association <opensource@libra.org>"]
+description = "Libra subscription service"
+repository = "https://github.com/libra/libra"
+homepage = "https://libra.org"
+license = "Apache-2.0"
+publish = false
+edition = "2018"
+
+[dependencies]
+anyhow = "1.0"
+
+libra-types = { path = "../../types", version = "0.1.0" }
+channel = { path = "..//channel", version = "0.1.0" }

--- a/libra-node/Cargo.toml
+++ b/libra-node/Cargo.toml
@@ -34,6 +34,7 @@ libra-json-rpc = { path = "../json-rpc", version = "0.1.0" }
 state-synchronizer = { path = "../state-synchronizer", version = "0.1.0" }
 storage-client = { path = "../storage/storage-client", version = "0.1.0" }
 storage-service = { path = "../storage/storage-service", version = "0.1.0" }
+subscription-service = { path = "../common/subscription-service", version = "0.1.0" }
 libra-types = { path = "../types", version = "0.1.0" }
 libra-vm = { path = "../language/libra-vm", version = "0.1.0" }
 

--- a/libra-node/src/main_node.rs
+++ b/libra-node/src/main_node.rs
@@ -14,7 +14,6 @@ use libra_json_rpc::bootstrap_from_config as bootstrap_rpc;
 use libra_logger::prelude::*;
 use libra_mempool::MEMPOOL_SUBSCRIBED_CONFIGS;
 use libra_metrics::metric_server;
-use libra_types::event_subscription::ReconfigSubscription;
 use libra_vm::LibraVM;
 use network::validator_network::network_builder::{NetworkBuilder, TransportType};
 use state_synchronizer::StateSynchronizer;
@@ -27,6 +26,7 @@ use std::{
 };
 use storage_client::SyncStorageClient;
 use storage_service::{init_libra_db, start_storage_service_with_db};
+use subscription_service::ReconfigSubscription;
 use tokio::runtime::{Builder, Runtime};
 
 const AC_SMP_CHANNEL_BUFFER_SIZE: usize = 1_024;

--- a/state-synchronizer/Cargo.toml
+++ b/state-synchronizer/Cargo.toml
@@ -32,6 +32,7 @@ libra-metrics = { path = "../common/metrics", version = "0.1.0" }
 libra-types = { path = "../types", version = "0.1.0" }
 network = { path = "../network", version = "0.1.0" }
 storage-client = { path = "../storage/storage-client", version = "0.1.0" }
+subscription-service = { path = "../common/subscription-service", version = "0.1.0" }
 libra-vm = { path = "../language/libra-vm", version = "0.1.0" }
 
 [dev-dependencies]

--- a/state-synchronizer/src/executor_proxy.rs
+++ b/state-synchronizer/src/executor_proxy.rs
@@ -9,7 +9,6 @@ use itertools::Itertools;
 use libra_config::config::NodeConfig;
 use libra_types::{
     contract_event::ContractEvent,
-    event_subscription::ReconfigSubscription,
     ledger_info::LedgerInfoWithSignatures,
     on_chain_config::{ConfigID, OnChainConfigPayload, ON_CHAIN_CONFIG_REGISTRY},
     transaction::TransactionListWithProof,
@@ -21,6 +20,7 @@ use std::{
     sync::{Arc, Mutex},
 };
 use storage_client::{StorageRead, StorageReadServiceClient};
+use subscription_service::ReconfigSubscription;
 
 /// Proxies interactions with execution and storage for state synchronization
 #[async_trait::async_trait]

--- a/state-synchronizer/src/synchronizer.rs
+++ b/state-synchronizer/src/synchronizer.rs
@@ -16,8 +16,7 @@ use futures::{
 use libra_config::config::{NodeConfig, RoleType, StateSyncConfig};
 use libra_mempool::{CommitNotification, CommitResponse};
 use libra_types::{
-    contract_event::ContractEvent, event_subscription::ReconfigSubscription,
-    ledger_info::LedgerInfoWithSignatures, transaction::Transaction,
+    contract_event::ContractEvent, ledger_info::LedgerInfoWithSignatures, transaction::Transaction,
     validator_change::ValidatorChangeProof, waypoint::Waypoint,
 };
 use libra_vm::LibraVM;
@@ -25,6 +24,7 @@ use std::{
     sync::{Arc, Mutex},
     time::Duration,
 };
+use subscription_service::ReconfigSubscription;
 use tokio::{
     runtime::{Builder, Runtime},
     time::timeout,

--- a/state-synchronizer/src/tests/on_chain_config_tests.rs
+++ b/state-synchronizer/src/tests/on_chain_config_tests.rs
@@ -16,12 +16,12 @@ use libra_crypto::{
 };
 use libra_types::{
     account_config::{association_address, lbr_type_tag},
-    event_subscription::ReconfigSubscription,
     on_chain_config::{OnChainConfig, VMPublishingOption},
     transaction::authenticator::AuthenticationKey,
 };
 use std::sync::{Arc, Mutex};
 use stdlib::transaction_scripts::StdlibScript;
+use subscription_service::ReconfigSubscription;
 use transaction_builder::{
     encode_block_prologue_script, encode_publishing_option_script,
     encode_rotate_consensus_pubkey_script, encode_transfer_script,

--- a/types/Cargo.toml
+++ b/types/Cargo.toml
@@ -27,7 +27,6 @@ serde = { version = "1.0.106", default-features = false }
 thiserror = "1.0"
 tiny-keccak = { version = "2.0.2", default-features = false, features = ["sha3"] }
 
-channel = { path = "../common/channel", version = "0.1.0" }
 lcs = { path = "../common/lcs", version = "0.1.0", package = "libra-canonical-serialization" }
 libra-crypto = { path = "../crypto/crypto", version = "0.1.0" }
 libra-crypto-derive = { path = "../crypto/crypto-derive", version = "0.1.0" }

--- a/types/src/lib.rs
+++ b/types/src/lib.rs
@@ -15,7 +15,6 @@ pub mod discovery_info;
 pub mod discovery_set;
 pub mod epoch_info;
 pub mod event;
-pub mod event_subscription;
 pub mod get_with_proof;
 pub mod language_storage;
 pub mod ledger_info;


### PR DESCRIPTION
## Summary
- Move out` ReconfigSubscription` from `types` to `common` to remove dependencies 
- Generalize `ReconfigSubscription` to generic `SubscriptionService` framework. More work should be done developing this framework once we have better specs for concrete use cases