### PR TITLE
[x] add lint for build dependencies being defined without a build script

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2445,7 +2445,6 @@ dependencies = [
  "storage-client 0.1.0",
  "storage-service 0.1.0",
  "tokio 0.2.13 (registry+https://github.com/rust-lang/crates.io-index)",
- "tonic-build 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "ttl_cache 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "vm-validator 0.1.0",
 ]
@@ -6159,6 +6158,7 @@ dependencies = [
  "anyhow 1.0.28 (registry+https://github.com/rust-lang/crates.io-index)",
  "chrono 0.4.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "env_logger 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "guppy 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "libra-workspace-hack 0.1.0",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.106 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/devtools/x/Cargo.toml
+++ b/devtools/x/Cargo.toml
@@ -12,6 +12,7 @@ serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0.51"
 structopt = "0.3.14"
 anyhow = "1.0"
+guppy = "0.3.1"
 toml = "0.5.6"
 env_logger = "0.7.1"
 log = "0.4.8"

--- a/devtools/x/src/lint/mod.rs
+++ b/devtools/x/src/lint/mod.rs
@@ -26,6 +26,7 @@ pub fn run(args: Args, xctx: XContext) -> crate::Result<()> {
     let package_linters: &[&dyn PackageLinter] = &[
         &guppy::EnforcedAttributes::new(&workspace_config.enforced_attributes),
         &guppy::CrateNamesPaths,
+        &guppy::IrrelevantBuildDeps,
         &guppy::WorkspaceHack,
     ];
 

--- a/mempool/Cargo.toml
+++ b/mempool/Cargo.toml
@@ -46,9 +46,6 @@ storage-service = { path = "../storage/storage-service", version = "0.1.0", opti
 parity-multiaddr = { version = "0.8.0", default-features = false }
 rand = "0.7.3"
 
-[build-dependencies]
-tonic-build = "0.2"
-
 [features]
 default = []
 fuzzing = ["libra-types/fuzzing", "storage-service", "storage-service/fuzzing"]


### PR DESCRIPTION
Cargo ignores such dependencies.