### PR TITLE
[executor] split executor to use ChunkExecutor and BlockExecutor

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4792,6 +4792,7 @@ dependencies = [
  "rand 0.7.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.106 (registry+https://github.com/rust-lang/crates.io-index)",
  "stdlib 0.1.0",
+ "storage-client 0.1.0",
  "storage-interface 0.1.0",
  "storage-service 0.1.0",
  "subscription-service 0.1.0",

--- a/consensus/src/block_storage/block_store.rs
+++ b/consensus/src/block_storage/block_store.rs
@@ -137,9 +137,7 @@ impl<T: Payload> BlockStore<T> {
             assert!(!block.is_genesis_block());
             let output = state_computer
                 .compute(&block, block.parent_id())
-                .unwrap_or_else(|_| {
-                    panic!("fail to compute state result for block {}", block.id())
-                });
+                .unwrap_or_else(|e| panic!("Execute block {} emits error: {}", block.id(), e));
             // if this block is certified, ensure we agree with the certified state.
             if let Some(qc) = quorum_certs.get(&block.id()) {
                 assert_eq!(

--- a/consensus/src/consensus_provider.rs
+++ b/consensus/src/consensus_provider.rs
@@ -12,15 +12,14 @@ use crate::{
     util::time_service::ClockTimeService,
 };
 use channel::libra_channel;
-use executor::Executor;
+use executor::BlockExecutor;
 use futures::channel::mpsc;
 use libra_config::config::NodeConfig;
 use libra_logger::prelude::*;
 use libra_mempool::ConsensusRequest;
 use libra_types::{on_chain_config::OnChainConfigPayload, transaction::SignedTransaction};
-use libra_vm::LibraVM;
 use state_synchronizer::StateSyncClient;
-use std::sync::{Arc, Mutex};
+use std::{boxed::Box, sync::Arc};
 use storage_interface::DbReader;
 use tokio::runtime::{self, Runtime};
 
@@ -29,7 +28,7 @@ pub fn start_consensus(
     node_config: &mut NodeConfig,
     network_sender: ConsensusNetworkSender<Vec<SignedTransaction>>,
     network_events: ConsensusNetworkEvents<Vec<SignedTransaction>>,
-    executor: Arc<Mutex<Executor<LibraVM>>>,
+    executor: Box<dyn BlockExecutor>,
     state_sync_client: Arc<StateSyncClient>,
     consensus_to_mempool_sender: mpsc::Sender<ConsensusRequest>,
     libra_db: Arc<dyn DbReader>,

--- a/consensus/src/test_utils/mock_state_computer.rs
+++ b/consensus/src/test_utils/mock_state_computer.rs
@@ -43,6 +43,7 @@ impl MockStateComputer {
 #[async_trait::async_trait]
 impl StateComputer for MockStateComputer {
     type Payload = Vec<usize>;
+
     fn compute(
         &self,
         block: &Block<Self::Payload>,
@@ -122,6 +123,7 @@ pub struct EmptyStateComputer;
 #[async_trait::async_trait]
 impl StateComputer for EmptyStateComputer {
     type Payload = TestPayload;
+
     fn compute(
         &self,
         _block: &Block<Self::Payload>,

--- a/language/libra-vm/src/lib.rs
+++ b/language/libra-vm/src/lib.rs
@@ -135,7 +135,7 @@ pub trait VMValidator {
 }
 
 /// This trait describes the VM's execution interface.
-pub trait VMExecutor {
+pub trait VMExecutor: Send {
     // NOTE: At the moment there are no persistent caches that live past the end of a block (that's
     // why execute_block doesn't take &self.)
     // There are some cache invalidation issues around transactions publishing code that need to be

--- a/state-synchronizer/Cargo.toml
+++ b/state-synchronizer/Cargo.toml
@@ -45,6 +45,7 @@ transaction-builder = { path = "../language/transaction-builder", version = "0.1
 channel = { path = "../common/channel", version = "0.1.0" }
 executor-utils = { path = "../execution/executor-utils", version = "0.1.0" }
 stdlib = { path = "../language/stdlib", version = "0.1.0" }
+storage-client = { path = "../storage/storage-client", version = "0.1.0" }
 storage-service = { path = "../storage/storage-service", version = "0.1.0" }
 
 [features]

--- a/state-synchronizer/src/synchronizer.rs
+++ b/state-synchronizer/src/synchronizer.rs
@@ -7,7 +7,7 @@ use crate::{
     SynchronizerState,
 };
 use anyhow::{format_err, Result};
-use executor::Executor;
+use executor::ChunkExecutor;
 use futures::{
     channel::{mpsc, oneshot},
     future::Future,
@@ -19,11 +19,7 @@ use libra_types::{
     contract_event::ContractEvent, epoch_change::EpochChangeProof,
     ledger_info::LedgerInfoWithSignatures, transaction::Transaction, waypoint::Waypoint,
 };
-use libra_vm::LibraVM;
-use std::{
-    sync::{Arc, Mutex},
-    time::Duration,
-};
+use std::{boxed::Box, sync::Arc, time::Duration};
 use storage_interface::DbReader;
 use subscription_service::ReconfigSubscription;
 use tokio::{
@@ -42,7 +38,7 @@ impl StateSynchronizer {
         network: Vec<(StateSynchronizerSender, StateSynchronizerEvents)>,
         state_sync_to_mempool_sender: mpsc::Sender<CommitNotification>,
         storage: Arc<dyn DbReader>,
-        executor: Arc<Mutex<Executor<LibraVM>>>,
+        executor: Box<dyn ChunkExecutor>,
         config: &NodeConfig,
         reconfig_event_subscriptions: Vec<ReconfigSubscription>,
     ) -> Self {


### PR DESCRIPTION
## Motivation

Another important step according to #2519 .

In order to let zone 3 and TCB both access to `Executor` we have to split executor into 2 instances but share the same code as much as possible. So we adopt trait objects:
- `ChunkExecutor` for state sync
- `BlockExecutor` for TCB

They both lie on the same struct `Executor` but expose only limited APIs for its proper context.

To make it work, I also edit some tests and add a new method in executor to refresh the internal cache because now that we have two executors, they may be out-of-sync after the node switch back and forth between sync mode and consensus mode. 

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?

Y
## Test Plan

CI

