### PR TITLE
[db-bootstrapper] works on pre-genesis state

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,7 +4,7 @@ executors:
   build-executor:
     docker:
       - image: circleci/rust:buster
-    resource_class: 2xlarge
+    resource_class: 2xlarge+
   test-executor:
     docker:
       - image: circleci/rust:buster

--- a/execution/executor-utils/src/lib.rs
+++ b/execution/executor-utils/src/lib.rs
@@ -4,7 +4,7 @@
 #[cfg(any(test, feature = "testing"))]
 pub mod test_helpers;
 
-use executor::{db_bootstrapper::maybe_bootstrap_db, Executor};
+use executor::{db_bootstrapper::bootstrap_db_if_empty, Executor};
 use libra_config::config::NodeConfig;
 use libra_vm::LibraVM;
 use storage_client::SyncStorageClient;
@@ -12,10 +12,10 @@ use storage_service::{init_libra_db, start_storage_service_with_db};
 use tokio::runtime::Runtime;
 
 pub fn create_storage_service_and_executor(config: &NodeConfig) -> (Runtime, Executor<LibraVM>) {
-    let (arc_db, db_reader_writer) = init_libra_db(config);
-    maybe_bootstrap_db::<LibraVM>(db_reader_writer, config).unwrap();
+    let (db, db_rw) = init_libra_db(config);
+    bootstrap_db_if_empty::<LibraVM>(&db_rw, config).unwrap();
 
-    let rt = start_storage_service_with_db(config, arc_db);
+    let rt = start_storage_service_with_db(config, db);
     let executor = Executor::new(SyncStorageClient::new(&config.storage.address).into());
 
     (rt, executor)

--- a/execution/executor/src/db_bootstrapper.rs
+++ b/execution/executor/src/db_bootstrapper.rs
@@ -4,26 +4,23 @@
 #![forbid(unsafe_code)]
 
 use crate::{BlockExecutor, Executor};
-use anyhow::Result;
+use anyhow::{format_err, Result};
 use libra_config::config::NodeConfig;
 use libra_crypto::{hash::PRE_GENESIS_BLOCK_ID, HashValue};
 use libra_logger::prelude::*;
 use libra_temppath::TempPath;
 use libra_types::{
-    ledger_info::{LedgerInfo, LedgerInfoWithSignatures},
-    transaction::Transaction,
-    waypoint::Waypoint,
+    ledger_info::LedgerInfoWithSignatures, transaction::Transaction, waypoint::Waypoint,
 };
 use libra_vm::VMExecutor;
 use libradb::LibraDB;
 use storage_interface::DbReaderWriter;
+use storage_proto::TreeState;
 
-pub fn maybe_bootstrap_db<V: VMExecutor>(db: DbReaderWriter, config: &NodeConfig) -> Result<()> {
-    let startup_info_opt = db.reader.get_startup_info()?;
-    if startup_info_opt.is_some() {
-        return Ok(());
-    }
-
+pub fn bootstrap_db_if_empty<V: VMExecutor>(
+    db: &DbReaderWriter,
+    config: &NodeConfig,
+) -> Result<Option<Waypoint>> {
     let genesis_txn = config
         .execution
         .genesis
@@ -31,26 +28,32 @@ pub fn maybe_bootstrap_db<V: VMExecutor>(db: DbReaderWriter, config: &NodeConfig
         .expect("failed to load genesis txn!")
         .clone();
 
-    execute_and_commit::<V>(db, genesis_txn).map(|_| ())
+    bootstrap_db_if_empty_impl::<V>(db, genesis_txn)
 }
 
-pub fn compute_genesis_waypoint<V: VMExecutor>(genesis: Transaction) -> Result<Waypoint> {
-    let path = TempPath::new();
-    path.create_as_dir().expect("Unable to create directory");
-    let (_, db) = DbReaderWriter::wrap(LibraDB::new(&path.path()));
-    let ledger_info = execute_and_commit::<V>(db, genesis)?;
-    Waypoint::new(&ledger_info)
+/// Bootstraps DB and returns the Waypoint if DB is empty, otherwise returns None.
+fn bootstrap_db_if_empty_impl<V: VMExecutor>(
+    db: &DbReaderWriter,
+    genesis_txn: Transaction,
+) -> Result<Option<Waypoint>> {
+    let tree_state = db.reader.get_latest_tree_state()?;
+    if !tree_state.is_empty() {
+        return Ok(None);
+    }
+
+    Ok(Some(bootstrap_db::<V>(db, tree_state, genesis_txn)?))
 }
 
-fn execute_and_commit<V: VMExecutor>(
-    db: DbReaderWriter,
-    genesis: Transaction,
-) -> Result<LedgerInfo> {
-    let mut executor = Executor::<V>::new_on_unbootstrapped_db(db);
+pub fn bootstrap_db<V: VMExecutor>(
+    db: &DbReaderWriter,
+    tree_state: TreeState,
+    genesis_txn: Transaction,
+) -> Result<Waypoint> {
+    let mut executor = Executor::<V>::new_on_unbootstrapped_db(db.clone(), tree_state);
 
     let block_id = HashValue::zero(); // match with the id in BlockInfo::genesis(...)
-                                      // Create a block with genesis being the only txn. Execute it then commit it immediately.
-    let result = executor.execute_block((block_id, vec![genesis]), *PRE_GENESIS_BLOCK_ID)?;
+                                      // Create a block with genesis_txn being the only txn. Execute it then commit it immediately.
+    let result = executor.execute_block((block_id, vec![genesis_txn]), *PRE_GENESIS_BLOCK_ID)?;
 
     let root_hash = result.root_hash();
     let validator_set = result
@@ -59,11 +62,21 @@ fn execute_and_commit<V: VMExecutor>(
         .expect("Genesis transaction must emit a validator set.");
 
     let ledger_info_with_sigs = LedgerInfoWithSignatures::genesis(root_hash, validator_set.clone());
-    let ledger_info = ledger_info_with_sigs.ledger_info().clone();
+    let waypoint = Waypoint::new(ledger_info_with_sigs.ledger_info())?;
+
     executor.commit_blocks(vec![HashValue::zero()], ledger_info_with_sigs)?;
     info!(
         "GENESIS transaction is committed with state_id {} and ValidatorSet {}.",
         root_hash, validator_set
     );
-    Ok(ledger_info)
+    // DB bootstrapped, avoid anything that could fail after this.
+
+    Ok(waypoint)
+}
+
+pub fn compute_genesis_waypoint<V: VMExecutor>(genesis_txn: Transaction) -> Result<Waypoint> {
+    let path = TempPath::new();
+    let (_, db_rw) = DbReaderWriter::wrap(LibraDB::new(&path.path()));
+    bootstrap_db_if_empty_impl::<V>(&db_rw, genesis_txn)?
+        .ok_or_else(|| format_err!("Failed to bootstrap empty DB."))
 }

--- a/execution/executor/src/executor_test.rs
+++ b/execution/executor/src/executor_test.rs
@@ -3,7 +3,7 @@
 
 use super::*;
 use crate::{
-    db_bootstrapper::maybe_bootstrap_db,
+    db_bootstrapper::bootstrap_db_if_empty,
     mock_vm::{
         encode_mint_transaction, encode_reconfiguration_transaction, encode_transfer_transaction,
         MockVM, DISCARD_STATUS, KEEP_STATUS,
@@ -38,10 +38,9 @@ fn build_test_config() -> (NodeConfig, Ed25519PrivateKey) {
 }
 
 fn create_storage(config: &NodeConfig) -> Runtime {
-    let (arc_db, db_reader_writer) = init_libra_db(&config);
-    maybe_bootstrap_db::<MockVM>(db_reader_writer, &config)
-        .expect("Db-bootstrapper should not fail.");
-    start_storage_service_with_db(&config, arc_db)
+    let (db, db_rw) = init_libra_db(&config);
+    bootstrap_db_if_empty::<MockVM>(&db_rw, &config).expect("Db-bootstrapper should not fail.");
+    start_storage_service_with_db(&config, db)
 }
 
 fn create_executor(config: &NodeConfig) -> Executor<MockVM> {

--- a/execution/executor/src/lib.rs
+++ b/execution/executor/src/lib.rs
@@ -47,6 +47,7 @@ use std::{
     sync::Arc,
 };
 use storage_interface::{state_view::VerifiedStateView, DbReaderWriter};
+use storage_proto::TreeState;
 
 static OP_COUNTERS: Lazy<libra_metrics::OpMetrics> =
     Lazy::new(|| libra_metrics::OpMetrics::new_and_registered("executor"));
@@ -124,10 +125,10 @@ where
         }
     }
 
-    fn new_on_unbootstrapped_db(db: DbReaderWriter) -> Self {
+    fn new_on_unbootstrapped_db(db: DbReaderWriter, tree_state: TreeState) -> Self {
         Self {
             db,
-            cache: SpeculationCache::new(),
+            cache: SpeculationCache::new_with_tree_state(tree_state),
             phantom: PhantomData,
         }
     }

--- a/execution/executor/src/speculation_cache/mod.rs
+++ b/execution/executor/src/speculation_cache/mod.rs
@@ -27,7 +27,7 @@ use std::{
     collections::HashMap,
     sync::{Arc, Mutex, Weak},
 };
-use storage_proto::StartupInfo;
+use storage_proto::{StartupInfo, TreeState};
 
 /// The struct that stores all speculation result of its counterpart in consensus.
 pub(crate) struct SpeculationBlock {
@@ -125,6 +125,16 @@ impl SpeculationCache {
             cache.update_synced_trees(ExecutedTrees::from(synced_tree_state));
         }
         cache
+    }
+
+    pub fn new_with_tree_state(tree_state: TreeState) -> Self {
+        Self {
+            synced_trees: ExecutedTrees::new_empty(),
+            committed_trees: ExecutedTrees::from(tree_state),
+            heads: vec![],
+            block_map: Arc::new(Mutex::new(HashMap::new())),
+            committed_block_id: *PRE_GENESIS_BLOCK_ID,
+        }
     }
 
     pub fn committed_block_id(&self) -> HashValue {

--- a/execution/executor/tests/db_bootstrapper_test.rs
+++ b/execution/executor/tests/db_bootstrapper_test.rs
@@ -3,13 +3,40 @@
 
 #![forbid(unsafe_code)]
 
+use anyhow::Result;
 use config_builder::test_config;
-use executor::db_bootstrapper::bootstrap_db_if_empty;
+use executor::{
+    db_bootstrapper::{bootstrap_db, bootstrap_db_if_empty},
+    BlockExecutor, Executor,
+};
+use executor_utils::test_helpers::{gen_ledger_info_with_sigs, get_test_signed_transaction};
+use libra_crypto::{
+    ed25519::Ed25519PrivateKey, test_utils::TEST_SEED, HashValue, PrivateKey, Uniform,
+};
 use libra_temppath::TempPath;
-use libra_types::waypoint::Waypoint;
+use libra_types::{
+    access_path::AccessPath,
+    account_address::AccountAddress,
+    account_config::{association_address, lbr_type_tag, BalanceResource},
+    account_state::AccountState,
+    account_state_blob::AccountStateBlob,
+    contract_event::ContractEvent,
+    move_resource::MoveResource,
+    on_chain_config,
+    on_chain_config::{OnChainConfig, ValidatorSet},
+    proof::SparseMerkleRangeProof,
+    transaction::{
+        authenticator::AuthenticationKey, ChangeSet, Transaction, Version, PRE_GENESIS_VERSION,
+    },
+    waypoint::Waypoint,
+    write_set::{WriteOp, WriteSetMut},
+};
 use libra_vm::LibraVM;
 use libradb::LibraDB;
-use storage_interface::DbReaderWriter;
+use rand::SeedableRng;
+use std::convert::TryFrom;
+use storage_interface::{DbReader, DbReaderWriter};
+use transaction_builder::encode_create_account_script;
 
 #[test]
 fn test_empty_db() {
@@ -38,4 +65,179 @@ fn test_empty_db() {
     assert!(bootstrap_db_if_empty::<LibraVM>(&db_rw, &config)
         .unwrap()
         .is_none())
+}
+
+fn execute_and_commit(txns: Vec<Transaction>, db: &DbReaderWriter) {
+    let block_id = HashValue::random();
+    let version = db
+        .reader
+        .get_latest_ledger_info()
+        .unwrap()
+        .ledger_info()
+        .version();
+    let target_version = version + txns.len() as u64;
+    let mut executor = Executor::<LibraVM>::new(db.clone());
+    let output = executor
+        .execute_block((block_id, txns), executor.committed_block_id())
+        .unwrap();
+    let ledger_info_with_sigs =
+        gen_ledger_info_with_sigs(target_version, output.root_hash(), block_id);
+    executor
+        .commit_blocks(vec![block_id], ledger_info_with_sigs)
+        .unwrap();
+}
+
+fn get_demo_accounts() -> (
+    AccountAddress,
+    AuthenticationKey,
+    AccountAddress,
+    AuthenticationKey,
+) {
+    let seed = [1u8; 32];
+    // TEST_SEED is also used to generate a random validator set in get_test_config. Each account
+    // in this random validator set gets created in genesis. If one of {account1, account2,
+    // account3} already exists in genesis, the code below will fail.
+    assert!(seed != TEST_SEED);
+    let mut rng = ::rand::rngs::StdRng::from_seed(seed);
+
+    let privkey1 = Ed25519PrivateKey::generate(&mut rng);
+    let pubkey1 = privkey1.public_key();
+    let account1_auth_key = AuthenticationKey::ed25519(&pubkey1);
+    let account1 = account1_auth_key.derived_address();
+
+    let privkey2 = Ed25519PrivateKey::generate(&mut rng);
+    let pubkey2 = privkey2.public_key();
+    let account2_auth_key = AuthenticationKey::ed25519(&pubkey2);
+    let account2 = account2_auth_key.derived_address();
+
+    (account1, account1_auth_key, account2, account2_auth_key)
+}
+
+fn get_mint_transaction(
+    association_key: &Ed25519PrivateKey,
+    association_seq_num: u64,
+    account: &AccountAddress,
+    account_auth_key: &AuthenticationKey,
+    amount: u64,
+) -> Transaction {
+    get_test_signed_transaction(
+        association_address(),
+        /* sequence_number = */ association_seq_num,
+        association_key.clone(),
+        association_key.public_key(),
+        Some(encode_create_account_script(
+            &account,
+            account_auth_key.prefix().to_vec(),
+            amount,
+        )),
+    )
+}
+
+fn get_balance(account: &AccountAddress, db: &DbReaderWriter) -> u64 {
+    let account_state_blob = db
+        .reader
+        .get_latest_account_state(account.clone())
+        .unwrap()
+        .unwrap();
+    let account_state = AccountState::try_from(&account_state_blob).unwrap();
+    account_state
+        .get_balance_resource()
+        .unwrap()
+        .unwrap()
+        .coin()
+}
+
+fn get_state_backup(
+    db: &LibraDB,
+) -> (
+    Vec<(HashValue, AccountStateBlob)>,
+    SparseMerkleRangeProof,
+    HashValue,
+) {
+    let backup_handler = db.get_backup_handler();
+    let accounts = backup_handler
+        .get_account_iter(2)
+        .unwrap()
+        .collect::<Result<Vec<_>>>()
+        .unwrap();
+    let proof = backup_handler
+        .get_account_state_range_proof(accounts.last().unwrap().0, 1)
+        .unwrap();
+    let root_hash = db.get_latest_state_root().unwrap().1;
+
+    (accounts, proof, root_hash)
+}
+
+fn restore_state_to_db(
+    db: &LibraDB,
+    accounts: Vec<(HashValue, AccountStateBlob)>,
+    proof: SparseMerkleRangeProof,
+    root_hash: HashValue,
+    version: Version,
+) {
+    db.restore_account_state(vec![(accounts, proof)].into_iter(), version, root_hash)
+        .unwrap();
+}
+
+#[test]
+fn test_pre_genesis() {
+    let (config, genesis_key) = config_builder::test_config();
+
+    // Create bootstrapped DB.
+    let tmp_dir = TempPath::new();
+    let (db, db_rw) = DbReaderWriter::wrap(LibraDB::new(&tmp_dir));
+    bootstrap_db_if_empty::<LibraVM>(&db_rw, &config).unwrap();
+
+    // Mint for 2 demo accounts.
+    let (account1, account1_auth_key, account2, account2_auth_key) = get_demo_accounts();
+    let txn1 = get_mint_transaction(&genesis_key, 1, &account1, &account1_auth_key, 2000);
+    let txn2 = get_mint_transaction(&genesis_key, 2, &account2, &account2_auth_key, 2000);
+    execute_and_commit(vec![txn1, txn2], &db_rw);
+    assert_eq!(get_balance(&account1, &db_rw), 2000);
+    assert_eq!(get_balance(&account2, &db_rw), 2000);
+
+    // Get state tree backup.
+    let (accounts_backup, proof, root_hash) = get_state_backup(&db);
+    // Restore into PRE-GENESIS state of a new empty DB.
+    let tmp_dir = TempPath::new();
+    let (db, db_rw) = DbReaderWriter::wrap(LibraDB::new(&tmp_dir));
+    restore_state_to_db(&db, accounts_backup, proof, root_hash, PRE_GENESIS_VERSION);
+
+    // DB is not empty, `bootstrap_db_if_empty()` won't apply default genesis txn.
+    assert!(bootstrap_db_if_empty::<LibraVM>(&db_rw, &config)
+        .unwrap()
+        .is_none());
+    // Nor is it able to boot Executor.
+    assert!(db_rw.reader.get_startup_info().unwrap().is_none());
+
+    // New genesis transaction: set validator set and overwrite account1 balance
+    let genesis_txn = Transaction::WaypointWriteSet(ChangeSet::new(
+        WriteSetMut::new(vec![
+            (
+                ValidatorSet::CONFIG_ID.access_path(),
+                WriteOp::Value(lcs::to_bytes(&ValidatorSet::new(vec![])).unwrap()),
+            ),
+            (
+                AccessPath::new(account1, BalanceResource::resource_path()),
+                WriteOp::Value(lcs::to_bytes(&BalanceResource::new(1000)).unwrap()),
+            ),
+        ])
+        .freeze()
+        .unwrap(),
+        vec![ContractEvent::new(
+            on_chain_config::new_epoch_event_key(),
+            0,
+            lbr_type_tag(),
+            vec![],
+        )],
+    ));
+
+    // Bootstrap DB on top of pre-genesis state.
+    let tree_state = db_rw.reader.get_latest_tree_state().unwrap();
+    bootstrap_db::<LibraVM>(&db_rw, tree_state, genesis_txn).unwrap();
+
+    // Effect of bootstrapping reflected.
+    assert_eq!(get_balance(&account1, &db_rw), 1000);
+    // Pre-genesis state accessible.
+    assert_eq!(get_balance(&account2, &db_rw), 2000);
 }

--- a/execution/executor/tests/db_bootstrapper_test.rs
+++ b/execution/executor/tests/db_bootstrapper_test.rs
@@ -1,0 +1,41 @@
+// Copyright (c) The Libra Core Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+#![forbid(unsafe_code)]
+
+use config_builder::test_config;
+use executor::db_bootstrapper::bootstrap_db_if_empty;
+use libra_temppath::TempPath;
+use libra_types::waypoint::Waypoint;
+use libra_vm::LibraVM;
+use libradb::LibraDB;
+use storage_interface::DbReaderWriter;
+
+#[test]
+fn test_empty_db() {
+    let (config, _) = test_config();
+    let tmp_dir = TempPath::new();
+    let db_rw = DbReaderWriter::new(LibraDB::new(&tmp_dir));
+
+    // Executor won't be able to boot on empty db due to lack of StartupInfo.
+    assert!(db_rw.reader.get_startup_info().unwrap().is_none());
+
+    // Bootstrap empty DB.
+    let waypoint = bootstrap_db_if_empty::<LibraVM>(&db_rw, &config)
+        .expect("Should not fail.")
+        .expect("Should not be None.");
+    let startup_info = db_rw
+        .reader
+        .get_startup_info()
+        .expect("Should not fail.")
+        .expect("Should not be None.");
+    assert_eq!(
+        Waypoint::new(startup_info.latest_ledger_info.ledger_info()).unwrap(),
+        waypoint
+    );
+
+    // `bootstrap_db_if_empty()` does nothing on non-empty DB.
+    assert!(bootstrap_db_if_empty::<LibraVM>(&db_rw, &config)
+        .unwrap()
+        .is_none())
+}

--- a/json-rpc/src/tests/mock_db.rs
+++ b/json-rpc/src/tests/mock_db.rs
@@ -22,7 +22,7 @@ use libra_types::{
 };
 use std::collections::BTreeMap;
 use storage_interface::DbReader;
-use storage_proto::StartupInfo;
+use storage_proto::{StartupInfo, TreeState};
 
 /// Lightweight mock of LibraDB
 #[derive(Clone)]
@@ -233,6 +233,10 @@ impl DbReader for MockLibraDB {
     }
 
     fn get_latest_state_root(&self) -> Result<(u64, HashValue)> {
+        unimplemented!()
+    }
+
+    fn get_latest_tree_state(&self) -> Result<TreeState> {
         unimplemented!()
     }
 }

--- a/libra-node/src/main_node.rs
+++ b/libra-node/src/main_node.rs
@@ -7,7 +7,7 @@ use debug_interface::{
     node_debug_service::NodeDebugService,
     proto::node_debug_interface_server::NodeDebugInterfaceServer,
 };
-use executor::{db_bootstrapper::maybe_bootstrap_db, Executor};
+use executor::{db_bootstrapper::bootstrap_db_if_empty, Executor};
 use futures::{channel::mpsc::channel, executor::block_on};
 use libra_config::config::{NetworkConfig, NodeConfig, RoleType};
 use libra_json_rpc::bootstrap_from_config as bootstrap_rpc;
@@ -160,9 +160,9 @@ pub fn setup_environment(node_config: &mut NodeConfig) -> LibraHandle {
         .expect("Building rayon global thread pool should work.");
 
     let mut instant = Instant::now();
-    let (libra_db, db_reader_writer) = init_libra_db(&node_config);
+    let (libra_db, db_rw) = init_libra_db(&node_config);
     let storage = start_storage_service_with_db(&node_config, Arc::clone(&libra_db));
-    maybe_bootstrap_db::<LibraVM>(db_reader_writer, node_config)
+    bootstrap_db_if_empty::<LibraVM>(&db_rw, node_config)
         .expect("Db-bootstrapper should not fail.");
 
     debug!(

--- a/secure/json-rpc/src/lib.rs
+++ b/secure/json-rpc/src/lib.rs
@@ -296,7 +296,7 @@ mod test {
     use libradb::errors::LibraDbError::NotFound;
     use std::{collections::BTreeMap, convert::TryFrom, sync::Arc};
     use storage_interface::DbReader;
-    use storage_proto::StartupInfo;
+    use storage_proto::{StartupInfo, TreeState};
     use tokio::runtime::Runtime;
     use vm_validator::{
         mocks::mock_vm_validator::MockVMValidator, vm_validator::TransactionValidation,
@@ -599,6 +599,10 @@ mod test {
         }
 
         fn get_latest_state_root(&self) -> Result<(u64, HashValue)> {
+            unimplemented!()
+        }
+
+        fn get_latest_tree_state(&self) -> Result<TreeState> {
             unimplemented!()
         }
     }

--- a/secure/key-manager/src/tests.rs
+++ b/secure/key-manager/src/tests.rs
@@ -72,7 +72,7 @@ fn setup_secure_storage(
 impl Node {
     fn setup(config: &NodeConfig) -> Self {
         let (storage, db_rw) = DbReaderWriter::wrap(LibraDB::new(&config.storage.dir()));
-        db_bootstrapper::maybe_bootstrap_db::<LibraVM>(db_rw.clone(), config)
+        db_bootstrapper::bootstrap_db_if_empty::<LibraVM>(&db_rw, config)
             .expect("Failed to execute genesis");
         let executor = Executor::new(db_rw);
         let libra = TestLibraInterface {

--- a/storage/libradb/src/lib.rs
+++ b/storage/libradb/src/lib.rs
@@ -370,25 +370,6 @@ impl LibraDB {
             .collect::<Result<Vec<_>>>()
     }
 
-    // =========================== Libra Core Internal APIs ========================================
-
-    /// Gets the latest TreeState no matter if db has been bootstrapped.
-    /// Used by the Db-bootstrapper.
-    pub fn get_latest_tree_state(&self) -> Result<TreeState> {
-        let tree_state = match self.ledger_store.get_latest_transaction_info_option()? {
-            Some((version, txn_info)) => self.ledger_store.get_tree_state(version + 1, txn_info)?,
-            None => TreeState::new(
-                0,
-                vec![],
-                self.state_store
-                    .get_root_hash_option(PRE_GENESIS_VERSION)?
-                    .unwrap_or(*SPARSE_MERKLE_PLACEHOLDER_HASH),
-            ),
-        };
-
-        Ok(tree_state)
-    }
-
     // ================================== Backup APIs ===================================
 
     /// Gets an instance of `BackupHandler` for data backup purpose.
@@ -823,6 +804,21 @@ impl DbReader for LibraDB {
     fn get_latest_state_root(&self) -> Result<(Version, HashValue)> {
         let (version, txn_info) = self.ledger_store.get_latest_transaction_info()?;
         Ok((version, txn_info.state_root_hash()))
+    }
+
+    fn get_latest_tree_state(&self) -> Result<TreeState> {
+        let tree_state = match self.ledger_store.get_latest_transaction_info_option()? {
+            Some((version, txn_info)) => self.ledger_store.get_tree_state(version + 1, txn_info)?,
+            None => TreeState::new(
+                0,
+                vec![],
+                self.state_store
+                    .get_root_hash_option(PRE_GENESIS_VERSION)?
+                    .unwrap_or(*SPARSE_MERKLE_PLACEHOLDER_HASH),
+            ),
+        };
+
+        Ok(tree_state)
     }
 }
 

--- a/storage/storage-client/src/lib.rs
+++ b/storage/storage-client/src/lib.rs
@@ -49,7 +49,7 @@ use storage_proto::{
     GetAccountStateWithProofByVersionRequest, GetAccountStateWithProofByVersionResponse,
     GetEpochChangeLedgerInfosRequest, GetLatestAccountStateRequest, GetLatestAccountStateResponse,
     GetLatestStateRootResponse, GetStartupInfoResponse, GetTransactionsRequest,
-    GetTransactionsResponse, SaveTransactionsRequest, StartupInfo,
+    GetTransactionsResponse, SaveTransactionsRequest, StartupInfo, TreeState,
 };
 use tokio::runtime::Runtime;
 
@@ -687,6 +687,10 @@ impl DbReader for SyncStorageClient {
             self.rt
                 .spawn(async move { reader.get_latest_state_root().await }),
         )?
+    }
+
+    fn get_latest_tree_state(&self) -> Result<TreeState> {
+        unimplemented!()
     }
 }
 

--- a/storage/storage-interface/src/lib.rs
+++ b/storage/storage-interface/src/lib.rs
@@ -15,7 +15,7 @@ use libra_types::{
 };
 use serde::{Deserialize, Serialize};
 use std::sync::Arc;
-use storage_proto::StartupInfo;
+use storage_proto::{StartupInfo, TreeState};
 use thiserror::Error;
 
 pub mod state_view;
@@ -150,6 +150,10 @@ pub trait DbReader: Send + Sync {
 
     /// Gets the latest state root hash together with its version.
     fn get_latest_state_root(&self) -> Result<(Version, HashValue)>;
+
+    /// Gets the latest TreeState no matter if db has been bootstrapped.
+    /// Used by the Db-bootstrapper.
+    fn get_latest_tree_state(&self) -> Result<TreeState>;
 }
 
 /// Trait that is implemented by a DB that supports certain public (to client) write APIs

--- a/storage/storage-proto/src/lib.rs
+++ b/storage/storage-proto/src/lib.rs
@@ -28,7 +28,7 @@
 pub mod proto;
 
 use anyhow::{ensure, format_err, Error, Result};
-use libra_crypto::HashValue;
+use libra_crypto::{hash::SPARSE_MERKLE_PLACEHOLDER_HASH, HashValue};
 use libra_types::{
     account_address::AccountAddress,
     account_state_blob::AccountStateBlob,
@@ -510,6 +510,11 @@ impl TreeState {
             ledger_frozen_subtree_hashes,
             account_state_root_hash,
         }
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.num_transactions == 0
+            && self.account_state_root_hash == *SPARSE_MERKLE_PLACEHOLDER_HASH
     }
 }
 


### PR DESCRIPTION
## Motivation
In case we encounter really bad issue and we would ditch the whole transaction history but keep the state, we use the DB-bootstrapper on top of an empty Transaction accumulator but an existing Merkle state tree. (such a DB is only producible via the backup & restore tool set at this point.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?

yes

## Test Plan

unit tests added.
## Related PRs

(If this PR adds or changes functionality, please take some time to update the docs at https://github.com/libra/website, and link to your PR here.)
