### PR TITLE
[network] Add ErrorCode::NotSupported to wire protocol

### DIFF
--- a/network/src/protocols/wire/messaging/v1/mod.rs
+++ b/network/src/protocols/wire/messaging/v1/mod.rs
@@ -30,6 +30,8 @@ pub enum ErrorCode {
     ParsingError(MessagingProtocolVersion, Box<NetworkMessage>),
     /// Ping timed out.
     TimedOut,
+    /// A message was received for a protocol that is not supported over this connection.
+    NotSupported(ProtocolId),
 }
 
 /// Nonces used by Ping and Pong message types.


### PR DESCRIPTION
### Motivation

ErrorCode::ParsingError does not capture the case where we support a protocol in the code, but don't want to expose it to a client. An example might be the internal protocols like the one that will be created for Validator -> SafetyRules communication - these protocols can be correctly parse, but should not be exposed to external nodes.