### PR TITLE
[key-manager] strip out storage service dependency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2417,11 +2417,8 @@ dependencies = [
  "libra-vm 0.1.0",
  "libradb 0.1.0",
  "rand 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "storage-client 0.1.0",
  "storage-interface 0.1.0",
- "storage-service 0.1.0",
  "thiserror 1.0.15 (registry+https://github.com/rust-lang/crates.io-index)",
- "tokio 0.2.13 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]

--- a/secure/key-manager/Cargo.toml
+++ b/secure/key-manager/Cargo.toml
@@ -21,7 +21,6 @@ thiserror = "1.0"
 [dev-dependencies]
 anyhow = "1.0"
 rand = "0.6.5"
-tokio = { version = "0.2.12", features = ["full"] }
 
 config-builder = { path = "../../config/config-builder", version = "0.1.0" }
 executor = { path = "../../execution/executor", version = "0.1.0" }
@@ -29,6 +28,4 @@ executor-types = { path = "../../execution/executor-types", version = "0.1.0" }
 libradb = { path = "../../storage/libradb", version = "0.1.0" }
 libra-config = { path = "../../config", version = "0.1.0", features = ["fuzzing"]}
 libra-vm = { path = "../../language/libra-vm", version = "0.1.0" }
-storage-client = { path = "../../storage/storage-client", version = "0.1.0" }
-storage-service = { path = "../../storage/storage-service", version = "0.1.0" }
 storage-interface= { path = "../../storage/storage-interface", version = "0.1.0" }


### PR DESCRIPTION
Executor folks made it so that executor doesn't depend on storage
service, but this code still did, now it doesn't.