### PR TITLE
[epoch proof] make proof inclusive of latest epoch change

### DIFF
--- a/client/cli/src/libra_client.rs
+++ b/client/cli/src/libra_client.rs
@@ -285,24 +285,26 @@ impl LibraClient {
             TrustedStateChange::Epoch {
                 new_state,
                 latest_epoch_change_li,
-                latest_validator_set,
-                ..
             } => {
                 info!(
                     "Verified epoch change to epoch: {}, validator set: [{}]",
                     latest_epoch_change_li.ledger_info().epoch(),
-                    latest_validator_set
+                    latest_epoch_change_li
+                        .ledger_info()
+                        .next_validator_set()
+                        .expect("no validator set in epoch change ledger info"),
                 );
                 // Update client state
                 self.trusted_state = new_state;
                 self.latest_epoch_change_li = Some(latest_epoch_change_li.clone());
             }
-            TrustedStateChange::Version { new_state, .. } => {
+            TrustedStateChange::Version { new_state } => {
                 if self.trusted_state.latest_version() < new_state.latest_version() {
                     info!("Verified version change to: {}", new_state.latest_version());
                 }
                 self.trusted_state = new_state;
             }
+            TrustedStateChange::NoChange => (),
         }
         Ok(())
     }

--- a/consensus/src/persistent_liveness_storage.rs
+++ b/consensus/src/persistent_liveness_storage.rs
@@ -407,11 +407,7 @@ impl<T: Payload> PersistentLivenessStorage<T> for StorageWriteProxy {
     }
 
     fn retrieve_validator_change_proof(&self, version: u64) -> Result<ValidatorChangeProof> {
-        let (latest_lis, mut proofs, _) = self.libra_db.get_state_proof(version)?;
-        // Include the epoch ending LIs as well.
-        if latest_lis.ledger_info().next_validator_set().is_some() {
-            proofs.ledger_info_with_sigs.push(latest_lis);
-        }
+        let (_, proofs, _) = self.libra_db.get_state_proof(version)?;
         Ok(proofs)
     }
 

--- a/execution/executor/tests/db_bootstrapper_test.rs
+++ b/execution/executor/tests/db_bootstrapper_test.rs
@@ -365,7 +365,6 @@ fn test_new_genesis() {
         .get_state_proof(trusted_state.latest_version())
         .unwrap();
     assert_eq!(li.ledger_info().version(), 3);
-    assert!(validator_change_proof.ledger_info_with_sigs.is_empty());
     assert!(accumulator_consistency_proof.subtrees().is_empty());
     trusted_state
         .verify_and_ratchet(&li, &validator_change_proof)

--- a/network/onchain-discovery/src/lib.rs
+++ b/network/onchain-discovery/src/lib.rs
@@ -409,11 +409,10 @@ where
             }
         };
 
