### PR TITLE
[db-bootstrapper] command  line tool to invoke the bootstrapper

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1126,6 +1126,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "db-bootstrapper"
+version = "0.1.0"
+dependencies = [
+ "anyhow 1.0.28 (registry+https://github.com/rust-lang/crates.io-index)",
+ "executor 0.1.0",
+ "libra-canonical-serialization 0.1.0",
+ "libra-crypto 0.1.0",
+ "libra-types 0.1.0",
+ "libra-vm 0.1.0",
+ "libra-workspace-hack 0.1.0",
+ "libradb 0.1.0",
+ "storage-interface 0.1.0",
+ "structopt 0.3.13 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "debug-interface"
 version = "0.1.0"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,6 +39,7 @@ members = [
     "devtools/x",
     "devtools/x-core",
     "devtools/x-lint",
+    "execution/db-bootstrapper",
     "execution/executor",
     "execution/executor-benchmark",
     "execution/executor-types",

--- a/crypto/crypto/src/hash.rs
+++ b/crypto/crypto/src/hash.rs
@@ -97,7 +97,7 @@ use once_cell::sync::Lazy;
 use proptest_derive::Arbitrary;
 use rand::{rngs::OsRng, Rng};
 use serde::{de, ser};
-use std::{self, convert::AsRef, fmt, str::FromStr};
+use std::{self, convert::AsRef, fmt};
 use tiny_keccak::{Hasher, Sha3};
 
 const LIBRA_HASH_SUFFIX: &[u8] = b"@@$$LIBRA$$@@";
@@ -255,14 +255,6 @@ impl HashValue {
     /// Parse a given hex string to a hash value.
     pub fn from_hex(hex_str: &str) -> Result<Self> {
         Self::from_slice(hex::decode(hex_str)?.as_slice())
-    }
-}
-
-impl FromStr for HashValue {
-    type Err = anyhow::Error;
-
-    fn from_str(s: &str) -> Result<Self> {
-        Self::from_hex(s)
     }
 }
 

--- a/crypto/crypto/src/hash.rs
+++ b/crypto/crypto/src/hash.rs
@@ -97,7 +97,7 @@ use once_cell::sync::Lazy;
 use proptest_derive::Arbitrary;
 use rand::{rngs::OsRng, Rng};
 use serde::{de, ser};
-use std::{self, convert::AsRef, fmt};
+use std::{self, convert::AsRef, fmt, str::FromStr};
 use tiny_keccak::{Hasher, Sha3};
 
 const LIBRA_HASH_SUFFIX: &[u8] = b"@@$$LIBRA$$@@";
@@ -255,6 +255,14 @@ impl HashValue {
     /// Parse a given hex string to a hash value.
     pub fn from_hex(hex_str: &str) -> Result<Self> {
         Self::from_slice(hex::decode(hex_str)?.as_slice())
+    }
+}
+
+impl FromStr for HashValue {
+    type Err = anyhow::Error;
+
+    fn from_str(s: &str) -> Result<Self> {
+        Self::from_hex(s)
     }
 }
 

--- a/execution/db-bootstrapper/Cargo.toml
+++ b/execution/db-bootstrapper/Cargo.toml
@@ -1,0 +1,23 @@
+[package]
+name = "db-bootstrapper"
+version = "0.1.0"
+authors = ["Libra Association <opensource@libra.org>"]
+description = "Libra DB-Bootstrapper."
+repository = "https://github.com/libra/libra"
+homepage = "https://libra.org"
+license = "Apache-2.0"
+publish = false
+edition = "2018"
+
+[dependencies]
+anyhow = "1.0"
+structopt = "0.3.13"
+
+executor = { path = "../executor", version = "0.1.0" }
+lcs = { path = "../../common/lcs", version = "0.1.0", package = "libra-canonical-serialization" }
+libradb = { path = "../../storage/libradb", version = "0.1.0" }
+libra-crypto = { path = "../../crypto/crypto", version = "0.1.0" }
+libra-types = { path = "../../types", version = "0.1.0" }
+libra-vm = { path = "../../language/libra-vm", version = "0.1.0" }
+libra-workspace-hack = { path = "../../common/workspace-hack", version = "0.1.0" }
+storage-interface = { path = "../../storage/storage-interface", version = "0.1.0" }

--- a/execution/db-bootstrapper/src/bin/db_bootstrapper.rs
+++ b/execution/db-bootstrapper/src/bin/db_bootstrapper.rs
@@ -1,0 +1,88 @@
+// Copyright (c) The Libra Core Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+use anyhow::{ensure, format_err, Context, Result};
+use executor::db_bootstrapper::calculate_genesis;
+use libra_crypto::HashValue;
+use libra_types::transaction::Transaction;
+use libra_vm::LibraVM;
+use libradb::LibraDB;
+use std::{fs::File, io::Read, path::PathBuf};
+use storage_interface::DbReaderWriter;
+use structopt::StructOpt;
+
+#[derive(StructOpt)]
+#[structopt(
+    name = "db-bootstrapper",
+    about = "Calculate, verify and commit the genesis to local DB without a consensus among validators."
+)]
+struct Opt {
+    #[structopt(parse(from_os_str))]
+    db_dir: PathBuf,
+
+    #[structopt(short, long, parse(from_os_str))]
+    genesis_txn_file: PathBuf,
+
+    #[structopt(short = "v", long, requires("check-waypoint-hash"))]
+    check_waypoint_version: Option<u64>,
+
+    #[structopt(short = "h", long, requires("check-waypoint-version"))]
+    check_waypoint_hash: Option<HashValue>,
+
+    #[structopt(long, requires_all(&["check-waypoint-version", "check-waypoint-hash"]))]
+    commit: bool,
+}
+
+fn main() -> Result<()> {
+    let opt = Opt::from_args();
+
+    let genesis_txn = load_genesis_txn(&opt.genesis_txn_file)
+        .with_context(|| format_err!("Failed loading genesis txn."))?;
+    let db = DbReaderWriter::new(
+        LibraDB::open(&opt.db_dir, false /* readonly */)
+            .with_context(|| format_err!("Failed to open DB."))?,
+    );
+
+    let tree_state = db
+        .reader
+        .get_latest_tree_state()
+        .with_context(|| format_err!("Failed to get latest tree state."))?;
+    let committer = calculate_genesis::<LibraVM>(&db, tree_state, &genesis_txn)
+        .with_context(|| format_err!("Failed to calculate genesis."))?;
+    println!("Successfully calculated genesis.");
+    println!("{:?}", committer.waypoint());
+
+    if opt.check_waypoint_version.is_some() {
+        let waypoint = committer.waypoint();
+        ensure!(
+            opt.check_waypoint_version.unwrap() == waypoint.version(),
+            "Waypoint version not expected. Expected {:?} got {:?}",
+            opt.check_waypoint_version.unwrap(),
+            waypoint.version(),
+        );
+        ensure!(
+            opt.check_waypoint_hash.unwrap() == waypoint.value(),
+            "Waypoint hash not expected. Expected {:?} got {:?}",
+            opt.check_waypoint_hash.unwrap(),
+            waypoint.value(),
+        );
+        println!("Waypoint verified.");
+
+        if opt.commit {
+            committer
+                .commit()
+                .with_context(|| format_err!("Committing genesis to DB."))?;
+            println!("Successfully committed genesis.")
+        }
+    }
+
+    Ok(())
+}
+
+fn load_genesis_txn(path: &PathBuf) -> Result<Transaction> {
+    let mut file = File::open(&path)?;
+    let mut buffer = vec![];
+    file.read_to_end(&mut buffer)?;
+
+    Ok(lcs::from_bytes(&buffer)?)
+}

