### PR TITLE
[Move Prover] Changed signature of WriteRef and refactored Branch instruction

### DIFF
--- a/language/move-prover/stackless-bytecode-generator/src/lifetime_analysis.rs
+++ b/language/move-prover/stackless-bytecode-generator/src/lifetime_analysis.rs
@@ -378,8 +378,8 @@ impl<'a> LifetimeAnalysis<'a> {
                         after_state.borrow_graph.move_local(src);
                     }
                     WriteRef => {
-                        let dst = dsts[0];
-                        after_state.borrow_graph.move_local(dst);
+                        let src = srcs[0];
+                        after_state.borrow_graph.move_local(src);
                     }
                     ReadRef => {
                         let src = srcs[0];

--- a/language/move-prover/stackless-bytecode-generator/src/livevar_analysis.rs
+++ b/language/move-prover/stackless-bytecode-generator/src/livevar_analysis.rs
@@ -7,7 +7,7 @@ use crate::{
     },
     function_target::{FunctionTarget, FunctionTargetData},
     function_target_pipeline::{FunctionTargetProcessor, FunctionTargetsHolder},
-    stackless_bytecode::{BranchCond, Bytecode, Operation, TempIndex},
+    stackless_bytecode::{Bytecode, Operation, TempIndex},
     stackless_control_flow_graph::{BlockId, StacklessControlFlowGraph},
 };
 use itertools::Itertools;
