### PR TITLE
Consistently import parity-multiaddr

### DIFF
--- a/language/tools/vm-genesis/Cargo.toml
+++ b/language/tools/vm-genesis/Cargo.toml
@@ -25,7 +25,7 @@ move-vm-cache = { path = "../../move-vm/cache", version = "0.1.0" }
 move-vm-runtime = { path = "../../move-vm/runtime", version = "0.1.0"}
 move-vm-state = { path = "../../move-vm/state", version = "0.1.0"}
 move-vm-types = { path = "../../move-vm/types", version = "0.1.0" }
-parity-multiaddr = "0.8.0"
+parity-multiaddr = { version = "0.8.0", default-features = false }
 stdlib = { path = "../../stdlib", version = "0.1.0" }
 transaction-builder = { path = "../../transaction-builder", version = "0.1.0"}
 vm = { path = "../../vm", version = "0.1.0" }

--- a/libra-node/Cargo.toml
+++ b/libra-node/Cargo.toml
@@ -12,7 +12,7 @@ edition = "2018"
 [dependencies]
 futures = "0.3.0"
 jemallocator = { version = "0.3.2", features = ["profiling", "unprefixed_malloc_on_supported_platforms"] }
-parity-multiaddr = "0.8.0"
+parity-multiaddr = { version = "0.8.0", default-features = false }
 rayon = "1.2.0"
 structopt = "0.3.13"
 tokio = { version = "0.2.13", features = ["full"] }

--- a/network/Cargo.toml
+++ b/network/Cargo.toml
@@ -14,7 +14,7 @@ anyhow = "1.0"
 bytes = { version = "0.5.4", features = ["serde"] }
 futures = "0.3.0"
 once_cell = "1.3.1"
-parity-multiaddr = "0.8.0"
+parity-multiaddr = { version = "0.8.0", default-features = false }
 pin-project = "0.4.2"
 prometheus = { version = "0.8.0", default-features = false }
 rand = "0.6.5"

--- a/network/socket-bench-server/Cargo.toml
+++ b/network/socket-bench-server/Cargo.toml
@@ -11,7 +11,7 @@ edition = "2018"
 
 [dependencies]
 futures = { version = "0.3.0"  }
-parity-multiaddr = "0.8.0"
+parity-multiaddr = { version = "0.8.0", default-features = false }
 tokio = { version = "0.2.13", features = ["full"] }
 tokio-util = { version = "0.3", features = ["codec"] }
 

--- a/state-synchronizer/Cargo.toml
+++ b/state-synchronizer/Cargo.toml
@@ -39,7 +39,7 @@ bytes = "0.5.4"
 
 config-builder = { path = "../config/config-builder", version = "0.1.0" }
 libra-crypto = { path = "../crypto/crypto", version = "0.1.0" }
-parity-multiaddr = "0.8.0"
+parity-multiaddr = { version = "0.8.0", default-features = false }
 vm-genesis = { path = "../language/tools/vm-genesis", version = "0.1.0" }
 transaction-builder = { path = "../language/transaction-builder", version = "0.1.0" }
 channel = { path = "../common/channel", version = "0.1.0" }

--- a/types/Cargo.toml
+++ b/types/Cargo.toml
@@ -17,7 +17,7 @@ hex = "0.4.2"
 itertools = { version = "0.9.0", default-features = false }
 once_cell = "1.3.1"
 mirai-annotations = "1.5.0"
-parity-multiaddr = "0.8.0"
+parity-multiaddr = { version = "0.8.0", default-features = false }
 proptest = { version = "0.9.4", default-features = false, optional = true }
 proptest-derive = { version = "0.1.2", default-features = false, optional = true }
 prost = "0.6"


### PR DESCRIPTION
The default features includes quite a lot of optional code, and some code was
importing it without `default-features = false`. This makes the whole codebase
import this consistently.
