### PR TITLE
[core] batch of core changes related to multicurrecy setup

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2317,6 +2317,7 @@ dependencies = [
  "libra-types 0.1.0",
  "libra-workspace-hack 0.1.0",
  "libradb 0.1.0",
+ "move-core-types 0.1.0",
  "once_cell 1.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "prometheus 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "proptest 0.9.6 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/client/cli/src/client_proxy.rs
+++ b/client/cli/src/client_proxy.rs
@@ -254,8 +254,8 @@ impl ClientProxy {
         );
         let (address, _) = self.get_account_address_from_parameter(space_delim_strings[1])?;
         self.get_account_resource_and_update(address).map(|res| {
-            let whole_num = res.balance / 1_000_000;
-            let remainder = res.balance % 1_000_000;
+            let whole_num = res.balance.amount / 1_000_000;
+            let remainder = res.balance.amount % 1_000_000;
             format!("{}.{:0>6}", whole_num.to_string(), remainder.to_string())
         })
     }

--- a/json-rpc/Cargo.toml
+++ b/json-rpc/Cargo.toml
@@ -32,6 +32,7 @@ libra-proptest-helpers = { path = "../common/proptest-helpers", optional = true 
 libra-types = { path = "../types", version = "0.1.0" }
 libra-workspace-hack = { path = "../common/workspace-hack", version = "0.1.0" }
 libradb = { path = "../storage/libradb", version = "0.1.0" }
+move-core-types = { path = "../language/move-core/types", version = "0.1.0" }
 storage-interface = { path = "../storage/storage-interface", version = "0.1.0" }
 transaction-builder = { path = "../language/transaction-builder", version = "0.1.0"}
 debug-interface = { path = "../common/debug-interface", version = "0.1.0" }

--- a/json-rpc/src/tests/unit_tests.rs
+++ b/json-rpc/src/tests/unit_tests.rs
@@ -249,7 +249,7 @@ fn test_get_account_state() {
         .unwrap()
         .expect("account does not exist");
     assert_eq!(
-        account.balance,
+        account.balance.amount,
         expected_resource
             .get_balance_resource()
             .unwrap()
@@ -285,7 +285,7 @@ fn test_get_account_state() {
             .unwrap()
             .expect("account does not exist");
         assert_eq!(
-            account.balance,
+            account.balance.amount,
             states[idx].get_balance_resource().unwrap().unwrap().coin()
         );
         assert_eq!(

--- a/mempool/src/core_mempool/index.rs
+++ b/mempool/src/core_mempool/index.rs
@@ -53,6 +53,7 @@ impl PriorityIndex {
             expiration_time: txn.expiration_time,
             address: txn.get_sender(),
             sequence_number: txn.get_sequence_number(),
+            is_governance_txn: txn.is_governance_txn,
         }
     }
 
@@ -72,6 +73,7 @@ pub struct OrderedQueueKey {
     pub expiration_time: Duration,
     pub address: AccountAddress,
     pub sequence_number: u64,
+    pub is_governance_txn: bool,
 }
 
 impl PartialOrd for OrderedQueueKey {
@@ -82,6 +84,10 @@ impl PartialOrd for OrderedQueueKey {
 
 impl Ord for OrderedQueueKey {
     fn cmp(&self, other: &OrderedQueueKey) -> Ordering {
+        match self.is_governance_txn.cmp(&other.is_governance_txn) {
+            Ordering::Equal => {}
+            ordering => return ordering,
+        }
         match self.gas_ranking_score.cmp(&other.gas_ranking_score) {
             Ordering::Equal => {}
             ordering => return ordering,

--- a/mempool/src/core_mempool/mempool.rs
+++ b/mempool/src/core_mempool/mempool.rs
@@ -111,6 +111,7 @@ impl Mempool {
         rankin_score: u64,
         db_sequence_number: u64,
         timeline_state: TimelineState,
+        is_governance_txn: bool,
     ) -> MempoolStatus {
         trace_event!("mempool::add_txn", {"txn", txn.sender(), txn.sequence_number()});
         trace!(
@@ -152,6 +153,7 @@ impl Mempool {
             gas_amount,
             rankin_score,
             timeline_state,
+            is_governance_txn,
         );
 
         let status = self.transactions.insert(txn_info, sequence_number);

--- a/mempool/src/core_mempool/transaction.rs
+++ b/mempool/src/core_mempool/transaction.rs
@@ -12,6 +12,7 @@ pub struct MempoolTransaction {
     pub gas_amount: u64,
     pub ranking_score: u64,
     pub timeline_state: TimelineState,
+    pub is_governance_txn: bool,
 }
 
 impl MempoolTransaction {
@@ -21,6 +22,7 @@ impl MempoolTransaction {
         gas_amount: u64,
         ranking_score: u64,
         timeline_state: TimelineState,
+        is_governance_txn: bool,
     ) -> Self {
         Self {
             txn,
@@ -28,6 +30,7 @@ impl MempoolTransaction {
             ranking_score,
             expiration_time,
             timeline_state,
+            is_governance_txn,
         }
     }
     pub(crate) fn get_sequence_number(&self) -> u64 {

--- a/mempool/src/shared_mempool/tasks.rs
+++ b/mempool/src/shared_mempool/tasks.rs
@@ -252,12 +252,14 @@ where
                     None => {
                         let gas_amount = transaction.max_gas_amount();
                         let rankin_score = validation_result.score();
+                        let is_governance_txn = validation_result.is_governance_txn();
                         let mempool_status = mempool.add_txn(
                             transaction,
                             gas_amount,
                             rankin_score,
                             sequence_number,
                             timeline_state,
+                            is_governance_txn,
                         );
                         statuses.push((mempool_status, None));
                     }

--- a/mempool/src/tests/common.rs
+++ b/mempool/src/tests/common.rs
@@ -21,14 +21,21 @@ pub(crate) fn setup_mempool() -> (CoreMempool, ConsensusMock) {
     )
 }
 
-static ACCOUNTS: Lazy<Vec<AccountAddress>> =
-    Lazy::new(|| vec![AccountAddress::random(), AccountAddress::random()]);
+static ACCOUNTS: Lazy<Vec<AccountAddress>> = Lazy::new(|| {
+    vec![
+        AccountAddress::random(),
+        AccountAddress::random(),
+        AccountAddress::random(),
+        AccountAddress::random(),
+    ]
+});
 
 #[derive(Clone)]
 pub struct TestTransaction {
     pub(crate) address: usize,
     pub(crate) sequence_number: u64,
-    gas_price: u64,
+    pub(crate) gas_price: u64,
+    pub(crate) is_governance_txn: bool,
 }
 
 impl TestTransaction {
@@ -37,6 +44,7 @@ impl TestTransaction {
             address,
             sequence_number,
             gas_price,
+            is_governance_txn: false,
         }
     }
 
@@ -103,6 +111,7 @@ pub(crate) fn add_txns_to_mempool(
             txn.gas_unit_price(),
             0,
             TimelineState::NotReady,
+            transaction.is_governance_txn,
         );
         transactions.push(txn);
     }
@@ -121,6 +130,7 @@ pub(crate) fn add_signed_txn(pool: &mut CoreMempool, transaction: SignedTransact
             transaction.gas_unit_price(),
             0,
             TimelineState::NotReady,
+            false,
         )
         .code
     {

--- a/mempool/src/tests/mocks.rs
+++ b/mempool/src/tests/mocks.rs
@@ -126,6 +126,7 @@ impl MockSharedMempool {
                         txn.gas_unit_price(),
                         0,
                         TimelineState::NotReady,
+                        false,
                     )
                     .code
                     != MempoolStatusCode::Accepted

--- a/mempool/src/tests/shared_mempool_test.rs
+++ b/mempool/src/tests/shared_mempool_test.rs
@@ -169,6 +169,7 @@ impl SharedMempoolNetwork {
                 transaction.gas_unit_price(),
                 0,
                 TimelineState::NotReady,
+                false,
             );
         }
     }

--- a/types/src/account_config.rs
+++ b/types/src/account_config.rs
@@ -598,4 +598,8 @@ impl CurrencyInfoResource {
             &Accesses::empty(),
         )
     }
+
+    pub fn try_from_bytes(bytes: &[u8]) -> Result<Self> {
+        lcs::from_bytes(bytes).map_err(Into::into)
+    }
 }


### PR DESCRIPTION
it includes
* mempool prioritizes association transactions over the rest
* json-rpc existing endpoints will use AmountView that includes currency code instead of plain u64 value
* added new meta endpoint that lists all available currencies on libra blockchain

Example:
```curl -X POST -H "Content-Type: application/json" --data '{"jsonrpc":"2.0", "method":"currencies_info","params":[],"id":1}' ```
Output:
```{"id":1,"jsonrpc":"2.0","result":[{"code":"Coin1","fractional_part":100,"scaling_factor":1000000},{"code":"Coin2","fractional_part":100,"scaling_factor":1000000},{"code":"LBR","fractional_part":1000,"scaling_factor":1000000}]}```