### PR TITLE
[move-lang] Extending the specification grammar by pragmas and schemas

### DIFF
--- a/language/move-lang/src/expansion/ast.rs
+++ b/language/move-lang/src/expansion/ast.rs
@@ -4,7 +4,7 @@
 use crate::{
     parser::ast::{
         BinOp, Field, FunctionName, FunctionVisibility, InvariantKind, Kind, ModuleIdent,
-        ModuleName, NamePatternFragment, PragmaProperty, ResourceLoc, SpecBlockTarget,
+        ModuleName, PragmaProperty, ResourceLoc, SpecApplyFragment, SpecBlockTarget,
         SpecConditionKind, StructName, UnaryOp, Value, Var,
     },
     shared::{ast_debug::*, unique_map::UniqueMap, *},
@@ -97,13 +97,13 @@ pub struct Function {
 //**************************************************************************************************
 
 #[derive(Debug, PartialEq)]
-pub struct FunctionPattern_ {
+pub struct SpecApplyPattern_ {
     pub visibility: Option<FunctionVisibility>,
-    pub name_pattern: Vec<NamePatternFragment>,
+    pub name_pattern: Vec<SpecApplyFragment>,
     pub type_arguments: Option<Vec<Type>>,
 }
 
-pub type FunctionPattern = Spanned<FunctionPattern_>;
+pub type SpecApplyPattern = Spanned<SpecApplyPattern_>;
 
 #[derive(Debug, PartialEq)]
 pub struct SpecBlock_ {
@@ -141,8 +141,8 @@ pub enum SpecBlockMember_ {
     Apply {
         name: ModuleAccess,
         type_arguments: Option<Vec<Type>>,
-        patterns: Vec<FunctionPattern>,
-        exclusion_patterns: Vec<FunctionPattern>,
+        patterns: Vec<SpecApplyPattern>,
+        exclusion_patterns: Vec<SpecApplyPattern>,
     },
     Pragma {
         properties: Vec<PragmaProperty>,
@@ -522,7 +522,7 @@ impl AstDebug for SpecBlockMember_ {
     }
 }
 
-impl AstDebug for FunctionPattern_ {
+impl AstDebug for SpecApplyPattern_ {
     fn ast_debug(&self, w: &mut AstWriter) {
         w.list(&self.name_pattern, "", |w, f| {
             f.ast_debug(w);

--- a/language/move-lang/src/expansion/ast.rs
+++ b/language/move-lang/src/expansion/ast.rs
@@ -98,6 +98,7 @@ pub struct Function {
 
 #[derive(Debug, PartialEq)]
 pub struct FunctionPattern_ {
+    pub visibility: Option<FunctionVisibility>,
     pub name_pattern: Vec<NamePatternFragment>,
     pub type_arguments: Option<Vec<Type>>,
 }
@@ -141,6 +142,7 @@ pub enum SpecBlockMember_ {
         name: ModuleAccess,
         type_arguments: Option<Vec<Type>>,
         patterns: Vec<FunctionPattern>,
+        exclusion_patterns: Vec<FunctionPattern>,
     },
     Pragma {
         properties: Vec<PragmaProperty>,
@@ -488,6 +490,7 @@ impl AstDebug for SpecBlockMember_ {
                 name,
                 type_arguments,
                 patterns,
+                exclusion_patterns,
             } => {
                 w.write(&format!("apply {}", name));
                 if let Some(ty_args) = type_arguments {
@@ -500,6 +503,13 @@ impl AstDebug for SpecBlockMember_ {
                     p.ast_debug(w);
                     true
                 });
+                if !exclusion_patterns.is_empty() {
+                    w.write(" exclude ");
+                    w.list(exclusion_patterns, ", ", |w, p| {
+                        p.ast_debug(w);
+                        true
+                    });
+                }
             }
             SpecBlockMember_::Pragma { properties } => {
                 w.write("pragma ");

--- a/language/move-lang/src/expansion/ast.rs
+++ b/language/move-lang/src/expansion/ast.rs
@@ -115,6 +115,7 @@ pub struct SpecBlock_ {
 pub type SpecBlock = Spanned<SpecBlock_>;
 
 #[derive(Debug, PartialEq)]
+#[allow(clippy::large_enum_variant)]
 pub enum SpecBlockMember_ {
     Condition {
         kind: SpecConditionKind,

--- a/language/move-lang/src/expansion/translate.rs
+++ b/language/move-lang/src/expansion/translate.rs
@@ -615,6 +615,7 @@ fn spec_member(
             }
         }
         PM::Variable {
+            is_global,
             name,
             type_parameters: pty_params,
             type_: t,
@@ -622,6 +623,7 @@ fn spec_member(
             let type_parameters = type_parameters(context, pty_params);
             let t = type_(context, t);
             EM::Variable {
+                is_global,
                 name,
                 type_parameters,
                 type_: t,
@@ -630,12 +632,14 @@ fn spec_member(
         PM::Include {
             name: pn,
             type_arguments: ptys_opt,
+            renamings,
         } => {
             let name = module_access(context, pn)?;
             let type_arguments = optional_types(context, ptys_opt);
             EM::Include {
                 name,
                 type_arguments,
+                renamings,
             }
         }
         PM::Apply {

--- a/language/move-lang/src/expansion/translate.rs
+++ b/language/move-lang/src/expansion/translate.rs
@@ -648,11 +648,11 @@ fn spec_member(
             let type_arguments = optional_types(context, ptys_opt);
             let patterns = ppatterns
                 .into_iter()
-                .map(|p| function_pattern(context, p))
+                .map(|p| spec_apply_pattern(context, p))
                 .collect();
             let exclusion_patterns = pe_patterns
                 .into_iter()
-                .map(|p| function_pattern(context, p))
+                .map(|p| spec_apply_pattern(context, p))
                 .collect();
             EM::Apply {
                 name,
@@ -666,21 +666,21 @@ fn spec_member(
     Some(sp(loc, em))
 }
 
-fn function_pattern(
+fn spec_apply_pattern(
     context: &mut Context,
     sp!(
         loc,
-        P::FunctionPattern_ {
+        P::SpecApplyPattern_ {
             visibility,
             name_pattern,
             type_arguments: pty_args
         }
-    ): P::FunctionPattern,
-) -> E::FunctionPattern {
+    ): P::SpecApplyPattern,
+) -> E::SpecApplyPattern {
     let type_arguments = pty_args.map(|tys| types(context, tys));
     sp(
         loc,
-        E::FunctionPattern_ {
+        E::SpecApplyPattern_ {
             visibility,
             name_pattern,
             type_arguments,

--- a/language/move-lang/src/expansion/translate.rs
+++ b/language/move-lang/src/expansion/translate.rs
@@ -642,6 +642,7 @@ fn spec_member(
             name: pn,
             type_arguments: ptys_opt,
             patterns: ppatterns,
+            exclusion_patterns: pe_patterns,
         } => {
             let name = module_access(context, pn)?;
             let type_arguments = optional_types(context, ptys_opt);
@@ -649,10 +650,15 @@ fn spec_member(
                 .into_iter()
                 .map(|p| function_pattern(context, p))
                 .collect();
+            let exclusion_patterns = pe_patterns
+                .into_iter()
+                .map(|p| function_pattern(context, p))
+                .collect();
             EM::Apply {
                 name,
                 type_arguments,
                 patterns,
+                exclusion_patterns,
             }
         }
         PM::Pragma { properties } => EM::Pragma { properties },
@@ -665,6 +671,7 @@ fn function_pattern(
     sp!(
         loc,
         P::FunctionPattern_ {
+            visibility,
             name_pattern,
             type_arguments: pty_args
         }
@@ -674,6 +681,7 @@ fn function_pattern(
     sp(
         loc,
         E::FunctionPattern_ {
+            visibility,
             name_pattern,
             type_arguments,
         },

--- a/language/move-lang/src/parser/ast.rs
+++ b/language/move-lang/src/parser/ast.rs
@@ -197,6 +197,7 @@ pub type PragmaProperty = Spanned<PragmaProperty_>;
 
 #[derive(Debug, PartialEq)]
 pub struct FunctionPattern_ {
+    pub visibility: Option<FunctionVisibility>,
     pub name_pattern: Vec<NamePatternFragment>,
     pub type_arguments: Option<Vec<Type>>,
 }
@@ -239,6 +240,7 @@ pub enum SpecBlockMember_ {
         name: ModuleAccess,
         type_arguments: Option<Vec<Type>>,
         patterns: Vec<FunctionPattern>,
+        exclusion_patterns: Vec<FunctionPattern>,
     },
     Pragma {
         properties: Vec<PragmaProperty>,
@@ -918,6 +920,7 @@ impl AstDebug for SpecBlockMember_ {
                 name,
                 type_arguments,
                 patterns,
+                exclusion_patterns,
             } => {
                 w.write("apply ");
                 name.ast_debug(w);
@@ -931,6 +934,13 @@ impl AstDebug for SpecBlockMember_ {
                     p.ast_debug(w);
                     true
                 });
+                if !exclusion_patterns.is_empty() {
+                    w.write(" exclude ");
+                    w.list(exclusion_patterns, ", ", |w, p| {
+                        p.ast_debug(w);
+                        true
+                    });
+                }
             }
             SpecBlockMember_::Pragma { properties } => {
                 w.write("pragma ");

--- a/language/move-lang/src/parser/ast.rs
+++ b/language/move-lang/src/parser/ast.rs
@@ -196,21 +196,21 @@ pub struct PragmaProperty_ {
 pub type PragmaProperty = Spanned<PragmaProperty_>;
 
 #[derive(Debug, PartialEq)]
-pub struct FunctionPattern_ {
+pub struct SpecApplyPattern_ {
     pub visibility: Option<FunctionVisibility>,
-    pub name_pattern: Vec<NamePatternFragment>,
+    pub name_pattern: Vec<SpecApplyFragment>,
     pub type_arguments: Option<Vec<Type>>,
 }
 
-pub type FunctionPattern = Spanned<FunctionPattern_>;
+pub type SpecApplyPattern = Spanned<SpecApplyPattern_>;
 
 #[derive(Debug, PartialEq)]
-pub enum NamePatternFragment_ {
+pub enum SpecApplyFragment_ {
     Wildcard,
     NamePart(Name),
 }
 
-pub type NamePatternFragment = Spanned<NamePatternFragment_>;
+pub type SpecApplyFragment = Spanned<SpecApplyFragment_>;
 
 #[derive(Debug, PartialEq)]
 pub enum SpecBlockMember_ {
@@ -239,8 +239,8 @@ pub enum SpecBlockMember_ {
     Apply {
         name: ModuleAccess,
         type_arguments: Option<Vec<Type>>,
-        patterns: Vec<FunctionPattern>,
-        exclusion_patterns: Vec<FunctionPattern>,
+        patterns: Vec<SpecApplyPattern>,
+        exclusion_patterns: Vec<SpecApplyPattern>,
     },
     Pragma {
         properties: Vec<PragmaProperty>,
@@ -953,7 +953,7 @@ impl AstDebug for SpecBlockMember_ {
     }
 }
 
-impl AstDebug for FunctionPattern_ {
+impl AstDebug for SpecApplyPattern_ {
     fn ast_debug(&self, w: &mut AstWriter) {
         w.list(&self.name_pattern, "", |w, f| {
             f.ast_debug(w);
@@ -967,11 +967,11 @@ impl AstDebug for FunctionPattern_ {
     }
 }
 
-impl AstDebug for NamePatternFragment_ {
+impl AstDebug for SpecApplyFragment_ {
     fn ast_debug(&self, w: &mut AstWriter) {
         match self {
-            NamePatternFragment_::Wildcard => w.write("*"),
-            NamePatternFragment_::NamePart(n) => w.write(&n.value),
+            SpecApplyFragment_::Wildcard => w.write("*"),
+            SpecApplyFragment_::NamePart(n) => w.write(&n.value),
         }
     }
 }

--- a/language/move-lang/src/parser/ast.rs
+++ b/language/move-lang/src/parser/ast.rs
@@ -213,6 +213,7 @@ pub enum SpecApplyFragment_ {
 pub type SpecApplyFragment = Spanned<SpecApplyFragment_>;
 
 #[derive(Debug, PartialEq)]
+#[allow(clippy::large_enum_variant)]
 pub enum SpecBlockMember_ {
     Condition {
         kind: SpecConditionKind,

--- a/language/move-lang/src/parser/syntax.rs
+++ b/language/move-lang/src/parser/syntax.rs
@@ -1751,6 +1751,7 @@ fn parse_spec_apply<'input>(tokens: &mut Lexer<'input>) -> Result<SpecBlockMembe
     } else {
         vec![]
     };
+    consume_token(tokens, Tok::Semicolon)?;
     Ok(spanned(
         tokens.file_name(),
         start_loc,
@@ -1771,14 +1772,12 @@ fn parse_function_pattern<'input>(tokens: &mut Lexer<'input>) -> Result<Function
     let public_opt = consume_optional_token_with_loc(tokens, Tok::Public)?;
     let visibility = if let Some(loc) = public_opt {
         Some(FunctionVisibility::Public(loc))
+    } else if tokens.peek() == Tok::NameValue && tokens.content() == "internal" {
+        // Its not ideal right now that we do not have a loc here, but acceptable for what
+        // we are doing with this in specs.
+        Some(FunctionVisibility::Internal)
     } else {
-        if tokens.peek() == Tok::NameValue && tokens.content() == "internal" {
-            // Its not ideal right now that we do not have a loc here, but acceptable for what
-            // we are doing with this in specs.
-            Some(FunctionVisibility::Internal)
-        } else {
-            None
-        }
+        None
     };
     let name_pattern = parse_list(
         tokens,

--- a/language/move-lang/tests/move_check/parser/spec_parsing_ok.move
+++ b/language/move-lang/tests/move_check/parser/spec_parsing_ok.move
@@ -127,6 +127,7 @@ module M {
 
     spec module {
         apply ModuleInvariant<X, Y> to *foo*<Y, X>;
+        apply ModuleInvariant<X, Y> to *foo*<Y, X>, bar except public *, internal baz<X>;
         pragma do_not_verify, timeout = 60;
     }
 }

--- a/language/move-lang/tests/move_check/parser/spec_parsing_ok.move
+++ b/language/move-lang/tests/move_check/parser/spec_parsing_ok.move
@@ -115,4 +115,18 @@ module M {
         ensures generic<T> == 1;
         ensures Self::generic<T> == 1;
     }
+
+    spec schema ModuleInvariant<X, Y> {
+        requires global<X>(0x0).f == global<X>(0x1).f;
+        ensures global<X>(0x0).f == global<X>(0x1).f;
+    }
+
+    spec fun some_generic {
+        include ModuleInvariant<T, T>;
+    }
+
+    spec module {
+        apply ModuleInvariant<X, Y> to *foo*<Y, X>;
+        pragma do_not_verify, timeout = 60;
+    }
 }

--- a/language/move-lang/tests/move_check/parser/spec_parsing_ok.move
+++ b/language/move-lang/tests/move_check/parser/spec_parsing_ok.move
@@ -104,6 +104,9 @@ module M {
     }
 
     spec module {
+        global x: u64;
+        local y: u64;
+        z: u64;
         global generic<T>: u64;
         invariant update generic<u64> = 23;
         invariant update Self::generic<u64> = 24;
@@ -122,7 +125,7 @@ module M {
     }
 
     spec fun some_generic {
-        include ModuleInvariant<T, T>;
+        include ModuleInvariant<T, T>{foo:bar, x:y};
     }
 
     spec module {

--- a/language/move-prover/spec-lang/src/ast.rs
+++ b/language/move-prover/spec-lang/src/ast.rs
@@ -65,6 +65,7 @@ impl SpecConditionKind {
             PA::SpecConditionKind::Ensures => Ensures,
             PA::SpecConditionKind::Requires => Requires,
             PA::SpecConditionKind::AbortsIf => AbortsIf,
+            PA::SpecConditionKind::RequiresModule => unimplemented!(),
         }
     }
 

--- a/language/move-prover/spec-lang/src/translate.rs
+++ b/language/move-prover/spec-lang/src/translate.rs
@@ -781,6 +781,7 @@ impl<'env, 'translator> ModuleTranslator<'env, 'translator> {
                     name,
                     type_,
                     type_parameters,
+                    ..
                 } => self.decl_ana_var(&loc, name, type_parameters, type_),
                 _ => {}
             }

--- a/language/move-prover/spec-lang/src/translate.rs
+++ b/language/move-prover/spec-lang/src/translate.rs
@@ -713,6 +713,7 @@ impl<'env, 'translator> ModuleTranslator<'env, 'translator> {
                 }
             }
             PA::SpecBlockTarget_::Module => Some(SpecBlockContext::Module),
+            PA::SpecBlockTarget_::Schema(..) => unimplemented!(),
         }
     }
 }
@@ -982,6 +983,7 @@ impl<'env, 'translator> ModuleTranslator<'env, 'translator> {
                     signature, body, ..
                 } => self.def_ana_spec_fun(signature, body),
                 Variable { .. } => { /* nothing to do right now */ }
+                Include { .. } | Apply { .. } | Pragma { .. } => unimplemented!(),
             }
         }
     }


### PR DESCRIPTION
This introduces two new syntactic constructs into the specification subset of the Move language.

- Pragmas: pragmas allow to pass options to the prover on a per-spec block base. Example:
  ```
  spec {
      pragma no_verify, timeout = 60;
  }
  ```
  The pragma (weak) keyword is followed by a list of properties, which can either be simple names, or simple names with a constant value assignment.

- Schemas: schemas are a way to group multiple items in a specification block which can then be included elsewhere, or are applied to a set of functions. Example:
  ```
  spec schema ModuleInvariant<X> {
      requires P; ensures Q;
  }
  spec fun some_fun {
      include ModuleInvariant<T>;
  }
  spec module {
      apply ModuleInvariant<X> to *foo<X>, *bar<X>;
  }
  ```

These grammar changes are isolated to spec blocks and do not affect others parts of the Move grammar. However, to avoid code duplication, some parser logic has been factored out, namely parsing inferred numbers, type parameters, and type arguments.

## Motivation

Global specs.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

Added new test cases.

## Related PRs

NA
