### PR TITLE
[CI][easy] enable verbose full trace in e2e test

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -284,7 +284,7 @@ jobs:
               status=1
               failed_tests=
               while [[ $status != 0 && $retry < ${E2E_RETRIES} ]]; do
-                RUST_BACKTRACE=1 timeout --kill-after=370 --preserve-status 360 \
+                RUST_BACKTRACE=full timeout --kill-after=370 --preserve-status 360 \
                   $libratest $target --test-threads 1 --exact --nocapture
                 status=$?
                 retry=$((retry + 1))


### PR DESCRIPTION
## Motivation
Some e2e smoke tests fail due to panic. The current trace level is not sufficient to reveal what went wrong.  A few examples from today:
test_basic_fault_tolerance, https://circleci.com/gh/libra/libra/79214#tests/containers/3
smoke_test_single_node_block_metadata, https://circleci.com/gh/libra/libra/79408#tests/containers/2
smoke_test_single_node, https://circleci.com/gh/libra/libra/79397#tests/containers/1

Run e2e tests with `RUST_BACKTRACE=full` for a verbose backtrace.

## Test Plan
CI