### PR TITLE
[language] add Debug::print_stack_trace

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2224,6 +2224,7 @@ dependencies = [
  "libra-workspace-hack 0.1.0",
  "move-core-types 0.1.0",
  "move-vm-cache 0.1.0",
+ "move-vm-runtime 0.1.0",
  "move-vm-state 0.1.0",
  "move-vm-types 0.1.0",
  "once_cell 1.3.1 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/language/e2e-tests/Cargo.toml
+++ b/language/e2e-tests/Cargo.toml
@@ -24,6 +24,7 @@ move-core-types = { path = "../move-core/types", version = "0.1.0" }
 move-vm-cache = { path = "../move-vm/cache", version = "0.1.0" }
 move-vm-state = { path = "../move-vm/state", version = "0.1.0" }
 move-vm-types = { path = "../move-vm/types", version = "0.1.0", features = ["debug_module"] }
+move-vm-runtime = { path = "../move-vm/runtime", version = "0.1.0", features = ["debug_module"] }
 transaction-builder = { path = "../transaction-builder", version = "0.1.0", features = ["fuzzing"]}
 vm = { path = "../vm", version = "0.1.0" }
 vm-genesis = { path = "../tools/vm-genesis", version = "0.1.0" }

--- a/language/move-lang/tests/functional/debug/print_values.move
+++ b/language/move-lang/tests/functional/debug/print_values.move
@@ -1,5 +1,3 @@
-//! debug
-
 module M {
     use 0x0::Debug;
     use 0x0::Vector;

--- a/language/move-lang/tests/functional/debug/stack_trace.move
+++ b/language/move-lang/tests/functional/debug/stack_trace.move
@@ -1,0 +1,50 @@
+//! account: alice
+//! account: bob
+
+//! sender: alice
+module M {
+    use 0x0::Debug;
+
+    public fun sum(n: u64): u64 {
+        if (n < 2) {
+            Debug::print_stack_trace();
+            n
+        } else {
+            n + sum(n - 1)
+        }
+    }
+}
+// check: EXECUTED
+
+//! new-transaction
+//! sender: bob
+module N {
+    use {{alice}}::M;
+
+    public fun foo<T1, T2>(): u64 {
+        let x = 3;
+        let y = &mut x;
+        let z = M::sum(4);
+        _ = y;
+        z
+    }
+}
+// check: EXECUTED
+
+//! new-transaction
+//! sender: alice
+use {{bob}}::N;
+use 0x0::Vector;
+use 0x0::Debug;
+use 0x0::LibraAccount;
+
+fun main() {
+    let v = Vector::empty();
+    Vector::push_back(&mut v, true);
+    Vector::push_back(&mut v, false);
+    let r = Vector::borrow(&mut v, 1);
+    let x = N::foo<bool, LibraAccount::T>();
+    Debug::print(&x);
+    _ = r;
+}
+// check: EXECUTED

--- a/language/move-vm/runtime/Cargo.toml
+++ b/language/move-vm/runtime/Cargo.toml
@@ -39,3 +39,4 @@ move-vm-state = { path = "../state", version = "0.1.0" }
 
 [features]
 default = []
+debug_module = []

--- a/language/move-vm/runtime/src/loaded_data/function.rs
+++ b/language/move-vm/runtime/src/loaded_data/function.rs
@@ -7,7 +7,10 @@ use bytecode_verifier::VerifiedModule;
 use move_core_types::identifier::IdentStr;
 use vm::{
     access::ModuleAccess,
-    file_format::{Bytecode, CodeUnit, FunctionDefinitionIndex, FunctionHandle, Kind, Signature},
+    file_format::{
+        Bytecode, CodeUnit, FunctionDefinitionIndex, FunctionHandle, Kind, Signature,
+        SignatureIndex,
+    },
     internals::ModuleIndex,
 };
 
@@ -22,8 +25,16 @@ pub trait FunctionReference<'txn>: Sized + Clone {
     /// Fetch the code of the function definition
     fn code_definition(&self) -> &'txn [Bytecode];
 
+    /// Return the locals for the function
+    fn locals(&self) -> Option<&'txn Signature>;
+
     /// Return the number of locals for the function
-    fn local_count(&self) -> usize;
+    fn local_count(&self) -> usize {
+        match self.locals() {
+            Some(locals) => locals.len(),
+            None => 0,
+        }
+    }
 
     /// Return the number of input parameters for the function
     fn arg_count(&self) -> usize;
@@ -74,11 +85,6 @@ impl<'txn> FunctionReference<'txn> for FunctionRef<'txn> {
     fn code_definition(&self) -> &'txn [Bytecode] {
         &self.def.code
     }
-
-    fn local_count(&self) -> usize {
-        self.def.local_count
-    }
-
     fn arg_count(&self) -> usize {
         self.def.arg_count
     }
@@ -109,6 +115,10 @@ impl<'txn> FunctionReference<'txn> for FunctionRef<'txn> {
     fn type_parameters(&self) -> &'txn [Kind] {
         &self.handle.type_parameters
     }
