### PR TITLE
[management] secure_backend to dyn storage

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2413,6 +2413,7 @@ dependencies = [
  "libra-types 0.1.0",
  "libra-workspace-hack 0.1.0",
  "structopt 0.3.14 (registry+https://github.com/rust-lang/crates.io-index)",
+ "thiserror 1.0.16 (registry+https://github.com/rust-lang/crates.io-index)",
  "transaction-builder 0.1.0",
  "vm-genesis 0.1.0",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2406,6 +2406,7 @@ dependencies = [
 name = "libra-management"
 version = "0.1.0"
 dependencies = [
+ "libra-config 0.1.0",
  "libra-crypto 0.1.0",
  "libra-network-address 0.1.0",
  "libra-secure-storage 0.1.0",

--- a/config/management/Cargo.toml
+++ b/config/management/Cargo.toml
@@ -13,6 +13,7 @@ edition = "2018"
 structopt = "0.3.14"
 thiserror = "1.0"
 
+libra-config = { path = "..", version = "0.1.0" }
 libra-crypto = { path = "../../crypto/crypto", version = "0.1.0" }
 libra-network-address = { path = "../../network/network-address", version = "0.1.0" }
 libra-secure-storage = { path = "../../secure/storage", version = "0.1.0" }

--- a/config/management/Cargo.toml
+++ b/config/management/Cargo.toml
@@ -11,6 +11,7 @@ edition = "2018"
 
 [dependencies]
 structopt = "0.3.14"
+thiserror = "1.0"
 
 libra-crypto = { path = "../../crypto/crypto", version = "0.1.0" }
 libra-network-address = { path = "../../network/network-address", version = "0.1.0" }

--- a/config/management/src/error.rs
+++ b/config/management/src/error.rs
@@ -5,6 +5,12 @@ use thiserror::Error;
 
 #[derive(Debug, Error, PartialEq)]
 pub enum Error {
+    #[error("Invalid key value found in backend: {0}")]
+    BackendInvalidKeyValue(String),
+    #[error("Backend is missing the backend key")]
+    BackendMissingBackendKey,
+    #[error("Backend parsing error: {0}")]
+    BackendParsingError(String),
     #[error("Local storage unavailable, please check your configuration")]
     LocalStorageUnavailable,
     #[error("Failed to read local storage: {0}")]

--- a/config/management/src/error.rs
+++ b/config/management/src/error.rs
@@ -17,6 +17,10 @@ pub enum Error {
     LocalStorageReadError(String),
     #[error("Failed to sign data using local storage: {0}")]
     LocalStorageSigningError(String),
+    #[error("Failed to read remote storage: {0}")]
+    RemoteStorageReadError(String),
+    #[error("Remote storage unavailable, please check your configuration")]
+    RemoteStorageUnavailable,
     #[error("Unexpected command, expected {0}, found {1}")]
     UnexpectedCommand(String, String),
 }

--- a/config/management/src/error.rs
+++ b/config/management/src/error.rs
@@ -1,0 +1,16 @@
+// Copyright (c) The Libra Core Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+use thiserror::Error;
+
+#[derive(Debug, Error, PartialEq)]
+pub enum Error {
+    #[error("Local storage unavailable, please check your configuration")]
+    LocalStorageUnavailable,
+    #[error("Failed to read local storage: {0}")]
+    LocalStorageReadError(String),
+    #[error("Failed to sign data using local storage: {0}")]
+    LocalStorageSigningError(String),
+    #[error("Unexpected command, expected {0}, found {1}")]
+    UnexpectedCommand(String, String),
+}

--- a/config/management/src/lib.rs
+++ b/config/management/src/lib.rs
@@ -524,7 +524,7 @@ pub mod tests {
                     token={token};\
                     namespace={remote_ns}\
             ",
-            backend = "vault",
+            backend = crate::secure_backend::VAULT,
             server = VAULT_HOST,
             token = VAULT_ROOT_TOKEN,
             local_ns = local_ns,
@@ -549,7 +549,7 @@ pub mod tests {
                     token={token};\
                     namespace={remote_ns}\
             ",
-            backend = "vault",
+            backend = crate::secure_backend::VAULT,
             server = VAULT_HOST,
             token = VAULT_ROOT_TOKEN,
             local_ns = local_ns,
@@ -581,7 +581,7 @@ pub mod tests {
             owner_address = owner_address,
             validator_address = validator_address,
             fullnode_address = fullnode_address,
-            backend = "vault",
+            backend = crate::secure_backend::VAULT,
             server = VAULT_HOST,
             token = VAULT_ROOT_TOKEN,
             ns = namespace,
@@ -601,7 +601,7 @@ pub mod tests {
                     token={token};\
                     namespace={ns}
             ",
-            backend = "vault",
+            backend = crate::secure_backend::VAULT,
             server = VAULT_HOST,
             token = VAULT_ROOT_TOKEN,
             ns = namespace,

--- a/config/management/src/lib.rs
+++ b/config/management/src/lib.rs
@@ -4,6 +4,7 @@
 #![forbid(unsafe_code)]
 
 mod error;
+mod secure_backend;
 
 use crate::error::Error;
 use libra_crypto::{ed25519::Ed25519PublicKey, hash::CryptoHash, x25519, ValidCryptoMaterial};

--- a/config/management/src/secure_backend.rs
+++ b/config/management/src/secure_backend.rs
@@ -11,6 +11,10 @@ use std::{
     str::FromStr,
 };
 
+pub const DISK: &str = "disk";
+pub const MEMORY: &str = "memory";
+pub const VAULT: &str = "vault";
+
 /// SecureBackend is a parameter that is stored as set of semi-colon separated key/value pairs. The
 /// only expected key is backend which defines which of the SecureBackends the parameters refer to.
 /// Some backends require parameters others do not, so that requires a conversion into the
@@ -63,7 +67,7 @@ impl TryInto<config::SecureBackend> for SecureBackend {
 
     fn try_into(mut self) -> Result<config::SecureBackend, Error> {
         let backend = match self.backend.as_ref() {
-            "disk" => {
+            DISK => {
                 let mut config = OnDiskStorageConfig::default();
                 config.set_data_dir(PathBuf::from(""));
                 let path = self
@@ -73,8 +77,8 @@ impl TryInto<config::SecureBackend> for SecureBackend {
                 config.path = PathBuf::from(path);
                 config::SecureBackend::OnDiskStorage(config)
             }
-            "memory" => config::SecureBackend::InMemoryStorage,
-            "vault" => {
+            MEMORY => config::SecureBackend::InMemoryStorage,
+            VAULT => {
                 let server = self
                     .parameters
                     .remove("server")

--- a/config/management/src/secure_backend.rs
+++ b/config/management/src/secure_backend.rs
@@ -1,0 +1,135 @@
+// Copyright (c) The Libra Core Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::error::Error;
+use libra_config::config::{self, OnDiskStorageConfig, VaultConfig};
+use std::{
+    collections::HashMap,
+    convert::{TryFrom, TryInto},
+    path::PathBuf,
+};
+
+/// SecureBackend is a parameter that is stored as set of semi-colon separated key/value pairs. The
+/// only expected key is backend which defines which of the SecureBackends the parameters refer to.
+/// Some backends require parameters others do not, so that requires a conversion into the
+/// config::SecureBackend type to parse.
+///
+/// Example: backend=vault;server=http://127.0.0.1:8080;token=123456
+struct SecureBackend {
+    backend: String,
+    parameters: HashMap<String, String>,
+}
+
+impl SecureBackend {
+    const BACKEND: &'static str = "backend";
+}
+
+impl TryFrom<&str> for SecureBackend {
+    type Error = Error;
+
+    fn try_from(s: &str) -> Result<Self, Error> {
+        let kvs = s.split(';');
+        let mut parameters = HashMap::new();
+        for pair in kvs {
+            let kv = pair.split('=').collect::<Vec<_>>();
+            if kv.len() != 2 {
+                return Err(Error::BackendInvalidKeyValue(format!("{:?}", kv)));
+            }
+            parameters.insert(kv[0].into(), kv[1].into());
+        }
+        let backend = parameters
+            .remove(Self::BACKEND)
+            .ok_or(Error::BackendMissingBackendKey)?;
+        Ok(Self {
+            backend,
+            parameters,
+        })
+    }
+}
+
+impl TryInto<config::SecureBackend> for SecureBackend {
+    type Error = Error;
+
+    fn try_into(mut self) -> Result<config::SecureBackend, Error> {
+        let backend = match self.backend.as_ref() {
+            "disk" => {
+                let mut config = OnDiskStorageConfig::default();
+                config.set_data_dir(PathBuf::from(""));
+                let path = self
+                    .parameters
+                    .remove("path")
+                    .ok_or_else(|| Error::BackendParsingError("missing path".into()))?;
+                config.path = PathBuf::from(path);
+                config::SecureBackend::OnDiskStorage(config)
+            }
+            "memory" => config::SecureBackend::InMemoryStorage,
+            "vault" => {
+                let server = self
+                    .parameters
+                    .remove("server")
+                    .ok_or_else(|| Error::BackendParsingError("missing server".into()))?;
+                let token = self
+                    .parameters
+                    .remove("token")
+                    .ok_or_else(|| Error::BackendParsingError("missing token".into()))?;
+                config::SecureBackend::Vault(VaultConfig {
+                    default: false,
+                    namespace: self.parameters.remove("namespace"),
+                    server,
+                    // TODO(davidiw) Make this a path to a file
+                    token,
+                })
+            }
+            _ => panic!("Invalid backend: {}", self.backend),
+        };
+
+        if !self.parameters.is_empty() {
+            let error = format!("found extra parameters: {:?}", self.parameters);
+            return Err(Error::BackendParsingError(error));
+        }
+
+        Ok(backend)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use libra_secure_storage::Storage;
+
+    #[test]
+    fn test_memory() {
+        let memory = "backend=memory";
+        storage(memory).unwrap();
+
+        let memory = "backend=memory;extra=stuff";
+        assert!(storage(memory).is_err());
+    }
+
+    #[test]
+    fn test_disk() {
+        let disk = "backend=disk;path=some_path";
+        storage(disk).unwrap();
+
+        let disk = "backend=disk";
+        assert!(storage(disk).is_err());
+    }
+
+    #[test]
+    fn test_vault() {
+        let vault = "backend=vault;server=http://127.0.0.1:8080;token=123456";
+        storage(vault).unwrap();
+
+        let vault = "backend=vault;server=http://127.0.0.1:8080;token=123456;namespace=test";
+        storage(vault).unwrap();
+
+        let vault = "backend=vault";
+        assert!(storage(vault).is_err());
+    }
+
+    fn storage(s: &str) -> Result<Box<dyn Storage>, Error> {
+        let management_backend: SecureBackend = s.try_into()?;
+        let config: config::SecureBackend = management_backend.try_into()?;
+        Ok((&config).into())
+    }
+}

--- a/secure/storage/Cargo.toml
+++ b/secure/storage/Cargo.toml
@@ -12,6 +12,7 @@ edition = "2018"
 [dependencies]
 chrono = "0.4.9"
 lcs = { path = "../../common/lcs", version = "0.1.0", package = "libra-canonical-serialization" }
+libra-config = { path = "../../config", version = "0.1.0" }
 libra-crypto = { path = "../../crypto/crypto", version = "0.1.0" }
 libra-secure-time = { path = "../time", version = "0.1.0" }
 libra-temppath = { path = "../../common/temppath", version = "0.1.0" }
@@ -24,7 +25,6 @@ thiserror = "1.0"
 toml = { version = "0.5.3", default-features = false }
 
 [dev-dependencies]
-libra-config = { path = "../../config", version = "0.1.0" }
 rand = "0.7.3"
 
 [features]

--- a/secure/storage/src/in_memory.rs
+++ b/secure/storage/src/in_memory.rs
@@ -69,6 +69,7 @@ impl<T: Send + Sync + TimeService> KVStorage for InMemoryStorageInternal<T> {
                 let key = lcs::from_bytes(&bytes)?;
                 Value::Ed25519PrivateKey(key)
             }
+            Value::Ed25519PublicKey(value) => Value::Ed25519PublicKey(value.clone()),
             Value::HashValue(value) => Value::HashValue(*value),
             Value::String(value) => Value::String(value.clone()),
             Value::U64(value) => Value::U64(*value),

--- a/secure/storage/src/kv_storage.rs
+++ b/secure/storage/src/kv_storage.rs
@@ -15,6 +15,10 @@ pub trait KVStorage: Send + Sync {
     /// Creates a new value in storage and fails if it already exists
     fn create(&mut self, key: &str, value: Value, policy: &Policy) -> Result<(), Error>;
 
+    fn create_with_default_policy(&mut self, key: &str, value: Value) -> Result<(), Error> {
+        self.create(key, value, &Policy::default())
+    }
+
     /// Creates a new value if it does not exist fails only if there is some other issue.
     fn create_if_not_exists(
         &mut self,

--- a/secure/storage/src/lib.rs
+++ b/secure/storage/src/lib.rs
@@ -3,6 +3,9 @@
 
 #![forbid(unsafe_code)]
 
+use libra_config::config::SecureBackend;
+use std::convert::From;
+
 mod crypto_kv_storage;
 mod crypto_storage;
 mod error;
@@ -28,6 +31,20 @@ pub use crate::{
     value::Value,
     vault::VaultStorage,
 };
+
+impl From<&SecureBackend> for Box<dyn Storage> {
+    fn from(backend: &SecureBackend) -> Self {
+        match backend {
+            SecureBackend::InMemoryStorage => Box::new(InMemoryStorage::new()),
+            SecureBackend::OnDiskStorage(config) => Box::new(OnDiskStorage::new(config.path())),
+            SecureBackend::Vault(config) => Box::new(VaultStorage::new(
+                config.server.clone(),
+                config.token.clone(),
+                config.namespace.clone(),
+            )),
+        }
+    }
+}
 
 #[cfg(test)]
 mod tests;

--- a/secure/storage/src/policy.rs
+++ b/secure/storage/src/policy.rs
@@ -4,7 +4,7 @@
 use serde::{Deserialize, Serialize};
 
 /// Dictates a set of permissions
-#[derive(Debug, Deserialize, Serialize)]
+#[derive(Debug, Default, Deserialize, PartialEq, Serialize)]
 pub struct Policy {
     pub permissions: Vec<Permission>,
 }
@@ -12,6 +12,10 @@ pub struct Policy {
 impl Policy {
     pub fn new(permissions: Vec<Permission>) -> Self {
         Self { permissions }
+    }
+
+    pub fn is_default(&self) -> bool {
+        Self::default() == *self
     }
 
     pub fn public() -> Self {
@@ -23,7 +27,7 @@ impl Policy {
 }
 
 /// Maps an identity to a set of capabilities
-#[derive(Debug, Deserialize, Serialize)]
+#[derive(Debug, Deserialize, PartialEq, Serialize)]
 pub struct Permission {
     pub id: Identity,
     pub capabilities: Vec<Capability>,
@@ -40,7 +44,7 @@ impl Permission {
 /// verifiable material. For example, the process running safety_rules may have a token that is
 /// intended for only safety_rules to own. The specifics are left to the implementation of the
 /// storage backend interface layer.
-#[derive(Debug, Deserialize, Serialize)]
+#[derive(Debug, Deserialize, PartialEq, Serialize)]
 pub enum Identity {
     User(String),
     Anyone,
@@ -48,7 +52,7 @@ pub enum Identity {
 }
 
 /// Represents actions
-#[derive(Debug, Deserialize, Serialize)]
+#[derive(Debug, Deserialize, PartialEq, Serialize)]
 pub enum Capability {
     Export,
     Read,

--- a/secure/storage/src/value.rs
+++ b/secure/storage/src/value.rs
@@ -2,13 +2,17 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::error::Error;
-use libra_crypto::{ed25519::Ed25519PrivateKey, hash::HashValue};
+use libra_crypto::{
+    ed25519::{Ed25519PrivateKey, Ed25519PublicKey},
+    hash::HashValue,
+};
 use serde::{Deserialize, Serialize};
 
 #[derive(Debug, Deserialize, PartialEq, Serialize)]
 #[serde(content = "value", rename_all = "snake_case", tag = "type")]
 pub enum Value {
     Ed25519PrivateKey(Ed25519PrivateKey),
+    Ed25519PublicKey(Ed25519PublicKey),
     HashValue(HashValue),
     String(String),
     U64(u64),
@@ -17,6 +21,14 @@ pub enum Value {
 impl Value {
     pub fn ed25519_private_key(self) -> Result<Ed25519PrivateKey, Error> {
         if let Value::Ed25519PrivateKey(value) = self {
+            Ok(value)
+        } else {
+            Err(Error::UnexpectedValueType)
+        }
+    }
+
+    pub fn ed25519_public_key(self) -> Result<Ed25519PublicKey, Error> {
+        if let Value::Ed25519PublicKey(value) = self {
             Ok(value)
         } else {
             Err(Error::UnexpectedValueType)

--- a/secure/storage/src/vault.rs
+++ b/secure/storage/src/vault.rs
@@ -235,7 +235,9 @@ impl KVStorage for VaultStorage {
         }
 
         self.set_secret(&key, value)?;
-        self.set_policies(key, &VaultEngine::KVSecrets, policy)?;
+        if !policy.is_default() {
+            self.set_policies(key, &VaultEngine::KVSecrets, policy)?;
+        }
         Ok(())
     }
 
@@ -266,7 +268,9 @@ impl CryptoStorage for VaultStorage {
         }
 
         self.client.create_ed25519_key(&ns_name, true)?;
-        self.set_policies(&ns_name, &VaultEngine::Transit, policy)?;
+        if !policy.is_default() {
+            self.set_policies(&ns_name, &VaultEngine::Transit, policy)?;
+        }
         self.get_public_key(name).map(|v| v.public_key)
     }
 


### PR DESCRIPTION
This introduces a means to convert from the new command-line storage
parameter to an actual storage backend.

The format for the command-line is
"k0=v0;k1=v1;..."
where at least one of the k_i must be backend and the rest are options
for that backend.

The test vectors show what should be parseable and what is not. Some
advanced parameters, for example, the server address or token for Vault
will only be tested upon use.