### PR TITLE
[k8s][cluster-test] Delete old jobs in delete_all

### DIFF
--- a/testsuite/cluster-test/src/cluster_swarm/job_template.yaml
+++ b/testsuite/cluster-test/src/cluster_swarm/job_template.yaml
@@ -4,6 +4,7 @@ metadata:
   name: {name}
   labels:
     app: {label}
+    libra-node: "true"
 spec:
   template:
     metadata:


### PR DESCRIPTION
## Summary

* Replace `delete_pod`, `delete_service` with a generic `delete_resource`
* Update `delete_all` method to cleanup old `Job` objects as well

## Test Plan

Ran against my cluster