### PR TITLE
[move-prover] Update libra_account.move

### DIFF
--- a/language/move-prover/src/spec_translator.rs
+++ b/language/move-prover/src/spec_translator.rs
@@ -322,13 +322,13 @@ impl<'env> SpecTranslator<'env> {
             .collect_vec();
         if !aborts_if.is_empty() {
             self.writer.set_location(&aborts_if[0].loc);
-            emit!(self.writer, "ensures ");
+            emit!(self.writer, "ensures (");
             self.translate_seq(aborts_if.iter(), " || ", |c| {
                 emit!(self.writer, "b#Boolean(old(");
                 self.translate_exp_parenthesised(&c.exp);
                 emit!(self.writer, "))")
             });
-            emitln!(self.writer, " == $abort_flag;");
+            emitln!(self.writer, ") <==> $abort_flag;");
         }
 
         // Generate ensures

--- a/language/move-prover/tests/sources/aborts-if.exp
+++ b/language/move-prover/tests/sources/aborts-if.exp
@@ -75,3 +75,15 @@ error:  A postcondition might not hold on this return path.
     =         _x = <redacted>,
     =         _y = <redacted>
     =     at tests/sources/aborts-if.move:90:5: multi_abort3_incorrect (exit)
+
+error:  A postcondition might not hold on this return path.
+
+     ┌── tests/sources/aborts-if.move:114:9 ───
+     │
+ 114 │         aborts_if true;
+     │         ^^^^^^^^^^^^^^^
+     │
+     =     at tests/sources/aborts-if.move:108:5: multi_abort5_incorrect (entry)
+     =     at tests/sources/aborts-if.move:109:9: multi_abort5_incorrect
+     =         x = <redacted>
+     =     at tests/sources/aborts-if.move:108:5: multi_abort5_incorrect (exit)

--- a/language/move-prover/tests/sources/aborts-if.move
+++ b/language/move-prover/tests/sources/aborts-if.move
@@ -104,4 +104,14 @@ module TestAbortsIf {
         aborts_if _x == _y;
         aborts_if _x > _y;
     }
+
+    fun multi_abort5_incorrect(x: u64) {
+        if (x == 0) {
+            abort 1
+        };
+    }
+    spec fun multi_abort5_incorrect {
+        aborts_if true;
+        aborts_if x > 0;
+    }
 }

