### PR TITLE
[coverage ]small cleanups

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -495,7 +495,10 @@ workflows:
       - build-docker
       - validate-cluster-test-dockerfile
       - terraform
-      - prefetch-crates
+      - prefetch-crates:
+        filters:
+          branches:
+            ignore: gh-pages
       - lint:
           requires:
             - prefetch-crates
@@ -517,15 +520,9 @@ workflows:
       - run-crypto-unit-test:
           requires:
             - prefetch-crates
-      #- run-flaky-unit-test:
-      #    requires:
-      #      - prefetch-crates
       - build-docs:
           requires:
             - lint
-          filters:
-            branches:
-              only: master
       - deploy-docs:
           requires:
             - build-docs

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -122,7 +122,6 @@ commands:
       - run:
           name: Send job status
           command: |
-            set -x
             if [ -e <<parameters.payload_file>> ]; then
               jq -n \
                 --arg msg "$(cat <<parameters.payload_file>>)" \
@@ -147,8 +146,8 @@ commands:
                 <<parameters.webhook>>
               else
                 echo "Not sending messages as no webhook url is set."
-                echo "Chances are you are not building on master or circle is misconfigured."
-                echo "webhook is <<parameters.webhook>>"
+                echo "Chances are you are not building on master, or circle is misconfigured."
+                echo "webhook is empty"
                 exit 0
               fi
             fi

--- a/scripts/coverage_report.sh
+++ b/scripts/coverage_report.sh
@@ -96,6 +96,10 @@ echo "Running tests..."
 while read -r line; do
         subdir=$(dirname "$line");
         dirline=$(realpath "$subdir");
+        if [ "${subdir}" == "." ]; then
+          echo "Not running coverage for root crate"
+          continue
+        fi
         # Don't fail out of the loop here. We just want to run the test binary
         # to collect its profile data.  Also note which crates fail under coverage.
         ( cd "$dirline" && pwd && cargo xtest ) || FAILED_CRATES="${FAILED_CRATES}:${subdir}"
@@ -108,7 +112,7 @@ fi
 
 # Generate lcov report
 echo "Generating lcov report at ${COVERAGE_DIR}/lcov.info..."
-grcov target -t lcov  --llvm --branch --ignore "/*" --ignore "x/*" --ignore "testsuite/*" -o "$COVERAGE_DIR/lcov.info"
+grcov target -t lcov  --llvm --branch --ignore "/*" --ignore "devtools/*/*" --ignore "testsuite/*" -o "$COVERAGE_DIR/lcov.info"
 
 # Generate HTML report
 echo "Generating report at ${COVERAGE_DIR}..."

--- a/testsuite/libra-fuzzer/README.md
+++ b/testsuite/libra-fuzzer/README.md
@@ -83,10 +83,10 @@ See [Google OSS-Fuzz's documentation on reproducing bugs](https://google.github.
 
 ### Fuzzing Coverage
 
-To test coverage of our fuzzers you can run the following command with [tarpaulin](https://crates.io/crates/cargo-tarpaulin):
+To test coverage of our fuzzers you can run the following command with [grcov](https://github.com/mozilla/grcov):
 
 ```
-CORPUS_PATH=fuzz/corpus cargo tarpaulin -p libra-fuzzer -- coverage
+CORPUS_PATH=fuzz/corpus cargo xtest --html-cov-dir <some path for html output> -p libra-fuzzer -- coverage
 ```
 
 ### Google OSS-Fuzz Integration


### PR DESCRIPTION
<!--
Thank you for sending a PR. We appreciate you spending time to help improve the Libra project.

The project is undergoing daily changes. Pull Requests will be reviewed and responded to as time permits.
-->

## Motivation

libra has a lot of virtual crates, it appeared that they were all being run during coverage generation, turns out it was only the root Cargo.toml, all other virtual crates were ignored.

* ensure the top level Cargo.toml isn't invoked.
* fuzzing coverage documentation cleanups.

Other minor cleanups include:

* removing a set -x which made logging hard to read.
* logging cleanups for legibility.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?

## Test Plan

CI.

## Related PRs

None.
