### PR TITLE
[consensus] use on-chain config payload to start processor

### DIFF
--- a/consensus/src/chained_bft/chained_bft_smr.rs
+++ b/consensus/src/chained_bft/chained_bft_smr.rs
@@ -20,10 +20,7 @@ use consensus_types::common::{Author, Payload, Round};
 use futures::{select, stream::StreamExt};
 use libra_config::config::ConsensusConfig;
 use libra_logger::prelude::*;
-use libra_types::{
-    epoch_info::EpochInfo,
-    on_chain_config::{OnChainConfigPayload, ValidatorSet},
-};
+use libra_types::on_chain_config::OnChainConfigPayload;
 use safety_rules::SafetyRulesManager;
 use std::{
     sync::{Arc, Mutex},
@@ -89,13 +86,7 @@ impl<T: Payload> ChainedBftSMR<T> {
                 select! {
                     payload = reconfig_events.select_next_some() => {
                         idle_duration = pre_select_instant.elapsed();
-                        let epoch_info = EpochInfo {
-                            epoch: payload.epoch(),
-                            verifier: Arc::new((&payload.get::<ValidatorSet>()
-                                .expect("failed to get ValidatorSet from payload"))
-                                .into()),
-                        };
-                        epoch_manager.start_processor(epoch_info).await
+                        epoch_manager.start_processor(payload).await
                     }
                     msg = network_receivers.consensus_messages.select_next_some() => {
                         idle_duration = pre_select_instant.elapsed();

--- a/consensus/src/chained_bft/event_processor.rs
+++ b/consensus/src/chained_bft/event_processor.rs
@@ -1019,10 +1019,6 @@ impl<T: Payload> EventProcessor<T> {
         self.safety_rules.consensus_state().unwrap()
     }
 
-    pub fn block_store(&self) -> Arc<BlockStore<T>> {
-        self.block_store.clone()
-    }
-
     pub fn epoch_info(&self) -> &EpochInfo {
         &self.epoch_info
     }

--- a/consensus/src/chained_bft/event_processor_fuzzing.rs
+++ b/consensus/src/chained_bft/event_processor_fuzzing.rs
@@ -21,8 +21,8 @@ use channel::{self, libra_channel, message_queues::QueueStyle};
 use consensus_types::proposal_msg::ProposalMsg;
 use futures::{channel::mpsc, executor::block_on};
 use libra_types::{
-    ledger_info::LedgerInfoWithSignatures, validator_signer::ValidatorSigner,
-    validator_verifier::ValidatorVerifier,
+    epoch_info::EpochInfo, ledger_info::LedgerInfoWithSignatures,
+    validator_signer::ValidatorSigner, validator_verifier::ValidatorVerifier,
 };
 use network::peer_manager::{ConnectionRequestSender, PeerManagerRequestSender};
 use once_cell::sync::Lazy;
@@ -105,7 +105,10 @@ fn create_node_for_fuzzing() -> EventProcessor<TestPayload> {
     );
     let (self_sender, _self_receiver) = channel::new_test(8);
 
-    let epoch_info = initial_data.epoch_info();
+    let epoch_info = EpochInfo {
+        epoch: 1,
+        verifier: Arc::new(storage.get_validator_set().into()),
+    };
     let network = NetworkSender::new(
         signer.author(),
         network_sender,

--- a/consensus/src/chained_bft/event_processor_test.rs
+++ b/consensus/src/chained_bft/event_processor_test.rs
@@ -47,6 +47,7 @@ use futures::{
 use libra_crypto::HashValue;
 use libra_types::{
     block_info::BlockInfo,
+    epoch_info::EpochInfo,
     ledger_info::LedgerInfoWithSignatures,
     validator_signer::ValidatorSigner,
     validator_verifier::{random_validator_verifier, ValidatorVerifier},
@@ -122,7 +123,10 @@ impl NodeSetup {
         initial_data: RecoveryData<TestPayload>,
         safety_rules_manager: SafetyRulesManager<TestPayload>,
     ) -> Self {
-        let epoch_info = initial_data.epoch_info();
+        let epoch_info = EpochInfo {
+            epoch: 1,
+            verifier: Arc::new(storage.get_validator_set().into()),
+        };
         let validators = epoch_info.verifier.clone();
         let (network_reqs_tx, network_reqs_rx) =
             libra_channel::new(QueueStyle::FIFO, NonZeroUsize::new(8).unwrap(), None);

--- a/consensus/src/chained_bft/persistent_liveness_storage.rs
+++ b/consensus/src/chained_bft/persistent_liveness_storage.rs
@@ -12,11 +12,7 @@ use executor_types::ExecutedTrees;
 use libra_config::config::NodeConfig;
 use libra_crypto::HashValue;
 use libra_logger::prelude::*;
-use libra_types::{
-    block_info::Round, epoch_info::EpochInfo, ledger_info::LedgerInfo,
-    on_chain_config::ValidatorSet, transaction::Version, validator_info::ValidatorInfo,
-    validator_verifier::ValidatorVerifier,
-};
+use libra_types::{block_info::Round, ledger_info::LedgerInfo, transaction::Version};
 use std::{cmp::max, collections::HashSet, sync::Arc};
 use storage_interface::DbReader;
 
@@ -55,40 +51,16 @@ pub struct RootInfo<T>(pub Block<T>, pub QuorumCert, pub QuorumCert);
 /// LedgerRecoveryData is a subset of RecoveryData that we can get solely from ledger info.
 #[derive(Clone)]
 pub struct LedgerRecoveryData {
-    epoch: u64,
-    validators: Arc<ValidatorVerifier>,
-    validator_keys: ValidatorSet,
     storage_ledger: LedgerInfo,
 }
 
 impl LedgerRecoveryData {
-    pub fn new(storage_ledger: LedgerInfo, validator_keys: ValidatorSet) -> Self {
-        let epoch = if storage_ledger.next_validator_set().is_some() {
-            storage_ledger.epoch() + 1
-        } else {
-            storage_ledger.epoch()
-        };
-        LedgerRecoveryData {
-            epoch,
-            validators: Arc::new((&validator_keys).into()),
-            validator_keys,
-            storage_ledger,
-        }
-    }
-
-    pub fn epoch_info(&self) -> EpochInfo {
-        EpochInfo {
-            epoch: self.epoch,
-            verifier: Arc::clone(&self.validators),
-        }
+    pub fn new(storage_ledger: LedgerInfo) -> Self {
+        LedgerRecoveryData { storage_ledger }
     }
 
     pub fn commit_round(&self) -> Round {
         self.storage_ledger.round()
-    }
-
-    pub fn validator_keys(&self) -> Vec<ValidatorInfo> {
-        self.validator_keys.payload().to_vec()
     }
 
     /// Finds the root (last committed block) and returns the root block, the QC to the root block
@@ -174,7 +146,6 @@ impl RootMetadata {
 /// The recovery data constructed from raw consensusdb data, it'll find the root value and
 /// blocks that need cleanup or return error if the input data is inconsistent.
 pub struct RecoveryData<T> {
-    ledger_recovery_data: LedgerRecoveryData,
     // The last vote message sent by this validator.
     last_vote: Option<Vote>,
     root: RootInfo<T>,
@@ -226,7 +197,6 @@ impl<T: Payload> RecoveryData<T> {
         ));
         let epoch = root.0.epoch();
         Ok(RecoveryData {
-            ledger_recovery_data,
             last_vote: match last_vote {
                 Some(v) if v.epoch() == epoch => Some(v),
                 _ => None,
@@ -241,10 +211,6 @@ impl<T: Payload> RecoveryData<T> {
                 _ => None,
             },
         })
-    }
-
-    pub fn epoch_info(&self) -> EpochInfo {
-        self.ledger_recovery_data.epoch_info()
     }
 
     pub fn root_block(&self) -> &Block<T> {
@@ -272,10 +238,6 @@ impl<T: Payload> RecoveryData<T> {
 
     pub fn highest_timeout_certificate(&self) -> Option<TimeoutCertificate> {
         self.highest_timeout_certificate.clone()
-    }
-
-    pub fn validator_keys(&self) -> Vec<ValidatorInfo> {
-        self.ledger_recovery_data.validator_keys()
     }
 
     fn find_blocks_to_prune(
@@ -345,10 +307,7 @@ impl<T: Payload> PersistentLivenessStorage<T> for StorageWriteProxy {
             .expect("unable to read ledger info from storage")
             .expect("startup info is None");
 
-        LedgerRecoveryData::new(
-            startup_info.latest_ledger_info.ledger_info().clone(),
-            startup_info.get_validator_set().clone(),
-        )
+        LedgerRecoveryData::new(startup_info.latest_ledger_info.ledger_info().clone())
     }
 
     fn start(&self) -> LivenessStorageData<T> {
@@ -387,11 +346,8 @@ impl<T: Payload> PersistentLivenessStorage<T> for StorageWriteProxy {
             .get_startup_info()
             .expect("unable to read ledger info from storage")
             .expect("startup info is None");
-        let validator_set = startup_info.get_validator_set().clone();
-        let ledger_recovery_data = LedgerRecoveryData::new(
-            startup_info.latest_ledger_info.ledger_info().clone(),
-            validator_set,
-        );
+        let ledger_recovery_data =
+            LedgerRecoveryData::new(startup_info.latest_ledger_info.ledger_info().clone());
         let frozen_root_hashes = startup_info
             .committed_tree_state
             .ledger_frozen_subtree_hashes

--- a/consensus/src/chained_bft/test_utils/mock_storage.rs
+++ b/consensus/src/chained_bft/test_utils/mock_storage.rs
@@ -86,10 +86,7 @@ impl<T: Payload> MockStorage<T> {
     }
 
     pub fn get_ledger_recovery_data(&self) -> LedgerRecoveryData {
-        LedgerRecoveryData::new(
-            self.storage_ledger.lock().unwrap().clone(),
-            self.shared_storage.validator_set.clone(),
-        )
+        LedgerRecoveryData::new(self.storage_ledger.lock().unwrap().clone())
     }
 
     pub fn try_start(&self) -> Result<RecoveryData<T>> {
@@ -263,7 +260,7 @@ impl<T: Payload> PersistentLivenessStorage<T> for EmptyStorage<T> {
     }
 
     fn recover_from_ledger(&self) -> LedgerRecoveryData {
-        LedgerRecoveryData::new(LedgerInfo::mock_genesis(), ValidatorSet::new(vec![]))
+        LedgerRecoveryData::new(LedgerInfo::mock_genesis())
     }
 
     fn start(&self) -> LivenessStorageData<T> {

--- a/consensus/src/chained_bft/test_utils/mock_storage.rs
+++ b/consensus/src/chained_bft/test_utils/mock_storage.rs
@@ -81,6 +81,10 @@ impl<T: Payload> MockStorage<T> {
         }
     }
 
+    pub fn get_validator_set(&self) -> &ValidatorSet {
+        &self.shared_storage.validator_set
+    }
+
     pub fn get_ledger_recovery_data(&self) -> LedgerRecoveryData {
         LedgerRecoveryData::new(
             self.storage_ledger.lock().unwrap().clone(),

--- a/state-synchronizer/src/synchronizer.rs
+++ b/state-synchronizer/src/synchronizer.rs
@@ -44,8 +44,20 @@ impl StateSynchronizer {
         config: &NodeConfig,
         reconfig_event_subscriptions: Vec<ReconfigSubscription>,
     ) -> Self {
-        let executor_proxy = ExecutorProxy::new(executor, config, reconfig_event_subscriptions);
+        let mut runtime = Builder::new()
+            .thread_name("state-sync-")
+            .threaded_scheduler()
+            .enable_all()
+            .build()
+            .expect("[state synchronizer] failed to create runtime");
+
+        let executor_proxy = runtime.block_on(ExecutorProxy::new(
+            executor,
+            config,
+            reconfig_event_subscriptions,
+        ));
         Self::bootstrap_with_executor_proxy(
+            runtime,
             network,
             state_sync_to_mempool_sender,
             config.base.role,
@@ -56,30 +68,19 @@ impl StateSynchronizer {
     }
 
     pub fn bootstrap_with_executor_proxy<E: ExecutorProxyTrait + 'static>(
+        mut runtime: Runtime,
         network: Vec<(StateSynchronizerSender, StateSynchronizerEvents)>,
         state_sync_to_mempool_sender: mpsc::Sender<CommitNotification>,
         role: RoleType,
         waypoint: Option<Waypoint>,
         state_sync_config: &StateSyncConfig,
-        mut executor_proxy: E,
+        executor_proxy: E,
     ) -> Self {
-        let mut runtime = Builder::new()
-            .thread_name("state-sync-")
-            .threaded_scheduler()
-            .enable_all()
-            .build()
-            .expect("[state synchronizer] failed to create runtime");
-
         let (coordinator_sender, coordinator_receiver) = mpsc::unbounded();
 
         let initial_state = runtime
             .block_on(executor_proxy.get_local_storage_state())
             .expect("[state sync] Start failure: cannot sync with storage.");
-
-        // initial read of on-chain configs
-        runtime
-            .block_on(executor_proxy.load_on_chain_configs())
-            .expect("[state sync] Failed initial read of on-chain configs");
 
         let coordinator = SyncCoordinator::new(
             coordinator_receiver,

--- a/state-synchronizer/src/tests/integration_tests.rs
+++ b/state-synchronizer/src/tests/integration_tests.rs
@@ -293,6 +293,7 @@ impl SynchronizerEnv {
         )));
         let (mempool_channel, mempool_requests) = futures::channel::mpsc::channel(1_024);
         let synchronizer = StateSynchronizer::bootstrap_with_executor_proxy(
+            Runtime::new().unwrap(),
             vec![(sender, events)],
             mempool_channel,
             role,

--- a/state-synchronizer/src/tests/on_chain_config_tests.rs
+++ b/state-synchronizer/src/tests/on_chain_config_tests.rs
@@ -38,7 +38,11 @@ fn test_on_chain_config_pub_sub() {
     let (mut config, genesis_key) = config_builder::test_config();
     let (_storage_server_handle, executor) = create_storage_service_and_executor(&config);
     let executor = Arc::new(Mutex::new(executor));
-    let mut executor_proxy = ExecutorProxy::new(executor.clone(), &config, vec![subscription]);
+    let mut executor_proxy = rt.block_on(ExecutorProxy::new(
+        executor.clone(),
+        &config,
+        vec![subscription],
+    ));
 
     // start state sync with initial loading of on-chain configs
     rt.block_on(executor_proxy.load_on_chain_configs())

--- a/state-synchronizer/src/tests/on_chain_config_tests.rs
+++ b/state-synchronizer/src/tests/on_chain_config_tests.rs
@@ -44,6 +44,14 @@ fn test_on_chain_config_pub_sub() {
         vec![subscription],
     ));
 
+    assert!(
+        reconfig_receiver
+            .select_next_some()
+            .now_or_never()
+            .is_some(),
+        "expect initial config notification",
+    );
+
     // start state sync with initial loading of on-chain configs
     rt.block_on(executor_proxy.load_on_chain_configs())
         .expect("failed to load on-chain configs");

--- a/types/src/on_chain_config/mod.rs
+++ b/types/src/on_chain_config/mod.rs
@@ -48,12 +48,17 @@ pub const ON_CHAIN_CONFIG_REGISTRY: &[ConfigID] = &[
 
 #[derive(Clone, Debug, PartialEq)]
 pub struct OnChainConfigPayload {
+    epoch: u64,
     configs: Arc<HashMap<ConfigID, Vec<u8>>>,
 }
 
 impl OnChainConfigPayload {
-    pub fn new(configs: Arc<HashMap<ConfigID, Vec<u8>>>) -> Self {
-        Self { configs }
+    pub fn new(epoch: u64, configs: Arc<HashMap<ConfigID, Vec<u8>>>) -> Self {
+        Self { epoch, configs }
+    }
+
+    pub fn epoch(&self) -> u64 {
+        self.epoch
     }
 
     pub fn get<T: OnChainConfig>(&self) -> Result<T> {
@@ -62,6 +67,10 @@ impl OnChainConfigPayload {
             .get(&T::CONFIG_ID)
             .ok_or_else(|| format_err!("[on-chain cfg] config not in payload"))?;
         T::deserialize_into_config(bytes)
+    }
+
+    pub fn configs(&self) -> &HashMap<ConfigID, Vec<u8>> {
+        &self.configs
     }
 }
 
@@ -140,6 +149,9 @@ pub struct ConfigurationResource {
 }
 
 impl ConfigurationResource {
+    pub fn epoch(&self) -> u64 {
+        self.epoch
+    }
     pub fn last_reconfiguration_time(&self) -> u64 {
         self.last_reconfiguration_time
     }


### PR DESCRIPTION
<!--
Thank you for sending a PR. We appreciate you spending time to help improve the Libra project.

The project is undergoing daily changes. Pull Requests will be reviewed and responded to as time permits.
-->

## Motivation

Instead of using RecoveryData, this PR uses OnChainConfigPayload to
bootstrap processor in epoch_mananger.

Also this PR adds an initial publish upon state synchronizer starts to
unify the flow.

Have to use the ugly Arc<Mutex<Option<Arc<_>>>> for test purpose because
now EventProcessor only starts when received reconfig_events, will
revisit the tests later.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?

Y

## Test Plan

Existing tests.

## Related PRs

(If this PR adds or changes functionality, please take some time to update the docs at https://github.com/libra/website, and link to your PR here.)
