### PR TITLE
[move-prover] Setting up infrastructure for analysis/transformation tests.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4872,14 +4872,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 name = "stackless-bytecode-generator"
 version = "0.1.0"
 dependencies = [
+ "anyhow 1.0.28 (registry+https://github.com/rust-lang/crates.io-index)",
  "bytecode-verifier 0.1.0",
+ "codespan 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "codespan-reporting 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "datatest-stable 0.1.0",
  "ir-to-bytecode 0.1.0",
  "itertools 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libra-temppath 0.1.0",
  "libra-types 0.1.0",
  "num 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "proptest 0.9.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "spec-lang 0.0.1",
  "stdlib 0.1.0",
+ "test-utils 0.1.0",
  "vm 0.1.0",
 ]
 

--- a/language/move-prover/spec-lang/src/env.rs
+++ b/language/move-prover/spec-lang/src/env.rs
@@ -1401,9 +1401,10 @@ impl<'env> FunctionEnv<'env> {
         {
             if let Some((ident, _)) = fmap.get_local_name(idx as u64) {
                 // The move compiler produces temporay names of the form `<foo>%#<num>`.
-                // Replace occurences of `%#` so they are accepted by boogie.
-                let ident = ident.replace("%#", "$$");
-                return self.module_env.env.symbol_pool.make(ident.as_str());
+                // Ignore those names and use the idx-based repr instead.
+                if !ident.contains("%#") {
+                    return self.module_env.env.symbol_pool.make(ident.as_str());
+                }
             }
         }
         self.module_env.env.symbol_pool.make(&format!("$t{}", idx))

--- a/language/move-prover/spec-lang/src/translate.rs
+++ b/language/move-prover/spec-lang/src/translate.rs
@@ -1477,7 +1477,7 @@ impl<'env, 'translator, 'module_translator> ExpTranslator<'env, 'translator, 'mo
 
     /// Constructs a type display context used to visualize types in error messages.
     fn type_display_context(&self) -> TypeDisplayContext<'_> {
-        TypeDisplayContext {
+        TypeDisplayContext::WithoutEnv {
             symbol_pool: self.symbol_pool(),
             reverse_struct_table: &self.parent.parent.reverse_struct_table,
         }

--- a/language/move-prover/stackless-bytecode-generator/Cargo.toml
+++ b/language/move-prover/stackless-bytecode-generator/Cargo.toml
@@ -19,9 +19,14 @@ num = "0.2.0"
 itertools = "0.9.0"
 
 [dev-dependencies]
-proptest = "0.9"
 libra-types = { path = "../../../types", version = "0.1.0" }
+datatest-stable = { path = "../../../common/datatest-stable", version = "0.1.0" }
+test-utils = { path = "../test-utils", version = "0.1.0" }
+codespan = "0.8.0"
+codespan-reporting = "0.8.0"
+libra-temppath = { path = "../../../common/temppath", version = "0.1.0" }
+anyhow = "1.0.*"
 
-[features]
-default = []
-fuzzing = ["libra-types/fuzzing"]
+[[test]]
+name = "testsuite"
+harness = false

--- a/language/move-prover/stackless-bytecode-generator/src/function_target_pipeline.rs
+++ b/language/move-prover/stackless-bytecode-generator/src/function_target_pipeline.rs
@@ -55,7 +55,7 @@ impl FunctionTargetsHolder {
             .targets
             .get(&(func_env.module_env.get_id(), func_env.get_id()))
             .expect("function target exists");
-        FunctionTarget { func_env, data }
+        FunctionTarget::new(func_env, data)
     }
 
     /// Processes the function target data for given function.

--- a/language/move-prover/stackless-bytecode-generator/src/lib.rs
+++ b/language/move-prover/stackless-bytecode-generator/src/lib.rs
@@ -8,6 +8,7 @@ pub mod dataflow_analysis;
 pub mod function_target;
 pub mod function_target_pipeline;
 pub mod lifetime_analysis;
+pub mod reaching_def_analysis;
 pub mod stackless_bytecode;
 pub mod stackless_bytecode_generator;
 pub mod stackless_control_flow_graph;

--- a/language/move-prover/stackless-bytecode-generator/src/reaching_def_analysis.rs
+++ b/language/move-prover/stackless-bytecode-generator/src/reaching_def_analysis.rs
@@ -1,0 +1,204 @@
+// Copyright (c) The Libra Core Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::{
+    dataflow_analysis::{DataflowAnalysis, TransferFunctions},
+    function_target::{FunctionTarget, FunctionTargetData},
+    function_target_pipeline::{FunctionTargetProcessor, FunctionTargetsHolder},
+    stackless_bytecode::{Bytecode, Constant, TempIndex},
+    stackless_control_flow_graph::StacklessControlFlowGraph,
+};
+use bytecode_verifier::{
+    absint::{AbstractDomain, JoinResult},
+    control_flow_graph::ControlFlowGraph,
+};
+use itertools::Itertools;
+use spec_lang::env::FunctionEnv;
+use std::collections::{BTreeMap, BTreeSet};
+use vm::file_format::CodeOffset;
+
+/// The definitions we are capturing. Currently we only capture constants
+/// and aliases (assignment).
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
+pub enum Def {
+    Const(Constant),
+    Alias(TempIndex),
+}
+
+/// The annotation for reaching definitions. For each code position, we have a map of local
+/// indices to the set of definitions reaching the code position.
+#[derive(Default)]
+pub struct ReachingDefAnnotation(BTreeMap<CodeOffset, BTreeMap<TempIndex, BTreeSet<Def>>>);
+
+pub struct ReachingDefProcessor();
+
+impl ReachingDefProcessor {
+    pub fn new() -> Box<Self> {
+        Box::new(ReachingDefProcessor())
+    }
+}
+
+impl FunctionTargetProcessor for ReachingDefProcessor {
+    fn process(
+        &self,
+        _targets: &mut FunctionTargetsHolder,
+        func_env: &FunctionEnv<'_>,
+        mut data: FunctionTargetData,
+    ) -> FunctionTargetData {
+        let defs = if func_env.is_native() {
+            BTreeMap::new()
+        } else {
+            let cfg = StacklessControlFlowGraph::new(&data.code);
+            let mut analyzer = ReachingDefAnalysis {
+                _target: FunctionTarget::new(func_env, &data),
+            };
+            let mut block_state_map = analyzer.analyze_function(
+                ReachingDefState {
+                    map: BTreeMap::new(),
+                },
+                &data.code,
+                &cfg,
+            );
+            // Convert the block state map into a map for each code offset. We achieve this by
+            // replaying execution of the instructions of each individual block, based on the pre
+            // state. Because the analyzes converged to a fixpoint, the result is sound.
+            let mut res = BTreeMap::new();
+            for block_id in cfg.blocks() {
+                let mut state = block_state_map.remove(&block_id).expect("basic block").pre;
+                for code_offset in cfg.instr_indexes(block_id) {
+                    res.insert(code_offset, state.map.clone());
+                    state = analyzer.execute(state, &data.code[code_offset as usize], code_offset);
+                }
+            }
+            res
+        };
+        data.annotations.set(ReachingDefAnnotation(defs));
+        data
+    }
+}
+
+struct ReachingDefAnalysis<'a> {
+    _target: FunctionTarget<'a>,
+}
+
+#[derive(Debug, Clone, Eq, PartialEq)]
+struct ReachingDefState {
+    map: BTreeMap<TempIndex, BTreeSet<Def>>,
+}
+
+impl<'a> TransferFunctions for ReachingDefAnalysis<'a> {
+    type State = ReachingDefState;
+    type InstrType = Bytecode;
+
+    fn execute(
+        &mut self,
+        pre: Self::State,
+        instr: &Self::InstrType,
+        _idx: CodeOffset,
+    ) -> Self::State {
+        use Bytecode::*;
+        let mut post = pre;
+        match instr.skip_labelled() {
+            Assign(_, dst, src, _) => {
+                post.def_alias(*dst, *src);
+            }
+            Load(_, dst, cons) => {
+                post.def_const(*dst, cons.clone());
+            }
+            Call(_, dsts, ..) | Unpack(_, dsts, ..) => {
+                for dst in dsts {
+                    post.kill(*dst);
+                }
+            }
+            BorrowLoc(_, dst, ..)
+            | BorrowField(_, dst, ..)
+            | BorrowGlobal(_, dst, ..)
+            | MoveFrom(_, dst, ..)
+            | Exists(_, dst, ..)
+            | Unary(_, _, dst, ..)
+            | Binary(_, _, dst, ..) => post.kill(*dst),
+            _ => {}
+        }
+        post
+    }
+}
+
+impl<'a> DataflowAnalysis for ReachingDefAnalysis<'a> {}
+
+impl AbstractDomain for ReachingDefState {
+    fn join(&mut self, other: &Self) -> JoinResult {
+        let mut result = JoinResult::Unchanged;
+        for (idx, other_defs) in &other.map {
+            if !self.map.contains_key(idx) {
+                self.map.insert(*idx, other_defs.clone());
+                result = JoinResult::Changed;
+            } else {
+                let defs = self.map.get_mut(idx).unwrap();
+                for d in other_defs {
+                    if defs.insert(d.clone()) {
+                        result = JoinResult::Changed;
+                    }
+                }
+            }
+        }
+        result
+    }
+}
+
+impl ReachingDefState {
+    fn def_alias(&mut self, dest: TempIndex, src: TempIndex) {
+        let set = self.map.entry(dest).or_insert_with(BTreeSet::new);
+        set.clear();
+        set.insert(Def::Alias(src));
+    }
+
+    fn def_const(&mut self, dest: TempIndex, cons: Constant) {
+        let set = self.map.entry(dest).or_insert_with(BTreeSet::new);
+        set.clear();
+        set.insert(Def::Const(cons));
+    }
+
+    fn kill(&mut self, dest: TempIndex) {
+        self.map.remove(&dest);
+    }
+}
+
+// =================================================================================================
+// Formatting
+
+/// Format a reaching definition annotation.
+pub fn format_reaching_def_annotation(
+    target: &FunctionTarget<'_>,
+    code_offset: CodeOffset,
+) -> Option<String> {
+    if let Some(ReachingDefAnnotation(map)) =
+        target.get_annotations().get::<ReachingDefAnnotation>()
+    {
+        if let Some(map_at) = map.get(&code_offset) {
+            let mut res = map_at
+                .iter()
+                .map(|(idx, defs)| {
+                    let name = target.get_local_name(*idx);
+                    format!(
+                        "{} -> {{{}}}",
+                        name.display(target.symbol_pool()),
+                        defs.iter()
+                            .map(|def| {
+                                match def {
+                                    Def::Alias(a) => format!(
+                                        "{}",
+                                        target.get_local_name(*a).display(target.symbol_pool())
+                                    ),
+                                    Def::Const(c) => format!("{}", c),
+                                }
+                            })
+                            .join(", ")
+                    )
+                })
+                .join(", ");
+            res.insert_str(0, "reach: ");
+            return Some(res);
+        }
+    }
+    None
+}