+
+    fn locals(&self) -> Option<&'txn Signature> {
+        self.def.locals_idx.map(|idx| self.module.signature_at(idx))
+    }
 }
 
 impl<'txn> FunctionRef<'txn> {
@@ -128,7 +138,7 @@ impl<'txn> FunctionRef<'txn> {
 /// Resolved form of a function definition
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct FunctionDef {
-    pub local_count: usize,
+    pub locals_idx: Option<SignatureIndex>,
     pub arg_count: usize,
     pub return_count: usize,
     pub code: Vec<Bytecode>,
@@ -144,18 +154,18 @@ impl FunctionDef {
         let parameters = module.signature_at(handle.parameters);
         let return_ = module.signature_at(handle.return_);
         let flags = definition.flags;
+        let locals_idx = if (flags & CodeUnit::NATIVE) == CodeUnit::NATIVE {
+            None
+        } else {
+            Some(definition.code.locals)
+        };
 
         FunctionDef {
             code,
             flags,
             arg_count: parameters.len(),
             return_count: return_.len(),
-            // Local count for native function is omitted
-            local_count: if (flags & CodeUnit::NATIVE) == CodeUnit::NATIVE {
-                0
-            } else {
-                module.signature_at(definition.code.locals).0.len()
-            },
+            locals_idx,
         }
     }
 }

--- a/language/move-vm/runtime/src/special_names.rs
+++ b/language/move-vm/runtime/src/special_names.rs
@@ -11,3 +11,6 @@ pub(crate) static EMIT_EVENT_NAME: Lazy<Identifier> =
 
 pub(crate) static SAVE_ACCOUNT_NAME: Lazy<Identifier> =
     Lazy::new(|| Identifier::new("save_account").unwrap());
+
+pub(crate) static PRINT_STACK_TRACE_NAME: Lazy<Identifier> =
+    Lazy::new(|| Identifier::new("print_stack_trace").unwrap());

--- a/language/move-vm/types/src/lib.rs
+++ b/language/move-vm/types/src/lib.rs
@@ -3,6 +3,24 @@
 
 #![forbid(unsafe_code)]
 
+macro_rules! debug_write {
+    ($($toks: tt)*) => {
+        write!($($toks)*).map_err(|_|
+            VMStatus::new(StatusCode::UNKNOWN_INVARIANT_VIOLATION_ERROR)
+                .with_message("failed to write to buffer".to_string())
+        )
+    };
+}
+
+macro_rules! debug_writeln {
+    ($($toks: tt)*) => {
+        writeln!($($toks)*).map_err(|_|
+            VMStatus::new(StatusCode::UNKNOWN_INVARIANT_VIOLATION_ERROR)
+                .with_message("failed to write to buffer".to_string())
+        )
+    };
+}
+
 pub mod chain_state;
 pub mod identifier;
 pub mod loaded_data;

--- a/language/move-vm/types/src/native_functions/dispatch.rs
+++ b/language/move-vm/types/src/native_functions/dispatch.rs
@@ -84,6 +84,7 @@ pub enum NativeFunction {
     AccountWriteEvent,
     AccountSaveAccount,
     DebugPrint,
+    DebugPrintStackTrace,
 }
 
 impl NativeFunction {
@@ -114,6 +115,7 @@ impl NativeFunction {
             (&CORE_CODE_ADDRESS, "LibraAccount", "write_to_event_store") => AccountWriteEvent,
             (&CORE_CODE_ADDRESS, "LibraAccount", "save_account") => AccountSaveAccount,
             (&CORE_CODE_ADDRESS, "Debug", "print") => DebugPrint,
+            (&CORE_CODE_ADDRESS, "Debug", "print_stack_trace") => DebugPrintStackTrace,
             _ => return None,
         })
     }
@@ -149,6 +151,9 @@ impl NativeFunction {
             Self::AccountSaveAccount => Err(VMStatus::new(StatusCode::UNREACHABLE)
                 .with_message("save_account does not have a native implementation".to_string())),
             Self::DebugPrint => debug::native_print(t, v, c),
+            Self::DebugPrintStackTrace => Err(VMStatus::new(StatusCode::UNREACHABLE).with_message(
+                "print_stack_trace does not have a native implementation".to_string(),
+            )),
         }
     }
 
