### PR TITLE
[config-builer] add account auth key

### DIFF
--- a/config/config-builder/Cargo.toml
+++ b/config/config-builder/Cargo.toml
@@ -30,3 +30,7 @@ libra-workspace-hack = { path = "../../common/workspace-hack", version = "0.1.0"
 libradb = { path = "../../storage/libradb", version = "0.1.0" }
 storage-interface = { path = "../../storage/storage-interface", version = "0.1.0" }
 vm-genesis = { path = "../../language/tools/vm-genesis", version = "0.1.0" }
+
+[features]
+default = []
+fuzzing = ["libra-config/fuzzing"]

--- a/config/src/config/test_data/random.complete.node.config.toml
+++ b/config/src/config/test_data/random.complete.node.config.toml
@@ -66,6 +66,9 @@ address = "127.0.0.1:6184"
 dir = "libradb/db"
 grpc_max_receive_len = 100000000
 
+[test]
+auth_key = "837e3b2b2b32ee2543c24676ee66326431893204fa402143c11b26ce8a89ea1d"
+
 [test.account_keypair]
 private_key = "f6b898412f4ab061943167c1e23efaa2ba98e345a093f0b06da13bffdbd4b2c7"
 public_key = "5cea31ed5918cbdac5f5c4e782d295c0b3033ed5d0eac941e8ea8bb0ab4480a3"

--- a/config/src/config/test_data/random.default.node.config.toml
+++ b/config/src/config/test_data/random.default.node.config.toml
@@ -10,6 +10,9 @@ identity_public_key = "2eaab94e262f1f7443c558588157cbb3185a7302263dafc4bfe75a2b0
 private_key = "66dd107034b4582a2ef42c5e1ea475f2fea477a10a9f1d75b3635243b2506b32"
 public_key = "f09263c17aa2e64a311b1ce512608f3e35f8481c736ae1d7db125a0ce58d3782"
 
+[test]
+auth_key = "837e3b2b2b32ee2543c24676ee66326431893204fa402143c11b26ce8a89ea1d"
+
 [test.account_keypair]
 private_key = "f6b898412f4ab061943167c1e23efaa2ba98e345a093f0b06da13bffdbd4b2c7"
 public_key = "5cea31ed5918cbdac5f5c4e782d295c0b3033ed5d0eac941e8ea8bb0ab4480a3"

--- a/config/src/config/test_data/single.node.config.toml
+++ b/config/src/config/test_data/single.node.config.toml
@@ -29,6 +29,10 @@ address = "0.0.0.0"
 address = "127.0.0.1:6184"
 dir = "libradb/db"
 grpc_max_receive_len = 100000000
+
+[test]
+auth_key = "8e0d19280063fa870fe4dbb85cc724091a398451c5c11e1e76e64cdc7b588510"
+
 [test.account_keypair]
 private_key = "76b8e0ada0f13d90405d6ae55386bd28bdd219b8a08ded1aa836efcc8b770dc7"
 public_key = "20fdbac9b10b7587bba7b5bc163bce69e796d71e4ed44c10fcb4488689f7a144"


### PR DESCRIPTION
<!--
Thank you for sending a PR. We appreciate you spending time to help improve the Libra project.

The project is undergoing daily changes. Pull Requests will be reviewed and responded to as time permits.
-->

## Motivation

Since we need auth key to create the account and cli doesn't support
passing the public key directly anymore this PR adds the auth key to the
config.

We need to create the account before register the validator.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?

Y

## Test Plan

cargo x test -p config-builder

## Related PRs

(If this PR adds or changes functionality, please take some time to update the docs at https://github.com/libra/website, and link to your PR here.)