--- a/language/move-prover/stackless-bytecode-generator/tests/from_move/smoke_test.exp
+++ b/language/move-prover/stackless-bytecode-generator/tests/from_move/smoke_test.exp
@@ -1,0 +1,461 @@
+============ initial translation from Move ================
+
+fun SmokeTest::arithmetic_ops(a: u64): (u64, u64) {
+    var c: u64
+    var $t2: u64
+    var $t3: u64
+    var $t4: u64
+    var $t5: u64
+    var $t6: u64
+    var $t7: u64
+    var $t8: u64
+    var $t9: u64
+    var $t10: u64
+    var $t11: u64
+    var $t12: u64
+    var $t13: u64
+    var $t14: u64
+    var $t15: bool
+    var $t16: u64
+    var $t17: u64
+    var $t18: u64
+    $t2 := 6
+    $t3 := 4
+    $t4 := $t2 + $t3
+    $t5 := 1
+    $t6 := $t4 - $t5
+    $t7 := 2
+    $t8 := $t6 * $t7
+    $t9 := 3
+    $t10 := $t8 / $t9
+    $t11 := 4
+    $t12 := $t10 % $t11
+    c := $t12
+    $t13 := copy(c)
+    $t14 := 2
+    $t15 := $t13 != $t14
+    if ($t15) goto L0
+    goto L1
+    L0: $t16 := 42
+    abort($t16)
+    L1: $t17 := copy(c)
+    $t18 := copy(a)
+    return ($t17, $t18)
+}
+
+
+fun SmokeTest::bool_ops(a: u64, b: u64): (bool, bool) {
+    var c: bool
+    var d: bool
+    var $t4: bool
+    var $t5: bool
+    var $t6: u64
+    var $t7: u64
+    var $t8: bool
+    var $t9: u64
+    var $t10: u64
+    var $t11: bool
+    var $t12: bool
+    var $t13: bool
+    var $t14: u64
+    var $t15: u64
+    var $t16: bool
+    var $t17: bool
+    var $t18: u64
+    var $t19: u64
+    var $t20: bool
+    var $t21: bool
+    var $t22: bool
+    var $t23: bool
+    var $t24: bool
+    var $t25: bool
+    var $t26: u64
+    var $t27: bool
+    var $t28: bool
+    $t6 := copy(a)
+    $t7 := copy(b)
+    $t8 := $t6 > $t7
+    if ($t8) goto L0
+    goto L1
+    L0: $t9 := copy(a)
+    $t10 := copy(b)
+    $t11 := $t9 >= $t10
+    $t4 := $t11
+    goto L2
+    L1: $t12 := false
+    $t4 := $t12
+    L2: $t13 := move($t4)
+    c := $t13
+    $t14 := copy(a)
+    $t15 := copy(b)
+    $t16 := $t14 < $t15
+    if ($t16) goto L3
+    goto L4
+    L3: $t17 := true
+    $t5 := $t17
+    goto L5
+    L4: $t18 := copy(a)
+    $t19 := copy(b)
+    $t20 := $t18 <= $t19
+    $t5 := $t20
+    L5: $t21 := move($t5)
+    d := $t21
+    $t22 := copy(c)
+    $t23 := copy(d)
+    $t24 := $t22 != $t23
+    $t25 := ! $t24
+    if ($t25) goto L6
+    goto L7
+    L6: $t26 := 42
+    abort($t26)
+    L7: $t27 := copy(c)
+    $t28 := copy(d)
+    return ($t27, $t28)
+}
+
+
+fun SmokeTest::borrow_global_mut_test(a: address) {
+    var r: &mut SmokeTest::R
+    var r2: &mut SmokeTest::R
+    var $t3: address
+    var $t4: &mut SmokeTest::R
+    var $t5: &mut SmokeTest::R
+    var $t6: address
+    var $t7: &mut SmokeTest::R
+    var $t8: &mut SmokeTest::R
+    $t3 := copy(a)
+    $t4 := &mut global<SmokeTest::R>($t3)
+    r := $t4
+    $t5 := move(r)
+    destroy($t5)
+    $t6 := copy(a)
+    $t7 := &mut global<SmokeTest::R>($t6)
+    r2 := $t7
+    $t8 := move(r2)
+    destroy($t8)
+    return ()
+}
+
+
+fun SmokeTest::create_resource() {
+    var $t0: u64
+    var $t1: SmokeTest::R
+    $t0 := 1
+    $t1 := pack SmokeTest::R($t0)
+    move_to_sender<SmokeTest::R>($t1)
+    return ()
+}
+
+
+fun SmokeTest::create_resoure_generic() {
+    var $t0: u64
+    var $t1: SmokeTest::G<u64>
+    $t0 := 1
+    $t1 := pack SmokeTest::G<u64>($t0)
+    move_to_sender<SmokeTest::G<u64>>($t1)
+    return ()
+}
+
+
+fun SmokeTest::exists_resource(): bool {
+    var $t0: address
+    var $t1: bool
+    $t0 := txn_sender
+    $t1 := exists<SmokeTest::R>($t0)
+    return $t1
+}
+
+
+fun SmokeTest::identity(a: SmokeTest::A, b: SmokeTest::B, c: SmokeTest::C): (SmokeTest::A, SmokeTest::B, SmokeTest::C) {
+    var $t3: SmokeTest::A
+    var $t4: SmokeTest::B
+    var $t5: SmokeTest::C
+    $t3 := move(a)
+    $t4 := move(b)
+    $t5 := move(c)
+    return ($t3, $t4, $t5)
+}
+
+
+fun SmokeTest::move_from_addr(a: address) {
+    var r: SmokeTest::R
+    var $t2: address
+    var $t3: SmokeTest::R
+    var $t4: SmokeTest::R
+    var $t5: u64
+    $t2 := copy(a)
+    $t3 := move_from<SmokeTest::R>($t2)
+    r := $t3
+    $t4 := move(r)
+    $t5 := unpack SmokeTest::R($t4)
+    destroy($t5)
+    return ()
+}
+
+
+fun SmokeTest::move_from_addr_to_sender(a: address) {
+    var r: SmokeTest::R
+    var x: u64
+    var $t3: address
+    var $t4: SmokeTest::R
+    var $t5: SmokeTest::R
+    var $t6: u64
+    var $t7: u64
+    var $t8: SmokeTest::R
+    $t3 := copy(a)
+    $t4 := move_from<SmokeTest::R>($t3)
+    r := $t4
+    $t5 := move(r)
+    $t6 := unpack SmokeTest::R($t5)
+    x := $t6
+    $t7 := copy(x)
+    $t8 := pack SmokeTest::R($t7)
+    move_to_sender<SmokeTest::R>($t8)
+    return ()
+}
+
+
+fun SmokeTest::pack_A(a: address, va: u64): SmokeTest::A {
+    var $t2: address
+    var $t3: u64
+    var $t4: SmokeTest::A
+    $t2 := copy(a)
+    $t3 := copy(va)
+    $t4 := pack SmokeTest::A($t2, $t3)
+    return $t4
+}
+
+
+fun SmokeTest::pack_B(a: address, va: u64, vb: u64): SmokeTest::B {
+    var var_a: SmokeTest::A
+    var var_b: SmokeTest::B
+    var $t5: address
+    var $t6: u64
+    var $t7: SmokeTest::A
+    var $t8: u64
+    var $t9: SmokeTest::A
+    var $t10: SmokeTest::B
+    var $t11: SmokeTest::B
+    $t5 := copy(a)
+    $t6 := copy(va)
+    $t7 := pack SmokeTest::A($t5, $t6)
+    var_a := $t7
+    $t8 := copy(vb)
+    $t9 := move(var_a)
+    $t10 := pack SmokeTest::B($t8, $t9)
+    var_b := $t10
+    $t11 := move(var_b)
+    return $t11
+}
+
+
+fun SmokeTest::pack_C(a: address, va: u64, vb: u64, vc: u64): SmokeTest::C {
+    var var_a: SmokeTest::A
+    var var_b: SmokeTest::B
+    var var_c: SmokeTest::C
+    var $t7: address
+    var $t8: u64
+    var $t9: SmokeTest::A
+    var $t10: u64
+    var $t11: SmokeTest::A
+    var $t12: SmokeTest::B
+    var $t13: u64
+    var $t14: SmokeTest::B
+    var $t15: SmokeTest::C
+    var $t16: SmokeTest::C
+    $t7 := copy(a)
+    $t8 := copy(va)
+    $t9 := pack SmokeTest::A($t7, $t8)
+    var_a := $t9
+    $t10 := copy(vb)
+    $t11 := move(var_a)
+    $t12 := pack SmokeTest::B($t10, $t11)
+    var_b := $t12
+    $t13 := copy(vc)
+    $t14 := move(var_b)
+    $t15 := pack SmokeTest::C($t13, $t14)
+    var_c := $t15
+    $t16 := move(var_c)
+    return $t16
+}
+
+
+fun SmokeTest::ref_A(a: address, b: bool): SmokeTest::A {
+    var b_val_ref: &u64
+    var b_var: u64
+    var $t4: SmokeTest::A
+    var var_a: SmokeTest::A
+    var var_a_ref: &SmokeTest::A
+    var $t7: bool
+    var $t8: address
+    var $t9: u64
+    var $t10: SmokeTest::A
+    var $t11: address
+    var $t12: u64
+    var $t13: SmokeTest::A
+    var $t14: SmokeTest::A
+    var $t15: &SmokeTest::A
+    var $t16: &SmokeTest::A
+    var $t17: &u64
+    var $t18: &u64
+    var $t19: u64
+    var $t20: u64
+    var $t21: u64
+    var $t22: bool
+    var $t23: u64
+    var $t24: SmokeTest::A
+    $t7 := copy(b)
+    if ($t7) goto L0
+    goto L1
+    L0: $t8 := copy(a)
+    $t9 := 1
+    $t10 := pack SmokeTest::A($t8, $t9)
+    $t4 := $t10
+    goto L2
+    L1: $t11 := copy(a)
+    $t12 := 42
+    $t13 := pack SmokeTest::A($t11, $t12)
+    $t4 := $t13
+    L2: $t14 := move($t4)
+    var_a := $t14
+    $t15 := &var_a
+    var_a_ref := $t15
+    $t16 := move(var_a_ref)
+    $t17 := &$t16.val
+    b_val_ref := $t17
+    $t18 := move(b_val_ref)
+    $t19 := *$t18
+    b_var := $t19
+    $t20 := copy(b_var)
+    $t21 := 42
+    $t22 := $t20 != $t21
+    if ($t22) goto L3
+    goto L4
+    L3: $t23 := 42
+    abort($t23)
+    L4: $t24 := move(var_a)
+    return $t24
+}
+
+
+fun SmokeTest::unpack_A(a: address, va: u64): (address, u64) {
+    var aa: address
+    var v1: u64
+    var var_a: SmokeTest::A
+    var $t5: address
+    var $t6: u64
+    var $t7: SmokeTest::A
+    var $t8: SmokeTest::A
+    var $t9: address
+    var $t10: u64
+    var $t11: address
+    var $t12: u64
+    $t5 := copy(a)
+    $t6 := copy(va)
+    $t7 := pack SmokeTest::A($t5, $t6)
+    var_a := $t7
+    $t8 := move(var_a)
+    ($t9, $t10) := unpack SmokeTest::A($t8)
+    v1 := $t10
+    aa := $t9
+    $t11 := copy(aa)
+    $t12 := copy(v1)
+    return ($t11, $t12)
+}
+
+
+fun SmokeTest::unpack_B(a: address, va: u64, vb: u64): (address, u64, u64) {
+    var aa: address
+    var v1: u64
+    var v2: u64
+    var var_a: SmokeTest::A
+    var var_b: SmokeTest::B
+    var $t8: address
+    var $t9: u64
+    var $t10: SmokeTest::A
+    var $t11: u64
+    var $t12: SmokeTest::A
+    var $t13: SmokeTest::B
+    var $t14: SmokeTest::B
+    var $t15: u64
+    var $t16: SmokeTest::A
+    var $t17: address
+    var $t18: u64
+    var $t19: address
+    var $t20: u64
+    var $t21: u64
+    $t8 := copy(a)
+    $t9 := copy(va)
+    $t10 := pack SmokeTest::A($t8, $t9)
+    var_a := $t10
+    $t11 := copy(vb)
+    $t12 := move(var_a)
+    $t13 := pack SmokeTest::B($t11, $t12)
+    var_b := $t13
+    $t14 := move(var_b)
+    ($t15, $t16) := unpack SmokeTest::B($t14)
+    ($t17, $t18) := unpack SmokeTest::A($t16)
+    v1 := $t18
+    aa := $t17
+    v2 := $t15
+    $t19 := copy(aa)
+    $t20 := copy(v1)
+    $t21 := copy(v2)
+    return ($t19, $t20, $t21)
+}
+
+
+fun SmokeTest::unpack_C(a: address, va: u64, vb: u64, vc: u64): (address, u64, u64, u64) {
+    var aa: address
+    var v1: u64
+    var v2: u64
+    var v3: u64
+    var var_a: SmokeTest::A
+    var var_b: SmokeTest::B
+    var var_c: SmokeTest::C
+    var $t11: address
+    var $t12: u64
+    var $t13: SmokeTest::A
+    var $t14: u64
+    var $t15: SmokeTest::A
+    var $t16: SmokeTest::B
+    var $t17: u64
+    var $t18: SmokeTest::B
+    var $t19: SmokeTest::C
+    var $t20: SmokeTest::C
+    var $t21: u64
+    var $t22: SmokeTest::B
+    var $t23: u64
+    var $t24: SmokeTest::A
+    var $t25: address
+    var $t26: u64
+    var $t27: address
+    var $t28: u64
+    var $t29: u64
+    var $t30: u64
+    $t11 := copy(a)
+    $t12 := copy(va)
+    $t13 := pack SmokeTest::A($t11, $t12)
+    var_a := $t13
+    $t14 := copy(vb)
+    $t15 := move(var_a)
+    $t16 := pack SmokeTest::B($t14, $t15)
+    var_b := $t16
+    $t17 := copy(vc)
+    $t18 := move(var_b)
+    $t19 := pack SmokeTest::C($t17, $t18)
+    var_c := $t19
+    $t20 := move(var_c)
+    ($t21, $t22) := unpack SmokeTest::C($t20)
+    ($t23, $t24) := unpack SmokeTest::B($t22)
+    ($t25, $t26) := unpack SmokeTest::A($t24)
+    v1 := $t26
+    aa := $t25
+    v2 := $t23
+    v3 := $t21
+    $t27 := copy(aa)
+    $t28 := copy(v1)
+    $t29 := copy(v2)
+    $t30 := copy(v3)
+    return ($t27, $t28, $t29, $t30)
+}

