### PR TITLE
[move-lang] Capture documentation comments, as well as support block comments

### DIFF
--- a/language/move-lang/src/lib.rs
+++ b/language/move-lang/src/lib.rs
@@ -27,10 +27,12 @@ use move_ir_types::location::*;
 use parser::syntax::parse_file_string;
 use shared::Address;
 use std::{
-    collections::HashMap,
+    collections::{BTreeMap, HashMap},
     fs::File,
     io::{self, ErrorKind, Read, Write},
+    iter::Peekable,
     path::{Path, PathBuf},
+    str::Chars,
 };
 
 pub const MOVE_EXTENSION: &str = "move";
@@ -64,7 +66,8 @@ pub fn move_check_no_report(
     deps: &[String],
     sender_opt: Option<Address>,
 ) -> io::Result<(FilesSourceText, Errors)> {
-    let (files, pprog_res) = parse_program(targets, deps)?;
+    let (files, pprog_and_comments_res) = parse_program(targets, deps)?;
+    let pprog_res = pprog_and_comments_res.map(|(pprog, _)| pprog);
     match check_program(pprog_res, sender_opt) {
         Err(errors) => Ok((files, errors)),
         Ok(_) => Ok((files, vec![])),
@@ -81,7 +84,8 @@ pub fn move_compile(
     deps: &[String],
     sender_opt: Option<Address>,
 ) -> io::Result<(FilesSourceText, Vec<CompiledUnit>)> {
-    let (files, pprog_res) = parse_program(targets, deps)?;
+    let (files, pprog_and_comments_res) = parse_program(targets, deps)?;
+    let pprog_res = pprog_and_comments_res.map(|(pprog, _)| pprog);
     match compile_program(pprog_res, sender_opt) {
         Err(errors) => errors::report_errors(files, errors),
         Ok(compiled_units) => Ok((files, compiled_units)),
@@ -94,24 +98,30 @@ pub fn move_compile_no_report(
     deps: &[String],
     sender_opt: Option<Address>,
 ) -> io::Result<(FilesSourceText, Result<Vec<CompiledUnit>, Errors>)> {
-    let (files, pprog_res) = parse_program(targets, deps)?;
+    let (files, pprog_and_comments_res) = parse_program(targets, deps)?;
+    let pprog_res = pprog_and_comments_res.map(|(pprog, _)| pprog);
     Ok(match compile_program(pprog_res, sender_opt) {
         Err(errors) => (files, Err(errors)),
         Ok(units) => (files, Ok(units)),
     })
 }
 
-/// Move compile up to expansion phase, returning errors instead of reporting them to stderr
+/// Move compile up to expansion phase, returning errors instead of reporting them to stderr.
+///
+/// This also returns a map containing documentation comments for each source in `targets`.
 pub fn move_compile_to_expansion_no_report(
     targets: &[String],
     deps: &[String],
     sender_opt: Option<Address>,
-) -> io::Result<(FilesSourceText, Result<expansion::ast::Program, Errors>)> {
-    let (files, pprog_res) = parse_program(targets, deps)?;
-    let res = pprog_res.and_then(|pprog| {
+) -> io::Result<(
+    FilesSourceText,
+    Result<(expansion::ast::Program, CommentMap), Errors>,
+)> {
+    let (files, pprog_and_comments_res) = parse_program(targets, deps)?;
+    let res = pprog_and_comments_res.and_then(|(pprog, comment_map)| {
         let (eprog, errors) = expansion::translate::program(pprog, sender_opt);
         check_errors(errors)?;
-        Ok(eprog)
+        Ok((eprog, comment_map))
     });
     Ok((files, res))
 }
@@ -237,31 +247,39 @@ fn compile_program(
 fn parse_program(
     targets: &[String],
     deps: &[String],
-) -> io::Result<(FilesSourceText, Result<parser::ast::Program, Errors>)> {
+) -> io::Result<(
+    FilesSourceText,
+    Result<(parser::ast::Program, CommentMap), Errors>,
+)> {
     let targets = find_and_intern_move_filenames(targets)?;
     let deps = find_and_intern_move_filenames(deps)?;
     let mut files: FilesSourceText = HashMap::new();
     let mut source_definitions = Vec::new();
+    let mut source_comments = CommentMap::new();
     let mut lib_definitions = Vec::new();
     let mut errors: Errors = Vec::new();
 
     for fname in targets {
-        let (defs, mut es) = parse_file(&mut files, fname)?;
+        let (defs, comments, mut es) = parse_file(&mut files, fname)?;
         source_definitions.extend(defs);
+        source_comments.insert(fname, comments);
         errors.append(&mut es);
     }
 
     for fname in deps {
-        let (defs, mut es) = parse_file(&mut files, fname)?;
+        let (defs, _, mut es) = parse_file(&mut files, fname)?;
         lib_definitions.extend(defs);
         errors.append(&mut es);
     }
 
     let res = if errors.is_empty() {
-        Ok(parser::ast::Program {
-            source_definitions,
-            lib_definitions,
-        })
+        Ok((
+            parser::ast::Program {
+                source_definitions,
+                lib_definitions,
+            },
+            source_comments,
+        ))
     } else {
         Err(errors)
     };
@@ -321,29 +339,29 @@ fn leak_str(s: &str) -> &'static str {
 fn parse_file(
     files: &mut FilesSourceText,
     fname: &'static str,
-) -> io::Result<(Vec<parser::ast::Definition>, Errors)> {
+) -> io::Result<(Vec<parser::ast::Definition>, MatchedFileCommentMap, Errors)> {
     let mut errors: Errors = Vec::new();
     let mut f = File::open(fname)
         .map_err(|err| std::io::Error::new(err.kind(), format!("{}: {}", err, fname)))?;
     let mut source_buffer = String::new();
     f.read_to_string(&mut source_buffer)?;
-    let no_comments_buffer = match strip_comments_and_verify(fname, &source_buffer) {
-        Err(err) => {
-            errors.push(err);
+    let (no_comments_buffer, comment_map) = match strip_comments_and_verify(fname, &source_buffer) {
+        Err(errs) => {
+            errors.extend(errs.into_iter());
             files.insert(fname, source_buffer);
-            return Ok((vec![], errors));
+            return Ok((vec![], MatchedFileCommentMap::new(), errors));
         }
-        Ok(no_comments_buffer) => no_comments_buffer,
+        Ok(result) => result,
     };
-    let defs = match parse_file_string(fname, &no_comments_buffer) {
-        Ok(defs) => defs,
-        Err(err) => {
-            errors.push(err);
-            vec![]
+    let (defs, comments) = match parse_file_string(fname, &no_comments_buffer, comment_map) {
+        Ok(defs_and_comments) => defs_and_comments,
+        Err(errs) => {
+            errors.extend(errs);
+            (vec![], MatchedFileCommentMap::new())
         }
     };
-    files.insert(fname, no_comments_buffer);
-    Ok((defs, errors))
+    files.insert(fname, source_buffer);
+    Ok((defs, comments, errors))
 }
 
 //**************************************************************************************************
@@ -378,7 +396,7 @@ pub fn is_permitted_char(c: char) -> bool {
     is_permitted_printable_char(c) || is_permitted_newline_char(c)
 }
 
-fn verify_string(fname: &'static str, string: &str) -> Result<(), Error> {
+fn verify_string(fname: &'static str, string: &str) -> Result<(), Errors> {
     match string
         .chars()
         .enumerate()
@@ -394,33 +412,170 @@ fn verify_string(fname: &'static str, string: &str) -> Result<(), Error> {
                  are permitted.",
                 chr
             );
-            Err(vec![(loc, msg)])
+            Err(vec![vec![(loc, msg)]])
         }
     }
 }
 
-fn strip_comments(source: &str) -> String {
+/// Types to represent comments.
+pub type CommentMap = BTreeMap<&'static str, MatchedFileCommentMap>;
+pub type MatchedFileCommentMap = BTreeMap<ByteIndex, String>;
+pub type FileCommentMap = BTreeMap<Span, String>;
+
+/// Strips line and block comments from input source, and collects documentation comments,
+/// putting them into a map indexed by the span of the comment region. Comments in the original
+/// source will be replaced by spaces, such that positions of source items stay unchanged.
+/// Block comments can be nested.
+///
+/// Documentation comments are comments which start with
+/// `///` or `/**`, but not `////` or `/***`. The actually comment delimiters
+/// (`/// .. <newline>` and `/** .. */`) will be not included in extracted comment string. The
+/// span in the returned map, however, covers the whole region of the comment, including the
+/// delimiters.
+fn strip_comments(fname: &'static str, input: &str) -> Result<(String, FileCommentMap), Errors> {
     const SLASH: char = '/';
     const SPACE: char = ' ';
+    const STAR: char = '*';
 
-    let mut in_comment = false;
-    let mut acc = String::with_capacity(source.len());
-    let mut char_iter = source.chars().peekable();
-
-    while let Some(chr) = char_iter.next() {
-        let at_newline = is_permitted_newline_char(chr);
-        let at_or_after_slash_slash =
-            in_comment || (chr == SLASH && char_iter.peek().map(|c| *c == SLASH).unwrap_or(false));
-        in_comment = !at_newline && at_or_after_slash_slash;
-        acc.push(if in_comment { SPACE } else { chr });
+    enum State {
+        Source,
+        LineComment,
+        BlockComment,
     }
 
-    acc
+    let mut source = String::with_capacity(input.len());
+    let mut comment_map = FileCommentMap::new();
+
+    let mut state = State::Source;
+    let mut pos = 0;
+    let mut comment_start_pos = 0;
+    let mut comment = String::new();
+    let mut block_nest = 0;
+
+    let next_is =
+        |peekable: &mut Peekable<Chars>, chr| peekable.peek().map(|c| *c == chr).unwrap_or(false);
+
+    let mut commit_comment = |state, start_pos, end_pos, content: String| match state {
+        State::BlockComment if !content.starts_with('*') || content.starts_with("**") => {}
+        State::LineComment if !content.starts_with('/') || content.starts_with("//") => {}
+        _ => {
+            comment_map.insert(Span::new(start_pos, end_pos), content[1..].to_string());
+        }
+    };
+
+    let mut char_iter = input.chars().peekable();
+    while let Some(chr) = char_iter.next() {
+        match state {
+            // Line comments
+            State::Source if chr == SLASH && next_is(&mut char_iter, SLASH) => {
+                // Starting line comment. We do not capture the `//` in the comment.
+                char_iter.next();
+                source.push(SPACE);
+                source.push(SPACE);
+                comment_start_pos = pos;
+                pos += 2;
+                state = State::LineComment;
+            }
+            State::LineComment if is_permitted_newline_char(chr) => {
+                // Ending line comment. The newline will be added to the source.
+                commit_comment(state, comment_start_pos, pos, std::mem::take(&mut comment));
+                source.push(chr);
+                pos += 1;
+                state = State::Source;
+            }
+            State::LineComment => {
+                // Continuing line comment.
+                source.push(SPACE);
+                comment.push(chr);
+                pos += 1;
+            }
+
+            // Block comments.
+            State::Source if chr == SLASH && next_is(&mut char_iter, STAR) => {
+                // Starting block comment. We do not capture the `/*` in the comment.
+                char_iter.next();
+                source.push(SPACE);
+                source.push(SPACE);
+                comment_start_pos = pos;
+                pos += 2;
+                state = State::BlockComment;
+            }
+            State::BlockComment if chr == SLASH && next_is(&mut char_iter, STAR) => {
+                // Starting nested block comment.
+                char_iter.next();
+                source.push(SPACE);
+                comment.push(chr);
+                pos += 1;
+                block_nest += 1;
+            }
+            State::BlockComment
+                if block_nest > 0 && chr == STAR && next_is(&mut char_iter, SLASH) =>
+            {
+                // Ending nested block comment.
+                char_iter.next();
+                source.push(SPACE);
+                comment.push(chr);
+                pos -= 1;
+                block_nest -= 1;
+            }
+            State::BlockComment
+                if block_nest == 0 && chr == STAR && next_is(&mut char_iter, SLASH) =>
+            {
+                // Ending block comment. The `*/` will not be captured and also not part of the
+                // source.
+                char_iter.next();
+                source.push(SPACE);
+                source.push(SPACE);
+                pos += 2;
+                commit_comment(state, comment_start_pos, pos, std::mem::take(&mut comment));
+                state = State::Source;
+            }
+            State::BlockComment => {
+                // Continuing block comment.
+                source.push(SPACE);
+                comment.push(chr);
+                pos += 1;
+            }
+            State::Source => {
+                // Continuing regular source.
+                source.push(chr);
+                pos += 1;
+            }
+        }
+    }
+    match state {
+        State::LineComment => {
+            // We allow the last line to have no line terminator
+            commit_comment(state, comment_start_pos, pos, std::mem::take(&mut comment));
+        }
+        State::BlockComment => {
+            if pos > 0 {
+                // try to point to last real character
+                pos -= 1;
+            }
+            return Err(vec![vec![
+                (
+                    Loc::new(fname, Span::new(pos, pos)),
+                    "unclosed block comment".to_string(),
+                ),
+                (
+                    Loc::new(fname, Span::new(comment_start_pos, comment_start_pos + 2)),
+                    "begin of unclosed block comment".to_string(),
+                ),
+            ]]);
+        }
+        State::Source => {}
+    }
+
+    Ok((source, comment_map))
 }
 
 // We restrict strings to only ascii visual characters (0x20 <= c <= 0x7E) or a permitted newline
 // character--\n--or a tab--\t.
-fn strip_comments_and_verify(fname: &'static str, string: &str) -> Result<String, Error> {
+fn strip_comments_and_verify(
+    fname: &'static str,
+    string: &str,
+) -> Result<(String, FileCommentMap), Errors> {
     verify_string(fname, string)?;
-    Ok(strip_comments(string))
+    strip_comments(fname, string)
 }

--- a/language/move-lang/tests/move_check/naming/generics_shadowing_invalid.exp
+++ b/language/move-lang/tests/move_check/naming/generics_shadowing_invalid.exp
@@ -16,7 +16,7 @@ error:
 
    ┌── tests/move_check/naming/generics_shadowing_invalid.move:8:20 ───
    │
- 8 │         let s: S = S {};
+ 8 │         let s: S = S {}; // TODO error? should this try to construct the generic ?
    │                    ^ Invalid construction. Expected a struct name
    ·
  6 │     fun foo<S>(s1: S, s2: S): S {

--- a/language/move-lang/tests/move_check/parser/comments_ok.move
+++ b/language/move-lang/tests/move_check/parser/comments_ok.move
@@ -1,0 +1,16 @@
+/// This is a test.
+module M {
+    /**
+     * One can have /* nested */
+     * // block comments
+     */
+    fun f() { }
+
+    /* This is a nested /* regular comment // */ */
+    fun g() {}
+
+    // This is a line comment which contains unbalanced /* delimiter.
+    fun h() {}
+
+    // This is a regular comment which appears where a doc comment would not be allowed.
+}

--- a/language/move-lang/tests/move_check/parser/comments_unbalanced.exp
+++ b/language/move-lang/tests/move_check/parser/comments_unbalanced.exp
@@ -1,0 +1,11 @@
+error: 
+
+   ┌── tests/move_check/parser/comments_unbalanced.move:5:2 ───
+   │
+ 5 │ }
+   │  ^ unclosed block comment
+   ·
+ 3 │     /** This comment must be closed.
+   │     -- begin of unclosed block comment
+   │
+

--- a/language/move-lang/tests/move_check/parser/comments_unbalanced.move
+++ b/language/move-lang/tests/move_check/parser/comments_unbalanced.move
@@ -1,0 +1,5 @@
+/// This is a test.
+module M {
+    /** This comment must be closed.
+    fun f() { }
+}

--- a/language/move-lang/tests/move_check/parser/doc_comments_placement.exp
+++ b/language/move-lang/tests/move_check/parser/doc_comments_placement.exp
@@ -1,0 +1,40 @@
+error: 
+
+   ┌── tests/move_check/parser/doc_comments_placement.move:6:5 ───
+   │
+ 6 │     /** There can be no doc comment on uses. */
+   │     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ documentation comment cannot be matched to a language item
+   │
+
+error: 
+
+    ┌── tests/move_check/parser/doc_comments_placement.move:16:9 ───
+    │
+ 16 │         /// There can be no doc comment after last field.
+    │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ documentation comment cannot be matched to a language item
+    │
+
+error: 
+
+    ┌── tests/move_check/parser/doc_comments_placement.move:23:9 ───
+    │
+ 23 │         /// There can be no doc comment after last block member.
+    │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ documentation comment cannot be matched to a language item
+    │
+
+error: 
+
+    ┌── tests/move_check/parser/doc_comments_placement.move:26:5 ───
+    │
+ 26 │     /// There can be no doc comment after last module item.
+    │     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ documentation comment cannot be matched to a language item
+    │
+
+error: 
+
+    ┌── tests/move_check/parser/doc_comments_placement.move:29:1 ───
+    │
+ 29 │ /// There can be no doc comment at end of file.
+    │ ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ documentation comment cannot be matched to a language item
+    │
+

--- a/language/move-lang/tests/move_check/parser/doc_comments_placement.move
+++ b/language/move-lang/tests/move_check/parser/doc_comments_placement.move
@@ -1,0 +1,29 @@
+/// This is documentation for module M.
+
+/// Documentation comments can have multiple blocks.
+/** They may use different limiters. */
+module M {
+    /** There can be no doc comment on uses. */
+    use 0x0::Transaction;
+
+    /// This is f.
+    fun f() { }
+
+    /// This is T
+    struct T {
+        /// This is a field of T.
+        f: u64,
+        /// There can be no doc comment after last field.
+    }
+
+    /// This is some spec.
+    spec module {
+        /// This is a pragma.
+        pragma verify = true;
+        /// There can be no doc comment after last block member.
+    }
+
+    /// There can be no doc comment after last module item.
+}
+
+/// There can be no doc comment at end of file.

--- a/language/move-lang/tests/move_check/parser/function_type_extra_comma.exp
+++ b/language/move-lang/tests/move_check/parser/function_type_extra_comma.exp
@@ -2,7 +2,7 @@ error:
 
    ┌── tests/move_check/parser/function_type_extra_comma.move:2:12 ───
    │
- 2 │     fun fn<,T>() { }
+ 2 │     fun fn<,T>() { } // Test a comma before the first type parameter
    │            ^ Expected a type parameter
    │
 

--- a/language/move-lang/tests/move_check/parser/let_binding_missing_fields.exp
+++ b/language/move-lang/tests/move_check/parser/let_binding_missing_fields.exp
@@ -2,10 +2,10 @@ error:
 
    ┌── tests/move_check/parser/let_binding_missing_fields.move:6:26 ───
    │
- 6 │         let Generic<u64> = g;
+ 6 │         let Generic<u64> = g; // Test a type name with no field bindings
    │                          ^ Unexpected '='
    ·
- 6 │         let Generic<u64> = g;
+ 6 │         let Generic<u64> = g; // Test a type name with no field bindings
    │                          - Expected '{'
    │
 

--- a/language/move-lang/tests/move_check/parser/let_binding_missing_paren.exp
+++ b/language/move-lang/tests/move_check/parser/let_binding_missing_paren.exp
@@ -2,10 +2,10 @@ error:
 
    ┌── tests/move_check/parser/let_binding_missing_paren.move:3:21 ───
    │
- 3 │         let (x1, x2 = (1, 2);
+ 3 │         let (x1, x2 = (1, 2); // Test a missing right parenthesis
    │                     ^ Expected ')'
    ·
- 3 │         let (x1, x2 = (1, 2);
+ 3 │         let (x1, x2 = (1, 2); // Test a missing right parenthesis
    │             - To match this '('
    │
 

--- a/language/move-lang/tests/move_check/parser/let_binding_missing_type.exp
+++ b/language/move-lang/tests/move_check/parser/let_binding_missing_type.exp
@@ -2,10 +2,10 @@ error:
 
    ┌── tests/move_check/parser/let_binding_missing_type.move:3:17 ───
    │
- 3 │         let x : = 0;
+ 3 │         let x : = 0; // Test a missing let type (but with a colon)
    │                 ^ Unexpected '='
    ·
- 3 │         let x : = 0;
+ 3 │         let x : = 0; // Test a missing let type (but with a colon)
    │                 - Expected a type name
    │
 

--- a/language/move-lang/tests/move_check/parser/struct_field_missing_type.exp
+++ b/language/move-lang/tests/move_check/parser/struct_field_missing_type.exp
@@ -2,10 +2,10 @@ error:
 
    ┌── tests/move_check/parser/struct_field_missing_type.move:2:18 ───
    │
- 2 │     struct S { f }
+ 2 │     struct S { f } // Each field must specify a type
    │                  ^ Unexpected '}'
    ·
- 2 │     struct S { f }
+ 2 │     struct S { f } // Each field must specify a type
    │                  - Expected ':'
    │
 

--- a/language/move-lang/tests/move_check/parser/struct_missing_lbrace.exp
+++ b/language/move-lang/tests/move_check/parser/struct_missing_lbrace.exp
@@ -5,7 +5,7 @@ error:
  3 │     fun f() {}
    │     ^ Expected '}'
    ·
- 2 │     struct S { f: u64
+ 2 │     struct S { f: u64 // }
    │              - To match this '{'
    │
 

--- a/language/move-lang/tests/move_check/parser/struct_type_extra_comma.exp
+++ b/language/move-lang/tests/move_check/parser/struct_type_extra_comma.exp
@@ -2,7 +2,7 @@ error:
 
    ┌── tests/move_check/parser/struct_type_extra_comma.move:2:14 ───
    │
- 2 │     struct S<,T> { }
+ 2 │     struct S<,T> { } // Test a comma before the first type parameter
    │              ^ Expected a type parameter
    │
 

--- a/language/move-prover/spec-lang/src/lib.rs
+++ b/language/move-prover/spec-lang/src/lib.rs
@@ -72,7 +72,7 @@ pub fn run_spec_lang_compiler(
                 // AST clonable and tee it somehow out of the regular compile chain.
                 let (_, eprog_or_errors) =
                     move_compile_to_expansion_no_report(&all_sources, &[], address_opt)?;
-                let eprog = eprog_or_errors.expect("no compilation errors");
+                let eprog = eprog_or_errors.expect("no compilation errors").0;
                 // Run the spec checker on verified units plus expanded AST. This will
                 // populate the environment including any errors.
                 run_spec_checker(&mut env, verified_units, eprog)?;

--- a/language/move-prover/tests/sources/functional/hash_model.exp
+++ b/language/move-prover/tests/sources/functional/hash_model.exp
@@ -3,7 +3,7 @@ error:  A postcondition might not hold on this return path.
 
     ┌── tests/sources/functional/hash_model.move:44:9 ───
     │
- 44 │         ensures len(result_1) > 0 ==> result_1[0] < max_u8();
+ 44 │         ensures len(result_1) > 0 ==> result_1[0] < max_u8(); // should be <=
     │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
     │
     =     at tests/sources/functional/hash_model.move:35:5: hash_test1_incorrect (entry)

--- a/language/move-prover/tests/sources/functional/hash_model_invalid.exp
+++ b/language/move-prover/tests/sources/functional/hash_model_invalid.exp
@@ -3,7 +3,7 @@ error:  A postcondition might not hold on this return path.
 
     ┌── tests/sources/functional/hash_model_invalid.move:17:9 ───
     │
- 17 │         ensures len(result_1) > 0 ==> result_1[0] < max_u8();
+ 17 │         ensures len(result_1) > 0 ==> result_1[0] < max_u8(); // should be <=
     │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
     │
     =     at tests/sources/functional/hash_model_invalid.move:6:5: hash_test1 (entry)

--- a/language/move-prover/tests/sources/regression/type_param_bug_200228.exp
+++ b/language/move-prover/tests/sources/regression/type_param_bug_200228.exp
@@ -3,7 +3,7 @@ error:  A postcondition might not hold on this return path.
 
     ┌── tests/sources/regression/type_param_bug_200228.move:12:5 ───
     │
- 12 │     ensures old(exists<Balance<Tok_1>>(addr)) ==> old(exists<Balance<Tok_2>>(addr));
+ 12 │     ensures old(exists<Balance<Tok_1>>(addr)) ==> old(exists<Balance<Tok_2>>(addr)); // original bug: proved by Prover, but should not be.
     │     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
     │
     =     at tests/sources/regression/type_param_bug_200228.move:6:3: type_param_bug (entry)


### PR DESCRIPTION
This PR suggests to extend the move-lang compiler to be able to capture documentation comments and pass them to upstream tools.

This is achieved by extending the existing `strip_comments` function to return a map from `codespan::Span` to comment strings. This map is then passed into the lexer which allows to check and consolidate correct placement of doc comments, with minimal intrusion for the parser. The doc comments are not stored in the AST, but managed as a separate data structure.

The comment stripper has also been extended to support block comments in addition to line comments. Block comments may become important for larger documentation embedded in Move sources, and are also handy for development as they easily allow to comment out larger regions of code. Block comments can be nested.

In order to give reasonable error messages in the presence of comments (unbalanced block comments, displaced documentation comments), the source on which the move lang compiler reports errors does now include the comments. This let to some baseline file updates where comments where previously stripped in error messages.

## Motivation

Beautifully documented and specified Move sources.


### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?

Yes.

## Test Plan

Added new baseline tests.

## Related PRs

NA
