### PR TITLE
[x] move direct-dep-dups linter to x

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -197,14 +197,6 @@ jobs:
       - run:
           name: cargo fmt
           command: cargo xfmt --check
-      - run:
-          name: cargo guppy
-          command: |
-            cargo install cargo-guppy \
-              --git http://github.com/calibra/cargo-guppy \
-              --rev 8b2bc45c0cd6323a7a2b8170ddad6d2a5b79047b
-            [[ -z $(cargo guppy dups --target x86_64-unknown-linux-gnu \
-              --kind directthirdparty) ]]
   build-dev:
     executor: build-executor
     description: Development Build

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1649,7 +1649,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "guppy"
-version = "0.4.0"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "cargo_metadata 0.9.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -6250,7 +6250,7 @@ dependencies = [
  "anyhow 1.0.28 (registry+https://github.com/rust-lang/crates.io-index)",
  "chrono 0.4.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "env_logger 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "guppy 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "guppy 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "libra-workspace-hack 0.1.0",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.106 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -6265,7 +6265,7 @@ dependencies = [
 name = "x-core"
 version = "0.1.0"
 dependencies = [
- "guppy 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "guppy 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "libra-workspace-hack 0.1.0",
  "once_cell 1.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -6274,7 +6274,7 @@ dependencies = [
 name = "x-lint"
 version = "0.1.0"
 dependencies = [
- "guppy 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "guppy 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "libra-workspace-hack 0.1.0",
  "once_cell 1.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "x-core 0.1.0",
@@ -6459,7 +6459,7 @@ dependencies = [
 "checksum getrandom 0.1.14 (registry+https://github.com/rust-lang/crates.io-index)" = "7abc8dd8451921606d809ba32e95b6111925cd2906060d2dcc29c070220503eb"
 "checksum ghash 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "9f0930ed19a7184089ea46d2fedead2f6dc2b674c5db4276b7da336c7cd83252"
 "checksum glob 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "9b919933a397b79c37e33b77bb2aa3dc8eb6e165ad809e58ff75bc7db2e34574"
-"checksum guppy 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "44289950b618086aaaaa9caaff6452871a0f4c63dd3d734899fdc276ab3f71e7"
+"checksum guppy 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)" = "a830ab35ef74099bb82f0c0ea223c4a9876e4ad3ccf103059ce5277f5dd5a5f6"
 "checksum h2 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "9d5c295d1c0c68e4e42003d75f908f5e16a1edd1cbe0b0d02e4dc2006a384f47"
 "checksum headers 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "a72b4bd7cbbf0c22190e82f02517f456a6b9be24c25a6827b5802e478b8c2d70"
 "checksum headers-core 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "e7f66481bfee273957b1f20485a4ff3362987f85b2c236580d81b4eb7a326429"

--- a/devtools/x-core/Cargo.toml
+++ b/devtools/x-core/Cargo.toml
@@ -8,6 +8,6 @@ publish = false
 license = "Apache-2.0"
 
 [dependencies]
-guppy = "0.4.0"
+guppy = "0.4.1"
 libra-workspace-hack = { path = "../../common/workspace-hack", version = "0.1.0" }
 once_cell = "1.3.1"

--- a/devtools/x-lint/Cargo.toml
+++ b/devtools/x-lint/Cargo.toml
@@ -8,7 +8,7 @@ publish = false
 license = "Apache-2.0"
 
 [dependencies]
-guppy = "0.4.0"
+guppy = "0.4.1"
 libra-workspace-hack = { path = "../../common/workspace-hack", version = "0.1.0" }
 once_cell = "1.3.1"
 x-core = { version = "0.1.0", path = "../x-core" }

--- a/devtools/x/Cargo.toml
+++ b/devtools/x/Cargo.toml
@@ -12,7 +12,7 @@ serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0.52"
 structopt = "0.3.14"
 anyhow = "1.0"
-guppy = "0.4.0"
+guppy = "0.4.1"
 toml = "0.5.6"
 env_logger = "0.7.1"
 log = "0.4.8"

--- a/devtools/x/src/lint/guppy.rs
+++ b/devtools/x/src/lint/guppy.rs
@@ -4,7 +4,11 @@
 //! Project and package linters that run queries on guppy.
 
 use crate::config::EnforcedAttributesConfig;
-use std::{collections::HashMap, ffi::OsStr};
+use guppy::Version;
+use std::{
+    collections::{BTreeMap, HashMap},
+    ffi::OsStr,
+};
 use x_lint::prelude::*;
 
 /// Ban certain crates from being used as direct dependencies.
@@ -232,6 +236,57 @@ impl PackageLinter for IrrelevantBuildDeps {
 
         if !metadata.has_build_script() && has_build_dep {
             out.write(LintLevel::Error, "build dependencies but no build script");
+        }
+
+        Ok(RunStatus::Executed)
+    }
+}
+
+/// Ensure that packages within the workspace only depend on one version of a third-party crate.
+#[derive(Debug)]
+pub struct DirectDepDups;
+
+impl Linter for DirectDepDups {
+    fn name(&self) -> &'static str {
+        "direct-dep-dups"
+    }
+}
+
+impl ProjectLinter for DirectDepDups {
+    fn run<'l>(
+        &self,
+        ctx: &ProjectContext<'l>,
+        out: &mut LintFormatter<'l, '_>,
+    ) -> Result<RunStatus<'l>> {
+        let package_graph = ctx.package_graph()?;
+
+        // This is a map of direct deps by name -> version -> packages that depend on it.
+        let mut direct_deps: BTreeMap<&str, BTreeMap<&Version, Vec<&str>>> = BTreeMap::new();
+        package_graph.query_workspace().resolve_with_fn(|_, link| {
+            // Collect direct dependencies of workspace packages.
+            let (from, to) = link.endpoints();
+            if from.in_workspace() && !to.in_workspace() {
+                direct_deps
+                    .entry(to.name())
+                    .or_default()
+                    .entry(to.version())
+                    .or_default()
+                    .push(from.name());
+            }
+            // query_workspace + preventing further traversals will mean that only direct
+            // dependencies are considered.
+            false
+        });
+        for (direct_dep, versions) in direct_deps {
+            if versions.len() > 1 {
+                let mut msg = format!("duplicate direct dependency '{}':\n", direct_dep);
+                for (version, packages) in versions {
+                    msg.push_str(&format!("  * {} (", version));
+                    msg.push_str(&packages.join(", "));
+                    msg.push_str(")\n");
+                }
+                out.write(LintLevel::Error, msg);
+            }
         }
 
         Ok(RunStatus::Executed)

--- a/devtools/x/src/lint/mod.rs
+++ b/devtools/x/src/lint/mod.rs
@@ -19,9 +19,10 @@ pub struct Args {
 pub fn run(args: Args, xctx: XContext) -> crate::Result<()> {
     let workspace_config = xctx.config().workspace_config();
 
-    let project_linters: &[&dyn ProjectLinter] = &[&guppy::BannedDirectDeps::new(
-        &workspace_config.banned_direct_deps,
-    )];
+    let project_linters: &[&dyn ProjectLinter] = &[
+        &guppy::BannedDirectDeps::new(&workspace_config.banned_direct_deps),
+        &guppy::DirectDepDups,
+    ];
 
     let package_linters: &[&dyn PackageLinter] = &[
         &guppy::EnforcedAttributes::new(&workspace_config.enforced_attributes),


### PR DESCRIPTION
This currently lives in cargo-guppy + circleci, but is better expressed as a 
guppy lint.

The error looks like:

```
[ERROR] [direct-dep-dups] [project]: duplicate direct dependency 'ureq':
  * 0.12.1 (libra-secure-json-rpc, cli, libra-secure-push-metrics)
  * 1.0.0 (libra-vault-client)
```
