### PR TITLE
[cli] add consistency assertions for client_proxy commands

### DIFF
--- a/client/cli/src/client_proxy.rs
+++ b/client/cli/src/client_proxy.rs
@@ -338,6 +338,11 @@ impl ClientProxy {
         is_blocking: bool,
     ) -> Result<()> {
         ensure!(
+            space_delim_strings[0] == "enable_custom_script",
+            "inconsistent command '{}' for enable_custom_script",
+            space_delim_strings[0]
+        );
+        ensure!(
             space_delim_strings.len() == 1,
             "Invalid number of arguments for setting publishing option"
         );
@@ -358,6 +363,11 @@ impl ClientProxy {
         space_delim_strings: &[&str],
         is_blocking: bool,
     ) -> Result<()> {
+        ensure!(
+            space_delim_strings[0] == "disable_custom_script",
+            "inconsistent command '{}' for disable_custom_script",
+            space_delim_strings[0]
+        );
         ensure!(
             space_delim_strings.len() == 1,
             "Invalid number of arguments for setting publishing option"
@@ -380,6 +390,11 @@ impl ClientProxy {
         is_blocking: bool,
     ) -> Result<()> {
         ensure!(
+            space_delim_strings[0] == "remove_validator",
+            "inconsistent command '{}' for remove_validator",
+            space_delim_strings[0]
+        );
+        ensure!(
             space_delim_strings.len() == 2,
             "Invalid number of arguments for removing validator"
         );
@@ -396,6 +411,11 @@ impl ClientProxy {
 
     /// Add a new validator.
     pub fn add_validator(&mut self, space_delim_strings: &[&str], is_blocking: bool) -> Result<()> {
+        ensure!(
+            space_delim_strings[0] == "add_validator",
+            "inconsistent command '{}' for add_validator",
+            space_delim_strings[0]
+        );
         ensure!(
             space_delim_strings.len() == 2,
             "Invalid number of arguments for adding validator"
@@ -417,6 +437,11 @@ impl ClientProxy {
         space_delim_strings: &[&str],
         is_blocking: bool,
     ) -> Result<()> {
+        ensure!(
+            space_delim_strings[0] == "register_validator",
+            "inconsistent command '{}' for register_validator",
+            space_delim_strings[0]
+        );
         ensure!(
             space_delim_strings.len() == 9,
             "Invalid number of arguments for registering validator"
@@ -631,6 +656,11 @@ impl ClientProxy {
 
     /// Compile move program
     pub fn compile_program(&mut self, space_delim_strings: &[&str]) -> Result<String> {
+        ensure!(
+            space_delim_strings[0] == "compile",
+            "inconsistent command '{}' for compile_program",
+            space_delim_strings[0]
+        );
         let (address, _) = self.get_account_address_from_parameter(space_delim_strings[1])?;
         let file_path = space_delim_strings[2];
         let is_module = match space_delim_strings[3] {
@@ -753,6 +783,11 @@ impl ClientProxy {
 
     /// Publish move module
     pub fn publish_module(&mut self, space_delim_strings: &[&str]) -> Result<()> {
+        ensure!(
+            space_delim_strings[0] == "publish",
+            "inconsistent command '{}' for publish_module",
+            space_delim_strings[0]
+        );
         let module_bytes = fs::read(space_delim_strings[2])?;
         self.submit_program(
             space_delim_strings,
@@ -762,6 +797,11 @@ impl ClientProxy {
 
     /// Execute custom script
     pub fn execute_script(&mut self, space_delim_strings: &[&str]) -> Result<()> {
+        ensure!(
+            space_delim_strings[0] == "execute",
+            "inconsistent command '{}' for execute_script",
+            space_delim_strings[0]
+        );
         let script_bytes = fs::read(space_delim_strings[2])?;
         let arguments: Vec<_> = space_delim_strings[3..]
             .iter()

--- a/testsuite/tests/libratest/smoke_test.rs
+++ b/testsuite/tests/libratest/smoke_test.rs
@@ -251,7 +251,7 @@ fn test_execute_custom_module_and_script() {
     let script_path = workspace_builder::workspace_root()
         .join("testsuite/tests/libratest/dev_modules/script.mvir");
     let unwrapped_script_path = script_path.to_str().unwrap();
-    let script_params = &["execute", "0", unwrapped_script_path, "script"];
+    let script_params = &["compile", "0", unwrapped_script_path, "script"];
     let script_compiled_path = client_proxy.compile_program(script_params).unwrap();
     let formatted_recipient_address = format!("0x{}", recipient_address);
 
@@ -952,7 +952,7 @@ fn test_e2e_modify_publishing_option() {
     let script_path = workspace_builder::workspace_root()
         .join("testsuite/tests/libratest/dev_modules/test_script.mvir");
     let unwrapped_script_path = script_path.to_str().unwrap();
-    let script_params = &["execute", "0", unwrapped_script_path, "script"];
+    let script_params = &["compile", "0", unwrapped_script_path, "script"];
     let script_compiled_path = client_proxy.compile_program(script_params).unwrap();
 
     // Initially publishing option was set to CustomScript, this transaction should be executed.
@@ -969,7 +969,7 @@ fn test_e2e_modify_publishing_option() {
     );
 
     client_proxy
-        .disable_custom_script(&["disallow_custom_script"], true)
+        .disable_custom_script(&["disable_custom_script"], true)
         .unwrap();
 
     // mint another 10 coins after restart
@@ -1075,7 +1075,7 @@ fn test_malformed_script() {
     let script_path = workspace_builder::workspace_root()
         .join("testsuite/tests/libratest/dev_modules/test_script.mvir");
     let unwrapped_script_path = script_path.to_str().unwrap();
-    let script_params = &["execute", "0", unwrapped_script_path, "script"];
+    let script_params = &["compile", "0", unwrapped_script_path, "script"];
     let script_compiled_path = client_proxy.compile_program(script_params).unwrap();
 
     // the script expects two arguments. Passing only one in the test, which will cause a failure.


### PR DESCRIPTION
When the client_proxy commands are dispatched through the DevCommand struct, the first argument determines which command is executed, but when the commands are invoked directly, that first argument is ignored. I noticed several cases where the command argument was incorrect and was confused for a while. This adds assertions to check that the command argument matches the command being executed and fixes the places that were inconsistent.

## Motivation

Fixing inconsistencies and avoiding confusion

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

Ran the tests