### PR TITLE
[docker] use wget in build

### DIFF
--- a/docker/cluster-test/cluster-test.Dockerfile
+++ b/docker/cluster-test/cluster-test.Dockerfile
@@ -18,8 +18,8 @@ RUN rustup install $(cat rust-toolchain)
 COPY . /libra
 RUN docker/cluster-test/compile.sh
 FROM debian:buster
-RUN apt-get update && apt-get install -y openssh-client curl
-RUN curl -L "https://storage.googleapis.com/kubernetes-release/release/`curl -s https://storage.googleapis.com/kubernetes-release/release/stable.txt`/bin/linux/amd64/kubectl" -o /usr/local/bin/kubectl && chmod +x /usr/local/bin/kubectl
+RUN apt-get update && apt-get install -y openssh-client wget
+RUN cd /usr/local/bin && wget "https://storage.googleapis.com/kubernetes-release/release/v1.17.0/bin/linux/amd64/kubectl" -O kubectl && chmod +x kubectl
 RUN mkdir /etc/cluster-test
 WORKDIR /etc/cluster-test
 COPY --from=builder /target/release/cluster-test /usr/local/bin/cluster-test

--- a/docker/cluster-test/cluster-test.Dockerfile.template
+++ b/docker/cluster-test/cluster-test.Dockerfile.template
@@ -17,8 +17,8 @@ RUN docker/cluster-test/compile.sh
 
 FROM debian:buster
 
-RUN apt-get update && apt-get install -y openssh-client curl
-RUN curl -L "https://storage.googleapis.com/kubernetes-release/release/`curl -s https://storage.googleapis.com/kubernetes-release/release/stable.txt`/bin/linux/amd64/kubectl" -o /usr/local/bin/kubectl && chmod +x /usr/local/bin/kubectl
+RUN apt-get update && apt-get install -y openssh-client wget
+RUN cd /usr/local/bin && wget "https://storage.googleapis.com/kubernetes-release/release/v1.17.0/bin/linux/amd64/kubectl" -O kubectl && chmod +x kubectl
 
 RUN mkdir /etc/cluster-test
 WORKDIR /etc/cluster-test

--- a/docker/cluster-test/cluster-test.container.Dockerfile
+++ b/docker/cluster-test/cluster-test.container.Dockerfile
@@ -7,8 +7,8 @@
 ## - To comment must use double ##, single # will be treated as pre-processor command
 ## -
 FROM debian:buster
-RUN apt-get update && apt-get install -y openssh-client curl
-RUN curl -L "https://storage.googleapis.com/kubernetes-release/release/`curl -s https://storage.googleapis.com/kubernetes-release/release/stable.txt`/bin/linux/amd64/kubectl" -o /usr/local/bin/kubectl && chmod +x /usr/local/bin/kubectl
+RUN apt-get update && apt-get install -y openssh-client wget
+RUN cd /usr/local/bin && wget "https://storage.googleapis.com/kubernetes-release/release/v1.17.0/bin/linux/amd64/kubectl" -O kubectl && chmod +x kubectl
 RUN mkdir /etc/cluster-test
 WORKDIR /etc/cluster-test
 COPY cluster_test_docker_builder_cluster_test /usr/local/bin/cluster-test

--- a/docker/init/Dockerfile
+++ b/docker/init/Dockerfile
@@ -21,8 +21,8 @@ RUN cargo build --release -p libra-node -p cli -p config-builder -p safety-rules
 ### Production Image ###
 FROM debian:buster AS prod
 
-RUN apt-get update && apt-get -y install curl gettext-base && apt-get clean && rm -r /var/lib/apt/lists/*
-RUN cd /usr/local/bin && curl -LO https://storage.googleapis.com/kubernetes-release/release/v1.17.0/bin/linux/amd64/kubectl && chmod +x kubectl
+RUN apt-get update && apt-get -y install wget gettext-base && apt-get clean && rm -r /var/lib/apt/lists/*
+RUN cd /usr/local/bin && wget "https://storage.googleapis.com/kubernetes-release/release/v1.17.0/bin/linux/amd64/kubectl" -O kubectl && chmod +x kubectl
 
 RUN mkdir -p /opt/libra/bin
 COPY --from=builder /libra/target/release/config-builder /opt/libra/bin


### PR DESCRIPTION
## Motivation
We started seeing frequent build failures, on CI hosts and local dev
machines, due to a mysterious connection reset (openssl errno 104) in
downloading resource from certain 3rd party sites

  curl: (56) OpenSSL SSL_read: SSL_ERROR_SYSCALL, errno 104

This commit uses wget as some have reported success.

## Test Plan
Docker build job in CI.