### PR TITLE
[move lang/prover] codespan update

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6146,7 +6146,6 @@ dependencies = [
 "checksum clap 2.33.0 (registry+https://github.com/rust-lang/crates.io-index)" = "5067f5bb2d80ef5d68b4c87db81601f0b75bca627bc2ef76b141d7b846a3c6d9"
 "checksum clear_on_drop 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "97276801e127ffb46b66ce23f35cc96bd454fa311294bced4bbace7baa8b1d17"
 "checksum cloudabi 0.0.3 (registry+https://github.com/rust-lang/crates.io-index)" = "ddfc5b9aa5d4507acaf872de71051dfd0e309860e88966e1051e462a077aac4f"
-"checksum cmake 0.1.42 (registry+https://github.com/rust-lang/crates.io-index)" = "81fb25b677f8bf1eb325017cb6bb8452f87969db0fedb4f757b297bee78a7c62"
 "checksum codespan 0.9.2 (registry+https://github.com/rust-lang/crates.io-index)" = "e922c62c92c7cae8ae89393d00586fe16660c7f4e2cefef200858198d8bab936"
 "checksum codespan-reporting 0.9.2 (registry+https://github.com/rust-lang/crates.io-index)" = "4efca5ddfdf45cee2eedd9dadbe7a5fa90a5536af6f580f1814267b2a4d6107f"
 "checksum constant_time_eq 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "245097e9a4535ee1e3e3931fcfcd55a796a44c643e8596ff6566d68f09b87bbc"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -425,8 +425,8 @@ name = "bytecode-source-map"
 version = "0.1.0"
 dependencies = [
  "anyhow 1.0.28 (registry+https://github.com/rust-lang/crates.io-index)",
- "codespan 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "codespan-reporting 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "codespan 0.9.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "codespan-reporting 0.9.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "libra-types 0.1.0",
  "libra-workspace-hack 0.1.0",
  "move-core-types 0.1.0",
@@ -704,19 +704,19 @@ dependencies = [
 
 [[package]]
 name = "codespan"
-version = "0.8.0"
+version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
+ "codespan-reporting 0.9.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.106 (registry+https://github.com/rust-lang/crates.io-index)",
- "unicode-segmentation 1.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "codespan-reporting"
-version = "0.8.0"
+version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "codespan 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.106 (registry+https://github.com/rust-lang/crates.io-index)",
  "termcolor 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "unicode-width 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -1836,8 +1836,8 @@ version = "0.1.0"
 dependencies = [
  "anyhow 1.0.28 (registry+https://github.com/rust-lang/crates.io-index)",
  "bytecode-source-map 0.1.0",
- "codespan 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "codespan-reporting 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "codespan 0.9.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "codespan-reporting 0.9.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "ir-to-bytecode-syntax 0.1.0",
  "libra-types 0.1.0",
  "libra-workspace-hack 0.1.0",
@@ -1854,7 +1854,7 @@ name = "ir-to-bytecode-syntax"
 version = "0.1.0"
 dependencies = [
  "anyhow 1.0.28 (registry+https://github.com/rust-lang/crates.io-index)",
- "codespan 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "codespan 0.9.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "hex 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "libra-types 0.1.0",
  "libra-workspace-hack 0.1.0",
@@ -2930,7 +2930,7 @@ name = "move-ir-types"
 version = "0.1.0"
 dependencies = [
  "anyhow 1.0.28 (registry+https://github.com/rust-lang/crates.io-index)",
- "codespan 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "codespan 0.9.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "hex 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "libra-types 0.1.0",
  "libra-workspace-hack 0.1.0",
@@ -2947,8 +2947,8 @@ dependencies = [
  "borrow-graph 0.0.1",
  "bytecode-source-map 0.1.0",
  "bytecode-verifier 0.1.0",
- "codespan 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "codespan-reporting 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "codespan 0.9.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "codespan-reporting 0.9.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "datatest-stable 0.1.0",
  "difference 2.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "functional-tests 0.1.0",
@@ -2972,8 +2972,8 @@ dependencies = [
  "anyhow 1.0.28 (registry+https://github.com/rust-lang/crates.io-index)",
  "bytecode-source-map 0.1.0",
  "clap 2.33.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "codespan 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "codespan-reporting 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "codespan 0.9.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "codespan-reporting 0.9.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "datatest-stable 0.1.0",
  "itertools 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "libra-temppath 0.1.0",
@@ -4590,8 +4590,8 @@ dependencies = [
  "anyhow 1.0.28 (registry+https://github.com/rust-lang/crates.io-index)",
  "bytecode-source-map 0.1.0",
  "bytecode-verifier 0.1.0",
- "codespan 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "codespan-reporting 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "codespan 0.9.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "codespan-reporting 0.9.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "datatest-stable 0.1.0",
  "itertools 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "libra-types 0.1.0",
@@ -4623,8 +4623,8 @@ version = "0.1.0"
 dependencies = [
  "anyhow 1.0.28 (registry+https://github.com/rust-lang/crates.io-index)",
  "bytecode-verifier 0.1.0",
- "codespan 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "codespan-reporting 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "codespan 0.9.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "codespan-reporting 0.9.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "datatest-stable 0.1.0",
  "ir-to-bytecode 0.1.0",
  "itertools 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -6146,8 +6146,9 @@ dependencies = [
 "checksum clap 2.33.0 (registry+https://github.com/rust-lang/crates.io-index)" = "5067f5bb2d80ef5d68b4c87db81601f0b75bca627bc2ef76b141d7b846a3c6d9"
 "checksum clear_on_drop 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "97276801e127ffb46b66ce23f35cc96bd454fa311294bced4bbace7baa8b1d17"
 "checksum cloudabi 0.0.3 (registry+https://github.com/rust-lang/crates.io-index)" = "ddfc5b9aa5d4507acaf872de71051dfd0e309860e88966e1051e462a077aac4f"
-"checksum codespan 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)" = "52899426b69706219a1aaee2e95868fd01a0bd8006bb163f069578a0af5b5bb2"
-"checksum codespan-reporting 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)" = "600c3317d4705222ff820139aaa76a3a208024ffc41f894da565a4c3b949d4c9"
+"checksum cmake 0.1.42 (registry+https://github.com/rust-lang/crates.io-index)" = "81fb25b677f8bf1eb325017cb6bb8452f87969db0fedb4f757b297bee78a7c62"
+"checksum codespan 0.9.2 (registry+https://github.com/rust-lang/crates.io-index)" = "e922c62c92c7cae8ae89393d00586fe16660c7f4e2cefef200858198d8bab936"
+"checksum codespan-reporting 0.9.2 (registry+https://github.com/rust-lang/crates.io-index)" = "4efca5ddfdf45cee2eedd9dadbe7a5fa90a5536af6f580f1814267b2a4d6107f"
 "checksum constant_time_eq 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "245097e9a4535ee1e3e3931fcfcd55a796a44c643e8596ff6566d68f09b87bbc"
 "checksum cookie 0.13.3 (registry+https://github.com/rust-lang/crates.io-index)" = "0c60ef6d0bbf56ad2674249b6bb74f2c6aeb98b98dd57b5d3e37cace33011d69"
 "checksum core-foundation 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "57d24c7a13c43e870e37c1556b74555437870a04514f7685f5b354e090567171"

--- a/language/compiler/bytecode-source-map/Cargo.toml
+++ b/language/compiler/bytecode-source-map/Cargo.toml
@@ -13,8 +13,8 @@ libra-workspace-hack = { path = "../../../common/workspace-hack", version = "0.1
 move-core-types = { path = "../../move-core/types", version = "0.1.0" }
 move-ir-types = { path = "../../move-ir/types", version = "0.1.0" }
 vm = { path = "../../vm", version = "0.1.0" }
-codespan = "0.8.0"
-codespan-reporting = "0.8.0"
+codespan = "0.9.2"
+codespan-reporting = "0.9.2"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 

--- a/language/compiler/bytecode-source-map/src/utils.rs
+++ b/language/compiler/bytecode-source-map/src/utils.rs
@@ -47,9 +47,7 @@ pub fn render_errors(source_mapper: &SourceMapping<Loc>, errors: Errors) -> Resu
 }
 
 pub fn create_diagnostic(id: FileId, (loc, msg): Error) -> Diagnostic<FileId> {
-    Diagnostic::<FileId>::error()
-        .with_labels([Label::primary(id, loc.span()).with_message(msg)].to_vec())
-        .with_message("")
+    Diagnostic::error().with_labels(vec![Label::primary(id, loc.span()).with_message(msg)])
 }
 
 //***************************************************************************

--- a/language/compiler/bytecode-source-map/src/utils.rs
+++ b/language/compiler/bytecode-source-map/src/utils.rs
@@ -46,8 +46,10 @@ pub fn render_errors(source_mapper: &SourceMapping<Loc>, errors: Errors) -> Resu
     }
 }
 
-pub fn create_diagnostic(id: FileId, (loc, msg): Error) -> Diagnostic {
-    Diagnostic::new_error("", Label::new(id, loc.span(), msg))
+pub fn create_diagnostic(id: FileId, (loc, msg): Error) -> Diagnostic<FileId> {
+    Diagnostic::<FileId>::error()
+        .with_labels([Label::primary(id, loc.span()).with_message(msg)].to_vec())
+        .with_message("")
 }
 
 //***************************************************************************

--- a/language/compiler/ir-to-bytecode/Cargo.toml
+++ b/language/compiler/ir-to-bytecode/Cargo.toml
@@ -20,8 +20,8 @@ move-vm-types = { path = "../../move-vm/types", version = "0.1.0" }
 vm = { path = "../../vm", version = "0.1.0" }
 bytecode-source-map = { path = "../bytecode-source-map", version = "0.1.0" }
 log = "0.4.7"
-codespan = "0.8.0"
-codespan-reporting = "0.8.0"
+codespan = "0.9.2"
+codespan-reporting = "0.9.2"
 thiserror = "1.0"
 
 [features]

--- a/language/compiler/ir-to-bytecode/src/parser.rs
+++ b/language/compiler/ir-to-bytecode/src/parser.rs
@@ -123,8 +123,10 @@ fn handle_error<T>(e: syntax::ParseError<Loc, anyhow::Error>, code_str: &str) ->
         ParseError::InvalidToken { location } => {
             let mut files = Files::new();
             let id = files.add(location.file(), code_str.to_string());
-            let lbl = Label::new(id, location.span(), "Invalid Token");
-            let error = Diagnostic::new_error("Parser Error", lbl);
+            let lbl = Label::primary(id, location.span()).with_message("Invalid Token");
+            let error = Diagnostic::error()
+                .with_message("Parser Error")
+                .with_labels([lbl].to_vec());
             let writer = &mut StandardStream::stderr(ColorChoice::Auto);
             emit(writer, &Config::default(), &files, &error).unwrap();
             "Invalid Token".to_string()

--- a/language/compiler/ir-to-bytecode/syntax/Cargo.toml
+++ b/language/compiler/ir-to-bytecode/syntax/Cargo.toml
@@ -11,7 +11,7 @@ edition = "2018"
 
 [dependencies]
 anyhow = "1.0"
-codespan = { version = "0.8.0", features = ["serialization"] }
+codespan = { version = "0.9.2", features = ["serialization"] }
 hex = "0.4.2"
 move-ir-types = { path = "../../../move-ir/types", version = "0.1.0" }
 move-core-types = { path = "../../../move-core/types", version = "0.1.0" }

--- a/language/move-ir/types/Cargo.toml
+++ b/language/move-ir/types/Cargo.toml
@@ -12,7 +12,7 @@ edition = "2018"
 
 [dependencies]
 anyhow = "1.0"
-codespan = { version = "0.8.0", features = ["serialization"] }
+codespan = { version = "0.9.2", features = ["serialization"] }
 serde = { version = "1.0.106", features = ["derive"] }
 hex = "0.4.2"
 once_cell = "1.3.1"

--- a/language/move-lang/Cargo.toml
+++ b/language/move-lang/Cargo.toml
@@ -7,8 +7,8 @@ edition = "2018"
 license = "Apache-2.0"
 
 [dependencies]
-codespan = "0.8.0"
-codespan-reporting = "0.8.0"
+codespan = "0.9.2"
+codespan-reporting = "0.9.2"
 hex = "0.4.2"
 regex = "1.3.7"
 structopt = "0.3.13"

--- a/language/move-lang/src/errors/mod.rs
+++ b/language/move-lang/src/errors/mod.rs
@@ -122,13 +122,13 @@ fn render_error(
     file_mapping: &FileMapping,
     mut error: Error,
 ) -> Diagnostic<FileId> {
-    let mk_secondary_lbl = |err: (Loc, String)| -> Label<FileId> {
-        let (id, span) = convert_loc(files, file_mapping, err.0);
-        Label::<FileId>::secondary(id, span).with_message(err.1)
-    };
     let mk_primary_lbl = |err: (Loc, String)| -> Label<FileId> {
         let (id, span) = convert_loc(files, file_mapping, err.0);
-        Label::<FileId>::primary(id, span).with_message(err.1)
+        Label::primary(id, span).with_message(err.1)
+    };
+    let mk_secondary_lbl = |err: (Loc, String)| -> Label<FileId> {
+        let (id, span) = convert_loc(files, file_mapping, err.0);
+        Label::secondary(id, span).with_message(err.1)
     };
 
     let err = error.remove(0);
@@ -136,7 +136,5 @@ fn render_error(
     labels.extend(error.into_iter().map(mk_secondary_lbl));
 
     // TODO message with each error msg
-    Diagnostic::<FileId>::error()
-        .with_message("")
-        .with_labels(labels)
+    Diagnostic::error().with_labels(labels)
 }

--- a/language/move-lang/tests/move_check/borrows/assign_local_combo_invalid.exp
+++ b/language/move-lang/tests/move_check/borrows/assign_local_combo_invalid.exp
@@ -1,55 +1,50 @@
 error: 
 
-    ┌── tests/move_check/borrows/assign_local_combo_invalid.move:14:9 ───
+    ┌── tests/move_check/borrows/assign_local_combo_invalid.move:13:37 ───
     │
- 14 │         s = S { f: 0, g: 0 };
-    │         ^ Invalid assignment of local 's'
-    ·
  13 │         if (cond) f = &s.f else f = &s.g;
     │                                     ---- It is still being borrowed by this reference
+ 14 │         s = S { f: 0, g: 0 };
+    │         ^ Invalid assignment of local 's'
     │
 
 error: 
 
-    ┌── tests/move_check/borrows/assign_local_combo_invalid.move:23:9 ───
+    ┌── tests/move_check/borrows/assign_local_combo_invalid.move:22:23 ───
     │
- 23 │         s = S { f: 0, g: 0 };
-    │         ^ Invalid assignment of local 's'
-    ·
  22 │         if (cond) f = &mut s.f else f = &mut other.f;
     │                       -------- It is still being mutably borrowed by this reference
+ 23 │         s = S { f: 0, g: 0 };
+    │         ^ Invalid assignment of local 's'
     │
 
 error: 
 
-    ┌── tests/move_check/borrows/assign_local_combo_invalid.move:32:9 ───
+    ┌── tests/move_check/borrows/assign_local_combo_invalid.move:31:23 ───
     │
- 32 │         s = S { f: 0, g: 0 };
-    │         ^ Invalid assignment of local 's'
-    ·
  31 │         if (cond) f = &mut s else f = other;
     │                       ------ It is still being mutably borrowed by this reference
+ 32 │         s = S { f: 0, g: 0 };
+    │         ^ Invalid assignment of local 's'
     │
 
 error: 
 
-    ┌── tests/move_check/borrows/assign_local_combo_invalid.move:41:9 ───
+    ┌── tests/move_check/borrows/assign_local_combo_invalid.move:40:23 ───
     │
- 41 │         s = S { f: 0, g: 0 };
-    │         ^ Invalid assignment of local 's'
-    ·
  40 │         if (cond) f = id_mut(&mut s) else f = other;
     │                       -------------- It is still being mutably borrowed by this reference
+ 41 │         s = S { f: 0, g: 0 };
+    │         ^ Invalid assignment of local 's'
     │
 
 error: 
 
-    ┌── tests/move_check/borrows/assign_local_combo_invalid.move:49:19 ───
+    ┌── tests/move_check/borrows/assign_local_combo_invalid.move:48:17 ───
     │
- 49 │         if (cond) s = S { f: 0, g: 0 };
-    │                   ^ Invalid assignment of local 's'
-    ·
  48 │         let f = &s.f;
     │                 ---- It is still being borrowed by this reference
+ 49 │         if (cond) s = S { f: 0, g: 0 };
+    │                   ^ Invalid assignment of local 's'
     │
 

--- a/language/move-lang/tests/move_check/borrows/assign_local_field_invalid.exp
+++ b/language/move-lang/tests/move_check/borrows/assign_local_field_invalid.exp
@@ -1,44 +1,40 @@
 error: 
 
-    ┌── tests/move_check/borrows/assign_local_field_invalid.move:13:9 ───
+    ┌── tests/move_check/borrows/assign_local_field_invalid.move:12:17 ───
     │
- 13 │         s = S { f: 0, g: 0 };
-    │         ^ Invalid assignment of local 's'
-    ·
  12 │         let f = &s.f;
     │                 ---- It is still being borrowed by this reference
+ 13 │         s = S { f: 0, g: 0 };
+    │         ^ Invalid assignment of local 's'
     │
 
 error: 
 
-    ┌── tests/move_check/borrows/assign_local_field_invalid.move:19:9 ───
+    ┌── tests/move_check/borrows/assign_local_field_invalid.move:18:17 ───
     │
- 19 │         s = S { f: 0, g: 0 };
-    │         ^ Invalid assignment of local 's'
-    ·
  18 │         let f = &mut s.f;
     │                 -------- It is still being mutably borrowed by this reference
+ 19 │         s = S { f: 0, g: 0 };
+    │         ^ Invalid assignment of local 's'
     │
 
 error: 
 
-    ┌── tests/move_check/borrows/assign_local_field_invalid.move:25:9 ───
+    ┌── tests/move_check/borrows/assign_local_field_invalid.move:24:17 ───
     │
- 25 │         s = S { f: 0, g: 0 };
-    │         ^ Invalid assignment of local 's'
-    ·
  24 │         let f = id(&s.f);
     │                 -------- It is still being borrowed by this reference
+ 25 │         s = S { f: 0, g: 0 };
+    │         ^ Invalid assignment of local 's'
     │
 
 error: 
 
-    ┌── tests/move_check/borrows/assign_local_field_invalid.move:31:9 ───
+    ┌── tests/move_check/borrows/assign_local_field_invalid.move:30:17 ───
     │
- 31 │         s = S { f: 0, g: 0 };
-    │         ^ Invalid assignment of local 's'
-    ·
  30 │         let f = id_mut(&mut s.f);
     │                 ---------------- It is still being mutably borrowed by this reference
+ 31 │         s = S { f: 0, g: 0 };
+    │         ^ Invalid assignment of local 's'
     │
 

--- a/language/move-lang/tests/move_check/borrows/assign_local_full_invalid.exp
+++ b/language/move-lang/tests/move_check/borrows/assign_local_full_invalid.exp
@@ -1,44 +1,40 @@
 error: 
 
-    ┌── tests/move_check/borrows/assign_local_full_invalid.move:13:9 ───
+    ┌── tests/move_check/borrows/assign_local_full_invalid.move:12:17 ───
     │
- 13 │         x = 0;
-    │         ^ Invalid assignment of local 'x'
-    ·
  12 │         let f = &x;
     │                 -- It is still being borrowed by this reference
+ 13 │         x = 0;
+    │         ^ Invalid assignment of local 'x'
     │
 
 error: 
 
-    ┌── tests/move_check/borrows/assign_local_full_invalid.move:19:9 ───
+    ┌── tests/move_check/borrows/assign_local_full_invalid.move:18:17 ───
     │
- 19 │         x = 0;
-    │         ^ Invalid assignment of local 'x'
-    ·
  18 │         let f = &mut x;
     │                 ------ It is still being mutably borrowed by this reference
+ 19 │         x = 0;
+    │         ^ Invalid assignment of local 'x'
     │
 
 error: 
 
-    ┌── tests/move_check/borrows/assign_local_full_invalid.move:25:9 ───
+    ┌── tests/move_check/borrows/assign_local_full_invalid.move:24:17 ───
     │
- 25 │         x = 0;
-    │         ^ Invalid assignment of local 'x'
-    ·
  24 │         let f = id(&x);
     │                 ------ It is still being borrowed by this reference
+ 25 │         x = 0;
+    │         ^ Invalid assignment of local 'x'
     │
 
 error: 
 
-    ┌── tests/move_check/borrows/assign_local_full_invalid.move:31:9 ───
+    ┌── tests/move_check/borrows/assign_local_full_invalid.move:30:17 ───
     │
- 31 │         x = 0;
-    │         ^ Invalid assignment of local 'x'
-    ·
  30 │         let f = id_mut(&mut x);
     │                 -------------- It is still being mutably borrowed by this reference
+ 31 │         x = 0;
+    │         ^ Invalid assignment of local 'x'
     │
 

--- a/language/move-lang/tests/move_check/borrows/borrow_field_combo_invalid.exp
+++ b/language/move-lang/tests/move_check/borrows/borrow_field_combo_invalid.exp
@@ -1,66 +1,60 @@
 error: 
 
-    ┌── tests/move_check/borrows/borrow_field_combo_invalid.move:14:18 ───
+    ┌── tests/move_check/borrows/borrow_field_combo_invalid.move:13:30 ───
     │
- 14 │         let f1 = &inner.f1;
-    │                  ^^^^^^^^^ Invalid immutable borrow at field 'f1'.
-    ·
  13 │         let c; if (cond) c = copy inner else c = &mut outer.s1;
     │                              ---------- It is still being mutably borrowed by this reference
+ 14 │         let f1 = &inner.f1;
+    │                  ^^^^^^^^^ Invalid immutable borrow at field 'f1'.
     │
 
 error: 
 
-    ┌── tests/move_check/borrows/borrow_field_combo_invalid.move:25:18 ───
+    ┌── tests/move_check/borrows/borrow_field_combo_invalid.move:24:30 ───
     │
- 25 │         let f1 = &inner.f1;
-    │                  ^^^^^^^^^ Invalid immutable borrow at field 'f1'.
-    ·
  24 │         let c; if (cond) c = id_mut(copy inner) else c = &mut outer.s1;
     │                              ------------------ It is still being mutably borrowed by this reference
+ 25 │         let f1 = &inner.f1;
+    │                  ^^^^^^^^^ Invalid immutable borrow at field 'f1'.
     │
 
 error: 
 
-    ┌── tests/move_check/borrows/borrow_field_combo_invalid.move:36:18 ───
+    ┌── tests/move_check/borrows/borrow_field_combo_invalid.move:35:30 ───
     │
- 36 │         let f1 = &mut inner.f1;
-    │                  ^^^^^^^^^^^^^ Invalid mutable borrow at field 'f1'.
-    ·
  35 │         let c; if (cond) c = copy inner else c = &mut outer.s1;
     │                              ---------- It is still being mutably borrowed by this reference
+ 36 │         let f1 = &mut inner.f1;
+    │                  ^^^^^^^^^^^^^ Invalid mutable borrow at field 'f1'.
     │
 
 error: 
 
-    ┌── tests/move_check/borrows/borrow_field_combo_invalid.move:47:18 ───
+    ┌── tests/move_check/borrows/borrow_field_combo_invalid.move:46:30 ───
     │
- 47 │         let f1 = &mut inner.f1;
-    │                  ^^^^^^^^^^^^^ Invalid mutable borrow at field 'f1'.
-    ·
  46 │         let c; if (cond) c = id_mut(copy inner) else c = &mut outer.s1;
     │                              ------------------ It is still being mutably borrowed by this reference
+ 47 │         let f1 = &mut inner.f1;
+    │                  ^^^^^^^^^^^^^ Invalid mutable borrow at field 'f1'.
     │
 
 error: 
 
-    ┌── tests/move_check/borrows/borrow_field_combo_invalid.move:58:18 ───
+    ┌── tests/move_check/borrows/borrow_field_combo_invalid.move:57:30 ───
     │
- 58 │         let f1 = &inner.f1;
-    │                  ^^^^^^^^^ Invalid immutable borrow at field 'f1'.
-    ·
  57 │         let c; if (cond) c = &mut inner.f1 else c = &mut inner.f2;
     │                              ------------- Field 'f1' is still being mutably borrowed by this reference
+ 58 │         let f1 = &inner.f1;
+    │                  ^^^^^^^^^ Invalid immutable borrow at field 'f1'.
     │
 
 error: 
 
-    ┌── tests/move_check/borrows/borrow_field_combo_invalid.move:67:18 ───
+    ┌── tests/move_check/borrows/borrow_field_combo_invalid.move:66:61 ───
     │
- 67 │         let f1 = &inner.f1;
-    │                  ^^^^^^^^^ Invalid immutable borrow at field 'f1'.
-    ·
  66 │         let c; if (cond) c = id_mut(&mut inner.f1) else c = &mut inner.f1;
     │                                                             ------------- Field 'f1' is still being mutably borrowed by this reference
+ 67 │         let f1 = &inner.f1;
+    │                  ^^^^^^^^^ Invalid immutable borrow at field 'f1'.
     │
 

--- a/language/move-lang/tests/move_check/borrows/borrow_field_field_invalid.exp
+++ b/language/move-lang/tests/move_check/borrows/borrow_field_field_invalid.exp
@@ -1,22 +1,20 @@
 error: 
 
-    ┌── tests/move_check/borrows/borrow_field_field_invalid.move:14:18 ───
+    ┌── tests/move_check/borrows/borrow_field_field_invalid.move:13:17 ───
     │
- 14 │         let f1 = &inner.f1;
-    │                  ^^^^^^^^^ Invalid immutable borrow at field 'f1'.
-    ·
  13 │         let c = &mut inner.f1;
     │                 ------------- Field 'f1' is still being mutably borrowed by this reference
+ 14 │         let f1 = &inner.f1;
+    │                  ^^^^^^^^^ Invalid immutable borrow at field 'f1'.
     │
 
 error: 
 
-    ┌── tests/move_check/borrows/borrow_field_field_invalid.move:21:18 ───
+    ┌── tests/move_check/borrows/borrow_field_field_invalid.move:20:17 ───
     │
- 21 │         let f1 = &inner.f1;
-    │                  ^^^^^^^^^ Invalid immutable borrow at field 'f1'.
-    ·
  20 │         let c = id_mut(&mut inner.f1);
     │                 --------------------- Field 'f1' is still being mutably borrowed by this reference
+ 21 │         let f1 = &inner.f1;
+    │                  ^^^^^^^^^ Invalid immutable borrow at field 'f1'.
     │
 

--- a/language/move-lang/tests/move_check/borrows/borrow_field_full_invalid.exp
+++ b/language/move-lang/tests/move_check/borrows/borrow_field_full_invalid.exp
@@ -1,44 +1,40 @@
 error: 
 
-    ┌── tests/move_check/borrows/borrow_field_full_invalid.move:14:18 ───
+    ┌── tests/move_check/borrows/borrow_field_full_invalid.move:13:17 ───
     │
- 14 │         let f1 = &inner.f1;
-    │                  ^^^^^^^^^ Invalid immutable borrow at field 'f1'.
-    ·
  13 │         let c = copy inner;
     │                 ---------- It is still being mutably borrowed by this reference
+ 14 │         let f1 = &inner.f1;
+    │                  ^^^^^^^^^ Invalid immutable borrow at field 'f1'.
     │
 
 error: 
 
-    ┌── tests/move_check/borrows/borrow_field_full_invalid.move:23:18 ───
+    ┌── tests/move_check/borrows/borrow_field_full_invalid.move:22:17 ───
     │
- 23 │         let f1 = &inner.f1;
-    │                  ^^^^^^^^^ Invalid immutable borrow at field 'f1'.
-    ·
  22 │         let c = id_mut(copy inner);
     │                 ------------------ It is still being mutably borrowed by this reference
+ 23 │         let f1 = &inner.f1;
+    │                  ^^^^^^^^^ Invalid immutable borrow at field 'f1'.
     │
 
 error: 
 
-    ┌── tests/move_check/borrows/borrow_field_full_invalid.move:32:18 ───
+    ┌── tests/move_check/borrows/borrow_field_full_invalid.move:31:17 ───
     │
- 32 │         let f1 = &mut inner.f1;
-    │                  ^^^^^^^^^^^^^ Invalid mutable borrow at field 'f1'.
-    ·
  31 │         let c = copy inner;
     │                 ---------- It is still being mutably borrowed by this reference
+ 32 │         let f1 = &mut inner.f1;
+    │                  ^^^^^^^^^^^^^ Invalid mutable borrow at field 'f1'.
     │
 
 error: 
 
-    ┌── tests/move_check/borrows/borrow_field_full_invalid.move:41:18 ───
+    ┌── tests/move_check/borrows/borrow_field_full_invalid.move:40:17 ───
     │
- 41 │         let f1 = &mut inner.f1;
-    │                  ^^^^^^^^^^^^^ Invalid mutable borrow at field 'f1'.
-    ·
  40 │         let c = id_mut(copy inner);
     │                 ------------------ It is still being mutably borrowed by this reference
+ 41 │         let f1 = &mut inner.f1;
+    │                  ^^^^^^^^^^^^^ Invalid mutable borrow at field 'f1'.
     │
 

--- a/language/move-lang/tests/move_check/borrows/borrow_global_invalid.exp
+++ b/language/move-lang/tests/move_check/borrows/borrow_global_invalid.exp
@@ -1,77 +1,70 @@
 error: 
 
-   ┌── tests/move_check/borrows/borrow_global_invalid.move:6:18 ───
+   ┌── tests/move_check/borrows/borrow_global_invalid.move:5:18 ───
    │
- 6 │         let r2 = borrow_global<R>(addr);
-   │                  ^^^^^^^^^^^^^^^^^^^^^^ Invalid borrowing of resource 'R'
-   ·
  5 │         let r1 = borrow_global_mut<R>(addr);
    │                  -------------------------- It is still being mutably borrowed by this reference
+ 6 │         let r2 = borrow_global<R>(addr);
+   │                  ^^^^^^^^^^^^^^^^^^^^^^ Invalid borrowing of resource 'R'
    │
 
 error: 
 
-    ┌── tests/move_check/borrows/borrow_global_invalid.move:12:18 ───
+    ┌── tests/move_check/borrows/borrow_global_invalid.move:11:17 ───
     │
- 12 │         let r2 = borrow_global<R>(addr);
-    │                  ^^^^^^^^^^^^^^^^^^^^^^ Invalid borrowing of resource 'R'
-    ·
  11 │         let f = &mut borrow_global_mut<R>(addr).f;
     │                 --------------------------------- It is still being mutably borrowed by this reference
+ 12 │         let r2 = borrow_global<R>(addr);
+    │                  ^^^^^^^^^^^^^^^^^^^^^^ Invalid borrowing of resource 'R'
     │
 
 error: 
 
-    ┌── tests/move_check/borrows/borrow_global_invalid.move:18:18 ───
+    ┌── tests/move_check/borrows/borrow_global_invalid.move:17:18 ───
     │
- 18 │         let f = &borrow_global<R>(addr).f;
-    │                  ^^^^^^^^^^^^^^^^^^^^^^ Invalid borrowing of resource 'R'
-    ·
  17 │         let r1 = borrow_global_mut<R>(addr);
     │                  -------------------------- It is still being mutably borrowed by this reference
+ 18 │         let f = &borrow_global<R>(addr).f;
+    │                  ^^^^^^^^^^^^^^^^^^^^^^ Invalid borrowing of resource 'R'
     │
 
 error: 
 
-    ┌── tests/move_check/borrows/borrow_global_invalid.move:24:18 ───
+    ┌── tests/move_check/borrows/borrow_global_invalid.move:23:18 ───
     │
- 24 │         let r1 = borrow_global_mut<R>(addr);
-    │                  ^^^^^^^^^^^^^^^^^^^^^^^^^^ Invalid borrowing of resource 'R'
-    ·
  23 │         let r2 = borrow_global<R>(addr);
     │                  ---------------------- It is still being borrowed by this reference
+ 24 │         let r1 = borrow_global_mut<R>(addr);
+    │                  ^^^^^^^^^^^^^^^^^^^^^^^^^^ Invalid borrowing of resource 'R'
     │
 
 error: 
 
-    ┌── tests/move_check/borrows/borrow_global_invalid.move:30:18 ───
+    ┌── tests/move_check/borrows/borrow_global_invalid.move:29:17 ───
     │
- 30 │         let r2 = borrow_global<R>(addr);
-    │                  ^^^^^^^^^^^^^^^^^^^^^^ Invalid borrowing of resource 'R'
-    ·
  29 │         let f = &mut borrow_global_mut<R>(addr).f;
     │                 --------------------------------- It is still being mutably borrowed by this reference
+ 30 │         let r2 = borrow_global<R>(addr);
+    │                  ^^^^^^^^^^^^^^^^^^^^^^ Invalid borrowing of resource 'R'
     │
 
 error: 
 
-    ┌── tests/move_check/borrows/borrow_global_invalid.move:36:18 ───
+    ┌── tests/move_check/borrows/borrow_global_invalid.move:35:18 ───
     │
- 36 │         let f = &borrow_global<R>(addr).f;
-    │                  ^^^^^^^^^^^^^^^^^^^^^^ Invalid borrowing of resource 'R'
-    ·
  35 │         let r1 = borrow_global_mut<R>(addr);
     │                  -------------------------- It is still being mutably borrowed by this reference
+ 36 │         let f = &borrow_global<R>(addr).f;
+    │                  ^^^^^^^^^^^^^^^^^^^^^^ Invalid borrowing of resource 'R'
     │
 
 error: 
 
-    ┌── tests/move_check/borrows/borrow_global_invalid.move:43:18 ───
+    ┌── tests/move_check/borrows/borrow_global_invalid.move:42:32 ───
     │
- 43 │         let f = &borrow_global<R>(addr).f;
-    │                  ^^^^^^^^^^^^^^^^^^^^^^ Invalid borrowing of resource 'R'
-    ·
  42 │         let r1; if (cond) r1 = borrow_global_mut<R>(addr) else r1 = &mut r;
     │                                -------------------------- It is still being mutably borrowed by this reference
+ 43 │         let f = &borrow_global<R>(addr).f;
+    │                  ^^^^^^^^^^^^^^^^^^^^^^ Invalid borrowing of resource 'R'
     │
 

--- a/language/move-lang/tests/move_check/borrows/borrow_global_mut_invalid.exp
+++ b/language/move-lang/tests/move_check/borrows/borrow_global_mut_invalid.exp
@@ -1,77 +1,70 @@
 error: 
 
-   ┌── tests/move_check/borrows/borrow_global_mut_invalid.move:6:18 ───
+   ┌── tests/move_check/borrows/borrow_global_mut_invalid.move:5:18 ───
    │
- 6 │         let r2 = borrow_global_mut<R>(addr);
-   │                  ^^^^^^^^^^^^^^^^^^^^^^^^^^ Invalid borrowing of resource 'R'
-   ·
  5 │         let r1 = borrow_global_mut<R>(addr);
    │                  -------------------------- It is still being mutably borrowed by this reference
+ 6 │         let r2 = borrow_global_mut<R>(addr);
+   │                  ^^^^^^^^^^^^^^^^^^^^^^^^^^ Invalid borrowing of resource 'R'
    │
 
 error: 
 
-    ┌── tests/move_check/borrows/borrow_global_mut_invalid.move:12:18 ───
+    ┌── tests/move_check/borrows/borrow_global_mut_invalid.move:11:17 ───
     │
- 12 │         let r2 = borrow_global_mut<R>(addr);
-    │                  ^^^^^^^^^^^^^^^^^^^^^^^^^^ Invalid borrowing of resource 'R'
-    ·
  11 │         let f = &mut borrow_global_mut<R>(addr).f;
     │                 --------------------------------- It is still being mutably borrowed by this reference
+ 12 │         let r2 = borrow_global_mut<R>(addr);
+    │                  ^^^^^^^^^^^^^^^^^^^^^^^^^^ Invalid borrowing of resource 'R'
     │
 
 error: 
 
-    ┌── tests/move_check/borrows/borrow_global_mut_invalid.move:18:22 ───
+    ┌── tests/move_check/borrows/borrow_global_mut_invalid.move:17:18 ───
     │
- 18 │         let f = &mut borrow_global_mut<R>(addr).f;
-    │                      ^^^^^^^^^^^^^^^^^^^^^^^^^^ Invalid borrowing of resource 'R'
-    ·
  17 │         let r1 = borrow_global_mut<R>(addr);
     │                  -------------------------- It is still being mutably borrowed by this reference
+ 18 │         let f = &mut borrow_global_mut<R>(addr).f;
+    │                      ^^^^^^^^^^^^^^^^^^^^^^^^^^ Invalid borrowing of resource 'R'
     │
 
 error: 
 
-    ┌── tests/move_check/borrows/borrow_global_mut_invalid.move:24:18 ───
+    ┌── tests/move_check/borrows/borrow_global_mut_invalid.move:23:18 ───
     │
- 24 │         let r2 = borrow_global<R>(addr);
-    │                  ^^^^^^^^^^^^^^^^^^^^^^ Invalid borrowing of resource 'R'
-    ·
  23 │         let r1 = borrow_global_mut<R>(addr);
     │                  -------------------------- It is still being mutably borrowed by this reference
+ 24 │         let r2 = borrow_global<R>(addr);
+    │                  ^^^^^^^^^^^^^^^^^^^^^^ Invalid borrowing of resource 'R'
     │
 
 error: 
 
-    ┌── tests/move_check/borrows/borrow_global_mut_invalid.move:30:18 ───
+    ┌── tests/move_check/borrows/borrow_global_mut_invalid.move:29:17 ───
     │
- 30 │         let r2 = borrow_global_mut<R>(addr);
-    │                  ^^^^^^^^^^^^^^^^^^^^^^^^^^ Invalid borrowing of resource 'R'
-    ·
  29 │         let f = &borrow_global<R>(addr).f;
     │                 ------------------------- It is still being borrowed by this reference
+ 30 │         let r2 = borrow_global_mut<R>(addr);
+    │                  ^^^^^^^^^^^^^^^^^^^^^^^^^^ Invalid borrowing of resource 'R'
     │
 
 error: 
 
-    ┌── tests/move_check/borrows/borrow_global_mut_invalid.move:36:18 ───
+    ┌── tests/move_check/borrows/borrow_global_mut_invalid.move:35:18 ───
     │
- 36 │         let f = &borrow_global_mut<R>(addr).f;
-    │                  ^^^^^^^^^^^^^^^^^^^^^^^^^^ Invalid borrowing of resource 'R'
-    ·
  35 │         let r1 = borrow_global_mut<R>(addr);
     │                  -------------------------- It is still being mutably borrowed by this reference
+ 36 │         let f = &borrow_global_mut<R>(addr).f;
+    │                  ^^^^^^^^^^^^^^^^^^^^^^^^^^ Invalid borrowing of resource 'R'
     │
 
 error: 
 
-    ┌── tests/move_check/borrows/borrow_global_mut_invalid.move:43:18 ───
+    ┌── tests/move_check/borrows/borrow_global_mut_invalid.move:42:32 ───
     │
- 43 │         let f = &borrow_global_mut<R>(addr).f;
-    │                  ^^^^^^^^^^^^^^^^^^^^^^^^^^ Invalid borrowing of resource 'R'
-    ·
  42 │         let r1; if (cond) r1 = borrow_global_mut<R>(addr) else r1 = &mut r;
     │                                -------------------------- It is still being mutably borrowed by this reference
+ 43 │         let f = &borrow_global_mut<R>(addr).f;
+    │                  ^^^^^^^^^^^^^^^^^^^^^^^^^^ Invalid borrowing of resource 'R'
     │
 

--- a/language/move-lang/tests/move_check/borrows/borrow_local_combo_invalid.exp
+++ b/language/move-lang/tests/move_check/borrows/borrow_local_combo_invalid.exp
@@ -1,55 +1,52 @@
 error: 
 
-    ┌── tests/move_check/borrows/borrow_local_combo_invalid.move:13:17 ───
+    ┌── tests/move_check/borrows/borrow_local_combo_invalid.move:12:23 ───
     │
- 13 │         let x = &s;
-    │                 ^^ Invalid borrow of local 's'
-    ·
  12 │         if (cond) f = &mut s.f else f = &mut other.f;
     │                       -------- It is still being mutably borrowed by this reference
+ 13 │         let x = &s;
+    │                 ^^ Invalid borrow of local 's'
     │
 
 error: 
 
-    ┌── tests/move_check/borrows/borrow_local_combo_invalid.move:23:9 ───
+    ┌── tests/move_check/borrows/borrow_local_combo_invalid.move:20:23 ───
     │
- 23 │         *x;
-    │         ^^ Invalid dereference.
-    ·
  20 │         if (cond) f = &mut s.f else f = &mut other.f;
     │                       -------- Field 'f' is still being mutably borrowed by this reference
+    ·
+ 23 │         *x;
+    │         ^^ Invalid dereference.
     │
 
 error: 
 
-    ┌── tests/move_check/borrows/borrow_local_combo_invalid.move:30:17 ───
+    ┌── tests/move_check/borrows/borrow_local_combo_invalid.move:29:41 ───
     │
- 30 │         let x = &s;
-    │                 ^^ Invalid borrow of local 's'
-    ·
  29 │         if (cond) f = &mut s.f else f = &mut s.g;
     │                                         -------- It is still being mutably borrowed by this reference
+ 30 │         let x = &s;
+    │                 ^^ Invalid borrow of local 's'
     │
 
 error: 
 
-    ┌── tests/move_check/borrows/borrow_local_combo_invalid.move:38:17 ───
+    ┌── tests/move_check/borrows/borrow_local_combo_invalid.move:37:23 ───
     │
- 38 │         let y = &s;
-    │                 ^^ Invalid borrow of local 's'
-    ·
  37 │         if (cond) x = &mut s else x = other;
     │                       ------ It is still being mutably borrowed by this reference
+ 38 │         let y = &s;
+    │                 ^^ Invalid borrow of local 's'
     │
 
 error: 
 
-    ┌── tests/move_check/borrows/borrow_local_combo_invalid.move:48:9 ───
+    ┌── tests/move_check/borrows/borrow_local_combo_invalid.move:46:23 ───
     │
- 48 │         *y;
-    │         ^^ Invalid dereference.
-    ·
  46 │         if (cond) x = &mut s else x = other;
     │                       ------ It is still being mutably borrowed by this reference
+ 47 │         let y = &mut s;
+ 48 │         *y;
+    │         ^^ Invalid dereference.
     │
 

--- a/language/move-lang/tests/move_check/borrows/borrow_local_field_invalid.exp
+++ b/language/move-lang/tests/move_check/borrows/borrow_local_field_invalid.exp
@@ -1,22 +1,21 @@
 error: 
 
-    ┌── tests/move_check/borrows/borrow_local_field_invalid.move:14:9 ───
+    ┌── tests/move_check/borrows/borrow_local_field_invalid.move:12:17 ───
     │
- 14 │         *s = S { f: 0, g: 0 };
-    │         ^^^^^^^^^^^^^^^^^^^^^ Invalid mutation of reference.
-    ·
  12 │         let f = &v.f;
     │                 ---- Field 'f' is still being borrowed by this reference
+ 13 │         let s = &mut v;
+ 14 │         *s = S { f: 0, g: 0 };
+    │         ^^^^^^^^^^^^^^^^^^^^^ Invalid mutation of reference.
     │
 
 error: 
 
-    ┌── tests/move_check/borrows/borrow_local_field_invalid.move:19:17 ───
+    ┌── tests/move_check/borrows/borrow_local_field_invalid.move:18:17 ───
     │
- 19 │         let s = &v;
-    │                 ^^ Invalid borrow of local 'v'
-    ·
  18 │         let f = &mut v.f;
     │                 -------- It is still being mutably borrowed by this reference
+ 19 │         let s = &v;
+    │                 ^^ Invalid borrow of local 'v'
     │
 

--- a/language/move-lang/tests/move_check/borrows/borrow_local_full_invalid.exp
+++ b/language/move-lang/tests/move_check/borrows/borrow_local_full_invalid.exp
@@ -1,44 +1,42 @@
 error: 
 
-    ┌── tests/move_check/borrows/borrow_local_full_invalid.move:14:9 ───
+    ┌── tests/move_check/borrows/borrow_local_full_invalid.move:12:17 ───
     │
- 14 │         *y;
-    │         ^^ Invalid dereference.
-    ·
  12 │         let x = &mut v;
     │                 ------ It is still being mutably borrowed by this reference
+ 13 │         let y = &mut v;
+ 14 │         *y;
+    │         ^^ Invalid dereference.
     │
 
 error: 
 
-    ┌── tests/move_check/borrows/borrow_local_full_invalid.move:18:17 ───
+    ┌── tests/move_check/borrows/borrow_local_full_invalid.move:17:17 ───
     │
- 18 │         let y = id_mut(&mut v);
-    │                 ^^^^^^^^^^^^^^ Invalid usage of reference as function argument. Cannot transfer a mutable reference that is being borrowed
-    ·
  17 │         let x = &mut v;
     │                 ------ It is still being mutably borrowed by this reference
+ 18 │         let y = id_mut(&mut v);
+    │                 ^^^^^^^^^^^^^^ Invalid usage of reference as function argument. Cannot transfer a mutable reference that is being borrowed
     │
 
 error: 
 
-    ┌── tests/move_check/borrows/borrow_local_full_invalid.move:24:9 ───
+    ┌── tests/move_check/borrows/borrow_local_full_invalid.move:22:17 ───
     │
- 24 │         *y = 0;
-    │         ^^^^^^ Invalid mutation of reference.
-    ·
  22 │         let x = &v;
     │                 -- It is still being borrowed by this reference
+ 23 │         let y = &mut v;
+ 24 │         *y = 0;
+    │         ^^^^^^ Invalid mutation of reference.
     │
 
 error: 
 
-    ┌── tests/move_check/borrows/borrow_local_full_invalid.move:33:17 ───
+    ┌── tests/move_check/borrows/borrow_local_full_invalid.move:32:17 ───
     │
- 33 │         let y = &v;
-    │                 ^^ Invalid borrow of local 'v'
-    ·
  32 │         let x = &mut v;
     │                 ------ It is still being mutably borrowed by this reference
+ 33 │         let y = &v;
+    │                 ^^ Invalid borrow of local 'v'
     │
 

--- a/language/move-lang/tests/move_check/borrows/call_acquires_invalid.exp
+++ b/language/move-lang/tests/move_check/borrows/call_acquires_invalid.exp
@@ -1,99 +1,90 @@
 error: 
 
-    ┌── tests/move_check/borrows/call_acquires_invalid.move:16:23 ───
+    ┌── tests/move_check/borrows/call_acquires_invalid.move:15:18 ───
     │
- 16 │         let R { f } = acq(addr);
-    │                       ^^^^^^^^^ Invalid acquiring of resource 'R'
-    ·
  15 │         let r1 = borrow_global_mut<R>(addr);
     │                  -------------------------- It is still being mutably borrowed by this reference
+ 16 │         let R { f } = acq(addr);
+    │                       ^^^^^^^^^ Invalid acquiring of resource 'R'
     │
 
 error: 
 
-    ┌── tests/move_check/borrows/call_acquires_invalid.move:22:23 ───
+    ┌── tests/move_check/borrows/call_acquires_invalid.move:21:21 ───
     │
- 22 │         let R { f } = acq(addr);
-    │                       ^^^^^^^^^ Invalid acquiring of resource 'R'
-    ·
  21 │         let f_ref = &mut borrow_global_mut<R>(addr).f;
     │                     --------------------------------- It is still being mutably borrowed by this reference
+ 22 │         let R { f } = acq(addr);
+    │                       ^^^^^^^^^ Invalid acquiring of resource 'R'
     │
 
 error: 
 
-    ┌── tests/move_check/borrows/call_acquires_invalid.move:28:23 ───
+    ┌── tests/move_check/borrows/call_acquires_invalid.move:27:18 ───
     │
- 28 │         let R { f } = acq(addr);
-    │                       ^^^^^^^^^ Invalid acquiring of resource 'R'
-    ·
  27 │         let r1 = id_mut(borrow_global_mut<R>(addr));
     │                  ---------------------------------- It is still being mutably borrowed by this reference
+ 28 │         let R { f } = acq(addr);
+    │                       ^^^^^^^^^ Invalid acquiring of resource 'R'
     │
 
 error: 
 
-    ┌── tests/move_check/borrows/call_acquires_invalid.move:34:23 ───
+    ┌── tests/move_check/borrows/call_acquires_invalid.move:33:21 ───
     │
- 34 │         let R { f } = acq(addr);
-    │                       ^^^^^^^^^ Invalid acquiring of resource 'R'
-    ·
  33 │         let f_ref = id_mut(&mut borrow_global_mut<R>(addr).f);
     │                     ----------------------------------------- It is still being mutably borrowed by this reference
+ 34 │         let R { f } = acq(addr);
+    │                       ^^^^^^^^^ Invalid acquiring of resource 'R'
     │
 
 error: 
 
-    ┌── tests/move_check/borrows/call_acquires_invalid.move:40:23 ───
+    ┌── tests/move_check/borrows/call_acquires_invalid.move:39:18 ───
     │
- 40 │         let R { f } = acq(addr);
-    │                       ^^^^^^^^^ Invalid acquiring of resource 'R'
-    ·
  39 │         let r1 = borrow_global<R>(addr);
     │                  ---------------------- It is still being borrowed by this reference
+ 40 │         let R { f } = acq(addr);
+    │                       ^^^^^^^^^ Invalid acquiring of resource 'R'
     │
 
 error: 
 
-    ┌── tests/move_check/borrows/call_acquires_invalid.move:46:23 ───
+    ┌── tests/move_check/borrows/call_acquires_invalid.move:45:21 ───
     │
- 46 │         let R { f } = acq(addr);
-    │                       ^^^^^^^^^ Invalid acquiring of resource 'R'
-    ·
  45 │         let f_ref = &borrow_global<R>(addr).f;
     │                     ------------------------- It is still being borrowed by this reference
+ 46 │         let R { f } = acq(addr);
+    │                       ^^^^^^^^^ Invalid acquiring of resource 'R'
     │
 
 error: 
 
-    ┌── tests/move_check/borrows/call_acquires_invalid.move:52:23 ───
+    ┌── tests/move_check/borrows/call_acquires_invalid.move:51:18 ───
     │
- 52 │         let R { f } = acq(addr);
-    │                       ^^^^^^^^^ Invalid acquiring of resource 'R'
-    ·
  51 │         let r1 = id(borrow_global<R>(addr));
     │                  -------------------------- It is still being borrowed by this reference
+ 52 │         let R { f } = acq(addr);
+    │                       ^^^^^^^^^ Invalid acquiring of resource 'R'
     │
 
 error: 
 
-    ┌── tests/move_check/borrows/call_acquires_invalid.move:58:23 ───
+    ┌── tests/move_check/borrows/call_acquires_invalid.move:57:21 ───
     │
- 58 │         let R { f } = acq(addr);
-    │                       ^^^^^^^^^ Invalid acquiring of resource 'R'
-    ·
  57 │         let f_ref = id(&borrow_global<R>(addr).f);
     │                     ----------------------------- It is still being borrowed by this reference
+ 58 │         let R { f } = acq(addr);
+    │                       ^^^^^^^^^ Invalid acquiring of resource 'R'
     │
 
 error: 
 
-    ┌── tests/move_check/borrows/call_acquires_invalid.move:66:23 ───
+    ┌── tests/move_check/borrows/call_acquires_invalid.move:65:32 ───
     │
- 66 │         let R { f } = acq(addr);
-    │                       ^^^^^^^^^ Invalid acquiring of resource 'R'
-    ·
  65 │         let r1; if (cond) r1 = borrow_global_mut<R>(addr) else r1 = &mut r;
     │                                -------------------------- It is still being mutably borrowed by this reference
+ 66 │         let R { f } = acq(addr);
+    │                       ^^^^^^^^^ Invalid acquiring of resource 'R'
     │
 

--- a/language/move-lang/tests/move_check/borrows/call_mutual_borrows_invalid.exp
+++ b/language/move-lang/tests/move_check/borrows/call_mutual_borrows_invalid.exp
@@ -1,45 +1,41 @@
 error: 
 
-    ┌── tests/move_check/borrows/call_mutual_borrows_invalid.move:15:9 ───
+    ┌── tests/move_check/borrows/call_mutual_borrows_invalid.move:14:17 ───
     │
- 15 │         mut_imm(s1, f);
-    │         ^^^^^^^^^^^^^^ Invalid usage of reference as function argument. Cannot transfer a mutable reference that is being borrowed
-    ·
  14 │         let f = freeze(s1);
     │                 ---------- It is still being borrowed by this reference
+ 15 │         mut_imm(s1, f);
+    │         ^^^^^^^^^^^^^^ Invalid usage of reference as function argument. Cannot transfer a mutable reference that is being borrowed
     │
 
 error: 
 
-    ┌── tests/move_check/borrows/call_mutual_borrows_invalid.move:17:9 ───
+    ┌── tests/move_check/borrows/call_mutual_borrows_invalid.move:16:17 ───
     │
- 17 │         mut_imm(s1, f);
-    │         ^^^^^^^^^^^^^^ Invalid usage of reference as function argument. Cannot transfer a mutable reference that is being borrowed
-    ·
  16 │         let f = &s1.f;
     │                 ----- Field 'f' is still being borrowed by this reference
+ 17 │         mut_imm(s1, f);
+    │         ^^^^^^^^^^^^^^ Invalid usage of reference as function argument. Cannot transfer a mutable reference that is being borrowed
     │
 
 error: 
 
-    ┌── tests/move_check/borrows/call_mutual_borrows_invalid.move:19:9 ───
+    ┌── tests/move_check/borrows/call_mutual_borrows_invalid.move:18:17 ───
     │
- 19 │         mut_imm(&mut s1.f, f);
-    │         ^^^^^^^^^^^^^^^^^^^^^ Invalid usage of reference as function argument. Cannot transfer a mutable reference that is being borrowed
-    ·
  18 │         let f = &s1.f;
     │                 ----- It is still being borrowed by this reference
+ 19 │         mut_imm(&mut s1.f, f);
+    │         ^^^^^^^^^^^^^^^^^^^^^ Invalid usage of reference as function argument. Cannot transfer a mutable reference that is being borrowed
     │
 
 error: 
 
-    ┌── tests/move_check/borrows/call_mutual_borrows_invalid.move:21:9 ───
+    ┌── tests/move_check/borrows/call_mutual_borrows_invalid.move:20:17 ───
     │
- 21 │         id_mut(&mut s1.f); f;
-    │         ^^^^^^^^^^^^^^^^^ Invalid usage of reference as function argument. Cannot transfer a mutable reference that is being borrowed
-    ·
  20 │         let f = id(&s1.f);
     │                 --------- It is still being borrowed by this reference
+ 21 │         id_mut(&mut s1.f); f;
+    │         ^^^^^^^^^^^^^^^^^ Invalid usage of reference as function argument. Cannot transfer a mutable reference that is being borrowed
     │
 
 error: 
@@ -48,20 +44,17 @@ error:
     │
  23 │         mut_mut(s1, s1);
     │         ^^^^^^^^^^^^^^^ Invalid usage of reference as function argument. Cannot transfer a mutable reference that is being borrowed
-    ·
- 23 │         mut_mut(s1, s1);
     │                 -- It is still being mutably borrowed by this reference
     │
 
 error: 
 
-    ┌── tests/move_check/borrows/call_mutual_borrows_invalid.move:25:9 ───
+    ┌── tests/move_check/borrows/call_mutual_borrows_invalid.move:24:17 ───
     │
- 25 │         mut_mut(s1, f);
-    │         ^^^^^^^^^^^^^^ Invalid usage of reference as function argument. Cannot transfer a mutable reference that is being borrowed
-    ·
  24 │         let f = &mut s1.f;
     │                 --------- Field 'f' is still being mutably borrowed by this reference
+ 25 │         mut_mut(s1, f);
+    │         ^^^^^^^^^^^^^^ Invalid usage of reference as function argument. Cannot transfer a mutable reference that is being borrowed
     │
 
 error: 
@@ -70,31 +63,27 @@ error:
     │
  26 │         mut_mut(&mut s1.f, s1);
     │         ^^^^^^^^^^^^^^^^^^^^^^ Invalid usage of reference as function argument. Cannot transfer a mutable reference that is being borrowed
-    ·
- 26 │         mut_mut(&mut s1.f, s1);
     │                 --------- Field 'f' is still being mutably borrowed by this reference
     │
 
 error: 
 
-    ┌── tests/move_check/borrows/call_mutual_borrows_invalid.move:28:9 ───
+    ┌── tests/move_check/borrows/call_mutual_borrows_invalid.move:27:17 ───
     │
- 28 │         id_mut(s1);
-    │         ^^^^^^^^^^ Invalid usage of reference as function argument. Cannot transfer a mutable reference that is being borrowed
-    ·
  27 │         let s = id_mut(s1);
     │                 ---------- It is still being mutably borrowed by this reference
+ 28 │         id_mut(s1);
+    │         ^^^^^^^^^^ Invalid usage of reference as function argument. Cannot transfer a mutable reference that is being borrowed
     │
 
 error: 
 
-    ┌── tests/move_check/borrows/call_mutual_borrows_invalid.move:31:9 ───
+    ┌── tests/move_check/borrows/call_mutual_borrows_invalid.move:30:17 ───
     │
- 31 │         mut_mut(s1, f);
-    │         ^^^^^^^^^^^^^^ Invalid usage of reference as function argument. Cannot transfer a mutable reference that is being borrowed
-    ·
  30 │         let f = id_mut(&mut s1.f);
     │                 ----------------- Field 'f' is still being mutably borrowed by this reference
+ 31 │         mut_mut(s1, f);
+    │         ^^^^^^^^^^^^^^ Invalid usage of reference as function argument. Cannot transfer a mutable reference that is being borrowed
     │
 
 error: 
@@ -103,8 +92,6 @@ error:
     │
  32 │         mut_mut(id_mut(&mut s1.f), s1);
     │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Invalid usage of reference as function argument. Cannot transfer a mutable reference that is being borrowed
-    ·
- 32 │         mut_mut(id_mut(&mut s1.f), s1);
     │                 ----------------- Field 'f' is still being mutably borrowed by this reference
     │
 

--- a/language/move-lang/tests/move_check/borrows/call_ordering.exp
+++ b/language/move-lang/tests/move_check/borrows/call_ordering.exp
@@ -1,22 +1,19 @@
 error: 
 
-   ┌── tests/move_check/borrows/call_ordering.move:7:13 ───
+   ┌── tests/move_check/borrows/call_ordering.move:6:17 ───
    │
- 7 │         foo(freeze(s), { *f = 0; 1 })
-   │             ^^^^^^^^^ Invalid freeze.
-   ·
  6 │         let f = &mut s.f;
    │                 -------- Field 'f' is still being mutably borrowed by this reference
+ 7 │         foo(freeze(s), { *f = 0; 1 })
+   │             ^^^^^^^^^ Invalid freeze.
    │
 
 error: 
 
-    ┌── tests/move_check/borrows/call_ordering.move:12:25 ───
+    ┌── tests/move_check/borrows/call_ordering.move:12:13 ───
     │
  12 │         bar(&mut s.f, { s.f = 0; 1 })
-    │                         ^^^^^^^ Invalid mutation of reference.
-    ·
- 12 │         bar(&mut s.f, { s.f = 0; 1 })
     │             -------- It is still being mutably borrowed by this reference
+    │                         ^^^^^^^ Invalid mutation of reference.
     │
 

--- a/language/move-lang/tests/move_check/borrows/call_transfer_borrows_invalid.exp
+++ b/language/move-lang/tests/move_check/borrows/call_transfer_borrows_invalid.exp
@@ -1,33 +1,31 @@
 error: 
 
-    ┌── tests/move_check/borrows/call_transfer_borrows_invalid.move:16:9 ───
+    ┌── tests/move_check/borrows/call_transfer_borrows_invalid.move:15:17 ───
     │
- 16 │         move y;
-    │         ^^^^^^ Invalid move of local 'y'
-    ·
  15 │         let r = take_imm_mut_give_mut(move x_ref, move y_ref);
     │                 --------------------------------------------- It is still being mutably borrowed by this reference
+ 16 │         move y;
+    │         ^^^^^^ Invalid move of local 'y'
     │
 
 error: 
 
-    ┌── tests/move_check/borrows/call_transfer_borrows_invalid.move:26:9 ───
+    ┌── tests/move_check/borrows/call_transfer_borrows_invalid.move:25:17 ───
     │
+ 25 │         let r = take_imm_mut_give_imm(move x_ref, move y_ref);
+    │                 --------------------------------------------- It is still being borrowed by this reference
  26 │         move x;
     │         ^^^^^^ Invalid move of local 'x'
-    ·
- 25 │         let r = take_imm_mut_give_imm(move x_ref, move y_ref);
-    │                 --------------------------------------------- It is still being borrowed by this reference
     │
 
 error: 
 
-    ┌── tests/move_check/borrows/call_transfer_borrows_invalid.move:27:9 ───
+    ┌── tests/move_check/borrows/call_transfer_borrows_invalid.move:25:17 ───
     │
- 27 │         move y;
-    │         ^^^^^^ Invalid move of local 'y'
-    ·
  25 │         let r = take_imm_mut_give_imm(move x_ref, move y_ref);
     │                 --------------------------------------------- It is still being borrowed by this reference
+ 26 │         move x;
+ 27 │         move y;
+    │         ^^^^^^ Invalid move of local 'y'
     │
 

--- a/language/move-lang/tests/move_check/borrows/copy_combo_invalid.exp
+++ b/language/move-lang/tests/move_check/borrows/copy_combo_invalid.exp
@@ -1,44 +1,40 @@
 error: 
 
-    ┌── tests/move_check/borrows/copy_combo_invalid.move:14:9 ───
+    ┌── tests/move_check/borrows/copy_combo_invalid.move:13:23 ───
     │
- 14 │         copy s;
-    │         ^^^^^^ Invalid copy of local 's'
-    ·
  13 │         if (cond) f = &mut s.f else f = &mut other.f;
     │                       -------- It is still being mutably borrowed by this reference
+ 14 │         copy s;
+    │         ^^^^^^ Invalid copy of local 's'
     │
 
 error: 
 
-    ┌── tests/move_check/borrows/copy_combo_invalid.move:23:9 ───
+    ┌── tests/move_check/borrows/copy_combo_invalid.move:22:23 ───
     │
- 23 │         copy s;
-    │         ^^^^^^ Invalid copy of local 's'
-    ·
  22 │         if (cond) f = &mut s else f = other;
     │                       ------ It is still being mutably borrowed by this reference
+ 23 │         copy s;
+    │         ^^^^^^ Invalid copy of local 's'
     │
 
 error: 
 
-    ┌── tests/move_check/borrows/copy_combo_invalid.move:32:9 ───
+    ┌── tests/move_check/borrows/copy_combo_invalid.move:31:23 ───
     │
- 32 │         copy s;
-    │         ^^^^^^ Invalid copy of local 's'
-    ·
  31 │         if (cond) f = id_mut(&mut s) else f = other;
     │                       -------------- It is still being mutably borrowed by this reference
+ 32 │         copy s;
+    │         ^^^^^^ Invalid copy of local 's'
     │
 
 error: 
 
-    ┌── tests/move_check/borrows/copy_combo_invalid.move:40:21 ───
+    ┌── tests/move_check/borrows/copy_combo_invalid.move:39:17 ───
     │
- 40 │         if (cond) { copy s; };
-    │                     ^^^^^^ Invalid copy of local 's'
-    ·
  39 │         let f = &mut s.f;
     │                 -------- It is still being mutably borrowed by this reference
+ 40 │         if (cond) { copy s; };
+    │                     ^^^^^^ Invalid copy of local 's'
     │
 

--- a/language/move-lang/tests/move_check/borrows/copy_field_invalid.exp
+++ b/language/move-lang/tests/move_check/borrows/copy_field_invalid.exp
@@ -1,22 +1,20 @@
 error: 
 
-    ┌── tests/move_check/borrows/copy_field_invalid.move:13:9 ───
+    ┌── tests/move_check/borrows/copy_field_invalid.move:12:17 ───
     │
- 13 │         copy s;
-    │         ^^^^^^ Invalid copy of local 's'
-    ·
  12 │         let f = &mut s.f;
     │                 -------- It is still being mutably borrowed by this reference
+ 13 │         copy s;
+    │         ^^^^^^ Invalid copy of local 's'
     │
 
 error: 
 
-    ┌── tests/move_check/borrows/copy_field_invalid.move:19:9 ───
+    ┌── tests/move_check/borrows/copy_field_invalid.move:18:17 ───
     │
- 19 │         copy s;
-    │         ^^^^^^ Invalid copy of local 's'
-    ·
  18 │         let f = id_mut(&mut s.f);
     │                 ---------------- It is still being mutably borrowed by this reference
+ 19 │         copy s;
+    │         ^^^^^^ Invalid copy of local 's'
     │
 

--- a/language/move-lang/tests/move_check/borrows/copy_full_invalid.exp
+++ b/language/move-lang/tests/move_check/borrows/copy_full_invalid.exp
@@ -1,22 +1,20 @@
 error: 
 
-    ┌── tests/move_check/borrows/copy_full_invalid.move:13:9 ───
+    ┌── tests/move_check/borrows/copy_full_invalid.move:12:17 ───
     │
- 13 │         x;
-    │         ^ Invalid copy of local 'x'
-    ·
  12 │         let f = &mut x;
     │                 ------ It is still being mutably borrowed by this reference
+ 13 │         x;
+    │         ^ Invalid copy of local 'x'
     │
 
 error: 
 
-    ┌── tests/move_check/borrows/copy_full_invalid.move:19:9 ───
+    ┌── tests/move_check/borrows/copy_full_invalid.move:18:17 ───
     │
- 19 │         x;
-    │         ^ Invalid copy of local 'x'
-    ·
  18 │         let f = id_mut(&mut x);
     │                 -------------- It is still being mutably borrowed by this reference
+ 19 │         x;
+    │         ^ Invalid copy of local 'x'
     │
 

--- a/language/move-lang/tests/move_check/borrows/dereference_combo_invalid.exp
+++ b/language/move-lang/tests/move_check/borrows/dereference_combo_invalid.exp
@@ -1,36 +1,31 @@
 error: 
 
-    ┌── tests/move_check/borrows/dereference_combo_invalid.move:13:9 ───
+    ┌── tests/move_check/borrows/dereference_combo_invalid.move:12:23 ───
     │
- 13 │         *s;
-    │         ^^ Invalid dereference.
-    ·
  12 │         if (cond) f = &mut s.f else f = &mut other.f;
     │                       -------- Field 'f' is still being mutably borrowed by this reference
+ 13 │         *s;
+    │         ^^ Invalid dereference.
     │
 
 error: 
 
-    ┌── tests/move_check/borrows/dereference_combo_invalid.move:20:9 ───
+    ┌── tests/move_check/borrows/dereference_combo_invalid.move:19:23 ───
     │
- 20 │         *s;
-    │         ^^ Invalid dereference.
-    ·
  19 │         if (cond) f = &mut s.f else f = &mut s.g;
     │                       -------- Field 'f' is still being mutably borrowed by this reference
-    ·
- 19 │         if (cond) f = &mut s.f else f = &mut s.g;
     │                                         -------- Field 'g' is still being mutably borrowed by this reference
+ 20 │         *s;
+    │         ^^ Invalid dereference.
     │
 
 error: 
 
-    ┌── tests/move_check/borrows/dereference_combo_invalid.move:27:9 ───
+    ┌── tests/move_check/borrows/dereference_combo_invalid.move:26:23 ───
     │
- 27 │         *s;
-    │         ^^ Invalid dereference.
-    ·
  26 │         if (cond) x = copy s else x = other;
     │                       ------ It is still being mutably borrowed by this reference
+ 27 │         *s;
+    │         ^^ Invalid dereference.
     │
 

--- a/language/move-lang/tests/move_check/borrows/dereference_field_invalid.exp
+++ b/language/move-lang/tests/move_check/borrows/dereference_field_invalid.exp
@@ -1,22 +1,20 @@
 error: 
 
-    ┌── tests/move_check/borrows/dereference_field_invalid.move:12:9 ───
+    ┌── tests/move_check/borrows/dereference_field_invalid.move:11:17 ───
     │
- 12 │         *s;
-    │         ^^ Invalid dereference.
-    ·
  11 │         let f = &mut s.f;
     │                 -------- Field 'f' is still being mutably borrowed by this reference
+ 12 │         *s;
+    │         ^^ Invalid dereference.
     │
 
 error: 
 
-    ┌── tests/move_check/borrows/dereference_field_invalid.move:16:9 ───
+    ┌── tests/move_check/borrows/dereference_field_invalid.move:15:17 ───
     │
- 16 │         *s;
-    │         ^^ Invalid dereference.
-    ·
  15 │         let f = id_mut(&mut s.f);
     │                 ---------------- Field 'f' is still being mutably borrowed by this reference
+ 16 │         *s;
+    │         ^^ Invalid dereference.
     │
 

--- a/language/move-lang/tests/move_check/borrows/dereference_full_invalid.exp
+++ b/language/move-lang/tests/move_check/borrows/dereference_full_invalid.exp
@@ -1,22 +1,20 @@
 error: 
 
-    ┌── tests/move_check/borrows/dereference_full_invalid.move:13:9 ───
+    ┌── tests/move_check/borrows/dereference_full_invalid.move:12:17 ───
     │
- 13 │         *x;
-    │         ^^ Invalid dereference.
-    ·
  12 │         let y = copy x;
     │                 ------ It is still being mutably borrowed by this reference
+ 13 │         *x;
+    │         ^^ Invalid dereference.
     │
 
 error: 
 
-    ┌── tests/move_check/borrows/dereference_full_invalid.move:18:9 ───
+    ┌── tests/move_check/borrows/dereference_full_invalid.move:17:17 ───
     │
- 18 │         *x;
-    │         ^^ Invalid dereference.
-    ·
  17 │         let y = id_mut(x);
     │                 --------- It is still being mutably borrowed by this reference
+ 18 │         *x;
+    │         ^^ Invalid dereference.
     │
 

--- a/language/move-lang/tests/move_check/borrows/freeze_combo_invalid.exp
+++ b/language/move-lang/tests/move_check/borrows/freeze_combo_invalid.exp
@@ -1,36 +1,31 @@
 error: 
 
-    ┌── tests/move_check/borrows/freeze_combo_invalid.move:13:9 ───
+    ┌── tests/move_check/borrows/freeze_combo_invalid.move:12:23 ───
     │
- 13 │         freeze(s);
-    │         ^^^^^^^^^ Invalid freeze.
-    ·
  12 │         if (cond) f = &mut s.f else f = &mut other.f;
     │                       -------- Field 'f' is still being mutably borrowed by this reference
+ 13 │         freeze(s);
+    │         ^^^^^^^^^ Invalid freeze.
     │
 
 error: 
 
-    ┌── tests/move_check/borrows/freeze_combo_invalid.move:20:9 ───
+    ┌── tests/move_check/borrows/freeze_combo_invalid.move:19:23 ───
     │
- 20 │         freeze(s);
-    │         ^^^^^^^^^ Invalid freeze.
-    ·
  19 │         if (cond) f = &mut s.f else f = &mut s.g;
     │                       -------- Field 'f' is still being mutably borrowed by this reference
-    ·
- 19 │         if (cond) f = &mut s.f else f = &mut s.g;
     │                                         -------- Field 'g' is still being mutably borrowed by this reference
+ 20 │         freeze(s);
+    │         ^^^^^^^^^ Invalid freeze.
     │
 
 error: 
 
-    ┌── tests/move_check/borrows/freeze_combo_invalid.move:27:9 ───
+    ┌── tests/move_check/borrows/freeze_combo_invalid.move:26:23 ───
     │
- 27 │         freeze(s);
-    │         ^^^^^^^^^ Invalid freeze.
-    ·
  26 │         if (cond) x = s else x = other;
     │                       - It is still being mutably borrowed by this reference
+ 27 │         freeze(s);
+    │         ^^^^^^^^^ Invalid freeze.
     │
 

--- a/language/move-lang/tests/move_check/borrows/freeze_field_invalid.exp
+++ b/language/move-lang/tests/move_check/borrows/freeze_field_invalid.exp
@@ -1,22 +1,20 @@
 error: 
 
-    ┌── tests/move_check/borrows/freeze_field_invalid.move:12:9 ───
+    ┌── tests/move_check/borrows/freeze_field_invalid.move:11:17 ───
     │
- 12 │         freeze(s);
-    │         ^^^^^^^^^ Invalid freeze.
-    ·
  11 │         let f = &mut s.f;
     │                 -------- Field 'f' is still being mutably borrowed by this reference
+ 12 │         freeze(s);
+    │         ^^^^^^^^^ Invalid freeze.
     │
 
 error: 
 
-    ┌── tests/move_check/borrows/freeze_field_invalid.move:19:9 ───
+    ┌── tests/move_check/borrows/freeze_field_invalid.move:18:17 ───
     │
- 19 │         freeze(s);
-    │         ^^^^^^^^^ Invalid freeze.
-    ·
  18 │         let g = &mut s.f;
     │                 -------- Field 'f' is still being mutably borrowed by this reference
+ 19 │         freeze(s);
+    │         ^^^^^^^^^ Invalid freeze.
     │
 

--- a/language/move-lang/tests/move_check/borrows/move_combo_invalid.exp
+++ b/language/move-lang/tests/move_check/borrows/move_combo_invalid.exp
@@ -1,55 +1,50 @@
 error: 
 
-    ┌── tests/move_check/borrows/move_combo_invalid.move:14:9 ───
+    ┌── tests/move_check/borrows/move_combo_invalid.move:13:37 ───
     │
- 14 │         move s;
-    │         ^^^^^^ Invalid move of local 's'
-    ·
  13 │         if (cond) f = &s.f else f = &s.g;
     │                                     ---- It is still being borrowed by this reference
+ 14 │         move s;
+    │         ^^^^^^ Invalid move of local 's'
     │
 
 error: 
 
-    ┌── tests/move_check/borrows/move_combo_invalid.move:22:9 ───
+    ┌── tests/move_check/borrows/move_combo_invalid.move:21:23 ───
     │
- 22 │         move s;
-    │         ^^^^^^ Invalid move of local 's'
-    ·
  21 │         if (cond) f = &mut s.f else f = &mut other.f;
     │                       -------- It is still being mutably borrowed by this reference
+ 22 │         move s;
+    │         ^^^^^^ Invalid move of local 's'
     │
 
 error: 
 
-    ┌── tests/move_check/borrows/move_combo_invalid.move:30:9 ───
+    ┌── tests/move_check/borrows/move_combo_invalid.move:29:23 ───
     │
- 30 │         move s;
-    │         ^^^^^^ Invalid move of local 's'
-    ·
  29 │         if (cond) f = &mut s else f = other;
     │                       ------ It is still being mutably borrowed by this reference
+ 30 │         move s;
+    │         ^^^^^^ Invalid move of local 's'
     │
 
 error: 
 
-    ┌── tests/move_check/borrows/move_combo_invalid.move:38:9 ───
+    ┌── tests/move_check/borrows/move_combo_invalid.move:37:23 ───
     │
- 38 │         move s;
-    │         ^^^^^^ Invalid move of local 's'
-    ·
  37 │         if (cond) f = id_mut(&mut s) else f = other;
     │                       -------------- It is still being mutably borrowed by this reference
+ 38 │         move s;
+    │         ^^^^^^ Invalid move of local 's'
     │
 
 error: 
 
-    ┌── tests/move_check/borrows/move_combo_invalid.move:45:21 ───
+    ┌── tests/move_check/borrows/move_combo_invalid.move:44:17 ───
     │
- 45 │         if (cond) { move s; };
-    │                     ^^^^^^ Invalid move of local 's'
-    ·
  44 │         let f = &s.f;
     │                 ---- It is still being borrowed by this reference
+ 45 │         if (cond) { move s; };
+    │                     ^^^^^^ Invalid move of local 's'
     │
 

--- a/language/move-lang/tests/move_check/borrows/move_field_invalid.exp
+++ b/language/move-lang/tests/move_check/borrows/move_field_invalid.exp
@@ -1,44 +1,40 @@
 error: 
 
-    ┌── tests/move_check/borrows/move_field_invalid.move:13:9 ───
+    ┌── tests/move_check/borrows/move_field_invalid.move:12:17 ───
     │
- 13 │         move s;
-    │         ^^^^^^ Invalid move of local 's'
-    ·
  12 │         let f = &s.f;
     │                 ---- It is still being borrowed by this reference
+ 13 │         move s;
+    │         ^^^^^^ Invalid move of local 's'
     │
 
 error: 
 
-    ┌── tests/move_check/borrows/move_field_invalid.move:18:9 ───
+    ┌── tests/move_check/borrows/move_field_invalid.move:17:17 ───
     │
- 18 │         move s;
-    │         ^^^^^^ Invalid move of local 's'
-    ·
  17 │         let f = &mut s.f;
     │                 -------- It is still being mutably borrowed by this reference
+ 18 │         move s;
+    │         ^^^^^^ Invalid move of local 's'
     │
 
 error: 
 
-    ┌── tests/move_check/borrows/move_field_invalid.move:23:9 ───
+    ┌── tests/move_check/borrows/move_field_invalid.move:22:17 ───
     │
- 23 │         move s;
-    │         ^^^^^^ Invalid move of local 's'
-    ·
  22 │         let f = id(&s.f);
     │                 -------- It is still being borrowed by this reference
+ 23 │         move s;
+    │         ^^^^^^ Invalid move of local 's'
     │
 
 error: 
 
-    ┌── tests/move_check/borrows/move_field_invalid.move:28:9 ───
+    ┌── tests/move_check/borrows/move_field_invalid.move:27:17 ───
     │
- 28 │         move s;
-    │         ^^^^^^ Invalid move of local 's'
-    ·
  27 │         let f = id_mut(&mut s.f);
     │                 ---------------- It is still being mutably borrowed by this reference
+ 28 │         move s;
+    │         ^^^^^^ Invalid move of local 's'
     │
 

--- a/language/move-lang/tests/move_check/borrows/move_from_invalid.exp
+++ b/language/move-lang/tests/move_check/borrows/move_from_invalid.exp
@@ -1,99 +1,90 @@
 error: 
 
-    ┌── tests/move_check/borrows/move_from_invalid.move:12:23 ───
+    ┌── tests/move_check/borrows/move_from_invalid.move:11:18 ───
     │
- 12 │         let R { f } = move_from<R>(addr);
-    │                       ^^^^^^^^^^^^^^^^^^ Invalid extraction of resource 'R'
-    ·
  11 │         let r1 = borrow_global_mut<R>(addr);
     │                  -------------------------- It is still being mutably borrowed by this reference
+ 12 │         let R { f } = move_from<R>(addr);
+    │                       ^^^^^^^^^^^^^^^^^^ Invalid extraction of resource 'R'
     │
 
 error: 
 
-    ┌── tests/move_check/borrows/move_from_invalid.move:18:23 ───
+    ┌── tests/move_check/borrows/move_from_invalid.move:17:21 ───
     │
- 18 │         let R { f } = move_from<R>(addr);
-    │                       ^^^^^^^^^^^^^^^^^^ Invalid extraction of resource 'R'
-    ·
  17 │         let f_ref = &mut borrow_global_mut<R>(addr).f;
     │                     --------------------------------- It is still being mutably borrowed by this reference
+ 18 │         let R { f } = move_from<R>(addr);
+    │                       ^^^^^^^^^^^^^^^^^^ Invalid extraction of resource 'R'
     │
 
 error: 
 
-    ┌── tests/move_check/borrows/move_from_invalid.move:24:23 ───
+    ┌── tests/move_check/borrows/move_from_invalid.move:23:18 ───
     │
- 24 │         let R { f } = move_from<R>(addr);
-    │                       ^^^^^^^^^^^^^^^^^^ Invalid extraction of resource 'R'
-    ·
  23 │         let r1 = id_mut(borrow_global_mut<R>(addr));
     │                  ---------------------------------- It is still being mutably borrowed by this reference
+ 24 │         let R { f } = move_from<R>(addr);
+    │                       ^^^^^^^^^^^^^^^^^^ Invalid extraction of resource 'R'
     │
 
 error: 
 
-    ┌── tests/move_check/borrows/move_from_invalid.move:30:23 ───
+    ┌── tests/move_check/borrows/move_from_invalid.move:29:21 ───
     │
- 30 │         let R { f } = move_from<R>(addr);
-    │                       ^^^^^^^^^^^^^^^^^^ Invalid extraction of resource 'R'
-    ·
  29 │         let f_ref = id_mut(&mut borrow_global_mut<R>(addr).f);
     │                     ----------------------------------------- It is still being mutably borrowed by this reference
+ 30 │         let R { f } = move_from<R>(addr);
+    │                       ^^^^^^^^^^^^^^^^^^ Invalid extraction of resource 'R'
     │
 
 error: 
 
-    ┌── tests/move_check/borrows/move_from_invalid.move:36:23 ───
+    ┌── tests/move_check/borrows/move_from_invalid.move:35:18 ───
     │
- 36 │         let R { f } = move_from<R>(addr);
-    │                       ^^^^^^^^^^^^^^^^^^ Invalid extraction of resource 'R'
-    ·
  35 │         let r1 = borrow_global<R>(addr);
     │                  ---------------------- It is still being borrowed by this reference
+ 36 │         let R { f } = move_from<R>(addr);
+    │                       ^^^^^^^^^^^^^^^^^^ Invalid extraction of resource 'R'
     │
 
 error: 
 
-    ┌── tests/move_check/borrows/move_from_invalid.move:42:23 ───
+    ┌── tests/move_check/borrows/move_from_invalid.move:41:21 ───
     │
- 42 │         let R { f } = move_from<R>(addr);
-    │                       ^^^^^^^^^^^^^^^^^^ Invalid extraction of resource 'R'
-    ·
  41 │         let f_ref = &borrow_global<R>(addr).f;
     │                     ------------------------- It is still being borrowed by this reference
+ 42 │         let R { f } = move_from<R>(addr);
+    │                       ^^^^^^^^^^^^^^^^^^ Invalid extraction of resource 'R'
     │
 
 error: 
 
-    ┌── tests/move_check/borrows/move_from_invalid.move:48:23 ───
+    ┌── tests/move_check/borrows/move_from_invalid.move:47:18 ───
     │
- 48 │         let R { f } = move_from<R>(addr);
-    │                       ^^^^^^^^^^^^^^^^^^ Invalid extraction of resource 'R'
-    ·
  47 │         let r1 = id(borrow_global<R>(addr));
     │                  -------------------------- It is still being borrowed by this reference
+ 48 │         let R { f } = move_from<R>(addr);
+    │                       ^^^^^^^^^^^^^^^^^^ Invalid extraction of resource 'R'
     │
 
 error: 
 
-    ┌── tests/move_check/borrows/move_from_invalid.move:54:23 ───
+    ┌── tests/move_check/borrows/move_from_invalid.move:53:21 ───
     │
- 54 │         let R { f } = move_from<R>(addr);
-    │                       ^^^^^^^^^^^^^^^^^^ Invalid extraction of resource 'R'
-    ·
  53 │         let f_ref = id(&borrow_global<R>(addr).f);
     │                     ----------------------------- It is still being borrowed by this reference
+ 54 │         let R { f } = move_from<R>(addr);
+    │                       ^^^^^^^^^^^^^^^^^^ Invalid extraction of resource 'R'
     │
 
 error: 
 
-    ┌── tests/move_check/borrows/move_from_invalid.move:62:23 ───
+    ┌── tests/move_check/borrows/move_from_invalid.move:61:32 ───
     │
- 62 │         let R { f } = move_from<R>(addr);
-    │                       ^^^^^^^^^^^^^^^^^^ Invalid extraction of resource 'R'
-    ·
  61 │         let r1; if (cond) r1 = borrow_global_mut<R>(addr) else r1 = &mut r;
     │                                -------------------------- It is still being mutably borrowed by this reference
+ 62 │         let R { f } = move_from<R>(addr);
+    │                       ^^^^^^^^^^^^^^^^^^ Invalid extraction of resource 'R'
     │
 

--- a/language/move-lang/tests/move_check/borrows/move_full_invalid.exp
+++ b/language/move-lang/tests/move_check/borrows/move_full_invalid.exp
@@ -1,44 +1,40 @@
 error: 
 
-    ┌── tests/move_check/borrows/move_full_invalid.move:13:9 ───
+    ┌── tests/move_check/borrows/move_full_invalid.move:12:17 ───
     │
- 13 │         move x;
-    │         ^^^^^^ Invalid move of local 'x'
-    ·
  12 │         let f = &x;
     │                 -- It is still being borrowed by this reference
+ 13 │         move x;
+    │         ^^^^^^ Invalid move of local 'x'
     │
 
 error: 
 
-    ┌── tests/move_check/borrows/move_full_invalid.move:18:9 ───
+    ┌── tests/move_check/borrows/move_full_invalid.move:17:17 ───
     │
- 18 │         move x;
-    │         ^^^^^^ Invalid move of local 'x'
-    ·
  17 │         let f = &mut x;
     │                 ------ It is still being mutably borrowed by this reference
+ 18 │         move x;
+    │         ^^^^^^ Invalid move of local 'x'
     │
 
 error: 
 
-    ┌── tests/move_check/borrows/move_full_invalid.move:23:9 ───
+    ┌── tests/move_check/borrows/move_full_invalid.move:22:17 ───
     │
- 23 │         move x;
-    │         ^^^^^^ Invalid move of local 'x'
-    ·
  22 │         let f = id(&x);
     │                 ------ It is still being borrowed by this reference
+ 23 │         move x;
+    │         ^^^^^^ Invalid move of local 'x'
     │
 
 error: 
 
-    ┌── tests/move_check/borrows/move_full_invalid.move:28:9 ───
+    ┌── tests/move_check/borrows/move_full_invalid.move:27:17 ───
     │
- 28 │         move x;
-    │         ^^^^^^ Invalid move of local 'x'
-    ·
  27 │         let f = id_mut(&mut x);
     │                 -------------- It is still being mutably borrowed by this reference
+ 28 │         move x;
+    │         ^^^^^^ Invalid move of local 'x'
     │
 

--- a/language/move-lang/tests/move_check/borrows/mutate_combo_invalid.exp
+++ b/language/move-lang/tests/move_check/borrows/mutate_combo_invalid.exp
@@ -1,58 +1,51 @@
 error: 
 
-    ┌── tests/move_check/borrows/mutate_combo_invalid.move:14:9 ───
+    ┌── tests/move_check/borrows/mutate_combo_invalid.move:13:23 ───
     │
- 14 │         *s = S { f: 0, g: 0 };
-    │         ^^^^^^^^^^^^^^^^^^^^^ Invalid mutation of reference.
-    ·
  13 │         if (cond) f = &s.f else f = &s.g;
     │                       ---- Field 'f' is still being borrowed by this reference
-    ·
- 13 │         if (cond) f = &s.f else f = &s.g;
     │                                     ---- Field 'g' is still being borrowed by this reference
+ 14 │         *s = S { f: 0, g: 0 };
+    │         ^^^^^^^^^^^^^^^^^^^^^ Invalid mutation of reference.
     │
 
 error: 
 
-    ┌── tests/move_check/borrows/mutate_combo_invalid.move:23:9 ───
+    ┌── tests/move_check/borrows/mutate_combo_invalid.move:22:23 ───
     │
- 23 │         *s = S { f: 0, g: 0 };
-    │         ^^^^^^^^^^^^^^^^^^^^^ Invalid mutation of reference.
-    ·
  22 │         if (cond) f = &mut s.f else f = &mut other.f;
     │                       -------- Field 'f' is still being mutably borrowed by this reference
+ 23 │         *s = S { f: 0, g: 0 };
+    │         ^^^^^^^^^^^^^^^^^^^^^ Invalid mutation of reference.
     │
 
 error: 
 
-    ┌── tests/move_check/borrows/mutate_combo_invalid.move:32:9 ───
+    ┌── tests/move_check/borrows/mutate_combo_invalid.move:31:23 ───
     │
- 32 │         *s = S { f: 0, g: 0 };
-    │         ^^^^^^^^^^^^^^^^^^^^^ Invalid mutation of reference.
-    ·
  31 │         if (cond) f = s else f = other;
     │                       - It is still being mutably borrowed by this reference
+ 32 │         *s = S { f: 0, g: 0 };
+    │         ^^^^^^^^^^^^^^^^^^^^^ Invalid mutation of reference.
     │
 
 error: 
 
-    ┌── tests/move_check/borrows/mutate_combo_invalid.move:41:9 ───
+    ┌── tests/move_check/borrows/mutate_combo_invalid.move:40:23 ───
     │
- 41 │         *s = S { f: 0, g: 0 };
-    │         ^^^^^^^^^^^^^^^^^^^^^ Invalid mutation of reference.
-    ·
  40 │         if (cond) f = id_mut(s) else f = other;
     │                       --------- It is still being mutably borrowed by this reference
+ 41 │         *s = S { f: 0, g: 0 };
+    │         ^^^^^^^^^^^^^^^^^^^^^ Invalid mutation of reference.
     │
 
 error: 
 
-    ┌── tests/move_check/borrows/mutate_combo_invalid.move:49:19 ───
+    ┌── tests/move_check/borrows/mutate_combo_invalid.move:48:17 ───
     │
- 49 │         if (cond) *s = S { f: 0, g: 0 };
-    │                   ^^^^^^^^^^^^^^^^^^^^^ Invalid mutation of reference.
-    ·
  48 │         let f = &s.f;
     │                 ---- Field 'f' is still being borrowed by this reference
+ 49 │         if (cond) *s = S { f: 0, g: 0 };
+    │                   ^^^^^^^^^^^^^^^^^^^^^ Invalid mutation of reference.
     │
 

--- a/language/move-lang/tests/move_check/borrows/mutate_field_invalid.exp
+++ b/language/move-lang/tests/move_check/borrows/mutate_field_invalid.exp
@@ -1,44 +1,40 @@
 error: 
 
-    ┌── tests/move_check/borrows/mutate_field_invalid.move:11:9 ───
+    ┌── tests/move_check/borrows/mutate_field_invalid.move:10:17 ───
     │
- 11 │         *s = S { f: 0, g: 0 };
-    │         ^^^^^^^^^^^^^^^^^^^^^ Invalid mutation of reference.
-    ·
  10 │         let f = &s.f;
     │                 ---- Field 'f' is still being borrowed by this reference
+ 11 │         *s = S { f: 0, g: 0 };
+    │         ^^^^^^^^^^^^^^^^^^^^^ Invalid mutation of reference.
     │
 
 error: 
 
-    ┌── tests/move_check/borrows/mutate_field_invalid.move:15:9 ───
+    ┌── tests/move_check/borrows/mutate_field_invalid.move:14:17 ───
     │
- 15 │         *s = S { f: 0, g: 0 };
-    │         ^^^^^^^^^^^^^^^^^^^^^ Invalid mutation of reference.
-    ·
  14 │         let f = &mut s.f;
     │                 -------- Field 'f' is still being mutably borrowed by this reference
+ 15 │         *s = S { f: 0, g: 0 };
+    │         ^^^^^^^^^^^^^^^^^^^^^ Invalid mutation of reference.
     │
 
 error: 
 
-    ┌── tests/move_check/borrows/mutate_field_invalid.move:19:9 ───
+    ┌── tests/move_check/borrows/mutate_field_invalid.move:18:17 ───
     │
- 19 │         *s = S { f: 0, g: 0 };
-    │         ^^^^^^^^^^^^^^^^^^^^^ Invalid mutation of reference.
-    ·
  18 │         let f = id(&s.f);
     │                 -------- Field 'f' is still being borrowed by this reference
+ 19 │         *s = S { f: 0, g: 0 };
+    │         ^^^^^^^^^^^^^^^^^^^^^ Invalid mutation of reference.
     │
 
 error: 
 
-    ┌── tests/move_check/borrows/mutate_field_invalid.move:23:9 ───
+    ┌── tests/move_check/borrows/mutate_field_invalid.move:22:17 ───
     │
- 23 │         *s = S { f: 0, g: 0 };
-    │         ^^^^^^^^^^^^^^^^^^^^^ Invalid mutation of reference.
-    ·
  22 │         let f = id_mut(&mut s.f);
     │                 ---------------- Field 'f' is still being mutably borrowed by this reference
+ 23 │         *s = S { f: 0, g: 0 };
+    │         ^^^^^^^^^^^^^^^^^^^^^ Invalid mutation of reference.
     │
 

--- a/language/move-lang/tests/move_check/borrows/mutate_full_invalid.exp
+++ b/language/move-lang/tests/move_check/borrows/mutate_full_invalid.exp
@@ -1,44 +1,40 @@
 error: 
 
-    ┌── tests/move_check/borrows/mutate_full_invalid.move:13:9 ───
+    ┌── tests/move_check/borrows/mutate_full_invalid.move:12:17 ───
     │
- 13 │         *x = 0;
-    │         ^^^^^^ Invalid mutation of reference.
-    ·
  12 │         let f = x;
     │                 - It is still being mutably borrowed by this reference
+ 13 │         *x = 0;
+    │         ^^^^^^ Invalid mutation of reference.
     │
 
 error: 
 
-    ┌── tests/move_check/borrows/mutate_full_invalid.move:18:9 ───
+    ┌── tests/move_check/borrows/mutate_full_invalid.move:17:17 ───
     │
- 18 │         *x = 0;
-    │         ^^^^^^ Invalid mutation of reference.
-    ·
  17 │         let f = freeze(x);
     │                 --------- It is still being borrowed by this reference
+ 18 │         *x = 0;
+    │         ^^^^^^ Invalid mutation of reference.
     │
 
 error: 
 
-    ┌── tests/move_check/borrows/mutate_full_invalid.move:23:9 ───
+    ┌── tests/move_check/borrows/mutate_full_invalid.move:22:17 ───
     │
- 23 │         *x = 0;
-    │         ^^^^^^ Invalid mutation of reference.
-    ·
  22 │         let f = id(x);
     │                 ----- It is still being borrowed by this reference
+ 23 │         *x = 0;
+    │         ^^^^^^ Invalid mutation of reference.
     │
 
 error: 
 
-    ┌── tests/move_check/borrows/mutate_full_invalid.move:28:9 ───
+    ┌── tests/move_check/borrows/mutate_full_invalid.move:27:17 ───
     │
- 28 │         *x = 0;
-    │         ^^^^^^ Invalid mutation of reference.
-    ·
  27 │         let f = id_mut(x);
     │                 --------- It is still being mutably borrowed by this reference
+ 28 │         *x = 0;
+    │         ^^^^^^ Invalid mutation of reference.
     │
 

--- a/language/move-lang/tests/move_check/borrows/return_borrowed_local_invalid.exp
+++ b/language/move-lang/tests/move_check/borrows/return_borrowed_local_invalid.exp
@@ -1,43 +1,39 @@
 error: 
 
     ┌── tests/move_check/borrows/return_borrowed_local_invalid.move:19:9 ───
-    │
+    │  
  19 │ ╭         (&mut v1,
  20 │ │         &v2,
  21 │ │         id_mut(&mut v3),
  22 │ │         id(&v4),
  23 │ │         &mut s1.f,
+    │ │         --------- It is still being mutably borrowed by this reference
  24 │ │         &s2.f,
  25 │ │         id_mut(&mut s3.f),
  26 │ │         id(&s4.f))
     │ ╰──────────────────^ Invalid return. Local 's1' is still being borrowed.
-    ·
- 23 │         &mut s1.f,
-    │         --------- It is still being mutably borrowed by this reference
-    │
+    │  
 
 error: 
 
     ┌── tests/move_check/borrows/return_borrowed_local_invalid.move:19:9 ───
-    │
+    │  
  19 │ ╭         (&mut v1,
  20 │ │         &v2,
  21 │ │         id_mut(&mut v3),
  22 │ │         id(&v4),
  23 │ │         &mut s1.f,
  24 │ │         &s2.f,
+    │ │         ----- It is still being borrowed by this reference
  25 │ │         id_mut(&mut s3.f),
  26 │ │         id(&s4.f))
     │ ╰──────────────────^ Invalid return. Local 's2' is still being borrowed.
-    ·
- 24 │         &s2.f,
-    │         ----- It is still being borrowed by this reference
-    │
+    │  
 
 error: 
 
     ┌── tests/move_check/borrows/return_borrowed_local_invalid.move:19:9 ───
-    │
+    │  
  19 │ ╭         (&mut v1,
  20 │ │         &v2,
  21 │ │         id_mut(&mut v3),
@@ -45,17 +41,15 @@ error:
  23 │ │         &mut s1.f,
  24 │ │         &s2.f,
  25 │ │         id_mut(&mut s3.f),
+    │ │         ----------------- It is still being mutably borrowed by this reference
  26 │ │         id(&s4.f))
     │ ╰──────────────────^ Invalid return. Local 's3' is still being borrowed.
-    ·
- 25 │         id_mut(&mut s3.f),
-    │         ----------------- It is still being mutably borrowed by this reference
-    │
+    │  
 
 error: 
 
     ┌── tests/move_check/borrows/return_borrowed_local_invalid.move:19:9 ───
-    │
+    │  
  19 │ ╭         (&mut v1,
  20 │ │         &v2,
  21 │ │         id_mut(&mut v3),
@@ -64,17 +58,16 @@ error:
  24 │ │         &s2.f,
  25 │ │         id_mut(&mut s3.f),
  26 │ │         id(&s4.f))
+    │ │         --------- It is still being borrowed by this reference
     │ ╰──────────────────^ Invalid return. Local 's4' is still being borrowed.
-    ·
- 26 │         id(&s4.f))
-    │         --------- It is still being borrowed by this reference
-    │
+    │  
 
 error: 
 
     ┌── tests/move_check/borrows/return_borrowed_local_invalid.move:19:9 ───
-    │
+    │  
  19 │ ╭         (&mut v1,
+    │ │          ------- It is still being mutably borrowed by this reference
  20 │ │         &v2,
  21 │ │         id_mut(&mut v3),
  22 │ │         id(&v4),
@@ -83,17 +76,15 @@ error:
  25 │ │         id_mut(&mut s3.f),
  26 │ │         id(&s4.f))
     │ ╰──────────────────^ Invalid return. Local 'v1' is still being borrowed.
-    ·
- 19 │         (&mut v1,
-    │          ------- It is still being mutably borrowed by this reference
-    │
+    │  
 
 error: 
 
     ┌── tests/move_check/borrows/return_borrowed_local_invalid.move:19:9 ───
-    │
+    │  
  19 │ ╭         (&mut v1,
  20 │ │         &v2,
+    │ │         --- It is still being borrowed by this reference
  21 │ │         id_mut(&mut v3),
  22 │ │         id(&v4),
  23 │ │         &mut s1.f,
@@ -101,44 +92,37 @@ error:
  25 │ │         id_mut(&mut s3.f),
  26 │ │         id(&s4.f))
     │ ╰──────────────────^ Invalid return. Local 'v2' is still being borrowed.
-    ·
- 20 │         &v2,
-    │         --- It is still being borrowed by this reference
-    │
+    │  
 
 error: 
 
     ┌── tests/move_check/borrows/return_borrowed_local_invalid.move:19:9 ───
-    │
+    │  
  19 │ ╭         (&mut v1,
  20 │ │         &v2,
  21 │ │         id_mut(&mut v3),
+    │ │         --------------- It is still being mutably borrowed by this reference
  22 │ │         id(&v4),
  23 │ │         &mut s1.f,
  24 │ │         &s2.f,
  25 │ │         id_mut(&mut s3.f),
  26 │ │         id(&s4.f))
     │ ╰──────────────────^ Invalid return. Local 'v3' is still being borrowed.
-    ·
- 21 │         id_mut(&mut v3),
-    │         --------------- It is still being mutably borrowed by this reference
-    │
+    │  
 
 error: 
 
     ┌── tests/move_check/borrows/return_borrowed_local_invalid.move:19:9 ───
-    │
+    │  
  19 │ ╭         (&mut v1,
  20 │ │         &v2,
  21 │ │         id_mut(&mut v3),
  22 │ │         id(&v4),
+    │ │         ------- It is still being borrowed by this reference
  23 │ │         &mut s1.f,
  24 │ │         &s2.f,
  25 │ │         id_mut(&mut s3.f),
  26 │ │         id(&s4.f))
     │ ╰──────────────────^ Invalid return. Local 'v4' is still being borrowed.
-    ·
- 22 │         id(&v4),
-    │         ------- It is still being borrowed by this reference
-    │
+    │  
 

--- a/language/move-lang/tests/move_check/borrows/return_mutual_borrows_invalid.exp
+++ b/language/move-lang/tests/move_check/borrows/return_mutual_borrows_invalid.exp
@@ -1,45 +1,41 @@
 error: 
 
-    ┌── tests/move_check/borrows/return_mutual_borrows_invalid.move:15:9 ───
+    ┌── tests/move_check/borrows/return_mutual_borrows_invalid.move:14:17 ───
     │
- 15 │         (s1, f)
-    │         ^^^^^^^ Invalid return of reference. Cannot transfer a mutable reference that is being borrowed
-    ·
  14 │         let f = freeze(s1);
     │                 ---------- It is still being borrowed by this reference
+ 15 │         (s1, f)
+    │         ^^^^^^^ Invalid return of reference. Cannot transfer a mutable reference that is being borrowed
     │
 
 error: 
 
-    ┌── tests/move_check/borrows/return_mutual_borrows_invalid.move:19:9 ───
+    ┌── tests/move_check/borrows/return_mutual_borrows_invalid.move:18:17 ───
     │
- 19 │         (s1, f)
-    │         ^^^^^^^ Invalid return of reference. Cannot transfer a mutable reference that is being borrowed
-    ·
  18 │         let f = &s1.f;
     │                 ----- Field 'f' is still being borrowed by this reference
+ 19 │         (s1, f)
+    │         ^^^^^^^ Invalid return of reference. Cannot transfer a mutable reference that is being borrowed
     │
 
 error: 
 
-    ┌── tests/move_check/borrows/return_mutual_borrows_invalid.move:23:9 ───
+    ┌── tests/move_check/borrows/return_mutual_borrows_invalid.move:22:17 ───
     │
- 23 │         (&mut s1.f, f)
-    │         ^^^^^^^^^^^^^^ Invalid return of reference. Cannot transfer a mutable reference that is being borrowed
-    ·
  22 │         let f = &s1.f;
     │                 ----- It is still being borrowed by this reference
+ 23 │         (&mut s1.f, f)
+    │         ^^^^^^^^^^^^^^ Invalid return of reference. Cannot transfer a mutable reference that is being borrowed
     │
 
 error: 
 
-    ┌── tests/move_check/borrows/return_mutual_borrows_invalid.move:27:9 ───
+    ┌── tests/move_check/borrows/return_mutual_borrows_invalid.move:26:17 ───
     │
- 27 │         (&mut s1.f, f)
-    │         ^^^^^^^^^^^^^^ Invalid return of reference. Cannot transfer a mutable reference that is being borrowed
-    ·
  26 │         let f = id(&s1.f);
     │                 --------- It is still being borrowed by this reference
+ 27 │         (&mut s1.f, f)
+    │         ^^^^^^^^^^^^^^ Invalid return of reference. Cannot transfer a mutable reference that is being borrowed
     │
 
 error: 
@@ -48,20 +44,17 @@ error:
     │
  31 │         (s1, s1)
     │         ^^^^^^^^ Invalid return of reference. Cannot transfer a mutable reference that is being borrowed
-    ·
- 31 │         (s1, s1)
     │          -- It is still being mutably borrowed by this reference
     │
 
 error: 
 
-    ┌── tests/move_check/borrows/return_mutual_borrows_invalid.move:35:9 ───
+    ┌── tests/move_check/borrows/return_mutual_borrows_invalid.move:34:18 ───
     │
- 35 │         (s1, f)
-    │         ^^^^^^^ Invalid return of reference. Cannot transfer a mutable reference that is being borrowed
-    ·
  34 │         let f =  &mut s1.f;
     │                  --------- Field 'f' is still being mutably borrowed by this reference
+ 35 │         (s1, f)
+    │         ^^^^^^^ Invalid return of reference. Cannot transfer a mutable reference that is being borrowed
     │
 
 error: 
@@ -70,8 +63,6 @@ error:
     │
  38 │         (&mut s1.f, s1)
     │         ^^^^^^^^^^^^^^^ Invalid return of reference. Cannot transfer a mutable reference that is being borrowed
-    ·
- 38 │         (&mut s1.f, s1)
     │          --------- Field 'f' is still being mutably borrowed by this reference
     │
 
@@ -81,20 +72,17 @@ error:
     │
  41 │         (id_mut(s1), s1)
     │         ^^^^^^^^^^^^^^^^ Invalid return of reference. Cannot transfer a mutable reference that is being borrowed
-    ·
- 41 │         (id_mut(s1), s1)
     │          ---------- It is still being mutably borrowed by this reference
     │
 
 error: 
 
-    ┌── tests/move_check/borrows/return_mutual_borrows_invalid.move:45:9 ───
+    ┌── tests/move_check/borrows/return_mutual_borrows_invalid.move:44:17 ───
     │
- 45 │         (s1, f)
-    │         ^^^^^^^ Invalid return of reference. Cannot transfer a mutable reference that is being borrowed
-    ·
  44 │         let f = id_mut(&mut s1.f);
     │                 ----------------- Field 'f' is still being mutably borrowed by this reference
+ 45 │         (s1, f)
+    │         ^^^^^^^ Invalid return of reference. Cannot transfer a mutable reference that is being borrowed
     │
 
 error: 
@@ -103,8 +91,6 @@ error:
     │
  48 │         (id_mut(&mut s1.f), s1)
     │         ^^^^^^^^^^^^^^^^^^^^^^^ Invalid return of reference. Cannot transfer a mutable reference that is being borrowed
-    ·
- 48 │         (id_mut(&mut s1.f), s1)
     │          ----------------- Field 'f' is still being mutably borrowed by this reference
     │
 

--- a/language/move-lang/tests/move_check/dependencies/cycle_2.exp
+++ b/language/move-lang/tests/move_check/dependencies/cycle_2.exp
@@ -3,9 +3,7 @@ error:
    ┌── tests/move_check/dependencies/cycle_2.move:5:9 ───
    │
  5 │         0x1::B::foo()
-   │         ^^^^^^^^^^^^^ Invalid use of module '0x1::B' in module '0x1::A'.
-   ·
- 5 │         0x1::B::foo()
    │         ------------- Using this module creates a dependency cycle: '0x1::B' uses '0x1::A' uses '0x1::B'
+   │         ^^^^^^^^^^^^^ Invalid use of module '0x1::B' in module '0x1::A'.
    │
 

--- a/language/move-lang/tests/move_check/dependencies/cycle_3.exp
+++ b/language/move-lang/tests/move_check/dependencies/cycle_3.exp
@@ -3,9 +3,7 @@ error:
     ┌── tests/move_check/dependencies/cycle_3.move:93:16 ───
     │
  93 │     fun foo(): 0x3::C::S {
-    │                ^^^^^^^^^ Invalid use of module '0x3::C' in module '0x3::B'.
-    ·
- 93 │     fun foo(): 0x3::C::S {
     │                --------- Using this module creates a dependency cycle: '0x3::C' uses '0x3::A' uses '0x3::B' uses '0x3::C'
+    │                ^^^^^^^^^ Invalid use of module '0x3::C' in module '0x3::B'.
     │
 

--- a/language/move-lang/tests/move_check/dependencies/intersecting_cycles.exp
+++ b/language/move-lang/tests/move_check/dependencies/intersecting_cycles.exp
@@ -3,9 +3,7 @@ error:
     ┌── tests/move_check/dependencies/intersecting_cycles.move:10:14 ───
     │
  10 │     fun c(): 0x1::C::S { abort 0 }
-    │              ^^^^^^^^^ Invalid use of module '0x1::C' in module '0x1::B'.
-    ·
- 10 │     fun c(): 0x1::C::S { abort 0 }
     │              --------- Using this module creates a dependency cycle: '0x1::C' uses '0x1::A' uses '0x1::B' uses '0x1::C'
+    │              ^^^^^^^^^ Invalid use of module '0x1::C' in module '0x1::B'.
     │
 

--- a/language/move-lang/tests/move_check/dependencies/multiple_cycles.exp
+++ b/language/move-lang/tests/move_check/dependencies/multiple_cycles.exp
@@ -3,9 +3,7 @@ error:
     ┌── tests/move_check/dependencies/multiple_cycles.move:25:14 ───
     │
  25 │     fun f(): 0x1::F::S { abort 0 }
-    │              ^^^^^^^^^ Invalid use of module '0x1::F' in module '0x1::D'.
-    ·
- 25 │     fun f(): 0x1::F::S { abort 0 }
     │              --------- Using this module creates a dependency cycle: '0x1::F' uses '0x1::D' uses '0x1::F'
+    │              ^^^^^^^^^ Invalid use of module '0x1::F' in module '0x1::D'.
     │
 

--- a/language/move-lang/tests/move_check/expansion/duplicate_alias.exp
+++ b/language/move-lang/tests/move_check/expansion/duplicate_alias.exp
@@ -1,12 +1,11 @@
 error: 
 
-   ┌── tests/move_check/expansion/duplicate_alias.move:8:19 ───
+   ┌── tests/move_check/expansion/duplicate_alias.move:7:19 ───
    │
- 8 │     use 0x1::Y as Z;
-   │                   ^ Duplicate definition for alias 'Z'
-   ·
  7 │     use 0x1::X as Z;
    │                   - Previously defined here
+ 8 │     use 0x1::Y as Z;
+   │                   ^ Duplicate definition for alias 'Z'
    │
 
 error: 

--- a/language/move-lang/tests/move_check/expansion/duplicate_field.exp
+++ b/language/move-lang/tests/move_check/expansion/duplicate_field.exp
@@ -1,11 +1,10 @@
 error: 
 
-   ┌── tests/move_check/expansion/duplicate_field.move:4:9 ───
+   ┌── tests/move_check/expansion/duplicate_field.move:3:9 ───
    │
- 4 │         f: u64,
-   │         ^ Duplicate definition for field 'f' in struct 'S'
-   ·
  3 │         f: u64,
    │         - Previously defined here
+ 4 │         f: u64,
+   │         ^ Duplicate definition for field 'f' in struct 'S'
    │
 

--- a/language/move-lang/tests/move_check/expansion/duplicate_field_assign.exp
+++ b/language/move-lang/tests/move_check/expansion/duplicate_field_assign.exp
@@ -4,11 +4,7 @@ error:
    │
  5 │         S { f, f } = S { f: 0 };
    │         ^^^^^^^^^^ Invalid deconstructing assignment
-   ·
- 5 │         S { f, f } = S { f: 0 };
-   │                - Duplicate assignment binding given for field 'f'
-   ·
- 5 │         S { f, f } = S { f: 0 };
    │             - Previously defined here
+   │                - Duplicate assignment binding given for field 'f'
    │
 

--- a/language/move-lang/tests/move_check/expansion/duplicate_field_pack.exp
+++ b/language/move-lang/tests/move_check/expansion/duplicate_field_pack.exp
@@ -4,11 +4,7 @@ error:
    │
  4 │         S { f: 0, f: 0 };
    │         ^^^^^^^^^^^^^^^^ Invalid construction
-   ·
- 4 │         S { f: 0, f: 0 };
-   │                   - Duplicate argument given for field 'f'
-   ·
- 4 │         S { f: 0, f: 0 };
    │             - Previously defined here
+   │                   - Duplicate argument given for field 'f'
    │
 

--- a/language/move-lang/tests/move_check/expansion/duplicate_field_unpack.exp
+++ b/language/move-lang/tests/move_check/expansion/duplicate_field_unpack.exp
@@ -4,11 +4,7 @@ error:
    │
  4 │         let S { f, f } = S { f: 0 };
    │             ^^^^^^^^^^ Invalid deconstruction binding
-   ·
- 4 │         let S { f, f } = S { f: 0 };
-   │                    - Duplicate binding given for field 'f'
-   ·
- 4 │         let S { f, f } = S { f: 0 };
    │                 - Previously defined here
+   │                    - Duplicate binding given for field 'f'
    │
 

--- a/language/move-lang/tests/move_check/expansion/duplicate_function_in_module.exp
+++ b/language/move-lang/tests/move_check/expansion/duplicate_function_in_module.exp
@@ -1,11 +1,10 @@
 error: 
 
-   ┌── tests/move_check/expansion/duplicate_function_in_module.move:3:9 ───
+   ┌── tests/move_check/expansion/duplicate_function_in_module.move:2:9 ───
    │
- 3 │     fun foo() { }
-   │         ^^^ Duplicate definition for function 'foo' in module 'M'
-   ·
  2 │     fun foo() { }
    │         --- Previously defined here
+ 3 │     fun foo() { }
+   │         ^^^ Duplicate definition for function 'foo' in module 'M'
    │
 

--- a/language/move-lang/tests/move_check/expansion/duplicate_module.exp
+++ b/language/move-lang/tests/move_check/expansion/duplicate_module.exp
@@ -1,11 +1,10 @@
 error: 
 
-   ┌── tests/move_check/expansion/duplicate_module.move:2:8 ───
+   ┌── tests/move_check/expansion/duplicate_module.move:1:8 ───
    │
- 2 │ module M {}
-   │        ^ Duplicate definition for module '0x8675309::M'
-   ·
  1 │ module M {}
    │        - Previously defined here
+ 2 │ module M {}
+   │        ^ Duplicate definition for module '0x8675309::M'
    │
 

--- a/language/move-lang/tests/move_check/expansion/duplicate_struct.exp
+++ b/language/move-lang/tests/move_check/expansion/duplicate_struct.exp
@@ -1,11 +1,10 @@
 error: 
 
-   ┌── tests/move_check/expansion/duplicate_struct.move:3:12 ───
+   ┌── tests/move_check/expansion/duplicate_struct.move:2:12 ───
    │
- 3 │     struct S {}
-   │            ^ Duplicate definition for struct 'S' in module 'M'
-   ·
  2 │     struct S {}
    │            - Previously defined here
+ 3 │     struct S {}
+   │            ^ Duplicate definition for struct 'S' in module 'M'
    │
 

--- a/language/move-lang/tests/move_check/expansion/global_access_pack.exp
+++ b/language/move-lang/tests/move_check/expansion/global_access_pack.exp
@@ -3,9 +3,7 @@ error:
    ┌── tests/move_check/expansion/global_access_pack.move:3:13 ───
    │
  3 │         ::S { }
-   │             ^ Unexpected '{'
-   ·
- 3 │         ::S { }
    │             - Expected '('
+   │             ^ Unexpected '{'
    │
 

--- a/language/move-lang/tests/move_check/expansion/invalid_unpack_assign_lhs_not_name.exp
+++ b/language/move-lang/tests/move_check/expansion/invalid_unpack_assign_lhs_not_name.exp
@@ -3,9 +3,7 @@ error:
    ┌── tests/move_check/expansion/invalid_unpack_assign_lhs_not_name.move:4:11 ───
    │
  4 │         0 { f } = 0;
-   │           ^ Unexpected '{'
-   ·
- 4 │         0 { f } = 0;
    │           - Expected ';'
+   │           ^ Unexpected '{'
    │
 

--- a/language/move-lang/tests/move_check/expansion/invalid_unpack_assign_lhs_other_value.exp
+++ b/language/move-lang/tests/move_check/expansion/invalid_unpack_assign_lhs_other_value.exp
@@ -3,9 +3,7 @@ error:
    ┌── tests/move_check/expansion/invalid_unpack_assign_lhs_other_value.move:3:11 ───
    │
  3 │         0 {} = 0;
-   │           ^ Unexpected '{'
-   ·
- 3 │         0 {} = 0;
    │           - Expected ';'
+   │           ^ Unexpected '{'
    │
 

--- a/language/move-lang/tests/move_check/expansion/mdot_with_non_address_exp.exp
+++ b/language/move-lang/tests/move_check/expansion/mdot_with_non_address_exp.exp
@@ -3,9 +3,7 @@ error:
    ┌── tests/move_check/expansion/mdot_with_non_address_exp.move:9:11 ───
    │
  9 │         01::X::bar()
-   │           ^^ Unexpected '::'
-   ·
- 9 │         01::X::bar()
    │           -- Expected ';'
+   │           ^^ Unexpected '::'
    │
 

--- a/language/move-lang/tests/move_check/expansion/module_alias_as_type.exp
+++ b/language/move-lang/tests/move_check/expansion/module_alias_as_type.exp
@@ -3,9 +3,7 @@ error:
    ┌── tests/move_check/expansion/module_alias_as_type.move:7:16 ───
    │
  7 │     fun foo(x: X) {}
-   │                ^ Unexpected module alias 'X'
-   ·
- 7 │     fun foo(x: X) {}
    │                - Modules are not types. Try accessing a struct inside the module instead
+   │                ^ Unexpected module alias 'X'
    │
 

--- a/language/move-lang/tests/move_check/expansion/pack_no_fields_block_expr.exp
+++ b/language/move-lang/tests/move_check/expansion/pack_no_fields_block_expr.exp
@@ -3,9 +3,7 @@ error:
    ┌── tests/move_check/expansion/pack_no_fields_block_expr.move:4:21 ───
    │
  4 │         let s = S { let x = 0; x };
-   │                     ^^^ Unexpected 'let'
-   ·
- 4 │         let s = S { let x = 0; x };
    │                     --- Expected a name value
+   │                     ^^^ Unexpected 'let'
    │
 

--- a/language/move-lang/tests/move_check/expansion/pack_no_fields_single_block_expr.exp
+++ b/language/move-lang/tests/move_check/expansion/pack_no_fields_single_block_expr.exp
@@ -3,9 +3,7 @@ error:
    ┌── tests/move_check/expansion/pack_no_fields_single_block_expr.move:4:21 ───
    │
  4 │         let s = S { false };
-   │                     ^^^^^ Unexpected 'false'
-   ·
- 4 │         let s = S { false };
    │                     ----- Expected a name value
+   │                     ^^^^^ Unexpected 'false'
    │
 

--- a/language/move-lang/tests/move_check/expansion/pack_no_fields_single_block_other_expr.exp
+++ b/language/move-lang/tests/move_check/expansion/pack_no_fields_single_block_other_expr.exp
@@ -3,9 +3,7 @@ error:
    ┌── tests/move_check/expansion/pack_no_fields_single_block_other_expr.move:6:19 ───
    │
  6 │         let s = S 0;
-   │                   ^ Unexpected '0'
-   ·
- 6 │         let s = S 0;
    │                   - Expected ';'
+   │                   ^ Unexpected '0'
    │
 

--- a/language/move-lang/tests/move_check/expansion/standalone_fields.exp
+++ b/language/move-lang/tests/move_check/expansion/standalone_fields.exp
@@ -3,9 +3,7 @@ error:
    ┌── tests/move_check/expansion/standalone_fields.move:3:11 ───
    │
  3 │         {f: 1, g: 0};
-   │           ^ Unexpected ':'
-   ·
- 3 │         {f: 1, g: 0};
    │           - Expected ';'
+   │           ^ Unexpected ':'
    │
 

--- a/language/move-lang/tests/move_check/expansion/type_arguments_on_field_access.exp
+++ b/language/move-lang/tests/move_check/expansion/type_arguments_on_field_access.exp
@@ -3,9 +3,7 @@ error:
    ┌── tests/move_check/expansion/type_arguments_on_field_access.move:6:17 ───
    │
  6 │         x.f<u64>;
-   │                 ^ Unexpected ';'
-   ·
- 6 │         x.f<u64>;
    │                 - Expected an expression term
+   │                 ^ Unexpected ';'
    │
 

--- a/language/move-lang/tests/move_check/expansion/unpack_assign_block_expr.exp
+++ b/language/move-lang/tests/move_check/expansion/unpack_assign_block_expr.exp
@@ -3,9 +3,7 @@ error:
    ┌── tests/move_check/expansion/unpack_assign_block_expr.move:4:13 ───
    │
  4 │         S { let f = 0; } = S { f: 0 };
-   │             ^^^ Unexpected 'let'
-   ·
- 4 │         S { let f = 0; } = S { f: 0 };
    │             --- Expected a name value
+   │             ^^^ Unexpected 'let'
    │
 

--- a/language/move-lang/tests/move_check/expansion/unpack_assign_block_single_expr.exp
+++ b/language/move-lang/tests/move_check/expansion/unpack_assign_block_single_expr.exp
@@ -3,9 +3,7 @@ error:
    ┌── tests/move_check/expansion/unpack_assign_block_single_expr.move:4:13 ───
    │
  4 │         S { 0 } = S { f: 0 };
-   │             ^ Unexpected '0'
-   ·
- 4 │         S { 0 } = S { f: 0 };
    │             - Expected a name value
+   │             ^ Unexpected '0'
    │
 

--- a/language/move-lang/tests/move_check/expansion/unpack_assign_other_expr.exp
+++ b/language/move-lang/tests/move_check/expansion/unpack_assign_other_expr.exp
@@ -3,9 +3,7 @@ error:
    ┌── tests/move_check/expansion/unpack_assign_other_expr.move:9:11 ───
    │
  9 │         S f = S { f: 0 };
-   │           ^ Unexpected 'f'
-   ·
- 9 │         S f = S { f: 0 };
    │           - Expected ';'
+   │           ^ Unexpected 'f'
    │
 

--- a/language/move-lang/tests/move_check/expansion/weird_apply_assign.exp
+++ b/language/move-lang/tests/move_check/expansion/weird_apply_assign.exp
@@ -3,9 +3,7 @@ error:
    ┌── tests/move_check/expansion/weird_apply_assign.move:7:11 ───
    │
  7 │         S f = S { f: 0 };
-   │           ^ Unexpected 'f'
-   ·
- 7 │         S f = S { f: 0 };
    │           - Expected ';'
+   │           ^ Unexpected 'f'
    │
 

--- a/language/move-lang/tests/move_check/liveness/copy_after_move.exp
+++ b/language/move-lang/tests/move_check/liveness/copy_after_move.exp
@@ -1,11 +1,10 @@
 error: 
 
-   ┌── tests/move_check/liveness/copy_after_move.move:5:9 ───
+   ┌── tests/move_check/liveness/copy_after_move.move:4:9 ───
    │
- 5 │         copy x;
-   │         ^^^^^^ Invalid usage of local 'x'
-   ·
  4 │         move x;
    │         ------ The local does not have a value due to this position. The local must be assigned a value before being used
+ 5 │         copy x;
+   │         ^^^^^^ Invalid usage of local 'x'
    │
 

--- a/language/move-lang/tests/move_check/liveness/dead_refs_branch_both_invalid.exp
+++ b/language/move-lang/tests/move_check/liveness/dead_refs_branch_both_invalid.exp
@@ -1,44 +1,44 @@
 error: 
 
-    ┌── tests/move_check/liveness/dead_refs_branch_both_invalid.move:10:13 ───
+    ┌── tests/move_check/liveness/dead_refs_branch_both_invalid.move:4:21 ───
     │
+  4 │         let x_ref = &mut x;
+    │                     ------ It is still being mutably borrowed by this reference
+    ·
  10 │         _ = x;
     │             ^ Invalid copy of local 'x'
-    ·
-  4 │         let x_ref = &mut x;
-    │                     ------ It is still being mutably borrowed by this reference
     │
 
 error: 
 
-    ┌── tests/move_check/liveness/dead_refs_branch_both_invalid.move:11:13 ───
+    ┌── tests/move_check/liveness/dead_refs_branch_both_invalid.move:4:21 ───
     │
+  4 │         let x_ref = &mut x;
+    │                     ------ It is still being mutably borrowed by this reference
+    ·
  11 │         _ = move x;
     │             ^^^^^^ Invalid move of local 'x'
-    ·
-  4 │         let x_ref = &mut x;
-    │                     ------ It is still being mutably borrowed by this reference
     │
 
 error: 
 
-    ┌── tests/move_check/liveness/dead_refs_branch_both_invalid.move:23:13 ───
+    ┌── tests/move_check/liveness/dead_refs_branch_both_invalid.move:17:21 ───
     │
+ 17 │         let x_ref = &mut x;
+    │                     ------ It is still being mutably borrowed by this reference
+    ·
  23 │         _ = x;
     │             ^ Invalid copy of local 'x'
-    ·
- 17 │         let x_ref = &mut x;
-    │                     ------ It is still being mutably borrowed by this reference
     │
 
 error: 
 
-    ┌── tests/move_check/liveness/dead_refs_branch_both_invalid.move:24:13 ───
+    ┌── tests/move_check/liveness/dead_refs_branch_both_invalid.move:17:21 ───
     │
- 24 │         _ = move x;
-    │             ^^^^^^ Invalid move of local 'x'
-    ·
  17 │         let x_ref = &mut x;
     │                     ------ It is still being mutably borrowed by this reference
+    ·
+ 24 │         _ = move x;
+    │             ^^^^^^ Invalid move of local 'x'
     │
 

--- a/language/move-lang/tests/move_check/liveness/dead_refs_branch_invalid.exp
+++ b/language/move-lang/tests/move_check/liveness/dead_refs_branch_invalid.exp
@@ -1,44 +1,44 @@
 error: 
 
-   ┌── tests/move_check/liveness/dead_refs_branch_invalid.move:8:13 ───
+   ┌── tests/move_check/liveness/dead_refs_branch_invalid.move:4:21 ───
    │
+ 4 │         let x_ref = &mut x;
+   │                     ------ It is still being mutably borrowed by this reference
+   ·
  8 │         _ = x;
    │             ^ Invalid copy of local 'x'
-   ·
- 4 │         let x_ref = &mut x;
-   │                     ------ It is still being mutably borrowed by this reference
    │
 
 error: 
 
-   ┌── tests/move_check/liveness/dead_refs_branch_invalid.move:9:13 ───
+   ┌── tests/move_check/liveness/dead_refs_branch_invalid.move:4:21 ───
    │
+ 4 │         let x_ref = &mut x;
+   │                     ------ It is still being mutably borrowed by this reference
+   ·
  9 │         _ = move x;
    │             ^^^^^^ Invalid move of local 'x'
-   ·
- 4 │         let x_ref = &mut x;
-   │                     ------ It is still being mutably borrowed by this reference
    │
 
 error: 
 
-    ┌── tests/move_check/liveness/dead_refs_branch_invalid.move:20:13 ───
+    ┌── tests/move_check/liveness/dead_refs_branch_invalid.move:15:21 ───
     │
- 20 │         _ = x;
-    │             ^ Invalid copy of local 'x'
-    ·
  15 │         let x_ref = &mut x;
     │                     ------ It is still being mutably borrowed by this reference
+    ·
+ 20 │         _ = x;
+    │             ^ Invalid copy of local 'x'
     │
 
 error: 
 
-    ┌── tests/move_check/liveness/dead_refs_branch_invalid.move:21:13 ───
+    ┌── tests/move_check/liveness/dead_refs_branch_invalid.move:15:21 ───
     │
- 21 │         _ = move x;
-    │             ^^^^^^ Invalid move of local 'x'
-    ·
  15 │         let x_ref = &mut x;
     │                     ------ It is still being mutably borrowed by this reference
+    ·
+ 21 │         _ = move x;
+    │             ^^^^^^ Invalid move of local 'x'
     │
 

--- a/language/move-lang/tests/move_check/liveness/dead_refs_loop_invalid.exp
+++ b/language/move-lang/tests/move_check/liveness/dead_refs_loop_invalid.exp
@@ -1,33 +1,33 @@
 error: 
 
-   ┌── tests/move_check/liveness/dead_refs_loop_invalid.move:6:17 ───
+   ┌── tests/move_check/liveness/dead_refs_loop_invalid.move:4:21 ───
    │
- 6 │             _ = x;
-   │                 ^ Invalid copy of local 'x'
-   ·
  4 │         let x_ref = &mut x;
    │                     ------ It is still being mutably borrowed by this reference
+ 5 │         while (cond) {
+ 6 │             _ = x;
+   │                 ^ Invalid copy of local 'x'
    │
 
 error: 
 
-    ┌── tests/move_check/liveness/dead_refs_loop_invalid.move:16:16 ───
+    ┌── tests/move_check/liveness/dead_refs_loop_invalid.move:13:21 ───
     │
- 16 │            _ = x;
-    │                ^ Invalid copy of local 'x'
-    ·
  13 │         let x_ref = &mut x;
     │                     ------ It is still being mutably borrowed by this reference
+    ·
+ 16 │            _ = x;
+    │                ^ Invalid copy of local 'x'
     │
 
 error: 
 
-    ┌── tests/move_check/liveness/dead_refs_loop_invalid.move:25:17 ───
+    ┌── tests/move_check/liveness/dead_refs_loop_invalid.move:22:21 ───
     │
- 25 │             _ = x;
-    │                 ^ Invalid copy of local 'x'
-    ·
  22 │         let x_ref = &mut x;
     │                     ------ It is still being mutably borrowed by this reference
+    ·
+ 25 │             _ = x;
+    │                 ^ Invalid copy of local 'x'
     │
 

--- a/language/move-lang/tests/move_check/liveness/dead_refs_nested_invalid.exp
+++ b/language/move-lang/tests/move_check/liveness/dead_refs_nested_invalid.exp
@@ -1,33 +1,33 @@
 error: 
 
-   ┌── tests/move_check/liveness/dead_refs_nested_invalid.move:9:17 ───
+   ┌── tests/move_check/liveness/dead_refs_nested_invalid.move:4:21 ───
    │
- 9 │             _ = x;
-   │                 ^ Invalid copy of local 'x'
-   ·
  4 │         let x_ref = &mut x;
    │                     ------ It is still being mutably borrowed by this reference
+   ·
+ 9 │             _ = x;
+   │                 ^ Invalid copy of local 'x'
    │
 
 error: 
 
-    ┌── tests/move_check/liveness/dead_refs_nested_invalid.move:19:20 ───
+    ┌── tests/move_check/liveness/dead_refs_nested_invalid.move:15:21 ───
     │
- 19 │                _ = x;
-    │                    ^ Invalid copy of local 'x'
-    ·
  15 │         let x_ref = &mut x;
     │                     ------ It is still being mutably borrowed by this reference
+    ·
+ 19 │                _ = x;
+    │                    ^ Invalid copy of local 'x'
     │
 
 error: 
 
-    ┌── tests/move_check/liveness/dead_refs_nested_invalid.move:29:71 ───
+    ┌── tests/move_check/liveness/dead_refs_nested_invalid.move:27:21 ───
     │
- 29 │             if (cond) { _ = x_ref; break } else { while (!cond) { _ = x } }
-    │                                                                       ^ Invalid copy of local 'x'
-    ·
  27 │         let x_ref = &mut x;
     │                     ------ It is still being mutably borrowed by this reference
+ 28 │         loop {
+ 29 │             if (cond) { _ = x_ref; break } else { while (!cond) { _ = x } }
+    │                                                                       ^ Invalid copy of local 'x'
     │
 

--- a/language/move-lang/tests/move_check/liveness/dead_refs_simple_invalid.exp
+++ b/language/move-lang/tests/move_check/liveness/dead_refs_simple_invalid.exp
@@ -1,44 +1,42 @@
 error: 
 
-   ┌── tests/move_check/liveness/dead_refs_simple_invalid.move:5:13 ───
+   ┌── tests/move_check/liveness/dead_refs_simple_invalid.move:4:21 ───
    │
+ 4 │         let x_ref = &mut x;
+   │                     ------ It is still being mutably borrowed by this reference
  5 │         _ = x;
    │             ^ Invalid copy of local 'x'
-   ·
- 4 │         let x_ref = &mut x;
-   │                     ------ It is still being mutably borrowed by this reference
    │
 
 error: 
 
-   ┌── tests/move_check/liveness/dead_refs_simple_invalid.move:6:13 ───
+   ┌── tests/move_check/liveness/dead_refs_simple_invalid.move:4:21 ───
    │
+ 4 │         let x_ref = &mut x;
+   │                     ------ It is still being mutably borrowed by this reference
+ 5 │         _ = x;
  6 │         _ = move x;
    │             ^^^^^^ Invalid move of local 'x'
-   ·
- 4 │         let x_ref = &mut x;
-   │                     ------ It is still being mutably borrowed by this reference
    │
 
 error: 
 
-    ┌── tests/move_check/liveness/dead_refs_simple_invalid.move:13:13 ───
+    ┌── tests/move_check/liveness/dead_refs_simple_invalid.move:12:21 ───
     │
- 13 │         _ = x;
-    │             ^ Invalid copy of local 'x'
-    ·
  12 │         let x_ref = &mut x;
     │                     ------ It is still being mutably borrowed by this reference
+ 13 │         _ = x;
+    │             ^ Invalid copy of local 'x'
     │
 
 error: 
 
-    ┌── tests/move_check/liveness/dead_refs_simple_invalid.move:14:13 ───
+    ┌── tests/move_check/liveness/dead_refs_simple_invalid.move:12:21 ───
     │
- 14 │         _ = move x;
-    │             ^^^^^^ Invalid move of local 'x'
-    ·
  12 │         let x_ref = &mut x;
     │                     ------ It is still being mutably borrowed by this reference
+ 13 │         _ = x;
+ 14 │         _ = move x;
+    │             ^^^^^^ Invalid move of local 'x'
     │
 

--- a/language/move-lang/tests/move_check/locals/assign_partial_resource.exp
+++ b/language/move-lang/tests/move_check/locals/assign_partial_resource.exp
@@ -8,13 +8,12 @@ error:
 
 error: 
 
-   ┌── tests/move_check/locals/assign_partial_resource.move:7:9 ───
+   ┌── tests/move_check/locals/assign_partial_resource.move:6:21 ───
    │
- 7 │         r = R{};
-   │         ^ Invalid assignment to local 'r'
-   ·
  6 │         if (cond) { r = R{}; };
    │                     - The local might contain a resource value due to this assignment. The resource must be used before you assign to this local again
+ 7 │         r = R{};
+   │         ^ Invalid assignment to local 'r'
    │
 
 error: 
@@ -27,13 +26,12 @@ error:
 
 error: 
 
-    ┌── tests/move_check/locals/assign_partial_resource.move:14:9 ───
+    ┌── tests/move_check/locals/assign_partial_resource.move:13:29 ───
     │
- 14 │         r = R{};
-    │         ^ Invalid assignment to local 'r'
-    ·
  13 │         if (cond) {} else { r = R{}; };
     │                             - The local might contain a resource value due to this assignment. The resource must be used before you assign to this local again
+ 14 │         r = R{};
+    │         ^ Invalid assignment to local 'r'
     │
 
 error: 
@@ -49,21 +47,18 @@ error:
     ┌── tests/move_check/locals/assign_partial_resource.move:20:24 ───
     │
  20 │         while (cond) { r = R{} };
-    │                        ^ Invalid assignment to local 'r'
-    ·
- 20 │         while (cond) { r = R{} };
     │                        - The local might contain a resource value due to this assignment. The resource must be used before you assign to this local again
+    │                        ^ Invalid assignment to local 'r'
     │
 
 error: 
 
-    ┌── tests/move_check/locals/assign_partial_resource.move:21:9 ───
+    ┌── tests/move_check/locals/assign_partial_resource.move:20:24 ───
     │
- 21 │         r = R{};
-    │         ^ Invalid assignment to local 'r'
-    ·
  20 │         while (cond) { r = R{} };
     │                        - The local might contain a resource value due to this assignment. The resource must be used before you assign to this local again
+ 21 │         r = R{};
+    │         ^ Invalid assignment to local 'r'
     │
 
 error: 
@@ -79,31 +74,27 @@ error:
     ┌── tests/move_check/locals/assign_partial_resource.move:27:16 ───
     │
  27 │         loop { r = R{} }
-    │                ^ Invalid assignment to local 'r'
-    ·
- 27 │         loop { r = R{} }
     │                - The local might contain a resource value due to this assignment. The resource must be used before you assign to this local again
+    │                ^ Invalid assignment to local 'r'
     │
 
 error: 
 
-    ┌── tests/move_check/locals/assign_partial_resource.move:31:21 ───
+    ┌── tests/move_check/locals/assign_partial_resource.move:30:27 ───
     │
- 31 │         if (cond) { x = y };
-    │                     ^ Invalid assignment to local 'x'
-    ·
  30 │     fun t5<T>(cond: bool, x: T, y: T): (T, T) {
     │                           - The local might contain a resource value due to this assignment. The resource must be used before you assign to this local again
+ 31 │         if (cond) { x = y };
+    │                     ^ Invalid assignment to local 'x'
     │
 
 error: 
 
-    ┌── tests/move_check/locals/assign_partial_resource.move:32:13 ───
+    ┌── tests/move_check/locals/assign_partial_resource.move:31:25 ───
     │
- 32 │         (x, y)
-    │             ^ Invalid usage of local 'y'
-    ·
  31 │         if (cond) { x = y };
     │                         - The local might not have a value due to this position. The local must be assigned a value before being used
+ 32 │         (x, y)
+    │             ^ Invalid usage of local 'y'
     │
 

--- a/language/move-lang/tests/move_check/locals/assign_resource.exp
+++ b/language/move-lang/tests/move_check/locals/assign_resource.exp
@@ -8,46 +8,42 @@ error:
 
 error: 
 
-   ┌── tests/move_check/locals/assign_resource.move:6:9 ───
+   ┌── tests/move_check/locals/assign_resource.move:5:13 ───
    │
- 6 │         r = R{};
-   │         ^ Invalid assignment to local 'r'
-   ·
  5 │         let r = R{};
    │             - The local contains a resource value due to this assignment. The resource must be used before you assign to this local again
+ 6 │         r = R{};
+   │         ^ Invalid assignment to local 'r'
    │
 
 error: 
 
-    ┌── tests/move_check/locals/assign_resource.move:12:21 ───
+    ┌── tests/move_check/locals/assign_resource.move:11:13 ───
     │
- 12 │         if (cond) { r = R{}; };
-    │                     ^ Invalid assignment to local 'r'
-    ·
  11 │         let r = R{};
     │             - The local contains a resource value due to this assignment. The resource must be used before you assign to this local again
+ 12 │         if (cond) { r = R{}; };
+    │                     ^ Invalid assignment to local 'r'
     │
 
 error: 
 
-    ┌── tests/move_check/locals/assign_resource.move:18:29 ───
+    ┌── tests/move_check/locals/assign_resource.move:17:13 ───
     │
- 18 │         if (cond) {} else { r = R{}; };
-    │                             ^ Invalid assignment to local 'r'
-    ·
  17 │         let r = R{};
     │             - The local contains a resource value due to this assignment. The resource must be used before you assign to this local again
+ 18 │         if (cond) {} else { r = R{}; };
+    │                             ^ Invalid assignment to local 'r'
     │
 
 error: 
 
-    ┌── tests/move_check/locals/assign_resource.move:24:24 ───
+    ┌── tests/move_check/locals/assign_resource.move:23:13 ───
     │
- 24 │         while (cond) { r = R{} };
-    │                        ^ Invalid assignment to local 'r'
-    ·
  23 │         let r = R{};
     │             - The local contains a resource value due to this assignment. The resource must be used before you assign to this local again
+ 24 │         while (cond) { r = R{} };
+    │                        ^ Invalid assignment to local 'r'
     │
 
 error: 
@@ -60,23 +56,21 @@ error:
 
 error: 
 
-    ┌── tests/move_check/locals/assign_resource.move:30:16 ───
+    ┌── tests/move_check/locals/assign_resource.move:29:13 ───
     │
- 30 │         loop { r = R{}; R {} = r }
-    │                ^ Invalid assignment to local 'r'
-    ·
  29 │         let r = R{};
     │             - The local might contain a resource value due to this assignment. The resource must be used before you assign to this local again
+ 30 │         loop { r = R{}; R {} = r }
+    │                ^ Invalid assignment to local 'r'
     │
 
 error: 
 
-    ┌── tests/move_check/locals/assign_resource.move:34:9 ───
+    ┌── tests/move_check/locals/assign_resource.move:33:15 ───
     │
- 34 │         x = y;
-    │         ^ Invalid assignment to local 'x'
-    ·
  33 │     fun t5<T>(x: T, y: T): T {
     │               - The local might contain a resource value due to this assignment. The resource must be used before you assign to this local again
+ 34 │         x = y;
+    │         ^ Invalid assignment to local 'x'
     │
 

--- a/language/move-lang/tests/move_check/locals/eliminate_temps.exp
+++ b/language/move-lang/tests/move_check/locals/eliminate_temps.exp
@@ -1,44 +1,36 @@
 error: 
 
-   ┌── tests/move_check/locals/eliminate_temps.move:7:47 ───
+   ┌── tests/move_check/locals/eliminate_temps.move:7:39 ───
    │
- 7 │         let (boom, u): (&u64, u64) = (&mut x, x);
-   │                                               ^ Invalid copy of local 'x'
-   ·
  7 │         let (boom, u): (&u64, u64) = (&mut x, x);
    │                                       ------ It is still being mutably borrowed by this reference
+   │                                               ^ Invalid copy of local 'x'
    │
 
 error: 
 
-    ┌── tests/move_check/locals/eliminate_temps.move:14:39 ───
+    ┌── tests/move_check/locals/eliminate_temps.move:14:36 ───
     │
- 14 │         let (f, u): (&u64, u64) = (r, *r);
-    │                                       ^^ Invalid dereference.
-    ·
  14 │         let (f, u): (&u64, u64) = (r, *r);
     │                                    - It is still being mutably borrowed by this reference
+    │                                       ^^ Invalid dereference.
     │
 
 error: 
 
-    ┌── tests/move_check/locals/eliminate_temps.move:20:46 ───
+    ┌── tests/move_check/locals/eliminate_temps.move:20:36 ───
     │
- 20 │         let (f, u): (&u64, u64) = (&mut s.f, s.f);
-    │                                              ^^^ Invalid immutable borrow at field 'f'.
-    ·
  20 │         let (f, u): (&u64, u64) = (&mut s.f, s.f);
     │                                    -------- Field 'f' is still being mutably borrowed by this reference
+    │                                              ^^^ Invalid immutable borrow at field 'f'.
     │
 
 error: 
 
-    ┌── tests/move_check/locals/eliminate_temps.move:27:58 ───
+    ┌── tests/move_check/locals/eliminate_temps.move:27:33 ───
     │
  27 │         let (f, u): (&R, &R) = (borrow_global_mut<R>(a), borrow_global<R>(a));
-    │                                                          ^^^^^^^^^^^^^^^^^^^ Invalid borrowing of resource 'R'
-    ·
- 27 │         let (f, u): (&R, &R) = (borrow_global_mut<R>(a), borrow_global<R>(a));
     │                                 ----------------------- It is still being mutably borrowed by this reference
+    │                                                          ^^^^^^^^^^^^^^^^^^^ Invalid borrowing of resource 'R'
     │
 

--- a/language/move-lang/tests/move_check/locals/reassign_parameter.exp
+++ b/language/move-lang/tests/move_check/locals/reassign_parameter.exp
@@ -1,13 +1,12 @@
 error: 
 
-   ┌── tests/move_check/locals/reassign_parameter.move:7:9 ───
-   │
+   ┌── tests/move_check/locals/reassign_parameter.move:6:9 ───
+   │  
+ 6 │           r = R {};
+   │           - The parameter 'r' might still contain a resource value. The resource must be consumed before the function returns
  7 │ ╭         if  (true) {
  8 │ │             let R { } = r
  9 │ │         }
    │ ╰─────────^ Invalid return
-   ·
- 6 │         r = R {};
-   │         - The parameter 'r' might still contain a resource value. The resource must be consumed before the function returns
-   │
+   │  
 

--- a/language/move-lang/tests/move_check/locals/unused_resource.exp
+++ b/language/move-lang/tests/move_check/locals/unused_resource.exp
@@ -8,13 +8,11 @@ error:
 
 error: 
 
-   ┌── tests/move_check/locals/unused_resource.move:5:20 ───
+   ┌── tests/move_check/locals/unused_resource.move:5:13 ───
    │
  5 │         let r = R{};
-   │                    ^ Invalid return
-   ·
- 5 │         let r = R{};
    │             - The local 'r' still contains a resource value due to this assignment. The resource must be consumed before the function returns
+   │                    ^ Invalid return
    │
 
 error: 
@@ -27,13 +25,11 @@ error:
 
 error: 
 
-    ┌── tests/move_check/locals/unused_resource.move:10:31 ───
+    ┌── tests/move_check/locals/unused_resource.move:10:21 ───
     │
  10 │         if (cond) { r = R{}; };
-    │                               ^ Invalid return
-    ·
- 10 │         if (cond) { r = R{}; };
     │                     - The local 'r' might still contain a resource value due to this assignment. The resource must be consumed before the function returns
+    │                               ^ Invalid return
     │
 
 error: 
@@ -46,13 +42,11 @@ error:
 
 error: 
 
-    ┌── tests/move_check/locals/unused_resource.move:15:39 ───
+    ┌── tests/move_check/locals/unused_resource.move:15:29 ───
     │
  15 │         if (cond) {} else { r = R{}; };
-    │                                       ^ Invalid return
-    ·
- 15 │         if (cond) {} else { r = R{}; };
     │                             - The local 'r' might still contain a resource value due to this assignment. The resource must be consumed before the function returns
+    │                                       ^ Invalid return
     │
 
 error: 
@@ -68,21 +62,17 @@ error:
     ┌── tests/move_check/locals/unused_resource.move:20:24 ───
     │
  20 │         while (cond) { r = R{} };
-    │                        ^ Invalid assignment to local 'r'
-    ·
- 20 │         while (cond) { r = R{} };
     │                        - The local might contain a resource value due to this assignment. The resource must be used before you assign to this local again
+    │                        ^ Invalid assignment to local 'r'
     │
 
 error: 
 
-    ┌── tests/move_check/locals/unused_resource.move:20:33 ───
+    ┌── tests/move_check/locals/unused_resource.move:20:24 ───
     │
  20 │         while (cond) { r = R{} };
-    │                                 ^ Invalid return
-    ·
- 20 │         while (cond) { r = R{} };
     │                        - The local 'r' might still contain a resource value due to this assignment. The resource must be consumed before the function returns
+    │                                 ^ Invalid return
     │
 
 error: 
@@ -98,33 +88,27 @@ error:
     ┌── tests/move_check/locals/unused_resource.move:24:20 ───
     │
  24 │         loop { let r = R{}; }
-    │                    ^ Invalid assignment to local 'r'
-    ·
- 24 │         loop { let r = R{}; }
     │                    - The local might contain a resource value due to this assignment. The resource must be used before you assign to this local again
+    │                    ^ Invalid assignment to local 'r'
     │
 
 error: 
 
-    ┌── tests/move_check/locals/unused_resource.move:28:21 ───
+    ┌── tests/move_check/locals/unused_resource.move:28:18 ───
     │
- 28 │         let _ = &R{};
-    │                     ^ Invalid return
-    ·
  28 │         let _ = &R{};
     │                  --- The resource is created but not used. The resource must be consumed before the function returns
+    │                     ^ Invalid return
     │
 
 error: 
 
-    ┌── tests/move_check/locals/unused_resource.move:31:22 ───
-    │
+    ┌── tests/move_check/locals/unused_resource.move:31:15 ───
+    │  
  31 │       fun t6<T>(_x: R) {
+    │                 -- The parameter '_x' still contains a resource value. The resource must be consumed before the function returns
     │ ╭──────────────────────^
  32 │ │     }
     │ ╰─────^ Invalid return
-    ·
- 31 │     fun t6<T>(_x: R) {
-    │               -- The parameter '_x' still contains a resource value. The resource must be consumed before the function returns
-    │
+    │  
 

--- a/language/move-lang/tests/move_check/locals/unused_resource_explicit_return.exp
+++ b/language/move-lang/tests/move_check/locals/unused_resource_explicit_return.exp
@@ -8,46 +8,42 @@ error:
 
 error: 
 
-   ┌── tests/move_check/locals/unused_resource_explicit_return.move:6:9 ───
+   ┌── tests/move_check/locals/unused_resource_explicit_return.move:5:13 ───
    │
- 6 │         return ()
-   │         ^^^^^^^^^ Invalid return
-   ·
  5 │         let r = R{};
    │             - The local 'r' still contains a resource value due to this assignment. The resource must be consumed before the function returns
+ 6 │         return ()
+   │         ^^^^^^^^^ Invalid return
    │
 
 error: 
 
-    ┌── tests/move_check/locals/unused_resource_explicit_return.move:11:21 ───
+    ┌── tests/move_check/locals/unused_resource_explicit_return.move:10:13 ───
     │
- 11 │         if (cond) { return () };
-    │                     ^^^^^^^^^ Invalid return
-    ·
  10 │         let r = R {};
     │             - The local 'r' still contains a resource value due to this assignment. The resource must be consumed before the function returns
+ 11 │         if (cond) { return () };
+    │                     ^^^^^^^^^ Invalid return
     │
 
 error: 
 
-    ┌── tests/move_check/locals/unused_resource_explicit_return.move:17:29 ───
+    ┌── tests/move_check/locals/unused_resource_explicit_return.move:16:13 ───
     │
- 17 │         if (cond) {} else { return () };
-    │                             ^^^^^^^^^ Invalid return
-    ·
  16 │         let r = R{};
     │             - The local 'r' still contains a resource value due to this assignment. The resource must be consumed before the function returns
+ 17 │         if (cond) {} else { return () };
+    │                             ^^^^^^^^^ Invalid return
     │
 
 error: 
 
-    ┌── tests/move_check/locals/unused_resource_explicit_return.move:23:24 ───
+    ┌── tests/move_check/locals/unused_resource_explicit_return.move:22:13 ───
     │
- 23 │         while (cond) { return () };
-    │                        ^^^^^^^^^ Invalid return
-    ·
  22 │         let r = R {};
     │             - The local 'r' still contains a resource value due to this assignment. The resource must be consumed before the function returns
+ 23 │         while (cond) { return () };
+    │                        ^^^^^^^^^ Invalid return
     │
 
 error: 
@@ -60,13 +56,12 @@ error:
 
 error: 
 
-    ┌── tests/move_check/locals/unused_resource_explicit_return.move:29:16 ───
+    ┌── tests/move_check/locals/unused_resource_explicit_return.move:28:13 ───
     │
- 29 │         loop { return () }
-    │                ^^^^^^^^^ Invalid return
-    ·
  28 │         let r = R{};
     │             - The local 'r' still contains a resource value due to this assignment. The resource must be consumed before the function returns
+ 29 │         loop { return () }
+    │                ^^^^^^^^^ Invalid return
     │
 
 error: 
@@ -79,23 +74,21 @@ error:
 
 error: 
 
-    ┌── tests/move_check/locals/unused_resource_explicit_return.move:34:9 ───
+    ┌── tests/move_check/locals/unused_resource_explicit_return.move:33:18 ───
     │
- 34 │         return ()
-    │         ^^^^^^^^^ Invalid return
-    ·
  33 │         let x = &R{};
     │                  --- The resource is created but not used. The resource must be consumed before the function returns
+ 34 │         return ()
+    │         ^^^^^^^^^ Invalid return
     │
 
 error: 
 
-    ┌── tests/move_check/locals/unused_resource_explicit_return.move:38:9 ───
+    ┌── tests/move_check/locals/unused_resource_explicit_return.move:37:15 ───
     │
- 38 │         return ()
-    │         ^^^^^^^^^ Invalid return
-    ·
  37 │     fun t6<T>(_x: R) {
     │               -- The parameter '_x' still contains a resource value. The resource must be consumed before the function returns
+ 38 │         return ()
+    │         ^^^^^^^^^ Invalid return
     │
 

--- a/language/move-lang/tests/move_check/locals/use_after_move_if.exp
+++ b/language/move-lang/tests/move_check/locals/use_after_move_if.exp
@@ -1,33 +1,30 @@
 error: 
 
-   ┌── tests/move_check/locals/use_after_move_if.move:5:17 ───
+   ┌── tests/move_check/locals/use_after_move_if.move:4:25 ───
    │
- 5 │         let _ = move x + 1;
-   │                 ^^^^^^ Invalid usage of local 'x'
-   ·
  4 │         if (cond) { _ = move x };
    │                         ------ The local might not have a value due to this position. The local must be assigned a value before being used
+ 5 │         let _ = move x + 1;
+   │                 ^^^^^^ Invalid usage of local 'x'
    │
 
 error: 
 
-    ┌── tests/move_check/locals/use_after_move_if.move:11:17 ───
+    ┌── tests/move_check/locals/use_after_move_if.move:10:25 ───
     │
- 11 │         let _ = x + 1;
-    │                 ^ Invalid usage of local 'x'
-    ·
  10 │         if (cond) { _ = move x };
     │                         ------ The local might not have a value due to this position. The local must be assigned a value before being used
+ 11 │         let _ = x + 1;
+    │                 ^ Invalid usage of local 'x'
     │
 
 error: 
 
-    ┌── tests/move_check/locals/use_after_move_if.move:17:17 ───
+    ┌── tests/move_check/locals/use_after_move_if.move:16:25 ───
     │
- 17 │         let _ = &x;
-    │                 ^^ Invalid usage of local 'x'
-    ·
  16 │         if (cond) { _ = move x };
     │                         ------ The local might not have a value due to this position. The local must be assigned a value before being used
+ 17 │         let _ = &x;
+    │                 ^^ Invalid usage of local 'x'
     │
 

--- a/language/move-lang/tests/move_check/locals/use_after_move_if_else.exp
+++ b/language/move-lang/tests/move_check/locals/use_after_move_if_else.exp
@@ -1,66 +1,60 @@
 error: 
 
-   ┌── tests/move_check/locals/use_after_move_if_else.move:5:17 ───
+   ┌── tests/move_check/locals/use_after_move_if_else.move:4:45 ───
    │
- 5 │         let _ = move x + 1;
-   │                 ^^^^^^ Invalid usage of local 'x'
-   ·
  4 │         if (cond) { _ = move x } else { _ = move x };
    │                                             ------ The local does not have a value due to this position. The local must be assigned a value before being used
+ 5 │         let _ = move x + 1;
+   │                 ^^^^^^ Invalid usage of local 'x'
    │
 
 error: 
 
-    ┌── tests/move_check/locals/use_after_move_if_else.move:11:17 ───
+    ┌── tests/move_check/locals/use_after_move_if_else.move:10:25 ───
     │
- 11 │         let _ = move x + 1;
-    │                 ^^^^^^ Invalid usage of local 'x'
-    ·
  10 │         if (cond) { _ = move x } else { _ = x };
     │                         ------ The local might not have a value due to this position. The local must be assigned a value before being used
+ 11 │         let _ = move x + 1;
+    │                 ^^^^^^ Invalid usage of local 'x'
     │
 
 error: 
 
-    ┌── tests/move_check/locals/use_after_move_if_else.move:17:17 ───
+    ┌── tests/move_check/locals/use_after_move_if_else.move:16:45 ───
     │
- 17 │         let _ = x + 1;
-    │                 ^ Invalid usage of local 'x'
-    ·
  16 │         if (cond) { _ = move x } else { _ = move x };
     │                                             ------ The local does not have a value due to this position. The local must be assigned a value before being used
+ 17 │         let _ = x + 1;
+    │                 ^ Invalid usage of local 'x'
     │
 
 error: 
 
-    ┌── tests/move_check/locals/use_after_move_if_else.move:24:17 ───
+    ┌── tests/move_check/locals/use_after_move_if_else.move:23:25 ───
     │
- 24 │         let _ = x + 1;
-    │                 ^ Invalid usage of local 'x'
-    ·
  23 │         if (cond) { _ = move x } else { _ = x };
     │                         ------ The local might not have a value due to this position. The local must be assigned a value before being used
+ 24 │         let _ = x + 1;
+    │                 ^ Invalid usage of local 'x'
     │
 
 error: 
 
-    ┌── tests/move_check/locals/use_after_move_if_else.move:30:17 ───
+    ┌── tests/move_check/locals/use_after_move_if_else.move:29:45 ───
     │
- 30 │         let _ = &x;
-    │                 ^^ Invalid usage of local 'x'
-    ·
  29 │         if (cond) { _ = move x } else { _ = move x };
     │                                             ------ The local does not have a value due to this position. The local must be assigned a value before being used
+ 30 │         let _ = &x;
+    │                 ^^ Invalid usage of local 'x'
     │
 
 error: 
 
-    ┌── tests/move_check/locals/use_after_move_if_else.move:36:17 ───
+    ┌── tests/move_check/locals/use_after_move_if_else.move:35:25 ───
     │
- 36 │         let _ = &x;
-    │                 ^^ Invalid usage of local 'x'
-    ·
  35 │         if (cond) { _ = move x } else { _ = x };
     │                         ------ The local might not have a value due to this position. The local must be assigned a value before being used
+ 36 │         let _ = &x;
+    │                 ^^ Invalid usage of local 'x'
     │
 

--- a/language/move-lang/tests/move_check/locals/use_after_move_loop.exp
+++ b/language/move-lang/tests/move_check/locals/use_after_move_loop.exp
@@ -3,10 +3,8 @@ error:
    ┌── tests/move_check/locals/use_after_move_loop.move:4:20 ───
    │
  4 │         loop { _ = move x };
-   │                    ^^^^^^ Invalid usage of local 'x'
-   ·
- 4 │         loop { _ = move x };
    │                    ------ The local might not have a value due to this position. The local must be assigned a value before being used
+   │                    ^^^^^^ Invalid usage of local 'x'
    │
 
 error: 
@@ -22,10 +20,8 @@ error:
    ┌── tests/move_check/locals/use_after_move_loop.move:9:37 ───
    │
  9 │         loop { if (cond) break; _ = move x }
-   │                                     ^^^^^^ Invalid usage of local 'x'
-   ·
- 9 │         loop { if (cond) break; _ = move x }
    │                                     ------ The local might not have a value due to this position. The local must be assigned a value before being used
+   │                                     ^^^^^^ Invalid usage of local 'x'
    │
 
 error: 
@@ -34,8 +30,6 @@ error:
     │
  14 │         loop { let y = x; _ = move x; y; }
     │                        ^ Invalid usage of local 'x'
-    ·
- 14 │         loop { let y = x; _ = move x; y; }
     │                               ------ The local might not have a value due to this position. The local must be assigned a value before being used
     │
 
@@ -44,10 +38,8 @@ error:
     ┌── tests/move_check/locals/use_after_move_loop.move:14:31 ───
     │
  14 │         loop { let y = x; _ = move x; y; }
-    │                               ^^^^^^ Invalid usage of local 'x'
-    ·
- 14 │         loop { let y = x; _ = move x; y; }
     │                               ------ The local might not have a value due to this position. The local must be assigned a value before being used
+    │                               ^^^^^^ Invalid usage of local 'x'
     │
 
 error: 
@@ -56,8 +48,6 @@ error:
     │
  19 │         loop { let y = x; if (cond) continue; _ = move x; y; }
     │                        ^ Invalid usage of local 'x'
-    ·
- 19 │         loop { let y = x; if (cond) continue; _ = move x; y; }
     │                                                   ------ The local might not have a value due to this position. The local must be assigned a value before being used
     │
 
@@ -66,10 +56,8 @@ error:
     ┌── tests/move_check/locals/use_after_move_loop.move:19:51 ───
     │
  19 │         loop { let y = x; if (cond) continue; _ = move x; y; }
-    │                                                   ^^^^^^ Invalid usage of local 'x'
-    ·
- 19 │         loop { let y = x; if (cond) continue; _ = move x; y; }
     │                                                   ------ The local might not have a value due to this position. The local must be assigned a value before being used
+    │                                                   ^^^^^^ Invalid usage of local 'x'
     │
 
 error: 
@@ -78,8 +66,6 @@ error:
     │
  24 │         loop { let y = &x; _ = move y; _ = move x }
     │                        ^^ Invalid usage of local 'x'
-    ·
- 24 │         loop { let y = &x; _ = move y; _ = move x }
     │                                            ------ The local might not have a value due to this position. The local must be assigned a value before being used
     │
 
@@ -88,9 +74,7 @@ error:
     ┌── tests/move_check/locals/use_after_move_loop.move:24:44 ───
     │
  24 │         loop { let y = &x; _ = move y; _ = move x }
-    │                                            ^^^^^^ Invalid usage of local 'x'
-    ·
- 24 │         loop { let y = &x; _ = move y; _ = move x }
     │                                            ------ The local might not have a value due to this position. The local must be assigned a value before being used
+    │                                            ^^^^^^ Invalid usage of local 'x'
     │
 

--- a/language/move-lang/tests/move_check/locals/use_after_move_simple.exp
+++ b/language/move-lang/tests/move_check/locals/use_after_move_simple.exp
@@ -1,66 +1,60 @@
 error: 
 
-   ┌── tests/move_check/locals/use_after_move_simple.move:7:17 ───
+   ┌── tests/move_check/locals/use_after_move_simple.move:6:9 ───
    │
- 7 │         let _ = move x + 1;
-   │                 ^^^^^^ Invalid usage of local 'x'
-   ·
  6 │         move x;
    │         ------ The local does not have a value due to this position. The local must be assigned a value before being used
+ 7 │         let _ = move x + 1;
+   │                 ^^^^^^ Invalid usage of local 'x'
    │
 
 error: 
 
-    ┌── tests/move_check/locals/use_after_move_simple.move:11:19 ───
+    ┌── tests/move_check/locals/use_after_move_simple.move:10:19 ───
     │
- 11 │         let _s3 = s;
-    │                   ^ Invalid usage of local 's'
-    ·
  10 │         let _s2 = s;
     │                   - The local does not have a value due to this position. The local must be assigned a value before being used
+ 11 │         let _s3 = s;
+    │                   ^ Invalid usage of local 's'
     │
 
 error: 
 
-    ┌── tests/move_check/locals/use_after_move_simple.move:17:17 ───
+    ┌── tests/move_check/locals/use_after_move_simple.move:16:9 ───
     │
- 17 │         let _ = x + 1;
-    │                 ^ Invalid usage of local 'x'
-    ·
  16 │         move x;
     │         ------ The local does not have a value due to this position. The local must be assigned a value before being used
+ 17 │         let _ = x + 1;
+    │                 ^ Invalid usage of local 'x'
     │
 
 error: 
 
-    ┌── tests/move_check/locals/use_after_move_simple.move:21:19 ───
+    ┌── tests/move_check/locals/use_after_move_simple.move:20:19 ───
     │
- 21 │         let _s3 = copy s;
-    │                   ^^^^^^ Invalid usage of local 's'
-    ·
  20 │         let _s2 = s;
     │                   - The local does not have a value due to this position. The local must be assigned a value before being used
+ 21 │         let _s3 = copy s;
+    │                   ^^^^^^ Invalid usage of local 's'
     │
 
 error: 
 
-    ┌── tests/move_check/locals/use_after_move_simple.move:27:17 ───
+    ┌── tests/move_check/locals/use_after_move_simple.move:26:9 ───
     │
- 27 │         let _ = &x;
-    │                 ^^ Invalid usage of local 'x'
-    ·
  26 │         move x;
     │         ------ The local does not have a value due to this position. The local must be assigned a value before being used
+ 27 │         let _ = &x;
+    │                 ^^ Invalid usage of local 'x'
     │
 
 error: 
 
-    ┌── tests/move_check/locals/use_after_move_simple.move:31:19 ───
+    ┌── tests/move_check/locals/use_after_move_simple.move:30:19 ───
     │
- 31 │         let _s3 = &s;
-    │                   ^^ Invalid usage of local 's'
-    ·
  30 │         let _s2 = s;
     │                   - The local does not have a value due to this position. The local must be assigned a value before being used
+ 31 │         let _s3 = &s;
+    │                   ^^ Invalid usage of local 's'
     │
 

--- a/language/move-lang/tests/move_check/locals/use_after_move_while.exp
+++ b/language/move-lang/tests/move_check/locals/use_after_move_while.exp
@@ -3,10 +3,8 @@ error:
    ┌── tests/move_check/locals/use_after_move_while.move:4:28 ───
    │
  4 │         while (cond) { _ = move x };
-   │                            ^^^^^^ Invalid usage of local 'x'
-   ·
- 4 │         while (cond) { _ = move x };
    │                            ------ The local might not have a value due to this position. The local must be assigned a value before being used
+   │                            ^^^^^^ Invalid usage of local 'x'
    │
 
 error: 
@@ -14,10 +12,8 @@ error:
    ┌── tests/move_check/locals/use_after_move_while.move:9:45 ───
    │
  9 │         while (cond) { if (cond) break; _ = move x };
-   │                                             ^^^^^^ Invalid usage of local 'x'
-   ·
- 9 │         while (cond) { if (cond) break; _ = move x };
    │                                             ------ The local might not have a value due to this position. The local must be assigned a value before being used
+   │                                             ^^^^^^ Invalid usage of local 'x'
    │
 
 error: 
@@ -26,8 +22,6 @@ error:
     │
  14 │         while (cond) { let y = x; _ = move x; y; };
     │                                ^ Invalid usage of local 'x'
-    ·
- 14 │         while (cond) { let y = x; _ = move x; y; };
     │                                       ------ The local might not have a value due to this position. The local must be assigned a value before being used
     │
 
@@ -36,10 +30,8 @@ error:
     ┌── tests/move_check/locals/use_after_move_while.move:14:39 ───
     │
  14 │         while (cond) { let y = x; _ = move x; y; };
-    │                                       ^^^^^^ Invalid usage of local 'x'
-    ·
- 14 │         while (cond) { let y = x; _ = move x; y; };
     │                                       ------ The local might not have a value due to this position. The local must be assigned a value before being used
+    │                                       ^^^^^^ Invalid usage of local 'x'
     │
 
 error: 
@@ -48,8 +40,6 @@ error:
     │
  19 │         while (cond) { let y = x; if (cond) continue; _ = move x; y; };
     │                                ^ Invalid usage of local 'x'
-    ·
- 19 │         while (cond) { let y = x; if (cond) continue; _ = move x; y; };
     │                                                           ------ The local might not have a value due to this position. The local must be assigned a value before being used
     │
 
@@ -58,10 +48,8 @@ error:
     ┌── tests/move_check/locals/use_after_move_while.move:19:59 ───
     │
  19 │         while (cond) { let y = x; if (cond) continue; _ = move x; y; };
-    │                                                           ^^^^^^ Invalid usage of local 'x'
-    ·
- 19 │         while (cond) { let y = x; if (cond) continue; _ = move x; y; };
     │                                                           ------ The local might not have a value due to this position. The local must be assigned a value before being used
+    │                                                           ^^^^^^ Invalid usage of local 'x'
     │
 
 error: 
@@ -70,8 +58,6 @@ error:
     │
  24 │         while (cond) { let y = &x; _ = move y; _ = move x };
     │                                ^^ Invalid usage of local 'x'
-    ·
- 24 │         while (cond) { let y = &x; _ = move y; _ = move x };
     │                                                    ------ The local might not have a value due to this position. The local must be assigned a value before being used
     │
 
@@ -80,9 +66,7 @@ error:
     ┌── tests/move_check/locals/use_after_move_while.move:24:52 ───
     │
  24 │         while (cond) { let y = &x; _ = move y; _ = move x };
-    │                                                    ^^^^^^ Invalid usage of local 'x'
-    ·
- 24 │         while (cond) { let y = &x; _ = move y; _ = move x };
     │                                                    ------ The local might not have a value due to this position. The local must be assigned a value before being used
+    │                                                    ^^^^^^ Invalid usage of local 'x'
     │
 

--- a/language/move-lang/tests/move_check/locals/use_before_assign_if.exp
+++ b/language/move-lang/tests/move_check/locals/use_before_assign_if.exp
@@ -1,33 +1,33 @@
 error: 
 
-   ┌── tests/move_check/locals/use_before_assign_if.move:5:17 ───
+   ┌── tests/move_check/locals/use_before_assign_if.move:3:13 ───
    │
- 5 │         let _ = move x + 1;
-   │                 ^^^^^^ Invalid usage of local 'x'
-   ·
  3 │         let x: u64;
    │             - The local might not have a value due to this position. The local must be assigned a value before being used
+ 4 │         if (cond) { x = 0 };
+ 5 │         let _ = move x + 1;
+   │                 ^^^^^^ Invalid usage of local 'x'
    │
 
 error: 
 
-    ┌── tests/move_check/locals/use_before_assign_if.move:11:17 ───
+    ┌── tests/move_check/locals/use_before_assign_if.move:9:13 ───
     │
- 11 │         let _ = x + 1;
-    │                 ^ Invalid usage of local 'x'
-    ·
   9 │         let x: u64;
     │             - The local might not have a value due to this position. The local must be assigned a value before being used
+ 10 │         if (cond) { x = 0 };
+ 11 │         let _ = x + 1;
+    │                 ^ Invalid usage of local 'x'
     │
 
 error: 
 
-    ┌── tests/move_check/locals/use_before_assign_if.move:17:17 ───
+    ┌── tests/move_check/locals/use_before_assign_if.move:15:13 ───
     │
- 17 │         let _ = &x;
-    │                 ^^ Invalid usage of local 'x'
-    ·
  15 │         let x: u64;
     │             - The local might not have a value due to this position. The local must be assigned a value before being used
+ 16 │         if (cond) { x = 0 };
+ 17 │         let _ = &x;
+    │                 ^^ Invalid usage of local 'x'
     │
 

--- a/language/move-lang/tests/move_check/locals/use_before_assign_if_else.exp
+++ b/language/move-lang/tests/move_check/locals/use_before_assign_if_else.exp
@@ -1,33 +1,33 @@
 error: 
 
-   ┌── tests/move_check/locals/use_before_assign_if_else.move:5:17 ───
+   ┌── tests/move_check/locals/use_before_assign_if_else.move:3:13 ───
    │
- 5 │         let _ = move x + 1;
-   │                 ^^^^^^ Invalid usage of local 'x'
-   ·
  3 │         let x: u64;
    │             - The local might not have a value due to this position. The local must be assigned a value before being used
+ 4 │         if (cond) { } else { x = 0 };
+ 5 │         let _ = move x + 1;
+   │                 ^^^^^^ Invalid usage of local 'x'
    │
 
 error: 
 
-    ┌── tests/move_check/locals/use_before_assign_if_else.move:11:17 ───
+    ┌── tests/move_check/locals/use_before_assign_if_else.move:9:13 ───
     │
- 11 │         let _ = move x + 1;
-    │                 ^^^^^^ Invalid usage of local 'x'
-    ·
   9 │         let x: u64;
     │             - The local might not have a value due to this position. The local must be assigned a value before being used
+ 10 │         if (cond) { } else { x = 0 };
+ 11 │         let _ = move x + 1;
+    │                 ^^^^^^ Invalid usage of local 'x'
     │
 
 error: 
 
-    ┌── tests/move_check/locals/use_before_assign_if_else.move:17:17 ───
+    ┌── tests/move_check/locals/use_before_assign_if_else.move:15:13 ───
     │
- 17 │         let _ = move x + 1;
-    │                 ^^^^^^ Invalid usage of local 'x'
-    ·
  15 │         let x: u64;
     │             - The local might not have a value due to this position. The local must be assigned a value before being used
+ 16 │         if (cond) { } else { x = 0 };
+ 17 │         let _ = move x + 1;
+    │                 ^^^^^^ Invalid usage of local 'x'
     │
 

--- a/language/move-lang/tests/move_check/locals/use_before_assign_loop.exp
+++ b/language/move-lang/tests/move_check/locals/use_before_assign_loop.exp
@@ -1,55 +1,51 @@
 error: 
 
-   ┌── tests/move_check/locals/use_before_assign_loop.move:4:24 ───
+   ┌── tests/move_check/locals/use_before_assign_loop.move:3:13 ───
    │
- 4 │         loop { let y = move x + 1; x = 0; y; }
-   │                        ^^^^^^ Invalid usage of local 'x'
-   ·
  3 │         let x: u64;
    │             - The local might not have a value due to this position. The local must be assigned a value before being used
+ 4 │         loop { let y = move x + 1; x = 0; y; }
+   │                        ^^^^^^ Invalid usage of local 'x'
    │
 
 error: 
 
-   ┌── tests/move_check/locals/use_before_assign_loop.move:9:24 ───
+   ┌── tests/move_check/locals/use_before_assign_loop.move:8:13 ───
    │
- 9 │         loop { let y = x + 1; if (cond) { continue }; x = 0; y; }
-   │                        ^ Invalid usage of local 'x'
-   ·
  8 │         let x: u64;
    │             - The local might not have a value due to this position. The local must be assigned a value before being used
+ 9 │         loop { let y = x + 1; if (cond) { continue }; x = 0; y; }
+   │                        ^ Invalid usage of local 'x'
    │
 
 error: 
 
-    ┌── tests/move_check/locals/use_before_assign_loop.move:14:24 ───
+    ┌── tests/move_check/locals/use_before_assign_loop.move:13:13 ───
     │
- 14 │         loop { let y = &x; _ = move y; x = 0 }
-    │                        ^^ Invalid usage of local 'x'
-    ·
  13 │         let x: u64;
     │             - The local might not have a value due to this position. The local must be assigned a value before being used
+ 14 │         loop { let y = &x; _ = move y; x = 0 }
+    │                        ^^ Invalid usage of local 'x'
     │
 
 error: 
 
-    ┌── tests/move_check/locals/use_before_assign_loop.move:19:24 ───
+    ┌── tests/move_check/locals/use_before_assign_loop.move:18:13 ───
     │
- 19 │         loop { let y = &x; _ = move y; if (cond) { x = 0 }; break };
-    │                        ^^ Invalid usage of local 'x'
-    ·
  18 │         let x: u64;
     │             - The local does not have a value due to this position. The local must be assigned a value before being used
+ 19 │         loop { let y = &x; _ = move y; if (cond) { x = 0 }; break };
+    │                        ^^ Invalid usage of local 'x'
     │
 
 error: 
 
-    ┌── tests/move_check/locals/use_before_assign_loop.move:20:9 ───
+    ┌── tests/move_check/locals/use_before_assign_loop.move:18:13 ───
     │
- 20 │         x;
-    │         ^ Invalid usage of local 'x'
-    ·
  18 │         let x: u64;
     │             - The local might not have a value due to this position. The local must be assigned a value before being used
+ 19 │         loop { let y = &x; _ = move y; if (cond) { x = 0 }; break };
+ 20 │         x;
+    │         ^ Invalid usage of local 'x'
     │
 

--- a/language/move-lang/tests/move_check/locals/use_before_assign_simple.exp
+++ b/language/move-lang/tests/move_check/locals/use_before_assign_simple.exp
@@ -1,66 +1,60 @@
 error: 
 
-   ┌── tests/move_check/locals/use_before_assign_simple.move:6:17 ───
+   ┌── tests/move_check/locals/use_before_assign_simple.move:5:13 ───
    │
- 6 │         let _ = move x + 1;
-   │                 ^^^^^^ Invalid usage of local 'x'
-   ·
  5 │         let x: u64;
    │             - The local does not have a value due to this position. The local must be assigned a value before being used
+ 6 │         let _ = move x + 1;
+   │                 ^^^^^^ Invalid usage of local 'x'
    │
 
 error: 
 
-   ┌── tests/move_check/locals/use_before_assign_simple.move:9:19 ───
+   ┌── tests/move_check/locals/use_before_assign_simple.move:8:13 ───
    │
- 9 │         let _s2 = s;
-   │                   ^ Invalid usage of local 's'
-   ·
  8 │         let s: S;
    │             - The local does not have a value due to this position. The local must be assigned a value before being used
+ 9 │         let _s2 = s;
+   │                   ^ Invalid usage of local 's'
    │
 
 error: 
 
-    ┌── tests/move_check/locals/use_before_assign_simple.move:14:17 ───
+    ┌── tests/move_check/locals/use_before_assign_simple.move:13:13 ───
     │
- 14 │         let _ = x + 1;
-    │                 ^ Invalid usage of local 'x'
-    ·
  13 │         let x: u64;
     │             - The local does not have a value due to this position. The local must be assigned a value before being used
+ 14 │         let _ = x + 1;
+    │                 ^ Invalid usage of local 'x'
     │
 
 error: 
 
-    ┌── tests/move_check/locals/use_before_assign_simple.move:17:19 ───
+    ┌── tests/move_check/locals/use_before_assign_simple.move:16:13 ───
     │
- 17 │         let _s3 = copy s;
-    │                   ^^^^^^ Invalid usage of local 's'
-    ·
  16 │         let s: S;
     │             - The local does not have a value due to this position. The local must be assigned a value before being used
+ 17 │         let _s3 = copy s;
+    │                   ^^^^^^ Invalid usage of local 's'
     │
 
 error: 
 
-    ┌── tests/move_check/locals/use_before_assign_simple.move:22:17 ───
+    ┌── tests/move_check/locals/use_before_assign_simple.move:21:13 ───
     │
- 22 │         let _ = &x;
-    │                 ^^ Invalid usage of local 'x'
-    ·
  21 │         let x: u64;
     │             - The local does not have a value due to this position. The local must be assigned a value before being used
+ 22 │         let _ = &x;
+    │                 ^^ Invalid usage of local 'x'
     │
 
 error: 
 
-    ┌── tests/move_check/locals/use_before_assign_simple.move:25:19 ───
+    ┌── tests/move_check/locals/use_before_assign_simple.move:24:13 ───
     │
- 25 │         let _s2 = &s;
-    │                   ^^ Invalid usage of local 's'
-    ·
  24 │         let s: S;
     │             - The local does not have a value due to this position. The local must be assigned a value before being used
+ 25 │         let _s2 = &s;
+    │                   ^^ Invalid usage of local 's'
     │
 

--- a/language/move-lang/tests/move_check/locals/use_before_assign_while.exp
+++ b/language/move-lang/tests/move_check/locals/use_before_assign_while.exp
@@ -1,45 +1,41 @@
 error: 
 
-   ┌── tests/move_check/locals/use_before_assign_while.move:4:32 ───
+   ┌── tests/move_check/locals/use_before_assign_while.move:3:13 ───
    │
- 4 │         while (cond) { let y = move x + 1; x = 0; y; }
-   │                                ^^^^^^ Invalid usage of local 'x'
-   ·
  3 │         let x: u64;
    │             - The local might not have a value due to this position. The local must be assigned a value before being used
+ 4 │         while (cond) { let y = move x + 1; x = 0; y; }
+   │                                ^^^^^^ Invalid usage of local 'x'
    │
 
 error: 
 
-   ┌── tests/move_check/locals/use_before_assign_while.move:9:32 ───
+   ┌── tests/move_check/locals/use_before_assign_while.move:8:13 ───
    │
- 9 │         while (cond) { let y = move x + 1; if (cond) { continue }; x = 0; y; }
-   │                                ^^^^^^ Invalid usage of local 'x'
-   ·
  8 │         let x: u64;
    │             - The local might not have a value due to this position. The local must be assigned a value before being used
+ 9 │         while (cond) { let y = move x + 1; if (cond) { continue }; x = 0; y; }
+   │                                ^^^^^^ Invalid usage of local 'x'
    │
 
 error: 
 
-    ┌── tests/move_check/locals/use_before_assign_while.move:14:32 ───
+    ┌── tests/move_check/locals/use_before_assign_while.move:13:13 ───
     │
- 14 │         while (cond) { let y = &x; _ = move y; x = 0 }
-    │                                ^^ Invalid usage of local 'x'
-    ·
  13 │         let x: u64;
     │             - The local might not have a value due to this position. The local must be assigned a value before being used
+ 14 │         while (cond) { let y = &x; _ = move y; x = 0 }
+    │                                ^^ Invalid usage of local 'x'
     │
 
 error: 
 
-    ┌── tests/move_check/locals/use_before_assign_while.move:19:32 ───
+    ┌── tests/move_check/locals/use_before_assign_while.move:18:13 ───
     │
- 19 │         while (cond) { let y = &x; _ = move y; if (cond) { x = 0 }; break }
-    │                                ^^ Invalid usage of local 'x'
-    ·
  18 │         let x: u64;
     │             - The local does not have a value due to this position. The local must be assigned a value before being used
+ 19 │         while (cond) { let y = &x; _ = move y; if (cond) { x = 0 }; break }
+    │                                ^^ Invalid usage of local 'x'
     │
 
 error: 

--- a/language/move-lang/tests/move_check/naming/duplicate_acquires_list_item.exp
+++ b/language/move-lang/tests/move_check/naming/duplicate_acquires_list_item.exp
@@ -1,12 +1,19 @@
 error: 
 
-   ┌── tests/move_check/naming/duplicate_acquires_list_item.move:4:29 ───
+   ┌── tests/move_check/naming/duplicate_acquires_list_item.move:4:23 ───
    │
  4 │     fun t0() acquires R, X, R {
-   │                             ^ Duplicate acquires item
-   ·
- 4 │     fun t0() acquires R, X, R {
    │                       - Previously listed here
+   │                             ^ Duplicate acquires item
+   │
+
+error: 
+
+   ┌── tests/move_check/naming/duplicate_acquires_list_item.move:8:23 ───
+   │
+ 8 │     fun t1() acquires R, X, R, R, R {
+   │                       - Previously listed here
+   │                             ^ Duplicate acquires item
    │
 
 error: 
@@ -14,10 +21,8 @@ error:
    ┌── tests/move_check/naming/duplicate_acquires_list_item.move:8:29 ───
    │
  8 │     fun t1() acquires R, X, R, R, R {
-   │                             ^ Duplicate acquires item
-   ·
- 8 │     fun t1() acquires R, X, R, R, R {
-   │                       - Previously listed here
+   │                             - Previously listed here
+   │                                ^ Duplicate acquires item
    │
 
 error: 
@@ -25,20 +30,7 @@ error:
    ┌── tests/move_check/naming/duplicate_acquires_list_item.move:8:32 ───
    │
  8 │     fun t1() acquires R, X, R, R, R {
-   │                                ^ Duplicate acquires item
-   ·
- 8 │     fun t1() acquires R, X, R, R, R {
-   │                             - Previously listed here
-   │
-
-error: 
-
-   ┌── tests/move_check/naming/duplicate_acquires_list_item.move:8:35 ───
-   │
- 8 │     fun t1() acquires R, X, R, R, R {
-   │                                   ^ Duplicate acquires item
-   ·
- 8 │     fun t1() acquires R, X, R, R, R {
    │                                - Previously listed here
+   │                                   ^ Duplicate acquires item
    │
 

--- a/language/move-lang/tests/move_check/naming/duplicate_type_parameter_function.exp
+++ b/language/move-lang/tests/move_check/naming/duplicate_type_parameter_function.exp
@@ -1,12 +1,19 @@
 error: 
 
-   ┌── tests/move_check/naming/duplicate_type_parameter_function.move:2:16 ───
+   ┌── tests/move_check/naming/duplicate_type_parameter_function.move:2:13 ───
    │
  2 │     fun foo<T, T>() {}
-   │                ^ Duplicate type parameter declared with name 'T'
-   ·
- 2 │     fun foo<T, T>() {}
    │             - Previously defined here
+   │                ^ Duplicate type parameter declared with name 'T'
+   │
+
+error: 
+
+   ┌── tests/move_check/naming/duplicate_type_parameter_function.move:3:14 ───
+   │
+ 3 │     fun foo2<T: copyable, T: resource, T>() {}
+   │              - Previously defined here
+   │                           ^ Duplicate type parameter declared with name 'T'
    │
 
 error: 
@@ -14,20 +21,7 @@ error:
    ┌── tests/move_check/naming/duplicate_type_parameter_function.move:3:27 ───
    │
  3 │     fun foo2<T: copyable, T: resource, T>() {}
-   │                           ^ Duplicate type parameter declared with name 'T'
-   ·
- 3 │     fun foo2<T: copyable, T: resource, T>() {}
-   │              - Previously defined here
-   │
-
-error: 
-
-   ┌── tests/move_check/naming/duplicate_type_parameter_function.move:3:40 ───
-   │
- 3 │     fun foo2<T: copyable, T: resource, T>() {}
-   │                                        ^ Duplicate type parameter declared with name 'T'
-   ·
- 3 │     fun foo2<T: copyable, T: resource, T>() {}
    │                           - Previously defined here
+   │                                        ^ Duplicate type parameter declared with name 'T'
    │
 

--- a/language/move-lang/tests/move_check/naming/duplicate_type_parameter_struct.exp
+++ b/language/move-lang/tests/move_check/naming/duplicate_type_parameter_struct.exp
@@ -1,12 +1,19 @@
 error: 
 
-   ┌── tests/move_check/naming/duplicate_type_parameter_struct.move:2:17 ───
+   ┌── tests/move_check/naming/duplicate_type_parameter_struct.move:2:14 ───
    │
  2 │     struct S<T, T> {}
-   │                 ^ Duplicate type parameter declared with name 'T'
-   ·
- 2 │     struct S<T, T> {}
    │              - Previously defined here
+   │                 ^ Duplicate type parameter declared with name 'T'
+   │
+
+error: 
+
+   ┌── tests/move_check/naming/duplicate_type_parameter_struct.move:3:15 ───
+   │
+ 3 │     struct S2<T: copyable, T: resource, T> {}
+   │               - Previously defined here
+   │                            ^ Duplicate type parameter declared with name 'T'
    │
 
 error: 
@@ -14,32 +21,26 @@ error:
    ┌── tests/move_check/naming/duplicate_type_parameter_struct.move:3:28 ───
    │
  3 │     struct S2<T: copyable, T: resource, T> {}
-   │                            ^ Duplicate type parameter declared with name 'T'
-   ·
- 3 │     struct S2<T: copyable, T: resource, T> {}
-   │               - Previously defined here
-   │
-
-error: 
-
-   ┌── tests/move_check/naming/duplicate_type_parameter_struct.move:3:41 ───
-   │
- 3 │     struct S2<T: copyable, T: resource, T> {}
-   │                                         ^ Duplicate type parameter declared with name 'T'
-   ·
- 3 │     struct S2<T: copyable, T: resource, T> {}
    │                            - Previously defined here
+   │                                         ^ Duplicate type parameter declared with name 'T'
    │
 
 error: 
 
-   ┌── tests/move_check/naming/duplicate_type_parameter_struct.move:4:17 ───
+   ┌── tests/move_check/naming/duplicate_type_parameter_struct.move:4:14 ───
    │
- 4 │     struct R<T, T> {}
-   │                 ^ Duplicate type parameter declared with name 'T'
-   ·
  4 │     struct R<T, T> {}
    │              - Previously defined here
+   │                 ^ Duplicate type parameter declared with name 'T'
+   │
+
+error: 
+
+   ┌── tests/move_check/naming/duplicate_type_parameter_struct.move:5:15 ───
+   │
+ 5 │     struct R2<T: copyable, T: resource, T> {}
+   │               - Previously defined here
+   │                            ^ Duplicate type parameter declared with name 'T'
    │
 
 error: 
@@ -47,20 +48,7 @@ error:
    ┌── tests/move_check/naming/duplicate_type_parameter_struct.move:5:28 ───
    │
  5 │     struct R2<T: copyable, T: resource, T> {}
-   │                            ^ Duplicate type parameter declared with name 'T'
-   ·
- 5 │     struct R2<T: copyable, T: resource, T> {}
-   │               - Previously defined here
-   │
-
-error: 
-
-   ┌── tests/move_check/naming/duplicate_type_parameter_struct.move:5:41 ───
-   │
- 5 │     struct R2<T: copyable, T: resource, T> {}
-   │                                         ^ Duplicate type parameter declared with name 'T'
-   ·
- 5 │     struct R2<T: copyable, T: resource, T> {}
    │                            - Previously defined here
+   │                                         ^ Duplicate type parameter declared with name 'T'
    │
 

--- a/language/move-lang/tests/move_check/naming/generics_shadowing_invalid.exp
+++ b/language/move-lang/tests/move_check/naming/generics_shadowing_invalid.exp
@@ -1,37 +1,34 @@
 error: 
 
-   ┌── tests/move_check/naming/generics_shadowing_invalid.move:7:14 ───
+   ┌── tests/move_check/naming/generics_shadowing_invalid.move:6:20 ───
    │
- 7 │         (s1: Self::S);
-   │              ^^^^^^^ Invalid type annotation
-   ·
  6 │     fun foo<S>(s1: S, s2: S): S {
    │                    - The type: 'S'
-   ·
  7 │         (s1: Self::S);
    │              ------- Is not compatible with: '0x1::M::S'
+   │              ^^^^^^^ Invalid type annotation
    │
 
 error: 
 
-   ┌── tests/move_check/naming/generics_shadowing_invalid.move:8:20 ───
+   ┌── tests/move_check/naming/generics_shadowing_invalid.move:6:13 ───
    │
- 8 │         let s: S = S {};
-   │                    ^ Invalid construction. Expected a struct name
-   ·
  6 │     fun foo<S>(s1: S, s2: S): S {
    │             - But 'S' was declared as a type parameter here
+ 7 │         (s1: Self::S);
+ 8 │         let s: S = S {};
+   │                    ^ Invalid construction. Expected a struct name
    │
 
 error: 
 
-    ┌── tests/move_check/naming/generics_shadowing_invalid.move:9:9 ───
+    ┌── tests/move_check/naming/generics_shadowing_invalid.move:6:20 ───
     │
-  9 │         bar(s1);
-    │         ^^^^^^^ Invalid call of '0x1::M::bar'. Invalid argument for parameter 's'
-    ·
   6 │     fun foo<S>(s1: S, s2: S): S {
     │                    - The type: 'S'
+    ·
+  9 │         bar(s1);
+    │         ^^^^^^^ Invalid call of '0x1::M::bar'. Invalid argument for parameter 's'
     ·
  13 │     fun bar(s: S) {}
     │                - Is not compatible with: '0x1::M::S'
@@ -39,12 +36,12 @@ error:
 
 error: 
 
-    ┌── tests/move_check/naming/generics_shadowing_invalid.move:10:9 ───
+    ┌── tests/move_check/naming/generics_shadowing_invalid.move:6:13 ───
     │
- 10 │         S {}
-    │         ^ Invalid construction. Expected a struct name
-    ·
   6 │     fun foo<S>(s1: S, s2: S): S {
     │             - But 'S' was declared as a type parameter here
+    ·
+ 10 │         S {}
+    │         ^ Invalid construction. Expected a struct name
     │
 

--- a/language/move-lang/tests/move_check/naming/global_builtin_many_type_arguments.exp
+++ b/language/move-lang/tests/move_check/naming/global_builtin_many_type_arguments.exp
@@ -4,8 +4,6 @@ error:
    │
  8 │         borrow_global<R1, R2>(0x1);
    │         ^^^^^^^^^^^^^ Invalid call to builtin function: 'borrow_global'
-   ·
- 8 │         borrow_global<R1, R2>(0x1);
    │         -------------------------- Expected 1 type arguments but got 2
    │
 
@@ -15,8 +13,6 @@ error:
    │
  9 │         exists<R1, R2, R3>(0x1);
    │         ^^^^^^ Invalid call to builtin function: 'exists'
-   ·
- 9 │         exists<R1, R2, R3>(0x1);
    │         ----------------------- Expected 1 type arguments but got 3
    │
 
@@ -26,8 +22,6 @@ error:
     │
  10 │         R1 {} = move_from<R1, R2, R3, R4>(0x1);
     │                 ^^^^^^^^^ Invalid call to builtin function: 'move_from'
-    ·
- 10 │         R1 {} = move_from<R1, R2, R3, R4>(0x1);
     │                 ------------------------------ Expected 1 type arguments but got 4
     │
 
@@ -37,8 +31,6 @@ error:
     │
  11 │         move_to_sender<R1, R2, R3, R4, R5>(R1{});
     │         ^^^^^^^^^^^^^^ Invalid call to builtin function: 'move_to_sender'
-    ·
- 11 │         move_to_sender<R1, R2, R3, R4, R5>(R1{});
     │         ---------------------------------------- Expected 1 type arguments but got 5
     │
 

--- a/language/move-lang/tests/move_check/naming/global_builtin_zero_type_arguments.exp
+++ b/language/move-lang/tests/move_check/naming/global_builtin_zero_type_arguments.exp
@@ -4,8 +4,6 @@ error:
    │
  4 │         borrow_global<>(0x1);
    │         ^^^^^^^^^^^^^ Invalid call to builtin function: 'borrow_global'
-   ·
- 4 │         borrow_global<>(0x1);
    │         -------------------- Expected 1 type arguments but got 0
    │
 
@@ -15,8 +13,6 @@ error:
    │
  5 │         exists<>(0x1);
    │         ^^^^^^ Invalid call to builtin function: 'exists'
-   ·
- 5 │         exists<>(0x1);
    │         ------------- Expected 1 type arguments but got 0
    │
 
@@ -26,8 +22,6 @@ error:
    │
  6 │         R1 {} = move_from<>(0x1);
    │                 ^^^^^^^^^ Invalid call to builtin function: 'move_from'
-   ·
- 6 │         R1 {} = move_from<>(0x1);
    │                 ---------------- Expected 1 type arguments but got 0
    │
 
@@ -37,8 +31,6 @@ error:
    │
  7 │         move_to_sender<>(R1{});
    │         ^^^^^^^^^^^^^^ Invalid call to builtin function: 'move_to_sender'
-   ·
- 7 │         move_to_sender<>(R1{});
    │         ---------------------- Expected 1 type arguments but got 0
    │
 

--- a/language/move-lang/tests/move_check/naming/nominal_resource_field_in_struct_deep.exp
+++ b/language/move-lang/tests/move_check/naming/nominal_resource_field_in_struct_deep.exp
@@ -1,68 +1,59 @@
 error: 
 
-   ┌── tests/move_check/naming/nominal_resource_field_in_struct_deep.move:6:9 ───
+   ┌── tests/move_check/naming/nominal_resource_field_in_struct_deep.move:2:5 ───
    │
+ 2 │     resource struct R {}
+   │     -------- Type '0x8675309::M::R' was declared as a resource here
+   ·
+ 5 │     struct S {
+   │            - 'S' declared as a `struct` here
  6 │         f: RCup<R>,
    │         ^ Invalid resource field 'f' for struct 'S'. Structs cannot contain resource types, except through type parameters
-   ·
- 6 │         f: RCup<R>,
    │                 - Field 'f' is a resource due to the type: '0x8675309::M::R'
-   ·
+   │
+
+error: 
+
+   ┌── tests/move_check/naming/nominal_resource_field_in_struct_deep.move:2:5 ───
+   │
  2 │     resource struct R {}
    │     -------- Type '0x8675309::M::R' was declared as a resource here
    ·
  5 │     struct S {
    │            - 'S' declared as a `struct` here
-   │
-
-error: 
-
-   ┌── tests/move_check/naming/nominal_resource_field_in_struct_deep.move:7:9 ───
-   │
+ 6 │         f: RCup<R>,
  7 │         g: Cup<R>,
    │         ^ Invalid resource field 'g' for struct 'S'. Structs cannot contain resource types, except through type parameters
-   ·
- 7 │         g: Cup<R>,
    │                - Field 'g' is a resource due to the type: '0x8675309::M::R'
-   ·
- 2 │     resource struct R {}
-   │     -------- Type '0x8675309::M::R' was declared as a resource here
-   ·
- 5 │     struct S {
-   │            - 'S' declared as a `struct` here
    │
 
 error: 
 
-    ┌── tests/move_check/naming/nominal_resource_field_in_struct_deep.move:12:9 ───
+    ┌── tests/move_check/naming/nominal_resource_field_in_struct_deep.move:2:5 ───
     │
- 12 │         g1: RCup<RCup<RCup<R>>>,
-    │         ^^ Invalid resource field 'g1' for struct 'S2'. Structs cannot contain resource types, except through type parameters
-    ·
- 12 │         g1: RCup<RCup<RCup<R>>>,
-    │                            - Field 'g1' is a resource due to the type: '0x8675309::M::R'
-    ·
   2 │     resource struct R {}
     │     -------- Type '0x8675309::M::R' was declared as a resource here
     ·
   9 │     struct S2<T: resource> {
     │            -- 'S2' declared as a `struct` here
+    ·
+ 12 │         g1: RCup<RCup<RCup<R>>>,
+    │         ^^ Invalid resource field 'g1' for struct 'S2'. Structs cannot contain resource types, except through type parameters
+    │                            - Field 'g1' is a resource due to the type: '0x8675309::M::R'
     │
 
 error: 
 
-    ┌── tests/move_check/naming/nominal_resource_field_in_struct_deep.move:13:9 ───
+    ┌── tests/move_check/naming/nominal_resource_field_in_struct_deep.move:2:5 ───
     │
- 13 │         g2: Cup<Cup<Cup<R>>>,
-    │         ^^ Invalid resource field 'g2' for struct 'S2'. Structs cannot contain resource types, except through type parameters
-    ·
- 13 │         g2: Cup<Cup<Cup<R>>>,
-    │                         - Field 'g2' is a resource due to the type: '0x8675309::M::R'
-    ·
   2 │     resource struct R {}
     │     -------- Type '0x8675309::M::R' was declared as a resource here
     ·
   9 │     struct S2<T: resource> {
     │            -- 'S2' declared as a `struct` here
+    ·
+ 13 │         g2: Cup<Cup<Cup<R>>>,
+    │         ^^ Invalid resource field 'g2' for struct 'S2'. Structs cannot contain resource types, except through type parameters
+    │                         - Field 'g2' is a resource due to the type: '0x8675309::M::R'
     │
 

--- a/language/move-lang/tests/move_check/naming/nominal_resource_field_in_struct_shallow.exp
+++ b/language/move-lang/tests/move_check/naming/nominal_resource_field_in_struct_shallow.exp
@@ -1,34 +1,27 @@
 error: 
 
-   ┌── tests/move_check/naming/nominal_resource_field_in_struct_shallow.move:4:9 ───
+   ┌── tests/move_check/naming/nominal_resource_field_in_struct_shallow.move:2:5 ───
    │
- 4 │         f: R
-   │         ^ Invalid resource field 'f' for struct 'S'. Structs cannot contain resource types, except through type parameters
-   ·
- 4 │         f: R
-   │            - Field 'f' is a resource due to the type: '0x8675309::M::R'
-   ·
  2 │     resource struct R {}
    │     -------- Type '0x8675309::M::R' was declared as a resource here
-   ·
  3 │     struct S {
    │            - 'S' declared as a `struct` here
+ 4 │         f: R
+   │         ^ Invalid resource field 'f' for struct 'S'. Structs cannot contain resource types, except through type parameters
+   │            - Field 'f' is a resource due to the type: '0x8675309::M::R'
    │
 
 error: 
 
-   ┌── tests/move_check/naming/nominal_resource_field_in_struct_shallow.move:7:9 ───
+   ┌── tests/move_check/naming/nominal_resource_field_in_struct_shallow.move:2:5 ───
    │
- 7 │         f: R
-   │         ^ Invalid resource field 'f' for struct 'S2'. Structs cannot contain resource types, except through type parameters
-   ·
- 7 │         f: R
-   │            - Field 'f' is a resource due to the type: '0x8675309::M::R'
-   ·
  2 │     resource struct R {}
    │     -------- Type '0x8675309::M::R' was declared as a resource here
    ·
  6 │     struct S2<T: resource> {
    │            -- 'S2' declared as a `struct` here
+ 7 │         f: R
+   │         ^ Invalid resource field 'f' for struct 'S2'. Structs cannot contain resource types, except through type parameters
+   │            - Field 'f' is a resource due to the type: '0x8675309::M::R'
    │
 

--- a/language/move-lang/tests/move_check/naming/standalone_module_ident.exp
+++ b/language/move-lang/tests/move_check/naming/standalone_module_ident.exp
@@ -3,9 +3,7 @@ error:
    ┌── tests/move_check/naming/standalone_module_ident.move:9:23 ───
    │
  9 │         let x = 0x1::X;
-   │                       ^ Unexpected ';'
-   ·
- 9 │         let x = 0x1::X;
    │                       - Expected '::'
+   │                       ^ Unexpected ';'
    │
 

--- a/language/move-lang/tests/move_check/parser/acquires_list_generic.exp
+++ b/language/move-lang/tests/move_check/parser/acquires_list_generic.exp
@@ -3,9 +3,7 @@ error:
    ┌── tests/move_check/parser/acquires_list_generic.move:6:25 ───
    │
  6 │     fun foo() acquires B<CupC<R>> {
-   │                         ^ Unexpected '<'
-   ·
- 6 │     fun foo() acquires B<CupC<R>> {
    │                         - Expected ','
+   │                         ^ Unexpected '<'
    │
 

--- a/language/move-lang/tests/move_check/parser/address_not_hex.exp
+++ b/language/move-lang/tests/move_check/parser/address_not_hex.exp
@@ -3,9 +3,7 @@ error:
    ┌── tests/move_check/parser/address_not_hex.move:1:9 ───
    │
  1 │ address 1:
-   │         ^ Unexpected '1'
-   ·
- 1 │ address 1:
    │         - Expected an account address value
+   │         ^ Unexpected '1'
    │
 

--- a/language/move-lang/tests/move_check/parser/expr_abort_missing_value.exp
+++ b/language/move-lang/tests/move_check/parser/expr_abort_missing_value.exp
@@ -3,9 +3,7 @@ error:
    ┌── tests/move_check/parser/expr_abort_missing_value.move:5:5 ───
    │
  5 │     }
-   │     ^ Unexpected '}'
-   ·
- 5 │     }
    │     - Expected an expression term
+   │     ^ Unexpected '}'
    │
 

--- a/language/move-lang/tests/move_check/parser/expr_if_missing_parens.exp
+++ b/language/move-lang/tests/move_check/parser/expr_if_missing_parens.exp
@@ -3,9 +3,7 @@ error:
    ┌── tests/move_check/parser/expr_if_missing_parens.move:4:12 ───
    │
  4 │         if v < 3 ()
-   │            ^ Unexpected 'v'
-   ·
- 4 │         if v < 3 ()
    │            - Expected '('
+   │            ^ Unexpected 'v'
    │
 

--- a/language/move-lang/tests/move_check/parser/expr_unary_negation.exp
+++ b/language/move-lang/tests/move_check/parser/expr_unary_negation.exp
@@ -3,9 +3,7 @@ error:
    ┌── tests/move_check/parser/expr_unary_negation.move:5:31 ───
    │
  5 │     Transaction::assert(((1 - -2) == 3) && (-(1 - 2) == 1), 100);
-   │                               ^ Unexpected '-'
-   ·
- 5 │     Transaction::assert(((1 - -2) == 3) && (-(1 - 2) == 1), 100);
    │                               - Expected an expression term
+   │                               ^ Unexpected '-'
    │
 

--- a/language/move-lang/tests/move_check/parser/expr_while_missing_parens.exp
+++ b/language/move-lang/tests/move_check/parser/expr_while_missing_parens.exp
@@ -3,9 +3,7 @@ error:
    ┌── tests/move_check/parser/expr_while_missing_parens.move:4:15 ───
    │
  4 │         while v < 3 { v = v + 1 }
-   │               ^ Unexpected 'v'
-   ·
- 4 │         while v < 3 { v = v + 1 }
    │               - Expected '('
+   │               ^ Unexpected 'v'
    │
 

--- a/language/move-lang/tests/move_check/parser/function_acquires_bad_name.exp
+++ b/language/move-lang/tests/move_check/parser/function_acquires_bad_name.exp
@@ -3,9 +3,7 @@ error:
    ┌── tests/move_check/parser/function_acquires_bad_name.move:3:22 ───
    │
  3 │     fun f() acquires {
-   │                      ^ Unexpected '{'
-   ·
- 3 │     fun f() acquires {
    │                      - Expected a resource struct name
+   │                      ^ Unexpected '{'
    │
 

--- a/language/move-lang/tests/move_check/parser/function_acquires_missing_comma.exp
+++ b/language/move-lang/tests/move_check/parser/function_acquires_missing_comma.exp
@@ -3,9 +3,7 @@ error:
    ┌── tests/move_check/parser/function_acquires_missing_comma.move:5:25 ───
    │
  5 │     fun f() acquires X1 X2 {
-   │                         ^^ Unexpected 'X2'
-   ·
- 5 │     fun f() acquires X1 X2 {
    │                         -- Expected ','
+   │                         ^^ Unexpected 'X2'
    │
 

--- a/language/move-lang/tests/move_check/parser/function_incomplete.exp
+++ b/language/move-lang/tests/move_check/parser/function_incomplete.exp
@@ -3,9 +3,7 @@ error:
    ┌── tests/move_check/parser/function_incomplete.move:3:1 ───
    │
  3 │ 
-   │ ^ Unexpected end-of-file
-   ·
- 3 │ 
    │ - Expected an expression term
+   │ ^ Unexpected end-of-file
    │
 

--- a/language/move-lang/tests/move_check/parser/function_native_with_body.exp
+++ b/language/move-lang/tests/move_check/parser/function_native_with_body.exp
@@ -3,9 +3,7 @@ error:
    ┌── tests/move_check/parser/function_native_with_body.move:3:21 ───
    │
  3 │     native fun fn() {}
-   │                     ^ Unexpected '{'
-   ·
- 3 │     native fun fn() {}
    │                     - Expected ';'
+   │                     ^ Unexpected '{'
    │
 

--- a/language/move-lang/tests/move_check/parser/function_params_missing.exp
+++ b/language/move-lang/tests/move_check/parser/function_params_missing.exp
@@ -3,9 +3,7 @@ error:
    ┌── tests/move_check/parser/function_params_missing.move:3:12 ───
    │
  3 │     fun fn { }
-   │            ^ Unexpected '{'
-   ·
- 3 │     fun fn { }
    │            - Expected '('
+   │            ^ Unexpected '{'
    │
 

--- a/language/move-lang/tests/move_check/parser/function_public_native.exp
+++ b/language/move-lang/tests/move_check/parser/function_public_native.exp
@@ -3,9 +3,7 @@ error:
    ┌── tests/move_check/parser/function_public_native.move:3:12 ───
    │
  3 │     public native fun f();
-   │            ^^^^^^ Unexpected 'native'
-   ·
- 3 │     public native fun f();
    │            ------ Expected 'fun'
+   │            ^^^^^^ Unexpected 'native'
    │
 

--- a/language/move-lang/tests/move_check/parser/function_return_type_missing.exp
+++ b/language/move-lang/tests/move_check/parser/function_return_type_missing.exp
@@ -3,9 +3,7 @@ error:
    ┌── tests/move_check/parser/function_return_type_missing.move:3:14 ───
    │
  3 │     fun f(): { }
-   │              ^ Unexpected '{'
-   ·
- 3 │     fun f(): { }
    │              - Expected a type name
+   │              ^ Unexpected '{'
    │
 

--- a/language/move-lang/tests/move_check/parser/function_type_missing_angle.exp
+++ b/language/move-lang/tests/move_check/parser/function_type_missing_angle.exp
@@ -1,11 +1,9 @@
 error: 
 
-   ┌── tests/move_check/parser/function_type_missing_angle.move:3:19 ───
+   ┌── tests/move_check/parser/function_type_missing_angle.move:3:11 ───
    │
  3 │     fun fn<T1, T2 () { }
-   │                   ^ Expected '>'
-   ·
- 3 │     fun fn<T1, T2 () { }
    │           - To match this '<'
+   │                   ^ Expected '>'
    │
 

--- a/language/move-lang/tests/move_check/parser/function_without_body.exp
+++ b/language/move-lang/tests/move_check/parser/function_without_body.exp
@@ -3,9 +3,7 @@ error:
    ┌── tests/move_check/parser/function_without_body.move:3:13 ───
    │
  3 │     fun fn();
-   │             ^ Unexpected ';'
-   ·
- 3 │     fun fn();
    │             - Expected '{'
+   │             ^ Unexpected ';'
    │
 

--- a/language/move-lang/tests/move_check/parser/invalid_call_lhs_complex_expression.exp
+++ b/language/move-lang/tests/move_check/parser/invalid_call_lhs_complex_expression.exp
@@ -3,9 +3,7 @@ error:
    ┌── tests/move_check/parser/invalid_call_lhs_complex_expression.move:3:29 ───
    │
  3 │         (if (true) 5 else 0)();
-   │                             ^ Unexpected '('
-   ·
- 3 │         (if (true) 5 else 0)();
    │                             - Expected ';'
+   │                             ^ Unexpected '('
    │
 

--- a/language/move-lang/tests/move_check/parser/invalid_call_lhs_parens_around_name.exp
+++ b/language/move-lang/tests/move_check/parser/invalid_call_lhs_parens_around_name.exp
@@ -3,9 +3,7 @@ error:
    ┌── tests/move_check/parser/invalid_call_lhs_parens_around_name.move:3:14 ───
    │
  3 │         (foo)()
-   │              ^ Unexpected '('
-   ·
- 3 │         (foo)()
    │              - Expected ';'
+   │              ^ Unexpected '('
    │
 

--- a/language/move-lang/tests/move_check/parser/invalid_call_lhs_return.exp
+++ b/language/move-lang/tests/move_check/parser/invalid_call_lhs_return.exp
@@ -3,9 +3,7 @@ error:
    ┌── tests/move_check/parser/invalid_call_lhs_return.move:3:20 ───
    │
  3 │         (return ())(0, 1);
-   │                    ^ Unexpected '('
-   ·
- 3 │         (return ())(0, 1);
    │                    - Expected ';'
+   │                    ^ Unexpected '('
    │
 

--- a/language/move-lang/tests/move_check/parser/invalid_call_lhs_value.exp
+++ b/language/move-lang/tests/move_check/parser/invalid_call_lhs_value.exp
@@ -3,9 +3,7 @@ error:
    ┌── tests/move_check/parser/invalid_call_lhs_value.move:3:10 ───
    │
  3 │         5();
-   │          ^ Unexpected '('
-   ·
- 3 │         5();
    │          - Expected ';'
+   │          ^ Unexpected '('
    │
 

--- a/language/move-lang/tests/move_check/parser/invalid_pack_mname_non_addr.exp
+++ b/language/move-lang/tests/move_check/parser/invalid_pack_mname_non_addr.exp
@@ -3,9 +3,7 @@ error:
    ┌── tests/move_check/parser/invalid_pack_mname_non_addr.move:4:14 ───
    │
  4 │         false::M::S { }
-   │              ^^ Unexpected '::'
-   ·
- 4 │         false::M::S { }
    │              -- Expected ';'
+   │              ^^ Unexpected '::'
    │
 

--- a/language/move-lang/tests/move_check/parser/invalid_unpack_assign_lhs_mdot_no_addr.exp
+++ b/language/move-lang/tests/move_check/parser/invalid_unpack_assign_lhs_mdot_no_addr.exp
@@ -3,9 +3,7 @@ error:
    ┌── tests/move_check/parser/invalid_unpack_assign_lhs_mdot_no_addr.move:4:14 ───
    │
  4 │         false::M { f } = 0;
-   │              ^^ Unexpected '::'
-   ·
- 4 │         false::M { f } = 0;
    │              -- Expected ';'
+   │              ^^ Unexpected '::'
    │
 

--- a/language/move-lang/tests/move_check/parser/invalid_unpack_assign_rhs_not_fields.exp
+++ b/language/move-lang/tests/move_check/parser/invalid_unpack_assign_rhs_not_fields.exp
@@ -3,9 +3,7 @@ error:
     ┌── tests/move_check/parser/invalid_unpack_assign_rhs_not_fields.move:11:14 ───
     │
  11 │         X::S 0 = 0;
-    │              ^ Unexpected '0'
-    ·
- 11 │         X::S 0 = 0;
     │              - Expected ';'
+    │              ^ Unexpected '0'
     │
 

--- a/language/move-lang/tests/move_check/parser/less_than_space.exp
+++ b/language/move-lang/tests/move_check/parser/less_than_space.exp
@@ -1,14 +1,10 @@
 error: 
 
-   ┌── tests/move_check/parser/less_than_space.move:5:16 ───
+   ┌── tests/move_check/parser/less_than_space.move:5:14 ───
    │
  5 │         if (v< 10) return v;
-   │                ^^ Unexpected '10'
-   ·
- 5 │         if (v< 10) return v;
-   │                -- Expected a type name
-   ·
- 5 │         if (v< 10) return v;
    │              - Perhaps you need a blank space before this '<' operator?
+   │                -- Expected a type name
+   │                ^^ Unexpected '10'
    │
 

--- a/language/move-lang/tests/move_check/parser/let_binding_bad_name.exp
+++ b/language/move-lang/tests/move_check/parser/let_binding_bad_name.exp
@@ -3,9 +3,7 @@ error:
    ┌── tests/move_check/parser/let_binding_bad_name.move:4:13 ───
    │
  4 │         let {};
-   │             ^ Unexpected '{'
-   ·
- 4 │         let {};
    │             - Expected a variable or struct name
+   │             ^ Unexpected '{'
    │
 

--- a/language/move-lang/tests/move_check/parser/let_binding_missing_fields.exp
+++ b/language/move-lang/tests/move_check/parser/let_binding_missing_fields.exp
@@ -3,9 +3,7 @@ error:
    ┌── tests/move_check/parser/let_binding_missing_fields.move:6:26 ───
    │
  6 │         let Generic<u64> = g;
-   │                          ^ Unexpected '='
-   ·
- 6 │         let Generic<u64> = g;
    │                          - Expected '{'
+   │                          ^ Unexpected '='
    │
 

--- a/language/move-lang/tests/move_check/parser/let_binding_missing_paren.exp
+++ b/language/move-lang/tests/move_check/parser/let_binding_missing_paren.exp
@@ -1,11 +1,9 @@
 error: 
 
-   ┌── tests/move_check/parser/let_binding_missing_paren.move:3:21 ───
+   ┌── tests/move_check/parser/let_binding_missing_paren.move:3:13 ───
    │
  3 │         let (x1, x2 = (1, 2);
-   │                     ^ Expected ')'
-   ·
- 3 │         let (x1, x2 = (1, 2);
    │             - To match this '('
+   │                     ^ Expected ')'
    │
 

--- a/language/move-lang/tests/move_check/parser/let_binding_missing_type.exp
+++ b/language/move-lang/tests/move_check/parser/let_binding_missing_type.exp
@@ -3,9 +3,7 @@ error:
    ┌── tests/move_check/parser/let_binding_missing_type.move:3:17 ───
    │
  3 │         let x : = 0;
-   │                 ^ Unexpected '='
-   ·
- 3 │         let x : = 0;
    │                 - Expected a type name
+   │                 ^ Unexpected '='
    │
 

--- a/language/move-lang/tests/move_check/parser/missing_angle_brace_close.exp
+++ b/language/move-lang/tests/move_check/parser/missing_angle_brace_close.exp
@@ -1,14 +1,10 @@
 error: 
 
-   ┌── tests/move_check/parser/missing_angle_brace_close.move:3:22 ───
+   ┌── tests/move_check/parser/missing_angle_brace_close.move:3:18 ───
    │
  3 │         let x = t<u64;
-   │                      ^ Expected '>'
-   ·
- 3 │         let x = t<u64;
-   │                  - To match this '<'
-   ·
- 3 │         let x = t<u64;
    │                  - Perhaps you need a blank space before this '<' operator?
+   │                  - To match this '<'
+   │                      ^ Expected '>'
    │
 

--- a/language/move-lang/tests/move_check/parser/module_missing_lbrace.exp
+++ b/language/move-lang/tests/move_check/parser/module_missing_lbrace.exp
@@ -3,9 +3,7 @@ error:
    ┌── tests/move_check/parser/module_missing_lbrace.move:2:5 ───
    │
  2 │     fun f() {}
-   │     ^^^ Unexpected 'fun'
-   ·
- 2 │     fun f() {}
    │     --- Expected '{'
+   │     ^^^ Unexpected 'fun'
    │
 

--- a/language/move-lang/tests/move_check/parser/module_missing_rbrace.exp
+++ b/language/move-lang/tests/move_check/parser/module_missing_rbrace.exp
@@ -3,9 +3,7 @@ error:
    ┌── tests/move_check/parser/module_missing_rbrace.move:4:1 ───
    │
  4 │ 
-   │ ^ Unexpected end-of-file
-   ·
- 4 │ 
    │ - Expected 'fun'
+   │ ^ Unexpected end-of-file
    │
 

--- a/language/move-lang/tests/move_check/parser/module_use_after_func.exp
+++ b/language/move-lang/tests/move_check/parser/module_use_after_func.exp
@@ -3,9 +3,7 @@ error:
    ┌── tests/move_check/parser/module_use_after_func.move:4:5 ───
    │
  4 │     use 0x1::X;
-   │     ^^^ Unexpected 'use'
-   ·
- 4 │     use 0x1::X;
    │     --- Expected 'fun'
+   │     ^^^ Unexpected 'use'
    │
 

--- a/language/move-lang/tests/move_check/parser/module_use_after_struct.exp
+++ b/language/move-lang/tests/move_check/parser/module_use_after_struct.exp
@@ -3,9 +3,7 @@ error:
    ┌── tests/move_check/parser/module_use_after_struct.move:4:5 ───
    │
  4 │     use 0x1::X;
-   │     ^^^ Unexpected 'use'
-   ·
- 4 │     use 0x1::X;
    │     --- Expected 'fun'
+   │     ^^^ Unexpected 'use'
    │
 

--- a/language/move-lang/tests/move_check/parser/spec_parsing_inside_fun.exp
+++ b/language/move-lang/tests/move_check/parser/spec_parsing_inside_fun.exp
@@ -3,35 +3,27 @@ error:
     ┌── tests/move_check/parser/spec_parsing_inside_fun.move:32:9 ───
     │
  32 │         spec {} + 1;
-    │         ^^^^^^^ Invalid argument to '+'
-    ·
- 32 │         spec {} + 1;
     │         ------- Found: '()'. But expected: 'u8', 'u64', 'u128'
+    │         ^^^^^^^ Invalid argument to '+'
     │
 
 error: 
 
-    ┌── tests/move_check/parser/spec_parsing_inside_fun.move:32:19 ───
+    ┌── tests/move_check/parser/spec_parsing_inside_fun.move:32:9 ───
     │
- 32 │         spec {} + 1;
-    │                   ^ Incompatible arguments to '+'
-    ·
- 32 │         spec {} + 1;
-    │                   - The type: integer
-    ·
  32 │         spec {} + 1;
     │         ------- Is not compatible with: '()'
+    │                   - The type: integer
+    │                   ^ Incompatible arguments to '+'
     │
 
 error: 
 
-    ┌── tests/move_check/parser/spec_parsing_inside_fun.move:32:19 ───
+    ┌── tests/move_check/parser/spec_parsing_inside_fun.move:32:9 ───
     │
  32 │         spec {} + 1;
-    │                   ^ Invalid argument to '+'
-    ·
- 32 │         spec {} + 1;
     │         ------- Found: '()'. But expected: 'u8', 'u64', 'u128'
+    │                   ^ Invalid argument to '+'
     │
 
 error: 
@@ -39,27 +31,19 @@ error:
     ┌── tests/move_check/parser/spec_parsing_inside_fun.move:33:9 ───
     │
  33 │         spec {} && spec {};
-    │         ^^^^^^^ Incompatible arguments to '&&'
-    ·
- 33 │         spec {} && spec {};
     │         ------- The type: '()'
-    ·
- 33 │         spec {} && spec {};
     │         ------- Is not compatible with: 'bool'
+    │         ^^^^^^^ Incompatible arguments to '&&'
     │
 
 error: 
 
-    ┌── tests/move_check/parser/spec_parsing_inside_fun.move:33:20 ───
+    ┌── tests/move_check/parser/spec_parsing_inside_fun.move:33:9 ───
     │
  33 │         spec {} && spec {};
-    │                    ^^^^^^^ Incompatible arguments to '&&'
-    ·
- 33 │         spec {} && spec {};
-    │                    ------- The type: '()'
-    ·
- 33 │         spec {} && spec {};
     │         ------- Is not compatible with: 'bool'
+    │                    ------- The type: '()'
+    │                    ^^^^^^^ Incompatible arguments to '&&'
     │
 
 error: 
@@ -68,8 +52,6 @@ error:
     │
  34 │         &mut spec {};
     │         ^^^^^^^^^^^^ Invalid borrow
-    ·
- 34 │         &mut spec {};
     │              ------- Expected a single non-reference type, but found: '()'
     │
 

--- a/language/move-lang/tests/move_check/parser/struct_field_missing_type.exp
+++ b/language/move-lang/tests/move_check/parser/struct_field_missing_type.exp
@@ -3,9 +3,7 @@ error:
    ┌── tests/move_check/parser/struct_field_missing_type.move:2:18 ───
    │
  2 │     struct S { f }
-   │                  ^ Unexpected '}'
-   ·
- 2 │     struct S { f }
    │                  - Expected ':'
+   │                  ^ Unexpected '}'
    │
 

--- a/language/move-lang/tests/move_check/parser/struct_missing_lbrace.exp
+++ b/language/move-lang/tests/move_check/parser/struct_missing_lbrace.exp
@@ -1,11 +1,10 @@
 error: 
 
-   ┌── tests/move_check/parser/struct_missing_lbrace.move:3:5 ───
+   ┌── tests/move_check/parser/struct_missing_lbrace.move:2:14 ───
    │
- 3 │     fun f() {}
-   │     ^ Expected '}'
-   ·
  2 │     struct S { f: u64
    │              - To match this '{'
+ 3 │     fun f() {}
+   │     ^ Expected '}'
    │
 

--- a/language/move-lang/tests/move_check/parser/struct_native_missing_semicolon.exp
+++ b/language/move-lang/tests/move_check/parser/struct_native_missing_semicolon.exp
@@ -3,9 +3,7 @@ error:
    ┌── tests/move_check/parser/struct_native_missing_semicolon.move:3:1 ───
    │
  3 │ }
-   │ ^ Unexpected '}'
-   ·
- 3 │ }
    │ - Expected ';'
+   │ ^ Unexpected '}'
    │
 

--- a/language/move-lang/tests/move_check/parser/struct_native_resource.exp
+++ b/language/move-lang/tests/move_check/parser/struct_native_resource.exp
@@ -3,9 +3,7 @@ error:
    ┌── tests/move_check/parser/struct_native_resource.move:3:14 ───
    │
  3 │     resource native struct S;
-   │              ^^^^^^ Unexpected 'native'
-   ·
- 3 │     resource native struct S;
    │              ------ Expected 'struct'
+   │              ^^^^^^ Unexpected 'native'
    │
 

--- a/language/move-lang/tests/move_check/parser/struct_native_with_fields.exp
+++ b/language/move-lang/tests/move_check/parser/struct_native_with_fields.exp
@@ -3,9 +3,7 @@ error:
    ┌── tests/move_check/parser/struct_native_with_fields.move:3:21 ───
    │
  3 │     native struct S { f: u64 }
-   │                     ^ Unexpected '{'
-   ·
- 3 │     native struct S { f: u64 }
    │                     - Expected ';'
+   │                     ^ Unexpected '{'
    │
 

--- a/language/move-lang/tests/move_check/parser/struct_resource.exp
+++ b/language/move-lang/tests/move_check/parser/struct_resource.exp
@@ -3,9 +3,7 @@ error:
    ┌── tests/move_check/parser/struct_resource.move:3:12 ───
    │
  3 │     struct resource S { }
-   │            ^^^^^^^^ Unexpected 'resource'
-   ·
- 3 │     struct resource S { }
    │            -------- Expected a name value
+   │            ^^^^^^^^ Unexpected 'resource'
    │
 

--- a/language/move-lang/tests/move_check/parser/struct_type_copyable.exp
+++ b/language/move-lang/tests/move_check/parser/struct_type_copyable.exp
@@ -3,9 +3,7 @@ error:
    ┌── tests/move_check/parser/struct_type_copyable.move:3:17 ───
    │
  3 │     struct S<T: copy> { }
-   │                 ^^^^ Unexpected 'copy'
-   ·
- 3 │     struct S<T: copy> { }
    │                 ---- Expected either 'copyable' or 'resource'
+   │                 ^^^^ Unexpected 'copy'
    │
 

--- a/language/move-lang/tests/move_check/parser/struct_type_missing_angle.exp
+++ b/language/move-lang/tests/move_check/parser/struct_type_missing_angle.exp
@@ -1,11 +1,9 @@
 error: 
 
-   ┌── tests/move_check/parser/struct_type_missing_angle.move:3:21 ───
+   ┌── tests/move_check/parser/struct_type_missing_angle.move:3:13 ───
    │
  3 │     struct S<T1, T2 { }
-   │                     ^ Expected '>'
-   ·
- 3 │     struct S<T1, T2 { }
    │             - To match this '<'
+   │                     ^ Expected '>'
    │
 

--- a/language/move-lang/tests/move_check/parser/struct_type_resource.exp
+++ b/language/move-lang/tests/move_check/parser/struct_type_resource.exp
@@ -3,9 +3,7 @@ error:
    ┌── tests/move_check/parser/struct_type_resource.move:3:17 ───
    │
  3 │     struct S<T: res> { }
-   │                 ^^^ Unexpected 'res'
-   ·
- 3 │     struct S<T: res> { }
    │                 --- Expected either 'copyable' or 'resource'
+   │                 ^^^ Unexpected 'res'
    │
 

--- a/language/move-lang/tests/move_check/parser/struct_without_fields.exp
+++ b/language/move-lang/tests/move_check/parser/struct_without_fields.exp
@@ -3,9 +3,7 @@ error:
    ┌── tests/move_check/parser/struct_without_fields.move:3:13 ───
    │
  3 │     struct S;
-   │             ^ Unexpected ';'
-   ·
- 3 │     struct S;
    │             - Expected '{'
+   │             ^ Unexpected ';'
    │
 

--- a/language/move-lang/tests/move_check/parser/use_with_address.exp
+++ b/language/move-lang/tests/move_check/parser/use_with_address.exp
@@ -3,9 +3,7 @@ error:
    ┌── tests/move_check/parser/use_with_address.move:3:1 ───
    │
  3 │ address 0x1:
-   │ ^^^^^^^ Unexpected 'address'
-   ·
- 3 │ address 0x1:
    │ ------- Expected 'fun'
+   │ ^^^^^^^ Unexpected 'address'
    │
 

--- a/language/move-lang/tests/move_check/parser/use_with_module.exp
+++ b/language/move-lang/tests/move_check/parser/use_with_module.exp
@@ -3,9 +3,7 @@ error:
    ┌── tests/move_check/parser/use_with_module.move:3:1 ───
    │
  3 │ module M {
-   │ ^^^^^^ Unexpected 'module'
-   ·
- 3 │ module M {
    │ ------ Expected 'fun'
+   │ ^^^^^^ Unexpected 'module'
    │
 

--- a/language/move-lang/tests/move_check/translated_ir_tests/borrow_tests/borrow_global_acquires_duplicate_annotation.exp
+++ b/language/move-lang/tests/move_check/translated_ir_tests/borrow_tests/borrow_global_acquires_duplicate_annotation.exp
@@ -1,11 +1,9 @@
 error: 
 
-   ┌── tests/move_check/translated_ir_tests/borrow_tests/borrow_global_acquires_duplicate_annotation.move:5:36 ───
+   ┌── tests/move_check/translated_ir_tests/borrow_tests/borrow_global_acquires_duplicate_annotation.move:5:32 ───
    │
  5 │     public fun test() acquires T1, T1 {
-   │                                    ^^ Duplicate acquires item
-   ·
- 5 │     public fun test() acquires T1, T1 {
    │                                -- Previously listed here
+   │                                    ^^ Duplicate acquires item
    │
 

--- a/language/move-lang/tests/move_check/translated_ir_tests/borrow_tests/borrow_global_acquires_invalid_1.exp
+++ b/language/move-lang/tests/move_check/translated_ir_tests/borrow_tests/borrow_global_acquires_invalid_1.exp
@@ -1,11 +1,10 @@
 error: 
 
-   ┌── tests/move_check/translated_ir_tests/borrow_tests/borrow_global_acquires_invalid_1.move:7:9 ───
+   ┌── tests/move_check/translated_ir_tests/borrow_tests/borrow_global_acquires_invalid_1.move:6:17 ───
    │
- 7 │         acquires_t1();
-   │         ^^^^^^^^^^^^^ Invalid acquiring of resource 'T1'
-   ·
  6 │         let x = borrow_global_mut<T1>(Transaction::sender());
    │                 -------------------------------------------- It is still being mutably borrowed by this reference
+ 7 │         acquires_t1();
+   │         ^^^^^^^^^^^^^ Invalid acquiring of resource 'T1'
    │
 

--- a/language/move-lang/tests/move_check/translated_ir_tests/borrow_tests/borrow_global_acquires_invalid_2.exp
+++ b/language/move-lang/tests/move_check/translated_ir_tests/borrow_tests/borrow_global_acquires_invalid_2.exp
@@ -1,33 +1,32 @@
 error: 
 
-   ┌── tests/move_check/translated_ir_tests/borrow_tests/borrow_global_acquires_invalid_2.move:9:9 ───
+   ┌── tests/move_check/translated_ir_tests/borrow_tests/borrow_global_acquires_invalid_2.move:7:17 ───
    │
- 9 │         acquires_t1();
-   │         ^^^^^^^^^^^^^ Invalid acquiring of resource 'T1'
-   ·
  7 │         let x = borrow_global_mut<T1>(Transaction::sender());
    │                 -------------------------------------------- It is still being mutably borrowed by this reference
+ 8 │         acquires_t2();
+ 9 │         acquires_t1();
+   │         ^^^^^^^^^^^^^ Invalid acquiring of resource 'T1'
    │
 
 error: 
 
-    ┌── tests/move_check/translated_ir_tests/borrow_tests/borrow_global_acquires_invalid_2.move:16:9 ───
+    ┌── tests/move_check/translated_ir_tests/borrow_tests/borrow_global_acquires_invalid_2.move:14:17 ───
     │
- 16 │         acquires_t1();
-    │         ^^^^^^^^^^^^^ Invalid acquiring of resource 'T1'
-    ·
  14 │         let x = borrow_global_mut<T1>(Transaction::sender());
     │                 -------------------------------------------- It is still being mutably borrowed by this reference
+ 15 │         acquires_t2();
+ 16 │         acquires_t1();
+    │         ^^^^^^^^^^^^^ Invalid acquiring of resource 'T1'
     │
 
 error: 
 
-    ┌── tests/move_check/translated_ir_tests/borrow_tests/borrow_global_acquires_invalid_2.move:22:9 ───
+    ┌── tests/move_check/translated_ir_tests/borrow_tests/borrow_global_acquires_invalid_2.move:21:17 ───
     │
- 22 │         acquires_t1();
-    │         ^^^^^^^^^^^^^ Invalid acquiring of resource 'T1'
-    ·
  21 │         let x = borrow_global_mut<T1>(Transaction::sender());
     │                 -------------------------------------------- It is still being mutably borrowed by this reference
+ 22 │         acquires_t1();
+    │         ^^^^^^^^^^^^^ Invalid acquiring of resource 'T1'
     │
 

--- a/language/move-lang/tests/move_check/translated_ir_tests/borrow_tests/borrow_global_acquires_invalid_3.exp
+++ b/language/move-lang/tests/move_check/translated_ir_tests/borrow_tests/borrow_global_acquires_invalid_3.exp
@@ -1,33 +1,31 @@
 error: 
 
-   ┌── tests/move_check/translated_ir_tests/borrow_tests/borrow_global_acquires_invalid_3.move:9:9 ───
+   ┌── tests/move_check/translated_ir_tests/borrow_tests/borrow_global_acquires_invalid_3.move:8:17 ───
    │
- 9 │         acquires_t1();
-   │         ^^^^^^^^^^^^^ Invalid acquiring of resource 'T1'
-   ·
  8 │         let y = get_v(x);
    │                 -------- It is still being mutably borrowed by this reference
+ 9 │         acquires_t1();
+   │         ^^^^^^^^^^^^^ Invalid acquiring of resource 'T1'
    │
 
 error: 
 
-    ┌── tests/move_check/translated_ir_tests/borrow_tests/borrow_global_acquires_invalid_3.move:18:9 ───
+    ┌── tests/move_check/translated_ir_tests/borrow_tests/borrow_global_acquires_invalid_3.move:16:17 ───
     │
- 18 │         acquires_t1();
-    │         ^^^^^^^^^^^^^ Invalid acquiring of resource 'T1'
-    ·
  16 │         let y = get_v(x);
     │                 -------- It is still being mutably borrowed by this reference
+ 17 │         acquires_t2();
+ 18 │         acquires_t1();
+    │         ^^^^^^^^^^^^^ Invalid acquiring of resource 'T1'
     │
 
 error: 
 
-    ┌── tests/move_check/translated_ir_tests/borrow_tests/borrow_global_acquires_invalid_3.move:25:9 ───
+    ┌── tests/move_check/translated_ir_tests/borrow_tests/borrow_global_acquires_invalid_3.move:24:17 ───
     │
- 25 │         acquires_t1();
-    │         ^^^^^^^^^^^^^ Invalid acquiring of resource 'T1'
-    ·
  24 │         let y = get_v(x);
     │                 -------- It is still being mutably borrowed by this reference
+ 25 │         acquires_t1();
+    │         ^^^^^^^^^^^^^ Invalid acquiring of resource 'T1'
     │
 

--- a/language/move-lang/tests/move_check/translated_ir_tests/borrow_tests/borrow_global_acquires_missing_annotation.exp
+++ b/language/move-lang/tests/move_check/translated_ir_tests/borrow_tests/borrow_global_acquires_missing_annotation.exp
@@ -4,8 +4,6 @@ error:
    │
  6 │         borrow_global_mut<T1>(Transaction::sender());
    │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Invalid call to borrow_global_mut.
-   ·
- 6 │         borrow_global_mut<T1>(Transaction::sender());
    │                           -- The call acquires '0x8675309::A::T1', but the 'acquires' list for the current function does not contain this type. It must be present in the calling context's acquires list
    │
 

--- a/language/move-lang/tests/move_check/translated_ir_tests/borrow_tests/borrow_global_acquires_return_reference_invalid_1.exp
+++ b/language/move-lang/tests/move_check/translated_ir_tests/borrow_tests/borrow_global_acquires_return_reference_invalid_1.exp
@@ -3,9 +3,7 @@ error:
     ┌── tests/move_check/translated_ir_tests/borrow_tests/borrow_global_acquires_return_reference_invalid_1.move:10:9 ───
     │
  10 │         borrow_global_mut<T1>(Transaction::sender())
-    │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Invalid return. Resource 'T1' is still being borrowed.
-    ·
- 10 │         borrow_global_mut<T1>(Transaction::sender())
     │         -------------------------------------------- It is still being mutably borrowed by this reference
+    │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Invalid return. Resource 'T1' is still being borrowed.
     │
 

--- a/language/move-lang/tests/move_check/translated_ir_tests/borrow_tests/borrow_global_bad0.exp
+++ b/language/move-lang/tests/move_check/translated_ir_tests/borrow_tests/borrow_global_bad0.exp
@@ -1,11 +1,11 @@
 error: 
 
-   ┌── tests/move_check/translated_ir_tests/borrow_tests/borrow_global_bad0.move:9:13 ───
+   ┌── tests/move_check/translated_ir_tests/borrow_tests/borrow_global_bad0.move:7:17 ───
    │
- 9 │         x = borrow_global_mut<T>(sender);
-   │             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Invalid borrowing of resource 'T'
-   ·
  7 │         let x = borrow_global_mut<T>(sender);
    │                 ---------------------------- It is still being mutably borrowed by this reference
+ 8 │         copy x;
+ 9 │         x = borrow_global_mut<T>(sender);
+   │             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Invalid borrowing of resource 'T'
    │
 

--- a/language/move-lang/tests/move_check/translated_ir_tests/borrow_tests/borrow_global_bad1.exp
+++ b/language/move-lang/tests/move_check/translated_ir_tests/borrow_tests/borrow_global_bad1.exp
@@ -1,11 +1,10 @@
 error: 
 
-   ┌── tests/move_check/translated_ir_tests/borrow_tests/borrow_global_bad1.move:7:17 ───
+   ┌── tests/move_check/translated_ir_tests/borrow_tests/borrow_global_bad1.move:6:17 ───
    │
- 7 │         let y = borrow_global_mut<T>(addr);
-   │                 ^^^^^^^^^^^^^^^^^^^^^^^^^^ Invalid borrowing of resource 'T'
-   ·
  6 │         let x = borrow_global_mut<T>(Transaction::sender());
    │                 ------------------------------------------- It is still being mutably borrowed by this reference
+ 7 │         let y = borrow_global_mut<T>(addr);
+   │                 ^^^^^^^^^^^^^^^^^^^^^^^^^^ Invalid borrowing of resource 'T'
    │
 

--- a/language/move-lang/tests/move_check/translated_ir_tests/borrow_tests/borrow_global_bad2.exp
+++ b/language/move-lang/tests/move_check/translated_ir_tests/borrow_tests/borrow_global_bad2.exp
@@ -1,11 +1,10 @@
 error: 
 
-   ┌── tests/move_check/translated_ir_tests/borrow_tests/borrow_global_bad2.move:8:22 ───
+   ┌── tests/move_check/translated_ir_tests/borrow_tests/borrow_global_bad2.move:7:21 ───
    │
- 8 │         T { v: _ } = move_from<T>(sender);
-   │                      ^^^^^^^^^^^^^^^^^^^^ Invalid extraction of resource 'T'
-   ·
  7 │         let t_ref = borrow_global_mut<T>(sender);
    │                     ---------------------------- It is still being mutably borrowed by this reference
+ 8 │         T { v: _ } = move_from<T>(sender);
+   │                      ^^^^^^^^^^^^^^^^^^^^ Invalid extraction of resource 'T'
    │
 

--- a/language/move-lang/tests/move_check/translated_ir_tests/borrow_tests/borrow_global_bad5.exp
+++ b/language/move-lang/tests/move_check/translated_ir_tests/borrow_tests/borrow_global_bad5.exp
@@ -1,11 +1,10 @@
 error: 
 
-   ┌── tests/move_check/translated_ir_tests/borrow_tests/borrow_global_bad5.move:8:22 ───
+   ┌── tests/move_check/translated_ir_tests/borrow_tests/borrow_global_bad5.move:7:29 ───
    │
- 8 │         let t2_ref = borrow_global_mut<T>(Transaction::sender());
-   │                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Invalid borrowing of resource 'T'
-   ·
  7 │         let t1_ref = if (b) borrow_global_mut<T>(Transaction::sender()) else &mut t;
    │                             ------------------------------------------- It is still being mutably borrowed by this reference
+ 8 │         let t2_ref = borrow_global_mut<T>(Transaction::sender());
+   │                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Invalid borrowing of resource 'T'
    │
 

--- a/language/move-lang/tests/move_check/translated_ir_tests/borrow_tests/borrow_if.exp
+++ b/language/move-lang/tests/move_check/translated_ir_tests/borrow_tests/borrow_if.exp
@@ -1,11 +1,11 @@
 error: 
 
-   ┌── tests/move_check/translated_ir_tests/borrow_tests/borrow_if.move:7:31 ───
+   ┌── tests/move_check/translated_ir_tests/borrow_tests/borrow_if.move:3:9 ───
    │
- 7 │     0x0::Transaction::assert(*move ref == 5, 42);
-   │                               ^^^^^^^^ Invalid usage of local 'ref'
-   ·
  3 │     let ref;
    │         --- The local might not have a value due to this position. The local must be assigned a value before being used
+   ·
+ 7 │     0x0::Transaction::assert(*move ref == 5, 42);
+   │                               ^^^^^^^^ Invalid usage of local 'ref'
    │
 

--- a/language/move-lang/tests/move_check/translated_ir_tests/borrow_tests/borrow_return_mutable_borrow_bad.exp
+++ b/language/move-lang/tests/move_check/translated_ir_tests/borrow_tests/borrow_return_mutable_borrow_bad.exp
@@ -1,11 +1,11 @@
 error: 
 
-   ┌── tests/move_check/translated_ir_tests/borrow_tests/borrow_return_mutable_borrow_bad.move:9:9 ───
+   ┌── tests/move_check/translated_ir_tests/borrow_tests/borrow_return_mutable_borrow_bad.move:7:25 ───
    │
- 9 │         (ref_x_f, ref_x_f_g)
-   │         ^^^^^^^^^^^^^^^^^^^^ Invalid return of reference. Cannot transfer a mutable reference that is being borrowed
-   ·
  7 │         let ref_x_f_g = &ref_x_f.g;
    │                         ---------- Field 'g' is still being borrowed by this reference
+ 8 │ 
+ 9 │         (ref_x_f, ref_x_f_g)
+   │         ^^^^^^^^^^^^^^^^^^^^ Invalid return of reference. Cannot transfer a mutable reference that is being borrowed
    │
 

--- a/language/move-lang/tests/move_check/translated_ir_tests/borrow_tests/copy_loc_borrowed_field_invalid.exp
+++ b/language/move-lang/tests/move_check/translated_ir_tests/borrow_tests/copy_loc_borrowed_field_invalid.exp
@@ -1,11 +1,10 @@
 error: 
 
-   ┌── tests/move_check/translated_ir_tests/borrow_tests/copy_loc_borrowed_field_invalid.move:7:9 ───
+   ┌── tests/move_check/translated_ir_tests/borrow_tests/copy_loc_borrowed_field_invalid.move:6:18 ───
    │
- 7 │         copy x;
-   │         ^^^^^^ Invalid copy of local 'x'
-   ·
  6 │         let r1 = &mut x.f;
    │                  -------- It is still being mutably borrowed by this reference
+ 7 │         copy x;
+   │         ^^^^^^ Invalid copy of local 'x'
    │
 

--- a/language/move-lang/tests/move_check/translated_ir_tests/borrow_tests/copy_loc_borrowed_indirect_invalid.exp
+++ b/language/move-lang/tests/move_check/translated_ir_tests/borrow_tests/copy_loc_borrowed_indirect_invalid.exp
@@ -1,11 +1,10 @@
 error: 
 
-   ┌── tests/move_check/translated_ir_tests/borrow_tests/copy_loc_borrowed_indirect_invalid.move:6:9 ───
+   ┌── tests/move_check/translated_ir_tests/borrow_tests/copy_loc_borrowed_indirect_invalid.move:5:18 ───
    │
- 6 │         copy x;
-   │         ^^^^^^ Invalid copy of local 'x'
-   ·
  5 │         let r1 = foo(&mut x, &mut y);
    │                  ------------------- It is still being mutably borrowed by this reference
+ 6 │         copy x;
+   │         ^^^^^^ Invalid copy of local 'x'
    │
 

--- a/language/move-lang/tests/move_check/translated_ir_tests/borrow_tests/copy_loc_borrowed_invalid.exp
+++ b/language/move-lang/tests/move_check/translated_ir_tests/borrow_tests/copy_loc_borrowed_invalid.exp
@@ -1,11 +1,10 @@
 error: 
 
-   ┌── tests/move_check/translated_ir_tests/borrow_tests/copy_loc_borrowed_invalid.move:5:9 ───
+   ┌── tests/move_check/translated_ir_tests/borrow_tests/copy_loc_borrowed_invalid.move:4:18 ───
    │
- 5 │         copy x;
-   │         ^^^^^^ Invalid copy of local 'x'
-   ·
  4 │         let r1 = &mut x;
    │                  ------ It is still being mutably borrowed by this reference
+ 5 │         copy x;
+   │         ^^^^^^ Invalid copy of local 'x'
    │
 

--- a/language/move-lang/tests/move_check/translated_ir_tests/borrow_tests/factor_invalid_1.exp
+++ b/language/move-lang/tests/move_check/translated_ir_tests/borrow_tests/factor_invalid_1.exp
@@ -1,22 +1,22 @@
 error: 
 
-    ┌── tests/move_check/translated_ir_tests/borrow_tests/factor_invalid_1.move:12:9 ───
+    ┌── tests/move_check/translated_ir_tests/borrow_tests/factor_invalid_1.move:9:19 ───
     │
- 12 │         foo(f_g, f);
-    │         ^^^^^^^^^^^ Invalid usage of reference as function argument. Cannot transfer a mutable reference that is being borrowed
-    ·
   9 │         let f_g = &mut f.g;
     │                   -------- Field 'g' is still being mutably borrowed by this reference
+    ·
+ 12 │         foo(f_g, f);
+    │         ^^^^^^^^^^^ Invalid usage of reference as function argument. Cannot transfer a mutable reference that is being borrowed
     │
 
 error: 
 
-    ┌── tests/move_check/translated_ir_tests/borrow_tests/factor_invalid_1.move:22:9 ───
+    ┌── tests/move_check/translated_ir_tests/borrow_tests/factor_invalid_1.move:19:19 ───
     │
- 22 │         bar(f, f_g);
-    │         ^^^^^^^^^^^ Invalid usage of reference as function argument. Cannot transfer a mutable reference that is being borrowed
-    ·
  19 │         let f_g = &mut f.g;
     │                   -------- Field 'g' is still being mutably borrowed by this reference
+    ·
+ 22 │         bar(f, f_g);
+    │         ^^^^^^^^^^^ Invalid usage of reference as function argument. Cannot transfer a mutable reference that is being borrowed
     │
 

--- a/language/move-lang/tests/move_check/translated_ir_tests/borrow_tests/factor_invalid_2.exp
+++ b/language/move-lang/tests/move_check/translated_ir_tests/borrow_tests/factor_invalid_2.exp
@@ -1,11 +1,11 @@
 error: 
 
-   ┌── tests/move_check/translated_ir_tests/borrow_tests/factor_invalid_2.move:8:9 ───
+   ┌── tests/move_check/translated_ir_tests/borrow_tests/factor_invalid_2.move:6:29 ───
    │
- 8 │         &mut root.g;
-   │         ^^^^^^^^^^^ Invalid mutable borrow at field 'g'.
-   ·
  6 │         let eps = if (cond) bar(root) else &x1;
    │                             --------- It is still being borrowed by this reference
+ 7 │ 
+ 8 │         &mut root.g;
+   │         ^^^^^^^^^^^ Invalid mutable borrow at field 'g'.
    │
 

--- a/language/move-lang/tests/move_check/translated_ir_tests/borrow_tests/imm_borrow_global_invalid.exp
+++ b/language/move-lang/tests/move_check/translated_ir_tests/borrow_tests/imm_borrow_global_invalid.exp
@@ -1,33 +1,30 @@
 error: 
 
-    ┌── tests/move_check/translated_ir_tests/borrow_tests/imm_borrow_global_invalid.move:30:18 ───
+    ┌── tests/move_check/translated_ir_tests/borrow_tests/imm_borrow_global_invalid.move:29:18 ───
     │
- 30 │         let p2 = borrow_global_mut<Pair>(addr2);
-    │                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Invalid borrowing of resource 'Pair'
-    ·
  29 │         let p1 = borrow_global_mut<Pair>(addr1);
     │                  ------------------------------ It is still being mutably borrowed by this reference
+ 30 │         let p2 = borrow_global_mut<Pair>(addr2);
+    │                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Invalid borrowing of resource 'Pair'
     │
 
 error: 
 
-    ┌── tests/move_check/translated_ir_tests/borrow_tests/imm_borrow_global_invalid.move:36:25 ───
+    ┌── tests/move_check/translated_ir_tests/borrow_tests/imm_borrow_global_invalid.move:35:18 ───
     │
- 36 │         let p2 = freeze(borrow_global_mut<Pair>(addr2));
-    │                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Invalid borrowing of resource 'Pair'
-    ·
  35 │         let p1 = freeze(borrow_global_mut<Pair>(addr1));
     │                  -------------------------------------- It is still being borrowed by this reference
+ 36 │         let p2 = freeze(borrow_global_mut<Pair>(addr2));
+    │                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Invalid borrowing of resource 'Pair'
     │
 
 error: 
 
-    ┌── tests/move_check/translated_ir_tests/borrow_tests/imm_borrow_global_invalid.move:42:19 ───
+    ┌── tests/move_check/translated_ir_tests/borrow_tests/imm_borrow_global_invalid.move:41:18 ───
     │
- 42 │         let c2 = &borrow_global_mut<Pair>(addr2).x;
-    │                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Invalid borrowing of resource 'Pair'
-    ·
  41 │         let c1 = &borrow_global_mut<Pair>(addr1).x;
     │                  --------------------------------- It is still being borrowed by this reference
+ 42 │         let c2 = &borrow_global_mut<Pair>(addr2).x;
+    │                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Invalid borrowing of resource 'Pair'
     │
 

--- a/language/move-lang/tests/move_check/translated_ir_tests/borrow_tests/imm_borrow_global_lossy_acquire_invalid.exp
+++ b/language/move-lang/tests/move_check/translated_ir_tests/borrow_tests/imm_borrow_global_lossy_acquire_invalid.exp
@@ -1,11 +1,11 @@
 error: 
 
-    ┌── tests/move_check/translated_ir_tests/borrow_tests/imm_borrow_global_lossy_acquire_invalid.move:32:9 ───
+    ┌── tests/move_check/translated_ir_tests/borrow_tests/imm_borrow_global_lossy_acquire_invalid.move:29:18 ───
     │
- 32 │         eq_helper(p1, addr2)
-    │         ^^^^^^^^^^^^^^^^^^^^ Invalid acquiring of resource 'Pair'
-    ·
  29 │         let p1 = borrow_global<Pair>(addr1);
     │                  -------------------------- It is still being borrowed by this reference
+    ·
+ 32 │         eq_helper(p1, addr2)
+    │         ^^^^^^^^^^^^^^^^^^^^ Invalid acquiring of resource 'Pair'
     │
 

--- a/language/move-lang/tests/move_check/translated_ir_tests/borrow_tests/imm_borrow_global_requires_acquire.exp
+++ b/language/move-lang/tests/move_check/translated_ir_tests/borrow_tests/imm_borrow_global_requires_acquire.exp
@@ -4,8 +4,6 @@ error:
    │
  5 │         borrow_global<T1>(addr);
    │         ^^^^^^^^^^^^^^^^^^^^^^^ Invalid call to borrow_global.
-   ·
- 5 │         borrow_global<T1>(addr);
    │                       -- The call acquires '0x8675309::A::T1', but the 'acquires' list for the current function does not contain this type. It must be present in the calling context's acquires list
    │
 

--- a/language/move-lang/tests/move_check/translated_ir_tests/borrow_tests/imm_borrow_on_mut_invalid.exp
+++ b/language/move-lang/tests/move_check/translated_ir_tests/borrow_tests/imm_borrow_on_mut_invalid.exp
@@ -1,22 +1,20 @@
 error: 
 
-    ┌── tests/move_check/translated_ir_tests/borrow_tests/imm_borrow_on_mut_invalid.move:22:29 ───
+    ┌── tests/move_check/translated_ir_tests/borrow_tests/imm_borrow_on_mut_invalid.move:21:25 ───
     │
- 22 │         let x_val = *freeze(&mut point_ref.x);
-    │                             ^^^^^^^^^^^^^^^^ Invalid mutable borrow at field 'x'.
-    ·
  21 │         let field_ref = set_and_pick(copy point_ref);
     │                         ---------------------------- It is still being mutably borrowed by this reference
+ 22 │         let x_val = *freeze(&mut point_ref.x);
+    │                             ^^^^^^^^^^^^^^^^ Invalid mutable borrow at field 'x'.
     │
 
 error: 
 
-    ┌── tests/move_check/translated_ir_tests/borrow_tests/imm_borrow_on_mut_invalid.move:36:23 ───
+    ┌── tests/move_check/translated_ir_tests/borrow_tests/imm_borrow_on_mut_invalid.move:35:25 ───
     │
- 36 │         let x_val = *&freeze(point_ref).x;
-    │                       ^^^^^^^^^^^^^^^^^ Invalid freeze.
-    ·
  35 │         let field_ref = set_and_pick(copy point_ref);
     │                         ---------------------------- It is still being mutably borrowed by this reference
+ 36 │         let x_val = *&freeze(point_ref).x;
+    │                       ^^^^^^^^^^^^^^^^^ Invalid freeze.
     │
 

--- a/language/move-lang/tests/move_check/translated_ir_tests/borrow_tests/imm_borrow_on_mut_trivial_invalid.exp
+++ b/language/move-lang/tests/move_check/translated_ir_tests/borrow_tests/imm_borrow_on_mut_trivial_invalid.exp
@@ -1,11 +1,11 @@
 error: 
 
-    ┌── tests/move_check/translated_ir_tests/borrow_tests/imm_borrow_on_mut_trivial_invalid.move:12:59 ───
+    ┌── tests/move_check/translated_ir_tests/borrow_tests/imm_borrow_on_mut_trivial_invalid.move:10:28 ───
     │
- 12 │         0x0::Transaction::assert(*returned_ref == *freeze(&mut x_ref.f) + 1, 42);
-    │                                                           ^^^^^^^^^^^^ Invalid mutable borrow at field 'f'.
-    ·
  10 │         let returned_ref = bump_and_give(x_ref);
     │                            -------------------- It is still being borrowed by this reference
+ 11 │ 
+ 12 │         0x0::Transaction::assert(*returned_ref == *freeze(&mut x_ref.f) + 1, 42);
+    │                                                           ^^^^^^^^^^^^ Invalid mutable borrow at field 'f'.
     │
 

--- a/language/move-lang/tests/move_check/translated_ir_tests/borrow_tests/mutable_borrow_invalid.exp
+++ b/language/move-lang/tests/move_check/translated_ir_tests/borrow_tests/mutable_borrow_invalid.exp
@@ -1,22 +1,22 @@
 error: 
 
-   ┌── tests/move_check/translated_ir_tests/borrow_tests/mutable_borrow_invalid.move:9:9 ───
+   ┌── tests/move_check/translated_ir_tests/borrow_tests/mutable_borrow_invalid.move:6:27 ───
    │
- 9 │         root.f = 1;
-   │         ^^^^^^^^^^ Invalid mutation of reference.
-   ·
  6 │         let x = if (cond) &mut root.f else &mut root.g;
    │                           ----------- It is still being mutably borrowed by this reference
+   ·
+ 9 │         root.f = 1;
+   │         ^^^^^^^^^^ Invalid mutation of reference.
    │
 
 error: 
 
-    ┌── tests/move_check/translated_ir_tests/borrow_tests/mutable_borrow_invalid.move:17:9 ───
+    ┌── tests/move_check/translated_ir_tests/borrow_tests/mutable_borrow_invalid.move:14:27 ───
     │
- 17 │         foo(x, &mut root.f);
-    │         ^^^^^^^^^^^^^^^^^^^ Invalid usage of reference as function argument. Cannot transfer a mutable reference that is being borrowed
-    ·
  14 │         let x = if (cond) &mut root.f else &mut root.g;
     │                           ----------- It is still being mutably borrowed by this reference
+    ·
+ 17 │         foo(x, &mut root.f);
+    │         ^^^^^^^^^^^^^^^^^^^ Invalid usage of reference as function argument. Cannot transfer a mutable reference that is being borrowed
     │
 

--- a/language/move-lang/tests/move_check/translated_ir_tests/borrow_tests/mutable_borrow_local_twice_invalid.exp
+++ b/language/move-lang/tests/move_check/translated_ir_tests/borrow_tests/mutable_borrow_local_twice_invalid.exp
@@ -1,11 +1,11 @@
 error: 
 
-   ┌── tests/move_check/translated_ir_tests/borrow_tests/mutable_borrow_local_twice_invalid.move:6:9 ───
+   ┌── tests/move_check/translated_ir_tests/borrow_tests/mutable_borrow_local_twice_invalid.move:4:18 ───
    │
- 6 │         *r2 = 2;
-   │         ^^^^^^^ Invalid mutation of reference.
-   ·
  4 │         let r1 = &mut a;
    │                  ------ It is still being mutably borrowed by this reference
+ 5 │         let r2 = &mut a;
+ 6 │         *r2 = 2;
+   │         ^^^^^^^ Invalid mutation of reference.
    │
 

--- a/language/move-lang/tests/move_check/translated_ir_tests/borrow_tests/mutate_with_borrowed_loc_invalid.exp
+++ b/language/move-lang/tests/move_check/translated_ir_tests/borrow_tests/mutate_with_borrowed_loc_invalid.exp
@@ -1,11 +1,10 @@
 error: 
 
-   ┌── tests/move_check/translated_ir_tests/borrow_tests/mutate_with_borrowed_loc_invalid.move:5:9 ───
+   ┌── tests/move_check/translated_ir_tests/borrow_tests/mutate_with_borrowed_loc_invalid.move:4:17 ───
    │
- 5 │         x = 0;
-   │         ^ Invalid assignment of local 'x'
-   ·
  4 │         let y = &x;
    │                 -- It is still being borrowed by this reference
+ 5 │         x = 0;
+   │         ^ Invalid assignment of local 'x'
    │
 

--- a/language/move-lang/tests/move_check/translated_ir_tests/borrow_tests/mutate_with_borrowed_loc_struct_invalid.exp
+++ b/language/move-lang/tests/move_check/translated_ir_tests/borrow_tests/mutate_with_borrowed_loc_struct_invalid.exp
@@ -1,33 +1,31 @@
 error: 
 
-   ┌── tests/move_check/translated_ir_tests/borrow_tests/mutate_with_borrowed_loc_struct_invalid.move:7:9 ───
+   ┌── tests/move_check/translated_ir_tests/borrow_tests/mutate_with_borrowed_loc_struct_invalid.move:5:13 ───
    │
- 7 │         x = X { b: true };
-   │         ^ Invalid assignment to local 'x'
-   ·
  5 │         let x = X { b: true };
    │             - The local contains a resource value due to this assignment. The resource must be used before you assign to this local again
+ 6 │         let y = &x;
+ 7 │         x = X { b: true };
+   │         ^ Invalid assignment to local 'x'
    │
 
 error: 
 
-   ┌── tests/move_check/translated_ir_tests/borrow_tests/mutate_with_borrowed_loc_struct_invalid.move:7:9 ───
+   ┌── tests/move_check/translated_ir_tests/borrow_tests/mutate_with_borrowed_loc_struct_invalid.move:6:17 ───
    │
- 7 │         x = X { b: true };
-   │         ^ Invalid assignment of local 'x'
-   ·
  6 │         let y = &x;
    │                 -- It is still being borrowed by this reference
+ 7 │         x = X { b: true };
+   │         ^ Invalid assignment of local 'x'
    │
 
 error: 
 
-    ┌── tests/move_check/translated_ir_tests/borrow_tests/mutate_with_borrowed_loc_struct_invalid.move:16:9 ───
+    ┌── tests/move_check/translated_ir_tests/borrow_tests/mutate_with_borrowed_loc_struct_invalid.move:15:17 ───
     │
- 16 │         s = S { z: 7 };
-    │         ^ Invalid assignment of local 's'
-    ·
  15 │         let z = &y.z;
     │                 ---- It is still being borrowed by this reference
+ 16 │         s = S { z: 7 };
+    │         ^ Invalid assignment of local 's'
     │
 

--- a/language/move-lang/tests/move_check/translated_ir_tests/borrow_tests/return_with_borrowed_loc_invalid.exp
+++ b/language/move-lang/tests/move_check/translated_ir_tests/borrow_tests/return_with_borrowed_loc_invalid.exp
@@ -3,10 +3,8 @@ error:
    ┌── tests/move_check/translated_ir_tests/borrow_tests/return_with_borrowed_loc_invalid.move:7:9 ───
    │
  7 │         &x
-   │         ^^ Invalid return. Local 'x' is still being borrowed.
-   ·
- 7 │         &x
    │         -- It is still being borrowed by this reference
+   │         ^^ Invalid return. Local 'x' is still being borrowed.
    │
 
 error: 
@@ -14,21 +12,18 @@ error:
     ┌── tests/move_check/translated_ir_tests/borrow_tests/return_with_borrowed_loc_invalid.move:13:9 ───
     │
  13 │         copy y
-    │         ^^^^^^ Invalid return. Local 'x' is still being borrowed.
-    ·
- 13 │         copy y
     │         ------ It is still being borrowed by this reference
+    │         ^^^^^^ Invalid return. Local 'x' is still being borrowed.
     │
 
 error: 
 
-    ┌── tests/move_check/translated_ir_tests/borrow_tests/return_with_borrowed_loc_invalid.move:21:9 ───
+    ┌── tests/move_check/translated_ir_tests/borrow_tests/return_with_borrowed_loc_invalid.move:20:17 ───
     │
- 21 │         move u
-    │         ^^^^^^ Invalid return. Local 's' is still being borrowed.
-    ·
  20 │         let u = &y.u;
     │                 ---- It is still being borrowed by this reference
+ 21 │         move u
+    │         ^^^^^^ Invalid return. Local 's' is still being borrowed.
     │
 
 error: 
@@ -36,9 +31,7 @@ error:
     ┌── tests/move_check/translated_ir_tests/borrow_tests/return_with_borrowed_loc_invalid.move:29:9 ───
     │
  29 │         copy u
-    │         ^^^^^^ Invalid return. Local 's' is still being borrowed.
-    ·
- 29 │         copy u
     │         ------ It is still being borrowed by this reference
+    │         ^^^^^^ Invalid return. Local 's' is still being borrowed.
     │
 

--- a/language/move-lang/tests/move_check/translated_ir_tests/borrow_tests/return_with_borrowed_loc_resource_invalid.exp
+++ b/language/move-lang/tests/move_check/translated_ir_tests/borrow_tests/return_with_borrowed_loc_resource_invalid.exp
@@ -1,11 +1,11 @@
 error: 
 
-   ┌── tests/move_check/translated_ir_tests/borrow_tests/return_with_borrowed_loc_resource_invalid.move:7:15 ───
+   ┌── tests/move_check/translated_ir_tests/borrow_tests/return_with_borrowed_loc_resource_invalid.move:5:13 ───
    │
- 7 │         copy u;
-   │               ^ Invalid return
-   ·
  5 │         let s = X { u: 0 };
    │             - The local 's' still contains a resource value due to this assignment. The resource must be consumed before the function returns
+ 6 │         let u = &s.u;
+ 7 │         copy u;
+   │               ^ Invalid return
    │
 

--- a/language/move-lang/tests/move_check/translated_ir_tests/borrow_tests/writeref_borrow_invalid.exp
+++ b/language/move-lang/tests/move_check/translated_ir_tests/borrow_tests/writeref_borrow_invalid.exp
@@ -1,11 +1,11 @@
 error: 
 
-    ┌── tests/move_check/translated_ir_tests/borrow_tests/writeref_borrow_invalid.move:10:9 ───
+    ┌── tests/move_check/translated_ir_tests/borrow_tests/writeref_borrow_invalid.move:6:21 ───
     │
- 10 │         *g_mut = G { v: 0 };
-    │         ^^^^^^^^^^^^^^^^^^^ Invalid mutation of reference.
-    ·
   6 │         let v_mut = &mut root.g.v;
     │                     ------------- Field 'v' is still being mutably borrowed by this reference
+    ·
+ 10 │         *g_mut = G { v: 0 };
+    │         ^^^^^^^^^^^^^^^^^^^ Invalid mutation of reference.
     │
 

--- a/language/move-lang/tests/move_check/translated_ir_tests/commands/abort_negative_stack_size.exp
+++ b/language/move-lang/tests/move_check/translated_ir_tests/commands/abort_negative_stack_size.exp
@@ -3,9 +3,7 @@ error:
    ┌── tests/move_check/translated_ir_tests/commands/abort_negative_stack_size.move:5:1 ───
    │
  5 │ }
-   │ ^ Unexpected '}'
-   ·
- 5 │ }
    │ - Expected an expression term
+   │ ^ Unexpected '}'
    │
 

--- a/language/move-lang/tests/move_check/translated_ir_tests/commands/assign_in_one_if_branch.exp
+++ b/language/move-lang/tests/move_check/translated_ir_tests/commands/assign_in_one_if_branch.exp
@@ -1,22 +1,22 @@
 error: 
 
-   ┌── tests/move_check/translated_ir_tests/commands/assign_in_one_if_branch.move:6:5 ───
+   ┌── tests/move_check/translated_ir_tests/commands/assign_in_one_if_branch.move:2:9 ───
    │
- 6 │     x == y;
-   │     ^ Invalid usage of local 'x'
-   ·
  2 │     let x;
    │         - The local might not have a value due to this position. The local must be assigned a value before being used
+   ·
+ 6 │     x == y;
+   │     ^ Invalid usage of local 'x'
    │
 
 error: 
 
-   ┌── tests/move_check/translated_ir_tests/commands/assign_in_one_if_branch.move:6:10 ───
+   ┌── tests/move_check/translated_ir_tests/commands/assign_in_one_if_branch.move:3:9 ───
    │
- 6 │     x == y;
-   │          ^ Invalid usage of local 'y'
-   ·
  3 │     let y;
    │         - The local might not have a value due to this position. The local must be assigned a value before being used
+   ·
+ 6 │     x == y;
+   │          ^ Invalid usage of local 'y'
    │
 

--- a/language/move-lang/tests/move_check/translated_ir_tests/commands/assign_resource.exp
+++ b/language/move-lang/tests/move_check/translated_ir_tests/commands/assign_resource.exp
@@ -1,22 +1,19 @@
 error: 
 
-   ┌── tests/move_check/translated_ir_tests/commands/assign_resource.move:6:9 ───
+   ┌── tests/move_check/translated_ir_tests/commands/assign_resource.move:5:13 ───
    │
- 6 │         t = T {}; &t;
-   │         ^ Invalid assignment to local 't'
-   ·
  5 │         let t = T{}; &t;
    │             - The local contains a resource value due to this assignment. The resource must be used before you assign to this local again
+ 6 │         t = T {}; &t;
+   │         ^ Invalid assignment to local 't'
    │
 
 error: 
 
-   ┌── tests/move_check/translated_ir_tests/commands/assign_resource.move:6:21 ───
+   ┌── tests/move_check/translated_ir_tests/commands/assign_resource.move:6:9 ───
    │
  6 │         t = T {}; &t;
-   │                     ^ Invalid return
-   ·
- 6 │         t = T {}; &t;
    │         - The local 't' still contains a resource value due to this assignment. The resource must be consumed before the function returns
+   │                     ^ Invalid return
    │
 

--- a/language/move-lang/tests/move_check/translated_ir_tests/commands/assign_wrong_if_branch.exp
+++ b/language/move-lang/tests/move_check/translated_ir_tests/commands/assign_wrong_if_branch.exp
@@ -1,11 +1,11 @@
 error: 
 
-   ┌── tests/move_check/translated_ir_tests/commands/assign_wrong_if_branch.move:4:30 ───
+   ┌── tests/move_check/translated_ir_tests/commands/assign_wrong_if_branch.move:2:9 ───
    │
- 4 │     0x0::Transaction::assert(x == 100, 42);
-   │                              ^ Invalid usage of local 'x'
-   ·
  2 │     let x: u64;
    │         - The local might not have a value due to this position. The local must be assigned a value before being used
+ 3 │     if (true) () else x = 100;
+ 4 │     0x0::Transaction::assert(x == 100, 42);
+   │                              ^ Invalid usage of local 'x'
    │
 

--- a/language/move-lang/tests/move_check/translated_ir_tests/commands/assign_wrong_if_branch_no_else.exp
+++ b/language/move-lang/tests/move_check/translated_ir_tests/commands/assign_wrong_if_branch_no_else.exp
@@ -1,11 +1,11 @@
 error: 
 
-   ┌── tests/move_check/translated_ir_tests/commands/assign_wrong_if_branch_no_else.move:4:30 ───
+   ┌── tests/move_check/translated_ir_tests/commands/assign_wrong_if_branch_no_else.move:2:9 ───
    │
- 4 │     0x0::Transaction::assert(x == 100, 42);
-   │                              ^ Invalid usage of local 'x'
-   ·
  2 │     let x: u64;
    │         - The local might not have a value due to this position. The local must be assigned a value before being used
+ 3 │     if (false) x = 100;
+ 4 │     0x0::Transaction::assert(x == 100, 42);
+   │                              ^ Invalid usage of local 'x'
    │
 

--- a/language/move-lang/tests/move_check/translated_ir_tests/commands/assign_wrong_type.exp
+++ b/language/move-lang/tests/move_check/translated_ir_tests/commands/assign_wrong_type.exp
@@ -1,14 +1,11 @@
 error: 
 
-   ┌── tests/move_check/translated_ir_tests/commands/assign_wrong_type.move:5:5 ───
+   ┌── tests/move_check/translated_ir_tests/commands/assign_wrong_type.move:4:12 ───
    │
- 5 │     x = false
-   │     ^ Invalid assignment to local 'x'
-   ·
- 5 │     x = false
-   │         ----- The type: 'bool'
-   ·
  4 │     let x: u64;
    │            --- Is not compatible with: 'u64'
+ 5 │     x = false
+   │     ^ Invalid assignment to local 'x'
+   │         ----- The type: 'bool'
    │
 

--- a/language/move-lang/tests/move_check/translated_ir_tests/commands/branch_assigns_then_moves.exp
+++ b/language/move-lang/tests/move_check/translated_ir_tests/commands/branch_assigns_then_moves.exp
@@ -1,11 +1,11 @@
 error: 
 
-    ┌── tests/move_check/translated_ir_tests/commands/branch_assigns_then_moves.move:11:30 ───
+    ┌── tests/move_check/translated_ir_tests/commands/branch_assigns_then_moves.move:6:13 ───
     │
- 11 │     0x0::Transaction::assert(x == 5, 42);
-    │                              ^ Invalid usage of local 'x'
-    ·
   6 │         y = move x;
     │             ------ The local might not have a value due to this position. The local must be assigned a value before being used
+    ·
+ 11 │     0x0::Transaction::assert(x == 5, 42);
+    │                              ^ Invalid usage of local 'x'
     │
 

--- a/language/move-lang/tests/move_check/translated_ir_tests/commands/else_assigns_if_doesnt.exp
+++ b/language/move-lang/tests/move_check/translated_ir_tests/commands/else_assigns_if_doesnt.exp
@@ -1,11 +1,11 @@
 error: 
 
-    ┌── tests/move_check/translated_ir_tests/commands/else_assigns_if_doesnt.move:10:30 ───
+    ┌── tests/move_check/translated_ir_tests/commands/else_assigns_if_doesnt.move:3:9 ───
     │
- 10 │     0x0::Transaction::assert(y == 0, 42);
-    │                              ^ Invalid usage of local 'y'
-    ·
   3 │     let y;
     │         - The local might not have a value due to this position. The local must be assigned a value before being used
+    ·
+ 10 │     0x0::Transaction::assert(y == 0, 42);
+    │                              ^ Invalid usage of local 'y'
     │
 

--- a/language/move-lang/tests/move_check/translated_ir_tests/commands/else_moves_if_doesnt.exp
+++ b/language/move-lang/tests/move_check/translated_ir_tests/commands/else_moves_if_doesnt.exp
@@ -1,11 +1,10 @@
 error: 
 
-   ┌── tests/move_check/translated_ir_tests/commands/else_moves_if_doesnt.move:4:30 ───
+   ┌── tests/move_check/translated_ir_tests/commands/else_moves_if_doesnt.move:3:30 ───
    │
- 4 │     0x0::Transaction::assert(x == 0, 42);
-   │                              ^ Invalid usage of local 'x'
-   ·
  3 │     let y = if (true) 0 else move x; y;
    │                              ------ The local might not have a value due to this position. The local must be assigned a value before being used
+ 4 │     0x0::Transaction::assert(x == 0, 42);
+   │                              ^ Invalid usage of local 'x'
    │
 

--- a/language/move-lang/tests/move_check/translated_ir_tests/commands/if_assigns_else_doesnt.exp
+++ b/language/move-lang/tests/move_check/translated_ir_tests/commands/if_assigns_else_doesnt.exp
@@ -1,11 +1,11 @@
 error: 
 
-    ┌── tests/move_check/translated_ir_tests/commands/if_assigns_else_doesnt.move:10:30 ───
+    ┌── tests/move_check/translated_ir_tests/commands/if_assigns_else_doesnt.move:2:9 ───
     │
- 10 │     0x0::Transaction::assert(x == 42, 42);
-    │                              ^ Invalid usage of local 'x'
-    ·
   2 │     let x;
     │         - The local might not have a value due to this position. The local must be assigned a value before being used
+    ·
+ 10 │     0x0::Transaction::assert(x == 42, 42);
+    │                              ^ Invalid usage of local 'x'
     │
 

--- a/language/move-lang/tests/move_check/translated_ir_tests/commands/if_assigns_no_else.exp
+++ b/language/move-lang/tests/move_check/translated_ir_tests/commands/if_assigns_no_else.exp
@@ -1,11 +1,11 @@
 error: 
 
-   ┌── tests/move_check/translated_ir_tests/commands/if_assigns_no_else.move:4:30 ───
+   ┌── tests/move_check/translated_ir_tests/commands/if_assigns_no_else.move:2:9 ───
    │
- 4 │     0x0::Transaction::assert(x == 42, 42);
-   │                              ^ Invalid usage of local 'x'
-   ·
  2 │     let x;
    │         - The local might not have a value due to this position. The local must be assigned a value before being used
+ 3 │     if (true) x = 42;
+ 4 │     0x0::Transaction::assert(x == 42, 42);
+   │                              ^ Invalid usage of local 'x'
    │
 

--- a/language/move-lang/tests/move_check/translated_ir_tests/commands/if_moves_else_doesnt.exp
+++ b/language/move-lang/tests/move_check/translated_ir_tests/commands/if_moves_else_doesnt.exp
@@ -1,11 +1,11 @@
 error: 
 
-   ┌── tests/move_check/translated_ir_tests/commands/if_moves_else_doesnt.move:5:30 ───
+   ┌── tests/move_check/translated_ir_tests/commands/if_moves_else_doesnt.move:3:23 ───
    │
- 5 │     0x0::Transaction::assert(x == 0, 42);
-   │                              ^ Invalid usage of local 'x'
-   ·
  3 │     let y = if (true) move x else 0;
    │                       ------ The local might not have a value due to this position. The local must be assigned a value before being used
+ 4 │     y;
+ 5 │     0x0::Transaction::assert(x == 0, 42);
+   │                              ^ Invalid usage of local 'x'
    │
 

--- a/language/move-lang/tests/move_check/translated_ir_tests/commands/if_moves_no_else.exp
+++ b/language/move-lang/tests/move_check/translated_ir_tests/commands/if_moves_no_else.exp
@@ -1,11 +1,11 @@
 error: 
 
-   ┌── tests/move_check/translated_ir_tests/commands/if_moves_no_else.move:7:30 ───
+   ┌── tests/move_check/translated_ir_tests/commands/if_moves_no_else.move:4:17 ───
    │
- 7 │     0x0::Transaction::assert(x == 0, 42);
-   │                              ^ Invalid usage of local 'x'
-   ·
  4 │         let y = move x;
    │                 ------ The local might not have a value due to this position. The local must be assigned a value before being used
+   ·
+ 7 │     0x0::Transaction::assert(x == 0, 42);
+   │                              ^ Invalid usage of local 'x'
    │
 

--- a/language/move-lang/tests/move_check/translated_ir_tests/commands/join_failure.exp
+++ b/language/move-lang/tests/move_check/translated_ir_tests/commands/join_failure.exp
@@ -1,11 +1,11 @@
 error: 
 
-    ┌── tests/move_check/translated_ir_tests/commands/join_failure.move:13:21 ───
+    ┌── tests/move_check/translated_ir_tests/commands/join_failure.move:8:22 ───
     │
- 13 │         R{ f: _ } = move r;
-    │                     ^^^^^^ Invalid usage of local 'r'
-    ·
   8 │             R{ f } = move r;
     │                      ------ The local might not have a value due to this position. The local must be assigned a value before being used
+    ·
+ 13 │         R{ f: _ } = move r;
+    │                     ^^^^^^ Invalid usage of local 'r'
     │
 

--- a/language/move-lang/tests/move_check/translated_ir_tests/commands/move_before_assign.exp
+++ b/language/move-lang/tests/move_check/translated_ir_tests/commands/move_before_assign.exp
@@ -8,12 +8,11 @@ error:
 
 error: 
 
-   ┌── tests/move_check/translated_ir_tests/commands/move_before_assign.move:3:13 ───
+   ┌── tests/move_check/translated_ir_tests/commands/move_before_assign.move:2:9 ───
    │
- 3 │     let y = move x;
-   │             ^^^^^^ Invalid usage of local 'x'
-   ·
  2 │     let x: u64;
    │         - The local does not have a value due to this position. The local must be assigned a value before being used
+ 3 │     let y = move x;
+   │             ^^^^^^ Invalid usage of local 'x'
    │
 

--- a/language/move-lang/tests/move_check/translated_ir_tests/commands/pop_negative.exp
+++ b/language/move-lang/tests/move_check/translated_ir_tests/commands/pop_negative.exp
@@ -1,14 +1,12 @@
 error: 
 
-   ┌── tests/move_check/translated_ir_tests/commands/pop_negative.move:7:9 ───
+   ┌── tests/move_check/translated_ir_tests/commands/pop_negative.move:2:18 ───
    │
- 7 │         (_, _, _, _) = three();
-   │         ^^^^^^^^^^^^ Invalid value for assignment
+ 2 │     fun three(): (u64, u64, u64) {
+   │                  --------------- Is not compatible with the expression list type of length 3: '(u64, u64, u64)'
    ·
  7 │         (_, _, _, _) = three();
    │         ------------ The expression list type of length 4: '(_, _, _, _)'
-   ·
- 2 │     fun three(): (u64, u64, u64) {
-   │                  --------------- Is not compatible with the expression list type of length 3: '(u64, u64, u64)'
+   │         ^^^^^^^^^^^^ Invalid value for assignment
    │
 

--- a/language/move-lang/tests/move_check/translated_ir_tests/commands/pop_positive.exp
+++ b/language/move-lang/tests/move_check/translated_ir_tests/commands/pop_positive.exp
@@ -1,14 +1,12 @@
 error: 
 
-   ┌── tests/move_check/translated_ir_tests/commands/pop_positive.move:7:9 ───
+   ┌── tests/move_check/translated_ir_tests/commands/pop_positive.move:2:18 ───
    │
- 7 │         (_, _) = three();
-   │         ^^^^^^ Invalid value for assignment
+ 2 │     fun three(): (u64, u64, u64) {
+   │                  --------------- Is not compatible with the expression list type of length 3: '(u64, u64, u64)'
    ·
  7 │         (_, _) = three();
    │         ------ The expression list type of length 2: '(_, _)'
-   ·
- 2 │     fun three(): (u64, u64, u64) {
-   │                  --------------- Is not compatible with the expression list type of length 3: '(u64, u64, u64)'
+   │         ^^^^^^ Invalid value for assignment
    │
 

--- a/language/move-lang/tests/move_check/translated_ir_tests/commands/pop_weird.exp
+++ b/language/move-lang/tests/move_check/translated_ir_tests/commands/pop_weird.exp
@@ -3,12 +3,8 @@ error:
     ┌── tests/move_check/translated_ir_tests/commands/pop_weird.move:13:9 ───
     │
  13 │         (_, _) = ();
-    │         ^^^^^^ Invalid value for assignment
-    ·
- 13 │         (_, _) = ();
     │         ------ The type: '(_, _)'
-    ·
- 13 │         (_, _) = ();
+    │         ^^^^^^ Invalid value for assignment
     │                  -- Is not compatible with: '()'
     │
 
@@ -18,8 +14,6 @@ error:
     │
  14 │         (_) = ();
     │         ^^^ Invalid type for local
-    ·
- 14 │         (_) = ();
     │               -- Expected a single type, but found expression list type: '()'
     │
 

--- a/language/move-lang/tests/move_check/translated_ir_tests/commands/return_type_mismatch_and_unused_resource.exp
+++ b/language/move-lang/tests/move_check/translated_ir_tests/commands/return_type_mismatch_and_unused_resource.exp
@@ -1,22 +1,21 @@
 error: 
 
-   ┌── tests/move_check/translated_ir_tests/commands/return_type_mismatch_and_unused_resource.move:7:9 ───
+   ┌── tests/move_check/translated_ir_tests/commands/return_type_mismatch_and_unused_resource.move:5:13 ───
    │
- 7 │         false
-   │         ^^^^^ Invalid return
-   ·
  5 │         let x = X {};
    │             - The local 'x' still contains a resource value due to this assignment. The resource must be consumed before the function returns
+ 6 │         &x;
+ 7 │         false
+   │         ^^^^^ Invalid return
    │
 
 error: 
 
-    ┌── tests/move_check/translated_ir_tests/commands/return_type_mismatch_and_unused_resource.move:13:9 ───
+    ┌── tests/move_check/translated_ir_tests/commands/return_type_mismatch_and_unused_resource.move:12:17 ───
     │
- 13 │         r
-    │         ^ Invalid return. Local 'u' is still being borrowed.
-    ·
  12 │         let r = &u;
     │                 -- It is still being borrowed by this reference
+ 13 │         r
+    │         ^ Invalid return. Local 'u' is still being borrowed.
     │
 

--- a/language/move-lang/tests/move_check/translated_ir_tests/commands/unpack_wrong_type.exp
+++ b/language/move-lang/tests/move_check/translated_ir_tests/commands/unpack_wrong_type.exp
@@ -1,14 +1,11 @@
 error: 
 
-   ┌── tests/move_check/translated_ir_tests/commands/unpack_wrong_type.move:6:9 ───
+   ┌── tests/move_check/translated_ir_tests/commands/unpack_wrong_type.move:5:29 ───
    │
- 6 │         X { b: _ } = t;
-   │         ^^^^^^^^^^ Invalid deconstruction assignment
-   ·
- 6 │         X { b: _ } = t;
-   │         ---------- The type: '0x8675309::Test::X'
-   ·
  5 │     public fun destroy_t(t: T) {
    │                             - Is not compatible with: '0x8675309::Test::T'
+ 6 │         X { b: _ } = t;
+   │         ---------- The type: '0x8675309::Test::X'
+   │         ^^^^^^^^^^ Invalid deconstruction assignment
    │
 

--- a/language/move-lang/tests/move_check/translated_ir_tests/commands/use_before_assign.exp
+++ b/language/move-lang/tests/move_check/translated_ir_tests/commands/use_before_assign.exp
@@ -8,12 +8,11 @@ error:
 
 error: 
 
-   ┌── tests/move_check/translated_ir_tests/commands/use_before_assign.move:3:13 ───
+   ┌── tests/move_check/translated_ir_tests/commands/use_before_assign.move:2:9 ───
    │
- 3 │     let y = x;
-   │             ^ Invalid usage of local 'x'
-   ·
  2 │     let x: u64;
    │         - The local does not have a value due to this position. The local must be assigned a value before being used
+ 3 │     let y = x;
+   │             ^ Invalid usage of local 'x'
    │
 

--- a/language/move-lang/tests/move_check/translated_ir_tests/commands/while_move_local.exp
+++ b/language/move-lang/tests/move_check/translated_ir_tests/commands/while_move_local.exp
@@ -3,9 +3,7 @@ error:
    ┌── tests/move_check/translated_ir_tests/commands/while_move_local.move:6:13 ───
    │
  6 │         y = move x;
-   │             ^^^^^^ Invalid usage of local 'x'
-   ·
- 6 │         y = move x;
    │             ------ The local might not have a value due to this position. The local must be assigned a value before being used
+   │             ^^^^^^ Invalid usage of local 'x'
    │
 

--- a/language/move-lang/tests/move_check/translated_ir_tests/commands/while_move_local_2.exp
+++ b/language/move-lang/tests/move_check/translated_ir_tests/commands/while_move_local_2.exp
@@ -3,10 +3,8 @@ error:
    ┌── tests/move_check/translated_ir_tests/commands/while_move_local_2.move:7:17 ───
    │
  7 │             y = move x;
-   │                 ^^^^^^ Invalid usage of local 'x'
-   ·
- 7 │             y = move x;
    │                 ------ The local might not have a value due to this position. The local must be assigned a value before being used
+   │                 ^^^^^^ Invalid usage of local 'x'
    │
 
 error: 
@@ -14,9 +12,7 @@ error:
    ┌── tests/move_check/translated_ir_tests/commands/while_move_local_2.move:9:17 ───
    │
  9 │             x = move y;
-   │                 ^^^^^^ Invalid usage of local 'y'
-   ·
- 9 │             x = move y;
    │                 ------ The local might not have a value due to this position. The local must be assigned a value before being used
+   │                 ^^^^^^ Invalid usage of local 'y'
    │
 

--- a/language/move-lang/tests/move_check/translated_ir_tests/generics/instantiation_loops/complex_1.exp
+++ b/language/move-lang/tests/move_check/translated_ir_tests/generics/instantiation_loops/complex_1.exp
@@ -3,38 +3,29 @@ error:
     ┌── tests/move_check/translated_ir_tests/generics/instantiation_loops/complex_1.move:10:9 ───
     │
  10 │         c<S<T2>, bool>()
+    │         ---------------- 'b<_, c::T1>' calls 'c<0x8675309::M::S<c::T1>, _>'
     │         ^^^^^^^^^^^^^^^^ Invalid call to '0x8675309::M::c'
-    ·
- 10 │         c<S<T2>, bool>()
     │           ----- The type parameter 'c::T1' was instantiated with the type '0x8675309::M::S<T2>', which contains the type parameter 'c::T2'. A cycle of recursive calls causes the instantiation to recurse infinitely
     ·
  14 │         c<u64, T1>();
     │         ------------ 'c<c::T1, _>' calls 'c<_, c::T1>'
-    ·
  15 │         d<T2>();
     │         ------- 'c<_, c::T1>' calls 'd<c::T1>'
     ·
  20 │         b<u64, T>()
     │         ----------- 'd<c::T1>' calls 'b<_, c::T1>'
-    ·
- 10 │         c<S<T2>, bool>()
-    │         ---------------- 'b<_, c::T1>' calls 'c<0x8675309::M::S<c::T1>, _>'
     │
 
 error: 
 
-    ┌── tests/move_check/translated_ir_tests/generics/instantiation_loops/complex_1.move:31:9 ───
+    ┌── tests/move_check/translated_ir_tests/generics/instantiation_loops/complex_1.move:27:9 ───
     │
- 31 │         f<S<T>>()
-    │         ^^^^^^^^^ Invalid call to '0x8675309::M::f'
-    ·
- 31 │         f<S<T>>()
-    │           ---- The type parameter 'g::T' was instantiated with the type '0x8675309::M::S<T>', which contains the type parameter 'f::T'. These mutually recursive calls causes the instantiation to recurse infinitely
-    ·
  27 │         g<T>()
     │         ------ 'f<f::T>' calls 'g<f::T>'
     ·
  31 │         f<S<T>>()
     │         --------- 'g<f::T>' calls 'f<0x8675309::M::S<f::T>>'
+    │         ^^^^^^^^^ Invalid call to '0x8675309::M::f'
+    │           ---- The type parameter 'g::T' was instantiated with the type '0x8675309::M::S<T>', which contains the type parameter 'f::T'. These mutually recursive calls causes the instantiation to recurse infinitely
     │
 

--- a/language/move-lang/tests/move_check/translated_ir_tests/generics/instantiation_loops/mutually_recursive_three_args_type_con_shifting.exp
+++ b/language/move-lang/tests/move_check/translated_ir_tests/generics/instantiation_loops/mutually_recursive_three_args_type_con_shifting.exp
@@ -1,38 +1,22 @@
 error: 
 
-    ┌── tests/move_check/translated_ir_tests/generics/instantiation_loops/mutually_recursive_three_args_type_con_shifting.move:9:9 ───
+    ┌── tests/move_check/translated_ir_tests/generics/instantiation_loops/mutually_recursive_three_args_type_con_shifting.move:5:9 ───
     │
-  9 │         h<T1, T2, S<T3>>()
-    │         ^^^^^^^^^^^^^^^^^^ Invalid call to '0x8675309::M::h'
-    ·
-  9 │         h<T1, T2, S<T3>>()
-    │                   ----- The type parameter 'f::T3' was instantiated with the type '0x8675309::M::S<T3>', which contains the type parameter 'h::T3'. A cycle of recursive calls causes the instantiation to recurse infinitely
-    ·
- 13 │         f<T1, T2, T3>()
-    │         --------------- 'h<_, _, h::T3>' calls 'f<_, _, h::T3>'
-    ·
   5 │         g<T2, T3, T1>()
+    │         --------------- 'f<_, h::T3, _>' calls 'g<h::T3, _, _>'
+    │         --------------- 'f<h::T3, _, _>' calls 'g<_, _, h::T3>'
     │         --------------- 'f<_, _, h::T3>' calls 'g<_, h::T3, _>'
     ·
   9 │         h<T1, T2, S<T3>>()
     │         ------------------ 'g<_, h::T3, _>' calls 'h<_, h::T3, _>'
+    │         ------------------ 'g<h::T3, _, _>' calls 'h<h::T3, _, _>'
+    │         ------------------ 'g<_, _, h::T3>' calls 'h<_, _, 0x8675309::M::S<h::T3>>'
+    │         ^^^^^^^^^^^^^^^^^^ Invalid call to '0x8675309::M::h'
+    │                   ----- The type parameter 'f::T3' was instantiated with the type '0x8675309::M::S<T3>', which contains the type parameter 'h::T3'. A cycle of recursive calls causes the instantiation to recurse infinitely
     ·
  13 │         f<T1, T2, T3>()
     │         --------------- 'h<_, h::T3, _>' calls 'f<_, h::T3, _>'
-    ·
-  5 │         g<T2, T3, T1>()
-    │         --------------- 'f<_, h::T3, _>' calls 'g<h::T3, _, _>'
-    ·
-  9 │         h<T1, T2, S<T3>>()
-    │         ------------------ 'g<h::T3, _, _>' calls 'h<h::T3, _, _>'
-    ·
- 13 │         f<T1, T2, T3>()
     │         --------------- 'h<h::T3, _, _>' calls 'f<h::T3, _, _>'
-    ·
-  5 │         g<T2, T3, T1>()
-    │         --------------- 'f<h::T3, _, _>' calls 'g<_, _, h::T3>'
-    ·
-  9 │         h<T1, T2, S<T3>>()
-    │         ------------------ 'g<_, _, h::T3>' calls 'h<_, _, 0x8675309::M::S<h::T3>>'
+    │         --------------- 'h<_, _, h::T3>' calls 'f<_, _, h::T3>'
     │
 

--- a/language/move-lang/tests/move_check/translated_ir_tests/generics/instantiation_loops/mutually_recursive_two_args_swapping_type_con.exp
+++ b/language/move-lang/tests/move_check/translated_ir_tests/generics/instantiation_loops/mutually_recursive_two_args_swapping_type_con.exp
@@ -1,23 +1,15 @@
 error: 
 
-   ┌── tests/move_check/translated_ir_tests/generics/instantiation_loops/mutually_recursive_two_args_swapping_type_con.move:9:9 ───
+   ┌── tests/move_check/translated_ir_tests/generics/instantiation_loops/mutually_recursive_two_args_swapping_type_con.move:5:9 ───
    │
- 9 │         f<T1, S<T2>, u64>()
-   │         ^^^^^^^^^^^^^^^^^^^ Invalid call to '0x8675309::M::f'
-   ·
- 9 │         f<T1, S<T2>, u64>()
-   │               ----- The type parameter 'g::T2' was instantiated with the type '0x8675309::M::S<T2>', which contains the type parameter 'f::T2'. A cycle of recursive calls causes the instantiation to recurse infinitely
-   ·
  5 │         g<T2, T1>()
+   │         ----------- 'f<f::T2, _, _>' calls 'g<_, f::T2>'
    │         ----------- 'f<_, f::T2, _>' calls 'g<f::T2, _>'
    ·
  9 │         f<T1, S<T2>, u64>()
    │         ------------------- 'g<f::T2, _>' calls 'f<f::T2, _, _>'
-   ·
- 5 │         g<T2, T1>()
-   │         ----------- 'f<f::T2, _, _>' calls 'g<_, f::T2>'
-   ·
- 9 │         f<T1, S<T2>, u64>()
    │         ------------------- 'g<_, f::T2>' calls 'f<_, 0x8675309::M::S<f::T2>, _>'
+   │         ^^^^^^^^^^^^^^^^^^^ Invalid call to '0x8675309::M::f'
+   │               ----- The type parameter 'g::T2' was instantiated with the type '0x8675309::M::S<T2>', which contains the type parameter 'f::T2'. A cycle of recursive calls causes the instantiation to recurse infinitely
    │
 

--- a/language/move-lang/tests/move_check/translated_ir_tests/generics/instantiation_loops/mutually_recursive_type_con.exp
+++ b/language/move-lang/tests/move_check/translated_ir_tests/generics/instantiation_loops/mutually_recursive_type_con.exp
@@ -3,15 +3,11 @@ error:
     ┌── tests/move_check/translated_ir_tests/generics/instantiation_loops/mutually_recursive_type_con.move:8:9 ───
     │
   8 │         g<S<T>>()
+    │         --------- 'f<g::T>' calls 'g<0x8675309::M::S<g::T>>'
     │         ^^^^^^^^^ Invalid call to '0x8675309::M::g'
-    ·
-  8 │         g<S<T>>()
     │           ---- The type parameter 'f::T' was instantiated with the type '0x8675309::M::S<T>', which contains the type parameter 'g::T'. These mutually recursive calls causes the instantiation to recurse infinitely
     ·
  12 │         f<T>()
     │         ------ 'g<g::T>' calls 'f<g::T>'
-    ·
-  8 │         g<S<T>>()
-    │         --------- 'f<g::T>' calls 'g<0x8675309::M::S<g::T>>'
     │
 

--- a/language/move-lang/tests/move_check/translated_ir_tests/generics/instantiation_loops/nested_types_1.exp
+++ b/language/move-lang/tests/move_check/translated_ir_tests/generics/instantiation_loops/nested_types_1.exp
@@ -4,8 +4,6 @@ error:
    │
  5 │         foo<S<S<T>>>()
    │         ^^^^^^^^^^^^^^ Invalid call to '0x8675309::M::foo'
-   ·
- 5 │         foo<S<S<T>>>()
    │             ------- The type parameter 'foo::T' was instantiated with the type '0x8675309::M::S<0x8675309::M::S<T>>', which contains the type parameter 'foo::T'. This recursive call causes the instantiation to recurse infinitely
    │
 

--- a/language/move-lang/tests/move_check/translated_ir_tests/generics/instantiation_loops/nested_types_2.exp
+++ b/language/move-lang/tests/move_check/translated_ir_tests/generics/instantiation_loops/nested_types_2.exp
@@ -4,8 +4,6 @@ error:
    │
  6 │         foo<R<u64, S<S<T>>>>()
    │         ^^^^^^^^^^^^^^^^^^^^^^ Invalid call to '0x8675309::M::foo'
-   ·
- 6 │         foo<R<u64, S<S<T>>>>()
    │             --------------- The type parameter 'foo::T' was instantiated with the type '0x8675309::M::R<u64, 0x8675309::M::S<0x8675309::M::S<T>>>', which contains the type parameter 'foo::T'. This recursive call causes the instantiation to recurse infinitely
    │
 

--- a/language/move-lang/tests/move_check/translated_ir_tests/generics/instantiation_loops/recursive_infinite_type_terminates.exp
+++ b/language/move-lang/tests/move_check/translated_ir_tests/generics/instantiation_loops/recursive_infinite_type_terminates.exp
@@ -4,8 +4,6 @@ error:
     │
  11 │         unbox<T>(f<Box<T>>(n - 1, Box<T> { x }))
     │                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Invalid call to '0x8675309::M::f'
-    ·
- 11 │         unbox<T>(f<Box<T>>(n - 1, Box<T> { x }))
     │                    ------ The type parameter 'f::T' was instantiated with the type '0x8675309::M::Box<T>', which contains the type parameter 'f::T'. This recursive call causes the instantiation to recurse infinitely
     │
 

--- a/language/move-lang/tests/move_check/translated_ir_tests/generics/instantiation_loops/recursive_one_arg_type_con.exp
+++ b/language/move-lang/tests/move_check/translated_ir_tests/generics/instantiation_loops/recursive_one_arg_type_con.exp
@@ -4,8 +4,6 @@ error:
    │
  7 │         f<S<T>>(S<T> { b: true })
    │         ^^^^^^^^^^^^^^^^^^^^^^^^^ Invalid call to '0x8675309::M::f'
-   ·
- 7 │         f<S<T>>(S<T> { b: true })
    │           ---- The type parameter 'f::T' was instantiated with the type '0x8675309::M::S<T>', which contains the type parameter 'f::T'. This recursive call causes the instantiation to recurse infinitely
    │
 

--- a/language/move-lang/tests/move_check/translated_ir_tests/generics/instantiation_loops/recursive_struct.exp
+++ b/language/move-lang/tests/move_check/translated_ir_tests/generics/instantiation_loops/recursive_struct.exp
@@ -3,10 +3,8 @@ error:
    ┌── tests/move_check/translated_ir_tests/generics/instantiation_loops/recursive_struct.move:4:21 ───
    │
  4 │     struct Foo { f: Foo }
-   │                     ^^^ Invalid field containing 'Foo' in struct 'Foo'.
-   ·
- 4 │     struct Foo { f: Foo }
    │                     --- Using this struct creates a cycle: 'Foo' contains 'Foo'
+   │                     ^^^ Invalid field containing 'Foo' in struct 'Foo'.
    │
 
 error: 
@@ -14,10 +12,8 @@ error:
     ┌── tests/move_check/translated_ir_tests/generics/instantiation_loops/recursive_struct.move:10:25 ───
     │
  10 │     struct Foo { f: Cup<Foo> }
-    │                         ^^^ Invalid field containing 'Foo' in struct 'Foo'.
-    ·
- 10 │     struct Foo { f: Cup<Foo> }
     │                         --- Using this struct creates a cycle: 'Foo' contains 'Foo'
+    │                         ^^^ Invalid field containing 'Foo' in struct 'Foo'.
     │
 
 error: 
@@ -25,21 +21,19 @@ error:
     ┌── tests/move_check/translated_ir_tests/generics/instantiation_loops/recursive_struct.move:20:35 ───
     │
  20 │     resource struct X { y: vector<Y> }
-    │                                   ^ Invalid field containing 'Y' in struct 'X'.
-    ·
- 20 │     resource struct X { y: vector<Y> }
     │                                   - Using this struct creates a cycle: 'Y' contains 'X' contains 'Y'
+    │                                   ^ Invalid field containing 'Y' in struct 'X'.
     │
 
 error: 
 
-    ┌── tests/move_check/translated_ir_tests/generics/instantiation_loops/recursive_struct.move:41:8 ───
+    ┌── tests/move_check/translated_ir_tests/generics/instantiation_loops/recursive_struct.move:34:8 ───
     │
- 41 │ module M3 {
-    │        ^^ Duplicate definition for module '0x42::M3'
-    ·
  34 │ module M3 {
     │        -- Previously defined here
+    ·
+ 41 │ module M3 {
+    │        ^^ Duplicate definition for module '0x42::M3'
     │
 
 error: 
@@ -47,9 +41,7 @@ error:
     ┌── tests/move_check/translated_ir_tests/generics/instantiation_loops/recursive_struct.move:46:26 ───
     │
  46 │     struct C { d: vector<D> }
-    │                          ^ Invalid field containing 'D' in struct 'C'.
-    ·
- 46 │     struct C { d: vector<D> }
     │                          - Using this struct creates a cycle: 'D' contains 'A' contains 'B' contains 'C' contains 'D'
+    │                          ^ Invalid field containing 'D' in struct 'C'.
     │
 

--- a/language/move-lang/tests/move_check/translated_ir_tests/generics/instantiation_loops/recursive_two_args_swapping_type_con.exp
+++ b/language/move-lang/tests/move_check/translated_ir_tests/generics/instantiation_loops/recursive_two_args_swapping_type_con.exp
@@ -3,15 +3,9 @@ error:
    ┌── tests/move_check/translated_ir_tests/generics/instantiation_loops/recursive_two_args_swapping_type_con.move:8:9 ───
    │
  8 │         f<S<T2>, T1>(S<T2> { x }, a)
-   │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Invalid call to '0x8675309::M::f'
-   ·
- 8 │         f<S<T2>, T1>(S<T2> { x }, a)
-   │           ----- The type parameter 'f::T1' was instantiated with the type '0x8675309::M::S<T2>', which contains the type parameter 'f::T2'. These mutually recursive calls causes the instantiation to recurse infinitely
-   ·
- 8 │         f<S<T2>, T1>(S<T2> { x }, a)
    │         ---------------------------- 'f<f::T1, _>' calls 'f<_, f::T1>'
-   ·
- 8 │         f<S<T2>, T1>(S<T2> { x }, a)
    │         ---------------------------- 'f<_, f::T1>' calls 'f<0x8675309::M::S<f::T1>, _>'
+   │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Invalid call to '0x8675309::M::f'
+   │           ----- The type parameter 'f::T1' was instantiated with the type '0x8675309::M::S<T2>', which contains the type parameter 'f::T2'. These mutually recursive calls causes the instantiation to recurse infinitely
    │
 

--- a/language/move-lang/tests/move_check/translated_ir_tests/generics/instantiation_loops/two_loops.exp
+++ b/language/move-lang/tests/move_check/translated_ir_tests/generics/instantiation_loops/two_loops.exp
@@ -4,8 +4,6 @@ error:
    │
  8 │         f<S<T>>()
    │         ^^^^^^^^^ Invalid call to '0x8675309::M::f'
-   ·
- 8 │         f<S<T>>()
    │           ---- The type parameter 'f::T' was instantiated with the type '0x8675309::M::S<T>', which contains the type parameter 'f::T'. This recursive call causes the instantiation to recurse infinitely
    │
 
@@ -15,8 +13,6 @@ error:
     │
  12 │         g<S<T>>()
     │         ^^^^^^^^^ Invalid call to '0x8675309::M::g'
-    ·
- 12 │         g<S<T>>()
     │           ---- The type parameter 'g::T' was instantiated with the type '0x8675309::M::S<T>', which contains the type parameter 'g::T'. This recursive call causes the instantiation to recurse infinitely
     │
 

--- a/language/move-lang/tests/move_check/typing/assign_duplicate_assigning.exp
+++ b/language/move-lang/tests/move_check/typing/assign_duplicate_assigning.exp
@@ -1,12 +1,19 @@
 error: 
 
-   ┌── tests/move_check/typing/assign_duplicate_assigning.move:6:13 ───
+   ┌── tests/move_check/typing/assign_duplicate_assigning.move:6:10 ───
    │
  6 │         (x, x) = (0, 0);
-   │             ^ Duplicate usage of local 'x' in a given assignment
-   ·
- 6 │         (x, x) = (0, 0);
    │          - Previously assigned here
+   │             ^ Duplicate usage of local 'x' in a given assignment
+   │
+
+error: 
+
+   ┌── tests/move_check/typing/assign_duplicate_assigning.move:8:10 ───
+   │
+ 8 │         (f, R{f}, f) = (0, R { f: 0 }, 0);
+   │          - Previously assigned here
+   │               ^ Duplicate usage of local 'f' in a given assignment
    │
 
 error: 
@@ -14,20 +21,7 @@ error:
    ┌── tests/move_check/typing/assign_duplicate_assigning.move:8:15 ───
    │
  8 │         (f, R{f}, f) = (0, R { f: 0 }, 0);
-   │               ^ Duplicate usage of local 'f' in a given assignment
-   ·
- 8 │         (f, R{f}, f) = (0, R { f: 0 }, 0);
-   │          - Previously assigned here
-   │
-
-error: 
-
-   ┌── tests/move_check/typing/assign_duplicate_assigning.move:8:19 ───
-   │
- 8 │         (f, R{f}, f) = (0, R { f: 0 }, 0);
-   │                   ^ Duplicate usage of local 'f' in a given assignment
-   ·
- 8 │         (f, R{f}, f) = (0, R { f: 0 }, 0);
    │               - Previously assigned here
+   │                   ^ Duplicate usage of local 'f' in a given assignment
    │
 

--- a/language/move-lang/tests/move_check/typing/assign_pop_resource.exp
+++ b/language/move-lang/tests/move_check/typing/assign_pop_resource.exp
@@ -1,42 +1,36 @@
 error: 
 
-   ┌── tests/move_check/typing/assign_pop_resource.move:5:9 ───
+   ┌── tests/move_check/typing/assign_pop_resource.move:2:5 ───
    │
+ 2 │     resource struct R {}
+   │     -------- Is found to be a non-copyable type here
+   ·
  5 │         _ = R{};
    │         ^ Cannot ignore resource values. The value must be used
-   ·
- 5 │         _ = R{};
    │             --- The type: '0x8675309::M::R'
-   ·
- 2 │     resource struct R {}
-   │     -------- Is found to be a non-copyable type here
    │
 
 error: 
 
-   ┌── tests/move_check/typing/assign_pop_resource.move:6:10 ───
+   ┌── tests/move_check/typing/assign_pop_resource.move:2:5 ───
    │
+ 2 │     resource struct R {}
+   │     -------- Is found to be a non-copyable type here
+   ·
  6 │         (_, _) = (R{}, R{});
    │          ^ Cannot ignore resource values. The value must be used
-   ·
- 6 │         (_, _) = (R{}, R{});
    │                   --- The type: '0x8675309::M::R'
-   ·
- 2 │     resource struct R {}
-   │     -------- Is found to be a non-copyable type here
    │
 
 error: 
 
-   ┌── tests/move_check/typing/assign_pop_resource.move:6:13 ───
+   ┌── tests/move_check/typing/assign_pop_resource.move:2:5 ───
    │
- 6 │         (_, _) = (R{}, R{});
-   │             ^ Cannot ignore resource values. The value must be used
-   ·
- 6 │         (_, _) = (R{}, R{});
-   │                        --- The type: '0x8675309::M::R'
-   ·
  2 │     resource struct R {}
    │     -------- Is found to be a non-copyable type here
+   ·
+ 6 │         (_, _) = (R{}, R{});
+   │             ^ Cannot ignore resource values. The value must be used
+   │                        --- The type: '0x8675309::M::R'
    │
 

--- a/language/move-lang/tests/move_check/typing/assign_unpack_references_invalid.exp
+++ b/language/move-lang/tests/move_check/typing/assign_unpack_references_invalid.exp
@@ -1,84 +1,69 @@
 error: 
 
-   ┌── tests/move_check/typing/assign_unpack_references_invalid.move:9:9 ───
+   ┌── tests/move_check/typing/assign_unpack_references_invalid.move:8:21 ───
    │
- 9 │         f = 0;
-   │         ^ Invalid assignment to local 'f'
-   ·
- 9 │         f = 0;
-   │         - The type: integer
-   ·
  8 │         R { s1: S { f }, s2 } = &R { s1: S{f: 0}, s2: S{f: 1} };
    │                     - Is not compatible with: '&u64'
+ 9 │         f = 0;
+   │         - The type: integer
+   │         ^ Invalid assignment to local 'f'
    │
 
 error: 
 
-    ┌── tests/move_check/typing/assign_unpack_references_invalid.move:10:9 ───
+    ┌── tests/move_check/typing/assign_unpack_references_invalid.move:8:26 ───
     │
- 10 │         s2 = S { f: 0 }
-    │         ^^ Invalid assignment to local 's2'
-    ·
- 10 │         s2 = S { f: 0 }
-    │              ---------- The type: '0x8675309::M::S'
-    ·
   8 │         R { s1: S { f }, s2 } = &R { s1: S{f: 0}, s2: S{f: 1} };
     │                          -- Is not compatible with: '&0x8675309::M::S'
+  9 │         f = 0;
+ 10 │         s2 = S { f: 0 }
+    │         ^^ Invalid assignment to local 's2'
+    │              ---------- The type: '0x8675309::M::S'
     │
 
 error: 
 
-    ┌── tests/move_check/typing/assign_unpack_references_invalid.move:17:9 ───
+    ┌── tests/move_check/typing/assign_unpack_references_invalid.move:16:21 ───
     │
- 17 │         f = 0;
-    │         ^ Invalid assignment to local 'f'
-    ·
- 17 │         f = 0;
-    │         - The type: integer
-    ·
  16 │         R { s1: S { f }, s2 } = &mut R { s1: S{f: 0}, s2: S{f: 1} };
     │                     - Is not compatible with: '&mut u64'
+ 17 │         f = 0;
+    │         - The type: integer
+    │         ^ Invalid assignment to local 'f'
     │
 
 error: 
 
-    ┌── tests/move_check/typing/assign_unpack_references_invalid.move:18:9 ───
+    ┌── tests/move_check/typing/assign_unpack_references_invalid.move:16:26 ───
     │
- 18 │         s2 = S { f: 0 }
-    │         ^^ Invalid assignment to local 's2'
-    ·
- 18 │         s2 = S { f: 0 }
-    │              ---------- The type: '0x8675309::M::S'
-    ·
  16 │         R { s1: S { f }, s2 } = &mut R { s1: S{f: 0}, s2: S{f: 1} };
     │                          -- Is not compatible with: '&mut 0x8675309::M::S'
+ 17 │         f = 0;
+ 18 │         s2 = S { f: 0 }
+    │         ^^ Invalid assignment to local 's2'
+    │              ---------- The type: '0x8675309::M::S'
     │
 
 error: 
 
-    ┌── tests/move_check/typing/assign_unpack_references_invalid.move:26:9 ───
+    ┌── tests/move_check/typing/assign_unpack_references_invalid.move:25:21 ───
     │
- 26 │         f = &0;
-    │         ^ Invalid assignment to local 'f'
-    ·
- 26 │         f = &0;
-    │             -- The type: '&{integer}'
-    ·
  25 │         R { s1: S { f }, s2 } = &mut R { s1: S{f: 0}, s2: S{f: 1} };
     │                     - Is not a subtype of: '&mut u64'
+ 26 │         f = &0;
+    │         ^ Invalid assignment to local 'f'
+    │             -- The type: '&{integer}'
     │
 
 error: 
 
-    ┌── tests/move_check/typing/assign_unpack_references_invalid.move:27:9 ───
+    ┌── tests/move_check/typing/assign_unpack_references_invalid.move:25:26 ───
     │
- 27 │         s2 = &S { f: 0 }
-    │         ^^ Invalid assignment to local 's2'
-    ·
- 27 │         s2 = &S { f: 0 }
-    │              ----------- The type: '&0x8675309::M::S'
-    ·
  25 │         R { s1: S { f }, s2 } = &mut R { s1: S{f: 0}, s2: S{f: 1} };
     │                          -- Is not a subtype of: '&mut 0x8675309::M::S'
+ 26 │         f = &0;
+ 27 │         s2 = &S { f: 0 }
+    │         ^^ Invalid assignment to local 's2'
+    │              ----------- The type: '&0x8675309::M::S'
     │
 

--- a/language/move-lang/tests/move_check/typing/assign_wrong_arity.exp
+++ b/language/move-lang/tests/move_check/typing/assign_wrong_arity.exp
@@ -4,7 +4,6 @@ error:
    │
  5 │         let x;
    │             ^ Invalid type for local
-   ·
  6 │         x = ();
    │             -- Expected a single type, but found expression list type: '()'
    │
@@ -15,23 +14,18 @@ error:
    │
  6 │         x = ();
    │         ^ Invalid type for local
-   ·
- 6 │         x = ();
    │             -- Expected a single type, but found expression list type: '()'
    │
 
 error: 
 
-   ┌── tests/move_check/typing/assign_wrong_arity.move:7:9 ───
+   ┌── tests/move_check/typing/assign_wrong_arity.move:6:13 ───
    │
- 7 │         x = (0, 1, 2);
-   │         ^ Invalid assignment to local 'x'
-   ·
- 7 │         x = (0, 1, 2);
-   │             --------- The type: '({integer}, {integer}, {integer})'
-   ·
  6 │         x = ();
    │             -- Is not compatible with: '()'
+ 7 │         x = (0, 1, 2);
+   │         ^ Invalid assignment to local 'x'
+   │             --------- The type: '({integer}, {integer}, {integer})'
    │
 
 error: 
@@ -40,8 +34,6 @@ error:
    │
  7 │         x = (0, 1, 2);
    │         ^ Invalid type for local
-   ·
- 7 │         x = (0, 1, 2);
    │             --------- Expected a single type, but found expression list type: '(u64, u64, u64)'
    │
 
@@ -50,13 +42,9 @@ error:
    ┌── tests/move_check/typing/assign_wrong_arity.move:8:9 ───
    │
  8 │         () = 0;
-   │         ^^ Invalid value for assignment
-   ·
- 8 │         () = 0;
-   │              - The type: integer
-   ·
- 8 │         () = 0;
    │         -- Is not compatible with: '()'
+   │         ^^ Invalid value for assignment
+   │              - The type: integer
    │
 
 error: 
@@ -64,12 +52,8 @@ error:
     ┌── tests/move_check/typing/assign_wrong_arity.move:11:9 ───
     │
  11 │         (x, b, R{f}) = (0, false, R{f: 0}, R{f: 0});
-    │         ^^^^^^^^^^^^ Invalid value for assignment
-    ·
- 11 │         (x, b, R{f}) = (0, false, R{f: 0}, R{f: 0});
     │         ------------ The expression list type of length 3: '(_, _, _)'
-    ·
- 11 │         (x, b, R{f}) = (0, false, R{f: 0}, R{f: 0});
+    │         ^^^^^^^^^^^^ Invalid value for assignment
     │                        ---------------------------- Is not compatible with the expression list type of length 4: '({integer}, bool, 0x8675309::M::R, 0x8675309::M::R)'
     │
 
@@ -78,12 +62,8 @@ error:
     ┌── tests/move_check/typing/assign_wrong_arity.move:12:9 ───
     │
  12 │         (x, b, R{f}) = (0, false);
-    │         ^^^^^^^^^^^^ Invalid value for assignment
-    ·
- 12 │         (x, b, R{f}) = (0, false);
     │         ------------ The expression list type of length 3: '(_, _, _)'
-    ·
- 12 │         (x, b, R{f}) = (0, false);
+    │         ^^^^^^^^^^^^ Invalid value for assignment
     │                        ---------- Is not compatible with the expression list type of length 2: '({integer}, bool)'
     │
 

--- a/language/move-lang/tests/move_check/typing/assign_wrong_type.exp
+++ b/language/move-lang/tests/move_check/typing/assign_wrong_type.exp
@@ -3,12 +3,8 @@ error:
    ┌── tests/move_check/typing/assign_wrong_type.move:8:9 ───
    │
  8 │         S { g } = R {f :0};
-   │         ^^^^^^^ Invalid deconstruction assignment
-   ·
- 8 │         S { g } = R {f :0};
    │         ------- The type: '0x8675309::M::S'
-   ·
- 8 │         S { g } = R {f :0};
+   │         ^^^^^^^ Invalid deconstruction assignment
    │                   -------- Is not compatible with: '0x8675309::M::R'
    │
 
@@ -17,12 +13,8 @@ error:
    ┌── tests/move_check/typing/assign_wrong_type.move:9:10 ───
    │
  9 │         (S { g }, R { f }) = (R{ f: 0 }, R{ f: 1 });
-   │          ^^^^^^^ Invalid deconstruction assignment
-   ·
- 9 │         (S { g }, R { f }) = (R{ f: 0 }, R{ f: 1 });
    │          ------- The type: '0x8675309::M::S'
-   ·
- 9 │         (S { g }, R { f }) = (R{ f: 0 }, R{ f: 1 });
+   │          ^^^^^^^ Invalid deconstruction assignment
    │                               --------- Is not compatible with: '0x8675309::M::R'
    │
 
@@ -43,8 +35,6 @@ error:
     │
  16 │         x = ();
     │         ^ Invalid type for local
-    ·
- 16 │         x = ();
     │             -- Expected a single type, but found expression list type: '()'
     │
 
@@ -53,13 +43,9 @@ error:
     ┌── tests/move_check/typing/assign_wrong_type.move:17:9 ───
     │
  17 │         () = 0;
-    │         ^^ Invalid value for assignment
-    ·
- 17 │         () = 0;
-    │              - The type: integer
-    ·
- 17 │         () = 0;
     │         -- Is not compatible with: '()'
+    │         ^^ Invalid value for assignment
+    │              - The type: integer
     │
 
 error: 
@@ -67,12 +53,8 @@ error:
     ┌── tests/move_check/typing/assign_wrong_type.move:18:9 ───
     │
  18 │         (x, b, R{f}) = (0, false, R{f: 0}, R{f: 0});
-    │         ^^^^^^^^^^^^ Invalid value for assignment
-    ·
- 18 │         (x, b, R{f}) = (0, false, R{f: 0}, R{f: 0});
     │         ------------ The expression list type of length 3: '(_, _, _)'
-    ·
- 18 │         (x, b, R{f}) = (0, false, R{f: 0}, R{f: 0});
+    │         ^^^^^^^^^^^^ Invalid value for assignment
     │                        ---------------------------- Is not compatible with the expression list type of length 4: '({integer}, bool, 0x8675309::M::R, 0x8675309::M::R)'
     │
 
@@ -81,68 +63,57 @@ error:
     ┌── tests/move_check/typing/assign_wrong_type.move:19:9 ───
     │
  19 │         (x, b, R{f}) = (0, false);
-    │         ^^^^^^^^^^^^ Invalid value for assignment
-    ·
- 19 │         (x, b, R{f}) = (0, false);
     │         ------------ The expression list type of length 3: '(_, _, _)'
-    ·
- 19 │         (x, b, R{f}) = (0, false);
+    │         ^^^^^^^^^^^^ Invalid value for assignment
     │                        ---------- Is not compatible with the expression list type of length 2: '({integer}, bool)'
     │
 
 error: 
 
-    ┌── tests/move_check/typing/assign_wrong_type.move:27:10 ───
+    ┌── tests/move_check/typing/assign_wrong_type.move:23:17 ───
     │
- 27 │         (x, b, R{f}, r) = (0, false, R{f: 0}, R{f: 0});
-    │          ^ Invalid assignment to local 'x'
+ 23 │         let x = false;
+    │                 ----- Is not compatible with: 'bool'
     ·
  27 │         (x, b, R{f}, r) = (0, false, R{f: 0}, R{f: 0});
     │          - The type: integer
-    ·
- 23 │         let x = false;
-    │                 ----- Is not compatible with: 'bool'
+    │          ^ Invalid assignment to local 'x'
     │
 
 error: 
 
-    ┌── tests/move_check/typing/assign_wrong_type.move:27:13 ───
+    ┌── tests/move_check/typing/assign_wrong_type.move:24:13 ───
     │
- 27 │         (x, b, R{f}, r) = (0, false, R{f: 0}, R{f: 0});
-    │             ^ Invalid assignment to local 'b'
-    ·
  24 │         let b = 0;
     │             - The type: integer
     ·
  27 │         (x, b, R{f}, r) = (0, false, R{f: 0}, R{f: 0});
+    │             ^ Invalid assignment to local 'b'
     │                               ----- Is not compatible with: 'bool'
     │
 
 error: 
 
-    ┌── tests/move_check/typing/assign_wrong_type.move:27:18 ───
+    ┌── tests/move_check/typing/assign_wrong_type.move:2:27 ───
     │
- 27 │         (x, b, R{f}, r) = (0, false, R{f: 0}, R{f: 0});
-    │                  ^ Invalid assignment to local 'f'
-    ·
   2 │     resource struct R {f: u64}
     │                           --- The type: 'u64'
     ·
  25 │         let f = 0x0;
     │                 --- Is not compatible with: 'address'
+ 26 │         let r = S{ g: 0 };
+ 27 │         (x, b, R{f}, r) = (0, false, R{f: 0}, R{f: 0});
+    │                  ^ Invalid assignment to local 'f'
     │
 
 error: 
 
-    ┌── tests/move_check/typing/assign_wrong_type.move:27:22 ───
+    ┌── tests/move_check/typing/assign_wrong_type.move:26:17 ───
     │
- 27 │         (x, b, R{f}, r) = (0, false, R{f: 0}, R{f: 0});
-    │                      ^ Invalid assignment to local 'r'
-    ·
- 27 │         (x, b, R{f}, r) = (0, false, R{f: 0}, R{f: 0});
-    │                                               ------- The type: '0x8675309::M::R'
-    ·
  26 │         let r = S{ g: 0 };
     │                 --------- Is not compatible with: '0x8675309::M::S'
+ 27 │         (x, b, R{f}, r) = (0, false, R{f: 0}, R{f: 0});
+    │                      ^ Invalid assignment to local 'r'
+    │                                               ------- The type: '0x8675309::M::R'
     │
 

--- a/language/move-lang/tests/move_check/typing/binary_add_invalid.exp
+++ b/language/move-lang/tests/move_check/typing/binary_add_invalid.exp
@@ -3,35 +3,27 @@ error:
    ┌── tests/move_check/typing/binary_add_invalid.move:8:9 ───
    │
  8 │         false + true;
+   │         ----- Found: 'bool'. But expected: 'u8', 'u64', 'u128'
    │         ^^^^^ Invalid argument to '+'
-   ·
- 8 │         false + true;
-   │         ----- Found: 'bool'. But expected: 'u8', 'u64', 'u128'
    │
 
 error: 
 
-   ┌── tests/move_check/typing/binary_add_invalid.move:8:17 ───
+   ┌── tests/move_check/typing/binary_add_invalid.move:8:9 ───
    │
  8 │         false + true;
+   │         ----- Found: 'bool'. But expected: 'u8', 'u64', 'u128'
    │                 ^^^^ Invalid argument to '+'
-   ·
- 8 │         false + true;
-   │         ----- Found: 'bool'. But expected: 'u8', 'u64', 'u128'
    │
 
 error: 
 
-   ┌── tests/move_check/typing/binary_add_invalid.move:9:13 ───
+   ┌── tests/move_check/typing/binary_add_invalid.move:9:9 ───
    │
- 9 │         1 + false;
-   │             ^^^^^ Incompatible arguments to '+'
-   ·
  9 │         1 + false;
    │         - The type: integer
-   ·
- 9 │         1 + false;
    │             ----- Is not compatible with: 'bool'
+   │             ^^^^^ Incompatible arguments to '+'
    │
 
 error: 
@@ -39,35 +31,27 @@ error:
     ┌── tests/move_check/typing/binary_add_invalid.move:10:9 ───
     │
  10 │         false + 1;
-    │         ^^^^^ Invalid argument to '+'
-    ·
- 10 │         false + 1;
     │         ----- Found: 'bool'. But expected: 'u8', 'u64', 'u128'
+    │         ^^^^^ Invalid argument to '+'
     │
 
 error: 
 
-    ┌── tests/move_check/typing/binary_add_invalid.move:10:17 ───
+    ┌── tests/move_check/typing/binary_add_invalid.move:10:9 ───
     │
- 10 │         false + 1;
-    │                 ^ Incompatible arguments to '+'
-    ·
- 10 │         false + 1;
-    │                 - The type: integer
-    ·
  10 │         false + 1;
     │         ----- Is not compatible with: 'bool'
+    │                 - The type: integer
+    │                 ^ Incompatible arguments to '+'
     │
 
 error: 
 
-    ┌── tests/move_check/typing/binary_add_invalid.move:10:17 ───
+    ┌── tests/move_check/typing/binary_add_invalid.move:10:9 ───
     │
  10 │         false + 1;
-    │                 ^ Invalid argument to '+'
-    ·
- 10 │         false + 1;
     │         ----- Found: 'bool'. But expected: 'u8', 'u64', 'u128'
+    │                 ^ Invalid argument to '+'
     │
 
 error: 
@@ -75,93 +59,85 @@ error:
     ┌── tests/move_check/typing/binary_add_invalid.move:11:9 ───
     │
  11 │         0x0 + 0x1;
+    │         --- Found: 'address'. But expected: 'u8', 'u64', 'u128'
     │         ^^^ Invalid argument to '+'
-    ·
- 11 │         0x0 + 0x1;
-    │         --- Found: 'address'. But expected: 'u8', 'u64', 'u128'
     │
 
 error: 
 
-    ┌── tests/move_check/typing/binary_add_invalid.move:11:15 ───
+    ┌── tests/move_check/typing/binary_add_invalid.move:11:9 ───
     │
  11 │         0x0 + 0x1;
+    │         --- Found: 'address'. But expected: 'u8', 'u64', 'u128'
     │               ^^^ Invalid argument to '+'
-    ·
- 11 │         0x0 + 0x1;
-    │         --- Found: 'address'. But expected: 'u8', 'u64', 'u128'
     │
 
 error: 
 
-    ┌── tests/move_check/typing/binary_add_invalid.move:12:19 ───
+    ┌── tests/move_check/typing/binary_add_invalid.move:12:13 ───
     │
- 12 │         (0: u8) + (1: u128);
-    │                   ^^^^^^^^^ Incompatible arguments to '+'
-    ·
  12 │         (0: u8) + (1: u128);
     │             -- The type: 'u8'
-    ·
- 12 │         (0: u8) + (1: u128);
+    │                   ^^^^^^^^^ Incompatible arguments to '+'
     │                       ---- Is not compatible with: 'u128'
     │
 
 error: 
 
-    ┌── tests/move_check/typing/binary_add_invalid.move:13:9 ───
+    ┌── tests/move_check/typing/binary_add_invalid.move:7:23 ───
     │
- 13 │         r + r;
-    │         ^ Invalid argument to '+'
-    ·
   7 │     fun t0(x: u64, r: R, s: S) {
     │                       - Found: '0x8675309::M::R'. But expected: 'u8', 'u64', 'u128'
+    ·
+ 13 │         r + r;
+    │         ^ Invalid argument to '+'
     │
 
 error: 
 
-    ┌── tests/move_check/typing/binary_add_invalid.move:13:9 ───
+    ┌── tests/move_check/typing/binary_add_invalid.move:3:5 ───
     │
- 13 │         r + r;
-    │         ^^^^^ Cannot ignore resource values. The value must be used
+  3 │     resource struct R {
+    │     -------- Is found to be a non-copyable type here
     ·
   7 │     fun t0(x: u64, r: R, s: S) {
     │                       - The type: '0x8675309::M::R'
     ·
-  3 │     resource struct R {
-    │     -------- Is found to be a non-copyable type here
+ 13 │         r + r;
+    │         ^^^^^ Cannot ignore resource values. The value must be used
     │
 
 error: 
 
-    ┌── tests/move_check/typing/binary_add_invalid.move:13:13 ───
+    ┌── tests/move_check/typing/binary_add_invalid.move:7:23 ───
     │
- 13 │         r + r;
-    │             ^ Invalid argument to '+'
-    ·
   7 │     fun t0(x: u64, r: R, s: S) {
     │                       - Found: '0x8675309::M::R'. But expected: 'u8', 'u64', 'u128'
+    ·
+ 13 │         r + r;
+    │             ^ Invalid argument to '+'
     │
 
 error: 
 
-    ┌── tests/move_check/typing/binary_add_invalid.move:14:9 ───
+    ┌── tests/move_check/typing/binary_add_invalid.move:7:29 ───
     │
+  7 │     fun t0(x: u64, r: R, s: S) {
+    │                             - Found: '0x8675309::M::S'. But expected: 'u8', 'u64', 'u128'
+    ·
  14 │         s + s;
     │         ^ Invalid argument to '+'
-    ·
-  7 │     fun t0(x: u64, r: R, s: S) {
-    │                             - Found: '0x8675309::M::S'. But expected: 'u8', 'u64', 'u128'
     │
 
 error: 
 
-    ┌── tests/move_check/typing/binary_add_invalid.move:14:13 ───
+    ┌── tests/move_check/typing/binary_add_invalid.move:7:29 ───
     │
- 14 │         s + s;
-    │             ^ Invalid argument to '+'
-    ·
   7 │     fun t0(x: u64, r: R, s: S) {
     │                             - Found: '0x8675309::M::S'. But expected: 'u8', 'u64', 'u128'
+    ·
+ 14 │         s + s;
+    │             ^ Invalid argument to '+'
     │
 
 error: 
@@ -170,8 +146,6 @@ error:
     │
  15 │         1 + false + 0x0 + 0;
     │         ^^^^^^^^^ Invalid argument to '+'
-    ·
- 15 │         1 + false + 0x0 + 0;
     │             ----- Found: '_'. But expected: 'u8', 'u64', 'u128'
     │
 
@@ -181,9 +155,17 @@ error:
     │
  15 │         1 + false + 0x0 + 0;
     │         ^^^^^^^^^^^^^^^ Invalid argument to '+'
-    ·
- 15 │         1 + false + 0x0 + 0;
     │                     --- Found: 'address'. But expected: 'u8', 'u64', 'u128'
+    │
+
+error: 
+
+    ┌── tests/move_check/typing/binary_add_invalid.move:15:9 ───
+    │
+ 15 │         1 + false + 0x0 + 0;
+    │         - The type: integer
+    │             ----- Is not compatible with: 'bool'
+    │             ^^^^^ Incompatible arguments to '+'
     │
 
 error: 
@@ -191,13 +173,8 @@ error:
     ┌── tests/move_check/typing/binary_add_invalid.move:15:13 ───
     │
  15 │         1 + false + 0x0 + 0;
-    │             ^^^^^ Incompatible arguments to '+'
-    ·
- 15 │         1 + false + 0x0 + 0;
-    │         - The type: integer
-    ·
- 15 │         1 + false + 0x0 + 0;
-    │             ----- Is not compatible with: 'bool'
+    │             ----- Found: '_'. But expected: 'u8', 'u64', 'u128'
+    │                     ^^^ Invalid argument to '+'
     │
 
 error: 
@@ -205,35 +182,18 @@ error:
     ┌── tests/move_check/typing/binary_add_invalid.move:15:21 ───
     │
  15 │         1 + false + 0x0 + 0;
-    │                     ^^^ Invalid argument to '+'
-    ·
- 15 │         1 + false + 0x0 + 0;
-    │             ----- Found: '_'. But expected: 'u8', 'u64', 'u128'
-    │
-
-error: 
-
-    ┌── tests/move_check/typing/binary_add_invalid.move:15:27 ───
-    │
- 15 │         1 + false + 0x0 + 0;
-    │                           ^ Incompatible arguments to '+'
-    ·
- 15 │         1 + false + 0x0 + 0;
-    │                           - The type: integer
-    ·
- 15 │         1 + false + 0x0 + 0;
     │                     --- Is not compatible with: 'address'
+    │                           - The type: integer
+    │                           ^ Incompatible arguments to '+'
     │
 
 error: 
 
-    ┌── tests/move_check/typing/binary_add_invalid.move:15:27 ───
+    ┌── tests/move_check/typing/binary_add_invalid.move:15:21 ───
     │
- 15 │         1 + false + 0x0 + 0;
-    │                           ^ Invalid argument to '+'
-    ·
  15 │         1 + false + 0x0 + 0;
     │                     --- Found: 'address'. But expected: 'u8', 'u64', 'u128'
+    │                           ^ Invalid argument to '+'
     │
 
 error: 
@@ -241,35 +201,27 @@ error:
     ┌── tests/move_check/typing/binary_add_invalid.move:16:9 ───
     │
  16 │         () + ();
+    │         -- Found: '()'. But expected: 'u8', 'u64', 'u128'
     │         ^^ Invalid argument to '+'
-    ·
- 16 │         () + ();
-    │         -- Found: '()'. But expected: 'u8', 'u64', 'u128'
     │
 
 error: 
 
-    ┌── tests/move_check/typing/binary_add_invalid.move:16:14 ───
+    ┌── tests/move_check/typing/binary_add_invalid.move:16:9 ───
     │
  16 │         () + ();
+    │         -- Found: '()'. But expected: 'u8', 'u64', 'u128'
     │              ^^ Invalid argument to '+'
-    ·
- 16 │         () + ();
-    │         -- Found: '()'. But expected: 'u8', 'u64', 'u128'
     │
 
 error: 
 
-    ┌── tests/move_check/typing/binary_add_invalid.move:17:13 ───
+    ┌── tests/move_check/typing/binary_add_invalid.move:17:9 ───
     │
- 17 │         1 + ();
-    │             ^^ Incompatible arguments to '+'
-    ·
  17 │         1 + ();
     │         - The type: integer
-    ·
- 17 │         1 + ();
     │             -- Is not compatible with: '()'
+    │             ^^ Incompatible arguments to '+'
     │
 
 error: 
@@ -277,35 +229,27 @@ error:
     ┌── tests/move_check/typing/binary_add_invalid.move:18:9 ───
     │
  18 │         (0, 1) + (0, 1, 2);
-    │         ^^^^^^ Invalid argument to '+'
-    ·
- 18 │         (0, 1) + (0, 1, 2);
     │         ------ Found: '(u64, u64)'. But expected: 'u8', 'u64', 'u128'
+    │         ^^^^^^ Invalid argument to '+'
     │
 
 error: 
 
-    ┌── tests/move_check/typing/binary_add_invalid.move:18:18 ───
+    ┌── tests/move_check/typing/binary_add_invalid.move:18:9 ───
     │
- 18 │         (0, 1) + (0, 1, 2);
-    │                  ^^^^^^^^^ Incompatible arguments to '+'
-    ·
  18 │         (0, 1) + (0, 1, 2);
     │         ------ The expression list type of length 2: '({integer}, {integer})'
-    ·
- 18 │         (0, 1) + (0, 1, 2);
     │                  --------- Is not compatible with the expression list type of length 3: '({integer}, {integer}, {integer})'
+    │                  ^^^^^^^^^ Incompatible arguments to '+'
     │
 
 error: 
 
-    ┌── tests/move_check/typing/binary_add_invalid.move:18:18 ───
+    ┌── tests/move_check/typing/binary_add_invalid.move:18:9 ───
     │
  18 │         (0, 1) + (0, 1, 2);
-    │                  ^^^^^^^^^ Invalid argument to '+'
-    ·
- 18 │         (0, 1) + (0, 1, 2);
     │         ------ Found: '(u64, u64)'. But expected: 'u8', 'u64', 'u128'
+    │                  ^^^^^^^^^ Invalid argument to '+'
     │
 
 error: 
@@ -313,20 +257,16 @@ error:
     ┌── tests/move_check/typing/binary_add_invalid.move:19:9 ───
     │
  19 │         (1, 2) + (0, 1);
-    │         ^^^^^^ Invalid argument to '+'
-    ·
- 19 │         (1, 2) + (0, 1);
     │         ------ Found: '(u64, u64)'. But expected: 'u8', 'u64', 'u128'
+    │         ^^^^^^ Invalid argument to '+'
     │
 
 error: 
 
-    ┌── tests/move_check/typing/binary_add_invalid.move:19:18 ───
+    ┌── tests/move_check/typing/binary_add_invalid.move:19:9 ───
     │
  19 │         (1, 2) + (0, 1);
-    │                  ^^^^^^ Invalid argument to '+'
-    ·
- 19 │         (1, 2) + (0, 1);
     │         ------ Found: '(u64, u64)'. But expected: 'u8', 'u64', 'u128'
+    │                  ^^^^^^ Invalid argument to '+'
     │
 

--- a/language/move-lang/tests/move_check/typing/binary_and_invalid.exp
+++ b/language/move-lang/tests/move_check/typing/binary_and_invalid.exp
@@ -3,27 +3,19 @@ error:
    ┌── tests/move_check/typing/binary_and_invalid.move:8:9 ───
    │
  8 │         0 && 1;
-   │         ^ Incompatible arguments to '&&'
-   ·
- 8 │         0 && 1;
    │         - The type: integer
-   ·
- 8 │         0 && 1;
    │         - Is not compatible with: 'bool'
+   │         ^ Incompatible arguments to '&&'
    │
 
 error: 
 
-   ┌── tests/move_check/typing/binary_and_invalid.move:8:14 ───
+   ┌── tests/move_check/typing/binary_and_invalid.move:8:9 ───
    │
  8 │         0 && 1;
-   │              ^ Incompatible arguments to '&&'
-   ·
- 8 │         0 && 1;
-   │              - The type: integer
-   ·
- 8 │         0 && 1;
    │         - Is not compatible with: 'bool'
+   │              - The type: integer
+   │              ^ Incompatible arguments to '&&'
    │
 
 error: 
@@ -31,27 +23,19 @@ error:
    ┌── tests/move_check/typing/binary_and_invalid.move:9:9 ───
    │
  9 │         1 && false;
-   │         ^ Incompatible arguments to '&&'
-   ·
- 9 │         1 && false;
    │         - The type: integer
-   ·
- 9 │         1 && false;
    │         - Is not compatible with: 'bool'
+   │         ^ Incompatible arguments to '&&'
    │
 
 error: 
 
-    ┌── tests/move_check/typing/binary_and_invalid.move:10:18 ───
+    ┌── tests/move_check/typing/binary_and_invalid.move:10:9 ───
     │
  10 │         false && 1;
-    │                  ^ Incompatible arguments to '&&'
-    ·
- 10 │         false && 1;
-    │                  - The type: integer
-    ·
- 10 │         false && 1;
     │         ----- Is not compatible with: 'bool'
+    │                  - The type: integer
+    │                  ^ Incompatible arguments to '&&'
     │
 
 error: 
@@ -59,27 +43,19 @@ error:
     ┌── tests/move_check/typing/binary_and_invalid.move:11:9 ───
     │
  11 │         0x0 && 0x1;
-    │         ^^^ Incompatible arguments to '&&'
-    ·
- 11 │         0x0 && 0x1;
     │         --- The type: 'address'
-    ·
- 11 │         0x0 && 0x1;
     │         --- Is not compatible with: 'bool'
+    │         ^^^ Incompatible arguments to '&&'
     │
 
 error: 
 
-    ┌── tests/move_check/typing/binary_and_invalid.move:11:16 ───
+    ┌── tests/move_check/typing/binary_and_invalid.move:11:9 ───
     │
  11 │         0x0 && 0x1;
-    │                ^^^ Incompatible arguments to '&&'
-    ·
- 11 │         0x0 && 0x1;
-    │                --- The type: 'address'
-    ·
- 11 │         0x0 && 0x1;
     │         --- Is not compatible with: 'bool'
+    │                --- The type: 'address'
+    │                ^^^ Incompatible arguments to '&&'
     │
 
 error: 
@@ -87,83 +63,67 @@ error:
     ┌── tests/move_check/typing/binary_and_invalid.move:12:9 ───
     │
  12 │         (0: u8) && (1: u128);
+    │         ------- Is not compatible with: 'bool'
     │         ^^^^^^^ Incompatible arguments to '&&'
-    ·
- 12 │         (0: u8) && (1: u128);
     │             -- The type: 'u8'
-    ·
- 12 │         (0: u8) && (1: u128);
-    │         ------- Is not compatible with: 'bool'
     │
 
 error: 
 
-    ┌── tests/move_check/typing/binary_and_invalid.move:12:20 ───
+    ┌── tests/move_check/typing/binary_and_invalid.move:12:9 ───
     │
  12 │         (0: u8) && (1: u128);
+    │         ------- Is not compatible with: 'bool'
     │                    ^^^^^^^^^ Incompatible arguments to '&&'
-    ·
- 12 │         (0: u8) && (1: u128);
     │                        ---- The type: 'u128'
-    ·
- 12 │         (0: u8) && (1: u128);
-    │         ------- Is not compatible with: 'bool'
     │
 
 error: 
 
-    ┌── tests/move_check/typing/binary_and_invalid.move:13:9 ───
+    ┌── tests/move_check/typing/binary_and_invalid.move:7:23 ───
     │
- 13 │         r && r;
-    │         ^ Incompatible arguments to '&&'
-    ·
   7 │     fun t0(x: u64, r: R, s: S) {
     │                       - The type: '0x8675309::M::R'
     ·
  13 │         r && r;
     │         - Is not compatible with: 'bool'
+    │         ^ Incompatible arguments to '&&'
     │
 
 error: 
 
-    ┌── tests/move_check/typing/binary_and_invalid.move:13:14 ───
+    ┌── tests/move_check/typing/binary_and_invalid.move:7:23 ───
     │
- 13 │         r && r;
-    │              ^ Incompatible arguments to '&&'
-    ·
   7 │     fun t0(x: u64, r: R, s: S) {
     │                       - The type: '0x8675309::M::R'
     ·
  13 │         r && r;
     │         - Is not compatible with: 'bool'
-    │
-
-error: 
-
-    ┌── tests/move_check/typing/binary_and_invalid.move:14:9 ───
-    │
- 14 │         s && s;
-    │         ^ Incompatible arguments to '&&'
-    ·
-  7 │     fun t0(x: u64, r: R, s: S) {
-    │                             - The type: '0x8675309::M::S'
-    ·
- 14 │         s && s;
-    │         - Is not compatible with: 'bool'
-    │
-
-error: 
-
-    ┌── tests/move_check/typing/binary_and_invalid.move:14:14 ───
-    │
- 14 │         s && s;
     │              ^ Incompatible arguments to '&&'
-    ·
+    │
+
+error: 
+
+    ┌── tests/move_check/typing/binary_and_invalid.move:7:29 ───
+    │
   7 │     fun t0(x: u64, r: R, s: S) {
     │                             - The type: '0x8675309::M::S'
     ·
  14 │         s && s;
     │         - Is not compatible with: 'bool'
+    │         ^ Incompatible arguments to '&&'
+    │
+
+error: 
+
+    ┌── tests/move_check/typing/binary_and_invalid.move:7:29 ───
+    │
+  7 │     fun t0(x: u64, r: R, s: S) {
+    │                             - The type: '0x8675309::M::S'
+    ·
+ 14 │         s && s;
+    │         - Is not compatible with: 'bool'
+    │              ^ Incompatible arguments to '&&'
     │
 
 error: 
@@ -171,41 +131,29 @@ error:
     ┌── tests/move_check/typing/binary_and_invalid.move:15:9 ───
     │
  15 │         () && ();
-    │         ^^ Incompatible arguments to '&&'
-    ·
- 15 │         () && ();
     │         -- The type: '()'
-    ·
- 15 │         () && ();
     │         -- Is not compatible with: 'bool'
+    │         ^^ Incompatible arguments to '&&'
     │
 
 error: 
 
-    ┌── tests/move_check/typing/binary_and_invalid.move:15:15 ───
+    ┌── tests/move_check/typing/binary_and_invalid.move:15:9 ───
     │
  15 │         () && ();
-    │               ^^ Incompatible arguments to '&&'
-    ·
- 15 │         () && ();
+    │         -- Is not compatible with: 'bool'
     │               -- The type: '()'
-    ·
- 15 │         () && ();
-    │         -- Is not compatible with: 'bool'
+    │               ^^ Incompatible arguments to '&&'
     │
 
 error: 
 
-    ┌── tests/move_check/typing/binary_and_invalid.move:16:17 ───
+    ┌── tests/move_check/typing/binary_and_invalid.move:16:9 ───
     │
- 16 │         true && ();
-    │                 ^^ Incompatible arguments to '&&'
-    ·
- 16 │         true && ();
-    │                 -- The type: '()'
-    ·
  16 │         true && ();
     │         ---- Is not compatible with: 'bool'
+    │                 -- The type: '()'
+    │                 ^^ Incompatible arguments to '&&'
     │
 
 error: 
@@ -213,27 +161,19 @@ error:
     ┌── tests/move_check/typing/binary_and_invalid.move:17:9 ───
     │
  17 │         (true, false) && (true, false, true);
-    │         ^^^^^^^^^^^^^ Incompatible arguments to '&&'
-    ·
- 17 │         (true, false) && (true, false, true);
     │         ------------- The type: '(bool, bool)'
-    ·
- 17 │         (true, false) && (true, false, true);
     │         ------------- Is not compatible with: 'bool'
+    │         ^^^^^^^^^^^^^ Incompatible arguments to '&&'
     │
 
 error: 
 
-    ┌── tests/move_check/typing/binary_and_invalid.move:17:26 ───
+    ┌── tests/move_check/typing/binary_and_invalid.move:17:9 ───
     │
  17 │         (true, false) && (true, false, true);
-    │                          ^^^^^^^^^^^^^^^^^^^ Incompatible arguments to '&&'
-    ·
- 17 │         (true, false) && (true, false, true);
-    │                          ------------------- The type: '(bool, bool, bool)'
-    ·
- 17 │         (true, false) && (true, false, true);
     │         ------------- Is not compatible with: 'bool'
+    │                          ------------------- The type: '(bool, bool, bool)'
+    │                          ^^^^^^^^^^^^^^^^^^^ Incompatible arguments to '&&'
     │
 
 error: 
@@ -241,26 +181,18 @@ error:
     ┌── tests/move_check/typing/binary_and_invalid.move:18:9 ───
     │
  18 │         (true, true) && (false, false);
-    │         ^^^^^^^^^^^^ Incompatible arguments to '&&'
-    ·
- 18 │         (true, true) && (false, false);
     │         ------------ The type: '(bool, bool)'
-    ·
- 18 │         (true, true) && (false, false);
     │         ------------ Is not compatible with: 'bool'
+    │         ^^^^^^^^^^^^ Incompatible arguments to '&&'
     │
 
 error: 
 
-    ┌── tests/move_check/typing/binary_and_invalid.move:18:25 ───
+    ┌── tests/move_check/typing/binary_and_invalid.move:18:9 ───
     │
  18 │         (true, true) && (false, false);
-    │                         ^^^^^^^^^^^^^^ Incompatible arguments to '&&'
-    ·
- 18 │         (true, true) && (false, false);
-    │                         -------------- The type: '(bool, bool)'
-    ·
- 18 │         (true, true) && (false, false);
     │         ------------ Is not compatible with: 'bool'
+    │                         -------------- The type: '(bool, bool)'
+    │                         ^^^^^^^^^^^^^^ Incompatible arguments to '&&'
     │
 

--- a/language/move-lang/tests/move_check/typing/binary_bit_and_invalid.exp
+++ b/language/move-lang/tests/move_check/typing/binary_bit_and_invalid.exp
@@ -3,10 +3,8 @@ error:
    ┌── tests/move_check/typing/binary_bit_and_invalid.move:8:9 ───
    │
  8 │         false & true;
-   │         ^^^^^ Invalid argument to '&'
-   ·
- 8 │         false & true;
    │         ----- Found: 'bool'. But expected: 'u8', 'u64', 'u128'
+   │         ^^^^^ Invalid argument to '&'
    │
 
 error: 
@@ -15,20 +13,16 @@ error:
    │
  8 │         false & true;
    │         ^^^^^^^^^^^^ Invalid argument to '&'
-   ·
- 8 │         false & true;
    │                 ---- Found: 'bool'. But expected: 'u8', 'u64', 'u128'
    │
 
 error: 
 
-   ┌── tests/move_check/typing/binary_bit_and_invalid.move:8:17 ───
+   ┌── tests/move_check/typing/binary_bit_and_invalid.move:8:9 ───
    │
  8 │         false & true;
-   │                 ^^^^ Invalid argument to '&'
-   ·
- 8 │         false & true;
    │         ----- Found: 'bool'. But expected: 'u8', 'u64', 'u128'
+   │                 ^^^^ Invalid argument to '&'
    │
 
 error: 
@@ -37,23 +31,17 @@ error:
    │
  9 │         1 & false;
    │         ^^^^^^^^^ Invalid argument to '&'
-   ·
- 9 │         1 & false;
    │             ----- Found: '_'. But expected: 'u8', 'u64', 'u128'
    │
 
 error: 
 
-   ┌── tests/move_check/typing/binary_bit_and_invalid.move:9:13 ───
+   ┌── tests/move_check/typing/binary_bit_and_invalid.move:9:9 ───
    │
  9 │         1 & false;
-   │             ^^^^^ Incompatible arguments to '&'
-   ·
- 9 │         1 & false;
    │         - The type: integer
-   ·
- 9 │         1 & false;
    │             ----- Is not compatible with: 'bool'
+   │             ^^^^^ Incompatible arguments to '&'
    │
 
 error: 
@@ -61,10 +49,8 @@ error:
     ┌── tests/move_check/typing/binary_bit_and_invalid.move:10:9 ───
     │
  10 │         false & 1;
-    │         ^^^^^ Invalid argument to '&'
-    ·
- 10 │         false & 1;
     │         ----- Found: 'bool'. But expected: 'u8', 'u64', 'u128'
+    │         ^^^^^ Invalid argument to '&'
     │
 
 error: 
@@ -73,34 +59,26 @@ error:
     │
  10 │         false & 1;
     │         ^^^^^^^^^ Invalid argument to '&'
-    ·
- 10 │         false & 1;
     │                 - Found: '_'. But expected: 'u8', 'u64', 'u128'
     │
 
 error: 
 
-    ┌── tests/move_check/typing/binary_bit_and_invalid.move:10:17 ───
+    ┌── tests/move_check/typing/binary_bit_and_invalid.move:10:9 ───
     │
  10 │         false & 1;
-    │                 ^ Incompatible arguments to '&'
-    ·
- 10 │         false & 1;
-    │                 - The type: integer
-    ·
- 10 │         false & 1;
     │         ----- Is not compatible with: 'bool'
+    │                 - The type: integer
+    │                 ^ Incompatible arguments to '&'
     │
 
 error: 
 
-    ┌── tests/move_check/typing/binary_bit_and_invalid.move:10:17 ───
+    ┌── tests/move_check/typing/binary_bit_and_invalid.move:10:9 ───
     │
  10 │         false & 1;
-    │                 ^ Invalid argument to '&'
-    ·
- 10 │         false & 1;
     │         ----- Found: 'bool'. But expected: 'u8', 'u64', 'u128'
+    │                 ^ Invalid argument to '&'
     │
 
 error: 
@@ -108,10 +86,8 @@ error:
     ┌── tests/move_check/typing/binary_bit_and_invalid.move:11:9 ───
     │
  11 │         0x0 & 0x1;
-    │         ^^^ Invalid argument to '&'
-    ·
- 11 │         0x0 & 0x1;
     │         --- Found: 'address'. But expected: 'u8', 'u64', 'u128'
+    │         ^^^ Invalid argument to '&'
     │
 
 error: 
@@ -120,20 +96,16 @@ error:
     │
  11 │         0x0 & 0x1;
     │         ^^^^^^^^^ Invalid argument to '&'
-    ·
- 11 │         0x0 & 0x1;
     │               --- Found: 'address'. But expected: 'u8', 'u64', 'u128'
     │
 
 error: 
 
-    ┌── tests/move_check/typing/binary_bit_and_invalid.move:11:15 ───
+    ┌── tests/move_check/typing/binary_bit_and_invalid.move:11:9 ───
     │
  11 │         0x0 & 0x1;
-    │               ^^^ Invalid argument to '&'
-    ·
- 11 │         0x0 & 0x1;
     │         --- Found: 'address'. But expected: 'u8', 'u64', 'u128'
+    │               ^^^ Invalid argument to '&'
     │
 
 error: 
@@ -142,103 +114,97 @@ error:
     │
  12 │         (0: u8) & (1: u128);
     │         ^^^^^^^^^^^^^^^^^^^ Invalid argument to '&'
-    ·
- 12 │         (0: u8) & (1: u128);
     │                   --------- Found: '_'. But expected: 'u8', 'u64', 'u128'
     │
 
 error: 
 
-    ┌── tests/move_check/typing/binary_bit_and_invalid.move:12:19 ───
+    ┌── tests/move_check/typing/binary_bit_and_invalid.move:12:13 ───
     │
  12 │         (0: u8) & (1: u128);
-    │                   ^^^^^^^^^ Incompatible arguments to '&'
-    ·
- 12 │         (0: u8) & (1: u128);
     │             -- The type: 'u8'
-    ·
- 12 │         (0: u8) & (1: u128);
+    │                   ^^^^^^^^^ Incompatible arguments to '&'
     │                       ---- Is not compatible with: 'u128'
     │
 
 error: 
 
-    ┌── tests/move_check/typing/binary_bit_and_invalid.move:13:9 ───
+    ┌── tests/move_check/typing/binary_bit_and_invalid.move:7:23 ───
     │
+  7 │     fun t0(x: u64, r: R, s: S) {
+    │                       - Found: '0x8675309::M::R'. But expected: 'u8', 'u64', 'u128'
+    ·
  13 │         r & r;
     │         ^ Invalid argument to '&'
-    ·
-  7 │     fun t0(x: u64, r: R, s: S) {
-    │                       - Found: '0x8675309::M::R'. But expected: 'u8', 'u64', 'u128'
     │
 
 error: 
 
-    ┌── tests/move_check/typing/binary_bit_and_invalid.move:13:9 ───
+    ┌── tests/move_check/typing/binary_bit_and_invalid.move:7:23 ───
     │
+  7 │     fun t0(x: u64, r: R, s: S) {
+    │                       - Found: '0x8675309::M::R'. But expected: 'u8', 'u64', 'u128'
+    ·
  13 │         r & r;
     │         ^^^^^ Invalid argument to '&'
-    ·
-  7 │     fun t0(x: u64, r: R, s: S) {
-    │                       - Found: '0x8675309::M::R'. But expected: 'u8', 'u64', 'u128'
     │
 
 error: 
 
-    ┌── tests/move_check/typing/binary_bit_and_invalid.move:13:9 ───
+    ┌── tests/move_check/typing/binary_bit_and_invalid.move:3:5 ───
     │
- 13 │         r & r;
-    │         ^^^^^ Cannot ignore resource values. The value must be used
+  3 │     resource struct R {
+    │     -------- Is found to be a non-copyable type here
     ·
   7 │     fun t0(x: u64, r: R, s: S) {
     │                       - The type: '0x8675309::M::R'
     ·
-  3 │     resource struct R {
-    │     -------- Is found to be a non-copyable type here
+ 13 │         r & r;
+    │         ^^^^^ Cannot ignore resource values. The value must be used
     │
 
 error: 
 
-    ┌── tests/move_check/typing/binary_bit_and_invalid.move:13:13 ───
+    ┌── tests/move_check/typing/binary_bit_and_invalid.move:7:23 ───
     │
- 13 │         r & r;
-    │             ^ Invalid argument to '&'
-    ·
   7 │     fun t0(x: u64, r: R, s: S) {
     │                       - Found: '0x8675309::M::R'. But expected: 'u8', 'u64', 'u128'
+    ·
+ 13 │         r & r;
+    │             ^ Invalid argument to '&'
     │
 
 error: 
 
-    ┌── tests/move_check/typing/binary_bit_and_invalid.move:14:9 ───
+    ┌── tests/move_check/typing/binary_bit_and_invalid.move:7:29 ───
     │
+  7 │     fun t0(x: u64, r: R, s: S) {
+    │                             - Found: '0x8675309::M::S'. But expected: 'u8', 'u64', 'u128'
+    ·
  14 │         s & s;
     │         ^ Invalid argument to '&'
-    ·
-  7 │     fun t0(x: u64, r: R, s: S) {
-    │                             - Found: '0x8675309::M::S'. But expected: 'u8', 'u64', 'u128'
     │
 
 error: 
 
-    ┌── tests/move_check/typing/binary_bit_and_invalid.move:14:9 ───
+    ┌── tests/move_check/typing/binary_bit_and_invalid.move:7:29 ───
     │
+  7 │     fun t0(x: u64, r: R, s: S) {
+    │                             - Found: '0x8675309::M::S'. But expected: 'u8', 'u64', 'u128'
+    ·
  14 │         s & s;
     │         ^^^^^ Invalid argument to '&'
-    ·
-  7 │     fun t0(x: u64, r: R, s: S) {
-    │                             - Found: '0x8675309::M::S'. But expected: 'u8', 'u64', 'u128'
     │
 
 error: 
 
-    ┌── tests/move_check/typing/binary_bit_and_invalid.move:14:13 ───
+    ┌── tests/move_check/typing/binary_bit_and_invalid.move:7:29 ───
     │
- 14 │         s & s;
-    │             ^ Invalid argument to '&'
-    ·
   7 │     fun t0(x: u64, r: R, s: S) {
     │                             - Found: '0x8675309::M::S'. But expected: 'u8', 'u64', 'u128'
+    ·
+ 14 │         s & s;
+    │             ^ Invalid argument to '&'
     │
 
 error: 
@@ -247,8 +213,6 @@ error:
     │
  15 │         1 & false & 0x0 & 0;
     │         ^^^^^^^^^ Invalid argument to '&'
-    ·
- 15 │         1 & false & 0x0 & 0;
     │             ----- Found: '_'. But expected: 'u8', 'u64', 'u128'
     │
 
@@ -258,8 +222,6 @@ error:
     │
  15 │         1 & false & 0x0 & 0;
     │         ^^^^^^^^^^^^^^^ Invalid argument to '&'
-    ·
- 15 │         1 & false & 0x0 & 0;
     │                     --- Found: 'address'. But expected: 'u8', 'u64', 'u128'
     │
 
@@ -269,9 +231,17 @@ error:
     │
  15 │         1 & false & 0x0 & 0;
     │         ^^^^^^^^^^^^^^^^^^^ Invalid argument to '&'
-    ·
- 15 │         1 & false & 0x0 & 0;
     │                           - Found: '_'. But expected: 'u8', 'u64', 'u128'
+    │
+
+error: 
+
+    ┌── tests/move_check/typing/binary_bit_and_invalid.move:15:9 ───
+    │
+ 15 │         1 & false & 0x0 & 0;
+    │         - The type: integer
+    │             ----- Is not compatible with: 'bool'
+    │             ^^^^^ Incompatible arguments to '&'
     │
 
 error: 
@@ -279,13 +249,8 @@ error:
     ┌── tests/move_check/typing/binary_bit_and_invalid.move:15:13 ───
     │
  15 │         1 & false & 0x0 & 0;
-    │             ^^^^^ Incompatible arguments to '&'
-    ·
- 15 │         1 & false & 0x0 & 0;
-    │         - The type: integer
-    ·
- 15 │         1 & false & 0x0 & 0;
-    │             ----- Is not compatible with: 'bool'
+    │             ----- Found: '_'. But expected: 'u8', 'u64', 'u128'
+    │                     ^^^ Invalid argument to '&'
     │
 
 error: 
@@ -293,35 +258,18 @@ error:
     ┌── tests/move_check/typing/binary_bit_and_invalid.move:15:21 ───
     │
  15 │         1 & false & 0x0 & 0;
-    │                     ^^^ Invalid argument to '&'
-    ·
- 15 │         1 & false & 0x0 & 0;
-    │             ----- Found: '_'. But expected: 'u8', 'u64', 'u128'
-    │
-
-error: 
-
-    ┌── tests/move_check/typing/binary_bit_and_invalid.move:15:27 ───
-    │
- 15 │         1 & false & 0x0 & 0;
-    │                           ^ Incompatible arguments to '&'
-    ·
- 15 │         1 & false & 0x0 & 0;
-    │                           - The type: integer
-    ·
- 15 │         1 & false & 0x0 & 0;
     │                     --- Is not compatible with: 'address'
+    │                           - The type: integer
+    │                           ^ Incompatible arguments to '&'
     │
 
 error: 
 
-    ┌── tests/move_check/typing/binary_bit_and_invalid.move:15:27 ───
+    ┌── tests/move_check/typing/binary_bit_and_invalid.move:15:21 ───
     │
- 15 │         1 & false & 0x0 & 0;
-    │                           ^ Invalid argument to '&'
-    ·
  15 │         1 & false & 0x0 & 0;
     │                     --- Found: 'address'. But expected: 'u8', 'u64', 'u128'
+    │                           ^ Invalid argument to '&'
     │
 
 error: 
@@ -329,10 +277,8 @@ error:
     ┌── tests/move_check/typing/binary_bit_and_invalid.move:16:9 ───
     │
  16 │         () & ();
-    │         ^^ Invalid argument to '&'
-    ·
- 16 │         () & ();
     │         -- Found: '()'. But expected: 'u8', 'u64', 'u128'
+    │         ^^ Invalid argument to '&'
     │
 
 error: 
@@ -341,20 +287,16 @@ error:
     │
  16 │         () & ();
     │         ^^^^^^^ Invalid argument to '&'
-    ·
- 16 │         () & ();
     │              -- Found: '()'. But expected: 'u8', 'u64', 'u128'
     │
 
 error: 
 
-    ┌── tests/move_check/typing/binary_bit_and_invalid.move:16:14 ───
+    ┌── tests/move_check/typing/binary_bit_and_invalid.move:16:9 ───
     │
  16 │         () & ();
-    │              ^^ Invalid argument to '&'
-    ·
- 16 │         () & ();
     │         -- Found: '()'. But expected: 'u8', 'u64', 'u128'
+    │              ^^ Invalid argument to '&'
     │
 
 error: 
@@ -363,23 +305,17 @@ error:
     │
  17 │         1 & ();
     │         ^^^^^^ Invalid argument to '&'
-    ·
- 17 │         1 & ();
     │             -- Found: '_'. But expected: 'u8', 'u64', 'u128'
     │
 
 error: 
 
-    ┌── tests/move_check/typing/binary_bit_and_invalid.move:17:13 ───
+    ┌── tests/move_check/typing/binary_bit_and_invalid.move:17:9 ───
     │
  17 │         1 & ();
-    │             ^^ Incompatible arguments to '&'
-    ·
- 17 │         1 & ();
     │         - The type: integer
-    ·
- 17 │         1 & ();
     │             -- Is not compatible with: '()'
+    │             ^^ Incompatible arguments to '&'
     │
 
 error: 
@@ -387,10 +323,8 @@ error:
     ┌── tests/move_check/typing/binary_bit_and_invalid.move:18:9 ───
     │
  18 │         (0, 1) & (0, 1, 2);
-    │         ^^^^^^ Invalid argument to '&'
-    ·
- 18 │         (0, 1) & (0, 1, 2);
     │         ------ Found: '(u64, u64)'. But expected: 'u8', 'u64', 'u128'
+    │         ^^^^^^ Invalid argument to '&'
     │
 
 error: 
@@ -399,34 +333,26 @@ error:
     │
  18 │         (0, 1) & (0, 1, 2);
     │         ^^^^^^^^^^^^^^^^^^ Invalid argument to '&'
-    ·
- 18 │         (0, 1) & (0, 1, 2);
     │                  --------- Found: '_'. But expected: 'u8', 'u64', 'u128'
     │
 
 error: 
 
-    ┌── tests/move_check/typing/binary_bit_and_invalid.move:18:18 ───
+    ┌── tests/move_check/typing/binary_bit_and_invalid.move:18:9 ───
     │
  18 │         (0, 1) & (0, 1, 2);
-    │                  ^^^^^^^^^ Incompatible arguments to '&'
-    ·
- 18 │         (0, 1) & (0, 1, 2);
     │         ------ The expression list type of length 2: '({integer}, {integer})'
-    ·
- 18 │         (0, 1) & (0, 1, 2);
     │                  --------- Is not compatible with the expression list type of length 3: '({integer}, {integer}, {integer})'
+    │                  ^^^^^^^^^ Incompatible arguments to '&'
     │
 
 error: 
 
-    ┌── tests/move_check/typing/binary_bit_and_invalid.move:18:18 ───
+    ┌── tests/move_check/typing/binary_bit_and_invalid.move:18:9 ───
     │
  18 │         (0, 1) & (0, 1, 2);
-    │                  ^^^^^^^^^ Invalid argument to '&'
-    ·
- 18 │         (0, 1) & (0, 1, 2);
     │         ------ Found: '(u64, u64)'. But expected: 'u8', 'u64', 'u128'
+    │                  ^^^^^^^^^ Invalid argument to '&'
     │
 
 error: 
@@ -434,10 +360,8 @@ error:
     ┌── tests/move_check/typing/binary_bit_and_invalid.move:19:9 ───
     │
  19 │         (1, 2) & (0, 1);
-    │         ^^^^^^ Invalid argument to '&'
-    ·
- 19 │         (1, 2) & (0, 1);
     │         ------ Found: '(u64, u64)'. But expected: 'u8', 'u64', 'u128'
+    │         ^^^^^^ Invalid argument to '&'
     │
 
 error: 
@@ -446,19 +370,15 @@ error:
     │
  19 │         (1, 2) & (0, 1);
     │         ^^^^^^^^^^^^^^^ Invalid argument to '&'
-    ·
- 19 │         (1, 2) & (0, 1);
     │                  ------ Found: '(u64, u64)'. But expected: 'u8', 'u64', 'u128'
     │
 
 error: 
 
-    ┌── tests/move_check/typing/binary_bit_and_invalid.move:19:18 ───
+    ┌── tests/move_check/typing/binary_bit_and_invalid.move:19:9 ───
     │
  19 │         (1, 2) & (0, 1);
-    │                  ^^^^^^ Invalid argument to '&'
-    ·
- 19 │         (1, 2) & (0, 1);
     │         ------ Found: '(u64, u64)'. But expected: 'u8', 'u64', 'u128'
+    │                  ^^^^^^ Invalid argument to '&'
     │
 

--- a/language/move-lang/tests/move_check/typing/binary_bit_or_invalid.exp
+++ b/language/move-lang/tests/move_check/typing/binary_bit_or_invalid.exp
@@ -3,10 +3,8 @@ error:
    ┌── tests/move_check/typing/binary_bit_or_invalid.move:8:9 ───
    │
  8 │         false | true;
-   │         ^^^^^ Invalid argument to '|'
-   ·
- 8 │         false | true;
    │         ----- Found: 'bool'. But expected: 'u8', 'u64', 'u128'
+   │         ^^^^^ Invalid argument to '|'
    │
 
 error: 
@@ -15,20 +13,16 @@ error:
    │
  8 │         false | true;
    │         ^^^^^^^^^^^^ Invalid argument to '|'
-   ·
- 8 │         false | true;
    │                 ---- Found: 'bool'. But expected: 'u8', 'u64', 'u128'
    │
 
 error: 
 
-   ┌── tests/move_check/typing/binary_bit_or_invalid.move:8:17 ───
+   ┌── tests/move_check/typing/binary_bit_or_invalid.move:8:9 ───
    │
  8 │         false | true;
-   │                 ^^^^ Invalid argument to '|'
-   ·
- 8 │         false | true;
    │         ----- Found: 'bool'. But expected: 'u8', 'u64', 'u128'
+   │                 ^^^^ Invalid argument to '|'
    │
 
 error: 
@@ -37,23 +31,17 @@ error:
    │
  9 │         1 | false;
    │         ^^^^^^^^^ Invalid argument to '|'
-   ·
- 9 │         1 | false;
    │             ----- Found: '_'. But expected: 'u8', 'u64', 'u128'
    │
 
 error: 
 
-   ┌── tests/move_check/typing/binary_bit_or_invalid.move:9:13 ───
+   ┌── tests/move_check/typing/binary_bit_or_invalid.move:9:9 ───
    │
  9 │         1 | false;
-   │             ^^^^^ Incompatible arguments to '|'
-   ·
- 9 │         1 | false;
    │         - The type: integer
-   ·
- 9 │         1 | false;
    │             ----- Is not compatible with: 'bool'
+   │             ^^^^^ Incompatible arguments to '|'
    │
 
 error: 
@@ -61,10 +49,8 @@ error:
     ┌── tests/move_check/typing/binary_bit_or_invalid.move:10:9 ───
     │
  10 │         false | 1;
-    │         ^^^^^ Invalid argument to '|'
-    ·
- 10 │         false | 1;
     │         ----- Found: 'bool'. But expected: 'u8', 'u64', 'u128'
+    │         ^^^^^ Invalid argument to '|'
     │
 
 error: 
@@ -73,34 +59,26 @@ error:
     │
  10 │         false | 1;
     │         ^^^^^^^^^ Invalid argument to '|'
-    ·
- 10 │         false | 1;
     │                 - Found: '_'. But expected: 'u8', 'u64', 'u128'
     │
 
 error: 
 
-    ┌── tests/move_check/typing/binary_bit_or_invalid.move:10:17 ───
+    ┌── tests/move_check/typing/binary_bit_or_invalid.move:10:9 ───
     │
  10 │         false | 1;
-    │                 ^ Incompatible arguments to '|'
-    ·
- 10 │         false | 1;
-    │                 - The type: integer
-    ·
- 10 │         false | 1;
     │         ----- Is not compatible with: 'bool'
+    │                 - The type: integer
+    │                 ^ Incompatible arguments to '|'
     │
 
 error: 
 
-    ┌── tests/move_check/typing/binary_bit_or_invalid.move:10:17 ───
+    ┌── tests/move_check/typing/binary_bit_or_invalid.move:10:9 ───
     │
  10 │         false | 1;
-    │                 ^ Invalid argument to '|'
-    ·
- 10 │         false | 1;
     │         ----- Found: 'bool'. But expected: 'u8', 'u64', 'u128'
+    │                 ^ Invalid argument to '|'
     │
 
 error: 
@@ -108,10 +86,8 @@ error:
     ┌── tests/move_check/typing/binary_bit_or_invalid.move:11:9 ───
     │
  11 │         0x0 | 0x1;
-    │         ^^^ Invalid argument to '|'
-    ·
- 11 │         0x0 | 0x1;
     │         --- Found: 'address'. But expected: 'u8', 'u64', 'u128'
+    │         ^^^ Invalid argument to '|'
     │
 
 error: 
@@ -120,20 +96,16 @@ error:
     │
  11 │         0x0 | 0x1;
     │         ^^^^^^^^^ Invalid argument to '|'
-    ·
- 11 │         0x0 | 0x1;
     │               --- Found: 'address'. But expected: 'u8', 'u64', 'u128'
     │
 
 error: 
 
-    ┌── tests/move_check/typing/binary_bit_or_invalid.move:11:15 ───
+    ┌── tests/move_check/typing/binary_bit_or_invalid.move:11:9 ───
     │
  11 │         0x0 | 0x1;
-    │               ^^^ Invalid argument to '|'
-    ·
- 11 │         0x0 | 0x1;
     │         --- Found: 'address'. But expected: 'u8', 'u64', 'u128'
+    │               ^^^ Invalid argument to '|'
     │
 
 error: 
@@ -142,103 +114,97 @@ error:
     │
  12 │         (0: u8) | (1: u128);
     │         ^^^^^^^^^^^^^^^^^^^ Invalid argument to '|'
-    ·
- 12 │         (0: u8) | (1: u128);
     │                   --------- Found: '_'. But expected: 'u8', 'u64', 'u128'
     │
 
 error: 
 
-    ┌── tests/move_check/typing/binary_bit_or_invalid.move:12:19 ───
+    ┌── tests/move_check/typing/binary_bit_or_invalid.move:12:13 ───
     │
  12 │         (0: u8) | (1: u128);
-    │                   ^^^^^^^^^ Incompatible arguments to '|'
-    ·
- 12 │         (0: u8) | (1: u128);
     │             -- The type: 'u8'
-    ·
- 12 │         (0: u8) | (1: u128);
+    │                   ^^^^^^^^^ Incompatible arguments to '|'
     │                       ---- Is not compatible with: 'u128'
     │
 
 error: 
 
-    ┌── tests/move_check/typing/binary_bit_or_invalid.move:13:9 ───
+    ┌── tests/move_check/typing/binary_bit_or_invalid.move:7:23 ───
     │
+  7 │     fun t0(x: u64, r: R, s: S) {
+    │                       - Found: '0x8675309::M::R'. But expected: 'u8', 'u64', 'u128'
+    ·
  13 │         r | r;
     │         ^ Invalid argument to '|'
-    ·
-  7 │     fun t0(x: u64, r: R, s: S) {
-    │                       - Found: '0x8675309::M::R'. But expected: 'u8', 'u64', 'u128'
     │
 
 error: 
 
-    ┌── tests/move_check/typing/binary_bit_or_invalid.move:13:9 ───
+    ┌── tests/move_check/typing/binary_bit_or_invalid.move:7:23 ───
     │
+  7 │     fun t0(x: u64, r: R, s: S) {
+    │                       - Found: '0x8675309::M::R'. But expected: 'u8', 'u64', 'u128'
+    ·
  13 │         r | r;
     │         ^^^^^ Invalid argument to '|'
-    ·
-  7 │     fun t0(x: u64, r: R, s: S) {
-    │                       - Found: '0x8675309::M::R'. But expected: 'u8', 'u64', 'u128'
     │
 
 error: 
 
-    ┌── tests/move_check/typing/binary_bit_or_invalid.move:13:9 ───
+    ┌── tests/move_check/typing/binary_bit_or_invalid.move:3:5 ───
     │
- 13 │         r | r;
-    │         ^^^^^ Cannot ignore resource values. The value must be used
+  3 │     resource struct R {
+    │     -------- Is found to be a non-copyable type here
     ·
   7 │     fun t0(x: u64, r: R, s: S) {
     │                       - The type: '0x8675309::M::R'
     ·
-  3 │     resource struct R {
-    │     -------- Is found to be a non-copyable type here
+ 13 │         r | r;
+    │         ^^^^^ Cannot ignore resource values. The value must be used
     │
 
 error: 
 
-    ┌── tests/move_check/typing/binary_bit_or_invalid.move:13:13 ───
+    ┌── tests/move_check/typing/binary_bit_or_invalid.move:7:23 ───
     │
- 13 │         r | r;
-    │             ^ Invalid argument to '|'
-    ·
   7 │     fun t0(x: u64, r: R, s: S) {
     │                       - Found: '0x8675309::M::R'. But expected: 'u8', 'u64', 'u128'
+    ·
+ 13 │         r | r;
+    │             ^ Invalid argument to '|'
     │
 
 error: 
 
-    ┌── tests/move_check/typing/binary_bit_or_invalid.move:14:9 ───
+    ┌── tests/move_check/typing/binary_bit_or_invalid.move:7:29 ───
     │
+  7 │     fun t0(x: u64, r: R, s: S) {
+    │                             - Found: '0x8675309::M::S'. But expected: 'u8', 'u64', 'u128'
+    ·
  14 │         s | s;
     │         ^ Invalid argument to '|'
-    ·
-  7 │     fun t0(x: u64, r: R, s: S) {
-    │                             - Found: '0x8675309::M::S'. But expected: 'u8', 'u64', 'u128'
     │
 
 error: 
 
-    ┌── tests/move_check/typing/binary_bit_or_invalid.move:14:9 ───
+    ┌── tests/move_check/typing/binary_bit_or_invalid.move:7:29 ───
     │
+  7 │     fun t0(x: u64, r: R, s: S) {
+    │                             - Found: '0x8675309::M::S'. But expected: 'u8', 'u64', 'u128'
+    ·
  14 │         s | s;
     │         ^^^^^ Invalid argument to '|'
-    ·
-  7 │     fun t0(x: u64, r: R, s: S) {
-    │                             - Found: '0x8675309::M::S'. But expected: 'u8', 'u64', 'u128'
     │
 
 error: 
 
-    ┌── tests/move_check/typing/binary_bit_or_invalid.move:14:13 ───
+    ┌── tests/move_check/typing/binary_bit_or_invalid.move:7:29 ───
     │
- 14 │         s | s;
-    │             ^ Invalid argument to '|'
-    ·
   7 │     fun t0(x: u64, r: R, s: S) {
     │                             - Found: '0x8675309::M::S'. But expected: 'u8', 'u64', 'u128'
+    ·
+ 14 │         s | s;
+    │             ^ Invalid argument to '|'
     │
 
 error: 
@@ -247,8 +213,6 @@ error:
     │
  15 │         1 | false | 0x0 | 0;
     │         ^^^^^^^^^ Invalid argument to '|'
-    ·
- 15 │         1 | false | 0x0 | 0;
     │             ----- Found: '_'. But expected: 'u8', 'u64', 'u128'
     │
 
@@ -258,8 +222,6 @@ error:
     │
  15 │         1 | false | 0x0 | 0;
     │         ^^^^^^^^^^^^^^^ Invalid argument to '|'
-    ·
- 15 │         1 | false | 0x0 | 0;
     │                     --- Found: 'address'. But expected: 'u8', 'u64', 'u128'
     │
 
@@ -269,9 +231,17 @@ error:
     │
  15 │         1 | false | 0x0 | 0;
     │         ^^^^^^^^^^^^^^^^^^^ Invalid argument to '|'
-    ·
- 15 │         1 | false | 0x0 | 0;
     │                           - Found: '_'. But expected: 'u8', 'u64', 'u128'
+    │
+
+error: 
+
+    ┌── tests/move_check/typing/binary_bit_or_invalid.move:15:9 ───
+    │
+ 15 │         1 | false | 0x0 | 0;
+    │         - The type: integer
+    │             ----- Is not compatible with: 'bool'
+    │             ^^^^^ Incompatible arguments to '|'
     │
 
 error: 
@@ -279,13 +249,8 @@ error:
     ┌── tests/move_check/typing/binary_bit_or_invalid.move:15:13 ───
     │
  15 │         1 | false | 0x0 | 0;
-    │             ^^^^^ Incompatible arguments to '|'
-    ·
- 15 │         1 | false | 0x0 | 0;
-    │         - The type: integer
-    ·
- 15 │         1 | false | 0x0 | 0;
-    │             ----- Is not compatible with: 'bool'
+    │             ----- Found: '_'. But expected: 'u8', 'u64', 'u128'
+    │                     ^^^ Invalid argument to '|'
     │
 
 error: 
@@ -293,35 +258,18 @@ error:
     ┌── tests/move_check/typing/binary_bit_or_invalid.move:15:21 ───
     │
  15 │         1 | false | 0x0 | 0;
-    │                     ^^^ Invalid argument to '|'
-    ·
- 15 │         1 | false | 0x0 | 0;
-    │             ----- Found: '_'. But expected: 'u8', 'u64', 'u128'
-    │
-
-error: 
-
-    ┌── tests/move_check/typing/binary_bit_or_invalid.move:15:27 ───
-    │
- 15 │         1 | false | 0x0 | 0;
-    │                           ^ Incompatible arguments to '|'
-    ·
- 15 │         1 | false | 0x0 | 0;
-    │                           - The type: integer
-    ·
- 15 │         1 | false | 0x0 | 0;
     │                     --- Is not compatible with: 'address'
+    │                           - The type: integer
+    │                           ^ Incompatible arguments to '|'
     │
 
 error: 
 
-    ┌── tests/move_check/typing/binary_bit_or_invalid.move:15:27 ───
+    ┌── tests/move_check/typing/binary_bit_or_invalid.move:15:21 ───
     │
- 15 │         1 | false | 0x0 | 0;
-    │                           ^ Invalid argument to '|'
-    ·
  15 │         1 | false | 0x0 | 0;
     │                     --- Found: 'address'. But expected: 'u8', 'u64', 'u128'
+    │                           ^ Invalid argument to '|'
     │
 
 error: 
@@ -329,10 +277,8 @@ error:
     ┌── tests/move_check/typing/binary_bit_or_invalid.move:16:9 ───
     │
  16 │         () | ();
-    │         ^^ Invalid argument to '|'
-    ·
- 16 │         () | ();
     │         -- Found: '()'. But expected: 'u8', 'u64', 'u128'
+    │         ^^ Invalid argument to '|'
     │
 
 error: 
@@ -341,20 +287,16 @@ error:
     │
  16 │         () | ();
     │         ^^^^^^^ Invalid argument to '|'
-    ·
- 16 │         () | ();
     │              -- Found: '()'. But expected: 'u8', 'u64', 'u128'
     │
 
 error: 
 
-    ┌── tests/move_check/typing/binary_bit_or_invalid.move:16:14 ───
+    ┌── tests/move_check/typing/binary_bit_or_invalid.move:16:9 ───
     │
  16 │         () | ();
-    │              ^^ Invalid argument to '|'
-    ·
- 16 │         () | ();
     │         -- Found: '()'. But expected: 'u8', 'u64', 'u128'
+    │              ^^ Invalid argument to '|'
     │
 
 error: 
@@ -363,23 +305,17 @@ error:
     │
  17 │         1 | ();
     │         ^^^^^^ Invalid argument to '|'
-    ·
- 17 │         1 | ();
     │             -- Found: '_'. But expected: 'u8', 'u64', 'u128'
     │
 
 error: 
 
-    ┌── tests/move_check/typing/binary_bit_or_invalid.move:17:13 ───
+    ┌── tests/move_check/typing/binary_bit_or_invalid.move:17:9 ───
     │
  17 │         1 | ();
-    │             ^^ Incompatible arguments to '|'
-    ·
- 17 │         1 | ();
     │         - The type: integer
-    ·
- 17 │         1 | ();
     │             -- Is not compatible with: '()'
+    │             ^^ Incompatible arguments to '|'
     │
 
 error: 
@@ -387,10 +323,8 @@ error:
     ┌── tests/move_check/typing/binary_bit_or_invalid.move:18:9 ───
     │
  18 │         (0, 1) | (0, 1, 2);
-    │         ^^^^^^ Invalid argument to '|'
-    ·
- 18 │         (0, 1) | (0, 1, 2);
     │         ------ Found: '(u64, u64)'. But expected: 'u8', 'u64', 'u128'
+    │         ^^^^^^ Invalid argument to '|'
     │
 
 error: 
@@ -399,34 +333,26 @@ error:
     │
  18 │         (0, 1) | (0, 1, 2);
     │         ^^^^^^^^^^^^^^^^^^ Invalid argument to '|'
-    ·
- 18 │         (0, 1) | (0, 1, 2);
     │                  --------- Found: '_'. But expected: 'u8', 'u64', 'u128'
     │
 
 error: 
 
-    ┌── tests/move_check/typing/binary_bit_or_invalid.move:18:18 ───
+    ┌── tests/move_check/typing/binary_bit_or_invalid.move:18:9 ───
     │
  18 │         (0, 1) | (0, 1, 2);
-    │                  ^^^^^^^^^ Incompatible arguments to '|'
-    ·
- 18 │         (0, 1) | (0, 1, 2);
     │         ------ The expression list type of length 2: '({integer}, {integer})'
-    ·
- 18 │         (0, 1) | (0, 1, 2);
     │                  --------- Is not compatible with the expression list type of length 3: '({integer}, {integer}, {integer})'
+    │                  ^^^^^^^^^ Incompatible arguments to '|'
     │
 
 error: 
 
-    ┌── tests/move_check/typing/binary_bit_or_invalid.move:18:18 ───
+    ┌── tests/move_check/typing/binary_bit_or_invalid.move:18:9 ───
     │
  18 │         (0, 1) | (0, 1, 2);
-    │                  ^^^^^^^^^ Invalid argument to '|'
-    ·
- 18 │         (0, 1) | (0, 1, 2);
     │         ------ Found: '(u64, u64)'. But expected: 'u8', 'u64', 'u128'
+    │                  ^^^^^^^^^ Invalid argument to '|'
     │
 
 error: 
@@ -434,10 +360,8 @@ error:
     ┌── tests/move_check/typing/binary_bit_or_invalid.move:19:9 ───
     │
  19 │         (1, 2) | (0, 1);
-    │         ^^^^^^ Invalid argument to '|'
-    ·
- 19 │         (1, 2) | (0, 1);
     │         ------ Found: '(u64, u64)'. But expected: 'u8', 'u64', 'u128'
+    │         ^^^^^^ Invalid argument to '|'
     │
 
 error: 
@@ -446,19 +370,15 @@ error:
     │
  19 │         (1, 2) | (0, 1);
     │         ^^^^^^^^^^^^^^^ Invalid argument to '|'
-    ·
- 19 │         (1, 2) | (0, 1);
     │                  ------ Found: '(u64, u64)'. But expected: 'u8', 'u64', 'u128'
     │
 
 error: 
 
-    ┌── tests/move_check/typing/binary_bit_or_invalid.move:19:18 ───
+    ┌── tests/move_check/typing/binary_bit_or_invalid.move:19:9 ───
     │
  19 │         (1, 2) | (0, 1);
-    │                  ^^^^^^ Invalid argument to '|'
-    ·
- 19 │         (1, 2) | (0, 1);
     │         ------ Found: '(u64, u64)'. But expected: 'u8', 'u64', 'u128'
+    │                  ^^^^^^ Invalid argument to '|'
     │
 

--- a/language/move-lang/tests/move_check/typing/binary_bit_xor_invalid.exp
+++ b/language/move-lang/tests/move_check/typing/binary_bit_xor_invalid.exp
@@ -3,10 +3,8 @@ error:
    ┌── tests/move_check/typing/binary_bit_xor_invalid.move:8:9 ───
    │
  8 │         false ^ true;
-   │         ^^^^^ Invalid argument to '^'
-   ·
- 8 │         false ^ true;
    │         ----- Found: 'bool'. But expected: 'u8', 'u64', 'u128'
+   │         ^^^^^ Invalid argument to '^'
    │
 
 error: 
@@ -15,20 +13,16 @@ error:
    │
  8 │         false ^ true;
    │         ^^^^^^^^^^^^ Invalid argument to '^'
-   ·
- 8 │         false ^ true;
    │                 ---- Found: 'bool'. But expected: 'u8', 'u64', 'u128'
    │
 
 error: 
 
-   ┌── tests/move_check/typing/binary_bit_xor_invalid.move:8:17 ───
+   ┌── tests/move_check/typing/binary_bit_xor_invalid.move:8:9 ───
    │
  8 │         false ^ true;
-   │                 ^^^^ Invalid argument to '^'
-   ·
- 8 │         false ^ true;
    │         ----- Found: 'bool'. But expected: 'u8', 'u64', 'u128'
+   │                 ^^^^ Invalid argument to '^'
    │
 
 error: 
@@ -37,23 +31,17 @@ error:
    │
  9 │         1 ^ false;
    │         ^^^^^^^^^ Invalid argument to '^'
-   ·
- 9 │         1 ^ false;
    │             ----- Found: '_'. But expected: 'u8', 'u64', 'u128'
    │
 
 error: 
 
-   ┌── tests/move_check/typing/binary_bit_xor_invalid.move:9:13 ───
+   ┌── tests/move_check/typing/binary_bit_xor_invalid.move:9:9 ───
    │
  9 │         1 ^ false;
-   │             ^^^^^ Incompatible arguments to '^'
-   ·
- 9 │         1 ^ false;
    │         - The type: integer
-   ·
- 9 │         1 ^ false;
    │             ----- Is not compatible with: 'bool'
+   │             ^^^^^ Incompatible arguments to '^'
    │
 
 error: 
@@ -61,10 +49,8 @@ error:
     ┌── tests/move_check/typing/binary_bit_xor_invalid.move:10:9 ───
     │
  10 │         false ^ 1;
-    │         ^^^^^ Invalid argument to '^'
-    ·
- 10 │         false ^ 1;
     │         ----- Found: 'bool'. But expected: 'u8', 'u64', 'u128'
+    │         ^^^^^ Invalid argument to '^'
     │
 
 error: 
@@ -73,34 +59,26 @@ error:
     │
  10 │         false ^ 1;
     │         ^^^^^^^^^ Invalid argument to '^'
-    ·
- 10 │         false ^ 1;
     │                 - Found: '_'. But expected: 'u8', 'u64', 'u128'
     │
 
 error: 
 
-    ┌── tests/move_check/typing/binary_bit_xor_invalid.move:10:17 ───
+    ┌── tests/move_check/typing/binary_bit_xor_invalid.move:10:9 ───
     │
  10 │         false ^ 1;
-    │                 ^ Incompatible arguments to '^'
-    ·
- 10 │         false ^ 1;
-    │                 - The type: integer
-    ·
- 10 │         false ^ 1;
     │         ----- Is not compatible with: 'bool'
+    │                 - The type: integer
+    │                 ^ Incompatible arguments to '^'
     │
 
 error: 
 
-    ┌── tests/move_check/typing/binary_bit_xor_invalid.move:10:17 ───
+    ┌── tests/move_check/typing/binary_bit_xor_invalid.move:10:9 ───
     │
  10 │         false ^ 1;
-    │                 ^ Invalid argument to '^'
-    ·
- 10 │         false ^ 1;
     │         ----- Found: 'bool'. But expected: 'u8', 'u64', 'u128'
+    │                 ^ Invalid argument to '^'
     │
 
 error: 
@@ -108,10 +86,8 @@ error:
     ┌── tests/move_check/typing/binary_bit_xor_invalid.move:11:9 ───
     │
  11 │         0x0 ^ 0x1;
-    │         ^^^ Invalid argument to '^'
-    ·
- 11 │         0x0 ^ 0x1;
     │         --- Found: 'address'. But expected: 'u8', 'u64', 'u128'
+    │         ^^^ Invalid argument to '^'
     │
 
 error: 
@@ -120,20 +96,16 @@ error:
     │
  11 │         0x0 ^ 0x1;
     │         ^^^^^^^^^ Invalid argument to '^'
-    ·
- 11 │         0x0 ^ 0x1;
     │               --- Found: 'address'. But expected: 'u8', 'u64', 'u128'
     │
 
 error: 
 
-    ┌── tests/move_check/typing/binary_bit_xor_invalid.move:11:15 ───
+    ┌── tests/move_check/typing/binary_bit_xor_invalid.move:11:9 ───
     │
  11 │         0x0 ^ 0x1;
-    │               ^^^ Invalid argument to '^'
-    ·
- 11 │         0x0 ^ 0x1;
     │         --- Found: 'address'. But expected: 'u8', 'u64', 'u128'
+    │               ^^^ Invalid argument to '^'
     │
 
 error: 
@@ -142,103 +114,97 @@ error:
     │
  12 │         (0: u8) ^ (1: u128);
     │         ^^^^^^^^^^^^^^^^^^^ Invalid argument to '^'
-    ·
- 12 │         (0: u8) ^ (1: u128);
     │                   --------- Found: '_'. But expected: 'u8', 'u64', 'u128'
     │
 
 error: 
 
-    ┌── tests/move_check/typing/binary_bit_xor_invalid.move:12:19 ───
+    ┌── tests/move_check/typing/binary_bit_xor_invalid.move:12:13 ───
     │
  12 │         (0: u8) ^ (1: u128);
-    │                   ^^^^^^^^^ Incompatible arguments to '^'
-    ·
- 12 │         (0: u8) ^ (1: u128);
     │             -- The type: 'u8'
-    ·
- 12 │         (0: u8) ^ (1: u128);
+    │                   ^^^^^^^^^ Incompatible arguments to '^'
     │                       ---- Is not compatible with: 'u128'
     │
 
 error: 
 
-    ┌── tests/move_check/typing/binary_bit_xor_invalid.move:13:9 ───
+    ┌── tests/move_check/typing/binary_bit_xor_invalid.move:7:23 ───
     │
+  7 │     fun t0(x: u64, r: R, s: S) {
+    │                       - Found: '0x8675309::M::R'. But expected: 'u8', 'u64', 'u128'
+    ·
  13 │         r ^ r;
     │         ^ Invalid argument to '^'
-    ·
-  7 │     fun t0(x: u64, r: R, s: S) {
-    │                       - Found: '0x8675309::M::R'. But expected: 'u8', 'u64', 'u128'
     │
 
 error: 
 
-    ┌── tests/move_check/typing/binary_bit_xor_invalid.move:13:9 ───
+    ┌── tests/move_check/typing/binary_bit_xor_invalid.move:7:23 ───
     │
+  7 │     fun t0(x: u64, r: R, s: S) {
+    │                       - Found: '0x8675309::M::R'. But expected: 'u8', 'u64', 'u128'
+    ·
  13 │         r ^ r;
     │         ^^^^^ Invalid argument to '^'
-    ·
-  7 │     fun t0(x: u64, r: R, s: S) {
-    │                       - Found: '0x8675309::M::R'. But expected: 'u8', 'u64', 'u128'
     │
 
 error: 
 
-    ┌── tests/move_check/typing/binary_bit_xor_invalid.move:13:9 ───
+    ┌── tests/move_check/typing/binary_bit_xor_invalid.move:3:5 ───
     │
- 13 │         r ^ r;
-    │         ^^^^^ Cannot ignore resource values. The value must be used
+  3 │     resource struct R {
+    │     -------- Is found to be a non-copyable type here
     ·
   7 │     fun t0(x: u64, r: R, s: S) {
     │                       - The type: '0x8675309::M::R'
     ·
-  3 │     resource struct R {
-    │     -------- Is found to be a non-copyable type here
+ 13 │         r ^ r;
+    │         ^^^^^ Cannot ignore resource values. The value must be used
     │
 
 error: 
 
-    ┌── tests/move_check/typing/binary_bit_xor_invalid.move:13:13 ───
+    ┌── tests/move_check/typing/binary_bit_xor_invalid.move:7:23 ───
     │
- 13 │         r ^ r;
-    │             ^ Invalid argument to '^'
-    ·
   7 │     fun t0(x: u64, r: R, s: S) {
     │                       - Found: '0x8675309::M::R'. But expected: 'u8', 'u64', 'u128'
+    ·
+ 13 │         r ^ r;
+    │             ^ Invalid argument to '^'
     │
 
 error: 
 
-    ┌── tests/move_check/typing/binary_bit_xor_invalid.move:14:9 ───
+    ┌── tests/move_check/typing/binary_bit_xor_invalid.move:7:29 ───
     │
+  7 │     fun t0(x: u64, r: R, s: S) {
+    │                             - Found: '0x8675309::M::S'. But expected: 'u8', 'u64', 'u128'
+    ·
  14 │         s ^ s;
     │         ^ Invalid argument to '^'
-    ·
-  7 │     fun t0(x: u64, r: R, s: S) {
-    │                             - Found: '0x8675309::M::S'. But expected: 'u8', 'u64', 'u128'
     │
 
 error: 
 
-    ┌── tests/move_check/typing/binary_bit_xor_invalid.move:14:9 ───
+    ┌── tests/move_check/typing/binary_bit_xor_invalid.move:7:29 ───
     │
+  7 │     fun t0(x: u64, r: R, s: S) {
+    │                             - Found: '0x8675309::M::S'. But expected: 'u8', 'u64', 'u128'
+    ·
  14 │         s ^ s;
     │         ^^^^^ Invalid argument to '^'
-    ·
-  7 │     fun t0(x: u64, r: R, s: S) {
-    │                             - Found: '0x8675309::M::S'. But expected: 'u8', 'u64', 'u128'
     │
 
 error: 
 
-    ┌── tests/move_check/typing/binary_bit_xor_invalid.move:14:13 ───
+    ┌── tests/move_check/typing/binary_bit_xor_invalid.move:7:29 ───
     │
- 14 │         s ^ s;
-    │             ^ Invalid argument to '^'
-    ·
   7 │     fun t0(x: u64, r: R, s: S) {
     │                             - Found: '0x8675309::M::S'. But expected: 'u8', 'u64', 'u128'
+    ·
+ 14 │         s ^ s;
+    │             ^ Invalid argument to '^'
     │
 
 error: 
@@ -247,8 +213,6 @@ error:
     │
  15 │         1 ^ false ^ 0x0 ^ 0;
     │         ^^^^^^^^^ Invalid argument to '^'
-    ·
- 15 │         1 ^ false ^ 0x0 ^ 0;
     │             ----- Found: '_'. But expected: 'u8', 'u64', 'u128'
     │
 
@@ -258,8 +222,6 @@ error:
     │
  15 │         1 ^ false ^ 0x0 ^ 0;
     │         ^^^^^^^^^^^^^^^ Invalid argument to '^'
-    ·
- 15 │         1 ^ false ^ 0x0 ^ 0;
     │                     --- Found: 'address'. But expected: 'u8', 'u64', 'u128'
     │
 
@@ -269,9 +231,17 @@ error:
     │
  15 │         1 ^ false ^ 0x0 ^ 0;
     │         ^^^^^^^^^^^^^^^^^^^ Invalid argument to '^'
-    ·
- 15 │         1 ^ false ^ 0x0 ^ 0;
     │                           - Found: '_'. But expected: 'u8', 'u64', 'u128'
+    │
+
+error: 
+
+    ┌── tests/move_check/typing/binary_bit_xor_invalid.move:15:9 ───
+    │
+ 15 │         1 ^ false ^ 0x0 ^ 0;
+    │         - The type: integer
+    │             ----- Is not compatible with: 'bool'
+    │             ^^^^^ Incompatible arguments to '^'
     │
 
 error: 
@@ -279,13 +249,8 @@ error:
     ┌── tests/move_check/typing/binary_bit_xor_invalid.move:15:13 ───
     │
  15 │         1 ^ false ^ 0x0 ^ 0;
-    │             ^^^^^ Incompatible arguments to '^'
-    ·
- 15 │         1 ^ false ^ 0x0 ^ 0;
-    │         - The type: integer
-    ·
- 15 │         1 ^ false ^ 0x0 ^ 0;
-    │             ----- Is not compatible with: 'bool'
+    │             ----- Found: '_'. But expected: 'u8', 'u64', 'u128'
+    │                     ^^^ Invalid argument to '^'
     │
 
 error: 
@@ -293,35 +258,18 @@ error:
     ┌── tests/move_check/typing/binary_bit_xor_invalid.move:15:21 ───
     │
  15 │         1 ^ false ^ 0x0 ^ 0;
-    │                     ^^^ Invalid argument to '^'
-    ·
- 15 │         1 ^ false ^ 0x0 ^ 0;
-    │             ----- Found: '_'. But expected: 'u8', 'u64', 'u128'
-    │
-
-error: 
-
-    ┌── tests/move_check/typing/binary_bit_xor_invalid.move:15:27 ───
-    │
- 15 │         1 ^ false ^ 0x0 ^ 0;
-    │                           ^ Incompatible arguments to '^'
-    ·
- 15 │         1 ^ false ^ 0x0 ^ 0;
-    │                           - The type: integer
-    ·
- 15 │         1 ^ false ^ 0x0 ^ 0;
     │                     --- Is not compatible with: 'address'
+    │                           - The type: integer
+    │                           ^ Incompatible arguments to '^'
     │
 
 error: 
 
-    ┌── tests/move_check/typing/binary_bit_xor_invalid.move:15:27 ───
+    ┌── tests/move_check/typing/binary_bit_xor_invalid.move:15:21 ───
     │
- 15 │         1 ^ false ^ 0x0 ^ 0;
-    │                           ^ Invalid argument to '^'
-    ·
  15 │         1 ^ false ^ 0x0 ^ 0;
     │                     --- Found: 'address'. But expected: 'u8', 'u64', 'u128'
+    │                           ^ Invalid argument to '^'
     │
 
 error: 
@@ -329,10 +277,8 @@ error:
     ┌── tests/move_check/typing/binary_bit_xor_invalid.move:16:9 ───
     │
  16 │         () ^ ();
-    │         ^^ Invalid argument to '^'
-    ·
- 16 │         () ^ ();
     │         -- Found: '()'. But expected: 'u8', 'u64', 'u128'
+    │         ^^ Invalid argument to '^'
     │
 
 error: 
@@ -341,20 +287,16 @@ error:
     │
  16 │         () ^ ();
     │         ^^^^^^^ Invalid argument to '^'
-    ·
- 16 │         () ^ ();
     │              -- Found: '()'. But expected: 'u8', 'u64', 'u128'
     │
 
 error: 
 
-    ┌── tests/move_check/typing/binary_bit_xor_invalid.move:16:14 ───
+    ┌── tests/move_check/typing/binary_bit_xor_invalid.move:16:9 ───
     │
  16 │         () ^ ();
-    │              ^^ Invalid argument to '^'
-    ·
- 16 │         () ^ ();
     │         -- Found: '()'. But expected: 'u8', 'u64', 'u128'
+    │              ^^ Invalid argument to '^'
     │
 
 error: 
@@ -363,23 +305,17 @@ error:
     │
  17 │         1 ^ ();
     │         ^^^^^^ Invalid argument to '^'
-    ·
- 17 │         1 ^ ();
     │             -- Found: '_'. But expected: 'u8', 'u64', 'u128'
     │
 
 error: 
 
-    ┌── tests/move_check/typing/binary_bit_xor_invalid.move:17:13 ───
+    ┌── tests/move_check/typing/binary_bit_xor_invalid.move:17:9 ───
     │
  17 │         1 ^ ();
-    │             ^^ Incompatible arguments to '^'
-    ·
- 17 │         1 ^ ();
     │         - The type: integer
-    ·
- 17 │         1 ^ ();
     │             -- Is not compatible with: '()'
+    │             ^^ Incompatible arguments to '^'
     │
 
 error: 
@@ -387,10 +323,8 @@ error:
     ┌── tests/move_check/typing/binary_bit_xor_invalid.move:18:9 ───
     │
  18 │         (0, 1) ^ (0, 1, 2);
-    │         ^^^^^^ Invalid argument to '^'
-    ·
- 18 │         (0, 1) ^ (0, 1, 2);
     │         ------ Found: '(u64, u64)'. But expected: 'u8', 'u64', 'u128'
+    │         ^^^^^^ Invalid argument to '^'
     │
 
 error: 
@@ -399,34 +333,26 @@ error:
     │
  18 │         (0, 1) ^ (0, 1, 2);
     │         ^^^^^^^^^^^^^^^^^^ Invalid argument to '^'
-    ·
- 18 │         (0, 1) ^ (0, 1, 2);
     │                  --------- Found: '_'. But expected: 'u8', 'u64', 'u128'
     │
 
 error: 
 
-    ┌── tests/move_check/typing/binary_bit_xor_invalid.move:18:18 ───
+    ┌── tests/move_check/typing/binary_bit_xor_invalid.move:18:9 ───
     │
  18 │         (0, 1) ^ (0, 1, 2);
-    │                  ^^^^^^^^^ Incompatible arguments to '^'
-    ·
- 18 │         (0, 1) ^ (0, 1, 2);
     │         ------ The expression list type of length 2: '({integer}, {integer})'
-    ·
- 18 │         (0, 1) ^ (0, 1, 2);
     │                  --------- Is not compatible with the expression list type of length 3: '({integer}, {integer}, {integer})'
+    │                  ^^^^^^^^^ Incompatible arguments to '^'
     │
 
 error: 
 
-    ┌── tests/move_check/typing/binary_bit_xor_invalid.move:18:18 ───
+    ┌── tests/move_check/typing/binary_bit_xor_invalid.move:18:9 ───
     │
  18 │         (0, 1) ^ (0, 1, 2);
-    │                  ^^^^^^^^^ Invalid argument to '^'
-    ·
- 18 │         (0, 1) ^ (0, 1, 2);
     │         ------ Found: '(u64, u64)'. But expected: 'u8', 'u64', 'u128'
+    │                  ^^^^^^^^^ Invalid argument to '^'
     │
 
 error: 
@@ -434,10 +360,8 @@ error:
     ┌── tests/move_check/typing/binary_bit_xor_invalid.move:19:9 ───
     │
  19 │         (1, 2) ^ (0, 1);
-    │         ^^^^^^ Invalid argument to '^'
-    ·
- 19 │         (1, 2) ^ (0, 1);
     │         ------ Found: '(u64, u64)'. But expected: 'u8', 'u64', 'u128'
+    │         ^^^^^^ Invalid argument to '^'
     │
 
 error: 
@@ -446,19 +370,15 @@ error:
     │
  19 │         (1, 2) ^ (0, 1);
     │         ^^^^^^^^^^^^^^^ Invalid argument to '^'
-    ·
- 19 │         (1, 2) ^ (0, 1);
     │                  ------ Found: '(u64, u64)'. But expected: 'u8', 'u64', 'u128'
     │
 
 error: 
 
-    ┌── tests/move_check/typing/binary_bit_xor_invalid.move:19:18 ───
+    ┌── tests/move_check/typing/binary_bit_xor_invalid.move:19:9 ───
     │
  19 │         (1, 2) ^ (0, 1);
-    │                  ^^^^^^ Invalid argument to '^'
-    ·
- 19 │         (1, 2) ^ (0, 1);
     │         ------ Found: '(u64, u64)'. But expected: 'u8', 'u64', 'u128'
+    │                  ^^^^^^ Invalid argument to '^'
     │
 

--- a/language/move-lang/tests/move_check/typing/binary_div_invalid.exp
+++ b/language/move-lang/tests/move_check/typing/binary_div_invalid.exp
@@ -3,35 +3,27 @@ error:
    ┌── tests/move_check/typing/binary_div_invalid.move:8:9 ───
    │
  8 │         false / true;
+   │         ----- Found: 'bool'. But expected: 'u8', 'u64', 'u128'
    │         ^^^^^ Invalid argument to '/'
-   ·
- 8 │         false / true;
-   │         ----- Found: 'bool'. But expected: 'u8', 'u64', 'u128'
    │
 
 error: 
 
-   ┌── tests/move_check/typing/binary_div_invalid.move:8:17 ───
+   ┌── tests/move_check/typing/binary_div_invalid.move:8:9 ───
    │
  8 │         false / true;
+   │         ----- Found: 'bool'. But expected: 'u8', 'u64', 'u128'
    │                 ^^^^ Invalid argument to '/'
-   ·
- 8 │         false / true;
-   │         ----- Found: 'bool'. But expected: 'u8', 'u64', 'u128'
    │
 
 error: 
 
-   ┌── tests/move_check/typing/binary_div_invalid.move:9:13 ───
+   ┌── tests/move_check/typing/binary_div_invalid.move:9:9 ───
    │
- 9 │         1 / false;
-   │             ^^^^^ Incompatible arguments to '/'
-   ·
  9 │         1 / false;
    │         - The type: integer
-   ·
- 9 │         1 / false;
    │             ----- Is not compatible with: 'bool'
+   │             ^^^^^ Incompatible arguments to '/'
    │
 
 error: 
@@ -39,35 +31,27 @@ error:
     ┌── tests/move_check/typing/binary_div_invalid.move:10:9 ───
     │
  10 │         false / 1;
-    │         ^^^^^ Invalid argument to '/'
-    ·
- 10 │         false / 1;
     │         ----- Found: 'bool'. But expected: 'u8', 'u64', 'u128'
+    │         ^^^^^ Invalid argument to '/'
     │
 
 error: 
 
-    ┌── tests/move_check/typing/binary_div_invalid.move:10:17 ───
+    ┌── tests/move_check/typing/binary_div_invalid.move:10:9 ───
     │
- 10 │         false / 1;
-    │                 ^ Incompatible arguments to '/'
-    ·
- 10 │         false / 1;
-    │                 - The type: integer
-    ·
  10 │         false / 1;
     │         ----- Is not compatible with: 'bool'
+    │                 - The type: integer
+    │                 ^ Incompatible arguments to '/'
     │
 
 error: 
 
-    ┌── tests/move_check/typing/binary_div_invalid.move:10:17 ───
+    ┌── tests/move_check/typing/binary_div_invalid.move:10:9 ───
     │
  10 │         false / 1;
-    │                 ^ Invalid argument to '/'
-    ·
- 10 │         false / 1;
     │         ----- Found: 'bool'. But expected: 'u8', 'u64', 'u128'
+    │                 ^ Invalid argument to '/'
     │
 
 error: 
@@ -75,93 +59,85 @@ error:
     ┌── tests/move_check/typing/binary_div_invalid.move:11:9 ───
     │
  11 │         0x0 / 0x1;
+    │         --- Found: 'address'. But expected: 'u8', 'u64', 'u128'
     │         ^^^ Invalid argument to '/'
-    ·
- 11 │         0x0 / 0x1;
-    │         --- Found: 'address'. But expected: 'u8', 'u64', 'u128'
     │
 
 error: 
 
-    ┌── tests/move_check/typing/binary_div_invalid.move:11:15 ───
+    ┌── tests/move_check/typing/binary_div_invalid.move:11:9 ───
     │
  11 │         0x0 / 0x1;
+    │         --- Found: 'address'. But expected: 'u8', 'u64', 'u128'
     │               ^^^ Invalid argument to '/'
-    ·
- 11 │         0x0 / 0x1;
-    │         --- Found: 'address'. But expected: 'u8', 'u64', 'u128'
     │
 
 error: 
 
-    ┌── tests/move_check/typing/binary_div_invalid.move:12:19 ───
+    ┌── tests/move_check/typing/binary_div_invalid.move:12:13 ───
     │
- 12 │         (0: u8) / (1: u128);
-    │                   ^^^^^^^^^ Incompatible arguments to '/'
-    ·
  12 │         (0: u8) / (1: u128);
     │             -- The type: 'u8'
-    ·
- 12 │         (0: u8) / (1: u128);
+    │                   ^^^^^^^^^ Incompatible arguments to '/'
     │                       ---- Is not compatible with: 'u128'
     │
 
 error: 
 
-    ┌── tests/move_check/typing/binary_div_invalid.move:13:9 ───
+    ┌── tests/move_check/typing/binary_div_invalid.move:7:23 ───
     │
- 13 │         r / r;
-    │         ^ Invalid argument to '/'
-    ·
   7 │     fun t0(x: u64, r: R, s: S) {
     │                       - Found: '0x8675309::M::R'. But expected: 'u8', 'u64', 'u128'
+    ·
+ 13 │         r / r;
+    │         ^ Invalid argument to '/'
     │
 
 error: 
 
-    ┌── tests/move_check/typing/binary_div_invalid.move:13:9 ───
+    ┌── tests/move_check/typing/binary_div_invalid.move:3:5 ───
     │
- 13 │         r / r;
-    │         ^^^^^ Cannot ignore resource values. The value must be used
+  3 │     resource struct R {
+    │     -------- Is found to be a non-copyable type here
     ·
   7 │     fun t0(x: u64, r: R, s: S) {
     │                       - The type: '0x8675309::M::R'
     ·
-  3 │     resource struct R {
-    │     -------- Is found to be a non-copyable type here
+ 13 │         r / r;
+    │         ^^^^^ Cannot ignore resource values. The value must be used
     │
 
 error: 
 
-    ┌── tests/move_check/typing/binary_div_invalid.move:13:13 ───
+    ┌── tests/move_check/typing/binary_div_invalid.move:7:23 ───
     │
- 13 │         r / r;
-    │             ^ Invalid argument to '/'
-    ·
   7 │     fun t0(x: u64, r: R, s: S) {
     │                       - Found: '0x8675309::M::R'. But expected: 'u8', 'u64', 'u128'
+    ·
+ 13 │         r / r;
+    │             ^ Invalid argument to '/'
     │
 
 error: 
 
-    ┌── tests/move_check/typing/binary_div_invalid.move:14:9 ───
+    ┌── tests/move_check/typing/binary_div_invalid.move:7:29 ───
     │
+  7 │     fun t0(x: u64, r: R, s: S) {
+    │                             - Found: '0x8675309::M::S'. But expected: 'u8', 'u64', 'u128'
+    ·
  14 │         s / s;
     │         ^ Invalid argument to '/'
-    ·
-  7 │     fun t0(x: u64, r: R, s: S) {
-    │                             - Found: '0x8675309::M::S'. But expected: 'u8', 'u64', 'u128'
     │
 
 error: 
 
-    ┌── tests/move_check/typing/binary_div_invalid.move:14:13 ───
+    ┌── tests/move_check/typing/binary_div_invalid.move:7:29 ───
     │
- 14 │         s / s;
-    │             ^ Invalid argument to '/'
-    ·
   7 │     fun t0(x: u64, r: R, s: S) {
     │                             - Found: '0x8675309::M::S'. But expected: 'u8', 'u64', 'u128'
+    ·
+ 14 │         s / s;
+    │             ^ Invalid argument to '/'
     │
 
 error: 
@@ -170,8 +146,6 @@ error:
     │
  15 │         1 / false / 0x0 / 0;
     │         ^^^^^^^^^ Invalid argument to '/'
-    ·
- 15 │         1 / false / 0x0 / 0;
     │             ----- Found: '_'. But expected: 'u8', 'u64', 'u128'
     │
 
@@ -181,9 +155,17 @@ error:
     │
  15 │         1 / false / 0x0 / 0;
     │         ^^^^^^^^^^^^^^^ Invalid argument to '/'
-    ·
- 15 │         1 / false / 0x0 / 0;
     │                     --- Found: 'address'. But expected: 'u8', 'u64', 'u128'
+    │
+
+error: 
+
+    ┌── tests/move_check/typing/binary_div_invalid.move:15:9 ───
+    │
+ 15 │         1 / false / 0x0 / 0;
+    │         - The type: integer
+    │             ----- Is not compatible with: 'bool'
+    │             ^^^^^ Incompatible arguments to '/'
     │
 
 error: 
@@ -191,13 +173,8 @@ error:
     ┌── tests/move_check/typing/binary_div_invalid.move:15:13 ───
     │
  15 │         1 / false / 0x0 / 0;
-    │             ^^^^^ Incompatible arguments to '/'
-    ·
- 15 │         1 / false / 0x0 / 0;
-    │         - The type: integer
-    ·
- 15 │         1 / false / 0x0 / 0;
-    │             ----- Is not compatible with: 'bool'
+    │             ----- Found: '_'. But expected: 'u8', 'u64', 'u128'
+    │                     ^^^ Invalid argument to '/'
     │
 
 error: 
@@ -205,35 +182,18 @@ error:
     ┌── tests/move_check/typing/binary_div_invalid.move:15:21 ───
     │
  15 │         1 / false / 0x0 / 0;
-    │                     ^^^ Invalid argument to '/'
-    ·
- 15 │         1 / false / 0x0 / 0;
-    │             ----- Found: '_'. But expected: 'u8', 'u64', 'u128'
-    │
-
-error: 
-
-    ┌── tests/move_check/typing/binary_div_invalid.move:15:27 ───
-    │
- 15 │         1 / false / 0x0 / 0;
-    │                           ^ Incompatible arguments to '/'
-    ·
- 15 │         1 / false / 0x0 / 0;
-    │                           - The type: integer
-    ·
- 15 │         1 / false / 0x0 / 0;
     │                     --- Is not compatible with: 'address'
+    │                           - The type: integer
+    │                           ^ Incompatible arguments to '/'
     │
 
 error: 
 
-    ┌── tests/move_check/typing/binary_div_invalid.move:15:27 ───
+    ┌── tests/move_check/typing/binary_div_invalid.move:15:21 ───
     │
- 15 │         1 / false / 0x0 / 0;
-    │                           ^ Invalid argument to '/'
-    ·
  15 │         1 / false / 0x0 / 0;
     │                     --- Found: 'address'. But expected: 'u8', 'u64', 'u128'
+    │                           ^ Invalid argument to '/'
     │
 
 error: 
@@ -241,35 +201,27 @@ error:
     ┌── tests/move_check/typing/binary_div_invalid.move:16:9 ───
     │
  16 │         () / ();
+    │         -- Found: '()'. But expected: 'u8', 'u64', 'u128'
     │         ^^ Invalid argument to '/'
-    ·
- 16 │         () / ();
-    │         -- Found: '()'. But expected: 'u8', 'u64', 'u128'
     │
 
 error: 
 
-    ┌── tests/move_check/typing/binary_div_invalid.move:16:14 ───
+    ┌── tests/move_check/typing/binary_div_invalid.move:16:9 ───
     │
  16 │         () / ();
+    │         -- Found: '()'. But expected: 'u8', 'u64', 'u128'
     │              ^^ Invalid argument to '/'
-    ·
- 16 │         () / ();
-    │         -- Found: '()'. But expected: 'u8', 'u64', 'u128'
     │
 
 error: 
 
-    ┌── tests/move_check/typing/binary_div_invalid.move:17:13 ───
+    ┌── tests/move_check/typing/binary_div_invalid.move:17:9 ───
     │
- 17 │         1 / ();
-    │             ^^ Incompatible arguments to '/'
-    ·
  17 │         1 / ();
     │         - The type: integer
-    ·
- 17 │         1 / ();
     │             -- Is not compatible with: '()'
+    │             ^^ Incompatible arguments to '/'
     │
 
 error: 
@@ -277,35 +229,27 @@ error:
     ┌── tests/move_check/typing/binary_div_invalid.move:18:9 ───
     │
  18 │         (0, 1) / (0, 1, 2);
-    │         ^^^^^^ Invalid argument to '/'
-    ·
- 18 │         (0, 1) / (0, 1, 2);
     │         ------ Found: '(u64, u64)'. But expected: 'u8', 'u64', 'u128'
+    │         ^^^^^^ Invalid argument to '/'
     │
 
 error: 
 
-    ┌── tests/move_check/typing/binary_div_invalid.move:18:18 ───
+    ┌── tests/move_check/typing/binary_div_invalid.move:18:9 ───
     │
- 18 │         (0, 1) / (0, 1, 2);
-    │                  ^^^^^^^^^ Incompatible arguments to '/'
-    ·
  18 │         (0, 1) / (0, 1, 2);
     │         ------ The expression list type of length 2: '({integer}, {integer})'
-    ·
- 18 │         (0, 1) / (0, 1, 2);
     │                  --------- Is not compatible with the expression list type of length 3: '({integer}, {integer}, {integer})'
+    │                  ^^^^^^^^^ Incompatible arguments to '/'
     │
 
 error: 
 
-    ┌── tests/move_check/typing/binary_div_invalid.move:18:18 ───
+    ┌── tests/move_check/typing/binary_div_invalid.move:18:9 ───
     │
  18 │         (0, 1) / (0, 1, 2);
-    │                  ^^^^^^^^^ Invalid argument to '/'
-    ·
- 18 │         (0, 1) / (0, 1, 2);
     │         ------ Found: '(u64, u64)'. But expected: 'u8', 'u64', 'u128'
+    │                  ^^^^^^^^^ Invalid argument to '/'
     │
 
 error: 
@@ -313,20 +257,16 @@ error:
     ┌── tests/move_check/typing/binary_div_invalid.move:19:9 ───
     │
  19 │         (1, 2) / (0, 1);
-    │         ^^^^^^ Invalid argument to '/'
-    ·
- 19 │         (1, 2) / (0, 1);
     │         ------ Found: '(u64, u64)'. But expected: 'u8', 'u64', 'u128'
+    │         ^^^^^^ Invalid argument to '/'
     │
 
 error: 
 
-    ┌── tests/move_check/typing/binary_div_invalid.move:19:18 ───
+    ┌── tests/move_check/typing/binary_div_invalid.move:19:9 ───
     │
  19 │         (1, 2) / (0, 1);
-    │                  ^^^^^^ Invalid argument to '/'
-    ·
- 19 │         (1, 2) / (0, 1);
     │         ------ Found: '(u64, u64)'. But expected: 'u8', 'u64', 'u128'
+    │                  ^^^^^^ Invalid argument to '/'
     │
 

--- a/language/move-lang/tests/move_check/typing/binary_geq_invalid.exp
+++ b/language/move-lang/tests/move_check/typing/binary_geq_invalid.exp
@@ -3,35 +3,27 @@ error:
    ┌── tests/move_check/typing/binary_geq_invalid.move:8:9 ───
    │
  8 │         false >= true;
+   │         ----- Found: 'bool'. But expected: 'u8', 'u64', 'u128'
    │         ^^^^^ Invalid argument to '>='
-   ·
- 8 │         false >= true;
-   │         ----- Found: 'bool'. But expected: 'u8', 'u64', 'u128'
    │
 
 error: 
 
-   ┌── tests/move_check/typing/binary_geq_invalid.move:8:18 ───
+   ┌── tests/move_check/typing/binary_geq_invalid.move:8:9 ───
    │
  8 │         false >= true;
+   │         ----- Found: 'bool'. But expected: 'u8', 'u64', 'u128'
    │                  ^^^^ Invalid argument to '>='
-   ·
- 8 │         false >= true;
-   │         ----- Found: 'bool'. But expected: 'u8', 'u64', 'u128'
    │
 
 error: 
 
-   ┌── tests/move_check/typing/binary_geq_invalid.move:9:14 ───
+   ┌── tests/move_check/typing/binary_geq_invalid.move:9:9 ───
    │
- 9 │         1 >= false;
-   │              ^^^^^ Incompatible arguments to '>='
-   ·
  9 │         1 >= false;
    │         - The type: integer
-   ·
- 9 │         1 >= false;
    │              ----- Is not compatible with: 'bool'
+   │              ^^^^^ Incompatible arguments to '>='
    │
 
 error: 
@@ -39,35 +31,27 @@ error:
     ┌── tests/move_check/typing/binary_geq_invalid.move:10:9 ───
     │
  10 │         false >= 1;
-    │         ^^^^^ Invalid argument to '>='
-    ·
- 10 │         false >= 1;
     │         ----- Found: 'bool'. But expected: 'u8', 'u64', 'u128'
+    │         ^^^^^ Invalid argument to '>='
     │
 
 error: 
 
-    ┌── tests/move_check/typing/binary_geq_invalid.move:10:18 ───
+    ┌── tests/move_check/typing/binary_geq_invalid.move:10:9 ───
     │
- 10 │         false >= 1;
-    │                  ^ Incompatible arguments to '>='
-    ·
- 10 │         false >= 1;
-    │                  - The type: integer
-    ·
  10 │         false >= 1;
     │         ----- Is not compatible with: 'bool'
+    │                  - The type: integer
+    │                  ^ Incompatible arguments to '>='
     │
 
 error: 
 
-    ┌── tests/move_check/typing/binary_geq_invalid.move:10:18 ───
+    ┌── tests/move_check/typing/binary_geq_invalid.move:10:9 ───
     │
  10 │         false >= 1;
-    │                  ^ Invalid argument to '>='
-    ·
- 10 │         false >= 1;
     │         ----- Found: 'bool'. But expected: 'u8', 'u64', 'u128'
+    │                  ^ Invalid argument to '>='
     │
 
 error: 
@@ -75,79 +59,71 @@ error:
     ┌── tests/move_check/typing/binary_geq_invalid.move:11:9 ───
     │
  11 │         0x0 >= 0x1;
+    │         --- Found: 'address'. But expected: 'u8', 'u64', 'u128'
     │         ^^^ Invalid argument to '>='
-    ·
- 11 │         0x0 >= 0x1;
-    │         --- Found: 'address'. But expected: 'u8', 'u64', 'u128'
     │
 
 error: 
 
-    ┌── tests/move_check/typing/binary_geq_invalid.move:11:16 ───
+    ┌── tests/move_check/typing/binary_geq_invalid.move:11:9 ───
     │
  11 │         0x0 >= 0x1;
+    │         --- Found: 'address'. But expected: 'u8', 'u64', 'u128'
     │                ^^^ Invalid argument to '>='
-    ·
- 11 │         0x0 >= 0x1;
-    │         --- Found: 'address'. But expected: 'u8', 'u64', 'u128'
     │
 
 error: 
 
-    ┌── tests/move_check/typing/binary_geq_invalid.move:12:20 ───
+    ┌── tests/move_check/typing/binary_geq_invalid.move:12:13 ───
     │
- 12 │         (0: u8) >= (1: u128);
-    │                    ^^^^^^^^^ Incompatible arguments to '>='
-    ·
  12 │         (0: u8) >= (1: u128);
     │             -- The type: 'u8'
-    ·
- 12 │         (0: u8) >= (1: u128);
+    │                    ^^^^^^^^^ Incompatible arguments to '>='
     │                        ---- Is not compatible with: 'u128'
     │
 
 error: 
 
-    ┌── tests/move_check/typing/binary_geq_invalid.move:13:9 ───
+    ┌── tests/move_check/typing/binary_geq_invalid.move:7:23 ───
     │
- 13 │         r >= r;
-    │         ^ Invalid argument to '>='
-    ·
   7 │     fun t0(x: u64, r: R, s: S) {
     │                       - Found: '0x8675309::M::R'. But expected: 'u8', 'u64', 'u128'
+    ·
+ 13 │         r >= r;
+    │         ^ Invalid argument to '>='
     │
 
 error: 
 
-    ┌── tests/move_check/typing/binary_geq_invalid.move:13:14 ───
+    ┌── tests/move_check/typing/binary_geq_invalid.move:7:23 ───
     │
- 13 │         r >= r;
-    │              ^ Invalid argument to '>='
-    ·
   7 │     fun t0(x: u64, r: R, s: S) {
     │                       - Found: '0x8675309::M::R'. But expected: 'u8', 'u64', 'u128'
+    ·
+ 13 │         r >= r;
+    │              ^ Invalid argument to '>='
     │
 
 error: 
 
-    ┌── tests/move_check/typing/binary_geq_invalid.move:14:9 ───
+    ┌── tests/move_check/typing/binary_geq_invalid.move:7:29 ───
     │
+  7 │     fun t0(x: u64, r: R, s: S) {
+    │                             - Found: '0x8675309::M::S'. But expected: 'u8', 'u64', 'u128'
+    ·
  14 │         s >= s;
     │         ^ Invalid argument to '>='
-    ·
-  7 │     fun t0(x: u64, r: R, s: S) {
-    │                             - Found: '0x8675309::M::S'. But expected: 'u8', 'u64', 'u128'
     │
 
 error: 
 
-    ┌── tests/move_check/typing/binary_geq_invalid.move:14:14 ───
+    ┌── tests/move_check/typing/binary_geq_invalid.move:7:29 ───
     │
- 14 │         s >= s;
-    │              ^ Invalid argument to '>='
-    ·
   7 │     fun t0(x: u64, r: R, s: S) {
     │                             - Found: '0x8675309::M::S'. But expected: 'u8', 'u64', 'u128'
+    ·
+ 14 │         s >= s;
+    │              ^ Invalid argument to '>='
     │
 
 error: 
@@ -155,49 +131,37 @@ error:
     ┌── tests/move_check/typing/binary_geq_invalid.move:15:9 ───
     │
  15 │         0 >= 1 >= 2;
-    │         ^^^^^^ Invalid argument to '>='
-    ·
- 15 │         0 >= 1 >= 2;
     │         ------ Found: 'bool'. But expected: 'u8', 'u64', 'u128'
+    │         ^^^^^^ Invalid argument to '>='
     │
 
 error: 
 
-    ┌── tests/move_check/typing/binary_geq_invalid.move:15:19 ───
+    ┌── tests/move_check/typing/binary_geq_invalid.move:15:9 ───
     │
- 15 │         0 >= 1 >= 2;
-    │                   ^ Incompatible arguments to '>='
-    ·
- 15 │         0 >= 1 >= 2;
-    │                   - The type: integer
-    ·
  15 │         0 >= 1 >= 2;
     │         ------ Is not compatible with: 'bool'
+    │                   - The type: integer
+    │                   ^ Incompatible arguments to '>='
     │
 
 error: 
 
-    ┌── tests/move_check/typing/binary_geq_invalid.move:15:19 ───
+    ┌── tests/move_check/typing/binary_geq_invalid.move:15:9 ───
     │
- 15 │         0 >= 1 >= 2;
-    │                   ^ Invalid argument to '>='
-    ·
  15 │         0 >= 1 >= 2;
     │         ------ Found: 'bool'. But expected: 'u8', 'u64', 'u128'
+    │                   ^ Invalid argument to '>='
     │
 
 error: 
 
-    ┌── tests/move_check/typing/binary_geq_invalid.move:16:15 ───
+    ┌── tests/move_check/typing/binary_geq_invalid.move:16:10 ───
     │
  16 │         (1 >= false) && (0x0 >= 0);
-    │               ^^^^^ Incompatible arguments to '>='
-    ·
- 16 │         (1 >= false) && (0x0 >= 0);
     │          - The type: integer
-    ·
- 16 │         (1 >= false) && (0x0 >= 0);
     │               ----- Is not compatible with: 'bool'
+    │               ^^^^^ Incompatible arguments to '>='
     │
 
 error: 
@@ -205,35 +169,27 @@ error:
     ┌── tests/move_check/typing/binary_geq_invalid.move:16:26 ───
     │
  16 │         (1 >= false) && (0x0 >= 0);
-    │                          ^^^ Invalid argument to '>='
-    ·
- 16 │         (1 >= false) && (0x0 >= 0);
     │                          --- Found: 'address'. But expected: 'u8', 'u64', 'u128'
+    │                          ^^^ Invalid argument to '>='
     │
 
 error: 
 
-    ┌── tests/move_check/typing/binary_geq_invalid.move:16:33 ───
+    ┌── tests/move_check/typing/binary_geq_invalid.move:16:26 ───
     │
- 16 │         (1 >= false) && (0x0 >= 0);
-    │                                 ^ Incompatible arguments to '>='
-    ·
- 16 │         (1 >= false) && (0x0 >= 0);
-    │                                 - The type: integer
-    ·
  16 │         (1 >= false) && (0x0 >= 0);
     │                          --- Is not compatible with: 'address'
+    │                                 - The type: integer
+    │                                 ^ Incompatible arguments to '>='
     │
 
 error: 
 
-    ┌── tests/move_check/typing/binary_geq_invalid.move:16:33 ───
+    ┌── tests/move_check/typing/binary_geq_invalid.move:16:26 ───
     │
  16 │         (1 >= false) && (0x0 >= 0);
-    │                                 ^ Invalid argument to '>='
-    ·
- 16 │         (1 >= false) && (0x0 >= 0);
     │                          --- Found: 'address'. But expected: 'u8', 'u64', 'u128'
+    │                                 ^ Invalid argument to '>='
     │
 
 error: 
@@ -241,35 +197,27 @@ error:
     ┌── tests/move_check/typing/binary_geq_invalid.move:17:9 ───
     │
  17 │         () >= ();
+    │         -- Found: '()'. But expected: 'u8', 'u64', 'u128'
     │         ^^ Invalid argument to '>='
-    ·
- 17 │         () >= ();
-    │         -- Found: '()'. But expected: 'u8', 'u64', 'u128'
     │
 
 error: 
 
-    ┌── tests/move_check/typing/binary_geq_invalid.move:17:15 ───
+    ┌── tests/move_check/typing/binary_geq_invalid.move:17:9 ───
     │
  17 │         () >= ();
+    │         -- Found: '()'. But expected: 'u8', 'u64', 'u128'
     │               ^^ Invalid argument to '>='
-    ·
- 17 │         () >= ();
-    │         -- Found: '()'. But expected: 'u8', 'u64', 'u128'
     │
 
 error: 
 
-    ┌── tests/move_check/typing/binary_geq_invalid.move:18:14 ───
+    ┌── tests/move_check/typing/binary_geq_invalid.move:18:9 ───
     │
- 18 │         1 >= ();
-    │              ^^ Incompatible arguments to '>='
-    ·
  18 │         1 >= ();
     │         - The type: integer
-    ·
- 18 │         1 >= ();
     │              -- Is not compatible with: '()'
+    │              ^^ Incompatible arguments to '>='
     │
 
 error: 
@@ -277,35 +225,27 @@ error:
     ┌── tests/move_check/typing/binary_geq_invalid.move:19:9 ───
     │
  19 │         (0, 1) >= (0, 1, 2);
-    │         ^^^^^^ Invalid argument to '>='
-    ·
- 19 │         (0, 1) >= (0, 1, 2);
     │         ------ Found: '(u64, u64)'. But expected: 'u8', 'u64', 'u128'
+    │         ^^^^^^ Invalid argument to '>='
     │
 
 error: 
 
-    ┌── tests/move_check/typing/binary_geq_invalid.move:19:19 ───
+    ┌── tests/move_check/typing/binary_geq_invalid.move:19:9 ───
     │
- 19 │         (0, 1) >= (0, 1, 2);
-    │                   ^^^^^^^^^ Incompatible arguments to '>='
-    ·
  19 │         (0, 1) >= (0, 1, 2);
     │         ------ The expression list type of length 2: '({integer}, {integer})'
-    ·
- 19 │         (0, 1) >= (0, 1, 2);
     │                   --------- Is not compatible with the expression list type of length 3: '({integer}, {integer}, {integer})'
+    │                   ^^^^^^^^^ Incompatible arguments to '>='
     │
 
 error: 
 
-    ┌── tests/move_check/typing/binary_geq_invalid.move:19:19 ───
+    ┌── tests/move_check/typing/binary_geq_invalid.move:19:9 ───
     │
  19 │         (0, 1) >= (0, 1, 2);
-    │                   ^^^^^^^^^ Invalid argument to '>='
-    ·
- 19 │         (0, 1) >= (0, 1, 2);
     │         ------ Found: '(u64, u64)'. But expected: 'u8', 'u64', 'u128'
+    │                   ^^^^^^^^^ Invalid argument to '>='
     │
 
 error: 
@@ -313,20 +253,16 @@ error:
     ┌── tests/move_check/typing/binary_geq_invalid.move:20:9 ───
     │
  20 │         (1, 2) >= (0, 1);
-    │         ^^^^^^ Invalid argument to '>='
-    ·
- 20 │         (1, 2) >= (0, 1);
     │         ------ Found: '(u64, u64)'. But expected: 'u8', 'u64', 'u128'
+    │         ^^^^^^ Invalid argument to '>='
     │
 
 error: 
 
-    ┌── tests/move_check/typing/binary_geq_invalid.move:20:19 ───
+    ┌── tests/move_check/typing/binary_geq_invalid.move:20:9 ───
     │
  20 │         (1, 2) >= (0, 1);
-    │                   ^^^^^^ Invalid argument to '>='
-    ·
- 20 │         (1, 2) >= (0, 1);
     │         ------ Found: '(u64, u64)'. But expected: 'u8', 'u64', 'u128'
+    │                   ^^^^^^ Invalid argument to '>='
     │
 

--- a/language/move-lang/tests/move_check/typing/binary_gt_invalid.exp
+++ b/language/move-lang/tests/move_check/typing/binary_gt_invalid.exp
@@ -3,35 +3,27 @@ error:
    ┌── tests/move_check/typing/binary_gt_invalid.move:8:9 ───
    │
  8 │         false > true;
+   │         ----- Found: 'bool'. But expected: 'u8', 'u64', 'u128'
    │         ^^^^^ Invalid argument to '>'
-   ·
- 8 │         false > true;
-   │         ----- Found: 'bool'. But expected: 'u8', 'u64', 'u128'
    │
 
 error: 
 
-   ┌── tests/move_check/typing/binary_gt_invalid.move:8:17 ───
+   ┌── tests/move_check/typing/binary_gt_invalid.move:8:9 ───
    │
  8 │         false > true;
+   │         ----- Found: 'bool'. But expected: 'u8', 'u64', 'u128'
    │                 ^^^^ Invalid argument to '>'
-   ·
- 8 │         false > true;
-   │         ----- Found: 'bool'. But expected: 'u8', 'u64', 'u128'
    │
 
 error: 
 
-   ┌── tests/move_check/typing/binary_gt_invalid.move:9:13 ───
+   ┌── tests/move_check/typing/binary_gt_invalid.move:9:9 ───
    │
- 9 │         1 > false;
-   │             ^^^^^ Incompatible arguments to '>'
-   ·
  9 │         1 > false;
    │         - The type: integer
-   ·
- 9 │         1 > false;
    │             ----- Is not compatible with: 'bool'
+   │             ^^^^^ Incompatible arguments to '>'
    │
 
 error: 
@@ -39,35 +31,27 @@ error:
     ┌── tests/move_check/typing/binary_gt_invalid.move:10:9 ───
     │
  10 │         false > 1;
-    │         ^^^^^ Invalid argument to '>'
-    ·
- 10 │         false > 1;
     │         ----- Found: 'bool'. But expected: 'u8', 'u64', 'u128'
+    │         ^^^^^ Invalid argument to '>'
     │
 
 error: 
 
-    ┌── tests/move_check/typing/binary_gt_invalid.move:10:17 ───
+    ┌── tests/move_check/typing/binary_gt_invalid.move:10:9 ───
     │
- 10 │         false > 1;
-    │                 ^ Incompatible arguments to '>'
-    ·
- 10 │         false > 1;
-    │                 - The type: integer
-    ·
  10 │         false > 1;
     │         ----- Is not compatible with: 'bool'
+    │                 - The type: integer
+    │                 ^ Incompatible arguments to '>'
     │
 
 error: 
 
-    ┌── tests/move_check/typing/binary_gt_invalid.move:10:17 ───
+    ┌── tests/move_check/typing/binary_gt_invalid.move:10:9 ───
     │
  10 │         false > 1;
-    │                 ^ Invalid argument to '>'
-    ·
- 10 │         false > 1;
     │         ----- Found: 'bool'. But expected: 'u8', 'u64', 'u128'
+    │                 ^ Invalid argument to '>'
     │
 
 error: 
@@ -75,79 +59,71 @@ error:
     ┌── tests/move_check/typing/binary_gt_invalid.move:11:9 ───
     │
  11 │         0x0 > 0x1;
+    │         --- Found: 'address'. But expected: 'u8', 'u64', 'u128'
     │         ^^^ Invalid argument to '>'
-    ·
- 11 │         0x0 > 0x1;
-    │         --- Found: 'address'. But expected: 'u8', 'u64', 'u128'
     │
 
 error: 
 
-    ┌── tests/move_check/typing/binary_gt_invalid.move:11:15 ───
+    ┌── tests/move_check/typing/binary_gt_invalid.move:11:9 ───
     │
  11 │         0x0 > 0x1;
+    │         --- Found: 'address'. But expected: 'u8', 'u64', 'u128'
     │               ^^^ Invalid argument to '>'
-    ·
- 11 │         0x0 > 0x1;
-    │         --- Found: 'address'. But expected: 'u8', 'u64', 'u128'
     │
 
 error: 
 
-    ┌── tests/move_check/typing/binary_gt_invalid.move:12:19 ───
+    ┌── tests/move_check/typing/binary_gt_invalid.move:12:13 ───
     │
- 12 │         (0: u8) > (1: u128);
-    │                   ^^^^^^^^^ Incompatible arguments to '>'
-    ·
  12 │         (0: u8) > (1: u128);
     │             -- The type: 'u8'
-    ·
- 12 │         (0: u8) > (1: u128);
+    │                   ^^^^^^^^^ Incompatible arguments to '>'
     │                       ---- Is not compatible with: 'u128'
     │
 
 error: 
 
-    ┌── tests/move_check/typing/binary_gt_invalid.move:13:9 ───
+    ┌── tests/move_check/typing/binary_gt_invalid.move:7:23 ───
     │
- 13 │         r > r;
-    │         ^ Invalid argument to '>'
-    ·
   7 │     fun t0(x: u64, r: R, s: S) {
     │                       - Found: '0x8675309::M::R'. But expected: 'u8', 'u64', 'u128'
+    ·
+ 13 │         r > r;
+    │         ^ Invalid argument to '>'
     │
 
 error: 
 
-    ┌── tests/move_check/typing/binary_gt_invalid.move:13:13 ───
+    ┌── tests/move_check/typing/binary_gt_invalid.move:7:23 ───
     │
- 13 │         r > r;
-    │             ^ Invalid argument to '>'
-    ·
   7 │     fun t0(x: u64, r: R, s: S) {
     │                       - Found: '0x8675309::M::R'. But expected: 'u8', 'u64', 'u128'
+    ·
+ 13 │         r > r;
+    │             ^ Invalid argument to '>'
     │
 
 error: 
 
-    ┌── tests/move_check/typing/binary_gt_invalid.move:14:9 ───
+    ┌── tests/move_check/typing/binary_gt_invalid.move:7:29 ───
     │
+  7 │     fun t0(x: u64, r: R, s: S) {
+    │                             - Found: '0x8675309::M::S'. But expected: 'u8', 'u64', 'u128'
+    ·
  14 │         s > s;
     │         ^ Invalid argument to '>'
-    ·
-  7 │     fun t0(x: u64, r: R, s: S) {
-    │                             - Found: '0x8675309::M::S'. But expected: 'u8', 'u64', 'u128'
     │
 
 error: 
 
-    ┌── tests/move_check/typing/binary_gt_invalid.move:14:13 ───
+    ┌── tests/move_check/typing/binary_gt_invalid.move:7:29 ───
     │
- 14 │         s > s;
-    │             ^ Invalid argument to '>'
-    ·
   7 │     fun t0(x: u64, r: R, s: S) {
     │                             - Found: '0x8675309::M::S'. But expected: 'u8', 'u64', 'u128'
+    ·
+ 14 │         s > s;
+    │             ^ Invalid argument to '>'
     │
 
 error: 
@@ -155,49 +131,37 @@ error:
     ┌── tests/move_check/typing/binary_gt_invalid.move:15:9 ───
     │
  15 │         0 > 1 > 2;
-    │         ^^^^^ Invalid argument to '>'
-    ·
- 15 │         0 > 1 > 2;
     │         ----- Found: 'bool'. But expected: 'u8', 'u64', 'u128'
+    │         ^^^^^ Invalid argument to '>'
     │
 
 error: 
 
-    ┌── tests/move_check/typing/binary_gt_invalid.move:15:17 ───
+    ┌── tests/move_check/typing/binary_gt_invalid.move:15:9 ───
     │
- 15 │         0 > 1 > 2;
-    │                 ^ Incompatible arguments to '>'
-    ·
- 15 │         0 > 1 > 2;
-    │                 - The type: integer
-    ·
  15 │         0 > 1 > 2;
     │         ----- Is not compatible with: 'bool'
+    │                 - The type: integer
+    │                 ^ Incompatible arguments to '>'
     │
 
 error: 
 
-    ┌── tests/move_check/typing/binary_gt_invalid.move:15:17 ───
+    ┌── tests/move_check/typing/binary_gt_invalid.move:15:9 ───
     │
- 15 │         0 > 1 > 2;
-    │                 ^ Invalid argument to '>'
-    ·
  15 │         0 > 1 > 2;
     │         ----- Found: 'bool'. But expected: 'u8', 'u64', 'u128'
+    │                 ^ Invalid argument to '>'
     │
 
 error: 
 
-    ┌── tests/move_check/typing/binary_gt_invalid.move:16:14 ───
+    ┌── tests/move_check/typing/binary_gt_invalid.move:16:10 ───
     │
  16 │         (1 > false) && (0x0 > 0);
-    │              ^^^^^ Incompatible arguments to '>'
-    ·
- 16 │         (1 > false) && (0x0 > 0);
     │          - The type: integer
-    ·
- 16 │         (1 > false) && (0x0 > 0);
     │              ----- Is not compatible with: 'bool'
+    │              ^^^^^ Incompatible arguments to '>'
     │
 
 error: 
@@ -205,35 +169,27 @@ error:
     ┌── tests/move_check/typing/binary_gt_invalid.move:16:25 ───
     │
  16 │         (1 > false) && (0x0 > 0);
-    │                         ^^^ Invalid argument to '>'
-    ·
- 16 │         (1 > false) && (0x0 > 0);
     │                         --- Found: 'address'. But expected: 'u8', 'u64', 'u128'
+    │                         ^^^ Invalid argument to '>'
     │
 
 error: 
 
-    ┌── tests/move_check/typing/binary_gt_invalid.move:16:31 ───
+    ┌── tests/move_check/typing/binary_gt_invalid.move:16:25 ───
     │
- 16 │         (1 > false) && (0x0 > 0);
-    │                               ^ Incompatible arguments to '>'
-    ·
- 16 │         (1 > false) && (0x0 > 0);
-    │                               - The type: integer
-    ·
  16 │         (1 > false) && (0x0 > 0);
     │                         --- Is not compatible with: 'address'
+    │                               - The type: integer
+    │                               ^ Incompatible arguments to '>'
     │
 
 error: 
 
-    ┌── tests/move_check/typing/binary_gt_invalid.move:16:31 ───
+    ┌── tests/move_check/typing/binary_gt_invalid.move:16:25 ───
     │
  16 │         (1 > false) && (0x0 > 0);
-    │                               ^ Invalid argument to '>'
-    ·
- 16 │         (1 > false) && (0x0 > 0);
     │                         --- Found: 'address'. But expected: 'u8', 'u64', 'u128'
+    │                               ^ Invalid argument to '>'
     │
 
 error: 
@@ -241,35 +197,27 @@ error:
     ┌── tests/move_check/typing/binary_gt_invalid.move:17:9 ───
     │
  17 │         () > ();
+    │         -- Found: '()'. But expected: 'u8', 'u64', 'u128'
     │         ^^ Invalid argument to '>'
-    ·
- 17 │         () > ();
-    │         -- Found: '()'. But expected: 'u8', 'u64', 'u128'
     │
 
 error: 
 
-    ┌── tests/move_check/typing/binary_gt_invalid.move:17:14 ───
+    ┌── tests/move_check/typing/binary_gt_invalid.move:17:9 ───
     │
  17 │         () > ();
+    │         -- Found: '()'. But expected: 'u8', 'u64', 'u128'
     │              ^^ Invalid argument to '>'
-    ·
- 17 │         () > ();
-    │         -- Found: '()'. But expected: 'u8', 'u64', 'u128'
     │
 
 error: 
 
-    ┌── tests/move_check/typing/binary_gt_invalid.move:18:13 ───
+    ┌── tests/move_check/typing/binary_gt_invalid.move:18:9 ───
     │
- 18 │         1 > ();
-    │             ^^ Incompatible arguments to '>'
-    ·
  18 │         1 > ();
     │         - The type: integer
-    ·
- 18 │         1 > ();
     │             -- Is not compatible with: '()'
+    │             ^^ Incompatible arguments to '>'
     │
 
 error: 
@@ -277,35 +225,27 @@ error:
     ┌── tests/move_check/typing/binary_gt_invalid.move:19:9 ───
     │
  19 │         (0, 1) > (0, 1, 2);
-    │         ^^^^^^ Invalid argument to '>'
-    ·
- 19 │         (0, 1) > (0, 1, 2);
     │         ------ Found: '(u64, u64)'. But expected: 'u8', 'u64', 'u128'
+    │         ^^^^^^ Invalid argument to '>'
     │
 
 error: 
 
-    ┌── tests/move_check/typing/binary_gt_invalid.move:19:18 ───
+    ┌── tests/move_check/typing/binary_gt_invalid.move:19:9 ───
     │
- 19 │         (0, 1) > (0, 1, 2);
-    │                  ^^^^^^^^^ Incompatible arguments to '>'
-    ·
  19 │         (0, 1) > (0, 1, 2);
     │         ------ The expression list type of length 2: '({integer}, {integer})'
-    ·
- 19 │         (0, 1) > (0, 1, 2);
     │                  --------- Is not compatible with the expression list type of length 3: '({integer}, {integer}, {integer})'
+    │                  ^^^^^^^^^ Incompatible arguments to '>'
     │
 
 error: 
 
-    ┌── tests/move_check/typing/binary_gt_invalid.move:19:18 ───
+    ┌── tests/move_check/typing/binary_gt_invalid.move:19:9 ───
     │
  19 │         (0, 1) > (0, 1, 2);
-    │                  ^^^^^^^^^ Invalid argument to '>'
-    ·
- 19 │         (0, 1) > (0, 1, 2);
     │         ------ Found: '(u64, u64)'. But expected: 'u8', 'u64', 'u128'
+    │                  ^^^^^^^^^ Invalid argument to '>'
     │
 
 error: 
@@ -313,20 +253,16 @@ error:
     ┌── tests/move_check/typing/binary_gt_invalid.move:20:9 ───
     │
  20 │         (1, 2) > (0, 1);
-    │         ^^^^^^ Invalid argument to '>'
-    ·
- 20 │         (1, 2) > (0, 1);
     │         ------ Found: '(u64, u64)'. But expected: 'u8', 'u64', 'u128'
+    │         ^^^^^^ Invalid argument to '>'
     │
 
 error: 
 
-    ┌── tests/move_check/typing/binary_gt_invalid.move:20:18 ───
+    ┌── tests/move_check/typing/binary_gt_invalid.move:20:9 ───
     │
  20 │         (1, 2) > (0, 1);
-    │                  ^^^^^^ Invalid argument to '>'
-    ·
- 20 │         (1, 2) > (0, 1);
     │         ------ Found: '(u64, u64)'. But expected: 'u8', 'u64', 'u128'
+    │                  ^^^^^^ Invalid argument to '>'
     │
 

--- a/language/move-lang/tests/move_check/typing/binary_leq_invalid.exp
+++ b/language/move-lang/tests/move_check/typing/binary_leq_invalid.exp
@@ -3,35 +3,27 @@ error:
    ┌── tests/move_check/typing/binary_leq_invalid.move:8:9 ───
    │
  8 │         false <= true;
+   │         ----- Found: 'bool'. But expected: 'u8', 'u64', 'u128'
    │         ^^^^^ Invalid argument to '<='
-   ·
- 8 │         false <= true;
-   │         ----- Found: 'bool'. But expected: 'u8', 'u64', 'u128'
    │
 
 error: 
 
-   ┌── tests/move_check/typing/binary_leq_invalid.move:8:18 ───
+   ┌── tests/move_check/typing/binary_leq_invalid.move:8:9 ───
    │
  8 │         false <= true;
+   │         ----- Found: 'bool'. But expected: 'u8', 'u64', 'u128'
    │                  ^^^^ Invalid argument to '<='
-   ·
- 8 │         false <= true;
-   │         ----- Found: 'bool'. But expected: 'u8', 'u64', 'u128'
    │
 
 error: 
 
-   ┌── tests/move_check/typing/binary_leq_invalid.move:9:14 ───
+   ┌── tests/move_check/typing/binary_leq_invalid.move:9:9 ───
    │
- 9 │         1 <= false;
-   │              ^^^^^ Incompatible arguments to '<='
-   ·
  9 │         1 <= false;
    │         - The type: integer
-   ·
- 9 │         1 <= false;
    │              ----- Is not compatible with: 'bool'
+   │              ^^^^^ Incompatible arguments to '<='
    │
 
 error: 
@@ -39,35 +31,27 @@ error:
     ┌── tests/move_check/typing/binary_leq_invalid.move:10:9 ───
     │
  10 │         false <= 1;
-    │         ^^^^^ Invalid argument to '<='
-    ·
- 10 │         false <= 1;
     │         ----- Found: 'bool'. But expected: 'u8', 'u64', 'u128'
+    │         ^^^^^ Invalid argument to '<='
     │
 
 error: 
 
-    ┌── tests/move_check/typing/binary_leq_invalid.move:10:18 ───
+    ┌── tests/move_check/typing/binary_leq_invalid.move:10:9 ───
     │
- 10 │         false <= 1;
-    │                  ^ Incompatible arguments to '<='
-    ·
- 10 │         false <= 1;
-    │                  - The type: integer
-    ·
  10 │         false <= 1;
     │         ----- Is not compatible with: 'bool'
+    │                  - The type: integer
+    │                  ^ Incompatible arguments to '<='
     │
 
 error: 
 
-    ┌── tests/move_check/typing/binary_leq_invalid.move:10:18 ───
+    ┌── tests/move_check/typing/binary_leq_invalid.move:10:9 ───
     │
  10 │         false <= 1;
-    │                  ^ Invalid argument to '<='
-    ·
- 10 │         false <= 1;
     │         ----- Found: 'bool'. But expected: 'u8', 'u64', 'u128'
+    │                  ^ Invalid argument to '<='
     │
 
 error: 
@@ -75,79 +59,71 @@ error:
     ┌── tests/move_check/typing/binary_leq_invalid.move:11:9 ───
     │
  11 │         0x0 <= 0x1;
+    │         --- Found: 'address'. But expected: 'u8', 'u64', 'u128'
     │         ^^^ Invalid argument to '<='
-    ·
- 11 │         0x0 <= 0x1;
-    │         --- Found: 'address'. But expected: 'u8', 'u64', 'u128'
     │
 
 error: 
 
-    ┌── tests/move_check/typing/binary_leq_invalid.move:11:16 ───
+    ┌── tests/move_check/typing/binary_leq_invalid.move:11:9 ───
     │
  11 │         0x0 <= 0x1;
+    │         --- Found: 'address'. But expected: 'u8', 'u64', 'u128'
     │                ^^^ Invalid argument to '<='
-    ·
- 11 │         0x0 <= 0x1;
-    │         --- Found: 'address'. But expected: 'u8', 'u64', 'u128'
     │
 
 error: 
 
-    ┌── tests/move_check/typing/binary_leq_invalid.move:12:20 ───
+    ┌── tests/move_check/typing/binary_leq_invalid.move:12:13 ───
     │
- 12 │         (0: u8) <= (1: u128);
-    │                    ^^^^^^^^^ Incompatible arguments to '<='
-    ·
  12 │         (0: u8) <= (1: u128);
     │             -- The type: 'u8'
-    ·
- 12 │         (0: u8) <= (1: u128);
+    │                    ^^^^^^^^^ Incompatible arguments to '<='
     │                        ---- Is not compatible with: 'u128'
     │
 
 error: 
 
-    ┌── tests/move_check/typing/binary_leq_invalid.move:13:9 ───
+    ┌── tests/move_check/typing/binary_leq_invalid.move:7:23 ───
     │
- 13 │         r <= r;
-    │         ^ Invalid argument to '<='
-    ·
   7 │     fun t0(x: u64, r: R, s: S) {
     │                       - Found: '0x8675309::M::R'. But expected: 'u8', 'u64', 'u128'
+    ·
+ 13 │         r <= r;
+    │         ^ Invalid argument to '<='
     │
 
 error: 
 
-    ┌── tests/move_check/typing/binary_leq_invalid.move:13:14 ───
+    ┌── tests/move_check/typing/binary_leq_invalid.move:7:23 ───
     │
- 13 │         r <= r;
-    │              ^ Invalid argument to '<='
-    ·
   7 │     fun t0(x: u64, r: R, s: S) {
     │                       - Found: '0x8675309::M::R'. But expected: 'u8', 'u64', 'u128'
+    ·
+ 13 │         r <= r;
+    │              ^ Invalid argument to '<='
     │
 
 error: 
 
-    ┌── tests/move_check/typing/binary_leq_invalid.move:14:9 ───
+    ┌── tests/move_check/typing/binary_leq_invalid.move:7:29 ───
     │
+  7 │     fun t0(x: u64, r: R, s: S) {
+    │                             - Found: '0x8675309::M::S'. But expected: 'u8', 'u64', 'u128'
+    ·
  14 │         s <= s;
     │         ^ Invalid argument to '<='
-    ·
-  7 │     fun t0(x: u64, r: R, s: S) {
-    │                             - Found: '0x8675309::M::S'. But expected: 'u8', 'u64', 'u128'
     │
 
 error: 
 
-    ┌── tests/move_check/typing/binary_leq_invalid.move:14:14 ───
+    ┌── tests/move_check/typing/binary_leq_invalid.move:7:29 ───
     │
- 14 │         s <= s;
-    │              ^ Invalid argument to '<='
-    ·
   7 │     fun t0(x: u64, r: R, s: S) {
     │                             - Found: '0x8675309::M::S'. But expected: 'u8', 'u64', 'u128'
+    ·
+ 14 │         s <= s;
+    │              ^ Invalid argument to '<='
     │
 
 error: 
@@ -155,49 +131,37 @@ error:
     ┌── tests/move_check/typing/binary_leq_invalid.move:15:9 ───
     │
  15 │         0 <= 1 <= 2;
-    │         ^^^^^^ Invalid argument to '<='
-    ·
- 15 │         0 <= 1 <= 2;
     │         ------ Found: 'bool'. But expected: 'u8', 'u64', 'u128'
+    │         ^^^^^^ Invalid argument to '<='
     │
 
 error: 
 
-    ┌── tests/move_check/typing/binary_leq_invalid.move:15:19 ───
+    ┌── tests/move_check/typing/binary_leq_invalid.move:15:9 ───
     │
- 15 │         0 <= 1 <= 2;
-    │                   ^ Incompatible arguments to '<='
-    ·
- 15 │         0 <= 1 <= 2;
-    │                   - The type: integer
-    ·
  15 │         0 <= 1 <= 2;
     │         ------ Is not compatible with: 'bool'
+    │                   - The type: integer
+    │                   ^ Incompatible arguments to '<='
     │
 
 error: 
 
-    ┌── tests/move_check/typing/binary_leq_invalid.move:15:19 ───
+    ┌── tests/move_check/typing/binary_leq_invalid.move:15:9 ───
     │
- 15 │         0 <= 1 <= 2;
-    │                   ^ Invalid argument to '<='
-    ·
  15 │         0 <= 1 <= 2;
     │         ------ Found: 'bool'. But expected: 'u8', 'u64', 'u128'
+    │                   ^ Invalid argument to '<='
     │
 
 error: 
 
-    ┌── tests/move_check/typing/binary_leq_invalid.move:16:15 ───
+    ┌── tests/move_check/typing/binary_leq_invalid.move:16:10 ───
     │
  16 │         (1 <= false) && (0x0 <= 0);
-    │               ^^^^^ Incompatible arguments to '<='
-    ·
- 16 │         (1 <= false) && (0x0 <= 0);
     │          - The type: integer
-    ·
- 16 │         (1 <= false) && (0x0 <= 0);
     │               ----- Is not compatible with: 'bool'
+    │               ^^^^^ Incompatible arguments to '<='
     │
 
 error: 
@@ -205,35 +169,27 @@ error:
     ┌── tests/move_check/typing/binary_leq_invalid.move:16:26 ───
     │
  16 │         (1 <= false) && (0x0 <= 0);
-    │                          ^^^ Invalid argument to '<='
-    ·
- 16 │         (1 <= false) && (0x0 <= 0);
     │                          --- Found: 'address'. But expected: 'u8', 'u64', 'u128'
+    │                          ^^^ Invalid argument to '<='
     │
 
 error: 
 
-    ┌── tests/move_check/typing/binary_leq_invalid.move:16:33 ───
+    ┌── tests/move_check/typing/binary_leq_invalid.move:16:26 ───
     │
- 16 │         (1 <= false) && (0x0 <= 0);
-    │                                 ^ Incompatible arguments to '<='
-    ·
- 16 │         (1 <= false) && (0x0 <= 0);
-    │                                 - The type: integer
-    ·
  16 │         (1 <= false) && (0x0 <= 0);
     │                          --- Is not compatible with: 'address'
+    │                                 - The type: integer
+    │                                 ^ Incompatible arguments to '<='
     │
 
 error: 
 
-    ┌── tests/move_check/typing/binary_leq_invalid.move:16:33 ───
+    ┌── tests/move_check/typing/binary_leq_invalid.move:16:26 ───
     │
  16 │         (1 <= false) && (0x0 <= 0);
-    │                                 ^ Invalid argument to '<='
-    ·
- 16 │         (1 <= false) && (0x0 <= 0);
     │                          --- Found: 'address'. But expected: 'u8', 'u64', 'u128'
+    │                                 ^ Invalid argument to '<='
     │
 
 error: 
@@ -241,35 +197,27 @@ error:
     ┌── tests/move_check/typing/binary_leq_invalid.move:17:9 ───
     │
  17 │         () <= ();
+    │         -- Found: '()'. But expected: 'u8', 'u64', 'u128'
     │         ^^ Invalid argument to '<='
-    ·
- 17 │         () <= ();
-    │         -- Found: '()'. But expected: 'u8', 'u64', 'u128'
     │
 
 error: 
 
-    ┌── tests/move_check/typing/binary_leq_invalid.move:17:15 ───
+    ┌── tests/move_check/typing/binary_leq_invalid.move:17:9 ───
     │
  17 │         () <= ();
+    │         -- Found: '()'. But expected: 'u8', 'u64', 'u128'
     │               ^^ Invalid argument to '<='
-    ·
- 17 │         () <= ();
-    │         -- Found: '()'. But expected: 'u8', 'u64', 'u128'
     │
 
 error: 
 
-    ┌── tests/move_check/typing/binary_leq_invalid.move:18:14 ───
+    ┌── tests/move_check/typing/binary_leq_invalid.move:18:9 ───
     │
- 18 │         1 <= ();
-    │              ^^ Incompatible arguments to '<='
-    ·
  18 │         1 <= ();
     │         - The type: integer
-    ·
- 18 │         1 <= ();
     │              -- Is not compatible with: '()'
+    │              ^^ Incompatible arguments to '<='
     │
 
 error: 
@@ -277,35 +225,27 @@ error:
     ┌── tests/move_check/typing/binary_leq_invalid.move:19:9 ───
     │
  19 │         (0, 1) <= (0, 1, 2);
-    │         ^^^^^^ Invalid argument to '<='
-    ·
- 19 │         (0, 1) <= (0, 1, 2);
     │         ------ Found: '(u64, u64)'. But expected: 'u8', 'u64', 'u128'
+    │         ^^^^^^ Invalid argument to '<='
     │
 
 error: 
 
-    ┌── tests/move_check/typing/binary_leq_invalid.move:19:19 ───
+    ┌── tests/move_check/typing/binary_leq_invalid.move:19:9 ───
     │
- 19 │         (0, 1) <= (0, 1, 2);
-    │                   ^^^^^^^^^ Incompatible arguments to '<='
-    ·
  19 │         (0, 1) <= (0, 1, 2);
     │         ------ The expression list type of length 2: '({integer}, {integer})'
-    ·
- 19 │         (0, 1) <= (0, 1, 2);
     │                   --------- Is not compatible with the expression list type of length 3: '({integer}, {integer}, {integer})'
+    │                   ^^^^^^^^^ Incompatible arguments to '<='
     │
 
 error: 
 
-    ┌── tests/move_check/typing/binary_leq_invalid.move:19:19 ───
+    ┌── tests/move_check/typing/binary_leq_invalid.move:19:9 ───
     │
  19 │         (0, 1) <= (0, 1, 2);
-    │                   ^^^^^^^^^ Invalid argument to '<='
-    ·
- 19 │         (0, 1) <= (0, 1, 2);
     │         ------ Found: '(u64, u64)'. But expected: 'u8', 'u64', 'u128'
+    │                   ^^^^^^^^^ Invalid argument to '<='
     │
 
 error: 
@@ -313,20 +253,16 @@ error:
     ┌── tests/move_check/typing/binary_leq_invalid.move:20:9 ───
     │
  20 │         (1, 2) <= (0, 1);
-    │         ^^^^^^ Invalid argument to '<='
-    ·
- 20 │         (1, 2) <= (0, 1);
     │         ------ Found: '(u64, u64)'. But expected: 'u8', 'u64', 'u128'
+    │         ^^^^^^ Invalid argument to '<='
     │
 
 error: 
 
-    ┌── tests/move_check/typing/binary_leq_invalid.move:20:19 ───
+    ┌── tests/move_check/typing/binary_leq_invalid.move:20:9 ───
     │
  20 │         (1, 2) <= (0, 1);
-    │                   ^^^^^^ Invalid argument to '<='
-    ·
- 20 │         (1, 2) <= (0, 1);
     │         ------ Found: '(u64, u64)'. But expected: 'u8', 'u64', 'u128'
+    │                   ^^^^^^ Invalid argument to '<='
     │
 

--- a/language/move-lang/tests/move_check/typing/binary_lt_invalid.exp
+++ b/language/move-lang/tests/move_check/typing/binary_lt_invalid.exp
@@ -3,35 +3,27 @@ error:
    ┌── tests/move_check/typing/binary_lt_invalid.move:8:9 ───
    │
  8 │         false < true;
+   │         ----- Found: 'bool'. But expected: 'u8', 'u64', 'u128'
    │         ^^^^^ Invalid argument to '<'
-   ·
- 8 │         false < true;
-   │         ----- Found: 'bool'. But expected: 'u8', 'u64', 'u128'
    │
 
 error: 
 
-   ┌── tests/move_check/typing/binary_lt_invalid.move:8:17 ───
+   ┌── tests/move_check/typing/binary_lt_invalid.move:8:9 ───
    │
  8 │         false < true;
+   │         ----- Found: 'bool'. But expected: 'u8', 'u64', 'u128'
    │                 ^^^^ Invalid argument to '<'
-   ·
- 8 │         false < true;
-   │         ----- Found: 'bool'. But expected: 'u8', 'u64', 'u128'
    │
 
 error: 
 
-   ┌── tests/move_check/typing/binary_lt_invalid.move:9:13 ───
+   ┌── tests/move_check/typing/binary_lt_invalid.move:9:9 ───
    │
- 9 │         1 < false;
-   │             ^^^^^ Incompatible arguments to '<'
-   ·
  9 │         1 < false;
    │         - The type: integer
-   ·
- 9 │         1 < false;
    │             ----- Is not compatible with: 'bool'
+   │             ^^^^^ Incompatible arguments to '<'
    │
 
 error: 
@@ -39,35 +31,27 @@ error:
     ┌── tests/move_check/typing/binary_lt_invalid.move:10:9 ───
     │
  10 │         false < 1;
-    │         ^^^^^ Invalid argument to '<'
-    ·
- 10 │         false < 1;
     │         ----- Found: 'bool'. But expected: 'u8', 'u64', 'u128'
+    │         ^^^^^ Invalid argument to '<'
     │
 
 error: 
 
-    ┌── tests/move_check/typing/binary_lt_invalid.move:10:17 ───
+    ┌── tests/move_check/typing/binary_lt_invalid.move:10:9 ───
     │
- 10 │         false < 1;
-    │                 ^ Incompatible arguments to '<'
-    ·
- 10 │         false < 1;
-    │                 - The type: integer
-    ·
  10 │         false < 1;
     │         ----- Is not compatible with: 'bool'
+    │                 - The type: integer
+    │                 ^ Incompatible arguments to '<'
     │
 
 error: 
 
-    ┌── tests/move_check/typing/binary_lt_invalid.move:10:17 ───
+    ┌── tests/move_check/typing/binary_lt_invalid.move:10:9 ───
     │
  10 │         false < 1;
-    │                 ^ Invalid argument to '<'
-    ·
- 10 │         false < 1;
     │         ----- Found: 'bool'. But expected: 'u8', 'u64', 'u128'
+    │                 ^ Invalid argument to '<'
     │
 
 error: 
@@ -75,79 +59,71 @@ error:
     ┌── tests/move_check/typing/binary_lt_invalid.move:11:9 ───
     │
  11 │         0x0 < 0x1;
+    │         --- Found: 'address'. But expected: 'u8', 'u64', 'u128'
     │         ^^^ Invalid argument to '<'
-    ·
- 11 │         0x0 < 0x1;
-    │         --- Found: 'address'. But expected: 'u8', 'u64', 'u128'
     │
 
 error: 
 
-    ┌── tests/move_check/typing/binary_lt_invalid.move:11:15 ───
+    ┌── tests/move_check/typing/binary_lt_invalid.move:11:9 ───
     │
  11 │         0x0 < 0x1;
+    │         --- Found: 'address'. But expected: 'u8', 'u64', 'u128'
     │               ^^^ Invalid argument to '<'
-    ·
- 11 │         0x0 < 0x1;
-    │         --- Found: 'address'. But expected: 'u8', 'u64', 'u128'
     │
 
 error: 
 
-    ┌── tests/move_check/typing/binary_lt_invalid.move:12:19 ───
+    ┌── tests/move_check/typing/binary_lt_invalid.move:12:13 ───
     │
- 12 │         (0: u8) < (1: u128);
-    │                   ^^^^^^^^^ Incompatible arguments to '<'
-    ·
  12 │         (0: u8) < (1: u128);
     │             -- The type: 'u8'
-    ·
- 12 │         (0: u8) < (1: u128);
+    │                   ^^^^^^^^^ Incompatible arguments to '<'
     │                       ---- Is not compatible with: 'u128'
     │
 
 error: 
 
-    ┌── tests/move_check/typing/binary_lt_invalid.move:13:9 ───
+    ┌── tests/move_check/typing/binary_lt_invalid.move:7:23 ───
     │
- 13 │         r < r;
-    │         ^ Invalid argument to '<'
-    ·
   7 │     fun t0(x: u64, r: R, s: S) {
     │                       - Found: '0x8675309::M::R'. But expected: 'u8', 'u64', 'u128'
+    ·
+ 13 │         r < r;
+    │         ^ Invalid argument to '<'
     │
 
 error: 
 
-    ┌── tests/move_check/typing/binary_lt_invalid.move:13:13 ───
+    ┌── tests/move_check/typing/binary_lt_invalid.move:7:23 ───
     │
- 13 │         r < r;
-    │             ^ Invalid argument to '<'
-    ·
   7 │     fun t0(x: u64, r: R, s: S) {
     │                       - Found: '0x8675309::M::R'. But expected: 'u8', 'u64', 'u128'
+    ·
+ 13 │         r < r;
+    │             ^ Invalid argument to '<'
     │
 
 error: 
 
-    ┌── tests/move_check/typing/binary_lt_invalid.move:14:9 ───
+    ┌── tests/move_check/typing/binary_lt_invalid.move:7:29 ───
     │
+  7 │     fun t0(x: u64, r: R, s: S) {
+    │                             - Found: '0x8675309::M::S'. But expected: 'u8', 'u64', 'u128'
+    ·
  14 │         s < s;
     │         ^ Invalid argument to '<'
-    ·
-  7 │     fun t0(x: u64, r: R, s: S) {
-    │                             - Found: '0x8675309::M::S'. But expected: 'u8', 'u64', 'u128'
     │
 
 error: 
 
-    ┌── tests/move_check/typing/binary_lt_invalid.move:14:13 ───
+    ┌── tests/move_check/typing/binary_lt_invalid.move:7:29 ───
     │
- 14 │         s < s;
-    │             ^ Invalid argument to '<'
-    ·
   7 │     fun t0(x: u64, r: R, s: S) {
     │                             - Found: '0x8675309::M::S'. But expected: 'u8', 'u64', 'u128'
+    ·
+ 14 │         s < s;
+    │             ^ Invalid argument to '<'
     │
 
 error: 
@@ -155,49 +131,37 @@ error:
     ┌── tests/move_check/typing/binary_lt_invalid.move:15:9 ───
     │
  15 │         0 < 1 < 2;
-    │         ^^^^^ Invalid argument to '<'
-    ·
- 15 │         0 < 1 < 2;
     │         ----- Found: 'bool'. But expected: 'u8', 'u64', 'u128'
+    │         ^^^^^ Invalid argument to '<'
     │
 
 error: 
 
-    ┌── tests/move_check/typing/binary_lt_invalid.move:15:17 ───
+    ┌── tests/move_check/typing/binary_lt_invalid.move:15:9 ───
     │
- 15 │         0 < 1 < 2;
-    │                 ^ Incompatible arguments to '<'
-    ·
- 15 │         0 < 1 < 2;
-    │                 - The type: integer
-    ·
  15 │         0 < 1 < 2;
     │         ----- Is not compatible with: 'bool'
+    │                 - The type: integer
+    │                 ^ Incompatible arguments to '<'
     │
 
 error: 
 
-    ┌── tests/move_check/typing/binary_lt_invalid.move:15:17 ───
+    ┌── tests/move_check/typing/binary_lt_invalid.move:15:9 ───
     │
- 15 │         0 < 1 < 2;
-    │                 ^ Invalid argument to '<'
-    ·
  15 │         0 < 1 < 2;
     │         ----- Found: 'bool'. But expected: 'u8', 'u64', 'u128'
+    │                 ^ Invalid argument to '<'
     │
 
 error: 
 
-    ┌── tests/move_check/typing/binary_lt_invalid.move:16:14 ───
+    ┌── tests/move_check/typing/binary_lt_invalid.move:16:10 ───
     │
  16 │         (1 < false) && (0x0 < 0);
-    │              ^^^^^ Incompatible arguments to '<'
-    ·
- 16 │         (1 < false) && (0x0 < 0);
     │          - The type: integer
-    ·
- 16 │         (1 < false) && (0x0 < 0);
     │              ----- Is not compatible with: 'bool'
+    │              ^^^^^ Incompatible arguments to '<'
     │
 
 error: 
@@ -205,35 +169,27 @@ error:
     ┌── tests/move_check/typing/binary_lt_invalid.move:16:25 ───
     │
  16 │         (1 < false) && (0x0 < 0);
-    │                         ^^^ Invalid argument to '<'
-    ·
- 16 │         (1 < false) && (0x0 < 0);
     │                         --- Found: 'address'. But expected: 'u8', 'u64', 'u128'
+    │                         ^^^ Invalid argument to '<'
     │
 
 error: 
 
-    ┌── tests/move_check/typing/binary_lt_invalid.move:16:31 ───
+    ┌── tests/move_check/typing/binary_lt_invalid.move:16:25 ───
     │
- 16 │         (1 < false) && (0x0 < 0);
-    │                               ^ Incompatible arguments to '<'
-    ·
- 16 │         (1 < false) && (0x0 < 0);
-    │                               - The type: integer
-    ·
  16 │         (1 < false) && (0x0 < 0);
     │                         --- Is not compatible with: 'address'
+    │                               - The type: integer
+    │                               ^ Incompatible arguments to '<'
     │
 
 error: 
 
-    ┌── tests/move_check/typing/binary_lt_invalid.move:16:31 ───
+    ┌── tests/move_check/typing/binary_lt_invalid.move:16:25 ───
     │
  16 │         (1 < false) && (0x0 < 0);
-    │                               ^ Invalid argument to '<'
-    ·
- 16 │         (1 < false) && (0x0 < 0);
     │                         --- Found: 'address'. But expected: 'u8', 'u64', 'u128'
+    │                               ^ Invalid argument to '<'
     │
 
 error: 
@@ -241,35 +197,27 @@ error:
     ┌── tests/move_check/typing/binary_lt_invalid.move:17:9 ───
     │
  17 │         () < ();
+    │         -- Found: '()'. But expected: 'u8', 'u64', 'u128'
     │         ^^ Invalid argument to '<'
-    ·
- 17 │         () < ();
-    │         -- Found: '()'. But expected: 'u8', 'u64', 'u128'
     │
 
 error: 
 
-    ┌── tests/move_check/typing/binary_lt_invalid.move:17:14 ───
+    ┌── tests/move_check/typing/binary_lt_invalid.move:17:9 ───
     │
  17 │         () < ();
+    │         -- Found: '()'. But expected: 'u8', 'u64', 'u128'
     │              ^^ Invalid argument to '<'
-    ·
- 17 │         () < ();
-    │         -- Found: '()'. But expected: 'u8', 'u64', 'u128'
     │
 
 error: 
 
-    ┌── tests/move_check/typing/binary_lt_invalid.move:18:13 ───
+    ┌── tests/move_check/typing/binary_lt_invalid.move:18:9 ───
     │
- 18 │         1 < ();
-    │             ^^ Incompatible arguments to '<'
-    ·
  18 │         1 < ();
     │         - The type: integer
-    ·
- 18 │         1 < ();
     │             -- Is not compatible with: '()'
+    │             ^^ Incompatible arguments to '<'
     │
 
 error: 
@@ -277,35 +225,27 @@ error:
     ┌── tests/move_check/typing/binary_lt_invalid.move:19:9 ───
     │
  19 │         (0, 1) < (0, 1, 2);
-    │         ^^^^^^ Invalid argument to '<'
-    ·
- 19 │         (0, 1) < (0, 1, 2);
     │         ------ Found: '(u64, u64)'. But expected: 'u8', 'u64', 'u128'
+    │         ^^^^^^ Invalid argument to '<'
     │
 
 error: 
 
-    ┌── tests/move_check/typing/binary_lt_invalid.move:19:18 ───
+    ┌── tests/move_check/typing/binary_lt_invalid.move:19:9 ───
     │
- 19 │         (0, 1) < (0, 1, 2);
-    │                  ^^^^^^^^^ Incompatible arguments to '<'
-    ·
  19 │         (0, 1) < (0, 1, 2);
     │         ------ The expression list type of length 2: '({integer}, {integer})'
-    ·
- 19 │         (0, 1) < (0, 1, 2);
     │                  --------- Is not compatible with the expression list type of length 3: '({integer}, {integer}, {integer})'
+    │                  ^^^^^^^^^ Incompatible arguments to '<'
     │
 
 error: 
 
-    ┌── tests/move_check/typing/binary_lt_invalid.move:19:18 ───
+    ┌── tests/move_check/typing/binary_lt_invalid.move:19:9 ───
     │
  19 │         (0, 1) < (0, 1, 2);
-    │                  ^^^^^^^^^ Invalid argument to '<'
-    ·
- 19 │         (0, 1) < (0, 1, 2);
     │         ------ Found: '(u64, u64)'. But expected: 'u8', 'u64', 'u128'
+    │                  ^^^^^^^^^ Invalid argument to '<'
     │
 
 error: 
@@ -313,20 +253,16 @@ error:
     ┌── tests/move_check/typing/binary_lt_invalid.move:20:9 ───
     │
  20 │         (1, 2) < (0, 1);
-    │         ^^^^^^ Invalid argument to '<'
-    ·
- 20 │         (1, 2) < (0, 1);
     │         ------ Found: '(u64, u64)'. But expected: 'u8', 'u64', 'u128'
+    │         ^^^^^^ Invalid argument to '<'
     │
 
 error: 
 
-    ┌── tests/move_check/typing/binary_lt_invalid.move:20:18 ───
+    ┌── tests/move_check/typing/binary_lt_invalid.move:20:9 ───
     │
  20 │         (1, 2) < (0, 1);
-    │                  ^^^^^^ Invalid argument to '<'
-    ·
- 20 │         (1, 2) < (0, 1);
     │         ------ Found: '(u64, u64)'. But expected: 'u8', 'u64', 'u128'
+    │                  ^^^^^^ Invalid argument to '<'
     │
 

--- a/language/move-lang/tests/move_check/typing/binary_mod_invalid.exp
+++ b/language/move-lang/tests/move_check/typing/binary_mod_invalid.exp
@@ -3,35 +3,27 @@ error:
    ┌── tests/move_check/typing/binary_mod_invalid.move:8:9 ───
    │
  8 │         false % true;
+   │         ----- Found: 'bool'. But expected: 'u8', 'u64', 'u128'
    │         ^^^^^ Invalid argument to '%'
-   ·
- 8 │         false % true;
-   │         ----- Found: 'bool'. But expected: 'u8', 'u64', 'u128'
    │
 
 error: 
 
-   ┌── tests/move_check/typing/binary_mod_invalid.move:8:17 ───
+   ┌── tests/move_check/typing/binary_mod_invalid.move:8:9 ───
    │
  8 │         false % true;
+   │         ----- Found: 'bool'. But expected: 'u8', 'u64', 'u128'
    │                 ^^^^ Invalid argument to '%'
-   ·
- 8 │         false % true;
-   │         ----- Found: 'bool'. But expected: 'u8', 'u64', 'u128'
    │
 
 error: 
 
-   ┌── tests/move_check/typing/binary_mod_invalid.move:9:13 ───
+   ┌── tests/move_check/typing/binary_mod_invalid.move:9:9 ───
    │
- 9 │         1 % false;
-   │             ^^^^^ Incompatible arguments to '%'
-   ·
  9 │         1 % false;
    │         - The type: integer
-   ·
- 9 │         1 % false;
    │             ----- Is not compatible with: 'bool'
+   │             ^^^^^ Incompatible arguments to '%'
    │
 
 error: 
@@ -39,35 +31,27 @@ error:
     ┌── tests/move_check/typing/binary_mod_invalid.move:10:9 ───
     │
  10 │         false % 1;
-    │         ^^^^^ Invalid argument to '%'
-    ·
- 10 │         false % 1;
     │         ----- Found: 'bool'. But expected: 'u8', 'u64', 'u128'
+    │         ^^^^^ Invalid argument to '%'
     │
 
 error: 
 
-    ┌── tests/move_check/typing/binary_mod_invalid.move:10:17 ───
+    ┌── tests/move_check/typing/binary_mod_invalid.move:10:9 ───
     │
- 10 │         false % 1;
-    │                 ^ Incompatible arguments to '%'
-    ·
- 10 │         false % 1;
-    │                 - The type: integer
-    ·
  10 │         false % 1;
     │         ----- Is not compatible with: 'bool'
+    │                 - The type: integer
+    │                 ^ Incompatible arguments to '%'
     │
 
 error: 
 
-    ┌── tests/move_check/typing/binary_mod_invalid.move:10:17 ───
+    ┌── tests/move_check/typing/binary_mod_invalid.move:10:9 ───
     │
  10 │         false % 1;
-    │                 ^ Invalid argument to '%'
-    ·
- 10 │         false % 1;
     │         ----- Found: 'bool'. But expected: 'u8', 'u64', 'u128'
+    │                 ^ Invalid argument to '%'
     │
 
 error: 
@@ -75,93 +59,85 @@ error:
     ┌── tests/move_check/typing/binary_mod_invalid.move:11:9 ───
     │
  11 │         0x0 % 0x1;
+    │         --- Found: 'address'. But expected: 'u8', 'u64', 'u128'
     │         ^^^ Invalid argument to '%'
-    ·
- 11 │         0x0 % 0x1;
-    │         --- Found: 'address'. But expected: 'u8', 'u64', 'u128'
     │
 
 error: 
 
-    ┌── tests/move_check/typing/binary_mod_invalid.move:11:15 ───
+    ┌── tests/move_check/typing/binary_mod_invalid.move:11:9 ───
     │
  11 │         0x0 % 0x1;
+    │         --- Found: 'address'. But expected: 'u8', 'u64', 'u128'
     │               ^^^ Invalid argument to '%'
-    ·
- 11 │         0x0 % 0x1;
-    │         --- Found: 'address'. But expected: 'u8', 'u64', 'u128'
     │
 
 error: 
 
-    ┌── tests/move_check/typing/binary_mod_invalid.move:12:19 ───
+    ┌── tests/move_check/typing/binary_mod_invalid.move:12:13 ───
     │
- 12 │         (0: u8) % (1: u128);
-    │                   ^^^^^^^^^ Incompatible arguments to '%'
-    ·
  12 │         (0: u8) % (1: u128);
     │             -- The type: 'u8'
-    ·
- 12 │         (0: u8) % (1: u128);
+    │                   ^^^^^^^^^ Incompatible arguments to '%'
     │                       ---- Is not compatible with: 'u128'
     │
 
 error: 
 
-    ┌── tests/move_check/typing/binary_mod_invalid.move:13:9 ───
+    ┌── tests/move_check/typing/binary_mod_invalid.move:7:23 ───
     │
- 13 │         r % r;
-    │         ^ Invalid argument to '%'
-    ·
   7 │     fun t0(x: u64, r: R, s: S) {
     │                       - Found: '0x8675309::M::R'. But expected: 'u8', 'u64', 'u128'
+    ·
+ 13 │         r % r;
+    │         ^ Invalid argument to '%'
     │
 
 error: 
 
-    ┌── tests/move_check/typing/binary_mod_invalid.move:13:9 ───
+    ┌── tests/move_check/typing/binary_mod_invalid.move:3:5 ───
     │
- 13 │         r % r;
-    │         ^^^^^ Cannot ignore resource values. The value must be used
+  3 │     resource struct R {
+    │     -------- Is found to be a non-copyable type here
     ·
   7 │     fun t0(x: u64, r: R, s: S) {
     │                       - The type: '0x8675309::M::R'
     ·
-  3 │     resource struct R {
-    │     -------- Is found to be a non-copyable type here
+ 13 │         r % r;
+    │         ^^^^^ Cannot ignore resource values. The value must be used
     │
 
 error: 
 
-    ┌── tests/move_check/typing/binary_mod_invalid.move:13:13 ───
+    ┌── tests/move_check/typing/binary_mod_invalid.move:7:23 ───
     │
- 13 │         r % r;
-    │             ^ Invalid argument to '%'
-    ·
   7 │     fun t0(x: u64, r: R, s: S) {
     │                       - Found: '0x8675309::M::R'. But expected: 'u8', 'u64', 'u128'
+    ·
+ 13 │         r % r;
+    │             ^ Invalid argument to '%'
     │
 
 error: 
 
-    ┌── tests/move_check/typing/binary_mod_invalid.move:14:9 ───
+    ┌── tests/move_check/typing/binary_mod_invalid.move:7:29 ───
     │
+  7 │     fun t0(x: u64, r: R, s: S) {
+    │                             - Found: '0x8675309::M::S'. But expected: 'u8', 'u64', 'u128'
+    ·
  14 │         s % s;
     │         ^ Invalid argument to '%'
-    ·
-  7 │     fun t0(x: u64, r: R, s: S) {
-    │                             - Found: '0x8675309::M::S'. But expected: 'u8', 'u64', 'u128'
     │
 
 error: 
 
-    ┌── tests/move_check/typing/binary_mod_invalid.move:14:13 ───
+    ┌── tests/move_check/typing/binary_mod_invalid.move:7:29 ───
     │
- 14 │         s % s;
-    │             ^ Invalid argument to '%'
-    ·
   7 │     fun t0(x: u64, r: R, s: S) {
     │                             - Found: '0x8675309::M::S'. But expected: 'u8', 'u64', 'u128'
+    ·
+ 14 │         s % s;
+    │             ^ Invalid argument to '%'
     │
 
 error: 
@@ -170,8 +146,6 @@ error:
     │
  15 │         1 % false % 0x0 % 0;
     │         ^^^^^^^^^ Invalid argument to '%'
-    ·
- 15 │         1 % false % 0x0 % 0;
     │             ----- Found: '_'. But expected: 'u8', 'u64', 'u128'
     │
 
@@ -181,9 +155,17 @@ error:
     │
  15 │         1 % false % 0x0 % 0;
     │         ^^^^^^^^^^^^^^^ Invalid argument to '%'
-    ·
- 15 │         1 % false % 0x0 % 0;
     │                     --- Found: 'address'. But expected: 'u8', 'u64', 'u128'
+    │
+
+error: 
+
+    ┌── tests/move_check/typing/binary_mod_invalid.move:15:9 ───
+    │
+ 15 │         1 % false % 0x0 % 0;
+    │         - The type: integer
+    │             ----- Is not compatible with: 'bool'
+    │             ^^^^^ Incompatible arguments to '%'
     │
 
 error: 
@@ -191,13 +173,8 @@ error:
     ┌── tests/move_check/typing/binary_mod_invalid.move:15:13 ───
     │
  15 │         1 % false % 0x0 % 0;
-    │             ^^^^^ Incompatible arguments to '%'
-    ·
- 15 │         1 % false % 0x0 % 0;
-    │         - The type: integer
-    ·
- 15 │         1 % false % 0x0 % 0;
-    │             ----- Is not compatible with: 'bool'
+    │             ----- Found: '_'. But expected: 'u8', 'u64', 'u128'
+    │                     ^^^ Invalid argument to '%'
     │
 
 error: 
@@ -205,35 +182,18 @@ error:
     ┌── tests/move_check/typing/binary_mod_invalid.move:15:21 ───
     │
  15 │         1 % false % 0x0 % 0;
-    │                     ^^^ Invalid argument to '%'
-    ·
- 15 │         1 % false % 0x0 % 0;
-    │             ----- Found: '_'. But expected: 'u8', 'u64', 'u128'
-    │
-
-error: 
-
-    ┌── tests/move_check/typing/binary_mod_invalid.move:15:27 ───
-    │
- 15 │         1 % false % 0x0 % 0;
-    │                           ^ Incompatible arguments to '%'
-    ·
- 15 │         1 % false % 0x0 % 0;
-    │                           - The type: integer
-    ·
- 15 │         1 % false % 0x0 % 0;
     │                     --- Is not compatible with: 'address'
+    │                           - The type: integer
+    │                           ^ Incompatible arguments to '%'
     │
 
 error: 
 
-    ┌── tests/move_check/typing/binary_mod_invalid.move:15:27 ───
+    ┌── tests/move_check/typing/binary_mod_invalid.move:15:21 ───
     │
- 15 │         1 % false % 0x0 % 0;
-    │                           ^ Invalid argument to '%'
-    ·
  15 │         1 % false % 0x0 % 0;
     │                     --- Found: 'address'. But expected: 'u8', 'u64', 'u128'
+    │                           ^ Invalid argument to '%'
     │
 
 error: 
@@ -241,35 +201,27 @@ error:
     ┌── tests/move_check/typing/binary_mod_invalid.move:16:9 ───
     │
  16 │         () % ();
+    │         -- Found: '()'. But expected: 'u8', 'u64', 'u128'
     │         ^^ Invalid argument to '%'
-    ·
- 16 │         () % ();
-    │         -- Found: '()'. But expected: 'u8', 'u64', 'u128'
     │
 
 error: 
 
-    ┌── tests/move_check/typing/binary_mod_invalid.move:16:14 ───
+    ┌── tests/move_check/typing/binary_mod_invalid.move:16:9 ───
     │
  16 │         () % ();
+    │         -- Found: '()'. But expected: 'u8', 'u64', 'u128'
     │              ^^ Invalid argument to '%'
-    ·
- 16 │         () % ();
-    │         -- Found: '()'. But expected: 'u8', 'u64', 'u128'
     │
 
 error: 
 
-    ┌── tests/move_check/typing/binary_mod_invalid.move:17:13 ───
+    ┌── tests/move_check/typing/binary_mod_invalid.move:17:9 ───
     │
- 17 │         1 % ();
-    │             ^^ Incompatible arguments to '%'
-    ·
  17 │         1 % ();
     │         - The type: integer
-    ·
- 17 │         1 % ();
     │             -- Is not compatible with: '()'
+    │             ^^ Incompatible arguments to '%'
     │
 
 error: 
@@ -277,35 +229,27 @@ error:
     ┌── tests/move_check/typing/binary_mod_invalid.move:18:9 ───
     │
  18 │         (0, 1) % (0, 1, 2);
-    │         ^^^^^^ Invalid argument to '%'
-    ·
- 18 │         (0, 1) % (0, 1, 2);
     │         ------ Found: '(u64, u64)'. But expected: 'u8', 'u64', 'u128'
+    │         ^^^^^^ Invalid argument to '%'
     │
 
 error: 
 
-    ┌── tests/move_check/typing/binary_mod_invalid.move:18:18 ───
+    ┌── tests/move_check/typing/binary_mod_invalid.move:18:9 ───
     │
- 18 │         (0, 1) % (0, 1, 2);
-    │                  ^^^^^^^^^ Incompatible arguments to '%'
-    ·
  18 │         (0, 1) % (0, 1, 2);
     │         ------ The expression list type of length 2: '({integer}, {integer})'
-    ·
- 18 │         (0, 1) % (0, 1, 2);
     │                  --------- Is not compatible with the expression list type of length 3: '({integer}, {integer}, {integer})'
+    │                  ^^^^^^^^^ Incompatible arguments to '%'
     │
 
 error: 
 
-    ┌── tests/move_check/typing/binary_mod_invalid.move:18:18 ───
+    ┌── tests/move_check/typing/binary_mod_invalid.move:18:9 ───
     │
  18 │         (0, 1) % (0, 1, 2);
-    │                  ^^^^^^^^^ Invalid argument to '%'
-    ·
- 18 │         (0, 1) % (0, 1, 2);
     │         ------ Found: '(u64, u64)'. But expected: 'u8', 'u64', 'u128'
+    │                  ^^^^^^^^^ Invalid argument to '%'
     │
 
 error: 
@@ -313,20 +257,16 @@ error:
     ┌── tests/move_check/typing/binary_mod_invalid.move:19:9 ───
     │
  19 │         (1, 2) % (0, 1);
-    │         ^^^^^^ Invalid argument to '%'
-    ·
- 19 │         (1, 2) % (0, 1);
     │         ------ Found: '(u64, u64)'. But expected: 'u8', 'u64', 'u128'
+    │         ^^^^^^ Invalid argument to '%'
     │
 
 error: 
 
-    ┌── tests/move_check/typing/binary_mod_invalid.move:19:18 ───
+    ┌── tests/move_check/typing/binary_mod_invalid.move:19:9 ───
     │
  19 │         (1, 2) % (0, 1);
-    │                  ^^^^^^ Invalid argument to '%'
-    ·
- 19 │         (1, 2) % (0, 1);
     │         ------ Found: '(u64, u64)'. But expected: 'u8', 'u64', 'u128'
+    │                  ^^^^^^ Invalid argument to '%'
     │
 

--- a/language/move-lang/tests/move_check/typing/binary_mul_invalid.exp
+++ b/language/move-lang/tests/move_check/typing/binary_mul_invalid.exp
@@ -3,35 +3,27 @@ error:
    ┌── tests/move_check/typing/binary_mul_invalid.move:8:9 ───
    │
  8 │         false * true;
+   │         ----- Found: 'bool'. But expected: 'u8', 'u64', 'u128'
    │         ^^^^^ Invalid argument to '*'
-   ·
- 8 │         false * true;
-   │         ----- Found: 'bool'. But expected: 'u8', 'u64', 'u128'
    │
 
 error: 
 
-   ┌── tests/move_check/typing/binary_mul_invalid.move:8:17 ───
+   ┌── tests/move_check/typing/binary_mul_invalid.move:8:9 ───
    │
  8 │         false * true;
+   │         ----- Found: 'bool'. But expected: 'u8', 'u64', 'u128'
    │                 ^^^^ Invalid argument to '*'
-   ·
- 8 │         false * true;
-   │         ----- Found: 'bool'. But expected: 'u8', 'u64', 'u128'
    │
 
 error: 
 
-   ┌── tests/move_check/typing/binary_mul_invalid.move:9:13 ───
+   ┌── tests/move_check/typing/binary_mul_invalid.move:9:9 ───
    │
- 9 │         1 * false;
-   │             ^^^^^ Incompatible arguments to '*'
-   ·
  9 │         1 * false;
    │         - The type: integer
-   ·
- 9 │         1 * false;
    │             ----- Is not compatible with: 'bool'
+   │             ^^^^^ Incompatible arguments to '*'
    │
 
 error: 
@@ -39,35 +31,27 @@ error:
     ┌── tests/move_check/typing/binary_mul_invalid.move:10:9 ───
     │
  10 │         false * 1;
-    │         ^^^^^ Invalid argument to '*'
-    ·
- 10 │         false * 1;
     │         ----- Found: 'bool'. But expected: 'u8', 'u64', 'u128'
+    │         ^^^^^ Invalid argument to '*'
     │
 
 error: 
 
-    ┌── tests/move_check/typing/binary_mul_invalid.move:10:17 ───
+    ┌── tests/move_check/typing/binary_mul_invalid.move:10:9 ───
     │
- 10 │         false * 1;
-    │                 ^ Incompatible arguments to '*'
-    ·
- 10 │         false * 1;
-    │                 - The type: integer
-    ·
  10 │         false * 1;
     │         ----- Is not compatible with: 'bool'
+    │                 - The type: integer
+    │                 ^ Incompatible arguments to '*'
     │
 
 error: 
 
-    ┌── tests/move_check/typing/binary_mul_invalid.move:10:17 ───
+    ┌── tests/move_check/typing/binary_mul_invalid.move:10:9 ───
     │
  10 │         false * 1;
-    │                 ^ Invalid argument to '*'
-    ·
- 10 │         false * 1;
     │         ----- Found: 'bool'. But expected: 'u8', 'u64', 'u128'
+    │                 ^ Invalid argument to '*'
     │
 
 error: 
@@ -75,93 +59,85 @@ error:
     ┌── tests/move_check/typing/binary_mul_invalid.move:11:9 ───
     │
  11 │         0x0 * 0x1;
+    │         --- Found: 'address'. But expected: 'u8', 'u64', 'u128'
     │         ^^^ Invalid argument to '*'
-    ·
- 11 │         0x0 * 0x1;
-    │         --- Found: 'address'. But expected: 'u8', 'u64', 'u128'
     │
 
 error: 
 
-    ┌── tests/move_check/typing/binary_mul_invalid.move:11:15 ───
+    ┌── tests/move_check/typing/binary_mul_invalid.move:11:9 ───
     │
  11 │         0x0 * 0x1;
+    │         --- Found: 'address'. But expected: 'u8', 'u64', 'u128'
     │               ^^^ Invalid argument to '*'
-    ·
- 11 │         0x0 * 0x1;
-    │         --- Found: 'address'. But expected: 'u8', 'u64', 'u128'
     │
 
 error: 
 
-    ┌── tests/move_check/typing/binary_mul_invalid.move:12:19 ───
+    ┌── tests/move_check/typing/binary_mul_invalid.move:12:13 ───
     │
- 12 │         (0: u8) * (1: u128);
-    │                   ^^^^^^^^^ Incompatible arguments to '*'
-    ·
  12 │         (0: u8) * (1: u128);
     │             -- The type: 'u8'
-    ·
- 12 │         (0: u8) * (1: u128);
+    │                   ^^^^^^^^^ Incompatible arguments to '*'
     │                       ---- Is not compatible with: 'u128'
     │
 
 error: 
 
-    ┌── tests/move_check/typing/binary_mul_invalid.move:13:9 ───
+    ┌── tests/move_check/typing/binary_mul_invalid.move:7:23 ───
     │
- 13 │         r * r;
-    │         ^ Invalid argument to '*'
-    ·
   7 │     fun t0(x: u64, r: R, s: S) {
     │                       - Found: '0x8675309::M::R'. But expected: 'u8', 'u64', 'u128'
+    ·
+ 13 │         r * r;
+    │         ^ Invalid argument to '*'
     │
 
 error: 
 
-    ┌── tests/move_check/typing/binary_mul_invalid.move:13:9 ───
+    ┌── tests/move_check/typing/binary_mul_invalid.move:3:5 ───
     │
- 13 │         r * r;
-    │         ^^^^^ Cannot ignore resource values. The value must be used
+  3 │     resource struct R {
+    │     -------- Is found to be a non-copyable type here
     ·
   7 │     fun t0(x: u64, r: R, s: S) {
     │                       - The type: '0x8675309::M::R'
     ·
-  3 │     resource struct R {
-    │     -------- Is found to be a non-copyable type here
+ 13 │         r * r;
+    │         ^^^^^ Cannot ignore resource values. The value must be used
     │
 
 error: 
 
-    ┌── tests/move_check/typing/binary_mul_invalid.move:13:13 ───
+    ┌── tests/move_check/typing/binary_mul_invalid.move:7:23 ───
     │
- 13 │         r * r;
-    │             ^ Invalid argument to '*'
-    ·
   7 │     fun t0(x: u64, r: R, s: S) {
     │                       - Found: '0x8675309::M::R'. But expected: 'u8', 'u64', 'u128'
+    ·
+ 13 │         r * r;
+    │             ^ Invalid argument to '*'
     │
 
 error: 
 
-    ┌── tests/move_check/typing/binary_mul_invalid.move:14:9 ───
+    ┌── tests/move_check/typing/binary_mul_invalid.move:7:29 ───
     │
+  7 │     fun t0(x: u64, r: R, s: S) {
+    │                             - Found: '0x8675309::M::S'. But expected: 'u8', 'u64', 'u128'
+    ·
  14 │         s * s;
     │         ^ Invalid argument to '*'
-    ·
-  7 │     fun t0(x: u64, r: R, s: S) {
-    │                             - Found: '0x8675309::M::S'. But expected: 'u8', 'u64', 'u128'
     │
 
 error: 
 
-    ┌── tests/move_check/typing/binary_mul_invalid.move:14:13 ───
+    ┌── tests/move_check/typing/binary_mul_invalid.move:7:29 ───
     │
- 14 │         s * s;
-    │             ^ Invalid argument to '*'
-    ·
   7 │     fun t0(x: u64, r: R, s: S) {
     │                             - Found: '0x8675309::M::S'. But expected: 'u8', 'u64', 'u128'
+    ·
+ 14 │         s * s;
+    │             ^ Invalid argument to '*'
     │
 
 error: 
@@ -170,8 +146,6 @@ error:
     │
  15 │         1 * false * 0x0 * 0;
     │         ^^^^^^^^^ Invalid argument to '*'
-    ·
- 15 │         1 * false * 0x0 * 0;
     │             ----- Found: '_'. But expected: 'u8', 'u64', 'u128'
     │
 
@@ -181,9 +155,17 @@ error:
     │
  15 │         1 * false * 0x0 * 0;
     │         ^^^^^^^^^^^^^^^ Invalid argument to '*'
-    ·
- 15 │         1 * false * 0x0 * 0;
     │                     --- Found: 'address'. But expected: 'u8', 'u64', 'u128'
+    │
+
+error: 
+
+    ┌── tests/move_check/typing/binary_mul_invalid.move:15:9 ───
+    │
+ 15 │         1 * false * 0x0 * 0;
+    │         - The type: integer
+    │             ----- Is not compatible with: 'bool'
+    │             ^^^^^ Incompatible arguments to '*'
     │
 
 error: 
@@ -191,13 +173,8 @@ error:
     ┌── tests/move_check/typing/binary_mul_invalid.move:15:13 ───
     │
  15 │         1 * false * 0x0 * 0;
-    │             ^^^^^ Incompatible arguments to '*'
-    ·
- 15 │         1 * false * 0x0 * 0;
-    │         - The type: integer
-    ·
- 15 │         1 * false * 0x0 * 0;
-    │             ----- Is not compatible with: 'bool'
+    │             ----- Found: '_'. But expected: 'u8', 'u64', 'u128'
+    │                     ^^^ Invalid argument to '*'
     │
 
 error: 
@@ -205,35 +182,18 @@ error:
     ┌── tests/move_check/typing/binary_mul_invalid.move:15:21 ───
     │
  15 │         1 * false * 0x0 * 0;
-    │                     ^^^ Invalid argument to '*'
-    ·
- 15 │         1 * false * 0x0 * 0;
-    │             ----- Found: '_'. But expected: 'u8', 'u64', 'u128'
-    │
-
-error: 
-
-    ┌── tests/move_check/typing/binary_mul_invalid.move:15:27 ───
-    │
- 15 │         1 * false * 0x0 * 0;
-    │                           ^ Incompatible arguments to '*'
-    ·
- 15 │         1 * false * 0x0 * 0;
-    │                           - The type: integer
-    ·
- 15 │         1 * false * 0x0 * 0;
     │                     --- Is not compatible with: 'address'
+    │                           - The type: integer
+    │                           ^ Incompatible arguments to '*'
     │
 
 error: 
 
-    ┌── tests/move_check/typing/binary_mul_invalid.move:15:27 ───
+    ┌── tests/move_check/typing/binary_mul_invalid.move:15:21 ───
     │
- 15 │         1 * false * 0x0 * 0;
-    │                           ^ Invalid argument to '*'
-    ·
  15 │         1 * false * 0x0 * 0;
     │                     --- Found: 'address'. But expected: 'u8', 'u64', 'u128'
+    │                           ^ Invalid argument to '*'
     │
 
 error: 
@@ -241,35 +201,27 @@ error:
     ┌── tests/move_check/typing/binary_mul_invalid.move:16:9 ───
     │
  16 │         () * ();
+    │         -- Found: '()'. But expected: 'u8', 'u64', 'u128'
     │         ^^ Invalid argument to '*'
-    ·
- 16 │         () * ();
-    │         -- Found: '()'. But expected: 'u8', 'u64', 'u128'
     │
 
 error: 
 
-    ┌── tests/move_check/typing/binary_mul_invalid.move:16:14 ───
+    ┌── tests/move_check/typing/binary_mul_invalid.move:16:9 ───
     │
  16 │         () * ();
+    │         -- Found: '()'. But expected: 'u8', 'u64', 'u128'
     │              ^^ Invalid argument to '*'
-    ·
- 16 │         () * ();
-    │         -- Found: '()'. But expected: 'u8', 'u64', 'u128'
     │
 
 error: 
 
-    ┌── tests/move_check/typing/binary_mul_invalid.move:17:13 ───
+    ┌── tests/move_check/typing/binary_mul_invalid.move:17:9 ───
     │
- 17 │         1 * ();
-    │             ^^ Incompatible arguments to '*'
-    ·
  17 │         1 * ();
     │         - The type: integer
-    ·
- 17 │         1 * ();
     │             -- Is not compatible with: '()'
+    │             ^^ Incompatible arguments to '*'
     │
 
 error: 
@@ -277,35 +229,27 @@ error:
     ┌── tests/move_check/typing/binary_mul_invalid.move:18:9 ───
     │
  18 │         (0, 1) * (0, 1, 2);
-    │         ^^^^^^ Invalid argument to '*'
-    ·
- 18 │         (0, 1) * (0, 1, 2);
     │         ------ Found: '(u64, u64)'. But expected: 'u8', 'u64', 'u128'
+    │         ^^^^^^ Invalid argument to '*'
     │
 
 error: 
 
-    ┌── tests/move_check/typing/binary_mul_invalid.move:18:18 ───
+    ┌── tests/move_check/typing/binary_mul_invalid.move:18:9 ───
     │
- 18 │         (0, 1) * (0, 1, 2);
-    │                  ^^^^^^^^^ Incompatible arguments to '*'
-    ·
  18 │         (0, 1) * (0, 1, 2);
     │         ------ The expression list type of length 2: '({integer}, {integer})'
-    ·
- 18 │         (0, 1) * (0, 1, 2);
     │                  --------- Is not compatible with the expression list type of length 3: '({integer}, {integer}, {integer})'
+    │                  ^^^^^^^^^ Incompatible arguments to '*'
     │
 
 error: 
 
-    ┌── tests/move_check/typing/binary_mul_invalid.move:18:18 ───
+    ┌── tests/move_check/typing/binary_mul_invalid.move:18:9 ───
     │
  18 │         (0, 1) * (0, 1, 2);
-    │                  ^^^^^^^^^ Invalid argument to '*'
-    ·
- 18 │         (0, 1) * (0, 1, 2);
     │         ------ Found: '(u64, u64)'. But expected: 'u8', 'u64', 'u128'
+    │                  ^^^^^^^^^ Invalid argument to '*'
     │
 
 error: 
@@ -313,20 +257,16 @@ error:
     ┌── tests/move_check/typing/binary_mul_invalid.move:19:9 ───
     │
  19 │         (1, 2) * (0, 1);
-    │         ^^^^^^ Invalid argument to '*'
-    ·
- 19 │         (1, 2) * (0, 1);
     │         ------ Found: '(u64, u64)'. But expected: 'u8', 'u64', 'u128'
+    │         ^^^^^^ Invalid argument to '*'
     │
 
 error: 
 
-    ┌── tests/move_check/typing/binary_mul_invalid.move:19:18 ───
+    ┌── tests/move_check/typing/binary_mul_invalid.move:19:9 ───
     │
  19 │         (1, 2) * (0, 1);
-    │                  ^^^^^^ Invalid argument to '*'
-    ·
- 19 │         (1, 2) * (0, 1);
     │         ------ Found: '(u64, u64)'. But expected: 'u8', 'u64', 'u128'
+    │                  ^^^^^^ Invalid argument to '*'
     │
 

--- a/language/move-lang/tests/move_check/typing/binary_or_invalid.exp
+++ b/language/move-lang/tests/move_check/typing/binary_or_invalid.exp
@@ -3,27 +3,19 @@ error:
    ┌── tests/move_check/typing/binary_or_invalid.move:8:9 ───
    │
  8 │         0 || 1;
-   │         ^ Incompatible arguments to '||'
-   ·
- 8 │         0 || 1;
    │         - The type: integer
-   ·
- 8 │         0 || 1;
    │         - Is not compatible with: 'bool'
+   │         ^ Incompatible arguments to '||'
    │
 
 error: 
 
-   ┌── tests/move_check/typing/binary_or_invalid.move:8:14 ───
+   ┌── tests/move_check/typing/binary_or_invalid.move:8:9 ───
    │
  8 │         0 || 1;
-   │              ^ Incompatible arguments to '||'
-   ·
- 8 │         0 || 1;
-   │              - The type: integer
-   ·
- 8 │         0 || 1;
    │         - Is not compatible with: 'bool'
+   │              - The type: integer
+   │              ^ Incompatible arguments to '||'
    │
 
 error: 
@@ -31,27 +23,19 @@ error:
    ┌── tests/move_check/typing/binary_or_invalid.move:9:9 ───
    │
  9 │         1 || false;
-   │         ^ Incompatible arguments to '||'
-   ·
- 9 │         1 || false;
    │         - The type: integer
-   ·
- 9 │         1 || false;
    │         - Is not compatible with: 'bool'
+   │         ^ Incompatible arguments to '||'
    │
 
 error: 
 
-    ┌── tests/move_check/typing/binary_or_invalid.move:10:18 ───
+    ┌── tests/move_check/typing/binary_or_invalid.move:10:9 ───
     │
  10 │         false || 1;
-    │                  ^ Incompatible arguments to '||'
-    ·
- 10 │         false || 1;
-    │                  - The type: integer
-    ·
- 10 │         false || 1;
     │         ----- Is not compatible with: 'bool'
+    │                  - The type: integer
+    │                  ^ Incompatible arguments to '||'
     │
 
 error: 
@@ -59,27 +43,19 @@ error:
     ┌── tests/move_check/typing/binary_or_invalid.move:11:9 ───
     │
  11 │         0x0 || 0x1;
-    │         ^^^ Incompatible arguments to '||'
-    ·
- 11 │         0x0 || 0x1;
     │         --- The type: 'address'
-    ·
- 11 │         0x0 || 0x1;
     │         --- Is not compatible with: 'bool'
+    │         ^^^ Incompatible arguments to '||'
     │
 
 error: 
 
-    ┌── tests/move_check/typing/binary_or_invalid.move:11:16 ───
+    ┌── tests/move_check/typing/binary_or_invalid.move:11:9 ───
     │
  11 │         0x0 || 0x1;
-    │                ^^^ Incompatible arguments to '||'
-    ·
- 11 │         0x0 || 0x1;
-    │                --- The type: 'address'
-    ·
- 11 │         0x0 || 0x1;
     │         --- Is not compatible with: 'bool'
+    │                --- The type: 'address'
+    │                ^^^ Incompatible arguments to '||'
     │
 
 error: 
@@ -87,83 +63,67 @@ error:
     ┌── tests/move_check/typing/binary_or_invalid.move:12:9 ───
     │
  12 │         (0: u8) || (1: u128);
+    │         ------- Is not compatible with: 'bool'
     │         ^^^^^^^ Incompatible arguments to '||'
-    ·
- 12 │         (0: u8) || (1: u128);
     │             -- The type: 'u8'
-    ·
- 12 │         (0: u8) || (1: u128);
-    │         ------- Is not compatible with: 'bool'
     │
 
 error: 
 
-    ┌── tests/move_check/typing/binary_or_invalid.move:12:20 ───
+    ┌── tests/move_check/typing/binary_or_invalid.move:12:9 ───
     │
  12 │         (0: u8) || (1: u128);
+    │         ------- Is not compatible with: 'bool'
     │                    ^^^^^^^^^ Incompatible arguments to '||'
-    ·
- 12 │         (0: u8) || (1: u128);
     │                        ---- The type: 'u128'
-    ·
- 12 │         (0: u8) || (1: u128);
-    │         ------- Is not compatible with: 'bool'
     │
 
 error: 
 
-    ┌── tests/move_check/typing/binary_or_invalid.move:13:9 ───
+    ┌── tests/move_check/typing/binary_or_invalid.move:7:23 ───
     │
- 13 │         r || r;
-    │         ^ Incompatible arguments to '||'
-    ·
   7 │     fun t0(x: u64, r: R, s: S) {
     │                       - The type: '0x8675309::M::R'
     ·
  13 │         r || r;
     │         - Is not compatible with: 'bool'
+    │         ^ Incompatible arguments to '||'
     │
 
 error: 
 
-    ┌── tests/move_check/typing/binary_or_invalid.move:13:14 ───
+    ┌── tests/move_check/typing/binary_or_invalid.move:7:23 ───
     │
- 13 │         r || r;
-    │              ^ Incompatible arguments to '||'
-    ·
   7 │     fun t0(x: u64, r: R, s: S) {
     │                       - The type: '0x8675309::M::R'
     ·
  13 │         r || r;
     │         - Is not compatible with: 'bool'
-    │
-
-error: 
-
-    ┌── tests/move_check/typing/binary_or_invalid.move:14:9 ───
-    │
- 14 │         s || s;
-    │         ^ Incompatible arguments to '||'
-    ·
-  7 │     fun t0(x: u64, r: R, s: S) {
-    │                             - The type: '0x8675309::M::S'
-    ·
- 14 │         s || s;
-    │         - Is not compatible with: 'bool'
-    │
-
-error: 
-
-    ┌── tests/move_check/typing/binary_or_invalid.move:14:14 ───
-    │
- 14 │         s || s;
     │              ^ Incompatible arguments to '||'
-    ·
+    │
+
+error: 
+
+    ┌── tests/move_check/typing/binary_or_invalid.move:7:29 ───
+    │
   7 │     fun t0(x: u64, r: R, s: S) {
     │                             - The type: '0x8675309::M::S'
     ·
  14 │         s || s;
     │         - Is not compatible with: 'bool'
+    │         ^ Incompatible arguments to '||'
+    │
+
+error: 
+
+    ┌── tests/move_check/typing/binary_or_invalid.move:7:29 ───
+    │
+  7 │     fun t0(x: u64, r: R, s: S) {
+    │                             - The type: '0x8675309::M::S'
+    ·
+ 14 │         s || s;
+    │         - Is not compatible with: 'bool'
+    │              ^ Incompatible arguments to '||'
     │
 
 error: 
@@ -171,41 +131,29 @@ error:
     ┌── tests/move_check/typing/binary_or_invalid.move:15:9 ───
     │
  15 │         () || ();
-    │         ^^ Incompatible arguments to '||'
-    ·
- 15 │         () || ();
     │         -- The type: '()'
-    ·
- 15 │         () || ();
     │         -- Is not compatible with: 'bool'
+    │         ^^ Incompatible arguments to '||'
     │
 
 error: 
 
-    ┌── tests/move_check/typing/binary_or_invalid.move:15:15 ───
+    ┌── tests/move_check/typing/binary_or_invalid.move:15:9 ───
     │
  15 │         () || ();
-    │               ^^ Incompatible arguments to '||'
-    ·
- 15 │         () || ();
+    │         -- Is not compatible with: 'bool'
     │               -- The type: '()'
-    ·
- 15 │         () || ();
-    │         -- Is not compatible with: 'bool'
+    │               ^^ Incompatible arguments to '||'
     │
 
 error: 
 
-    ┌── tests/move_check/typing/binary_or_invalid.move:16:17 ───
+    ┌── tests/move_check/typing/binary_or_invalid.move:16:9 ───
     │
- 16 │         true || ();
-    │                 ^^ Incompatible arguments to '||'
-    ·
- 16 │         true || ();
-    │                 -- The type: '()'
-    ·
  16 │         true || ();
     │         ---- Is not compatible with: 'bool'
+    │                 -- The type: '()'
+    │                 ^^ Incompatible arguments to '||'
     │
 
 error: 
@@ -213,27 +161,19 @@ error:
     ┌── tests/move_check/typing/binary_or_invalid.move:17:9 ───
     │
  17 │         (true, false) || (true, false, true);
-    │         ^^^^^^^^^^^^^ Incompatible arguments to '||'
-    ·
- 17 │         (true, false) || (true, false, true);
     │         ------------- The type: '(bool, bool)'
-    ·
- 17 │         (true, false) || (true, false, true);
     │         ------------- Is not compatible with: 'bool'
+    │         ^^^^^^^^^^^^^ Incompatible arguments to '||'
     │
 
 error: 
 
-    ┌── tests/move_check/typing/binary_or_invalid.move:17:26 ───
+    ┌── tests/move_check/typing/binary_or_invalid.move:17:9 ───
     │
  17 │         (true, false) || (true, false, true);
-    │                          ^^^^^^^^^^^^^^^^^^^ Incompatible arguments to '||'
-    ·
- 17 │         (true, false) || (true, false, true);
-    │                          ------------------- The type: '(bool, bool, bool)'
-    ·
- 17 │         (true, false) || (true, false, true);
     │         ------------- Is not compatible with: 'bool'
+    │                          ------------------- The type: '(bool, bool, bool)'
+    │                          ^^^^^^^^^^^^^^^^^^^ Incompatible arguments to '||'
     │
 
 error: 
@@ -241,26 +181,18 @@ error:
     ┌── tests/move_check/typing/binary_or_invalid.move:18:9 ───
     │
  18 │         (true, true) || (false, false);
-    │         ^^^^^^^^^^^^ Incompatible arguments to '||'
-    ·
- 18 │         (true, true) || (false, false);
     │         ------------ The type: '(bool, bool)'
-    ·
- 18 │         (true, true) || (false, false);
     │         ------------ Is not compatible with: 'bool'
+    │         ^^^^^^^^^^^^ Incompatible arguments to '||'
     │
 
 error: 
 
-    ┌── tests/move_check/typing/binary_or_invalid.move:18:25 ───
+    ┌── tests/move_check/typing/binary_or_invalid.move:18:9 ───
     │
  18 │         (true, true) || (false, false);
-    │                         ^^^^^^^^^^^^^^ Incompatible arguments to '||'
-    ·
- 18 │         (true, true) || (false, false);
-    │                         -------------- The type: '(bool, bool)'
-    ·
- 18 │         (true, true) || (false, false);
     │         ------------ Is not compatible with: 'bool'
+    │                         -------------- The type: '(bool, bool)'
+    │                         ^^^^^^^^^^^^^^ Incompatible arguments to '||'
     │
 

--- a/language/move-lang/tests/move_check/typing/binary_shl_invalid.exp
+++ b/language/move-lang/tests/move_check/typing/binary_shl_invalid.exp
@@ -3,10 +3,8 @@ error:
    ┌── tests/move_check/typing/binary_shl_invalid.move:8:9 ───
    │
  8 │         false << true;
-   │         ^^^^^ Invalid argument to '<<'
-   ·
- 8 │         false << true;
    │         ----- Found: 'bool'. But expected: 'u8', 'u64', 'u128'
+   │         ^^^^^ Invalid argument to '<<'
    │
 
 error: 
@@ -14,13 +12,9 @@ error:
    ┌── tests/move_check/typing/binary_shl_invalid.move:8:18 ───
    │
  8 │         false << true;
-   │                  ^^^^ Invalid argument to '<<'
-   ·
- 8 │         false << true;
    │                  ---- The type: 'bool'
-   ·
- 8 │         false << true;
    │                  ---- Is not compatible with: 'u8'
+   │                  ^^^^ Invalid argument to '<<'
    │
 
 error: 
@@ -28,13 +22,9 @@ error:
    ┌── tests/move_check/typing/binary_shl_invalid.move:9:14 ───
    │
  9 │         1 << false;
-   │              ^^^^^ Invalid argument to '<<'
-   ·
- 9 │         1 << false;
    │              ----- The type: 'bool'
-   ·
- 9 │         1 << false;
    │              ----- Is not compatible with: 'u8'
+   │              ^^^^^ Invalid argument to '<<'
    │
 
 error: 
@@ -42,10 +32,8 @@ error:
     ┌── tests/move_check/typing/binary_shl_invalid.move:10:9 ───
     │
  10 │         false << 1;
-    │         ^^^^^ Invalid argument to '<<'
-    ·
- 10 │         false << 1;
     │         ----- Found: 'bool'. But expected: 'u8', 'u64', 'u128'
+    │         ^^^^^ Invalid argument to '<<'
     │
 
 error: 
@@ -53,10 +41,8 @@ error:
     ┌── tests/move_check/typing/binary_shl_invalid.move:11:9 ───
     │
  11 │         0x0 << 0x1;
-    │         ^^^ Invalid argument to '<<'
-    ·
- 11 │         0x0 << 0x1;
     │         --- Found: 'address'. But expected: 'u8', 'u64', 'u128'
+    │         ^^^ Invalid argument to '<<'
     │
 
 error: 
@@ -64,13 +50,9 @@ error:
     ┌── tests/move_check/typing/binary_shl_invalid.move:11:16 ───
     │
  11 │         0x0 << 0x1;
-    │                ^^^ Invalid argument to '<<'
-    ·
- 11 │         0x0 << 0x1;
     │                --- The type: 'address'
-    ·
- 11 │         0x0 << 0x1;
     │                --- Is not compatible with: 'u8'
+    │                ^^^ Invalid argument to '<<'
     │
 
 error: 
@@ -78,77 +60,69 @@ error:
     ┌── tests/move_check/typing/binary_shl_invalid.move:12:20 ───
     │
  12 │         (0: u8) << (1: u128);
-    │                    ^^^^^^^^^ Invalid argument to '<<'
-    ·
- 12 │         (0: u8) << (1: u128);
-    │                        ---- The type: 'u128'
-    ·
- 12 │         (0: u8) << (1: u128);
     │                    --------- Is not compatible with: 'u8'
+    │                    ^^^^^^^^^ Invalid argument to '<<'
+    │                        ---- The type: 'u128'
     │
 
 error: 
 
-    ┌── tests/move_check/typing/binary_shl_invalid.move:13:9 ───
+    ┌── tests/move_check/typing/binary_shl_invalid.move:7:23 ───
     │
- 13 │         r << r;
-    │         ^ Invalid argument to '<<'
-    ·
   7 │     fun t0(x: u64, r: R, s: S) {
     │                       - Found: '0x8675309::M::R'. But expected: 'u8', 'u64', 'u128'
+    ·
+ 13 │         r << r;
+    │         ^ Invalid argument to '<<'
     │
 
 error: 
 
-    ┌── tests/move_check/typing/binary_shl_invalid.move:13:9 ───
+    ┌── tests/move_check/typing/binary_shl_invalid.move:3:5 ───
     │
- 13 │         r << r;
-    │         ^^^^^^ Cannot ignore resource values. The value must be used
+  3 │     resource struct R {
+    │     -------- Is found to be a non-copyable type here
     ·
   7 │     fun t0(x: u64, r: R, s: S) {
     │                       - The type: '0x8675309::M::R'
     ·
-  3 │     resource struct R {
-    │     -------- Is found to be a non-copyable type here
+ 13 │         r << r;
+    │         ^^^^^^ Cannot ignore resource values. The value must be used
     │
 
 error: 
 
-    ┌── tests/move_check/typing/binary_shl_invalid.move:13:14 ───
+    ┌── tests/move_check/typing/binary_shl_invalid.move:7:23 ───
     │
- 13 │         r << r;
-    │              ^ Invalid argument to '<<'
-    ·
   7 │     fun t0(x: u64, r: R, s: S) {
     │                       - The type: '0x8675309::M::R'
     ·
  13 │         r << r;
     │              - Is not compatible with: 'u8'
+    │              ^ Invalid argument to '<<'
     │
 
 error: 
 
-    ┌── tests/move_check/typing/binary_shl_invalid.move:14:9 ───
+    ┌── tests/move_check/typing/binary_shl_invalid.move:7:29 ───
     │
- 14 │         s << s;
-    │         ^ Invalid argument to '<<'
-    ·
   7 │     fun t0(x: u64, r: R, s: S) {
     │                             - Found: '0x8675309::M::S'. But expected: 'u8', 'u64', 'u128'
+    ·
+ 14 │         s << s;
+    │         ^ Invalid argument to '<<'
     │
 
 error: 
 
-    ┌── tests/move_check/typing/binary_shl_invalid.move:14:14 ───
+    ┌── tests/move_check/typing/binary_shl_invalid.move:7:29 ───
     │
- 14 │         s << s;
-    │              ^ Invalid argument to '<<'
-    ·
   7 │     fun t0(x: u64, r: R, s: S) {
     │                             - The type: '0x8675309::M::S'
     ·
  14 │         s << s;
     │              - Is not compatible with: 'u8'
+    │              ^ Invalid argument to '<<'
     │
 
 error: 
@@ -156,13 +130,9 @@ error:
     ┌── tests/move_check/typing/binary_shl_invalid.move:15:14 ───
     │
  15 │         1 << false << 0x0 << 0;
-    │              ^^^^^ Invalid argument to '<<'
-    ·
- 15 │         1 << false << 0x0 << 0;
     │              ----- The type: 'bool'
-    ·
- 15 │         1 << false << 0x0 << 0;
     │              ----- Is not compatible with: 'u8'
+    │              ^^^^^ Invalid argument to '<<'
     │
 
 error: 
@@ -170,13 +140,9 @@ error:
     ┌── tests/move_check/typing/binary_shl_invalid.move:15:23 ───
     │
  15 │         1 << false << 0x0 << 0;
-    │                       ^^^ Invalid argument to '<<'
-    ·
- 15 │         1 << false << 0x0 << 0;
     │                       --- The type: 'address'
-    ·
- 15 │         1 << false << 0x0 << 0;
     │                       --- Is not compatible with: 'u8'
+    │                       ^^^ Invalid argument to '<<'
     │
 
 error: 
@@ -184,10 +150,8 @@ error:
     ┌── tests/move_check/typing/binary_shl_invalid.move:16:9 ───
     │
  16 │         () << ();
-    │         ^^ Invalid argument to '<<'
-    ·
- 16 │         () << ();
     │         -- Found: '()'. But expected: 'u8', 'u64', 'u128'
+    │         ^^ Invalid argument to '<<'
     │
 
 error: 
@@ -195,13 +159,9 @@ error:
     ┌── tests/move_check/typing/binary_shl_invalid.move:16:15 ───
     │
  16 │         () << ();
-    │               ^^ Invalid argument to '<<'
-    ·
- 16 │         () << ();
     │               -- The type: '()'
-    ·
- 16 │         () << ();
     │               -- Is not compatible with: 'u8'
+    │               ^^ Invalid argument to '<<'
     │
 
 error: 
@@ -209,13 +169,9 @@ error:
     ┌── tests/move_check/typing/binary_shl_invalid.move:17:14 ───
     │
  17 │         1 << ();
-    │              ^^ Invalid argument to '<<'
-    ·
- 17 │         1 << ();
     │              -- The type: '()'
-    ·
- 17 │         1 << ();
     │              -- Is not compatible with: 'u8'
+    │              ^^ Invalid argument to '<<'
     │
 
 error: 
@@ -223,10 +179,8 @@ error:
     ┌── tests/move_check/typing/binary_shl_invalid.move:18:9 ───
     │
  18 │         (0, 1) << (0, 1, 2);
-    │         ^^^^^^ Invalid argument to '<<'
-    ·
- 18 │         (0, 1) << (0, 1, 2);
     │         ------ Found: '(u64, u64)'. But expected: 'u8', 'u64', 'u128'
+    │         ^^^^^^ Invalid argument to '<<'
     │
 
 error: 
@@ -234,13 +188,9 @@ error:
     ┌── tests/move_check/typing/binary_shl_invalid.move:18:19 ───
     │
  18 │         (0, 1) << (0, 1, 2);
-    │                   ^^^^^^^^^ Invalid argument to '<<'
-    ·
- 18 │         (0, 1) << (0, 1, 2);
     │                   --------- The type: '({integer}, {integer}, {integer})'
-    ·
- 18 │         (0, 1) << (0, 1, 2);
     │                   --------- Is not compatible with: 'u8'
+    │                   ^^^^^^^^^ Invalid argument to '<<'
     │
 
 error: 
@@ -248,10 +198,8 @@ error:
     ┌── tests/move_check/typing/binary_shl_invalid.move:19:9 ───
     │
  19 │         (1, 2) << (0, 1);
-    │         ^^^^^^ Invalid argument to '<<'
-    ·
- 19 │         (1, 2) << (0, 1);
     │         ------ Found: '(u64, u64)'. But expected: 'u8', 'u64', 'u128'
+    │         ^^^^^^ Invalid argument to '<<'
     │
 
 error: 
@@ -259,12 +207,8 @@ error:
     ┌── tests/move_check/typing/binary_shl_invalid.move:19:19 ───
     │
  19 │         (1, 2) << (0, 1);
-    │                   ^^^^^^ Invalid argument to '<<'
-    ·
- 19 │         (1, 2) << (0, 1);
     │                   ------ The type: '({integer}, {integer})'
-    ·
- 19 │         (1, 2) << (0, 1);
     │                   ------ Is not compatible with: 'u8'
+    │                   ^^^^^^ Invalid argument to '<<'
     │
 

--- a/language/move-lang/tests/move_check/typing/binary_shr_invalid.exp
+++ b/language/move-lang/tests/move_check/typing/binary_shr_invalid.exp
@@ -3,10 +3,8 @@ error:
    ┌── tests/move_check/typing/binary_shr_invalid.move:8:9 ───
    │
  8 │         false >> true;
-   │         ^^^^^ Invalid argument to '>>'
-   ·
- 8 │         false >> true;
    │         ----- Found: 'bool'. But expected: 'u8', 'u64', 'u128'
+   │         ^^^^^ Invalid argument to '>>'
    │
 
 error: 
@@ -14,13 +12,9 @@ error:
    ┌── tests/move_check/typing/binary_shr_invalid.move:8:18 ───
    │
  8 │         false >> true;
-   │                  ^^^^ Invalid argument to '>>'
-   ·
- 8 │         false >> true;
    │                  ---- The type: 'bool'
-   ·
- 8 │         false >> true;
    │                  ---- Is not compatible with: 'u8'
+   │                  ^^^^ Invalid argument to '>>'
    │
 
 error: 
@@ -28,13 +22,9 @@ error:
    ┌── tests/move_check/typing/binary_shr_invalid.move:9:14 ───
    │
  9 │         1 >> false;
-   │              ^^^^^ Invalid argument to '>>'
-   ·
- 9 │         1 >> false;
    │              ----- The type: 'bool'
-   ·
- 9 │         1 >> false;
    │              ----- Is not compatible with: 'u8'
+   │              ^^^^^ Invalid argument to '>>'
    │
 
 error: 
@@ -42,10 +32,8 @@ error:
     ┌── tests/move_check/typing/binary_shr_invalid.move:10:9 ───
     │
  10 │         false >> 1;
-    │         ^^^^^ Invalid argument to '>>'
-    ·
- 10 │         false >> 1;
     │         ----- Found: 'bool'. But expected: 'u8', 'u64', 'u128'
+    │         ^^^^^ Invalid argument to '>>'
     │
 
 error: 
@@ -53,10 +41,8 @@ error:
     ┌── tests/move_check/typing/binary_shr_invalid.move:11:9 ───
     │
  11 │         0x0 >> 0x1;
-    │         ^^^ Invalid argument to '>>'
-    ·
- 11 │         0x0 >> 0x1;
     │         --- Found: 'address'. But expected: 'u8', 'u64', 'u128'
+    │         ^^^ Invalid argument to '>>'
     │
 
 error: 
@@ -64,13 +50,9 @@ error:
     ┌── tests/move_check/typing/binary_shr_invalid.move:11:16 ───
     │
  11 │         0x0 >> 0x1;
-    │                ^^^ Invalid argument to '>>'
-    ·
- 11 │         0x0 >> 0x1;
     │                --- The type: 'address'
-    ·
- 11 │         0x0 >> 0x1;
     │                --- Is not compatible with: 'u8'
+    │                ^^^ Invalid argument to '>>'
     │
 
 error: 
@@ -78,77 +60,69 @@ error:
     ┌── tests/move_check/typing/binary_shr_invalid.move:12:20 ───
     │
  12 │         (0: u8) >> (1: u128);
-    │                    ^^^^^^^^^ Invalid argument to '>>'
-    ·
- 12 │         (0: u8) >> (1: u128);
-    │                        ---- The type: 'u128'
-    ·
- 12 │         (0: u8) >> (1: u128);
     │                    --------- Is not compatible with: 'u8'
+    │                    ^^^^^^^^^ Invalid argument to '>>'
+    │                        ---- The type: 'u128'
     │
 
 error: 
 
-    ┌── tests/move_check/typing/binary_shr_invalid.move:13:9 ───
+    ┌── tests/move_check/typing/binary_shr_invalid.move:7:23 ───
     │
- 13 │         r >> r;
-    │         ^ Invalid argument to '>>'
-    ·
   7 │     fun t0(x: u64, r: R, s: S) {
     │                       - Found: '0x8675309::M::R'. But expected: 'u8', 'u64', 'u128'
+    ·
+ 13 │         r >> r;
+    │         ^ Invalid argument to '>>'
     │
 
 error: 
 
-    ┌── tests/move_check/typing/binary_shr_invalid.move:13:9 ───
+    ┌── tests/move_check/typing/binary_shr_invalid.move:3:5 ───
     │
- 13 │         r >> r;
-    │         ^^^^^^ Cannot ignore resource values. The value must be used
+  3 │     resource struct R {
+    │     -------- Is found to be a non-copyable type here
     ·
   7 │     fun t0(x: u64, r: R, s: S) {
     │                       - The type: '0x8675309::M::R'
     ·
-  3 │     resource struct R {
-    │     -------- Is found to be a non-copyable type here
+ 13 │         r >> r;
+    │         ^^^^^^ Cannot ignore resource values. The value must be used
     │
 
 error: 
 
-    ┌── tests/move_check/typing/binary_shr_invalid.move:13:14 ───
+    ┌── tests/move_check/typing/binary_shr_invalid.move:7:23 ───
     │
- 13 │         r >> r;
-    │              ^ Invalid argument to '>>'
-    ·
   7 │     fun t0(x: u64, r: R, s: S) {
     │                       - The type: '0x8675309::M::R'
     ·
  13 │         r >> r;
     │              - Is not compatible with: 'u8'
+    │              ^ Invalid argument to '>>'
     │
 
 error: 
 
-    ┌── tests/move_check/typing/binary_shr_invalid.move:14:9 ───
+    ┌── tests/move_check/typing/binary_shr_invalid.move:7:29 ───
     │
- 14 │         s >> s;
-    │         ^ Invalid argument to '>>'
-    ·
   7 │     fun t0(x: u64, r: R, s: S) {
     │                             - Found: '0x8675309::M::S'. But expected: 'u8', 'u64', 'u128'
+    ·
+ 14 │         s >> s;
+    │         ^ Invalid argument to '>>'
     │
 
 error: 
 
-    ┌── tests/move_check/typing/binary_shr_invalid.move:14:14 ───
+    ┌── tests/move_check/typing/binary_shr_invalid.move:7:29 ───
     │
- 14 │         s >> s;
-    │              ^ Invalid argument to '>>'
-    ·
   7 │     fun t0(x: u64, r: R, s: S) {
     │                             - The type: '0x8675309::M::S'
     ·
  14 │         s >> s;
     │              - Is not compatible with: 'u8'
+    │              ^ Invalid argument to '>>'
     │
 
 error: 
@@ -156,13 +130,9 @@ error:
     ┌── tests/move_check/typing/binary_shr_invalid.move:15:14 ───
     │
  15 │         1 >> false >> 0x0 >> 0;
-    │              ^^^^^ Invalid argument to '>>'
-    ·
- 15 │         1 >> false >> 0x0 >> 0;
     │              ----- The type: 'bool'
-    ·
- 15 │         1 >> false >> 0x0 >> 0;
     │              ----- Is not compatible with: 'u8'
+    │              ^^^^^ Invalid argument to '>>'
     │
 
 error: 
@@ -170,13 +140,9 @@ error:
     ┌── tests/move_check/typing/binary_shr_invalid.move:15:23 ───
     │
  15 │         1 >> false >> 0x0 >> 0;
-    │                       ^^^ Invalid argument to '>>'
-    ·
- 15 │         1 >> false >> 0x0 >> 0;
     │                       --- The type: 'address'
-    ·
- 15 │         1 >> false >> 0x0 >> 0;
     │                       --- Is not compatible with: 'u8'
+    │                       ^^^ Invalid argument to '>>'
     │
 
 error: 
@@ -184,10 +150,8 @@ error:
     ┌── tests/move_check/typing/binary_shr_invalid.move:16:9 ───
     │
  16 │         () >> ();
-    │         ^^ Invalid argument to '>>'
-    ·
- 16 │         () >> ();
     │         -- Found: '()'. But expected: 'u8', 'u64', 'u128'
+    │         ^^ Invalid argument to '>>'
     │
 
 error: 
@@ -195,13 +159,9 @@ error:
     ┌── tests/move_check/typing/binary_shr_invalid.move:16:15 ───
     │
  16 │         () >> ();
-    │               ^^ Invalid argument to '>>'
-    ·
- 16 │         () >> ();
     │               -- The type: '()'
-    ·
- 16 │         () >> ();
     │               -- Is not compatible with: 'u8'
+    │               ^^ Invalid argument to '>>'
     │
 
 error: 
@@ -209,13 +169,9 @@ error:
     ┌── tests/move_check/typing/binary_shr_invalid.move:17:14 ───
     │
  17 │         1 >> ();
-    │              ^^ Invalid argument to '>>'
-    ·
- 17 │         1 >> ();
     │              -- The type: '()'
-    ·
- 17 │         1 >> ();
     │              -- Is not compatible with: 'u8'
+    │              ^^ Invalid argument to '>>'
     │
 
 error: 
@@ -223,10 +179,8 @@ error:
     ┌── tests/move_check/typing/binary_shr_invalid.move:18:9 ───
     │
  18 │         (0, 1) >> (0, 1, 2);
-    │         ^^^^^^ Invalid argument to '>>'
-    ·
- 18 │         (0, 1) >> (0, 1, 2);
     │         ------ Found: '(u64, u64)'. But expected: 'u8', 'u64', 'u128'
+    │         ^^^^^^ Invalid argument to '>>'
     │
 
 error: 
@@ -234,13 +188,9 @@ error:
     ┌── tests/move_check/typing/binary_shr_invalid.move:18:19 ───
     │
  18 │         (0, 1) >> (0, 1, 2);
-    │                   ^^^^^^^^^ Invalid argument to '>>'
-    ·
- 18 │         (0, 1) >> (0, 1, 2);
     │                   --------- The type: '({integer}, {integer}, {integer})'
-    ·
- 18 │         (0, 1) >> (0, 1, 2);
     │                   --------- Is not compatible with: 'u8'
+    │                   ^^^^^^^^^ Invalid argument to '>>'
     │
 
 error: 
@@ -248,10 +198,8 @@ error:
     ┌── tests/move_check/typing/binary_shr_invalid.move:19:9 ───
     │
  19 │         (1, 2) >> (0, 1);
-    │         ^^^^^^ Invalid argument to '>>'
-    ·
- 19 │         (1, 2) >> (0, 1);
     │         ------ Found: '(u64, u64)'. But expected: 'u8', 'u64', 'u128'
+    │         ^^^^^^ Invalid argument to '>>'
     │
 
 error: 
@@ -259,12 +207,8 @@ error:
     ┌── tests/move_check/typing/binary_shr_invalid.move:19:19 ───
     │
  19 │         (1, 2) >> (0, 1);
-    │                   ^^^^^^ Invalid argument to '>>'
-    ·
- 19 │         (1, 2) >> (0, 1);
     │                   ------ The type: '({integer}, {integer})'
-    ·
- 19 │         (1, 2) >> (0, 1);
     │                   ------ Is not compatible with: 'u8'
+    │                   ^^^^^^ Invalid argument to '>>'
     │
 

--- a/language/move-lang/tests/move_check/typing/binary_sub_invalid.exp
+++ b/language/move-lang/tests/move_check/typing/binary_sub_invalid.exp
@@ -3,35 +3,27 @@ error:
    ┌── tests/move_check/typing/binary_sub_invalid.move:8:9 ───
    │
  8 │         false - true;
+   │         ----- Found: 'bool'. But expected: 'u8', 'u64', 'u128'
    │         ^^^^^ Invalid argument to '-'
-   ·
- 8 │         false - true;
-   │         ----- Found: 'bool'. But expected: 'u8', 'u64', 'u128'
    │
 
 error: 
 
-   ┌── tests/move_check/typing/binary_sub_invalid.move:8:17 ───
+   ┌── tests/move_check/typing/binary_sub_invalid.move:8:9 ───
    │
  8 │         false - true;
+   │         ----- Found: 'bool'. But expected: 'u8', 'u64', 'u128'
    │                 ^^^^ Invalid argument to '-'
-   ·
- 8 │         false - true;
-   │         ----- Found: 'bool'. But expected: 'u8', 'u64', 'u128'
    │
 
 error: 
 
-   ┌── tests/move_check/typing/binary_sub_invalid.move:9:13 ───
+   ┌── tests/move_check/typing/binary_sub_invalid.move:9:9 ───
    │
- 9 │         1 - false;
-   │             ^^^^^ Incompatible arguments to '-'
-   ·
  9 │         1 - false;
    │         - The type: integer
-   ·
- 9 │         1 - false;
    │             ----- Is not compatible with: 'bool'
+   │             ^^^^^ Incompatible arguments to '-'
    │
 
 error: 
@@ -39,35 +31,27 @@ error:
     ┌── tests/move_check/typing/binary_sub_invalid.move:10:9 ───
     │
  10 │         false - 1;
-    │         ^^^^^ Invalid argument to '-'
-    ·
- 10 │         false - 1;
     │         ----- Found: 'bool'. But expected: 'u8', 'u64', 'u128'
+    │         ^^^^^ Invalid argument to '-'
     │
 
 error: 
 
-    ┌── tests/move_check/typing/binary_sub_invalid.move:10:17 ───
+    ┌── tests/move_check/typing/binary_sub_invalid.move:10:9 ───
     │
- 10 │         false - 1;
-    │                 ^ Incompatible arguments to '-'
-    ·
- 10 │         false - 1;
-    │                 - The type: integer
-    ·
  10 │         false - 1;
     │         ----- Is not compatible with: 'bool'
+    │                 - The type: integer
+    │                 ^ Incompatible arguments to '-'
     │
 
 error: 
 
-    ┌── tests/move_check/typing/binary_sub_invalid.move:10:17 ───
+    ┌── tests/move_check/typing/binary_sub_invalid.move:10:9 ───
     │
  10 │         false - 1;
-    │                 ^ Invalid argument to '-'
-    ·
- 10 │         false - 1;
     │         ----- Found: 'bool'. But expected: 'u8', 'u64', 'u128'
+    │                 ^ Invalid argument to '-'
     │
 
 error: 
@@ -75,93 +59,85 @@ error:
     ┌── tests/move_check/typing/binary_sub_invalid.move:11:9 ───
     │
  11 │         0x0 - 0x1;
+    │         --- Found: 'address'. But expected: 'u8', 'u64', 'u128'
     │         ^^^ Invalid argument to '-'
-    ·
- 11 │         0x0 - 0x1;
-    │         --- Found: 'address'. But expected: 'u8', 'u64', 'u128'
     │
 
 error: 
 
-    ┌── tests/move_check/typing/binary_sub_invalid.move:11:15 ───
+    ┌── tests/move_check/typing/binary_sub_invalid.move:11:9 ───
     │
  11 │         0x0 - 0x1;
+    │         --- Found: 'address'. But expected: 'u8', 'u64', 'u128'
     │               ^^^ Invalid argument to '-'
-    ·
- 11 │         0x0 - 0x1;
-    │         --- Found: 'address'. But expected: 'u8', 'u64', 'u128'
     │
 
 error: 
 
-    ┌── tests/move_check/typing/binary_sub_invalid.move:12:19 ───
+    ┌── tests/move_check/typing/binary_sub_invalid.move:12:13 ───
     │
- 12 │         (0: u8) - (1: u128);
-    │                   ^^^^^^^^^ Incompatible arguments to '-'
-    ·
  12 │         (0: u8) - (1: u128);
     │             -- The type: 'u8'
-    ·
- 12 │         (0: u8) - (1: u128);
+    │                   ^^^^^^^^^ Incompatible arguments to '-'
     │                       ---- Is not compatible with: 'u128'
     │
 
 error: 
 
-    ┌── tests/move_check/typing/binary_sub_invalid.move:13:9 ───
+    ┌── tests/move_check/typing/binary_sub_invalid.move:7:23 ───
     │
- 13 │         r - r;
-    │         ^ Invalid argument to '-'
-    ·
   7 │     fun t0(x: u64, r: R, s: S) {
     │                       - Found: '0x8675309::M::R'. But expected: 'u8', 'u64', 'u128'
+    ·
+ 13 │         r - r;
+    │         ^ Invalid argument to '-'
     │
 
 error: 
 
-    ┌── tests/move_check/typing/binary_sub_invalid.move:13:9 ───
+    ┌── tests/move_check/typing/binary_sub_invalid.move:3:5 ───
     │
- 13 │         r - r;
-    │         ^^^^^ Cannot ignore resource values. The value must be used
+  3 │     resource struct R {
+    │     -------- Is found to be a non-copyable type here
     ·
   7 │     fun t0(x: u64, r: R, s: S) {
     │                       - The type: '0x8675309::M::R'
     ·
-  3 │     resource struct R {
-    │     -------- Is found to be a non-copyable type here
+ 13 │         r - r;
+    │         ^^^^^ Cannot ignore resource values. The value must be used
     │
 
 error: 
 
-    ┌── tests/move_check/typing/binary_sub_invalid.move:13:13 ───
+    ┌── tests/move_check/typing/binary_sub_invalid.move:7:23 ───
     │
- 13 │         r - r;
-    │             ^ Invalid argument to '-'
-    ·
   7 │     fun t0(x: u64, r: R, s: S) {
     │                       - Found: '0x8675309::M::R'. But expected: 'u8', 'u64', 'u128'
+    ·
+ 13 │         r - r;
+    │             ^ Invalid argument to '-'
     │
 
 error: 
 
-    ┌── tests/move_check/typing/binary_sub_invalid.move:14:9 ───
+    ┌── tests/move_check/typing/binary_sub_invalid.move:7:29 ───
     │
+  7 │     fun t0(x: u64, r: R, s: S) {
+    │                             - Found: '0x8675309::M::S'. But expected: 'u8', 'u64', 'u128'
+    ·
  14 │         s - s;
     │         ^ Invalid argument to '-'
-    ·
-  7 │     fun t0(x: u64, r: R, s: S) {
-    │                             - Found: '0x8675309::M::S'. But expected: 'u8', 'u64', 'u128'
     │
 
 error: 
 
-    ┌── tests/move_check/typing/binary_sub_invalid.move:14:13 ───
+    ┌── tests/move_check/typing/binary_sub_invalid.move:7:29 ───
     │
- 14 │         s - s;
-    │             ^ Invalid argument to '-'
-    ·
   7 │     fun t0(x: u64, r: R, s: S) {
     │                             - Found: '0x8675309::M::S'. But expected: 'u8', 'u64', 'u128'
+    ·
+ 14 │         s - s;
+    │             ^ Invalid argument to '-'
     │
 
 error: 
@@ -170,8 +146,6 @@ error:
     │
  15 │         1 - false - 0x0 - 0;
     │         ^^^^^^^^^ Invalid argument to '-'
-    ·
- 15 │         1 - false - 0x0 - 0;
     │             ----- Found: '_'. But expected: 'u8', 'u64', 'u128'
     │
 
@@ -181,9 +155,17 @@ error:
     │
  15 │         1 - false - 0x0 - 0;
     │         ^^^^^^^^^^^^^^^ Invalid argument to '-'
-    ·
- 15 │         1 - false - 0x0 - 0;
     │                     --- Found: 'address'. But expected: 'u8', 'u64', 'u128'
+    │
+
+error: 
+
+    ┌── tests/move_check/typing/binary_sub_invalid.move:15:9 ───
+    │
+ 15 │         1 - false - 0x0 - 0;
+    │         - The type: integer
+    │             ----- Is not compatible with: 'bool'
+    │             ^^^^^ Incompatible arguments to '-'
     │
 
 error: 
@@ -191,13 +173,8 @@ error:
     ┌── tests/move_check/typing/binary_sub_invalid.move:15:13 ───
     │
  15 │         1 - false - 0x0 - 0;
-    │             ^^^^^ Incompatible arguments to '-'
-    ·
- 15 │         1 - false - 0x0 - 0;
-    │         - The type: integer
-    ·
- 15 │         1 - false - 0x0 - 0;
-    │             ----- Is not compatible with: 'bool'
+    │             ----- Found: '_'. But expected: 'u8', 'u64', 'u128'
+    │                     ^^^ Invalid argument to '-'
     │
 
 error: 
@@ -205,35 +182,18 @@ error:
     ┌── tests/move_check/typing/binary_sub_invalid.move:15:21 ───
     │
  15 │         1 - false - 0x0 - 0;
-    │                     ^^^ Invalid argument to '-'
-    ·
- 15 │         1 - false - 0x0 - 0;
-    │             ----- Found: '_'. But expected: 'u8', 'u64', 'u128'
-    │
-
-error: 
-
-    ┌── tests/move_check/typing/binary_sub_invalid.move:15:27 ───
-    │
- 15 │         1 - false - 0x0 - 0;
-    │                           ^ Incompatible arguments to '-'
-    ·
- 15 │         1 - false - 0x0 - 0;
-    │                           - The type: integer
-    ·
- 15 │         1 - false - 0x0 - 0;
     │                     --- Is not compatible with: 'address'
+    │                           - The type: integer
+    │                           ^ Incompatible arguments to '-'
     │
 
 error: 
 
-    ┌── tests/move_check/typing/binary_sub_invalid.move:15:27 ───
+    ┌── tests/move_check/typing/binary_sub_invalid.move:15:21 ───
     │
- 15 │         1 - false - 0x0 - 0;
-    │                           ^ Invalid argument to '-'
-    ·
  15 │         1 - false - 0x0 - 0;
     │                     --- Found: 'address'. But expected: 'u8', 'u64', 'u128'
+    │                           ^ Invalid argument to '-'
     │
 
 error: 
@@ -241,35 +201,27 @@ error:
     ┌── tests/move_check/typing/binary_sub_invalid.move:16:9 ───
     │
  16 │         () - ();
+    │         -- Found: '()'. But expected: 'u8', 'u64', 'u128'
     │         ^^ Invalid argument to '-'
-    ·
- 16 │         () - ();
-    │         -- Found: '()'. But expected: 'u8', 'u64', 'u128'
     │
 
 error: 
 
-    ┌── tests/move_check/typing/binary_sub_invalid.move:16:14 ───
+    ┌── tests/move_check/typing/binary_sub_invalid.move:16:9 ───
     │
  16 │         () - ();
+    │         -- Found: '()'. But expected: 'u8', 'u64', 'u128'
     │              ^^ Invalid argument to '-'
-    ·
- 16 │         () - ();
-    │         -- Found: '()'. But expected: 'u8', 'u64', 'u128'
     │
 
 error: 
 
-    ┌── tests/move_check/typing/binary_sub_invalid.move:17:13 ───
+    ┌── tests/move_check/typing/binary_sub_invalid.move:17:9 ───
     │
- 17 │         1 - ();
-    │             ^^ Incompatible arguments to '-'
-    ·
  17 │         1 - ();
     │         - The type: integer
-    ·
- 17 │         1 - ();
     │             -- Is not compatible with: '()'
+    │             ^^ Incompatible arguments to '-'
     │
 
 error: 
@@ -277,35 +229,27 @@ error:
     ┌── tests/move_check/typing/binary_sub_invalid.move:18:9 ───
     │
  18 │         (0, 1) - (0, 1, 2);
-    │         ^^^^^^ Invalid argument to '-'
-    ·
- 18 │         (0, 1) - (0, 1, 2);
     │         ------ Found: '(u64, u64)'. But expected: 'u8', 'u64', 'u128'
+    │         ^^^^^^ Invalid argument to '-'
     │
 
 error: 
 
-    ┌── tests/move_check/typing/binary_sub_invalid.move:18:18 ───
+    ┌── tests/move_check/typing/binary_sub_invalid.move:18:9 ───
     │
- 18 │         (0, 1) - (0, 1, 2);
-    │                  ^^^^^^^^^ Incompatible arguments to '-'
-    ·
  18 │         (0, 1) - (0, 1, 2);
     │         ------ The expression list type of length 2: '({integer}, {integer})'
-    ·
- 18 │         (0, 1) - (0, 1, 2);
     │                  --------- Is not compatible with the expression list type of length 3: '({integer}, {integer}, {integer})'
+    │                  ^^^^^^^^^ Incompatible arguments to '-'
     │
 
 error: 
 
-    ┌── tests/move_check/typing/binary_sub_invalid.move:18:18 ───
+    ┌── tests/move_check/typing/binary_sub_invalid.move:18:9 ───
     │
  18 │         (0, 1) - (0, 1, 2);
-    │                  ^^^^^^^^^ Invalid argument to '-'
-    ·
- 18 │         (0, 1) - (0, 1, 2);
     │         ------ Found: '(u64, u64)'. But expected: 'u8', 'u64', 'u128'
+    │                  ^^^^^^^^^ Invalid argument to '-'
     │
 
 error: 
@@ -313,20 +257,16 @@ error:
     ┌── tests/move_check/typing/binary_sub_invalid.move:19:9 ───
     │
  19 │         (1, 2) - (0, 1);
-    │         ^^^^^^ Invalid argument to '-'
-    ·
- 19 │         (1, 2) - (0, 1);
     │         ------ Found: '(u64, u64)'. But expected: 'u8', 'u64', 'u128'
+    │         ^^^^^^ Invalid argument to '-'
     │
 
 error: 
 
-    ┌── tests/move_check/typing/binary_sub_invalid.move:19:18 ───
+    ┌── tests/move_check/typing/binary_sub_invalid.move:19:9 ───
     │
  19 │         (1, 2) - (0, 1);
-    │                  ^^^^^^ Invalid argument to '-'
-    ·
- 19 │         (1, 2) - (0, 1);
     │         ------ Found: '(u64, u64)'. But expected: 'u8', 'u64', 'u128'
+    │                  ^^^^^^ Invalid argument to '-'
     │
 

--- a/language/move-lang/tests/move_check/typing/bind_duplicate_binding.exp
+++ b/language/move-lang/tests/move_check/typing/bind_duplicate_binding.exp
@@ -1,12 +1,19 @@
 error: 
 
-   ┌── tests/move_check/typing/bind_duplicate_binding.move:5:17 ───
+   ┌── tests/move_check/typing/bind_duplicate_binding.move:5:14 ───
    │
  5 │         let (x, x) = (0, 0);
-   │                 ^ Duplicate declaration for local 'x' in a given 'let'
-   ·
- 5 │         let (x, x) = (0, 0);
    │              - Previously declared here
+   │                 ^ Duplicate declaration for local 'x' in a given 'let'
+   │
+
+error: 
+
+   ┌── tests/move_check/typing/bind_duplicate_binding.move:6:14 ───
+   │
+ 6 │         let (f, R{f}, f) = (0, R { f: 0 }, 0);
+   │              - Previously declared here
+   │                   ^ Duplicate declaration for local 'f' in a given 'let'
    │
 
 error: 
@@ -14,20 +21,7 @@ error:
    ┌── tests/move_check/typing/bind_duplicate_binding.move:6:19 ───
    │
  6 │         let (f, R{f}, f) = (0, R { f: 0 }, 0);
-   │                   ^ Duplicate declaration for local 'f' in a given 'let'
-   ·
- 6 │         let (f, R{f}, f) = (0, R { f: 0 }, 0);
-   │              - Previously declared here
-   │
-
-error: 
-
-   ┌── tests/move_check/typing/bind_duplicate_binding.move:6:23 ───
-   │
- 6 │         let (f, R{f}, f) = (0, R { f: 0 }, 0);
-   │                       ^ Duplicate declaration for local 'f' in a given 'let'
-   ·
- 6 │         let (f, R{f}, f) = (0, R { f: 0 }, 0);
    │                   - Previously declared here
+   │                       ^ Duplicate declaration for local 'f' in a given 'let'
    │
 

--- a/language/move-lang/tests/move_check/typing/bind_pop_resource.exp
+++ b/language/move-lang/tests/move_check/typing/bind_pop_resource.exp
@@ -1,56 +1,48 @@
 error: 
 
-   ┌── tests/move_check/typing/bind_pop_resource.move:5:13 ───
+   ┌── tests/move_check/typing/bind_pop_resource.move:2:5 ───
    │
+ 2 │     resource struct R {}
+   │     -------- Is found to be a non-copyable type here
+   ·
  5 │         let _: R = R{};
    │             ^ Cannot ignore resource values. The value must be used
-   ·
- 5 │         let _: R = R{};
    │                - The type: '0x8675309::M::R'
-   ·
- 2 │     resource struct R {}
-   │     -------- Is found to be a non-copyable type here
    │
 
 error: 
 
-   ┌── tests/move_check/typing/bind_pop_resource.move:6:13 ───
+   ┌── tests/move_check/typing/bind_pop_resource.move:2:5 ───
    │
+ 2 │     resource struct R {}
+   │     -------- Is found to be a non-copyable type here
+   ·
  6 │         let _r: R = R{};
    │             ^^ Cannot ignore resource values. The value must be used
-   ·
- 6 │         let _r: R = R{};
    │                 - The type: '0x8675309::M::R'
-   ·
- 2 │     resource struct R {}
-   │     -------- Is found to be a non-copyable type here
    │
 
 error: 
 
-   ┌── tests/move_check/typing/bind_pop_resource.move:7:14 ───
+   ┌── tests/move_check/typing/bind_pop_resource.move:2:5 ───
    │
+ 2 │     resource struct R {}
+   │     -------- Is found to be a non-copyable type here
+   ·
  7 │         let (_, _):(R, R) = (R{}, R{});
    │              ^ Cannot ignore resource values. The value must be used
-   ·
- 7 │         let (_, _):(R, R) = (R{}, R{});
    │                     - The type: '0x8675309::M::R'
-   ·
- 2 │     resource struct R {}
-   │     -------- Is found to be a non-copyable type here
    │
 
 error: 
 
-   ┌── tests/move_check/typing/bind_pop_resource.move:7:17 ───
+   ┌── tests/move_check/typing/bind_pop_resource.move:2:5 ───
    │
- 7 │         let (_, _):(R, R) = (R{}, R{});
-   │                 ^ Cannot ignore resource values. The value must be used
-   ·
- 7 │         let (_, _):(R, R) = (R{}, R{});
-   │                        - The type: '0x8675309::M::R'
-   ·
  2 │     resource struct R {}
    │     -------- Is found to be a non-copyable type here
+   ·
+ 7 │         let (_, _):(R, R) = (R{}, R{});
+   │                 ^ Cannot ignore resource values. The value must be used
+   │                        - The type: '0x8675309::M::R'
    │
 

--- a/language/move-lang/tests/move_check/typing/bind_unpack_references_invalid.exp
+++ b/language/move-lang/tests/move_check/typing/bind_unpack_references_invalid.exp
@@ -1,84 +1,69 @@
 error: 
 
-   ┌── tests/move_check/typing/bind_unpack_references_invalid.move:7:9 ───
+   ┌── tests/move_check/typing/bind_unpack_references_invalid.move:6:25 ───
    │
- 7 │         f = 0;
-   │         ^ Invalid assignment to local 'f'
-   ·
- 7 │         f = 0;
-   │         - The type: integer
-   ·
  6 │         let R { s1: S { f }, s2 } = &R { s1: S{f: 0}, s2: S{f: 1} };
    │                         - Is not compatible with: '&u64'
+ 7 │         f = 0;
+   │         - The type: integer
+   │         ^ Invalid assignment to local 'f'
    │
 
 error: 
 
-   ┌── tests/move_check/typing/bind_unpack_references_invalid.move:8:9 ───
+   ┌── tests/move_check/typing/bind_unpack_references_invalid.move:6:30 ───
    │
- 8 │         s2 = S { f: 0 }
-   │         ^^ Invalid assignment to local 's2'
-   ·
- 8 │         s2 = S { f: 0 }
-   │              ---------- The type: '0x8675309::M::S'
-   ·
  6 │         let R { s1: S { f }, s2 } = &R { s1: S{f: 0}, s2: S{f: 1} };
    │                              -- Is not compatible with: '&0x8675309::M::S'
+ 7 │         f = 0;
+ 8 │         s2 = S { f: 0 }
+   │         ^^ Invalid assignment to local 's2'
+   │              ---------- The type: '0x8675309::M::S'
    │
 
 error: 
 
-    ┌── tests/move_check/typing/bind_unpack_references_invalid.move:13:9 ───
+    ┌── tests/move_check/typing/bind_unpack_references_invalid.move:12:25 ───
     │
- 13 │         f = 0;
-    │         ^ Invalid assignment to local 'f'
-    ·
- 13 │         f = 0;
-    │         - The type: integer
-    ·
  12 │         let R { s1: S { f }, s2 } = &mut R { s1: S{f: 0}, s2: S{f: 1} };
     │                         - Is not compatible with: '&mut u64'
+ 13 │         f = 0;
+    │         - The type: integer
+    │         ^ Invalid assignment to local 'f'
     │
 
 error: 
 
-    ┌── tests/move_check/typing/bind_unpack_references_invalid.move:14:9 ───
+    ┌── tests/move_check/typing/bind_unpack_references_invalid.move:12:30 ───
     │
- 14 │         s2 = S { f: 0 }
-    │         ^^ Invalid assignment to local 's2'
-    ·
- 14 │         s2 = S { f: 0 }
-    │              ---------- The type: '0x8675309::M::S'
-    ·
  12 │         let R { s1: S { f }, s2 } = &mut R { s1: S{f: 0}, s2: S{f: 1} };
     │                              -- Is not compatible with: '&mut 0x8675309::M::S'
+ 13 │         f = 0;
+ 14 │         s2 = S { f: 0 }
+    │         ^^ Invalid assignment to local 's2'
+    │              ---------- The type: '0x8675309::M::S'
     │
 
 error: 
 
-    ┌── tests/move_check/typing/bind_unpack_references_invalid.move:20:9 ───
+    ┌── tests/move_check/typing/bind_unpack_references_invalid.move:19:25 ───
     │
- 20 │         f = &0;
-    │         ^ Invalid assignment to local 'f'
-    ·
- 20 │         f = &0;
-    │             -- The type: '&{integer}'
-    ·
  19 │         let R { s1: S { f }, s2 } = &mut R { s1: S{f: 0}, s2: S{f: 1} };
     │                         - Is not a subtype of: '&mut u64'
+ 20 │         f = &0;
+    │         ^ Invalid assignment to local 'f'
+    │             -- The type: '&{integer}'
     │
 
 error: 
 
-    ┌── tests/move_check/typing/bind_unpack_references_invalid.move:21:9 ───
+    ┌── tests/move_check/typing/bind_unpack_references_invalid.move:19:30 ───
     │
- 21 │         s2 = &S { f: 0 }
-    │         ^^ Invalid assignment to local 's2'
-    ·
- 21 │         s2 = &S { f: 0 }
-    │              ----------- The type: '&0x8675309::M::S'
-    ·
  19 │         let R { s1: S { f }, s2 } = &mut R { s1: S{f: 0}, s2: S{f: 1} };
     │                              -- Is not a subtype of: '&mut 0x8675309::M::S'
+ 20 │         f = &0;
+ 21 │         s2 = &S { f: 0 }
+    │         ^^ Invalid assignment to local 's2'
+    │              ----------- The type: '&0x8675309::M::S'
     │
 

--- a/language/move-lang/tests/move_check/typing/bind_wrong_arity.exp
+++ b/language/move-lang/tests/move_check/typing/bind_wrong_arity.exp
@@ -4,8 +4,6 @@ error:
    │
  5 │         let x: () = ();
    │             ^ Invalid type for local
-   ·
- 5 │         let x: () = ();
    │                -- Expected a single type, but found expression list type: '()'
    │
 
@@ -14,12 +12,8 @@ error:
    ┌── tests/move_check/typing/bind_wrong_arity.move:6:13 ───
    │
  6 │         let (): u64 = 0;
-   │             ^^ Invalid value for binding
-   ·
- 6 │         let (): u64 = 0;
    │             -- The type: '()'
-   ·
- 6 │         let (): u64 = 0;
+   │             ^^ Invalid value for binding
    │                 --- Is not compatible with: 'u64'
    │
 
@@ -28,12 +22,8 @@ error:
    ┌── tests/move_check/typing/bind_wrong_arity.move:7:13 ───
    │
  7 │         let (x, b, R{f}): (u64, bool, R, R) = (0, false, R{f: 0}, R{f: 0});
-   │             ^^^^^^^^^^^^ Invalid value for binding
-   ·
- 7 │         let (x, b, R{f}): (u64, bool, R, R) = (0, false, R{f: 0}, R{f: 0});
    │             ------------ The expression list type of length 3: '(_, _, _)'
-   ·
- 7 │         let (x, b, R{f}): (u64, bool, R, R) = (0, false, R{f: 0}, R{f: 0});
+   │             ^^^^^^^^^^^^ Invalid value for binding
    │                           ----------------- Is not compatible with the expression list type of length 4: '(u64, bool, 0x8675309::M::R, 0x8675309::M::R)'
    │
 
@@ -42,12 +32,8 @@ error:
    ┌── tests/move_check/typing/bind_wrong_arity.move:8:13 ───
    │
  8 │         let (x, b, R{f}): (u64, bool) = (0, false);
-   │             ^^^^^^^^^^^^ Invalid value for binding
-   ·
- 8 │         let (x, b, R{f}): (u64, bool) = (0, false);
    │             ------------ The expression list type of length 3: '(_, _, _)'
-   ·
- 8 │         let (x, b, R{f}): (u64, bool) = (0, false);
+   │             ^^^^^^^^^^^^ Invalid value for binding
    │                           ----------- Is not compatible with the expression list type of length 2: '(u64, bool)'
    │
 

--- a/language/move-lang/tests/move_check/typing/bind_wrong_type.exp
+++ b/language/move-lang/tests/move_check/typing/bind_wrong_type.exp
@@ -3,12 +3,8 @@ error:
    ┌── tests/move_check/typing/bind_wrong_type.move:6:13 ───
    │
  6 │         let S { g } = R {f :0};
-   │             ^^^^^^^ Invalid deconstruction binding
-   ·
- 6 │         let S { g } = R {f :0};
    │             ------- The type: '0x8675309::M::S'
-   ·
- 6 │         let S { g } = R {f :0};
+   │             ^^^^^^^ Invalid deconstruction binding
    │                       -------- Is not compatible with: '0x8675309::M::R'
    │
 
@@ -17,12 +13,8 @@ error:
    ┌── tests/move_check/typing/bind_wrong_type.move:7:14 ───
    │
  7 │         let (S { g }, R { f }) = (R{ f: 0 }, R{ f: 1 });
-   │              ^^^^^^^ Invalid deconstruction binding
-   ·
- 7 │         let (S { g }, R { f }) = (R{ f: 0 }, R{ f: 1 });
    │              ------- The type: '0x8675309::M::S'
-   ·
- 7 │         let (S { g }, R { f }) = (R{ f: 0 }, R{ f: 1 });
+   │              ^^^^^^^ Invalid deconstruction binding
    │                                   --------- Is not compatible with: '0x8675309::M::R'
    │
 
@@ -32,8 +24,6 @@ error:
     │
  11 │         let x = ();
     │             ^ Invalid type for local
-    ·
- 11 │         let x = ();
     │                 -- Expected a single type, but found expression list type: '()'
     │
 
@@ -42,13 +32,9 @@ error:
     ┌── tests/move_check/typing/bind_wrong_type.move:12:13 ───
     │
  12 │         let () = 0;
-    │             ^^ Invalid value for binding
-    ·
- 12 │         let () = 0;
-    │                  - The type: integer
-    ·
- 12 │         let () = 0;
     │             -- Is not compatible with: '()'
+    │             ^^ Invalid value for binding
+    │                  - The type: integer
     │
 
 error: 
@@ -56,12 +42,8 @@ error:
     ┌── tests/move_check/typing/bind_wrong_type.move:13:13 ───
     │
  13 │         let (x, b, R{f}) = (0, false, R{f: 0}, R{f: 0});
-    │             ^^^^^^^^^^^^ Invalid value for binding
-    ·
- 13 │         let (x, b, R{f}) = (0, false, R{f: 0}, R{f: 0});
     │             ------------ The expression list type of length 3: '(_, _, _)'
-    ·
- 13 │         let (x, b, R{f}) = (0, false, R{f: 0}, R{f: 0});
+    │             ^^^^^^^^^^^^ Invalid value for binding
     │                            ---------------------------- Is not compatible with the expression list type of length 4: '({integer}, bool, 0x8675309::M::R, 0x8675309::M::R)'
     │
 
@@ -70,12 +52,8 @@ error:
     ┌── tests/move_check/typing/bind_wrong_type.move:14:13 ───
     │
  14 │         let (x, b, R{f}) = (0, false);
-    │             ^^^^^^^^^^^^ Invalid value for binding
-    ·
- 14 │         let (x, b, R{f}) = (0, false);
     │             ------------ The expression list type of length 3: '(_, _, _)'
-    ·
- 14 │         let (x, b, R{f}) = (0, false);
+    │             ^^^^^^^^^^^^ Invalid value for binding
     │                            ---------- Is not compatible with the expression list type of length 2: '({integer}, bool)'
     │
 
@@ -85,8 +63,6 @@ error:
     │
  18 │         let x: () = 0;
     │             ^ Invalid type for local
-    ·
- 18 │         let x: () = 0;
     │                -- Expected a single type, but found expression list type: '()'
     │
 
@@ -95,13 +71,9 @@ error:
     ┌── tests/move_check/typing/bind_wrong_type.move:18:16 ───
     │
  18 │         let x: () = 0;
-    │                ^^ Invalid type annotation
-    ·
- 18 │         let x: () = 0;
-    │                     - The type: integer
-    ·
- 18 │         let x: () = 0;
     │                -- Is not compatible with: '()'
+    │                ^^ Invalid type annotation
+    │                     - The type: integer
     │
 
 error: 
@@ -109,12 +81,8 @@ error:
     ┌── tests/move_check/typing/bind_wrong_type.move:19:13 ───
     │
  19 │         let (): u64 = ();
-    │             ^^ Invalid value for binding
-    ·
- 19 │         let (): u64 = ();
     │             -- The type: '()'
-    ·
- 19 │         let (): u64 = ();
+    │             ^^ Invalid value for binding
     │                 --- Is not compatible with: 'u64'
     │
 
@@ -123,13 +91,9 @@ error:
     ┌── tests/move_check/typing/bind_wrong_type.move:19:17 ───
     │
  19 │         let (): u64 = ();
-    │                 ^^^ Invalid type annotation
-    ·
- 19 │         let (): u64 = ();
-    │                       -- The type: '()'
-    ·
- 19 │         let (): u64 = ();
     │                 --- Is not compatible with: 'u64'
+    │                 ^^^ Invalid type annotation
+    │                       -- The type: '()'
     │
 
 error: 
@@ -137,12 +101,8 @@ error:
     ┌── tests/move_check/typing/bind_wrong_type.move:20:13 ───
     │
  20 │         let (x, b, R{f}): (u64, bool, R, R) = (0, false, R{f: 0});
-    │             ^^^^^^^^^^^^ Invalid value for binding
-    ·
- 20 │         let (x, b, R{f}): (u64, bool, R, R) = (0, false, R{f: 0});
     │             ------------ The expression list type of length 3: '(_, _, _)'
-    ·
- 20 │         let (x, b, R{f}): (u64, bool, R, R) = (0, false, R{f: 0});
+    │             ^^^^^^^^^^^^ Invalid value for binding
     │                           ----------------- Is not compatible with the expression list type of length 4: '(u64, bool, 0x8675309::M::R, 0x8675309::M::R)'
     │
 
@@ -151,13 +111,9 @@ error:
     ┌── tests/move_check/typing/bind_wrong_type.move:20:27 ───
     │
  20 │         let (x, b, R{f}): (u64, bool, R, R) = (0, false, R{f: 0});
-    │                           ^^^^^^^^^^^^^^^^^ Invalid type annotation
-    ·
- 20 │         let (x, b, R{f}): (u64, bool, R, R) = (0, false, R{f: 0});
-    │                                               ------------------- The expression list type of length 3: '({integer}, bool, 0x8675309::M::R)'
-    ·
- 20 │         let (x, b, R{f}): (u64, bool, R, R) = (0, false, R{f: 0});
     │                           ----------------- Is not compatible with the expression list type of length 4: '(u64, bool, 0x8675309::M::R, 0x8675309::M::R)'
+    │                           ^^^^^^^^^^^^^^^^^ Invalid type annotation
+    │                                               ------------------- The expression list type of length 3: '({integer}, bool, 0x8675309::M::R)'
     │
 
 error: 
@@ -165,12 +121,8 @@ error:
     ┌── tests/move_check/typing/bind_wrong_type.move:21:13 ───
     │
  21 │         let (x, b, R{f}): (u64, bool) = (0, false, R{f: 0});
-    │             ^^^^^^^^^^^^ Invalid value for binding
-    ·
- 21 │         let (x, b, R{f}): (u64, bool) = (0, false, R{f: 0});
     │             ------------ The expression list type of length 3: '(_, _, _)'
-    ·
- 21 │         let (x, b, R{f}): (u64, bool) = (0, false, R{f: 0});
+    │             ^^^^^^^^^^^^ Invalid value for binding
     │                           ----------- Is not compatible with the expression list type of length 2: '(u64, bool)'
     │
 
@@ -179,12 +131,8 @@ error:
     ┌── tests/move_check/typing/bind_wrong_type.move:21:27 ───
     │
  21 │         let (x, b, R{f}): (u64, bool) = (0, false, R{f: 0});
-    │                           ^^^^^^^^^^^ Invalid type annotation
-    ·
- 21 │         let (x, b, R{f}): (u64, bool) = (0, false, R{f: 0});
-    │                                         ------------------- The expression list type of length 3: '({integer}, bool, 0x8675309::M::R)'
-    ·
- 21 │         let (x, b, R{f}): (u64, bool) = (0, false, R{f: 0});
     │                           ----------- Is not compatible with the expression list type of length 2: '(u64, bool)'
+    │                           ^^^^^^^^^^^ Invalid type annotation
+    │                                         ------------------- The expression list type of length 3: '({integer}, bool, 0x8675309::M::R)'
     │
 

--- a/language/move-lang/tests/move_check/typing/block_empty_invalid.exp
+++ b/language/move-lang/tests/move_check/typing/block_empty_invalid.exp
@@ -1,42 +1,30 @@
 error: 
 
-   ┌── tests/move_check/typing/block_empty_invalid.move:3:14 ───
+   ┌── tests/move_check/typing/block_empty_invalid.move:3:10 ───
    │
  3 │         ({}: u64);
-   │              ^^^ Invalid type annotation
-   ·
- 3 │         ({}: u64);
    │          -- The type: '()'
-   ·
- 3 │         ({}: u64);
    │              --- Is not compatible with: 'u64'
+   │              ^^^ Invalid type annotation
    │
 
 error: 
 
-   ┌── tests/move_check/typing/block_empty_invalid.move:4:14 ───
+   ┌── tests/move_check/typing/block_empty_invalid.move:4:10 ───
    │
  4 │         ({}: &u64);
-   │              ^^^^ Invalid type annotation
-   ·
- 4 │         ({}: &u64);
    │          -- The type: '()'
-   ·
- 4 │         ({}: &u64);
    │              ---- Is not compatible with: '&u64'
+   │              ^^^^ Invalid type annotation
    │
 
 error: 
 
-   ┌── tests/move_check/typing/block_empty_invalid.move:5:14 ───
+   ┌── tests/move_check/typing/block_empty_invalid.move:5:10 ───
    │
  5 │         ({}: (u64, bool));
-   │              ^^^^^^^^^^^ Invalid type annotation
-   ·
- 5 │         ({}: (u64, bool));
    │          -- The type: '()'
-   ·
- 5 │         ({}: (u64, bool));
    │              ----------- Is not compatible with: '(u64, bool)'
+   │              ^^^^^^^^^^^ Invalid type annotation
    │
 

--- a/language/move-lang/tests/move_check/typing/block_single_expr_invalid.exp
+++ b/language/move-lang/tests/move_check/typing/block_single_expr_invalid.exp
@@ -1,70 +1,52 @@
 error: 
 
-   ┌── tests/move_check/typing/block_single_expr_invalid.move:4:18 ───
+   ┌── tests/move_check/typing/block_single_expr_invalid.move:4:12 ───
    │
- 4 │         ({ 0 } : bool);
-   │                  ^^^^ Invalid type annotation
-   ·
  4 │         ({ 0 } : bool);
    │            - The type: integer
-   ·
- 4 │         ({ 0 } : bool);
    │                  ---- Is not compatible with: 'bool'
+   │                  ^^^^ Invalid type annotation
    │
 
 error: 
 
-   ┌── tests/move_check/typing/block_single_expr_invalid.move:5:19 ───
+   ┌── tests/move_check/typing/block_single_expr_invalid.move:5:12 ───
    │
- 5 │         ({ &0 } : u64);
-   │                   ^^^ Invalid type annotation
-   ·
  5 │         ({ &0 } : u64);
    │            -- The type: '&{integer}'
-   ·
- 5 │         ({ &0 } : u64);
    │                   --- Is not compatible with: 'u64'
+   │                   ^^^ Invalid type annotation
    │
 
 error: 
 
-   ┌── tests/move_check/typing/block_single_expr_invalid.move:6:23 ───
+   ┌── tests/move_check/typing/block_single_expr_invalid.move:6:12 ───
    │
- 6 │         ({ &mut 0 } : ());
-   │                       ^^ Invalid type annotation
-   ·
  6 │         ({ &mut 0 } : ());
    │            ------ The type: '&mut {integer}'
-   ·
- 6 │         ({ &mut 0 } : ());
    │                       -- Is not compatible with: '()'
+   │                       ^^ Invalid type annotation
    │
 
 error: 
 
-   ┌── tests/move_check/typing/block_single_expr_invalid.move:7:9 ───
+   ┌── tests/move_check/typing/block_single_expr_invalid.move:2:5 ───
    │
- 7 │         ({ R {} } : R);
-   │         ^^^^^^^^^^^^^^ Cannot ignore resource values. The value must be used
-   ·
- 7 │         ({ R {} } : R);
-   │                     - The type: '0x8675309::M::R'
-   ·
  2 │     resource struct R {}
    │     -------- Is found to be a non-copyable type here
+   ·
+ 7 │         ({ R {} } : R);
+   │         ^^^^^^^^^^^^^^ Cannot ignore resource values. The value must be used
+   │                     - The type: '0x8675309::M::R'
    │
 
 error: 
 
-   ┌── tests/move_check/typing/block_single_expr_invalid.move:8:34 ───
+   ┌── tests/move_check/typing/block_single_expr_invalid.move:8:12 ───
    │
  8 │         ({ (0, false, false) } : (u64, bool));
-   │                                  ^^^^^^^^^^^ Invalid type annotation
-   ·
- 8 │         ({ (0, false, false) } : (u64, bool));
    │            ----------------- The expression list type of length 3: '({integer}, bool, bool)'
-   ·
- 8 │         ({ (0, false, false) } : (u64, bool));
    │                                  ----------- Is not compatible with the expression list type of length 2: '(u64, bool)'
+   │                                  ^^^^^^^^^^^ Invalid type annotation
    │
 

--- a/language/move-lang/tests/move_check/typing/block_with_statements_invalid.exp
+++ b/language/move-lang/tests/move_check/typing/block_with_statements_invalid.exp
@@ -1,70 +1,52 @@
 error: 
 
-   ┌── tests/move_check/typing/block_with_statements_invalid.move:4:29 ───
+   ┌── tests/move_check/typing/block_with_statements_invalid.move:4:16 ───
    │
- 4 │         ({ let x = 0; x } : bool);
-   │                             ^^^^ Invalid type annotation
-   ·
  4 │         ({ let x = 0; x } : bool);
    │                - The type: integer
-   ·
- 4 │         ({ let x = 0; x } : bool);
    │                             ---- Is not compatible with: 'bool'
+   │                             ^^^^ Invalid type annotation
    │
 
 error: 
 
-   ┌── tests/move_check/typing/block_with_statements_invalid.move:5:30 ───
+   ┌── tests/move_check/typing/block_with_statements_invalid.move:5:23 ───
    │
- 5 │         ({ let x = 0; &x } : u64);
-   │                              ^^^ Invalid type annotation
-   ·
  5 │         ({ let x = 0; &x } : u64);
    │                       -- The type: '&{integer}'
-   ·
- 5 │         ({ let x = 0; &x } : u64);
    │                              --- Is not compatible with: 'u64'
+   │                              ^^^ Invalid type annotation
    │
 
 error: 
 
-   ┌── tests/move_check/typing/block_with_statements_invalid.move:6:40 ───
+   ┌── tests/move_check/typing/block_with_statements_invalid.move:6:23 ───
    │
- 6 │         ({ let y = 0; &mut (y + 1) } : ());
-   │                                        ^^ Invalid type annotation
-   ·
  6 │         ({ let y = 0; &mut (y + 1) } : ());
    │                       ------------ The type: '&mut {integer}'
-   ·
- 6 │         ({ let y = 0; &mut (y + 1) } : ());
    │                                        -- Is not compatible with: '()'
+   │                                        ^^ Invalid type annotation
    │
 
 error: 
 
-   ┌── tests/move_check/typing/block_with_statements_invalid.move:7:9 ───
+   ┌── tests/move_check/typing/block_with_statements_invalid.move:2:5 ───
    │
- 7 │         ({ let r = { let r = R {}; r }; r } : R);
-   │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Cannot ignore resource values. The value must be used
-   ·
- 7 │         ({ let r = { let r = R {}; r }; r } : R);
-   │                                               - The type: '0x8675309::M::R'
-   ·
  2 │     resource struct R {}
    │     -------- Is found to be a non-copyable type here
+   ·
+ 7 │         ({ let r = { let r = R {}; r }; r } : R);
+   │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Cannot ignore resource values. The value must be used
+   │                                               - The type: '0x8675309::M::R'
    │
 
 error: 
 
-   ┌── tests/move_check/typing/block_with_statements_invalid.move:8:45 ───
+   ┌── tests/move_check/typing/block_with_statements_invalid.move:8:23 ───
    │
  8 │         ({ let x = 0; (x, false, false) } : (u64, bool));
-   │                                             ^^^^^^^^^^^ Invalid type annotation
-   ·
- 8 │         ({ let x = 0; (x, false, false) } : (u64, bool));
    │                       ----------------- The expression list type of length 3: '({integer}, bool, bool)'
-   ·
- 8 │         ({ let x = 0; (x, false, false) } : (u64, bool));
    │                                             ----------- Is not compatible with the expression list type of length 2: '(u64, bool)'
+   │                                             ^^^^^^^^^^^ Invalid type annotation
    │
 

--- a/language/move-lang/tests/move_check/typing/borrow_field_from_non_struct.exp
+++ b/language/move-lang/tests/move_check/typing/borrow_field_from_non_struct.exp
@@ -3,10 +3,8 @@ error:
    ┌── tests/move_check/typing/borrow_field_from_non_struct.move:6:10 ───
    │
  6 │         &0.f;
-   │          ^^^ Unbound field 'f'
-   ·
- 6 │         &0.f;
    │          - Could not infer the type. Try annotating here
+   │          ^^^ Unbound field 'f'
    │
 
 error: 
@@ -14,65 +12,61 @@ error:
    ┌── tests/move_check/typing/borrow_field_from_non_struct.move:7:10 ───
    │
  7 │         &0.g;
-   │          ^^^ Unbound field 'g'
-   ·
- 7 │         &0.g;
    │          - Could not infer the type. Try annotating here
+   │          ^^^ Unbound field 'g'
    │
 
 error: 
 
-   ┌── tests/move_check/typing/borrow_field_from_non_struct.move:8:10 ───
+   ┌── tests/move_check/typing/borrow_field_from_non_struct.move:5:15 ───
    │
- 8 │         &u.value;
-   │          ^^^^^^^ Unbound field 'value'
-   ·
  5 │     fun t0(u: u64, cond: bool, addr: address) {
    │               --- Expected a struct type in the current module but got: 'u64'
+   ·
+ 8 │         &u.value;
+   │          ^^^^^^^ Unbound field 'value'
    │
 
 error: 
 
-   ┌── tests/move_check/typing/borrow_field_from_non_struct.move:9:10 ───
+   ┌── tests/move_check/typing/borrow_field_from_non_struct.move:5:26 ───
    │
- 9 │         &cond.value;
-   │          ^^^^^^^^^^ Unbound field 'value'
-   ·
  5 │     fun t0(u: u64, cond: bool, addr: address) {
    │                          ---- Expected a struct type in the current module but got: 'bool'
+   ·
+ 9 │         &cond.value;
+   │          ^^^^^^^^^^ Unbound field 'value'
    │
 
 error: 
 
-    ┌── tests/move_check/typing/borrow_field_from_non_struct.move:10:10 ───
+    ┌── tests/move_check/typing/borrow_field_from_non_struct.move:5:38 ───
     │
+  5 │     fun t0(u: u64, cond: bool, addr: address) {
+    │                                      ------- Expected a struct type in the current module but got: 'address'
+    ·
  10 │         &addr.R;
     │          ^^^^^^ Unbound field 'R'
-    ·
-  5 │     fun t0(u: u64, cond: bool, addr: address) {
-    │                                      ------- Expected a struct type in the current module but got: 'address'
     │
 
 error: 
 
-    ┌── tests/move_check/typing/borrow_field_from_non_struct.move:11:10 ───
+    ┌── tests/move_check/typing/borrow_field_from_non_struct.move:5:38 ───
     │
+  5 │     fun t0(u: u64, cond: bool, addr: address) {
+    │                                      ------- Expected a struct type in the current module but got: 'address'
+    ·
  11 │         &addr.f;
     │          ^^^^^^ Unbound field 'f'
-    ·
-  5 │     fun t0(u: u64, cond: bool, addr: address) {
-    │                                      ------- Expected a struct type in the current module but got: 'address'
     │
 
 error: 
 
     ┌── tests/move_check/typing/borrow_field_from_non_struct.move:12:10 ───
     │
- 12 │         &().R;
-    │          ^^ Invalid dot access
-    ·
  12 │         &().R;
     │          -- Expected a single type, but found expression list type: '()'
+    │          ^^ Invalid dot access
     │
 
 error: 
@@ -80,21 +74,17 @@ error:
     ┌── tests/move_check/typing/borrow_field_from_non_struct.move:12:10 ───
     │
  12 │         &().R;
-    │          ^^^^ Unbound field 'R'
-    ·
- 12 │         &().R;
     │          -- Expected a struct type in the current module but got: '()'
+    │          ^^^^ Unbound field 'R'
     │
 
 error: 
 
     ┌── tests/move_check/typing/borrow_field_from_non_struct.move:13:10 ───
     │
- 13 │         &(&S{f: 0}, &S{f:0}).f;
-    │          ^^^^^^^^^^^^^^^^^^^ Invalid dot access
-    ·
  13 │         &(&S{f: 0}, &S{f:0}).f;
     │          ------------------- Expected a single type, but found expression list type: '(&0x8675309::M::S, &0x8675309::M::S)'
+    │          ^^^^^^^^^^^^^^^^^^^ Invalid dot access
     │
 
 error: 
@@ -102,9 +92,7 @@ error:
     ┌── tests/move_check/typing/borrow_field_from_non_struct.move:13:10 ───
     │
  13 │         &(&S{f: 0}, &S{f:0}).f;
-    │          ^^^^^^^^^^^^^^^^^^^^^ Unbound field 'f'
-    ·
- 13 │         &(&S{f: 0}, &S{f:0}).f;
     │          ------------------- Expected a struct type in the current module but got: '(&0x8675309::M::S, &0x8675309::M::S)'
+    │          ^^^^^^^^^^^^^^^^^^^^^ Unbound field 'f'
     │
 

--- a/language/move-lang/tests/move_check/typing/borrow_local_invalid.exp
+++ b/language/move-lang/tests/move_check/typing/borrow_local_invalid.exp
@@ -1,44 +1,43 @@
 error: 
 
-   ┌── tests/move_check/typing/borrow_local_invalid.move:3:9 ───
+   ┌── tests/move_check/typing/borrow_local_invalid.move:2:15 ───
    │
+ 2 │     fun t0(r: &u64, r_mut: &mut u64) {
+   │               ---- Expected a single non-reference type, but found: '&u64'
  3 │         &r;
    │         ^^ Invalid borrow
-   ·
- 2 │     fun t0(r: &u64, r_mut: &mut u64) {
-   │               ---- Expected a single non-reference type, but found: '&u64'
    │
 
 error: 
 
-   ┌── tests/move_check/typing/borrow_local_invalid.move:4:9 ───
+   ┌── tests/move_check/typing/borrow_local_invalid.move:2:28 ───
    │
+ 2 │     fun t0(r: &u64, r_mut: &mut u64) {
+   │                            -------- Expected a single non-reference type, but found: '&mut u64'
+ 3 │         &r;
  4 │         &r_mut;
    │         ^^^^^^ Invalid borrow
-   ·
- 2 │     fun t0(r: &u64, r_mut: &mut u64) {
-   │                            -------- Expected a single non-reference type, but found: '&mut u64'
    │
 
 error: 
 
-   ┌── tests/move_check/typing/borrow_local_invalid.move:5:9 ───
+   ┌── tests/move_check/typing/borrow_local_invalid.move:2:15 ───
    │
- 5 │         &mut r;
-   │         ^^^^^^ Invalid borrow
-   ·
  2 │     fun t0(r: &u64, r_mut: &mut u64) {
    │               ---- Expected a single non-reference type, but found: '&u64'
+   ·
+ 5 │         &mut r;
+   │         ^^^^^^ Invalid borrow
    │
 
 error: 
 
-   ┌── tests/move_check/typing/borrow_local_invalid.move:6:9 ───
+   ┌── tests/move_check/typing/borrow_local_invalid.move:2:28 ───
    │
- 6 │         &mut r_mut;
-   │         ^^^^^^^^^^ Invalid borrow
-   ·
  2 │     fun t0(r: &u64, r_mut: &mut u64) {
    │                            -------- Expected a single non-reference type, but found: '&mut u64'
+   ·
+ 6 │         &mut r_mut;
+   │         ^^^^^^^^^^ Invalid borrow
    │
 

--- a/language/move-lang/tests/move_check/typing/borrow_local_temp_invalid.exp
+++ b/language/move-lang/tests/move_check/typing/borrow_local_temp_invalid.exp
@@ -4,8 +4,6 @@ error:
    │
  3 │         &();
    │         ^^^ Invalid borrow
-   ·
- 3 │         &();
    │          -- Expected a single non-reference type, but found: '()'
    │
 
@@ -15,8 +13,6 @@ error:
    │
  4 │         &(0, 1);
    │         ^^^^^^^ Invalid borrow
-   ·
- 4 │         &(0, 1);
    │          ------ Expected a single non-reference type, but found: '(u64, u64)'
    │
 
@@ -26,8 +22,6 @@ error:
    │
  5 │         &(0, 1, true, 0x0);
    │         ^^^^^^^^^^^^^^^^^^ Invalid borrow
-   ·
- 5 │         &(0, 1, true, 0x0);
    │          ----------------- Expected a single non-reference type, but found: '(u64, u64, bool, address)'
    │
 
@@ -37,8 +31,6 @@ error:
    │
  9 │         &(&0);
    │         ^^^^^ Invalid borrow
-   ·
- 9 │         &(&0);
    │          ---- Expected a single non-reference type, but found: '&u64'
    │
 
@@ -48,8 +40,6 @@ error:
     │
  10 │         &(&mut 1);
     │         ^^^^^^^^^ Invalid borrow
-    ·
- 10 │         &(&mut 1);
     │          -------- Expected a single non-reference type, but found: '&mut u64'
     │
 
@@ -59,8 +49,6 @@ error:
     │
  11 │         &mut &2;
     │         ^^^^^^^ Invalid borrow
-    ·
- 11 │         &mut &2;
     │              -- Expected a single non-reference type, but found: '&u64'
     │
 
@@ -70,8 +58,6 @@ error:
     │
  12 │         &mut &mut 3;
     │         ^^^^^^^^^^^ Invalid borrow
-    ·
- 12 │         &mut &mut 3;
     │              ------ Expected a single non-reference type, but found: '&mut u64'
     │
 

--- a/language/move-lang/tests/move_check/typing/borrow_local_temp_resource.exp
+++ b/language/move-lang/tests/move_check/typing/borrow_local_temp_resource.exp
@@ -1,22 +1,19 @@
 error: 
 
-   ┌── tests/move_check/typing/borrow_local_temp_resource.move:7:17 ───
+   ┌── tests/move_check/typing/borrow_local_temp_resource.move:6:10 ───
    │
- 7 │         &mut R{};
-   │                 ^ Invalid return
-   ·
  6 │         &R{};
    │          --- The resource is created but not used. The resource must be consumed before the function returns
+ 7 │         &mut R{};
+   │                 ^ Invalid return
    │
 
 error: 
 
-   ┌── tests/move_check/typing/borrow_local_temp_resource.move:7:17 ───
+   ┌── tests/move_check/typing/borrow_local_temp_resource.move:7:14 ───
    │
  7 │         &mut R{};
-   │                 ^ Invalid return
-   ·
- 7 │         &mut R{};
    │              --- The resource is created but not used. The resource must be consumed before the function returns
+   │                 ^ Invalid return
    │
 

--- a/language/move-lang/tests/move_check/typing/cast_invalid.exp
+++ b/language/move-lang/tests/move_check/typing/cast_invalid.exp
@@ -3,10 +3,8 @@ error:
    ┌── tests/move_check/typing/cast_invalid.move:6:10 ───
    │
  6 │         (false as u8);
-   │          ^^^^^ Invalid argument to 'as'
-   ·
- 6 │         (false as u8);
    │          ----- Found: 'bool'. But expected: 'u8', 'u64', 'u128'
+   │          ^^^^^ Invalid argument to 'as'
    │
 
 error: 
@@ -14,10 +12,8 @@ error:
    ┌── tests/move_check/typing/cast_invalid.move:7:10 ───
    │
  7 │         (true as u128);
-   │          ^^^^ Invalid argument to 'as'
-   ·
- 7 │         (true as u128);
    │          ---- Found: 'bool'. But expected: 'u8', 'u64', 'u128'
+   │          ^^^^ Invalid argument to 'as'
    │
 
 error: 
@@ -25,10 +21,8 @@ error:
    ┌── tests/move_check/typing/cast_invalid.move:9:10 ───
    │
  9 │         (() as u64);
-   │          ^^ Invalid argument to 'as'
-   ·
- 9 │         (() as u64);
    │          -- Found: '()'. But expected: 'u8', 'u64', 'u128'
+   │          ^^ Invalid argument to 'as'
    │
 
 error: 
@@ -36,10 +30,8 @@ error:
     ┌── tests/move_check/typing/cast_invalid.move:10:10 ───
     │
  10 │         ((0, 1) as u8);
-    │          ^^^^^^ Invalid argument to 'as'
-    ·
- 10 │         ((0, 1) as u8);
     │          ------ Found: '(u64, u64)'. But expected: 'u8', 'u64', 'u128'
+    │          ^^^^^^ Invalid argument to 'as'
     │
 
 error: 
@@ -47,10 +39,8 @@ error:
     ┌── tests/move_check/typing/cast_invalid.move:12:15 ───
     │
  12 │         (0 as bool);
-    │               ^^^^ Invalid argument to 'as'
-    ·
- 12 │         (0 as bool);
     │               ---- Found: 'bool'. But expected: 'u8', 'u64', 'u128'
+    │               ^^^^ Invalid argument to 'as'
     │
 
 error: 
@@ -58,10 +48,8 @@ error:
     ┌── tests/move_check/typing/cast_invalid.move:13:15 ───
     │
  13 │         (0 as address);
-    │               ^^^^^^^ Invalid argument to 'as'
-    ·
- 13 │         (0 as address);
     │               ------- Found: 'address'. But expected: 'u8', 'u64', 'u128'
+    │               ^^^^^^^ Invalid argument to 'as'
     │
 
 error: 
@@ -69,10 +57,8 @@ error:
     ┌── tests/move_check/typing/cast_invalid.move:14:21 ───
     │
  14 │         R{} = (0 as R);
-    │                     ^ Invalid argument to 'as'
-    ·
- 14 │         R{} = (0 as R);
     │                     - Found: '0x8675309::M::R'. But expected: 'u8', 'u64', 'u128'
+    │                     ^ Invalid argument to 'as'
     │
 
 error: 
@@ -80,10 +66,8 @@ error:
     ┌── tests/move_check/typing/cast_invalid.move:15:15 ───
     │
  15 │         (0 as Cup<u8>);
-    │               ^^^^^^^ Invalid argument to 'as'
-    ·
- 15 │         (0 as Cup<u8>);
     │               ------- Found: '0x8675309::M::Cup<u8>'. But expected: 'u8', 'u64', 'u128'
+    │               ^^^^^^^ Invalid argument to 'as'
     │
 
 error: 
@@ -91,10 +75,8 @@ error:
     ┌── tests/move_check/typing/cast_invalid.move:16:15 ───
     │
  16 │         (0 as ());
-    │               ^^ Invalid argument to 'as'
-    ·
- 16 │         (0 as ());
     │               -- Found: '()'. But expected: 'u8', 'u64', 'u128'
+    │               ^^ Invalid argument to 'as'
     │
 
 error: 
@@ -102,10 +84,8 @@ error:
     ┌── tests/move_check/typing/cast_invalid.move:17:15 ───
     │
  17 │         (0 as (u64, u8));
-    │               ^^^^^^^^^ Invalid argument to 'as'
-    ·
- 17 │         (0 as (u64, u8));
     │               --------- Found: '(u64, u8)'. But expected: 'u8', 'u64', 'u128'
+    │               ^^^^^^^^^ Invalid argument to 'as'
     │
 
 error: 
@@ -113,9 +93,7 @@ error:
     ┌── tests/move_check/typing/cast_invalid.move:19:3 ───
     │
  19 │     (x"1234" as u64);
-    │      ^^^^^^^ Invalid argument to 'as'
-    ·
- 19 │     (x"1234" as u64);
     │      ------- Found: 'vector<u8>'. But expected: 'u8', 'u64', 'u128'
+    │      ^^^^^^^ Invalid argument to 'as'
     │
 

--- a/language/move-lang/tests/move_check/typing/constraints_not_satisfied_all_cases.exp
+++ b/language/move-lang/tests/move_check/typing/constraints_not_satisfied_all_cases.exp
@@ -1,102 +1,81 @@
 error: 
 
-   ┌── tests/move_check/typing/constraints_not_satisfied_all_cases.move:7:29 ───
+   ┌── tests/move_check/typing/constraints_not_satisfied_all_cases.move:3:20 ───
    │
- 7 │     fun no_constraint<T>(c: CupC<T>, r: CupR<T>) {}
-   │                             ^^^^^^^ Constraint not satisfied.
-   ·
- 7 │     fun no_constraint<T>(c: CupC<T>, r: CupR<T>) {}
-   │                                  - The type 'T' does not satisfy the constraint 'copyable'
-   ·
- 7 │     fun no_constraint<T>(c: CupC<T>, r: CupR<T>) {}
-   │                       - The type's constraint information was determined here
-   ·
  3 │     struct CupC<T: copyable> {}
    │                    -------- 'copyable' constraint declared here
-   │
-
-error: 
-
-   ┌── tests/move_check/typing/constraints_not_satisfied_all_cases.move:7:41 ───
-   │
- 7 │     fun no_constraint<T>(c: CupC<T>, r: CupR<T>) {}
-   │                                         ^^^^^^^ Constraint not satisfied.
-   ·
- 7 │     fun no_constraint<T>(c: CupC<T>, r: CupR<T>) {}
-   │                                              - The copyable type 'T' does not satisfy the constraint 'resource'
    ·
  7 │     fun no_constraint<T>(c: CupC<T>, r: CupR<T>) {}
    │                       - The type's constraint information was determined here
-   ·
- 2 │     struct CupR<T: resource> {}
-   │                    -------- 'resource' constraint declared here
+   │                             ^^^^^^^ Constraint not satisfied.
+   │                                  - The type 'T' does not satisfy the constraint 'copyable'
    │
 
 error: 
 
-   ┌── tests/move_check/typing/constraints_not_satisfied_all_cases.move:9:36 ───
+   ┌── tests/move_check/typing/constraints_not_satisfied_all_cases.move:2:20 ───
    │
- 9 │     fun t_resource<T: resource>(c: CupC<T>, r: CupR<T>) {}
-   │                                    ^^^^^^^ Constraint not satisfied.
+ 2 │     struct CupR<T: resource> {}
+   │                    -------- 'resource' constraint declared here
    ·
- 9 │     fun t_resource<T: resource>(c: CupC<T>, r: CupR<T>) {}
-   │                                         - The resource type 'T' does not satisfy the constraint 'copyable'
+ 7 │     fun no_constraint<T>(c: CupC<T>, r: CupR<T>) {}
+   │                       - The type's constraint information was determined here
+   │                                         ^^^^^^^ Constraint not satisfied.
+   │                                              - The copyable type 'T' does not satisfy the constraint 'resource'
+   │
+
+error: 
+
+   ┌── tests/move_check/typing/constraints_not_satisfied_all_cases.move:3:20 ───
+   │
+ 3 │     struct CupC<T: copyable> {}
+   │                    -------- 'copyable' constraint declared here
    ·
  9 │     fun t_resource<T: resource>(c: CupC<T>, r: CupR<T>) {}
    │                       -------- The type's constraint information was determined here
-   ·
- 3 │     struct CupC<T: copyable> {}
-   │                    -------- 'copyable' constraint declared here
+   │                                    ^^^^^^^ Constraint not satisfied.
+   │                                         - The resource type 'T' does not satisfy the constraint 'copyable'
    │
 
 error: 
 
-    ┌── tests/move_check/typing/constraints_not_satisfied_all_cases.move:11:48 ───
+    ┌── tests/move_check/typing/constraints_not_satisfied_all_cases.move:2:20 ───
     │
- 11 │     fun t_copyable<T: copyable>(c: CupC<T>, r: CupR<T>) {}
-    │                                                ^^^^^^^ Constraint not satisfied.
-    ·
- 11 │     fun t_copyable<T: copyable>(c: CupC<T>, r: CupR<T>) {}
-    │                                                     - The copyable type 'T' does not satisfy the constraint 'resource'
+  2 │     struct CupR<T: resource> {}
+    │                    -------- 'resource' constraint declared here
     ·
  11 │     fun t_copyable<T: copyable>(c: CupC<T>, r: CupR<T>) {}
     │                       -------- The type's constraint information was determined here
-    ·
-  2 │     struct CupR<T: resource> {}
-    │                    -------- 'resource' constraint declared here
+    │                                                ^^^^^^^ Constraint not satisfied.
+    │                                                     - The copyable type 'T' does not satisfy the constraint 'resource'
     │
 
 error: 
 
-    ┌── tests/move_check/typing/constraints_not_satisfied_all_cases.move:13:14 ───
+    ┌── tests/move_check/typing/constraints_not_satisfied_all_cases.move:3:20 ───
     │
- 13 │     fun r(c: CupC<R>, r: CupR<R>) {}
-    │              ^^^^^^^ Constraint not satisfied.
-    ·
- 13 │     fun r(c: CupC<R>, r: CupR<R>) {}
-    │                   - The resource type '0x8675309::M::R' does not satisfy the constraint 'copyable'
-    ·
+  3 │     struct CupC<T: copyable> {}
+    │                    -------- 'copyable' constraint declared here
   4 │     resource struct R {}
     │     -------- The type's constraint information was determined here
     ·
-  3 │     struct CupC<T: copyable> {}
-    │                    -------- 'copyable' constraint declared here
+ 13 │     fun r(c: CupC<R>, r: CupR<R>) {}
+    │              ^^^^^^^ Constraint not satisfied.
+    │                   - The resource type '0x8675309::M::R' does not satisfy the constraint 'copyable'
     │
 
 error: 
 
-    ┌── tests/move_check/typing/constraints_not_satisfied_all_cases.move:15:26 ───
+    ┌── tests/move_check/typing/constraints_not_satisfied_all_cases.move:2:20 ───
     │
- 15 │     fun c(c: CupC<C>, r: CupR<C>) {}
-    │                          ^^^^^^^ Constraint not satisfied.
-    ·
- 15 │     fun c(c: CupC<C>, r: CupR<C>) {}
-    │                               - The copyable type '0x8675309::M::C' does not satisfy the constraint 'resource'
+  2 │     struct CupR<T: resource> {}
+    │                    -------- 'resource' constraint declared here
     ·
   5 │     struct C {}
     │            - The type's constraint information was determined here
     ·
-  2 │     struct CupR<T: resource> {}
-    │                    -------- 'resource' constraint declared here
+ 15 │     fun c(c: CupC<C>, r: CupR<C>) {}
+    │                          ^^^^^^^ Constraint not satisfied.
+    │                               - The copyable type '0x8675309::M::C' does not satisfy the constraint 'resource'
     │
 

--- a/language/move-lang/tests/move_check/typing/constraints_not_satisfied_function_parameter.exp
+++ b/language/move-lang/tests/move_check/typing/constraints_not_satisfied_function_parameter.exp
@@ -1,17 +1,14 @@
 error: 
 
-   ┌── tests/move_check/typing/constraints_not_satisfied_function_parameter.move:5:16 ───
+   ┌── tests/move_check/typing/constraints_not_satisfied_function_parameter.move:2:20 ───
    │
- 5 │     fun foo(x: CupC<R>) {}
-   │                ^^^^^^^ Constraint not satisfied.
-   ·
- 5 │     fun foo(x: CupC<R>) {}
-   │                     - The resource type '0x8675309::M::R' does not satisfy the constraint 'copyable'
-   ·
- 3 │     resource struct R {}
-   │     -------- The type's constraint information was determined here
-   ·
  2 │     struct CupC<T: copyable> {}
    │                    -------- 'copyable' constraint declared here
+ 3 │     resource struct R {}
+   │     -------- The type's constraint information was determined here
+ 4 │ 
+ 5 │     fun foo(x: CupC<R>) {}
+   │                ^^^^^^^ Constraint not satisfied.
+   │                     - The resource type '0x8675309::M::R' does not satisfy the constraint 'copyable'
    │
 

--- a/language/move-lang/tests/move_check/typing/constraints_not_satisfied_function_return_type.exp
+++ b/language/move-lang/tests/move_check/typing/constraints_not_satisfied_function_return_type.exp
@@ -1,17 +1,14 @@
 error: 
 
-   ┌── tests/move_check/typing/constraints_not_satisfied_function_return_type.move:5:17 ───
+   ┌── tests/move_check/typing/constraints_not_satisfied_function_return_type.move:2:20 ───
    │
- 5 │     fun foo():  CupC<R> {
-   │                 ^^^^^^^ Constraint not satisfied.
-   ·
- 5 │     fun foo():  CupC<R> {
-   │                      - The resource type '0x8675309::M::R' does not satisfy the constraint 'copyable'
-   ·
- 3 │     resource struct R {}
-   │     -------- The type's constraint information was determined here
-   ·
  2 │     struct CupC<T: copyable> {}
    │                    -------- 'copyable' constraint declared here
+ 3 │     resource struct R {}
+   │     -------- The type's constraint information was determined here
+ 4 │ 
+ 5 │     fun foo():  CupC<R> {
+   │                 ^^^^^^^ Constraint not satisfied.
+   │                      - The resource type '0x8675309::M::R' does not satisfy the constraint 'copyable'
    │
 

--- a/language/move-lang/tests/move_check/typing/constraints_not_satisfied_lvalues_bind_type.exp
+++ b/language/move-lang/tests/move_check/typing/constraints_not_satisfied_lvalues_bind_type.exp
@@ -1,17 +1,14 @@
 error: 
 
-   ┌── tests/move_check/typing/constraints_not_satisfied_lvalues_bind_type.move:6:16 ───
+   ┌── tests/move_check/typing/constraints_not_satisfied_lvalues_bind_type.move:2:20 ───
    │
- 6 │         let x: CupC<R> = abort 0;
-   │                ^^^^^^^ Constraint not satisfied.
-   ·
- 6 │         let x: CupC<R> = abort 0;
-   │                     - The resource type '0x8675309::M::R' does not satisfy the constraint 'copyable'
-   ·
+ 2 │     struct CupC<T: copyable> {}
+   │                    -------- 'copyable' constraint declared here
  3 │     resource struct R {}
    │     -------- The type's constraint information was determined here
    ·
- 2 │     struct CupC<T: copyable> {}
-   │                    -------- 'copyable' constraint declared here
+ 6 │         let x: CupC<R> = abort 0;
+   │                ^^^^^^^ Constraint not satisfied.
+   │                     - The resource type '0x8675309::M::R' does not satisfy the constraint 'copyable'
    │
 

--- a/language/move-lang/tests/move_check/typing/constraints_not_satisfied_lvalues_decl_type.exp
+++ b/language/move-lang/tests/move_check/typing/constraints_not_satisfied_lvalues_decl_type.exp
@@ -1,17 +1,14 @@
 error: 
 
-   ┌── tests/move_check/typing/constraints_not_satisfied_lvalues_decl_type.move:6:16 ───
+   ┌── tests/move_check/typing/constraints_not_satisfied_lvalues_decl_type.move:2:20 ───
    │
- 6 │         let x: CupC<R>;
-   │                ^^^^^^^ Constraint not satisfied.
-   ·
- 6 │         let x: CupC<R>;
-   │                     - The resource type '0x8675309::M::R' does not satisfy the constraint 'copyable'
-   ·
+ 2 │     struct CupC<T: copyable> {}
+   │                    -------- 'copyable' constraint declared here
  3 │     resource struct R {}
    │     -------- The type's constraint information was determined here
    ·
- 2 │     struct CupC<T: copyable> {}
-   │                    -------- 'copyable' constraint declared here
+ 6 │         let x: CupC<R>;
+   │                ^^^^^^^ Constraint not satisfied.
+   │                     - The resource type '0x8675309::M::R' does not satisfy the constraint 'copyable'
    │
 

--- a/language/move-lang/tests/move_check/typing/constraints_not_satisfied_lvalues_pack_type_args.exp
+++ b/language/move-lang/tests/move_check/typing/constraints_not_satisfied_lvalues_pack_type_args.exp
@@ -1,34 +1,28 @@
 error: 
 
-   ┌── tests/move_check/typing/constraints_not_satisfied_lvalues_pack_type_args.move:8:15 ───
+   ┌── tests/move_check/typing/constraints_not_satisfied_lvalues_pack_type_args.move:2:20 ───
    │
- 8 │         let B<CupC<R>> {} = abort 0;
-   │               ^^^^^^^ Constraint not satisfied.
-   ·
- 8 │         let B<CupC<R>> {} = abort 0;
-   │                    - The resource type '0x8675309::M::R' does not satisfy the constraint 'copyable'
-   ·
+ 2 │     struct CupC<T: copyable> {}
+   │                    -------- 'copyable' constraint declared here
  3 │     resource struct R {}
    │     -------- The type's constraint information was determined here
    ·
- 2 │     struct CupC<T: copyable> {}
-   │                    -------- 'copyable' constraint declared here
+ 8 │         let B<CupC<R>> {} = abort 0;
+   │               ^^^^^^^ Constraint not satisfied.
+   │                    - The resource type '0x8675309::M::R' does not satisfy the constraint 'copyable'
    │
 
 error: 
 
-   ┌── tests/move_check/typing/constraints_not_satisfied_lvalues_pack_type_args.move:9:11 ───
+   ┌── tests/move_check/typing/constraints_not_satisfied_lvalues_pack_type_args.move:2:20 ───
    │
- 9 │         B<CupC<R>> {} = abort 0;
-   │           ^^^^^^^ Constraint not satisfied.
-   ·
- 9 │         B<CupC<R>> {} = abort 0;
-   │                - The resource type '0x8675309::M::R' does not satisfy the constraint 'copyable'
-   ·
+ 2 │     struct CupC<T: copyable> {}
+   │                    -------- 'copyable' constraint declared here
  3 │     resource struct R {}
    │     -------- The type's constraint information was determined here
    ·
- 2 │     struct CupC<T: copyable> {}
-   │                    -------- 'copyable' constraint declared here
+ 9 │         B<CupC<R>> {} = abort 0;
+   │           ^^^^^^^ Constraint not satisfied.
+   │                - The resource type '0x8675309::M::R' does not satisfy the constraint 'copyable'
    │
 

--- a/language/move-lang/tests/move_check/typing/constraints_not_satisfied_struct_field.exp
+++ b/language/move-lang/tests/move_check/typing/constraints_not_satisfied_struct_field.exp
@@ -1,17 +1,14 @@
 error: 
 
-   ┌── tests/move_check/typing/constraints_not_satisfied_struct_field.move:6:12 ───
+   ┌── tests/move_check/typing/constraints_not_satisfied_struct_field.move:2:20 ───
    │
- 6 │         f: CupC<R>,
-   │            ^^^^^^^ Constraint not satisfied.
-   ·
- 6 │         f: CupC<R>,
-   │                 - The resource type '0x8675309::M::R' does not satisfy the constraint 'copyable'
-   ·
+ 2 │     struct CupC<T: copyable> {}
+   │                    -------- 'copyable' constraint declared here
  3 │     resource struct R {}
    │     -------- The type's constraint information was determined here
    ·
- 2 │     struct CupC<T: copyable> {}
-   │                    -------- 'copyable' constraint declared here
+ 6 │         f: CupC<R>,
+   │            ^^^^^^^ Constraint not satisfied.
+   │                 - The resource type '0x8675309::M::R' does not satisfy the constraint 'copyable'
    │
 

--- a/language/move-lang/tests/move_check/typing/constraints_not_satisfied_type_annotation.exp
+++ b/language/move-lang/tests/move_check/typing/constraints_not_satisfied_type_annotation.exp
@@ -1,17 +1,15 @@
 error: 
 
-   ┌── tests/move_check/typing/constraints_not_satisfied_type_annotation.move:7:26 ───
+   ┌── tests/move_check/typing/constraints_not_satisfied_type_annotation.move:2:20 ───
    │
- 7 │         ignore((abort 0: CupC<R>));
-   │                          ^^^^^^^ Constraint not satisfied.
-   ·
- 7 │         ignore((abort 0: CupC<R>));
-   │                               - The resource type '0x8675309::M::R' does not satisfy the constraint 'copyable'
-   ·
+ 2 │     struct CupC<T: copyable> {}
+   │                    -------- 'copyable' constraint declared here
+ 3 │     struct C {}
  4 │     resource struct R {}
    │     -------- The type's constraint information was determined here
    ·
- 2 │     struct CupC<T: copyable> {}
-   │                    -------- 'copyable' constraint declared here
+ 7 │         ignore((abort 0: CupC<R>));
+   │                          ^^^^^^^ Constraint not satisfied.
+   │                               - The resource type '0x8675309::M::R' does not satisfy the constraint 'copyable'
    │
 

--- a/language/move-lang/tests/move_check/typing/constraints_not_satisfied_type_arguments_internal_call.exp
+++ b/language/move-lang/tests/move_check/typing/constraints_not_satisfied_type_arguments_internal_call.exp
@@ -1,17 +1,14 @@
 error: 
 
-   ┌── tests/move_check/typing/constraints_not_satisfied_type_arguments_internal_call.move:9:13 ───
+   ┌── tests/move_check/typing/constraints_not_satisfied_type_arguments_internal_call.move:2:20 ───
    │
- 9 │         box<CupC<R>>();
-   │             ^^^^^^^ Constraint not satisfied.
-   ·
- 9 │         box<CupC<R>>();
-   │                  - The resource type '0x8675309::M::R' does not satisfy the constraint 'copyable'
-   ·
+ 2 │     struct CupC<T: copyable> {}
+   │                    -------- 'copyable' constraint declared here
  3 │     resource struct R {}
    │     -------- The type's constraint information was determined here
    ·
- 2 │     struct CupC<T: copyable> {}
-   │                    -------- 'copyable' constraint declared here
+ 9 │         box<CupC<R>>();
+   │             ^^^^^^^ Constraint not satisfied.
+   │                  - The resource type '0x8675309::M::R' does not satisfy the constraint 'copyable'
    │
 

--- a/language/move-lang/tests/move_check/typing/constraints_not_satisfied_type_arguments_internal_pack.exp
+++ b/language/move-lang/tests/move_check/typing/constraints_not_satisfied_type_arguments_internal_pack.exp
@@ -1,45 +1,38 @@
 error: 
 
-   ┌── tests/move_check/typing/constraints_not_satisfied_type_arguments_internal_pack.move:8:9 ───
+   ┌── tests/move_check/typing/constraints_not_satisfied_type_arguments_internal_pack.move:3:5 ───
    │
- 8 │         Box<CupC<R>>{};
-   │         ^^^^^^^^^^^^^^ Cannot ignore resource values. The value must be used
+ 3 │     resource struct R {}
+   │     -------- Is found to be a non-copyable type here
    ·
  8 │         Box<CupC<R>>{};
    │         -------------- The type: '0x8675309::M::Box<0x8675309::M::CupC<0x8675309::M::R>>'
-   ·
- 3 │     resource struct R {}
-   │     -------- Is found to be a non-copyable type here
+   │         ^^^^^^^^^^^^^^ Cannot ignore resource values. The value must be used
    │
 
 error: 
 
-   ┌── tests/move_check/typing/constraints_not_satisfied_type_arguments_internal_pack.move:8:13 ───
+   ┌── tests/move_check/typing/constraints_not_satisfied_type_arguments_internal_pack.move:2:20 ───
    │
- 8 │         Box<CupC<R>>{};
-   │             ^^^^^^^ Constraint not satisfied.
-   ·
- 8 │         Box<CupC<R>>{};
-   │                  - The resource type '0x8675309::M::R' does not satisfy the constraint 'copyable'
-   ·
+ 2 │     struct CupC<T: copyable> {}
+   │                    -------- 'copyable' constraint declared here
  3 │     resource struct R {}
    │     -------- The type's constraint information was determined here
    ·
- 2 │     struct CupC<T: copyable> {}
-   │                    -------- 'copyable' constraint declared here
+ 8 │         Box<CupC<R>>{};
+   │             ^^^^^^^ Constraint not satisfied.
+   │                  - The resource type '0x8675309::M::R' does not satisfy the constraint 'copyable'
    │
 
 error: 
 
-   ┌── tests/move_check/typing/constraints_not_satisfied_type_arguments_internal_pack.move:9:9 ───
+   ┌── tests/move_check/typing/constraints_not_satisfied_type_arguments_internal_pack.move:3:5 ───
    │
- 9 │         Box<R>{};
-   │         ^^^^^^^^ Cannot ignore resource values. The value must be used
+ 3 │     resource struct R {}
+   │     -------- Is found to be a non-copyable type here
    ·
  9 │         Box<R>{};
    │         -------- The type: '0x8675309::M::Box<0x8675309::M::R>'
-   ·
- 3 │     resource struct R {}
-   │     -------- Is found to be a non-copyable type here
+   │         ^^^^^^^^ Cannot ignore resource values. The value must be used
    │
 

--- a/language/move-lang/tests/move_check/typing/declare_duplicate_binding.exp
+++ b/language/move-lang/tests/move_check/typing/declare_duplicate_binding.exp
@@ -8,13 +8,11 @@ error:
 
 error: 
 
-   ┌── tests/move_check/typing/declare_duplicate_binding.move:5:17 ───
+   ┌── tests/move_check/typing/declare_duplicate_binding.move:5:14 ───
    │
  5 │         let (x, x);
-   │                 ^ Duplicate declaration for local 'x' in a given 'let'
-   ·
- 5 │         let (x, x);
    │              - Previously declared here
+   │                 ^ Duplicate declaration for local 'x' in a given 'let'
    │
 
 error: 
@@ -27,23 +25,19 @@ error:
 
 error: 
 
-   ┌── tests/move_check/typing/declare_duplicate_binding.move:6:19 ───
+   ┌── tests/move_check/typing/declare_duplicate_binding.move:6:14 ───
    │
  6 │         let (f, R{f}, f);
-   │                   ^ Duplicate declaration for local 'f' in a given 'let'
-   ·
- 6 │         let (f, R{f}, f);
    │              - Previously declared here
+   │                   ^ Duplicate declaration for local 'f' in a given 'let'
    │
 
 error: 
 
-   ┌── tests/move_check/typing/declare_duplicate_binding.move:6:23 ───
+   ┌── tests/move_check/typing/declare_duplicate_binding.move:6:19 ───
    │
  6 │         let (f, R{f}, f);
-   │                       ^ Duplicate declaration for local 'f' in a given 'let'
-   ·
- 6 │         let (f, R{f}, f);
    │                   - Previously declared here
+   │                       ^ Duplicate declaration for local 'f' in a given 'let'
    │
 

--- a/language/move-lang/tests/move_check/typing/declare_pop_resource.exp
+++ b/language/move-lang/tests/move_check/typing/declare_pop_resource.exp
@@ -1,56 +1,48 @@
 error: 
 
-   ┌── tests/move_check/typing/declare_pop_resource.move:5:13 ───
+   ┌── tests/move_check/typing/declare_pop_resource.move:2:5 ───
    │
+ 2 │     resource struct R {f: u64}
+   │     -------- Is found to be a non-copyable type here
+   ·
  5 │         let _: R;
    │             ^ Cannot ignore resource values. The value must be used
-   ·
- 5 │         let _: R;
    │                - The type: '0x8675309::M::R'
-   ·
- 2 │     resource struct R {f: u64}
-   │     -------- Is found to be a non-copyable type here
    │
 
 error: 
 
-   ┌── tests/move_check/typing/declare_pop_resource.move:6:13 ───
+   ┌── tests/move_check/typing/declare_pop_resource.move:2:5 ───
    │
+ 2 │     resource struct R {f: u64}
+   │     -------- Is found to be a non-copyable type here
+   ·
  6 │         let _r: R;
    │             ^^ Cannot ignore resource values. The value must be used
-   ·
- 6 │         let _r: R;
    │                 - The type: '0x8675309::M::R'
-   ·
- 2 │     resource struct R {f: u64}
-   │     -------- Is found to be a non-copyable type here
    │
 
 error: 
 
-   ┌── tests/move_check/typing/declare_pop_resource.move:7:14 ───
+   ┌── tests/move_check/typing/declare_pop_resource.move:2:5 ───
    │
+ 2 │     resource struct R {f: u64}
+   │     -------- Is found to be a non-copyable type here
+   ·
  7 │         let (_, _):(R, R);
    │              ^ Cannot ignore resource values. The value must be used
-   ·
- 7 │         let (_, _):(R, R);
    │                     - The type: '0x8675309::M::R'
-   ·
- 2 │     resource struct R {f: u64}
-   │     -------- Is found to be a non-copyable type here
    │
 
 error: 
 
-   ┌── tests/move_check/typing/declare_pop_resource.move:7:17 ───
+   ┌── tests/move_check/typing/declare_pop_resource.move:2:5 ───
    │
- 7 │         let (_, _):(R, R);
-   │                 ^ Cannot ignore resource values. The value must be used
-   ·
- 7 │         let (_, _):(R, R);
-   │                        - The type: '0x8675309::M::R'
-   ·
  2 │     resource struct R {f: u64}
    │     -------- Is found to be a non-copyable type here
+   ·
+ 7 │         let (_, _):(R, R);
+   │                 ^ Cannot ignore resource values. The value must be used
+   │                        - The type: '0x8675309::M::R'
    │
 

--- a/language/move-lang/tests/move_check/typing/declare_wrong_arity.exp
+++ b/language/move-lang/tests/move_check/typing/declare_wrong_arity.exp
@@ -4,8 +4,6 @@ error:
    │
  5 │         let x: ();
    │             ^ Invalid type for local
-   ·
- 5 │         let x: ();
    │                -- Expected a single type, but found expression list type: '()'
    │
 
@@ -14,12 +12,8 @@ error:
    ┌── tests/move_check/typing/declare_wrong_arity.move:6:13 ───
    │
  6 │         let (): u64;
-   │             ^^ Invalid value for binding
-   ·
- 6 │         let (): u64;
    │             -- The type: '()'
-   ·
- 6 │         let (): u64;
+   │             ^^ Invalid value for binding
    │                 --- Is not compatible with: 'u64'
    │
 
@@ -28,12 +22,8 @@ error:
    ┌── tests/move_check/typing/declare_wrong_arity.move:7:13 ───
    │
  7 │         let (x, b, R{f}): (u64, bool, R, R);
-   │             ^^^^^^^^^^^^ Invalid value for binding
-   ·
- 7 │         let (x, b, R{f}): (u64, bool, R, R);
    │             ------------ The expression list type of length 3: '(_, _, _)'
-   ·
- 7 │         let (x, b, R{f}): (u64, bool, R, R);
+   │             ^^^^^^^^^^^^ Invalid value for binding
    │                           ----------------- Is not compatible with the expression list type of length 4: '(u64, bool, 0x8675309::M::R, 0x8675309::M::R)'
    │
 
@@ -42,12 +32,8 @@ error:
    ┌── tests/move_check/typing/declare_wrong_arity.move:8:13 ───
    │
  8 │         let (x, b, R{f}): (u64, bool);
-   │             ^^^^^^^^^^^^ Invalid value for binding
-   ·
- 8 │         let (x, b, R{f}): (u64, bool);
    │             ------------ The expression list type of length 3: '(_, _, _)'
-   ·
- 8 │         let (x, b, R{f}): (u64, bool);
+   │             ^^^^^^^^^^^^ Invalid value for binding
    │                           ----------- Is not compatible with the expression list type of length 2: '(u64, bool)'
    │
 

--- a/language/move-lang/tests/move_check/typing/declare_wrong_type.exp
+++ b/language/move-lang/tests/move_check/typing/declare_wrong_type.exp
@@ -3,12 +3,8 @@ error:
    ┌── tests/move_check/typing/declare_wrong_type.move:6:13 ───
    │
  6 │         let S { g } : R;
-   │             ^^^^^^^ Invalid deconstruction binding
-   ·
- 6 │         let S { g } : R;
    │             ------- The type: '0x8675309::M::S'
-   ·
- 6 │         let S { g } : R;
+   │             ^^^^^^^ Invalid deconstruction binding
    │                       - Is not compatible with: '0x8675309::M::R'
    │
 
@@ -17,12 +13,8 @@ error:
    ┌── tests/move_check/typing/declare_wrong_type.move:7:14 ───
    │
  7 │         let (S { g }, R { f }): (R, R);
-   │              ^^^^^^^ Invalid deconstruction binding
-   ·
- 7 │         let (S { g }, R { f }): (R, R);
    │              ------- The type: '0x8675309::M::S'
-   ·
- 7 │         let (S { g }, R { f }): (R, R);
+   │              ^^^^^^^ Invalid deconstruction binding
    │                                  - Is not compatible with: '0x8675309::M::R'
    │
 

--- a/language/move-lang/tests/move_check/typing/derefrence_invalid.exp
+++ b/language/move-lang/tests/move_check/typing/derefrence_invalid.exp
@@ -1,168 +1,143 @@
 error: 
 
-   ┌── tests/move_check/typing/derefrence_invalid.move:6:15 ───
+   ┌── tests/move_check/typing/derefrence_invalid.move:5:16 ───
    │
- 6 │         (*x : bool);
-   │               ^^^^ Invalid type annotation
-   ·
  5 │     fun t0(x: &u64, x_mut: &mut u64, s: &S, s_mut: &mut S){
    │                --- The type: 'u64'
-   ·
  6 │         (*x : bool);
    │               ---- Is not compatible with: 'bool'
+   │               ^^^^ Invalid type annotation
    │
 
 error: 
 
-   ┌── tests/move_check/typing/derefrence_invalid.move:7:18 ───
+   ┌── tests/move_check/typing/derefrence_invalid.move:5:33 ───
    │
- 7 │         (*x_mut: &u64);
-   │                  ^^^^ Invalid type annotation
-   ·
  5 │     fun t0(x: &u64, x_mut: &mut u64, s: &S, s_mut: &mut S){
    │                                 --- The type: 'u64'
-   ·
+ 6 │         (*x : bool);
  7 │         (*x_mut: &u64);
    │                  ---- Is not compatible with: '&u64'
+   │                  ^^^^ Invalid type annotation
    │
 
 error: 
 
-   ┌── tests/move_check/typing/derefrence_invalid.move:9:14 ───
+   ┌── tests/move_check/typing/derefrence_invalid.move:5:42 ───
    │
- 9 │         (*s: X);
-   │              ^ Invalid type annotation
-   ·
  5 │     fun t0(x: &u64, x_mut: &mut u64, s: &S, s_mut: &mut S){
    │                                          - The type: '0x8675309::M::S'
    ·
  9 │         (*s: X);
    │              - Is not compatible with: '0x8675309::M::X'
+   │              ^ Invalid type annotation
    │
 
 error: 
 
-    ┌── tests/move_check/typing/derefrence_invalid.move:10:17 ───
+    ┌── tests/move_check/typing/derefrence_invalid.move:3:19 ───
     │
- 10 │         (*&s.f: bool);
-    │                 ^^^^ Invalid type annotation
-    ·
   3 │     struct S { f: u64, x: X }
     │                   --- The type: 'u64'
     ·
  10 │         (*&s.f: bool);
     │                 ---- Is not compatible with: 'bool'
+    │                 ^^^^ Invalid type annotation
     │
 
 error: 
 
-    ┌── tests/move_check/typing/derefrence_invalid.move:11:15 ───
+    ┌── tests/move_check/typing/derefrence_invalid.move:3:19 ───
     │
- 11 │         (s.f: &u64);
-    │               ^^^^ Invalid type annotation
-    ·
   3 │     struct S { f: u64, x: X }
     │                   --- The type: 'u64'
     ·
  11 │         (s.f: &u64);
     │               ---- Is not compatible with: '&u64'
+    │               ^^^^ Invalid type annotation
     │
 
 error: 
 
-    ┌── tests/move_check/typing/derefrence_invalid.move:12:17 ───
+    ┌── tests/move_check/typing/derefrence_invalid.move:3:27 ───
     │
- 12 │         (*&s.x: &X);
-    │                 ^^ Invalid type annotation
-    ·
   3 │     struct S { f: u64, x: X }
     │                           - The type: '0x8675309::M::X'
     ·
  12 │         (*&s.x: &X);
     │                 -- Is not compatible with: '&0x8675309::M::X'
+    │                 ^^ Invalid type annotation
     │
 
 error: 
 
-    ┌── tests/move_check/typing/derefrence_invalid.move:14:18 ───
+    ┌── tests/move_check/typing/derefrence_invalid.move:5:57 ───
     │
- 14 │         (*s_mut: X);
-    │                  ^ Invalid type annotation
-    ·
   5 │     fun t0(x: &u64, x_mut: &mut u64, s: &S, s_mut: &mut S){
     │                                                         - The type: '0x8675309::M::S'
     ·
  14 │         (*s_mut: X);
     │                  - Is not compatible with: '0x8675309::M::X'
+    │                  ^ Invalid type annotation
     │
 
 error: 
 
-    ┌── tests/move_check/typing/derefrence_invalid.move:15:21 ───
+    ┌── tests/move_check/typing/derefrence_invalid.move:3:19 ───
     │
- 15 │         (*&s_mut.f: bool);
-    │                     ^^^^ Invalid type annotation
-    ·
   3 │     struct S { f: u64, x: X }
     │                   --- The type: 'u64'
     ·
  15 │         (*&s_mut.f: bool);
     │                     ---- Is not compatible with: 'bool'
+    │                     ^^^^ Invalid type annotation
     │
 
 error: 
 
-    ┌── tests/move_check/typing/derefrence_invalid.move:16:25 ───
+    ┌── tests/move_check/typing/derefrence_invalid.move:3:19 ───
     │
- 16 │         (*&mut s_mut.f: (bool, u64));
-    │                         ^^^^^^^^^^^ Invalid type annotation
-    ·
   3 │     struct S { f: u64, x: X }
     │                   --- The type: 'u64'
     ·
  16 │         (*&mut s_mut.f: (bool, u64));
     │                         ----------- Is not compatible with: '(bool, u64)'
+    │                         ^^^^^^^^^^^ Invalid type annotation
     │
 
 error: 
 
-    ┌── tests/move_check/typing/derefrence_invalid.move:17:19 ───
+    ┌── tests/move_check/typing/derefrence_invalid.move:3:19 ───
     │
- 17 │         (s_mut.f: &u64);
-    │                   ^^^^ Invalid type annotation
-    ·
   3 │     struct S { f: u64, x: X }
     │                   --- The type: 'u64'
     ·
  17 │         (s_mut.f: &u64);
     │                   ---- Is not compatible with: '&u64'
+    │                   ^^^^ Invalid type annotation
     │
 
 error: 
 
-    ┌── tests/move_check/typing/derefrence_invalid.move:18:21 ───
+    ┌── tests/move_check/typing/derefrence_invalid.move:3:27 ───
     │
- 18 │         (*&s_mut.x: (X, S));
-    │                     ^^^^^^ Invalid type annotation
-    ·
   3 │     struct S { f: u64, x: X }
     │                           - The type: '0x8675309::M::X'
     ·
  18 │         (*&s_mut.x: (X, S));
     │                     ------ Is not compatible with: '(0x8675309::M::X, 0x8675309::M::S)'
+    │                     ^^^^^^ Invalid type annotation
     │
 
 error: 
 
-    ┌── tests/move_check/typing/derefrence_invalid.move:19:25 ───
+    ┌── tests/move_check/typing/derefrence_invalid.move:3:27 ───
     │
- 19 │         (*&mut s_mut.x: ());
-    │                         ^^ Invalid type annotation
-    ·
   3 │     struct S { f: u64, x: X }
     │                           - The type: '0x8675309::M::X'
     ·
  19 │         (*&mut s_mut.x: ());
     │                         -- Is not compatible with: '()'
+    │                         ^^ Invalid type annotation
     │
 

--- a/language/move-lang/tests/move_check/typing/derefrence_reference.exp
+++ b/language/move-lang/tests/move_check/typing/derefrence_reference.exp
@@ -1,98 +1,93 @@
 error: 
 
-   ┌── tests/move_check/typing/derefrence_reference.move:6:16 ───
+   ┌── tests/move_check/typing/derefrence_reference.move:2:5 ───
    │
- 6 │         R {} = *r;
-   │                ^^ Invalid dereference. Can only dereference references to copyable types
+ 2 │     resource struct R {}
+   │     -------- Is found to be a non-copyable type here
    ·
  5 │     fun t0(r: &R, b: &B) {
    │                - The type: '0x8675309::M::R'
-   ·
- 2 │     resource struct R {}
-   │     -------- Is found to be a non-copyable type here
+ 6 │         R {} = *r;
+   │                ^^ Invalid dereference. Can only dereference references to copyable types
    │
 
 error: 
 
-   ┌── tests/move_check/typing/derefrence_reference.move:7:24 ───
+   ┌── tests/move_check/typing/derefrence_reference.move:3:5 ───
    │
- 7 │         B { r: R{} } = *b;
-   │                        ^^ Invalid dereference. Can only dereference references to copyable types
-   ·
- 5 │     fun t0(r: &R, b: &B) {
-   │                       - The type: '0x8675309::M::B'
-   ·
  3 │     resource struct B { r: R }
    │     -------- Is found to be a non-copyable type here
+ 4 │ 
+ 5 │     fun t0(r: &R, b: &B) {
+   │                       - The type: '0x8675309::M::B'
+ 6 │         R {} = *r;
+ 7 │         B { r: R{} } = *b;
+   │                        ^^ Invalid dereference. Can only dereference references to copyable types
    │
 
 error: 
 
-   ┌── tests/move_check/typing/derefrence_reference.move:8:15 ───
+   ┌── tests/move_check/typing/derefrence_reference.move:2:5 ───
    │
- 8 │         R{} = *&b.r;
-   │               ^^^^^ Invalid dereference. Can only dereference references to copyable types
-   ·
+ 2 │     resource struct R {}
+   │     -------- Is found to be a non-copyable type here
  3 │     resource struct B { r: R }
    │                            - The type: '0x8675309::M::R'
    ·
- 2 │     resource struct R {}
-   │     -------- Is found to be a non-copyable type here
+ 8 │         R{} = *&b.r;
+   │               ^^^^^ Invalid dereference. Can only dereference references to copyable types
    │
 
 error: 
 
-    ┌── tests/move_check/typing/derefrence_reference.move:12:16 ───
+    ┌── tests/move_check/typing/derefrence_reference.move:2:5 ───
     │
- 12 │         R {} = *r;
-    │                ^^ Invalid dereference. Can only dereference references to copyable types
+  2 │     resource struct R {}
+    │     -------- Is found to be a non-copyable type here
     ·
  11 │     fun t1(r: &mut R, b: &mut B) {
     │                    - The type: '0x8675309::M::R'
-    ·
-  2 │     resource struct R {}
-    │     -------- Is found to be a non-copyable type here
+ 12 │         R {} = *r;
+    │                ^^ Invalid dereference. Can only dereference references to copyable types
     │
 
 error: 
 
-    ┌── tests/move_check/typing/derefrence_reference.move:13:24 ───
+    ┌── tests/move_check/typing/derefrence_reference.move:3:5 ───
     │
- 13 │         B { r: R{} } = *b;
-    │                        ^^ Invalid dereference. Can only dereference references to copyable types
+  3 │     resource struct B { r: R }
+    │     -------- Is found to be a non-copyable type here
     ·
  11 │     fun t1(r: &mut R, b: &mut B) {
     │                               - The type: '0x8675309::M::B'
-    ·
-  3 │     resource struct B { r: R }
-    │     -------- Is found to be a non-copyable type here
+ 12 │         R {} = *r;
+ 13 │         B { r: R{} } = *b;
+    │                        ^^ Invalid dereference. Can only dereference references to copyable types
     │
 
 error: 
 
-    ┌── tests/move_check/typing/derefrence_reference.move:14:15 ───
+    ┌── tests/move_check/typing/derefrence_reference.move:2:5 ───
     │
+  2 │     resource struct R {}
+    │     -------- Is found to be a non-copyable type here
+  3 │     resource struct B { r: R }
+    │                            - The type: '0x8675309::M::R'
+    ·
  14 │         R{} = *&b.r;
     │               ^^^^^ Invalid dereference. Can only dereference references to copyable types
-    ·
-  3 │     resource struct B { r: R }
-    │                            - The type: '0x8675309::M::R'
-    ·
-  2 │     resource struct R {}
-    │     -------- Is found to be a non-copyable type here
     │
 
 error: 
 
-    ┌── tests/move_check/typing/derefrence_reference.move:15:15 ───
+    ┌── tests/move_check/typing/derefrence_reference.move:2:5 ───
     │
- 15 │         R{} = *&mut b.r;
-    │               ^^^^^^^^^ Invalid dereference. Can only dereference references to copyable types
-    ·
+  2 │     resource struct R {}
+    │     -------- Is found to be a non-copyable type here
   3 │     resource struct B { r: R }
     │                            - The type: '0x8675309::M::R'
     ·
-  2 │     resource struct R {}
-    │     -------- Is found to be a non-copyable type here
+ 15 │         R{} = *&mut b.r;
+    │               ^^^^^^^^^ Invalid dereference. Can only dereference references to copyable types
     │
 

--- a/language/move-lang/tests/move_check/typing/duplicate_function_parameter_names.exp
+++ b/language/move-lang/tests/move_check/typing/duplicate_function_parameter_names.exp
@@ -1,11 +1,9 @@
 error: 
 
-   ┌── tests/move_check/typing/duplicate_function_parameter_names.move:2:21 ───
+   ┌── tests/move_check/typing/duplicate_function_parameter_names.move:2:13 ───
    │
  2 │     fun foo(x: u64, x: u64) {}
-   │                     ^ Duplicate parameter with name 'x'
-   ·
- 2 │     fun foo(x: u64, x: u64) {}
    │             - Previously declared here
+   │                     ^ Duplicate parameter with name 'x'
    │
 

--- a/language/move-lang/tests/move_check/typing/eq_invalid.exp
+++ b/language/move-lang/tests/move_check/typing/eq_invalid.exp
@@ -1,99 +1,78 @@
 error: 
 
-    ┌── tests/move_check/typing/eq_invalid.move:13:20 ───
+    ┌── tests/move_check/typing/eq_invalid.move:13:13 ───
     │
  13 │         (0: u8) == (1: u128);
-    │                    ^^^^^^^^^ Incompatible arguments to '=='
-    ·
- 13 │         (0: u8) == (1: u128);
     │             -- The type: 'u8'
-    ·
- 13 │         (0: u8) == (1: u128);
+    │                    ^^^^^^^^^ Incompatible arguments to '=='
     │                        ---- Is not compatible with: 'u128'
     │
 
 error: 
 
-    ┌── tests/move_check/typing/eq_invalid.move:14:14 ───
+    ┌── tests/move_check/typing/eq_invalid.move:14:9 ───
     │
  14 │         0 == false;
-    │              ^^^^^ Incompatible arguments to '=='
-    ·
- 14 │         0 == false;
     │         - The type: integer
-    ·
- 14 │         0 == false;
     │              ----- Is not compatible with: 'bool'
+    │              ^^^^^ Incompatible arguments to '=='
     │
 
 error: 
 
-    ┌── tests/move_check/typing/eq_invalid.move:15:15 ───
+    ┌── tests/move_check/typing/eq_invalid.move:15:9 ───
     │
- 15 │         &0 == 1;
-    │               ^ Incompatible arguments to '=='
-    ·
- 15 │         &0 == 1;
-    │               - The type: integer
-    ·
  15 │         &0 == 1;
     │         -- Is not compatible with: '&{integer}'
+    │               - The type: integer
+    │               ^ Incompatible arguments to '=='
     │
 
 error: 
 
-    ┌── tests/move_check/typing/eq_invalid.move:16:14 ───
+    ┌── tests/move_check/typing/eq_invalid.move:16:9 ───
     │
- 16 │         1 == &0;
-    │              ^^ Incompatible arguments to '=='
-    ·
  16 │         1 == &0;
     │         - The type: integer
-    ·
- 16 │         1 == &0;
     │              -- Is not compatible with: '&{integer}'
+    │              ^^ Incompatible arguments to '=='
     │
 
 error: 
 
-    ┌── tests/move_check/typing/eq_invalid.move:17:14 ───
+    ┌── tests/move_check/typing/eq_invalid.move:12:37 ───
     │
- 17 │         s == s_ref;
-    │              ^^^^^ Incompatible arguments to '=='
-    ·
  12 │     fun t0(r: &R, r_mut: &mut R, s: S, s_ref: &S, s_mut: &mut S) {
     │                                     - The type: '0x8675309::M::S'
-    ·
- 12 │     fun t0(r: &R, r_mut: &mut R, s: S, s_ref: &S, s_mut: &mut S) {
     │                                               -- Is not compatible with: '&0x8675309::M::S'
+    ·
+ 17 │         s == s_ref;
+    │              ^^^^^ Incompatible arguments to '=='
     │
 
 error: 
 
-    ┌── tests/move_check/typing/eq_invalid.move:18:18 ───
+    ┌── tests/move_check/typing/eq_invalid.move:12:37 ───
     │
- 18 │         s_mut == s;
-    │                  ^ Incompatible arguments to '=='
-    ·
- 12 │     fun t0(r: &R, r_mut: &mut R, s: S, s_ref: &S, s_mut: &mut S) {
-    │                                                          ------ The type: '&mut 0x8675309::M::S'
-    ·
  12 │     fun t0(r: &R, r_mut: &mut R, s: S, s_ref: &S, s_mut: &mut S) {
     │                                     - Is not compatible with: '0x8675309::M::S'
+    │                                                          ------ The type: '&mut 0x8675309::M::S'
+    ·
+ 18 │         s_mut == s;
+    │                  ^ Incompatible arguments to '=='
     │
 
 error: 
 
-    ┌── tests/move_check/typing/eq_invalid.move:22:9 ───
+    ┌── tests/move_check/typing/eq_invalid.move:3:5 ───
     │
- 22 │         r == r;
-    │         ^^^^^^ Cannot use '==' on resource values. This would destroy the resource. Try borrowing the values with '&' first.'
+  3 │     resource struct R {
+    │     -------- Is found to be a non-copyable type here
     ·
  21 │     fun t1(r: R) {
     │               - The type: '0x8675309::M::R'
-    ·
-  3 │     resource struct R {
-    │     -------- Is found to be a non-copyable type here
+ 22 │         r == r;
+    │         ^^^^^^ Cannot use '==' on resource values. This would destroy the resource. Try borrowing the values with '&' first.'
     │
 
 error: 
@@ -122,16 +101,14 @@ error:
 
 error: 
 
-    ┌── tests/move_check/typing/eq_invalid.move:27:9 ───
+    ┌── tests/move_check/typing/eq_invalid.move:7:18 ───
     │
- 27 │         G1{} == G1{};
-    │         ^^^^^^^^^^^^ Cannot use '==' on resource values. This would destroy the resource. Try borrowing the values with '&' first.'
-    ·
- 27 │         G1{} == G1{};
-    │                 ---- The type: '0x8675309::M::G1<_>'
-    ·
   7 │     struct G1<T: resource> {}
     │                  -------- Is found to be a non-copyable type here
+    ·
+ 27 │         G1{} == G1{};
+    │         ^^^^^^^^^^^^ Cannot use '==' on resource values. This would destroy the resource. Try borrowing the values with '&' first.'
+    │                 ---- The type: '0x8675309::M::G1<_>'
     │
 
 error: 
@@ -152,16 +129,14 @@ error:
 
 error: 
 
-    ┌── tests/move_check/typing/eq_invalid.move:28:9 ───
+    ┌── tests/move_check/typing/eq_invalid.move:8:15 ───
     │
- 28 │         G2{} == G2{};
-    │         ^^^^^^^^^^^^ Cannot use '==' on resource values. This would destroy the resource. Try borrowing the values with '&' first.'
-    ·
- 28 │         G2{} == G2{};
-    │                 ---- The type: '0x8675309::M::G2<_>'
-    ·
   8 │     struct G2<T> {}
     │               - Is found to be a non-copyable type here
+    ·
+ 28 │         G2{} == G2{};
+    │         ^^^^^^^^^^^^ Cannot use '==' on resource values. This would destroy the resource. Try borrowing the values with '&' first.'
+    │                 ---- The type: '0x8675309::M::G2<_>'
     │
 
 error: 
@@ -178,8 +153,6 @@ error:
     │
  32 │         () == ();
     │         ^^^^^^^^ Invalid arguments to '=='
-    ·
- 32 │         () == ();
     │               -- Expected a single type, but found expression list type: '()'
     │
 
@@ -189,36 +162,26 @@ error:
     │
  33 │         (0, 1) == (0, 1);
     │         ^^^^^^^^^^^^^^^^ Invalid arguments to '=='
-    ·
- 33 │         (0, 1) == (0, 1);
     │                   ------ Expected a single type, but found expression list type: '(u64, u64)'
     │
 
 error: 
 
-    ┌── tests/move_check/typing/eq_invalid.move:34:22 ───
+    ┌── tests/move_check/typing/eq_invalid.move:34:9 ───
     │
  34 │         (1, 2, 3) == (0, 1);
-    │                      ^^^^^^ Incompatible arguments to '=='
-    ·
- 34 │         (1, 2, 3) == (0, 1);
     │         --------- The expression list type of length 3: '({integer}, {integer}, {integer})'
-    ·
- 34 │         (1, 2, 3) == (0, 1);
     │                      ------ Is not compatible with the expression list type of length 2: '({integer}, {integer})'
+    │                      ^^^^^^ Incompatible arguments to '=='
     │
 
 error: 
 
-    ┌── tests/move_check/typing/eq_invalid.move:35:19 ───
+    ┌── tests/move_check/typing/eq_invalid.move:35:9 ───
     │
  35 │         (0, 1) == (1, 2, 3);
-    │                   ^^^^^^^^^ Incompatible arguments to '=='
-    ·
- 35 │         (0, 1) == (1, 2, 3);
     │         ------ The expression list type of length 2: '({integer}, {integer})'
-    ·
- 35 │         (0, 1) == (1, 2, 3);
     │                   --------- Is not compatible with the expression list type of length 3: '({integer}, {integer}, {integer})'
+    │                   ^^^^^^^^^ Incompatible arguments to '=='
     │
 

--- a/language/move-lang/tests/move_check/typing/exp_list_nested.exp
+++ b/language/move-lang/tests/move_check/typing/exp_list_nested.exp
@@ -1,15 +1,12 @@
 error: 
 
-   ┌── tests/move_check/typing/exp_list_nested.move:6:9 ───
+   ┌── tests/move_check/typing/exp_list_nested.move:5:15 ───
    │
- 6 │         (0, (S{}, R{}))
-   │         ^^^^^^^^^^^^^^^ Invalid return expression
-   ·
- 6 │         (0, (S{}, R{}))
-   │         --------------- The expression list type of length 2: '({integer}, (0x8675309::M::S, 0x8675309::M::R<_>))'
-   ·
  5 │     fun t0(): (u64, S, R<u64>) {
    │               ---------------- Is not compatible with the expression list type of length 3: '(u64, 0x8675309::M::S, 0x8675309::M::R<u64>)'
+ 6 │         (0, (S{}, R{}))
+   │         --------------- The expression list type of length 2: '({integer}, (0x8675309::M::S, 0x8675309::M::R<_>))'
+   │         ^^^^^^^^^^^^^^^ Invalid return expression
    │
 
 error: 
@@ -18,8 +15,6 @@ error:
    │
  6 │         (0, (S{}, R{}))
    │         ^^^^^^^^^^^^^^^ Invalid expression list type argument
-   ·
- 6 │         (0, (S{}, R{}))
    │             ---------- Expected a single type, but found expression list type: '(0x8675309::M::S, 0x8675309::M::R<_>)'
    │
 

--- a/language/move-lang/tests/move_check/typing/exp_list_resource_drop.exp
+++ b/language/move-lang/tests/move_check/typing/exp_list_resource_drop.exp
@@ -1,43 +1,37 @@
 error: 
 
-   ┌── tests/move_check/typing/exp_list_resource_drop.move:7:9 ───
+   ┌── tests/move_check/typing/exp_list_resource_drop.move:2:5 ───
    │
- 7 │         (0, S{}, R<u64> {});
-   │         ^^^^^^^^^^^^^^^^^^^ Cannot ignore resource values. The value must be used
+ 2 │     resource struct R<T> {}
+   │     -------- Is found to be a non-copyable type here
    ·
  7 │         (0, S{}, R<u64> {});
    │         ------------------- The type: '(u64, 0x8675309::M::S, 0x8675309::M::R<u64>)'
-   ·
- 2 │     resource struct R<T> {}
-   │     -------- Is found to be a non-copyable type here
+   │         ^^^^^^^^^^^^^^^^^^^ Cannot ignore resource values. The value must be used
    │
 
 error: 
 
-   ┌── tests/move_check/typing/exp_list_resource_drop.move:8:9 ───
+   ┌── tests/move_check/typing/exp_list_resource_drop.move:2:5 ───
    │
- 8 │         (0, S{}, Box<R<u64>> {});
-   │         ^^^^^^^^^^^^^^^^^^^^^^^^ Cannot ignore resource values. The value must be used
+ 2 │     resource struct R<T> {}
+   │     -------- Is found to be a non-copyable type here
    ·
  8 │         (0, S{}, Box<R<u64>> {});
    │         ------------------------ The type: '(u64, 0x8675309::M::S, 0x8675309::M::Box<0x8675309::M::R<u64>>)'
-   ·
- 2 │     resource struct R<T> {}
-   │     -------- Is found to be a non-copyable type here
+   │         ^^^^^^^^^^^^^^^^^^^^^^^^ Cannot ignore resource values. The value must be used
    │
 
 error: 
 
-   ┌── tests/move_check/typing/exp_list_resource_drop.move:9:9 ───
+   ┌── tests/move_check/typing/exp_list_resource_drop.move:4:16 ───
    │
- 9 │         (0, S{}, Box {});
-   │         ^^^^^^^^^^^^^^^^ Cannot ignore resource values. The value must be used
+ 4 │     struct Box<T> {}
+   │                - Is found to be a non-copyable type here
    ·
  9 │         (0, S{}, Box {});
    │         ---------------- The type: '(u64, 0x8675309::M::S, 0x8675309::M::Box<_>)'
-   ·
- 4 │     struct Box<T> {}
-   │                - Is found to be a non-copyable type here
+   │         ^^^^^^^^^^^^^^^^ Cannot ignore resource values. The value must be used
    │
 
 error: 

--- a/language/move-lang/tests/move_check/typing/global_builtins_invalid.exp
+++ b/language/move-lang/tests/move_check/typing/global_builtins_invalid.exp
@@ -4,8 +4,6 @@ error:
    │
  5 │         let _ : bool = exists<R>();
    │                        ^^^^^^^^^^^ Invalid call of 'exists'. The call expected 1 argument(s) but got 0
-   ·
- 5 │         let _ : bool = exists<R>();
    │                                 -- Found 0 argument(s) here
    │
 
@@ -15,8 +13,6 @@ error:
    │
  6 │         let () = move_to_sender<R>();
    │                  ^^^^^^^^^^^^^^^^^^^ Invalid call of 'move_to_sender'. The call expected 1 argument(s) but got 0
-   ·
- 6 │         let () = move_to_sender<R>();
    │                                   -- Found 0 argument(s) here
    │
 
@@ -26,8 +22,6 @@ error:
    │
  7 │         let _ : &R = borrow_global<R>();
    │                      ^^^^^^^^^^^^^^^^^^ Invalid call of 'borrow_global'. The call expected 1 argument(s) but got 0
-   ·
- 7 │         let _ : &R = borrow_global<R>();
    │                                      -- Found 0 argument(s) here
    │
 
@@ -37,8 +31,6 @@ error:
    │
  8 │         let _ : &mut R = borrow_global_mut<R>();
    │                          ^^^^^^^^^^^^^^^^^^^^^^ Invalid call of 'borrow_global_mut'. The call expected 1 argument(s) but got 0
-   ·
- 8 │         let _ : &mut R = borrow_global_mut<R>();
    │                                              -- Found 0 argument(s) here
    │
 
@@ -48,8 +40,6 @@ error:
    │
  9 │         let R {} = move_from<R>();
    │                    ^^^^^^^^^^^^^^ Invalid call of 'move_from'. The call expected 1 argument(s) but got 0
-   ·
- 9 │         let R {} = move_from<R>();
    │                                -- Found 0 argument(s) here
    │
 
@@ -58,13 +48,9 @@ error:
     ┌── tests/move_check/typing/global_builtins_invalid.move:13:24 ───
     │
  13 │         let _ : bool = exists<R>(0);
-    │                        ^^^^^^^^^^^^ Invalid call of 'exists'. Invalid argument for parameter '0'
-    ·
- 13 │         let _ : bool = exists<R>(0);
-    │                                  - The type: integer
-    ·
- 13 │         let _ : bool = exists<R>(0);
     │                        ------ Is not compatible with: 'address'
+    │                        ^^^^^^^^^^^^ Invalid call of 'exists'. Invalid argument for parameter '0'
+    │                                  - The type: integer
     │
 
 error: 
@@ -73,12 +59,8 @@ error:
     │
  14 │         let () = move_to_sender<R>(0);
     │                  ^^^^^^^^^^^^^^^^^^^^ Invalid call of 'move_to_sender'. Invalid argument for parameter '0'
-    ·
- 14 │         let () = move_to_sender<R>(0);
-    │                                    - The type: integer
-    ·
- 14 │         let () = move_to_sender<R>(0);
     │                                 - Is not compatible with: '0x8675309::M::R'
+    │                                    - The type: integer
     │
 
 error: 
@@ -87,8 +69,6 @@ error:
     │
  15 │         let () = move_to_sender(0);
     │                  ^^^^^^^^^^^^^^^^^ Invalid call to move_to_sender.
-    ·
- 15 │         let () = move_to_sender(0);
     │                                 - Expected a nominal resource. Found the type: 'u64'
     │
 
@@ -97,13 +77,9 @@ error:
     ┌── tests/move_check/typing/global_builtins_invalid.move:16:22 ───
     │
  16 │         let _ : &R = borrow_global<R>(0);
-    │                      ^^^^^^^^^^^^^^^^^^^ Invalid call of 'borrow_global'. Invalid argument for parameter '0'
-    ·
- 16 │         let _ : &R = borrow_global<R>(0);
-    │                                       - The type: integer
-    ·
- 16 │         let _ : &R = borrow_global<R>(0);
     │                      ------------- Is not compatible with: 'address'
+    │                      ^^^^^^^^^^^^^^^^^^^ Invalid call of 'borrow_global'. Invalid argument for parameter '0'
+    │                                       - The type: integer
     │
 
 error: 
@@ -111,13 +87,9 @@ error:
     ┌── tests/move_check/typing/global_builtins_invalid.move:17:26 ───
     │
  17 │         let _ : &mut R = borrow_global_mut<R>(0);
-    │                          ^^^^^^^^^^^^^^^^^^^^^^^ Invalid call of 'borrow_global_mut'. Invalid argument for parameter '0'
-    ·
- 17 │         let _ : &mut R = borrow_global_mut<R>(0);
-    │                                               - The type: integer
-    ·
- 17 │         let _ : &mut R = borrow_global_mut<R>(0);
     │                          ----------------- Is not compatible with: 'address'
+    │                          ^^^^^^^^^^^^^^^^^^^^^^^ Invalid call of 'borrow_global_mut'. Invalid argument for parameter '0'
+    │                                               - The type: integer
     │
 
 error: 
@@ -125,13 +97,9 @@ error:
     ┌── tests/move_check/typing/global_builtins_invalid.move:18:20 ───
     │
  18 │         let R {} = move_from<R>(0);
-    │                    ^^^^^^^^^^^^^^^ Invalid call of 'move_from'. Invalid argument for parameter '0'
-    ·
- 18 │         let R {} = move_from<R>(0);
-    │                                 - The type: integer
-    ·
- 18 │         let R {} = move_from<R>(0);
     │                    --------- Is not compatible with: 'address'
+    │                    ^^^^^^^^^^^^^^^ Invalid call of 'move_from'. Invalid argument for parameter '0'
+    │                                 - The type: integer
     │
 
 error: 
@@ -140,8 +108,6 @@ error:
     │
  22 │         let _ : bool = exists<R>(0x0, 0);
     │                        ^^^^^^^^^^^^^^^^^ Invalid call of 'exists'. The call expected 1 argument(s) but got 2
-    ·
- 22 │         let _ : bool = exists<R>(0x0, 0);
     │                                 -------- Found 2 argument(s) here
     │
 
@@ -151,8 +117,6 @@ error:
     │
  23 │         let () = move_to_sender<R>(R{}, 0);
     │                  ^^^^^^^^^^^^^^^^^^^^^^^^^ Invalid call of 'move_to_sender'. The call expected 1 argument(s) but got 2
-    ·
- 23 │         let () = move_to_sender<R>(R{}, 0);
     │                                   -------- Found 2 argument(s) here
     │
 
@@ -162,8 +126,6 @@ error:
     │
  24 │         let () = move_to_sender(R{}, 0);
     │                  ^^^^^^^^^^^^^^^^^^^^^^ Invalid call of 'move_to_sender'. The call expected 1 argument(s) but got 2
-    ·
- 24 │         let () = move_to_sender(R{}, 0);
     │                                -------- Found 2 argument(s) here
     │
 
@@ -173,8 +135,6 @@ error:
     │
  25 │         let _ : &R = borrow_global<R>(0x0, false);
     │                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Invalid call of 'borrow_global'. The call expected 1 argument(s) but got 2
-    ·
- 25 │         let _ : &R = borrow_global<R>(0x0, false);
     │                                      ------------ Found 2 argument(s) here
     │
 
@@ -184,8 +144,6 @@ error:
     │
  26 │         let _ : &mut R = borrow_global_mut<R>(0x0, true);
     │                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Invalid call of 'borrow_global_mut'. The call expected 1 argument(s) but got 2
-    ·
- 26 │         let _ : &mut R = borrow_global_mut<R>(0x0, true);
     │                                              ----------- Found 2 argument(s) here
     │
 
@@ -195,8 +153,6 @@ error:
     │
  27 │         let R {} = move_from<R>(0x0, 0);
     │                    ^^^^^^^^^^^^^^^^^^^^ Invalid call of 'move_from'. The call expected 1 argument(s) but got 2
-    ·
- 27 │         let R {} = move_from<R>(0x0, 0);
     │                                -------- Found 2 argument(s) here
     │
 

--- a/language/move-lang/tests/move_check/typing/if_branches_subtype_invalid.exp
+++ b/language/move-lang/tests/move_check/typing/if_branches_subtype_invalid.exp
@@ -1,196 +1,165 @@
 error: 
 
-   ┌── tests/move_check/typing/if_branches_subtype_invalid.move:3:16 ───
+   ┌── tests/move_check/typing/if_branches_subtype_invalid.move:2:27 ───
    │
- 3 │         let _: &mut u64 = if (cond) u else u_mut;
-   │                ^^^^^^^^ Invalid type annotation
-   ·
  2 │     fun t0(cond: bool, u: &u64, u_mut: &mut u64) {
    │                           ---- The type: '&u64'
-   ·
  3 │         let _: &mut u64 = if (cond) u else u_mut;
    │                -------- Is not a subtype of: '&mut u64'
+   │                ^^^^^^^^ Invalid type annotation
    │
 
 error: 
 
-   ┌── tests/move_check/typing/if_branches_subtype_invalid.move:4:16 ───
+   ┌── tests/move_check/typing/if_branches_subtype_invalid.move:2:27 ───
    │
- 4 │         let _: &mut u64 = if (cond) u_mut else u;
-   │                ^^^^^^^^ Invalid type annotation
-   ·
  2 │     fun t0(cond: bool, u: &u64, u_mut: &mut u64) {
    │                           ---- The type: '&u64'
-   ·
+ 3 │         let _: &mut u64 = if (cond) u else u_mut;
  4 │         let _: &mut u64 = if (cond) u_mut else u;
    │                -------- Is not a subtype of: '&mut u64'
+   │                ^^^^^^^^ Invalid type annotation
    │
 
 error: 
 
-   ┌── tests/move_check/typing/if_branches_subtype_invalid.move:5:16 ───
+   ┌── tests/move_check/typing/if_branches_subtype_invalid.move:2:27 ───
    │
- 5 │         let _: &mut u64 = if (cond) u else u;
-   │                ^^^^^^^^ Invalid type annotation
-   ·
  2 │     fun t0(cond: bool, u: &u64, u_mut: &mut u64) {
    │                           ---- The type: '&u64'
    ·
  5 │         let _: &mut u64 = if (cond) u else u;
    │                -------- Is not a subtype of: '&mut u64'
+   │                ^^^^^^^^ Invalid type annotation
    │
 
 error: 
 
-   ┌── tests/move_check/typing/if_branches_subtype_invalid.move:9:23 ───
+   ┌── tests/move_check/typing/if_branches_subtype_invalid.move:8:28 ───
    │
- 9 │         let _: &u64 = if (cond) u else b;
-   │                       ^^^^^^^^^^^^^^^^^^ Incompatible branches
-   ·
  8 │     fun t1(cond: bool, u: &u64, u_mut: &mut u64, b: &bool, b_mut: &mut bool) {
    │                            --- The type: 'u64'
-   ·
- 8 │     fun t1(cond: bool, u: &u64, u_mut: &mut u64, b: &bool, b_mut: &mut bool) {
    │                                                      ---- Is not compatible with: 'bool'
+ 9 │         let _: &u64 = if (cond) u else b;
+   │                       ^^^^^^^^^^^^^^^^^^ Incompatible branches
    │
 
 error: 
 
-    ┌── tests/move_check/typing/if_branches_subtype_invalid.move:10:23 ───
+    ┌── tests/move_check/typing/if_branches_subtype_invalid.move:8:28 ───
     │
+  8 │     fun t1(cond: bool, u: &u64, u_mut: &mut u64, b: &bool, b_mut: &mut bool) {
+    │                            --- Is not compatible with: 'u64'
+    │                                                      ---- The type: 'bool'
+  9 │         let _: &u64 = if (cond) u else b;
  10 │         let _: &u64 = if (cond) b else u;
     │                       ^^^^^^^^^^^^^^^^^^ Incompatible branches
-    ·
-  8 │     fun t1(cond: bool, u: &u64, u_mut: &mut u64, b: &bool, b_mut: &mut bool) {
-    │                                                      ---- The type: 'bool'
-    ·
-  8 │     fun t1(cond: bool, u: &u64, u_mut: &mut u64, b: &bool, b_mut: &mut bool) {
-    │                            --- Is not compatible with: 'u64'
     │
 
 error: 
 
-    ┌── tests/move_check/typing/if_branches_subtype_invalid.move:12:23 ───
+    ┌── tests/move_check/typing/if_branches_subtype_invalid.move:8:45 ───
     │
+  8 │     fun t1(cond: bool, u: &u64, u_mut: &mut u64, b: &bool, b_mut: &mut bool) {
+    │                                             --- The type: 'u64'
+    │                                                      ---- Is not compatible with: 'bool'
+    ·
  12 │         let _: &u64 = if (cond) u_mut else b;
     │                       ^^^^^^^^^^^^^^^^^^^^^^ Incompatible branches
-    ·
-  8 │     fun t1(cond: bool, u: &u64, u_mut: &mut u64, b: &bool, b_mut: &mut bool) {
-    │                                             --- The type: 'u64'
-    ·
-  8 │     fun t1(cond: bool, u: &u64, u_mut: &mut u64, b: &bool, b_mut: &mut bool) {
-    │                                                      ---- Is not compatible with: 'bool'
     │
 
 error: 
 
-    ┌── tests/move_check/typing/if_branches_subtype_invalid.move:13:23 ───
+    ┌── tests/move_check/typing/if_branches_subtype_invalid.move:8:45 ───
     │
- 13 │         let _: &u64 = if (cond) b else u_mut;
-    │                       ^^^^^^^^^^^^^^^^^^^^^^ Incompatible branches
-    ·
   8 │     fun t1(cond: bool, u: &u64, u_mut: &mut u64, b: &bool, b_mut: &mut bool) {
+    │                                             --- Is not compatible with: 'u64'
     │                                                      ---- The type: 'bool'
     ·
-  8 │     fun t1(cond: bool, u: &u64, u_mut: &mut u64, b: &bool, b_mut: &mut bool) {
-    │                                             --- Is not compatible with: 'u64'
+ 13 │         let _: &u64 = if (cond) b else u_mut;
+    │                       ^^^^^^^^^^^^^^^^^^^^^^ Incompatible branches
     │
 
 error: 
 
-    ┌── tests/move_check/typing/if_branches_subtype_invalid.move:15:23 ───
+    ┌── tests/move_check/typing/if_branches_subtype_invalid.move:8:28 ───
     │
- 15 │         let _: &u64 = if (cond) u else b_mut;
-    │                       ^^^^^^^^^^^^^^^^^^^^^^ Incompatible branches
-    ·
   8 │     fun t1(cond: bool, u: &u64, u_mut: &mut u64, b: &bool, b_mut: &mut bool) {
     │                            --- The type: 'u64'
-    ·
-  8 │     fun t1(cond: bool, u: &u64, u_mut: &mut u64, b: &bool, b_mut: &mut bool) {
     │                                                                        ---- Is not compatible with: 'bool'
+    ·
+ 15 │         let _: &u64 = if (cond) u else b_mut;
+    │                       ^^^^^^^^^^^^^^^^^^^^^^ Incompatible branches
     │
 
 error: 
 
-    ┌── tests/move_check/typing/if_branches_subtype_invalid.move:16:23 ───
+    ┌── tests/move_check/typing/if_branches_subtype_invalid.move:8:28 ───
     │
- 16 │         let _: &u64 = if (cond) b_mut else u;
-    │                       ^^^^^^^^^^^^^^^^^^^^^^ Incompatible branches
-    ·
-  8 │     fun t1(cond: bool, u: &u64, u_mut: &mut u64, b: &bool, b_mut: &mut bool) {
-    │                                                                        ---- The type: 'bool'
-    ·
   8 │     fun t1(cond: bool, u: &u64, u_mut: &mut u64, b: &bool, b_mut: &mut bool) {
     │                            --- Is not compatible with: 'u64'
-    │
-
-error: 
-
-    ┌── tests/move_check/typing/if_branches_subtype_invalid.move:19:27 ───
-    │
- 19 │         let _: &mut u64 = if (cond) u_mut else b_mut;
-    │                           ^^^^^^^^^^^^^^^^^^^^^^^^^^ Incompatible branches
-    ·
-  8 │     fun t1(cond: bool, u: &u64, u_mut: &mut u64, b: &bool, b_mut: &mut bool) {
-    │                                             --- The type: 'u64'
-    ·
-  8 │     fun t1(cond: bool, u: &u64, u_mut: &mut u64, b: &bool, b_mut: &mut bool) {
-    │                                                                        ---- Is not compatible with: 'bool'
-    │
-
-error: 
-
-    ┌── tests/move_check/typing/if_branches_subtype_invalid.move:20:27 ───
-    │
- 20 │         let _: &mut u64 = if (cond) b_mut else u_mut;
-    │                           ^^^^^^^^^^^^^^^^^^^^^^^^^^ Incompatible branches
-    ·
-  8 │     fun t1(cond: bool, u: &u64, u_mut: &mut u64, b: &bool, b_mut: &mut bool) {
     │                                                                        ---- The type: 'bool'
     ·
+ 16 │         let _: &u64 = if (cond) b_mut else u;
+    │                       ^^^^^^^^^^^^^^^^^^^^^^ Incompatible branches
+    │
+
+error: 
+
+    ┌── tests/move_check/typing/if_branches_subtype_invalid.move:8:45 ───
+    │
+  8 │     fun t1(cond: bool, u: &u64, u_mut: &mut u64, b: &bool, b_mut: &mut bool) {
+    │                                             --- The type: 'u64'
+    │                                                                        ---- Is not compatible with: 'bool'
+    ·
+ 19 │         let _: &mut u64 = if (cond) u_mut else b_mut;
+    │                           ^^^^^^^^^^^^^^^^^^^^^^^^^^ Incompatible branches
+    │
+
+error: 
+
+    ┌── tests/move_check/typing/if_branches_subtype_invalid.move:8:45 ───
+    │
   8 │     fun t1(cond: bool, u: &u64, u_mut: &mut u64, b: &bool, b_mut: &mut bool) {
     │                                             --- Is not compatible with: 'u64'
+    │                                                                        ---- The type: 'bool'
+    ·
+ 20 │         let _: &mut u64 = if (cond) b_mut else u_mut;
+    │                           ^^^^^^^^^^^^^^^^^^^^^^^^^^ Incompatible branches
     │
 
 error: 
 
-    ┌── tests/move_check/typing/if_branches_subtype_invalid.move:25:21 ───
+    ┌── tests/move_check/typing/if_branches_subtype_invalid.move:24:27 ───
     │
- 25 │         let (_, _): (&mut u64, &mut u64) = if (cond) (u, u) else (u_mut, u_mut);
-    │                     ^^^^^^^^^^^^^^^^^^^^ Invalid type annotation
-    ·
  24 │     fun t2(cond: bool, u: &u64, u_mut: &mut u64) {
     │                           ---- The type: '&u64'
-    ·
  25 │         let (_, _): (&mut u64, &mut u64) = if (cond) (u, u) else (u_mut, u_mut);
+    │                     ^^^^^^^^^^^^^^^^^^^^ Invalid type annotation
     │                      -------- Is not a subtype of: '&mut u64'
     │
 
 error: 
 
-    ┌── tests/move_check/typing/if_branches_subtype_invalid.move:26:21 ───
+    ┌── tests/move_check/typing/if_branches_subtype_invalid.move:24:27 ───
     │
- 26 │         let (_, _): (&mut u64, &mut u64) = if (cond) (u_mut, u) else (u, u_mut);
-    │                     ^^^^^^^^^^^^^^^^^^^^ Invalid type annotation
-    ·
  24 │     fun t2(cond: bool, u: &u64, u_mut: &mut u64) {
     │                           ---- The type: '&u64'
-    ·
+ 25 │         let (_, _): (&mut u64, &mut u64) = if (cond) (u, u) else (u_mut, u_mut);
  26 │         let (_, _): (&mut u64, &mut u64) = if (cond) (u_mut, u) else (u, u_mut);
+    │                     ^^^^^^^^^^^^^^^^^^^^ Invalid type annotation
     │                      -------- Is not a subtype of: '&mut u64'
     │
 
 error: 
 
-    ┌── tests/move_check/typing/if_branches_subtype_invalid.move:27:21 ───
+    ┌── tests/move_check/typing/if_branches_subtype_invalid.move:24:27 ───
     │
- 27 │         let (_, _): (&mut u64, &mut u64) = if (cond) (u, u_mut) else (u_mut, u);
-    │                     ^^^^^^^^^^^^^^^^^^^^ Invalid type annotation
-    ·
  24 │     fun t2(cond: bool, u: &u64, u_mut: &mut u64) {
     │                           ---- The type: '&u64'
     ·
  27 │         let (_, _): (&mut u64, &mut u64) = if (cond) (u, u_mut) else (u_mut, u);
+    │                     ^^^^^^^^^^^^^^^^^^^^ Invalid type annotation
     │                      -------- Is not a subtype of: '&mut u64'
     │
 

--- a/language/move-lang/tests/move_check/typing/if_condition_invalid.exp
+++ b/language/move-lang/tests/move_check/typing/if_condition_invalid.exp
@@ -3,13 +3,9 @@ error:
    ┌── tests/move_check/typing/if_condition_invalid.move:3:13 ───
    │
  3 │         if (()) () else ();
-   │             ^^ Invalid if condition
-   ·
- 3 │         if (()) () else ();
    │             -- The type: '()'
-   ·
- 3 │         if (()) () else ();
    │             -- Is not compatible with: 'bool'
+   │             ^^ Invalid if condition
    │
 
 error: 
@@ -17,13 +13,9 @@ error:
    ┌── tests/move_check/typing/if_condition_invalid.move:4:13 ───
    │
  4 │         if ((())) () else ();
-   │             ^^^^ Invalid if condition
-   ·
- 4 │         if ((())) () else ();
    │             ---- The type: '()'
-   ·
- 4 │         if ((())) () else ();
    │             ---- Is not compatible with: 'bool'
+   │             ^^^^ Invalid if condition
    │
 
 error: 
@@ -31,27 +23,20 @@ error:
    ┌── tests/move_check/typing/if_condition_invalid.move:5:13 ───
    │
  5 │         if ({}) () else ()
-   │             ^^ Invalid if condition
-   ·
- 5 │         if ({}) () else ()
    │             -- The type: '()'
-   ·
- 5 │         if ({}) () else ()
    │             -- Is not compatible with: 'bool'
+   │             ^^ Invalid if condition
    │
 
 error: 
 
-   ┌── tests/move_check/typing/if_condition_invalid.move:9:13 ───
+   ┌── tests/move_check/typing/if_condition_invalid.move:8:28 ───
    │
- 9 │         if (x) () else ();
-   │             ^ Invalid if condition
-   ·
  8 │     fun t1<T: copyable>(x: T) {
    │                            - The type: 'T'
-   ·
  9 │         if (x) () else ();
    │             - Is not compatible with: 'bool'
+   │             ^ Invalid if condition
    │
 
 error: 
@@ -59,13 +44,9 @@ error:
     ┌── tests/move_check/typing/if_condition_invalid.move:10:13 ───
     │
  10 │         if (0) () else ();
-    │             ^ Invalid if condition
-    ·
- 10 │         if (0) () else ();
     │             - The type: integer
-    ·
- 10 │         if (0) () else ();
     │             - Is not compatible with: 'bool'
+    │             ^ Invalid if condition
     │
 
 error: 
@@ -73,13 +54,9 @@ error:
     ┌── tests/move_check/typing/if_condition_invalid.move:11:13 ───
     │
  11 │         if (0x0) () else ()
-    │             ^^^ Invalid if condition
-    ·
- 11 │         if (0x0) () else ()
     │             --- The type: 'address'
-    ·
- 11 │         if (0x0) () else ()
     │             --- Is not compatible with: 'bool'
+    │             ^^^ Invalid if condition
     │
 
 error: 
@@ -87,13 +64,9 @@ error:
     ┌── tests/move_check/typing/if_condition_invalid.move:15:13 ───
     │
  15 │         if ((false, true)) () else ();
-    │             ^^^^^^^^^^^^^ Invalid if condition
-    ·
- 15 │         if ((false, true)) () else ();
     │             ------------- The type: '(bool, bool)'
-    ·
- 15 │         if ((false, true)) () else ();
     │             ------------- Is not compatible with: 'bool'
+    │             ^^^^^^^^^^^^^ Invalid if condition
     │
 
 error: 
@@ -101,12 +74,8 @@ error:
     ┌── tests/move_check/typing/if_condition_invalid.move:16:13 ───
     │
  16 │         if ((0, false)) () else ()
-    │             ^^^^^^^^^^ Invalid if condition
-    ·
- 16 │         if ((0, false)) () else ()
     │             ---------- The type: '({integer}, bool)'
-    ·
- 16 │         if ((0, false)) () else ()
     │             ---------- Is not compatible with: 'bool'
+    │             ^^^^^^^^^^ Invalid if condition
     │
 

--- a/language/move-lang/tests/move_check/typing/if_mismatched_branches.exp
+++ b/language/move-lang/tests/move_check/typing/if_mismatched_branches.exp
@@ -4,12 +4,8 @@ error:
    │
  3 │         if (cond) () else 0;
    │         ^^^^^^^^^^^^^^^^^^^ Incompatible branches
-   ·
- 3 │         if (cond) () else 0;
-   │                           - The type: integer
-   ·
- 3 │         if (cond) () else 0;
    │                   -- Is not compatible with: '()'
+   │                           - The type: integer
    │
 
 error: 
@@ -18,11 +14,7 @@ error:
    │
  4 │         if (cond) 0 else ();
    │         ^^^^^^^^^^^^^^^^^^^ Incompatible branches
-   ·
- 4 │         if (cond) 0 else ();
    │                   - The type: integer
-   ·
- 4 │         if (cond) 0 else ();
    │                          -- Is not compatible with: '()'
    │
 
@@ -32,12 +24,8 @@ error:
    │
  8 │         if (cond) 0x0 else 0;
    │         ^^^^^^^^^^^^^^^^^^^^ Incompatible branches
-   ·
- 8 │         if (cond) 0x0 else 0;
-   │                            - The type: integer
-   ·
- 8 │         if (cond) 0x0 else 0;
    │                   --- Is not compatible with: 'address'
+   │                            - The type: integer
    │
 
 error: 
@@ -46,11 +34,7 @@ error:
    │
  9 │         if (cond) 0 else false;
    │         ^^^^^^^^^^^^^^^^^^^^^^ Incompatible branches
-   ·
- 9 │         if (cond) 0 else false;
    │                   - The type: integer
-   ·
- 9 │         if (cond) 0 else false;
    │                          ----- Is not compatible with: 'bool'
    │
 
@@ -60,12 +44,8 @@ error:
     │
  13 │         if (cond) (0, false) else (1, 1);
     │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Incompatible branches
-    ·
- 13 │         if (cond) (0, false) else (1, 1);
-    │                                       - The type: integer
-    ·
- 13 │         if (cond) (0, false) else (1, 1);
     │                       ----- Is not compatible with: 'bool'
+    │                                       - The type: integer
     │
 
 error: 
@@ -74,11 +54,7 @@ error:
     │
  14 │         if (cond) (0, false) else (false, false);
     │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Incompatible branches
-    ·
- 14 │         if (cond) (0, false) else (false, false);
     │                    - The type: integer
-    ·
- 14 │         if (cond) (0, false) else (false, false);
     │                                    ----- Is not compatible with: 'bool'
     │
 
@@ -88,11 +64,7 @@ error:
     │
  15 │         if (cond) (0, false) else (true, 0x0);
     │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Incompatible branches
-    ·
- 15 │         if (cond) (0, false) else (true, 0x0);
     │                    - The type: integer
-    ·
- 15 │         if (cond) (0, false) else (true, 0x0);
     │                                    ---- Is not compatible with: 'bool'
     │
 
@@ -102,11 +74,7 @@ error:
     │
  19 │         if (cond) (0, false, 0) else (0, false);
     │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Incompatible branches
-    ·
- 19 │         if (cond) (0, false, 0) else (0, false);
     │                   ------------- The expression list type of length 3: '({integer}, bool, {integer})'
-    ·
- 19 │         if (cond) (0, false, 0) else (0, false);
     │                                      ---------- Is not compatible with the expression list type of length 2: '({integer}, bool)'
     │
 
@@ -116,11 +84,7 @@ error:
     │
  20 │         if (cond) (0, false) else (0, false, 0);
     │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Incompatible branches
-    ·
- 20 │         if (cond) (0, false) else (0, false, 0);
     │                   ---------- The expression list type of length 2: '({integer}, bool)'
-    ·
- 20 │         if (cond) (0, false) else (0, false, 0);
     │                                   ------------- Is not compatible with the expression list type of length 3: '({integer}, bool, {integer})'
     │
 

--- a/language/move-lang/tests/move_check/typing/ignore_inferred_resource.exp
+++ b/language/move-lang/tests/move_check/typing/ignore_inferred_resource.exp
@@ -1,15 +1,13 @@
 error: 
 
-   ┌── tests/move_check/typing/ignore_inferred_resource.move:4:9 ───
+   ┌── tests/move_check/typing/ignore_inferred_resource.move:2:14 ───
    │
- 4 │         S{};
-   │         ^^^ Cannot ignore resource values. The value must be used
-   ·
- 4 │         S{};
-   │         --- The type: '0x8675309::M::S<_>'
-   ·
  2 │     struct S<T> {}
    │              - Is found to be a non-copyable type here
+ 3 │     fun no() {
+ 4 │         S{};
+   │         --- The type: '0x8675309::M::S<_>'
+   │         ^^^ Cannot ignore resource values. The value must be used
    │
 
 error: 

--- a/language/move-lang/tests/move_check/typing/implicit_deref_borrow_field_chain_missing.exp
+++ b/language/move-lang/tests/move_check/typing/implicit_deref_borrow_field_chain_missing.exp
@@ -24,13 +24,13 @@ error:
 
 error: 
 
-    ┌── tests/move_check/typing/implicit_deref_borrow_field_chain_missing.move:10:9 ───
+    ┌── tests/move_check/typing/implicit_deref_borrow_field_chain_missing.move:4:20 ───
     │
- 10 │         x1.x2.x3.f.g;
-    │         ^^^^^^^^^^^^ Unbound field 'g'
-    ·
   4 │     struct X3 { f: u64, }
     │                    --- Expected a struct type in the current module but got: 'u64'
+    ·
+ 10 │         x1.x2.x3.f.g;
+    │         ^^^^^^^^^^^^ Unbound field 'g'
     │
 
 error: 
@@ -59,12 +59,12 @@ error:
 
 error: 
 
-    ┌── tests/move_check/typing/implicit_deref_borrow_field_chain_missing.move:14:9 ───
+    ┌── tests/move_check/typing/implicit_deref_borrow_field_chain_missing.move:4:20 ───
     │
- 14 │         x1_mut.x2.x3.f.g;
-    │         ^^^^^^^^^^^^^^^^ Unbound field 'g'
-    ·
   4 │     struct X3 { f: u64, }
     │                    --- Expected a struct type in the current module but got: 'u64'
+    ·
+ 14 │         x1_mut.x2.x3.f.g;
+    │         ^^^^^^^^^^^^^^^^ Unbound field 'g'
     │
 

--- a/language/move-lang/tests/move_check/typing/implicit_deref_borrow_field_from_non_struct.exp
+++ b/language/move-lang/tests/move_check/typing/implicit_deref_borrow_field_from_non_struct.exp
@@ -3,10 +3,8 @@ error:
    ┌── tests/move_check/typing/implicit_deref_borrow_field_from_non_struct.move:6:9 ───
    │
  6 │         0.f;
-   │         ^^^ Unbound field 'f'
-   ·
- 6 │         0.f;
    │         - Could not infer the type. Try annotating here
+   │         ^^^ Unbound field 'f'
    │
 
 error: 
@@ -14,65 +12,61 @@ error:
    ┌── tests/move_check/typing/implicit_deref_borrow_field_from_non_struct.move:7:9 ───
    │
  7 │         0.g;
-   │         ^^^ Unbound field 'g'
-   ·
- 7 │         0.g;
    │         - Could not infer the type. Try annotating here
+   │         ^^^ Unbound field 'g'
    │
 
 error: 
 
-   ┌── tests/move_check/typing/implicit_deref_borrow_field_from_non_struct.move:8:9 ───
+   ┌── tests/move_check/typing/implicit_deref_borrow_field_from_non_struct.move:5:15 ───
    │
- 8 │         u.value;
-   │         ^^^^^^^ Unbound field 'value'
-   ·
  5 │     fun t0(u: u64, cond: bool, addr: address) {
    │               --- Expected a struct type in the current module but got: 'u64'
+   ·
+ 8 │         u.value;
+   │         ^^^^^^^ Unbound field 'value'
    │
 
 error: 
 
-   ┌── tests/move_check/typing/implicit_deref_borrow_field_from_non_struct.move:9:9 ───
+   ┌── tests/move_check/typing/implicit_deref_borrow_field_from_non_struct.move:5:26 ───
    │
- 9 │         cond.value;
-   │         ^^^^^^^^^^ Unbound field 'value'
-   ·
  5 │     fun t0(u: u64, cond: bool, addr: address) {
    │                          ---- Expected a struct type in the current module but got: 'bool'
+   ·
+ 9 │         cond.value;
+   │         ^^^^^^^^^^ Unbound field 'value'
    │
 
 error: 
 
-    ┌── tests/move_check/typing/implicit_deref_borrow_field_from_non_struct.move:10:9 ───
+    ┌── tests/move_check/typing/implicit_deref_borrow_field_from_non_struct.move:5:38 ───
     │
+  5 │     fun t0(u: u64, cond: bool, addr: address) {
+    │                                      ------- Expected a struct type in the current module but got: 'address'
+    ·
  10 │         addr.R;
     │         ^^^^^^ Unbound field 'R'
-    ·
-  5 │     fun t0(u: u64, cond: bool, addr: address) {
-    │                                      ------- Expected a struct type in the current module but got: 'address'
     │
 
 error: 
 
-    ┌── tests/move_check/typing/implicit_deref_borrow_field_from_non_struct.move:11:9 ───
+    ┌── tests/move_check/typing/implicit_deref_borrow_field_from_non_struct.move:5:38 ───
     │
+  5 │     fun t0(u: u64, cond: bool, addr: address) {
+    │                                      ------- Expected a struct type in the current module but got: 'address'
+    ·
  11 │         addr.f;
     │         ^^^^^^ Unbound field 'f'
-    ·
-  5 │     fun t0(u: u64, cond: bool, addr: address) {
-    │                                      ------- Expected a struct type in the current module but got: 'address'
     │
 
 error: 
 
     ┌── tests/move_check/typing/implicit_deref_borrow_field_from_non_struct.move:12:9 ───
     │
- 12 │         ().R;
-    │         ^^ Invalid dot access
-    ·
  12 │         ().R;
     │         -- Expected a single type, but found expression list type: '()'
+    │         ^^ Invalid dot access
     │
 
 error: 
@@ -80,21 +74,17 @@ error:
     ┌── tests/move_check/typing/implicit_deref_borrow_field_from_non_struct.move:12:9 ───
     │
  12 │         ().R;
-    │         ^^^^ Unbound field 'R'
-    ·
- 12 │         ().R;
     │         -- Expected a struct type in the current module but got: '()'
+    │         ^^^^ Unbound field 'R'
     │
 
 error: 
 
     ┌── tests/move_check/typing/implicit_deref_borrow_field_from_non_struct.move:13:9 ───
     │
- 13 │         (S{f: 0}, S{f:0}).f;
-    │         ^^^^^^^^^^^^^^^^^ Invalid dot access
-    ·
  13 │         (S{f: 0}, S{f:0}).f;
     │         ----------------- Expected a single type, but found expression list type: '(0x8675309::M::S, 0x8675309::M::S)'
+    │         ^^^^^^^^^^^^^^^^^ Invalid dot access
     │
 
 error: 
@@ -102,9 +92,7 @@ error:
     ┌── tests/move_check/typing/implicit_deref_borrow_field_from_non_struct.move:13:9 ───
     │
  13 │         (S{f: 0}, S{f:0}).f;
-    │         ^^^^^^^^^^^^^^^^^^^ Unbound field 'f'
-    ·
- 13 │         (S{f: 0}, S{f:0}).f;
     │         ----------------- Expected a struct type in the current module but got: '(0x8675309::M::S, 0x8675309::M::S)'
+    │         ^^^^^^^^^^^^^^^^^^^ Unbound field 'f'
     │
 

--- a/language/move-lang/tests/move_check/typing/implicit_deref_borrow_field_not_copyable.exp
+++ b/language/move-lang/tests/move_check/typing/implicit_deref_borrow_field_not_copyable.exp
@@ -1,56 +1,54 @@
 error: 
 
-   ┌── tests/move_check/typing/implicit_deref_borrow_field_not_copyable.move:7:10 ───
+   ┌── tests/move_check/typing/implicit_deref_borrow_field_not_copyable.move:3:12 ───
    │
- 7 │         (b.s: S);
-   │          ^^^ Invalid implicit copy of field 's'. Try adding '*&' to the front of the field access
-   ·
+ 3 │     struct S {}
+   │            - Is declared as a non-implicitly copyable type here
  4 │     resource struct B { s: S, r: R }
    │                            - The type: '0x8675309::M::S'
    ·
- 3 │     struct S {}
-   │            - Is declared as a non-implicitly copyable type here
+ 7 │         (b.s: S);
+   │          ^^^ Invalid implicit copy of field 's'. Try adding '*&' to the front of the field access
    │
 
 error: 
 
-   ┌── tests/move_check/typing/implicit_deref_borrow_field_not_copyable.move:8:15 ───
+   ┌── tests/move_check/typing/implicit_deref_borrow_field_not_copyable.move:2:5 ───
    │
- 8 │         R{} = b.r;
-   │               ^^^ Invalid implicit copy of field 'r'.
-   ·
+ 2 │     resource struct R {}
+   │     -------- Is declared as a non-copyable type here
+ 3 │     struct S {}
  4 │     resource struct B { s: S, r: R }
    │                                  - The type: '0x8675309::M::R'
    ·
- 2 │     resource struct R {}
-   │     -------- Is declared as a non-copyable type here
+ 8 │         R{} = b.r;
+   │               ^^^ Invalid implicit copy of field 'r'.
    │
 
 error: 
 
-    ┌── tests/move_check/typing/implicit_deref_borrow_field_not_copyable.move:10:10 ───
+    ┌── tests/move_check/typing/implicit_deref_borrow_field_not_copyable.move:3:12 ───
     │
- 10 │         (bref.s: S);
-    │          ^^^^^^ Invalid implicit copy of field 's'. Try adding '*&' to the front of the field access
-    ·
+  3 │     struct S {}
+    │            - Is declared as a non-implicitly copyable type here
   4 │     resource struct B { s: S, r: R }
     │                            - The type: '0x8675309::M::S'
     ·
-  3 │     struct S {}
-    │            - Is declared as a non-implicitly copyable type here
+ 10 │         (bref.s: S);
+    │          ^^^^^^ Invalid implicit copy of field 's'. Try adding '*&' to the front of the field access
     │
 
 error: 
 
-    ┌── tests/move_check/typing/implicit_deref_borrow_field_not_copyable.move:11:15 ───
+    ┌── tests/move_check/typing/implicit_deref_borrow_field_not_copyable.move:2:5 ───
     │
- 11 │         R{} = bref.r;
-    │               ^^^^^^ Invalid implicit copy of field 'r'.
-    ·
+  2 │     resource struct R {}
+    │     -------- Is declared as a non-copyable type here
+  3 │     struct S {}
   4 │     resource struct B { s: S, r: R }
     │                                  - The type: '0x8675309::M::R'
     ·
-  2 │     resource struct R {}
-    │     -------- Is declared as a non-copyable type here
+ 11 │         R{} = bref.r;
+    │               ^^^^^^ Invalid implicit copy of field 'r'.
     │
 

--- a/language/move-lang/tests/move_check/typing/infinite_instantiations_invalid.exp
+++ b/language/move-lang/tests/move_check/typing/infinite_instantiations_invalid.exp
@@ -4,38 +4,26 @@ error:
    │
  7 │         t<Box<T>>()
    │         ^^^^^^^^^^^ Invalid call to '0x42::X::t'
-   ·
- 7 │         t<Box<T>>()
    │           ------ The type parameter 't::T' was instantiated with the type '0x42::X::Box<T>', which contains the type parameter 't::T'. This recursive call causes the instantiation to recurse infinitely
    │
 
 error: 
 
-    ┌── tests/move_check/typing/infinite_instantiations_invalid.move:14:9 ───
+    ┌── tests/move_check/typing/infinite_instantiations_invalid.move:11:9 ───
     │
- 14 │         x<Box<T>>()
-    │         ^^^^^^^^^^^ Invalid call to '0x42::X::x'
-    ·
- 14 │         x<Box<T>>()
-    │           ------ The type parameter 'y::T' was instantiated with the type '0x42::X::Box<T>', which contains the type parameter 'x::T'. These mutually recursive calls causes the instantiation to recurse infinitely
-    ·
  11 │         y<Box<T>>()
     │         ----------- 'x<x::T>' calls 'y<0x42::X::Box<x::T>>'
     ·
  14 │         x<Box<T>>()
     │         ----------- 'y<0x42::X::Box<x::T>>' calls 'x<0x42::X::Box<0x42::X::Box<x::T>>>'
+    │         ^^^^^^^^^^^ Invalid call to '0x42::X::x'
+    │           ------ The type parameter 'y::T' was instantiated with the type '0x42::X::Box<T>', which contains the type parameter 'x::T'. These mutually recursive calls causes the instantiation to recurse infinitely
     │
 
 error: 
 
-    ┌── tests/move_check/typing/infinite_instantiations_invalid.move:24:9 ───
+    ┌── tests/move_check/typing/infinite_instantiations_invalid.move:18:9 ───
     │
- 24 │         a<Box<C>>()
-    │         ^^^^^^^^^^^ Invalid call to '0x42::X::a'
-    ·
- 24 │         a<Box<C>>()
-    │           ------ The type parameter 'b::A' was instantiated with the type '0x42::X::Box<C>', which contains the type parameter 'a::C'. A cycle of recursive calls causes the instantiation to recurse infinitely
-    ·
  18 │         b<A>()
     │         ------ 'a<a::A>' calls 'b<a::A>'
     ·
@@ -44,6 +32,8 @@ error:
     ·
  24 │         a<Box<C>>()
     │         ----------- 'c<a::A>' calls 'a<0x42::X::Box<a::A>>'
+    │         ^^^^^^^^^^^ Invalid call to '0x42::X::a'
+    │           ------ The type parameter 'b::A' was instantiated with the type '0x42::X::Box<C>', which contains the type parameter 'a::C'. A cycle of recursive calls causes the instantiation to recurse infinitely
     │
 
 error: 
@@ -52,24 +42,13 @@ error:
     │
  38 │         z<Box<T>>()
     │         ^^^^^^^^^^^ Invalid call to '0x42::Y::z'
-    ·
- 38 │         z<Box<T>>()
     │           ------ The type parameter 'z::T' was instantiated with the type '0x42::Y::Box<T>', which contains the type parameter 'z::T'. This recursive call causes the instantiation to recurse infinitely
     │
 
 error: 
 
-    ┌── tests/move_check/typing/infinite_instantiations_invalid.move:48:9 ───
+    ┌── tests/move_check/typing/infinite_instantiations_invalid.move:42:9 ───
     │
- 48 │         d<Box<C>>()
-    │         ^^^^^^^^^^^ Invalid call to '0x42::Y::d'
-    ·
- 48 │         d<Box<C>>()
-    │           ------ The type parameter 'a::D' was instantiated with the type '0x42::Y::Box<C>', which contains the type parameter 'd::C'. A cycle of recursive calls causes the instantiation to recurse infinitely
-    ·
- 51 │         a<D>()
-    │         ------ 'd<d::D>' calls 'a<d::D>'
-    ·
  42 │         b<A>()
     │         ------ 'a<d::D>' calls 'b<d::D>'
     ·
@@ -78,25 +57,26 @@ error:
     ·
  48 │         d<Box<C>>()
     │         ----------- 'c<d::D>' calls 'd<0x42::Y::Box<d::D>>'
+    │         ^^^^^^^^^^^ Invalid call to '0x42::Y::d'
+    │           ------ The type parameter 'a::D' was instantiated with the type '0x42::Y::Box<C>', which contains the type parameter 'd::C'. A cycle of recursive calls causes the instantiation to recurse infinitely
+    ·
+ 51 │         a<D>()
+    │         ------ 'd<d::D>' calls 'a<d::D>'
     │
 
 error: 
 
-    ┌── tests/move_check/typing/infinite_instantiations_invalid.move:62:9 ───
+    ┌── tests/move_check/typing/infinite_instantiations_invalid.move:59:9 ───
     │
- 62 │         bl<Box<TR>>();
-    │         ^^^^^^^^^^^^^ Invalid call to '0x42::Z::bl'
-    ·
- 62 │         bl<Box<TR>>();
-    │            ------- The type parameter 'tl::BL' was instantiated with the type '0x42::Z::Box<TR>', which contains the type parameter 'bl::TR'. A cycle of recursive calls causes the instantiation to recurse infinitely
-    ·
- 69 │         tl<BL>()
-    │         -------- 'bl<bl::BL>' calls 'tl<bl::BL>'
-    ·
  59 │         tr<TL>()
     │         -------- 'tl<bl::BL>' calls 'tr<bl::BL>'
     ·
  62 │         bl<Box<TR>>();
     │         ------------- 'tr<bl::BL>' calls 'bl<0x42::Z::Box<bl::BL>>'
+    │         ^^^^^^^^^^^^^ Invalid call to '0x42::Z::bl'
+    │            ------- The type parameter 'tl::BL' was instantiated with the type '0x42::Z::Box<TR>', which contains the type parameter 'bl::TR'. A cycle of recursive calls causes the instantiation to recurse infinitely
+    ·
+ 69 │         tl<BL>()
+    │         -------- 'bl<bl::BL>' calls 'tl<bl::BL>'
     │
 

--- a/language/move-lang/tests/move_check/typing/invalid_type_acquire.exp
+++ b/language/move-lang/tests/move_check/typing/invalid_type_acquire.exp
@@ -20,20 +20,18 @@ error:
     │
  20 │         X::R,
     │         ^^^^ Invalid acquires item
-    ·
- 20 │         X::R,
     │            - The struct 'R' was not declared in the current module. Global storage access is internal to the module'
     │
 
 error: 
 
-    ┌── tests/move_check/typing/invalid_type_acquire.move:21:9 ───
+    ┌── tests/move_check/typing/invalid_type_acquire.move:10:12 ───
     │
- 21 │         S,
-    │         ^ Invalid acquires item. Expected a nominal resource.
-    ·
  10 │     struct S {}
     │            - Declared as a normal struct here
+    ·
+ 21 │         S,
+    │         ^ Invalid acquires item. Expected a nominal resource.
     │
 
 error: 
@@ -58,8 +56,6 @@ error:
     │
  31 │         destroy(move_from<T>(a));
     │                 ^^^^^^^^^^^^^^^ Invalid call to move_from.
-    ·
- 31 │         destroy(move_from<T>(a));
     │                           - Expected a nominal resource. Found the type: 'T'
     │
 
@@ -69,8 +65,6 @@ error:
     │
  32 │         destroy(move_from<u64>(a));
     │                 ^^^^^^^^^^^^^^^^^ Invalid call to move_from.
-    ·
- 32 │         destroy(move_from<u64>(a));
     │                           --- Expected a nominal resource. Found the type: 'u64'
     │
 
@@ -80,23 +74,19 @@ error:
     │
  33 │         destroy(move_from<X::R>(a));
     │                 ^^^^^^^^^^^^^^^^^^ Invalid call to move_from.
-    ·
- 33 │         destroy(move_from<X::R>(a));
     │                           ---- The type '0x1::X::R' was not declared in the current module. Global storage access is internal to the module'
     │
 
 error: 
 
-    ┌── tests/move_check/typing/invalid_type_acquire.move:34:17 ───
+    ┌── tests/move_check/typing/invalid_type_acquire.move:10:12 ───
     │
- 34 │         destroy(move_from<S>(a));
-    │                 ^^^^^^^^^^^^^^^ Invalid call to move_from.
-    ·
- 34 │         destroy(move_from<S>(a));
-    │                           - Expected a nominal resource. Found the type: '0x1::M::S'
-    ·
  10 │     struct S {}
     │            - Declared as a normal struct here
+    ·
+ 34 │         destroy(move_from<S>(a));
+    │                 ^^^^^^^^^^^^^^^ Invalid call to move_from.
+    │                           - Expected a nominal resource. Found the type: '0x1::M::S'
     │
 
 error: 
@@ -113,8 +103,6 @@ error:
     │
  37 │         borrow_global<T>(a);
     │         ^^^^^^^^^^^^^^^^^^^ Invalid call to borrow_global.
-    ·
- 37 │         borrow_global<T>(a);
     │                       - Expected a nominal resource. Found the type: 'T'
     │
 
@@ -124,8 +112,6 @@ error:
     │
  38 │         borrow_global<u64>(a);
     │         ^^^^^^^^^^^^^^^^^^^^^ Invalid call to borrow_global.
-    ·
- 38 │         borrow_global<u64>(a);
     │                       --- Expected a nominal resource. Found the type: 'u64'
     │
 
@@ -135,23 +121,19 @@ error:
     │
  39 │         borrow_global<X::R>(a);
     │         ^^^^^^^^^^^^^^^^^^^^^^ Invalid call to borrow_global.
-    ·
- 39 │         borrow_global<X::R>(a);
     │                       ---- The type '0x1::X::R' was not declared in the current module. Global storage access is internal to the module'
     │
 
 error: 
 
-    ┌── tests/move_check/typing/invalid_type_acquire.move:40:9 ───
+    ┌── tests/move_check/typing/invalid_type_acquire.move:10:12 ───
     │
- 40 │         borrow_global<S>(a);
-    │         ^^^^^^^^^^^^^^^^^^^ Invalid call to borrow_global.
-    ·
- 40 │         borrow_global<S>(a);
-    │                       - Expected a nominal resource. Found the type: '0x1::M::S'
-    ·
  10 │     struct S {}
     │            - Declared as a normal struct here
+    ·
+ 40 │         borrow_global<S>(a);
+    │         ^^^^^^^^^^^^^^^^^^^ Invalid call to borrow_global.
+    │                       - Expected a nominal resource. Found the type: '0x1::M::S'
     │
 
 error: 
@@ -168,8 +150,6 @@ error:
     │
  43 │         borrow_global_mut<T>(a);
     │         ^^^^^^^^^^^^^^^^^^^^^^^ Invalid call to borrow_global_mut.
-    ·
- 43 │         borrow_global_mut<T>(a);
     │                           - Expected a nominal resource. Found the type: 'T'
     │
 
@@ -179,8 +159,6 @@ error:
     │
  44 │         borrow_global_mut<u64>(a);
     │         ^^^^^^^^^^^^^^^^^^^^^^^^^ Invalid call to borrow_global_mut.
-    ·
- 44 │         borrow_global_mut<u64>(a);
     │                           --- Expected a nominal resource. Found the type: 'u64'
     │
 
@@ -190,23 +168,19 @@ error:
     │
  45 │         borrow_global_mut<X::R>(a);
     │         ^^^^^^^^^^^^^^^^^^^^^^^^^^ Invalid call to borrow_global_mut.
-    ·
- 45 │         borrow_global_mut<X::R>(a);
     │                           ---- The type '0x1::X::R' was not declared in the current module. Global storage access is internal to the module'
     │
 
 error: 
 
-    ┌── tests/move_check/typing/invalid_type_acquire.move:46:9 ───
+    ┌── tests/move_check/typing/invalid_type_acquire.move:10:12 ───
     │
- 46 │         borrow_global_mut<S>(a);
-    │         ^^^^^^^^^^^^^^^^^^^^^^^ Invalid call to borrow_global_mut.
-    ·
- 46 │         borrow_global_mut<S>(a);
-    │                           - Expected a nominal resource. Found the type: '0x1::M::S'
-    ·
  10 │     struct S {}
     │            - Declared as a normal struct here
+    ·
+ 46 │         borrow_global_mut<S>(a);
+    │         ^^^^^^^^^^^^^^^^^^^^^^^ Invalid call to borrow_global_mut.
+    │                           - Expected a nominal resource. Found the type: '0x1::M::S'
     │
 
 error: 
@@ -223,8 +197,6 @@ error:
     │
  49 │         exists<T>(a);
     │         ^^^^^^^^^^^^ Invalid call to exists.
-    ·
- 49 │         exists<T>(a);
     │                - Expected a nominal resource. Found the type: 'T'
     │
 
@@ -234,8 +206,6 @@ error:
     │
  50 │         exists<u64>(a);
     │         ^^^^^^^^^^^^^^ Invalid call to exists.
-    ·
- 50 │         exists<u64>(a);
     │                --- Expected a nominal resource. Found the type: 'u64'
     │
 
@@ -245,23 +215,19 @@ error:
     │
  51 │         exists<X::R>(a);
     │         ^^^^^^^^^^^^^^^ Invalid call to exists.
-    ·
- 51 │         exists<X::R>(a);
     │                ---- The type '0x1::X::R' was not declared in the current module. Global storage access is internal to the module'
     │
 
 error: 
 
-    ┌── tests/move_check/typing/invalid_type_acquire.move:52:9 ───
+    ┌── tests/move_check/typing/invalid_type_acquire.move:10:12 ───
     │
- 52 │         exists<S>(a);
-    │         ^^^^^^^^^^^^ Invalid call to exists.
-    ·
- 52 │         exists<S>(a);
-    │                - Expected a nominal resource. Found the type: '0x1::M::S'
-    ·
  10 │     struct S {}
     │            - Declared as a normal struct here
+    ·
+ 52 │         exists<S>(a);
+    │         ^^^^^^^^^^^^ Invalid call to exists.
+    │                - Expected a nominal resource. Found the type: '0x1::M::S'
     │
 
 error: 
@@ -286,8 +252,6 @@ error:
     │
  55 │         move_to_sender<T>(any());
     │         ^^^^^^^^^^^^^^^^^^^^^^^^ Invalid call to move_to_sender.
-    ·
- 55 │         move_to_sender<T>(any());
     │                        - Expected a nominal resource. Found the type: 'T'
     │
 
@@ -297,8 +261,6 @@ error:
     │
  56 │         move_to_sender<u64>(any());
     │         ^^^^^^^^^^^^^^^^^^^^^^^^^^ Invalid call to move_to_sender.
-    ·
- 56 │         move_to_sender<u64>(any());
     │                        --- Expected a nominal resource. Found the type: 'u64'
     │
 
@@ -308,22 +270,18 @@ error:
     │
  57 │         move_to_sender<X::R>(any());
     │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^ Invalid call to move_to_sender.
-    ·
- 57 │         move_to_sender<X::R>(any());
     │                        ---- The type '0x1::X::R' was not declared in the current module. Global storage access is internal to the module'
     │
 
 error: 
 
-    ┌── tests/move_check/typing/invalid_type_acquire.move:58:9 ───
+    ┌── tests/move_check/typing/invalid_type_acquire.move:10:12 ───
     │
- 58 │         move_to_sender<S>(any());
-    │         ^^^^^^^^^^^^^^^^^^^^^^^^ Invalid call to move_to_sender.
-    ·
- 58 │         move_to_sender<S>(any());
-    │                        - Expected a nominal resource. Found the type: '0x1::M::S'
-    ·
  10 │     struct S {}
     │            - Declared as a normal struct here
+    ·
+ 58 │         move_to_sender<S>(any());
+    │         ^^^^^^^^^^^^^^^^^^^^^^^^ Invalid call to move_to_sender.
+    │                        - Expected a nominal resource. Found the type: '0x1::M::S'
     │
 

--- a/language/move-lang/tests/move_check/typing/loop_body_invalid.exp
+++ b/language/move-lang/tests/move_check/typing/loop_body_invalid.exp
@@ -3,13 +3,9 @@ error:
    ┌── tests/move_check/typing/loop_body_invalid.move:3:14 ───
    │
  3 │         loop 0
-   │              ^ Invalid loop body
-   ·
- 3 │         loop 0
    │              - The type: integer
-   ·
- 3 │         loop 0
    │              - Is not compatible with: '()'
+   │              ^ Invalid loop body
    │
 
 error: 
@@ -17,13 +13,9 @@ error:
    ┌── tests/move_check/typing/loop_body_invalid.move:7:14 ───
    │
  7 │         loop false
-   │              ^^^^^ Invalid loop body
-   ·
- 7 │         loop false
    │              ----- The type: 'bool'
-   ·
- 7 │         loop false
    │              ----- Is not compatible with: '()'
+   │              ^^^^^ Invalid loop body
    │
 
 error: 
@@ -31,13 +23,9 @@ error:
     ┌── tests/move_check/typing/loop_body_invalid.move:11:14 ───
     │
  11 │         loop { 0x0 }
-    │              ^^^^^^^ Invalid loop body
-    ·
- 11 │         loop { 0x0 }
-    │                --- The type: 'address'
-    ·
- 11 │         loop { 0x0 }
     │              ------- Is not compatible with: '()'
+    │              ^^^^^^^ Invalid loop body
+    │                --- The type: 'address'
     │
 
 error: 
@@ -45,13 +33,9 @@ error:
     ┌── tests/move_check/typing/loop_body_invalid.move:15:14 ───
     │
  15 │         loop { let x = 0; x }
-    │              ^^^^^^^^^^^^^^^^ Invalid loop body
-    ·
- 15 │         loop { let x = 0; x }
-    │                    - The type: integer
-    ·
- 15 │         loop { let x = 0; x }
     │              ---------------- Is not compatible with: '()'
+    │              ^^^^^^^^^^^^^^^^ Invalid loop body
+    │                    - The type: integer
     │
 
 error: 
@@ -59,12 +43,8 @@ error:
     ┌── tests/move_check/typing/loop_body_invalid.move:19:14 ───
     │
  19 │         loop { if (true) 1 else 0 }
-    │              ^^^^^^^^^^^^^^^^^^^^^^ Invalid loop body
-    ·
- 19 │         loop { if (true) 1 else 0 }
-    │                                 - The type: integer
-    ·
- 19 │         loop { if (true) 1 else 0 }
     │              ---------------------- Is not compatible with: '()'
+    │              ^^^^^^^^^^^^^^^^^^^^^^ Invalid loop body
+    │                                 - The type: integer
     │
 

--- a/language/move-lang/tests/move_check/typing/loop_result_type_invalid.exp
+++ b/language/move-lang/tests/move_check/typing/loop_result_type_invalid.exp
@@ -1,29 +1,23 @@
 error: 
 
-    ┌── tests/move_check/typing/loop_result_type_invalid.move:11:9 ───
+    ┌── tests/move_check/typing/loop_result_type_invalid.move:10:15 ───
     │
- 11 │         loop { if (false) break }
-    │         ^^^^^^^^^^^^^^^^^^^^^^^^^ Invalid return expression
-    ·
- 11 │         loop { if (false) break }
-    │         ------------------------- The type: '()'
-    ·
  10 │     fun t0(): X::R {
     │               ---- Is not compatible with: '0x1::X::R'
+ 11 │         loop { if (false) break }
+    │         ------------------------- The type: '()'
+    │         ^^^^^^^^^^^^^^^^^^^^^^^^^ Invalid return expression
     │
 
 error: 
 
-    ┌── tests/move_check/typing/loop_result_type_invalid.move:15:9 ───
+    ┌── tests/move_check/typing/loop_result_type_invalid.move:14:15 ───
     │
- 15 │         loop { let x = 0; break }
-    │         ^^^^^^^^^^^^^^^^^^^^^^^^^ Invalid return expression
-    ·
- 15 │         loop { let x = 0; break }
-    │         ------------------------- The type: '()'
-    ·
  14 │     fun t1(): u64 {
     │               --- Is not compatible with: 'u64'
+ 15 │         loop { let x = 0; break }
+    │         ------------------------- The type: '()'
+    │         ^^^^^^^^^^^^^^^^^^^^^^^^^ Invalid return expression
     │
 
 error: 
@@ -32,8 +26,6 @@ error:
     │
  19 │         foo(loop { break })
     │         ^^^^^^^^^^^^^^^^^^^ Invalid call of '0x1::M::foo'. Invalid argument for parameter 'x'
-    ·
- 19 │         foo(loop { break })
     │             -------------- The type: '()'
     ·
  22 │     fun foo(x: u64) {}
@@ -46,8 +38,6 @@ error:
     │
  25 │         let x = loop { break };
     │             ^ Invalid type for local
-    ·
- 25 │         let x = loop { break };
     │                 -------------- Expected a single type, but found expression list type: '()'
     │
 
@@ -56,12 +46,8 @@ error:
     ┌── tests/move_check/typing/loop_result_type_invalid.move:26:13 ───
     │
  26 │         let (x, y) = loop { if (false) break };
-    │             ^^^^^^ Invalid value for binding
-    ·
- 26 │         let (x, y) = loop { if (false) break };
     │             ------ The type: '(_, _)'
-    ·
- 26 │         let (x, y) = loop { if (false) break };
+    │             ^^^^^^ Invalid value for binding
     │                      ------------------------- Is not compatible with: '()'
     │
 

--- a/language/move-lang/tests/move_check/typing/main_arguments_invalid.exp
+++ b/language/move-lang/tests/move_check/typing/main_arguments_invalid.exp
@@ -4,8 +4,6 @@ error:
    │
  1 │ fun main<T: copyable>(x: T, y: vector<T>, z: vector<vector<u8>>, a: vector<vector<T>>) {
    │     ^^^^ Invalid parameter for 'main'
-   ·
- 1 │ fun main<T: copyable>(x: T, y: vector<T>, z: vector<vector<u8>>, a: vector<vector<T>>) {
    │                          - Found: 'T'. But expected: u8, u64, u128, bool, address, vector<u8>
    │
 
@@ -15,8 +13,6 @@ error:
    │
  1 │ fun main<T: copyable>(x: T, y: vector<T>, z: vector<vector<u8>>, a: vector<vector<T>>) {
    │     ^^^^ Invalid parameter for 'main'
-   ·
- 1 │ fun main<T: copyable>(x: T, y: vector<T>, z: vector<vector<u8>>, a: vector<vector<T>>) {
    │                                --------- Found: 'vector<T>'. But expected: u8, u64, u128, bool, address, vector<u8>
    │
 
@@ -26,8 +22,6 @@ error:
    │
  1 │ fun main<T: copyable>(x: T, y: vector<T>, z: vector<vector<u8>>, a: vector<vector<T>>) {
    │     ^^^^ Invalid parameter for 'main'
-   ·
- 1 │ fun main<T: copyable>(x: T, y: vector<T>, z: vector<vector<u8>>, a: vector<vector<T>>) {
    │                                              ------------------ Found: 'vector<vector<u8>>'. But expected: u8, u64, u128, bool, address, vector<u8>
    │
 
@@ -37,8 +31,6 @@ error:
    │
  1 │ fun main<T: copyable>(x: T, y: vector<T>, z: vector<vector<u8>>, a: vector<vector<T>>) {
    │     ^^^^ Invalid parameter for 'main'
-   ·
- 1 │ fun main<T: copyable>(x: T, y: vector<T>, z: vector<vector<u8>>, a: vector<vector<T>>) {
    │                                                                     ----------------- Found: 'vector<vector<T>>'. But expected: u8, u64, u128, bool, address, vector<u8>
    │
 

--- a/language/move-lang/tests/move_check/typing/main_return_type_invalid.exp
+++ b/language/move-lang/tests/move_check/typing/main_return_type_invalid.exp
@@ -3,12 +3,8 @@ error:
    ┌── tests/move_check/typing/main_return_type_invalid.move:1:5 ───
    │
  1 │ fun main(): u64 {
-   │     ^^^^ Invalid main return type
-   ·
- 1 │ fun main(): u64 {
-   │             --- The type: 'u64'
-   ·
- 1 │ fun main(): u64 {
    │     ---- Is not compatible with: '()'
+   │     ^^^^ Invalid main return type
+   │             --- The type: 'u64'
    │
 

--- a/language/move-lang/tests/move_check/typing/missing_acquire.exp
+++ b/language/move-lang/tests/move_check/typing/missing_acquire.exp
@@ -15,8 +15,6 @@ error:
    │
  9 │         borrow_global<R1>(a);
    │         ^^^^^^^^^^^^^^^^^^^^ Invalid call to borrow_global.
-   ·
- 9 │         borrow_global<R1>(a);
    │                       -- The call acquires '0x8675309::M::R1', but the 'acquires' list for the current function does not contain this type. It must be present in the calling context's acquires list
    │
 
@@ -26,8 +24,6 @@ error:
     │
  10 │         borrow_global_mut<R1>(a);
     │         ^^^^^^^^^^^^^^^^^^^^^^^^ Invalid call to borrow_global_mut.
-    ·
- 10 │         borrow_global_mut<R1>(a);
     │                           -- The call acquires '0x8675309::M::R1', but the 'acquires' list for the current function does not contain this type. It must be present in the calling context's acquires list
     │
 
@@ -37,8 +33,6 @@ error:
     │
  11 │         R1{} = move_from<R1>(a);
     │                ^^^^^^^^^^^^^^^^ Invalid call to move_from.
-    ·
- 11 │         R1{} = move_from<R1>(a);
     │                          -- The call acquires '0x8675309::M::R1', but the 'acquires' list for the current function does not contain this type. It must be present in the calling context's acquires list
     │
 

--- a/language/move-lang/tests/move_check/typing/module_call.exp
+++ b/language/move-lang/tests/move_check/typing/module_call.exp
@@ -4,23 +4,21 @@ error:
     │
  43 │         let () = X::bing(X::baz(X::bar(X::foo())));
     │                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Invalid call of '0x1::X::bing'. The call expected 3 argument(s) but got 1
-    ·
- 43 │         let () = X::bing(X::baz(X::bar(X::foo())));
     │                         -------------------------- Found 1 argument(s) here
     │
 
 error: 
 
-    ┌── tests/move_check/typing/module_call.move:43:18 ───
+    ┌── tests/move_check/typing/module_call.move:8:43 ───
     │
- 43 │         let () = X::bing(X::baz(X::bar(X::foo())));
-    │                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Invalid call of '0x1::X::bing'. Invalid argument for parameter 'b'
-    ·
   8 │     public fun baz<T1, T2>(a: T1, x: T2): (bool, T1, T2) {
     │                                           -------------- The type: '(bool, (address, u64), _)'
     ·
  11 │     public fun bing(b: bool, a: address, x: u64) {
     │                        ---- Is not compatible with: 'bool'
+    ·
+ 43 │         let () = X::bing(X::baz(X::bar(X::foo())));
+    │                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Invalid call of '0x1::X::bing'. Invalid argument for parameter 'b'
     │
 
 error: 
@@ -29,20 +27,18 @@ error:
     │
  43 │         let () = X::bing(X::baz(X::bar(X::foo())));
     │                          ^^^^^^^^^^^^^^^^^^^^^^^^ Invalid call of '0x1::X::baz'. The call expected 2 argument(s) but got 1
-    ·
- 43 │         let () = X::bing(X::baz(X::bar(X::foo())));
     │                                ------------------ Found 1 argument(s) here
     │
 
 error: 
 
-    ┌── tests/move_check/typing/module_call.move:43:26 ───
+    ┌── tests/move_check/typing/module_call.move:5:29 ───
     │
- 43 │         let () = X::bing(X::baz(X::bar(X::foo())));
-    │                          ^^^^^^^^^^^^^^^^^^^^^^^^ Invalid type argument
-    ·
   5 │     public fun bar(x: u64): (address, u64) {
     │                             -------------- Expected a single non-reference type, but found: '(address, u64)'
+    ·
+ 43 │         let () = X::bing(X::baz(X::bar(X::foo())));
+    │                          ^^^^^^^^^^^^^^^^^^^^^^^^ Invalid type argument
     │
 
 error: 
@@ -51,23 +47,21 @@ error:
     │
  44 │         let () = X::bing (X::baz (X::bar (X::foo())));
     │                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Invalid call of '0x1::X::bing'. The call expected 3 argument(s) but got 1
-    ·
- 44 │         let () = X::bing (X::baz (X::bar (X::foo())));
     │                          ---------------------------- Found 1 argument(s) here
     │
 
 error: 
 
-    ┌── tests/move_check/typing/module_call.move:44:18 ───
+    ┌── tests/move_check/typing/module_call.move:8:43 ───
     │
- 44 │         let () = X::bing (X::baz (X::bar (X::foo())));
-    │                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Invalid call of '0x1::X::bing'. Invalid argument for parameter 'b'
-    ·
   8 │     public fun baz<T1, T2>(a: T1, x: T2): (bool, T1, T2) {
     │                                           -------------- The type: '(bool, (address, u64), _)'
     ·
  11 │     public fun bing(b: bool, a: address, x: u64) {
     │                        ---- Is not compatible with: 'bool'
+    ·
+ 44 │         let () = X::bing (X::baz (X::bar (X::foo())));
+    │                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Invalid call of '0x1::X::bing'. Invalid argument for parameter 'b'
     │
 
 error: 
@@ -76,20 +70,18 @@ error:
     │
  44 │         let () = X::bing (X::baz (X::bar (X::foo())));
     │                           ^^^^^^^^^^^^^^^^^^^^^^^^^^ Invalid call of '0x1::X::baz'. The call expected 2 argument(s) but got 1
-    ·
- 44 │         let () = X::bing (X::baz (X::bar (X::foo())));
     │                                  ------------------- Found 1 argument(s) here
     │
 
 error: 
 
-    ┌── tests/move_check/typing/module_call.move:44:27 ───
+    ┌── tests/move_check/typing/module_call.move:5:29 ───
     │
- 44 │         let () = X::bing (X::baz (X::bar (X::foo())));
-    │                           ^^^^^^^^^^^^^^^^^^^^^^^^^^ Invalid type argument
-    ·
   5 │     public fun bar(x: u64): (address, u64) {
     │                             -------------- Expected a single non-reference type, but found: '(address, u64)'
+    ·
+ 44 │         let () = X::bing (X::baz (X::bar (X::foo())));
+    │                           ^^^^^^^^^^^^^^^^^^^^^^^^^^ Invalid type argument
     │
 
 error: 
@@ -98,23 +90,21 @@ error:
     │
  45 │         let () = X::bing (X::baz (X::bar(1)));
     │                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Invalid call of '0x1::X::bing'. The call expected 3 argument(s) but got 1
-    ·
- 45 │         let () = X::bing (X::baz (X::bar(1)));
     │                          -------------------- Found 1 argument(s) here
     │
 
 error: 
 
-    ┌── tests/move_check/typing/module_call.move:45:18 ───
+    ┌── tests/move_check/typing/module_call.move:8:43 ───
     │
- 45 │         let () = X::bing (X::baz (X::bar(1)));
-    │                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Invalid call of '0x1::X::bing'. Invalid argument for parameter 'b'
-    ·
   8 │     public fun baz<T1, T2>(a: T1, x: T2): (bool, T1, T2) {
     │                                           -------------- The type: '(bool, (address, u64), _)'
     ·
  11 │     public fun bing(b: bool, a: address, x: u64) {
     │                        ---- Is not compatible with: 'bool'
+    ·
+ 45 │         let () = X::bing (X::baz (X::bar(1)));
+    │                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Invalid call of '0x1::X::bing'. Invalid argument for parameter 'b'
     │
 
 error: 
@@ -123,20 +113,18 @@ error:
     │
  45 │         let () = X::bing (X::baz (X::bar(1)));
     │                           ^^^^^^^^^^^^^^^^^^ Invalid call of '0x1::X::baz'. The call expected 2 argument(s) but got 1
-    ·
- 45 │         let () = X::bing (X::baz (X::bar(1)));
     │                                  ----------- Found 1 argument(s) here
     │
 
 error: 
 
-    ┌── tests/move_check/typing/module_call.move:45:27 ───
+    ┌── tests/move_check/typing/module_call.move:5:29 ───
     │
- 45 │         let () = X::bing (X::baz (X::bar(1)));
-    │                           ^^^^^^^^^^^^^^^^^^ Invalid type argument
-    ·
   5 │     public fun bar(x: u64): (address, u64) {
     │                             -------------- Expected a single non-reference type, but found: '(address, u64)'
+    ·
+ 45 │         let () = X::bing (X::baz (X::bar(1)));
+    │                           ^^^^^^^^^^^^^^^^^^ Invalid type argument
     │
 
 error: 
@@ -145,23 +133,21 @@ error:
     │
  46 │         let () = X::bing (X::baz (0x0, 1));
     │                  ^^^^^^^^^^^^^^^^^^^^^^^^^ Invalid call of '0x1::X::bing'. The call expected 3 argument(s) but got 1
-    ·
- 46 │         let () = X::bing (X::baz (0x0, 1));
     │                          ----------------- Found 1 argument(s) here
     │
 
 error: 
 
-    ┌── tests/move_check/typing/module_call.move:46:18 ───
+    ┌── tests/move_check/typing/module_call.move:8:43 ───
     │
- 46 │         let () = X::bing (X::baz (0x0, 1));
-    │                  ^^^^^^^^^^^^^^^^^^^^^^^^^ Invalid call of '0x1::X::bing'. Invalid argument for parameter 'b'
-    ·
   8 │     public fun baz<T1, T2>(a: T1, x: T2): (bool, T1, T2) {
     │                                           -------------- The type: '(bool, address, {integer})'
     ·
  11 │     public fun bing(b: bool, a: address, x: u64) {
     │                        ---- Is not compatible with: 'bool'
+    ·
+ 46 │         let () = X::bing (X::baz (0x0, 1));
+    │                  ^^^^^^^^^^^^^^^^^^^^^^^^^ Invalid call of '0x1::X::bing'. Invalid argument for parameter 'b'
     │
 
 error: 
@@ -170,23 +156,21 @@ error:
     │
  51 │         let () = bing(baz(bar(foo())));
     │                  ^^^^^^^^^^^^^^^^^^^^^ Invalid call of '0x1::M::bing'. The call expected 3 argument(s) but got 1
-    ·
- 51 │         let () = bing(baz(bar(foo())));
     │                      ----------------- Found 1 argument(s) here
     │
 
 error: 
 
-    ┌── tests/move_check/typing/module_call.move:51:18 ───
+    ┌── tests/move_check/typing/module_call.move:22:36 ───
     │
- 51 │         let () = bing(baz(bar(foo())));
-    │                  ^^^^^^^^^^^^^^^^^^^^^ Invalid call of '0x1::M::bing'. Invalid argument for parameter 'b'
-    ·
  22 │     fun baz<T1, T2>(a: T1, x: T2): (bool, T1, T2) {
     │                                    -------------- The type: '(bool, (address, u64), _)'
     ·
  25 │     fun bing(b: bool, a: address, x: u64) {
     │                 ---- Is not compatible with: 'bool'
+    ·
+ 51 │         let () = bing(baz(bar(foo())));
+    │                  ^^^^^^^^^^^^^^^^^^^^^ Invalid call of '0x1::M::bing'. Invalid argument for parameter 'b'
     │
 
 error: 
@@ -195,20 +179,18 @@ error:
     │
  51 │         let () = bing(baz(bar(foo())));
     │                       ^^^^^^^^^^^^^^^ Invalid call of '0x1::M::baz'. The call expected 2 argument(s) but got 1
-    ·
- 51 │         let () = bing(baz(bar(foo())));
     │                          ------------ Found 1 argument(s) here
     │
 
 error: 
 
-    ┌── tests/move_check/typing/module_call.move:51:23 ───
+    ┌── tests/move_check/typing/module_call.move:19:22 ───
     │
- 51 │         let () = bing(baz(bar(foo())));
-    │                       ^^^^^^^^^^^^^^^ Invalid type argument
-    ·
  19 │     fun bar(x: u64): (address, u64) {
     │                      -------------- Expected a single non-reference type, but found: '(address, u64)'
+    ·
+ 51 │         let () = bing(baz(bar(foo())));
+    │                       ^^^^^^^^^^^^^^^ Invalid type argument
     │
 
 error: 
@@ -217,23 +199,21 @@ error:
     │
  52 │         let () = bing (baz (bar (foo())));
     │                  ^^^^^^^^^^^^^^^^^^^^^^^^ Invalid call of '0x1::M::bing'. The call expected 3 argument(s) but got 1
-    ·
- 52 │         let () = bing (baz (bar (foo())));
     │                       ------------------- Found 1 argument(s) here
     │
 
 error: 
 
-    ┌── tests/move_check/typing/module_call.move:52:18 ───
+    ┌── tests/move_check/typing/module_call.move:22:36 ───
     │
- 52 │         let () = bing (baz (bar (foo())));
-    │                  ^^^^^^^^^^^^^^^^^^^^^^^^ Invalid call of '0x1::M::bing'. Invalid argument for parameter 'b'
-    ·
  22 │     fun baz<T1, T2>(a: T1, x: T2): (bool, T1, T2) {
     │                                    -------------- The type: '(bool, (address, u64), _)'
     ·
  25 │     fun bing(b: bool, a: address, x: u64) {
     │                 ---- Is not compatible with: 'bool'
+    ·
+ 52 │         let () = bing (baz (bar (foo())));
+    │                  ^^^^^^^^^^^^^^^^^^^^^^^^ Invalid call of '0x1::M::bing'. Invalid argument for parameter 'b'
     │
 
 error: 
@@ -242,20 +222,18 @@ error:
     │
  52 │         let () = bing (baz (bar (foo())));
     │                        ^^^^^^^^^^^^^^^^^ Invalid call of '0x1::M::baz'. The call expected 2 argument(s) but got 1
-    ·
- 52 │         let () = bing (baz (bar (foo())));
     │                            ------------- Found 1 argument(s) here
     │
 
 error: 
 
-    ┌── tests/move_check/typing/module_call.move:52:24 ───
+    ┌── tests/move_check/typing/module_call.move:19:22 ───
     │
- 52 │         let () = bing (baz (bar (foo())));
-    │                        ^^^^^^^^^^^^^^^^^ Invalid type argument
-    ·
  19 │     fun bar(x: u64): (address, u64) {
     │                      -------------- Expected a single non-reference type, but found: '(address, u64)'
+    ·
+ 52 │         let () = bing (baz (bar (foo())));
+    │                        ^^^^^^^^^^^^^^^^^ Invalid type argument
     │
 
 error: 
@@ -264,23 +242,21 @@ error:
     │
  53 │         let () = bing (baz (bar(1)));
     │                  ^^^^^^^^^^^^^^^^^^^ Invalid call of '0x1::M::bing'. The call expected 3 argument(s) but got 1
-    ·
- 53 │         let () = bing (baz (bar(1)));
     │                       -------------- Found 1 argument(s) here
     │
 
 error: 
 
-    ┌── tests/move_check/typing/module_call.move:53:18 ───
+    ┌── tests/move_check/typing/module_call.move:22:36 ───
     │
- 53 │         let () = bing (baz (bar(1)));
-    │                  ^^^^^^^^^^^^^^^^^^^ Invalid call of '0x1::M::bing'. Invalid argument for parameter 'b'
-    ·
  22 │     fun baz<T1, T2>(a: T1, x: T2): (bool, T1, T2) {
     │                                    -------------- The type: '(bool, (address, u64), _)'
     ·
  25 │     fun bing(b: bool, a: address, x: u64) {
     │                 ---- Is not compatible with: 'bool'
+    ·
+ 53 │         let () = bing (baz (bar(1)));
+    │                  ^^^^^^^^^^^^^^^^^^^ Invalid call of '0x1::M::bing'. Invalid argument for parameter 'b'
     │
 
 error: 
@@ -289,20 +265,18 @@ error:
     │
  53 │         let () = bing (baz (bar(1)));
     │                        ^^^^^^^^^^^^ Invalid call of '0x1::M::baz'. The call expected 2 argument(s) but got 1
-    ·
- 53 │         let () = bing (baz (bar(1)));
     │                            -------- Found 1 argument(s) here
     │
 
 error: 
 
-    ┌── tests/move_check/typing/module_call.move:53:24 ───
+    ┌── tests/move_check/typing/module_call.move:19:22 ───
     │
- 53 │         let () = bing (baz (bar(1)));
-    │                        ^^^^^^^^^^^^ Invalid type argument
-    ·
  19 │     fun bar(x: u64): (address, u64) {
     │                      -------------- Expected a single non-reference type, but found: '(address, u64)'
+    ·
+ 53 │         let () = bing (baz (bar(1)));
+    │                        ^^^^^^^^^^^^ Invalid type argument
     │
 
 error: 
@@ -311,22 +285,20 @@ error:
     │
  54 │         let () = bing (baz (0x0, 1));
     │                  ^^^^^^^^^^^^^^^^^^^ Invalid call of '0x1::M::bing'. The call expected 3 argument(s) but got 1
-    ·
- 54 │         let () = bing (baz (0x0, 1));
     │                       -------------- Found 1 argument(s) here
     │
 
 error: 
 
-    ┌── tests/move_check/typing/module_call.move:54:18 ───
+    ┌── tests/move_check/typing/module_call.move:22:36 ───
     │
- 54 │         let () = bing (baz (0x0, 1));
-    │                  ^^^^^^^^^^^^^^^^^^^ Invalid call of '0x1::M::bing'. Invalid argument for parameter 'b'
-    ·
  22 │     fun baz<T1, T2>(a: T1, x: T2): (bool, T1, T2) {
     │                                    -------------- The type: '(bool, address, {integer})'
     ·
  25 │     fun bing(b: bool, a: address, x: u64) {
     │                 ---- Is not compatible with: 'bool'
+    ·
+ 54 │         let () = bing (baz (0x0, 1));
+    │                  ^^^^^^^^^^^^^^^^^^^ Invalid call of '0x1::M::bing'. Invalid argument for parameter 'b'
     │
 

--- a/language/move-lang/tests/move_check/typing/module_call_complicated_rhs.exp
+++ b/language/move-lang/tests/move_check/typing/module_call_complicated_rhs.exp
@@ -4,8 +4,6 @@ error:
     │
  11 │         foo (if (cond) () else ());
     │         ^^^^^^^^^^^^^^^^^^^^^^^^^^ Invalid call of '0x8675309::M::foo'. The call expected 0 argument(s) but got 1
-    ·
- 11 │         foo (if (cond) () else ());
     │             ---------------------- Found 1 argument(s) here
     │
 
@@ -15,8 +13,6 @@ error:
     │
  13 │         baz (if (cond) (false, 0x0) else (true, 0x1));
     │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Invalid call of '0x8675309::M::baz'. The call expected 2 argument(s) but got 1
-    ·
- 13 │         baz (if (cond) (false, 0x0) else (true, 0x1));
     │             ----------------------------------------- Found 1 argument(s) here
     │
 
@@ -26,8 +22,6 @@ error:
     │
  13 │         baz (if (cond) (false, 0x0) else (true, 0x1));
     │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Invalid type argument
-    ·
- 13 │         baz (if (cond) (false, 0x0) else (true, 0x1));
     │                                          ----------- Expected a single non-reference type, but found: '(bool, address)'
     │
 
@@ -37,8 +31,6 @@ error:
     │
  17 │         foo(if (cond) () else ());
     │         ^^^^^^^^^^^^^^^^^^^^^^^^^ Invalid call of '0x8675309::M::foo'. The call expected 0 argument(s) but got 1
-    ·
- 17 │         foo(if (cond) () else ());
     │            ---------------------- Found 1 argument(s) here
     │
 
@@ -48,8 +40,6 @@ error:
     │
  19 │         baz(if (cond) (false, 0x0) else (true, 0x1));
     │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Invalid call of '0x8675309::M::baz'. The call expected 2 argument(s) but got 1
-    ·
- 19 │         baz(if (cond) (false, 0x0) else (true, 0x1));
     │            ----------------------------------------- Found 1 argument(s) here
     │
 
@@ -59,8 +49,6 @@ error:
     │
  19 │         baz(if (cond) (false, 0x0) else (true, 0x1));
     │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Invalid type argument
-    ·
- 19 │         baz(if (cond) (false, 0x0) else (true, 0x1));
     │                                         ----------- Expected a single non-reference type, but found: '(bool, address)'
     │
 
@@ -70,8 +58,6 @@ error:
     │
  23 │         foo({});
     │         ^^^^^^^ Invalid call of '0x8675309::M::foo'. The call expected 0 argument(s) but got 1
-    ·
- 23 │         foo({});
     │            ---- Found 1 argument(s) here
     │
 
@@ -81,8 +67,6 @@ error:
     │
  24 │         foo({ let _x = 0; });
     │         ^^^^^^^^^^^^^^^^^^^^ Invalid call of '0x8675309::M::foo'. The call expected 0 argument(s) but got 1
-    ·
- 24 │         foo({ let _x = 0; });
     │            ----------------- Found 1 argument(s) here
     │
 
@@ -92,8 +76,6 @@ error:
     │
  31 │         baz({ (a, x) });
     │         ^^^^^^^^^^^^^^^ Invalid call of '0x8675309::M::baz'. The call expected 2 argument(s) but got 1
-    ·
- 31 │         baz({ (a, x) });
     │            ------------ Found 1 argument(s) here
     │
 
@@ -103,8 +85,6 @@ error:
     │
  31 │         baz({ (a, x) });
     │         ^^^^^^^^^^^^^^^ Invalid type argument
-    ·
- 31 │         baz({ (a, x) });
     │               ------ Expected a single non-reference type, but found: '(address, u64)'
     │
 
@@ -114,8 +94,6 @@ error:
     │
  32 │         baz({ let a = false; (a, x) });
     │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Invalid call of '0x8675309::M::baz'. The call expected 2 argument(s) but got 1
-    ·
- 32 │         baz({ let a = false; (a, x) });
     │            --------------------------- Found 1 argument(s) here
     │
 
@@ -125,8 +103,6 @@ error:
     │
  32 │         baz({ let a = false; (a, x) });
     │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Invalid type argument
-    ·
- 32 │         baz({ let a = false; (a, x) });
     │                              ------ Expected a single non-reference type, but found: '(bool, u64)'
     │
 
@@ -136,8 +112,6 @@ error:
     │
  36 │         foo({});
     │         ^^^^^^^ Invalid call of '0x8675309::M::foo'. The call expected 0 argument(s) but got 1
-    ·
- 36 │         foo({});
     │            ---- Found 1 argument(s) here
     │
 
@@ -147,8 +121,6 @@ error:
     │
  37 │         foo({ let _x = 0; });
     │         ^^^^^^^^^^^^^^^^^^^^ Invalid call of '0x8675309::M::foo'. The call expected 0 argument(s) but got 1
-    ·
- 37 │         foo({ let _x = 0; });
     │            ----------------- Found 1 argument(s) here
     │
 
@@ -158,8 +130,6 @@ error:
     │
  44 │         baz({ (a, x) });
     │         ^^^^^^^^^^^^^^^ Invalid call of '0x8675309::M::baz'. The call expected 2 argument(s) but got 1
-    ·
- 44 │         baz({ (a, x) });
     │            ------------ Found 1 argument(s) here
     │
 
@@ -169,8 +139,6 @@ error:
     │
  44 │         baz({ (a, x) });
     │         ^^^^^^^^^^^^^^^ Invalid type argument
-    ·
- 44 │         baz({ (a, x) });
     │               ------ Expected a single non-reference type, but found: '(address, u64)'
     │
 
@@ -180,8 +148,6 @@ error:
     │
  45 │         baz({ let a = false; (a, x) });
     │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Invalid call of '0x8675309::M::baz'. The call expected 2 argument(s) but got 1
-    ·
- 45 │         baz({ let a = false; (a, x) });
     │            --------------------------- Found 1 argument(s) here
     │
 
@@ -191,8 +157,6 @@ error:
     │
  45 │         baz({ let a = false; (a, x) });
     │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Invalid type argument
-    ·
- 45 │         baz({ let a = false; (a, x) });
     │                              ------ Expected a single non-reference type, but found: '(bool, u64)'
     │
 

--- a/language/move-lang/tests/move_check/typing/module_call_constraints_not_satisfied.exp
+++ b/language/move-lang/tests/move_check/typing/module_call_constraints_not_satisfied.exp
@@ -1,357 +1,311 @@
 error: 
 
-    ┌── tests/move_check/typing/module_call_constraints_not_satisfied.move:21:9 ───
+    ┌── tests/move_check/typing/module_call_constraints_not_satisfied.move:2:12 ───
     │
- 21 │         both(S{}, Coin{});
-    │         ^^^^^^^^^^^^^^^^^ Constraint not satisfied.
-    ·
- 21 │         both(S{}, Coin{});
-    │              --- The copyable type '0x8675309::M::S' does not satisfy the constraint 'resource'
-    ·
   2 │     struct S {}
     │            - The type's constraint information was determined here
     ·
   7 │     fun both<R: resource, C: copyable>(r: R, c: C) {
     │                 -------- 'resource' constraint declared here
-    │
-
-error: 
-
-    ┌── tests/move_check/typing/module_call_constraints_not_satisfied.move:21:9 ───
-    │
+    ·
  21 │         both(S{}, Coin{});
     │         ^^^^^^^^^^^^^^^^^ Constraint not satisfied.
+    │              --- The copyable type '0x8675309::M::S' does not satisfy the constraint 'resource'
+    │
+
+error: 
+
+    ┌── tests/move_check/typing/module_call_constraints_not_satisfied.move:3:5 ───
+    │
+  3 │     resource struct Coin {}
+    │     -------- The type's constraint information was determined here
+    ·
+  7 │     fun both<R: resource, C: copyable>(r: R, c: C) {
+    │                              -------- 'copyable' constraint declared here
     ·
  21 │         both(S{}, Coin{});
+    │         ^^^^^^^^^^^^^^^^^ Constraint not satisfied.
     │                   ------ The resource type '0x8675309::M::Coin' does not satisfy the constraint 'copyable'
-    ·
-  3 │     resource struct Coin {}
-    │     -------- The type's constraint information was determined here
-    ·
-  7 │     fun both<R: resource, C: copyable>(r: R, c: C) {
-    │                              -------- 'copyable' constraint declared here
     │
 
 error: 
 
-    ┌── tests/move_check/typing/module_call_constraints_not_satisfied.move:22:9 ───
+    ┌── tests/move_check/typing/module_call_constraints_not_satisfied.move:7:17 ───
     │
- 22 │         both(0, Coin{})
-    │         ^^^^^^^^^^^^^^^ Constraint not satisfied.
-    ·
- 22 │         both(0, Coin{})
-    │              - The copyable type 'u64' does not satisfy the constraint 'resource'
-    ·
- 22 │         both(0, Coin{})
-    │              - The type's constraint information was determined here
-    ·
   7 │     fun both<R: resource, C: copyable>(r: R, c: C) {
     │                 -------- 'resource' constraint declared here
+    ·
+ 22 │         both(0, Coin{})
+    │         ^^^^^^^^^^^^^^^ Constraint not satisfied.
+    │              - The type's constraint information was determined here
+    │              - The copyable type 'u64' does not satisfy the constraint 'resource'
     │
 
 error: 
 
-    ┌── tests/move_check/typing/module_call_constraints_not_satisfied.move:22:9 ───
+    ┌── tests/move_check/typing/module_call_constraints_not_satisfied.move:3:5 ───
     │
- 22 │         both(0, Coin{})
-    │         ^^^^^^^^^^^^^^^ Constraint not satisfied.
-    ·
- 22 │         both(0, Coin{})
-    │                 ------ The resource type '0x8675309::M::Coin' does not satisfy the constraint 'copyable'
-    ·
   3 │     resource struct Coin {}
     │     -------- The type's constraint information was determined here
     ·
   7 │     fun both<R: resource, C: copyable>(r: R, c: C) {
     │                              -------- 'copyable' constraint declared here
+    ·
+ 22 │         both(0, Coin{})
+    │         ^^^^^^^^^^^^^^^ Constraint not satisfied.
+    │                 ------ The resource type '0x8675309::M::Coin' does not satisfy the constraint 'copyable'
     │
 
 error: 
 
-    ┌── tests/move_check/typing/module_call_constraints_not_satisfied.move:26:9 ───
+    ┌── tests/move_check/typing/module_call_constraints_not_satisfied.move:4:12 ───
     │
- 26 │         both(Box<C> {}, Box<R> {})
-    │         ^^^^^^^^^^^^^^^^^^^^^^^^^^ Constraint not satisfied.
-    ·
- 26 │         both(Box<C> {}, Box<R> {})
-    │              --------- The copyable type '0x8675309::M::Box<C>' does not satisfy the constraint 'resource'
-    ·
   4 │     struct Box<T> {}
     │            --- The type's constraint information was determined here
     ·
   7 │     fun both<R: resource, C: copyable>(r: R, c: C) {
     │                 -------- 'resource' constraint declared here
+    ·
+ 26 │         both(Box<C> {}, Box<R> {})
+    │         ^^^^^^^^^^^^^^^^^^^^^^^^^^ Constraint not satisfied.
+    │              --------- The copyable type '0x8675309::M::Box<C>' does not satisfy the constraint 'resource'
     │
 
 error: 
 
-    ┌── tests/move_check/typing/module_call_constraints_not_satisfied.move:26:9 ───
+    ┌── tests/move_check/typing/module_call_constraints_not_satisfied.move:7:30 ───
     │
- 26 │         both(Box<C> {}, Box<R> {})
-    │         ^^^^^^^^^^^^^^^^^^^^^^^^^^ Constraint not satisfied.
-    ·
- 26 │         both(Box<C> {}, Box<R> {})
-    │                         --------- The resource type '0x8675309::M::Box<R>' does not satisfy the constraint 'copyable'
+  7 │     fun both<R: resource, C: copyable>(r: R, c: C) {
+    │                              -------- 'copyable' constraint declared here
     ·
  25 │     fun t1<R: resource, C: copyable>() {
     │               -------- The type's constraint information was determined here
-    ·
-  7 │     fun both<R: resource, C: copyable>(r: R, c: C) {
-    │                              -------- 'copyable' constraint declared here
+ 26 │         both(Box<C> {}, Box<R> {})
+    │         ^^^^^^^^^^^^^^^^^^^^^^^^^^ Constraint not satisfied.
+    │                         --------- The resource type '0x8675309::M::Box<R>' does not satisfy the constraint 'copyable'
     │
 
 error: 
 
-    ┌── tests/move_check/typing/module_call_constraints_not_satisfied.move:30:9 ───
+    ┌── tests/move_check/typing/module_call_constraints_not_satisfied.move:5:12 ───
     │
- 30 │         rsrc(Box3<C, C, C> {});
-    │         ^^^^^^^^^^^^^^^^^^^^^^ Constraint not satisfied.
-    ·
- 30 │         rsrc(Box3<C, C, C> {});
-    │              ---------------- The copyable type '0x8675309::M::Box3<C, C, C>' does not satisfy the constraint 'resource'
-    ·
   5 │     struct Box3<T1, T2, T3> {}
     │            ---- The type's constraint information was determined here
     ·
  15 │     fun rsrc<R: resource>(r: R) {
     │                 -------- 'resource' constraint declared here
+    ·
+ 30 │         rsrc(Box3<C, C, C> {});
+    │         ^^^^^^^^^^^^^^^^^^^^^^ Constraint not satisfied.
+    │              ---------------- The copyable type '0x8675309::M::Box3<C, C, C>' does not satisfy the constraint 'resource'
     │
 
 error: 
 
-    ┌── tests/move_check/typing/module_call_constraints_not_satisfied.move:32:9 ───
+    ┌── tests/move_check/typing/module_call_constraints_not_satisfied.move:11:16 ───
     │
- 32 │         cpy(Box3<R, C, C> {});
-    │         ^^^^^^^^^^^^^^^^^^^^^ Constraint not satisfied.
+ 11 │     fun cpy<C: copyable>(c: C) {
+    │                -------- 'copyable' constraint declared here
+    ·
+ 29 │     fun t2<R: resource, C: copyable>() {
+    │               -------- The type's constraint information was determined here
     ·
  32 │         cpy(Box3<R, C, C> {});
+    │         ^^^^^^^^^^^^^^^^^^^^^ Constraint not satisfied.
     │             ---------------- The resource type '0x8675309::M::Box3<R, C, C>' does not satisfy the constraint 'copyable'
-    ·
- 29 │     fun t2<R: resource, C: copyable>() {
-    │               -------- The type's constraint information was determined here
-    ·
- 11 │     fun cpy<C: copyable>(c: C) {
-    │                -------- 'copyable' constraint declared here
     │
 
 error: 
 
-    ┌── tests/move_check/typing/module_call_constraints_not_satisfied.move:33:9 ───
+    ┌── tests/move_check/typing/module_call_constraints_not_satisfied.move:11:16 ───
     │
- 33 │         cpy(Box3<C, R, C> {});
-    │         ^^^^^^^^^^^^^^^^^^^^^ Constraint not satisfied.
+ 11 │     fun cpy<C: copyable>(c: C) {
+    │                -------- 'copyable' constraint declared here
+    ·
+ 29 │     fun t2<R: resource, C: copyable>() {
+    │               -------- The type's constraint information was determined here
     ·
  33 │         cpy(Box3<C, R, C> {});
+    │         ^^^^^^^^^^^^^^^^^^^^^ Constraint not satisfied.
     │             ---------------- The resource type '0x8675309::M::Box3<C, R, C>' does not satisfy the constraint 'copyable'
-    ·
- 29 │     fun t2<R: resource, C: copyable>() {
-    │               -------- The type's constraint information was determined here
-    ·
- 11 │     fun cpy<C: copyable>(c: C) {
-    │                -------- 'copyable' constraint declared here
     │
 
 error: 
 
-    ┌── tests/move_check/typing/module_call_constraints_not_satisfied.move:34:9 ───
+    ┌── tests/move_check/typing/module_call_constraints_not_satisfied.move:11:16 ───
     │
- 34 │         cpy(Box3<C, C, R> {});
-    │         ^^^^^^^^^^^^^^^^^^^^^ Constraint not satisfied.
+ 11 │     fun cpy<C: copyable>(c: C) {
+    │                -------- 'copyable' constraint declared here
+    ·
+ 29 │     fun t2<R: resource, C: copyable>() {
+    │               -------- The type's constraint information was determined here
     ·
  34 │         cpy(Box3<C, C, R> {});
+    │         ^^^^^^^^^^^^^^^^^^^^^ Constraint not satisfied.
     │             ---------------- The resource type '0x8675309::M::Box3<C, C, R>' does not satisfy the constraint 'copyable'
-    ·
- 29 │     fun t2<R: resource, C: copyable>() {
-    │               -------- The type's constraint information was determined here
-    ·
- 11 │     fun cpy<C: copyable>(c: C) {
-    │                -------- 'copyable' constraint declared here
     │
 
 error: 
 
-    ┌── tests/move_check/typing/module_call_constraints_not_satisfied.move:36:9 ───
+    ┌── tests/move_check/typing/module_call_constraints_not_satisfied.move:11:16 ───
     │
- 36 │         cpy(Box3<C, R, R> {});
-    │         ^^^^^^^^^^^^^^^^^^^^^ Constraint not satisfied.
+ 11 │     fun cpy<C: copyable>(c: C) {
+    │                -------- 'copyable' constraint declared here
+    ·
+ 29 │     fun t2<R: resource, C: copyable>() {
+    │               -------- The type's constraint information was determined here
     ·
  36 │         cpy(Box3<C, R, R> {});
+    │         ^^^^^^^^^^^^^^^^^^^^^ Constraint not satisfied.
     │             ---------------- The resource type '0x8675309::M::Box3<C, R, R>' does not satisfy the constraint 'copyable'
-    ·
- 29 │     fun t2<R: resource, C: copyable>() {
-    │               -------- The type's constraint information was determined here
-    ·
- 11 │     fun cpy<C: copyable>(c: C) {
-    │                -------- 'copyable' constraint declared here
     │
 
 error: 
 
-    ┌── tests/move_check/typing/module_call_constraints_not_satisfied.move:37:9 ───
+    ┌── tests/move_check/typing/module_call_constraints_not_satisfied.move:11:16 ───
     │
- 37 │         cpy(Box3<R, C, R> {});
-    │         ^^^^^^^^^^^^^^^^^^^^^ Constraint not satisfied.
+ 11 │     fun cpy<C: copyable>(c: C) {
+    │                -------- 'copyable' constraint declared here
+    ·
+ 29 │     fun t2<R: resource, C: copyable>() {
+    │               -------- The type's constraint information was determined here
     ·
  37 │         cpy(Box3<R, C, R> {});
+    │         ^^^^^^^^^^^^^^^^^^^^^ Constraint not satisfied.
     │             ---------------- The resource type '0x8675309::M::Box3<R, C, R>' does not satisfy the constraint 'copyable'
-    ·
- 29 │     fun t2<R: resource, C: copyable>() {
-    │               -------- The type's constraint information was determined here
-    ·
- 11 │     fun cpy<C: copyable>(c: C) {
-    │                -------- 'copyable' constraint declared here
     │
 
 error: 
 
-    ┌── tests/move_check/typing/module_call_constraints_not_satisfied.move:38:9 ───
+    ┌── tests/move_check/typing/module_call_constraints_not_satisfied.move:11:16 ───
     │
- 38 │         cpy(Box3<R, R, C> {});
-    │         ^^^^^^^^^^^^^^^^^^^^^ Constraint not satisfied.
+ 11 │     fun cpy<C: copyable>(c: C) {
+    │                -------- 'copyable' constraint declared here
+    ·
+ 29 │     fun t2<R: resource, C: copyable>() {
+    │               -------- The type's constraint information was determined here
     ·
  38 │         cpy(Box3<R, R, C> {});
+    │         ^^^^^^^^^^^^^^^^^^^^^ Constraint not satisfied.
     │             ---------------- The resource type '0x8675309::M::Box3<R, R, C>' does not satisfy the constraint 'copyable'
-    ·
- 29 │     fun t2<R: resource, C: copyable>() {
-    │               -------- The type's constraint information was determined here
-    ·
- 11 │     fun cpy<C: copyable>(c: C) {
-    │                -------- 'copyable' constraint declared here
     │
 
 error: 
 
-    ┌── tests/move_check/typing/module_call_constraints_not_satisfied.move:40:9 ───
+    ┌── tests/move_check/typing/module_call_constraints_not_satisfied.move:11:16 ───
     │
- 40 │         cpy(Box3<R, R, R> {});
-    │         ^^^^^^^^^^^^^^^^^^^^^ Constraint not satisfied.
+ 11 │     fun cpy<C: copyable>(c: C) {
+    │                -------- 'copyable' constraint declared here
+    ·
+ 29 │     fun t2<R: resource, C: copyable>() {
+    │               -------- The type's constraint information was determined here
     ·
  40 │         cpy(Box3<R, R, R> {});
+    │         ^^^^^^^^^^^^^^^^^^^^^ Constraint not satisfied.
     │             ---------------- The resource type '0x8675309::M::Box3<R, R, R>' does not satisfy the constraint 'copyable'
-    ·
- 29 │     fun t2<R: resource, C: copyable>() {
-    │               -------- The type's constraint information was determined here
-    ·
- 11 │     fun cpy<C: copyable>(c: C) {
-    │                -------- 'copyable' constraint declared here
     │
 
 error: 
 
-    ┌── tests/move_check/typing/module_call_constraints_not_satisfied.move:44:9 ───
+    ┌── tests/move_check/typing/module_call_constraints_not_satisfied.move:11:16 ───
     │
+ 11 │     fun cpy<C: copyable>(c: C) {
+    │                -------- 'copyable' constraint declared here
+    ·
+ 43 │     fun t3<U, C: copyable>() {
+    │            - The type's constraint information was determined here
  44 │         cpy(Box3<U, C, C> {});
     │         ^^^^^^^^^^^^^^^^^^^^^ Constraint not satisfied.
-    ·
- 44 │         cpy(Box3<U, C, C> {});
     │             ---------------- The type '0x8675309::M::Box3<U, C, C>' does not satisfy the constraint 'copyable'
-    ·
- 43 │     fun t3<U, C: copyable>() {
-    │            - The type's constraint information was determined here
-    ·
- 11 │     fun cpy<C: copyable>(c: C) {
-    │                -------- 'copyable' constraint declared here
     │
 
 error: 
 
-    ┌── tests/move_check/typing/module_call_constraints_not_satisfied.move:45:9 ───
+    ┌── tests/move_check/typing/module_call_constraints_not_satisfied.move:11:16 ───
     │
+ 11 │     fun cpy<C: copyable>(c: C) {
+    │                -------- 'copyable' constraint declared here
+    ·
+ 43 │     fun t3<U, C: copyable>() {
+    │            - The type's constraint information was determined here
+ 44 │         cpy(Box3<U, C, C> {});
  45 │         cpy(Box3<C, U, C> {});
     │         ^^^^^^^^^^^^^^^^^^^^^ Constraint not satisfied.
-    ·
- 45 │         cpy(Box3<C, U, C> {});
     │             ---------------- The type '0x8675309::M::Box3<C, U, C>' does not satisfy the constraint 'copyable'
-    ·
- 43 │     fun t3<U, C: copyable>() {
-    │            - The type's constraint information was determined here
-    ·
- 11 │     fun cpy<C: copyable>(c: C) {
-    │                -------- 'copyable' constraint declared here
     │
 
 error: 
 
-    ┌── tests/move_check/typing/module_call_constraints_not_satisfied.move:46:9 ───
+    ┌── tests/move_check/typing/module_call_constraints_not_satisfied.move:11:16 ───
     │
- 46 │         cpy(Box3<C, C, U> {});
-    │         ^^^^^^^^^^^^^^^^^^^^^ Constraint not satisfied.
+ 11 │     fun cpy<C: copyable>(c: C) {
+    │                -------- 'copyable' constraint declared here
+    ·
+ 43 │     fun t3<U, C: copyable>() {
+    │            - The type's constraint information was determined here
     ·
  46 │         cpy(Box3<C, C, U> {});
+    │         ^^^^^^^^^^^^^^^^^^^^^ Constraint not satisfied.
     │             ---------------- The type '0x8675309::M::Box3<C, C, U>' does not satisfy the constraint 'copyable'
-    ·
- 43 │     fun t3<U, C: copyable>() {
-    │            - The type's constraint information was determined here
-    ·
- 11 │     fun cpy<C: copyable>(c: C) {
-    │                -------- 'copyable' constraint declared here
     │
 
 error: 
 
-    ┌── tests/move_check/typing/module_call_constraints_not_satisfied.move:48:9 ───
+    ┌── tests/move_check/typing/module_call_constraints_not_satisfied.move:11:16 ───
     │
- 48 │         cpy(Box3<C, U, U> {});
-    │         ^^^^^^^^^^^^^^^^^^^^^ Constraint not satisfied.
+ 11 │     fun cpy<C: copyable>(c: C) {
+    │                -------- 'copyable' constraint declared here
+    ·
+ 43 │     fun t3<U, C: copyable>() {
+    │            - The type's constraint information was determined here
     ·
  48 │         cpy(Box3<C, U, U> {});
+    │         ^^^^^^^^^^^^^^^^^^^^^ Constraint not satisfied.
     │             ---------------- The type '0x8675309::M::Box3<C, U, U>' does not satisfy the constraint 'copyable'
-    ·
- 43 │     fun t3<U, C: copyable>() {
-    │            - The type's constraint information was determined here
-    ·
- 11 │     fun cpy<C: copyable>(c: C) {
-    │                -------- 'copyable' constraint declared here
     │
 
 error: 
 
-    ┌── tests/move_check/typing/module_call_constraints_not_satisfied.move:49:9 ───
+    ┌── tests/move_check/typing/module_call_constraints_not_satisfied.move:11:16 ───
     │
- 49 │         cpy(Box3<U, C, U> {});
-    │         ^^^^^^^^^^^^^^^^^^^^^ Constraint not satisfied.
+ 11 │     fun cpy<C: copyable>(c: C) {
+    │                -------- 'copyable' constraint declared here
+    ·
+ 43 │     fun t3<U, C: copyable>() {
+    │            - The type's constraint information was determined here
     ·
  49 │         cpy(Box3<U, C, U> {});
+    │         ^^^^^^^^^^^^^^^^^^^^^ Constraint not satisfied.
     │             ---------------- The type '0x8675309::M::Box3<U, C, U>' does not satisfy the constraint 'copyable'
-    ·
- 43 │     fun t3<U, C: copyable>() {
-    │            - The type's constraint information was determined here
-    ·
- 11 │     fun cpy<C: copyable>(c: C) {
-    │                -------- 'copyable' constraint declared here
     │
 
 error: 
 
-    ┌── tests/move_check/typing/module_call_constraints_not_satisfied.move:50:9 ───
+    ┌── tests/move_check/typing/module_call_constraints_not_satisfied.move:11:16 ───
     │
- 50 │         cpy(Box3<U, U, C> {});
-    │         ^^^^^^^^^^^^^^^^^^^^^ Constraint not satisfied.
+ 11 │     fun cpy<C: copyable>(c: C) {
+    │                -------- 'copyable' constraint declared here
+    ·
+ 43 │     fun t3<U, C: copyable>() {
+    │            - The type's constraint information was determined here
     ·
  50 │         cpy(Box3<U, U, C> {});
+    │         ^^^^^^^^^^^^^^^^^^^^^ Constraint not satisfied.
     │             ---------------- The type '0x8675309::M::Box3<U, U, C>' does not satisfy the constraint 'copyable'
-    ·
- 43 │     fun t3<U, C: copyable>() {
-    │            - The type's constraint information was determined here
-    ·
- 11 │     fun cpy<C: copyable>(c: C) {
-    │                -------- 'copyable' constraint declared here
     │
 
 error: 
 
-    ┌── tests/move_check/typing/module_call_constraints_not_satisfied.move:52:9 ───
+    ┌── tests/move_check/typing/module_call_constraints_not_satisfied.move:11:16 ───
     │
- 52 │         cpy(Box3<U, U, U> {});
-    │         ^^^^^^^^^^^^^^^^^^^^^ Constraint not satisfied.
-    ·
- 52 │         cpy(Box3<U, U, U> {});
-    │             ---------------- The type '0x8675309::M::Box3<U, U, U>' does not satisfy the constraint 'copyable'
+ 11 │     fun cpy<C: copyable>(c: C) {
+    │                -------- 'copyable' constraint declared here
     ·
  43 │     fun t3<U, C: copyable>() {
     │            - The type's constraint information was determined here
     ·
- 11 │     fun cpy<C: copyable>(c: C) {
-    │                -------- 'copyable' constraint declared here
+ 52 │         cpy(Box3<U, U, U> {});
+    │         ^^^^^^^^^^^^^^^^^^^^^ Constraint not satisfied.
+    │             ---------------- The type '0x8675309::M::Box3<U, U, U>' does not satisfy the constraint 'copyable'
     │
 

--- a/language/move-lang/tests/move_check/typing/module_call_explicit_type_arguments.exp
+++ b/language/move-lang/tests/move_check/typing/module_call_explicit_type_arguments.exp
@@ -1,26 +1,22 @@
 error: 
 
-   ┌── tests/move_check/typing/module_call_explicit_type_arguments.move:2:33 ───
-   │
+   ┌── tests/move_check/typing/module_call_explicit_type_arguments.move:2:19 ───
+   │  
  2 │       fun foo<T, U>(_x: T, _y: U) {
+   │                     -- The parameter '_x' might still contain a resource value. The resource must be consumed before the function returns
    │ ╭─────────────────────────────────^
  3 │ │     }
    │ ╰─────^ Invalid return
-   ·
- 2 │     fun foo<T, U>(_x: T, _y: U) {
-   │                   -- The parameter '_x' might still contain a resource value. The resource must be consumed before the function returns
-   │
+   │  
 
 error: 
 
-   ┌── tests/move_check/typing/module_call_explicit_type_arguments.move:2:33 ───
-   │
+   ┌── tests/move_check/typing/module_call_explicit_type_arguments.move:2:26 ───
+   │  
  2 │       fun foo<T, U>(_x: T, _y: U) {
+   │                            -- The parameter '_y' might still contain a resource value. The resource must be consumed before the function returns
    │ ╭─────────────────────────────────^
  3 │ │     }
    │ ╰─────^ Invalid return
-   ·
- 2 │     fun foo<T, U>(_x: T, _y: U) {
-   │                          -- The parameter '_y' might still contain a resource value. The resource must be consumed before the function returns
-   │
+   │  
 

--- a/language/move-lang/tests/move_check/typing/module_call_explicit_type_arguments_invalid.exp
+++ b/language/move-lang/tests/move_check/typing/module_call_explicit_type_arguments_invalid.exp
@@ -4,12 +4,8 @@ error:
    │
  6 │         foo<u64, u64>(false, false);
    │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^ Invalid call of '0x8675309::M::foo'. Invalid argument for parameter 'x'
-   ·
- 6 │         foo<u64, u64>(false, false);
-   │                       ----- The type: 'bool'
-   ·
- 6 │         foo<u64, u64>(false, false);
    │             --- Is not compatible with: 'u64'
+   │                       ----- The type: 'bool'
    │
 
 error: 
@@ -18,12 +14,8 @@ error:
    │
  6 │         foo<u64, u64>(false, false);
    │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^ Invalid call of '0x8675309::M::foo'. Invalid argument for parameter 'y'
-   ·
- 6 │         foo<u64, u64>(false, false);
-   │                              ----- The type: 'bool'
-   ·
- 6 │         foo<u64, u64>(false, false);
    │                  --- Is not compatible with: 'u64'
+   │                              ----- The type: 'bool'
    │
 
 error: 
@@ -32,12 +24,8 @@ error:
    │
  7 │         foo<bool, bool>(0, false);
    │         ^^^^^^^^^^^^^^^^^^^^^^^^^ Invalid call of '0x8675309::M::foo'. Invalid argument for parameter 'x'
-   ·
- 7 │         foo<bool, bool>(0, false);
-   │                         - The type: integer
-   ·
- 7 │         foo<bool, bool>(0, false);
    │             ---- Is not compatible with: 'bool'
+   │                         - The type: integer
    │
 
 error: 
@@ -46,12 +34,8 @@ error:
    │
  8 │         foo<bool, bool>(false, 0);
    │         ^^^^^^^^^^^^^^^^^^^^^^^^^ Invalid call of '0x8675309::M::foo'. Invalid argument for parameter 'y'
-   ·
- 8 │         foo<bool, bool>(false, 0);
-   │                                - The type: integer
-   ·
- 8 │         foo<bool, bool>(false, 0);
    │                   ---- Is not compatible with: 'bool'
+   │                                - The type: integer
    │
 
 error: 
@@ -60,12 +44,8 @@ error:
    │
  9 │         foo<bool, bool>(0, 0);
    │         ^^^^^^^^^^^^^^^^^^^^^ Invalid call of '0x8675309::M::foo'. Invalid argument for parameter 'x'
-   ·
- 9 │         foo<bool, bool>(0, 0);
-   │                         - The type: integer
-   ·
- 9 │         foo<bool, bool>(0, 0);
    │             ---- Is not compatible with: 'bool'
+   │                         - The type: integer
    │
 
 error: 
@@ -74,53 +54,42 @@ error:
    │
  9 │         foo<bool, bool>(0, 0);
    │         ^^^^^^^^^^^^^^^^^^^^^ Invalid call of '0x8675309::M::foo'. Invalid argument for parameter 'y'
-   ·
- 9 │         foo<bool, bool>(0, 0);
-   │                            - The type: integer
-   ·
- 9 │         foo<bool, bool>(0, 0);
    │                   ---- Is not compatible with: 'bool'
+   │                            - The type: integer
    │
 
 error: 
 
-    ┌── tests/move_check/typing/module_call_explicit_type_arguments_invalid.move:13:9 ───
+    ┌── tests/move_check/typing/module_call_explicit_type_arguments_invalid.move:12:24 ───
     │
- 13 │         foo<U, u64>(t, 0);
-    │         ^^^^^^^^^^^^^^^^^ Invalid call of '0x8675309::M::foo'. Invalid argument for parameter 'x'
-    ·
  12 │     fun t2<T, U, V>(t: T, u: U, v: V) {
     │                        - The type: 'T'
-    ·
  13 │         foo<U, u64>(t, 0);
+    │         ^^^^^^^^^^^^^^^^^ Invalid call of '0x8675309::M::foo'. Invalid argument for parameter 'x'
     │             - Is not compatible with: 'U'
     │
 
 error: 
 
-    ┌── tests/move_check/typing/module_call_explicit_type_arguments_invalid.move:14:9 ───
+    ┌── tests/move_check/typing/module_call_explicit_type_arguments_invalid.move:12:30 ───
     │
- 14 │         foo<V, T>(u, v);
-    │         ^^^^^^^^^^^^^^^ Invalid call of '0x8675309::M::foo'. Invalid argument for parameter 'x'
-    ·
  12 │     fun t2<T, U, V>(t: T, u: U, v: V) {
     │                              - The type: 'U'
-    ·
+ 13 │         foo<U, u64>(t, 0);
  14 │         foo<V, T>(u, v);
+    │         ^^^^^^^^^^^^^^^ Invalid call of '0x8675309::M::foo'. Invalid argument for parameter 'x'
     │             - Is not compatible with: 'V'
     │
 
 error: 
 
-    ┌── tests/move_check/typing/module_call_explicit_type_arguments_invalid.move:14:9 ───
+    ┌── tests/move_check/typing/module_call_explicit_type_arguments_invalid.move:12:36 ───
     │
- 14 │         foo<V, T>(u, v);
-    │         ^^^^^^^^^^^^^^^ Invalid call of '0x8675309::M::foo'. Invalid argument for parameter 'y'
-    ·
  12 │     fun t2<T, U, V>(t: T, u: U, v: V) {
     │                                    - The type: 'V'
-    ·
+ 13 │         foo<U, u64>(t, 0);
  14 │         foo<V, T>(u, v);
+    │         ^^^^^^^^^^^^^^^ Invalid call of '0x8675309::M::foo'. Invalid argument for parameter 'y'
     │                - Is not compatible with: 'T'
     │
 

--- a/language/move-lang/tests/move_check/typing/module_call_internal.exp
+++ b/language/move-lang/tests/move_check/typing/module_call_internal.exp
@@ -1,11 +1,11 @@
 error: 
 
-    ┌── tests/move_check/typing/module_call_internal.move:10:9 ───
+    ┌── tests/move_check/typing/module_call_internal.move:4:9 ───
     │
- 10 │         X::foo()
-    │         ^^^^^^^^ Invalid call to '0x1::X::foo'
-    ·
   4 │     fun foo() {}
     │         --- This function is internal to its module. Only 'public' functions can be called outside of their module
+    ·
+ 10 │         X::foo()
+    │         ^^^^^^^^ Invalid call to '0x1::X::foo'
     │
 

--- a/language/move-lang/tests/move_check/typing/module_call_wrong_argument_in_list.exp
+++ b/language/move-lang/tests/move_check/typing/module_call_wrong_argument_in_list.exp
@@ -1,252 +1,216 @@
 error: 
 
-    ┌── tests/move_check/typing/module_call_wrong_argument_in_list.move:20:9 ───
+    ┌── tests/move_check/typing/module_call_wrong_argument_in_list.move:16:23 ───
     │
+ 16 │     public fun foo(a: address, u: u64, s: S) {
+    │                       ------- Is not compatible with: 'address'
+    ·
  20 │         foo(false, 0, S{});
     │         ^^^^^^^^^^^^^^^^^^ Invalid call of '0x1::M::foo'. Invalid argument for parameter 'a'
-    ·
- 20 │         foo(false, 0, S{});
     │             ----- The type: 'bool'
-    ·
- 16 │     public fun foo(a: address, u: u64, s: S) {
-    │                       ------- Is not compatible with: 'address'
     │
 
 error: 
 
-    ┌── tests/move_check/typing/module_call_wrong_argument_in_list.move:21:9 ───
+    ┌── tests/move_check/typing/module_call_wrong_argument_in_list.move:16:35 ───
     │
+ 16 │     public fun foo(a: address, u: u64, s: S) {
+    │                                   --- Is not compatible with: 'u64'
+    ·
  21 │         foo(0x0, false, S{});
     │         ^^^^^^^^^^^^^^^^^^^^ Invalid call of '0x1::M::foo'. Invalid argument for parameter 'u'
-    ·
- 21 │         foo(0x0, false, S{});
     │                  ----- The type: 'bool'
-    ·
- 16 │     public fun foo(a: address, u: u64, s: S) {
-    │                                   --- Is not compatible with: 'u64'
     │
 
 error: 
 
-    ┌── tests/move_check/typing/module_call_wrong_argument_in_list.move:22:9 ───
+    ┌── tests/move_check/typing/module_call_wrong_argument_in_list.move:16:43 ───
     │
+ 16 │     public fun foo(a: address, u: u64, s: S) {
+    │                                           - Is not compatible with: '0x1::M::S'
+    ·
  22 │         foo(0x0, 0, false);
     │         ^^^^^^^^^^^^^^^^^^ Invalid call of '0x1::M::foo'. Invalid argument for parameter 's'
-    ·
- 22 │         foo(0x0, 0, false);
     │                     ----- The type: 'bool'
-    ·
- 16 │     public fun foo(a: address, u: u64, s: S) {
-    │                                           - Is not compatible with: '0x1::M::S'
     │
 
 error: 
 
-    ┌── tests/move_check/typing/module_call_wrong_argument_in_list.move:23:9 ───
+    ┌── tests/move_check/typing/module_call_wrong_argument_in_list.move:16:35 ───
     │
- 23 │         foo(0x0, false, false);
-    │         ^^^^^^^^^^^^^^^^^^^^^^ Invalid call of '0x1::M::foo'. Invalid argument for parameter 'u'
-    ·
- 23 │         foo(0x0, false, false);
-    │                  ----- The type: 'bool'
-    ·
  16 │     public fun foo(a: address, u: u64, s: S) {
     │                                   --- Is not compatible with: 'u64'
+    ·
+ 23 │         foo(0x0, false, false);
+    │         ^^^^^^^^^^^^^^^^^^^^^^ Invalid call of '0x1::M::foo'. Invalid argument for parameter 'u'
+    │                  ----- The type: 'bool'
     │
 
 error: 
 
-    ┌── tests/move_check/typing/module_call_wrong_argument_in_list.move:23:9 ───
+    ┌── tests/move_check/typing/module_call_wrong_argument_in_list.move:16:43 ───
     │
+ 16 │     public fun foo(a: address, u: u64, s: S) {
+    │                                           - Is not compatible with: '0x1::M::S'
+    ·
  23 │         foo(0x0, false, false);
     │         ^^^^^^^^^^^^^^^^^^^^^^ Invalid call of '0x1::M::foo'. Invalid argument for parameter 's'
-    ·
- 23 │         foo(0x0, false, false);
     │                         ----- The type: 'bool'
-    ·
- 16 │     public fun foo(a: address, u: u64, s: S) {
-    │                                           - Is not compatible with: '0x1::M::S'
     │
 
 error: 
 
-    ┌── tests/move_check/typing/module_call_wrong_argument_in_list.move:24:9 ───
+    ┌── tests/move_check/typing/module_call_wrong_argument_in_list.move:16:23 ───
     │
+ 16 │     public fun foo(a: address, u: u64, s: S) {
+    │                       ------- Is not compatible with: 'address'
+    ·
  24 │         foo(false, 0, false);
     │         ^^^^^^^^^^^^^^^^^^^^ Invalid call of '0x1::M::foo'. Invalid argument for parameter 'a'
-    ·
- 24 │         foo(false, 0, false);
     │             ----- The type: 'bool'
-    ·
- 16 │     public fun foo(a: address, u: u64, s: S) {
-    │                       ------- Is not compatible with: 'address'
     │
 
 error: 
 
-    ┌── tests/move_check/typing/module_call_wrong_argument_in_list.move:24:9 ───
+    ┌── tests/move_check/typing/module_call_wrong_argument_in_list.move:16:43 ───
     │
- 24 │         foo(false, 0, false);
-    │         ^^^^^^^^^^^^^^^^^^^^ Invalid call of '0x1::M::foo'. Invalid argument for parameter 's'
-    ·
- 24 │         foo(false, 0, false);
-    │                       ----- The type: 'bool'
-    ·
  16 │     public fun foo(a: address, u: u64, s: S) {
     │                                           - Is not compatible with: '0x1::M::S'
+    ·
+ 24 │         foo(false, 0, false);
+    │         ^^^^^^^^^^^^^^^^^^^^ Invalid call of '0x1::M::foo'. Invalid argument for parameter 's'
+    │                       ----- The type: 'bool'
     │
 
 error: 
 
-    ┌── tests/move_check/typing/module_call_wrong_argument_in_list.move:25:9 ───
+    ┌── tests/move_check/typing/module_call_wrong_argument_in_list.move:16:23 ───
     │
+ 16 │     public fun foo(a: address, u: u64, s: S) {
+    │                       ------- Is not compatible with: 'address'
+    ·
  25 │         foo(false, false, S{});
     │         ^^^^^^^^^^^^^^^^^^^^^^ Invalid call of '0x1::M::foo'. Invalid argument for parameter 'a'
-    ·
- 25 │         foo(false, false, S{});
     │             ----- The type: 'bool'
-    ·
- 16 │     public fun foo(a: address, u: u64, s: S) {
-    │                       ------- Is not compatible with: 'address'
     │
 
 error: 
 
-    ┌── tests/move_check/typing/module_call_wrong_argument_in_list.move:25:9 ───
+    ┌── tests/move_check/typing/module_call_wrong_argument_in_list.move:16:35 ───
     │
+ 16 │     public fun foo(a: address, u: u64, s: S) {
+    │                                   --- Is not compatible with: 'u64'
+    ·
  25 │         foo(false, false, S{});
     │         ^^^^^^^^^^^^^^^^^^^^^^ Invalid call of '0x1::M::foo'. Invalid argument for parameter 'u'
-    ·
- 25 │         foo(false, false, S{});
     │                    ----- The type: 'bool'
-    ·
- 16 │     public fun foo(a: address, u: u64, s: S) {
-    │                                   --- Is not compatible with: 'u64'
     │
 
 error: 
 
-    ┌── tests/move_check/typing/module_call_wrong_argument_in_list.move:29:9 ───
+    ┌── tests/move_check/typing/module_call_wrong_argument_in_list.move:8:23 ───
     │
+  8 │     public fun foo(a: address, u: u64, s: S) {
+    │                       ------- Is not compatible with: 'address'
+    ·
  29 │         X::foo(false, 0, X::s());
     │         ^^^^^^^^^^^^^^^^^^^^^^^^ Invalid call of '0x1::X::foo'. Invalid argument for parameter 'a'
-    ·
- 29 │         X::foo(false, 0, X::s());
     │                ----- The type: 'bool'
-    ·
-  8 │     public fun foo(a: address, u: u64, s: S) {
-    │                       ------- Is not compatible with: 'address'
     │
 
 error: 
 
-    ┌── tests/move_check/typing/module_call_wrong_argument_in_list.move:30:9 ───
+    ┌── tests/move_check/typing/module_call_wrong_argument_in_list.move:8:35 ───
     │
+  8 │     public fun foo(a: address, u: u64, s: S) {
+    │                                   --- Is not compatible with: 'u64'
+    ·
  30 │         X::foo(0x0, false, X::s());
     │         ^^^^^^^^^^^^^^^^^^^^^^^^^^ Invalid call of '0x1::X::foo'. Invalid argument for parameter 'u'
-    ·
- 30 │         X::foo(0x0, false, X::s());
     │                     ----- The type: 'bool'
-    ·
-  8 │     public fun foo(a: address, u: u64, s: S) {
-    │                                   --- Is not compatible with: 'u64'
     │
 
 error: 
 
-    ┌── tests/move_check/typing/module_call_wrong_argument_in_list.move:31:9 ───
+    ┌── tests/move_check/typing/module_call_wrong_argument_in_list.move:8:43 ───
     │
+  8 │     public fun foo(a: address, u: u64, s: S) {
+    │                                           - Is not compatible with: '0x1::X::S'
+    ·
  31 │         X::foo(0x0, 0, S{});
     │         ^^^^^^^^^^^^^^^^^^^ Invalid call of '0x1::X::foo'. Invalid argument for parameter 's'
-    ·
- 31 │         X::foo(0x0, 0, S{});
     │                        --- The type: '0x1::M::S'
-    ·
-  8 │     public fun foo(a: address, u: u64, s: S) {
-    │                                           - Is not compatible with: '0x1::X::S'
     │
 
 error: 
 
-    ┌── tests/move_check/typing/module_call_wrong_argument_in_list.move:32:9 ───
+    ┌── tests/move_check/typing/module_call_wrong_argument_in_list.move:8:35 ───
     │
+  8 │     public fun foo(a: address, u: u64, s: S) {
+    │                                   --- Is not compatible with: 'u64'
+    ·
  32 │         X::foo(0x0, false, S{});
     │         ^^^^^^^^^^^^^^^^^^^^^^^ Invalid call of '0x1::X::foo'. Invalid argument for parameter 'u'
-    ·
- 32 │         X::foo(0x0, false, S{});
     │                     ----- The type: 'bool'
-    ·
-  8 │     public fun foo(a: address, u: u64, s: S) {
-    │                                   --- Is not compatible with: 'u64'
     │
 
 error: 
 
-    ┌── tests/move_check/typing/module_call_wrong_argument_in_list.move:32:9 ───
+    ┌── tests/move_check/typing/module_call_wrong_argument_in_list.move:8:43 ───
     │
+  8 │     public fun foo(a: address, u: u64, s: S) {
+    │                                           - Is not compatible with: '0x1::X::S'
+    ·
  32 │         X::foo(0x0, false, S{});
     │         ^^^^^^^^^^^^^^^^^^^^^^^ Invalid call of '0x1::X::foo'. Invalid argument for parameter 's'
-    ·
- 32 │         X::foo(0x0, false, S{});
     │                            --- The type: '0x1::M::S'
-    ·
-  8 │     public fun foo(a: address, u: u64, s: S) {
-    │                                           - Is not compatible with: '0x1::X::S'
     │
 
 error: 
 
-    ┌── tests/move_check/typing/module_call_wrong_argument_in_list.move:33:9 ───
+    ┌── tests/move_check/typing/module_call_wrong_argument_in_list.move:8:23 ───
     │
+  8 │     public fun foo(a: address, u: u64, s: S) {
+    │                       ------- Is not compatible with: 'address'
+    ·
  33 │         X::foo(false, 0, S{});
     │         ^^^^^^^^^^^^^^^^^^^^^ Invalid call of '0x1::X::foo'. Invalid argument for parameter 'a'
-    ·
- 33 │         X::foo(false, 0, S{});
     │                ----- The type: 'bool'
-    ·
-  8 │     public fun foo(a: address, u: u64, s: S) {
-    │                       ------- Is not compatible with: 'address'
     │
 
 error: 
 
-    ┌── tests/move_check/typing/module_call_wrong_argument_in_list.move:33:9 ───
+    ┌── tests/move_check/typing/module_call_wrong_argument_in_list.move:8:43 ───
     │
- 33 │         X::foo(false, 0, S{});
-    │         ^^^^^^^^^^^^^^^^^^^^^ Invalid call of '0x1::X::foo'. Invalid argument for parameter 's'
-    ·
- 33 │         X::foo(false, 0, S{});
-    │                          --- The type: '0x1::M::S'
-    ·
   8 │     public fun foo(a: address, u: u64, s: S) {
     │                                           - Is not compatible with: '0x1::X::S'
+    ·
+ 33 │         X::foo(false, 0, S{});
+    │         ^^^^^^^^^^^^^^^^^^^^^ Invalid call of '0x1::X::foo'. Invalid argument for parameter 's'
+    │                          --- The type: '0x1::M::S'
     │
 
 error: 
 
-    ┌── tests/move_check/typing/module_call_wrong_argument_in_list.move:34:9 ───
+    ┌── tests/move_check/typing/module_call_wrong_argument_in_list.move:8:23 ───
     │
- 34 │         X::foo(false, false, X::s());
-    │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Invalid call of '0x1::X::foo'. Invalid argument for parameter 'a'
-    ·
- 34 │         X::foo(false, false, X::s());
-    │                ----- The type: 'bool'
-    ·
   8 │     public fun foo(a: address, u: u64, s: S) {
     │                       ------- Is not compatible with: 'address'
+    ·
+ 34 │         X::foo(false, false, X::s());
+    │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Invalid call of '0x1::X::foo'. Invalid argument for parameter 'a'
+    │                ----- The type: 'bool'
     │
 
 error: 
 
-    ┌── tests/move_check/typing/module_call_wrong_argument_in_list.move:34:9 ───
+    ┌── tests/move_check/typing/module_call_wrong_argument_in_list.move:8:35 ───
     │
- 34 │         X::foo(false, false, X::s());
-    │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Invalid call of '0x1::X::foo'. Invalid argument for parameter 'u'
-    ·
- 34 │         X::foo(false, false, X::s());
-    │                       ----- The type: 'bool'
-    ·
   8 │     public fun foo(a: address, u: u64, s: S) {
     │                                   --- Is not compatible with: 'u64'
+    ·
+ 34 │         X::foo(false, false, X::s());
+    │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Invalid call of '0x1::X::foo'. Invalid argument for parameter 'u'
+    │                       ----- The type: 'bool'
     │
 

--- a/language/move-lang/tests/move_check/typing/module_call_wrong_arity.exp
+++ b/language/move-lang/tests/move_check/typing/module_call_wrong_arity.exp
@@ -4,8 +4,6 @@ error:
     │
  27 │         X::foo(1);
     │         ^^^^^^^^^ Invalid call of '0x1::X::foo'. The call expected 0 argument(s) but got 1
-    ·
- 27 │         X::foo(1);
     │               --- Found 1 argument(s) here
     │
 
@@ -15,8 +13,6 @@ error:
     │
  28 │         X::foo(1, 2);
     │         ^^^^^^^^^^^^ Invalid call of '0x1::X::foo'. The call expected 0 argument(s) but got 2
-    ·
- 28 │         X::foo(1, 2);
     │               ------ Found 2 argument(s) here
     │
 
@@ -26,8 +22,6 @@ error:
     │
  29 │         X::bar();
     │         ^^^^^^^^ Invalid call of '0x1::X::bar'. The call expected 1 argument(s) but got 0
-    ·
- 29 │         X::bar();
     │               -- Found 0 argument(s) here
     │
 
@@ -37,8 +31,6 @@ error:
     │
  30 │         X::bar(1, 2);
     │         ^^^^^^^^^^^^ Invalid call of '0x1::X::bar'. The call expected 1 argument(s) but got 2
-    ·
- 30 │         X::bar(1, 2);
     │               ------ Found 2 argument(s) here
     │
 
@@ -48,8 +40,6 @@ error:
     │
  31 │         X::baz<u64, u64>();
     │         ^^^^^^^^^^^^^^^^^^ Invalid call of '0x1::X::baz'. The call expected 2 argument(s) but got 0
-    ·
- 31 │         X::baz<u64, u64>();
     │                         -- Found 0 argument(s) here
     │
 
@@ -59,8 +49,6 @@ error:
     │
  32 │         X::baz<u64, u64>(1);
     │         ^^^^^^^^^^^^^^^^^^^ Invalid call of '0x1::X::baz'. The call expected 2 argument(s) but got 1
-    ·
- 32 │         X::baz<u64, u64>(1);
     │                         --- Found 1 argument(s) here
     │
 
@@ -70,8 +58,6 @@ error:
     │
  33 │         X::baz(1, 2, 3);
     │         ^^^^^^^^^^^^^^^ Invalid call of '0x1::X::baz'. The call expected 2 argument(s) but got 3
-    ·
- 33 │         X::baz(1, 2, 3);
     │               --------- Found 3 argument(s) here
     │
 
@@ -81,8 +67,6 @@ error:
     │
  37 │         foo(1);
     │         ^^^^^^ Invalid call of '0x1::M::foo'. The call expected 0 argument(s) but got 1
-    ·
- 37 │         foo(1);
     │            --- Found 1 argument(s) here
     │
 
@@ -92,8 +76,6 @@ error:
     │
  38 │         foo(1, 2);
     │         ^^^^^^^^^ Invalid call of '0x1::M::foo'. The call expected 0 argument(s) but got 2
-    ·
- 38 │         foo(1, 2);
     │            ------ Found 2 argument(s) here
     │
 
@@ -103,8 +85,6 @@ error:
     │
  39 │         bar();
     │         ^^^^^ Invalid call of '0x1::M::bar'. The call expected 1 argument(s) but got 0
-    ·
- 39 │         bar();
     │            -- Found 0 argument(s) here
     │
 
@@ -114,8 +94,6 @@ error:
     │
  40 │         bar(1, 2);
     │         ^^^^^^^^^ Invalid call of '0x1::M::bar'. The call expected 1 argument(s) but got 2
-    ·
- 40 │         bar(1, 2);
     │            ------ Found 2 argument(s) here
     │
 
@@ -125,8 +103,6 @@ error:
     │
  41 │         baz<u64, u64>();
     │         ^^^^^^^^^^^^^^^ Invalid call of '0x1::M::baz'. The call expected 2 argument(s) but got 0
-    ·
- 41 │         baz<u64, u64>();
     │                      -- Found 0 argument(s) here
     │
 
@@ -136,8 +112,6 @@ error:
     │
  42 │         baz<u64, u64>(1);
     │         ^^^^^^^^^^^^^^^^ Invalid call of '0x1::M::baz'. The call expected 2 argument(s) but got 1
-    ·
- 42 │         baz<u64, u64>(1);
     │                      --- Found 1 argument(s) here
     │
 
@@ -147,8 +121,6 @@ error:
     │
  43 │         baz(1, 2, 3);
     │         ^^^^^^^^^^^^ Invalid call of '0x1::M::baz'. The call expected 2 argument(s) but got 3
-    ·
- 43 │         baz(1, 2, 3);
     │            --------- Found 3 argument(s) here
     │
 

--- a/language/move-lang/tests/move_check/typing/module_call_wrong_single_argument.exp
+++ b/language/move-lang/tests/move_check/typing/module_call_wrong_single_argument.exp
@@ -1,98 +1,84 @@
 error: 
 
-    ┌── tests/move_check/typing/module_call_wrong_single_argument.move:24:9 ───
+    ┌── tests/move_check/typing/module_call_wrong_single_argument.move:17:23 ───
     │
- 24 │         foo(0);
-    │         ^^^^^^ Invalid call of '0x1::M::foo'. Invalid argument for parameter 's'
-    ·
- 24 │         foo(0);
-    │             - The type: integer
-    ·
  17 │     public fun foo(s: S) {
     │                       - Is not compatible with: '0x1::M::S'
+    ·
+ 24 │         foo(0);
+    │         ^^^^^^ Invalid call of '0x1::M::foo'. Invalid argument for parameter 's'
+    │             - The type: integer
     │
 
 error: 
 
-    ┌── tests/move_check/typing/module_call_wrong_single_argument.move:25:9 ───
+    ┌── tests/move_check/typing/module_call_wrong_single_argument.move:20:23 ───
     │
- 25 │         bar(S{});
-    │         ^^^^^^^^ Invalid call of '0x1::M::bar'. Invalid argument for parameter 'x'
+ 20 │     public fun bar(x: u64) {
+    │                       --- Is not compatible with: 'u64'
     ·
  25 │         bar(S{});
+    │         ^^^^^^^^ Invalid call of '0x1::M::bar'. Invalid argument for parameter 'x'
     │             --- The type: '0x1::M::S'
-    ·
- 20 │     public fun bar(x: u64) {
-    │                       --- Is not compatible with: 'u64'
     │
 
 error: 
 
-    ┌── tests/move_check/typing/module_call_wrong_single_argument.move:26:9 ───
+    ┌── tests/move_check/typing/module_call_wrong_single_argument.move:20:23 ───
     │
+ 20 │     public fun bar(x: u64) {
+    │                       --- Is not compatible with: 'u64'
+    ·
  26 │         bar(0x0);
     │         ^^^^^^^^ Invalid call of '0x1::M::bar'. Invalid argument for parameter 'x'
-    ·
- 26 │         bar(0x0);
     │             --- The type: 'address'
-    ·
- 20 │     public fun bar(x: u64) {
-    │                       --- Is not compatible with: 'u64'
     │
 
 error: 
 
-    ┌── tests/move_check/typing/module_call_wrong_single_argument.move:30:9 ───
+    ┌── tests/move_check/typing/module_call_wrong_single_argument.move:6:23 ───
     │
+  6 │     public fun foo(s: S) {
+    │                       - Is not compatible with: '0x1::X::S'
+    ·
  30 │         X::foo(S{});
     │         ^^^^^^^^^^^ Invalid call of '0x1::X::foo'. Invalid argument for parameter 's'
-    ·
- 30 │         X::foo(S{});
     │                --- The type: '0x1::M::S'
-    ·
-  6 │     public fun foo(s: S) {
-    │                       - Is not compatible with: '0x1::X::S'
     │
 
 error: 
 
-    ┌── tests/move_check/typing/module_call_wrong_single_argument.move:31:9 ───
+    ┌── tests/move_check/typing/module_call_wrong_single_argument.move:6:23 ───
     │
+  6 │     public fun foo(s: S) {
+    │                       - Is not compatible with: '0x1::X::S'
+    ·
  31 │         X::foo(0);
     │         ^^^^^^^^^ Invalid call of '0x1::X::foo'. Invalid argument for parameter 's'
-    ·
- 31 │         X::foo(0);
     │                - The type: integer
-    ·
-  6 │     public fun foo(s: S) {
-    │                       - Is not compatible with: '0x1::X::S'
     │
 
 error: 
 
-    ┌── tests/move_check/typing/module_call_wrong_single_argument.move:32:9 ───
+    ┌── tests/move_check/typing/module_call_wrong_single_argument.move:9:23 ───
     │
+  9 │     public fun bar(x: u64) {
+    │                       --- Is not compatible with: 'u64'
+    ·
  32 │         X::bar(S{});
     │         ^^^^^^^^^^^ Invalid call of '0x1::X::bar'. Invalid argument for parameter 'x'
-    ·
- 32 │         X::bar(S{});
     │                --- The type: '0x1::M::S'
-    ·
-  9 │     public fun bar(x: u64) {
-    │                       --- Is not compatible with: 'u64'
     │
 
 error: 
 
-    ┌── tests/move_check/typing/module_call_wrong_single_argument.move:33:9 ───
+    ┌── tests/move_check/typing/module_call_wrong_single_argument.move:9:23 ───
     │
- 33 │         X::bar(false);
-    │         ^^^^^^^^^^^^^ Invalid call of '0x1::X::bar'. Invalid argument for parameter 'x'
-    ·
- 33 │         X::bar(false);
-    │                ----- The type: 'bool'
-    ·
   9 │     public fun bar(x: u64) {
     │                       --- Is not compatible with: 'u64'
+    ·
+ 33 │         X::bar(false);
+    │         ^^^^^^^^^^^^^ Invalid call of '0x1::X::bar'. Invalid argument for parameter 'x'
+    │                ----- The type: 'bool'
     │
 

--- a/language/move-lang/tests/move_check/typing/mutable_borrow_from_immutable.exp
+++ b/language/move-lang/tests/move_check/typing/mutable_borrow_from_immutable.exp
@@ -4,8 +4,6 @@ error:
    │
  6 │         &mut (&s).v;
    │         ^^^^^^^^^^^ Invalid mutable borrow from an immutable reference
-   ·
- 6 │         &mut (&s).v;
    │              ---- Immutable because of this position
    │
 
@@ -15,31 +13,29 @@ error:
    │
  7 │         &mut (&s.x).f;
    │         ^^^^^^^^^^^^^ Invalid mutable borrow from an immutable reference
-   ·
- 7 │         &mut (&s.x).f;
    │              ------ Immutable because of this position
    │
 
 error: 
 
-    ┌── tests/move_check/typing/mutable_borrow_from_immutable.move:10:9 ───
+    ┌── tests/move_check/typing/mutable_borrow_from_immutable.move:8:20 ───
     │
- 10 │         &mut sref.v;
-    │         ^^^^^^^^^^^ Invalid mutable borrow from an immutable reference
-    ·
   8 │         let sref = &s;
     │                    -- Immutable because of this position
+  9 │         let xref = &s.x;
+ 10 │         &mut sref.v;
+    │         ^^^^^^^^^^^ Invalid mutable borrow from an immutable reference
     │
 
 error: 
 
-    ┌── tests/move_check/typing/mutable_borrow_from_immutable.move:11:9 ───
+    ┌── tests/move_check/typing/mutable_borrow_from_immutable.move:9:20 ───
     │
- 11 │         &mut xref.v;
-    │         ^^^^^^^^^^^ Invalid mutable borrow from an immutable reference
-    ·
   9 │         let xref = &s.x;
     │                    ---- Immutable because of this position
+ 10 │         &mut sref.v;
+ 11 │         &mut xref.v;
+    │         ^^^^^^^^^^^ Invalid mutable borrow from an immutable reference
     │
 
 error: 
@@ -52,23 +48,22 @@ error:
 
 error: 
 
-    ┌── tests/move_check/typing/mutable_borrow_from_immutable.move:15:9 ───
+    ┌── tests/move_check/typing/mutable_borrow_from_immutable.move:14:22 ───
     │
- 15 │         x.f = x.f + 1;
-    │         ^^^ Invalid mutable borrow from an immutable reference
-    ·
  14 │     fun t2(s: &S, x: &X) {
     │                      -- Immutable because of this position
+ 15 │         x.f = x.f + 1;
+    │         ^^^ Invalid mutable borrow from an immutable reference
     │
 
 error: 
 
-    ┌── tests/move_check/typing/mutable_borrow_from_immutable.move:16:9 ───
+    ┌── tests/move_check/typing/mutable_borrow_from_immutable.move:14:15 ───
     │
- 16 │         s.x.f = s.x.f + 1
-    │         ^^^^^ Invalid mutable borrow from an immutable reference
-    ·
  14 │     fun t2(s: &S, x: &X) {
     │               -- Immutable because of this position
+ 15 │         x.f = x.f + 1;
+ 16 │         s.x.f = s.x.f + 1
+    │         ^^^^^ Invalid mutable borrow from an immutable reference
     │
 

--- a/language/move-lang/tests/move_check/typing/mutable_eq_and_neq_invalid.exp
+++ b/language/move-lang/tests/move_check/typing/mutable_eq_and_neq_invalid.exp
@@ -1,22 +1,20 @@
 error: 
 
-   ┌── tests/move_check/typing/mutable_eq_and_neq_invalid.move:7:20 ───
+   ┌── tests/move_check/typing/mutable_eq_and_neq_invalid.move:6:17 ───
    │
- 7 │         let comp = (&mut p.b1) == (&mut p.b2);
-   │                    ^^^^^^^^^^^ Invalid freeze.
-   ·
  6 │         let f = &mut p.b1.f;
    │                 ----------- Field 'f' is still being mutably borrowed by this reference
+ 7 │         let comp = (&mut p.b1) == (&mut p.b2);
+   │                    ^^^^^^^^^^^ Invalid freeze.
    │
 
 error: 
 
-    ┌── tests/move_check/typing/mutable_eq_and_neq_invalid.move:13:20 ───
+    ┌── tests/move_check/typing/mutable_eq_and_neq_invalid.move:12:17 ───
     │
- 13 │         let comp = (&mut p.b1) != (&mut p.b2);
-    │                    ^^^^^^^^^^^ Invalid freeze.
-    ·
  12 │         let f = &mut p.b1.f;
     │                 ----------- Field 'f' is still being mutably borrowed by this reference
+ 13 │         let comp = (&mut p.b1) != (&mut p.b2);
+    │                    ^^^^^^^^^^^ Invalid freeze.
     │
 

--- a/language/move-lang/tests/move_check/typing/mutate_immutable.exp
+++ b/language/move-lang/tests/move_check/typing/mutate_immutable.exp
@@ -3,13 +3,9 @@ error:
    ┌── tests/move_check/typing/mutate_immutable.move:5:10 ───
    │
  5 │         *(s: &S) = S { f: 0 };
-   │          ^^^^^^^ Invalid mutation. Expected a mutable reference
-   ·
- 5 │         *(s: &S) = S { f: 0 };
-   │              -- The type: '&0x8675309::M::S'
-   ·
- 5 │         *(s: &S) = S { f: 0 };
    │          ------- Is not a subtype of: '&mut _'
+   │          ^^^^^^^ Invalid mutation. Expected a mutable reference
+   │              -- The type: '&0x8675309::M::S'
    │
 
 error: 
@@ -17,26 +13,19 @@ error:
    ┌── tests/move_check/typing/mutate_immutable.move:6:10 ───
    │
  6 │         *&0 = 1;
-   │          ^^ Invalid mutation. Expected a mutable reference
-   ·
- 6 │         *&0 = 1;
    │          -- The type: '&{integer}'
-   ·
- 6 │         *&0 = 1;
    │          -- Is not a subtype of: '&mut _'
+   │          ^^ Invalid mutation. Expected a mutable reference
    │
 
 error: 
 
-    ┌── tests/move_check/typing/mutate_immutable.move:10:10 ───
+    ┌── tests/move_check/typing/mutate_immutable.move:9:20 ───
     │
- 10 │         *x_ref = 0;
-    │          ^^^^^ Invalid mutation. Expected a mutable reference
-    ·
   9 │         let x_ref: &u64 = x_ref;
     │                    ---- The type: '&u64'
-    ·
  10 │         *x_ref = 0;
     │          ----- Is not a subtype of: '&mut _'
+    │          ^^^^^ Invalid mutation. Expected a mutable reference
     │
 

--- a/language/move-lang/tests/move_check/typing/mutate_invalid.exp
+++ b/language/move-lang/tests/move_check/typing/mutate_invalid.exp
@@ -3,27 +3,21 @@ error:
    ┌── tests/move_check/typing/mutate_invalid.move:6:10 ───
    │
  6 │         *&mut 0 = false;
-   │          ^^^^^^ Invalid mutation. New value is not valid for the reference
-   ·
- 6 │         *&mut 0 = false;
    │          ------ The type: integer
-   ·
- 6 │         *&mut 0 = false;
+   │          ^^^^^^ Invalid mutation. New value is not valid for the reference
    │                   ----- Is not compatible with: 'bool'
    │
 
 error: 
 
-   ┌── tests/move_check/typing/mutate_invalid.move:7:10 ───
+   ┌── tests/move_check/typing/mutate_invalid.move:2:19 ───
    │
- 7 │         *&mut S{f:0}.f = &1;
-   │          ^^^^^^^^^^^^^ Invalid mutation. New value is not valid for the reference
-   ·
- 7 │         *&mut S{f:0}.f = &1;
-   │                          -- The type: '&{integer}'
-   ·
  2 │     struct S { f: u64 }
    │                   --- Is not compatible with: 'u64'
+   ·
+ 7 │         *&mut S{f:0}.f = &1;
+   │          ^^^^^^^^^^^^^ Invalid mutation. New value is not valid for the reference
+   │                          -- The type: '&{integer}'
    │
 
 error: 
@@ -32,8 +26,6 @@ error:
     │
   8 │         *foo(&mut 0) = (1, 0);
     │          ^^^^^^^^^^^ Invalid mutation. New value is not valid for the reference
-    ·
-  8 │         *foo(&mut 0) = (1, 0);
     │                        ------ The type: '({integer}, {integer})'
     ·
  23 │     fun foo(x: &mut u64): &mut u64 {
@@ -42,99 +34,84 @@ error:
 
 error: 
 
-   ┌── tests/move_check/typing/mutate_invalid.move:9:9 ───
+   ┌── tests/move_check/typing/mutate_invalid.move:2:19 ───
    │
- 9 │         bar(&mut S{f:0}).f = ();
-   │         ^^^^^^^^^^^^^^^^^^ Invalid mutation. New value is not valid for the reference
-   ·
- 9 │         bar(&mut S{f:0}).f = ();
-   │                              -- The type: '()'
-   ·
  2 │     struct S { f: u64 }
    │                   --- Is not compatible with: 'u64'
+   ·
+ 9 │         bar(&mut S{f:0}).f = ();
+   │         ^^^^^^^^^^^^^^^^^^ Invalid mutation. New value is not valid for the reference
+   │                              -- The type: '()'
    │
 
 error: 
 
-    ┌── tests/move_check/typing/mutate_invalid.move:10:10 ───
+    ┌── tests/move_check/typing/mutate_invalid.move:2:19 ───
     │
+  2 │     struct S { f: u64 }
+    │                   --- Is not compatible with: 'u64'
+    ·
  10 │         *&mut bar(&mut S{f:0}).f = &0;
     │          ^^^^^^^^^^^^^^^^^^^^^^^ Invalid mutation. New value is not valid for the reference
-    ·
- 10 │         *&mut bar(&mut S{f:0}).f = &0;
     │                                    -- The type: '&{integer}'
-    ·
-  2 │     struct S { f: u64 }
-    │                   --- Is not compatible with: 'u64'
     │
 
 error: 
 
-    ┌── tests/move_check/typing/mutate_invalid.move:11:9 ───
+    ┌── tests/move_check/typing/mutate_invalid.move:2:19 ───
     │
+  2 │     struct S { f: u64 }
+    │                   --- Is not compatible with: 'u64'
+    ·
  11 │         baz().f = false;
     │         ^^^^^^^ Invalid mutation. New value is not valid for the reference
-    ·
- 11 │         baz().f = false;
     │                   ----- The type: 'bool'
-    ·
-  2 │     struct S { f: u64 }
-    │                   --- Is not compatible with: 'u64'
     │
 
 error: 
 
-    ┌── tests/move_check/typing/mutate_invalid.move:12:10 ───
+    ┌── tests/move_check/typing/mutate_invalid.move:2:19 ───
     │
+  2 │     struct S { f: u64 }
+    │                   --- Is not compatible with: 'u64'
+    ·
  12 │         *&mut baz().f = false;
     │          ^^^^^^^^^^^^ Invalid mutation. New value is not valid for the reference
-    ·
- 12 │         *&mut baz().f = false;
     │                         ----- The type: 'bool'
-    ·
-  2 │     struct S { f: u64 }
-    │                   --- Is not compatible with: 'u64'
     │
 
 error: 
 
-    ┌── tests/move_check/typing/mutate_invalid.move:17:10 ───
+    ┌── tests/move_check/typing/mutate_invalid.move:16:22 ───
     │
- 17 │         *r = X { f: 1 };
-    │          ^ Invalid mutation. New value is not valid for the reference
-    ·
- 17 │         *r = X { f: 1 };
-    │              ---------- The type: '0x8675309::M::X'
-    ·
  16 │         let r = &mut S{ f: 0 };
     │                      --------- Is not compatible with: '0x8675309::M::S'
+ 17 │         *r = X { f: 1 };
+    │          ^ Invalid mutation. New value is not valid for the reference
+    │              ---------- The type: '0x8675309::M::X'
     │
 
 error: 
 
-    ┌── tests/move_check/typing/mutate_invalid.move:19:9 ───
+    ┌── tests/move_check/typing/mutate_invalid.move:2:19 ───
     │
+  2 │     struct S { f: u64 }
+    │                   --- Is not compatible with: 'u64'
+    ·
  19 │         r.f = &0;
     │         ^^^ Invalid mutation. New value is not valid for the reference
-    ·
- 19 │         r.f = &0;
     │               -- The type: '&{integer}'
-    ·
-  2 │     struct S { f: u64 }
-    │                   --- Is not compatible with: 'u64'
     │
 
 error: 
 
-    ┌── tests/move_check/typing/mutate_invalid.move:20:10 ───
+    ┌── tests/move_check/typing/mutate_invalid.move:2:19 ───
     │
- 20 │         *&mut r.f = ();
-    │          ^^^^^^^^ Invalid mutation. New value is not valid for the reference
-    ·
- 20 │         *&mut r.f = ();
-    │                     -- The type: '()'
-    ·
   2 │     struct S { f: u64 }
     │                   --- Is not compatible with: 'u64'
+    ·
+ 20 │         *&mut r.f = ();
+    │          ^^^^^^^^ Invalid mutation. New value is not valid for the reference
+    │                     -- The type: '()'
     │
 

--- a/language/move-lang/tests/move_check/typing/mutate_non_ref.exp
+++ b/language/move-lang/tests/move_check/typing/mutate_non_ref.exp
@@ -1,140 +1,120 @@
 error: 
 
-   ┌── tests/move_check/typing/mutate_non_ref.move:7:10 ───
+   ┌── tests/move_check/typing/mutate_non_ref.move:6:13 ───
    │
- 7 │         *u = 1;
-   │          ^ Invalid mutation. Expected a mutable reference
-   ·
  6 │         let u = 0;
    │             - The type: integer
-   ·
  7 │         *u = 1;
    │          - Is not compatible with: '&mut _'
+   │          ^ Invalid mutation. Expected a mutable reference
    │
 
 error: 
 
-    ┌── tests/move_check/typing/mutate_non_ref.move:10:10 ───
+    ┌── tests/move_check/typing/mutate_non_ref.move:9:17 ───
     │
- 10 │         *s = S { f: 0 };
-    │          ^ Invalid mutation. Expected a mutable reference
-    ·
   9 │         let s = S { f: 0 };
     │                 ---------- The type: '0x8675309::M::S'
-    ·
  10 │         *s = S { f: 0 };
     │          - Is not compatible with: '&mut _'
+    │          ^ Invalid mutation. Expected a mutable reference
     │
 
 error: 
 
-    ┌── tests/move_check/typing/mutate_non_ref.move:11:10 ───
+    ┌── tests/move_check/typing/mutate_non_ref.move:2:19 ───
     │
- 11 │         *s.f = 0;
-    │          ^^^ Invalid mutation. Expected a mutable reference
-    ·
   2 │     struct S { f: u64 }
     │                   --- The type: 'u64'
     ·
  11 │         *s.f = 0;
     │          --- Is not compatible with: '&mut _'
+    │          ^^^ Invalid mutation. Expected a mutable reference
     │
 
 error: 
 
-    ┌── tests/move_check/typing/mutate_non_ref.move:14:10 ───
+    ┌── tests/move_check/typing/mutate_non_ref.move:2:19 ───
     │
- 14 │         *s_ref.f = 0;
-    │          ^^^^^^^ Invalid mutation. Expected a mutable reference
-    ·
   2 │     struct S { f: u64 }
     │                   --- The type: 'u64'
     ·
  14 │         *s_ref.f = 0;
     │          ------- Is not compatible with: '&mut _'
+    │          ^^^^^^^ Invalid mutation. Expected a mutable reference
     │
 
 error: 
 
-    ┌── tests/move_check/typing/mutate_non_ref.move:17:10 ───
+    ┌── tests/move_check/typing/mutate_non_ref.move:3:19 ───
     │
- 17 │         *x.s = S { f: 0 };
-    │          ^^^ Invalid mutation. Expected a mutable reference
-    ·
   3 │     struct X { s: S }
     │                   - The type: '0x8675309::M::S'
     ·
  17 │         *x.s = S { f: 0 };
     │          --- Is not compatible with: '&mut _'
+    │          ^^^ Invalid mutation. Expected a mutable reference
     │
 
 error: 
 
-    ┌── tests/move_check/typing/mutate_non_ref.move:17:10 ───
+    ┌── tests/move_check/typing/mutate_non_ref.move:2:12 ───
     │
- 17 │         *x.s = S { f: 0 };
-    │          ^^^ Invalid implicit copy of field 's'. Try adding '*&' to the front of the field access
-    ·
+  2 │     struct S { f: u64 }
+    │            - Is declared as a non-implicitly copyable type here
   3 │     struct X { s: S }
     │                   - The type: '0x8675309::M::S'
     ·
-  2 │     struct S { f: u64 }
-    │            - Is declared as a non-implicitly copyable type here
+ 17 │         *x.s = S { f: 0 };
+    │          ^^^ Invalid implicit copy of field 's'. Try adding '*&' to the front of the field access
     │
 
 error: 
 
-    ┌── tests/move_check/typing/mutate_non_ref.move:18:10 ───
+    ┌── tests/move_check/typing/mutate_non_ref.move:2:19 ───
     │
- 18 │         *x.s.f = 0;
-    │          ^^^^^ Invalid mutation. Expected a mutable reference
-    ·
   2 │     struct S { f: u64 }
     │                   --- The type: 'u64'
     ·
  18 │         *x.s.f = 0;
     │          ----- Is not compatible with: '&mut _'
+    │          ^^^^^ Invalid mutation. Expected a mutable reference
     │
 
 error: 
 
-    ┌── tests/move_check/typing/mutate_non_ref.move:21:10 ───
+    ┌── tests/move_check/typing/mutate_non_ref.move:3:19 ───
     │
- 21 │         *x_ref.s = S{ f: 0 };
-    │          ^^^^^^^ Invalid mutation. Expected a mutable reference
-    ·
   3 │     struct X { s: S }
     │                   - The type: '0x8675309::M::S'
     ·
  21 │         *x_ref.s = S{ f: 0 };
     │          ------- Is not compatible with: '&mut _'
+    │          ^^^^^^^ Invalid mutation. Expected a mutable reference
     │
 
 error: 
 
-    ┌── tests/move_check/typing/mutate_non_ref.move:21:10 ───
+    ┌── tests/move_check/typing/mutate_non_ref.move:2:12 ───
     │
- 21 │         *x_ref.s = S{ f: 0 };
-    │          ^^^^^^^ Invalid implicit copy of field 's'. Try adding '*&' to the front of the field access
-    ·
+  2 │     struct S { f: u64 }
+    │            - Is declared as a non-implicitly copyable type here
   3 │     struct X { s: S }
     │                   - The type: '0x8675309::M::S'
     ·
-  2 │     struct S { f: u64 }
-    │            - Is declared as a non-implicitly copyable type here
+ 21 │         *x_ref.s = S{ f: 0 };
+    │          ^^^^^^^ Invalid implicit copy of field 's'. Try adding '*&' to the front of the field access
     │
 
 error: 
 
-    ┌── tests/move_check/typing/mutate_non_ref.move:22:10 ───
+    ┌── tests/move_check/typing/mutate_non_ref.move:2:19 ───
     │
- 22 │         *x_ref.s.f = 0;
-    │          ^^^^^^^^^ Invalid mutation. Expected a mutable reference
-    ·
   2 │     struct S { f: u64 }
     │                   --- The type: 'u64'
     ·
  22 │         *x_ref.s.f = 0;
     │          --------- Is not compatible with: '&mut _'
+    │          ^^^^^^^^^ Invalid mutation. Expected a mutable reference
     │
 

--- a/language/move-lang/tests/move_check/typing/mutate_resource.exp
+++ b/language/move-lang/tests/move_check/typing/mutate_resource.exp
@@ -1,42 +1,35 @@
 error: 
 
-   ┌── tests/move_check/typing/mutate_resource.move:5:10 ───
+   ┌── tests/move_check/typing/mutate_resource.move:2:5 ───
    │
- 5 │         *r = R {};
-   │          ^ Invalid mutation. Can only assign to references of a copyable type
-   ·
- 4 │     fun t0(r: &mut R) {
-   │                    - The type: '0x8675309::M::R'
-   ·
  2 │     resource struct R {}
    │     -------- Is found to be a non-copyable type here
+ 3 │ 
+ 4 │     fun t0(r: &mut R) {
+   │                    - The type: '0x8675309::M::R'
+ 5 │         *r = R {};
+   │          ^ Invalid mutation. Can only assign to references of a copyable type
    │
 
 error: 
 
-   ┌── tests/move_check/typing/mutate_resource.move:9:10 ───
+   ┌── tests/move_check/typing/mutate_resource.move:8:12 ───
    │
- 9 │         *r = x;
-   │          ^ Invalid mutation. Can only assign to references of a copyable type
-   ·
- 8 │     fun t1<T>(r: &mut T, x: T) {
-   │                       - The type: 'T'
-   ·
  8 │     fun t1<T>(r: &mut T, x: T) {
    │            - Is found to be a non-copyable type here
+   │                       - The type: 'T'
+ 9 │         *r = x;
+   │          ^ Invalid mutation. Can only assign to references of a copyable type
    │
 
 error: 
 
-    ┌── tests/move_check/typing/mutate_resource.move:13:10 ───
+    ┌── tests/move_check/typing/mutate_resource.move:12:15 ───
     │
- 13 │         *r = x;
-    │          ^ Invalid mutation. Can only assign to references of a copyable type
-    ·
- 12 │     fun t2<T: resource>(r: &mut T, x: T) {
-    │                                 - The type: 'T'
-    ·
  12 │     fun t2<T: resource>(r: &mut T, x: T) {
     │               -------- Is found to be a non-copyable type here
+    │                                 - The type: 'T'
+ 13 │         *r = x;
+    │          ^ Invalid mutation. Can only assign to references of a copyable type
     │
 

--- a/language/move-lang/tests/move_check/typing/neq_invalid.exp
+++ b/language/move-lang/tests/move_check/typing/neq_invalid.exp
@@ -1,99 +1,78 @@
 error: 
 
-    ┌── tests/move_check/typing/neq_invalid.move:13:20 ───
+    ┌── tests/move_check/typing/neq_invalid.move:13:13 ───
     │
  13 │         (0: u8) != (1: u128);
-    │                    ^^^^^^^^^ Incompatible arguments to '!='
-    ·
- 13 │         (0: u8) != (1: u128);
     │             -- The type: 'u8'
-    ·
- 13 │         (0: u8) != (1: u128);
+    │                    ^^^^^^^^^ Incompatible arguments to '!='
     │                        ---- Is not compatible with: 'u128'
     │
 
 error: 
 
-    ┌── tests/move_check/typing/neq_invalid.move:14:14 ───
+    ┌── tests/move_check/typing/neq_invalid.move:14:9 ───
     │
  14 │         0 != false;
-    │              ^^^^^ Incompatible arguments to '!='
-    ·
- 14 │         0 != false;
     │         - The type: integer
-    ·
- 14 │         0 != false;
     │              ----- Is not compatible with: 'bool'
+    │              ^^^^^ Incompatible arguments to '!='
     │
 
 error: 
 
-    ┌── tests/move_check/typing/neq_invalid.move:15:15 ───
+    ┌── tests/move_check/typing/neq_invalid.move:15:9 ───
     │
- 15 │         &0 != 1;
-    │               ^ Incompatible arguments to '!='
-    ·
- 15 │         &0 != 1;
-    │               - The type: integer
-    ·
  15 │         &0 != 1;
     │         -- Is not compatible with: '&{integer}'
+    │               - The type: integer
+    │               ^ Incompatible arguments to '!='
     │
 
 error: 
 
-    ┌── tests/move_check/typing/neq_invalid.move:16:14 ───
+    ┌── tests/move_check/typing/neq_invalid.move:16:9 ───
     │
- 16 │         1 != &0;
-    │              ^^ Incompatible arguments to '!='
-    ·
  16 │         1 != &0;
     │         - The type: integer
-    ·
- 16 │         1 != &0;
     │              -- Is not compatible with: '&{integer}'
+    │              ^^ Incompatible arguments to '!='
     │
 
 error: 
 
-    ┌── tests/move_check/typing/neq_invalid.move:17:14 ───
+    ┌── tests/move_check/typing/neq_invalid.move:12:37 ───
     │
- 17 │         s != s_ref;
-    │              ^^^^^ Incompatible arguments to '!='
-    ·
  12 │     fun t0(r: &R, r_mut: &mut R, s: S, s_ref: &S, s_mut: &mut S) {
     │                                     - The type: '0x8675309::M::S'
-    ·
- 12 │     fun t0(r: &R, r_mut: &mut R, s: S, s_ref: &S, s_mut: &mut S) {
     │                                               -- Is not compatible with: '&0x8675309::M::S'
+    ·
+ 17 │         s != s_ref;
+    │              ^^^^^ Incompatible arguments to '!='
     │
 
 error: 
 
-    ┌── tests/move_check/typing/neq_invalid.move:18:18 ───
+    ┌── tests/move_check/typing/neq_invalid.move:12:37 ───
     │
- 18 │         s_mut != s;
-    │                  ^ Incompatible arguments to '!='
-    ·
- 12 │     fun t0(r: &R, r_mut: &mut R, s: S, s_ref: &S, s_mut: &mut S) {
-    │                                                          ------ The type: '&mut 0x8675309::M::S'
-    ·
  12 │     fun t0(r: &R, r_mut: &mut R, s: S, s_ref: &S, s_mut: &mut S) {
     │                                     - Is not compatible with: '0x8675309::M::S'
+    │                                                          ------ The type: '&mut 0x8675309::M::S'
+    ·
+ 18 │         s_mut != s;
+    │                  ^ Incompatible arguments to '!='
     │
 
 error: 
 
-    ┌── tests/move_check/typing/neq_invalid.move:22:9 ───
+    ┌── tests/move_check/typing/neq_invalid.move:3:5 ───
     │
- 22 │         r != r;
-    │         ^^^^^^ Cannot use '!=' on resource values. This would destroy the resource. Try borrowing the values with '&' first.'
+  3 │     resource struct R {
+    │     -------- Is found to be a non-copyable type here
     ·
  21 │     fun t1(r: R) {
     │               - The type: '0x8675309::M::R'
-    ·
-  3 │     resource struct R {
-    │     -------- Is found to be a non-copyable type here
+ 22 │         r != r;
+    │         ^^^^^^ Cannot use '!=' on resource values. This would destroy the resource. Try borrowing the values with '&' first.'
     │
 
 error: 
@@ -122,16 +101,14 @@ error:
 
 error: 
 
-    ┌── tests/move_check/typing/neq_invalid.move:27:9 ───
+    ┌── tests/move_check/typing/neq_invalid.move:7:18 ───
     │
- 27 │         G1{} != G1{};
-    │         ^^^^^^^^^^^^ Cannot use '!=' on resource values. This would destroy the resource. Try borrowing the values with '&' first.'
-    ·
- 27 │         G1{} != G1{};
-    │                 ---- The type: '0x8675309::M::G1<_>'
-    ·
   7 │     struct G1<T: resource> {}
     │                  -------- Is found to be a non-copyable type here
+    ·
+ 27 │         G1{} != G1{};
+    │         ^^^^^^^^^^^^ Cannot use '!=' on resource values. This would destroy the resource. Try borrowing the values with '&' first.'
+    │                 ---- The type: '0x8675309::M::G1<_>'
     │
 
 error: 
@@ -152,16 +129,14 @@ error:
 
 error: 
 
-    ┌── tests/move_check/typing/neq_invalid.move:28:9 ───
+    ┌── tests/move_check/typing/neq_invalid.move:8:15 ───
     │
- 28 │         G2{} != G2{};
-    │         ^^^^^^^^^^^^ Cannot use '!=' on resource values. This would destroy the resource. Try borrowing the values with '&' first.'
-    ·
- 28 │         G2{} != G2{};
-    │                 ---- The type: '0x8675309::M::G2<_>'
-    ·
   8 │     struct G2<T> {}
     │               - Is found to be a non-copyable type here
+    ·
+ 28 │         G2{} != G2{};
+    │         ^^^^^^^^^^^^ Cannot use '!=' on resource values. This would destroy the resource. Try borrowing the values with '&' first.'
+    │                 ---- The type: '0x8675309::M::G2<_>'
     │
 
 error: 
@@ -178,8 +153,6 @@ error:
     │
  32 │         () != ();
     │         ^^^^^^^^ Invalid arguments to '!='
-    ·
- 32 │         () != ();
     │               -- Expected a single type, but found expression list type: '()'
     │
 
@@ -189,36 +162,26 @@ error:
     │
  33 │         (0, 1) != (0, 1);
     │         ^^^^^^^^^^^^^^^^ Invalid arguments to '!='
-    ·
- 33 │         (0, 1) != (0, 1);
     │                   ------ Expected a single type, but found expression list type: '(u64, u64)'
     │
 
 error: 
 
-    ┌── tests/move_check/typing/neq_invalid.move:34:22 ───
+    ┌── tests/move_check/typing/neq_invalid.move:34:9 ───
     │
  34 │         (1, 2, 3) != (0, 1);
-    │                      ^^^^^^ Incompatible arguments to '!='
-    ·
- 34 │         (1, 2, 3) != (0, 1);
     │         --------- The expression list type of length 3: '({integer}, {integer}, {integer})'
-    ·
- 34 │         (1, 2, 3) != (0, 1);
     │                      ------ Is not compatible with the expression list type of length 2: '({integer}, {integer})'
+    │                      ^^^^^^ Incompatible arguments to '!='
     │
 
 error: 
 
-    ┌── tests/move_check/typing/neq_invalid.move:35:19 ───
+    ┌── tests/move_check/typing/neq_invalid.move:35:9 ───
     │
  35 │         (0, 1) != (1, 2, 3);
-    │                   ^^^^^^^^^ Incompatible arguments to '!='
-    ·
- 35 │         (0, 1) != (1, 2, 3);
     │         ------ The expression list type of length 2: '({integer}, {integer})'
-    ·
- 35 │         (0, 1) != (1, 2, 3);
     │                   --------- Is not compatible with the expression list type of length 3: '({integer}, {integer}, {integer})'
+    │                   ^^^^^^^^^ Incompatible arguments to '!='
     │
 

--- a/language/move-lang/tests/move_check/typing/number_literal_too_large.exp
+++ b/language/move-lang/tests/move_check/typing/number_literal_too_large.exp
@@ -3,13 +3,9 @@ error:
    ┌── tests/move_check/typing/number_literal_too_large.move:3:9 ───
    │
  3 │         340282366920938463463374607431768211455;
-   │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Invalid numerical literal
-   ·
- 3 │         340282366920938463463374607431768211455;
    │         --------------------------------------- Expected a literal of type 'u64', but the value is too large.
-   ·
- 3 │         340282366920938463463374607431768211455;
    │         --------------------------------------- Annotating the literal might help inference: '340282366920938463463374607431768211455u128'
+   │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Invalid numerical literal
    │
 
 error: 
@@ -17,13 +13,9 @@ error:
    ┌── tests/move_check/typing/number_literal_too_large.move:5:10 ───
    │
  5 │         (340282366920938463463374607431768211454: u64);
-   │          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Invalid numerical literal
-   ·
- 5 │         (340282366920938463463374607431768211454: u64);
-   │                                                   --- Expected a literal of type 'u64', but the value is too large.
-   ·
- 5 │         (340282366920938463463374607431768211454: u64);
    │          --------------------------------------- Annotating the literal might help inference: '340282366920938463463374607431768211454u128'
+   │          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Invalid numerical literal
+   │                                                   --- Expected a literal of type 'u64', but the value is too large.
    │
 
 error: 
@@ -31,13 +23,9 @@ error:
    ┌── tests/move_check/typing/number_literal_too_large.move:6:10 ───
    │
  6 │         (340282366920938463463374607431768211454: u8);
-   │          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Invalid numerical literal
-   ·
- 6 │         (340282366920938463463374607431768211454: u8);
-   │                                                   -- Expected a literal of type 'u8', but the value is too large.
-   ·
- 6 │         (340282366920938463463374607431768211454: u8);
    │          --------------------------------------- Annotating the literal might help inference: '340282366920938463463374607431768211454u128'
+   │          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Invalid numerical literal
+   │                                                   -- Expected a literal of type 'u8', but the value is too large.
    │
 
 error: 
@@ -45,13 +33,9 @@ error:
    ┌── tests/move_check/typing/number_literal_too_large.move:8:10 ───
    │
  8 │         (18446744073709551616: u64);
-   │          ^^^^^^^^^^^^^^^^^^^^ Invalid numerical literal
-   ·
- 8 │         (18446744073709551616: u64);
-   │                                --- Expected a literal of type 'u64', but the value is too large.
-   ·
- 8 │         (18446744073709551616: u64);
    │          -------------------- Annotating the literal might help inference: '18446744073709551616u128'
+   │          ^^^^^^^^^^^^^^^^^^^^ Invalid numerical literal
+   │                                --- Expected a literal of type 'u64', but the value is too large.
    │
 
 error: 
@@ -59,13 +43,9 @@ error:
    ┌── tests/move_check/typing/number_literal_too_large.move:9:10 ───
    │
  9 │         (18446744073709551616: u8);
-   │          ^^^^^^^^^^^^^^^^^^^^ Invalid numerical literal
-   ·
- 9 │         (18446744073709551616: u8);
-   │                                -- Expected a literal of type 'u8', but the value is too large.
-   ·
- 9 │         (18446744073709551616: u8);
    │          -------------------- Annotating the literal might help inference: '18446744073709551616u128'
+   │          ^^^^^^^^^^^^^^^^^^^^ Invalid numerical literal
+   │                                -- Expected a literal of type 'u8', but the value is too large.
    │
 
 error: 
@@ -73,13 +53,9 @@ error:
     ┌── tests/move_check/typing/number_literal_too_large.move:11:10 ───
     │
  11 │         (18446744073709551615: u8);
-    │          ^^^^^^^^^^^^^^^^^^^^ Invalid numerical literal
-    ·
- 11 │         (18446744073709551615: u8);
-    │                                -- Expected a literal of type 'u8', but the value is too large.
-    ·
- 11 │         (18446744073709551615: u8);
     │          -------------------- Annotating the literal might help inference: '18446744073709551615u64'
+    │          ^^^^^^^^^^^^^^^^^^^^ Invalid numerical literal
+    │                                -- Expected a literal of type 'u8', but the value is too large.
     │
 
 error: 
@@ -87,12 +63,8 @@ error:
     ┌── tests/move_check/typing/number_literal_too_large.move:13:10 ───
     │
  13 │         (256: u8);
-    │          ^^^ Invalid numerical literal
-    ·
- 13 │         (256: u8);
-    │               -- Expected a literal of type 'u8', but the value is too large.
-    ·
- 13 │         (256: u8);
     │          --- Annotating the literal might help inference: '256u64'
+    │          ^^^ Invalid numerical literal
+    │               -- Expected a literal of type 'u8', but the value is too large.
     │
 

--- a/language/move-lang/tests/move_check/typing/pack_constraint_not_satisfied.exp
+++ b/language/move-lang/tests/move_check/typing/pack_constraint_not_satisfied.exp
@@ -1,181 +1,147 @@
 error: 
 
-   ┌── tests/move_check/typing/pack_constraint_not_satisfied.move:7:9 ───
+   ┌── tests/move_check/typing/pack_constraint_not_satisfied.move:3:16 ───
    │
+ 3 │     struct R<T:resource>  { r: T }
+   │                -------- 'resource' constraint declared here
+   ·
  7 │         R {r:_ } = R { r: 0 };
    │         ^^^^^^^^ Constraint not satisfied.
-   ·
- 7 │         R {r:_ } = R { r: 0 };
-   │                           - The copyable type 'u64' does not satisfy the constraint 'resource'
-   ·
- 7 │         R {r:_ } = R { r: 0 };
    │                           - The type's constraint information was determined here
-   ·
- 3 │     struct R<T:resource>  { r: T }
-   │                -------- 'resource' constraint declared here
+   │                           - The copyable type 'u64' does not satisfy the constraint 'resource'
    │
 
 error: 
 
-   ┌── tests/move_check/typing/pack_constraint_not_satisfied.move:7:20 ───
+   ┌── tests/move_check/typing/pack_constraint_not_satisfied.move:3:16 ───
    │
+ 3 │     struct R<T:resource>  { r: T }
+   │                -------- 'resource' constraint declared here
+   ·
  7 │         R {r:_ } = R { r: 0 };
    │                    ^^^^^^^^^^ Constraint not satisfied.
-   ·
- 7 │         R {r:_ } = R { r: 0 };
-   │                           - The copyable type 'u64' does not satisfy the constraint 'resource'
-   ·
- 7 │         R {r:_ } = R { r: 0 };
    │                           - The type's constraint information was determined here
-   ·
- 3 │     struct R<T:resource>  { r: T }
-   │                -------- 'resource' constraint declared here
+   │                           - The copyable type 'u64' does not satisfy the constraint 'resource'
    │
 
 error: 
 
-   ┌── tests/move_check/typing/pack_constraint_not_satisfied.move:8:9 ───
+   ┌── tests/move_check/typing/pack_constraint_not_satisfied.move:2:5 ───
    │
- 8 │         S { c: Coin {} };
-   │         ^^^^^^^^^^^^^^^^ Constraint not satisfied.
-   ·
- 8 │         S { c: Coin {} };
-   │                ------- The resource type '0x8675309::M::Coin' does not satisfy the constraint 'copyable'
-   ·
  2 │     resource struct Coin {}
    │     -------- The type's constraint information was determined here
-   ·
+ 3 │     struct R<T:resource>  { r: T }
  4 │     struct S<T:copyable> { c: T }
    │                -------- 'copyable' constraint declared here
+   ·
+ 8 │         S { c: Coin {} };
+   │         ^^^^^^^^^^^^^^^^ Constraint not satisfied.
+   │                ------- The resource type '0x8675309::M::Coin' does not satisfy the constraint 'copyable'
    │
 
 error: 
 
-   ┌── tests/move_check/typing/pack_constraint_not_satisfied.move:8:9 ───
+   ┌── tests/move_check/typing/pack_constraint_not_satisfied.move:2:5 ───
    │
- 8 │         S { c: Coin {} };
-   │         ^^^^^^^^^^^^^^^^ Cannot ignore resource values. The value must be used
+ 2 │     resource struct Coin {}
+   │     -------- Is found to be a non-copyable type here
    ·
  8 │         S { c: Coin {} };
    │         ---------------- The type: '0x8675309::M::S<0x8675309::M::Coin>'
-   ·
- 2 │     resource struct Coin {}
-   │     -------- Is found to be a non-copyable type here
+   │         ^^^^^^^^^^^^^^^^ Cannot ignore resource values. The value must be used
    │
 
 error: 
 
-    ┌── tests/move_check/typing/pack_constraint_not_satisfied.move:12:9 ───
+    ┌── tests/move_check/typing/pack_constraint_not_satisfied.move:3:12 ───
     │
+  3 │     struct R<T:resource>  { r: T }
+    │            - The type's constraint information was determined here
+    │                -------- 'resource' constraint declared here
+    ·
  12 │         R {r: R { r: _ } } = R { r: R { r: 0 }};
     │         ^^^^^^^^^^^^^^^^^^ Constraint not satisfied.
-    ·
- 12 │         R {r: R { r: _ } } = R { r: R { r: 0 }};
     │                                     ---------- The copyable type '0x8675309::M::R<u64>' does not satisfy the constraint 'resource'
-    ·
-  3 │     struct R<T:resource>  { r: T }
-    │            - The type's constraint information was determined here
-    ·
-  3 │     struct R<T:resource>  { r: T }
-    │                -------- 'resource' constraint declared here
     │
 
 error: 
 
-    ┌── tests/move_check/typing/pack_constraint_not_satisfied.move:12:15 ───
+    ┌── tests/move_check/typing/pack_constraint_not_satisfied.move:3:16 ───
     │
+  3 │     struct R<T:resource>  { r: T }
+    │                -------- 'resource' constraint declared here
+    ·
  12 │         R {r: R { r: _ } } = R { r: R { r: 0 }};
     │               ^^^^^^^^^^ Constraint not satisfied.
-    ·
- 12 │         R {r: R { r: _ } } = R { r: R { r: 0 }};
-    │                                            - The copyable type 'u64' does not satisfy the constraint 'resource'
-    ·
- 12 │         R {r: R { r: _ } } = R { r: R { r: 0 }};
     │                                            - The type's constraint information was determined here
-    ·
-  3 │     struct R<T:resource>  { r: T }
-    │                -------- 'resource' constraint declared here
+    │                                            - The copyable type 'u64' does not satisfy the constraint 'resource'
     │
 
 error: 
 
-    ┌── tests/move_check/typing/pack_constraint_not_satisfied.move:12:30 ───
+    ┌── tests/move_check/typing/pack_constraint_not_satisfied.move:3:12 ───
     │
- 12 │         R {r: R { r: _ } } = R { r: R { r: 0 }};
-    │                              ^^^^^^^^^^^^^^^^^^ Constraint not satisfied.
-    ·
- 12 │         R {r: R { r: _ } } = R { r: R { r: 0 }};
-    │                                     ---------- The copyable type '0x8675309::M::R<u64>' does not satisfy the constraint 'resource'
-    ·
   3 │     struct R<T:resource>  { r: T }
     │            - The type's constraint information was determined here
-    ·
-  3 │     struct R<T:resource>  { r: T }
     │                -------- 'resource' constraint declared here
+    ·
+ 12 │         R {r: R { r: _ } } = R { r: R { r: 0 }};
+    │                              ^^^^^^^^^^^^^^^^^^ Constraint not satisfied.
+    │                                     ---------- The copyable type '0x8675309::M::R<u64>' does not satisfy the constraint 'resource'
     │
 
 error: 
 
-    ┌── tests/move_check/typing/pack_constraint_not_satisfied.move:12:37 ───
+    ┌── tests/move_check/typing/pack_constraint_not_satisfied.move:3:16 ───
     │
+  3 │     struct R<T:resource>  { r: T }
+    │                -------- 'resource' constraint declared here
+    ·
  12 │         R {r: R { r: _ } } = R { r: R { r: 0 }};
     │                                     ^^^^^^^^^^ Constraint not satisfied.
-    ·
- 12 │         R {r: R { r: _ } } = R { r: R { r: 0 }};
-    │                                            - The copyable type 'u64' does not satisfy the constraint 'resource'
-    ·
- 12 │         R {r: R { r: _ } } = R { r: R { r: 0 }};
     │                                            - The type's constraint information was determined here
-    ·
-  3 │     struct R<T:resource>  { r: T }
-    │                -------- 'resource' constraint declared here
+    │                                            - The copyable type 'u64' does not satisfy the constraint 'resource'
     │
 
 error: 
 
-    ┌── tests/move_check/typing/pack_constraint_not_satisfied.move:13:9 ───
+    ┌── tests/move_check/typing/pack_constraint_not_satisfied.move:2:5 ───
     │
- 13 │         S { c: S { c: Coin {} } };
-    │         ^^^^^^^^^^^^^^^^^^^^^^^^^ Constraint not satisfied.
-    ·
- 13 │         S { c: S { c: Coin {} } };
-    │                ---------------- The resource type '0x8675309::M::S<0x8675309::M::Coin>' does not satisfy the constraint 'copyable'
-    ·
   2 │     resource struct Coin {}
     │     -------- The type's constraint information was determined here
-    ·
+  3 │     struct R<T:resource>  { r: T }
   4 │     struct S<T:copyable> { c: T }
     │                -------- 'copyable' constraint declared here
+    ·
+ 13 │         S { c: S { c: Coin {} } };
+    │         ^^^^^^^^^^^^^^^^^^^^^^^^^ Constraint not satisfied.
+    │                ---------------- The resource type '0x8675309::M::S<0x8675309::M::Coin>' does not satisfy the constraint 'copyable'
     │
 
 error: 
 
-    ┌── tests/move_check/typing/pack_constraint_not_satisfied.move:13:9 ───
+    ┌── tests/move_check/typing/pack_constraint_not_satisfied.move:2:5 ───
     │
- 13 │         S { c: S { c: Coin {} } };
-    │         ^^^^^^^^^^^^^^^^^^^^^^^^^ Cannot ignore resource values. The value must be used
+  2 │     resource struct Coin {}
+    │     -------- Is found to be a non-copyable type here
     ·
  13 │         S { c: S { c: Coin {} } };
     │         ------------------------- The type: '0x8675309::M::S<0x8675309::M::S<0x8675309::M::Coin>>'
-    ·
-  2 │     resource struct Coin {}
-    │     -------- Is found to be a non-copyable type here
+    │         ^^^^^^^^^^^^^^^^^^^^^^^^^ Cannot ignore resource values. The value must be used
     │
 
 error: 
 
-    ┌── tests/move_check/typing/pack_constraint_not_satisfied.move:13:16 ───
+    ┌── tests/move_check/typing/pack_constraint_not_satisfied.move:2:5 ───
     │
- 13 │         S { c: S { c: Coin {} } };
-    │                ^^^^^^^^^^^^^^^^ Constraint not satisfied.
-    ·
- 13 │         S { c: S { c: Coin {} } };
-    │                       ------- The resource type '0x8675309::M::Coin' does not satisfy the constraint 'copyable'
-    ·
   2 │     resource struct Coin {}
     │     -------- The type's constraint information was determined here
-    ·
+  3 │     struct R<T:resource>  { r: T }
   4 │     struct S<T:copyable> { c: T }
     │                -------- 'copyable' constraint declared here
+    ·
+ 13 │         S { c: S { c: Coin {} } };
+    │                ^^^^^^^^^^^^^^^^ Constraint not satisfied.
+    │                       ------- The resource type '0x8675309::M::Coin' does not satisfy the constraint 'copyable'
     │
 

--- a/language/move-lang/tests/move_check/typing/pack_invalid_argument.exp
+++ b/language/move-lang/tests/move_check/typing/pack_invalid_argument.exp
@@ -1,70 +1,64 @@
 error: 
 
-   ┌── tests/move_check/typing/pack_invalid_argument.move:7:17 ───
+   ┌── tests/move_check/typing/pack_invalid_argument.move:2:19 ───
    │
- 7 │         (S { f: false } : S);
-   │                 ^^^^^ Invalid argument for field 'f' for '0x8675309::M::S'
+ 2 │     struct S { f: u64 }
+   │                   --- Is not compatible with: 'u64'
    ·
  7 │         (S { f: false } : S);
    │                 ----- The type: 'bool'
-   ·
- 2 │     struct S { f: u64 }
-   │                   --- Is not compatible with: 'u64'
+   │                 ^^^^^ Invalid argument for field 'f' for '0x8675309::M::S'
    │
 
 error: 
 
-    ┌── tests/move_check/typing/pack_invalid_argument.move:17:16 ───
+    ┌── tests/move_check/typing/pack_invalid_argument.move:4:28 ───
     │
- 17 │             s: r,
-    │                ^ Invalid argument for field 's' for '0x8675309::M::R'
+  4 │     resource struct R { s: S, f: u64, n1: Nat<u64>, n2: Nat<S> }
+    │                            - Is not compatible with: '0x8675309::M::S'
     ·
  15 │          } : R);
     │              - The type: '0x8675309::M::R'
-    ·
-  4 │     resource struct R { s: S, f: u64, n1: Nat<u64>, n2: Nat<S> }
-    │                            - Is not compatible with: '0x8675309::M::S'
+ 16 │         (R {
+ 17 │             s: r,
+    │                ^ Invalid argument for field 's' for '0x8675309::M::R'
     │
 
 error: 
 
-    ┌── tests/move_check/typing/pack_invalid_argument.move:18:16 ───
+    ┌── tests/move_check/typing/pack_invalid_argument.move:4:34 ───
     │
- 18 │             f: false,
-    │                ^^^^^ Invalid argument for field 'f' for '0x8675309::M::R'
+  4 │     resource struct R { s: S, f: u64, n1: Nat<u64>, n2: Nat<S> }
+    │                                  --- Is not compatible with: 'u64'
     ·
  18 │             f: false,
     │                ----- The type: 'bool'
-    ·
-  4 │     resource struct R { s: S, f: u64, n1: Nat<u64>, n2: Nat<S> }
-    │                                  --- Is not compatible with: 'u64'
+    │                ^^^^^ Invalid argument for field 'f' for '0x8675309::M::R'
     │
 
 error: 
 
-    ┌── tests/move_check/typing/pack_invalid_argument.move:19:17 ───
+    ┌── tests/move_check/typing/pack_invalid_argument.move:4:47 ───
     │
- 19 │             n1: Nat { f: false },
-    │                 ^^^^^^^^^^^^^^^^ Invalid argument for field 'n1' for '0x8675309::M::R'
-    ·
- 19 │             n1: Nat { f: false },
-    │                          ----- The type: 'bool'
-    ·
   4 │     resource struct R { s: S, f: u64, n1: Nat<u64>, n2: Nat<S> }
     │                                               --- Is not compatible with: 'u64'
+    ·
+ 19 │             n1: Nat { f: false },
+    │                 ^^^^^^^^^^^^^^^^ Invalid argument for field 'n1' for '0x8675309::M::R'
+    │                          ----- The type: 'bool'
     │
 
 error: 
 
-    ┌── tests/move_check/typing/pack_invalid_argument.move:20:17 ───
+    ┌── tests/move_check/typing/pack_invalid_argument.move:4:61 ───
     │
- 20 │             n2: Nat{ f: r }
-    │                 ^^^^^^^^^^^ Invalid argument for field 'n2' for '0x8675309::M::R'
+  4 │     resource struct R { s: S, f: u64, n1: Nat<u64>, n2: Nat<S> }
+    │                                                             - Is not compatible with: '0x8675309::M::S'
     ·
  15 │          } : R);
     │              - The type: '0x8675309::M::R'
     ·
-  4 │     resource struct R { s: S, f: u64, n1: Nat<u64>, n2: Nat<S> }
-    │                                                             - Is not compatible with: '0x8675309::M::S'
+ 20 │             n2: Nat{ f: r }
+    │                 ^^^^^^^^^^^ Invalid argument for field 'n2' for '0x8675309::M::R'
     │
 

--- a/language/move-lang/tests/move_check/typing/pack_multiple.exp
+++ b/language/move-lang/tests/move_check/typing/pack_multiple.exp
@@ -4,8 +4,6 @@ error:
    │
  5 │         Box { f: (0, 1) };
    │         ^^^^^^^^^^^^^^^^^ Invalid type argument
-   ·
- 5 │         Box { f: (0, 1) };
    │                  ------ Expected a single non-reference type, but found: '(u64, u64)'
    │
 
@@ -15,8 +13,6 @@ error:
    │
  6 │         Box { f: (0, 1, 2) };
    │         ^^^^^^^^^^^^^^^^^^^^ Invalid type argument
-   ·
- 6 │         Box { f: (0, 1, 2) };
    │                  --------- Expected a single non-reference type, but found: '(u64, u64, u64)'
    │
 
@@ -26,8 +22,6 @@ error:
    │
  7 │         Box { f: (true, Box { f: 0 }) };
    │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Invalid type argument
-   ·
- 7 │         Box { f: (true, Box { f: 0 }) };
    │                  -------------------- Expected a single non-reference type, but found: '(bool, 0x8675309::M::Box<u64>)'
    │
 

--- a/language/move-lang/tests/move_check/typing/pack_reference.exp
+++ b/language/move-lang/tests/move_check/typing/pack_reference.exp
@@ -1,22 +1,21 @@
 error: 
 
-   ┌── tests/move_check/typing/pack_reference.move:5:9 ───
+   ┌── tests/move_check/typing/pack_reference.move:4:19 ───
    │
- 5 │         Box { f: r_imm };
-   │         ^^^^^^^^^^^^^^^^ Invalid type argument
-   ·
  4 │     fun t0(r_imm: &u64, r_mut: &mut u64) {
    │                   ---- Expected a single non-reference type, but found: '&u64'
+ 5 │         Box { f: r_imm };
+   │         ^^^^^^^^^^^^^^^^ Invalid type argument
    │
 
 error: 
 
-   ┌── tests/move_check/typing/pack_reference.move:6:9 ───
+   ┌── tests/move_check/typing/pack_reference.move:4:32 ───
    │
- 6 │         Box { f: r_mut };
-   │         ^^^^^^^^^^^^^^^^ Invalid type argument
-   ·
  4 │     fun t0(r_imm: &u64, r_mut: &mut u64) {
    │                                -------- Expected a single non-reference type, but found: '&mut u64'
+ 5 │         Box { f: r_imm };
+ 6 │         Box { f: r_mut };
+   │         ^^^^^^^^^^^^^^^^ Invalid type argument
    │
 

--- a/language/move-lang/tests/move_check/typing/pack_unit.exp
+++ b/language/move-lang/tests/move_check/typing/pack_unit.exp
@@ -4,8 +4,6 @@ error:
    │
  5 │         Box { f: () };
    │         ^^^^^^^^^^^^^ Invalid type argument
-   ·
- 5 │         Box { f: () };
    │                  -- Expected a single non-reference type, but found: '()'
    │
 

--- a/language/move-lang/tests/move_check/typing/recursive_structs.exp
+++ b/language/move-lang/tests/move_check/typing/recursive_structs.exp
@@ -3,10 +3,8 @@ error:
    ┌── tests/move_check/typing/recursive_structs.move:4:21 ───
    │
  4 │     struct Foo { f: Foo }
-   │                     ^^^ Invalid field containing 'Foo' in struct 'Foo'.
-   ·
- 4 │     struct Foo { f: Foo }
    │                     --- Using this struct creates a cycle: 'Foo' contains 'Foo'
+   │                     ^^^ Invalid field containing 'Foo' in struct 'Foo'.
    │
 
 error: 
@@ -14,10 +12,8 @@ error:
    ┌── tests/move_check/typing/recursive_structs.move:7:25 ───
    │
  7 │     struct Bar { f: Cup<Bar> }
-   │                         ^^^ Invalid field containing 'Bar' in struct 'Bar'.
-   ·
- 7 │     struct Bar { f: Cup<Bar> }
    │                         --- Using this struct creates a cycle: 'Bar' contains 'Bar'
+   │                         ^^^ Invalid field containing 'Bar' in struct 'Bar'.
    │
 
 error: 
@@ -25,10 +21,8 @@ error:
    ┌── tests/move_check/typing/recursive_structs.move:9:35 ───
    │
  9 │     resource struct X { y: vector<Y> }
-   │                                   ^ Invalid field containing 'Y' in struct 'X'.
-   ·
- 9 │     resource struct X { y: vector<Y> }
    │                                   - Using this struct creates a cycle: 'Y' contains 'X' contains 'Y'
+   │                                   ^ Invalid field containing 'Y' in struct 'X'.
    │
 
 error: 
@@ -36,10 +30,8 @@ error:
     ┌── tests/move_check/typing/recursive_structs.move:17:29 ───
     │
  17 │     struct Foo { f: M0::Cup<Foo> }
-    │                             ^^^ Invalid field containing 'Foo' in struct 'Foo'.
-    ·
- 17 │     struct Foo { f: M0::Cup<Foo> }
     │                             --- Using this struct creates a cycle: 'Foo' contains 'Foo'
+    │                             ^^^ Invalid field containing 'Foo' in struct 'Foo'.
     │
 
 error: 
@@ -47,9 +39,7 @@ error:
     ┌── tests/move_check/typing/recursive_structs.move:21:26 ───
     │
  21 │     struct C { d: vector<D> }
-    │                          ^ Invalid field containing 'D' in struct 'C'.
-    ·
- 21 │     struct C { d: vector<D> }
     │                          - Using this struct creates a cycle: 'D' contains 'A' contains 'B' contains 'C' contains 'D'
+    │                          ^ Invalid field containing 'D' in struct 'C'.
     │
 

--- a/language/move-lang/tests/move_check/typing/recursive_structs_malformed.exp
+++ b/language/move-lang/tests/move_check/typing/recursive_structs_malformed.exp
@@ -3,10 +3,8 @@ error:
    ┌── tests/move_check/typing/recursive_structs_malformed.move:4:21 ───
    │
  4 │     struct Foo { f: (Foo, Foo) }
-   │                     ^^^^^^^^^^ Invalid field type
-   ·
- 4 │     struct Foo { f: (Foo, Foo) }
    │                     ---------- Expected a single non-reference type, but found: '(0x42::M0::Foo, 0x42::M0::Foo)'
+   │                     ^^^^^^^^^^ Invalid field type
    │
 
 error: 
@@ -14,10 +12,8 @@ error:
    ┌── tests/move_check/typing/recursive_structs_malformed.move:4:27 ───
    │
  4 │     struct Foo { f: (Foo, Foo) }
-   │                           ^^^ Invalid field containing 'Foo' in struct 'Foo'.
-   ·
- 4 │     struct Foo { f: (Foo, Foo) }
    │                           --- Using this struct creates a cycle: 'Foo' contains 'Foo'
+   │                           ^^^ Invalid field containing 'Foo' in struct 'Foo'.
    │
 
 error: 
@@ -25,10 +21,8 @@ error:
    ┌── tests/move_check/typing/recursive_structs_malformed.move:5:21 ───
    │
  5 │     struct Bar { f: &Bar }
-   │                     ^^^^ Invalid field type
-   ·
- 5 │     struct Bar { f: &Bar }
    │                     ---- Expected a single non-reference type, but found: '&0x42::M0::Bar'
+   │                     ^^^^ Invalid field type
    │
 
 error: 
@@ -36,10 +30,8 @@ error:
    ┌── tests/move_check/typing/recursive_structs_malformed.move:5:22 ───
    │
  5 │     struct Bar { f: &Bar }
-   │                      ^^^ Invalid field containing 'Bar' in struct 'Bar'.
-   ·
- 5 │     struct Bar { f: &Bar }
    │                      --- Using this struct creates a cycle: 'Bar' contains 'Bar'
+   │                      ^^^ Invalid field containing 'Bar' in struct 'Bar'.
    │
 
 error: 
@@ -48,8 +40,6 @@ error:
    │
  6 │     struct Baz { f: vector<(&Baz, &mut Baz)> }
    │                     ^^^^^^^^^^^^^^^^^^^^^^^^ Invalid type argument
-   ·
- 6 │     struct Baz { f: vector<(&Baz, &mut Baz)> }
    │                            ---------------- Expected a single non-reference type, but found: '(&0x42::M0::Baz, &mut 0x42::M0::Baz)'
    │
 
@@ -58,9 +48,7 @@ error:
    ┌── tests/move_check/typing/recursive_structs_malformed.move:6:40 ───
    │
  6 │     struct Baz { f: vector<(&Baz, &mut Baz)> }
-   │                                        ^^^ Invalid field containing 'Baz' in struct 'Baz'.
-   ·
- 6 │     struct Baz { f: vector<(&Baz, &mut Baz)> }
    │                                        --- Using this struct creates a cycle: 'Baz' contains 'Baz'
+   │                                        ^^^ Invalid field containing 'Baz' in struct 'Baz'.
    │
 

--- a/language/move-lang/tests/move_check/typing/return_type_explicit_exp_invalid.exp
+++ b/language/move-lang/tests/move_check/typing/return_type_explicit_exp_invalid.exp
@@ -1,84 +1,66 @@
 error: 
 
-   ┌── tests/move_check/typing/return_type_explicit_exp_invalid.move:5:9 ───
+   ┌── tests/move_check/typing/return_type_explicit_exp_invalid.move:4:15 ───
    │
- 5 │         return ()
-   │         ^^^^^^^^^ Invalid return
-   ·
- 5 │         return ()
-   │                -- The type: '()'
-   ·
  4 │     fun t0(): u64 {
    │               --- Is not compatible with: 'u64'
+ 5 │         return ()
+   │         ^^^^^^^^^ Invalid return
+   │                -- The type: '()'
    │
 
 error: 
 
-   ┌── tests/move_check/typing/return_type_explicit_exp_invalid.move:9:19 ───
+   ┌── tests/move_check/typing/return_type_explicit_exp_invalid.move:8:15 ───
    │
+ 8 │     fun t1(): () {
+   │               -- Is not compatible with: '()'
  9 │         if (true) return 1 else return 0
    │                   ^^^^^^^^ Invalid return
-   ·
- 9 │         if (true) return 1 else return 0
    │                          - The type: integer
-   ·
- 8 │     fun t1(): () {
-   │               -- Is not compatible with: '()'
    │
 
 error: 
 
-   ┌── tests/move_check/typing/return_type_explicit_exp_invalid.move:9:33 ───
+   ┌── tests/move_check/typing/return_type_explicit_exp_invalid.move:8:15 ───
    │
+ 8 │     fun t1(): () {
+   │               -- Is not compatible with: '()'
  9 │         if (true) return 1 else return 0
    │                                 ^^^^^^^^ Invalid return
-   ·
- 9 │         if (true) return 1 else return 0
    │                                        - The type: integer
-   ·
- 8 │     fun t1(): () {
-   │               -- Is not compatible with: '()'
    │
 
 error: 
 
-    ┌── tests/move_check/typing/return_type_explicit_exp_invalid.move:13:14 ───
+    ┌── tests/move_check/typing/return_type_explicit_exp_invalid.move:12:15 ───
     │
- 13 │         loop return (0, false, R{});
-    │              ^^^^^^^^^^^^^^^^^^^^^^ Invalid return
-    ·
- 13 │         loop return (0, false, R{});
-    │                     --------------- The expression list type of length 3: '({integer}, bool, 0x8675309::M::R)'
-    ·
  12 │     fun t2(): (u64, bool) {
     │               ----------- Is not compatible with the expression list type of length 2: '(u64, bool)'
+ 13 │         loop return (0, false, R{});
+    │              ^^^^^^^^^^^^^^^^^^^^^^ Invalid return
+    │                     --------------- The expression list type of length 3: '({integer}, bool, 0x8675309::M::R)'
     │
 
 error: 
 
-    ┌── tests/move_check/typing/return_type_explicit_exp_invalid.move:18:22 ───
+    ┌── tests/move_check/typing/return_type_explicit_exp_invalid.move:17:15 ───
     │
- 18 │         while (true) return (0, false, R{});
-    │                      ^^^^^^^^^^^^^^^^^^^^^^ Invalid return
-    ·
- 18 │         while (true) return (0, false, R{});
-    │                             --------------- The expression list type of length 3: '({integer}, bool, 0x8675309::M::R)'
-    ·
  17 │     fun t3(): (u64, bool, R, bool) {
     │               -------------------- Is not compatible with the expression list type of length 4: '(u64, bool, 0x8675309::M::R, bool)'
+ 18 │         while (true) return (0, false, R{});
+    │                      ^^^^^^^^^^^^^^^^^^^^^^ Invalid return
+    │                             --------------- The expression list type of length 3: '({integer}, bool, 0x8675309::M::R)'
     │
 
 error: 
 
-    ┌── tests/move_check/typing/return_type_explicit_exp_invalid.move:23:23 ───
+    ┌── tests/move_check/typing/return_type_explicit_exp_invalid.move:22:16 ───
     │
- 23 │         while (false) return (0, false, R{});
-    │                       ^^^^^^^^^^^^^^^^^^^^^^ Invalid return
-    ·
- 23 │         while (false) return (0, false, R{});
-    │                               - The type: integer
-    ·
  22 │     fun t4(): (bool, u64, R) {
     │                ---- Is not compatible with: 'bool'
+ 23 │         while (false) return (0, false, R{});
+    │                       ^^^^^^^^^^^^^^^^^^^^^^ Invalid return
+    │                               - The type: integer
     │
 

--- a/language/move-lang/tests/move_check/typing/return_type_last_exp_invalid.exp
+++ b/language/move-lang/tests/move_check/typing/return_type_last_exp_invalid.exp
@@ -1,70 +1,55 @@
 error: 
 
-   ┌── tests/move_check/typing/return_type_last_exp_invalid.move:5:9 ───
+   ┌── tests/move_check/typing/return_type_last_exp_invalid.move:4:15 ───
    │
- 5 │         ()
-   │         ^^ Invalid return expression
-   ·
- 5 │         ()
-   │         -- The type: '()'
-   ·
  4 │     fun t0(): u64 {
    │               --- Is not compatible with: 'u64'
+ 5 │         ()
+   │         -- The type: '()'
+   │         ^^ Invalid return expression
    │
 
 error: 
 
-   ┌── tests/move_check/typing/return_type_last_exp_invalid.move:9:9 ───
+   ┌── tests/move_check/typing/return_type_last_exp_invalid.move:8:15 ───
    │
- 9 │         0
-   │         ^ Invalid return expression
-   ·
- 9 │         0
-   │         - The type: integer
-   ·
  8 │     fun t1(): () {
    │               -- Is not compatible with: '()'
+ 9 │         0
+   │         - The type: integer
+   │         ^ Invalid return expression
    │
 
 error: 
 
-    ┌── tests/move_check/typing/return_type_last_exp_invalid.move:13:9 ───
+    ┌── tests/move_check/typing/return_type_last_exp_invalid.move:12:15 ───
     │
- 13 │         (0, false, R{})
-    │         ^^^^^^^^^^^^^^^ Invalid return expression
-    ·
- 13 │         (0, false, R{})
-    │         --------------- The expression list type of length 3: '({integer}, bool, 0x8675309::M::R)'
-    ·
  12 │     fun t2(): (u64, bool) {
     │               ----------- Is not compatible with the expression list type of length 2: '(u64, bool)'
+ 13 │         (0, false, R{})
+    │         --------------- The expression list type of length 3: '({integer}, bool, 0x8675309::M::R)'
+    │         ^^^^^^^^^^^^^^^ Invalid return expression
     │
 
 error: 
 
-    ┌── tests/move_check/typing/return_type_last_exp_invalid.move:17:9 ───
+    ┌── tests/move_check/typing/return_type_last_exp_invalid.move:16:15 ───
     │
- 17 │         (0, false, R{})
-    │         ^^^^^^^^^^^^^^^ Invalid return expression
-    ·
- 17 │         (0, false, R{})
-    │         --------------- The expression list type of length 3: '({integer}, bool, 0x8675309::M::R)'
-    ·
  16 │     fun t3(): (u64, bool, R, bool) {
     │               -------------------- Is not compatible with the expression list type of length 4: '(u64, bool, 0x8675309::M::R, bool)'
+ 17 │         (0, false, R{})
+    │         --------------- The expression list type of length 3: '({integer}, bool, 0x8675309::M::R)'
+    │         ^^^^^^^^^^^^^^^ Invalid return expression
     │
 
 error: 
 
-    ┌── tests/move_check/typing/return_type_last_exp_invalid.move:21:9 ───
+    ┌── tests/move_check/typing/return_type_last_exp_invalid.move:20:16 ───
     │
- 21 │         (0, false, R{})
-    │         ^^^^^^^^^^^^^^^ Invalid return expression
-    ·
- 21 │         (0, false, R{})
-    │          - The type: integer
-    ·
  20 │     fun t4(): (bool, u64, R) {
     │                ---- Is not compatible with: 'bool'
+ 21 │         (0, false, R{})
+    │         ^^^^^^^^^^^^^^^ Invalid return expression
+    │          - The type: integer
     │
 

--- a/language/move-lang/tests/move_check/typing/seq_cannot_ignore_resource.exp
+++ b/language/move-lang/tests/move_check/typing/seq_cannot_ignore_resource.exp
@@ -1,56 +1,49 @@
 error: 
 
-   ┌── tests/move_check/typing/seq_cannot_ignore_resource.move:5:9 ───
+   ┌── tests/move_check/typing/seq_cannot_ignore_resource.move:2:5 ───
    │
- 5 │         R{};
-   │         ^^^ Cannot ignore resource values. The value must be used
+ 2 │     resource struct R {}
+   │     -------- Is found to be a non-copyable type here
    ·
  5 │         R{};
    │         --- The type: '0x8675309::M::R'
-   ·
- 2 │     resource struct R {}
-   │     -------- Is found to be a non-copyable type here
+   │         ^^^ Cannot ignore resource values. The value must be used
    │
 
 error: 
 
-    ┌── tests/move_check/typing/seq_cannot_ignore_resource.move:10:9 ───
+    ┌── tests/move_check/typing/seq_cannot_ignore_resource.move:2:5 ───
     │
- 10 │         r;
-    │         ^ Cannot ignore resource values. The value must be used
+  2 │     resource struct R {}
+    │     -------- Is found to be a non-copyable type here
     ·
   9 │         let r = R{};
     │                 --- The type: '0x8675309::M::R'
-    ·
-  2 │     resource struct R {}
-    │     -------- Is found to be a non-copyable type here
+ 10 │         r;
+    │         ^ Cannot ignore resource values. The value must be used
     │
 
 error: 
 
-    ┌── tests/move_check/typing/seq_cannot_ignore_resource.move:14:9 ───
+    ┌── tests/move_check/typing/seq_cannot_ignore_resource.move:2:5 ───
     │
- 14 │         (0, false, R{});
-    │         ^^^^^^^^^^^^^^^ Cannot ignore resource values. The value must be used
+  2 │     resource struct R {}
+    │     -------- Is found to be a non-copyable type here
     ·
  14 │         (0, false, R{});
     │         --------------- The type: '(u64, bool, 0x8675309::M::R)'
-    ·
-  2 │     resource struct R {}
-    │     -------- Is found to be a non-copyable type here
+    │         ^^^^^^^^^^^^^^^ Cannot ignore resource values. The value must be used
     │
 
 error: 
 
-    ┌── tests/move_check/typing/seq_cannot_ignore_resource.move:19:9 ───
+    ┌── tests/move_check/typing/seq_cannot_ignore_resource.move:2:5 ───
     │
- 19 │         if (true) (0, false, R{}) else (0, false, r);
-    │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Cannot ignore resource values. The value must be used
-    ·
- 19 │         if (true) (0, false, R{}) else (0, false, r);
-    │                                        ------------- The type: '(u64, bool, 0x8675309::M::R)'
-    ·
   2 │     resource struct R {}
     │     -------- Is found to be a non-copyable type here
+    ·
+ 19 │         if (true) (0, false, R{}) else (0, false, r);
+    │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Cannot ignore resource values. The value must be used
+    │                                        ------------- The type: '(u64, bool, 0x8675309::M::R)'
     │
 

--- a/language/move-lang/tests/move_check/typing/shadowing_invalid_types.exp
+++ b/language/move-lang/tests/move_check/typing/shadowing_invalid_types.exp
@@ -1,154 +1,124 @@
 error: 
 
-   ┌── tests/move_check/typing/shadowing_invalid_types.move:8:13 ───
+   ┌── tests/move_check/typing/shadowing_invalid_types.move:5:13 ───
    │
- 8 │         (x: bool);
-   │             ^^^^ Invalid type annotation
-   ·
  5 │         let x = 0;
    │             - The type: integer
    ·
  8 │         (x: bool);
    │             ---- Is not compatible with: 'bool'
+   │             ^^^^ Invalid type annotation
    │
 
 error: 
 
-    ┌── tests/move_check/typing/shadowing_invalid_types.move:10:30 ───
+    ┌── tests/move_check/typing/shadowing_invalid_types.move:10:19 ───
     │
  10 │         { let x = false; (x: u64); };
-    │                              ^^^ Invalid type annotation
-    ·
- 10 │         { let x = false; (x: u64); };
     │                   ----- The type: 'bool'
-    ·
- 10 │         { let x = false; (x: u64); };
     │                              --- Is not compatible with: 'u64'
+    │                              ^^^ Invalid type annotation
     │
 
 error: 
 
-    ┌── tests/move_check/typing/shadowing_invalid_types.move:11:13 ───
+    ┌── tests/move_check/typing/shadowing_invalid_types.move:5:13 ───
     │
- 11 │         (x: bool);
-    │             ^^^^ Invalid type annotation
-    ·
   5 │         let x = 0;
     │             - The type: integer
     ·
  11 │         (x: bool);
     │             ---- Is not compatible with: 'bool'
+    │             ^^^^ Invalid type annotation
     │
 
 error: 
 
-    ┌── tests/move_check/typing/shadowing_invalid_types.move:13:45 ───
+    ┌── tests/move_check/typing/shadowing_invalid_types.move:13:36 ───
     │
- 13 │         { let x = false; { let x = 0x0; (x: u64); }; (x: address); };
-    │                                             ^^^ Invalid type annotation
-    ·
  13 │         { let x = false; { let x = 0x0; (x: u64); }; (x: address); };
     │                                    --- The type: 'address'
-    ·
- 13 │         { let x = false; { let x = 0x0; (x: u64); }; (x: address); };
     │                                             --- Is not compatible with: 'u64'
+    │                                             ^^^ Invalid type annotation
     │
 
 error: 
 
-    ┌── tests/move_check/typing/shadowing_invalid_types.move:13:58 ───
+    ┌── tests/move_check/typing/shadowing_invalid_types.move:13:19 ───
     │
- 13 │         { let x = false; { let x = 0x0; (x: u64); }; (x: address); };
-    │                                                          ^^^^^^^ Invalid type annotation
-    ·
  13 │         { let x = false; { let x = 0x0; (x: u64); }; (x: address); };
     │                   ----- The type: 'bool'
-    ·
- 13 │         { let x = false; { let x = 0x0; (x: u64); }; (x: address); };
     │                                                          ------- Is not compatible with: 'address'
+    │                                                          ^^^^^^^ Invalid type annotation
     │
 
 error: 
 
-    ┌── tests/move_check/typing/shadowing_invalid_types.move:14:13 ───
+    ┌── tests/move_check/typing/shadowing_invalid_types.move:5:13 ───
     │
- 14 │         (x: bool);
-    │             ^^^^ Invalid type annotation
-    ·
   5 │         let x = 0;
     │             - The type: integer
     ·
  14 │         (x: bool);
     │             ---- Is not compatible with: 'bool'
+    │             ^^^^ Invalid type annotation
     │
 
 error: 
 
-    ┌── tests/move_check/typing/shadowing_invalid_types.move:21:17 ───
+    ┌── tests/move_check/typing/shadowing_invalid_types.move:20:34 ───
     │
- 21 │             (x: u64);
-    │                 ^^^ Invalid type annotation
-    ·
  20 │             let (a, x) = (false, false);
     │                                  ----- The type: 'bool'
-    ·
  21 │             (x: u64);
     │                 --- Is not compatible with: 'u64'
+    │                 ^^^ Invalid type annotation
     │
 
 error: 
 
-    ┌── tests/move_check/typing/shadowing_invalid_types.move:25:17 ───
+    ┌── tests/move_check/typing/shadowing_invalid_types.move:24:21 ───
     │
- 25 │             (x: u64);
-    │                 ^^^ Invalid type annotation
-    ·
  24 │             let x = 0x0;
     │                     --- The type: 'address'
-    ·
  25 │             (x: u64);
     │                 --- Is not compatible with: 'u64'
+    │                 ^^^ Invalid type annotation
     │
 
 error: 
 
-    ┌── tests/move_check/typing/shadowing_invalid_types.move:27:13 ───
+    ┌── tests/move_check/typing/shadowing_invalid_types.move:18:13 ───
     │
- 27 │         (x: address);
-    │             ^^^^^^^ Invalid type annotation
-    ·
  18 │         let x = 0;
     │             - The type: integer
     ·
  27 │         (x: address);
     │             ------- Is not compatible with: 'address'
+    │             ^^^^^^^ Invalid type annotation
     │
 
 error: 
 
-    ┌── tests/move_check/typing/shadowing_invalid_types.move:34:17 ───
+    ┌── tests/move_check/typing/shadowing_invalid_types.move:2:26 ───
     │
- 34 │             (x: u64);
-    │                 ^^^ Invalid type annotation
-    ·
   2 │     struct S {f: u64, b: bool}
     │                          ---- The type: 'bool'
     ·
  34 │             (x: u64);
     │                 --- Is not compatible with: 'u64'
+    │                 ^^^ Invalid type annotation
     │
 
 error: 
 
-    ┌── tests/move_check/typing/shadowing_invalid_types.move:37:13 ───
+    ┌── tests/move_check/typing/shadowing_invalid_types.move:31:13 ───
     │
- 37 │         (x: bool);
-    │             ^^^^ Invalid type annotation
-    ·
  31 │         let x = 0;
     │             - The type: integer
     ·
  37 │         (x: bool);
     │             ---- Is not compatible with: 'bool'
+    │             ^^^^ Invalid type annotation
     │
 

--- a/language/move-lang/tests/move_check/typing/spec_block_fail.exp
+++ b/language/move-lang/tests/move_check/typing/spec_block_fail.exp
@@ -1,42 +1,30 @@
 error: 
 
-   ┌── tests/move_check/typing/spec_block_fail.move:3:19 ───
+   ┌── tests/move_check/typing/spec_block_fail.move:3:10 ───
    │
  3 │         (spec {}: u64);
-   │                   ^^^ Invalid type annotation
-   ·
- 3 │         (spec {}: u64);
    │          ------- The type: '()'
-   ·
- 3 │         (spec {}: u64);
    │                   --- Is not compatible with: 'u64'
+   │                   ^^^ Invalid type annotation
    │
 
 error: 
 
-   ┌── tests/move_check/typing/spec_block_fail.move:4:19 ───
+   ┌── tests/move_check/typing/spec_block_fail.move:4:10 ───
    │
  4 │         (spec {}: &u64);
-   │                   ^^^^ Invalid type annotation
-   ·
- 4 │         (spec {}: &u64);
    │          ------- The type: '()'
-   ·
- 4 │         (spec {}: &u64);
    │                   ---- Is not compatible with: '&u64'
+   │                   ^^^^ Invalid type annotation
    │
 
 error: 
 
-   ┌── tests/move_check/typing/spec_block_fail.move:5:19 ───
+   ┌── tests/move_check/typing/spec_block_fail.move:5:10 ───
    │
  5 │         (spec {}: (u64, u64));
-   │                   ^^^^^^^^^^ Invalid type annotation
-   ·
- 5 │         (spec {}: (u64, u64));
    │          ------- The type: '()'
-   ·
- 5 │         (spec {}: (u64, u64));
    │                   ---------- Is not compatible with: '(u64, u64)'
+   │                   ^^^^^^^^^^ Invalid type annotation
    │
 

--- a/language/move-lang/tests/move_check/typing/subtype_annotation_invalid.exp
+++ b/language/move-lang/tests/move_check/typing/subtype_annotation_invalid.exp
@@ -1,56 +1,40 @@
 error: 
 
-   ┌── tests/move_check/typing/subtype_annotation_invalid.move:5:14 ───
+   ┌── tests/move_check/typing/subtype_annotation_invalid.move:5:10 ───
    │
  5 │         (&0: &mut u64);
-   │              ^^^^^^^^ Invalid type annotation
-   ·
- 5 │         (&0: &mut u64);
    │          -- The type: '&{integer}'
-   ·
- 5 │         (&0: &mut u64);
    │              -------- Is not a subtype of: '&mut u64'
+   │              ^^^^^^^^ Invalid type annotation
    │
 
 error: 
 
-   ┌── tests/move_check/typing/subtype_annotation_invalid.move:9:20 ───
+   ┌── tests/move_check/typing/subtype_annotation_invalid.move:9:11 ───
    │
  9 │         ((&0, &0): (&mut u64, &mut u64));
-   │                    ^^^^^^^^^^^^^^^^^^^^ Invalid type annotation
-   ·
- 9 │         ((&0, &0): (&mut u64, &mut u64));
    │           -- The type: '&{integer}'
-   ·
- 9 │         ((&0, &0): (&mut u64, &mut u64));
+   │                    ^^^^^^^^^^^^^^^^^^^^ Invalid type annotation
    │                     -------- Is not a subtype of: '&mut u64'
    │
 
 error: 
 
-    ┌── tests/move_check/typing/subtype_annotation_invalid.move:10:20 ───
+    ┌── tests/move_check/typing/subtype_annotation_invalid.move:10:11 ───
     │
  10 │         ((&0, &0): (&mut u64, &u64));
-    │                    ^^^^^^^^^^^^^^^^ Invalid type annotation
-    ·
- 10 │         ((&0, &0): (&mut u64, &u64));
     │           -- The type: '&{integer}'
-    ·
- 10 │         ((&0, &0): (&mut u64, &u64));
+    │                    ^^^^^^^^^^^^^^^^ Invalid type annotation
     │                     -------- Is not a subtype of: '&mut u64'
     │
 
 error: 
 
-    ┌── tests/move_check/typing/subtype_annotation_invalid.move:11:20 ───
+    ┌── tests/move_check/typing/subtype_annotation_invalid.move:11:15 ───
     │
  11 │         ((&0, &0): (&u64, &mut u64));
-    │                    ^^^^^^^^^^^^^^^^ Invalid type annotation
-    ·
- 11 │         ((&0, &0): (&u64, &mut u64));
     │               -- The type: '&{integer}'
-    ·
- 11 │         ((&0, &0): (&u64, &mut u64));
+    │                    ^^^^^^^^^^^^^^^^ Invalid type annotation
     │                           -------- Is not a subtype of: '&mut u64'
     │
 

--- a/language/move-lang/tests/move_check/typing/subtype_args_invalid.exp
+++ b/language/move-lang/tests/move_check/typing/subtype_args_invalid.exp
@@ -1,84 +1,72 @@
 error: 
 
-    ┌── tests/move_check/typing/subtype_args_invalid.move:10:9 ───
+    ┌── tests/move_check/typing/subtype_args_invalid.move:4:19 ───
     │
+  4 │     fun mut<T>(x: &mut T) {}
+    │                   ------ Is not a subtype of: '&mut u64'
+    ·
  10 │         mut<u64>(&0);
     │         ^^^^^^^^^^^^ Invalid call of '0x8675309::M::mut'. Invalid argument for parameter 'x'
-    ·
- 10 │         mut<u64>(&0);
     │                  -- The type: '&{integer}'
-    ·
-  4 │     fun mut<T>(x: &mut T) {}
-    │                   ------ Is not a subtype of: '&mut u64'
     │
 
 error: 
 
-    ┌── tests/move_check/typing/subtype_args_invalid.move:11:9 ───
+    ┌── tests/move_check/typing/subtype_args_invalid.move:4:19 ───
     │
+  4 │     fun mut<T>(x: &mut T) {}
+    │                   ------ Is not a subtype of: '&mut u64'
+    ·
  11 │         mut<u64>(&S{});
     │         ^^^^^^^^^^^^^^ Invalid call of '0x8675309::M::mut'. Invalid argument for parameter 'x'
-    ·
- 11 │         mut<u64>(&S{});
     │                  ---- The type: '&0x8675309::M::S'
-    ·
-  4 │     fun mut<T>(x: &mut T) {}
-    │                   ------ Is not a subtype of: '&mut u64'
     │
 
 error: 
 
-    ┌── tests/move_check/typing/subtype_args_invalid.move:15:9 ───
+    ┌── tests/move_check/typing/subtype_args_invalid.move:5:30 ───
     │
- 15 │         imm_mut<u64>(&0, &0);
-    │         ^^^^^^^^^^^^^^^^^^^^ Invalid call of '0x8675309::M::imm_mut'. Invalid argument for parameter 'y'
-    ·
- 15 │         imm_mut<u64>(&0, &0);
-    │                          -- The type: '&{integer}'
-    ·
   5 │     fun imm_mut<T>(x: &T, y: &mut T) {}
     │                              ------ Is not a subtype of: '&mut u64'
+    ·
+ 15 │         imm_mut<u64>(&0, &0);
+    │         ^^^^^^^^^^^^^^^^^^^^ Invalid call of '0x8675309::M::imm_mut'. Invalid argument for parameter 'y'
+    │                          -- The type: '&{integer}'
     │
 
 error: 
 
-    ┌── tests/move_check/typing/subtype_args_invalid.move:16:9 ───
+    ┌── tests/move_check/typing/subtype_args_invalid.move:6:23 ───
     │
- 16 │         mut_imm<u64>(&0, &0);
-    │         ^^^^^^^^^^^^^^^^^^^^ Invalid call of '0x8675309::M::mut_imm'. Invalid argument for parameter 'x'
-    ·
- 16 │         mut_imm<u64>(&0, &0);
-    │                      -- The type: '&{integer}'
-    ·
   6 │     fun mut_imm<T>(x: &mut T, y: &T) {}
     │                       ------ Is not a subtype of: '&mut u64'
+    ·
+ 16 │         mut_imm<u64>(&0, &0);
+    │         ^^^^^^^^^^^^^^^^^^^^ Invalid call of '0x8675309::M::mut_imm'. Invalid argument for parameter 'x'
+    │                      -- The type: '&{integer}'
     │
 
 error: 
 
-    ┌── tests/move_check/typing/subtype_args_invalid.move:17:9 ───
+    ┌── tests/move_check/typing/subtype_args_invalid.move:7:23 ───
     │
- 17 │         mut_mut<u64>(&0, &0);
-    │         ^^^^^^^^^^^^^^^^^^^^ Invalid call of '0x8675309::M::mut_mut'. Invalid argument for parameter 'x'
-    ·
- 17 │         mut_mut<u64>(&0, &0);
-    │                      -- The type: '&{integer}'
-    ·
   7 │     fun mut_mut<T>(x: &mut T, y: &mut T) {}
     │                       ------ Is not a subtype of: '&mut u64'
+    ·
+ 17 │         mut_mut<u64>(&0, &0);
+    │         ^^^^^^^^^^^^^^^^^^^^ Invalid call of '0x8675309::M::mut_mut'. Invalid argument for parameter 'x'
+    │                      -- The type: '&{integer}'
     │
 
 error: 
 
-    ┌── tests/move_check/typing/subtype_args_invalid.move:17:9 ───
+    ┌── tests/move_check/typing/subtype_args_invalid.move:7:34 ───
     │
- 17 │         mut_mut<u64>(&0, &0);
-    │         ^^^^^^^^^^^^^^^^^^^^ Invalid call of '0x8675309::M::mut_mut'. Invalid argument for parameter 'y'
-    ·
- 17 │         mut_mut<u64>(&0, &0);
-    │                          -- The type: '&{integer}'
-    ·
   7 │     fun mut_mut<T>(x: &mut T, y: &mut T) {}
     │                                  ------ Is not a subtype of: '&mut u64'
+    ·
+ 17 │         mut_mut<u64>(&0, &0);
+    │         ^^^^^^^^^^^^^^^^^^^^ Invalid call of '0x8675309::M::mut_mut'. Invalid argument for parameter 'y'
+    │                          -- The type: '&{integer}'
     │
 

--- a/language/move-lang/tests/move_check/typing/subtype_assign_invalid.exp
+++ b/language/move-lang/tests/move_check/typing/subtype_assign_invalid.exp
@@ -3,68 +3,52 @@ error:
    ┌── tests/move_check/typing/subtype_assign_invalid.move:5:16 ───
    │
  5 │         let x: &mut u64 = &0;
-   │                ^^^^^^^^ Invalid type annotation
-   ·
- 5 │         let x: &mut u64 = &0;
-   │                           -- The type: '&{integer}'
-   ·
- 5 │         let x: &mut u64 = &0;
    │                -------- Is not a subtype of: '&mut u64'
+   │                ^^^^^^^^ Invalid type annotation
+   │                           -- The type: '&{integer}'
    │
 
 error: 
 
-    ┌── tests/move_check/typing/subtype_assign_invalid.move:10:10 ───
+    ┌── tests/move_check/typing/subtype_assign_invalid.move:9:22 ───
     │
- 10 │         (x, y) = (&0, &0);
-    │          ^ Invalid assignment to local 'x'
-    ·
- 10 │         (x, y) = (&0, &0);
-    │                   -- The type: '&{integer}'
-    ·
   9 │         let (x, y): (&mut u64, &mut u64);
     │                      -------- Is not a subtype of: '&mut u64'
+ 10 │         (x, y) = (&0, &0);
+    │          ^ Invalid assignment to local 'x'
+    │                   -- The type: '&{integer}'
     │
 
 error: 
 
-    ┌── tests/move_check/typing/subtype_assign_invalid.move:10:13 ───
+    ┌── tests/move_check/typing/subtype_assign_invalid.move:9:32 ───
     │
- 10 │         (x, y) = (&0, &0);
-    │             ^ Invalid assignment to local 'y'
-    ·
- 10 │         (x, y) = (&0, &0);
-    │                       -- The type: '&{integer}'
-    ·
   9 │         let (x, y): (&mut u64, &mut u64);
     │                                -------- Is not a subtype of: '&mut u64'
+ 10 │         (x, y) = (&0, &0);
+    │             ^ Invalid assignment to local 'y'
+    │                       -- The type: '&{integer}'
     │
 
 error: 
 
-    ┌── tests/move_check/typing/subtype_assign_invalid.move:13:10 ───
+    ┌── tests/move_check/typing/subtype_assign_invalid.move:12:22 ───
     │
- 13 │         (x, y) = (&0, &0);
-    │          ^ Invalid assignment to local 'x'
-    ·
- 13 │         (x, y) = (&0, &0);
-    │                   -- The type: '&{integer}'
-    ·
  12 │         let (x, y): (&mut u64, &u64);
     │                      -------- Is not a subtype of: '&mut u64'
+ 13 │         (x, y) = (&0, &0);
+    │          ^ Invalid assignment to local 'x'
+    │                   -- The type: '&{integer}'
     │
 
 error: 
 
-    ┌── tests/move_check/typing/subtype_assign_invalid.move:16:13 ───
+    ┌── tests/move_check/typing/subtype_assign_invalid.move:15:28 ───
     │
- 16 │         (x, y)= (&0, &0);
-    │             ^ Invalid assignment to local 'y'
-    ·
- 16 │         (x, y)= (&0, &0);
-    │                      -- The type: '&{integer}'
-    ·
  15 │         let (x, y): (&u64, &mut u64);
     │                            -------- Is not a subtype of: '&mut u64'
+ 16 │         (x, y)= (&0, &0);
+    │             ^ Invalid assignment to local 'y'
+    │                      -- The type: '&{integer}'
     │
 

--- a/language/move-lang/tests/move_check/typing/subtype_bind_invalid.exp
+++ b/language/move-lang/tests/move_check/typing/subtype_bind_invalid.exp
@@ -3,13 +3,9 @@ error:
    ┌── tests/move_check/typing/subtype_bind_invalid.move:5:16 ───
    │
  5 │         let x: &mut u64 = &0;
-   │                ^^^^^^^^ Invalid type annotation
-   ·
- 5 │         let x: &mut u64 = &0;
-   │                           -- The type: '&{integer}'
-   ·
- 5 │         let x: &mut u64 = &0;
    │                -------- Is not a subtype of: '&mut u64'
+   │                ^^^^^^^^ Invalid type annotation
+   │                           -- The type: '&{integer}'
    │
 
 error: 
@@ -18,12 +14,8 @@ error:
    │
  9 │         let (x, y): (&mut u64, &mut u64) = (&0, &0);
    │                     ^^^^^^^^^^^^^^^^^^^^ Invalid type annotation
-   ·
- 9 │         let (x, y): (&mut u64, &mut u64) = (&0, &0);
-   │                                             -- The type: '&{integer}'
-   ·
- 9 │         let (x, y): (&mut u64, &mut u64) = (&0, &0);
    │                      -------- Is not a subtype of: '&mut u64'
+   │                                             -- The type: '&{integer}'
    │
 
 error: 
@@ -32,12 +24,8 @@ error:
     │
  10 │         let (x, y): (&mut u64, &u64) = (&0, &0);
     │                     ^^^^^^^^^^^^^^^^ Invalid type annotation
-    ·
- 10 │         let (x, y): (&mut u64, &u64) = (&0, &0);
-    │                                         -- The type: '&{integer}'
-    ·
- 10 │         let (x, y): (&mut u64, &u64) = (&0, &0);
     │                      -------- Is not a subtype of: '&mut u64'
+    │                                         -- The type: '&{integer}'
     │
 
 error: 
@@ -46,11 +34,7 @@ error:
     │
  11 │         let (x, y): (&u64, &mut u64) = (&0, &0);
     │                     ^^^^^^^^^^^^^^^^ Invalid type annotation
-    ·
- 11 │         let (x, y): (&u64, &mut u64) = (&0, &0);
-    │                                             -- The type: '&{integer}'
-    ·
- 11 │         let (x, y): (&u64, &mut u64) = (&0, &0);
     │                            -------- Is not a subtype of: '&mut u64'
+    │                                             -- The type: '&{integer}'
     │
 

--- a/language/move-lang/tests/move_check/typing/subtype_return_invalid.exp
+++ b/language/move-lang/tests/move_check/typing/subtype_return_invalid.exp
@@ -1,70 +1,55 @@
 error: 
 
-   ┌── tests/move_check/typing/subtype_return_invalid.move:5:9 ───
+   ┌── tests/move_check/typing/subtype_return_invalid.move:4:15 ───
    │
- 5 │         u
-   │         ^ Invalid return expression
-   ·
  4 │     fun t0(u: &u64): &mut u64 {
    │               ---- The type: '&u64'
-   ·
- 4 │     fun t0(u: &u64): &mut u64 {
    │                      -------- Is not a subtype of: '&mut u64'
+ 5 │         u
+   │         ^ Invalid return expression
    │
 
 error: 
 
-   ┌── tests/move_check/typing/subtype_return_invalid.move:9:9 ───
+   ┌── tests/move_check/typing/subtype_return_invalid.move:8:15 ───
    │
- 9 │         s
-   │         ^ Invalid return expression
-   ·
  8 │     fun t1(s: &S): &mut S {
    │               -- The type: '&0x8675309::M::S'
-   ·
- 8 │     fun t1(s: &S): &mut S {
    │                    ------ Is not a subtype of: '&mut 0x8675309::M::S'
+ 9 │         s
+   │         ^ Invalid return expression
    │
 
 error: 
 
-    ┌── tests/move_check/typing/subtype_return_invalid.move:13:9 ───
+    ┌── tests/move_check/typing/subtype_return_invalid.move:12:26 ───
     │
- 13 │         (u1, u2)
-    │         ^^^^^^^^ Invalid return expression
-    ·
  12 │     fun t2(u1: &u64, u2: &u64): (&u64, &mut u64) {
     │                          ---- The type: '&u64'
-    ·
- 12 │     fun t2(u1: &u64, u2: &u64): (&u64, &mut u64) {
     │                                        -------- Is not a subtype of: '&mut u64'
+ 13 │         (u1, u2)
+    │         ^^^^^^^^ Invalid return expression
     │
 
 error: 
 
-    ┌── tests/move_check/typing/subtype_return_invalid.move:17:9 ───
+    ┌── tests/move_check/typing/subtype_return_invalid.move:16:16 ───
     │
+ 16 │     fun t3(u1: &u64, u2: &u64): (&mut u64, &u64) {
+    │                ---- The type: '&u64'
+    │                                  -------- Is not a subtype of: '&mut u64'
  17 │         (u1, u2)
     │         ^^^^^^^^ Invalid return expression
-    ·
- 16 │     fun t3(u1: &u64, u2: &u64): (&mut u64, &u64) {
-    │                ---- The type: '&u64'
-    ·
- 16 │     fun t3(u1: &u64, u2: &u64): (&mut u64, &u64) {
-    │                                  -------- Is not a subtype of: '&mut u64'
     │
 
 error: 
 
-    ┌── tests/move_check/typing/subtype_return_invalid.move:21:9 ───
+    ┌── tests/move_check/typing/subtype_return_invalid.move:20:16 ───
     │
- 21 │         (u1, u2)
-    │         ^^^^^^^^ Invalid return expression
-    ·
  20 │     fun t4(u1: &u64, u2: &u64): (&mut u64, &mut u64) {
     │                ---- The type: '&u64'
-    ·
- 20 │     fun t4(u1: &u64, u2: &u64): (&mut u64, &mut u64) {
     │                                  -------- Is not a subtype of: '&mut u64'
+ 21 │         (u1, u2)
+    │         ^^^^^^^^ Invalid return expression
     │
 

--- a/language/move-lang/tests/move_check/typing/type_variable_join_single_pack_invalid.exp
+++ b/language/move-lang/tests/move_check/typing/type_variable_join_single_pack_invalid.exp
@@ -1,28 +1,20 @@
 error: 
 
-   ┌── tests/move_check/typing/type_variable_join_single_pack_invalid.move:5:38 ───
+   ┌── tests/move_check/typing/type_variable_join_single_pack_invalid.move:5:27 ───
    │
  5 │         let b = Box { f1: false, f2: 1 };
-   │                                      ^ Invalid argument for field 'f2' for '0x8675309::M::Box'
-   ·
- 5 │         let b = Box { f1: false, f2: 1 };
-   │                                      - The type: integer
-   ·
- 5 │         let b = Box { f1: false, f2: 1 };
    │                           ----- Is not compatible with: 'bool'
+   │                                      - The type: integer
+   │                                      ^ Invalid argument for field 'f2' for '0x8675309::M::Box'
    │
 
 error: 
 
-   ┌── tests/move_check/typing/type_variable_join_single_pack_invalid.move:6:55 ───
+   ┌── tests/move_check/typing/type_variable_join_single_pack_invalid.move:6:28 ───
    │
  6 │         let b2 = Box { f1: Box { f1: 0, f2: 0 }, f2:  Box { f1: false, f2: false } };
-   │                                                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Invalid argument for field 'f2' for '0x8675309::M::Box'
-   ·
- 6 │         let b2 = Box { f1: Box { f1: 0, f2: 0 }, f2:  Box { f1: false, f2: false } };
    │                            -------------------- The type: integer
-   ·
- 6 │         let b2 = Box { f1: Box { f1: 0, f2: 0 }, f2:  Box { f1: false, f2: false } };
+   │                                                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Invalid argument for field 'f2' for '0x8675309::M::Box'
    │                                                                 ----- Is not compatible with: 'bool'
    │
 

--- a/language/move-lang/tests/move_check/typing/type_variable_join_single_unpack_assign_invalid.exp
+++ b/language/move-lang/tests/move_check/typing/type_variable_join_single_unpack_assign_invalid.exp
@@ -1,28 +1,22 @@
 error: 
 
-    ┌── tests/move_check/typing/type_variable_join_single_unpack_assign_invalid.move:13:14 ───
+    ┌── tests/move_check/typing/type_variable_join_single_unpack_assign_invalid.move:12:14 ───
     │
- 13 │         (f2: bool);
-    │              ^^^^ Invalid type annotation
-    ·
  12 │         (f1: u64);
     │              --- The type: 'u64'
-    ·
  13 │         (f2: bool);
     │              ---- Is not compatible with: 'bool'
+    │              ^^^^ Invalid type annotation
     │
 
 error: 
 
-    ┌── tests/move_check/typing/type_variable_join_single_unpack_assign_invalid.move:18:14 ───
+    ┌── tests/move_check/typing/type_variable_join_single_unpack_assign_invalid.move:17:18 ───
     │
- 18 │         (f2: Box<bool>);
-    │              ^^^^^^^^^ Invalid type annotation
-    ·
  17 │         (f1: Box<u64>);
     │                  --- The type: 'u64'
-    ·
  18 │         (f2: Box<bool>);
+    │              ^^^^^^^^^ Invalid type annotation
     │                  ---- Is not compatible with: 'bool'
     │
 

--- a/language/move-lang/tests/move_check/typing/type_variable_join_single_unpack_invalid.exp
+++ b/language/move-lang/tests/move_check/typing/type_variable_join_single_unpack_invalid.exp
@@ -1,28 +1,22 @@
 error: 
 
-    ┌── tests/move_check/typing/type_variable_join_single_unpack_invalid.move:11:14 ───
+    ┌── tests/move_check/typing/type_variable_join_single_unpack_invalid.move:10:14 ───
     │
- 11 │         (f2: bool);
-    │              ^^^^ Invalid type annotation
-    ·
  10 │         (f1: u64);
     │              --- The type: 'u64'
-    ·
  11 │         (f2: bool);
     │              ---- Is not compatible with: 'bool'
+    │              ^^^^ Invalid type annotation
     │
 
 error: 
 
-    ┌── tests/move_check/typing/type_variable_join_single_unpack_invalid.move:14:14 ───
+    ┌── tests/move_check/typing/type_variable_join_single_unpack_invalid.move:13:18 ───
     │
- 14 │         (f2: Box<bool>);
-    │              ^^^^^^^^^ Invalid type annotation
-    ·
  13 │         (f1: Box<u64>);
     │                  --- The type: 'u64'
-    ·
  14 │         (f2: Box<bool>);
+    │              ^^^^^^^^^ Invalid type annotation
     │                  ---- Is not compatible with: 'bool'
     │
 

--- a/language/move-lang/tests/move_check/typing/type_variable_join_threaded_pack_invalid.exp
+++ b/language/move-lang/tests/move_check/typing/type_variable_join_threaded_pack_invalid.exp
@@ -1,31 +1,31 @@
 error: 
 
-    ┌── tests/move_check/typing/type_variable_join_threaded_pack_invalid.move:42:9 ───
+    ┌── tests/move_check/typing/type_variable_join_threaded_pack_invalid.move:35:19 ───
     │
- 42 │         b
-    │         ^ Invalid return expression
+ 35 │     fun t0(): Box<bool> {
+    │                   ---- Is not compatible with: 'bool'
     ·
  40 │         let r = Container::get_ref(&v);
     │                 ---------------------- The type: integer
-    ·
- 35 │     fun t0(): Box<bool> {
-    │                   ---- Is not compatible with: 'bool'
+ 41 │         id(r);
+ 42 │         b
+    │         ^ Invalid return expression
     │
 
 error: 
 
-    ┌── tests/move_check/typing/type_variable_join_threaded_pack_invalid.move:47:17 ───
+    ┌── tests/move_check/typing/type_variable_join_threaded_pack_invalid.move:10:23 ───
     │
- 47 │         let x = Container::get(&v);
-    │                 ^^^^^^^^^^^^^^^^^^ Constraint not satisfied.
-    ·
- 49 │         Container::put(&mut v, Box {f1: R{}, f2: R{}});
-    │                                ---------------------- The resource type '0x1::M::Box<0x1::M::R>' does not satisfy the constraint 'copyable'
+ 10 │     public fun get<V: copyable>(self: &T<V>): V {
+    │                       -------- 'copyable' constraint declared here
     ·
  28 │     resource struct R{}
     │     -------- The type's constraint information was determined here
     ·
- 10 │     public fun get<V: copyable>(self: &T<V>): V {
-    │                       -------- 'copyable' constraint declared here
+ 47 │         let x = Container::get(&v);
+    │                 ^^^^^^^^^^^^^^^^^^ Constraint not satisfied.
+ 48 │         let b = Box { f1: x, f2: x };
+ 49 │         Container::put(&mut v, Box {f1: R{}, f2: R{}});
+    │                                ---------------------- The resource type '0x1::M::Box<0x1::M::R>' does not satisfy the constraint 'copyable'
     │
 

--- a/language/move-lang/tests/move_check/typing/type_variable_join_threaded_unpack_assign_invalid.exp
+++ b/language/move-lang/tests/move_check/typing/type_variable_join_threaded_unpack_assign_invalid.exp
@@ -1,31 +1,29 @@
 error: 
 
-    ┌── tests/move_check/typing/type_variable_join_threaded_unpack_assign_invalid.move:36:9 ───
+    ┌── tests/move_check/typing/type_variable_join_threaded_unpack_assign_invalid.move:30:15 ───
     │
- 36 │         f1
-    │         ^^ Invalid return expression
+ 30 │     fun t0(): bool {
+    │               ---- Is not compatible with: 'bool'
     ·
  34 │         Box { f1, f2 }  = Container::get(&v);
     │         -------------- The type: integer
-    ·
- 30 │     fun t0(): bool {
-    │               ---- Is not compatible with: 'bool'
+ 35 │         Container::put(&mut v, Box { f1: 0, f2: 0});
+ 36 │         f1
+    │         ^^ Invalid return expression
     │
 
 error: 
 
-    ┌── tests/move_check/typing/type_variable_join_threaded_unpack_assign_invalid.move:43:27 ───
+    ┌── tests/move_check/typing/type_variable_join_threaded_unpack_assign_invalid.move:10:23 ───
     │
- 43 │         Box { f1, f2 }  = Container::get(&v);
-    │                           ^^^^^^^^^^^^^^^^^^ Constraint not satisfied.
-    ·
- 43 │         Box { f1, f2 }  = Container::get(&v);
-    │         -------------- The resource type '0x1::M::Box<0x1::M::R>' does not satisfy the constraint 'copyable'
+ 10 │     public fun get<V: copyable>(self: &T<V>): V {
+    │                       -------- 'copyable' constraint declared here
     ·
  24 │     resource struct R{}
     │     -------- The type's constraint information was determined here
     ·
- 10 │     public fun get<V: copyable>(self: &T<V>): V {
-    │                       -------- 'copyable' constraint declared here
+ 43 │         Box { f1, f2 }  = Container::get(&v);
+    │         -------------- The resource type '0x1::M::Box<0x1::M::R>' does not satisfy the constraint 'copyable'
+    │                           ^^^^^^^^^^^^^^^^^^ Constraint not satisfied.
     │
 

--- a/language/move-lang/tests/move_check/typing/type_variable_join_threaded_unpack_invalid.exp
+++ b/language/move-lang/tests/move_check/typing/type_variable_join_threaded_unpack_invalid.exp
@@ -1,31 +1,29 @@
 error: 
 
-    ┌── tests/move_check/typing/type_variable_join_threaded_unpack_invalid.move:34:9 ───
+    ┌── tests/move_check/typing/type_variable_join_threaded_unpack_invalid.move:30:15 ───
     │
- 34 │         f1
-    │         ^^ Invalid return expression
-    ·
- 32 │         let Box { f1, f2 }  = Container::get(&v);
-    │             -------------- The type: integer
-    ·
  30 │     fun t0(): bool {
     │               ---- Is not compatible with: 'bool'
+ 31 │         let v = Container::new();
+ 32 │         let Box { f1, f2 }  = Container::get(&v);
+    │             -------------- The type: integer
+ 33 │         Container::put(&mut v, Box { f1: 0, f2: 0});
+ 34 │         f1
+    │         ^^ Invalid return expression
     │
 
 error: 
 
-    ┌── tests/move_check/typing/type_variable_join_threaded_unpack_invalid.move:39:31 ───
+    ┌── tests/move_check/typing/type_variable_join_threaded_unpack_invalid.move:10:23 ───
     │
- 39 │         let Box { f1, f2 }  = Container::get(&v);
-    │                               ^^^^^^^^^^^^^^^^^^ Constraint not satisfied.
-    ·
- 39 │         let Box { f1, f2 }  = Container::get(&v);
-    │             -------------- The resource type '0x1::M::Box<0x1::M::R>' does not satisfy the constraint 'copyable'
+ 10 │     public fun get<V: copyable>(self: &T<V>): V {
+    │                       -------- 'copyable' constraint declared here
     ·
  24 │     resource struct R{}
     │     -------- The type's constraint information was determined here
     ·
- 10 │     public fun get<V: copyable>(self: &T<V>): V {
-    │                       -------- 'copyable' constraint declared here
+ 39 │         let Box { f1, f2 }  = Container::get(&v);
+    │             -------------- The resource type '0x1::M::Box<0x1::M::R>' does not satisfy the constraint 'copyable'
+    │                               ^^^^^^^^^^^^^^^^^^ Constraint not satisfied.
     │
 

--- a/language/move-lang/tests/move_check/typing/unary_not_invalid.exp
+++ b/language/move-lang/tests/move_check/typing/unary_not_invalid.exp
@@ -3,13 +3,9 @@ error:
    ┌── tests/move_check/typing/unary_not_invalid.move:7:10 ───
    │
  7 │         !&true;
-   │          ^^^^^ Invalid argument to '!'
-   ·
- 7 │         !&true;
    │          ----- The type: '&bool'
-   ·
- 7 │         !&true;
    │          ----- Is not compatible with: 'bool'
+   │          ^^^^^ Invalid argument to '!'
    │
 
 error: 
@@ -17,13 +13,9 @@ error:
    ┌── tests/move_check/typing/unary_not_invalid.move:8:10 ───
    │
  8 │         !&false;
-   │          ^^^^^^ Invalid argument to '!'
-   ·
- 8 │         !&false;
    │          ------ The type: '&bool'
-   ·
- 8 │         !&false;
    │          ------ Is not compatible with: 'bool'
+   │          ^^^^^^ Invalid argument to '!'
    │
 
 error: 
@@ -31,13 +23,9 @@ error:
    ┌── tests/move_check/typing/unary_not_invalid.move:9:10 ───
    │
  9 │         !0;
-   │          ^ Invalid argument to '!'
-   ·
- 9 │         !0;
    │          - The type: integer
-   ·
- 9 │         !0;
    │          - Is not compatible with: 'bool'
+   │          ^ Invalid argument to '!'
    │
 
 error: 
@@ -45,41 +33,33 @@ error:
     ┌── tests/move_check/typing/unary_not_invalid.move:10:10 ───
     │
  10 │         !1;
-    │          ^ Invalid argument to '!'
-    ·
- 10 │         !1;
     │          - The type: integer
-    ·
- 10 │         !1;
     │          - Is not compatible with: 'bool'
+    │          ^ Invalid argument to '!'
     │
 
 error: 
 
-    ┌── tests/move_check/typing/unary_not_invalid.move:11:10 ───
+    ┌── tests/move_check/typing/unary_not_invalid.move:6:24 ───
     │
- 11 │         !r;
-    │          ^ Invalid argument to '!'
-    ·
   6 │     fun t0(x: bool, r: R) {
     │                        - The type: '0x8675309::M::R'
     ·
  11 │         !r;
     │          - Is not compatible with: 'bool'
+    │          ^ Invalid argument to '!'
     │
 
 error: 
 
-    ┌── tests/move_check/typing/unary_not_invalid.move:12:10 ───
+    ┌── tests/move_check/typing/unary_not_invalid.move:6:24 ───
     │
- 12 │         !r;
-    │          ^ Invalid argument to '!'
-    ·
   6 │     fun t0(x: bool, r: R) {
     │                        - The type: '0x8675309::M::R'
     ·
  12 │         !r;
     │          - Is not compatible with: 'bool'
+    │          ^ Invalid argument to '!'
     │
 
 error: 
@@ -87,13 +67,9 @@ error:
     ┌── tests/move_check/typing/unary_not_invalid.move:13:10 ───
     │
  13 │         !(0, false);
-    │          ^^^^^^^^^^ Invalid argument to '!'
-    ·
- 13 │         !(0, false);
     │          ---------- The type: '({integer}, bool)'
-    ·
- 13 │         !(0, false);
     │          ---------- Is not compatible with: 'bool'
+    │          ^^^^^^^^^^ Invalid argument to '!'
     │
 
 error: 
@@ -101,12 +77,8 @@ error:
     ┌── tests/move_check/typing/unary_not_invalid.move:14:10 ───
     │
  14 │         !();
-    │          ^^ Invalid argument to '!'
-    ·
- 14 │         !();
     │          -- The type: '()'
-    ·
- 14 │         !();
     │          -- Is not compatible with: 'bool'
+    │          ^^ Invalid argument to '!'
     │
 

--- a/language/move-lang/tests/move_check/typing/uninferred_type_pack.exp
+++ b/language/move-lang/tests/move_check/typing/uninferred_type_pack.exp
@@ -1,15 +1,13 @@
 error: 
 
-   ┌── tests/move_check/typing/uninferred_type_pack.move:5:9 ───
+   ┌── tests/move_check/typing/uninferred_type_pack.move:2:14 ───
    │
- 5 │         S{};
-   │         ^^^ Cannot ignore resource values. The value must be used
+ 2 │     struct S<T> {}
+   │              - Is found to be a non-copyable type here
    ·
  5 │         S{};
    │         --- The type: '0x8675309::M::S<_>'
-   ·
- 2 │     struct S<T> {}
-   │              - Is found to be a non-copyable type here
+   │         ^^^ Cannot ignore resource values. The value must be used
    │
 
 error: 

--- a/language/move-lang/tests/move_check/typing/while_body_invalid.exp
+++ b/language/move-lang/tests/move_check/typing/while_body_invalid.exp
@@ -3,13 +3,9 @@ error:
    ┌── tests/move_check/typing/while_body_invalid.move:3:22 ───
    │
  3 │         while (cond) 0;
-   │                      ^ Invalid loop body
-   ·
- 3 │         while (cond) 0;
    │                      - The type: integer
-   ·
- 3 │         while (cond) 0;
    │                      - Is not compatible with: '()'
+   │                      ^ Invalid loop body
    │
 
 error: 
@@ -17,13 +13,9 @@ error:
    ┌── tests/move_check/typing/while_body_invalid.move:4:22 ───
    │
  4 │         while (cond) false;
-   │                      ^^^^^ Invalid loop body
-   ·
- 4 │         while (cond) false;
    │                      ----- The type: 'bool'
-   ·
- 4 │         while (cond) false;
    │                      ----- Is not compatible with: '()'
+   │                      ^^^^^ Invalid loop body
    │
 
 error: 
@@ -31,13 +23,9 @@ error:
    ┌── tests/move_check/typing/while_body_invalid.move:5:22 ───
    │
  5 │         while (cond) { 0x0 };
-   │                      ^^^^^^^ Invalid loop body
-   ·
- 5 │         while (cond) { 0x0 };
-   │                        --- The type: 'address'
-   ·
- 5 │         while (cond) { 0x0 };
    │                      ------- Is not compatible with: '()'
+   │                      ^^^^^^^ Invalid loop body
+   │                        --- The type: 'address'
    │
 
 error: 
@@ -45,13 +33,9 @@ error:
    ┌── tests/move_check/typing/while_body_invalid.move:6:22 ───
    │
  6 │         while (cond) { let x = 0; x };
-   │                      ^^^^^^^^^^^^^^^^ Invalid loop body
-   ·
- 6 │         while (cond) { let x = 0; x };
-   │                            - The type: integer
-   ·
- 6 │         while (cond) { let x = 0; x };
    │                      ---------------- Is not compatible with: '()'
+   │                      ^^^^^^^^^^^^^^^^ Invalid loop body
+   │                            - The type: integer
    │
 
 error: 
@@ -59,12 +43,8 @@ error:
    ┌── tests/move_check/typing/while_body_invalid.move:7:22 ───
    │
  7 │         while (cond) { if (cond) 1 else 0 };
-   │                      ^^^^^^^^^^^^^^^^^^^^^^ Invalid loop body
-   ·
- 7 │         while (cond) { if (cond) 1 else 0 };
-   │                                         - The type: integer
-   ·
- 7 │         while (cond) { if (cond) 1 else 0 };
    │                      ---------------------- Is not compatible with: '()'
+   │                      ^^^^^^^^^^^^^^^^^^^^^^ Invalid loop body
+   │                                         - The type: integer
    │
 

--- a/language/move-lang/tests/move_check/typing/while_condition_invalid.exp
+++ b/language/move-lang/tests/move_check/typing/while_condition_invalid.exp
@@ -3,13 +3,9 @@ error:
    ┌── tests/move_check/typing/while_condition_invalid.move:3:16 ───
    │
  3 │         while (()) ();
-   │                ^^ Invalid while condition
-   ·
- 3 │         while (()) ();
    │                -- The type: '()'
-   ·
- 3 │         while (()) ();
    │                -- Is not compatible with: 'bool'
+   │                ^^ Invalid while condition
    │
 
 error: 
@@ -17,13 +13,9 @@ error:
    ┌── tests/move_check/typing/while_condition_invalid.move:4:16 ───
    │
  4 │         while ((())) ();
-   │                ^^^^ Invalid while condition
-   ·
- 4 │         while ((())) ();
    │                ---- The type: '()'
-   ·
- 4 │         while ((())) ();
    │                ---- Is not compatible with: 'bool'
+   │                ^^^^ Invalid while condition
    │
 
 error: 
@@ -31,27 +23,20 @@ error:
    ┌── tests/move_check/typing/while_condition_invalid.move:5:16 ───
    │
  5 │         while ({}) ()
-   │                ^^ Invalid while condition
-   ·
- 5 │         while ({}) ()
    │                -- The type: '()'
-   ·
- 5 │         while ({}) ()
    │                -- Is not compatible with: 'bool'
+   │                ^^ Invalid while condition
    │
 
 error: 
 
-   ┌── tests/move_check/typing/while_condition_invalid.move:9:16 ───
+   ┌── tests/move_check/typing/while_condition_invalid.move:8:28 ───
    │
- 9 │         while (x) ();
-   │                ^ Invalid while condition
-   ·
  8 │     fun t1<T: copyable>(x: T) {
    │                            - The type: 'T'
-   ·
  9 │         while (x) ();
    │                - Is not compatible with: 'bool'
+   │                ^ Invalid while condition
    │
 
 error: 
@@ -59,13 +44,9 @@ error:
     ┌── tests/move_check/typing/while_condition_invalid.move:10:16 ───
     │
  10 │         while (0) ();
-    │                ^ Invalid while condition
-    ·
- 10 │         while (0) ();
     │                - The type: integer
-    ·
- 10 │         while (0) ();
     │                - Is not compatible with: 'bool'
+    │                ^ Invalid while condition
     │
 
 error: 
@@ -73,13 +54,9 @@ error:
     ┌── tests/move_check/typing/while_condition_invalid.move:11:16 ───
     │
  11 │         while (0x0) ()
-    │                ^^^ Invalid while condition
-    ·
- 11 │         while (0x0) ()
     │                --- The type: 'address'
-    ·
- 11 │         while (0x0) ()
     │                --- Is not compatible with: 'bool'
+    │                ^^^ Invalid while condition
     │
 
 error: 
@@ -87,13 +64,9 @@ error:
     ┌── tests/move_check/typing/while_condition_invalid.move:15:16 ───
     │
  15 │         while ((false, true)) ();
-    │                ^^^^^^^^^^^^^ Invalid while condition
-    ·
- 15 │         while ((false, true)) ();
     │                ------------- The type: '(bool, bool)'
-    ·
- 15 │         while ((false, true)) ();
     │                ------------- Is not compatible with: 'bool'
+    │                ^^^^^^^^^^^^^ Invalid while condition
     │
 
 error: 
@@ -101,12 +74,8 @@ error:
     ┌── tests/move_check/typing/while_condition_invalid.move:16:16 ───
     │
  16 │         while ((0, false)) ()
-    │                ^^^^^^^^^^ Invalid while condition
-    ·
- 16 │         while ((0, false)) ()
     │                ---------- The type: '({integer}, bool)'
-    ·
- 16 │         while ((0, false)) ()
     │                ---------- Is not compatible with: 'bool'
+    │                ^^^^^^^^^^ Invalid while condition
     │
 

--- a/language/move-prover/Cargo.toml
+++ b/language/move-prover/Cargo.toml
@@ -23,8 +23,8 @@ stdlib = { path = "../stdlib", version = "0.1.0" }
 # external dependencies
 anyhow = "1.0.*"
 clap = "2.33.0"
-codespan = "0.8.0"
-codespan-reporting = "0.8.0"
+codespan = "0.9.2"
+codespan-reporting = "0.9.2"
 itertools = "0.9.0"
 log = "0.4.8"
 num = "0.2.0"

--- a/language/move-prover/spec-lang/Cargo.toml
+++ b/language/move-prover/spec-lang/Cargo.toml
@@ -19,8 +19,8 @@ move-vm-types = { path = "../../move-vm/types", version = "0.1.0" }
 stdlib = { path = "../../stdlib", version = "0.1.0" }
 
 # external dependencies
-codespan = "0.8.0"
-codespan-reporting = "0.8.0"
+codespan = "0.9.2"
+codespan-reporting = "0.9.2"
 itertools = "0.9.0"
 log = "0.4.8"
 num = "0.2.0"

--- a/language/move-prover/spec-lang/src/env.rs
+++ b/language/move-prover/spec-lang/src/env.rs
@@ -286,8 +286,8 @@ impl GlobalEnv {
 
     /// Adds an error to this environment, with notes.
     pub fn error_with_notes(&self, loc: &Loc, msg: &str, notes: Vec<String>) {
-        let diag = Diagnostic::<FileId>::error()
-            .with_labels([Label::<FileId>::primary(loc.file_id, loc.span)].to_vec())
+        let diag = Diagnostic::error()
+            .with_labels(vec![Label::primary(loc.file_id, loc.span)])
             .with_message(msg)
             .with_notes(notes);
         self.add_diag(diag);

--- a/language/move-prover/spec-lang/src/lib.rs
+++ b/language/move-prover/spec-lang/src/lib.rs
@@ -73,22 +73,19 @@ pub fn run_spec_lang_compiler(
 }
 
 fn add_move_lang_errors(env: &mut GlobalEnv, errors: Errors) {
-    let mk_secondary_lbl = |err: (move_ir_types::location::Loc, String)| -> Label<FileId> {
-        let loc = env.to_loc(&err.0);
-        Label::<FileId>::secondary(loc.file_id(), loc.span()).with_message(err.1)
-    };
     let mk_primary_lbl = |err: (move_ir_types::location::Loc, String)| -> Label<FileId> {
         let loc = env.to_loc(&err.0);
-        Label::<FileId>::primary(loc.file_id(), loc.span()).with_message(err.1)
+        Label::primary(loc.file_id(), loc.span()).with_message(err.1)
     };
-
+    let mk_secondary_lbl = |err: (move_ir_types::location::Loc, String)| -> Label<FileId> {
+        let loc = env.to_loc(&err.0);
+        Label::secondary(loc.file_id(), loc.span()).with_message(err.1)
+    };
     for mut error in errors {
         let err = error.remove(0);
         let mut labels = vec![mk_primary_lbl(err)];
         labels.extend(error.into_iter().map(mk_secondary_lbl));
-        Diagnostic::<FileId>::error()
-            .with_message("")
-            .with_labels(labels);
+        Diagnostic::error().with_labels(labels);
     }
 }
 

--- a/language/move-prover/src/boogie_wrapper.rs
+++ b/language/move-prover/src/boogie_wrapper.rs
@@ -138,19 +138,19 @@ impl<'env> BoogieWrapper<'env> {
             }
         });
         let on_source = loc_opt.is_some();
-        let label: Label<FileId> = if let Some(loc) = &loc_opt {
-            Label::<FileId>::primary(loc.file_id(), loc.span()).with_message("")
+        let label = if let Some(loc) = &loc_opt {
+            Label::primary(loc.file_id(), loc.span()).with_message("")
         } else {
-            Label::<FileId>::primary(self.boogie_file_id, Span::new(index, index)).with_message("")
+            Label::primary(self.boogie_file_id, Span::new(index, index)).with_message("")
         };
 
         let mut diag = if on_source {
-            Diagnostic::<FileId>::error()
+            Diagnostic::error()
         } else {
-            Diagnostic::<FileId>::bug()
+            Diagnostic::bug()
         }
         .with_message(&error.message)
-        .with_labels([label].to_vec());
+        .with_labels(vec![label]);
 
         // Now add trace diagnostics.
         if error.kind.is_from_verification()

--- a/language/move-prover/stackless-bytecode-generator/Cargo.toml
+++ b/language/move-prover/stackless-bytecode-generator/Cargo.toml
@@ -24,8 +24,8 @@ move-vm-types = { path = "../../move-vm/types", version = "0.1.0" }
 [dev-dependencies]
 datatest-stable = { path = "../../../common/datatest-stable", version = "0.1.0" }
 test-utils = { path = "../test-utils", version = "0.1.0" }
-codespan = "0.8.0"
-codespan-reporting = "0.8.0"
+codespan = "0.9.2"
+codespan-reporting = "0.9.2"
 libra-temppath = { path = "../../../common/temppath", version = "0.1.0" }
 anyhow = "1.0.*"
 


### PR DESCRIPTION
<!--
Thank you for sending a PR. We appreciate you spending time to help improve the Libra project.

The project is undergoing daily changes. Pull Requests will be reviewed and responded to as time permits.
-->

## Motivation

Update codespan.   

### Have you read the [Contributing Guidelines on pull requests]

yes

## Test Plan

CI, unit tests, getting move lang folks to validate the error output behavior change that is a result of codespan-reportings's change in handling output (single lining multi line errors)

Seems like it's otherwise okay.   Aside from the emit needing a non-borrowed reference.

## Related PRs

Couple of codespan updates from dependabot that will get autoclosed.