### PR TITLE
[management] Support end-to-end genesis building

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2398,10 +2398,13 @@ dependencies = [
  "libra-network-address 0.1.0",
  "libra-secure-storage 0.1.0",
  "libra-secure-time 0.1.0",
+ "libra-temppath 0.1.0",
  "libra-types 0.1.0",
  "libra-workspace-hack 0.1.0",
+ "serde 1.0.106 (registry+https://github.com/rust-lang/crates.io-index)",
  "structopt 0.3.14 (registry+https://github.com/rust-lang/crates.io-index)",
  "thiserror 1.0.16 (registry+https://github.com/rust-lang/crates.io-index)",
+ "toml 0.5.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "transaction-builder 0.1.0",
  "vm-genesis 0.1.0",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2585,6 +2585,7 @@ dependencies = [
  "libra-crypto 0.1.0",
  "libra-secure-time 0.1.0",
  "libra-temppath 0.1.0",
+ "libra-types 0.1.0",
  "libra-vault-client 0.1.0",
  "libra-workspace-hack 0.1.0",
  "rand 0.7.3 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/config/management/Cargo.toml
+++ b/config/management/Cargo.toml
@@ -10,8 +10,10 @@ publish = false
 edition = "2018"
 
 [dependencies]
+serde = { version = "1.0.106", features = ["rc"], default-features = false }
 structopt = "0.3.14"
 thiserror = "1.0"
+toml = { version = "0.5.3", default-features = false }
 
 libra-config = { path = "..", version = "0.1.0" }
 libra-crypto = { path = "../../crypto/crypto", version = "0.1.0" }
@@ -22,3 +24,6 @@ libra-types = { path = "../../types", version = "0.1.0" }
 libra-workspace-hack = { path = "../../common/workspace-hack", version = "0.1.0" }
 transaction-builder = { path = "../../language/transaction-builder", version = "0.1.0" }
 vm-genesis = { path = "../../language/tools/vm-genesis", version = "0.1.0" }
+
+[dev-dependencies]
+libra-temppath = { path = "../../common/temppath", version = "0.1.0" }

--- a/config/management/src/error.rs
+++ b/config/management/src/error.rs
@@ -25,4 +25,6 @@ pub enum Error {
     RemoteStorageUnavailable,
     #[error("Unexpected command, expected {0}, found {1}")]
     UnexpectedCommand(String, String),
+    #[error("Unexpected error: {0}")]
+    UnexpectedError(String),
 }

--- a/config/management/src/error.rs
+++ b/config/management/src/error.rs
@@ -13,12 +13,14 @@ pub enum Error {
     BackendParsingError(String),
     #[error("Local storage unavailable, please check your configuration")]
     LocalStorageUnavailable,
-    #[error("Failed to read local storage: {0}")]
+    #[error("Failed to read from local storage: {0}")]
     LocalStorageReadError(String),
     #[error("Failed to sign data using local storage: {0}")]
     LocalStorageSigningError(String),
-    #[error("Failed to read remote storage: {0}")]
+    #[error("Failed to read from remote storage: {0}")]
     RemoteStorageReadError(String),
+    #[error("Failed to write to remote storage: {0}")]
+    RemoteStorageWriteError(String),
     #[error("Remote storage unavailable, please check your configuration")]
     RemoteStorageUnavailable,
     #[error("Unexpected command, expected {0}, found {1}")]

--- a/config/management/src/error.rs
+++ b/config/management/src/error.rs
@@ -1,6 +1,7 @@
 // Copyright (c) The Libra Core Contributors
 // SPDX-License-Identifier: Apache-2.0
 
+use crate::CommandName;
 use thiserror::Error;
 
 #[derive(Debug, Error, PartialEq)]
@@ -24,7 +25,7 @@ pub enum Error {
     #[error("Remote storage unavailable, please check your configuration")]
     RemoteStorageUnavailable,
     #[error("Unexpected command, expected {0}, found {1}")]
-    UnexpectedCommand(String, String),
+    UnexpectedCommand(CommandName, CommandName),
     #[error("Unexpected error: {0}")]
     UnexpectedError(String),
 }

--- a/config/management/src/genesis.rs
+++ b/config/management/src/genesis.rs
@@ -1,0 +1,105 @@
+// Copyright (c) The Libra Core Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::{constants, error::Error, layout::Layout, SingleBackend};
+use libra_crypto::ed25519::Ed25519PublicKey;
+use libra_secure_storage::Storage;
+use libra_types::transaction::{Transaction, TransactionPayload};
+use std::{convert::TryInto, path::PathBuf};
+use structopt::StructOpt;
+use vm_genesis::ValidatorRegistration;
+
+// TODO(davidiw) add operator_address, since that will eventually be the identity producing this.
+/// Note, it is implicitly expected that the storage supports
+/// a namespace but one has not been set.
+#[derive(Debug, StructOpt)]
+pub struct Genesis {
+    #[structopt(flatten)]
+    backend: SingleBackend,
+    #[structopt(long)]
+    path: Option<PathBuf>,
+}
+
+impl Genesis {
+    pub fn execute(self) -> Result<Transaction, Error> {
+        let layout = self.layout()?;
+        let association_key = self.association(&layout)?;
+        let validators = self.validators(&layout)?;
+
+        Ok(vm_genesis::encode_genesis_transaction_with_validator(
+            association_key,
+            &validators,
+            None,
+        ))
+    }
+
+    /// Retrieves association key from the remote storage. Note, at this point in time, genesis
+    /// only supports a single association key.
+    pub fn association(&self, layout: &Layout) -> Result<Ed25519PublicKey, Error> {
+        let mut association_config = self.backend.backend.clone();
+        association_config
+            .parameters
+            .insert("namespace".into(), layout.association[0].clone());
+        let association: Box<dyn Storage> = association_config.try_into()?;
+
+        let association_key = association
+            .get(constants::ASSOCIATION_KEY)
+            .map_err(|e| Error::RemoteStorageReadError(e.to_string()))?;
+        association_key
+            .value
+            .ed25519_public_key()
+            .map_err(|e| Error::RemoteStorageReadError(e.to_string()))
+    }
+
+    /// Retrieves a layout from the remote storage.
+    pub fn layout(&self) -> Result<Layout, Error> {
+        let mut common_config = self.backend.backend.clone();
+        common_config
+            .parameters
+            .insert("namespace".into(), constants::COMMON_NS.into());
+        let common: Box<dyn Storage> = common_config.try_into()?;
+
+        let layout = common
+            .get(constants::LAYOUT)
+            .map_err(|e| Error::RemoteStorageReadError(e.to_string()))?
+            .value
+            .string()
+            .map_err(|e| Error::RemoteStorageReadError(e.to_string()))?;
+        Layout::parse(&layout).map_err(|e| Error::RemoteStorageReadError(e.to_string()))
+    }
+
+    /// Produces a set of ValidatorRegistration from the remote storage.
+    pub fn validators(&self, layout: &Layout) -> Result<Vec<ValidatorRegistration>, Error> {
+        let mut validators = Vec::new();
+        for operator in layout.operators.iter() {
+            let mut validator_config = self.backend.backend.clone();
+            validator_config
+                .parameters
+                .insert("namespace".into(), operator.into());
+            let validator: Box<dyn Storage> = validator_config.try_into()?;
+
+            let key = validator
+                .get(constants::OPERATOR_KEY)
+                .map_err(|e| Error::RemoteStorageReadError(e.to_string()))?
+                .value
+                .ed25519_public_key()
+                .map_err(|e| Error::RemoteStorageReadError(e.to_string()))?;
+
+            let txn = validator
+                .get(constants::VALIDATOR_CONFIG)
+                .map_err(|e| Error::RemoteStorageReadError(e.to_string()))?
+                .value;
+            let txn = txn.transaction().unwrap();
+            let txn = txn.as_signed_user_txn().unwrap().payload();
+            let txn = if let TransactionPayload::Script(script) = txn {
+                script.clone()
+            } else {
+                return Err(Error::UnexpectedError("Found invalid registration".into()));
+            };
+
+            validators.push((key, txn));
+        }
+
+        Ok(validators)
+    }
+}

--- a/config/management/src/layout.rs
+++ b/config/management/src/layout.rs
@@ -1,0 +1,92 @@
+// Copyright (c) The Libra Core Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::{constants, error::Error, SingleBackend};
+use libra_secure_storage::{Storage, Value};
+use serde::{Deserialize, Serialize};
+use std::{
+    convert::TryInto,
+    fs::File,
+    io::Read,
+    path::{Path, PathBuf},
+};
+use structopt::StructOpt;
+
+/// Layout defines the set of roles to identities within genesis. In practice, these identities
+/// will map to distinct namespaces where the expected data should be stored in the deterministic
+/// location as defined within this tool.
+#[derive(Debug, Deserialize, Serialize)]
+pub struct Layout {
+    pub operators: Vec<String>,
+    pub owners: Vec<String>,
+    pub association: Vec<String>,
+}
+
+impl Layout {
+    pub fn from_disk<P: AsRef<Path>>(path: P) -> Result<Self, Error> {
+        let mut file = File::open(&path).map_err(|e| Error::UnexpectedError(e.to_string()))?;
+        let mut contents = String::new();
+        file.read_to_string(&mut contents)
+            .map_err(|e| Error::UnexpectedError(e.to_string()))?;
+        Self::parse(&contents)
+    }
+
+    pub fn parse(contents: &str) -> Result<Self, Error> {
+        toml::from_str(&contents).map_err(|e| Error::UnexpectedError(e.to_string()))
+    }
+}
+
+impl std::fmt::Display for Layout {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        write!(f, "{}", toml::to_string(self).unwrap())
+    }
+}
+
+#[derive(Debug, StructOpt)]
+pub struct SetLayout {
+    #[structopt(long)]
+    path: PathBuf,
+    #[structopt(flatten)]
+    backend: SingleBackend,
+}
+
+impl SetLayout {
+    pub fn execute(self) -> Result<Layout, Error> {
+        let layout = Layout::from_disk(&self.path)?;
+        let data = toml::to_string(&layout).map_err(|e| Error::UnexpectedError(e.to_string()))?;
+
+        let mut remote: Box<dyn Storage> = self.backend.backend.try_into()?;
+        if !remote.available() {
+            return Err(Error::RemoteStorageUnavailable);
+        }
+
+        let value = Value::String(data);
+        remote
+            .create_with_default_policy(constants::LAYOUT, value)
+            .map_err(|e| Error::RemoteStorageWriteError(e.to_string()))?;
+
+        Ok(layout)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_layout() {
+        let contents = "\
+            operators = [\"alice\", \"bob\"]\n\
+            owners = [\"carol\"]\n\
+            association = [\"dave\"]\n\
+        ";
+
+        let layout = Layout::parse(contents).unwrap();
+        assert_eq!(
+            layout.operators,
+            vec!["alice".to_string(), "bob".to_string()]
+        );
+        assert_eq!(layout.owners, vec!["carol".to_string()]);
+        assert_eq!(layout.association, vec!["dave".to_string()]);
+    }
+}

--- a/config/management/src/lib.rs
+++ b/config/management/src/lib.rs
@@ -55,6 +55,7 @@ pub enum Command {
     Verify(SingleBackend),
 }
 
+#[derive(Debug, PartialEq)]
 pub enum CommandName {
     AssociationKey,
     Genesis,
@@ -111,9 +112,10 @@ impl Command {
         if let Command::AssociationKey(secure_backends) = self {
             Self::submit_key(constants::ASSOCIATION_KEY, secure_backends)
         } else {
-            let expected = CommandName::AssociationKey.to_string();
-            let actual = CommandName::from(&self).to_string();
-            Err(Error::UnexpectedCommand(expected, actual))
+            Err(Error::UnexpectedCommand(
+                CommandName::AssociationKey,
+                CommandName::from(&self),
+            ))
         }
     }
 
@@ -121,9 +123,10 @@ impl Command {
         if let Command::Genesis(genesis) = self {
             genesis.execute()
         } else {
-            let expected = CommandName::Genesis.to_string();
-            let actual = CommandName::from(&self).to_string();
-            Err(Error::UnexpectedCommand(expected, actual))
+            Err(Error::UnexpectedCommand(
+                CommandName::Genesis,
+                CommandName::from(&self),
+            ))
         }
     }
 
@@ -131,9 +134,10 @@ impl Command {
         if let Command::OperatorKey(secure_backends) = self {
             Self::submit_key(constants::OPERATOR_KEY, secure_backends)
         } else {
-            let expected = CommandName::OperatorKey.to_string();
-            let actual = CommandName::from(&self).to_string();
-            Err(Error::UnexpectedCommand(expected, actual))
+            Err(Error::UnexpectedCommand(
+                CommandName::OperatorKey,
+                CommandName::from(&self),
+            ))
         }
     }
 
@@ -141,9 +145,10 @@ impl Command {
         if let Command::OwnerKey(secure_backends) = self {
             Self::submit_key(constants::OWNER_KEY, secure_backends)
         } else {
-            let expected = CommandName::OwnerKey.to_string();
-            let actual = CommandName::from(&self).to_string();
-            Err(Error::UnexpectedCommand(expected, actual))
+            Err(Error::UnexpectedCommand(
+                CommandName::OwnerKey,
+                CommandName::from(&self),
+            ))
         }
     }
 
@@ -151,9 +156,10 @@ impl Command {
         if let Command::SetLayout(set_layout) = self {
             set_layout.execute()
         } else {
-            let expected = CommandName::SetLayout.to_string();
-            let actual = CommandName::from(&self).to_string();
-            Err(Error::UnexpectedCommand(expected, actual))
+            Err(Error::UnexpectedCommand(
+                CommandName::SetLayout,
+                CommandName::from(&self),
+            ))
         }
     }
 
@@ -161,9 +167,10 @@ impl Command {
         if let Command::ValidatorConfig(config) = self {
             config.execute()
         } else {
-            let expected = CommandName::ValidatorConfig.to_string();
-            let actual = CommandName::from(&self).to_string();
-            Err(Error::UnexpectedCommand(expected, actual))
+            Err(Error::UnexpectedCommand(
+                CommandName::ValidatorConfig,
+                CommandName::from(&self),
+            ))
         }
     }
 

--- a/config/management/src/lib.rs
+++ b/config/management/src/lib.rs
@@ -5,23 +5,13 @@
 
 mod error;
 mod secure_backend;
+mod validator_config;
 
-use crate::{error::Error, secure_backend::SecureBackend};
-use libra_crypto::{ed25519::Ed25519PublicKey, hash::CryptoHash, x25519, ValidCryptoMaterial};
-use libra_network_address::{NetworkAddress, RawNetworkAddress};
+use crate::{error::Error, secure_backend::SecureBackend, validator_config::ValidatorConfig};
+use libra_crypto::ed25519::Ed25519PublicKey;
 use libra_secure_storage::{Storage, Value};
-use libra_secure_time::{RealTimeService, TimeService};
-use libra_types::{
-    account_address::AccountAddress,
-    transaction::{RawTransaction, SignedTransaction, Transaction},
-    waypoint::Waypoint,
-};
-use std::{
-    convert::{TryFrom, TryInto},
-    fmt::Write,
-    str::FromStr,
-    time::Duration,
-};
+use libra_types::{transaction::Transaction, waypoint::Waypoint};
+use std::{convert::TryInto, fmt::Write, str::FromStr};
 use structopt::StructOpt;
 
 pub mod constants {
@@ -116,75 +106,7 @@ impl Command {
 
     pub fn validator_config(self) -> Result<Transaction, Error> {
         if let Command::ValidatorConfig(config) = self {
-            let mut storage: Box<dyn Storage> = config.backend.backend.try_into()?;
-            if !storage.available() {
-                return Err(Error::LocalStorageUnavailable);
-            }
-
-            let consensus_key = storage
-                .get_public_key(constants::CONSENSUS_KEY)
-                .map_err(|e| Error::LocalStorageReadError(e.to_string()))?
-                .public_key;
-            let fullnode_network_key = storage
-                .get_public_key(constants::FULLNODE_NETWORK_KEY)
-                .map_err(|e| Error::LocalStorageReadError(e.to_string()))?
-                .public_key;
-            let validator_network_key = storage
-                .get_public_key(constants::VALIDATOR_NETWORK_KEY)
-                .map_err(|e| Error::LocalStorageReadError(e.to_string()))?
-                .public_key;
-
-            let fullnode_address = RawNetworkAddress::try_from(&config.fullnode_address)
-                .expect("Unable to serialize fullnode network address from config");
-            let validator_address = RawNetworkAddress::try_from(&config.validator_address)
-                .expect("Unable to serialize validator network address from config");
-
-            let fullnode_network_key = fullnode_network_key.to_bytes();
-            let fullnode_network_key: x25519::PublicKey = fullnode_network_key
-                .as_ref()
-                .try_into()
-                .expect("Unable to decode x25519 from fullnode_network_key");
-
-            let validator_network_key = validator_network_key.to_bytes();
-            let validator_network_key: x25519::PublicKey = validator_network_key
-                .as_ref()
-                .try_into()
-                .expect("Unable to decode x25519 from validator_network_key");
-
-            let owner_key = storage
-                .get_public_key(constants::OWNER_KEY)
-                .map_err(|e| Error::LocalStorageReadError(e.to_string()))?
-                .public_key;
-
-            // TODO(davidiw): The signing key, parameter 2, will be deleted soon, so this is a
-            // temporary hack to reduce over-engineering.
-            let script = transaction_builder::encode_register_validator_script(
-                consensus_key.to_bytes().to_vec(),
-                owner_key.to_bytes().to_vec(),
-                validator_network_key.to_bytes(),
-                validator_address.into(),
-                fullnode_network_key.to_bytes(),
-                fullnode_address.into(),
-            );
-
-            let sender = config.owner_address;
-            // TODO(davidiw): In genesis this is irrelevant -- afterward we need to obtain the
-            // current sequence number by querying the blockchain.
-            let sequence_number = 0;
-            let expiration_time = RealTimeService::new().now() + constants::TXN_EXPIRATION_SECS;
-            let raw_transaction = RawTransaction::new_script(
-                sender,
-                sequence_number,
-                script,
-                constants::MAX_GAS_AMOUNT,
-                constants::GAS_UNIT_PRICE,
-                Duration::from_secs(expiration_time),
-            );
-            let signature = storage
-                .sign_message(constants::OWNER_KEY, &raw_transaction.hash())
-                .map_err(|e| Error::LocalStorageSigningError(e.to_string()))?;
-            let signed_txn = SignedTransaction::new(raw_transaction, owner_key, signature);
-            Ok(Transaction::UserTransaction(signed_txn))
+            config.execute()
         } else {
             let expected = CommandName::ValidatorConfig.to_string();
             let actual = CommandName::from(&self).to_string();
@@ -331,19 +253,6 @@ pub struct SingleBackend {
     backend: SecureBackend,
 }
 
-// TODO(davidiw) add operator_address, since that will eventually be the identity producing this.
-#[derive(Debug, StructOpt)]
-pub struct ValidatorConfig {
-    #[structopt(long)]
-    owner_address: AccountAddress,
-    #[structopt(long)]
-    validator_address: NetworkAddress,
-    #[structopt(long)]
-    fullnode_address: NetworkAddress,
-    #[structopt(flatten)]
-    backend: SingleBackend,
-}
-
 /// These tests depends on running Vault, which can be done by using the provided docker run script
 /// in `docker/vault/run.sh`.
 /// Note: Some of these tests may fail if you run them too quickly one after another due to data
@@ -352,8 +261,9 @@ pub struct ValidatorConfig {
 #[cfg(test)]
 pub mod tests {
     use super::*;
+    use libra_network_address::NetworkAddress;
     use libra_secure_storage::{Policy, Value, VaultStorage};
-    use libra_types::transaction::TransactionPayload;
+    use libra_types::{account_address::AccountAddress, transaction::TransactionPayload};
 
     const VAULT_HOST: &str = "http://localhost:8200";
     const VAULT_ROOT_TOKEN: &str = "root_token";

--- a/config/management/src/secure_backend.rs
+++ b/config/management/src/secure_backend.rs
@@ -21,10 +21,10 @@ pub const VAULT: &str = "vault";
 /// config::SecureBackend type to parse.
 ///
 /// Example: backend=vault;server=http://127.0.0.1:8080;token=123456
-#[derive(Debug)]
+#[derive(Clone, Debug)]
 pub struct SecureBackend {
-    backend: String,
-    parameters: HashMap<String, String>,
+    pub backend: String,
+    pub parameters: HashMap<String, String>,
 }
 
 impl SecureBackend {

--- a/config/management/src/validator_config.rs
+++ b/config/management/src/validator_config.rs
@@ -1,8 +1,6 @@
 // Copyright (c) The Libra Core Contributors
 // SPDX-License-Identifier: Apache-2.0
 
-#![forbid(unsafe_code)]
-
 use crate::{constants, error::Error, SecureBackends};
 use libra_crypto::{hash::CryptoHash, x25519, ValidCryptoMaterial};
 use libra_network_address::{NetworkAddress, RawNetworkAddress};

--- a/config/management/src/validator_config.rs
+++ b/config/management/src/validator_config.rs
@@ -1,0 +1,106 @@
+// Copyright (c) The Libra Core Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+#![forbid(unsafe_code)]
+
+use crate::{constants, error::Error, SingleBackend};
+use libra_crypto::{hash::CryptoHash, x25519, ValidCryptoMaterial};
+use libra_network_address::{NetworkAddress, RawNetworkAddress};
+use libra_secure_storage::Storage;
+use libra_secure_time::{RealTimeService, TimeService};
+use libra_types::{
+    account_address::AccountAddress,
+    transaction::{RawTransaction, SignedTransaction, Transaction},
+};
+use std::{
+    convert::{TryFrom, TryInto},
+    time::Duration,
+};
+use structopt::StructOpt;
+
+// TODO(davidiw) add operator_address, since that will eventually be the identity producing this.
+#[derive(Debug, StructOpt)]
+pub struct ValidatorConfig {
+    #[structopt(long)]
+    owner_address: AccountAddress,
+    #[structopt(long)]
+    validator_address: NetworkAddress,
+    #[structopt(long)]
+    fullnode_address: NetworkAddress,
+    #[structopt(flatten)]
+    backend: SingleBackend,
+}
+
+impl ValidatorConfig {
+    pub fn execute(self) -> Result<Transaction, Error> {
+        let mut storage: Box<dyn Storage> = self.backend.backend.try_into()?;
+        if !storage.available() {
+            return Err(Error::LocalStorageUnavailable);
+        }
+
+        let consensus_key = storage
+            .get_public_key(constants::CONSENSUS_KEY)
+            .map_err(|e| Error::LocalStorageReadError(e.to_string()))?
+            .public_key;
+        let fullnode_network_key = storage
+            .get_public_key(constants::FULLNODE_NETWORK_KEY)
+            .map_err(|e| Error::LocalStorageReadError(e.to_string()))?
+            .public_key;
+        let validator_network_key = storage
+            .get_public_key(constants::VALIDATOR_NETWORK_KEY)
+            .map_err(|e| Error::LocalStorageReadError(e.to_string()))?
+            .public_key;
+
+        let fullnode_address = RawNetworkAddress::try_from(&self.fullnode_address)
+            .expect("Unable to serialize fullnode network address from config");
+        let validator_address = RawNetworkAddress::try_from(&self.validator_address)
+            .expect("Unable to serialize validator network address from config");
+
+        let fullnode_network_key = fullnode_network_key.to_bytes();
+        let fullnode_network_key: x25519::PublicKey = fullnode_network_key
+            .as_ref()
+            .try_into()
+            .expect("Unable to decode x25519 from fullnode_network_key");
+
+        let validator_network_key = validator_network_key.to_bytes();
+        let validator_network_key: x25519::PublicKey = validator_network_key
+            .as_ref()
+            .try_into()
+            .expect("Unable to decode x25519 from validator_network_key");
+
+        let owner_key = storage
+            .get_public_key(constants::OWNER_KEY)
+            .map_err(|e| Error::LocalStorageReadError(e.to_string()))?
+            .public_key;
+
+        // TODO(davidiw): The signing key, parameter 2, will be deleted soon, so this is a
+        // temporary hack to reduce over-engineering.
+        let script = transaction_builder::encode_register_validator_script(
+            consensus_key.to_bytes().to_vec(),
+            owner_key.to_bytes().to_vec(),
+            validator_network_key.to_bytes(),
+            validator_address.into(),
+            fullnode_network_key.to_bytes(),
+            fullnode_address.into(),
+        );
+
+        let sender = self.owner_address;
+        // TODO(davidiw): In genesis this is irrelevant -- afterward we need to obtain the
+        // current sequence number by querying the blockchain.
+        let sequence_number = 0;
+        let expiration_time = RealTimeService::new().now() + constants::TXN_EXPIRATION_SECS;
+        let raw_transaction = RawTransaction::new_script(
+            sender,
+            sequence_number,
+            script,
+            constants::MAX_GAS_AMOUNT,
+            constants::GAS_UNIT_PRICE,
+            Duration::from_secs(expiration_time),
+        );
+        let signature = storage
+            .sign_message(constants::OWNER_KEY, &raw_transaction.hash())
+            .map_err(|e| Error::LocalStorageSigningError(e.to_string()))?;
+        let signed_txn = SignedTransaction::new(raw_transaction, owner_key, signature);
+        Ok(Transaction::UserTransaction(signed_txn))
+    }
+}

--- a/secure/storage/Cargo.toml
+++ b/secure/storage/Cargo.toml
@@ -16,6 +16,7 @@ libra-config = { path = "../../config", version = "0.1.0" }
 libra-crypto = { path = "../../crypto/crypto", version = "0.1.0" }
 libra-secure-time = { path = "../time", version = "0.1.0" }
 libra-temppath = { path = "../../common/temppath", version = "0.1.0" }
+libra-types = { path = "../../types", version = "0.1.0" }
 libra-vault-client = { path = "vault", version = "0.1.0" }
 libra-workspace-hack = { path = "../../common/workspace-hack", version = "0.1.0" }
 rand = "0.7.3"

--- a/secure/storage/src/in_memory.rs
+++ b/secure/storage/src/in_memory.rs
@@ -73,6 +73,7 @@ impl<T: Send + Sync + TimeService> KVStorage for InMemoryStorageInternal<T> {
             Value::HashValue(value) => Value::HashValue(*value),
             Value::String(value) => Value::String(value.clone()),
             Value::U64(value) => Value::U64(*value),
+            Value::Transaction(value) => Value::Transaction(value.clone()),
         };
 
         let last_update = response.last_update;

--- a/secure/storage/src/value.rs
+++ b/secure/storage/src/value.rs
@@ -6,15 +6,18 @@ use libra_crypto::{
     ed25519::{Ed25519PrivateKey, Ed25519PublicKey},
     hash::HashValue,
 };
+use libra_types::transaction::Transaction;
 use serde::{Deserialize, Serialize};
 
 #[derive(Debug, Deserialize, PartialEq, Serialize)]
 #[serde(content = "value", rename_all = "snake_case", tag = "type")]
+#[allow(clippy::large_enum_variant)]
 pub enum Value {
     Ed25519PrivateKey(Ed25519PrivateKey),
     Ed25519PublicKey(Ed25519PublicKey),
     HashValue(HashValue),
     String(String),
+    Transaction(Transaction),
     U64(u64),
 }
 
@@ -53,6 +56,14 @@ impl Value {
 
     pub fn u64(self) -> Result<u64, Error> {
         if let Value::U64(value) = self {
+            Ok(value)
+        } else {
+            Err(Error::UnexpectedValueType)
+        }
+    }
+
+    pub fn transaction(self) -> Result<Transaction, Error> {
+        if let Value::Transaction(value) = self {
             Ok(value)
         } else {
             Err(Error::UnexpectedValueType)


### PR DESCRIPTION
This adds support to build a genesis using a namespaced storage solution -- currently only Vault is exposed -- need some work to expose namespaces for others.

* Can upload a validator-config to a remote storage
* Add a layout for the initial set of accounts
* Tooling to place data into the position that layout expects for association account -- operator and owner were done already
* Consumption of all of these to produce a genesis!

There is still quite a bit more work to do to make this accessible for our tests inside Libra:
* waypoint generation
* merging with config generation
* support for either in memory or on disk storage solutions
* deterministic generation of configs -- do not need to add noise to our testing frameworks

but this does hit our goal of supporting the ability to produce a genesis blob!