### PR TITLE
[move-prover] Update script_incorrect.exp

### DIFF
--- a/language/move-prover/tests/sources/functional/script_incorrect.exp
+++ b/language/move-prover/tests/sources/functional/script_incorrect.exp
@@ -6,7 +6,10 @@ error:  A postcondition might not hold on this return path.
  10 │     aborts_if false;
     │     ^^^^^^^^^^^^^^^^
     │
+    =     at tests/sources/functional/script_incorrect.move:5:1: main (entry)
     =     at tests/sources/functional/script_provider.move:9:5: register (entry)
     =     at tests/sources/functional/script_provider.move:10:9: register
     =     at tests/sources/functional/script_provider.move:12:5: register
     =     at tests/sources/functional/script_provider.move:9:5: register (exit)
+    =     at tests/sources/functional/script_incorrect.move:6:21: main
+    =     at tests/sources/functional/script_incorrect.move:5:1: main (exit)


### PR DESCRIPTION
- Fix the baseline file for the "script_incorrect" test which was broken from https://github.com/libra/libra/pull/3669

## Motivation

To fix the broken baseline file

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

cargo test