### PR TITLE
[CI] half e2e test parallelism

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -249,7 +249,7 @@ jobs:
             - target/debug/deps/libratest*
   run-e2e-test:
     executor: test-executor
-    parallelism: 8
+    parallelism: 4
     description: Run E2E tests in parallel. Each container runs a subset of
       test targets.
     environment:


### PR DESCRIPTION
## Motivation
Following up 9fe06c79, half the e2e test parallelism as the test job is no longer on the critical path.

Based on https://circleci.com/pricing/, we can save ~58% credits.
```
|                       |                Before (a5263e3)     |                After              |
| Job Name              | Tier      | Exec time     | Credits | Tier        | Exec time | Credits |
|-------------------------------------------------------------------------------------------------|
| prefetch-crates       | xlarge        | ~  0:45   |   40    | medium      | ~  1:00   |   10    |
| build-dev             | 2xlarge+      | ~  7:00   |  700    | 2xlarge     | ~  7:30   |  640    |
| build-release         | 2xlarge+      | ~  6:15   |  700    | xlarge      | ~ 11:30   |  480    |
| build-e2e-test        | 2xlarge+      | ~  3:30   |  400    | xlarge      | ~  3:30   |  160    |
| run-e2e-test          | 2xlarge+ (8x) | ~  5:45   | 4800    | xlarge (4x) | ~  7:30   | 1280    |
| run-unit-test         | 2xlarge+      | ~ 13:15   | 1400    | 2xlarge     | ~ 13:30   | 1120    |
| run-crypto-unit-test  | xlarge        | ~  1:30   |   80    | medium      | ~  1:45   |   20    |
| validate-cluster-test | 2xlarge+      | ~  0:30   |  100    | medium      | ~  0:45   |   10    |
|-------------------------------------------------------------------------------------------------|
  Total workflow time   |                 ~ 14:06   | 8820    |               ~ 14:36   | 3720    |
```

## Test Plan
CI