### PR TITLE
[Serde reflection] Add visitors + docs

### DIFF
--- a/common/serde-reflection/src/format.rs
+++ b/common/serde-reflection/src/format.rs
@@ -103,7 +103,7 @@ pub enum VariantFormat {
 
 pub trait FormatHolder {
     /// Visit all the formats in `self` in a depth-first way.
-    fn visit(&self, f: &mut dyn FnMut(&Format) -> Result<()>) -> Result<()>;
+    fn visit<'a>(&'a self, f: &mut dyn FnMut(&'a Format) -> Result<()>) -> Result<()>;
 
     /// Mutably visit all the formats in `self` in a depth-first way.
     fn visit_mut(&mut self, f: &mut dyn FnMut(&mut Format) -> Result<()>) -> Result<()>;
@@ -153,7 +153,7 @@ where
 }
 
 impl FormatHolder for VariantFormat {
-    fn visit(&self, f: &mut dyn FnMut(&Format) -> Result<()>) -> Result<()> {
+    fn visit<'a>(&'a self, f: &mut dyn FnMut(&'a Format) -> Result<()>) -> Result<()> {
         match self {
             Self::Unknown => {
                 return Err(Error::UnknownFormat);
@@ -247,7 +247,7 @@ impl<T> FormatHolder for Named<T>
 where
     T: FormatHolder + std::fmt::Debug,
 {
-    fn visit(&self, f: &mut dyn FnMut(&Format) -> Result<()>) -> Result<()> {
+    fn visit<'a>(&'a self, f: &mut dyn FnMut(&'a Format) -> Result<()>) -> Result<()> {
         self.value.visit(f)
     }
 
@@ -264,7 +264,7 @@ where
 }
 
 impl FormatHolder for ContainerFormat {
-    fn visit(&self, f: &mut dyn FnMut(&Format) -> Result<()>) -> Result<()> {
+    fn visit<'a>(&'a self, f: &mut dyn FnMut(&'a Format) -> Result<()>) -> Result<()> {
         match self {
             Self::UnitStruct => (),
             Self::NewTypeStruct(format) => format.visit(f)?,
@@ -367,7 +367,7 @@ impl FormatHolder for ContainerFormat {
 }
 
 impl FormatHolder for Format {
-    fn visit(&self, f: &mut dyn FnMut(&Format) -> Result<()>) -> Result<()> {
+    fn visit<'a>(&'a self, f: &mut dyn FnMut(&'a Format) -> Result<()>) -> Result<()> {
         match self {
             Self::Unknown => {
                 return Err(Error::UnknownFormat);

--- a/common/serde-reflection/src/lib.rs
+++ b/common/serde-reflection/src/lib.rs
@@ -196,7 +196,8 @@
 //! record formats for all the types that `T` depends on. Besides, if `T` is an enum, it
 //! will record all the variants of `T`.
 //!
-//! (0) Container names must not collide. (TODO: handle this using `std::any::type_name`?)
+//! (0) Container names must not collide. If this happens, consider using `#[serde(rename = "name")]`,
+//! or implementing serde traits manually.
 //!
 //! (1) The first variants of mutually recursive enums must be a "base case". That is,
 //! defaulting to the first variant for every enum type (along with `None` for option values

--- a/common/serde-reflection/tests/format.rs
+++ b/common/serde-reflection/tests/format.rs
@@ -4,6 +4,37 @@
 use serde_reflection::{ContainerFormat, Error, Format, FormatHolder, Named, VariantFormat};
 
 #[test]
+fn test_format_visiting() {
+    use Format::*;
+
+    let format = ContainerFormat::Enum(
+        vec![(
+            0,
+            Named {
+                name: "foo".into(),
+                value: VariantFormat::Tuple(vec![U8, U8, Seq(Box::new(U8))]),
+            },
+        )]
+        .into_iter()
+        .collect(),
+    );
+    let mut counter: usize = 0;
+    format
+        .visit(&mut |format| {
+            match format {
+                U8 => counter += 1,
+                _ => (),
+            }
+            Ok(())
+        })
+        .unwrap();
+    assert_eq!(counter, 3);
+
+    assert!(VariantFormat::Unknown.visit(&mut |_| Ok(())).is_err());
+    assert!(Format::Unknown.visit(&mut |_| Ok(())).is_err());
+}
+
+#[test]
 fn test_format_unification() {
     use Format::*;
 

--- a/common/serde-reflection/tests/format.rs
+++ b/common/serde-reflection/tests/format.rs
@@ -21,9 +21,8 @@ fn test_format_visiting() {
     let mut counter: usize = 0;
     format
         .visit(&mut |format| {
-            match format {
-                U8 => counter += 1,
-                _ => (),
+            if let U8 = format {
+                counter += 1;
             }
             Ok(())
         })


### PR DESCRIPTION
## Motivation

* For code generation, I need generic visitors. This adds them and refactor `normalize`.
* I realized we cannot easily access the fully qualified name of types, so scrape the TODO.

## Testing

```
cargo x test -p serde-reflection
```