### PR TITLE
[Key Manager] Implemented LibraInterface using the secure JsonRpcClient.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2338,9 +2338,12 @@ dependencies = [
  "config-builder 0.1.0",
  "executor 0.1.0",
  "executor-types 0.1.0",
+ "futures 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "libra-config 0.1.0",
  "libra-crypto 0.1.0",
+ "libra-json-rpc 0.1.0",
  "libra-logger 0.1.0",
+ "libra-secure-json-rpc 0.1.0",
  "libra-secure-storage 0.1.0",
  "libra-secure-time 0.1.0",
  "libra-transaction-scripts 0.1.0",
@@ -2351,6 +2354,8 @@ dependencies = [
  "rand 0.7.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "storage-interface 0.1.0",
  "thiserror 1.0.15 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio 0.2.13 (registry+https://github.com/rust-lang/crates.io-index)",
+ "vm-validator 0.1.0",
 ]
 
 [[package]]

--- a/secure/json-rpc/src/lib.rs
+++ b/secure/json-rpc/src/lib.rs
@@ -64,6 +64,7 @@ impl From<FromHexError> for Error {
 }
 
 /// Provides a lightweight JsonRpcClient implementation.
+#[derive(Clone)]
 pub struct JsonRpcClient {
     host: String,
 }

--- a/secure/key-manager/Cargo.toml
+++ b/secure/key-manager/Cargo.toml
@@ -12,6 +12,7 @@ publish = false
 [dependencies]
 libra-crypto = { path = "../../crypto/crypto", version = "0.1.0" }
 libra-logger = { path = "../../common/logger", version = "0.1.0" }
+libra-secure-json-rpc = { path = "../../secure/json-rpc", version = "0.1.0" }
 libra-secure-storage = { path = "../../secure/storage", version = "0.1.0" }
 libra-secure-time = { path = "../../secure/time", version = "0.1.0" }
 libra-transaction-scripts = { path = "../transaction-scripts", version = "0.1.0" }
@@ -21,12 +22,16 @@ thiserror = "1.0"
 
 [dev-dependencies]
 anyhow = "1.0"
+futures = "0.3.0"
 rand = "0.7.3"
+tokio = { version = "0.2.13", features = ["full"] }
 
 config-builder = { path = "../../config/config-builder", version = "0.1.0" }
 executor = { path = "../../execution/executor", version = "0.1.0" }
 executor-types = { path = "../../execution/executor-types", version = "0.1.0" }
 libradb = { path = "../../storage/libradb", version = "0.1.0" }
 libra-config = { path = "../../config", version = "0.1.0", features = ["fuzzing"]}
+libra-json-rpc = { path = "../../json-rpc", version = "0.1.0", features = ["fuzzing"] }
 libra-vm = { path = "../../language/libra-vm", version = "0.1.0" }
 storage-interface= { path = "../../storage/storage-interface", version = "0.1.0" }
+vm-validator = { path = "../../vm-validator", version = "0.1.0" }

--- a/secure/key-manager/src/libra_interface.rs
+++ b/secure/key-manager/src/libra_interface.rs
@@ -1,0 +1,187 @@
+// Copyright (c) The Libra Core Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::Error;
+use libra_secure_json_rpc::JsonRpcClient;
+use libra_types::{
+    account_address::AccountAddress, account_config, account_state::AccountState,
+    transaction::Transaction, validator_config::ValidatorConfig, validator_info::ValidatorInfo,
+};
+
+/// This defines a generic trait used to interact with the Libra blockchain. In production, this
+/// will be talking to a JSON-RPC service. For tests, this may be an executor and storage directly.
+pub trait LibraInterface {
+    /// Retrieves the current time from the blockchain, this is returned as microseconds.
+    fn libra_timestamp(&self) -> Result<u64, Error>;
+
+    /// Retrieves the last reconfiguration time from the blockchain, this is returned as
+    /// microseconds.
+    fn last_reconfiguration(&self) -> Result<u64, Error>;
+
+    /// Retrieve current sequence number for the provided account.
+    fn retrieve_sequence_number(&self, account: AccountAddress) -> Result<u64, Error>;
+
+    /// Submits a transaction to the block chain and returns successfully if the transaction was
+    /// successfully submitted. It does not necessarily mean the transaction successfully executed.
+    fn submit_transaction(&self, transaction: Transaction) -> Result<(), Error>;
+
+    /// Retrieves the ValidatorConfig at the specified AccountAddress if one exists.
+    fn retrieve_validator_config(&self, account: AccountAddress) -> Result<ValidatorConfig, Error>;
+
+    /// Retrieves the ValidatorInfo for the specified account from the current ValidatorSet if one
+    /// exists.
+    fn retrieve_validator_info(&self, account: AccountAddress) -> Result<ValidatorInfo, Error>;
+
+    /// Fetches the AccountState associated with a specific account. This is currently only
+    /// used by test code, but it's not completely inconceivable that non-test code will want
+    /// access to this in the future.
+    fn retrieve_account_state(&self, account: AccountAddress) -> Result<AccountState, Error>;
+}
+
+/// This implements the LibraInterface by talking directly to the JSON RPC API.
+///
+/// DISCLAIMER: this implementation assumes that the json rpc client explicitly trusts the json rpc
+/// server that is responding to its requests (e.g., the client assumes the server has already been
+/// authenticated, provides encrypted and freshness protected messages, etc.). As such, the security
+/// of the server will need to be verified in production before this interface should be used.
+/// Pointing the client to an untrusted (and potentially malicious) json rpc server, can result in
+/// denial-of-service attacks (e.g., against the key manager).
+///
+/// TODO(joshlind): add proof checks to the JsonRpcClient to verify the state returned by the json
+/// rpc server we're talking to. Although we won't be able to guarantee freshness, it's better than
+/// simply trusting the response for correctness..
+#[derive(Clone)]
+pub struct JsonRpcLibraInterface {
+    client: JsonRpcClient,
+}
+
+#[allow(dead_code)]
+impl JsonRpcLibraInterface {
+    pub fn new(client: JsonRpcClient) -> Self {
+        Self { client }
+    }
+}
+
+impl LibraInterface for JsonRpcLibraInterface {
+    fn libra_timestamp(&self) -> Result<u64, Error> {
+        let account = account_config::association_address();
+        let libra_timestamp_resource = self
+            .retrieve_account_state(account)?
+            .get_libra_timestamp_resource();
+
+        match libra_timestamp_resource {
+            Ok(timestamp_resource) => timestamp_resource
+                .map(|timestamp_resource| timestamp_resource.libra_timestamp.microseconds)
+                .ok_or_else(|| {
+                    Error::DataDoesNotExist(format!(
+                        "LibraTimestampResource not found for account: {:?}",
+                        account
+                    ))
+                }),
+            e => Err(Error::UnknownError(format!("{:?}", e))),
+        }
+    }
+
+    fn last_reconfiguration(&self) -> Result<u64, Error> {
+        let account = account_config::association_address();
+        let configuration_resource = self
+            .retrieve_account_state(account)?
+            .get_configuration_resource();
+
+        match configuration_resource {
+            Ok(config_resource) => config_resource
+                .map(|config_resource| config_resource.last_reconfiguration_time())
+                .ok_or_else(|| {
+                    Error::DataDoesNotExist(format!(
+                        "ConfigurationResource not found for account: {:?}",
+                        account
+                    ))
+                }),
+            e => Err(Error::UnknownError(format!("{:?}", e))),
+        }
+    }
+
+    fn retrieve_sequence_number(&self, account: AccountAddress) -> Result<u64, Error> {
+        let account_resource = self.retrieve_account_state(account)?.get_account_resource();
+
+        match account_resource {
+            Ok(account_resource) => account_resource
+                .map(|account_resource| account_resource.sequence_number())
+                .ok_or_else(|| {
+                    Error::DataDoesNotExist(format!(
+                        "AccountResource not found for account: {:?}",
+                        account
+                    ))
+                }),
+            e => Err(Error::UnknownError(format!("{:?}", e))),
+        }
+    }
+
+    fn submit_transaction(&self, transaction: Transaction) -> Result<(), Error> {
+        if let Transaction::UserTransaction(signed_txn) = transaction {
+            self.client
+                .submit_signed_transaction(signed_txn)
+                .map_err(|e| {
+                    Error::UnknownError(format!(
+                        "Failed to submit signed transaction. Error: {:?}",
+                        e,
+                    ))
+                })
+        } else {
+            Err(Error::UnknownError(format!(
+                "Unable to submit a transaction type that is not a SignedTransaction: {:?}",
+                transaction
+            )))
+        }
+    }
+
+    fn retrieve_validator_config(&self, account: AccountAddress) -> Result<ValidatorConfig, Error> {
+        let validator_config_resource = self
+            .retrieve_account_state(account)?
+            .get_validator_config_resource();
+
+        match validator_config_resource {
+            Ok(config_resource) => config_resource
+                .map(|config_resource| config_resource.validator_config)
+                .ok_or_else(|| {
+                    Error::DataDoesNotExist(format!(
+                        "ValidatorConfigResource not found for account: {:?}",
+                        account
+                    ))
+                }),
+            e => Err(Error::UnknownError(format!("{:?}", e))),
+        }
+    }
+
+    fn retrieve_validator_info(&self, account: AccountAddress) -> Result<ValidatorInfo, Error> {
+        let validator_set_account = account_config::validator_set_address();
+        let validator_set = self
+            .retrieve_account_state(validator_set_account)?
+            .get_validator_set();
+
+        match validator_set {
+            Ok(validator_set) => match validator_set {
+                Some(validator_set) => validator_set
+                    .payload()
+                    .iter()
+                    .find(|validator_info| validator_info.account_address() == &account)
+                    .cloned()
+                    .ok_or(Error::ValidatorInfoNotFound(account)),
+                None => Err(Error::DataDoesNotExist(format!(
+                    "ValidatorSet not found for account: {:?}",
+                    account
+                ))),
+            },
+            Err(e) => Err(Error::UnknownError(format!("{:?}", e))),
+        }
+    }
+
+    fn retrieve_account_state(&self, account: AccountAddress) -> Result<AccountState, Error> {
+        self.client.get_account_state(account, None).map_err(|e| {
+            Error::UnknownError(format!(
+                "Failed to get AccountState for account: {:?}. Error: {:?}",
+                account, e
+            ))
+        })
+    }
+}

--- a/secure/key-manager/src/tests.rs
+++ b/secure/key-manager/src/tests.rs
@@ -1,10 +1,13 @@
 // Copyright (c) The Libra Core Contributors
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::{Action, Error, KeyManager, LibraInterface};
+use crate::{libra_interface::JsonRpcLibraInterface, Action, Error, KeyManager, LibraInterface};
+use anyhow::Result;
 use executor::{db_bootstrapper, BlockExecutor, Executor};
-use libra_config::{config::NodeConfig, utils::get_genesis_txn};
+use futures::{channel::mpsc::channel, StreamExt};
+use libra_config::{config::NodeConfig, utils, utils::get_genesis_txn};
 use libra_crypto::{ed25519::Ed25519PrivateKey, HashValue, PrivateKey, Uniform};
+use libra_secure_json_rpc::JsonRpcClient;
 use libra_secure_storage::{InMemoryStorageInternal, KVStorage, Policy, Value};
 use libra_secure_time::{MockTimeService, TimeService};
 use libra_types::{
@@ -15,6 +18,7 @@ use libra_types::{
     block_metadata::{BlockMetadata, LibraBlockResource},
     discovery_set::DiscoverySet,
     ledger_info::{LedgerInfo, LedgerInfoWithSignatures},
+    mempool_status::{MempoolStatus, MempoolStatusCode},
     on_chain_config::{ConfigurationResource, ValidatorSet},
     transaction::Transaction,
     validator_config::ValidatorConfig,
@@ -25,75 +29,40 @@ use libradb::LibraDB;
 use rand::{rngs::StdRng, SeedableRng};
 use std::{cell::RefCell, collections::BTreeMap, convert::TryFrom, sync::Arc, time::Duration};
 use storage_interface::{DbReader, DbReaderWriter};
+use tokio::runtime::Runtime;
+use vm_validator::{
+    mocks::mock_vm_validator::MockVMValidator, vm_validator::TransactionValidation,
+};
 
-struct Node {
+struct Node<T: LibraInterface> {
     account: AccountAddress,
     executor: Executor<LibraVM>,
-    libra: TestLibraInterface,
-    key_manager:
-        KeyManager<TestLibraInterface, InMemoryStorageInternal<MockTimeService>, MockTimeService>,
+    libra: LibraInterfaceTestHarness<T>,
+    key_manager: KeyManager<
+        LibraInterfaceTestHarness<T>,
+        InMemoryStorageInternal<MockTimeService>,
+        MockTimeService,
+    >,
     time: MockTimeService,
 }
 
-fn setup_secure_storage(
-    config: &NodeConfig,
-    time: MockTimeService,
-) -> InMemoryStorageInternal<MockTimeService> {
-    let mut sec_storage = InMemoryStorageInternal::new_with_time_service(time);
-    let test_config = config.clone().test.unwrap();
-
-    let mut a_keypair = test_config.account_keypair.unwrap();
-    let a_prikey = Value::Ed25519PrivateKey(a_keypair.take_private().unwrap());
-
-    sec_storage
-        .create(crate::ACCOUNT_KEY, a_prikey, &Policy::public())
-        .unwrap();
-
-    let mut c_keypair = test_config.consensus_keypair.unwrap();
-    let c_prikey = c_keypair.take_private().unwrap();
-    let c_prikey0 = Value::Ed25519PrivateKey(c_prikey.clone());
-    let c_prikey1 = Value::Ed25519PrivateKey(c_prikey);
-
-    sec_storage
-        .create(crate::CONSENSUS_KEY, c_prikey0, &Policy::public())
-        .unwrap();
-    // Ugly hack but we need this until we support retrieving a policy from within storage and that
-    // currently is not easy, since we would need to convert from Vault -> Libra policy.
-    sec_storage
-        .create(
-            &format!("{}_previous", crate::CONSENSUS_KEY),
-            c_prikey1,
-            &Policy::public(),
-        )
-        .unwrap();
-    sec_storage
-}
-
-impl Node {
-    fn setup(config: &NodeConfig) -> Self {
-        let (storage, db_rw) = DbReaderWriter::wrap(LibraDB::new(&config.storage.dir()));
-        db_bootstrapper::bootstrap_db_if_empty::<LibraVM>(&db_rw, get_genesis_txn(config).unwrap())
-            .expect("Failed to execute genesis");
-        let executor = Executor::new(db_rw);
-        let libra = TestLibraInterface {
-            queued_transactions: Arc::new(RefCell::new(Vec::new())),
-            storage,
-        };
-        let time = MockTimeService::new();
-        let account = config.validator_network.as_ref().unwrap().peer_id;
-        let key_manager = KeyManager::new(
-            account,
-            "consensus_key".to_owned(),
-            libra.clone(),
-            setup_secure_storage(&config, time.clone()),
-            time.clone(),
-        );
-
+impl<T: LibraInterface> Node<T> {
+    pub fn new(
+        account: AccountAddress,
+        executor: Executor<LibraVM>,
+        libra: LibraInterfaceTestHarness<T>,
+        key_manager: KeyManager<
+            LibraInterfaceTestHarness<T>,
+            InMemoryStorageInternal<MockTimeService>,
+            MockTimeService,
+        >,
+        time: MockTimeService,
+    ) -> Self {
         Self {
             account,
             executor,
-            key_manager,
             libra,
+            key_manager,
             time,
         }
     }
@@ -135,45 +104,97 @@ impl Node {
     }
 }
 
+/// The struct below is a LibraInterface wrapper that exposes several additional methods to better
+/// test the internal state of a LibraInterface implementation (e.g., during end-to-end and
+/// integration tests).
 #[derive(Clone)]
-struct TestLibraInterface {
-    queued_transactions: Arc<RefCell<Vec<Transaction>>>,
-    storage: Arc<LibraDB>,
+struct LibraInterfaceTestHarness<T: LibraInterface> {
+    libra: T,
+    submitted_transactions: Arc<RefCell<Vec<Transaction>>>,
 }
 
-impl TestLibraInterface {
-    fn retrieve_account_state(&self, account: AccountAddress) -> Result<AccountState, Error> {
-        let blob = self
-            .storage
-            .get_latest_account_state(account)?
-            .ok_or(Error::DataDoesNotExist("AccountState"))?;
-        Ok(AccountState::try_from(&blob)?)
+impl<T: LibraInterface> LibraInterfaceTestHarness<T> {
+    fn new(libra: T) -> Self {
+        Self {
+            libra,
+            submitted_transactions: Arc::new(RefCell::new(Vec::new())),
+        }
     }
 
+    /// Returns the discover set associated with the discovery set address.
     fn retrieve_discovery_set(&self) -> Result<DiscoverySet, Error> {
         let account = account_config::discovery_set_address();
-        let account_state = self.retrieve_account_state(account)?;
+        let account_state = self.libra.retrieve_account_state(account)?;
         Ok(account_state
             .get_discovery_set_resource()?
-            .ok_or(Error::DataDoesNotExist("DiscoverySetResource"))?
+            .ok_or_else(|| Error::DataDoesNotExist("DiscoverySetResource".into()))?
             .discovery_set()
             .clone())
     }
 
+    /// Returns the libra block resource associated with the association address.
+    fn retrieve_libra_block_resource(&self) -> Result<LibraBlockResource, Error> {
+        let account = account_config::association_address();
+        let account_state = self.libra.retrieve_account_state(account)?;
+        account_state
+            .get_libra_block_resource()?
+            .ok_or_else(|| Error::DataDoesNotExist("BlockMetadata".into()))
+    }
+
+    /// Return (and clear) all transactions that have been submitted to this interface since the
+    /// last time this method was called.
+    fn take_all_transactions(&self) -> Vec<Transaction> {
+        self.submitted_transactions.borrow_mut().drain(..).collect()
+    }
+}
+
+impl<T: LibraInterface> LibraInterface for LibraInterfaceTestHarness<T> {
+    fn libra_timestamp(&self) -> Result<u64, Error> {
+        self.libra.libra_timestamp()
+    }
+
+    fn last_reconfiguration(&self) -> Result<u64, Error> {
+        self.libra.last_reconfiguration()
+    }
+
+    fn retrieve_sequence_number(&self, account: AccountAddress) -> Result<u64, Error> {
+        self.libra.retrieve_sequence_number(account)
+    }
+
+    fn submit_transaction(&self, transaction: Transaction) -> Result<(), Error> {
+        self.submitted_transactions
+            .borrow_mut()
+            .push(transaction.clone());
+        self.libra.submit_transaction(transaction)
+    }
+
+    fn retrieve_validator_config(&self, account: AccountAddress) -> Result<ValidatorConfig, Error> {
+        self.libra.retrieve_validator_config(account)
+    }
+
+    fn retrieve_validator_info(&self, account: AccountAddress) -> Result<ValidatorInfo, Error> {
+        self.libra.retrieve_validator_info(account)
+    }
+
+    fn retrieve_account_state(&self, account: AccountAddress) -> Result<AccountState, Error> {
+        self.libra.retrieve_account_state(account)
+    }
+}
+
+/// A mock libra interface implementation that stores a pointer to the LibraDB from which to
+/// process API requests.
+#[derive(Clone)]
+struct MockLibraInterface {
+    storage: Arc<LibraDB>,
+}
+
+impl MockLibraInterface {
     fn retrieve_validator_set_resource(&self) -> Result<ValidatorSet, Error> {
         let account = account_config::validator_set_address();
         let account_state = self.retrieve_account_state(account)?;
         account_state
             .get_validator_set()?
-            .ok_or(Error::DataDoesNotExist("ValidatorSet"))
-    }
-
-    fn retrieve_libra_block_resource(&self) -> Result<LibraBlockResource, Error> {
-        let account = account_config::association_address();
-        let account_state = self.retrieve_account_state(account)?;
-        account_state
-            .get_libra_block_resource()?
-            .ok_or(Error::DataDoesNotExist("BlockMetadata"))
+            .ok_or_else(|| Error::DataDoesNotExist("ValidatorSet".into()))
     }
 
     pub fn retrieve_configuration_resource(&self) -> Result<ConfigurationResource, Error> {
@@ -181,25 +202,21 @@ impl TestLibraInterface {
         let account_state = self.retrieve_account_state(account)?;
         account_state
             .get_configuration_resource()?
-            .ok_or(Error::DataDoesNotExist("Configuration"))
-    }
-
-    fn take_all_transactions(&self) -> Vec<Transaction> {
-        self.queued_transactions.borrow_mut().drain(0..).collect()
+            .ok_or_else(|| Error::DataDoesNotExist("Configuration".into()))
     }
 }
 
-impl LibraInterface for TestLibraInterface {
+impl LibraInterface for MockLibraInterface {
     fn libra_timestamp(&self) -> Result<u64, Error> {
         let account = account_config::association_address();
         let blob = self
             .storage
             .get_latest_account_state(account)?
-            .ok_or(Error::DataDoesNotExist("AccountState"))?;
+            .ok_or_else(|| Error::DataDoesNotExist("AccountState".into()))?;
         let account_state = AccountState::try_from(&blob).unwrap();
         Ok(account_state
             .get_libra_timestamp_resource()?
-            .ok_or(Error::DataDoesNotExist("LibraTimestampResource"))?
+            .ok_or_else(|| Error::DataDoesNotExist("LibraTimestampResource".into()))?
             .libra_timestamp
             .microseconds)
     }
@@ -213,16 +230,15 @@ impl LibraInterface for TestLibraInterface {
         let blob = self
             .storage
             .get_latest_account_state(account)?
-            .ok_or(Error::DataDoesNotExist("AccountState"))?;
+            .ok_or_else(|| Error::DataDoesNotExist("AccountState".into()))?;
         let account_state = AccountState::try_from(&blob).unwrap();
         Ok(account_state
             .get_account_resource()?
-            .ok_or(Error::DataDoesNotExist("AccountResource"))?
+            .ok_or_else(|| Error::DataDoesNotExist("AccountResource".into()))?
             .sequence_number())
     }
 
-    fn submit_transaction(&self, transaction: Transaction) -> Result<(), Error> {
-        self.queued_transactions.borrow_mut().push(transaction);
+    fn submit_transaction(&self, _transaction: Transaction) -> Result<(), Error> {
         Ok(())
     }
 
@@ -230,11 +246,11 @@ impl LibraInterface for TestLibraInterface {
         let blob = self
             .storage
             .get_latest_account_state(account)?
-            .ok_or(Error::DataDoesNotExist("AccountState"))?;
+            .ok_or_else(|| Error::DataDoesNotExist("AccountState".into()))?;
         let account_state = AccountState::try_from(&blob).unwrap();
         Ok(account_state
             .get_validator_config_resource()?
-            .ok_or(Error::DataDoesNotExist("ValidatorConfigResource"))?
+            .ok_or_else(|| Error::DataDoesNotExist("ValidatorConfigResource".into()))?
             .validator_config)
     }
 
@@ -249,19 +265,157 @@ impl LibraInterface for TestLibraInterface {
             .cloned()
             .ok_or(Error::ValidatorInfoNotFound(validator_account))
     }
+
+    fn retrieve_account_state(&self, account: AccountAddress) -> Result<AccountState, Error> {
+        let blob = self
+            .storage
+            .get_latest_account_state(account)?
+            .ok_or_else(|| Error::DataDoesNotExist("AccountState".into()))?;
+        Ok(AccountState::try_from(&blob)?)
+    }
+}
+
+// Creates and returns a test node that uses the JsonRpcLibraInterface.
+// This setup is useful for testing nodes as they operate in a production environment.
+fn setup_node_using_json_rpc(config: &NodeConfig) -> (Node<JsonRpcLibraInterface>, Runtime) {
+    let (_storage, db_rw) = setup_libra_db(config);
+    let (client, server) = setup_json_client_and_server(db_rw.clone());
+    let libra = JsonRpcLibraInterface::new(client);
+    let executor = Executor::new(db_rw);
+
+    (setup_node(config, executor, libra), server)
+}
+
+// Creates and returns a Node using the MockLibraInterface implementation.
+// This setup is useful for testing and verifying new development features quickly.
+fn setup_node_using_test_mocks(config: &NodeConfig) -> Node<MockLibraInterface> {
+    let (storage, db_rw) = setup_libra_db(config);
+    let libra = MockLibraInterface { storage };
+    let executor = Executor::new(db_rw);
+
+    setup_node(config, executor, libra)
+}
+
+// Creates and returns a libra database and database reader/writer pair bootstrapped with genesis.
+fn setup_libra_db(config: &NodeConfig) -> (Arc<LibraDB>, DbReaderWriter) {
+    let (storage, db_rw) = DbReaderWriter::wrap(LibraDB::new(&config.storage.dir()));
+    db_bootstrapper::bootstrap_db_if_empty::<LibraVM>(&db_rw, get_genesis_txn(config).unwrap())
+        .expect("Failed to execute genesis");
+
+    (storage, db_rw)
+}
+
+// Creates and returns a node for testing using the given config, executor and libra interface
+// wrapper implementation.
+fn setup_node<T: LibraInterface + Clone>(
+    config: &NodeConfig,
+    executor: Executor<LibraVM>,
+    libra: T,
+) -> Node<T> {
+    let account = config.validator_network.as_ref().unwrap().peer_id;
+    let time = MockTimeService::new();
+    let libra_test_harness = LibraInterfaceTestHarness::new(libra);
+    let key_manager = KeyManager::new(
+        account,
+        crate::CONSENSUS_KEY.into(),
+        libra_test_harness.clone(),
+        setup_secure_storage(&config, time.clone()),
+        time.clone(),
+    );
+
+    Node::new(account, executor, libra_test_harness, key_manager, time)
+}
+
+// Creates and returns a secure storage implementation (based on an in memory storage engine) for
+// testing. As part of the initialization, the consensus key is created.
+fn setup_secure_storage(
+    config: &NodeConfig,
+    time: MockTimeService,
+) -> InMemoryStorageInternal<MockTimeService> {
+    let mut sec_storage = InMemoryStorageInternal::new_with_time_service(time);
+    let test_config = config.clone().test.unwrap();
+
+    let mut a_keypair = test_config.account_keypair.unwrap();
+    let a_prikey = Value::Ed25519PrivateKey(a_keypair.take_private().unwrap());
+
+    sec_storage
+        .create(crate::ACCOUNT_KEY, a_prikey, &Policy::public())
+        .unwrap();
+
+    let mut c_keypair = test_config.consensus_keypair.unwrap();
+    let c_prikey = c_keypair.take_private().unwrap();
+    let c_prikey0 = Value::Ed25519PrivateKey(c_prikey.clone());
+    let c_prikey1 = Value::Ed25519PrivateKey(c_prikey);
+
+    sec_storage
+        .create(crate::CONSENSUS_KEY, c_prikey0, &Policy::public())
+        .unwrap();
+    // Ugly hack but we need this until we support retrieving a policy from within storage and that
+    // currently is not easy, since we would need to convert from Vault -> Libra policy.
+    sec_storage
+        .create(
+            &format!("{}_previous", crate::CONSENSUS_KEY),
+            c_prikey1,
+            &Policy::public(),
+        )
+        .unwrap();
+    sec_storage
+}
+
+// Generates and returns a (client, server) pair, where the client is a lightweight JSON client
+// and the server is a JSON server that serves the JSON RPC requests. The server communicates
+// with the given database reader/writer to handle each JSON RPC request.
+fn setup_json_client_and_server(db_rw: DbReaderWriter) -> (JsonRpcClient, Runtime) {
+    let address = "0.0.0.0";
+    let port = utils::get_available_port();
+    let host = format!("{}:{}", address, port);
+
+    let (mp_sender, mut mp_events) = channel(1024);
+    let server = libra_json_rpc::bootstrap(host.parse().unwrap(), db_rw.reader, mp_sender);
+
+    // Provide a VMValidator to the runtime.
+    server.spawn(async move {
+        while let Some((txn, cb)) = mp_events.next().await {
+            let vm_status = MockVMValidator
+                .validate_transaction(txn)
+                .await
+                .unwrap()
+                .status();
+            let result = if vm_status.is_some() {
+                (MempoolStatus::new(MempoolStatusCode::VmError), vm_status)
+            } else {
+                (MempoolStatus::new(MempoolStatusCode::Accepted), None)
+            };
+            cb.send(Ok(result)).unwrap();
+        }
+    });
+
+    let url = format!("http://{}", host);
+    let client = JsonRpcClient::new(url);
+
+    (client, server)
 }
 
 #[test]
 // This simple test just proves that genesis took effect and the values are in storage
 fn test_ability_to_read_move_data() {
+    // Test the mock libra interface implementation
     let (config, _genesis_key) = config_builder::test_config();
-    let node = Node::setup(&config);
+    let node = setup_node_using_test_mocks(&config);
+    verify_ability_to_read_move_data(node);
 
-    node.libra.last_reconfiguration().unwrap();
-    node.libra.retrieve_discovery_set().unwrap();
-    node.libra.retrieve_validator_config(node.account).unwrap();
-    node.libra.retrieve_discovery_set().unwrap();
-    node.libra.retrieve_validator_info(node.account).unwrap();
+    // Test the json libra interface implementation
+    let (config, _genesis_key) = config_builder::test_config();
+    let (node, _runtime) = setup_node_using_json_rpc(&config);
+    verify_ability_to_read_move_data(node);
+}
+
+fn verify_ability_to_read_move_data<T: LibraInterface>(node: Node<T>) {
+    assert!(node.libra.last_reconfiguration().is_ok());
+    assert!(node.libra.retrieve_discovery_set().is_ok());
+    assert!(node.libra.retrieve_validator_config(node.account).is_ok());
+    assert!(node.libra.retrieve_discovery_set().is_ok());
+    assert!(node.libra.retrieve_validator_info(node.account).is_ok());
     assert!(node.libra.retrieve_libra_block_resource().is_ok());
 }
 
@@ -269,27 +423,38 @@ fn test_ability_to_read_move_data() {
 // This tests that a manual consensus key rotation can be performed by generating a new keypair,
 // creating a new rotation transaction, and executing the transaction locally.
 fn test_manual_consensus_rotation() {
+    // Test the mock libra interface implementation
     let (config, _genesis_key) = config_builder::test_config();
-    let mut node = Node::setup(&config);
+    let node = setup_node_using_test_mocks(&config);
+    verify_manual_consensus_rotation(config, node);
 
+    // Test the json libra interface implementation
+    let (config, _genesis_key) = config_builder::test_config();
+    let (node, _runtime) = setup_node_using_json_rpc(&config);
+    verify_manual_consensus_rotation(config, node);
+}
+
+fn verify_manual_consensus_rotation<T: LibraInterface>(config: NodeConfig, mut node: Node<T>) {
     let test_config = config.test.unwrap();
-    let mut keypair = test_config.consensus_keypair.unwrap();
-
-    let genesis_prikey = keypair.take_private().unwrap();
-    let genesis_pubkey = genesis_prikey.public_key();
     let account_prikey = test_config.account_keypair.unwrap().take_private().unwrap();
+    let genesis_pubkey = test_config
+        .consensus_keypair
+        .unwrap()
+        .take_private()
+        .unwrap()
+        .public_key();
 
     let genesis_config = node.libra.retrieve_validator_config(node.account).unwrap();
     let genesis_info = node.libra.retrieve_validator_info(node.account).unwrap();
 
+    // Check on-chain consensus state matches the genesis state
     assert_eq!(genesis_pubkey, genesis_config.consensus_pubkey);
     assert_eq!(&genesis_pubkey, genesis_info.consensus_public_key());
     assert_eq!(&node.account, genesis_info.account_address());
 
+    // Perform rotation
     let mut rng = StdRng::from_seed([44u8; 32]);
-    let new_prikey = Ed25519PrivateKey::generate(&mut rng);
-    let new_pubkey = new_prikey.public_key();
-
+    let new_pubkey = Ed25519PrivateKey::generate(&mut rng).public_key();
     let txn = crate::build_rotation_transaction(
         node.account,
         0,
@@ -297,12 +462,12 @@ fn test_manual_consensus_rotation() {
         &new_pubkey,
         Duration::from_secs(node.time.now() + 100),
     );
-
     node.execute_and_commit(vec![txn]);
 
     let new_config = node.libra.retrieve_validator_config(node.account).unwrap();
     let new_info = node.libra.retrieve_validator_info(node.account).unwrap();
 
+    // Check on-chain consensus state has been rotated
     assert_ne!(new_pubkey, genesis_pubkey);
     assert_eq!(new_pubkey, new_config.consensus_pubkey);
     assert_eq!(&new_pubkey, new_info.consensus_public_key());
@@ -311,16 +476,27 @@ fn test_manual_consensus_rotation() {
 #[test]
 // This verifies the key manager is properly setup and that a basic rotation can occur
 fn test_key_manager_init_and_basic_rotation() {
+    // Test the mock libra interface implementation
     let (config, _genesis_key) = config_builder::test_config();
-    let mut node = Node::setup(&config);
-    node.key_manager.compare_storage_to_config().unwrap();
-    node.key_manager.compare_info_to_config().unwrap();
+    let node = setup_node_using_test_mocks(&config);
+    verify_init_and_basic_rotation(node);
+
+    // Test the json libra interface implementation
+    let (config, _genesis_key) = config_builder::test_config();
+    let (node, _runtime) = setup_node_using_json_rpc(&config);
+    verify_init_and_basic_rotation(node);
+}
+
+fn verify_init_and_basic_rotation<T: LibraInterface>(mut node: Node<T>) {
+    // Verify correct initialization (on-chain and in storage)
+    assert!(node.key_manager.compare_storage_to_config().is_ok());
+    assert!(node.key_manager.compare_info_to_config().is_ok());
     assert_eq!(node.time.now(), node.key_manager.last_rotation().unwrap());
-    // No reconfiguration yet
-    assert_eq!(0, node.key_manager.last_reconfiguration().unwrap());
     // No executions yet
+    assert_eq!(0, node.key_manager.last_reconfiguration().unwrap());
     assert_eq!(0, node.key_manager.libra_timestamp().unwrap());
 
+    // Perform key rotation locally
     let genesis_info = node.libra.retrieve_validator_info(node.account).unwrap();
     let new_key = node.key_manager.rotate_consensus_key().unwrap();
     let pre_exe_rotated_info = node.libra.retrieve_validator_info(node.account).unwrap();
@@ -330,6 +506,7 @@ fn test_key_manager_init_and_basic_rotation() {
     );
     assert_ne!(pre_exe_rotated_info.consensus_public_key(), &new_key);
 
+    // Execute key rotation on-chain
     node.execute_and_commit(node.libra.take_all_transactions());
     let rotated_info = node.libra.retrieve_validator_info(node.account).unwrap();
     assert_ne!(
@@ -355,22 +532,35 @@ fn test_key_manager_init_and_basic_rotation() {
 
 #[test]
 // This tests the application's main loop to ensure it handles basic operations and reliabilities
-fn test_loop() {
+fn test_main_loop() {
+    // Test the mock libra interface implementation
     let (config, _genesis_key) = config_builder::test_config();
-    let mut node = Node::setup(&config);
+    let node = setup_node_using_test_mocks(&config);
+    verify_main_loop(node);
 
+    // Test the json libra interface implementation
+    let (config, _genesis_key) = config_builder::test_config();
+    let (node, _runtime) = setup_node_using_json_rpc(&config);
+    verify_main_loop(node);
+}
+
+fn verify_main_loop<T: LibraInterface>(mut node: Node<T>) {
+    // Verify nothing to be done initially
     let mut action = node.key_manager.evaluate_status().unwrap();
     assert_eq!(action, Action::NoAction);
     node.key_manager.perform_action(action).unwrap();
 
+    // Verify rotation required after enough time elapsed
     node.time.increment_by(crate::ROTATION_PERIOD_SECS);
     action = node.key_manager.evaluate_status().unwrap();
     assert_eq!(action, Action::FullKeyRotation);
     node.key_manager.perform_action(action).unwrap();
 
+    // Verify rotation was performed, nothing to be done
     action = node.key_manager.evaluate_status().unwrap();
     assert_eq!(action, Action::NoAction);
 
+    // Verify transaction not executed, now expired
     node.time.increment_by(crate::TXN_RETRY_SECS);
     action = node.key_manager.evaluate_status().unwrap();
     assert_eq!(action, Action::SubmitKeyRotationTransaction);

--- a/types/src/on_chain_config/mod.rs
+++ b/types/src/on_chain_config/mod.rs
@@ -142,7 +142,7 @@ pub fn access_path_for_config(address: AccountAddress, config_name: Identifier) 
     )
 }
 
-#[derive(Deserialize, Serialize)]
+#[derive(Debug, Deserialize, Serialize)]
 pub struct ConfigurationResource {
     epoch: u64,
     last_reconfiguration_time: u64,


### PR DESCRIPTION
## Motivation

In order for the key manager to rotate security-sensitive keys (e.g., the consensus key on each validator), it must be able to read and write to the blockchain (e.g., query and update on-chain validator state). To achieve this goal, this PR offers a 'LibraInterface' implementation that uses the secure JSON RPC client to communicate with the blockchain. As a result, the key manager can now interact with on-chain state by performing JSON RPC related calls. 

This PR provides a single commit that:

1) Defines the JsonRpcLibraInterface, which implements the LibraInterface using a JsonRpcClient internally.
2) Refactors the existing key manager tests to support both the existing MockLibraInterface, and the new JsonRpcLibraInterface for the integration tests. To achieve this without excessive duplication, we define a LibraInterfaceWrapper trait which exposes additional methods to allow each test to verify the correct internal state of each LibraInterface implementation.
3) Add a security disclaimer to the JsonRpcLibraInterface stating that in order for the key manager to operate securely, the JsonRpcService used by the key manager must be trusted (e.g., authenticated and integrity protected).

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?

Yes.

## Test Plan

All local tests pass (including those that were newly refactored).

## Related PRs

None.
