### PR TITLE
[language] Add constant pool back to proptest (CompiledModule)

### DIFF
--- a/language/bytecode-verifier/bytecode-verifier-tests/src/unit_tests/bounds_tests.rs
+++ b/language/bytecode-verifier/bytecode-verifier-tests/src/unit_tests/bounds_tests.rs
@@ -151,7 +151,7 @@ proptest! {
 #[test]
 fn valid_bounds_no_members() {
     let mut gen = CompiledModuleStrategyGen::new(20);
-    gen.member_count(0);
+    gen.zeros_all();
     proptest!(|(_module in gen.generate())| {
         // gen.generate() will panic if there are any bounds check issues.
     });

--- a/language/vm/src/proptest_types/constants.rs
+++ b/language/vm/src/proptest_types/constants.rs
@@ -1,0 +1,64 @@
+// Copyright (c) The Libra Core Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::file_format::{Constant, SignatureToken};
+use libra_types::account_address::AccountAddress;
+use proptest::{
+    arbitrary::any,
+    collection::{btree_set, vec, SizeRange},
+    strategy::Strategy,
+};
+
+// A `ConstantPoolGen` gives you back a `Strategy` that makes a constant pool with
+// `Address` and `Vector<U8>` only.
+// TODO: make it more general and plug in a constant API
+#[derive(Clone, Debug)]
+pub struct ConstantPoolGen {
+    addresses: Vec<AccountAddress>,
+    byte_arrays: Vec<Vec<u8>>,
+}
+
+impl ConstantPoolGen {
+    // Return a `Strategy` that builds a ConstantPool with a number of `addresse`s and
+    // `vector<u8>` respectively driven by `address_count` and `byte_array_count`
+    pub fn strategy(
+        address_count: impl Into<SizeRange>,
+        byte_array_count: impl Into<SizeRange>,
+    ) -> impl Strategy<Value = Self> {
+        // get unique sets of addresses and vector<U8> (empty vector allowed)
+        (
+            btree_set(any::<AccountAddress>(), address_count),
+            btree_set(vec(any::<u8>(), 0..=20), byte_array_count),
+        )
+            .prop_map(|(addresses, byte_arrays)| Self {
+                addresses: addresses.into_iter().collect(),
+                byte_arrays: byte_arrays.into_iter().collect(),
+            })
+    }
+
+    // Return the `ConstantPool`
+    pub fn constant_pool(self) -> Vec<Constant> {
+        let mut constants = vec![];
+        for address in self.addresses {
+            constants.push(Constant {
+                type_: SignatureToken::Address,
+                data: address.to_vec(),
+            });
+        }
+        for mut byte_array in self.byte_arrays {
+            // TODO: below is a trick to make serialization easy (size being one byte)
+            // This can hopefully help soon in defining an API for constants
+            // As a restriction is a non issue as we don't have input over big numbers (>100)
+            if byte_array.len() > 127 {
+                continue;
+            }
+            byte_array.push(byte_array.len() as u8);
+            byte_array.reverse();
+            constants.push(Constant {
+                type_: SignatureToken::Vector(Box::new(SignatureToken::U8)),
+                data: byte_array,
+            });
+        }
+        constants
+    }
+}

--- a/language/vm/src/proptest_types/functions.rs
+++ b/language/vm/src/proptest_types/functions.rs
@@ -3,10 +3,10 @@
 
 use crate::{
     file_format::{
-        Bytecode, CodeOffset, CodeUnit, FieldHandle, FieldHandleIndex, FieldInstantiation,
-        FunctionDefinition, FunctionHandle, FunctionHandleIndex, FunctionInstantiation,
-        IdentifierIndex, LocalIndex, ModuleHandleIndex, Signature, SignatureIndex,
-        StructDefInstantiation, StructDefinitionIndex, TableIndex,
+        Bytecode, CodeOffset, CodeUnit, ConstantPoolIndex, FieldHandle, FieldHandleIndex,
+        FieldInstantiation, FunctionDefinition, FunctionHandle, FunctionHandleIndex,
+        FunctionInstantiation, IdentifierIndex, LocalIndex, ModuleHandleIndex, Signature,
+        SignatureIndex, StructDefInstantiation, StructDefinitionIndex, TableIndex,
     },
     proptest_types::{
         signature::{SignatureGen, SignatureTokenGen},
@@ -497,9 +497,13 @@ impl BytecodeGen {
     ) -> Option<Bytecode> {
         let bytecode = match self {
             BytecodeGen::Simple(bytecode) => bytecode,
-            BytecodeGen::LdConst(_idx) => {
-                // TODO constant generation
-                return None;
+            BytecodeGen::LdConst(idx) => {
+                if state.constant_pool_len == 0 {
+                    return None;
+                }
+                Bytecode::LdConst(ConstantPoolIndex(
+                    idx.index(state.constant_pool_len) as TableIndex
+                ))
             }
             BytecodeGen::MutBorrowField((def, field)) => {
                 let def_idx = def.index(state.struct_defs_len);


### PR DESCRIPTION
Adding back the constant pool to the strategy generator for `CompiledModule` 
and also generating the `LdConst` bytecode.
This extends coverage all around, though more specific error cases would have 
to be plugged in. 
We are also making the strategy a bit more controlled/granular. 
All pretty simple and more needs to come.
Improving constant pool is something anybody could drive moving forward