### PR TITLE
[move] Implement an initial version of move resource annotator.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1564,8 +1564,11 @@ dependencies = [
  "libra-canonical-serialization 0.1.0",
  "libra-types 0.1.0",
  "libra-workspace-hack 0.1.0",
+ "resource-viewer 0.1.0",
+ "stdlib 0.1.0",
  "structopt 0.3.14 (registry+https://github.com/rust-lang/crates.io-index)",
  "vm 0.1.0",
+ "vm-genesis 0.1.0",
 ]
 
 [[package]]
@@ -4186,6 +4189,26 @@ dependencies = [
  "web-sys 0.3.36 (registry+https://github.com/rust-lang/crates.io-index)",
  "webpki-roots 0.18.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "winreg 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "resource-viewer"
+version = "0.1.0"
+dependencies = [
+ "anyhow 1.0.28 (registry+https://github.com/rust-lang/crates.io-index)",
+ "hex 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libra-canonical-serialization 0.1.0",
+ "libra-state-view 0.1.0",
+ "libra-types 0.1.0",
+ "libra-workspace-hack 0.1.0",
+ "move-core-types 0.1.0",
+ "move-vm-types 0.1.0",
+ "once_cell 1.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.106 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_json 1.0.52 (registry+https://github.com/rust-lang/crates.io-index)",
+ "stdlib 0.1.0",
+ "vm 0.1.0",
+ "vm-genesis 0.1.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -78,6 +78,7 @@ members = [
     "language/move-vm/runtime",
     "language/move-vm/state",
     "language/move-vm/types",
+    "language/resource-viewer",
     "language/stdlib",
     "language/vm",
     "language/vm/serializer-tests",

--- a/language/e2e-tests/src/executor.rs
+++ b/language/e2e-tests/src/executor.rs
@@ -106,6 +106,7 @@ impl FakeExecutor {
                 &genesis_modules,
                 publishing_options,
             )
+            .0
         };
         Self::from_genesis(genesis_change_set.write_set())
     }

--- a/language/move-vm/types/src/loaded_data/types.rs
+++ b/language/move-vm/types/src/loaded_data/types.rs
@@ -12,12 +12,11 @@ use std::fmt::Write;
 use vm::errors::VMResult;
 
 use libra_types::access_path::{AccessPath, Accesses};
-#[cfg(feature = "fuzzing")]
 use serde::{Deserialize, Serialize};
 
 /// VM representation of a struct type in Move.
