### PR TITLE
[RFC][Move] Change move build output directory to something less generic

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,3 +40,6 @@ language/tools/vm-genesis/genesis/vm_config.toml
 
 # Terraform
 .terraform/
+
+# Move Build Output
+move_build_output/

--- a/language/move-lang/README.md
+++ b/language/move-lang/README.md
@@ -97,7 +97,7 @@ FLAGS:
 OPTIONS:
     -s, --sender <address>                             The sender address for modules and scripts
     -d, --dependencies <path-to-dependency-file>...    The library files needed as dependencies
-    -o, --out-dir <path-to-output-directory>           The move bytecode output directory [default: move_build_output]
+    -o, --out-dir <path-to-output-directory>           The Move Bytecode output directory [default: move_build_output]
     -f, --source-files <path-to-source-file>...        The source files to check and compile
 ```
 

--- a/language/move-lang/README.md
+++ b/language/move-lang/README.md
@@ -97,7 +97,7 @@ FLAGS:
 OPTIONS:
     -s, --sender <address>                             The sender address for modules and scripts
     -d, --dependencies <path-to-dependency-file>...    The library files needed as dependencies
-    -o, --out-dir <path-to-output-directory>           The Move Bytecode output directory [default: move_build_output]
+    -o, --out-dir <path-to-output-directory>           The Move bytecode output directory [default: move_build_output]
     -f, --source-files <path-to-source-file>...        The source files to check and compile
 ```
 

--- a/language/move-lang/README.md
+++ b/language/move-lang/README.md
@@ -97,7 +97,7 @@ FLAGS:
 OPTIONS:
     -s, --sender <address>                             The sender address for modules and scripts
     -d, --dependencies <path-to-dependency-file>...    The library files needed as dependencies
-    -o, --out-dir <path-to-output-directory>           The directory for outputing move bytecode [default: output]
+    -o, --out-dir <path-to-output-directory>           The move bytecode output directory [default: move_build_output]
     -f, --source-files <path-to-source-file>...        The source files to check and compile
 ```
 

--- a/language/move-lang/src/bin/move-build.rs
+++ b/language/move-lang/src/bin/move-build.rs
@@ -37,7 +37,7 @@ pub struct Options {
     )]
     pub sender: Option<Address>,
 
-    /// The Move Bytecode output directory
+    /// The Move bytecode output directory
     #[structopt(
         name = "PATH_TO_OUTPUT_DIRECTORY",
         short = cli::OUT_DIR_SHORT,

--- a/language/move-lang/src/bin/move-build.rs
+++ b/language/move-lang/src/bin/move-build.rs
@@ -37,7 +37,7 @@ pub struct Options {
     )]
     pub sender: Option<Address>,
 
-    /// The directory for outputing move bytecode
+    /// The move bytecode output directory
     #[structopt(
         name = "PATH_TO_OUTPUT_DIRECTORY",
         short = cli::OUT_DIR_SHORT,

--- a/language/move-lang/src/bin/move-build.rs
+++ b/language/move-lang/src/bin/move-build.rs
@@ -37,7 +37,7 @@ pub struct Options {
     )]
     pub sender: Option<Address>,
 
-    /// The move bytecode output directory
+    /// The Move Bytecode output directory
     #[structopt(
         name = "PATH_TO_OUTPUT_DIRECTORY",
         short = cli::OUT_DIR_SHORT,

--- a/language/move-lang/src/command_line/mod.rs
+++ b/language/move-lang/src/command_line/mod.rs
@@ -14,7 +14,7 @@ pub const SENDER_SHORT: &str = "s";
 
 pub const OUT_DIR: &str = "out-dir";
 pub const OUT_DIR_SHORT: &str = "o";
-pub const DEFAULT_OUTPUT_DIR: &str = "output";
+pub const DEFAULT_OUTPUT_DIR: &str = "move_build_output";
 
 pub const SOURCE_MAP: &str = "source-map";
 pub const SOURCE_MAP_SHORT: &str = "m";


### PR DESCRIPTION
## Motivation

Change the `move build` output directory to something more specific to Move instead of the more generic `output`

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

Ran a build

![Screenshot 2020-04-28 11 58 39](https://user-images.githubusercontent.com/3757713/80526640-ea037580-8947-11ea-9079-1176b8a9f0bb.png)

## Related PRs

N/A