--- a/language/move-prover/stackless-bytecode-generator/tests/from_move/smoke_test.move
+++ b/language/move-prover/stackless-bytecode-generator/tests/from_move/smoke_test.move
@@ -1,0 +1,138 @@
+// This module contains just some arbitrary code to smoke test the basic functionality of translation from Move
+// to stackless bytecode. Coverage for byte code translation is achieved by many more tests in the prover.
+
+// dep: ../tests/sources/stdlib/modules/transaction.move
+
+module SmokeTest {
+    use 0x0::Transaction;
+
+    // -----------------
+    // Basic Ops
+    // -----------------
+
+	fun bool_ops(a: u64, b: u64): (bool, bool) {
+        let c: bool;
+        let d: bool;
+        c = a > b && a >= b;
+        d = a < b || a <= b;
+        if (!(c != d)) abort 42;
+        (c, d)
+    }
+
+	fun arithmetic_ops(a: u64): (u64, u64) {
+        let c: u64;
+        c = (6 + 4 - 1) * 2 / 3 % 4;
+        if (c != 2) abort 42;
+        (c, a)
+    }
+
+    // -----------------
+    // Resources
+    // -----------------
+
+    resource struct R {
+        x: u64
+    }
+
+    fun create_resource() {
+        move_to_sender<R>(R{x:1});
+    }
+
+    fun exists_resource(): bool {
+        exists<R>(Transaction::sender())
+    }
+
+    fun move_from_addr(a: address) acquires R {
+        let r = move_from<R>(a);
+        let R{x: _} = r;
+    }
+
+    fun move_from_addr_to_sender(a: address) acquires R {
+        let r = move_from<R>(a);
+        let R{x: x} = r;
+        move_to_sender<R>(R{x: x});
+    }
+
+    fun borrow_global_mut_test(a: address) acquires R {
+        let r = borrow_global_mut<R>(a);
+        _ = r;
+        let r2 = borrow_global_mut<R>(a);
+        _ = r2;
+    }
+
+    resource struct G<X> {
+        x: X
+    }
+
+    fun create_resoure_generic() {
+        move_to_sender<G<u64>>(G{x:1});
+    }
+
+
+    resource struct A {
+        addr: address,
+        val: u64,
+    }
+
+    resource struct B {
+        val: u64,
+        a: A,
+    }
+
+    resource struct C {
+        val: u64,
+        b: B,
+    }
+
+    fun identity(a: A, b: B, c: C): (A,B,C) {
+        (a, b, c)
+    }
+
+    fun pack_A(a: address, va: u64): A {
+        A{ addr:a, val:va }
+    }
+
+    fun pack_B(a: address, va: u64, vb: u64): B {
+        let var_a = A{ addr: a, val: va };
+        let var_b = B{ val: vb, a: var_a };
+        var_b
+    }
+
+    fun pack_C(a: address, va: u64, vb: u64, vc: u64): C {
+        let var_a = A{ addr: a, val: va };
+        let var_b = B{ val: vb, a: var_a };
+        let var_c = C{ val: vc, b: var_b };
+        var_c
+    }
+
+    fun unpack_A(a: address, va: u64): (address, u64) {
+        let var_a = A{ addr:a, val:va };
+        let A{addr: aa, val:v1} = var_a;
+        (aa, v1)
+    }
+
+    fun unpack_B(a: address, va: u64, vb: u64): (address, u64, u64) {
+        let var_a = A{ addr: a, val: va };
+        let var_b = B{ val: vb, a: var_a };
+        let B{val: v2, a: A{ addr:aa, val: v1}} = var_b;
+        (aa, v1, v2)
+    }
+
+    fun unpack_C(a: address, va: u64, vb: u64, vc: u64): (address, u64, u64, u64) {
+        let var_a = A{ addr: a, val: va };
+        let var_b = B{ val: vb, a: var_a };
+        let var_c = C{ val: vc, b: var_b };
+        let C{val: v3, b: B{val: v2, a: A{ addr:aa, val: v1}}} = var_c;
+        (aa, v1, v2, v3)
+    }
+
+    fun ref_A(a: address, b: bool): A {
+        let var_a = if (b) A{ addr: a, val: 1 }
+                    else A{ addr: a, val: 42 };
+        let var_a_ref = &var_a;
+        let b_val_ref = &var_a_ref.val;
+        let b_var = *b_val_ref;
+        if (b_var != 42) abort 42;
+        var_a
+    }
+}

