### PR TITLE
[executor] stop using storage-server and storage-client (trait StorageRead) in tests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1273,11 +1273,8 @@ dependencies = [
  "scratchpad 0.1.0",
  "serde_json 1.0.51 (registry+https://github.com/rust-lang/crates.io-index)",
  "stdlib 0.1.0",
- "storage-client 0.1.0",
  "storage-interface 0.1.0",
  "storage-proto 0.1.0",
- "storage-service 0.1.0",
- "tokio 0.2.13 (registry+https://github.com/rust-lang/crates.io-index)",
  "transaction-builder 0.1.0",
  "vm-genesis 0.1.0",
 ]

--- a/execution/executor/Cargo.toml
+++ b/execution/executor/Cargo.toml
@@ -15,7 +15,6 @@ futures = "0.3.0"
 itertools = { version = "0.9.0", default-features = false }
 once_cell = "1.3.1"
 serde_json = "1.0"
-tokio = { version = "0.2.12", features = ["full"] }
 
 consensus-types = { path = "../../consensus/consensus-types", version = "0.1.0"}
 debug-interface = { path = "../../common/debug-interface", version = "0.1.0" }
@@ -43,8 +42,6 @@ rusty-fork = "0.2.1"
 config-builder = { path = "../../config/config-builder", version = "0.1.0" }
 executor-utils = { path = "../executor-utils", version = "0.1.0" }
 stdlib = { path = "../../language/stdlib", version = "0.1.0" }
-storage-client = { path = "../../storage/storage-client", version = "0.1.0" }
-storage-service = { path = "../../storage/storage-service", version = "0.1.0" }
 transaction-builder = { path = "../../language/transaction-builder", version = "0.1.0" }
 vm-genesis = { path = "../../language/tools/vm-genesis", version = "0.1.0" }
 

--- a/execution/executor/src/db_bootstrapper.rs
+++ b/execution/executor/src/db_bootstrapper.rs
@@ -52,7 +52,8 @@ pub fn bootstrap_db<V: VMExecutor>(
     let mut executor = Executor::<V>::new_on_unbootstrapped_db(db.clone(), tree_state);
 
     let block_id = HashValue::zero(); // match with the id in BlockInfo::genesis(...)
-                                      // Create a block with genesis_txn being the only txn. Execute it then commit it immediately.
+
+    // Create a block with genesis_txn being the only txn. Execute it then commit it immediately.
     let result = executor.execute_block((block_id, vec![genesis_txn]), *PRE_GENESIS_BLOCK_ID)?;
 
     let root_hash = result.root_hash();


### PR DESCRIPTION


## Motivation

Those are to be deprecated.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?

(Write your answer here.)

## Test Plan

existing tests converted.

## Related PRs

(If this PR adds or changes functionality, please take some time to update the docs at https://github.com/libra/website, and link to your PR here.)
