### PR TITLE
[cti][land-blocking] Check for valid image and increase timeout

### DIFF
--- a/.github/workflows/land-blocking.yml
+++ b/.github/workflows/land-blocking.yml
@@ -10,7 +10,7 @@ jobs:
   build-and-run-cluster-test:
     name: Build images and run cluster test
     runs-on: self-hosted
-    timeout-minutes: 20
+    timeout-minutes: 25
     steps:
       - uses: actions/checkout@v1
       - name: Setup env

--- a/scripts/cti
+++ b/scripts/cti
@@ -58,11 +58,16 @@ kube_select_cluster () {
   for attempt in {1..360} ; do
     for ((i = 0; i < ${K8S_POOL_SIZE}; i++)); do
       local context=${K8S_CONTEXT_PATTERN/CLUSTERNAME/ct-${i}}
-      local running_pods=$(kubectl --context="${context}" get pods -l app=cluster-test --field-selector=status.phase==Running 2> /dev/null | wc -l)
+      local running_pods=$(kubectl --context="${context}" get pods -l app=cluster-test --field-selector=status.phase==Running 2> /dev/null  | grep -v ^NAME | wc -l)
+      local pending_pods=$(kubectl --context="${context}" get pods -l app=cluster-test --field-selector=status.phase==Pending 2> /dev/null | grep -v ^NAME | wc -l)
       local prometheus_healthy_containers=$(kubectl --context="${context}" get pod/libra-testnet-prometheus-server-0 | grep 'libra-testnet-prometheus-server-0' | awk '{print $2}')
-      if [[ ${prometheus_healthy_containers} != "2/2" ]]; then
-        echo "prometheus is not healthy for ct-${i}"
-      elif [[ $running_pods -eq 0 ]] && [[ ${prometheus_healthy_containers} == "2/2" ]]; then
+      if [[ "${pending_pods}" -gt 0 ]]; then
+        echo "ct-${i} has ${pending_pods} pending pods. Skipping."
+      elif [[ ${prometheus_healthy_containers} != "2/2" ]]; then
+        echo "prometheus is not healthy for ct-${i}. Skipping."
+      elif [[ ${running_pods} -gt 0 ]]; then
+        echo "ct-${i} has ${running_pods} running pods. Skipping."
+      else
         retval_kube_select_cluster="ct-${i}"
         return
       fi
@@ -88,8 +93,15 @@ kube_wait_pod () {
       echo "${pod_name} reached phase : ${phase}"
       return
     fi
+    if kubectl --context="${context}" get pod "${pod_name}" | grep -i -e ImagePullBackOff -e ErrImagePull &>/dev/null; then
+      image_name=$(kubectl --context="${context}" get pod "${pod_name}" -o jsonpath="{.spec.containers[0].image}")
+      echo "${pod_name} name failed to be scheduled because there was an error pulling the image : ${image_name}"
+      # Delete the pod so that it doesn't block other pods from being scheduled on this
+      kubectl  --context="${context}" delete pod "${pod_name}"
+      exit 1
+    fi
     echo "Waiting for ${pod_name} to be scheduled. Current phase : ${phase}"
-    sleep 5
+    sleep 10
   done
   echo "Pod ${pod_name} failed to be scheduled"
   exit 1


### PR DESCRIPTION
## Summary

* Increase GHAR timeout to 25 min
* Ensure in `cti` script that if the cluster-test image does not exist, we delete that pod so as to avoid blocking other workloads from the cluster. If not deleted, kubernetes keeps retrying to pull the image.

## Test Plan

```
% ./scripts/cti -E RUST_LOG=debug --k8s --tag foobarbaz --run bench
Running cluster-test on Kubernetes
Pod Spec : /var/folders/pl/fwpsbmh93mj444lfn6xpyf800000gn/T/tmp.cg2M7VKu
Using cluster : ct-1
pod/cluster-test-kush-1586815615 created
Waiting for cluster-test-kush-1586815615 to be scheduled. Current phase : Pending
cluster-test-kush-1586815615 name failed to be scheduled because there was an error pulling the image : 853397791086.dkr.ecr.us-west-2.amazonaws.com/libra_cluster_test:foobarbaz
pod "cluster-test-kush-1586815615" deleted
```
