### PR TITLE
[language][vm] non-recursive bounds checker implementation for SignatureToken

### DIFF
--- a/language/vm/serializer-tests/tests/serializer_tests.rs
+++ b/language/vm/serializer-tests/tests/serializer_tests.rs
@@ -47,6 +47,7 @@ fn serialize_and_deserialize_deeply_nested_types() {
 
     // TODO: Run bounds checker here once we get that fixed .
     let mut serialized = Vec::with_capacity(2048);
+    let m = m.freeze().expect("module should bounds check");
     m.serialize(&mut serialized)
         .expect("serialization should work");
 

--- a/language/vm/src/serializer.rs
+++ b/language/vm/src/serializer.rs
@@ -469,18 +469,16 @@ fn serialize_signature_tokens(binary: &mut BinaryData, tokens: &[SignatureToken]
 /// Values for types are defined in `SerializedType`.
 fn serialize_signature_token(binary: &mut BinaryData, token: &SignatureToken) -> Result<()> {
     // Non-recursive implementation to avoid overflowing the stack.
-    let mut stack = vec![token];
 
-    while let Some(token) = stack.pop() {
+    for token in token.preorder_traversal() {
         match token {
             SignatureToken::Bool => binary.push(SerializedType::BOOL as u8)?,
             SignatureToken::U8 => binary.push(SerializedType::U8 as u8)?,
             SignatureToken::U64 => binary.push(SerializedType::U64 as u8)?,
             SignatureToken::U128 => binary.push(SerializedType::U128 as u8)?,
             SignatureToken::Address => binary.push(SerializedType::ADDRESS as u8)?,
-            SignatureToken::Vector(boxed_token) => {
+            SignatureToken::Vector(_) => {
                 binary.push(SerializedType::VECTOR as u8)?;
-                stack.push(boxed_token);
             }
             SignatureToken::Struct(idx) => {
                 binary.push(SerializedType::STRUCT as u8)?;
@@ -498,15 +496,12 @@ fn serialize_signature_token(binary: &mut BinaryData, token: &SignatureToken) ->
                     )
                 }
                 binary.push(len as u8)?;
-                stack.extend(type_params.iter().rev());
             }
-            SignatureToken::Reference(boxed_token) => {
+            SignatureToken::Reference(_) => {
                 binary.push(SerializedType::REFERENCE as u8)?;
-                stack.push(boxed_token);
             }
-            SignatureToken::MutableReference(boxed_token) => {
+            SignatureToken::MutableReference(_) => {
                 binary.push(SerializedType::MUTABLE_REFERENCE as u8)?;
-                stack.push(boxed_token);
             }
             SignatureToken::TypeParameter(idx) => {
                 binary.push(SerializedType::TYPE_PARAMETER as u8)?;


### PR DESCRIPTION
## Summary
Reimplement the bounds checker for SignatureToken in a non-recursive fashion to avoid overflowing the stack.

## Test Plan
cargo test

## Dependencies
#3572 