### PR TITLE
[management] Update config-builder flags and README for clarity

### DIFF
--- a/config/README.md
+++ b/config/README.md
@@ -38,33 +38,34 @@ configuration from many of the services.
 
 ## Building a Test Network (TestNet)
 
-`config-builder` builds an entire network's or swarm's configuration including the
-genesis blob. It takes as one of its input parameters an index that selects, which
-of these configs to return. This can be used to create a Libra TestNet by specifying
-distinct indices for each validator. Similarly the tool can be used to add Fullnodes
-to an existing network.  Finally, it enables generation of a mint/faucet client
-capable of performing mint transactions/creating accounts.
+`config-builder` builds an entire configuration for a Validator or FullNode,
+including the genesis blob. It takes as one of its input parameters an index that
+specifies the specific node config to return. This can be used to create a Libra
+TestNet by constructing compatible configurations for the full set of Validators.
+Similarly the tool can be used to add Fullnodes to an existing network.  Finally,
+it enables generation of a mint/faucet client capable of performing mint
+transactions/creating accounts.
 
 ## Generating a new TestNet
 
-The only requirements for generating a TestNet configuration are: (i) having IP
-addresses and ports for each Libra node; (ii) a pre-agreed upon shared secret;
-and (iii) a fixed ordering for each Node in the network. Full node networks can
-either be added to existing configs or generate completely new configs.
+The only requirements for generating the configuration for a full TestNet are: (i)
+having IP addresses and ports for each Validator; (ii) a pre-agreed upon shared secret
+for the Validator network; and (iii) a fixed ordering for the Validators in the
+network. FullNode configs can either be newly generated added to existing configs.
 
-Each peer, `I`, can then generate their own configurations by:
+The configuration for validator `I`, can be produced by:
 
     config-builder validator \
-        -a $PUBLIC_MULTIADDR_FOR_NODE_I \
-        -b $PUBLIC_MULTIADDR_FOR_NODE_0 \
+        -a $PUBLIC_MULTIADDR_FOR_VALIDATOR_I \
+        -b $PUBLIC_MULTIADDR_FOR_VALIDATOR_0 \
         -d /opt/libra/data \
         -i $I \
-        -l $ANY_MULTIADDR_FOR_NODE_I \
-        -n $TOTAL_NUMBER_OF_NODES \
+        -l $ANY_MULTIADDR_FOR_VALIDATOR_I \
+        -n $TOTAL_NUMBER_OF_VALIDATORS \
         -o /opt/libra/etc \
         -s $SHARED_SECRET
 
-As an example, this is the 2nd node (offset 1) in a set of 4:
+As an example, this is the 2nd Validator (offset 1) in a 4 Validator TestNet:
 
     config-builder validator \
         -a "/ip4/1.1.1.2/tcp/7000" \
@@ -82,7 +83,7 @@ To create a mint service's key:
         -o /opt/libra/etc \
         -s 0123456789abcdef101112131415161718191a1b1c1d1e1f2021222324252627
 
-Adding a Fullnode network is similar to instantiating a Validator config.
+Instantiating a FullNode config is similar to instantiating a Validator config.
 Though there are three possible routes: (i) creating a new node config; (ii)
 extending an existing Fullnode with another network; and (iii) extending a
 Validator with a Fullnode network. The input is similar for all three cases
@@ -94,27 +95,42 @@ Note: currently, the tool does not support the creation of trees of Fullnode
 networks.
 
     config-builder full-node (create | extend) \
-        -a $PUBLIC_MULTIADDR_FOR_NODE_I \
-        -b $PUBLIC_MULTIADDR_FOR_NODE_0 \
+        -a $PUBLIC_MULTIADDR_FOR_FULL_NODE_I \
+        -b $PUBLIC_MULTIADDR_FOR_FULL_NODE_0 \
         -d /opt/libra/data \
-        -l $ANY_MULTIADDR_FOR_NODE_I \
-        -n $TOTAL_NUMBER_OF_NODES \
+        -l $ANY_MULTIADDR_FOR_FULL_NODE_I \
+        -n $TOTAL_NUMBER_OF_VALIDATORS \
         -o /opt/libra/etc \
-        -s $SHARED_SECRET \
+        -s $VALIDATOR_SHARED_SECRET \
         [ -i $I -f $TOTAL_NUMBER_OF_FULL_NODES -c $FULL_NODE_SHARED_SECRET | -p ]
 
-Here's an example of adding a 4 membered and authenticated network connecting to the
-node above:
+Here an example of extending the Validator configuration above with a FullNode
+configuration.
+
+    config-builder full-node extend \
+        -a "/ip4/1.1.1.2/tcp/7100" \
+        -b "/ip4/1.1.1.2/tcp/7100" \
+        -d /opt/libra/data \
+        -l "/ip4/0.0.0.0/tcp/7100" \
+        -n 4 \
+        -o /opt/libra/etc \
+        -s 0123456789abcdef101112131415161718191a1b1c1d1e1f2021222324252627 \
+        -i 0 \
+        -f 4 \
+        -c 28292a2b2c2d2e2f303132333435363738393a3b3c3d3e3f4041424344454547
+
+Here is an example of creating a new FullNode that will connect to the
+Validator/FullNode hybrid configured above.
 
     config-builder full-node create \
