### PR TITLE
[move-resources] use trait to define Move resource

### DIFF
--- a/client/libra-dev/src/account_resource.rs
+++ b/client/libra-dev/src/account_resource.rs
@@ -72,15 +72,15 @@ pub unsafe extern "C" fn libra_LibraAccountResource_from(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use libra_types::account_config::balance_resource_path;
 
     /// Generate an AccountBlob and verify we can parse it
     #[test]
     fn test_get_accountresource() {
         use libra_crypto::{ed25519::Ed25519PrivateKey, PrivateKey, Uniform};
         use libra_types::{
-            account_config::{AccountResource, BalanceResource, ACCOUNT_RESOURCE_PATH},
+            account_config::{AccountResource, BalanceResource},
             event::{EventHandle, EventKey},
+            move_resource::MoveResource,
             transaction::authenticator::AuthenticationKey,
         };
         use std::collections::BTreeMap;
@@ -104,11 +104,11 @@ mod tests {
 
         // Fill in data
         map.insert(
-            ACCOUNT_RESOURCE_PATH.to_vec(),
+            AccountResource::resource_path(),
             lcs::to_bytes(&ar).expect("Account resource lcs serialization was not successful"),
         );
         map.insert(
-            balance_resource_path(),
+            BalanceResource::resource_path(),
             lcs::to_bytes(&br).expect("Balance resource lcs serialization was not successful"),
         );
 

--- a/json-rpc/src/views.rs
+++ b/json-rpc/src/views.rs
@@ -6,14 +6,12 @@ use anyhow::{format_err, Error, Result};
 use hex;
 use libra_crypto::HashValue;
 use libra_types::{
-    account_config::{
-        received_payment_tag, sent_payment_tag, AccountResource, BalanceResource,
-        ReceivedPaymentEvent, SentPaymentEvent,
-    },
+    account_config::{AccountResource, BalanceResource, ReceivedPaymentEvent, SentPaymentEvent},
     account_state_blob::AccountStateWithProof,
     contract_event::ContractEvent,
     language_storage::TypeTag,
     ledger_info::LedgerInfoWithSignatures,
+    move_resource::MoveResource,
     proof::{AccountStateProof, AccumulatorConsistencyProof},
     transaction::{Transaction, TransactionArgument, TransactionPayload},
     validator_change::ValidatorChangeProof,
@@ -118,7 +116,8 @@ pub enum EventDataView {
 impl From<(u64, ContractEvent)> for EventView {
     /// Tries to convert the provided byte array into Event Key.
     fn from((txn_version, event): (u64, ContractEvent)) -> EventView {
-        let event_data = if event.type_tag() == &TypeTag::Struct(received_payment_tag()) {
+        let event_data = if event.type_tag() == &TypeTag::Struct(ReceivedPaymentEvent::struct_tag())
+        {
             if let Ok(received_event) = ReceivedPaymentEvent::try_from(&event) {
                 Ok(EventDataView::ReceivedPayment {
                     amount: received_event.amount(),
@@ -128,7 +127,7 @@ impl From<(u64, ContractEvent)> for EventView {
             } else {
                 Err(format_err!("Unable to parse ReceivedPaymentEvent"))
             }
-        } else if event.type_tag() == &TypeTag::Struct(sent_payment_tag()) {
+        } else if event.type_tag() == &TypeTag::Struct(SentPaymentEvent::struct_tag()) {
             if let Ok(sent_event) = SentPaymentEvent::try_from(&event) {
                 Ok(EventDataView::SentPayment {
                     amount: sent_event.amount(),

--- a/language/e2e-tests/src/account.rs
+++ b/language/e2e-tests/src/account.rs
@@ -8,9 +8,12 @@ use libra_crypto::ed25519::*;
 use libra_types::{
     access_path::AccessPath,
     account_address::AccountAddress,
-    account_config,
+    account_config::{
+        self, AccountResource, BalanceResource, ReceivedPaymentEvent, SentPaymentEvent,
+    },
     event::EventHandle,
     language_storage::{StructTag, TypeTag},
+    move_resource::MoveResource,
     transaction::{
         authenticator::AuthenticationKey, RawTransaction, Script, SignedTransaction,
         TransactionArgument, TransactionPayload,
@@ -99,14 +102,14 @@ impl Account {
     ///
     /// Use this to retrieve or publish the Account blob.
     pub fn make_account_access_path(&self) -> AccessPath {
-        self.make_access_path(account_config::account_struct_tag())
+        self.make_access_path(AccountResource::struct_tag())
     }
 
     /// Returns the AccessPath that describes the Account balance resource instance.
     ///
     /// Use this to retrieve or publish the Account balance blob.
     pub fn make_balance_access_path(&self) -> AccessPath {
-        self.make_access_path(account_config::account_balance_struct_tag())
+        self.make_access_path(BalanceResource::struct_tag())
     }
 
     // TODO: plug in the account type
@@ -386,7 +389,7 @@ impl Balance {
         StructType {
             address: account_config::CORE_CODE_ADDRESS,
             module: account_config::account_module_name().to_owned(),
-            name: account_config::account_balance_struct_name().to_owned(),
+            name: BalanceResource::struct_identifier(),
             is_resource: true,
             ty_args: vec![],
             layout: vec![Type::U64],
@@ -468,7 +471,7 @@ impl AccountData {
         StructType {
             address: account_config::CORE_CODE_ADDRESS,
             module: account_config::account_module_name().to_owned(),
-            name: account_config::sent_event_name().to_owned(),
+            name: SentPaymentEvent::struct_identifier(),
             is_resource: false,
             ty_args: vec![],
             layout: vec![Type::U64, Type::Address, Type::Vector(Box::new(Type::U8))],
@@ -479,7 +482,7 @@ impl AccountData {
         StructType {
             address: account_config::CORE_CODE_ADDRESS,
             module: account_config::account_module_name().to_owned(),
-            name: account_config::received_event_name().to_owned(),
+            name: ReceivedPaymentEvent::struct_identifier(),
             is_resource: false,
             ty_args: vec![],
             layout: vec![Type::U64, Type::Address, Type::Vector(Box::new(Type::U8))],
@@ -513,7 +516,7 @@ impl AccountData {
         StructType {
             address: account_config::CORE_CODE_ADDRESS,
             module: account_config::account_module_name().to_owned(),
-            name: account_config::account_struct_name().to_owned(),
+            name: AccountResource::struct_identifier(),
             is_resource: true,
             ty_args: vec![],
             layout: vec![

--- a/language/move-vm/runtime/src/interpreter.rs
+++ b/language/move-vm/runtime/src/interpreter.rs
@@ -15,9 +15,10 @@ use libra_logger::prelude::*;
 use libra_types::{
     access_path::AccessPath,
     account_address::AccountAddress,
-    account_config,
+    account_config::{self, AccountResource, BalanceResource},
     contract_event::ContractEvent,
     event::EventKey,
+    move_resource::MoveResource,
     transaction::MAX_TRANSACTION_SIZE_IN_BYTES,
     vm_error::{StatusCode, StatusType, VMStatus},
 };
@@ -842,7 +843,7 @@ impl<'txn> Interpreter<'txn> {
             context,
             &[],
             account_module,
-            account_config::account_struct_name(),
+            &AccountResource::struct_identifier(),
             self.operand_stack.pop_as::<Struct>()?,
             address,
         )?;
@@ -851,7 +852,7 @@ impl<'txn> Interpreter<'txn> {
             context,
             &ty_args,
             account_module,
-            account_config::account_balance_struct_name(),
+            &BalanceResource::struct_identifier(),
             self.operand_stack.pop_as::<Struct>()?,
             address,
         )

--- a/language/move-vm/types/src/native_functions/dispatch.rs
+++ b/language/move-vm/types/src/native_functions/dispatch.rs
@@ -8,10 +8,9 @@ use crate::{
 };
 use libra_types::{
     account_address::AccountAddress,
-    account_config::{
-        account_balance_struct_name, account_module_name, account_struct_name, CORE_CODE_ADDRESS,
-    },
+    account_config::{account_module_name, AccountResource, BalanceResource, CORE_CODE_ADDRESS},
     language_storage::ModuleId,
+    move_resource::MoveResource,
     vm_error::{StatusCode, VMStatus},
 };
 use move_core_types::identifier::IdentStr;
@@ -335,13 +334,13 @@ impl NativeFunction {
                     m?,
                     &CORE_CODE_ADDRESS,
                     account_module_name().as_str(),
-                    account_struct_name().as_str(),
+                    AccountResource::STRUCT_NAME,
                 )?;
                 let balance_t_idx = struct_handle_idx(
                     m?,
                     &CORE_CODE_ADDRESS,
                     account_module_name().as_str(),
-                    account_balance_struct_name().as_str(),
+                    BalanceResource::STRUCT_NAME,
                 )?;
                 let parameters = vec![
                     StructInstantiation(balance_t_idx, vec![TypeParameter(0)]),

--- a/storage/storage-service/src/mocks/mock_storage_client.rs
+++ b/storage/storage-service/src/mocks/mock_storage_client.rs
@@ -14,6 +14,7 @@ use libra_types::{
     event::EventHandle,
     get_with_proof::{RequestItem, ResponseItem},
     ledger_info::{LedgerInfo, LedgerInfoWithSignatures},
+    move_resource::MoveResource,
     proof::{AccumulatorConsistencyProof, SparseMerkleProof, SparseMerkleRangeProof},
     proto::types::{
         request_item::RequestedItems, response_item::ResponseItems, AccountStateWithProof,
@@ -243,7 +244,7 @@ fn get_mock_account_state_blob() -> AccountStateBlob {
 
     let mut account_state = AccountState::default();
     account_state.insert(
-        libra_types::account_config::ACCOUNT_RESOURCE_PATH.to_vec(),
+        libra_types::account_config::AccountResource::resource_path(),
         lcs::to_bytes(&account_resource).unwrap(),
     );
 

--- a/types/src/access_path.rs
+++ b/types/src/access_path.rs
@@ -37,8 +37,9 @@
 
 use crate::{
     account_address::AccountAddress,
-    account_config::{ACCOUNT_RECEIVED_EVENT_PATH, ACCOUNT_RESOURCE_PATH, ACCOUNT_SENT_EVENT_PATH},
+    account_config::{AccountResource, ACCOUNT_RECEIVED_EVENT_PATH, ACCOUNT_SENT_EVENT_PATH},
     language_storage::{ModuleId, ResourceKey, StructTag},
+    move_resource::MoveResource,
 };
 use anyhow::{Error, Result};
 use libra_crypto::hash::{CryptoHash, HashValue};
@@ -208,7 +209,7 @@ impl AccessPath {
 
     /// Given an address, returns the corresponding access path that stores the Account resource.
     pub fn new_for_account(address: AccountAddress) -> Self {
-        Self::new(address, ACCOUNT_RESOURCE_PATH.to_vec())
+        Self::new(address, AccountResource::resource_path())
     }
 
     /// Create an AccessPath to the event for the sender account in a deposit operation.

--- a/types/src/account_config.rs
+++ b/types/src/account_config.rs
@@ -6,6 +6,7 @@ use crate::{
     account_address::AccountAddress,
     event::EventHandle,
     language_storage::{ModuleId, StructTag, TypeTag},
+    move_resource::MoveResource,
 };
 use anyhow::Result;
 use move_core_types::identifier::{IdentStr, Identifier};
@@ -15,6 +16,7 @@ use proptest_derive::Arbitrary;
 use serde::{Deserialize, Serialize};
 
 pub const LBR_NAME: &str = "LBR";
+const ACCOUNT_MODULE_NAME: &str = "LibraAccount";
 
 // Libra
 static COIN_MODULE_NAME: Lazy<Identifier> = Lazy::new(|| Identifier::new("Libra").unwrap());
@@ -23,11 +25,8 @@ pub static COIN_MODULE: Lazy<ModuleId> =
     Lazy::new(|| ModuleId::new(CORE_CODE_ADDRESS, COIN_MODULE_NAME.clone()));
 
 // Account
-static ACCOUNT_MODULE_NAME: Lazy<Identifier> =
+static ACCOUNT_MODULE_IDENTIFIER: Lazy<Identifier> =
     Lazy::new(|| Identifier::new("LibraAccount").unwrap());
-static ACCOUNT_STRUCT_NAME: Lazy<Identifier> = Lazy::new(|| Identifier::new("T").unwrap());
-static ACCOUNT_BALANCE_STRUCT_NAME: Lazy<Identifier> =
-    Lazy::new(|| Identifier::new("Balance").unwrap());
 static ACCOUNT_EVENT_HANDLE_STRUCT_NAME: Lazy<Identifier> =
     Lazy::new(|| Identifier::new("EventHandle").unwrap());
 static ACCOUNT_EVENT_HANDLE_GENERATOR_STRUCT_NAME: Lazy<Identifier> =
@@ -35,13 +34,7 @@ static ACCOUNT_EVENT_HANDLE_GENERATOR_STRUCT_NAME: Lazy<Identifier> =
 
 /// The ModuleId for the Account module.
 pub static ACCOUNT_MODULE: Lazy<ModuleId> =
-    Lazy::new(|| ModuleId::new(CORE_CODE_ADDRESS, ACCOUNT_MODULE_NAME.clone()));
-
-// Payment Events
-static SENT_EVENT_NAME: Lazy<Identifier> =
-    Lazy::new(|| Identifier::new("SentPaymentEvent").unwrap());
-static RECEIVED_EVENT_NAME: Lazy<Identifier> =
-    Lazy::new(|| Identifier::new("ReceivedPaymentEvent").unwrap());
+    Lazy::new(|| ModuleId::new(CORE_CODE_ADDRESS, ACCOUNT_MODULE_IDENTIFIER.clone()));
 
 pub fn coin_module_name() -> &'static IdentStr {
     &*COIN_MODULE_NAME
@@ -52,15 +45,7 @@ pub fn coin_struct_name() -> &'static IdentStr {
 }
 
 pub fn account_module_name() -> &'static IdentStr {
-    &*ACCOUNT_MODULE_NAME
-}
-
-pub fn account_struct_name() -> &'static IdentStr {
-    &*ACCOUNT_STRUCT_NAME
-}
-
-pub fn account_balance_struct_name() -> &'static IdentStr {
-    &*ACCOUNT_BALANCE_STRUCT_NAME
+    &*ACCOUNT_MODULE_IDENTIFIER
 }
 
 pub fn account_event_handle_struct_name() -> &'static IdentStr {
@@ -69,14 +54,6 @@ pub fn account_event_handle_struct_name() -> &'static IdentStr {
 
 pub fn account_event_handle_generator_struct_name() -> &'static IdentStr {
     &*ACCOUNT_EVENT_HANDLE_GENERATOR_STRUCT_NAME
-}
-
-pub fn sent_event_name() -> &'static IdentStr {
-    &*SENT_EVENT_NAME
-}
-
-pub fn received_event_name() -> &'static IdentStr {
-    &*RECEIVED_EVENT_NAME
 }
 
 pub const CORE_CODE_ADDRESS: AccountAddress = AccountAddress::DEFAULT;
@@ -101,15 +78,6 @@ pub fn discovery_set_address() -> AccountAddress {
         .expect("Parsing valid hex literal should always succeed")
 }
 
-pub fn account_struct_tag() -> StructTag {
-    StructTag {
-        address: CORE_CODE_ADDRESS,
-        module: account_module_name().to_owned(),
-        name: account_struct_name().to_owned(),
-        type_params: vec![],
-    }
-}
-
 pub fn lbr_type_tag() -> TypeTag {
     TypeTag::Struct(StructTag {
         address: CORE_CODE_ADDRESS,
@@ -117,33 +85,6 @@ pub fn lbr_type_tag() -> TypeTag {
         name: coin_struct_name().to_owned(),
         type_params: vec![],
     })
-}
-
-pub fn account_balance_struct_tag() -> StructTag {
-    StructTag {
-        address: CORE_CODE_ADDRESS,
-        module: account_module_name().to_owned(),
-        name: account_balance_struct_name().to_owned(),
-        type_params: vec![lbr_type_tag()],
-    }
-}
-
-pub fn sent_payment_tag() -> StructTag {
-    StructTag {
-        address: CORE_CODE_ADDRESS,
-        module: account_module_name().to_owned(),
-        name: sent_event_name().to_owned(),
-        type_params: vec![],
-    }
-}
-
-pub fn received_payment_tag() -> StructTag {
-    StructTag {
-        address: CORE_CODE_ADDRESS,
-        module: account_module_name().to_owned(),
-        name: received_event_name().to_owned(),
-        type_params: vec![],
-    }
 }
 
 pub fn type_tag_for_ticker(ticker_symbol: Identifier) -> TypeTag {
@@ -226,6 +167,11 @@ impl AccountResource {
     }
 }
 
+impl MoveResource for AccountResource {
+    const MODULE_NAME: &'static str = ACCOUNT_MODULE_NAME;
+    const STRUCT_NAME: &'static str = "T";
+}
+
 /// The balance resource held under an account.
 #[derive(Debug, Serialize, Deserialize)]
 #[cfg_attr(any(test, feature = "fuzzing"), derive(Arbitrary))]
@@ -243,14 +189,24 @@ impl BalanceResource {
     }
 }
 
+impl MoveResource for BalanceResource {
+    const MODULE_NAME: &'static str = ACCOUNT_MODULE_NAME;
+    const STRUCT_NAME: &'static str = "Balance";
+
+    fn type_params() -> Vec<TypeTag> {
+        vec![lbr_type_tag()]
+    }
+}
+
 pub fn balance_resource_path() -> Vec<u8> {
-    AccessPath::resource_access_vec(&account_balance_struct_tag(), &Accesses::empty())
+    AccessPath::resource_access_vec(&BalanceResource::struct_tag(), &Accesses::empty())
 }
 
 /// Path to the Account resource.
 /// It can be used to create an AccessPath for an Account resource.
-pub static ACCOUNT_RESOURCE_PATH: Lazy<Vec<u8>> =
-    Lazy::new(|| AccessPath::resource_access_vec(&account_struct_tag(), &Accesses::empty()));
+pub static ACCOUNT_RESOURCE_PATH: Lazy<Vec<u8>> = Lazy::new(|| {
+    AccessPath::resource_access_vec(&AccountResource::struct_tag(), &Accesses::empty())
+});
 
 /// The path to the sent event counter for an Account resource.
 /// It can be used to query the event DB for the given event.
@@ -306,6 +262,11 @@ impl SentPaymentEvent {
     }
 }
 
+impl MoveResource for SentPaymentEvent {
+    const MODULE_NAME: &'static str = ACCOUNT_MODULE_NAME;
+    const STRUCT_NAME: &'static str = "SentPaymentEvent";
+}
+
 /// Struct that represents a ReceivedPaymentEvent.
 #[derive(Debug, Serialize, Deserialize)]
 pub struct ReceivedPaymentEvent {
@@ -342,4 +303,9 @@ impl ReceivedPaymentEvent {
     pub fn metadata(&self) -> &Vec<u8> {
         &self.metadata
     }
+}
+
+impl MoveResource for ReceivedPaymentEvent {
+    const MODULE_NAME: &'static str = ACCOUNT_MODULE_NAME;
+    const STRUCT_NAME: &'static str = "ReceivedPaymentEvent";
 }

--- a/types/src/account_config.rs
+++ b/types/src/account_config.rs
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::{
-    access_path::{AccessPath, Accesses},
     account_address::AccountAddress,
     event::EventHandle,
     language_storage::{ModuleId, StructTag, TypeTag},
@@ -198,20 +197,10 @@ impl MoveResource for BalanceResource {
     }
 }
 
-pub fn balance_resource_path() -> Vec<u8> {
-    AccessPath::resource_access_vec(&BalanceResource::struct_tag(), &Accesses::empty())
-}
-
-/// Path to the Account resource.
-/// It can be used to create an AccessPath for an Account resource.
-pub static ACCOUNT_RESOURCE_PATH: Lazy<Vec<u8>> = Lazy::new(|| {
-    AccessPath::resource_access_vec(&AccountResource::struct_tag(), &Accesses::empty())
-});
-
 /// The path to the sent event counter for an Account resource.
 /// It can be used to query the event DB for the given event.
 pub static ACCOUNT_SENT_EVENT_PATH: Lazy<Vec<u8>> = Lazy::new(|| {
-    let mut path = ACCOUNT_RESOURCE_PATH.to_vec();
+    let mut path = AccountResource::resource_path();
     path.extend_from_slice(b"/sent_events_count/");
     path
 });
@@ -219,7 +208,7 @@ pub static ACCOUNT_SENT_EVENT_PATH: Lazy<Vec<u8>> = Lazy::new(|| {
 /// Returns the path to the received event counter for an Account resource.
 /// It can be used to query the event DB for the given event.
 pub static ACCOUNT_RECEIVED_EVENT_PATH: Lazy<Vec<u8>> = Lazy::new(|| {
-    let mut path = ACCOUNT_RESOURCE_PATH.to_vec();
+    let mut path = AccountResource::resource_path();
     path.extend_from_slice(b"/received_events_count/");
     path
 });

--- a/types/src/account_state.rs
+++ b/types/src/account_state.rs
@@ -4,17 +4,15 @@
 use crate::{
     account_address::AccountAddress,
     account_config::{
-        balance_resource_path, AccountResource, BalanceResource, ACCOUNT_RECEIVED_EVENT_PATH,
-        ACCOUNT_RESOURCE_PATH, ACCOUNT_SENT_EVENT_PATH,
+        AccountResource, BalanceResource, ACCOUNT_RECEIVED_EVENT_PATH, ACCOUNT_SENT_EVENT_PATH,
     },
-    block_metadata::{LibraBlockResource, LIBRA_BLOCK_RESOURCE_PATH, NEW_BLOCK_EVENT_PATH},
-    discovery_set::{
-        DiscoverySetResource, DISCOVERY_SET_CHANGE_EVENT_PATH, DISCOVERY_SET_RESOURCE_PATH,
-    },
+    block_metadata::{LibraBlockResource, NEW_BLOCK_EVENT_PATH},
+    discovery_set::{DiscoverySetResource, DISCOVERY_SET_CHANGE_EVENT_PATH},
     event::EventHandle,
-    libra_timestamp::{LibraTimestampResource, LIBRA_TIMESTAMP_RESOURCE_PATH},
-    on_chain_config::{ConfigurationResource, OnChainConfig, CONFIGURATION_RESOURCE_PATH},
-    validator_config::{ValidatorConfigResource, VALIDATOR_CONFIG_RESOURCE_PATH},
+    libra_timestamp::LibraTimestampResource,
+    move_resource::MoveResource,
+    on_chain_config::{ConfigurationResource, OnChainConfig},
+    validator_config::ValidatorConfigResource,
     validator_set::ValidatorSet,
 };
 use anyhow::{bail, Error, Result};
@@ -32,27 +30,27 @@ impl AccountState {
     }
 
     pub fn get_account_resource(&self) -> Result<Option<AccountResource>> {
-        self.get_resource(&*ACCOUNT_RESOURCE_PATH)
+        self.get_resource(&AccountResource::resource_path())
     }
 
     pub fn get_balance_resource(&self) -> Result<Option<BalanceResource>> {
-        self.get_resource(&balance_resource_path())
+        self.get_resource(&BalanceResource::resource_path())
     }
 
     pub fn get_configuration_resource(&self) -> Result<Option<ConfigurationResource>> {
-        self.get_resource(&*CONFIGURATION_RESOURCE_PATH)
+        self.get_resource(&ConfigurationResource::resource_path())
     }
 
     pub fn get_discovery_set_resource(&self) -> Result<Option<DiscoverySetResource>> {
-        self.get_resource(&*DISCOVERY_SET_RESOURCE_PATH)
+        self.get_resource(&DiscoverySetResource::resource_path())
     }
 
     pub fn get_libra_timestamp_resource(&self) -> Result<Option<LibraTimestampResource>> {
-        self.get_resource(&*LIBRA_TIMESTAMP_RESOURCE_PATH)
+        self.get_resource(&LibraTimestampResource::resource_path())
     }
 
     pub fn get_validator_config_resource(&self) -> Result<Option<ValidatorConfigResource>> {
-        self.get_resource(&*VALIDATOR_CONFIG_RESOURCE_PATH)
+        self.get_resource(&ValidatorConfigResource::resource_path())
     }
 
     pub fn get_validator_set(&self) -> Result<Option<ValidatorSet>> {
@@ -60,7 +58,7 @@ impl AccountState {
     }
 
     pub fn get_libra_block_resource(&self) -> Result<Option<LibraBlockResource>> {
-        self.get_resource(&*LIBRA_BLOCK_RESOURCE_PATH)
+        self.get_resource(&LibraBlockResource::resource_path())
     }
 
     pub fn get_event_handle_by_query_path(&self, query_path: &[u8]) -> Result<Option<EventHandle>> {
@@ -162,10 +160,13 @@ impl TryFrom<(&AccountResource, &BalanceResource)> for AccountState {
     ) -> Result<Self> {
         let mut btree_map: BTreeMap<Vec<u8>, Vec<u8>> = BTreeMap::new();
         btree_map.insert(
-            ACCOUNT_RESOURCE_PATH.to_vec(),
+            AccountResource::resource_path(),
             lcs::to_bytes(account_resource)?,
         );
-        btree_map.insert(balance_resource_path(), lcs::to_bytes(balance_resource)?);
+        btree_map.insert(
+            BalanceResource::resource_path(),
+            lcs::to_bytes(balance_resource)?,
+        );
 
         Ok(Self(btree_map))
     }

--- a/types/src/block_metadata.rs
+++ b/types/src/block_metadata.rs
@@ -4,14 +4,12 @@
 use crate::{
     access_path::{AccessPath, Accesses},
     account_address::AccountAddress,
-    account_config,
     account_config::association_address,
     event::{EventHandle, EventKey},
-    language_storage::StructTag,
+    move_resource::MoveResource,
 };
 use anyhow::Result;
 use libra_crypto::HashValue;
-use move_core_types::identifier::{IdentStr, Identifier};
 use once_cell::sync::Lazy;
 use serde::{Deserialize, Serialize};
 
@@ -79,31 +77,10 @@ pub fn new_block_event_key() -> EventKey {
     EventKey::new_from_address(&association_address(), 2)
 }
 
-static LIBRA_BLOCK_MODULE_NAME: Lazy<Identifier> =
-    Lazy::new(|| Identifier::new("LibraBlock").unwrap());
-static BLOCK_STRUCT_NAME: Lazy<Identifier> =
-    Lazy::new(|| Identifier::new("BlockMetadata").unwrap());
-
-pub fn libra_block_module_name() -> &'static IdentStr {
-    &*LIBRA_BLOCK_MODULE_NAME
-}
-
-pub fn block_struct_name() -> &'static IdentStr {
-    &*BLOCK_STRUCT_NAME
-}
-
-pub fn libra_block_tag() -> StructTag {
-    StructTag {
-        address: account_config::CORE_CODE_ADDRESS,
-        name: block_struct_name().to_owned(),
-        module: libra_block_module_name().to_owned(),
-        type_params: vec![],
-    }
-}
-
 /// The access path where the BlockMetadata resource is stored.
-pub static LIBRA_BLOCK_RESOURCE_PATH: Lazy<Vec<u8>> =
-    Lazy::new(|| AccessPath::resource_access_vec(&libra_block_tag(), &Accesses::empty()));
+pub static LIBRA_BLOCK_RESOURCE_PATH: Lazy<Vec<u8>> = Lazy::new(|| {
+    AccessPath::resource_access_vec(&LibraBlockResource::struct_tag(), &Accesses::empty())
+});
 
 /// The path to the new block event handle under a LibraBlock::BlockMetadata resource.
 pub static NEW_BLOCK_EVENT_PATH: Lazy<Vec<u8>> = Lazy::new(|| {
@@ -123,6 +100,11 @@ impl LibraBlockResource {
     pub fn new_block_events(&self) -> &EventHandle {
         &self.new_block_events
     }
+}
+
+impl MoveResource for LibraBlockResource {
+    const MODULE_NAME: &'static str = "LibraBlock";
+    const STRUCT_NAME: &'static str = "BlockMetadata";
 }
 
 #[derive(Clone, Deserialize, Serialize)]

--- a/types/src/block_metadata.rs
+++ b/types/src/block_metadata.rs
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::{
-    access_path::{AccessPath, Accesses},
     account_address::AccountAddress,
     account_config::association_address,
     event::{EventHandle, EventKey},
@@ -77,14 +76,9 @@ pub fn new_block_event_key() -> EventKey {
     EventKey::new_from_address(&association_address(), 2)
 }
 
-/// The access path where the BlockMetadata resource is stored.
-pub static LIBRA_BLOCK_RESOURCE_PATH: Lazy<Vec<u8>> = Lazy::new(|| {
-    AccessPath::resource_access_vec(&LibraBlockResource::struct_tag(), &Accesses::empty())
-});
-
 /// The path to the new block event handle under a LibraBlock::BlockMetadata resource.
 pub static NEW_BLOCK_EVENT_PATH: Lazy<Vec<u8>> = Lazy::new(|| {
-    let mut path = LIBRA_BLOCK_RESOURCE_PATH.to_vec();
+    let mut path = LibraBlockResource::resource_path();
     // it can be anything as long as it's referenced in AccountState::get_event_handle_by_query_path
     path.extend_from_slice(b"/new_block_event/");
     path

--- a/types/src/contract_event.rs
+++ b/types/src/contract_event.rs
@@ -2,12 +2,11 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::{
-    account_config::{
-        received_payment_tag, sent_payment_tag, ReceivedPaymentEvent, SentPaymentEvent,
-    },
+    account_config::{ReceivedPaymentEvent, SentPaymentEvent},
     event::EventKey,
     language_storage::TypeTag,
     ledger_info::LedgerInfo,
+    move_resource::MoveResource,
     proof::EventProof,
     transaction::Version,
 };
@@ -108,7 +107,7 @@ impl TryFrom<&ContractEvent> for SentPaymentEvent {
     type Error = Error;
 
     fn try_from(event: &ContractEvent) -> Result<Self> {
-        if event.type_tag != TypeTag::Struct(sent_payment_tag()) {
+        if event.type_tag != TypeTag::Struct(SentPaymentEvent::struct_tag()) {
             anyhow::bail!("Expected Sent Payment")
         }
         Self::try_from_bytes(&event.event_data)
@@ -119,7 +118,7 @@ impl TryFrom<&ContractEvent> for ReceivedPaymentEvent {
     type Error = Error;
 
     fn try_from(event: &ContractEvent) -> Result<Self> {
-        if event.type_tag != TypeTag::Struct(received_payment_tag()) {
+        if event.type_tag != TypeTag::Struct(ReceivedPaymentEvent::struct_tag()) {
             anyhow::bail!("Expected Received Payment")
         }
         Self::try_from_bytes(&event.event_data)

--- a/types/src/discovery_set.rs
+++ b/types/src/discovery_set.rs
@@ -6,7 +6,7 @@ use crate::{
     account_config,
     discovery_info::DiscoveryInfo,
     event::{EventHandle, EventKey},
-    language_storage::StructTag,
+    move_resource::MoveResource,
 };
 use anyhow::Result;
 use move_core_types::identifier::{IdentStr, Identifier};
@@ -19,29 +19,14 @@ use std::{iter::IntoIterator, ops::Deref, vec};
 static DISCOVERY_SET_MODULE_NAME: Lazy<Identifier> =
     Lazy::new(|| Identifier::new("LibraSystem").unwrap());
 
-static DISCOVERY_SET_STRUCT_NAME: Lazy<Identifier> =
-    Lazy::new(|| Identifier::new("DiscoverySet").unwrap());
-
 pub fn discovery_set_module_name() -> &'static IdentStr {
     &*DISCOVERY_SET_MODULE_NAME
 }
 
-pub fn discovery_set_struct_name() -> &'static IdentStr {
-    &*DISCOVERY_SET_STRUCT_NAME
-}
-
-pub fn discovery_set_tag() -> StructTag {
-    StructTag {
-        address: account_config::CORE_CODE_ADDRESS,
-        name: discovery_set_struct_name().to_owned(),
-        module: discovery_set_module_name().to_owned(),
-        type_params: vec![],
-    }
-}
-
 /// Path to the DiscoverySet resource.
-pub static DISCOVERY_SET_RESOURCE_PATH: Lazy<Vec<u8>> =
-    Lazy::new(|| AccessPath::resource_access_vec(&discovery_set_tag(), &Accesses::empty()));
+pub static DISCOVERY_SET_RESOURCE_PATH: Lazy<Vec<u8>> = Lazy::new(|| {
+    AccessPath::resource_access_vec(&DiscoverySetResource::struct_tag(), &Accesses::empty())
+});
 
 /// The path to the discovery set change event handle under a DiscoverSetResource.
 pub static DISCOVERY_SET_CHANGE_EVENT_PATH: Lazy<Vec<u8>> = Lazy::new(|| {
@@ -74,6 +59,11 @@ impl DiscoverySetResource {
     pub fn discovery_set(&self) -> &DiscoverySet {
         &self.discovery_set
     }
+}
+
+impl MoveResource for DiscoverySetResource {
+    const MODULE_NAME: &'static str = "LibraSystem";
+    const STRUCT_NAME: &'static str = "DiscoverySet";
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]

--- a/types/src/discovery_set.rs
+++ b/types/src/discovery_set.rs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::{
-    access_path::{AccessPath, Accesses},
+    access_path::AccessPath,
     account_config,
     discovery_info::DiscoveryInfo,
     event::{EventHandle, EventKey},
@@ -23,14 +23,9 @@ pub fn discovery_set_module_name() -> &'static IdentStr {
     &*DISCOVERY_SET_MODULE_NAME
 }
 
-/// Path to the DiscoverySet resource.
-pub static DISCOVERY_SET_RESOURCE_PATH: Lazy<Vec<u8>> = Lazy::new(|| {
-    AccessPath::resource_access_vec(&DiscoverySetResource::struct_tag(), &Accesses::empty())
-});
-
 /// The path to the discovery set change event handle under a DiscoverSetResource.
 pub static DISCOVERY_SET_CHANGE_EVENT_PATH: Lazy<Vec<u8>> = Lazy::new(|| {
-    let mut path = DISCOVERY_SET_RESOURCE_PATH.to_vec();
+    let mut path = DiscoverySetResource::resource_path();
     path.extend_from_slice(b"/change_events_count/");
     path
 });

--- a/types/src/lib.rs
+++ b/types/src/lib.rs
@@ -20,6 +20,7 @@ pub mod language_storage;
 pub mod ledger_info;
 pub mod libra_timestamp;
 pub mod mempool_status;
+pub mod move_resource;
 pub mod on_chain_config;
 pub mod proof;
 #[cfg(any(test, feature = "fuzzing"))]

--- a/types/src/libra_timestamp.rs
+++ b/types/src/libra_timestamp.rs
@@ -1,17 +1,8 @@
 // Copyright (c) The Libra Core Contributors
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::{
-    access_path::{AccessPath, Accesses},
-    move_resource::MoveResource,
-};
-use once_cell::sync::Lazy;
+use crate::move_resource::MoveResource;
 use serde::{Deserialize, Serialize};
-
-/// The access path where the Libra Timestamp resource is stored.
-pub static LIBRA_TIMESTAMP_RESOURCE_PATH: Lazy<Vec<u8>> = Lazy::new(|| {
-    AccessPath::resource_access_vec(&LibraTimestampResource::struct_tag(), &Accesses::empty())
-});
 
 #[derive(Debug, Deserialize, Serialize)]
 pub struct LibraTimestampResource {

--- a/types/src/libra_timestamp.rs
+++ b/types/src/libra_timestamp.rs
@@ -3,42 +3,24 @@
 
 use crate::{
     access_path::{AccessPath, Accesses},
-    account_config,
-    language_storage::StructTag,
+    move_resource::MoveResource,
 };
-use move_core_types::identifier::{IdentStr, Identifier};
 use once_cell::sync::Lazy;
 use serde::{Deserialize, Serialize};
 
-static LIBRA_TIMESTAMP_MODULE_NAME: Lazy<Identifier> =
-    Lazy::new(|| Identifier::new("LibraTimestamp").unwrap());
-static LIBRA_TIMESTAMP_STRUCT_NAME: Lazy<Identifier> =
-    Lazy::new(|| Identifier::new("CurrentTimeMicroseconds").unwrap());
-
-pub fn libra_timestamp_module_name() -> &'static IdentStr {
-    &*LIBRA_TIMESTAMP_MODULE_NAME
-}
-
-pub fn libra_timestamp_struct_name() -> &'static IdentStr {
-    &*LIBRA_TIMESTAMP_STRUCT_NAME
-}
-
-pub fn libra_timestamp_tag() -> StructTag {
-    StructTag {
-        address: account_config::CORE_CODE_ADDRESS,
-        name: libra_timestamp_struct_name().to_owned(),
-        module: libra_timestamp_module_name().to_owned(),
-        type_params: vec![],
-    }
-}
-
-/// The access path where the Validator Set resource is stored.
-pub static LIBRA_TIMESTAMP_RESOURCE_PATH: Lazy<Vec<u8>> =
-    Lazy::new(|| AccessPath::resource_access_vec(&libra_timestamp_tag(), &Accesses::empty()));
+/// The access path where the Libra Timestamp resource is stored.
+pub static LIBRA_TIMESTAMP_RESOURCE_PATH: Lazy<Vec<u8>> = Lazy::new(|| {
+    AccessPath::resource_access_vec(&LibraTimestampResource::struct_tag(), &Accesses::empty())
+});
 
 #[derive(Debug, Deserialize, Serialize)]
 pub struct LibraTimestampResource {
     pub libra_timestamp: LibraTimestamp,
+}
+
+impl MoveResource for LibraTimestampResource {
+    const MODULE_NAME: &'static str = "LibraTimestamp";
+    const STRUCT_NAME: &'static str = "CurrentTimeMicroseconds";
 }
 
 #[derive(Clone, Debug, Deserialize, Serialize)]

--- a/types/src/move_resource.rs
+++ b/types/src/move_resource.rs
@@ -1,23 +1,34 @@
 // Copyright (c) The Libra Core Contributors
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::{account_config, language_storage::StructTag};
-use move_core_types::identifier::IdentStr;
+use crate::{
+    account_config,
+    language_storage::{StructTag, TypeTag},
+};
+use move_core_types::identifier::{IdentStr, Identifier};
 
 pub trait MoveResource {
     const MODULE_NAME: &'static str;
     const STRUCT_NAME: &'static str;
 
+    fn struct_identifier() -> Identifier {
+        IdentStr::new(Self::STRUCT_NAME)
+            .expect("failed to get IdentStr for Move struct")
+            .to_owned()
+    }
+
+    fn type_params() -> Vec<TypeTag> {
+        vec![]
+    }
+
     fn struct_tag() -> StructTag {
         StructTag {
             address: account_config::CORE_CODE_ADDRESS,
-            name: IdentStr::new(Self::STRUCT_NAME)
-                .expect("failed to get IdentStr for Move struct")
-                .to_owned(),
+            name: Self::struct_identifier(),
             module: IdentStr::new(Self::MODULE_NAME)
                 .expect("failed to get IdentStr for Move module")
                 .to_owned(),
-            type_params: vec![],
+            type_params: Self::type_params(),
         }
     }
 }

--- a/types/src/move_resource.rs
+++ b/types/src/move_resource.rs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::{
+    access_path::{AccessPath, Accesses},
     account_config,
     language_storage::{StructTag, TypeTag},
 };
@@ -30,5 +31,9 @@ pub trait MoveResource {
                 .to_owned(),
             type_params: Self::type_params(),
         }
+    }
+
+    fn resource_path() -> Vec<u8> {
+        AccessPath::resource_access_vec(&Self::struct_tag(), &Accesses::empty())
     }
 }

--- a/types/src/move_resource.rs
+++ b/types/src/move_resource.rs
@@ -1,0 +1,23 @@
+// Copyright (c) The Libra Core Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::{account_config, language_storage::StructTag};
+use move_core_types::identifier::IdentStr;
+
+pub trait MoveResource {
+    const MODULE_NAME: &'static str;
+    const STRUCT_NAME: &'static str;
+
+    fn struct_tag() -> StructTag {
+        StructTag {
+            address: account_config::CORE_CODE_ADDRESS,
+            name: IdentStr::new(Self::STRUCT_NAME)
+                .expect("failed to get IdentStr for Move struct")
+                .to_owned(),
+            module: IdentStr::new(Self::MODULE_NAME)
+                .expect("failed to get IdentStr for Move module")
+                .to_owned(),
+            type_params: vec![],
+        }
+    }
+}

--- a/types/src/on_chain_config.rs
+++ b/types/src/on_chain_config.rs
@@ -12,7 +12,6 @@ use crate::{
 use anyhow::{format_err, Result};
 use libra_crypto::HashValue;
 use move_core_types::identifier::Identifier;
-use once_cell::sync::Lazy;
 use serde::{de::DeserializeOwned, Deserialize, Serialize};
 use std::{collections::HashMap, sync::Arc};
 
@@ -116,11 +115,6 @@ pub fn access_path_for_config(config_name: Identifier) -> AccessPath {
         ),
     )
 }
-
-/// Path to the configuration resource.
-pub static CONFIGURATION_RESOURCE_PATH: Lazy<Vec<u8>> = Lazy::new(|| {
-    AccessPath::resource_access_vec(&ConfigurationResource::struct_tag(), &Accesses::empty())
-});
 
 #[derive(Deserialize, Serialize)]
 pub struct ConfigurationResource {

--- a/types/src/validator_config.rs
+++ b/types/src/validator_config.rs
@@ -1,45 +1,19 @@
 // Copyright (c) The Libra Core Contributors
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::{
-    access_path::{AccessPath, Accesses},
-    account_config,
-    language_storage::StructTag,
-};
+use crate::move_resource::MoveResource;
 use libra_crypto::{ed25519::Ed25519PublicKey, x25519::X25519StaticPublicKey};
-use move_core_types::identifier::{IdentStr, Identifier};
-use once_cell::sync::Lazy;
 use parity_multiaddr::Multiaddr;
 use serde::{Deserialize, Serialize};
-
-static VALIDATOR_CONFIG_MODULE_NAME: Lazy<Identifier> =
-    Lazy::new(|| Identifier::new("ValidatorConfig").unwrap());
-static VALIDATOR_CONFIG_STRUCT_NAME: Lazy<Identifier> = Lazy::new(|| Identifier::new("T").unwrap());
-
-pub fn validator_config_module_name() -> &'static IdentStr {
-    &*VALIDATOR_CONFIG_MODULE_NAME
-}
-
-pub fn validator_config_struct_name() -> &'static IdentStr {
-    &*VALIDATOR_CONFIG_STRUCT_NAME
-}
-
-pub fn validator_config_tag() -> StructTag {
-    StructTag {
-        address: account_config::CORE_CODE_ADDRESS,
-        name: validator_config_struct_name().to_owned(),
-        module: validator_config_module_name().to_owned(),
-        type_params: vec![],
-    }
-}
-
-/// The access path where the Validator Set resource is stored.
-pub static VALIDATOR_CONFIG_RESOURCE_PATH: Lazy<Vec<u8>> =
-    Lazy::new(|| AccessPath::resource_access_vec(&validator_config_tag(), &Accesses::empty()));
 
 #[derive(Debug, Deserialize, Serialize)]
 pub struct ValidatorConfigResource {
     pub validator_config: ValidatorConfig,
+}
+
+impl MoveResource for ValidatorConfigResource {
+    const MODULE_NAME: &'static str = "ValidatorConfig";
+    const STRUCT_NAME: &'static str = "T";
 }
 
 #[derive(Clone, Debug, Deserialize, Serialize)]


### PR DESCRIPTION
## Motivation

Add `MoveResource` trait to help define Move resources. This will help bring more structure to the codebase and reduce a lot of the redundant code and usage of `Lazy` across Move resource implementations

## Test Plan

Existing tests