--- a/language/move-prover/stackless-bytecode-generator/tests/lifetime/basic_test.exp
+++ b/language/move-prover/stackless-bytecode-generator/tests/lifetime/basic_test.exp
@@ -1,0 +1,323 @@
+============ initial translation from Move ================
+
+fun TestLifetime::lifetime_(cond: bool): (TestLifetime::T, TestLifetime::S) {
+    var a: TestLifetime::T
+    var a_ref: &mut TestLifetime::T
+    var b: TestLifetime::S
+    var b_ref: &mut TestLifetime::S
+    var $t5: &mut u64
+    var x_ref: &mut u64
+    var $t7: u64
+    var $t8: TestLifetime::T
+    var $t9: u64
+    var $t10: TestLifetime::S
+    var $t11: &mut TestLifetime::T
+    var $t12: &mut TestLifetime::S
+    var $t13: bool
+    var $t14: &mut TestLifetime::S
+    var $t15: &mut TestLifetime::T
+    var $t16: &mut u64
+    var $t17: &mut TestLifetime::T
+    var $t18: &mut TestLifetime::S
+    var $t19: &mut u64
+    var $t20: &mut u64
+    var $t21: bool
+    var $t22: u64
+    var $t23: &mut u64
+    var $t24: u64
+    var $t25: &mut u64
+    var $t26: TestLifetime::T
+    var $t27: TestLifetime::S
+    $t7 := 3
+    $t8 := pack TestLifetime::T($t7)
+    a := $t8
+    $t9 := 4
+    $t10 := pack TestLifetime::S($t9)
+    b := $t10
+    $t11 := &mut a
+    a_ref := $t11
+    $t12 := &mut b
+    b_ref := $t12
+    $t13 := copy(cond)
+    if ($t13) goto L0
+    goto L1
+    L0: $t14 := move(b_ref)
+    destroy($t14)
+    $t15 := move(a_ref)
+    $t16 := &mut $t15.x
+    $t5 := $t16
+    goto L2
+    L1: $t17 := move(a_ref)
+    destroy($t17)
+    $t18 := move(b_ref)
+    $t19 := &mut $t18.y
+    $t5 := $t19
+    L2: $t20 := move($t5)
+    x_ref := $t20
+    $t21 := copy(cond)
+    if ($t21) goto L3
+    goto L4
+    L3: $t22 := 2
+    $t23 := move(x_ref)
+    *$t23 := $t22
+    goto L5
+    L4: $t24 := 0
+    $t25 := move(x_ref)
+    *$t25 := $t24
+    L5: $t26 := move(a)
+    $t27 := move(b)
+    return ($t26, $t27)
+}
+
+
+fun TestLifetime::lifetime_R(): TestLifetime::R {
+    var r: TestLifetime::R
+    var r_ref: &mut TestLifetime::R
+    var x_ref: &mut u64
+    var $t3: u64
+    var $t4: TestLifetime::R
+    var $t5: &mut TestLifetime::R
+    var $t6: &mut TestLifetime::R
+    var $t7: &mut u64
+    var $t8: u64
+    var $t9: &mut u64
+    var $t10: &mut TestLifetime::R
+    var $t11: &mut TestLifetime::R
+    var $t12: &mut u64
+    var $t13: u64
+    var $t14: &mut u64
+    var $t15: TestLifetime::R
+    $t3 := 3
+    $t4 := pack TestLifetime::R($t3)
+    r := $t4
+    $t5 := &mut r
+    r_ref := $t5
+    $t6 := move(r_ref)
+    $t7 := &mut $t6.x
+    x_ref := $t7
+    $t8 := 0
+    $t9 := move(x_ref)
+    *$t9 := $t8
+    $t10 := &mut r
+    r_ref := $t10
+    $t11 := move(r_ref)
+    $t12 := &mut $t11.x
+    x_ref := $t12
+    $t13 := 2
+    $t14 := move(x_ref)
+    *$t14 := $t13
+    $t15 := move(r)
+    return $t15
+}
+
+
+fun TestLifetime::lifetime_R_2(): TestLifetime::R {
+    var r: TestLifetime::R
+    var r_ref: &mut TestLifetime::R
+    var x_ref: &mut u64
+    var $t3: u64
+    var $t4: TestLifetime::R
+    var $t5: &mut TestLifetime::R
+    var $t6: &mut TestLifetime::R
+    var $t7: &mut u64
+    var $t8: u64
+    var $t9: &mut u64
+    var $t10: u64
+    var $t11: &mut u64
+    var $t12: &mut TestLifetime::R
+    var $t13: &mut TestLifetime::R
+    var $t14: &mut u64
+    var $t15: u64
+    var $t16: &mut u64
+    var $t17: TestLifetime::R
+    $t3 := 4
+    $t4 := pack TestLifetime::R($t3)
+    r := $t4
+    $t5 := &mut r
+    r_ref := $t5
+    $t6 := move(r_ref)
+    $t7 := &mut $t6.x
+    x_ref := $t7
+    $t8 := 0
+    $t9 := copy(x_ref)
+    *$t9 := $t8
+    $t10 := 2
+    $t11 := move(x_ref)
+    *$t11 := $t10
+    $t12 := &mut r
+    r_ref := $t12
+    $t13 := move(r_ref)
+    $t14 := &mut $t13.x
+    x_ref := $t14
+    $t15 := 3
+    $t16 := move(x_ref)
+    *$t16 := $t15
+    $t17 := move(r)
+    return $t17
+}
+
+============ after pipeline `lifetime` ================
+
+fun TestLifetime::lifetime_(cond: bool): (TestLifetime::T, TestLifetime::S) {
+    var a: TestLifetime::T
+    var a_ref: &mut TestLifetime::T
+    var b: TestLifetime::S
+    var b_ref: &mut TestLifetime::S
+    var $t5: &mut u64
+    var x_ref: &mut u64
+    var $t7: u64
+    var $t8: TestLifetime::T
+    var $t9: u64
+    var $t10: TestLifetime::S
+    var $t11: &mut TestLifetime::T
+    var $t12: &mut TestLifetime::S
+    var $t13: bool
+    var $t14: &mut TestLifetime::S
+    var $t15: &mut TestLifetime::T
+    var $t16: &mut u64
+    var $t17: &mut TestLifetime::T
+    var $t18: &mut TestLifetime::S
+    var $t19: &mut u64
+    var $t20: &mut u64
+    var $t21: bool
+    var $t22: u64
+    var $t23: &mut u64
+    var $t24: u64
+    var $t25: &mut u64
+    var $t26: TestLifetime::T
+    var $t27: TestLifetime::S
+    $t7 := 3
+    $t8 := pack TestLifetime::T($t7)
+    a := $t8
+    $t9 := 4
+    $t10 := pack TestLifetime::S($t9)
+    b := $t10
+    $t11 := &mut a
+    a_ref := $t11
+    $t12 := &mut b
+    b_ref := $t12
+    $t13 := copy(cond)
+    if ($t13) goto L0
+    goto L1
+    L0: $t14 := move(b_ref)
+    // mut ends: $t14
+    destroy($t14)
+    $t15 := move(a_ref)
+    $t16 := &mut $t15.x
+    $t5 := $t16
+    goto L2
+    L1: $t17 := move(a_ref)
+    // mut ends: $t17
+    destroy($t17)
+    $t18 := move(b_ref)
+    $t19 := &mut $t18.y
+    $t5 := $t19
+    L2: $t20 := move($t5)
+    x_ref := $t20
+    $t21 := copy(cond)
+    if ($t21) goto L3
+    goto L4
+    L3: $t22 := 2
+    $t23 := move(x_ref)
+    // mut ends: $t15, $t18, $t23
+    *$t23 := $t22
+    goto L5
+    L4: $t24 := 0
+    $t25 := move(x_ref)
+    // mut ends: $t15, $t18, $t25
+    *$t25 := $t24
+    L5: $t26 := move(a)
+    $t27 := move(b)
+    return ($t26, $t27)
+}
+
+
+fun TestLifetime::lifetime_R(): TestLifetime::R {
+    var r: TestLifetime::R
+    var r_ref: &mut TestLifetime::R
+    var x_ref: &mut u64
+    var $t3: u64
+    var $t4: TestLifetime::R
+    var $t5: &mut TestLifetime::R
+    var $t6: &mut TestLifetime::R
+    var $t7: &mut u64
+    var $t8: u64
+    var $t9: &mut u64
+    var $t10: &mut TestLifetime::R
+    var $t11: &mut TestLifetime::R
+    var $t12: &mut u64
+    var $t13: u64
+    var $t14: &mut u64
+    var $t15: TestLifetime::R
+    $t3 := 3
+    $t4 := pack TestLifetime::R($t3)
+    r := $t4
+    $t5 := &mut r
+    r_ref := $t5
+    $t6 := move(r_ref)
+    $t7 := &mut $t6.x
+    x_ref := $t7
+    $t8 := 0
+    $t9 := move(x_ref)
+    // mut ends: $t6, $t9
+    *$t9 := $t8
+    $t10 := &mut r
+    r_ref := $t10
+    $t11 := move(r_ref)
+    $t12 := &mut $t11.x
+    x_ref := $t12
+    $t13 := 2
+    $t14 := move(x_ref)
+    // mut ends: $t11, $t14
+    *$t14 := $t13
+    $t15 := move(r)
+    return $t15
+}
+
+
+fun TestLifetime::lifetime_R_2(): TestLifetime::R {
+    var r: TestLifetime::R
+    var r_ref: &mut TestLifetime::R
+    var x_ref: &mut u64
+    var $t3: u64
+    var $t4: TestLifetime::R
+    var $t5: &mut TestLifetime::R
+    var $t6: &mut TestLifetime::R
+    var $t7: &mut u64
+    var $t8: u64
+    var $t9: &mut u64
+    var $t10: u64
+    var $t11: &mut u64
+    var $t12: &mut TestLifetime::R
+    var $t13: &mut TestLifetime::R
+    var $t14: &mut u64
+    var $t15: u64
+    var $t16: &mut u64
+    var $t17: TestLifetime::R
+    $t3 := 4
+    $t4 := pack TestLifetime::R($t3)
+    r := $t4
+    $t5 := &mut r
+    r_ref := $t5
+    $t6 := move(r_ref)
+    $t7 := &mut $t6.x
+    x_ref := $t7
+    $t8 := 0
+    $t9 := copy(x_ref)
+    *$t9 := $t8
+    $t10 := 2
+    $t11 := move(x_ref)
+    // mut ends: $t6, $t11
+    *$t11 := $t10
+    $t12 := &mut r
+    r_ref := $t12
+    $t13 := move(r_ref)
+    $t14 := &mut $t13.x
+    x_ref := $t14
+    $t15 := 3
+    $t16 := move(x_ref)
+    // mut ends: $t13, $t16
+    *$t16 := $t15
+    $t17 := move(r)
+    return $t17
+}