--- a/execution/executor/src/db_bootstrapper.rs
+++ b/execution/executor/src/db_bootstrapper.rs
@@ -136,12 +136,8 @@ pub fn calculate_genesis<V: VMExecutor>(
 
     let committer = GenesisCommitter::new(executor, ledger_info_with_sigs)?;
     info!(
-        "Genesis calculated: root_hash {:?}, waypoint {:?}",
-        committer
-            .ledger_info_with_sigs
-            .ledger_info()
-            .transaction_accumulator_hash(),
-        committer.waypoint,
+        "Genesis calculated: ledger_info_with_sigs {:?}, waypoint {:?}",
+        committer.ledger_info_with_sigs, committer.waypoint,
     );
     Ok(committer)
 }

--- a/execution/executor/src/db_bootstrapper.rs
+++ b/execution/executor/src/db_bootstrapper.rs
@@ -32,14 +32,55 @@ pub fn bootstrap_db_if_empty<V: VMExecutor>(
         return Ok(None);
     }
 
-    Ok(Some(bootstrap_db::<V>(db, tree_state, genesis_txn)?))
+    let committer = calculate_genesis::<V>(db, tree_state, genesis_txn)?;
+    let waypoint = committer.waypoint;
+    committer.commit()?;
+    Ok(Some(waypoint))
 }
 