-#[derive(Debug, Clone)]
-#[cfg_attr(feature = "fuzzing", derive(Serialize, Deserialize, Eq, PartialEq))]
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[cfg_attr(feature = "fuzzing", derive(Eq, PartialEq))]
 pub struct FatStructType {
     pub address: AccountAddress,
     pub module: Identifier,
@@ -34,8 +33,8 @@ pub struct FatStructType {
 /// should NOT be serialized in any form. Currently we still derive `Serialize` and
 /// `Deserialize`, but this is a hack for fuzzing and should be guarded behind the
 /// "fuzzing" feature flag. We should look into ways to get rid of this.
-#[derive(Debug, Clone)]
-#[cfg_attr(feature = "fuzzing", derive(Serialize, Deserialize, Eq, PartialEq))]
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[cfg_attr(feature = "fuzzing", derive(Eq, PartialEq))]
 pub enum FatType {
     Bool,
     U8,

--- a/language/resource-viewer/Cargo.toml
+++ b/language/resource-viewer/Cargo.toml
@@ -1,0 +1,27 @@
+[package]
+name = "resource-viewer"
+version = "0.1.0"
+authors = ["Libra Association <opensource@libra.org>"]
+description = "Libra genesis viewer"
+repository = "https://github.com/libra/libra"
+homepage = "https://libra.org"
+license = "Apache-2.0"
+publish = false
+edition = "2018"
+
+[dependencies]
+lcs = { path = "../../common/lcs", version = "0.1.0", package = "libra-canonical-serialization" }
+libra-state-view = { path = "../../storage/state-view", version = "0.1.0" }
+libra-types = { path = "../../types", version = "0.1.0"  }
+libra-workspace-hack = { path = "../../common/workspace-hack", version = "0.1.0" }
+move-core-types = { path = "../move-core/types", version = "0.1.0" }
+move-vm-types = { path = "../move-vm/types", version = "0.1.0" }
+stdlib = { path = "../stdlib", version = "0.1.0" }
+vm = { path = "../vm", version = "0.1.0" }
+vm-genesis = { path = "../tools/vm-genesis", version = "0.1.0" }
+serde_json = "1.0"
+serde = { version = "1.0", features = ["derive", "rc"] }
+
+anyhow = "1.0"
+once_cell = "1.3.1"
+hex = "0.4.2"

--- a/language/resource-viewer/move_type_map/mapping.txt
+++ b/language/resource-viewer/move_type_map/mapping.txt
@@ -1,0 +1,2281 @@
+[
+  [
+    "01036af619c954928f4831bf70fad456286493e06ab2a0ab13f8a716733f2c0e9c",
+    {
+      "address": "00000000000000000000000000000000",
+      "module": "AccountType",
+      "name": "TransitionCapability",
+      "is_resource": true,
+      "ty_args": [
+        {
+          "Struct": {
+            "address": "00000000000000000000000000000000",
+            "module": "VASP",
+            "name": "RootVASP",
+            "is_resource": false,
+            "ty_args": [],
+            "layout": [
+              {
+                "Vector": "U8"
+              },
+              {
+                "Vector": "U8"
+              },
+              "U64",
+              {
+                "Vector": "U8"
+              }
+            ]
+          }
+        }
+      ],
+      "layout": [
+        "Bool",
+        "Address"
+      ]
+    }
+  ],
+  [
+    "0103dc58b18a0cf95afff1b5d12da6c42f361f94d023a18a2699d7cca2ec21acf5",
+    {
+      "address": "00000000000000000000000000000000",
+      "module": "Libra",
+      "name": "MintCapability",
+      "is_resource": true,
+      "ty_args": [
+        {
+          "Struct": {
+            "address": "00000000000000000000000000000000",
+            "module": "Coin2",
+            "name": "T",
+            "is_resource": false,
+            "ty_args": [],
+            "layout": [
+              "Bool"
+            ]
+          }
+        }
+      ],
+      "layout": [
+        "Bool"
+      ]
+    }
+  ],
+  [
+    "010b0ee82b5e5fd4ec9442ec6fad8f1f737171597e32366b585b41a9ef5e58ea59",
+    {
+      "address": "00000000000000000000000000000000",
+      "module": "LibraAccount",
+      "name": "AccountOperationsCapability",
+      "is_resource": true,
+      "ty_args": [],
+      "layout": [
+        {
+          "Struct": {
+            "address": "00000000000000000000000000000000",
+            "module": "AccountTrack",
+            "name": "CallingCapability",
+            "is_resource": true,
+            "ty_args": [],
+            "layout": [
+              "Bool"
+            ]
+          }
+        },
+        {
+          "Struct": {
+            "address": "00000000000000000000000000000000",
+            "module": "Event",
+            "name": "EventHandleGeneratorCreationCapability",
+            "is_resource": true,
+            "ty_args": [],
+            "layout": [
+              "Bool"
+            ]
+          }
+        }
+      ]
+    }
+  ],
+  [
+    "010b959de875ff83372d4413ec9fdd16e772acf46047531b126f389fa718687d96",
+    {
+      "address": "00000000000000000000000000000000",
+      "module": "ValidatorConfig",
+      "name": "T",
+      "is_resource": true,
+      "ty_args": [],
+      "layout": [
+        {
+          "Struct": {
+            "address": "00000000000000000000000000000000",
+            "module": "ValidatorConfig",
+            "name": "Config",
+            "is_resource": false,
+            "ty_args": [],
+            "layout": [
+              {
+                "Vector": "U8"
+              },
+              {
+                "Vector": "U8"
+              },
+              {
+                "Vector": "U8"
+              }
+            ]
+          }
+        },
+        {
+          "Struct": {
+            "address": "00000000000000000000000000000000",
+            "module": "ValidatorConfig",
+            "name": "DiscoveryConfig",
+            "is_resource": false,
+            "ty_args": [],
+            "layout": [
+              {
+                "Vector": "U8"
+              },
+              {
+                "Vector": "U8"
+              },
+              {
+                "Vector": "U8"
+              },
+              {
+                "Vector": "U8"
+              }
+            ]
+          }
+        },
+        {
+          "Struct": {
+            "address": "00000000000000000000000000000000",
+            "module": "Option",
+            "name": "T",
+            "is_resource": false,
+            "ty_args": [
+              "Address"
+            ],
+            "layout": [
+              {
+                "Vector": "Address"
+              }
+            ]
+          }
+        }
+      ]
+    }
+  ],
+  [
+    "010cbe38965c90163d66c0817c596c2efb96bc73615d72edc47f96e36f7319b1f9",
+    {
+      "address": "00000000000000000000000000000000",
+      "module": "Event",
+      "name": "EventHandleGenerator",
+      "is_resource": true,
+      "ty_args": [],
+      "layout": [
+        "U64",
+        "Address"
+      ]
+    }
+  ],
+  [
+    "010db07da33998edeeb2df85784683de5ba42cb53efa144d2835200e5ad88263c2",
+    {
+      "address": "00000000000000000000000000000000",
+      "module": "LBR",
+      "name": "Reserve",
+      "is_resource": true,
+      "ty_args": [],
+      "layout": [
+        {
+          "Struct": {
+            "address": "00000000000000000000000000000000",
+            "module": "Libra",
+            "name": "MintCapability",
+            "is_resource": true,
+            "ty_args": [
+              {
+                "Struct": {
+                  "address": "00000000000000000000000000000000",
+                  "module": "LBR",
+                  "name": "T",
+                  "is_resource": true,
+                  "ty_args": [],
+                  "layout": [
+                    "Bool"
+                  ]
+                }
+              }
+            ],
+            "layout": [
+              "Bool"
+            ]
+          }
+        },
+        {
+          "Struct": {
+            "address": "00000000000000000000000000000000",
+            "module": "Libra",
+            "name": "BurnCapability",
+            "is_resource": true,
+            "ty_args": [
+              {
+                "Struct": {
+                  "address": "00000000000000000000000000000000",
+                  "module": "LBR",
+                  "name": "T",
+                  "is_resource": true,
+                  "ty_args": [],
+                  "layout": [
+                    "Bool"
+                  ]
+                }
+              }
+            ],
+            "layout": [
+              "Bool"
+            ]
+          }
+        },
+        {
+          "Struct": {
+            "address": "00000000000000000000000000000000",
+            "module": "Libra",
+            "name": "Preburn",
+            "is_resource": true,
+            "ty_args": [
+              {
+                "Struct": {
+                  "address": "00000000000000000000000000000000",
+                  "module": "LBR",
+                  "name": "T",
+                  "is_resource": true,
+                  "ty_args": [],
+                  "layout": [
+                    "Bool"
+                  ]
+                }
+              }
+            ],
+            "layout": [
+              {
+                "Vector": {
+                  "Struct": {
+                    "address": "00000000000000000000000000000000",
+                    "module": "Libra",
+                    "name": "T",
+                    "is_resource": true,
+                    "ty_args": [
+                      {
+                        "Struct": {
+                          "address": "00000000000000000000000000000000",
+                          "module": "LBR",
+                          "name": "T",
+                          "is_resource": true,
+                          "ty_args": [],
+                          "layout": [
+                            "Bool"
+                          ]
+                        }
+                      }
+                    ],
+                    "layout": [
+                      "U64"
+                    ]
+                  }
+                }
+              },
+              "Bool"
+            ]
+          }
+        },
+        {
+          "Struct": {
+            "address": "00000000000000000000000000000000",
+            "module": "LBR",
+            "name": "ReserveComponent",
+            "is_resource": true,
+            "ty_args": [
+              {
+                "Struct": {
+                  "address": "00000000000000000000000000000000",
+                  "module": "Coin1",
+                  "name": "T",
+                  "is_resource": false,
+                  "ty_args": [],
+                  "layout": [
+                    "Bool"
+                  ]
+                }
+              }
+            ],
+            "layout": [
+              {
+                "Struct": {
+                  "address": "00000000000000000000000000000000",
+                  "module": "FixedPoint32",
+                  "name": "T",
+                  "is_resource": false,
+                  "ty_args": [],
+                  "layout": [
+                    "U64"
+                  ]
+                }
+              },
+              {
+                "Struct": {
+                  "address": "00000000000000000000000000000000",
+                  "module": "Libra",
+                  "name": "T",
+                  "is_resource": true,
+                  "ty_args": [
+                    {
+                      "Struct": {
+                        "address": "00000000000000000000000000000000",
+                        "module": "Coin1",
+                        "name": "T",
+                        "is_resource": false,
+                        "ty_args": [],
+                        "layout": [
+                          "Bool"
+                        ]
+                      }
+                    }
+                  ],
+                  "layout": [
+                    "U64"
+                  ]
+                }
+              }
+            ]
+          }
+        },
+        {
+          "Struct": {
+            "address": "00000000000000000000000000000000",
+            "module": "LBR",
+            "name": "ReserveComponent",
+            "is_resource": true,
+            "ty_args": [
+              {
+                "Struct": {
+                  "address": "00000000000000000000000000000000",
+                  "module": "Coin2",
+                  "name": "T",
+                  "is_resource": false,
+                  "ty_args": [],
+                  "layout": [
+                    "Bool"
+                  ]
+                }
+              }
+            ],
+            "layout": [
+              {
+                "Struct": {
+                  "address": "00000000000000000000000000000000",
+                  "module": "FixedPoint32",
+                  "name": "T",
+                  "is_resource": false,
+                  "ty_args": [],
+                  "layout": [
+                    "U64"
+                  ]
+                }
+              },
+              {
+                "Struct": {
+                  "address": "00000000000000000000000000000000",
+                  "module": "Libra",
+                  "name": "T",
+                  "is_resource": true,
+                  "ty_args": [
+                    {
+                      "Struct": {
+                        "address": "00000000000000000000000000000000",
+                        "module": "Coin2",
+                        "name": "T",
+                        "is_resource": false,
+                        "ty_args": [],
+                        "layout": [
+                          "Bool"
+                        ]
+                      }
+                    }
+                  ],
+                  "layout": [
+                    "U64"
+                  ]
+                }
+              }
+            ]
+          }
+        }
+      ]
+    }
+  ],
+  [
+    "0112d3634858c141a8d23a1b1e179391f495a9820d8709bc80971e90e9ec1c9c95",
+    {
+      "address": "00000000000000000000000000000000",
+      "module": "Association",
+      "name": "PrivilegedCapability",
+      "is_resource": true,
+      "ty_args": [
+        {
+          "Struct": {
+            "address": "00000000000000000000000000000000",
+            "module": "Libra",
+            "name": "AddCurrency",
+            "is_resource": false,
+            "ty_args": [],
+            "layout": [
+              "Bool"
+            ]
+          }
+        }
+      ],
+      "layout": [
+        "Bool"
+      ]
+    }
+  ],
+  [
+    "0122d17fad41a0417102aa1f89d7b7d8f6d2f97de7d68b3f2650dbab45237d94b5",
+    {
+      "address": "00000000000000000000000000000000",
+      "module": "LibraSystem",
+      "name": "DiscoverySet",
+      "is_resource": true,
+      "ty_args": [],
+      "layout": [
+        {
+          "Vector": {
+            "Struct": {
+              "address": "00000000000000000000000000000000",
+              "module": "LibraSystem",
+              "name": "DiscoveryInfo",
+              "is_resource": false,
+              "ty_args": [],
+              "layout": [
+                "Address",
+                {
+                  "Struct": {
+                    "address": "00000000000000000000000000000000",
+                    "module": "ValidatorConfig",
+                    "name": "DiscoveryConfig",
+                    "is_resource": false,
+                    "ty_args": [],
+                    "layout": [
+                      {
+                        "Vector": "U8"
+                      },
+                      {
+                        "Vector": "U8"
+                      },
+                      {
+                        "Vector": "U8"
+                      },
+                      {
+                        "Vector": "U8"
+                      }
+                    ]
+                  }
+                }
+              ]
+            }
+          }
+        },
+        {
+          "Struct": {
+            "address": "00000000000000000000000000000000",
+            "module": "Event",
+            "name": "EventHandle",
+            "is_resource": true,
+            "ty_args": [
+              {
+                "Struct": {
+                  "address": "00000000000000000000000000000000",
+                  "module": "LibraSystem",
+                  "name": "DiscoverySetChangeEvent",
+                  "is_resource": false,
+                  "ty_args": [],
+                  "layout": [
+                    {
+                      "Vector": {
+                        "Struct": {
+                          "address": "00000000000000000000000000000000",
+                          "module": "LibraSystem",
+                          "name": "DiscoveryInfo",
+                          "is_resource": false,
+                          "ty_args": [],
+                          "layout": [
+                            "Address",
+                            {
+                              "Struct": {
+                                "address": "00000000000000000000000000000000",
+                                "module": "ValidatorConfig",
+                                "name": "DiscoveryConfig",
+                                "is_resource": false,
+                                "ty_args": [],
+                                "layout": [
+                                  {
+                                    "Vector": "U8"
+                                  },
+                                  {
+                                    "Vector": "U8"
+                                  },
+                                  {
+                                    "Vector": "U8"
+                                  },
+                                  {
+                                    "Vector": "U8"
+                                  }
+                                ]
+                              }
+                            }
+                          ]
+                        }
+                      }
+                    }
+                  ]
+                }
+              }
+            ],
+            "layout": [
+              "U64",
+              {
+                "Vector": "U8"
+              }
+            ]
+          }
+        }
+      ]
+    }
+  ],
+  [
+    "012b0e0d6ebe2496c3efebaae2fdeb25d86677979846443e2bcea8555ef74cd741",
+    {
+      "address": "00000000000000000000000000000000",
+      "module": "AccountLimits",
+      "name": "LimitsDefinition",
+      "is_resource": true,
+      "ty_args": [],
+      "layout": [
+        "U64",
+        "U64",
+        "U64",
+        "U64",
+        "Bool"
+      ]
+    }
+  ],
+  [
+    "012b62e80f65f2b573d3916c46712545d9b709d9c71216bfb552db81d09bff418e",
+    {
+      "address": "00000000000000000000000000000000",
+      "module": "AccountType",
+      "name": "GrantingCapability",
+      "is_resource": true,
+      "ty_args": [
+        {
+          "Struct": {
+            "address": "00000000000000000000000000000000",
+            "module": "VASP",
+            "name": "RootVASP",
+            "is_resource": false,
+            "ty_args": [],
+            "layout": [
+              {
+                "Vector": "U8"
+              },
+              {
+                "Vector": "U8"
+              },
+              "U64",
+              {
+                "Vector": "U8"
+              }
+            ]
+          }
+        }
+      ],
+      "layout": [
+        "Bool"
+      ]
+    }
+  ],
+  [
+    "0130afeabcd3c39fd6938ef08fc552d10ceef6373a6a24157d4852b124c7070080",
+    {
+      "address": "00000000000000000000000000000000",
+      "module": "LibraTransactionTimeout",
+      "name": "TTL",
+      "is_resource": true,
+      "ty_args": [],
+      "layout": [
+        "U64"
+      ]
+    }
+  ],
+  [
+    "014321309608736789afeae38ffbfd99e05fc285529b8689080dc604e5a3d228dc",
+    {
+      "address": "00000000000000000000000000000000",
+      "module": "LibraConfig",
+      "name": "T",
+      "is_resource": true,
+      "ty_args": [
+        {
+          "Struct": {
+            "address": "00000000000000000000000000000000",
+            "module": "LibraVMConfig",
+            "name": "T",
+            "is_resource": false,
+            "ty_args": [],
+            "layout": [
+              {
+                "Vector": "U8"
+              },
+              {
+                "Struct": {
+                  "address": "00000000000000000000000000000000",
+                  "module": "LibraVMConfig",
+                  "name": "GasSchedule",
+                  "is_resource": false,
+                  "ty_args": [],
+                  "layout": [
+                    {
+                      "Vector": "U8"
+                    },
+                    {
+                      "Vector": "U8"
+                    },
+                    {
+                      "Struct": {
+                        "address": "00000000000000000000000000000000",
+                        "module": "LibraVMConfig",
+                        "name": "GasConstants",
+                        "is_resource": false,
+                        "ty_args": [],
+                        "layout": [
+                          "U64",
+                          "U64",
+                          "U64",
+                          "U64",
+                          "U64",
+                          "U64",
+                          "U64",
+                          "U64",
+                          "U64"
+                        ]
+                      }
+                    }
+                  ]
+                }
+              }
+            ]
+          }
+        }
+      ],
+      "layout": [
+        {
+          "Struct": {
+            "address": "00000000000000000000000000000000",
+            "module": "LibraVMConfig",
+            "name": "T",
+            "is_resource": false,
+            "ty_args": [],
+            "layout": [
+              {
+                "Vector": "U8"
+              },
+              {
+                "Struct": {
+                  "address": "00000000000000000000000000000000",
+                  "module": "LibraVMConfig",
+                  "name": "GasSchedule",
+                  "is_resource": false,
+                  "ty_args": [],
+                  "layout": [
+                    {
+                      "Vector": "U8"
+                    },
+                    {
+                      "Vector": "U8"
+                    },
+                    {
+                      "Struct": {
+                        "address": "00000000000000000000000000000000",
+                        "module": "LibraVMConfig",
+                        "name": "GasConstants",
+                        "is_resource": false,
+                        "ty_args": [],
+                        "layout": [
+                          "U64",
+                          "U64",
+                          "U64",
+                          "U64",
+                          "U64",
+                          "U64",
+                          "U64",
+                          "U64",
+                          "U64"
+                        ]
+                      }
+                    }
+                  ]
+                }
+              }
+            ]
+          }
+        }
+      ]
+    }
+  ],
+  [
+    "014bb80e80641d11869158d536f3530c01fd21ddbd700ee6ff48e70df4b6a31847",
+    {
+      "address": "00000000000000000000000000000000",
+      "module": "LibraAccount",
+      "name": "T",
+      "is_resource": true,
+      "ty_args": [],
+      "layout": [
+        {
+          "Vector": "U8"
+        },
+        "Bool",
+        "Bool",
+        {
+          "Struct": {
+            "address": "00000000000000000000000000000000",
+            "module": "Event",
+            "name": "EventHandle",
+            "is_resource": true,
+            "ty_args": [
+              {
+                "Struct": {
+                  "address": "00000000000000000000000000000000",
+                  "module": "LibraAccount",
+                  "name": "ReceivedPaymentEvent",
+                  "is_resource": false,
+                  "ty_args": [],
+                  "layout": [
+                    "U64",
+                    {
+                      "Vector": "U8"
+                    },
+                    "Address",
+                    {
+                      "Vector": "U8"
+                    }
+                  ]
+                }
+              }
+            ],
+            "layout": [
+              "U64",
+              {
+                "Vector": "U8"
+              }
+            ]
+          }
+        },
+        {
+          "Struct": {
+            "address": "00000000000000000000000000000000",
+            "module": "Event",
+            "name": "EventHandle",
+            "is_resource": true,
+            "ty_args": [
+              {
+                "Struct": {
+                  "address": "00000000000000000000000000000000",
+                  "module": "LibraAccount",
+                  "name": "SentPaymentEvent",
+                  "is_resource": false,
+                  "ty_args": [],
+                  "layout": [
+                    "U64",
+                    {
+                      "Vector": "U8"
+                    },
+                    "Address",
+                    {
+                      "Vector": "U8"
+                    }
+                  ]
+                }
+              }
+            ],
+            "layout": [
+              "U64",
+              {
+                "Vector": "U8"
+              }
+            ]
+          }
+        },
+        "U64",
+        "Bool",
+        {
+          "Vector": "U8"
+        }
+      ]
+    }
+  ],
+  [
+    "014e7d08f533a4a63609157e2995cfb60f0c612441f80e903109e9ee9901abd052",
+    {
+      "address": "00000000000000000000000000000000",
+      "module": "Libra",
+      "name": "CurrencyInfo",
+      "is_resource": true,
+      "ty_args": [
+        {
+          "Struct": {
+            "address": "00000000000000000000000000000000",
+            "module": "LBR",
+            "name": "T",
+            "is_resource": true,
+            "ty_args": [],
+            "layout": [
+              "Bool"
+            ]
+          }
+        }
+      ],
+      "layout": [
+        "U128",
+        "U64",
+        {
+          "Struct": {
+            "address": "00000000000000000000000000000000",
+            "module": "FixedPoint32",
+            "name": "T",
+            "is_resource": false,
+            "ty_args": [],
+            "layout": [
+              "U64"
+            ]
+          }
+        },
+        "Bool",
+        "U64",
+        "U64",
+        {
+          "Vector": "U8"
+        },
+        "Bool",
+        {
+          "Struct": {
+            "address": "00000000000000000000000000000000",
+            "module": "Event",
+            "name": "EventHandle",
+            "is_resource": true,
+            "ty_args": [
+              {
+                "Struct": {
+                  "address": "00000000000000000000000000000000",
+                  "module": "Libra",
+                  "name": "MintEvent",
+                  "is_resource": false,
+                  "ty_args": [],
+                  "layout": [
+                    "U64",
+                    {
+                      "Vector": "U8"
+                    }
+                  ]
+                }
+              }
+            ],
+            "layout": [
+              "U64",
+              {
+                "Vector": "U8"
+              }
+            ]
+          }
+        },
+        {
+          "Struct": {
+            "address": "00000000000000000000000000000000",
+            "module": "Event",
+            "name": "EventHandle",
+            "is_resource": true,
+            "ty_args": [
+              {
+                "Struct": {
+                  "address": "00000000000000000000000000000000",
+                  "module": "Libra",
+                  "name": "BurnEvent",
+                  "is_resource": false,
+                  "ty_args": [],
+                  "layout": [
+                    "U64",
+                    {
+                      "Vector": "U8"
+                    },
+                    "Address"
+                  ]
+                }
+              }
+            ],
+            "layout": [
+              "U64",
+              {
+                "Vector": "U8"
+              }
+            ]
+          }
+        },
+        {
+          "Struct": {
+            "address": "00000000000000000000000000000000",
+            "module": "Event",
+            "name": "EventHandle",
+            "is_resource": true,
+            "ty_args": [
+              {
+                "Struct": {
+                  "address": "00000000000000000000000000000000",
+                  "module": "Libra",
+                  "name": "PreburnEvent",
+                  "is_resource": false,
+                  "ty_args": [],
+                  "layout": [
+                    "U64",
+                    {
+                      "Vector": "U8"
+                    },
+                    "Address"
+                  ]
+                }
+              }
+            ],
+            "layout": [
+              "U64",
+              {
+                "Vector": "U8"
+              }
+            ]
+          }
+        },
+        {
+          "Struct": {
+            "address": "00000000000000000000000000000000",
+            "module": "Event",
+            "name": "EventHandle",
+            "is_resource": true,
+            "ty_args": [
+              {
+                "Struct": {
+                  "address": "00000000000000000000000000000000",
+                  "module": "Libra",
+                  "name": "CancelBurnEvent",
+                  "is_resource": false,
+                  "ty_args": [],
+                  "layout": [
+                    "U64",
+                    {
+                      "Vector": "U8"
+                    },
+                    "Address"
+                  ]
+                }
+              }
+            ],
+            "layout": [
+              "U64",
+              {
+                "Vector": "U8"
+              }
+            ]
+          }
+        }
+      ]
+    }
+  ],
+  [
+    "01590df0fd4917cb7b570fee669ebf853b28389d778ae8d9515e3ab46ff7ea8c0b",
+    {
+      "address": "00000000000000000000000000000000",
+      "module": "LibraWriteSetManager",
+      "name": "T",
+      "is_resource": true,
+      "ty_args": [],
+      "layout": [
+        "U64",
+        {
+          "Struct": {
+            "address": "00000000000000000000000000000000",
+            "module": "Event",
+            "name": "EventHandle",
+            "is_resource": true,
+            "ty_args": [
+              {
+                "Struct": {
+                  "address": "00000000000000000000000000000000",
+                  "module": "LibraWriteSetManager",
+                  "name": "UpgradeEvent",
+                  "is_resource": false,
+                  "ty_args": [],
+                  "layout": [
+                    {
+                      "Vector": "U8"
+                    }
+                  ]
+                }
+              }
+            ],
+            "layout": [
+              "U64",
+              {
+                "Vector": "U8"
+              }
+            ]
+          }
+        }
+      ]
+    }
+  ],
+  [
+    "0162c2830e5083d8f5bd0e73900812854affd93964fba4c73777400483dfedd873",
+    {
+      "address": "00000000000000000000000000000000",
+      "module": "Libra",
+      "name": "MintCapability",
+      "is_resource": true,
+      "ty_args": [
+        {
+          "Struct": {
+            "address": "00000000000000000000000000000000",
+            "module": "LBR",
+            "name": "T",
+            "is_resource": true,
+            "ty_args": [],
+            "layout": [
+              "Bool"
+            ]
+          }
+        }
+      ],
+      "layout": [
+        "Bool"
+      ]
+    }
+  ],
+  [
+    "016991b9e4523af4a62e55afaff19c47b9faa5de68d7f7000f59c247a8ddc5c772",
+    {
+      "address": "00000000000000000000000000000000",
+      "module": "LibraConfig",
+      "name": "Configuration",
+      "is_resource": true,
+      "ty_args": [],
+      "layout": [
+        "U64",
+        "U64",
+        {
+          "Struct": {
+            "address": "00000000000000000000000000000000",
+            "module": "Event",
+            "name": "EventHandle",
+            "is_resource": true,
+            "ty_args": [
+              {
+                "Struct": {
+                  "address": "00000000000000000000000000000000",
+                  "module": "LibraConfig",
+                  "name": "NewEpochEvent",
+                  "is_resource": false,
+                  "ty_args": [],
+                  "layout": [
+                    "U64"
+                  ]
+                }
+              }
+            ],
+            "layout": [
+              "U64",
+              {
+                "Vector": "U8"
+              }
+            ]
+          }
+        }
+      ]
+    }
+  ],
+  [
+    "016b17565a825085fcbe76f22667a211b35269a611a9c79066c9b3c864bce3c2a9",
+    {
+      "address": "00000000000000000000000000000000",
+      "module": "LibraBlock",
+      "name": "BlockMetadata",
+      "is_resource": true,
+      "ty_args": [],
+      "layout": [
+        "U64",
+        {
+          "Struct": {
+            "address": "00000000000000000000000000000000",
+            "module": "Event",
+            "name": "EventHandle",
+            "is_resource": true,
+            "ty_args": [
+              {
+                "Struct": {
+                  "address": "00000000000000000000000000000000",
+                  "module": "LibraBlock",
+                  "name": "NewBlockEvent",
+                  "is_resource": false,
+                  "ty_args": [],
+                  "layout": [
+                    "U64",
+                    "Address",
+                    {
+                      "Vector": "Address"
+                    },
+                    "U64"
+                  ]
+                }
+              }
+            ],
+            "layout": [
+              "U64",
+              {
+                "Vector": "U8"
+              }
+            ]
+          }
+        }
+      ]
+    }
+  ],
+  [
+    "016b23f02c526ac363b128b37141f7be4add33412424e247f34d428cfe340bb9e3",
+    {
+      "address": "00000000000000000000000000000000",
+      "module": "Libra",
+      "name": "BurnCapability",
+      "is_resource": true,
+      "ty_args": [
+        {
+          "Struct": {
+            "address": "00000000000000000000000000000000",
+            "module": "Coin2",
+            "name": "T",
+            "is_resource": false,
+            "ty_args": [],
+            "layout": [
+              "Bool"
+            ]
+          }
+        }
+      ],
+      "layout": [
+        "Bool"
+      ]
+    }
+  ],
+  [
+    "017b64ba141bcd3eef394b13610fa05e4d59d7aa242dc3a1660a798e31d6bb0a95",
+    {
+      "address": "00000000000000000000000000000000",
+      "module": "Association",
+      "name": "PrivilegedCapability",
+      "is_resource": true,
+      "ty_args": [
+        {
+          "Struct": {
+            "address": "00000000000000000000000000000000",
+            "module": "Association",
+            "name": "T",
+            "is_resource": false,
+            "ty_args": [],
+            "layout": [
+              "Bool"
+            ]
+          }
+        }
+      ],
+      "layout": [
+        "Bool"
+      ]
+    }
+  ],
+  [
+    "0182cefd920777d9eab6b822d0e1c3a9e35e92130bf4f77f4c3b8d42aa585979b6",
+    {
+      "address": "00000000000000000000000000000000",
+      "module": "LibraConfig",
+      "name": "T",
+      "is_resource": true,
+      "ty_args": [
+        {
+          "Struct": {
+            "address": "00000000000000000000000000000000",
+            "module": "RegisteredCurrencies",
+            "name": "T",
+            "is_resource": false,
+            "ty_args": [],
+            "layout": [
+              {
+                "Vector": {
+                  "Vector": "U8"
+                }
+              }
+            ]
+          }
+        }
+      ],
+      "layout": [
+        {
+          "Struct": {
+            "address": "00000000000000000000000000000000",
+            "module": "RegisteredCurrencies",
+            "name": "T",
+            "is_resource": false,
+            "ty_args": [],
+            "layout": [
+              {
+                "Vector": {
+                  "Vector": "U8"
+                }
+              }
+            ]
+          }
+        }
+      ]
+    }
+  ],
+  [
+    "0184336aa7655dff2ec54246cf0566df3e4168ba282bb9d3ecc4529d98ee463236",
+    {
+      "address": "00000000000000000000000000000000",
+      "module": "Libra",
+      "name": "CurrencyInfo",
+      "is_resource": true,
+      "ty_args": [
+        {
+          "Struct": {
+            "address": "00000000000000000000000000000000",
+            "module": "Coin2",
+            "name": "T",
+            "is_resource": false,
+            "ty_args": [],
+            "layout": [
+              "Bool"
+            ]
+          }
+        }
+      ],
+      "layout": [
+        "U128",
+        "U64",
+        {
+          "Struct": {
+            "address": "00000000000000000000000000000000",
+            "module": "FixedPoint32",
+            "name": "T",
+            "is_resource": false,
+            "ty_args": [],
+            "layout": [
+              "U64"
+            ]
+          }
+        },
+        "Bool",
+        "U64",
+        "U64",
+        {
+          "Vector": "U8"
+        },
+        "Bool",
+        {
+          "Struct": {
+            "address": "00000000000000000000000000000000",
+            "module": "Event",
+            "name": "EventHandle",
+            "is_resource": true,
+            "ty_args": [
+              {
+                "Struct": {
+                  "address": "00000000000000000000000000000000",
+                  "module": "Libra",
+                  "name": "MintEvent",
+                  "is_resource": false,
+                  "ty_args": [],
+                  "layout": [
+                    "U64",
+                    {
+                      "Vector": "U8"
+                    }
+                  ]
+                }
+              }
+            ],
+            "layout": [
+              "U64",
+              {
+                "Vector": "U8"
+              }
+            ]
+          }
+        },
+        {
+          "Struct": {
+            "address": "00000000000000000000000000000000",
+            "module": "Event",
+            "name": "EventHandle",
+            "is_resource": true,
+            "ty_args": [
+              {
+                "Struct": {
+                  "address": "00000000000000000000000000000000",
+                  "module": "Libra",
+                  "name": "BurnEvent",
+                  "is_resource": false,
+                  "ty_args": [],
+                  "layout": [
+                    "U64",
+                    {
+                      "Vector": "U8"
+                    },
+                    "Address"
+                  ]
+                }
+              }
+            ],
+            "layout": [
+              "U64",
+              {
+                "Vector": "U8"
+              }
+            ]
+          }
+        },
+        {
+          "Struct": {
+            "address": "00000000000000000000000000000000",
+            "module": "Event",
+            "name": "EventHandle",
+            "is_resource": true,
+            "ty_args": [
+              {
+                "Struct": {
+                  "address": "00000000000000000000000000000000",
+                  "module": "Libra",
+                  "name": "PreburnEvent",
+                  "is_resource": false,
+                  "ty_args": [],
+                  "layout": [
+                    "U64",
+                    {
+                      "Vector": "U8"
+                    },
+                    "Address"
+                  ]
+                }
+              }
+            ],
+            "layout": [
+              "U64",
+              {
+                "Vector": "U8"
+              }
+            ]
+          }
+        },
+        {
+          "Struct": {
+            "address": "00000000000000000000000000000000",
+            "module": "Event",
+            "name": "EventHandle",
+            "is_resource": true,
+            "ty_args": [
+              {
+                "Struct": {
+                  "address": "00000000000000000000000000000000",
+                  "module": "Libra",
+                  "name": "CancelBurnEvent",
+                  "is_resource": false,
+                  "ty_args": [],
+                  "layout": [
+                    "U64",
+                    {
+                      "Vector": "U8"
+                    },
+                    "Address"
+                  ]
+                }
+              }
+            ],
+            "layout": [
+              "U64",
+              {
+                "Vector": "U8"
+              }
+            ]
+          }
+        }
+      ]
+    }
+  ],
+  [
+    "018635a9a7eaeb9cf5dee420f1f1a5f151a9068086576cd02c1ef8e1714f61a135",
+    {
+      "address": "00000000000000000000000000000000",
+      "module": "LibraAccount",
+      "name": "Balance",
+      "is_resource": true,
+      "ty_args": [
+        {
+          "Struct": {
+            "address": "00000000000000000000000000000000",
+            "module": "Coin1",
+            "name": "T",
+            "is_resource": false,
+            "ty_args": [],
+            "layout": [
+              "Bool"
+            ]
+          }
+        }
+      ],
+      "layout": [
+        {
+          "Struct": {
+            "address": "00000000000000000000000000000000",
+            "module": "Libra",
+            "name": "T",
+            "is_resource": true,
+            "ty_args": [
+              {
+                "Struct": {
+                  "address": "00000000000000000000000000000000",
+                  "module": "Coin1",
+                  "name": "T",
+                  "is_resource": false,
+                  "ty_args": [],
+                  "layout": [
+                    "Bool"
+                  ]
+                }
+              }
+            ],
+            "layout": [
+              "U64"
+            ]
+          }
+        }
+      ]
+    }
+  ],
+  [
+    "018988523c0dce5a414a9f80755a3721334db68e1191c1821060a60d9684c6d9ab",
+    {
+      "address": "00000000000000000000000000000000",
+      "module": "LibraConfig",
+      "name": "T",
+      "is_resource": true,
+      "ty_args": [
+        {
+          "Struct": {
+            "address": "00000000000000000000000000000000",
+            "module": "LibraVersion",
+            "name": "T",
+            "is_resource": false,
+            "ty_args": [],
+            "layout": [
+              "U64"
+            ]
+          }
+        }
+      ],
+      "layout": [
+        {
+          "Struct": {
+            "address": "00000000000000000000000000000000",
+            "module": "LibraVersion",
+            "name": "T",
+            "is_resource": false,
+            "ty_args": [],
+            "layout": [
+              "U64"
+            ]
+          }
+        }
+      ]
+    }
+  ],
+  [
+    "018d575384368712ec38fcfb1215d2e8f88fbcad9994930416671ea29149ae7d9c",
+    {
+      "address": "00000000000000000000000000000000",
+      "module": "AccountType",
+      "name": "Registered",
+      "is_resource": true,
+      "ty_args": [
+        {
+          "Struct": {
+            "address": "00000000000000000000000000000000",
+            "module": "VASP",
+            "name": "ChildVASP",
+            "is_resource": false,
+            "ty_args": [],
+            "layout": [
+              "Bool"
+            ]
+          }
+        }
+      ],
+      "layout": [
+        "Bool"
+      ]
+    }
+  ],
+  [
+    "019123f269df8738c896b4fa63d2ae5d1c98d9ca8566b83f343db8a28e3ff7aab7",
+    {
+      "address": "00000000000000000000000000000000",
+      "module": "AccountTrack",
+      "name": "AccountLimitsCapability",
+      "is_resource": true,
+      "ty_args": [],
+      "layout": [
+        {
+          "Struct": {
+            "address": "00000000000000000000000000000000",
+            "module": "AccountLimits",
+            "name": "UpdateCapability",
+            "is_resource": true,
+            "ty_args": [],
+            "layout": [
+              "Bool"
+            ]
+          }
+        },
+        {
+          "Struct": {
+            "address": "00000000000000000000000000000000",
+            "module": "AccountType",
+            "name": "UpdateCapability",
+            "is_resource": true,
+            "ty_args": [],
+            "layout": [
+              "Bool"
+            ]
+          }
+        }
+      ]
+    }
+  ],
+  [
+    "01971e71c0d6cdaee64c5dbeab3185e5678a9796926641ced76bcb6549257d67e7",
+    {
+      "address": "00000000000000000000000000000000",
+      "module": "AccountType",
+      "name": "T",
+      "is_resource": true,
+      "ty_args": [
+        {
+          "Struct": {
+            "address": "00000000000000000000000000000000",
+            "module": "Unhosted",
+            "name": "T",
+            "is_resource": false,
+            "ty_args": [],
+            "layout": [
+              {
+                "Struct": {
+                  "address": "00000000000000000000000000000000",
+                  "module": "AccountLimits",
+                  "name": "Window",
+                  "is_resource": false,
+                  "ty_args": [],
+                  "layout": [
+                    "U64",
+                    "U64",
+                    "U64",
+                    "U64"
+                  ]
+                }
+              }
+            ]
+          }
+        }
+      ],
+      "layout": [
+        "Bool",
+        {
+          "Struct": {
+            "address": "00000000000000000000000000000000",
+            "module": "Unhosted",
+            "name": "T",
+            "is_resource": false,
+            "ty_args": [],
+            "layout": [
+              {
+                "Struct": {
+                  "address": "00000000000000000000000000000000",
+                  "module": "AccountLimits",
+                  "name": "Window",
+                  "is_resource": false,
+                  "ty_args": [],
+                  "layout": [
+                    "U64",
+                    "U64",
+                    "U64",
+                    "U64"
+                  ]
+                }
+              }
+            ]
+          }
+        },
+        "Address"
+      ]
+    }
+  ],
+  [
+    "019780c94460f5a49e52572cab8785559f69691819d37ac16e9987c76385cf4c3c",
+    {
+      "address": "00000000000000000000000000000000",
+      "module": "Libra",
+      "name": "MintCapability",
+      "is_resource": true,
+      "ty_args": [
+        {
+          "Struct": {
+            "address": "00000000000000000000000000000000",
+            "module": "Coin1",
+            "name": "T",
+            "is_resource": false,
+            "ty_args": [],
+            "layout": [
+              "Bool"
+            ]
+          }
+        }
+      ],
+      "layout": [
+        "Bool"
+      ]
+    }
+  ],
+  [
+    "01b46130a0fbd966d9a43113932434b0fb6e1f7a61e94b39376f8aee00badf4975",
+    {
+      "address": "00000000000000000000000000000000",
+      "module": "TransactionFee",
+      "name": "TransactionFees",
+      "is_resource": true,
+      "ty_args": [],
+      "layout": [
+        {
+          "Struct": {
+            "address": "00000000000000000000000000000000",
+            "module": "LibraAccount",
+            "name": "WithdrawalCapability",
+            "is_resource": true,
+            "ty_args": [],
+            "layout": [
+              "Address"
+            ]
+          }
+        }
+      ]
+    }
+  ],
+  [
+    "01be88f89b98ec9dc840cee32763bf9d155987bab54273367b671e29a66dba7825",
+    {
+      "address": "00000000000000000000000000000000",
+      "module": "LibraTimestamp",
+      "name": "CurrentTimeMicroseconds",
+      "is_resource": true,
+      "ty_args": [],
+      "layout": [
+        "U64"
+      ]
+    }
+  ],
+  [
+    "01c0eec80bf3794187df76baeecd53334617296c19c4e65967e8b2591101793579",
+    {
+      "address": "00000000000000000000000000000000",
+      "module": "Association",
+      "name": "Root",
+      "is_resource": true,
+      "ty_args": [],
+      "layout": [
+        "Bool"
+      ]
+    }
+  ],
+  [
+    "01c507cb163e0d3c3e23077fa29f09f4a9031666e0c9e6b3d062a5410d32bb26a3",
+    {
+      "address": "00000000000000000000000000000000",
+      "module": "LibraAccount",
+      "name": "Balance",
+      "is_resource": true,
+      "ty_args": [
+        {
+          "Struct": {
+            "address": "00000000000000000000000000000000",
+            "module": "Coin2",
+            "name": "T",
+            "is_resource": false,
+            "ty_args": [],
+            "layout": [
+              "Bool"
+            ]
+          }
+        }
+      ],
+      "layout": [
+        {
+          "Struct": {
+            "address": "00000000000000000000000000000000",
+            "module": "Libra",
+            "name": "T",
+            "is_resource": true,
+            "ty_args": [
+              {
+                "Struct": {
+                  "address": "00000000000000000000000000000000",
+                  "module": "Coin2",
+                  "name": "T",
+                  "is_resource": false,
+                  "ty_args": [],
+                  "layout": [
+                    "Bool"
+                  ]
+                }
+              }
+            ],
+            "layout": [
+              "U64"
+            ]
+          }
+        }
+      ]
+    }
+  ],
+  [
+    "01c6105a7dcbe17812e8df3fcc7ee5962dfea6d3043e9d5f341a1c4d30871bd1c4",
+    {
+      "address": "00000000000000000000000000000000",
+      "module": "AccountType",
+      "name": "Registered",
+      "is_resource": true,
+      "ty_args": [
+        {
+          "Struct": {
+            "address": "00000000000000000000000000000000",
+            "module": "Unhosted",
+            "name": "T",
+            "is_resource": false,
+            "ty_args": [],
+            "layout": [
+              {
+                "Struct": {
+                  "address": "00000000000000000000000000000000",
+                  "module": "AccountLimits",
+                  "name": "Window",
+                  "is_resource": false,
+                  "ty_args": [],
+                  "layout": [
+                    "U64",
+                    "U64",
+                    "U64",
+                    "U64"
+                  ]
+                }
+              }
+            ]
+          }
+        }
+      ],
+      "layout": [
+        "Bool"
+      ]
+    }
+  ],
+  [
+    "01c62a1ef9fa1d82dbe17d2ac7692ddea2653262447f97554ef07aad06c7560449",
+    {
+      "address": "00000000000000000000000000000000",
+      "module": "Libra",
+      "name": "CurrencyRegistrationCapability",
+      "is_resource": true,
+      "ty_args": [],
+      "layout": [
+        {
+          "Struct": {
+            "address": "00000000000000000000000000000000",
+            "module": "RegisteredCurrencies",
+            "name": "RegistrationCapability",
+            "is_resource": true,
+            "ty_args": [],
+            "layout": [
+              "Bool"
+            ]
+          }
+        }
+      ]
+    }
+  ],
+  [
+    "01c7f230e698082e776f6833558fc5c5f86e175e852f483372173d2e3bd4b1896b",
+    {
+      "address": "00000000000000000000000000000000",
+      "module": "Libra",
+      "name": "BurnCapability",
+      "is_resource": true,
+      "ty_args": [
+        {
+          "Struct": {
+            "address": "00000000000000000000000000000000",
+            "module": "LBR",
+            "name": "T",
+            "is_resource": true,
+            "ty_args": [],
+            "layout": [
+              "Bool"
+            ]
+          }
+        }
+      ],
+      "layout": [
+        "Bool"
+      ]
+    }
+  ],
+  [
+    "01da83c4348f9ee678e9d99387447c05f62a7a3ebee69f37985ece1218c15738c8",
+    {
+      "address": "00000000000000000000000000000000",
+      "module": "LibraConfig",
+      "name": "T",
+      "is_resource": true,
+      "ty_args": [
+        {
+          "Struct": {
+            "address": "00000000000000000000000000000000",
+            "module": "LibraSystem",
+            "name": "T",
+            "is_resource": false,
+            "ty_args": [],
+            "layout": [
+              "U8",
+              {
+                "Vector": {
+                  "Struct": {
+                    "address": "00000000000000000000000000000000",
+                    "module": "LibraSystem",
+                    "name": "ValidatorInfo",
+                    "is_resource": false,
+                    "ty_args": [],
+                    "layout": [
+                      "Address",
+                      "U64",
+                      {
+                        "Struct": {
+                          "address": "00000000000000000000000000000000",
+                          "module": "ValidatorConfig",
+                          "name": "Config",
+                          "is_resource": false,
+                          "ty_args": [],
+                          "layout": [
+                            {
+                              "Vector": "U8"
+                            },
+                            {
+                              "Vector": "U8"
+                            },
+                            {
+                              "Vector": "U8"
+                            }
+                          ]
+                        }
+                      }
+                    ]
+                  }
+                }
+              }
+            ]
+          }
+        }
+      ],
+      "layout": [
+        {
+          "Struct": {
+            "address": "00000000000000000000000000000000",
+            "module": "LibraSystem",
+            "name": "T",
+            "is_resource": false,
+            "ty_args": [],
+            "layout": [
+              "U8",
+              {
+                "Vector": {
+                  "Struct": {
+                    "address": "00000000000000000000000000000000",
+                    "module": "LibraSystem",
+                    "name": "ValidatorInfo",
+                    "is_resource": false,
+                    "ty_args": [],
+                    "layout": [
+                      "Address",
+                      "U64",
+                      {
+                        "Struct": {
+                          "address": "00000000000000000000000000000000",
+                          "module": "ValidatorConfig",
+                          "name": "Config",
+                          "is_resource": false,
+                          "ty_args": [],
+                          "layout": [
+                            {
+                              "Vector": "U8"
+                            },
+                            {
+                              "Vector": "U8"
+                            },
+                            {
+                              "Vector": "U8"
+                            }
+                          ]
+                        }
+                      }
+                    ]
+                  }
+                }
+              }
+            ]
+          }
+        }
+      ]
+    }
+  ],
+  [
+    "01e045fdb7e54f67ae0e51afb40a0b3c9d23deabb1cc0357e85ced4978c655b558",
+    {
+      "address": "00000000000000000000000000000000",
+      "module": "Libra",
+      "name": "BurnCapability",
+      "is_resource": true,
+      "ty_args": [
+        {
+          "Struct": {
+            "address": "00000000000000000000000000000000",
+            "module": "Coin1",
+            "name": "T",
+            "is_resource": false,
+            "ty_args": [],
+            "layout": [
+              "Bool"
+            ]
+          }
+        }
+      ],
+      "layout": [
+        "Bool"
+      ]
+    }
+  ],
+  [
+    "01e40c6658618bf6c002f3fc8933ad7d0a920e823f92a88ec0d229aa5e08f9efca",
+    {
+      "address": "00000000000000000000000000000000",
+      "module": "LibraAccount",
+      "name": "Balance",
+      "is_resource": true,
+      "ty_args": [
+        {
+          "Struct": {
+            "address": "00000000000000000000000000000000",
+            "module": "LBR",
+            "name": "T",
+            "is_resource": true,
+            "ty_args": [],
+            "layout": [
+              "Bool"
+            ]
+          }
+        }
+      ],
+      "layout": [
+        {
+          "Struct": {
+            "address": "00000000000000000000000000000000",
+            "module": "Libra",
+            "name": "T",
+            "is_resource": true,
+            "ty_args": [
+              {
+                "Struct": {
+                  "address": "00000000000000000000000000000000",
+                  "module": "LBR",
+                  "name": "T",
+                  "is_resource": true,
+                  "ty_args": [],
+                  "layout": [
+                    "Bool"
+                  ]
+                }
+              }
+            ],
+            "layout": [
+              "U64"
+            ]
+          }
+        }
+      ]
+    }
+  ],
+  [
+    "01e4a5c3986500214a2a60dde2a646566030558eee351345490c3be7f6e7d0d2a8",
+    {
+      "address": "00000000000000000000000000000000",
+      "module": "AccountType",
+      "name": "Registered",
+      "is_resource": true,
+      "ty_args": [
+        {
+          "Struct": {
+            "address": "00000000000000000000000000000000",
+            "module": "Empty",
+            "name": "T",
+            "is_resource": false,
+            "ty_args": [],
+            "layout": [
+              "Bool"
+            ]
+          }
+        }
+      ],
+      "layout": [
+        "Bool"
+      ]
+    }
+  ],
+  [
+    "01f973af429c8eba108f35bad0a0360e45111a0b7adfd58ed5272d9f954f095d84",
+    {
+      "address": "00000000000000000000000000000000",
+      "module": "Libra",
+      "name": "CurrencyInfo",
+      "is_resource": true,
+      "ty_args": [
+        {
+          "Struct": {
+            "address": "00000000000000000000000000000000",
+            "module": "Coin1",
+            "name": "T",
+            "is_resource": false,
+            "ty_args": [],
+            "layout": [
+              "Bool"
+            ]
+          }
+        }
+      ],
+      "layout": [
+        "U128",
+        "U64",
+        {
+          "Struct": {
+            "address": "00000000000000000000000000000000",
+            "module": "FixedPoint32",
+            "name": "T",
+            "is_resource": false,
+            "ty_args": [],
+            "layout": [
+              "U64"
+            ]
+          }
+        },
+        "Bool",
+        "U64",
+        "U64",
+        {
+          "Vector": "U8"
+        },
+        "Bool",
+        {
+          "Struct": {
+            "address": "00000000000000000000000000000000",
+            "module": "Event",
+            "name": "EventHandle",
+            "is_resource": true,
+            "ty_args": [
+              {
+                "Struct": {
+                  "address": "00000000000000000000000000000000",
+                  "module": "Libra",
+                  "name": "MintEvent",
+                  "is_resource": false,
+                  "ty_args": [],
+                  "layout": [
+                    "U64",
+                    {
+                      "Vector": "U8"
+                    }
+                  ]
+                }
+              }
+            ],
+            "layout": [
+              "U64",
+              {
+                "Vector": "U8"
+              }
+            ]
+          }
+        },
+        {
+          "Struct": {
+            "address": "00000000000000000000000000000000",
+            "module": "Event",
+            "name": "EventHandle",
+            "is_resource": true,
+            "ty_args": [
+              {
+                "Struct": {
+                  "address": "00000000000000000000000000000000",
+                  "module": "Libra",
+                  "name": "BurnEvent",
+                  "is_resource": false,
+                  "ty_args": [],
+                  "layout": [
+                    "U64",
+                    {
+                      "Vector": "U8"
+                    },
+                    "Address"
+                  ]
+                }
+              }
+            ],
+            "layout": [
+              "U64",
+              {
+                "Vector": "U8"
+              }
+            ]
+          }
+        },
+        {
+          "Struct": {
+            "address": "00000000000000000000000000000000",
+            "module": "Event",
+            "name": "EventHandle",
+            "is_resource": true,
+            "ty_args": [
+              {
+                "Struct": {
+                  "address": "00000000000000000000000000000000",
+                  "module": "Libra",
+                  "name": "PreburnEvent",
+                  "is_resource": false,
+                  "ty_args": [],
+                  "layout": [
+                    "U64",
+                    {
+                      "Vector": "U8"
+                    },
+                    "Address"
+                  ]
+                }
+              }
+            ],
+            "layout": [
+              "U64",
+              {
+                "Vector": "U8"
+              }
+            ]
+          }
+        },
+        {
+          "Struct": {
+            "address": "00000000000000000000000000000000",
+            "module": "Event",
+            "name": "EventHandle",
+            "is_resource": true,
+            "ty_args": [
+              {
+                "Struct": {
+                  "address": "00000000000000000000000000000000",
+                  "module": "Libra",
+                  "name": "CancelBurnEvent",
+                  "is_resource": false,
+                  "ty_args": [],
+                  "layout": [
+                    "U64",
+                    {
+                      "Vector": "U8"
+                    },
+                    "Address"
+                  ]
+                }
+              }
+            ],
+            "layout": [
+              "U64",
+              {
+                "Vector": "U8"
+              }
+            ]
+          }
+        }
+      ]
+    }
+  ],
+  [
+    "01fd874b739170a09f797092e3a0a428a2f3b7972c8e9c210b69a68b2dfe4de271",
+    {
+      "address": "00000000000000000000000000000000",
+      "module": "AccountType",
+      "name": "Registered",
+      "is_resource": true,
+      "ty_args": [
+        {
+          "Struct": {
+            "address": "00000000000000000000000000000000",
+            "module": "VASP",
+            "name": "RootVASP",
+            "is_resource": false,
+            "ty_args": [],
+            "layout": [
+              {
+                "Vector": "U8"
+              },
+              {
+                "Vector": "U8"
+              },
+              "U64",
+              {
+                "Vector": "U8"
+              }
+            ]
+          }
+        }
+      ],
+      "layout": [
+        "Bool"
+      ]
+    }
+  ]
+]

--- a/language/resource-viewer/src/cached_access_path_table.rs
+++ b/language/resource-viewer/src/cached_access_path_table.rs
@@ -1,0 +1,40 @@
+// Copyright (c) The Libra Core Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+use anyhow::{anyhow, Result};
+use move_vm_types::loaded_data::types::FatStructType;
+use once_cell::sync::Lazy;
+use std::{collections::btree_map::BTreeMap, fs::File, io::Write, path::PathBuf};
+use vm_genesis::generate_genesis_type_mapping;
+
+pub const TYPE_MAP_PATH: &str = "move_type_map/mapping.txt";
+pub const STAGED_TYPE_MAP_BYTES: &[u8] = std::include_bytes!("../move_type_map/mapping.txt");
+
+static STAGED_TYPE_MAP: Lazy<BTreeMap<Vec<u8>, FatStructType>> = Lazy::new(build_mapping);
+
+pub fn update_mapping() {
+    let new_mapping = generate_genesis_type_mapping()
+        .into_iter()
+        .map(|(k, v)| (hex::encode(&k), v))
+        .collect::<Vec<_>>();
+    let file_path = PathBuf::from(TYPE_MAP_PATH);
+    let mapping_str = serde_json::to_string_pretty(&new_mapping).unwrap();
+    let mut module_file = File::create(file_path).unwrap();
+    module_file.write_all(&mapping_str.as_bytes()).unwrap();
+    module_file.write_all(b"\n").unwrap();
+}
+
+pub fn build_mapping() -> BTreeMap<Vec<u8>, FatStructType> {
+    serde_json::from_slice::<Vec<(String, FatStructType)>>(STAGED_TYPE_MAP_BYTES)
+        .unwrap()
+        .into_iter()
+        .map(|(k, v)| (hex::decode(k.as_bytes()).unwrap(), v))
+        .collect()
+}
+
+pub fn resource_vec_to_type_tag(resource_vec: &[u8]) -> Result<FatStructType> {
+    STAGED_TYPE_MAP
+        .get(resource_vec)
+        .cloned()
+        .ok_or_else(|| anyhow!("Unknown AccessPath"))
+}

--- a/language/resource-viewer/src/lib.rs
+++ b/language/resource-viewer/src/lib.rs
@@ -1,0 +1,236 @@
+// Copyright (c) The Libra Core Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::{
+    cached_access_path_table::resource_vec_to_type_tag,
+    resolver::Resolver,
+    value::{MoveStruct, MoveStructLayout, MoveTypeLayout, MoveValue},
+};
+use anyhow::{anyhow, Result};
+use libra_state_view::StateView;
+use libra_types::{
+    access_path::AccessPath, account_address::AccountAddress, account_state::AccountState,
+    contract_event::ContractEvent, language_storage::StructTag,
+};
+use move_core_types::identifier::Identifier;
+use std::{
+    collections::btree_map::BTreeMap,
+    convert::TryFrom,
+    fmt::{Display, Formatter},
+};
+
+pub use cached_access_path_table::update_mapping;
+use move_vm_types::loaded_data::types::{FatStructType, FatType};
+
+mod cached_access_path_table;
+mod module_cache;
+mod resolver;
+pub mod value;
+
+#[derive(Debug)]
+pub struct AnnotatedAccountStateBlob(BTreeMap<StructTag, AnnotatedMoveStruct>);
+
+#[derive(Debug)]
+pub struct AnnotatedMoveStruct {
+    is_resource: bool,
+    type_: StructTag,
+    value: Vec<(Identifier, AnnotatedMoveValue)>,
+}
+
+/// AnnotatedMoveValue is a fully expanded version of on chain move data. This should only be used
+/// for debugging/client purpose right now and just for a better visualization of on chain data. In
+/// the long run, we would like to transform this struct to a Json value so that we can have a cross
+/// platform interpretation of the on chain data.
+#[derive(Debug)]
+pub enum AnnotatedMoveValue {
+    U8(u8),
+    U64(u64),
+    U128(u128),
+    Bool(bool),
+    Address(AccountAddress),
+    Vector(Vec<AnnotatedMoveValue>),
+    Bytes(Vec<u8>),
+    Struct(AnnotatedMoveStruct),
+}
+
+pub struct MoveValueAnnotator<'a> {
+    cache: Resolver<'a>,
+    _data_view: &'a dyn StateView,
+}
+
+impl<'a> MoveValueAnnotator<'a> {
+    pub fn new(view: &'a dyn StateView) -> Self {
+        Self {
+            cache: Resolver::new(view, true),
+            _data_view: view,
+        }
+    }
+
+    pub fn view_access_path(
+        &self,
+        access_path: AccessPath,
+        blob: &[u8],
+    ) -> Result<AnnotatedMoveStruct> {
+        let ty = resource_vec_to_type_tag(&access_path.path)?;
+        let struct_def = MoveStructLayout::try_from(&ty)?;
+        let move_struct = MoveStruct::simple_deserialize(blob, &struct_def)?;
+        self.annotate_struct(&move_struct, &ty)
+    }
+
+    pub fn view_contract_event(&self, event: &ContractEvent) -> Result<AnnotatedMoveValue> {
+        let ty = self.cache.resolve_type(event.type_tag())?;
+        let move_ty = MoveTypeLayout::try_from(&ty)?;
+        let move_value = MoveValue::simple_deserialize(event.event_data(), &move_ty)?;
+        self.annotate_value(&move_value, &ty)
+    }
+
+    pub fn view_account_state(&self, state: &AccountState) -> Result<AnnotatedAccountStateBlob> {
+        let mut output = BTreeMap::new();
+        for (k, v) in state.iter() {
+            let ty = resource_vec_to_type_tag(k.as_slice())?;
+            let struct_def = MoveStructLayout::try_from(&ty)?;
+            let move_struct = MoveStruct::simple_deserialize(v.as_slice(), &struct_def)?;
+            output.insert(ty.struct_tag()?, self.annotate_struct(&move_struct, &ty)?);
+        }
+        Ok(AnnotatedAccountStateBlob(output))
+    }
+
+    fn annotate_struct(
+        &self,
+        move_struct: &MoveStruct,
+        ty: &FatStructType,
+    ) -> Result<AnnotatedMoveStruct> {
+        let struct_tag = ty.struct_tag()?;
+        let field_names = self.cache.get_field_names(ty)?;
+        let mut annotated_fields = vec![];
+        for (ty, v) in ty.layout.iter().zip(move_struct.fields().iter()) {
+            annotated_fields.push(self.annotate_value(v, ty)?);
+        }
+        Ok(AnnotatedMoveStruct {
+            is_resource: ty.is_resource,
+            type_: struct_tag,
+            value: field_names
+                .into_iter()
+                .zip(annotated_fields.into_iter())
+                .collect(),
+        })
+    }
+
+    fn annotate_value(&self, value: &MoveValue, ty: &FatType) -> Result<AnnotatedMoveValue> {
+        Ok(match (value, ty) {
+            (MoveValue::Bool(b), FatType::Bool) => AnnotatedMoveValue::Bool(*b),
+            (MoveValue::U8(i), FatType::U8) => AnnotatedMoveValue::U8(*i),
+            (MoveValue::U64(i), FatType::U64) => AnnotatedMoveValue::U64(*i),
+            (MoveValue::U128(i), FatType::U128) => AnnotatedMoveValue::U128(*i),
+            (MoveValue::Address(a), FatType::Address) => AnnotatedMoveValue::Address(*a),
+            (MoveValue::Vector(a), FatType::Vector(ty)) => match ty.as_ref() {
+                FatType::U8 => AnnotatedMoveValue::Bytes(
+                    a.iter()
+                        .map(|v| match v {
+                            MoveValue::U8(i) => Ok(*i),
+                            _ => Err(anyhow!("unexpected value type")),
+                        })
+                        .collect::<Result<_>>()?,
+                ),
+                _ => AnnotatedMoveValue::Vector(
+                    a.iter()
+                        .map(|v| self.annotate_value(v, ty.as_ref()))
+                        .collect::<Result<_>>()?,
+                ),
+            },
+            (MoveValue::Struct(s), FatType::Struct(ty)) => {
+                AnnotatedMoveValue::Struct(self.annotate_struct(s, ty.as_ref())?)
+            }
+            _ => {
+                return Err(anyhow!(
+                    "Cannot annotate value {:?} with type {:?}",
+                    value,
+                    ty
+                ))
+            }
+        })
+    }
+}
+
+fn write_indent(f: &mut Formatter, indent: u64) -> std::fmt::Result {
+    for _i in 0..indent {
+        write!(f, " ")?;
+    }
+    Ok(())
+}
+
+fn pretty_print_value(
+    f: &mut Formatter,
+    value: &AnnotatedMoveValue,
+    indent: u64,
+) -> std::fmt::Result {
+    match value {
+        AnnotatedMoveValue::Bool(b) => write!(f, "{}", b),
+        AnnotatedMoveValue::U8(v) => write!(f, "{}u8", v),
+        AnnotatedMoveValue::U64(v) => write!(f, "{}", v),
+        AnnotatedMoveValue::U128(v) => write!(f, "{}u128", v),
+        AnnotatedMoveValue::Address(a) => write!(f, "{}", a.short_str()),
+        AnnotatedMoveValue::Vector(v) => {
+            writeln!(f, "[")?;
+            for value in v.iter() {
+                write_indent(f, indent + 4)?;
+                pretty_print_value(f, value, indent + 4)?;
+                writeln!(f, ",")?;
+            }
+            write_indent(f, indent)?;
+            write!(f, "]")
+        }
+        AnnotatedMoveValue::Bytes(v) => write!(f, "{}", hex::encode(&v)),
+        AnnotatedMoveValue::Struct(s) => pretty_print_struct(f, s, indent),
+    }
+}
+
+fn pretty_print_struct(
+    f: &mut Formatter,
+    value: &AnnotatedMoveStruct,
+    indent: u64,
+) -> std::fmt::Result {
+    writeln!(
+        f,
+        "{}{} {{",
+        if value.is_resource { "resource " } else { "" },
+        value.type_
+    )?;
+    for (field_name, v) in value.value.iter() {
+        write_indent(f, indent + 4)?;
+        write!(f, "{}: ", field_name)?;
+        pretty_print_value(f, v, indent + 4)?;
+        writeln!(f)?;
+    }
+    write_indent(f, indent)?;
+    write!(f, "}}")
+}
+
+impl Display for AnnotatedMoveValue {
+    fn fmt(&self, f: &mut Formatter) -> std::fmt::Result {
+        pretty_print_value(f, self, 0)
+    }
+}
+
+impl Display for AnnotatedMoveStruct {
+    fn fmt(&self, f: &mut Formatter) -> std::fmt::Result {
+        pretty_print_struct(f, self, 0)
+    }
+}
+
+#[derive(Default)]
+pub struct NullStateView();
+
+impl StateView for NullStateView {
+    fn get(&self, _access_path: &AccessPath) -> Result<Option<Vec<u8>>> {
+        Err(anyhow!("No data"))
+    }
+
+    fn multi_get(&self, _access_paths: &[AccessPath]) -> Result<Vec<Option<Vec<u8>>>> {
+        Err(anyhow!("No data"))
+    }
+
+    fn is_genesis(&self) -> bool {
+        false
+    }
+}

--- a/language/resource-viewer/src/main.rs
+++ b/language/resource-viewer/src/main.rs
@@ -1,0 +1,8 @@
+// Copyright (c) The Libra Core Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+use resource_viewer::update_mapping;
+
+fn main() {
+    update_mapping();
+}

--- a/language/resource-viewer/src/module_cache.rs
+++ b/language/resource-viewer/src/module_cache.rs
@@ -1,0 +1,43 @@
+// Copyright (c) The Libra Core Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+use libra_types::language_storage::ModuleId;
+use std::{cell::RefCell, collections::hash_map::HashMap, hash::Hash, rc::Rc};
+use vm::CompiledModule;
+
+pub struct ModuleCacheImpl<K, V> {
+    id_map: RefCell<HashMap<K, usize>>,
+    modules: RefCell<Vec<Rc<V>>>,
+}
+
+impl<K, V> ModuleCacheImpl<K, V>
+where
+    K: Eq + Hash,
+{
+    pub fn new() -> Self {
+        Self {
+            id_map: RefCell::new(HashMap::new()),
+            modules: RefCell::new(vec![]),
+        }
+    }
+
+    pub fn insert(&self, key: K, module: V) -> Rc<V> {
+        self.modules.borrow_mut().push(Rc::new(module));
+        let idx = self.modules.borrow().len() - 1;
+        self.id_map.borrow_mut().insert(key, idx);
+        self.modules
+            .borrow()
+            .last()
+            .expect("ModuleCache: last() after push() impossible failure")
+            .clone()
+    }
+
+    pub fn get(&self, key: &K) -> Option<Rc<V>> {
+        self.id_map
+            .borrow()
+            .get(&key)
+            .and_then(|idx| self.modules.borrow().get(*idx).cloned())
+    }
+}
+
+pub type ModuleCache = ModuleCacheImpl<ModuleId, CompiledModule>;

--- a/language/resource-viewer/src/resolver.rs
+++ b/language/resource-viewer/src/resolver.rs
@@ -1,0 +1,197 @@
+// Copyright (c) The Libra Core Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::module_cache::ModuleCache;
+use anyhow::{anyhow, Result};
+use libra_state_view::StateView;
+use libra_types::{
+    access_path::AccessPath,
+    account_address::AccountAddress,
+    language_storage::{ModuleId, StructTag, TypeTag},
+};
+use move_core_types::identifier::{IdentStr, Identifier};
+use move_vm_types::loaded_data::types::{FatStructType, FatType};
+use std::rc::Rc;
+use stdlib::{stdlib_modules, StdLibOptions};
+use vm::{
+    access::ModuleAccess,
+    file_format::{
+        SignatureToken, StructDefinitionIndex, StructFieldInformation, StructHandleIndex,
+    },
+    CompiledModule,
+};
+
+pub(crate) struct Resolver<'a> {
+    state: &'a dyn StateView,
+    cache: ModuleCache,
+}
+
+impl<'a> Resolver<'a> {
+    pub fn new(state: &'a dyn StateView, use_stdlib: bool) -> Self {
+        let cache = ModuleCache::new();
+        if use_stdlib {
+            let modules = stdlib_modules(StdLibOptions::Staged);
+            for module in modules {
+                cache.insert(module.self_id(), module.clone().into_inner());
+            }
+        }
+        Resolver { state, cache }
+    }
+
+    fn get_module(&self, address: &AccountAddress, name: &IdentStr) -> Result<Rc<CompiledModule>> {
+        let module_id = ModuleId::new(*address, name.to_owned());
+        if let Some(module) = self.cache.get(&module_id) {
+            return Ok(module);
+        }
+        let blob = self
+            .state
+            .get(&AccessPath::code_access_path(&module_id))?
+            .ok_or_else(|| anyhow!("Module {:?} can't be found", module_id))?;
+        let compiled_module = CompiledModule::deserialize(&blob).map_err(|status| {
+            anyhow!(
+                "Module {:?} deserialize with error code {:?}",
+                module_id,
+                status
+            )
+        })?;
+        Ok(self.cache.insert(module_id, compiled_module))
+    }
+
+    pub fn resolve_type(&self, type_tag: &TypeTag) -> Result<FatType> {
+        Ok(match type_tag {
+            TypeTag::Address => FatType::Address,
+            TypeTag::Bool => FatType::Bool,
+            TypeTag::Struct(st) => FatType::Struct(Box::new(self.resolve_struct(st)?)),
+            TypeTag::U8 => FatType::U8,
+            TypeTag::U64 => FatType::U64,
+            TypeTag::U128 => FatType::U128,
+            TypeTag::Vector(ty) => FatType::Vector(Box::new(self.resolve_type(ty)?)),
+        })
+    }
+
+    pub fn resolve_struct(&self, struct_tag: &StructTag) -> Result<FatStructType> {
+        let module = self.get_module(&struct_tag.address, &struct_tag.module)?;
+        let struct_def = find_struct_def_in_module(module.clone(), struct_tag.name.as_ident_str())?;
+        self.resolve_struct_definition(module, struct_def)
+    }
+
+    pub fn get_field_names(&self, ty: &FatStructType) -> Result<Vec<Identifier>> {
+        let module = self.get_module(&ty.address, ty.module.as_ident_str())?;
+        let struct_def_idx = find_struct_def_in_module(module.clone(), ty.name.as_ident_str())?;
+        let struct_def = module.struct_def_at(struct_def_idx);
+
+        match &struct_def.field_information {
+            StructFieldInformation::Native => Err(anyhow!("Unexpected Native Struct")),
+            StructFieldInformation::Declared(defs) => Ok(defs
+                .iter()
+                .map(|field_def| module.identifier_at(field_def.name).to_owned())
+                .collect()),
+        }
+    }
+
+    fn resolve_signature(
+        &self,
+        module: Rc<CompiledModule>,
+        sig: &SignatureToken,
+    ) -> Result<FatType> {
+        Ok(match sig {
+            SignatureToken::Bool => FatType::Bool,
+            SignatureToken::U8 => FatType::U8,
+            SignatureToken::U64 => FatType::U64,
+            SignatureToken::U128 => FatType::U128,
+            SignatureToken::Address => FatType::Address,
+            SignatureToken::Vector(ty) => {
+                FatType::Vector(Box::new(self.resolve_signature(module, ty)?))
+            }
+            SignatureToken::Struct(idx) => {
+                FatType::Struct(Box::new(self.resolve_struct_handle(module, *idx)?))
+            }
+            SignatureToken::StructInstantiation(idx, toks) => {
+                let struct_ty = self.resolve_struct_handle(module.clone(), *idx)?;
+                let args = toks
+                    .iter()
+                    .map(|tok| self.resolve_signature(module.clone(), tok))
+                    .collect::<Result<Vec<_>>>()?;
+                FatType::Struct(Box::new(
+                    struct_ty
+                        .subst(&args)
+                        .map_err(|status| anyhow!("Substitution failure: {:?}", status))?,
+                ))
+            }
+            SignatureToken::TypeParameter(idx) => FatType::TyParam(*idx as usize),
+            SignatureToken::MutableReference(_) | SignatureToken::Reference(_) => {
+                return Err(anyhow!("Unexpected Reference"))
+            }
+        })
+    }
+
+    fn resolve_struct_handle(
+        &self,
+        module: Rc<CompiledModule>,
+        idx: StructHandleIndex,
+    ) -> Result<FatStructType> {
+        let struct_handle = module.struct_handle_at(idx);
+        let target_module = {
+            let module_handle = module.module_handle_at(struct_handle.module);
+            self.get_module(
+                module.address_identifier_at(module_handle.address),
+                module.identifier_at(module_handle.name),
+            )?
+        };
+        let target_idx = find_struct_def_in_module(
+            target_module.clone(),
+            module.identifier_at(struct_handle.name),
+        )?;
+        self.resolve_struct_definition(target_module, target_idx)
+    }
+
+    fn resolve_struct_definition(
+        &self,
+        module: Rc<CompiledModule>,
+        idx: StructDefinitionIndex,
+    ) -> Result<FatStructType> {
+        let struct_def = module.struct_def_at(idx);
+        let struct_handle = module.struct_handle_at(struct_def.struct_handle);
+        let address = *module.address();
+        let module_name = module.name().to_owned();
+        let name = module.identifier_at(struct_handle.name).to_owned();
+        let is_resource = struct_handle.is_nominal_resource;
+        let ty_args = (0..struct_handle.type_parameters.len())
+            .map(FatType::TyParam)
+            .collect();
+        match &struct_def.field_information {
+            StructFieldInformation::Native => Err(anyhow!("Unexpected Native Struct")),
+            StructFieldInformation::Declared(defs) => {
+                let mut fields = vec![];
+                for field_def in defs.iter() {
+                    fields.push(self.resolve_signature(module.clone(), &field_def.signature.0)?);
+                }
+                Ok(FatStructType {
+                    address,
+                    module: module_name,
+                    name,
+                    is_resource,
+                    ty_args,
+                    layout: fields,
+                })
+            }
+        }
+    }
+}
+
+fn find_struct_def_in_module(
+    module: Rc<CompiledModule>,
+    name: &IdentStr,
+) -> Result<StructDefinitionIndex> {
+    for (i, defs) in module.struct_defs().iter().enumerate() {
+        let st_handle = module.struct_handle_at(defs.struct_handle);
+        if module.identifier_at(st_handle.name) == name {
+            return Ok(StructDefinitionIndex::new(i as u16));
+        }
+    }
+    Err(anyhow!(
+        "Struct {:?} not found in {:?}",
+        name,
+        module.self_id()
+    ))
+}

