### PR TITLE
[cluster-test] Print submission stats in --swarm mode

### DIFF
--- a/testsuite/cluster-test/src/experiments/performance_benchmark.rs
+++ b/testsuite/cluster-test/src/experiments/performance_benchmark.rs
@@ -20,7 +20,6 @@ use serde_json::Value;
 use std::{
     collections::HashSet,
     fmt::{Display, Error, Formatter},
-    sync::atomic::Ordering,
     time::Duration,
 };
 use structopt::StructOpt;
@@ -166,8 +165,8 @@ impl Experiment for PerformanceBenchmark {
             .map(|ic| context.cluster_swarm.upsert_node(ic.clone(), false))
             .collect();
         try_join_all(futures).await?;
-        let submitted_txn = stats.submitted.load(Ordering::Relaxed);
-        let expired_txn = stats.expired.load(Ordering::Relaxed);
+        let submitted_txn = stats.submitted;
+        let expired_txn = stats.expired;
         context
             .report
             .report_metric(&self, "submitted_txn", submitted_txn as f64);


### PR DESCRIPTION
Example output:

```
INFO 2020-05-05 23:09:17 testsuite/cluster-test/src/tx_emitter.rs:180 Will use 1 workers per AC with total 2 AC clients
INFO 2020-05-05 23:09:17 testsuite/cluster-test/src/tx_emitter.rs:185 Will create 15 accounts_per_client with total 30 accounts
INFO 2020-05-05 23:09:21 testsuite/cluster-test/src/tx_emitter.rs:274 Completed minting seed accounts
INFO 2020-05-05 23:09:25 testsuite/cluster-test/src/tx_emitter.rs:307 Mint is done
submitted: 12 txn/s, committed: 10 txn/s, expired: 0 txn/s
submitted: 14 txn/s, committed: 15 txn/s, expired: 0 txn/s
submitted: 17 txn/s, committed: 16 txn/s, expired: 0 txn/s
submitted: 15 txn/s, committed: 15 txn/s, expired: 0 txn/s
submitted: 12 txn/s, committed: 12 txn/s, expired: 0 txn/s
submitted: 15 txn/s, committed: 15 txn/s, expired: 0 txn/s
Total stats: submitted: 870, committed: 870, expired: 0
Average rate: submitted: 14 txn/s, committed: 14 txn/s, expired: 0 txn/s
```
