### PR TITLE
[move-resources] add generic MoveStorage trait to replace ConfigStorage

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4841,6 +4841,7 @@ name = "storage-interface"
 version = "0.1.0"
 dependencies = [
  "anyhow 1.0.28 (registry+https://github.com/rust-lang/crates.io-index)",
+ "itertools 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "libra-canonical-serialization 0.1.0",
  "libra-crypto 0.1.0",
  "libra-secure-net 0.1.0",

--- a/json-rpc/src/tests/mock_db.rs
+++ b/json-rpc/src/tests/mock_db.rs
@@ -4,7 +4,6 @@
 use anyhow::{Error, Result};
 use libra_crypto::HashValue;
 use libra_types::{
-    access_path::AccessPath,
     account_address::AccountAddress,
     account_state_blob::{AccountStateBlob, AccountStateWithProof},
     block_info::BlockInfo,
@@ -245,10 +244,6 @@ impl DbReader for MockLibraDB {
         _start_epoch: u64,
         _end_epoch: u64,
     ) -> Result<ValidatorChangeProof> {
-        unimplemented!()
-    }
-
-    fn batch_fetch_config(&self, _access_paths: Vec<AccessPath>) -> Result<Vec<Vec<u8>>> {
         unimplemented!()
     }
 

--- a/language/move-vm/state/src/data_cache.rs
+++ b/language/move-vm/state/src/data_cache.rs
@@ -75,6 +75,7 @@ pub trait RemoteCache {
     fn get(&self, access_path: &AccessPath) -> VMResult<Option<Vec<u8>>>;
 }
 
+// TODO deprecate this in favor of `MoveStorage`
 impl ConfigStorage for &dyn RemoteCache {
     fn fetch_config(&self, access_path: AccessPath) -> Option<Vec<u8>> {
         self.get(&access_path).ok()?

--- a/secure/json-rpc/src/lib.rs
+++ b/secure/json-rpc/src/lib.rs
@@ -609,13 +609,6 @@ mod test {
             unimplemented!()
         }
 
-        fn batch_fetch_config(
-            &self,
-            _: std::vec::Vec<libra_types::access_path::AccessPath>,
-        ) -> Result<Vec<Vec<u8>>> {
-            unimplemented!()
-        }
-
         fn get_ledger_info(&self, _: u64) -> Result<LedgerInfoWithSignatures> {
             unimplemented!()
         }

--- a/state-synchronizer/src/executor_proxy.rs
+++ b/state-synchronizer/src/executor_proxy.rs
@@ -11,6 +11,7 @@ use libra_types::{
     account_state::AccountState,
     contract_event::ContractEvent,
     ledger_info::LedgerInfoWithSignatures,
+    move_resource::MoveStorage,
     on_chain_config::{OnChainConfigPayload, ON_CHAIN_CONFIG_REGISTRY},
     transaction::TransactionListWithProof,
     validator_change::ValidatorChangeProof,
@@ -98,7 +99,7 @@ impl ExecutorProxy {
             .iter()
             .map(|config_id| config_id.access_path())
             .collect();
-        let configs = storage.batch_fetch_config(access_paths)?;
+        let configs = storage.batch_fetch_resources(access_paths)?;
         let epoch = storage
             .get_latest_account_state(association_address())?
             .map(|blob| {

--- a/storage/storage-client/src/lib.rs
+++ b/storage/storage-client/src/lib.rs
@@ -668,10 +668,6 @@ impl DbReader for SyncStorageClient {
         unimplemented!()
     }
 
-    fn batch_fetch_config(&self, _access_paths: Vec<AccessPath>) -> Result<Vec<Vec<u8>>> {
-        unimplemented!()
-    }
-
     fn get_account_state_with_proof_by_version(
         &self,
         address: AccountAddress,

--- a/storage/storage-interface/Cargo.toml
+++ b/storage/storage-interface/Cargo.toml
@@ -11,6 +11,7 @@ edition = "2018"
 
 [dependencies]
 anyhow = "1.0"
+itertools = "0.9.0"
 serde = { version = "1.0.106", default-features = false }
 thiserror = "1.0"
 

--- a/types/src/move_resource.rs
+++ b/types/src/move_resource.rs
@@ -5,7 +5,9 @@ use crate::{
     access_path::{AccessPath, Accesses},
     account_config,
     language_storage::{StructTag, TypeTag},
+    transaction::Version,
 };
+use anyhow::Result;
 use move_core_types::identifier::{IdentStr, Identifier};
 
 pub trait MoveResource {
@@ -36,4 +38,20 @@ pub trait MoveResource {
     fn resource_path() -> Vec<u8> {
         AccessPath::resource_access_vec(&Self::struct_tag(), &Accesses::empty())
     }
+}
+
+// TODO combine with ConfigStorage
+pub trait MoveStorage {
+    /// Returns a vector of Move resources as serialized byte array
+    /// Order of resources returned matches the order of `access_path`
+    fn batch_fetch_resources(&self, access_paths: Vec<AccessPath>) -> Result<Vec<Vec<u8>>>;
+
+    /// Returns a vector of Move resources as serialized byte array from a
+    /// specified version of the database
+    /// Order of resources returned matches the order of `access_path`
+    fn batch_fetch_resources_by_version(
+        &self,
+        access_paths: Vec<AccessPath>,
+        version: Version,
+    ) -> Result<Vec<Vec<u8>>>;
 }

--- a/types/src/on_chain_config/mod.rs
+++ b/types/src/on_chain_config/mod.rs
@@ -81,7 +81,7 @@ pub trait ConfigStorage {
 }
 
 /// Trait to be implemented by a Rust struct representation of an on-chain config
-/// that is stored in storage as a deserialized byte array
+/// that is stored in storage as a serialized byte array
 pub trait OnChainConfig: Send + Sync + DeserializeOwned {
     // association_address
     const ADDRESS: &'static str = "0xA550C18";


### PR DESCRIPTION
## Motivation

- DbReader is finally not async anymore, so we can pull out config-fetching API as a trait implementation for `ConfigStorage`
- We can actually generalize ConfigStorage trait to MoveStorage trait to support fetching Move resources, not just on-chain configs

This PR is only part of the work done to fully support MoveStorage
