### PR TITLE
[json-rpc] Seperate an reusable json-rpc client crate

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,4 +1,4 @@
 # Subscribe to potential API changing PRs
-/json-rpc/src/views.rs @thefallentree @phoenix-antigravity @christinacelee
+/client/json-rpc/src/views.rs @thefallentree @phoenix-antigravity @christinacelee
 # Subscribe to LCS format changes
 /testsuite/generate-format/tests/staged/libra.yaml @thefallentree @matbd

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -691,7 +691,7 @@ dependencies = [
  "libra-canonical-serialization 0.1.0",
  "libra-config 0.1.0",
  "libra-crypto 0.1.0",
- "libra-json-rpc 0.1.0",
+ "libra-json-rpc-client 0.1.0",
  "libra-logger 0.1.0",
  "libra-metrics 0.1.0",
  "libra-temppath 0.1.0",
@@ -2324,6 +2324,7 @@ dependencies = [
  "libra-canonical-serialization 0.1.0",
  "libra-config 0.1.0",
  "libra-crypto 0.1.0",
+ "libra-json-rpc-client 0.1.0",
  "libra-logger 0.1.0",
  "libra-mempool 0.1.0",
  "libra-metrics 0.1.0",
@@ -2332,17 +2333,33 @@ dependencies = [
  "libra-types 0.1.0",
  "libra-workspace-hack 0.1.0",
  "libradb 0.1.0",
- "move-core-types 0.1.0",
  "once_cell 1.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "prometheus 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "proptest 0.9.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "reqwest 0.10.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.106 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.51 (registry+https://github.com/rust-lang/crates.io-index)",
  "storage-interface 0.1.0",
  "tokio 0.2.13 (registry+https://github.com/rust-lang/crates.io-index)",
- "transaction-builder 0.1.0",
  "vm-validator 0.1.0",
  "warp 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "libra-json-rpc-client"
+version = "0.1.0"
+dependencies = [
+ "anyhow 1.0.28 (registry+https://github.com/rust-lang/crates.io-index)",
+ "hex 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libra-canonical-serialization 0.1.0",
+ "libra-crypto 0.1.0",
+ "libra-types 0.1.0",
+ "libra-workspace-hack 0.1.0",
+ "move-core-types 0.1.0",
+ "reqwest 0.10.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.106 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_json 1.0.51 (registry+https://github.com/rust-lang/crates.io-index)",
+ "transaction-builder 0.1.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,6 +6,7 @@ members = [
     "client/cli",
     "client/libra-wallet",
     "client/libra-dev",
+    "client/json-rpc",
     "common/bitvec",
     "common/bounded-executor",
     "common/channel",

--- a/client/cli/Cargo.toml
+++ b/client/cli/Cargo.toml
@@ -34,7 +34,7 @@ crash-handler = { path = "../../common/crash-handler", version = "0.1.0" }
 libra-crypto = { path = "../../crypto/crypto", version = "0.1.0" }
 lcs = { path = "../../common/lcs", version = "0.1.0", package = "libra-canonical-serialization" }
 libra-wallet = { path = "../libra-wallet", version = "0.1.0" }
-libra-json-rpc = { path = "../../json-rpc", version = "0.1.0" }
+libra-json-rpc-client = { path = "../json-rpc", version = "0.1.0" }
 libra-logger =  { path = "../../common/logger", version = "0.1.0" }
 libra-metrics = { path = "../../common/metrics", version = "0.1.0" }
 libra-types = { path = "../../types", version = "0.1.0" }

--- a/client/cli/src/client_proxy.rs
+++ b/client/cli/src/client_proxy.rs
@@ -13,7 +13,7 @@ use libra_crypto::{
     traits::ValidKey,
     x25519, ValidKeyStringExt,
 };
-use libra_json_rpc::views::{AccountView, BlockMetadata, EventView, TransactionView};
+use libra_json_rpc_client::views::{AccountView, BlockMetadata, EventView, TransactionView};
 use libra_logger::prelude::*;
 use libra_temppath::TempPath;
 use libra_types::{

--- a/client/json-rpc/Cargo.toml
+++ b/client/json-rpc/Cargo.toml
@@ -1,0 +1,28 @@
+[package]
+name = "libra-json-rpc-client"
+version = "0.1.0"
+authors = ["Libra Association <opensource@libra.org>"]
+description = "Libra JSONRPC client"
+repository = "https://github.com/libra/libra"
+homepage = "https://libra.org"
+license = "Apache-2.0"
+publish = false
+edition = "2018"
+
+[dependencies]
+anyhow = "1.0"
+hex = "0.4.2"
+reqwest = { version = "0.10.4", features = ["blocking", "json"], default_features = false }
+serde = { version = "1.0.106", default-features = false }
+serde_json = "1.0.51"
+
+lcs = { path = "../../common/lcs", version = "0.1.0", package = "libra-canonical-serialization" }
+libra-types = { path = "../../types", version = "0.1.0" }
+libra-crypto = { path = "../../crypto/crypto", version = "0.1.0" }
+libra-workspace-hack = { path = "../../common/workspace-hack", version = "0.1.0" }
+move-core-types = { path = "../../language/move-core/types", version = "0.1.0" }
+transaction-builder = { path = "../../language/transaction-builder", version = "0.1.0"}
+
+[features]
+default = ["tls"]
+tls = ["reqwest/rustls-tls"]

--- a/client/json-rpc/src/blocking.rs
+++ b/client/json-rpc/src/blocking.rs
@@ -1,0 +1,74 @@
+// Copyright (c) The Libra Core Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::{process_batch_response, JsonRpcBatch, JsonRpcResponse};
+use anyhow::{ensure, format_err, Result};
+use reqwest::{
+    blocking::{Client, ClientBuilder},
+    Url,
+};
+use std::time::Duration;
+
+const JSON_RPC_TIMEOUT_MS: u64 = 5_000;
+const MAX_JSON_RPC_RETRY_COUNT: u64 = 2;
+
+pub struct JsonRpcClient {
+    url: Url,
+    client: Client,
+}
+
+impl JsonRpcClient {
+    pub fn new(url: Url) -> Result<Self> {
+        Ok(Self {
+            client: ClientBuilder::new().use_rustls_tls().build()?,
+            url,
+        })
+    }
+
+    /// Sends a JSON RPC batched request.
+    /// Returns a vector of responses s.t. response order matches the request order
+    pub fn execute(&mut self, batch: JsonRpcBatch) -> Result<Vec<Result<JsonRpcResponse>>> {
+        if batch.requests.is_empty() {
+            return Ok(vec![]);
+        }
+        let request = batch.json_request();
+
+        //retry send
+        let response = self
+            .send_with_retry(request)?
+            .error_for_status()
+            .map_err(|e| format_err!("Server returned error: {:?}", e))?;
+
+        let response = process_batch_response(batch.clone(), response.json()?)?;
+        ensure!(
+            batch.requests.len() == response.len(),
+            "received unexpected number of responses in batch"
+        );
+        Ok(response)
+    }
+
+    // send with retry
+    pub fn send_with_retry(
+        &mut self,
+        request: serde_json::Value,
+    ) -> Result<reqwest::blocking::Response> {
+        let mut response = self.send(&request);
+        let mut try_cnt = 0;
+
+        // retry if send fails
+        while try_cnt < MAX_JSON_RPC_RETRY_COUNT && response.is_err() {
+            response = self.send(&request);
+            try_cnt += 1;
+        }
+        response
+    }
+
+    fn send(&mut self, request: &serde_json::Value) -> Result<reqwest::blocking::Response> {
+        self.client
+            .post(self.url.clone())
+            .json(request)
+            .timeout(Duration::from_millis(JSON_RPC_TIMEOUT_MS))
+            .send()
+            .map_err(Into::into)
+    }
+}

--- a/client/json-rpc/src/client.rs
+++ b/client/json-rpc/src/client.rs
@@ -10,7 +10,7 @@ use crate::{
 };
 use anyhow::{ensure, format_err, Error, Result};
 use libra_types::{account_address::AccountAddress, transaction::SignedTransaction};
-use reqwest::Client;
+use reqwest::{Client, Url};
 use serde_json::{json, Value};
 use std::{collections::HashSet, convert::TryFrom, fmt};
 
@@ -120,9 +120,19 @@ pub struct JsonRpcAsyncClient {
 }
 
 impl JsonRpcAsyncClient {
-    pub fn new(client: Client, host: &str, port: u16) -> Self {
-        let address = format!("http://{}:{}", host, port);
-        Self { address, client }
+    /// Pass in full url for endpoint, supports HTTPS
+    pub fn new(url: Url) -> Self {
+        Self {
+            address: url.to_string(),
+            client: Client::new(),
+        }
+    }
+
+    pub fn new_with_client(client: Client, url: Url) -> Self {
+        Self {
+            address: url.to_string(),
+            client,
+        }
     }
 
     pub async fn get_accounts_state(

--- a/client/json-rpc/src/errors.rs
+++ b/client/json-rpc/src/errors.rs
@@ -47,11 +47,11 @@ impl std::fmt::Display for JsonRpcError {
 }
 
 impl JsonRpcError {
-    pub(crate) fn serialize(self) -> Value {
+    pub fn serialize(self) -> Value {
         serde_json::to_value(self).unwrap_or(Value::Null)
     }
 
-    pub(crate) fn invalid_request() -> Self {
+    pub fn invalid_request() -> Self {
         Self {
             code: -32600,
             message: "Invalid Request".to_string(),
@@ -59,7 +59,7 @@ impl JsonRpcError {
         }
     }
 
-    pub(crate) fn invalid_params() -> Self {
+    pub fn invalid_params() -> Self {
         Self {
             code: -32602,
             message: "Invalid params".to_string(),
@@ -67,7 +67,7 @@ impl JsonRpcError {
         }
     }
 
-    pub(crate) fn method_not_found() -> Self {
+    pub fn method_not_found() -> Self {
         Self {
             code: -32601,
             message: "Method not found".to_string(),
@@ -75,7 +75,7 @@ impl JsonRpcError {
         }
     }
 
-    pub(crate) fn internal_error(message: String) -> Self {
+    pub fn internal_error(message: String) -> Self {
         Self {
             code: ServerCode::DefaultServerError as i16,
             message: format!("Server error: {}", message),
@@ -83,7 +83,7 @@ impl JsonRpcError {
         }
     }
 
-    pub(crate) fn mempool_error(error: MempoolStatus) -> Result<Self> {
+    pub fn mempool_error(error: MempoolStatus) -> Result<Self> {
         let code = match error.code {
             MempoolStatusCode::InvalidSeqNumber => ServerCode::MempoolInvalidSeqNumber,
             MempoolStatusCode::MempoolIsFull => ServerCode::MempoolIsFull,
@@ -108,7 +108,7 @@ impl JsonRpcError {
         })
     }
 
-    pub(crate) fn vm_error(error: VMStatus) -> Self {
+    pub fn vm_error(error: VMStatus) -> Self {
         // map VM status to custom server code
         let vm_status_type = error.status_type();
         let code = match vm_status_type {

--- a/client/json-rpc/src/lib.rs
+++ b/client/json-rpc/src/lib.rs
@@ -1,0 +1,14 @@
+// Copyright (c) The Libra Core Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+mod blocking;
+mod client;
+
+pub mod errors;
+pub mod views;
+
+pub use blocking::JsonRpcClient;
+pub use client::{
+    get_response_from_batch, process_batch_response, JsonRpcAsyncClient, JsonRpcBatch,
+    JsonRpcResponse,
+};

--- a/client/json-rpc/src/views.rs
+++ b/client/json-rpc/src/views.rs
@@ -1,7 +1,7 @@
 // Copyright (c) The Libra Core Contributors
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::JsonRpcResponse;
+use crate::client::JsonRpcResponse;
 use anyhow::{format_err, Error, Result};
 use hex;
 use libra_crypto::HashValue;

--- a/json-rpc/Cargo.toml
+++ b/json-rpc/Cargo.toml
@@ -11,17 +11,20 @@ edition = "2018"
 
 [dependencies]
 anyhow = "1.0"
+futures = "0.3.0"
 hex = "0.4.2"
+once_cell = "1.3.1"
+prometheus = { version = "0.8.0", default-features = false }
+reqwest = { version = "0.10.4", features = ["blocking", "json"], default_features = false }
 serde_json = "1.0.51"
 serde = { version = "1.0.106", default-features = false }
-warp = "0.2.2"
-futures = "0.3.0"
-reqwest = { version = "0.10.4", features = ["blocking", "json"], default_features = false }
 tokio = { version = "0.2.13", features = ["full"] }
-once_cell = "1.3.1"
+warp = "0.2.2"
 
-proptest = { version = "0.9.6", optional = true }
+client = { path = "../client/json-rpc", version = "0.1.0", package = "libra-json-rpc-client" }
+debug-interface = { path = "../common/debug-interface", version = "0.1.0" }
 lcs = { path = "../common/lcs", version = "0.1.0", package = "libra-canonical-serialization" }
+libradb = { path = "../storage/libradb", version = "0.1.0" }
 libra-config = { path = "../config", version = "0.1.0" }
 libra-crypto = { path = "../crypto/crypto", version = "0.1.0" }
 libra-logger = { path = "../common/logger", version = "0.1.0" }
@@ -29,13 +32,10 @@ libra-mempool = { path = "../mempool", version = "0.1.0" }
 libra-metrics = { path = "../common/metrics", version = "0.1.0" }
 libra-proptest-helpers = { path = "../common/proptest-helpers", optional = true }
 libra-types = { path = "../types", version = "0.1.0" }
-libra-workspace-hack = { path = "../common/workspace-hack", version = "0.1.0" }
-libradb = { path = "../storage/libradb", version = "0.1.0" }
-move-core-types = { path = "../language/move-core/types", version = "0.1.0" }
-storage-interface = { path = "../storage/storage-interface", version = "0.1.0" }
-transaction-builder = { path = "../language/transaction-builder", version = "0.1.0"}
-debug-interface = { path = "../common/debug-interface", version = "0.1.0" }
 libra-temppath = { path = "../common/temppath", version = "0.1.0", optional = true }
+libra-workspace-hack = { path = "../common/workspace-hack", version = "0.1.0" }
+proptest = { version = "0.9.6", optional = true }
+storage-interface = { path = "../storage/storage-interface", version = "0.1.0" }
 
 [dev-dependencies]
 vm-validator = { path = "../vm-validator", version = "0.1.0" }

--- a/json-rpc/src/lib.rs
+++ b/json-rpc/src/lib.rs
@@ -10,19 +10,19 @@
 //!
 //! Module organization:
 //! ├── methods.rs        # contains all available JSON RPC method handlers
-//! ├── views.rs          # custom JSON serializers for Libra data types
 //! ├── runtime.rs        # implementation of JSON RPC protocol over HTTP
 //! ├── tests.rs          # tests
 
 #[macro_use]
 mod util;
 
-mod client;
+extern crate prometheus;
+
 mod counters;
-pub mod errors;
 mod methods;
 mod runtime;
-pub mod views;
+
+pub use client::{errors, views};
 
 pub use client::{
     get_response_from_batch, process_batch_response, JsonRpcAsyncClient, JsonRpcBatch,

--- a/testsuite/cluster-test/src/tx_emitter.rs
+++ b/testsuite/cluster-test/src/tx_emitter.rs
@@ -37,9 +37,10 @@ use tokio::runtime::{Handle, Runtime};
 use futures::{executor::block_on, future::FutureExt};
 use libra_json_rpc::JsonRpcAsyncClient;
 use libra_types::transaction::SignedTransaction;
-use reqwest::Client;
+use reqwest::{Client, Url};
 use std::{
     cmp::{max, min},
+    str::FromStr,
     sync::atomic::{AtomicBool, AtomicU64, Ordering},
 };
 use tokio::{task::JoinHandle, time};
@@ -305,10 +306,10 @@ impl TxEmitter {
     }
 
     fn make_client(&self, instance: &Instance) -> JsonRpcAsyncClient {
-        JsonRpcAsyncClient::new(
+        JsonRpcAsyncClient::new_with_client(
             self.http_client.clone(),
-            instance.ip(),
-            instance.ac_port() as u16,
+            Url::from_str(format!("http://{}:{}", instance.ip(), instance.ac_port()).as_str())
+                .expect("Invalid URL."),
         )
     }
 


### PR DESCRIPTION
create an reusable json-rpc client crate that could be used for consuming json-rpc service.

No behavior change, just moving stuff around.