### PR TITLE
[crypto] Forces implementations of the (Signing|Verifying)Key, Signature traits to reside in the crypto crate.

### DIFF
--- a/crypto/crypto-derive/src/unions.rs
+++ b/crypto/crypto-derive/src/unions.rs
@@ -187,6 +187,7 @@ pub fn impl_enum_verifyingkey(
             type SigningKeyMaterial = #pkt;
             type SignatureMaterial = #st;
         }
+        impl libra_crypto::private::Sealed for #name {}
     };
     res.into()
 }
@@ -219,6 +220,7 @@ pub fn impl_enum_signingkey(
                 }
             }
         }
+        impl libra_crypto::private::Sealed for #name {}
     };
     res.into()
 }
@@ -271,6 +273,8 @@ pub fn impl_enum_signature(
                 }
             }
         }
+
+        impl libra_crypto::private::Sealed for #name {}
     });
     res.into()
 }

--- a/crypto/crypto/src/ed25519.rs
+++ b/crypto/crypto/src/ed25519.rs
@@ -32,7 +32,7 @@
 use crate::{traits::*, HashValue};
 use anyhow::{anyhow, Result};
 use core::convert::TryFrom;
-use libra_crypto_derive::{DeserializeKey, SerializeKey};
+use libra_crypto_derive::{DeserializeKey, SerializeKey, SilentDebug, SilentDisplay};
 use std::{cmp::Ordering, fmt};
 
 /// The length of the Ed25519PrivateKey
@@ -49,7 +49,7 @@ const L: [u8; 32] = [
 ];
 
 /// An Ed25519 private key
-#[derive(DeserializeKey, SerializeKey)]
+#[derive(DeserializeKey, SerializeKey, SilentDebug, SilentDisplay)]
 pub struct Ed25519PrivateKey(ed25519_dalek::SecretKey);
 
 #[cfg(feature = "assert-private-keys-not-cloneable")]
@@ -278,21 +278,9 @@ impl fmt::Display for Ed25519PublicKey {
     }
 }
 
-impl fmt::Display for Ed25519PrivateKey {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "{}", hex::encode(&self.0.as_bytes()))
-    }
-}
-
 impl fmt::Debug for Ed25519PublicKey {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "Ed25519PublicKey({})", self)
-    }
-}
-
-impl fmt::Debug for Ed25519PrivateKey {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "Ed25519PrivateKey({})", self)
     }
 }
 


### PR DESCRIPTION
This helps make sure cryptographers look at & maintain implementations.

See https://rust-lang.github.io/api-guidelines/future-proofing.html#sealed-traits-protect-against-downstream-implementations-c-sealed for details.