### PR TITLE
[move-lang] allow specifying directories for input files and dependencies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3032,6 +3032,7 @@ dependencies = [
  "structopt 0.3.12 (registry+https://github.com/rust-lang/crates.io-index)",
  "tempfile 3.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "vm 0.1.0",
+ "walkdir 2.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]

--- a/language/move-lang/Cargo.toml
+++ b/language/move-lang/Cargo.toml
@@ -14,6 +14,7 @@ structopt = "0.3.12"
 difference = "2.0"
 petgraph = "0.5.0"
 datatest-stable = { path = "../../common/datatest-stable", version = "0.1.0" }
+walkdir = "2.3.1"
 
 move-vm = { path = "../vm", package = "vm" }
 move-bytecode-verifier = { path = "../bytecode-verifier", package = "bytecode-verifier" }

--- a/language/move-lang/src/bin/move-build.rs
+++ b/language/move-lang/src/bin/move-build.rs
@@ -47,7 +47,17 @@ pub struct Options {
     pub out_dir: String,
 }
 
-pub fn main() -> std::io::Result<()> {
+pub fn main() {
+    std::process::exit(match real_main() {
+        Ok(_) => 0,
+        Err(e) => {
+            eprintln!("error: {}", e);
+            1
+        }
+    });
+}
+
+fn real_main() -> std::io::Result<()> {
     let Options {
         source_files,
         dependencies,

--- a/language/move-lang/src/bin/move-build.rs
+++ b/language/move-lang/src/bin/move-build.rs
@@ -48,7 +48,7 @@ pub struct Options {
 }
 
 pub fn main() {
-    std::process::exit(match real_main() {
+    std::process::exit(match main_impl() {
         Ok(_) => 0,
         Err(e) => {
             eprintln!("error: {}", e);
@@ -57,7 +57,7 @@ pub fn main() {
     });
 }
 
-fn real_main() -> std::io::Result<()> {
+fn main_impl() -> std::io::Result<()> {
     let Options {
         source_files,
         dependencies,

--- a/language/move-lang/src/bin/move-check.rs
+++ b/language/move-lang/src/bin/move-check.rs
@@ -41,7 +41,17 @@ pub struct Options {
     pub sender: Option<Address>,
 }
 
-pub fn main() -> std::io::Result<()> {
+pub fn main() {
+    std::process::exit(match real_main() {
+        Ok(_) => 0,
+        Err(e) => {
+            eprintln!("error: {}", e);
+            1
+        }
+    });
+}
+
+pub fn real_main() -> std::io::Result<()> {
     let Options {
         source_files,
         dependencies,

--- a/language/move-lang/src/bin/move-check.rs
+++ b/language/move-lang/src/bin/move-check.rs
@@ -42,7 +42,7 @@ pub struct Options {
 }
 
 pub fn main() {
-    std::process::exit(match real_main() {
+    std::process::exit(match main_impl() {
         Ok(_) => 0,
         Err(e) => {
             eprintln!("error: {}", e);
@@ -51,7 +51,7 @@ pub fn main() {
     });
 }
 
-pub fn real_main() -> std::io::Result<()> {
+pub fn main_impl() -> std::io::Result<()> {
     let Options {
         source_files,
         dependencies,


### PR DESCRIPTION
When compiling a Move file that is not part of the standard library, there are typically a number of dependencies on the stdlib modules. It is a hassle to specify these individually. This change lets you specify the directory containing the stdlib modules as a dependency, and the compiler will expand that to include all the ".move" files inside that directory. We can do the same for the input files to make it easier to build the stdlib (or any other collection of Move files).

This also changes the move-build and move-check programs to customize the error printing. The default output for io::Error results is not very pretty.

## Motivation

Compiler ease of use

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

Ran existing tests.

It would be nice to exercise this new functionality somewhere in our testing process, but I'm not sure where to do that. Suggestions welcome.
