### PR TITLE
[docker] switch to bash script

### DIFF
--- a/docker/validator-dynamic/run.sh
+++ b/docker/validator-dynamic/run.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 # Copyright (c) The Libra Core Contributors
 # SPDX-License-Identifier: Apache-2.0
 set -ex


### PR DESCRIPTION
<!--
Thank you for sending a PR. We appreciate you spending time to help improve the Libra project.

The project is undergoing daily changes. Pull Requests will be reviewed and responded to as time permits.
-->

## Motivation

run.sh in the validator-dynamic folder uses a `for (( expr ; expr ; expr ))` which is not available in sh.
https://github.com/libra/libra/issues/3224

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

Just follow the ReadMe in the docker folder and run the run.sh script


