### PR TITLE
Improve serde-reflection and generate-format

### DIFF
--- a/common/serde-reflection/src/de.rs
+++ b/common/serde-reflection/src/de.rs
@@ -468,7 +468,7 @@ impl<'de, 'a> de::Deserializer<'de> for Deserializer<'de, 'a> {
     }
 
     fn is_human_readable(&self) -> bool {
-        self.tracer.is_human_readable
+        self.tracer.config.is_human_readable
     }
 }
 

--- a/common/serde-reflection/src/lib.rs
+++ b/common/serde-reflection/src/lib.rs
@@ -223,8 +223,8 @@
 //! * while visiting a container, if the container's name is mapped to a recorded value,
 //! we MAY decide to use it.
 //!
-//! Currently, we always pick the recorded value for a NewTypeStruct and never do in the other cases.
-//! (TODO: decide what to do)
+//! The default configuration `TracerConfig:default()` always picks the recorded value for a
+//! `NewTypeStruct` and never does in the other cases.
 
 mod de;
 mod error;

--- a/common/serde-reflection/src/lib.rs
+++ b/common/serde-reflection/src/lib.rs
@@ -54,7 +54,7 @@
 //!
 //! # fn main() -> Result<(), Error> {
 //! // Start a session to trace formats.
-//! let mut tracer = Tracer::new(/* is_human_readable */ false);
+//! let mut tracer = Tracer::new(TracerConfig::default());
 //! // Create a store to hold samples of Rust values.
 //! let mut records = SerializationRecords::new();
 //!
@@ -129,7 +129,7 @@
 //! }
 //!
 //! # fn main() -> Result<(), Error> {
-//! let mut tracer = Tracer::new(/* is_human_readable */ false);
+//! let mut tracer = Tracer::new(TracerConfig::default());
 //! let mut records = SerializationRecords::new();
 //! tracer.trace_value(&mut records, &FullName { first: "", middle: Some(""), last: "" })?;
 //! let registry = tracer.registry()?;
@@ -159,7 +159,7 @@
 //! #   last: &'a str,
 //! # }
 //! # fn main() -> Result<(), Error> {
-//! let mut tracer = Tracer::new(/* is_human_readable */ false);
+//! let mut tracer = Tracer::new(TracerConfig::default());
 //! let mut records = SerializationRecords::new();
 //! tracer.trace_value(&mut records, &FullName { first: "", middle: None, last: "" })?;
 //! assert_eq!(tracer.registry().unwrap_err(), Error::UnknownFormatInContainer("FullName"));
@@ -235,5 +235,5 @@ mod value;
 
 pub use error::{Error, Result};
 pub use format::{ContainerFormat, Format, FormatHolder, Named, VariantFormat};
-pub use trace::{Registry, RegistryOwned, SerializationRecords, Tracer};
+pub use trace::{Registry, RegistryOwned, SerializationRecords, Tracer, TracerConfig};
 pub use value::Value;

--- a/common/serde-reflection/src/ser.rs
+++ b/common/serde-reflection/src/ser.rs
@@ -261,7 +261,7 @@ impl<'a> ser::Serializer for Serializer<'a> {
     }
 
     fn is_human_readable(&self) -> bool {
-        self.tracer.is_human_readable
+        self.tracer.config.is_human_readable
     }
 }
 

--- a/common/serde-reflection/src/ser.rs
+++ b/common/serde-reflection/src/ser.rs
@@ -118,8 +118,13 @@ impl<'a> ser::Serializer for Serializer<'a> {
     }
 
     fn serialize_unit_struct(self, name: &'static str) -> Result<(Format, Value)> {
-        self.tracer
-            .record_container(self.records, name, ContainerFormat::UnitStruct, Value::Unit)
+        self.tracer.record_container(
+            self.records,
+            name,
+            ContainerFormat::UnitStruct,
+            Value::Unit,
+            false,
+        )
     }
 
     fn serialize_unit_variant(
@@ -148,6 +153,7 @@ impl<'a> ser::Serializer for Serializer<'a> {
             name,
             ContainerFormat::NewTypeStruct(Box::new(format)),
             value,
+            self.tracer.config.record_samples_for_newtype_structs,
         )
     }
 
