### PR TITLE
[move-prover] Finishing pragma implementation and introducing `pragma verify`

### DIFF
--- a/language/move-prover/spec-lang/src/ast.rs
+++ b/language/move-prover/spec-lang/src/ast.rs
@@ -46,7 +46,7 @@ pub struct SpecFunDecl {
 // =================================================================================================
 /// # Conditions
 
-#[derive(Debug, PartialEq, Clone, Copy)]
+#[derive(Debug, PartialEq, Eq, Clone, Copy, PartialOrd, Ord)]
 pub enum SpecConditionKind {
     Assert,
     Assume,
@@ -102,16 +102,29 @@ pub struct Condition {
     pub exp: Exp,
 }
 
+/// Specification and properties associated with a function.
 #[derive(Debug, Default)]
 pub struct FunSpec {
     pub on_decl: Vec<Condition>,
     pub on_impl: BTreeMap<CodeOffset, Vec<Condition>>,
+    pub properties_on_decl: PropertyBag,
+    pub properties_on_impl: BTreeMap<CodeOffset, PropertyBag>,
 }
+
+/// Specification and properties associated with a struct.
+#[derive(Debug, Default)]
+pub struct StructSpec {
+    pub invariants: BTreeMap<InvariantKind, Vec<Invariant>>,
+    pub properties: PropertyBag,
+}
+
+/// A set of properties stemming from pragmas.
+pub type PropertyBag = BTreeMap<Symbol, Value>;
 
 // =================================================================================================
 /// # Invariants
 
-#[derive(Debug, PartialEq, Clone, Copy)]
+#[derive(Debug, PartialEq, Eq, Clone, Copy, PartialOrd, Ord)]
 pub enum InvariantKind {
     Data,
     Update,
@@ -270,6 +283,7 @@ pub enum Value {
     Address(BigUint),
     Number(BigUint),
     Bool(bool),
+    ByteArray(Vec<u8>),
 }
 
 // =================================================================================================

--- a/language/move-prover/src/spec_translator.rs
+++ b/language/move-prover/src/spec_translator.rs
@@ -12,9 +12,9 @@ use spec_lang::{
 
 use crate::{
     boogie_helpers::{
-        boogie_declare_global, boogie_field_name, boogie_global_declarator, boogie_local_type,
-        boogie_spec_fun_name, boogie_spec_var_name, boogie_struct_name, boogie_type_value,
-        boogie_well_formed_expr, WellFormedMode,
+        boogie_byte_blob, boogie_declare_global, boogie_field_name, boogie_global_declarator,
+        boogie_local_type, boogie_spec_fun_name, boogie_spec_var_name, boogie_struct_name,
+        boogie_type_value, boogie_well_formed_expr, WellFormedMode,
     },
     code_writer::CodeWriter,
 };
@@ -784,6 +784,7 @@ impl<'env> SpecTranslator<'env> {
             Value::Address(addr) => emit!(self.writer, "Address({})", addr),
             Value::Number(val) => emit!(self.writer, "Integer({})", val),
             Value::Bool(val) => emit!(self.writer, "Boolean({})", val),
+            Value::ByteArray(val) => emit!(self.writer, &boogie_byte_blob(val)),
         }
     }
 

--- a/language/move-prover/tests/README.md
+++ b/language/move-prover/tests/README.md
@@ -1,12 +1,42 @@
 # Tests for Move Prover
 
-This directory contains the tests for Move Prover (or Prover for short). More specifically, `sources/stdlib/modules/` contains the clones of the current Move standard modules. `sources/` contains various Move functions (with specifications) to test Prover. The functions are grouped into different `.move` files in the directory, and further grouped into sections within a file divided by the dashed comment line (e.g., `// ----`). Please see `source/arithm.move` for example.
+This directory contains the tests for Move Prover (or Prover for short). More specifically, `sources/stdlib/modules/`
+contains the clones of the current Move standard modules. `sources/` contains various Move functions
+(with specifications) to test Prover. The functions are grouped into different `.move` files in the directory,
+and further grouped into sections within a file divided e.g. by a dashed comment line (e.g., `// ----`).
+Please see `source/arithm.move` for example.
 
-There is a convention for test cases under this directory. First of all, all functions defined as test cases should be valid, passing the syntax & type check. In addition, there are two kinds of test cases, which can be mixed in a file. The first type of test cases are "correct" Move functions which are expected to be proved by Prover. Another type of test cases are incorrect Move functions which are expected to be disproved by Prover. The incorrect functions have suffix `_incorrect` in their names for indication (this indication is currently for humans, not for the automated test infrastructure).
+There is a convention for test cases under this directory. First of all, all functions defined as test cases should
+be valid, passing the syntax & type check. In addition, there are two kinds of test cases, which can be
+mixed in a file. The first type of test cases are "correct" Move functions which are expected to be proved by Prover.
+Another type of test cases are incorrect Move functions which are expected to be disproved by Prover.
+The incorrect functions have suffix `_incorrect` in their names for indication (this indication is currently for
+humans, not for the automated test infrastructure).
 
-`cargo test` will automatically detect all `.move` files under this directory and let Prover attempt to prove each file, i.e., every function defeind in the file. Unlike `cargo run`, `cargo test` can also detect the line "`// dep: {file_to_import}`" in the `.move` file under test, and import other `.move` files accordingly. For each `.move` file, there is a corresponding baseline flie (`.exp`) which stores the expected Prover's output for the `.move` file. `cargo test` invokes Prover against each `.move` file, and examine the output of Prover. The test is considered to "fail" if the output of Prover is different from the expected output stored in the corresponding `.exp` file. To update the baseline file, run the test with setting the env variable `UPBL=1` (i.e., run `UPBL=1 cargo test`). Also, one can run the indivisual test by giving a specific filename (for example, `cargo test arithm.move`, and `UPBL=1 cargo test arithm.move`). Note that Prover currently skips proving some functions such as the native functions and the functions in stanard vector module (`sources/stdlib/modules/vector.move`) even though these functions come with specifications. Prover also skips verifying the files which contains the line "`// no-verify`".
+`cargo test` will automatically detect all `.move` files under this directory and its sub-directories and let the Prover
+attempt to prove each function in the file. Unlike `cargo run`, `cargo test` can detect various directives
+in comments in the move source:
 
-Lastly, if the environment variables such as `BOOGIE_EXE` and `Z3_EXE` are not defined, `cargo test` will only partially test Prover without invoking Boogie (e.g., only testing the translation to Boogie). The instruction on how to set the environment variables can be found in `../scripts/README.md`.
+- The line `// dep: <path-to-file>` indicates a dependency of this test which is automatically added to the set
+  of sources. The path provided is relative to the root of the crate.
+- The line `// flag: <flag>` provides a flag to the Prover (see `cargo run -- --help` for  available flags). For
+  example, use  `// flag: --verify=public` to restrict verification to public functions (by default, tests use
+  `--verify=all`, or `// flag: --boogie=-noVerify` to turn off Boogie verification.
+- The line `// no-boogie-test` instructs the test driver to not attempt to run boogie at all. This is to support
+  negative tests where translation to boogie actually fails.
+
+For each `.move` file, there is a corresponding baseline file (`.exp`) which stores the expected Prover's output
+for the `.move` file. `cargo test` invokes Prover against each `.move` file, and examine the output of Prover.
+The test is considered to "fail" if the output of Prover is different from the expected output stored in the
+corresponding `.exp` file. To update the baseline file, run the test with setting the env variable `UPBL=1`
+(i.e., run `UPBL=1 cargo test`). Also, one can run the individual test by giving a specific filename
+(for example, `cargo test arithm.move`, and `UPBL=1 cargo test arithm.move`). Note that Prover currently skips
+proving some functions such as the native functions and the functions in stanard vector module
+(`sources/stdlib/modules/vector.move`) even though these functions come with specifications.
+
+Lastly, if the environment variables such as `BOOGIE_EXE` and `Z3_EXE` are not defined, `cargo test` will only
+partially test Prover without invoking Boogie (e.g., only testing the translation to Boogie). The
+instruction on how to set the environment variables can be found in `../scripts/README.md`.
 
 
 ## Code coverage
@@ -14,8 +44,11 @@ Lastly, if the environment variables such as `BOOGIE_EXE` and `Z3_EXE` are not d
 Analyzing the test coverage of the libra repo is regularly done in CI, and the result updates the online report at
 * https://codecov.io/gh/libra/libra
 
-Note that this report is based on the the coverage test when the environment variable `BOOGIE_EXE` is not set. So, the coverage result may not be as accurate as expected because all verifications with Boogie/Z3 are skipped during the test.
+Note that this report is based on the the coverage test when the environment variable `BOOGIE_EXE` is not set.
+So, the coverage result may not be as accurate as expected because all verifications with Boogie/Z3 are skipped
+during the test.
 
-To run the coverage test locally, one can use `scripts/coverage_report.sh`. However, note that there seems to be a small accuracy issue here too because some coverage lines are spilled in `lcov` conversion from `grcov`.
+To run the coverage test locally, one can use `scripts/coverage_report.sh`. However, note that there seems to be
+a small accuracy issue here too because some coverage lines are spilled in `lcov` conversion from `grcov`.
 
 For any questions regarding code coverage, please use the Calibra slack channel "#code_coverage".

--- a/language/move-prover/tests/sources/pragma.exp
+++ b/language/move-prover/tests/sources/pragma.exp
@@ -1,0 +1,12 @@
+Move prover returns: exiting with boogie verification errors
+error:  A postcondition might not hold on this return path.
+
+    ┌── tests/sources/pragma.move:15:9 ───
+    │
+ 15 │         aborts_if _c;
+    │         ^^^^^^^^^^^^^
+    │
+    =     at tests/sources/pragma.move:10:5: always_aborts_with_verify_incorrect (entry)
+    =     at tests/sources/pragma.move:11:9: always_aborts_with_verify_incorrect
+    =         _c = <redacted>
+    =     at tests/sources/pragma.move:10:5: always_aborts_with_verify_incorrect (exit)

--- a/language/move-prover/tests/sources/pragma.move
+++ b/language/move-prover/tests/sources/pragma.move
@@ -1,0 +1,25 @@
+// Tests pragmas.
+
+module TestPragma {
+
+    spec module {
+        // if not specified otherwise, verification is off.
+        pragma verify=false;
+    }
+
+    fun always_aborts_with_verify_incorrect(_c: bool) {
+        abort(1)
+    }
+    spec fun always_aborts_with_verify_incorrect {
+        pragma verify=true;
+        aborts_if _c;
+    }
+
+    fun always_aborts_without_verify(_c: bool) {
+        abort(1)
+    }
+    spec fun always_aborts_without_verify {
+        // Will not be flagged because we have verify=false on module level
+        aborts_if _c;
+    }
+}

--- a/language/move-prover/tests/sources/stdlib/modules/approved_payment.move
+++ b/language/move-prover/tests/sources/stdlib/modules/approved_payment.move
@@ -8,7 +8,7 @@
 // dep: tests/sources/stdlib/modules/libra_transaction_timeout.move
 // dep: tests/sources/stdlib/modules/libra_time.move
 // dep: tests/sources/stdlib/modules/hash.move
-// no-verify
+// flag: --verify=none
 
 // Module that allows a payee to approve payments with a cryptographic signature. The basic flow is:
 // (1) Payer sends `metadata` to the payee

--- a/language/move-prover/tests/sources/stdlib/modules/fixedpoint32.move
+++ b/language/move-prover/tests/sources/stdlib/modules/fixedpoint32.move
@@ -1,6 +1,6 @@
 // dep: tests/sources/stdlib/modules/transaction.move
+// flag: --verify=none
 // requires shift-left and shift-right which are currently not implemented in prelude
-// no-verify
 
 address 0x0:
 

--- a/language/move-prover/tests/sources/stdlib/modules/libra_account.move
+++ b/language/move-prover/tests/sources/stdlib/modules/libra_account.move
@@ -6,7 +6,7 @@
 // dep: tests/sources/stdlib/modules/transaction.move
 // dep: tests/sources/stdlib/modules/vector.move
 // dep: tests/sources/stdlib/modules/libra_time.move
-// no-verify
+// flag: --verify=none
 
 address 0x0:
 

--- a/language/move-prover/tests/sources/stdlib/modules/libra_block.move
+++ b/language/move-prover/tests/sources/stdlib/modules/libra_block.move
@@ -10,7 +10,7 @@
 // dep: tests/sources/stdlib/modules/hash.move
 // dep: tests/sources/stdlib/modules/lcs.move
 // dep: tests/sources/stdlib/modules/libra_transaction_timeout.move
-// no-verify
+// flag: --verify=none
 
 address 0x0:
 

--- a/language/move-prover/tests/sources/stdlib/modules/libra_configs.move
+++ b/language/move-prover/tests/sources/stdlib/modules/libra_configs.move
@@ -9,7 +9,7 @@
 // dep: tests/sources/stdlib/modules/vector.move
 // dep: tests/sources/stdlib/modules/libra_time.move
 // dep: tests/sources/stdlib/modules/validator_config.move
-// no-verify
+// flag: --verify=none
 
 address 0x0:
 module LibraConfig {

--- a/language/move-prover/tests/sources/stdlib/modules/libra_system.move
+++ b/language/move-prover/tests/sources/stdlib/modules/libra_system.move
@@ -8,7 +8,7 @@
 // dep: tests/sources/stdlib/modules/vector.move
 // dep: tests/sources/stdlib/modules/libra_time.move
 // dep: tests/sources/stdlib/modules/validator_config.move
-// no-verify
+// flag: --verify=none
 
 address 0x0:
 

--- a/language/move-prover/tests/sources/stdlib/modules/script_whitelist.move
+++ b/language/move-prover/tests/sources/stdlib/modules/script_whitelist.move
@@ -10,7 +10,7 @@
 // dep: tests/sources/stdlib/modules/vector.move
 // dep: tests/sources/stdlib/modules/libra_time.move
 // dep: tests/sources/stdlib/modules/validator_config.move
-// no-verify
+// flag: --verify=none
 
 address 0x0:
 

--- a/language/move-prover/tests/sources/stdlib/modules/transaction_fee.move
+++ b/language/move-prover/tests/sources/stdlib/modules/transaction_fee.move
@@ -9,7 +9,7 @@
 // dep: tests/sources/stdlib/modules/libra_time.move
 // dep: tests/sources/stdlib/modules/libra_system.move
 // dep: tests/sources/stdlib/modules/validator_config.move
-// no-verify
+// flag: --verify=none
 
 address 0x0:
 

--- a/language/move-prover/tests/testsuite.rs
+++ b/language/move-prover/tests/testsuite.rs
@@ -13,13 +13,13 @@ fn test_runner(path: &Path) -> datatest_stable::Result<()> {
     let no_boogie = read_env_var("BOOGIE_EXE").is_empty() || read_env_var("Z3_EXE").is_empty();
     let baseline_valid =
         !no_boogie || !extract_test_directives(path, "// no-boogie-test")?.is_empty();
-    let no_verify = !extract_test_directives(path, "// no-verify")?.is_empty();
     let mut sources = extract_test_directives(path, "// dep:")?;
     sources.push(path.to_string_lossy().to_string());
     // The first argument in the args list is interpreted as program name, so set something here.
     let mut args = vec!["mvp_test".to_string()];
-    if no_verify {
-        args.push("--boogie=-noVerify".to_string());
+    args.extend(extract_test_directives(path, "// flag:")?);
+    if args.iter().find(|a| a.contains("--verify")).is_none() {
+        args.push("--verify=all".to_string());
     }
     args.extend_from_slice(&sources);
     let mut options = Options::default();


### PR DESCRIPTION
This finishes the implementation of pragmas and pipes them through from the parser to the prover's environment.

Also introduces a pragma property `verify` as well a command line flag `--verify` to control the scope of verification:

- on the command line one can specifiy which funtions are verified by default using `--verify=public|all|none`. `public` means only public functions are verified standalone (the `_verify` boogie function entry is generated), `all` public and private, and `none` none. `public` is the default (NOTE that is a breaking change in the previous behavior of the prover, which verified all functions).
- the command line behavior can be overriden in spec blocks using `spec fun foo { pragma verify=true'; .. }`. The pragma can also be provided on module level, `spec module { pragma verify=true; .. }`, in which case it provides the default for all functions in the module which do not have their own pragma.

## Motivation

Finer control over verification.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

Added a test.

## Related PRs

NA

(If this PR adds or changes functionality, please take some time to update the docs at https://github.com/libra/website, and link to your PR here.)
