### PR TITLE
[mempool] add v0 of peer manager

### DIFF
--- a/config/config-builder/src/full_node_config.rs
+++ b/config/config-builder/src/full_node_config.rs
@@ -242,7 +242,7 @@ impl FullNodeConfig {
             upstream.upstream_peers = vec![PeerNetworkId(network.peer_id, upstream_peer_id)]
                 .into_iter()
                 .collect::<HashSet<_>>();
-            config.upstream = upstream.clone();
+            config.upstream = upstream;
         }
 
         Ok((configs, faucet_key))

--- a/config/src/config/mempool_config.rs
+++ b/config/src/config/mempool_config.rs
@@ -10,6 +10,7 @@ pub struct MempoolConfig {
     pub shared_mempool_tick_interval_ms: u64,
     pub shared_mempool_batch_size: usize,
     pub shared_mempool_max_concurrent_inbound_syncs: usize,
+    pub shared_mempool_min_broadcast_recipient_count: Option<usize>,
     pub capacity: usize,
     // max number of transactions per user in Mempool
     pub capacity_per_user: usize,
@@ -24,6 +25,7 @@ impl Default for MempoolConfig {
             shared_mempool_tick_interval_ms: 50,
             shared_mempool_batch_size: 100,
             shared_mempool_max_concurrent_inbound_syncs: 100,
+            shared_mempool_min_broadcast_recipient_count: None,
             capacity: 1_000_000,
             capacity_per_user: 100,
             system_transaction_timeout_secs: 86400,

--- a/config/src/config/mod.rs
+++ b/config/src/config/mod.rs
@@ -38,6 +38,8 @@ mod storage_config;
 pub use storage_config::*;
 mod safety_rules_config;
 pub use safety_rules_config::*;
+mod upstream_config;
+pub use upstream_config::*;
 mod test_config;
 use libra_types::waypoint::Waypoint;
 pub use test_config::*;
@@ -76,6 +78,8 @@ pub struct NodeConfig {
     pub storage: StorageConfig,
     #[serde(default)]
     pub test: Option<TestConfig>,
+    #[serde(default)]
+    pub upstream: UpstreamConfig,
     #[serde(default)]
     pub validator_network: Option<NetworkConfig>,
 }
@@ -173,6 +177,7 @@ impl NodeConfig {
             state_sync: self.state_sync.clone(),
             storage: self.storage.clone(),
             test: None,
+            upstream: self.upstream.clone(),
             validator_network: self
                 .validator_network
                 .as_ref()
@@ -182,9 +187,6 @@ impl NodeConfig {
 
     /// Determines whether a node `peer_id` is an upstream peer of a node with this NodeConfig.
     /// For a validator node, any of its validator peers are considered an upstream peer
-    /// In general, a network ID is a PeerId that this node uses to uniquely identify a network it belongs to.
-    /// This is equivalent to the `peer_id` field in the NetworkConfig of this NodeConfig
-    /// Here, `network_id` is the ID of the network that the peer and this node belong to.
     pub fn is_upstream_peer(&self, peer_id: PeerId, network_id: PeerId) -> bool {
         match self.base.role {
             RoleType::Validator => self
@@ -241,15 +243,6 @@ impl NodeConfig {
         // This must be last as calling save on subconfigs may change their fields
         self.save_config(&output_path)?;
         Ok(())
-    }
-
-    /// Returns true if network_config is for an upstream network
-    pub fn is_upstream_network(&self, network_config: &NetworkConfig) -> bool {
-        self.state_sync
-            .upstream_peers
-            .upstream_peers
-            .iter()
-            .any(|peer_id| network_config.network_peers.peers.contains_key(peer_id))
     }
 
     pub fn randomize_ports(&mut self) {

--- a/config/src/config/mod.rs
+++ b/config/src/config/mod.rs
@@ -185,23 +185,6 @@ impl NodeConfig {
         }
     }
 
-    /// Determines whether a node `peer_id` is an upstream peer of a node with this NodeConfig.
-    /// For a validator node, any of its validator peers are considered an upstream peer
-    pub fn is_upstream_peer(&self, peer_id: PeerId, network_id: PeerId) -> bool {
-        match self.base.role {
-            RoleType::Validator => self
-                .validator_network
-                .as_ref()
-                .map(|cfg| cfg.peer_id == network_id)
-                .unwrap_or_default(),
-            RoleType::FullNode => self
-                .state_sync
-                .upstream_peers
-                .upstream_peers
-                .contains(&peer_id),
-        }
-    }
-
     /// Reads the config file and returns the configuration object in addition to doing some
     /// post-processing of the config
     /// Paths used in the config are either absolute or relative to the config location

--- a/config/src/config/upstream_config.rs
+++ b/config/src/config/upstream_config.rs
@@ -5,51 +5,44 @@ use libra_types::PeerId;
 use serde::{Deserialize, Serialize};
 use std::collections::HashSet;
 
-#[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
+/// In general, a network ID is a PeerId that this node uses to uniquely identify a network it belongs to.
+/// This is equivalent to the `peer_id` field in the NetworkConfig of this NodeConfig
+type NetworkId = PeerId;
+
+#[derive(Clone, Default, Debug, Deserialize, PartialEq, Serialize)]
 #[serde(default, deny_unknown_fields)]
 pub struct UpstreamConfig {
-    // The upstream networks that this node belongs to as statically defined in the NodeConfig of this UpstreamConfig
-    // A network is considered upstream if all peers in this network are upstream w.r.t. this node
-    pub primary_networks: HashSet<PeerId>,
+    // primary upstream network ids. All peers in such network are used as upstream for this node
+    pub primary_networks: Vec<NetworkId>,
     // All upstream peers of this node, across all the networks that are statically defined in this node's config
-    // this is mostly meaningful in VFNs, where there is a strict hierarchy in a network
+    // this is mostly meaningful in VFN networks, where there is a strict hierarchy in a network
     pub upstream_peers: HashSet<PeerNetworkId>,
-    // ID of network that connects to VFNs
-    // used to connect to more upstream peers if upstream peers in the primary_network
-    // or `upstream_peers` are not available
+    // optional fallback network id. Used to as a failover if preferred upstream peers are not available
     // TODO replace PeerId with `NetworkConfig` to contain actual info needed to build fallback_network
-    pub fallback_network: Option<PeerId>,
+    pub fallback_networks: Vec<NetworkId>,
 }
 
 impl UpstreamConfig {
-    pub fn is_upstream_peer(&self, network_id: PeerId, peer_id: PeerId) -> bool {
+    /// Determines whether a node `peer_id` in network `network_id` is an upstream peer of a node with this NodeConfig.
+    pub fn is_upstream_peer(&self, network_id: NetworkId, peer_id: PeerId) -> bool {
+        self.is_primary_upstream_peer(network_id, peer_id)
+            || self.fallback_networks.contains(&network_id)
+    }
+
+    pub fn is_primary_upstream_peer(&self, network_id: NetworkId, peer_id: PeerId) -> bool {
         self.primary_networks.contains(&network_id)
             || self
                 .upstream_peers
                 .contains(&PeerNetworkId(network_id, peer_id))
-            || self.fallback_network == Some(peer_id)
-    }
-}
-
-impl Default for UpstreamConfig {
-    fn default() -> UpstreamConfig {
-        UpstreamConfig {
-            primary_networks: HashSet::new(),
-            upstream_peers: HashSet::new(),
-            fallback_network: None,
-        }
     }
 }
 
 #[derive(Clone, Debug, Deserialize, Eq, Hash, PartialEq, Serialize)]
 /// Identifier of a node, represented as (network_id, peer_id)
-/// In general, a network ID is a PeerId that this node uses to uniquely identify a network it belongs to.
-/// This is equivalent to the `peer_id` field in the NetworkConfig of this NodeConfig
-/// Here, `network_id` is the ID of the network that the peer and this node belong to.
-pub struct PeerNetworkId(pub PeerId, pub PeerId);
+pub struct PeerNetworkId(pub NetworkId, pub PeerId);
 
 impl PeerNetworkId {
-    pub fn network_id(&self) -> PeerId {
+    pub fn network_id(&self) -> NetworkId {
         self.0
     }
 

--- a/config/src/config/upstream_config.rs
+++ b/config/src/config/upstream_config.rs
@@ -1,0 +1,59 @@
+// Copyright (c) The Libra Core Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+use libra_types::PeerId;
+use serde::{Deserialize, Serialize};
+use std::collections::HashSet;
+
+#[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
+#[serde(default, deny_unknown_fields)]
+pub struct UpstreamConfig {
+    // The upstream networks that this node belongs to as statically defined in the NodeConfig of this UpstreamConfig
+    // A network is considered upstream if all peers in this network are upstream w.r.t. this node
+    pub primary_networks: HashSet<PeerId>,
+    // All upstream peers of this node, across all the networks that are statically defined in this node's config
+    // this is mostly meaningful in VFNs, where there is a strict hierarchy in a network
+    pub upstream_peers: HashSet<PeerNetworkId>,
+    // ID of network that connects to VFNs
+    // used to connect to more upstream peers if upstream peers in the primary_network
+    // or `upstream_peers` are not available
+    // TODO replace PeerId with `NetworkConfig` to contain actual info needed to build fallback_network
+    pub fallback_network: Option<PeerId>,
+}
+
+impl UpstreamConfig {
+    pub fn is_upstream_peer(&self, network_id: PeerId, peer_id: PeerId) -> bool {
+        self.primary_networks.contains(&network_id)
+            || self
+                .upstream_peers
+                .contains(&PeerNetworkId(network_id, peer_id))
+            || self.fallback_network == Some(peer_id)
+    }
+}
+
+impl Default for UpstreamConfig {
+    fn default() -> UpstreamConfig {
+        UpstreamConfig {
+            primary_networks: HashSet::new(),
+            upstream_peers: HashSet::new(),
+            fallback_network: None,
+        }
+    }
+}
+
+#[derive(Clone, Debug, Deserialize, Eq, Hash, PartialEq, Serialize)]
+/// Identifier of a node, represented as (network_id, peer_id)
+/// In general, a network ID is a PeerId that this node uses to uniquely identify a network it belongs to.
+/// This is equivalent to the `peer_id` field in the NetworkConfig of this NodeConfig
+/// Here, `network_id` is the ID of the network that the peer and this node belong to.
+pub struct PeerNetworkId(pub PeerId, pub PeerId);
+
+impl PeerNetworkId {
+    pub fn network_id(&self) -> PeerId {
+        self.0
+    }
+
+    pub fn peer_id(&self) -> PeerId {
+        self.1
+    }
+}

--- a/config/src/generator.rs
+++ b/config/src/generator.rs
@@ -83,6 +83,10 @@ pub fn validator_swarm(
             fullnodes_network_address: network.advertised_address.clone(),
         });
 
+        // set UpstreamConfig
+        // For a validator node, any of its validator peers are considered an upstream peer
+        node.upstream.primary_networks.push(network.peer_id);
+
         nodes.push(node);
     }
 

--- a/libra-node/src/main_node.rs
+++ b/libra-node/src/main_node.rs
@@ -279,6 +279,9 @@ pub fn setup_environment(node_config: &mut NodeConfig) -> LibraHandle {
         debug!("Network started for peer_id: {}", full_node_network.peer_id);
     }
 
+    // TODO set up on-chain discovery network based on UpstreamConfig.fallback_network
+    // and pass network handles to mempool/state sync
+
     // for state sync to send requests to mempool
     let (state_sync_to_mempool_sender, state_sync_requests) =
         channel(INTRA_NODE_CHANNEL_BUFFER_SIZE);

--- a/mempool/Cargo.toml
+++ b/mempool/Cargo.toml
@@ -16,6 +16,7 @@ futures = "0.3.0"
 once_cell = "1.3.1"
 lru-cache = "0.1.1"
 prost = "0.6"
+rand = { version = "0.7.3", default-features = false }
 serde = { version = "1.0.106", default-features = false }
 tokio = { version = "0.2.13", features = ["full"] }
 ttl_cache = "0.5.1"

--- a/mempool/src/shared_mempool/mod.rs
+++ b/mempool/src/shared_mempool/mod.rs
@@ -8,4 +8,5 @@ pub use runtime::bootstrap;
 #[cfg(feature = "fuzzing")]
 pub(crate) use runtime::start_shared_mempool;
 mod coordinator;
+mod peer_manager;
 mod tasks;

--- a/mempool/src/shared_mempool/peer_manager.rs
+++ b/mempool/src/shared_mempool/peer_manager.rs
@@ -1,0 +1,121 @@
+// Copyright (c) The Libra Core Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+use libra_config::config::UpstreamConfig;
+use libra_types::PeerId;
+use rand::seq::IteratorRandom;
+use std::{collections::HashMap, sync::Mutex};
+
+/// stores only peers that receive txns from this node
+pub(crate) type PeerInfo = HashMap<PeerId, PeerSyncState>;
+
+/// state of last sync with peer
+/// `timeline_id` is position in log of ready transactions
+/// `is_alive` - is connection healthy
+/// `network_id` - ID of the mempool network that this peer belongs to
+#[derive(Clone)]
+pub(crate) struct PeerSyncState {
+    pub timeline_id: u64,
+    pub is_alive: bool,
+    pub network_id: PeerId,
+}
+
+pub(crate) struct PeerManager {
+    upstream_config: UpstreamConfig,
+    peer_info: Mutex<PeerInfo>,
+    min_broadcast_recipient_count: usize,
+}
+
+impl PeerManager {
+    pub fn new(upstream_config: UpstreamConfig, min_broadcast_recipient_count: usize) -> Self {
+        let peer_info = Mutex::new(PeerInfo::new());
+        Self {
+            upstream_config,
+            peer_info,
+            min_broadcast_recipient_count,
+        }
+    }
+
+    pub fn add_peer(&self, network_id: PeerId, peer_id: PeerId) {
+        if self.is_upstream_peer(network_id, peer_id) {
+            self.peer_info
+                .lock()
+                .expect("failed to acquire peer info lock")
+                .entry(peer_id)
+                .or_insert(PeerSyncState {
+                    timeline_id: 0,
+                    is_alive: true,
+                    network_id,
+                })
+                .is_alive = true;
+        }
+    }
+
+    pub fn disable_peer(&self, peer_id: PeerId) {
+        if let Some(state) = self
+            .peer_info
+            .lock()
+            .expect("failed to acquire peer info lock")
+            .get_mut(&peer_id)
+        {
+            state.is_alive = false;
+        }
+    }
+
+    // pick_peers
+    // picks peers to broadcast to. Will first try to pick *all* preferred peers (= upstream as defined by config)
+    // if preferred upstream peers < `k = min_broadcast_recipient_count`, pick fallback peers to fill up k
+    pub fn pick_peers(&self) -> PeerInfo {
+        let peer_info = self
+            .peer_info
+            .lock()
+            .expect("failed to acquire peer info lock");
+        // pick all preferred peers
+        let mut picked_peers: PeerInfo = peer_info
+            .iter()
+            .filter(|(peer, state)| {
+                state.is_alive
+                    && self
+                        .upstream_config
+                        .is_primary_upstream_peer(state.network_id, **peer)
+            })
+            .map(|(peer, state)| (*peer, state.clone()))
+            .collect();
+
+        let picked_peers_count = picked_peers.len();
+        if picked_peers_count < self.min_broadcast_recipient_count {
+            // randomly select fallback peers
+            // TODO add peer scoring schema to use for selecting fallback peers
+            let fallback_peers: PeerInfo = peer_info
+                .iter()
+                .filter(|(peer, state)| !picked_peers.contains_key(&peer) && state.is_alive)
+                .map(|(peer, state)| (*peer, state.clone()))
+                .choose_multiple(
+                    &mut rand::thread_rng(),
+                    self.min_broadcast_recipient_count - picked_peers_count,
+                )
+                .into_iter()
+                .collect();
+
+            picked_peers.extend(fallback_peers);
+        }
+        picked_peers
+    }
+
+    pub fn update_peer_broadcast(&self, peer_broadcasts: Vec<(PeerId, u64)>) {
+        let mut peer_info = self
+            .peer_info
+            .lock()
+            .expect("failed to acquire peer_info lock");
+
+        for (peer_id, new_timeline_id) in peer_broadcasts {
+            peer_info.entry(peer_id).and_modify(|t| {
+                t.timeline_id = new_timeline_id;
+            });
+        }
+    }
+
+    pub fn is_upstream_peer(&self, network_id: PeerId, peer_id: PeerId) -> bool {
+        self.upstream_config.is_upstream_peer(network_id, peer_id)
+    }
+}

--- a/mempool/src/shared_mempool/types.rs
+++ b/mempool/src/shared_mempool/types.rs
@@ -3,7 +3,10 @@
 
 //! Objects used by/related to shared mempool
 
-use crate::{core_mempool::CoreMempool, shared_mempool::network::MempoolNetworkSender};
+use crate::{
+    core_mempool::CoreMempool,
+    shared_mempool::{network::MempoolNetworkSender, peer_manager::PeerManager},
+};
 use anyhow::Result;
 use futures::{
     channel::{mpsc, mpsc::UnboundedSender, oneshot},
@@ -27,6 +30,8 @@ use storage_client::StorageRead;
 use tokio::sync::RwLock;
 use vm_validator::vm_validator::TransactionValidation;
 
+pub(crate) const DEFAULT_MIN_BROADCAST_RECIPIENT_COUNT: usize = 0;
+
 /// Struct that owns all dependencies required by shared mempool routines
 #[derive(Clone)]
 pub(crate) struct SharedMempool<V>
@@ -38,7 +43,7 @@ where
     pub network_senders: HashMap<PeerId, MempoolNetworkSender>,
     pub storage_read_client: Arc<dyn StorageRead>,
     pub validator: Arc<RwLock<V>>,
-    pub peer_info: Arc<Mutex<PeerInfo>>,
+    pub peer_manager: Arc<PeerManager>,
     pub subscribers: Vec<UnboundedSender<SharedMempoolNotification>>,
 }
 
@@ -48,20 +53,6 @@ pub enum SharedMempoolNotification {
     PeerStateChange,
     NewTransactions,
     ACK,
-}
-
-/// stores only peers that receive txns from this node
-pub(crate) type PeerInfo = HashMap<PeerId, PeerSyncState>;
-
-/// state of last sync with peer
-/// `timeline_id` is position in log of ready transactions
-/// `is_alive` - is connection healthy
-/// `network_id` - ID of the mempool network that this peer belongs to
-#[derive(Clone)]
-pub(crate) struct PeerSyncState {
-    pub timeline_id: u64,
-    pub is_alive: bool,
-    pub network_id: PeerId,
 }
 
 #[derive(Debug)]


### PR DESCRIPTION
## Motivation

- Add peer manager for mempool that implements basic k-policy (k = min # broadcast recipients, and there are two classes of upstream peers: preferred (defined as upstream in config) and fallback (most likely from discovery set networks). If there are less than `k` preferred peers, pick more fallback peers)
- add `UpstreamConfig` to better handle logic for determining whether a peer of a node is upstream or not

Notes/TODOs on top of this PR:
- need to deprecate `upstream_peers` defined in state sync config, and refactor state sync peer manager to use `UpstreamConfig`
- both mempool and state sync assume that peer_id of a node is a unique identifier. This is a false assumption - so we need to refactor mempool and state sync to uniquely identify a peer using (network_id, peer_id).
- Add peer scoring schema for mempool

