### PR TITLE
[move-lang] Use the term "identifier" instead of "name" in the parser

### DIFF
--- a/language/move-lang/src/parser/lexer.rs
+++ b/language/move-lang/src/parser/lexer.rs
@@ -13,7 +13,7 @@ pub enum Tok {
     U64Value,
     U128Value,
     ByteStringValue,
-    NameValue,
+    IdentifierValue,
     Exclaim,
     ExclaimEqual,
     Percent,
@@ -87,7 +87,7 @@ impl fmt::Display for Tok {
             U64Value => "[U64]",
             U128Value => "[U128]",
             ByteStringValue => "[ByteString]",
-            NameValue => "[Name]",
+            IdentifierValue => "[Identifier]",
             Exclaim => "!",
             ExclaimEqual => "!=",
             Percent => "%",
@@ -419,6 +419,6 @@ fn get_name_token(name: &str) -> Tok {
         "true" => Tok::True,
         "use" => Tok::Use,
         "while" => Tok::While,
-        _ => Tok::NameValue,
+        _ => Tok::IdentifierValue,
     }
 }

--- a/language/move-lang/tests/move_check/expansion/pack_no_fields_block_expr.exp
+++ b/language/move-lang/tests/move_check/expansion/pack_no_fields_block_expr.exp
@@ -6,6 +6,6 @@ error:
    │                     ^^^ Unexpected 'let'
    ·
  4 │         let s = S { let x = 0; x };
-   │                     --- Expected a name value
+   │                     --- Expected an identifier
    │
 

--- a/language/move-lang/tests/move_check/expansion/pack_no_fields_single_block_expr.exp
+++ b/language/move-lang/tests/move_check/expansion/pack_no_fields_single_block_expr.exp
@@ -6,6 +6,6 @@ error:
    │                     ^^^^^ Unexpected 'false'
    ·
  4 │         let s = S { false };
-   │                     ----- Expected a name value
+   │                     ----- Expected an identifier
    │
 

--- a/language/move-lang/tests/move_check/expansion/unpack_assign_block_expr.exp
+++ b/language/move-lang/tests/move_check/expansion/unpack_assign_block_expr.exp
@@ -6,6 +6,6 @@ error:
    │             ^^^ Unexpected 'let'
    ·
  4 │         S { let f = 0; } = S { f: 0 };
-   │             --- Expected a name value
+   │             --- Expected an identifier
    │
 

--- a/language/move-lang/tests/move_check/expansion/unpack_assign_block_single_expr.exp
+++ b/language/move-lang/tests/move_check/expansion/unpack_assign_block_single_expr.exp
@@ -6,6 +6,6 @@ error:
    │             ^ Unexpected '0'
    ·
  4 │         S { 0 } = S { f: 0 };
-   │             - Expected a name value
+   │             - Expected an identifier
    │
 

--- a/language/move-lang/tests/move_check/parser/struct_resource.exp
+++ b/language/move-lang/tests/move_check/parser/struct_resource.exp
@@ -6,6 +6,6 @@ error:
    │            ^^^^^^^^ Unexpected 'resource'
    ·
  3 │     struct resource S { }
-   │            -------- Expected a name value
+   │            -------- Expected an identifier
    │
 


### PR DESCRIPTION
The term "identifier" is well known and used by other compilers like Clang and Rust, both internally and in diagnostic messages. We should do the same for Move. (I would also like to repurpose the "name" term for what we now call a "ModuleAccess", but let's take this one step at a time....)

## Motivation

Clarifying naming

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

I ran the tests and updated the expected output as needed