### PR TITLE
[move-prover] Refactor Abort

### DIFF
--- a/language/move-prover/src/bytecode_translator.rs
+++ b/language/move-prover/src/bytecode_translator.rs
@@ -1616,23 +1616,23 @@ impl<'env> ModuleTranslator<'env> {
                             bytecode
                         );
                     }
-                    Abort => {
-                        // Below we introduce a dummy `if` for $DebugTrackAbort to ensure boogie creates
-                        // a execution trace entry for this statement.
-                        emitln!(
-                            self.writer,
-                            "if (true) {{ assume $DebugTrackAbort({}, {}); }}",
-                            func_target
-                                .func_env
-                                .module_env
-                                .env
-                                .file_id_to_idx(loc.file_id()),
-                            loc.span().start(),
-                        );
-                        emitln!(self.writer, "goto Abort;")
-                    }
                     Destroy => {}
                 }
+            }
+            Abort(..) => {
+                // Below we introduce a dummy `if` for $DebugTrackAbort to ensure boogie creates
+                // a execution trace entry for this statement.
+                emitln!(
+                    self.writer,
+                    "if (true) {{ assume $DebugTrackAbort({}, {}); }}",
+                    func_target
+                        .func_env
+                        .module_env
+                        .env
+                        .file_id_to_idx(loc.file_id()),
+                    loc.span().start(),
+                );
+                emitln!(self.writer, "goto Abort;")
             }
             Nop(..) => {}
         }

--- a/language/move-prover/stackless-bytecode-generator/src/stackless_bytecode_generator.rs
+++ b/language/move-prover/stackless-bytecode-generator/src/stackless_bytecode_generator.rs
@@ -183,8 +183,7 @@ impl<'a> StacklessBytecodeGenerator<'a> {
 
             MoveBytecode::Abort => {
                 let error_code_index = self.temp_stack.pop().unwrap();
-                self.code
-                    .push(mk_call(Operation::Abort, vec![], vec![error_code_index]));
+                self.code.push(Bytecode::Abort(attr_id, error_code_index));
             }
 
             MoveBytecode::StLoc(idx) => {


### PR DESCRIPTION

## Motivation

This PR moves Abort from an Operation into a top-level Bytecode.  This change allows an Abort to end a basic block.  Since such a basic block will have no outgoing edges, any propagation in dataflow analysis is naturally and easily avoided.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?

Yes.

## Test Plan

Existing tests

## Related PRs

