### PR TITLE
[move-prover] Implementing the schema `apply` weaving operator.

### DIFF
--- a/language/move-lang/src/expansion/ast.rs
+++ b/language/move-lang/src/expansion/ast.rs
@@ -4,7 +4,7 @@
 use crate::{
     parser::ast::{
         BinOp, Field, FunctionName, FunctionVisibility, InvariantKind, Kind, ModuleIdent,
-        ModuleName, PragmaProperty, ResourceLoc, SpecApplyFragment, SpecBlockTarget,
+        ModuleName, PragmaProperty, ResourceLoc, SpecApplyPattern, SpecBlockTarget,
         SpecConditionKind, StructName, UnaryOp, Value, Var,
     },
     shared::{ast_debug::*, unique_map::UniqueMap, *},
@@ -95,15 +95,6 @@ pub struct Function {
 //**************************************************************************************************
 // Specification Blocks
 //**************************************************************************************************
-
-#[derive(Debug, PartialEq)]
-pub struct SpecApplyPattern_ {
-    pub visibility: Option<FunctionVisibility>,
-    pub name_pattern: Vec<SpecApplyFragment>,
-    pub type_arguments: Option<Vec<Type>>,
-}
-
-pub type SpecApplyPattern = Spanned<SpecApplyPattern_>;
 
 #[derive(Debug, PartialEq)]
 pub struct SpecBlock_ {
@@ -550,20 +541,6 @@ impl AstDebug for SpecBlockMember_ {
                     true
                 });
             }
-        }
-    }
-}
-
-impl AstDebug for SpecApplyPattern_ {
-    fn ast_debug(&self, w: &mut AstWriter) {
-        w.list(&self.name_pattern, "", |w, f| {
-            f.ast_debug(w);
-            true
-        });
-        if let Some(tys) = &self.type_arguments {
-            w.write("<");
-            tys.ast_debug(w);
-            w.write(">");
         }
     }
 }

--- a/language/move-lang/src/expansion/translate.rs
+++ b/language/move-lang/src/expansion/translate.rs
@@ -650,22 +650,14 @@ fn spec_member(
             name: pn,
             type_arguments: ptys_opt,
             arguments: parguments,
-            patterns: ppatterns,
-            exclusion_patterns: pe_patterns,
+            patterns,
+            exclusion_patterns,
         } => {
             let name = module_access(context, pn)?;
             let type_arguments = optional_types(context, ptys_opt);
             let arguments = parguments
                 .into_iter()
                 .map(|(n, e)| (n, exp_(context, e)))
-                .collect();
-            let patterns = ppatterns
-                .into_iter()
-                .map(|p| spec_apply_pattern(context, p))
-                .collect();
-            let exclusion_patterns = pe_patterns
-                .into_iter()
-                .map(|p| spec_apply_pattern(context, p))
                 .collect();
             EM::Apply {
                 name,
@@ -678,28 +670,6 @@ fn spec_member(
         PM::Pragma { properties } => EM::Pragma { properties },
     };
     Some(sp(loc, em))
-}
-
-fn spec_apply_pattern(
-    context: &mut Context,
-    sp!(
-        loc,
-        P::SpecApplyPattern_ {
-            visibility,
-            name_pattern,
-            type_arguments: pty_args
-        }
-    ): P::SpecApplyPattern,
-) -> E::SpecApplyPattern {
-    let type_arguments = pty_args.map(|tys| types(context, tys));
-    sp(
-        loc,
-        E::SpecApplyPattern_ {
-            visibility,
-            name_pattern,
-            type_arguments,
-        },
-    )
 }
 
 //**************************************************************************************************

--- a/language/move-lang/src/parser/ast.rs
+++ b/language/move-lang/src/parser/ast.rs
@@ -199,7 +199,7 @@ pub type PragmaProperty = Spanned<PragmaProperty_>;
 pub struct SpecApplyPattern_ {
     pub visibility: Option<FunctionVisibility>,
     pub name_pattern: Vec<SpecApplyFragment>,
-    pub type_arguments: Option<Vec<Type>>,
+    pub type_parameters: Vec<(Name, Kind)>,
 }
 
 pub type SpecApplyPattern = Spanned<SpecApplyPattern_>;
@@ -991,9 +991,9 @@ impl AstDebug for SpecApplyPattern_ {
             f.ast_debug(w);
             true
         });
-        if let Some(tys) = &self.type_arguments {
+        if !self.type_parameters.is_empty() {
             w.write("<");
-            tys.ast_debug(w);
+            self.type_parameters.ast_debug(w);
             w.write(">");
         }
     }

--- a/language/move-lang/src/parser/syntax.rs
+++ b/language/move-lang/src/parser/syntax.rs
@@ -1842,7 +1842,7 @@ fn parse_spec_apply_pattern<'input>(tokens: &mut Lexer<'input>) -> Result<SpecAp
         },
         parse_spec_apply_fragment,
     )?;
-    let type_arguments = parse_optional_type_args(tokens)?;
+    let type_parameters = parse_optional_type_parameters(tokens)?;
     Ok(spanned(
         tokens.file_name(),
         start_loc,
@@ -1850,7 +1850,7 @@ fn parse_spec_apply_pattern<'input>(tokens: &mut Lexer<'input>) -> Result<SpecAp
         SpecApplyPattern_ {
             visibility,
             name_pattern,
-            type_arguments,
+            type_parameters,
         },
     ))
 }

