### PR TITLE
[cluster-test] Set Autoscaling Group Size from cluster-test

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -751,6 +751,9 @@ dependencies = [
  "rand 0.7.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "regex 1.3.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "reqwest 0.10.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rusoto_autoscaling 0.43.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rusoto_core 0.43.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rusoto_sts 0.43.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.106 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.51 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_yaml 0.8.11 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2895,6 +2898,11 @@ version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "md5"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
 name = "memchr"
 version = "2.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4252,6 +4260,105 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "libc 0.2.69 (registry+https://github.com/rust-lang/crates.io-index)",
  "librocksdb-sys 6.7.3 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "rusoto_autoscaling"
+version = "0.43.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "async-trait 0.1.30 (registry+https://github.com/rust-lang/crates.io-index)",
+ "bytes 0.5.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "futures 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rusoto_core 0.43.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_urlencoded 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "xml-rs 0.8.2 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "rusoto_core"
+version = "0.43.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "async-trait 0.1.30 (registry+https://github.com/rust-lang/crates.io-index)",
+ "base64 0.12.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "bytes 0.5.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "futures 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "hmac 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "http 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "hyper 0.13.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "hyper-tls 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "md5 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "percent-encoding 2.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "pin-project 0.4.9 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rusoto_credential 0.43.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rusoto_signature 0.43.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc_version 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.106 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_json 1.0.51 (registry+https://github.com/rust-lang/crates.io-index)",
+ "sha2 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio 0.2.13 (registry+https://github.com/rust-lang/crates.io-index)",
+ "xml-rs 0.8.2 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "rusoto_credential"
+version = "0.43.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "async-trait 0.1.30 (registry+https://github.com/rust-lang/crates.io-index)",
+ "chrono 0.4.11 (registry+https://github.com/rust-lang/crates.io-index)",
+ "dirs 2.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "futures 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "hyper 0.13.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "pin-project 0.4.9 (registry+https://github.com/rust-lang/crates.io-index)",
+ "regex 1.3.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.106 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_json 1.0.51 (registry+https://github.com/rust-lang/crates.io-index)",
+ "shlex 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio 0.2.13 (registry+https://github.com/rust-lang/crates.io-index)",
+ "zeroize 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "rusoto_signature"
+version = "0.43.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "base64 0.12.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "bytes 0.5.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "futures 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "hex 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "hmac 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "http 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "hyper 0.13.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "md5 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "percent-encoding 2.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "pin-project 0.4.9 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rusoto_credential 0.43.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc_version 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.106 (registry+https://github.com/rust-lang/crates.io-index)",
+ "sha2 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "time 0.2.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio 0.2.13 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "rusoto_sts"
+version = "0.43.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "async-trait 0.1.30 (registry+https://github.com/rust-lang/crates.io-index)",
+ "bytes 0.5.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "chrono 0.4.11 (registry+https://github.com/rust-lang/crates.io-index)",
+ "futures 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rusoto_core 0.43.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_urlencoded 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tempfile 3.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "xml-rs 0.8.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -6206,6 +6313,11 @@ dependencies = [
 ]
 
 [[package]]
+name = "xml-rs"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
 name = "yaml-rust"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6410,6 +6522,7 @@ dependencies = [
 "checksum lru-cache 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "31e24f1ad8321ca0e8a1e0ac13f23cb668e6f5466c2c57319f6a5cf1cc8e3b1c"
 "checksum matches 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)" = "7ffc5c5338469d4d3ea17d269fa8ea3512ad247247c30bd2df69e68309ed0a08"
 "checksum maybe-uninit 2.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "60302e4db3a61da70c0cb7991976248362f30319e88850c487b9b95bbf059e00"
+"checksum md5 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "490cc448043f947bae3cbee9c203358d62dbee0db12107a74be5c30ccfd09771"
 "checksum memchr 2.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "3728d817d99e5ac407411fa471ff9800a778d88a24685968b36824eaf4bee400"
 "checksum memoffset 0.5.3 (registry+https://github.com/rust-lang/crates.io-index)" = "75189eb85871ea5c2e2c15abbdd541185f63b408415e5051f5cac122d8c774b9"
 "checksum merlin 1.2.1 (git+https://github.com/isislovecruft/merlin?branch=develop)" = "<none>"
@@ -6525,6 +6638,11 @@ dependencies = [
 "checksum ring 0.16.11 (registry+https://github.com/rust-lang/crates.io-index)" = "741ba1704ae21999c00942f9f5944f801e977f54302af346b596287599ad1862"
 "checksum ripemd160 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ad5112e0dbbb87577bfbc56c42450235e3012ce336e29c5befd7807bd626da4a"
 "checksum rocksdb 0.14.0 (registry+https://github.com/rust-lang/crates.io-index)" = "61aa17a99a2413cd71c1106691bf59dad7de0cd5099127f90e9d99c429c40d4a"
+"checksum rusoto_autoscaling 0.43.0 (registry+https://github.com/rust-lang/crates.io-index)" = "72d92e3c0c413d31664ecc3ce7e94ce0ef0e68a627a26a911d16fcc0b125af15"
+"checksum rusoto_core 0.43.0 (registry+https://github.com/rust-lang/crates.io-index)" = "3a8d624cb48fcaca612329e4dd544380aa329ef338e83d3a90f5b7897e631971"
+"checksum rusoto_credential 0.43.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ba3e7cdf483d7198d9bca7414746d3ba656239e89e467b715d0571912f0b492f"
+"checksum rusoto_signature 0.43.0 (registry+https://github.com/rust-lang/crates.io-index)" = "62940a2bd479900a1bf8935b8f254d3e19368ac3ac4570eb4bd48eb46551a1b7"
+"checksum rusoto_sts 0.43.0 (registry+https://github.com/rust-lang/crates.io-index)" = "e83d166cfb294672db98a60159c4a81a8169c6c91054a275cb812158c73815e5"
 "checksum rust-argon2 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "2bc8af4bda8e1ff4932523b94d3dd20ee30a87232323eda55903ffd71d2fb017"
 "checksum rust_decimal 1.4.1 (registry+https://github.com/rust-lang/crates.io-index)" = "1989cf75ea3463a3584ad69f92642e8046083482f519017aa2258333e5dc61cd"
 "checksum rustc-demangle 0.1.16 (registry+https://github.com/rust-lang/crates.io-index)" = "4c691c0e608126e00913e33f0ccf3727d5fc84573623b8d65b2df340b5201783"
@@ -6681,6 +6799,7 @@ dependencies = [
 "checksum ws2_32-sys 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "d59cefebd0c892fa2dd6de581e937301d8552cb44489cdff035c6187cb63fa5e"
 "checksum x25519-dalek 0.6.0 (git+https://github.com/calibra/x25519-dalek.git?branch=fiat2)" = "<none>"
 "checksum x25519-dalek 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)" = "637ff90c9540fa3073bb577e65033069e4bae7c79d49d74aa3ffdf5342a53217"
+"checksum xml-rs 0.8.2 (registry+https://github.com/rust-lang/crates.io-index)" = "2bb76e5c421bbbeb8924c60c030331b345555024d56261dae8f3e786ed817c23"
 "checksum yaml-rust 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)" = "65923dd1784f44da1d2c3dbbc5e822045628c590ba72123e1c73d3c230c4434d"
 "checksum zeroize 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "3cbac2ed2ba24cc90f5e06485ac8c7c1e5449fe8911aef4d8877218af021a5b8"
 "checksum zeroize_derive 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "de251eec69fc7c1bc3923403d18ececb929380e016afe103da75f396704f8ca2"

--- a/scripts/cti
+++ b/scripts/cti
@@ -195,6 +195,7 @@ pod_name=${pod_name/_/-} #underscore not allowed in pod name
 specfile=$(mktemp)
 echo "Pod Spec : ${specfile}"
 join_args $*
+ENV="$ENV AWS_ROLE_SESSION_NAME=AWS_ROLE_SESSION_NAME"
 join_env_vars $ENV
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 sed -e "s/{pod_name}/${pod_name}/g" \

--- a/testsuite/cluster-test/Cargo.toml
+++ b/testsuite/cluster-test/Cargo.toml
@@ -24,6 +24,9 @@ termion = "1.5.3"
 serde = { version = "1.0.106", features = ["derive"] }
 structopt = "0.3.14"
 chrono = { version = "0.4.11" }
+rusoto_core = "0.43.0"
+rusoto_autoscaling = "0.43.0"
+rusoto_sts =  "0.43.0"
 
 debug-interface = { path = "../../common/debug-interface", version = "0.1.0"}
 libra-json-rpc = { path = "../../json-rpc", version = "0.1.0"}

--- a/testsuite/cluster-test/src/aws.rs
+++ b/testsuite/cluster-test/src/aws.rs
@@ -1,0 +1,78 @@
+// Copyright (c) The Libra Core Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+#![forbid(unsafe_code)]
+
+use anyhow::{bail, format_err, Result};
+use libra_logger::info;
+use rusoto_autoscaling::{
+    AutoScalingGroupNamesType, Autoscaling, AutoscalingClient, SetDesiredCapacityType,
+};
+use rusoto_core::Region;
+use rusoto_sts::WebIdentityProvider;
+use util::retry;
+
+/// set_asg_size sets the size of the given autoscaling group
+pub async fn set_asg_size(
+    min_desired_capacity: i64,
+    buffer_percent: f64,
+    asg_name: &str,
+) -> Result<()> {
+    let buffer = ((min_desired_capacity as f64 * buffer_percent) / 100_f64).ceil() as i64;
+    info!(
+        "Scaling to min_desired_capacity : {}, buffer: {}, asg_name: {}",
+        min_desired_capacity, buffer, asg_name
+    );
+    let set_desired_capacity_type = SetDesiredCapacityType {
+        auto_scaling_group_name: asg_name.to_string(),
+        desired_capacity: min_desired_capacity + buffer,
+        honor_cooldown: Some(false),
+    };
+    let credentials_provider = WebIdentityProvider::from_k8s_env();
+
+    let dispatcher = rusoto_core::HttpClient::new().expect("failed to create request dispatcher");
+    let asc = AutoscalingClient::new_with(dispatcher, credentials_provider, Region::UsWest2);
+    asc.set_desired_capacity(set_desired_capacity_type)
+        .await
+        .map_err(|e| format_err!("set_desired_capacity failed: {:?}", e))?;
+    retry::retry_async(retry::fixed_retry_strategy(10_000, 30), || {
+        let asc_clone = asc.clone();
+        Box::pin(async move {
+            let auto_scaling_group_names_type = AutoScalingGroupNamesType {
+                auto_scaling_group_names: Some(vec![asg_name.to_string()]),
+                max_records: Some(min_desired_capacity),
+                next_token: None,
+            };
+            let asgs = asc_clone
+                .describe_auto_scaling_groups(auto_scaling_group_names_type)
+                .await?;
+            if asgs.auto_scaling_groups.is_empty() {
+                bail!("asgs.auto_scaling_groups.is_empty()");
+            }
+            let asg = &asgs.auto_scaling_groups[0];
+            let count = asg
+                .instances
+                .clone()
+                .ok_or_else(|| format_err!("instances not found for auto_scaling_group"))?
+                .iter()
+                .filter(|instance| instance.lifecycle_state == "InService")
+                .count() as i64;
+            info!(
+                "Waiting for scale-up to complete. Current size: {}, Min Desired Size: {}",
+                count, min_desired_capacity
+            );
+
+            if count < min_desired_capacity {
+                bail!(
+                    "Waiting for scale-up to complete. Current size: {}, Min Desired Size: {}",
+                    count,
+                    min_desired_capacity
+                );
+            } else {
+                info!("Scale up completed");
+                Ok(())
+            }
+        })
+    })
+    .await
+}

--- a/testsuite/cluster-test/src/lib.rs
+++ b/testsuite/cluster-test/src/lib.rs
@@ -1,6 +1,7 @@
 // Copyright (c) The Libra Core Contributors
 // SPDX-License-Identifier: Apache-2.0
 
+pub mod aws;
 pub mod cluster;
 pub mod cluster_swarm;
 pub mod experiments;


### PR DESCRIPTION
## Summary

* We were seeing issues where an instance was failing to launch in the AWS autoscaling group - causing a libra node to be unassigned
![image](https://user-images.githubusercontent.com/796949/80295003-a9c3ad80-8723-11ea-9a2b-7e82f1124506.png)

* Create `set_asg_size` which sets the autoscaling group size to the min desired capacity plus an additional buffer

* When cluster-test starts, set the autoscaling group size to the desired size plus a buffer of 3 nodes to tolerate upto 3 instance launch failures

This diff depends upon https://github.com/calibra/libra-ops/pull/524

## Test Plan

Ran cluster-test