### PR TITLE
[DbReader] Replace storage-client with DbReader from AC and Mempool

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -61,7 +61,7 @@ dependencies = [
  "prost 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.7.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.51 (registry+https://github.com/rust-lang/crates.io-index)",
- "storage-client 0.1.0",
+ "storage-interface 0.1.0",
  "tokio 0.2.13 (registry+https://github.com/rust-lang/crates.io-index)",
  "tonic 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "vm-validator 0.1.0",
@@ -2437,12 +2437,13 @@ dependencies = [
  "network 0.1.0",
  "once_cell 1.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "parity-multiaddr 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "prometheus 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "proptest 0.9.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "prost 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.7.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.106 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.51 (registry+https://github.com/rust-lang/crates.io-index)",
- "storage-client 0.1.0",
+ "storage-interface 0.1.0",
  "storage-service 0.1.0",
  "tokio 0.2.13 (registry+https://github.com/rust-lang/crates.io-index)",
  "tonic-build 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -5902,7 +5903,6 @@ name = "vm-validator"
 version = "0.1.0"
 dependencies = [
  "anyhow 1.0.28 (registry+https://github.com/rust-lang/crates.io-index)",
- "async-trait 0.1.30 (registry+https://github.com/rust-lang/crates.io-index)",
  "config-builder 0.1.0",
  "executor 0.1.0",
  "futures 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -5917,7 +5917,6 @@ dependencies = [
  "storage-client 0.1.0",
  "storage-interface 0.1.0",
  "storage-service 0.1.0",
- "tokio 0.2.13 (registry+https://github.com/rust-lang/crates.io-index)",
  "transaction-builder 0.1.0",
 ]
 

--- a/admission-control/admission-control-service/Cargo.toml
+++ b/admission-control/admission-control-service/Cargo.toml
@@ -28,7 +28,7 @@ libra-metrics = { path = "../../common/metrics", version = "0.1.0" }
 libra-types = { path = "../../types", version = "0.1.0" }
 libra-workspace-hack = { path = "../../common/workspace-hack", version = "0.1.0" }
 debug-interface = { path = "../../common/debug-interface", version = "0.1.0" }
-storage-client = { path = "../../storage/storage-client", version = "0.1.0" }
+storage-interface = { path = "../../storage/storage-interface", version = "0.1.0" }
 
 [dev-dependencies]
 assert_matches = "1.3.0"

--- a/admission-control/admission-control-service/src/unit_tests/admission_control_service_test.rs
+++ b/admission-control/admission-control-service/src/unit_tests/admission_control_service_test.rs
@@ -112,7 +112,7 @@ impl AdmissionControl for MockAdmissionControlService {
 
         let mut resp = ProtoSubmitTransactionResponse::default();
 
-        let validation_result = self.mock_vm.validate_transaction(transaction).await;
+        let validation_result = self.mock_vm.validate_transaction(transaction);
         match validation_result.as_ref().map(|result| result.status()) {
             Ok(Some(vm_status)) => {
                 resp.status = Some(Status::VmStatus(VmStatusProto::from(vm_status)));

--- a/json-rpc/src/tests/unit_tests.rs
+++ b/json-rpc/src/tests/unit_tests.rs
@@ -190,7 +190,7 @@ fn test_transaction_submission() {
     runtime.spawn(async move {
         let validator = MockVMValidator;
         while let Some((txn, cb)) = mp_events.next().await {
-            let vm_status = validator.validate_transaction(txn).await.unwrap().status();
+            let vm_status = validator.validate_transaction(txn).unwrap().status();
             let result = if vm_status.is_some() {
                 (MempoolStatus::new(MempoolStatusCode::VmError), vm_status)
             } else {

--- a/libra-node/src/main_node.rs
+++ b/libra-node/src/main_node.rs
@@ -303,8 +303,11 @@ pub fn setup_environment(node_config: &mut NodeConfig) -> LibraHandle {
     );
     let (mp_client_sender, mp_client_events) = channel(AC_SMP_CHANNEL_BUFFER_SIZE);
 
-    let admission_control_runtime =
-        AdmissionControlService::bootstrap(&node_config, mp_client_sender.clone());
+    let admission_control_runtime = AdmissionControlService::bootstrap(
+        &node_config,
+        Arc::clone(&libra_db) as Arc<dyn DbReader>,
+        mp_client_sender.clone(),
+    );
     let rpc_runtime = bootstrap_rpc(&node_config, libra_db.clone(), mp_client_sender);
 
     let mut consensus_runtime = None;
@@ -313,6 +316,7 @@ pub fn setup_environment(node_config: &mut NodeConfig) -> LibraHandle {
     instant = Instant::now();
     let mempool = libra_mempool::bootstrap(
         node_config,
+        Arc::clone(&libra_db) as Arc<dyn DbReader>,
         mempool_network_handles,
         mp_client_events,
         consensus_requests,

--- a/mempool/Cargo.toml
+++ b/mempool/Cargo.toml
@@ -23,6 +23,7 @@ ttl_cache = "0.5.1"
 
 bounded-executor = { path = "../common/bounded-executor", version = "0.1.0" }
 channel = { path = "../common/channel", version = "0.1.0" }
+debug-interface = { path = "../common/debug-interface", version = "0.1.0" }
 lcs = { path = "../common/lcs", version = "0.1.0", package = "libra-canonical-serialization" }
 libra-config = { path = "../config", version = "0.1.0" }
 libra-crypto = { path = "../crypto/crypto", version = "0.1.0" }
@@ -33,10 +34,10 @@ libra-types = { path = "../types", version = "0.1.0" }
 libra-workspace-hack = { path = "../common/workspace-hack", version = "0.1.0" }
 mirai-annotations = "1.7.0"
 network = { path = "../network", version = "0.1.0" }
-storage-client = { path = "../storage/storage-client", version = "0.1.0" }
-vm-validator = { path = "../vm-validator", version = "0.1.0" }
-debug-interface = { path = "../common/debug-interface", version = "0.1.0" }
+prometheus = { version = "0.8.0", default-features = false }
 serde_json = "1.0"
+storage-interface = { path = "../storage/storage-interface", version = "0.1.0" }
+vm-validator = { path = "../vm-validator", version = "0.1.0" }
 
 libra-proptest-helpers = { path = "../common/proptest-helpers", optional = true }
 proptest = { version = "0.9.6", optional = true }
@@ -51,4 +52,4 @@ tonic-build = "0.2"
 
 [features]
 default = []
-fuzzing = ["libra-types/fuzzing", "storage-service", "storage-service/fuzzing"]
+fuzzing = ["libra-types/fuzzing", "storage-interface/fuzzing"]

--- a/mempool/src/shared_mempool/types.rs
+++ b/mempool/src/shared_mempool/types.rs
@@ -24,10 +24,9 @@ use libra_types::{
 use std::{
     collections::HashMap,
     pin::Pin,
-    sync::{Arc, Mutex},
+    sync::{Arc, Mutex, RwLock},
 };
-use storage_client::StorageRead;
-use tokio::sync::RwLock;
+use storage_interface::DbReader;
 use vm_validator::vm_validator::TransactionValidation;
 
 pub(crate) const DEFAULT_MIN_BROADCAST_RECIPIENT_COUNT: usize = 0;
@@ -41,7 +40,7 @@ where
     pub mempool: Arc<Mutex<CoreMempool>>,
     pub config: MempoolConfig,
     pub network_senders: HashMap<PeerId, MempoolNetworkSender>,
-    pub storage_read_client: Arc<dyn StorageRead>,
+    pub db: Arc<dyn DbReader>,
     pub validator: Arc<RwLock<V>>,
     pub peer_manager: Arc<PeerManager>,
     pub subscribers: Vec<UnboundedSender<SharedMempoolNotification>>,

--- a/mempool/src/tests/mocks.rs
+++ b/mempool/src/tests/mocks.rs
@@ -20,13 +20,10 @@ use network::peer_manager::{
 };
 use std::{
     num::NonZeroUsize,
-    sync::{Arc, Mutex},
+    sync::{Arc, Mutex, RwLock},
 };
-use storage_service::mocks::mock_storage_client::MockStorageReadClient;
-use tokio::{
-    runtime::{Builder, Runtime},
-    sync::RwLock,
-};
+use storage_interface::mock::MockDbReader;
+use tokio::runtime::{Builder, Runtime};
 use vm_validator::mocks::mock_vm_validator::MockVMValidator;
 
 /// Mock of a running instance of shared mempool
@@ -96,7 +93,7 @@ impl MockSharedMempool {
             consensus_events,
             state_sync_events,
             reconfig_event_subscriber,
-            Arc::new(MockStorageReadClient),
+            Arc::new(MockDbReader),
             Arc::new(RwLock::new(MockVMValidator)),
             vec![sender],
             None,

--- a/mempool/src/tests/shared_mempool_test.rs
+++ b/mempool/src/tests/shared_mempool_test.rs
@@ -36,14 +36,11 @@ use parity_multiaddr::Multiaddr;
 use std::{
     collections::{HashMap, HashSet},
     num::NonZeroUsize,
-    sync::{Arc, Mutex},
+    sync::{Arc, Mutex, RwLock},
     time::Duration,
 };
-use storage_service::mocks::mock_storage_client::MockStorageReadClient;
-use tokio::{
-    runtime::{Builder, Runtime},
-    sync::RwLock,
-};
+use storage_interface::mock::MockDbReader;
+use tokio::runtime::{Builder, Runtime};
 use vm_validator::mocks::mock_vm_validator::MockVMValidator;
 
 #[derive(Default)]
@@ -100,7 +97,7 @@ fn init_single_shared_mempool(smp: &mut SharedMempoolNetwork, peer_id: PeerId, c
         consensus_events,
         state_sync_events,
         reconfig_events_receiver,
-        Arc::new(MockStorageReadClient),
+        Arc::new(MockDbReader),
         Arc::new(RwLock::new(MockVMValidator)),
         vec![sender],
         Some(timer_receiver.map(|_| SyncEvent).boxed()),
@@ -169,7 +166,7 @@ fn init_smp_multiple_networks(
         consensus_events,
         state_sync_events,
         reconfig_events_receiver,
-        Arc::new(MockStorageReadClient),
+        Arc::new(MockDbReader),
         Arc::new(RwLock::new(MockVMValidator)),
         vec![sender],
         Some(timer_receiver.map(|_| SyncEvent).boxed()),

--- a/secure/json-rpc/src/lib.rs
+++ b/secure/json-rpc/src/lib.rs
@@ -421,11 +421,7 @@ mod test {
             // Provide a VMValidator to the runtime.
             server.spawn(async move {
                 while let Some((txn, cb)) = mp_events.next().await {
-                    let vm_status = MockVMValidator
-                        .validate_transaction(txn)
-                        .await
-                        .unwrap()
-                        .status();
+                    let vm_status = MockVMValidator.validate_transaction(txn).unwrap().status();
                     let result = if vm_status.is_some() {
                         (MempoolStatus::new(MempoolStatusCode::VmError), vm_status)
                     } else {

--- a/secure/key-manager/src/tests.rs
+++ b/secure/key-manager/src/tests.rs
@@ -376,11 +376,7 @@ fn setup_json_client_and_server(db_rw: DbReaderWriter) -> (JsonRpcClient, Runtim
     // Provide a VMValidator to the runtime.
     server.spawn(async move {
         while let Some((txn, cb)) = mp_events.next().await {
-            let vm_status = MockVMValidator
-                .validate_transaction(txn)
-                .await
-                .unwrap()
-                .status();
+            let vm_status = MockVMValidator.validate_transaction(txn).unwrap().status();
             let result = if vm_status.is_some() {
                 (MempoolStatus::new(MempoolStatusCode::VmError), vm_status)
             } else {

--- a/storage/libradb/src/lib.rs
+++ b/storage/libradb/src/lib.rs
@@ -609,6 +609,19 @@ impl LibraDB {
 }
 
 impl DbReader for LibraDB {
+    fn update_to_latest_ledger(
+        &self,
+        client_known_version: Version,
+        request_items: Vec<RequestItem>,
+    ) -> Result<(
+        Vec<ResponseItem>,
+        LedgerInfoWithSignatures,
+        EpochChangeProof,
+        AccumulatorConsistencyProof,
+    )> {
+        Self::update_to_latest_ledger(&self, client_known_version, request_items)
+    }
+
     fn get_epoch_change_ledger_infos(
         &self,
         start_epoch: u64,

--- a/storage/storage-interface/Cargo.toml
+++ b/storage/storage-interface/Cargo.toml
@@ -22,3 +22,7 @@ libra-state-view = { path = "../../storage/state-view", version = "0.1.0" }
 libra-types = { path = "../../types", version = "0.1.0" }
 libra-workspace-hack = { path = "../../common/workspace-hack", version = "0.1.0" }
 scratchpad = { path = "../scratchpad", version = "0.1.0" }
+
+[features]
+default = []
+fuzzing = ["libra-types/fuzzing"]

--- a/storage/storage-interface/src/lib.rs
+++ b/storage/storage-interface/src/lib.rs
@@ -12,6 +12,7 @@ use libra_types::{
     contract_event::ContractEvent,
     epoch_change::EpochChangeProof,
     event::EventKey,
+    get_with_proof::{RequestItem, ResponseItem},
     ledger_info::LedgerInfoWithSignatures,
     move_resource::MoveStorage,
     on_chain_config::ValidatorSet,
@@ -26,6 +27,8 @@ use std::{
 };
 use thiserror::Error;
 
+#[cfg(any(feature = "testing", feature = "fuzzing"))]
+pub mod mock;
 pub mod state_view;
 
 #[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
@@ -125,6 +128,20 @@ impl From<libra_secure_net::Error> for Error {
 /// Trait that is implemented by a DB that supports certain public (to client) read APIs
 /// expected of a Libra DB
 pub trait DbReader: Send + Sync {
+    // TODO: Remove this API after deprecating AC.
+    fn update_to_latest_ledger(
+        &self,
+        _client_known_version: Version,
+        _request_items: Vec<RequestItem>,
+    ) -> Result<(
+        Vec<ResponseItem>,
+        LedgerInfoWithSignatures,
+        EpochChangeProof,
+        AccumulatorConsistencyProof,
+    )> {
+        unimplemented!()
+    }
+
     /// See [`LibraDB::get_epoch_change_ledger_infos`].
     ///
     /// [`LibraDB::get_epoch_change_ledger_infos`]:

--- a/storage/storage-interface/src/mock.rs
+++ b/storage/storage-interface/src/mock.rs
@@ -1,0 +1,151 @@
+// Copyright (c) The Libra Core Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+//! This module provides mock dbreader for tests.
+
+use crate::{DbReader, StartupInfo, TreeState};
+use anyhow::Result;
+use libra_crypto::HashValue;
+use libra_types::{
+    account_address::AccountAddress,
+    account_config::{from_currency_code_string, AccountResource, LBR_NAME},
+    account_state::AccountState,
+    account_state_blob::{AccountStateBlob, AccountStateWithProof},
+    contract_event::ContractEvent,
+    epoch_change::EpochChangeProof,
+    event::{EventHandle, EventKey},
+    ledger_info::LedgerInfoWithSignatures,
+    move_resource::MoveResource,
+    proof::{AccumulatorConsistencyProof, SparseMerkleProof},
+    transaction::{TransactionListWithProof, TransactionWithProof, Version},
+};
+use std::convert::TryFrom;
+
+/// This is a mock of the dbreader in tests.
+pub struct MockDbReader;
+
+impl DbReader for MockDbReader {
+    fn get_epoch_change_ledger_infos(
+        &self,
+        _start_epoch: u64,
+        _end_epoch: u64,
+    ) -> Result<EpochChangeProof> {
+        unimplemented!()
+    }
+
+    fn get_transactions(
+        &self,
+        _start_version: Version,
+        _batch_size: u64,
+        _ledger_version: Version,
+        _fetch_events: bool,
+    ) -> Result<TransactionListWithProof> {
+        unimplemented!()
+    }
+
+    /// Returns events by given event key
+    fn get_events(
+        &self,
+        _event_key: &EventKey,
+        _start: u64,
+        _ascending: bool,
+        _limit: u64,
+    ) -> Result<Vec<(u64, ContractEvent)>> {
+        unimplemented!()
+    }
+
+    fn get_latest_account_state(
+        &self,
+        _address: AccountAddress,
+    ) -> Result<Option<AccountStateBlob>> {
+        Ok(Some(get_mock_account_state_blob()))
+    }
+
+    /// Returns the latest ledger info.
+    fn get_latest_ledger_info(&self) -> Result<LedgerInfoWithSignatures> {
+        unimplemented!()
+    }
+
+    fn get_startup_info(&self) -> Result<Option<StartupInfo>> {
+        unimplemented!()
+    }
+
+    fn get_txn_by_account(
+        &self,
+        _address: AccountAddress,
+        _seq_num: u64,
+        _ledger_version: Version,
+        _fetch_events: bool,
+    ) -> Result<Option<TransactionWithProof>> {
+        unimplemented!()
+    }
+
+    fn get_state_proof_with_ledger_info(
+        &self,
+        _known_version: u64,
+        _ledger_info: LedgerInfoWithSignatures,
+    ) -> Result<(EpochChangeProof, AccumulatorConsistencyProof)> {
+        unimplemented!()
+    }
+
+    fn get_state_proof(
+        &self,
+        _known_version: u64,
+    ) -> Result<(
+        LedgerInfoWithSignatures,
+        EpochChangeProof,
+        AccumulatorConsistencyProof,
+    )> {
+        unimplemented!()
+    }
+
+    fn get_account_state_with_proof(
+        &self,
+        _address: AccountAddress,
+        _version: Version,
+        _ledger_version: Version,
+    ) -> Result<AccountStateWithProof> {
+        unimplemented!()
+    }
+
+    fn get_account_state_with_proof_by_version(
+        &self,
+        _address: AccountAddress,
+        _version: Version,
+    ) -> Result<(Option<AccountStateBlob>, SparseMerkleProof)> {
+        unimplemented!()
+    }
+
+    fn get_latest_state_root(&self) -> Result<(Version, HashValue)> {
+        unimplemented!()
+    }
+
+    fn get_latest_tree_state(&self) -> Result<TreeState> {
+        unimplemented!()
+    }
+
+    fn get_ledger_info(&self, _known_version: u64) -> Result<LedgerInfoWithSignatures> {
+        unimplemented!()
+    }
+}
+
+fn get_mock_account_state_blob() -> AccountStateBlob {
+    let account_resource = AccountResource::new(
+        0,
+        vec![],
+        false,
+        false,
+        EventHandle::random_handle(0),
+        EventHandle::random_handle(0),
+        false,
+        from_currency_code_string(LBR_NAME).unwrap(),
+    );
+
+    let mut account_state = AccountState::default();
+    account_state.insert(
+        AccountResource::resource_path(),
+        lcs::to_bytes(&account_resource).unwrap(),
+    );
+
+    AccountStateBlob::try_from(&account_state).unwrap()
+}

--- a/vm-validator/Cargo.toml
+++ b/vm-validator/Cargo.toml
@@ -11,9 +11,7 @@ edition = "2018"
 
 [dependencies]
 anyhow = "1.0"
-async-trait = "0.1"
 futures = "0.3.0"
-tokio = { version = "0.2.13", features = ["full"] }
 libra-config = { path = "../config", version = "0.1.0" }
 scratchpad = { path = "../storage/scratchpad", version = "0.1.0" }
 libra-state-view = { path = "../storage/state-view", version = "0.1.0" }

--- a/vm-validator/src/mocks/mock_vm_validator.rs
+++ b/vm-validator/src/mocks/mock_vm_validator.rs
@@ -26,10 +26,9 @@ impl VMValidator for MockVMValidator {
     }
 }
 
-#[async_trait::async_trait]
 impl TransactionValidation for MockVMValidator {
     type ValidationInstance = MockVMValidator;
-    async fn validate_transaction(&self, txn: SignedTransaction) -> Result<VMValidatorResult> {
+    fn validate_transaction(&self, txn: SignedTransaction) -> Result<VMValidatorResult> {
         let txn = match txn.check_signature() {
             Ok(txn) => txn,
             Err(_) => {

--- a/vm-validator/src/vm_validator.rs
+++ b/vm-validator/src/vm_validator.rs
@@ -11,19 +11,17 @@ use libra_types::{
 use libra_vm::LibraVM;
 use scratchpad::SparseMerkleTree;
 use std::{convert::TryFrom, sync::Arc};
-use storage_client::StorageRead;
 use storage_interface::{state_view::VerifiedStateView, DbReader};
 
 #[cfg(test)]
 #[path = "unit_tests/vm_validator_test.rs"]
 mod vm_validator_test;
 
-#[async_trait::async_trait]
 pub trait TransactionValidation: Send + Sync + Clone {
     type ValidationInstance: libra_vm::VMValidator;
 
     /// Validate a txn from client
-    async fn validate_transaction(&self, _txn: SignedTransaction) -> Result<VMValidatorResult>;
+    fn validate_transaction(&self, _txn: SignedTransaction) -> Result<VMValidatorResult>;
 
     /// Restart the transaction validation instance
     fn restart(&mut self, config: OnChainConfigPayload) -> Result<()>;
@@ -48,35 +46,20 @@ impl VMValidator {
     }
 }
 
-#[async_trait::async_trait]
 impl TransactionValidation for VMValidator {
     type ValidationInstance = LibraVM;
 
-    async fn validate_transaction(&self, txn: SignedTransaction) -> Result<VMValidatorResult> {
+    fn validate_transaction(&self, txn: SignedTransaction) -> Result<VMValidatorResult> {
         use libra_vm::VMValidator;
 
         let (version, state_root) = self.db_reader.get_latest_state_root()?;
         let db_reader = Arc::clone(&self.db_reader);
         let vm = self.vm.clone();
-        // We have to be careful here. The storage read client only exposes async functions but the
-        // whole VM is synchronous and async/await isn't currently using in the VM. Due to this
-        // there is a trick in the StateView impl which spawns a task on a runtime to actually do
-        // the async read while using "block_on" to synchronously wait for the read to complete.
-        // This is where things get tricky. If that task is spawned onto the same thread in the
-        // pool as the task that is using "block_on" then there is a chance that the read will
-        // never complete since it will be resource starved resulting in the "block_on" task
-        // hanging forever.
-        //
-        // In order to work around this issue we can use "spawn_blocking" to move the task that is
-        // using "block_on" to its own thread, where it won't interfere with have a chance to
-        // starve other async tasks.
-        tokio::task::spawn_blocking(move || {
-            let smt = SparseMerkleTree::new(state_root);
-            let state_view = VerifiedStateView::new(db_reader, Some(version), state_root, &smt);
-            vm.validate_transaction(txn, &state_view)
-        })
-        .await
-        .map_err(Into::into)
+
+        let smt = SparseMerkleTree::new(state_root);
+        let state_view = VerifiedStateView::new(db_reader, Some(version), state_root, &smt);
+
+        Ok(vm.validate_transaction(txn, &state_view))
     }
 
     fn restart(&mut self, config: OnChainConfigPayload) -> Result<()> {
@@ -89,14 +72,8 @@ impl TransactionValidation for VMValidator {
 }
 
 /// returns account's sequence number from storage
-pub async fn get_account_sequence_number(
-    storage_read_client: Arc<dyn StorageRead>,
-    address: AccountAddress,
-) -> Result<u64> {
-    match storage_read_client
-        .get_latest_account_state(address)
-        .await?
-    {
+pub fn get_account_sequence_number(storage: &dyn DbReader, address: AccountAddress) -> Result<u64> {
+    match storage.get_latest_account_state(address)? {
         Some(blob) => Ok(AccountResource::try_from(&blob)?.sequence_number()),
         None => Ok(0),
     }


### PR DESCRIPTION
## Motivation

As title. Cleanup grpc based api from Ac and Mempool.
According to #2519 

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?

Y

## Test Plan

CI


