### PR TITLE
[logging] print structure log to stdout if no file env set

### DIFF
--- a/common/logger/src/struct_log.rs
+++ b/common/logger/src/struct_log.rs
@@ -179,32 +179,32 @@ pub fn struct_logger_set() -> bool {
 
 /// Initializes struct logger from STRUCT_LOG_FILE env var
 /// Can only be called once
-pub fn init_struct_log_from_env() -> Result<(), InitFileLoggerError> {
+pub fn init_struct_log_from_env() -> Result<(), InitLoggerError> {
     if let Ok(file) = env::var("STRUCT_LOG_FILE") {
         init_file_struct_log(file)
     } else {
-        Ok(())
+        init_println_struct_log()
     }
 }
 
 /// Initializes struct logger sink that writes to specified file
 /// Can only be called once
-pub fn init_file_struct_log(file_path: String) -> Result<(), InitFileLoggerError> {
-    let logger = FileStructLog::start_new(file_path).map_err(InitFileLoggerError::IoError)?;
+pub fn init_file_struct_log(file_path: String) -> Result<(), InitLoggerError> {
+    let logger = FileStructLog::start_new(file_path).map_err(InitLoggerError::IoError)?;
     let logger = Box::leak(Box::new(logger));
-    set_struct_logger(logger).map_err(|_| InitFileLoggerError::StructLoggerAlreadySet)
+    set_struct_logger(logger).map_err(|_| InitLoggerError::StructLoggerAlreadySet)
 }
 
 /// Initialize struct logger sink that prints all structured logs to stdout
 /// Can only be called once
-pub fn init_println_struct_log() -> Result<(), ()> {
+pub fn init_println_struct_log() -> Result<(), InitLoggerError> {
     let logger = PrintStructLog {};
     let logger = Box::leak(Box::new(logger));
-    set_struct_logger(logger)
+    set_struct_logger(logger).map_err(|_| InitLoggerError::StructLoggerAlreadySet)
 }
 
 #[derive(Debug)]
-pub enum InitFileLoggerError {
+pub enum InitLoggerError {
     IoError(io::Error),
     StructLoggerAlreadySet,
 }


### PR DESCRIPTION
<!--
Thank you for sending a PR. We appreciate you spending time to help improve the Libra project.

The project is undergoing daily changes. Pull Requests will be reviewed and responded to as time permits.
-->

## Motivation

If structure log file env is not set, print structure log to stdout. Docker will still write application log to local file, but with a built in option to set the log retention. This will be easier to manage the log file size.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

Build and run libra-swarm locally

## Related PRs

(If this PR adds or changes functionality, please take some time to update the docs at https://github.com/libra/website, and link to your PR here.)