--- a/language/move-prover/tests/sources/stdlib/modules/libra.move
+++ b/language/move-prover/tests/sources/stdlib/modules/libra.move
@@ -95,10 +95,10 @@ module Libra {
     spec fun burn {
         aborts_if !exists<MintCapability<Token>>(sender());
         aborts_if !exists<Preburn<Token>>(preburn_address);
-        aborts_if old(len(global<Preburn<Token>>(preburn_address).requests)) == 0;
+        aborts_if len(global<Preburn<Token>>(preburn_address).requests) == 0;
         aborts_if !exists<Info<Token>>(0xA550C18);
-        aborts_if old(global<Info<Token>>(0xA550C18).total_value) < old(global<Preburn<Token>>(preburn_address).requests[0].value);
-        aborts_if old(global<Info<Token>>(0xA550C18).preburn_value) < old(global<Preburn<Token>>(preburn_address).requests[0].value);
+        aborts_if global<Info<Token>>(0xA550C18).total_value < global<Preburn<Token>>(preburn_address).requests[0].value;
+        aborts_if global<Info<Token>>(0xA550C18).preburn_value < global<Preburn<Token>>(preburn_address).requests[0].value;
         ensures Vector::eq_pop_front(global<Preburn<Token>>(preburn_address).requests, old(global<Preburn<Token>>(preburn_address).requests));
         ensures global<Info<Token>>(0xA550C18).total_value == old(global<Info<Token>>(0xA550C18).total_value) - old(global<Preburn<Token>>(preburn_address).requests[0].value);
         ensures global<Info<Token>>(0xA550C18).preburn_value == old(global<Info<Token>>(0xA550C18).preburn_value) - old(global<Preburn<Token>>(preburn_address).requests[0].value);
@@ -117,9 +117,9 @@ module Libra {
     spec fun cancel_burn {
         aborts_if !exists<MintCapability<Token>>(sender());
         aborts_if !exists<Preburn<Token>>(preburn_address);
-        aborts_if old(len(global<Preburn<Token>>(preburn_address).requests)) == 0;
+        aborts_if len(global<Preburn<Token>>(preburn_address).requests) == 0;
         aborts_if !exists<Info<Token>>(0xA550C18);
-        aborts_if old(global<Info<Token>>(0xA550C18).preburn_value) < old(global<Preburn<Token>>(preburn_address).requests[0].value);
+        aborts_if global<Info<Token>>(0xA550C18).preburn_value < global<Preburn<Token>>(preburn_address).requests[0].value;
         ensures Vector::eq_pop_front(global<Preburn<Token>>(preburn_address).requests, old(global<Preburn<Token>>(preburn_address).requests));
         ensures global<Info<Token>>(0xA550C18).preburn_value == old(global<Info<Token>>(0xA550C18).preburn_value) - old(global<Preburn<Token>>(preburn_address).requests[0].value);
         ensures result == old(global<Preburn<Token>>(preburn_address).requests[0]);
@@ -182,7 +182,7 @@ module Libra {
     spec fun preburn {
         // aborts_if !preburn_ref.is_approved; // TODO: bring this back once we can automate approvals in testnet
         aborts_if !exists<Info<Token>>(0xA550C18);
-        aborts_if old(global<Info<Token>>(0xA550C18).preburn_value) + coin.value > max_u64();
+        aborts_if global<Info<Token>>(0xA550C18).preburn_value + coin.value > max_u64();
         ensures global<Info<Token>>(0xA550C18).preburn_value == old(global<Info<Token>>(0xA550C18).preburn_value) + coin.value;
         ensures Vector::eq_push_back(preburn_ref.requests, old(preburn_ref.requests), coin);
     }
@@ -197,7 +197,7 @@ module Libra {
         // aborts_if !preburn_ref.is_approved; // TODO: bring this back once we can automate approvals in testnet
         aborts_if !exists<Info<Token>>(0xA550C18);
         aborts_if !exists<Preburn<Token>>(sender());
-        aborts_if old(global<Info<Token>>(0xA550C18).preburn_value) + coin.value > max_u64();
+        aborts_if global<Info<Token>>(0xA550C18).preburn_value + coin.value > max_u64();
         ensures global<Info<Token>>(0xA550C18).preburn_value == old(global<Info<Token>>(0xA550C18).preburn_value) + coin.value;
         ensures Vector::eq_push_back(global<Preburn<Token>>(sender()).requests, old(global<Preburn<Token>>(sender()).requests), coin);
     }
@@ -221,10 +221,10 @@ module Libra {
     }
     spec fun burn_with_capability {
         aborts_if !exists<Preburn<Token>>(preburn_address);
-        aborts_if old(len(global<Preburn<Token>>(preburn_address).requests)) == 0;
+        aborts_if len(global<Preburn<Token>>(preburn_address).requests) == 0;
         aborts_if !exists<Info<Token>>(0xA550C18);
-        aborts_if old(global<Info<Token>>(0xA550C18).total_value) < old(global<Preburn<Token>>(preburn_address).requests[0].value);
-        aborts_if old(global<Info<Token>>(0xA550C18).preburn_value) < old(global<Preburn<Token>>(preburn_address).requests[0].value);
+        aborts_if global<Info<Token>>(0xA550C18).total_value < global<Preburn<Token>>(preburn_address).requests[0].value;
+        aborts_if global<Info<Token>>(0xA550C18).preburn_value < global<Preburn<Token>>(preburn_address).requests[0].value;
         ensures Vector::eq_pop_front(global<Preburn<Token>>(preburn_address).requests, old(global<Preburn<Token>>(preburn_address).requests));
         ensures global<Info<Token>>(0xA550C18).total_value == old(global<Info<Token>>(0xA550C18).total_value) - old(global<Preburn<Token>>(preburn_address).requests[0].value);
         ensures global<Info<Token>>(0xA550C18).preburn_value == old(global<Info<Token>>(0xA550C18).preburn_value) - old(global<Preburn<Token>>(preburn_address).requests[0].value);
@@ -250,9 +250,9 @@ module Libra {
     }
     spec fun cancel_burn_with_capability {
         aborts_if !exists<Preburn<Token>>(preburn_address);
-        aborts_if old(len(global<Preburn<Token>>(preburn_address).requests)) == 0;
+        aborts_if len(global<Preburn<Token>>(preburn_address).requests) == 0;
         aborts_if !exists<Info<Token>>(0xA550C18);
-        aborts_if old(global<Info<Token>>(0xA550C18).preburn_value) < old(global<Preburn<Token>>(preburn_address).requests[0].value);
+        aborts_if global<Info<Token>>(0xA550C18).preburn_value < global<Preburn<Token>>(preburn_address).requests[0].value;
         ensures Vector::eq_pop_front(global<Preburn<Token>>(preburn_address).requests, old(global<Preburn<Token>>(preburn_address).requests));
         ensures global<Info<Token>>(0xA550C18).preburn_value == old(global<Info<Token>>(0xA550C18).preburn_value) - old(global<Preburn<Token>>(preburn_address).requests[0].value);
         ensures result == old(global<Preburn<Token>>(preburn_address).requests[0]);
@@ -371,7 +371,7 @@ module Libra {
         T { value }
     }
     spec fun withdraw {
-        aborts_if old(coin_ref.value) < value;
+        aborts_if coin_ref.value < value;
         ensures coin_ref.value == old(coin_ref.value) - value;
         ensures result.value == value;
     }
@@ -394,7 +394,7 @@ module Libra {
         coin_ref.value= coin_ref.value + value;
     }
     spec fun deposit {
-        aborts_if old(coin_ref.value) + check.value > max_u64();
+        aborts_if coin_ref.value + check.value > max_u64();
         ensures coin_ref.value == old(coin_ref.value) + check.value;
     }
 


### PR DESCRIPTION
- Fixed the bug in the "aborts_if" translation which generates incorrect formula regarding operator precedence
- Added a test case to make sure the bug is gone.
- Updated the golden file accordingly
- added and verfied 5 more functions in LibraAccount
    - deposit_with_sender_and_metadata, deposit_with_metadata, deposit,
deposit_to_sender, cancel_burn

## Motivation

To verify LibraAccount module

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?

yes

## Test Plan

cargo test, or

time cargo run -- --verbose debug --only-verify-spec libra_account.move hash.move lbr.move lcs.move libra.move libra_transaction_timeout.move transaction.move vector.move libra_time.move
