### PR TITLE
[Key Manager] Make time based operations configurable for the key manager.

### DIFF
--- a/config/src/config/secure_config.rs
+++ b/config/src/config/secure_config.rs
@@ -4,8 +4,14 @@
 use serde::{Deserialize, Serialize};
 use std::{net::SocketAddr, path::PathBuf};
 
+// JSON RPC endpoint related defaults
 const DEFAULT_JSON_RPC_ADDR: &str = "127.0.0.1";
 const DEFAULT_JSON_RPC_PORT: u16 = 8080;
+
+// Key manager timing related defaults
+const DEFAULT_ROTATION_PERIOD_SECS: u64 = 604_800; // 1 week
+const DEFAULT_SLEEP_PERIOD_SECS: u64 = 600; // 10 minutes
+const DEFAULT_TXN_EXPIRATION_SECS: u64 = 3600; // 1 hour
 
 #[derive(Clone, Debug, Default, Deserialize, PartialEq, Serialize)]
 #[serde(default, deny_unknown_fields)]
@@ -16,6 +22,10 @@ pub struct SecureConfig {
 #[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
 #[serde(default, deny_unknown_fields)]
 pub struct KeyManagerConfig {
+    pub rotation_period_secs: u64,
+    pub sleep_period_secs: u64,
+    pub txn_expiration_secs: u64,
+
     pub json_rpc_address: SocketAddr,
     pub secure_backend: SecureBackend,
 }
@@ -27,6 +37,9 @@ impl Default for KeyManagerConfig {
                 .parse()
                 .unwrap(),
             secure_backend: SecureBackend::InMemoryStorage,
+            rotation_period_secs: DEFAULT_ROTATION_PERIOD_SECS,
+            sleep_period_secs: DEFAULT_SLEEP_PERIOD_SECS,
+            txn_expiration_secs: DEFAULT_TXN_EXPIRATION_SECS,
         }
     }
 }

--- a/secure/key-manager/src/lib.rs
+++ b/secure/key-manager/src/lib.rs
@@ -47,7 +47,6 @@ const MAX_GAS_AMOUNT: u64 = 400_000;
 const ROTATION_PERIOD_SECS: u64 = 604_800; // 1 week
 const SLEEP_PERIOD_SECS: u64 = 600; // 10 minutes, after which the key manager will awaken again
 const TXN_EXPIRATION_SECS: u64 = 3600; // 1 hour, we'll try again after that
-const TXN_RETRY_SECS: u64 = 3600; // 1 hour retry period
 
 /// Defines actions that KeyManager should perform after a check of all associated state.
 #[derive(Debug, PartialEq)]