--- a/language/move-prover/stackless-bytecode-generator/tests/lifetime/basic_test.move
+++ b/language/move-prover/stackless-bytecode-generator/tests/lifetime/basic_test.move
@@ -1,0 +1,58 @@
+module TestLifetime {
+
+    struct R {
+        x: u64
+    }
+
+
+    fun lifetime_R() : R {
+        let r = R {x: 3};
+        let r_ref = &mut r;
+        let x_ref = &mut r_ref.x;
+        *x_ref = 0; // r_ref goes out of scope here
+
+        r_ref = &mut r;
+        x_ref = &mut r_ref.x;
+        *x_ref = 2;
+
+        r
+    }
+
+    fun lifetime_R_2() : R {
+        let r = R {x: 4};
+        let r_ref = &mut r;
+        let x_ref = &mut r_ref.x;
+        *x_ref = 0;
+        *x_ref = 2; // r_ref goes out of scope here
+
+        r_ref = &mut r;
+        x_ref = &mut r_ref.x;
+        *x_ref = 3;
+
+        r
+    }
+
+    struct T {
+        x: u64
+    }
+
+    struct S {
+        y: u64
+    }
+
+    fun lifetime_(cond: bool): (T, S) {
+      let a = T {x: 3};
+      let b = S {y: 4};
+      let a_ref = &mut a;
+      let b_ref = &mut b;
+      let x_ref = if (cond) { &mut a_ref.x } else { &mut b_ref.y };
+
+      if (cond) {
+          *x_ref = 2;
+      } else {
+          *x_ref = 0;
+      };
+
+      (a, b)
+    }
+}

