### PR TITLE
[safety-rules] Improve QC handling

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -843,6 +843,7 @@ dependencies = [
  "libra-logger 0.1.0",
  "libra-mempool 0.1.0",
  "libra-metrics 0.1.0",
+ "libra-secure-storage 0.1.0",
  "libra-security-logger 0.1.0",
  "libra-temppath 0.1.0",
  "libra-types 0.1.0",

--- a/consensus/Cargo.toml
+++ b/consensus/Cargo.toml
@@ -40,6 +40,7 @@ libra-crypto = { path = "../crypto/crypto", version = "0.1.0" }
 libra-logger = { path = "../common/logger", version = "0.1.0" }
 libra-mempool = { path = "../mempool", version = "0.1.0" }
 libra-metrics = { path = "../common/metrics", version = "0.1.0" }
+libra-secure-storage = { path = "../secure/storage", version = "0.1.0" }
 libra-security-logger = { path = "../common/security-logger", version = "0.1.0" }
 libra-temppath = { path = "../common/temppath", version = "0.1.0" }
 libra-types = { path = "../types", version = "0.1.0" }

--- a/consensus/consensus-types/src/accumulator_extension_proof.rs
+++ b/consensus/consensus-types/src/accumulator_extension_proof.rs
@@ -14,8 +14,7 @@ use std::marker::PhantomData;
 /// A proof that first verifies that establishes correct computation of the root and then
 /// returns the new tree to acquire a new root and version. Note: this is used internally by
 /// VoteProposal hence why it exists within consensus-types andd not libra-types.
-/// @TODO This should contain AccumulatorConsistencyProof once that is code complete
-#[derive(Clone, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct AccumulatorExtensionProof<H> {
     /// Represents the roots of all the full subtrees from left to right in the original accumulator.
     frozen_subtree_roots: Vec<HashValue>,

--- a/consensus/consensus-types/src/quorum_cert.rs
+++ b/consensus/consensus-types/src/quorum_cert.rs
@@ -123,6 +123,7 @@ impl QuorumCert {
         self.ledger_info()
             .verify_signatures(validator)
             .context("Fail to verify QuorumCert")?;
+        self.vote_data.verify()?;
         Ok(())
     }
 }

