### PR TITLE
[move-prover] Fixed scripts

### DIFF
--- a/language/move-prover/scripts/README.md
+++ b/language/move-prover/scripts/README.md
@@ -4,6 +4,12 @@ There are three experimental scripts in this folder.
 3. `install-z3.sh` installs a specific version of Z3.
 
 `install-dotnet.sh` must be executed before `install-boogie.sh`.  There is no other dependency.
+`install-dotnet.sh` installs the Dotnet Core SDK and the `dotnet` tool.  The installation could fail
+on your machine because a few directories must be writable by your user account.  You should
+change the ownership of these directories to your user.
+  sudo chown -R $(whoami) /usr/local/bin /usr/local/lib /usr/local/sbin
+And make sure that your user has write permission.
+  chmod u+w /usr/local/bin /usr/local/lib /usr/local/sbin
 
 The commands `boogie` and `z3` should be in your path once these scripts have finished successfully.
 
@@ -22,6 +28,6 @@ this crate, these environment variables must be set.  To set these environment v
 execute the following at the command-line after running the installation scripts described
 above:
 ```
-export BOOGIE_EXE=~/.dotnet/tools/boogie
+export BOOGIE_EXE=/Users/$(whoami)/.dotnet/tools/boogie
 export Z3_EXE=/usr/local/bin/z3
 ```

--- a/language/move-prover/scripts/install-boogie.sh
+++ b/language/move-prover/scripts/install-boogie.sh
@@ -3,5 +3,4 @@
 # Copyright (c) The Libra Core Contributors
 # SPDX-License-Identifier: Apache-2.0
 
-dotnet tool uninstall --global Boogie
-dotnet tool install --global Boogie
+dotnet tool update --global Boogie --version 2.5.7

--- a/language/move-prover/scripts/install-dotnet.sh
+++ b/language/move-prover/scripts/install-dotnet.sh
@@ -5,3 +5,4 @@
 
 brew tap isen-ng/dotnet-sdk-versions
 brew cask install dotnet-sdk-3.1.100
+brew cask install dotnet


### PR DESCRIPTION
## Motivation

This PR makes the following changes:
- adds command for installing dotnet tool to install-dotnet.sh.
- increases robustness of install-boogie.sh by using "dotnet tool update" which works both on a fresh installation and for updating an existing installation.
- locks the Boogie version to a fixed one in install-boogie.sh; I have picked 2.5.7 for now but we can update when we need to.
- adds more comments to README.md to help in troubleshooting.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

Manually tested the scripts.

## Related PRs