@@ -172,6 +177,7 @@ impl NativeFunction {
             Self::AccountWriteEvent => 3,
             Self::AccountSaveAccount => 3,
             Self::DebugPrint => 1,
+            Self::DebugPrintStackTrace => 0,
         }
     }
 
@@ -359,6 +365,7 @@ impl NativeFunction {
                 vec![Reference(Box::new(TypeParameter(0)))],
                 vec![]
             ),
+            Self::DebugPrintStackTrace => simple!(vec![], vec![], vec![]),
         })
     }
 }

--- a/language/stdlib/modules/debug.move
+++ b/language/stdlib/modules/debug.move
@@ -2,4 +2,6 @@ address 0x0:
 
 module Debug {
     native public fun print<T>(x: &T);
+
+    native public fun print_stack_trace();
 }

--- a/types/src/account_config.rs
+++ b/types/src/account_config.rs
@@ -35,6 +35,12 @@ static ACCOUNT_EVENT_HANDLE_GENERATOR_STRUCT_NAME: Lazy<Identifier> =
 pub static ACCOUNT_MODULE: Lazy<ModuleId> =
     Lazy::new(|| ModuleId::new(CORE_CODE_ADDRESS, ACCOUNT_MODULE_IDENTIFIER.clone()));
 
+// Debug
+pub static DEBUG_MODULE_NAME: Lazy<Identifier> = Lazy::new(|| Identifier::new("Debug").unwrap());
+
+pub static DEBUG_MODULE: Lazy<ModuleId> =
+    Lazy::new(|| ModuleId::new(CORE_CODE_ADDRESS, DEBUG_MODULE_NAME.clone()));
+
 pub fn coin_module_name() -> &'static IdentStr {
     &*COIN_MODULE_NAME
 }


### PR DESCRIPTION
## Summary
This adds a function to print out stack traces of the Move VM.

Here's a sample debug trace:
```
Call Stack:
    [0] c4ece0edf07cfbf7fae8714f668ecdf1::<SELF>::main

        Code:
            [13] CallGeneric(2)
            [14] StLoc(0)
            [15] CallGeneric(3)
          > [16] StLoc(4)
            [17] ImmBorrowLoc(4)
            [18] CallGeneric(4)
            [19] MoveLoc(0)

        Locals:
            [0] (&) false
            [1] (invalid)
            [2] (invalid)
            [3] [true, false]
            [4] (invalid)


    [1] 2f69b785590fa94f87533a25593b683d::N::foo<bool, LibraAccount::T>

        Code:
            [3] StLoc(1)
            [4] LdU64(4)
            [5] Call(0)
          > [6] StLoc(2)
            [7] MoveLoc(1)
            [8] Pop
            [9] CopyLoc(2)

        Locals:
            [0] 3u64
            [1] (&mut) 3u64
            [2] (invalid)


    [2] c4ece0edf07cfbf7fae8714f668ecdf1::M::sum

        Code:
            [13] LdU64(1)
            [14] Sub
            [15] Call(2)
          > [16] Add
            [17] StLoc(1)
            [18] MoveLoc(1)
            [19] Ret

        Locals:
            [0] 4u64
            [1] (invalid)


    [3] c4ece0edf07cfbf7fae8714f668ecdf1::M::sum

        Code:
            [13] LdU64(1)
            [14] Sub
            [15] Call(2)
          > [16] Add
            [17] StLoc(1)
            [18] MoveLoc(1)
            [19] Ret

        Locals:
            [0] 3u64
            [1] (invalid)


    [4] c4ece0edf07cfbf7fae8714f668ecdf1::M::sum

        Code:
            [13] LdU64(1)
            [14] Sub
            [15] Call(2)
          > [16] Add
            [17] StLoc(1)
            [18] MoveLoc(1)
            [19] Ret

        Locals:
            [0] 2u64
            [1] (invalid)


Operand Stack:
    [0] U64(4)
    [1] U64(3)
    [2] U64(2)
```
## Test Plan
cargo test