### PR TITLE
[Key Manager] Support configurable protocols (e.g., http/https) in the key manager config.

### DIFF
--- a/config/src/config/secure_config.rs
+++ b/config/src/config/secure_config.rs
@@ -2,11 +2,10 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use serde::{Deserialize, Serialize};
-use std::{net::SocketAddr, path::PathBuf};
+use std::path::PathBuf;
 
 // JSON RPC endpoint related defaults
-const DEFAULT_JSON_RPC_ADDR: &str = "127.0.0.1";
-const DEFAULT_JSON_RPC_PORT: u16 = 8080;
+const DEFAULT_JSON_RPC_ENDPOINT: &str = "https://127.0.0.1:8080";
 
 // Key manager timing related defaults
 const DEFAULT_ROTATION_PERIOD_SECS: u64 = 604_800; // 1 week
@@ -26,20 +25,18 @@ pub struct KeyManagerConfig {
     pub sleep_period_secs: u64,
     pub txn_expiration_secs: u64,
 
-    pub json_rpc_address: SocketAddr,
+    pub json_rpc_endpoint: String,
     pub secure_backend: SecureBackend,
 }
 
 impl Default for KeyManagerConfig {
     fn default() -> KeyManagerConfig {
         KeyManagerConfig {
-            json_rpc_address: format!("{}:{}", DEFAULT_JSON_RPC_ADDR, DEFAULT_JSON_RPC_PORT)
-                .parse()
-                .unwrap(),
-            secure_backend: SecureBackend::InMemoryStorage,
             rotation_period_secs: DEFAULT_ROTATION_PERIOD_SECS,
             sleep_period_secs: DEFAULT_SLEEP_PERIOD_SECS,
             txn_expiration_secs: DEFAULT_TXN_EXPIRATION_SECS,
+            json_rpc_endpoint: DEFAULT_JSON_RPC_ENDPOINT.into(),
+            secure_backend: SecureBackend::InMemoryStorage,
         }
     }
 }

--- a/secure/key-manager/src/libra_interface.rs
+++ b/secure/key-manager/src/libra_interface.rs
@@ -57,8 +57,10 @@ pub struct JsonRpcLibraInterface {
 }
 
 impl JsonRpcLibraInterface {
-    pub fn new(client: JsonRpcClient) -> Self {
-        Self { client }
+    pub fn new(json_rpc_endpoint: String) -> Self {
+        Self {
+            client: JsonRpcClient::new(json_rpc_endpoint),
+        }
     }
 }
 

--- a/secure/key-manager/src/main.rs
+++ b/secure/key-manager/src/main.rs
@@ -10,11 +10,10 @@ use libra_key_manager::{
     counters::COUNTERS, libra_interface::JsonRpcLibraInterface, Error, KeyManager,
 };
 use libra_logger::info;
-use libra_secure_json_rpc::JsonRpcClient;
 use libra_secure_push_metrics::MetricsPusher;
 use libra_secure_storage::{BoxStorage, Storage};
 use libra_secure_time::RealTimeService;
-use std::{convert::TryInto, env, net::SocketAddr, process};
+use std::{convert::TryInto, env, process};
 
 fn main() {
     let args: Vec<String> = env::args().collect();
@@ -57,7 +56,7 @@ fn create_and_execute_key_manager(
     key_manager_config: KeyManagerConfig,
 ) -> Result<(), Error> {
     let account = network_config.peer_id;
-    let libra_interface = create_libra_interface(key_manager_config.json_rpc_address);
+    let libra_interface = create_libra_interface(key_manager_config.json_rpc_endpoint);
     let storage: Box<dyn Storage> = (&key_manager_config.secure_backend)
         .try_into()
         .expect("Unable to initialize storage");
@@ -75,12 +74,10 @@ fn create_and_execute_key_manager(
     .execute()
 }
 
-fn create_libra_interface(json_rpc_address: SocketAddr) -> JsonRpcLibraInterface {
-    let json_rpc_url = format!("https://{}", json_rpc_address.to_string());
+fn create_libra_interface(json_rpc_endpoint: String) -> JsonRpcLibraInterface {
     info!(
         "Creating a libra interface that talks to the JSON RPC endpoint at: {:?}.",
-        json_rpc_url.clone()
+        json_rpc_endpoint.clone()
     );
-    let json_rpc_client = JsonRpcClient::new(json_rpc_url);
-    JsonRpcLibraInterface::new(json_rpc_client)
+    JsonRpcLibraInterface::new(json_rpc_endpoint)
 }


### PR DESCRIPTION
## Motivation

The key manager communicates with the blockchain using a JSON RPC endpoint. However, the key manager currently assumes the use of "https" for this endpoint.

Given that there are deployment scenarios in which one would prefer to use "http" instead of "https" (such as testing, or local deployments of the key manager on the same node as the JSON RPC endpoint), it makes sense to allow the key manager configuration to specify which protocol to use. Note: by default, the config is still set to use "https", unless overridden. 

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?

Yes.

## Test Plan

A local tests still pass.

## Related PRs

None.
