### PR TITLE
[CI] use lowest resource on non-critical path jobs

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,7 +4,7 @@ executors:
   build-executor:
     docker:
       - image: circleci/rust:buster
-    resource_class: 2xlarge+
+    resource_class: 2xlarge
   test-executor:
     docker:
       - image: circleci/rust:buster
@@ -12,7 +12,7 @@ executors:
   audit-executor:
     docker:
       - image: circleci/rust:buster
-    resource_class: xlarge
+    resource_class: medium
   terraform-executor:
     docker:
       - image: hashicorp/terraform
@@ -161,7 +161,7 @@ commands:
 
 jobs:
   prefetch-crates:
-    executor: test-executor
+    executor: audit-executor
     description: Prefetch cargo crates for subsequent jobs.
     steps:
       - build_setup
@@ -219,17 +219,17 @@ jobs:
           command: RUST_BACKTRACE=1 cargo build -j 16 -p test-generation
       - build_teardown
   build-release:
-    executor: build-executor
+    executor: test-executor
     description: Release Build
     steps:
       - build_setup
       - restore_cargo_package_cache
       - run:
           name: Build release
-          command: RUST_BACKTRACE=1 cargo build -j 16 --release
+          command: RUST_BACKTRACE=1 cargo build -j 8 --release
       - build_teardown
   build-e2e-test:
-    executor: build-executor
+    executor: test-executor
     description: Generate a list of E2E test targets to be distributed.
     steps:
       - build_setup
@@ -248,7 +248,7 @@ jobs:
             - e2e_tests
             - target/debug/deps/libratest*
   run-e2e-test:
-    executor: build-executor
+    executor: test-executor
     parallelism: 8
     description: Run E2E tests in parallel. Each container runs a subset of
       test targets.
@@ -322,7 +322,7 @@ jobs:
           command: |
             RUST_BACKTRACE=1 $CI_TIMEOUT cargo x test --unit
   run-crypto-unit-test:
-    executor: test-executor
+    executor: audit-executor
     description: Run crypto unit tests without formally verified crypto, to insulate against a curve25519 "default" backend regression
     steps:
       - build_setup
@@ -347,7 +347,7 @@ jobs:
             ./scripts/run_quarantined.sh -c <your package here> -r 3 -f
   validate-cluster-test-dockerfile:
     description: Validate that committed docker files for cluster test are up to date
-    executor: build-executor
+    executor: audit-executor
     steps:
       - build_setup
       - run:
@@ -359,6 +359,7 @@ jobs:
     executor: audit-executor
     steps:
       - build_setup
+      - restore_cargo_package_cache
       - run:
           name: Install Cargo Audit
           command: |
@@ -375,7 +376,7 @@ jobs:
       - build_teardown
   code-coverage:
     description: Run code coverage
-    executor: build-executor
+    executor: test-executor
     steps:
       - build_setup
       - install_code_coverage_deps


### PR DESCRIPTION
## Motivation
During audit of CI resource allocation, it is found that almost all build and test jobs are using the largest resource class, 2xlarge+. While we may need the largest one for the critical path job, it seems wasteful for the jobs off the critical path.  This is particularly painful to digest when are billed by the minutes on these resource tiers that we don't really need. 

Take the most recent CI build from the auto branch (a5263e3)
https://circleci.com/workflow-run/5eecb7c3-6da5-4a8b-aca0-963a74e257ff
<img width="1598" alt="image" src="https://user-images.githubusercontent.com/7528420/80781888-eb3fc880-8b28-11ea-8748-92d1b3bb6489.png">

The unit test job is the critical path. The other jobs can run a little slower on lower tiers. Although we brute force the unit test job to run faster, it should be be parallelized in the future and have its resource tiers shrunk. 

This commit tries to reduce the waste. Below is the comparison of the original (above) vs the PR's test result (https://circleci.com/workflow-run/80f005d0-86f5-43bb-a622-1a84544045a1)
<img width="1599" alt="image" src="https://user-images.githubusercontent.com/7528420/80783138-8cc91900-8b2d-11ea-80a2-ccaa60b8f759.png">

```
|                       |         Before        |         After         |
| Job Name              | Tier      | Exec time | Tier      | Exec time |
|-----------------------------------------------------------------------|
| prefetch-crates       | xlarge    | ~  0:45   | medium    | ~  1:00   |
| build-dev             | 2xlarge+  | ~  7:00   | 2xlarge   | ~  7:30   |
| build-release         | 2xlarge+  | ~  6:15   | xlarge    | ~ 11:30   |
| build-e2e-test        | 2xlarge+  | ~  3:30   | xlarge    | ~  3:30   |
| run-e2e-test          | 2xlarge+  | ~  5:45   | xlarge    | ~  6:45   |
| run-unit-test         | 2xlarge+  | ~ 13:15   | 2xlarge   | ~ 13:30   |
| run-crypto-unit-test  | xlarge    | ~  1:30   | medium    | ~  1:45   |
| validate-cluster-test | 2xlarge+  | ~  0:30   | medium    | ~  0:45   |
|-----------------------------------------------------------------------|
  Total workflow time   |             ~ 14:00   |             ~ 14:30   |
```

Unfortunately, the billing model is opaque to us.  We won't find out the full effect until next month's bill is out.

## Test Plan
CI