### PR TITLE
[generate format] ensure 100% coverage of Libra transactions

### DIFF
--- a/common/serde-reflection/src/error.rs
+++ b/common/serde-reflection/src/error.rs
@@ -17,6 +17,8 @@ pub enum Error {
     NotSupported(&'static str),
     #[error("Failed to deserialize {0}")]
     DeserializationError(&'static str),
+    #[error("In container {0}, recorded value for serialization format {1:?} failed to deserialize into {2}")]
+    UnexpectedDeserializationFormat(&'static str, crate::ContainerFormat, &'static str),
     #[error("Incompatible formats detected: {0} {1}")]
     Incompatible(String, String),
     #[error("Incomplete tracing detected")]

--- a/common/serde-reflection/src/trace.rs
+++ b/common/serde-reflection/src/trace.rs
@@ -194,7 +194,19 @@ impl Tracer {
         self.record_container(name, format, value)
     }
 
-    pub(crate) fn get_value(&mut self, name: &'static str) -> Option<&Value> {
-        self.values.get(name)
+    pub(crate) fn get_recorded_value(
+        &mut self,
+        name: &'static str,
+    ) -> Option<(&ContainerFormat, &Value)> {
+        match self.values.get(name) {
+            Some(value) => {
+                let format = self
+                    .registry
+                    .get(name)
+                    .expect("recorded containers should have a format already");
+                Some((format, value))
+            }
+            None => None,
+        }
     }
 }

--- a/common/serde-reflection/src/value.rs
+++ b/common/serde-reflection/src/value.rs
@@ -304,7 +304,7 @@ where
     {
         match self.values.next() {
             Some(x) => seed.deserialize(x.into_deserializer()),
-            None => Err(Error::DeserializationError("map (invalid sequence)")),
+            None => Err(Error::DeserializationError("value in map")),
         }
     }
 

--- a/crypto/crypto-derive/src/lib.rs
+++ b/crypto/crypto-derive/src/lib.rs
@@ -162,10 +162,10 @@ pub fn deserialize_key(source: TokenStream) -> TokenStream {
                     // as the original type.
                     #[derive(::serde::Deserialize)]
                     #[serde(rename = #name_string)]
-                    struct Value<'a>(&'a[u8]);
+                    struct Value(Vec<u8>);
 
                     let value = Value::deserialize(deserializer)?;
-                    #name::try_from(value.0).map_err(|s| {
+                    #name::try_from(value.0.as_slice()).map_err(|s| {
                         <D::Error as ::serde::de::Error>::custom(format!("{} with {}", s, #name_string))
                     })
                 }
@@ -193,7 +193,7 @@ pub fn serialize_key(source: TokenStream) -> TokenStream {
                         .and_then(|str| serializer.serialize_str(&str[..]))
                 } else {
                     // See comment in deserialize_key.
-                    serializer.serialize_newtype_struct(#name_string, &ValidKey::to_bytes(self))
+                    serializer.serialize_newtype_struct(#name_string, &ValidKey::to_bytes(self).as_slice())
                 }
             }
         }

--- a/crypto/crypto/src/hash.rs
+++ b/crypto/crypto/src/hash.rs
@@ -292,10 +292,10 @@ impl<'de> de::Deserialize<'de> for HashValue {
             // See comment in serialize.
             #[derive(::serde::Deserialize)]
             #[serde(rename = "HashValue")]
-            struct Value<'a>(&'a [u8]);
+            struct Value(Vec<u8>);
 
             let value = Value::deserialize(deserializer)?;
-            Self::from_slice(value.0).map_err(<D::Error as ::serde::de::Error>::custom)
+            Self::from_slice(value.0.as_slice()).map_err(<D::Error as ::serde::de::Error>::custom)
         }
     }
 }