--- a/language/resource-viewer/src/value.rs
+++ b/language/resource-viewer/src/value.rs
@@ -1,0 +1,192 @@
+// Copyright (c) The Libra Core Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+use anyhow::{anyhow, Error, Result as AResult};
+use libra_types::account_address::AccountAddress;
+use move_vm_types::loaded_data::types::{FatStructType, FatType};
+use serde::{de::Error as DeError, Deserialize};
+use std::{
+    convert::TryFrom,
+    fmt::{self, Debug},
+};
+
+#[derive(Debug)]
+pub struct MoveStruct(Vec<MoveValue>);
+
+#[derive(Debug)]
+pub enum MoveValue {
+    U8(u8),
+    U64(u64),
+    U128(u128),
+    Bool(bool),
+    Address(AccountAddress),
+    Vector(Vec<MoveValue>),
+    Struct(MoveStruct),
+}
+
+#[derive(Debug)]
+pub struct MoveStructLayout(Vec<MoveTypeLayout>);
+
+#[derive(Debug)]
+pub enum MoveTypeLayout {
+    Bool,
+    U8,
+    U64,
+    U128,
+    Address,
+    Vector(Box<MoveTypeLayout>),
+    Struct(MoveStructLayout),
+}
+
+impl MoveValue {
+    pub fn simple_deserialize(blob: &[u8], ty: &MoveTypeLayout) -> AResult<Self> {
+        Ok(lcs::from_bytes_seed(ty, blob)?)
+    }
+}
+impl MoveStruct {
+    pub fn new(value: Vec<MoveValue>) -> Self {
+        MoveStruct(value)
+    }
+
+    pub fn simple_deserialize(blob: &[u8], ty: &MoveStructLayout) -> AResult<Self> {
+        Ok(lcs::from_bytes_seed(ty, blob)?)
+    }
+
+    pub fn fields(&self) -> &[MoveValue] {
+        &self.0
+    }
+
+    pub fn into_inner(self) -> Vec<MoveValue> {
+        self.0
+    }
+}
+
+impl MoveStructLayout {
+    pub fn new(types: Vec<MoveTypeLayout>) -> Self {
+        MoveStructLayout(types)
+    }
+    pub fn fields(&self) -> &[MoveTypeLayout] {
+        &self.0
+    }
+}
+
+impl<'d> serde::de::DeserializeSeed<'d> for &MoveTypeLayout {
+    type Value = MoveValue;
+
+    fn deserialize<D: serde::de::Deserializer<'d>>(
+        self,
+        deserializer: D,
+    ) -> Result<Self::Value, D::Error> {
+        match self {
+            MoveTypeLayout::Bool => bool::deserialize(deserializer).map(MoveValue::Bool),
+            MoveTypeLayout::U8 => u8::deserialize(deserializer).map(MoveValue::U8),
+            MoveTypeLayout::U64 => u64::deserialize(deserializer).map(MoveValue::U64),
+            MoveTypeLayout::U128 => u128::deserialize(deserializer).map(MoveValue::U128),
+            MoveTypeLayout::Address => {
+                AccountAddress::deserialize(deserializer).map(MoveValue::Address)
+            }
+
+            MoveTypeLayout::Struct(ty) => Ok(MoveValue::Struct(ty.deserialize(deserializer)?)),
+
+            MoveTypeLayout::Vector(layout) => Ok(MoveValue::Vector(
+                deserializer.deserialize_seq(VectorElementVisitor(layout))?,
+            )),
+        }
+    }
+}
+
+struct VectorElementVisitor<'a>(&'a MoveTypeLayout);
+
+impl<'d, 'a> serde::de::Visitor<'d> for VectorElementVisitor<'a> {
+    type Value = Vec<MoveValue>;
+
+    fn expecting(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.write_str("Vector")
+    }
+
+    fn visit_seq<A>(self, mut seq: A) -> Result<Self::Value, A::Error>
+    where
+        A: serde::de::SeqAccess<'d>,
+    {
+        let mut vals = Vec::new();
+        while let Some(elem) = seq.next_element_seed(self.0)? {
+            vals.push(elem)
+        }
+        Ok(vals)
+    }
+}
+
+struct StructFieldVisitor<'a>(&'a [MoveTypeLayout]);
+
+impl<'d, 'a> serde::de::Visitor<'d> for StructFieldVisitor<'a> {
+    type Value = Vec<MoveValue>;
+
+    fn expecting(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.write_str("Struct")
+    }
+
+    fn visit_seq<A>(self, mut seq: A) -> Result<Self::Value, A::Error>
+    where
+        A: serde::de::SeqAccess<'d>,
+    {
+        let mut val = Vec::new();
+        for (i, field_type) in self.0.iter().enumerate() {
+            if let Some(elem) = seq.next_element_seed(field_type)? {
+                val.push(elem)
+            } else {
+                return Err(A::Error::invalid_length(i, &self));
+            }
+        }
+        Ok(val)
+    }
+}
+
+impl<'d> serde::de::DeserializeSeed<'d> for &MoveStructLayout {
+    type Value = MoveStruct;
+
+    fn deserialize<D: serde::de::Deserializer<'d>>(
+        self,
+        deserializer: D,
+    ) -> Result<Self::Value, D::Error> {
+        let layout = &self.0;
+        let fields = deserializer.deserialize_tuple(layout.len(), StructFieldVisitor(layout))?;
+        Ok(MoveStruct(fields))
+    }
+}
+
+impl TryFrom<&FatStructType> for MoveStructLayout {
+    type Error = Error;
+
+    fn try_from(ty: &FatStructType) -> Result<Self, Self::Error> {
+        Ok(MoveStructLayout(
+            ty.layout
+                .iter()
+                .map(MoveTypeLayout::try_from)
+                .collect::<AResult<Vec<_>>>()?,
+        ))
+    }
+}
+
+impl TryFrom<&FatType> for MoveTypeLayout {
+    type Error = Error;
+
+    fn try_from(ty: &FatType) -> Result<Self, Self::Error> {
+        Ok(match ty {
+            FatType::Address => MoveTypeLayout::Address,
+            FatType::U8 => MoveTypeLayout::U8,
+            FatType::U64 => MoveTypeLayout::U64,
+            FatType::U128 => MoveTypeLayout::U128,
+            FatType::Bool => MoveTypeLayout::Bool,
+            FatType::Vector(v) => {
+                MoveTypeLayout::Vector(Box::new(MoveTypeLayout::try_from(v.as_ref())?))
+            }
+            FatType::Struct(s) => MoveTypeLayout::Struct(MoveStructLayout(
+                s.layout
+                    .iter()
+                    .map(MoveTypeLayout::try_from)
+                    .collect::<AResult<Vec<_>>>()?,
+            )),
+            _ => return Err(anyhow!("Unexpected type: {:?}", ty)),
+        })
+    }
+}

