### PR TITLE
[executor] remove "num_accounts" counter

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1296,7 +1296,6 @@ dependencies = [
  "once_cell 1.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "proptest 0.9.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.7.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "rusty-fork 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "scratchpad 0.1.0",
  "serde_json 1.0.51 (registry+https://github.com/rust-lang/crates.io-index)",
  "stdlib 0.1.0",

--- a/execution/executor-types/src/lib.rs
+++ b/execution/executor-types/src/lib.rs
@@ -129,9 +129,6 @@ pub struct TransactionData {
     /// The amount of gas used.
     gas_used: u64,
 
-    /// The number of newly created accounts.
-    num_account_created: usize,
-
     /// The transaction info hash if the VM status output was keep, None otherwise
     txn_info_hash: Option<HashValue>,
 }
@@ -144,7 +141,6 @@ impl TransactionData {
         state_tree: Arc<SparseMerkleTree>,
         event_tree: Arc<InMemoryAccumulator<EventAccumulatorHasher>>,
         gas_used: u64,
-        num_account_created: usize,
         txn_info_hash: Option<HashValue>,
     ) -> Self {
         TransactionData {
@@ -154,7 +150,6 @@ impl TransactionData {
             state_tree,
             event_tree,
             gas_used,
-            num_account_created,
             txn_info_hash,
         }
     }
@@ -181,10 +176,6 @@ impl TransactionData {
 
     pub fn gas_used(&self) -> u64 {
         self.gas_used
-    }
-
-    pub fn num_account_created(&self) -> usize {
-        self.num_account_created
     }
 
     pub fn prune_state_tree(&self) {

--- a/execution/executor/Cargo.toml
+++ b/execution/executor/Cargo.toml
@@ -32,7 +32,6 @@ storage-interface = { path = "../../storage/storage-interface", version = "0.1.0
 [dev-dependencies]
 proptest = "0.9.6"
 rand = "0.7.3"
-rusty-fork = "0.2.1"
 
 config-builder = { path = "../../config/config-builder", version = "0.1.0" }
 executor-utils = { path = "../executor-utils", version = "0.1.0" }

--- a/execution/executor/src/executor_test.rs
+++ b/execution/executor/src/executor_test.rs
@@ -237,18 +237,6 @@ fn test_executor_execute_same_block_multiple_times() {
     assert_eq!(responses.len(), 1);
 }
 
-rusty_fork_test! {
-    #[test]
-    fn test_num_accounts_created_counter() {
-        let mut executor = TestExecutor::new();
-        let mut parent_block_id = executor.committed_block_id();
-        for i in 0..20 {
-            parent_block_id = execute_and_commit_block(&mut executor, parent_block_id, i);
-            assert_eq!(OP_COUNTERS.counter("num_accounts").get() as u64, i + 1);
-        }
-    }
-}
-
 /// Generates a list of `TransactionListWithProof`s according to the given ranges.
 fn create_transaction_chunks(
     chunk_ranges: Vec<std::ops::Range<Version>>,

--- a/execution/executor/src/executor_test.rs
+++ b/execution/executor/src/executor_test.rs
@@ -8,7 +8,7 @@ use crate::{
         encode_mint_transaction, encode_reconfiguration_transaction, encode_transfer_transaction,
         MockVM, DISCARD_STATUS, KEEP_STATUS,
     },
-    BlockExecutor, Executor, OP_COUNTERS,
+    BlockExecutor, Executor,
 };
 use libra_config::{config::NodeConfig, utils::get_genesis_txn};
 use libra_crypto::{ed25519::Ed25519PrivateKey, HashValue};
@@ -21,7 +21,6 @@ use libra_types::{
 use libradb::LibraDB;
 use proptest::prelude::*;
 use rand::Rng;
-use rusty_fork::{rusty_fork_id, rusty_fork_test, rusty_fork_test_name};
 use std::collections::BTreeMap;
 
 fn build_test_config() -> (NodeConfig, Ed25519PrivateKey) {


### PR DESCRIPTION
in favor of "new_state_leaves" and "stale_state_leaves" counters in storage


## Motivation

The old counter loses its value on restart. 

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?

yes

## Test Plan

removed tests wrt the old counter :P

## Related PRs

#3571 removed usage of the old count in dashboards