### PR TITLE
[move-prover] Replace "IsEqual" with "==" in Boogie prelude.bpl

### DIFF
--- a/language/move-prover/src/cli.rs
+++ b/language/move-prover/src/cli.rs
@@ -79,7 +79,7 @@ pub struct Options {
     /// Whether to omit debug information in generated model.
     pub omit_model_debug: bool,
     /// Whether to use native array theory.
-    pub use_array_theory: bool,
+    pub no_array_theory: bool,
     /// Whether output for e.g. diagnosis shall be stable/redacted so it can be used in test
     /// output.
     pub stable_test_output: bool,
@@ -106,7 +106,7 @@ impl Default for Options {
             native_stubs: false,
             minimize_execution_trace: true,
             omit_model_debug: false,
-            use_array_theory: false,
+            no_array_theory: false,
             stable_test_output: false,
             verify_scope: VerificationScope::Public,
         }
@@ -211,8 +211,8 @@ impl Options {
                     .help("path to the cvc4 executable"),
             )
             .arg(
-                Arg::with_name("use-array-theory")
-                    .long("use-array-theory")
+                Arg::with_name("no-array-theory")
+                    .long("no-array-theory")
                     .help("whether to use native array theory"),
             )
             .arg(
@@ -296,7 +296,7 @@ impl Options {
         self.move_sources = get_vec("sources");
         self.move_deps = get_vec("dependencies");
         self.search_path = get_vec("search_path");
-        self.use_array_theory = matches.is_present("use-array-theory");
+        self.no_array_theory = matches.is_present("no-array-theory");
         self.stable_test_output = matches.is_present("stable-test-output");
         self.verify_scope = match get_with_default("verify").as_str() {
             "public" => VerificationScope::Public,
@@ -344,10 +344,10 @@ impl Options {
         } else {
             add(&[&format!("-proverOpt:PROVER_PATH={}", &self.z3_exe)]);
         }
-        if self.use_array_theory {
-            add(&["-useArrayTheory"]);
-        } else {
+        if self.no_array_theory {
             add(&["-proverOpt:O:smt.QI.EAGER_THRESHOLD=100"]);
+        } else {
+            add(&["-useArrayTheory"]);
         }
         for f in &self.boogie_flags {
             add(&[f.as_str()]);

--- a/language/move-prover/src/spec_translator.rs
+++ b/language/move-prover/src/spec_translator.rs
@@ -422,11 +422,11 @@ impl<'env> SpecTranslator<'env> {
 
     /// Generates functions which assumes the struct to be well-formed. The first function
     /// only checks type assumptions and is called to ensure well-formedness while the struct is
-    /// mutated. The second function checks both types and data invariants and is used while
+    /// mutated.  The second function checks both types and data invariants and is used while
     /// the struct is not mutated.
     fn translate_assume_well_formed(&self, struct_env: &StructEnv<'env>) {
         let emit_field_checks = |mode: WellFormedMode| {
-            emitln!(self.writer, "is#Vector($this)");
+            emitln!(self.writer, "$Vector_is_well_formed($this)");
             emitln!(
                 self.writer,
                 "  && $vlen($this) == {}",

--- a/language/move-prover/tests/testsuite.rs
+++ b/language/move-prover/tests/testsuite.rs
@@ -11,9 +11,24 @@ use libra_temppath::TempPath;
 use move_prover::{cli::Options, run_move_prover};
 use test_utils::{baseline_test::verify_or_update_baseline, extract_test_directives, read_env_var};
 
-const STDLIB_FLAGS: &[&str] = &["--search_path=../stdlib/modules"];
-const STDLIB_FLAGS_UNVERIFIED: &[&str] = &["--search_path=../stdlib/modules", "--verify=none"];
-const LEGACY_STDLIB_FLAGS: &[&str] = &["--search_path=tests/sources/stdlib/modules"];
+// commented out lines below are to run without array theory. Unfortunately, there
+// seem to be some problems that prevent these from working with cargo test.
+const STDLIB_FLAGS: &[&str] = &[
+    "--search_path=../stdlib/modules",
+    // "--no-array-theory",
+    // "-p src/no_array_theory_prelude.bpl",
+];
+const STDLIB_FLAGS_UNVERIFIED: &[&str] = &[
+    "--search_path=../stdlib/modules",
+    "--verify=none",
+    // "--no-array-theory",
+    // "-p src/no_array_theory_prelude.bpl",
+];
+const LEGACY_STDLIB_FLAGS: &[&str] = &[
+    "--search_path=tests/sources/stdlib/modules",
+    // "--no-array-theory",
+    // "-p src/no_array_theory_prelude.bpl"
+];
 
 fn test_runner(path: &Path) -> datatest_stable::Result<()> {
     let no_boogie = read_env_var("BOOGIE_EXE").is_empty() || read_env_var("Z3_EXE").is_empty();


### PR DESCRIPTION
[move-prover] Replace "IsEqual" with "==" in Boogie prelude.bpl

In the prelude that is included in generated boogie code, we were
using a recursive function, IsEqual, to check equality.  Since a real
recursive function would have caused trouble in Boogie, it was
stratified to a fixed depth ("IsEqual1", "IsEqual2", etc.).

There were several problems with this beyond ugliness. SMT solvers
understand equality extremely well, including the substitution
property, which is built-in and handled efficiently. "IsEquals" was
just another function to them without special properties. This change
will, I hope, enable a more efficient model for hashing and
serialization, where I am now using an uncomfortable number of
quantified formulas (I will try that later).  Finally, it unexpectedly
reduced the size of generated SMT files by a factor of about 50-100
(although, not with dramatic speedups).

In order to make it work, I had to force Boogie to use the builtin SMT
theory of arrays, which is extensional (arrays are equal if all
elements are equal). Boogie's default theory is not extensional.
Finite length vectors and records are represented as SMT arrays (which
have infinite index sets) and a length. IsEqual only compared these
for indices 0 .. len-1, so that invalid entries weren't compared.  I
had to take a little more care that all vectors and structs had
(Error) (also known as DefaultValue, currently) at all invalid
indices.  In particular, I had to replace generated "assume
is#vector(v)" in Module_Fun_is_well_formed with
$Vector_is_well_formed, which not only makes sure v is a vector, but
that its invalid elements are all (Error). That has a quantified
formula in it, but it's worked reliably so far.

I've changed the command-line option --use-array-theory to
--no-array-theory.  If you use --no-array-theory, you should specify
the old prelude, -p src/no_array_theory_prelude, on the command line.
Once we are confident that the array theory works reliably (or as
reliably as the old version), we can get rid of this option.

I cleaned up both preludes, updating outdated comments, deleting unused
functions, and making spacing more consistent.

<!--
Thank you for sending a PR. We appreciate you spending time to help improve the Libra project.

The project is undergoing daily changes. Pull Requests will be reviewed and responded to as time permits.
-->

## Motivation

Cleanup, enables future improvements.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?

Yes.

## Test Plan

cargo test

## Related PRs

(If this PR adds or changes functionality, please take some time to update the docs at https://github.com/libra/website, and link to your PR here.)
