### PR TITLE
Use retries when building docker image

### DIFF
--- a/docker/cluster-test/buildspec.yaml
+++ b/docker/cluster-test/buildspec.yaml
@@ -13,7 +13,7 @@ phases:
     commands:
       - echo Build started on `date`
       - echo Building the Docker image...
-      - docker/cluster-test/build.sh
+      - bash docker/cluster-test/build.sh
   post_build:
     commands:
       - echo Build completed on `date`

--- a/docker/cluster-test/cluster-test.Dockerfile
+++ b/docker/cluster-test/cluster-test.Dockerfile
@@ -18,7 +18,8 @@ RUN rustup install $(cat rust-toolchain)
 COPY . /libra
 RUN docker/cluster-test/compile.sh
 FROM debian:buster
-RUN apt-get update && apt-get install -y openssh-client curl && curl -L "https://storage.googleapis.com/kubernetes-release/release/`curl -s https://storage.googleapis.com/kubernetes-release/release/stable.txt`/bin/linux/amd64/kubectl" -o /usr/local/bin/kubectl && chmod +x /usr/local/bin/kubectl
+RUN apt-get update && apt-get install -y openssh-client curl
+RUN curl -L "https://storage.googleapis.com/kubernetes-release/release/`curl -s https://storage.googleapis.com/kubernetes-release/release/stable.txt`/bin/linux/amd64/kubectl" -o /usr/local/bin/kubectl && chmod +x /usr/local/bin/kubectl
 RUN mkdir /etc/cluster-test
 WORKDIR /etc/cluster-test
 COPY --from=builder /target/release/cluster-test /usr/local/bin/cluster-test

--- a/docker/cluster-test/cluster-test.Dockerfile.template
+++ b/docker/cluster-test/cluster-test.Dockerfile.template
@@ -17,7 +17,8 @@ RUN docker/cluster-test/compile.sh
 
 FROM debian:buster
 
-RUN apt-get update && apt-get install -y openssh-client curl && curl -L "https://storage.googleapis.com/kubernetes-release/release/`curl -s https://storage.googleapis.com/kubernetes-release/release/stable.txt`/bin/linux/amd64/kubectl" -o /usr/local/bin/kubectl && chmod +x /usr/local/bin/kubectl
+RUN apt-get update && apt-get install -y openssh-client curl
+RUN curl -L "https://storage.googleapis.com/kubernetes-release/release/`curl -s https://storage.googleapis.com/kubernetes-release/release/stable.txt`/bin/linux/amd64/kubectl" -o /usr/local/bin/kubectl && chmod +x /usr/local/bin/kubectl
 
 RUN mkdir /etc/cluster-test
 WORKDIR /etc/cluster-test

--- a/docker/cluster-test/cluster-test.container.Dockerfile
+++ b/docker/cluster-test/cluster-test.container.Dockerfile
@@ -7,7 +7,8 @@
 ## - To comment must use double ##, single # will be treated as pre-processor command
 ## -
 FROM debian:buster
-RUN apt-get update && apt-get install -y openssh-client curl && curl -L "https://storage.googleapis.com/kubernetes-release/release/`curl -s https://storage.googleapis.com/kubernetes-release/release/stable.txt`/bin/linux/amd64/kubectl" -o /usr/local/bin/kubectl && chmod +x /usr/local/bin/kubectl
+RUN apt-get update && apt-get install -y openssh-client curl
+RUN curl -L "https://storage.googleapis.com/kubernetes-release/release/`curl -s https://storage.googleapis.com/kubernetes-release/release/stable.txt`/bin/linux/amd64/kubectl" -o /usr/local/bin/kubectl && chmod +x /usr/local/bin/kubectl
 RUN mkdir /etc/cluster-test
 WORKDIR /etc/cluster-test
 COPY cluster_test_docker_builder_cluster_test /usr/local/bin/cluster-test

--- a/docker/init/build.sh
+++ b/docker/init/build.sh
@@ -1,7 +1,6 @@
-#!/bin/sh
+#!/bin/bash
 # Copyright (c) The Libra Core Contributors
 # SPDX-License-Identifier: Apache-2.0
-set -e
 
 DIR="$( cd "$( dirname "$0" )" && pwd )"
 
@@ -10,4 +9,13 @@ if [ "$https_proxy" ]; then
     PROXY=" --build-arg https_proxy=$https_proxy --build-arg http_proxy=$http_proxy"
 fi
 
-docker build -f $DIR/Dockerfile $DIR/../.. --tag libra_init --build-arg GIT_REV="$(git rev-parse HEAD)" --build-arg GIT_UPSTREAM="$(git merge-base HEAD origin/master)" --build-arg BUILD_DATE="$(date -u +'%Y-%m-%dT%H:%M:%SZ')" $PROXY "$@"
+for ((i = 0; i < 30; i++)); do
+  docker build -f $DIR/Dockerfile $DIR/../.. --tag libra_init --build-arg GIT_REV="$(git rev-parse HEAD)" --build-arg GIT_UPSTREAM="$(git merge-base HEAD origin/master)" --build-arg BUILD_DATE="$(date -u +'%Y-%m-%dT%H:%M:%SZ')" $PROXY "$@"
+  if [[ $? -eq 0 ]]; then
+    echo "docker build succeeded"
+    exit 0
+  fi
+  echo "docker build failed. retrying in 10 secs."
+  sleep 10
+done
+exit 1

--- a/docker/validator-dynamic/buildspec.yaml
+++ b/docker/validator-dynamic/buildspec.yaml
@@ -14,7 +14,7 @@ phases:
       - echo Build started on `date`
       - echo Building the Docker image...
       - docker/validator/build.sh
-      - docker/validator-dynamic/build.sh
+      - bash docker/validator-dynamic/build.sh
   post_build:
     commands:
       - echo Build completed on `date`


### PR DESCRIPTION
## Summary

* Failing to download kubectl was causing CI failures. 
* This adds a retry mechanism when building docker image

## Test Plan

Ran build script