-pub fn bootstrap_db<V: VMExecutor>(
+pub struct GenesisCommitter<V: VMExecutor> {
+    executor: Executor<V>,
+    ledger_info_with_sigs: LedgerInfoWithSignatures,
+    waypoint: Waypoint,
+}
+
+impl<V: VMExecutor> GenesisCommitter<V> {
+    pub fn new(
+        executor: Executor<V>,
+        ledger_info_with_sigs: LedgerInfoWithSignatures,
+    ) -> Result<Self> {
+        let waypoint = Waypoint::new(ledger_info_with_sigs.ledger_info())?;
+
+        Ok(Self {
+            executor,
+            ledger_info_with_sigs,
+            waypoint,
+        })
+    }
+
+    pub fn ledger_info_with_sigs(&self) -> &LedgerInfoWithSignatures {
+        &self.ledger_info_with_sigs
+    }
+
+    pub fn waypoint(&self) -> Waypoint {
+        self.waypoint
+    }
+
+    pub fn commit(mut self) -> Result<()> {
+        self.executor
+            .commit_blocks(vec![genesis_block_id()], self.ledger_info_with_sigs)?;
+        info!("Genesis commited.");
+        // DB bootstrapped, avoid anything that could fail after this.
+
+        Ok(())
+    }
+}
+
+pub fn calculate_genesis<V: VMExecutor>(
     db: &DbReaderWriter,
     tree_state: TreeState,
     genesis_txn: &Transaction,
-) -> Result<Waypoint> {
+) -> Result<GenesisCommitter<V>> {
     // DB bootstrapper works on either an empty transaction accumulator or an existing block chain.
     // In the very exetreme and sad situation of losing quorum among validators, we refer to the
     // second use case said above.
@@ -92,16 +133,17 @@ pub fn bootstrap_db<V: VMExecutor>(
         ),
         BTreeMap::default(), /* signatures */
     );
-    let waypoint = Waypoint::new(ledger_info_with_sigs.ledger_info())?;
 
-    executor.commit_blocks(vec![block_id], ledger_info_with_sigs)?;
+    let committer = GenesisCommitter::new(executor, ledger_info_with_sigs)?;
     info!(
-        "GENESIS transaction is committed with state_id {} and ValidatorSet {}.",
-        root_hash, next_validator_set
+        "Genesis calculated: root_hash {:?}, waypoint {:?}",
+        committer
+            .ledger_info_with_sigs
+            .ledger_info()
+            .transaction_accumulator_hash(),
+        committer.waypoint,
     );
-    // DB bootstrapped, avoid anything that could fail after this.
-
-    Ok(waypoint)
+    Ok(committer)
 }
 
 fn get_state_timestamp(state_view: &VerifiedStateView) -> Result<u64> {
@@ -124,4 +166,8 @@ fn get_state_epoch(state_view: &VerifiedStateView) -> Result<u64> {
         .ok_or_else(|| format_err!("ConfigurationResource missing."))?;
     let rsrc = lcs::from_bytes::<ConfigurationResource>(&rsrc_bytes)?;
     Ok(rsrc.epoch())
+}
+
+fn genesis_block_id() -> HashValue {
+    HashValue::zero()
 }


### PR DESCRIPTION
## Motivation

Expose the DB-Bootstrapper functionality via a CLI tool.
 
### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

**$ target/debug/db_bootstrapper /home/aldenhu/local/temp/libradb -g /home/aldenhu/local/temp/genesis.blob** 
Successfully calculated genesis.
Waypoint { version: 0, value: HashValue(c2e2fb941a43b4fce99d3e8430df6d04083ed89402f1f04428948ead11146d73) }

**$ target/debug/db_bootstrapper /home/aldenhu/local/temp/libradb -g /home/aldenhu/local/temp/genesis.blob -w '0:c2e2fb941a43b4fce99d3e8430df6d04083ed89402f1f04428948ead11146d73'**
Successfully calculated genesis.
Waypoint { version: 0, value: HashValue(c2e2fb941a43b4fce99d3e8430df6d04083ed89402f1f04428948ead11146d73) }
Waypoint verified.

**$ target/debug/db_bootstrapper /home/aldenhu/local/temp/libradb -g /home/aldenhu/local/temp/genesis.blob -w '0:c2e2fb941a43b4fce99d3e8430df6d04083ed89402f1f04428948ead11146d73' --commit**
Successfully calculated genesis.
Waypoint { version: 0, value: HashValue(c2e2fb941a43b4fce99d3e8430df6d04083ed89402f1f04428948ead11146d73) }
Waypoint verified.
Successfully committed genesis.

**$ target/debug/db_bootstrapper /home/aldenhu/local/temp/libradb -g /home/aldenhu/local/temp/genesis.blob** 
Error: Failed to calculate genesis.

Caused by:
    Genesis txn didn't bump epoch.

## Related PRs

(If this PR adds or changes functionality, please take some time to update the docs at https://github.com/libra/website, and link to your PR here.)
