### PR TITLE
[crypto] Rename ValidKey to ValidCryptoMaterial

### DIFF
--- a/client/cli/src/client_proxy.rs
+++ b/client/cli/src/client_proxy.rs
@@ -10,8 +10,8 @@ use anyhow::{bail, ensure, format_err, Error, Result};
 use libra_crypto::{
     ed25519::{Ed25519PrivateKey, Ed25519PublicKey, Ed25519Signature},
     test_utils::KeyPair,
-    traits::ValidKey,
-    x25519, ValidKeyStringExt,
+    traits::ValidCryptoMaterial,
+    x25519, ValidCryptoMaterialStringExt,
 };
 use libra_json_rpc_client::views::{AccountView, BlockMetadata, EventView, TransactionView};
 use libra_logger::prelude::*;

--- a/client/cli/src/lib.rs
+++ b/client/cli/src/lib.rs
@@ -12,7 +12,7 @@
 use libra_crypto::{
     ed25519::{Ed25519PrivateKey, Ed25519PublicKey},
     test_utils::KeyPair,
-    traits::ValidKeyStringExt,
+    traits::ValidCryptoMaterialStringExt,
 };
 use libra_types::account_address::AccountAddress;
 use serde::{Deserialize, Serialize};

--- a/config/src/keys.rs
+++ b/config/src/keys.rs
@@ -12,7 +12,7 @@
 //! while ignored during serialization.
 //!
 
-use libra_crypto::{PrivateKey, ValidKeyStringExt};
+use libra_crypto::{PrivateKey, ValidCryptoMaterialStringExt};
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
 
 #[cfg(test)]
@@ -24,7 +24,7 @@ use libra_crypto::Uniform;
 #[derive(Debug, PartialEq)]
 pub struct KeyPair<T>
 where
