### PR TITLE
Get rid of some path hacks

### DIFF
--- a/crypto/crypto/src/hash.rs
+++ b/crypto/crypto/src/hash.rs
@@ -101,11 +101,6 @@ use std::{self, convert::AsRef, fmt};
 use tiny_keccak::{Hasher, Sha3};
 
 const LIBRA_HASH_SUFFIX: &[u8] = b"@@$$LIBRA$$@@";
-
-#[cfg(test)]
-#[path = "unit_tests/hash_test.rs"]
-mod hash_test;
-
 const SHORT_STRING_LENGTH: usize = 4;
 
 /// Output value of our hash function. Intentionally opaque for safety and modularity.

--- a/crypto/crypto/src/unit_tests/hash_test.rs
+++ b/crypto/crypto/src/unit_tests/hash_test.rs
@@ -3,6 +3,7 @@
 
 use crate::hash::*;
 use bitvec::prelude::*;
+use libra_nibble::Nibble;
 use proptest::{collection::vec, prelude::*};
 use rand::{rngs::StdRng, SeedableRng};
 use serde::Serialize;

--- a/crypto/crypto/src/unit_tests/mod.rs
+++ b/crypto/crypto/src/unit_tests/mod.rs
@@ -3,5 +3,6 @@
 
 mod cross_test;
 mod ed25519_test;
+mod hash_test;
 mod hkdf_test;
 mod multi_ed25519_test;

--- a/types/src/proof/definition.rs
+++ b/types/src/proof/definition.rs
@@ -3,10 +3,6 @@
 
 //! This module has definition of various proofs.
 
-#[cfg(test)]
-#[path = "unit_tests/proof_conversion_test.rs"]
-mod proof_conversion_test;
-
 use super::{
     position::Position, verify_transaction_info, MerkleTreeInternalNode, SparseMerkleInternalNode,
     SparseMerkleLeafNode,

--- a/types/src/proof/mod.rs
+++ b/types/src/proof/mod.rs
@@ -8,8 +8,7 @@ pub mod position;
 pub mod proptest_proof;
 
 #[cfg(test)]
-#[path = "unit_tests/proof_test.rs"]
-mod proof_test;
+mod unit_tests;
 
 use crate::{
     ledger_info::LedgerInfo,

--- a/types/src/proof/unit_tests/mod.rs
+++ b/types/src/proof/unit_tests/mod.rs
@@ -1,0 +1,5 @@
+// Copyright (c) The Libra Core Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+mod proof_conversion_test;
+mod proof_test;


### PR DESCRIPTION
Using `#[path]` is unnecessary and kind of hacky.