### PR TITLE
[mempool] Remove unused prometheus dependency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2435,7 +2435,6 @@ dependencies = [
  "network 0.1.0",
  "once_cell 1.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "parity-multiaddr 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "prometheus 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "proptest 0.9.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.7.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.106 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/mempool/Cargo.toml
+++ b/mempool/Cargo.toml
@@ -32,7 +32,6 @@ libra-types = { path = "../types", version = "0.1.0" }
 libra-workspace-hack = { path = "../common/workspace-hack", version = "0.1.0" }
 mirai-annotations = "1.7.0"
 network = { path = "../network", version = "0.1.0" }
-prometheus = { version = "0.8.0", default-features = false }
 serde_json = "1.0"
 storage-interface = { path = "../storage/storage-interface", version = "0.1.0" }
 vm-validator = { path = "../vm-validator", version = "0.1.0" }


### PR DESCRIPTION
Found a remaining unused prometheus dependency in mempool during triage. This removes it.
