### PR TITLE
[move-prover] Speed up ExtendValueArray and ExtendTypeValueArray

### DIFF
--- a/language/move-prover/src/prelude.bpl
+++ b/language/move-prover/src/prelude.bpl
@@ -73,7 +73,8 @@ axiom l#TypeValueArray(EmptyTypeValueArray) == 0;
 axiom v#TypeValueArray(EmptyTypeValueArray) == MapConstTypeValue(DefaultTypeValue);
 
 function {:inline} ExtendTypeValueArray(ta: TypeValueArray, tv: TypeValue): TypeValueArray {
-    TypeValueArray(v#TypeValueArray(ta)[l#TypeValueArray(ta) := tv], l#TypeValueArray(ta) + 1)
+    (var len := l#TypeValueArray(ta);
+     TypeValueArray(v#TypeValueArray(ta)[len := tv], len + 1))
 }
 
 
@@ -171,7 +172,8 @@ function {:inline} SliceValueArray(a: ValueArray, i: int, j: int): ValueArray { 
     ValueArray((lambda k:int :: if 0 <= k && k < j-i then v#ValueArray(a)[i+k] else DefaultValue), (if j-i < 0 then 0 else j-i))
 }
 function {:inline} ExtendValueArray(a: ValueArray, elem: Value): ValueArray {
-    ValueArray(v#ValueArray(a)[l#ValueArray(a) := elem], l#ValueArray(a) + 1)
+    (var len := l#ValueArray(a);
+     ValueArray(v#ValueArray(a)[len := elem], len + 1))
 }
 function {:inline} UpdateValueArray(a: ValueArray, i: int, elem: Value): ValueArray {
     ValueArray(v#ValueArray(a)[i := elem], l#ValueArray(a))


### PR DESCRIPTION
[move-prover] Speed up ExtendValueArray and ExtendTypeValueArray
 
The prelude has some inline functions whose arguments are repeated
multiple times in the body. Apparently, Boogie just substitutes the 
actuals for the formals, which can result in exponential blowup in
expression size.
    
The simple change here is to "let-bind" a repeated argument. This
reduces z3 file size by about an order of magnitude, and speeds up
verification by at least one order of magnitude.

Here is an example.  "var len :=" is let-binding in Boogie.
    
    function {:inline} ExtendTypeValueArray(ta: TypeValueArray, tv: TypeValue): TypeValueArray {
        (var len := l#TypeValueArray(ta);
         TypeValueArray(v#TypeValueArray(ta)[len := tv], len + 1))
    }
    
Note: Repeated args in :inline functions appear all over the place in
the prelude and in generated code. I haven't seen it causing problems
except in Extend...Array. Clark made IsEqual2,3,4 non-inline, probably
because of the same problem. We should consider using let whenever
there are repeated args to minimize the risk of expression size blowup
when Boogie generates z3 files.
    
## Motivation

Speed up from 3-4 minutes to 10-20 seconds

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?

yes
## Test Plan

cargo test
## Related PRs

(If this PR adds or changes functionality, please take some time to update the docs at https://github.com/libra/website, and link to your PR here.)