--- a/language/move-prover/tests/sources/marketcap_as_schema_apply.exp
+++ b/language/move-prover/tests/sources/marketcap_as_schema_apply.exp
@@ -1,0 +1,16 @@
+Move prover returns: exiting with boogie verification errors
+error:  A postcondition might not hold on this return path.
+
+    ┌── tests/sources/marketcap_as_schema_apply.move:12:9 ───
+    │
+ 12 │         ensures global<MarketCap>(0xA550C18).total_value == sum_of_coins<X>;
+    │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    │
+    =     at tests/sources/marketcap_as_schema_apply.move:63:5: deposit_incorrect (entry)
+    =     at tests/sources/marketcap_as_schema_apply.move:64:17: deposit_incorrect
+    =         coin_ref = <redacted>,
+    =         check = <redacted>,
+    =         value = <redacted>
+    =     at tests/sources/marketcap_as_schema_apply.move:65:26: deposit_incorrect
+    =         coin_ref = <redacted>
+    =     at tests/sources/marketcap_as_schema_apply.move:63:5: deposit_incorrect (exit)

--- a/language/move-prover/tests/sources/marketcap_as_schema_apply.move
+++ b/language/move-prover/tests/sources/marketcap_as_schema_apply.move
@@ -1,0 +1,100 @@
+// A minimized version of the MarketCap verification problem.
+address 0x0:
+
+module TestMarketCapWithSchemas {
+
+    spec module {
+        global sum_of_coins<X>: num;
+    }
+
+    spec schema SumOfCoinsModuleInvariant<X> {
+        requires global<MarketCap>(0xA550C18).total_value == sum_of_coins<X>;
+        ensures global<MarketCap>(0xA550C18).total_value == sum_of_coins<X>;
+    }
+
+    spec module {
+        // This is the statement we are actually testing here. Expectation is that the invariant above
+        // is woven into any public function with one type parameter except it's name starts with
+        // `excepted_`.
+        apply SumOfCoinsModuleInvariant<X1> to public *deposit*<X1> except excepted_*;
+    }
+
+    // A resource representing the Libra coin
+    resource struct T<X> {
+        // The value of the coin. May be zero
+        value: u64,
+    }
+    spec struct T {
+        invariant pack sum_of_coins<X> = sum_of_coins<X> + value;
+        invariant unpack sum_of_coins<X> = sum_of_coins<X> - value;
+    }
+
+    resource struct MarketCap<X> {
+        // The sum of the values of all LibraCoin::T resources in the system
+        total_value: u128,
+    }
+
+    // A schema for deposit functions which match the module invariant.
+    spec schema DepositCorrect<X> {
+        coin_ref: &mut T<X>;
+        check: T<X>;
+        aborts_if coin_ref.value + check.value > max_u64();
+        ensures coin_ref.value == old(coin_ref.value) + check.value;
+    }
+
+    // A schema for deposit functions which do NOT match the module invariant.
+    spec schema DepositIncorrect<X> {
+        coin_ref: &mut T<X>;
+        check: T<X>;
+        aborts_if coin_ref.value + check.value / 2 > max_u64();
+        ensures coin_ref.value == old(coin_ref.value) + check.value / 2;
+    }
+
+    // A function which matches the schema apply and which satisfies the invariant.
+    public fun deposit<Token>(coin_ref: &mut T<Token>, check: T<Token>) {
+        let T { value } = check;
+        coin_ref.value = coin_ref.value + value;
+    }
+    spec fun deposit {
+        include DepositCorrect<Token>;
+    }
+
+    // A function which matches the schema apply and which does NOT satisfies the invariant.
+    public fun deposit_incorrect<Token>(coin_ref: &mut T<Token>, check: T<Token>) {
+        let T { value } = check;
+        coin_ref.value = coin_ref.value + value / 2;
+    }
+    spec fun deposit_incorrect {
+        include DepositIncorrect<Token>;
+    }
+
+    // A function which does NOT match the schema apply and which does NOT satisfies the invariant.
+    // It does not match because it is not public.
+    fun deposit_not_public<Token>(coin_ref: &mut T<Token>, check: T<Token>) {
+        let T { value } = check;
+        coin_ref.value = coin_ref.value + value / 2;
+    }
+    spec fun deposit_not_public {
+        include DepositIncorrect<Token>;
+    }
+
+    // A function which does NOT match the schema apply and which does NOT satisfies the invariant.
+    // It does not match because it's name starts with `excepted_`.
+    public fun excepted_deposit<Token>(coin_ref: &mut T<Token>, check: T<Token>) {
+        let T { value } = check;
+        coin_ref.value = coin_ref.value + value / 2;
+    }
+    spec fun excepted_deposit {
+        include DepositIncorrect<Token>;
+    }
+
+    // A function which does NOT match the schema apply and which does NOT satisfies the invariant.
+    // It does not match because it has a different type parameter arity.
+    public fun deposit_different_type_params<Token, Other>(coin_ref: &mut T<Token>, check: T<Token>) {
+        let T { value } = check;
+        coin_ref.value = coin_ref.value + value / 2;
+    }
+    spec fun deposit_different_type_params {
+        include DepositIncorrect<Token>;
+    }
+}


### PR DESCRIPTION
This implements the weaving operator for schemas. One can use something like:

```
spec module {
    apply SumOfCoinsModuleInvariant<X> to public *deposit*<X> except excepted_*;
}
spec schema SumOfCoinsModuleInvariant<X> { .. }
```

... to apply a schema to all functions in a module which match the inclusion/exclusion pattern.

This mechanism is to eventually replace our existing module invariants which did not work for methods of different genericity.

The example above is taken from the added test `marketcap_as_schema_apply.move`.

There are some changes to the move-lang parser as well, all simplifications because in type `SpecApplyPattern`, we actually only need type parameters, not type argument lists.

## Motivation

Global specifications.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

Add new test.

## Related PRs

NA
