### PR TITLE
[mempool] unify coordinators and simplify test framework

### DIFF
--- a/mempool/src/shared_mempool/coordinator.rs
+++ b/mempool/src/shared_mempool/coordinator.rs
@@ -9,10 +9,7 @@ use crate::{
     network::{MempoolNetworkEvents, MempoolSyncMsg},
     shared_mempool::{
         tasks,
-        types::{
-            notify_subscribers, IntervalStream, ScheduledBroadcast, SharedMempool,
-            SharedMempoolNotification,
-        },
+        types::{notify_subscribers, ScheduledBroadcast, SharedMempool, SharedMempoolNotification},
     },
     CommitNotification, ConsensusRequest, SubmissionStatus,
 };
@@ -38,49 +35,6 @@ use std::{
 use tokio::{runtime::Handle, time::interval};
 use vm_validator::vm_validator::TransactionValidation;
 
-/// Coordinator that handles [`SyncEvent`], which is periodically emitted for us to
-/// broadcast ready to go transactions to peers.
-pub(crate) async fn broadcast_coordinator<V>(
-    mut smp: SharedMempool<V>,
-    mut schedule_broadcast_rx: libra_channel::Receiver<PeerNetworkId, PeerNetworkId>,
-    executor: Handle,
-    // A stream that controls the broadcast loop. If provided, a single broadcast will happen when one event is emitted
-    // by `broadcast_ticker`. Should only be used for testing purposes to coordinate broadcast events
-    mut _broadcast_ticker: Option<IntervalStream>,
-) where
-    V: TransactionValidation,
-{
-    let peer_manager = smp.peer_manager;
-    let mempool = smp.mempool;
-    let mut network_senders = smp.network_senders;
-    let batch_size = smp.config.shared_mempool_batch_size;
-    let mut scheduled_broadcasts = FuturesUnordered::new();
-    let interval_ms = smp.config.shared_mempool_tick_interval_ms;
-    let subscribers = &mut smp.subscribers;
-
-    loop {
-//        tick(&mut broadcast_ticker).await;
-
-        ::futures::select! {
-            new_peer = schedule_broadcast_rx.select_next_some() => {
-                tasks::broadcast_single_peer(new_peer, &peer_manager, &mempool, &mut network_senders, batch_size, subscribers);
-                schedule_next_broadcast(new_peer, &mut scheduled_broadcasts, interval_ms, executor.clone());
-            }
-            peer = scheduled_broadcasts.select_next_some() => {
-                tasks::broadcast_single_peer(peer, &peer_manager, &mempool, &mut network_senders, batch_size, subscribers);
-                schedule_next_broadcast(peer, &mut scheduled_broadcasts, interval_ms, executor.clone());
-            }
-            complete => break,
-        }
-    }
-}
-
-//async fn tick(broadcast_ticker: &mut Option<IntervalStream>) {
-//    if let Some(ref mut ticker) = broadcast_ticker {
-//        while let None = ticker.next().await {}
-//    }
-//}
-
 fn schedule_next_broadcast(
     peer: PeerNetworkId,
     scheduled_broadcasts: &mut FuturesUnordered<ScheduledBroadcast>,
@@ -96,7 +50,7 @@ fn schedule_next_broadcast(
 
 /// Coordinator that handles inbound network events.
 pub(crate) async fn request_coordinator<V>(
-    mut smp: SharedMempool<V>,
+    smp: SharedMempool<V>,
     executor: Handle,
     network_events: Vec<(NetworkId, MempoolNetworkEvents)>,
     mut client_events: mpsc::Receiver<(
@@ -106,24 +60,28 @@ pub(crate) async fn request_coordinator<V>(
     mut consensus_requests: mpsc::Receiver<ConsensusRequest>,
     mut state_sync_requests: mpsc::Receiver<CommitNotification>,
     mut mempool_reconfig_events: libra_channel::Receiver<(), OnChainConfigPayload>,
-    mut schedule_broadcast_tx: libra_channel::Sender<PeerNetworkId, PeerNetworkId>,
     node_config: NodeConfig,
 ) where
     V: TransactionValidation,
 {
     let peer_manager = smp.peer_manager.clone();
-    let mut subscribers = smp.subscribers.clone();
     let smp_events: Vec<_> = network_events
         .into_iter()
         .map(|(network_id, events)| events.map(move |e| (network_id, e)))
         .collect();
     let mut events = select_all(smp_events).fuse();
     let is_validator = node_config.base.role.is_validator();
+    let mempool = smp.mempool.clone();
+    let mut network_senders = smp.network_senders.clone();
+    let subscribers = &mut smp.subscribers.clone();
+    let batch_size = smp.config.shared_mempool_batch_size;
+    let mut scheduled_broadcasts = FuturesUnordered::new();
+    let interval_ms = smp.config.shared_mempool_tick_interval_ms;
 
     // Use a BoundedExecutor to restrict only `workers_available` concurrent
     // worker tasks that can process incoming transactions.
     let workers_available = smp.config.shared_mempool_max_concurrent_inbound_syncs;
-    let bounded_executor = BoundedExecutor::new(workers_available, executor);
+    let bounded_executor = BoundedExecutor::new(workers_available, executor.clone());
 
     loop {
         ::futures::select! {
@@ -148,6 +106,10 @@ pub(crate) async fn request_coordinator<V>(
                 .spawn(tasks::process_config_update(config_update, smp.validator.clone()))
                 .await;
             },
+            peer = scheduled_broadcasts.select_next_some() => {
+                tasks::broadcast_single_peer(peer, &peer_manager, &mempool, &mut network_senders, batch_size, subscribers);
+                schedule_next_broadcast(peer, &mut scheduled_broadcasts, interval_ms, executor.clone());
+            },
             (network_id, event) = events.select_next_some() => {
                 match event {
                     Ok(network_event) => {
@@ -158,20 +120,18 @@ pub(crate) async fn request_coordinator<V>(
                                     .inc();
                                 let peer = PeerNetworkId(network_id, peer_id);
                                 let is_new_peer = peer_manager.add_peer(peer);
+                                notify_subscribers(SharedMempoolNotification::PeerStateChange, &subscribers);
                                 if is_new_peer && peer_manager.is_upstream_peer(peer) {
-                                    // schedule broadcast
-                                    if let Err(e) = schedule_broadcast_tx.push(peer, peer) {
-                                        error!("failed to schedule broadcast for new peer: {}", e);
-                                    }
+                                    tasks::broadcast_single_peer(peer, &peer_manager, &mempool, &mut network_senders, batch_size, subscribers);
+                                    schedule_next_broadcast(peer, &mut scheduled_broadcasts, interval_ms, executor.clone());
                                 }
-                                notify_subscribers(SharedMempoolNotification::PeerStateChange, &mut subscribers);
                             }
                             Event::LostPeer(peer_id) => {
                                 counters::SHARED_MEMPOOL_EVENTS
                                     .with_label_values(&["lost_peer".to_string().deref()])
                                     .inc();
                                 peer_manager.disable_peer(PeerNetworkId(network_id, peer_id));
-                                notify_subscribers(SharedMempoolNotification::PeerStateChange, &mut subscribers);
+                                notify_subscribers(SharedMempoolNotification::PeerStateChange, &subscribers);
                             }
                             Event::Message((peer_id, msg)) => {
                                 counters::SHARED_MEMPOOL_EVENTS
@@ -201,8 +161,8 @@ pub(crate) async fn request_coordinator<V>(
                                             .await;
                                     }
                                     MempoolSyncMsg::BroadcastTransactionsResponse{request_id} => {
-                                        tasks::process_broadcast_ack(smp.clone(), request_id, is_validator);
-                                        notify_subscribers(SharedMempoolNotification::ACK, &mut smp.subscribers);
+                                        tasks::process_broadcast_ack(&mempool, request_id, is_validator);
+                                        notify_subscribers(SharedMempoolNotification::ACK, &smp.subscribers);
                                     }
                                 };
                             }

--- a/mempool/src/shared_mempool/runtime.rs
+++ b/mempool/src/shared_mempool/runtime.rs
@@ -17,7 +17,7 @@ use crate::{
 use anyhow::Result;
 use channel::{libra_channel, message_queues::QueueStyle};
 use futures::channel::{
-    mpsc::{self, Receiver, UnboundedSender},
+    mpsc::{self, Receiver},
     oneshot,
 };
 use libra_config::config::NodeConfig;
@@ -49,7 +49,7 @@ pub(crate) fn start_shared_mempool<V>(
     mempool_reconfig_events: libra_channel::Receiver<(), OnChainConfigPayload>,
     db: Arc<dyn DbReader>,
     validator: Arc<RwLock<V>>,
-    subscribers: Vec<UnboundedSender<SharedMempoolNotification>>,
+    subscribers: Vec<libra_channel::Sender<(), SharedMempoolNotification>>,
     broadcast_ticker: Option<IntervalStream>,
 ) where
     V: TransactionValidation + 'static,

--- a/mempool/src/shared_mempool/runtime.rs
+++ b/mempool/src/shared_mempool/runtime.rs
@@ -5,7 +5,7 @@ use crate::{
     core_mempool::CoreMempool,
     network::{MempoolNetworkEvents, MempoolNetworkSender},
     shared_mempool::{
-        coordinator::{gc_coordinator, request_coordinator},
+        coordinator::{coordinator, gc_coordinator},
         peer_manager::PeerManager,
         types::{SharedMempool, SharedMempoolNotification, DEFAULT_MIN_BROADCAST_RECIPIENT_COUNT},
     },
@@ -76,7 +76,7 @@ pub(crate) fn start_shared_mempool<V>(
         subscribers,
     };
 
-    executor.spawn(request_coordinator(
+    executor.spawn(coordinator(
         smp,
         executor.clone(),
         all_network_events,

--- a/mempool/src/shared_mempool/types.rs
+++ b/mempool/src/shared_mempool/types.rs
@@ -50,7 +50,7 @@ where
     pub subscribers: Vec<UnboundedSender<SharedMempoolNotification>>,
 }
 
-#[derive(Copy, Clone, Debug, Eq, Hash, PartialEq)]
+#[derive(Copy, Clone, Debug, PartialEq)]
 pub enum SharedMempoolNotification {
     PeerStateChange,
     NewTransactions,

--- a/mempool/src/tests/mocks.rs
+++ b/mempool/src/tests/mocks.rs
@@ -10,7 +10,7 @@ use crate::{
 use anyhow::{format_err, Result};
 use channel::{self, libra_channel, message_queues::QueueStyle};
 use futures::channel::{
-    mpsc::{self, unbounded},
+    mpsc,
     oneshot,
 };
 use libra_config::config::{NetworkConfig, NodeConfig};
@@ -70,7 +70,7 @@ impl MockSharedMempool {
             ConnectionRequestSender::new(connection_reqs_tx),
         );
         let network_events = MempoolNetworkEvents::new(network_notifs_rx, conn_notifs_rx);
-        let (sender, _subscriber) = unbounded();
+//        let (sender, _subscriber) = unbounded();
         let (ac_client, client_events) = mpsc::channel(1_024);
         let (consensus_sender, consensus_events) = mpsc::channel(1_024);
         let (state_sync_sender, state_sync_events) = match state_sync {
@@ -95,7 +95,7 @@ impl MockSharedMempool {
             reconfig_event_subscriber,
             Arc::new(MockDbReader),
             Arc::new(RwLock::new(MockVMValidator)),
-            vec![sender],
+            vec![],
             None,
         );
 

--- a/mempool/src/tests/mocks.rs
+++ b/mempool/src/tests/mocks.rs
@@ -9,10 +9,7 @@ use crate::{
 };
 use anyhow::{format_err, Result};
 use channel::{self, libra_channel, message_queues::QueueStyle};
-use futures::channel::{
-    mpsc,
-    oneshot,
-};
+use futures::channel::{mpsc, oneshot};
 use libra_config::config::{NetworkConfig, NodeConfig};
 use libra_types::{mempool_status::MempoolStatusCode, transaction::SignedTransaction, PeerId};
 use network::peer_manager::{
@@ -70,7 +67,6 @@ impl MockSharedMempool {
             ConnectionRequestSender::new(connection_reqs_tx),
         );
         let network_events = MempoolNetworkEvents::new(network_notifs_rx, conn_notifs_rx);
-//        let (sender, _subscriber) = unbounded();
         let (ac_client, client_events) = mpsc::channel(1_024);
         let (consensus_sender, consensus_events) = mpsc::channel(1_024);
         let (state_sync_sender, state_sync_events) = match state_sync {
@@ -96,7 +92,6 @@ impl MockSharedMempool {
             Arc::new(MockDbReader),
             Arc::new(RwLock::new(MockVMValidator)),
             vec![],
-            None,
         );
 
         Self {

--- a/mempool/src/tests/shared_mempool_test.rs
+++ b/mempool/src/tests/shared_mempool_test.rs
@@ -278,10 +278,9 @@ impl SharedMempoolNetwork {
         peer: &PeerId,
         num_messages: usize,
     ) -> (Vec<SignedTransaction>, PeerId) {
-        let main_peer_id = self.peer_ids.get(peer).unwrap_or(peer).clone();
-        // emulate timer tick
+        // await broadcast notification
         for _ in 0..num_messages {
-            self.wait_for_event(&main_peer_id, SharedMempoolNotification::Broadcast);
+            self.wait_for_event(peer, SharedMempoolNotification::Broadcast);
         }
 
         // await next message from node

--- a/mempool/src/tests/shared_mempool_test.rs
+++ b/mempool/src/tests/shared_mempool_test.rs
@@ -5,17 +5,14 @@ use crate::{
     core_mempool::{CoreMempool, TimelineState},
     mocks::MockSharedMempool,
     network::{MempoolNetworkEvents, MempoolNetworkSender, MempoolSyncMsg},
-    shared_mempool::{
-        start_shared_mempool,
-        types::{SharedMempoolNotification, SyncEvent},
-    },
+    shared_mempool::{start_shared_mempool, types::SharedMempoolNotification},
     tests::common::{batch_add_signed_txn, TestTransaction},
     CommitNotification, CommittedTransaction, ConsensusRequest,
 };
 use channel::{self, libra_channel, message_queues::QueueStyle};
 use futures::{
     channel::{
-        mpsc::{self, unbounded, UnboundedReceiver, UnboundedSender},
+        mpsc::{self, unbounded, UnboundedReceiver},
         oneshot,
     },
     executor::block_on,
@@ -52,8 +49,7 @@ struct SharedMempoolNetwork {
         HashMap<PeerId, libra_channel::Sender<(PeerId, ProtocolId), PeerManagerNotification>>,
     network_conn_event_notifs_txs: HashMap<PeerId, conn_status_channel::Sender>,
     runtimes: HashMap<PeerId, Runtime>,
-    subscribers: HashMap<PeerId, libra_channel::Receiver<(), SharedMempoolNotification>>,
-    timers: HashMap<PeerId, UnboundedSender<SyncEvent>>,
+    subscribers: HashMap<PeerId, UnboundedReceiver<SharedMempoolNotification>>,
     peer_ids: HashMap<PeerId, PeerId>,
 }
 
@@ -73,9 +69,7 @@ fn init_single_shared_mempool(smp: &mut SharedMempoolNetwork, peer_id: PeerId, c
         ConnectionRequestSender::new(connection_reqs_tx),
     );
     let network_events = MempoolNetworkEvents::new(network_notifs_rx, conn_status_rx);
-//    let (sender, subscriber) = unbounded();
-    let (sender, subscriber) = libra_channel::new(QueueStyle::FIFO, NonZeroUsize::new(8).unwrap(), None);
-    let (timer_sender, timer_receiver) = unbounded();
+    let (sender, subscriber) = unbounded();
     let (_ac_endpoint_sender, ac_endpoint_receiver) = mpsc::channel(1_024);
     let network_handles = vec![(peer_id, network_sender, network_events)];
     let (_consensus_sender, consensus_events) = mpsc::channel(1_024);
@@ -101,7 +95,6 @@ fn init_single_shared_mempool(smp: &mut SharedMempoolNetwork, peer_id: PeerId, c
         Arc::new(MockDbReader),
         Arc::new(RwLock::new(MockVMValidator)),
         vec![sender],
-        Some(timer_receiver.map(|_| SyncEvent).boxed()),
     );
 
     smp.mempools.insert(peer_id, mempool);
@@ -110,7 +103,6 @@ fn init_single_shared_mempool(smp: &mut SharedMempoolNetwork, peer_id: PeerId, c
     smp.network_conn_event_notifs_txs
         .insert(peer_id, conn_status_tx);
     smp.subscribers.insert(peer_id, subscriber);
-    smp.timers.insert(peer_id, timer_sender);
     smp.runtimes.insert(peer_id, runtime);
 }
 
@@ -144,8 +136,7 @@ fn init_smp_multiple_networks(
             .insert(*peer_id, conn_status_tx);
     }
 
-    let (sender, subscriber) = libra_channel::new(QueueStyle::FIFO, NonZeroUsize::new(8).unwrap(), None);
-    let (timer_sender, timer_receiver) = unbounded();
+    let (sender, subscriber) = unbounded();
     let (_ac_endpoint_sender, ac_endpoint_receiver) = mpsc::channel(1_024);
     let (_consensus_sender, consensus_events) = mpsc::channel(1_024);
     let (_state_sync_sender, state_sync_events) = mpsc::channel(1_024);
@@ -170,12 +161,10 @@ fn init_smp_multiple_networks(
         Arc::new(MockDbReader),
         Arc::new(RwLock::new(MockVMValidator)),
         vec![sender],
-        Some(timer_receiver.map(|_| SyncEvent).boxed()),
     );
 
     let main_peer_id = network_ids[0];
     smp.subscribers.insert(main_peer_id, subscriber);
-    smp.timers.insert(main_peer_id, timer_sender);
     smp.mempools.insert(main_peer_id, mempool);
     smp.runtimes.insert(main_peer_id, runtime);
     for network_id in network_ids.into_iter().skip(1) {
@@ -265,32 +254,18 @@ impl SharedMempoolNetwork {
     fn wait_for_event(&mut self, peer_id: &PeerId, event: SharedMempoolNotification) {
         let main_peer_id = self.peer_ids.get(peer_id).unwrap_or(peer_id);
         let subscriber = self.subscribers.get_mut(main_peer_id).unwrap();
-//        while block_on(subscriber.next()).unwrap() != event {
-//            continue;
-//        }
-        let blah = block_on(subscriber.next()).unwrap();
-        println!("event {:?}", blah);
+        assert_eq!(block_on(subscriber.next()).unwrap(), event);
     }
 
     fn check_no_events(&mut self, peer_id: &PeerId) {
         let main_peer_id = self.peer_ids.get(peer_id).unwrap_or(peer_id);
         let subscriber = self.subscribers.get_mut(main_peer_id).unwrap();
-
-//        assert!(block_on(subscriber.next()).is_none());
         assert!(subscriber.select_next_some().now_or_never().is_none());
     }
 
     // checks that a node has no pending messages to send
     fn assert_no_message_sent(&mut self, peer: &PeerId) {
-        let main_peer_id = self.peer_ids.get(peer).unwrap_or(peer);
-        // emulate timer tick
-//        self.timers
-//            .get(main_peer_id)
-//            .unwrap()
-//            .unbounded_send(SyncEvent)
-//            .unwrap();
         self.check_no_events(peer);
-//        self.wait_for_event(&main_peer_id.clone(), SharedMempoolNotification::Broadcast);
 
         // await next message from node
         let network_reqs_rx = self.network_reqs_rxs.get_mut(peer).unwrap();
@@ -306,16 +281,8 @@ impl SharedMempoolNetwork {
         let main_peer_id = self.peer_ids.get(peer).unwrap_or(peer).clone();
         // emulate timer tick
         for _ in 0..num_messages {
-            println!("waiting");
-//            self.timers
-//                .get(main_peer_id)
-//                .unwrap()
-//                .unbounded_send(SyncEvent)
-//                .unwrap();
             self.wait_for_event(&main_peer_id, SharedMempoolNotification::Broadcast);
         }
-
-        println!("finished waiting");
 
         // await next message from node
         let network_reqs_rx = self.network_reqs_rxs.get_mut(peer).unwrap();
@@ -345,7 +312,6 @@ impl SharedMempoolNetwork {
 
                 // deliver ACK for this request
                 self.deliver_response(&peer_id);
-                println!("q?");
                 (transactions, peer_id)
             } else {
                 panic!("did not receive expected BroadcastTransactionsRequest");
@@ -463,28 +429,21 @@ fn test_interruption_in_sync() {
     );
     smp.add_txns(&peer_a, vec![TestTransaction::new(1, 0, 1)]);
 
-    // A discovers 2 peers
+    // A discovers first peer
     smp.send_connection_event(
         &peer_a,
         ConnectionStatusNotification::NewPeer(*peer_b, NetworkAddress::mock()),
     );
+    // make sure first txn delivered to first peer
+    assert_eq!(*peer_b, smp.deliver_message(&peer_a, 1).1);
+
+    // A discovers second peer
     smp.send_connection_event(
         &peer_a,
         ConnectionStatusNotification::NewPeer(*peer_c, NetworkAddress::mock()),
     );
-
-    println!("first");
-    // make sure it delivered first transaction to both nodes
-    let mut peers = vec![
-        smp.deliver_message(&peer_a, 1).1,
-        smp.deliver_message(&peer_a, 1).1,
-    ];
-    peers.sort();
-    let mut expected_peers = vec![*peer_b, *peer_c];
-    expected_peers.sort();
-    assert_eq!(peers, expected_peers);
-
-    println!("pls");
+    // make sure first txn delivered to second peer
+    assert_eq!(*peer_c, smp.deliver_message(&peer_a, 1).1);
 
     // A loses connection to B
     smp.send_connection_event(
@@ -496,21 +455,16 @@ fn test_interruption_in_sync() {
         ),
     );
 
-    println!("here");
     // only C receives following transactions
     smp.add_txns(&peer_a, vec![TestTransaction::new(1, 1, 1)]);
     let (txn, peer_id) = smp.deliver_message(&peer_a, 1);
     assert_eq!(peer_id, *peer_c);
     assert_eq!(txn.get(0).unwrap().sequence_number(), 1);
 
-    println!("next");
-
     smp.add_txns(&peer_a, vec![TestTransaction::new(1, 2, 1)]);
     let (txn, peer_id) = smp.deliver_message(&peer_a, 1);
     assert_eq!(peer_id, *peer_c);
     assert_eq!(txn.get(0).unwrap().sequence_number(), 2);
-
-    println!("yay");
 
     // A reconnects to B
     smp.send_connection_event(
@@ -877,12 +831,10 @@ fn test_k_policy_broadcast_no_fallback() {
     // add txn to fn_0
     smp.add_txns(&fn_0, vec![TestTransaction::new(1, 0, 1)]);
 
-    println!("delivering");
     // make sure it delivers txn to primary peer
     let peers = vec![smp.deliver_message(&fn_0, 1).1];
     assert_eq!(peers[0], v_0);
     // check that no messages have been sent to fallback upstream peer
-    println!("YO");
     smp.assert_no_message_sent(&fn_0_fallback_network_id);
 }
 
@@ -927,6 +879,5 @@ fn test_k_policy_broadcast_not_enough_fallbacks() {
     let peers = vec![smp.deliver_message(&fn_0, 1).1];
     assert_eq!(peers[0], v_0);
     // check that no messages have been sent to fallback upstream peer
-    println!("yo");
     smp.assert_no_message_sent(&fn_0_fallback_network_id);
 }


### PR DESCRIPTION
## Motivation

- Unify `broadcast_coordinator` and `request_coordinator` into single main `coordinator` for simplicity
- remove timer that controls broadcast loop
- clean up method signatures to reduce cloning

## Test Plan

Existing/refactored tests