-        let new_state = match trusted_state_change {
+        match trusted_state_change {
             TrustedStateChange::Epoch {
                 new_state,
                 latest_epoch_change_li,
-                ..
             } => {
                 info!(
                     "successfully ratcheted to new epoch: \
@@ -422,21 +421,19 @@ where
                     latest_epoch_change_li.ledger_info().epoch(),
                     new_state.latest_version(),
                 );
-                new_state
+                self.trusted_state = new_state;
             }
-            TrustedStateChange::Version { new_state, .. } => {
+            TrustedStateChange::Version { new_state } => {
                 debug!(
                     "successfully ratcheted to new version: \
                      peer: {}, version: {}",
                     peer_id.short_str(),
                     new_state.latest_version(),
                 );
-                new_state
+                self.trusted_state = new_state;
             }
+            TrustedStateChange::NoChange => (),
         };
-
-        // swap in our newly ratcheted trusted state
-        self.trusted_state = new_state;
 
         if let Some(discovery_set_event) = res_msg.event {
             self.handle_new_discovery_set_event(discovery_set_event)

--- a/storage/libradb/src/lib.rs
+++ b/storage/libradb/src/lib.rs
@@ -251,11 +251,9 @@ impl LibraDB {
 
         // TODO: cache last epoch change version to avoid a DB access in most cases.
         let client_epoch = self.ledger_store.get_epoch(client_known_version)?;
-        let validator_change_proof = if client_epoch < ledger_info.epoch() {
-            let (ledger_infos_with_sigs, more) = self.get_epoch_change_ledger_infos(
-                client_epoch,
-                self.ledger_store.get_epoch(ledger_info.version())?,
-            )?;
+        let validator_change_proof = if client_epoch < ledger_info.next_block_epoch() {
+            let (ledger_infos_with_sigs, more) =
+                self.get_epoch_change_ledger_infos(client_epoch, ledger_info.next_block_epoch())?;
             ValidatorChangeProof::new(ledger_infos_with_sigs, more)
         } else {
             ValidatorChangeProof::new(vec![], /* more = */ false)
@@ -742,11 +740,9 @@ impl DbReader for LibraDB {
     ) -> Result<(ValidatorChangeProof, AccumulatorConsistencyProof)> {
         let ledger_info = ledger_info_with_sigs.ledger_info();
         let known_epoch = self.ledger_store.get_epoch(known_version)?;
-        let validator_change_proof = if known_epoch < ledger_info.epoch() {
-            let (ledger_infos_with_sigs, more) = self.get_epoch_change_ledger_infos(
-                known_epoch,
-                self.ledger_store.get_epoch(ledger_info.version())?,
-            )?;
+        let validator_change_proof = if known_epoch < ledger_info.next_block_epoch() {
+            let (ledger_infos_with_sigs, more) =
+                self.get_epoch_change_ledger_infos(known_epoch, ledger_info.next_block_epoch())?;
             ValidatorChangeProof::new(ledger_infos_with_sigs, more)
         } else {
             ValidatorChangeProof::new(vec![], /* more = */ false)

--- a/storage/libradb/src/libradb_test.rs
+++ b/storage/libradb/src/libradb_test.rs
@@ -18,14 +18,10 @@ use proptest::prelude::*;
 use std::{collections::HashMap, convert::TryFrom};
 
 fn verify_epochs(db: &LibraDB, ledger_infos_with_sigs: &[LedgerInfoWithSignatures]) {
-    let (_, latest_li, actual_epoch_change_lis, _) =
-        db.update_to_latest_ledger(0, Vec::new()).unwrap();
+    let (_, _, actual_epoch_change_lis, _) = db.update_to_latest_ledger(0, Vec::new()).unwrap();
     let expected_epoch_change_lis: Vec<_> = ledger_infos_with_sigs
         .iter()
-        .filter(|info| {
-            info.ledger_info().next_validator_set().is_some()
-                && info.ledger_info().epoch() < latest_li.ledger_info().epoch()
-        })
+        .filter(|info| info.ledger_info().next_validator_set().is_some())
         .cloned()
         .collect();
     assert_eq!(

--- a/types/src/block_info.rs
+++ b/types/src/block_info.rs
@@ -118,6 +118,11 @@ impl BlockInfo {
         Self::genesis(*ACCUMULATOR_PLACEHOLDER_HASH, validator_set)
     }
 
+    /// The epoch after this block committed
+    pub fn next_block_epoch(&self) -> u64 {
+        self.epoch() + self.next_validator_set().map_or(0, |_| 1)
+    }
+
     pub fn epoch(&self) -> u64 {
         self.epoch
     }

--- a/types/src/ledger_info.rs
+++ b/types/src/ledger_info.rs
@@ -91,6 +91,10 @@ impl LedgerInfo {
         self.commit_info.epoch()
     }
 
+    pub fn next_block_epoch(&self) -> u64 {
+        self.commit_info.next_block_epoch()
+    }
+
     pub fn round(&self) -> Round {
         self.commit_info.round()
     }

--- a/types/src/validator_change.rs
+++ b/types/src/validator_change.rs
@@ -40,7 +40,9 @@ impl VerifierType {
             VerifierType::TrustedVerifier(epoch_info) => {
                 ensure!(
                     epoch_info.epoch == ledger_info.ledger_info().epoch(),
-                    "LedgerInfo has unexpected epoch"
+                    "LedgerInfo has unexpected epoch {}, expected {}",
+                    ledger_info.ledger_info().epoch(),
+                    epoch_info.epoch
                 );
                 ledger_info.verify_signatures(epoch_info.verifier.as_ref())?;
                 Ok(())
@@ -50,10 +52,10 @@ impl VerifierType {
 
     /// Returns true in case the given epoch is larger than the existing verifier can support.
     /// In this case the ValidatorChangeProof should be verified and the verifier updated.
-    pub fn epoch_change_verification_required(&self, latest_li: &LedgerInfo) -> bool {
+    pub fn epoch_change_verification_required(&self, epoch: u64) -> bool {
         match self {
-            VerifierType::Waypoint(waypoint) => latest_li.version() != waypoint.version(),
-            VerifierType::TrustedVerifier(epoch_info) => epoch_info.epoch < latest_li.epoch(),
+            VerifierType::Waypoint(_) => true,
+            VerifierType::TrustedVerifier(epoch_info) => epoch_info.epoch < epoch,
         }
     }
 


### PR DESCRIPTION
<!--
Thank you for sending a PR. We appreciate you spending time to help improve the Libra project.

The project is undergoing daily changes. Pull Requests will be reviewed and responded to as time permits.
-->

## Motivation

Instead of [client.epoch .. server.epoch], libradb now returns
[client.epoch, server.post_epoch] which is consistent with validators.

Upon an epoch change LI, TrustedState would ratchet to next epoch
verifier which makes it unable to verify the same LI.

We skip the verification of the same version for now, and we'll cache
latest LI and root hash next and guarantee root hash equals if version
equals.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?

Y

## Test Plan

Existing tests.

## Related PRs

(If this PR adds or changes functionality, please take some time to update the docs at https://github.com/libra/website, and link to your PR here.)
