### PR TITLE
[dashboard] remove usage of "num_accounts" counter

### DIFF
--- a/terraform/templates/dashboards/analytics.json
+++ b/terraform/templates/dashboards/analytics.json
@@ -165,7 +165,7 @@
       "tableColumn": "",
       "targets": [
         {
-          "expr": "max(storage_gauge{op='state_blobs_created'}) - max(storage_gauge{op='state_blobs_retired'})",
+          "expr": "max(storage_gauge{op=\"new_state_leaves\"} - ignoring (op) storage_gauge{op=\"stale_state_leaves\"})",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "Num Accounts Created",

--- a/terraform/templates/dashboards/analytics.json
+++ b/terraform/templates/dashboards/analytics.json
@@ -291,7 +291,7 @@
       "pluginVersion": "6.2.2",
       "targets": [
         {
-          "expr": "max(rate(executor{op='num_accounts'}[5m]))",
+          "expr": "max(rate((storage_gauge{op=\"new_state_leaves\",role=\"validator\"} - ignoring (op) storage_gauge{op=\"stale_state_leaves\",role=\"validator\"})[5m:]))",
           "format": "time_series",
           "instant": false,
           "interval": "",
@@ -433,7 +433,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "max(rate(executor{op='num_accounts'}[5m]))",
+          "expr": "max(rate((storage_gauge{op=\"new_state_leaves\",role=\"validator\"} - ignoring (op) storage_gauge{op=\"stale_state_leaves\",role=\"validator\"})[5m:]))",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "Num Accounts Created / second",
@@ -609,7 +609,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "executor{op='num_accounts'}",
+          "expr": "storage_gauge{op=\"new_state_leaves\",role=\"validator\"} - ignoring (op) storage_gauge{op=\"stale_state_leaves\",role=\"validator\"}",
           "format": "time_series",
           "instant": false,
           "interval": "",
@@ -622,7 +622,7 @@
       "timeFrom": null,
       "timeRegions": [],
       "timeShift": null,
-      "title": "Transaction count by node",
+      "title": "Account count by node",
       "tooltip": {
         "shared": true,
         "sort": 0,

--- a/terraform/templates/dashboards/overview_dashboard.json
+++ b/terraform/templates/dashboards/overview_dashboard.json
@@ -205,7 +205,7 @@
       "tableColumn": "",
       "targets": [
         {
-          "expr": "max(storage_gauge{op=\"new_state_leaves\"}) - max(storage_gauge{op=\"stale_state_leaves\"})",
+          "expr": "max(storage_gauge{op=\"new_state_leaves\"} - ignoring (op) storage_gauge{op=\"stale_state_leaves\"})",
           "format": "time_series",
           "instant": true,
           "intervalFactor": 1,

--- a/terraform/templates/dashboards/storage.json
+++ b/terraform/templates/dashboards/storage.json
@@ -149,12 +149,12 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "max(storage_gauge{op=\"new_state_nodes\"}) - max(storage_gauge{op=\"stale_state_nodes\"})",
+          "expr": "max(storage_gauge{op=\"new_state_nodes\"} - ignoring(op) storage_gauge{op=\"stale_state_nodes\"})",
           "legendFormat": "accounts",
           "refId": "A"
         },
         {
-          "expr": "max(storage_gauge{op=\"new_state_nodes\"}) - max(storage_gauge{op=\"stale_state_nodes\"}) - max(storage_gauge{op=\"new_state_leaves\"}) + max(storage_gauge{op=\"stale_state_leaves\"})",
+          "expr": "max(storage_gauge{op=\"new_state_nodes\"} - ignoring(op) storage_gauge{op=\"stale_state_nodes\"} - ignoring(op) storage_gauge{op=\"new_state_leaves\"} + ignoring(op) storage_gauge{op=\"stale_state_leaves\"})",
           "legendFormat": "internal_nodes",
           "refId": "B"
         }
@@ -1671,7 +1671,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "max(rate(storage_gauge{op=\"new_state_leaves\"}[10m])) / max(rate(storage_gauge{op=\"latest_transaction_version\"}[10m]))",
+          "expr": "max(irate(storage_gauge{op=\"new_state_leaves\"}[10m]) / ignoring(op) irate(storage_gauge{op=\"latest_transaction_version\"}[10m]))",
           "legendFormat": "accounts/txn",
           "refId": "A"
         }
@@ -1757,7 +1757,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "max(rate(storage_gauge{op=\"events_created\"}[10m])) / max(rate(storage_gauge{op=\"latest_transaction_version\"}[10m]))",
+          "expr": "max(irate(storage_gauge{op=\"events_created\"}[10m]) / ignoring(op) irate(storage_gauge{op=\"latest_transaction_version\"}[10m]))",
           "legendFormat": "events/txn",
           "refId": "A"
         }
@@ -1843,7 +1843,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "max(rate(storage_gauge{op=\"new_state_nodes\"}[10m])) / max(rate(storage_gauge{op=\"new_state_leaves\"}[10m])) - 1",
+          "expr": "max(irate(storage_gauge{op=\"new_state_nodes\"}[10m]) / ignoring(op) irate(storage_gauge{op=\"new_state_leaves\"}[10m])) - 1",
           "legendFormat": "internal nodes/accounts",
           "refId": "A"
         }

--- a/terraform/templates/dashboards/usage_stats.json
+++ b/terraform/templates/dashboards/usage_stats.json
@@ -308,7 +308,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "irate(executor{op=\"num_accounts\"}[2m])",
+          "expr": "irate((storage_gauge{op=\"new_state_leaves\",role=\"validator\"} - ignoring (op) storage_gauge{op=\"stale_state_leaves\",role=\"validator\"})[2m:])",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "{{peer_id}}",

--- a/terraform/templates/dashboards/usage_stats.json
+++ b/terraform/templates/dashboards/usage_stats.json
@@ -80,7 +80,7 @@
       "tableColumn": "",
       "targets": [
         {
-          "expr": "max(storage_gauge{op=\"state_blobs_created\"}) - max(storage_gauge{op=\"state_blobs_retired\"})",
+          "expr": "max(storage_gauge{op=\"new_state_leaves\"} - ignoring (op) storage_gauge{op=\"stale_state_leaves\"})",
           "format": "time_series",
           "instant": true,
           "intervalFactor": 1,


### PR DESCRIPTION


## Motivation

"new_state_leaves" and "stale_state_leaves" in storage were created to provide accurate number of accounts in the system. Gonan delete the old counter (which resets after node restart).

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?

yes
## Test Plan

play with the dashboard

## Related PRs

(If this PR adds or changes functionality, please take some time to update the docs at https://github.com/libra/website, and link to your PR here.)
