### PR TITLE
[cluster-test] Add a teardown method for ClusterTestRunner

### DIFF
--- a/testsuite/cluster-test/src/aws.rs
+++ b/testsuite/cluster-test/src/aws.rs
@@ -17,6 +17,7 @@ pub async fn set_asg_size(
     min_desired_capacity: i64,
     buffer_percent: f64,
     asg_name: &str,
+    wait_for_completion: bool,
 ) -> Result<()> {
     let buffer = ((min_desired_capacity as f64 * buffer_percent) / 100_f64).ceil() as i64;
     info!(
@@ -35,6 +36,9 @@ pub async fn set_asg_size(
     asc.set_desired_capacity(set_desired_capacity_type)
         .await
         .map_err(|e| format_err!("set_desired_capacity failed: {:?}", e))?;
+    if !wait_for_completion {
+        return Ok(());
+    }
     retry::retry_async(retry::fixed_retry_strategy(10_000, 30), || {
         let asc_clone = asc.clone();
         Box::pin(async move {


### PR DESCRIPTION
## Summary

Add a teardown method for ClusterTestRunner which scales down the cluster to size 0.

Depends upon https://github.com/calibra/libra-ops/pull/527

## Motivation

Now that cluster-test also performs autoscaling, it can conflict with the `cluster-autoscaler` running on the cluster. This has led to a couple of failures in cluster-test. There is no way to coordinate these two processes, so its easier that cluster-test does both the scaling-up and scaling-down.

One downside of this is that subsequent runs on the cluster-test will have to scale-down and scale up everytime, but the average scale-up overhead is only 40-50 seconds, so that should be fine

## Test Plan

Ran single experiment and ci suite