### PR TITLE
[move-prover] Support "pack" in spec

### DIFF
--- a/language/move-prover/src/bytecode_translator.rs
+++ b/language/move-prover/src/bytecode_translator.rs
@@ -679,7 +679,7 @@ impl<'env> ModuleTranslator<'env> {
         }
 
         emitln!(self.writer, "\n// initialize function execution");
-        emitln!(self.writer, "assume !$abort_flag;");
+        emitln!(self.writer, "assert !$abort_flag;");
         emitln!(self.writer, "$saved_m := $m;");
         emitln!(self.writer, "$frame := $local_counter;");
 

--- a/language/move-prover/src/prelude.bpl
+++ b/language/move-prover/src/prelude.bpl
@@ -395,8 +395,8 @@ function {:inline} $UpdateLocal(m: Memory, idx: int, v: Value): Memory {
 procedure {:inline 1} $InitVerification() {
   // Set local counter to 0
   $local_counter := 0;
-  // Assume sender account exists.
-  assume $ExistsTxnSenderAccount($m, $txn);
+  // Set abort_flag to false
+  $abort_flag := false;
 }
 
 // ============================================================================================

--- a/language/move-prover/tests/sources/resources.exp
+++ b/language/move-prover/tests/sources/resources.exp
@@ -1,10 +1,10 @@
 Move prover returns: exiting with boogie verification errors
 error:  A postcondition might not hold on this return path.
 
-    ┌── tests/sources/resources.move:29:9 ───
+    ┌── tests/sources/resources.move:29:6 ───
     │
- 29 │         ensures exists<R>(sender());
-    │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+ 29 │      ensures exists<R>(sender());
+    │      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
     │
     =     at tests/sources/resources.move:22:5: create_resource_incorrect (entry)
     =     at tests/sources/resources.move:23:9: create_resource_incorrect

--- a/language/move-prover/tests/sources/restrictions.exp
+++ b/language/move-prover/tests/sources/restrictions.exp
@@ -31,14 +31,6 @@ error: [boogie translator] `|x|e` (lambda) currently only supported as argument 
     │                     ^^^^^^^^^
     │
 
-error: [boogie translator] Pack not yet supported
-
-    ┌── tests/sources/restrictions.move:28:13 ───
-    │
- 28 │             S{f: 1}
-    │             ^^^^^^^
-    │
-
 error: [boogie translator] Shl not yet supported
 
     ┌── tests/sources/restrictions.move:33:13 ───


### PR DESCRIPTION
- Implemented the translation of pack expressions in spec
- Set `$abort_flag` to be `false` in `$InitVerification()` in Prelude initially, and let it asserted in other places in the generated Boogie procedure
- Added the specification for LibraAccount::create_account
- Added the test cases in `resource.move` that reveal a bug
    - Marked by "FIXME" comments in the file
    - The bug is that the return value of `MoveFrom` is not correctly assumed to be well-typed, so cannot be equated with some other well-typed resources (i.e., ones from `pack` operation).

## Motivation

To support "pack expressions" in spec

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

cargo test