-    T: PrivateKey + Serialize + ValidKeyStringExt,
+    T: PrivateKey + Serialize + ValidCryptoMaterialStringExt,
 {
     private_key: Option<T>,
     public_key: T::PublicKeyMaterial,
@@ -33,7 +33,7 @@ where
 #[cfg(test)]
 impl<T> Default for KeyPair<T>
 where
-    T: PrivateKey + Serialize + Uniform + ValidKeyStringExt,
+    T: PrivateKey + Serialize + Uniform + ValidCryptoMaterialStringExt,
 {
     fn default() -> Self {
         let private_key = T::generate_for_testing();
@@ -47,7 +47,7 @@ where
 
 impl<T> KeyPair<T>
 where
-    T: PrivateKey + Serialize + ValidKeyStringExt,
+    T: PrivateKey + Serialize + ValidCryptoMaterialStringExt,
 {
     /// This transforms a private key into a keypair data structure.
     pub fn load(private_key: T) -> Self {
@@ -76,12 +76,12 @@ where
 /// Serialization for a KeyPair only serializes the private key part (if present).
 impl<T> Serialize for KeyPair<T>
 where
-    T: PrivateKey + Serialize + ValidKeyStringExt,
+    T: PrivateKey + Serialize + ValidCryptoMaterialStringExt,
 {
     fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
     where
         S: Serializer,
-        T: Serialize + ValidKeyStringExt,
+        T: Serialize + ValidCryptoMaterialStringExt,
     {
         match &self.private_key {
             Some(key) => key.serialize(serializer),
@@ -93,7 +93,7 @@ where
 /// Deserializing a keypair only deserializes the private key, and dynamically derives the public key.
 impl<'de, T> Deserialize<'de> for KeyPair<T>
 where
-    T: PrivateKey + ValidKeyStringExt,
+    T: PrivateKey + ValidCryptoMaterialStringExt,
 {
     fn deserialize<D>(deserializer: D) -> std::result::Result<KeyPair<T>, D::Error>
     where

--- a/crypto/crypto-derive/src/unions.rs
+++ b/crypto/crypto-derive/src/unions.rs
@@ -33,7 +33,7 @@ pub fn impl_enum_tryfrom(name: &Ident, variants: &DataEnum) -> proc_macro2::Toke
     let mut try_iter = variants.variants.iter();
     let first_variant = try_iter
         .next()
-        .expect("#[derive(ValidKey] requires a non-empty enum.");
+        .expect("#[derive(ValidCryptoMaterial] requires a non-empty enum.");
     let first_variant_ident = &first_variant.ident;
     let first_variant_arg = &first_variant
         .fields
@@ -69,7 +69,7 @@ pub fn impl_enum_tryfrom(name: &Ident, variants: &DataEnum) -> proc_macro2::Toke
 }
 
 fn match_enum_to_bytes(name: &Ident, variants: &DataEnum) -> proc_macro2::TokenStream {
-    // the ValidKey dispatch proper
+    // the ValidCryptoMaterial dispatch proper
     let mut match_arms = quote! {};
     for variant in variants.variants.iter() {
         let variant_ident = &variant.ident;
@@ -81,14 +81,14 @@ fn match_enum_to_bytes(name: &Ident, variants: &DataEnum) -> proc_macro2::TokenS
     match_arms
 }
 
-pub fn impl_enum_validkey(name: &Ident, variants: &DataEnum) -> TokenStream {
+pub fn impl_enum_valid_crypto_material(name: &Ident, variants: &DataEnum) -> TokenStream {
     let mut try_from = impl_enum_tryfrom(name, variants);
 
     let to_bytes_arms = match_enum_to_bytes(name, variants);
 
     try_from.extend(quote! {
 
-        impl libra_crypto::ValidKey for #name {
+        impl libra_crypto::ValidCryptoMaterial for #name {
             fn to_bytes(&self) -> Vec<u8> {
                 match self {
                     #to_bytes_arms

--- a/crypto/crypto/src/ed25519.rs
+++ b/crypto/crypto/src/ed25519.rs
@@ -217,7 +217,7 @@ impl Length for Ed25519PrivateKey {
     }
 }
 
-impl ValidKey for Ed25519PrivateKey {
+impl ValidCryptoMaterial for Ed25519PrivateKey {
     fn to_bytes(&self) -> Vec<u8> {
         self.to_bytes().to_vec()
     }
@@ -323,7 +323,7 @@ impl Length for Ed25519PublicKey {
     }
 }
 
-impl ValidKey for Ed25519PublicKey {
+impl ValidCryptoMaterial for Ed25519PublicKey {
     fn to_bytes(&self) -> Vec<u8> {
         self.0.to_bytes().to_vec()
     }
@@ -390,7 +390,7 @@ impl Length for Ed25519Signature {
     }
 }
 
-impl ValidKey for Ed25519Signature {
+impl ValidCryptoMaterial for Ed25519Signature {
     fn to_bytes(&self) -> Vec<u8> {
         self.to_bytes().to_vec()
     }

--- a/crypto/crypto/src/multi_ed25519.rs
+++ b/crypto/crypto/src/multi_ed25519.rs
@@ -207,7 +207,7 @@ impl Length for MultiEd25519PrivateKey {
     }
 }
 
-impl ValidKey for MultiEd25519PrivateKey {
+impl ValidCryptoMaterial for MultiEd25519PrivateKey {
     fn to_bytes(&self) -> Vec<u8> {
         self.to_bytes()
     }
@@ -312,7 +312,7 @@ impl Length for MultiEd25519PublicKey {
     }
 }
 
-impl ValidKey for MultiEd25519PublicKey {
+impl ValidCryptoMaterial for MultiEd25519PublicKey {
     fn to_bytes(&self) -> Vec<u8> {
         self.to_bytes()
     }
@@ -440,7 +440,7 @@ impl fmt::Debug for MultiEd25519Signature {
     }
 }
 
-impl ValidKey for MultiEd25519Signature {
+impl ValidCryptoMaterial for MultiEd25519Signature {
     fn to_bytes(&self) -> Vec<u8> {
         self.to_bytes()
     }
@@ -510,8 +510,11 @@ impl From<Ed25519Signature> for MultiEd25519Signature {
 //////////////////////
 
 // Helper function required to MultiEd25519 keys to_bytes to add the threshold.
-fn to_bytes<T: ValidKey>(keys: &[T], threshold: u8) -> Vec<u8> {
-    let mut bytes: Vec<u8> = keys.iter().flat_map(ValidKey::to_bytes).collect();
+fn to_bytes<T: ValidCryptoMaterial>(keys: &[T], threshold: u8) -> Vec<u8> {
+    let mut bytes: Vec<u8> = keys
+        .iter()
+        .flat_map(ValidCryptoMaterial::to_bytes)
+        .collect();
     bytes.push(threshold);
     bytes
 }

--- a/crypto/crypto/src/unit_tests/cross_test.rs
+++ b/crypto/crypto/src/unit_tests/cross_test.rs
@@ -14,7 +14,7 @@ use crate::{
 use crate::hash::HashValue;
 
 use libra_crypto_derive::{
-    PrivateKey, PublicKey, Signature, SigningKey, SilentDebug, ValidKey, VerifyingKey,
+    PrivateKey, PublicKey, Signature, SigningKey, SilentDebug, ValidCryptoMaterial, VerifyingKey,
 };
 use proptest::prelude::*;
 use serde::{Deserialize, Serialize};
@@ -29,7 +29,16 @@ use serde::{Deserialize, Serialize};
 //
 
 #[derive(
-    Serialize, Deserialize, Debug, Clone, PartialEq, Eq, Hash, ValidKey, PublicKey, VerifyingKey,
+    Serialize,
+    Deserialize,
+    Debug,
+    Clone,
+    PartialEq,
+    Eq,
+    Hash,
+    ValidCryptoMaterial,
+    PublicKey,
+    VerifyingKey,
 )]
 #[PrivateKeyType = "PrivateK"]
 #[SignatureType = "Sig"]
@@ -38,7 +47,7 @@ enum PublicK {
     MultiEd(MultiEd25519PublicKey),
 }
 
-#[derive(Serialize, Deserialize, SilentDebug, ValidKey, PrivateKey, SigningKey)]
+#[derive(Serialize, Deserialize, SilentDebug, ValidCryptoMaterial, PrivateKey, SigningKey)]
 #[PublicKeyType = "PublicK"]
 #[SignatureType = "Sig"]
 enum PrivateK {

--- a/crypto/crypto/src/x25519.rs
+++ b/crypto/crypto/src/x25519.rs
@@ -20,7 +20,7 @@
 //! let public_key = private_key.public_key();
 //!
 //! // Deserialize an hexadecimal private or public key
-//! use libra_crypto::traits::ValidKeyStringExt;
+//! use libra_crypto::traits::ValidCryptoMaterialStringExt;
 //! # fn main() -> Result<(), libra_crypto::traits::CryptoMaterialError> {
 //! let private_key = "404acc8ec6a0f18df7359a6ee7823f19dd95616b10fed8bdb0de030e891b945a";
 //! let private_key = x25519::PrivateKey::from_encoded_string(&private_key)?;
@@ -31,7 +31,7 @@
 //! ```
 //!
 
-use crate::traits::{self, ValidKey, ValidKeyStringExt};
+use crate::traits::{self, ValidCryptoMaterial, ValidCryptoMaterialStringExt};
 use libra_crypto_derive::{DeserializeKey, SerializeKey, SilentDebug, SilentDisplay};
 use rand::{CryptoRng, RngCore};
 use std::convert::{TryFrom, TryInto};
@@ -140,7 +140,7 @@ impl traits::Uniform for PrivateKey {
 }
 
 // TODO: should this be gated under test flag? (mimoo)
-impl traits::ValidKey for PrivateKey {
+impl traits::ValidCryptoMaterial for PrivateKey {
     fn to_bytes(&self) -> Vec<u8> {
         self.0.to_bytes().to_vec()
     }
@@ -195,7 +195,7 @@ impl traits::PublicKey for PublicKey {
     type PrivateKeyMaterial = PrivateKey;
 }
 
-impl traits::ValidKey for PublicKey {
+impl traits::ValidCryptoMaterial for PublicKey {
     fn to_bytes(&self) -> Vec<u8> {
         self.0.to_vec()
     }

--- a/language/tools/vm-genesis/src/lib.rs
+++ b/language/tools/vm-genesis/src/lib.rs
@@ -11,7 +11,7 @@ use bytecode_verifier::VerifiedModule;
 use libra_config::{config::NodeConfig, generator};
 use libra_crypto::{
     ed25519::{Ed25519PrivateKey, Ed25519PublicKey},
-    traits::ValidKey,
+    traits::ValidCryptoMaterial,
     PrivateKey, Uniform,
 };
 use libra_state_view::StateView;

--- a/network/network-address/src/lib.rs
+++ b/network/network-address/src/lib.rs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use libra_crypto::{
-    traits::{CryptoMaterialError, ValidKeyStringExt},
+    traits::{CryptoMaterialError, ValidCryptoMaterialStringExt},
     x25519,
 };
 #[cfg(any(test, feature = "fuzzing"))]
@@ -384,7 +384,7 @@ impl fmt::Display for Protocol {
                 "/ln-noise-ik/{}",
                 pubkey
                     .to_encoded_string()
-                    .expect("ValidKeyStringExt::to_encoded_string is infallible")
+                    .expect("ValidCryptoMaterialStringExt::to_encoded_string is infallible")
             ),
             Handshake(version) => write!(f, "/ln-handshake/{}", version),
         }

--- a/network/noise/src/lib.rs
+++ b/network/noise/src/lib.rs
@@ -21,7 +21,7 @@ mod socket;
 pub use self::socket::noise_fuzzing;
 
 pub use self::socket::NoiseSocket;
-use libra_crypto::{x25519, ValidKey};
+use libra_crypto::{x25519, ValidCryptoMaterial};
 
 const NOISE_IX_25519_AESGCM_SHA256_PROTOCOL_NAME: &[u8] = b"/noise_ix_25519_aesgcm_sha256/1.0.0";
 const NOISE_PARAMETER: &str = "Noise_IX_25519_AESGCM_SHA256";

--- a/network/src/transport.rs
+++ b/network/src/transport.rs
@@ -9,7 +9,7 @@ use crate::{
     },
 };
 use futures::io::{AsyncRead, AsyncWrite};
-use libra_crypto::{traits::ValidKey, x25519};
+use libra_crypto::{traits::ValidCryptoMaterial, x25519};
 use libra_logger::prelude::*;
 use libra_security_logger::{security_log, SecurityEvent};
 use libra_types::PeerId;

--- a/types/src/transaction/authenticator.rs
+++ b/types/src/transaction/authenticator.rs
@@ -7,7 +7,7 @@ use libra_crypto::{
     ed25519::{Ed25519PublicKey, Ed25519Signature},
     multi_ed25519::{MultiEd25519PublicKey, MultiEd25519Signature},
     traits::Signature,
-    CryptoMaterialError, HashValue, ValidKey, ValidKeyStringExt,
+    CryptoMaterialError, HashValue, ValidCryptoMaterial, ValidCryptoMaterialStringExt,
 };
 use libra_crypto_derive::{CryptoHasher, DeserializeKey, SerializeKey};
 #[cfg(any(test, feature = "fuzzing"))]
@@ -207,7 +207,7 @@ impl AuthenticationKey {
     }
 }
 
-impl ValidKey for AuthenticationKey {
+impl ValidCryptoMaterial for AuthenticationKey {
     fn to_bytes(&self) -> Vec<u8> {
         self.to_vec()
     }

--- a/types/src/validator_info.rs
+++ b/types/src/validator_info.rs
@@ -5,7 +5,7 @@ use crate::account_address::AccountAddress;
 use anyhow::{Error, Result};
 #[cfg(any(test, feature = "fuzzing"))]
 use libra_crypto::{ed25519::Ed25519PrivateKey, PrivateKey, Uniform};
-use libra_crypto::{ed25519::Ed25519PublicKey, traits::ValidKey, x25519};
+use libra_crypto::{ed25519::Ed25519PublicKey, traits::ValidCryptoMaterial, x25519};
 #[cfg(any(test, feature = "fuzzing"))]
 use proptest_derive::Arbitrary;
 use serde::{Deserialize, Serialize};


### PR DESCRIPTION
## Motivation

Renaming ValidKey to ValidCryptoMaterial because it's used in signature payloads as well (not only keys).

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?

YES

## Test Plan

N/A

## Related PRs

No