--- a/language/move-prover/stackless-bytecode-generator/tests/reaching_def/basic_test.exp
+++ b/language/move-prover/stackless-bytecode-generator/tests/reaching_def/basic_test.exp
@@ -1,0 +1,88 @@
+============ initial translation from Move ================
+
+fun ReachingDefTest::basic(a: u64, b: u64): u64 {
+    var x: u64
+    var $t3: u64
+    var $t4: u64
+    var $t5: u64
+    var $t6: u64
+    var $t7: u64
+    var $t8: u64
+    var $t9: u64
+    var $t10: u64
+    $t3 := copy(a)
+    $t4 := copy(b)
+    $t5 := $t3 + $t4
+    $t6 := copy(a)
+    $t7 := $t5 / $t6
+    x := $t7
+    $t8 := copy(x)
+    $t9 := 1
+    $t10 := $t8 + $t9
+    return $t10
+}
+
+
+fun ReachingDefTest::create_resource() {
+    var r: ReachingDefTest::R
+    var $t1: u64
+    var $t2: bool
+    var $t3: ReachingDefTest::R
+    $t1 := 1
+    $t2 := false
+    $t3 := pack ReachingDefTest::R($t1, $t2)
+    move_to_sender<ReachingDefTest::R>($t3)
+    return ()
+}
+
+============ after pipeline `reaching_def` ================
+
+fun ReachingDefTest::basic(a: u64, b: u64): u64 {
+    var x: u64
+    var $t3: u64
+    var $t4: u64
+    var $t5: u64
+    var $t6: u64
+    var $t7: u64
+    var $t8: u64
+    var $t9: u64
+    var $t10: u64
+    // reach:
+    $t3 := copy(a)
+    // reach: $t3 -> {a}
+    $t4 := copy(b)
+    // reach: $t3 -> {a}, $t4 -> {b}
+    $t5 := $t3 + $t4
+    // reach: $t3 -> {a}, $t4 -> {b}
+    $t6 := copy(a)
+    // reach: $t3 -> {a}, $t4 -> {b}, $t6 -> {a}
+    $t7 := $t5 / $t6
+    // reach: $t3 -> {a}, $t4 -> {b}, $t6 -> {a}
+    x := $t7
+    // reach: x -> {$t7}, $t3 -> {a}, $t4 -> {b}, $t6 -> {a}
+    $t8 := copy(x)
+    // reach: x -> {$t7}, $t3 -> {a}, $t4 -> {b}, $t6 -> {a}, $t8 -> {x}
+    $t9 := 1
+    // reach: x -> {$t7}, $t3 -> {a}, $t4 -> {b}, $t6 -> {a}, $t8 -> {x}, $t9 -> {1}
+    $t10 := $t8 + $t9
+    // reach: x -> {$t7}, $t3 -> {a}, $t4 -> {b}, $t6 -> {a}, $t8 -> {x}, $t9 -> {1}
+    return $t10
+}
+
+
+fun ReachingDefTest::create_resource() {
+    var r: ReachingDefTest::R
+    var $t1: u64
+    var $t2: bool
+    var $t3: ReachingDefTest::R
+    // reach:
+    $t1 := 1
+    // reach: $t1 -> {1}
+    $t2 := false
+    // reach: $t1 -> {1}, $t2 -> {false}
+    $t3 := pack ReachingDefTest::R($t1, $t2)
+    // reach: $t1 -> {1}, $t2 -> {false}
+    move_to_sender<ReachingDefTest::R>($t3)
+    // reach: $t1 -> {1}, $t2 -> {false}
+    return ()
+}

