### PR TITLE
[Config Management] Add a global-constants crate to define constants that span multiple Libra crates/components.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2410,6 +2410,7 @@ dependencies = [
  "futures 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "libra-config 0.1.0",
  "libra-crypto 0.1.0",
+ "libra-global-constants 0.1.0",
  "libra-json-rpc 0.1.0",
  "libra-logger 0.1.0",
  "libra-secure-json-rpc 0.1.0",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4556,6 +4556,7 @@ dependencies = [
  "libra-canonical-serialization 0.1.0",
  "libra-config 0.1.0",
  "libra-crypto 0.1.0",
+ "libra-global-constants 0.1.0",
  "libra-logger 0.1.0",
  "libra-secure-net 0.1.0",
  "libra-secure-push-metrics 0.1.0",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2333,6 +2333,10 @@ dependencies = [
 ]
 
 [[package]]
+name = "libra-global-constants"
+version = "0.1.0"
+
+[[package]]
 name = "libra-json-rpc"
 version = "0.1.0"
 dependencies = [
@@ -2445,6 +2449,7 @@ version = "0.1.0"
 dependencies = [
  "libra-config 0.1.0",
  "libra-crypto 0.1.0",
+ "libra-global-constants 0.1.0",
  "libra-network-address 0.1.0",
  "libra-secure-storage 0.1.0",
  "libra-secure-time 0.1.0",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,6 +30,7 @@ members = [
     "config",
     "config/config-builder",
     "config/generate-key",
+    "config/global-constants",
     "config/management",
     "consensus",
     "consensus/consensus-types",

--- a/config/global-constants/Cargo.toml
+++ b/config/global-constants/Cargo.toml
@@ -1,0 +1,10 @@
+[package]
+name = "libra-global-constants"
+version = "0.1.0"
+authors = ["Libra Association <opensource@libra.org>"]
+description = "Libra's global constant crate: the source of truth for constant definitions that span multiple crates"
+repository = "https://github.com/libra/libra"
+homepage = "https://libra.org"
+license = "Apache-2.0"
+publish = false
+edition = "2018"

--- a/config/global-constants/src/lib.rs
+++ b/config/global-constants/src/lib.rs
@@ -1,0 +1,23 @@
+// Copyright (c) The Libra Core Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+//! The purpose of this crate is to offer a single source of truth for the definitions of shared
+//! constants within the Libra codebase. This is useful because many different components within
+//! Libra often require access to global constant definitions (e.g., Libra Safety Rules,
+//! the Key Manager, and Secure Storage). To avoid duplicating these definitions across crates
+//! (and better allow these constants to be updated in a single location), we define them here.
+#![forbid(unsafe_code)]
+
+/// Definitions of global cryptographic keys (e.g., as held in secure storage)
+pub const ASSOCIATION_KEY: &str = "association";
+pub const CONSENSUS_KEY: &str = "consensus";
+pub const FULLNODE_NETWORK_KEY: &str = "fullnode_network";
+pub const OPERATOR_KEY: &str = "operator";
+pub const OWNER_KEY: &str = "owner";
+pub const VALIDATOR_NETWORK_KEY: &str = "validator_network";
+
+/// Definitions of global data items (e.g., as held in secure storage)
+pub const EPOCH: &str = "epoch";
+pub const LAST_VOTED_ROUND: &str = "last_voted_round";
+pub const PREFERRED_ROUND: &str = "preferred_round";
+pub const WAYPOINT: &str = "waypoint";

--- a/config/management/Cargo.toml
+++ b/config/management/Cargo.toml
@@ -17,6 +17,7 @@ toml = { version = "0.5.3", default-features = false }
 
 libra-config = { path = "..", version = "0.1.0" }
 libra-crypto = { path = "../../crypto/crypto", version = "0.1.0" }
+libra-global-constants = { path = "../../config/global-constants", version = "0.1.0"}
 libra-network-address = { path = "../../network/network-address", version = "0.1.0" }
 libra-secure-storage = { path = "../../secure/storage", version = "0.1.0" }
 libra-secure-time = { path = "../../secure/time", version = "0.1.0" }

--- a/config/management/src/genesis.rs
+++ b/config/management/src/genesis.rs
@@ -1,8 +1,14 @@
 // Copyright (c) The Libra Core Contributors
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::{constants, error::Error, layout::Layout, SingleBackend};
+use crate::{
+    error::Error,
+    layout::Layout,
+    management_constants::{COMMON_NS, LAYOUT, VALIDATOR_CONFIG},
+    SingleBackend,
+};
 use libra_crypto::ed25519::Ed25519PublicKey;
+use libra_global_constants::{ASSOCIATION_KEY, OPERATOR_KEY};
 use libra_secure_storage::Storage;
 use libra_types::transaction::{Transaction, TransactionPayload};
 use std::{convert::TryInto, path::PathBuf};
@@ -43,7 +49,7 @@ impl Genesis {
         let association: Box<dyn Storage> = association_config.try_into()?;
 
         let association_key = association
-            .get(constants::ASSOCIATION_KEY)
+            .get(ASSOCIATION_KEY)
             .map_err(|e| Error::RemoteStorageReadError(e.to_string()))?;
         association_key
             .value
@@ -56,11 +62,11 @@ impl Genesis {
         let mut common_config = self.backend.backend.clone();
         common_config
             .parameters
-            .insert("namespace".into(), constants::COMMON_NS.into());
+            .insert("namespace".into(), COMMON_NS.into());
         let common: Box<dyn Storage> = common_config.try_into()?;
 
         let layout = common
-            .get(constants::LAYOUT)
+            .get(LAYOUT)
             .map_err(|e| Error::RemoteStorageReadError(e.to_string()))?
             .value
             .string()
@@ -79,14 +85,14 @@ impl Genesis {
             let validator: Box<dyn Storage> = validator_config.try_into()?;
 
             let key = validator
-                .get(constants::OPERATOR_KEY)
+                .get(OPERATOR_KEY)
                 .map_err(|e| Error::RemoteStorageReadError(e.to_string()))?
                 .value
                 .ed25519_public_key()
                 .map_err(|e| Error::RemoteStorageReadError(e.to_string()))?;
 
             let txn = validator
-                .get(constants::VALIDATOR_CONFIG)
+                .get(VALIDATOR_CONFIG)
                 .map_err(|e| Error::RemoteStorageReadError(e.to_string()))?
                 .value;
             let txn = txn.transaction().unwrap();

--- a/config/management/src/layout.rs
+++ b/config/management/src/layout.rs
@@ -1,7 +1,7 @@
 // Copyright (c) The Libra Core Contributors
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::{constants, error::Error, SingleBackend};
+use crate::{error::Error, management_constants::LAYOUT, SingleBackend};
 use libra_secure_storage::{Storage, Value};
 use serde::{Deserialize, Serialize};
 use std::{
@@ -62,7 +62,7 @@ impl SetLayout {
 
         let value = Value::String(data);
         remote
-            .create_with_default_policy(constants::LAYOUT, value)
+            .create_with_default_policy(LAYOUT, value)
             .map_err(|e| Error::RemoteStorageWriteError(e.to_string()))?;
 
         Ok(layout)

--- a/config/src/config/mod.rs
+++ b/config/src/config/mod.rs
@@ -263,7 +263,7 @@ impl NodeConfig {
             test.initialize_storage = true;
             test.random_account_key(rng);
             let peer_id = libra_types::account_address::from_public_key(
-                &test.account_keypair.as_ref().unwrap().public_key(),
+                &test.operator_keypair.as_ref().unwrap().public_key(),
             );
 
             if self.validator_network.is_none() {

--- a/config/src/config/test_config.rs
+++ b/config/src/config/test_config.rs
@@ -17,8 +17,8 @@ type ConsensusKeyPair = KeyPair<Ed25519PrivateKey>;
 #[derive(Debug, Default, Deserialize, Serialize)]
 pub struct TestConfig {
     pub auth_key: Option<AuthenticationKey>,
-    #[serde(rename = "account_private_key")]
-    pub account_keypair: Option<AccountKeyPair>,
+    #[serde(rename = "operator_private_key")]
+    pub operator_keypair: Option<AccountKeyPair>,
     #[serde(rename = "consensus_private_key")]
     pub consensus_keypair: Option<ConsensusKeyPair>,
     // Used to initialize storage defaults in safety rules
@@ -36,7 +36,7 @@ impl Clone for TestConfig {
     fn clone(&self) -> Self {
         Self {
             auth_key: self.auth_key,
-            account_keypair: self.account_keypair.clone(),
+            operator_keypair: self.operator_keypair.clone(),
             consensus_keypair: self.consensus_keypair.clone(),
             initialize_storage: self.initialize_storage,
             temp_dir: None,
@@ -47,7 +47,7 @@ impl Clone for TestConfig {
 
 impl PartialEq for TestConfig {
     fn eq(&self, other: &Self) -> bool {
-        self.account_keypair == other.account_keypair
+        self.operator_keypair == other.operator_keypair
             && self.auth_key == other.auth_key
             && self.consensus_keypair == other.consensus_keypair
             && self.initialize_storage == other.initialize_storage
@@ -58,7 +58,7 @@ impl TestConfig {
     pub fn open_module() -> Self {
         Self {
             auth_key: None,
-            account_keypair: None,
+            operator_keypair: None,
             consensus_keypair: None,
             initialize_storage: false,
             temp_dir: None,
@@ -71,7 +71,7 @@ impl TestConfig {
         temp_dir.create_as_dir().expect("error creating tempdir");
         Self {
             auth_key: None,
-            account_keypair: None,
+            operator_keypair: None,
             consensus_keypair: None,
             initialize_storage: false,
             temp_dir: Some(temp_dir),
@@ -82,7 +82,7 @@ impl TestConfig {
     pub fn random_account_key(&mut self, rng: &mut StdRng) {
         let privkey = Ed25519PrivateKey::generate(rng);
         self.auth_key = Some(AuthenticationKey::ed25519(&privkey.public_key()));
-        self.account_keypair = Some(AccountKeyPair::load(privkey));
+        self.operator_keypair = Some(AccountKeyPair::load(privkey));
     }
 
     pub fn random_consensus_key(&mut self, rng: &mut StdRng) {
@@ -104,7 +104,7 @@ mod test {
     fn verify_test_config_equality_using_keys() {
         // Create default test config without keys
         let mut test_config = TestConfig::new_with_temp_dir();
-        assert_eq!(test_config.account_keypair, None);
+        assert_eq!(test_config.operator_keypair, None);
         assert_eq!(test_config.consensus_keypair, None);
 
         // Clone the config and verify equality
@@ -120,7 +120,7 @@ mod test {
         assert_ne!(clone_test_config, test_config);
 
         // Copy keys across configs
-        clone_test_config.account_keypair = test_config.account_keypair.clone();
+        clone_test_config.operator_keypair = test_config.operator_keypair.clone();
         clone_test_config.consensus_keypair = test_config.consensus_keypair.clone();
         clone_test_config.auth_key = test_config.auth_key;
 

--- a/config/src/config/test_data/random.complete.node.config.toml
+++ b/config/src/config/test_data/random.complete.node.config.toml
@@ -67,7 +67,7 @@ grpc_max_receive_len = 100000000
 
 [test]
 auth_key = "837e3b2b2b32ee2543c24676ee66326431893204fa402143c11b26ce8a89ea1d"
-account_private_key = "f6b898412f4ab061943167c1e23efaa2ba98e345a093f0b06da13bffdbd4b2c7"
+operator_private_key = "f6b898412f4ab061943167c1e23efaa2ba98e345a093f0b06da13bffdbd4b2c7"
 consensus_private_key = "f2b916c8b1bf6123854d2fca5384f128199f7a1b2f847316481429b4b35238cc"
 initialize_storage = true
 

--- a/config/src/config/test_data/random.default.node.config.toml
+++ b/config/src/config/test_data/random.default.node.config.toml
@@ -8,6 +8,6 @@ signing_private_key = "66dd107034b4582a2ef42c5e1ea475f2fea477a10a9f1d75b3635243b
 
 [test]
 auth_key = "837e3b2b2b32ee2543c24676ee66326431893204fa402143c11b26ce8a89ea1d"
-account_private_key ="f6b898412f4ab061943167c1e23efaa2ba98e345a093f0b06da13bffdbd4b2c7"
+operator_private_key ="f6b898412f4ab061943167c1e23efaa2ba98e345a093f0b06da13bffdbd4b2c7"
 consensus_private_key = "f2b916c8b1bf6123854d2fca5384f128199f7a1b2f847316481429b4b35238cc"
 initialize_storage = true

--- a/config/src/config/test_data/single.node.config.toml
+++ b/config/src/config/test_data/single.node.config.toml
@@ -32,7 +32,7 @@ grpc_max_receive_len = 100000000
 
 [test]
 auth_key = "8e0d19280063fa870fe4dbb85cc724091a398451c5c11e1e76e64cdc7b588510"
-account_private_key = "76b8e0ada0f13d90405d6ae55386bd28bdd219b8a08ded1aa836efcc8b770dc7"
+operator_private_key = "76b8e0ada0f13d90405d6ae55386bd28bdd219b8a08ded1aa836efcc8b770dc7"
 consensus_private_key = "29b721769ce64e43d57133b074d839d531ed1f28510afb45ace10a1f4b794d6f"
 initialize_storage = true
 

--- a/consensus/safety-rules/Cargo.toml
+++ b/consensus/safety-rules/Cargo.toml
@@ -15,6 +15,7 @@ consensus-types = { path = "../consensus-types", version = "0.1.0" }
 lcs = { path = "../../common/lcs", version = "0.1.0", package = "libra-canonical-serialization" }
 libra-config = { path = "../../config", version = "0.1.0" }
 libra-crypto = { path = "../../crypto/crypto", version = "0.1.0" }
+libra-global-constants = { path = "../../config/global-constants", version = "0.1.0"}
 libra-logger = { path = "../../common/logger", version = "0.1.0" }
 libra-secure-net = { path = "../../secure/net", version = "0.1.0" }
 libra-secure-push-metrics = { path = "../../secure/push-metrics", version = "0.1.0" }

--- a/consensus/safety-rules/src/persistent_safety_storage.rs
+++ b/consensus/safety-rules/src/persistent_safety_storage.rs
@@ -4,6 +4,7 @@
 use anyhow::Result;
 use consensus_types::common::Round;
 use libra_crypto::ed25519::Ed25519PrivateKey;
+use libra_global_constants::{CONSENSUS_KEY, EPOCH, LAST_VOTED_ROUND, PREFERRED_ROUND, WAYPOINT};
 use libra_secure_storage::{InMemoryStorage, Policy, Storage, Value};
 use libra_types::waypoint::Waypoint;
 use std::str::FromStr;
@@ -16,12 +17,6 @@ use std::str::FromStr;
 pub struct PersistentSafetyStorage {
     internal_store: Box<dyn Storage>,
 }
-
-const CONSENSUS_KEY: &str = "consensus_key";
-const EPOCH: &str = "epoch";
-const LAST_VOTED_ROUND: &str = "last_voted_round";
-const PREFERRED_ROUND: &str = "preferred_round";
-const WAYPOINT: &str = "waypoint";
 
 impl PersistentSafetyStorage {
     pub fn in_memory(private_key: Ed25519PrivateKey) -> Self {

--- a/execution/executor/tests/storage_integration_test.rs
+++ b/execution/executor/tests/storage_integration_test.rs
@@ -114,7 +114,7 @@ fn test_reconfiguration() {
         .test
         .as_mut()
         .unwrap()
-        .account_keypair
+        .operator_keypair
         .as_mut()
         .unwrap();
     let validator_privkey = keys.take_private().unwrap();
@@ -207,7 +207,7 @@ fn test_change_publishing_option_to_custom() {
         .test
         .as_mut()
         .unwrap()
-        .account_keypair
+        .operator_keypair
         .as_mut()
         .unwrap();
     let validator_privkey = keys.take_private().unwrap();
@@ -383,7 +383,7 @@ fn test_extend_whitelist() {
         .test
         .as_mut()
         .unwrap()
-        .account_keypair
+        .operator_keypair
         .as_mut()
         .unwrap();
     let validator_privkey = keys.take_private().unwrap();

--- a/language/functional-tests/src/config/global.rs
+++ b/language/functional-tests/src/config/global.rs
@@ -168,7 +168,7 @@ impl Config {
                 .map(|c| {
                     let peer_id = c.validator_network.as_ref().unwrap().peer_id;
                     let account_keypair =
-                        c.test.as_mut().unwrap().account_keypair.as_mut().unwrap();
+                        c.test.as_mut().unwrap().operator_keypair.as_mut().unwrap();
                     let privkey = account_keypair.take_private().unwrap();
                     (peer_id, privkey)
                 })

--- a/language/tools/vm-genesis/src/lib.rs
+++ b/language/tools/vm-genesis/src/lib.rs
@@ -410,7 +410,7 @@ pub fn validator_registrations(node_configs: &[NodeConfig]) -> Vec<ValidatorRegi
         .iter()
         .map(|n| {
             let test = n.test.as_ref().unwrap();
-            let account_key = test.account_keypair.as_ref().unwrap().public_key();
+            let account_key = test.operator_keypair.as_ref().unwrap().public_key();
             let consensus_key = test.consensus_keypair.as_ref().unwrap().public_key();
             let network = n.validator_network.as_ref().unwrap();
             let network_keypairs = network.network_keypairs.as_ref().unwrap();

--- a/secure/key-manager/Cargo.toml
+++ b/secure/key-manager/Cargo.toml
@@ -16,6 +16,7 @@ thiserror = "1.0"
 
 libra-config = { path = "../../config", version = "0.1.0", features = ["fuzzing"]}
 libra-crypto = { path = "../../crypto/crypto", version = "0.1.0" }
+libra-global-constants = { path = "../../config/global-constants", version = "0.1.0"}
 libra-logger = { path = "../../common/logger", version = "0.1.0" }
 libra-secure-json-rpc = { path = "../../secure/json-rpc", version = "0.1.0" }
 libra-secure-push-metrics = { path = "../../secure/push-metrics", version = "0.1.0" }

--- a/secure/key-manager/src/lib.rs
+++ b/secure/key-manager/src/lib.rs
@@ -24,6 +24,7 @@ use libra_crypto::{
     ed25519::{Ed25519PrivateKey, Ed25519PublicKey},
     PrivateKey,
 };
+use libra_global_constants::{CONSENSUS_KEY, OPERATOR_KEY};
 use libra_logger::info;
 use libra_secure_storage::Storage;
 use libra_secure_time::TimeService;
@@ -39,9 +40,6 @@ pub mod libra_interface;
 
 #[cfg(test)]
 mod tests;
-
-pub const VALIDATOR_KEY: &str = "validator";
-pub const CONSENSUS_KEY: &str = "consensus";
 
 const GAS_UNIT_PRICE: u64 = 0;
 const MAX_GAS_AMOUNT: u64 = 400_000;
@@ -201,7 +199,7 @@ where
         &self,
         new_key: Ed25519PublicKey,
     ) -> Result<Ed25519PublicKey, Error> {
-        let account_prikey = self.storage.export_private_key(VALIDATOR_KEY)?;
+        let account_prikey = self.storage.export_private_key(OPERATOR_KEY)?;
         let seq_id = self.libra.retrieve_sequence_number(self.account)?;
         let expiration = Duration::from_secs(self.time_service.now() + self.txn_expiration_secs);
         let txn =

--- a/secure/key-manager/src/tests.rs
+++ b/secure/key-manager/src/tests.rs
@@ -346,7 +346,7 @@ fn setup_secure_storage(
     let mut sec_storage = InMemoryStorageInternal::new_with_time_service(time);
     let test_config = config.clone().test.unwrap();
 
-    let mut a_keypair = test_config.account_keypair.unwrap();
+    let mut a_keypair = test_config.operator_keypair.unwrap();
     let a_prikey = Value::Ed25519PrivateKey(a_keypair.take_private().unwrap());
 
     sec_storage
@@ -444,7 +444,11 @@ fn test_manual_rotation_on_chain() {
 
 fn verify_manual_rotation_on_chain<T: LibraInterface>(config: NodeConfig, mut node: Node<T>) {
     let test_config = config.test.unwrap();
-    let account_prikey = test_config.account_keypair.unwrap().take_private().unwrap();
+    let account_prikey = test_config
+        .operator_keypair
+        .unwrap()
+        .take_private()
+        .unwrap();
     let genesis_pubkey = test_config
         .consensus_keypair
         .unwrap()

--- a/secure/key-manager/src/tests.rs
+++ b/secure/key-manager/src/tests.rs
@@ -8,6 +8,7 @@ use executor_types::BlockExecutor;
 use futures::{channel::mpsc::channel, StreamExt};
 use libra_config::{config::NodeConfig, utils, utils::get_genesis_txn};
 use libra_crypto::{ed25519::Ed25519PrivateKey, HashValue, PrivateKey, Uniform};
+use libra_global_constants::OPERATOR_KEY;
 use libra_secure_json_rpc::JsonRpcClient;
 use libra_secure_storage::{InMemoryStorageInternal, KVStorage, Policy, Value};
 use libra_secure_time::{MockTimeService, TimeService};
@@ -349,7 +350,7 @@ fn setup_secure_storage(
     let a_prikey = Value::Ed25519PrivateKey(a_keypair.take_private().unwrap());
 
     sec_storage
-        .create(crate::VALIDATOR_KEY, a_prikey, &Policy::public())
+        .create(OPERATOR_KEY, a_prikey, &Policy::public())
         .unwrap();
 
     let mut c_keypair = test_config.consensus_keypair.unwrap();

--- a/state-synchronizer/src/tests/on_chain_config_tests.rs
+++ b/state-synchronizer/src/tests/on_chain_config_tests.rs
@@ -85,7 +85,7 @@ fn test_on_chain_config_pub_sub() {
         .test
         .as_mut()
         .unwrap()
-        .account_keypair
+        .operator_keypair
         .as_mut()
         .unwrap();
 


### PR DESCRIPTION
## Motivation

At present, several components in the codebase rely on the definition of shared global constant values (e.g., Libra Safety Rules and the Key Manager both require access to crypto key names held in Secure Storage -- such as the "consensus" and "operator" keys). To achieve this, these components simply re-define these constants locally, which causes duplicate constants to exist in the codebase and allows inconsistencies to arise (e.g., Libra Safety Rules currently thinks the consensus key is the string "consensus_key", while the Key Manager believes it is "consensus").

To avoid this, we introduce a single "global-constants" crate that provides a single source of truth for these shared constant definitions. To achieve this, the PR offers 4 commits:

1. We separate out the constant definitions in the Configuration Manager and introduce a new 'global-constants' crate in the config directory. Given that the Configuration Manager is the end-to-end tool that verifies the correctness of a local setup, this is probably the right place to define these constants.

2. We update the Key Manager to use the newly defined global constants crate. Note: VALIDATOR_KEY has now been replaced with OPERATOR_KEY, due to settling upon a new set of name definitions.

3. We update Libra Safety Rules to use the newly defined global constants crate.

4. We update the name of the "account" key pair in the test config to "operator" (to be consistent with the newly agreed upon nomenclature).

Note: even though the global constants crate currently seems to contain mostly items held in secure storage, it probably makes more sense to keep it generic (i.e. not storage specific), as more constants will probably be added over time.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?

Yes.

## Test Plan

All local tests still pass.

## Related PRs

None.
