### PR TITLE
[Serde reflection] support deserialization into borrowed bytes and strings

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2639,6 +2639,7 @@ dependencies = [
  "rand 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "regex 1.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.106 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_bytes 0.11.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "thiserror 1.0.15 (registry+https://github.com/rust-lang/crates.io-index)",
  "tiny-keccak 2.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2207,6 +2207,7 @@ dependencies = [
  "rand 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "ripemd160 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.106 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_bytes 0.11.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "sha2 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "sha3 0.8.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "static_assertions 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4452,6 +4452,7 @@ dependencies = [
  "bincode 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "libra-workspace-hack 0.1.0",
  "serde 1.0.106 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_bytes 0.11.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.51 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_yaml 0.8.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "thiserror 1.0.15 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/common/serde-reflection/Cargo.toml
+++ b/common/serde-reflection/Cargo.toml
@@ -18,3 +18,4 @@ serde = { version = "1.0", features = ["derive"] }
 bincode = "1.2"
 serde_json = "1.0"
 serde_yaml = "0.8"
+serde_bytes = "0.11.3"

--- a/common/serde-reflection/src/de.rs
+++ b/common/serde-reflection/src/de.rs
@@ -173,13 +173,13 @@ impl<'de, 'a> de::Deserializer<'de> for Deserializer<'a> {
         self.deserialize_bytes(visitor)
     }
 
-    fn deserialize_option<V>(mut self, visitor: V) -> Result<V::Value>
+    fn deserialize_option<V>(self, visitor: V) -> Result<V::Value>
     where
         V: Visitor<'de>,
     {
         self.format
             .unify(Format::Option(Box::new(Format::Unknown)))?;
-        let format = match &mut self.format {
+        let format = match self.format {
             Format::Option(x) => x,
             _ => unreachable!(),
         };
@@ -246,12 +246,12 @@ impl<'de, 'a> de::Deserializer<'de> for Deserializer<'a> {
         Ok(value)
     }
 
-    fn deserialize_seq<V>(mut self, visitor: V) -> Result<V::Value>
+    fn deserialize_seq<V>(self, visitor: V) -> Result<V::Value>
     where
         V: Visitor<'de>,
     {
         self.format.unify(Format::Seq(Box::new(Format::Unknown)))?;
-        let format = match &mut self.format {
+        let format = match self.format {
             Format::Seq(x) => x,
             _ => unreachable!(),
         };
@@ -266,13 +266,13 @@ impl<'de, 'a> de::Deserializer<'de> for Deserializer<'a> {
         }
     }
 
-    fn deserialize_tuple<V>(mut self, len: usize, visitor: V) -> Result<V::Value>
+    fn deserialize_tuple<V>(self, len: usize, visitor: V) -> Result<V::Value>
     where
         V: Visitor<'de>,
     {
         self.format
             .unify(Format::Tuple(vec![Format::Unknown; len]))?;
-        let formats = match &mut self.format {
+        let formats = match self.format {
             Format::Tuple(x) => x,
             _ => unreachable!(),
         };
@@ -309,7 +309,7 @@ impl<'de, 'a> de::Deserializer<'de> for Deserializer<'a> {
         Ok(value)
     }
 
-    fn deserialize_map<V>(mut self, visitor: V) -> Result<V::Value>
+    fn deserialize_map<V>(self, visitor: V) -> Result<V::Value>
     where
         V: Visitor<'de>,
     {
@@ -317,7 +317,7 @@ impl<'de, 'a> de::Deserializer<'de> for Deserializer<'a> {
             key: Box::new(Format::Unknown),
             value: Box::new(Format::Unknown),
         })?;
-        let formats = match &mut self.format {
+        let formats = match self.format {
             Format::Map { key, value } => vec![key.as_mut(), value.as_mut()],
             _ => unreachable!(),
         };
@@ -557,13 +557,13 @@ impl<'de, 'a> de::VariantAccess<'de> for EnumDeserializer<'a> {
         self.format.unify(VariantFormat::Unit)
     }
 
-    fn newtype_variant_seed<T>(mut self, seed: T) -> Result<T::Value>
+    fn newtype_variant_seed<T>(self, seed: T) -> Result<T::Value>
     where
         T: DeserializeSeed<'de>,
     {
         self.format
             .unify(VariantFormat::NewType(Box::new(Format::Unknown)))?;
-        let format = match &mut self.format {
+        let format = match self.format {
             VariantFormat::NewType(x) => x.as_mut(),
             _ => unreachable!(),
         };
@@ -571,13 +571,13 @@ impl<'de, 'a> de::VariantAccess<'de> for EnumDeserializer<'a> {
         seed.deserialize(inner)
     }
 
-    fn tuple_variant<V>(mut self, len: usize, visitor: V) -> Result<V::Value>
+    fn tuple_variant<V>(self, len: usize, visitor: V) -> Result<V::Value>
     where
         V: Visitor<'de>,
     {
         self.format
             .unify(VariantFormat::Tuple(vec![Format::Unknown; len]))?;
-        let formats = match &mut self.format {
+        let formats = match self.format {
             VariantFormat::Tuple(x) => x,
             _ => unreachable!(),
         };
@@ -585,7 +585,7 @@ impl<'de, 'a> de::VariantAccess<'de> for EnumDeserializer<'a> {
         visitor.visit_seq(inner)
     }
 
-    fn struct_variant<V>(mut self, fields: &'static [&'static str], visitor: V) -> Result<V::Value>
+    fn struct_variant<V>(self, fields: &'static [&'static str], visitor: V) -> Result<V::Value>
     where
         V: Visitor<'de>,
     {
@@ -598,7 +598,7 @@ impl<'de, 'a> de::VariantAccess<'de> for EnumDeserializer<'a> {
             .collect();
         self.format.unify(VariantFormat::Struct(formats))?;
 
-        let formats = match &mut self.format {
+        let formats = match self.format {
             VariantFormat::Struct(x) => x,
             _ => unreachable!(),
         };

--- a/common/serde-reflection/src/de.rs
+++ b/common/serde-reflection/src/de.rs
@@ -4,21 +4,21 @@
 use crate::{
     error::{Error, Result},
     format::{ContainerFormat, ContainerFormatEntry, Format, FormatHolder, Named, VariantFormat},
-    trace::{Records, Tracer},
+    trace::{SerializationRecords, Tracer},
 };
 use serde::de::{self, DeserializeSeed, IntoDeserializer, Visitor};
 use std::collections::BTreeMap;
 
 pub(crate) struct Deserializer<'de, 'a> {
     tracer: &'a mut Tracer,
-    records: &'de Records,
+    records: &'de SerializationRecords,
     format: &'a mut Format,
 }
 
 impl<'de, 'a> Deserializer<'de, 'a> {
     pub(crate) fn new(
         tracer: &'a mut Tracer,
-        records: &'de Records,
+        records: &'de SerializationRecords,
         format: &'a mut Format,
     ) -> Self {
         Deserializer {
@@ -464,12 +464,12 @@ impl<'de, 'a> de::Deserializer<'de> for Deserializer<'de, 'a> {
 
 struct SeqDeserializer<'de, 'a, I> {
     tracer: &'a mut Tracer,
-    records: &'de Records,
+    records: &'de SerializationRecords,
     formats: I,
 }
 
 impl<'de, 'a, I> SeqDeserializer<'de, 'a, I> {
-    fn new(tracer: &'a mut Tracer, records: &'de Records, formats: I) -> Self {
+    fn new(tracer: &'a mut Tracer, records: &'de SerializationRecords, formats: I) -> Self {
         Self {
             tracer,
             records,
@@ -539,7 +539,7 @@ where
 
 struct EnumDeserializer<'de, 'a> {
     tracer: &'a mut Tracer,
-    records: &'de Records,
+    records: &'de SerializationRecords,
     index: u32,
     format: &'a mut VariantFormat,
 }
@@ -547,7 +547,7 @@ struct EnumDeserializer<'de, 'a> {
 impl<'de, 'a> EnumDeserializer<'de, 'a> {
     fn new(
         tracer: &'a mut Tracer,
-        records: &'de Records,
+        records: &'de SerializationRecords,
         index: u32,
         format: &'a mut VariantFormat,
     ) -> Self {

--- a/common/serde-reflection/src/de.rs
+++ b/common/serde-reflection/src/de.rs
@@ -231,7 +231,7 @@ impl<'de, 'a> de::Deserializer<'de> for Deserializer<'de, 'a> {
         if let Some((format, hint)) = self.tracer.get_recorded_value(self.records, name) {
             // Hints are recorded during serialization-tracing therefore the registry is already accurate.
             return visitor
-                .visit_newtype_struct(hint.clone().into_deserializer())
+                .visit_newtype_struct(hint.into_deserializer())
                 .map_err(|err| match err {
                     Error::DeserializationError(msg) => {
                         Error::UnexpectedDeserializationFormat(name, format.clone(), msg)

--- a/common/serde-reflection/src/de.rs
+++ b/common/serde-reflection/src/de.rs
@@ -9,6 +9,11 @@ use crate::{
 use serde::de::{self, DeserializeSeed, IntoDeserializer, Visitor};
 use std::collections::BTreeMap;
 
+/// Deserialize a single value.
+/// * The lifetime 'a is set by the deserialization call site and the
+/// `&'a mut` references used to return tracing results.
+/// * The lifetime 'de is fixed and the `&'de` reference meant to let us
+/// borrow values from previous serialization runs.
 pub(crate) struct Deserializer<'de, 'a> {
     tracer: &'a mut Tracer,
     records: &'de SerializationRecords,

--- a/common/serde-reflection/src/format.rs
+++ b/common/serde-reflection/src/format.rs
@@ -262,7 +262,7 @@ impl FormatHolder for ContainerFormat {
     }
 
     fn normalize(&mut self) -> Result<()> {
-        match &mut *self {
+        match self {
             Self::UnitStruct => Ok(()),
 
             Self::NewTypeStruct(format) => format.normalize(),
@@ -370,7 +370,7 @@ impl FormatHolder for Format {
 
     fn normalize(&mut self) -> Result<()> {
         let normalized_tuple;
-        match &mut *self {
+        match self {
             Self::TypeName(_)
             | Self::Unit
             | Self::Bool
@@ -411,7 +411,7 @@ impl FormatHolder for Format {
 
             // The only case where compression happens.
             Self::Tuple(formats) => {
-                for format in &mut *formats {
+                for format in formats.iter_mut() {
                     format.normalize()?;
                 }
                 let size = formats.len();

--- a/common/serde-reflection/src/lib.rs
+++ b/common/serde-reflection/src/lib.rs
@@ -55,15 +55,16 @@
 //! # fn main() -> Result<(), Error> {
 //! // Start a session to trace formats.
 //! let mut tracer = Tracer::new(/* is_human_readable */ false);
+//! let mut records = Records::new();
 //!
 //! // For every type (here `Name`), if a user-defined implementation of `Deserialize` exists and
 //! // is known to perform custom validation checks, start by tracing the serialization of
 //! // a valid value of this type.
 //! let bob = Name("Bob".into());
-//! tracer.trace_value(&bob)?;
+//! tracer.trace_value(&mut records, &bob)?;
 //!
 //! // Now, let's trace deserialization for the top-level type `Person`.
-//! let (format, values) = tracer.trace_type::<Person>()?;
+//! let (format, values) = tracer.trace_type::<Person>(&records)?;
 //! assert_eq!(format, Format::TypeName("Person".into()));
 //!
 //! // As a byproduct, we have also obtained sample values of type `Person`.
@@ -126,7 +127,8 @@
 //!
 //! # fn main() -> Result<(), Error> {
 //! let mut tracer = Tracer::new(/* is_human_readable */ false);
-//! tracer.trace_value(&FullName { first: "", middle: Some(""), last: "" })?;
+//! let mut records = Records::new();
+//! tracer.trace_value(&mut records, &FullName { first: "", middle: Some(""), last: "" })?;
 //! let registry = tracer.registry()?;
 //! match registry.get("FullName").unwrap() {
 //!     ContainerFormat::Struct(fields) => assert_eq!(fields.len(), 3),
@@ -155,7 +157,8 @@
 //! # }
 //! # fn main() -> Result<(), Error> {
 //! let mut tracer = Tracer::new(/* is_human_readable */ false);
-//! tracer.trace_value(&FullName { first: "", middle: None, last: "" })?;
+//! let mut records = Records::new();
+//! tracer.trace_value(&mut records, &FullName { first: "", middle: None, last: "" })?;
 //! assert_eq!(tracer.registry().unwrap_err(), Error::UnknownFormatInContainer("FullName"));
 //! # Ok(())
 //! # }
@@ -229,5 +232,5 @@ mod value;
 
 pub use error::{Error, Result};
 pub use format::{ContainerFormat, Format, FormatHolder, Named, VariantFormat};
-pub use trace::{Registry, RegistryOwned, Tracer};
+pub use trace::{Records, Registry, RegistryOwned, Tracer};
 pub use value::Value;

--- a/common/serde-reflection/src/lib.rs
+++ b/common/serde-reflection/src/lib.rs
@@ -55,16 +55,18 @@
 //! # fn main() -> Result<(), Error> {
 //! // Start a session to trace formats.
 //! let mut tracer = Tracer::new(/* is_human_readable */ false);
+//! // Create a store to hold samples of Rust values.
 //! let mut records = SerializationRecords::new();
 //!
 //! // For every type (here `Name`), if a user-defined implementation of `Deserialize` exists and
-//! // is known to perform custom validation checks, start by tracing the serialization of
-//! // a valid value of this type. These sampled values are stored in `records`.
+//! // is known to perform custom validation checks, use `trace_value` first so that `records`
+//! // contains a valid Rust value of this type.
 //! let bob = Name("Bob".into());
 //! tracer.trace_value(&mut records, &bob)?;
+//! assert!(records.value("Name").is_some());
 //!
 //! // Now, let's trace deserialization for the top-level type `Person`.
-//! // We pass a reference to `records` so that sampled values can be used.
+//! // We pass a reference to `records` so that sampled values are used for custom types.
 //! let (format, values) = tracer.trace_type::<Person>(&records)?;
 //! assert_eq!(format, Format::TypeName("Person".into()));
 //!

--- a/common/serde-reflection/src/lib.rs
+++ b/common/serde-reflection/src/lib.rs
@@ -55,15 +55,16 @@
 //! # fn main() -> Result<(), Error> {
 //! // Start a session to trace formats.
 //! let mut tracer = Tracer::new(/* is_human_readable */ false);
-//! let mut records = Records::new();
+//! let mut records = SerializationRecords::new();
 //!
 //! // For every type (here `Name`), if a user-defined implementation of `Deserialize` exists and
 //! // is known to perform custom validation checks, start by tracing the serialization of
-//! // a valid value of this type.
+//! // a valid value of this type. These sampled values are stored in `records`.
 //! let bob = Name("Bob".into());
 //! tracer.trace_value(&mut records, &bob)?;
 //!
 //! // Now, let's trace deserialization for the top-level type `Person`.
+//! // We pass a reference to `records` so that sampled values can be used.
 //! let (format, values) = tracer.trace_type::<Person>(&records)?;
 //! assert_eq!(format, Format::TypeName("Person".into()));
 //!
@@ -127,7 +128,7 @@
 //!
 //! # fn main() -> Result<(), Error> {
 //! let mut tracer = Tracer::new(/* is_human_readable */ false);
-//! let mut records = Records::new();
+//! let mut records = SerializationRecords::new();
 //! tracer.trace_value(&mut records, &FullName { first: "", middle: Some(""), last: "" })?;
 //! let registry = tracer.registry()?;
 //! match registry.get("FullName").unwrap() {
@@ -157,7 +158,7 @@
 //! # }
 //! # fn main() -> Result<(), Error> {
 //! let mut tracer = Tracer::new(/* is_human_readable */ false);
-//! let mut records = Records::new();
+//! let mut records = SerializationRecords::new();
 //! tracer.trace_value(&mut records, &FullName { first: "", middle: None, last: "" })?;
 //! assert_eq!(tracer.registry().unwrap_err(), Error::UnknownFormatInContainer("FullName"));
 //! # Ok(())
@@ -232,5 +233,5 @@ mod value;
 
 pub use error::{Error, Result};
 pub use format::{ContainerFormat, Format, FormatHolder, Named, VariantFormat};
-pub use trace::{Records, Registry, RegistryOwned, Tracer};
+pub use trace::{Registry, RegistryOwned, SerializationRecords, Tracer};
 pub use value::Value;

--- a/common/serde-reflection/src/ser.rs
+++ b/common/serde-reflection/src/ser.rs
@@ -9,6 +9,9 @@ use crate::{
 };
 use serde::{ser, Serialize};
 
+/// Serialize a single value.
+/// The lifetime 'a is set by the serialization call site and the `&'a mut`
+/// references used to return tracing results and serialization records.
 pub(crate) struct Serializer<'a> {
     tracer: &'a mut Tracer,
     records: &'a mut SerializationRecords,

--- a/common/serde-reflection/src/ser.rs
+++ b/common/serde-reflection/src/ser.rs
@@ -4,18 +4,18 @@
 use crate::{
     error::{Error, Result},
     format::*,
-    trace::{Records, Tracer},
+    trace::{SerializationRecords, Tracer},
     value::Value,
 };
 use serde::{ser, Serialize};
 
 pub(crate) struct Serializer<'a> {
     tracer: &'a mut Tracer,
-    records: &'a mut Records,
+    records: &'a mut SerializationRecords,
 }
 
 impl<'a> Serializer<'a> {
-    pub(crate) fn new(tracer: &'a mut Tracer, records: &'a mut Records) -> Self {
+    pub(crate) fn new(tracer: &'a mut Tracer, records: &'a mut SerializationRecords) -> Self {
         Self { tracer, records }
     }
 }
@@ -264,7 +264,7 @@ impl<'a> ser::Serializer for Serializer<'a> {
 
 pub struct SeqSerializer<'a> {
     tracer: &'a mut Tracer,
-    records: &'a mut Records,
+    records: &'a mut SerializationRecords,
 
     format: Format,
     values: Vec<Value>,
@@ -291,7 +291,7 @@ impl<'a> ser::SerializeSeq for SeqSerializer<'a> {
 
 pub struct TupleSerializer<'a> {
     tracer: &'a mut Tracer,
-    records: &'a mut Records,
+    records: &'a mut SerializationRecords,
 
     formats: Vec<Format>,
     values: Vec<Value>,
@@ -318,7 +318,7 @@ impl<'a> ser::SerializeTuple for TupleSerializer<'a> {
 
 pub struct TupleStructSerializer<'a> {
     tracer: &'a mut Tracer,
-    records: &'a mut Records,
+    records: &'a mut SerializationRecords,
 
     name: &'static str,
     formats: Vec<Format>,
@@ -349,7 +349,7 @@ impl<'a> ser::SerializeTupleStruct for TupleStructSerializer<'a> {
 
 pub struct TupleVariantSerializer<'a> {
     tracer: &'a mut Tracer,
-    records: &'a mut Records,
+    records: &'a mut SerializationRecords,
 
     name: &'static str,
     variant_index: u32,
@@ -388,7 +388,7 @@ impl<'a> ser::SerializeTupleVariant for TupleVariantSerializer<'a> {
 
 pub struct MapSerializer<'a> {
     tracer: &'a mut Tracer,
-    records: &'a mut Records,
+    records: &'a mut SerializationRecords,
 
     key_format: Format,
     value_format: Format,
@@ -431,7 +431,7 @@ impl<'a> ser::SerializeMap for MapSerializer<'a> {
 
 pub struct StructSerializer<'a> {
     tracer: &'a mut Tracer,
-    records: &'a mut Records,
+    records: &'a mut SerializationRecords,
 
     name: &'static str,
     fields: Vec<Named<Format>>,
@@ -465,7 +465,7 @@ impl<'a> ser::SerializeStruct for StructSerializer<'a> {
 
 pub struct StructVariantSerializer<'a> {
     tracer: &'a mut Tracer,
-    records: &'a mut Records,
+    records: &'a mut SerializationRecords,
     name: &'static str,
     variant_index: u32,
     variant_name: &'static str,

--- a/common/serde-reflection/src/ser.rs
+++ b/common/serde-reflection/src/ser.rs
@@ -133,15 +133,11 @@ impl<'a> ser::Serializer for Serializer<'a> {
         )
     }
 
-    fn serialize_newtype_struct<T>(
-        mut self,
-        name: &'static str,
-        value: &T,
-    ) -> Result<(Format, Value)>
+    fn serialize_newtype_struct<T>(self, name: &'static str, value: &T) -> Result<(Format, Value)>
     where
         T: ?Sized + Serialize,
     {
-        let (format, value) = value.serialize(Serializer::new(&mut self.tracer))?;
+        let (format, value) = value.serialize(Serializer::new(self.tracer))?;
         self.tracer.record_container(
             name,
             ContainerFormat::NewTypeStruct(Box::new(format)),
@@ -150,7 +146,7 @@ impl<'a> ser::Serializer for Serializer<'a> {
     }
 
     fn serialize_newtype_variant<T>(
-        mut self,
+        self,
         name: &'static str,
         variant_index: u32,
         variant_name: &'static str,
@@ -159,7 +155,7 @@ impl<'a> ser::Serializer for Serializer<'a> {
     where
         T: ?Sized + Serialize,
     {
-        let (format, value) = value.serialize(Serializer::new(&mut self.tracer))?;
+        let (format, value) = value.serialize(Serializer::new(self.tracer))?;
         self.tracer.record_variant(
             name,
             variant_index,
@@ -171,7 +167,7 @@ impl<'a> ser::Serializer for Serializer<'a> {
 
     fn serialize_seq(self, _len: Option<usize>) -> Result<Self::SerializeSeq> {
         Ok(SeqSerializer {
-            tracer: &mut *self.tracer,
+            tracer: self.tracer,
             format: Format::Unknown,
             values: Vec::new(),
         })
@@ -179,7 +175,7 @@ impl<'a> ser::Serializer for Serializer<'a> {
 
     fn serialize_tuple(self, _len: usize) -> Result<Self::SerializeTuple> {
         Ok(TupleSerializer {
-            tracer: &mut *self.tracer,
+            tracer: self.tracer,
             formats: Vec::new(),
             values: Vec::new(),
         })
@@ -191,7 +187,7 @@ impl<'a> ser::Serializer for Serializer<'a> {
         _len: usize,
     ) -> Result<Self::SerializeTupleStruct> {
         Ok(TupleStructSerializer {
-            tracer: &mut *self.tracer,
+            tracer: self.tracer,
             name,
             formats: Vec::new(),
             values: Vec::new(),
@@ -206,7 +202,7 @@ impl<'a> ser::Serializer for Serializer<'a> {
         _len: usize,
     ) -> Result<Self::SerializeTupleVariant> {
         Ok(TupleVariantSerializer {
-            tracer: &mut *self.tracer,
+            tracer: self.tracer,
             name,
             variant_index,
             variant_name,
@@ -217,7 +213,7 @@ impl<'a> ser::Serializer for Serializer<'a> {
 
     fn serialize_map(self, _len: Option<usize>) -> Result<Self::SerializeMap> {
         Ok(MapSerializer {
-            tracer: &mut *self.tracer,
+            tracer: self.tracer,
             key_format: Format::Unknown,
             value_format: Format::Unknown,
             values: Vec::new(),
@@ -226,7 +222,7 @@ impl<'a> ser::Serializer for Serializer<'a> {
 
     fn serialize_struct(self, name: &'static str, _len: usize) -> Result<Self::SerializeStruct> {
         Ok(StructSerializer {
-            tracer: &mut *self.tracer,
+            tracer: self.tracer,
             name,
             fields: Vec::new(),
             values: Vec::new(),
@@ -241,7 +237,7 @@ impl<'a> ser::Serializer for Serializer<'a> {
         _len: usize,
     ) -> Result<Self::SerializeStructVariant> {
         Ok(StructVariantSerializer {
-            tracer: &mut *self.tracer,
+            tracer: self.tracer,
             name,
             variant_index,
             variant_name,
@@ -269,7 +265,7 @@ impl<'a> ser::SerializeSeq for SeqSerializer<'a> {
     where
         T: ?Sized + Serialize,
     {
-        let (format, value) = value.serialize(Serializer::new(&mut self.tracer))?;
+        let (format, value) = value.serialize(Serializer::new(self.tracer))?;
         self.format.unify(format)?;
         self.values.push(value);
         Ok(())
@@ -294,7 +290,7 @@ impl<'a> ser::SerializeTuple for TupleSerializer<'a> {
     where
         T: ?Sized + Serialize,
     {
-        let (format, value) = value.serialize(Serializer::new(&mut self.tracer))?;
+        let (format, value) = value.serialize(Serializer::new(self.tracer))?;
         self.formats.push(format);
         self.values.push(value);
         Ok(())
@@ -320,7 +316,7 @@ impl<'a> ser::SerializeTupleStruct for TupleStructSerializer<'a> {
     where
         T: ?Sized + Serialize,
     {
-        let (format, value) = value.serialize(Serializer::new(&mut self.tracer))?;
+        let (format, value) = value.serialize(Serializer::new(self.tracer))?;
         self.formats.push(format);
         self.values.push(value);
         Ok(())
@@ -350,7 +346,7 @@ impl<'a> ser::SerializeTupleVariant for TupleVariantSerializer<'a> {
     where
         T: ?Sized + Serialize,
     {
-        let (format, value) = v.serialize(Serializer::new(&mut self.tracer))?;
+        let (format, value) = v.serialize(Serializer::new(self.tracer))?;
         self.formats.push(format);
         self.values.push(value);
         Ok(())
@@ -384,7 +380,7 @@ impl<'a> ser::SerializeMap for MapSerializer<'a> {
     where
         T: ?Sized + Serialize,
     {
-        let (format, value) = key.serialize(Serializer::new(&mut self.tracer))?;
+        let (format, value) = key.serialize(Serializer::new(self.tracer))?;
         self.key_format.unify(format)?;
         self.values.push(value);
         Ok(())
@@ -394,7 +390,7 @@ impl<'a> ser::SerializeMap for MapSerializer<'a> {
     where
         T: ?Sized + Serialize,
     {
-        let (format, value) = value.serialize(Serializer::new(&mut self.tracer))?;
+        let (format, value) = value.serialize(Serializer::new(self.tracer))?;
         self.value_format.unify(format)?;
         self.values.push(value);
         Ok(())
@@ -425,7 +421,7 @@ impl<'a> ser::SerializeStruct for StructSerializer<'a> {
     where
         T: ?Sized + Serialize,
     {
-        let (format, value) = value.serialize(Serializer::new(&mut self.tracer))?;
+        let (format, value) = value.serialize(Serializer::new(self.tracer))?;
         self.fields.push(Named {
             name: name.into(),
             value: format,
@@ -458,7 +454,7 @@ impl<'a> ser::SerializeStructVariant for StructVariantSerializer<'a> {
     where
         T: ?Sized + Serialize,
     {
-        let (format, value) = value.serialize(Serializer::new(&mut self.tracer))?;
+        let (format, value) = value.serialize(Serializer::new(self.tracer))?;
         self.fields.push(Named {
             name: name.into(),
             value: format,

--- a/common/serde-reflection/src/trace.rs
+++ b/common/serde-reflection/src/trace.rs
@@ -72,7 +72,7 @@ impl Tracer {
         T: Deserialize<'de>,
     {
         let mut format = Format::Unknown;
-        let deserializer = Deserializer::new(&mut *self, &mut format);
+        let deserializer = Deserializer::new(self, &mut format);
         let value = T::deserialize(deserializer)?;
         Ok((format, value))
     }
@@ -83,7 +83,7 @@ impl Tracer {
         S: DeserializeSeed<'de>,
     {
         let mut format = Format::Unknown;
-        let deserializer = Deserializer::new(&mut *self, &mut format);
+        let deserializer = Deserializer::new(self, &mut format);
         let value = seed.deserialize(deserializer)?;
         Ok((format, value))
     }

--- a/common/serde-reflection/src/trace.rs
+++ b/common/serde-reflection/src/trace.rs
@@ -28,13 +28,24 @@ pub struct Tracer {
     /// serialization and/or deserialization.
     pub(crate) registry: Registry,
 
-    /// Value samples recorded during serialization.
-    /// This will help passing user-defined checks during deserialization.
-    values: BTreeMap<&'static str, Value>,
-
     /// Enums that have detected to be yet incomplete (i.e. missing variants)
     /// while tracing deserialization.
     pub(crate) incomplete_enums: BTreeSet<String>,
+}
+
+/// Value samples recorded during serialization.
+/// This will help passing user-defined checks during deserialization.
+#[derive(Debug, Default)]
+pub struct Records {
+    pub(crate) values: BTreeMap<&'static str, Value>,
+}
+
+impl Records {
+    pub fn new() -> Self {
+        Self {
+            values: BTreeMap::new(),
+        }
+    }
 }
 
 impl Tracer {
@@ -43,7 +54,6 @@ impl Tracer {
         Self {
             is_human_readable,
             registry: BTreeMap::new(),
-            values: BTreeMap::new(),
             incomplete_enums: BTreeSet::new(),
         }
     }
@@ -51,11 +61,11 @@ impl Tracer {
     /// Trace the serialization of a particular value.
     /// Nested containers will be added to the tracing registry, indexed by
     /// their (non-qualified) name.
-    pub fn trace_value<T>(&mut self, value: &T) -> Result<(Format, Value)>
+    pub fn trace_value<T>(&mut self, records: &mut Records, value: &T) -> Result<(Format, Value)>
     where
         T: ?Sized + Serialize,
     {
-        let serializer = Serializer::new(self);
+        let serializer = Serializer::new(self, records);
         value.serialize(serializer)
     }
 
@@ -67,23 +77,27 @@ impl Tracer {
     /// have implemented a custom deserializer that validates data. In this case,
     /// `trace_value` must be called first on the relevant user types to provide valid
     /// examples.
-    pub fn trace_type_once<'de, T>(&mut self) -> Result<(Format, T)>
+    pub fn trace_type_once<'de, T>(&mut self, records: &'de Records) -> Result<(Format, T)>
     where
         T: Deserialize<'de>,
     {
         let mut format = Format::Unknown;
-        let deserializer = Deserializer::new(self, &mut format);
+        let deserializer = Deserializer::new(self, records, &mut format);
         let value = T::deserialize(deserializer)?;
         Ok((format, value))
     }
 
     /// Same as `trace_type_once` for seeded deserialization.
-    pub fn trace_type_once_with_seed<'de, S>(&mut self, seed: S) -> Result<(Format, S::Value)>
+    pub fn trace_type_once_with_seed<'de, S>(
+        &mut self,
+        records: &'de Records,
+        seed: S,
+    ) -> Result<(Format, S::Value)>
     where
         S: DeserializeSeed<'de>,
     {
         let mut format = Format::Unknown;
-        let deserializer = Deserializer::new(self, &mut format);
+        let deserializer = Deserializer::new(self, records, &mut format);
         let value = seed.deserialize(deserializer)?;
         Ok((format, value))
     }
@@ -91,13 +105,13 @@ impl Tracer {
     /// Same as `trace_type_once` but if `T` is an enum, we repeat the process
     /// until all variants of `T` are covered.
     /// We accumulate and return all the sampled values at the end.
-    pub fn trace_type<'de, T>(&mut self) -> Result<(Format, Vec<T>)>
+    pub fn trace_type<'de, T>(&mut self, records: &'de Records) -> Result<(Format, Vec<T>)>
     where
         T: Deserialize<'de>,
     {
         let mut values = Vec::new();
         loop {
-            let (format, value) = self.trace_type_once::<T>()?;
+            let (format, value) = self.trace_type_once::<T>(records)?;
             values.push(value);
             if let Format::TypeName(name) = &format {
                 if self.incomplete_enums.contains(name) {
@@ -111,13 +125,17 @@ impl Tracer {
     }
 
     /// Same as `trace_type` for seeded deserialization.
-    pub fn trace_type_with_seed<'de, S>(&'de mut self, seed: S) -> Result<(Format, Vec<S::Value>)>
+    pub fn trace_type_with_seed<'de, S>(
+        &mut self,
+        records: &'de Records,
+        seed: S,
+    ) -> Result<(Format, Vec<S::Value>)>
     where
         S: DeserializeSeed<'de> + Clone,
     {
         let mut values = Vec::new();
         loop {
-            let (format, value) = self.trace_type_once_with_seed(seed.clone())?;
+            let (format, value) = self.trace_type_once_with_seed(records, seed.clone())?;
             values.push(value);
             if let Format::TypeName(name) = &format {
                 if self.incomplete_enums.contains(name) {
@@ -164,17 +182,19 @@ impl Tracer {
 
     pub(crate) fn record_container(
         &mut self,
+        records: &mut Records,
         name: &'static str,
         format: ContainerFormat,
         value: Value,
     ) -> Result<(Format, Value)> {
         self.registry.entry(name).unify(format)?;
-        self.values.insert(name, value.clone());
+        records.values.insert(name, value.clone());
         Ok((Format::TypeName(name.into()), value))
     }
 
     pub(crate) fn record_variant(
         &mut self,
+        records: &mut Records,
         name: &'static str,
         variant_index: u32,
         variant_name: &'static str,
@@ -191,14 +211,15 @@ impl Tracer {
         );
         let format = ContainerFormat::Enum(variants);
         let value = Value::Variant(variant_index, Box::new(variant_value));
-        self.record_container(name, format, value)
+        self.record_container(records, name, format, value)
     }
 
-    pub(crate) fn get_recorded_value(
-        &mut self,
+    pub(crate) fn get_recorded_value<'de, 'a>(
+        &'a self,
+        records: &'de Records,
         name: &'static str,
-    ) -> Option<(&ContainerFormat, &Value)> {
-        match self.values.get(name) {
+    ) -> Option<(&'a ContainerFormat, &'de Value)> {
+        match records.values.get(name) {
             Some(value) => {
                 let format = self
                     .registry

--- a/common/serde-reflection/src/value.rs
+++ b/common/serde-reflection/src/value.rs
@@ -36,18 +36,18 @@ pub enum Value {
 }
 
 /// Deserializer meant to reconstruct the Rust value behind a particular Serde value.
-pub struct Deserializer {
-    value: Value,
+pub struct Deserializer<'de> {
+    value: &'de Value,
 }
 
-impl Deserializer {
-    pub fn new(value: Value) -> Self {
+impl<'de> Deserializer<'de> {
+    pub fn new(value: &'de Value) -> Self {
         Self { value }
     }
 }
 
-impl<'de> IntoDeserializer<'de, Error> for Value {
-    type Deserializer = Deserializer;
+impl<'de> IntoDeserializer<'de, Error> for &'de Value {
+    type Deserializer = Deserializer<'de>;
 
     fn into_deserializer(self) -> Self::Deserializer {
         Deserializer::new(self)
@@ -61,6 +61,20 @@ macro_rules! declare_deserialize {
             V: Visitor<'de>,
         {
             match self.value {
+                Value::$token(x) => visitor.$visit(x.clone()),
+                _ => Err(Error::DeserializationError($str)),
+            }
+        }
+    }
+}
+
+macro_rules! declare_deserialize_borrowed {
+    ($method:ident, $token:ident, $visit:ident, $str:expr) => {
+        fn $method<V>(self, visitor: V) -> Result<V::Value>
+        where
+            V: Visitor<'de>,
+        {
+            match self.value {
                 Value::$token(x) => visitor.$visit(x),
                 _ => Err(Error::DeserializationError($str)),
             }
@@ -68,7 +82,7 @@ macro_rules! declare_deserialize {
     }
 }
 
-impl<'de> de::Deserializer<'de> for Deserializer {
+impl<'de> de::Deserializer<'de> for Deserializer<'de> {
     type Error = Error;
 
     fn deserialize_any<V>(self, _visitor: V) -> Result<V::Value>
@@ -97,9 +111,9 @@ impl<'de> de::Deserializer<'de> for Deserializer {
 
     declare_deserialize!(deserialize_char, Char, visit_char, "char");
     declare_deserialize!(deserialize_string, Str, visit_string, "string");
-    declare_deserialize!(deserialize_str, Str, visit_string, "str");
+    declare_deserialize_borrowed!(deserialize_str, Str, visit_borrowed_str, "str");
     declare_deserialize!(deserialize_byte_buf, Bytes, visit_byte_buf, "byte_buf");
-    declare_deserialize!(deserialize_bytes, Bytes, visit_byte_buf, "bytes");
+    declare_deserialize_borrowed!(deserialize_bytes, Bytes, visit_borrowed_bytes, "bytes");
 
     fn deserialize_option<V>(self, visitor: V) -> Result<V::Value>
     where
@@ -210,7 +224,7 @@ impl<'de> de::Deserializer<'de> for Deserializer {
     {
         match self.value {
             Value::Variant(index, variant) => {
-                let inner = EnumDeserializer::new(index, *variant);
+                let inner = EnumDeserializer::new(*index, &*variant);
                 visitor.visit_enum(inner)
             }
             _ => Err(Error::DeserializationError("enum")),
@@ -253,17 +267,17 @@ impl<I> SeqDeserializer<I> {
     }
 }
 
-impl IntoSeqDeserializer for Vec<Value> {
-    type SeqDeserializer = SeqDeserializer<std::vec::IntoIter<Value>>;
+impl<'de> IntoSeqDeserializer for &'de Vec<Value> {
+    type SeqDeserializer = SeqDeserializer<std::slice::Iter<'de, Value>>;
 
     fn into_seq_deserializer(self) -> Self::SeqDeserializer {
-        SeqDeserializer::new(self.into_iter())
+        SeqDeserializer::new(self.iter())
     }
 }
 
 impl<'de, I> de::SeqAccess<'de> for SeqDeserializer<I>
 where
-    I: Iterator<Item = Value>,
+    I: Iterator<Item = &'de Value>,
 {
     type Error = Error;
 
@@ -284,7 +298,7 @@ where
 
 impl<'de, I> de::MapAccess<'de> for SeqDeserializer<I>
 where
-    I: Iterator<Item = Value>,
+    I: Iterator<Item = &'de Value>,
 {
     type Error = Error;
 
@@ -313,18 +327,18 @@ where
     }
 }
 
-struct EnumDeserializer {
+struct EnumDeserializer<'de> {
     index: u32,
-    value: Value,
+    value: &'de Value,
 }
 
-impl EnumDeserializer {
-    fn new(index: u32, value: Value) -> Self {
+impl<'de> EnumDeserializer<'de> {
+    fn new(index: u32, value: &'de Value) -> Self {
         Self { index, value }
     }
 }
 
-impl<'de> de::EnumAccess<'de> for EnumDeserializer {
+impl<'de> de::EnumAccess<'de> for EnumDeserializer<'de> {
     type Error = Error;
     type Variant = Self;
 
@@ -337,7 +351,7 @@ impl<'de> de::EnumAccess<'de> for EnumDeserializer {
     }
 }
 
-impl<'de> de::VariantAccess<'de> for EnumDeserializer {
+impl<'de> de::VariantAccess<'de> for EnumDeserializer<'de> {
     type Error = Error;
 
     fn unit_variant(self) -> Result<()> {

--- a/common/serde-reflection/tests/serde.rs
+++ b/common/serde-reflection/tests/serde.rs
@@ -195,6 +195,7 @@ fn test_trace_deserialization_with_custom_invariants() {
     let (format, value) = tracer.trace_value(&mut records, &bob).unwrap();
     assert_eq!(format, Format::TypeName("Name".into()));
     assert_eq!(value, Value::Str("Bob".into()));
+    assert_eq!(records.value("Name"), Some(&value));
 
     // Now try again.
     let (format, samples) = tracer.trace_type::<Person>(&records).unwrap();

--- a/common/serde-reflection/tests/serde.rs
+++ b/common/serde-reflection/tests/serde.rs
@@ -5,7 +5,7 @@ use bincode;
 use serde::{de::IntoDeserializer, Deserialize, Serialize};
 use serde_json;
 use serde_reflection::{
-    ContainerFormat, Error, Format, Named, Records, Tracer, Value, VariantFormat,
+    ContainerFormat, Error, Format, Named, SerializationRecords, Tracer, Value, VariantFormat,
 };
 use serde_yaml;
 use std::collections::BTreeMap;
@@ -20,7 +20,7 @@ enum E {
 }
 
 fn test_variant(tracer: &mut Tracer, expr: E, expected_value: Value) {
-    let mut records = Records::new();
+    let mut records = SerializationRecords::new();
     let (format, value) = tracer.trace_value(&mut records, &expr).unwrap();
     // Check the local result of tracing.
     assert_eq!(format, Format::TypeName("E".into()));
@@ -130,7 +130,7 @@ fn test_tracers() {
     assert_eq!(*format, format4);
 
     // Tracing deserialization
-    let records = Records::new();
+    let records = SerializationRecords::new();
     let mut tracer = Tracer::new(/* is_human_readable */ false);
     let (ident, samples) = tracer.trace_type::<E>(&records).unwrap();
     assert_eq!(ident, Format::TypeName("E".into()));
@@ -182,7 +182,7 @@ enum Person {
 
 #[test]
 fn test_trace_deserialization_with_custom_invariants() {
-    let mut records = Records::new();
+    let mut records = SerializationRecords::new();
     let mut tracer = Tracer::new(/* is_human_readable */ false);
     // Type trace alone cannot guess a valid value for `Name`.
     assert_eq!(
@@ -258,7 +258,7 @@ mod bar {
 
 #[test]
 fn test_name_clash_not_suported() {
-    let mut records = Records::new();
+    let mut records = SerializationRecords::new();
     let mut tracer = Tracer::new(/* is_human_readable */ false);
     tracer.trace_value(&mut records, &foo::A).unwrap();
     // Repeating names is fine.
@@ -273,7 +273,7 @@ fn test_borrowed_slice() {
     struct Borrowed<'a>(&'a [u8]);
 
     let bytes = [1u8; 4];
-    let mut records = Records::new();
+    let mut records = SerializationRecords::new();
     let mut tracer = Tracer::new(/* is_human_readable */ false);
 
     let (format, value) = tracer.trace_value(&mut records, &Borrowed(&bytes)).unwrap();
@@ -298,7 +298,7 @@ fn test_borrowed_bytes() {
     struct Borrowed<'a>(#[serde(with = "serde_bytes")] &'a [u8]);
 
     let bytes = [1u8; 4];
-    let mut records = Records::new();
+    let mut records = SerializationRecords::new();
     let mut tracer = Tracer::new(/* is_human_readable */ false);
 
     let (format, value) = tracer.trace_value(&mut records, &Borrowed(&bytes)).unwrap();

--- a/common/serde-reflection/tests/serde.rs
+++ b/common/serde-reflection/tests/serde.rs
@@ -132,11 +132,11 @@ fn test_tracers() {
     // Tracing deserialization
     let records = Records::new();
     let mut tracer = Tracer::new(/* is_human_readable */ false);
-    let (ident, values) = tracer.trace_type::<E>(&records).unwrap();
+    let (ident, samples) = tracer.trace_type::<E>(&records).unwrap();
     assert_eq!(ident, Format::TypeName("E".into()));
     assert_eq!(tracer.registry().unwrap().get("E").unwrap(), format);
     assert_eq!(
-        values,
+        samples,
         vec![
             E::Unit,
             E::Newtype(0),
@@ -181,7 +181,7 @@ enum Person {
 }
 
 #[test]
-fn test_type_deserialization_with_custom_invariants() {
+fn test_trace_deserialization_with_custom_invariants() {
     let mut records = Records::new();
     let mut tracer = Tracer::new(/* is_human_readable */ false);
     // Type trace alone cannot guess a valid value for `Name`.
@@ -197,10 +197,10 @@ fn test_type_deserialization_with_custom_invariants() {
     assert_eq!(value, Value::Str("Bob".into()));
 
     // Now try again.
-    let (format, values) = tracer.trace_type::<Person>(&records).unwrap();
+    let (format, samples) = tracer.trace_type::<Person>(&records).unwrap();
     assert_eq!(format, Format::TypeName("Person".into()));
     assert_eq!(
-        values,
+        samples,
         vec![
             Person::NickName(bob.clone()),
             Person::FullName {
@@ -265,4 +265,54 @@ fn test_name_clash_not_suported() {
     assert!(tracer.trace_value(&mut records, &foo::A).is_ok());
     // but format have to match.
     assert!(tracer.trace_value(&mut records, &bar::A(0)).is_err());
+}
+
+#[test]
+fn test_borrowed_slice() {
+    #[derive(Serialize, Deserialize, PartialEq, Eq, Debug, Clone)]
+    struct Borrowed<'a>(&'a [u8]);
+
+    let bytes = [1u8; 4];
+    let mut records = Records::new();
+    let mut tracer = Tracer::new(/* is_human_readable */ false);
+
+    let (format, value) = tracer.trace_value(&mut records, &Borrowed(&bytes)).unwrap();
+    assert_eq!(format, Format::TypeName("Borrowed".into()));
+    // Slice was traced and serialized as a sequence.
+    assert_eq!(value, Value::Seq(vec![Value::U8(1); 4]));
+
+    // Unfortunately, borrowed slices can only de-serialize as bytes.
+    assert_eq!(
+        tracer.trace_type::<Borrowed>(&records),
+        Err(Error::UnexpectedDeserializationFormat(
+            "Borrowed",
+            ContainerFormat::NewTypeStruct(Box::new(Format::Seq(Box::new(Format::U8)))),
+            "bytes"
+        )),
+    );
+}
+
+#[test]
+fn test_borrowed_bytes() {
+    #[derive(Serialize, Deserialize, PartialEq, Eq, Debug, Clone)]
+    struct Borrowed<'a>(#[serde(with = "serde_bytes")] &'a [u8]);
+
+    let bytes = [1u8; 4];
+    let mut records = Records::new();
+    let mut tracer = Tracer::new(/* is_human_readable */ false);
+
+    let (format, value) = tracer.trace_value(&mut records, &Borrowed(&bytes)).unwrap();
+    assert_eq!(format, Format::TypeName("Borrowed".into()));
+    // Value was traced and serialized as a bytes.
+    assert_eq!(value, Value::Bytes(bytes.to_vec()));
+
+    let (format, samples) = tracer.trace_type::<Borrowed>(&records).unwrap();
+    assert_eq!(format, Format::TypeName("Borrowed".into()));
+    assert_eq!(samples, vec![Borrowed(&bytes),]);
+
+    let registry = tracer.registry().unwrap();
+    assert_eq!(
+        registry.get("Borrowed").unwrap(),
+        &ContainerFormat::NewTypeStruct(Box::new(Format::Bytes))
+    );
 }

--- a/common/serde-reflection/tests/serde.rs
+++ b/common/serde-reflection/tests/serde.rs
@@ -4,7 +4,9 @@
 use bincode;
 use serde::{de::IntoDeserializer, Deserialize, Serialize};
 use serde_json;
-use serde_reflection::{ContainerFormat, Error, Format, Named, Tracer, Value, VariantFormat};
+use serde_reflection::{
+    ContainerFormat, Error, Format, Named, Records, Tracer, Value, VariantFormat,
+};
 use serde_yaml;
 use std::collections::BTreeMap;
 
@@ -18,7 +20,8 @@ enum E {
 }
 
 fn test_variant(tracer: &mut Tracer, expr: E, expected_value: Value) {
-    let (format, value) = tracer.trace_value(&expr).unwrap();
+    let mut records = Records::new();
+    let (format, value) = tracer.trace_value(&mut records, &expr).unwrap();
     // Check the local result of tracing.
     assert_eq!(format, Format::TypeName("E".into()));
     assert_eq!(value, expected_value);
@@ -127,8 +130,9 @@ fn test_tracers() {
     assert_eq!(*format, format4);
 
     // Tracing deserialization
+    let records = Records::new();
     let mut tracer = Tracer::new(/* is_human_readable */ false);
-    let (ident, values) = tracer.trace_type::<E>().unwrap();
+    let (ident, values) = tracer.trace_type::<E>(&records).unwrap();
     assert_eq!(ident, Format::TypeName("E".into()));
     assert_eq!(tracer.registry().unwrap().get("E").unwrap(), format);
     assert_eq!(
@@ -178,21 +182,22 @@ enum Person {
 
 #[test]
 fn test_type_deserialization_with_custom_invariants() {
+    let mut records = Records::new();
     let mut tracer = Tracer::new(/* is_human_readable */ false);
     // Type trace alone cannot guess a valid value for `Name`.
     assert_eq!(
-        tracer.trace_type::<Person>().unwrap_err(),
+        tracer.trace_type::<Person>(&records).unwrap_err(),
         Error::Custom(format!("Invalid name {}", "")),
     );
 
     // Let's trace a sample Rust value first. We obtain an abstract value as a side effect.
     let bob = Name("Bob".into());
-    let (format, value) = tracer.trace_value(&bob).unwrap();
+    let (format, value) = tracer.trace_value(&mut records, &bob).unwrap();
     assert_eq!(format, Format::TypeName("Name".into()));
     assert_eq!(value, Value::Str("Bob".into()));
 
     // Now try again.
-    let (format, values) = tracer.trace_type::<Person>().unwrap();
+    let (format, values) = tracer.trace_type::<Person>(&records).unwrap();
     assert_eq!(format, Format::TypeName("Person".into()));
     assert_eq!(
         values,
@@ -253,10 +258,11 @@ mod bar {
 
 #[test]
 fn test_name_clash_not_suported() {
+    let mut records = Records::new();
     let mut tracer = Tracer::new(/* is_human_readable */ false);
-    tracer.trace_value(&foo::A).unwrap();
+    tracer.trace_value(&mut records, &foo::A).unwrap();
     // Repeating names is fine.
-    assert!(tracer.trace_value(&foo::A).is_ok());
+    assert!(tracer.trace_value(&mut records, &foo::A).is_ok());
     // but format have to match.
-    assert!(tracer.trace_value(&bar::A(0)).is_err());
+    assert!(tracer.trace_value(&mut records, &bar::A(0)).is_err());
 }

--- a/crypto/crypto-derive/src/lib.rs
+++ b/crypto/crypto-derive/src/lib.rs
@@ -162,10 +162,10 @@ pub fn deserialize_key(source: TokenStream) -> TokenStream {
                     // as the original type.
                     #[derive(::serde::Deserialize)]
                     #[serde(rename = #name_string)]
-                    struct Value(Vec<u8>);
+                    struct Value<'a>(&'a [u8]);
 
                     let value = Value::deserialize(deserializer)?;
-                    #name::try_from(value.0.as_slice()).map_err(|s| {
+                    #name::try_from(value.0).map_err(|s| {
                         <D::Error as ::serde::de::Error>::custom(format!("{} with {}", s, #name_string))
                     })
                 }
@@ -193,7 +193,10 @@ pub fn serialize_key(source: TokenStream) -> TokenStream {
                         .and_then(|str| serializer.serialize_str(&str[..]))
                 } else {
                     // See comment in deserialize_key.
-                    serializer.serialize_newtype_struct(#name_string, &ValidKey::to_bytes(self).as_slice())
+                    serializer.serialize_newtype_struct(
+                        #name_string,
+                        serde_bytes::Bytes::new(&ValidKey::to_bytes(self).as_slice()),
+                    )
                 }
             }
         }

--- a/crypto/crypto/Cargo.toml
+++ b/crypto/crypto/Cargo.toml
@@ -23,6 +23,7 @@ proptest = { version = "0.9.6", optional = true }
 proptest-derive = { version = "0.1.0", optional = true }
 rand = "0.6.5"
 serde = { version = "1.0.106", features = ["derive"] }
+serde_bytes = "0.11"
 sha2 = "0.8.0"
 static_assertions = { version = "1.0.0", optional = true }
 thiserror = "1.0"

--- a/crypto/crypto/src/hash.rs
+++ b/crypto/crypto/src/hash.rs
@@ -270,7 +270,8 @@ impl ser::Serialize for HashValue {
             // In order to preserve the Serde data model and help analysis tools,
             // make sure to wrap our value in a container with the same name
             // as the original type.
-            serializer.serialize_newtype_struct("HashValue", &self.hash[..])
+            serializer
+                .serialize_newtype_struct("HashValue", serde_bytes::Bytes::new(&self.hash[..]))
         }
     }
 }
@@ -287,10 +288,10 @@ impl<'de> de::Deserialize<'de> for HashValue {
             // See comment in serialize.
             #[derive(::serde::Deserialize)]
             #[serde(rename = "HashValue")]
-            struct Value(Vec<u8>);
+            struct Value<'a>(&'a [u8]);
 
             let value = Value::deserialize(deserializer)?;
-            Self::from_slice(value.0.as_slice()).map_err(<D::Error as ::serde::de::Error>::custom)
+            Self::from_slice(value.0).map_err(<D::Error as ::serde::de::Error>::custom)
         }
     }
 }

--- a/testsuite/generate-format/src/compute.rs
+++ b/testsuite/generate-format/src/compute.rs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use generate_format::{add_deserialization_tracing, add_proptest_serialization_tracing, FILE_PATH};
-use serde_reflection::Tracer;
+use serde_reflection::{Records, Tracer};
 use serde_yaml;
 use std::{fs::File, io::Write};
 use structopt::StructOpt;
@@ -23,10 +23,11 @@ struct Options {
 fn main() {
     let options = Options::from_args();
 
-    let mut tracer = Tracer::new(lcs::is_human_readable());
-    tracer = add_proptest_serialization_tracing(tracer);
+    let records = Records::new();
+    let tracer = Tracer::new(lcs::is_human_readable());
+    let (mut tracer, records) = add_proptest_serialization_tracing(tracer, records);
     if !options.skip_deserialize {
-        tracer = add_deserialization_tracing(tracer);
+        tracer = add_deserialization_tracing(tracer, &records);
     }
 
     let registry = tracer.registry().unwrap();

--- a/testsuite/generate-format/src/compute.rs
+++ b/testsuite/generate-format/src/compute.rs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use generate_format::{add_deserialization_tracing, add_proptest_serialization_tracing, FILE_PATH};
-use serde_reflection::{Records, Tracer};
+use serde_reflection::{SerializationRecords, Tracer};
 use serde_yaml;
 use std::{fs::File, io::Write};
 use structopt::StructOpt;
@@ -23,7 +23,7 @@ struct Options {
 fn main() {
     let options = Options::from_args();
 
-    let records = Records::new();
+    let records = SerializationRecords::new();
     let tracer = Tracer::new(lcs::is_human_readable());
     let (mut tracer, records) = add_proptest_serialization_tracing(tracer, records);
     if !options.skip_deserialize {

--- a/testsuite/generate-format/src/lib.rs
+++ b/testsuite/generate-format/src/lib.rs
@@ -8,7 +8,7 @@ use proptest::{
     prelude::*,
     test_runner::{Config, FileFailurePersistence, TestRunner},
 };
-use serde_reflection::{Records, Tracer};
+use serde_reflection::{SerializationRecords, Tracer};
 use std::sync::{Arc, Mutex};
 
 /// Default output file.
@@ -18,7 +18,10 @@ pub static FILE_PATH: &str = "tests/staged/libra.yaml";
 ///
 /// This step is useful to inject well-formed values that must pass
 /// custom-validation checks (e.g. keys).
-pub fn add_proptest_serialization_tracing(tracer: Tracer, records: Records) -> (Tracer, Records) {
+pub fn add_proptest_serialization_tracing(
+    tracer: Tracer,
+    records: SerializationRecords,
+) -> (Tracer, SerializationRecords) {
     let mut runner = TestRunner::new(Config {
         failure_persistence: Some(Box::new(FileFailurePersistence::Off)),
         ..Config::default()
@@ -59,7 +62,7 @@ pub fn add_proptest_serialization_tracing(tracer: Tracer, records: Records) -> (
 ///
 /// This step is useful to guarantee coverage of the analysis but it may
 /// fail if the previous step missed some custom types.
-pub fn add_deserialization_tracing(mut tracer: Tracer, records: &Records) -> Tracer {
+pub fn add_deserialization_tracing(mut tracer: Tracer, records: &SerializationRecords) -> Tracer {
     tracer
         .trace_type::<transaction::Transaction>(&records)
         .unwrap();

--- a/testsuite/generate-format/src/lib.rs
+++ b/testsuite/generate-format/src/lib.rs
@@ -8,7 +8,7 @@ use proptest::{
     prelude::*,
     test_runner::{Config, FileFailurePersistence, TestRunner},
 };
-use serde_reflection::Tracer;
+use serde_reflection::{Records, Tracer};
 use std::sync::{Arc, Mutex};
 
 /// Default output file.
@@ -18,7 +18,7 @@ pub static FILE_PATH: &str = "tests/staged/libra.yaml";
 ///
 /// This step is useful to inject well-formed values that must pass
 /// custom-validation checks (e.g. keys).
-pub fn add_proptest_serialization_tracing(tracer: Tracer) -> Tracer {
+pub fn add_proptest_serialization_tracing(tracer: Tracer, records: Records) -> (Tracer, Records) {
     let mut runner = TestRunner::new(Config {
         failure_persistence: Some(Box::new(FileFailurePersistence::Off)),
         ..Config::default()
@@ -26,33 +26,45 @@ pub fn add_proptest_serialization_tracing(tracer: Tracer) -> Tracer {
 
     // Wrap the tracer for (hypothetical) concurrent accesses.
     let tracer = Arc::new(Mutex::new(tracer));
+    let records = Arc::new(Mutex::new(records));
 
     runner
         .run(&any::<transaction::Transaction>(), |v| {
-            tracer.lock().unwrap().trace_value(&v)?;
+            tracer
+                .lock()
+                .unwrap()
+                .trace_value(&mut records.lock().unwrap(), &v)?;
             Ok(())
         })
         .unwrap();
 
     runner
         .run(&any::<contract_event::ContractEvent>(), |v| {
-            tracer.lock().unwrap().trace_value(&v)?;
+            tracer
+                .lock()
+                .unwrap()
+                .trace_value(&mut records.lock().unwrap(), &v)?;
             Ok(())
         })
         .unwrap();
 
     // Recover the Arc-mutex-ed tracer.
-    Arc::try_unwrap(tracer).unwrap().into_inner().unwrap()
+    (
+        Arc::try_unwrap(tracer).unwrap().into_inner().unwrap(),
+        Arc::try_unwrap(records).unwrap().into_inner().unwrap(),
+    )
 }
 
 /// Which Libra types to record with the deserialization tracing API.
 ///
 /// This step is useful to guarantee coverage of the analysis but it may
 /// fail if the previous step missed some custom types.
-pub fn add_deserialization_tracing(mut tracer: Tracer) -> Tracer {
-    tracer.trace_type::<transaction::Transaction>().unwrap();
+pub fn add_deserialization_tracing(mut tracer: Tracer, records: &Records) -> Tracer {
     tracer
-        .trace_type::<contract_event::ContractEvent>()
+        .trace_type::<transaction::Transaction>(&records)
+        .unwrap();
+    tracer
+        .trace_type::<contract_event::ContractEvent>(&records)
         .unwrap();
     tracer
 }

--- a/testsuite/generate-format/tests/detect_format_change.rs
+++ b/testsuite/generate-format/tests/detect_format_change.rs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use generate_format::{add_deserialization_tracing, add_proptest_serialization_tracing, FILE_PATH};
-use serde_reflection::{RegistryOwned, Tracer};
+use serde_reflection::{Records, RegistryOwned, Tracer};
 use serde_yaml;
 use std::collections::BTreeMap;
 
@@ -12,9 +12,10 @@ Please verify the changes to the recorded file(s) and tag your pull-request as `
 
 #[test]
 fn test_recorded_formats_did_not_change() {
-    let mut tracer = Tracer::new(lcs::is_human_readable());
-    tracer = add_proptest_serialization_tracing(tracer);
-    tracer = add_deserialization_tracing(tracer);
+    let records = Records::new();
+    let tracer = Tracer::new(lcs::is_human_readable());
+    let (mut tracer, records) = add_proptest_serialization_tracing(tracer, records);
+    tracer = add_deserialization_tracing(tracer, &records);
     let registry: BTreeMap<_, _> = tracer
         .registry()
         .unwrap()

--- a/testsuite/generate-format/tests/detect_format_change.rs
+++ b/testsuite/generate-format/tests/detect_format_change.rs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use generate_format::{add_deserialization_tracing, add_proptest_serialization_tracing, FILE_PATH};
-use serde_reflection::{Records, RegistryOwned, Tracer};
+use serde_reflection::{RegistryOwned, SerializationRecords, Tracer};
 use serde_yaml;
 use std::collections::BTreeMap;
 
@@ -12,7 +12,7 @@ Please verify the changes to the recorded file(s) and tag your pull-request as `
 
 #[test]
 fn test_recorded_formats_did_not_change() {
-    let records = Records::new();
+    let records = SerializationRecords::new();
     let tracer = Tracer::new(lcs::is_human_readable());
     let (mut tracer, records) = add_proptest_serialization_tracing(tracer, records);
     tracer = add_deserialization_tracing(tracer, &records);

--- a/testsuite/generate-format/tests/staged/libra.yaml
+++ b/testsuite/generate-format/tests/staged/libra.yaml
@@ -44,17 +44,13 @@ ContractEventV0:
     - event_data:
         SEQ: U8
 Ed25519PublicKey:
-  NEWTYPESTRUCT:
-    SEQ: U8
+  NEWTYPESTRUCT: BYTES
 Ed25519Signature:
-  NEWTYPESTRUCT:
-    SEQ: U8
+  NEWTYPESTRUCT: BYTES
 EventKey:
-  NEWTYPESTRUCT:
-    SEQ: U8
+  NEWTYPESTRUCT: BYTES
 HashValue:
-  NEWTYPESTRUCT:
-    SEQ: U8
+  NEWTYPESTRUCT: BYTES
 Identifier:
   NEWTYPESTRUCT: STR
 Module:
@@ -62,11 +58,9 @@ Module:
     - code:
         SEQ: U8
 MultiEd25519PublicKey:
-  NEWTYPESTRUCT:
-    SEQ: U8
+  NEWTYPESTRUCT: BYTES
 MultiEd25519Signature:
-  NEWTYPESTRUCT:
-    SEQ: U8
+  NEWTYPESTRUCT: BYTES
 RawTransaction:
   STRUCT:
     - sender:

--- a/types/Cargo.toml
+++ b/types/Cargo.toml
@@ -24,6 +24,7 @@ prost = "0.6"
 radix_trie = { version = "0.1.4", default-features = false }
 rand = "0.6.5"
 serde = { version = "1.0.106", default-features = false }
+serde_bytes = "0.11"
 thiserror = "1.0"
 tiny-keccak = { version = "2.0.2", default-features = false, features = ["sha3"] }
 

--- a/types/src/event.rs
+++ b/types/src/event.rs
@@ -82,7 +82,7 @@ impl ser::Serialize for EventKey {
         // In order to preserve the Serde data model and help analysis tools,
         // make sure to wrap our value in a container with the same name
         // as the original type.
-        serializer.serialize_newtype_struct("EventKey", &self.0[..])
+        serializer.serialize_newtype_struct("EventKey", serde_bytes::Bytes::new(&self.0))
     }
 }
 
@@ -94,10 +94,10 @@ impl<'de> de::Deserialize<'de> for EventKey {
         // See comment in serialize.
         #[derive(::serde::Deserialize)]
         #[serde(rename = "EventKey")]
-        struct Value(Vec<u8>);
+        struct Value<'a>(&'a [u8]);
 
         let value = Value::deserialize(deserializer)?;
-        Self::try_from(value.0.as_slice()).map_err(<D::Error as ::serde::de::Error>::custom)
+        Self::try_from(value.0).map_err(<D::Error as ::serde::de::Error>::custom)
     }
 }
 


### PR DESCRIPTION
## Motivation

While working https://github.com/libra/libra/pull/3372, I realized deserialization tracing would crash on borrowed bytes such as `&[u8]`. This is a fix.

## Test Plan

```
cargo x test -p generate-format
```
