### PR TITLE
[JSON-RPC] Make versions optional in the 'get_account_state_with_proof()' API call

### DIFF
--- a/json-rpc/src/client.rs
+++ b/json-rpc/src/client.rs
@@ -99,8 +99,8 @@ impl JsonRpcBatch {
     pub fn add_get_account_state_with_proof_request(
         &mut self,
         account: AccountAddress,
-        version: u64,
-        ledger_version: u64,
+        version: Option<u64>,
+        ledger_version: Option<u64>,
     ) {
         self.add_request(
             "get_account_state_with_proof".to_string(),


### PR DESCRIPTION
## Motivation

At present, the JSON-RPC server requires clients to specify the version heights when executing the 'get_account_state_with_proof()' API call. This is pessimistic, as it requires the client to first "sync up" to the latest state (or blockchain height), before being able to query the blockchain at that height. However, clients often generally just want to retrieve the latest state as is currently known on the blockchain, and then verify that state later on (e.g., by retrieving a state proof to fast forward). This flow is more optimistic.

This PR makes the version heights optional in the 'get_account_state_with_proof()' API call, to follow the optimistic flow. To achieve this, it:
- Allows clients to specify None values for versions. These are serialized across the wire and read at the server side.
- Adds new tests to verify the behaviour.
- Performs various small refactors to the test suite to avoid code duplication and redundancy. 

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?

Yes.

## Test Plan

All local tests pass (including the newly added ones).

## Related PRs

None.
