### PR TITLE
[language] save a copy of the stdlib source files when staging

### DIFF
--- a/language/stdlib/src/main.rs
+++ b/language/stdlib/src/main.rs
@@ -9,18 +9,28 @@ use std::{
     path::{Path, PathBuf},
 };
 use stdlib::{
-    build_stdlib, compile_script, filter_move_files, STAGED_EXTENSION, STAGED_OUTPUT_PATH,
-    STAGED_STDLIB_NAME, TRANSACTION_SCRIPTS,
+    build_stdlib, compile_script, filter_move_files, stdlib_files, STAGED_EXTENSION,
+    STAGED_OUTPUT_PATH, STAGED_STDLIB_NAME, TRANSACTION_SCRIPTS,
 };
 
-// Generates the staged stdlib and transaction scripts. Until this is run changes to the source
-// modules/scripts, and changes in the Move compiler will not be reflected in the stdlib used for
+// Generates the staged stdlib and transaction scripts. Until this is run, changes to the source
+// modules/scripts and changes in the Move compiler will not be reflected in the stdlib used for
 // genesis, and everywhere else across the code-base unless otherwise specified.
 fn main() {
     let mut scripts_path = PathBuf::from(STAGED_OUTPUT_PATH);
     scripts_path.push(TRANSACTION_SCRIPTS);
 
     std::fs::create_dir_all(&scripts_path).unwrap();
+
+    // Save copies of the module source files
+    let mut source_dir = PathBuf::from(STAGED_OUTPUT_PATH);
+    source_dir.push("src");
+    std::fs::create_dir_all(&source_dir).unwrap();
+    for file in &stdlib_files() {
+        let orig_file = PathBuf::from(file);
+        let copied_file = source_dir.join(orig_file.file_name().unwrap());
+        std::fs::copy(orig_file, copied_file).unwrap();
+    }
 
     // Write the stdlib blob
     let mut module_path = PathBuf::from(STAGED_OUTPUT_PATH);

--- a/language/stdlib/staged/src/approved_payment.move
+++ b/language/stdlib/staged/src/approved_payment.move
@@ -1,0 +1,97 @@
+// Module that allows a payee to approve payments with a cryptographic signature. The basic flow is:
+// (1) Payer sends `metadata` to the payee
+// (2) Payee signs `metadata` and sends 64 byte signature back to the payer
+// (3) Payer sends an approved payment to the payee by sending a transaction invoking `deposit`
+//     with payment metadata + signature. The transaction will abort if the signature check fails.
+// Note: approved payments are an accounting convenience/a courtesy mechansim for the payee, *not*
+// a hurdle that must be cleared for all payments to the payee. In addition, approved payments do
+// not have replay protection.
+address 0x0:
+module ApprovedPayment {
+    use 0x0::Libra;
+    use 0x0::LibraAccount;
+    use 0x0::Signature;
+    use 0x0::Transaction;
+    use 0x0::Vector;
+
+    // A resource to be published under the payee's account
+    resource struct T {
+        // 32 byte single Ed25519 public key whose counterpart must be used to sign the payment
+        // metadata. Note that this is different (and simpler) than the `authentication_key` used in
+        // LibraAccount::T, which is a hash of a public key + signature scheme identifier.
+        public_key: vector<u8>,
+        // TODO: events?
+    }
+
+    // Deposit `coin` in `payee`'s account if the `signature` on the payment metadata matches the
+    // public key stored in the `approved_payment` resource
+    public fun deposit<Token>(
+        approved_payment: &T,
+        payee: address,
+        coin: Libra::T<Token>,
+        metadata: vector<u8>,
+        signature: vector<u8>
+    ) {
+        // Sanity check of signature validity
+        Transaction::assert(Vector::length(&signature) == 64, 9001); // TODO: proper error code
+        // Cryptographic check of signature validity
+        Transaction::assert(
+            Signature::ed25519_verify(
+                signature,
+                *&approved_payment.public_key,
+                copy metadata
+            ),
+            9002, // TODO: proper error code
+        );
+        LibraAccount::deposit_with_metadata<Token>(payee, coin, metadata)
+    }
+
+    // Wrapper of `deposit` that withdraw's from the sender's balance and uses the top-level
+    // `ApprovedPayment::T` resource under the payee account.
+    public fun deposit_to_payee<Token>(
+        payee: address,
+        amount: u64,
+        metadata: vector<u8>,
+        signature: vector<u8>
+    ) acquires T {
+        deposit<Token>(
+            borrow_global<T>(payee),
+            payee,
+            LibraAccount::withdraw_from_sender<Token>(amount),
+            metadata,
+            signature
+        )
+    }
+
+    // Rotate the key used to sign approved payments. This will invalidate any approved payments
+    // that are currently in flight
+    public fun rotate_key(approved_payment: &mut T, new_public_key: vector<u8>) {
+        approved_payment.public_key = new_public_key
+    }
+
+    // Wrapper of `rotate_key` that rotates the sender's key
+    public fun rotate_sender_key(new_public_key: vector<u8>) acquires T {
+        // Sanity check for key validity
+        Transaction::assert(Vector::length(&new_public_key) == 32, 9003); // TODO: proper error code
+        rotate_key(borrow_global_mut<T>(Transaction::sender()), new_public_key)
+    }
+
+    // Publish an ApprovedPayment::T resource under the sender's account with approval key
+    // `public_key`
+    public fun publish(public_key: vector<u8>) {
+        // Sanity check for key validity
+        Transaction::assert(Vector::length(&public_key) == 32, 9003); // TODO: proper error code
+        move_to_sender(T { public_key })
+    }
+
+    // Remove and destroy the ApprovedPayment::T resource under the sender's account
+    public fun unpublish_from_sender() acquires T {
+        let T { public_key: _ } = move_from<T>(Transaction::sender())
+    }
+
+    // Return true if an ApprovedPayment::T resource exists under `addr`
+    public fun exists(addr: address): bool {
+        ::exists<T>(addr)
+    }
+
+}

--- a/language/stdlib/staged/src/association.move
+++ b/language/stdlib/staged/src/association.move
@@ -1,0 +1,111 @@
+// Implements logic for registering addresses as association addresses, and
+// determining if the sending account is an association account.
+// Errors:
+// 1000 -> INVALID_GENESIS_ADDR
+// 1001 -> INSUFFICIENT_PRIVILEGES
+// 1002 -> NOT_AN_ASSOCIATION_ACCOUNT
+// 1003 -> ACCOUNT_DOES_NOT_HAVE_PRIVILEGE
+// 1004 -> ACCOUNT_DOES_NOT_HAVE_PRIVILEGE_RESOURCE
+address 0x0:
+
+module Association {
+    use 0x0::Transaction;
+
+    // The root account privilege. This is created at genesis and has
+    // special privileges (e.g. removing an account as an association
+    // account). It cannot be removed.
+    resource struct Root { }
+
+    // There are certain association capabilities that are more
+    // privileged than other association operations. This resource with the
+    // type representing that privilege is published under the privileged
+    // account.
+    resource struct PrivilegedCapability<Privilege> { is_certified: bool }
+
+    // A type tag to mark that this account is an association account.
+    // It cannot be used for more specific/privileged operations.
+    struct T { }
+
+    // Initialization is called in genesis. It publishes the root resource
+    // under the root_address() address, marks it as a normal
+    // association account.
+    public fun initialize() {
+        let sender = Transaction::sender();
+        Transaction::assert(sender == root_address(), 1000);
+        move_to_sender(Root{ });
+        move_to_sender(PrivilegedCapability<T>{ is_certified: true });
+    }
+
+    // Publish a specific privilege under the sending account.
+    public fun apply_for_privilege<Privilege>() {
+        move_to_sender(PrivilegedCapability<Privilege>{ is_certified: false });
+    }
+
+    // Certify the privileged capability published under for_addr.
+    public fun grant_privilege<Privilege>(for_addr: address)
+    acquires PrivilegedCapability {
+        assert_sender_is_root();
+        Transaction::assert(exists<PrivilegedCapability<Privilege>>(for_addr), 1003);
+        borrow_global_mut<PrivilegedCapability<Privilege>>(for_addr).is_certified = true;
+    }
+
+    // Return whether the `addr` has the specified `Privilege`.
+    public fun has_privilege<Privilege>(addr: address): bool
+    acquires PrivilegedCapability {
+        addr_is_association(addr) &&
+        exists<PrivilegedCapability<Privilege>>(addr) &&
+        borrow_global<PrivilegedCapability<Privilege>>(addr).is_certified
+    }
+
+    // Remove the `Privilege` from the address at `addr`. The sender must
+    // be the root association account. The `Privilege` need not be
+    // certified.
+    public fun remove_privilege<Privilege>(addr: address)
+    acquires PrivilegedCapability {
+        assert_sender_is_root();
+        Transaction::assert(exists<PrivilegedCapability<Privilege>>(addr), 1004);
+        PrivilegedCapability<Privilege>{ is_certified: _ } = move_from<PrivilegedCapability<Privilege>>(addr);
+    }
+
+    // Publishes an Association::PrivilegedCapability<T> under the sending
+    // account.
+    public fun apply_for_association() {
+        apply_for_privilege<T>()
+    }
+
+    // Certifies the Association::PrivilegedCapability<T> resource that is
+    // published under `addr`.
+    public fun grant_association_address(addr: address)
+    acquires PrivilegedCapability {
+        grant_privilege<T>(addr)
+    }
+
+    // Assert that the sender is an association account.
+    public fun assert_sender_is_association()
+    acquires PrivilegedCapability {
+        assert_addr_is_association(Transaction::sender())
+    }
+
+    // Assert that the sender is the root association account.
+    public fun assert_sender_is_root() {
+        Transaction::assert(exists<Root>(Transaction::sender()), 1001);
+    }
+
+    // Return whether the account at `addr` is an association account.
+    public fun addr_is_association(addr: address): bool
+    acquires PrivilegedCapability {
+        exists<PrivilegedCapability<T>>(addr) &&
+            borrow_global<PrivilegedCapability<T>>(addr).is_certified
+    }
+
+    // The address at which the root account will be published.
+    public fun root_address(): address {
+        0xA550C18
+    }
+
+    // Assert that `addr` is an association account.
+    fun assert_addr_is_association(addr: address)
+    acquires PrivilegedCapability {
+        Transaction::assert(addr_is_association(addr), 1002);
+    }
+}

--- a/language/stdlib/staged/src/debug.move
+++ b/language/stdlib/staged/src/debug.move
@@ -1,0 +1,5 @@
+address 0x0:
+
+module Debug {
+    native public fun print<T>(x: &T);
+}

--- a/language/stdlib/staged/src/fixedpoint32.move
+++ b/language/stdlib/staged/src/fixedpoint32.move
@@ -1,0 +1,77 @@
+address 0x0:
+
+module FixedPoint32 {
+    use 0x0::Transaction;
+
+    // Define a fixed-point numeric type with 32 fractional bits.
+    // This is just a u64 integer but it is wrapped in a struct to
+    // make a unique type.
+    struct T { value: u64 }
+
+    // Multiply a u64 integer by a fixed-point number, truncating any
+    // fractional part of the product. This will abort if the product
+    // overflows.
+    public fun multiply_u64(num: u64, multiplier: T): u64 {
+        // The product of two 64 bit values has 128 bits, so perform the
+        // multiplication with u128 types and keep the full 128 bit product
+        // to avoid losing accuracy.
+        let unscaled_product = (num as u128) * (multiplier.value as u128);
+        // The unscaled product has 32 fractional bits (from the multiplier)
+        // so rescale it by shifting away the low bits.
+        let product = unscaled_product >> 32;
+        // Convert back to u64. If the multiplier is larger than 1.0,
+        // the value may be too large, which will cause the cast to fail
+        // with an arithmetic error.
+        (product as u64)
+    }
+
+    // Divide a u64 integer by a fixed-point number, truncating any
+    // fractional part of the quotient. This will abort if the divisor
+    // is zero or if the quotient overflows.
+    public fun divide_u64(num: u64, divisor: T): u64 {
+        // First convert to 128 bits and then shift left to
+        // add 32 fractional zero bits to the dividend.
+        let scaled_value = (num as u128) << 32;
+        // Divide and convert the quotient to 64 bits. If the divisor is zero,
+        // this will fail with a divide-by-zero error.
+        let quotient = scaled_value / (divisor.value as u128);
+        // Convert back to u64. If the divisor is less than 1.0,
+        // the value may be too large, which will cause the cast to fail
+        // with an arithmetic error.
+        (quotient as u64)
+    }
+
+    // Create a fixed-point value from a rational number specified by its
+    // numerator and denominator. This function is for convenience; it is also
+    // perfectly fine to create a fixed-point value by directly specifying the
+    // raw value. This will abort if the denominator is zero or if the ratio is
+    // not in the range 2^-32 .. 2^32-1.
+    public fun create_from_rational(numerator: u64, denominator: u64): T {
+        // Scale the numerator to have 64 fractional bits and the denominator
+        // to have 32 fractional bits, so that the quotient will have 32
+        // fractional bits.
+        let scaled_numerator = (numerator as u128) << 64;
+        let scaled_denominator = (denominator as u128) << 32;
+        // If the denominator is zero, this will fail with a divide-by-zero
+        // error.
+        let quotient = scaled_numerator / scaled_denominator;
+        // Check for underflow. Truncating to zero might be the desired result,
+        // but if you really want a ratio of zero, it is easy to create that
+        // from a raw value.
+        Transaction::assert(quotient != 0 || numerator == 0, 16);
+        // Return the quotient as a fixed-point number. The cast will fail
+        // with an arithmetic error if the number is too large.
+        T { value: (quotient as u64) }
+    }
+
+    public fun create_from_raw_value(value: u64): T {
+        T { value }
+    }
+
+    // Accessor for the raw u64 value. Other less common operations, such as
+    // adding or subtracting FixedPoint32 values, can be done using the raw
+    // values directly.
+    public fun get_raw_value(num: T): u64 {
+        num.value
+    }
+}

--- a/language/stdlib/staged/src/gas_schedule.move
+++ b/language/stdlib/staged/src/gas_schedule.move
@@ -1,0 +1,47 @@
+address 0x0:
+
+// The gas schedule keeps two separate schedules for the gas:
+// * The instruction_schedule: This holds the gas for each bytecode instruction.
+// * The native_schedule: This holds the gas for used (per-byte operated over) for each native
+//   function.
+// A couple notes:
+// 1. In the case that an instruction is deleted from the bytecode, that part of the cost schedule
+//    still needs to remain the same; once a slot in the table is taken by an instruction, that is its
+//    slot for the rest of time (since that instruction could already exist in a module on-chain).
+// 2. The initialization of the module will publish the instruction table to the association
+//    address, and will preload the vector with the gas schedule for instructions. The VM will then
+//    load this into memory at the startup of each block.
+module GasSchedule {
+    use 0x0::Vector;
+    use 0x0::Transaction;
+
+    // The gas cost for each instruction is represented using two amounts;
+    // one for the cpu, and the other for storage.
+    struct Cost {
+      cpu: u64,
+      storage: u64,
+    }
+
+    resource struct T {
+        instruction_schedule: vector<Cost>,
+        native_schedule: vector<Cost>,
+    }
+
+    // Initialize the table under the association account
+    fun initialize(gas_schedule: T) {
+        Transaction::assert(Transaction::sender() == 0xA550C18, 0);
+        move_to_sender<T>(gas_schedule);
+    }
+
+    public fun instruction_table_size(): u64 acquires T {
+        let table = borrow_global<T>(0xA550C18);
+        let instruction_table_len = Vector::length(&table.instruction_schedule);
+        instruction_table_len
+    }
+
+    public fun native_table_size(): u64 acquires T {
+        let table = borrow_global<T>(0xA550C18);
+        let native_table_len = Vector::length(&table.native_schedule);
+        native_table_len
+    }
+}

--- a/language/stdlib/staged/src/hash.move
+++ b/language/stdlib/staged/src/hash.move
@@ -1,0 +1,6 @@
+address 0x0:
+
+module Hash {
+    native public fun sha2_256(data: vector<u8>): vector<u8>;
+    native public fun sha3_256(data: vector<u8>): vector<u8>;
+}

--- a/language/stdlib/staged/src/lbr.move
+++ b/language/stdlib/staged/src/lbr.move
@@ -1,0 +1,13 @@
+address 0x0:
+
+module LBR {
+    use 0x0::Transaction;
+    use 0x0::Libra;
+
+    struct T { }
+
+    public fun initialize() {
+        Transaction::assert(Transaction::sender() == 0xA550C18, 0);
+        Libra::register<T>();
+    }
+}

--- a/language/stdlib/staged/src/lcs.move
+++ b/language/stdlib/staged/src/lcs.move
@@ -1,0 +1,10 @@
+// Utility for converting a Move value to its binary representation in LCS (Libra Canonical
+// Serialization). LCS is the binary encoding for Move resources and other non-module values
+// published on-chain. See https://github.com/libra/libra/tree/master/common/lcs for more
+// details on LCS (TODO: link to spec once we have one)
+
+address 0x0:
+module LCS {
+    // Return the binary representation of `v` in LCS (Libra Canonical Serialization) format
+    native public fun to_bytes<MoveValue>(v: &MoveValue): vector<u8>;
+}

--- a/language/stdlib/staged/src/libra.move
+++ b/language/stdlib/staged/src/libra.move
@@ -1,0 +1,257 @@
+address 0x0:
+
+module Libra {
+    use 0x0::Transaction;
+    use 0x0::Vector;
+
+    // A resource representing a fungible token
+    resource struct T<Token> {
+        // The value of the token. May be zero
+        value: u64,
+    }
+
+    // A singleton resource that grants access to `Libra::mint`. Only the Association has one.
+    resource struct MintCapability<Token> { }
+
+    resource struct Info<Token> {
+        // The sum of the values of all Libra::T resources in the system
+        total_value: u128,
+        // Value of funds that are in the process of being burned
+        preburn_value: u64,
+    }
+
+    // A holding area where funds that will subsequently be burned wait while their underyling
+    // assets are sold off-chain.
+    // This resource can only be created by the holder of the MintCapability. An account that
+    // contains this address has the authority to initiate a burn request. A burn request can be
+    // resolved by the holder of the MintCapability by either (1) burning the funds, or (2)
+    // returning the funds to the account that initiated the burn request.
+    // This design supports multiple preburn requests in flight at the same time, including multiple
+    // burn requests from the same account. However, burn requests from the same account must be
+    // resolved in FIFO order.
+    resource struct Preburn<Token> {
+        // Queue of pending burn requests
+        requests: vector<T<Token>>,
+        // Boolean that is true if the holder of the MintCapability has approved this account as a
+        // preburner
+        is_approved: bool,
+    }
+
+    public fun register<Token>() {
+        // Only callable by the Association address
+        Transaction::assert(Transaction::sender() == 0xA550C18, 1);
+        move_to_sender(MintCapability<Token>{ });
+        move_to_sender(Info<Token> { total_value: 0u128, preburn_value: 0 });
+    }
+
+    fun assert_is_registered<Token>() {
+        Transaction::assert(exists<Info<Token>>(0xA550C18), 12);
+    }
+
+    // Return `amount` coins.
+    // Fails if the sender does not have a published MintCapability.
+    public fun mint<Token>(amount: u64): T<Token> acquires Info, MintCapability {
+        mint_with_capability(amount, borrow_global<MintCapability<Token>>(Transaction::sender()))
+    }
+
+    // Burn the coins currently held in the preburn holding area under `preburn_address`.
+    // Fails if the sender does not have a published MintCapability.
+    public fun burn<Token>(
+        preburn_address: address
+    ) acquires Info, MintCapability, Preburn {
+        burn_with_capability(
+            preburn_address,
+            borrow_global<MintCapability<Token>>(Transaction::sender())
+        )
+    }
+
+    // Cancel the oldest burn request from `preburn_address`
+    // Fails if the sender does not have a published MintCapability.
+    public fun cancel_burn<Token>(
+        preburn_address: address
+    ): T<Token> acquires Info, MintCapability, Preburn {
+        cancel_burn_with_capability(
+            preburn_address,
+            borrow_global<MintCapability<Token>>(Transaction::sender())
+        )
+    }
+
+    // Create a new Preburn resource
+    public fun new_preburn<Token>(): Preburn<Token> {
+        assert_is_registered<Token>();
+        Preburn<Token> { requests: Vector::empty(), is_approved: false, }
+    }
+
+    // Mint a new Libra::T worth `value`. The caller must have a reference to a MintCapability.
+    // Only the Association account can acquire such a reference, and it can do so only via
+    // `borrow_sender_mint_capability`
+    public fun mint_with_capability<Token>(
+        value: u64,
+        _capability: &MintCapability<Token>
+    ): T<Token> acquires Info {
+        assert_is_registered<Token>();
+        // TODO: temporary measure for testnet only: limit minting to 1B Libra at a time.
+        // this is to prevent the market cap's total value from hitting u64_max due to excessive
+        // minting. This will not be a problem in the production Libra system because coins will
+        // be backed with real-world assets, and thus minting will be correspondingly rarer.
+        // * 1000000 here because the unit is microlibra
+        Transaction::assert(value <= 1000000000 * 1000000, 11);
+        // update market cap resource to reflect minting
+        let market_cap = borrow_global_mut<Info<Token>>(0xA550C18);
+        market_cap.total_value = market_cap.total_value + (value as u128);
+
+        T<Token> { value }
+    }
+
+    // Send coin to the preburn holding area `preburn_ref`, where it will wait to be burned.
+    public fun preburn<Token>(
+        preburn_ref: &mut Preburn<Token>,
+        coin: T<Token>
+    ) acquires Info {
+        // TODO: bring this back once we can automate approvals in testnet
+        // Transaction::assert(preburn_ref.is_approved, 13);
+        let coin_value = value(&coin);
+        Vector::push_back(
+            &mut preburn_ref.requests,
+            coin
+        );
+        let market_cap = borrow_global_mut<Info<Token>>(0xA550C18);
+        market_cap.preburn_value = market_cap.preburn_value + coin_value
+    }
+
+    // Send coin to the preburn holding area, where it will wait to be burned.
+    // Fails if the sender does not have a published Preburn resource
+    public fun preburn_to_sender<Token>(coin: T<Token>) acquires Info, Preburn {
+        preburn(borrow_global_mut<Preburn<Token>>(Transaction::sender()), coin)
+    }
+
+    // Permanently remove the coins held in the `Preburn` resource stored at `preburn_address` and
+    // update the market cap accordingly. If there are multiple preburn requests in progress, this
+    // will remove the oldest one.
+    // Can only be invoked by the holder of the MintCapability. Fails if the there is no `Preburn`
+    // resource under `preburn_address` or has one with no pending burn requests.
+    public fun burn_with_capability<Token>(
+        preburn_address: address,
+        _capability: &MintCapability<Token>
+    ) acquires Info, Preburn {
+        // destroy the coin at the head of the preburn queue
+        let preburn = borrow_global_mut<Preburn<Token>>(preburn_address);
+        let T { value } = Vector::remove(&mut preburn.requests, 0);
+        // update the market cap
+        let market_cap = borrow_global_mut<Info<Token>>(0xA550C18);
+        market_cap.total_value = market_cap.total_value - (value as u128);
+        market_cap.preburn_value = market_cap.preburn_value - value
+    }
+
+    // Cancel the burn request in the `Preburn` resource stored at `preburn_address` and
+    // return the coins to the caller.
+    // If there are multiple preburn requests in progress, this will cancel the oldest one.
+    // Can only be invoked by the holder of the MintCapability. Fails if the transaction sender
+    // does not have a published Preburn resource or has one with no pending burn requests.
+    public fun cancel_burn_with_capability<Token>(
+        preburn_address: address,
+        _capability: &MintCapability<Token>
+    ): T<Token> acquires Info, Preburn {
+        // destroy the coin at the head of the preburn queue
+        let preburn = borrow_global_mut<Preburn<Token>>(preburn_address);
+        let coin = Vector::remove(&mut preburn.requests, 0);
+        // update the market cap
+        let market_cap = borrow_global_mut<Info<Token>>(0xA550C18);
+        market_cap.preburn_value = market_cap.preburn_value - value(&coin);
+
+        coin
+    }
+
+    // Publish `preburn` under the sender's account
+    public fun publish_preburn<Token>(preburn: Preburn<Token>) {
+        move_to_sender(preburn)
+    }
+
+    // Remove and return the `Preburn` resource under the sender's account
+    public fun remove_preburn<Token>(): Preburn<Token> acquires Preburn {
+        move_from<Preburn<Token>>(Transaction::sender())
+    }
+
+    // Destroys the given preburn resource.
+    // Aborts if `requests` is non-empty
+    public fun destroy_preburn<Token>(preburn: Preburn<Token>) {
+        let Preburn { requests, is_approved: _ } = preburn;
+        Vector::destroy_empty(requests)
+    }
+
+    // Publish `capability` under the sender's account
+    public fun publish_mint_capability<Token>(capability: MintCapability<Token>) {
+        move_to_sender(capability)
+    }
+
+    // Remove and return the MintCapability from the sender's account. Fails if the sender does
+    // not have a published MintCapability
+    public fun remove_mint_capability<Token>(): MintCapability<Token> acquires MintCapability {
+        move_from<MintCapability<Token>>(Transaction::sender())
+    }
+
+    // Return the total value of all Libra in the system
+    public fun market_cap<Token>(): u128 acquires Info {
+        borrow_global<Info<Token>>(0xA550C18).total_value
+    }
+
+    // Return the total value of Libra to be burned
+    public fun preburn_value<Token>(): u64 acquires Info {
+        borrow_global<Info<Token>>(0xA550C18).preburn_value
+    }
+
+    // Create a new Libra::T with a value of 0
+    public fun zero<Token>(): T<Token> {
+        // prevent silly coin types (e.g., Libra<bool>) from being created
+        assert_is_registered<Token>();
+        T { value: 0 }
+    }
+
+    // Public accessor for the value of a coin
+    public fun value<Token>(coin_ref: &T<Token>): u64 {
+        coin_ref.value
+    }
+
+    // Splits the given coin into two and returns them both
+    // It leverages `withdraw` for any verifications of the values
+    public fun split<Token>(coin: T<Token>, amount: u64): (T<Token>, T<Token>) {
+        let other = withdraw(&mut coin, amount);
+        (coin, other)
+    }
+
+    // "Divides" the given coin into two, where original coin is modified in place
+    // The original coin will have value = original value - `value`
+    // The new coin will have a value = `value`
+    // Fails if the coins value is less than `value`
+    public fun withdraw<Token>(coin_ref: &mut T<Token>, value: u64): T<Token> {
+        // Check that `amount` is less than the coin's value
+        Transaction::assert(coin_ref.value >= value, 10);
+
+        // Split the coin
+        coin_ref.value = coin_ref.value - value;
+        T { value }
+    }
+
+    // Merges two coins and returns a new coin whose value is equal to the sum of the two inputs
+    public fun join<Token>(coin1: T<Token>, coin2: T<Token>): T<Token>  {
+        deposit(&mut coin1, coin2);
+        coin1
+    }
+
+    // "Merges" the two coins
+    // The coin passed in by reference will have a value equal to the sum of the two coins
+    // The `check` coin is consumed in the process
+    public fun deposit<Token>(coin_ref: &mut T<Token>, check: T<Token>) {
+        let T { value } = check;
+        coin_ref.value= coin_ref.value + value;
+    }
+
+    // Destroy a coin
+    // Fails if the value is non-zero
+    // The amount of Libra::T in the system is a tightly controlled property,
+    // so you cannot "burn" any non-zero amount of Libra::T
+    public fun destroy_zero<Token>(coin: T<Token>) {
+        let T<Token> { value } = coin;
+        Transaction::assert(value == 0, 11);
+    }
+}

--- a/language/stdlib/staged/src/libra_account.move
+++ b/language/stdlib/staged/src/libra_account.move
@@ -1,0 +1,546 @@
+address 0x0:
+
+// The module for the account resource that governs every Libra account
+module LibraAccount {
+    use 0x0::Hash;
+    use 0x0::LBR;
+    use 0x0::LCS;
+    use 0x0::Libra;
+    use 0x0::LibraTransactionTimeout;
+    use 0x0::Transaction;
+    use 0x0::Vector;
+
+    // Every Libra account has a LibraAccount::T resource
+    resource struct T {
+        // The current authentication key.
+        // This can be different than the key used to create the account
+        authentication_key: vector<u8>,
+        // If true, the authority to rotate the authentication key of this account resides elsewhere
+        delegated_key_rotation_capability: bool,
+        // If true, the authority to withdraw funds from this account resides elsewhere
+        delegated_withdrawal_capability: bool,
+        // Event handle for received event
+        received_events: EventHandle<ReceivedPaymentEvent>,
+        // Event handle for sent event
+        sent_events: EventHandle<SentPaymentEvent>,
+        // The current sequence number.
+        // Incremented by one each time a transaction is submitted
+        sequence_number: u64,
+        // Generator for event handles
+        event_generator: EventHandleGenerator,
+    }
+
+    // A resource that holds the coins stored in this account
+    resource struct Balance<Token> {
+        coin: Libra::T<Token>,
+    }
+
+    // The holder of WithdrawalCapability for account_address can withdraw Libra from
+    // account_address/LibraAccount::T/balance.
+    // There is at most one WithdrawalCapability in existence for a given address.
+    resource struct WithdrawalCapability {
+        account_address: address,
+    }
+
+    // The holder of KeyRotationCapability for account_address can rotate the authentication key for
+    // account_address (i.e., write to account_address/LibraAccount::T/authentication_key).
+    // There is at most one KeyRotationCapability in existence for a given address.
+    resource struct KeyRotationCapability {
+        account_address: address,
+    }
+
+    // Message for sent events
+    struct SentPaymentEvent {
+        // The amount of Libra::T<Token> sent
+        amount: u64,
+        // The address that was paid
+        payee: address,
+        // Metadata associated with the payment
+        metadata: vector<u8>,
+    }
+
+    // Message for received events
+    struct ReceivedPaymentEvent {
+        // The amount of Libra::T<Token> received
+        amount: u64,
+        // The address that sent the coin
+        payer: address,
+        // Metadata associated with the payment
+        metadata: vector<u8>,
+    }
+
+    /// Events
+    // A resource representing the counter used to generate uniqueness under each account. There won't be destructor for
+    // this resource to guarantee the uniqueness of the generated handle.
+    resource struct EventHandleGenerator {
+        // A monotonically increasing counter
+        counter: u64,
+    }
+
+    // A handle for an event such that:
+    // 1. Other modules can emit events to this handle.
+    // 2. Storage can use this handle to prove the total number of events that happened in the past.
+    resource struct EventHandle<T: copyable> {
+        // Total number of events emitted to this event stream.
+        counter: u64,
+        // A globally unique ID for this event stream.
+        guid: vector<u8>,
+    }
+
+    // Deposits the `to_deposit` coin into the `payee`'s account balance
+    public fun deposit<Token>(payee: address, to_deposit: Libra::T<Token>) acquires T, Balance {
+        // Since we don't have vector<u8> literals in the source language at
+        // the moment.
+        deposit_with_metadata(payee, to_deposit, x"")
+    }
+
+    // Deposits the `to_deposit` coin into the sender's account balance
+    public fun deposit_to_sender<Token>(to_deposit: Libra::T<Token>) acquires T, Balance {
+        deposit(Transaction::sender(), to_deposit)
+    }
+
+    // Deposits the `to_deposit` coin into the `payee`'s account balance with the attached `metadata`
+    public fun deposit_with_metadata<Token>(
+        payee: address,
+        to_deposit: Libra::T<Token>,
+        metadata: vector<u8>
+    ) acquires T, Balance {
+        deposit_with_sender_and_metadata(
+            payee,
+            Transaction::sender(),
+            to_deposit,
+            metadata
+        );
+    }
+
+    // Deposits the `to_deposit` coin into the `payee`'s account balance with the attached `metadata` and
+    // sender address
+    fun deposit_with_sender_and_metadata<Token>(
+        payee: address,
+        sender: address,
+        to_deposit: Libra::T<Token>,
+        metadata: vector<u8>
+    ) acquires T, Balance {
+        // Check that the `to_deposit` coin is non-zero
+        let deposit_value = Libra::value(&to_deposit);
+        Transaction::assert(deposit_value > 0, 7);
+
+        // Load the sender's account
+        let sender_account_ref = borrow_global_mut<T>(sender);
+        // Log a sent event
+        emit_event<SentPaymentEvent>(
+            &mut sender_account_ref.sent_events,
+            SentPaymentEvent {
+                amount: deposit_value,
+                payee: payee,
+                metadata: *&metadata
+            },
+        );
+
+        // Load the payee's account
+        let payee_account_ref = borrow_global_mut<T>(payee);
+        let payee_balance = borrow_global_mut<Balance<Token>>(payee);
+        // Deposit the `to_deposit` coin
+        Libra::deposit(&mut payee_balance.coin, to_deposit);
+        // Log a received event
+        emit_event<ReceivedPaymentEvent>(
+            &mut payee_account_ref.received_events,
+            ReceivedPaymentEvent {
+                amount: deposit_value,
+                payer: sender,
+                metadata: metadata
+            }
+        );
+    }
+
+    // mint_to_address can only be called by accounts with MintCapability (see Libra)
+    // and those accounts will be charged for gas. If those accounts don't have enough gas to pay
+    // for the transaction cost they will fail minting.
+    // However those account can also mint to themselves so that is a decent workaround
+    public fun mint_to_address(
+        payee: address,
+        auth_key_prefix: vector<u8>,
+        amount: u64
+    ) acquires T, Balance {
+        // Create an account if it does not exist
+        if (!exists(payee)) {
+            create_account(payee, auth_key_prefix);
+        };
+
+        // Mint and deposit the coin
+        deposit(payee, Libra::mint<LBR::T>(amount));
+    }
+
+    // Cancel the oldest burn request from `preburn_address` and return the funds.
+    // Fails if the sender does not have a published MintCapability.
+    public fun cancel_burn<Token>(
+        preburn_address: address,
+    ) acquires T, Balance {
+        let to_return = Libra::cancel_burn<Token>(preburn_address);
+        deposit(preburn_address, to_return)
+    }
+
+    // Helper to withdraw `amount` from the given account balance and return the withdrawn Libra::T<Token>
+    fun withdraw_from_balance<Token>(balance: &mut Balance<Token>, amount: u64): Libra::T<Token> {
+        Libra::withdraw(&mut balance.coin, amount)
+    }
+
+    // Withdraw `amount` Libra::T<Token> from the transaction sender's account balance
+    public fun withdraw_from_sender<Token>(amount: u64): Libra::T<Token> acquires T, Balance {
+        let sender_account = borrow_global_mut<T>(Transaction::sender());
+        let sender_balance = borrow_global_mut<Balance<Token>>(Transaction::sender());
+        // The sender has delegated the privilege to withdraw from her account elsewhere--abort.
+        Transaction::assert(!sender_account.delegated_withdrawal_capability, 11);
+        // The sender has retained her withdrawal privileges--proceed.
+        withdraw_from_balance<Token>(sender_balance, amount)
+    }
+
+    // Withdraw `amount` Libra::T<Token> from the account under cap.account_address
+    public fun withdraw_with_capability<Token>(
+        cap: &WithdrawalCapability, amount: u64
+    ): Libra::T<Token> acquires Balance {
+        let balance = borrow_global_mut<Balance<Token>>(cap.account_address);
+        withdraw_from_balance<Token>(balance , amount)
+    }
+
+    // Return a unique capability granting permission to withdraw from the sender's account balance.
+    public fun extract_sender_withdrawal_capability(): WithdrawalCapability acquires T {
+        let sender = Transaction::sender();
+        let sender_account = borrow_global_mut<T>(sender);
+
+        // Abort if we already extracted the unique withdrawal capability for this account.
+        Transaction::assert(!sender_account.delegated_withdrawal_capability, 11);
+
+        // Ensure the uniqueness of the capability
+        sender_account.delegated_withdrawal_capability = true;
+        WithdrawalCapability { account_address: sender }
+    }
+
+    // Return the withdrawal capability to the account it originally came from
+    public fun restore_withdrawal_capability(cap: WithdrawalCapability) acquires T {
+        // Destroy the capability
+        let WithdrawalCapability { account_address } = cap;
+        let account = borrow_global_mut<T>(account_address);
+        // Update the flag for `account_address` to indicate that the capability has been restored.
+        // The account owner will now be able to call pay_from_sender, withdraw_from_sender, and
+        // extract_sender_withdrawal_capability again.
+        account.delegated_withdrawal_capability = false;
+    }
+
+    // Withdraws `amount` Libra::T<Token> using the passed in WithdrawalCapability, and deposits it
+    // into the `payee`'s account balance. Creates the `payee` account if it doesn't exist.
+    public fun pay_from_capability<Token>(
+        payee: address,
+        auth_key_prefix: vector<u8>,
+        cap: &WithdrawalCapability,
+        amount: u64,
+        metadata: vector<u8>
+    ) acquires T, Balance {
+        if (!exists(payee)) {
+            create_account(payee, auth_key_prefix);
+        };
+        deposit_with_sender_and_metadata<Token>(
+            payee,
+            *&cap.account_address,
+            withdraw_with_capability(cap, amount),
+            metadata,
+        );
+    }
+
+    // Withdraw `amount` Libra::T<Token> from the transaction sender's
+    // account balance and send the coin to the `payee` address with the
+    // attached `metadata` Creates the `payee` account if it does not exist
+    public fun pay_from_sender_with_metadata<Token>(
+        payee: address,
+        auth_key_prefix: vector<u8>,
+        amount: u64,
+        metadata: vector<u8>
+    ) acquires T, Balance {
+        if (!exists(payee)) {
+            create_account(payee, auth_key_prefix);
+        };
+        deposit_with_metadata<Token>(
+            payee,
+            withdraw_from_sender(amount),
+            metadata
+        );
+    }
+
+    // Withdraw `amount` Libra::T<Token> from the transaction sender's
+    // account balance  and send the coin to the `payee` address
+    // Creates the `payee` account if it does not exist
+    public fun pay_from_sender<Token>(
+        payee: address,
+        auth_key_prefix: vector<u8>,
+        amount: u64
+    ) acquires T, Balance {
+        pay_from_sender_with_metadata<Token>(payee, auth_key_prefix, amount, x"");
+    }
+
+    fun rotate_authentication_key_for_account(account: &mut T, new_authentication_key: vector<u8>) {
+      // Don't allow rotating to clearly invalid key
+      Transaction::assert(Vector::length(&new_authentication_key) == 32, 12);
+      account.authentication_key = new_authentication_key;
+    }
+
+    // Rotate the transaction sender's authentication key
+    // The new key will be used for signing future transactions
+    public fun rotate_authentication_key(new_authentication_key: vector<u8>) acquires T {
+        let sender_account = borrow_global_mut<T>(Transaction::sender());
+        // The sender has delegated the privilege to rotate her key elsewhere--abort
+        Transaction::assert(!sender_account.delegated_key_rotation_capability, 11);
+        // The sender has retained her key rotation privileges--proceed.
+        rotate_authentication_key_for_account(
+            sender_account,
+            new_authentication_key
+        );
+    }
+
+    // Rotate the authentication key for the account under cap.account_address
+    public fun rotate_authentication_key_with_capability(
+        cap: &KeyRotationCapability,
+        new_authentication_key: vector<u8>,
+    ) acquires T  {
+        rotate_authentication_key_for_account(
+            borrow_global_mut<T>(*&cap.account_address),
+            new_authentication_key
+        );
+    }
+
+    // Return a unique capability granting permission to rotate the sender's authentication key
+    public fun extract_sender_key_rotation_capability(): KeyRotationCapability acquires T {
+        let sender = Transaction::sender();
+        let sender_account = borrow_global_mut<T>(sender);
+        // Abort if we already extracted the unique key rotation capability for this account.
+        Transaction::assert(!sender_account.delegated_key_rotation_capability, 11);
+        sender_account.delegated_key_rotation_capability = true; // Ensure uniqueness of the capability
+        KeyRotationCapability { account_address: sender }
+    }
+
+    // Return the key rotation capability to the account it originally came from
+    public fun restore_key_rotation_capability(cap: KeyRotationCapability) acquires T {
+        // Destroy the capability
+        let KeyRotationCapability { account_address } = cap;
+        let account = borrow_global_mut<T>(account_address);
+        // Update the flag for `account_address` to indicate that the capability has been restored.
+        // The account owner will now be able to call rotate_authentication_key and
+        // extract_sender_key_rotation_capability again
+        account.delegated_key_rotation_capability = false;
+    }
+
+    // Creates a new account at `fresh_address` with an initial balance of zero and authentication
+    // key `auth_key_prefix` | `fresh_address`
+    // Creating an account at address 0x0 will cause runtime failure as it is a
+    // reserved address for the MoveVM.
+    public fun create_account(fresh_address: address, auth_key_prefix: vector<u8>) {
+        let generator = EventHandleGenerator {counter: 0};
+        let authentication_key = auth_key_prefix;
+        Vector::append(&mut authentication_key, LCS::to_bytes(&fresh_address));
+        Transaction::assert(Vector::length(&authentication_key) == 32, 12);
+
+        save_account(
+            Balance{
+                coin: Libra::zero<LBR::T>()
+            },
+            T {
+                authentication_key,
+                delegated_key_rotation_capability: false,
+                delegated_withdrawal_capability: false,
+                received_events: new_event_handle_impl<ReceivedPaymentEvent>(&mut generator, fresh_address),
+                sent_events: new_event_handle_impl<SentPaymentEvent>(&mut generator, fresh_address),
+                sequence_number: 0,
+                event_generator: generator,
+            },
+            fresh_address,
+        );
+    }
+
+    // Creates a new account at `fresh_address` with the `initial_balance` deducted from the
+    // transaction sender's account
+    public fun create_new_account<Token>(
+        fresh_address: address,
+        auth_key_prefix: vector<u8>,
+        initial_balance: u64
+    ) acquires T, Balance {
+        create_account(fresh_address, auth_key_prefix);
+        if (initial_balance > 0) {
+            deposit_with_metadata(
+                fresh_address,
+                withdraw_from_sender<Token>(initial_balance),
+                Vector::empty(),
+            );
+        }
+    }
+
+    // Save an account to a given address if the address does not have account resources yet
+    native fun save_account<Token>(
+        balance: Balance<Token>,
+        account: Self::T,
+        addr: address,
+    );
+
+    // Helper to return the u64 value of the `balance` for `account`
+    fun balance_for<Token>(balance: &Balance<Token>): u64 {
+        Libra::value<Token>(&balance.coin)
+    }
+
+    // Return the current balance of the account at `addr`.
+    public fun balance<Token>(addr: address): u64 acquires Balance {
+        balance_for(borrow_global<Balance<Token>>(addr))
+    }
+
+    // Helper to return the sequence number field for given `account`
+    fun sequence_number_for_account(account: &T): u64 {
+        account.sequence_number
+    }
+
+    // Return the current sequence number at `addr`
+    public fun sequence_number(addr: address): u64 acquires T {
+        sequence_number_for_account(borrow_global<T>(addr))
+    }
+
+    // Return the authentication key for this account
+    public fun authentication_key(addr: address): vector<u8> acquires T {
+        *&borrow_global<T>(addr).authentication_key
+    }
+
+    // Return true if the account at `addr` has delegated its key rotation capability
+    public fun delegated_key_rotation_capability(addr: address): bool acquires T {
+        borrow_global<T>(addr).delegated_key_rotation_capability
+    }
+
+    // Return true if the account at `addr` has delegated its withdrawal capability
+    public fun delegated_withdrawal_capability(addr: address): bool acquires T {
+        borrow_global<T>(addr).delegated_withdrawal_capability
+    }
+
+    // Return a reference to the address associated with the given withdrawal capability
+    public fun withdrawal_capability_address(cap: &WithdrawalCapability): &address {
+        &cap.account_address
+    }
+
+    // Return a reference to the address associated with the given key rotation capability
+    public fun key_rotation_capability_address(cap: &KeyRotationCapability): &address {
+        &cap.account_address
+    }
+
+    // Checks if an account exists at `check_addr`
+    public fun exists(check_addr: address): bool {
+        ::exists<T>(check_addr)
+    }
+
+    // The prologue is invoked at the beginning of every transaction
+    // It verifies:
+    // - The account's auth key matches the transaction's public key
+    // - That the account has enough balance to pay for all of the gas
+    // - That the sequence number matches the transaction's sequence key
+    fun prologue(
+        txn_sequence_number: u64,
+        txn_public_key: vector<u8>,
+        txn_gas_price: u64,
+        txn_max_gas_units: u64,
+        txn_expiration_time: u64,
+    ) acquires T, Balance {
+        let transaction_sender = Transaction::sender();
+
+        // FUTURE: Make these error codes sequential
+        // Verify that the transaction sender's account exists
+        Transaction::assert(exists(transaction_sender), 5);
+
+        // Load the transaction sender's account
+        let sender_account = borrow_global_mut<T>(transaction_sender);
+
+        // Check that the hash of the transaction's public key matches the account's auth key
+        Transaction::assert(
+            Hash::sha3_256(txn_public_key) == *&sender_account.authentication_key,
+            2
+        );
+
+        // Check that the account has enough balance for all of the gas
+        let max_transaction_fee = txn_gas_price * txn_max_gas_units;
+        let balance_amount = balance<LBR::T>(transaction_sender);
+        Transaction::assert(balance_amount >= max_transaction_fee, 6);
+
+        // Check that the transaction sequence number matches the sequence number of the account
+        Transaction::assert(txn_sequence_number >= sender_account.sequence_number, 3);
+        Transaction::assert(txn_sequence_number == sender_account.sequence_number, 4);
+        Transaction::assert(LibraTransactionTimeout::is_valid_transaction_timestamp(txn_expiration_time), 7);
+    }
+
+    // The epilogue is invoked at the end of transactions.
+    // It collects gas and bumps the sequence number
+    fun epilogue(
+        txn_sequence_number: u64,
+        txn_gas_price: u64,
+        txn_max_gas_units: u64,
+        gas_units_remaining: u64
+    ) acquires T, Balance {
+        // Load the transaction sender's account and balance resources
+        let sender_account = borrow_global_mut<T>(Transaction::sender());
+        let sender_balance = borrow_global_mut<Balance<LBR::T>>(Transaction::sender());
+
+        // Charge for gas
+        let transaction_fee_amount = txn_gas_price * (txn_max_gas_units - gas_units_remaining);
+        Transaction::assert(
+            balance_for(sender_balance) >= transaction_fee_amount,
+            6
+        );
+        let transaction_fee = withdraw_from_balance(
+                sender_balance,
+                transaction_fee_amount
+            );
+
+        // Bump the sequence number
+        sender_account.sequence_number = txn_sequence_number + 1;
+        // Pay the transaction fee into the transaction fee balance
+        let transaction_fee_balance = borrow_global_mut<Balance<LBR::T>>(0xFEE);
+        Libra::deposit(&mut transaction_fee_balance.coin, transaction_fee);
+    }
+
+    /// Events
+    //
+    // Derive a fresh unique id by using sender's EventHandleGenerator. The generated vector<u8> is indeed unique because it
+    // was derived from the hash(sender's EventHandleGenerator || sender_address). This module guarantees that the
+    // EventHandleGenerator is only going to be monotonically increased and there's no way to revert it or destroy it. Thus
+    // such counter is going to give distinct value for each of the new event stream under each sender. And since we
+    // hash it with the sender's address, the result is guaranteed to be globally unique.
+    fun fresh_guid(counter: &mut EventHandleGenerator, sender: address): vector<u8> {
+        let sender_bytes = LCS::to_bytes(&sender);
+        let count_bytes = LCS::to_bytes(&counter.counter);
+        counter.counter = counter.counter + 1;
+
+        // EventHandleGenerator goes first just in case we want to extend address in the future.
+        Vector::append(&mut count_bytes, sender_bytes);
+
+        count_bytes
+    }
+
+    // Use EventHandleGenerator to generate a unique event handle that one can emit an event to.
+    fun new_event_handle_impl<T: copyable>(counter: &mut EventHandleGenerator, sender: address): EventHandle<T> {
+        EventHandle<T> {counter: 0, guid: fresh_guid(counter, sender)}
+    }
+
+    // Use sender's EventHandleGenerator to generate a unique event handle that one can emit an event to.
+    public fun new_event_handle<E: copyable>(): EventHandle<E> acquires T {
+        let sender_account_ref = borrow_global_mut<T>(Transaction::sender());
+        new_event_handle_impl<E>(&mut sender_account_ref.event_generator, Transaction::sender())
+    }
+
+    // Emit an event with payload `msg` by using handle's key and counter. Will change the payload from vector<u8> to a
+    // generic type parameter once we have generics.
+    public fun emit_event<T: copyable>(handle_ref: &mut EventHandle<T>, msg: T) {
+        let guid = *&handle_ref.guid;
+
+        write_to_event_store<T>(guid, handle_ref.counter, msg);
+        handle_ref.counter = handle_ref.counter + 1;
+    }
+
+    // Native procedure that writes to the actual event stream in Event store
+    // This will replace the "native" portion of EmitEvent bytecode
+    native fun write_to_event_store<T: copyable>(guid: vector<u8>, count: u64, msg: T);
+
+    // Destroy a unique handle.
+    public fun destroy_handle<T: copyable>(handle: EventHandle<T>) {
+        EventHandle<T> { counter: _, guid: _ } = handle;
+    }
+}

--- a/language/stdlib/staged/src/libra_block.move
+++ b/language/stdlib/staged/src/libra_block.move
@@ -1,0 +1,91 @@
+address 0x0:
+
+module LibraBlock {
+    use 0x0::LBR;
+    use 0x0::LibraAccount;
+    use 0x0::LibraSystem;
+    use 0x0::LibraTimestamp;
+    use 0x0::Transaction;
+    use 0x0::TransactionFee;
+
+    resource struct BlockMetadata {
+      // Height of the current block
+      // TODO: should we keep the height?
+      height: u64,
+      // Handle where events with the time of new blocks are emitted
+      new_block_events: LibraAccount::EventHandle<Self::NewBlockEvent>,
+    }
+
+    struct NewBlockEvent {
+      round: u64,
+      proposer: address,
+      previous_block_votes: vector<address>,
+
+      // On-chain time during  he block at the given height
+      time_microseconds: u64,
+    }
+
+    // This can only be invoked by the Association address, and only a single time.
+    // Currently, it is invoked in the genesis transaction
+    public fun initialize_block_metadata() {
+      // Only callable by the Association address
+      Transaction::assert(Transaction::sender() == 0xA550C18, 1);
+
+      move_to_sender<BlockMetadata>(BlockMetadata {
+        height: 0,
+        new_block_events: LibraAccount::new_event_handle<Self::NewBlockEvent>(),
+      });
+    }
+
+    // Set the metadata for the current block.
+    // The runtime always runs this before executing the transactions in a block.
+    // TODO: 1. Make this private, support other metadata
+    //       2. Should the previous block votes be provided from BlockMetadata or should it come from the ValidatorSet
+    //          Resource?
+    public fun block_prologue(
+        round: u64,
+        timestamp: u64,
+        previous_block_votes: vector<address>,
+        proposer: address
+    ) acquires BlockMetadata {
+        // Can only be invoked by LibraVM privilege.
+        Transaction::assert(Transaction::sender() == 0x0, 33);
+
+        process_block_prologue(round, timestamp, previous_block_votes, proposer);
+
+        // Currently distribute once per-block.
+        // TODO: Once we have a better on-chain representation of epochs we will make this per-epoch.
+        TransactionFee::distribute_transaction_fees<LBR::T>();
+
+        // TODO(valerini): call regular reconfiguration here LibraSystem2::update_all_validator_info()
+    }
+
+    // Update the BlockMetadata resource with the new blockmetada coming from the consensus.
+    fun process_block_prologue(
+        round: u64,
+        timestamp: u64,
+        previous_block_votes: vector<address>,
+        proposer: address
+    ) acquires BlockMetadata {
+        let block_metadata_ref = borrow_global_mut<BlockMetadata>(0xA550C18);
+
+        // TODO: Figure out a story for errors in the system transactions.
+        if(proposer != 0x0) Transaction::assert(LibraSystem::is_validator(proposer), 5002);
+        LibraTimestamp::update_global_time(proposer, timestamp);
+        block_metadata_ref.height = block_metadata_ref.height + 1;
+        LibraAccount::emit_event<NewBlockEvent>(
+          &mut block_metadata_ref.new_block_events,
+          NewBlockEvent {
+            round: round,
+            proposer: proposer,
+            previous_block_votes: previous_block_votes,
+            time_microseconds: timestamp,
+          }
+        );
+    }
+
+    // Get the current block height
+    public fun get_current_block_height(): u64 acquires BlockMetadata {
+      borrow_global<BlockMetadata>(0xA550C18).height
+    }
+}

--- a/language/stdlib/staged/src/libra_configs.move
+++ b/language/stdlib/staged/src/libra_configs.move
@@ -1,0 +1,98 @@
+address 0x0:
+module LibraConfig {
+    use 0x0::Transaction;
+    use 0x0::LibraAccount;
+    use 0x0::LibraTimestamp;
+
+    // A generic singleton resource that holds a value of a specific type.
+    resource struct T<Config: copyable> { payload: Config }
+
+    struct NewEpochEvent {
+        epoch: u64,
+    }
+
+    resource struct Configuration {
+        epoch: u64,
+        last_reconfiguration_time: u64,
+        events: LibraAccount::EventHandle<NewEpochEvent>,
+    }
+
+    // This can only be invoked by the Association address, and only a single time.
+    // Currently, it is invoked in the genesis transaction
+    public fun initialize_configuration() {
+        let sender = Transaction::sender();
+        // Only callable by the Association address for now.
+        Transaction::assert(sender == 0xA550C18, 1);
+
+        move_to_sender<Configuration>(Configuration {
+            epoch: 0,
+            last_reconfiguration_time: 0,
+            events: LibraAccount::new_event_handle<NewEpochEvent>(),
+        });
+    }
+
+    // We can't return reference here, this returns a copy of the config value.
+    public fun get<Config: copyable>(addr: address): Config acquires T {
+        Transaction::assert(::exists<T<Config>>(addr), 24);
+        *&borrow_global<T<Config>>(addr).payload
+    }
+
+    // Set a config item to a new value and trigger a reconfiguration.
+    public fun set<Config: copyable>(addr: address, payload: Config) acquires T, Configuration {
+        // TODO: impose proper permission checks
+        // Callable by the any address for now.
+
+        Transaction::assert(::exists<T<Config>>(addr), 24);
+        let config = borrow_global_mut<T<Config>>(addr);
+        config.payload = payload;
+
+        reconfigure_();
+    }
+
+    // Publish a new config item to a new value and trigger a reconfiguration.
+    public fun publish_new_config<Config: copyable>(payload: Config) acquires Configuration {
+        // TODO: impose proper permission checks
+        // Callable by the any address for now.
+
+        move_to_sender(T{ payload });
+        reconfigure_();
+    }
+
+    public fun reconfigure() acquires Configuration {
+        // Only callable by association address.
+        Transaction::assert(Transaction::sender() == 0xA550C18, 1);
+        reconfigure_();
+    }
+
+    fun reconfigure_() acquires Configuration {
+       // Do not do anything if time is not set up yet, this is to avoid genesis emit too many epochs.
+       if(LibraTimestamp::is_genesis()) {
+           return ()
+       };
+
+       let config_ref = borrow_global_mut<Configuration>(0xA550C18);
+
+       // Ensure that there is at most one reconfiguration per transaction. This ensures that there is a 1-1
+       // correspondence between system reconfigurations and emitted ReconfigurationEvents.
+
+       let current_block_time = LibraTimestamp::now_microseconds();
+       Transaction::assert(current_block_time > config_ref.last_reconfiguration_time, 23);
+       config_ref.last_reconfiguration_time = current_block_time;
+
+       emit_reconfiguration_event();
+    }
+
+    // Emit a reconfiguration event. This function will be invoked by the genesis directly to generate the very first
+    // reconfiguration event.
+    fun emit_reconfiguration_event() acquires Configuration {
+        let config_ref = borrow_global_mut<Configuration>(0xA550C18);
+        config_ref.epoch = config_ref.epoch + 1;
+
+        LibraAccount::emit_event<NewEpochEvent>(
+            &mut config_ref.events,
+            NewEpochEvent {
+                epoch: config_ref.epoch,
+            },
+        );
+    }
+}

--- a/language/stdlib/staged/src/libra_system.move
+++ b/language/stdlib/staged/src/libra_system.move
@@ -1,0 +1,434 @@
+address 0x0:
+
+module LibraSystem {
+    use 0x0::LibraAccount;
+    use 0x0::LibraConfig;
+    use 0x0::LibraSystem2;
+    use 0x0::Transaction;
+    use 0x0::ValidatorConfig;
+    use 0x0::Vector;
+
+    struct ValidatorInfo {
+        addr: address,
+        consensus_pubkey: vector<u8>,
+        consensus_voting_power: u64,
+        network_signing_pubkey: vector<u8>,
+        network_identity_pubkey: vector<u8>,
+    }
+
+    struct T {
+        // The current consensus crypto scheme.
+        scheme: u8,
+        // The current validator set. Updated only at epoch boundaries via reconfiguration.
+        validators: vector<ValidatorInfo>,
+    }
+
+    struct DiscoveryInfo {
+        addr: address,
+        validator_network_identity_pubkey: vector<u8>,
+        validator_network_address: vector<u8>,
+        fullnodes_network_identity_pubkey: vector<u8>,
+        fullnodes_network_address: vector<u8>,
+    }
+
+    struct DiscoverySetChangeEvent {
+        new_discovery_set: vector<DiscoveryInfo>,
+    }
+
+    resource struct DiscoverySet {
+        // The current discovery set. Updated only at epoch boundaries via reconfiguration.
+        discovery_set: vector<DiscoveryInfo>,
+        // Handle where discovery set change events are emitted
+        change_events: LibraAccount::EventHandle<DiscoverySetChangeEvent>,
+    }
+
+    // This can only be invoked by the Association address, and only a single time.
+    // Currently, it is invoked in the genesis transaction
+    public fun initialize_validator_set() {
+        // Only callable by the validator set address
+        Transaction::assert(Transaction::sender() == 0x1D8, 1);
+
+        LibraConfig::publish_new_config<T>(T {
+            scheme: 0,
+            validators: Vector::empty(),
+        });
+        LibraSystem2::initialize_validator_set();
+    }
+
+    // This returns a copy of the current validator set.
+    public fun get_validator_set(): T {
+        LibraConfig::get<T>(0x1D8)
+    }
+
+    public fun initialize_discovery_set() {
+        // Only callable by the discovery set address
+        Transaction::assert(Transaction::sender() == 0xD15C0, 1);
+
+        move_to_sender<DiscoverySet>(DiscoverySet {
+            discovery_set: Vector::empty(),
+            change_events: LibraAccount::new_event_handle<DiscoverySetChangeEvent>(),
+        });
+    }
+
+    // ValidatorInfo public accessors
+
+    public fun get_validator_address(v: &ValidatorInfo): &address {
+      &v.addr
+    }
+
+    public fun get_consensus_pubkey(v: &ValidatorInfo): &vector<u8> {
+      &v.consensus_pubkey
+    }
+
+    public fun get_consensus_voting_power(v: &ValidatorInfo): &u64 {
+      &v.consensus_voting_power
+    }
+
+    public fun get_network_signing_pubkey(v: &ValidatorInfo): &vector<u8> {
+      &v.network_signing_pubkey
+    }
+
+    public fun get_network_identity_pubkey(v: &ValidatorInfo): &vector<u8> {
+      &v.network_identity_pubkey
+    }
+
+    // DiscoveryInfo public accessors
+
+    public fun get_discovery_address(d: &DiscoveryInfo): &address {
+        &d.addr
+    }
+
+    public fun get_validator_network_identity_pubkey(d: &DiscoveryInfo): &vector<u8> {
+        &d.validator_network_identity_pubkey
+    }
+
+    public fun get_validator_network_address(d: &DiscoveryInfo): &vector<u8> {
+        &d.validator_network_address
+    }
+
+    public fun get_fullnodes_network_identity_pubkey(d: &DiscoveryInfo): &vector<u8> {
+        &d.fullnodes_network_identity_pubkey
+    }
+
+    public fun get_fullnodes_network_address(d: &DiscoveryInfo): &vector<u8> {
+        &d.fullnodes_network_address
+    }
+
+    // Return the size of the current validator set
+    public fun validator_set_size(): u64 {
+        Vector::length(&get_validator_set().validators)
+    }
+
+   fun is_validator_(addr: &address, validators_vec_ref: &vector<ValidatorInfo>): bool {
+        let size = Vector::length(validators_vec_ref);
+        if (size == 0) {
+            return false
+        };
+
+        let i = 0;
+        // this is only needed to make the bytecode verifier happy
+        let validator_info_ref = Vector::borrow(validators_vec_ref, i);
+        loop {
+            if (&validator_info_ref.addr == addr) {
+                return true
+            };
+            i = i + 1;
+            if (i >= size) { break };
+            validator_info_ref = Vector::borrow(validators_vec_ref, i);
+        };
+
+        false
+    }
+
+    // Return true if addr is a current validator
+    public fun is_validator(addr: address): bool {
+        is_validator_(&addr, &get_validator_set().validators)
+    }
+
+    // Get the ValidatorInfo for the ith validator
+    public fun get_ith_validator_info(i: u64): ValidatorInfo {
+      let validators_vec_ref = &get_validator_set().validators;
+      Transaction::assert(i < Vector::length(validators_vec_ref), 3);
+      *Vector::borrow(validators_vec_ref, i)
+    }
+
+    // Get the address of the i'th validator.
+    public fun get_ith_validator_address(i: u64): address {
+      let validator_set = get_validator_set();
+      let len = Vector::length(&validator_set.validators);
+      Transaction::assert(i < len, 3);
+      Vector::borrow(&validator_set.validators, i).addr
+    }
+
+    // Get the DiscoveryInfo for the ith validator
+    public fun get_ith_discovery_info(i: u64): DiscoveryInfo acquires DiscoverySet {
+        let discovery_vec_ref = &borrow_global<DiscoverySet>(0xD15C0).discovery_set;
+        Transaction::assert(i < Vector::length(discovery_vec_ref), 4);
+        *Vector::borrow(discovery_vec_ref, i)
+    }
+
+    // Get the index of the validator with address `addr` in `validators`.
+    // Aborts if `addr` is not the address of any validator
+    public fun get_validator_index(validators: &vector<ValidatorInfo>, addr: address): u64 {
+        let len = Vector::length(validators);
+        let i = 0;
+        loop {
+            if (get_validator_address(Vector::borrow(validators, i)) == &addr) {
+                return i
+            };
+
+            i = i + 1;
+            if (i >= len) { break };
+        };
+
+        abort 99
+    }
+
+    // Get the index of the discovery info with address `addr` in `discovery_set`.
+    // Aborts if `addr` is not in discovery set.
+    public fun get_discovery_index(discovery_set: &vector<DiscoveryInfo>, addr: address): u64 {
+        let len = Vector::length(discovery_set);
+        let i = 0;
+        loop {
+            if (get_discovery_address(Vector::borrow(discovery_set, i)) == &addr) {
+                return i
+            };
+
+            i = i + 1;
+            if (i >= len) { break };
+        };
+
+        abort 99
+    }
+
+    // Adds a validator to the addition buffer, which will cause it to be added to the validator
+    // set in the next epoch.
+    // Fails if `account_address` is already a validator or has already been added to the addition
+    // buffer.
+    // Only callable by the Association address
+    public fun add_validator(account_address: address) acquires DiscoverySet {
+        add_validator_(account_address);
+        emit_discovery_set_change();
+    }
+
+   fun add_validator_(account_address: address) acquires DiscoverySet {
+       // Only the Association can add new validators
+       Transaction::assert(Transaction::sender() == 0xA550C18, 1);
+       // A prospective validator must have a validator config resource
+       Transaction::assert(ValidatorConfig::has(account_address), 17);
+
+       let validator_set = get_validator_set();
+       let discovery_set_ref = borrow_global_mut<DiscoverySet>(0xD15C0);
+
+       // Ensure that this address is not already a validator
+       Transaction::assert(
+           !is_validator_(&account_address, &validator_set.validators),
+           18
+       );
+
+       Vector::push_back(
+           &mut validator_set.validators,
+           make_validator_info(account_address)
+       );
+       Vector::push_back(
+           &mut discovery_set_ref.discovery_set,
+           make_discovery_info(account_address)
+       );
+       set_validator_set(validator_set);
+   }
+
+   public fun remove_validator(account_address: address) acquires DiscoverySet {
+       // Only the Association can remove validators
+       Transaction::assert(Transaction::sender() == 0xA550C18, 1);
+
+       let validator_set = get_validator_set();
+       let discovery_set_ref = borrow_global_mut<DiscoverySet>(0xD15C0);
+       // Ensure that this address is already a validator
+       Transaction::assert(
+           is_validator_(&account_address, &validator_set.validators),
+           21
+       );
+
+       let to_remove_index = get_validator_index(
+           &validator_set.validators,
+           account_address
+       );
+
+       // remove corresponding ValidatorInfo from the validator set
+       _  = Vector::swap_remove(
+            &mut validator_set.validators,
+           to_remove_index
+       );
+       _  = Vector::swap_remove(
+           &mut discovery_set_ref.discovery_set,
+           to_remove_index
+       );
+
+       set_validator_set(validator_set);
+       emit_discovery_set_change();
+   }
+
+   public fun rotate_consensus_pubkey(consensus_pubkey: vector<u8>) {
+       let validator_set = get_validator_set();
+       let account_address = Transaction::sender();
+
+       // Ensure that this address is already a validator
+       Transaction::assert(
+           is_validator_(&account_address, &validator_set.validators),
+           21
+       );
+
+       ValidatorConfig::rotate_consensus_pubkey(consensus_pubkey);
+
+       let validator_index = get_validator_index(
+           &validator_set.validators,
+           account_address
+       );
+
+       if (copy_validator_info(Vector::borrow_mut(&mut validator_set.validators, validator_index))) {
+           set_validator_set(validator_set);
+       }
+   }
+
+   public fun rotate_validator_network_identity_pubkey(
+       validator_network_identity_pubkey: vector<u8>
+   ) acquires DiscoverySet {
+       let discovery_set_ref = borrow_global_mut<DiscoverySet>(0xD15C0);
+       let account_address = Transaction::sender();
+
+       ValidatorConfig::rotate_validator_network_identity_pubkey(validator_network_identity_pubkey);
+
+       let validator_index = get_discovery_index(
+           &discovery_set_ref.discovery_set,
+           account_address
+       );
+
+       if(copy_discovery_info(Vector::borrow_mut(&mut discovery_set_ref.discovery_set, validator_index))) {
+           emit_discovery_set_change();
+       }
+   }
+
+   public fun rotate_validator_network_address(
+       validator_network_address: vector<u8>
+   ) acquires DiscoverySet {
+       let discovery_set_ref = borrow_global_mut<DiscoverySet>(0xD15C0);
+       let account_address = Transaction::sender();
+
+       ValidatorConfig::rotate_validator_network_address(validator_network_address);
+
+       let validator_index = get_discovery_index(
+           &discovery_set_ref.discovery_set,
+           account_address
+       );
+
+       if(copy_discovery_info(Vector::borrow_mut(&mut discovery_set_ref.discovery_set, validator_index))) {
+           emit_discovery_set_change();
+       }
+   }
+
+   fun set_validator_set(value: T) {
+       LibraConfig::set<T>(0x1D8, value)
+   }
+
+   fun emit_discovery_set_change() acquires DiscoverySet {
+       let discovery_set_ref = borrow_global_mut<DiscoverySet>(0xD15C0);
+       LibraAccount::emit_event<DiscoverySetChangeEvent>(
+           &mut discovery_set_ref.change_events,
+           DiscoverySetChangeEvent {
+               new_discovery_set: *&discovery_set_ref.discovery_set,
+           },
+       );
+   }
+
+   // Return true if the ValidatorInfo given as input is different than the one
+   // derived from the ValidatorConfig published at validator_info.addr + copies
+   // the differing fields. Aborts if there is no ValidatorConfig at
+
+   // validator_info.addr
+   public fun copy_validator_info(validator_info: &mut ValidatorInfo): bool {
+
+       let config = ValidatorConfig::config(validator_info.addr);
+       let consensus_pubkey = ValidatorConfig::consensus_pubkey(&config);
+       let network_signing_pubkey = ValidatorConfig::validator_network_signing_pubkey(&config);
+       let network_identity_pubkey = ValidatorConfig::validator_network_identity_pubkey(&config);
+
+       let changed = false;
+       if (&consensus_pubkey != &validator_info.consensus_pubkey) {
+           *&mut validator_info.consensus_pubkey = consensus_pubkey;
+           changed = true;
+       };
+       if (&network_signing_pubkey != &validator_info.network_signing_pubkey) {
+           *&mut validator_info.network_signing_pubkey = network_signing_pubkey;
+           changed = true;
+       };
+       if (&network_identity_pubkey != &validator_info.network_identity_pubkey) {
+           *&mut validator_info.network_identity_pubkey = network_identity_pubkey;
+           changed = true;
+       };
+       changed
+   }
+
+   // Create a ValidatorInfo from the ValidatorConfig stored at addr.
+   // Aborts if addr does not have a ValidatorConfig
+   fun make_validator_info(addr: address): ValidatorInfo {
+       let config = ValidatorConfig::config(addr);
+
+      ValidatorInfo {
+          addr: addr,
+          consensus_pubkey: ValidatorConfig::consensus_pubkey(&config),
+          consensus_voting_power: 1,
+          network_signing_pubkey: ValidatorConfig::validator_network_signing_pubkey(&config),
+          network_identity_pubkey: ValidatorConfig::validator_network_identity_pubkey(&config),
+      }
+   }
+
+   // Return true if the DiscoveryInfo given as input is different than the one
+   // derived from the ValidatorConfig published at discovery_info.addr + copies
+   // the differing fields. Aborts if there is no ValidatorConfig at
+   // discovery_info.addr
+   public fun copy_discovery_info(discovery_info: &mut DiscoveryInfo): bool {
+       let config = ValidatorConfig::config(*&discovery_info.addr);
+       let validator_network_identity_pubkey = ValidatorConfig::validator_network_identity_pubkey(&config);
+       let validator_network_address = ValidatorConfig::validator_network_address(&config);
+       let fullnodes_network_identity_pubkey = ValidatorConfig::fullnodes_network_identity_pubkey(&config);
+       let fullnodes_network_address = ValidatorConfig::fullnodes_network_address(&config);
+
+       let changed = false;
+       if (&validator_network_identity_pubkey != &discovery_info.validator_network_identity_pubkey) {
+           *&mut discovery_info.validator_network_identity_pubkey = validator_network_identity_pubkey;
+           changed = true;
+       };
+       if (&validator_network_address != &discovery_info.validator_network_address) {
+           *&mut discovery_info.validator_network_address = validator_network_address;
+           changed = true;
+       };
+       if (&fullnodes_network_identity_pubkey != &discovery_info.fullnodes_network_identity_pubkey) {
+           *&mut discovery_info.fullnodes_network_identity_pubkey = fullnodes_network_identity_pubkey;
+           changed = true;
+       };
+       if (&fullnodes_network_address != &discovery_info.fullnodes_network_address) {
+           *&mut discovery_info.fullnodes_network_address = fullnodes_network_address;
+           changed = true;
+       };
+
+       changed
+   }
+
+   // Create a DiscoveryInfo from the ValidatorConfig stored at addr.
+   // Aborts if addr does not have a ValidatorConfig
+   fun make_discovery_info(addr: address): DiscoveryInfo {
+      let config = ValidatorConfig::config(addr);
+
+      DiscoveryInfo {
+          addr: addr,
+          validator_network_identity_pubkey:
+              ValidatorConfig::validator_network_identity_pubkey(&config),
+          validator_network_address:
+              ValidatorConfig::validator_network_address(&config),
+          fullnodes_network_identity_pubkey:
+              ValidatorConfig::fullnodes_network_identity_pubkey(&config),
+          fullnodes_network_address:
+              ValidatorConfig::fullnodes_network_address(&config),
+      }
+   }
+}

--- a/language/stdlib/staged/src/libra_system_2.move
+++ b/language/stdlib/staged/src/libra_system_2.move
@@ -1,0 +1,257 @@
+address 0x0:
+
+// These modules only change resources stored under the three addresses:
+// LibraAssociation's account address: 0xA550C18
+// ValidatorSet resource address: 0x1D8
+// DiscoverySet resource address: 0xD15C0
+// ValidatorSet and DiscoverySet are stored under different addresses in order to facilitate
+// cheaper reads of these sets from storage.
+module LibraSystem2 {
+    use 0x0::LibraAccount;
+    use 0x0::LibraTimestamp;
+    use 0x0::Transaction;
+    use 0x0::ValidatorConfig2;
+    use 0x0::Vector;
+
+    struct ValidatorInfo {
+        addr: address,
+        consensus_voting_power: u64,
+        config: ValidatorConfig2::Config,
+        // To protect against DDoS, the force updates are allowed only if the time passed
+        // since the last force update is larger than a threshold (24hr).
+        last_force_update_time: u64,
+    }
+
+    struct ValidatorSetChangeEvent {
+        new_validator_set: vector<ValidatorInfo>,
+    }
+
+    resource struct ValidatorSet {
+        validators: vector<ValidatorInfo>,
+        last_reconfiguration_time: u64,
+        change_events: LibraAccount::EventHandle<ValidatorSetChangeEvent>,
+    }
+
+    // ValidatorInfo public accessors
+
+    // Get validator's address from ValidatorInfo
+    public fun get_validator_address(v: &ValidatorInfo): &address {
+        &v.addr
+    }
+
+    // Get validator's config from ValidatorInfo
+    public fun get_validator_config(v: &ValidatorInfo): &ValidatorConfig2::Config {
+        &v.config
+    }
+
+    // Get validator's voting power from ValidatorInfo
+    public fun get_validator_voting_power(v: &ValidatorInfo): &u64 {
+        &v.consensus_voting_power
+    }
+
+    // Get last forced update time
+    public fun get_last_force_update_time(v: &ValidatorInfo): &u64 {
+        &v.last_force_update_time
+    }
+
+    // This can only be invoked by the ValidatorSet address to instantiate the resource under that address.
+    // It can only be called a single time. Currently, it is invoked in the genesis transaction.
+    public fun initialize_validator_set() {
+        Transaction::assert(Transaction::sender() == 0x1D8, 1);
+        move_to_sender<ValidatorSet>(ValidatorSet {
+            validators: Vector::empty(),
+            last_reconfiguration_time: 0,
+            change_events: LibraAccount::new_event_handle<ValidatorSetChangeEvent>(),
+        });
+    }
+
+    // Adds a new validator, only callable by the LibraAssociation address
+    // TODO(valerini): allow the Association to add multiple validators in a single block
+    public fun add_validator(account_address: &address) acquires ValidatorSet {
+        Transaction::assert(Transaction::sender() == 0xA550C18, 1);
+        // A prospective validator must have a validator config resource
+        Transaction::assert(ValidatorConfig2::has(*account_address), 17);
+
+        let validator_set_ref = borrow_global_mut<ValidatorSet>(0x1D8);
+        // Ensure that this address is not already a validator
+        Transaction::assert(!is_validator_(account_address, &validator_set_ref.validators), 18);
+
+        let config = ValidatorConfig2::get_config(*account_address);
+        let current_block_time = LibraTimestamp::now_microseconds();
+        Vector::push_back(&mut validator_set_ref.validators, ValidatorInfo {
+            addr: *account_address,
+            config: config, // copy the config over to ValidatorSet
+            consensus_voting_power: 1,
+            last_force_update_time: current_block_time,
+        });
+
+        emit_reconfiguration_event();
+    }
+
+    // Removes a validator, only callable by the LibraAssociation address
+    public fun remove_validator(account_address: &address) acquires ValidatorSet {
+        Transaction::assert(Transaction::sender() == 0xA550C18, 1);
+        let validator_set_ref = borrow_global_mut<ValidatorSet>(0x1D8);
+        let size = Vector::length(&validator_set_ref.validators);
+        // Make sure the size of validator set does not go beyond 4, which is the minimum safe number of validators
+        Transaction::assert(size > 4, 22);
+
+        // Ensure that this address is an active validator
+        let to_remove_index_vec = get_validator_index_(&validator_set_ref.validators, account_address);
+        Transaction::assert(!Vector::is_empty(&to_remove_index_vec), 21);
+        // Remove corresponding ValidatorInfo from the validator set
+        _  = Vector::swap_remove(&mut validator_set_ref.validators, *Vector::borrow(&to_remove_index_vec, 0));
+
+        emit_reconfiguration_event();
+    }
+
+    // Copies validator's config to ValidatorSet
+    // Callable by the LibraAssociation address only.
+    // Aborts if there are no changes to the config.
+    public fun update_validator_info(addr: &address) acquires ValidatorSet {
+        Transaction::assert(Transaction::sender() == 0xA550C18, 1);
+        let validator_set_ref = borrow_global_mut<ValidatorSet>(0x1D8);
+
+        let validator_index_vec = get_validator_index_(&validator_set_ref.validators, addr);
+        Transaction::assert(!Vector::is_empty(&validator_index_vec), 19);
+        Transaction::assert(update_ith_validator_info_(&mut validator_set_ref.validators, *Vector::borrow(&validator_index_vec, 0)), 42);
+        emit_reconfiguration_event();
+    }
+
+    // This function can be called by the validator's operator,
+    // which is either the validator itself or the validator's delegate account.
+    // Aborts if there are no changes to the config.
+    public fun force_update_validator_info(validator_address: &address) acquires ValidatorSet {
+        // Check the sender
+        Transaction::assert(ValidatorConfig2::get_validator_operator_account(*validator_address) == Transaction::sender(), 1);
+
+        let validator_vec_ref = borrow_global_mut<ValidatorSet>(0x1D8);
+        let validator_index_vec = get_validator_index_(&validator_vec_ref.validators, validator_address);
+        Transaction::assert(!Vector::is_empty(&validator_index_vec), 19);
+        let validator_index = *Vector::borrow(&validator_index_vec, 0);
+
+        // Update force update timer to enforce rate-limits
+        let validator_info_ref = Vector::borrow(&mut validator_vec_ref.validators, validator_index);
+
+        // If less than 24hr has passed since the last forced update, abort.
+        // Note that validators can always ask LibraAssocition offchain to invoke update.
+        let current_block_time = LibraTimestamp::now_microseconds();
+        Transaction::assert(current_block_time - validator_info_ref.last_force_update_time >= 86400000000, 11);
+
+        // Copy validator config from validator's account and assert that there are changes to the config
+        Transaction::assert(update_ith_validator_info_(&mut validator_vec_ref.validators, validator_index), 42);
+        let validator_info = Vector::borrow_mut(&mut validator_vec_ref.validators, validator_index);
+        *&mut validator_info.last_force_update_time = current_block_time;
+        emit_reconfiguration_event();
+    }
+
+    // This function can be invoked by the LibraAssociation or by the 0x0 LibraVM address in
+    // block_prologue to facilitate reconfigurations at regular intervals.
+    // Here for all of the validators the information from ValidatorConfig2 will get copied into the ValidatorSet,
+    // if any components of the configs have changed, appropriate events will be fired.
+    public fun update_all_validator_info() acquires ValidatorSet {
+        Transaction::assert(Transaction::sender() == 0xA550C18 || Transaction::sender() == 0x0, 1);
+        let validators = &mut borrow_global_mut<ValidatorSet>(0x1D8).validators;
+
+        let size = Vector::length(validators);
+        if (size == 0) {
+            return
+        };
+
+        let i = 0;
+        let configs_changed = false;
+        configs_changed = configs_changed || update_ith_validator_info_(validators, i);
+        loop {
+            i = i + 1;
+            if (i >= size) { break };
+            configs_changed = configs_changed || update_ith_validator_info_(validators, i);
+        };
+        Transaction::assert(configs_changed, 42);
+        emit_reconfiguration_event();
+    }
+
+    // Public getters
+
+    // Return true if addr is a current validator
+    public fun is_validator(addr: &address): bool acquires ValidatorSet { is_validator_(addr, &borrow_global<ValidatorSet>(0x1D8).validators) }
+
+    // Returns validator info
+    // If the address is not a validator, abort
+    public fun get_validator_info(addr: &address): ValidatorInfo acquires ValidatorSet {
+        let validator_set_ref = borrow_global<ValidatorSet>(0x1D8);
+        let validator_index_vec = get_validator_index_(&validator_set_ref.validators, addr);
+        Transaction::assert(!Vector::is_empty(&validator_index_vec), 19);
+
+        *Vector::borrow(&validator_set_ref.validators, *Vector::borrow(&validator_index_vec, 0))
+    }
+
+    // Return the size of the current validator set
+    public fun validator_set_size(): u64 acquires ValidatorSet {
+        Vector::length(&borrow_global<ValidatorSet>(0x1D8).validators)
+    }
+
+    // Private helper functions
+
+    // Emit a reconfiguration event. This function will be invoked by the genesis to generate the very first
+    // reconfiguration event.
+    fun emit_reconfiguration_event() acquires ValidatorSet {
+        let validator_set_ref = borrow_global_mut<ValidatorSet>(0x1D8);
+
+        // Ensure only one reconfiguration event is emitted per block
+        let current_block_time = LibraTimestamp::now_microseconds();
+
+        // Abort the transaction if reconfiguration was already called within the same block
+        Transaction::assert(current_block_time > validator_set_ref.last_reconfiguration_time, 14);
+
+        validator_set_ref.last_reconfiguration_time = current_block_time;
+        LibraAccount::emit_event<ValidatorSetChangeEvent>(
+            &mut validator_set_ref.change_events,
+            ValidatorSetChangeEvent {
+                new_validator_set: *&validator_set_ref.validators,
+            });
+    }
+
+    // Get the index of the validator by address in the `validators` vector
+    fun get_validator_index_(validators: &vector<ValidatorInfo>, addr: &address): vector<u64> {
+        let size = Vector::length(validators);
+        let result: vector<u64> = Vector::empty();
+        if (size == 0) {
+            return result
+        };
+
+        let i = 0;
+        let validator_info_ref = Vector::borrow(validators, i);
+        loop {
+            if (&validator_info_ref.addr == addr) {
+                Vector::push_back(&mut result, i);
+                return result
+            };
+            i = i + 1;
+            if (i >= size) { break };
+            validator_info_ref = Vector::borrow(validators, i);
+        };
+
+        result
+    }
+
+    // Updates ith validator info, if nothing changed, return false
+    fun update_ith_validator_info_(validators: &mut vector<ValidatorInfo>, i: u64): bool {
+        let size = Vector::length(validators);
+        if (i >= size) {
+            return false
+        };
+        let validator_info = Vector::borrow(validators, i);
+        let new_validator_config = ValidatorConfig2::get_config(validator_info.addr);
+        // check if information is the same
+        let config_ref = &mut Vector::borrow_mut(validators, i).config;
+        if (config_ref == &new_validator_config) {
+            return false
+        };
+        *config_ref = *&new_validator_config;
+        true
+    }
+
+    fun is_validator_(addr: &address, validators_vec_ref: &vector<ValidatorInfo>): bool {
+        !Vector::is_empty(&get_validator_index_(validators_vec_ref, addr))
+    }
+}

--- a/language/stdlib/staged/src/libra_time.move
+++ b/language/stdlib/staged/src/libra_time.move
@@ -1,0 +1,46 @@
+address 0x0:
+
+module LibraTimestamp {
+    use 0x0::Transaction;
+
+    // A singleton resource holding the current Unix time in microseconds
+    resource struct CurrentTimeMicroseconds {
+        microseconds: u64,
+    }
+
+    // Initialize the global wall clock time resource.
+    public fun initialize() {
+        // Only callable by the Association address
+        Transaction::assert(Transaction::sender() == 0xA550C18, 1);
+
+        // TODO: Should the initialized value be passed in to genesis?
+        let timer = CurrentTimeMicroseconds {microseconds: 0};
+        move_to_sender<CurrentTimeMicroseconds>(timer);
+    }
+
+    // Update the wall clock time by consensus. Requires VM privilege and will be invoked during block prologue.
+    public fun update_global_time(proposer: address, timestamp: u64) acquires CurrentTimeMicroseconds {
+        // Can only be invoked by LibraVM privilege.
+        Transaction::assert(Transaction::sender() == 0x0, 33);
+
+        let global_timer = borrow_global_mut<CurrentTimeMicroseconds>(0xA550C18);
+        if (proposer == 0x0) {
+            // NIL block with null address as proposer. Timestamp must be equal.
+            Transaction::assert(timestamp == global_timer.microseconds, 5001);
+        } else {
+            // Normal block. Time must advance
+            Transaction::assert(global_timer.microseconds < timestamp, 5001);
+        };
+        global_timer.microseconds = timestamp;
+    }
+
+    // Get the timestamp representing `now` in microseconds.
+    public fun now_microseconds(): u64 acquires CurrentTimeMicroseconds {
+        borrow_global<CurrentTimeMicroseconds>(0xA550C18).microseconds
+    }
+
+    // Helper function to determine if the blockchain is at genesis state.
+    public fun is_genesis(): bool {
+        !::exists<Self::CurrentTimeMicroseconds>(0xA550C18)
+    }
+}

--- a/language/stdlib/staged/src/libra_transaction_timeout.move
+++ b/language/stdlib/staged/src/libra_transaction_timeout.move
@@ -1,0 +1,45 @@
+address 0x0:
+
+module LibraTransactionTimeout {
+  use 0x0::Transaction;
+  use 0x0::LibraTimestamp;
+
+  resource struct TTL {
+    // Only transactions with timestamp in between block time and block time + duration would be accepted.
+    duration_microseconds: u64,
+  }
+
+  public fun initialize() {
+
+    // Only callable by the Association address
+    Transaction::assert(Transaction::sender() == 0xA550C18, 1);
+    // Currently set to 1day.
+    move_to_sender<TTL>(TTL {duration_microseconds: 86400000000});
+  }
+
+  public fun set_timeout(new_duration: u64) acquires TTL {
+    // Only callable by the Association address
+    Transaction::assert(Transaction::sender() == 0xA550C18, 1);
+
+    let timeout = borrow_global_mut<TTL>(0xA550C18);
+    timeout.duration_microseconds = new_duration;
+  }
+
+  public fun is_valid_transaction_timestamp(timestamp: u64): bool acquires TTL {
+    // Reject timestamp greater than u64::MAX / 1_000_000;
+    if(timestamp > 9223372036854) {
+      return false
+    };
+
+    let current_block_time = LibraTimestamp::now_microseconds();
+    let timeout = borrow_global<TTL>(0xA550C18).duration_microseconds;
+    let _max_txn_time = current_block_time + timeout;
+
+    let txn_time_microseconds = timestamp * 1000000;
+    // TODO: Add LibraTimestamp::is_before_exclusive(&txn_time_microseconds, &max_txn_time)
+    //       This is causing flaky test right now. The reason is that we will use this logic for AC, where its wall
+    //       clock time might be out of sync with the real block time stored in StateStore.
+    //       See details in issue #2346.
+    current_block_time < txn_time_microseconds
+  }
+}

--- a/language/stdlib/staged/src/libra_version.move
+++ b/language/stdlib/staged/src/libra_version.move
@@ -1,0 +1,28 @@
+address 0x0:
+
+module LibraVersion {
+    use 0x0::LibraConfig;
+    use 0x0::Transaction;
+
+    struct T {
+        major: u64,
+    }
+
+    public fun initialize() {
+
+        LibraConfig::publish_new_config<Self::T>(T {
+            major: 1,
+        })
+    }
+
+    public fun set(major: u64) {
+        let old_config = LibraConfig::get<Self::T>(Transaction::sender());
+
+        Transaction::assert(
+            old_config.major < major,
+            25
+        );
+
+        LibraConfig::set<Self::T>(Transaction::sender(), T { major } )
+    }
+}

--- a/language/stdlib/staged/src/libra_writeset_manager.move
+++ b/language/stdlib/staged/src/libra_writeset_manager.move
@@ -1,0 +1,54 @@
+module LibraWriteSetManager {
+    use 0x0::LibraAccount;
+    use 0x0::Hash;
+    use 0x0::Transaction;
+    use 0x0::LibraConfig;
+
+    resource struct T {
+        sequence_number: u64,
+        upgrade_events: LibraAccount::EventHandle<Self::UpgradeEvent>,
+    }
+
+    struct UpgradeEvent {
+        writeset_payload: vector<u8>,
+    }
+
+    public fun initialize() {
+        Transaction::assert(Transaction::sender() == 0xA550C18, 1);
+
+        move_to_sender<T>(T {
+            sequence_number: 0,
+            upgrade_events: LibraAccount::new_event_handle<Self::UpgradeEvent>(),
+        });
+    }
+
+    fun prologue(
+        writeset_sequence_number: u64,
+        writeset_public_key: vector<u8>,
+    ) acquires T {
+        let sender = Transaction::sender();
+        Transaction::assert(sender == 0xA550C18, 33);
+
+        let association_auth_key = LibraAccount::authentication_key(sender);
+
+        let t_ref = borrow_global<T>(0xA550C18);
+        Transaction::assert(writeset_sequence_number >= t_ref.sequence_number, 3);
+
+        Transaction::assert(writeset_sequence_number == t_ref.sequence_number, 11);
+        Transaction::assert(
+            Hash::sha3_256(writeset_public_key) == association_auth_key,
+            2
+        );
+    }
+
+    fun epilogue(writeset_payload: vector<u8>) acquires T {
+        let t_ref = borrow_global_mut<T>(0xA550C18);
+        t_ref.sequence_number = t_ref.sequence_number + 1;
+
+        LibraAccount::emit_event<Self::UpgradeEvent>(
+            &mut t_ref.upgrade_events,
+            UpgradeEvent { writeset_payload },
+        );
+        LibraConfig::reconfigure();
+    }
+}

--- a/language/stdlib/staged/src/offer.move
+++ b/language/stdlib/staged/src/offer.move
@@ -1,0 +1,37 @@
+address 0x0:
+
+// TODO: add optional timeout for reclaiming by original publisher once we have implemented time
+module Offer {
+  use 0x0::Transaction;
+  // A wrapper around value `offered` that can be claimed by the address stored in `for`.
+  resource struct T<Offered> { offered: Offered, for: address }
+
+  // Publish a value of type `Offered` under the sender's account. The value can be claimed by
+  // either the `for` address or the transaction sender.
+  public fun create<Offered>(offered: Offered, for: address) {
+    move_to_sender<T<Offered>>(T<Offered> { offered: offered, for: for });
+  }
+
+  // Claim the value of type `Offered` published at `offer_address`.
+  // Only succeeds if the sender is the intended recipient stored in `for` or the original
+  // publisher `offer_address`.
+  // Also fails if no such value exists.
+  public fun redeem<Offered>(offer_address: address): Offered acquires T {
+    let T<Offered> { offered, for } = move_from<T<Offered>>(offer_address);
+    let sender = Transaction::sender();
+    // fail with INSUFFICIENT_PRIVILEGES
+    Transaction::assert(sender == for || sender == offer_address, 11);
+    offered
+  }
+
+  // Returns true if an offer of type `Offered` exists at `offer_address`.
+  public fun exists_at<Offered>(offer_address: address): bool {
+    exists<T<Offered>>(offer_address)
+  }
+
+  // Returns the address of the `Offered` type stored at `offer_address.
+  // Fails if no such `Offer` exists.
+  public fun address_of<Offered>(offer_address: address): address acquires T {
+    borrow_global<T<Offered>>(offer_address).for
+  }
+}

--- a/language/stdlib/staged/src/script_whitelist.move
+++ b/language/stdlib/staged/src/script_whitelist.move
@@ -1,0 +1,16 @@
+address 0x0:
+
+module ScriptWhitelist {
+    use 0x0::LibraConfig;
+    use 0x0::Transaction;
+
+    struct T { payload: vector<u8> }
+
+    public fun initialize(payload: vector<u8>) {
+        LibraConfig::publish_new_config<Self::T>(T { payload })
+    }
+
+    public fun set(payload: vector<u8>) {
+        LibraConfig::set<Self::T>(Transaction::sender(), T { payload } )
+    }
+}

--- a/language/stdlib/staged/src/signature.move
+++ b/language/stdlib/staged/src/signature.move
@@ -1,0 +1,6 @@
+address 0x0:
+
+module Signature {
+    native public fun ed25519_verify(signature: vector<u8>, public_key: vector<u8>, message: vector<u8>): bool;
+    native public fun ed25519_threshold_verify(bitmap: vector<u8>, signature: vector<u8>, public_key: vector<u8>, message: vector<u8>): u64;
+}

--- a/language/stdlib/staged/src/transaction.move
+++ b/language/stdlib/staged/src/transaction.move
@@ -1,0 +1,15 @@
+address 0x0:
+
+module Transaction {
+    native public fun gas_unit_price(): u64;
+    native public fun max_gas_units(): u64;
+    native public fun gas_remaining(): u64;
+    native public fun sender(): address;
+    native public fun sequence_number(): u64;
+    native public fun public_key(): vector<u8>;
+
+    // inlined
+    public fun assert(check: bool, code: u64) {
+        if (check) () else abort code
+    }
+}

--- a/language/stdlib/staged/src/transaction_fee.move
+++ b/language/stdlib/staged/src/transaction_fee.move
@@ -1,0 +1,100 @@
+address 0x0:
+
+module TransactionFee {
+    use 0x0::LibraAccount;
+    use 0x0::LibraSystem;
+    use 0x0::Transaction;
+
+    ///////////////////////////////////////////////////////////////////////////
+    // Transaction Fee Distribution
+    ///////////////////////////////////////////////////////////////////////////
+    // Implements a basic transaction fee distribution logic.
+    //
+    // We have made a couple design decisions here that are worth noting:
+    //  * We pay out once per-block for now.
+    //    TODO: Once we have a better on-chain representation of
+    //          epochs this should be changed over to be once per-epoch.
+    //  * Sometimes the number of validators does not evenly divide the transaction fees to be
+    //    distributed. In such cases the remainder ("dust") is left in the transaction fees pot and
+    //    these remaining fees will be included in the calculations for the transaction fee
+    //    distribution in the next epoch. This distribution strategy is meant to in part minimize the
+    //    benefit of being the first validator in the validator set.
+
+    resource struct TransactionFees {
+        fee_withdrawal_capability: LibraAccount::WithdrawalCapability,
+    }
+
+    // Initialize the transaction fee distribution module. We keep track of the last paid block
+    // height in order to ensure that we don't try to pay more than once per-block. We also
+    // encapsulate the withdrawal capability to the transaction fee account so that we can withdraw
+    // the fees from this account from block metadata transactions.
+    fun initialize_transaction_fees() {
+        Transaction::assert(Transaction::sender() == 0xFEE, 0);
+        move_to_sender<TransactionFees>(TransactionFees {
+            fee_withdrawal_capability: LibraAccount::extract_sender_withdrawal_capability(),
+        });
+    }
+
+    public fun distribute_transaction_fees<Token>() acquires TransactionFees {
+      // Can only be invoked by LibraVM privilege.
+      Transaction::assert(Transaction::sender() == 0x0, 33);
+
+      let num_validators = LibraSystem::validator_set_size();
+      let amount_collected = LibraAccount::balance<Token>(0xFEE);
+
+      // If amount_collected == 0, this will also return early
+      if (amount_collected < num_validators) return ();
+
+      // Calculate the amount of money to be dispursed, along with the remainder.
+      let amount_to_distribute_per_validator = per_validator_distribution_amount(
+          amount_collected,
+          num_validators
+      );
+
+      // Iterate through the validators distributing fees equally
+      distribute_transaction_fees_internal<Token>(
+          amount_to_distribute_per_validator,
+          num_validators,
+      );
+    }
+
+    // After the book keeping has been performed, this then distributes the
+    // transaction fees equally to all validators with the exception that
+    // any remainder (in the case that the number of validators does not
+    // evenly divide the transaction fee pot) is distributed to the first
+    // validator.
+    fun distribute_transaction_fees_internal<Token>(
+        amount_to_distribute_per_validator: u64,
+        num_validators: u64
+    ) acquires TransactionFees {
+        let distribution_resource = borrow_global<TransactionFees>(0xFEE);
+        let index = 0;
+
+        while (index < num_validators) {
+
+            let addr = LibraSystem::get_ith_validator_address(index);
+            // Increment the index into the validator set.
+            index = index + 1;
+
+            LibraAccount::pay_from_capability<Token>(
+                addr,
+                x"",
+                &distribution_resource.fee_withdrawal_capability,
+                amount_to_distribute_per_validator,
+                x"",
+            );
+           }
+    }
+
+    // This calculates the amount to be distributed to each validator equally. We do this by calculating
+    // the integer division of the transaction fees collected by the number of validators. In
+    // particular, this means that if the number of validators does not evenly divide the
+    // transaction fees collected, then there will be a remainder that is left in the transaction
+    // fees pot to be distributed later.
+    fun per_validator_distribution_amount(amount_collected: u64, num_validators: u64): u64 {
+        Transaction::assert(num_validators != 0, 0);
+        let validator_payout = amount_collected / num_validators;
+        Transaction::assert(validator_payout * num_validators <= amount_collected, 1);
+        validator_payout
+    }
+}

--- a/language/stdlib/staged/src/validator_config.move
+++ b/language/stdlib/staged/src/validator_config.move
@@ -1,0 +1,119 @@
+address 0x0:
+
+module ValidatorConfig {
+
+    use 0x0::Transaction;
+    // TODO(philiphayes): We should probably enforce a max length for these fields
+
+    struct Config {
+        consensus_pubkey: vector<u8>,
+        validator_network_signing_pubkey: vector<u8>,
+        validator_network_identity_pubkey: vector<u8>,
+        validator_network_address: vector<u8>,
+        fullnodes_network_identity_pubkey: vector<u8>,
+        fullnodes_network_address: vector<u8>,
+    }
+
+    // A current or prospective validator should publish one of these under their address
+    resource struct T {
+        config: Config,
+    }
+
+    // Returns true if addr has a published ValidatorConfig::T resource
+    public fun has(addr: address): bool {
+        exists<T>(addr)
+    }
+
+    // The following are public accessors for retrieving config information about Validators
+
+    // Retrieve a read-only instance of a specific accounts ValidatorConfig::T.config
+    public fun config(addr: address): Config acquires T {
+      *&borrow_global<T>(addr).config
+    }
+
+    // Public accessor for consensus_pubkey
+    public fun consensus_pubkey(config_ref: &Config): vector<u8> {
+        *&config_ref.consensus_pubkey
+    }
+
+    // Public accessor for validator_network_signing_pubkey
+    public fun validator_network_signing_pubkey(config_ref: &Config): vector<u8> {
+        *&config_ref.validator_network_signing_pubkey
+    }
+
+    // Public accessor for validator_network_identity_pubkey
+    public fun validator_network_identity_pubkey(config_ref: &Config): vector<u8> {
+        *&config_ref.validator_network_identity_pubkey
+    }
+
+    // Public accessor for validator_network_address
+    public fun validator_network_address(config_ref: &Config): vector<u8> {
+        *&config_ref.validator_network_address
+    }
+
+    // Public accessor for fullnodes_network_identity_pubkey
+    public fun fullnodes_network_identity_pubkey(config_ref: &Config): vector<u8> {
+        *&config_ref.fullnodes_network_identity_pubkey
+    }
+
+    // Public accessor for fullnodes_network_address
+    public fun fullnodes_network_address(config_ref: &Config): vector<u8> {
+        *&config_ref.fullnodes_network_address
+    }
+
+    // The following are self methods for initializing and maintaining a Validator's config
+
+    // Register the transaction sender as a candidate validator by creating a ValidatorConfig
+    // resource under their account
+    public fun register_candidate_validator(
+        consensus_pubkey: vector<u8>,
+        validator_network_signing_pubkey: vector<u8>,
+        validator_network_identity_pubkey: vector<u8>,
+        validator_network_address: vector<u8>,
+        fullnodes_network_identity_pubkey: vector<u8>,
+        fullnodes_network_address: vector<u8>) {
+
+        move_to_sender<T>(
+            T {
+                config: Config {
+                     consensus_pubkey,
+                     validator_network_signing_pubkey,
+                     validator_network_identity_pubkey,
+                     validator_network_address,
+                     fullnodes_network_identity_pubkey,
+                     fullnodes_network_address,
+                }
+            }
+        );
+    }
+
+    // Rotate a validator candidate's consensus public key. The change will not take effect until
+    // the next reconfiguration.
+    public fun rotate_consensus_pubkey(consensus_pubkey: vector<u8>) acquires T {
+        let t_ref = borrow_global_mut<T>(Transaction::sender());
+        let key_ref = &mut t_ref.config.consensus_pubkey;
+        *key_ref = consensus_pubkey;
+    }
+
+    // TODO(philiphayes): fill out the rest of the rotate methods
+
+    // Rotate the network public key for validator discovery. This change will be
+    // committed in the next reconfiguration.
+    public fun rotate_validator_network_identity_pubkey(
+        validator_network_identity_pubkey: vector<u8>
+    ) acquires T {
+        let t_ref = borrow_global_mut<T>(Transaction::sender());
+        let key_ref = &mut t_ref.config.validator_network_identity_pubkey;
+        *key_ref = validator_network_identity_pubkey;
+    }
+
+    // Rotate the network address for validator discovery. This change will be
+    // committed in the next reconfiguration.
+    public fun rotate_validator_network_address(
+        validator_network_address: vector<u8>
+    ) acquires T {
+        let t_ref = borrow_global_mut<T>(Transaction::sender());
+        let key_ref = &mut t_ref.config.validator_network_address;
+        *key_ref = validator_network_address;
+    }
+}

--- a/language/stdlib/staged/src/validator_config_2.move
+++ b/language/stdlib/staged/src/validator_config_2.move
@@ -1,0 +1,109 @@
+address 0x0:
+
+module ValidatorConfig2 {
+    use 0x0::LibraAccount;
+    use 0x0::Transaction;
+
+    struct Config {
+        consensus_pubkey: vector<u8>,
+    }
+
+    // A current or prospective validator should publish one of these under their accounts.
+    // If delegation is enabled, only the delegated_account can change the config.
+    // If delegation is disabled, only the owner of this resource can change the config.
+    // The entity that can change the config is called a "validator operator".
+    // The owner of this resource can enable delegation and set delegated account.
+    // The owner can also disable delegation at any time.
+    resource struct T {
+        config: Config,
+        delegation_enabled: bool,
+        delegated_account: address,
+    }
+
+    // TODO(valerini): add events here
+
+    // Returns true if addr has a published ValidatorConfig::T resource
+    public fun has(addr: address): bool {
+        exists<T>(addr)
+    }
+
+    // Get Config
+    public fun get_config(addr: address): Config acquires T {
+        *&borrow_global<T>(addr).config
+    }
+
+    // Get consensus_pubkey from Config
+    public fun get_consensus_pubkey(config_ref: &Config): vector<u8> {
+        *&config_ref.consensus_pubkey
+    }
+
+    // Returns the address of the entity who is now in charge of managing the config.
+    public fun get_validator_operator_account(addr: address): address acquires T {
+        let t_ref = borrow_global<T>(addr);
+        if (t_ref.delegation_enabled) {
+            return *&t_ref.delegated_account
+        } else {
+            return addr
+        }
+    }
+
+    // Register the transaction sender as a candidate validator by creating a ValidatorConfig
+    // resource under their account. Note that only one such resource can be instantiated under an account.
+    public fun initialize(
+        consensus_pubkey: vector<u8>,) {
+
+        move_to_sender<T>(
+            T {
+                config: Config {
+                    consensus_pubkey: consensus_pubkey,
+                },
+                delegation_enabled: false,
+                delegated_account: 0x0
+            }
+        );
+    }
+
+    // If the sender of the transaction has a ValidatorConfig::T resource,
+    // this function will delegate management of the ValidatorConfig::T resource to a delegated_account.
+    public fun set_delegated_account(delegated_account: address) acquires T {
+        Transaction::assert(LibraAccount::exists(delegated_account), 5);
+        // check delegated address is different from transaction's sender
+        Transaction::assert(delegated_account != Transaction::sender(), 6);
+        let t_ref = borrow_global_mut<T>(Transaction::sender());
+        *(&mut t_ref.delegation_enabled) = true;
+        *(&mut t_ref.delegated_account) = delegated_account;
+    }
+
+    // If the sender of the transaction has a ValidatorConfig::T resource,
+    // this function will revoke management capabilities from the delegated_account account.
+    public fun remove_delegated_account() acquires T {
+        let t_ref = borrow_global_mut<T>(Transaction::sender());
+        *(&mut t_ref.delegation_enabled) = false;
+        *(&mut t_ref.delegated_account) = 0x0;
+    }
+
+    // Rotate validator's config.
+    // Here validator_account - is the account of the validator whose consensus_pubkey is going to be rotated.
+    public fun rotate_consensus_pubkey(
+        validator_account: address,
+        new_consensus_pubkey: vector<u8>,
+        _proof: vector<u8>
+    ) acquires T {
+        let addr = get_validator_operator_account(validator_account);
+        Transaction::assert(Transaction::sender() == addr, 1);
+
+        // TODO(valerini): verify the proof of posession of new_consensus_secretkey
+
+        let t_ref = borrow_global_mut<T>(validator_account);
+        // Assert that the new key is different from the old key
+        Transaction::assert(&t_ref.config.consensus_pubkey != &new_consensus_pubkey, 15);
+        // Set the new key
+        let key_ref = &mut t_ref.config.consensus_pubkey;
+        *key_ref = new_consensus_pubkey;
+    }
+
+    // Simplified arguments when the sender is the validators itself
+    public fun rotate_consensus_pubkey_of_sender(new_consensus_pubkey: vector<u8>, proof: vector<u8>) acquires T {
+        rotate_consensus_pubkey(Transaction::sender(), new_consensus_pubkey, proof);
+    }
+}

--- a/language/stdlib/staged/src/vector.move
+++ b/language/stdlib/staged/src/vector.move
@@ -1,0 +1,85 @@
+address 0x0:
+
+// A variable-sized container that can hold both unrestricted types and resources.
+module Vector {
+    native public fun empty<Element>(): vector<Element>;
+
+    // Return the length of the vector.
+    native public fun length<Element>(v: &vector<Element>): u64;
+
+    // Acquire an immutable reference to the ith element of the vector.
+    native public fun borrow<Element>(v: &vector<Element>, i: u64): &Element;
+
+    // Add an element to the end of the vector.
+    native public fun push_back<Element>(v: &mut vector<Element>, e: Element);
+
+    // Get mutable reference to the ith element in the vector, abort if out of bound.
+    native public fun borrow_mut<Element>(v: &mut vector<Element>, idx: u64): &mut Element;
+
+    // Pop an element from the end of vector, abort if the vector is empty.
+    native public fun pop_back<Element>(v: &mut vector<Element>): Element;
+
+    // Destroy the vector, abort if not empty.
+    native public fun destroy_empty<Element>(v: vector<Element>);
+
+    // Swaps the elements at the i'th and j'th indices in the vector.
+    native public fun swap<Element>(v: &mut vector<Element>, i: u64, j: u64);
+
+    // Reverses the order of the elements in the vector in place.
+    public fun reverse<Element>(v: &mut vector<Element>) {
+        let len = length(v);
+        if (len == 0) return ();
+
+        let front_index = 0;
+        let back_index = len -1;
+        while (front_index < back_index) {
+            swap(v, front_index, back_index);
+            front_index = front_index + 1;
+            back_index = back_index - 1;
+        }
+    }
+
+    // Moves all of the elements of the `other` vector into the `lhs` vector.
+    public fun append<Element>(lhs: &mut vector<Element>, other: vector<Element>) {
+        reverse(&mut other);
+        while (!is_empty(&other)) push_back(lhs, pop_back(&mut other));
+        destroy_empty(other);
+    }
+
+    // Return true if the vector has no elements
+    public fun is_empty<Element>(v: &vector<Element>): bool {
+        length(v) == 0
+    }
+
+    // Return true if `e` is in the vector `v`
+    public fun contains<Element>(v: &vector<Element>, e: &Element): bool {
+        let i = 0;
+        let len = length(v);
+        while (i < len) {
+            if (borrow(v, i) == e) return true;
+            i = i + 1;
+        };
+        false
+    }
+
+    // Remove the `i`th element E of the vector, shifting all subsequent elements
+    // It is O(n) and preserves ordering
+    public fun remove<Element>(v: &mut vector<Element>, i: u64): Element {
+        let len = length(v);
+        // i out of bounds; abort
+        if (i >= len) abort 10;
+
+        len = len - 1;
+        while (i < len) swap(v, i, { i = i + 1; i });
+        pop_back(v)
+    }
+
+    // Remove the `i`th element E of the vector by swapping it with the last element,
+    // and then popping it off
+    // It is O(1), but does not preserve ordering
+    public fun swap_remove<Element>(v: &mut vector<Element>, i: u64): Element {
+        let last_idx = length(v) - 1;
+        swap(v, i, last_idx);
+        pop_back(v)
+    }
+}


### PR DESCRIPTION
To compile a script or module that is not built with the stdlib, the Move compiler needs to import the stdlib source files for any dependencies. Those dependencies should match the Move binaries that are stored on-chain, so we need to save a copy of those sources when staging the stdlib binaries.

## Motivation

This is necessary to correctly use the Move source compiler for files with dependencies on the stdlib.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

I have a subsequent PR to switch libratest/smoke_test.rs to use the Move source language instead of the IR compiler. That will make use of these files and should catch problems with them.