### PR TITLE
[move-prover] Fixing a bug with struct type parameters.

### DIFF
--- a/language/move-prover/src/bytecode_translator.rs
+++ b/language/move-prover/src/bytecode_translator.rs
@@ -197,6 +197,10 @@ impl<'env> ModuleTranslator<'env> {
             .enumerate()
             .map(|(i, _)| format!("$tv{}: TypeValue", i))
             .join(", ");
+        let mut type_args_for_ctor = String::from("EmptyTypeValueArray");
+        for i in 0..struct_env.get_type_parameters().len() {
+            type_args_for_ctor = format!("ExtendTypeValueArray({}, $tv{})", type_args_for_ctor, i);
+        }
         let mut field_types = String::from("EmptyTypeValueArray");
         for field_env in struct_env.get_fields() {
             field_types = format!(
@@ -205,7 +209,10 @@ impl<'env> ModuleTranslator<'env> {
                 boogie_type_value(self.module_env.env, &field_env.get_type())
             );
         }
-        let type_value = format!("StructType({}, {})", struct_name, field_types);
+        let type_value = format!(
+            "StructType({}, {}, {})",
+            struct_name, type_args_for_ctor, field_types
+        );
         if struct_name == "$LibraAccount_T" {
             // Special treatment of well-known resource LibraAccount_T. The type_value
             // function is forward-declared in the prelude, here we only add an axiom for it.

--- a/language/move-prover/src/prelude.bpl
+++ b/language/move-prover/src/prelude.bpl
@@ -60,7 +60,7 @@ function {:constructor} AddressType() : TypeValue;
 function {:constructor} ByteArrayType() : TypeValue;
 function {:constructor} StrType() : TypeValue;
 function {:constructor} VectorType(t: TypeValue) : TypeValue;
-function {:constructor} StructType(name: TypeName, ts: TypeValueArray) : TypeValue;
+function {:constructor} StructType(name: TypeName, ps: TypeValueArray, ts: TypeValueArray) : TypeValue;
 function {:constructor} ErrorType() : TypeValue;
 const DefaultTypeValue: TypeValue;
 axiom DefaultTypeValue == ErrorType();

--- a/language/move-prover/tests/sources/regression/type_param_bug_200228.exp
+++ b/language/move-prover/tests/sources/regression/type_param_bug_200228.exp
@@ -1,0 +1,46 @@
+Move prover returns: exiting with boogie verification errors
+error:  A postcondition might not hold on this return path.
+
+    ┌── tests/sources/regression/type_param_bug_200228.move:16:5 ───
+    │
+ 16 │     ensures old(exists<Balance<Tok_1>>(addr)) ==> old(exists<EventHandle<Tok_2>>(addr));
+    │     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    │
+    =     at tests/sources/regression/type_param_bug_200228.move:6:3: type_param_bug (entry)
+    =     at tests/sources/regression/type_param_bug_200228.move:7:5: type_param_bug
+    =         addr = <redacted>,
+    =         result = <redacted>
+    =     at tests/sources/regression/type_param_bug_200228.move:6:3: type_param_bug (exit)
+
+error:  A postcondition might not hold on this return path.
+
+    ┌── tests/sources/regression/type_param_bug_200228.move:15:5 ───
+    │
+ 15 │     ensures old(exists<Balance<Tok_1>>(addr)) ==> old(exists<Balance<Tok_2>>(addr));
+    │     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    │
+    =     at tests/sources/regression/type_param_bug_200228.move:6:3: type_param_bug (entry)
+    =     at tests/sources/regression/type_param_bug_200228.move:7:5: type_param_bug
+    =     at tests/sources/regression/type_param_bug_200228.move:6:3: type_param_bug (exit)
+
+error:  A postcondition might not hold on this return path.
+
+    ┌── tests/sources/regression/type_param_bug_200228.move:14:5 ───
+    │
+ 14 │     ensures old(exists<Balance<Tok_1>>(addr)) ==> old(exists<Tok_1>(addr));
+    │     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    │
+    =     at tests/sources/regression/type_param_bug_200228.move:6:3: type_param_bug (entry)
+    =     at tests/sources/regression/type_param_bug_200228.move:7:5: type_param_bug
+    =     at tests/sources/regression/type_param_bug_200228.move:6:3: type_param_bug (exit)
+
+error:  A postcondition might not hold on this return path.
+
+    ┌── tests/sources/regression/type_param_bug_200228.move:13:5 ───
+    │
+ 13 │     ensures old(exists<Balance<Tok_1>>(addr)) ==> old(exists<EventHandle<Tok_1>>(addr));
+    │     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    │
+    =     at tests/sources/regression/type_param_bug_200228.move:6:3: type_param_bug (entry)
+    =     at tests/sources/regression/type_param_bug_200228.move:7:5: type_param_bug
+    =     at tests/sources/regression/type_param_bug_200228.move:6:3: type_param_bug (exit)

--- a/language/move-prover/tests/sources/regression/type_param_bug_200228.move
+++ b/language/move-prover/tests/sources/regression/type_param_bug_200228.move
@@ -1,0 +1,18 @@
+module Test {
+
+  resource struct Balance<Token> {}
+  resource struct EventHandle<Token> {}
+
+  fun type_param_bug<Tok_1, Tok_2>(addr: address): address {
+    addr
+  }
+  spec fun type_param_bug {
+    pragma verify=true;
+    aborts_if false;
+    ensures old(exists<Balance<Tok_1>>(addr)) ==> old(exists<Balance<Tok_1>>(addr)); // correctly proved. trivially true.
+    ensures old(exists<Balance<Tok_1>>(addr)) ==> old(exists<EventHandle<Tok_1>>(addr)); // correctly disproved.
+    ensures old(exists<Balance<Tok_1>>(addr)) ==> old(exists<Tok_1>(addr)); // correctly disproved.
+    ensures old(exists<Balance<Tok_1>>(addr)) ==> old(exists<Balance<Tok_2>>(addr)); // original bug: proved by Prover, but should not be.
+    ensures old(exists<Balance<Tok_1>>(addr)) ==> old(exists<EventHandle<Tok_2>>(addr)); // correctly disproved.
+  }
+}

--- a/language/move-prover/tests/testsuite.rs
+++ b/language/move-prover/tests/testsuite.rs
@@ -65,7 +65,7 @@ fn get_flags(path: &Path) -> anyhow::Result<(Vec<String>, PathBuf)> {
     let path_str = path.to_string_lossy();
     let base_flags = if path_str.contains("/new_stdlib/") {
         NEW_STDLIB_FLAGS
-    } else if path_str.contains("/functional/") {
+    } else if path_str.contains("/functional/") || path_str.contains("/regression/") {
         FUNCTIONAL_FLAGS
     } else if path_str.contains("/stdlib/") {
         STDLIB_FLAGS


### PR DESCRIPTION
If a struct type parameter isn't used in any field, like in `resource struct T<X>{}`, it wasn't included in the associated boogie TypeValue. This PR includes all type parameters into the type value, regardeless of whether they are used or not.

## Motivation

Bug fix.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

Added regression test; also opened a new sub-directory for this kind of tests.

## Related PRs

NA
