### PR TITLE
[move-lang] Extending parser and expansion by generic spec vars.

### DIFF
--- a/language/move-lang/src/expansion/translate.rs
+++ b/language/move-lang/src/expansion/translate.rs
@@ -785,8 +785,8 @@ fn exp_(context: &mut Context, sp!(loc, pe_): P::Exp) -> E::Exp {
         PE::Name(pn, ptys_opt) => {
             if (matches!(pn.value, P::ModuleAccess_::ModuleAccess(..)) || ptys_opt.is_some())
                 && !context.require_spec_context(
-                    pn.loc,
-                    "Expected either a brace-enclosed list of field expressions or a parenthesized list of arguments for a function call",
+                    loc,
+                    "Expected name to be followed by a brace-enclosed list of field expressions or a parenthesized list of arguments for a function call",
                 )
             {
                 assert!(context.has_errors());

--- a/language/move-lang/src/naming/translate.rs
+++ b/language/move-lang/src/naming/translate.rs
@@ -706,7 +706,7 @@ fn exp_(context: &mut Context, e: E::Exp) -> N::Exp {
         EE::Value(val) => NE::Value(val),
         EE::Move(v) => NE::Move(v),
         EE::Copy(v) => NE::Copy(v),
-        EE::Name(v) => NE::Use(Var(v)),
+        EE::Name(sp!(_, E::ModuleAccess_::Name(v)), None) => NE::Use(Var(v)),
 
         EE::IfElse(eb, et, ef) => {
             NE::IfElse(exp(context, *eb), exp(context, *et), exp(context, *ef))
@@ -845,7 +845,11 @@ fn exp_(context: &mut Context, e: E::Exp) -> N::Exp {
             assert!(context.has_errors());
             NE::UnresolvedError
         }
-        EE::Index(..) | EE::Lambda(..) => panic!("unexpected specification construct"),
+        EE::Index(..) | EE::Lambda(..) |
+        // matches name variants only allowed in specs (we handle the allowed ones above)
+        EE::Name(..) => {
+            panic!("unexpected specification construct")
+        }
     };
     sp(eloc, ne_)
 }
@@ -876,7 +880,8 @@ fn lvalue(context: &mut Context, case: LValueCase, sp!(loc, l_): E::LValue) -> O
     use E::LValue_ as EL;
     use N::LValue_ as NL;
     let nl_ = match l_ {
-        EL::Var(v) => {
+        EL::Var(sp!(_, E::ModuleAccess_::Name(n)), None) => {
+            let v = Var(n);
             if v.starts_with_underscore() {
                 NL::Ignore
             } else {
@@ -901,6 +906,7 @@ fn lvalue(context: &mut Context, case: LValueCase, sp!(loc, l_): E::LValue) -> O
                 nfields.expect("ICE fields were already unique"),
             )
         }
+        EL::Var(..) => panic!("unexpected specification construct"),
     };
     Some(sp(loc, nl_))
 }

--- a/language/move-lang/src/naming/translate.rs
+++ b/language/move-lang/src/naming/translate.rs
@@ -848,7 +848,7 @@ fn exp_(context: &mut Context, e: E::Exp) -> N::Exp {
         EE::Index(..) | EE::Lambda(..) |
         // matches name variants only allowed in specs (we handle the allowed ones above)
         EE::Name(..) => {
-            panic!("unexpected specification construct")
+            panic!("ICE unexpected specification construct")
         }
     };
     sp(eloc, ne_)

--- a/language/move-lang/src/parser/syntax.rs
+++ b/language/move-lang/src/parser/syntax.rs
@@ -581,7 +581,6 @@ fn parse_term<'input>(tokens: &mut Lexer<'input>) -> Result<Exp, Error> {
         }
 
         Tok::NameValue => {
-            let name_loc = make_loc(tokens.file_name(), start_loc, start_loc);
             // Check if this is a ModuleAccess for a pack or call expression.
             match tokens.lookahead()? {
                 Tok::ColonColon | Tok::LBrace | Tok::LParen => {
@@ -600,10 +599,14 @@ fn parse_term<'input>(tokens: &mut Lexer<'input>) -> Result<Exp, Error> {
                             Err(e)
                         })?
                     } else {
-                        Exp_::Name(sp(name_loc, ModuleAccess_::Name(parse_name(tokens)?)), None)
+                        let name = parse_name(tokens)?;
+                        Exp_::Name(sp(name.loc, ModuleAccess_::Name(name)), None)
                     }
                 }
-                _ => Exp_::Name(sp(name_loc, ModuleAccess_::Name(parse_name(tokens)?)), None),
+                _ => {
+                    let name = parse_name(tokens)?;
+                    Exp_::Name(sp(name.loc, ModuleAccess_::Name(name)), None)
+                }
             }
         }
 

--- a/language/move-lang/tests/move_check/expansion/standalone_mname_with_type_args.exp
+++ b/language/move-lang/tests/move_check/expansion/standalone_mname_with_type_args.exp
@@ -1,14 +1,8 @@
 error: 
 
-   ┌── tests/move_check/expansion/standalone_mname_with_type_args.move:3:27 ───
+   ┌── tests/move_check/expansion/standalone_mname_with_type_args.move:3:21 ───
    │
  3 │         let _ = 0 + M<u64>;
