### PR TITLE
[state sync] redo upstream logic in peer manager

### DIFF
--- a/config/src/config/upstream_config.rs
+++ b/config/src/config/upstream_config.rs
@@ -37,7 +37,7 @@ impl UpstreamConfig {
     }
 }
 
-#[derive(Clone, Debug, Deserialize, Eq, Hash, PartialEq, Serialize)]
+#[derive(Copy, Clone, Debug, Deserialize, Eq, Hash, PartialEq, Serialize)]
 /// Identifier of a node, represented as (network_id, peer_id)
 pub struct PeerNetworkId(pub NetworkId, pub PeerId);
 
@@ -48,5 +48,9 @@ impl PeerNetworkId {
 
     pub fn peer_id(&self) -> PeerId {
         self.1
+    }
+
+    pub fn random() -> Self {
+        Self(NetworkId::random(), PeerId::random())
     }
 }

--- a/config/src/config/upstream_config.rs
+++ b/config/src/config/upstream_config.rs
@@ -7,7 +7,7 @@ use std::collections::HashSet;
 
 /// In general, a network ID is a PeerId that this node uses to uniquely identify a network it belongs to.
 /// This is equivalent to the `peer_id` field in the NetworkConfig of this NodeConfig
-type NetworkId = PeerId;
+pub type NetworkId = PeerId;
 
 #[derive(Clone, Default, Debug, Deserialize, PartialEq, Serialize)]
 #[serde(default, deny_unknown_fields)]

--- a/libra-node/src/main_node.rs
+++ b/libra-node/src/main_node.rs
@@ -257,9 +257,9 @@ pub fn setup_environment(node_config: &mut NodeConfig) -> LibraHandle {
         let (runtime, mut network_builder) =
             setup_network(network, RoleType::Validator, Arc::clone(&storage_read));
 
-        state_sync_network_handles.push(state_synchronizer::network::add_to_network(
-            &mut network_builder,
-        ));
+        let (state_sync_sender, state_sync_events) =
+            state_synchronizer::network::add_to_network(&mut network_builder);
+        state_sync_network_handles.push((network.peer_id, state_sync_sender, state_sync_events));
 
         let (mempool_sender, mempool_events) =
             libra_mempool::network::add_to_network(&mut network_builder);
@@ -275,8 +275,12 @@ pub fn setup_environment(node_config: &mut NodeConfig) -> LibraHandle {
         );
 
         network_runtimes.push(runtime);
-        state_sync_network_handles.push(state_synchronizer::network::add_to_network(
-            &mut network_builder,
+        let (state_sync_sender, state_sync_events) =
+            state_synchronizer::network::add_to_network(&mut network_builder);
+        state_sync_network_handles.push((
+            full_node_network.peer_id,
+            state_sync_sender,
+            state_sync_events,
         ));
         let (mempool_sender, mempool_events) =
             libra_mempool::network::add_to_network(&mut network_builder);

--- a/state-synchronizer/src/tests/integration_tests.rs
+++ b/state-synchronizer/src/tests/integration_tests.rs
@@ -266,7 +266,7 @@ impl SynchronizerEnv {
         let peer_addr = network_builder.build();
 
         let mut config = config_builder::test_config().0;
-        let mut network = config.validator_network.clone().unwrap();
+        let mut network = config.validator_network.unwrap();
         let mut network_id = network.peer_id;
         if !role.is_validator() {
             network.peer_id = PeerId::default();

--- a/state-synchronizer/src/tests/integration_tests.rs
+++ b/state-synchronizer/src/tests/integration_tests.rs
@@ -8,7 +8,7 @@ use crate::{
 use anyhow::{bail, Result};
 use executor_types::ExecutedTrees;
 use futures::executor::block_on;
-use libra_config::config::RoleType;
+use libra_config::config::{PeerNetworkId, RoleType};
 use libra_crypto::{
     ed25519::Ed25519PrivateKey, hash::ACCUMULATOR_PLACEHOLDER_HASH, test_utils::TEST_SEED, x25519,
     PrivateKey, Uniform,
@@ -266,20 +266,19 @@ impl SynchronizerEnv {
         let peer_addr = network_builder.build();
 
         let mut config = config_builder::test_config().0;
+        let mut network = config.validator_network.clone().unwrap();
+        let mut network_id = network.peer_id;
         if !role.is_validator() {
-            let mut network = config.validator_network.unwrap();
             network.peer_id = PeerId::default();
+            network_id = network.peer_id;
             config.full_node_networks = vec![network];
             config.validator_network = None;
         }
         config.base.role = role;
         if new_peer_idx > 0 {
             // set the upstream peer in the config
-            config
-                .state_sync
-                .upstream_peers
-                .upstream_peers
-                .push(self.peer_ids[new_peer_idx - 1]);
+            let upstream_peer = PeerNetworkId(network_id, self.peer_ids[new_peer_idx - 1]);
+            config.upstream.upstream_peers.insert(upstream_peer);
         }
 
         let genesis_li = Self::genesis_li(&self.public_keys);
@@ -290,11 +289,12 @@ impl SynchronizerEnv {
         let (mempool_channel, mempool_requests) = futures::channel::mpsc::channel(1_024);
         let synchronizer = StateSynchronizer::bootstrap_with_executor_proxy(
             Runtime::new().unwrap(),
-            vec![(sender, events)],
+            vec![(network_id, sender, events)],
             mempool_channel,
             role,
             waypoint,
             &config.state_sync,
+            config.upstream,
             MockExecutorProxy::new(handler, storage_proxy.clone()),
         );
         self.mempools

--- a/state-synchronizer/src/tests/unit_tests.rs
+++ b/state-synchronizer/src/tests/unit_tests.rs
@@ -44,6 +44,9 @@ fn test_remove_requests() {
     let mut upstream_config = UpstreamConfig::default();
     upstream_config.upstream_peers = peers.iter().cloned().collect();
     let mut peer_manager = PeerManager::new(upstream_config);
+    for peer in peers.iter() {
+        peer_manager.enable_peer(*peer);
+    }
 
     peer_manager.process_request(1, peers[0]);
     peer_manager.process_request(3, peers[1]);
@@ -66,6 +69,9 @@ fn test_peer_manager_request_metadata() {
     let mut upstream_config = UpstreamConfig::default();
     upstream_config.upstream_peers = peers.iter().cloned().collect();
     let mut peer_manager = PeerManager::new(upstream_config);
+    for peer in peers.iter() {
+        peer_manager.enable_peer(*peer);
+    }
     assert!(peer_manager.get_first_request_time(1).is_none());
     peer_manager.process_request(1, peers[0]);
     peer_manager.process_timeout(1, true);


### PR DESCRIPTION
## Motivation

Update state sync peer manager:
- use `PeerNetworkID` instead of `PeerID` to identify peers in different networks
- use `UpstreamConfig` instead of `state_sync.upstream_peers` config
- move out network senders from peer manager
- clean up unnecessary API and internal peer management logic (e.g. `set_peers`)

## Test Plan

Existing tests
