### PR TITLE
[Key Manager] Creates a binary for the Key Manager.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2385,6 +2385,7 @@ dependencies = [
  "libra-workspace-hack 0.1.0",
  "libradb 0.1.0",
  "rand 0.7.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.106 (registry+https://github.com/rust-lang/crates.io-index)",
  "storage-interface 0.1.0",
  "thiserror 1.0.15 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio 0.2.13 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/config/config-builder/src/validator_config.rs
+++ b/config/config-builder/src/validator_config.rs
@@ -6,7 +6,7 @@ use anyhow::{ensure, format_err, Result};
 use executor::db_bootstrapper;
 use libra_config::{
     config::{
-        ConsensusType, NodeConfig, RemoteService, SafetyRulesBackend, SafetyRulesService,
+        ConsensusType, NodeConfig, RemoteService, SafetyRulesService, SecureBackend,
         SeedPeersConfig, VaultConfig,
     },
     generator,
@@ -255,9 +255,9 @@ impl ValidatorConfig {
 
         if let Some(backend) = &self.safety_rules_backend {
             safety_rules_config.backend = match backend.as_str() {
-                "in-memory" => SafetyRulesBackend::InMemoryStorage,
+                "in-memory" => SecureBackend::InMemoryStorage,
                 "on-disk" => safety_rules_config.backend.clone(),
-                "vault" => SafetyRulesBackend::Vault(VaultConfig {
+                "vault" => SecureBackend::Vault(VaultConfig {
                     default: true,
                     namespace: self.safety_rules_namespace.clone(),
                     server: self

--- a/config/src/config/mod.rs
+++ b/config/src/config/mod.rs
@@ -32,6 +32,8 @@ mod mempool_config;
 pub use mempool_config::*;
 mod network_config;
 pub use network_config::*;
+mod secure_config;
+pub use secure_config::*;
 mod state_sync_config;
 pub use state_sync_config::*;
 mod storage_config;
@@ -72,6 +74,8 @@ pub struct NodeConfig {
     pub metrics: MetricsConfig,
     #[serde(default)]
     pub mempool: MempoolConfig,
+    #[serde(default)]
+    pub secure: SecureConfig,
     #[serde(default)]
     pub state_sync: StateSyncConfig,
     #[serde(default)]
@@ -175,6 +179,7 @@ impl NodeConfig {
             metrics: self.metrics.clone(),
             mempool: self.mempool.clone(),
             state_sync: self.state_sync.clone(),
+            secure: self.secure.clone(),
             storage: self.storage.clone(),
             test: None,
             upstream: self.upstream.clone(),

--- a/config/src/config/safety_rules_config.rs
+++ b/config/src/config/safety_rules_config.rs
@@ -1,20 +1,21 @@
 // Copyright (c) The Libra Core Contributors
 // SPDX-License-Identifier: Apache-2.0
 
+use crate::config::SecureBackend;
 use serde::{Deserialize, Serialize};
 use std::{net::SocketAddr, path::PathBuf};
 
 #[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
 #[serde(default, deny_unknown_fields)]
 pub struct SafetyRulesConfig {
-    pub backend: SafetyRulesBackend,
+    pub backend: SecureBackend,
     pub service: SafetyRulesService,
 }
 
 impl Default for SafetyRulesConfig {
     fn default() -> Self {
         Self {
-            backend: SafetyRulesBackend::InMemoryStorage,
+            backend: SecureBackend::InMemoryStorage,
             service: SafetyRulesService::Local,
         }
     }
@@ -22,69 +23,10 @@ impl Default for SafetyRulesConfig {
 
 impl SafetyRulesConfig {
     pub fn set_data_dir(&mut self, data_dir: PathBuf) {
-        if let SafetyRulesBackend::OnDiskStorage(backend) = &mut self.backend {
+        if let SecureBackend::OnDiskStorage(backend) = &mut self.backend {
             backend.set_data_dir(data_dir);
         }
     }
-}
-
-#[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
-#[serde(tag = "type")]
-#[serde(rename_all = "snake_case")]
-pub enum SafetyRulesBackend {
-    InMemoryStorage,
-    Vault(VaultConfig),
-    OnDiskStorage(OnDiskStorageConfig),
-}
-
-#[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
-pub struct OnDiskStorageConfig {
-    // In testing scenarios this implies that the default state is okay if
-    // a state is not specified.
-    pub default: bool,
-    // Required path for on disk storage
-    pub path: PathBuf,
-    #[serde(skip)]
-    data_dir: PathBuf,
-}
-
-impl Default for OnDiskStorageConfig {
-    fn default() -> Self {
-        Self {
-            default: false,
-            path: PathBuf::from("safety_rules.toml"),
-            data_dir: PathBuf::from("/opt/libra/data/common"),
-        }
-    }
-}
-
-impl OnDiskStorageConfig {
-    pub fn path(&self) -> PathBuf {
-        if self.path.is_relative() {
-            self.data_dir.join(&self.path)
-        } else {
-            self.path.clone()
-        }
-    }
-
-    pub fn set_data_dir(&mut self, data_dir: PathBuf) {
-        self.data_dir = data_dir;
-    }
-}
-
-#[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
-pub struct VaultConfig {
-    /// In testing scenarios this will install baseline data if it is not specified. Note: this can
-    /// only be used if the token provided has root or sudo access.
-    pub default: bool,
-    /// A namespace is an optional portion of the path to a key stored within Vault. For example,
-    /// a secret, S, without a namespace would be available in secret/data/S, with a namespace, N, it
-    /// would be in secret/data/N/S.
-    pub namespace: Option<String>,
-    /// Vault's URL, note: only HTTP is currently supported.
-    pub server: String,
-    /// The authorization token for access secrets
-    pub token: String,
 }
 
 /// Defines how safety rules should be executed

--- a/config/src/config/secure_config.rs
+++ b/config/src/config/secure_config.rs
@@ -3,14 +3,40 @@
 
 use serde::{Deserialize, Serialize};
 use std::path::PathBuf;
+use std::net::SocketAddr;
+
+const DEFAULT_JSON_RPC_ADDR :&str = "127.0.0.1";
+const DEFAULT_JSON_RPC_PORT: u16 = 8080;
 
 #[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
 #[serde(default, deny_unknown_fields)]
-pub struct SecureConfig {}
+pub struct SecureConfig {
+    pub key_manager: KeyManagerConfig,
+}
 
 impl Default for SecureConfig {
     fn default() -> Self {
-        Self {}
+        Self {
+            key_manager : KeyManagerConfig::default(),
+        }
+    }
+}
+
+#[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
+#[serde(default, deny_unknown_fields)]
+pub struct KeyManagerConfig {
+    pub json_rpc_address: SocketAddr,
+    pub secure_backend: SecureBackend,
+}
+
+impl Default for KeyManagerConfig {
+    fn default() -> KeyManagerConfig {
+        KeyManagerConfig {
+            json_rpc_address: format!("{}:{}", DEFAULT_JSON_RPC_ADDR, DEFAULT_JSON_RPC_PORT)
+                .parse()
+                .unwrap(),
+            secure_backend : SecureBackend::InMemoryStorage,
+        }
     }
 }
 

--- a/config/src/config/secure_config.rs
+++ b/config/src/config/secure_config.rs
@@ -1,0 +1,74 @@
+// Copyright (c) The Libra Core Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+use serde::{Deserialize, Serialize};
+use std::path::PathBuf;
+
+#[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
+#[serde(default, deny_unknown_fields)]
+pub struct SecureConfig {}
+
+impl Default for SecureConfig {
+    fn default() -> Self {
+        Self {}
+    }
+}
+
+#[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
+#[serde(tag = "type")]
+#[serde(rename_all = "snake_case")]
+pub enum SecureBackend {
+    InMemoryStorage,
+    Vault(VaultConfig),
+    OnDiskStorage(OnDiskStorageConfig),
+}
+
+#[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
+pub struct VaultConfig {
+    /// In testing scenarios this will install baseline data if it is not specified. Note: this can
+    /// only be used if the token provided has root or sudo access.
+    pub default: bool,
+    /// A namespace is an optional portion of the path to a key stored within Vault. For example,
+    /// a secret, S, without a namespace would be available in secret/data/S, with a namespace, N, it
+    /// would be in secret/data/N/S.
+    pub namespace: Option<String>,
+    /// Vault's URL, note: only HTTP is currently supported.
+    pub server: String,
+    /// The authorization token for access secrets
+    pub token: String,
+}
+
+#[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
+pub struct OnDiskStorageConfig {
+    // In testing scenarios this implies that the default state is okay if
+    // a state is not specified.
+    pub default: bool,
+    // Required path for on disk storage
+    pub path: PathBuf,
+    #[serde(skip)]
+    data_dir: PathBuf,
+}
+
+impl Default for OnDiskStorageConfig {
+    fn default() -> Self {
+        Self {
+            default: false,
+            path: PathBuf::from("safety_rules.toml"),
+            data_dir: PathBuf::from("/opt/libra/data/common"),
+        }
+    }
+}
+
+impl OnDiskStorageConfig {
+    pub fn path(&self) -> PathBuf {
+        if self.path.is_relative() {
+            self.data_dir.join(&self.path)
+        } else {
+            self.path.clone()
+        }
+    }
+
+    pub fn set_data_dir(&mut self, data_dir: PathBuf) {
+        self.data_dir = data_dir;
+    }
+}

--- a/config/src/config/secure_config.rs
+++ b/config/src/config/secure_config.rs
@@ -2,10 +2,9 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use serde::{Deserialize, Serialize};
-use std::path::PathBuf;
-use std::net::SocketAddr;
+use std::{net::SocketAddr, path::PathBuf};
 
-const DEFAULT_JSON_RPC_ADDR :&str = "127.0.0.1";
+const DEFAULT_JSON_RPC_ADDR: &str = "127.0.0.1";
 const DEFAULT_JSON_RPC_PORT: u16 = 8080;
 
 #[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
@@ -17,7 +16,7 @@ pub struct SecureConfig {
 impl Default for SecureConfig {
     fn default() -> Self {
         Self {
-            key_manager : KeyManagerConfig::default(),
+            key_manager: KeyManagerConfig::default(),
         }
     }
 }
@@ -35,7 +34,7 @@ impl Default for KeyManagerConfig {
             json_rpc_address: format!("{}:{}", DEFAULT_JSON_RPC_ADDR, DEFAULT_JSON_RPC_PORT)
                 .parse()
                 .unwrap(),
-            secure_backend : SecureBackend::InMemoryStorage,
+            secure_backend: SecureBackend::InMemoryStorage,
         }
     }
 }

--- a/config/src/generator.rs
+++ b/config/src/generator.rs
@@ -6,7 +6,7 @@
 
 use crate::{
     config::{
-        NodeConfig, OnDiskStorageConfig, SafetyRulesBackend, SafetyRulesService, SeedPeersConfig,
+        NodeConfig, OnDiskStorageConfig, SafetyRulesService, SecureBackend, SeedPeersConfig,
         TestConfig,
     },
     utils,
@@ -36,7 +36,7 @@ pub fn validator_swarm(
         let mut storage_config = OnDiskStorageConfig::default();
         storage_config.default = true;
         node.consensus.safety_rules.service = SafetyRulesService::Thread;
-        node.consensus.safety_rules.backend = SafetyRulesBackend::OnDiskStorage(storage_config);
+        node.consensus.safety_rules.backend = SecureBackend::OnDiskStorage(storage_config);
 
         let network = node.validator_network.as_mut().unwrap();
         if randomize_libranet_ports {

--- a/consensus/safety-rules/benches/safety_rules.rs
+++ b/consensus/safety-rules/benches/safety_rules.rs
@@ -3,7 +3,7 @@
 
 use consensus_types::block::{block_test_utils, Block};
 use criterion::{black_box, criterion_group, criterion_main, Criterion};
-use libra_config::config::{OnDiskStorageConfig, SafetyRulesBackend};
+use libra_config::config::{OnDiskStorageConfig, SecureBackend};
 use libra_secure_storage::{InMemoryStorage, OnDiskStorage};
 use libra_types::validator_signer::ValidatorSigner;
 use rand::Rng;
@@ -108,7 +108,7 @@ fn process(n: u64) {
     let mut config = OnDiskStorageConfig::default();
     config.default = true;
     config.path = file_path;
-    let backend = SafetyRulesBackend::OnDiskStorage(config);
+    let backend = SecureBackend::OnDiskStorage(config);
     let client_wrapper = ProcessClientWrapper::new(backend);
     let signer = client_wrapper.signer();
 

--- a/consensus/safety-rules/src/process_client_wrapper.rs
+++ b/consensus/safety-rules/src/process_client_wrapper.rs
@@ -12,7 +12,7 @@ use consensus_types::{
     vote_proposal::VoteProposal,
 };
 use libra_config::{
-    config::{ConsensusType, NodeConfig, RemoteService, SafetyRulesBackend, SafetyRulesService},
+    config::{ConsensusType, NodeConfig, RemoteService, SafetyRulesService, SecureBackend},
     utils,
 };
 use libra_crypto::ed25519::Ed25519Signature;
@@ -32,7 +32,7 @@ pub struct ProcessClientWrapper<T> {
 }
 
 impl<T: Payload> ProcessClientWrapper<T> {
-    pub fn new(backend: SafetyRulesBackend) -> Self {
+    pub fn new(backend: SecureBackend) -> Self {
         let server_port = utils::get_available_port();
         let server_address = SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), server_port);
 

--- a/consensus/safety-rules/src/safety_rules_manager.rs
+++ b/consensus/safety-rules/src/safety_rules_manager.rs
@@ -12,7 +12,7 @@ use crate::{
     SafetyRules, TSafetyRules,
 };
 use consensus_types::common::{Author, Payload};
-use libra_config::config::{NodeConfig, SafetyRulesBackend, SafetyRulesService};
+use libra_config::config::{NodeConfig, SafetyRulesService, SecureBackend};
 use libra_secure_storage::{InMemoryStorage, OnDiskStorage, Storage, VaultStorage};
 use std::{
     net::SocketAddr,
@@ -28,11 +28,11 @@ pub fn extract_service_inputs(config: &mut NodeConfig) -> (Author, PersistentSaf
 
     let backend = &config.consensus.safety_rules.backend;
     let (initialize, internal_storage): (bool, Box<dyn Storage>) = match backend {
-        SafetyRulesBackend::InMemoryStorage => (true, InMemoryStorage::new_storage()),
-        SafetyRulesBackend::OnDiskStorage(config) => {
+        SecureBackend::InMemoryStorage => (true, InMemoryStorage::new_storage()),
+        SecureBackend::OnDiskStorage(config) => {
             (config.default, OnDiskStorage::new_storage(config.path()))
         }
-        SafetyRulesBackend::Vault(config) => (
+        SecureBackend::Vault(config) => (
             config.default,
             VaultStorage::new_storage(
                 config.server.clone(),

--- a/consensus/safety-rules/src/tests/spawned_process.rs
+++ b/consensus/safety-rules/src/tests/spawned_process.rs
@@ -3,7 +3,7 @@
 
 use crate::{process_client_wrapper::ProcessClientWrapper, tests::suite, TSafetyRules};
 use consensus_types::common::{Payload, Round};
-use libra_config::config::SafetyRulesBackend;
+use libra_config::config::SecureBackend;
 use libra_types::validator_signer::ValidatorSigner;
 
 #[test]
@@ -12,7 +12,7 @@ fn test() {
 }
 
 fn safety_rules<T: Payload>() -> (Box<dyn TSafetyRules<T>>, ValidatorSigner) {
-    let client_wrapper = ProcessClientWrapper::new(SafetyRulesBackend::InMemoryStorage);
+    let client_wrapper = ProcessClientWrapper::new(SecureBackend::InMemoryStorage);
     let signer = client_wrapper.signer();
     (Box::new(client_wrapper), signer)
 }

--- a/secure/key-manager/Cargo.toml
+++ b/secure/key-manager/Cargo.toml
@@ -10,6 +10,10 @@ license = "Apache-2.0"
 publish = false
 
 [dependencies]
+serde = { version = "1.0.106", features = ["rc"], default-features = false }
+thiserror = "1.0"
+
+libra-config = { path = "../../config", version = "0.1.0", features = ["fuzzing"]}
 libra-crypto = { path = "../../crypto/crypto", version = "0.1.0" }
 libra-logger = { path = "../../common/logger", version = "0.1.0" }
 libra-secure-json-rpc = { path = "../../secure/json-rpc", version = "0.1.0" }
@@ -18,7 +22,6 @@ libra-secure-time = { path = "../../secure/time", version = "0.1.0" }
 libra-transaction-scripts = { path = "../transaction-scripts", version = "0.1.0" }
 libra-types = { path = "../../types", version = "0.1.0" }
 libra-workspace-hack = { path = "../../common/workspace-hack", version = "0.1.0" }
-thiserror = "1.0"
 
 [dev-dependencies]
 anyhow = "1.0"
@@ -30,7 +33,6 @@ config-builder = { path = "../../config/config-builder", version = "0.1.0" }
 executor = { path = "../../execution/executor", version = "0.1.0" }
 executor-types = { path = "../../execution/executor-types", version = "0.1.0" }
 libradb = { path = "../../storage/libradb", version = "0.1.0" }
-libra-config = { path = "../../config", version = "0.1.0", features = ["fuzzing"]}
 libra-json-rpc = { path = "../../json-rpc", version = "0.1.0", features = ["fuzzing"] }
 libra-vm = { path = "../../language/libra-vm", version = "0.1.0" }
 storage-interface= { path = "../../storage/storage-interface", version = "0.1.0" }

--- a/secure/key-manager/src/lib.rs
+++ b/secure/key-manager/src/lib.rs
@@ -33,7 +33,8 @@ use libra_types::{
 use std::time::Duration;
 use thiserror::Error;
 
-mod libra_interface;
+pub mod libra_interface;
+
 #[cfg(test)]
 mod tests;
 

--- a/secure/key-manager/src/libra_interface.rs
+++ b/secure/key-manager/src/libra_interface.rs
@@ -55,7 +55,6 @@ pub struct JsonRpcLibraInterface {
     client: JsonRpcClient,
 }
 
-#[allow(dead_code)]
 impl JsonRpcLibraInterface {
     pub fn new(client: JsonRpcClient) -> Self {
         Self { client }

--- a/secure/key-manager/src/main.rs
+++ b/secure/key-manager/src/main.rs
@@ -1,0 +1,78 @@
+// Copyright (c) The Libra Core Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+//! Usage: ./key-manager node.config
+
+#![forbid(unsafe_code)]
+
+use libra_config::config::{KeyManagerConfig, NetworkConfig, NodeConfig, SecureBackend};
+use libra_key_manager::{libra_interface::JsonRpcLibraInterface, Error, KeyManager};
+use libra_secure_json_rpc::JsonRpcClient;
+use libra_secure_storage::{InMemoryStorage, OnDiskStorage, VaultStorage};
+use libra_secure_time::RealTimeService;
+use std::{env, process};
+
+// TODO(joshlind): initialize the metrics components for the key manager!
+fn main() {
+    let args: Vec<String> = env::args().collect();
+
+    if args.len() != 2 {
+        eprintln!("Incorrect number of parameters, expected a path to a config file");
+        process::exit(1);
+    }
+
+    let config = NodeConfig::load(&args[1]).unwrap_or_else(|e| {
+        eprintln!("Unable to read provided config: {}", e);
+        process::exit(1);
+    });
+
+    if config.validator_network.is_none() {
+        eprintln!("Validator config missing from node config");
+        process::exit(1);
+    }
+    let network_config = config.validator_network.unwrap();
+    let key_manager_config = config.secure.key_manager;
+
+    create_and_execute_key_manager(network_config, key_manager_config).unwrap_or_else(|e| {
+        eprintln!("The Key Manager has failed during execution: {}", e);
+        process::exit(1);
+    });
+}
+
+fn create_and_execute_key_manager(
+    network_config: NetworkConfig,
+    key_manager_config: KeyManagerConfig,
+) -> Result<(), Error> {
+    // Create the json rpc based libra interface
+    let json_rpc_url = format!(
+        "https://{}",
+        key_manager_config.json_rpc_address.to_string()
+    );
+    let json_rpc_client = JsonRpcClient::new(json_rpc_url);
+    let libra_interface = JsonRpcLibraInterface::new(json_rpc_client);
+
+    // Create the key manager based on the backend and execute
+    match key_manager_config.secure_backend {
+        SecureBackend::InMemoryStorage => KeyManager::new(
+            network_config.peer_id,
+            libra_interface,
+            InMemoryStorage::new(),
+            RealTimeService::new(),
+        )
+        .execute(),
+        SecureBackend::OnDiskStorage(config) => KeyManager::new(
+            network_config.peer_id,
+            libra_interface,
+            OnDiskStorage::new(config.path()),
+            RealTimeService::new(),
+        )
+        .execute(),
+        SecureBackend::Vault(config) => KeyManager::new(
+            network_config.peer_id,
+            libra_interface,
+            VaultStorage::new(config.server, config.token, config.namespace),
+            RealTimeService::new(),
+        )
+        .execute(),
+    }
+}

--- a/secure/key-manager/src/main.rs
+++ b/secure/key-manager/src/main.rs
@@ -7,34 +7,44 @@
 
 use libra_config::config::{KeyManagerConfig, NetworkConfig, NodeConfig, SecureBackend};
 use libra_key_manager::{libra_interface::JsonRpcLibraInterface, Error, KeyManager};
+use libra_logger::info;
 use libra_secure_json_rpc::JsonRpcClient;
-use libra_secure_storage::{InMemoryStorage, OnDiskStorage, VaultStorage};
+use libra_secure_storage::VaultStorage;
 use libra_secure_time::RealTimeService;
-use std::{env, process};
+use std::{env, net::SocketAddr, process};
 
 // TODO(joshlind): initialize the metrics components for the key manager!
 fn main() {
     let args: Vec<String> = env::args().collect();
 
     if args.len() != 2 {
-        eprintln!("Incorrect number of parameters, expected a path to a config file");
+        eprintln!("Error! Incorrect number of parameters, expected a path to a config file.");
         process::exit(1);
     }
 
     let config = NodeConfig::load(&args[1]).unwrap_or_else(|e| {
-        eprintln!("Unable to read provided config: {}", e);
+        eprintln!(
+            "Error! Unable to load provided config: {}, error: {}",
+            args[1], e
+        );
         process::exit(1);
     });
 
     if config.validator_network.is_none() {
-        eprintln!("Validator config missing from node config");
+        eprintln!("Error! Validator config missing from node config.");
         process::exit(1);
     }
     let network_config = config.validator_network.unwrap();
     let key_manager_config = config.secure.key_manager;
 
+    libra_logger::Logger::new()
+        .channel_size(config.logger.chan_size)
+        .is_async(config.logger.is_async)
+        .level(config.logger.level)
+        .init();
+
     create_and_execute_key_manager(network_config, key_manager_config).unwrap_or_else(|e| {
-        eprintln!("The Key Manager has failed during execution: {}", e);
+        eprintln!("Error! The Key Manager has failed during execution: {}", e);
         process::exit(1);
     });
 }
@@ -43,36 +53,33 @@ fn create_and_execute_key_manager(
     network_config: NetworkConfig,
     key_manager_config: KeyManagerConfig,
 ) -> Result<(), Error> {
-    // Create the json rpc based libra interface
-    let json_rpc_url = format!(
-        "https://{}",
-        key_manager_config.json_rpc_address.to_string()
+    let account = network_config.peer_id;
+    let libra_interface = create_libra_interface(key_manager_config.json_rpc_address);
+    let time_service = RealTimeService::new();
+
+    match key_manager_config.secure_backend {
+        SecureBackend::Vault(config) => {
+            let storage = VaultStorage::new(
+                config.server.clone(),
+                config.token.clone(),
+                config.namespace.clone(),
+            );
+            info!("Creating a key manager with vault secure storage. Vault server: {:?}, token: {:?}, namespace: {:?}.",
+                  config.server,
+                  config.token,
+                  config.namespace);
+            KeyManager::new(account, libra_interface, storage, time_service).execute()
+        }
+        _ => panic!("Unable to create a key manager with a secure backend that is not Vault!"),
+    }
+}
+
+fn create_libra_interface(json_rpc_address: SocketAddr) -> JsonRpcLibraInterface {
+    let json_rpc_url = format!("https://{}", json_rpc_address.to_string());
+    info!(
+        "Creating a libra interface that talks to the JSON RPC endpoint at: {:?}.",
+        json_rpc_url.clone()
     );
     let json_rpc_client = JsonRpcClient::new(json_rpc_url);
-    let libra_interface = JsonRpcLibraInterface::new(json_rpc_client);
-
-    // Create the key manager based on the backend and execute
-    match key_manager_config.secure_backend {
-        SecureBackend::InMemoryStorage => KeyManager::new(
-            network_config.peer_id,
-            libra_interface,
-            InMemoryStorage::new(),
-            RealTimeService::new(),
-        )
-        .execute(),
-        SecureBackend::OnDiskStorage(config) => KeyManager::new(
-            network_config.peer_id,
-            libra_interface,
-            OnDiskStorage::new(config.path()),
-            RealTimeService::new(),
-        )
-        .execute(),
-        SecureBackend::Vault(config) => KeyManager::new(
-            network_config.peer_id,
-            libra_interface,
-            VaultStorage::new(config.server, config.token, config.namespace),
-            RealTimeService::new(),
-        )
-        .execute(),
-    }
+    JsonRpcLibraInterface::new(json_rpc_client)
 }

--- a/secure/key-manager/src/tests.rs
+++ b/secure/key-manager/src/tests.rs
@@ -322,7 +322,6 @@ fn setup_node<T: LibraInterface + Clone>(
     let libra_test_harness = LibraInterfaceTestHarness::new(libra);
     let key_manager = KeyManager::new(
         account,
-        crate::CONSENSUS_KEY.into(),
         libra_test_harness.clone(),
         setup_secure_storage(&config, time.clone()),
         time.clone(),
@@ -344,7 +343,7 @@ fn setup_secure_storage(
     let a_prikey = Value::Ed25519PrivateKey(a_keypair.take_private().unwrap());
 
     sec_storage
-        .create(crate::ACCOUNT_KEY, a_prikey, &Policy::public())
+        .create(crate::VALIDATOR_KEY, a_prikey, &Policy::public())
         .unwrap();
 
     let mut c_keypair = test_config.consensus_keypair.unwrap();


### PR DESCRIPTION
## Motivation

This PR implements a main.rs file for the Libra Key Manager. This allows the Key Manager to be deployed as a self-contained binary. To achieve this, the PR offers the following commits:

1. Removing the "key_name" parameter from the Key Manager. This parameter doesn't make much sense given that the only key_name we care about (i.e., the only key we can currently rotate) is the consensus key. This commit also updates the key constants to be consistent with our deployment model.

2. Refactoring SafetyRulesBackend into SecureBackend to allow both Safety Rules and the Key Manager to have a configurable backend. As part of this commit, we create a SecureConfig template.

3. Add a main.rs file for the Key Manager and a KeyManagerConfig to allow the Key Manager to be built as a binary.

4. Added logging support (with some simple log messages) to the Key Manager, to allow execution to be monitored. Also refactored main() as part of this and removed in_memory and on_disk backend support for the Key Manager.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?

Yes.

## Test Plan

This PR was tested manually by: (i) executing a local Libra network; (ii) creating a key manager; and (iii) pointing the key manager to the JSON-RPC endpoint and secure storage backend of a Validator node in the network (by using a hand modified version of the same config file that started the local Libra network). For the secure storage backend we used the same on-disk storage used by Libra Safety Rules (with some hand tweaking to initialize the validator key and the rotated consensus key..). 

Once the local Libra network was initialized and running, I modified the various time constants (e.g., the rotation time and sleep time) to be on the order of 10's of seconds, and executed the Key Manager for >20 minutes. By observing the logs produced by the Key Manager I could verify certain behaviors (e.g., rotations, sleeps, status checks, interaction with the JSON-RPC endpoint).

Note: I also tested several failure scenarios and error cases (e.g., secure storage failures, JSON-RPC endpoint failures etc.). However, we'll obviously need to write some automated tests for this. See future steps below.

## Future steps

To allow the Key Manager to be deployed as a self-contained docker service, the next steps that follow this PR are: (i) adding support for metrics; (ii) writing some docker build/run scripts to invoke the Key Manager binary; and (iii) adding testing infrastructure to perform automated deployment tests (e.g., smoke tests).

## Related PRs

None.
