### PR TITLE
[Proof] Use SparseMerkleLeafNode in SparseMerkleProof

### DIFF
--- a/storage/jellyfish-merkle/src/lib.rs
+++ b/storage/jellyfish-merkle/src/lib.rs
@@ -541,13 +541,10 @@ where
                         } else {
                             None
                         },
-                        SparseMerkleProof::new(
-                            Some((leaf_node.account_key(), leaf_node.blob_hash())),
-                            {
-                                siblings.reverse();
-                                siblings
-                            },
-                        ),
+                        SparseMerkleProof::new(Some(leaf_node.into()), {
+                            siblings.reverse();
+                            siblings
+                        }),
                     ));
                 }
                 Node::Null => {

--- a/storage/jellyfish-merkle/src/node_type/mod.rs
+++ b/storage/jellyfish-merkle/src/node_type/mod.rs
@@ -541,6 +541,12 @@ impl CryptoHash for LeafNode {
     }
 }
 
+impl From<LeafNode> for SparseMerkleLeafNode {
+    fn from(leaf_node: LeafNode) -> Self {
+        Self::new(leaf_node.account_key, leaf_node.blob_hash)
+    }
+}
+
 #[repr(u8)]
 #[derive(FromPrimitive, ToPrimitive)]
 enum NodeTag {

--- a/storage/scratchpad/src/sparse_merkle/mod.rs
+++ b/storage/scratchpad/src/sparse_merkle/mod.rs
@@ -211,16 +211,12 @@ impl SparseMerkleTree {
                 // root hash of this subtree in memory). So we need to take into account the leaf
                 // in the proof.
                 let new_subtree = match proof.leaf() {
-                    Some((existing_key, existing_value_hash)) => {
-                        let existing_leaf =
-                            LeafNode::new(existing_key, LeafValue::BlobHash(existing_value_hash));
-                        Self::construct_subtree_with_new_leaf(
-                            key,
-                            new_blob,
-                            &existing_leaf,
-                            proof.siblings().len(),
-                        )
-                    }
+                    Some(existing_leaf) => Self::construct_subtree_with_new_leaf(
+                        key,
+                        new_blob,
+                        &existing_leaf.into(),
+                        proof.siblings().len(),
+                    ),
                     None => Arc::new(SparseMerkleNode::new_leaf(key, LeafValue::Blob(new_blob))),
                 };
 

--- a/storage/scratchpad/src/sparse_merkle/node.rs
+++ b/storage/scratchpad/src/sparse_merkle/node.rs
@@ -235,6 +235,12 @@ impl LeafNode {
     }
 }
 
+impl From<SparseMerkleLeafNode> for LeafNode {
+    fn from(leaf_node: SparseMerkleLeafNode) -> Self {
+        Self::new(leaf_node.key(), LeafValue::BlobHash(leaf_node.value_hash()))
+    }
+}
+
 /// A subtree node.
 #[derive(Debug)]
 pub struct SubtreeNode {

--- a/types/src/proof/mod.rs
+++ b/types/src/proof/mod.rs
@@ -23,6 +23,9 @@ use libra_crypto::{
     HashValue,
 };
 use libra_crypto_derive::CryptoHasher;
+#[cfg(any(test, feature = "fuzzing"))]
+use proptest_derive::Arbitrary;
+use serde::{Deserialize, Serialize};
 use std::marker::PhantomData;
 
 pub use self::definition::{
@@ -91,7 +94,8 @@ pub type TransactionAccumulatorInternalNode = MerkleTreeInternalNode<Transaction
 pub type EventAccumulatorInternalNode = MerkleTreeInternalNode<EventAccumulatorHasher>;
 pub type TestAccumulatorInternalNode = MerkleTreeInternalNode<TestOnlyHasher>;
 
-#[derive(CryptoHasher)]
+#[derive(Clone, Copy, CryptoHasher, Debug, Eq, PartialEq, Serialize, Deserialize)]
+#[cfg_attr(any(test, feature = "fuzzing"), derive(Arbitrary))]
 pub struct SparseMerkleLeafNode {
     key: HashValue,
     value_hash: HashValue,
@@ -100,6 +104,14 @@ pub struct SparseMerkleLeafNode {
 impl SparseMerkleLeafNode {
     pub fn new(key: HashValue, value_hash: HashValue) -> Self {
         SparseMerkleLeafNode { key, value_hash }
+    }
+
+    pub fn key(&self) -> HashValue {
+        self.key
+    }
+
+    pub fn value_hash(&self) -> HashValue {
+        self.value_hash
     }
 }
 

--- a/types/src/proof/proptest_proof.rs
+++ b/types/src/proof/proptest_proof.rs
@@ -6,7 +6,7 @@
 
 use crate::proof::{
     definition::MAX_ACCUMULATOR_PROOF_DEPTH, AccumulatorConsistencyProof, AccumulatorProof,
-    AccumulatorRangeProof, SparseMerkleProof, SparseMerkleRangeProof,
+    AccumulatorRangeProof, SparseMerkleLeafNode, SparseMerkleProof, SparseMerkleRangeProof,
 };
 use libra_crypto::{
     hash::{CryptoHasher, ACCUMULATOR_PLACEHOLDER_HASH, SPARSE_MERKLE_PLACEHOLDER_HASH},
@@ -75,7 +75,7 @@ impl Arbitrary for SparseMerkleProof {
 
     fn arbitrary_with(_args: Self::Parameters) -> Self::Strategy {
         (
-            any::<Option<(HashValue, HashValue)>>(),
+            any::<Option<SparseMerkleLeafNode>>(),
             (0..=256usize).prop_flat_map(|len| {
                 if len == 0 {
                     Just(vec![]).boxed()

--- a/types/src/proof/unit_tests/proof_test.rs
+++ b/types/src/proof/unit_tests/proof_test.rs
@@ -150,8 +150,9 @@ fn test_verify_single_element_sparse_merkle() {
     let blob: AccountStateBlob = b"world".to_vec().into();
     let blob_hash = blob.hash();
     let non_existing_blob = b"world?".to_vec().into();
-    let root_hash = SparseMerkleLeafNode::new(key, blob_hash).hash();
-    let proof = SparseMerkleProof::new(Some((key, blob_hash)), vec![]);
+    let root_node = SparseMerkleLeafNode::new(key, blob_hash);
+    let root_hash = root_node.hash();
+    let proof = SparseMerkleProof::new(Some(root_node), vec![]);
 
     // Trying to show this exact key exists with its value.
     assert!(proof.verify(root_hash, key, Some(&blob)).is_ok());
@@ -192,7 +193,8 @@ fn test_verify_three_element_sparse_merkle() {
     let blob2 = AccountStateBlob::from(b"2".to_vec());
     let blob3 = AccountStateBlob::from(b"3".to_vec());
 
-    let leaf1_hash = SparseMerkleLeafNode::new(key1, blob1.hash()).hash();
+    let leaf1 = SparseMerkleLeafNode::new(key1, blob1.hash());
+    let leaf1_hash = leaf1.hash();
     let leaf2_hash = SparseMerkleLeafNode::new(key2, blob2.hash()).hash();
     let leaf3_hash = SparseMerkleLeafNode::new(key3, blob3.hash()).hash();
     let internal_b_hash = SparseMerkleInternalNode::new(leaf2_hash, leaf3_hash).hash();
@@ -208,7 +210,7 @@ fn test_verify_three_element_sparse_merkle() {
     {
         // Construct a proof of key1.
         let proof = SparseMerkleProof::new(
-            Some((key1, blob1.hash())),
+            Some(leaf1),
             vec![internal_b_hash, *SPARSE_MERKLE_PLACEHOLDER_HASH],
         );
 
@@ -325,7 +327,8 @@ fn test_verify_account_state_and_event() {
     let blob3 = AccountStateBlob::from(b"value3".to_vec());
 
     let leaf1_hash = SparseMerkleLeafNode::new(key1, blob1.hash()).hash();
-    let leaf2_hash = SparseMerkleLeafNode::new(key2, blob2.hash()).hash();
+    let leaf2 = SparseMerkleLeafNode::new(key2, blob2.hash());
+    let leaf2_hash = leaf2.hash();
     let leaf3_hash = SparseMerkleLeafNode::new(key3, blob3.hash()).hash();
     let internal_d_hash = SparseMerkleInternalNode::new(leaf2_hash, leaf3_hash).hash();
     let internal_c_hash = SparseMerkleInternalNode::new(leaf1_hash, internal_d_hash).hash();
@@ -383,7 +386,7 @@ fn test_verify_account_state_and_event() {
     let ledger_info_to_transaction_info_proof =
         TransactionAccumulatorProof::new(vec![*ACCUMULATOR_PLACEHOLDER_HASH, internal_a_hash]);
     let transaction_info_to_account_proof = SparseMerkleProof::new(
-        Some((key2, blob2.hash())),
+        Some(leaf2),
         vec![leaf3_hash, leaf1_hash, *SPARSE_MERKLE_PLACEHOLDER_HASH],
     );
     let account_state_proof = AccountStateProof::new(


### PR DESCRIPTION
While writing some specification I noticed that we could replaced this `(HashValue, HashValue)` tuple with `SparseMerkleLeafNode`, now that we have this struct.