### PR TITLE
[Move Prover] Eliminate immutable references by converting them to values

### DIFF
--- a/language/move-prover/spec-lang/src/ty.rs
+++ b/language/move-prover/spec-lang/src/ty.rs
@@ -85,6 +85,15 @@ impl Type {
         }
     }
 
+    /// Determines whether this is an immutable reference.
+    pub fn is_immutable_reference(&self) -> bool {
+        if let Type::Reference(false, _) = self {
+            true
+        } else {
+            false
+        }
+    }
+
     /// Returns true if this is any number type.
     pub fn is_number(&self) -> bool {
         if let Type::Primitive(p) = self {

--- a/language/move-prover/src/lib.rs
+++ b/language/move-prover/src/lib.rs
@@ -14,6 +14,7 @@ use codespan_reporting::term::termcolor::WriteColor;
 use log::info;
 use spec_lang::{env::GlobalEnv, run_spec_lang_compiler};
 use stackless_bytecode_generator::{
+    eliminate_imm_refs::EliminateImmRefsProcessor,
     function_target_pipeline::{FunctionTargetPipeline, FunctionTargetsHolder},
     lifetime_analysis::LifetimeAnalysisProcessor,
 };
@@ -117,6 +118,7 @@ fn create_bytecode_processing_pipeline(_options: &Options) -> FunctionTargetPipe
     let mut res = FunctionTargetPipeline::default();
 
     // Add processors in order they are executed.
+    res.add_processor(EliminateImmRefsProcessor::new());
 
     // Must happen last as it is currently computing information based on raw code offsets.
     res.add_processor(LifetimeAnalysisProcessor::new());

--- a/language/move-prover/stackless-bytecode-generator/src/eliminate_imm_refs.rs
+++ b/language/move-prover/stackless-bytecode-generator/src/eliminate_imm_refs.rs
@@ -1,0 +1,142 @@
+// Copyright (c) The Libra Core Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::{
+    function_target::{FunctionTarget, FunctionTargetData},
+    function_target_pipeline::{FunctionTargetProcessor, FunctionTargetsHolder},
+    stackless_bytecode::{
+        AssignKind,
+        Bytecode::{self, *},
+        Operation::*,
+    },
+};
+use spec_lang::{env::FunctionEnv, ty::Type};
+
+pub struct EliminateImmRefsProcessor {}
+
+impl EliminateImmRefsProcessor {
+    pub fn new() -> Box<Self> {
+        Box::new(EliminateImmRefsProcessor {})
+    }
+}
+
+impl FunctionTargetProcessor for EliminateImmRefsProcessor {
+    fn process(
+        &self,
+        _targets: &mut FunctionTargetsHolder,
+        func_env: &FunctionEnv<'_>,
+        mut data: FunctionTargetData,
+    ) -> FunctionTargetData {
+        let code = std::mem::replace(&mut data.code, vec![]);
+        data.code = code
+            .into_iter()
+            .map(|bytecode| {
+                EliminateImmRefs::new(&FunctionTarget::new(func_env, &data))
+                    .transform_bytecode(bytecode)
+            })
+            .collect();
+        let local_types = std::mem::replace(&mut data.local_types, vec![]);
+        data.local_types = local_types
+            .into_iter()
+            .map(|ty| {
+                EliminateImmRefs::new(&FunctionTarget::new(func_env, &data)).transform_type(ty)
+            })
+            .collect();
+        let return_types = std::mem::replace(&mut data.return_types, vec![]);
+        data.return_types = return_types
+            .into_iter()
+            .map(|ty| {
+                EliminateImmRefs::new(&FunctionTarget::new(func_env, &data)).transform_type(ty)
+            })
+            .collect();
+        data
+    }
+}
+
+pub struct EliminateImmRefs<'a> {
+    func_target: &'a FunctionTarget<'a>,
+}
+
+impl<'a> EliminateImmRefs<'a> {
+    fn new(func_target: &'a FunctionTarget) -> Self {
+        Self { func_target }
+    }
+
+    fn transform_type(&self, ty: Type) -> Type {
+        if let Type::Reference(false, y) = ty {
+            *y
+        } else {
+            ty
+        }
+    }
+
+    fn transform_bytecode(&self, bytecode: Bytecode) -> Bytecode {
+        match &bytecode {
+            Call(attr_id, dests, op, srcs) => match op {
+                ReadRef => {
+                    let src = srcs[0];
+                    let dest = dests[0];
+                    if self
+                        .func_target
+                        .get_local_type(src)
+                        .is_immutable_reference()
+                    {
+                        Assign(*attr_id, dest, src, AssignKind::Move)
+                    } else {
+                        bytecode
+                    }
+                }
+                FreezeRef => Call(*attr_id, dests.to_vec(), ReadRef, srcs.to_vec()),
+                BorrowLoc => {
+                    let src = srcs[0];
+                    let dest = dests[0];
+                    if self
+                        .func_target
+                        .get_local_type(dest)
+                        .is_immutable_reference()
+                    {
+                        Assign(*attr_id, dest, src, AssignKind::Copy)
+                    } else {
+                        bytecode
+                    }
+                }
+                BorrowField(mid, sid, type_actuals, field_offset) => {
+                    let dest = dests[0];
+                    if self
+                        .func_target
+                        .get_local_type(dest)
+                        .is_immutable_reference()
+                    {
+                        Call(
+                            *attr_id,
+                            dests.to_vec(),
+                            GetField(*mid, *sid, type_actuals.to_vec(), *field_offset),
+                            srcs.to_vec(),
+                        )
+                    } else {
+                        bytecode
+                    }
+                }
+                BorrowGlobal(mid, sid, type_actuals) => {
+                    let dest = dests[0];
+                    if self
+                        .func_target
+                        .get_local_type(dest)
+                        .is_immutable_reference()
+                    {
+                        Call(
+                            *attr_id,
+                            dests.to_vec(),
+                            GetGlobal(*mid, *sid, type_actuals.to_vec()),
+                            srcs.to_vec(),
+                        )
+                    } else {
+                        bytecode
+                    }
+                }
+                _ => bytecode,
+            },
+            _ => bytecode,
+        }
+    }
+}

