### PR TITLE
[storage] add counters to track commit frequency / size

### DIFF
--- a/consensus/src/consensusdb/mod.rs
+++ b/consensus/src/consensusdb/mod.rs
@@ -36,7 +36,7 @@ impl ConsensusDB {
 
         let path = db_root_path.as_ref().join("consensusdb");
         let instant = Instant::now();
-        let db = DB::open(path.clone(), column_families)
+        let db = DB::open(path.clone(), "consensus", column_families)
             .expect("ConsensusDB open failed; unable to continue");
 
         info!(

--- a/storage/libradb/src/lib.rs
+++ b/storage/libradb/src/lib.rs
@@ -155,9 +155,9 @@ impl LibraDB {
         let instant = Instant::now();
 
         let db = Arc::new(if readonly {
-            DB::open_readonly(path.clone(), column_families)?
+            DB::open_readonly(path.clone(), "libradb_ro", column_families)?
         } else {
-            DB::open(path.clone(), column_families)?
+            DB::open(path.clone(), "libradb", column_families)?
         });
 
         info!(

--- a/storage/schemadb/tests/db.rs
+++ b/storage/schemadb/tests/db.rs
@@ -80,11 +80,11 @@ fn get_column_families() -> Vec<ColumnFamilyName> {
 }
 
 fn open_db(dir: &libra_temppath::TempPath) -> DB {
-    DB::open(&dir.path(), get_column_families()).expect("Failed to open DB.")
+    DB::open(&dir.path(), "test", get_column_families()).expect("Failed to open DB.")
 }
 
 fn open_db_read_only(dir: &libra_temppath::TempPath) -> DB {
-    DB::open_readonly(&dir.path(), get_column_families()).expect("Failed to open DB.")
+    DB::open_readonly(&dir.path(), "test", get_column_families()).expect("Failed to open DB.")
 }
 
 struct TestDB {

--- a/storage/schemadb/tests/iterator.rs
+++ b/storage/schemadb/tests/iterator.rs
@@ -79,7 +79,7 @@ impl TestDB {
     fn new() -> Self {
         let tmpdir = libra_temppath::TempPath::new();
         let column_families = vec![DEFAULT_CF_NAME, TestSchema::COLUMN_FAMILY_NAME];
-        let db = DB::open(&tmpdir.path(), column_families).unwrap();
+        let db = DB::open(&tmpdir.path(), "test", column_families).unwrap();
 
         db.put::<TestSchema>(&TestKey(1, 0, 0), &TestValue(100))
             .unwrap();


### PR DESCRIPTION

## Motivation

Suspecting most writes are from consensus DB when the network  is idle (running empty blocks only)

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?

yes
## Test Plan

clippy and eyeballs

## Related PRs

(If this PR adds or changes functionality, please take some time to update the docs at https://github.com/libra/website, and link to your PR here.)
