### PR TITLE
[move-prover] Fixed a bug in "aborts_if" translation

### DIFF
--- a/language/move-prover/src/spec_translator.rs
+++ b/language/move-prover/src/spec_translator.rs
@@ -322,13 +322,13 @@ impl<'env> SpecTranslator<'env> {
             .collect_vec();
         if !aborts_if.is_empty() {
             self.writer.set_location(&aborts_if[0].loc);
-            emit!(self.writer, "ensures ");
+            emit!(self.writer, "ensures (");
             self.translate_seq(aborts_if.iter(), " || ", |c| {
                 emit!(self.writer, "b#Boolean(old(");
                 self.translate_exp_parenthesised(&c.exp);
                 emit!(self.writer, "))")
             });
-            emitln!(self.writer, " == $abort_flag;");
+            emitln!(self.writer, ") <==> $abort_flag;");
         }
 
         // Generate ensures

--- a/language/move-prover/tests/sources/aborts-if.exp
+++ b/language/move-prover/tests/sources/aborts-if.exp
@@ -75,3 +75,15 @@ error:  A postcondition might not hold on this return path.
     =         _x = <redacted>,
     =         _y = <redacted>
     =     at tests/sources/aborts-if.move:90:5: multi_abort3_incorrect (exit)
+
+error:  A postcondition might not hold on this return path.
+
+     ┌── tests/sources/aborts-if.move:114:9 ───
+     │
+ 114 │         aborts_if true;
+     │         ^^^^^^^^^^^^^^^
+     │
+     =     at tests/sources/aborts-if.move:108:5: multi_abort5_incorrect (entry)
+     =     at tests/sources/aborts-if.move:109:9: multi_abort5_incorrect
+     =         x = <redacted>
+     =     at tests/sources/aborts-if.move:108:5: multi_abort5_incorrect (exit)

--- a/language/move-prover/tests/sources/aborts-if.move
+++ b/language/move-prover/tests/sources/aborts-if.move
@@ -104,4 +104,14 @@ module TestAbortsIf {
         aborts_if _x == _y;
         aborts_if _x > _y;
     }
+
+    fun multi_abort5_incorrect(x: u64) {
+        if (x == 0) {
+            abort 1
+        };
+    }
+    spec fun multi_abort5_incorrect {
+        aborts_if true;
+        aborts_if x > 0;
+    }
 }


### PR DESCRIPTION
- Fixed the bug in the "aborts_if" translation which generates incorrect formula regarding operator precedence
- Added a test case to make sure the bug is gone.
- Updated the golden file accordingly

## Motivation

To fix a bug in the translation of the "aborts_if" conditions

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

cargo test