--- a/crypto/crypto/src/multi_ed25519.rs
+++ b/crypto/crypto/src/multi_ed25519.rs
@@ -229,10 +229,10 @@ impl Genesis for MultiEd25519PrivateKey {
 //////////////////////
 
 /// Convenient method to create a MultiEd25519PublicKey from a single Ed25519PublicKey.
-impl From<&Ed25519PublicKey> for MultiEd25519PublicKey {
-    fn from(ed_public_key: &Ed25519PublicKey) -> Self {
+impl From<Ed25519PublicKey> for MultiEd25519PublicKey {
+    fn from(ed_public_key: Ed25519PublicKey) -> Self {
         MultiEd25519PublicKey {
-            public_keys: vec![ed_public_key.clone()],
+            public_keys: vec![ed_public_key],
             threshold: 1u8,
         }
     }
@@ -495,10 +495,10 @@ impl Signature for MultiEd25519Signature {
     }
 }
 
-impl From<&Ed25519Signature> for MultiEd25519Signature {
-    fn from(ed_signature: &Ed25519Signature) -> Self {
+impl From<Ed25519Signature> for MultiEd25519Signature {
+    fn from(ed_signature: Ed25519Signature) -> Self {
         MultiEd25519Signature {
-            signatures: vec![ed_signature.clone()],
+            signatures: vec![ed_signature],
             // "1000_0000 0000_0000 0000_0000 0000_0000"
             bitmap: [0b1000_0000u8, 0u8, 0u8, 0u8],
         }

--- a/crypto/crypto/src/unit_tests/multi_ed25519_test.rs
+++ b/crypto/crypto/src/unit_tests/multi_ed25519_test.rs
@@ -143,7 +143,7 @@ fn test_multi_ed25519_public_key_serialization() {
 
     // Check that MultiEd25519PublicKey::from Ed25519PublicKey works as expected.
     let multi_public_key_from_ed25519 = MultiEd25519PublicKey::from(
-        &multi_public_key_7of10_from_multi_private_key.public_keys()[0],
+        multi_public_key_7of10_from_multi_private_key.public_keys()[0].clone(),
     );
     assert_eq!(multi_public_key_from_ed25519.public_keys().len(), 1);
     assert_eq!(
@@ -191,7 +191,7 @@ fn test_multi_ed25519_signature_serialization() {
 
     // Construct from single Ed25519Signature.
     let single_signature = priv_keys_3[0].sign_message(&MESSAGE_HASH);
-    let multi_signature = MultiEd25519Signature::from(&single_signature);
+    let multi_signature = MultiEd25519Signature::from(single_signature.clone());
     assert_eq!(1, multi_signature.signatures().len());
     assert_eq!(multi_signature.signatures()[0], single_signature);
     assert_eq!(multi_signature.bitmap(), &[0b1000_0000u8, 0u8, 0u8, 0u8]);

--- a/language/e2e-tests/src/tests/rotate_key.rs
+++ b/language/e2e-tests/src/tests/rotate_key.rs
@@ -102,7 +102,7 @@ fn rotate_ed25519_multisig_key() {
 
     // (2) send a tx signed by privkey 1
     let txn1 = raw_rotate_key_txn(*sender_address, new_auth_key.to_vec(), seq_number);
-    let signature1 = MultiEd25519Signature::from(&privkey1.sign_message(&txn1.hash()));
+    let signature1 = MultiEd25519Signature::from(privkey1.sign_message(&txn1.hash()));
     let signed_txn1 =
         SignedTransaction::new_multisig(txn1, multi_ed_public_key.clone(), signature1);
     let output = &executor.execute_transaction(signed_txn1);

--- a/testsuite/generate-format/src/compute.rs
+++ b/testsuite/generate-format/src/compute.rs
@@ -14,7 +14,7 @@ use structopt::StructOpt;
 )]
 struct Options {
     #[structopt(short, long)]
-    with_deserialize: bool,
+    skip_deserialize: bool,
 
     #[structopt(short, long)]
     record: bool,
@@ -25,7 +25,7 @@ fn main() {
 
     let mut tracer = Tracer::new(lcs::is_human_readable());
     tracer = add_proptest_serialization_tracing(tracer);
-    if options.with_deserialize {
+    if !options.skip_deserialize {
         tracer = add_deserialization_tracing(tracer);
     }
 

--- a/testsuite/generate-format/tests/detect_format_change.rs
+++ b/testsuite/generate-format/tests/detect_format_change.rs
@@ -1,7 +1,7 @@
 // Copyright (c) The Libra Core Contributors
 // SPDX-License-Identifier: Apache-2.0
 
-use generate_format::{add_proptest_serialization_tracing, FILE_PATH};
+use generate_format::{add_deserialization_tracing, add_proptest_serialization_tracing, FILE_PATH};
 use serde_reflection::{RegistryOwned, Tracer};
 use serde_yaml;
 use std::collections::BTreeMap;
@@ -14,6 +14,7 @@ Please verify the changes to the recorded file(s) and tag your pull-request as `
 fn test_recorded_formats_did_not_change() {
     let mut tracer = Tracer::new(lcs::is_human_readable());
     tracer = add_proptest_serialization_tracing(tracer);
+    tracer = add_deserialization_tracing(tracer);
     let registry: BTreeMap<_, _> = tracer
         .registry()
         .unwrap()

--- a/testsuite/generate-format/tests/staged/libra.yaml
+++ b/testsuite/generate-format/tests/staged/libra.yaml
@@ -61,6 +61,12 @@ Module:
   STRUCT:
     - code:
         SEQ: U8
+MultiEd25519PublicKey:
+  NEWTYPESTRUCT:
+    SEQ: U8
+MultiEd25519Signature:
+  NEWTYPESTRUCT:
+    SEQ: U8
 RawTransaction:
   STRUCT:
     - sender:
@@ -138,6 +144,13 @@ TransactionAuthenticator:
               TYPENAME: Ed25519PublicKey
           - signature:
               TYPENAME: Ed25519Signature
+    1:
+      MultiEd25519:
+        STRUCT:
+          - public_key:
+              TYPENAME: MultiEd25519PublicKey
+          - signature:
+              TYPENAME: MultiEd25519Signature
 TransactionPayload:
   ENUM:
     0:

--- a/types/src/event.rs
+++ b/types/src/event.rs
@@ -94,10 +94,10 @@ impl<'de> de::Deserialize<'de> for EventKey {
         // See comment in serialize.
         #[derive(::serde::Deserialize)]
         #[serde(rename = "EventKey")]
-        struct Value<'a>(&'a [u8]);
+        struct Value(Vec<u8>);
 
         let value = Value::deserialize(deserializer)?;
-        Self::try_from(value.0).map_err(<D::Error as ::serde::de::Error>::custom)
+        Self::try_from(value.0.as_slice()).map_err(<D::Error as ::serde::de::Error>::custom)
     }
 }
 

--- a/types/src/proptest_types.rs
+++ b/types/src/proptest_types.rs
@@ -409,10 +409,20 @@ impl SignatureCheckedTransaction {
                     ),
                 )
             })
-            .prop_map(|(keypair, raw_txn)| {
-                raw_txn
-                    .sign(&keypair.private_key, keypair.public_key)
-                    .expect("signing should always work")
+            .prop_flat_map(|(keypair, raw_txn)| {
+                prop_oneof![
+                    Just(
+                        raw_txn
+                            .clone()
+                            .sign(&keypair.private_key, keypair.public_key.clone())
+                            .expect("signing should always work")
+                    ),
+                    Just(
+                        raw_txn
+                            .multi_sign_for_testing(&keypair.private_key, keypair.public_key)
+                            .expect("signing should always work")
+                    ),
+                ]
             })
     }
 }

--- a/types/src/transaction/mod.rs
+++ b/types/src/transaction/mod.rs
@@ -235,6 +235,18 @@ impl RawTransaction {
         )))
     }
 
+    #[cfg(any(test, feature = "fuzzing"))]
+    pub fn multi_sign_for_testing(
+        self,
+        private_key: &Ed25519PrivateKey,
+        public_key: Ed25519PublicKey,
+    ) -> Result<SignatureCheckedTransaction> {
+        let signature = private_key.sign_message(&self.hash());
+        Ok(SignatureCheckedTransaction(
+            SignedTransaction::new_multisig(self, public_key.into(), signature.into()),
+        ))
+    }
+
     pub fn into_payload(self) -> TransactionPayload {
         self.payload
     }


### PR DESCRIPTION
## Summary

* Add a simple proptest strategy to cover multisig authenticators
* Some nits in crypto conversion code to follow Rust best practices
* Improve error messages in Serde Reflection (used to debug the next issue)
* Make sure that Keys, EventKeys, Hashes are deserialized as Vec<u8> instead of Bytes.
* Turn on deserialization tracing by default.

In the future, we may also switch both serialization and deserialization of Keys, EventKeys, Hashes to Bytes (inducing a visible format change in python clients, though). Pending future improvement of Serde-reflection's deserializer, this would allow us to spare one data copy at deserialization time.

## Test Plan

```
cargo x test -p generate-format
```
