### PR TITLE
[Bytecode verifier] Add (unused) structural control flow checks

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -521,6 +521,7 @@ dependencies = [
  "move-core-types 0.1.0",
  "petgraph 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "proptest 0.9.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "stdlib 0.1.0",
  "vm 0.1.0",
 ]
 

--- a/language/bytecode-verifier/bytecode-verifier-tests/Cargo.toml
+++ b/language/bytecode-verifier/bytecode-verifier-tests/Cargo.toml
@@ -18,4 +18,5 @@ libra-types = { path = "../../../types", version = "0.1.0", features = ["fuzzing
 libra-workspace-hack = { path = "../../../common/workspace-hack", version = "0.1.0" }
 invalid-mutations = { path = "../invalid-mutations", version = "0.1.0" }
 move-core-types = { path = "../../move-core/types", version = "0.1.0" }
+stdlib = { path = "../../stdlib", version = "0.1.0" }
 vm = { path = "../../vm", version = "0.1.0", features = ["fuzzing"] }

--- a/language/bytecode-verifier/bytecode-verifier-tests/src/unit_tests/control_flow_tests.rs
+++ b/language/bytecode-verifier/bytecode-verifier-tests/src/unit_tests/control_flow_tests.rs
@@ -1,0 +1,85 @@
+// Copyright (c) The Libra Core Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+use bytecode_verifier::control_flow;
+use libra_types::vm_error::StatusCode;
+use stdlib::{stdlib_modules, StdLibOptions};
+use vm::{
+    access::ModuleAccess,
+    errors::VMResult,
+    file_format::{self, Bytecode, CompiledModule},
+};
+
+fn verify_module(module: &CompiledModule) -> VMResult<()> {
+    for function_definition in module.function_defs().iter().filter(|def| !def.is_native()) {
+        control_flow::verify(&module, &function_definition)?
+    }
+    Ok(())
+}
+
+//**************************************************************************************************
+// Simple cases -  Copied from code unit verifier
+//**************************************************************************************************
+
+#[test]
+fn invalid_fallthrough_br_true() {
+    let module = file_format::dummy_procedure_module(vec![Bytecode::LdFalse, Bytecode::BrTrue(1)]);
+    let result = verify_module(&module);
+    assert_eq!(
+        result.unwrap_err().major_status,
+        StatusCode::INVALID_FALL_THROUGH
+    );
+}
+
+#[test]
+fn invalid_fallthrough_br_false() {
+    let module = file_format::dummy_procedure_module(vec![Bytecode::LdTrue, Bytecode::BrFalse(1)]);
+    let result = verify_module(&module);
+    assert_eq!(
+        result.unwrap_err().major_status,
+        StatusCode::INVALID_FALL_THROUGH
+    );
+}
+
+// all non-branch instructions should trigger invalid fallthrough; just check one of them
+#[test]
+fn invalid_fallthrough_non_branch() {
+    let module = file_format::dummy_procedure_module(vec![Bytecode::LdTrue, Bytecode::Pop]);
+    let result = verify_module(&module);
+    assert_eq!(
+        result.unwrap_err().major_status,
+        StatusCode::INVALID_FALL_THROUGH
+    );
+}
+
+#[test]
+fn valid_fallthrough_branch() {
+    let module = file_format::dummy_procedure_module(vec![Bytecode::Branch(0)]);
+    let result = verify_module(&module);
+    assert!(result.is_ok());
+}
+
+#[test]
+fn valid_fallthrough_ret() {
+    let module = file_format::dummy_procedure_module(vec![Bytecode::Ret]);
+    let result = verify_module(&module);
+    assert!(result.is_ok());
+}
+
+#[test]
+fn valid_fallthrough_abort() {
+    let module = file_format::dummy_procedure_module(vec![Bytecode::LdU64(7), Bytecode::Abort]);
+    let result = verify_module(&module);
+    assert!(result.is_ok());
+}
+
+//**************************************************************************************************
+// Std Lib
+//**************************************************************************************************
+
+#[test]
+fn stdlib() {
+    for module in stdlib_modules(StdLibOptions::Staged) {
+        verify_module(module.as_inner()).unwrap()
+    }
+}

--- a/language/bytecode-verifier/bytecode-verifier-tests/src/unit_tests/mod.rs
+++ b/language/bytecode-verifier/bytecode-verifier-tests/src/unit_tests/mod.rs
@@ -4,6 +4,7 @@
 pub mod bounds_tests;
 pub mod code_unit_tests;
 pub mod constants_tests;
+pub mod control_flow_tests;
 pub mod duplication_tests;
 pub mod negative_stack_size_tests;
 pub mod resources_tests;

--- a/language/bytecode-verifier/src/code_unit_verifier.rs
+++ b/language/bytecode-verifier/src/code_unit_verifier.rs
@@ -4,18 +4,16 @@
 //! This module implements the checker for verifying correctness of function bodies.
 //! The overall verification is split between stack_usage_verifier.rs and
 //! abstract_interpreter.rs. CodeUnitVerifier simply orchestrates calls into these two files.
-use crate::control_flow_graph::VMControlFlowGraph;
+use crate::{
+    acquires_list_verifier::AcquiresVerifier, control_flow_graph::VMControlFlowGraph,
+    stack_usage_verifier::StackUsageVerifier, type_memory_safety::TypeAndMemorySafetyAnalysis,
+};
 use libra_types::vm_error::{StatusCode, VMStatus};
 use vm::{
     access::ModuleAccess,
-    errors::{append_err_info, VMResult},
+    errors::{append_err_info, err_at_offset, VMResult},
     file_format::{CompiledModule, FunctionDefinition},
     IndexKind,
-};
-
-use crate::{
-    acquires_list_verifier::AcquiresVerifier, stack_usage_verifier::StackUsageVerifier,
-    type_memory_safety::TypeAndMemorySafetyAnalysis,
 };
 
 pub struct CodeUnitVerifier<'a> {
@@ -41,12 +39,15 @@ impl<'a> CodeUnitVerifier<'a> {
         let code = &function_definition.code.code;
 
         // Check to make sure that the bytecode vector ends with a branching instruction.
-        if let Some(bytecode) = code.last() {
-            if !bytecode.is_unconditional_branch() {
-                return Err(VMStatus::new(StatusCode::INVALID_FALL_THROUGH));
+        match code.last() {
+            None => return Err(VMStatus::new(StatusCode::EMPTY_CODE_UNIT)),
+            Some(bytecode) if !bytecode.is_unconditional_branch() => {
+                return Err(err_at_offset(
+                    StatusCode::INVALID_FALL_THROUGH,
+                    code.len() - 1,
+                ))
             }
-        } else {
-            return Err(VMStatus::new(StatusCode::INVALID_FALL_THROUGH));
+            Some(_) => (),
         }
         self.verify_function_inner(function_definition, &VMControlFlowGraph::new(code))
     }

--- a/language/bytecode-verifier/src/control_flow.rs
+++ b/language/bytecode-verifier/src/control_flow.rs
@@ -1,0 +1,221 @@
+// Copyright (c) The Libra Core Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+//! This module implements a checker for verifies control flow. The following properties are
+//! ensured:
+//! - All forward jumps do not enter into the middle of a loop
+//! - All "breaks" (forward, loop-exiting jumps) go to the "end" of the loop
+//! - All "continues" (back jumps in a loop) are only to the current loop
+use libra_types::vm_error::{StatusCode, VMStatus};
+use std::{collections::HashSet, convert::TryInto};
+use vm::{
+    errors::{err_at_offset, VMResult},
+    file_format::{Bytecode, CodeOffset, CompiledModule, FunctionDefinition},
+};
+
+pub fn verify(_module: &CompiledModule, function_definition: &FunctionDefinition) -> VMResult<()> {
+    let code = &function_definition.code.code;
+
+    // check fall trhough
+    // Check to make sure that the bytecode vector ends with a branching instruction.
+    match code.last() {
+        None => return Err(VMStatus::new(StatusCode::EMPTY_CODE_UNIT)),
+        Some(last) if !last.is_unconditional_branch() => {
+            return Err(err_at_offset(
+                StatusCode::INVALID_FALL_THROUGH,
+                code.len() - 1,
+            ))
+        }
+        Some(_) => (),
+    }
+
+    // check jumps
+    let context = &ControlFlowVerifier { code };
+    let labels = instruction_labels(context);
+    check_jumps(context, labels)
+}
+
+#[derive(Clone, Copy)]
+enum Label {
+    Loop { last_continue: u16 },
+    Code,
+}
+
+struct ControlFlowVerifier<'a> {
+    code: &'a Vec<Bytecode>,
+}
+
+impl<'a> ControlFlowVerifier<'a> {
+    fn code(&self) -> impl Iterator<Item = (CodeOffset, &'a Bytecode)> {
+        self.code
+            .iter()
+            .enumerate()
+            .map(|(idx, instr)| (idx.try_into().unwrap(), instr))
+    }
+
+    fn labeled_code<'b: 'a>(
+        &self,
+        labels: &'b [Label],
+    ) -> impl Iterator<Item = (CodeOffset, &'a Bytecode, &'b Label)> {
+        self.code()
+            .zip(labels)
+            .map(|((i, instr), lbl)| (i, instr, lbl))
+    }
+}
+
+fn instruction_labels(context: &ControlFlowVerifier) -> Vec<Label> {
+    let mut labels: Vec<Label> = (0..context.code.len()).map(|_| Label::Code).collect();
+    let mut loop_continue = |loop_idx: CodeOffset, last_continue: CodeOffset| {
+        labels[loop_idx as usize] = Label::Loop { last_continue }
+    };
+    for (i, instr) in context.code() {
+        match instr {
+            // Back jump/"continue"
+            Bytecode::Branch(prev) | Bytecode::BrTrue(prev) | Bytecode::BrFalse(prev)
+                if *prev <= i =>
+            {
+                loop_continue(*prev, i)
+            }
+            _ => (),
+        }
+    }
+    labels
+}
+
+// Ensures the invariant:
+//   - All forward jumps do not enter into the middle of a loop
+//   - All "breaks" go to the "end" of the loop
+//   - All back jumps are only to the current loop
+fn check_jumps(context: &ControlFlowVerifier, labels: Vec<Label>) -> VMResult<()> {
+    // All back jumps are only to the current loop
+    check_continues(context, &labels)?;
+    // All "breaks" go to the "end" of the loop
+    check_breaks(context, &labels)?;
+    // All forward jumps do not enter into the middle of a loop
+    check_no_loop_splits(context, &labels)
+}
+
+fn check_code<F: FnMut(&Vec<(CodeOffset, CodeOffset)>, CodeOffset, &Bytecode) -> VMResult<()>>(
+    context: &ControlFlowVerifier,
+    labels: &[Label],
+    mut check: F,
+) -> VMResult<()> {
+    let mut loop_stack: Vec<(CodeOffset, CodeOffset)> = vec![];
+    for (i, instr, label) in context.labeled_code(labels) {
+        // Add loop to stack
+        if let Label::Loop { last_continue } = label {
+            loop_stack.push((i, *last_continue));
+        }
+
+        check(&loop_stack, i, instr)?;
+
+        // Pop if last continue
+        match instr {
+            // Back jump/"continue"
+            Bytecode::Branch(j) | Bytecode::BrTrue(j) | Bytecode::BrFalse(j) if *j <= i => {
+                let (_cur_loop, last_continue) = loop_stack.last().unwrap();
+                if i == *last_continue {
+                    loop_stack.pop();
+                }
+            }
+            _ => (),
+        }
+    }
+    Ok(())
+}
+
+// All back jumps are only to the current loop
+fn check_continues(context: &ControlFlowVerifier, labels: &[Label]) -> VMResult<()> {
+    check_code(context, labels, |loop_stack, i, instr| {
+        match instr {
+            // Back jump/"continue"
+            Bytecode::Branch(j) | Bytecode::BrTrue(j) | Bytecode::BrFalse(j) if *j <= i => {
+                let (cur_loop, _last_continue) = loop_stack.last().unwrap();
+                let is_continue = *j <= i;
+                if is_continue && j != cur_loop {
+                    // Invalid back jump. Cannot back jump outside of the current loop
+                    Err(err_at_offset(StatusCode::INVALID_LOOP_CONTINUE, i as usize))
+                } else {
+                    Ok(())
+                }
+            }
+            _ => Ok(()),
+        }
+    })
+}
+
+fn check_breaks(context: &ControlFlowVerifier, labels: &[Label]) -> VMResult<()> {
+    check_code(context, labels, |loop_stack, i, instr| {
+        match instr {
+            // Forward jump/"break"
+            Bytecode::Branch(j) | Bytecode::BrTrue(j) | Bytecode::BrFalse(j) if *j > i => {
+                match loop_stack.last() {
+                    Some((_cur_loop, last_continue))
+                        if j > last_continue && *j != last_continue + 1 =>
+                    {
+                        // Invalid loop break. Must break immediately to the instruction after
+                        // the last continue
+                        Err(err_at_offset(StatusCode::INVALID_LOOP_BREAK, i as usize))
+                    }
+                    _ => Ok(()),
+                }
+            }
+            _ => Ok(()),
+        }
+    })
+}
+
+fn check_no_loop_splits(context: &ControlFlowVerifier, labels: &[Label]) -> VMResult<()> {
+    let is_break = |loop_stack: &Vec<(CodeOffset, CodeOffset)>, jump_target: CodeOffset| -> bool {
+        match loop_stack.last() {
+            None => false,
+            Some((_cur_loop, last_continue)) => jump_target > *last_continue,
+        }
+    };
+    let loop_depth = count_loop_depth(&labels);
+    check_code(context, labels, |loop_stack, i, instr| {
+        match instr {
+            // Forward jump/"break"
+            Bytecode::Branch(j) | Bytecode::BrTrue(j) | Bytecode::BrFalse(j)
+                if *j > i && !is_break(loop_stack, *j) =>
+            {
+                let j = *j;
+                let before_depth = loop_depth[i as usize];
+                let after_depth = match &labels[j as usize] {
+                    Label::Loop { .. } => loop_depth[j as usize] - 1,
+                    Label::Code => loop_depth[j as usize],
+                };
+                if before_depth != after_depth {
+                    // Invalid forward jump. Entered the middle of a loop
+                    Err(err_at_offset(StatusCode::INVALID_LOOP_SPLIT, i as usize))
+                } else {
+                    Ok(())
+                }
+            }
+            _ => Ok(()),
+        }
+    })
+}
+
+// Only called after continues are verified, so we can assume that loops are well nested
+fn count_loop_depth(labels: &[Label]) -> Vec<usize> {
+    let last_continues: HashSet<CodeOffset> = labels
+        .iter()
+        .filter_map(|label| match label {
+            Label::Loop { last_continue } => Some(*last_continue),
+            Label::Code => None,
+        })
+        .collect();
+    let mut count = 0;
+    let mut counts = vec![];
+    for (idx, label) in labels.iter().enumerate() {
+        if let Label::Loop { .. } = label {
+            count += 1
+        }
+        counts.push(count);
+        if last_continues.contains(&idx.try_into().unwrap()) {
+            count -= 1;
+        }
+    }
+    counts
+}

--- a/language/bytecode-verifier/src/lib.rs
+++ b/language/bytecode-verifier/src/lib.rs
@@ -12,6 +12,7 @@ pub mod acquires_list_verifier;
 pub mod check_duplication;
 pub mod code_unit_verifier;
 pub mod constants;
+pub mod control_flow;
 pub mod control_flow_graph;
 pub mod instantiation_loops;
 pub mod resolver;

--- a/language/ir-testsuite/tests/commands/invalid_fallthrough1.mvir
+++ b/language/ir-testsuite/tests/commands/invalid_fallthrough1.mvir
@@ -1,4 +1,4 @@
 main() {
 }
 
-// check: INVALID_FALL_THROUGH
+// check: EMPTY_CODE_UNIT

--- a/language/move-lang/tests/functional/loops/immediate_break.move
+++ b/language/move-lang/tests/functional/loops/immediate_break.move
@@ -1,0 +1,3 @@
+fun main() {
+    loop break;
+}

--- a/language/move-lang/tests/functional/loops/nested_loops.move
+++ b/language/move-lang/tests/functional/loops/nested_loops.move
@@ -1,0 +1,17 @@
+module M {
+    public fun foobar(cond: bool) {
+        loop {
+            loop {
+                if (cond) break
+            };
+            if (cond) break
+        }
+    }
+}
+
+//! new-transaction
+use {{default}}::M;
+
+fun main() {
+    M::foobar(true)
+}

--- a/language/move-lang/tests/functional/translated_ir_tests/commands/loop_nested_breaks.move
+++ b/language/move-lang/tests/functional/translated_ir_tests/commands/loop_nested_breaks.move
@@ -3,5 +3,5 @@ fun main() {
         loop break;
         break
     };
-    ()
+    if (true) () else ()
 }

--- a/types/src/vm_error.rs
+++ b/types/src/vm_error.rs
@@ -394,9 +394,12 @@ pub enum StatusCode {
     /// Reported when a struct has zero fields
     ZERO_SIZED_STRUCT = 1080,
     LINKER_ERROR = 1081,
-    /// Constant's verification errors
     INVALID_CONSTANT_TYPE = 1082,
     MALFORMED_CONSTANT_DATA = 1083,
+    EMPTY_CODE_UNIT = 1084,
+    INVALID_LOOP_SPLIT = 1085,
+    INVALID_LOOP_BREAK = 1086,
+    INVALID_LOOP_CONTINUE = 1087,
 
     // These are errors that the VM might raise if a violation of internal
     // invariants takes place.


### PR DESCRIPTION
## Landing plans 

Currently, the checks described below are *not* hooked up to the code unit verifier. This means they are not run on any code that normally passes through the bytecode verifier. 

The plan is to land this PR and continue testing in a parallel implementation

## Motivation

Long term, we want to get the bytecode verifier to a place where the cost can be calculated easily, and up front. Currently, the big thorn preventing the cost from being represented by an easy formula is the abstract interpreter. The traversal of blocks is ill-defined, and the number of iterations needed to reach a fix point is unknown.

A long term solution would be to require all "back edges" in the control flow graph to have their abstract state annotated. This would be a massive undertaking to implement and likely isn't necessary to support the current core modules.

An interim solution is to require that all "back edges" cannot change the abstract state. This means that when checking a loop, it cannot result in any changes to the pre-state at the beginning of the loop. In less technical terms, loops cannot add new information the the check being performed.

## Open Issues

The reason I think this PR is important to get up ASAP is for these open questions

Critical:

* Does an 'interim solution' implementation require changes to the bytecode file format? (do we need new instructions/labels?)
* Does an 'interim solution' require changes to the core modules?

Less Critical:

* Do we ever need the 'long term' solution of annotated back edges?

## An 'Interim Solution' Implementation

* Step 1) Enforce a "structured" control flow on the bytecode. This allows for the identification of back edges.
* Step 2) Utilize the structure to require that "back edges" do not change the state

This PR provides Step 1 of 2.

## Specifics of this PR

* This PR adds a new verification step, `ControlFlowVerifier`, that checks certain properties about jumps inside of loops
* These restrictions go above and beyond what is strictly necessary for the 'Interim Solution' just to make our story very simple
* The rules that it enforces are as follows:
  * All "continues" (back jumps in a loop) are only to the current loop
  * All "breaks" (forward, loop-exiting jumps) go to the "end" of the loop
  * All forward jumps do not enter into the middle of a loop
* I think that only this first rule "All 'continues' (back jumps in a loop) are only to the current loop" is necessary for the back edge restriction on the CFG
* But the other rules are nice in that they keep loops incredibly sane, which gives us more flexibility for changes (not just in the bytecode verifier) in the future. 

## Algorithm Details

### Initial Data Gathered

* The first step is to find all of the "loop heads".
* We consider any `CodeOffset` to be a loop head if there is a "back jump" to that offset
  * A jump where the instruction index is less than or equal to the target offset
  * `i` s.t. `instructions[i]` is `Branch(j) | BrTrue(j) | BrFalse(j)` and `j <= i`
* We track the last jump to the loop head and call that the last "continue"

### All "continues" (back jumps in a loop) are only to the current loop

* Any back jump to a loop head is a "continue"
* We keep a stack of the current loop heads
  * The top of the stack is removed when its last continue has been reached
* If a given continue is not to the top of the loop stack, error

### All "breaks" (forward, loop-exiting jumps) go to the "end" of the loop

* We keep a stack of the current loop heads
  * The top of the stack is removed when its last continue has been reached
* Any forward jump past the last continue of current loop is a break
* Any break must jump to the instruction *immediately* after the last continue
  * `j` is the target of the break. `j == last_continue + 1`, otherwise error

### All forward jumps do not enter into the middle of a loop

* This one is a bit tricky to explain clearly, so let me know if you have questions.
* We determine the "loop depth" of every `CodeOffset`
  * In english, this is the number of loops the instruction is nested inside in.
  * Concretely:
    * Depth starts at 0
    * Iterate over the instructions
    * Increment the depth if the instruction is a loop head
    * Store the depth for that instruction
    * Decrement the depth if that instruction was a last continue for a loop
* We keep a stack of the current loop heads
  * The top of the stack is removed when its last continue has been reached
* Iterate over the instructions
* If the instruction is a forward jump that is *not* a break
  * Determine the depth at the current index
  * Determine the depth at the target index
    * Subtract one if that target index is a loop head as you have not yet "entered" the loop
  * If the depth before the jump is not the same as the depth after, error since the instruction must
  be landing inside some other loop.

## Test Plan

* Added the check and ran all the tests

## Follow up

* Implement (Step 2 of 2) for the 'interim solution', that is leverage these checks to change the abstract interpreter

## Relevant Pull Requests

* Blocked by #3493
