### PR TITLE
[shared mempool] tune libra channel for DDoS prevention

### DIFF
--- a/common/channel/src/message_queues_test.rs
+++ b/common/channel/src/message_queues_test.rs
@@ -136,6 +136,65 @@ fn test_lifo() {
 }
 
 #[test]
+fn test_klast() {
+    let mut q = PerKeyQueue::new(QueueStyle::KLAST, NonZeroUsize::new(3).unwrap(), None);
+    let validator = AccountAddress::new([0u8; AccountAddress::LENGTH]);
+
+    // Test order
+    q.push(
+        validator,
+        ProposalMsg {
+            msg: "msg1".to_string(),
+        },
+    );
+    q.push(
+        validator,
+        ProposalMsg {
+            msg: "msg2".to_string(),
+        },
+    );
+    q.push(
+        validator,
+        ProposalMsg {
+            msg: "msg3".to_string(),
+        },
+    );
+    assert_eq!(q.pop().unwrap().msg, "msg1".to_string());
+    assert_eq!(q.pop().unwrap().msg, "msg2".to_string());
+    assert_eq!(q.pop().unwrap().msg, "msg3".to_string());
+
+    // Test max queue size
+    q.push(
+        validator,
+        ProposalMsg {
+            msg: "msg1".to_string(),
+        },
+    );
+    q.push(
+        validator,
+        ProposalMsg {
+            msg: "msg2".to_string(),
+        },
+    );
+    q.push(
+        validator,
+        ProposalMsg {
+            msg: "msg3".to_string(),
+        },
+    );
+    q.push(
+        validator,
+        ProposalMsg {
+            msg: "msg4".to_string(),
+        },
+    );
+    assert_eq!(q.pop().unwrap().msg, "msg2".to_string());
+    assert_eq!(q.pop().unwrap().msg, "msg3".to_string());
+    assert_eq!(q.pop().unwrap().msg, "msg4".to_string());
+    assert_eq!(q.pop(), None);
+}
+
+#[test]
 fn test_fifo_round_robin() {
     let mut q = PerKeyQueue::new(QueueStyle::FIFO, NonZeroUsize::new(3).unwrap(), None);
     let validator1 = AccountAddress::new([0u8; AccountAddress::LENGTH]);
@@ -272,6 +331,77 @@ fn test_lifo_round_robin() {
         q.pop().unwrap(),
         ProposalMsg {
             msg: "validator1_msg1".to_string(),
+        }
+    );
+    assert_eq!(q.pop(), None);
+}
+
+#[test]
+fn test_klast_round_robin() {
+    let mut q = PerKeyQueue::new(QueueStyle::KLAST, NonZeroUsize::new(3).unwrap(), None);
+    let validator1 = AccountAddress::new([0u8; AccountAddress::LENGTH]);
+    let validator2 = AccountAddress::new([1u8; AccountAddress::LENGTH]);
+    let validator3 = AccountAddress::new([2u8; AccountAddress::LENGTH]);
+
+    q.push(
+        validator1,
+        ProposalMsg {
+            msg: "validator1_msg1".to_string(),
+        },
+    );
+    q.push(
+        validator1,
+        ProposalMsg {
+            msg: "validator1_msg2".to_string(),
+        },
+    );
+    q.push(
+        validator1,
+        ProposalMsg {
+            msg: "validator1_msg3".to_string(),
+        },
+    );
+    q.push(
+        validator2,
+        ProposalMsg {
+            msg: "validator2_msg1".to_string(),
+        },
+    );
+    q.push(
+        validator3,
+        ProposalMsg {
+            msg: "validator3_msg1".to_string(),
+        },
+    );
+
+    assert_eq!(
+        q.pop().unwrap(),
+        ProposalMsg {
+            msg: "validator1_msg1".to_string(),
+        }
+    );
+    assert_eq!(
+        q.pop().unwrap(),
+        ProposalMsg {
+            msg: "validator2_msg1".to_string(),
+        }
+    );
+    assert_eq!(
+        q.pop().unwrap(),
+        ProposalMsg {
+            msg: "validator3_msg1".to_string(),
+        }
+    );
+    assert_eq!(
+        q.pop().unwrap(),
+        ProposalMsg {
+            msg: "validator1_msg2".to_string(),
+        }
+    );
+    assert_eq!(
+        q.pop().unwrap(),
+        ProposalMsg {
+            msg: "validator1_msg3".to_string(),
         }
     );
     assert_eq!(q.pop(), None);

--- a/config/src/config/mempool_config.rs
+++ b/config/src/config/mempool_config.rs
@@ -11,6 +11,7 @@ pub struct MempoolConfig {
     pub shared_mempool_batch_size: usize,
     pub shared_mempool_max_concurrent_inbound_syncs: usize,
     pub shared_mempool_min_broadcast_recipient_count: Option<usize>,
+    pub max_broadcasts_per_peer: usize,
     pub capacity: usize,
     // max number of transactions per user in Mempool
     pub capacity_per_user: usize,
@@ -26,6 +27,7 @@ impl Default for MempoolConfig {
             shared_mempool_batch_size: 100,
             shared_mempool_max_concurrent_inbound_syncs: 100,
             shared_mempool_min_broadcast_recipient_count: None,
+            max_broadcasts_per_peer: 25,
             capacity: 1_000_000,
             capacity_per_user: 100,
             system_transaction_timeout_secs: 86400,

--- a/consensus/src/network_interface.rs
+++ b/consensus/src/network_interface.rs
@@ -24,7 +24,7 @@ use network::{
         network::{NetworkEvents, NetworkSender},
         rpc::error::RpcError,
     },
-    validator_network::network_builder::NetworkBuilder,
+    validator_network::network_builder::{NetworkBuilder, NETWORK_CHANNEL_SIZE},
     ProtocolId,
 };
 use serde::{Deserialize, Serialize};
@@ -87,6 +87,7 @@ pub fn add_to_network<T: Payload>(
             vec![ProtocolId::ConsensusRpc],
             vec![ProtocolId::ConsensusDirectSend],
             QueueStyle::LIFO,
+            NETWORK_CHANNEL_SIZE,
             Some(&counters::PENDING_CONSENSUS_NETWORK_EVENTS),
         );
     (

--- a/libra-node/src/main_node.rs
+++ b/libra-node/src/main_node.rs
@@ -279,8 +279,10 @@ pub fn setup_environment(node_config: &mut NodeConfig) -> LibraHandle {
             state_synchronizer::network::add_to_network(&mut network_builder);
         state_sync_network_handles.push((network.peer_id, state_sync_sender, state_sync_events));
 
-        let (mempool_sender, mempool_events) =
-            libra_mempool::network::add_to_network(&mut network_builder);
+        let (mempool_sender, mempool_events) = libra_mempool::network::add_to_network(
+            &mut network_builder,
+            node_config.mempool.max_broadcasts_per_peer,
+        );
         mempool_network_handles.push((network.peer_id, mempool_sender, mempool_events));
         validator_network_provider = Some((network.peer_id, runtime, network_builder));
     }
@@ -301,8 +303,10 @@ pub fn setup_environment(node_config: &mut NodeConfig) -> LibraHandle {
             state_sync_sender,
             state_sync_events,
         ));
-        let (mempool_sender, mempool_events) =
-            libra_mempool::network::add_to_network(&mut network_builder);
+        let (mempool_sender, mempool_events) = libra_mempool::network::add_to_network(
+            &mut network_builder,
+            node_config.mempool.max_broadcasts_per_peer,
+        );
         mempool_network_handles.push((full_node_network.peer_id, mempool_sender, mempool_events));
 
         // Start the network provider.

--- a/mempool/src/shared_mempool/network.rs
+++ b/mempool/src/shared_mempool/network.rs
@@ -60,12 +60,14 @@ pub struct MempoolNetworkSender {
 /// Receiver (Events) that explicitly returns only said ProtocolId.
 pub fn add_to_network(
     network: &mut NetworkBuilder,
+    max_broadcasts_per_peer: usize,
 ) -> (MempoolNetworkSender, MempoolNetworkEvents) {
     let (sender, receiver, connection_reqs_tx, connection_notifs_rx) = network
         .add_protocol_handler(
             vec![],
             vec![ProtocolId::MempoolDirectSend],
-            QueueStyle::LIFO,
+            QueueStyle::KLAST,
+            max_broadcasts_per_peer,
             Some(&counters::PENDING_MEMPOOL_NETWORK_EVENTS),
         );
     (

--- a/network/onchain-discovery/src/network_interface.rs
+++ b/network/onchain-discovery/src/network_interface.rs
@@ -15,7 +15,7 @@ use network::{
         PeerManagerRequestSender,
     },
     protocols::{network::NetworkSender, rpc::error::RpcError},
-    validator_network::network_builder::NetworkBuilder,
+    validator_network::network_builder::{NetworkBuilder, NETWORK_CHANNEL_SIZE},
     ProtocolId,
 };
 use std::{convert::TryFrom, time::Duration};
@@ -86,6 +86,7 @@ pub fn add_to_network(
             vec![ProtocolId::OnchainDiscoveryRpc],
             vec![],
             QueueStyle::LIFO,
+            NETWORK_CHANNEL_SIZE,
             // Some(&counters::PENDING_CONSENSUS_NETWORK_EVENTS),
             // TODO(philiphayes): add a counter for onchain discovery
             None,

--- a/network/src/protocols/discovery/mod.rs
+++ b/network/src/protocols/discovery/mod.rs
@@ -37,7 +37,7 @@ use crate::{
     error::{NetworkError, NetworkErrorKind},
     peer_manager::{ConnectionRequestSender, PeerManagerRequestSender},
     protocols::network::{Event, NetworkEvents, NetworkSender},
-    validator_network::network_builder::NetworkBuilder,
+    validator_network::network_builder::{NetworkBuilder, NETWORK_CHANNEL_SIZE},
     NetworkPublicKeys, ProtocolId,
 };
 use bytes::Bytes;
@@ -100,6 +100,7 @@ pub fn add_to_network(
             vec![],
             vec![ProtocolId::DiscoveryDirectSend],
             QueueStyle::LIFO,
+            NETWORK_CHANNEL_SIZE,
             Some(&counters::PENDING_DISCOVERY_NETWORK_EVENTS),
         );
     (

--- a/network/src/protocols/health_checker/mod.rs
+++ b/network/src/protocols/health_checker/mod.rs
@@ -25,7 +25,7 @@ use crate::{
         network::{Event, NetworkEvents, NetworkSender},
         rpc::error::RpcError,
     },
-    validator_network::network_builder::NetworkBuilder,
+    validator_network::network_builder::{NetworkBuilder, NETWORK_CHANNEL_SIZE},
     ProtocolId,
 };
 use bytes::Bytes;
@@ -73,6 +73,7 @@ pub fn add_to_network(
             vec![ProtocolId::HealthCheckerRpc],
             vec![],
             QueueStyle::LIFO,
+            NETWORK_CHANNEL_SIZE,
             Some(&counters::PENDING_HEALTH_CHECKER_NETWORK_EVENTS),
         );
     (

--- a/network/src/protocols/network/dummy.rs
+++ b/network/src/protocols/network/dummy.rs
@@ -10,7 +10,7 @@ use crate::{
         network::{Event, NetworkEvents, NetworkSender},
         rpc::error::RpcError,
     },
-    validator_network::network_builder::{NetworkBuilder, TransportType},
+    validator_network::network_builder::{NetworkBuilder, TransportType, NETWORK_CHANNEL_SIZE},
     NetworkPublicKeys, ProtocolId,
 };
 use channel::message_queues::QueueStyle;
@@ -38,6 +38,7 @@ fn add_to_network(network: &mut NetworkBuilder) -> (DummyNetworkSender, DummyNet
             vec![TEST_RPC_PROTOCOL],
             vec![TEST_DIRECT_SEND_PROTOCOL],
             QueueStyle::LIFO,
+            NETWORK_CHANNEL_SIZE,
             None,
         );
     (

--- a/network/src/validator_network/network_builder.rs
+++ b/network/src/validator_network/network_builder.rs
@@ -311,6 +311,7 @@ impl NetworkBuilder {
         rpc_protocols: Vec<ProtocolId>,
         direct_send_protocols: Vec<ProtocolId>,
         queue_preference: QueueStyle,
+        max_queue_size_per_peer: usize,
         counter: Option<&'static IntCounterVec>,
     ) -> (
         PeerManagerRequestSender,
@@ -323,7 +324,7 @@ impl NetworkBuilder {
         self.rpc_protocols.extend(rpc_protocols.clone());
         let (network_notifs_tx, network_notifs_rx) = libra_channel::new(
             queue_preference,
-            NonZeroUsize::new(self.channel_size).unwrap(),
+            NonZeroUsize::new(max_queue_size_per_peer).unwrap(),
             counter,
         );
         for protocol in rpc_protocols

--- a/state-synchronizer/src/network.rs
+++ b/state-synchronizer/src/network.rs
@@ -10,7 +10,7 @@ use network::{
     error::NetworkError,
     peer_manager::{ConnectionRequestSender, PeerManagerRequestSender},
     protocols::network::{NetworkEvents, NetworkSender},
-    validator_network::network_builder::NetworkBuilder,
+    validator_network::network_builder::{NetworkBuilder, NETWORK_CHANNEL_SIZE},
     ProtocolId,
 };
 use serde::{Deserialize, Serialize};
@@ -51,6 +51,7 @@ pub fn add_to_network(
             vec![],
             vec![ProtocolId::StateSynchronizerDirectSend],
             QueueStyle::FIFO,
+            NETWORK_CHANNEL_SIZE,
             Some(&counters::PENDING_STATE_SYNCHRONIZER_NETWORK_EVENTS),
         );
     (


### PR DESCRIPTION
this PR adds basic DDoS protection to SMP from noisy peers. Also it helps to prevent scenarios where mempool will try to replay old messages wasting CPU and IO resources.
For that libra channel basic functionality is used. Channel size per peer is set to configurable value on node startup.
New eviction policy is introduced KLAST. If chosen, it will keep latest k messages per peer in channel, but normal consumption in non-saturated channel will be FIFO-based     

_notes_ 
* PR changes signature of add_protocol_handler to specify size of libra channel
* for all other protocols existing default value is used(1024). Although we should modify them as well. For example for state sync it should be 1. 
* mempool uses new config value max_broadcasts_per_peer (25 default for now)
* new eviction policy is added to libra_channel KLAST  