### PR TITLE
[shared mempool] make network message implementation agnostic

### DIFF
--- a/mempool/src/shared_mempool/network.rs
+++ b/mempool/src/shared_mempool/network.rs
@@ -18,19 +18,18 @@ use serde::{Deserialize, Serialize};
 /// Container for exchanging transactions with other Mempools
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub enum MempoolSyncMsg {
-    /// Container for sending transactions to peers
-    BroadcastTransactionsRequest(
-        (
-            u64, // timeline ID that is lower than the first txn in this broadcast's transactions
-            u64, // last timeline ID in this broadcast's transactions
-        ),
-        Vec<SignedTransaction>, // transactions
-    ),
-    /// Response for the BroadcastTransactionsRequest confirming receipt
-    BroadcastTransactionsResponse(
-        u64, // first timeline ID of corresponding request for this response
-        u64, // last timeline ID of corresponding request for this response
-    ),
+    /// broadcast request issued by the sender
+    BroadcastTransactionsRequest {
+        /// unique id of sync request. Can be used by sender for rebroadcast analysis
+        request_id: String,
+        /// shared transactions in this batch
+        transactions: Vec<SignedTransaction>,
+    },
+    /// broadcast ack issued by the receiver
+    BroadcastTransactionsResponse {
+        /// unique id of received broadcast request
+        request_id: String,
+    },
 }
 
 /// Protocol id for mempool direct-send calls

--- a/mempool/src/tests/shared_mempool_test.rs
+++ b/mempool/src/tests/shared_mempool_test.rs
@@ -201,9 +201,7 @@ impl SharedMempoolNetwork {
 
         if let PeerManagerRequest::SendMessage(peer_id, msg) = network_req {
             let sync_msg = lcs::from_bytes(&msg.mdata).unwrap();
-            if let MempoolSyncMsg::BroadcastTransactionsRequest((_start, _end), transactions) =
-                sync_msg
-            {
+            if let MempoolSyncMsg::BroadcastTransactionsRequest { transactions, .. } = sync_msg {
                 // send it to peer
                 let receiver_network_notif_tx = self.network_notifs_txs.get_mut(&peer_id).unwrap();
                 receiver_network_notif_tx
@@ -241,7 +239,7 @@ impl SharedMempoolNetwork {
 
         if let PeerManagerRequest::SendMessage(peer_id, msg) = network_req {
             let sync_msg = lcs::from_bytes(&msg.mdata).unwrap();
-            if let MempoolSyncMsg::BroadcastTransactionsResponse(_start, _end) = sync_msg {
+            if let MempoolSyncMsg::BroadcastTransactionsResponse { .. } = sync_msg {
                 // send it to peer
                 let receiver_network_notif_tx = self.network_notifs_txs.get_mut(&peer_id).unwrap();
                 receiver_network_notif_tx


### PR DESCRIPTION
use abstract `request_id: String` instead of tuple of `(u64, u64)` to represent unique broadcast transaction batch.
this will enable alternative implementations of Mempool that don't necessary use timeline index abstraction
