### PR TITLE
[config-builder] guarantee consistent genesis building

### DIFF
--- a/config/config-builder/src/validator_config.rs
+++ b/config/config-builder/src/validator_config.rs
@@ -328,4 +328,17 @@ mod test {
         );
         assert!(config.execution.genesis.is_some());
     }
+
+    #[test]
+    fn verify_same_genesis() {
+        let config1 = ValidatorConfig::new().nodes(10).index(1).build().unwrap();
+        let config2 = ValidatorConfig::new()
+            .nodes(13)
+            .index(12)
+            .nodes_in_genesis(Some(10))
+            .build()
+            .unwrap();
+
+        assert_eq!(config1.execution.genesis, config2.execution.genesis);
+    }
 }

--- a/config/src/generator.rs
+++ b/config/src/generator.rs
@@ -97,8 +97,6 @@ pub fn validator_swarm(
         network.seed_peers = seed_peers.clone();
     }
 
-    validator_keys.sort_by(|k1, k2| k1.account_address().cmp(k2.account_address()));
-    discovery_infos.sort_by(|k1, k2| k1.account_address.cmp(&k2.account_address));
     ValidatorSwarm {
         nodes,
         validator_set: ValidatorSet::new(validator_keys),

--- a/language/functional-tests/src/config/global.rs
+++ b/language/functional-tests/src/config/global.rs
@@ -159,7 +159,7 @@ impl Config {
         // generate a validator set with |validator_accounts| validators
         let (validator_keys, validator_set) = if validator_accounts > 0 {
             let mut swarm = generator::validator_swarm_for_testing(validator_accounts);
-            let validator_keys: BTreeMap<_, _> = swarm
+            let validator_keys: Vec<_> = swarm
                 .nodes
                 .iter_mut()
                 .map(|c| {
@@ -172,7 +172,7 @@ impl Config {
                 .collect();
             (validator_keys, swarm.validator_set)
         } else {
-            (BTreeMap::new(), ValidatorSet::new(vec![]))
+            (vec![], ValidatorSet::new(vec![]))
         };
 
         // key generator with a fixed seed
@@ -187,7 +187,7 @@ impl Config {
                     let balance = def.balance.as_ref().unwrap_or(&DEFAULT_BALANCE).clone();
                     let account_data = if entry.is_validator() {
                         validator_accounts -= 1;
-                        let privkey = validator_keys.iter().nth(validator_accounts).unwrap().1;
+                        let privkey = &validator_keys.get(validator_accounts).unwrap().1;
                         AccountData::with_keypair(
                             privkey.clone(),
                             privkey.public_key(),


### PR DESCRIPTION
<!--
Thank you for sending a PR. We appreciate you spending time to help improve the Libra project.

The project is undergoing daily changes. Pull Requests will be reviewed and responded to as time permits.
-->

## Motivation

The Validator/DiscoverSet has been sorted based on account address which
results in inconsistent genesis building.

Imagine a random series of [1, 9, 2, 4, 3], with n = 3 it's [1, 2, 9],
with n = 5 and g = 3 it's [1, 2, 3].

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?

Y

## Test Plan

Added test.

## Related PRs

(If this PR adds or changes functionality, please take some time to update the docs at https://github.com/libra/website, and link to your PR here.)
https://github.com/libra/libra/issues/3532