### PR TITLE
[move-prover] Added global specs to the (old) test version of libra.move

### DIFF
--- a/language/move-prover/tests/sources/stdlib/modules/lbr.move
+++ b/language/move-prover/tests/sources/stdlib/modules/lbr.move
@@ -10,4 +10,31 @@ module LBR {
         Transaction::assert(Transaction::sender() == 0xA550C18, 0);
         Libra::register<T>();
     }
+    spec fun initialize {
+        // These conditions ensure that ghost variables are properly initialized
+        // before "initialize" is called. Otherwise, "Libra::register" will fail
+        // because they are ensures conditions of "Libra::register"
+        requires Libra::mint_capability_count<T> == 0;
+        requires Libra::sum_of_token_values<T> == 0;
+
+        // FIXME:
+        // The next is actually a conceptual problem in the prover. "initialize"
+        // registers the LBR token type, so it is only useful at the beginning
+        // before the LBR is registered. However, if initialize is erroneously called
+        // a second time, it will abort in Libra::register<T>, because it will do a move_to_sender
+        // to the association account, which will abort if the Info<Token> resource
+        // is already there (that's the test for whether a token is registered).
+
+        // However, the invariant adds a "requires"
+        // token_is_registered<Token>() ==> mint_capability_count<Token> == 1;
+        // and this fails because it doesn't know the function is going to abort.
+        // Does aborts_if P effectively imply requires !P?
+        requires !Libra::token_is_registered<T>();
+
+        // FIXME:
+        // Another bug:
+        // Boogie reports:
+        // bug: output.bpl(3882,158): Error: undeclared identifier: $tv0
+        // include Libra::RegisterAbortsIf<T>;
+    }
 }

--- a/language/move-prover/tests/sources/stdlib/modules/libra.move
+++ b/language/move-prover/tests/sources/stdlib/modules/libra.move
@@ -1,10 +1,5 @@
 address 0x0:
 
