### PR TITLE
[Storage] Kill ColumnFamilyOptions

### DIFF
--- a/consensus/src/chained_bft/consensusdb/mod.rs
+++ b/consensus/src/chained_bft/consensusdb/mod.rs
@@ -15,9 +15,7 @@ use consensus_types::{block::Block, common::Payload, quorum_cert::QuorumCert};
 use libra_crypto::HashValue;
 use libra_logger::prelude::*;
 use schema::{BLOCK_CF_NAME, QC_CF_NAME, SINGLE_ENTRY_CF_NAME};
-use schemadb::{
-    ColumnFamilyOptions, ColumnFamilyOptionsMap, ReadOptions, SchemaBatch, DB, DEFAULT_CF_NAME,
-};
+use schemadb::{ReadOptions, SchemaBatch, DB, DEFAULT_CF_NAME};
 use std::{collections::HashMap, iter::Iterator, path::Path, time::Instant};
 
 type HighestTimeoutCertificate = Vec<u8>;
@@ -29,22 +27,16 @@ pub struct ConsensusDB {
 
 impl ConsensusDB {
     pub fn new<P: AsRef<Path> + Clone>(db_root_path: P) -> Self {
-        let cf_opts_map: ColumnFamilyOptionsMap = [
-            (
-                /* UNUSED CF = */ DEFAULT_CF_NAME,
-                ColumnFamilyOptions::default(),
-            ),
-            (BLOCK_CF_NAME, ColumnFamilyOptions::default()),
-            (QC_CF_NAME, ColumnFamilyOptions::default()),
-            (SINGLE_ENTRY_CF_NAME, ColumnFamilyOptions::default()),
-        ]
-        .iter()
-        .cloned()
-        .collect();
+        let column_families = vec![
+            /* UNUSED CF = */ DEFAULT_CF_NAME,
+            BLOCK_CF_NAME,
+            QC_CF_NAME,
+            SINGLE_ENTRY_CF_NAME,
+        ];
 
         let path = db_root_path.as_ref().join("consensusdb");
         let instant = Instant::now();
-        let db = DB::open(path.clone(), cf_opts_map)
+        let db = DB::open(path.clone(), column_families)
             .expect("ConsensusDB open failed; unable to continue");
 
         info!(

--- a/storage/libradb/src/lib.rs
+++ b/storage/libradb/src/lib.rs
@@ -70,7 +70,7 @@ use libra_types::{
 };
 use once_cell::sync::Lazy;
 use prometheus::{IntCounter, IntGauge, IntGaugeVec};
-use schemadb::{ColumnFamilyOptions, ColumnFamilyOptionsMap, DB, DEFAULT_CF_NAME};
+use schemadb::{DB, DEFAULT_CF_NAME};
 use std::{iter::Iterator, path::Path, sync::Arc, time::Instant};
 use storage_interface::{DbReader, DbWriter};
 use storage_proto::{StartupInfo, TreeState};
@@ -137,43 +137,28 @@ impl LibraDB {
     const NUM_HISTORICAL_VERSIONS_TO_KEEP: u64 = 1_000_000;
 
     pub fn open<P: AsRef<Path> + Clone>(db_root_path: P, readonly: bool) -> Result<Self> {
-        let cf_opts_map: ColumnFamilyOptionsMap = [
-            (
-                /* LedgerInfo CF = */ DEFAULT_CF_NAME,
-                ColumnFamilyOptions::default(),
-            ),
-            (EPOCH_BY_VERSION_CF_NAME, ColumnFamilyOptions::default()),
-            (EVENT_ACCUMULATOR_CF_NAME, ColumnFamilyOptions::default()),
-            (EVENT_BY_KEY_CF_NAME, ColumnFamilyOptions::default()),
-            (EVENT_CF_NAME, ColumnFamilyOptions::default()),
-            (
-                JELLYFISH_MERKLE_NODE_CF_NAME,
-                ColumnFamilyOptions::default(),
-            ),
-            (LEDGER_COUNTERS_CF_NAME, ColumnFamilyOptions::default()),
-            (STALE_NODE_INDEX_CF_NAME, ColumnFamilyOptions::default()),
-            (TRANSACTION_CF_NAME, ColumnFamilyOptions::default()),
-            (
-                TRANSACTION_ACCUMULATOR_CF_NAME,
-                ColumnFamilyOptions::default(),
-            ),
-            (
-                TRANSACTION_BY_ACCOUNT_CF_NAME,
-                ColumnFamilyOptions::default(),
-            ),
-            (TRANSACTION_INFO_CF_NAME, ColumnFamilyOptions::default()),
-        ]
-        .iter()
-        .cloned()
-        .collect();
+        let column_families = vec![
+            /* LedgerInfo CF = */ DEFAULT_CF_NAME,
+            EPOCH_BY_VERSION_CF_NAME,
+            EVENT_ACCUMULATOR_CF_NAME,
+            EVENT_BY_KEY_CF_NAME,
+            EVENT_CF_NAME,
+            JELLYFISH_MERKLE_NODE_CF_NAME,
+            LEDGER_COUNTERS_CF_NAME,
+            STALE_NODE_INDEX_CF_NAME,
+            TRANSACTION_CF_NAME,
+            TRANSACTION_ACCUMULATOR_CF_NAME,
+            TRANSACTION_BY_ACCOUNT_CF_NAME,
+            TRANSACTION_INFO_CF_NAME,
+        ];
 
         let path = db_root_path.as_ref().join("libradb");
         let instant = Instant::now();
 
         let db = Arc::new(if readonly {
-            DB::open_readonly(path.clone(), cf_opts_map)?
+            DB::open_readonly(path.clone(), column_families)?
         } else {
-            DB::open(path.clone(), cf_opts_map)?
+            DB::open(path.clone(), column_families)?
         });
 
         info!(

--- a/storage/schemadb/tests/db.rs
+++ b/storage/schemadb/tests/db.rs
@@ -7,7 +7,7 @@ use proptest::{collection::vec, prelude::*};
 use schemadb::{
     define_schema,
     schema::{KeyCodec, Schema, ValueCodec},
-    ColumnFamilyOptions, ColumnFamilyOptionsMap, SchemaBatch, DB, DEFAULT_CF_NAME,
+    ColumnFamilyName, SchemaBatch, DB, DEFAULT_CF_NAME,
 };
 
 // Creating two schemas that share exactly the same structure but are stored in different column
@@ -71,29 +71,20 @@ impl ValueCodec<TestSchema2> for TestField {
     }
 }
 
-fn get_cf_opts_map() -> ColumnFamilyOptionsMap {
-    [
-        (DEFAULT_CF_NAME, ColumnFamilyOptions::default()),
-        (
-            TestSchema1::COLUMN_FAMILY_NAME,
-            ColumnFamilyOptions::default(),
-        ),
-        (
-            TestSchema2::COLUMN_FAMILY_NAME,
-            ColumnFamilyOptions::default(),
-        ),
+fn get_column_families() -> Vec<ColumnFamilyName> {
+    vec![
+        DEFAULT_CF_NAME,
+        TestSchema1::COLUMN_FAMILY_NAME,
+        TestSchema2::COLUMN_FAMILY_NAME,
     ]
-    .iter()
-    .cloned()
-    .collect()
 }
 
 fn open_db(dir: &libra_temppath::TempPath) -> DB {
-    DB::open(&dir.path(), get_cf_opts_map()).expect("Failed to open DB.")
+    DB::open(&dir.path(), get_column_families()).expect("Failed to open DB.")
 }
 
 fn open_db_read_only(dir: &libra_temppath::TempPath) -> DB {
-    DB::open_readonly(&dir.path(), get_cf_opts_map()).expect("Failed to open DB.")
+    DB::open_readonly(&dir.path(), get_column_families()).expect("Failed to open DB.")
 }
 
 struct TestDB {

--- a/storage/schemadb/tests/iterator.rs
+++ b/storage/schemadb/tests/iterator.rs
@@ -6,7 +6,7 @@ use byteorder::{BigEndian, ReadBytesExt, WriteBytesExt};
 use schemadb::{
     define_schema,
     schema::{KeyCodec, Schema, SeekKeyCodec, ValueCodec},
-    ColumnFamilyOptions, ColumnFamilyOptionsMap, SchemaIterator, DB, DEFAULT_CF_NAME,
+    SchemaIterator, DB, DEFAULT_CF_NAME,
 };
 
 define_schema!(TestSchema, TestKey, TestValue, "TestCF");
@@ -78,17 +78,8 @@ struct TestDB {
 impl TestDB {
     fn new() -> Self {
         let tmpdir = libra_temppath::TempPath::new();
-        let cf_opts_map: ColumnFamilyOptionsMap = [
-            (DEFAULT_CF_NAME, ColumnFamilyOptions::default()),
-            (
-                TestSchema::COLUMN_FAMILY_NAME,
-                ColumnFamilyOptions::default(),
-            ),
-        ]
-        .iter()
-        .cloned()
-        .collect();
-        let db = DB::open(&tmpdir.path(), cf_opts_map).unwrap();
+        let column_families = vec![DEFAULT_CF_NAME, TestSchema::COLUMN_FAMILY_NAME];
+        let db = DB::open(&tmpdir.path(), column_families).unwrap();
 
         db.put::<TestSchema>(&TestKey(1, 0, 0), &TestValue(100))
             .unwrap();


### PR DESCRIPTION
The new rocksdb binding we are going to use has a bit different API for column family options. Given that we are not using anything other than default option, we can just avoid exposing the API for simplicity. Even if we are going to use it in the future, some changes will need to be made, so just remove for now.