### PR TITLE
[config] Refactor generate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -818,6 +818,7 @@ dependencies = [
  "storage-interface 0.1.0",
  "structopt 0.3.14 (registry+https://github.com/rust-lang/crates.io-index)",
  "thiserror 1.0.15 (registry+https://github.com/rust-lang/crates.io-index)",
+ "transaction-builder 0.1.0",
  "vm-genesis 0.1.0",
 ]
 

--- a/config/config-builder/Cargo.toml
+++ b/config/config-builder/Cargo.toml
@@ -29,6 +29,7 @@ libra-vm = { path = "../../language/libra-vm", version = "0.1.0" }
 libra-workspace-hack = { path = "../../common/workspace-hack", version = "0.1.0" }
 libradb = { path = "../../storage/libradb", version = "0.1.0" }
 storage-interface = { path = "../../storage/storage-interface", version = "0.1.0" }
+transaction-builder = { path = "../../language/transaction-builder", version = "0.1.0" }
 vm-genesis = { path = "../../language/tools/vm-genesis", version = "0.1.0" }
 
 [features]

--- a/config/config-builder/src/validator_config.rs
+++ b/config/config-builder/src/validator_config.rs
@@ -221,7 +221,6 @@ impl ValidatorConfig {
             DiscoverySet::new(discovery_set.into_iter().take(nodes_in_genesis).collect());
 
         let genesis = vm_genesis::encode_genesis_transaction_with_validator(
-            &faucet_key,
             faucet_key.public_key(),
             &nodes,
             validator_set,

--- a/config/config-builder/src/validator_config.rs
+++ b/config/config-builder/src/validator_config.rs
@@ -189,17 +189,19 @@ impl ValidatorConfig {
         );
 
         let (faucet_key, config_seed) = self.build_faucet();
-        let ValidatorSwarm {
-            mut nodes,
-            validator_set,
-            discovery_set,
-        } = generator::validator_swarm(
+        let swarm = generator::validator_swarm(
             &self.template,
             self.nodes,
             config_seed,
             randomize_service_ports,
             randomize_libranet_ports,
         );
+        let auth_keys = swarm.auth_keys();
+        let ValidatorSwarm {
+            mut nodes,
+            validator_set,
+            discovery_set,
+        } = swarm;
 
         ensure!(
             nodes.len() == self.nodes,
@@ -222,7 +224,7 @@ impl ValidatorConfig {
 
         let genesis = vm_genesis::encode_genesis_transaction_with_validator(
             faucet_key.public_key(),
-            &nodes,
+            &auth_keys,
             validator_set,
             discovery_set,
             self.template

--- a/config/src/generator.rs
+++ b/config/src/generator.rs
@@ -13,7 +13,7 @@ use crate::{
 };
 use libra_types::{
     discovery_info::DiscoveryInfo, discovery_set::DiscoverySet, on_chain_config::ValidatorSet,
-    validator_info::ValidatorInfo,
+    transaction::authenticator::AuthenticationKey, validator_info::ValidatorInfo,
 };
 use rand::{rngs::StdRng, SeedableRng};
 
@@ -21,6 +21,19 @@ pub struct ValidatorSwarm {
     pub nodes: Vec<NodeConfig>,
     pub validator_set: ValidatorSet,
     pub discovery_set: DiscoverySet,
+}
+
+impl ValidatorSwarm {
+    pub fn auth_keys(&self) -> Vec<AuthenticationKey> {
+        self.nodes
+            .iter()
+            .map(|n| {
+                let test_config = n.test.as_ref().unwrap();
+                let key = test_config.account_keypair.as_ref().unwrap().public_key();
+                AuthenticationKey::ed25519(&key)
+            })
+            .collect::<Vec<_>>()
+    }
 }
 
 pub fn validator_swarm(

--- a/language/e2e-tests/src/data_store.rs
+++ b/language/e2e-tests/src/data_store.rs
@@ -9,6 +9,7 @@ use libra_state_view::StateView;
 use libra_types::{
     access_path::AccessPath,
     language_storage::ModuleId,
+    on_chain_config::ConfigStorage,
     transaction::ChangeSet,
     write_set::{WriteOp, WriteSet},
 };
@@ -85,6 +86,12 @@ impl FakeDataStore {
             .serialize(&mut blob)
             .expect("serializing this module should work");
         self.set(access_path, blob);
+    }
+}
+
+impl ConfigStorage for &FakeDataStore {
+    fn fetch_config(&self, access_path: AccessPath) -> Option<Vec<u8>> {
+        StateView::get(*self, &access_path).unwrap_or_default()
     }
 }
 

--- a/language/e2e-tests/src/executor.rs
+++ b/language/e2e-tests/src/executor.rs
@@ -16,7 +16,7 @@ use libra_types::{
     account_config::{AccountResource, BalanceResource},
     block_metadata::{new_block_event_key, BlockMetadata, NewBlockEvent},
     language_storage::ModuleId,
-    on_chain_config::{VMPublishingOption, ValidatorSet},
+    on_chain_config::{OnChainConfig, VMPublishingOption, ValidatorSet},
     transaction::{
         SignedTransaction, Transaction, TransactionOutput, TransactionStatus, VMValidatorResult,
     },
@@ -253,17 +253,15 @@ impl FakeExecutor {
     }
 
     pub fn new_block(&mut self) {
-        let validator_address = *generator::validator_swarm_for_testing(10)
-            .validator_set
-            .payload()[0]
-            .account_address();
+        let validator_set = ValidatorSet::fetch_config(&self.data_store)
+            .expect("Unable to retrieve the validator set from storage");
         self.block_time += 1;
         let new_block = BlockMetadata::new(
             HashValue::zero(),
             0,
             self.block_time,
             vec![],
-            validator_address,
+            *validator_set.payload()[0].account_address(),
         );
         let output = self
             .execute_transaction_block(vec![Transaction::BlockMetadata(new_block)])

--- a/language/e2e-tests/src/executor.rs
+++ b/language/e2e-tests/src/executor.rs
@@ -15,7 +15,6 @@ use libra_types::{
     access_path::AccessPath,
     account_config::{AccountResource, BalanceResource},
     block_metadata::{new_block_event_key, BlockMetadata, NewBlockEvent},
-    discovery_set::mock::mock_discovery_set,
     language_storage::ModuleId,
     on_chain_config::{VMPublishingOption, ValidatorSet},
     transaction::{
@@ -98,17 +97,12 @@ impl FakeExecutor {
         publishing_options: VMPublishingOption,
     ) -> Self {
         let genesis_change_set = {
-            let validator_set_len: usize = validator_set.as_ref().map_or(10, |s| s.payload().len());
-            let swarm = generator::validator_swarm_for_testing(validator_set_len);
-            let mut auth_keys = swarm.auth_keys();
-            auth_keys.truncate(validator_set_len);
-            let validator_set = validator_set.unwrap_or(swarm.validator_set);
-            let discovery_set = mock_discovery_set(&validator_set);
+            let validator_count: usize = validator_set.as_ref().map_or(10, |s| s.payload().len());
+            let swarm = generator::validator_swarm_for_testing(validator_count);
+
             vm_genesis::encode_genesis_change_set(
                 &GENESIS_KEYPAIR.1,
-                &auth_keys,
-                validator_set,
-                discovery_set,
+                &vm_genesis::validator_registrations(&swarm.nodes),
                 &genesis_modules,
                 publishing_options,
             )

--- a/language/e2e-tests/src/executor.rs
+++ b/language/e2e-tests/src/executor.rs
@@ -100,11 +100,13 @@ impl FakeExecutor {
         let genesis_change_set = {
             let validator_set_len: usize = validator_set.as_ref().map_or(10, |s| s.payload().len());
             let swarm = generator::validator_swarm_for_testing(validator_set_len);
+            let mut auth_keys = swarm.auth_keys();
+            auth_keys.truncate(validator_set_len);
             let validator_set = validator_set.unwrap_or(swarm.validator_set);
             let discovery_set = mock_discovery_set(&validator_set);
             vm_genesis::encode_genesis_change_set(
                 &GENESIS_KEYPAIR.1,
-                &swarm.nodes,
+                &auth_keys,
                 validator_set,
                 discovery_set,
                 &genesis_modules,

--- a/language/e2e-tests/src/executor.rs
+++ b/language/e2e-tests/src/executor.rs
@@ -93,11 +93,11 @@ impl FakeExecutor {
     /// Creates fresh genesis from the stdlib modules passed in.
     pub fn custom_genesis(
         genesis_modules: Vec<VerifiedModule>,
-        validator_set: Option<ValidatorSet>,
+        validator_accounts: Option<usize>,
         publishing_options: VMPublishingOption,
     ) -> Self {
         let genesis_change_set = {
-            let validator_count: usize = validator_set.as_ref().map_or(10, |s| s.payload().len());
+            let validator_count = validator_accounts.map_or(10, |s| s);
             let swarm = generator::validator_swarm_for_testing(validator_count);
 
             vm_genesis::encode_genesis_change_set(

--- a/language/e2e-tests/src/tests/validator_set_management.rs
+++ b/language/e2e-tests/src/tests/validator_set_management.rs
@@ -24,11 +24,11 @@ fn validator_add() {
 
     let txn = register_validator_txn(
         new_validator.account(),
+        vec![255; 32],
+        vec![254; 32],
+        vec![253; 32],
         vec![],
-        vec![],
-        vec![],
-        vec![],
-        vec![],
+        vec![252; 32],
         vec![],
         0,
     );
@@ -51,18 +51,18 @@ fn validator_rotate_key() {
     let mut executor = FakeExecutor::from_genesis_file();
     let genesis_account = Account::new_association();
     let new_validator = AccountData::new(1_000_000, 0);
-    executor.new_block();
 
     // create a FakeExecutor with a genesis from file
     executor.add_account_data(&new_validator);
+    executor.new_block();
 
     let txn = register_validator_txn(
         new_validator.account(),
+        vec![255; 32],
+        vec![254; 32],
+        vec![253; 32],
         vec![],
-        vec![],
-        vec![],
-        vec![],
-        vec![],
+        vec![252; 32],
         vec![],
         0,
     );
@@ -82,7 +82,7 @@ fn validator_rotate_key() {
     executor.apply_write_set(output.write_set());
     executor.new_block();
 
-    let txn = rotate_consensus_pubkey_txn(new_validator.account(), vec![1], 1);
+    let txn = rotate_consensus_pubkey_txn(new_validator.account(), vec![251; 32], 1);
     let output = executor.execute_transaction(txn);
     assert_eq!(
         output.status(),

--- a/language/functional-tests/src/evaluator.rs
+++ b/language/functional-tests/src/evaluator.rs
@@ -554,7 +554,7 @@ pub fn eval<TComp: Compiler>(
     let mut log = EvaluationLog { outputs: vec![] };
 
     // Set up a fake executor with the genesis block and create the accounts.
-    let mut exec = if config.validator_set.payload().is_empty() {
+    let mut exec = if config.validator_accounts == 0 {
         if compiler.use_staged_genesis() {
             FakeExecutor::from_genesis_file()
         } else {
@@ -570,7 +570,7 @@ pub fn eval<TComp: Compiler>(
                 StdLibOptions::Fresh
             })
             .to_vec(),
-            Some(config.validator_set.clone()),
+            Some(config.validator_accounts),
             VMPublishingOption::Open,
         )
     };

--- a/language/tools/vm-genesis/src/lib.rs
+++ b/language/tools/vm-genesis/src/lib.rs
@@ -114,7 +114,6 @@ pub fn name(name: &str) -> Identifier {
 }
 
 pub fn encode_genesis_transaction_with_validator(
-    private_key: &Ed25519PrivateKey,
     public_key: Ed25519PublicKey,
     nodes: &[NodeConfig],
     validator_set: ValidatorSet,
@@ -122,7 +121,6 @@ pub fn encode_genesis_transaction_with_validator(
     vm_publishing_option: Option<VMPublishingOption>,
 ) -> Transaction {
     encode_genesis_transaction(
-        private_key,
         public_key,
         nodes,
         validator_set,
@@ -211,7 +209,6 @@ pub fn encode_genesis_change_set(
 }
 
 pub fn encode_genesis_transaction(
-    _private_key: &Ed25519PrivateKey,
     public_key: Ed25519PublicKey,
     nodes: &[NodeConfig],
     validator_set: ValidatorSet,

--- a/network/onchain-discovery/src/test.rs
+++ b/network/onchain-discovery/src/test.rs
@@ -172,7 +172,6 @@ fn gen_configs(count: usize) -> (Vec<NodeConfig>, ValidatorSet, DiscoverySet) {
 
     let vm_publishing_option = None;
     let genesis = encode_genesis_transaction_with_validator(
-        &GENESIS_KEYPAIR.0,
         GENESIS_KEYPAIR.1.clone(),
         &nodes[..],
         validator_set.clone(),

--- a/network/onchain-discovery/src/test.rs
+++ b/network/onchain-discovery/src/test.rs
@@ -158,22 +158,24 @@ fn gen_configs(count: usize) -> (Vec<NodeConfig>, ValidatorSet, DiscoverySet) {
     let randomize_service_ports = true;
     let randomize_libranet_ports = false;
 
-    let ValidatorSwarm {
-        mut nodes,
-        validator_set,
-        discovery_set,
-    } = generator::validator_swarm(
+    let swarm = generator::validator_swarm(
         &config_template,
         count,
         config_seed,
         randomize_service_ports,
         randomize_libranet_ports,
     );
+    let auth_keys = swarm.auth_keys();
+    let ValidatorSwarm {
+        mut nodes,
+        validator_set,
+        discovery_set,
+    } = swarm;
 
     let vm_publishing_option = None;
     let genesis = encode_genesis_transaction_with_validator(
         GENESIS_KEYPAIR.1.clone(),
-        &nodes[..],
+        &auth_keys,
         validator_set.clone(),
         discovery_set.clone(),
         vm_publishing_option,


### PR DESCRIPTION
Back in the day, genesis generation was driven by the need to simplify test and test deployments. This takes a big step forward in moving toward a distributed approach in generating genesis:

* Eliminate the formerly used genesis private key -- no longer needed since this is a ChangeSet now
* Removing NodeConfig from being passed into APIs of genesis encoding
* Use scripts to initialize genesis
* Unify how config::generator was called and did so by cleaning up quite a bit of test code  
