### PR TITLE
[move-prover] Eliminate fall through and make all control jumps explicit

### DIFF
--- a/language/move-prover/stackless-bytecode-generator/src/stackless_bytecode.rs
+++ b/language/move-prover/stackless-bytecode-generator/src/stackless_bytecode.rs
@@ -220,27 +220,15 @@ impl Bytecode {
         label_offsets: &BTreeMap<Label, CodeOffset>,
     ) -> Vec<CodeOffset> {
         let bytecode = &code[pc as usize];
+        assert!(bytecode.is_branch());
         let mut v = vec![];
-
         for label in bytecode.branch_dests() {
             v.push(*label_offsets.get(&label).expect("label defined"));
         }
-
-        let next_pc = pc + 1;
-        if next_pc >= code.len() as CodeOffset {
-            return v;
-        }
-
-        if !bytecode.is_unconditional_branch() && !v.contains(&next_pc) {
-            // avoid duplicates
-            v.push(next_pc);
-        }
-
         // always give successors in ascending order
         if v.len() > 1 && v[0] > v[1] {
             v.swap(0, 1);
         }
-
         v
     }
 }

--- a/language/move-prover/stackless-bytecode-generator/tests/from_move/regression_generic_and_native_type.exp
+++ b/language/move-prover/stackless-bytecode-generator/tests/from_move/regression_generic_and_native_type.exp
@@ -12,6 +12,7 @@ pub fun Vector::append<$tv0>(lhs: &mut vector<#0>, other: vector<#0>) {
     var $t10: vector<#0>
     $t2 := borrow_local(other)
     Vector::reverse<#0>($t2)
+    goto L3
     L3:
     $t3 := borrow_local(other)
     $t4 := Vector::is_empty<#0>($t3)
@@ -70,6 +71,7 @@ pub fun Vector::contains<$tv0>(v: &vector<#0>, e: &#0): bool {
     $t5 := copy(v)
     $t6 := Vector::length<#0>($t5)
     len := $t6
+    goto L6
     L6:
     $t7 := copy(i)
     $t8 := copy(len)
@@ -190,6 +192,7 @@ pub fun Vector::remove<$tv0>(v: &mut vector<#0>, i: u64): #0 {
     $t14 := 1
     $t15 := -($t13, $t14)
     len := $t15
+    goto L6
     L6:
     $t16 := copy(i)
     $t17 := copy(len)
@@ -267,6 +270,7 @@ pub fun Vector::reverse<$tv0>(v: &mut vector<#0>) {
     $t13 := 1
     $t14 := -($t12, $t13)
     back_index := $t14
+    goto L6
     L6:
     $t15 := copy(front_index)
     $t16 := copy(back_index)

--- a/language/move-prover/stackless-bytecode-generator/tests/from_move/smoke_test.exp
+++ b/language/move-prover/stackless-bytecode-generator/tests/from_move/smoke_test.exp
@@ -90,6 +90,7 @@ fun SmokeTest::bool_ops(a: u64, b: u64): (bool, bool) {
     L2:
     $t12 := false
     $t4 := $t12
+    goto L3
     L3:
     $t13 := move($t4)
     c := $t13
@@ -108,6 +109,7 @@ fun SmokeTest::bool_ops(a: u64, b: u64): (bool, bool) {
     $t19 := copy(b)
     $t20 := <=($t18, $t19)
     $t5 := $t20
+    goto L7
     L7:
     $t21 := move($t5)
     d := $t21
@@ -333,6 +335,7 @@ fun SmokeTest::ref_A(a: address, b: bool): SmokeTest::A {
     $t12 := 42
     $t13 := pack SmokeTest::A($t11, $t12)
     $t4 := $t13
+    goto L3
     L3:
     $t14 := move($t4)
     var_a := $t14

--- a/language/move-prover/stackless-bytecode-generator/tests/from_move/specs-in-fun.exp
+++ b/language/move-prover/stackless-bytecode-generator/tests/from_move/specs-in-fun.exp
@@ -9,6 +9,7 @@ fun TestSpecBlock::looping(x: u64): u64 {
     var $t6: u64
     var $t7: u64
     spec at 592..616
+    goto L3
     L3:
     $t1 := copy(x)
     $t2 := 10

--- a/language/move-prover/stackless-bytecode-generator/tests/lifetime/basic_test.exp
+++ b/language/move-prover/stackless-bytecode-generator/tests/lifetime/basic_test.exp
@@ -55,6 +55,7 @@ fun TestLifetime::lifetime_(cond: bool): (TestLifetime::T, TestLifetime::S) {
     $t18 := move(b_ref)
     $t19 := borrow_field<TestLifetime::S>.y($t18)
     $t5 := $t19
+    goto L3
     L3:
     $t20 := move($t5)
     x_ref := $t20
@@ -71,6 +72,7 @@ fun TestLifetime::lifetime_(cond: bool): (TestLifetime::T, TestLifetime::S) {
     $t24 := 0
     $t25 := move(x_ref)
     write_ref($t25, $t24)
+    goto L7
     L7:
     $t26 := move(a)
     $t27 := move(b)
@@ -223,6 +225,7 @@ fun TestLifetime::lifetime_(cond: bool): (TestLifetime::T, TestLifetime::S) {
     $t18 := move(b_ref)
     $t19 := borrow_field<TestLifetime::S>.y($t18)
     $t5 := $t19
+    goto L3
     L3:
     $t20 := move($t5)
     x_ref := $t20
@@ -241,6 +244,7 @@ fun TestLifetime::lifetime_(cond: bool): (TestLifetime::T, TestLifetime::S) {
     $t25 := move(x_ref)
     // mut ends: $t15, $t18, $t25
     write_ref($t25, $t24)
+    goto L7
     L7:
     $t26 := move(a)
     $t27 := move(b)

--- a/language/move-prover/stackless-bytecode-generator/tests/livevar/basic_test.exp
+++ b/language/move-prover/stackless-bytecode-generator/tests/livevar/basic_test.exp
@@ -46,6 +46,7 @@ fun TestLiveVars::test2(b: bool): u64 {
     destroy($t10)
     $t11 := borrow_local(r2)
     r_ref := $t11
+    goto L2
     L2:
     $t12 := move(r_ref)
     $t13 := TestLiveVars::test1($t12)
@@ -82,6 +83,7 @@ fun TestLiveVars::test3(n: u64, r_ref: &TestLiveVars::R): u64 {
     $t6 := 4
     $t7 := pack TestLiveVars::R($t6)
     r2 := $t7
+    goto L7
     L7:
     $t8 := 0
     $t9 := copy(n)
@@ -107,6 +109,7 @@ fun TestLiveVars::test3(n: u64, r_ref: &TestLiveVars::R): u64 {
     L5:
     $t18 := borrow_local(r2)
     r_ref := $t18
+    goto L6
     L6:
     $t19 := copy(n)
     $t20 := 1
@@ -191,6 +194,8 @@ fun TestLiveVars::test2(b: bool): u64 {
     // live vars: $t11
     r_ref := $t11
     // live vars: r_ref
+    goto L2
+    // live vars: r_ref
     L2:
     // live vars: r_ref
     $t12 := move(r_ref)
@@ -236,6 +241,8 @@ fun TestLiveVars::test3(n: u64, r_ref: &TestLiveVars::R): u64 {
     $t7 := pack TestLiveVars::R($t6)
     // live vars: n, r_ref, r1, $t7
     r2 := $t7
+    // live vars: n, r_ref, r1, r2
+    goto L7
     // live vars: n, r_ref, r1, r2
     L7:
     // live vars: n, r_ref, r1, r2
@@ -286,6 +293,8 @@ fun TestLiveVars::test3(n: u64, r_ref: &TestLiveVars::R): u64 {
     $t18 := borrow_local(r2)
     // live vars: n, r1, r2, $t18
     r_ref := $t18
+    // live vars: n, r_ref, r1, r2
+    goto L6
     // live vars: n, r_ref, r1, r2
     L6:
     // live vars: n, r_ref, r1, r2


### PR DESCRIPTION
## Motivation

In an earlier PR #3656, I attempted to make all control jumps explicit by eliminate all sources of fall through.   I missed one case however which I am fixing with this PR.  As a result, the implementation of get_successors is tightened.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

Existing tests

## Related PRs

#3656 