### PR TITLE
[management] Add ability to retrieve account keys and improve output with verify

### DIFF
--- a/config/management/src/main.rs
+++ b/config/management/src/main.rs
@@ -7,6 +7,5 @@ use libra_management::Command;
 use structopt::StructOpt;
 
 fn main() {
-    let args = Command::from_args();
-    println!("{}", args.verify());
+    println!("{}", Command::from_args().execute());
 }


### PR DESCRIPTION
There are pretty clear commit messages. The first adds the next feature, which is key retrieval. The following improves the verifying output.