### PR TITLE
[language] Add function name and offset to Abort

### DIFF
--- a/language/e2e-tests/src/tests/write_set.rs
+++ b/language/e2e-tests/src/tests/write_set.rs
@@ -75,15 +75,13 @@ fn verify_and_execute_writeset() {
         1,
     );
     let output = executor.execute_transaction(writeset_txn.clone());
-    let expected_err = VMStatus::new(StatusCode::ABORTED).with_sub_status(11);
-    assert_eq!(
-        output.status(),
-        &TransactionStatus::Discard(expected_err.clone())
-    );
-    assert_eq!(
-        executor.verify_transaction(writeset_txn).status().unwrap(),
-        expected_err
-    );
+    let status = output.status();
+    assert!(status.is_discarded());
+    assert_eq!(status.vm_status().major_status, StatusCode::ABORTED);
+    assert_eq!(status.vm_status().sub_status, Some(11));
+    let err = executor.verify_transaction(writeset_txn).status().unwrap();
+    assert_eq!(err.major_status, StatusCode::ABORTED);
+    assert_eq!(err.sub_status, Some(11));
 }
 
 #[test]

--- a/language/ir-testsuite/tests/commands/abort_in_module.mvir
+++ b/language/ir-testsuite/tests/commands/abort_in_module.mvir
@@ -1,0 +1,19 @@
+module M {
+    public foo() {
+        abort 22;
+    }
+
+}
+
+//! new-transaction
+
+import {{default}}.M;
+
+main() {
+    M.foo();
+    return;
+}
+
+// check: ABORTED
+// check: 22
+// check: "::M::foo at offset 2"

--- a/language/ir-testsuite/tests/commands/abort_no_return.mvir
+++ b/language/ir-testsuite/tests/commands/abort_no_return.mvir
@@ -7,3 +7,4 @@ main() {
 
 // check: ABORTED
 // check: 0
+// check: "Script::main at offset 2"

--- a/language/ir-testsuite/tests/commands/abort_unreleased_reference.mvir
+++ b/language/ir-testsuite/tests/commands/abort_unreleased_reference.mvir
@@ -11,3 +11,4 @@ main() {
 
 // check: ABORTED
 // check: 0
+// check: "Script::main at offset 6"

--- a/language/move-lang/tests/functional/translated_ir_tests/commands/abort_in_module.move
+++ b/language/move-lang/tests/functional/translated_ir_tests/commands/abort_in_module.move
@@ -1,0 +1,16 @@
+module M {
+    public fun foo() {
+        abort 22
+    }
+}
+
+//! new-transaction
+use {{default}}::M;
+
+fun main() {
+    M::foo()
+}
+
+// check: ABORTED
+// check: 22
+// check: "::M::foo at offset 2"

--- a/language/move-vm/runtime/src/interpreter.rs
+++ b/language/move-vm/runtime/src/interpreter.rs
@@ -1139,7 +1139,13 @@ impl Frame {
                     Bytecode::Abort => {
                         gas!(const_instr: context, interpreter, Opcodes::ABORT)?;
                         let error_code = interpreter.operand_stack.pop_as::<u64>()?;
-                        return Err(VMStatus::new(StatusCode::ABORTED).with_sub_status(error_code));
+                        return Err(VMStatus::new(StatusCode::ABORTED)
+                            .with_sub_status(error_code)
+                            .with_message(format!(
+                                "{} at offset {}",
+                                self.function.pretty_string(),
+                                self.pc,
+                            )));
                     }
                     Bytecode::Eq => {
                         let lhs = interpreter.operand_stack.pop()?;

--- a/language/move-vm/runtime/src/loader.rs
+++ b/language/move-vm/runtime/src/loader.rs
@@ -1087,7 +1087,12 @@ impl Function {
     pub(crate) fn pretty_string(&self) -> String {
         match &self.scope {
             Scope::Script(_) => "Script::main".into(),
-            Scope::Module(id) => format!("{}::{}", id.name().as_str(), self.name.as_str()),
+            Scope::Module(id) => format!(
+                "0x{}::{}::{}",
+                id.address(),
+                id.name().as_str(),
+                self.name.as_str()
+            ),
         }
     }
 


### PR DESCRIPTION
When Aborting we are now reporting the "location" of the error
together with the error code.
So it's something along these lines:
major_status: ABORT
sub_status: ERROR_CODE
message: 0xADDR::module_name::function_name
