### PR TITLE
[consensus] use SimulatedTimeService in chained_bft_smr_test

### DIFF
--- a/config/src/config/consensus_config.rs
+++ b/config/src/config/consensus_config.rs
@@ -20,13 +20,13 @@ impl Default for ConsensusConfig {
     fn default() -> ConsensusConfig {
         ConsensusConfig {
             max_block_size: 1000,
+            contiguous_rounds: 2,
+            max_pruned_blocks_in_mem: 10000,
+            pacemaker_initial_timeout_ms: 1000,
             proposer_type: ConsensusProposerType::LeaderReputation(LeaderReputationConfig {
                 active_weights: 99,
                 inactive_weights: 1,
             }),
-            contiguous_rounds: 2,
-            max_pruned_blocks_in_mem: 10000,
-            pacemaker_initial_timeout_ms: 1000,
             safety_rules: SafetyRulesConfig::default(),
         }
     }

--- a/consensus/src/chained_bft/liveness/pacemaker.rs
+++ b/consensus/src/chained_bft/liveness/pacemaker.rs
@@ -82,7 +82,6 @@ pub struct ExponentialTimeInterval {
     max_exponent: usize,
 }
 
-#[allow(dead_code)]
 impl ExponentialTimeInterval {
     #[cfg(any(test, feature = "fuzzing"))]
     pub fn fixed(duration: Duration) -> Self {

--- a/consensus/src/chained_bft/network_tests.rs
+++ b/consensus/src/chained_bft/network_tests.rs
@@ -17,6 +17,7 @@ use consensus_types::{
     vote_msg::VoteMsg,
 };
 use futures::{channel::mpsc, SinkExt, StreamExt};
+use libra_logger::prelude::*;
 use libra_types::{block_info::BlockInfo, PeerId};
 use network::{
     peer_manager::{
@@ -223,6 +224,12 @@ impl NetworkPlayground {
                 msg_notif
             ),
         };
+        debug!(
+            "[network playground] Deliver {:?} from {} to {}",
+            msg_copy.1,
+            src.short_str(),
+            dst.short_str()
+        );
 
         node_consensus_tx
             .push((src, ProtocolId::ConsensusDirectSend), msg_notif)

--- a/consensus/src/chained_bft/test_utils/mod.rs
+++ b/consensus/src/chained_bft/test_utils/mod.rs
@@ -26,7 +26,7 @@ pub use mock_state_computer::{EmptyStateComputer, MockStateComputer};
 pub use mock_storage::{EmptyStorage, MockSharedStorage, MockStorage};
 pub use mock_txn_manager::MockTransactionManager;
 
-pub const TEST_TIMEOUT: Duration = Duration::from_secs(60);
+pub const TEST_TIMEOUT: Duration = Duration::from_secs(10);
 
 pub type TestPayload = Vec<usize>;
 


### PR DESCRIPTION
<!--
Thank you for sending a PR. We appreciate you spending time to help improve the Libra project.

The project is undergoing daily changes. Pull Requests will be reviewed and responded to as time permits.
-->

## Motivation

For the sake of all the flakiness, we replace the ClockTimeService with
SimulatedTimeService.

Note this doesn't eliminate all indeterminism since we can't properly
wait for events like a new round or new proposal received.

Any tests depending on non-exposing interface (block_store, new round,
received proposal etc) is probably written in wrong layer of
abstraction.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?

Y

## Test Plan

for i in {1..100}; do cargo x test -p consensus -- chained_bft_smr_test; done

## Related PRs

(If this PR adds or changes functionality, please take some time to update the docs at https://github.com/libra/website, and link to your PR here.)
