### PR TITLE
[move-prover] Verified save_account in LibraAccount

### DIFF
--- a/language/move-prover/src/bytecode_translator.rs
+++ b/language/move-prover/src/bytecode_translator.rs
@@ -205,13 +205,21 @@ impl<'env> ModuleTranslator<'env> {
             );
         }
         let type_value = format!("StructType({}, {})", struct_name, field_types);
-        if struct_name == "LibraAccount_T" {
+        if struct_name == "$LibraAccount_T" {
             // Special treatment of well-known resource LibraAccount_T. The type_value
-            // function is forward-declared in the prelude, here we only add an axiom for
-            // it.
+            // function is forward-declared in the prelude, here we only add an axiom for it.
             emitln!(
                 self.writer,
                 "axiom {}_type_value() == {};",
+                struct_name,
+                type_value
+            );
+        } else if struct_name == "$LibraAccount_Balance" {
+            // Special treatment of well-known resource LibraAccount_Balance. The type_value
+            // function is forward-declared in the prelude, here we only add an axiom for it.
+            emitln!(
+                self.writer,
+                "axiom (forall $tv0: TypeValue :: {}_type_value($tv0) == {});",
                 struct_name,
                 type_value
             );


### PR DESCRIPTION
- Updated Prelude to add the builtin Boogie model for the native function `LibraAccount::save_account`
- Corrected the forward declarations of `$LibraAccount_T_type_value` and `$LibraAccount_Balance_type_value` in Prelude and `bytecode_translator.rs`
- Added and verified a temporary function `verify_save_account` in LibraAccount
- Added a FIXME in `libra_account.move`
    - the current spec of `create_account` should be verified, but Z3 does not terminate on this.

<!--
Thank you for sending a PR. We appreciate you spending time to help improve the Libra project.

The project is undergoing daily changes. Pull Requests will be reviewed and responded to as time permits.
-->

## Motivation

(Write your motivation for proposed changes here.)

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?

(Write your answer here.)

## Test Plan

(Share your test plan here. If you changed code, please provide us with clear instructions for verifying that your changes work.)

## Related PRs

(If this PR adds or changes functionality, please take some time to update the docs at https://github.com/libra/website, and link to your PR here.)