--- a/language/tools/genesis-viewer/Cargo.toml
+++ b/language/tools/genesis-viewer/Cargo.toml
@@ -14,5 +14,8 @@ lcs = { path = "../../../common/lcs", version = "0.1.0", package = "libra-canoni
 libra-types = { path = "../../../types", version = "0.1.0" }
 libra-workspace-hack = { path = "../../../common/workspace-hack", version = "0.1.0" }
 vm = { path = "../../vm", version = "0.1.0" }
+resource-viewer = { path = "../../resource-viewer", version = "0.1.0"}
+vm-genesis = { path = "../vm-genesis", version = "0.1.0" }
+stdlib = { path = "../../stdlib", version = "0.1.0" }
 
 structopt = "0.3.14"

--- a/language/tools/vm-genesis/Cargo.toml
+++ b/language/tools/vm-genesis/Cargo.toml
@@ -35,6 +35,8 @@ libra-vm = { path = "../../libra-vm", version = "0.1.0" }
 proptest = "0.9.6"
 proptest-derive = "0.1.2"
 libra-proptest-helpers = { path = "../../../common/proptest-helpers", version = "0.1.0" }
+libra-types = { path = "../../../types", version = "0.1.0", features = ["fuzzing"] }
+move-vm-types = { path = "../../move-vm/types", version = "0.1.0", features = ["fuzzing"] }
 
 [features]
 default = []

--- a/types/src/account_state.rs
+++ b/types/src/account_state.rs
@@ -126,6 +126,10 @@ impl AccountState {
     pub fn is_empty(&self) -> bool {
         self.0.is_empty()
     }
+
+    pub fn iter(&self) -> impl std::iter::Iterator<Item = (&Vec<u8>, &Vec<u8>)> {
+        self.0.iter()
+    }
 }
 
 impl fmt::Debug for AccountState {

--- a/types/src/language_storage.rs
+++ b/types/src/language_storage.rs
@@ -8,6 +8,7 @@ use move_core_types::identifier::{IdentStr, Identifier};
 #[cfg(any(test, feature = "fuzzing"))]
 use proptest_derive::Arbitrary;
 use serde::{Deserialize, Serialize};
+use std::fmt::{Display, Formatter};
 
 #[derive(Serialize, Deserialize, Debug, PartialEq, Hash, Eq, Clone, PartialOrd, Ord)]
 pub enum TypeTag {
@@ -104,5 +105,40 @@ impl CryptoHash for StructTag {
         let mut state = Self::Hasher::default();
         state.write(&lcs::to_bytes(self).unwrap());
         state.finish()
+    }
+}
+
+impl Display for StructTag {
+    fn fmt(&self, f: &mut Formatter) -> std::fmt::Result {
+        write!(
+            f,
+            "{}::{}::{}",
+            self.address.short_str(),
+            self.module,
+            self.name
+        )?;
+        if let Some(first_ty) = self.type_params.first() {
+            write!(f, "<")?;
+            write!(f, "{}", first_ty)?;
+            for ty in self.type_params.iter().skip(1) {
+                write!(f, ", {}", ty)?;
+            }
+            write!(f, ">")?;
+        }
+        Ok(())
+    }
+}
+
+impl Display for TypeTag {
+    fn fmt(&self, f: &mut Formatter) -> std::fmt::Result {
+        match self {
+            TypeTag::Struct(s) => write!(f, "{}", s),
+            TypeTag::Vector(ty) => write!(f, "Vector<{}>", ty),
+            TypeTag::U8 => write!(f, "U8"),
+            TypeTag::U64 => write!(f, "U64"),
+            TypeTag::U128 => write!(f, "U128"),
+            TypeTag::Address => write!(f, "Address"),
+            TypeTag::Bool => write!(f, "Bool"),
+        }
     }
 }


### PR DESCRIPTION
<!--
Thank you for sending a PR. We appreciate you spending time to help improve the Libra project.

The project is undergoing daily changes. Pull Requests will be reviewed and responded to as time permits.
-->

## Motivation

Implement a pretty printer for on chain move resources and events! I only hooked the api up to the `genesis_viewer` for now so that we can see what's inside of the current genesis. In the future I'll hook this up to the cli client so that we can have a better view of all on chain data.

Usage:
`cargo run -- -a` in `genesis_viewer`, you should get something like:
```
RawData: [2, 0, 0, 0, 0, 0, 0, 0, 219, 225, 109, 160, 147, 48, 56, 58, 93, 229, 160, 106, 140, 118, 140, 138]
AccessPath: AccessPath { address: dbe16da09330383a5de5a06a8c768c8a, path: 014bb80e80641d11869158d536f3530c01fd21ddbd700ee6ff48e70df4b6a31847 }
Data: resource 00000000.LibraAccount::T {
    authentication_key: a5fcb5103eb356353d61202ddcbf7349dbe16da09330383a5de5a06a8c768c8a
    delegated_key_rotation_capability: false
    delegated_withdrawal_capability: false
    received_events: resource 00000000.Event::EventHandle<00000000.LibraAccount::ReceivedPaymentEvent> {
        counter: 0
        guid: 0000000000000000dbe16da09330383a5de5a06a8c768c8a
    }
    sent_events: resource 00000000.Event::EventHandle<00000000.LibraAccount::SentPaymentEvent> {
        counter: 0
        guid: 0100000000000000dbe16da09330383a5de5a06a8c768c8a
    }
    sequence_number: 0
    is_frozen: false
    balance_currency_code: 4c4252
}
+ EventKey([13, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 10, 85, 12, 24])
Type: Struct(StructTag { address: 00000000000000000000000000000000, module: Identifier("LibraAccount"), name: Identifier("SentPaymentEvent"), type_params: [] })
Seq. Num.: 0
Data:  00000000.LibraAccount::SentPaymentEvent {
    amount: 1000000000000000
    currency_code: 4c4252
    payee: 00000000
    metadata: 
}

```

There were a bunch design choices I've made:
1. For the cache of the resolver used in the `resource-annotator`, I copied most of the resolver code from the old VM implementation instead of using the new loader in the VM. This is because the loader is a heavy weight object that optimized for runtime performance, which is something we don't really need. All we need is pretty much the name/identifier information.

2. I used Rc instead of reference in the resolver for an easy lifetime story. We can use references and Arena as we used to if the performance indeed becomes an issue(which I highly doubt as such code is only going to be run on user/client side)

3. I cache all stdlib modules directly instead of reading all modules from the state_view. This is for the sake of hooking up with the client easily in the future. `StateView` isn't currently implemented for the `JsonRPC` client. Caching them will be the easiest thing that can work around with it.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?

Yes