### PR TITLE
[crypto] Fix inversion in CryptoHasher-derived names

### DIFF
--- a/crypto/crypto-derive/src/lib.rs
+++ b/crypto/crypto-derive/src/lib.rs
@@ -318,6 +318,9 @@ pub fn derive_enum_signature(input: TokenStream) -> TokenStream {
     }
 }
 
+// There is a unit test for this logic in the crypto crate, at
+// libra_crypto::unit_tests::cryptohasher — you may have to modify it if you
+// edit the below.
 #[proc_macro_derive(CryptoHasher, attributes(CryptoHasherSalt))]
 pub fn hasher_dispatch(input: TokenStream) -> TokenStream {
     let item = parse_macro_input!(input as DeriveInput);
@@ -343,7 +346,7 @@ pub fn hasher_dispatch(input: TokenStream) -> TokenStream {
                 let f_name = #fn_name;
 
                 #hasher_name(
-                    libra_crypto::hash::DefaultHasher::new_with_salt(&format!("{}::{}", f_name, mp).as_bytes()))
+                    libra_crypto::hash::DefaultHasher::new_with_salt(&format!("{}::{}", mp, f_name).as_bytes()))
             }
         }
 

--- a/crypto/crypto/src/unit_tests/cryptohasher.rs
+++ b/crypto/crypto/src/unit_tests/cryptohasher.rs
@@ -1,0 +1,62 @@
+// Copyright (c) The Libra Core Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+use crate as libra_crypto;
+use crate::{
+    hash::{CryptoHash, CryptoHasher},
+    HashValue,
+};
+use libra_crypto_derive::CryptoHasher;
+use tiny_keccak::{Hasher, Sha3};
+
+/// This file tests the CryptoHasher derive macro defined in the crypto-derive
+/// crate. This macro, as the comments there indicate, is meant to derive an
+/// instance of CryptoHasher (see `crate::hash`) for any type, which
+/// domain-separation tag is precisely the fully-qualified name of the
+/// struct. Here, we create a struct, manually "compute" its tag and compare it
+/// to the generated one.
+
+#[derive(CryptoHasher)]
+pub struct Foo {}
+
+impl CryptoHash for Foo {
+    type Hasher = FooHasher;
+
+    fn hash(&self) -> HashValue {
+        // we voluntarily keep the contents empty, since we just want to test
+        // the hasher prefix
+        let state = Self::Hasher::default();
+        state.finish()
+    }
+}
+
+// workaround of crate::hash::LIBRA_HASH_SUFFIX being private
+// the const below should always be a copy of it
+const LIBRA_HASH_SUFFIX_FOR_TESTING: &[u8] = b"@@$$LIBRA$$@@";
+
+#[test]
+fn test_cryptohasher_name() {
+    let mut name = "libra_crypto::unit_tests::cryptohasher::Foo"
+        .as_bytes()
+        .to_vec();
+    name.extend_from_slice(LIBRA_HASH_SUFFIX_FOR_TESTING);
+
+    let mut digest = Sha3::v256();
+    digest.update(HashValue::from_sha3_256(&name[..]).as_ref());
+
+    let expected = {
+        let mut hasher_bytes = [0u8; 32];
+        digest.finalize(&mut hasher_bytes);
+        hasher_bytes
+    };
+    let foo_instance = Foo {};
+    let foo_hash = CryptoHash::hash(&foo_instance);
+    let actual = foo_hash.as_ref();
+    assert_eq!(
+        &expected,
+        actual,
+        "\nexpected: {} actual: {}",
+        String::from_utf8_lossy(&expected),
+        String::from_utf8_lossy(actual)
+    );
+}

--- a/crypto/crypto/src/unit_tests/mod.rs
+++ b/crypto/crypto/src/unit_tests/mod.rs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 mod cross_test;
+mod cryptohasher;
 mod ed25519_test;
 mod hash_test;
 mod hkdf_test;

--- a/storage/libradb/src/state_store/state_store_test.rs
+++ b/storage/libradb/src/state_store/state_store_test.rs
@@ -123,7 +123,7 @@ fn test_state_store_reader_writer() {
             (address3, value3.clone()),
         ],
         1, /* version */
-        6, /* expected_nodes_created */
+        4, /* expected_nodes_created */
         1, /* expected_nodes_retired */
         1, /* expected_blobs_retired */
     );
@@ -158,7 +158,7 @@ fn test_retired_records() {
         store,
         vec![(address1, value1.clone()), (address2, value2)],
         0, /* version */
-        5, /* expected_nodes_created */
+        3, /* expected_nodes_created */
         0, /* expected_nodes_retired */
         0, /* expected_blobs_retired */
     );
@@ -169,8 +169,8 @@ fn test_retired_records() {
             (address3, value3.clone()),
         ],
         1, /* version */
-        5, /* expected_nodes_created */
-        4, /* expected_nodes_retired */
+        3, /* expected_nodes_created */
+        2, /* expected_nodes_retired */
         1, /* expected_blobs_retired */
     );
     let root2 = put_account_state_set(

--- a/types/src/unit_tests/address_test.rs
+++ b/types/src/unit_tests/address_test.rs
@@ -52,7 +52,7 @@ fn test_address() {
     });
 
     let hash_vec =
-        &Vec::from_hex("2f06a55a39cbe1bdfbb3a1ca7a770674af51849d48a9ce5a9beb6f82bde14e6f")
+        &Vec::from_hex("87090718c95e76db89afa7148a6294e3a2ce7aacddcb8d21172dd8cce1a3bbd6")
             .expect("You must provide a valid Hex format");
 
     let mut hash = [0u8; 32];


### PR DESCRIPTION
The derive macro for `CryptoHasher` derived an incorrect domain separation prefix, inverting struct name and struct path.

i.e. it derived:
`Foo::bar::baz::quux`
instead of
`bar::baz::quux::Foo` for struct `Foo` in crate `bar::baz::quux`.

This fixes the inversion and introduces a unit test in the crypto crate.

Review by @davidiw (who found the bug) and @matbd please. 