@@ -124,26 +124,21 @@ impl LiveVarAnalysis {
             }
             Call(_, dsts, op, srcs) => {
                 use Operation::*;
-                let removed = match op {
+                match op {
                     Abort => {
                         post.reset();
-                        true
                     }
-                    _ => post.remove(dsts),
+                    _ => {
+                        post.remove(dsts);
+                    }
                 };
-                if removed {
-                    post.insert(srcs.clone());
-                }
+                post.insert(srcs.clone());
             }
             Ret(_, srcs) => {
                 post.insert(srcs.clone());
             }
-            Branch(_, _, cond) => {
-                use BranchCond::*;
-                match cond {
-                    True(src) | False(src) => post.insert(vec![*src]),
-                    Always => {}
-                }
+            Branch(_, _, _, src) => {
+                post.insert(vec![*src]);
             }
             _ => {}
         }

--- a/language/move-prover/stackless-bytecode-generator/src/stackless_bytecode.rs
+++ b/language/move-prover/stackless-bytecode-generator/src/stackless_bytecode.rs
@@ -140,14 +140,6 @@ pub enum Operation {
     Neq,
 }
 
-/// A branch condition.
-#[derive(Debug, Clone, PartialEq, Eq, Copy)]
-pub enum BranchCond {
-    Always,
-    True(TempIndex),
-    False(TempIndex),
-}
-
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum Bytecode {
     SpecBlock(AttrId, SpecBlockId),
@@ -158,7 +150,8 @@ pub enum Bytecode {
     Ret(AttrId, Vec<TempIndex>),
 
     Load(AttrId, TempIndex, Constant),
-    Branch(AttrId, Label, BranchCond),
+    Branch(AttrId, Label, Label, TempIndex),
+    Jump(AttrId, Label),
     Label(AttrId, Label),
     Nop(AttrId),
 }
@@ -173,6 +166,7 @@ impl Bytecode {
             | Ret(id, ..)
             | Load(id, ..)
             | Branch(id, ..)
+            | Jump(id, ..)
             | Label(id, ..)
             | Nop(id) => *id,
         }
@@ -183,28 +177,23 @@ impl Bytecode {
     }
 
     pub fn is_unconditional_branch(&self) -> bool {
-        matches!(
-            self,
-            Bytecode::Ret(..) | Bytecode::Branch(_, _, BranchCond::Always)
-        )
+        matches!(self, Bytecode::Ret(..) | Bytecode::Jump(..))
     }
 
     pub fn is_conditional_branch(&self) -> bool {
-        matches!(
-            self,
-            Bytecode::Branch(_, _, BranchCond::False(_)) | Bytecode::Branch(_, _, BranchCond::True(_))
-        )
+        matches!(self, Bytecode::Branch(..))
     }
 
     pub fn is_branch(&self) -> bool {
         self.is_conditional_branch() || self.is_unconditional_branch()
     }
 
-    /// Return the destination of branching if self is a branching instruction
-    pub fn branch_dest(&self) -> Option<Label> {
+    /// Return the destination(s) if self is a branch/jump instruction
+    pub fn branch_dests(&self) -> Vec<Label> {
         match self {
-            Bytecode::Branch(_, label, _) => Some(*label),
-            _ => None,
+            Bytecode::Branch(_, then_label, else_label, _) => vec![*then_label, *else_label],
+            Bytecode::Jump(_, label) => vec![*label],
+            _ => vec![],
         }
     }
 
@@ -229,7 +218,7 @@ impl Bytecode {
         let bytecode = &code[pc as usize];
         let mut v = vec![];
 
-        if let Some(label) = bytecode.branch_dest() {
+        for label in bytecode.branch_dests() {
             v.push(*label_offsets.get(&label).expect("label defined"));
         }
 
@@ -309,17 +298,16 @@ impl<'env> fmt::Display for BytecodeDisplay<'env> {
             Load(_, dst, cons) => {
                 write!(f, "{} := {}", self.lstr(*dst), cons)?;
             }
-            Branch(_, label, cond) => {
-                use BranchCond::*;
-                match cond {
-                    True(src) => {
-                        write!(f, "if ({}) ", self.lstr(*src))?;
-                    }
-                    False(src) => {
-                        write!(f, "if (!{}) ", self.lstr(*src))?;
-                    }
-                    _ => {}
-                }
+            Branch(_, then_label, else_label, src) => {
+                write!(
+                    f,
+                    "if ({}) goto L{} else goto L{}",
+                    self.lstr(*src),
+                    then_label.as_usize(),
+                    else_label.as_usize()
+                )?;
+            }
+            Jump(_, label) => {
                 write!(f, "goto L{}", label.as_usize())?;
             }
             Label(_, label) => {

--- a/language/move-prover/stackless-bytecode-generator/src/stackless_control_flow_graph.rs
+++ b/language/move-prover/stackless-bytecode-generator/src/stackless_control_flow_graph.rs
@@ -118,7 +118,7 @@ impl StacklessControlFlowGraph {
     ) {
         let bytecode = &code[pc as usize];
 
-        if let Some(label) = bytecode.branch_dest() {
+        for label in bytecode.branch_dests() {
             block_ids.insert(*label_offsets.get(&label).unwrap());
         }
 

--- a/language/move-prover/stackless-bytecode-generator/tests/eliminate_imm_refs/basic_test.exp
+++ b/language/move-prover/stackless-bytecode-generator/tests/eliminate_imm_refs/basic_test.exp
@@ -22,7 +22,7 @@ fun TestEliminateImmRefs::test1(): TestEliminateImmRefs::R {
     x_ref := $t7
     $t8 := 0
     $t9 := move(x_ref)
-    $t9 := write_ref($t8)
+    write_ref($t9, $t8)
     $t10 := move(r)
     return $t10
 }
@@ -110,7 +110,7 @@ fun TestEliminateImmRefs::test1(): TestEliminateImmRefs::R {
     x_ref := $t7
     $t8 := 0
     $t9 := move(x_ref)
-    $t9 := write_ref($t8)
+    write_ref($t9, $t8)
     $t10 := move(r)
     return $t10
 }

--- a/language/move-prover/stackless-bytecode-generator/tests/from_move/regression_generic_and_native_type.exp
+++ b/language/move-prover/stackless-bytecode-generator/tests/from_move/regression_generic_and_native_type.exp
@@ -12,19 +12,20 @@ pub fun Vector::append<$tv0>(lhs: &mut vector<#0>, other: vector<#0>) {
     var $t10: vector<#0>
     $t2 := borrow_local(other)
     Vector::reverse<#0>($t2)
-    L2:
+    L3:
     $t3 := borrow_local(other)
     $t4 := Vector::is_empty<#0>($t3)
     $t5 := !($t4)
-    if ($t5) goto L0
-    goto L1
+    if ($t5) goto L0 else goto L1
+    L1:
+    goto L2
     L0:
     $t6 := copy(lhs)
     $t7 := borrow_local(other)
     $t8 := Vector::pop_back<#0>($t7)
     Vector::push_back<#0>($t6, $t8)
-    goto L2
-    L1:
+    goto L3
+    L2:
     $t9 := move(lhs)
     destroy($t9)
     $t10 := move(other)
@@ -69,34 +70,36 @@ pub fun Vector::contains<$tv0>(v: &vector<#0>, e: &#0): bool {
     $t5 := copy(v)
     $t6 := Vector::length<#0>($t5)
     len := $t6
-    L4:
+    L6:
     $t7 := copy(i)
     $t8 := copy(len)
     $t9 := <($t7, $t8)
-    if ($t9) goto L0
-    goto L1
+    if ($t9) goto L0 else goto L1
+    L1:
+    goto L2
     L0:
     $t10 := copy(v)
     $t11 := copy(i)
     $t12 := Vector::borrow<#0>($t10, $t11)
     $t13 := copy(e)
     $t14 := ==($t12, $t13)
-    if ($t14) goto L2
-    goto L3
-    L2:
+    if ($t14) goto L3 else goto L4
+    L4:
+    goto L5
+    L3:
     $t15 := move(v)
     destroy($t15)
     $t16 := move(e)
     destroy($t16)
     $t17 := true
     return $t17
-    L3:
+    L5:
     $t18 := copy(i)
     $t19 := 1
     $t20 := +($t18, $t19)
     i := $t20
-    goto L4
-    L1:
+    goto L6
+    L2:
     $t21 := move(v)
     destroy($t21)
     $t22 := move(e)
@@ -174,25 +177,27 @@ pub fun Vector::remove<$tv0>(v: &mut vector<#0>, i: u64): #0 {
     $t8 := copy(i)
     $t9 := copy(len)
     $t10 := >=($t8, $t9)
-    if ($t10) goto L0
-    goto L1
+    if ($t10) goto L0 else goto L1
+    L1:
+    goto L2
     L0:
     $t11 := move(v)
     destroy($t11)
     $t12 := 10
     abort($t12)
-    L1:
+    L2:
     $t13 := copy(len)
     $t14 := 1
     $t15 := -($t13, $t14)
     len := $t15
-    L4:
+    L6:
     $t16 := copy(i)
     $t17 := copy(len)
     $t18 := <($t16, $t17)
-    if ($t18) goto L2
-    goto L3
-    L2:
+    if ($t18) goto L3 else goto L4
+    L4:
+    goto L5
+    L3:
     $t19 := copy(v)
     $t4 := $t19
     $t20 := copy(i)
@@ -205,8 +210,8 @@ pub fun Vector::remove<$tv0>(v: &mut vector<#0>, i: u64): #0 {
     $t25 := move($t3)
     $t26 := copy(i)
     Vector::swap<#0>($t24, $t25, $t26)
-    goto L4
-    L3:
+    goto L6
+    L5:
     $t27 := move(v)
     $t28 := Vector::pop_back<#0>($t27)
     return $t28
@@ -248,26 +253,28 @@ pub fun Vector::reverse<$tv0>(v: &mut vector<#0>) {
     $t7 := copy(len)
     $t8 := 0
     $t9 := ==($t7, $t8)
-    if ($t9) goto L0
-    goto L1
+    if ($t9) goto L0 else goto L1
+    L1:
+    goto L2
     L0:
     $t10 := move(v)
     destroy($t10)
     return ()
-    L1:
+    L2:
     $t11 := 0
     front_index := $t11
     $t12 := copy(len)
     $t13 := 1
     $t14 := -($t12, $t13)
     back_index := $t14
-    L4:
+    L6:
     $t15 := copy(front_index)
     $t16 := copy(back_index)
     $t17 := <($t15, $t16)
-    if ($t17) goto L2
-    goto L3
-    L2:
+    if ($t17) goto L3 else goto L4
+    L4:
+    goto L5
+    L3:
     $t18 := copy(v)
     $t19 := copy(front_index)
     $t20 := copy(back_index)
@@ -280,8 +287,8 @@ pub fun Vector::reverse<$tv0>(v: &mut vector<#0>) {
     $t25 := 1
     $t26 := -($t24, $t25)
     back_index := $t26
-    goto L4
-    L3:
+    goto L6
+    L5:
     $t27 := move(v)
     destroy($t27)
     return ()
@@ -367,7 +374,7 @@ pub fun Libra::preburn<$tv0>(preburn_ref: &mut Libra::Preburn<#0>, coin: Libra::
     $t15 := +($t13, $t14)
     $t16 := move(market_cap)
     $t17 := borrow_field<Libra::Info<#0>>.preburn_value($t16)
-    $t17 := write_ref($t15)
+    write_ref($t17, $t15)
     return ()
 }
 

--- a/language/move-prover/stackless-bytecode-generator/tests/from_move/smoke_test.exp
+++ b/language/move-prover/stackless-bytecode-generator/tests/from_move/smoke_test.exp
@@ -34,12 +34,13 @@ fun SmokeTest::arithmetic_ops(a: u64): (u64, u64) {
     $t13 := copy(c)
     $t14 := 2
     $t15 := !=($t13, $t14)
-    if ($t15) goto L0
-    goto L1
+    if ($t15) goto L0 else goto L1
+    L1:
+    goto L2
     L0:
     $t16 := 42
     abort($t16)
-    L1:
+    L2:
     $t17 := copy(c)
     $t18 := copy(a)
     return ($t17, $t18)
@@ -77,47 +78,50 @@ fun SmokeTest::bool_ops(a: u64, b: u64): (bool, bool) {
     $t6 := copy(a)
     $t7 := copy(b)
     $t8 := >($t6, $t7)
-    if ($t8) goto L0
-    goto L1
+    if ($t8) goto L0 else goto L1
+    L1:
+    goto L2
     L0:
     $t9 := copy(a)
     $t10 := copy(b)
     $t11 := >=($t9, $t10)
     $t4 := $t11
-    goto L2
-    L1:
+    goto L3
+    L2:
     $t12 := false
     $t4 := $t12
-    L2:
+    L3:
     $t13 := move($t4)
     c := $t13
     $t14 := copy(a)
     $t15 := copy(b)
     $t16 := <($t14, $t15)
-    if ($t16) goto L3
-    goto L4
-    L3:
+    if ($t16) goto L4 else goto L5
+    L5:
+    goto L6
+    L4:
     $t17 := true
     $t5 := $t17
-    goto L5
-    L4:
+    goto L7
+    L6:
     $t18 := copy(a)
     $t19 := copy(b)
     $t20 := <=($t18, $t19)
     $t5 := $t20
-    L5:
+    L7:
     $t21 := move($t5)
     d := $t21
     $t22 := copy(c)
     $t23 := copy(d)
     $t24 := !=($t22, $t23)
     $t25 := !($t24)
-    if ($t25) goto L6
-    goto L7
-    L6:
+    if ($t25) goto L8 else goto L9
+    L9:
+    goto L10
+    L8:
     $t26 := 42
     abort($t26)
-    L7:
+    L10:
     $t27 := copy(c)
     $t28 := copy(d)
     return ($t27, $t28)
@@ -315,20 +319,21 @@ fun SmokeTest::ref_A(a: address, b: bool): SmokeTest::A {
     var $t23: u64
     var $t24: SmokeTest::A
     $t7 := copy(b)
-    if ($t7) goto L0
-    goto L1
+    if ($t7) goto L0 else goto L1
+    L1:
+    goto L2
     L0:
     $t8 := copy(a)
     $t9 := 1
     $t10 := pack SmokeTest::A($t8, $t9)
     $t4 := $t10
-    goto L2
-    L1:
+    goto L3
+    L2:
     $t11 := copy(a)
     $t12 := 42
     $t13 := pack SmokeTest::A($t11, $t12)
     $t4 := $t13
-    L2:
+    L3:
     $t14 := move($t4)
     var_a := $t14
     $t15 := borrow_local(var_a)
@@ -342,12 +347,13 @@ fun SmokeTest::ref_A(a: address, b: bool): SmokeTest::A {
     $t20 := copy(b_var)
     $t21 := 42
     $t22 := !=($t20, $t21)
-    if ($t22) goto L3
-    goto L4
-    L3:
+    if ($t22) goto L4 else goto L5
+    L5:
+    goto L6
+    L4:
     $t23 := 42
     abort($t23)
-    L4:
+    L6:
     $t24 := move(var_a)
     return $t24
 }

--- a/language/move-prover/stackless-bytecode-generator/tests/from_move/specs-in-fun.exp
+++ b/language/move-prover/stackless-bytecode-generator/tests/from_move/specs-in-fun.exp
@@ -9,20 +9,21 @@ fun TestSpecBlock::looping(x: u64): u64 {
     var $t6: u64
     var $t7: u64
     spec at 592..616
-    L2:
+    L3:
     $t1 := copy(x)
     $t2 := 10
     $t3 := <($t1, $t2)
-    if ($t3) goto L0
-    goto L1
+    if ($t3) goto L0 else goto L1
+    L1:
+    goto L2
     L0:
     spec at 653..676
     $t4 := copy(x)
     $t5 := 1
     $t6 := +($t4, $t5)
     x := $t6
-    goto L2
-    L1:
+    goto L3
+    L2:
     spec at 718..742
     $t7 := copy(x)
     return $t7
@@ -39,12 +40,13 @@ fun TestSpecBlock::simple1(x: u64, y: u64) {
     $t3 := copy(y)
     $t4 := >($t2, $t3)
     $t5 := !($t4)
-    if ($t5) goto L0
-    goto L1
+    if ($t5) goto L0 else goto L1
+    L1:
+    goto L2
     L0:
     $t6 := 1
     abort($t6)
-    L1:
+    L2:
     spec at 97..139
     return ()
 }

--- a/language/move-prover/stackless-bytecode-generator/tests/lifetime/basic_test.exp
+++ b/language/move-prover/stackless-bytecode-generator/tests/lifetime/basic_test.exp
@@ -39,37 +39,39 @@ fun TestLifetime::lifetime_(cond: bool): (TestLifetime::T, TestLifetime::S) {
     $t12 := borrow_local(b)
     b_ref := $t12
     $t13 := copy(cond)
-    if ($t13) goto L0
-    goto L1
+    if ($t13) goto L0 else goto L1
+    L1:
+    goto L2
     L0:
     $t14 := move(b_ref)
     destroy($t14)
     $t15 := move(a_ref)
     $t16 := borrow_field<TestLifetime::T>.x($t15)
     $t5 := $t16
-    goto L2
-    L1:
+    goto L3
+    L2:
     $t17 := move(a_ref)
     destroy($t17)
     $t18 := move(b_ref)
     $t19 := borrow_field<TestLifetime::S>.y($t18)
     $t5 := $t19
-    L2:
+    L3:
     $t20 := move($t5)
     x_ref := $t20
     $t21 := copy(cond)
-    if ($t21) goto L3
-    goto L4
-    L3:
+    if ($t21) goto L4 else goto L5
+    L5:
+    goto L6
+    L4:
     $t22 := 2
     $t23 := move(x_ref)
-    $t23 := write_ref($t22)
-    goto L5
-    L4:
+    write_ref($t23, $t22)
+    goto L7
+    L6:
     $t24 := 0
     $t25 := move(x_ref)
-    $t25 := write_ref($t24)
-    L5:
+    write_ref($t25, $t24)
+    L7:
     $t26 := move(a)
     $t27 := move(b)
     return ($t26, $t27)
@@ -103,7 +105,7 @@ fun TestLifetime::lifetime_R(): TestLifetime::R {
     x_ref := $t7
     $t8 := 0
     $t9 := move(x_ref)
-    $t9 := write_ref($t8)
+    write_ref($t9, $t8)
     $t10 := borrow_local(r)
     r_ref := $t10
     $t11 := move(r_ref)
@@ -111,7 +113,7 @@ fun TestLifetime::lifetime_R(): TestLifetime::R {
     x_ref := $t12
     $t13 := 2
     $t14 := move(x_ref)
-    $t14 := write_ref($t13)
+    write_ref($t14, $t13)
     $t15 := move(r)
     return $t15
 }
@@ -146,10 +148,10 @@ fun TestLifetime::lifetime_R_2(): TestLifetime::R {
     x_ref := $t7
     $t8 := 0
     $t9 := copy(x_ref)
-    $t9 := write_ref($t8)
+    write_ref($t9, $t8)
     $t10 := 2
     $t11 := move(x_ref)
-    $t11 := write_ref($t10)
+    write_ref($t11, $t10)
     $t12 := borrow_local(r)
     r_ref := $t12
     $t13 := move(r_ref)
@@ -157,7 +159,7 @@ fun TestLifetime::lifetime_R_2(): TestLifetime::R {
     x_ref := $t14
     $t15 := 3
     $t16 := move(x_ref)
-    $t16 := write_ref($t15)
+    write_ref($t16, $t15)
     $t17 := move(r)
     return $t17
 }
@@ -203,8 +205,9 @@ fun TestLifetime::lifetime_(cond: bool): (TestLifetime::T, TestLifetime::S) {
     $t12 := borrow_local(b)
     b_ref := $t12
     $t13 := copy(cond)
-    if ($t13) goto L0
-    goto L1
+    if ($t13) goto L0 else goto L1
+    L1:
+    goto L2
     L0:
     $t14 := move(b_ref)
     // mut ends: $t14
@@ -212,32 +215,33 @@ fun TestLifetime::lifetime_(cond: bool): (TestLifetime::T, TestLifetime::S) {
     $t15 := move(a_ref)
     $t16 := borrow_field<TestLifetime::T>.x($t15)
     $t5 := $t16
-    goto L2
-    L1:
+    goto L3
+    L2:
     $t17 := move(a_ref)
     // mut ends: $t17
     destroy($t17)
     $t18 := move(b_ref)
     $t19 := borrow_field<TestLifetime::S>.y($t18)
     $t5 := $t19
-    L2:
+    L3:
     $t20 := move($t5)
     x_ref := $t20
     $t21 := copy(cond)
-    if ($t21) goto L3
-    goto L4
-    L3:
+    if ($t21) goto L4 else goto L5
+    L5:
+    goto L6
+    L4:
     $t22 := 2
     $t23 := move(x_ref)
     // mut ends: $t15, $t18, $t23
-    $t23 := write_ref($t22)
-    goto L5
-    L4:
+    write_ref($t23, $t22)
+    goto L7
+    L6:
     $t24 := 0
     $t25 := move(x_ref)
     // mut ends: $t15, $t18, $t25
-    $t25 := write_ref($t24)
-    L5:
+    write_ref($t25, $t24)
+    L7:
     $t26 := move(a)
     $t27 := move(b)
     return ($t26, $t27)
@@ -272,7 +276,7 @@ fun TestLifetime::lifetime_R(): TestLifetime::R {
     $t8 := 0
     $t9 := move(x_ref)
     // mut ends: $t6, $t9
-    $t9 := write_ref($t8)
+    write_ref($t9, $t8)
     $t10 := borrow_local(r)
     r_ref := $t10
     $t11 := move(r_ref)
@@ -281,7 +285,7 @@ fun TestLifetime::lifetime_R(): TestLifetime::R {
     $t13 := 2
     $t14 := move(x_ref)
     // mut ends: $t11, $t14
-    $t14 := write_ref($t13)
+    write_ref($t14, $t13)
     $t15 := move(r)
     return $t15
 }
@@ -316,11 +320,11 @@ fun TestLifetime::lifetime_R_2(): TestLifetime::R {
     x_ref := $t7
     $t8 := 0
     $t9 := copy(x_ref)
-    $t9 := write_ref($t8)
+    write_ref($t9, $t8)
     $t10 := 2
     $t11 := move(x_ref)
     // mut ends: $t6, $t11
-    $t11 := write_ref($t10)
+    write_ref($t11, $t10)
     $t12 := borrow_local(r)
     r_ref := $t12
     $t13 := move(r_ref)
@@ -329,7 +333,7 @@ fun TestLifetime::lifetime_R_2(): TestLifetime::R {
     $t15 := 3
     $t16 := move(x_ref)
     // mut ends: $t13, $t16
-    $t16 := write_ref($t15)
+    write_ref($t16, $t15)
     $t17 := move(r)
     return $t17
 }

--- a/language/move-prover/stackless-bytecode-generator/tests/livevar/basic_test.exp
+++ b/language/move-prover/stackless-bytecode-generator/tests/livevar/basic_test.exp
@@ -38,14 +38,15 @@ fun TestLiveVars::test2(b: bool): u64 {
     $t8 := borrow_local(r1)
     r_ref := $t8
     $t9 := copy(b)
-    if ($t9) goto L0
-    goto L1
+    if ($t9) goto L0 else goto L1
+    L1:
+    goto L2
     L0:
     $t10 := move(r_ref)
     destroy($t10)
     $t11 := borrow_local(r2)
     r_ref := $t11
-    L1:
+    L2:
     $t12 := move(r_ref)
     $t13 := TestLiveVars::test1($t12)
     return $t13
@@ -81,12 +82,13 @@ fun TestLiveVars::test3(n: u64, r_ref: &TestLiveVars::R): u64 {
     $t6 := 4
     $t7 := pack TestLiveVars::R($t6)
     r2 := $t7
-    L5:
+    L7:
     $t8 := 0
     $t9 := copy(n)
     $t10 := <($t8, $t9)
-    if ($t10) goto L0
-    goto L1
+    if ($t10) goto L0 else goto L1
+    L1:
+    goto L2
     L0:
     $t11 := move(r_ref)
     destroy($t11)
@@ -95,22 +97,23 @@ fun TestLiveVars::test3(n: u64, r_ref: &TestLiveVars::R): u64 {
     $t14 := /($t12, $t13)
     $t15 := 0
     $t16 := ==($t14, $t15)
-    if ($t16) goto L2
-    goto L3
-    L2:
+    if ($t16) goto L3 else goto L4
+    L4:
+    goto L5
+    L3:
     $t17 := borrow_local(r1)
     r_ref := $t17
-    goto L4
-    L3:
+    goto L6
+    L5:
     $t18 := borrow_local(r2)
     r_ref := $t18
-    L4:
+    L6:
     $t19 := copy(n)
     $t20 := 1
     $t21 := -($t19, $t20)
     n := $t21
-    goto L5
-    L1:
+    goto L7
+    L2:
     $t22 := move(r_ref)
     $t23 := TestLiveVars::test1($t22)
     return $t23
@@ -172,21 +175,23 @@ fun TestLiveVars::test2(b: bool): u64 {
     // live vars: b, r2, r_ref
     $t9 := copy(b)
     // live vars: r2, r_ref, $t9
-    if ($t9) goto L0
+    if ($t9) goto L0 else goto L1
     // live vars: r_ref
-    goto L1
-    // live vars: r2
+    L1:
+    // live vars: r_ref
+    goto L2
+    // live vars: r2, r_ref
     L0:
-    // live vars: r2
+    // live vars: r2, r_ref
     $t10 := move(r_ref)
-    // live vars: r2
+    // live vars: r2, $t10
     destroy($t10)
     // live vars: r2
     $t11 := borrow_local(r2)
     // live vars: $t11
     r_ref := $t11
     // live vars: r_ref
-    L1:
+    L2:
     // live vars: r_ref
     $t12 := move(r_ref)
     // live vars: $t12
@@ -232,7 +237,7 @@ fun TestLiveVars::test3(n: u64, r_ref: &TestLiveVars::R): u64 {
     // live vars: n, r_ref, r1, $t7
     r2 := $t7
     // live vars: n, r_ref, r1, r2
-    L5:
+    L7:
     // live vars: n, r_ref, r1, r2
     $t8 := 0
     // live vars: n, r_ref, r1, r2, $t8
@@ -240,14 +245,16 @@ fun TestLiveVars::test3(n: u64, r_ref: &TestLiveVars::R): u64 {
     // live vars: n, r_ref, r1, r2, $t8, $t9
     $t10 := <($t8, $t9)
     // live vars: n, r_ref, r1, r2, $t10
-    if ($t10) goto L0
+    if ($t10) goto L0 else goto L1
     // live vars: r_ref
-    goto L1
-    // live vars: n, r1, r2
+    L1:
+    // live vars: r_ref
+    goto L2
+    // live vars: n, r_ref, r1, r2
     L0:
-    // live vars: n, r1, r2
+    // live vars: n, r_ref, r1, r2
     $t11 := move(r_ref)
-    // live vars: n, r1, r2
+    // live vars: n, r1, r2, $t11
     destroy($t11)
     // live vars: n, r1, r2
     $t12 := copy(n)
@@ -260,25 +267,27 @@ fun TestLiveVars::test3(n: u64, r_ref: &TestLiveVars::R): u64 {
     // live vars: n, r1, r2, $t14, $t15
     $t16 := ==($t14, $t15)
     // live vars: n, r1, r2, $t16
-    if ($t16) goto L2
+    if ($t16) goto L3 else goto L4
     // live vars: n, r1, r2
-    goto L3
+    L4:
     // live vars: n, r1, r2
-    L2:
+    goto L5
+    // live vars: n, r1, r2
+    L3:
     // live vars: n, r1, r2
     $t17 := borrow_local(r1)
     // live vars: n, r1, r2, $t17
     r_ref := $t17
     // live vars: n, r_ref, r1, r2
-    goto L4
+    goto L6
     // live vars: n, r1, r2
-    L3:
+    L5:
     // live vars: n, r1, r2
     $t18 := borrow_local(r2)
     // live vars: n, r1, r2, $t18
     r_ref := $t18
     // live vars: n, r_ref, r1, r2
-    L4:
+    L6:
     // live vars: n, r_ref, r1, r2
     $t19 := copy(n)
     // live vars: r_ref, r1, r2, $t19
@@ -288,9 +297,9 @@ fun TestLiveVars::test3(n: u64, r_ref: &TestLiveVars::R): u64 {
     // live vars: r_ref, r1, r2, $t21
     n := $t21
     // live vars: n, r_ref, r1, r2
-    goto L5
+    goto L7
     // live vars: r_ref
-    L1:
+    L2:
     // live vars: r_ref
     $t22 := move(r_ref)
     // live vars: $t22


### PR DESCRIPTION
## Motivation

This PR makes three changes:
- Changes signature of WriteRef so that the reference being written is an input rather than output of the instruction. This change will simplify the new pack analysis in a downstream PR.
- Refactors the Branch bytecode into Jump and Branch with the latter explicitly supply both the then and the else labels.  This change continues the work started earlier by creating abstract labels for all jumps and branches.  The changes also simplifies code in various places.
- Changes the propagation rules in liveness analysis with greater attention to side effects of all bytecodes.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?

Yes.

## Test Plan

Existing tests

## Related PRs
