### PR TITLE
[language] Add basic Move VM tracing, coverage map, and code coverage display

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -756,6 +756,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "colored"
+version = "1.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "atty 0.2.14 (registry+https://github.com/rust-lang/crates.io-index)",
+ "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "compiler"
 version = "0.1.0"
 dependencies = [
@@ -1178,10 +1188,12 @@ dependencies = [
  "anyhow 1.0.28 (registry+https://github.com/rust-lang/crates.io-index)",
  "bytecode-source-map 0.1.0",
  "bytecode-verifier 0.1.0",
+ "colored 1.9.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "ir-to-bytecode-syntax 0.1.0",
  "libra-types 0.1.0",
  "libra-workspace-hack 0.1.0",
  "move-core-types 0.1.0",
+ "move-coverage 0.1.0",
  "move-ir-types 0.1.0",
  "structopt 0.3.14 (registry+https://github.com/rust-lang/crates.io-index)",
  "vm 0.1.0",
@@ -3060,6 +3072,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "move-coverage"
+version = "0.1.0"
+dependencies = [
+ "anyhow 1.0.28 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libra-canonical-serialization 0.1.0",
+ "libra-types 0.1.0",
+ "libra-workspace-hack 0.1.0",
+ "move-core-types 0.1.0",
+ "once_cell 1.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.106 (registry+https://github.com/rust-lang/crates.io-index)",
+ "structopt 0.3.14 (registry+https://github.com/rust-lang/crates.io-index)",
+ "vm 0.1.0",
+]
+
+[[package]]
 name = "move-ir-types"
 version = "0.1.0"
 dependencies = [
@@ -3162,6 +3189,7 @@ dependencies = [
  "move-vm-natives 0.1.0",
  "move-vm-state 0.1.0",
  "move-vm-types 0.1.0",
+ "once_cell 1.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "proptest 0.9.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "vm 0.1.0",
 ]
@@ -6399,6 +6427,7 @@ dependencies = [
 "checksum cloudabi 0.0.3 (registry+https://github.com/rust-lang/crates.io-index)" = "ddfc5b9aa5d4507acaf872de71051dfd0e309860e88966e1051e462a077aac4f"
 "checksum codespan 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)" = "52899426b69706219a1aaee2e95868fd01a0bd8006bb163f069578a0af5b5bb2"
 "checksum codespan-reporting 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)" = "600c3317d4705222ff820139aaa76a3a208024ffc41f894da565a4c3b949d4c9"
+"checksum colored 1.9.3 (registry+https://github.com/rust-lang/crates.io-index)" = "f4ffc801dacf156c5854b9df4f425a626539c3a6ef7893cc0c5084a23f0b6c59"
 "checksum constant_time_eq 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "245097e9a4535ee1e3e3931fcfcd55a796a44c643e8596ff6566d68f09b87bbc"
 "checksum cookie 0.13.3 (registry+https://github.com/rust-lang/crates.io-index)" = "0c60ef6d0bbf56ad2674249b6bb74f2c6aeb98b98dd57b5d3e37cace33011d69"
 "checksum core-foundation 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "57d24c7a13c43e870e37c1556b74555437870a04514f7685f5b354e090567171"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -77,6 +77,7 @@ members = [
     "language/stdlib",
     "language/tools/disassembler",
     "language/tools/genesis-viewer",
+    "language/tools/move-coverage",
     "language/tools/test-generation",
     "language/tools/utils",
     "language/tools/vm-genesis",

--- a/language/move-vm/runtime/Cargo.toml
+++ b/language/move-vm/runtime/Cargo.toml
@@ -13,6 +13,7 @@ edition = "2018"
 
 [dependencies]
 mirai-annotations = "1.8.0"
+once_cell = "1.3.1"
 
 bytecode-verifier = { path = "../../bytecode-verifier", version = "0.1.0" }
 libra-crypto = { path = "../../../crypto/crypto", version = "0.1.0" }

--- a/language/move-vm/runtime/src/interpreter.rs
+++ b/language/move-vm/runtime/src/interpreter.rs
@@ -5,6 +5,7 @@ use crate::{
     gas,
     loader::{Function, Loader, Resolver},
     native_functions::FunctionContext,
+    trace,
 };
 use libra_logger::prelude::*;
 use libra_types::{
@@ -679,6 +680,7 @@ impl Frame {
         let code = self.function.code();
         loop {
             for instruction in &code[self.pc as usize..] {
+                trace!(self.function.pretty_string(), self.pc, instruction);
                 self.pc += 1;
 
                 match instruction {

--- a/language/move-vm/runtime/src/lib.rs
+++ b/language/move-vm/runtime/src/lib.rs
@@ -18,5 +18,7 @@ mod loader;
 mod move_vm;
 mod native_functions;
 mod runtime;
+#[macro_use]
+mod tracing;
 
 pub use move_vm::*;

--- a/language/move-vm/runtime/src/tracing.rs
+++ b/language/move-vm/runtime/src/tracing.rs
@@ -1,0 +1,55 @@
+// Copyright (c) The Libra Core Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+#[cfg(debug_assertions)]
+use once_cell::sync::Lazy;
+#[cfg(debug_assertions)]
+use std::{
+    env,
+    fs::{File, OpenOptions},
+    io::Write,
+    sync::Mutex,
+};
+#[cfg(debug_assertions)]
+use vm::file_format::Bytecode;
+
+#[cfg(debug_assertions)]
+const MOVE_VM_TRACING_ENV_VAR_NAME: &str = "MOVE_VM_TRACE";
+
+#[cfg(debug_assertions)]
+static FILE_PATH: Lazy<String> = Lazy::new(|| {
+    env::var(MOVE_VM_TRACING_ENV_VAR_NAME).unwrap_or_else(|_| "move_vm_trace.trace".to_string())
+});
+
+#[cfg(debug_assertions)]
+static TRACING_ENABLED: Lazy<bool> = Lazy::new(|| env::var(MOVE_VM_TRACING_ENV_VAR_NAME).is_ok());
+
+#[cfg(debug_assertions)]
+static LOGGING_FILE: Lazy<Mutex<File>> = Lazy::new(|| {
+    Mutex::new(
+        OpenOptions::new()
+            .write(true)
+            .create(true)
+            .append(true)
+            .open(&*FILE_PATH)
+            .unwrap(),
+    )
+});
+
+// Only include in debug builds
+#[cfg(debug_assertions)]
+pub fn trace(function_desc: &str, pc: u16, instr: &Bytecode) {
+    if *TRACING_ENABLED {
+        let f = &mut *LOGGING_FILE.lock().unwrap();
+        writeln!(f, "{},{},{:?}", function_desc, pc, instr).unwrap();
+    }
+}
+
+#[macro_export]
+macro_rules! trace {
+    ($function_desc:expr, $pc:expr, $instr:tt) => {
+        // Only include this code in debug releases
+        #[cfg(debug_assertions)]
+        crate::tracing::trace(&$function_desc, $pc, &$instr)
+    };
+}

--- a/language/tools/disassembler/Cargo.toml
+++ b/language/tools/disassembler/Cargo.toml
@@ -8,6 +8,8 @@ edition = "2018"
 
 [dependencies]
 anyhow = "1.0"
+colored = "1.9.3"
+
 bytecode-verifier = { path = "../../bytecode-verifier", version = "0.1.0" }
 bytecode-source-map = { path = "../../compiler/bytecode-source-map", version = "0.1.0" }
 ir-to-bytecode-syntax = { path = "../../compiler/ir-to-bytecode/syntax", version = "0.1.0" }
@@ -16,9 +18,9 @@ libra-workspace-hack = { path = "../../../common/workspace-hack", version = "0.1
 move-core-types = { path = "../../move-core/types", version = "0.1.0" }
 move-ir-types = { path = "../../move-ir/types", version = "0.1.0" }
 vm = { path = "../../vm", version = "0.1.0" }
+move-coverage = { path = "../move-coverage", version = "0.1.0" }
 
 structopt = "0.3.14"
 
 [features]
 default = []
-fuzzing = ["libra-types/fuzzing"]

--- a/language/tools/move-coverage/Cargo.toml
+++ b/language/tools/move-coverage/Cargo.toml
@@ -1,0 +1,26 @@
+[package]
+name = "move-coverage"
+version = "0.1.0"
+authors = ["Libra Association <opensource@libra.org>"]
+description = "Libra Move VM code coverage"
+repository = "https://github.com/libra/libra"
+homepage = "https://libra.org"
+license = "Apache-2.0"
+publish = false
+edition = "2018"
+
+[dependencies]
+once_cell = "1.3.1"
+structopt = "0.3.14"
+serde = { version = "1.0.106", default-features = false }
+anyhow = "1.0"
+
+lcs = { path = "../../../common/lcs", version = "0.1.0", package = "libra-canonical-serialization" }
+libra-types = { path = "../../../types", version = "0.1.0" }
+move-core-types = { path = "../../move-core/types", version = "0.1.0" }
+libra-workspace-hack = { path = "../../../common/workspace-hack", version = "0.1.0" }
+vm = { path = "../../vm", version = "0.1.0" }
+
+[features]
+default = []
+fuzzing = ["libra-types/fuzzing"]

--- a/language/tools/move-coverage/src/coverage_map.rs
+++ b/language/tools/move-coverage/src/coverage_map.rs
@@ -1,0 +1,100 @@
+// Copyright (c) The Libra Core Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+#![forbid(unsafe_code)]
+
+use anyhow::{format_err, Result};
+use libra_types::account_address::AccountAddress;
+use move_core_types::identifier::{IdentStr, Identifier};
+use serde::{Deserialize, Serialize};
+use std::{
+    collections::BTreeMap,
+    fs::File,
+    io::{BufRead, BufReader, Read, Write},
+    path::Path,
+};
+
+pub type FunctionCoverage = BTreeMap<u64, u64>;
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct CoverageMap {
+    pub module_maps: BTreeMap<(AccountAddress, Identifier), ModuleCoverageMap>,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct ModuleCoverageMap {
+    pub module_addr: AccountAddress,
+    pub module_name: Identifier,
+    pub function_maps: BTreeMap<Identifier, FunctionCoverage>,
+}
+
+impl CoverageMap {
+    /// Takes in a file containing a raw VM trace, and returns a coverage map.
+    pub fn from_trace_file<P: AsRef<Path>>(filename: P) -> Self {
+        let file = File::open(filename).unwrap();
+        let mut module_maps = BTreeMap::new();
+        for line in BufReader::new(file).lines() {
+            let line = line.unwrap();
+            let mut splits = line.split(',');
+            let context = splits.next().unwrap();
+            let pc = splits.next().unwrap().parse::<u64>().unwrap();
+
+            let mut context_segs: Vec<_> = context.split("::").collect();
+            let is_script = context_segs.len() == 2;
+            // Don't count scripts (for now)
+            if !is_script {
+                let func_name = Identifier::new(context_segs.pop().unwrap()).unwrap();
+                let module_name = Identifier::new(context_segs.pop().unwrap()).unwrap();
+                let addr = AccountAddress::from_hex_literal(context_segs.pop().unwrap()).unwrap();
+                let entry = module_maps
+                    .entry((addr, module_name.clone()))
+                    .or_insert_with(|| ModuleCoverageMap::new(addr, module_name));
+                entry.insert(func_name, pc);
+            }
+        }
+        CoverageMap { module_maps }
+    }
+
+    /// Takes in a file containing a serialized coverage map and returns a coverage map.
+    pub fn from_binary_file<P: AsRef<Path>>(filename: P) -> Self {
+        let mut bytes = Vec::new();
+        File::open(filename)
+            .ok()
+            .and_then(|mut file| file.read_to_end(&mut bytes).ok())
+            .ok_or_else(|| format_err!("Error while reading in coverage map binary"))
+            .unwrap();
+        lcs::from_bytes(&bytes)
+            .map_err(|_| format_err!("Error deserializing into coverage map"))
+            .unwrap()
+    }
+}
+
+impl ModuleCoverageMap {
+    pub fn new(module_addr: AccountAddress, module_name: Identifier) -> Self {
+        ModuleCoverageMap {
+            module_addr,
+            module_name,
+            function_maps: BTreeMap::new(),
+        }
+    }
+
+    pub fn insert(&mut self, func_name: Identifier, pc: u64) {
+        let func_entry = self
+            .function_maps
+            .entry(func_name)
+            .or_insert_with(FunctionCoverage::new);
+        let pc_entry = func_entry.entry(pc).or_insert(0);
+        *pc_entry += 1;
+    }
+
+    pub fn get_function_coverage(&self, func_name: &IdentStr) -> Option<&FunctionCoverage> {
+        self.function_maps.get(func_name)
+    }
+}
+
+pub fn output_map_to_file<M: Serialize, P: AsRef<Path>>(file_name: P, data: &M) -> Result<()> {
+    let bytes = lcs::to_bytes(data)?;
+    let mut file = File::create(file_name)?;
+    file.write_all(&bytes)?;
+    Ok(())
+}

--- a/language/tools/move-coverage/src/lib.rs
+++ b/language/tools/move-coverage/src/lib.rs
@@ -1,0 +1,4 @@
+// Copyright (c) The Libra Core Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+pub mod coverage_map;

--- a/language/tools/move-coverage/src/main.rs
+++ b/language/tools/move-coverage/src/main.rs
@@ -1,0 +1,32 @@
+// Copyright (c) The Libra Core Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+#![forbid(unsafe_code)]
+
+use move_coverage::coverage_map::{output_map_to_file, CoverageMap};
+use std::path::Path;
+use structopt::StructOpt;
+
+#[derive(Debug, StructOpt)]
+#[structopt(
+    name = "Move VM Coverage",
+    about = "Creates a coverage map from the raw data collected from the Move VM"
+)]
+struct Args {
+    /// The path to the input file
+    #[structopt(long = "input-file-path", short = "f")]
+    pub input_file_path: String,
+    /// The path to the output file location
+    #[structopt(long = "output-file-path", short = "o")]
+    pub output_file_path: String,
+}
+
+fn main() {
+    let args = Args::from_args();
+    let input_path = Path::new(&args.input_file_path);
+    let output_path = Path::new(&args.output_file_path);
+
+    let coverage_map = CoverageMap::from_trace_file(&input_path);
+    output_map_to_file(&output_path, &coverage_map)
+        .expect("Unable to serialize coverage map to output file")
+}


### PR DESCRIPTION
Adds a basic tracing functionality to the Move VM, and adds a basic utility for building an in-memory coverage map from a trace file. There is more work left here to make the tracing efficient, but that is something that can be worked on over time.

A couple things
* Tracing code in the interpreter loop is completely elided in `release` builds (so should add zero "real-world" overhead). 
* In debug builds with tracing turned off, tracing overhead should be fairly minimal (an function call and an `if`).
* Tracing can be turned on by setting the `MOVE_VM_TRACE` variable to the filename where you wish the trace to be stored.
* A tracing file can optionally be supplied to the dissembler to provide code coverage reporting (see attached screenshot).


An example of the raw trace that is output:
```
0x00000000000000000000000000000000::Genesis::initialize_association,0,Call(5)
0x00000000000000000000000000000000::Association::initialize,0,GetTxnSenderAddress
0x00000000000000000000000000000000::Association::initialize,1,Call(11)
0x00000000000000000000000000000000::Association::root_address,0,LdConst(0)
0x00000000000000000000000000000000::Association::root_address,1,Ret
0x00000000000000000000000000000000::Association::initialize,2,Eq
0x00000000000000000000000000000000::Association::initialize,3,StLoc(1)
0x00000000000000000000000000000000::Association::initialize,4,MoveLoc(1)
0x00000000000000000000000000000000::Association::initialize,5,BrTrue(7)
0x00000000000000000000000000000000::Association::initialize,7,Branch(10)
0x00000000000000000000000000000000::Association::initialize,10,LdFalse
0x00000000000000000000000000000000::Association::initialize,11,Pack(1)
0x00000000000000000000000000000000::Association::initialize,12,MoveToSender(StructDefinitionIndex(1))
0x00000000000000000000000000000000::Association::initialize,13,LdTrue
0x00000000000000000000000000000000::Association::initialize,14,PackGeneric(0)
0x00000000000000000000000000000000::Association::initialize,15,MoveToSenderGeneric(StructDefInstantiationIndex(0))
0x00000000000000000000000000000000::Association::initialize,16,Ret
0x00000000000000000000000000000000::Genesis::initialize_association,1,CallGeneric(7)
0x00000000000000000000000000000000::Association::apply_for_privilege,0,GetTxnSenderAddress
0x00000000000000000000000000000000::Association::apply_for_privilege,1,ExistsGeneric(StructDefInstantiationIndex(1))
0x00000000000000000000000000000000::Association::apply_for_privilege,2,BrTrue(4)
0x00000000000000000000000000000000::Association::apply_for_privilege,3,Branch(5)
0x00000000000000000000000000000000::Association::apply_for_privilege,5,LdFalse
0x00000000000000000000000000000000::Association::apply_for_privilege,6,PackGeneric(1)
0x00000000000000000000000000000000::Association::apply_for_privilege,7,MoveToSenderGeneric(StructDefInstantiationIndex(1))
0x00000000000000000000000000000000::Association::apply_for_privilege,8,Ret
0x00000000000000000000000000000000::Genesis::initialize_association,2,CopyLoc(0)
0x00000000000000000000000000000000::Genesis::initialize_association,3,CallGeneric(8)
0x00000000000000000000000000000000::Association::grant_privilege,0,Call(5)
```

And an example of the `CoverageMap` that is built from this in `move-coverage`:
```rust
CoverageMap {
    module_maps: {
        (
            "0x00000000000000000000000000000000",
            "AccountLimits",
        ): ModuleMap {
            module_addr: "0x00000000000000000000000000000000",
            module_name: "AccountLimits",
            function_maps: {
                "certify_limits_definition": {
                    0: 1,
                    1: 1,
                    2: 1,
                    3: 1,
                    4: 1,
                    5: 1,
                    6: 1,
                },
                "grant_account_tracking": {
                    0: 1,
                    1: 1,
                    2: 1,
                    3: 1,
                    5: 1,
                    8: 1,
                    9: 1,
                    10: 1,
                },
                "publish_limits_definition": {
                    0: 1,
                    1: 1,
                    2: 1,
                    3: 1,
                    4: 1,
                    5: 1,
                    6: 1,
                    7: 1,
                    8: 1,
                    9: 1,
                    10: 1,
                    11: 1,
                    12: 1,
                    13: 1,
                    14: 1,
                    15: 1,
                },
                "publish_unrestricted_limits": {
                    0: 1,
                    1: 1,
                    2: 1,
                    3: 1,
                    4: 1,
                    5: 1,
                    6: 1,
                    7: 1,
                },
            },
        },
```

Calling the dissembler, and passing a trace file in: 
```
cargo run -p disassembler -- -b ../../move-lang/move_build_output/modules/0_Association.mv -c my_trace
```

Will result in output like this:

![Screen Shot 2020-05-07 at 4 40 21 PM](https://user-images.githubusercontent.com/2895723/81356235-93074a00-9085-11ea-8323-6093b8245fb1.png)

 