### PR TITLE
[move-prover] Implements schema expressions.

### DIFF
--- a/language/move-lang/src/expansion/ast.rs
+++ b/language/move-lang/src/expansion/ast.rs
@@ -130,14 +130,10 @@ pub enum SpecBlockMember_ {
         type_: Type,
     },
     Include {
-        name: ModuleAccess,
-        type_arguments: Option<Vec<Type>>,
-        arguments: Vec<(Name, Exp)>,
+        exp: Exp,
     },
     Apply {
-        name: ModuleAccess,
-        type_arguments: Option<Vec<Type>>,
-        arguments: Vec<(Name, Exp)>,
+        exp: Exp,
         patterns: Vec<SpecApplyPattern>,
         exclusion_patterns: Vec<SpecApplyPattern>,
     },
@@ -472,51 +468,17 @@ impl AstDebug for SpecBlockMember_ {
                 w.write(": ");
                 type_.ast_debug(w);
             }
-            SpecBlockMember_::Include {
-                name,
-                type_arguments,
-                arguments,
-            } => {
-                w.write(&format!("include {}", name));
-                if let Some(ty_args) = type_arguments {
-                    w.write("<");
-                    ty_args.ast_debug(w);
-                    w.write(">");
-                }
-                if !arguments.is_empty() {
-                    w.write("{");
-                    w.list(arguments, ", ", |w, (l, r)| {
-                        w.write(&l.value);
-                        w.write(" : ");
-                        r.ast_debug(w);
-                        true
-                    });
-                    w.write("}");
-                }
+            SpecBlockMember_::Include { exp } => {
+                w.write("include ");
+                exp.ast_debug(w);
             }
             SpecBlockMember_::Apply {
-                name,
-                type_arguments,
-                arguments,
+                exp,
                 patterns,
                 exclusion_patterns,
             } => {
-                w.write(&format!("apply {}", name));
-                if let Some(ty_args) = type_arguments {
-                    w.write("<");
-                    ty_args.ast_debug(w);
-                    w.write(">");
-                }
-                if !arguments.is_empty() {
-                    w.write("{");
-                    w.list(arguments, ", ", |w, (l, r)| {
-                        w.write(&l.value);
-                        w.write(" : ");
-                        r.ast_debug(w);
-                        true
-                    });
-                    w.write("}");
-                }
+                w.write("apply ");
+                exp.ast_debug(w);
                 w.write(" to ");
                 w.list(patterns, ", ", |w, p| {
                     p.ast_debug(w);

--- a/language/move-lang/src/expansion/translate.rs
+++ b/language/move-lang/src/expansion/translate.rs
@@ -633,44 +633,18 @@ fn spec_member(
                 type_: t,
             }
         }
-        PM::Include {
-            name: pn,
-            type_arguments: ptys_opt,
-            arguments: parguments,
-        } => {
-            let name = module_access(context, pn)?;
-            let type_arguments = optional_types(context, ptys_opt);
-            let arguments = parguments
-                .into_iter()
-                .map(|(n, e)| (n, *exp(context, e)))
-                .collect();
-            EM::Include {
-                name,
-                type_arguments,
-                arguments,
-            }
-        }
+        PM::Include { exp: pexp } => EM::Include {
+            exp: exp_(context, pexp),
+        },
         PM::Apply {
-            name: pn,
-            type_arguments: ptys_opt,
-            arguments: parguments,
+            exp: pexp,
             patterns,
             exclusion_patterns,
-        } => {
-            let name = module_access(context, pn)?;
-            let type_arguments = optional_types(context, ptys_opt);
-            let arguments = parguments
-                .into_iter()
-                .map(|(n, e)| (n, exp_(context, e)))
-                .collect();
-            EM::Apply {
-                name,
-                type_arguments,
-                arguments,
-                patterns,
-                exclusion_patterns,
-            }
-        }
+        } => EM::Apply {
+            exp: exp_(context, pexp),
+            patterns,
+            exclusion_patterns,
+        },
         PM::Pragma { properties } => EM::Pragma { properties },
     };
     Some(sp(loc, em))

--- a/language/move-lang/src/parser/ast.rs
+++ b/language/move-lang/src/parser/ast.rs
@@ -232,15 +232,11 @@ pub enum SpecBlockMember_ {
         type_: Type,
     },
     Include {
-        name: ModuleAccess,
-        type_arguments: Option<Vec<Type>>,
-        arguments: Vec<(Name, Exp)>,
+        exp: Exp,
     },
     Apply {
-        name: ModuleAccess,
-        type_arguments: Option<Vec<Type>>,
+        exp: Exp,
         patterns: Vec<SpecApplyPattern>,
-        arguments: Vec<(Name, Exp)>,
         exclusion_patterns: Vec<SpecApplyPattern>,
     },
     Pragma {
@@ -921,53 +917,17 @@ impl AstDebug for SpecBlockMember_ {
                 w.write(": ");
                 type_.ast_debug(w);
             }
-            SpecBlockMember_::Include {
-                name,
-                type_arguments,
-                arguments,
-            } => {
+            SpecBlockMember_::Include { exp } => {
                 w.write("include ");
-                name.ast_debug(w);
-                if let Some(ty_args) = type_arguments {
-                    w.write("<");
-                    ty_args.ast_debug(w);
-                    w.write(">");
-                }
-                if !arguments.is_empty() {
-                    w.write("{");
-                    w.list(arguments, ", ", |w, (l, r)| {
-                        w.write(&l.value);
-                        w.write(" : ");
-                        r.ast_debug(w);
-                        true
-                    });
-                    w.write("}");
-                }
+                exp.ast_debug(w);
             }
             SpecBlockMember_::Apply {
-                name,
-                type_arguments,
-                arguments,
+                exp,
                 patterns,
                 exclusion_patterns,
             } => {
                 w.write("apply ");
-                name.ast_debug(w);
-                if let Some(ty_args) = type_arguments {
-                    w.write("<");
-                    ty_args.ast_debug(w);
-                    w.write(">");
-                }
-                if !arguments.is_empty() {
-                    w.write("{");
-                    w.list(arguments, ", ", |w, (l, r)| {
-                        w.write(&l.value);
-                        w.write(" : ");
-                        r.ast_debug(w);
-                        true
-                    });
-                    w.write("}");
-                }
+                exp.ast_debug(w);
                 w.write(" to ");
                 w.list(patterns, ", ", |w, p| {
                     p.ast_debug(w);

--- a/language/move-prover/spec-lang/src/ast.rs
+++ b/language/move-prover/spec-lang/src/ast.rs
@@ -45,7 +45,7 @@ pub struct SpecFunDecl {
 // =================================================================================================
 /// # Conditions
 
-#[derive(Debug, PartialEq, Eq, Clone, PartialOrd, Ord)]
+#[derive(Debug, PartialEq, Clone)]
 pub enum ConditionKind {
     Assert,
     Assume,
@@ -79,7 +79,7 @@ impl ConditionKind {
         matches!(self, Ensures | AbortsIf | InvariantUpdate | VarUpdate(..))
     }
 
-    /// Returns true if this condition is allowed on a function declaration.
+    /// Returns true if this condition is allowed on a public function declaration.
     pub fn allowed_on_public_fun_decl(&self) -> bool {
         use ConditionKind::*;
         matches!(
@@ -192,7 +192,7 @@ impl Spec {
 // =================================================================================================
 /// # Expressions
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq)]
 pub enum Exp {
     Error(NodeId),
     Value(NodeId, Value),
@@ -302,7 +302,7 @@ pub enum Operation {
     MaxU128,
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq)]
 pub struct LocalVarDecl {
     pub id: NodeId,
     pub name: Symbol,

--- a/language/move-prover/spec-lang/tests/sources/conditions_err.exp
+++ b/language/move-prover/spec-lang/tests/sources/conditions_err.exp
@@ -1,4 +1,4 @@
-error: expected `bool` but found `u64`
+error: expected `bool` but found `u64` in name expression
 
    ┌── tests/sources/conditions_err.move:7:15 ───
    │
@@ -6,7 +6,7 @@ error: expected `bool` but found `u64`
    │               ^
    │
 
-error: expected `bool` but found `num`
+error: expected `bool` but found `num` in expression
 
    ┌── tests/sources/conditions_err.move:8:13 ───
    │

--- a/language/move-prover/spec-lang/tests/sources/expressions_err.exp
+++ b/language/move-prover/spec-lang/tests/sources/expressions_err.exp
@@ -14,7 +14,7 @@ error: no function named `not_declared` found
     │       ^^^^^^^^^^^^^^
     │
 
-error: expected `num` but found `bool`
+error: expected `num` but found `bool` in expression
 
     ┌── tests/sources/expressions_err.move:22:7 ───
     │
@@ -31,7 +31,7 @@ error: no matching declaration of `>`
     │
     = outruled candidate `>(num, num): bool` (expected `num` but found `vector<num>` for argument 1)
 
-error: expected `(num, bool)` but found `bool`
+error: expected `(num, bool)` but found `bool` in expression
 
     ┌── tests/sources/expressions_err.move:32:7 ───
     │

--- a/language/move-prover/spec-lang/tests/sources/invariants_err.exp
+++ b/language/move-prover/spec-lang/tests/sources/invariants_err.exp
@@ -1,4 +1,4 @@
-error: expected `bool` but found `num`
+error: expected `bool` but found `num` in expression
 
    ┌── tests/sources/invariants_err.move:9:15 ───
    │

--- a/language/move-prover/spec-lang/tests/sources/schemas_err.exp
+++ b/language/move-prover/spec-lang/tests/sources/schemas_err.exp
@@ -8,18 +8,18 @@ error: undeclared `M::x`
 
 error: schema `M::Undeclared` undeclared
 
-   ┌── tests/sources/schemas_err.move:8:9 ───
+   ┌── tests/sources/schemas_err.move:8:17 ───
    │
  8 │         include Undeclared;
-   │         ^^^^^^^^^^^^^^^^^^^
+   │                 ^^^^^^^^^^
    │
 
 error: wrong number of type arguments (expected 1, got 2)
 
-    ┌── tests/sources/schemas_err.move:12:9 ───
+    ┌── tests/sources/schemas_err.move:12:17 ───
     │
  12 │         include WrongTypeArgsIncluded<num, num>;
-    │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    │                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
     │
 
 error: `wrong` not declared in schema
@@ -30,7 +30,7 @@ error: `wrong` not declared in schema
     │                                            ^^^^^
     │
 
-error: expected `num` but found `bool`
+error: expected `num` but found `bool` in name expression
 
     ┌── tests/sources/schemas_err.move:24:47 ───
     │
@@ -38,7 +38,7 @@ error: expected `num` but found `bool`
     │                                               ^
     │
 
-error: expected `bool` but found `num`
+error: expected `bool` but found `num` in expression
 
     ┌── tests/sources/schemas_err.move:28:48 ───
     │
@@ -46,36 +46,60 @@ error: expected `bool` but found `num`
     │                                                ^^^^^
     │
 
-error: incompatible type of included `x`; type in schema: `num`, type in inclusion context: `bool`
+error: expected `bool` but found `num` for `x` included from schema
 
-    ┌── tests/sources/schemas_err.move:33:9 ───
+    ┌── tests/sources/schemas_err.move:33:17 ───
     │
  33 │         include WronglyTypedVarIncluded;
-    │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    │                 ^^^^^^^^^^^^^^^^^^^^^^^
     │
 
-error: incompatible type of included `x`; type in schema: `num`, type in inclusion context: `bool`
+error: expected `bool` but found `num` for `x` included from schema
 
-    ┌── tests/sources/schemas_err.move:41:9 ───
+    ┌── tests/sources/schemas_err.move:41:17 ───
     │
  41 │         include WronglyTypedInstantiationIncluded<num>;
-    │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    │                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
     │
 
 error: cyclic schema dependency: Cycle1 -> Cycle2 -> Cycle3 -> Cycle1
 
-    ┌── tests/sources/schemas_err.move:80:9 ───
+    ┌── tests/sources/schemas_err.move:80:17 ───
     │
  80 │         include Cycle1;
-    │         ^^^^^^^^^^^^^^^
+    │                 ^^^^^^
+    │
+
+error: expected `bool` but found `u128` in expression
+
+    ┌── tests/sources/schemas_err.move:84:17 ───
+    │
+ 84 │         include 22 ==> Condition;
+    │                 ^^
+    │
+
+error: expression construct not supported for schemas
+
+    ┌── tests/sources/schemas_err.move:85:26 ───
+    │
+ 85 │         include true ==> 23;
+    │                          ^^
+    │
+
+error: expression construct not supported for schemas
+
+    ┌── tests/sources/schemas_err.move:86:17 ───
+    │
+ 86 │         include Condition || Condition;
+    │                 ^^^^^^^^^^^^^^^^^^^^^^
     │
 
 error: `y` cannot be matched to an existing name in inclusion context
 
-    ┌── tests/sources/schemas_err.move:52:9 ───
+    ┌── tests/sources/schemas_err.move:52:17 ───
     │
  52 │         include UndeclaredVarInInclude;
-    │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    │                 ^^^^^^^^^^^^^^^^^^^^^^
     │
 
 error: `requires` (included from schema) not allowed in this context

--- a/language/move-prover/spec-lang/tests/sources/schemas_err.move
+++ b/language/move-prover/spec-lang/tests/sources/schemas_err.move
@@ -79,4 +79,10 @@ module M {
     spec schema Cycle3 {
         include Cycle1;
     }
+
+    spec schema SchemaExp {
+        include 22 ==> Condition;
+        include true ==> 23;
+        include Condition || Condition;
+    }
 }

--- a/language/move-prover/spec-lang/tests/sources/schemas_ok.move
+++ b/language/move-prover/spec-lang/tests/sources/schemas_ok.move
@@ -64,4 +64,12 @@ module M {
         requires _x > _y;
     }
 
+    spec schema SchemaExp<T> {
+        x: bool;
+        include x ==> InvariantIsEqual<bool>;
+        include !x ==> InvariantIsEqual<bool>;
+        include InvariantIsEqual<bool> && InvariantIsEqual<bool>;
+        include if (x) InvariantIsEqual<bool> else InvariantIsEqual<bool>;
+    }
+
 }

--- a/language/move-prover/spec-lang/tests/sources/structs_err.exp
+++ b/language/move-prover/spec-lang/tests/sources/structs_err.exp
@@ -6,7 +6,7 @@ error: field `xx` not declared in struct `M::S`
     │       ^^^^
     │
 
-error: expected `bool` but found `u64`
+error: expected `bool` but found `u64` in field selection
 
     ┌── tests/sources/structs_err.move:31:7 ───
     │
@@ -14,7 +14,7 @@ error: expected `bool` but found `u64`
     │       ^^^
     │
 
-error: expected `bool` but found `u64`
+error: expected `bool` but found `u64` in name expression
 
     ┌── tests/sources/structs_err.move:36:18 ───
     │
@@ -30,7 +30,7 @@ error: missing fields `y`, `z`
     │       ^^^^^^^
     │
 
-error: expected `bool` but found `u64`
+error: expected `bool` but found `u64` in pack expression
 
     ┌── tests/sources/structs_err.move:45:7 ───
     │

--- a/language/move-prover/spec-lang/tests/sources/variables_err.exp
+++ b/language/move-prover/spec-lang/tests/sources/variables_err.exp
@@ -14,7 +14,7 @@ error: assignment only allowed in spec var updates
     │                      ^^^^^^^^^^^^^^^^
     │
 
-error: expected `num` but found `bool`
+error: expected `num` but found `bool` in expression
 
     ┌── tests/sources/variables_err.move:14:29 ───
     │

--- a/language/move-prover/tests/sources/functional/schema_exp.exp
+++ b/language/move-prover/tests/sources/functional/schema_exp.exp
@@ -1,0 +1,25 @@
+Move prover returns: exiting with boogie verification errors
+error:  A postcondition might not hold on this return path.
+
+   ┌── tests/sources/functional/schema_exp.move:8:9 ───
+   │
+ 8 │         aborts_if false;
+   │         ^^^^^^^^^^^^^^^^
+   │
+   =     at tests/sources/functional/schema_exp.move:20:5: bar_incorrect (entry)
+   =     at tests/sources/functional/schema_exp.move:21:9: bar_incorrect
+   =         c = <redacted>
+   =     at tests/sources/functional/schema_exp.move:20:5: bar_incorrect (exit)
+
+error:  A postcondition might not hold on this return path.
+
+    ┌── tests/sources/functional/schema_exp.move:42:9 ───
+    │
+ 42 │         ensures result == i + 2;
+    │         ^^^^^^^^^^^^^^^^^^^^^^^^
+    │
+    =     at tests/sources/functional/schema_exp.move:48:5: baz_incorrect (entry)
+    =     at tests/sources/functional/schema_exp.move:49:11: baz_incorrect
+    =         i = <redacted>,
+    =         result = <redacted>
+    =     at tests/sources/functional/schema_exp.move:48:5: baz_incorrect (exit)

--- a/language/move-prover/tests/sources/functional/schema_exp.move
+++ b/language/move-prover/tests/sources/functional/schema_exp.move
@@ -1,0 +1,56 @@
+module TestSchemaExp {
+
+    spec schema Aborts {
+        aborts_if true;
+    }
+
+    spec schema DontAborts {
+        aborts_if false;
+    }
+
+    fun foo(c: bool) {
+        if (!c) abort(1);
+    }
+
+    spec fun foo {
+        include c ==> DontAborts;
+        include !c ==> Aborts;
+    }
+
+    fun bar_incorrect(c: bool) {
+        if (!c) abort(1);
+    }
+
+    spec fun bar_incorrect {
+        // Once we include a schema with aborts, even conditionally, we need to provide a full spec of the aborts
+        // behavior. This is because the below translates to `aborts_if c && false`, which reduces
+        // to `aborts_if false`.
+        include c ==> DontAborts;
+    }
+
+    fun baz(i: u64): u64 {
+        if (i > 10) { i + 2 } else { i + 1 }
+    }
+    spec schema AddsOne {
+        i: num;
+        result: num;
+        ensures result == i + 1;
+    }
+    spec schema AddsTwo {
+        i: num;
+        result: num;
+        ensures result == i + 2;
+    }
+    spec fun baz {
+        include if (i > 10) AddsTwo else AddsOne;
+    }
+
+    fun baz_incorrect(i: u64): u64 {
+        i + 1
+    }
+    spec fun baz_incorrect {
+        include i > 10 ==> AddsTwo;
+        include i <= 10 ==> AddsOne;
+    }
+
+}


### PR DESCRIPTION
This implements a limited number of schema expressions:

- `include P ==> SchemaExp`: conditions in the schema will be prefixed with `P ==> ..`
  or `P && ..` for aborts_if.  Conditions which are not based on boolean expressions
  (as VarUpdate et. al) will be rejected.
- `include if (P) SchemaExp else SchemaExp`: this is treated similar as one include for
  `P ==> SchemaExp` and one for `!P ==> SchemaExp`.
- `include SchemaExp1 && SchemaExp2`: this is treated as two includes for the both expressions.
- `include SchemaExp1 || SchemaExp2`: this *could* be treated as
   `exists b: bool :: if (b) SchemaExp1 else SchemaExp2` (but as we do not have the
   existential quantifier yet in the spec language, it is actually not supported..)

## Motivation

Better specs.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

Added tests.

## Related PRs

NA
