### PR TITLE
[move-prover] Generalizing schema variable renamings to passing expressions.

### DIFF
--- a/language/move-lang/src/expansion/ast.rs
+++ b/language/move-lang/src/expansion/ast.rs
@@ -139,11 +139,12 @@ pub enum SpecBlockMember_ {
     Include {
         name: ModuleAccess,
         type_arguments: Option<Vec<Type>>,
-        renamings: Vec<(Name, Name)>,
+        arguments: Vec<(Name, Exp)>,
     },
     Apply {
         name: ModuleAccess,
         type_arguments: Option<Vec<Type>>,
+        arguments: Vec<(Name, Exp)>,
         patterns: Vec<SpecApplyPattern>,
         exclusion_patterns: Vec<SpecApplyPattern>,
     },
@@ -487,7 +488,7 @@ impl AstDebug for SpecBlockMember_ {
             SpecBlockMember_::Include {
                 name,
                 type_arguments,
-                renamings,
+                arguments,
             } => {
                 w.write(&format!("include {}", name));
                 if let Some(ty_args) = type_arguments {
@@ -495,12 +496,12 @@ impl AstDebug for SpecBlockMember_ {
                     ty_args.ast_debug(w);
                     w.write(">");
                 }
-                if !renamings.is_empty() {
+                if !arguments.is_empty() {
                     w.write("{");
-                    w.list(renamings, ", ", |w, (l, r)| {
+                    w.list(arguments, ", ", |w, (l, r)| {
                         w.write(&l.value);
                         w.write(" : ");
-                        w.write(&r.value);
+                        r.ast_debug(w);
                         true
                     });
                     w.write("}");
@@ -509,6 +510,7 @@ impl AstDebug for SpecBlockMember_ {
             SpecBlockMember_::Apply {
                 name,
                 type_arguments,
+                arguments,
                 patterns,
                 exclusion_patterns,
             } => {
@@ -517,6 +519,16 @@ impl AstDebug for SpecBlockMember_ {
                     w.write("<");
                     ty_args.ast_debug(w);
                     w.write(">");
+                }
+                if !arguments.is_empty() {
+                    w.write("{");
+                    w.list(arguments, ", ", |w, (l, r)| {
+                        w.write(&l.value);
+                        w.write(" : ");
+                        r.ast_debug(w);
+                        true
+                    });
+                    w.write("}");
                 }
                 w.write(" to ");
                 w.list(patterns, ", ", |w, p| {

--- a/language/move-lang/src/expansion/translate.rs
+++ b/language/move-lang/src/expansion/translate.rs
@@ -632,24 +632,33 @@ fn spec_member(
         PM::Include {
             name: pn,
             type_arguments: ptys_opt,
-            renamings,
+            arguments: parguments,
         } => {
             let name = module_access(context, pn)?;
             let type_arguments = optional_types(context, ptys_opt);
+            let arguments = parguments
+                .into_iter()
+                .map(|(n, e)| (n, *exp(context, e)))
+                .collect();
             EM::Include {
                 name,
                 type_arguments,
-                renamings,
+                arguments,
             }
         }
         PM::Apply {
             name: pn,
             type_arguments: ptys_opt,
+            arguments: parguments,
             patterns: ppatterns,
             exclusion_patterns: pe_patterns,
         } => {
             let name = module_access(context, pn)?;
             let type_arguments = optional_types(context, ptys_opt);
+            let arguments = parguments
+                .into_iter()
+                .map(|(n, e)| (n, exp_(context, e)))
+                .collect();
             let patterns = ppatterns
                 .into_iter()
                 .map(|p| spec_apply_pattern(context, p))
@@ -661,6 +670,7 @@ fn spec_member(
             EM::Apply {
                 name,
                 type_arguments,
+                arguments,
                 patterns,
                 exclusion_patterns,
             }

--- a/language/move-lang/src/parser/ast.rs
+++ b/language/move-lang/src/parser/ast.rs
@@ -237,12 +237,13 @@ pub enum SpecBlockMember_ {
     Include {
         name: ModuleAccess,
         type_arguments: Option<Vec<Type>>,
-        renamings: Vec<(Name, Name)>,
+        arguments: Vec<(Name, Exp)>,
     },
     Apply {
         name: ModuleAccess,
         type_arguments: Option<Vec<Type>>,
         patterns: Vec<SpecApplyPattern>,
+        arguments: Vec<(Name, Exp)>,
         exclusion_patterns: Vec<SpecApplyPattern>,
     },
     Pragma {
@@ -916,7 +917,7 @@ impl AstDebug for SpecBlockMember_ {
             SpecBlockMember_::Include {
                 name,
                 type_arguments,
-                renamings,
+                arguments,
             } => {
                 w.write("include ");
                 name.ast_debug(w);
@@ -925,12 +926,12 @@ impl AstDebug for SpecBlockMember_ {
                     ty_args.ast_debug(w);
                     w.write(">");
                 }
-                if !renamings.is_empty() {
+                if !arguments.is_empty() {
                     w.write("{");
-                    w.list(renamings, ", ", |w, (l, r)| {
+                    w.list(arguments, ", ", |w, (l, r)| {
                         w.write(&l.value);
                         w.write(" : ");
-                        w.write(&r.value);
+                        r.ast_debug(w);
                         true
                     });
                     w.write("}");
@@ -939,6 +940,7 @@ impl AstDebug for SpecBlockMember_ {
             SpecBlockMember_::Apply {
                 name,
                 type_arguments,
+                arguments,
                 patterns,
                 exclusion_patterns,
             } => {
@@ -948,6 +950,16 @@ impl AstDebug for SpecBlockMember_ {
                     w.write("<");
                     ty_args.ast_debug(w);
                     w.write(">");
+                }
+                if !arguments.is_empty() {
+                    w.write("{");
+                    w.list(arguments, ", ", |w, (l, r)| {
+                        w.write(&l.value);
+                        w.write(" : ");
+                        r.ast_debug(w);
+                        true
+                    });
+                    w.write("}");
                 }
                 w.write(" to ");
                 w.list(patterns, ", ", |w, p| {

--- a/language/move-prover/spec-lang/tests/sources/schemas_err.exp
+++ b/language/move-prover/spec-lang/tests/sources/schemas_err.exp
@@ -26,62 +26,70 @@ error: `wrong` not declared in schema
 
     ┌── tests/sources/schemas_err.move:19:44 ───
     │
- 19 │         include WrongTypeArgsIncluded<num>{wrong: x};
+ 19 │         include WrongTypeArgsIncluded<num>{wrong: 1};
     │                                            ^^^^^
     │
 
-error: incompatible type of included `x` (renamed to `y`); type in schema: `num`, type in inclusion context: `bool`
+error: expected `num` but found `bool`
 
-    ┌── tests/sources/schemas_err.move:24:9 ───
+    ┌── tests/sources/schemas_err.move:24:47 ───
     │
  24 │         include WrongTypeArgsIncluded<num>{x: y};
-    │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    │                                               ^
+    │
+
+error: expected `bool` but found `num`
+
+    ┌── tests/sources/schemas_err.move:28:48 ───
+    │
+ 28 │         include WrongTypeArgsIncluded<bool>{x: 1 + 2};
+    │                                                ^^^^^
     │
 
 error: incompatible type of included `x`; type in schema: `num`, type in inclusion context: `bool`
 
-    ┌── tests/sources/schemas_err.move:29:9 ───
+    ┌── tests/sources/schemas_err.move:33:9 ───
     │
- 29 │         include WronglyTypedVarIncluded;
+ 33 │         include WronglyTypedVarIncluded;
     │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
     │
 
 error: incompatible type of included `x`; type in schema: `num`, type in inclusion context: `bool`
 
-    ┌── tests/sources/schemas_err.move:37:9 ───
+    ┌── tests/sources/schemas_err.move:41:9 ───
     │
- 37 │         include WronglyTypedInstantiationIncluded<num>;
+ 41 │         include WronglyTypedInstantiationIncluded<num>;
     │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
     │
 
 error: cyclic schema dependency: Cycle1 -> Cycle2 -> Cycle3 -> Cycle1
 
-    ┌── tests/sources/schemas_err.move:76:9 ───
+    ┌── tests/sources/schemas_err.move:80:9 ───
     │
- 76 │         include Cycle1;
+ 80 │         include Cycle1;
     │         ^^^^^^^^^^^^^^^
     │
 
 error: `y` cannot be matched to an existing name in inclusion context
 
-    ┌── tests/sources/schemas_err.move:48:9 ───
+    ┌── tests/sources/schemas_err.move:52:9 ───
     │
- 48 │         include UndeclaredVarInInclude;
+ 52 │         include UndeclaredVarInInclude;
     │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
     │
 
 error: schema `M::Invariant` includes invariants which are not allowed in this context
 
-    ┌── tests/sources/schemas_err.move:57:9 ───
+    ┌── tests/sources/schemas_err.move:61:9 ───
     │
- 57 │         include Invariant;
+ 61 │         include Invariant;
     │         ^^^^^^^^^^^^^^^^^^
     │
 
 error: schema `M::Condition` includes conditions which are not allowed in this context
 
-    ┌── tests/sources/schemas_err.move:66:9 ───
+    ┌── tests/sources/schemas_err.move:70:9 ───
     │
- 66 │         include Condition;
+ 70 │         include Condition;
     │         ^^^^^^^^^^^^^^^^^^
     │

--- a/language/move-prover/spec-lang/tests/sources/schemas_err.move
+++ b/language/move-prover/spec-lang/tests/sources/schemas_err.move
@@ -16,12 +16,16 @@ module M {
     }
 
     spec schema WrongRenaming {
-        include WrongTypeArgsIncluded<num>{wrong: x};
+        include WrongTypeArgsIncluded<num>{wrong: 1};
     }
 
     spec schema WrongTypeAfterRenaming {
         y: bool;
         include WrongTypeArgsIncluded<num>{x: y};
+    }
+
+    spec schema WrongTypeAfterRenamingExp {
+        include WrongTypeArgsIncluded<bool>{x: 1 + 2};
     }
 
     spec schema WronglyTypedVar {


### PR DESCRIPTION
The first use cases of schemas in #3536 indicated that we should support `include S{x: <exp>}` instead of just `include S{x: <name>}`. In fact, this also appears more natural in the implementation. This PR extends parser and spec lang translator to support this.

## Motivation

Make specifications more concise and better readable.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

Existing tests and a new one.

## Related PRs

#3536 
