### PR TITLE
[CI] Increase machine sizing to support linkage needs due to updated mirai-annotations 

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,6 +5,10 @@ executors:
     docker:
       - image: circleci/rust:buster
     resource_class: 2xlarge
+  unittest-executor:
+    docker:
+      - image: circleci/rust:buster
+    resource_class: 2xlarge+
   test-executor:
     docker:
       - image: circleci/rust:buster
@@ -317,7 +321,7 @@ jobs:
           build_url: "${CIRCLE_BUILD_URL}#tests/containers/${CIRCLE_NODE_INDEX}"
           webhook: "${WEBHOOK_FLAKY_TESTS}"
   run-unit-test:
-    executor: build-executor
+    executor: unittest-executor
     description: Run all unit tests, excluding E2E and flaky tests that are
       explicitly ignored.
     steps:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -17,7 +17,7 @@ dependencies = [
  "libra-crypto 0.1.0",
  "libra-types 0.1.0",
  "libra-workspace-hack 0.1.0",
- "mirai-annotations 1.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "mirai-annotations 1.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "proptest 0.9.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.7.3 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -410,7 +410,7 @@ name = "borrow-graph"
 version = "0.0.1"
 dependencies = [
  "libra-workspace-hack 0.1.0",
- "mirai-annotations 1.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "mirai-annotations 1.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -478,7 +478,7 @@ dependencies = [
  "invalid-mutations 0.1.0",
  "libra-types 0.1.0",
  "libra-workspace-hack 0.1.0",
- "mirai-annotations 1.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "mirai-annotations 1.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "move-core-types 0.1.0",
  "move-vm-types 0.1.0",
  "petgraph 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -827,7 +827,7 @@ dependencies = [
  "libra-types 0.1.0",
  "libra-vm 0.1.0",
  "libra-workspace-hack 0.1.0",
- "mirai-annotations 1.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "mirai-annotations 1.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "network 0.1.0",
  "num-derive 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "num-traits 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -859,7 +859,7 @@ dependencies = [
  "libra-crypto-derive 0.1.0",
  "libra-types 0.1.0",
  "libra-workspace-hack 0.1.0",
- "mirai-annotations 1.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "mirai-annotations 1.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "proptest 0.9.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.106 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -1440,7 +1440,7 @@ dependencies = [
  "libra-types 0.1.0",
  "libra-vm 0.1.0",
  "libra-workspace-hack 0.1.0",
- "mirai-annotations 1.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "mirai-annotations 1.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "move-core-types 0.1.0",
  "once_cell 1.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "regex 1.3.7 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1967,7 +1967,7 @@ dependencies = [
  "libra-nibble 0.1.0",
  "libra-types 0.1.0",
  "libra-workspace-hack 0.1.0",
- "mirai-annotations 1.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "mirai-annotations 1.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "num-derive 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "num-traits 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "proptest 0.9.6 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2192,7 +2192,7 @@ dependencies = [
  "libra-types 0.1.0",
  "libra-workspace-hack 0.1.0",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "mirai-annotations 1.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "mirai-annotations 1.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.7.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.106 (registry+https://github.com/rust-lang/crates.io-index)",
  "thiserror 1.0.16 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2218,7 +2218,7 @@ dependencies = [
  "libra-crypto-derive 0.1.0",
  "libra-nibble 0.1.0",
  "libra-workspace-hack 0.1.0",
- "mirai-annotations 1.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "mirai-annotations 1.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "once_cell 1.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "proptest 0.9.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "proptest-derive 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2448,7 +2448,7 @@ dependencies = [
  "libra-security-logger 0.1.0",
  "libra-types 0.1.0",
  "libra-workspace-hack 0.1.0",
- "mirai-annotations 1.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "mirai-annotations 1.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "network 0.1.0",
  "once_cell 1.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.7.3 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2713,7 +2713,7 @@ dependencies = [
  "libra-proptest-helpers 0.1.0",
  "libra-prost-ext 0.1.0",
  "libra-workspace-hack 0.1.0",
- "mirai-annotations 1.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "mirai-annotations 1.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "move-core-types 0.1.0",
  "once_cell 1.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "proptest 0.9.6 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2765,7 +2765,7 @@ dependencies = [
  "libra-state-view 0.1.0",
  "libra-types 0.1.0",
  "libra-workspace-hack 0.1.0",
- "mirai-annotations 1.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "mirai-annotations 1.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "move-core-types 0.1.0",
  "move-vm-runtime 0.1.0",
  "move-vm-state 0.1.0",
@@ -2791,7 +2791,7 @@ dependencies = [
  "libra-temppath 0.1.0",
  "libra-types 0.1.0",
  "libra-workspace-hack 0.1.0",
- "mirai-annotations 1.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "mirai-annotations 1.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "pbkdf2 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.7.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.106 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -3039,7 +3039,7 @@ dependencies = [
 
 [[package]]
 name = "mirai-annotations"
-version = "1.7.0"
+version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -3049,7 +3049,7 @@ dependencies = [
  "anyhow 1.0.28 (registry+https://github.com/rust-lang/crates.io-index)",
  "libra-canonical-serialization 0.1.0",
  "libra-workspace-hack 0.1.0",
- "mirai-annotations 1.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "mirai-annotations 1.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "once_cell 1.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "proptest 0.9.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "proptest-derive 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -3136,7 +3136,7 @@ dependencies = [
  "libra-logger 0.1.0",
  "libra-types 0.1.0",
  "libra-workspace-hack 0.1.0",
- "mirai-annotations 1.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "mirai-annotations 1.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "move-core-types 0.1.0",
  "move-vm-types 0.1.0",
  "once_cell 1.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -3157,7 +3157,7 @@ dependencies = [
  "libra-state-view 0.1.0",
  "libra-types 0.1.0",
  "libra-workspace-hack 0.1.0",
- "mirai-annotations 1.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "mirai-annotations 1.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "move-core-types 0.1.0",
  "move-vm-natives 0.1.0",
  "move-vm-state 0.1.0",
@@ -3189,7 +3189,7 @@ dependencies = [
  "libra-logger 0.1.0",
  "libra-types 0.1.0",
  "libra-workspace-hack 0.1.0",
- "mirai-annotations 1.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "mirai-annotations 1.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "move-core-types 0.1.0",
  "once_cell 1.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "proptest 0.9.6 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -5245,7 +5245,7 @@ dependencies = [
  "libra-types 0.1.0",
  "libra-vm 0.1.0",
  "libra-workspace-hack 0.1.0",
- "mirai-annotations 1.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "mirai-annotations 1.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "move-core-types 0.1.0",
  "move-vm-types 0.1.0",
  "num_cpus 1.13.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -5757,7 +5757,7 @@ dependencies = [
  "libra-config 0.1.0",
  "libra-types 0.1.0",
  "libra-workspace-hack 0.1.0",
- "mirai-annotations 1.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "mirai-annotations 1.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "stdlib 0.1.0",
  "vm 0.1.0",
 ]
@@ -5955,7 +5955,7 @@ dependencies = [
  "libra-proptest-helpers 0.1.0",
  "libra-types 0.1.0",
  "libra-workspace-hack 0.1.0",
- "mirai-annotations 1.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "mirai-annotations 1.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "move-core-types 0.1.0",
  "num-variants 0.1.0",
  "once_cell 1.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -6517,7 +6517,7 @@ dependencies = [
 "checksum mio-uds 0.6.7 (registry+https://github.com/rust-lang/crates.io-index)" = "966257a94e196b11bb43aca423754d87429960a768de9414f3691d6957abf125"
 "checksum miow 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "8c1f2f3b1cf331de6896aabf6e9d55dca90356cc9960cca7eaaf408a355ae919"
 "checksum miow 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "396aa0f2003d7df8395cb93e09871561ccc3e785f0acb369170e8cc74ddf9226"
-"checksum mirai-annotations 1.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "a76c45e77b9af9f0a3fd33cfd462210c1c221029343ac5346306f28b86943ebd"
+"checksum mirai-annotations 1.8.0 (registry+https://github.com/rust-lang/crates.io-index)" = "258c143ddb5105becc4834f66d0b0ad3d3205d07cb3efc3236f33f623dd07b16"
 "checksum multimap 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)" = "a97fbd5d00e0e37bfb10f433af8f5aaf631e739368dc9fc28286ca81ca4948dc"
 "checksum multipart 0.16.1 (registry+https://github.com/rust-lang/crates.io-index)" = "136eed74cadb9edd2651ffba732b19a450316b680e4f48d6c79e905799e19d01"
 "checksum native-tls 0.2.4 (registry+https://github.com/rust-lang/crates.io-index)" = "2b0d88c06fe90d5ee94048ba40409ef1d9315d86f6f38c2efdaad4fb50c58b2d"

--- a/client/libra-wallet/Cargo.toml
+++ b/client/libra-wallet/Cargo.toml
@@ -25,7 +25,7 @@ libra-crypto = { path = "../../crypto/crypto", version = "0.1.0" }
 libra-temppath = { path = "../../common/temppath/", version = "0.1.0" }
 libra-types = { path = "../../types", version = "0.1.0" }
 libra-workspace-hack = { path = "../../common/workspace-hack", version = "0.1.0" }
-mirai-annotations = "1.7.0"
+mirai-annotations = "1.8.0"
 
 [features]
 default = []

--- a/config/Cargo.toml
+++ b/config/Cargo.toml
@@ -12,7 +12,7 @@ edition = "2018"
 [dependencies]
 anyhow = "1.0"
 get_if_addrs = { version = "0.5.3", default-features = false }
-mirai-annotations = "1.7.0"
+mirai-annotations = "1.8.0"
 rand = "0.7.3"
 serde = { version = "1.0.106", features = ["rc"], default-features = false }
 log = { version = "0.4.8", features = ["serde"] }

--- a/consensus/Cargo.toml
+++ b/consensus/Cargo.toml
@@ -16,7 +16,7 @@ byteorder = { version = "1.3.2", default-features = false }
 bytes = "0.5.4"
 futures = "0.3.0"
 once_cell = "1.3.1"
-mirai-annotations = { version = "1.7.0", default-features = false }
+mirai-annotations = { version = "1.8.0", default-features = false }
 num-derive = { version = "0.3.0", default-features = false }
 num-traits = { version = "0.2.8", default-features = false }
 rand = { version = "0.7.3", default-features = false }

--- a/consensus/consensus-types/Cargo.toml
+++ b/consensus/consensus-types/Cargo.toml
@@ -8,7 +8,7 @@ edition = "2018"
 
 [dependencies]
 anyhow = "1.0"
-mirai-annotations = { version = "1.7.0", default-features = false }
+mirai-annotations = { version = "1.8.0", default-features = false }
 proptest = { version = "0.9.6", optional = true }
 serde = { version = "1.0.106", default-features = false }
 

--- a/crypto/crypto/Cargo.toml
+++ b/crypto/crypto/Cargo.toml
@@ -18,7 +18,7 @@ ed25519-dalek = { git = "https://github.com/calibra/ed25519-dalek.git", branch =
 hex = "0.4.2"
 hmac = "0.7.1"
 once_cell = "1.3.1"
-mirai-annotations = "1.7.0"
+mirai-annotations = "1.8.0"
 proptest = { version = "0.9.6", optional = true }
 proptest-derive = { version = "0.1.2", optional = true }
 rand = "0.7.3"

--- a/language/borrow-graph/Cargo.toml
+++ b/language/borrow-graph/Cargo.toml
@@ -8,4 +8,4 @@ license = "Apache-2.0"
 
 [dependencies]
 libra-workspace-hack = { path = "../../common/workspace-hack", version = "0.1.0" }
-mirai-annotations = "1.7.0"
+mirai-annotations = "1.8.0"

--- a/language/bytecode-verifier/Cargo.toml
+++ b/language/bytecode-verifier/Cargo.toml
@@ -11,7 +11,7 @@ edition = "2018"
 
 [dependencies]
 anyhow = "1.0"
-mirai-annotations = "1.7.0"
+mirai-annotations = "1.8.0"
 petgraph = "0.5.0"
 
 borrow-graph = { path = "../borrow-graph", version = "0.0.1" }

--- a/language/functional-tests/Cargo.toml
+++ b/language/functional-tests/Cargo.toml
@@ -25,6 +25,6 @@ thiserror = "1.0"
 aho-corasick = "0.7.10"
 termcolor = "1.0.5"
 datatest-stable = { path = "../../common/datatest-stable", version = "0.1.0" }
-mirai-annotations = "1.7.0"
+mirai-annotations = "1.8.0"
 move-core-types = { path = "../move-core/types", version = "0.1.0" }
 stdlib = { path = "../stdlib", version = "0.1.0" }

--- a/language/libra-vm/Cargo.toml
+++ b/language/libra-vm/Cargo.toml
@@ -12,7 +12,7 @@ edition = "2018"
 [dependencies]
 once_cell = "1.3.1"
 rayon = "1.1"
-mirai-annotations = "1.7.0"
+mirai-annotations = "1.8.0"
 
 bytecode-verifier = { path = "../bytecode-verifier", version = "0.1.0" }
 lcs = { path = "../../common/lcs", version = "0.1.0", package = "libra-canonical-serialization" }

--- a/language/move-core/types/Cargo.toml
+++ b/language/move-core/types/Cargo.toml
@@ -12,7 +12,7 @@ edition = "2018"
 [dependencies]
 anyhow = "1.0"
 proptest = { version = "0.9.6", default-features = false, optional = true }
-mirai-annotations = "1.5.0"
+mirai-annotations = "1.8.0"
 proptest-derive = { version = "0.1.2", default-features = false, optional = true }
 ref-cast = "1.0"
 serde = { version = "1.0.106", default-features = false }

--- a/language/move-vm/natives/Cargo.toml
+++ b/language/move-vm/natives/Cargo.toml
@@ -14,7 +14,7 @@ edition = "2018"
 [dependencies]
 bit-vec = "0.6.2"
 once_cell = "1.3.1"
-mirai-annotations = "1.7.0"
+mirai-annotations = "1.8.0"
 sha2 = "0.8.0"
 
 libra-crypto = { path = "../../../crypto/crypto", version = "0.1.0" }

--- a/language/move-vm/runtime/Cargo.toml
+++ b/language/move-vm/runtime/Cargo.toml
@@ -12,7 +12,7 @@ edition = "2018"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-mirai-annotations = "1.7.0"
+mirai-annotations = "1.8.0"
 
 bytecode-verifier = { path = "../../bytecode-verifier", version = "0.1.0" }
 libra-crypto = { path = "../../../crypto/crypto", version = "0.1.0" }

--- a/language/move-vm/types/Cargo.toml
+++ b/language/move-vm/types/Cargo.toml
@@ -11,7 +11,7 @@ edition = "2018"
 
 [dependencies]
 bit-vec = "0.6.2"
-mirai-annotations = "1.7.0"
+mirai-annotations = "1.8.0"
 once_cell = "1.3.1"
 proptest = { version = "0.9.6", optional = true }
 sha2 = "0.8.0"

--- a/language/tools/test-generation/Cargo.toml
+++ b/language/tools/test-generation/Cargo.toml
@@ -12,7 +12,7 @@ edition = "2018"
 [dependencies]
 rand = "0.7.3"
 num_cpus = "1.13.0"
-mirai-annotations = "1.7.0"
+mirai-annotations = "1.8.0"
 structopt = "0.3.14"
 itertools = "0.9.0"
 hex = "0.4.2"

--- a/language/transaction-builder/Cargo.toml
+++ b/language/transaction-builder/Cargo.toml
@@ -9,7 +9,7 @@ license = "Apache-2.0"
 edition = "2018"
 
 [dependencies]
-mirai-annotations = "1.7.0"
+mirai-annotations = "1.8.0"
 
 libra-config = { path = "../../config", version = "0.1.0" }
 stdlib = { path = "../stdlib", version = "0.1.0" }

--- a/language/vm/Cargo.toml
+++ b/language/vm/Cargo.toml
@@ -13,7 +13,7 @@ edition = "2018"
 anyhow = "1.0"
 byteorder = "1.3.2"
 once_cell = "1.3.1"
-mirai-annotations = "1.7.0"
+mirai-annotations = "1.8.0"
 proptest = { version = "0.9.6", optional = true }
 proptest-derive = { version = "0.1.2", optional = true }
 ref-cast = "1.0"

--- a/mempool/Cargo.toml
+++ b/mempool/Cargo.toml
@@ -27,7 +27,7 @@ libra-metrics = { path = "../common/metrics", version = "0.1.0" }
 libra-security-logger = { path = "../common/security-logger", version = "0.1.0" }
 libra-types = { path = "../types", version = "0.1.0" }
 libra-workspace-hack = { path = "../common/workspace-hack", version = "0.1.0" }
-mirai-annotations = "1.7.0"
+mirai-annotations = "1.8.0"
 network = { path = "../network", version = "0.1.0" }
 serde_json = "1.0"
 storage-interface = { path = "../storage/storage-interface", version = "0.1.0" }

--- a/storage/accumulator/Cargo.toml
+++ b/storage/accumulator/Cargo.toml
@@ -12,7 +12,7 @@ edition = "2018"
 [dependencies]
 anyhow = "1.0"
 libra-crypto = { path = "../../crypto/crypto", version = "0.1.0" }
-mirai-annotations = "1.7.0"
+mirai-annotations = "1.8.0"
 libra-types = { path = "../../types", version = "0.1.0" }
 libra-workspace-hack = { path = "../../common/workspace-hack", version = "0.1.0" }
 

--- a/storage/jellyfish-merkle/Cargo.toml
+++ b/storage/jellyfish-merkle/Cargo.toml
@@ -12,7 +12,7 @@ edition = "2018"
 [dependencies]
 anyhow = "1.0"
 byteorder = "1.3.2"
-mirai-annotations = "1.7.0"
+mirai-annotations = "1.8.0"
 num-derive = "0.3.0"
 num-traits = "0.2"
 proptest = { version = "0.9.6", optional = true }

--- a/types/Cargo.toml
+++ b/types/Cargo.toml
@@ -16,7 +16,7 @@ chrono = { version = "0.4.11", default-features = false, features = ["clock"] }
 hex = "0.4.2"
 itertools = { version = "0.9.0", default-features = false }
 once_cell = "1.3.1"
-mirai-annotations = "1.7.0"
+mirai-annotations = "1.8.0"
 proptest = { version = "0.9.6", default-features = false, optional = true }
 proptest-derive = { version = "0.1.2", default-features = false, optional = true }
 prost = "0.6"


### PR DESCRIPTION
<!--
Thank you for sending a PR. We appreciate you spending time to help improve the Libra project.

The project is undergoing daily changes. Pull Requests will be reviewed and responded to as time permits.
-->

## Motivation

Unit tests appear to need a 2xLarge+ again with the mirai update, at least while linking in homu managed auto builds.

### Have you read the [Contributing Guidelines on pull requests]

y

## Test Plan

watch ci not oom during ld

## Related PRs

https://github.com/libra/libra/pull/3773

with two consecutive failures in auto branch unit testing during linkage:

https://app.circleci.com/pipelines/github/libra/libra/16167/workflows/2f59143e-2e34-4687-9b29-b6524caac6ff/jobs/82462
and
https://app.circleci.com/pipelines/github/libra/libra/16161/workflows/8db55c38-2f2e-4254-b6b9-731ee7e48c42/jobs/82400

