### PR TITLE
[crypto] Bring Uniform back to x25519

### DIFF
--- a/config/src/config/network_config.rs
+++ b/config/src/config/network_config.rs
@@ -175,7 +175,7 @@ impl NetworkConfig {
 
     pub fn random_with_peer_id(&mut self, rng: &mut StdRng, peer_id: Option<PeerId>) {
         let signing_key = Ed25519PrivateKey::generate(rng);
-        let identity_key = x25519::PrivateKey::for_test(rng);
+        let identity_key = x25519::PrivateKey::generate(rng);
         let network_keypairs = NetworkKeyPairs::load(identity_key, signing_key);
         self.peer_id = if let Some(peer_id) = peer_id {
             peer_id

--- a/consensus/safety-rules/src/test_utils.rs
+++ b/consensus/safety-rules/src/test_utils.rs
@@ -12,10 +12,7 @@ use consensus_types::{
     vote_data::VoteData,
     vote_proposal::VoteProposal,
 };
-use libra_crypto::{
-    hash::{CryptoHash, TransactionAccumulatorHasher},
-    test_utils::TEST_SEED,
-};
+use libra_crypto::hash::{CryptoHash, TransactionAccumulatorHasher};
 use libra_secure_storage::InMemoryStorage;
 use libra_types::{
     block_info::BlockInfo,
@@ -25,7 +22,6 @@ use libra_types::{
     validator_signer::ValidatorSigner,
     waypoint::Waypoint,
 };
-use rand::prelude::*;
 use std::{
     collections::BTreeMap,
     time::{SystemTime, UNIX_EPOCH},
@@ -143,10 +139,9 @@ pub fn make_proposal_with_parent<P: Payload>(
 }
 
 pub fn validator_signers_to_ledger_info(signers: &[&ValidatorSigner]) -> LedgerInfo {
-    let mut rng = StdRng::from_seed(TEST_SEED);
-    let infos = signers.iter().map(|v| {
-        ValidatorInfo::new_with_test_network_keys(&mut rng, v.author(), v.public_key(), 1)
-    });
+    let infos = signers
+        .iter()
+        .map(|v| ValidatorInfo::new_with_test_network_keys(v.author(), v.public_key(), 1));
     let validator_set = ValidatorSet::new(infos.collect());
     LedgerInfo::mock_genesis(Some(validator_set))
 }

--- a/crypto/crypto/src/ed25519.rs
+++ b/crypto/crypto/src/ed25519.rs
@@ -181,7 +181,7 @@ impl SigningKey for Ed25519PrivateKey {
 impl Uniform for Ed25519PrivateKey {
     fn generate<R>(rng: &mut R) -> Self
     where
-        R: ::rand::SeedableRng + ::rand::RngCore + ::rand::CryptoRng,
+        R: ::rand::RngCore + ::rand::CryptoRng,
     {
         Ed25519PrivateKey(ed25519_dalek::SecretKey::generate(rng))
     }

--- a/crypto/crypto/src/multi_ed25519.rs
+++ b/crypto/crypto/src/multi_ed25519.rs
@@ -159,7 +159,7 @@ impl SigningKey for MultiEd25519PrivateKey {
 impl Uniform for MultiEd25519PrivateKey {
     fn generate<R>(rng: &mut R) -> Self
     where
-        R: ::rand::SeedableRng + ::rand::RngCore + ::rand::CryptoRng,
+        R: ::rand::RngCore + ::rand::CryptoRng,
     {
         let num_of_keys = rng.gen_range(1, MAX_NUM_OF_KEYS + 1);
         let mut private_keys: Vec<Ed25519PrivateKey> = Vec::with_capacity(num_of_keys);

--- a/crypto/crypto/src/test_utils.rs
+++ b/crypto/crypto/src/test_utils.rs
@@ -41,7 +41,7 @@ where
 {
     fn generate<R>(rng: &mut R) -> Self
     where
-        R: ::rand::SeedableRng + ::rand::RngCore + ::rand::CryptoRng,
+        R: ::rand::RngCore + ::rand::CryptoRng,
     {
         let private_key = S::generate(rng);
         private_key.into()
@@ -56,7 +56,7 @@ where
 {
     fn generate<R>(rng: &mut R) -> Self
     where
-        R: ::rand::SeedableRng + ::rand::RngCore + ::rand::CryptoRng,
+        R: ::rand::RngCore + ::rand::CryptoRng,
     {
         let private_key = S::generate(rng);
         let public_key = (&private_key).into();

--- a/crypto/crypto/src/traits.rs
+++ b/crypto/crypto/src/traits.rs
@@ -249,7 +249,7 @@ pub trait Uniform {
     /// store private keys.
     fn generate<R>(rng: &mut R) -> Self
     where
-        R: SeedableRng + RngCore + CryptoRng;
+        R: RngCore + CryptoRng;
 
     /// Generate a random key using the shared TEST_SEED
     fn generate_for_testing() -> Self

--- a/network/noise/src/lib.rs
+++ b/network/noise/src/lib.rs
@@ -44,7 +44,8 @@ impl NoiseConfig {
     #[cfg(feature = "testing")]
     pub fn new_random(rng: &mut (impl rand_core::RngCore + rand_core::CryptoRng)) -> Self {
         let parameters: NoiseParams = NOISE_PARAMETER.parse().expect("Invalid protocol name");
-        let key = x25519::PrivateKey::for_test(rng);
+        use libra_crypto::Uniform;
+        let key = x25519::PrivateKey::generate(rng);
         Self { key, parameters }
     }
 

--- a/network/src/connectivity_manager/test.rs
+++ b/network/src/connectivity_manager/test.rs
@@ -40,7 +40,7 @@ fn setup_conn_mgr(
         .into_iter()
         .map(|peer_id| {
             let signing_public_key = Ed25519PrivateKey::generate(&mut rng).public_key();
-            let identity_public_key = x25519::PrivateKey::for_test(&mut rng).public_key();
+            let identity_public_key = x25519::PrivateKey::generate(&mut rng).public_key();
             let pubkeys = NetworkPublicKeys {
                 identity_public_key,
                 signing_public_key,
@@ -75,7 +75,7 @@ fn gen_peer() -> (PeerId, NetworkPublicKeys) {
     let peer_id = PeerId::random();
     let mut rng = StdRng::from_seed(TEST_SEED);
     let signing_public_key = Ed25519PrivateKey::generate(&mut rng).public_key();
-    let identity_public_key = x25519::PrivateKey::for_test(&mut rng).public_key();
+    let identity_public_key = x25519::PrivateKey::generate(&mut rng).public_key();
     (
         peer_id,
         NetworkPublicKeys {

--- a/network/src/protocols/discovery/test.rs
+++ b/network/src/protocols/discovery/test.rs
@@ -112,8 +112,8 @@ async fn expect_address_update(
 fn generate_network_pub_keys_and_signer(
     rng: &mut (impl rand::RngCore + rand::CryptoRng),
 ) -> (NetworkPublicKeys, Ed25519PrivateKey) {
-    let signing_priv_key = Ed25519PrivateKey::generate_for_testing();
-    let identity_pub_key = x25519::PrivateKey::for_test(rng).public_key();
+    let signing_priv_key = Ed25519PrivateKey::generate(rng);
+    let identity_pub_key = x25519::PrivateKey::generate(rng).public_key();
     (
         NetworkPublicKeys {
             signing_public_key: signing_priv_key.public_key(),

--- a/network/src/protocols/network/dummy.rs
+++ b/network/src/protocols/network/dummy.rs
@@ -106,13 +106,13 @@ pub fn setup_network() -> DummyNetwork {
     let mut rng = StdRng::from_seed(TEST_SEED);
     let dialer_signing_private_key = Ed25519PrivateKey::generate(&mut rng);
     let dialer_signing_public_key = dialer_signing_private_key.public_key();
-    let dialer_identity_private_key = x25519::PrivateKey::for_test(&mut rng);
+    let dialer_identity_private_key = x25519::PrivateKey::generate(&mut rng);
     let dialer_identity_public_key = dialer_identity_private_key.public_key();
 
     // Setup keys for listener.
     let listener_signing_private_key = Ed25519PrivateKey::generate(&mut rng);
     let listener_signing_public_key = listener_signing_private_key.public_key();
-    let listener_identity_private_key = x25519::PrivateKey::for_test(&mut rng);
+    let listener_identity_private_key = x25519::PrivateKey::generate(&mut rng);
     let listener_identity_public_key = listener_identity_private_key.public_key();
 
     // Setup trusted peers.

--- a/state-synchronizer/src/tests/integration_tests.rs
+++ b/state-synchronizer/src/tests/integration_tests.rs
@@ -140,7 +140,7 @@ impl SynchronizerEnv {
             .collect();
         // Setup identity public keys.
         let identity_private_keys: Vec<_> = (0..count)
-            .map(|_| x25519::PrivateKey::for_test(&mut rng))
+            .map(|_| x25519::PrivateKey::generate(&mut rng))
             .collect();
 
         let mut validators_keys = vec![];

--- a/types/src/discovery_set.rs
+++ b/types/src/discovery_set.rs
@@ -101,14 +101,12 @@ pub mod mock {
     use super::*;
 
     use crate::on_chain_config::ValidatorSet;
-    use libra_crypto::{test_utils::TEST_SEED, x25519};
+    use libra_crypto::{x25519, Uniform};
     use parity_multiaddr::Multiaddr;
-    use rand::prelude::*;
     use std::str::FromStr;
 
     pub fn mock_discovery_set(validator_set: &ValidatorSet) -> DiscoverySet {
-        let mut rng = StdRng::from_seed(TEST_SEED);
-        let mock_pubkey = x25519::PrivateKey::for_test(&mut rng).public_key();
+        let mock_pubkey = x25519::PrivateKey::generate_for_testing().public_key();
         let mock_addr = Multiaddr::from_str("/ip4/127.0.0.1/tcp/1234").unwrap();
 
         let discovery_set = validator_set

--- a/types/src/unit_tests/trusted_state_test.rs
+++ b/types/src/unit_tests/trusted_state_test.rs
@@ -17,14 +17,12 @@ use crate::{
 use libra_crypto::{
     ed25519::Ed25519Signature,
     hash::{CryptoHash, HashValue},
-    test_utils::TEST_SEED,
 };
 use proptest::{
     collection::{size_range, vec, SizeRange},
     prelude::*,
     sample::Index,
 };
-use rand::prelude::*;
 use std::collections::BTreeMap;
 
 // hack strategy to generate a length from `impl Into<SizeRange>`
@@ -60,13 +58,11 @@ fn arb_validator_sets(
 /// Convert a slice of `ValidatorSigner` (includes the private signing key) into
 /// the public-facing `ValidatorSet` type (just the public key).
 fn into_validator_set(signers: &[ValidatorSigner]) -> ValidatorSet {
-    let mut rng = StdRng::from_seed(TEST_SEED);
     ValidatorSet::new(
         signers
             .iter()
             .map(|signer| {
                 ValidatorInfo::new_with_test_network_keys(
-                    &mut rng,
                     signer.author(),
                     signer.public_key(),
                     1, /* voting power */

--- a/types/src/validator_info.rs
+++ b/types/src/validator_info.rs
@@ -59,14 +59,13 @@ impl ValidatorInfo {
 
     #[cfg(any(test, feature = "fuzzing"))]
     pub fn new_with_test_network_keys(
-        rng: &mut (impl rand::RngCore + rand::CryptoRng),
         account_address: AccountAddress,
         consensus_public_key: Ed25519PublicKey,
         consensus_voting_power: u64,
     ) -> Self {
         let network_signing_public_key = Ed25519PrivateKey::generate_for_testing().public_key();
-        let private_key = x25519::PrivateKey::for_test(rng);
-        let network_identity_public_key: x25519::PublicKey = private_key.public_key();
+        let private_key = x25519::PrivateKey::generate_for_testing();
+        let network_identity_public_key = private_key.public_key();
 
         Self {
             account_address,

--- a/types/src/validator_verifier.rs
+++ b/types/src/validator_verifier.rs
@@ -298,15 +298,11 @@ impl From<&ValidatorSet> for ValidatorVerifier {
 #[cfg(any(test, feature = "fuzzing"))]
 impl From<&ValidatorVerifier> for ValidatorSet {
     fn from(verifier: &ValidatorVerifier) -> Self {
-        use libra_crypto::test_utils::TEST_SEED;
-        use rand::prelude::*;
-        let mut rng = StdRng::from_seed(TEST_SEED);
         ValidatorSet::new(
             verifier
                 .get_ordered_account_addresses_iter()
                 .map(|addr| {
                     crate::validator_info::ValidatorInfo::new_with_test_network_keys(
-                        &mut rng,
                         addr,
                         verifier.get_public_key(&addr).unwrap(),
                         verifier.get_voting_power(&addr).unwrap(),


### PR DESCRIPTION
This helps simplify several use cases that do not need the
expressiveness of defining random x25519 keys where a single test key
would work. This in turn helps minimize code duplication.

@mimoo, this is not intended to address the naming concerns which still exist. This is purely a hack to enable simpler test harnesses where useful.