### PR TITLE
[move-prover] Added the local specs of libra_account.move

### DIFF
--- a/language/move-prover/src/bytecode_translator.rs
+++ b/language/move-prover/src/bytecode_translator.rs
@@ -139,9 +139,6 @@ impl<'env> ModuleTranslator<'env> {
 
     /// Translates this module.
     fn translate(&mut self) {
-        if self.is_module_provided_by_prelude() {
-            return;
-        }
         info!(
             "translating module {}",
             self.module_env
@@ -153,6 +150,9 @@ impl<'env> ModuleTranslator<'env> {
         let spec_translator = SpecTranslator::new(self.writer, &self.module_env, false);
         spec_translator.translate_spec_vars();
         spec_translator.translate_spec_funs();
+        if self.is_module_provided_by_prelude() {
+            return;
+        }
         self.translate_structs();
         self.translate_functions();
     }

--- a/language/move-prover/src/prelude.bpl
+++ b/language/move-prover/src/prelude.bpl
@@ -961,7 +961,7 @@ axiom (forall v1,v2: Value :: $Vector_is_well_formed(v1) && $Vector_is_well_form
 // and ensures properties when verifying code that calls it.
 procedure $Hash_sha2_256(val: Value) returns (res: Value);
 // It will still work without this, but this helps verifier find more reasonable counterexamples.
-// requires $IsValidU8Vector(val);  // FIXME: Generated callling code does not ensure validity.
+// requires $IsValidU8Vector(val);  // FIXME: Generated calling code does not ensure validity.
 ensures res == $sha2(val);     // returns sha2 value
 ensures $IsValidU8Vector(res);    // result is a legal vector of U8s.
 ensures $vlen(res) == 32;               // result is 32 bytes.
@@ -990,7 +990,7 @@ procedure {:inline 1} $LibraAccount_save_account(ta: TypeValue, balance: Value, 
 }
 
 procedure {:inline 1} $LibraAccount_write_to_event_store(ta: TypeValue, guid: Value, count: Value, msg: Value) {
-    assert false; // $LibraAccount_write_to_event_store not implemented
+    // This function is modeled as a no-op because the actual side effect of this native function is not observable from the Move side.
 }
 
 // ==================================================================================
@@ -1019,22 +1019,21 @@ procedure {:inline 1} Signature_ed25519_threshold_verify(bitmap: Value, signatur
 // Serialize is modeled as an uninterpreted function, with an additional
 // axiom to say it's an injection.
 
-function $serialize(ta: TypeValue, v: Value): Value;
+function $LCS_serialize(ta: TypeValue, v: Value): Value;
 
 // This says that $serialize respects isEquals (substitution property)
 // Without this, Boogie will get false positives where v1, v2 differ at invalid
 // indices.
 axiom (forall ta: TypeValue ::
-       (forall v1,v2: Value :: IsEqual(v1, v2) ==> IsEqual($serialize(ta, v1), $serialize(ta, v2))));
+       (forall v1,v2: Value :: IsEqual(v1, v2) ==> IsEqual($LCS_serialize(ta, v1), $LCS_serialize(ta, v2))));
 
 
 // This says that serialize is an injection
 axiom (forall ta1, ta2: TypeValue ::
-       (forall v1, v2: Value :: IsEqual($serialize(ta1, v1), $serialize(ta2, v2))
+       (forall v1, v2: Value :: IsEqual($LCS_serialize(ta1, v1), $LCS_serialize(ta2, v2))
            ==> IsEqual(v1, v2) && (ta1 == ta2)));
 
-
 procedure $LCS_to_bytes(ta: TypeValue, r: Reference) returns (res: Value);
-ensures res == $serialize(ta, $Dereference($m, r));
+ensures res == $LCS_serialize(ta, $Dereference($m, r));
 ensures $IsValidU8Vector(res);    // result is a legal vector of U8s.
 ensures $vlen(res) > 0;

--- a/language/move-prover/tests/sources/stdlib/modules/lcs.move
+++ b/language/move-prover/tests/sources/stdlib/modules/lcs.move
@@ -5,6 +5,9 @@
 
 address 0x0:
 module LCS {
+    spec module {
+        native define serialize<MoveValue>(v: &MoveValue): vector<u8>;
+    }
     // Return the binary representation of `v` in LCS (Libra Canonical Serialization) format
     native public fun to_bytes<MoveValue>(v: &MoveValue): vector<u8>;
 }

--- a/language/move-prover/tests/sources/stdlib/modules/libra.move
+++ b/language/move-prover/tests/sources/stdlib/modules/libra.move
@@ -99,7 +99,7 @@ module Libra {
         aborts_if !exists<Info<Token>>(0xA550C18);
         aborts_if old(global<Info<Token>>(0xA550C18).total_value) < old(global<Preburn<Token>>(preburn_address).requests[0].value);
         aborts_if old(global<Info<Token>>(0xA550C18).preburn_value) < old(global<Preburn<Token>>(preburn_address).requests[0].value);
-        ensures eq_pop_front(global<Preburn<Token>>(preburn_address).requests, old(global<Preburn<Token>>(preburn_address).requests));
+        ensures Vector::eq_pop_front(global<Preburn<Token>>(preburn_address).requests, old(global<Preburn<Token>>(preburn_address).requests));
         ensures global<Info<Token>>(0xA550C18).total_value == old(global<Info<Token>>(0xA550C18).total_value) - old(global<Preburn<Token>>(preburn_address).requests[0].value);
         ensures global<Info<Token>>(0xA550C18).preburn_value == old(global<Info<Token>>(0xA550C18).preburn_value) - old(global<Preburn<Token>>(preburn_address).requests[0].value);
     }
@@ -120,7 +120,7 @@ module Libra {
         aborts_if old(len(global<Preburn<Token>>(preburn_address).requests)) == 0;
         aborts_if !exists<Info<Token>>(0xA550C18);
         aborts_if old(global<Info<Token>>(0xA550C18).preburn_value) < old(global<Preburn<Token>>(preburn_address).requests[0].value);
-        ensures eq_pop_front(global<Preburn<Token>>(preburn_address).requests, old(global<Preburn<Token>>(preburn_address).requests));
+        ensures Vector::eq_pop_front(global<Preburn<Token>>(preburn_address).requests, old(global<Preburn<Token>>(preburn_address).requests));
         ensures global<Info<Token>>(0xA550C18).preburn_value == old(global<Info<Token>>(0xA550C18).preburn_value) - old(global<Preburn<Token>>(preburn_address).requests[0].value);
         ensures result == old(global<Preburn<Token>>(preburn_address).requests[0]);
     }
@@ -164,21 +164,6 @@ module Libra {
         ensures result.value == value;
     }
 
-    spec module {
-        // Auxiliary function to check if `v1` is equal to the result of adding `e` at the end of `v2`
-        define eq_push_back<Element>(v1: vector<Element>, v2: vector<Element>, e: Element): bool {
-            len(v1) == len(v2) + 1 &&
-            v1[len(v1)-1] == e &&
-            v1[0..len(v1)-1] == v2[0..len(v2)]
-        }
-
-        // Auxiliary function to check if `v1` is equal to the result of removing the first element of `v2`
-        define eq_pop_front<Element>(v1: vector<Element>, v2: vector<Element>): bool {
-            len(v1) + 1 == len(v2) &&
-            v1 == v2[1..len(v2)]
-        }
-    }
-
     // Send coin to the preburn holding area `preburn_ref`, where it will wait to be burned.
     public fun preburn<Token>(
         preburn_ref: &mut Preburn<Token>,
@@ -199,7 +184,7 @@ module Libra {
         aborts_if !exists<Info<Token>>(0xA550C18);
         aborts_if old(global<Info<Token>>(0xA550C18).preburn_value) + coin.value > max_u64();
         ensures global<Info<Token>>(0xA550C18).preburn_value == old(global<Info<Token>>(0xA550C18).preburn_value) + coin.value;
-        ensures eq_push_back(preburn_ref.requests, old(preburn_ref.requests), coin);
+        ensures Vector::eq_push_back(preburn_ref.requests, old(preburn_ref.requests), coin);
     }
 
     // Send coin to the preburn holding area, where it will wait to be burned.
@@ -214,7 +199,7 @@ module Libra {
         aborts_if !exists<Preburn<Token>>(sender());
         aborts_if old(global<Info<Token>>(0xA550C18).preburn_value) + coin.value > max_u64();
         ensures global<Info<Token>>(0xA550C18).preburn_value == old(global<Info<Token>>(0xA550C18).preburn_value) + coin.value;
-        ensures eq_push_back(global<Preburn<Token>>(sender()).requests, old(global<Preburn<Token>>(sender()).requests), coin);
+        ensures Vector::eq_push_back(global<Preburn<Token>>(sender()).requests, old(global<Preburn<Token>>(sender()).requests), coin);
     }
 
     // Permanently remove the coins held in the `Preburn` resource stored at `preburn_address` and
@@ -240,7 +225,7 @@ module Libra {
         aborts_if !exists<Info<Token>>(0xA550C18);
         aborts_if old(global<Info<Token>>(0xA550C18).total_value) < old(global<Preburn<Token>>(preburn_address).requests[0].value);
         aborts_if old(global<Info<Token>>(0xA550C18).preburn_value) < old(global<Preburn<Token>>(preburn_address).requests[0].value);
-        ensures eq_pop_front(global<Preburn<Token>>(preburn_address).requests, old(global<Preburn<Token>>(preburn_address).requests));
+        ensures Vector::eq_pop_front(global<Preburn<Token>>(preburn_address).requests, old(global<Preburn<Token>>(preburn_address).requests));
         ensures global<Info<Token>>(0xA550C18).total_value == old(global<Info<Token>>(0xA550C18).total_value) - old(global<Preburn<Token>>(preburn_address).requests[0].value);
         ensures global<Info<Token>>(0xA550C18).preburn_value == old(global<Info<Token>>(0xA550C18).preburn_value) - old(global<Preburn<Token>>(preburn_address).requests[0].value);
     }
@@ -268,7 +253,7 @@ module Libra {
         aborts_if old(len(global<Preburn<Token>>(preburn_address).requests)) == 0;
         aborts_if !exists<Info<Token>>(0xA550C18);
         aborts_if old(global<Info<Token>>(0xA550C18).preburn_value) < old(global<Preburn<Token>>(preburn_address).requests[0].value);
-        ensures eq_pop_front(global<Preburn<Token>>(preburn_address).requests, old(global<Preburn<Token>>(preburn_address).requests));
+        ensures Vector::eq_pop_front(global<Preburn<Token>>(preburn_address).requests, old(global<Preburn<Token>>(preburn_address).requests));
         ensures global<Info<Token>>(0xA550C18).preburn_value == old(global<Info<Token>>(0xA550C18).preburn_value) - old(global<Preburn<Token>>(preburn_address).requests[0].value);
         ensures result == old(global<Preburn<Token>>(preburn_address).requests[0]);
     }

--- a/language/move-prover/tests/sources/stdlib/modules/vector.move
+++ b/language/move-prover/tests/sources/stdlib/modules/vector.move
@@ -2,6 +2,28 @@ address 0x0:
 
 // A variable-sized container that can hold both unrestricted types and resources.
 module Vector {
+    spec module {
+        // Auxiliary function to check if `v1` is equal to the result of adding `e` at the end of `v2`
+        define eq_push_back<Element>(v1: vector<Element>, v2: vector<Element>, e: Element): bool {
+            len(v1) == len(v2) + 1 &&
+            v1[len(v1)-1] == e &&
+            v1[0..len(v1)-1] == v2[0..len(v2)]
+        }
+
+        // Auxiliary function to check if `v1` is equal to the result of removing the first element of `v2`
+        define eq_pop_front<Element>(v1: vector<Element>, v2: vector<Element>): bool {
+            len(v1) + 1 == len(v2) &&
+            v1 == v2[1..len(v2)]
+        }
+
+        // Auxiliary function to check if `v` is equal to the result of concatenating `v1` and `v2`
+        define eq_append<Element>(v: vector<Element>, v1: vector<Element>, v2: vector<Element>): bool {
+            len(v) == len(v1) + len(v2) &&
+            v[0..len(v1)] == v1 &&
+            v[len(v1)..len(v)] == v2
+        }
+    }
+
     native public fun empty<Element>(): vector<Element>;
 
     // Return the length of the vector.

--- a/language/move-prover/tests/sources/verify_lcs.exp
+++ b/language/move-prover/tests/sources/verify_lcs.exp
@@ -1,0 +1,1 @@
+Move prover all good, no errors!

--- a/language/move-prover/tests/sources/verify_lcs.move
+++ b/language/move-prover/tests/sources/verify_lcs.move
@@ -1,0 +1,15 @@
+// dep: tests/sources/stdlib/modules/lcs.move
+
+// This file is created to verify the native function in the standard LCS module.
+
+module VerifyVector {
+    use 0x0::LCS;
+
+    fun verify_to_bytes<MoveValue>(v: &MoveValue): vector<u8>
+    {
+        LCS::to_bytes(v)
+    }
+    spec fun verify_to_bytes {
+        ensures result == LCS::serialize(v);
+    }
+}


### PR DESCRIPTION
- Added the specifications for 21 functions (out of 40) in the LibraAccount module
    - Event-related functions
        - fresh_guid, new_event_handle_impl, new_event_handle, emit_event, write_to_event_store, destroy_handle ![event](https://user-images.githubusercontent.com/7842757/79055540-bc59c500-7c02-11ea-9f47-1b36db42fdc3.png)
    - Functions with simple call-dependencies
        - extract_sender_withdrawal_capability, restore_withdrawal_capability, rotate_authentication_key_for_account, rotate_authentication_key, rotate_authentication_key_with_capability, extract_sender_key_rotation_capability, restore_key_rotation_capability, sequence_number_for_account, sequence_number, authentication_key, delegated_key_rotation_capability, delegated_withdrawal_capability, withdrawal_capability_address, key_rotation_capability_address, exists
- Added the test case file (`verify_lcs.move`) to verify the native function of the LCS module (i.e., `to_bytes`)
- Updated the builtin boogle model for `$LibraAccount_write_to_event_store`
- Added the native spec function `serialize` to the LCS module
- Added the auxiliary spec functions to the Vector module, and 
- Modified `bytecode_translator.rs` to enable translating them to Boogie

<!--
Thank you for sending a PR. We appreciate you spending time to help improve the Libra project.

The project is undergoing daily changes. Pull Requests will be reviewed and responded to as time permits.
-->

## Motivation

To verify LibraAccount module

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

`cargo test`

In `libra/language/move-prover/tests/sources/stdlib/modules`, run the following command:
```
cargo run -- --only-verify-spec libra_account.move hash.move lbr.move lcs.move libra.move libra_transaction_timeout.move transaction.move vector.move libra_time.move
```

## Related PRs

