### PR TITLE
[RFC][docker] add toolchain layer

### DIFF
--- a/docker/client/Dockerfile
+++ b/docker/client/Dockerfile
@@ -1,19 +1,8 @@
-FROM debian:buster AS toolchain
-
-# To use http/https proxy while building, use:
-# docker build --build-arg https_proxy=http://fwdproxy:8080 --build-arg http_proxy=http://fwdproxy:8080
-
-RUN apt-get update && apt-get install -y cmake curl clang git
-
-RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --default-toolchain none
-ENV PATH "$PATH:/root/.cargo/bin"
+### Build layer
+ARG TOOLCHAIN_TAG
+FROM toolchain_rust:$TOOLCHAIN_TAG AS builder
 
 WORKDIR /libra
-COPY rust-toolchain /libra/rust-toolchain
-RUN rustup install $(cat rust-toolchain)
-
-FROM toolchain AS builder
-
 COPY . /libra
 
 RUN cargo build --release -p libra-node -p cli -p config-builder -p safety-rules && cd target/release && rm -r build deps incremental

--- a/docker/client/build.sh
+++ b/docker/client/build.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
 # Copyright (c) The Libra Core Contributors
 # SPDX-License-Identifier: Apache-2.0
-set -e
+set -ex
 
 DIR="$( cd "$( dirname "$0" )" && pwd )"
 
@@ -10,4 +10,17 @@ if [ "$https_proxy" ]; then
     PROXY=" --build-arg https_proxy=$https_proxy --build-arg http_proxy=$http_proxy"
 fi
 
-docker build -f $DIR/Dockerfile $DIR/../.. --tag libra_client --build-arg GIT_REV="$(git rev-parse HEAD)" --build-arg GIT_UPSTREAM="$(git merge-base HEAD origin/master)" --build-arg BUILD_DATE="$(date -u +'%Y-%m-%dT%H:%M:%SZ')" $PROXY
+TOOLCHAIN_TAG=$(cat $DIR/../../rust-toolchain)-$(shasum -a 256 $DIR/../../Cargo.lock | colrm 9)
+if ! docker image inspect toolchain_rust:$TOOLCHAIN_TAG &> /dev/null; then
+  echo "Image toolchain_rust:$TOOLCHAIN_TAG does not exist locally. Will build it."
+  $DIR/../toolchain/build.sh
+fi
+
+docker build -f $DIR/Dockerfile \
+  $DIR/../.. \
+  --tag libra_client \
+  --build-arg TOOLCHAIN_TAG="$TOOLCHAIN_TAG" \
+  --build-arg GIT_REV="$(git rev-parse HEAD)" \
+  --build-arg GIT_UPSTREAM="$(git merge-base HEAD origin/master)" \
+  --build-arg BUILD_DATE="$(date -u +'%Y-%m-%dT%H:%M:%SZ')" \
+  $PROXY

--- a/docker/init/Dockerfile
+++ b/docker/init/Dockerfile
@@ -1,19 +1,8 @@
-FROM debian:buster AS toolchain
-
-# To use http/https proxy while building, use:
-# docker build --build-arg https_proxy=http://fwdproxy:8080 --build-arg http_proxy=http://fwdproxy:8080
-
-RUN apt-get update && apt-get install -y cmake curl clang git
-
-RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --default-toolchain none
-ENV PATH "$PATH:/root/.cargo/bin"
+### Build layer
+ARG TOOLCHAIN_TAG
+FROM toolchain_rust:$TOOLCHAIN_TAG AS builder
 
 WORKDIR /libra
-COPY rust-toolchain /libra/rust-toolchain
-RUN rustup install $(cat rust-toolchain)
-
-FROM toolchain AS builder
-
 COPY . /libra
 
 RUN cargo build --release -p libra-node -p cli -p config-builder -p safety-rules && cd target/release && rm -r build deps incremental
@@ -21,8 +10,12 @@ RUN cargo build --release -p libra-node -p cli -p config-builder -p safety-rules
 ### Production Image ###
 FROM debian:buster AS prod
 
