### PR TITLE
TrustedState able to verify_and_ratchet at waypoint legder info itself.

### DIFF
--- a/execution/executor/tests/storage_integration_test.rs
+++ b/execution/executor/tests/storage_integration_test.rs
@@ -48,7 +48,7 @@ fn test_genesis() {
     let (li, validator_change_proof, _accumulator_consistency_proof) =
         db.reader.get_state_proof(0).unwrap();
 
-    let trusted_state = TrustedState::new_trust_any_genesis_WARNING_UNSAFE();
+    let trusted_state = TrustedState::from_waypoint(config.base.waypoint.unwrap());
     trusted_state
         .verify_and_ratchet(&li, &validator_change_proof)
         .unwrap();

--- a/types/src/trusted_state.rs
+++ b/types/src/trusted_state.rs
@@ -142,7 +142,7 @@ impl TrustedState {
 
         if self
             .verifier
-            .epoch_change_verification_required(latest_li.ledger_info().epoch())
+            .epoch_change_verification_required(latest_li.ledger_info())
         {
             // Verify the ValidatorChangeProof to move us into the latest epoch.
             let epoch_change_li = validator_change_proof.verify(&self.verifier)?;

--- a/types/src/unit_tests/trusted_state_test.rs
+++ b/types/src/unit_tests/trusted_state_test.rs
@@ -276,10 +276,11 @@ proptest! {
             1..5, /* validators per epoch */
         )
     ) {
-        let first_epoch_change_li = lis_with_sigs.first().map(|l| l.ledger_info()).unwrap();
-        let waypoint = Waypoint::new(first_epoch_change_li)
+        let first_epoch_change_li = lis_with_sigs.first().unwrap();
+        let waypoint = Waypoint::new(first_epoch_change_li.ledger_info())
             .expect("Generating waypoint failed even though we passed an epoch change ledger info");
         let trusted_state = TrustedState::from_waypoint(waypoint);
+        trusted_state.verify_and_ratchet(first_epoch_change_li, &ValidatorChangeProof::new(vec![], false /* more */)).expect("Should not error when verifying waypoint LedgerInfo itself.");
 
         let expected_latest_version = latest_li.ledger_info().version();
         let expected_latest_li = latest_li.clone();

--- a/types/src/validator_change.rs
+++ b/types/src/validator_change.rs
@@ -50,10 +50,10 @@ impl VerifierType {
 
     /// Returns true in case the given epoch is larger than the existing verifier can support.
     /// In this case the ValidatorChangeProof should be verified and the verifier updated.
-    pub fn epoch_change_verification_required(&self, epoch: u64) -> bool {
+    pub fn epoch_change_verification_required(&self, latest_li: &LedgerInfo) -> bool {
         match self {
-            VerifierType::Waypoint(_) => true,
-            VerifierType::TrustedVerifier(epoch_info) => epoch_info.epoch < epoch,
+            VerifierType::Waypoint(waypoint) => latest_li.version() != waypoint.version(),
+            VerifierType::TrustedVerifier(epoch_info) => epoch_info.epoch < latest_li.epoch(),
         }
     }
 


### PR DESCRIPTION


## Motivation

It makes more sense this way (used to complain about proof being empty.)

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?

yes

## Test Plan

updated tests.

## Related PRs

(If this PR adds or changes functionality, please take some time to update the docs at https://github.com/libra/website, and link to your PR here.)
