### PR TITLE
[move source language] Restrict local and struct names

### DIFF
--- a/language/move-lang/tests/functional/compare/compare.move
+++ b/language/move-lang/tests/functional/compare/compare.move
@@ -6,55 +6,55 @@ use 0x0::Transaction;
 
 fun main() {
     // TODO: replace with constants once the source lang has them
-    let EQUAL = 0u8;
-    let LESS_THAN = 1u8;
-    let GREATER_THAN = 2u8;
+    let equal = 0u8;
+    let less_than = 1u8;
+    let greater_than = 2u8;
 
     // equality of simple types
-    Transaction::assert(Compare::cmp_lcs_bytes(&LCS::to_bytes(&true), &LCS::to_bytes(&true)) == EQUAL, 8001);
-    Transaction::assert(Compare::cmp_lcs_bytes(&LCS::to_bytes(&1u8), &LCS::to_bytes(&1u8)) == EQUAL, 8002);
-    Transaction::assert(Compare::cmp_lcs_bytes(&LCS::to_bytes(&1), &LCS::to_bytes(&1)) == EQUAL, 8003);
-    Transaction::assert(Compare::cmp_lcs_bytes(&LCS::to_bytes(&1u128), &LCS::to_bytes(&1u128)) == EQUAL, 8004);
-    Transaction::assert(Compare::cmp_lcs_bytes(&LCS::to_bytes(&0x1), &LCS::to_bytes(&0x1)) == EQUAL, 8005);
-    Transaction::assert(Compare::cmp_lcs_bytes(&LCS::to_bytes(&x"1"), &LCS::to_bytes(&x"1")) == EQUAL, 8006);
+    Transaction::assert(Compare::cmp_lcs_bytes(&LCS::to_bytes(&true), &LCS::to_bytes(&true)) == equal, 8001);
+    Transaction::assert(Compare::cmp_lcs_bytes(&LCS::to_bytes(&1u8), &LCS::to_bytes(&1u8)) == equal, 8002);
+    Transaction::assert(Compare::cmp_lcs_bytes(&LCS::to_bytes(&1), &LCS::to_bytes(&1)) == equal, 8003);
+    Transaction::assert(Compare::cmp_lcs_bytes(&LCS::to_bytes(&1u128), &LCS::to_bytes(&1u128)) == equal, 8004);
+    Transaction::assert(Compare::cmp_lcs_bytes(&LCS::to_bytes(&0x1), &LCS::to_bytes(&0x1)) == equal, 8005);
+    Transaction::assert(Compare::cmp_lcs_bytes(&LCS::to_bytes(&x"1"), &LCS::to_bytes(&x"1")) == equal, 8006);
 
     // inequality of simple types
-    Transaction::assert(Compare::cmp_lcs_bytes(&LCS::to_bytes(&true), &LCS::to_bytes(&false)) != EQUAL, 8007);
-    Transaction::assert(Compare::cmp_lcs_bytes(&LCS::to_bytes(&1u8), &LCS::to_bytes(&0u8)) != EQUAL, 8008);
-    Transaction::assert(Compare::cmp_lcs_bytes(&LCS::to_bytes(&1), &LCS::to_bytes(&0)) != EQUAL, 8009);
-    Transaction::assert(Compare::cmp_lcs_bytes(&LCS::to_bytes(&1u128), &LCS::to_bytes(&0u128)) != EQUAL, 8010);
-    Transaction::assert(Compare::cmp_lcs_bytes(&LCS::to_bytes(&0x1), &LCS::to_bytes(&0x0)) != EQUAL, 8011);
-    Transaction::assert(Compare::cmp_lcs_bytes(&LCS::to_bytes(&x"1"), &LCS::to_bytes(&x"0")) != EQUAL, 8012);
+    Transaction::assert(Compare::cmp_lcs_bytes(&LCS::to_bytes(&true), &LCS::to_bytes(&false)) != equal, 8007);
+    Transaction::assert(Compare::cmp_lcs_bytes(&LCS::to_bytes(&1u8), &LCS::to_bytes(&0u8)) != equal, 8008);
+    Transaction::assert(Compare::cmp_lcs_bytes(&LCS::to_bytes(&1), &LCS::to_bytes(&0)) != equal, 8009);
+    Transaction::assert(Compare::cmp_lcs_bytes(&LCS::to_bytes(&1u128), &LCS::to_bytes(&0u128)) != equal, 8010);
+    Transaction::assert(Compare::cmp_lcs_bytes(&LCS::to_bytes(&0x1), &LCS::to_bytes(&0x0)) != equal, 8011);
+    Transaction::assert(Compare::cmp_lcs_bytes(&LCS::to_bytes(&x"1"), &LCS::to_bytes(&x"0")) != equal, 8012);
 
     // less than for types with a natural ordering exposed via bytecode operations
-    Transaction::assert(Compare::cmp_lcs_bytes(&LCS::to_bytes(&false), &LCS::to_bytes(&true)) == LESS_THAN, 8013);
-    Transaction::assert(Compare::cmp_lcs_bytes(&LCS::to_bytes(&0u8), &LCS::to_bytes(&1u8)) == LESS_THAN, 8014);
-    Transaction::assert(Compare::cmp_lcs_bytes(&LCS::to_bytes(&0), &LCS::to_bytes(&1)) == LESS_THAN, 8015);
-    Transaction::assert(Compare::cmp_lcs_bytes(&LCS::to_bytes(&0u128), &LCS::to_bytes(&1u128)) == LESS_THAN, 8016);
+    Transaction::assert(Compare::cmp_lcs_bytes(&LCS::to_bytes(&false), &LCS::to_bytes(&true)) == less_than, 8013);
+    Transaction::assert(Compare::cmp_lcs_bytes(&LCS::to_bytes(&0u8), &LCS::to_bytes(&1u8)) == less_than, 8014);
+    Transaction::assert(Compare::cmp_lcs_bytes(&LCS::to_bytes(&0), &LCS::to_bytes(&1)) == less_than, 8015);
+    Transaction::assert(Compare::cmp_lcs_bytes(&LCS::to_bytes(&0u128), &LCS::to_bytes(&1u128)) == less_than, 8016);
 
     // less then for types without a natural ordering exposed by bytecode operations
-    Transaction::assert(Compare::cmp_lcs_bytes(&LCS::to_bytes(&0x0), &LCS::to_bytes(&0x1)) == LESS_THAN, 8017); // sensible
-    Transaction::assert(Compare::cmp_lcs_bytes(&LCS::to_bytes(&0x01), &LCS::to_bytes(&0x10)) == LESS_THAN, 8018); // sensible
-    Transaction::assert(Compare::cmp_lcs_bytes(&LCS::to_bytes(&0x100), &LCS::to_bytes(&0x001)) == LESS_THAN, 8019); // potentially confusing
-    Transaction::assert(Compare::cmp_lcs_bytes(&LCS::to_bytes(&x"0"), &LCS::to_bytes(&x"1")) == LESS_THAN, 8020); // sensible
-    Transaction::assert(Compare::cmp_lcs_bytes(&LCS::to_bytes(&x"01"), &LCS::to_bytes(&x"10")) == LESS_THAN, 8021); // sensible
-    Transaction::assert(Compare::cmp_lcs_bytes(&LCS::to_bytes(&x"000"), &LCS::to_bytes(&x"01")) == LESS_THAN, 8022); //
-    Transaction::assert(Compare::cmp_lcs_bytes(&LCS::to_bytes(&x"100"), &LCS::to_bytes(&x"001")) == LESS_THAN, 8023); // potentially confusing
+    Transaction::assert(Compare::cmp_lcs_bytes(&LCS::to_bytes(&0x0), &LCS::to_bytes(&0x1)) == less_than, 8017); // sensible
+    Transaction::assert(Compare::cmp_lcs_bytes(&LCS::to_bytes(&0x01), &LCS::to_bytes(&0x10)) == less_than, 8018); // sensible
+    Transaction::assert(Compare::cmp_lcs_bytes(&LCS::to_bytes(&0x100), &LCS::to_bytes(&0x001)) == less_than, 8019); // potentially confusing
+    Transaction::assert(Compare::cmp_lcs_bytes(&LCS::to_bytes(&x"0"), &LCS::to_bytes(&x"1")) == less_than, 8020); // sensible
+    Transaction::assert(Compare::cmp_lcs_bytes(&LCS::to_bytes(&x"01"), &LCS::to_bytes(&x"10")) == less_than, 8021); // sensible
+    Transaction::assert(Compare::cmp_lcs_bytes(&LCS::to_bytes(&x"000"), &LCS::to_bytes(&x"01")) == less_than, 8022); //
+    Transaction::assert(Compare::cmp_lcs_bytes(&LCS::to_bytes(&x"100"), &LCS::to_bytes(&x"001")) == less_than, 8023); // potentially confusing
 
     // greater than for types with a natural ordering exposed by bytecode operations
-    Transaction::assert(Compare::cmp_lcs_bytes(&LCS::to_bytes(&true), &LCS::to_bytes(&false)) == GREATER_THAN, 8024);
-    Transaction::assert(Compare::cmp_lcs_bytes(&LCS::to_bytes(&1u8), &LCS::to_bytes(&0u8)) == GREATER_THAN, 8025);
-    Transaction::assert(Compare::cmp_lcs_bytes(&LCS::to_bytes(&1), &LCS::to_bytes(&0)) == GREATER_THAN, 8026);
-    Transaction::assert(Compare::cmp_lcs_bytes(&LCS::to_bytes(&1u128), &LCS::to_bytes(&0u128)) == GREATER_THAN, 8027);
+    Transaction::assert(Compare::cmp_lcs_bytes(&LCS::to_bytes(&true), &LCS::to_bytes(&false)) == greater_than, 8024);
+    Transaction::assert(Compare::cmp_lcs_bytes(&LCS::to_bytes(&1u8), &LCS::to_bytes(&0u8)) == greater_than, 8025);
+    Transaction::assert(Compare::cmp_lcs_bytes(&LCS::to_bytes(&1), &LCS::to_bytes(&0)) == greater_than, 8026);
+    Transaction::assert(Compare::cmp_lcs_bytes(&LCS::to_bytes(&1u128), &LCS::to_bytes(&0u128)) == greater_than, 8027);
 
     // greater than for types without a natural ordering exposed by by bytecode operations
-    Transaction::assert(Compare::cmp_lcs_bytes(&LCS::to_bytes(&0x1), &LCS::to_bytes(&0x0)) == GREATER_THAN, 8028); // sensible
-    Transaction::assert(Compare::cmp_lcs_bytes(&LCS::to_bytes(&0x10), &LCS::to_bytes(&0x01)) == GREATER_THAN, 8029); // sensible
-    Transaction::assert(Compare::cmp_lcs_bytes(&LCS::to_bytes(&0x001), &LCS::to_bytes(&0x100)) == GREATER_THAN, 8030); // potentially confusing
-    Transaction::assert(Compare::cmp_lcs_bytes(&LCS::to_bytes(&x"1"), &LCS::to_bytes(&x"0")) == GREATER_THAN, 8031); // sensible
-    Transaction::assert(Compare::cmp_lcs_bytes(&LCS::to_bytes(&x"10"), &LCS::to_bytes(&x"01")) == GREATER_THAN, 8032); // sensible
-    Transaction::assert(Compare::cmp_lcs_bytes(&LCS::to_bytes(&x"01"), &LCS::to_bytes(&x"000")) == GREATER_THAN, 8033); // sensible
-    Transaction::assert(Compare::cmp_lcs_bytes(&LCS::to_bytes(&x"001"), &LCS::to_bytes(&x"100")) == GREATER_THAN, 8034); // potentially confusing
+    Transaction::assert(Compare::cmp_lcs_bytes(&LCS::to_bytes(&0x1), &LCS::to_bytes(&0x0)) == greater_than, 8028); // sensible
+    Transaction::assert(Compare::cmp_lcs_bytes(&LCS::to_bytes(&0x10), &LCS::to_bytes(&0x01)) == greater_than, 8029); // sensible
+    Transaction::assert(Compare::cmp_lcs_bytes(&LCS::to_bytes(&0x001), &LCS::to_bytes(&0x100)) == greater_than, 8030); // potentially confusing
+    Transaction::assert(Compare::cmp_lcs_bytes(&LCS::to_bytes(&x"1"), &LCS::to_bytes(&x"0")) == greater_than, 8031); // sensible
+    Transaction::assert(Compare::cmp_lcs_bytes(&LCS::to_bytes(&x"10"), &LCS::to_bytes(&x"01")) == greater_than, 8032); // sensible
+    Transaction::assert(Compare::cmp_lcs_bytes(&LCS::to_bytes(&x"01"), &LCS::to_bytes(&x"000")) == greater_than, 8033); // sensible
+    Transaction::assert(Compare::cmp_lcs_bytes(&LCS::to_bytes(&x"001"), &LCS::to_bytes(&x"100")) == greater_than, 8034); // potentially confusing
 }
 }
 // check: EXECUTED

