### PR TITLE
[network][easy] check timeout before doing anything

### DIFF
--- a/network/netcore/src/transport/and_then.rs
+++ b/network/netcore/src/transport/and_then.rs
@@ -29,7 +29,7 @@ impl<T, F> AndThen<T, F> {
 impl<T, F, Fut, O> Transport for AndThen<T, F>
 where
     T: Transport,
-    F: FnOnce(T::Output, Multiaddr, ConnectionOrigin) -> Fut + Send + Unpin + Clone,
+    F: (FnOnce(T::Output, Multiaddr, ConnectionOrigin) -> Fut) + Send + Unpin + Clone,
     // Pin the error types to be the same for now
     // TODO don't require the error types to be the same
     Fut: Future<Output = Result<O, T::Error>> + Send,


### PR DESCRIPTION
Right now the network timeout is checked after polling the inner future,
this leads to unnecessary work.
At worse it can lead to sending data on the wire for nothing,
or parsing a response and computing cryptographic operations for nothing.

This PR reverses the logic to first check the timeout and then poll.
