### PR TITLE
[move-prover] Transforms and analyses for eliminating mutable references

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4909,6 +4909,7 @@ name = "stackless-bytecode-generator"
 version = "0.1.0"
 dependencies = [
  "anyhow 1.0.28 (registry+https://github.com/rust-lang/crates.io-index)",
+ "borrow-graph 0.0.1",
  "bytecode-verifier 0.1.0",
  "codespan 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "codespan-reporting 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/language/borrow-graph/src/graph.rs
+++ b/language/borrow-graph/src/graph.rs
@@ -51,7 +51,6 @@ impl<Loc: Copy, Lbl: Clone + Ord> BorrowGraph<Loc, Lbl> {
         let mut field_borrows: BTreeMap<Lbl, BTreeMap<RefID, Loc>> = BTreeMap::new();
         for (borrower, edges) in &borrowed_by.0 {
             let borrower = *borrower;
-            let edges: &BTreeSet<BorrowEdge<Loc, Lbl>> = edges;
             for edge in edges {
                 match edge.path.get(0) {
                     None => full_borrows.insert(borrower, edge.loc),
@@ -63,6 +62,40 @@ impl<Loc: Copy, Lbl: Clone + Ord> BorrowGraph<Loc, Lbl> {
             }
         }
         (full_borrows, field_borrows)
+    }
+
+    /// Return the edges between parent and child
+    pub fn between_edges(&self, parent: RefID, child: RefID) -> Vec<(Loc, Path<Lbl>, bool)> {
+        let edges = &self.0.get(&parent).unwrap().borrowed_by.0[&child];
+        edges
+            .iter()
+            .map(|edge| (edge.loc, edge.path.clone(), edge.strong))
+            .collect()
+    }
+
+    /// Return the outgoing edges from id
+    pub fn out_edges(&self, id: RefID) -> Vec<(Loc, Path<Lbl>, bool, RefID)> {
+        let mut returned_edges = vec![];
+        let borrowed_by = &self.0.get(&id).unwrap().borrowed_by;
+        for (borrower, edges) in &borrowed_by.0 {
+            let borrower = *borrower;
+            for edge in edges {
+                returned_edges.push((edge.loc, edge.path.clone(), edge.strong, borrower));
+            }
+        }
+        returned_edges
+    }
+
+    /// Return the incoming edges into id
+    pub fn in_edges(&self, id: RefID) -> Vec<(Loc, RefID, Path<Lbl>, bool)> {
+        let mut returned_edges = vec![];
+        let borrows_from = &self.0.get(&id).unwrap().borrows_from;
+        for src in borrows_from {
+            for edge in self.between_edges(*src, id) {
+                returned_edges.push((edge.0, *src, edge.1, edge.2));
+            }
+        }
+        returned_edges
     }
 
     //**********************************************************************************************

--- a/language/move-prover/spec-lang/src/env.rs
+++ b/language/move-prover/spec-lang/src/env.rs
@@ -1492,6 +1492,20 @@ impl<'env> FunctionEnv<'env> {
         &self.data.spec
     }
 
+    /// Returns the acquired global resource types.
+    pub fn get_acquires_global_resources(&'env self) -> Vec<StructId> {
+        let function_definition = self
+            .module_env
+            .data
+            .module
+            .function_def_at(self.get_def_idx());
+        function_definition
+            .acquires_global_resources
+            .iter()
+            .map(|x| self.module_env.get_struct_id(*x))
+            .collect()
+    }
+
     fn definition_view(&'env self) -> FunctionDefinitionView<'env, CompiledModule> {
         FunctionDefinitionView::new(
             &self.module_env.data.module,

--- a/language/move-prover/src/bytecode_translator.rs
+++ b/language/move-prover/src/bytecode_translator.rs
@@ -840,6 +840,7 @@ impl<'env> ModuleTranslator<'env> {
 
         // Translate the bytecode instruction.
         match bytecode {
+            WriteBack(..) | UnpackRef(..) | PackRef(..) | Splice(..) => unimplemented!(),
             SpecBlock(_, block_id) => {
                 self.generate_function_spec_inside_impl(func_target, *block_id);
             }

--- a/language/move-prover/stackless-bytecode-generator/Cargo.toml
+++ b/language/move-prover/stackless-bytecode-generator/Cargo.toml
@@ -13,6 +13,7 @@ edition = "2018"
 spec-lang = { path = "../spec-lang", version = "0.0.1" }
 vm = { path = "../../vm", version = "0.1.0" }
 bytecode-verifier = { path = "../../bytecode-verifier", version = "0.1.0" }
+borrow-graph = { path = "../../borrow-graph", version = "0.0.1" }
 ir-to-bytecode = { path = "../../compiler/ir-to-bytecode", version = "0.1.0" }
 libra-workspace-hack = { path = "../../../common/workspace-hack", version = "0.1.0" }
 num = "0.2.0"

--- a/language/move-prover/stackless-bytecode-generator/src/annotations.rs
+++ b/language/move-prover/stackless-bytecode-generator/src/annotations.rs
@@ -30,4 +30,10 @@ impl Annotations {
         let id = TypeId::of::<T>();
         self.map.insert(id, Box::new(x));
     }
+
+    /// Removes annotation of type T.
+    pub fn remove<T: Any>(&mut self) -> Option<Box<T>> {
+        let id = TypeId::of::<T>();
+        self.map.remove(&id).and_then(|d| d.downcast::<T>().ok())
+    }
 }

--- a/language/move-prover/stackless-bytecode-generator/src/borrow_analysis.rs
+++ b/language/move-prover/stackless-bytecode-generator/src/borrow_analysis.rs
@@ -1,0 +1,605 @@
+// Copyright (c) The Libra Core Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::{
+    dataflow_analysis::{
+        AbstractDomain, DataflowAnalysis, JoinResult, StateMap, TransferFunctions,
+    },
+    function_target::{FunctionTarget, FunctionTargetData},
+    function_target_pipeline::{FunctionTargetProcessor, FunctionTargetsHolder},
+    livevar_analysis::LiveVarAnnotation,
+    stackless_bytecode::{AssignKind, BorrowNode, Bytecode, Operation, StructDecl, TempIndex},
+    stackless_control_flow_graph::{BlockId, StacklessControlFlowGraph},
+};
+use borrow_graph::references::RefID;
+use itertools::Itertools;
+use spec_lang::env::FunctionEnv;
+use std::collections::{BTreeMap, BTreeSet};
+use vm::file_format::CodeOffset;
+
+#[derive(Debug, Clone, Eq, Ord, PartialEq, PartialOrd)]
+struct Field {
+    struct_decl: StructDecl,
+    field_offset: usize,
+}
+
+type BorrowGraph = borrow_graph::graph::BorrowGraph<(), Field>;
+
+#[derive(Debug, Clone)]
+pub struct BorrowInfo {
+    pub live_refs: BTreeSet<TempIndex>,
+    pub borrowed_by: BTreeMap<BorrowNode, BTreeSet<BorrowNode>>,
+    pub borrows_from: BTreeMap<BorrowNode, BTreeSet<BorrowNode>>,
+}
+
+impl BorrowInfo {
+    fn is_empty(&self) -> bool {
+        self.live_refs.is_empty() && self.borrowed_by.is_empty() && self.borrows_from.is_empty()
+    }
+
+    fn borrow_info_str(&self, func_target: &FunctionTarget<'_>) -> String {
+        let live_refs_str = format!(
+            "live_refs: {}",
+            self.live_refs
+                .iter()
+                .map(|idx| {
+                    let name = func_target.get_local_name(*idx);
+                    format!("{}", name.display(func_target.symbol_pool()),)
+                })
+                .join(", ")
+        );
+        let borrows_str = |(node, borrows): (&BorrowNode, &BTreeSet<BorrowNode>)| {
+            format!(
+                "{} -> {{{}}}",
+                node.display(func_target),
+                borrows
+                    .iter()
+                    .map(|borrow| borrow.display(func_target))
+                    .join(", ")
+            )
+        };
+        let borrowed_by_str = format!(
+            "borrowed_by: {}",
+            self.borrowed_by.iter().map(borrows_str).join(", ")
+        );
+        let borrows_from_str = format!(
+            "borrows_from: {}",
+            self.borrows_from.iter().map(borrows_str).join(", ")
+        );
+        format!("{} {} {}", live_refs_str, borrowed_by_str, borrows_from_str)
+    }
+}
+
+pub struct BorrowInfoAtCodeOffset {
+    pub before: BorrowInfo,
+    pub after: BorrowInfo,
+}
+
+/// Borrow annotation computed by the borrow analysis processor.
+pub struct BorrowAnnotation(BTreeMap<CodeOffset, BorrowInfoAtCodeOffset>);
+
+impl BorrowAnnotation {
+    pub fn get_borrow_info_at(&self, code_offset: CodeOffset) -> Option<&BorrowInfoAtCodeOffset> {
+        self.0.get(&code_offset)
+    }
+}
+
+#[derive(Debug, Clone)]
+struct PackError {
+    code_offset: CodeOffset,
+    indices: Vec<TempIndex>,
+}
+
+/// Borrow analysis processor.
+pub struct BorrowAnalysisProcessor {}
+
+impl BorrowAnalysisProcessor {
+    pub fn new() -> Box<Self> {
+        Box::new(BorrowAnalysisProcessor {})
+    }
+}
+
+impl FunctionTargetProcessor for BorrowAnalysisProcessor {
+    fn process(
+        &self,
+        _targets: &mut FunctionTargetsHolder,
+        func_env: &FunctionEnv<'_>,
+        mut data: FunctionTargetData,
+    ) -> FunctionTargetData {
+        let borrow_annotation = if func_env.is_native() {
+            // Native functions have no byte code.
+            BorrowAnnotation(BTreeMap::new())
+        } else {
+            let func_target = FunctionTarget::new(func_env, &data);
+            let mut analyzer = BorrowAnalysis::new(&func_target);
+            BorrowAnnotation(analyzer.analyze(&data.code))
+        };
+        // Annotate function target with computed borrow data.
+        data.annotations.set::<BorrowAnnotation>(borrow_annotation);
+        data.annotations.remove::<LiveVarAnnotation>();
+        data
+    }
+}
+
+#[derive(Debug, Clone, PartialEq)]
+struct BorrowState {
+    borrow_graph: BorrowGraph,
+    dead_edges: BTreeMap<BorrowNode, BTreeSet<BorrowNode>>,
+}
+
+impl BorrowState {}
+
+struct BorrowAnalysis<'a> {
+    func_target: &'a FunctionTarget<'a>,
+    livevar_annotation: &'a LiveVarAnnotation,
+    ref_id_to_borrow_node: BTreeMap<RefID, BorrowNode>,
+    borrow_node_to_ref_id: BTreeMap<BorrowNode, RefID>,
+}
+
+impl<'a> BorrowAnalysis<'a> {
+    fn new(func_target: &'a FunctionTarget<'a>) -> Self {
+        let livevar_annotation = func_target
+            .get_annotations()
+            .get::<LiveVarAnnotation>()
+            .expect("livevar annotation");
+
+        let mut ref_id_to_borrow_node = BTreeMap::new();
+        let mut borrow_node_to_ref_id = BTreeMap::new();
+        let local_count = func_target.get_local_count();
+        let parameter_count = func_target.get_parameter_count();
+        for idx in 0..local_count {
+            let ref_id = RefID::new(idx);
+            let ty = func_target.get_local_type(idx);
+            let borrow_node = if ty.is_reference() {
+                BorrowNode::Reference(idx)
+            } else {
+                BorrowNode::LocalRoot(idx)
+            };
+            ref_id_to_borrow_node.insert(ref_id, borrow_node.clone());
+            borrow_node_to_ref_id.insert(borrow_node, ref_id);
+            if ty.is_reference() && idx < parameter_count {
+                let ref_param_proxy_root_idx = Self::ref_param_proxy_root_idx(func_target, idx);
+                let ref_param_proxy_root = RefID::new(ref_param_proxy_root_idx);
+                ref_id_to_borrow_node.insert(ref_param_proxy_root, BorrowNode::LocalRoot(idx));
+                borrow_node_to_ref_id.insert(BorrowNode::LocalRoot(idx), ref_param_proxy_root);
+            }
+        }
+        let mut next_idx = local_count + parameter_count;
+        for struct_id in func_target.get_acquires_global_resources() {
+            let ref_id = RefID::new(next_idx);
+            let borrow_node = BorrowNode::GlobalRoot(StructDecl {
+                module_id: func_target.module_env().get_id(),
+                struct_id: *struct_id,
+            });
+            ref_id_to_borrow_node.insert(ref_id, borrow_node.clone());
+            borrow_node_to_ref_id.insert(borrow_node, ref_id);
+            next_idx += 1;
+        }
+        Self {
+            func_target,
+            livevar_annotation,
+            ref_id_to_borrow_node,
+            borrow_node_to_ref_id,
+        }
+    }
+
+    fn analyze(&mut self, instrs: &[Bytecode]) -> BTreeMap<CodeOffset, BorrowInfoAtCodeOffset> {
+        let cfg = StacklessControlFlowGraph::new_forward(instrs);
+        let mut borrow_graph = BorrowGraph::new();
+        for (ref_id, _) in self
+            .ref_id_to_borrow_node
+            .iter()
+            .filter(|(_, node)| match node {
+                BorrowNode::Reference(..) => false,
+                _ => true,
+            })
+        {
+            borrow_graph.new_ref(*ref_id, true);
+        }
+        for idx in 0..self.func_target.get_parameter_count() {
+            if self.func_target.get_local_type(idx).is_reference() {
+                let ref_id = RefID::new(idx);
+                borrow_graph.new_ref(ref_id, true);
+                borrow_graph.add_strong_borrow(
+                    (),
+                    RefID::new(Self::ref_param_proxy_root_idx(self.func_target, idx)),
+                    ref_id,
+                );
+            }
+        }
+        let initial_state = BorrowState {
+            borrow_graph,
+            dead_edges: BTreeMap::new(),
+        };
+        let state_map = self.analyze_function(initial_state, instrs, &cfg);
+        self.post_process(&cfg, instrs, state_map)
+    }
+
+    fn ref_param_proxy_root_idx(func_target: &FunctionTarget, ref_param_idx: usize) -> usize {
+        assert!(ref_param_idx < func_target.get_parameter_count());
+        func_target.get_local_count() + ref_param_idx
+    }
+
+    fn post_process(
+        &mut self,
+        cfg: &StacklessControlFlowGraph,
+        instrs: &[Bytecode],
+        state_map: StateMap<BorrowState, PackError>,
+    ) -> BTreeMap<CodeOffset, BorrowInfoAtCodeOffset> {
+        let mut result = BTreeMap::new();
+        for (block_id, block_state) in state_map {
+            let mut state = block_state.pre;
+            for offset in cfg.instr_indexes(block_id) {
+                let instr = &instrs[offset as usize];
+                let before = self.convert_state_to_info(&state);
+                state = self.execute(state, instr, offset).unwrap();
+                let after = self.convert_state_to_info(&state);
+                result.insert(offset, BorrowInfoAtCodeOffset { before, after });
+            }
+        }
+        result
+    }
+
+    fn convert_state_to_info(&self, borrow_state: &BorrowState) -> BorrowInfo {
+        let all_ref_ids = borrow_state.borrow_graph.all_refs();
+        let live_refs = (0..self.func_target.get_local_count())
+            .filter(|idx| {
+                if self.func_target.get_local_type(*idx).is_reference() {
+                    all_ref_ids.contains(&RefID::new(*idx))
+                } else {
+                    false
+                }
+            })
+            .collect();
+        let mut borrowed_by = BTreeMap::new();
+        let mut borrows_from = BTreeMap::new();
+        for ref_id in self.ref_id_to_borrow_node.keys() {
+            if all_ref_ids.contains(ref_id) {
+                let edges = borrow_state.borrow_graph.out_edges(*ref_id);
+                for edge in edges {
+                    let src = &self.ref_id_to_borrow_node[ref_id];
+                    let dest = &self.ref_id_to_borrow_node[&edge.3];
+                    Self::add_edge(&mut borrowed_by, src, dest);
+                    Self::add_edge(&mut borrows_from, dest, src);
+                }
+            }
+        }
+        for (src, dests) in &borrow_state.dead_edges {
+            for dest in dests {
+                Self::add_edge(&mut borrowed_by, src, dest);
+                Self::add_edge(&mut borrows_from, dest, src);
+            }
+        }
+        BorrowInfo {
+            live_refs,
+            borrowed_by,
+            borrows_from,
+        }
+    }
+
+    fn add_edge(
+        edges: &mut BTreeMap<BorrowNode, BTreeSet<BorrowNode>>,
+        at: &BorrowNode,
+        node: &BorrowNode,
+    ) {
+        edges.entry(at.clone()).or_insert_with(BTreeSet::new);
+        edges.entry(at.clone()).and_modify(|x| {
+            x.insert(node.clone());
+        });
+    }
+
+    fn add_edges(
+        edges: &mut BTreeMap<BorrowNode, BTreeSet<BorrowNode>>,
+        other: &BTreeMap<BorrowNode, BTreeSet<BorrowNode>>,
+    ) {
+        for x in other.keys() {
+            for y in &other[x] {
+                BorrowAnalysis::add_edge(edges, x, y);
+            }
+        }
+    }
+
+    fn is_subset(
+        other: &BTreeMap<BorrowNode, BTreeSet<BorrowNode>>,
+        edges: &BTreeMap<BorrowNode, BTreeSet<BorrowNode>>,
+    ) -> bool {
+        other
+            .iter()
+            .all(|(x, y)| edges.contains_key(x) && y.is_subset(&edges[x]))
+    }
+
+    fn error_indices(&self, state: &BorrowState, dests: Vec<TempIndex>) -> Vec<TempIndex> {
+        let mut indices = vec![];
+        let all_refs = state.borrow_graph.all_refs();
+        for idx in dests {
+            if self.func_target.get_local_type(idx).is_reference()
+                && (all_refs.contains(&RefID::new(idx))
+                    || state.dead_edges.contains_key(&BorrowNode::Reference(idx)))
+            {
+                indices.push(idx);
+            }
+        }
+        indices
+    }
+
+    fn remap_borrow_node(&self, node: &BorrowNode, id_map: &BTreeMap<RefID, RefID>) -> BorrowNode {
+        match node {
+            BorrowNode::Reference(idx) => {
+                let ref_id = RefID::new(*idx);
+                let node = if id_map.contains_key(&ref_id) {
+                    &self.ref_id_to_borrow_node[&id_map[&ref_id]]
+                } else {
+                    node
+                };
+                node.clone()
+            }
+            _ => node.clone(),
+        }
+    }
+
+    fn remap_edges(
+        &self,
+        edges: &mut BTreeMap<BorrowNode, BTreeSet<BorrowNode>>,
+        id_map: &BTreeMap<RefID, RefID>,
+    ) {
+        *edges = edges
+            .iter()
+            .map(|(src, dests)| {
+                (
+                    self.remap_borrow_node(src, id_map),
+                    dests
+                        .iter()
+                        .map(|dest| self.remap_borrow_node(dest, id_map))
+                        .collect(),
+                )
+            })
+            .collect();
+    }
+
+    fn execute(
+        &mut self,
+        pre: BorrowState,
+        instr: &Bytecode,
+        code_offset: CodeOffset,
+    ) -> Result<BorrowState, PackError> {
+        use Bytecode::*;
+        let mut post = pre;
+
+        // error if any unpacked ref (live or dead) is being overwritten by the instruction
+        let mut indices = vec![];
+        match instr {
+            Assign(_, dest, _, _) => indices.push(*dest),
+            Call(_, dests, _, _) => indices = dests.clone(),
+            _ => {}
+        };
+        indices = self.error_indices(&post, indices);
+        if !indices.is_empty() {
+            return Err(PackError {
+                code_offset,
+                indices,
+            });
+        }
+
+        // apply changes to post.borrow_graph based on the instruction
+        match instr {
+            Assign(_, dest, src, kind) => {
+                if self.func_target.get_local_type(*dest).is_reference() {
+                    let dest_ref_id = RefID::new(*dest);
+                    let src_ref_id = RefID::new(*src);
+                    match kind {
+                        AssignKind::Move | AssignKind::Store => {
+                            let mut id_map = BTreeMap::new();
+                            id_map.insert(src_ref_id, dest_ref_id);
+                            post.borrow_graph.remap_refs(&id_map);
+                            self.remap_edges(&mut post.dead_edges, &id_map);
+                        }
+                        AssignKind::Copy => {
+                            post.borrow_graph.new_ref(dest_ref_id, true);
+                            post.borrow_graph
+                                .add_strong_borrow((), src_ref_id, dest_ref_id);
+                        }
+                    }
+                }
+            }
+            Call(_, dests, oper, srcs) => {
+                use Operation::*;
+                match oper {
+                    BorrowLoc => {
+                        let dest = dests[0];
+                        let dest_ref_id = RefID::new(dest);
+                        let src = srcs[0];
+                        let src_ref_id = RefID::new(src);
+                        post.borrow_graph.new_ref(dest_ref_id, true);
+                        post.borrow_graph
+                            .add_strong_borrow((), src_ref_id, dest_ref_id);
+                    }
+                    BorrowGlobal(mid, sid, _) => {
+                        let dest = dests[0];
+                        let dest_ref_id = RefID::new(dest);
+                        let src_borrow_node = BorrowNode::GlobalRoot(StructDecl {
+                            module_id: *mid,
+                            struct_id: *sid,
+                        });
+                        let src_ref_id = self.borrow_node_to_ref_id[&src_borrow_node];
+                        post.borrow_graph.new_ref(dest_ref_id, true);
+                        post.borrow_graph
+                            .add_strong_borrow((), src_ref_id, dest_ref_id);
+                    }
+                    BorrowField(mid, sid, _, offset) => {
+                        let dest = dests[0];
+                        let dest_ref_id = RefID::new(dest);
+                        let src = srcs[0];
+                        let src_ref_id = RefID::new(src);
+                        post.borrow_graph.new_ref(dest_ref_id, true);
+                        post.borrow_graph.add_strong_field_borrow(
+                            (),
+                            src_ref_id,
+                            Field {
+                                struct_decl: StructDecl {
+                                    module_id: *mid,
+                                    struct_id: *sid,
+                                },
+                                field_offset: *offset,
+                            },
+                            dest_ref_id,
+                        );
+                    }
+                    Function(..) => {
+                        for src in srcs
+                            .iter()
+                            .filter(|idx| self.func_target.get_local_type(**idx).is_reference())
+                        {
+                            let src_ref_id = RefID::new(*src);
+                            for dest in dests
+                                .iter()
+                                .filter(|idx| self.func_target.get_local_type(**idx).is_reference())
+                            {
+                                let dest_ref_id = RefID::new(*dest);
+                                post.borrow_graph.new_ref(dest_ref_id, true);
+                                post.borrow_graph
+                                    .add_weak_borrow((), src_ref_id, dest_ref_id);
+                            }
+                        }
+                    }
+                    _ => {
+                        // Other operations do not create references
+                    }
+                }
+            }
+            _ => {
+                // Other instructions do not create references
+            }
+        }
+
+        // copy outgoing edges from dying refs in post.borrow_graph to post.dead_edges
+        // and release dying refs
+        let livevar_annotation_at = self
+            .livevar_annotation
+            .get_live_var_info_at(code_offset)
+            .unwrap();
+        for idx in livevar_annotation_at
+            .before
+            .difference(&livevar_annotation_at.after)
+        {
+            if self.func_target.get_local_type(*idx).is_reference() {
+                let ref_id = RefID::new(*idx);
+                if post.borrow_graph.contains_id(ref_id) {
+                    let borrow_node = &self.ref_id_to_borrow_node[&ref_id];
+                    let (full_borrows, field_borrows) = post.borrow_graph.borrowed_by(ref_id);
+                    for dest in full_borrows.keys() {
+                        Self::add_edge(
+                            &mut post.dead_edges,
+                            borrow_node,
+                            &self.ref_id_to_borrow_node[dest],
+                        );
+                    }
+                    for edges in field_borrows.values() {
+                        for dest in edges.keys() {
+                            Self::add_edge(
+                                &mut post.dead_edges,
+                                borrow_node,
+                                &self.ref_id_to_borrow_node[dest],
+                            );
+                        }
+                    }
+                    if !post.dead_edges.contains_key(borrow_node) {
+                        // add empty set if necessary to bootstrap the cleanup below
+                        post.dead_edges.insert(borrow_node.clone(), BTreeSet::new());
+                    }
+                    post.borrow_graph.release(ref_id);
+                }
+            }
+        }
+
+        // clean up post.dead_edges: remove nodes until every node has at least one outgoing edge
+        let mut dead_edges = std::mem::take(&mut post.dead_edges);
+        loop {
+            let (new_dead_edges, leaf_nodes) = Self::remove_leaves(dead_edges);
+            dead_edges = new_dead_edges;
+            if leaf_nodes.is_empty() {
+                break;
+            }
+            for (_, y) in dead_edges.iter_mut() {
+                for node in &leaf_nodes {
+                    y.remove(node);
+                }
+            }
+        }
+        post.dead_edges = dead_edges;
+
+        Ok(post)
+    }
+
+    fn remove_leaves(
+        dead_edges: BTreeMap<BorrowNode, BTreeSet<BorrowNode>>,
+    ) -> (BTreeMap<BorrowNode, BTreeSet<BorrowNode>>, Vec<BorrowNode>) {
+        let mut new_dead_edges = BTreeMap::new();
+        let mut leaf_nodes = vec![];
+        for (x, y) in dead_edges {
+            if y.is_empty() {
+                leaf_nodes.push(x);
+            } else {
+                new_dead_edges.insert(x, y);
+            }
+        }
+        (new_dead_edges, leaf_nodes)
+    }
+}
+
+impl<'a> TransferFunctions for BorrowAnalysis<'a> {
+    type State = BorrowState;
+    type AnalysisError = PackError;
+
+    fn execute_block(
+        &mut self,
+        block_id: BlockId,
+        pre_state: Self::State,
+        instrs: &[Bytecode],
+        cfg: &StacklessControlFlowGraph,
+    ) -> Result<Self::State, Self::AnalysisError> {
+        let mut state = pre_state;
+        for offset in cfg.instr_indexes(block_id) {
+            let instr = &instrs[offset as usize];
+            state = self.execute(state, instr, offset)?;
+        }
+        Ok(state)
+    }
+}
+
+impl<'a> DataflowAnalysis for BorrowAnalysis<'a> {}
+
+impl AbstractDomain for BorrowState {
+    fn join(&mut self, other: &Self) -> JoinResult {
+        let borrow_graph_unchanged = self.borrow_graph.leq(&other.borrow_graph);
+        if !borrow_graph_unchanged {
+            self.borrow_graph = self.borrow_graph.join(&other.borrow_graph);
+        }
+        let dead_edges_unchanged = BorrowAnalysis::is_subset(&other.dead_edges, &self.dead_edges);
+        if !dead_edges_unchanged {
+            BorrowAnalysis::add_edges(&mut self.dead_edges, &other.dead_edges);
+        }
+        if dead_edges_unchanged && borrow_graph_unchanged {
+            JoinResult::Unchanged
+        } else {
+            JoinResult::Changed
+        }
+    }
+}
+
+// =================================================================================================
+// Formatting
+
+/// Format a borrow annotation.
+pub fn format_borrow_annotation(
+    func_target: &FunctionTarget<'_>,
+    code_offset: CodeOffset,
+) -> Option<String> {
+    if let Some(BorrowAnnotation(map)) = func_target.get_annotations().get::<BorrowAnnotation>() {
+        if let Some(map_at) = map.get(&code_offset) {
+            if !map_at.before.is_empty() {
+                return Some(map_at.before.borrow_info_str(func_target));
+            }
+        }
+    }
+    None
+}

--- a/language/move-prover/stackless-bytecode-generator/src/eliminate_imm_refs.rs
+++ b/language/move-prover/stackless-bytecode-generator/src/eliminate_imm_refs.rs
@@ -27,7 +27,7 @@ impl FunctionTargetProcessor for EliminateImmRefsProcessor {
         func_env: &FunctionEnv<'_>,
         mut data: FunctionTargetData,
     ) -> FunctionTargetData {
-        let code = std::mem::replace(&mut data.code, vec![]);
+        let code = std::mem::take(&mut data.code);
         data.code = code
             .into_iter()
             .map(|bytecode| {
@@ -35,14 +35,14 @@ impl FunctionTargetProcessor for EliminateImmRefsProcessor {
                     .transform_bytecode(bytecode)
             })
             .collect();
-        let local_types = std::mem::replace(&mut data.local_types, vec![]);
+        let local_types = std::mem::take(&mut data.local_types);
         data.local_types = local_types
             .into_iter()
             .map(|ty| {
                 EliminateImmRefs::new(&FunctionTarget::new(func_env, &data)).transform_type(ty)
             })
             .collect();
-        let return_types = std::mem::replace(&mut data.return_types, vec![]);
+        let return_types = std::mem::take(&mut data.return_types);
         data.return_types = return_types
             .into_iter()
             .map(|ty| {

--- a/language/move-prover/stackless-bytecode-generator/src/eliminate_mut_refs.rs
+++ b/language/move-prover/stackless-bytecode-generator/src/eliminate_mut_refs.rs
@@ -1,0 +1,339 @@
+// Copyright (c) The Libra Core Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::{
+    borrow_analysis::BorrowAnnotation,
+    function_target::{FunctionTarget, FunctionTargetData},
+    function_target_pipeline::{FunctionTargetProcessor, FunctionTargetsHolder},
+    packref_analysis::{PackrefAnnotation, PackrefInstrumentation},
+    stackless_bytecode::{
+        AssignKind, AttrId, BorrowNode,
+        Bytecode::{self, *},
+        Operation::*,
+        TempIndex,
+    },
+    writeback_analysis::WritebackAnnotation,
+};
+use spec_lang::{env::FunctionEnv, ty::Type};
+use std::collections::BTreeMap;
+use vm::file_format::CodeOffset;
+
+pub struct EliminateMutRefsProcessor {}
+
+impl EliminateMutRefsProcessor {
+    pub fn new() -> Box<Self> {
+        Box::new(EliminateMutRefsProcessor {})
+    }
+}
+
+impl FunctionTargetProcessor for EliminateMutRefsProcessor {
+    fn process(
+        &self,
+        _targets: &mut FunctionTargetsHolder,
+        func_env: &FunctionEnv<'_>,
+        mut data: FunctionTargetData,
+    ) -> FunctionTargetData {
+        let local_types = &mut data.local_types;
+        let return_types = &mut data.return_types;
+
+        let mut param_proxy_map = BTreeMap::new();
+        let mut ref_param_proxy_map = BTreeMap::new();
+        for idx in 0..func_env.get_parameter_count() {
+            param_proxy_map.insert(idx, local_types.len());
+            local_types.push(EliminateMutRefs::transform_type(local_types[idx].clone()));
+            if local_types[idx].is_reference() {
+                let ty = local_types[idx].clone();
+                ref_param_proxy_map.insert(idx, local_types.len());
+                local_types.push(ty.clone());
+                return_types.push(EliminateMutRefs::transform_type(ty));
+            }
+        }
+
+        let mut max_ref_params_per_type = BTreeMap::new();
+        for bytecode in &data.code {
+            if let Call(_, _, Function(..), srcs) = bytecode {
+                let mut ref_params_per_type = BTreeMap::new();
+                for idx in srcs {
+                    let ty = &local_types[*idx];
+                    if ty.is_reference() {
+                        ref_params_per_type
+                            .entry(ty)
+                            .and_modify(|x| *x += 1)
+                            .or_insert_with(|| 1);
+                    }
+                }
+                for (ty, ref_params) in ref_params_per_type {
+                    max_ref_params_per_type
+                        .entry(ty.clone())
+                        .and_modify(|x| {
+                            if *x < ref_params {
+                                *x = ref_params;
+                            }
+                        })
+                        .or_insert_with(|| ref_params);
+                }
+            }
+        }
+        let mut ref_param_inout_proxy_map = BTreeMap::new();
+        for (ty, n) in max_ref_params_per_type {
+            let curr_len = local_types.len();
+            for _ in 0..n {
+                local_types.push(EliminateMutRefs::transform_type(ty.clone()));
+            }
+            ref_param_inout_proxy_map.insert(ty, curr_len);
+        }
+
+        // move inputs into the temporaries
+        let mut next_attr_id = data.code.len();
+        let mut new_code = vec![];
+        for idx in 0..func_env.get_parameter_count() {
+            new_code.push(Bytecode::Assign(
+                AttrId::new(next_attr_id),
+                param_proxy_map[&idx],
+                idx,
+                AssignKind::Move,
+            ));
+            next_attr_id += 1;
+        }
+
+        // take address of inputs that are references
+        for idx in 0..func_env.get_parameter_count() {
+            let ty = &local_types[idx];
+            if ty.is_reference() {
+                new_code.push(Bytecode::Call(
+                    AttrId::new(next_attr_id),
+                    vec![ref_param_proxy_map[&idx]],
+                    BorrowLoc,
+                    vec![param_proxy_map[&idx]],
+                ));
+                next_attr_id += 1;
+            }
+        }
+
+        // transform parameter types
+        data.local_types = data
+            .local_types
+            .into_iter()
+            .enumerate()
+            .map(|(idx, ty)| {
+                if idx < func_env.get_parameter_count() {
+                    EliminateMutRefs::transform_type(ty)
+                } else {
+                    ty
+                }
+            })
+            .collect();
+
+        // transform original code
+        data.annotations
+            .remove::<BorrowAnnotation>()
+            .expect("borrow annotation");
+        let writeback_annotation = *data
+            .annotations
+            .remove::<WritebackAnnotation>()
+            .expect("writeback annotation");
+        let packref_annotation = *data
+            .annotations
+            .remove::<PackrefAnnotation>()
+            .expect("packref annotation");
+        let code = std::mem::take(&mut data.code);
+        let func_target = FunctionTarget::new(func_env, &data);
+        let mut elim_mut_refs = EliminateMutRefs::new(
+            &func_target,
+            param_proxy_map,
+            ref_param_proxy_map,
+            ref_param_inout_proxy_map,
+            next_attr_id,
+        );
+        for (code_offset, bytecode) in code.into_iter().enumerate() {
+            let PackrefInstrumentation {
+                before: packref_instrs_before,
+                after: packref_instrs_after,
+            } = packref_annotation
+                .get_packref_instrumentation_at(code_offset as CodeOffset)
+                .unwrap();
+            let writeback_instrs = writeback_annotation
+                .get_writeback_instrs_at(code_offset as CodeOffset)
+                .unwrap();
+            new_code.append(&mut elim_mut_refs.transform_bytecodes(packref_instrs_before));
+            new_code.append(&mut elim_mut_refs.transform_bytecode(bytecode));
+            new_code.append(&mut elim_mut_refs.transform_bytecodes(writeback_instrs));
+            new_code.append(&mut elim_mut_refs.transform_bytecodes(packref_instrs_after));
+        }
+        data.code = new_code;
+        data
+    }
+}
+
+pub struct EliminateMutRefs<'a> {
+    func_target: &'a FunctionTarget<'a>,
+    param_proxy_map: BTreeMap<TempIndex, TempIndex>,
+    ref_param_proxy_map: BTreeMap<TempIndex, TempIndex>,
+    ref_param_inout_proxy_map: BTreeMap<Type, TempIndex>,
+    next_attr_id: usize,
+}
+
+impl<'a> EliminateMutRefs<'a> {
+    fn new(
+        func_target: &'a FunctionTarget,
+        param_proxy_map: BTreeMap<TempIndex, TempIndex>,
+        ref_param_proxy_map: BTreeMap<TempIndex, TempIndex>,
+        ref_param_inout_proxy_map: BTreeMap<Type, TempIndex>,
+        next_attr_id: usize,
+    ) -> Self {
+        Self {
+            func_target,
+            param_proxy_map,
+            ref_param_proxy_map,
+            ref_param_inout_proxy_map,
+            next_attr_id,
+        }
+    }
+
+    fn transform_type(ty: Type) -> Type {
+        if let Type::Reference(_, y) = ty {
+            *y
+        } else {
+            ty
+        }
+    }
+
+    fn transform_index(&self, idx: TempIndex) -> TempIndex {
+        if self.ref_param_proxy_map.contains_key(&idx) {
+            self.ref_param_proxy_map[&idx]
+        } else if self.param_proxy_map.contains_key(&idx) {
+            self.param_proxy_map[&idx]
+        } else {
+            idx
+        }
+    }
+
+    fn transform_index_for_local_root(&self, idx: TempIndex) -> TempIndex {
+        if self.param_proxy_map.contains_key(&idx) {
+            self.param_proxy_map[&idx]
+        } else {
+            idx
+        }
+    }
+
+    fn transform_indices(&self, indices: Vec<TempIndex>) -> Vec<TempIndex> {
+        indices
+            .into_iter()
+            .map(|idx| self.transform_index(idx))
+            .collect()
+    }
+
+    fn transform_bytecode_indices(&self, bytecode: Bytecode) -> Bytecode {
+        use BorrowNode::*;
+        match bytecode {
+            Assign(attr_id, dest, src, kind) => Assign(
+                attr_id,
+                self.transform_index(dest),
+                self.transform_index(src),
+                kind,
+            ),
+            Call(attr_id, dests, op, srcs) => Call(
+                attr_id,
+                self.transform_indices(dests),
+                op,
+                self.transform_indices(srcs),
+            ),
+            Ret(attr_id, srcs) => Ret(attr_id, self.transform_indices(srcs)),
+            Load(attr_id, dest, c) => Load(attr_id, self.transform_index(dest), c),
+            Branch(attr_id, then_label, else_label, src) => {
+                Branch(attr_id, then_label, else_label, self.transform_index(src))
+            }
+            WriteBack(attr_id, GlobalRoot(struct_decl), src) => {
+                WriteBack(attr_id, GlobalRoot(struct_decl), self.transform_index(src))
+            }
+            WriteBack(attr_id, LocalRoot(dest), src) => WriteBack(
+                attr_id,
+                LocalRoot(self.transform_index_for_local_root(dest)),
+                self.transform_index(src),
+            ),
+            WriteBack(attr_id, Reference(dest), src) => WriteBack(
+                attr_id,
+                Reference(self.transform_index(dest)),
+                self.transform_index(src),
+            ),
+            UnpackRef(attr_id, src) => UnpackRef(attr_id, self.transform_index(src)),
+            PackRef(attr_id, src) => PackRef(attr_id, self.transform_index(src)),
+            _ => bytecode,
+        }
+    }
+
+    fn new_attr_id(&mut self) -> AttrId {
+        let attr_id = AttrId::new(self.next_attr_id);
+        self.next_attr_id += 1;
+        attr_id
+    }
+
+    fn transform_bytecode(&mut self, bytecode: Bytecode) -> Vec<Bytecode> {
+        let bytecode = self.transform_bytecode_indices(bytecode);
+        match bytecode {
+            Call(attr_id, mut dests, Function(mid, fid, type_actuals), mut srcs) => {
+                let mut ref_param_count_per_type = BTreeMap::new();
+                let old_srcs = std::mem::take(&mut srcs);
+                let mut read_ref_bytecodes = vec![];
+                let mut write_ref_bytecodes = vec![];
+                let mut splice_map = BTreeMap::new();
+                for (pos, idx) in old_srcs.into_iter().enumerate() {
+                    let ty = self.func_target.get_local_type(idx);
+                    if ty.is_reference() {
+                        let ref_param_count =
+                            ref_param_count_per_type.entry(ty).or_insert_with(|| 0);
+                        let read_ref_dest_idx =
+                            self.ref_param_inout_proxy_map[ty] + *ref_param_count;
+                        srcs.push(read_ref_dest_idx);
+                        dests.push(read_ref_dest_idx);
+                        *ref_param_count += 1;
+                        read_ref_bytecodes.push(Call(
+                            self.new_attr_id(),
+                            vec![read_ref_dest_idx],
+                            ReadRef,
+                            vec![idx],
+                        ));
+                        write_ref_bytecodes.push(Call(
+                            self.new_attr_id(),
+                            vec![],
+                            WriteRef,
+                            vec![idx, read_ref_dest_idx],
+                        ));
+                        splice_map.insert(pos, idx);
+                    } else {
+                        srcs.push(idx);
+                    }
+                }
+                let mut splice_bytecodes = vec![];
+                for idx in &dests {
+                    let ty = self.func_target.get_local_type(*idx);
+                    if ty.is_reference() {
+                        splice_bytecodes.push(Splice(self.new_attr_id(), *idx, splice_map.clone()));
+                    }
+                }
+
+                let mut return_bytecodes = vec![];
+                return_bytecodes.append(&mut read_ref_bytecodes);
+                return_bytecodes.push(Call(attr_id, dests, Function(mid, fid, type_actuals), srcs));
+                return_bytecodes.append(&mut write_ref_bytecodes);
+                return_bytecodes.append(&mut splice_bytecodes);
+                return_bytecodes
+            }
+            Ret(attr_id, mut srcs) => {
+                for idx in self.ref_param_proxy_map.keys() {
+                    srcs.push(self.param_proxy_map[idx]);
+                }
+                vec![Ret(attr_id, srcs)]
+            }
+            _ => vec![bytecode],
+        }
+    }
+
+    fn transform_bytecodes(&mut self, instrs: &[Bytecode]) -> Vec<Bytecode> {
+        instrs
+            .iter()
+            .map(|bytecode| self.transform_bytecode(bytecode.clone()))
+            .flatten()
+            .collect()
+    }
+}

--- a/language/move-prover/stackless-bytecode-generator/src/lib.rs
+++ b/language/move-prover/stackless-bytecode-generator/src/lib.rs
@@ -4,13 +4,17 @@
 #![forbid(unsafe_code)]
 
 pub mod annotations;
+pub mod borrow_analysis;
 pub mod dataflow_analysis;
 pub mod eliminate_imm_refs;
+pub mod eliminate_mut_refs;
 pub mod function_target;
 pub mod function_target_pipeline;
 pub mod lifetime_analysis;
 pub mod livevar_analysis;
+pub mod packref_analysis;
 pub mod reaching_def_analysis;
 pub mod stackless_bytecode;
 pub mod stackless_bytecode_generator;
 pub mod stackless_control_flow_graph;
+pub mod writeback_analysis;

--- a/language/move-prover/stackless-bytecode-generator/src/livevar_analysis.rs
+++ b/language/move-prover/stackless-bytecode-generator/src/livevar_analysis.rs
@@ -7,7 +7,7 @@ use crate::{
     },
     function_target::{FunctionTarget, FunctionTargetData},
     function_target_pipeline::{FunctionTargetProcessor, FunctionTargetsHolder},
-    stackless_bytecode::{Bytecode, TempIndex},
+    stackless_bytecode::{AttrId, Bytecode, Label, Operation, TempIndex},
     stackless_control_flow_graph::{BlockId, StacklessControlFlowGraph},
 };
 use itertools::Itertools;
@@ -18,8 +18,23 @@ use vm::file_format::CodeOffset;
 /// The annotation for live variable analysis. For each code position, we have a set of local
 /// variable indices that are live just before the code offset, i.e. these variables are used
 /// before being overwritten.
+
+pub struct LiveVarInfoAtCodeOffset {
+    pub before: BTreeSet<TempIndex>,
+    pub after: BTreeSet<TempIndex>,
+}
+
 #[derive(Default)]
-pub struct LiveVarAnnotation(BTreeMap<CodeOffset, BTreeSet<TempIndex>>);
+pub struct LiveVarAnnotation(BTreeMap<CodeOffset, LiveVarInfoAtCodeOffset>);
+
+impl LiveVarAnnotation {
+    pub fn get_live_var_info_at(
+        &self,
+        code_offset: CodeOffset,
+    ) -> Option<&LiveVarInfoAtCodeOffset> {
+        self.0.get(&code_offset)
+    }
+}
 
 pub struct LiveVarAnalysisProcessor();
 
@@ -40,8 +55,12 @@ impl FunctionTargetProcessor for LiveVarAnalysisProcessor {
             // Native functions have no byte code.
             LiveVarAnnotation(BTreeMap::new())
         } else {
-            let cfg = StacklessControlFlowGraph::new_backward(&data.code);
-            LiveVarAnnotation(LiveVarAnalysis::analyze(&cfg, &data.code))
+            let code = std::mem::take(&mut data.code);
+            let func_target = FunctionTarget::new(func_env, &data);
+            let (code, _) = Self::analyze_and_transform(&func_target, code);
+            let (code, annotations) = Self::analyze_and_transform(&func_target, code);
+            data.code = code;
+            LiveVarAnnotation(annotations)
         };
         // Annotate function target with computed life variable data.
         data.annotations
@@ -50,7 +69,31 @@ impl FunctionTargetProcessor for LiveVarAnalysisProcessor {
     }
 }
 
-struct LiveVarAnalysis();
+impl LiveVarAnalysisProcessor {
+    fn analyze_and_transform(
+        func_target: &FunctionTarget,
+        code: Vec<Bytecode>,
+    ) -> (Vec<Bytecode>, BTreeMap<CodeOffset, LiveVarInfoAtCodeOffset>) {
+        let cfg = StacklessControlFlowGraph::new_backward(&code);
+        let mut analyzer = LiveVarAnalysis::new(&func_target);
+        let state_map = analyzer.analyze_function(
+            LiveVarState {
+                livevars: BTreeSet::new(),
+            },
+            &code,
+            &cfg,
+        );
+        let mut annotations = analyzer.post_process(&cfg, &code, state_map);
+        let new_bytecode = analyzer.possibly_transform_code(&mut annotations, code);
+        (new_bytecode, annotations)
+    }
+}
+
+struct LiveVarAnalysis<'a> {
+    func_target: &'a FunctionTarget<'a>,
+    next_label_id: usize,
+    next_attr_id: usize,
+}
 
 #[derive(Debug, Clone, Eq, PartialEq)]
 struct LiveVarState {
@@ -75,17 +118,126 @@ impl LiveVarState {
     }
 }
 
-impl LiveVarAnalysis {
-    fn analyze(
-        cfg: &StacklessControlFlowGraph,
-        instrs: &[Bytecode],
-    ) -> BTreeMap<CodeOffset, BTreeSet<TempIndex>> {
-        let initial_state = LiveVarState {
-            livevars: BTreeSet::new(),
-        };
-        let mut analyzer = LiveVarAnalysis {};
-        let state_map = analyzer.analyze_function(initial_state, &instrs, cfg);
-        analyzer.post_process(cfg, instrs, state_map)
+impl<'a> LiveVarAnalysis<'a> {
+    fn new(func_target: &'a FunctionTarget) -> Self {
+        Self {
+            func_target,
+            next_label_id: 0,
+            next_attr_id: 0,
+        }
+    }
+
+    fn possibly_transform_code(
+        &mut self,
+        annotations: &mut BTreeMap<CodeOffset, LiveVarInfoAtCodeOffset>,
+        code: Vec<Bytecode>,
+    ) -> Vec<Bytecode> {
+        let label_to_code_offset: BTreeMap<Label, usize> = code
+            .iter()
+            .enumerate()
+            .map(|(code_offset, bytecode)| {
+                use Bytecode::*;
+                match bytecode {
+                    Label(_, label) => Some((*label, code_offset)),
+                    _ => None,
+                }
+            })
+            .flatten()
+            .collect();
+        let mut transformed_code = vec![];
+        let mut new_bytecodes = vec![];
+        self.next_label_id = code.len();
+        self.next_attr_id = code.len();
+        for (code_offset, bytecode) in code.into_iter().enumerate() {
+            match bytecode {
+                Bytecode::Branch(attr_id, then_label, else_label, src) => {
+                    let (then_label, mut bytecodes) = self.create_block_to_destroy_refs(
+                        then_label,
+                        self.lost_refs_along_edge(
+                            annotations,
+                            code_offset as CodeOffset,
+                            label_to_code_offset[&then_label] as CodeOffset,
+                        ),
+                    );
+                    new_bytecodes.append(&mut bytecodes);
+                    let (else_label, mut bytecodes) = self.create_block_to_destroy_refs(
+                        else_label,
+                        self.lost_refs_along_edge(
+                            annotations,
+                            code_offset as CodeOffset,
+                            label_to_code_offset[&else_label] as CodeOffset,
+                        ),
+                    );
+                    new_bytecodes.append(&mut bytecodes);
+                    transformed_code.push(Bytecode::Branch(attr_id, then_label, else_label, src));
+                }
+                Bytecode::Assign(attr_id, dest, _, _) => {
+                    let annotation_at = &annotations[&(code_offset as CodeOffset)];
+                    if annotation_at.after.contains(&dest) {
+                        transformed_code.push(bytecode);
+                    } else {
+                        transformed_code.push(Bytecode::Nop(attr_id));
+                    }
+                }
+                _ => {
+                    transformed_code.push(bytecode);
+                }
+            }
+        }
+        transformed_code.append(&mut new_bytecodes);
+        transformed_code
+    }
+
+    fn new_label(&mut self) -> Label {
+        let label = Label::new(self.next_label_id);
+        self.next_label_id += 1;
+        label
+    }
+
+    fn new_attr_id(&mut self) -> AttrId {
+        let attr_id = AttrId::new(self.next_attr_id);
+        self.next_attr_id += 1;
+        attr_id
+    }
+
+    fn create_block_to_destroy_refs(
+        &mut self,
+        jump_label: Label,
+        refs: Vec<TempIndex>,
+    ) -> (Label, Vec<Bytecode>) {
+        let mut start_label = jump_label;
+        let mut new_bytecodes = vec![];
+        if !refs.is_empty() {
+            start_label = self.new_label();
+            new_bytecodes.push(Bytecode::Label(self.new_attr_id(), start_label));
+            for idx in refs {
+                new_bytecodes.push(Bytecode::Call(
+                    self.new_attr_id(),
+                    vec![],
+                    Operation::Destroy,
+                    vec![idx],
+                ));
+            }
+            new_bytecodes.push(Bytecode::Jump(self.new_attr_id(), jump_label));
+        }
+        (start_label, new_bytecodes)
+    }
+
+    fn lost_refs_along_edge(
+        &self,
+        annotations: &BTreeMap<CodeOffset, LiveVarInfoAtCodeOffset>,
+        src_code_offset: CodeOffset,
+        dest_code_offset: CodeOffset,
+    ) -> Vec<TempIndex> {
+        annotations[&src_code_offset]
+            .after
+            .iter()
+            .filter(|x| {
+                self.func_target.get_local_type(**x).is_reference()
+                    && !annotations[&dest_code_offset].before.contains(x)
+            })
+            .copied()
+            .collect()
     }
 
     fn post_process(
@@ -93,14 +245,16 @@ impl LiveVarAnalysis {
         cfg: &StacklessControlFlowGraph,
         instrs: &[Bytecode],
         state_map: StateMap<LiveVarState, ()>,
-    ) -> BTreeMap<CodeOffset, BTreeSet<TempIndex>> {
+    ) -> BTreeMap<CodeOffset, LiveVarInfoAtCodeOffset> {
         let mut result = BTreeMap::new();
         for (block_id, block_state) in state_map {
             let mut state = block_state.pre;
             for offset in cfg.instr_indexes(block_id).rev() {
                 let instr = &instrs[offset as usize];
+                let after = state.livevars.clone();
                 state = self.execute(state, instr, offset);
-                result.insert(offset, state.livevars.clone());
+                let before = state.livevars.clone();
+                result.insert(offset, LiveVarInfoAtCodeOffset { before, after });
             }
         }
         result
@@ -134,7 +288,7 @@ impl LiveVarAnalysis {
     }
 }
 
-impl TransferFunctions for LiveVarAnalysis {
+impl<'a> TransferFunctions for LiveVarAnalysis<'a> {
     type State = LiveVarState;
     type AnalysisError = ();
 
@@ -154,7 +308,7 @@ impl TransferFunctions for LiveVarAnalysis {
     }
 }
 
-impl DataflowAnalysis for LiveVarAnalysis {}
+impl<'a> DataflowAnalysis for LiveVarAnalysis<'a> {}
 
 impl AbstractDomain for LiveVarState {
     fn join(&mut self, other: &Self) -> JoinResult {
@@ -180,6 +334,7 @@ pub fn format_livevar_annotation(
     if let Some(LiveVarAnnotation(map)) = target.get_annotations().get::<LiveVarAnnotation>() {
         if let Some(map_at) = map.get(&code_offset) {
             let mut res = map_at
+                .before
                 .iter()
                 .map(|idx| {
                     let name = target.get_local_name(*idx);

--- a/language/move-prover/stackless-bytecode-generator/src/packref_analysis.rs
+++ b/language/move-prover/stackless-bytecode-generator/src/packref_analysis.rs
@@ -1,0 +1,276 @@
+// Copyright (c) The Libra Core Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::{
+    borrow_analysis::{BorrowAnnotation, BorrowInfo},
+    function_target::{FunctionTarget, FunctionTargetData},
+    function_target_pipeline::{FunctionTargetProcessor, FunctionTargetsHolder},
+    stackless_bytecode::{
+        AssignKind, AttrId, BorrowNode,
+        Bytecode::{self, *},
+        Operation, TempIndex,
+    },
+};
+use itertools::Itertools;
+use spec_lang::env::FunctionEnv;
+use std::collections::{BTreeMap, BTreeSet};
+use vm::file_format::CodeOffset;
+
+pub struct PackrefAnalysisProcessor {}
+
+impl PackrefAnalysisProcessor {
+    pub fn new() -> Box<Self> {
+        Box::new(PackrefAnalysisProcessor {})
+    }
+}
+
+impl FunctionTargetProcessor for PackrefAnalysisProcessor {
+    fn process(
+        &self,
+        _targets: &mut FunctionTargetsHolder,
+        func_env: &FunctionEnv<'_>,
+        mut data: FunctionTargetData,
+    ) -> FunctionTargetData {
+        let func_target = FunctionTarget::new(func_env, &data);
+        let mut pack_analysis = PackrefAnalysis::new(&func_target, &data.code);
+        let mut new_code = BTreeMap::new();
+        for (code_offset, bytecode) in data.code.iter().enumerate() {
+            new_code.insert(
+                code_offset as CodeOffset,
+                pack_analysis.compute_instrumentation(code_offset as CodeOffset, bytecode),
+            );
+        }
+        data.annotations
+            .set::<PackrefAnnotation>(PackrefAnnotation(new_code));
+        data
+    }
+}
+
+pub struct PackrefInstrumentation {
+    pub before: Vec<Bytecode>,
+    pub after: Vec<Bytecode>,
+}
+
+impl PackrefInstrumentation {
+    fn is_empty(&self) -> bool {
+        self.before.is_empty() && self.after.is_empty()
+    }
+}
+
+pub struct PackrefAnnotation(BTreeMap<CodeOffset, PackrefInstrumentation>);
+
+impl PackrefAnnotation {
+    pub fn get_packref_instrumentation_at(
+        &self,
+        code_offset: CodeOffset,
+    ) -> Option<&PackrefInstrumentation> {
+        self.0.get(&code_offset)
+    }
+}
+
+pub struct PackrefAnalysis<'a> {
+    func_target: &'a FunctionTarget<'a>,
+    borrow_annotation: &'a BorrowAnnotation,
+    next_attr_id: usize,
+}
+
+impl<'a> PackrefAnalysis<'a> {
+    fn new(func_target: &'a FunctionTarget<'a>, code: &[Bytecode]) -> Self {
+        let borrow_annotation = func_target
+            .get_annotations()
+            .get::<BorrowAnnotation>()
+            .expect("borrow annotation");
+
+        Self {
+            func_target,
+            borrow_annotation,
+            next_attr_id: code.len(),
+        }
+    }
+
+    fn compute_instrumentation(
+        &mut self,
+        code_offset: CodeOffset,
+        bytecode: &Bytecode,
+    ) -> PackrefInstrumentation {
+        let borrow_annotation_at = self
+            .borrow_annotation
+            .get_borrow_info_at(code_offset)
+            .unwrap();
+        let (before, mut after) = self.public_function_instrumentation(code_offset, &bytecode);
+        match bytecode {
+            SpecBlock(..)
+            | Assign(_, _, _, AssignKind::Move)
+            | Assign(_, _, _, AssignKind::Store)
+            | Ret(..)
+            | Load(..)
+            | Branch(..)
+            | Jump(..)
+            | Label(..)
+            | Abort(..)
+            | Nop(..) => {}
+            _ => {
+                after.append(&mut self.ref_create_destroy_instrumentation(
+                    bytecode,
+                    &borrow_annotation_at.before,
+                    &borrow_annotation_at.after,
+                ));
+            }
+        };
+        PackrefInstrumentation { before, after }
+    }
+
+    fn call_ends_lifetime(&self) -> bool {
+        self.func_target.is_public()
+            && self
+                .func_target
+                .get_return_types()
+                .iter()
+                .all(|ty| !ty.is_reference())
+    }
+
+    fn public_function_instrumentation(
+        &mut self,
+        code_offset: CodeOffset,
+        bytecode: &Bytecode,
+    ) -> (Vec<Bytecode>, Vec<Bytecode>) {
+        let mut before = vec![];
+        let mut after = vec![];
+        if self.call_ends_lifetime() && code_offset == 0 {
+            for idx in 0..self.func_target.get_parameter_count() {
+                if self.func_target.get_local_type(idx).is_reference() {
+                    before.push(Bytecode::UnpackRef(self.new_attr_id(), idx));
+                }
+            }
+        }
+        match &bytecode {
+            Call(_, dests, Operation::Function(mid, fid, _), srcs) => {
+                let module_env = self.func_target.module_env();
+                let call_ends_lifetime = dests
+                    .iter()
+                    .all(|idx| !self.func_target.get_local_type(*idx).is_reference())
+                    && (module_env.get_id() != *mid || module_env.get_function(*fid).is_public());
+                if call_ends_lifetime {
+                    let pack_refs: Vec<&TempIndex> = srcs
+                        .iter()
+                        .filter(|idx| self.func_target.get_local_type(**idx).is_reference())
+                        .collect();
+                    before.append(
+                        &mut pack_refs
+                            .iter()
+                            .map(|idx| Bytecode::PackRef(self.new_attr_id(), **idx))
+                            .collect(),
+                    );
+                    after.append(
+                        &mut pack_refs
+                            .into_iter()
+                            .map(|idx| Bytecode::UnpackRef(self.new_attr_id(), *idx))
+                            .collect(),
+                    );
+                }
+            }
+            Ret(..) => {
+                if self.call_ends_lifetime() {
+                    for idx in 0..self.func_target.get_parameter_count() {
+                        if self.func_target.get_local_type(idx).is_reference() {
+                            before.push(Bytecode::PackRef(self.new_attr_id(), idx));
+                        }
+                    }
+                }
+            }
+            _ => {}
+        };
+        (before, after)
+    }
+
+    fn new_attr_id(&mut self) -> AttrId {
+        let attr_id = AttrId::new(self.next_attr_id);
+        self.next_attr_id += 1;
+        attr_id
+    }
+
+    fn ref_create_destroy_instrumentation(
+        &mut self,
+        bytecode: &Bytecode,
+        before: &BorrowInfo,
+        after: &BorrowInfo,
+    ) -> Vec<Bytecode> {
+        let mut instrumented_bytecodes = vec![];
+        match bytecode {
+            Call(_, dests, op, _) => {
+                use Operation::*;
+                match op {
+                    BorrowLoc | BorrowField(..) | BorrowGlobal(..) => {
+                        instrumented_bytecodes
+                            .push(Bytecode::UnpackRef(self.new_attr_id(), dests[0]));
+                    }
+                    _ => {
+                        let filter_fn = |node: &BorrowNode| {
+                            if let BorrowNode::Reference(idx) = node {
+                                Some(*idx)
+                            } else {
+                                None
+                            }
+                        };
+                        let before_borrowed_by =
+                            before.borrowed_by.keys().filter_map(filter_fn).collect();
+                        let before_refs: BTreeSet<&TempIndex> =
+                            before.live_refs.union(&before_borrowed_by).collect();
+                        let after_borrowed_by =
+                            after.borrowed_by.keys().filter_map(filter_fn).collect();
+                        let after_refs: BTreeSet<&TempIndex> =
+                            after.live_refs.union(&after_borrowed_by).collect();
+                        for idx in before_refs.difference(&after_refs) {
+                            instrumented_bytecodes
+                                .push(Bytecode::PackRef(self.new_attr_id(), **idx));
+                        }
+                    }
+                }
+            }
+            Assign(_, dest, _, AssignKind::Copy) => {
+                if after
+                    .borrowed_by
+                    .contains_key(&BorrowNode::Reference(*dest))
+                {
+                    instrumented_bytecodes.push(Bytecode::UnpackRef(self.new_attr_id(), *dest));
+                }
+            }
+            _ => unreachable!(),
+        }
+        instrumented_bytecodes
+    }
+}
+
+// =================================================================================================
+// Formatting
+
+/// Format a packref annotation.
+pub fn format_packref_annotation(
+    func_target: &FunctionTarget<'_>,
+    code_offset: CodeOffset,
+) -> Option<String> {
+    if let Some(PackrefAnnotation(map)) = func_target.get_annotations().get::<PackrefAnnotation>() {
+        if let Some(map_at) = map.get(&code_offset) {
+            if !map_at.is_empty() {
+                let before_str = format!(
+                    "before: {}",
+                    map_at
+                        .before
+                        .iter()
+                        .map(|bytecode| bytecode.display(func_target))
+                        .join(", ")
+                );
+                let after_str = format!(
+                    "after: {}",
+                    map_at
+                        .after
+                        .iter()
+                        .map(|bytecode| bytecode.display(func_target))
+                        .join(", ")
+                );
+                return Some(format!("{} {}", before_str, after_str));
+            }
+        }
+    }
+    None
+}

--- a/language/move-prover/stackless-bytecode-generator/src/stackless_bytecode_generator.rs
+++ b/language/move-prover/stackless-bytecode-generator/src/stackless_bytecode_generator.rs
@@ -89,7 +89,7 @@ impl<'a> StacklessBytecodeGenerator<'a> {
         }
 
         // Eliminate fall-through for non-branching instructions
-        let code = std::mem::replace(&mut self.code, vec![]);
+        let code = std::mem::take(&mut self.code);
         for bytecode in code.into_iter() {
             if let Bytecode::Label(attr_id, label) = bytecode {
                 if !self.code.is_empty() && !self.code[self.code.len() - 1].is_branch() {
@@ -103,6 +103,7 @@ impl<'a> StacklessBytecodeGenerator<'a> {
             code: self.code,
             local_types: self.local_types,
             return_types: self.func_env.get_return_types(),
+            acquires_global_resources: self.func_env.get_acquires_global_resources(),
             locations: self.location_table,
             annotations: Annotations::default(),
             given_spec_blocks,

--- a/language/move-prover/stackless-bytecode-generator/src/writeback_analysis.rs
+++ b/language/move-prover/stackless-bytecode-generator/src/writeback_analysis.rs
@@ -1,0 +1,166 @@
+// Copyright (c) The Libra Core Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::{
+    borrow_analysis::{BorrowAnnotation, BorrowInfo},
+    function_target::{FunctionTarget, FunctionTargetData},
+    function_target_pipeline::{FunctionTargetProcessor, FunctionTargetsHolder},
+    stackless_bytecode::{
+        AttrId, BorrowNode,
+        Bytecode::{self, *},
+        TempIndex,
+    },
+};
+use itertools::Itertools;
+use spec_lang::env::FunctionEnv;
+use std::collections::{BTreeMap, BTreeSet};
+use vm::file_format::CodeOffset;
+
+pub struct WritebackAnalysisProcessor {}
+
+impl WritebackAnalysisProcessor {
+    pub fn new() -> Box<Self> {
+        Box::new(WritebackAnalysisProcessor {})
+    }
+}
+
+impl FunctionTargetProcessor for WritebackAnalysisProcessor {
+    fn process(
+        &self,
+        _targets: &mut FunctionTargetsHolder,
+        func_env: &FunctionEnv<'_>,
+        mut data: FunctionTargetData,
+    ) -> FunctionTargetData {
+        let func_target = FunctionTarget::new(func_env, &data);
+        let mut writeback_analysis = WritebackAnalysis::new(&func_target, &data.code);
+        let mut new_code = BTreeMap::new();
+        for (code_offset, bytecode) in data.code.iter().enumerate() {
+            new_code.insert(
+                code_offset as CodeOffset,
+                writeback_analysis.compute_instrumentation(code_offset as CodeOffset, bytecode),
+            );
+        }
+        data.annotations
+            .set::<WritebackAnnotation>(WritebackAnnotation(new_code));
+        data
+    }
+}
+
+// WriteBack instructions to be inserted right after a code offset
+pub struct WritebackAnnotation(BTreeMap<CodeOffset, Vec<Bytecode>>);
+
+impl WritebackAnnotation {
+    pub fn get_writeback_instrs_at(&self, code_offset: CodeOffset) -> Option<&Vec<Bytecode>> {
+        self.0.get(&code_offset)
+    }
+}
+
+pub struct WritebackAnalysis<'a> {
+    _func_target: &'a FunctionTarget<'a>,
+    borrow_annotation: &'a BorrowAnnotation,
+    next_attr_id: usize,
+}
+
+impl<'a> WritebackAnalysis<'a> {
+    fn new(func_target: &'a FunctionTarget<'a>, code: &[Bytecode]) -> Self {
+        let borrow_annotation = func_target
+            .get_annotations()
+            .get::<BorrowAnnotation>()
+            .expect("borrow annotation");
+
+        Self {
+            _func_target: func_target,
+            borrow_annotation,
+            next_attr_id: code.len(),
+        }
+    }
+
+    fn compute_instrumentation(
+        &mut self,
+        offset: CodeOffset,
+        bytecode: &Bytecode,
+    ) -> Vec<Bytecode> {
+        let borrow_annotation_at = self.borrow_annotation.get_borrow_info_at(offset).unwrap();
+        match bytecode {
+            SpecBlock(..) | Assign(..) | Ret(..) | Load(..) | Branch(..) | Jump(..) | Label(..)
+            | Abort(..) | Nop(..) => vec![],
+            _ => {
+                self.writeback_bytecodes(&borrow_annotation_at.before, &borrow_annotation_at.after)
+            }
+        }
+    }
+
+    fn visit(
+        idx: TempIndex,
+        borrows_from: &BTreeMap<BorrowNode, BTreeSet<BorrowNode>>,
+        visited: &mut BTreeSet<TempIndex>,
+        dfs_order: &mut Vec<TempIndex>,
+    ) {
+        visited.insert(idx);
+        let node = BorrowNode::Reference(idx);
+        if borrows_from.contains_key(&node) {
+            for n in &borrows_from[&node] {
+                if let BorrowNode::Reference(next_idx) = n {
+                    if !visited.contains(next_idx) {
+                        Self::visit(*next_idx, borrows_from, visited, dfs_order);
+                    }
+                }
+            }
+        }
+        dfs_order.push(idx);
+    }
+
+    fn new_attr_id(&mut self) -> AttrId {
+        let attr_id = AttrId::new(self.next_attr_id);
+        self.next_attr_id += 1;
+        attr_id
+    }
+
+    fn writeback_bytecodes(&mut self, before: &BorrowInfo, after: &BorrowInfo) -> Vec<Bytecode> {
+        let mut instrumented_bytecodes = vec![];
+        // add writebacks (youngest first) for all references that are live before but not after
+        let mut visited = BTreeSet::new();
+        let mut dfs_order = vec![];
+        for idx in before.live_refs.difference(&after.live_refs) {
+            Self::visit(*idx, &before.borrows_from, &mut visited, &mut dfs_order);
+        }
+        for idx in dfs_order {
+            if before.live_refs.contains(&idx) && !after.live_refs.contains(&idx) {
+                let node = BorrowNode::Reference(idx);
+                for n in &before.borrows_from[&node] {
+                    instrumented_bytecodes.push(Bytecode::WriteBack(
+                        self.new_attr_id(),
+                        n.clone(),
+                        idx,
+                    ));
+                }
+            }
+        }
+        instrumented_bytecodes
+    }
+}
+
+// =================================================================================================
+// Formatting
+
+/// Format a writeback annotation.
+pub fn format_writeback_annotation(
+    func_target: &FunctionTarget<'_>,
+    code_offset: CodeOffset,
+) -> Option<String> {
+    if let Some(WritebackAnnotation(map)) =
+        func_target.get_annotations().get::<WritebackAnnotation>()
+    {
+        if let Some(map_at) = map.get(&code_offset) {
+            if !map_at.is_empty() {
+                return Some(
+                    map_at
+                        .iter()
+                        .map(|bytecode| bytecode.display(func_target))
+                        .join(", "),
+                );
+            }
+        }
+    }
+    None
+}

--- a/language/move-prover/stackless-bytecode-generator/tests/borrow/basic_test.exp
+++ b/language/move-prover/stackless-bytecode-generator/tests/borrow/basic_test.exp
@@ -1,0 +1,522 @@
+============ initial translation from Move ================
+
+fun TestBorrow::test1(): TestBorrow::R {
+    var r: TestBorrow::R
+    var r_ref: &mut TestBorrow::R
+    var x_ref: &mut u64
+    var $t3: u64
+    var $t4: TestBorrow::R
+    var $t5: &mut TestBorrow::R
+    var $t6: &mut TestBorrow::R
+    var $t7: &mut u64
+    var $t8: u64
+    var $t9: &mut u64
+    var $t10: TestBorrow::R
+    $t3 := 3
+    $t4 := pack TestBorrow::R($t3)
+    r := $t4
+    $t5 := borrow_local(r)
+    r_ref := $t5
+    $t6 := move(r_ref)
+    $t7 := borrow_field<TestBorrow::R>.x($t6)
+    x_ref := $t7
+    $t8 := 0
+    $t9 := move(x_ref)
+    write_ref($t9, $t8)
+    $t10 := move(r)
+    return $t10
+}
+
+
+fun TestBorrow::test2(x_ref: &mut u64, v: u64) {
+    var $t2: u64
+    var $t3: &mut u64
+    $t2 := copy(v)
+    $t3 := move(x_ref)
+    write_ref($t3, $t2)
+    return ()
+}
+
+
+pub fun TestBorrow::test3(r_ref: &mut TestBorrow::R, v: u64) {
+    var x_ref: &mut u64
+    var $t3: &mut TestBorrow::R
+    var $t4: &mut u64
+    var $t5: &mut u64
+    var $t6: u64
+    $t3 := move(r_ref)
+    $t4 := borrow_field<TestBorrow::R>.x($t3)
+    x_ref := $t4
+    $t5 := move(x_ref)
+    $t6 := copy(v)
+    TestBorrow::test2($t5, $t6)
+    return ()
+}
+
+
+fun TestBorrow::test4(): TestBorrow::R {
+    var r: TestBorrow::R
+    var r_ref: &mut TestBorrow::R
+    var $t2: u64
+    var $t3: TestBorrow::R
+    var $t4: &mut TestBorrow::R
+    var $t5: &mut TestBorrow::R
+    var $t6: u64
+    var $t7: TestBorrow::R
+    $t2 := 3
+    $t3 := pack TestBorrow::R($t2)
+    r := $t3
+    $t4 := borrow_local(r)
+    r_ref := $t4
+    $t5 := move(r_ref)
+    $t6 := 0
+    TestBorrow::test3($t5, $t6)
+    $t7 := move(r)
+    return $t7
+}
+
+
+pub fun TestBorrow::test5(r_ref: &mut TestBorrow::R): &mut u64 {
+    var $t1: &mut TestBorrow::R
+    var $t2: &mut u64
+    $t1 := move(r_ref)
+    $t2 := borrow_field<TestBorrow::R>.x($t1)
+    return $t2
+}
+
+
+fun TestBorrow::test6(): TestBorrow::R {
+    var r: TestBorrow::R
+    var r_ref: &mut TestBorrow::R
+    var x_ref: &mut u64
+    var $t3: u64
+    var $t4: TestBorrow::R
+    var $t5: &mut TestBorrow::R
+    var $t6: &mut TestBorrow::R
+    var $t7: &mut u64
+    var $t8: &mut u64
+    var $t9: u64
+    var $t10: TestBorrow::R
+    $t3 := 3
+    $t4 := pack TestBorrow::R($t3)
+    r := $t4
+    $t5 := borrow_local(r)
+    r_ref := $t5
+    $t6 := move(r_ref)
+    $t7 := TestBorrow::test5($t6)
+    x_ref := $t7
+    $t8 := move(x_ref)
+    $t9 := 0
+    TestBorrow::test2($t8, $t9)
+    $t10 := move(r)
+    return $t10
+}
+
+
+fun TestBorrow::test7(b: bool) {
+    var r1: TestBorrow::R
+    var r2: TestBorrow::R
+    var r_ref: &mut TestBorrow::R
+    var $t4: u64
+    var $t5: TestBorrow::R
+    var $t6: u64
+    var $t7: TestBorrow::R
+    var $t8: &mut TestBorrow::R
+    var $t9: bool
+    var $t10: &mut TestBorrow::R
+    var $t11: &mut TestBorrow::R
+    var $t12: &mut TestBorrow::R
+    var $t13: u64
+    $t4 := 3
+    $t5 := pack TestBorrow::R($t4)
+    r1 := $t5
+    $t6 := 4
+    $t7 := pack TestBorrow::R($t6)
+    r2 := $t7
+    $t8 := borrow_local(r1)
+    r_ref := $t8
+    $t9 := copy(b)
+    if ($t9) goto L0 else goto L1
+    L1:
+    goto L2
+    L0:
+    $t10 := move(r_ref)
+    destroy($t10)
+    $t11 := borrow_local(r2)
+    r_ref := $t11
+    goto L2
+    L2:
+    $t12 := move(r_ref)
+    $t13 := 0
+    TestBorrow::test3($t12, $t13)
+    return ()
+}
+
+
+fun TestBorrow::test8(n: u64, r_ref: &mut TestBorrow::R) {
+    var r1: TestBorrow::R
+    var r2: TestBorrow::R
+    var $t4: u64
+    var $t5: TestBorrow::R
+    var $t6: u64
+    var $t7: TestBorrow::R
+    var $t8: u64
+    var $t9: u64
+    var $t10: bool
+    var $t11: &mut TestBorrow::R
+    var $t12: u64
+    var $t13: u64
+    var $t14: u64
+    var $t15: u64
+    var $t16: bool
+    var $t17: &mut TestBorrow::R
+    var $t18: &mut TestBorrow::R
+    var $t19: u64
+    var $t20: u64
+    var $t21: u64
+    var $t22: &mut TestBorrow::R
+    var $t23: u64
+    $t4 := 3
+    $t5 := pack TestBorrow::R($t4)
+    r1 := $t5
+    $t6 := 4
+    $t7 := pack TestBorrow::R($t6)
+    r2 := $t7
+    goto L7
+    L7:
+    $t8 := 0
+    $t9 := copy(n)
+    $t10 := <($t8, $t9)
+    if ($t10) goto L0 else goto L1
+    L1:
+    goto L2
+    L0:
+    $t11 := move(r_ref)
+    destroy($t11)
+    $t12 := copy(n)
+    $t13 := 2
+    $t14 := /($t12, $t13)
+    $t15 := 0
+    $t16 := ==($t14, $t15)
+    if ($t16) goto L3 else goto L4
+    L4:
+    goto L5
+    L3:
+    $t17 := borrow_local(r1)
+    r_ref := $t17
+    goto L6
+    L5:
+    $t18 := borrow_local(r2)
+    r_ref := $t18
+    goto L6
+    L6:
+    $t19 := copy(n)
+    $t20 := 1
+    $t21 := -($t19, $t20)
+    n := $t21
+    goto L7
+    L2:
+    $t22 := move(r_ref)
+    $t23 := 0
+    TestBorrow::test3($t22, $t23)
+    return ()
+}
+
+============ after pipeline `borrow` ================
+
+fun TestBorrow::test1(): TestBorrow::R {
+    var r: TestBorrow::R
+    var r_ref: &mut TestBorrow::R
+    var x_ref: &mut u64
+    var $t3: u64
+    var $t4: TestBorrow::R
+    var $t5: &mut TestBorrow::R
+    var $t6: &mut TestBorrow::R
+    var $t7: &mut u64
+    var $t8: u64
+    var $t9: &mut u64
+    var $t10: TestBorrow::R
+    $t3 := 3
+    $t4 := pack TestBorrow::R($t3)
+    r := $t4
+    $t5 := borrow_local(r)
+    // live_refs: $t5 borrowed_by: LocalRoot(r) -> {Reference($t5)} borrows_from: Reference($t5) -> {LocalRoot(r)}
+    r_ref := $t5
+    // live_refs: r_ref borrowed_by: LocalRoot(r) -> {Reference(r_ref)} borrows_from: Reference(r_ref) -> {LocalRoot(r)}
+    $t6 := move(r_ref)
+    // live_refs: $t6 borrowed_by: LocalRoot(r) -> {Reference($t6)} borrows_from: Reference($t6) -> {LocalRoot(r)}
+    $t7 := borrow_field<TestBorrow::R>.x($t6)
+    // live_refs: $t7 borrowed_by: LocalRoot(r) -> {Reference($t7)}, Reference($t6) -> {Reference($t7)} borrows_from: Reference($t7) -> {LocalRoot(r), Reference($t6)}
+    x_ref := $t7
+    // live_refs: x_ref borrowed_by: LocalRoot(r) -> {Reference(x_ref)}, Reference($t6) -> {Reference(x_ref)} borrows_from: Reference(x_ref) -> {LocalRoot(r), Reference($t6)}
+    $t8 := 0
+    // live_refs: x_ref borrowed_by: LocalRoot(r) -> {Reference(x_ref)}, Reference($t6) -> {Reference(x_ref)} borrows_from: Reference(x_ref) -> {LocalRoot(r), Reference($t6)}
+    $t9 := move(x_ref)
+    // live_refs: $t9 borrowed_by: LocalRoot(r) -> {Reference($t9)}, Reference($t6) -> {Reference($t9)} borrows_from: Reference($t9) -> {LocalRoot(r), Reference($t6)}
+    write_ref($t9, $t8)
+    $t10 := move(r)
+    return $t10
+}
+
+
+fun TestBorrow::test2(x_ref: &mut u64, v: u64) {
+    var $t2: u64
+    var $t3: &mut u64
+    // live_refs: x_ref borrowed_by: LocalRoot(x_ref) -> {Reference(x_ref)} borrows_from: Reference(x_ref) -> {LocalRoot(x_ref)}
+    $t2 := copy(v)
+    // live_refs: x_ref borrowed_by: LocalRoot(x_ref) -> {Reference(x_ref)} borrows_from: Reference(x_ref) -> {LocalRoot(x_ref)}
+    $t3 := move(x_ref)
+    // live_refs: $t3 borrowed_by: LocalRoot(x_ref) -> {Reference($t3)} borrows_from: Reference($t3) -> {LocalRoot(x_ref)}
+    write_ref($t3, $t2)
+    return ()
+}
+
+
+pub fun TestBorrow::test3(r_ref: &mut TestBorrow::R, v: u64) {
+    var x_ref: &mut u64
+    var $t3: &mut TestBorrow::R
+    var $t4: &mut u64
+    var $t5: &mut u64
+    var $t6: u64
+    // live_refs: r_ref borrowed_by: LocalRoot(r_ref) -> {Reference(r_ref)} borrows_from: Reference(r_ref) -> {LocalRoot(r_ref)}
+    $t3 := move(r_ref)
+    // live_refs: $t3 borrowed_by: LocalRoot(r_ref) -> {Reference($t3)} borrows_from: Reference($t3) -> {LocalRoot(r_ref)}
+    $t4 := borrow_field<TestBorrow::R>.x($t3)
+    // live_refs: $t4 borrowed_by: LocalRoot(r_ref) -> {Reference($t4)}, Reference($t3) -> {Reference($t4)} borrows_from: Reference($t4) -> {LocalRoot(r_ref), Reference($t3)}
+    x_ref := $t4
+    // live_refs: x_ref borrowed_by: LocalRoot(r_ref) -> {Reference(x_ref)}, Reference($t3) -> {Reference(x_ref)} borrows_from: Reference(x_ref) -> {LocalRoot(r_ref), Reference($t3)}
+    $t5 := move(x_ref)
+    // live_refs: $t5 borrowed_by: LocalRoot(r_ref) -> {Reference($t5)}, Reference($t3) -> {Reference($t5)} borrows_from: Reference($t5) -> {LocalRoot(r_ref), Reference($t3)}
+    $t6 := copy(v)
+    // live_refs: $t5 borrowed_by: LocalRoot(r_ref) -> {Reference($t5)}, Reference($t3) -> {Reference($t5)} borrows_from: Reference($t5) -> {LocalRoot(r_ref), Reference($t3)}
+    TestBorrow::test2($t5, $t6)
+    return ()
+}
+
+
+fun TestBorrow::test4(): TestBorrow::R {
+    var r: TestBorrow::R
+    var r_ref: &mut TestBorrow::R
+    var $t2: u64
+    var $t3: TestBorrow::R
+    var $t4: &mut TestBorrow::R
+    var $t5: &mut TestBorrow::R
+    var $t6: u64
+    var $t7: TestBorrow::R
+    $t2 := 3
+    $t3 := pack TestBorrow::R($t2)
+    r := $t3
+    $t4 := borrow_local(r)
+    // live_refs: $t4 borrowed_by: LocalRoot(r) -> {Reference($t4)} borrows_from: Reference($t4) -> {LocalRoot(r)}
+    r_ref := $t4
+    // live_refs: r_ref borrowed_by: LocalRoot(r) -> {Reference(r_ref)} borrows_from: Reference(r_ref) -> {LocalRoot(r)}
+    $t5 := move(r_ref)
+    // live_refs: $t5 borrowed_by: LocalRoot(r) -> {Reference($t5)} borrows_from: Reference($t5) -> {LocalRoot(r)}
+    $t6 := 0
+    // live_refs: $t5 borrowed_by: LocalRoot(r) -> {Reference($t5)} borrows_from: Reference($t5) -> {LocalRoot(r)}
+    TestBorrow::test3($t5, $t6)
+    $t7 := move(r)
+    return $t7
+}
+
+
+pub fun TestBorrow::test5(r_ref: &mut TestBorrow::R): &mut u64 {
+    var $t1: &mut TestBorrow::R
+    var $t2: &mut u64
+    // live_refs: r_ref borrowed_by: LocalRoot(r_ref) -> {Reference(r_ref)} borrows_from: Reference(r_ref) -> {LocalRoot(r_ref)}
+    $t1 := move(r_ref)
+    // live_refs: $t1 borrowed_by: LocalRoot(r_ref) -> {Reference($t1)} borrows_from: Reference($t1) -> {LocalRoot(r_ref)}
+    $t2 := borrow_field<TestBorrow::R>.x($t1)
+    // live_refs: $t2 borrowed_by: LocalRoot(r_ref) -> {Reference($t2)}, Reference($t1) -> {Reference($t2)} borrows_from: Reference($t2) -> {LocalRoot(r_ref), Reference($t1)}
+    return $t2
+}
+
+
+fun TestBorrow::test6(): TestBorrow::R {
+    var r: TestBorrow::R
+    var r_ref: &mut TestBorrow::R
+    var x_ref: &mut u64
+    var $t3: u64
+    var $t4: TestBorrow::R
+    var $t5: &mut TestBorrow::R
+    var $t6: &mut TestBorrow::R
+    var $t7: &mut u64
+    var $t8: &mut u64
+    var $t9: u64
+    var $t10: TestBorrow::R
+    $t3 := 3
+    $t4 := pack TestBorrow::R($t3)
+    r := $t4
+    $t5 := borrow_local(r)
+    // live_refs: $t5 borrowed_by: LocalRoot(r) -> {Reference($t5)} borrows_from: Reference($t5) -> {LocalRoot(r)}
+    r_ref := $t5
+    // live_refs: r_ref borrowed_by: LocalRoot(r) -> {Reference(r_ref)} borrows_from: Reference(r_ref) -> {LocalRoot(r)}
+    $t6 := move(r_ref)
+    // live_refs: $t6 borrowed_by: LocalRoot(r) -> {Reference($t6)} borrows_from: Reference($t6) -> {LocalRoot(r)}
+    $t7 := TestBorrow::test5($t6)
+    // live_refs: $t7 borrowed_by: LocalRoot(r) -> {Reference($t7)}, Reference($t6) -> {Reference($t7)} borrows_from: Reference($t7) -> {LocalRoot(r), Reference($t6)}
+    x_ref := $t7
+    // live_refs: x_ref borrowed_by: LocalRoot(r) -> {Reference(x_ref)}, Reference($t6) -> {Reference(x_ref)} borrows_from: Reference(x_ref) -> {LocalRoot(r), Reference($t6)}
+    $t8 := move(x_ref)
+    // live_refs: $t8 borrowed_by: LocalRoot(r) -> {Reference($t8)}, Reference($t6) -> {Reference($t8)} borrows_from: Reference($t8) -> {LocalRoot(r), Reference($t6)}
+    $t9 := 0
+    // live_refs: $t8 borrowed_by: LocalRoot(r) -> {Reference($t8)}, Reference($t6) -> {Reference($t8)} borrows_from: Reference($t8) -> {LocalRoot(r), Reference($t6)}
+    TestBorrow::test2($t8, $t9)
+    $t10 := move(r)
+    return $t10
+}
+
+
+fun TestBorrow::test7(b: bool) {
+    var r1: TestBorrow::R
+    var r2: TestBorrow::R
+    var r_ref: &mut TestBorrow::R
+    var $t4: u64
+    var $t5: TestBorrow::R
+    var $t6: u64
+    var $t7: TestBorrow::R
+    var $t8: &mut TestBorrow::R
+    var $t9: bool
+    var $t10: &mut TestBorrow::R
+    var $t11: &mut TestBorrow::R
+    var $t12: &mut TestBorrow::R
+    var $t13: u64
+    $t4 := 3
+    $t5 := pack TestBorrow::R($t4)
+    r1 := $t5
+    $t6 := 4
+    $t7 := pack TestBorrow::R($t6)
+    r2 := $t7
+    $t8 := borrow_local(r1)
+    // live_refs: $t8 borrowed_by: LocalRoot(r1) -> {Reference($t8)} borrows_from: Reference($t8) -> {LocalRoot(r1)}
+    r_ref := $t8
+    // live_refs: r_ref borrowed_by: LocalRoot(r1) -> {Reference(r_ref)} borrows_from: Reference(r_ref) -> {LocalRoot(r1)}
+    $t9 := copy(b)
+    // live_refs: r_ref borrowed_by: LocalRoot(r1) -> {Reference(r_ref)} borrows_from: Reference(r_ref) -> {LocalRoot(r1)}
+    if ($t9) goto L0 else goto L1
+    // live_refs: r_ref borrowed_by: LocalRoot(r1) -> {Reference(r_ref)} borrows_from: Reference(r_ref) -> {LocalRoot(r1)}
+    L1:
+    // live_refs: r_ref borrowed_by: LocalRoot(r1) -> {Reference(r_ref)} borrows_from: Reference(r_ref) -> {LocalRoot(r1)}
+    goto L2
+    // live_refs: r_ref borrowed_by: LocalRoot(r1) -> {Reference(r_ref)} borrows_from: Reference(r_ref) -> {LocalRoot(r1)}
+    L0:
+    // live_refs: r_ref borrowed_by: LocalRoot(r1) -> {Reference(r_ref)} borrows_from: Reference(r_ref) -> {LocalRoot(r1)}
+    $t10 := move(r_ref)
+    // live_refs: $t10 borrowed_by: LocalRoot(r1) -> {Reference($t10)} borrows_from: Reference($t10) -> {LocalRoot(r1)}
+    destroy($t10)
+    $t11 := borrow_local(r2)
+    // live_refs: $t11 borrowed_by: LocalRoot(r2) -> {Reference($t11)} borrows_from: Reference($t11) -> {LocalRoot(r2)}
+    r_ref := $t11
+    // live_refs: r_ref borrowed_by: LocalRoot(r2) -> {Reference(r_ref)} borrows_from: Reference(r_ref) -> {LocalRoot(r2)}
+    goto L2
+    // live_refs: r_ref borrowed_by: LocalRoot(r1) -> {Reference(r_ref)}, LocalRoot(r2) -> {Reference(r_ref)} borrows_from: Reference(r_ref) -> {LocalRoot(r1), LocalRoot(r2)}
+    L2:
+    // live_refs: r_ref borrowed_by: LocalRoot(r1) -> {Reference(r_ref)}, LocalRoot(r2) -> {Reference(r_ref)} borrows_from: Reference(r_ref) -> {LocalRoot(r1), LocalRoot(r2)}
+    $t12 := move(r_ref)
+    // live_refs: $t12 borrowed_by: LocalRoot(r1) -> {Reference($t12)}, LocalRoot(r2) -> {Reference($t12)} borrows_from: Reference($t12) -> {LocalRoot(r1), LocalRoot(r2)}
+    $t13 := 0
+    // live_refs: $t12 borrowed_by: LocalRoot(r1) -> {Reference($t12)}, LocalRoot(r2) -> {Reference($t12)} borrows_from: Reference($t12) -> {LocalRoot(r1), LocalRoot(r2)}
+    TestBorrow::test3($t12, $t13)
+    return ()
+}
+
+
+fun TestBorrow::test8(n: u64, r_ref: &mut TestBorrow::R) {
+    var r1: TestBorrow::R
+    var r2: TestBorrow::R
+    var $t4: u64
+    var $t5: TestBorrow::R
+    var $t6: u64
+    var $t7: TestBorrow::R
+    var $t8: u64
+    var $t9: u64
+    var $t10: bool
+    var $t11: &mut TestBorrow::R
+    var $t12: u64
+    var $t13: u64
+    var $t14: u64
+    var $t15: u64
+    var $t16: bool
+    var $t17: &mut TestBorrow::R
+    var $t18: &mut TestBorrow::R
+    var $t19: u64
+    var $t20: u64
+    var $t21: u64
+    var $t22: &mut TestBorrow::R
+    var $t23: u64
+    // live_refs: r_ref borrowed_by: LocalRoot(r_ref) -> {Reference(r_ref)} borrows_from: Reference(r_ref) -> {LocalRoot(r_ref)}
+    $t4 := 3
+    // live_refs: r_ref borrowed_by: LocalRoot(r_ref) -> {Reference(r_ref)} borrows_from: Reference(r_ref) -> {LocalRoot(r_ref)}
+    $t5 := pack TestBorrow::R($t4)
+    // live_refs: r_ref borrowed_by: LocalRoot(r_ref) -> {Reference(r_ref)} borrows_from: Reference(r_ref) -> {LocalRoot(r_ref)}
+    r1 := $t5
+    // live_refs: r_ref borrowed_by: LocalRoot(r_ref) -> {Reference(r_ref)} borrows_from: Reference(r_ref) -> {LocalRoot(r_ref)}
+    $t6 := 4
+    // live_refs: r_ref borrowed_by: LocalRoot(r_ref) -> {Reference(r_ref)} borrows_from: Reference(r_ref) -> {LocalRoot(r_ref)}
+    $t7 := pack TestBorrow::R($t6)
+    // live_refs: r_ref borrowed_by: LocalRoot(r_ref) -> {Reference(r_ref)} borrows_from: Reference(r_ref) -> {LocalRoot(r_ref)}
+    r2 := $t7
+    // live_refs: r_ref borrowed_by: LocalRoot(r_ref) -> {Reference(r_ref)} borrows_from: Reference(r_ref) -> {LocalRoot(r_ref)}
+    goto L7
+    // live_refs: r_ref borrowed_by: LocalRoot(r_ref) -> {Reference(r_ref)}, LocalRoot(r1) -> {Reference(r_ref)}, LocalRoot(r2) -> {Reference(r_ref)} borrows_from: Reference(r_ref) -> {LocalRoot(r_ref), LocalRoot(r1), LocalRoot(r2)}
+    L7:
+    // live_refs: r_ref borrowed_by: LocalRoot(r_ref) -> {Reference(r_ref)}, LocalRoot(r1) -> {Reference(r_ref)}, LocalRoot(r2) -> {Reference(r_ref)} borrows_from: Reference(r_ref) -> {LocalRoot(r_ref), LocalRoot(r1), LocalRoot(r2)}
+    $t8 := 0
+    // live_refs: r_ref borrowed_by: LocalRoot(r_ref) -> {Reference(r_ref)}, LocalRoot(r1) -> {Reference(r_ref)}, LocalRoot(r2) -> {Reference(r_ref)} borrows_from: Reference(r_ref) -> {LocalRoot(r_ref), LocalRoot(r1), LocalRoot(r2)}
+    $t9 := copy(n)
+    // live_refs: r_ref borrowed_by: LocalRoot(r_ref) -> {Reference(r_ref)}, LocalRoot(r1) -> {Reference(r_ref)}, LocalRoot(r2) -> {Reference(r_ref)} borrows_from: Reference(r_ref) -> {LocalRoot(r_ref), LocalRoot(r1), LocalRoot(r2)}
+    $t10 := <($t8, $t9)
+    // live_refs: r_ref borrowed_by: LocalRoot(r_ref) -> {Reference(r_ref)}, LocalRoot(r1) -> {Reference(r_ref)}, LocalRoot(r2) -> {Reference(r_ref)} borrows_from: Reference(r_ref) -> {LocalRoot(r_ref), LocalRoot(r1), LocalRoot(r2)}
+    if ($t10) goto L0 else goto L1
+    // live_refs: r_ref borrowed_by: LocalRoot(r_ref) -> {Reference(r_ref)}, LocalRoot(r1) -> {Reference(r_ref)}, LocalRoot(r2) -> {Reference(r_ref)} borrows_from: Reference(r_ref) -> {LocalRoot(r_ref), LocalRoot(r1), LocalRoot(r2)}
+    L1:
+    // live_refs: r_ref borrowed_by: LocalRoot(r_ref) -> {Reference(r_ref)}, LocalRoot(r1) -> {Reference(r_ref)}, LocalRoot(r2) -> {Reference(r_ref)} borrows_from: Reference(r_ref) -> {LocalRoot(r_ref), LocalRoot(r1), LocalRoot(r2)}
+    goto L2
+    // live_refs: r_ref borrowed_by: LocalRoot(r_ref) -> {Reference(r_ref)}, LocalRoot(r1) -> {Reference(r_ref)}, LocalRoot(r2) -> {Reference(r_ref)} borrows_from: Reference(r_ref) -> {LocalRoot(r_ref), LocalRoot(r1), LocalRoot(r2)}
+    L0:
+    // live_refs: r_ref borrowed_by: LocalRoot(r_ref) -> {Reference(r_ref)}, LocalRoot(r1) -> {Reference(r_ref)}, LocalRoot(r2) -> {Reference(r_ref)} borrows_from: Reference(r_ref) -> {LocalRoot(r_ref), LocalRoot(r1), LocalRoot(r2)}
+    $t11 := move(r_ref)
+    // live_refs: $t11 borrowed_by: LocalRoot(r_ref) -> {Reference($t11)}, LocalRoot(r1) -> {Reference($t11)}, LocalRoot(r2) -> {Reference($t11)} borrows_from: Reference($t11) -> {LocalRoot(r_ref), LocalRoot(r1), LocalRoot(r2)}
+    destroy($t11)
+    $t12 := copy(n)
+    $t13 := 2
+    $t14 := /($t12, $t13)
+    $t15 := 0
+    $t16 := ==($t14, $t15)
+    if ($t16) goto L3 else goto L4
+    L4:
+    goto L5
+    L3:
+    $t17 := borrow_local(r1)
+    // live_refs: $t17 borrowed_by: LocalRoot(r1) -> {Reference($t17)} borrows_from: Reference($t17) -> {LocalRoot(r1)}
+    r_ref := $t17
+    // live_refs: r_ref borrowed_by: LocalRoot(r1) -> {Reference(r_ref)} borrows_from: Reference(r_ref) -> {LocalRoot(r1)}
+    goto L6
+    L5:
+    $t18 := borrow_local(r2)
+    // live_refs: $t18 borrowed_by: LocalRoot(r2) -> {Reference($t18)} borrows_from: Reference($t18) -> {LocalRoot(r2)}
+    r_ref := $t18
+    // live_refs: r_ref borrowed_by: LocalRoot(r2) -> {Reference(r_ref)} borrows_from: Reference(r_ref) -> {LocalRoot(r2)}
+    goto L6
+    // live_refs: r_ref borrowed_by: LocalRoot(r1) -> {Reference(r_ref)}, LocalRoot(r2) -> {Reference(r_ref)} borrows_from: Reference(r_ref) -> {LocalRoot(r1), LocalRoot(r2)}
+    L6:
+    // live_refs: r_ref borrowed_by: LocalRoot(r1) -> {Reference(r_ref)}, LocalRoot(r2) -> {Reference(r_ref)} borrows_from: Reference(r_ref) -> {LocalRoot(r1), LocalRoot(r2)}
+    $t19 := copy(n)
+    // live_refs: r_ref borrowed_by: LocalRoot(r1) -> {Reference(r_ref)}, LocalRoot(r2) -> {Reference(r_ref)} borrows_from: Reference(r_ref) -> {LocalRoot(r1), LocalRoot(r2)}
+    $t20 := 1
+    // live_refs: r_ref borrowed_by: LocalRoot(r1) -> {Reference(r_ref)}, LocalRoot(r2) -> {Reference(r_ref)} borrows_from: Reference(r_ref) -> {LocalRoot(r1), LocalRoot(r2)}
+    $t21 := -($t19, $t20)
+    // live_refs: r_ref borrowed_by: LocalRoot(r1) -> {Reference(r_ref)}, LocalRoot(r2) -> {Reference(r_ref)} borrows_from: Reference(r_ref) -> {LocalRoot(r1), LocalRoot(r2)}
+    n := $t21
+    // live_refs: r_ref borrowed_by: LocalRoot(r1) -> {Reference(r_ref)}, LocalRoot(r2) -> {Reference(r_ref)} borrows_from: Reference(r_ref) -> {LocalRoot(r1), LocalRoot(r2)}
+    goto L7
+    // live_refs: r_ref borrowed_by: LocalRoot(r_ref) -> {Reference(r_ref)}, LocalRoot(r1) -> {Reference(r_ref)}, LocalRoot(r2) -> {Reference(r_ref)} borrows_from: Reference(r_ref) -> {LocalRoot(r_ref), LocalRoot(r1), LocalRoot(r2)}
+    L2:
+    // live_refs: r_ref borrowed_by: LocalRoot(r_ref) -> {Reference(r_ref)}, LocalRoot(r1) -> {Reference(r_ref)}, LocalRoot(r2) -> {Reference(r_ref)} borrows_from: Reference(r_ref) -> {LocalRoot(r_ref), LocalRoot(r1), LocalRoot(r2)}
+    $t22 := move(r_ref)
+    // live_refs: $t22 borrowed_by: LocalRoot(r_ref) -> {Reference($t22)}, LocalRoot(r1) -> {Reference($t22)}, LocalRoot(r2) -> {Reference($t22)} borrows_from: Reference($t22) -> {LocalRoot(r_ref), LocalRoot(r1), LocalRoot(r2)}
+    $t23 := 0
+    // live_refs: $t22 borrowed_by: LocalRoot(r_ref) -> {Reference($t22)}, LocalRoot(r1) -> {Reference($t22)}, LocalRoot(r2) -> {Reference($t22)} borrows_from: Reference($t22) -> {LocalRoot(r_ref), LocalRoot(r1), LocalRoot(r2)}
+    TestBorrow::test3($t22, $t23)
+    return ()
+}

--- a/language/move-prover/stackless-bytecode-generator/tests/borrow/basic_test.move
+++ b/language/move-prover/stackless-bytecode-generator/tests/borrow/basic_test.move
@@ -1,0 +1,65 @@
+module TestBorrow {
+    struct R {
+        x: u64
+    }
+
+    fun test1() : R {
+        let r = R {x: 3};
+        let r_ref = &mut r;
+        let x_ref = &mut r_ref.x;
+        *x_ref = 0;
+        r
+    }
+
+    fun test2(x_ref: &mut u64, v: u64) {
+        *x_ref = v
+    }
+
+    public fun test3(r_ref: &mut R, v: u64) {
+        let x_ref = &mut r_ref.x;
+        test2(x_ref, v)
+    }
+
+    fun test4() : R {
+        let r = R {x: 3};
+        let r_ref = &mut r;
+        test3(r_ref, 0);
+        r
+    }
+
+    public fun test5(r_ref: &mut R) : &mut u64 {
+        &mut r_ref.x
+    }
+
+    fun test6() : R {
+        let r = R {x: 3};
+        let r_ref = &mut r;
+        let x_ref = test5(r_ref);
+        test2(x_ref, 0);
+        r
+    }
+
+    fun test7(b: bool) {
+        let r1 = R {x: 3};
+        let r2 = R {x: 4};
+        let r_ref = &mut r1;
+        if (b) {
+            r_ref = &mut r2;
+        };
+        test3(r_ref, 0)
+    }
+
+    fun test8(n: u64, r_ref: &mut R) {
+        let r1 = R {x: 3};
+        let r2 = R {x: 4};
+        while (0 < n) {
+            if (n/2 == 0) {
+                r_ref = &mut r1
+            } else {
+                r_ref = &mut r2;
+            };
+            n = n - 1
+        };
+        test3(r_ref, 0)
+    }
+}

--- a/language/move-prover/stackless-bytecode-generator/tests/eliminate_mut_refs/basic_test.exp
+++ b/language/move-prover/stackless-bytecode-generator/tests/eliminate_mut_refs/basic_test.exp
@@ -1,0 +1,541 @@
+============ initial translation from Move ================
+
+fun TestEliminateMutRefs::test1(): TestEliminateMutRefs::R {
+    var r: TestEliminateMutRefs::R
+    var r_ref: &mut TestEliminateMutRefs::R
+    var x_ref: &mut u64
+    var $t3: u64
+    var $t4: TestEliminateMutRefs::R
+    var $t5: &mut TestEliminateMutRefs::R
+    var $t6: &mut TestEliminateMutRefs::R
+    var $t7: &mut u64
+    var $t8: u64
+    var $t9: &mut u64
+    var $t10: TestEliminateMutRefs::R
+    $t3 := 3
+    $t4 := pack TestEliminateMutRefs::R($t3)
+    r := $t4
+    $t5 := borrow_local(r)
+    r_ref := $t5
+    $t6 := move(r_ref)
+    $t7 := borrow_field<TestEliminateMutRefs::R>.x($t6)
+    x_ref := $t7
+    $t8 := 0
+    $t9 := move(x_ref)
+    write_ref($t9, $t8)
+    $t10 := move(r)
+    return $t10
+}
+
+
+fun TestEliminateMutRefs::test2(x_ref: &mut u64, v: u64) {
+    var $t2: u64
+    var $t3: &mut u64
+    $t2 := copy(v)
+    $t3 := move(x_ref)
+    write_ref($t3, $t2)
+    return ()
+}
+
+
+pub fun TestEliminateMutRefs::test3(r_ref: &mut TestEliminateMutRefs::R, v: u64) {
+    var x_ref: &mut u64
+    var $t3: &mut TestEliminateMutRefs::R
+    var $t4: &mut u64
+    var $t5: &mut u64
+    var $t6: u64
+    $t3 := move(r_ref)
+    $t4 := borrow_field<TestEliminateMutRefs::R>.x($t3)
+    x_ref := $t4
+    $t5 := move(x_ref)
+    $t6 := copy(v)
+    TestEliminateMutRefs::test2($t5, $t6)
+    return ()
+}
+
+
+fun TestEliminateMutRefs::test4(): TestEliminateMutRefs::R {
+    var r: TestEliminateMutRefs::R
+    var r_ref: &mut TestEliminateMutRefs::R
+    var $t2: u64
+    var $t3: TestEliminateMutRefs::R
+    var $t4: &mut TestEliminateMutRefs::R
+    var $t5: &mut TestEliminateMutRefs::R
+    var $t6: u64
+    var $t7: TestEliminateMutRefs::R
+    $t2 := 3
+    $t3 := pack TestEliminateMutRefs::R($t2)
+    r := $t3
+    $t4 := borrow_local(r)
+    r_ref := $t4
+    $t5 := move(r_ref)
+    $t6 := 0
+    TestEliminateMutRefs::test3($t5, $t6)
+    $t7 := move(r)
+    return $t7
+}
+
+
+pub fun TestEliminateMutRefs::test5(r_ref: &mut TestEliminateMutRefs::R): &mut u64 {
+    var $t1: &mut TestEliminateMutRefs::R
+    var $t2: &mut u64
+    $t1 := move(r_ref)
+    $t2 := borrow_field<TestEliminateMutRefs::R>.x($t1)
+    return $t2
+}
+
+
+fun TestEliminateMutRefs::test6(): TestEliminateMutRefs::R {
+    var r: TestEliminateMutRefs::R
+    var r_ref: &mut TestEliminateMutRefs::R
+    var x_ref: &mut u64
+    var $t3: u64
+    var $t4: TestEliminateMutRefs::R
+    var $t5: &mut TestEliminateMutRefs::R
+    var $t6: &mut TestEliminateMutRefs::R
+    var $t7: &mut u64
+    var $t8: &mut u64
+    var $t9: u64
+    var $t10: TestEliminateMutRefs::R
+    $t3 := 3
+    $t4 := pack TestEliminateMutRefs::R($t3)
+    r := $t4
+    $t5 := borrow_local(r)
+    r_ref := $t5
+    $t6 := move(r_ref)
+    $t7 := TestEliminateMutRefs::test5($t6)
+    x_ref := $t7
+    $t8 := move(x_ref)
+    $t9 := 0
+    TestEliminateMutRefs::test2($t8, $t9)
+    $t10 := move(r)
+    return $t10
+}
+
+
+fun TestEliminateMutRefs::test7(b: bool) {
+    var r1: TestEliminateMutRefs::R
+    var r2: TestEliminateMutRefs::R
+    var r_ref: &mut TestEliminateMutRefs::R
+    var $t4: u64
+    var $t5: TestEliminateMutRefs::R
+    var $t6: u64
+    var $t7: TestEliminateMutRefs::R
+    var $t8: &mut TestEliminateMutRefs::R
+    var $t9: bool
+    var $t10: &mut TestEliminateMutRefs::R
+    var $t11: &mut TestEliminateMutRefs::R
+    var $t12: &mut TestEliminateMutRefs::R
+    var $t13: u64
+    $t4 := 3
+    $t5 := pack TestEliminateMutRefs::R($t4)
+    r1 := $t5
+    $t6 := 4
+    $t7 := pack TestEliminateMutRefs::R($t6)
+    r2 := $t7
+    $t8 := borrow_local(r1)
+    r_ref := $t8
+    $t9 := copy(b)
+    if ($t9) goto L0 else goto L1
+    L1:
+    goto L2
+    L0:
+    $t10 := move(r_ref)
+    destroy($t10)
+    $t11 := borrow_local(r2)
+    r_ref := $t11
+    goto L2
+    L2:
+    $t12 := move(r_ref)
+    $t13 := 0
+    TestEliminateMutRefs::test3($t12, $t13)
+    return ()
+}
+
+
+fun TestEliminateMutRefs::test8(n: u64, r_ref: &mut TestEliminateMutRefs::R) {
+    var r1: TestEliminateMutRefs::R
+    var r2: TestEliminateMutRefs::R
+    var $t4: u64
+    var $t5: TestEliminateMutRefs::R
+    var $t6: u64
+    var $t7: TestEliminateMutRefs::R
+    var $t8: u64
+    var $t9: u64
+    var $t10: bool
+    var $t11: &mut TestEliminateMutRefs::R
+    var $t12: u64
+    var $t13: u64
+    var $t14: u64
+    var $t15: u64
+    var $t16: bool
+    var $t17: &mut TestEliminateMutRefs::R
+    var $t18: &mut TestEliminateMutRefs::R
+    var $t19: u64
+    var $t20: u64
+    var $t21: u64
+    var $t22: &mut TestEliminateMutRefs::R
+    var $t23: u64
+    $t4 := 3
+    $t5 := pack TestEliminateMutRefs::R($t4)
+    r1 := $t5
+    $t6 := 4
+    $t7 := pack TestEliminateMutRefs::R($t6)
+    r2 := $t7
+    goto L7
+    L7:
+    $t8 := 0
+    $t9 := copy(n)
+    $t10 := <($t8, $t9)
+    if ($t10) goto L0 else goto L1
+    L1:
+    goto L2
+    L0:
+    $t11 := move(r_ref)
+    destroy($t11)
+    $t12 := copy(n)
+    $t13 := 2
+    $t14 := /($t12, $t13)
+    $t15 := 0
+    $t16 := ==($t14, $t15)
+    if ($t16) goto L3 else goto L4
+    L4:
+    goto L5
+    L3:
+    $t17 := borrow_local(r1)
+    r_ref := $t17
+    goto L6
+    L5:
+    $t18 := borrow_local(r2)
+    r_ref := $t18
+    goto L6
+    L6:
+    $t19 := copy(n)
+    $t20 := 1
+    $t21 := -($t19, $t20)
+    n := $t21
+    goto L7
+    L2:
+    $t22 := move(r_ref)
+    $t23 := 0
+    TestEliminateMutRefs::test3($t22, $t23)
+    return ()
+}
+
+============ after pipeline `eliminate_mut_refs` ================
+
+fun TestEliminateMutRefs::test1(): TestEliminateMutRefs::R {
+    var r: TestEliminateMutRefs::R
+    var r_ref: &mut TestEliminateMutRefs::R
+    var x_ref: &mut u64
+    var $t3: u64
+    var $t4: TestEliminateMutRefs::R
+    var $t5: &mut TestEliminateMutRefs::R
+    var $t6: &mut TestEliminateMutRefs::R
+    var $t7: &mut u64
+    var $t8: u64
+    var $t9: &mut u64
+    var $t10: TestEliminateMutRefs::R
+    $t3 := 3
+    $t4 := pack TestEliminateMutRefs::R($t3)
+    r := $t4
+    $t5 := borrow_local(r)
+    UnpackRef($t5)
+    r_ref := $t5
+    $t6 := move(r_ref)
+    $t7 := borrow_field<TestEliminateMutRefs::R>.x($t6)
+    LocalRoot(r) <- $t6
+    UnpackRef($t7)
+    x_ref := $t7
+    $t8 := 0
+    $t9 := move(x_ref)
+    write_ref($t9, $t8)
+    LocalRoot(r) <- $t9
+    Reference($t6) <- $t9
+    PackRef($t6)
+    PackRef($t9)
+    $t10 := move(r)
+    return $t10
+}
+
+
+fun TestEliminateMutRefs::test2(x_ref: u64, v: u64): u64 {
+    var $t2: u64
+    var $t3: &mut u64
+    var $t4: u64
+    var $t5: &mut u64
+    var $t6: u64
+    $t4 := move(x_ref)
+    $t6 := move(v)
+    $t5 := borrow_local($t4)
+    $t2 := copy($t6)
+    $t3 := move($t5)
+    write_ref($t3, $t2)
+    LocalRoot($t4) <- $t3
+    PackRef($t3)
+    return $t4
+}
+
+
+pub fun TestEliminateMutRefs::test3(r_ref: TestEliminateMutRefs::R, v: u64): TestEliminateMutRefs::R {
+    var x_ref: &mut u64
+    var $t3: &mut TestEliminateMutRefs::R
+    var $t4: &mut u64
+    var $t5: &mut u64
+    var $t6: u64
+    var $t7: TestEliminateMutRefs::R
+    var $t8: &mut TestEliminateMutRefs::R
+    var $t9: u64
+    var $t10: u64
+    $t7 := move(r_ref)
+    $t9 := move(v)
+    $t8 := borrow_local($t7)
+    UnpackRef($t8)
+    $t3 := move($t8)
+    $t4 := borrow_field<TestEliminateMutRefs::R>.x($t3)
+    LocalRoot($t7) <- $t3
+    UnpackRef($t4)
+    x_ref := $t4
+    $t5 := move(x_ref)
+    $t6 := copy($t9)
+    $t10 := read_ref($t5)
+    $t10 := TestEliminateMutRefs::test2($t10, $t6)
+    write_ref($t5, $t10)
+    LocalRoot($t7) <- $t5
+    Reference($t3) <- $t5
+    PackRef($t3)
+    PackRef($t5)
+    PackRef($t8)
+    return $t7
+}
+
+
+fun TestEliminateMutRefs::test4(): TestEliminateMutRefs::R {
+    var r: TestEliminateMutRefs::R
+    var r_ref: &mut TestEliminateMutRefs::R
+    var $t2: u64
+    var $t3: TestEliminateMutRefs::R
+    var $t4: &mut TestEliminateMutRefs::R
+    var $t5: &mut TestEliminateMutRefs::R
+    var $t6: u64
+    var $t7: TestEliminateMutRefs::R
+    var $t8: TestEliminateMutRefs::R
+    $t2 := 3
+    $t3 := pack TestEliminateMutRefs::R($t2)
+    r := $t3
+    $t4 := borrow_local(r)
+    UnpackRef($t4)
+    r_ref := $t4
+    $t5 := move(r_ref)
+    $t6 := 0
+    PackRef($t5)
+    $t8 := read_ref($t5)
+    $t8 := TestEliminateMutRefs::test3($t8, $t6)
+    write_ref($t5, $t8)
+    LocalRoot(r) <- $t5
+    UnpackRef($t5)
+    PackRef($t5)
+    $t7 := move(r)
+    return $t7
+}
+
+
+pub fun TestEliminateMutRefs::test5(r_ref: TestEliminateMutRefs::R): (&mut u64, TestEliminateMutRefs::R) {
+    var $t1: &mut TestEliminateMutRefs::R
+    var $t2: &mut u64
+    var $t3: TestEliminateMutRefs::R
+    var $t4: &mut TestEliminateMutRefs::R
+    $t3 := move(r_ref)
+    $t4 := borrow_local($t3)
+    $t1 := move($t4)
+    $t2 := borrow_field<TestEliminateMutRefs::R>.x($t1)
+    LocalRoot($t3) <- $t1
+    UnpackRef($t2)
+    return ($t2, $t3)
+}
+
+
+fun TestEliminateMutRefs::test6(): TestEliminateMutRefs::R {
+    var r: TestEliminateMutRefs::R
+    var r_ref: &mut TestEliminateMutRefs::R
+    var x_ref: &mut u64
+    var $t3: u64
+    var $t4: TestEliminateMutRefs::R
+    var $t5: &mut TestEliminateMutRefs::R
+    var $t6: &mut TestEliminateMutRefs::R
+    var $t7: &mut u64
+    var $t8: &mut u64
+    var $t9: u64
+    var $t10: TestEliminateMutRefs::R
+    var $t11: u64
+    var $t12: TestEliminateMutRefs::R
+    $t3 := 3
+    $t4 := pack TestEliminateMutRefs::R($t3)
+    r := $t4
+    $t5 := borrow_local(r)
+    UnpackRef($t5)
+    r_ref := $t5
+    $t6 := move(r_ref)
+    $t12 := read_ref($t6)
+    ($t7, $t12) := TestEliminateMutRefs::test5($t12)
+    write_ref($t6, $t12)
+    $t7 ~- [0 -> $t6]
+    LocalRoot(r) <- $t6
+    x_ref := $t7
+    $t8 := move(x_ref)
+    $t9 := 0
+    $t11 := read_ref($t8)
+    $t11 := TestEliminateMutRefs::test2($t11, $t9)
+    write_ref($t8, $t11)
+    LocalRoot(r) <- $t8
+    Reference($t6) <- $t8
+    PackRef($t6)
+    PackRef($t8)
+    $t10 := move(r)
+    return $t10
+}
+
+
+fun TestEliminateMutRefs::test7(b: bool) {
+    var r1: TestEliminateMutRefs::R
+    var r2: TestEliminateMutRefs::R
+    var r_ref: &mut TestEliminateMutRefs::R
+    var $t4: u64
+    var $t5: TestEliminateMutRefs::R
+    var $t6: u64
+    var $t7: TestEliminateMutRefs::R
+    var $t8: &mut TestEliminateMutRefs::R
+    var $t9: bool
+    var $t10: &mut TestEliminateMutRefs::R
+    var $t11: &mut TestEliminateMutRefs::R
+    var $t12: &mut TestEliminateMutRefs::R
+    var $t13: u64
+    var $t14: bool
+    var $t15: TestEliminateMutRefs::R
+    $t14 := move(b)
+    $t4 := 3
+    $t5 := pack TestEliminateMutRefs::R($t4)
+    r1 := $t5
+    $t6 := 4
+    $t7 := pack TestEliminateMutRefs::R($t6)
+    r2 := $t7
+    $t8 := borrow_local(r1)
+    UnpackRef($t8)
+    r_ref := $t8
+    $t9 := copy($t14)
+    if ($t9) goto L0 else goto L1
+    L1:
+    goto L2
+    L0:
+    $t10 := move(r_ref)
+    destroy($t10)
+    LocalRoot(r1) <- $t10
+    PackRef($t10)
+    $t11 := borrow_local(r2)
+    UnpackRef($t11)
+    r_ref := $t11
+    goto L2
+    L2:
+    $t12 := move(r_ref)
+    $t13 := 0
+    PackRef($t12)
+    $t15 := read_ref($t12)
+    $t15 := TestEliminateMutRefs::test3($t15, $t13)
+    write_ref($t12, $t15)
+    LocalRoot(r1) <- $t12
+    LocalRoot(r2) <- $t12
+    UnpackRef($t12)
+    PackRef($t12)
+    return ()
+}
+
+
+fun TestEliminateMutRefs::test8(n: u64, r_ref: TestEliminateMutRefs::R): TestEliminateMutRefs::R {
+    var r1: TestEliminateMutRefs::R
+    var r2: TestEliminateMutRefs::R
+    var $t4: u64
+    var $t5: TestEliminateMutRefs::R
+    var $t6: u64
+    var $t7: TestEliminateMutRefs::R
+    var $t8: u64
+    var $t9: u64
+    var $t10: bool
+    var $t11: &mut TestEliminateMutRefs::R
+    var $t12: u64
+    var $t13: u64
+    var $t14: u64
+    var $t15: u64
+    var $t16: bool
+    var $t17: &mut TestEliminateMutRefs::R
+    var $t18: &mut TestEliminateMutRefs::R
+    var $t19: u64
+    var $t20: u64
+    var $t21: u64
+    var $t22: &mut TestEliminateMutRefs::R
+    var $t23: u64
+    var $t24: u64
+    var $t25: TestEliminateMutRefs::R
+    var $t26: &mut TestEliminateMutRefs::R
+    var $t27: TestEliminateMutRefs::R
+    $t24 := move(n)
+    $t25 := move(r_ref)
+    $t26 := borrow_local($t25)
+    $t4 := 3
+    $t5 := pack TestEliminateMutRefs::R($t4)
+    r1 := $t5
+    $t6 := 4
+    $t7 := pack TestEliminateMutRefs::R($t6)
+    r2 := $t7
+    goto L7
+    L7:
+    $t8 := 0
+    $t9 := copy($t24)
+    $t10 := <($t8, $t9)
+    if ($t10) goto L0 else goto L1
+    L1:
+    goto L2
+    L0:
+    $t11 := move($t26)
+    destroy($t11)
+    LocalRoot($t25) <- $t11
+    LocalRoot(r1) <- $t11
+    LocalRoot(r2) <- $t11
+    PackRef($t11)
+    $t12 := copy($t24)
+    $t13 := 2
+    $t14 := /($t12, $t13)
+    $t15 := 0
+    $t16 := ==($t14, $t15)
+    if ($t16) goto L3 else goto L4
+    L4:
+    goto L5
+    L3:
+    $t17 := borrow_local(r1)
+    UnpackRef($t17)
+    $t26 := $t17
+    goto L6
+    L5:
+    $t18 := borrow_local(r2)
+    UnpackRef($t18)
+    $t26 := $t18
+    goto L6
+    L6:
+    $t19 := copy($t24)
+    $t20 := 1
+    $t21 := -($t19, $t20)
+    $t24 := $t21
+    goto L7
+    L2:
+    $t22 := move($t26)
+    $t23 := 0
+    PackRef($t22)
+    $t27 := read_ref($t22)
+    $t27 := TestEliminateMutRefs::test3($t27, $t23)
+    write_ref($t22, $t27)
+    LocalRoot($t25) <- $t22
+    LocalRoot(r1) <- $t22
+    LocalRoot(r2) <- $t22
+    UnpackRef($t22)
+    PackRef($t22)
+    return $t25
+}

--- a/language/move-prover/stackless-bytecode-generator/tests/eliminate_mut_refs/basic_test.move
+++ b/language/move-prover/stackless-bytecode-generator/tests/eliminate_mut_refs/basic_test.move
@@ -1,0 +1,66 @@
+module TestEliminateMutRefs {
+
+    struct R {
+        x: u64
+    }
+
+    fun test1() : R {
+        let r = R {x: 3};
+        let r_ref = &mut r;
+        let x_ref = &mut r_ref.x;
+        *x_ref = 0;
+        r
+    }
+
+    fun test2(x_ref: &mut u64, v: u64) {
+        *x_ref = v
+    }
+
+    public fun test3(r_ref: &mut R, v: u64) {
+        let x_ref = &mut r_ref.x;
+        test2(x_ref, v)
+    }
+
+    fun test4() : R {
+        let r = R {x: 3};
+        let r_ref = &mut r;
+        test3(r_ref, 0);
+        r
+    }
+
+    public fun test5(r_ref: &mut R) : &mut u64 {
+        &mut r_ref.x
+    }
+
+    fun test6() : R {
+        let r = R {x: 3};
+        let r_ref = &mut r;
+        let x_ref = test5(r_ref);
+        test2(x_ref, 0);
+        r
+    }
+
+    fun test7(b: bool) {
+        let r1 = R {x: 3};
+        let r2 = R {x: 4};
+        let r_ref = &mut r1;
+        if (b) {
+            r_ref = &mut r2;
+        };
+        test3(r_ref, 0)
+    }
+
+    fun test8(n: u64, r_ref: &mut R) {
+        let r1 = R {x: 3};
+        let r2 = R {x: 4};
+        while (0 < n) {
+            if (n/2 == 0) {
+                r_ref = &mut r1
+            } else {
+                r_ref = &mut r2;
+            };
+            n = n - 1
+        };
+        test3(r_ref, 0)
+    }
+}

--- a/language/move-prover/stackless-bytecode-generator/tests/livevar/basic_test.move
+++ b/language/move-prover/stackless-bytecode-generator/tests/livevar/basic_test.move
@@ -1,5 +1,4 @@
 module TestLiveVars {
-
     struct R {
         x: u64
     }

--- a/language/move-prover/stackless-bytecode-generator/tests/packref/basic_test.exp
+++ b/language/move-prover/stackless-bytecode-generator/tests/packref/basic_test.exp
@@ -1,0 +1,543 @@
+============ initial translation from Move ================
+
+fun TestPackref::test1(): TestPackref::R {
+    var r: TestPackref::R
+    var r_ref: &mut TestPackref::R
+    var x_ref: &mut u64
+    var $t3: u64
+    var $t4: TestPackref::R
+    var $t5: &mut TestPackref::R
+    var $t6: &mut TestPackref::R
+    var $t7: &mut u64
+    var $t8: u64
+    var $t9: &mut u64
+    var $t10: TestPackref::R
+    $t3 := 3
+    $t4 := pack TestPackref::R($t3)
+    r := $t4
+    $t5 := borrow_local(r)
+    r_ref := $t5
+    $t6 := move(r_ref)
+    $t7 := borrow_field<TestPackref::R>.x($t6)
+    x_ref := $t7
+    $t8 := 0
+    $t9 := move(x_ref)
+    write_ref($t9, $t8)
+    $t10 := move(r)
+    return $t10
+}
+
+
+fun TestPackref::test2(x_ref: &mut u64, v: u64) {
+    var $t2: u64
+    var $t3: &mut u64
+    $t2 := copy(v)
+    $t3 := move(x_ref)
+    write_ref($t3, $t2)
+    return ()
+}
+
+
+pub fun TestPackref::test3(r_ref: &mut TestPackref::R, v: u64) {
+    var x_ref: &mut u64
+    var $t3: &mut TestPackref::R
+    var $t4: &mut u64
+    var $t5: &mut u64
+    var $t6: u64
+    $t3 := move(r_ref)
+    $t4 := borrow_field<TestPackref::R>.x($t3)
+    x_ref := $t4
+    $t5 := move(x_ref)
+    $t6 := copy(v)
+    TestPackref::test2($t5, $t6)
+    return ()
+}
+
+
+fun TestPackref::test4(): TestPackref::R {
+    var r: TestPackref::R
+    var r_ref: &mut TestPackref::R
+    var $t2: u64
+    var $t3: TestPackref::R
+    var $t4: &mut TestPackref::R
+    var $t5: &mut TestPackref::R
+    var $t6: u64
+    var $t7: TestPackref::R
+    $t2 := 3
+    $t3 := pack TestPackref::R($t2)
+    r := $t3
+    $t4 := borrow_local(r)
+    r_ref := $t4
+    $t5 := move(r_ref)
+    $t6 := 0
+    TestPackref::test3($t5, $t6)
+    $t7 := move(r)
+    return $t7
+}
+
+
+pub fun TestPackref::test5(r_ref: &mut TestPackref::R): &mut u64 {
+    var $t1: &mut TestPackref::R
+    var $t2: &mut u64
+    $t1 := move(r_ref)
+    $t2 := borrow_field<TestPackref::R>.x($t1)
+    return $t2
+}
+
+
+fun TestPackref::test6(): TestPackref::R {
+    var r: TestPackref::R
+    var r_ref: &mut TestPackref::R
+    var x_ref: &mut u64
+    var $t3: u64
+    var $t4: TestPackref::R
+    var $t5: &mut TestPackref::R
+    var $t6: &mut TestPackref::R
+    var $t7: &mut u64
+    var $t8: &mut u64
+    var $t9: u64
+    var $t10: TestPackref::R
+    $t3 := 3
+    $t4 := pack TestPackref::R($t3)
+    r := $t4
+    $t5 := borrow_local(r)
+    r_ref := $t5
+    $t6 := move(r_ref)
+    $t7 := TestPackref::test5($t6)
+    x_ref := $t7
+    $t8 := move(x_ref)
+    $t9 := 0
+    TestPackref::test2($t8, $t9)
+    $t10 := move(r)
+    return $t10
+}
+
+
+fun TestPackref::test7(b: bool) {
+    var r1: TestPackref::R
+    var r2: TestPackref::R
+    var r_ref: &mut TestPackref::R
+    var $t4: u64
+    var $t5: TestPackref::R
+    var $t6: u64
+    var $t7: TestPackref::R
+    var $t8: &mut TestPackref::R
+    var $t9: bool
+    var $t10: &mut TestPackref::R
+    var $t11: &mut TestPackref::R
+    var $t12: &mut TestPackref::R
+    var $t13: u64
+    $t4 := 3
+    $t5 := pack TestPackref::R($t4)
+    r1 := $t5
+    $t6 := 4
+    $t7 := pack TestPackref::R($t6)
+    r2 := $t7
+    $t8 := borrow_local(r1)
+    r_ref := $t8
+    $t9 := copy(b)
+    if ($t9) goto L0 else goto L1
+    L1:
+    goto L2
+    L0:
+    $t10 := move(r_ref)
+    destroy($t10)
+    $t11 := borrow_local(r2)
+    r_ref := $t11
+    goto L2
+    L2:
+    $t12 := move(r_ref)
+    $t13 := 0
+    TestPackref::test3($t12, $t13)
+    return ()
+}
+
+
+fun TestPackref::test8(n: u64, r_ref: &mut TestPackref::R) {
+    var r1: TestPackref::R
+    var r2: TestPackref::R
+    var $t4: u64
+    var $t5: TestPackref::R
+    var $t6: u64
+    var $t7: TestPackref::R
+    var $t8: u64
+    var $t9: u64
+    var $t10: bool
+    var $t11: &mut TestPackref::R
+    var $t12: u64
+    var $t13: u64
+    var $t14: u64
+    var $t15: u64
+    var $t16: bool
+    var $t17: &mut TestPackref::R
+    var $t18: &mut TestPackref::R
+    var $t19: u64
+    var $t20: u64
+    var $t21: u64
+    var $t22: &mut TestPackref::R
+    var $t23: u64
+    $t4 := 3
+    $t5 := pack TestPackref::R($t4)
+    r1 := $t5
+    $t6 := 4
+    $t7 := pack TestPackref::R($t6)
+    r2 := $t7
+    goto L7
+    L7:
+    $t8 := 0
+    $t9 := copy(n)
+    $t10 := <($t8, $t9)
+    if ($t10) goto L0 else goto L1
+    L1:
+    goto L2
+    L0:
+    $t11 := move(r_ref)
+    destroy($t11)
+    $t12 := copy(n)
+    $t13 := 2
+    $t14 := /($t12, $t13)
+    $t15 := 0
+    $t16 := ==($t14, $t15)
+    if ($t16) goto L3 else goto L4
+    L4:
+    goto L5
+    L3:
+    $t17 := borrow_local(r1)
+    r_ref := $t17
+    goto L6
+    L5:
+    $t18 := borrow_local(r2)
+    r_ref := $t18
+    goto L6
+    L6:
+    $t19 := copy(n)
+    $t20 := 1
+    $t21 := -($t19, $t20)
+    n := $t21
+    goto L7
+    L2:
+    $t22 := move(r_ref)
+    $t23 := 0
+    TestPackref::test3($t22, $t23)
+    return ()
+}
+
+============ after pipeline `packref` ================
+
+fun TestPackref::test1(): TestPackref::R {
+    var r: TestPackref::R
+    var r_ref: &mut TestPackref::R
+    var x_ref: &mut u64
+    var $t3: u64
+    var $t4: TestPackref::R
+    var $t5: &mut TestPackref::R
+    var $t6: &mut TestPackref::R
+    var $t7: &mut u64
+    var $t8: u64
+    var $t9: &mut u64
+    var $t10: TestPackref::R
+    $t3 := 3
+    $t4 := pack TestPackref::R($t3)
+    r := $t4
+    // before:  after: UnpackRef($t5)
+    $t5 := borrow_local(r)
+    // live_refs: $t5 borrowed_by: LocalRoot(r) -> {Reference($t5)} borrows_from: Reference($t5) -> {LocalRoot(r)}
+    r_ref := $t5
+    // live_refs: r_ref borrowed_by: LocalRoot(r) -> {Reference(r_ref)} borrows_from: Reference(r_ref) -> {LocalRoot(r)}
+    $t6 := move(r_ref)
+    // live_refs: $t6 borrowed_by: LocalRoot(r) -> {Reference($t6)} borrows_from: Reference($t6) -> {LocalRoot(r)}
+    // before:  after: UnpackRef($t7)
+    $t7 := borrow_field<TestPackref::R>.x($t6)
+    // live_refs: $t7 borrowed_by: LocalRoot(r) -> {Reference($t7)}, Reference($t6) -> {Reference($t7)} borrows_from: Reference($t7) -> {LocalRoot(r), Reference($t6)}
+    x_ref := $t7
+    // live_refs: x_ref borrowed_by: LocalRoot(r) -> {Reference(x_ref)}, Reference($t6) -> {Reference(x_ref)} borrows_from: Reference(x_ref) -> {LocalRoot(r), Reference($t6)}
+    $t8 := 0
+    // live_refs: x_ref borrowed_by: LocalRoot(r) -> {Reference(x_ref)}, Reference($t6) -> {Reference(x_ref)} borrows_from: Reference(x_ref) -> {LocalRoot(r), Reference($t6)}
+    $t9 := move(x_ref)
+    // live_refs: $t9 borrowed_by: LocalRoot(r) -> {Reference($t9)}, Reference($t6) -> {Reference($t9)} borrows_from: Reference($t9) -> {LocalRoot(r), Reference($t6)}
+    // before:  after: PackRef($t6), PackRef($t9)
+    write_ref($t9, $t8)
+    $t10 := move(r)
+    return $t10
+}
+
+
+fun TestPackref::test2(x_ref: &mut u64, v: u64) {
+    var $t2: u64
+    var $t3: &mut u64
+    // live_refs: x_ref borrowed_by: LocalRoot(x_ref) -> {Reference(x_ref)} borrows_from: Reference(x_ref) -> {LocalRoot(x_ref)}
+    $t2 := copy(v)
+    // live_refs: x_ref borrowed_by: LocalRoot(x_ref) -> {Reference(x_ref)} borrows_from: Reference(x_ref) -> {LocalRoot(x_ref)}
+    $t3 := move(x_ref)
+    // live_refs: $t3 borrowed_by: LocalRoot(x_ref) -> {Reference($t3)} borrows_from: Reference($t3) -> {LocalRoot(x_ref)}
+    // before:  after: PackRef($t3)
+    write_ref($t3, $t2)
+    return ()
+}
+
+
+pub fun TestPackref::test3(r_ref: &mut TestPackref::R, v: u64) {
+    var x_ref: &mut u64
+    var $t3: &mut TestPackref::R
+    var $t4: &mut u64
+    var $t5: &mut u64
+    var $t6: u64
+    // live_refs: r_ref borrowed_by: LocalRoot(r_ref) -> {Reference(r_ref)} borrows_from: Reference(r_ref) -> {LocalRoot(r_ref)}
+    // before: UnpackRef(r_ref) after:
+    $t3 := move(r_ref)
+    // live_refs: $t3 borrowed_by: LocalRoot(r_ref) -> {Reference($t3)} borrows_from: Reference($t3) -> {LocalRoot(r_ref)}
+    // before:  after: UnpackRef($t4)
+    $t4 := borrow_field<TestPackref::R>.x($t3)
+    // live_refs: $t4 borrowed_by: LocalRoot(r_ref) -> {Reference($t4)}, Reference($t3) -> {Reference($t4)} borrows_from: Reference($t4) -> {LocalRoot(r_ref), Reference($t3)}
+    x_ref := $t4
+    // live_refs: x_ref borrowed_by: LocalRoot(r_ref) -> {Reference(x_ref)}, Reference($t3) -> {Reference(x_ref)} borrows_from: Reference(x_ref) -> {LocalRoot(r_ref), Reference($t3)}
+    $t5 := move(x_ref)
+    // live_refs: $t5 borrowed_by: LocalRoot(r_ref) -> {Reference($t5)}, Reference($t3) -> {Reference($t5)} borrows_from: Reference($t5) -> {LocalRoot(r_ref), Reference($t3)}
+    $t6 := copy(v)
+    // live_refs: $t5 borrowed_by: LocalRoot(r_ref) -> {Reference($t5)}, Reference($t3) -> {Reference($t5)} borrows_from: Reference($t5) -> {LocalRoot(r_ref), Reference($t3)}
+    // before:  after: PackRef($t3), PackRef($t5)
+    TestPackref::test2($t5, $t6)
+    // before: PackRef(r_ref) after:
+    return ()
+}
+
+
+fun TestPackref::test4(): TestPackref::R {
+    var r: TestPackref::R
+    var r_ref: &mut TestPackref::R
+    var $t2: u64
+    var $t3: TestPackref::R
+    var $t4: &mut TestPackref::R
+    var $t5: &mut TestPackref::R
+    var $t6: u64
+    var $t7: TestPackref::R
+    $t2 := 3
+    $t3 := pack TestPackref::R($t2)
+    r := $t3
+    // before:  after: UnpackRef($t4)
+    $t4 := borrow_local(r)
+    // live_refs: $t4 borrowed_by: LocalRoot(r) -> {Reference($t4)} borrows_from: Reference($t4) -> {LocalRoot(r)}
+    r_ref := $t4
+    // live_refs: r_ref borrowed_by: LocalRoot(r) -> {Reference(r_ref)} borrows_from: Reference(r_ref) -> {LocalRoot(r)}
+    $t5 := move(r_ref)
+    // live_refs: $t5 borrowed_by: LocalRoot(r) -> {Reference($t5)} borrows_from: Reference($t5) -> {LocalRoot(r)}
+    $t6 := 0
+    // live_refs: $t5 borrowed_by: LocalRoot(r) -> {Reference($t5)} borrows_from: Reference($t5) -> {LocalRoot(r)}
+    // before: PackRef($t5) after: UnpackRef($t5), PackRef($t5)
+    TestPackref::test3($t5, $t6)
+    $t7 := move(r)
+    return $t7
+}
+
+
+pub fun TestPackref::test5(r_ref: &mut TestPackref::R): &mut u64 {
+    var $t1: &mut TestPackref::R
+    var $t2: &mut u64
+    // live_refs: r_ref borrowed_by: LocalRoot(r_ref) -> {Reference(r_ref)} borrows_from: Reference(r_ref) -> {LocalRoot(r_ref)}
+    $t1 := move(r_ref)
+    // live_refs: $t1 borrowed_by: LocalRoot(r_ref) -> {Reference($t1)} borrows_from: Reference($t1) -> {LocalRoot(r_ref)}
+    // before:  after: UnpackRef($t2)
+    $t2 := borrow_field<TestPackref::R>.x($t1)
+    // live_refs: $t2 borrowed_by: LocalRoot(r_ref) -> {Reference($t2)}, Reference($t1) -> {Reference($t2)} borrows_from: Reference($t2) -> {LocalRoot(r_ref), Reference($t1)}
+    return $t2
+}
+
+
+fun TestPackref::test6(): TestPackref::R {
+    var r: TestPackref::R
+    var r_ref: &mut TestPackref::R
+    var x_ref: &mut u64
+    var $t3: u64
+    var $t4: TestPackref::R
+    var $t5: &mut TestPackref::R
+    var $t6: &mut TestPackref::R
+    var $t7: &mut u64
+    var $t8: &mut u64
+    var $t9: u64
+    var $t10: TestPackref::R
+    $t3 := 3
+    $t4 := pack TestPackref::R($t3)
+    r := $t4
+    // before:  after: UnpackRef($t5)
+    $t5 := borrow_local(r)
+    // live_refs: $t5 borrowed_by: LocalRoot(r) -> {Reference($t5)} borrows_from: Reference($t5) -> {LocalRoot(r)}
+    r_ref := $t5
+    // live_refs: r_ref borrowed_by: LocalRoot(r) -> {Reference(r_ref)} borrows_from: Reference(r_ref) -> {LocalRoot(r)}
+    $t6 := move(r_ref)
+    // live_refs: $t6 borrowed_by: LocalRoot(r) -> {Reference($t6)} borrows_from: Reference($t6) -> {LocalRoot(r)}
+    $t7 := TestPackref::test5($t6)
+    // live_refs: $t7 borrowed_by: LocalRoot(r) -> {Reference($t7)}, Reference($t6) -> {Reference($t7)} borrows_from: Reference($t7) -> {LocalRoot(r), Reference($t6)}
+    x_ref := $t7
+    // live_refs: x_ref borrowed_by: LocalRoot(r) -> {Reference(x_ref)}, Reference($t6) -> {Reference(x_ref)} borrows_from: Reference(x_ref) -> {LocalRoot(r), Reference($t6)}
+    $t8 := move(x_ref)
+    // live_refs: $t8 borrowed_by: LocalRoot(r) -> {Reference($t8)}, Reference($t6) -> {Reference($t8)} borrows_from: Reference($t8) -> {LocalRoot(r), Reference($t6)}
+    $t9 := 0
+    // live_refs: $t8 borrowed_by: LocalRoot(r) -> {Reference($t8)}, Reference($t6) -> {Reference($t8)} borrows_from: Reference($t8) -> {LocalRoot(r), Reference($t6)}
+    // before:  after: PackRef($t6), PackRef($t8)
+    TestPackref::test2($t8, $t9)
+    $t10 := move(r)
+    return $t10
+}
+
+
+fun TestPackref::test7(b: bool) {
+    var r1: TestPackref::R
+    var r2: TestPackref::R
+    var r_ref: &mut TestPackref::R
+    var $t4: u64
+    var $t5: TestPackref::R
+    var $t6: u64
+    var $t7: TestPackref::R
+    var $t8: &mut TestPackref::R
+    var $t9: bool
+    var $t10: &mut TestPackref::R
+    var $t11: &mut TestPackref::R
+    var $t12: &mut TestPackref::R
+    var $t13: u64
+    $t4 := 3
+    $t5 := pack TestPackref::R($t4)
+    r1 := $t5
+    $t6 := 4
+    $t7 := pack TestPackref::R($t6)
+    r2 := $t7
+    // before:  after: UnpackRef($t8)
+    $t8 := borrow_local(r1)
+    // live_refs: $t8 borrowed_by: LocalRoot(r1) -> {Reference($t8)} borrows_from: Reference($t8) -> {LocalRoot(r1)}
+    r_ref := $t8
+    // live_refs: r_ref borrowed_by: LocalRoot(r1) -> {Reference(r_ref)} borrows_from: Reference(r_ref) -> {LocalRoot(r1)}
+    $t9 := copy(b)
+    // live_refs: r_ref borrowed_by: LocalRoot(r1) -> {Reference(r_ref)} borrows_from: Reference(r_ref) -> {LocalRoot(r1)}
+    if ($t9) goto L0 else goto L1
+    // live_refs: r_ref borrowed_by: LocalRoot(r1) -> {Reference(r_ref)} borrows_from: Reference(r_ref) -> {LocalRoot(r1)}
+    L1:
+    // live_refs: r_ref borrowed_by: LocalRoot(r1) -> {Reference(r_ref)} borrows_from: Reference(r_ref) -> {LocalRoot(r1)}
+    goto L2
+    // live_refs: r_ref borrowed_by: LocalRoot(r1) -> {Reference(r_ref)} borrows_from: Reference(r_ref) -> {LocalRoot(r1)}
+    L0:
+    // live_refs: r_ref borrowed_by: LocalRoot(r1) -> {Reference(r_ref)} borrows_from: Reference(r_ref) -> {LocalRoot(r1)}
+    $t10 := move(r_ref)
+    // live_refs: $t10 borrowed_by: LocalRoot(r1) -> {Reference($t10)} borrows_from: Reference($t10) -> {LocalRoot(r1)}
+    // before:  after: PackRef($t10)
+    destroy($t10)
+    // before:  after: UnpackRef($t11)
+    $t11 := borrow_local(r2)
+    // live_refs: $t11 borrowed_by: LocalRoot(r2) -> {Reference($t11)} borrows_from: Reference($t11) -> {LocalRoot(r2)}
+    r_ref := $t11
+    // live_refs: r_ref borrowed_by: LocalRoot(r2) -> {Reference(r_ref)} borrows_from: Reference(r_ref) -> {LocalRoot(r2)}
+    goto L2
+    // live_refs: r_ref borrowed_by: LocalRoot(r1) -> {Reference(r_ref)}, LocalRoot(r2) -> {Reference(r_ref)} borrows_from: Reference(r_ref) -> {LocalRoot(r1), LocalRoot(r2)}
+    L2:
+    // live_refs: r_ref borrowed_by: LocalRoot(r1) -> {Reference(r_ref)}, LocalRoot(r2) -> {Reference(r_ref)} borrows_from: Reference(r_ref) -> {LocalRoot(r1), LocalRoot(r2)}
+    $t12 := move(r_ref)
+    // live_refs: $t12 borrowed_by: LocalRoot(r1) -> {Reference($t12)}, LocalRoot(r2) -> {Reference($t12)} borrows_from: Reference($t12) -> {LocalRoot(r1), LocalRoot(r2)}
+    $t13 := 0
+    // live_refs: $t12 borrowed_by: LocalRoot(r1) -> {Reference($t12)}, LocalRoot(r2) -> {Reference($t12)} borrows_from: Reference($t12) -> {LocalRoot(r1), LocalRoot(r2)}
+    // before: PackRef($t12) after: UnpackRef($t12), PackRef($t12)
+    TestPackref::test3($t12, $t13)
+    return ()
+}
+
+
+fun TestPackref::test8(n: u64, r_ref: &mut TestPackref::R) {
+    var r1: TestPackref::R
+    var r2: TestPackref::R
+    var $t4: u64
+    var $t5: TestPackref::R
+    var $t6: u64
+    var $t7: TestPackref::R
+    var $t8: u64
+    var $t9: u64
+    var $t10: bool
+    var $t11: &mut TestPackref::R
+    var $t12: u64
+    var $t13: u64
+    var $t14: u64
+    var $t15: u64
+    var $t16: bool
+    var $t17: &mut TestPackref::R
+    var $t18: &mut TestPackref::R
+    var $t19: u64
+    var $t20: u64
+    var $t21: u64
+    var $t22: &mut TestPackref::R
+    var $t23: u64
+    // live_refs: r_ref borrowed_by: LocalRoot(r_ref) -> {Reference(r_ref)} borrows_from: Reference(r_ref) -> {LocalRoot(r_ref)}
+    $t4 := 3
+    // live_refs: r_ref borrowed_by: LocalRoot(r_ref) -> {Reference(r_ref)} borrows_from: Reference(r_ref) -> {LocalRoot(r_ref)}
+    $t5 := pack TestPackref::R($t4)
+    // live_refs: r_ref borrowed_by: LocalRoot(r_ref) -> {Reference(r_ref)} borrows_from: Reference(r_ref) -> {LocalRoot(r_ref)}
+    r1 := $t5
+    // live_refs: r_ref borrowed_by: LocalRoot(r_ref) -> {Reference(r_ref)} borrows_from: Reference(r_ref) -> {LocalRoot(r_ref)}
+    $t6 := 4
+    // live_refs: r_ref borrowed_by: LocalRoot(r_ref) -> {Reference(r_ref)} borrows_from: Reference(r_ref) -> {LocalRoot(r_ref)}
+    $t7 := pack TestPackref::R($t6)
+    // live_refs: r_ref borrowed_by: LocalRoot(r_ref) -> {Reference(r_ref)} borrows_from: Reference(r_ref) -> {LocalRoot(r_ref)}
+    r2 := $t7
+    // live_refs: r_ref borrowed_by: LocalRoot(r_ref) -> {Reference(r_ref)} borrows_from: Reference(r_ref) -> {LocalRoot(r_ref)}
+    goto L7
+    // live_refs: r_ref borrowed_by: LocalRoot(r_ref) -> {Reference(r_ref)}, LocalRoot(r1) -> {Reference(r_ref)}, LocalRoot(r2) -> {Reference(r_ref)} borrows_from: Reference(r_ref) -> {LocalRoot(r_ref), LocalRoot(r1), LocalRoot(r2)}
+    L7:
+    // live_refs: r_ref borrowed_by: LocalRoot(r_ref) -> {Reference(r_ref)}, LocalRoot(r1) -> {Reference(r_ref)}, LocalRoot(r2) -> {Reference(r_ref)} borrows_from: Reference(r_ref) -> {LocalRoot(r_ref), LocalRoot(r1), LocalRoot(r2)}
+    $t8 := 0
+    // live_refs: r_ref borrowed_by: LocalRoot(r_ref) -> {Reference(r_ref)}, LocalRoot(r1) -> {Reference(r_ref)}, LocalRoot(r2) -> {Reference(r_ref)} borrows_from: Reference(r_ref) -> {LocalRoot(r_ref), LocalRoot(r1), LocalRoot(r2)}
+    $t9 := copy(n)
+    // live_refs: r_ref borrowed_by: LocalRoot(r_ref) -> {Reference(r_ref)}, LocalRoot(r1) -> {Reference(r_ref)}, LocalRoot(r2) -> {Reference(r_ref)} borrows_from: Reference(r_ref) -> {LocalRoot(r_ref), LocalRoot(r1), LocalRoot(r2)}
+    $t10 := <($t8, $t9)
+    // live_refs: r_ref borrowed_by: LocalRoot(r_ref) -> {Reference(r_ref)}, LocalRoot(r1) -> {Reference(r_ref)}, LocalRoot(r2) -> {Reference(r_ref)} borrows_from: Reference(r_ref) -> {LocalRoot(r_ref), LocalRoot(r1), LocalRoot(r2)}
+    if ($t10) goto L0 else goto L1
+    // live_refs: r_ref borrowed_by: LocalRoot(r_ref) -> {Reference(r_ref)}, LocalRoot(r1) -> {Reference(r_ref)}, LocalRoot(r2) -> {Reference(r_ref)} borrows_from: Reference(r_ref) -> {LocalRoot(r_ref), LocalRoot(r1), LocalRoot(r2)}
+    L1:
+    // live_refs: r_ref borrowed_by: LocalRoot(r_ref) -> {Reference(r_ref)}, LocalRoot(r1) -> {Reference(r_ref)}, LocalRoot(r2) -> {Reference(r_ref)} borrows_from: Reference(r_ref) -> {LocalRoot(r_ref), LocalRoot(r1), LocalRoot(r2)}
+    goto L2
+    // live_refs: r_ref borrowed_by: LocalRoot(r_ref) -> {Reference(r_ref)}, LocalRoot(r1) -> {Reference(r_ref)}, LocalRoot(r2) -> {Reference(r_ref)} borrows_from: Reference(r_ref) -> {LocalRoot(r_ref), LocalRoot(r1), LocalRoot(r2)}
+    L0:
+    // live_refs: r_ref borrowed_by: LocalRoot(r_ref) -> {Reference(r_ref)}, LocalRoot(r1) -> {Reference(r_ref)}, LocalRoot(r2) -> {Reference(r_ref)} borrows_from: Reference(r_ref) -> {LocalRoot(r_ref), LocalRoot(r1), LocalRoot(r2)}
+    $t11 := move(r_ref)
+    // live_refs: $t11 borrowed_by: LocalRoot(r_ref) -> {Reference($t11)}, LocalRoot(r1) -> {Reference($t11)}, LocalRoot(r2) -> {Reference($t11)} borrows_from: Reference($t11) -> {LocalRoot(r_ref), LocalRoot(r1), LocalRoot(r2)}
+    // before:  after: PackRef($t11)
+    destroy($t11)
+    $t12 := copy(n)
+    $t13 := 2
+    $t14 := /($t12, $t13)
+    $t15 := 0
+    $t16 := ==($t14, $t15)
+    if ($t16) goto L3 else goto L4
+    L4:
+    goto L5
+    L3:
+    // before:  after: UnpackRef($t17)
+    $t17 := borrow_local(r1)
+    // live_refs: $t17 borrowed_by: LocalRoot(r1) -> {Reference($t17)} borrows_from: Reference($t17) -> {LocalRoot(r1)}
+    r_ref := $t17
+    // live_refs: r_ref borrowed_by: LocalRoot(r1) -> {Reference(r_ref)} borrows_from: Reference(r_ref) -> {LocalRoot(r1)}
+    goto L6
+    L5:
+    // before:  after: UnpackRef($t18)
+    $t18 := borrow_local(r2)
+    // live_refs: $t18 borrowed_by: LocalRoot(r2) -> {Reference($t18)} borrows_from: Reference($t18) -> {LocalRoot(r2)}
+    r_ref := $t18
+    // live_refs: r_ref borrowed_by: LocalRoot(r2) -> {Reference(r_ref)} borrows_from: Reference(r_ref) -> {LocalRoot(r2)}
+    goto L6
+    // live_refs: r_ref borrowed_by: LocalRoot(r1) -> {Reference(r_ref)}, LocalRoot(r2) -> {Reference(r_ref)} borrows_from: Reference(r_ref) -> {LocalRoot(r1), LocalRoot(r2)}
+    L6:
+    // live_refs: r_ref borrowed_by: LocalRoot(r1) -> {Reference(r_ref)}, LocalRoot(r2) -> {Reference(r_ref)} borrows_from: Reference(r_ref) -> {LocalRoot(r1), LocalRoot(r2)}
+    $t19 := copy(n)
+    // live_refs: r_ref borrowed_by: LocalRoot(r1) -> {Reference(r_ref)}, LocalRoot(r2) -> {Reference(r_ref)} borrows_from: Reference(r_ref) -> {LocalRoot(r1), LocalRoot(r2)}
+    $t20 := 1
+    // live_refs: r_ref borrowed_by: LocalRoot(r1) -> {Reference(r_ref)}, LocalRoot(r2) -> {Reference(r_ref)} borrows_from: Reference(r_ref) -> {LocalRoot(r1), LocalRoot(r2)}
+    $t21 := -($t19, $t20)
+    // live_refs: r_ref borrowed_by: LocalRoot(r1) -> {Reference(r_ref)}, LocalRoot(r2) -> {Reference(r_ref)} borrows_from: Reference(r_ref) -> {LocalRoot(r1), LocalRoot(r2)}
+    n := $t21
+    // live_refs: r_ref borrowed_by: LocalRoot(r1) -> {Reference(r_ref)}, LocalRoot(r2) -> {Reference(r_ref)} borrows_from: Reference(r_ref) -> {LocalRoot(r1), LocalRoot(r2)}
+    goto L7
+    // live_refs: r_ref borrowed_by: LocalRoot(r_ref) -> {Reference(r_ref)}, LocalRoot(r1) -> {Reference(r_ref)}, LocalRoot(r2) -> {Reference(r_ref)} borrows_from: Reference(r_ref) -> {LocalRoot(r_ref), LocalRoot(r1), LocalRoot(r2)}
+    L2:
+    // live_refs: r_ref borrowed_by: LocalRoot(r_ref) -> {Reference(r_ref)}, LocalRoot(r1) -> {Reference(r_ref)}, LocalRoot(r2) -> {Reference(r_ref)} borrows_from: Reference(r_ref) -> {LocalRoot(r_ref), LocalRoot(r1), LocalRoot(r2)}
+    $t22 := move(r_ref)
+    // live_refs: $t22 borrowed_by: LocalRoot(r_ref) -> {Reference($t22)}, LocalRoot(r1) -> {Reference($t22)}, LocalRoot(r2) -> {Reference($t22)} borrows_from: Reference($t22) -> {LocalRoot(r_ref), LocalRoot(r1), LocalRoot(r2)}
+    $t23 := 0
+    // live_refs: $t22 borrowed_by: LocalRoot(r_ref) -> {Reference($t22)}, LocalRoot(r1) -> {Reference($t22)}, LocalRoot(r2) -> {Reference($t22)} borrows_from: Reference($t22) -> {LocalRoot(r_ref), LocalRoot(r1), LocalRoot(r2)}
+    // before: PackRef($t22) after: UnpackRef($t22), PackRef($t22)
+    TestPackref::test3($t22, $t23)
+    return ()
+}

--- a/language/move-prover/stackless-bytecode-generator/tests/packref/basic_test.move
+++ b/language/move-prover/stackless-bytecode-generator/tests/packref/basic_test.move
@@ -1,0 +1,65 @@
+module TestPackref {
+    struct R {
+        x: u64
+    }
+
+    fun test1() : R {
+        let r = R {x: 3};
+        let r_ref = &mut r;
+        let x_ref = &mut r_ref.x;
+        *x_ref = 0;
+        r
+    }
+
+    fun test2(x_ref: &mut u64, v: u64) {
+        *x_ref = v
+    }
+
+    public fun test3(r_ref: &mut R, v: u64) {
+        let x_ref = &mut r_ref.x;
+        test2(x_ref, v)
+    }
+
+    fun test4() : R {
+        let r = R {x: 3};
+        let r_ref = &mut r;
+        test3(r_ref, 0);
+        r
+    }
+
+    public fun test5(r_ref: &mut R) : &mut u64 {
+        &mut r_ref.x
+    }
+
+    fun test6() : R {
+        let r = R {x: 3};
+        let r_ref = &mut r;
+        let x_ref = test5(r_ref);
+        test2(x_ref, 0);
+        r
+    }
+
+    fun test7(b: bool) {
+        let r1 = R {x: 3};
+        let r2 = R {x: 4};
+        let r_ref = &mut r1;
+        if (b) {
+            r_ref = &mut r2;
+        };
+        test3(r_ref, 0)
+    }
+
+    fun test8(n: u64, r_ref: &mut R) {
+        let r1 = R {x: 3};
+        let r2 = R {x: 4};
+        while (0 < n) {
+            if (n/2 == 0) {
+                r_ref = &mut r1
+            } else {
+                r_ref = &mut r2;
+            };
+            n = n - 1
+        };
+        test3(r_ref, 0)
+    }
+}

--- a/language/move-prover/stackless-bytecode-generator/tests/testsuite.rs
+++ b/language/move-prover/stackless-bytecode-generator/tests/testsuite.rs
@@ -8,11 +8,15 @@ use codespan_reporting::term::termcolor::Buffer;
 
 use spec_lang::{env::GlobalEnv, run_spec_lang_compiler};
 use stackless_bytecode_generator::{
+    borrow_analysis::BorrowAnalysisProcessor,
     eliminate_imm_refs::EliminateImmRefsProcessor,
+    eliminate_mut_refs::EliminateMutRefsProcessor,
     function_target_pipeline::{FunctionTargetPipeline, FunctionTargetsHolder},
     lifetime_analysis::LifetimeAnalysisProcessor,
     livevar_analysis::LiveVarAnalysisProcessor,
+    packref_analysis::PackrefAnalysisProcessor,
     reaching_def_analysis::ReachingDefProcessor,
+    writeback_analysis::WritebackAnalysisProcessor,
 };
 use test_utils::{baseline_test::verify_or_update_baseline, extract_test_directives};
 
@@ -29,6 +33,39 @@ fn get_tested_transformation_pipeline(
         "livevar" => {
             let mut pipeline = FunctionTargetPipeline::default();
             pipeline.add_processor(Box::new(LiveVarAnalysisProcessor {}));
+            Ok(Some(pipeline))
+        }
+        "borrow" => {
+            let mut pipeline = FunctionTargetPipeline::default();
+            pipeline.add_processor(Box::new(EliminateImmRefsProcessor {}));
+            pipeline.add_processor(Box::new(LiveVarAnalysisProcessor {}));
+            pipeline.add_processor(Box::new(BorrowAnalysisProcessor {}));
+            Ok(Some(pipeline))
+        }
+        "writeback" => {
+            let mut pipeline = FunctionTargetPipeline::default();
+            pipeline.add_processor(Box::new(EliminateImmRefsProcessor {}));
+            pipeline.add_processor(Box::new(LiveVarAnalysisProcessor {}));
+            pipeline.add_processor(Box::new(BorrowAnalysisProcessor {}));
+            pipeline.add_processor(Box::new(WritebackAnalysisProcessor {}));
+            Ok(Some(pipeline))
+        }
+        "packref" => {
+            let mut pipeline = FunctionTargetPipeline::default();
+            pipeline.add_processor(Box::new(EliminateImmRefsProcessor {}));
+            pipeline.add_processor(Box::new(LiveVarAnalysisProcessor {}));
+            pipeline.add_processor(Box::new(BorrowAnalysisProcessor {}));
+            pipeline.add_processor(Box::new(PackrefAnalysisProcessor {}));
+            Ok(Some(pipeline))
+        }
+        "eliminate_mut_refs" => {
+            let mut pipeline = FunctionTargetPipeline::default();
+            pipeline.add_processor(Box::new(EliminateImmRefsProcessor {}));
+            pipeline.add_processor(Box::new(LiveVarAnalysisProcessor {}));
+            pipeline.add_processor(Box::new(BorrowAnalysisProcessor {}));
+            pipeline.add_processor(Box::new(WritebackAnalysisProcessor {}));
+            pipeline.add_processor(Box::new(PackrefAnalysisProcessor {}));
+            pipeline.add_processor(Box::new(EliminateMutRefsProcessor {}));
             Ok(Some(pipeline))
         }
         "lifetime" => {

--- a/language/move-prover/stackless-bytecode-generator/tests/writeback/basic_test.exp
+++ b/language/move-prover/stackless-bytecode-generator/tests/writeback/basic_test.exp
@@ -1,0 +1,535 @@
+============ initial translation from Move ================
+
+fun TestWriteback::test1(): TestWriteback::R {
+    var r: TestWriteback::R
+    var r_ref: &mut TestWriteback::R
+    var x_ref: &mut u64
+    var $t3: u64
+    var $t4: TestWriteback::R
+    var $t5: &mut TestWriteback::R
+    var $t6: &mut TestWriteback::R
+    var $t7: &mut u64
+    var $t8: u64
+    var $t9: &mut u64
+    var $t10: TestWriteback::R
+    $t3 := 3
+    $t4 := pack TestWriteback::R($t3)
+    r := $t4
+    $t5 := borrow_local(r)
+    r_ref := $t5
+    $t6 := move(r_ref)
+    $t7 := borrow_field<TestWriteback::R>.x($t6)
+    x_ref := $t7
+    $t8 := 0
+    $t9 := move(x_ref)
+    write_ref($t9, $t8)
+    $t10 := move(r)
+    return $t10
+}
+
+
+fun TestWriteback::test2(x_ref: &mut u64, v: u64) {
+    var $t2: u64
+    var $t3: &mut u64
+    $t2 := copy(v)
+    $t3 := move(x_ref)
+    write_ref($t3, $t2)
+    return ()
+}
+
+
+pub fun TestWriteback::test3(r_ref: &mut TestWriteback::R, v: u64) {
+    var x_ref: &mut u64
+    var $t3: &mut TestWriteback::R
+    var $t4: &mut u64
+    var $t5: &mut u64
+    var $t6: u64
+    $t3 := move(r_ref)
+    $t4 := borrow_field<TestWriteback::R>.x($t3)
+    x_ref := $t4
+    $t5 := move(x_ref)
+    $t6 := copy(v)
+    TestWriteback::test2($t5, $t6)
+    return ()
+}
+
+
+fun TestWriteback::test4(): TestWriteback::R {
+    var r: TestWriteback::R
+    var r_ref: &mut TestWriteback::R
+    var $t2: u64
+    var $t3: TestWriteback::R
+    var $t4: &mut TestWriteback::R
+    var $t5: &mut TestWriteback::R
+    var $t6: u64
+    var $t7: TestWriteback::R
+    $t2 := 3
+    $t3 := pack TestWriteback::R($t2)
+    r := $t3
+    $t4 := borrow_local(r)
+    r_ref := $t4
+    $t5 := move(r_ref)
+    $t6 := 0
+    TestWriteback::test3($t5, $t6)
+    $t7 := move(r)
+    return $t7
+}
+
+
+pub fun TestWriteback::test5(r_ref: &mut TestWriteback::R): &mut u64 {
+    var $t1: &mut TestWriteback::R
+    var $t2: &mut u64
+    $t1 := move(r_ref)
+    $t2 := borrow_field<TestWriteback::R>.x($t1)
+    return $t2
+}
+
+
+fun TestWriteback::test6(): TestWriteback::R {
+    var r: TestWriteback::R
+    var r_ref: &mut TestWriteback::R
+    var x_ref: &mut u64
+    var $t3: u64
+    var $t4: TestWriteback::R
+    var $t5: &mut TestWriteback::R
+    var $t6: &mut TestWriteback::R
+    var $t7: &mut u64
+    var $t8: &mut u64
+    var $t9: u64
+    var $t10: TestWriteback::R
+    $t3 := 3
+    $t4 := pack TestWriteback::R($t3)
+    r := $t4
+    $t5 := borrow_local(r)
+    r_ref := $t5
+    $t6 := move(r_ref)
+    $t7 := TestWriteback::test5($t6)
+    x_ref := $t7
+    $t8 := move(x_ref)
+    $t9 := 0
+    TestWriteback::test2($t8, $t9)
+    $t10 := move(r)
+    return $t10
+}
+
+
+fun TestWriteback::test7(b: bool) {
+    var r1: TestWriteback::R
+    var r2: TestWriteback::R
+    var r_ref: &mut TestWriteback::R
+    var $t4: u64
+    var $t5: TestWriteback::R
+    var $t6: u64
+    var $t7: TestWriteback::R
+    var $t8: &mut TestWriteback::R
+    var $t9: bool
+    var $t10: &mut TestWriteback::R
+    var $t11: &mut TestWriteback::R
+    var $t12: &mut TestWriteback::R
+    var $t13: u64
+    $t4 := 3
+    $t5 := pack TestWriteback::R($t4)
+    r1 := $t5
+    $t6 := 4
+    $t7 := pack TestWriteback::R($t6)
+    r2 := $t7
+    $t8 := borrow_local(r1)
+    r_ref := $t8
+    $t9 := copy(b)
+    if ($t9) goto L0 else goto L1
+    L1:
+    goto L2
+    L0:
+    $t10 := move(r_ref)
+    destroy($t10)
+    $t11 := borrow_local(r2)
+    r_ref := $t11
+    goto L2
+    L2:
+    $t12 := move(r_ref)
+    $t13 := 0
+    TestWriteback::test3($t12, $t13)
+    return ()
+}
+
+
+fun TestWriteback::test8(n: u64, r_ref: &mut TestWriteback::R) {
+    var r1: TestWriteback::R
+    var r2: TestWriteback::R
+    var $t4: u64
+    var $t5: TestWriteback::R
+    var $t6: u64
+    var $t7: TestWriteback::R
+    var $t8: u64
+    var $t9: u64
+    var $t10: bool
+    var $t11: &mut TestWriteback::R
+    var $t12: u64
+    var $t13: u64
+    var $t14: u64
+    var $t15: u64
+    var $t16: bool
+    var $t17: &mut TestWriteback::R
+    var $t18: &mut TestWriteback::R
+    var $t19: u64
+    var $t20: u64
+    var $t21: u64
+    var $t22: &mut TestWriteback::R
+    var $t23: u64
+    $t4 := 3
+    $t5 := pack TestWriteback::R($t4)
+    r1 := $t5
+    $t6 := 4
+    $t7 := pack TestWriteback::R($t6)
+    r2 := $t7
+    goto L7
+    L7:
+    $t8 := 0
+    $t9 := copy(n)
+    $t10 := <($t8, $t9)
+    if ($t10) goto L0 else goto L1
+    L1:
+    goto L2
+    L0:
+    $t11 := move(r_ref)
+    destroy($t11)
+    $t12 := copy(n)
+    $t13 := 2
+    $t14 := /($t12, $t13)
+    $t15 := 0
+    $t16 := ==($t14, $t15)
+    if ($t16) goto L3 else goto L4
+    L4:
+    goto L5
+    L3:
+    $t17 := borrow_local(r1)
+    r_ref := $t17
+    goto L6
+    L5:
+    $t18 := borrow_local(r2)
+    r_ref := $t18
+    goto L6
+    L6:
+    $t19 := copy(n)
+    $t20 := 1
+    $t21 := -($t19, $t20)
+    n := $t21
+    goto L7
+    L2:
+    $t22 := move(r_ref)
+    $t23 := 0
+    TestWriteback::test3($t22, $t23)
+    return ()
+}
+
+============ after pipeline `writeback` ================
+
+fun TestWriteback::test1(): TestWriteback::R {
+    var r: TestWriteback::R
+    var r_ref: &mut TestWriteback::R
+    var x_ref: &mut u64
+    var $t3: u64
+    var $t4: TestWriteback::R
+    var $t5: &mut TestWriteback::R
+    var $t6: &mut TestWriteback::R
+    var $t7: &mut u64
+    var $t8: u64
+    var $t9: &mut u64
+    var $t10: TestWriteback::R
+    $t3 := 3
+    $t4 := pack TestWriteback::R($t3)
+    r := $t4
+    $t5 := borrow_local(r)
+    // live_refs: $t5 borrowed_by: LocalRoot(r) -> {Reference($t5)} borrows_from: Reference($t5) -> {LocalRoot(r)}
+    r_ref := $t5
+    // live_refs: r_ref borrowed_by: LocalRoot(r) -> {Reference(r_ref)} borrows_from: Reference(r_ref) -> {LocalRoot(r)}
+    $t6 := move(r_ref)
+    // live_refs: $t6 borrowed_by: LocalRoot(r) -> {Reference($t6)} borrows_from: Reference($t6) -> {LocalRoot(r)}
+    // LocalRoot(r) <- $t6
+    $t7 := borrow_field<TestWriteback::R>.x($t6)
+    // live_refs: $t7 borrowed_by: LocalRoot(r) -> {Reference($t7)}, Reference($t6) -> {Reference($t7)} borrows_from: Reference($t7) -> {LocalRoot(r), Reference($t6)}
+    x_ref := $t7
+    // live_refs: x_ref borrowed_by: LocalRoot(r) -> {Reference(x_ref)}, Reference($t6) -> {Reference(x_ref)} borrows_from: Reference(x_ref) -> {LocalRoot(r), Reference($t6)}
+    $t8 := 0
+    // live_refs: x_ref borrowed_by: LocalRoot(r) -> {Reference(x_ref)}, Reference($t6) -> {Reference(x_ref)} borrows_from: Reference(x_ref) -> {LocalRoot(r), Reference($t6)}
+    $t9 := move(x_ref)
+    // live_refs: $t9 borrowed_by: LocalRoot(r) -> {Reference($t9)}, Reference($t6) -> {Reference($t9)} borrows_from: Reference($t9) -> {LocalRoot(r), Reference($t6)}
+    // LocalRoot(r) <- $t9, Reference($t6) <- $t9
+    write_ref($t9, $t8)
+    $t10 := move(r)
+    return $t10
+}
+
+
+fun TestWriteback::test2(x_ref: &mut u64, v: u64) {
+    var $t2: u64
+    var $t3: &mut u64
+    // live_refs: x_ref borrowed_by: LocalRoot(x_ref) -> {Reference(x_ref)} borrows_from: Reference(x_ref) -> {LocalRoot(x_ref)}
+    $t2 := copy(v)
+    // live_refs: x_ref borrowed_by: LocalRoot(x_ref) -> {Reference(x_ref)} borrows_from: Reference(x_ref) -> {LocalRoot(x_ref)}
+    $t3 := move(x_ref)
+    // live_refs: $t3 borrowed_by: LocalRoot(x_ref) -> {Reference($t3)} borrows_from: Reference($t3) -> {LocalRoot(x_ref)}
+    // LocalRoot(x_ref) <- $t3
+    write_ref($t3, $t2)
+    return ()
+}
+
+
+pub fun TestWriteback::test3(r_ref: &mut TestWriteback::R, v: u64) {
+    var x_ref: &mut u64
+    var $t3: &mut TestWriteback::R
+    var $t4: &mut u64
+    var $t5: &mut u64
+    var $t6: u64
+    // live_refs: r_ref borrowed_by: LocalRoot(r_ref) -> {Reference(r_ref)} borrows_from: Reference(r_ref) -> {LocalRoot(r_ref)}
+    $t3 := move(r_ref)
+    // live_refs: $t3 borrowed_by: LocalRoot(r_ref) -> {Reference($t3)} borrows_from: Reference($t3) -> {LocalRoot(r_ref)}
+    // LocalRoot(r_ref) <- $t3
+    $t4 := borrow_field<TestWriteback::R>.x($t3)
+    // live_refs: $t4 borrowed_by: LocalRoot(r_ref) -> {Reference($t4)}, Reference($t3) -> {Reference($t4)} borrows_from: Reference($t4) -> {LocalRoot(r_ref), Reference($t3)}
+    x_ref := $t4
+    // live_refs: x_ref borrowed_by: LocalRoot(r_ref) -> {Reference(x_ref)}, Reference($t3) -> {Reference(x_ref)} borrows_from: Reference(x_ref) -> {LocalRoot(r_ref), Reference($t3)}
+    $t5 := move(x_ref)
+    // live_refs: $t5 borrowed_by: LocalRoot(r_ref) -> {Reference($t5)}, Reference($t3) -> {Reference($t5)} borrows_from: Reference($t5) -> {LocalRoot(r_ref), Reference($t3)}
+    $t6 := copy(v)
+    // live_refs: $t5 borrowed_by: LocalRoot(r_ref) -> {Reference($t5)}, Reference($t3) -> {Reference($t5)} borrows_from: Reference($t5) -> {LocalRoot(r_ref), Reference($t3)}
+    // LocalRoot(r_ref) <- $t5, Reference($t3) <- $t5
+    TestWriteback::test2($t5, $t6)
+    return ()
+}
+
+
+fun TestWriteback::test4(): TestWriteback::R {
+    var r: TestWriteback::R
+    var r_ref: &mut TestWriteback::R
+    var $t2: u64
+    var $t3: TestWriteback::R
+    var $t4: &mut TestWriteback::R
+    var $t5: &mut TestWriteback::R
+    var $t6: u64
+    var $t7: TestWriteback::R
+    $t2 := 3
+    $t3 := pack TestWriteback::R($t2)
+    r := $t3
+    $t4 := borrow_local(r)
+    // live_refs: $t4 borrowed_by: LocalRoot(r) -> {Reference($t4)} borrows_from: Reference($t4) -> {LocalRoot(r)}
+    r_ref := $t4
+    // live_refs: r_ref borrowed_by: LocalRoot(r) -> {Reference(r_ref)} borrows_from: Reference(r_ref) -> {LocalRoot(r)}
+    $t5 := move(r_ref)
+    // live_refs: $t5 borrowed_by: LocalRoot(r) -> {Reference($t5)} borrows_from: Reference($t5) -> {LocalRoot(r)}
+    $t6 := 0
+    // live_refs: $t5 borrowed_by: LocalRoot(r) -> {Reference($t5)} borrows_from: Reference($t5) -> {LocalRoot(r)}
+    // LocalRoot(r) <- $t5
+    TestWriteback::test3($t5, $t6)
+    $t7 := move(r)
+    return $t7
+}
+
+
+pub fun TestWriteback::test5(r_ref: &mut TestWriteback::R): &mut u64 {
+    var $t1: &mut TestWriteback::R
+    var $t2: &mut u64
+    // live_refs: r_ref borrowed_by: LocalRoot(r_ref) -> {Reference(r_ref)} borrows_from: Reference(r_ref) -> {LocalRoot(r_ref)}
+    $t1 := move(r_ref)
+    // live_refs: $t1 borrowed_by: LocalRoot(r_ref) -> {Reference($t1)} borrows_from: Reference($t1) -> {LocalRoot(r_ref)}
+    // LocalRoot(r_ref) <- $t1
+    $t2 := borrow_field<TestWriteback::R>.x($t1)
+    // live_refs: $t2 borrowed_by: LocalRoot(r_ref) -> {Reference($t2)}, Reference($t1) -> {Reference($t2)} borrows_from: Reference($t2) -> {LocalRoot(r_ref), Reference($t1)}
+    return $t2
+}
+
+
+fun TestWriteback::test6(): TestWriteback::R {
+    var r: TestWriteback::R
+    var r_ref: &mut TestWriteback::R
+    var x_ref: &mut u64
+    var $t3: u64
+    var $t4: TestWriteback::R
+    var $t5: &mut TestWriteback::R
+    var $t6: &mut TestWriteback::R
+    var $t7: &mut u64
+    var $t8: &mut u64
+    var $t9: u64
+    var $t10: TestWriteback::R
+    $t3 := 3
+    $t4 := pack TestWriteback::R($t3)
+    r := $t4
+    $t5 := borrow_local(r)
+    // live_refs: $t5 borrowed_by: LocalRoot(r) -> {Reference($t5)} borrows_from: Reference($t5) -> {LocalRoot(r)}
+    r_ref := $t5
+    // live_refs: r_ref borrowed_by: LocalRoot(r) -> {Reference(r_ref)} borrows_from: Reference(r_ref) -> {LocalRoot(r)}
+    $t6 := move(r_ref)
+    // live_refs: $t6 borrowed_by: LocalRoot(r) -> {Reference($t6)} borrows_from: Reference($t6) -> {LocalRoot(r)}
+    // LocalRoot(r) <- $t6
+    $t7 := TestWriteback::test5($t6)
+    // live_refs: $t7 borrowed_by: LocalRoot(r) -> {Reference($t7)}, Reference($t6) -> {Reference($t7)} borrows_from: Reference($t7) -> {LocalRoot(r), Reference($t6)}
+    x_ref := $t7
+    // live_refs: x_ref borrowed_by: LocalRoot(r) -> {Reference(x_ref)}, Reference($t6) -> {Reference(x_ref)} borrows_from: Reference(x_ref) -> {LocalRoot(r), Reference($t6)}
+    $t8 := move(x_ref)
+    // live_refs: $t8 borrowed_by: LocalRoot(r) -> {Reference($t8)}, Reference($t6) -> {Reference($t8)} borrows_from: Reference($t8) -> {LocalRoot(r), Reference($t6)}
+    $t9 := 0
+    // live_refs: $t8 borrowed_by: LocalRoot(r) -> {Reference($t8)}, Reference($t6) -> {Reference($t8)} borrows_from: Reference($t8) -> {LocalRoot(r), Reference($t6)}
+    // LocalRoot(r) <- $t8, Reference($t6) <- $t8
+    TestWriteback::test2($t8, $t9)
+    $t10 := move(r)
+    return $t10
+}
+
+
+fun TestWriteback::test7(b: bool) {
+    var r1: TestWriteback::R
+    var r2: TestWriteback::R
+    var r_ref: &mut TestWriteback::R
+    var $t4: u64
+    var $t5: TestWriteback::R
+    var $t6: u64
+    var $t7: TestWriteback::R
+    var $t8: &mut TestWriteback::R
+    var $t9: bool
+    var $t10: &mut TestWriteback::R
+    var $t11: &mut TestWriteback::R
+    var $t12: &mut TestWriteback::R
+    var $t13: u64
+    $t4 := 3
+    $t5 := pack TestWriteback::R($t4)
+    r1 := $t5
+    $t6 := 4
+    $t7 := pack TestWriteback::R($t6)
+    r2 := $t7
+    $t8 := borrow_local(r1)
+    // live_refs: $t8 borrowed_by: LocalRoot(r1) -> {Reference($t8)} borrows_from: Reference($t8) -> {LocalRoot(r1)}
+    r_ref := $t8
+    // live_refs: r_ref borrowed_by: LocalRoot(r1) -> {Reference(r_ref)} borrows_from: Reference(r_ref) -> {LocalRoot(r1)}
+    $t9 := copy(b)
+    // live_refs: r_ref borrowed_by: LocalRoot(r1) -> {Reference(r_ref)} borrows_from: Reference(r_ref) -> {LocalRoot(r1)}
+    if ($t9) goto L0 else goto L1
+    // live_refs: r_ref borrowed_by: LocalRoot(r1) -> {Reference(r_ref)} borrows_from: Reference(r_ref) -> {LocalRoot(r1)}
+    L1:
+    // live_refs: r_ref borrowed_by: LocalRoot(r1) -> {Reference(r_ref)} borrows_from: Reference(r_ref) -> {LocalRoot(r1)}
+    goto L2
+    // live_refs: r_ref borrowed_by: LocalRoot(r1) -> {Reference(r_ref)} borrows_from: Reference(r_ref) -> {LocalRoot(r1)}
+    L0:
+    // live_refs: r_ref borrowed_by: LocalRoot(r1) -> {Reference(r_ref)} borrows_from: Reference(r_ref) -> {LocalRoot(r1)}
+    $t10 := move(r_ref)
+    // live_refs: $t10 borrowed_by: LocalRoot(r1) -> {Reference($t10)} borrows_from: Reference($t10) -> {LocalRoot(r1)}
+    // LocalRoot(r1) <- $t10
+    destroy($t10)
+    $t11 := borrow_local(r2)
+    // live_refs: $t11 borrowed_by: LocalRoot(r2) -> {Reference($t11)} borrows_from: Reference($t11) -> {LocalRoot(r2)}
+    r_ref := $t11
+    // live_refs: r_ref borrowed_by: LocalRoot(r2) -> {Reference(r_ref)} borrows_from: Reference(r_ref) -> {LocalRoot(r2)}
+    goto L2
+    // live_refs: r_ref borrowed_by: LocalRoot(r1) -> {Reference(r_ref)}, LocalRoot(r2) -> {Reference(r_ref)} borrows_from: Reference(r_ref) -> {LocalRoot(r1), LocalRoot(r2)}
+    L2:
+    // live_refs: r_ref borrowed_by: LocalRoot(r1) -> {Reference(r_ref)}, LocalRoot(r2) -> {Reference(r_ref)} borrows_from: Reference(r_ref) -> {LocalRoot(r1), LocalRoot(r2)}
+    $t12 := move(r_ref)
+    // live_refs: $t12 borrowed_by: LocalRoot(r1) -> {Reference($t12)}, LocalRoot(r2) -> {Reference($t12)} borrows_from: Reference($t12) -> {LocalRoot(r1), LocalRoot(r2)}
+    $t13 := 0
+    // live_refs: $t12 borrowed_by: LocalRoot(r1) -> {Reference($t12)}, LocalRoot(r2) -> {Reference($t12)} borrows_from: Reference($t12) -> {LocalRoot(r1), LocalRoot(r2)}
+    // LocalRoot(r1) <- $t12, LocalRoot(r2) <- $t12
+    TestWriteback::test3($t12, $t13)
+    return ()
+}
+
+
+fun TestWriteback::test8(n: u64, r_ref: &mut TestWriteback::R) {
+    var r1: TestWriteback::R
+    var r2: TestWriteback::R
+    var $t4: u64
+    var $t5: TestWriteback::R
+    var $t6: u64
+    var $t7: TestWriteback::R
+    var $t8: u64
+    var $t9: u64
+    var $t10: bool
+    var $t11: &mut TestWriteback::R
+    var $t12: u64
+    var $t13: u64
+    var $t14: u64
+    var $t15: u64
+    var $t16: bool
+    var $t17: &mut TestWriteback::R
+    var $t18: &mut TestWriteback::R
+    var $t19: u64
+    var $t20: u64
+    var $t21: u64
+    var $t22: &mut TestWriteback::R
+    var $t23: u64
+    // live_refs: r_ref borrowed_by: LocalRoot(r_ref) -> {Reference(r_ref)} borrows_from: Reference(r_ref) -> {LocalRoot(r_ref)}
+    $t4 := 3
+    // live_refs: r_ref borrowed_by: LocalRoot(r_ref) -> {Reference(r_ref)} borrows_from: Reference(r_ref) -> {LocalRoot(r_ref)}
+    $t5 := pack TestWriteback::R($t4)
+    // live_refs: r_ref borrowed_by: LocalRoot(r_ref) -> {Reference(r_ref)} borrows_from: Reference(r_ref) -> {LocalRoot(r_ref)}
+    r1 := $t5
+    // live_refs: r_ref borrowed_by: LocalRoot(r_ref) -> {Reference(r_ref)} borrows_from: Reference(r_ref) -> {LocalRoot(r_ref)}
+    $t6 := 4
+    // live_refs: r_ref borrowed_by: LocalRoot(r_ref) -> {Reference(r_ref)} borrows_from: Reference(r_ref) -> {LocalRoot(r_ref)}
+    $t7 := pack TestWriteback::R($t6)
+    // live_refs: r_ref borrowed_by: LocalRoot(r_ref) -> {Reference(r_ref)} borrows_from: Reference(r_ref) -> {LocalRoot(r_ref)}
+    r2 := $t7
+    // live_refs: r_ref borrowed_by: LocalRoot(r_ref) -> {Reference(r_ref)} borrows_from: Reference(r_ref) -> {LocalRoot(r_ref)}
+    goto L7
+    // live_refs: r_ref borrowed_by: LocalRoot(r_ref) -> {Reference(r_ref)}, LocalRoot(r1) -> {Reference(r_ref)}, LocalRoot(r2) -> {Reference(r_ref)} borrows_from: Reference(r_ref) -> {LocalRoot(r_ref), LocalRoot(r1), LocalRoot(r2)}
+    L7:
+    // live_refs: r_ref borrowed_by: LocalRoot(r_ref) -> {Reference(r_ref)}, LocalRoot(r1) -> {Reference(r_ref)}, LocalRoot(r2) -> {Reference(r_ref)} borrows_from: Reference(r_ref) -> {LocalRoot(r_ref), LocalRoot(r1), LocalRoot(r2)}
+    $t8 := 0
+    // live_refs: r_ref borrowed_by: LocalRoot(r_ref) -> {Reference(r_ref)}, LocalRoot(r1) -> {Reference(r_ref)}, LocalRoot(r2) -> {Reference(r_ref)} borrows_from: Reference(r_ref) -> {LocalRoot(r_ref), LocalRoot(r1), LocalRoot(r2)}
+    $t9 := copy(n)
+    // live_refs: r_ref borrowed_by: LocalRoot(r_ref) -> {Reference(r_ref)}, LocalRoot(r1) -> {Reference(r_ref)}, LocalRoot(r2) -> {Reference(r_ref)} borrows_from: Reference(r_ref) -> {LocalRoot(r_ref), LocalRoot(r1), LocalRoot(r2)}
+    $t10 := <($t8, $t9)
+    // live_refs: r_ref borrowed_by: LocalRoot(r_ref) -> {Reference(r_ref)}, LocalRoot(r1) -> {Reference(r_ref)}, LocalRoot(r2) -> {Reference(r_ref)} borrows_from: Reference(r_ref) -> {LocalRoot(r_ref), LocalRoot(r1), LocalRoot(r2)}
+    if ($t10) goto L0 else goto L1
+    // live_refs: r_ref borrowed_by: LocalRoot(r_ref) -> {Reference(r_ref)}, LocalRoot(r1) -> {Reference(r_ref)}, LocalRoot(r2) -> {Reference(r_ref)} borrows_from: Reference(r_ref) -> {LocalRoot(r_ref), LocalRoot(r1), LocalRoot(r2)}
+    L1:
+    // live_refs: r_ref borrowed_by: LocalRoot(r_ref) -> {Reference(r_ref)}, LocalRoot(r1) -> {Reference(r_ref)}, LocalRoot(r2) -> {Reference(r_ref)} borrows_from: Reference(r_ref) -> {LocalRoot(r_ref), LocalRoot(r1), LocalRoot(r2)}
+    goto L2
+    // live_refs: r_ref borrowed_by: LocalRoot(r_ref) -> {Reference(r_ref)}, LocalRoot(r1) -> {Reference(r_ref)}, LocalRoot(r2) -> {Reference(r_ref)} borrows_from: Reference(r_ref) -> {LocalRoot(r_ref), LocalRoot(r1), LocalRoot(r2)}
+    L0:
+    // live_refs: r_ref borrowed_by: LocalRoot(r_ref) -> {Reference(r_ref)}, LocalRoot(r1) -> {Reference(r_ref)}, LocalRoot(r2) -> {Reference(r_ref)} borrows_from: Reference(r_ref) -> {LocalRoot(r_ref), LocalRoot(r1), LocalRoot(r2)}
+    $t11 := move(r_ref)
+    // live_refs: $t11 borrowed_by: LocalRoot(r_ref) -> {Reference($t11)}, LocalRoot(r1) -> {Reference($t11)}, LocalRoot(r2) -> {Reference($t11)} borrows_from: Reference($t11) -> {LocalRoot(r_ref), LocalRoot(r1), LocalRoot(r2)}
+    // LocalRoot(r_ref) <- $t11, LocalRoot(r1) <- $t11, LocalRoot(r2) <- $t11
+    destroy($t11)
+    $t12 := copy(n)
+    $t13 := 2
+    $t14 := /($t12, $t13)
+    $t15 := 0
+    $t16 := ==($t14, $t15)
+    if ($t16) goto L3 else goto L4
+    L4:
+    goto L5
+    L3:
+    $t17 := borrow_local(r1)
+    // live_refs: $t17 borrowed_by: LocalRoot(r1) -> {Reference($t17)} borrows_from: Reference($t17) -> {LocalRoot(r1)}
+    r_ref := $t17
+    // live_refs: r_ref borrowed_by: LocalRoot(r1) -> {Reference(r_ref)} borrows_from: Reference(r_ref) -> {LocalRoot(r1)}
+    goto L6
+    L5:
+    $t18 := borrow_local(r2)
+    // live_refs: $t18 borrowed_by: LocalRoot(r2) -> {Reference($t18)} borrows_from: Reference($t18) -> {LocalRoot(r2)}
+    r_ref := $t18
+    // live_refs: r_ref borrowed_by: LocalRoot(r2) -> {Reference(r_ref)} borrows_from: Reference(r_ref) -> {LocalRoot(r2)}
+    goto L6
+    // live_refs: r_ref borrowed_by: LocalRoot(r1) -> {Reference(r_ref)}, LocalRoot(r2) -> {Reference(r_ref)} borrows_from: Reference(r_ref) -> {LocalRoot(r1), LocalRoot(r2)}
+    L6:
+    // live_refs: r_ref borrowed_by: LocalRoot(r1) -> {Reference(r_ref)}, LocalRoot(r2) -> {Reference(r_ref)} borrows_from: Reference(r_ref) -> {LocalRoot(r1), LocalRoot(r2)}
+    $t19 := copy(n)
+    // live_refs: r_ref borrowed_by: LocalRoot(r1) -> {Reference(r_ref)}, LocalRoot(r2) -> {Reference(r_ref)} borrows_from: Reference(r_ref) -> {LocalRoot(r1), LocalRoot(r2)}
+    $t20 := 1
+    // live_refs: r_ref borrowed_by: LocalRoot(r1) -> {Reference(r_ref)}, LocalRoot(r2) -> {Reference(r_ref)} borrows_from: Reference(r_ref) -> {LocalRoot(r1), LocalRoot(r2)}
+    $t21 := -($t19, $t20)
+    // live_refs: r_ref borrowed_by: LocalRoot(r1) -> {Reference(r_ref)}, LocalRoot(r2) -> {Reference(r_ref)} borrows_from: Reference(r_ref) -> {LocalRoot(r1), LocalRoot(r2)}
+    n := $t21
+    // live_refs: r_ref borrowed_by: LocalRoot(r1) -> {Reference(r_ref)}, LocalRoot(r2) -> {Reference(r_ref)} borrows_from: Reference(r_ref) -> {LocalRoot(r1), LocalRoot(r2)}
+    goto L7
+    // live_refs: r_ref borrowed_by: LocalRoot(r_ref) -> {Reference(r_ref)}, LocalRoot(r1) -> {Reference(r_ref)}, LocalRoot(r2) -> {Reference(r_ref)} borrows_from: Reference(r_ref) -> {LocalRoot(r_ref), LocalRoot(r1), LocalRoot(r2)}
+    L2:
+    // live_refs: r_ref borrowed_by: LocalRoot(r_ref) -> {Reference(r_ref)}, LocalRoot(r1) -> {Reference(r_ref)}, LocalRoot(r2) -> {Reference(r_ref)} borrows_from: Reference(r_ref) -> {LocalRoot(r_ref), LocalRoot(r1), LocalRoot(r2)}
+    $t22 := move(r_ref)
+    // live_refs: $t22 borrowed_by: LocalRoot(r_ref) -> {Reference($t22)}, LocalRoot(r1) -> {Reference($t22)}, LocalRoot(r2) -> {Reference($t22)} borrows_from: Reference($t22) -> {LocalRoot(r_ref), LocalRoot(r1), LocalRoot(r2)}
+    $t23 := 0
+    // live_refs: $t22 borrowed_by: LocalRoot(r_ref) -> {Reference($t22)}, LocalRoot(r1) -> {Reference($t22)}, LocalRoot(r2) -> {Reference($t22)} borrows_from: Reference($t22) -> {LocalRoot(r_ref), LocalRoot(r1), LocalRoot(r2)}
+    // LocalRoot(r_ref) <- $t22, LocalRoot(r1) <- $t22, LocalRoot(r2) <- $t22
+    TestWriteback::test3($t22, $t23)
+    return ()
+}

--- a/language/move-prover/stackless-bytecode-generator/tests/writeback/basic_test.move
+++ b/language/move-prover/stackless-bytecode-generator/tests/writeback/basic_test.move
@@ -1,0 +1,65 @@
+module TestWriteback {
+    struct R {
+        x: u64
+    }
+
+    fun test1() : R {
+        let r = R {x: 3};
+        let r_ref = &mut r;
+        let x_ref = &mut r_ref.x;
+        *x_ref = 0;
+        r
+    }
+
+    fun test2(x_ref: &mut u64, v: u64) {
+        *x_ref = v
+    }
+
+    public fun test3(r_ref: &mut R, v: u64) {
+        let x_ref = &mut r_ref.x;
+        test2(x_ref, v)
+    }
+
+    fun test4() : R {
+        let r = R {x: 3};
+        let r_ref = &mut r;
+        test3(r_ref, 0);
+        r
+    }
+
+    public fun test5(r_ref: &mut R) : &mut u64 {
+        &mut r_ref.x
+    }
+
+    fun test6() : R {
+        let r = R {x: 3};
+        let r_ref = &mut r;
+        let x_ref = test5(r_ref);
+        test2(x_ref, 0);
+        r
+    }
+
+    fun test7(b: bool) {
+        let r1 = R {x: 3};
+        let r2 = R {x: 4};
+        let r_ref = &mut r1;
+        if (b) {
+            r_ref = &mut r2;
+        };
+        test3(r_ref, 0)
+    }
+
+    fun test8(n: u64, r_ref: &mut R) {
+        let r1 = R {x: 3};
+        let r2 = R {x: 4};
+        while (0 < n) {
+            if (n/2 == 0) {
+                r_ref = &mut r1
+            } else {
+                r_ref = &mut r2;
+            };
+            n = n - 1
+        };
+        test3(r_ref, 0)
+    }
+}


### PR DESCRIPTION
## Motivation

This PR takes an initial step toward implementing the new memory model.  Specifically, the following new concepts are introduced:
- A forward dataflow analysis (borrow_analysis) that leverages the live variable analysis and computes live references and borrowed_from edges at each control point.  Importantly, the borrow analysis uses the shared borrow graph used by the Move language and Move bytecode verifier.  This borrow analysis also attempts to adhere to the borrow checking algorithm in Move bytecode verifier.  These two aspects make this borrow analysis different from that implemented in lifetime analysis.
- Two bytecodes WriteBack and Splice for "bookkeeping" operations in the new memory model. The new analysis writeback_analysis computes WriteBack operations at bytecode offsets using the results of borrow_analysis.
- Two bytecodes UnpackRef and PackRef that make explicit in the bytecode the pack/unpack methodology.  The new analysis packref_analysis heuristically generates UnpackRef and PackRef instructions at bytecode offsets using the results of borrow_analysis.
- A transform (eliminate_mut_refs) that takes the resulting bytecode (on which WriteBack, UnpackRef and PackRef are annotated) and localizes all references to individual functions by doing two things: (1) Encoding reference passing as copy-in/copy-out, (2) Splicing references returned from a function into the caller's references using the new Splice bytecode.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

Pipeline tests have been added for the new analyses and transformations.

## Related PRs

