### PR TITLE
[language] update the libra-vm monitoring counters

### DIFF
--- a/common/metrics/src/op_counters.rs
+++ b/common/metrics/src/op_counters.rs
@@ -15,7 +15,7 @@ use std::time::Duration;
 
 /// A small wrapper around Histogram to handle the special case
 /// of duration buckets.
-/// This Histogram will handle the correct granularty for logging
+/// This Histogram will handle the correct granularity for logging
 /// time duration in a way that fits the used buckets.
 pub struct DurationHistogram {
     histogram: Histogram,
@@ -27,7 +27,7 @@ impl DurationHistogram {
     }
 
     pub fn observe_duration(&self, d: Duration) {
-        // Duration is full seconds + nanos elapsed from the presious full second
+        // Duration is full seconds + nanos elapsed from the previous full second
         let v = d.as_secs() as f64 + f64::from(d.subsec_nanos()) / 1e9;
         self.histogram.observe(v);
     }
@@ -145,7 +145,7 @@ impl OpMetrics {
     }
 
     pub fn observe_duration(&self, op: &str, d: Duration) {
-        // Duration is full seconds + nanos elapsed from the presious full second
+        // Duration is full seconds + nanos elapsed from the previous full second
         let v = d.as_secs() as f64 + f64::from(d.subsec_nanos()) / 1e9;
         self.duration_histograms.with_label_values(&[op]).observe(v);
     }

--- a/language/libra-vm/src/counters.rs
+++ b/language/libra-vm/src/counters.rs
@@ -1,174 +1,102 @@
 // Copyright (c) The Libra Core Contributors
 // SPDX-License-Identifier: Apache-2.0
 
-use libra_metrics::{IntCounter, IntGauge, OpMetrics};
-use libra_types::{
-    transaction::TransactionStatus,
-    vm_error::{StatusCode, StatusType, VMStatus},
+use libra_metrics::{
+    register_histogram, register_int_counter_vec, register_int_gauge, Histogram, IntCounterVec,
+    IntGauge,
 };
 use once_cell::sync::Lazy;
-use std::{convert::TryFrom, time::Instant};
 
-// constants used to create counters
-const TXN_EXECUTION_KEEP: &str = "txn.execution.keep";
-const TXN_EXECUTION_DISCARD: &str = "txn.execution.discard";
-const TXN_VERIFICATION_SUCCESS: &str = "txn.verification.success";
-const TXN_VERIFICATION_FAIL: &str = "txn.verification.fail";
-const TXN_BLOCK_COUNT: &str = "txn.block.count";
-pub const TXN_TOTAL_TIME_TAKEN: &str = "txn_gas_total_time_taken";
-pub const TXN_VERIFICATION_TIME_TAKEN: &str = "txn_gas_verification_time_taken";
-pub const TXN_VALIDATION_TIME_TAKEN: &str = "txn_gas_validation_time_taken";
-pub const TXN_EXECUTION_TIME_TAKEN: &str = "txn_gas_execution_time_taken";
-pub const TXN_PROLOGUE_TIME_TAKEN: &str = "txn_gas_prologue_time_taken";
-pub const TXN_EPILOGUE_TIME_TAKEN: &str = "txn_gas_epilogue_time_taken";
-pub const TXN_EXECUTION_GAS_USAGE: &str = "txn_gas_execution_gas_usage";
-pub const TXN_TOTAL_GAS_USAGE: &str = "txn_gas_total_gas_usage";
+/// Count the number of transactions verified, with a "status" label to
+/// distinguish success or failure results.
+pub static TRANSACTIONS_VERIFIED: Lazy<IntCounterVec> = Lazy::new(|| {
+    register_int_counter_vec!(
+        "libra_vm_transactions_verified",
+        "Number of transactions verified",
+        &["status"]
+    )
+    .unwrap()
+});
 
-// the main metric (move_vm)
-pub static VM_COUNTERS: Lazy<OpMetrics> = Lazy::new(|| OpMetrics::new_and_registered("move_vm"));
+/// Count the number of transactions executed, with a "status" label to
+/// distinguish completed vs. discarded transactions.
+pub static TRANSACTIONS_EXECUTED: Lazy<IntCounterVec> = Lazy::new(|| {
+    register_int_counter_vec!(
+        "libra_vm_transactions_executed",
+        "Number of transactions executed",
+        &["status"]
+    )
+    .unwrap()
+});
 
-static VERIFIED_TRANSACTION: Lazy<IntCounter> =
-    Lazy::new(|| VM_COUNTERS.counter(TXN_VERIFICATION_SUCCESS));
-static BLOCK_TRANSACTION_COUNT: Lazy<IntGauge> = Lazy::new(|| VM_COUNTERS.gauge(TXN_BLOCK_COUNT));
+pub static BLOCK_TRANSACTION_COUNT: Lazy<IntGauge> = Lazy::new(|| {
+    register_int_gauge!(
+        "libra_vm_block_transaction_count",
+        "Number of transaction per block"
+    )
+    .unwrap()
+});
 
-/// Wrapper around time::Instant.
-pub fn start_profile() -> Instant {
-    Instant::now()
-}
+pub static TXN_TOTAL_SECONDS: Lazy<Histogram> = Lazy::new(|| {
+    register_histogram!(
+        "libra_vm_txn_total_seconds",
+        "Histogram of total time per transaction"
+    )
+    .unwrap()
+});
 
-/// Reports the number of transactions in a block.
-pub fn report_block_count(count: usize) {
-    match i64::try_from(count) {
-        Ok(val) => BLOCK_TRANSACTION_COUNT.set(val),
-        Err(_) => BLOCK_TRANSACTION_COUNT.set(std::i64::MAX),
-    }
-}
+pub static TXN_VERIFICATION_SECONDS: Lazy<Histogram> = Lazy::new(|| {
+    register_histogram!(
+        "libra_vm_txn_verification_seconds",
+        "Histogram of verification time per transaction"
+    )
+    .unwrap()
+});
 
-// All statistics gather operations for the time taken/gas usage should go through this macro. This
-// gives us the ability to turn these metrics on and off easily from one place.
-#[macro_export]
-macro_rules! record_stats {
-    // Gather some information that is only needed in relation to recording statistics
-    (info | $($stmt:stmt);+;) => {
-        $($stmt);+;
-    };
-    // Set the $ident gauge to $amount
-    (gauge set | $ident:ident | $amount:expr) => {
-        VM_COUNTERS.set($ident, $amount as f64)
-    };
-    // Increment the $ident gauge by $amount
-    (gauge inc | $ident:ident | $amount:expr) => {
-        VM_COUNTERS.add($ident, $amount as f64)
-    };
-    // Decrement the $ident gauge by $amount
-    (gauge dec | $ident:ident | $amount:expr) => {
-        VM_COUNTERS.sub($ident, $amount as f64)
-    };
-    // Set the $ident gauge to $amount
-    (counter set | $ident:ident | $amount:expr) => {
-        VM_COUNTERS.set($ident, $amount as f64)
-    };
-    // Increment the $ident gauge by $amount
-    (counter inc | $ident:ident | $amount:expr) => {
-        VM_COUNTERS.add($ident, $amount as f64)
-    };
-    // Decrement the $ident gauge by $amount
-    (counter dec | $ident:ident | $amount:expr) => {
-        VM_COUNTERS.sub($ident, $amount as f64)
-    };
-    // Set the gas histogram for $ident to be $amount.
-    (observe | $ident:ident | $amount:expr) => {
-        VM_COUNTERS.observe($ident, $amount as f64)
-    };
-    // Per-block info: time and record the amount of time it took to execute $block under the
-    // $ident histogram. NB that this does not provide per-transaction level information, but will
-    // only per-block information.
-    (time_hist | $ident:ident | $block:block) => {{
-        let timer = start_profile();
-        let tmp = $block;
-        let duration = timer.elapsed();
-        VM_COUNTERS.observe_duration($ident, duration);
-        tmp
-    }};
-}
+pub static TXN_VALIDATION_SECONDS: Lazy<Histogram> = Lazy::new(|| {
+    register_histogram!(
+        "libra_vm_txn_validation_seconds",
+        "Histogram of validation time per transaction"
+    )
+    .unwrap()
+});
 
-/// Reports the result of a transaction execution.
-///
-/// Counters are prefixed with `TXN_EXECUTION_KEEP` or `TXN_EXECUTION_DISCARD`.
-/// The prefix can be used with regex to combine different counters in a dashboard.
-pub fn report_execution_status(status: &TransactionStatus) {
-    match status {
-        TransactionStatus::Keep(vm_status) => inc_counter(TXN_EXECUTION_KEEP, vm_status),
-        TransactionStatus::Discard(vm_status) => inc_counter(TXN_EXECUTION_DISCARD, vm_status),
-        TransactionStatus::Retry => (),
-    }
-}
+pub static TXN_EXECUTION_SECONDS: Lazy<Histogram> = Lazy::new(|| {
+    register_histogram!(
+        "libra_vm_txn_execution_seconds",
+        "Histogram of execution time per transaction"
+    )
+    .unwrap()
+});
 
-/// Reports the result of a transaction verification.
-///
-/// Counters are prefixed with `TXN_VERIFICATION_SUCCESS` or `TXN_VERIFICATION_FAIL`.
-/// The prefix can be used with regex to combine different counters in a dashboard.
-pub fn report_verification_status(result: &Option<VMStatus>) {
-    match result {
-        None => VERIFIED_TRANSACTION.inc(),
-        Some(status) => inc_counter(TXN_VERIFICATION_FAIL, status),
-    }
-}
+pub static TXN_PROLOGUE_SECONDS: Lazy<Histogram> = Lazy::new(|| {
+    register_histogram!(
+        "libra_vm_txn_prologue_seconds",
+        "Histogram of prologue time per transaction"
+    )
+    .unwrap()
+});
 
-/// Increments one of the counter for verification or execution.
-fn inc_counter(prefix: &str, status: &VMStatus) {
-    match status.status_type() {
-        StatusType::Deserialization => {
-            // all serialization error are lumped into one bucket
-            VM_COUNTERS.inc(&format!("{}.deserialization", prefix));
-        }
-        StatusType::Execution => {
-            // counters for ExecutionStatus are as granular as the enum
-            VM_COUNTERS.inc(&format!("{}.{}", prefix, status));
-        }
-        StatusType::InvariantViolation => {
-            // counters for VMInvariantViolationError are as granular as the enum
-            VM_COUNTERS.inc(&format!("{}.invariant_violation.{}", prefix, status));
-        }
-        StatusType::Validation => {
-            // counters for validation errors are grouped according to get_validation_status()
-            VM_COUNTERS.inc(&format!(
-                "{}.validation.{}",
-                prefix,
-                get_validation_status(status.major_status)
-            ));
-        }
-        StatusType::Verification => {
-            // all verifier errors are lumped into one bucket
-            VM_COUNTERS.inc(&format!("{}.verifier_error", prefix));
-        }
-        StatusType::Unknown => {
-            VM_COUNTERS.inc(&format!("{}.Unknown", prefix));
-        }
-    }
-}
+pub static TXN_EPILOGUE_SECONDS: Lazy<Histogram> = Lazy::new(|| {
+    register_histogram!(
+        "libra_vm_txn_epilogue_seconds",
+        "Histogram of epilogue time per transaction"
+    )
+    .unwrap()
+});
 
-/// Translate a `VMValidationStatus` enum to a set of strings that are appended to a 'base' counter
-/// name.
-fn get_validation_status(validation_status: StatusCode) -> &'static str {
-    match validation_status {
-        StatusCode::INVALID_SIGNATURE => "InvalidSignature",
-        StatusCode::INVALID_AUTH_KEY => "InvalidAuthKey",
-        StatusCode::SEQUENCE_NUMBER_TOO_OLD => "SequenceNumberTooOld",
-        StatusCode::SEQUENCE_NUMBER_TOO_NEW => "SequenceNumberTooNew",
-        StatusCode::INSUFFICIENT_BALANCE_FOR_TRANSACTION_FEE => {
-            "InsufficientBalanceForTransactionFee"
-        }
-        StatusCode::TRANSACTION_EXPIRED => "TransactionExpired",
-        StatusCode::SENDING_ACCOUNT_DOES_NOT_EXIST => "SendingAccountDoesNotExist",
-        StatusCode::EXCEEDED_MAX_TRANSACTION_SIZE => "ExceededMaxTransactionSize",
-        StatusCode::UNKNOWN_SCRIPT => "UnknownScript",
-        StatusCode::UNKNOWN_MODULE => "UnknownModule",
-        StatusCode::MAX_GAS_UNITS_EXCEEDS_MAX_GAS_UNITS_BOUND
-        | StatusCode::MAX_GAS_UNITS_BELOW_MIN_TRANSACTION_GAS_UNITS
-        | StatusCode::GAS_UNIT_PRICE_BELOW_MIN_BOUND
-        | StatusCode::GAS_UNIT_PRICE_ABOVE_MAX_BOUND => "GasError",
-        StatusCode::REJECTED_WRITE_SET | StatusCode::INVALID_WRITE_SET => "WriteSetError",
-        _ => "UnknownValidationStatus",
-    }
-}
+pub static TXN_EXECUTION_GAS_USAGE: Lazy<Histogram> = Lazy::new(|| {
+    register_histogram!(
+        "libra_vm_txn_execution_gas_usage",
+        "Histogram for the gas used during txn execution"
+    )
+    .unwrap()
+});
+
+pub static TXN_TOTAL_GAS_USAGE: Lazy<Histogram> = Lazy::new(|| {
+    register_histogram!(
+        "libra_vm_txn_total_gas_usage",
+        "Histogram for the total gas used for txns"
+    )
+    .unwrap()
+});


### PR DESCRIPTION
- Adopt the same conventions for Prometheus counters in libra-vm as in the rest of Libra, with a separate name for each counter and using the same naming convention as elsewhere.
- Simplify the status counters: Failed transactions should be rare, so I don't think we need to count separately for each type of failure. If there's an increase in failure counts, I expect someone would look into the logs to see what is causing that.
- Change to access the counters directly from libra_vm.rs. Previously the counters were private to the counters.rs file with public functions and macros to update them. This didn't seem to add much value and it was inconsistent with other Libra components.
- It's not clear whether all the time histograms here are needed but the original motivation of using them to correlate with gas costs seems still valid, so I did not remove any of them.

## Motivation

Simplify VM monitoring and follow conventions from other Libra components.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

Ran tests. Once this lands, I will set up a dashboard to observe the results.