--- a/consensus/consensus-types/src/vote_data.rs
+++ b/consensus/consensus-types/src/vote_data.rs
@@ -43,6 +43,26 @@ impl VoteData {
     pub fn proposed(&self) -> &BlockInfo {
         &self.proposed
     }
+
+    pub fn verify(&self) -> anyhow::Result<()> {
+        anyhow::ensure!(
+            self.parent.epoch() == self.proposed.epoch(),
+            "Parent and proposed epochs do not match",
+        );
+        anyhow::ensure!(
+            self.parent.round() < self.proposed.round(),
+            "Proposed round is less than parent round",
+        );
+        anyhow::ensure!(
+            self.parent.timestamp_usecs() <= self.proposed.timestamp_usecs(),
+            "Proposed happened before parent",
+        );
+        anyhow::ensure!(
+            self.parent.version() <= self.proposed.version(),
+            "Proposed version is less than parent version",
+        );
+        Ok(())
+    }
 }
 
 impl CryptoHash for VoteData {

--- a/consensus/safety-rules/src/error.rs
+++ b/consensus/safety-rules/src/error.rs
@@ -26,6 +26,12 @@ pub enum Error {
     #[error("No next_validator_set specified in the provided Ledger Info")]
     InvalidLedgerInfo,
 
+    #[error("Invalid QC: {}", {0})]
+    InvalidQuorumCertificate(String),
+
+    #[error("validator_verifier is not set, SafetyRules is not initialized")]
+    NotInitialized,
+
     /// This proposal's round is less than round of preferred block.
     /// Returns the id of the preferred block.
     #[error(

--- a/consensus/safety-rules/src/local_client.rs
+++ b/consensus/safety-rules/src/local_client.rs
@@ -36,10 +36,6 @@ impl<T: Payload> TSafetyRules<T> for LocalClient<T> {
         self.internal.write().unwrap().update(qc)
     }
 
-    fn start_new_epoch(&mut self, qc: &QuorumCert) -> Result<(), Error> {
-        self.internal.write().unwrap().start_new_epoch(qc)
-    }
-
     fn construct_and_sign_vote(&mut self, vote_proposal: &VoteProposal<T>) -> Result<Vote, Error> {
         self.internal
             .write()

--- a/consensus/safety-rules/src/process_client_wrapper.rs
+++ b/consensus/safety-rules/src/process_client_wrapper.rs
@@ -93,10 +93,6 @@ impl<T: Payload> TSafetyRules<T> for ProcessClientWrapper<T> {
         self.safety_rules.update(qc)
     }
 
-    fn start_new_epoch(&mut self, qc: &QuorumCert) -> Result<(), Error> {
-        self.safety_rules.start_new_epoch(qc)
-    }
-
     fn construct_and_sign_vote(&mut self, vote_proposal: &VoteProposal<T>) -> Result<Vote, Error> {
         self.safety_rules.construct_and_sign_vote(vote_proposal)
     }

--- a/consensus/safety-rules/src/safety_rules.rs
+++ b/consensus/safety-rules/src/safety_rules.rs
@@ -23,6 +23,7 @@ use libra_types::{
     validator_change::{ValidatorChangeProof, VerifierType},
     validator_signer::ValidatorSigner,
     validator_verifier::ValidatorVerifier,
+    waypoint::Waypoint,
 };
 use std::marker::PhantomData;
 
@@ -84,6 +85,32 @@ impl<T: Payload> SafetyRules<T> {
     pub fn signer(&self) -> &ValidatorSigner {
         &self.validator_signer
     }
+
+    /// This sets the current validator verifier and updates the epoch and round information
+    /// if this is a new epoch ending ledger info. It also sets the current waypoint to this
+    /// LedgerInfo.
+    fn start_new_epoch(&mut self, ledger_info: &LedgerInfo) -> Result<(), Error> {
+        let validator_set = ledger_info.next_validator_set();
+        self.validator_verifier = Some(validator_set.ok_or(Error::InvalidLedgerInfo)?.into());
+
+        let current_epoch = self.persistent_storage.epoch()?;
+        let next_epoch = ledger_info.epoch() + 1;
+
+        if current_epoch < next_epoch {
+            // This is ordered specifically to avoid configuration issues:
+            // * First set the waypoint to lock in the minimum restarting point,
+            // * set the round information,
+            // * finally, set the epoch information because once the epoch is set, this `if`
+            // statement cannot be re-entered.
+            self.persistent_storage
+                .set_waypoint(&Waypoint::new(ledger_info)?)?;
+            self.persistent_storage.set_last_voted_round(0)?;
+            self.persistent_storage.set_preferred_round(0)?;
+            self.persistent_storage.set_epoch(ledger_info.epoch() + 1)?;
+        }
+
+        Ok(())
+    }
 }
 
 impl<T: Payload> TSafetyRules<T> for SafetyRules<T> {
@@ -101,9 +128,7 @@ impl<T: Payload> TSafetyRules<T> for SafetyRules<T> {
         let last_li = proof
             .verify(&VerifierType::Waypoint(waypoint))
             .map_err(|e| Error::WaypointMismatch(format!("{}", e)))?;
-        let validator_set = last_li.ledger_info().next_validator_set();
-        self.validator_verifier = Some(validator_set.ok_or(Error::InvalidLedgerInfo)?.into());
-        Ok(())
+        self.start_new_epoch(last_li.ledger_info())
     }
 
     /// @TODO verify signatures of the QC, also the special genesis QC
@@ -112,25 +137,16 @@ impl<T: Payload> TSafetyRules<T> for SafetyRules<T> {
     ///     signatures are incorrect,
     ///     epoch is unexpected
     ///     updating to new preferred round
-    /// @TODO update epoch with validator set
     /// @TODO if public key does not match private key in validator set, access persistent storage
     /// to identify new key
     fn update(&mut self, qc: &QuorumCert) -> Result<(), Error> {
-        if qc.parent_block().round() > self.persistent_storage.preferred_round()? {
-            self.persistent_storage
-                .set_preferred_round(qc.parent_block().round())?;
+        let parent_round = qc.parent_block().round();
+        if parent_round > self.persistent_storage.preferred_round()? {
+            self.persistent_storage.set_preferred_round(parent_round)?;
         }
-        Ok(())
-    }
-
-    fn start_new_epoch(&mut self, qc: &QuorumCert) -> Result<(), Error> {
-        if qc.commit_info().epoch() > self.persistent_storage.epoch()? {
-            self.persistent_storage
-                .set_epoch(qc.commit_info().epoch())?;
-            self.persistent_storage.set_last_voted_round(0)?;
-            self.persistent_storage.set_preferred_round(0)?;
+        if qc.ends_epoch() {
+            self.start_new_epoch(qc.ledger_info().ledger_info())?;
         }
-        self.update(qc)?;
         Ok(())
     }
 

--- a/consensus/safety-rules/src/serializer.rs
+++ b/consensus/safety-rules/src/serializer.rs
@@ -16,7 +16,6 @@ pub enum SafetyRulesInput<T> {
     ConsensusState,
     Initialize(Box<ValidatorChangeProof>),
     Update(Box<QuorumCert>),
-    StartNewEpoch(Box<QuorumCert>),
     #[serde(bound = "T: Payload")]
     ConstructAndSignVote(Box<VoteProposal<T>>),
     #[serde(bound = "T: Payload")]
@@ -40,9 +39,6 @@ impl<T: Payload> SerializerService<T> {
             SafetyRulesInput::ConsensusState => lcs::to_bytes(&self.internal.consensus_state()),
             SafetyRulesInput::Initialize(li) => lcs::to_bytes(&self.internal.initialize(&li)),
             SafetyRulesInput::Update(qc) => lcs::to_bytes(&self.internal.update(&qc)),
-            SafetyRulesInput::StartNewEpoch(qc) => {
-                lcs::to_bytes(&self.internal.start_new_epoch(&qc))
-            }
             SafetyRulesInput::ConstructAndSignVote(vote_proposal) => {
                 lcs::to_bytes(&self.internal.construct_and_sign_vote(&vote_proposal))
             }
@@ -90,11 +86,6 @@ impl<T: Payload> TSafetyRules<T> for SerializerClient<T> {
 
     fn update(&mut self, qc: &QuorumCert) -> Result<(), Error> {
         let response = self.request(SafetyRulesInput::Update(Box::new(qc.clone())))?;
-        lcs::from_bytes(&response)?
-    }
-
-    fn start_new_epoch(&mut self, qc: &QuorumCert) -> Result<(), Error> {
-        let response = self.request(SafetyRulesInput::StartNewEpoch(Box::new(qc.clone())))?;
         lcs::from_bytes(&response)?
     }
 

--- a/consensus/safety-rules/src/t_safety_rules.rs
+++ b/consensus/safety-rules/src/t_safety_rules.rs
@@ -21,12 +21,9 @@ pub trait TSafetyRules<T> {
     /// new epoch but SafetyRules did not.
     fn initialize(&mut self, proof: &ValidatorChangeProof) -> Result<(), Error>;
 
-    /// Learn about a new quorum certificate. In normal state, this updates the preferred round,
-    /// if the parent is greater than our current preferred round.
+    /// Learn about a new quorum certificate. This can lead to updating the preferred round or the
+    /// validator verifier if this ends an epoch and increments the epoch as well.
     fn update(&mut self, qc: &QuorumCert) -> Result<(), Error>;
-
-    /// Notify the safety rules about the new epoch start.
-    fn start_new_epoch(&mut self, qc: &QuorumCert) -> Result<(), Error>;
 
     /// Attempts to vote for a given proposal following the voting rules.
     fn construct_and_sign_vote(&mut self, vote_proposal: &VoteProposal<T>) -> Result<Vote, Error>;

--- a/consensus/src/epoch_manager.rs
+++ b/consensus/src/epoch_manager.rs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::{
-    block_storage::{BlockReader, BlockStore},
+    block_storage::BlockStore,
     counters,
     event_processor::{EventProcessor, SyncProcessor, UnverifiedEvent, VerifiedEvent},
     liveness::{
@@ -300,9 +300,6 @@ impl<T: Payload> EpochManager<T> {
         safety_rules
             .initialize(&proofs)
             .expect("Unable to initialize SafetyRules");
-        safety_rules
-            .start_new_epoch(block_store.highest_quorum_cert().as_ref())
-            .expect("Unable to transition SafetyRules to the new epoch");
 
         info!("Create ProposalGenerator");
         // txn manager is required both by proposal generator (to pull the proposers)

--- a/consensus/src/persistent_liveness_storage.rs
+++ b/consensus/src/persistent_liveness_storage.rs
@@ -408,7 +408,8 @@ impl<T: Payload> PersistentLivenessStorage<T> for StorageWriteProxy {
 
     fn retrieve_validator_change_proof(&self, version: u64) -> Result<ValidatorChangeProof> {
         let (latest_lis, mut proofs, _) = self.libra_db.get_state_proof(version)?;
-        if latest_lis.ledger_info().version() == version {
+        // Include the epoch ending LIs as well.
+        if latest_lis.ledger_info().next_validator_set().is_some() {
             proofs.ledger_info_with_sigs.push(latest_lis);
         }
         Ok(proofs)

--- a/consensus/src/test_utils/mock_storage.rs
+++ b/consensus/src/test_utils/mock_storage.rs
@@ -161,16 +161,15 @@ impl<T: Payload> MockStorage<T> {
             lis: Mutex::new(HashMap::new()),
             last_vote: Mutex::new(None),
             highest_timeout_certificate: Mutex::new(None),
-            validator_set,
+            validator_set: validator_set.clone(),
         });
-        let storage = Arc::new(MockStorage::new(Arc::clone(&shared_storage)));
+        let genesis_li = LedgerInfo::mock_genesis(Some(validator_set));
+        let storage = Self::new_with_ledger_info(shared_storage, genesis_li);
+        let recovery_data = storage
+            .start()
+            .expect_recovery_data("Mock storage should never fail constructing recovery data");
 
-        (
-            storage
-                .start()
-                .expect_recovery_data("Mock storage should never fail constructing recovery data"),
-            storage,
-        )
+        (recovery_data, Arc::new(storage))
     }
 }
 


### PR DESCRIPTION
* Unify the 3 methods that care about LIs/QCs to just 2
* Verify QCs and BlockInfos are sane -- probably should also add in LIs to that mix -- next PR!

Because we now verify QCs, SafetyRules /must/ be initialized properly so a good chunk of the PR is spent making our tests more functionally accurate.