### PR TITLE
[language] Cleanup in VmValidator

### DIFF
--- a/language/e2e-tests/src/executor.rs
+++ b/language/e2e-tests/src/executor.rs
@@ -24,7 +24,7 @@ use libra_types::{
     vm_error::{StatusCode, VMStatus},
     write_set::WriteSet,
 };
-use libra_vm::{LibraVM, VMExecutor, VMVerifier};
+use libra_vm::{LibraVM, VMExecutor, VMValidator};
 use stdlib::{stdlib_modules, transaction_scripts::StdlibScript, StdLibOptions};
 use vm::CompiledModule;
 use vm_genesis::GENESIS_KEYPAIR;

--- a/language/libra-vm/src/lib.rs
+++ b/language/libra-vm/src/lib.rs
@@ -122,8 +122,8 @@ use libra_types::{
     vm_error::VMStatus,
 };
 
-/// This trait describes the VM's verification interfaces.
-pub trait VMVerifier {
+/// This trait describes the VM's validation interfaces.
+pub trait VMValidator {
     /// Executes the prologue of the Libra Account and verifies that the transaction is valid.
     /// only. Returns `None` if the transaction was validated, or Some(VMStatus) if the transaction
     /// was unable to be validated with status `VMStatus`.

--- a/vm-validator/src/mocks/mock_vm_validator.rs
+++ b/vm-validator/src/mocks/mock_vm_validator.rs
@@ -10,13 +10,13 @@ use libra_types::{
     transaction::{SignedTransaction, VMValidatorResult},
     vm_error::{StatusCode, VMStatus},
 };
-use libra_vm::VMVerifier;
+use libra_vm::VMValidator;
 use std::convert::TryFrom;
 
 #[derive(Clone)]
 pub struct MockVMValidator;
 
-impl VMVerifier for MockVMValidator {
+impl VMValidator for MockVMValidator {
     fn validate_transaction(
         &self,
         _transaction: SignedTransaction,

--- a/vm-validator/src/vm_validator.rs
+++ b/vm-validator/src/vm_validator.rs
@@ -8,7 +8,7 @@ use libra_types::{
     on_chain_config::{LibraVersion, OnChainConfigPayload, VMConfig},
     transaction::{SignedTransaction, VMValidatorResult},
 };
-use libra_vm::{LibraVM, VMVerifier};
+use libra_vm::LibraVM;
 use scratchpad::SparseMerkleTree;
 use std::{convert::TryFrom, sync::Arc};
 use storage_client::StorageRead;
@@ -20,7 +20,7 @@ mod vm_validator_test;
 
 #[async_trait::async_trait]
 pub trait TransactionValidation: Send + Sync + Clone {
-    type ValidationInstance: VMVerifier;
+    type ValidationInstance: libra_vm::VMValidator;
 
     /// Validate a txn from client
     async fn validate_transaction(&self, _txn: SignedTransaction) -> Result<VMValidatorResult>;
@@ -53,6 +53,8 @@ impl TransactionValidation for VMValidator {
     type ValidationInstance = LibraVM;
 
     async fn validate_transaction(&self, txn: SignedTransaction) -> Result<VMValidatorResult> {
+        use libra_vm::VMValidator;
+
         let (version, state_root) = self.db_reader.get_latest_state_root()?;
         let db_reader = Arc::clone(&self.db_reader);
         let vm = self.vm.clone();


### PR DESCRIPTION
- renaming VmVerifier to VmValidator (which is what this is called everywhere to avoid confusion withe bytecode verifier)
- Fixing spelling error ("Transcation")

## Motivation

Cleanup

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?

Y

## Test Plan

Refactoring
