### PR TITLE
[Executor] Replace gprc storage service with simple storage service

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1322,7 +1322,7 @@ dependencies = [
  "libra-workspace-hack 0.1.0",
  "rand 0.7.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "rayon 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "storage-client 0.1.0",
+ "storage-interface 0.1.0",
  "structopt 0.3.14 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio 0.2.13 (registry+https://github.com/rust-lang/crates.io-index)",
  "transaction-builder 0.1.0",
@@ -1350,7 +1350,7 @@ dependencies = [
  "libra-types 0.1.0",
  "libra-vm 0.1.0",
  "libra-workspace-hack 0.1.0",
- "storage-client 0.1.0",
+ "simple-storage-client 0.1.0",
  "storage-interface 0.1.0",
  "storage-service 0.1.0",
  "tokio 0.2.13 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2516,6 +2516,7 @@ dependencies = [
  "onchain-discovery 0.1.0",
  "parity-multiaddr 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "rayon 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "simple-storage-client 0.1.0",
  "state-synchronizer 0.1.0",
  "storage-client 0.1.0",
  "storage-interface 0.1.0",
@@ -4651,13 +4652,14 @@ dependencies = [
 name = "simple-storage-client"
 version = "0.1.0"
 dependencies = [
+ "anyhow 1.0.28 (registry+https://github.com/rust-lang/crates.io-index)",
  "libra-canonical-serialization 0.1.0",
+ "libra-crypto 0.1.0",
  "libra-secure-net 0.1.0",
  "libra-types 0.1.0",
  "libra-workspace-hack 0.1.0",
  "serde 1.0.106 (registry+https://github.com/rust-lang/crates.io-index)",
  "storage-interface 0.1.0",
- "tonic 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]

--- a/config/src/config/storage_config.rs
+++ b/config/src/config/storage_config.rs
@@ -9,6 +9,9 @@ use std::{net::SocketAddr, path::PathBuf};
 #[serde(default, deny_unknown_fields)]
 pub struct StorageConfig {
     pub address: SocketAddr,
+    // Use a different address name for non-GRPC storage serivce.
+    // Will be renamed as `address` once GRPC service is deprecated.
+    pub simple_address: SocketAddr,
     pub dir: PathBuf,
     pub grpc_max_receive_len: Option<i32>,
     #[serde(skip)]
@@ -19,6 +22,7 @@ impl Default for StorageConfig {
     fn default() -> StorageConfig {
         StorageConfig {
             address: "127.0.0.1:6184".parse().unwrap(),
+            simple_address: "127.0.0.1:6666".parse().unwrap(),
             dir: PathBuf::from("libradb/db"),
             grpc_max_receive_len: Some(100_000_000),
             data_dir: PathBuf::from("/opt/libra/data/common"),
@@ -41,5 +45,6 @@ impl StorageConfig {
 
     pub fn randomize_ports(&mut self) {
         self.address.set_port(utils::get_available_port());
+        self.simple_address.set_port(utils::get_available_port());
     }
 }

--- a/execution/executor-benchmark/Cargo.toml
+++ b/execution/executor-benchmark/Cargo.toml
@@ -25,7 +25,7 @@ libra-config = { path = "../../config", version = "0.1.0" }
 libra-crypto = { path = "../../crypto/crypto", version = "0.1.0" }
 libra-logger = { path = "../../common/logger", version = "0.1.0" }
 libra-types = { path = "../../types", version = "0.1.0" }
-storage-client = { path = "../../storage/storage-client", version = "0.1.0" }
+storage-interface = { path = "../../storage/storage-interface", version = "0.1.0" }
 transaction-builder = { path = "../../language/transaction-builder", version = "0.1.0" }
 libra-vm= { path = "../../language/libra-vm", version = "0.1.0" }
 libra-workspace-hack = { path = "../../common/workspace-hack", version = "0.1.0" }

--- a/execution/executor-utils/Cargo.toml
+++ b/execution/executor-utils/Cargo.toml
@@ -14,7 +14,7 @@ tokio = { version = "0.2.12", features = ["full"] }
 
 executor = { path = "../executor", version = "0.1.0" }
 libra-config = { path = "../../config", version = "0.1.0" }
-storage-client = { path = "../../storage/storage-client", version = "0.1.0" }
+simple-storage-client = { path = "../../storage/simple-storage-client", version = "0.1.0" }
 storage-interface = { path = "../../storage/storage-interface", version = "0.1.0" }
 storage-service = { path = "../../storage/storage-service", version = "0.1.0" }
 libra-vm = { path = "../../language/libra-vm", version = "0.1.0" }

--- a/execution/executor-utils/src/lib.rs
+++ b/execution/executor-utils/src/lib.rs
@@ -7,20 +7,19 @@ pub mod test_helpers;
 use executor::{db_bootstrapper::bootstrap_db_if_empty, Executor};
 use libra_config::{config::NodeConfig, utils::get_genesis_txn};
 use libra_vm::LibraVM;
+use simple_storage_client::SimpleStorageClient;
 use std::sync::Arc;
-use storage_client::SyncStorageClient;
 use storage_interface::DbReader;
-use storage_service::{init_libra_db, start_storage_service_with_db};
-use tokio::runtime::Runtime;
+use storage_service::{init_libra_db, start_simple_storage_service_with_db};
 
 pub fn create_storage_service_and_executor(
     config: &NodeConfig,
-) -> (Arc<dyn DbReader>, Runtime, Executor<LibraVM>) {
+) -> (Arc<dyn DbReader>, Executor<LibraVM>) {
     let (db, db_rw) = init_libra_db(config);
     bootstrap_db_if_empty::<LibraVM>(&db_rw, get_genesis_txn(config).unwrap()).unwrap();
 
-    let rt = start_storage_service_with_db(config, db.clone());
-    let executor = Executor::new(SyncStorageClient::new(&config.storage.address).into());
+    let _handble = start_simple_storage_service_with_db(config, db.clone());
+    let executor = Executor::new(SimpleStorageClient::new(&config.storage.simple_address).into());
 
-    (db, rt, executor)
+    (db, executor)
 }

--- a/libra-node/Cargo.toml
+++ b/libra-node/Cargo.toml
@@ -32,6 +32,7 @@ libra-crypto = { path = "../crypto/crypto", version = "0.1.0" }
 network = { path = "../network", version = "0.1.0" }
 onchain-discovery = { path = "../network/onchain-discovery", version = "0.1.0" }
 libra-json-rpc = { path = "../json-rpc", version = "0.1.0" }
+simple-storage-client = { path = "../storage/simple-storage-client", version = "0.1.0" }
 state-synchronizer = { path = "../state-synchronizer", version = "0.1.0" }
 storage-client = { path = "../storage/storage-client", version = "0.1.0" }
 storage-interface= { path = "../storage/storage-interface", version = "0.1.0" }

--- a/storage/simple-storage-client/Cargo.toml
+++ b/storage/simple-storage-client/Cargo.toml
@@ -10,13 +10,15 @@ publish = false
 edition = "2018"
 
 [dependencies]
+anyhow = "1.0"
 serde = "1.0"
-tonic = "0.2"
+
 lcs = { path = "../../common/lcs", version = "0.1.0", package = "libra-canonical-serialization" }
+libra-crypto = { path = "../../crypto/crypto", version = "0.1.0" }
 libra-secure-net = { path = "../../secure/net", version = "0.1.0" }
-storage-interface = { path = "../storage-interface", version = "0.1.0" }
 libra-types = { path = "../../types", version = "0.1.0" }
 libra-workspace-hack = { path = "../../common/workspace-hack", version = "0.1.0" }
+storage-interface = { path = "../storage-interface", version = "0.1.0" }
 
 [features]
 default = []

--- a/storage/simple-storage-client/src/lib.rs
+++ b/storage/simple-storage-client/src/lib.rs
@@ -3,19 +3,24 @@
 
 #![forbid(unsafe_code)]
 
+use anyhow::Result;
+use libra_crypto::HashValue;
 use libra_secure_net::NetworkClient;
 use libra_types::{
     account_address::AccountAddress,
-    account_state_blob::AccountStateBlob,
+    account_state_blob::{AccountStateBlob, AccountStateWithProof},
+    contract_event::ContractEvent,
+    epoch_change::EpochChangeProof,
+    event::EventKey,
     ledger_info::LedgerInfoWithSignatures,
-    proof::SparseMerkleProof,
-    transaction::{TransactionToCommit, Version},
+    proof::{AccumulatorConsistencyProof, SparseMerkleProof},
+    transaction::{TransactionListWithProof, TransactionToCommit, TransactionWithProof, Version},
 };
 use serde::de::DeserializeOwned;
 use std::{net::SocketAddr, sync::Mutex};
 use storage_interface::{
-    Error, GetAccountStateWithProofByVersionRequest, SaveTransactionsRequest, StartupInfo,
-    StorageRequest,
+    DbReader, DbWriter, Error, GetAccountStateWithProofByVersionRequest, SaveTransactionsRequest,
+    StartupInfo, StorageRequest, TreeState,
 };
 
 pub struct SimpleStorageClient {
@@ -29,7 +34,7 @@ impl SimpleStorageClient {
         }
     }
 
-    fn request<T: DeserializeOwned>(&self, input: StorageRequest) -> Result<T, Error> {
+    fn request<T: DeserializeOwned>(&self, input: StorageRequest) -> std::result::Result<T, Error> {
         let input_message = lcs::to_bytes(&input)?;
         let mut client = self.network_client.lock().unwrap();
         client.write(&input_message)?;
@@ -41,7 +46,7 @@ impl SimpleStorageClient {
         &self,
         address: AccountAddress,
         version: Version,
-    ) -> Result<(Option<AccountStateBlob>, SparseMerkleProof), Error> {
+    ) -> std::result::Result<(Option<AccountStateBlob>, SparseMerkleProof), Error> {
         self.request(StorageRequest::GetAccountStateWithProofByVersionRequest(
             Box::new(GetAccountStateWithProofByVersionRequest::new(
                 address, version,
@@ -49,7 +54,7 @@ impl SimpleStorageClient {
         ))
     }
 
-    pub fn get_startup_info(&self) -> Result<Option<StartupInfo>, Error> {
+    pub fn get_startup_info(&self) -> std::result::Result<Option<StartupInfo>, Error> {
         self.request(StorageRequest::GetStartupInfoRequest)
     }
 
@@ -58,9 +63,130 @@ impl SimpleStorageClient {
         txns_to_commit: Vec<TransactionToCommit>,
         first_version: Version,
         ledger_info_with_sigs: Option<LedgerInfoWithSignatures>,
-    ) -> Result<(), Error> {
+    ) -> std::result::Result<(), Error> {
         self.request(StorageRequest::SaveTransactionsRequest(Box::new(
             SaveTransactionsRequest::new(txns_to_commit, first_version, ledger_info_with_sigs),
         )))
+    }
+}
+
+impl DbReader for SimpleStorageClient {
+    fn get_account_state_with_proof_by_version(
+        &self,
+        address: AccountAddress,
+        version: u64,
+    ) -> Result<(Option<AccountStateBlob>, SparseMerkleProof)> {
+        Ok(Self::get_account_state_with_proof_by_version(
+            self, address, version,
+        )?)
+    }
+
+    fn get_startup_info(&self) -> Result<Option<StartupInfo>> {
+        Ok(Self::get_startup_info(self)?)
+    }
+
+    fn get_latest_account_state(
+        &self,
+        _address: AccountAddress,
+    ) -> Result<Option<AccountStateBlob>> {
+        unimplemented!()
+    }
+
+    fn get_latest_ledger_info(&self) -> Result<LedgerInfoWithSignatures> {
+        unimplemented!()
+    }
+
+    fn get_txn_by_account(
+        &self,
+        _address: AccountAddress,
+        _seq_num: u64,
+        _ledger_version: u64,
+        _fetch_events: bool,
+    ) -> Result<Option<TransactionWithProof>> {
+        unimplemented!()
+    }
+
+    fn get_transactions(
+        &self,
+        _start_version: u64,
+        _limit: u64,
+        _ledger_version: u64,
+        _fetch_events: bool,
+    ) -> Result<TransactionListWithProof> {
+        unimplemented!()
+    }
+
+    fn get_events(
+        &self,
+        _key: &EventKey,
+        _start: u64,
+        _ascending: bool,
+        _limit: u64,
+    ) -> Result<Vec<(u64, ContractEvent)>> {
+        unimplemented!()
+    }
+
+    fn get_state_proof(
+        &self,
+        _known_version: u64,
+    ) -> Result<(
+        LedgerInfoWithSignatures,
+        EpochChangeProof,
+        AccumulatorConsistencyProof,
+    )> {
+        unimplemented!()
+    }
+
+    fn get_state_proof_with_ledger_info(
+        &self,
+        _known_version: u64,
+        _ledger_info: LedgerInfoWithSignatures,
+    ) -> Result<(EpochChangeProof, AccumulatorConsistencyProof)> {
+        unimplemented!()
+    }
+
+    fn get_account_state_with_proof(
+        &self,
+        _address: AccountAddress,
+        _version: Version,
+        _ledger_version: Version,
+    ) -> Result<AccountStateWithProof> {
+        unimplemented!()
+    }
+
+    fn get_latest_state_root(&self) -> Result<(u64, HashValue)> {
+        unimplemented!()
+    }
+
+    fn get_latest_tree_state(&self) -> Result<TreeState> {
+        unimplemented!()
+    }
+
+    fn get_epoch_change_ledger_infos(
+        &self,
+        _start_epoch: u64,
+        _end_epoch: u64,
+    ) -> Result<EpochChangeProof> {
+        unimplemented!()
+    }
+
+    fn get_ledger_info(&self, _: u64) -> Result<LedgerInfoWithSignatures> {
+        unimplemented!()
+    }
+}
+
+impl DbWriter for SimpleStorageClient {
+    fn save_transactions(
+        &self,
+        txns_to_commit: &[TransactionToCommit],
+        first_version: Version,
+        ledger_info_with_sigs: Option<&LedgerInfoWithSignatures>,
+    ) -> Result<()> {
+        Ok(Self::save_transactions(
+            self,
+            txns_to_commit.to_vec(),
+            first_version,
+            ledger_info_with_sigs.cloned(),
+        )?)
     }
 }

--- a/storage/storage-service/src/lib.rs
+++ b/storage/storage-service/src/lib.rs
@@ -107,7 +107,7 @@ impl SimpleStorageService {
     }
 
     fn run(self, config: &NodeConfig) -> JoinHandle<()> {
-        let mut network_server = NetworkServer::new(config.storage.address);
+        let mut network_server = NetworkServer::new(config.storage.simple_address);
         thread::spawn(move || loop {
             if let Err(e) = self.process_one_message(&mut network_server) {
                 warn!("Failed to process message: {}", e);

--- a/storage/storage-service/src/storage_service_test.rs
+++ b/storage/storage-service/src/storage_service_test.rs
@@ -30,11 +30,11 @@ fn start_test_storage_with_client() -> (
     config.storage.dir = tmp_dir.path().to_path_buf();
 
     let server_port = utils::get_available_port();
-    config.storage.address = SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), server_port);
+    config.storage.simple_address = SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), server_port);
 
     let storage_server_handle = start_simple_storage_service(&config);
 
-    let client = SimpleStorageClient::new(&config.storage.address);
+    let client = SimpleStorageClient::new(&config.storage.simple_address);
     (storage_server_handle, tmp_dir, client)
 }
 


### PR DESCRIPTION
## Motivation

According to #2519 , we replace gprc-based storage service with simple storage service for `Executor`. The others should use `dyn DbReader` directly from zone 3 except on_chain_config and backup_service.

on-chain-config needs to be refactored to call `DbReader` directly.
backup_service will be merged into the successor of simple storage service that is based on LibraNet.
cc: @phlip9 @bothra90 

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?

Y

## Test Plan

CI