--- a/language/move-lang/tests/move_check/expansion/almost_invalid_local_name.move
+++ b/language/move-lang/tests/move_check/expansion/almost_invalid_local_name.move
@@ -1,0 +1,15 @@
+module M {
+    struct F { No: u64 }
+
+    fun t(_No: u64) {
+    }
+
+    fun t2() {
+        let _No;
+    }
+
+    fun t3() {
+        let _No = 100;
+    }
+
+}

--- a/language/move-lang/tests/move_check/expansion/invalid_local_name.exp
+++ b/language/move-lang/tests/move_check/expansion/invalid_local_name.exp
@@ -1,0 +1,24 @@
+error: 
+
+   ┌── tests/move_check/expansion/invalid_local_name.move:4:11 ───
+   │
+ 4 │     fun t(No: u64) {
+   │           ^^ Invalid local name 'No'. Local names must start with 'a'..'z' (or '_')
+   │
+
+error: 
+
+   ┌── tests/move_check/expansion/invalid_local_name.move:9:13 ───
+   │
+ 9 │         let No;
+   │             ^^ Invalid local name 'No'. Local names must start with 'a'..'z' (or '_')
+   │
+
+error: 
+
+    ┌── tests/move_check/expansion/invalid_local_name.move:14:13 ───
+    │
+ 14 │         let No = 100;
+    │             ^^ Invalid local name 'No'. Local names must start with 'a'..'z' (or '_')
+    │
+

--- a/language/move-lang/tests/move_check/expansion/invalid_local_name.move
+++ b/language/move-lang/tests/move_check/expansion/invalid_local_name.move
@@ -1,0 +1,18 @@
+module M {
+    struct F { No: u64 }
+
+    fun t(No: u64) {
+        No;
+    }
+
+    fun t2() {
+        let No;
+        No = 100;
+    }
+
+    fun t3() {
+        let No = 100;
+        F { No };
+    }
+
+}

--- a/language/move-lang/tests/move_check/expansion/invalid_struct_name.exp
+++ b/language/move-lang/tests/move_check/expansion/invalid_struct_name.exp
@@ -1,0 +1,16 @@
+error: 
+
+   ┌── tests/move_check/expansion/invalid_struct_name.move:2:12 ───
+   │
+ 2 │     struct no {}
+   │            ^^ Invalid struct name 'no'. Struct names must start with 'A'..'Z'
+   │
+
+error: 
+
+   ┌── tests/move_check/expansion/invalid_struct_name.move:9:21 ───
+   │
+ 9 │     resource struct no2 {}
+   │                     ^^^ Invalid struct name 'no2'. Struct names must start with 'A'..'Z'
+   │
+

--- a/language/move-lang/tests/move_check/expansion/invalid_struct_name.move
+++ b/language/move-lang/tests/move_check/expansion/invalid_struct_name.move
@@ -1,0 +1,17 @@
+module M {
+    struct no {}
+    struct X { f: no }
+
+    fun mk(x: no): no {
+        no {}
+    }
+
+    resource struct no2 {}
+    resource struct Y { f: no }
+
+    fun mk2(x: no2): no2 {
+        let no2 {} = x;
+        no2 {}
+    }
+
+}

--- a/language/move-prover/spec-lang/tests/sources/schemas_err.move
+++ b/language/move-prover/spec-lang/tests/sources/schemas_err.move
@@ -61,12 +61,12 @@ module M {
         include Invariant;
     }
 
-    struct wrong_condition_in_struct { x: u64 }
+    struct Wrong_condition_in_struct { x: u64 }
     spec schema Condition {
         x: num;
         requires x > 0;
     }
-    spec struct wrong_condition_in_struct {
+    spec struct Wrong_condition_in_struct {
         include Condition;
     }
 


### PR DESCRIPTION
## What it is?

- Locals must start with _ or a..z
- Structs (and eventually constants) must start with A..Z

## Motivation

- Soon we will be adding aliases for structs and functions (e.g. `use 0x0::Coin::T as Coin` or `use 0x0::Account::deposit`
- This feature will be extended eventually once we have some form of public constants. 
- To prevent a short term and long term problem with collisions with local variables and struct/constant aliases, locals are now guaranteed to be syntactically different than structs/constants

### Short term issue
- In the short term, resolving this without a syntactic separation between locals and constants, we would have to resolve the constant aliases during `naming` (or essentially lift a lot of the logic of `naming` into `expansion`)
- This would greatly hurt the move prover team as they fork off the AST after expansion, so it would require them to duplicate some additional work 

### Long term issue 
- In the long term, not having this syntactic separation causes weird design problems, particularly with pattern matching.
- Consider pattern matching against constants 
```
let c: char = get_last_char(s);
match c {
  MY_SPECIAL_CASE => ...,
  '\n' => ...,
   _ => ...,
}
```
- If there is no syntactic/grammatical separation, how do you decide if `MY_SPECIAL_CASE` is a constant pattern, or is a pattern that introduces a no local variable/binding?
- Rust takes the approach that if `MY_SPECIAL_CASE` is a constant (or enum or struct) in scope, it becomes a constant (or enum or struct) pattern. Otherwise, it introduces a new local binding
  - This leads to weird errors when it is *not* in scope as you will get some error like `All patterns after `MY_SPECIAL_CASE` are unreachable`
  - If you had put `MY_SPECIAL_CASE` as the last pattern, and then used the local named `MY_SPECIAL_CASE` in the case, you could be suppressing errors and missing cases! Particularly dangerous if you are using an enum. But Rust then will give you a warning that locals should start with a lower case letter
- By taking the syntactic separation as proposed above, the compiler (and all the programmers) can at-a-glance decide if something is a constant/enum/struct pattern, or if it is a new local variable/binding

## Test Plan

- new tests
