### PR TITLE
[move-prover] Finish module invariants.

### DIFF
--- a/language/move-prover/spec-lang/src/ast.rs
+++ b/language/move-prover/spec-lang/src/ast.rs
@@ -80,18 +80,18 @@ impl ConditionKind {
     }
 
     /// Returns true if this condition is allowed on a function declaration.
-    pub fn allowed_on_fun_decl(&self) -> bool {
+    pub fn allowed_on_public_fun_decl(&self) -> bool {
         use ConditionKind::*;
         matches!(
             self,
-            Requires
-                | RequiresModule
-                | Invariant
-                | InvariantModule
-                | AbortsIf
-                | Ensures
-                | VarUpdate(..)
+            Requires | RequiresModule | AbortsIf | Ensures | VarUpdate(..)
         )
+    }
+
+    /// Returns true if this condition is allowed on a private function declaration.
+    pub fn allowed_on_private_fun_decl(&self) -> bool {
+        use ConditionKind::*;
+        matches!(self, Requires | AbortsIf | Ensures | VarUpdate(..))
     }
 
     /// Returns true if this condition is allowed in a function body.
@@ -112,11 +112,32 @@ impl ConditionKind {
     /// Returns true if this condition is allowed on a module.
     pub fn allowed_on_module(&self) -> bool {
         use ConditionKind::*;
-        matches!(self, Invariant | InvariantModule)
+        matches!(self, Invariant)
     }
 }
 
-#[derive(Debug)]
+impl std::fmt::Display for ConditionKind {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        use ConditionKind::*;
+        match self {
+            Assert => write!(f, "assert"),
+            Assume => write!(f, "assume"),
+            Decreases => write!(f, "decreases"),
+            AbortsIf => write!(f, "aborts_if"),
+            Ensures => write!(f, "ensures"),
+            Requires => write!(f, "requires"),
+            RequiresModule => write!(f, "requires module"),
+            Invariant => write!(f, "invariant"),
+            InvariantModule => write!(f, "invariant module"),
+            InvariantUpdate => write!(f, "invariant update"),
+            VarUpdate(..) => write!(f, "invariant update assign"),
+            VarPack(..) => write!(f, "invariant pack assign"),
+            VarUnpack(..) => write!(f, "invariant unpack assign"),
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
 pub struct Condition {
     pub loc: Loc,
     pub kind: ConditionKind,
@@ -130,7 +151,7 @@ pub struct Condition {
 pub type PropertyBag = BTreeMap<Symbol, Value>;
 
 /// Specification and properties associated with a language item.
-#[derive(Debug, Default)]
+#[derive(Debug, Clone, Default)]
 pub struct Spec {
     // The set of conditions associated with this item.
     pub conditions: Vec<Condition>,

--- a/language/move-prover/spec-lang/src/ty.rs
+++ b/language/move-prover/spec-lang/src/ty.rs
@@ -130,7 +130,11 @@ impl Type {
 
     /// Instantiates type parameters in this type.
     pub fn instantiate(&self, params: &[Type]) -> Type {
-        self.replace(Some(params), None)
+        if params.is_empty() {
+            self.clone()
+        } else {
+            self.replace(Some(params), None)
+        }
     }
 
     /// A helper function to do replacement of type parameters and/or type variables.

--- a/language/move-prover/spec-lang/tests/sources/schemas_err.exp
+++ b/language/move-prover/spec-lang/tests/sources/schemas_err.exp
@@ -78,7 +78,7 @@ error: `y` cannot be matched to an existing name in inclusion context
     │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
     │
 
-error: schema includes condition which is not allowed in this context
+error: `requires` (included from schema) not allowed in this context
 
     ┌── tests/sources/schemas_err.move:70:9 ───
     │

--- a/language/move-prover/src/bytecode_translator.rs
+++ b/language/move-prover/src/bytecode_translator.rs
@@ -1013,9 +1013,10 @@ impl<'env> ModuleTranslator<'env> {
                             && callee_env.module_env.get_spec().has_conditions()
                         {
                             let spec_translator =
-                                SpecTranslator::new(self.writer, &callee_env.module_env, false);
+                                SpecTranslator::new(self.writer, &callee_env.module_env, false)
+                                    .set_type_args(type_actuals.clone());
                             spec_translator
-                                .assume_module_invariants(&self.targets.get_target(&callee_env));
+                                .assume_module_preconditions(&self.targets.get_target(&callee_env));
                         }
                         // If this is a call to a public function within the same module,
                         // and it has parameters which are mutated currently, we end mutating now,

--- a/language/move-prover/tests/sources/functional/marketcap_as_schema.exp
+++ b/language/move-prover/tests/sources/functional/marketcap_as_schema.exp
@@ -1,16 +1,16 @@
 Move prover returns: exiting with boogie verification errors
 error:  A postcondition might not hold on this return path.
 
-    ┌── tests/sources/functional/marketcap_as_schema.move:12:9 ───
+    ┌── tests/sources/functional/marketcap_as_schema.move:11:9 ───
     │
- 12 │         ensures global<MarketCap>(0xA550C18).total_value == sum_of_coins<X>;
-    │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+ 11 │         invariant module global<MarketCap>(0xA550C18).total_value == sum_of_coins<X>;
+    │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
     │
-    =     at tests/sources/functional/marketcap_as_schema.move:55:6: deposit_invalid (entry)
-    =     at tests/sources/functional/marketcap_as_schema.move:56:18: deposit_invalid
+    =     at tests/sources/functional/marketcap_as_schema.move:54:6: deposit_invalid (entry)
+    =     at tests/sources/functional/marketcap_as_schema.move:55:18: deposit_invalid
     =         coin_ref = <redacted>,
     =         check = <redacted>,
     =         value = <redacted>
-    =     at tests/sources/functional/marketcap_as_schema.move:57:27: deposit_invalid
+    =     at tests/sources/functional/marketcap_as_schema.move:56:27: deposit_invalid
     =         coin_ref = <redacted>
-    =     at tests/sources/functional/marketcap_as_schema.move:55:6: deposit_invalid (exit)
+    =     at tests/sources/functional/marketcap_as_schema.move:54:6: deposit_invalid (exit)

--- a/language/move-prover/tests/sources/functional/marketcap_as_schema.move
+++ b/language/move-prover/tests/sources/functional/marketcap_as_schema.move
@@ -8,8 +8,7 @@ module TestMarketCapWithSchemas {
     }
 
     spec schema SumOfCoinsModuleInvariant<X> {
-        requires global<MarketCap>(0xA550C18).total_value == sum_of_coins<X>;
-        ensures global<MarketCap>(0xA550C18).total_value == sum_of_coins<X>;
+        invariant module global<MarketCap>(0xA550C18).total_value == sum_of_coins<X>;
     }
 
     // A resource representing the Libra coin

--- a/language/move-prover/tests/sources/functional/marketcap_as_schema_apply.exp
+++ b/language/move-prover/tests/sources/functional/marketcap_as_schema_apply.exp
@@ -1,16 +1,16 @@
 Move prover returns: exiting with boogie verification errors
 error:  A postcondition might not hold on this return path.
 
-    ┌── tests/sources/functional/marketcap_as_schema_apply.move:12:9 ───
+    ┌── tests/sources/functional/marketcap_as_schema_apply.move:11:9 ───
     │
- 12 │         ensures global<MarketCap>(0xA550C18).total_value == sum_of_coins<X>;
-    │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+ 11 │         invariant module global<MarketCap>(0xA550C18).total_value == sum_of_coins<X>;
+    │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
     │
-    =     at tests/sources/functional/marketcap_as_schema_apply.move:63:5: deposit_incorrect (entry)
-    =     at tests/sources/functional/marketcap_as_schema_apply.move:64:17: deposit_incorrect
+    =     at tests/sources/functional/marketcap_as_schema_apply.move:62:5: deposit_incorrect (entry)
+    =     at tests/sources/functional/marketcap_as_schema_apply.move:63:17: deposit_incorrect
     =         coin_ref = <redacted>,
     =         check = <redacted>,
     =         value = <redacted>
-    =     at tests/sources/functional/marketcap_as_schema_apply.move:65:26: deposit_incorrect
+    =     at tests/sources/functional/marketcap_as_schema_apply.move:64:26: deposit_incorrect
     =         coin_ref = <redacted>
-    =     at tests/sources/functional/marketcap_as_schema_apply.move:63:5: deposit_incorrect (exit)
+    =     at tests/sources/functional/marketcap_as_schema_apply.move:62:5: deposit_incorrect (exit)

--- a/language/move-prover/tests/sources/functional/marketcap_as_schema_apply.move
+++ b/language/move-prover/tests/sources/functional/marketcap_as_schema_apply.move
@@ -8,8 +8,7 @@ module TestMarketCapWithSchemas {
     }
 
     spec schema SumOfCoinsModuleInvariant<X> {
-        requires global<MarketCap>(0xA550C18).total_value == sum_of_coins<X>;
-        ensures global<MarketCap>(0xA550C18).total_value == sum_of_coins<X>;
+        invariant module global<MarketCap>(0xA550C18).total_value == sum_of_coins<X>;
     }
 
     spec module {


### PR DESCRIPTION
This finishes new style of module invariants which can use schemas.

- One can now use `invariant module P` in a schema or function block. This is explained as syntactic sugar for the pair `requires module P; ensures P`.
- The `requires module P` condition is translated as follows: it is assumed for calls from the outside of the module, and asserted for calls from inside.
- One can also now use `invariant P` (without the module qualifier) in schemas and function blocks. This is explained as syntactic sugar for the pair `requires P; ensures P`, thus has not the special property of an assumed precondition for calls from the outside of a module.
- Old-style invariants on the module spec block are still supported and resolved as syntactic sugar in spec-lang. A spec block `spec module { invariant P; }` is reduced to an `invariant module P` for each function spec block, where it is then further broken down to `requires module P; ensures P` as described above.

The problem to keep module invariant/requires consistent with *all* possible exit points from a module is for now not tackled. The solution would be  a safeguard for someone misusing the feature of module invariant/requires, which is not so urgent to solve for now (and has some open conceptual problems).

<!--
Thank you for sending a PR. We appreciate you spending time to help improve the Libra project.

The project is undergoing daily changes. Pull Requests will be reviewed and responded to as time permits.
-->

## Motivation

Global specs.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

Existing tests refactored to use new features.

## Related PRs

NA