-// global spec ideas
-// SPEC TODO: total value global spec
-// SPEC TODO: Number of coins global spec.
-// SPEC TODO: who/what functions can mint.
-
 module Libra {
     use 0x0::Transaction;
     use 0x0::Vector;
@@ -15,12 +10,41 @@ module Libra {
         value: u64,
     }
 
+    spec module {
+         // This ghost variable is defined to have the true sum values of all instances of Token
+         global sum_of_token_values<Token>: num;
+    }
+
+    // maintain sum_of_tokens
+    spec struct T {
+        invariant pack sum_of_token_values<Token> = sum_of_token_values<Token> + value;
+        invariant unpack sum_of_token_values<Token> = sum_of_token_values<Token> - value;
+        invariant update sum_of_token_values<Token> = sum_of_token_values<Token> - old(value) + value;
+    }
+
     // A singleton resource that grants access to `Libra::mint`. Only the Association has one.
     resource struct MintCapability<Token> { }
+
+    // maintain mint_capability_count
+    spec struct MintCapability {
+        invariant pack mint_capability_count<Token> = mint_capability_count<Token> + 1;
+        invariant unpack mint_capability_count<Token> = mint_capability_count<Token> - 1;
+    }
 
     // Specification helpers to work with MintCapability
     spec module {
         define exists_sender_mint_capability<Token>(): bool { exists<MintCapability<Token>>(sender()) }
+        // Ghost variable representing the total number of MintCapability instances for Token (0 or 1).
+        global mint_capability_count<Token>: num;
+    }
+
+    // There is a MintCapability for Token iff the token is registered
+    spec schema MintCapabilityCountInvariant<Token> {
+         invariant !token_is_registered<Token>() ==> mint_capability_count<Token> == 0;
+         invariant token_is_registered<Token>() ==> mint_capability_count<Token> == 1;
+    }
+    spec module {
+        apply MintCapabilityCountInvariant<Token> to *<Token>;
     }
 
     resource struct Info<Token> {
@@ -33,8 +57,44 @@ module Libra {
     // Specifications helpers for working with Info<Token> at association address.
     spec module {
        define association_address(): address { 0xA550C18 }
-       define exists_info<Token>(): bool { exists<Info<Token>>(association_address()) }
+       define token_is_registered<Token>(): bool { exists<Info<Token>>(association_address()) }
        define info<Token>(): Info<Token> { global<Info<Token>>(association_address()) }
+    }
+
+    spec schema SumRemainsSame<Token> {
+         ensures sum_of_token_values<Token> == old(sum_of_token_values<Token>);
+    }
+    spec module {
+        // Only mint/burn & with capability versions can change the total amount of currency.
+        // skip mint, burn, mint_with_capability, burn_with_capability.
+        // Burn always aborts because Preburn.is_approved is always false.
+        apply SumRemainsSame<Token> to *<Token> except mint*<Token>, burn*<Token>;
+    }
+
+    // Once registered, a token stays registered forever.
+    spec schema RegistrationPersists<Token> {
+         ensures old(token_is_registered<Token>()) ==> token_is_registered<Token>();
+    }
+    spec module {
+        apply RegistrationPersists<Token> to *<Token>;
+    }
+
+    spec schema SumOfTokenValuesInvariant<Token> {
+         // SPEC: MarketCap == Sum of all the instances of a particular token.
+
+         // Note: this works even though the verifier does not
+         // know that each existing token.value must be <= sum_of_token_values. I assume that
+         // total_value is constrained to be non-negative, so it all works. I should check this out.
+
+         // Note: What is the value of a ghost variable in the genesis state?
+         // State machine with two states (not registered/registered), so write as two invariants.
+
+         invariant !token_is_registered<Token>() ==> sum_of_token_values<Token> == 0;
+         invariant token_is_registered<Token>()
+                     ==> sum_of_token_values<Token> == global<Info<Token>>(0xA550C18).total_value;
+    }
+    spec module {
+        apply SumOfTokenValuesInvariant<Token> to *<Token>;
     }
 
     // A holding area where funds that will subsequently be burned wait while their underyling
@@ -54,6 +114,12 @@ module Libra {
         is_approved: bool,
     }
 
+   spec schema RegisterAbortsIf<Token>{
+        aborts_if sender() != association_address();
+        aborts_if exists_sender_mint_capability<Token>();
+        aborts_if token_is_registered<Token>();
+    }
+
     public fun register<Token>() {
         // Only callable by the Association address
         Transaction::assert(Transaction::sender() == 0xA550C18, 1);
@@ -61,11 +127,9 @@ module Libra {
         move_to_sender(Info<Token> { total_value: 0u128, preburn_value: 0 });
     }
     spec fun register {
-        aborts_if sender() != association_address();
-        aborts_if exists_sender_mint_capability<Token>();
-        aborts_if exists_info<Token>();
+        include RegisterAbortsIf<Token>;
         ensures exists_sender_mint_capability<Token>();
-        ensures exists_info<Token>();
+        ensures token_is_registered<Token>();
         ensures info<Token>().total_value == 0;
         ensures info<Token>().preburn_value == 0;
     }
@@ -74,7 +138,7 @@ module Libra {
         Transaction::assert(exists<Info<Token>>(0xA550C18), 12);
     }
     spec fun assert_is_registered {
-        aborts_if !exists_info<Token>();
+        aborts_if !token_is_registered<Token>();
     }
 
     // Return `amount` coins.
@@ -84,7 +148,7 @@ module Libra {
     }
     spec schema MintAbortsIf<Token> {
         amount: u64;
-        aborts_if !exists_info<Token>();
+        aborts_if !token_is_registered<Token>();
         aborts_if amount > 1000000000 * 1000000;
         aborts_if info<Token>().total_value + amount > max_u128();
     }
@@ -115,7 +179,7 @@ module Libra {
         preburn_address: address;
         aborts_if !exists<Preburn<Token>>(preburn_address);
         aborts_if len(global<Preburn<Token>>(preburn_address).requests) == 0;
-        aborts_if !exists_info<Token>();
+        aborts_if !token_is_registered<Token>();
         aborts_if info<Token>().preburn_value < global<Preburn<Token>>(preburn_address).requests[0].value;
     }
     spec schema BurnAbortsIf<Token> {
@@ -172,7 +236,7 @@ module Libra {
         Preburn<Token> { requests: Vector::empty(), is_approved: false, }
     }
     spec fun new_preburn {
-        aborts_if !exists_info<Token>();
+        aborts_if !token_is_registered<Token>();
         ensures len(result.requests) == 0;
         ensures result.is_approved == false;
     }
@@ -220,7 +284,7 @@ module Libra {
     spec schema PreburnAbortsIf<Token> {
         coin: T<Token>;
         // aborts_if !preburn_ref.is_approved; // TODO: bring this back once we can automate approvals in testnet
-        aborts_if !exists_info<Token>();
+        aborts_if !token_is_registered<Token>();
         aborts_if info<Token>().preburn_value + coin.value > max_u64();
     }
     spec schema PreburnEnsures<Token> {
@@ -348,7 +412,7 @@ module Libra {
         borrow_global<Info<Token>>(0xA550C18).total_value
     }
     spec fun market_cap {
-        aborts_if !exists_info<Token>();
+        aborts_if !token_is_registered<Token>();
         ensures result == info<Token>().total_value;
     }
 
@@ -357,7 +421,7 @@ module Libra {
         borrow_global<Info<Token>>(0xA550C18).preburn_value
     }
     spec fun preburn_value {
-        aborts_if !exists_info<Token>();
+        aborts_if !token_is_registered<Token>();
         ensures result == info<Token>().preburn_value;
     }
 
@@ -368,7 +432,7 @@ module Libra {
         T { value: 0 }
     }
     spec fun zero {
-        aborts_if !exists_info<Token>();
+        aborts_if !token_is_registered<Token>();
         ensures result.value == 0;
     }
 


### PR DESCRIPTION
Merged global specs with Wolfgang's schemified local specs in
tests/sources/stdlib/modules/libra.move

Global specs include:
sum_of_token_values always equals MarketCap for each token.
sum_of_token_values never changes except when mint or burn (or
capability versions are called).
When a token is registered, it stays registered forever.
The number of MintCapabilities is 0 when a token is not registered,
and 1 when it is registered.

I changed the "info_exists" helper function to "token_is_registered",
because that is the significance of "info_exists"

libra.move verifies

I had to add some specifications to lbr.move, because it calls
Libra::register, and "requires" for that function was failing.

Several issues were revealed:
1. a bug: output.bpl(3882,158): Error: undeclared identifier: $tv0
in lbr.move (see comments in that file) when I included the
spec schema Libra::RegisterAbortsIf<T>. I suspect this is because
"initialize" doesn't have a type parameter (it only initializes
the LBR token).

2. A subtle issue with "requires" and abort. (I think) It is
unnecessary to specify a requires for a condition that always cause
abort. However, the abort may happen in code that is distant from
the "requires", and the prover might not know about it (but maybe
"aborts_if" saves us).

3. I discovered that apply foo<Token> to *; is dangerous because it
doesn't add the specifications anywhere and the verifier appears to
succeed when it actually does nothing.


## Motivation

This is the most extensive real example of global specifications so far, and a useful test case.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?

yes
## Test Plan

cargo test
## Related PRs

(If this PR adds or changes functionality, please take some time to update the docs at https://github.com/libra/website, and link to your PR here.)
