### PR TITLE
[move-prover] Fixing order of pack arguments.

### DIFF
--- a/language/move-prover/spec-lang/tests/sources/structs_ok.move
+++ b/language/move-prover/spec-lang/tests/sources/structs_ok.move
@@ -33,6 +33,10 @@ module M {
       S{x: x, y: y, z: z}
     }
 
+    define struct_pack_other_order(x: u64, y: bool, z: vector<u64>): S {
+      S{z: z, y: y, x: x}
+    }
+
     define generic_struct_pack(x: u64, y: bool): G<u64> {
       G{x: x, y: y}
     }


### PR DESCRIPTION
It appears the fields in a pack expression we get from move-lang expansion phase are not ordered by offset. This PR uses the order as found in the declaration instead of in the pack expression.

## Motivation

Bug fix

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

As we don't yet translate Pack to Boogie, this is not easy to test, so it's kind of a blind flight.

## Related PRs

NA