@@ -345,8 +351,13 @@ impl<'a> ser::SerializeTupleStruct for TupleStructSerializer<'a> {
     fn end(self) -> Result<(Format, Value)> {
         let format = ContainerFormat::TupleStruct(self.formats);
         let value = Value::Seq(self.values);
-        self.tracer
-            .record_container(self.records, self.name, format, value)
+        self.tracer.record_container(
+            self.records,
+            self.name,
+            format,
+            value,
+            self.tracer.config.record_samples_for_tuple_structs,
+        )
     }
 }
 
@@ -461,8 +472,13 @@ impl<'a> ser::SerializeStruct for StructSerializer<'a> {
     fn end(self) -> Result<(Format, Value)> {
         let format = ContainerFormat::Struct(self.fields);
         let value = Value::Seq(self.values);
-        self.tracer
-            .record_container(self.records, self.name, format, value)
+        self.tracer.record_container(
+            self.records,
+            self.name,
+            format,
+            value,
+            self.tracer.config.record_samples_for_structs,
+        )
     }
 }
 

--- a/common/serde-reflection/src/trace.rs
+++ b/common/serde-reflection/src/trace.rs
@@ -41,12 +41,14 @@ pub struct SerializationRecords {
 }
 
 impl SerializationRecords {
+    /// Create a new structure to hold value samples.
     pub fn new() -> Self {
         Self {
             values: BTreeMap::new(),
         }
     }
 
+    /// Obtain a (serialized) sample.
     pub fn value(&self, name: &'static str) -> Option<&Value> {
         self.values.get(name)
     }

--- a/common/serde-reflection/src/trace.rs
+++ b/common/serde-reflection/src/trace.rs
@@ -21,8 +21,8 @@ pub type RegistryOwned = BTreeMap<String, ContainerFormat>;
 /// This typically aims at computing a `Registry`.
 #[derive(Debug)]
 pub struct Tracer {
-    /// Whether to trace the human readable variant of the (De)Serialize traits.
-    pub(crate) is_human_readable: bool,
+    /// Hold configuration options.
+    pub(crate) config: TracerConfig,
 
     /// Formats of the named containers discovered so far, while tracing
     /// serialization and/or deserialization.
@@ -43,9 +43,7 @@ pub struct SerializationRecords {
 impl SerializationRecords {
     /// Create a new structure to hold value samples.
     pub fn new() -> Self {
-        Self {
-            values: BTreeMap::new(),
-        }
+        Self::default()
     }
 
     /// Obtain a (serialized) sample.
@@ -54,11 +52,35 @@ impl SerializationRecords {
     }
 }
 
+/// Configuration object to create a tracer.
+#[derive(Debug)]
+pub struct TracerConfig {
+    pub(crate) is_human_readable: bool,
+}
+
+impl Default for TracerConfig {
+    /// Create a new structure to hold value samples.
+    fn default() -> Self {
+        Self {
+            is_human_readable: false,
+        }
+    }
+}
+
+impl TracerConfig {
+    /// Whether to trace the human readable encoding of (de)serialization.
+    #[allow(clippy::wrong_self_convention)]
+    pub fn is_human_readable(mut self, value: bool) -> Self {
+        self.is_human_readable = value;
+        self
+    }
+}
+
 impl Tracer {
     /// Start tracing deserialization.
-    pub fn new(is_human_readable: bool) -> Self {
+    pub fn new(config: TracerConfig) -> Self {
         Self {
-            is_human_readable,
+            config,
             registry: BTreeMap::new(),
             incomplete_enums: BTreeSet::new(),
         }

--- a/common/serde-reflection/src/value.rs
+++ b/common/serde-reflection/src/value.rs
@@ -54,6 +54,15 @@ impl<'de> IntoDeserializer<'de, Error> for &'de Value {
     }
 }
 
+impl Value {
+    pub(crate) fn seq_values(&self) -> Result<&Vec<Value>> {
+        match self {
+            Value::Seq(x) => Ok(x),
+            _ => Err(Error::DeserializationError("seq_values")),
+        }
+    }
+}
+
 macro_rules! declare_deserialize {
     ($method:ident, $token:ident, $visit:ident, $str:expr) => {
         fn $method<V>(self, visitor: V) -> Result<V::Value>
@@ -251,11 +260,11 @@ impl<'de> de::Deserializer<'de> for Deserializer<'de> {
     }
 }
 
-struct SeqDeserializer<I> {
+pub(crate) struct SeqDeserializer<I> {
     values: I,
 }
 
-trait IntoSeqDeserializer {
+pub(crate) trait IntoSeqDeserializer {
     type SeqDeserializer;
 
     fn into_seq_deserializer(self) -> Self::SeqDeserializer;

--- a/common/serde-reflection/tests/serde.rs
+++ b/common/serde-reflection/tests/serde.rs
@@ -5,7 +5,8 @@ use bincode;
 use serde::{de::IntoDeserializer, Deserialize, Serialize};
 use serde_json;
 use serde_reflection::{
-    ContainerFormat, Error, Format, Named, SerializationRecords, Tracer, Value, VariantFormat,
+    ContainerFormat, Error, Format, Named, SerializationRecords, Tracer, TracerConfig, Value,
+    VariantFormat,
 };
 use serde_yaml;
 use std::collections::BTreeMap;
@@ -31,7 +32,7 @@ fn test_variant(tracer: &mut Tracer, expr: E, expected_value: Value) {
 
 #[test]
 fn test_tracers() {
-    let mut tracer = Tracer::new(/* is_human_readable */ false);
+    let mut tracer = Tracer::new(TracerConfig::default());
 
     test_variant(
         &mut tracer,
@@ -131,7 +132,7 @@ fn test_tracers() {
 
     // Tracing deserialization
     let records = SerializationRecords::new();
-    let mut tracer = Tracer::new(/* is_human_readable */ false);
+    let mut tracer = Tracer::new(TracerConfig::default());
     let (ident, samples) = tracer.trace_type::<E>(&records).unwrap();
     assert_eq!(ident, Format::TypeName("E".into()));
     assert_eq!(tracer.registry().unwrap().get("E").unwrap(), format);
@@ -183,7 +184,7 @@ enum Person {
 #[test]
 fn test_trace_deserialization_with_custom_invariants() {
     let mut records = SerializationRecords::new();
-    let mut tracer = Tracer::new(/* is_human_readable */ false);
+    let mut tracer = Tracer::new(TracerConfig::default());
     // Type trace alone cannot guess a valid value for `Name`.
     assert_eq!(
         tracer.trace_type::<Person>(&records).unwrap_err(),
@@ -260,7 +261,7 @@ mod bar {
 #[test]
 fn test_name_clash_not_supported() {
     let mut records = SerializationRecords::new();
-    let mut tracer = Tracer::new(/* is_human_readable */ false);
+    let mut tracer = Tracer::new(TracerConfig::default());
     tracer.trace_value(&mut records, &foo::A).unwrap();
     // Repeating names is fine.
     assert!(tracer.trace_value(&mut records, &foo::A).is_ok());
@@ -275,7 +276,7 @@ fn test_borrowed_slice() {
 
     let bytes = [1u8; 4];
     let mut records = SerializationRecords::new();
-    let mut tracer = Tracer::new(/* is_human_readable */ false);
+    let mut tracer = Tracer::new(TracerConfig::default());
 
     let (format, value) = tracer.trace_value(&mut records, &Borrowed(&bytes)).unwrap();
     assert_eq!(format, Format::TypeName("Borrowed".into()));
@@ -300,7 +301,7 @@ fn test_borrowed_bytes() {
 
     let bytes = [1u8; 4];
     let mut records = SerializationRecords::new();
-    let mut tracer = Tracer::new(/* is_human_readable */ false);
+    let mut tracer = Tracer::new(TracerConfig::default());
 
     let (format, value) = tracer.trace_value(&mut records, &Borrowed(&bytes)).unwrap();
     assert_eq!(format, Format::TypeName("Borrowed".into()));
@@ -327,7 +328,7 @@ fn test_trace_deserialization_with_recursive_types() {
     }
 
     let records = SerializationRecords::new();
-    let mut tracer = Tracer::new(/* is_human_readable */ false);
+    let mut tracer = Tracer::new(TracerConfig::default());
 
     tracer.trace_type::<List<u32>>(&records).unwrap();
 

--- a/testsuite/generate-format/src/compute.rs
+++ b/testsuite/generate-format/src/compute.rs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use generate_format::{add_deserialization_tracing, add_proptest_serialization_tracing, FILE_PATH};
-use serde_reflection::{SerializationRecords, Tracer};
+use serde_reflection::{SerializationRecords, Tracer, TracerConfig};
 use serde_yaml;
 use std::{fs::File, io::Write};
 use structopt::StructOpt;
@@ -24,7 +24,7 @@ fn main() {
     let options = Options::from_args();
 
     let records = SerializationRecords::new();
-    let tracer = Tracer::new(lcs::is_human_readable());
+    let tracer = Tracer::new(TracerConfig::default().is_human_readable(lcs::is_human_readable()));
     let (mut tracer, records) = add_proptest_serialization_tracing(tracer, records);
     if !options.skip_deserialize {
         tracer = add_deserialization_tracing(tracer, &records);

--- a/testsuite/generate-format/src/lib.rs
+++ b/testsuite/generate-format/src/lib.rs
@@ -1,73 +1,44 @@
 // Copyright (c) The Libra Core Contributors
 // SPDX-License-Identifier: Apache-2.0
 
-/// How to record the format of interesting Libra types.
-/// See API documentation with `cargo doc -p serde-reflection --open`
-use libra_types::{contract_event, transaction};
-use proptest::{
-    prelude::*,
-    test_runner::{Config, FileFailurePersistence, TestRunner},
-};
-use serde_reflection::{SerializationRecords, Tracer};
-use std::sync::{Arc, Mutex};
+//! How and where to record the Serde format of interesting Libra types.
+//! See API documentation with `cargo doc -p serde-reflection --open`
 
-/// Default output file.
-pub static FILE_PATH: &str = "tests/staged/libra.yaml";
+use serde_reflection::Registry;
+use std::str::FromStr;
+use structopt::{clap::arg_enum, StructOpt};
 
-/// Which Libra values to record with the serialization tracing API.
-///
-/// This step is useful to inject well-formed values that must pass
-/// custom-validation checks (e.g. keys).
-pub fn add_proptest_serialization_tracing(
-    tracer: Tracer,
-    records: SerializationRecords,
-) -> (Tracer, SerializationRecords) {
-    let mut runner = TestRunner::new(Config {
-        failure_persistence: Some(Box::new(FileFailurePersistence::Off)),
-        ..Config::default()
-    });
+/// Libra transactions.
+mod libra;
 
-    // Wrap the tracer for (hypothetical) concurrent accesses.
-    let tracer = Arc::new(Mutex::new(tracer));
-    let records = Arc::new(Mutex::new(records));
-
-    runner
-        .run(&any::<transaction::Transaction>(), |v| {
-            tracer
-                .lock()
-                .unwrap()
-                .trace_value(&mut records.lock().unwrap(), &v)?;
-            Ok(())
-        })
-        .unwrap();
-
-    runner
-        .run(&any::<contract_event::ContractEvent>(), |v| {
-            tracer
-                .lock()
-                .unwrap()
-                .trace_value(&mut records.lock().unwrap(), &v)?;
-            Ok(())
-        })
-        .unwrap();
-
-    // Recover the Arc-mutex-ed tracer.
-    (
-        Arc::try_unwrap(tracer).unwrap().into_inner().unwrap(),
-        Arc::try_unwrap(records).unwrap().into_inner().unwrap(),
-    )
+arg_enum! {
+#[derive(Debug, StructOpt, Clone, Copy)]
+/// A corpus of Rust types to trace, and optionally record on disk.
+pub enum Corpus {
+    Libra,
+}
 }
 
-/// Which Libra types to record with the deserialization tracing API.
-///
-/// This step is useful to guarantee coverage of the analysis but it may
-/// fail if the previous step missed some custom types.
-pub fn add_deserialization_tracing(mut tracer: Tracer, records: &SerializationRecords) -> Tracer {
-    tracer
-        .trace_type::<transaction::Transaction>(&records)
-        .unwrap();
-    tracer
-        .trace_type::<contract_event::ContractEvent>(&records)
-        .unwrap();
-    tracer
+impl Corpus {
+    /// All corpuses.
+    pub fn values() -> Vec<Corpus> {
+        Corpus::variants()
+            .iter()
+            .filter_map(|s| Corpus::from_str(s).ok())
+            .collect()
+    }
+
+    /// Compute the registry of formats.
+    pub fn get_registry(self, skip_deserialize: bool) -> Registry {
+        match self {
+            Corpus::Libra => libra::get_registry(self.to_string(), skip_deserialize),
+        }
+    }
+
+    /// Where to record this corpus on disk.
+    pub fn output_file(self) -> Option<&'static str> {
+        match self {
+            Corpus::Libra => libra::output_file(),
+        }
+    }
 }

--- a/testsuite/generate-format/src/libra.rs
+++ b/testsuite/generate-format/src/libra.rs
@@ -6,7 +6,7 @@ use proptest::{
     prelude::*,
     test_runner::{Config, FileFailurePersistence, TestRunner},
 };
-use serde_reflection::{Registry, SerializationRecords, Tracer, TracerConfig};
+use serde_reflection::{Registry, Samples, Tracer, TracerConfig};
 use std::sync::{Arc, Mutex};
 
 /// Default output file.
@@ -15,9 +15,9 @@ pub fn output_file() -> Option<&'static str> {
 }
 
 pub fn get_registry(_name: String, skip_deserialize: bool) -> Registry {
-    let (mut tracer, records) = proptest_serialization_tracing();
+    let (mut tracer, samples) = proptest_serialization_tracing();
     if !skip_deserialize {
-        deserialization_tracing(&mut tracer, &records);
+        deserialization_tracing(&mut tracer, &samples);
     }
     tracer.registry().unwrap()
 }
@@ -26,7 +26,7 @@ pub fn get_registry(_name: String, skip_deserialize: bool) -> Registry {
 ///
 /// This step is useful to inject well-formed values that must pass
 /// custom-validation checks (e.g. keys).
-fn proptest_serialization_tracing() -> (Tracer, SerializationRecords) {
+fn proptest_serialization_tracing() -> (Tracer, Samples) {
     let mut runner = TestRunner::new(Config {
         failure_persistence: Some(Box::new(FileFailurePersistence::Off)),
         ..Config::default()
@@ -35,14 +35,14 @@ fn proptest_serialization_tracing() -> (Tracer, SerializationRecords) {
     let tracer = Arc::new(Mutex::new(Tracer::new(
         TracerConfig::default().is_human_readable(lcs::is_human_readable()),
     )));
-    let records = Arc::new(Mutex::new(SerializationRecords::new()));
+    let samples = Arc::new(Mutex::new(Samples::new()));
 
     runner
         .run(&any::<transaction::Transaction>(), |v| {
             tracer
                 .lock()
                 .unwrap()
-                .trace_value(&mut records.lock().unwrap(), &v)?;
+                .trace_value(&mut samples.lock().unwrap(), &v)?;
             Ok(())
         })
         .unwrap();
@@ -52,7 +52,7 @@ fn proptest_serialization_tracing() -> (Tracer, SerializationRecords) {
             tracer
                 .lock()
                 .unwrap()
-                .trace_value(&mut records.lock().unwrap(), &v)?;
+                .trace_value(&mut samples.lock().unwrap(), &v)?;
             Ok(())
         })
         .unwrap();
@@ -60,7 +60,7 @@ fn proptest_serialization_tracing() -> (Tracer, SerializationRecords) {
     // Recover the Arc-mutex-ed tracer.
     (
         Arc::try_unwrap(tracer).unwrap().into_inner().unwrap(),
-        Arc::try_unwrap(records).unwrap().into_inner().unwrap(),
+        Arc::try_unwrap(samples).unwrap().into_inner().unwrap(),
     )
 }
 
@@ -68,11 +68,11 @@ fn proptest_serialization_tracing() -> (Tracer, SerializationRecords) {
 ///
 /// This step is useful to guarantee coverage of the analysis but it may
 /// fail if the previous step missed some custom types.
-fn deserialization_tracing(tracer: &mut Tracer, records: &SerializationRecords) {
+fn deserialization_tracing(tracer: &mut Tracer, samples: &Samples) {
     tracer
-        .trace_type::<transaction::Transaction>(&records)
+        .trace_type::<transaction::Transaction>(&samples)
         .unwrap();
     tracer
-        .trace_type::<contract_event::ContractEvent>(&records)
+        .trace_type::<contract_event::ContractEvent>(&samples)
         .unwrap();
 }

--- a/testsuite/generate-format/src/libra.rs
+++ b/testsuite/generate-format/src/libra.rs
@@ -32,8 +32,9 @@ fn proptest_serialization_tracing() -> (Tracer, SerializationRecords) {
         ..Config::default()
     });
 
-    let tracer = Arc::new(Mutex::new(
-        Tracer::new(TracerConfig::default().is_human_readable(lcs::is_human_readable()))));
+    let tracer = Arc::new(Mutex::new(Tracer::new(
+        TracerConfig::default().is_human_readable(lcs::is_human_readable()),
+    )));
     let records = Arc::new(Mutex::new(SerializationRecords::new()));
 
     runner

--- a/testsuite/generate-format/src/libra.rs
+++ b/testsuite/generate-format/src/libra.rs
@@ -1,0 +1,77 @@
+// Copyright (c) The Libra Core Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+use libra_types::{contract_event, transaction};
+use proptest::{
+    prelude::*,
+    test_runner::{Config, FileFailurePersistence, TestRunner},
+};
+use serde_reflection::{Registry, SerializationRecords, Tracer, TracerConfig};
+use std::sync::{Arc, Mutex};
+
+/// Default output file.
+pub fn output_file() -> Option<&'static str> {
+    Some("tests/staged/libra.yaml")
+}
+
+pub fn get_registry(_name: String, skip_deserialize: bool) -> Registry {
+    let (mut tracer, records) = proptest_serialization_tracing();
+    if !skip_deserialize {
+        deserialization_tracing(&mut tracer, &records);
+    }
+    tracer.registry().unwrap()
+}
+
+/// Which Libra values to record with the serialization tracing API.
+///
+/// This step is useful to inject well-formed values that must pass
+/// custom-validation checks (e.g. keys).
+fn proptest_serialization_tracing() -> (Tracer, SerializationRecords) {
+    let mut runner = TestRunner::new(Config {
+        failure_persistence: Some(Box::new(FileFailurePersistence::Off)),
+        ..Config::default()
+    });
+
+    let tracer = Arc::new(Mutex::new(
+        Tracer::new(TracerConfig::default().is_human_readable(lcs::is_human_readable()))));
+    let records = Arc::new(Mutex::new(SerializationRecords::new()));
+
+    runner
+        .run(&any::<transaction::Transaction>(), |v| {
+            tracer
+                .lock()
+                .unwrap()
+                .trace_value(&mut records.lock().unwrap(), &v)?;
+            Ok(())
+        })
+        .unwrap();
+
+    runner
+        .run(&any::<contract_event::ContractEvent>(), |v| {
+            tracer
+                .lock()
+                .unwrap()
+                .trace_value(&mut records.lock().unwrap(), &v)?;
+            Ok(())
+        })
+        .unwrap();
+
+    // Recover the Arc-mutex-ed tracer.
+    (
+        Arc::try_unwrap(tracer).unwrap().into_inner().unwrap(),
+        Arc::try_unwrap(records).unwrap().into_inner().unwrap(),
+    )
+}
+
+/// Which Libra types to record with the deserialization tracing API.
+///
+/// This step is useful to guarantee coverage of the analysis but it may
+/// fail if the previous step missed some custom types.
+fn deserialization_tracing(tracer: &mut Tracer, records: &SerializationRecords) {
+    tracer
+        .trace_type::<transaction::Transaction>(&records)
+        .unwrap();
+    tracer
+        .trace_type::<contract_event::ContractEvent>(&records)
+        .unwrap();
+}

--- a/testsuite/generate-format/tests/detect_format_change.rs
+++ b/testsuite/generate-format/tests/detect_format_change.rs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use generate_format::{add_deserialization_tracing, add_proptest_serialization_tracing, FILE_PATH};
-use serde_reflection::{RegistryOwned, SerializationRecords, Tracer};
+use serde_reflection::{RegistryOwned, SerializationRecords, Tracer, TracerConfig};
 use serde_yaml;
 use std::collections::BTreeMap;
 
@@ -13,7 +13,7 @@ Please verify the changes to the recorded file(s) and tag your pull-request as `
 #[test]
 fn test_recorded_formats_did_not_change() {
     let records = SerializationRecords::new();
-    let tracer = Tracer::new(lcs::is_human_readable());
+    let tracer = Tracer::new(TracerConfig::default().is_human_readable(lcs::is_human_readable()));
     let (mut tracer, records) = add_proptest_serialization_tracing(tracer, records);
     tracer = add_deserialization_tracing(tracer, &records);
     let registry: BTreeMap<_, _> = tracer


### PR DESCRIPTION
## Summary

* Fix recursion logic in serde reflection
* Add a config object `TracerConfig`
* Use the config object to fix one TODO (giving control on value sampling)
* Improve docs in serde-reflection
* Add notion of corpus to generate-format.

The latest feature will be used in future PRs possibly adding more YAML files to trace Libra types not related to Libra transactions.

## Test Plan

```
cargo x test -p generate-format -p serde-reflection
```