--- a/language/move-prover/stackless-bytecode-generator/src/function_target.rs
+++ b/language/move-prover/stackless-bytecode-generator/src/function_target.rs
@@ -22,6 +22,7 @@ use vm::file_format::CodeOffset;
 pub struct FunctionTarget<'env> {
     pub func_env: &'env FunctionEnv<'env>,
     pub data: &'env FunctionTargetData,
+    pub name_to_index: BTreeMap<Symbol, usize>,
 
     // Used for debugging and testing, containing any attached annotation formatters.
     annotation_formatters: RefCell<Vec<Box<AnnotationFormatter>>>,
@@ -51,9 +52,13 @@ impl<'env> FunctionTarget<'env> {
         func_env: &'env FunctionEnv<'env>,
         data: &'env FunctionTargetData,
     ) -> FunctionTarget<'env> {
+        let name_to_index = (0..func_env.get_local_count())
+            .map(|idx| (func_env.get_local_name(idx), idx))
+            .collect();
         FunctionTarget {
             func_env,
             data,
+            name_to_index,
             annotation_formatters: RefCell::new(vec![]),
         }
     }
@@ -135,6 +140,11 @@ impl<'env> FunctionTarget<'env> {
     /// otherwise generate a unique name.
     pub fn get_local_name(&self, idx: usize) -> Symbol {
         self.func_env.get_local_name(idx)
+    }
+
+    /// Get the index corresponding to a local name
+    pub fn get_local_index(&self, name: Symbol) -> Option<&usize> {
+        self.name_to_index.get(&name)
     }
 
     /// Gets the number of locals of this function, including parameters.

--- a/language/move-prover/stackless-bytecode-generator/src/lib.rs
+++ b/language/move-prover/stackless-bytecode-generator/src/lib.rs
@@ -5,6 +5,7 @@
 
 pub mod annotations;
 pub mod dataflow_analysis;
+pub mod eliminate_imm_refs;
 pub mod function_target;
 pub mod function_target_pipeline;
 pub mod lifetime_analysis;

--- a/language/move-prover/stackless-bytecode-generator/src/stackless_bytecode.rs
+++ b/language/move-prover/stackless-bytecode-generator/src/stackless_bytecode.rs
@@ -102,6 +102,10 @@ pub enum Operation {
     BorrowField(ModuleId, StructId, Vec<Type>, usize),
     BorrowGlobal(ModuleId, StructId, Vec<Type>),
 
+    // Get
+    GetField(ModuleId, StructId, Vec<Type>, usize),
+    GetGlobal(ModuleId, StructId, Vec<Type>),
+
     // Builtins
     Abort,
     Destroy,
@@ -425,6 +429,23 @@ impl<'env> fmt::Display for OperationDisplay<'env> {
             }
             BorrowGlobal(mid, sid, targs) => {
                 write!(f, "borrow_global<{}>", self.struct_str(*mid, *sid, targs))?;
+            }
+            GetField(mid, sid, targs, offset) => {
+                write!(f, "get_field<{}>", self.struct_str(*mid, *sid, targs))?;
+                let struct_env = self
+                    .func_target
+                    .global_env()
+                    .get_module(*mid)
+                    .into_struct(*sid);
+                let field_env = struct_env.get_field_by_offset(*offset);
+                write!(
+                    f,
+                    ".{}",
+                    field_env.get_name().display(struct_env.symbol_pool())
+                )?;
+            }
+            GetGlobal(mid, sid, targs) => {
+                write!(f, "get_global<{}>", self.struct_str(*mid, *sid, targs))?;
             }
 
             // Resources

--- a/language/move-prover/stackless-bytecode-generator/tests/elim_imm_refs/basic_test.exp
+++ b/language/move-prover/stackless-bytecode-generator/tests/elim_imm_refs/basic_test.exp
@@ -1,0 +1,175 @@
+============ initial translation from Move ================
+
+fun TestEliminateImmRefs::test1(): TestEliminateImmRefs::R {
+    var r: TestEliminateImmRefs::R
+    var r_ref: &mut TestEliminateImmRefs::R
+    var x_ref: &mut u64
+    var $t3: u64
+    var $t4: TestEliminateImmRefs::R
+    var $t5: &mut TestEliminateImmRefs::R
+    var $t6: &mut TestEliminateImmRefs::R
+    var $t7: &mut u64
+    var $t8: u64
+    var $t9: &mut u64
+    var $t10: TestEliminateImmRefs::R
+    $t3 := 3
+    $t4 := pack TestEliminateImmRefs::R($t3)
+    r := $t4
+    $t5 := borrow_local(r)
+    r_ref := $t5
+    $t6 := move(r_ref)
+    $t7 := borrow_field<TestEliminateImmRefs::R>.x($t6)
+    x_ref := $t7
+    $t8 := 0
+    $t9 := move(x_ref)
+    $t9 := write_ref($t8)
+    $t10 := move(r)
+    return $t10
+}
+
+
+fun TestEliminateImmRefs::test2(): u64 {
+    var r: TestEliminateImmRefs::R
+    var r_ref: &TestEliminateImmRefs::R
+    var x_ref: &u64
+    var $t3: u64
+    var $t4: TestEliminateImmRefs::R
+    var $t5: &TestEliminateImmRefs::R
+    var $t6: &TestEliminateImmRefs::R
+    var $t7: &u64
+    var $t8: &u64
+    var $t9: u64
+    $t3 := 3
+    $t4 := pack TestEliminateImmRefs::R($t3)
+    r := $t4
+    $t5 := borrow_local(r)
+    r_ref := $t5
+    $t6 := move(r_ref)
+    $t7 := borrow_field<TestEliminateImmRefs::R>.x($t6)
+    x_ref := $t7
+    $t8 := move(x_ref)
+    $t9 := read_ref($t8)
+    return $t9
+}
+
+
+fun TestEliminateImmRefs::test3(r_ref: &TestEliminateImmRefs::R): u64 {
+    var x_ref: &u64
+    var $t2: &TestEliminateImmRefs::R
+    var $t3: &u64
+    var $t4: &u64
+    var $t5: u64
+    $t2 := move(r_ref)
+    $t3 := borrow_field<TestEliminateImmRefs::R>.x($t2)
+    x_ref := $t3
+    $t4 := move(x_ref)
+    $t5 := read_ref($t4)
+    return $t5
+}
+
+
+fun TestEliminateImmRefs::test4(): u64 {
+    var r: TestEliminateImmRefs::R
+    var r_ref: &TestEliminateImmRefs::R
+    var $t2: u64
+    var $t3: TestEliminateImmRefs::R
+    var $t4: &TestEliminateImmRefs::R
+    var $t5: &TestEliminateImmRefs::R
+    var $t6: u64
+    $t2 := 3
+    $t3 := pack TestEliminateImmRefs::R($t2)
+    r := $t3
+    $t4 := borrow_local(r)
+    r_ref := $t4
+    $t5 := move(r_ref)
+    $t6 := TestEliminateImmRefs::test3($t5)
+    return $t6
+}
+
+============ after pipeline `elim_imm_refs` ================
+
+fun TestEliminateImmRefs::test1(): TestEliminateImmRefs::R {
+    var r: TestEliminateImmRefs::R
+    var r_ref: &mut TestEliminateImmRefs::R
+    var x_ref: &mut u64
+    var $t3: u64
+    var $t4: TestEliminateImmRefs::R
+    var $t5: &mut TestEliminateImmRefs::R
+    var $t6: &mut TestEliminateImmRefs::R
+    var $t7: &mut u64
+    var $t8: u64
+    var $t9: &mut u64
+    var $t10: TestEliminateImmRefs::R
+    $t3 := 3
+    $t4 := pack TestEliminateImmRefs::R($t3)
+    r := $t4
+    $t5 := borrow_local(r)
+    r_ref := $t5
+    $t6 := move(r_ref)
+    $t7 := borrow_field<TestEliminateImmRefs::R>.x($t6)
+    x_ref := $t7
+    $t8 := 0
+    $t9 := move(x_ref)
+    $t9 := write_ref($t8)
+    $t10 := move(r)
+    return $t10
+}
+
+
+fun TestEliminateImmRefs::test2(): u64 {
+    var r: TestEliminateImmRefs::R
+    var r_ref: TestEliminateImmRefs::R
+    var x_ref: u64
+    var $t3: u64
+    var $t4: TestEliminateImmRefs::R
+    var $t5: TestEliminateImmRefs::R
+    var $t6: TestEliminateImmRefs::R
+    var $t7: u64
+    var $t8: u64
+    var $t9: u64
+    $t3 := 3
+    $t4 := pack TestEliminateImmRefs::R($t3)
+    r := $t4
+    $t5 := copy(r)
+    r_ref := $t5
+    $t6 := move(r_ref)
+    $t7 := get_field<TestEliminateImmRefs::R>.x($t6)
+    x_ref := $t7
+    $t8 := move(x_ref)
+    $t9 := move($t8)
+    return $t9
+}
+
+
+fun TestEliminateImmRefs::test3(r_ref: TestEliminateImmRefs::R): u64 {
+    var x_ref: u64
+    var $t2: TestEliminateImmRefs::R
+    var $t3: u64
+    var $t4: u64
+    var $t5: u64
+    $t2 := move(r_ref)
+    $t3 := get_field<TestEliminateImmRefs::R>.x($t2)
+    x_ref := $t3
+    $t4 := move(x_ref)
+    $t5 := move($t4)
+    return $t5
+}
+
+
+fun TestEliminateImmRefs::test4(): u64 {
+    var r: TestEliminateImmRefs::R
+    var r_ref: TestEliminateImmRefs::R
+    var $t2: u64
+    var $t3: TestEliminateImmRefs::R
+    var $t4: TestEliminateImmRefs::R
+    var $t5: TestEliminateImmRefs::R
+    var $t6: u64
+    $t2 := 3
+    $t3 := pack TestEliminateImmRefs::R($t2)
+    r := $t3
+    $t4 := copy(r)
+    r_ref := $t4
+    $t5 := move(r_ref)
+    $t6 := TestEliminateImmRefs::test3($t5)
+    return $t6
+}

--- a/language/move-prover/stackless-bytecode-generator/tests/elim_imm_refs/basic_test.move
+++ b/language/move-prover/stackless-bytecode-generator/tests/elim_imm_refs/basic_test.move
@@ -1,0 +1,32 @@
+module TestEliminateImmRefs {
+
+    struct R {
+        x: u64
+    }
+
+    fun test1() : R {
+        let r = R {x: 3};
+        let r_ref = &mut r;
+        let x_ref = &mut r_ref.x;
+        *x_ref = 0;
+        r
+    }
+
+    fun test2() : u64 {
+        let r = R {x: 3};
+        let r_ref = & r;
+        let x_ref = & r_ref.x;
+        *x_ref
+    }
+
+    fun test3(r_ref: &R) : u64 {
+        let x_ref = & r_ref.x;
+        *x_ref
+    }
+
+    fun test4() : u64 {
+        let r = R {x: 3};
+        let r_ref = & r;
+        test3(r_ref)
+    }
+}

--- a/language/move-prover/stackless-bytecode-generator/tests/testsuite.rs
+++ b/language/move-prover/stackless-bytecode-generator/tests/testsuite.rs
@@ -8,6 +8,7 @@ use codespan_reporting::term::termcolor::Buffer;
 
 use spec_lang::{env::GlobalEnv, run_spec_lang_compiler};
 use stackless_bytecode_generator::{
+    eliminate_imm_refs::EliminateImmRefsProcessor,
     function_target_pipeline::{FunctionTargetPipeline, FunctionTargetsHolder},
     lifetime_analysis::LifetimeAnalysisProcessor,
     reaching_def_analysis::ReachingDefProcessor,
@@ -19,6 +20,11 @@ fn get_tested_transformation_pipeline(
 ) -> anyhow::Result<Option<FunctionTargetPipeline>> {
     match dir_name {
         "from_move" => Ok(None),
+        "elim_imm_refs" => {
+            let mut pipeline = FunctionTargetPipeline::default();
+            pipeline.add_processor(Box::new(EliminateImmRefsProcessor {}));
+            Ok(Some(pipeline))
+        }
         "lifetime" => {
             let mut pipeline = FunctionTargetPipeline::default();
             pipeline.add_processor(Box::new(LifetimeAnalysisProcessor {}));


### PR DESCRIPTION
## Motivation

This PR eliminates immutable references from the bytecode and specifications before translating the result to Boogie.  This is the first PR in a two-PR cycle the second of which attempt to allocate as many values locally (off the heap) as possible.  This  PR also eliminates some redundant procedures and functions in prelude.bpl.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

Existing tests.  Also added a pipeline test.

## Related PRs

