### PR TITLE
[move-prover] Update script_provider.move

### DIFF
--- a/language/move-prover/tests/sources/functional/script_provider.move
+++ b/language/move-prover/tests/sources/functional/script_provider.move
@@ -9,7 +9,8 @@ module ScriptProvider {
     public fun register<T>() {
         Transaction::assert(Transaction::sender() == 0x1, 1);
         move_to_sender(Info<T>{})
-    nfddenvnfiguetvlferbfjiii
+    }
+    spec schema RegisterConditions<T> {
         aborts_if sender() != 0x1;
         aborts_if exists<Info<T>>(0x1);
         ensures exists<Info<T>>(0x1);


### PR DESCRIPTION
Fixed a mysterious string in `script_provider.move` which cause Prover test fail

## Motivation

To remove the typo

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

cargo test

## Related PRs

