### PR TITLE
[cli] fix incorrect argument check for compile command

### DIFF
--- a/client/cli/src/dev_commands.rs
+++ b/client/cli/src/dev_commands.rs
@@ -41,13 +41,13 @@ impl Command for DevCommandCompile {
         vec!["compile", "c"]
     }
     fn get_params_help(&self) -> &'static str {
-        "<sender_account_address>|<sender_account_ref_id> <file_path> <dependency source files...>"
+        "<sender_account_address>|<sender_account_ref_id> <file_path> <dependency_source_files...>"
     }
     fn get_description(&self) -> &'static str {
         "Compile Move program"
     }
     fn execute(&self, client: &mut ClientProxy, params: &[&str]) {
-        if params.len() < 4 {
+        if params.len() < 3 {
             println!("Invalid number of arguments for compilation");
             return;
         }


### PR DESCRIPTION
This is a follow up to #3425 where I changed the arguments for the compile command. I missed that the minimum number of arguments is now 3 instead of 4.

This also changes the help message to refer to "dependency_source_files" with underscores instead of spaces to separate the words. That is more consistent with the other messages.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?

Yes