### PR TITLE
[network] record RPC request latency with corresponding counter

### DIFF
--- a/language/stdlib/modules/libra.move
+++ b/language/stdlib/modules/libra.move
@@ -93,7 +93,7 @@ module Libra {
         burn_events: Event::EventHandle<BurnEvent>,
         // event stream for preburn requests
         preburn_events: Event::EventHandle<PreburnEvent>,
-        // event stream for cancelled prebunr requests
+        // event stream for canceled prebunr requests
         cancel_burn_events: Event::EventHandle<CancelBurnEvent>,
     }
 

--- a/network/onchain-discovery/src/service.rs
+++ b/network/onchain-discovery/src/service.rs
@@ -136,7 +136,7 @@ async fn handle_query_discovery_set_request(
     let peer_id_short = peer_id.short_str();
 
     // cancel the internal storage rpc request early if the external rpc request
-    // is cancelled.
+    // is canceled.
     futures::select! {
         res = storage_query_discovery_set(storage_read_client, req_msg).fuse() => {
             let (_req_msg, res_msg) = match res {

--- a/network/src/connectivity_manager/mod.rs
+++ b/network/src/connectivity_manager/mod.rs
@@ -68,7 +68,7 @@ pub struct ConnectivityManager<TTicker, TBackoff> {
     connection_notifs_rx: conn_status_channel::Receiver,
     /// Channel over which we receive requests from other actors.
     requests_rx: channel::Receiver<ConnectivityRequest>,
-    /// Peers queued to be dialed, potentially with some delay. The dial can be cancelled by
+    /// Peers queued to be dialed, potentially with some delay. The dial can be canceled by
     /// sending over (or dropping) the associated oneshot sender.
     dial_queue: HashMap<PeerId, oneshot::Sender<()>>,
     /// The state of any currently executing dials. Used to keep track of what
@@ -331,7 +331,7 @@ where
                         .deadline()
                         .duration_since(tokio::time::Instant::from_std(now))
                 );
-                // We dial after a delay. The dial can be cancelled by sending to or dropping
+                // We dial after a delay. The dial can be canceled by sending to or dropping
                 // `cancel_rx`.
                 let dial_result = ::futures::select! {
                     _ = f_delay.fuse() => {

--- a/network/src/counters.rs
+++ b/network/src/counters.rs
@@ -2,10 +2,21 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use libra_metrics::{
-    register_histogram, register_histogram_vec, register_int_counter_vec, register_int_gauge_vec,
-    Histogram, HistogramVec, IntCounterVec, IntGauge, IntGaugeVec, OpMetrics,
+    register_histogram_vec, register_int_counter_vec, register_int_gauge_vec, HistogramVec,
+    IntCounterVec, IntGauge, IntGaugeVec, OpMetrics,
 };
 use once_cell::sync::Lazy;
+
+// some type labels
+pub const REQUEST_LABEL: &str = "request";
+pub const RESPONSE_LABEL: &str = "response";
+
+// some state labels
+pub const CANCELED_LABEL: &str = "canceled";
+pub const DECLINED_LABEL: &str = "declined";
+pub const FAILED_LABEL: &str = "failed";
+pub const RECEIVED_LABEL: &str = "received";
+pub const SENT_LABEL: &str = "sent";
 
 pub static LIBRA_NETWORK_PEERS: Lazy<IntGaugeVec> = Lazy::new(|| {
     register_int_gauge_vec!(
@@ -49,10 +60,11 @@ pub static LIBRA_NETWORK_RPC_BYTES: Lazy<HistogramVec> = Lazy::new(|| {
     .unwrap()
 });
 
-pub static LIBRA_NETWORK_RPC_LATENCY: Lazy<Histogram> = Lazy::new(|| {
-    register_histogram!(
+pub static LIBRA_NETWORK_RPC_LATENCY: Lazy<HistogramVec> = Lazy::new(|| {
+    register_histogram_vec!(
         "libra_network_rpc_latency_seconds",
-        "Libra network rpc latency histogram"
+        "Libra network rpc latency histogram",
+        &["type", "protocol_id", "peer_id"]
     )
     .unwrap()
 });

--- a/network/src/protocols/rpc/test.rs
+++ b/network/src/protocols/rpc/test.rs
@@ -8,6 +8,7 @@
 
 use super::{error::RpcError, *};
 use crate::{
+    counters::{CANCELED_LABEL, FAILED_LABEL, REQUEST_LABEL, RESPONSE_LABEL},
     peer::{PeerNotification, PeerRequest},
     peer_manager::PeerManagerError,
 };
@@ -355,11 +356,11 @@ fn outbound_cancellation_before_send() {
             .await
             .unwrap();
 
-        // drop res_rx to cancel the rpc request and wait for request to be cancelled.
+        // drop res_rx to cancel the rpc request and wait for request to be canceled.
         drop(res_rx);
 
         while counters::LIBRA_NETWORK_RPC_MESSAGES
-            .with_label_values(&["request", "cancelled"])
+            .with_label_values(&[REQUEST_LABEL, CANCELED_LABEL])
             .get() as u64
             != 1
         {
@@ -369,7 +370,7 @@ fn outbound_cancellation_before_send() {
     rt.block_on(f_send_rpc);
 }
 
-// Test that outbound rpcs can be cancelled before receiving response.
+// Test that outbound rpcs can be canceled before receiving response.
 #[test]
 #[serial]
 fn outbound_cancellation_before_recv() {
@@ -401,11 +402,11 @@ fn outbound_cancellation_before_recv() {
         // mock sending to remote peer.
         expect_successful_send(&mut peer_reqs_rx, protocol_id, request).await;
 
-        // drop res_rx to cancel the rpc request and wait for request to be cancelled.
+        // drop res_rx to cancel the rpc request and wait for request to be canceled.
         drop(res_rx);
 
         while counters::LIBRA_NETWORK_RPC_MESSAGES
-            .with_label_values(&["request", "cancelled"])
+            .with_label_values(&[REQUEST_LABEL, CANCELED_LABEL])
             .get() as u64
             != 1
         {
@@ -601,7 +602,7 @@ fn inbound_rpc_timeout() {
         tokio::time::delay_for(Duration::from_millis(1500)).await;
         assert_eq!(
             counters::LIBRA_NETWORK_RPC_MESSAGES
-                .with_label_values(&["response", "failed"])
+                .with_label_values(&[RESPONSE_LABEL, FAILED_LABEL])
                 .get() as u64,
             1
         );
@@ -650,7 +651,7 @@ fn inbound_rpc_failed_response_delivery() {
         .await;
         // Failure counter should increase.
         while counters::LIBRA_NETWORK_RPC_MESSAGES
-            .with_label_values(&["response", "failed"])
+            .with_label_values(&[RESPONSE_LABEL, FAILED_LABEL])
             .get() as u64
             != 1
         {
@@ -688,7 +689,7 @@ fn inbound_rpc_failed_upstream_delivery() {
             .unwrap();
         // Failure counter should increase.
         while counters::LIBRA_NETWORK_RPC_MESSAGES
-            .with_label_values(&["response", "failed"])
+            .with_label_values(&[RESPONSE_LABEL, FAILED_LABEL])
             .get() as u64
             != 1
         {

--- a/network/src/protocols/wire/handshake/v1/mod.rs
+++ b/network/src/protocols/wire/handshake/v1/mod.rs
@@ -11,7 +11,7 @@
 //! intersecting messaging protocol version and use that for the remainder of the session.
 
 use serde::{Deserialize, Serialize};
-use std::{collections::BTreeMap, convert::TryInto, iter::Iterator};
+use std::{collections::BTreeMap, convert::TryInto, fmt, iter::Iterator};
 
 #[cfg(test)]
 mod test;
@@ -29,6 +29,28 @@ pub enum ProtocolId {
     HealthCheckerRpc = 5,
     IdentityDirectSend = 6,
     OnchainDiscoveryRpc = 7,
+}
+
+impl ProtocolId {
+    pub fn as_str(self) -> &'static str {
+        use ProtocolId::*;
+        match self {
+            ConsensusRpc => "ConsensusRpc",
+            ConsensusDirectSend => "ConsensusDirectSend",
+            MempoolDirectSend => "MempoolDirectSend",
+            StateSynchronizerDirectSend => "StateSynchronizerDirectSend",
+            DiscoveryDirectSend => "DiscoveryDirectSend",
+            HealthCheckerRpc => "HealthCheckerRpc",
+            IdentityDirectSend => "IdentityDirectSend",
+            OnchainDiscoveryRpc => "OnchainDiscoveryRpc",
+        }
+    }
+}
+
+impl fmt::Display for ProtocolId {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "{}", self.as_str())
+    }
 }
 
 #[derive(Clone, Debug, Default, PartialEq, Deserialize, Serialize)]

--- a/scripts/record_and_replay.sh
+++ b/scripts/record_and_replay.sh
@@ -99,7 +99,7 @@ else
             echo
         fi
     else
-        echo "Record and replay cancelled"
+        echo "Record and replay canceled"
         exit 1
     fi
 fi

--- a/terraform/templates/dashboards/network.json
+++ b/terraform/templates/dashboards/network.json
@@ -737,7 +737,7 @@
           "refId": "A"
         },
         {
-          "expr": "irate(libra_network_rpc_messages{type=\"request\",state=\"cancelled\"}[1m])",
+          "expr": "irate(libra_network_rpc_messages{type=\"request\",state=\"canceled\"}[1m])",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "{{peer_id}}",

--- a/types/src/account_config/events/cancel_burn.rs
+++ b/types/src/account_config/events/cancel_burn.rs
@@ -17,7 +17,7 @@ pub struct CancelBurnEvent {
 }
 
 impl CancelBurnEvent {
-    /// Get the amount cancelled
+    /// Get the amount canceled
     pub fn amount(&self) -> u64 {
         self.amount
     }


### PR DESCRIPTION
<!--
Thank you for sending a PR. We appreciate you spending time to help improve the Libra project.

The project is undergoing daily changes. Pull Requests will be reviewed and responded to as time permits.
-->

## Motivation
Addressing issue https://github.com/libra/libra/issues/3681

- Changed the `LIBRA_NETWORK_RPC_LATENCY` in `network/src/counters.rs` to a `HistogramVec` so that the latencies for different `NetworkMessage`, `ProtocolId` and Peer ID combinations can be collected separately.
- Added logging and collection for the RPC request latency in `protocols/rpc/mod.rs`

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan
- cargo xtest
- TBD