-RUN apt-get update && apt-get -y install wget gettext-base && apt-get clean && rm -r /var/lib/apt/lists/*
-RUN cd /usr/local/bin && wget "https://storage.googleapis.com/kubernetes-release/release/v1.17.0/bin/linux/amd64/kubectl" -O kubectl && chmod +x kubectl
+RUN apt-get update \
+    && apt-get -y install gettext-base=0.19.8.1-9 \
+    && apt-get clean \
+    && rm -r /var/lib/apt/lists/*
+COPY --from=builder /staging/bin/kubectl /usr/local/bin
+RUN chmod a+x /usr/local/bin/kubectl
 
 RUN mkdir -p /opt/libra/bin
 COPY --from=builder /libra/target/release/config-builder /opt/libra/bin

--- a/docker/mint/Dockerfile
+++ b/docker/mint/Dockerfile
@@ -1,19 +1,9 @@
-FROM debian:buster AS toolchain
 
-# To use http/https proxy while building, use:
-# docker build --build-arg https_proxy=http://fwdproxy:8080 --build-arg http_proxy=http://fwdproxy:8080
-
-RUN apt-get update && apt-get install -y cmake curl clang git
-
-RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --default-toolchain none
-ENV PATH "$PATH:/root/.cargo/bin"
+### Build layer
+ARG TOOLCHAIN_TAG
+FROM toolchain_rust:$TOOLCHAIN_TAG AS builder
 
 WORKDIR /libra
-COPY rust-toolchain /libra/rust-toolchain
-RUN rustup install $(cat rust-toolchain)
-
-FROM toolchain AS builder
-
 COPY . /libra
 
 RUN cargo build --release -p libra-node -p cli -p config-builder -p safety-rules && cd target/release && rm -r build deps incremental
@@ -22,8 +12,16 @@ RUN cargo build --release -p libra-node -p cli -p config-builder -p safety-rules
 FROM debian:buster AS pre-test
 
 # TODO: Unsure which of these are needed exactly for client
-RUN apt-get update && apt-get install -y python3-pip nano net-tools tcpdump iproute2 netcat \
-    && apt-get clean && rm -r /var/lib/apt/lists/*
+RUN apt-get update \
+    && apt-get install -y \
+        iproute2=4.20.0-2 \
+        nano=3.2-3 \
+        net-tools=1.60+git20180626.aebd88e-1 \
+        netcat=1.10-41.1 \
+        python3-pip=18.1-5 \
+        tcpdump=4.9.3-1~deb10u1 \
+    && apt-get clean \
+    && rm -r /var/lib/apt/lists/*
 
 # RUN apt-get install python3
 COPY docker/mint/requirements.txt /libra/docker/mint/requirements.txt
@@ -40,7 +38,10 @@ COPY docker/mint/docker-run.sh /opt/libra/bin
 FROM pre-test AS test
 
 #install needed tools
-RUN apt-get update && apt-get install -y procps
+RUN apt-get update \
+    && apt-get install -y procps=2:3.3.15-2 \
+    && apt-get clean \
+    && rm -r /var/lib/apt/lists/*
 
 # TEST docker-run.sh
 #   GIVEN necessary environment arguments to run docker-run.sh

--- a/docker/mint/build.sh
+++ b/docker/mint/build.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
 # Copyright (c) The Libra Core Contributors
 # SPDX-License-Identifier: Apache-2.0
-set -e
+set -ex
 
 DIR="$( cd "$( dirname "$0" )" && pwd )"
 
@@ -10,4 +10,17 @@ if [ "$https_proxy" ]; then
     PROXY=" --build-arg https_proxy=$https_proxy --build-arg http_proxy=$http_proxy"
 fi
 
-docker build -f $DIR/Dockerfile $DIR/../.. --tag libra_mint  --build-arg GIT_REV=$(git rev-parse HEAD) --build-arg GIT_UPSTREAM=$(git merge-base --fork-point origin/master) --build-arg BUILD_DATE="$(date -u +'%Y-%m-%dT%H:%M:%SZ')" $PROXY
+TOOLCHAIN_TAG=$(cat $DIR/../../rust-toolchain)-$(shasum -a 256 $DIR/../../Cargo.lock | colrm 9)
+if ! docker image inspect toolchain_rust:$TOOLCHAIN_TAG &> /dev/null; then
+  echo "Image toolchain_rust:$TOOLCHAIN_TAG does not exist locally. Will build it."
+  $DIR/../toolchain/build.sh
+fi
+
+docker build -f $DIR/Dockerfile \
+  $DIR/../.. \
+  --tag libra_mint \
+  --build-arg TOOLCHAIN_TAG="$TOOLCHAIN_TAG" \
+  --build-arg GIT_REV=$(git rev-parse HEAD) \
+  --build-arg GIT_UPSTREAM=$(git merge-base --fork-point origin/master) \
+  --build-arg BUILD_DATE="$(date -u +'%Y-%m-%dT%H:%M:%SZ')" \
+  $PROXY

--- a/docker/safety-rules/Dockerfile
+++ b/docker/safety-rules/Dockerfile
@@ -1,19 +1,8 @@
-FROM debian:buster AS toolchain
-
-# To use http/https proxy while building, use:
-# docker build --build-arg https_proxy=http://fwdproxy:8080 --build-arg http_proxy=http://fwdproxy:8080
-
-RUN apt-get update && apt-get install -y cmake curl clang git
-
-RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --default-toolchain none
-ENV PATH "$PATH:/root/.cargo/bin"
+### Build layer
+ARG TOOLCHAIN_TAG
+FROM toolchain_rust:$TOOLCHAIN_TAG AS builder
 
 WORKDIR /libra
-COPY rust-toolchain /libra/rust-toolchain
-RUN rustup install $(cat rust-toolchain)
-
-FROM toolchain AS builder
-
 COPY . /libra
 
 RUN cargo build --release -p libra-node -p cli -p config-builder -p safety-rules && cd target/release && rm -r build deps incremental

--- a/docker/safety-rules/build.sh
+++ b/docker/safety-rules/build.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
 # Copyright (c) The Libra Core Contributors
 # SPDX-License-Identifier: Apache-2.0
-set -e
+set -ex
 
 DIR="$( cd "$( dirname "$0" )" && pwd )"
 
@@ -10,4 +10,17 @@ if [ "$https_proxy" ]; then
     PROXY=" --build-arg https_proxy=$https_proxy --build-arg http_proxy=$http_proxy"
 fi
 
-docker build -f $DIR/Dockerfile $DIR/../.. --tag libra_safety_rules --build-arg GIT_REV="$(git rev-parse HEAD)" --build-arg GIT_UPSTREAM="$(git merge-base HEAD origin/master)" --build-arg BUILD_DATE="$(date -u +'%Y-%m-%dT%H:%M:%SZ')" $PROXY "$@"
+TOOLCHAIN_TAG=$(cat $DIR/../../rust-toolchain)-$(shasum -a 256 $DIR/../../Cargo.lock | colrm 9)
+if ! docker image inspect toolchain_rust:$TOOLCHAIN_TAG &> /dev/null; then
+  echo "Image toolchain_rust:$TOOLCHAIN_TAG does not exist locally. Will build it."
+  $DIR/../toolchain/build.sh
+fi
+
+docker build -f $DIR/Dockerfile \
+  $DIR/../.. \
+  --tag libra_safety_rules \
+  --build-arg TOOLCHAIN_TAG="$TOOLCHAIN_TAG" \
+  --build-arg GIT_REV="$(git rev-parse HEAD)" \
+  --build-arg GIT_UPSTREAM="$(git merge-base HEAD origin/master)" \
+  --build-arg BUILD_DATE="$(date -u +'%Y-%m-%dT%H:%M:%SZ')" \
+  $PROXY "$@"

--- a/docker/toolchain/Dockerfile
+++ b/docker/toolchain/Dockerfile
@@ -1,0 +1,34 @@
+### Toolchain layer
+FROM debian:buster AS toolchain
+
+# To use http/https proxy while building, use:
+# docker build --build-arg https_proxy=http://fwdproxy:8080 --build-arg http_proxy=http://fwdproxy:8080
+
+RUN apt-get update \
+    && apt-get install -y \
+        cmake=3.13.4-1 \
+        curl=7.64.0-4+deb10u1 \
+        clang=1:7.0-47 \
+        git=1:2.20.1-2+deb10u1 \
+        wget=1.20.1-1.1 \
+    && apt-get clean \
+    && rm -r /var/lib/apt/lists/*
+# 3rd party bin
+RUN mkdir -p /staging/bin && \
+    cd /staging/bin && \
+    wget https://storage.googleapis.com/kubernetes-release/release/v1.17.0/bin/linux/amd64/kubectl -O kubectl
+
+# Rust toolchain
+RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --default-toolchain none
+ENV PATH "$PATH:/root/.cargo/bin"
+
+WORKDIR /staging/libra
+COPY . /staging/libra
+COPY rust-toolchain /staging/rust-toolchain
+RUN rustup install $(cat rust-toolchain)
+
+# Prefetch crates
+RUN cargo fetch
+RUN set -e; shasum -a 256 Cargo.lock | cut -d' ' -f1 > /staging/crates_cache.sha256
+WORKDIR /staging
+RUN rm -rf /staging/libra

--- a/docker/toolchain/build.sh
+++ b/docker/toolchain/build.sh
@@ -1,0 +1,15 @@
+#!/bin/sh
+# Copyright (c) The Libra Core Contributors
+# SPDX-License-Identifier: Apache-2.0
+set -ex
+
+DIR="$( cd "$( dirname "$0" )" && pwd )"
+
+PROXY=""
+if [ "$https_proxy" ]; then
+    PROXY=" --build-arg https_proxy=$https_proxy --build-arg http_proxy=$http_proxy"
+fi
+
+docker build -f $DIR/Dockerfile \
+  $DIR/../.. \
+  --tag toolchain_rust:$(cat $DIR/../../rust-toolchain)-$(shasum -a 256 $DIR/../../Cargo.lock | colrm 9)

--- a/docker/validator-dynamic/build.sh
+++ b/docker/validator-dynamic/build.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
 # Copyright (c) The Libra Core Contributors
 # SPDX-License-Identifier: Apache-2.0
-set -e
+set -ex
 
 DIR="$( cd "$( dirname "$0" )" && pwd )"
 
@@ -11,7 +11,13 @@ if [ "$https_proxy" ]; then
 fi
 
 # Build validator base image first
-docker build -f $DIR/../validator/Dockerfile $DIR/../.. --tag libra_e2e --build-arg GIT_REV="$(git rev-parse HEAD)" --build-arg GIT_UPSTREAM="$(git merge-base HEAD origin/master)" --build-arg BUILD_DATE="$(date -u +'%Y-%m-%dT%H:%M:%SZ')" $PROXY "$@"
+$DIR/../validator/build.sh
 
 # Build validator_dynamic
-docker build -f $DIR/Dockerfile $DIR/../.. --tag libra_validator_dynamic --build-arg GIT_REV="$(git rev-parse HEAD)" --build-arg GIT_UPSTREAM="$(git merge-base HEAD origin/master)" --build-arg BUILD_DATE="$(date -u +'%Y-%m-%dT%H:%M:%SZ')" $PROXY "$@"
+docker build -f $DIR/Dockerfile \
+  $DIR/../.. \
+  --tag libra_validator_dynamic \
+  --build-arg GIT_REV="$(git rev-parse HEAD)" \
+  --build-arg GIT_UPSTREAM="$(git merge-base HEAD origin/master)" \
+  --build-arg BUILD_DATE="$(date -u +'%Y-%m-%dT%H:%M:%SZ')" \
+  $PROXY "$@"

--- a/docker/validator-dynamic/buildspec.yaml
+++ b/docker/validator-dynamic/buildspec.yaml
@@ -13,6 +13,7 @@ phases:
     commands:
       - echo Build started on `date`
       - echo Building the Docker image...
+      - docker/toolchain/build.sh
       - docker/validator/build.sh
       - bash docker/validator-dynamic/build.sh
   post_build:

--- a/docker/validator/Dockerfile
+++ b/docker/validator/Dockerfile
@@ -1,19 +1,8 @@
-FROM debian:buster AS toolchain
-
-# To use http/https proxy while building, use:
-# docker build --build-arg https_proxy=http://fwdproxy:8080 --build-arg http_proxy=http://fwdproxy:8080
-
-RUN apt-get update && apt-get install -y cmake curl clang git
-
-RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --default-toolchain none
-ENV PATH "$PATH:/root/.cargo/bin"
+### Build layer
+ARG TOOLCHAIN_TAG
+FROM toolchain_rust:$TOOLCHAIN_TAG AS builder
 
 WORKDIR /libra
-COPY rust-toolchain /libra/rust-toolchain
-RUN rustup install $(cat rust-toolchain)
-
-FROM toolchain AS builder
-
 COPY . /libra
 
 RUN cargo build --release -p libra-node -p cli -p config-builder -p safety-rules && cd target/release && rm -r build deps incremental

--- a/docker/validator/build.sh
+++ b/docker/validator/build.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
 # Copyright (c) The Libra Core Contributors
 # SPDX-License-Identifier: Apache-2.0
-set -e
+set -ex
 
 DIR="$( cd "$( dirname "$0" )" && pwd )"
 
@@ -10,4 +10,17 @@ if [ "$https_proxy" ]; then
     PROXY=" --build-arg https_proxy=$https_proxy --build-arg http_proxy=$http_proxy"
 fi
 
-docker build -f $DIR/Dockerfile $DIR/../.. --tag libra_e2e --build-arg GIT_REV="$(git rev-parse HEAD)" --build-arg GIT_UPSTREAM="$(git merge-base HEAD origin/master)" --build-arg BUILD_DATE="$(date -u +'%Y-%m-%dT%H:%M:%SZ')" $PROXY "$@"
+TOOLCHAIN_TAG=$(cat $DIR/../../rust-toolchain)-$(shasum -a 256 $DIR/../../Cargo.lock | colrm 9)
+if ! docker image inspect toolchain_rust:$TOOLCHAIN_TAG &> /dev/null; then
+  echo "Image toolchain_rust:$TOOLCHAIN_TAG does not exist locally. Will build it."
+  $DIR/../toolchain/build.sh
+fi
+
+docker build -f $DIR/Dockerfile \
+  $DIR/../.. \
+  --tag libra_e2e \
+  --build-arg TOOLCHAIN_TAG="$TOOLCHAIN_TAG" \
+  --build-arg GIT_REV="$(git rev-parse HEAD)" \
+  --build-arg GIT_UPSTREAM="$(git merge-base HEAD origin/master)" \
+  --build-arg BUILD_DATE="$(date -u +'%Y-%m-%dT%H:%M:%SZ')" \
+  $PROXY "$@"


### PR DESCRIPTION
## Motivation
There are multiple failure points in our CI/CD pipeline. Building the
prod images requires network access to a plephora of sources. Some may
be necessary to get the latest source code, but some, such as 3rd party
tooling binaries, could be and should be cached. This will reduce our
exposure to external dependencies.

The end goal is to build the prod images from the cache layer without
network. For the time being, we want to be able to cache as many
artifacts as possible to limit exposure.

This toolchain cache layer (toolchain_rust) does the following:

    install the matching Rust compiler outlined in libra/rust-toolchain
    prefetch crates
    install 3rd party binaries, such as kubectl

The layer tag includes Rust compiler version and first 8 digits of
sha256 sum of Cargos.lock. For example, at commit 1a8c6c564 in
libra/libra, the tag is 1.42.0-0151b8a7

## Test Plan
- CI
- Built all images locally
- Local CTI 