### PR TITLE
[move-prover] Specification schema type checking and expansion.

### DIFF
--- a/language/move-prover/spec-lang/tests/sources/schemas_err.exp
+++ b/language/move-prover/spec-lang/tests/sources/schemas_err.exp
@@ -1,0 +1,87 @@
+error: undeclared `M::x`
+
+   ┌── tests/sources/schemas_err.move:4:17 ───
+   │
+ 4 │         ensures x > 0;
+   │                 ^
+   │
+
+error: schema `M::Undeclared` undeclared
+
+   ┌── tests/sources/schemas_err.move:8:9 ───
+   │
+ 8 │         include Undeclared;
+   │         ^^^^^^^^^^^^^^^^^^^
+   │
+
+error: wrong number of type arguments (expected 1, got 2)
+
+    ┌── tests/sources/schemas_err.move:12:9 ───
+    │
+ 12 │         include WrongTypeArgsIncluded<num, num>;
+    │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    │
+
+error: `wrong` not declared in schema
+
+    ┌── tests/sources/schemas_err.move:19:44 ───
+    │
+ 19 │         include WrongTypeArgsIncluded<num>{wrong: x};
+    │                                            ^^^^^
+    │
+
+error: incompatible type of included `x` (renamed to `y`); type in schema: `num`, type in inclusion context: `bool`
+
+    ┌── tests/sources/schemas_err.move:24:9 ───
+    │
+ 24 │         include WrongTypeArgsIncluded<num>{x: y};
+    │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    │
+
+error: incompatible type of included `x`; type in schema: `num`, type in inclusion context: `bool`
+
+    ┌── tests/sources/schemas_err.move:29:9 ───
+    │
+ 29 │         include WronglyTypedVarIncluded;
+    │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    │
+
+error: incompatible type of included `x`; type in schema: `num`, type in inclusion context: `bool`
+
+    ┌── tests/sources/schemas_err.move:37:9 ───
+    │
+ 37 │         include WronglyTypedInstantiationIncluded<num>;
+    │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    │
+
+error: cyclic schema dependency: Cycle1 -> Cycle2 -> Cycle3 -> Cycle1
+
+    ┌── tests/sources/schemas_err.move:76:9 ───
+    │
+ 76 │         include Cycle1;
+    │         ^^^^^^^^^^^^^^^
+    │
+
+error: `y` cannot be matched to an existing name in inclusion context
+
+    ┌── tests/sources/schemas_err.move:48:9 ───
+    │
+ 48 │         include UndeclaredVarInInclude;
+    │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    │
+
+error: schema `M::Invariant` includes invariants which are not allowed in this context
+
+    ┌── tests/sources/schemas_err.move:57:9 ───
+    │
+ 57 │         include Invariant;
+    │         ^^^^^^^^^^^^^^^^^^
+    │
+
+error: schema `M::Condition` includes conditions which are not allowed in this context
+
+    ┌── tests/sources/schemas_err.move:66:9 ───
+    │
+ 66 │         include Condition;
+    │         ^^^^^^^^^^^^^^^^^^
+    │

--- a/language/move-prover/spec-lang/tests/sources/schemas_err.move
+++ b/language/move-prover/spec-lang/tests/sources/schemas_err.move
@@ -1,0 +1,78 @@
+module M {
+
+    spec schema UndeclaredVar {
+        ensures x > 0;
+    }
+
+    spec schema UndeclaredSchema {
+        include Undeclared;
+    }
+
+    spec schema WrongTypeArgs {
+        include WrongTypeArgsIncluded<num, num>;
+    }
+    spec schema WrongTypeArgsIncluded<T> {
+        x: T;
+    }
+
+    spec schema WrongRenaming {
+        include WrongTypeArgsIncluded<num>{wrong: x};
+    }
+
+    spec schema WrongTypeAfterRenaming {
+        y: bool;
+        include WrongTypeArgsIncluded<num>{x: y};
+    }
+
+    spec schema WronglyTypedVar {
+        x: bool;
+        include WronglyTypedVarIncluded;
+    }
+    spec schema WronglyTypedVarIncluded {
+        x: num;
+    }
+
+    spec schema WronglyTypedInstantiation {
+        x: bool;
+        include WronglyTypedInstantiationIncluded<num>;
+    }
+    spec schema WronglyTypedInstantiationIncluded<T> {
+        x: T;
+    }
+
+    fun undeclared_var_in_include(x: u64): u64 { x }
+    spec schema UndeclaredVarInInclude {
+        y: u64;
+    }
+    spec fun undeclared_var_in_include {
+        include UndeclaredVarInInclude;
+    }
+
+    fun wrong_invariant_in_fun(x: u64): u64 { x }
+    spec schema Invariant {
+        x: num;
+        invariant x > 0;
+    }
+    spec fun wrong_invariant_in_fun {
+        include Invariant;
+    }
+
+    struct wrong_condition_in_struct { x: u64 }
+    spec schema Condition {
+        x: num;
+        requires x > 0;
+    }
+    spec struct wrong_condition_in_struct {
+        include Condition;
+    }
+
+    spec schema Cycle1 {
+        include Cycle2;
+    }
+    spec schema Cycle2 {
+        include Cycle3;
+    }
+    spec schema Cycle3 {
+        include Cycle1;
+    }
+}

