### PR TITLE
[move-prover] Allow spec functions to depend on global state.

### DIFF
--- a/language/move-prover/src/prelude.bpl
+++ b/language/move-prover/src/prelude.bpl
@@ -1031,21 +1031,25 @@ procedure {:inline 1} Signature_ed25519_threshold_verify(bitmap: Value, signatur
 // Serialize is modeled as an uninterpreted function, with an additional
 // axiom to say it's an injection.
 
-function $LCS_serialize(ta: TypeValue, v: Value): Value;
+function {:inline} $LCS_serialize($m: Memory, ta: TypeValue, v: Value): Value {
+    $LCS_serialize_core(ta, v)
+}
+
+function $LCS_serialize_core(ta: TypeValue, v: Value): Value;
 
 // This says that $serialize respects isEquals (substitution property)
 // Without this, Boogie will get false positives where v1, v2 differ at invalid
 // indices.
 axiom (forall ta: TypeValue ::
-       (forall v1,v2: Value :: IsEqual(v1, v2) ==> IsEqual($LCS_serialize(ta, v1), $LCS_serialize(ta, v2))));
+       (forall v1,v2: Value :: IsEqual(v1, v2) ==> IsEqual($LCS_serialize_core(ta, v1), $LCS_serialize_core(ta, v2))));
 
 
 // This says that serialize is an injection
 axiom (forall ta1, ta2: TypeValue ::
-       (forall v1, v2: Value :: IsEqual($LCS_serialize(ta1, v1), $LCS_serialize(ta2, v2))
+       (forall v1, v2: Value :: IsEqual($LCS_serialize_core(ta1, v1), $LCS_serialize_core(ta2, v2))
            ==> IsEqual(v1, v2) && (ta1 == ta2)));
 
 procedure $LCS_to_bytes(ta: TypeValue, r: Reference) returns (res: Value);
-ensures res == $LCS_serialize(ta, $Dereference($m, r));
+ensures res == $LCS_serialize_core(ta, $Dereference($m, r));
 ensures $IsValidU8Vector(res);    // result is a legal vector of U8s.
 ensures $vlen(res) > 0;

--- a/language/move-prover/src/spec_translator.rs
+++ b/language/move-prover/src/spec_translator.rs
@@ -201,7 +201,11 @@ impl<'env> SpecTranslator<'env> {
                 self.writer,
                 "function {{:inline}} {}({}): {} {{",
                 boogie_spec_fun_name(&self.module_env, *id),
-                type_params.chain(params).join(", "),
+                vec!["$m: Memory".to_string()]
+                    .into_iter()
+                    .chain(type_params)
+                    .chain(params)
+                    .join(", "),
                 result_type
             );
             self.writer.indent();
@@ -815,20 +819,13 @@ impl<'env> SpecTranslator<'env> {
         let module_env = self.module_env.env.get_module(module_id);
         let name = boogie_spec_fun_name(&module_env, fun_id);
         emit!(self.writer, "{}(", name);
-        let mut first = true;
-        let mut maybe_comma = || {
-            if first {
-                first = false;
-            } else {
-                emit!(self.writer, ", ");
-            }
-        };
+        emit!(self.writer, "$m");
         for ty in instantiation.iter() {
-            maybe_comma();
+            emit!(self.writer, ", ");
             emit!(self.writer, &boogie_type_value(self.module_env.env, ty));
         }
         for exp in args {
-            maybe_comma();
+            emit!(self.writer, ", ");
             self.translate_exp(exp);
         }
         emit!(self.writer, ")");

--- a/language/move-prover/tests/sources/defines.move
+++ b/language/move-prover/tests/sources/defines.move
@@ -16,4 +16,29 @@ module TestDefines {
         aborts_if !in_range(x + y, 0, 18446744073709551615);
         ensures eq(result, x + y);
     }
+
+    // --------------------------------------
+    // Spec functions accessing global state.
+    // --------------------------------------
+
+    resource struct R { x: u64 }
+
+    spec module {
+        define exists_both(addr1: address, addr2: address): bool {
+            exists<R>(addr1) && exists<R>(addr2)
+        }
+        define get(addr: address): u64 {
+            global<R>(addr).x
+        }
+    }
+
+    fun equal_R(addr1: address, addr2: address): bool acquires R {
+        let r1 = borrow_global<R>(addr1);
+        let r2 = borrow_global<R>(addr2);
+        r1.x == r2.x
+    }
+    spec fun equal_R {
+        aborts_if !exists_both(addr1, addr2);
+        ensures result == (get(addr1) == get(addr2));
+    }
 }


### PR DESCRIPTION
## Motivation

Allow spec functions to provide state dependent abstractions.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

Added a new test.

## Related PRs

NA