### PR TITLE
[Move-prover] Allow dataflow analysis to compute error output for a block

### DIFF
--- a/language/move-prover/stackless-bytecode-generator/src/livevar_analysis.rs
+++ b/language/move-prover/stackless-bytecode-generator/src/livevar_analysis.rs
@@ -96,7 +96,7 @@ impl LiveVarAnalysis {
         &mut self,
         cfg: &StacklessControlFlowGraph,
         instrs: &[Bytecode],
-        state_map: StateMap<LiveVarState>,
+        state_map: StateMap<LiveVarState, ()>,
     ) -> BTreeMap<CodeOffset, BTreeSet<TempIndex>> {
         let mut result = BTreeMap::new();
         for (block_id, block_state) in state_map {
@@ -153,6 +153,7 @@ impl LiveVarAnalysis {
 
 impl TransferFunctions for LiveVarAnalysis {
     type State = LiveVarState;
+    type AnalysisError = ();
 
     fn execute_block(
         &mut self,
@@ -160,13 +161,13 @@ impl TransferFunctions for LiveVarAnalysis {
         pre_state: Self::State,
         instrs: &[Bytecode],
         cfg: &StacklessControlFlowGraph,
-    ) -> Self::State {
+    ) -> Result<Self::State, Self::AnalysisError> {
         let mut state = pre_state;
         for offset in cfg.instr_indexes(block_id).rev() {
             let instr = &instrs[offset as usize];
             state = self.execute(state, instr, offset);
         }
-        state
+        Ok(state)
     }
 }
 

--- a/language/move-prover/stackless-bytecode-generator/src/reaching_def_analysis.rs
+++ b/language/move-prover/stackless-bytecode-generator/src/reaching_def_analysis.rs
@@ -111,6 +111,7 @@ impl<'a> ReachingDefAnalysis<'a> {
 
 impl<'a> TransferFunctions for ReachingDefAnalysis<'a> {
     type State = ReachingDefState;
+    type AnalysisError = ();
 
     fn execute_block(
         &mut self,
@@ -118,13 +119,13 @@ impl<'a> TransferFunctions for ReachingDefAnalysis<'a> {
         pre_state: Self::State,
         instrs: &[Bytecode],
         cfg: &StacklessControlFlowGraph,
-    ) -> Self::State {
+    ) -> Result<Self::State, Self::AnalysisError> {
         let mut state = pre_state;
         for offset in cfg.instr_indexes(block_id) {
             let instr = &instrs[offset as usize];
             state = self.execute(state, instr, offset);
         }
-        state
+        Ok(state)
     }
 }
 


### PR DESCRIPTION
## Motivation

For one of the phases in the bytecode transformation pipeline, it is possible that an analysis computes an error for a block. This PR generalizes the dataflow analysis to account for error output.  Also, this capability is generally useful for analyses we may write in the future.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?

Yes.

## Test Plan

Existing tests.

## Related PRs