--- a/language/move-prover/spec-lang/tests/sources/schemas_ok.exp
+++ b/language/move-prover/spec-lang/tests/sources/schemas_ok.exp
@@ -1,0 +1,1 @@
+All good, no errors!

--- a/language/move-prover/spec-lang/tests/sources/schemas_ok.move
+++ b/language/move-prover/spec-lang/tests/sources/schemas_ok.move
@@ -1,0 +1,67 @@
+module M {
+
+    spec schema Increases {
+        x: num;
+        result: num;
+        requires x > 0;
+        ensures result >= x;
+    }
+
+    spec schema IncreasesStrictly {
+        include Increases;
+        ensures result > x;
+    }
+
+    spec schema IncreasesWithTwoResults {
+        result_1: num;
+        result_2: num;
+        include Increases{result: result_1};
+        ensures result_2 > result_1;
+    }
+
+    spec schema IsEqual<T> {
+        x: T;
+        y: T;
+        ensures x == y;
+    }
+
+    spec schema IsEqualConcrete {
+        z: num;
+        include IsEqual<num>{x: z};
+        ensures z <= y;
+    }
+
+    fun add(x: u64): u64 { x + 1 }
+    spec fun add {
+        include Increases;
+    }
+
+    fun id(x: u64): u64 { x }
+    spec fun add {
+        include IsEqual<num>{y: result};
+    }
+
+    spec schema InvariantIsEqual<T> {
+        x: T;
+        invariant update x == old(x);
+    }
+    struct S<X> { x: X }
+    spec struct S {
+        include InvariantIsEqual<X>;
+    }
+
+    spec schema GenericIncludesGeneric<T> {
+        include InvariantIsEqual<T>;
+    }
+
+    spec schema MultipleTypeParams<T, R> {
+        _x: T;
+        _y: R;
+    }
+    fun multiple(_x: u64, _y: u64) {}
+    spec fun multiple {
+        include MultipleTypeParams<num, num>;
+        requires _x > _y;
+    }
+
+}

--- a/language/move-prover/tests/sources/marketcap_as_schema.exp
+++ b/language/move-prover/tests/sources/marketcap_as_schema.exp
@@ -1,0 +1,16 @@
+Move prover returns: exiting with boogie verification errors
+error:  A postcondition might not hold on this return path.
+
+    ┌── tests/sources/marketcap_as_schema.move:12:9 ───
+    │
+ 12 │         ensures global<MarketCap>(0xA550C18).total_value == sum_of_coins<X>;
+    │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    │
+    =     at tests/sources/marketcap_as_schema.move:55:6: deposit_invalid (entry)
+    =     at tests/sources/marketcap_as_schema.move:56:18: deposit_invalid
+    =         coin_ref = <redacted>,
+    =         check = <redacted>,
+    =         value = <redacted>
+    =     at tests/sources/marketcap_as_schema.move:57:27: deposit_invalid
+    =         coin_ref = <redacted>
+    =     at tests/sources/marketcap_as_schema.move:55:6: deposit_invalid (exit)

