### PR TITLE
[types/language] Update default gas price for testing to be 0

### DIFF
--- a/execution/executor/tests/storage_integration_test.rs
+++ b/execution/executor/tests/storage_integration_test.rs
@@ -582,7 +582,7 @@ fn test_execution_with_storage() {
             lbr_type_tag(),
             &account1,
             account1_auth_key.prefix().to_vec(),
-            20_000_000,
+            2_000_000,
         )),
     );
 
@@ -596,7 +596,7 @@ fn test_execution_with_storage() {
             lbr_type_tag(),
             &account2,
             account2_auth_key.prefix().to_vec(),
-            10_200_000,
+            1_200_000,
         )),
     );
 
@@ -610,7 +610,7 @@ fn test_execution_with_storage() {
             lbr_type_tag(),
             &account3,
             account3_auth_key.prefix().to_vec(),
-            10_000_000,
+            1_000_000,
         )),
     );
 
@@ -754,19 +754,19 @@ fn test_execution_with_storage() {
         .reader
         .get_account_state_with_proof(account1, current_version, current_version)
         .unwrap();
-    verify_account_balance(&account1_state_with_proof, |x| x < 19_910_000).unwrap();
+    verify_account_balance(&account1_state_with_proof, |x| x == 1_910_000).unwrap();
 
     let account2_state_with_proof = db
         .reader
         .get_account_state_with_proof(account2, current_version, current_version)
         .unwrap();
-    verify_account_balance(&account2_state_with_proof, |x| x < 10_060_000).unwrap();
+    verify_account_balance(&account2_state_with_proof, |x| x == 1_210_000).unwrap();
 
     let account3_state_with_proof = db
         .reader
         .get_account_state_with_proof(account3, current_version, current_version)
         .unwrap();
-    verify_account_balance(&account3_state_with_proof, |x| x == 10_080_000).unwrap();
+    verify_account_balance(&account3_state_with_proof, |x| x == 1_080_000).unwrap();
 
     let transaction_list_with_proof = db
         .reader
@@ -861,13 +861,13 @@ fn test_execution_with_storage() {
         .reader
         .get_account_state_with_proof(account1, current_version, current_version)
         .unwrap();
-    verify_account_balance(&account1_state_with_proof, |x| x < 18_000_000).unwrap();
+    verify_account_balance(&account1_state_with_proof, |x| x == 1_770_000).unwrap();
 
     let account3_state_with_proof = db
         .reader
         .get_account_state_with_proof(account3, current_version, current_version)
         .unwrap();
-    verify_account_balance(&account3_state_with_proof, |x| x == 10_220_000).unwrap();
+    verify_account_balance(&account3_state_with_proof, |x| x == 1_220_000).unwrap();
 
     let transaction_list_with_proof = db
         .reader

--- a/language/ir-testsuite/tests/epilogue/charge_less_gas_for_less_work.mvir
+++ b/language/ir-testsuite/tests/epilogue/charge_less_gas_for_less_work.mvir
@@ -2,6 +2,7 @@
 //! account: bob, 10000
 
 //! sender: alice
+//! gas-price: 1
 main() {
     return;
 }
@@ -9,6 +10,7 @@ main() {
 
 //! new-transaction
 //! sender: bob
+//! gas-price: 1
 main() {
     let x: u64;
     x = 1 + 2 + 3;

--- a/language/ir-testsuite/tests/epilogue/charge_more_gas_on_tx_script_failure.mvir
+++ b/language/ir-testsuite/tests/epilogue/charge_more_gas_on_tx_script_failure.mvir
@@ -2,6 +2,7 @@
 //! account: bob, 10000
 
 //! sender: alice
+//! gas-price: 1
 //! args: 0
 main(abrt: u64) {
     assert(move(abrt) == 0, 77);
@@ -13,6 +14,7 @@ main(abrt: u64) {
 
 //! new-transaction
 //! sender: bob
+//! gas-price: 1
 //! args: 1
 main(abrt: u64) {
     assert(move(abrt) == 0, 78);

--- a/language/ir-testsuite/tests/epilogue/good_transaction_consumes_gas_less_than_or_equal_to_set_maximum.mvir
+++ b/language/ir-testsuite/tests/epilogue/good_transaction_consumes_gas_less_than_or_equal_to_set_maximum.mvir
@@ -1,5 +1,6 @@
 //! account: default, 10000, 0
 
+//! gas-price: 1
 //! max-gas: 5000
 main() {
     return;

--- a/language/ir-testsuite/tests/epilogue/loop_out_of_gas.mvir
+++ b/language/ir-testsuite/tests/epilogue/loop_out_of_gas.mvir
@@ -1,5 +1,6 @@
 //! account: default, 100000
 
+//! gas-price: 1
 //! max-gas: 10000
 main() {
     loop {}

--- a/language/ir-testsuite/tests/epilogue/recursion_out_of_gas.mvir
+++ b/language/ir-testsuite/tests/epilogue/recursion_out_of_gas.mvir
@@ -9,6 +9,7 @@ module M {
 
 
 //! new-transaction
+//! gas-price: 1
 //! max-gas: 5000
 import {{default}}.M;
 

--- a/language/ir-testsuite/tests/epilogue/revert_tx_script_state_changes_after_failed_epilogue.mvir
+++ b/language/ir-testsuite/tests/epilogue/revert_tx_script_state_changes_after_failed_epilogue.mvir
@@ -8,6 +8,7 @@
 // changes and re-execute the epilogue. Alice will still be charged for the gas she used.
 
 //! sender: alice
+//! gas-price: 1
 //! args: 1000000
 import 0x0.LibraAccount;
 import 0x0.LBR;
@@ -27,6 +28,7 @@ main(amount: u64) {
 
 //! new-transaction
 //! sender: bob
+//! gas-price: 1
 //! args: 1000
 import 0x0.LibraAccount;
 import 0x0.LBR;

--- a/language/ir-testsuite/tests/epilogue/while_out_of_gas.mvir
+++ b/language/ir-testsuite/tests/epilogue/while_out_of_gas.mvir
@@ -1,5 +1,6 @@
 //! account: default, 100000
 
+//! gas-price: 1
 //! max-gas: 10000
 main() {
     while(true) {}

--- a/language/ir-testsuite/tests/examples/gas_submitted_too_low.mvir
+++ b/language/ir-testsuite/tests/examples/gas_submitted_too_low.mvir
@@ -3,6 +3,7 @@
 // this sets up Alice's account with very low balance, which is not sufficient to cover the gas cost
 
 //! sender: Alice
+//! max-gas: 10
 main() {
     let x: u64;
     let y: u64;

--- a/language/ir-testsuite/tests/prologue/fail_if_cant_pay_deposit.mvir
+++ b/language/ir-testsuite/tests/prologue/fail_if_cant_pay_deposit.mvir
@@ -1,5 +1,6 @@
 //! account: default, 5000
 
+//! gas-price: 1
 //! max-gas: 5001
 main() {
     return;

--- a/language/ir-testsuite/tests/transaction_fee_distribution/test_txn_fee_collection.mvir
+++ b/language/ir-testsuite/tests/transaction_fee_distribution/test_txn_fee_collection.mvir
@@ -1,6 +1,7 @@
 //! account: alice, 90000
 
 //! sender: alice
+//! gas-price: 1
 
 import 0x0.LibraAccount;
 import 0x0.LBR;

--- a/language/move-lang/tests/functional/compare/set.move
+++ b/language/move-lang/tests/functional/compare/set.move
@@ -91,7 +91,6 @@ fun main() {
 // check: 999
 
 //! new-transaction
-//! max-gas: 1000000
 //! gas-price: 0
 use {{default}}::Set;
 use 0x0::Transaction;

--- a/language/move-lang/tests/functional/libra/swap_into_libra.move
+++ b/language/move-lang/tests/functional/libra/swap_into_libra.move
@@ -44,7 +44,6 @@ fun main() {
 
 //! new-transaction
 //! sender: alice
-//! max-gas: 100000
 //! gas-price: 0
 use {{default}}::MultiCurrencyAccount;
 // Now add coin1 (alice's) account to the multi currency account in bob's
@@ -55,7 +54,6 @@ fun main() {
 
 //! new-transaction
 //! sender: cody
-//! max-gas: 100000
 //! gas-price: 0
 use {{default}}::MultiCurrencyAccount;
 // Now add coin1 (alice's) account to the multi currency account in bob's
@@ -67,7 +65,6 @@ fun main() {
 // Now mint LBR to bob's account
 //! new-transaction
 //! sender: bob
-//! max-gas: 1000000
 //! gas-price: 0
 use 0x0::Coin1;
 use 0x0::Coin2;
@@ -93,7 +90,6 @@ fun main() {
 // Now mint LBR to bob's account
 //! new-transaction
 //! sender: bob
-//! max-gas: 1000000
 //! gas-price: 0
 use 0x0::LBR;
 use 0x0::LibraAccount;

--- a/language/move-lang/tests/functional/libra_account/freezing.move
+++ b/language/move-lang/tests/functional/libra_account/freezing.move
@@ -68,7 +68,6 @@ fun main() {
 //! new-transaction
 //! sender: vasp
 //! gas-price: 0
-//! max-gas: 1000000
 use 0x0::VASP;
 use 0x0::LCS;
 fun main() {
@@ -94,7 +93,6 @@ fun main() {
 //! new-transaction
 //! sender: vasp
 //! gas-price: 0
-//! max-gas: 1000000
 fun main() {
     0x0::VASP::allow_child_accounts();
 }
@@ -103,7 +101,6 @@ fun main() {
 //! new-transaction
 //! sender: childvasp
 //! gas-price: 0
-//! max-gas: 1000000
 fun main() {
     0x0::VASP::apply_for_child_vasp_credential({{vasp}});
 }
@@ -112,7 +109,6 @@ fun main() {
 //! new-transaction
 //! sender: vasp
 //! gas-price: 0
-//! max-gas: 1000000
 fun main() {
     0x0::VASP::grant_child_account({{childvasp}});
 }

--- a/types/src/test_helpers/transaction_test_helpers.rs
+++ b/types/src/test_helpers/transaction_test_helpers.rs
@@ -10,7 +10,7 @@ use libra_crypto::{ed25519::*, hash::CryptoHash, traits::*};
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
 const MAX_GAS_AMOUNT: u64 = 1_000_000;
-const MAX_GAS_PRICE: u64 = 1;
+const TEST_GAS_PRICE: u64 = 0;
 
 static EMPTY_SCRIPT: &[u8] =
     include_bytes!("../../../language/stdlib/staged/transaction_scripts/empty_script.mv");
@@ -33,7 +33,7 @@ pub fn get_test_signed_module_publishing_transaction(
         sequence_number,
         module,
         MAX_GAS_AMOUNT,
-        MAX_GAS_PRICE,
+        TEST_GAS_PRICE,
         Duration::from_secs(expiration_time),
     );
 
@@ -113,7 +113,7 @@ pub fn get_test_signed_txn(
         public_key,
         script,
         expiration_time,
-        MAX_GAS_PRICE,
+        TEST_GAS_PRICE,
         None,
     )
 }
@@ -137,7 +137,7 @@ pub fn get_test_unchecked_txn(
         public_key,
         script,
         expiration_time,
-        MAX_GAS_PRICE,
+        TEST_GAS_PRICE,
         None,
     )
 }


### PR DESCRIPTION
Non-zero gas prices were causing lots of changes to need to be made to tests unrelated to gas whenever modules were updated. This PR updates tests so that the default gas price is zero so that these updates won't be needed in the future. 

