### PR TITLE
[network] add multi-source support to connectivity manager

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3262,6 +3262,7 @@ dependencies = [
  "memsocket 0.1.0",
  "netcore 0.1.0",
  "noise 0.1.0",
+ "num-variants 0.1.0",
  "once_cell 1.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "parity-multiaddr 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "pin-project 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/network/Cargo.toml
+++ b/network/Cargo.toml
@@ -38,6 +38,7 @@ libra-security-logger = { path = "../common/security-logger", version = "0.1.0" 
 memsocket = { path = "memsocket", version = "0.1.0" }
 netcore = { path = "netcore", version = "0.1.0" }
 noise = { path = "noise", version = "0.1.0" }
+num-variants = { path = "../common/num-variants", version = "0.1.0" }
 libra-proptest-helpers = { path = "../common/proptest-helpers", version = "0.1.0", optional = true }
 stream-ratelimiter = { path = "../common/stream-ratelimiter", version = "0.1.0" }
 proptest = { version = "0.9.4", default-features = true, optional = true }

--- a/network/src/connectivity_manager/mod.rs
+++ b/network/src/connectivity_manager/mod.rs
@@ -101,7 +101,7 @@ impl DiscoverySource {
 #[derive(Debug)]
 pub enum ConnectivityRequest {
     /// Request to update known addresses of peer with id `PeerId` to given list.
-    UpdateAddresses(PeerId, Vec<Multiaddr>),
+    UpdateAddresses(DiscoverySource, PeerId, Vec<Multiaddr>),
     /// Update set of nodes eligible to join the network.
     UpdateEligibleNodes(HashMap<PeerId, NetworkPublicKeys>),
     /// Gets current size of dial queue. This is useful in tests.
@@ -376,12 +376,13 @@ where
 
     fn handle_request(&mut self, req: ConnectivityRequest) {
         match req {
-            ConnectivityRequest::UpdateAddresses(peer_id, addrs) => {
+            ConnectivityRequest::UpdateAddresses(src, peer_id, addrs) => {
                 trace!(
-                    "Received updated addresses for peer: {}",
-                    peer_id.short_str()
+                    "Received updated addresses for peer: {} from {:?} discovery source",
+                    peer_id.short_str(),
+                    src,
                 );
-                self.update_peer_addrs(peer_id, addrs);
+                self.update_peer_addrs(src, peer_id, addrs);
                 // Ensure that the next dial attempt starts from the first addr.
                 if let Some(dial_state) = self.dial_states.get_mut(&peer_id) {
                     dial_state.reset_addr();
@@ -397,10 +398,7 @@ where
         }
     }
 
-    fn update_peer_addrs(&mut self, peer_id: PeerId, addrs: Vec<Multiaddr>) {
-        // TODO(philiphayes): use real value here
-        let src = DiscoverySource::Gossip;
-
+    fn update_peer_addrs(&mut self, src: DiscoverySource, peer_id: PeerId, addrs: Vec<Multiaddr>) {
         self.peer_addresses
             .entry(peer_id)
             .or_default()
@@ -518,7 +516,7 @@ where
     }
 
     fn next_addr<'a>(&mut self, addrs: &'a Addresses) -> &'a Multiaddr {
-        assert_ne!(0, addrs.len());
+        assert!(!addrs.is_empty());
 
         let addr_idx = self.addr_idx;
         self.addr_idx = self.addr_idx.wrapping_add(1);

--- a/network/src/connectivity_manager/test.rs
+++ b/network/src/connectivity_manager/test.rs
@@ -216,6 +216,7 @@ fn connect_to_seeds_on_startup() {
         info!("Sending same address of seed peer");
         conn_mgr_reqs_tx
             .send(ConnectivityRequest::UpdateAddresses(
+                DiscoverySource::Gossip,
                 seed_peer_id,
                 vec![seed_addr.clone()],
             ))
@@ -231,6 +232,7 @@ fn connect_to_seeds_on_startup() {
         info!("Sending new address of seed peer");
         conn_mgr_reqs_tx
             .send(ConnectivityRequest::UpdateAddresses(
+                DiscoverySource::Gossip,
                 seed_peer_id,
                 vec![new_seed_addr.clone()],
             ))
@@ -309,6 +311,7 @@ fn addr_change() {
         info!("Sending address of other peer");
         conn_mgr_reqs_tx
             .send(ConnectivityRequest::UpdateAddresses(
+                DiscoverySource::Gossip,
                 other_peer_id,
                 vec![other_address.clone()],
             ))
@@ -338,6 +341,7 @@ fn addr_change() {
         info!("Sending same address of other peer");
         conn_mgr_reqs_tx
             .send(ConnectivityRequest::UpdateAddresses(
+                DiscoverySource::Gossip,
                 other_peer_id,
                 vec![other_address.clone()],
             ))
@@ -353,6 +357,7 @@ fn addr_change() {
         info!("Sending new address of other peer");
         conn_mgr_reqs_tx
             .send(ConnectivityRequest::UpdateAddresses(
+                DiscoverySource::Gossip,
                 other_peer_id,
                 vec![other_address_new.clone()],
             ))
@@ -414,6 +419,7 @@ fn lost_connection() {
         info!("Sending address of other peer");
         conn_mgr_reqs_tx
             .send(ConnectivityRequest::UpdateAddresses(
+                DiscoverySource::Gossip,
                 other_peer_id,
                 vec![other_address.clone()],
             ))
@@ -487,6 +493,7 @@ fn disconnect() {
         info!("Sending address of other peer");
         conn_mgr_reqs_tx
             .send(ConnectivityRequest::UpdateAddresses(
+                DiscoverySource::Gossip,
                 other_peer_id,
                 vec![other_address.clone()],
             ))
@@ -553,6 +560,7 @@ fn retry_on_failure() {
         info!("Sending address of other peer");
         conn_mgr_reqs_tx
             .send(ConnectivityRequest::UpdateAddresses(
+                DiscoverySource::Gossip,
                 other_peer_id,
                 vec![other_address.clone()],
             ))
@@ -656,6 +664,7 @@ fn no_op_requests() {
         info!("Sending address of other peer");
         conn_mgr_reqs_tx
             .send(ConnectivityRequest::UpdateAddresses(
+                DiscoverySource::Gossip,
                 other_peer_id,
                 vec![other_address.clone()],
             ))
@@ -767,6 +776,7 @@ fn backoff_on_failure() {
         info!("Sending address of peer a");
         conn_mgr_reqs_tx
             .send(ConnectivityRequest::UpdateAddresses(
+                DiscoverySource::Gossip,
                 peer_a,
                 vec![peer_a_address.clone()],
             ))
@@ -776,6 +786,7 @@ fn backoff_on_failure() {
         info!("Sending address of peer b");
         conn_mgr_reqs_tx
             .send(ConnectivityRequest::UpdateAddresses(
+                DiscoverySource::Gossip,
                 peer_b,
                 vec![peer_b_address.clone()],
             ))
@@ -844,6 +855,7 @@ fn multiple_addrs_basic() {
         info!("Sending address of other peer");
         conn_mgr_reqs_tx
             .send(ConnectivityRequest::UpdateAddresses(
+                DiscoverySource::Gossip,
                 other_peer_id,
                 vec![other_addr_1.clone(), other_addr_2.clone()],
             ))
@@ -911,6 +923,7 @@ fn multiple_addrs_wrapping() {
         info!("Sending address of other peer");
         conn_mgr_reqs_tx
             .send(ConnectivityRequest::UpdateAddresses(
+                DiscoverySource::Gossip,
                 other_peer_id,
                 vec![other_addr_1.clone(), other_addr_2.clone()],
             ))
@@ -995,6 +1008,7 @@ fn multiple_addrs_shrinking() {
         info!("Sending address of other peer");
         conn_mgr_reqs_tx
             .send(ConnectivityRequest::UpdateAddresses(
+                DiscoverySource::Gossip,
                 other_peer_id,
                 vec![
                     other_addr_1.clone(),
@@ -1030,6 +1044,7 @@ fn multiple_addrs_shrinking() {
         info!("Sending address of other peer");
         conn_mgr_reqs_tx
             .send(ConnectivityRequest::UpdateAddresses(
+                DiscoverySource::Gossip,
                 other_peer_id,
                 vec![other_addr_4.clone(), other_addr_5.clone()],
             ))

--- a/network/src/protocols/discovery/mod.rs
+++ b/network/src/protocols/discovery/mod.rs
@@ -31,7 +31,7 @@
 //!
 //! [`ConnectivityManager`]: ../../connectivity_manager
 use crate::{
-    connectivity_manager::ConnectivityRequest,
+    connectivity_manager::{ConnectivityRequest, DiscoverySource},
     counters,
     error::{NetworkError, NetworkErrorKind},
     peer_manager::{ConnectionRequestSender, PeerManagerRequestSender},
@@ -376,6 +376,7 @@ where
 
                         self.conn_mgr_reqs_tx
                             .send(ConnectivityRequest::UpdateAddresses(
+                                DiscoverySource::Gossip,
                                 note.as_note().peer_id,
                                 peer_addrs,
                             ))

--- a/network/src/protocols/discovery/test.rs
+++ b/network/src/protocols/discovery/test.rs
@@ -97,7 +97,8 @@ async fn expect_address_update(
     expected_addrs: &[Multiaddr],
 ) {
     match conn_mgr_reqs_rx.next().await.unwrap() {
-        ConnectivityRequest::UpdateAddresses(peer_id, addrs) => {
+        ConnectivityRequest::UpdateAddresses(src, peer_id, addrs) => {
+            assert_eq!(DiscoverySource::Gossip, src);
             assert_eq!(expected_peer_id, peer_id);
             assert_eq!(expected_addrs, &addrs[..]);
         }


### PR DESCRIPTION
To expedite deployment of the new onchain discovery protocol and reduce onchain discovery's dependency on finishing genesis ceremony, this diff allows ConnectivityManager to support multiple discovery sources at once.

Different discovery sources notify the ConnectivityManager of updates to peers' addresses. Currently, there are 3 discovery sources (ordered by decreasing dial priority, i.e., first is highest priority):

1. Onchain discovery protocol
2. Gossip discovery protocol
3. Seed peers from config

In other words, if a we have some addresses discovered via onchain discovery and some seed addresses from our local config, we will try the onchain discovery addresses first and the local seed addresses after.
