### PR TITLE
[move-lang] Parser cleanup for GlobalCalls and ModuleAccess

### DIFF
--- a/language/move-lang/src/parser/lexer.rs
+++ b/language/move-lang/src/parser/lexer.rs
@@ -203,12 +203,6 @@ impl<'input> Lexer<'input> {
         Ok(tok)
     }
 
-    // Return the starting offset for the next token after the current one.
-    pub fn lookahead_start_loc(&self) -> usize {
-        let text = self.text[self.cur_end..].trim_start();
-        self.text.len() - text.len()
-    }
-
     pub fn advance(&mut self) -> Result<(), Error> {
         self.prev_end = self.cur_end;
         let text = self.text[self.cur_end..].trim_start();

--- a/language/move-lang/tests/move_check/expansion/global_access_pack.exp
+++ b/language/move-lang/tests/move_check/expansion/global_access_pack.exp
@@ -1,11 +1,11 @@
 error: 
 
-   ┌── tests/move_check/expansion/global_access_pack.move:3:13 ───
+   ┌── tests/move_check/expansion/global_access_pack.move:3:9 ───
    │
  3 │         ::S { }
-   │             ^ Unexpected '{'
+   │         ^^^ Invalid use of global name '::S'
    ·
  3 │         ::S { }
-   │             - Expected '('
+   │         --- Global names can only be used in function calls
    │
 

--- a/language/move-lang/tests/move_check/expansion/global_access_value.exp
+++ b/language/move-lang/tests/move_check/expansion/global_access_value.exp
@@ -1,0 +1,8 @@
+error: 
+
+   ┌── tests/move_check/expansion/global_access_value.move:3:13 ───
+   │
+ 3 │         1 + ::global_value
+   │             ^^^^^^^^^^^^^^ Unexpected global name '::global_value'. Global names are not values
+   │
+

--- a/language/move-lang/tests/move_check/expansion/global_access_value.move
+++ b/language/move-lang/tests/move_check/expansion/global_access_value.move
@@ -1,0 +1,5 @@
+module M {
+    fun foo(): u64 {
+        1 + ::global_value
+    }
+}


### PR DESCRIPTION
Wolfgang's changes in #3438 laid the groundwork for some simplifications around the way that we use the ModuleAccess nodes. Besides simplifying the parser, I'm looking into adding support for name aliases and plan to move toward using the ModuleAccess AST nodes to represent all the different kinds of names. (I'd like to rename "ModuleAccess" but I'm leaving that for a separate PR.)

- Extend the ModuleAccess AST node to also include global names.
- Distinguish Calls and GlobalCalls in the expansion phase, not the parser.
- Introduce a new "NameExp" non-terminal in the grammar (instead of the parse_pack_or_call_or_generic_name helper function) and refactor the code that uses it.

## Motivation

Cleanup

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

Updated tests and ran them
