### PR TITLE
[config] Improve how we use use SecureBackend

### DIFF
--- a/config/config-builder/src/validator_config.rs
+++ b/config/config-builder/src/validator_config.rs
@@ -265,7 +265,6 @@ impl ValidatorConfig {
                 "in-memory" => SecureBackend::InMemoryStorage,
                 "on-disk" => safety_rules_config.backend.clone(),
                 "vault" => SecureBackend::Vault(VaultConfig {
-                    default: true,
                     namespace: self.safety_rules_namespace.clone(),
                     server: self
                         .safety_rules_host

--- a/config/management/src/secure_backend.rs
+++ b/config/management/src/secure_backend.rs
@@ -88,7 +88,6 @@ impl TryInto<config::SecureBackend> for SecureBackend {
                     .remove("token")
                     .ok_or_else(|| Error::BackendParsingError("missing token".into()))?;
                 config::SecureBackend::Vault(VaultConfig {
-                    default: false,
                     namespace: self.parameters.remove("namespace"),
                     server,
                     // TODO(davidiw) Make this a path to a file

--- a/config/src/config/mod.rs
+++ b/config/src/config/mod.rs
@@ -261,6 +261,7 @@ impl NodeConfig {
         let mut test = TestConfig::new_with_temp_dir();
 
         if self.base.role == RoleType::Validator {
+            test.initialize_storage = true;
             test.random_account_key(rng);
             let peer_id =
                 PeerId::from_public_key(&test.account_keypair.as_ref().unwrap().public_key());

--- a/config/src/config/safety_rules_config.rs
+++ b/config/src/config/safety_rules_config.rs
@@ -16,7 +16,7 @@ impl Default for SafetyRulesConfig {
     fn default() -> Self {
         Self {
             backend: SecureBackend::InMemoryStorage,
-            service: SafetyRulesService::Local,
+            service: SafetyRulesService::Thread,
         }
     }
 }

--- a/config/src/config/secure_config.rs
+++ b/config/src/config/secure_config.rs
@@ -42,9 +42,6 @@ pub enum SecureBackend {
 
 #[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
 pub struct VaultConfig {
-    /// In testing scenarios this will install baseline data if it is not specified. Note: this can
-    /// only be used if the token provided has root or sudo access.
-    pub default: bool,
     /// A namespace is an optional portion of the path to a key stored within Vault. For example,
     /// a secret, S, without a namespace would be available in secret/data/S, with a namespace, N, it
     /// would be in secret/data/N/S.
@@ -57,9 +54,6 @@ pub struct VaultConfig {
 
 #[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
 pub struct OnDiskStorageConfig {
-    // In testing scenarios this implies that the default state is okay if
-    // a state is not specified.
-    pub default: bool,
     // Required path for on disk storage
     pub path: PathBuf,
     #[serde(skip)]
@@ -69,7 +63,6 @@ pub struct OnDiskStorageConfig {
 impl Default for OnDiskStorageConfig {
     fn default() -> Self {
         Self {
-            default: false,
             path: PathBuf::from("safety_rules.toml"),
             data_dir: PathBuf::from("/opt/libra/data/common"),
         }

--- a/config/src/config/secure_config.rs
+++ b/config/src/config/secure_config.rs
@@ -7,18 +7,10 @@ use std::{net::SocketAddr, path::PathBuf};
 const DEFAULT_JSON_RPC_ADDR: &str = "127.0.0.1";
 const DEFAULT_JSON_RPC_PORT: u16 = 8080;
 
-#[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, PartialEq, Serialize)]
 #[serde(default, deny_unknown_fields)]
 pub struct SecureConfig {
     pub key_manager: KeyManagerConfig,
-}
-
-impl Default for SecureConfig {
-    fn default() -> Self {
-        Self {
-            key_manager: KeyManagerConfig::default(),
-        }
-    }
 }
 
 #[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]

--- a/config/src/config/test_config.rs
+++ b/config/src/config/test_config.rs
@@ -21,6 +21,8 @@ pub struct TestConfig {
     pub account_keypair: Option<AccountKeyPair>,
     #[serde(rename = "consensus_private_key")]
     pub consensus_keypair: Option<ConsensusKeyPair>,
+    // Used to initialize storage defaults in safety rules
+    pub initialize_storage: bool,
     // Used only to prevent a potentially temporary data_dir from being deleted. This should
     // eventually be moved to be owned by something outside the config.
     #[serde(skip)]
@@ -36,6 +38,7 @@ impl Clone for TestConfig {
             auth_key: self.auth_key,
             account_keypair: self.account_keypair.clone(),
             consensus_keypair: self.consensus_keypair.clone(),
+            initialize_storage: self.initialize_storage,
             temp_dir: None,
             publishing_option: self.publishing_option.clone(),
         }
@@ -45,8 +48,9 @@ impl Clone for TestConfig {
 impl PartialEq for TestConfig {
     fn eq(&self, other: &Self) -> bool {
         self.account_keypair == other.account_keypair
-            && self.consensus_keypair == other.consensus_keypair
             && self.auth_key == other.auth_key
+            && self.consensus_keypair == other.consensus_keypair
+            && self.initialize_storage == other.initialize_storage
     }
 }
 
@@ -56,6 +60,7 @@ impl TestConfig {
             auth_key: None,
             account_keypair: None,
             consensus_keypair: None,
+            initialize_storage: false,
             temp_dir: None,
             publishing_option: Some(VMPublishingOption::Open),
         }
@@ -68,6 +73,7 @@ impl TestConfig {
             auth_key: None,
             account_keypair: None,
             consensus_keypair: None,
+            initialize_storage: false,
             temp_dir: Some(temp_dir),
             publishing_option: None,
         }

--- a/config/src/config/test_data/random.complete.node.config.toml
+++ b/config/src/config/test_data/random.complete.node.config.toml
@@ -69,6 +69,7 @@ grpc_max_receive_len = 100000000
 auth_key = "837e3b2b2b32ee2543c24676ee66326431893204fa402143c11b26ce8a89ea1d"
 account_private_key = "f6b898412f4ab061943167c1e23efaa2ba98e345a093f0b06da13bffdbd4b2c7"
 consensus_private_key = "f2b916c8b1bf6123854d2fca5384f128199f7a1b2f847316481429b4b35238cc"
+initialize_storage = true
 
 [validator_network]
 peer_id = "31893204fa402143c11b26ce8a89ea1d"

--- a/config/src/config/test_data/random.default.node.config.toml
+++ b/config/src/config/test_data/random.default.node.config.toml
@@ -10,3 +10,4 @@ signing_private_key = "66dd107034b4582a2ef42c5e1ea475f2fea477a10a9f1d75b3635243b
 auth_key = "837e3b2b2b32ee2543c24676ee66326431893204fa402143c11b26ce8a89ea1d"
 account_private_key ="f6b898412f4ab061943167c1e23efaa2ba98e345a093f0b06da13bffdbd4b2c7"
 consensus_private_key = "f2b916c8b1bf6123854d2fca5384f128199f7a1b2f847316481429b4b35238cc"
+initialize_storage = true

--- a/config/src/config/test_data/single.node.config.toml
+++ b/config/src/config/test_data/single.node.config.toml
@@ -34,6 +34,7 @@ grpc_max_receive_len = 100000000
 auth_key = "8e0d19280063fa870fe4dbb85cc724091a398451c5c11e1e76e64cdc7b588510"
 account_private_key = "76b8e0ada0f13d90405d6ae55386bd28bdd219b8a08ded1aa836efcc8b770dc7"
 consensus_private_key = "29b721769ce64e43d57133b074d839d531ed1f28510afb45ace10a1f4b794d6f"
+initialize_storage = true
 
 [validator_network]
 peer_id = "1a398451c5c11e1e76e64cdc7b588510"

--- a/config/src/generator.rs
+++ b/config/src/generator.rs
@@ -5,10 +5,7 @@
 //! genesis.blob.
 
 use crate::{
-    config::{
-        NodeConfig, OnDiskStorageConfig, SafetyRulesService, SecureBackend, SeedPeersConfig,
-        TestConfig,
-    },
+    config::{NodeConfig, SeedPeersConfig, TestConfig},
     utils,
 };
 use rand::{rngs::StdRng, SeedableRng};
@@ -32,11 +29,6 @@ pub fn validator_swarm(
         if randomize_service_ports {
             node.randomize_ports();
         }
-
-        let mut storage_config = OnDiskStorageConfig::default();
-        storage_config.default = true;
-        node.consensus.safety_rules.service = SafetyRulesService::Thread;
-        node.consensus.safety_rules.backend = SecureBackend::OnDiskStorage(storage_config);
 
         let network = node.validator_network.as_mut().unwrap();
         if randomize_libranet_ports {

--- a/consensus/safety-rules/benches/safety_rules.rs
+++ b/consensus/safety-rules/benches/safety_rules.rs
@@ -106,7 +106,6 @@ fn thread(n: u64) {
 fn process(n: u64) {
     let file_path = NamedTempFile::new().unwrap().into_temp_path().to_path_buf();
     let mut config = OnDiskStorageConfig::default();
-    config.default = true;
     config.path = file_path;
     let backend = SecureBackend::OnDiskStorage(config);
     let client_wrapper = ProcessClientWrapper::new(backend);

--- a/consensus/safety-rules/src/safety_rules_manager.rs
+++ b/consensus/safety-rules/src/safety_rules_manager.rs
@@ -14,7 +14,11 @@ use crate::{
 use consensus_types::common::{Author, Payload};
 use libra_config::config::{NodeConfig, SafetyRulesService};
 use libra_secure_storage::Storage;
-use std::{convert::TryInto, net::SocketAddr, sync::{Arc, RwLock}};
+use std::{
+    convert::TryInto,
+    net::SocketAddr,
+    sync::{Arc, RwLock},
+};
 
 pub fn extract_service_inputs(config: &mut NodeConfig) -> (Author, PersistentSafetyStorage) {
     let author = config
@@ -24,7 +28,8 @@ pub fn extract_service_inputs(config: &mut NodeConfig) -> (Author, PersistentSaf
         .peer_id;
 
     let backend = &config.consensus.safety_rules.backend;
-    let internal_storage: Box<dyn Storage> = backend.try_into().expect("Unable to initialize storage");
+    let internal_storage: Box<dyn Storage> =
+        backend.try_into().expect("Unable to initialize storage");
 
     let storage = if let Some(test_config) = config.test.as_mut() {
         let private_key = test_config

--- a/secure/storage/src/lib.rs
+++ b/secure/storage/src/lib.rs
@@ -27,7 +27,7 @@ pub use crate::{
     namespaced_storage::NamespacedStorage,
     on_disk::{OnDiskStorage, OnDiskStorageInternal},
     policy::{Capability, Identity, Permission, Policy},
-    storage::Storage,
+    storage::{BoxStorage, Storage},
     value::Value,
     vault::VaultStorage,
 };

--- a/secure/storage/src/storage.rs
+++ b/secure/storage/src/storage.rs
@@ -1,7 +1,11 @@
 // Copyright (c) The Libra Core Contributors
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::{CryptoStorage, KVStorage};
+use crate::{CryptoStorage, Error, GetResponse, KVStorage, Policy, PublicKeyResponse, Value};
+use libra_crypto::{
+    ed25519::{Ed25519PrivateKey, Ed25519PublicKey, Ed25519Signature},
+    HashValue,
+};
 
 /// This is the Libra interface into secure storage. Any storage engine implementing this trait
 /// should support both key/value operations (e.g., get, set and create) and cryptographic key
@@ -9,3 +13,68 @@ use crate::{CryptoStorage, KVStorage};
 pub trait Storage: KVStorage + CryptoStorage {}
 
 impl<T> Storage for T where T: KVStorage + CryptoStorage {}
+
+/// This is a hack that allows us to convert from SecureBackend into a useable T: Storage, since
+/// Box<dyn Storage> is not T: Storage.
+pub struct BoxStorage(pub Box<dyn Storage>);
+
+impl KVStorage for BoxStorage {
+    fn available(&self) -> bool {
+        self.0.available()
+    }
+
+    fn create(&mut self, key: &str, value: Value, policy: &Policy) -> Result<(), Error> {
+        self.0.create(key, value, policy)
+    }
+
+    fn get(&self, key: &str) -> Result<GetResponse, Error> {
+        self.0.get(key)
+    }
+
+    fn set(&mut self, key: &str, value: Value) -> Result<(), Error> {
+        self.0.set(key, value)
+    }
+
+    fn reset_and_clear(&mut self) -> Result<(), Error> {
+        self.0.reset_and_clear()
+    }
+}
+
+impl CryptoStorage for BoxStorage {
+    fn create_key(&mut self, name: &str, policy: &Policy) -> Result<Ed25519PublicKey, Error> {
+        self.0.create_key(name, policy)
+    }
+
+    fn export_private_key(&self, name: &str) -> Result<Ed25519PrivateKey, Error> {
+        self.0.export_private_key(name)
+    }
+
+    fn export_private_key_for_version(
+        &self,
+        name: &str,
+        version: Ed25519PublicKey,
+    ) -> Result<Ed25519PrivateKey, Error> {
+        self.0.export_private_key_for_version(name, version)
+    }
+
+    fn get_public_key(&self, name: &str) -> Result<PublicKeyResponse, Error> {
+        self.0.get_public_key(name)
+    }
+
+    fn rotate_key(&mut self, name: &str) -> Result<Ed25519PublicKey, Error> {
+        self.0.rotate_key(name)
+    }
+
+    fn sign_message(&mut self, name: &str, message: &HashValue) -> Result<Ed25519Signature, Error> {
+        self.0.sign_message(name, message)
+    }
+
+    fn sign_message_using_version(
+        &mut self,
+        name: &str,
+        version: Ed25519PublicKey,
+        message: &HashValue,
+    ) -> Result<Ed25519Signature, Error> {
+        self.0.sign_message_using_version(name, version, message)
+    }
+}


### PR DESCRIPTION
* Move default initialization to test
* Use SecureBackend::TryInt::<Box<DynStorage>> where possible
* Eliminate an unnecessary default impl

also fix a security bug where we inadvertently print the token to a log