-        -a "/ip4/1.1.1.2/tcp/7100" \
+        -a "/ip4/1.1.1.3/tcp/7100" \
         -b "/ip4/1.1.1.2/tcp/7100" \
         -d /opt/libra/fn/data \
         -l "/ip4/0.0.0.0/tcp/7100" \
         -n 4 \
         -o /opt/libra/fn/etc \
         -s 0123456789abcdef101112131415161718191a1b1c1d1e1f2021222324252627 \
-        -i 0 \
+        -i 1 \
         -f 4 \
         -c 28292a2b2c2d2e2f303132333435363738393a3b3c3d3e3f4041424344454547
 
@@ -170,7 +186,7 @@ Configuration tests serve several purposes:
 - Verifying that default filename assumptions are maintained
 
 Several of the defaults in the configurations, in particular paths and
-addresses, have dependecies outside the Libra code base. These tests serve as
+addresses, have dependencies outside the Libra code base. These tests serve as
 a reminder that there may be rammifications from breaking these tests, which
 may impact production deployments.
 

--- a/config/config-builder/src/full_node_config.rs
+++ b/config/config-builder/src/full_node_config.rs
@@ -95,8 +95,8 @@ impl FullNodeConfig {
         self
     }
 
-    pub fn nodes(&mut self, nodes: usize) -> &mut Self {
-        self.validator_config.nodes(nodes);
+    pub fn validators(&mut self, nodes: usize) -> &mut Self {
+        self.validator_config.validators(nodes);
         self
     }
 

--- a/config/config-builder/src/main.rs
+++ b/config/config-builder/src/main.rs
@@ -35,7 +35,7 @@ struct FaucetArgs {
     seed: Option<String>,
     #[structopt(short = "n", long)]
     /// Specify the number of validators coded in genesis blob to produce waypoint.
-    nodes_in_genesis: usize,
+    validators_in_genesis: usize,
 }
 
 #[derive(Debug, StructOpt)]
@@ -51,7 +51,7 @@ struct FullNodeArgs {
     // Describe the validator networrk
     #[structopt(short = "n", long, default_value = "1")]
     /// Specify the number of Validators to configure in the genesis blob.
-    nodes: usize,
+    validators: usize,
     #[structopt(short = "s", long)]
     /// Use the provided seed for generating keys for each of the validators.
     seed: Option<String>,
@@ -74,7 +74,7 @@ struct FullNodeArgs {
     full_nodes: usize,
     #[structopt(short = "i", long, default_value = "0")]
     /// Specify the index of the FullNode being configured.  Must be in the range 0..f-1.
-    index: usize,
+    full_node_index: usize,
     #[structopt(short = "l", long, parse(from_str = parse_addr))]
     /// Listening address for this node.
     listen: NetworkAddress,
@@ -118,17 +118,17 @@ struct ValidatorCommonArgs {
     data_dir: PathBuf,
     #[structopt(short = "i", long, default_value = "0")]
     /// Specify the index of the Validator being configured.  Must be in the range 0..n-1.
-    index: usize,
+    validator_index: usize,
     #[structopt(short = "o", long, parse(from_os_str))]
     /// The output directory.
     output_dir: PathBuf,
     #[structopt(short = "n", long, default_value = "1")]
     /// Specify the potential number of Validators to configure in the genesis blob.
-    nodes: usize,
+    validators: usize,
     #[structopt(short = "g", long)]
     /// Specify the number of Validators coded in genesis blob, will use all validators if
     /// unspecified.  Must be in the range 0..n-1.
-    nodes_in_genesis: Option<usize>,
+    validators_in_genesis: Option<usize>,
     #[structopt(long, parse(from_str = parse_socket_addr))]
     /// Specify the IP:Port for Safety rules. If this is not defined, SafetyRules will run in its
     /// default configuration.
@@ -174,7 +174,7 @@ fn main() {
 
 fn build_faucet(args: FaucetArgs) {
     let mut config_builder = ValidatorConfig::new();
-    config_builder.nodes(args.nodes_in_genesis);
+    config_builder.validators(args.validators_in_genesis);
 
     if let Some(seed) = args.seed.as_ref() {
         let seed = hex::decode(seed).expect("Invalid hex in seed.");
@@ -239,10 +239,10 @@ fn build_full_node_config_builder(args: &FullNodeArgs) -> FullNodeConfig {
     config_builder
         .advertised(args.advertised.clone())
         .bootstrap(args.bootstrap.clone())
-        .full_node_index(args.index)
+        .full_node_index(args.full_node_index)
         .full_nodes(args.full_nodes)
         .listen(args.listen.clone())
-        .nodes(args.nodes)
+        .validators(args.validators)
         .template(load_template(args.template.as_ref()));
 
     if let Some(fn_seed) = args.full_node_seed.as_ref() {
@@ -282,10 +282,10 @@ fn build_validator(args: ValidatorArgs) {
     config_builder
         .advertised(args.advertised)
         .bootstrap(args.bootstrap)
-        .index(args.validator_common.index)
+        .validator_index(args.validator_common.validator_index)
         .listen(args.listen)
-        .nodes(args.validator_common.nodes)
-        .nodes_in_genesis(args.validator_common.nodes_in_genesis);
+        .validators(args.validator_common.validators)
+        .validators_in_genesis(args.validator_common.validators_in_genesis);
 
     if let Some(seed) = args.validator_common.seed.as_ref() {
         config_builder.seed(parse_seed(seed));
@@ -300,8 +300,8 @@ fn safety_rules_common(args: &ValidatorCommonArgs) -> ValidatorConfig {
     let mut config_builder = ValidatorConfig::new();
 
     config_builder
-        .index(args.index)
-        .nodes(args.nodes)
+        .validator_index(args.validator_index)
+        .validators(args.validators)
         .safety_rules_addr(args.safety_rules_addr.clone())
         .safety_rules_backend(args.safety_rules_backend.clone())
         .safety_rules_host(args.safety_rules_host.clone())

--- a/config/config-builder/src/validator_config.rs
+++ b/config/config-builder/src/validator_config.rs
@@ -83,7 +83,7 @@ impl ValidatorConfig {
         self
     }
 
-    pub fn index(&mut self, index: usize) -> &mut Self {
+    pub fn validator_index(&mut self, index: usize) -> &mut Self {
         self.index = index;
         self
     }
@@ -93,12 +93,12 @@ impl ValidatorConfig {
         self
     }
 
-    pub fn nodes(&mut self, nodes: usize) -> &mut Self {
+    pub fn validators(&mut self, nodes: usize) -> &mut Self {
         self.nodes = nodes;
         self
     }
 
-    pub fn nodes_in_genesis(&mut self, nodes_in_genesis: Option<usize>) -> &mut Self {
+    pub fn validators_in_genesis(&mut self, nodes_in_genesis: Option<usize>) -> &mut Self {
         self.nodes_in_genesis = nodes_in_genesis;
         self
     }
@@ -304,7 +304,11 @@ mod test {
     #[test]
     fn verify_correctness() {
         let mut validator_config = ValidatorConfig::new();
-        let config = validator_config.nodes(2).index(1).build().unwrap();
+        let config = validator_config
+            .validators(2)
+            .validator_index(1)
+            .build()
+            .unwrap();
         let network = config.validator_network.as_ref().unwrap();
         let (seed_peer_id, seed_peer_ips) = network.seed_peers.seed_peers.iter().next().unwrap();
         assert!(&network.peer_id != seed_peer_id);
@@ -323,11 +327,15 @@ mod test {
 
     #[test]
     fn verify_same_genesis() {
-        let config1 = ValidatorConfig::new().nodes(10).index(1).build().unwrap();
+        let config1 = ValidatorConfig::new()
+            .validators(10)
+            .validator_index(1)
+            .build()
+            .unwrap();
         let config2 = ValidatorConfig::new()
-            .nodes(13)
-            .index(12)
-            .nodes_in_genesis(Some(10))
+            .validators(13)
+            .validator_index(12)
+            .validators_in_genesis(Some(10))
             .build()
             .unwrap();
 

--- a/network/onchain-discovery/src/test.rs
+++ b/network/onchain-discovery/src/test.rs
@@ -163,7 +163,7 @@ fn read_discovery_set(libra_db: &Arc<dyn DbReader>) -> DiscoverySet {
 
 fn gen_configs(count: usize) -> Vec<NodeConfig> {
     config_builder::ValidatorConfig::new()
-        .nodes(count)
+        .validators(count)
         .build_common(true, false)
         .unwrap()
         .0

--- a/testsuite/libra-swarm/src/swarm.rs
+++ b/testsuite/libra-swarm/src/swarm.rs
@@ -314,7 +314,9 @@ impl LibraSwarm {
         let config_path = &swarm_config_dir.as_ref().to_path_buf();
         let config = if role.is_validator() {
             let mut validator_builder = ValidatorConfig::new();
-            validator_builder.template(node_config).nodes(num_nodes);
+            validator_builder
+                .template(node_config)
+                .validators(num_nodes);
             SwarmConfig::build(&validator_builder, config_path)?
         } else {
             let upstream_config_dir = upstream_config_dir.expect("No upstream node for full nodes");


### PR DESCRIPTION
<!--
Thank you for sending a PR. We appreciate you spending time to help improve the Libra project.

The project is undergoing daily changes. Pull Requests will be reviewed and responded to as time permits.
-->

## Motivation
The config-builder flag descriptions and README file are not clear for external users. At the root of this tension is a number of terms (node specifically) that are overloaded with different implicit meaning and a description that is deeply tied to the internal testing use cases.

This PR is an attempt to clarify the flag documentation and README based on an outsider's experience using the config-builder to assist in setting up a TestNet.

Note:  this is a repeat of https://github.com/libra/libra/pull/3740



### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?

yes

## Test Plan

Integration tests should suffice. The change is cosmetic and based on documentation.

## Related PRs

stand alone PR.

