### PR TITLE
Use formally-verified crypto by default

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -323,7 +323,7 @@ jobs:
             RUST_BACKTRACE=1 $CI_TIMEOUT cargo x test --unit
   run-crypto-unit-test:
     executor: test-executor
-    description: Run crypto unit tests
+    description: Run crypto unit tests without formally verified crypto, to insulate against a curve25519 "default" backend regression
     steps:
       - build_setup
       - restore_cargo_package_cache
@@ -332,7 +332,7 @@ jobs:
           command: |
             cd crypto/crypto && \
             RUST_BACKTRACE=1 cargo test \
-              --features='std fiat_u64_backend batch fuzzing' \
+              --features='std u64_backend batch fuzzing' \
               --no-default-features
   run-flaky-unit-test:
     executor: test-executor

--- a/crypto/crypto/Cargo.toml
+++ b/crypto/crypto/Cargo.toml
@@ -48,7 +48,7 @@ sha3 = "0.8.2"
 serde_json = "1.0.51"
 
 [features]
-default = ["std", "batch", "u64_backend"]
+default = ["std", "batch", "fiat_u64_backend"]
 assert-private-keys-not-cloneable = ["static_assertions"]
 cloneable-private-keys = []
 fuzzing = ["proptest", "proptest-derive", "cloneable-private-keys"]


### PR DESCRIPTION
The construction is now full Rust extracted directly from Coq at:
https://github.com/dalek-cryptography/curve25519-dalek/compare/master...calibra:fiat2
which brings in the formally verified code of:
https://github.com/mit-plv/fiat-crypto

This has been unit-tested continuously since last August, without a single break (see the present commit, which switches the place where we used to run those unit tests on formally verified crypto to testing the non-certified dalek backend, to ensure we can always come back to it if we need to).

Our construction is also running in fiat-crypto's continuous integration tests, which protects us from a regression on the Coq side.
https://github.com/mit-plv/fiat-crypto/blob/master/etc/ci/test-fiat-rust.sh

Since this is mature, safer and well-understood, we can switch to using it by default.

