### PR TITLE
[crypto] renaming NamespaceKeys -> namespace::Keys

### DIFF
--- a/admission-control/admission-control-service/src/unit_tests/admission_control_service_test.rs
+++ b/admission-control/admission-control-service/src/unit_tests/admission_control_service_test.rs
@@ -10,7 +10,7 @@ use admission_control_proto::{
 };
 use anyhow::Result;
 use futures::executor::block_on;
-use libra_crypto::{ed25519::Ed25519PrivateKey, test_utils::TEST_SEED, PrivateKey, Uniform};
+use libra_crypto::{ed25519::Ed25519PrivateKey, test_utils::TEST_SEED, PrivateKeyExt, Uniform};
 use libra_types::{
     account_address::AccountAddress,
     mempool_status::MempoolStatusCode,

--- a/admission-control/admission-control-service/src/unit_tests/admission_control_service_test.rs
+++ b/admission-control/admission-control-service/src/unit_tests/admission_control_service_test.rs
@@ -10,7 +10,7 @@ use admission_control_proto::{
 };
 use anyhow::Result;
 use futures::executor::block_on;
-use libra_crypto::{ed25519::Ed25519PrivateKey, test_utils::TEST_SEED, PrivateKeyExt, Uniform};
+use libra_crypto::{ed25519, test_utils::TEST_SEED, PrivateKeyExt, Uniform};
 use libra_types::{
     account_address::AccountAddress,
     mempool_status::MempoolStatusCode,
@@ -35,11 +35,11 @@ fn submit_transaction(
     are_keys_valid: bool,
 ) -> SubmitTransactionResponse {
     let mut rng = ::rand::rngs::StdRng::from_seed(TEST_SEED);
-    let private_key = Ed25519PrivateKey::generate(&mut rng);
+    let private_key = ed25519::PrivateKey::generate(&mut rng);
     let public_key = if are_keys_valid {
         private_key.public_key()
     } else {
-        Ed25519PrivateKey::generate(&mut rng).public_key()
+        ed25519::PrivateKey::generate(&mut rng).public_key()
     };
     let mut req = SubmitTransactionRequest::default();
     req.transaction = Some(get_test_signed_txn(sender, 0, &private_key, public_key, None).into());

--- a/client/cli/src/client_proxy.rs
+++ b/client/cli/src/client_proxy.rs
@@ -8,10 +8,7 @@ use crate::{
 };
 use anyhow::{bail, ensure, format_err, Error, Result};
 use libra_crypto::{
-    ed25519::{Ed25519PrivateKey, Ed25519PublicKey, Ed25519Signature},
-    test_utils::KeyPair,
-    x25519::X25519StaticPublicKey,
-    ValidKey, ValidKeyStringExt,
+    ed25519, test_utils::KeyPair, x25519::X25519StaticPublicKey, ValidKey, ValidKeyStringExt,
 };
 use libra_json_rpc::views::{AccountView, BlockMetadata, EventView, TransactionView};
 use libra_logger::prelude::*;
@@ -135,13 +132,13 @@ impl ClientProxy {
         let faucet_account = if faucet_account_file.is_empty() {
             None
         } else {
-            let faucet_account_keypair: KeyPair<Ed25519PrivateKey, Ed25519PublicKey> =
+            let faucet_account_keypair: KeyPair<ed25519::PrivateKey, ed25519::PublicKey> =
                 ClientProxy::load_faucet_account_file(faucet_account_file);
             let faucet_account_data = Self::get_account_data_from_address(
                 &mut client,
                 association_address(),
                 true,
-                Some(KeyPair::<Ed25519PrivateKey, _>::from(
+                Some(KeyPair::<ed25519::PrivateKey, _>::from(
                     faucet_account_keypair.private_key,
                 )),
                 None,
@@ -422,9 +419,9 @@ impl ClientProxy {
             "Invalid number of arguments for registering validator"
         );
         let (address, _) = self.get_account_address_from_parameter(space_delim_strings[1])?;
-        let private_key = Ed25519PrivateKey::from_encoded_string(space_delim_strings[2])?;
-        let consensus_public_key = Ed25519PublicKey::from_encoded_string(space_delim_strings[3])?;
-        let network_signing_key = Ed25519PublicKey::from_encoded_string(space_delim_strings[4])?;
+        let private_key = ed25519::PrivateKey::from_encoded_string(space_delim_strings[2])?;
+        let consensus_public_key = ed25519::PublicKey::from_encoded_string(space_delim_strings[3])?;
+        let network_signing_key = ed25519::PublicKey::from_encoded_string(space_delim_strings[4])?;
         let network_identity_key =
             X25519StaticPublicKey::from_encoded_string(space_delim_strings[5])?;
         let network_address = Multiaddr::from_str(space_delim_strings[6])?;
@@ -718,8 +715,8 @@ impl ClientProxy {
     pub fn submit_signed_transaction(
         &mut self,
         raw_txn: RawTransaction,
-        public_key: Ed25519PublicKey,
-        signature: Ed25519Signature,
+        public_key: ed25519::PublicKey,
+        signature: ed25519::Signature,
     ) -> Result<()> {
         let transaction = SignedTransaction::new(raw_txn, public_key, signature);
 
@@ -1042,7 +1039,7 @@ impl ClientProxy {
         client: &mut LibraClient,
         address: AccountAddress,
         sync_with_validator: bool,
-        key_pair: Option<KeyPair<Ed25519PrivateKey, Ed25519PublicKey>>,
+        key_pair: Option<KeyPair<ed25519::PrivateKey, ed25519::PublicKey>>,
         authentication_key_opt: Option<Vec<u8>>,
     ) -> Result<AccountData> {
         let (sequence_number, authentication_key, status) = if sync_with_validator {
@@ -1098,7 +1095,7 @@ impl ClientProxy {
 
     fn load_faucet_account_file(
         faucet_account_file: &str,
-    ) -> KeyPair<Ed25519PrivateKey, Ed25519PublicKey> {
+    ) -> KeyPair<ed25519::PrivateKey, ed25519::PublicKey> {
         match fs::read(faucet_account_file) {
             Ok(data) => {
                 lcs::from_bytes(&data[..]).expect("Unable to deserialize faucet account file")

--- a/client/cli/src/lib.rs
+++ b/client/cli/src/lib.rs
@@ -9,11 +9,7 @@
 //! Client (binary) is the CLI tool to interact with Libra validator.
 //! It supposes all public APIs.
 
-use libra_crypto::{
-    ed25519::{Ed25519PrivateKey, Ed25519PublicKey},
-    test_utils::KeyPair,
-    traits::ValidKeyStringExt,
-};
+use libra_crypto::{ed25519, test_utils::KeyPair, traits::ValidKeyStringExt};
 use libra_types::account_address::AccountAddress;
 use serde::{Deserialize, Serialize};
 
@@ -38,7 +34,7 @@ pub struct AccountData {
     /// Authentication key of the account.
     pub authentication_key: Option<Vec<u8>>,
     /// (private_key, public_key) pair if the account is not managed by wallet.
-    pub key_pair: Option<KeyPair<Ed25519PrivateKey, Ed25519PublicKey>>,
+    pub key_pair: Option<KeyPair<ed25519::PrivateKey, ed25519::PublicKey>>,
     /// Latest sequence number maintained by client, it can be different from validator.
     pub sequence_number: u64,
     /// Whether the account is initialized on chain, cached local only, or status unknown.

--- a/client/libra-dev/src/account.rs
+++ b/client/libra-dev/src/account.rs
@@ -5,7 +5,7 @@ use crate::{
     data::{LibraAccountKey, LibraStatus},
     error::*,
 };
-use libra_crypto::{ed25519::Ed25519PrivateKey, PrivateKeyExt};
+use libra_crypto::{ed25519, PrivateKeyExt};
 use libra_types::account_address::AccountAddress;
 use std::{convert::TryFrom, slice};
 
@@ -22,9 +22,9 @@ pub unsafe extern "C" fn libra_LibraAccountKey_from(
     }
 
     let private_key_buf: &[u8] =
-        slice::from_raw_parts(private_key_bytes, Ed25519PrivateKey::LENGTH);
+        slice::from_raw_parts(private_key_bytes, ed25519::PrivateKey::LENGTH);
 
-    let private_key = match Ed25519PrivateKey::try_from(private_key_buf) {
+    let private_key = match ed25519::PrivateKey::try_from(private_key_buf) {
         Ok(result) => result,
         Err(e) => {
             update_last_error(format!("Invalid private key bytes: {}", e.to_string()));
@@ -48,7 +48,7 @@ pub unsafe extern "C" fn libra_LibraAccountKey_from(
 fn test_libra_account_from() {
     use libra_crypto::Uniform;
 
-    let private_key = Ed25519PrivateKey::generate_for_testing();
+    let private_key = ed25519::PrivateKey::generate_for_testing();
     let mut libra_account = LibraAccountKey::default();
     let result =
         unsafe { libra_LibraAccountKey_from(private_key.to_bytes().as_ptr(), &mut libra_account) };

--- a/client/libra-dev/src/account.rs
+++ b/client/libra-dev/src/account.rs
@@ -5,7 +5,7 @@ use crate::{
     data::{LibraAccountKey, LibraStatus},
     error::*,
 };
-use libra_crypto::{ed25519::Ed25519PrivateKey, PrivateKey};
+use libra_crypto::{ed25519::Ed25519PrivateKey, PrivateKeyExt};
 use libra_types::account_address::AccountAddress;
 use std::{convert::TryFrom, slice};
 

--- a/client/libra-dev/src/account_resource.rs
+++ b/client/libra-dev/src/account_resource.rs
@@ -4,7 +4,7 @@ use crate::{
     data::{LibraAccountResource, LibraEventHandle, LibraStatus},
     error::*,
 };
-use libra_crypto::ed25519::ED25519_PUBLIC_KEY_LENGTH;
+use libra_crypto::ed25519;
 use libra_types::{account_state::AccountState, account_state_blob::AccountStateBlob};
 use std::{convert::TryFrom, slice};
 
@@ -15,7 +15,7 @@ pub fn libra_LibraAccountResource_from_safe(
     if let Ok(account_state) = AccountState::try_from(&blob) {
         if let Ok(Some(account_resource)) = account_state.get_account_resource() {
             if let Ok(Some(balance_resource)) = account_state.get_balance_resource() {
-                let mut authentication_key = [0u8; ED25519_PUBLIC_KEY_LENGTH];
+                let mut authentication_key = [0u8; ed25519::PUBLIC_KEY_LENGTH];
                 authentication_key.copy_from_slice(account_resource.authentication_key());
 
                 let sent_events = LibraEventHandle {
@@ -76,7 +76,7 @@ mod tests {
     /// Generate an AccountBlob and verify we can parse it
     #[test]
     fn test_get_accountresource() {
-        use libra_crypto::{ed25519::Ed25519PrivateKey, PrivateKeyExt, Uniform};
+        use libra_crypto::{ed25519, PrivateKeyExt, Uniform};
         use libra_types::{
             account_config::{AccountResource, BalanceResource},
             event::{EventHandle, EventKey},
@@ -85,7 +85,7 @@ mod tests {
         };
         use std::collections::BTreeMap;
 
-        let pubkey = Ed25519PrivateKey::generate_for_testing().public_key();
+        let pubkey = ed25519::PrivateKey::generate_for_testing().public_key();
 
         // Figure out how to use Libra code to generate AccountStateBlob directly, not involving btreemap directly
         let mut map: BTreeMap<Vec<u8>, Vec<u8>> = BTreeMap::new();

--- a/client/libra-dev/src/account_resource.rs
+++ b/client/libra-dev/src/account_resource.rs
@@ -76,7 +76,7 @@ mod tests {
     /// Generate an AccountBlob and verify we can parse it
     #[test]
     fn test_get_accountresource() {
-        use libra_crypto::{ed25519::Ed25519PrivateKey, PrivateKey, Uniform};
+        use libra_crypto::{ed25519::Ed25519PrivateKey, PrivateKeyExt, Uniform};
         use libra_types::{
             account_config::{AccountResource, BalanceResource},
             event::{EventHandle, EventKey},

--- a/client/libra-dev/src/event.rs
+++ b/client/libra-dev/src/event.rs
@@ -174,7 +174,7 @@ pub unsafe extern "C" fn libra_LibraEvent_free(ptr: *mut LibraEvent) {
 
 #[test]
 fn test_libra_LibraEvent_from() {
-    use libra_crypto::{ed25519::Ed25519PrivateKey, PrivateKeyExt, Uniform};
+    use libra_crypto::{ed25519, PrivateKeyExt, Uniform};
     use libra_types::{
         account_address::AccountAddress,
         account_config::SentPaymentEvent,
@@ -185,7 +185,7 @@ fn test_libra_LibraEvent_from() {
     use move_core_types::identifier::Identifier;
     use std::ffi::CStr;
 
-    let public_key = Ed25519PrivateKey::generate_for_testing().public_key();
+    let public_key = ed25519::PrivateKey::generate_for_testing().public_key();
     let sender_address = AccountAddress::from_public_key(&public_key);
     let sent_event_handle = EventHandle::new(EventKey::new_from_address(&sender_address, 0), 0);
     let sequence_number = sent_event_handle.count();

--- a/client/libra-dev/src/event.rs
+++ b/client/libra-dev/src/event.rs
@@ -174,7 +174,7 @@ pub unsafe extern "C" fn libra_LibraEvent_free(ptr: *mut LibraEvent) {
 
 #[test]
 fn test_libra_LibraEvent_from() {
-    use libra_crypto::{ed25519::Ed25519PrivateKey, PrivateKey, Uniform};
+    use libra_crypto::{ed25519::Ed25519PrivateKey, PrivateKeyExt, Uniform};
     use libra_types::{
         account_address::AccountAddress,
         account_config::SentPaymentEvent,

--- a/client/libra-dev/src/lib.rs
+++ b/client/libra-dev/src/lib.rs
@@ -16,10 +16,10 @@ pub mod transaction;
 use crate::data::{
     LIBRA_ADDRESS_SIZE, LIBRA_EVENT_KEY_SIZE, LIBRA_PRIVKEY_SIZE, LIBRA_PUBKEY_SIZE,
 };
-use libra_crypto::ed25519::{ED25519_PRIVATE_KEY_LENGTH, ED25519_PUBLIC_KEY_LENGTH};
+use libra_crypto::ed25519;
 use libra_types::{account_address::AccountAddress, event::EventKey};
 
-static_assertions::const_assert_eq!(LIBRA_PUBKEY_SIZE, ED25519_PUBLIC_KEY_LENGTH as u32);
-static_assertions::const_assert_eq!(LIBRA_PRIVKEY_SIZE, ED25519_PRIVATE_KEY_LENGTH as u32);
+static_assertions::const_assert_eq!(LIBRA_PUBKEY_SIZE, ed25519::PUBLIC_KEY_LENGTH as u32);
+static_assertions::const_assert_eq!(LIBRA_PRIVKEY_SIZE, ed25519::PRIVATE_KEY_LENGTH as u32);
 static_assertions::const_assert_eq!(LIBRA_ADDRESS_SIZE, AccountAddress::LENGTH as u32);
 static_assertions::const_assert_eq!(LIBRA_EVENT_KEY_SIZE, EventKey::LENGTH as u32);

--- a/client/libra-dev/src/transaction.rs
+++ b/client/libra-dev/src/transaction.rs
@@ -10,11 +10,7 @@ use crate::{
     error::*,
 };
 use lcs::to_bytes;
-use libra_crypto::{
-    ed25519::{Ed25519PrivateKey, Ed25519PublicKey, Ed25519Signature},
-    test_utils::KeyPair,
-    PrivateKeyExt,
-};
+use libra_crypto::{ed25519, test_utils::KeyPair, PrivateKeyExt};
 use libra_types::{
     account_address::AccountAddress,
     account_config::{lbr_type_tag, LBR_NAME},
@@ -45,8 +41,8 @@ pub unsafe extern "C" fn libra_SignedTransactionBytes_from(
         return LibraStatus::InvalidArgument;
     }
     let private_key_buf: &[u8] =
-        slice::from_raw_parts(sender_private_key_bytes, Ed25519PrivateKey::LENGTH);
-    let private_key = match Ed25519PrivateKey::try_from(private_key_buf) {
+        slice::from_raw_parts(sender_private_key_bytes, ed25519::PrivateKey::LENGTH);
+    let private_key = match ed25519::PrivateKey::try_from(private_key_buf) {
         Ok(result) => result,
         Err(e) => {
             update_last_error(format!("Invalid private key bytes: {}", e.to_string()));
@@ -242,7 +238,7 @@ pub unsafe extern "C" fn libra_RawTransaction_sign(
         return LibraStatus::InvalidArgument;
     }
     let public_key_bytes: &[u8] = slice::from_raw_parts(buf_public_key, len_public_key);
-    let public_key = match Ed25519PublicKey::try_from(public_key_bytes) {
+    let public_key = match ed25519::PublicKey::try_from(public_key_bytes) {
         Ok(result) => result,
         Err(e) => {
             update_last_error(format!("Invalid public key bytes: {}", e.to_string()));
@@ -255,7 +251,7 @@ pub unsafe extern "C" fn libra_RawTransaction_sign(
         return LibraStatus::InvalidArgument;
     }
     let signature_bytes: &[u8] = slice::from_raw_parts(buf_signature, len_signature);
-    let signature = match Ed25519Signature::try_from(signature_bytes) {
+    let signature = match ed25519::Signature::try_from(signature_bytes) {
         Ok(result) => result,
         Err(e) => {
             update_last_error(format!("Invalid signature bytes: {}", e.to_string()));
@@ -408,7 +404,7 @@ mod test {
     #[test]
     fn test_lcs_signed_transaction() {
         // generate key pair
-        let private_key = Ed25519PrivateKey::generate_for_testing();
+        let private_key = ed25519::PrivateKey::generate_for_testing();
         let public_key = private_key.public_key();
         let private_key_bytes = private_key.to_bytes();
 
@@ -495,7 +491,7 @@ mod test {
     /// Generate a Raw Transaction, sign it, then deserialize
     #[test]
     fn test_libra_raw_transaction_bytes_from() {
-        let private_key = Ed25519PrivateKey::generate_for_testing();
+        let private_key = ed25519::PrivateKey::generate_for_testing();
         let public_key = private_key.public_key();
 
         // create transfer parameters
@@ -578,7 +574,7 @@ mod test {
     /// Generate a Signed Transaction and deserialize
     #[test]
     fn test_libra_signed_transaction_deserialize() {
-        let public_key = Ed25519PrivateKey::generate_for_testing().public_key();
+        let public_key = ed25519::PrivateKey::generate_for_testing().public_key();
         let sender = AccountAddress::random();
         let receiver_auth_key = AuthenticationKey::random();
         let sequence_number = 1;
@@ -586,7 +582,8 @@ mod test {
         let max_gas_amount = 10;
         let gas_unit_price = 1;
         let expiration_time_secs = 5;
-        let signature = Ed25519Signature::try_from(&[1u8; Ed25519Signature::LENGTH][..]).unwrap();
+        let signature =
+            ed25519::Signature::try_from(&[1u8; ed25519::Signature::LENGTH][..]).unwrap();
 
         let program = encode_transfer_script(
             lbr_type_tag(),
@@ -660,7 +657,7 @@ mod test {
         assert_eq!(public_key.to_bytes(), libra_signed_txn.public_key);
         assert_eq!(
             signature,
-            Ed25519Signature::try_from(libra_signed_txn.signature.as_ref()).unwrap()
+            ed25519::Signature::try_from(libra_signed_txn.signature.as_ref()).unwrap()
         );
         assert_eq!(
             expiration_time_secs,

--- a/client/libra-dev/src/transaction.rs
+++ b/client/libra-dev/src/transaction.rs
@@ -13,7 +13,7 @@ use lcs::to_bytes;
 use libra_crypto::{
     ed25519::{Ed25519PrivateKey, Ed25519PublicKey, Ed25519Signature},
     test_utils::KeyPair,
-    PrivateKey,
+    PrivateKeyExt,
 };
 use libra_types::{
     account_address::AccountAddress,
@@ -400,7 +400,7 @@ pub unsafe extern "C" fn libra_LibraSignedTransaction_from(
 mod test {
     use super::*;
     use lcs::from_bytes;
-    use libra_crypto::{hash::CryptoHash, PrivateKey, SigningKey, Uniform};
+    use libra_crypto::{hash::CryptoHash, PrivateKeyExt, SigningKey, Uniform};
     use libra_types::transaction::{SignedTransaction, TransactionArgument};
     use std::ffi::CStr;
 

--- a/config/config-builder/src/full_node_config.rs
+++ b/config/config-builder/src/full_node_config.rs
@@ -7,7 +7,7 @@ use libra_config::{
     config::{NetworkPeersConfig, NodeConfig, RoleType, SeedPeersConfig, UpstreamPeersConfig},
     utils,
 };
-use libra_crypto::ed25519::Ed25519PrivateKey;
+use libra_crypto::ed25519;
 use libra_types::transaction::Transaction;
 use parity_multiaddr::Multiaddr;
 use rand::{rngs::StdRng, SeedableRng};
@@ -157,7 +157,7 @@ impl FullNodeConfig {
     fn build_internal(
         &self,
         randomize_ports: bool,
-    ) -> Result<(Vec<NodeConfig>, Ed25519PrivateKey)> {
+    ) -> Result<(Vec<NodeConfig>, ed25519::PrivateKey)> {
         ensure!(self.full_nodes > 0, Error::NonZeroNetwork);
         ensure!(
             self.full_node_index < self.full_nodes,
@@ -252,7 +252,7 @@ impl FullNodeConfig {
 }
 
 impl BuildSwarm for FullNodeConfig {
-    fn build_swarm(&self) -> Result<(Vec<NodeConfig>, Ed25519PrivateKey)> {
+    fn build_swarm(&self) -> Result<(Vec<NodeConfig>, ed25519::PrivateKey)> {
         let (mut configs, faucet_key) = self.build_internal(true)?;
         configs.swap_remove(configs.len() - 1);
         Ok((configs, faucet_key))

--- a/config/config-builder/src/main.rs
+++ b/config/config-builder/src/main.rs
@@ -5,10 +5,7 @@
 
 use config_builder::{FullNodeConfig, ValidatorConfig};
 use libra_config::config::NodeConfig;
-use libra_crypto::{
-    ed25519::{Ed25519PrivateKey, Ed25519PublicKey},
-    test_utils::KeyPair,
-};
+use libra_crypto::{ed25519, test_utils::KeyPair};
 use parity_multiaddr::Multiaddr;
 use std::{
     convert::TryInto,
@@ -188,7 +185,7 @@ fn build_faucet(args: FaucetArgs) {
 
     let faucet_key = config_builder.build_faucet_client();
     let key_path = args.output_dir.join("mint.key");
-    let faucet_keypair = KeyPair::<Ed25519PrivateKey, Ed25519PublicKey>::from(faucet_key);
+    let faucet_keypair = KeyPair::<ed25519::PrivateKey, ed25519::PublicKey>::from(faucet_key);
     let serialized_keys = lcs::to_bytes(&faucet_keypair).expect("Unable to serialize keys");
 
     fs::create_dir_all(&args.output_dir).expect("Unable to create output directory");

--- a/config/config-builder/src/swarm_config.rs
+++ b/config/config-builder/src/swarm_config.rs
@@ -3,15 +3,12 @@
 
 use anyhow::Result;
 use libra_config::config::NodeConfig;
-use libra_crypto::{
-    ed25519::{Ed25519PrivateKey, Ed25519PublicKey},
-    test_utils::KeyPair,
-};
+use libra_crypto::{ed25519, test_utils::KeyPair};
 use std::{fs::File, io::Write, path::PathBuf};
 
 pub trait BuildSwarm {
     /// Generate the configs for a swarm
-    fn build_swarm(&self) -> Result<(Vec<NodeConfig>, Ed25519PrivateKey)>;
+    fn build_swarm(&self) -> Result<(Vec<NodeConfig>, ed25519::PrivateKey)>;
 }
 
 pub struct SwarmConfig {
@@ -35,7 +32,7 @@ impl SwarmConfig {
         }
 
         let faucet_key_path = output_dir.join("mint.key");
-        let faucet_keypair = KeyPair::<Ed25519PrivateKey, Ed25519PublicKey>::from(faucet_key);
+        let faucet_keypair = KeyPair::<ed25519::PrivateKey, ed25519::PublicKey>::from(faucet_key);
         let serialized_keys = lcs::to_bytes(&faucet_keypair)?;
         let mut key_file = File::create(&faucet_key_path)?;
         key_file.write_all(&serialized_keys)?;

--- a/config/config-builder/src/validator_config.rs
+++ b/config/config-builder/src/validator_config.rs
@@ -10,7 +10,7 @@ use libra_config::{
     },
     generator::{self, ValidatorSwarm},
 };
-use libra_crypto::{ed25519::Ed25519PrivateKey, PrivateKey, Uniform};
+use libra_crypto::{ed25519::Ed25519PrivateKey, PrivateKeyExt, Uniform};
 use libra_types::{discovery_set::DiscoverySet, validator_set::ValidatorSet};
 use parity_multiaddr::Multiaddr;
 use rand::{rngs::StdRng, Rng, SeedableRng};

--- a/config/config-builder/src/validator_config.rs
+++ b/config/config-builder/src/validator_config.rs
@@ -10,7 +10,7 @@ use libra_config::{
     },
     generator::{self, ValidatorSwarm},
 };
-use libra_crypto::{ed25519::Ed25519PrivateKey, PrivateKeyExt, Uniform};
+use libra_crypto::{ed25519, PrivateKeyExt, Uniform};
 use libra_types::{discovery_set::DiscoverySet, validator_set::ValidatorSet};
 use parity_multiaddr::Multiaddr;
 use rand::{rngs::StdRng, Rng, SeedableRng};
@@ -157,7 +157,7 @@ impl ValidatorConfig {
         Ok(configs)
     }
 
-    pub fn build_faucet_client(&self) -> Ed25519PrivateKey {
+    pub fn build_faucet_client(&self) -> ed25519::PrivateKey {
         let (faucet_key, _) = self.build_faucet();
         faucet_key
     }
@@ -166,7 +166,7 @@ impl ValidatorConfig {
         &self,
         randomize_service_ports: bool,
         randomize_libranet_ports: bool,
-    ) -> Result<(Vec<NodeConfig>, Ed25519PrivateKey)> {
+    ) -> Result<(Vec<NodeConfig>, ed25519::PrivateKey)> {
         ensure!(self.nodes > 0, Error::NonZeroNetwork);
         ensure!(
             self.index < self.nodes,
@@ -227,9 +227,9 @@ impl ValidatorConfig {
         Ok((nodes, faucet_key))
     }
 
-    fn build_faucet(&self) -> (Ed25519PrivateKey, [u8; 32]) {
+    fn build_faucet(&self) -> (ed25519::PrivateKey, [u8; 32]) {
         let mut faucet_rng = StdRng::from_seed(self.seed);
-        let faucet_key = Ed25519PrivateKey::generate(&mut faucet_rng);
+        let faucet_key = ed25519::PrivateKey::generate(&mut faucet_rng);
         let config_seed: [u8; 32] = faucet_rng.gen();
         (faucet_key, config_seed)
     }
@@ -270,12 +270,12 @@ impl ValidatorConfig {
 }
 
 impl BuildSwarm for ValidatorConfig {
-    fn build_swarm(&self) -> Result<(Vec<NodeConfig>, Ed25519PrivateKey)> {
+    fn build_swarm(&self) -> Result<(Vec<NodeConfig>, ed25519::PrivateKey)> {
         self.build_common(true, true)
     }
 }
 
-pub fn test_config() -> (NodeConfig, Ed25519PrivateKey) {
+pub fn test_config() -> (NodeConfig, ed25519::PrivateKey) {
     let validator_config = ValidatorConfig::new();
     let (mut configs, key) = validator_config.build_swarm().unwrap();
     (configs.swap_remove(0), key)

--- a/config/generate-keypair/src/lib.rs
+++ b/config/generate-keypair/src/lib.rs
@@ -4,11 +4,7 @@
 #![forbid(unsafe_code)]
 
 use anyhow::Result;
-use libra_crypto::{
-    ed25519::{Ed25519PrivateKey, Ed25519PublicKey},
-    test_utils::KeyPair,
-    Uniform,
-};
+use libra_crypto::{ed25519, test_utils::KeyPair, Uniform};
 use libra_temppath::TempPath;
 use rand::{rngs::OsRng, Rng, SeedableRng};
 use std::{
@@ -17,7 +13,9 @@ use std::{
     path::Path,
 };
 
-pub fn create_faucet_key_file(output_file: &str) -> KeyPair<Ed25519PrivateKey, Ed25519PublicKey> {
+pub fn create_faucet_key_file(
+    output_file: &str,
+) -> KeyPair<ed25519::PrivateKey, ed25519::PublicKey> {
     let output_file_path = Path::new(&output_file);
 
     if output_file_path.exists() && !output_file_path.is_file() {
@@ -27,7 +25,7 @@ pub fn create_faucet_key_file(output_file: &str) -> KeyPair<Ed25519PrivateKey, E
     let mut seed_rng = OsRng::new().expect("can't access OsRng");
     let mut rng = rand::rngs::StdRng::from_seed(seed_rng.gen());
 
-    let private_key = Ed25519PrivateKey::generate(&mut rng);
+    let private_key = ed25519::PrivateKey::generate(&mut rng);
     let keypair = KeyPair::from(private_key);
 
     // Write to disk
@@ -42,7 +40,7 @@ pub fn create_faucet_key_file(output_file: &str) -> KeyPair<Ed25519PrivateKey, E
 /// Tries to load a keypair from the path given as argument
 pub fn load_key_from_file<P: AsRef<Path>>(
     path: P,
-) -> Result<KeyPair<Ed25519PrivateKey, Ed25519PublicKey>> {
+) -> Result<KeyPair<ed25519::PrivateKey, ed25519::PublicKey>> {
     lcs::from_bytes(&fs::read(path)?[..]).map_err(Into::into)
 }
 
@@ -52,7 +50,7 @@ pub fn load_key_from_file<P: AsRef<Path>>(
 pub fn load_faucet_key_or_create_default(
     file_path: Option<String>,
 ) -> (
-    KeyPair<Ed25519PrivateKey, Ed25519PublicKey>,
+    KeyPair<ed25519::PrivateKey, ed25519::PublicKey>,
     String,
     Option<TempPath>,
 ) {

--- a/config/src/config/network_config.rs
+++ b/config/src/config/network_config.rs
@@ -8,7 +8,7 @@ use crate::{
 };
 use anyhow::{anyhow, ensure, Result};
 use libra_crypto::{
-    ed25519::{Ed25519PrivateKey, Ed25519PublicKey},
+    ed25519,
     x25519::{X25519StaticPrivateKey, X25519StaticPublicKey},
     Uniform, ValidKey,
 };
@@ -175,7 +175,7 @@ impl NetworkConfig {
     }
 
     pub fn random_with_peer_id(&mut self, rng: &mut StdRng, peer_id: Option<PeerId>) {
-        let signing_key = Ed25519PrivateKey::generate(rng);
+        let signing_key = ed25519::PrivateKey::generate(rng);
         let identity_key = X25519StaticPrivateKey::generate(rng);
         let network_keypairs = NetworkKeyPairs::load(signing_key, identity_key);
         self.peer_id = if let Some(peer_id) = peer_id {
@@ -200,14 +200,14 @@ pub struct SeedPeersConfig {
 #[cfg_attr(any(test, feature = "fuzzing"), derive(Clone))]
 #[derive(Debug, Default, Deserialize, PartialEq, Serialize)]
 pub struct NetworkKeyPairs {
-    pub signing_keys: KeyPair<Ed25519PrivateKey>,
+    pub signing_keys: KeyPair<ed25519::PrivateKey>,
     pub identity_keys: KeyPair<X25519StaticPrivateKey>,
 }
 
 impl NetworkKeyPairs {
     // used in testing to fill the structure with test keypairs
     pub fn load(
-        signing_private_key: Ed25519PrivateKey,
+        signing_private_key: ed25519::PrivateKey,
         identity_private_key: X25519StaticPrivateKey,
     ) -> Self {
         Self {
@@ -240,7 +240,7 @@ impl std::fmt::Debug for NetworkPeersConfig {
 #[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
 pub struct NetworkPeerInfo {
     #[serde(rename = "ns")]
-    pub signing_public_key: Ed25519PublicKey,
+    pub signing_public_key: ed25519::PublicKey,
     #[serde(rename = "ni")]
     pub identity_public_key: X25519StaticPublicKey,
 }

--- a/config/src/config/test_config.rs
+++ b/config/src/config/test_config.rs
@@ -2,15 +2,15 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::keys::KeyPair;
-use libra_crypto::{ed25519::Ed25519PrivateKey, Uniform};
+use libra_crypto::{ed25519, Uniform};
 use libra_temppath::TempPath;
 use libra_types::on_chain_config::VMPublishingOption;
 use rand::rngs::StdRng;
 use serde::{Deserialize, Serialize};
 use std::path::Path;
 
-type AccountKeyPair = KeyPair<Ed25519PrivateKey>;
-type ConsensusKeyPair = KeyPair<Ed25519PrivateKey>;
+type AccountKeyPair = KeyPair<ed25519::PrivateKey>;
+type ConsensusKeyPair = KeyPair<ed25519::PrivateKey>;
 
 #[derive(Debug, Default, Deserialize, Serialize)]
 pub struct TestConfig {
@@ -65,12 +65,12 @@ impl TestConfig {
     }
 
     pub fn random_account_key(&mut self, rng: &mut StdRng) {
-        let privkey = Ed25519PrivateKey::generate(rng);
+        let privkey = ed25519::PrivateKey::generate(rng);
         self.account_keypair = Some(AccountKeyPair::load(privkey));
     }
 
     pub fn random_consensus_key(&mut self, rng: &mut StdRng) {
-        let privkey = Ed25519PrivateKey::generate(rng);
+        let privkey = ed25519::PrivateKey::generate(rng);
         self.consensus_keypair = Some(ConsensusKeyPair::load(privkey));
     }
 

--- a/config/src/keys.rs
+++ b/config/src/keys.rs
@@ -1,7 +1,7 @@
 // Copyright (c) The Libra Core Contributors
 // SPDX-License-Identifier: Apache-2.0
 
-use libra_crypto::{PrivateKey, Uniform, ValidKeyStringExt};
+use libra_crypto::{PrivateKeyExt, Uniform, ValidKeyStringExt};
 use mirai_annotations::verify_unreachable;
 use serde::{de::DeserializeOwned, Deserialize, Deserializer, Serialize, Serializer};
 
@@ -15,7 +15,7 @@ pub enum PrivateKeyContainer<T> {
 
 impl<T> PrivateKeyContainer<T>
 where
-    T: PrivateKey,
+    T: PrivateKeyExt,
 {
     pub fn take(&mut self) -> Option<T> {
         match self {
@@ -67,7 +67,7 @@ where
 #[derive(Debug, Deserialize, PartialEq, Serialize)]
 pub struct KeyPair<T>
 where
-    T: PrivateKey + Serialize + ValidKeyStringExt,
+    T: PrivateKeyExt + Serialize + ValidKeyStringExt,
 {
     #[serde(bound(deserialize = "PrivateKeyContainer<T>: Deserialize<'de>"))]
     private_key: PrivateKeyContainer<T>,
@@ -76,7 +76,7 @@ where
 
 impl<T> Default for KeyPair<T>
 where
-    T: PrivateKey + Serialize + Uniform + ValidKeyStringExt,
+    T: PrivateKeyExt + Serialize + Uniform + ValidKeyStringExt,
     T::PublicKeyMaterial: DeserializeOwned + 'static + Serialize + ValidKeyStringExt,
 {
     fn default() -> Self {
@@ -91,7 +91,7 @@ where
 
 impl<T> KeyPair<T>
 where
-    T: PrivateKey + Serialize + ValidKeyStringExt,
+    T: PrivateKeyExt + Serialize + ValidKeyStringExt,
     T::PublicKeyMaterial: DeserializeOwned + 'static + Serialize + ValidKeyStringExt,
 {
     pub fn load(private_key: T) -> Self {

--- a/consensus/consensus-types/src/block.rs
+++ b/consensus/consensus-types/src/block.rs
@@ -7,7 +7,7 @@ use crate::{
     quorum_cert::QuorumCert,
 };
 use anyhow::{bail, ensure, format_err};
-use libra_crypto::{ed25519::Ed25519Signature, hash::CryptoHash, HashValue};
+use libra_crypto::{ed25519, hash::CryptoHash, HashValue};
 use libra_types::{
     block_info::BlockInfo, block_metadata::BlockMetadata, ledger_info::LedgerInfo,
     transaction::Version, validator_set::ValidatorSet, validator_signer::ValidatorSigner,
@@ -36,7 +36,7 @@ pub struct Block<T> {
     block_data: BlockData<T>,
     /// Signature that the hash of this block has been authored by the owner of the private key,
     /// this is only set within Proposal blocks
-    signature: Option<Ed25519Signature>,
+    signature: Option<ed25519::Signature>,
 }
 
 impl<T> fmt::Debug for Block<T> {
@@ -95,7 +95,7 @@ impl<T> Block<T> {
         self.block_data.round()
     }
 
-    pub fn signature(&self) -> Option<&Ed25519Signature> {
+    pub fn signature(&self) -> Option<&ed25519::Signature> {
         self.signature.as_ref()
     }
 
@@ -267,7 +267,7 @@ impl<'de, T: DeserializeOwned + Serialize> Deserialize<'de> for Block<T> {
         struct BlockWithoutId<T> {
             #[serde(bound(deserialize = "BlockData<T>: Deserialize<'de>"))]
             block_data: BlockData<T>,
-            signature: Option<Ed25519Signature>,
+            signature: Option<ed25519::Signature>,
         };
 
         let BlockWithoutId {

--- a/consensus/consensus-types/src/block_test_utils.rs
+++ b/consensus/consensus-types/src/block_test_utils.rs
@@ -6,7 +6,7 @@ use crate::{
     vote_data::VoteData,
 };
 use libra_crypto::{
-    ed25519::Ed25519PrivateKey,
+    ed25519,
     hash::{CryptoHash, HashValue},
 };
 use libra_types::{
@@ -149,7 +149,7 @@ prop_compose! {
 /// vector
 fn block_forest_from_keys(
     depth: u32,
-    keypairs: Vec<Ed25519PrivateKey>,
+    keypairs: Vec<ed25519::PrivateKey>,
 ) -> impl Strategy<Value = LinearizedBlockForest<Vec<usize>>> {
     let leaf = leaf_strategy().prop_map(|block| vec![block]);
     // Note that having `expected_branch_size` of 1 seems to generate significantly larger trees
@@ -164,7 +164,7 @@ fn block_forest_from_keys(
 pub fn block_forest_and_its_keys(
     quorum_size: usize,
     depth: u32,
-) -> impl Strategy<Value = (Vec<Ed25519PrivateKey>, LinearizedBlockForest<Vec<usize>>)> {
+) -> impl Strategy<Value = (Vec<ed25519::PrivateKey>, LinearizedBlockForest<Vec<usize>>)> {
     proptest::collection::vec(proptests::arb_signing_key(), quorum_size).prop_flat_map(
         move |private_key| {
             (

--- a/consensus/consensus-types/src/timeout.rs
+++ b/consensus/consensus-types/src/timeout.rs
@@ -3,7 +3,7 @@
 
 use crate::{block::Block, common::Round};
 use libra_crypto::{
-    ed25519::Ed25519Signature,
+    ed25519,
     hash::{CryptoHash, CryptoHasher, HashValue},
 };
 use libra_crypto_derive::CryptoHasher;
@@ -41,7 +41,7 @@ impl Timeout {
         self.round
     }
 
-    pub fn sign(&self, signer: &ValidatorSigner) -> Ed25519Signature {
+    pub fn sign(&self, signer: &ValidatorSigner) -> ed25519::Signature {
         signer.sign_message(self.hash())
     }
 }

--- a/consensus/consensus-types/src/timeout_certificate.rs
+++ b/consensus/consensus-types/src/timeout_certificate.rs
@@ -6,7 +6,7 @@ use crate::{
     timeout::Timeout,
 };
 use anyhow::Context;
-use libra_crypto::{ed25519::Ed25519Signature, hash::CryptoHash};
+use libra_crypto::{ed25519, hash::CryptoHash};
 use libra_types::validator_verifier::ValidatorVerifier;
 use serde::{Deserialize, Serialize};
 use std::{collections::BTreeMap, fmt};
@@ -16,7 +16,7 @@ use std::{collections::BTreeMap, fmt};
 /// have voted in round r and we can now move to round r+1.
 pub struct TimeoutCertificate {
     timeout: Timeout,
-    signatures: BTreeMap<Author, Ed25519Signature>,
+    signatures: BTreeMap<Author, ed25519::Signature>,
 }
 
 impl fmt::Display for TimeoutCertificate {
@@ -59,11 +59,11 @@ impl TimeoutCertificate {
     }
 
     /// Returns the signatures certifying the round
-    pub fn signatures(&self) -> &BTreeMap<Author, Ed25519Signature> {
+    pub fn signatures(&self) -> &BTreeMap<Author, ed25519::Signature> {
         &self.signatures
     }
 
-    pub fn add_signature(&mut self, author: Author, signature: Ed25519Signature) {
+    pub fn add_signature(&mut self, author: Author, signature: ed25519::Signature) {
         self.signatures.entry(author).or_insert(signature);
     }
 

--- a/consensus/consensus-types/src/vote.rs
+++ b/consensus/consensus-types/src/vote.rs
@@ -3,7 +3,7 @@
 
 use crate::{common::Author, timeout::Timeout, vote_data::VoteData};
 use anyhow::{ensure, Context};
-use libra_crypto::{ed25519::Ed25519Signature, hash::CryptoHash};
+use libra_crypto::{ed25519, hash::CryptoHash};
 use libra_types::{
     ledger_info::LedgerInfo, validator_signer::ValidatorSigner,
     validator_verifier::ValidatorVerifier,
@@ -24,9 +24,9 @@ pub struct Vote {
     /// LedgerInfo of a block that is going to be committed in case this vote gathers QC.
     ledger_info: LedgerInfo,
     /// Signature of the LedgerInfo
-    signature: Ed25519Signature,
+    signature: ed25519::Signature,
     /// The round signatures can be aggregated into a timeout certificate if present.
-    timeout_signature: Option<Ed25519Signature>,
+    timeout_signature: Option<ed25519::Signature>,
 }
 
 impl Display for Vote {
@@ -64,7 +64,7 @@ impl Vote {
 
     /// Generates a round signature, which can then be used for aggregating a timeout certificate.
     /// Typically called for generating vote messages that are sent upon timeouts.
-    pub fn add_timeout_signature(&mut self, signature: Ed25519Signature) {
+    pub fn add_timeout_signature(&mut self, signature: ed25519::Signature) {
         if self.timeout_signature.is_some() {
             return; // round signature is already set
         }
@@ -87,7 +87,7 @@ impl Vote {
     }
 
     /// Return the signature of the vote
-    pub fn signature(&self) -> &Ed25519Signature {
+    pub fn signature(&self) -> &ed25519::Signature {
         &self.signature
     }
 
@@ -106,7 +106,7 @@ impl Vote {
 
     /// Returns the signature for the vote_data().proposed().round() that can be aggregated for
     /// TimeoutCertificate.
-    pub fn timeout_signature(&self) -> Option<&Ed25519Signature> {
+    pub fn timeout_signature(&self) -> Option<&ed25519::Signature> {
         self.timeout_signature.as_ref()
     }
 

--- a/consensus/safety-rules/src/local_client.rs
+++ b/consensus/safety-rules/src/local_client.rs
@@ -6,7 +6,7 @@ use consensus_types::{
     block::Block, block_data::BlockData, common::Payload, quorum_cert::QuorumCert,
     timeout::Timeout, vote::Vote, vote_proposal::VoteProposal,
 };
-use libra_crypto::ed25519::Ed25519Signature;
+use libra_crypto::ed25519;
 use std::sync::{Arc, RwLock};
 
 /// A local interface into SafetyRules. Constructed in such a way that the container / caller
@@ -46,7 +46,7 @@ impl<T: Payload> TSafetyRules<T> for LocalClient<T> {
         self.internal.write().unwrap().sign_proposal(block_data)
     }
 
-    fn sign_timeout(&mut self, timeout: &Timeout) -> Result<Ed25519Signature, Error> {
+    fn sign_timeout(&mut self, timeout: &Timeout) -> Result<ed25519::Signature, Error> {
         self.internal.write().unwrap().sign_timeout(timeout)
     }
 }

--- a/consensus/safety-rules/src/persistent_safety_storage.rs
+++ b/consensus/safety-rules/src/persistent_safety_storage.rs
@@ -3,7 +3,7 @@
 
 use anyhow::Result;
 use consensus_types::common::Round;
-use libra_crypto::ed25519::Ed25519PrivateKey;
+use libra_crypto::ed25519;
 use libra_secure_storage::{InMemoryStorage, Policy, Storage, Value};
 
 /// SafetyRules needs an abstract storage interface to act as a common utility for storing
@@ -21,7 +21,7 @@ const LAST_VOTED_ROUND: &str = "last_voted_round";
 const PREFERRED_ROUND: &str = "preferred_round";
 
 impl PersistentSafetyStorage {
-    pub fn in_memory(private_key: Ed25519PrivateKey) -> Self {
+    pub fn in_memory(private_key: ed25519::PrivateKey) -> Self {
         let storage = InMemoryStorage::new_storage();
         Self::initialize(storage, private_key)
     }
@@ -30,7 +30,7 @@ impl PersistentSafetyStorage {
     /// SafetyRules values set.
     pub fn initialize(
         mut internal_store: Box<dyn Storage>,
-        private_key: Ed25519PrivateKey,
+        private_key: ed25519::PrivateKey,
     ) -> Self {
         let perms = Policy::public();
         internal_store
@@ -54,14 +54,14 @@ impl PersistentSafetyStorage {
         Self { internal_store }
     }
 
-    pub fn consensus_key(&self) -> Result<Ed25519PrivateKey> {
+    pub fn consensus_key(&self) -> Result<ed25519::PrivateKey> {
         Ok(self
             .internal_store
             .get(CONSENSUS_KEY)
             .and_then(|r| r.value.ed25519_private_key())?)
     }
 
-    pub fn set_consensus_key(&mut self, consensus_key: Ed25519PrivateKey) -> Result<()> {
+    pub fn set_consensus_key(&mut self, consensus_key: ed25519::PrivateKey) -> Result<()> {
         self.internal_store
             .set(CONSENSUS_KEY, Value::Ed25519PrivateKey(consensus_key))?;
         Ok(())

--- a/consensus/safety-rules/src/process_client_wrapper.rs
+++ b/consensus/safety-rules/src/process_client_wrapper.rs
@@ -15,7 +15,7 @@ use libra_config::{
     config::{ConsensusType, NodeConfig, RemoteService, SafetyRulesBackend, SafetyRulesService},
     utils,
 };
-use libra_crypto::ed25519::Ed25519Signature;
+use libra_crypto::ed25519;
 use libra_types::validator_signer::ValidatorSigner;
 use std::{
     any::TypeId,
@@ -97,7 +97,7 @@ impl<T: Payload> TSafetyRules<T> for ProcessClientWrapper<T> {
         self.safety_rules.sign_proposal(block_data)
     }
 
-    fn sign_timeout(&mut self, timeout: &Timeout) -> Result<Ed25519Signature, Error> {
+    fn sign_timeout(&mut self, timeout: &Timeout) -> Result<ed25519::Signature, Error> {
         self.safety_rules.sign_timeout(timeout)
     }
 }

--- a/consensus/safety-rules/src/safety_rules.rs
+++ b/consensus/safety-rules/src/safety_rules.rs
@@ -15,7 +15,7 @@ use consensus_types::{
     vote_data::VoteData,
     vote_proposal::VoteProposal,
 };
-use libra_crypto::{ed25519::Ed25519Signature, hash::HashValue};
+use libra_crypto::{ed25519, hash::HashValue};
 use libra_logger::debug;
 use libra_types::{
     block_info::BlockInfo, ledger_info::LedgerInfo, validator_signer::ValidatorSigner,
@@ -191,7 +191,7 @@ impl<T: Payload> TSafetyRules<T> for SafetyRules<T> {
 
     /// @TODO only sign a timeout if it matches last_voted_round or last_voted_round + 1
     /// @TODO update last_voted_round
-    fn sign_timeout(&mut self, timeout: &Timeout) -> Result<Ed25519Signature, Error> {
+    fn sign_timeout(&mut self, timeout: &Timeout) -> Result<ed25519::Signature, Error> {
         COUNTERS.sign_timeout.inc();
         debug!("Incoming timeout message to sign.");
         Ok(timeout.sign(&self.validator_signer))

--- a/consensus/safety-rules/src/serializer.rs
+++ b/consensus/safety-rules/src/serializer.rs
@@ -6,7 +6,7 @@ use consensus_types::{
     block::Block, block_data::BlockData, common::Payload, quorum_cert::QuorumCert,
     timeout::Timeout, vote::Vote, vote_proposal::VoteProposal,
 };
-use libra_crypto::ed25519::Ed25519Signature;
+use libra_crypto::ed25519;
 use serde::{Deserialize, Serialize};
 use std::sync::{Arc, RwLock};
 
@@ -102,7 +102,7 @@ impl<T: Payload> TSafetyRules<T> for SerializerClient<T> {
         lcs::from_bytes(&response)?
     }
 
-    fn sign_timeout(&mut self, timeout: &Timeout) -> Result<Ed25519Signature, Error> {
+    fn sign_timeout(&mut self, timeout: &Timeout) -> Result<ed25519::Signature, Error> {
         let response = self.request(SafetyRulesInput::SignTimeout(Box::new(timeout.clone())))?;
         lcs::from_bytes(&response)?
     }

--- a/consensus/safety-rules/src/t_safety_rules.rs
+++ b/consensus/safety-rules/src/t_safety_rules.rs
@@ -6,7 +6,7 @@ use consensus_types::{
     block::Block, block_data::BlockData, quorum_cert::QuorumCert, timeout::Timeout, vote::Vote,
     vote_proposal::VoteProposal,
 };
-use libra_crypto::ed25519::Ed25519Signature;
+use libra_crypto::ed25519;
 
 /// Interface for SafetyRules
 pub trait TSafetyRules<T> {
@@ -30,5 +30,5 @@ pub trait TSafetyRules<T> {
 
     /// As the holder of the private key, SafetyRules also signs what is effectively a
     /// timeout message. This returns the signature for that timeout message.
-    fn sign_timeout(&mut self, timeout: &Timeout) -> Result<Ed25519Signature, Error>;
+    fn sign_timeout(&mut self, timeout: &Timeout) -> Result<ed25519::Signature, Error>;
 }

--- a/consensus/src/chained_bft/block_storage/block_store_test.rs
+++ b/consensus/src/chained_bft/block_storage/block_store_test.rs
@@ -19,7 +19,7 @@ use consensus_types::{
     vote::Vote,
     vote_data::VoteData,
 };
-use libra_crypto::{HashValue, PrivateKey};
+use libra_crypto::{HashValue, PrivateKeyExt};
 use libra_types::{
     account_address::AccountAddress, validator_signer::ValidatorSigner,
     validator_verifier::random_validator_verifier,

--- a/crypto/crypto-derive/src/lib.rs
+++ b/crypto/crypto-derive/src/lib.rs
@@ -55,7 +55,7 @@
 //! use libra_crypto::{
 //!     hash::HashValue,
 //!     bls12381::{BLS12381PrivateKey, BLS12381PublicKey, BLS12381Signature},
-//!     ed25519::{Ed25519PrivateKey, Ed25519PublicKey, Ed25519Signature},
+//!     ed25519,
 //! };
 //! use libra_crypto_derive::{
 //!     SilentDebug, PrivateKey, PublicKey, Signature, SigningKey, ValidKey, VerifyingKey,
@@ -69,7 +69,7 @@
 //! #[SignatureType = "GenericSignature"]
 //! pub enum GenericPublicKey {
 //!     /// Ed25519 public key
-//!     Ed(Ed25519PublicKey),
+//!     Ed(ed25519::PublicKey),
 //!     /// BLS12-381 public key
 //!     BLS(BLS12381PublicKey),
 //! }
@@ -79,7 +79,7 @@
 //! #[SignatureType = "GenericSignature"]
 //! pub enum GenericPrivateKey {
 //!     /// Ed25519 private key
-//!     Ed(Ed25519PrivateKey),
+//!     Ed(ed25519::PrivateKey),
 //!     /// BLS12-381 private key
 //!     BLS(BLS12381PrivateKey),
 //! }
@@ -90,7 +90,7 @@
 //! #[PublicKeyType = "GenericPublicKey"]
 //! pub enum GenericSignature {
 //!     /// Ed25519 signature
-//!     Ed(Ed25519Signature),
+//!     Ed(ed25519::Signature),
 //!     /// BLS12-381 signature
 //!     BLS(BLS12381Signature),
 //! }

--- a/crypto/crypto-derive/src/lib.rs
+++ b/crypto/crypto-derive/src/lib.rs
@@ -234,7 +234,7 @@ pub fn derive_enum_validkey(input: TokenStream) -> TokenStream {
     }
 }
 
-#[proc_macro_derive(PublicKey, attributes(PrivateKeyType))]
+#[proc_macro_derive(PublicKeyExt, attributes(PrivateKeyType))]
 pub fn derive_enum_publickey(input: TokenStream) -> TokenStream {
     let ast = parse_macro_input!(input as DeriveInput);
 
@@ -243,12 +243,12 @@ pub fn derive_enum_publickey(input: TokenStream) -> TokenStream {
     match ast.data {
         Data::Enum(ref variants) => impl_enum_publickey(name, private_key_type, variants),
         Data::Struct(_) | Data::Union(_) => {
-            panic!("#[derive(PublicKey)] is only defined for enums")
+            panic!("#[derive(PublicKeyExt)] is only defined for enums")
         }
     }
 }
 
-#[proc_macro_derive(PrivateKey, attributes(PublicKeyType))]
+#[proc_macro_derive(PrivateKeyExt, attributes(PublicKeyType))]
 pub fn derive_enum_privatekey(input: TokenStream) -> TokenStream {
     let ast = parse_macro_input!(input as DeriveInput);
 
@@ -257,7 +257,7 @@ pub fn derive_enum_privatekey(input: TokenStream) -> TokenStream {
     match ast.data {
         Data::Enum(ref variants) => impl_enum_privatekey(name, public_key_type, variants),
         Data::Struct(_) | Data::Union(_) => {
-            panic!("#[derive(PrivateKey)] is only defined for enums")
+            panic!("#[derive(PrivateKeyExt)] is only defined for enums")
         }
     }
 }
@@ -274,7 +274,7 @@ pub fn derive_enum_verifyingkey(input: TokenStream) -> TokenStream {
             impl_enum_verifyingkey(name, private_key_type, signature_type, variants)
         }
         Data::Struct(_) | Data::Union(_) => {
-            panic!("#[derive(PrivateKey)] is only defined for enums")
+            panic!("#[derive(VerifyingKey)] is only defined for enums")
         }
     }
 }
@@ -291,12 +291,12 @@ pub fn derive_enum_signingkey(input: TokenStream) -> TokenStream {
             impl_enum_signingkey(name, public_key_type, signature_type, variants)
         }
         Data::Struct(_) | Data::Union(_) => {
-            panic!("#[derive(PrivateKey)] is only defined for enums")
+            panic!("#[derive(SigningKey)] is only defined for enums")
         }
     }
 }
 
-#[proc_macro_derive(Signature, attributes(PublicKeyType, PrivateKeyType))]
+#[proc_macro_derive(SignatureExt, attributes(PublicKeyType, PrivateKeyType))]
 pub fn derive_enum_signature(input: TokenStream) -> TokenStream {
     let ast = parse_macro_input!(input as DeriveInput);
 
@@ -308,7 +308,7 @@ pub fn derive_enum_signature(input: TokenStream) -> TokenStream {
             impl_enum_signature(name, public_key_type, private_key_type, variants)
         }
         Data::Struct(_) | Data::Union(_) => {
-            panic!("#[derive(PrivateKey)] is only defined for enums")
+            panic!("#[derive(SignatureExt)] is only defined for enums")
         }
     }
 }

--- a/crypto/crypto-derive/src/unions.rs
+++ b/crypto/crypto-derive/src/unions.rs
@@ -153,7 +153,7 @@ pub fn impl_enum_publickey(
         }
     };
     res.extend(quote! {
-        impl libra_crypto::PublicKey for #name {
+        impl libra_crypto::PublicKeyExt for #name {
             type PrivateKeyMaterial = #pkt;
         }
     });
@@ -167,7 +167,7 @@ pub fn impl_enum_privatekey(
 ) -> TokenStream {
     let pkt: syn::Type = public_key_type.parse().unwrap();
     let res = quote! {
-        impl libra_crypto::PrivateKey for #name {
+        impl libra_crypto::PrivateKeyExt for #name {
             type PublicKeyMaterial = #pkt;
         }
     };
@@ -247,7 +247,7 @@ pub fn impl_enum_signature(
 
     res.extend(quote! {
 
-        impl libra_crypto::Signature for #name {
+        impl libra_crypto::SignatureExt for #name {
             type VerifyingKeyMaterial = #pub_kt;
             type SigningKeyMaterial = #priv_kt;
 

--- a/crypto/crypto/src/ed25519.rs
+++ b/crypto/crypto/src/ed25519.rs
@@ -12,7 +12,7 @@
 //! use libra_crypto::hash::{CryptoHasher, TestOnlyHasher};
 //! use libra_crypto::{
 //!     ed25519::*,
-//!     traits::{Signature, SigningKey, Uniform},
+//!     traits::{SignatureExt, SigningKey, Uniform},
 //! };
 //! use rand::{rngs::StdRng, SeedableRng};
 //!
@@ -160,7 +160,7 @@ impl Ed25519Signature {
 // PrivateKey Traits //
 ///////////////////////
 
-impl PrivateKey for Ed25519PrivateKey {
+impl PrivateKeyExt for Ed25519PrivateKey {
     type PublicKeyMaterial = Ed25519PublicKey;
 }
 
@@ -245,7 +245,7 @@ impl From<&Ed25519PrivateKey> for Ed25519PublicKey {
 }
 
 // We deduce PublicKey from this
-impl PublicKey for Ed25519PublicKey {
+impl PublicKeyExt for Ed25519PublicKey {
     type PrivateKeyMaterial = Ed25519PrivateKey;
 }
 
@@ -333,7 +333,7 @@ impl ValidKey for Ed25519PublicKey {
 // Signature Traits //
 //////////////////////
 
-impl Signature for Ed25519Signature {
+impl SignatureExt for Ed25519Signature {
     type VerifyingKeyMaterial = Ed25519PublicKey;
     type SigningKeyMaterial = Ed25519PrivateKey;
 

--- a/crypto/crypto/src/ed25519.rs
+++ b/crypto/crypto/src/ed25519.rs
@@ -21,8 +21,8 @@
 //! let hashed_message = hasher.finish();
 //!
 //! let mut rng: StdRng = SeedableRng::from_seed([0; 32]);
-//! let private_key = Ed25519PrivateKey::generate(&mut rng);
-//! let public_key: Ed25519PublicKey = (&private_key).into();
+//! let private_key = PrivateKey::generate(&mut rng);
+//! let public_key: PublicKey = (&private_key).into();
 //! let signature = private_key.sign_message(&hashed_message);
 //! assert!(signature.verify(&hashed_message, &public_key).is_ok());
 //! ```
@@ -35,12 +35,12 @@ use core::convert::TryFrom;
 use libra_crypto_derive::{DeserializeKey, SerializeKey, SilentDebug, SilentDisplay};
 use std::{cmp::Ordering, fmt};
 
-/// The length of the Ed25519PrivateKey
-pub const ED25519_PRIVATE_KEY_LENGTH: usize = ed25519_dalek::SECRET_KEY_LENGTH;
-/// The length of the Ed25519PublicKey
-pub const ED25519_PUBLIC_KEY_LENGTH: usize = ed25519_dalek::PUBLIC_KEY_LENGTH;
-/// The length of the Ed25519Signature
-pub const ED25519_SIGNATURE_LENGTH: usize = ed25519_dalek::SIGNATURE_LENGTH;
+/// The length of the PrivateKey
+pub const PRIVATE_KEY_LENGTH: usize = ed25519_dalek::SECRET_KEY_LENGTH;
+/// The length of the PublicKey
+pub const PUBLIC_KEY_LENGTH: usize = ed25519_dalek::PUBLIC_KEY_LENGTH;
+/// The length of the Signature
+pub const SIGNATURE_LENGTH: usize = ed25519_dalek::SIGNATURE_LENGTH;
 
 /// The order of ed25519 as defined in [RFC8032](https://tools.ietf.org/html/rfc8032).
 const L: [u8; 32] = [
@@ -50,80 +50,78 @@ const L: [u8; 32] = [
 
 /// An Ed25519 private key
 #[derive(DeserializeKey, SilentDisplay, SilentDebug, SerializeKey)]
-pub struct Ed25519PrivateKey(ed25519_dalek::SecretKey);
+pub struct PrivateKey(ed25519_dalek::SecretKey);
 
 #[cfg(feature = "assert-private-keys-not-cloneable")]
-static_assertions::assert_not_impl_any!(Ed25519PrivateKey: Clone);
+static_assertions::assert_not_impl_any!(PrivateKey: Clone);
 
 #[cfg(any(test, feature = "cloneable-private-keys"))]
-impl Clone for Ed25519PrivateKey {
+impl Clone for PrivateKey {
     fn clone(&self) -> Self {
         let serialized: &[u8] = &(self.to_bytes());
-        Ed25519PrivateKey::try_from(serialized).unwrap()
+        PrivateKey::try_from(serialized).unwrap()
     }
 }
 
 /// An Ed25519 public key
 #[derive(DeserializeKey, Clone, SerializeKey)]
-pub struct Ed25519PublicKey(ed25519_dalek::PublicKey);
+pub struct PublicKey(ed25519_dalek::PublicKey);
 
 /// An Ed25519 signature
 #[derive(DeserializeKey, Clone, SerializeKey)]
-pub struct Ed25519Signature(ed25519_dalek::Signature);
+pub struct Signature(ed25519_dalek::Signature);
 
-impl Ed25519PrivateKey {
-    /// The length of the Ed25519PrivateKey
+impl PrivateKey {
+    /// The length of the PrivateKey
     pub const LENGTH: usize = ed25519_dalek::SECRET_KEY_LENGTH;
 
-    /// Serialize an Ed25519PrivateKey.
-    pub fn to_bytes(&self) -> [u8; ED25519_PRIVATE_KEY_LENGTH] {
+    /// Serialize an PrivateKey.
+    pub fn to_bytes(&self) -> [u8; PRIVATE_KEY_LENGTH] {
         self.0.to_bytes()
     }
 
-    /// Deserialize an Ed25519PrivateKey without any validation checks apart from expected key size.
-    fn from_bytes_unchecked(
-        bytes: &[u8],
-    ) -> std::result::Result<Ed25519PrivateKey, CryptoMaterialError> {
+    /// Deserialize an PrivateKey without any validation checks apart from expected key size.
+    fn from_bytes_unchecked(bytes: &[u8]) -> std::result::Result<PrivateKey, CryptoMaterialError> {
         match ed25519_dalek::SecretKey::from_bytes(bytes) {
-            Ok(dalek_secret_key) => Ok(Ed25519PrivateKey(dalek_secret_key)),
+            Ok(dalek_secret_key) => Ok(PrivateKey(dalek_secret_key)),
             Err(_) => Err(CryptoMaterialError::DeserializationError),
         }
     }
 }
 
-impl Ed25519PublicKey {
-    /// Serialize an Ed25519PublicKey.
-    pub fn to_bytes(&self) -> [u8; ED25519_PUBLIC_KEY_LENGTH] {
+impl PublicKey {
+    /// Serialize an PublicKey.
+    pub fn to_bytes(&self) -> [u8; PUBLIC_KEY_LENGTH] {
         self.0.to_bytes()
     }
 
-    /// Deserialize an Ed25519PublicKey without any validation checks apart from expected key size.
+    /// Deserialize an PublicKey without any validation checks apart from expected key size.
     pub(crate) fn from_bytes_unchecked(
         bytes: &[u8],
-    ) -> std::result::Result<Ed25519PublicKey, CryptoMaterialError> {
+    ) -> std::result::Result<PublicKey, CryptoMaterialError> {
         match ed25519_dalek::PublicKey::from_bytes(bytes) {
-            Ok(dalek_public_key) => Ok(Ed25519PublicKey(dalek_public_key)),
+            Ok(dalek_public_key) => Ok(PublicKey(dalek_public_key)),
             Err(_) => Err(CryptoMaterialError::DeserializationError),
         }
     }
 }
 
-impl Ed25519Signature {
-    /// The length of the Ed25519Signature
+impl Signature {
+    /// The length of the Signature
     pub const LENGTH: usize = ed25519_dalek::SIGNATURE_LENGTH;
 
-    /// Serialize an Ed25519Signature.
-    pub fn to_bytes(&self) -> [u8; ED25519_SIGNATURE_LENGTH] {
+    /// Serialize an Signature.
+    pub fn to_bytes(&self) -> [u8; SIGNATURE_LENGTH] {
         self.0.to_bytes()
     }
 
-    /// Deserialize an Ed25519Signature without any validation checks (malleability)
+    /// Deserialize an Signature without any validation checks (malleability)
     /// apart from expected key size.
     pub(crate) fn from_bytes_unchecked(
         bytes: &[u8],
-    ) -> std::result::Result<Ed25519Signature, CryptoMaterialError> {
+    ) -> std::result::Result<Signature, CryptoMaterialError> {
         match ed25519_dalek::Signature::from_bytes(bytes) {
-            Ok(dalek_signature) => Ok(Ed25519Signature(dalek_signature)),
+            Ok(dalek_signature) => Ok(Signature(dalek_signature)),
             Err(_) => Err(CryptoMaterialError::DeserializationError),
         }
     }
@@ -146,7 +144,7 @@ impl Ed25519Signature {
     /// choosing a different nonce, so this method protects against malleability attacks performed
     /// by a non-signer.
     pub fn check_malleability(bytes: &[u8]) -> std::result::Result<(), CryptoMaterialError> {
-        if bytes.len() != ED25519_SIGNATURE_LENGTH {
+        if bytes.len() != SIGNATURE_LENGTH {
             return Err(CryptoMaterialError::WrongLengthError);
         }
         if !check_s_lt_l(&bytes[32..]) {
@@ -160,73 +158,73 @@ impl Ed25519Signature {
 // PrivateKey Traits //
 ///////////////////////
 
-impl PrivateKeyExt for Ed25519PrivateKey {
-    type PublicKeyMaterial = Ed25519PublicKey;
+impl PrivateKeyExt for PrivateKey {
+    type PublicKeyMaterial = PublicKey;
 }
 
-impl SigningKey for Ed25519PrivateKey {
-    type VerifyingKeyMaterial = Ed25519PublicKey;
-    type SignatureMaterial = Ed25519Signature;
+impl SigningKey for PrivateKey {
+    type VerifyingKeyMaterial = PublicKey;
+    type SignatureMaterial = Signature;
 
-    fn sign_message(&self, message: &HashValue) -> Ed25519Signature {
+    fn sign_message(&self, message: &HashValue) -> Signature {
         let secret_key: &ed25519_dalek::SecretKey = &self.0;
-        let public_key: Ed25519PublicKey = self.into();
+        let public_key: PublicKey = self.into();
         let expanded_secret_key: ed25519_dalek::ExpandedSecretKey =
             ed25519_dalek::ExpandedSecretKey::from(secret_key);
         let sig = expanded_secret_key.sign(message.as_ref(), &public_key.0);
-        Ed25519Signature(sig)
+        Signature(sig)
     }
 }
 
-impl Uniform for Ed25519PrivateKey {
+impl Uniform for PrivateKey {
     fn generate<R>(rng: &mut R) -> Self
     where
         R: ::rand::SeedableRng + ::rand::RngCore + ::rand::CryptoRng,
     {
-        Ed25519PrivateKey(ed25519_dalek::SecretKey::generate(rng))
+        PrivateKey(ed25519_dalek::SecretKey::generate(rng))
     }
 }
 
-impl PartialEq<Self> for Ed25519PrivateKey {
+impl PartialEq<Self> for PrivateKey {
     fn eq(&self, other: &Self) -> bool {
         self.to_bytes() == other.to_bytes()
     }
 }
 
-impl Eq for Ed25519PrivateKey {}
+impl Eq for PrivateKey {}
 
 // We could have a distinct kind of validation for the PrivateKey, for
 // ex. checking the derived PublicKey is valid?
-impl TryFrom<&[u8]> for Ed25519PrivateKey {
+impl TryFrom<&[u8]> for PrivateKey {
     type Error = CryptoMaterialError;
 
-    /// Deserialize an Ed25519PrivateKey. This method will also check for key validity.
-    fn try_from(bytes: &[u8]) -> std::result::Result<Ed25519PrivateKey, CryptoMaterialError> {
+    /// Deserialize an PrivateKey. This method will also check for key validity.
+    fn try_from(bytes: &[u8]) -> std::result::Result<PrivateKey, CryptoMaterialError> {
         // Note that the only requirement is that the size of the key is 32 bytes, something that
         // is already checked during deserialization of ed25519_dalek::SecretKey
         // Also, the underlying ed25519_dalek implementation ensures that the derived public key
         // is safe and it will not lie in a small-order group, thus no extra check for PublicKey
         // validation is required.
-        Ed25519PrivateKey::from_bytes_unchecked(bytes)
+        PrivateKey::from_bytes_unchecked(bytes)
     }
 }
 
-impl Length for Ed25519PrivateKey {
+impl Length for PrivateKey {
     fn length(&self) -> usize {
         Self::LENGTH
     }
 }
 
-impl ValidKey for Ed25519PrivateKey {
+impl ValidKey for PrivateKey {
     fn to_bytes(&self) -> Vec<u8> {
         self.to_bytes().to_vec()
     }
 }
 
-impl Genesis for Ed25519PrivateKey {
+impl Genesis for PrivateKey {
     fn genesis() -> Self {
-        let mut buf = [0u8; ED25519_PRIVATE_KEY_LENGTH];
-        buf[ED25519_PRIVATE_KEY_LENGTH - 1] = 1;
+        let mut buf = [0u8; PRIVATE_KEY_LENGTH];
+        buf[PRIVATE_KEY_LENGTH - 1] = 1;
         Self::try_from(buf.as_ref()).unwrap()
     }
 }
@@ -236,20 +234,20 @@ impl Genesis for Ed25519PrivateKey {
 //////////////////////
 
 // Implementing From<&PrivateKey<...>> allows to derive a public key in a more elegant fashion
-impl From<&Ed25519PrivateKey> for Ed25519PublicKey {
-    fn from(private_key: &Ed25519PrivateKey) -> Self {
+impl From<&PrivateKey> for PublicKey {
+    fn from(private_key: &PrivateKey) -> Self {
         let secret: &ed25519_dalek::SecretKey = &private_key.0;
         let public: ed25519_dalek::PublicKey = secret.into();
-        Ed25519PublicKey(public)
+        PublicKey(public)
     }
 }
 
 // We deduce PublicKey from this
-impl PublicKeyExt for Ed25519PublicKey {
-    type PrivateKeyMaterial = Ed25519PrivateKey;
+impl PublicKeyExt for PublicKey {
+    type PrivateKeyMaterial = PrivateKey;
 }
 
-impl std::hash::Hash for Ed25519PublicKey {
+impl std::hash::Hash for PublicKey {
     fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
         let encoded_pubkey = self.to_bytes();
         state.write(&encoded_pubkey);
@@ -257,47 +255,47 @@ impl std::hash::Hash for Ed25519PublicKey {
 }
 
 // Those are required by the implementation of hash above
-impl PartialEq for Ed25519PublicKey {
-    fn eq(&self, other: &Ed25519PublicKey) -> bool {
+impl PartialEq for PublicKey {
+    fn eq(&self, other: &PublicKey) -> bool {
         self.to_bytes() == other.to_bytes()
     }
 }
 
-impl Eq for Ed25519PublicKey {}
+impl Eq for PublicKey {}
 
 // We deduce VerifyingKey from pointing to the signature material
 // we get the ability to do `pubkey.validate(msg, signature)`
-impl VerifyingKey for Ed25519PublicKey {
-    type SigningKeyMaterial = Ed25519PrivateKey;
-    type SignatureMaterial = Ed25519Signature;
+impl VerifyingKey for PublicKey {
+    type SigningKeyMaterial = PrivateKey;
+    type SignatureMaterial = Signature;
 }
 
-impl fmt::Display for Ed25519PublicKey {
+impl fmt::Display for PublicKey {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "{}", hex::encode(&self.0.as_bytes()))
     }
 }
 
-impl fmt::Debug for Ed25519PublicKey {
+impl fmt::Debug for PublicKey {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "Ed25519PublicKey({})", self)
+        write!(f, "PublicKey({})", self)
     }
 }
 
-impl TryFrom<&[u8]> for Ed25519PublicKey {
+impl TryFrom<&[u8]> for PublicKey {
     type Error = CryptoMaterialError;
 
-    /// Deserialize an Ed25519PublicKey. This method will also check for key validity, for instance
+    /// Deserialize an PublicKey. This method will also check for key validity, for instance
     ///  it will only deserialize keys that are safe against small subgroup attacks.
-    fn try_from(bytes: &[u8]) -> std::result::Result<Ed25519PublicKey, CryptoMaterialError> {
+    fn try_from(bytes: &[u8]) -> std::result::Result<PublicKey, CryptoMaterialError> {
         // We need to access the Edwards point which is not directly accessible from
         // ed25519_dalek::PublicKey, so we need to do some custom deserialization.
-        if bytes.len() != ED25519_PUBLIC_KEY_LENGTH {
+        if bytes.len() != PUBLIC_KEY_LENGTH {
             return Err(CryptoMaterialError::WrongLengthError);
         }
 
-        let mut bits = [0u8; ED25519_PUBLIC_KEY_LENGTH];
-        bits.copy_from_slice(&bytes[..ED25519_PUBLIC_KEY_LENGTH]);
+        let mut bits = [0u8; PUBLIC_KEY_LENGTH];
+        bits.copy_from_slice(&bytes[..PUBLIC_KEY_LENGTH]);
 
         let compressed = curve25519_dalek::edwards::CompressedEdwardsY(bits);
         let point = compressed
@@ -311,19 +309,19 @@ impl TryFrom<&[u8]> for Ed25519PublicKey {
         }
 
         // Unfortunately, tuple struct `PublicKey` is private so we cannot
-        // Ok(Ed25519PublicKey(ed25519_dalek::PublicKey(compressed, point)))
+        // Ok(PublicKey(ed25519_dalek::PublicKey(compressed, point)))
         // and we have to again invoke deserialization.
-        Ed25519PublicKey::from_bytes_unchecked(bytes)
+        PublicKey::from_bytes_unchecked(bytes)
     }
 }
 
-impl Length for Ed25519PublicKey {
+impl Length for PublicKey {
     fn length(&self) -> usize {
-        ED25519_PUBLIC_KEY_LENGTH
+        PUBLIC_KEY_LENGTH
     }
 }
 
-impl ValidKey for Ed25519PublicKey {
+impl ValidKey for PublicKey {
     fn to_bytes(&self) -> Vec<u8> {
         self.0.to_bytes().to_vec()
     }
@@ -333,20 +331,20 @@ impl ValidKey for Ed25519PublicKey {
 // Signature Traits //
 //////////////////////
 
-impl SignatureExt for Ed25519Signature {
-    type VerifyingKeyMaterial = Ed25519PublicKey;
-    type SigningKeyMaterial = Ed25519PrivateKey;
+impl SignatureExt for Signature {
+    type VerifyingKeyMaterial = PublicKey;
+    type SigningKeyMaterial = PrivateKey;
 
     /// Checks that `self` is valid for `message` using `public_key`.
-    fn verify(&self, message: &HashValue, public_key: &Ed25519PublicKey) -> Result<()> {
+    fn verify(&self, message: &HashValue, public_key: &PublicKey) -> Result<()> {
         self.verify_arbitrary_msg(message.as_ref(), public_key)
     }
 
     /// Checks that `self` is valid for an arbitrary &[u8] `message` using `public_key`.
     /// Outside of this crate, this particular function should only be used for native signature
     /// verification in move
-    fn verify_arbitrary_msg(&self, message: &[u8], public_key: &Ed25519PublicKey) -> Result<()> {
-        Ed25519Signature::check_malleability(&self.to_bytes())?;
+    fn verify_arbitrary_msg(&self, message: &[u8], public_key: &PublicKey) -> Result<()> {
+        Signature::check_malleability(&self.to_bytes())?;
 
         public_key
             .0
@@ -367,7 +365,7 @@ impl SignatureExt for Ed25519Signature {
         keys_and_signatures: Vec<(Self::VerifyingKeyMaterial, Self)>,
     ) -> Result<()> {
         for (_, sig) in keys_and_signatures.iter() {
-            Ed25519Signature::check_malleability(&sig.to_bytes())?
+            Signature::check_malleability(&sig.to_bytes())?
         }
         let batch_argument = keys_and_signatures
             .into_iter()
@@ -384,52 +382,52 @@ impl SignatureExt for Ed25519Signature {
     }
 }
 
-impl Length for Ed25519Signature {
+impl Length for Signature {
     fn length(&self) -> usize {
-        ED25519_SIGNATURE_LENGTH
+        SIGNATURE_LENGTH
     }
 }
 
-impl ValidKey for Ed25519Signature {
+impl ValidKey for Signature {
     fn to_bytes(&self) -> Vec<u8> {
         self.to_bytes().to_vec()
     }
 }
 
-impl std::hash::Hash for Ed25519Signature {
+impl std::hash::Hash for Signature {
     fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
         let encoded_signature = self.to_bytes();
         state.write(&encoded_signature);
     }
 }
 
-impl TryFrom<&[u8]> for Ed25519Signature {
+impl TryFrom<&[u8]> for Signature {
     type Error = CryptoMaterialError;
 
-    fn try_from(bytes: &[u8]) -> std::result::Result<Ed25519Signature, CryptoMaterialError> {
-        Ed25519Signature::check_malleability(bytes)?;
-        Ed25519Signature::from_bytes_unchecked(bytes)
+    fn try_from(bytes: &[u8]) -> std::result::Result<Signature, CryptoMaterialError> {
+        Signature::check_malleability(bytes)?;
+        Signature::from_bytes_unchecked(bytes)
     }
 }
 
 // Those are required by the implementation of hash above
-impl PartialEq for Ed25519Signature {
-    fn eq(&self, other: &Ed25519Signature) -> bool {
+impl PartialEq for Signature {
+    fn eq(&self, other: &Signature) -> bool {
         self.to_bytes().as_ref() == other.to_bytes().as_ref()
     }
 }
 
-impl Eq for Ed25519Signature {}
+impl Eq for Signature {}
 
-impl fmt::Display for Ed25519Signature {
+impl fmt::Display for Signature {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "{}", hex::encode(&self.0.to_bytes()[..]))
     }
 }
 
-impl fmt::Debug for Ed25519Signature {
+impl fmt::Debug for Signature {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "Ed25519Signature({})", self)
+        write!(f, "Signature({})", self)
     }
 }
 
@@ -451,20 +449,20 @@ use crate::test_utils::{self, KeyPair};
 
 /// Produces a uniformly random ed25519 keypair from a seed
 #[cfg(any(test, feature = "fuzzing"))]
-pub fn keypair_strategy() -> impl Strategy<Value = KeyPair<Ed25519PrivateKey, Ed25519PublicKey>> {
-    test_utils::uniform_keypair_strategy::<Ed25519PrivateKey, Ed25519PublicKey>()
+pub fn keypair_strategy() -> impl Strategy<Value = KeyPair<PrivateKey, PublicKey>> {
+    test_utils::uniform_keypair_strategy::<PrivateKey, PublicKey>()
 }
 
 #[cfg(any(test, feature = "fuzzing"))]
 use proptest::prelude::*;
 
 #[cfg(any(test, feature = "fuzzing"))]
-impl proptest::arbitrary::Arbitrary for Ed25519PublicKey {
+impl proptest::arbitrary::Arbitrary for PublicKey {
     type Parameters = ();
     type Strategy = BoxedStrategy<Self>;
 
     fn arbitrary_with(_args: Self::Parameters) -> Self::Strategy {
-        crate::test_utils::uniform_keypair_strategy::<Ed25519PrivateKey, Ed25519PublicKey>()
+        crate::test_utils::uniform_keypair_strategy::<PrivateKey, PublicKey>()
             .prop_map(|v| v.public_key)
             .boxed()
     }

--- a/crypto/crypto/src/multi_ed25519.rs
+++ b/crypto/crypto/src/multi_ed25519.rs
@@ -129,7 +129,7 @@ impl From<&Ed25519PrivateKey> for MultiEd25519PrivateKey {
     }
 }
 
-impl PrivateKey for MultiEd25519PrivateKey {
+impl PrivateKeyExt for MultiEd25519PrivateKey {
     type PublicKeyMaterial = MultiEd25519PublicKey;
 }
 
@@ -244,7 +244,7 @@ impl From<&MultiEd25519PrivateKey> for MultiEd25519PublicKey {
         let public_keys = private_key
             .private_keys
             .iter()
-            .map(PrivateKey::public_key)
+            .map(PrivateKeyExt::public_key)
             .collect();
         MultiEd25519PublicKey {
             public_keys,
@@ -254,7 +254,7 @@ impl From<&MultiEd25519PrivateKey> for MultiEd25519PublicKey {
 }
 
 /// We deduce PublicKey from this.
-impl PublicKey for MultiEd25519PublicKey {
+impl PublicKeyExt for MultiEd25519PublicKey {
     type PrivateKeyMaterial = MultiEd25519PrivateKey;
 }
 
@@ -446,7 +446,7 @@ impl ValidKey for MultiEd25519Signature {
     }
 }
 
-impl Signature for MultiEd25519Signature {
+impl SignatureExt for MultiEd25519Signature {
     type VerifyingKeyMaterial = MultiEd25519PublicKey;
     type SigningKeyMaterial = MultiEd25519PrivateKey;
 

--- a/crypto/crypto/src/unit_tests/cross_test.rs
+++ b/crypto/crypto/src/unit_tests/cross_test.rs
@@ -4,12 +4,7 @@
 // This is necessary for the derive macros which rely on being used in a
 // context where the crypto crate is external
 use crate as libra_crypto;
-use crate::{
-    ed25519::{Ed25519PrivateKey, Ed25519PublicKey, Ed25519Signature},
-    multi_ed25519,
-    test_utils::uniform_keypair_strategy,
-    traits::*,
-};
+use crate::{ed25519, multi_ed25519, test_utils::uniform_keypair_strategy, traits::*};
 
 use crate::hash::HashValue;
 
@@ -34,7 +29,7 @@ use serde::{Deserialize, Serialize};
 #[PrivateKeyType = "PrivateK"]
 #[SignatureType = "Sig"]
 enum PublicK {
-    Ed(Ed25519PublicKey),
+    Ed(ed25519::PublicKey),
     MultiEd(PublicKey),
 }
 
@@ -42,7 +37,7 @@ enum PublicK {
 #[PublicKeyType = "PublicK"]
 #[SignatureType = "Sig"]
 enum PrivateK {
-    Ed(Ed25519PrivateKey),
+    Ed(ed25519::PrivateKey),
     MultiEd(PrivateKey),
 }
 
@@ -51,7 +46,7 @@ enum PrivateK {
 #[PublicKeyType = "PublicK"]
 #[PrivateKeyType = "PrivateK"]
 enum Sig {
-    Ed(Ed25519Signature),
+    Ed(ed25519::Signature),
     MultiEd(Signature),
 }
 
@@ -64,14 +59,14 @@ proptest! {
     #[test]
     fn test_keys_mix(
         hash in any::<HashValue>(),
-        ed_keypair1 in uniform_keypair_strategy::<Ed25519PrivateKey, Ed25519PublicKey>(),
-        ed_keypair2 in uniform_keypair_strategy::<Ed25519PrivateKey, Ed25519PublicKey>(),
+        ed_keypair1 in uniform_keypair_strategy::<ed25519::PrivateKey, ed25519::PublicKey>(),
+        ed_keypair2 in uniform_keypair_strategy::<ed25519::PrivateKey, ed25519::PublicKey>(),
         med_keypair in uniform_keypair_strategy::<multi_ed25519::PrivateKey, multi_ed25519::PublicKey>()
     ) {
         // this is impossible to write statically, due to the trait not being
         // object-safe (voluntarily)
         // let mut l: Vec<Box<dyn PrivateKey>> = vec![];
-        let mut l: Vec<Ed25519PrivateKey> = vec![];
+        let mut l: Vec<ed25519::PrivateKey> = vec![];
         l.push(ed_keypair1.private_key);
         let ed_key = l.pop().unwrap();
         let signature = ed_key.sign_message(&hash);
@@ -80,7 +75,7 @@ proptest! {
         prop_assert!(signature.verify(&hash, &ed_keypair1.public_key).is_ok());
 
         // This is impossible to write, and generates:
-        // expected struct `ed25519::Ed25519PublicKey`, found struct `med12381::multi_ed25519::PublicKey`
+        // expected struct `ed25519::ed25519::PublicKey`, found struct `med12381::multi_ed25519::PublicKey`
         // prop_assert!(signature.verify(&hash, &med_keypair.public_key).is_ok());
 
         let mut l2: Vec<PrivateK> = vec![];

--- a/crypto/crypto/src/unit_tests/cross_test.rs
+++ b/crypto/crypto/src/unit_tests/cross_test.rs
@@ -6,7 +6,7 @@
 use crate as libra_crypto;
 use crate::{
     ed25519::{Ed25519PrivateKey, Ed25519PublicKey, Ed25519Signature},
-    multi_ed25519::{MultiEd25519PrivateKey, MultiEd25519PublicKey, MultiEd25519Signature},
+    multi_ed25519,
     test_utils::uniform_keypair_strategy,
     traits::*,
 };
@@ -35,7 +35,7 @@ use serde::{Deserialize, Serialize};
 #[SignatureType = "Sig"]
 enum PublicK {
     Ed(Ed25519PublicKey),
-    MultiEd(MultiEd25519PublicKey),
+    MultiEd(PublicKey),
 }
 
 #[derive(Serialize, Deserialize, SilentDebug, ValidKey, PrivateKeyExt, SigningKey)]
@@ -43,7 +43,7 @@ enum PublicK {
 #[SignatureType = "Sig"]
 enum PrivateK {
     Ed(Ed25519PrivateKey),
-    MultiEd(MultiEd25519PrivateKey),
+    MultiEd(PrivateKey),
 }
 
 #[allow(clippy::large_enum_variant)]
@@ -52,7 +52,7 @@ enum PrivateK {
 #[PrivateKeyType = "PrivateK"]
 enum Sig {
     Ed(Ed25519Signature),
-    MultiEd(MultiEd25519Signature),
+    MultiEd(Signature),
 }
 
 ///////////////////////////////////////////////////////
@@ -66,7 +66,7 @@ proptest! {
         hash in any::<HashValue>(),
         ed_keypair1 in uniform_keypair_strategy::<Ed25519PrivateKey, Ed25519PublicKey>(),
         ed_keypair2 in uniform_keypair_strategy::<Ed25519PrivateKey, Ed25519PublicKey>(),
-        med_keypair in uniform_keypair_strategy::<MultiEd25519PrivateKey, MultiEd25519PublicKey>()
+        med_keypair in uniform_keypair_strategy::<multi_ed25519::PrivateKey, multi_ed25519::PublicKey>()
     ) {
         // this is impossible to write statically, due to the trait not being
         // object-safe (voluntarily)
@@ -80,7 +80,7 @@ proptest! {
         prop_assert!(signature.verify(&hash, &ed_keypair1.public_key).is_ok());
 
         // This is impossible to write, and generates:
-        // expected struct `ed25519::Ed25519PublicKey`, found struct `med12381::MultiEd25519PublicKey`
+        // expected struct `ed25519::Ed25519PublicKey`, found struct `med12381::multi_ed25519::PublicKey`
         // prop_assert!(signature.verify(&hash, &med_keypair.public_key).is_ok());
 
         let mut l2: Vec<PrivateK> = vec![];

--- a/crypto/crypto/src/unit_tests/cross_test.rs
+++ b/crypto/crypto/src/unit_tests/cross_test.rs
@@ -14,7 +14,7 @@ use crate::{
 use crate::hash::HashValue;
 
 use libra_crypto_derive::{
-    PrivateKey, PublicKey, Signature, SigningKey, SilentDebug, ValidKey, VerifyingKey,
+    PrivateKeyExt, PublicKeyExt, SignatureExt, SigningKey, SilentDebug, ValidKey, VerifyingKey,
 };
 use proptest::prelude::*;
 use serde::{Deserialize, Serialize};
@@ -29,7 +29,7 @@ use serde::{Deserialize, Serialize};
 //
 
 #[derive(
-    Serialize, Deserialize, Debug, Clone, PartialEq, Eq, Hash, ValidKey, PublicKey, VerifyingKey,
+    Serialize, Deserialize, Debug, Clone, PartialEq, Eq, Hash, ValidKey, PublicKeyExt, VerifyingKey,
 )]
 #[PrivateKeyType = "PrivateK"]
 #[SignatureType = "Sig"]
@@ -38,7 +38,7 @@ enum PublicK {
     MultiEd(MultiEd25519PublicKey),
 }
 
-#[derive(Serialize, Deserialize, SilentDebug, ValidKey, PrivateKey, SigningKey)]
+#[derive(Serialize, Deserialize, SilentDebug, ValidKey, PrivateKeyExt, SigningKey)]
 #[PublicKeyType = "PublicK"]
 #[SignatureType = "Sig"]
 enum PrivateK {
@@ -47,7 +47,7 @@ enum PrivateK {
 }
 
 #[allow(clippy::large_enum_variant)]
-#[derive(Clone, Debug, PartialEq, Eq, Hash, Signature)]
+#[derive(Clone, Debug, PartialEq, Eq, Hash, SignatureExt)]
 #[PublicKeyType = "PublicK"]
 #[PrivateKeyType = "PrivateK"]
 enum Sig {

--- a/crypto/crypto/src/unit_tests/ed25519_test.rs
+++ b/crypto/crypto/src/unit_tests/ed25519_test.rs
@@ -1,14 +1,7 @@
 // Copyright (c) The Libra Core Contributors
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::{
-    ed25519::{
-        Ed25519PrivateKey, Ed25519PublicKey, Ed25519Signature, ED25519_PRIVATE_KEY_LENGTH,
-        ED25519_PUBLIC_KEY_LENGTH, ED25519_SIGNATURE_LENGTH,
-    },
-    test_utils::uniform_keypair_strategy,
-    traits::*,
-};
+use crate::{ed25519, test_utils::uniform_keypair_strategy, traits::*};
 
 use core::{
     convert::TryFrom,
@@ -20,19 +13,19 @@ use proptest::prelude::*;
 
 proptest! {
     #[test]
-    fn test_keys_encode(keypair in uniform_keypair_strategy::<Ed25519PrivateKey, Ed25519PublicKey>()) {
+    fn test_keys_encode(keypair in uniform_keypair_strategy::<ed25519::PrivateKey, ed25519::PublicKey>()) {
         {
             let encoded = keypair.private_key.to_encoded_string().unwrap();
              // Hex encoding of a 32-bytes key is 64 (2 x 32) characters.
-            prop_assert_eq!(2 * ED25519_PRIVATE_KEY_LENGTH, encoded.len());
-            let decoded = Ed25519PrivateKey::from_encoded_string(&encoded);
+            prop_assert_eq!(2 * ed25519::PRIVATE_KEY_LENGTH, encoded.len());
+            let decoded = ed25519::PrivateKey::from_encoded_string(&encoded);
             prop_assert_eq!(Some(keypair.private_key), decoded.ok());
         }
         {
             let encoded = keypair.public_key.to_encoded_string().unwrap();
             // Hex encoding of a 32-bytes key is 64 (2 x 32) characters.
             prop_assert_eq!(2 * ED25519_PUBLIC_KEY_LENGTH, encoded.len());
-            let decoded = Ed25519PublicKey::from_encoded_string(&encoded);
+            let decoded = ed25519::PublicKey::from_encoded_string(&encoded);
             prop_assert_eq!(Some(keypair.public_key), decoded.ok());
         }
     }
@@ -40,33 +33,33 @@ proptest! {
     #[test]
     fn test_batch_verify(
         hash in any::<HashValue>(),
-        keypairs in proptest::array::uniform10(uniform_keypair_strategy::<Ed25519PrivateKey, Ed25519PublicKey>())) {
-        let mut signatures: Vec<(Ed25519PublicKey, Ed25519Signature)> = keypairs.iter().map(|keypair| {
+        keypairs in proptest::array::uniform10(uniform_keypair_strategy::<ed25519::PrivateKey, ed25519::PublicKey>())) {
+        let mut signatures: Vec<(ed25519::PublicKey, ed25519::Signature)> = keypairs.iter().map(|keypair| {
             (keypair.public_key.clone(), keypair.private_key.sign_message(&hash))
         }).collect();
-        prop_assert!(Ed25519Signature::batch_verify_signatures(&hash, signatures.clone()).is_ok());
+        prop_assert!(ed25519::Signature::batch_verify_signatures(&hash, signatures.clone()).is_ok());
         // We swap message and signature for the last element,
         // resulting in an incorrect signature
         let (key, _sig) = signatures.pop().unwrap();
         let other_sig = signatures.last().unwrap().clone().1;
         signatures.push((key, other_sig));
-        prop_assert!(Ed25519Signature::batch_verify_signatures(&hash, signatures).is_err());
+        prop_assert!(ed25519::Signature::batch_verify_signatures(&hash, signatures).is_err());
     }
 
     #[test]
     fn test_keys_custom_serialisation(
-        keypair in uniform_keypair_strategy::<Ed25519PrivateKey, Ed25519PublicKey>()
+        keypair in uniform_keypair_strategy::<ed25519::PrivateKey, ed25519::PublicKey>()
     ) {
         {
             let serialized: &[u8] = &(keypair.private_key.to_bytes());
-            prop_assert_eq!(ED25519_PRIVATE_KEY_LENGTH, serialized.len());
-            let deserialized = Ed25519PrivateKey::try_from(serialized);
+            prop_assert_eq!(ed25519::PRIVATE_KEY_LENGTH, serialized.len());
+            let deserialized = ed25519::PrivateKey::try_from(serialized);
             prop_assert_eq!(Some(keypair.private_key), deserialized.ok());
         }
         {
             let serialized: &[u8] = &(keypair.public_key.to_bytes());
             prop_assert_eq!(ED25519_PUBLIC_KEY_LENGTH, serialized.len());
-            let deserialized = Ed25519PublicKey::try_from(serialized);
+            let deserialized = ed25519::PublicKey::try_from(serialized);
             prop_assert_eq!(Some(keypair.public_key), deserialized.ok());
         }
     }
@@ -74,12 +67,12 @@ proptest! {
     #[test]
     fn test_signature_verification_custom_serialisation(
         hash in any::<HashValue>(),
-        keypair in uniform_keypair_strategy::<Ed25519PrivateKey, Ed25519PublicKey>()
+        keypair in uniform_keypair_strategy::<ed25519::PrivateKey, ed25519::PublicKey>()
     ) {
         let signature = keypair.private_key.sign_message(&hash);
         let serialized: &[u8] = &(signature.to_bytes());
-        prop_assert_eq!(ED25519_SIGNATURE_LENGTH, serialized.len());
-        let deserialized = Ed25519Signature::try_from(serialized).unwrap();
+        prop_assert_eq!(ed25519::SIGNATURE_LENGTH, serialized.len());
+        let deserialized = ed25519::Signature::try_from(serialized).unwrap();
         prop_assert!(keypair.public_key.verify_signature(&hash, &deserialized).is_ok());
     }
 
@@ -87,7 +80,7 @@ proptest! {
     #[test]
     fn test_signature_malleability(
         hash in any::<HashValue>(),
-        keypair in uniform_keypair_strategy::<Ed25519PrivateKey, Ed25519PublicKey>()
+        keypair in uniform_keypair_strategy::<ed25519::PrivateKey, ed25519::PublicKey>()
     ) {
         let signature = keypair.private_key.sign_message(&hash);
         let mut serialized = signature.to_bytes();
@@ -125,13 +118,13 @@ proptest! {
         // try_from will fail on malleable signatures. We detect malleable signatures
         // during deserialization.
         prop_assert_eq!(
-            Ed25519Signature::try_from(serialized_malleable),
+            ed25519::Signature::try_from(serialized_malleable),
             Err(CryptoMaterialError::CanonicalRepresentationError)
         );
 
         // We expect from_bytes_unchecked deserialization not to fail, as we don't check
         // for signature malleability. This method is pub(crate) and only used for test purposes.
-        let sig_unchecked = Ed25519Signature::from_bytes_unchecked(&serialized).unwrap();
+        let sig_unchecked = ed25519::Signature::from_bytes_unchecked(&serialized).unwrap();
 
         // Malleable signatures will fail to verify in our implementation, even if for some reason
         // we receive one. Note that this is a second step of validation as we typically check
@@ -143,7 +136,7 @@ proptest! {
         let serialized_malleable_l: &[u8] = &serialized;
         // try_from will fail with CanonicalRepresentationError.
         prop_assert_eq!(
-            Ed25519Signature::try_from(serialized_malleable_l),
+            ed25519::Signature::try_from(serialized_malleable_l),
             Err(CryptoMaterialError::CanonicalRepresentationError)
         );
     }
@@ -155,10 +148,10 @@ fn test_publickey_smallorder() {
     for torsion_point in &EIGHT_TORSION {
         let serialized: &[u8] = torsion_point;
         // We expect from_bytes_unchecked to pass, as it does not validate the key.
-        assert!(Ed25519PublicKey::from_bytes_unchecked(serialized).is_ok());
+        assert!(ed25519::PublicKey::from_bytes_unchecked(serialized).is_ok());
         // from_bytes will fail on invalid key.
         assert_eq!(
-            Ed25519PublicKey::try_from(serialized),
+            ed25519::PublicKey::try_from(serialized),
             Err(CryptoMaterialError::SmallSubgroupError)
         );
     }

--- a/crypto/crypto/src/unit_tests/multi_ed25519_test.rs
+++ b/crypto/crypto/src/unit_tests/multi_ed25519_test.rs
@@ -4,13 +4,11 @@
 use crate::{
     ed25519::{Ed25519PrivateKey, Ed25519PublicKey, ED25519_PUBLIC_KEY_LENGTH},
     hash::HashValue,
-    multi_ed25519::{MultiEd25519PrivateKey, MultiEd25519PublicKey},
+    multi_ed25519,
     test_utils::TEST_SEED,
     traits::*,
     CryptoMaterialError::{ValidationError, WrongLengthError},
 };
-
-use crate::multi_ed25519::MultiEd25519Signature;
 use core::convert::TryFrom;
 use once_cell::sync::Lazy;
 use rand::{rngs::StdRng, SeedableRng};
@@ -28,20 +26,20 @@ fn generate_keys(n: usize) -> Vec<Ed25519PrivateKey> {
 // Reused assertions in our tests.
 fn test_successful_public_key_serialization(original_keys: &[Ed25519PublicKey], threshold: u8) {
     let n = original_keys.len();
-    let public_key: MultiEd25519PublicKey =
-        MultiEd25519PublicKey::new(original_keys.to_vec(), threshold).unwrap();
+    let public_key: multi_ed25519::PublicKey =
+        multi_ed25519::PublicKey::new(original_keys.to_vec(), threshold).unwrap();
     assert_eq!(public_key.threshold(), &threshold);
     assert_eq!(public_key.public_keys().len(), n);
     assert_eq!(public_key.public_keys(), &original_keys.to_vec());
     let serialized = public_key.to_bytes();
     assert_eq!(serialized.len(), n * ED25519_PUBLIC_KEY_LENGTH + 1);
-    let reserialized = MultiEd25519PublicKey::try_from(&serialized[..]);
+    let reserialized = multi_ed25519::PublicKey::try_from(&serialized[..]);
     assert!(reserialized.is_ok());
     assert_eq!(public_key, reserialized.unwrap());
 }
 
 fn test_failed_public_key_serialization(
-    result: std::result::Result<MultiEd25519PublicKey, CryptoMaterialError>,
+    result: std::result::Result<multi_ed25519::PublicKey, CryptoMaterialError>,
     expected_error: CryptoMaterialError,
 ) {
     assert!(result.is_err());
@@ -49,13 +47,14 @@ fn test_failed_public_key_serialization(
 }
 
 fn test_successful_signature_serialization(private_keys: &[Ed25519PrivateKey], threshold: u8) {
-    let multi_private_key = MultiEd25519PrivateKey::new(private_keys.to_vec(), threshold).unwrap();
-    let multi_public_key = MultiEd25519PublicKey::from(&multi_private_key);
+    let multi_private_key =
+        multi_ed25519::PrivateKey::new(private_keys.to_vec(), threshold).unwrap();
+    let multi_public_key = multi_ed25519::PublicKey::from(&multi_private_key);
     let multi_signature = multi_private_key.sign_message(&MESSAGE_HASH);
 
     // Serialize then Deserialize.
     let multi_signature_serialized =
-        MultiEd25519Signature::try_from(&multi_signature.to_bytes()[..]);
+        multi_ed25519::Signature::try_from(&multi_signature.to_bytes()[..]);
     assert!(multi_signature_serialized.is_ok());
     let multi_signature_serialized_unwrapped = multi_signature_serialized.unwrap();
     assert_eq!(multi_signature, multi_signature_serialized_unwrapped);
@@ -87,62 +86,63 @@ fn test_multi_ed25519_public_key_serialization() {
     test_successful_public_key_serialization(&pub_keys_32, 32);
 
     // Test 11-of-10 (should fail).
-    let multi_key_11of10 = MultiEd25519PublicKey::new(pub_keys_10.clone(), 11);
+    let multi_key_11of10 = multi_ed25519::PublicKey::new(pub_keys_10.clone(), 11);
     test_failed_public_key_serialization(multi_key_11of10, ValidationError);
 
     // Test 0-of-10 (should fail).
-    let multi_key_0of10 = MultiEd25519PublicKey::new(pub_keys_10, 0);
+    let multi_key_0of10 = multi_ed25519::PublicKey::new(pub_keys_10, 0);
     test_failed_public_key_serialization(multi_key_0of10, ValidationError);
 
     // Test 1-of-33 (should fail).
-    let multi_key_1of33 = MultiEd25519PublicKey::new(pub_keys_33, 1);
+    let multi_key_1of33 = multi_ed25519::PublicKey::new(pub_keys_33, 1);
     test_failed_public_key_serialization(multi_key_1of33, WrongLengthError);
 
     // Test try_from empty bytes (should fail).
-    let multi_key_empty_bytes = MultiEd25519PublicKey::try_from(&[] as &[u8]);
+    let multi_key_empty_bytes = multi_ed25519::PublicKey::try_from(&[] as &[u8]);
     test_failed_public_key_serialization(multi_key_empty_bytes, WrongLengthError);
 
     // Test try_from 1 byte (should fail).
-    let multi_key_1_byte = MultiEd25519PublicKey::try_from(&[0u8][..]);
+    let multi_key_1_byte = multi_ed25519::PublicKey::try_from(&[0u8][..]);
     test_failed_public_key_serialization(multi_key_1_byte, WrongLengthError);
 
     // Test try_from 31 bytes (should fail).
     let multi_key_31_bytes =
-        MultiEd25519PublicKey::try_from(&[0u8; ED25519_PUBLIC_KEY_LENGTH - 1][..]);
+        multi_ed25519::PublicKey::try_from(&[0u8; ED25519_PUBLIC_KEY_LENGTH - 1][..]);
     test_failed_public_key_serialization(multi_key_31_bytes, WrongLengthError);
 
     // Test try_from 32 bytes (should fail) because we always need ED25519_PUBLIC_KEY_LENGTH * N + 1
     // bytes (thus 32N + 1).
-    let multi_key_32_bytes = MultiEd25519PublicKey::try_from(&[0u8; ED25519_PUBLIC_KEY_LENGTH][..]);
+    let multi_key_32_bytes =
+        multi_ed25519::PublicKey::try_from(&[0u8; ED25519_PUBLIC_KEY_LENGTH][..]);
     test_failed_public_key_serialization(multi_key_32_bytes, WrongLengthError);
 
     // Test try_from 34 bytes (should fail).
     let multi_key_34_bytes =
-        MultiEd25519PublicKey::try_from(&[0u8; ED25519_PUBLIC_KEY_LENGTH + 2][..]);
+        multi_ed25519::PublicKey::try_from(&[0u8; ED25519_PUBLIC_KEY_LENGTH + 2][..]);
     test_failed_public_key_serialization(multi_key_34_bytes, WrongLengthError);
 
     // Test try_from 33 all zero bytes (size is fine, but it should fail due to
     // validation issues).
     let multi_key_33_zero_bytes =
-        MultiEd25519PublicKey::try_from(&[0u8; ED25519_PUBLIC_KEY_LENGTH + 1][..]);
+        multi_ed25519::PublicKey::try_from(&[0u8; ED25519_PUBLIC_KEY_LENGTH + 1][..]);
     test_failed_public_key_serialization(multi_key_33_zero_bytes, ValidationError);
 
     let priv_keys_10 = generate_keys(10);
     let pub_keys_10: Vec<_> = priv_keys_10.iter().map(|x| x.public_key()).collect();
 
-    let multi_private_key_7of10 = MultiEd25519PrivateKey::new(priv_keys_10, 7).unwrap();
-    let multi_public_key_7of10 = MultiEd25519PublicKey::new(pub_keys_10, 7).unwrap();
+    let multi_private_key_7of10 = multi_ed25519::PrivateKey::new(priv_keys_10, 7).unwrap();
+    let multi_public_key_7of10 = multi_ed25519::PublicKey::new(pub_keys_10, 7).unwrap();
 
-    // Check that MultiEd25519PublicKey::from MultiEd25519PrivateKey works as expected.
+    // Check that multi_ed25519::PublicKey::from multi_ed25519::PrivateKey works as expected.
     let multi_public_key_7of10_from_multi_private_key =
-        MultiEd25519PublicKey::from(&multi_private_key_7of10);
+        multi_ed25519::PublicKey::from(&multi_private_key_7of10);
     assert_eq!(
         multi_public_key_7of10_from_multi_private_key,
         multi_public_key_7of10
     );
 
     // Check that MultiEd25519PublicKey::from Ed25519PublicKey works as expected.
-    let multi_public_key_from_ed25519 = MultiEd25519PublicKey::from(
+    let multi_public_key_from_ed25519 = multi_ed25519::PublicKey::from(
         multi_public_key_7of10_from_multi_private_key.public_keys()[0].clone(),
     );
     assert_eq!(multi_public_key_from_ed25519.public_keys().len(), 1);
@@ -163,7 +163,7 @@ fn test_publickey_smallorder() {
         0, 0, 1,
     ];
 
-    let torsion_key = MultiEd25519PublicKey::try_from(&torsion_point_with_threshold_1[..]);
+    let torsion_key = multi_ed25519::PublicKey::try_from(&torsion_point_with_threshold_1[..]);
     assert!(torsion_key.is_err());
     assert_eq!(
         torsion_key.err().unwrap(),
@@ -191,12 +191,12 @@ fn test_multi_ed25519_signature_serialization() {
 
     // Construct from single Ed25519Signature.
     let single_signature = priv_keys_3[0].sign_message(&MESSAGE_HASH);
-    let multi_signature = MultiEd25519Signature::from(single_signature.clone());
+    let multi_signature = multi_ed25519::PublicKey::from(single_signature.clone());
     assert_eq!(1, multi_signature.signatures().len());
     assert_eq!(multi_signature.signatures()[0], single_signature);
     assert_eq!(multi_signature.bitmap(), &[0b1000_0000u8, 0u8, 0u8, 0u8]);
-    let multi_priv_key_1of3 = MultiEd25519PrivateKey::new(priv_keys_3.to_vec(), 1).unwrap();
-    let multi_pub_key_1of3 = MultiEd25519PublicKey::from(&multi_priv_key_1of3);
+    let multi_priv_key_1of3 = multi_ed25519::PrivateKey::new(priv_keys_3.to_vec(), 1).unwrap();
+    let multi_pub_key_1of3 = multi_ed25519::PublicKey::from(&multi_priv_key_1of3);
     assert!(multi_signature
         .verify(&MESSAGE_HASH, &multi_pub_key_1of3)
         .is_ok());
@@ -206,7 +206,7 @@ fn test_multi_ed25519_signature_serialization() {
     let indices: Vec<u8> = (0..32).collect();
     let sig32_tuple = sigs_32.into_iter().zip(indices.into_iter()).collect();
 
-    let multi_sig32 = MultiEd25519Signature::new(sig32_tuple);
+    let multi_sig32 = multi_ed25519::Signature::new(sig32_tuple);
     assert!(multi_sig32.is_ok());
     let multi_sig32_unwrapped = multi_sig32.unwrap();
     assert_eq!(
@@ -214,24 +214,24 @@ fn test_multi_ed25519_signature_serialization() {
         &[0b1111_1111, 0b1111_1111, 0b1111_1111, 0b1111_1111]
     );
     let pub_key_32 = vec![priv_keys_3[0].public_key(); 32];
-    let multi_pub_key_32 = MultiEd25519PublicKey::new(pub_key_32, 32).unwrap();
+    let multi_pub_key_32 = multi_ed25519::PublicKey::new(pub_key_32, 32).unwrap();
     assert!(multi_sig32_unwrapped
         .verify(&MESSAGE_HASH, &multi_pub_key_32)
         .is_ok());
 
-    // Fail to construct a MultiEd25519Signature object from 33 or more single signatures.
+    // Fail to construct a multi_ed25519::Signature object from 33 or more single signatures.
     let sigs_33 = vec![single_signature.clone(); 33];
     let indices: Vec<u8> = (0..33).collect();
     let sig33_tuple = sigs_33.into_iter().zip(indices.into_iter()).collect();
 
-    let multi_sig33 = MultiEd25519Signature::new(sig33_tuple);
+    let multi_sig33 = multi_ed25519::Signature::new(sig33_tuple);
     assert!(multi_sig33.is_err());
     assert_eq!(
         multi_sig33.err().unwrap(),
         CryptoMaterialError::ValidationError
     );
 
-    // Fail to construct a MultiEd25519Signature object if there are duplicated indexes.
+    // Fail to construct a multi_ed25519::Signature object if there are duplicated indexes.
     let sigs_3 = vec![single_signature; 3];
     let indices_with_duplicate = vec![0u8, 1u8, 1u8];
     let sig3_tuple = sigs_3
@@ -240,21 +240,21 @@ fn test_multi_ed25519_signature_serialization() {
         .zip(indices_with_duplicate.into_iter())
         .collect();
 
-    let multi_sig3 = MultiEd25519Signature::new(sig3_tuple);
+    let multi_sig3 = multi_ed25519::Signature::new(sig3_tuple);
     assert!(multi_sig3.is_err());
     assert_eq!(
         multi_sig3.err().unwrap(),
         CryptoMaterialError::BitVecError("Duplicate signature index".to_string())
     );
 
-    // Fail to construct a MultiEd25519Signature object if an index is out of range.
+    // Fail to construct a multi_ed25519::Signature object if an index is out of range.
     let indices_with_out_of_range = vec![0u8, 33u8, 1u8];
     let sig3_tuple = sigs_3
         .into_iter()
         .zip(indices_with_out_of_range.into_iter())
         .collect();
 
-    let multi_sig3 = MultiEd25519Signature::new(sig3_tuple);
+    let multi_sig3 = multi_ed25519::Signature::new(sig3_tuple);
     assert!(multi_sig3.is_err());
     assert_eq!(
         multi_sig3.err().unwrap(),
@@ -268,8 +268,8 @@ fn test_multi_ed25519_signature_verification() {
     let priv_keys_10 = generate_keys(10);
     let pub_keys_10: Vec<_> = priv_keys_10.iter().map(|x| x.public_key()).collect();
 
-    let multi_private_key_7of10 = MultiEd25519PrivateKey::new(priv_keys_10.clone(), 7).unwrap();
-    let multi_public_key_7of10 = MultiEd25519PublicKey::from(&multi_private_key_7of10);
+    let multi_private_key_7of10 = multi_ed25519::PrivateKey::new(priv_keys_10.clone(), 7).unwrap();
+    let multi_public_key_7of10 = multi_ed25519::PublicKey::from(&multi_private_key_7of10);
 
     // Verifying a 7-of-10 signature against a public key with the same threshold should pass.
     let multi_signature_7of10 = multi_private_key_7of10.sign_message(&MESSAGE_HASH);
@@ -282,36 +282,36 @@ fn test_multi_ed25519_signature_verification() {
         .is_ok());
 
     // Verifying a 7-of-10 signature against a public key with bigger threshold (i.e., 8) should fail.
-    let multi_public_key_8of10 = MultiEd25519PublicKey::new(pub_keys_10.clone(), 8).unwrap();
+    let multi_public_key_8of10 = multi_ed25519::PublicKey::new(pub_keys_10.clone(), 8).unwrap();
     assert!(multi_signature_7of10
         .verify(&MESSAGE_HASH, &multi_public_key_8of10)
         .is_err());
 
     // Verifying a 7-of-10 signature against a public key with smaller threshold (i.e., 6) should pass.
-    let multi_public_key_6of10 = MultiEd25519PublicKey::new(pub_keys_10.clone(), 6).unwrap();
+    let multi_public_key_6of10 = multi_ed25519::PublicKey::new(pub_keys_10.clone(), 6).unwrap();
     assert!(multi_signature_7of10
         .verify(&MESSAGE_HASH, &multi_public_key_6of10)
         .is_ok());
 
-    // Verifying a 7-of-10 signature against a reordered MultiEd25519PublicKey should fail.
+    // Verifying a 7-of-10 signature against a reordered multi_ed25519::PublicKey should fail.
     // To deterministically simulate reshuffling, we use a reversed vector of 10 keys.
     // Note that because 10 is an even number, all of they keys will change position.
     let mut pub_keys_10_reversed = pub_keys_10;
     pub_keys_10_reversed.reverse();
     let multi_public_key_7of10_reversed =
-        MultiEd25519PublicKey::new(pub_keys_10_reversed, 7).unwrap();
+        multi_ed25519::PublicKey::new(pub_keys_10_reversed, 7).unwrap();
     assert!(multi_signature_7of10
         .verify(&MESSAGE_HASH, &multi_public_key_7of10_reversed)
         .is_err());
 
     let priv_keys_3 = generate_keys(3);
 
-    let multi_private_key_1of3 = MultiEd25519PrivateKey::new(priv_keys_3.clone(), 1).unwrap();
-    let multi_public_key_1of3 = MultiEd25519PublicKey::from(&multi_private_key_1of3);
+    let multi_private_key_1of3 = multi_ed25519::PrivateKey::new(priv_keys_3.clone(), 1).unwrap();
+    let multi_public_key_1of3 = multi_ed25519::PublicKey::from(&multi_private_key_1of3);
 
     // Signing with the 2nd key must succeed.
     let sig_with_2nd_key = priv_keys_3[1].sign_message(&MESSAGE_HASH);
-    let multi_sig_signed_by_2nd_key = MultiEd25519Signature::new(vec![(sig_with_2nd_key, 1)]);
+    let multi_sig_signed_by_2nd_key = multi_ed25519::Signature::new(vec![(sig_with_2nd_key, 1)]);
     assert!(multi_sig_signed_by_2nd_key.is_ok());
     let multi_sig_signed_by_2nd_key_unwrapped = multi_sig_signed_by_2nd_key.unwrap();
     assert_eq!(
@@ -325,7 +325,7 @@ fn test_multi_ed25519_signature_verification() {
     // Signing with the 2nd key but using wrong index will fail.
     let sig_with_2nd_key = priv_keys_3[1].sign_message(&MESSAGE_HASH);
     let multi_sig_signed_by_2nd_key_wrong_index =
-        MultiEd25519Signature::new(vec![(sig_with_2nd_key.clone(), 2)]);
+        multi_ed25519::Signature::new(vec![(sig_with_2nd_key.clone(), 2)]);
     assert!(multi_sig_signed_by_2nd_key_wrong_index.is_ok());
     let failed_multi_sig_signed_by_2nd_key_wrong_index = multi_sig_signed_by_2nd_key_wrong_index
         .unwrap()
@@ -334,7 +334,7 @@ fn test_multi_ed25519_signature_verification() {
 
     // Signing with the 2nd and 3rd keys must succeed, even if we surpass the threshold.
     let sig_with_3rd_key = priv_keys_3[2].sign_message(&MESSAGE_HASH);
-    let multi_sig_signed_by_2nd_and_3rd_key = MultiEd25519Signature::new(vec![
+    let multi_sig_signed_by_2nd_and_3rd_key = multi_ed25519::Signature::new(vec![
         (sig_with_2nd_key.clone(), 1),
         (sig_with_3rd_key.clone(), 2),
     ]);
@@ -350,7 +350,7 @@ fn test_multi_ed25519_signature_verification() {
         .is_ok());
 
     // Signing with the 2nd and 3rd keys will fail if we swap indexes.
-    let multi_sig_signed_by_2nd_and_3rd_key_swapped = MultiEd25519Signature::new(vec![
+    let multi_sig_signed_by_2nd_and_3rd_key_swapped = multi_ed25519::Signature::new(vec![
         (sig_with_2nd_key.clone(), 2),
         (sig_with_3rd_key.clone(), 1),
     ]);
@@ -363,7 +363,7 @@ fn test_multi_ed25519_signature_verification() {
     // Signing with the 2nd and an unrelated key. Although threshold is met, it should fail as
     // we don't accept invalid signatures.
     let sig_with_unrelated_key = priv_keys_10[9].sign_message(&MESSAGE_HASH);
-    let multi_sig_signed_by_2nd_and_unrelated_key = MultiEd25519Signature::new(vec![
+    let multi_sig_signed_by_2nd_and_unrelated_key = multi_ed25519::Signature::new(vec![
         (sig_with_2nd_key.clone(), 1),
         (sig_with_unrelated_key, 2),
     ]);
@@ -374,13 +374,13 @@ fn test_multi_ed25519_signature_verification() {
     assert!(failed_verified_sig.is_err());
 
     // Testing all combinations for 2 of 3.
-    let multi_private_key_2of3 = MultiEd25519PrivateKey::new(priv_keys_3.clone(), 2).unwrap();
-    let multi_public_key_2of3 = MultiEd25519PublicKey::from(&multi_private_key_2of3);
+    let multi_private_key_2of3 = multi_ed25519::PrivateKey::new(priv_keys_3.clone(), 2).unwrap();
+    let multi_public_key_2of3 = multi_ed25519::PublicKey::from(&multi_private_key_2of3);
 
     let sig_with_1st_key = priv_keys_3[0].sign_message(&MESSAGE_HASH);
 
     // Signing with the 1st and 2nd keys must succeed.
-    let signed_by_1st_and_2nd_key = MultiEd25519Signature::new(vec![
+    let signed_by_1st_and_2nd_key = multi_ed25519::Signature::new(vec![
         (sig_with_1st_key.clone(), 0),
         (sig_with_2nd_key.clone(), 1),
     ]);
@@ -395,7 +395,7 @@ fn test_multi_ed25519_signature_verification() {
         .is_ok());
 
     // Signing with the 1st and 3rd keys must succeed.
-    let signed_by_1st_and_3rd_key = MultiEd25519Signature::new(vec![
+    let signed_by_1st_and_3rd_key = multi_ed25519::Signature::new(vec![
         (sig_with_1st_key.clone(), 0),
         (sig_with_3rd_key.clone(), 2),
     ]);
@@ -410,7 +410,7 @@ fn test_multi_ed25519_signature_verification() {
         .is_ok());
 
     // Signing with the 2nd and 3rd keys must succeed.
-    let signed_by_2nd_and_3rd_key = MultiEd25519Signature::new(vec![
+    let signed_by_2nd_and_3rd_key = multi_ed25519::Signature::new(vec![
         (sig_with_2nd_key.clone(), 1),
         (sig_with_3rd_key.clone(), 2),
     ]);
@@ -425,7 +425,7 @@ fn test_multi_ed25519_signature_verification() {
         .is_ok());
 
     // Signing with the 2nd and 3rd keys must succeed.
-    let signed_by_all_3_keys = MultiEd25519Signature::new(vec![
+    let signed_by_all_3_keys = multi_ed25519::Signature::new(vec![
         (sig_with_1st_key, 0),
         (sig_with_2nd_key.clone(), 1),
         (sig_with_3rd_key, 2),
@@ -441,7 +441,7 @@ fn test_multi_ed25519_signature_verification() {
         .is_ok());
 
     // Signing with the 2nd only will fail.
-    let signed_by_2nd_key = MultiEd25519Signature::new(vec![(sig_with_2nd_key, 1)]);
+    let signed_by_2nd_key = multi_ed25519::Signature::new(vec![(sig_with_2nd_key, 1)]);
     assert!(signed_by_2nd_key.is_ok());
     let signed_by_2nd_key_unwrapped = signed_by_2nd_key.unwrap();
     assert_eq!(

--- a/crypto/crypto/src/unit_tests/multi_ed25519_test.rs
+++ b/crypto/crypto/src/unit_tests/multi_ed25519_test.rs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::{
-    ed25519::{Ed25519PrivateKey, Ed25519PublicKey, ED25519_PUBLIC_KEY_LENGTH},
+    ed25519,
     hash::HashValue,
     multi_ed25519,
     test_utils::TEST_SEED,
@@ -16,15 +16,15 @@ use rand::{rngs::StdRng, SeedableRng};
 static MESSAGE_HASH: Lazy<HashValue> = Lazy::new(|| HashValue::from_sha3_256(b"Test Message"));
 
 // Helper function to generate N key pairs.
-fn generate_keys(n: usize) -> Vec<Ed25519PrivateKey> {
+fn generate_keys(n: usize) -> Vec<ed25519::PrivateKey> {
     let mut rng = StdRng::from_seed(TEST_SEED);
     (0..n)
-        .map(|_| Ed25519PrivateKey::generate(&mut rng))
+        .map(|_| ed25519::PrivateKey::generate(&mut rng))
         .collect()
 }
 
 // Reused assertions in our tests.
-fn test_successful_public_key_serialization(original_keys: &[Ed25519PublicKey], threshold: u8) {
+fn test_successful_public_key_serialization(original_keys: &[ed25519::PublicKey], threshold: u8) {
     let n = original_keys.len();
     let public_key: multi_ed25519::PublicKey =
         multi_ed25519::PublicKey::new(original_keys.to_vec(), threshold).unwrap();
@@ -46,7 +46,7 @@ fn test_failed_public_key_serialization(
     assert_eq!(result.err().unwrap(), expected_error);
 }
 
-fn test_successful_signature_serialization(private_keys: &[Ed25519PrivateKey], threshold: u8) {
+fn test_successful_signature_serialization(private_keys: &[ed25519::PrivateKey], threshold: u8) {
     let multi_private_key =
         multi_ed25519::PrivateKey::new(private_keys.to_vec(), threshold).unwrap();
     let multi_public_key = multi_ed25519::PublicKey::from(&multi_private_key);
@@ -141,7 +141,7 @@ fn test_multi_ed25519_public_key_serialization() {
         multi_public_key_7of10
     );
 
-    // Check that MultiEd25519PublicKey::from Ed25519PublicKey works as expected.
+    // Check that multi_ed25519::PublicKey::from ed25519::PublicKey works as expected.
     let multi_public_key_from_ed25519 = multi_ed25519::PublicKey::from(
         multi_public_key_7of10_from_multi_private_key.public_keys()[0].clone(),
     );
@@ -189,7 +189,7 @@ fn test_multi_ed25519_signature_serialization() {
     // Test 32 of 32
     test_successful_signature_serialization(&priv_keys_32, 32);
 
-    // Construct from single Ed25519Signature.
+    // Construct from single ed25519::Signature.
     let single_signature = priv_keys_3[0].sign_message(&MESSAGE_HASH);
     let multi_signature = multi_ed25519::PublicKey::from(single_signature.clone());
     assert_eq!(1, multi_signature.signatures().len());

--- a/crypto/crypto/src/x25519.rs
+++ b/crypto/crypto/src/x25519.rs
@@ -108,7 +108,7 @@ impl Uniform for X25519EphemeralPrivateKey {
     }
 }
 
-impl PrivateKey for X25519EphemeralPrivateKey {
+impl PrivateKeyExt for X25519EphemeralPrivateKey {
     type PublicKeyMaterial = X25519PublicKey;
 }
 
@@ -189,7 +189,7 @@ impl Uniform for X25519StaticPrivateKey {
     }
 }
 
-impl PrivateKey for X25519StaticPrivateKey {
+impl PrivateKeyExt for X25519StaticPrivateKey {
     type PublicKeyMaterial = X25519StaticPublicKey;
 }
 
@@ -267,11 +267,11 @@ impl PartialEq for X25519PublicKey {
 
 impl Eq for X25519PublicKey {}
 
-impl PublicKey for X25519PublicKey {
+impl PublicKeyExt for X25519PublicKey {
     type PrivateKeyMaterial = X25519EphemeralPrivateKey;
 }
 
-impl PublicKey for X25519StaticPublicKey {
+impl PublicKeyExt for X25519StaticPublicKey {
     type PrivateKeyMaterial = X25519StaticPrivateKey;
 }
 

--- a/execution/executor-benchmark/src/lib.rs
+++ b/execution/executor-benchmark/src/lib.rs
@@ -4,7 +4,7 @@
 use executor::Executor;
 use executor_utils::create_storage_service_and_executor;
 use libra_crypto::{
-    ed25519::{Ed25519PrivateKey, Ed25519PublicKey},
+    ed25519,
     hash::{CryptoHash, HashValue},
     PrivateKeyExt, SigningKey, Uniform,
 };
@@ -25,8 +25,8 @@ use storage_client::{StorageRead, StorageReadServiceClient};
 use transaction_builder::{encode_create_account_script, encode_transfer_script};
 
 struct AccountData {
-    private_key: Ed25519PrivateKey,
-    public_key: Ed25519PublicKey,
+    private_key: ed25519::PrivateKey,
+    public_key: ed25519::PublicKey,
     address: AccountAddress,
     sequence_number: u64,
 }
@@ -45,7 +45,7 @@ struct TransactionGenerator {
     accounts: Vec<AccountData>,
 
     /// Used to mint accounts.
-    genesis_key: Ed25519PrivateKey,
+    genesis_key: ed25519::PrivateKey,
 
     /// For deterministic transaction generation.
     rng: StdRng,
@@ -60,7 +60,7 @@ struct TransactionGenerator {
 
 impl TransactionGenerator {
     fn new(
-        genesis_key: Ed25519PrivateKey,
+        genesis_key: ed25519::PrivateKey,
         num_accounts: usize,
         block_sender: mpsc::SyncSender<Vec<Transaction>>,
         storage_client: StorageReadServiceClient,
@@ -70,7 +70,7 @@ impl TransactionGenerator {
 
         let mut accounts = Vec::with_capacity(num_accounts);
         for _i in 0..num_accounts {
-            let private_key = Ed25519PrivateKey::generate(&mut rng);
+            let private_key = ed25519::PrivateKey::generate(&mut rng);
             let public_key = private_key.public_key();
             let address = AccountAddress::from_public_key(&public_key);
             let account = AccountData {
@@ -306,8 +306,8 @@ pub fn run_benchmark(
 fn create_transaction(
     sender: AccountAddress,
     sequence_number: u64,
-    private_key: &Ed25519PrivateKey,
-    public_key: Ed25519PublicKey,
+    private_key: &ed25519::PrivateKey,
+    public_key: ed25519::PublicKey,
     program: Script,
 ) -> Transaction {
     let now = std::time::SystemTime::now()

--- a/execution/executor-benchmark/src/lib.rs
+++ b/execution/executor-benchmark/src/lib.rs
@@ -6,7 +6,7 @@ use executor_utils::create_storage_service_and_executor;
 use libra_crypto::{
     ed25519::{Ed25519PrivateKey, Ed25519PublicKey},
     hash::{CryptoHash, HashValue},
-    PrivateKey, SigningKey, Uniform,
+    PrivateKeyExt, SigningKey, Uniform,
 };
 use libra_logger::prelude::*;
 use libra_types::{

--- a/execution/executor-utils/src/test_helpers.rs
+++ b/execution/executor-utils/src/test_helpers.rs
@@ -1,10 +1,7 @@
 // Copyright (c) The Libra Core Contributors
 // SPDX-License-Identifier: Apache-2.0
 
-use libra_crypto::{
-    ed25519::{Ed25519PrivateKey, Ed25519PublicKey},
-    HashValue,
-};
+use libra_crypto::{ed25519, HashValue};
 use libra_types::{
     account_address::AccountAddress,
     block_info::BlockInfo,
@@ -44,8 +41,8 @@ pub fn gen_block_metadata(index: u8, proposer: AccountAddress) -> BlockMetadata 
 pub fn get_test_signed_transaction(
     sender: AccountAddress,
     sequence_number: u64,
-    private_key: Ed25519PrivateKey,
-    public_key: Ed25519PublicKey,
+    private_key: ed25519::PrivateKey,
+    public_key: ed25519::PublicKey,
     program: Option<Script>,
 ) -> Transaction {
     Transaction::UserTransaction(get_test_signed_txn(

--- a/execution/executor/src/executor_test.rs
+++ b/execution/executor/src/executor_test.rs
@@ -11,7 +11,7 @@ use crate::{
     Executor, OP_COUNTERS,
 };
 use libra_config::config::NodeConfig;
-use libra_crypto::{ed25519::Ed25519PrivateKey, HashValue};
+use libra_crypto::{ed25519, HashValue};
 use libra_types::{
     account_address::AccountAddress,
     block_info::BlockInfo,
@@ -26,7 +26,7 @@ use storage_client::{StorageRead, StorageReadServiceClient, SyncStorageClient};
 use storage_service::{init_libra_db, start_storage_service_with_db};
 use tokio::runtime::Runtime;
 
-fn build_test_config() -> (NodeConfig, Ed25519PrivateKey) {
+fn build_test_config() -> (NodeConfig, ed25519::PrivateKey) {
     let validator_config = config_builder::ValidatorConfig::new();
     let randomize_service_ports = true;
     let randomize_libranet_ports = false;

--- a/execution/executor/src/mock_vm/mod.rs
+++ b/execution/executor/src/mock_vm/mod.rs
@@ -4,7 +4,7 @@
 #[cfg(test)]
 mod mock_vm_test;
 
-use libra_crypto::{ed25519::Ed25519PrivateKey, PrivateKeyExt, Uniform};
+use libra_crypto::{ed25519, PrivateKeyExt, Uniform};
 use libra_state_view::StateView;
 use libra_types::{
     access_path::AccessPath,
@@ -317,7 +317,7 @@ fn encode_transaction(sender: AccountAddress, program: Script) -> Transaction {
         std::time::Duration::from_secs(0),
     );
 
-    let privkey = Ed25519PrivateKey::generate_for_testing();
+    let privkey = ed25519::PrivateKey::generate_for_testing();
     Transaction::UserTransaction(
         raw_transaction
             .sign(&privkey, privkey.public_key())
@@ -329,7 +329,7 @@ fn encode_transaction(sender: AccountAddress, program: Script) -> Transaction {
 pub fn encode_reconfiguration_transaction(sender: AccountAddress) -> Transaction {
     let raw_transaction = RawTransaction::new_write_set(sender, 0, WriteSet::default());
 
-    let privkey = Ed25519PrivateKey::generate_for_testing();
+    let privkey = ed25519::PrivateKey::generate_for_testing();
     Transaction::UserTransaction(
         raw_transaction
             .sign(&privkey, privkey.public_key())

--- a/execution/executor/src/mock_vm/mod.rs
+++ b/execution/executor/src/mock_vm/mod.rs
@@ -4,7 +4,7 @@
 #[cfg(test)]
 mod mock_vm_test;
 
-use libra_crypto::{ed25519::Ed25519PrivateKey, PrivateKey, Uniform};
+use libra_crypto::{ed25519::Ed25519PrivateKey, PrivateKeyExt, Uniform};
 use libra_state_view::StateView;
 use libra_types::{
     access_path::AccessPath,

--- a/execution/executor/tests/storage_integration_test.rs
+++ b/execution/executor/tests/storage_integration_test.rs
@@ -8,7 +8,7 @@ use executor_utils::{
         gen_block_id, gen_block_metadata, gen_ledger_info_with_sigs, get_test_signed_transaction,
     },
 };
-use libra_crypto::{ed25519::*, test_utils::TEST_SEED, HashValue, PrivateKey, Uniform};
+use libra_crypto::{ed25519::*, test_utils::TEST_SEED, HashValue, PrivateKeyExt, Uniform};
 use libra_types::{
     access_path::AccessPath,
     account_config::{association_address, lbr_type_tag, AccountResource},

--- a/execution/executor/tests/storage_integration_test.rs
+++ b/execution/executor/tests/storage_integration_test.rs
@@ -8,7 +8,7 @@ use executor_utils::{
         gen_block_id, gen_block_metadata, gen_ledger_info_with_sigs, get_test_signed_transaction,
     },
 };
-use libra_crypto::{ed25519::*, test_utils::TEST_SEED, HashValue, PrivateKeyExt, Uniform};
+use libra_crypto::{ed25519, test_utils::TEST_SEED, HashValue, PrivateKeyExt, Uniform};
 use libra_types::{
     access_path::AccessPath,
     account_config::{association_address, lbr_type_tag, AccountResource},
@@ -149,7 +149,7 @@ fn test_reconfiguration() {
     let txn2 = encode_block_prologue_script(gen_block_metadata(1, validator_account));
 
     // rotate the validator's connsensus pubkey to trigger a reconfiguration
-    let new_pubkey = Ed25519PrivateKey::generate_for_testing().public_key();
+    let new_pubkey = ed25519::PrivateKey::generate_for_testing().public_key();
     let txn3 = get_test_signed_transaction(
         validator_account,
         /* sequence_number = */ 0,
@@ -701,21 +701,21 @@ fn test_execution_with_storage() {
     assert!(seed != TEST_SEED);
     let mut rng = ::rand::rngs::StdRng::from_seed(seed);
 
-    let privkey1 = Ed25519PrivateKey::generate(&mut rng);
+    let privkey1 = ed25519::PrivateKey::generate(&mut rng);
     let pubkey1 = privkey1.public_key();
     let account1_auth_key = AuthenticationKey::ed25519(&pubkey1);
     let account1 = account1_auth_key.derived_address();
 
-    let privkey2 = Ed25519PrivateKey::generate(&mut rng);
+    let privkey2 = ed25519::PrivateKey::generate(&mut rng);
     let pubkey2 = privkey2.public_key();
     let account2_auth_key = AuthenticationKey::ed25519(&pubkey2);
     let account2 = account2_auth_key.derived_address();
 
-    let pubkey3 = Ed25519PrivateKey::generate(&mut rng).public_key();
+    let pubkey3 = ed25519::PrivateKey::generate(&mut rng).public_key();
     let account3_auth_key = AuthenticationKey::ed25519(&pubkey3);
     let account3 = account3_auth_key.derived_address();
 
-    let pubkey4 = Ed25519PrivateKey::generate(&mut rng).public_key();
+    let pubkey4 = ed25519::PrivateKey::generate(&mut rng).public_key();
     let account4_auth_key = AuthenticationKey::ed25519(&pubkey4); // non-existent account
     let account4 = account4_auth_key.derived_address();
     let genesis_account = association_address();

--- a/json-rpc/src/tests/unit_tests.rs
+++ b/json-rpc/src/tests/unit_tests.rs
@@ -14,7 +14,7 @@ use crate::{
 use futures::{channel::mpsc::channel, StreamExt};
 use hex;
 use libra_config::utils;
-use libra_crypto::{ed25519::Ed25519PrivateKey, HashValue, PrivateKey, Uniform};
+use libra_crypto::{ed25519::Ed25519PrivateKey, HashValue, PrivateKeyExt, Uniform};
 use libra_proptest_helpers::ValueGenerator;
 use libra_types::{
     account_address::AccountAddress,

--- a/json-rpc/src/tests/unit_tests.rs
+++ b/json-rpc/src/tests/unit_tests.rs
@@ -14,7 +14,7 @@ use crate::{
 use futures::{channel::mpsc::channel, StreamExt};
 use hex;
 use libra_config::utils;
-use libra_crypto::{ed25519::Ed25519PrivateKey, HashValue, PrivateKeyExt, Uniform};
+use libra_crypto::{ed25519, HashValue, PrivateKeyExt, Uniform};
 use libra_proptest_helpers::ValueGenerator;
 use libra_types::{
     account_address::AccountAddress,
@@ -201,7 +201,7 @@ fn test_transaction_submission() {
 
     // closure that checks transaction submission for given account
     let mut txn_submission = move |sender| {
-        let privkey = Ed25519PrivateKey::generate_for_testing();
+        let privkey = ed25519::PrivateKey::generate_for_testing();
         let txn = get_test_signed_txn(sender, 0, &privkey, privkey.public_key(), None);
         let mut batch = JsonRpcBatch::default();
         batch.add_submit_request(txn).unwrap();

--- a/language/e2e-tests/src/account.rs
+++ b/language/e2e-tests/src/account.rs
@@ -4,7 +4,7 @@
 //! Test infrastructure for modeling Libra accounts.
 
 use crate::{gas_costs, keygen::KeyGen};
-use libra_crypto::ed25519::*;
+use libra_crypto::ed25519;
 use libra_types::{
     access_path::AccessPath,
     account_address::AccountAddress,
@@ -39,9 +39,9 @@ pub const DEFAULT_EXPIRATION_TIME: u64 = 40_000;
 pub struct Account {
     addr: AccountAddress,
     /// The current private key for this account.
-    pub privkey: Ed25519PrivateKey,
+    pub privkey: ed25519::PrivateKey,
     /// The current public key for this account.
-    pub pubkey: Ed25519PublicKey,
+    pub pubkey: ed25519::PublicKey,
 }
 
 impl Account {
@@ -61,7 +61,7 @@ impl Account {
     ///
     /// Like with [`Account::new`], the account returned by this constructor is a purely logical
     /// entity.
-    pub fn with_keypair(privkey: Ed25519PrivateKey, pubkey: Ed25519PublicKey) -> Self {
+    pub fn with_keypair(privkey: ed25519::PrivateKey, pubkey: ed25519::PublicKey) -> Self {
         let addr = AccountAddress::from_public_key(&pubkey);
         Account {
             addr,
@@ -119,7 +119,7 @@ impl Account {
     }
 
     /// Changes the keys for this account to the provided ones.
-    pub fn rotate_key(&mut self, privkey: Ed25519PrivateKey, pubkey: Ed25519PublicKey) {
+    pub fn rotate_key(&mut self, privkey: ed25519::PrivateKey, pubkey: ed25519::PublicKey) {
         self.privkey = privkey;
         self.pubkey = pubkey;
     }
@@ -431,8 +431,8 @@ impl AccountData {
 
     /// Creates a new `AccountData` with the provided account.
     pub fn with_keypair(
-        privkey: Ed25519PrivateKey,
-        pubkey: Ed25519PublicKey,
+        privkey: ed25519::PrivateKey,
+        pubkey: ed25519::PublicKey,
         balance: u64,
         sequence_number: u64,
     ) -> Self {
@@ -463,7 +463,7 @@ impl AccountData {
     }
 
     /// Changes the keys for this account to the provided ones.
-    pub fn rotate_key(&mut self, privkey: Ed25519PrivateKey, pubkey: Ed25519PublicKey) {
+    pub fn rotate_key(&mut self, privkey: ed25519::PrivateKey, pubkey: ed25519::PublicKey) {
         self.account.rotate_key(privkey, pubkey)
     }
 

--- a/language/e2e-tests/src/account_universe.rs
+++ b/language/e2e-tests/src/account_universe.rs
@@ -24,7 +24,7 @@ use crate::{
     account::{Account, AccountData},
     gas_costs,
 };
-use libra_crypto::ed25519::{Ed25519PrivateKey, Ed25519PublicKey};
+use libra_crypto::ed25519;
 use libra_types::{
     transaction::{SignedTransaction, TransactionStatus},
     vm_error::{StatusCode, VMStatus},
@@ -140,7 +140,7 @@ impl AccountCurrent {
     }
 
     /// Rotates the key in this account.
-    pub fn rotate_key(&mut self, privkey: Ed25519PrivateKey, pubkey: Ed25519PublicKey) {
+    pub fn rotate_key(&mut self, privkey: ed25519::PrivateKey, pubkey: ed25519::PublicKey) {
         self.initial_data.rotate_key(privkey, pubkey);
     }
 

--- a/language/e2e-tests/src/account_universe/rotate_key.rs
+++ b/language/e2e-tests/src/account_universe/rotate_key.rs
@@ -6,10 +6,7 @@ use crate::{
     common_transactions::rotate_key_txn,
     gas_costs,
 };
-use libra_crypto::{
-    ed25519::{self, Ed25519PrivateKey, Ed25519PublicKey},
-    test_utils::KeyPair,
-};
+use libra_crypto::{ed25519, test_utils::KeyPair};
 use libra_proptest_helpers::Index;
 use libra_types::{
     account_address::AccountAddress,
@@ -25,7 +22,7 @@ use proptest_derive::Arbitrary;
 pub struct RotateKeyGen {
     sender: Index,
     #[proptest(strategy = "ed25519::keypair_strategy()")]
-    new_keypair: KeyPair<Ed25519PrivateKey, Ed25519PublicKey>,
+    new_keypair: KeyPair<ed25519::PrivateKey, ed25519::PublicKey>,
 }
 
 impl AUTransactionGen for RotateKeyGen {

--- a/language/e2e-tests/src/gas_costs.rs
+++ b/language/e2e-tests/src/gas_costs.rs
@@ -8,7 +8,7 @@ use crate::{
     common_transactions::{create_account_txn, peer_to_peer_txn, rotate_key_txn},
     executor::FakeExecutor,
 };
-use libra_crypto::{ed25519::Ed25519PrivateKey, PrivateKey, Uniform};
+use libra_crypto::{ed25519::Ed25519PrivateKey, PrivateKeyExt, Uniform};
 use libra_types::{account_address::AccountAddress, transaction::SignedTransaction};
 use once_cell::sync::Lazy;
 

--- a/language/e2e-tests/src/gas_costs.rs
+++ b/language/e2e-tests/src/gas_costs.rs
@@ -8,7 +8,7 @@ use crate::{
     common_transactions::{create_account_txn, peer_to_peer_txn, rotate_key_txn},
     executor::FakeExecutor,
 };
-use libra_crypto::{ed25519::Ed25519PrivateKey, PrivateKeyExt, Uniform};
+use libra_crypto::{ed25519, PrivateKeyExt, Uniform};
 use libra_types::{account_address::AccountAddress, transaction::SignedTransaction};
 use once_cell::sync::Lazy;
 
@@ -244,7 +244,7 @@ pub static ROTATE_KEY: Lazy<u64> = Lazy::new(|| {
     let mut executor = FakeExecutor::from_genesis_file();
     let sender = AccountData::new(1_000_000, 10);
     executor.add_account_data(&sender);
-    let pubkey = Ed25519PrivateKey::generate_for_testing().public_key();
+    let pubkey = ed25519::PrivateKey::generate_for_testing().public_key();
     let new_key_hash = AccountAddress::authentication_key(&pubkey).to_vec();
 
     let txn = rotate_key_txn(sender.account(), new_key_hash, 10);

--- a/language/e2e-tests/src/keygen.rs
+++ b/language/e2e-tests/src/keygen.rs
@@ -3,7 +3,7 @@
 
 use libra_crypto::{
     ed25519::{Ed25519PrivateKey, Ed25519PublicKey},
-    PrivateKey, Uniform,
+    PrivateKeyExt, Uniform,
 };
 use rand::{
     rngs::{OsRng, StdRng},

--- a/language/e2e-tests/src/keygen.rs
+++ b/language/e2e-tests/src/keygen.rs
@@ -1,10 +1,7 @@
 // Copyright (c) The Libra Core Contributors
 // SPDX-License-Identifier: Apache-2.0
 
-use libra_crypto::{
-    ed25519::{Ed25519PrivateKey, Ed25519PublicKey},
-    PrivateKeyExt, Uniform,
-};
+use libra_crypto::{ed25519, PrivateKeyExt, Uniform};
 use rand::{
     rngs::{OsRng, StdRng},
     Rng, SeedableRng,
@@ -28,8 +25,8 @@ impl KeyGen {
     }
 
     /// Generate an Ed25519 key pair.
-    pub fn generate_keypair(&mut self) -> (Ed25519PrivateKey, Ed25519PublicKey) {
-        let private_key = Ed25519PrivateKey::generate(&mut self.0);
+    pub fn generate_keypair(&mut self) -> (ed25519::PrivateKey, ed25519::PublicKey) {
+        let private_key = ed25519::PrivateKey::generate(&mut self.0);
         let public_key = private_key.public_key();
         (private_key, public_key)
     }

--- a/language/e2e-tests/src/tests/rotate_key.rs
+++ b/language/e2e-tests/src/tests/rotate_key.rs
@@ -8,10 +8,7 @@ use crate::{
     keygen::KeyGen,
 };
 use libra_crypto::{
-    ed25519::Ed25519PrivateKey,
-    hash::CryptoHash,
-    multi_ed25519::{MultiEd25519PublicKey, MultiEd25519Signature},
-    PrivateKeyExt, SigningKey, Uniform,
+    ed25519::Ed25519PrivateKey, hash::CryptoHash, multi_ed25519, PrivateKeyExt, SigningKey, Uniform,
 };
 use libra_types::{
     account_address::AccountAddress,
@@ -84,7 +81,7 @@ fn rotate_ed25519_multisig_key() {
     let (privkey2, pubkey2) = keygen.generate_keypair();
     let threshold = 1;
     let multi_ed_public_key =
-        MultiEd25519PublicKey::new(vec![pubkey1, pubkey2], threshold).unwrap();
+        multi_ed25519::PublicKey::new(vec![pubkey1, pubkey2], threshold).unwrap();
     let new_auth_key = AuthenticationKey::multi_ed25519(&multi_ed_public_key);
 
     // (1) rotate key to multisig
@@ -102,7 +99,7 @@ fn rotate_ed25519_multisig_key() {
 
     // (2) send a tx signed by privkey 1
     let txn1 = raw_rotate_key_txn(*sender_address, new_auth_key.to_vec(), seq_number);
-    let signature1 = MultiEd25519Signature::from(privkey1.sign_message(&txn1.hash()));
+    let signature1 = multi_ed25519::Signature::from(privkey1.sign_message(&txn1.hash()));
     let signed_txn1 =
         SignedTransaction::new_multisig(txn1, multi_ed_public_key.clone(), signature1);
     let output = &executor.execute_transaction(signed_txn1);
@@ -117,7 +114,7 @@ fn rotate_ed25519_multisig_key() {
     let txn2 = raw_rotate_key_txn(*sender_address, new_auth_key.to_vec(), seq_number);
     let pubkey_index = 1;
     let signature2 =
-        MultiEd25519Signature::new(vec![(privkey2.sign_message(&txn2.hash()), pubkey_index)])
+        multi_ed25519::Signature::new(vec![(privkey2.sign_message(&txn2.hash()), pubkey_index)])
             .unwrap();
     let signed_txn2 = SignedTransaction::new_multisig(txn2, multi_ed_public_key, signature2);
     signed_txn2.clone().check_signature().unwrap();

--- a/language/e2e-tests/src/tests/rotate_key.rs
+++ b/language/e2e-tests/src/tests/rotate_key.rs
@@ -11,7 +11,7 @@ use libra_crypto::{
     ed25519::Ed25519PrivateKey,
     hash::CryptoHash,
     multi_ed25519::{MultiEd25519PublicKey, MultiEd25519Signature},
-    PrivateKey, SigningKey, Uniform,
+    PrivateKeyExt, SigningKey, Uniform,
 };
 use libra_types::{
     account_address::AccountAddress,

--- a/language/e2e-tests/src/tests/rotate_key.rs
+++ b/language/e2e-tests/src/tests/rotate_key.rs
@@ -7,9 +7,7 @@ use crate::{
     executor::FakeExecutor,
     keygen::KeyGen,
 };
-use libra_crypto::{
-    ed25519::Ed25519PrivateKey, hash::CryptoHash, multi_ed25519, PrivateKeyExt, SigningKey, Uniform,
-};
+use libra_crypto::{ed25519, hash::CryptoHash, multi_ed25519, PrivateKeyExt, SigningKey, Uniform};
 use libra_types::{
     account_address::AccountAddress,
     transaction::{authenticator::AuthenticationKey, SignedTransaction, TransactionStatus},
@@ -23,7 +21,7 @@ fn rotate_ed25519_key() {
     let mut sender = AccountData::new(1_000_000, 10);
     executor.add_account_data(&sender);
 
-    let privkey = Ed25519PrivateKey::generate_for_testing();
+    let privkey = ed25519::PrivateKey::generate_for_testing();
     let pubkey = privkey.public_key();
     let new_key_hash = AccountAddress::authentication_key(&pubkey).to_vec();
     let txn = rotate_key_txn(sender.account(), new_key_hash.clone(), 10);

--- a/language/e2e-tests/src/tests/verify_txn.rs
+++ b/language/e2e-tests/src/tests/verify_txn.rs
@@ -7,7 +7,7 @@ use crate::{
 };
 use bytecode_verifier::VerifiedModule;
 use compiler::Compiler;
-use libra_crypto::{ed25519::Ed25519PrivateKey, PrivateKeyExt, Uniform};
+use libra_crypto::{ed25519, PrivateKeyExt, Uniform};
 use libra_types::{
     account_config::{lbr_type_tag, CORE_CODE_ADDRESS, LBR_NAME},
     on_chain_config::VMPublishingOption,
@@ -28,7 +28,7 @@ fn verify_signature() {
     let sender = AccountData::new(900_000, 10);
     executor.add_account_data(&sender);
     // Generate a new key pair to try and sign things with.
-    let private_key = Ed25519PrivateKey::generate_for_testing();
+    let private_key = ed25519::PrivateKey::generate_for_testing();
     let program = encode_transfer_script(lbr_type_tag(), sender.address(), vec![], 100);
     let signed_txn = transaction_test_helpers::get_test_unchecked_txn(
         *sender.address(),
@@ -51,7 +51,7 @@ fn verify_reserved_sender() {
     let sender = AccountData::new(900_000, 10);
     executor.add_account_data(&sender);
     // Generate a new key pair to try and sign things with.
-    let private_key = Ed25519PrivateKey::generate_for_testing();
+    let private_key = ed25519::PrivateKey::generate_for_testing();
     let program = encode_transfer_script(lbr_type_tag(), sender.address(), vec![], 100);
     let signed_txn = transaction_test_helpers::get_test_signed_txn(
         CORE_CODE_ADDRESS,

--- a/language/e2e-tests/src/tests/verify_txn.rs
+++ b/language/e2e-tests/src/tests/verify_txn.rs
@@ -7,7 +7,7 @@ use crate::{
 };
 use bytecode_verifier::VerifiedModule;
 use compiler::Compiler;
-use libra_crypto::{ed25519::Ed25519PrivateKey, PrivateKey, Uniform};
+use libra_crypto::{ed25519::Ed25519PrivateKey, PrivateKeyExt, Uniform};
 use libra_types::{
     account_config::{lbr_type_tag, CORE_CODE_ADDRESS, LBR_NAME},
     on_chain_config::VMPublishingOption,

--- a/language/functional-tests/src/config/global.rs
+++ b/language/functional-tests/src/config/global.rs
@@ -10,7 +10,7 @@ use language_e2e_tests::{
     keygen::KeyGen,
 };
 use libra_config::generator;
-use libra_crypto::PrivateKey;
+use libra_crypto::PrivateKeyExt;
 use libra_types::validator_set::ValidatorSet;
 use std::{
     collections::{btree_map, BTreeMap},

--- a/language/functional-tests/src/evaluator.rs
+++ b/language/functional-tests/src/evaluator.rs
@@ -10,7 +10,7 @@ use bytecode_verifier::verifier::{
     verify_module_dependencies, verify_script_dependencies, VerifiedModule, VerifiedScript,
 };
 use language_e2e_tests::executor::FakeExecutor;
-use libra_crypto::ed25519::{Ed25519PrivateKey, Ed25519PublicKey};
+use libra_crypto::ed25519;
 use libra_state_view::StateView;
 use libra_types::{
     access_path::AccessPath,
@@ -260,8 +260,8 @@ pub fn verify_module(
 /// A set of common parameters required to create transactions.
 struct TransactionParameters<'a> {
     pub sender_addr: AccountAddress,
-    pub pubkey: &'a Ed25519PublicKey,
-    pub privkey: &'a Ed25519PrivateKey,
+    pub pubkey: &'a ed25519::PublicKey,
+    pub privkey: &'a ed25519::PrivateKey,
     pub sequence_number: u64,
     pub max_gas_amount: u64,
     pub gas_unit_price: u64,

--- a/language/tools/vm-genesis/src/lib.rs
+++ b/language/tools/vm-genesis/src/lib.rs
@@ -11,7 +11,7 @@ use bytecode_verifier::VerifiedModule;
 use libra_config::{config::NodeConfig, generator};
 use libra_crypto::{
     ed25519::{Ed25519PrivateKey, Ed25519PublicKey},
-    PrivateKey, Uniform, ValidKey,
+    PrivateKeyExt, Uniform, ValidKey,
 };
 use libra_state_view::StateView;
 use libra_types::{

--- a/language/tools/vm-genesis/src/lib.rs
+++ b/language/tools/vm-genesis/src/lib.rs
@@ -9,10 +9,7 @@ use crate::genesis_gas_schedule::initial_gas_schedule;
 use anyhow::Result;
 use bytecode_verifier::VerifiedModule;
 use libra_config::{config::NodeConfig, generator};
-use libra_crypto::{
-    ed25519::{Ed25519PrivateKey, Ed25519PublicKey},
-    PrivateKeyExt, Uniform, ValidKey,
-};
+use libra_crypto::{ed25519, PrivateKeyExt, Uniform, ValidKey};
 use libra_state_view::StateView;
 use libra_types::{
     access_path::AccessPath,
@@ -48,9 +45,9 @@ const GENESIS_SEED: [u8; 32] = [42; 32];
 /// The initial balance of the association account.
 pub const ASSOCIATION_INIT_BALANCE: u64 = 1_000_000_000_000_000;
 
-pub static GENESIS_KEYPAIR: Lazy<(Ed25519PrivateKey, Ed25519PublicKey)> = Lazy::new(|| {
+pub static GENESIS_KEYPAIR: Lazy<(ed25519::PrivateKey, ed25519::PublicKey)> = Lazy::new(|| {
     let mut rng = StdRng::from_seed(GENESIS_SEED);
-    let private_key = Ed25519PrivateKey::generate(&mut rng);
+    let private_key = ed25519::PrivateKey::generate(&mut rng);
     let public_key = private_key.public_key();
     (private_key, public_key)
 });
@@ -116,8 +113,8 @@ static LIBRA_TIME_MODULE: Lazy<ModuleId> = Lazy::new(|| {
 });
 
 pub fn encode_genesis_transaction_with_validator(
-    private_key: &Ed25519PrivateKey,
-    public_key: Ed25519PublicKey,
+    private_key: &ed25519::PrivateKey,
+    public_key: ed25519::PublicKey,
     nodes: &[NodeConfig],
     validator_set: ValidatorSet,
     discovery_set: DiscoverySet,
@@ -136,7 +133,7 @@ pub fn encode_genesis_transaction_with_validator(
 }
 
 pub fn encode_genesis_change_set(
-    public_key: &Ed25519PublicKey,
+    public_key: &ed25519::PublicKey,
     nodes: &[NodeConfig],
     validator_set: ValidatorSet,
     discovery_set: DiscoverySet,
@@ -199,8 +196,8 @@ pub fn encode_genesis_change_set(
 }
 
 pub fn encode_genesis_transaction(
-    _private_key: &Ed25519PrivateKey,
-    public_key: Ed25519PublicKey,
+    _private_key: &ed25519::PrivateKey,
+    public_key: ed25519::PublicKey,
     nodes: &[NodeConfig],
     validator_set: ValidatorSet,
     discovery_set: DiscoverySet,
@@ -222,7 +219,7 @@ fn create_and_initialize_main_accounts(
     move_vm: &MoveVM,
     gas_schedule: &CostTable,
     interpreter_context: &mut TransactionExecutionContext,
-    public_key: &Ed25519PublicKey,
+    public_key: &ed25519::PublicKey,
     initial_gas_schedule: Value,
 ) {
     let association_addr = account_config::association_address();

--- a/language/vm/src/transaction_metadata.rs
+++ b/language/vm/src/transaction_metadata.rs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::gas_schedule::{AbstractMemorySize, GasAlgebra, GasCarrier, GasPrice, GasUnits};
-use libra_crypto::{ed25519::Ed25519PrivateKey, PrivateKeyExt};
+use libra_crypto::{ed25519, PrivateKeyExt};
 use libra_types::{
     account_address::AccountAddress,
     transaction::{authenticator::AuthenticationKeyPreimage, SignedTransaction},
@@ -66,9 +66,11 @@ impl TransactionMetadata {
 
 impl Default for TransactionMetadata {
     fn default() -> Self {
-        let mut buf = [0u8; Ed25519PrivateKey::LENGTH];
-        buf[Ed25519PrivateKey::LENGTH - 1] = 1;
-        let public_key = Ed25519PrivateKey::try_from(&buf[..]).unwrap().public_key();
+        let mut buf = [0u8; ed25519::PrivateKey::LENGTH];
+        buf[ed25519::PrivateKey::LENGTH - 1] = 1;
+        let public_key = ed25519::PrivateKey::try_from(&buf[..])
+            .unwrap()
+            .public_key();
         TransactionMetadata {
             sender: AccountAddress::default(),
             authentication_key_preimage: AuthenticationKeyPreimage::ed25519(&public_key).into_vec(),

--- a/language/vm/src/transaction_metadata.rs
+++ b/language/vm/src/transaction_metadata.rs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::gas_schedule::{AbstractMemorySize, GasAlgebra, GasCarrier, GasPrice, GasUnits};
-use libra_crypto::{ed25519::Ed25519PrivateKey, PrivateKey};
+use libra_crypto::{ed25519::Ed25519PrivateKey, PrivateKeyExt};
 use libra_types::{
     account_address::AccountAddress,
     transaction::{authenticator::AuthenticationKeyPreimage, SignedTransaction},

--- a/mempool/src/core_mempool/unit_tests/common.rs
+++ b/mempool/src/core_mempool/unit_tests/common.rs
@@ -4,7 +4,7 @@
 use crate::core_mempool::{CoreMempool, TimelineState, TxnPointer};
 use anyhow::{format_err, Result};
 use libra_config::config::NodeConfig;
-use libra_crypto::{ed25519::Ed25519PrivateKey, PrivateKeyExt, Uniform};
+use libra_crypto::{ed25519, PrivateKeyExt, Uniform};
 use libra_types::{
     account_address::AccountAddress,
     account_config::LBR_NAME,
@@ -79,7 +79,7 @@ impl TestTransaction {
         let mut seed: [u8; 32] = [0u8; 32];
         seed[..4].copy_from_slice(&[1, 2, 3, 4]);
         let mut rng: StdRng = StdRng::from_seed(seed);
-        let privkey = Ed25519PrivateKey::generate(&mut rng);
+        let privkey = ed25519::PrivateKey::generate(&mut rng);
         raw_txn
             .sign(&privkey, privkey.public_key())
             .expect("Failed to sign raw transaction.")

--- a/mempool/src/core_mempool/unit_tests/common.rs
+++ b/mempool/src/core_mempool/unit_tests/common.rs
@@ -4,7 +4,7 @@
 use crate::core_mempool::{CoreMempool, TimelineState, TxnPointer};
 use anyhow::{format_err, Result};
 use libra_config::config::NodeConfig;
-use libra_crypto::{ed25519::Ed25519PrivateKey, PrivateKey, Uniform};
+use libra_crypto::{ed25519::Ed25519PrivateKey, PrivateKeyExt, Uniform};
 use libra_types::{
     account_address::AccountAddress,
     account_config::LBR_NAME,

--- a/network/src/connectivity_manager/test.rs
+++ b/network/src/connectivity_manager/test.rs
@@ -10,7 +10,7 @@ use channel::{libra_channel, message_queues::QueueStyle};
 use core::str::FromStr;
 use futures::SinkExt;
 use libra_crypto::{
-    ed25519::Ed25519PrivateKey, test_utils::TEST_SEED, x25519::X25519StaticPrivateKey, PrivateKey,
+    ed25519::Ed25519PrivateKey, test_utils::TEST_SEED, x25519::X25519StaticPrivateKey, PrivateKeyExt,
     Uniform,
 };
 use libra_logger::info;

--- a/network/src/connectivity_manager/test.rs
+++ b/network/src/connectivity_manager/test.rs
@@ -10,8 +10,7 @@ use channel::{libra_channel, message_queues::QueueStyle};
 use core::str::FromStr;
 use futures::SinkExt;
 use libra_crypto::{
-    ed25519::Ed25519PrivateKey, test_utils::TEST_SEED, x25519::X25519StaticPrivateKey, PrivateKeyExt,
-    Uniform,
+    ed25519, test_utils::TEST_SEED, x25519::X25519StaticPrivateKey, PrivateKeyExt, Uniform,
 };
 use libra_logger::info;
 use rand::{rngs::StdRng, SeedableRng};
@@ -40,7 +39,7 @@ fn setup_conn_mgr(
     let eligible_peers = eligible_peers
         .into_iter()
         .map(|peer_id| {
-            let signing_public_key = Ed25519PrivateKey::generate(&mut rng).public_key();
+            let signing_public_key = ed25519::PrivateKey::generate(&mut rng).public_key();
             let identity_public_key = X25519StaticPrivateKey::generate(&mut rng).public_key();
             let pubkeys = NetworkPublicKeys {
                 identity_public_key,
@@ -75,7 +74,7 @@ fn setup_conn_mgr(
 fn gen_peer() -> (PeerId, NetworkPublicKeys) {
     let peer_id = PeerId::random();
     let mut rng = StdRng::from_seed(TEST_SEED);
-    let signing_public_key = Ed25519PrivateKey::generate(&mut rng).public_key();
+    let signing_public_key = ed25519::PrivateKey::generate(&mut rng).public_key();
     let identity_public_key = X25519StaticPrivateKey::generate(&mut rng).public_key();
     (
         peer_id,

--- a/network/src/protocols/discovery/mod.rs
+++ b/network/src/protocols/discovery/mod.rs
@@ -47,7 +47,7 @@ use futures::{
 };
 use libra_config::config::RoleType;
 use libra_crypto::{
-    ed25519::{Ed25519PrivateKey, Ed25519PublicKey, Ed25519Signature},
+    ed25519,
     hash::{CryptoHasher, DiscoveryMsgHasher},
     HashValue, SignatureExt, SigningKey,
 };
@@ -139,8 +139,8 @@ pub struct Discovery<TTicker> {
     dns_seed_addr: Bytes,
     /// Validator for verifying signatures on messages.
     trusted_peers: Arc<RwLock<HashMap<PeerId, NetworkPublicKeys>>>,
-    /// Ed25519PrivateKey for signing notes.
-    signer: Ed25519PrivateKey,
+    /// ed25519::PrivateKey for signing notes.
+    signer: ed25519::PrivateKey,
     /// Current state, maintaining the most recent Note for each peer, alongside parsed PeerInfo.
     known_peers: HashMap<PeerId, VerifiedNote>,
     /// Currently connected peers.
@@ -166,7 +166,7 @@ where
         self_peer_id: PeerId,
         role: RoleType,
         self_addrs: Vec<Multiaddr>,
-        signer: Ed25519PrivateKey,
+        signer: ed25519::PrivateKey,
         trusted_peers: Arc<RwLock<HashMap<PeerId, NetworkPublicKeys>>>,
         ticker: TTicker,
         network_reqs_tx: DiscoveryNetworkSender,
@@ -438,7 +438,7 @@ pub struct Note {
 
 impl Note {
     fn new(
-        signer: &Ed25519PrivateKey,
+        signer: &ed25519::PrivateKey,
         peer_id: PeerId,
         addrs: Vec<Multiaddr>,
         dns_seed_addr: &[u8],
@@ -462,7 +462,7 @@ impl Note {
 
     /// Verifies validity of notes. Most fields have already been verified during initial
     /// deserialization, so this only verifies that the note contains properly signed infos.
-    fn verify(self, pub_key: &Ed25519PublicKey) -> Result<VerifiedNote, NetworkError> {
+    fn verify(self, pub_key: &ed25519::PublicKey) -> Result<VerifiedNote, NetworkError> {
         self.signed_peer_info.verify(&pub_key)?;
         self.signed_full_node_info.verify(&pub_key)?;
         Ok(VerifiedNote(self))
@@ -486,11 +486,11 @@ pub struct SignedPeerInfo {
     peer_info: PeerInfo,
     /// A signature over the above serialzed `PeerInfo`, signed by the validator's
     /// `network_signing_key` referred to by the `peer_id` account address.
-    signature: Ed25519Signature,
+    signature: ed25519::Signature,
 }
 
 impl SignedPeerInfo {
-    fn verify(&self, pub_key: &Ed25519PublicKey) -> Result<(), NetworkError> {
+    fn verify(&self, pub_key: &ed25519::PublicKey) -> Result<(), NetworkError> {
         let peer_info_bytes =
             lcs::to_bytes(&self.peer_info).map_err(|_| NetworkErrorKind::ParsingError)?;
         self.signature
@@ -512,7 +512,7 @@ pub struct PeerInfo {
 }
 
 impl PeerInfo {
-    fn sign(self, signer: &Ed25519PrivateKey) -> SignedPeerInfo {
+    fn sign(self, signer: &ed25519::PrivateKey) -> SignedPeerInfo {
         let peer_info_bytes = lcs::to_bytes(&self).expect("LCS serialization fails");
         let signature = signer.sign_message(&get_hash(&peer_info_bytes));
         SignedPeerInfo {
@@ -528,11 +528,11 @@ pub struct SignedFullNodeInfo {
     full_node_info: FullNodeInfo,
     /// A signature over the above serialzed `FullNodeInfo`, signed by the validator's
     /// `network_signing_key` referred to by the `peer_id` account address.
-    signature: Ed25519Signature,
+    signature: ed25519::Signature,
 }
 
 impl SignedFullNodeInfo {
-    fn verify(&self, pub_key: &Ed25519PublicKey) -> Result<(), NetworkError> {
+    fn verify(&self, pub_key: &ed25519::PublicKey) -> Result<(), NetworkError> {
         let full_node_info_bytes =
             lcs::to_bytes(&self.full_node_info).map_err(|_| NetworkErrorKind::ParsingError)?;
         self.signature
@@ -555,7 +555,7 @@ pub struct FullNodeInfo {
 }
 
 impl FullNodeInfo {
-    fn sign(self, signer: &Ed25519PrivateKey) -> SignedFullNodeInfo {
+    fn sign(self, signer: &ed25519::PrivateKey) -> SignedFullNodeInfo {
         let full_node_info_bytes = lcs::to_bytes(&self).expect("LCS serialization failed");
         let signature = signer.sign_message(&get_hash(&full_node_info_bytes));
         SignedFullNodeInfo {

--- a/network/src/protocols/discovery/mod.rs
+++ b/network/src/protocols/discovery/mod.rs
@@ -49,7 +49,7 @@ use libra_config::config::RoleType;
 use libra_crypto::{
     ed25519::{Ed25519PrivateKey, Ed25519PublicKey, Ed25519Signature},
     hash::{CryptoHasher, DiscoveryMsgHasher},
-    HashValue, Signature, SigningKey,
+    HashValue, SignatureExt, SigningKey,
 };
 use libra_logger::prelude::*;
 use libra_security_logger::{security_log, SecurityEvent};

--- a/network/src/protocols/discovery/test.rs
+++ b/network/src/protocols/discovery/test.rs
@@ -16,7 +16,7 @@ use core::str::FromStr;
 use futures::channel::oneshot;
 use libra_config::config::RoleType;
 use libra_crypto::{
-    ed25519::Ed25519PrivateKey, x25519::X25519StaticPrivateKey, PrivateKey, Uniform,
+    ed25519::Ed25519PrivateKey, x25519::X25519StaticPrivateKey, PrivateKeyExt, Uniform,
 };
 use std::num::NonZeroUsize;
 use tokio::runtime::Runtime;

--- a/network/src/protocols/discovery/test.rs
+++ b/network/src/protocols/discovery/test.rs
@@ -15,9 +15,7 @@ use channel::{libra_channel, message_queues::QueueStyle};
 use core::str::FromStr;
 use futures::channel::oneshot;
 use libra_config::config::RoleType;
-use libra_crypto::{
-    ed25519::Ed25519PrivateKey, x25519::X25519StaticPrivateKey, PrivateKeyExt, Uniform,
-};
+use libra_crypto::{ed25519, x25519::X25519StaticPrivateKey, PrivateKeyExt, Uniform};
 use std::num::NonZeroUsize;
 use tokio::runtime::Runtime;
 
@@ -46,7 +44,7 @@ fn setup_discovery(
     rt: &mut Runtime,
     peer_id: PeerId,
     addrs: Vec<Multiaddr>,
-    signer: Ed25519PrivateKey,
+    signer: ed25519::PrivateKey,
     trusted_peers: Arc<RwLock<HashMap<PeerId, NetworkPublicKeys>>>,
 ) -> (
     libra_channel::Receiver<(PeerId, ProtocolId), PeerManagerRequest>,
@@ -108,8 +106,8 @@ async fn expect_address_update(
     }
 }
 
-fn generate_network_pub_keys_and_signer() -> (NetworkPublicKeys, Ed25519PrivateKey) {
-    let signing_priv_key = Ed25519PrivateKey::generate_for_testing();
+fn generate_network_pub_keys_and_signer() -> (NetworkPublicKeys, ed25519::PrivateKey) {
+    let signing_priv_key = ed25519::PrivateKey::generate_for_testing();
     let identity_pub_key = X25519StaticPrivateKey::generate_for_testing().public_key();
     (
         NetworkPublicKeys {

--- a/network/src/protocols/network/dummy.rs
+++ b/network/src/protocols/network/dummy.rs
@@ -17,7 +17,7 @@ use channel::message_queues::QueueStyle;
 use futures::{executor::block_on, StreamExt};
 use libra_config::config::RoleType;
 use libra_crypto::{
-    ed25519::Ed25519PrivateKey, test_utils::TEST_SEED, x25519::X25519StaticPrivateKey, PrivateKey,
+    ed25519::Ed25519PrivateKey, test_utils::TEST_SEED, x25519::X25519StaticPrivateKey, PrivateKeyExt,
     Uniform,
 };
 use libra_types::PeerId;

--- a/network/src/protocols/network/dummy.rs
+++ b/network/src/protocols/network/dummy.rs
@@ -17,8 +17,7 @@ use channel::message_queues::QueueStyle;
 use futures::{executor::block_on, StreamExt};
 use libra_config::config::RoleType;
 use libra_crypto::{
-    ed25519::Ed25519PrivateKey, test_utils::TEST_SEED, x25519::X25519StaticPrivateKey, PrivateKeyExt,
-    Uniform,
+    ed25519, test_utils::TEST_SEED, x25519::X25519StaticPrivateKey, PrivateKeyExt, Uniform,
 };
 use libra_types::PeerId;
 use parity_multiaddr::Multiaddr;
@@ -105,13 +104,13 @@ pub fn setup_network() -> DummyNetwork {
 
     // Setup keys for dialer.
     let mut rng = StdRng::from_seed(TEST_SEED);
-    let dialer_signing_private_key = Ed25519PrivateKey::generate(&mut rng);
+    let dialer_signing_private_key = ed25519::PrivateKey::generate(&mut rng);
     let dialer_signing_public_key = dialer_signing_private_key.public_key();
     let dialer_identity_private_key = X25519StaticPrivateKey::generate(&mut rng);
     let dialer_identity_public_key = dialer_identity_private_key.public_key();
 
     // Setup keys for listener.
-    let listener_signing_private_key = Ed25519PrivateKey::generate(&mut rng);
+    let listener_signing_private_key = ed25519::PrivateKey::generate(&mut rng);
     let listener_signing_public_key = listener_signing_private_key.public_key();
     let listener_identity_private_key = X25519StaticPrivateKey::generate(&mut rng);
     let listener_identity_public_key = listener_identity_private_key.public_key();

--- a/network/src/transport.rs
+++ b/network/src/transport.rs
@@ -223,7 +223,7 @@ pub fn build_unauthenticated_memory_noise_transport(
                     noise_config.upgrade_connection(socket, origin).await?;
                 // Generate PeerId from X25519StaticPublicKey.
                 // Note: This is inconsistent with current types because AccountAddress is derived
-                // from consensus key which is of type Ed25519PublicKey. Since AccountAddress does
+                // from consensus key which is of type ed25519::PublicKey. Since AccountAddress does
                 // not mean anything in a setting without remote authentication, we use the network
                 // public key to generate a peer_id for the peer. The only reason this works is
                 // that both are 32 bytes in size. If/when this condition no longer holds, we will
@@ -307,7 +307,7 @@ pub fn build_unauthenticated_tcp_noise_transport(
                     noise_config.upgrade_connection(socket, origin).await?;
                 // Generate PeerId from X25519StaticPublicKey.
                 // Note: This is inconsistent with current types because AccountAddress is derived
-                // from consensus key which is of type Ed25519PublicKey. Since AccountAddress does
+                // from consensus key which is of type ed25519::PublicKey. Since AccountAddress does
                 // not mean anything in a setting without remote authentication, we use the network
                 // public key to generate a peer_id for the peer. The only reason this works is that
                 // both are 32 bytes in size. If/when this condition no longer holds, we will receive

--- a/network/src/validator_network/network_builder.rs
+++ b/network/src/validator_network/network_builder.rs
@@ -30,7 +30,7 @@ use channel::{self, libra_channel, message_queues::QueueStyle};
 use futures::stream::StreamExt;
 use libra_config::config::RoleType;
 use libra_crypto::{
-    ed25519::{Ed25519PrivateKey, Ed25519PublicKey},
+    ed25519,
     x25519::{X25519StaticPrivateKey, X25519StaticPublicKey},
 };
 use libra_logger::prelude::*;
@@ -113,7 +113,7 @@ pub struct NetworkBuilder {
     max_concurrent_network_reqs: usize,
     max_concurrent_network_notifs: usize,
     max_connection_delay_ms: u64,
-    signing_keys: Option<(Ed25519PrivateKey, Ed25519PublicKey)>,
+    signing_keys: Option<(ed25519::PrivateKey, ed25519::PublicKey)>,
     enable_remote_authentication: bool,
 }
 
@@ -194,7 +194,7 @@ impl NetworkBuilder {
     }
 
     /// Set signing keys of local node.
-    pub fn signing_keys(&mut self, keys: (Ed25519PrivateKey, Ed25519PublicKey)) -> &mut Self {
+    pub fn signing_keys(&mut self, keys: (ed25519::PrivateKey, ed25519::PublicKey)) -> &mut Self {
         self.signing_keys = Some(keys);
         self
     }

--- a/secure/key-manager/src/lib.rs
+++ b/secure/key-manager/src/lib.rs
@@ -21,7 +21,7 @@
 
 use libra_crypto::{
     ed25519::{Ed25519PrivateKey, Ed25519PublicKey},
-    PrivateKey,
+    PrivateKeyExt,
 };
 use libra_secure_storage::Storage;
 use libra_secure_time::TimeService;

--- a/secure/key-manager/src/tests.rs
+++ b/secure/key-manager/src/tests.rs
@@ -4,7 +4,7 @@
 use crate::{Action, Error, KeyManager, LibraInterface};
 use executor::{db_bootstrapper, Executor};
 use libra_config::config::NodeConfig;
-use libra_crypto::{ed25519::Ed25519PrivateKey, HashValue, PrivateKey, Uniform};
+use libra_crypto::{ed25519::Ed25519PrivateKey, HashValue, PrivateKeyExt, Uniform};
 use libra_secure_storage::{InMemoryStorageInternal, KVStorage, Policy, Value};
 use libra_secure_time::{MockTimeService, TimeService};
 use libra_types::{

--- a/secure/key-manager/src/tests.rs
+++ b/secure/key-manager/src/tests.rs
@@ -4,7 +4,7 @@
 use crate::{Action, Error, KeyManager, LibraInterface};
 use executor::{db_bootstrapper, Executor};
 use libra_config::config::NodeConfig;
-use libra_crypto::{ed25519::Ed25519PrivateKey, HashValue, PrivateKeyExt, Uniform};
+use libra_crypto::{ed25519, HashValue, PrivateKeyExt, Uniform};
 use libra_secure_storage::{InMemoryStorageInternal, KVStorage, Policy, Value};
 use libra_secure_time::{MockTimeService, TimeService};
 use libra_types::{
@@ -288,7 +288,7 @@ fn test_manual_consensus_rotation() {
     assert_eq!(&node.account, genesis_info.account_address());
 
     let mut rng = StdRng::from_seed([44u8; 32]);
-    let new_prikey = Ed25519PrivateKey::generate(&mut rng);
+    let new_prikey = ed25519::PrivateKey::generate(&mut rng);
     let new_pubkey = new_prikey.public_key();
 
     let txn = crate::build_rotation_transaction(

--- a/secure/storage/src/crypto_kv_storage.rs
+++ b/secure/storage/src/crypto_kv_storage.rs
@@ -2,10 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::{CryptoStorage, Error, KVStorage, Policy, PublicKeyResponse, Value};
-use libra_crypto::{
-    ed25519::{Ed25519PrivateKey, Ed25519PublicKey, Ed25519Signature},
-    HashValue, PrivateKeyExt, SigningKey, Uniform,
-};
+use libra_crypto::{ed25519, HashValue, PrivateKeyExt, SigningKey, Uniform};
 use rand::{rngs::OsRng, Rng, SeedableRng};
 
 /// CryptoKVStorage offers a CryptoStorage implementation by extending a key value store (KVStorage)
@@ -14,7 +11,7 @@ use rand::{rngs::OsRng, Rng, SeedableRng};
 pub trait CryptoKVStorage: KVStorage {}
 
 impl<T: CryptoKVStorage> CryptoStorage for T {
-    fn create_key(&mut self, name: &str, policy: &Policy) -> Result<Ed25519PublicKey, Error> {
+    fn create_key(&mut self, name: &str, policy: &Policy) -> Result<ed25519::PublicKey, Error> {
         // Generate and store the new named key pair
         let (private_key, public_key) = new_ed25519_key_pair()?;
         self.create(name, Value::Ed25519PrivateKey(private_key), policy)?;
@@ -31,7 +28,7 @@ impl<T: CryptoKVStorage> CryptoStorage for T {
         Ok(public_key)
     }
 
-    fn export_private_key(&self, name: &str) -> Result<Ed25519PrivateKey, Error> {
+    fn export_private_key(&self, name: &str) -> Result<ed25519::PrivateKey, Error> {
         match self.get(name)?.value {
             Value::Ed25519PrivateKey(private_key) => Ok(private_key),
             _ => Err(Error::UnexpectedValueType),
@@ -41,8 +38,8 @@ impl<T: CryptoKVStorage> CryptoStorage for T {
     fn export_private_key_for_version(
         &self,
         name: &str,
-        version: Ed25519PublicKey,
-    ) -> Result<Ed25519PrivateKey, Error> {
+        version: ed25519::PublicKey,
+    ) -> Result<ed25519::PrivateKey, Error> {
         let current_private_key = self.export_private_key(name)?;
         if current_private_key.public_key().eq(&version) {
             return Ok(current_private_key);
@@ -70,7 +67,7 @@ impl<T: CryptoKVStorage> CryptoStorage for T {
         })
     }
 
-    fn rotate_key(&mut self, name: &str) -> Result<Ed25519PublicKey, Error> {
+    fn rotate_key(&mut self, name: &str) -> Result<ed25519::PublicKey, Error> {
         match self.get(name)?.value {
             Value::Ed25519PrivateKey(private_key) => {
                 let (new_private_key, new_public_key) = new_ed25519_key_pair()?;
@@ -85,7 +82,11 @@ impl<T: CryptoKVStorage> CryptoStorage for T {
         }
     }
 
-    fn sign_message(&mut self, name: &str, message: &HashValue) -> Result<Ed25519Signature, Error> {
+    fn sign_message(
+        &mut self,
+        name: &str,
+        message: &HashValue,
+    ) -> Result<ed25519::Signature, Error> {
         let private_key = self.export_private_key(name)?;
         Ok(private_key.sign_message(message))
     }
@@ -93,19 +94,19 @@ impl<T: CryptoKVStorage> CryptoStorage for T {
     fn sign_message_using_version(
         &mut self,
         name: &str,
-        version: Ed25519PublicKey,
+        version: ed25519::PublicKey,
         message: &HashValue,
-    ) -> Result<Ed25519Signature, Error> {
+    ) -> Result<ed25519::Signature, Error> {
         let private_key = self.export_private_key_for_version(name, version)?;
         Ok(private_key.sign_message(message))
     }
 }
 
 /// Private helper method to generate a new ed25519 key pair using entropy from the OS.
-fn new_ed25519_key_pair() -> Result<(Ed25519PrivateKey, Ed25519PublicKey), Error> {
+fn new_ed25519_key_pair() -> Result<(ed25519::PrivateKey, ed25519::PublicKey), Error> {
     let mut seed_rng = OsRng::new().map_err(|e| Error::EntropyError(e.to_string()))?;
     let mut rng = rand::rngs::StdRng::from_seed(seed_rng.gen());
-    let private_key = Ed25519PrivateKey::generate(&mut rng);
+    let private_key = ed25519::PrivateKey::generate(&mut rng);
     let public_key = private_key.public_key();
     Ok((private_key, public_key))
 }

--- a/secure/storage/src/crypto_kv_storage.rs
+++ b/secure/storage/src/crypto_kv_storage.rs
@@ -4,7 +4,7 @@
 use crate::{CryptoStorage, Error, KVStorage, Policy, PublicKeyResponse, Value};
 use libra_crypto::{
     ed25519::{Ed25519PrivateKey, Ed25519PublicKey, Ed25519Signature},
-    HashValue, PrivateKey, SigningKey, Uniform,
+    HashValue, PrivateKeyExt, SigningKey, Uniform,
 };
 use rand::{rngs::OsRng, Rng, SeedableRng};
 

--- a/secure/storage/src/tests/suite.rs
+++ b/secure/storage/src/tests/suite.rs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::{Error, Policy, Storage, Value};
-use libra_crypto::{ed25519::Ed25519PrivateKey, HashValue, PrivateKeyExt, SignatureExt, Uniform};
+use libra_crypto::{ed25519, HashValue, PrivateKeyExt, SignatureExt, Uniform};
 
 /// This suite contains tests for secure storage backends. We test the correct functionality
 /// of both key/value and cryptographic operations for storage implementations. All storage backend
@@ -48,7 +48,7 @@ pub fn execute_all_storage_tests(storage: &mut dyn Storage) {
 /// This test tries to get and set non-existent keys in storage and asserts that the correct
 /// errors are returned on these operations.
 fn test_get_set_non_existent(storage: &mut dyn Storage) {
-    let crypto_value = Value::Ed25519PrivateKey(Ed25519PrivateKey::generate_for_testing());
+    let crypto_value = Value::Ed25519PrivateKey(ed25519::PrivateKey::generate_for_testing());
     let u64_value = Value::U64(10);
 
     assert_eq!(
@@ -72,8 +72,8 @@ fn test_get_set_non_existent(storage: &mut dyn Storage) {
 /// This test stores various key/value pairs in storage, updates them, retrieves the values and
 /// unwraps them to ensure the correct value types are returned.
 fn test_create_get_set_unwrap(storage: &mut dyn Storage) {
-    let crypto_private_1 = Ed25519PrivateKey::generate_for_testing();
-    let crypto_private_2 = Ed25519PrivateKey::generate_for_testing();
+    let crypto_private_1 = ed25519::PrivateKey::generate_for_testing();
+    let crypto_private_2 = ed25519::PrivateKey::generate_for_testing();
     let u64_1 = 10;
     let u64_2 = 647;
     let policy = Policy::public();
@@ -124,7 +124,7 @@ fn test_create_get_set_unwrap(storage: &mut dyn Storage) {
 /// This test stores different types of values into storage, retrieves them, and asserts
 /// that the value unwrap functions return an unexpected type error on an incorrect unwrap.
 fn test_verify_incorrect_value_types_unwrap(storage: &mut dyn Storage) {
-    let crypto_value = Value::Ed25519PrivateKey(Ed25519PrivateKey::generate_for_testing());
+    let crypto_value = Value::Ed25519PrivateKey(ed25519::PrivateKey::generate_for_testing());
     let u64_value = Value::U64(10);
     let policy = Policy::public();
 
@@ -237,7 +237,7 @@ fn test_create_and_get_non_existent_version(storage: &mut dyn Storage) {
         .expect("Failed to create a test Ed25519 key pair!");
 
     // Get a non-existent version of the new key pair and verify failure
-    let non_existent_public_key = Ed25519PrivateKey::generate_for_testing().public_key();
+    let non_existent_public_key = ed25519::PrivateKey::generate_for_testing().public_key();
     assert!(
         storage.export_private_key_for_version(CRYPTO_NAME, non_existent_public_key).is_err(),
         "We have tried to retrieve a non-existent private key version -- the call should have failed!",

--- a/secure/storage/src/tests/suite.rs
+++ b/secure/storage/src/tests/suite.rs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::{Error, Policy, Storage, Value};
-use libra_crypto::{ed25519::Ed25519PrivateKey, HashValue, PrivateKey, Signature, Uniform};
+use libra_crypto::{ed25519::Ed25519PrivateKey, HashValue, PrivateKeyExt, SignatureExt, Uniform};
 
 /// This suite contains tests for secure storage backends. We test the correct functionality
 /// of both key/value and cryptographic operations for storage implementations. All storage backend

--- a/secure/storage/src/tests/vault.rs
+++ b/secure/storage/src/tests/vault.rs
@@ -5,7 +5,7 @@ use crate::{
     tests::suite, vault::VaultStorage, Capability, CryptoStorage, Error, Identity, KVStorage,
     Permission, Policy, Value,
 };
-use libra_crypto::{HashValue, Signature};
+use libra_crypto::{HashValue, SignatureExt};
 
 /// VaultStorage test constants
 const VAULT_HOST: &str = "http://localhost:8200";

--- a/secure/storage/src/value.rs
+++ b/secure/storage/src/value.rs
@@ -2,19 +2,19 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::error::Error;
-use libra_crypto::{ed25519::Ed25519PrivateKey, hash::HashValue};
+use libra_crypto::{ed25519, hash::HashValue};
 use serde::{Deserialize, Serialize};
 
 #[derive(Debug, Deserialize, PartialEq, Serialize)]
 #[serde(content = "value", rename_all = "snake_case", tag = "type")]
 pub enum Value {
-    Ed25519PrivateKey(Ed25519PrivateKey),
+    Ed25519PrivateKey(ed25519::PrivateKey),
     HashValue(HashValue),
     U64(u64),
 }
 
 impl Value {
-    pub fn ed25519_private_key(self) -> Result<Ed25519PrivateKey, Error> {
+    pub fn ed25519_private_key(self) -> Result<ed25519::PrivateKey, Error> {
         if let Value::Ed25519PrivateKey(value) = self {
             Ok(value)
         } else {
@@ -57,7 +57,7 @@ mod tests {
 
     #[test]
     fn ed25519_private_key() {
-        let value = Ed25519PrivateKey::generate_for_testing();
+        let value = ed25519::PrivateKey::generate_for_testing();
         let value = Value::Ed25519PrivateKey(value);
         let base64 = value.to_base64().unwrap();
         let out_value = Value::from_base64(&base64).unwrap();

--- a/state-synchronizer/src/tests/integration_tests.rs
+++ b/state-synchronizer/src/tests/integration_tests.rs
@@ -11,7 +11,7 @@ use futures::executor::block_on;
 use libra_config::config::RoleType;
 use libra_crypto::{
     ed25519::Ed25519PrivateKey, hash::ACCUMULATOR_PLACEHOLDER_HASH, test_utils::TEST_SEED,
-    x25519::X25519StaticPrivateKey, PrivateKey, Uniform,
+    x25519::X25519StaticPrivateKey, PrivateKeyExt, Uniform,
 };
 use libra_mempool::mocks::MockSharedMempool;
 use libra_types::{

--- a/state-synchronizer/src/tests/integration_tests.rs
+++ b/state-synchronizer/src/tests/integration_tests.rs
@@ -10,7 +10,7 @@ use executor_types::ExecutedTrees;
 use futures::executor::block_on;
 use libra_config::config::RoleType;
 use libra_crypto::{
-    ed25519::Ed25519PrivateKey, hash::ACCUMULATOR_PLACEHOLDER_HASH, test_utils::TEST_SEED,
+    ed25519, hash::ACCUMULATOR_PLACEHOLDER_HASH, test_utils::TEST_SEED,
     x25519::X25519StaticPrivateKey, PrivateKeyExt, Uniform,
 };
 use libra_mempool::mocks::MockSharedMempool;
@@ -120,7 +120,7 @@ struct SynchronizerEnv {
     clients: Vec<Arc<StateSyncClient>>,
     storage_proxies: Vec<Arc<RwLock<MockStorage>>>, // to directly modify peers storage
     signers: Vec<ValidatorSigner>,
-    network_signers: Vec<Ed25519PrivateKey>,
+    network_signers: Vec<ed25519::PrivateKey>,
     public_keys: Vec<ValidatorInfo>,
     peer_ids: Vec<PeerId>,
     peer_addresses: Vec<Multiaddr>,
@@ -133,7 +133,7 @@ impl SynchronizerEnv {
         count: usize,
     ) -> (
         Vec<ValidatorSigner>,
-        Vec<Ed25519PrivateKey>,
+        Vec<ed25519::PrivateKey>,
         Vec<ValidatorInfo>,
     ) {
         let (signers, _verifier) = random_validator_verifier(count, None, true);
@@ -141,7 +141,7 @@ impl SynchronizerEnv {
         // Setup signing public keys.
         let mut rng = StdRng::from_seed(TEST_SEED);
         let signing_keys: Vec<_> = (0..count)
-            .map(|_| Ed25519PrivateKey::generate(&mut rng))
+            .map(|_| ed25519::PrivateKey::generate(&mut rng))
             .collect();
         // Setup identity public keys.
         let identity_keys: Vec<_> = (0..count)

--- a/state-synchronizer/src/tests/on_chain_config_tests.rs
+++ b/state-synchronizer/src/tests/on_chain_config_tests.rs
@@ -10,7 +10,7 @@ use executor_utils::{
 };
 use futures::{future::FutureExt, stream::StreamExt};
 use libra_crypto::{
-    ed25519::*,
+    ed25519,
     traits::{PrivateKeyExt, Uniform},
     HashValue,
 };
@@ -152,7 +152,7 @@ fn test_on_chain_config_pub_sub() {
     let txn4 = encode_block_prologue_script(gen_block_metadata(2, validator_account));
 
     // rotate the validator's consensus pubkey to trigger a reconfiguration
-    let new_pubkey = Ed25519PrivateKey::generate_for_testing().public_key();
+    let new_pubkey = ed25519::PrivateKey::generate_for_testing().public_key();
     let txn5 = get_test_signed_transaction(
         validator_account,
         /* sequence_number = */ 0,

--- a/state-synchronizer/src/tests/on_chain_config_tests.rs
+++ b/state-synchronizer/src/tests/on_chain_config_tests.rs
@@ -11,7 +11,7 @@ use executor_utils::{
 use futures::{future::FutureExt, stream::StreamExt};
 use libra_crypto::{
     ed25519::*,
-    traits::{PrivateKey, Uniform},
+    traits::{PrivateKeyExt, Uniform},
     HashValue,
 };
 use libra_types::{

--- a/storage/storage-service/src/mocks/mock_storage_client.rs
+++ b/storage/storage-service/src/mocks/mock_storage_client.rs
@@ -5,7 +5,7 @@
 
 use anyhow::{Error, Result};
 use futures::stream::BoxStream;
-use libra_crypto::{ed25519::Ed25519PrivateKey, HashValue, PrivateKeyExt, Uniform};
+use libra_crypto::{ed25519, HashValue, PrivateKeyExt, Uniform};
 use libra_types::{
     access_path::AccessPath,
     account_address::AccountAddress,
@@ -259,7 +259,7 @@ fn get_mock_txn_data(
     let mut seed_rng = OsRng::new().expect("can't access OsRng");
     let seed_buf: [u8; 32] = seed_rng.gen();
     let mut rng = StdRng::from_seed(seed_buf);
-    let priv_key = Ed25519PrivateKey::generate(&mut rng);
+    let priv_key = ed25519::PrivateKey::generate(&mut rng);
     let mut txns = vec![];
     for i in start_seq..=end_seq {
         let txn = Transaction::UserTransaction(get_test_signed_txn(

--- a/storage/storage-service/src/mocks/mock_storage_client.rs
+++ b/storage/storage-service/src/mocks/mock_storage_client.rs
@@ -5,7 +5,7 @@
 
 use anyhow::{Error, Result};
 use futures::stream::BoxStream;
-use libra_crypto::{ed25519::Ed25519PrivateKey, HashValue, PrivateKey, Uniform};
+use libra_crypto::{ed25519::Ed25519PrivateKey, HashValue, PrivateKeyExt, Uniform};
 use libra_types::{
     access_path::AccessPath,
     account_address::AccountAddress,

--- a/testsuite/cluster-test/src/cluster.rs
+++ b/testsuite/cluster-test/src/cluster.rs
@@ -8,10 +8,7 @@ use anyhow::{ensure, format_err, Result};
 use config_builder::ValidatorConfig;
 use generate_keypair::load_key_from_file;
 use libra_config::config::DEFAULT_JSON_RPC_PORT;
-use libra_crypto::{
-    ed25519::{Ed25519PrivateKey, Ed25519PublicKey},
-    test_utils::KeyPair,
-};
+use libra_crypto::{ed25519, test_utils::KeyPair};
 use libra_logger::*;
 use rand::prelude::*;
 use rusoto_ec2::{DescribeInstancesRequest, Ec2, Filter, Tag};
@@ -23,7 +20,7 @@ pub struct Cluster {
     validator_instances: Vec<Instance>,
     fullnode_instances: Vec<Instance>,
     prometheus_ip: Option<String>,
-    mint_key_pair: KeyPair<Ed25519PrivateKey, Ed25519PublicKey>,
+    mint_key_pair: KeyPair<ed25519::PrivateKey, ed25519::PublicKey>,
 }
 
 impl Cluster {
@@ -38,7 +35,7 @@ impl Cluster {
                 )
             })
             .collect();
-        let mint_key_pair: KeyPair<Ed25519PrivateKey, Ed25519PublicKey> =
+        let mint_key_pair: KeyPair<ed25519::PrivateKey, ed25519::PublicKey> =
             load_key_from_file(mint_file).expect("invalid faucet keypair file");
         Self {
             validator_instances: instances,
@@ -48,7 +45,7 @@ impl Cluster {
         }
     }
 
-    fn get_mint_key_pair() -> KeyPair<Ed25519PrivateKey, Ed25519PublicKey> {
+    fn get_mint_key_pair() -> KeyPair<ed25519::PrivateKey, ed25519::PublicKey> {
         let seed = "1337133713371337133713371337133713371337133713371337133713371337";
         let seed = hex::decode(seed).expect("Invalid hex in seed.");
         let seed = seed[..32].try_into().expect("Invalid seed");
@@ -182,7 +179,7 @@ impl Cluster {
         self.prometheus_ip.as_ref()
     }
 
-    pub fn mint_key_pair(&self) -> &KeyPair<Ed25519PrivateKey, Ed25519PublicKey> {
+    pub fn mint_key_pair(&self) -> &KeyPair<ed25519::PrivateKey, ed25519::PublicKey> {
         &self.mint_key_pair
     }
 

--- a/testsuite/cluster-test/src/tx_emitter.rs
+++ b/testsuite/cluster-test/src/tx_emitter.rs
@@ -13,11 +13,7 @@ use std::{
 
 use anyhow::{format_err, Result};
 use itertools::zip;
-use libra_crypto::{
-    ed25519::{Ed25519PrivateKey, Ed25519PublicKey},
-    test_utils::KeyPair,
-    traits::Uniform,
-};
+use libra_crypto::{ed25519, test_utils::KeyPair, traits::Uniform};
 use libra_logger::*;
 use libra_types::{
     account_address::AccountAddress,
@@ -49,7 +45,7 @@ const MAX_TXN_BATCH_SIZE: usize = 100; // Max transactions per account in mempoo
 
 pub struct TxEmitter {
     accounts: Vec<AccountData>,
-    mint_key_pair: KeyPair<Ed25519PrivateKey, Ed25519PublicKey>,
+    mint_key_pair: KeyPair<ed25519::PrivateKey, ed25519::PublicKey>,
     http_client: Client,
 }
 
@@ -631,7 +627,7 @@ async fn create_new_accounts(
 #[derive(Clone)]
 pub struct AccountData {
     pub address: AccountAddress,
-    pub key_pair: KeyPair<Ed25519PrivateKey, Ed25519PublicKey>,
+    pub key_pair: KeyPair<ed25519::PrivateKey, ed25519::PublicKey>,
     pub sequence_number: u64,
 }
 

--- a/testsuite/tests/libratest/smoke_test.rs
+++ b/testsuite/tests/libratest/smoke_test.rs
@@ -8,7 +8,7 @@ use libra_crypto::{
     ed25519::{Ed25519PrivateKey, Ed25519PublicKey},
     hash::CryptoHash,
     test_utils::KeyPair,
-    PrivateKey, SigningKey, Uniform,
+    PrivateKeyExt, SigningKey, Uniform,
 };
 use libra_json_rpc::views::{ScriptView, TransactionDataView};
 use libra_logger::prelude::*;

--- a/testsuite/tests/libratest/smoke_test.rs
+++ b/testsuite/tests/libratest/smoke_test.rs
@@ -5,10 +5,7 @@ use cli::client_proxy::ClientProxy;
 use debug_interface::{libra_trace, node_debug_service::parse_events, NodeDebugClient};
 use libra_config::config::{NodeConfig, RoleType, TestConfig};
 use libra_crypto::{
-    ed25519::{Ed25519PrivateKey, Ed25519PublicKey},
-    hash::CryptoHash,
-    test_utils::KeyPair,
-    PrivateKeyExt, SigningKey, Uniform,
+    ed25519, hash::CryptoHash, test_utils::KeyPair, PrivateKeyExt, SigningKey, Uniform,
 };
 use libra_json_rpc::views::{ScriptView, TransactionDataView};
 use libra_logger::prelude::*;
@@ -29,7 +26,7 @@ use std::{
 struct TestEnvironment {
     validator_swarm: LibraSwarm,
     full_node_swarm: Option<LibraSwarm>,
-    faucet_key: (KeyPair<Ed25519PrivateKey, Ed25519PublicKey>, String),
+    faucet_key: (KeyPair<ed25519::PrivateKey, ed25519::PublicKey>, String),
     mnemonic_file: TempPath,
 }
 
@@ -651,7 +648,7 @@ fn test_external_transaction_signer() {
     let (_swarm, mut client_proxy) = setup_swarm_and_client_proxy(1, 0);
 
     // generate key pair
-    let private_key = Ed25519PrivateKey::generate_for_testing();
+    let private_key = ed25519::PrivateKey::generate_for_testing();
     let public_key = private_key.public_key();
 
     // create transfer parameters

--- a/types/src/account_address.rs
+++ b/types/src/account_address.rs
@@ -5,7 +5,7 @@ use crate::transaction::authenticator::AuthenticationKey;
 use anyhow::{ensure, Error, Result};
 use bytes::Bytes;
 use libra_crypto::{
-    ed25519::Ed25519PublicKey,
+    ed25519,
     hash::{CryptoHash, CryptoHasher},
     HashValue,
 };
@@ -48,11 +48,11 @@ impl AccountAddress {
         self.0.to_vec()
     }
 
-    pub fn authentication_key(public_key: &Ed25519PublicKey) -> AuthenticationKey {
+    pub fn authentication_key(public_key: &ed25519::PublicKey) -> AuthenticationKey {
         AuthenticationKey::ed25519(public_key)
     }
 
-    pub fn from_public_key(public_key: &Ed25519PublicKey) -> Self {
+    pub fn from_public_key(public_key: &ed25519::PublicKey) -> Self {
         AccountAddress::authentication_key(public_key).derived_address()
     }
 

--- a/types/src/ledger_info.rs
+++ b/types/src/ledger_info.rs
@@ -10,7 +10,7 @@ use crate::{
 };
 use anyhow::{Error, Result};
 use libra_crypto::{
-    ed25519::Ed25519Signature,
+    ed25519,
     hash::{CryptoHash, CryptoHasher, HashValue},
 };
 use libra_crypto_derive::CryptoHasher;
@@ -200,7 +200,7 @@ impl Display for LedgerInfoWithSignatures {
 impl LedgerInfoWithSignatures {
     pub fn new(
         ledger_info: LedgerInfo,
-        signatures: BTreeMap<AccountAddress, Ed25519Signature>,
+        signatures: BTreeMap<AccountAddress, ed25519::Signature>,
     ) -> Self {
         LedgerInfoWithSignatures::V0(LedgerInfoWithV0::new(ledger_info, signatures))
     }
@@ -243,7 +243,7 @@ pub struct LedgerInfoWithV0 {
     ledger_info: LedgerInfo,
     /// The validator is identified by its account address: in order to verify a signature
     /// one needs to retrieve the public key of the validator for the given epoch.
-    signatures: BTreeMap<AccountAddress, Ed25519Signature>,
+    signatures: BTreeMap<AccountAddress, ed25519::Signature>,
 }
 
 impl Display for LedgerInfoWithV0 {
@@ -255,7 +255,7 @@ impl Display for LedgerInfoWithV0 {
 impl LedgerInfoWithV0 {
     pub fn new(
         ledger_info: LedgerInfo,
-        signatures: BTreeMap<AccountAddress, Ed25519Signature>,
+        signatures: BTreeMap<AccountAddress, ed25519::Signature>,
     ) -> Self {
         LedgerInfoWithV0 {
             ledger_info,
@@ -281,7 +281,7 @@ impl LedgerInfoWithV0 {
         &self.ledger_info
     }
 
-    pub fn add_signature(&mut self, validator: AccountAddress, signature: Ed25519Signature) {
+    pub fn add_signature(&mut self, validator: AccountAddress, signature: ed25519::Signature) {
         self.signatures.entry(validator).or_insert(signature);
     }
 
@@ -289,7 +289,7 @@ impl LedgerInfoWithV0 {
         self.signatures.remove(&validator);
     }
 
-    pub fn signatures(&self) -> &BTreeMap<AccountAddress, Ed25519Signature> {
+    pub fn signatures(&self) -> &BTreeMap<AccountAddress, ed25519::Signature> {
         &self.signatures
     }
 

--- a/types/src/proof/unit_tests/proof_test.rs
+++ b/types/src/proof/unit_tests/proof_test.rs
@@ -22,7 +22,7 @@ use libra_crypto::{
         CryptoHash, TestOnlyHash, ACCUMULATOR_PLACEHOLDER_HASH, GENESIS_BLOCK_ID,
         SPARSE_MERKLE_PLACEHOLDER_HASH,
     },
-    HashValue, PrivateKey, Uniform,
+    HashValue, PrivateKeyExt, Uniform,
 };
 
 #[test]

--- a/types/src/proof/unit_tests/proof_test.rs
+++ b/types/src/proof/unit_tests/proof_test.rs
@@ -17,7 +17,7 @@ use crate::{
     vm_error::StatusCode,
 };
 use libra_crypto::{
-    ed25519::Ed25519PrivateKey,
+    ed25519,
     hash::{
         CryptoHash, TestOnlyHash, ACCUMULATOR_PLACEHOLDER_HASH, GENESIS_BLOCK_ID,
         SPARSE_MERKLE_PLACEHOLDER_HASH,
@@ -336,7 +336,7 @@ fn test_verify_account_state_and_event() {
     let txn_info0_hash = b"hellohello".test_only_hash();
     let txn_info1_hash = b"worldworld".test_only_hash();
 
-    let privkey = Ed25519PrivateKey::generate_for_testing();
+    let privkey = ed25519::PrivateKey::generate_for_testing();
     let pubkey = privkey.public_key();
     let txn2_hash = Transaction::UserTransaction(
         RawTransaction::new_script(

--- a/types/src/proptest_types.rs
+++ b/types/src/proptest_types.rs
@@ -26,11 +26,7 @@ use crate::{
     write_set::{WriteOp, WriteSet, WriteSetMut},
 };
 use libra_crypto::{
-    ed25519::{self, Ed25519PrivateKey, Ed25519PublicKey, Ed25519Signature},
-    hash::CryptoHash,
-    test_utils::KeyPair,
-    traits::*,
-    x25519::X25519StaticPublicKey,
+    ed25519, hash::CryptoHash, test_utils::KeyPair, traits::*, x25519::X25519StaticPublicKey,
     HashValue,
 };
 use libra_proptest_helpers::Index;
@@ -112,15 +108,15 @@ impl Arbitrary for ChangeSet {
 #[derive(Debug)]
 struct AccountInfo {
     address: AccountAddress,
-    private_key: Ed25519PrivateKey,
-    public_key: Ed25519PublicKey,
+    private_key: ed25519::PrivateKey,
+    public_key: ed25519::PublicKey,
     sequence_number: u64,
     sent_event_handle: EventHandle,
     received_event_handle: EventHandle,
 }
 
 impl AccountInfo {
-    pub fn new(private_key: Ed25519PrivateKey, public_key: Ed25519PublicKey) -> Self {
+    pub fn new(private_key: ed25519::PrivateKey, public_key: ed25519::PublicKey) -> Self {
         let address = AccountAddress::from_public_key(&public_key);
         Self {
             address,
@@ -143,7 +139,7 @@ pub struct AccountInfoUniverse {
 
 impl AccountInfoUniverse {
     fn new(
-        keypairs: Vec<(Ed25519PrivateKey, Ed25519PublicKey)>,
+        keypairs: Vec<(ed25519::PrivateKey, ed25519::PublicKey)>,
         epoch: u64,
         round: Round,
         next_version: Version,
@@ -349,7 +345,7 @@ impl SignatureCheckedTransaction {
     // This isn't an Arbitrary impl because this doesn't generate *any* possible SignedTransaction,
     // just one kind of them.
     pub fn script_strategy(
-        keypair_strategy: impl Strategy<Value = KeyPair<Ed25519PrivateKey, Ed25519PublicKey>>,
+        keypair_strategy: impl Strategy<Value = KeyPair<ed25519::PrivateKey, ed25519::PublicKey>>,
         gas_specifier_strategy: impl Strategy<Value = String>,
     ) -> impl Strategy<Value = Self> {
         Self::strategy_impl(
@@ -360,7 +356,7 @@ impl SignatureCheckedTransaction {
     }
 
     pub fn module_strategy(
-        keypair_strategy: impl Strategy<Value = KeyPair<Ed25519PrivateKey, Ed25519PublicKey>>,
+        keypair_strategy: impl Strategy<Value = KeyPair<ed25519::PrivateKey, ed25519::PublicKey>>,
         gas_specifier_strategy: impl Strategy<Value = String>,
     ) -> impl Strategy<Value = Self> {
         Self::strategy_impl(
@@ -371,7 +367,7 @@ impl SignatureCheckedTransaction {
     }
 
     pub fn write_set_strategy(
-        keypair_strategy: impl Strategy<Value = KeyPair<Ed25519PrivateKey, Ed25519PublicKey>>,
+        keypair_strategy: impl Strategy<Value = KeyPair<ed25519::PrivateKey, ed25519::PublicKey>>,
         gas_specifier_strategy: impl Strategy<Value = String>,
     ) -> impl Strategy<Value = Self> {
         Self::strategy_impl(
@@ -382,7 +378,7 @@ impl SignatureCheckedTransaction {
     }
 
     pub fn genesis_strategy(
-        keypair_strategy: impl Strategy<Value = KeyPair<Ed25519PrivateKey, Ed25519PublicKey>>,
+        keypair_strategy: impl Strategy<Value = KeyPair<ed25519::PrivateKey, ed25519::PublicKey>>,
         gas_specifier_strategy: impl Strategy<Value = String>,
     ) -> impl Strategy<Value = Self> {
         Self::strategy_impl(
@@ -393,7 +389,7 @@ impl SignatureCheckedTransaction {
     }
 
     fn strategy_impl(
-        keypair_strategy: impl Strategy<Value = KeyPair<Ed25519PrivateKey, Ed25519PublicKey>>,
+        keypair_strategy: impl Strategy<Value = KeyPair<ed25519::PrivateKey, ed25519::PublicKey>>,
         payload_strategy: impl Strategy<Value = TransactionPayload>,
         gas_specifier_strategy: impl Strategy<Value = String>,
     ) -> impl Strategy<Value = Self> {
@@ -601,7 +597,7 @@ prop_compose! {
     fn arb_validator_signature_for_hash(hash: HashValue)(
         hash in Just(hash),
         keypair in ed25519::keypair_strategy(),
-    ) -> (AccountAddress, Ed25519Signature) {
+    ) -> (AccountAddress, ed25519::Signature) {
         let signature = keypair.private_key.sign_message(&hash);
         (AccountAddress::from_public_key(&keypair.public_key), signature)
     }

--- a/types/src/test_helpers/transaction_test_helpers.rs
+++ b/types/src/test_helpers/transaction_test_helpers.rs
@@ -7,7 +7,7 @@ use crate::{
     transaction::{Module, RawTransaction, Script, SignatureCheckedTransaction, SignedTransaction},
     write_set::WriteSet,
 };
-use libra_crypto::{ed25519::*, hash::CryptoHash, traits::*};
+use libra_crypto::{ed25519, hash::CryptoHash, traits::*};
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
 const MAX_GAS_AMOUNT: u64 = 400_000;
@@ -20,8 +20,8 @@ static EMPTY_SCRIPT: &[u8] =
 pub fn get_test_signed_module_publishing_transaction(
     sender: AccountAddress,
     sequence_number: u64,
-    private_key: &Ed25519PrivateKey,
-    public_key: Ed25519PublicKey,
+    private_key: &ed25519::PrivateKey,
+    public_key: ed25519::PublicKey,
     module: Module,
 ) -> SignedTransaction {
     let expiration_time = SystemTime::now()
@@ -48,8 +48,8 @@ pub fn get_test_signed_module_publishing_transaction(
 pub fn get_test_signed_transaction(
     sender: AccountAddress,
     sequence_number: u64,
-    private_key: &Ed25519PrivateKey,
-    public_key: Ed25519PublicKey,
+    private_key: &ed25519::PrivateKey,
+    public_key: ed25519::PublicKey,
     script: Option<Script>,
     expiration_time: u64,
     gas_unit_price: u64,
@@ -75,8 +75,8 @@ pub fn get_test_signed_transaction(
 pub fn get_test_unchecked_transaction(
     sender: AccountAddress,
     sequence_number: u64,
-    private_key: &Ed25519PrivateKey,
-    public_key: Ed25519PublicKey,
+    private_key: &ed25519::PrivateKey,
+    public_key: ed25519::PublicKey,
     script: Option<Script>,
     expiration_time: u64,
     gas_unit_price: u64,
@@ -103,8 +103,8 @@ pub fn get_test_unchecked_transaction(
 pub fn get_test_signed_txn(
     sender: AccountAddress,
     sequence_number: u64,
-    private_key: &Ed25519PrivateKey,
-    public_key: Ed25519PublicKey,
+    private_key: &ed25519::PrivateKey,
+    public_key: ed25519::PublicKey,
     script: Option<Script>,
 ) -> SignedTransaction {
     let expiration_time = SystemTime::now()
@@ -128,8 +128,8 @@ pub fn get_test_signed_txn(
 pub fn get_test_unchecked_txn(
     sender: AccountAddress,
     sequence_number: u64,
-    private_key: &Ed25519PrivateKey,
-    public_key: Ed25519PublicKey,
+    private_key: &ed25519::PrivateKey,
+    public_key: ed25519::PublicKey,
     script: Option<Script>,
 ) -> SignedTransaction {
     let expiration_time = SystemTime::now()
@@ -153,8 +153,8 @@ pub fn get_test_unchecked_txn(
 pub fn get_write_set_txn(
     sender: AccountAddress,
     sequence_number: u64,
-    private_key: &Ed25519PrivateKey,
-    public_key: Ed25519PublicKey,
+    private_key: &ed25519::PrivateKey,
+    public_key: ed25519::PublicKey,
     write_set: Option<WriteSet>,
 ) -> SignatureCheckedTransaction {
     let write_set = write_set.unwrap_or_default();

--- a/types/src/transaction/authenticator.rs
+++ b/types/src/transaction/authenticator.rs
@@ -3,12 +3,7 @@
 
 use crate::account_address::AccountAddress;
 use anyhow::{ensure, Error, Result};
-use libra_crypto::{
-    ed25519::{Ed25519PublicKey, Ed25519Signature},
-    multi_ed25519,
-    traits::SignatureExt,
-    HashValue,
-};
+use libra_crypto::{ed25519, multi_ed25519, traits::SignatureExt, HashValue};
 use libra_crypto_derive::CryptoHasher;
 #[cfg(any(test, feature = "fuzzing"))]
 use proptest_derive::Arbitrary;
@@ -51,8 +46,8 @@ impl fmt::Display for Scheme {
 pub enum TransactionAuthenticator {
     /// Single signature
     Ed25519 {
-        public_key: Ed25519PublicKey,
-        signature: Ed25519Signature,
+        public_key: ed25519::PublicKey,
+        signature: ed25519::Signature,
     },
     /// K-of-N multisignature
     MultiEd25519 {
@@ -72,7 +67,7 @@ impl TransactionAuthenticator {
     }
 
     /// Create a single-signature ed25519 authenticator
-    pub fn ed25519(public_key: Ed25519PublicKey, signature: Ed25519Signature) -> Self {
+    pub fn ed25519(public_key: ed25519::PublicKey, signature: ed25519::Signature) -> Self {
         Self::Ed25519 {
             public_key,
             signature,
@@ -152,7 +147,7 @@ impl AuthenticationKey {
     }
 
     /// Create an authentication key from an Ed25519 public key
-    pub fn ed25519(public_key: &Ed25519PublicKey) -> AuthenticationKey {
+    pub fn ed25519(public_key: &ed25519::PublicKey) -> AuthenticationKey {
         Self::from_preimage(&AuthenticationKeyPreimage::ed25519(public_key))
     }
 
@@ -206,7 +201,7 @@ impl AuthenticationKeyPreimage {
     }
 
     /// Construct a preimage from an Ed25519 public key
-    pub fn ed25519(public_key: &Ed25519PublicKey) -> AuthenticationKeyPreimage {
+    pub fn ed25519(public_key: &ed25519::PublicKey) -> AuthenticationKeyPreimage {
         Self::new(public_key.to_bytes().to_vec(), Scheme::Ed25519)
     }
 

--- a/types/src/transaction/authenticator.rs
+++ b/types/src/transaction/authenticator.rs
@@ -5,7 +5,7 @@ use crate::account_address::AccountAddress;
 use anyhow::{ensure, Error, Result};
 use libra_crypto::{
     ed25519::{Ed25519PublicKey, Ed25519Signature},
-    multi_ed25519::{MultiEd25519PublicKey, MultiEd25519Signature},
+    multi_ed25519,
     traits::SignatureExt,
     HashValue,
 };
@@ -56,8 +56,8 @@ pub enum TransactionAuthenticator {
     },
     /// K-of-N multisignature
     MultiEd25519 {
-        public_key: MultiEd25519PublicKey,
-        signature: MultiEd25519Signature,
+        public_key: multi_ed25519::PublicKey,
+        signature: multi_ed25519::Signature,
     },
     // ... add more schemes here
 }
@@ -81,8 +81,8 @@ impl TransactionAuthenticator {
 
     /// Create a multisignature ed25519 authenticator
     pub fn multi_ed25519(
-        public_key: MultiEd25519PublicKey,
-        signature: MultiEd25519Signature,
+        public_key: multi_ed25519::PublicKey,
+        signature: multi_ed25519::Signature,
     ) -> Self {
         Self::MultiEd25519 {
             public_key,
@@ -157,7 +157,7 @@ impl AuthenticationKey {
     }
 
     /// Create an authentication key from a MultiEd25519 public key
-    pub fn multi_ed25519(public_key: &MultiEd25519PublicKey) -> Self {
+    pub fn multi_ed25519(public_key: &multi_ed25519::PublicKey) -> Self {
         Self::from_preimage(&AuthenticationKeyPreimage::multi_ed25519(public_key))
     }
 
@@ -211,7 +211,7 @@ impl AuthenticationKeyPreimage {
     }
 
     /// Construct a preimage from a MultiEd25519 public key
-    pub fn multi_ed25519(public_key: &MultiEd25519PublicKey) -> AuthenticationKeyPreimage {
+    pub fn multi_ed25519(public_key: &multi_ed25519::PublicKey) -> AuthenticationKeyPreimage {
         Self::new(public_key.to_bytes(), Scheme::MultiEd25519)
     }
 

--- a/types/src/transaction/authenticator.rs
+++ b/types/src/transaction/authenticator.rs
@@ -6,7 +6,7 @@ use anyhow::{ensure, Error, Result};
 use libra_crypto::{
     ed25519::{Ed25519PublicKey, Ed25519Signature},
     multi_ed25519::{MultiEd25519PublicKey, MultiEd25519Signature},
-    traits::Signature,
+    traits::SignatureExt,
     HashValue,
 };
 use libra_crypto_derive::CryptoHasher;

--- a/types/src/transaction/helpers.rs
+++ b/types/src/transaction/helpers.rs
@@ -9,11 +9,10 @@ use crate::{
 use anyhow::Result;
 use chrono::Utc;
 use libra_crypto::{
-    ed25519::*,
+    ed25519,
     hash::{CryptoHash, TestOnlyHash},
     test_utils::KeyPair,
-    traits::SigningKey,
-    HashValue,
+    HashValue, SigningKey,
 };
 
 /// Used to get the digest of a set of signed transactions.  This is used by a validator
@@ -75,7 +74,7 @@ pub fn create_user_txn<T: TransactionSigner + ?Sized>(
     signer.sign_txn(raw_txn)
 }
 
-impl TransactionSigner for KeyPair<Ed25519PrivateKey, Ed25519PublicKey> {
+impl TransactionSigner for KeyPair<ed25519::PrivateKey, ed25519::PublicKey> {
     fn sign_txn(&self, raw_txn: RawTransaction) -> Result<SignedTransaction> {
         let signature = self.private_key.sign_message(&raw_txn.hash());
         Ok(SignedTransaction::new(

--- a/types/src/transaction/mod.rs
+++ b/types/src/transaction/mod.rs
@@ -15,7 +15,7 @@ use crate::{
 };
 use anyhow::{ensure, format_err, Error, Result};
 use libra_crypto::{
-    ed25519::*,
+    ed25519,
     hash::{CryptoHash, CryptoHasher, EventAccumulatorHasher},
     multi_ed25519,
     traits::SigningKey,
@@ -226,8 +226,8 @@ impl RawTransaction {
     /// For a transaction that has just been signed, its signature is expected to be valid.
     pub fn sign(
         self,
-        private_key: &Ed25519PrivateKey,
-        public_key: Ed25519PublicKey,
+        private_key: &ed25519::PrivateKey,
+        public_key: ed25519::PublicKey,
     ) -> Result<SignatureCheckedTransaction> {
         let signature = private_key.sign_message(&self.hash());
         Ok(SignatureCheckedTransaction(SignedTransaction::new(
@@ -238,8 +238,8 @@ impl RawTransaction {
     #[cfg(any(test, feature = "fuzzing"))]
     pub fn multi_sign_for_testing(
         self,
-        private_key: &Ed25519PrivateKey,
-        public_key: Ed25519PublicKey,
+        private_key: &ed25519::PrivateKey,
+        public_key: ed25519::PublicKey,
     ) -> Result<SignatureCheckedTransaction> {
         let signature = private_key.sign_message(&self.hash());
         Ok(SignatureCheckedTransaction(
@@ -380,8 +380,8 @@ impl fmt::Debug for SignedTransaction {
 impl SignedTransaction {
     pub fn new(
         raw_txn: RawTransaction,
-        public_key: Ed25519PublicKey,
-        signature: Ed25519Signature,
+        public_key: ed25519::PublicKey,
+        signature: ed25519::Signature,
     ) -> SignedTransaction {
         let authenticator = TransactionAuthenticator::ed25519(public_key, signature);
         SignedTransaction {

--- a/types/src/transaction/mod.rs
+++ b/types/src/transaction/mod.rs
@@ -17,7 +17,7 @@ use anyhow::{ensure, format_err, Error, Result};
 use libra_crypto::{
     ed25519::*,
     hash::{CryptoHash, CryptoHasher, EventAccumulatorHasher},
-    multi_ed25519::{MultiEd25519PublicKey, MultiEd25519Signature},
+    multi_ed25519,
     traits::SigningKey,
     HashValue,
 };
@@ -392,8 +392,8 @@ impl SignedTransaction {
 
     pub fn new_multisig(
         raw_txn: RawTransaction,
-        public_key: MultiEd25519PublicKey,
-        signature: MultiEd25519Signature,
+        public_key: multi_ed25519::PublicKey,
+        signature: multi_ed25519::Signature,
     ) -> SignedTransaction {
         let authenticator = TransactionAuthenticator::multi_ed25519(public_key, signature);
         SignedTransaction {

--- a/types/src/unit_tests/transaction_test.rs
+++ b/types/src/unit_tests/transaction_test.rs
@@ -12,7 +12,7 @@ use crate::{
 use lcs::test_helpers::assert_canonical_encode_decode;
 use libra_crypto::{
     ed25519::{self, Ed25519PrivateKey, Ed25519Signature},
-    PrivateKey, Uniform,
+    PrivateKeyExt, Uniform,
 };
 use libra_prost_ext::test_helpers::assert_protobuf_encode_decode;
 use proptest::prelude::*;

--- a/types/src/unit_tests/transaction_test.rs
+++ b/types/src/unit_tests/transaction_test.rs
@@ -10,10 +10,7 @@ use crate::{
     },
 };
 use lcs::test_helpers::assert_canonical_encode_decode;
-use libra_crypto::{
-    ed25519::{self, Ed25519PrivateKey, Ed25519Signature},
-    PrivateKeyExt, Uniform,
-};
+use libra_crypto::{ed25519, PrivateKeyExt, Uniform};
 use libra_prost_ext::test_helpers::assert_protobuf_encode_decode;
 use proptest::prelude::*;
 use std::convert::TryFrom;
@@ -30,8 +27,8 @@ fn test_invalid_signature() {
             LBR_NAME.to_string(),
             std::time::Duration::new(0, 0),
         ),
-        Ed25519PrivateKey::generate_for_testing().public_key(),
-        Ed25519Signature::try_from(&[1u8; 64][..]).unwrap(),
+        ed25519::PrivateKey::generate_for_testing().public_key(),
+        ed25519::Signature::try_from(&[1u8; 64][..]).unwrap(),
     )
     .into();
     let txn = SignedTransaction::try_from(proto_txn)

--- a/types/src/unit_tests/trusted_state_test.rs
+++ b/types/src/unit_tests/trusted_state_test.rs
@@ -15,7 +15,7 @@ use crate::{
     waypoint::Waypoint,
 };
 use libra_crypto::{
-    ed25519::Ed25519Signature,
+    ed25519,
     hash::{CryptoHash, HashValue},
 };
 use proptest::{
@@ -77,7 +77,7 @@ fn into_validator_set(signers: &[ValidatorSigner]) -> ValidatorSet {
 fn sign_ledger_info(
     signers: &[ValidatorSigner],
     ledger_info: &LedgerInfo,
-) -> BTreeMap<AccountAddress, Ed25519Signature> {
+) -> BTreeMap<AccountAddress, ed25519::Signature> {
     signers
         .iter()
         .map(|s| (s.author(), s.sign_message(ledger_info.hash())))

--- a/types/src/validator_config.rs
+++ b/types/src/validator_config.rs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::move_resource::MoveResource;
-use libra_crypto::{ed25519::Ed25519PublicKey, x25519::X25519StaticPublicKey};
+use libra_crypto::{ed25519, x25519::X25519StaticPublicKey};
 use parity_multiaddr::Multiaddr;
 use serde::{Deserialize, Serialize};
 
@@ -18,8 +18,8 @@ impl MoveResource for ValidatorConfigResource {
 
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct ValidatorConfig {
-    pub consensus_pubkey: Ed25519PublicKey,
-    pub validator_network_signing_pubkey: Ed25519PublicKey,
+    pub consensus_pubkey: ed25519::PublicKey,
+    pub validator_network_signing_pubkey: ed25519::PublicKey,
     pub validator_network_identity_pubkey: X25519StaticPublicKey,
     pub validator_network_address: Multiaddr,
     pub fullnodes_network_identity_pubkey: X25519StaticPublicKey,

--- a/types/src/validator_info.rs
+++ b/types/src/validator_info.rs
@@ -5,7 +5,7 @@ use crate::account_address::AccountAddress;
 use anyhow::{Error, Result};
 #[cfg(any(test, feature = "fuzzing"))]
 use libra_crypto::{
-    ed25519::Ed25519PrivateKey, x25519::X25519StaticPrivateKey, PrivateKey, Uniform,
+    ed25519::Ed25519PrivateKey, x25519::X25519StaticPrivateKey, PrivateKeyExt, Uniform,
 };
 use libra_crypto::{ed25519::Ed25519PublicKey, x25519::X25519StaticPublicKey, ValidKey};
 #[cfg(any(test, feature = "fuzzing"))]

--- a/types/src/validator_signer.rs
+++ b/types/src/validator_signer.rs
@@ -2,11 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::account_address::AccountAddress;
-use libra_crypto::{
-    ed25519::{Ed25519PrivateKey, Ed25519PublicKey, Ed25519Signature},
-    test_utils::TEST_SEED,
-    HashValue, PrivateKeyExt, SigningKey, Uniform,
-};
+use libra_crypto::{ed25519, test_utils::TEST_SEED, HashValue, PrivateKeyExt, SigningKey, Uniform};
 use rand::{rngs::StdRng, SeedableRng};
 use std::convert::TryFrom;
 
@@ -17,11 +13,11 @@ use std::convert::TryFrom;
 #[cfg_attr(any(test, feature = "fuzzing"), derive(Clone))]
 pub struct ValidatorSigner {
     author: AccountAddress,
-    private_key: Ed25519PrivateKey,
+    private_key: ed25519::PrivateKey,
 }
 
 impl ValidatorSigner {
-    pub fn new(author: AccountAddress, private_key: Ed25519PrivateKey) -> Self {
+    pub fn new(author: AccountAddress, private_key: ed25519::PrivateKey) -> Self {
         ValidatorSigner {
             author,
             private_key,
@@ -29,7 +25,7 @@ impl ValidatorSigner {
     }
 
     /// Constructs a signature for `message` using `private_key`.
-    pub fn sign_message(&self, message: HashValue) -> Ed25519Signature {
+    pub fn sign_message(&self, message: HashValue) -> ed25519::Signature {
         self.private_key.sign_message(&message)
     }
 
@@ -39,13 +35,13 @@ impl ValidatorSigner {
     }
 
     /// Returns the public key associated with this signer.
-    pub fn public_key(&self) -> Ed25519PublicKey {
+    pub fn public_key(&self) -> ed25519::PublicKey {
         self.private_key.public_key()
     }
 
     /// Returns the private key associated with this signer. Only available for testing purposes.
     #[cfg(any(test, feature = "fuzzing"))]
-    pub fn private_key(&self) -> &Ed25519PrivateKey {
+    pub fn private_key(&self) -> &ed25519::PrivateKey {
         &self.private_key
     }
 }
@@ -59,7 +55,7 @@ impl ValidatorSigner {
         let mut rng = StdRng::from_seed(opt_rng_seed.into().unwrap_or(TEST_SEED));
         Self::new(
             AccountAddress::random(),
-            Ed25519PrivateKey::generate(&mut rng),
+            ed25519::PrivateKey::generate(&mut rng),
         )
     }
 
@@ -68,7 +64,7 @@ impl ValidatorSigner {
     pub fn from_int(num: u8) -> Self {
         let mut address = [0; AccountAddress::LENGTH];
         address[0] = num;
-        let private_key = Ed25519PrivateKey::generate_for_testing();
+        let private_key = ed25519::PrivateKey::generate_for_testing();
         Self::new(AccountAddress::try_from(&address[..]).unwrap(), private_key)
     }
 }
@@ -80,17 +76,17 @@ pub mod proptests {
     use proptest::{prelude::*, sample, strategy::LazyJust};
 
     #[allow(clippy::redundant_closure)]
-    pub fn arb_signing_key() -> impl Strategy<Value = Ed25519PrivateKey> {
+    pub fn arb_signing_key() -> impl Strategy<Value = ed25519::PrivateKey> {
         prop_oneof![
             // The no_shrink here reflects that particular keypair choices out
             // of random options are irrelevant.
-            LazyJust::new(|| Ed25519PrivateKey::generate_for_testing()),
-            LazyJust::new(|| Ed25519PrivateKey::genesis()),
+            LazyJust::new(|| ed25519::PrivateKey::generate_for_testing()),
+            LazyJust::new(|| ed25519::PrivateKey::genesis()),
         ]
     }
 
     pub fn signer_strategy(
-        signing_key_strategy: impl Strategy<Value = Ed25519PrivateKey>,
+        signing_key_strategy: impl Strategy<Value = ed25519::PrivateKey>,
     ) -> impl Strategy<Value = ValidatorSigner> {
         signing_key_strategy
             .prop_map(|signing_key| ValidatorSigner::new(AccountAddress::random(), signing_key))
@@ -106,18 +102,20 @@ pub mod proptests {
         prop_oneof![
             rand_signer(),
             LazyJust::new(|| {
-                let genesis_key = Ed25519PrivateKey::genesis();
+                let genesis_key = ed25519::PrivateKey::genesis();
                 ValidatorSigner::new(AccountAddress::random(), genesis_key)
             })
         ]
     }
 
-    fn select_keypair(keys: Vec<Ed25519PrivateKey>) -> impl Strategy<Value = Ed25519PrivateKey> {
+    fn select_keypair(
+        keys: Vec<ed25519::PrivateKey>,
+    ) -> impl Strategy<Value = ed25519::PrivateKey> {
         sample::select(keys)
     }
 
     pub fn mostly_in_keypair_pool(
-        keys: Vec<Ed25519PrivateKey>,
+        keys: Vec<ed25519::PrivateKey>,
     ) -> impl Strategy<Value = ValidatorSigner> {
         prop::strategy::Union::new_weighted(vec![
             (9, signer_strategy(select_keypair(keys)).boxed()),

--- a/types/src/validator_signer.rs
+++ b/types/src/validator_signer.rs
@@ -5,7 +5,7 @@ use crate::account_address::AccountAddress;
 use libra_crypto::{
     ed25519::{Ed25519PrivateKey, Ed25519PublicKey, Ed25519Signature},
     test_utils::TEST_SEED,
-    HashValue, PrivateKey, SigningKey, Uniform,
+    HashValue, PrivateKeyExt, SigningKey, Uniform,
 };
 use rand::{rngs::StdRng, SeedableRng};
 use std::convert::TryFrom;

--- a/vm-validator/src/unit_tests/vm_validator_test.rs
+++ b/vm-validator/src/unit_tests/vm_validator_test.rs
@@ -4,7 +4,7 @@
 use crate::vm_validator::{TransactionValidation, VMValidator};
 use executor::db_bootstrapper::maybe_bootstrap_db;
 use libra_config::config::NodeConfig;
-use libra_crypto::{ed25519::Ed25519PrivateKey, PrivateKeyExt, Uniform};
+use libra_crypto::{ed25519, PrivateKeyExt, Uniform};
 use libra_types::{
     account_address, account_config,
     account_config::{lbr_type_tag, LBR_NAME},
@@ -97,7 +97,7 @@ fn test_validate_invalid_signature() {
     let (vm_validator, mut rt) = TestValidator::new(&config);
 
     let mut rng = ::rand::rngs::StdRng::from_seed([1u8; 32]);
-    let other_private_key = Ed25519PrivateKey::generate(&mut rng);
+    let other_private_key = ed25519::PrivateKey::generate(&mut rng);
     // Submit with an account using an different private/public keypair
 
     let address = account_config::association_address();
@@ -305,7 +305,7 @@ fn test_validate_invalid_auth_key() {
     let (vm_validator, mut rt) = TestValidator::new(&config);
 
     let mut rng = ::rand::rngs::StdRng::from_seed([1u8; 32]);
-    let other_private_key = Ed25519PrivateKey::generate(&mut rng);
+    let other_private_key = ed25519::PrivateKey::generate(&mut rng);
     // Submit with an account using an different private/public keypair
 
     let address = account_config::association_address();

--- a/vm-validator/src/unit_tests/vm_validator_test.rs
+++ b/vm-validator/src/unit_tests/vm_validator_test.rs
@@ -4,7 +4,7 @@
 use crate::vm_validator::{TransactionValidation, VMValidator};
 use executor::db_bootstrapper::maybe_bootstrap_db;
 use libra_config::config::NodeConfig;
-use libra_crypto::{ed25519::Ed25519PrivateKey, PrivateKey, Uniform};
+use libra_crypto::{ed25519::Ed25519PrivateKey, PrivateKeyExt, Uniform};
 use libra_types::{
     account_address, account_config,
     account_config::{lbr_type_tag, LBR_NAME},


### PR DESCRIPTION
**WORK IN PROGRESS. DON'T REVIEW NOW**

We use the following pattern for all variables currently in the crypto crate (with an example on public keys):

```
ed25519::Ed25519PublicKey
```

This PR renames all of these as:

```
ed25519::PublicKey
```

The rational is that:

* from the point of view of the ed25519 library, a key is just a key
* from the point of view of the caller, rust provides namespace just for this