--- a/language/move-prover/stackless-bytecode-generator/tests/reaching_def/basic_test.move
+++ b/language/move-prover/stackless-bytecode-generator/tests/reaching_def/basic_test.move
@@ -1,0 +1,17 @@
+module ReachingDefTest {
+
+    resource struct R {
+        x: u64,
+        y: bool
+    }
+
+	fun basic(a: u64, b: u64): u64 {
+	    let x = (a + b) / a;
+	    x + 1
+	}
+
+    fun create_resource() {
+        let r = R{ x: 1, y: false};
+        move_to_sender<R>(r);
+    }
+}

--- a/language/move-prover/stackless-bytecode-generator/tests/testsuite.rs
+++ b/language/move-prover/stackless-bytecode-generator/tests/testsuite.rs
@@ -1,0 +1,91 @@
+// Copyright (c) The Libra Core Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+use anyhow::anyhow;
+use std::path::Path;
+
+use codespan_reporting::term::termcolor::Buffer;
+
+use spec_lang::{env::GlobalEnv, run_spec_lang_compiler};
+use stackless_bytecode_generator::{
+    function_target_pipeline::{FunctionTargetPipeline, FunctionTargetsHolder},
+    lifetime_analysis::LifetimeAnalysisProcessor,
+    reaching_def_analysis::ReachingDefProcessor,
+};
+use test_utils::{baseline_test::verify_or_update_baseline, extract_test_directives};
+
+fn get_tested_transformation_pipeline(
+    dir_name: &str,
+) -> anyhow::Result<Option<FunctionTargetPipeline>> {
+    match dir_name {
+        "from_move" => Ok(None),
+        "lifetime" => {
+            let mut pipeline = FunctionTargetPipeline::default();
+            pipeline.add_processor(Box::new(LifetimeAnalysisProcessor {}));
+            Ok(Some(pipeline))
+        }
+        "reaching_def" => {
+            let mut pipeline = FunctionTargetPipeline::default();
+            pipeline.add_processor(Box::new(ReachingDefProcessor()));
+            Ok(Some(pipeline))
+        }
+        _ => Err(anyhow!(
+            "the sub-directory `{}` has no associated pipeline to test",
+            dir_name
+        )),
+    }
+}
+
+fn test_runner(path: &Path) -> datatest_stable::Result<()> {
+    let mut sources = extract_test_directives(path, "// dep:")?;
+    sources.push(path.to_string_lossy().to_string());
+    let env: GlobalEnv = run_spec_lang_compiler(sources, vec![], Some("0x2345467"))?;
+    let out = if env.has_errors() {
+        let mut error_writer = Buffer::no_color();
+        env.report_errors(&mut error_writer);
+        String::from_utf8_lossy(&error_writer.into_inner()).to_string()
+    } else {
+        let dir_name = path
+            .parent()
+            .and_then(|p| p.file_name())
+            .and_then(|p| p.to_str())
+            .ok_or_else(|| anyhow!("bad file name"))?;
+        let pipeline_opt = get_tested_transformation_pipeline(dir_name)?;
+
+        // Initialize and print function targets
+        let mut text = String::new();
+        let mut targets = FunctionTargetsHolder::default();
+        for module_env in env.get_modules() {
+            for func_env in module_env.get_functions() {
+                targets.add_target(&func_env);
+            }
+        }
+        text += &print_targets(&env, "initial translation from Move", &targets);
+
+        // Run pipeline if any
+        if let Some(pipeline) = pipeline_opt {
+            pipeline.run(&env, &mut targets);
+            text += &print_targets(&env, &format!("after pipeline `{}`", dir_name), &targets);
+        }
+
+        text
+    };
+    let baseline_path = path.with_extension("exp");
+    verify_or_update_baseline(baseline_path.as_path(), &out)?;
+    Ok(())
+}
+
+fn print_targets(env: &GlobalEnv, header: &str, targets: &FunctionTargetsHolder) -> String {
+    let mut text = String::new();
+    text.push_str(&format!("============ {} ================\n", header));
+    for module_env in env.get_modules() {
+        for func_env in module_env.get_functions() {
+            let target = targets.get_target(&func_env);
+            target.register_annotation_formatters_for_test();
+            text += &format!("\n{}\n", target);
+        }
+    }
+    text
+}
+
+datatest_stable::harness!(test_runner, "tests", r".*\.move");

