### PR TITLE
[x] upgrade to guppy 0.3.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1633,7 +1633,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "guppy"
-version = "0.2.1"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "cargo_metadata 0.9.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -6076,7 +6076,7 @@ name = "x-core"
 version = "0.1.0"
 dependencies = [
  "cargo_metadata 0.9.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "guppy 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "guppy 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "libra-workspace-hack 0.1.0",
  "once_cell 1.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -6085,7 +6085,7 @@ dependencies = [
 name = "x-lint"
 version = "0.1.0"
 dependencies = [
- "guppy 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "guppy 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "libra-workspace-hack 0.1.0",
  "once_cell 1.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "x-core 0.1.0",
@@ -6279,7 +6279,7 @@ dependencies = [
 "checksum get_if_addrs-sys 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "0d04f9fb746cf36b191c00f3ede8bde9c8e64f9f4b05ae2694a9ccf5e3f5ab48"
 "checksum getrandom 0.1.14 (registry+https://github.com/rust-lang/crates.io-index)" = "7abc8dd8451921606d809ba32e95b6111925cd2906060d2dcc29c070220503eb"
 "checksum glob 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "9b919933a397b79c37e33b77bb2aa3dc8eb6e165ad809e58ff75bc7db2e34574"
-"checksum guppy 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "ce60fc3a7abb42b1730ec1b7c9cc1b58cd95b83a2b1678940fafe7a1cd145436"
+"checksum guppy 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "1934f2169fc7cf100b38f8df941590069d597a204c58cf392388580b028be269"
 "checksum h2 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "9d5c295d1c0c68e4e42003d75f908f5e16a1edd1cbe0b0d02e4dc2006a384f47"
 "checksum headers 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "a72b4bd7cbbf0c22190e82f02517f456a6b9be24c25a6827b5802e478b8c2d70"
 "checksum headers-core 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "e7f66481bfee273957b1f20485a4ff3362987f85b2c236580d81b4eb7a326429"

--- a/devtools/x-core/Cargo.toml
+++ b/devtools/x-core/Cargo.toml
@@ -9,6 +9,6 @@ license = "Apache-2.0"
 
 [dependencies]
 cargo_metadata = "0.9.1"
-guppy = "0.2.1"
+guppy = "0.3.0"
 libra-workspace-hack = { path = "../../common/workspace-hack", version = "0.1.0" }
 once_cell = "1.3.1"

--- a/devtools/x-lint/Cargo.toml
+++ b/devtools/x-lint/Cargo.toml
@@ -8,7 +8,7 @@ publish = false
 license = "Apache-2.0"
 
 [dependencies]
-guppy = "0.2.1"
+guppy = "0.3.0"
 libra-workspace-hack = { path = "../../common/workspace-hack", version = "0.1.0" }
 once_cell = "1.3.1"
 x-core = { version = "0.1.0", path = "../x-core" }

--- a/devtools/x-lint/src/package.rs
+++ b/devtools/x-lint/src/package.rs
@@ -2,10 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::{prelude::*, LintContext};
-use guppy::{
-    graph::{PackageGraph, PackageMetadata},
-    PackageId,
-};
+use guppy::graph::PackageMetadata;
 use std::path::Path;
 
 /// Represents a linter that runs once per package.
@@ -28,14 +25,13 @@ pub struct PackageContext<'l> {
 impl<'l> PackageContext<'l> {
     pub fn new(
         project_ctx: ProjectContext<'l>,
-        package_graph: &'l PackageGraph,
         workspace_path: &'l Path,
-        id: &PackageId,
+        metadata: &'l PackageMetadata,
     ) -> Self {
         Self {
             project_ctx,
             workspace_path,
-            metadata: package_graph.metadata(id).expect("package id is valid"),
+            metadata,
         }
     }
 

--- a/devtools/x-lint/src/runner.rs
+++ b/devtools/x-lint/src/runner.rs
@@ -115,9 +115,8 @@ impl<'cfg> LintEngine<'cfg> {
         if !self.config.package_linters.is_empty() {
             let package_graph = project_ctx.package_graph()?;
 
-            for (workspace_path, id) in package_graph.workspace().members() {
-                let package_ctx =
-                    PackageContext::new(project_ctx, package_graph, workspace_path, id);
+            for (workspace_path, metadata) in package_graph.workspace().members() {
+                let package_ctx = PackageContext::new(project_ctx, workspace_path, metadata);
                 for linter in self.config.package_linters {
                     let source = package_ctx.source(linter.name());
                     let mut formatter = LintFormatter::new(source, &mut messages);


### PR DESCRIPTION
The new APIs suggested by @metajack mean the workspace hack linter is
simpler.