### PR TITLE
[Storage] Breaking: disable all RocksDB compressions other than lz4

### DIFF
--- a/storage/schemadb/Cargo.toml
+++ b/storage/schemadb/Cargo.toml
@@ -14,7 +14,11 @@ anyhow = "1.0"
 once_cell = "1.3.1"
 libra-metrics = { path = "../../common/metrics", version = "0.1.0" }
 libra-workspace-hack = { path = "../../common/workspace-hack", version = "0.1.0" }
-rocksdb = "0.14"
+
+[dependencies.rocksdb]
+version = "0.14"
+default-features = false
+features = ["lz4"]
 
 [dev-dependencies]
 byteorder = "1.3.2"

--- a/storage/schemadb/src/lib.rs
+++ b/storage/schemadb/src/lib.rs
@@ -211,7 +211,15 @@ impl DB {
         path: impl AsRef<Path>,
         column_families: Vec<ColumnFamilyName>,
     ) -> Result<DB> {
-        let inner = rocksdb::DB::open_cf(opts, path, &column_families)?;
+        let inner = rocksdb::DB::open_cf_descriptors(
+            opts,
+            path,
+            column_families.iter().map(|cf_name| {
+                let mut cf_opts = rocksdb::Options::default();
+                cf_opts.set_compression_type(rocksdb::DBCompressionType::Lz4);
+                rocksdb::ColumnFamilyDescriptor::new((*cf_name).to_string(), cf_opts)
+            }),
+        )?;
         Ok(DB {
             inner,
             column_families,


### PR DESCRIPTION
Should theoretically reduce a few dependencies. At least we don't need to build snappy/zlib/zstd/bzip2.

The default compression method was snappy. I think using lz4 for now is probably good enough.