-   │                           ^ Unexpected ';'
-   ·
- 3 │         let _ = 0 + M<u64>;
-   │                           - Expected either a brace-enclosed list of field expressions or a parenthesized list of arguments for a function call
-   ·
- 3 │         let _ = 0 + M<u64>;
-   │                      - Perhaps you need a blank space before this '<' operator?
+   │                     ^ Expected either a brace-enclosed list of field expressions or a parenthesized list of arguments for a function call
    │
 

--- a/language/move-lang/tests/move_check/expansion/standalone_mname_with_type_args.exp
+++ b/language/move-lang/tests/move_check/expansion/standalone_mname_with_type_args.exp
@@ -3,6 +3,6 @@ error:
    ┌── tests/move_check/expansion/standalone_mname_with_type_args.move:3:21 ───
    │
  3 │         let _ = 0 + M<u64>;
-   │                     ^ Expected either a brace-enclosed list of field expressions or a parenthesized list of arguments for a function call
+   │                     ^^^^^^ Expected name to be followed by a brace-enclosed list of field expressions or a parenthesized list of arguments for a function call
    │
 

--- a/language/move-lang/tests/move_check/expansion/standalone_name_with_type_args.exp
+++ b/language/move-lang/tests/move_check/expansion/standalone_name_with_type_args.exp
@@ -3,6 +3,6 @@ error:
    ┌── tests/move_check/expansion/standalone_name_with_type_args.move:3:17 ───
    │
  3 │         let _ = n<u64>;
-   │                 ^ Expected either a brace-enclosed list of field expressions or a parenthesized list of arguments for a function call
+   │                 ^^^^^^ Expected name to be followed by a brace-enclosed list of field expressions or a parenthesized list of arguments for a function call
    │
 

--- a/language/move-lang/tests/move_check/expansion/standalone_name_with_type_args.exp
+++ b/language/move-lang/tests/move_check/expansion/standalone_name_with_type_args.exp
@@ -1,14 +1,8 @@
 error: 
 
-   ┌── tests/move_check/expansion/standalone_name_with_type_args.move:3:23 ───
+   ┌── tests/move_check/expansion/standalone_name_with_type_args.move:3:17 ───
    │
  3 │         let _ = n<u64>;
-   │                       ^ Unexpected ';'
-   ·
- 3 │         let _ = n<u64>;
-   │                       - Expected either a brace-enclosed list of field expressions or a parenthesized list of arguments for a function call
-   ·
- 3 │         let _ = n<u64>;
-   │                  - Perhaps you need a blank space before this '<' operator?
+   │                 ^ Expected either a brace-enclosed list of field expressions or a parenthesized list of arguments for a function call
    │
 

--- a/language/move-lang/tests/move_check/parser/invalid_unpack_assign_rhs_not_fields.exp
+++ b/language/move-lang/tests/move_check/parser/invalid_unpack_assign_rhs_not_fields.exp
@@ -6,6 +6,6 @@ error:
     │              ^ Unexpected '0'
     ·
  11 │         X::S 0 = 0;
-    │              - Expected either a brace-enclosed list of field expressions or a parenthesized list of arguments for a function call
+    │              - Expected ';'
     │
 

--- a/language/move-lang/tests/move_check/parser/missing_angle_brace_close.exp
+++ b/language/move-lang/tests/move_check/parser/missing_angle_brace_close.exp
@@ -1,0 +1,14 @@
+error: 
+
+   ┌── tests/move_check/parser/missing_angle_brace_close.move:3:22 ───
+   │
+ 3 │         let x = t<u64;
+   │                      ^ Expected '>'
+   ·
+ 3 │         let x = t<u64;
+   │                  - To match this '<'
+   ·
+ 3 │         let x = t<u64;
+   │                  - Perhaps you need a blank space before this '<' operator?
+   │
+

--- a/language/move-lang/tests/move_check/parser/missing_angle_brace_close.move
+++ b/language/move-lang/tests/move_check/parser/missing_angle_brace_close.move
@@ -1,0 +1,5 @@
+module M {
+    fun foo() {
+        let x = t<u64;
+    }
+}

--- a/language/move-lang/tests/move_check/parser/spec_parsing_ok.move
+++ b/language/move-lang/tests/move_check/parser/spec_parsing_ok.move
@@ -102,4 +102,17 @@ module M {
     fun using_implies(x: u64): u64 {
         x
     }
+
+    spec module {
+        global generic<T>: u64;
+        invariant update generic<u64> = 23;
+        invariant update Self::generic<u64> = 24;
+    }
+
+    fun some_generic<T>() {
+    }
+    spec fun some_generic {
+        ensures generic<T> == 1;
+        ensures Self::generic<T> == 1;
+    }
 }


### PR DESCRIPTION
This PR adds the syntax `name<t1, .., tn>` resp. `mod::name<t1,..,tn>` to the asts and syntax of move lang. Move prover needs to have this expression forms to deal with global specifications of generic resources (like the new generic coin type).

As with other expression constructs only allowed in specs, we parse this form and then reject it in expansion if it doesn't appear in a spec block.

There is some change in error reporting implied by this change. Previously, if we had `name<t1,..,tn>`, an error would have been produced that either a `(..)` or a `{..}` needs to follow. Instead, now we accept this during parsing, but reject it in expansion. The existing test cases for this have been taken over, but now produce different baseline output. Because those tests where also the only case where we test the hint 'Perhaps you missed a space before `<`' a new test case was added to cover this error.

## Motivation

Global specifications

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

Added tests.

## Related PRs

NA
