### PR TITLE
[vm] Load the writeset from StateView before committing it to the executor

### DIFF
--- a/language/libra-vm/src/libra_vm.rs
+++ b/language/libra-vm/src/libra_vm.rs
@@ -238,18 +238,14 @@ impl LibraVM {
     fn check_change_set(&self, change_set: &ChangeSet, state_view: &dyn StateView) -> VMResult<()> {
         // This function is only invoked by WaypointWriteSet for now. We don't enforce the same
         // check on TransactionPayload::WriteSet.
-        if state_view.is_genesis() {
-            for (_access_path, write_op) in change_set.write_set() {
-                // Genesis transactions only add entries, never delete them.
-                if write_op.is_deletion() {
-                    error!("[VM] Bad genesis block");
-                    return Err(VMStatus::new(StatusCode::INVALID_WRITE_SET));
-                }
+        for (_access_path, write_op) in change_set.write_set() {
+            // Genesis transactions only add entries, never delete them.
+            if write_op.is_deletion() {
+                error!("[VM] Bad genesis block");
+                return Err(VMStatus::new(StatusCode::INVALID_WRITE_SET));
             }
-            Ok(())
-        } else {
-            Err(VMStatus::new(StatusCode::REJECTED_WRITE_SET))
         }
+        Ok(())
     }
 
     fn resolve_type_argument(
@@ -470,20 +466,34 @@ impl LibraVM {
         result
     }
 
+    fn load_writeset(
+        &self,
+        remote_cache: &BlockDataCache<'_>,
+        write_set: &WriteSet,
+    ) -> VMResult<()> {
+        // Load writeset contents into cache. Executor expects each writeop to be read from
+        // StateView before being able to commit them.
+        for op in write_set.iter() {
+            remote_cache.get(ap)?;
+        }
+        Ok(())
+    }
+
     fn process_waypoint_change_set(
         &mut self,
         remote_cache: &mut BlockDataCache<'_>,
         change_set: ChangeSet,
-    ) -> TransactionOutput {
+    ) -> VMResult<TransactionOutput> {
         let (write_set, events) = change_set.into_inner();
+        self.load_writeset(remote_cache, &write_set)?;
         remote_cache.push_write_set(&write_set);
         self.load_configs_impl(remote_cache);
-        TransactionOutput::new(
+        Ok(TransactionOutput::new(
             write_set,
             events,
             0,
             VMStatus::new(StatusCode::EXECUTED).into(),
-        )
+        ))
     }
 
     fn process_block_prologue(
@@ -567,6 +577,10 @@ impl LibraVM {
         let mut interpreter_context = SystemExecutionContext::new(remote_cache, GasUnits::new(0));
 
         self.run_writeset_epilogue(&mut interpreter_context, change_set, &txn_data)?;
+
+        if let Err(e) = self.load_writeset(remote_cache, &change_set.write_set()) {
+            return Ok(discard_error_output(e));
+        };
 
         let epilogue_writeset = interpreter_context.make_write_set()?;
         let epilogue_events = interpreter_context.events().to_vec();
@@ -780,7 +794,7 @@ impl LibraVM {
                 }
                 TransactionBlock::WaypointWriteSet(change_set) => result.push(
                     self.check_change_set(&change_set, state_view)
-                        .map(|_| self.process_waypoint_change_set(&mut data_cache, change_set))
+                        .and_then(|_| self.process_waypoint_change_set(&mut data_cache, change_set))
                         .unwrap_or_else(discard_error_output),
                 ),
                 TransactionBlock::WriteSet(txn) => {


### PR DESCRIPTION
…cutor

<!--
Thank you for sending a PR. We appreciate you spending time to help improve the Libra project.

The project is undergoing daily changes. Pull Requests will be reviewed and responded to as time permits.
-->

## Motivation

As requested by @msmouse , Executor will expects writesets to be loaded from `StateView` before being applied. This PR will add this loading logic to the VM's logic of processing writesets.

Also the `check_change_set` logic is removed as it's no longer needed.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?

Yes
