### PR TITLE
[Generate format] index consensus types + cleanups

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1550,10 +1550,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 name = "generate-format"
 version = "0.1.0"
 dependencies = [
+ "consensus 0.1.0",
+ "consensus-types 0.1.0",
  "libra-canonical-serialization 0.1.0",
+ "libra-crypto 0.1.0",
  "libra-types 0.1.0",
  "libra-workspace-hack 0.1.0",
  "proptest 0.9.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand 0.7.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.106 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde-reflection 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_yaml 0.8.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "structopt 0.3.14 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/consensus/consensus-types/src/block.rs
+++ b/consensus/consensus-types/src/block.rs
@@ -264,6 +264,7 @@ impl<'de, T: DeserializeOwned + Serialize> Deserialize<'de> for Block<T> {
         D: Deserializer<'de>,
     {
         #[derive(Deserialize)]
+        #[serde(rename = "Block")]
         struct BlockWithoutId<T> {
             #[serde(bound(deserialize = "BlockData<T>: Deserialize<'de>"))]
             block_data: BlockData<T>,

--- a/testsuite/generate-format/Cargo.toml
+++ b/testsuite/generate-format/Cargo.toml
@@ -11,11 +11,16 @@ edition = "2018"
 
 [dependencies]
 proptest = "0.9.6"
+rand = "0.7.3"
+serde = { version = "1.0.106", features = ["derive"] }
 serde-reflection = "0.1.0"
 serde_yaml = "0.8"
 structopt = "0.3.14"
 
+consensus = { path = "../../consensus", version = "0.1.0", features=["fuzzing"] }
+consensus-types = { path = "../../consensus/consensus-types", version = "0.1.0", features=["fuzzing"] }
 lcs = { path = "../../common/lcs", version = "0.1.0", package = "libra-canonical-serialization" }
+libra-crypto = { path = "../../crypto/crypto", version = "0.1.0", features=["fuzzing"] }
 libra-types = { path = "../../types", version = "0.1.0", features=["fuzzing"] }
 libra-workspace-hack = { path = "../../common/workspace-hack", version = "0.1.0" }
 

--- a/testsuite/generate-format/src/compute.rs
+++ b/testsuite/generate-format/src/compute.rs
@@ -15,16 +15,13 @@ struct Options {
     corpus: Corpus,
 
     #[structopt(long)]
-    skip_deserialize: bool,
-
-    #[structopt(long)]
     record: bool,
 }
 
 fn main() {
     let options = Options::from_args();
 
-    let registry = options.corpus.get_registry(options.skip_deserialize);
+    let registry = options.corpus.get_registry();
     let output_file = options.corpus.output_file();
 
     let content = serde_yaml::to_string(&registry).unwrap();

--- a/testsuite/generate-format/src/consensus.rs
+++ b/testsuite/generate-format/src/consensus.rs
@@ -1,0 +1,56 @@
+// Copyright (c) The Libra Core Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+use libra_crypto::{
+    ed25519::{Ed25519PrivateKey, Ed25519PublicKey},
+    hash::{CryptoHasher, TestOnlyHasher},
+    traits::{SigningKey, Uniform},
+};
+use rand::{rngs::StdRng, SeedableRng};
+use serde::{Deserialize, Serialize};
+use serde_reflection::{Registry, Result, Samples, Tracer, TracerConfig};
+
+/// Return a relative path to start tracking changes in commits.
+pub fn output_file() -> Option<&'static str> {
+    Some("tests/staged/consensus.yaml")
+}
+
+/// Record sample values for crypto types used by consensus.
+fn trace_crypto_values(tracer: &mut Tracer, samples: &mut Samples) -> Result<()> {
+    let mut hasher = TestOnlyHasher::default();
+    hasher.write(b"Test message");
+    let hashed_message = hasher.finish();
+
+    let mut rng: StdRng = SeedableRng::from_seed([0; 32]);
+    let private_key = Ed25519PrivateKey::generate(&mut rng);
+    let public_key: Ed25519PublicKey = (&private_key).into();
+    let signature = private_key.sign_message(&hashed_message);
+
+    tracer.trace_value(samples, &public_key)?;
+    tracer.trace_value(samples, &signature)?;
+    Ok(())
+}
+
+/// Placeholder type.
+#[derive(Serialize, Deserialize, Eq, PartialEq, Debug, Default, Clone)]
+struct Payload;
+
+/// Create a registry for consensus types.
+pub fn get_registry() -> Result<Registry> {
+    let mut tracer =
+        Tracer::new(TracerConfig::default().is_human_readable(lcs::is_human_readable()));
+    let mut samples = Samples::new();
+    // 1. Record samples for types with custom deserializers.
+    trace_crypto_values(&mut tracer, &mut samples)?;
+    tracer.trace_value(
+        &mut samples,
+        &consensus_types::block::Block::<Payload>::make_genesis_block(),
+    )?;
+
+    // 2. Trace the main entry point(s) + every enum separately.
+    tracer.trace_type::<consensus::network_interface::ConsensusMsg<Payload>>(&samples)?;
+    tracer.trace_type::<consensus_types::block_data::BlockType<Payload>>(&samples)?;
+    tracer.trace_type::<consensus_types::block_retrieval::BlockRetrievalStatus>(&samples)?;
+
+    tracer.registry()
+}

--- a/testsuite/generate-format/src/lib.rs
+++ b/testsuite/generate-format/src/lib.rs
@@ -32,9 +32,9 @@ impl Corpus {
     }
 
     /// Compute the registry of formats.
-    pub fn get_registry(self, skip_deserialize: bool) -> Registry {
+    pub fn get_registry(self) -> Registry {
         match self {
-            Corpus::Libra => libra::get_registry(self.to_string(), skip_deserialize),
+            Corpus::Libra => libra::get_registry().unwrap(),
             Corpus::Consensus => consensus::get_registry().unwrap(),
         }
     }

--- a/testsuite/generate-format/src/lib.rs
+++ b/testsuite/generate-format/src/lib.rs
@@ -8,6 +8,8 @@ use serde_reflection::Registry;
 use std::str::FromStr;
 use structopt::{clap::arg_enum, StructOpt};
 
+/// consensus types.
+mod consensus;
 /// Libra transactions.
 mod libra;
 
@@ -16,6 +18,7 @@ arg_enum! {
 /// A corpus of Rust types to trace, and optionally record on disk.
 pub enum Corpus {
     Libra,
+    Consensus,
 }
 }
 
@@ -32,6 +35,7 @@ impl Corpus {
     pub fn get_registry(self, skip_deserialize: bool) -> Registry {
         match self {
             Corpus::Libra => libra::get_registry(self.to_string(), skip_deserialize),
+            Corpus::Consensus => consensus::get_registry().unwrap(),
         }
     }
 
@@ -39,6 +43,7 @@ impl Corpus {
     pub fn output_file(self) -> Option<&'static str> {
         match self {
             Corpus::Libra => libra::output_file(),
+            Corpus::Consensus => consensus::output_file(),
         }
     }
 }

--- a/testsuite/generate-format/src/libra.rs
+++ b/testsuite/generate-format/src/libra.rs
@@ -1,73 +1,55 @@
 // Copyright (c) The Libra Core Contributors
 // SPDX-License-Identifier: Apache-2.0
 
-use libra_types::{contract_event, transaction};
-use proptest::{
-    prelude::*,
-    test_runner::{Config, FileFailurePersistence, TestRunner},
+use libra_crypto::{
+    ed25519::{Ed25519PrivateKey, Ed25519PublicKey},
+    hash::{CryptoHasher, TestOnlyHasher},
+    multi_ed25519::{MultiEd25519PublicKey, MultiEd25519Signature},
+    traits::{SigningKey, Uniform},
 };
+use libra_types::{contract_event, event, language_storage, transaction, write_set};
+use rand::{rngs::StdRng, SeedableRng};
 use serde_reflection::{Registry, Result, Samples, Tracer, TracerConfig};
-use std::sync::{Arc, Mutex};
 
 /// Default output file.
 pub fn output_file() -> Option<&'static str> {
     Some("tests/staged/libra.yaml")
 }
 
-pub fn get_registry() -> Result<Registry> {
-    let (mut tracer, samples) = proptest_serialization_tracing()?;
-    deserialization_tracing(&mut tracer, &samples)?;
-    tracer.registry()
-}
+/// Record sample values for crypto types used by transactions.
+fn trace_crypto_values(tracer: &mut Tracer, samples: &mut Samples) -> Result<()> {
+    let mut hasher = TestOnlyHasher::default();
+    hasher.write(b"Test message");
+    let hashed_message = hasher.finish();
 
-/// Which Libra values to record with the serialization tracing API.
-///
-/// This step is useful to inject well-formed values that must pass
-/// custom-validation checks (e.g. keys).
-fn proptest_serialization_tracing() -> Result<(Tracer, Samples)> {
-    let mut runner = TestRunner::new(Config {
-        failure_persistence: Some(Box::new(FileFailurePersistence::Off)),
-        ..Config::default()
-    });
+    let mut rng: StdRng = SeedableRng::from_seed([0; 32]);
+    let private_key = Ed25519PrivateKey::generate(&mut rng);
+    let public_key: Ed25519PublicKey = (&private_key).into();
+    let signature = private_key.sign_message(&hashed_message);
 
-    let tracer = Arc::new(Mutex::new(Tracer::new(
-        TracerConfig::default().is_human_readable(lcs::is_human_readable()),
-    )));
-    let samples = Arc::new(Mutex::new(Samples::new()));
-
-    runner
-        .run(&any::<transaction::Transaction>(), |v| {
-            tracer
-                .lock()
-                .unwrap()
-                .trace_value(&mut samples.lock().unwrap(), &v)?;
-            Ok(())
-        })
-        .unwrap();
-
-    runner
-        .run(&any::<contract_event::ContractEvent>(), |v| {
-            tracer
-                .lock()
-                .unwrap()
-                .trace_value(&mut samples.lock().unwrap(), &v)?;
-            Ok(())
-        })
-        .unwrap();
-
-    // Recover the Arc-mutex-ed tracer.
-    Ok((
-        Arc::try_unwrap(tracer).unwrap().into_inner().unwrap(),
-        Arc::try_unwrap(samples).unwrap().into_inner().unwrap(),
-    ))
-}
-
-/// Which Libra types to record with the deserialization tracing API.
-///
-/// This step is useful to guarantee coverage of the analysis but it may
-/// fail if the previous step missed some custom types.
-fn deserialization_tracing(tracer: &mut Tracer, samples: &Samples) -> Result<()> {
-    tracer.trace_type::<transaction::Transaction>(&samples)?;
-    tracer.trace_type::<contract_event::ContractEvent>(&samples)?;
+    tracer.trace_value(samples, &hashed_message)?;
+    tracer.trace_value(samples, &public_key)?;
+    tracer.trace_value::<MultiEd25519PublicKey>(samples, &public_key.into())?;
+    tracer.trace_value(samples, &signature)?;
+    tracer.trace_value::<MultiEd25519Signature>(samples, &signature.into())?;
     Ok(())
+}
+
+pub fn get_registry() -> Result<Registry> {
+    let mut tracer =
+        Tracer::new(TracerConfig::default().is_human_readable(lcs::is_human_readable()));
+    let mut samples = Samples::new();
+    // 1. Record samples for types with custom deserializers.
+    trace_crypto_values(&mut tracer, &mut samples)?;
+    tracer.trace_value(&mut samples, &event::EventKey::random())?;
+
+    // 2. Trace the main entry point(s) + every enum separately.
+    tracer.trace_type::<contract_event::ContractEvent>(&samples)?;
+    tracer.trace_type::<language_storage::TypeTag>(&samples)?;
+    tracer.trace_type::<transaction::Transaction>(&samples)?;
+    tracer.trace_type::<transaction::TransactionArgument>(&samples)?;
+    tracer.trace_type::<transaction::TransactionPayload>(&samples)?;
+    tracer.trace_type::<transaction::authenticator::TransactionAuthenticator>(&samples)?;
+    tracer.trace_type::<write_set::WriteOp>(&samples)?;
+    tracer.registry()
 }

--- a/testsuite/generate-format/tests/detect_format_change.rs
+++ b/testsuite/generate-format/tests/detect_format_change.rs
@@ -8,7 +8,7 @@ use serde_reflection::RegistryOwned;
 fn test_that_recorded_formats_did_not_change() {
     for corpus in Corpus::values() {
         let registry: RegistryOwned = corpus
-            .get_registry(/* skip_deserialization */ false)
+            .get_registry()
             .into_iter()
             .map(|(k, v)| (k.to_string(), v))
             .collect();

--- a/testsuite/generate-format/tests/staged/consensus.yaml
+++ b/testsuite/generate-format/tests/staged/consensus.yaml
@@ -1,0 +1,217 @@
+---
+AccountAddress:
+  NEWTYPESTRUCT:
+    TUPLEARRAY:
+      CONTENT: U8
+      SIZE: 16
+Block:
+  STRUCT:
+    - block_data:
+        TYPENAME: BlockData
+    - signature:
+        OPTION:
+          TYPENAME: Ed25519Signature
+BlockData:
+  STRUCT:
+    - epoch: U64
+    - round: U64
+    - timestamp_usecs: U64
+    - quorum_cert:
+        TYPENAME: QuorumCert
+    - block_type:
+        TYPENAME: BlockType
+BlockInfo:
+  STRUCT:
+    - epoch: U64
+    - round: U64
+    - id:
+        TYPENAME: HashValue
+    - executed_state_id:
+        TYPENAME: HashValue
+    - version: U64
+    - timestamp_usecs: U64
+    - next_epoch_info:
+        OPTION:
+          TYPENAME: EpochInfo
+BlockRetrievalRequest:
+  STRUCT:
+    - block_id:
+        TYPENAME: HashValue
+    - num_blocks: U64
+BlockRetrievalResponse:
+  STRUCT:
+    - status:
+        TYPENAME: BlockRetrievalStatus
+    - blocks:
+        SEQ:
+          TYPENAME: Block
+BlockRetrievalStatus:
+  ENUM:
+    0:
+      Succeeded: UNIT
+    1:
+      IdNotFound: UNIT
+    2:
+      NotEnoughBlocks: UNIT
+BlockType:
+  ENUM:
+    0:
+      Proposal:
+        STRUCT:
+          - payload:
+              TYPENAME: Payload
+          - author:
+              TYPENAME: AccountAddress
+    1:
+      NilBlock: UNIT
+    2:
+      Genesis: UNIT
+ConsensusMsg:
+  ENUM:
+    0:
+      BlockRetrievalRequest:
+        NEWTYPE:
+          TYPENAME: BlockRetrievalRequest
+    1:
+      BlockRetrievalResponse:
+        NEWTYPE:
+          TYPENAME: BlockRetrievalResponse
+    2:
+      EpochRetrievalRequest:
+        NEWTYPE:
+          TYPENAME: EpochRetrievalRequest
+    3:
+      ProposalMsg:
+        NEWTYPE:
+          TYPENAME: ProposalMsg
+    4:
+      SyncInfo:
+        NEWTYPE:
+          TYPENAME: SyncInfo
+    5:
+      EpochChangeProof:
+        NEWTYPE:
+          TYPENAME: EpochChangeProof
+    6:
+      VoteMsg:
+        NEWTYPE:
+          TYPENAME: VoteMsg
+Ed25519PublicKey:
+  NEWTYPESTRUCT: BYTES
+Ed25519Signature:
+  NEWTYPESTRUCT: BYTES
+EpochChangeProof:
+  STRUCT:
+    - ledger_info_with_sigs:
+        SEQ:
+          TYPENAME: LedgerInfoWithSignatures
+    - more: BOOL
+EpochInfo:
+  STRUCT:
+    - epoch: U64
+    - verifier:
+        TYPENAME: ValidatorVerifier
+EpochRetrievalRequest:
+  STRUCT:
+    - start_epoch: U64
+    - end_epoch: U64
+HashValue:
+  NEWTYPESTRUCT: BYTES
+LedgerInfo:
+  STRUCT:
+    - commit_info:
+        TYPENAME: BlockInfo
+    - consensus_data_hash:
+        TYPENAME: HashValue
+LedgerInfoWithSignatures:
+  ENUM:
+    0:
+      V0:
+        NEWTYPE:
+          TYPENAME: LedgerInfoWithV0
+LedgerInfoWithV0:
+  STRUCT:
+    - ledger_info:
+        TYPENAME: LedgerInfo
+    - signatures:
+        MAP:
+          KEY:
+            TYPENAME: AccountAddress
+          VALUE:
+            TYPENAME: Ed25519Signature
+Payload: UNITSTRUCT
+ProposalMsg:
+  STRUCT:
+    - proposal:
+        TYPENAME: Block
+    - sync_info:
+        TYPENAME: SyncInfo
+QuorumCert:
+  STRUCT:
+    - vote_data:
+        TYPENAME: VoteData
+    - signed_ledger_info:
+        TYPENAME: LedgerInfoWithSignatures
+SyncInfo:
+  STRUCT:
+    - highest_quorum_cert:
+        TYPENAME: QuorumCert
+    - highest_commit_cert:
+        TYPENAME: QuorumCert
+    - highest_timeout_cert:
+        OPTION:
+          TYPENAME: TimeoutCertificate
+Timeout:
+  STRUCT:
+    - epoch: U64
+    - round: U64
+TimeoutCertificate:
+  STRUCT:
+    - timeout:
+        TYPENAME: Timeout
+    - signatures:
+        MAP:
+          KEY:
+            TYPENAME: AccountAddress
+          VALUE:
+            TYPENAME: Ed25519Signature
+ValidatorConsensusInfo:
+  STRUCT:
+    - public_key:
+        TYPENAME: Ed25519PublicKey
+    - voting_power: U64
+ValidatorVerifier:
+  STRUCT:
+    - address_to_validator_info:
+        MAP:
+          KEY:
+            TYPENAME: AccountAddress
+          VALUE:
+            TYPENAME: ValidatorConsensusInfo
+    - quorum_voting_power: U64
+    - total_voting_power: U64
+Vote:
+  STRUCT:
+    - vote_data:
+        TYPENAME: VoteData
+    - author:
+        TYPENAME: AccountAddress
+    - ledger_info:
+        TYPENAME: LedgerInfo
+    - signature:
+        TYPENAME: Ed25519Signature
+    - timeout_signature:
+        OPTION:
+          TYPENAME: Ed25519Signature
+VoteData:
+  STRUCT:
+    - proposed:
+        TYPENAME: BlockInfo
+    - parent:
+        TYPENAME: BlockInfo
+VoteMsg:
+  STRUCT:
+    - vote:
+        TYPENAME: Vote
+    - sync_info:
+        TYPENAME: SyncInfo


### PR DESCRIPTION
## Motivation

* As discussed with @aching, this PR adds a file `consensus.yaml` in the repo to track consensus types. We wish to use this eventually to verify that Rust quotes in future documentation matches the serialization formats.

* I took this opportunity to clean up the code that generates `libra.yaml` in the following commits.

## Test Plan

```
cargo run -p generate-format -- --corpus consensus
cargo x test -p generate-format
```