### PR TITLE
[move-prover] Using schemas to simplify libra.move spec.

### DIFF
--- a/language/move-prover/src/prelude.bpl
+++ b/language/move-prover/src/prelude.bpl
@@ -947,7 +947,7 @@ procedure {:inline 1} $Vector_contains(ta: TypeValue, v: Value, e: Value) return
 // assert that sha2/3 are injections without using global quantified axioms.
 
 
-function {:inline} $Hash_sha2($m: Memory, val: Value): Value {
+function {:inline} $Hash_sha2($m: Memory, $txn: Transaction, val: Value): Value {
     $Hash_sha2_core(val)
 }
 
@@ -973,7 +973,7 @@ ensures $IsValidU8Vector(res);    // result is a legal vector of U8s.
 ensures $vlen(res) == 32;               // result is 32 bytes.
 
 // similarly for Hash_sha3
-function {:inline} $Hash_sha3($m: Memory, val: Value): Value {
+function {:inline} $Hash_sha3($m: Memory, $txn: Transaction, val: Value): Value {
     $Hash_sha3_core(val)
 }
 function $Hash_sha3_core(val: Value): Value;
@@ -1047,7 +1047,7 @@ procedure {:inline 1} Signature_ed25519_threshold_verify(bitmap: Value, signatur
 // Serialize is modeled as an uninterpreted function, with an additional
 // axiom to say it's an injection.
 
-function {:inline} $LCS_serialize($m: Memory, ta: TypeValue, v: Value): Value {
+function {:inline} $LCS_serialize($m: Memory, $txn: Transaction, ta: TypeValue, v: Value): Value {
     $LCS_serialize_core(ta, v)
 }
 

--- a/language/move-prover/src/spec_translator.rs
+++ b/language/move-prover/src/spec_translator.rs
@@ -241,7 +241,7 @@ impl<'env> SpecTranslator<'env> {
                 self.writer,
                 "function {{:inline}} {}({}): {} {{",
                 boogie_spec_fun_name(&self.module_env(), *id),
-                vec!["$m: Memory".to_string()]
+                vec!["$m: Memory, $txn: Transaction".to_string()]
                     .into_iter()
                     .chain(spec_var_params)
                     .chain(type_params)
@@ -907,7 +907,7 @@ impl<'env> SpecTranslator<'env> {
         let fun_decl = module_env.get_spec_fun(fun_id);
         let name = boogie_spec_fun_name(&module_env, fun_id);
         emit!(self.writer, "{}(", name);
-        emit!(self.writer, "$m");
+        emit!(self.writer, "$m, $txn");
         for (mid, vid) in &fun_decl.used_spec_vars {
             emit!(self.writer, ", ");
             let declaring_module = self.module_env().env.get_module(*mid);


### PR DESCRIPTION
This uses the new schemas to avoid some repetition in libra.move specs. It also fixes a bug with specification functions using the `sender()` builtin.

The exercise showed the need for a more powerful parameter mechanism in schemas (replacing the renaming we have right now), which is in a PR on which this one is based.

## Motivation

Making specs better readable.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

Existing tests pass.

## Related PRs

NA