### PR TITLE
[move source lang] Don't type check dependencies

### DIFF
--- a/language/move-lang/src/typing/globals.rs
+++ b/language/move-lang/src/typing/globals.rs
@@ -24,7 +24,7 @@ pub fn function_body_(
 ) {
     let mut seen = Seen::new();
     match b_ {
-        T::FunctionBody_::Native => (),
+        T::FunctionBody_::Native => return,
         T::FunctionBody_::Defined(es) => sequence(context, annotated_acquires, &mut seen, es),
     }
 


### PR DESCRIPTION
## Motivation

- For efficiency, dependencies now have all of their structs and functions marked as native
- The signatures will still be checked, but the bodies will be affectively skipped

## Test Plan

- cargo test