@@ -236,7 +235,7 @@ where
 
         // If this is inconsistent, then the transaction either failed or was never submitted.
         if let Err(Error::ConfigStorageKeyMismatch(..)) = self.compare_storage_to_config() {
-            return if last_rotation + TXN_RETRY_SECS <= self.time_service.now() {
+            return if last_rotation + TXN_EXPIRATION_SECS <= self.time_service.now() {
                 Ok(Action::SubmitKeyRotationTransaction)
             } else {
                 Ok(Action::NoAction)

--- a/secure/key-manager/src/main.rs
+++ b/secure/key-manager/src/main.rs
@@ -58,12 +58,21 @@ fn create_and_execute_key_manager(
 ) -> Result<(), Error> {
     let account = network_config.peer_id;
     let libra_interface = create_libra_interface(key_manager_config.json_rpc_address);
-    let time_service = RealTimeService::new();
-
     let storage: Box<dyn Storage> = (&key_manager_config.secure_backend)
         .try_into()
         .expect("Unable to initialize storage");
-    KeyManager::new(account, libra_interface, BoxStorage(storage), time_service).execute()
+    let time_service = RealTimeService::new();
+
+    KeyManager::new(
+        account,
+        libra_interface,
+        BoxStorage(storage),
+        time_service,
+        key_manager_config.rotation_period_secs,
+        key_manager_config.sleep_period_secs,
+        key_manager_config.txn_expiration_secs,
+    )
+    .execute()
 }
 
 fn create_libra_interface(json_rpc_address: SocketAddr) -> JsonRpcLibraInterface {

--- a/secure/key-manager/src/tests.rs
+++ b/secure/key-manager/src/tests.rs
@@ -573,7 +573,7 @@ fn verify_execute<T: LibraInterface>(mut node: Node<T>) {
     );
 
     // Verify rotation transaction not executed, now expired
-    node.time.increment_by(crate::TXN_RETRY_SECS);
+    node.time.increment_by(crate::TXN_EXPIRATION_SECS);
     node.update_libra_timestamp();
     assert_eq!(
         Action::SubmitKeyRotationTransaction,

--- a/secure/key-manager/src/tests.rs
+++ b/secure/key-manager/src/tests.rs
@@ -320,11 +320,16 @@ fn setup_node<T: LibraInterface + Clone>(
     let account = config.validator_network.as_ref().unwrap().peer_id;
     let time = MockTimeService::new();
     let libra_test_harness = LibraInterfaceTestHarness::new(libra);
+    let key_manager_config = &config.secure.key_manager;
+
     let key_manager = KeyManager::new(
         account,
         libra_test_harness.clone(),
         setup_secure_storage(&config, time.clone()),
         time.clone(),
+        key_manager_config.rotation_period_secs,
+        key_manager_config.sleep_period_secs,
+        key_manager_config.txn_expiration_secs,
     );
 
     Node::new(account, executor, libra_test_harness, key_manager, time)
@@ -540,21 +545,22 @@ fn test_execute() {
     // Test the mock libra interface implementation
     let (config, _genesis_key) = config_builder::test_config();
     let node = setup_node_using_test_mocks(&config);
-    verify_execute(node);
+    verify_execute(&config, node);
 
     // Test the json libra interface implementation
     let (config, _genesis_key) = config_builder::test_config();
     let (node, _runtime) = setup_node_using_json_rpc(&config);
-    verify_execute(node);
+    verify_execute(&config, node);
 }
 
-fn verify_execute<T: LibraInterface>(mut node: Node<T>) {
+fn verify_execute<T: LibraInterface>(config: &NodeConfig, mut node: Node<T>) {
     // Verify correct initial state (i.e., nothing to be done by key manager)
     assert_eq!(0, node.time.now());
     assert_eq!(0, node.libra.last_reconfiguration().unwrap());
 
     // Verify rotation required after enough time
-    node.time.increment_by(crate::ROTATION_PERIOD_SECS);
+    node.time
+        .increment_by(config.secure.key_manager.rotation_period_secs);
     node.update_libra_timestamp();
     assert_eq!(
         Action::FullKeyRotation,
@@ -573,7 +579,8 @@ fn verify_execute<T: LibraInterface>(mut node: Node<T>) {
     );
 
     // Verify rotation transaction not executed, now expired
-    node.time.increment_by(crate::TXN_EXPIRATION_SECS);
+    node.time
+        .increment_by(config.secure.key_manager.txn_expiration_secs);
     node.update_libra_timestamp();
     assert_eq!(
         Action::SubmitKeyRotationTransaction,


### PR DESCRIPTION
## Motivation

The key manager performs various time-based operations (e.g., rotating keys every X seconds). At present, the frequency of these operations is hard-coded into the codebase, but it makes more sense to allow these things to be configured as different deployments may require different timings (e.g., testing). As such, this small PR makes the timing of these operations configurable, in two commits:

1. First, we unify two previously defined constants: TXN_EXPIRATION_SECS and TXN_RETRY_SECS. TXN_EXPIRATION_SECS is the time after which a rotation transaction will expire. TXN_RETRY_SECS is the time after which the key manager will resubmit a rotation transaction (as the previously submitted one expired). However, I can't see many use-cases where we want these to be different:. For example: (i) if the transaction has not yet expired, there's no point resubmitting; and (ii) if the transaction has expired, we would want to resubmit immediately, so why wait longer? From what it seems these constants make the most sense being equal (e.g., as they are already in the code), and thus we may as well unify them.

2. Second, we add the remaining 3 time-related constants to the key manager configuration (so they can be specified on deployment). To do this, we define default values in the configuration (that match the current code) and allow these values to be potentially over-ridden and passed into the key manager on creation.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?

Yes.

## Test Plan

All local tests still pass.

## Related PRs

None.
