### PR TITLE
[state sync] remove dead async reqs in executor proxy

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4644,7 +4644,6 @@ name = "state-synchronizer"
 version = "0.1.0"
 dependencies = [
  "anyhow 1.0.28 (registry+https://github.com/rust-lang/crates.io-index)",
- "async-trait 0.1.30 (registry+https://github.com/rust-lang/crates.io-index)",
  "bytes 0.5.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "channel 0.1.0",
  "config-builder 0.1.0",

--- a/state-synchronizer/Cargo.toml
+++ b/state-synchronizer/Cargo.toml
@@ -11,7 +11,6 @@ edition = "2018"
 
 [dependencies]
 anyhow = "1.0"
-async-trait = "0.1"
 futures = "0.3.0"
 serde = { version = "1.0.106", default-features = false }
 lcs = { path = "../common/lcs", version = "0.1.0", package = "libra-canonical-serialization" }

--- a/state-synchronizer/src/executor_proxy.rs
+++ b/state-synchronizer/src/executor_proxy.rs
@@ -26,7 +26,7 @@ use storage_interface::DbReader;
 use subscription_service::ReconfigSubscription;
 
 /// Proxies interactions with execution and storage for state synchronization
-pub trait ExecutorProxyTrait: Sync + Send {
+pub trait ExecutorProxyTrait: Send {
     /// Sync the local state with the latest in storage.
     fn get_local_storage_state(&self) -> Result<SynchronizerState>;
 


### PR DESCRIPTION
## Motivation

Executor proxy recently became a sync trait with storage async->sync refactor, so we can remove async dependencies. 
- remove async_trait crate dependency
- remove `Sync` trait req for executor proxy
