### PR TITLE
[config] dynamically derive public key from private key

### DIFF
--- a/config/src/config/mod.rs
+++ b/config/src/config/mod.rs
@@ -281,7 +281,8 @@ impl NodeConfig {
 
         if self.base.role == RoleType::Validator {
             test.random_account_key(rng);
-            let peer_id = PeerId::from_public_key(test.account_keypair.as_ref().unwrap().public());
+            let peer_id =
+                PeerId::from_public_key(&test.account_keypair.as_ref().unwrap().public_key());
 
             if self.validator_network.is_none() {
                 self.validator_network = Some(NetworkConfig::default());

--- a/config/src/config/test_config.rs
+++ b/config/src/config/test_config.rs
@@ -17,7 +17,9 @@ type ConsensusKeyPair = KeyPair<Ed25519PrivateKey>;
 #[derive(Debug, Default, Deserialize, Serialize)]
 pub struct TestConfig {
     pub auth_key: Option<AuthenticationKey>,
+    #[serde(rename = "account_private_key")]
     pub account_keypair: Option<AccountKeyPair>,
+    #[serde(rename = "consensus_private_key")]
     pub consensus_keypair: Option<ConsensusKeyPair>,
     // Used only to prevent a potentially temporary data_dir from being deleted. This should
     // eventually be moved to be owned by something outside the config.

--- a/config/src/config/test_data/random.complete.node.config.toml
+++ b/config/src/config/test_data/random.complete.node.config.toml
@@ -68,13 +68,8 @@ grpc_max_receive_len = 100000000
 
 [test]
 auth_key = "837e3b2b2b32ee2543c24676ee66326431893204fa402143c11b26ce8a89ea1d"
-
-[test.account_keypair]
-private_key = "f6b898412f4ab061943167c1e23efaa2ba98e345a093f0b06da13bffdbd4b2c7"
-public_key = "5cea31ed5918cbdac5f5c4e782d295c0b3033ed5d0eac941e8ea8bb0ab4480a3"
-[test.consensus_keypair]
-private_key = "f2b916c8b1bf6123854d2fca5384f128199f7a1b2f847316481429b4b35238cc"
-public_key = "ca68c65c24a94c3aca0626e573dbdfe7e799a2565e9051b634fec1a42d3baaf9"
+account_private_key = "f6b898412f4ab061943167c1e23efaa2ba98e345a093f0b06da13bffdbd4b2c7"
+consensus_private_key = "f2b916c8b1bf6123854d2fca5384f128199f7a1b2f847316481429b4b35238cc"
 
 [validator_network]
 peer_id = "31893204fa402143c11b26ce8a89ea1d"
@@ -89,8 +84,4 @@ seed_peers_file = "31893204fa402143c11b26ce8a89ea1d.seed_peers.toml"
 
 [validator_network.network_keypairs]
 identity_private_key = "288b53541ed20ddaa5dea1b78f1fc08446de1f93b0e07080f7f2ee9be681e47f"
-identity_public_key = "2eaab94e262f1f7443c558588157cbb3185a7302263dafc4bfe75a2b01f06776"
-
-[validator_network.network_keypairs.signing_keys]
-private_key = "66dd107034b4582a2ef42c5e1ea475f2fea477a10a9f1d75b3635243b2506b32"
-public_key = "f09263c17aa2e64a311b1ce512608f3e35f8481c736ae1d7db125a0ce58d3782"
+signing_private_key = "66dd107034b4582a2ef42c5e1ea475f2fea477a10a9f1d75b3635243b2506b32"

--- a/config/src/config/test_data/random.default.node.config.toml
+++ b/config/src/config/test_data/random.default.node.config.toml
@@ -4,18 +4,9 @@ seed_peers_file = "31893204fa402143c11b26ce8a89ea1d.seed_peers.toml"
 
 [validator_network.network_keypairs]
 identity_private_key = "288b53541ed20ddaa5dea1b78f1fc08446de1f93b0e07080f7f2ee9be681e47f"
-identity_public_key = "2eaab94e262f1f7443c558588157cbb3185a7302263dafc4bfe75a2b01f06776"
-
-[validator_network.network_keypairs.signing_keys]
-private_key = "66dd107034b4582a2ef42c5e1ea475f2fea477a10a9f1d75b3635243b2506b32"
-public_key = "f09263c17aa2e64a311b1ce512608f3e35f8481c736ae1d7db125a0ce58d3782"
+signing_private_key = "66dd107034b4582a2ef42c5e1ea475f2fea477a10a9f1d75b3635243b2506b32"
 
 [test]
 auth_key = "837e3b2b2b32ee2543c24676ee66326431893204fa402143c11b26ce8a89ea1d"
-
-[test.account_keypair]
-private_key = "f6b898412f4ab061943167c1e23efaa2ba98e345a093f0b06da13bffdbd4b2c7"
-public_key = "5cea31ed5918cbdac5f5c4e782d295c0b3033ed5d0eac941e8ea8bb0ab4480a3"
-[test.consensus_keypair]
-private_key = "f2b916c8b1bf6123854d2fca5384f128199f7a1b2f847316481429b4b35238cc"
-public_key = "ca68c65c24a94c3aca0626e573dbdfe7e799a2565e9051b634fec1a42d3baaf9"
+account_private_key ="f6b898412f4ab061943167c1e23efaa2ba98e345a093f0b06da13bffdbd4b2c7"
+consensus_private_key = "f2b916c8b1bf6123854d2fca5384f128199f7a1b2f847316481429b4b35238cc"

--- a/config/src/config/test_data/single.node.config.toml
+++ b/config/src/config/test_data/single.node.config.toml
@@ -32,13 +32,8 @@ grpc_max_receive_len = 100000000
 
 [test]
 auth_key = "8e0d19280063fa870fe4dbb85cc724091a398451c5c11e1e76e64cdc7b588510"
-
-[test.account_keypair]
-private_key = "76b8e0ada0f13d90405d6ae55386bd28bdd219b8a08ded1aa836efcc8b770dc7"
-public_key = "20fdbac9b10b7587bba7b5bc163bce69e796d71e4ed44c10fcb4488689f7a144"
-[test.consensus_keypair]
-private_key = "29b721769ce64e43d57133b074d839d531ed1f28510afb45ace10a1f4b794d6f"
-public_key = "beada06126c78d98b4a1a69f6ee6189694f0f4751538da824f1adc8b14a1b562"
+account_private_key = "76b8e0ada0f13d90405d6ae55386bd28bdd219b8a08ded1aa836efcc8b770dc7"
+consensus_private_key = "29b721769ce64e43d57133b074d839d531ed1f28510afb45ace10a1f4b794d6f"
 
 [validator_network]
 peer_id = "1a398451c5c11e1e76e64cdc7b588510"

--- a/config/src/generator.rs
+++ b/config/src/generator.rs
@@ -53,7 +53,12 @@ pub fn validator_swarm(
         }
 
         let test = node.test.as_ref().unwrap();
-        let consensus_pubkey = test.consensus_keypair.as_ref().unwrap().public().clone();
+        let consensus_pubkey = test
+            .consensus_keypair
+            .as_ref()
+            .unwrap()
+            .public_key()
+            .clone();
         let network_keypairs = network
             .network_keypairs
             .as_ref()
@@ -63,8 +68,8 @@ pub fn validator_swarm(
             network.peer_id,
             consensus_pubkey,
             1, // @TODO: Add support for dynamic weights
-            network_keypairs.signing_keys.public().clone(),
-            network_keypairs.identity_public_key(),
+            network_keypairs.signing_keypair.public_key(),
+            network_keypairs.identity_keypair.public_key(),
         ));
 
         // TODO(philiphayes): as a temporary hack, we'll just duplicate the
@@ -72,9 +77,9 @@ pub fn validator_swarm(
         // empty fullnode info.
         discovery_infos.push(DiscoveryInfo {
             account_address: network.peer_id,
-            validator_network_identity_pubkey: network_keypairs.identity_public_key(),
+            validator_network_identity_pubkey: network_keypairs.identity_keypair.public_key(),
             validator_network_address: network.advertised_address.clone(),
-            fullnodes_network_identity_pubkey: network_keypairs.identity_public_key(),
+            fullnodes_network_identity_pubkey: network_keypairs.identity_keypair.public_key(),
             fullnodes_network_address: network.advertised_address.clone(),
         });
 

--- a/config/src/keys.rs
+++ b/config/src/keys.rs
@@ -1,96 +1,45 @@
 // Copyright (c) The Libra Core Contributors
 // SPDX-License-Identifier: Apache-2.0
 
-use libra_crypto::{PrivateKey, Uniform, ValidKeyStringExt};
-use mirai_annotations::verify_unreachable;
-use serde::{de::DeserializeOwned, Deserialize, Deserializer, Serialize, Serializer};
+//! This file implements a KeyPair data structure.
+//!
+//! The point of a KeyPair is to deserialize a private key into a structure
+//! that will only allow the private key to be moved out once
+//! (hence providing good key hygiene)
+//! while allowing access to the public key part forever.
+//!
+//! The public key part is dynamically derived during deserialization,
+//! while ignored during serialization.
+//!
 
+use libra_crypto::{PrivateKey, ValidKeyStringExt};
+use serde::{Deserialize, Deserializer, Serialize, Serializer};
+
+#[cfg(test)]
+use libra_crypto::Uniform;
+
+/// A KeyPair has a private key that can only be taken once,
+/// and a public key that can be cloned ad infinitum.
+#[cfg_attr(any(test, feature = "fuzzing"), derive(Clone))]
 #[derive(Debug, PartialEq)]
-#[cfg_attr(any(test, feature = "fuzzing"), derive(Clone))]
-pub enum PrivateKeyContainer<T> {
-    Present(T),
-    Removed,
-    Absent,
-}
-
-impl<T> PrivateKeyContainer<T>
-where
-    T: PrivateKey,
-{
-    pub fn take(&mut self) -> Option<T> {
-        match self {
-            PrivateKeyContainer::Present(_) => {
-                let key = std::mem::replace(self, PrivateKeyContainer::Removed);
-                match key {
-                    PrivateKeyContainer::Present(priv_key) => Some(priv_key),
-                    _ => verify_unreachable!(
-                        "mem::replace returned value for PrivateKeyContainer different from the one observed right before the call"
-                    ),
-                }
-            }
-            _ => None,
-        }
-    }
-
-    pub fn public_key(&self) -> Option<T::PublicKeyMaterial> {
-        match self {
-            PrivateKeyContainer::Present(private_key) => Some(private_key.public_key()),
-            _ => None,
-        }
-    }
-}
-
-impl<T> Serialize for PrivateKeyContainer<T>
-where
-    T: Serialize + ValidKeyStringExt,
-{
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
-    where
-        S: Serializer,
-    {
-        match self {
-            PrivateKeyContainer::Present(key) => key.serialize(serializer),
-            _ => serializer.serialize_str(""),
-        }
-    }
-}
-
-impl<'de, T> Deserialize<'de> for PrivateKeyContainer<T>
-where
-    T: ValidKeyStringExt,
-{
-    fn deserialize<D>(deserializer: D) -> std::result::Result<PrivateKeyContainer<T>, D::Error>
-    where
-        D: Deserializer<'de>,
-    {
-        // Note: Any error in parsing is assumed to be due to the private key being absent.
-        T::deserialize(deserializer)
-            .map(PrivateKeyContainer::Present)
-            .or_else(|_| Ok(PrivateKeyContainer::Absent))
-    }
-}
-
-#[cfg_attr(any(test, feature = "fuzzing"), derive(Clone))]
-#[derive(Debug, Deserialize, PartialEq, Serialize)]
 pub struct KeyPair<T>
 where
     T: PrivateKey + Serialize + ValidKeyStringExt,
 {
-    #[serde(bound(deserialize = "PrivateKeyContainer<T>: Deserialize<'de>"))]
-    private_key: PrivateKeyContainer<T>,
+    private_key: Option<T>,
     public_key: T::PublicKeyMaterial,
 }
 
+#[cfg(test)]
 impl<T> Default for KeyPair<T>
 where
     T: PrivateKey + Serialize + Uniform + ValidKeyStringExt,
-    T::PublicKeyMaterial: DeserializeOwned + 'static + Serialize + ValidKeyStringExt,
 {
     fn default() -> Self {
         let private_key = T::generate_for_testing();
         let public_key = private_key.public_key();
         Self {
-            private_key: PrivateKeyContainer::Present(private_key),
+            private_key: Some(private_key),
             public_key,
         }
     }
@@ -99,22 +48,66 @@ where
 impl<T> KeyPair<T>
 where
     T: PrivateKey + Serialize + ValidKeyStringExt,
-    T::PublicKeyMaterial: DeserializeOwned + 'static + Serialize + ValidKeyStringExt,
 {
+    /// This transforms a private key into a keypair data structure.
     pub fn load(private_key: T) -> Self {
         let public_key = private_key.public_key();
         Self {
-            private_key: PrivateKeyContainer::Present(private_key),
+            private_key: Some(private_key),
             public_key,
         }
     }
 
-    pub fn public(&self) -> &T::PublicKeyMaterial {
-        &self.public_key
-    }
-
-    /// Beware, this destroys the private key from this NodeConfig
+    /// Takes the key from the data structure, calling this function a second time will return None.
     pub fn take_private(&mut self) -> Option<T> {
         self.private_key.take()
+    }
+
+    /// Returns the public key part. This always work, even after the private key was taken.
+    pub fn public_key(&self) -> T::PublicKeyMaterial {
+        self.public_key.clone()
+    }
+}
+
+//
+// Serialization and Deserialization functions
+//
+
+/// Serialization for a KeyPair only serializes the private key part (if present).
+impl<T> Serialize for KeyPair<T>
+where
+    T: PrivateKey + Serialize + ValidKeyStringExt,
+{
+    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+        T: Serialize + ValidKeyStringExt,
+    {
+        match &self.private_key {
+            Some(key) => key.serialize(serializer),
+            None => serializer.serialize_str(""),
+        }
+    }
+}
+
+/// Deserializing a keypair only deserializes the private key, and dynamically derives the public key.
+impl<'de, T> Deserialize<'de> for KeyPair<T>
+where
+    T: PrivateKey + ValidKeyStringExt,
+{
+    fn deserialize<D>(deserializer: D) -> std::result::Result<KeyPair<T>, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        match T::deserialize(deserializer) {
+            Ok(private_key) => {
+                let public_key = private_key.public_key();
+                Ok(KeyPair {
+                    private_key: Some(private_key),
+                    public_key,
+                })
+            }
+            Err(err) => Err(err),
+        }
     }
 }

--- a/consensus/src/network_interface.rs
+++ b/consensus/src/network_interface.rs
@@ -161,12 +161,12 @@ impl<T: Payload> ConsensusNetworkSender<T> {
             .send(ConnectivityRequest::UpdateEligibleNodes(
                 validators
                     .into_iter()
-                    .map(|keys| {
+                    .map(|validator| {
                         (
-                            *keys.account_address(),
+                            *validator.account_address(),
                             NetworkPublicKeys {
-                                identity_public_key: keys.network_identity_public_key(),
-                                signing_public_key: keys.network_signing_public_key().clone(),
+                                identity_public_key: validator.network_identity_public_key(),
+                                signing_public_key: validator.network_signing_public_key().clone(),
                             },
                         )
                     })

--- a/execution/executor/tests/storage_integration_test.rs
+++ b/execution/executor/tests/storage_integration_test.rs
@@ -113,7 +113,7 @@ fn test_reconfiguration() {
         .as_mut()
         .unwrap();
     let validator_privkey = keys.take_private().unwrap();
-    let validator_pubkey = keys.public().clone();
+    let validator_pubkey = keys.public_key();
     let auth_key = AuthenticationKey::ed25519(&validator_pubkey);
     let validator_auth_key_prefix = auth_key.prefix().to_vec();
     assert!(
@@ -206,7 +206,7 @@ fn test_change_publishing_option_to_custom() {
         .unwrap();
 
     let validator_privkey = keys.take_private().unwrap();
-    let validator_pubkey = keys.public().clone();
+    let validator_pubkey = keys.public_key();
     let auth_key = AuthenticationKey::ed25519(&validator_pubkey);
     let validator_auth_key_prefix = auth_key.prefix().to_vec();
     assert_eq!(
@@ -378,7 +378,7 @@ fn test_extend_whitelist() {
         .unwrap();
 
     let validator_privkey = keys.take_private().unwrap();
-    let validator_pubkey = keys.public().clone();
+    let validator_pubkey = keys.public_key();
     let auth_key = AuthenticationKey::ed25519(&validator_pubkey);
     let validator_auth_key_prefix = auth_key.prefix().to_vec();
     assert!(

--- a/language/tools/vm-genesis/src/lib.rs
+++ b/language/tools/vm-genesis/src/lib.rs
@@ -541,8 +541,8 @@ fn get_validator_authentication_key(
             .account_keypair
             .as_ref()
             .unwrap()
-            .public();
-        let validator_authentication_key = AuthenticationKey::ed25519(public_key);
+            .public_key();
+        let validator_authentication_key = AuthenticationKey::ed25519(&public_key);
         let derived_address = validator_authentication_key.derived_address();
         if derived_address == *address {
             return Some(validator_authentication_key);

--- a/libra-node/src/main_node.rs
+++ b/libra-node/src/main_node.rs
@@ -102,15 +102,15 @@ pub fn setup_network(config: &mut NetworkConfig, role: RoleType) -> (Runtime, Ne
             .network_keypairs
             .as_mut()
             .expect("Network keypairs are not defined");
-        let signing_keys = &mut network_keypairs.signing_keys;
-        let signing_private = signing_keys
+        let signing_keypair = &mut network_keypairs.signing_keypair;
+        let signing_private = signing_keypair
             .take_private()
             .expect("Failed to take Network signing private key, key absent or already read");
-        let signing_public = signing_keys.public().clone();
+        let signing_public = signing_keypair.public_key();
 
         let identity_key = network_keypairs
-            .identity_private_key
-            .take()
+            .identity_keypair
+            .take_private()
             .expect("identity key should be present");
 
         let trusted_peers = if role == RoleType::Validator {
@@ -124,7 +124,7 @@ pub fn setup_network(config: &mut NetworkConfig, role: RoleType) -> (Runtime, Ne
             .connectivity_check_interval_ms(config.connectivity_check_interval_ms)
             .seed_peers(seed_peers)
             .trusted_peers(trusted_peers)
-            .signing_keys((signing_private, signing_public))
+            .signing_keypair((signing_private, signing_public))
             .discovery_interval_ms(config.discovery_interval_ms)
             .add_discovery();
     } else if config.enable_noise {
@@ -132,8 +132,8 @@ pub fn setup_network(config: &mut NetworkConfig, role: RoleType) -> (Runtime, Ne
             .network_keypairs
             .as_mut()
             .expect("Network keypairs are not defined")
-            .identity_private_key
-            .take()
+            .identity_keypair
+            .take_private()
             .expect("identity key should be present");
         // Even if a network end-point operates without remote authentication, it might want to prove
         // its identity to another peer it connects to. For this, we use TCP + Noise but without

--- a/network/src/protocols/network/dummy.rs
+++ b/network/src/protocols/network/dummy.rs
@@ -145,7 +145,7 @@ pub fn setup_network() -> DummyNetwork {
     network_builder
         .transport(TransportType::TcpNoise(Some(listener_identity_private_key)))
         .trusted_peers(trusted_peers.clone())
-        .signing_keys((listener_signing_private_key, listener_signing_public_key))
+        .signing_keypair((listener_signing_private_key, listener_signing_public_key))
         .discovery_interval_ms(HOUR_IN_MS)
         .add_discovery();
     let (listener_sender, mut listener_events) = add_to_network(&mut network_builder);
@@ -161,7 +161,7 @@ pub fn setup_network() -> DummyNetwork {
     network_builder
         .transport(TransportType::TcpNoise(Some(dialer_identity_private_key)))
         .trusted_peers(trusted_peers)
-        .signing_keys((dialer_signing_private_key, dialer_signing_public_key))
+        .signing_keypair((dialer_signing_private_key, dialer_signing_public_key))
         .seed_peers(
             [(listener_peer_id, vec![listen_addr])]
                 .iter()

--- a/network/src/validator_network/network_builder.rs
+++ b/network/src/validator_network/network_builder.rs
@@ -113,7 +113,7 @@ pub struct NetworkBuilder {
     max_concurrent_network_reqs: usize,
     max_concurrent_network_notifs: usize,
     max_connection_delay_ms: u64,
-    signing_keys: Option<(Ed25519PrivateKey, Ed25519PublicKey)>,
+    signing_keypair: Option<(Ed25519PrivateKey, Ed25519PublicKey)>,
     enable_remote_authentication: bool,
 }
 
@@ -167,7 +167,7 @@ impl NetworkBuilder {
             max_concurrent_network_reqs: MAX_CONCURRENT_NETWORK_REQS,
             max_concurrent_network_notifs: MAX_CONCURRENT_NETWORK_NOTIFS,
             max_connection_delay_ms: MAX_CONNECTION_DELAY_MS,
-            signing_keys: None,
+            signing_keypair: None,
             enable_remote_authentication: true,
         }
     }
@@ -194,8 +194,8 @@ impl NetworkBuilder {
     }
 
     /// Set signing keys of local node.
-    pub fn signing_keys(&mut self, keys: (Ed25519PrivateKey, Ed25519PublicKey)) -> &mut Self {
-        self.signing_keys = Some(keys);
+    pub fn signing_keypair(&mut self, keypair: (Ed25519PrivateKey, Ed25519PublicKey)) -> &mut Self {
+        self.signing_keypair = Some(keypair);
         self
     }
 
@@ -386,7 +386,7 @@ impl NetworkBuilder {
         // discovery module or not. We should make this more explicit eventually.
         // Initialize and start Discovery actor.
         let (signing_private_key, _signing_public_key) =
-            self.signing_keys.take().expect("Signing keys not set");
+            self.signing_keypair.take().expect("Signing keys not set");
         // Get handles for network events and sender.
         let (discovery_network_tx, discovery_network_rx) = discovery::add_to_network(self);
         let addrs = vec![self

--- a/state-synchronizer/src/tests/integration_tests.rs
+++ b/state-synchronizer/src/tests/integration_tests.rs
@@ -135,11 +135,11 @@ impl SynchronizerEnv {
 
         // Setup signing public keys.
         let mut rng = StdRng::from_seed(TEST_SEED);
-        let signing_keys: Vec<_> = (0..count)
+        let signing_private_keys: Vec<_> = (0..count)
             .map(|_| Ed25519PrivateKey::generate(&mut rng))
             .collect();
         // Setup identity public keys.
-        let identity_keys: Vec<_> = (0..count)
+        let identity_private_keys: Vec<_> = (0..count)
             .map(|_| x25519::PrivateKey::for_test(&mut rng))
             .collect();
 
@@ -151,12 +151,12 @@ impl SynchronizerEnv {
                 signer.author(),
                 signer.public_key(),
                 voting_power,
-                signing_keys[idx].public_key(),
-                identity_keys[idx].public_key(),
+                signing_private_keys[idx].public_key(),
+                identity_private_keys[idx].public_key(),
             );
             validators_keys.push(validator_info);
         }
-        (signers, signing_keys, validators_keys)
+        (signers, signing_private_keys, validators_keys)
     }
 
     // Moves peer 0 to the next epoch. Note that other peers are not going to be able to discover
@@ -250,7 +250,7 @@ impl SynchronizerEnv {
             RoleType::Validator,
         );
         network_builder
-            .signing_keys((
+            .signing_keypair((
                 self.network_signers[new_peer_idx].clone(),
                 self.public_keys[new_peer_idx]
                     .network_signing_public_key()

--- a/state-synchronizer/src/tests/on_chain_config_tests.rs
+++ b/state-synchronizer/src/tests/on_chain_config_tests.rs
@@ -82,7 +82,7 @@ fn test_on_chain_config_pub_sub() {
         .unwrap();
 
     let validator_privkey = keys.take_private().unwrap();
-    let validator_pubkey = keys.public().clone();
+    let validator_pubkey = keys.public_key();
     let auth_key = AuthenticationKey::ed25519(&validator_pubkey);
     let validator_auth_key_prefix = auth_key.prefix().to_vec();
 

--- a/types/src/validator_verifier.rs
+++ b/types/src/validator_verifier.rs
@@ -281,12 +281,12 @@ impl From<&ValidatorSet> for ValidatorVerifier {
     fn from(validator_set: &ValidatorSet) -> Self {
         ValidatorVerifier::new(validator_set.payload().iter().fold(
             BTreeMap::new(),
-            |mut map, key| {
+            |mut map, validator| {
                 map.insert(
-                    key.account_address().clone(),
+                    validator.account_address().clone(),
                     ValidatorConsensusInfo::new(
-                        key.consensus_public_key().clone(),
-                        key.consensus_voting_power(),
+                        validator.consensus_public_key().clone(),
+                        validator.consensus_voting_power(),
                     ),
                 );
                 map


### PR DESCRIPTION
We currently obtain both the private key and public key (of different types)
from config files.
We then keep them both in a struct without verifying that the public key
is indeed the correct one associated to the private counterpart.

This PR changes this behavior to only serialize and deserialize the
private key part. The public key part is dynamically derived during
deserialization of the private key.

This way, no mistakes can be made when given a configuration that has a
wrong public key.
