### PR TITLE
[move-prover] Fixes a bug with instantiation of schemas from other modules

### DIFF
--- a/language/move-prover/spec-lang/src/translate.rs
+++ b/language/move-prover/spec-lang/src/translate.rs
@@ -3909,11 +3909,7 @@ impl<'env, 'translator, 'rewriter> ExpRewriter<'env, 'translator, 'rewriter> {
                 .get(&node_id)
                 .expect("type defined")
                 .instantiate(self.type_args);
-            let instantiation_opt = self.parent.instantiation_map.get(&node_id).map(|tys| {
-                tys.iter()
-                    .map(|ty| ty.instantiate(self.type_args))
-                    .collect_vec()
-            });
+            let instantiation_opt = self.parent.instantiation_map.get(&node_id).cloned();
             (loc, ty, instantiation_opt)
         } else {
             let module_env = self.parent.parent.env.get_module(self.originating_module);
@@ -3930,6 +3926,11 @@ impl<'env, 'translator, 'rewriter> ExpRewriter<'env, 'translator, 'rewriter> {
                 },
             )
         };
+        let instantiation_opt = instantiation_opt.map(|tys| {
+            tys.into_iter()
+                .map(|ty| ty.instantiate(self.type_args))
+                .collect_vec()
+        });
         let new_node_id = self.parent.new_node_id();
         self.parent.loc_map.insert(new_node_id, loc);
         self.parent.type_map.insert(new_node_id, ty);

--- a/language/move-prover/tests/sources/stdlib/modules/libra_account.move
+++ b/language/move-prover/tests/sources/stdlib/modules/libra_account.move
@@ -229,7 +229,7 @@ module LibraAccount {
     }
     spec fun mint_LBR {
         pragma verify=false; // FIXME: this function should be verified.
-        // include Libra::MintAbortsIf<LBR::T>; // TODO: uncomment this to reveal the bug
+        include Libra::MintAbortsIf<LBR::T>; // TODO: uncomment this to reveal the bug
         aborts_if !Libra::exists_sender_mint_capability<LBR::T>();
     }
 
@@ -260,7 +260,7 @@ module LibraAccount {
         aborts_if !exists<T>(payee) && !exists<Libra::Info<LBR::T>>(0xA550C18); // modified
 
         // derived from Libra::mint
-        aborts_if !Libra::exists_info<LBR::T>();
+        aborts_if !Libra::token_is_registered<LBR::T>();
         aborts_if amount > 1000000000 * 1000000;
         aborts_if Libra::info<LBR::T>().total_value + amount > max_u128();
         //include Libra::MintAbortsIf<LBR::T>; //FIXME: uncomment this so that a schema inclusion bug manifests. The bug is in the instantiation of the type variable


### PR DESCRIPTION
If one would write `M::Schema<T>` the type instantiation was not correctly propagated.

Also fixes a racing condition between two older PRs which made tests fail.

## Motivation

Bug fix.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

Passes repro.

## Related PRs

NA