### PR TITLE
[language] Bring cost table code in the Move VM

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2050,6 +2050,7 @@ dependencies = [
  "move-lang 0.0.1",
  "move-vm-runtime 0.1.0",
  "move-vm-state 0.1.0",
+ "move-vm-types 0.1.0",
  "proptest 0.9.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "vm 0.1.0",
 ]
@@ -3151,7 +3152,9 @@ dependencies = [
  "libra-logger 0.1.0",
  "libra-types 0.1.0",
  "libra-workspace-hack 0.1.0",
+ "mirai-annotations 1.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "move-core-types 0.1.0",
+ "once_cell 1.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "proptest 0.9.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.106 (registry+https://github.com/rust-lang/crates.io-index)",
  "sha2 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/language/benchmarks/Cargo.toml
+++ b/language/benchmarks/Cargo.toml
@@ -24,6 +24,7 @@ move-core-types = { path = "../move-core/types", version = "0.1.0" }
 move-lang = { path = "../move-lang", version = "0.0.1" }
 move-vm-runtime = { path = "../move-vm/runtime", version = "0.1.0" }
 move-vm-state = { path = "../move-vm/state", version = "0.1.0" }
+move-vm-types = { path = "../move-vm/types", version = "0.1.0" }
 vm = { path = "../vm", version = "0.1.0" }
 libra-vm = { path = "../libra-vm", version = "0.1.0" }
 

--- a/language/benchmarks/src/move_vm.rs
+++ b/language/benchmarks/src/move_vm.rs
@@ -15,8 +15,9 @@ use move_core_types::{
 use move_lang::{compiled_unit::CompiledUnit, shared::Address};
 use move_vm_runtime::MoveVM;
 use move_vm_state::{data_cache::BlockDataCache, execution_context::TransactionExecutionContext};
+use move_vm_types::gas_schedule::zero_cost_schedule;
 use std::path::PathBuf;
-use vm::{gas_schedule::zero_cost_schedule, transaction_metadata::TransactionMetadata};
+use vm::transaction_metadata::TransactionMetadata;
 
 /// Entry point for the bench, provide a function name to invoke in Module Bench in bench.move.
 pub fn bench(c: &mut Criterion, fun: &str) {

--- a/language/libra-vm/src/libra_vm.rs
+++ b/language/libra-vm/src/libra_vm.rs
@@ -31,12 +31,15 @@ use move_vm_state::{
     data_cache::{BlockDataCache, RemoteCache, RemoteStorage},
     execution_context::{ExecutionContext, SystemExecutionContext, TransactionExecutionContext},
 };
-use move_vm_types::{chain_state::ChainState, values::Value};
+use move_vm_types::{
+    chain_state::ChainState,
+    gas_schedule::{calculate_intrinsic_gas, zero_cost_schedule},
+    values::Value,
+};
 use rayon::prelude::*;
 use std::{collections::HashSet, convert::TryFrom, sync::Arc};
 use vm::{
     errors::{convert_prologue_runtime_error, VMResult},
-    gas_schedule::{calculate_intrinsic_gas, zero_cost_schedule},
     transaction_metadata::TransactionMetadata,
 };
 

--- a/language/move-core/types/src/gas_schedule.rs
+++ b/language/move-core/types/src/gas_schedule.rs
@@ -176,7 +176,7 @@ pub struct GasConstants {
     /// 1 nanosecond should equal one unit of computational gas. We bound the maximum
     /// computational time of any given transaction at 10 milliseconds. We want this number and
     /// `MAX_PRICE_PER_GAS_UNIT` to always satisfy the inequality that
-    ///         MAXIMUM_NUMBER_OF_GAS_UNITS * MAX_PRICE_PER_GAS_UNIT < min(u64::MAX, GasUnits<GasCarrier>::MAX)
+    /// MAXIMUM_NUMBER_OF_GAS_UNITS * MAX_PRICE_PER_GAS_UNIT < min(u64::MAX, GasUnits<GasCarrier>::MAX)
     pub maximum_number_of_gas_units: GasUnits<GasCarrier>,
 
     /// The minimum gas price that a transaction can be submitted with.
@@ -221,10 +221,8 @@ impl CostTable {
     }
 
     #[inline]
-    pub fn native_cost(&self, native_index: NativeCostIndex) -> &GasCost {
-        precondition!(
-            native_index as u8 > 0 && native_index as u8 <= (self.native_table.len() as u8)
-        );
+    pub fn native_cost(&self, native_index: u8) -> &GasCost {
+        precondition!(native_index as u8 > 0 && native_index <= (self.native_table.len() as u8));
         &self.native_table[native_index as usize]
     }
 }
@@ -267,24 +265,4 @@ pub fn words_in(size: AbstractMemorySize<GasCarrier>) -> AbstractMemorySize<GasC
         assume!(size <= u64::max_value() - word_size);
         (size + (word_size - 1)) / word_size
     })
-}
-
-#[allow(non_camel_case_types)]
-#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq, PartialOrd, Ord)]
-#[repr(u8)]
-pub enum NativeCostIndex {
-    SHA2_256 = 0,
-    SHA3_256 = 1,
-    ED25519_VERIFY = 2,
-    ED25519_THRESHOLD_VERIFY = 3,
-    LCS_TO_BYTES = 4,
-    LENGTH = 5,
-    EMPTY = 6,
-    BORROW = 7,
-    BORROW_MUT = 8,
-    PUSH_BACK = 9,
-    POP_BACK = 10,
-    DESTROY_EMPTY = 11,
-    SWAP = 12,
-    SAVE_ACCOUNT = 13,
 }

--- a/language/move-vm/natives/src/account.rs
+++ b/language/move-vm/natives/src/account.rs
@@ -8,8 +8,8 @@ use libra_types::{
     move_resource::MoveResource,
     vm_error::{StatusCode, VMStatus},
 };
-use move_core_types::gas_schedule::NativeCostIndex;
 use move_vm_types::{
+    gas_schedule::NativeCostIndex,
     loaded_data::runtime_types::Type,
     natives::function::{native_gas, NativeContext, NativeResult},
     values::{Struct, Value},

--- a/language/move-vm/natives/src/hash.rs
+++ b/language/move-vm/natives/src/hash.rs
@@ -2,8 +2,8 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use libra_crypto::HashValue;
-use move_core_types::gas_schedule::NativeCostIndex;
 use move_vm_types::{
+    gas_schedule::NativeCostIndex,
     loaded_data::runtime_types::Type,
     natives::function::{native_gas, NativeContext, NativeResult},
     values::Value,

--- a/language/move-vm/natives/src/lcs.rs
+++ b/language/move-vm/natives/src/lcs.rs
@@ -2,8 +2,8 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use libra_types::vm_error::{sub_status::NFE_LCS_SERIALIZATION_FAILURE, StatusCode, VMStatus};
-use move_core_types::gas_schedule::NativeCostIndex;
 use move_vm_types::{
+    gas_schedule::NativeCostIndex,
     loaded_data::runtime_types::Type,
     natives::function::{native_gas, NativeContext, NativeResult},
     values::{values_impl::Reference, Value},

--- a/language/move-vm/natives/src/signature.rs
+++ b/language/move-vm/natives/src/signature.rs
@@ -8,8 +8,9 @@ use libra_crypto::{
     HashValue,
 };
 use libra_types::vm_error::{StatusCode, VMStatus};
-use move_core_types::gas_schedule::{CostTable, NativeCostIndex};
+use move_core_types::gas_schedule::CostTable;
 use move_vm_types::{
+    gas_schedule::NativeCostIndex,
     loaded_data::runtime_types::Type,
     natives::function::{native_gas, NativeContext, NativeResult},
     values::Value,

--- a/language/move-vm/runtime/src/interpreter.rs
+++ b/language/move-vm/runtime/src/interpreter.rs
@@ -15,6 +15,7 @@ use libra_types::{
 };
 use move_core_types::gas_schedule::{AbstractMemorySize, CostTable, GasAlgebra, GasCarrier};
 use move_vm_types::{
+    gas_schedule::calculate_intrinsic_gas,
     interpreter_context::InterpreterContext,
     loaded_data::{runtime_types::Type, types::FatStructType},
     values::{self, IntegerValue, Locals, Reference, Struct, StructRef, VMValueCast, Value},
@@ -26,7 +27,7 @@ use vm::{
         Bytecode, FunctionHandleIndex, FunctionInstantiationIndex, StructDefInstantiationIndex,
         StructDefinitionIndex,
     },
-    gas_schedule::{calculate_intrinsic_gas, Opcodes},
+    file_format_common::Opcodes,
     transaction_metadata::TransactionMetadata,
 };
 

--- a/language/move-vm/types/Cargo.toml
+++ b/language/move-vm/types/Cargo.toml
@@ -11,6 +11,8 @@ edition = "2018"
 
 [dependencies]
 bit-vec = "0.6.1"
+mirai-annotations = "1.7.0"
+once_cell = "1.3.1"
 proptest = { version = "0.9.6", optional = true }
 sha2 = "0.8.0"
 serde = { version = "1.0", features = ["derive", "rc"] }

--- a/language/move-vm/types/src/lib.rs
+++ b/language/move-vm/types/src/lib.rs
@@ -22,6 +22,7 @@ macro_rules! debug_writeln {
 }
 
 pub mod chain_state;
+pub mod gas_schedule;
 pub mod interpreter_context;
 pub mod loaded_data;
 pub mod natives;

--- a/language/move-vm/types/src/natives/function.rs
+++ b/language/move-vm/types/src/natives/function.rs
@@ -17,6 +17,7 @@
 //! function.
 
 use crate::{
+    gas_schedule::NativeCostIndex,
     loaded_data::{runtime_types::Type, types::FatType},
     values::{Struct, Value},
 };
@@ -25,9 +26,7 @@ use libra_types::{
     vm_error::VMStatus,
 };
 use move_core_types::{
-    gas_schedule::{
-        AbstractMemorySize, CostTable, GasAlgebra, GasCarrier, GasUnits, NativeCostIndex,
-    },
+    gas_schedule::{AbstractMemorySize, CostTable, GasAlgebra, GasCarrier, GasUnits},
     identifier::IdentStr,
 };
 use std::fmt::Write;
@@ -97,7 +96,7 @@ impl NativeResult {
 /// Return the native gas entry in `CostTable` for the given key.
 /// The key is the specific native function index known to `CostTable`.
 pub fn native_gas(table: &CostTable, key: NativeCostIndex, size: usize) -> GasUnits<GasCarrier> {
-    let gas_amt = table.native_cost(key);
+    let gas_amt = table.native_cost(key as u8);
     let memory_size = AbstractMemorySize::new(size as GasCarrier);
     gas_amt.total().mul(memory_size)
 }

--- a/language/move-vm/types/src/values/values_impl.rs
+++ b/language/move-vm/types/src/values/values_impl.rs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::{
+    gas_schedule::NativeCostIndex,
     loaded_data::types::{FatStructType, FatType},
     natives::function::{native_gas, NativeResult},
 };
@@ -10,8 +11,7 @@ use libra_types::{
     vm_error::{sub_status::NFE_VECTOR_ERROR_BASE, StatusCode, VMStatus},
 };
 use move_core_types::gas_schedule::{
-    words_in, AbstractMemorySize, GasAlgebra, GasCarrier, NativeCostIndex, CONST_SIZE,
-    REFERENCE_SIZE, STRUCT_SIZE,
+    words_in, AbstractMemorySize, GasAlgebra, GasCarrier, CONST_SIZE, REFERENCE_SIZE, STRUCT_SIZE,
 };
 use std::{
     cell::{Ref, RefCell, RefMut},
@@ -1471,11 +1471,11 @@ pub mod vector {
         let r = pop_arg_front!(args, ContainerRef);
         let e = args.pop_front().unwrap();
 
-        let cost = context
-            .cost_table()
-            .native_cost(NativeCostIndex::PUSH_BACK)
-            .total()
-            .mul(e.size());
+        let cost = native_gas(
+            context.cost_table(),
+            NativeCostIndex::PUSH_BACK,
+            e.size().get() as usize,
+        );
 
         let mut v = r.borrow_mut();
         check_elem_layout(&ty_args[0], &*v)?;

--- a/language/tools/vm-genesis/src/genesis_context.rs
+++ b/language/tools/vm-genesis/src/genesis_context.rs
@@ -19,9 +19,9 @@ use move_core_types::{
 };
 use move_vm_runtime::MoveVM;
 use move_vm_state::{data_cache::BlockDataCache, execution_context::TransactionExecutionContext};
-use move_vm_types::values::Value;
+use move_vm_types::{gas_schedule::zero_cost_schedule, values::Value};
 use std::collections::HashMap;
-use vm::{gas_schedule::zero_cost_schedule, transaction_metadata::TransactionMetadata};
+use vm::transaction_metadata::TransactionMetadata;
 
 /// A context that holds state for generating the genesis write set
 pub(crate) struct GenesisContext<'a> {

--- a/language/tools/vm-genesis/src/genesis_gas_schedule.rs
+++ b/language/tools/vm-genesis/src/genesis_gas_schedule.rs
@@ -11,7 +11,7 @@ use vm::{
         FunctionHandleIndex, FunctionInstantiationIndex, StructDefInstantiationIndex,
         StructDefinitionIndex, NUMBER_OF_NATIVE_FUNCTIONS,
     },
-    gas_schedule::instruction_key,
+    file_format_common::instruction_key,
 };
 
 pub(crate) static INITIAL_GAS_SCHEDULE: Lazy<(Vec<u8>, Vec<u8>)> = Lazy::new(|| {

--- a/language/vm/src/lib.rs
+++ b/language/vm/src/lib.rs
@@ -15,7 +15,6 @@ pub mod errors;
 pub mod deserializer;
 pub mod file_format;
 pub mod file_format_common;
-pub mod gas_schedule;
 pub mod internals;
 #[cfg(any(test, feature = "fuzzing"))]
 pub mod proptest_types;


### PR DESCRIPTION
This move cost table related code away from the VM and into move-core/types 
and move-vm/types.
The goal is to bring everything about native functions into the 
MoveVM where we can rationalize that first and then maybe relax and move 
it to the Libra layer.
That cleaned up dependencies a bit too
