### PR TITLE
[language] Update source-map to use LCS. Add to move lang compiler

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -485,12 +485,12 @@ dependencies = [
  "anyhow 1.0.28 (registry+https://github.com/rust-lang/crates.io-index)",
  "codespan 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "codespan-reporting 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libra-canonical-serialization 0.1.0",
  "libra-types 0.1.0",
  "libra-workspace-hack 0.1.0",
  "move-core-types 0.1.0",
  "move-ir-types 0.1.0",
  "serde 1.0.106 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde_json 1.0.51 (registry+https://github.com/rust-lang/crates.io-index)",
  "vm 0.1.0",
 ]
 
@@ -787,6 +787,7 @@ dependencies = [
  "bytecode-source-map 0.1.0",
  "bytecode-verifier 0.1.0",
  "ir-to-bytecode 0.1.0",
+ "libra-canonical-serialization 0.1.0",
  "libra-types 0.1.0",
  "libra-workspace-hack 0.1.0",
  "move-ir-types 0.1.0",
@@ -1212,8 +1213,6 @@ dependencies = [
  "libra-workspace-hack 0.1.0",
  "move-core-types 0.1.0",
  "move-ir-types 0.1.0",
- "serde 1.0.106 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde_json 1.0.51 (registry+https://github.com/rust-lang/crates.io-index)",
  "structopt 0.3.14 (registry+https://github.com/rust-lang/crates.io-index)",
  "vm 0.1.0",
 ]
@@ -3082,6 +3081,7 @@ dependencies = [
  "functional-tests 0.1.0",
  "hex 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "ir-to-bytecode 0.1.0",
+ "libra-canonical-serialization 0.1.0",
  "libra-types 0.1.0",
  "libra-workspace-hack 0.1.0",
  "move-ir-types 0.1.0",

--- a/language/compiler/Cargo.toml
+++ b/language/compiler/Cargo.toml
@@ -19,6 +19,7 @@ libra-types = { path = "../../types", version = "0.1.0" }
 libra-workspace-hack = { path = "../../common/workspace-hack", version = "0.1.0" }
 move-ir-types = { path = "../move-ir/types", version = "0.1.0" }
 vm = { path = "../vm", version = "0.1.0" }
+lcs = { path = "../../common/lcs", version = "0.1.0", package = "libra-canonical-serialization" }
 structopt = "0.3.14"
 serde_json = "1.0.51"
 

--- a/language/compiler/bytecode-source-map/Cargo.toml
+++ b/language/compiler/bytecode-source-map/Cargo.toml
@@ -13,10 +13,10 @@ libra-workspace-hack = { path = "../../../common/workspace-hack", version = "0.1
 move-core-types = { path = "../../move-core/types", version = "0.1.0" }
 move-ir-types = { path = "../../move-ir/types", version = "0.1.0" }
 vm = { path = "../../vm", version = "0.1.0" }
+lcs = { path = "../../../common/lcs", version = "0.1.0", package = "libra-canonical-serialization" }
 codespan = "0.8.0"
 codespan-reporting = "0.8.0"
-serde = { version = "1", features = ["derive"] }
-serde_json = "1"
+serde = { version = "1.0.106", default-features = false }
 
 [features]
 default = []

--- a/language/compiler/src/main.rs
+++ b/language/compiler/src/main.rs
@@ -163,8 +163,8 @@ fn main() {
         };
 
         if args.output_source_maps {
-            let source_map_bytes = serde_json::to_vec(&source_map)
-                .expect("Unable to serialize source maps for script");
+            let source_map_bytes =
+                lcs::to_bytes(&source_map).expect("Unable to serialize source maps for script");
             write_output(
                 &source_path.with_extension(source_map_extension),
                 &source_map_bytes,
@@ -187,8 +187,8 @@ fn main() {
         };
 
         if args.output_source_maps {
-            let source_map_bytes = serde_json::to_vec(&source_map)
-                .expect("Unable to serialize source maps for module");
+            let source_map_bytes =
+                lcs::to_bytes(&source_map).expect("Unable to serialize source maps for module");
             write_output(
                 &source_path.with_extension(source_map_extension),
                 &source_map_bytes,

--- a/language/move-lang/Cargo.toml
+++ b/language/move-lang/Cargo.toml
@@ -25,6 +25,7 @@ move-ir-types = {path = "../move-ir/types" }
 ir-to-bytecode = {path = "../compiler/ir-to-bytecode" }
 borrow-graph = { path = "../borrow-graph" }
 bytecode-source-map = { path = "../compiler/bytecode-source-map" }
+lcs = { path = "../../common/lcs", version = "0.1.0", package = "libra-canonical-serialization" }
 
 
 [dev-dependencies]

--- a/language/move-lang/src/bin/move-build.rs
+++ b/language/move-lang/src/bin/move-build.rs
@@ -45,6 +45,14 @@ pub struct Options {
         default_value = cli::DEFAULT_OUTPUT_DIR,
     )]
     pub out_dir: String,
+
+    /// Save bytecode source map to disk
+    #[structopt(
+        name = "",
+        short = cli::SOURCE_MAP_SHORT,
+        long = cli::SOURCE_MAP,
+    )]
+    pub emit_source_map: bool,
 }
 
 pub fn main() {
@@ -63,7 +71,8 @@ fn main_impl() -> std::io::Result<()> {
         dependencies,
         sender,
         out_dir,
+        emit_source_map,
     } = Options::from_args();
     let (files, compiled_units) = move_lang::move_compile(&source_files, &dependencies, sender)?;
-    move_lang::output_compiled_units(files, compiled_units, &out_dir)
+    move_lang::output_compiled_units(emit_source_map, files, compiled_units, &out_dir)
 }

--- a/language/move-lang/src/command_line/mod.rs
+++ b/language/move-lang/src/command_line/mod.rs
@@ -16,6 +16,9 @@ pub const OUT_DIR: &str = "out-dir";
 pub const OUT_DIR_SHORT: &str = "o";
 pub const DEFAULT_OUTPUT_DIR: &str = "output";
 
+pub const SOURCE_MAP: &str = "source-map";
+pub const SOURCE_MAP_SHORT: &str = "m";
+
 pub fn parse_address(s: &str) -> Result<Address, String> {
     Address::parse_str(s).map_err(|msg| format!("Invalid argument to '{}': {}", SENDER, msg))
 }

--- a/language/move-lang/src/compiled_unit.rs
+++ b/language/move-lang/src/compiled_unit.rs
@@ -78,6 +78,13 @@ impl CompiledUnit {
         .into()
     }
 
+    pub fn serialize_source_map(&self) -> Vec<u8> {
+        match self {
+            CompiledUnit::Module { source_map, .. } => lcs::to_bytes(source_map).unwrap(),
+            CompiledUnit::Script { source_map, .. } => lcs::to_bytes(source_map).unwrap(),
+        }
+    }
+
     pub fn verify(self) -> (Self, Errors) {
         match self {
             CompiledUnit::Module {

--- a/language/tools/disassembler/Cargo.toml
+++ b/language/tools/disassembler/Cargo.toml
@@ -18,8 +18,6 @@ move-ir-types = { path = "../../move-ir/types", version = "0.1.0" }
 vm = { path = "../../vm", version = "0.1.0" }
 
 structopt = "0.3.14"
-serde = { version = "1", features = ["derive"] }
-serde_json = "1"
 
 [features]
 default = []


### PR DESCRIPTION
This PR updates the source-map to use LCS for serialization/deserialization. It also adds a source-map deserialization option to the Move language compiler.

An example:

`tester.move`:

```rust 
address 0x0:
module BlahBlah {
    resource struct X<T> {
        a: T,
    }

    public fun tester<A: copyable, B>(a: A, b: B): B {
        let _y = a;
        let r = b;
        r
    }
}
```

```
cargo run --bin move-build -- -m -f tester.move
```

After which `cargo run -- -b ../../move-lang/output/transaction_0_module_BlahBlah.mv` produces the following disassembly:
```rust
module 00000000.BlahBlah {
resource X<T: All> {
        a: T
}

public tester<A: Copyable, B: All>(a: A, b: B): B {
L0:     r: B
B0:
        0: MoveLoc[0](a: A)
        1: Pop
        2: MoveLoc[1](b: B)
        3: StLoc[2](r: B)
        4: MoveLoc[2](r: B)
        5: Ret
}
}
```