### PR TITLE
[storage-proto] move TreeState and StartupInfo to storage-interface

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1277,7 +1277,6 @@ dependencies = [
  "serde_json 1.0.51 (registry+https://github.com/rust-lang/crates.io-index)",
  "stdlib 0.1.0",
  "storage-interface 0.1.0",
- "storage-proto 0.1.0",
  "transaction-builder 0.1.0",
  "vm-genesis 0.1.0",
 ]
@@ -1315,7 +1314,7 @@ dependencies = [
  "libra-workspace-hack 0.1.0",
  "scratchpad 0.1.0",
  "serde 1.0.106 (registry+https://github.com/rust-lang/crates.io-index)",
- "storage-proto 0.1.0",
+ "storage-interface 0.1.0",
 ]
 
 [[package]]
@@ -2309,7 +2308,6 @@ dependencies = [
  "serde 1.0.106 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.51 (registry+https://github.com/rust-lang/crates.io-index)",
  "storage-interface 0.1.0",
- "storage-proto 0.1.0",
  "tokio 0.2.13 (registry+https://github.com/rust-lang/crates.io-index)",
  "transaction-builder 0.1.0",
  "vm-validator 0.1.0",
@@ -2487,7 +2485,6 @@ dependencies = [
  "serde 1.0.106 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.51 (registry+https://github.com/rust-lang/crates.io-index)",
  "storage-interface 0.1.0",
- "storage-proto 0.1.0",
  "thiserror 1.0.15 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio 0.2.13 (registry+https://github.com/rust-lang/crates.io-index)",
  "ureq 0.12.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2763,7 +2760,6 @@ dependencies = [
  "schemadb 0.1.0",
  "serde 1.0.106 (registry+https://github.com/rust-lang/crates.io-index)",
  "storage-interface 0.1.0",
- "storage-proto 0.1.0",
  "thiserror 1.0.15 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -4852,7 +4848,6 @@ dependencies = [
  "libra-workspace-hack 0.1.0",
  "scratchpad 0.1.0",
  "serde 1.0.106 (registry+https://github.com/rust-lang/crates.io-index)",
- "storage-proto 0.1.0",
  "thiserror 1.0.15 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -4869,6 +4864,7 @@ dependencies = [
  "proptest-derive 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "prost 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.106 (registry+https://github.com/rust-lang/crates.io-index)",
+ "storage-interface 0.1.0",
  "tonic 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "tonic-build 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]

--- a/execution/executor-types/Cargo.toml
+++ b/execution/executor-types/Cargo.toml
@@ -16,7 +16,7 @@ libra-crypto = { path = "../../crypto/crypto", version = "0.1.0" }
 libra-types = { path = "../../types", version = "0.1.0" }
 libra-workspace-hack = { path = "../../common/workspace-hack", version = "0.1.0" }
 scratchpad = { path = "../../storage/scratchpad", version = "0.1.0" }
-storage-proto = { path = "../../storage/storage-proto", version = "0.1.0" }
+storage-interface = { path = "../../storage/storage-interface", version = "0.1.0" }
 
 [features]
 default = []

--- a/execution/executor-types/src/lib.rs
+++ b/execution/executor-types/src/lib.rs
@@ -17,7 +17,7 @@ use libra_types::{
 };
 use scratchpad::{ProofRead, SparseMerkleTree};
 use std::{cmp::max, collections::HashMap, sync::Arc};
-use storage_proto::TreeState;
+use storage_interface::TreeState;
 
 /// A structure that summarizes the result of the execution needed for consensus to agree on.
 /// The execution is responsible for generating the ID of the new state, which is returned in the

--- a/execution/executor/Cargo.toml
+++ b/execution/executor/Cargo.toml
@@ -29,7 +29,6 @@ libra-vm = { path = "../../language/libra-vm", version = "0.1.0" }
 libra-workspace-hack = { path = "../../common/workspace-hack", version = "0.1.0" }
 scratchpad = { path = "../../storage/scratchpad", version = "0.1.0" }
 storage-interface = { path = "../../storage/storage-interface", version = "0.1.0" }
-storage-proto = { path = "../../storage/storage-proto", version = "0.1.0" }
 
 [dev-dependencies]
 proptest = "0.9.6"

--- a/execution/executor/src/db_bootstrapper.rs
+++ b/execution/executor/src/db_bootstrapper.rs
@@ -11,8 +11,7 @@ use libra_types::{
     ledger_info::LedgerInfoWithSignatures, transaction::Transaction, waypoint::Waypoint,
 };
 use libra_vm::VMExecutor;
-use storage_interface::DbReaderWriter;
-use storage_proto::TreeState;
+use storage_interface::{DbReaderWriter, TreeState};
 
 pub fn bootstrap_db_if_empty<V: VMExecutor>(
     db: &DbReaderWriter,

--- a/execution/executor/src/lib.rs
+++ b/execution/executor/src/lib.rs
@@ -46,8 +46,7 @@ use std::{
     marker::PhantomData,
     sync::Arc,
 };
-use storage_interface::{state_view::VerifiedStateView, DbReaderWriter};
-use storage_proto::TreeState;
+use storage_interface::{state_view::VerifiedStateView, DbReaderWriter, TreeState};
 
 static OP_COUNTERS: Lazy<libra_metrics::OpMetrics> =
     Lazy::new(|| libra_metrics::OpMetrics::new_and_registered("executor"));

--- a/execution/executor/src/speculation_cache/mod.rs
+++ b/execution/executor/src/speculation_cache/mod.rs
@@ -27,7 +27,7 @@ use std::{
     collections::HashMap,
     sync::{Arc, Mutex, Weak},
 };
-use storage_proto::{StartupInfo, TreeState};
+use storage_interface::{StartupInfo, TreeState};
 
 /// The struct that stores all speculation result of its counterpart in consensus.
 pub(crate) struct SpeculationBlock {

--- a/json-rpc/Cargo.toml
+++ b/json-rpc/Cargo.toml
@@ -36,7 +36,6 @@ storage-interface = { path = "../storage/storage-interface", version = "0.1.0" }
 transaction-builder = { path = "../language/transaction-builder", version = "0.1.0"}
 debug-interface = { path = "../common/debug-interface", version = "0.1.0" }
 libra-temppath = { path = "../common/temppath", version = "0.1.0", optional = true }
-storage-proto = { path = "../storage/storage-proto", version = "0.1.0" }
 
 [dev-dependencies]
 vm-validator = { path = "../vm-validator", version = "0.1.0" }

--- a/json-rpc/src/tests/mock_db.rs
+++ b/json-rpc/src/tests/mock_db.rs
@@ -22,8 +22,7 @@ use libra_types::{
     vm_error::StatusCode,
 };
 use std::collections::BTreeMap;
-use storage_interface::DbReader;
-use storage_proto::{StartupInfo, TreeState};
+use storage_interface::{DbReader, StartupInfo, TreeState};
 
 /// Lightweight mock of LibraDB
 #[derive(Clone)]

--- a/secure/json-rpc/Cargo.toml
+++ b/secure/json-rpc/Cargo.toml
@@ -32,5 +32,4 @@ libra-temppath = { path = "../../common/temppath", version = "0.1.0" }
 libra-types = { path = "../../types", version = "0.1.0", features = ["fuzzing"] }
 libradb = { path = "../../storage/libradb", version = "0.1.0" }
 storage-interface = { path = "../../storage/storage-interface", version = "0.1.0" }
-storage-proto = { path = "../../storage/storage-proto", version = "0.1.0" }
 vm-validator = { path = "../../vm-validator", version = "0.1.0" }

--- a/secure/json-rpc/src/lib.rs
+++ b/secure/json-rpc/src/lib.rs
@@ -295,8 +295,7 @@ mod test {
     };
     use libradb::errors::LibraDbError::NotFound;
     use std::{collections::BTreeMap, convert::TryFrom, sync::Arc};
-    use storage_interface::DbReader;
-    use storage_proto::{StartupInfo, TreeState};
+    use storage_interface::{DbReader, StartupInfo, TreeState};
     use tokio::runtime::Runtime;
     use vm_validator::{
         mocks::mock_vm_validator::MockVMValidator, vm_validator::TransactionValidation,

--- a/storage/libradb/Cargo.toml
+++ b/storage/libradb/Cargo.toml
@@ -31,7 +31,6 @@ libra-logger = { path = "../../common/logger", version = "0.1.0" }
 libra-metrics = { path = "../../common/metrics", version = "0.1.0" }
 schemadb = { path = "../schemadb", version = "0.1.0" }
 storage-interface = { path = "../storage-interface", version = "0.1.0" }
-storage-proto = { path = "../storage-proto", version = "0.1.0" }
 libra-types = { path = "../../types", version = "0.1.0" }
 libra-proptest-helpers = { path = "../../common/proptest-helpers", version = "0.1.0", optional = true }
 libra-temppath = { path = "../../common/temppath", version = "0.1.0", optional = true }

--- a/storage/libradb/src/ledger_store/mod.rs
+++ b/storage/libradb/src/ledger_store/mod.rs
@@ -32,7 +32,7 @@ use libra_types::{
 };
 use schemadb::{ReadOptions, SchemaIterator, DB};
 use std::{ops::Deref, sync::Arc};
-use storage_proto::{StartupInfo, TreeState};
+use storage_interface::{StartupInfo, TreeState};
 
 pub(crate) struct LedgerStore {
     db: Arc<DB>,

--- a/storage/libradb/src/lib.rs
+++ b/storage/libradb/src/lib.rs
@@ -80,8 +80,7 @@ use std::{
     sync::Arc,
     time::Instant,
 };
-use storage_interface::{DbReader, DbWriter};
-use storage_proto::{StartupInfo, TreeState};
+use storage_interface::{DbReader, DbWriter, StartupInfo, TreeState};
 
 static OP_COUNTER: Lazy<OpMetrics> = Lazy::new(|| OpMetrics::new_and_registered("storage"));
 

--- a/storage/storage-client/src/lib.rs
+++ b/storage/storage-client/src/lib.rs
@@ -38,7 +38,7 @@ use std::{
     net::SocketAddr,
     sync::{Arc, Mutex},
 };
-use storage_interface::{DbReader, DbWriter};
+use storage_interface::{DbReader, DbWriter, StartupInfo, TreeState};
 use storage_proto::{
     proto::storage::{
         storage_client::StorageClient, GetLatestStateRootRequest, GetStartupInfoRequest,
@@ -49,7 +49,7 @@ use storage_proto::{
     GetAccountStateWithProofByVersionRequest, GetAccountStateWithProofByVersionResponse,
     GetEpochChangeLedgerInfosRequest, GetLatestAccountStateRequest, GetLatestAccountStateResponse,
     GetLatestStateRootResponse, GetStartupInfoResponse, GetTransactionsRequest,
-    GetTransactionsResponse, SaveTransactionsRequest, StartupInfo, TreeState,
+    GetTransactionsResponse, SaveTransactionsRequest,
 };
 use tokio::runtime::Runtime;
 

--- a/storage/storage-interface/Cargo.toml
+++ b/storage/storage-interface/Cargo.toml
@@ -21,4 +21,3 @@ libra-state-view = { path = "../../storage/state-view", version = "0.1.0" }
 libra-types = { path = "../../types", version = "0.1.0" }
 libra-workspace-hack = { path = "../../common/workspace-hack", version = "0.1.0" }
 scratchpad = { path = "../scratchpad", version = "0.1.0" }
-storage-proto = { path = "../storage-proto", version = "0.1.0" }

--- a/storage/storage-proto/Cargo.toml
+++ b/storage/storage-proto/Cargo.toml
@@ -20,6 +20,7 @@ serde = { version = "1.0.106", default-features = false }
 libra-crypto = { path = "../../crypto/crypto", version = "0.1.0" }
 libra-types = { path = "../../types", version = "0.1.0" }
 libra-workspace-hack = { path = "../../common/workspace-hack", version = "0.1.0" }
+storage-interface = { path = "../storage-interface", version = "0.1.0" }
 
 [build-dependencies]
 tonic-build = "0.2"

--- a/storage/storage-proto/src/tests.rs
+++ b/storage/storage-proto/src/tests.rs
@@ -3,6 +3,8 @@
 
 use super::*;
 use libra_prost_ext::test_helpers::assert_protobuf_encode_decode;
+#[cfg(any(test, feature = "fuzzing"))]
+use proptest::prelude::*;
 
 macro_rules! test_conversion {
     ($test_name: ident, $rust_type: ident $(,)?) => {
@@ -41,9 +43,6 @@ test_conversion!(
 test_conversion!(test_save_transactions_request, SaveTransactionsRequest);
 test_conversion!(test_get_transactions_request, GetTransactionsRequest);
 test_conversion!(test_get_transactions_response, GetTransactionsResponse);
-test_conversion!(test_tree_state, TreeState);
-test_conversion!(test_startup_info, StartupInfo);
-test_conversion!(test_get_startup_info_response, GetStartupInfoResponse);
 test_conversion!(
     test_get_epoch_change_ledger_infos_request,
     GetEpochChangeLedgerInfosRequest,

--- a/storage/storage-service/src/lib.rs
+++ b/storage/storage-service/src/lib.rs
@@ -21,7 +21,7 @@ use libra_types::proto::types::{
 };
 use libradb::LibraDB;
 use std::{convert::TryFrom, path::Path, sync::Arc};
-use storage_interface::{DbReader, DbReaderWriter, DbWriter, Error};
+use storage_interface::{DbReader, DbReaderWriter, DbWriter, Error, StartupInfo};
 use storage_proto::proto::storage::{
     storage_server::{Storage, StorageServer},
     BackupAccountStateRequest, BackupAccountStateResponse, BackupTransactionInfoRequest,
@@ -38,7 +38,6 @@ use tokio::runtime::Runtime;
 use libra_secure_net::NetworkServer;
 use libra_types::{account_state_blob::AccountStateBlob, proof::SparseMerkleProof};
 use std::thread::{self, JoinHandle};
-use storage_proto::StartupInfo;
 
 /// Starts storage service with a given LibraDB
 pub fn start_simple_storage_service_with_db(

--- a/storage/storage-service/src/mocks/mock_storage_client.rs
+++ b/storage/storage-service/src/mocks/mock_storage_client.rs
@@ -34,9 +34,9 @@ use rand::{
 };
 use std::{collections::BTreeMap, convert::TryFrom};
 use storage_client::StorageRead;
+use storage_interface::StartupInfo;
 use storage_proto::{
     BackupAccountStateResponse, BackupTransactionInfoResponse, BackupTransactionResponse,
-    StartupInfo,
 };
 
 /// This is a mock of the storage read client used in tests.


### PR DESCRIPTION
## Motivation

storage-proto depends on `tonic` whereas most components in TCB needs `TreeState` and `StartupInfo`. As a result, they depend on `tonic` indirectly. 
After this PR, the dependency is removed. 

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?

Y

## Test Plan

CI