--- a/language/move-prover/tests/sources/aborts-if.exp
+++ b/language/move-prover/tests/sources/aborts-if.exp
@@ -3,13 +3,13 @@ error:  A postcondition might not hold on this return path.
 
     ┌── tests/sources/aborts-if.move:31:9 ───
     │
- 31 │         aborts_if x <= y;
-    │         ^^^^^^^^^^^^^^^^^
+ 31 │         aborts_if _x <= _y;
+    │         ^^^^^^^^^^^^^^^^^^^
     │
     =     at tests/sources/aborts-if.move:28:5: abort2_incorrect (entry)
     =     at tests/sources/aborts-if.move:28:5: abort2_incorrect (exit)
-    =         x = <redacted>,
-    =         y = <redacted>
+    =         _x = <redacted>,
+    =         _y = <redacted>
 
 error:  A postcondition might not hold on this return path.
 
@@ -67,11 +67,11 @@ error:  A postcondition might not hold on this return path.
 
     ┌── tests/sources/aborts-if.move:94:9 ───
     │
- 94 │         aborts_if x < y;
-    │         ^^^^^^^^^^^^^^^^
+ 94 │         aborts_if _x < _y;
+    │         ^^^^^^^^^^^^^^^^^^
     │
     =     at tests/sources/aborts-if.move:90:5: multi_abort3_incorrect (entry)
     =     at tests/sources/aborts-if.move:91:9: multi_abort3_incorrect
-    =         x = <redacted>,
-    =         y = <redacted>
+    =         _x = <redacted>,
+    =         _y = <redacted>
     =     at tests/sources/aborts-if.move:90:5: multi_abort3_incorrect (exit)

--- a/language/move-prover/tests/sources/aborts-if.move
+++ b/language/move-prover/tests/sources/aborts-if.move
@@ -5,7 +5,7 @@ module TestAbortsIf {
     // -------------------------
 
     // succeeds, because the specification claims no 'aborts_if' condition.
-    fun no_aborts_if(x: u64, y: u64) {
+    fun no_aborts_if(_x: u64, _y: u64) {
         abort 1
     }
     spec fun no_aborts_if {
@@ -25,14 +25,14 @@ module TestAbortsIf {
     }
 
     // fails, because it does not abort when x <= y.
-    fun abort2_incorrect(x: u64, y: u64) {
+    fun abort2_incorrect(_x: u64, _y: u64) {
     }
     spec fun abort2_incorrect {
-        aborts_if x <= y;
+        aborts_if _x <= _y;
     }
 
     // succeeds.
-    fun abort3(x: u64, y: u64) {
+    fun abort3(_x: u64, _y: u64) {
         abort 1
     }
     spec fun abort3 {
@@ -87,21 +87,21 @@ module TestAbortsIf {
     }
 
     // fails, because it also abort when x > y which condition has not been specified.
-    fun multi_abort3_incorrect(x: u64, y: u64) {
+    fun multi_abort3_incorrect(_x: u64, _y: u64) {
         abort 1
     }
     spec fun multi_abort3_incorrect {
-        aborts_if x < y;
-        aborts_if x == y;
+        aborts_if _x < _y;
+        aborts_if _x == _y;
     }
 
     // succeeds. Aborts all the time.
-    fun multi_abort4(x: u64, y: u64) {
+    fun multi_abort4(_x: u64, _y: u64) {
         abort 1
     }
     spec fun multi_abort4 {
-        aborts_if x < y;
-        aborts_if x == y;
-        aborts_if x > y;
+        aborts_if _x < _y;
+        aborts_if _x == _y;
+        aborts_if _x > _y;
     }
 }

--- a/language/move-prover/tests/sources/arithm.move
+++ b/language/move-prover/tests/sources/arithm.move
@@ -51,7 +51,7 @@ module TestArithmetic {
     }
 
     // succeeds.
-	fun arithmetic_ops(a: u64, b: u64): (u64, u64) {
+	fun arithmetic_ops(a: u64): (u64, u64) {
         let c: u64;
         c = (6 + 4 - 1) * 2 / 3 % 4;
         if (c != 2) abort 42;

--- a/language/move-prover/tests/sources/invariants.exp
+++ b/language/move-prover/tests/sources/invariants.exp
@@ -139,9 +139,11 @@ error:  This assertion might not hold.
      =     at tests/sources/invariants.move:144:19: lifetime_invalid_S_branching
      =         b_ref = <redacted>
      =     at tests/sources/invariants.move:145:23: lifetime_invalid_S_branching
+     =         $t5 = <redacted>,
      =         x_ref = <redacted>
      =     at tests/sources/invariants.move:147:11: lifetime_invalid_S_branching
      =     at tests/sources/invariants.move:150:11: lifetime_invalid_S_branching
      =         a_ref = <redacted>,
      =         b_ref = <redacted>,
+     =         $t5 = <redacted>,
      =         x_ref = <redacted>

--- a/language/move-prover/tests/sources/simple_vector_client.move
+++ b/language/move-prover/tests/sources/simple_vector_client.move
@@ -11,18 +11,18 @@ module TestVector {
     // Testing with concrete vectors
     // -----------------------------
 
-    fun test_vector_equal(v: vector<u64>, w: &mut vector<u64>) {
+    fun test_vector_equal(_v: vector<u64>, _w: &mut vector<u64>) {
     }
     spec fun test_vector_equal {
         aborts_if false;
-        ensures v == v;
-        ensures old(v) == old(v);
-        ensures v == v[0..len(v)];
-        ensures old(v) == old(v[0..len(v)]);
-        ensures w == w;
-        ensures old(w) == old(w);
-        ensures w == w[0..len(w)];
-        ensures old(w) == old(w[0..len(w)]);
+        ensures _v == _v;
+        ensures old(_v) == old(_v);
+        ensures _v == _v[0..len(_v)];
+        ensures old(_v) == old(_v[0..len(_v)]);
+        ensures _w == _w;
+        ensures old(_w) == old(_w);
+        ensures _w == _w[0..len(_w)];
+        ensures old(_w) == old(_w[0..len(_w)]);
     }
 
     // succeeds. [] == [].


### PR DESCRIPTION
This sets up the infrastrucure for testing analysis phases (which create annotations) and transformations.

- A printer for stackless bytecode functions.
- The printer supports a mechanism to dump annotations as produced by analysis phases.
- A test driver which executes baseline tests in `stackless-bytecode-generator/tests/<subdir>` where each `subdir` represents a set of tests related to a particular pipeline. These tests are based on printing out the initial bytecode and the bytecode+annotations for the result of running a pipeline.

This new feature is demonstrated on a basic test in `stackless-bytecode-generator/tests/lifetime`.

This PR also adds a new analysis for reaching definitions, and tests it using the above mechanism, but nothing is yet done with the result of this analysis. It also adds some code to `stackless_control_graph.rs` for tracking predecessors blocks in addition to successor blocks, which will allow backward analysis (in a future PR).


## Motivation

Improve prover architecture.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

New infrastructure for tests of bytecode analysis and some concrete tests.

## Related PRs

NA
