### PR TITLE
[WIP][CI] cache move-lang in e2e test

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -249,7 +249,7 @@ jobs:
             - target/debug/deps/libratest*
   run-e2e-test:
     executor: test-executor
-    parallelism: 8
+    parallelism: 4
     description: Run E2E tests in parallel. Each container runs a subset of
       test targets.
     environment:


### PR DESCRIPTION
## Motivation
Cache the move-lang crate in the e2e test workflow as some tests depend
on it. This reduces the longest e2e test job by ~1 minute.

## Test Plan
Canary in-place in CI