### PR TITLE
[consensus] simplify event processor test

### DIFF
--- a/consensus/src/network_tests.rs
+++ b/consensus/src/network_tests.rs
@@ -315,6 +315,16 @@ impl NetworkPlayground {
             .unwrap()
             .stop_drop_message_for(src, dst)
     }
+
+    pub async fn start<T: Payload>(mut self) {
+        // Take the next queued message
+        while let Some((src, net_req)) = self.outbound_msgs_rx.next().await {
+            // Deliver and copy message it if it's not dropped
+            if !self.is_message_dropped(&src, &net_req) {
+                self.deliver_message::<T>(src, net_req).await;
+            }
+        }
+    }
 }
 
 struct DropConfig(HashMap<Author, HashSet<Author>>);


### PR DESCRIPTION
<!--
Thank you for sending a PR. We appreciate you spending time to help improve the Libra project.

The project is undergoing daily changes. Pull Requests will be reviewed and responded to as time permits.
-->

## Motivation

We add the support to inspect messages from network both from self and
remote which greatly simplify how tests are written. For example we
don't need 2 nodes to test network message anymore, and no need to
wait_for network playground anymore.


### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?

Y

## Test Plan

Existing tests.

## Related PRs

(If this PR adds or changes functionality, please take some time to update the docs at https://github.com/libra/website, and link to your PR here.)