--- a/language/move-prover/tests/sources/marketcap_as_schema.move
+++ b/language/move-prover/tests/sources/marketcap_as_schema.move
@@ -1,0 +1,67 @@
+// A minimized version of the MarketCap verification problem.
+address 0x0:
+
+module TestMarketCapWithSchemas {
+
+    spec module {
+        global sum_of_coins<X>: num;
+    }
+
+    spec schema SumOfCoinsModuleInvariant<X> {
+        requires global<MarketCap>(0xA550C18).total_value == sum_of_coins<X>;
+        ensures global<MarketCap>(0xA550C18).total_value == sum_of_coins<X>;
+    }
+
+    // A resource representing the Libra coin
+    resource struct T<X> {
+        // The value of the coin. May be zero
+        value: u64,
+    }
+    spec struct T {
+        include UpdateSumOfCoins<X>;
+    }
+    spec schema UpdateSumOfCoins<X> {
+        value: num;
+        invariant pack sum_of_coins<X> = sum_of_coins<X> + value;
+        invariant unpack sum_of_coins<X> = sum_of_coins<X> - value;
+        invariant update sum_of_coins<X> = sum_of_coins<X> - old(value) + value;
+    }
+
+
+    resource struct MarketCap<X> {
+        // The sum of the values of all LibraCoin::T resources in the system
+        total_value: u128,
+    }
+
+    public fun deposit<X>(coin_ref: &mut T<X>, check: T<X>) {
+        let T { value } = check;
+        coin_ref.value = coin_ref.value + value;
+    }
+    spec schema DepositContract<X> {
+        coin_ref: &mut T<X>;
+        check: T<X>;
+        aborts_if coin_ref.value + check.value > max_u64();
+        ensures coin_ref.value == old(coin_ref.value) + check.value;
+    }
+    spec fun deposit {
+        // module invariant
+        include SumOfCoinsModuleInvariant<X>;
+
+        // function contract
+        include DepositContract<X>;
+    }
+
+     // Deposit a check which violates the MarketCap module invariant.
+     public fun deposit_invalid<X>(coin_ref: &mut T<X>, check: T<X>) {
+         let T { value } = check;
+         coin_ref.value = coin_ref.value + value / 2;
+     }
+     spec fun deposit_invalid {
+         // module invariant
+         include SumOfCoinsModuleInvariant<X>;
+
+         // function contract
+         aborts_if coin_ref.value + check.value / 2 > max_u64();
+         ensures coin_ref.value == old(coin_ref.value) + check.value / 2;
+     }
+}


### PR DESCRIPTION
This implements spec schemas in the type checker and translator. Right now, conditions and invariants introduced by schemas are expanded in the inclusion context during translation time, so the boogie translator stays unchanged. However, the design is ready to pass schemas also to the backend should we want to prove properties about them standalone.

This PR does not yet implement the `apply` weaving operator for schemas. This is syntactic sugar and will be added later once we see the approach reasonably works.

Here is a quick intro on how to use schemas. A schema is a named, possibly generic specification block. It can contain any item other spec blocks can contains (requires, aborts_if, ensures, assert, assume, invariant). Those items can use global specification variables and functions. A schema need to declare any local variables it uses so it can be reasoned about independently (which distinguishes schemas from pure macros). For example:

```
spec schema Increases {
   x: num; result: num;
   ensures result >= x;
}
```

Such a schema can be included in another spec block, where the variables it introduces are matched against existing ones:

```
fun foo(x: u64): u64 { x + 1 }
spec fun foo {
  include Increases; // matches x and result
}
```

At the point where a schema is included, the items it contains are checked to be valid in the inclusion context. For example, if a schema contains invariants and is included in function spec, an error will be produced.

If needed, renaming can be applied at schema inclusion time to match variables in the context:

```
fun foo2(x: u64): (u64, u64) { (x + 1, x + 2) }
spec fun foo2 {
  include Increases{result: result_1};
  include Increases{result: result_2};
}
```

Schemas can be generic, in which case the type parameters need to be provided at inclusion time (no type inference for schemas):

```
spec schema Identity<X> {
  x: X; result: X;
  ensures x == result;
}
fun identity<X>(x: X): X { x }
spec fun identity {
  include Identity<X>;
}
```

Schemas can include other schemas in order to build structured specifications. If a schema is included in another schema, any variables will be added to this context if they aren't yet declared:

```
spec schema Signature {
  x: u64;
  result: u64;
}
spec schema Decreases {
  include Signature;
  ensures x > result;
}
spec schema Increases {
  include Signature;
  ensures x < result;
}
```

<!--
Thank you for sending a PR. We appreciate you spending time to help improve the Libra project.

The project is undergoing daily changes. Pull Requests will be reviewed and responded to as time permits.
-->

## Motivation

Make specifications better readable.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

Added tests for spec-lang (schema type checking) and for move-prover (test `marketcap_as_schema.move`.

## Related PRs

NA
