### PR TITLE
[move-prover] Misc fixes.

### DIFF
--- a/language/move-prover/spec-lang/tests/sources/schemas_err.exp
+++ b/language/move-prover/spec-lang/tests/sources/schemas_err.exp
@@ -102,7 +102,7 @@ error: `y` cannot be matched to an existing name in inclusion context
     │                 ^^^^^^^^^^^^^^^^^^^^^^
     │
 
-error: `requires` (included from schema) not allowed in this context
+error: `requires` not allowed in struct context (included from schema)
 
     ┌── tests/sources/schemas_err.move:70:9 ───
     │

--- a/language/move-prover/src/cli.rs
+++ b/language/move-prover/src/cli.rs
@@ -22,6 +22,9 @@ const DEFAULT_BOOGIE_FLAGS: &[&str] = &[
     "-noinfer",
     "-printVerifiedProceduresCount:0",
     "-printModel:4",
+    // Right now, we let boogie only produce one error per procedure. The boogie wrapper isn't
+    // capable to sort out multiple errors and associate them with models otherwise.
+    "-errorLimit:1",
 ];
 
 /// Atomic used to prevent re-initialization of logging.
@@ -347,7 +350,7 @@ impl Options {
         if self.use_array_theory {
             add(&["-useArrayTheory"]);
         } else {
-            add(&["-proverOpt:O:smt.QI.EAGER_THRESHOLD=100"]);
+            add(&["-proverOpt:O:smt.QI.EAGER_THRESHOLD=30"]);
         }
         for f in &self.boogie_flags {
             add(&[f.as_str()]);

--- a/language/move-prover/src/lib.rs
+++ b/language/move-prover/src/lib.rs
@@ -163,7 +163,7 @@ fn calculate_deps_recursively(
     if !visited.insert(path.to_string_lossy().to_string()) {
         return Ok(());
     }
-    for dep in extract_matches(path, r"use .*::\s*(\w+);")? {
+    for dep in extract_matches(path, r"0x[0-9,a,b,c,d,e,f,A,B,C,D,E,F]+::\s*(\w+)")? {
         if let Some(dep_path) = file_map.get(&dep) {
             let dep_str = dep_path.to_string_lossy().to_string();
             if !deps.contains(&dep_str) {

--- a/language/move-prover/tests/sources/functional/aborts-if.exp
+++ b/language/move-prover/tests/sources/functional/aborts-if.exp
@@ -24,18 +24,22 @@ error:  A postcondition might not hold on this return path.
     =         y = <redacted>
     =     at tests/sources/functional/aborts-if.move:43:5: abort4_incorrect (exit)
 
-error:  A postcondition might not hold on this return path.
+error: abort not covered by any of the `aborts_if` clauses
 
-    ┌── tests/sources/functional/aborts-if.move:55:9 ───
+    ┌── tests/sources/functional/aborts-if.move:51:5 ───
     │
- 55 │         aborts_if x < y;
-    │         ^^^^^^^^^^^^^^^^
+ 51 │ ╭     fun abort5_incorrect(x: u64, y: u64) {
+ 52 │ │         if (x <= y) abort 1
+ 53 │ │     }
+    │ ╰─────^
+    ·
+ 52 │         if (x <= y) abort 1
+    │         ------------------- abort happened here
     │
     =     at tests/sources/functional/aborts-if.move:51:5: abort5_incorrect (entry)
-    =     at tests/sources/functional/aborts-if.move:52:9: abort5_incorrect
+    =     at tests/sources/functional/aborts-if.move:52:9: abort5_incorrect (ABORTED)
     =         x = <redacted>,
     =         y = <redacted>
-    =     at tests/sources/functional/aborts-if.move:51:5: abort5_incorrect (exit)
 
 error:  A postcondition might not hold on this return path.
 
@@ -52,10 +56,10 @@ error:  A postcondition might not hold on this return path.
 
 error:  A postcondition might not hold on this return path.
 
-    ┌── tests/sources/functional/aborts-if.move:85:9 ───
+    ┌── tests/sources/functional/aborts-if.move:86:9 ───
     │
- 85 │         aborts_if x < y;
-    │         ^^^^^^^^^^^^^^^^
+ 86 │         aborts_if x == y;
+    │         ^^^^^^^^^^^^^^^^^
     │
     =     at tests/sources/functional/aborts-if.move:81:5: multi_abort2_incorrect (entry)
     =     at tests/sources/functional/aborts-if.move:82:9: multi_abort2_incorrect
@@ -63,18 +67,22 @@ error:  A postcondition might not hold on this return path.
     =         y = <redacted>
     =     at tests/sources/functional/aborts-if.move:81:5: multi_abort2_incorrect (exit)
 
-error:  A postcondition might not hold on this return path.
+error: abort not covered by any of the `aborts_if` clauses
 
-    ┌── tests/sources/functional/aborts-if.move:94:9 ───
+    ┌── tests/sources/functional/aborts-if.move:90:5 ───
     │
- 94 │         aborts_if _x < _y;
-    │         ^^^^^^^^^^^^^^^^^^
+ 90 │ ╭     fun multi_abort3_incorrect(_x: u64, _y: u64) {
+ 91 │ │         abort 1
+ 92 │ │     }
+    │ ╰─────^
+    ·
+ 91 │         abort 1
+    │         ------- abort happened here
     │
     =     at tests/sources/functional/aborts-if.move:90:5: multi_abort3_incorrect (entry)
-    =     at tests/sources/functional/aborts-if.move:91:9: multi_abort3_incorrect
+    =     at tests/sources/functional/aborts-if.move:91:9: multi_abort3_incorrect (ABORTED)
     =         _x = <redacted>,
     =         _y = <redacted>
-    =     at tests/sources/functional/aborts-if.move:90:5: multi_abort3_incorrect (exit)
 
 error:  A postcondition might not hold on this return path.
 

--- a/language/move-prover/tests/sources/functional/arithm.exp
+++ b/language/move-prover/tests/sources/functional/arithm.exp
@@ -1,82 +1,117 @@
 Move prover returns: exiting with boogie verification errors
-error:  A postcondition might not hold on this return path.
+error: abort not covered by any of the `aborts_if` clauses
 
-     ┌── tests/sources/functional/arithm.move:125:9 ───
+     ┌── tests/sources/functional/arithm.move:121:5 ───
      │
- 125 │         aborts_if false;
-     │         ^^^^^^^^^^^^^^^^
+ 121 │ ╭     fun div_by_zero_u64_incorrect(x: u64, y: u64): u64 {
+ 122 │ │         x / y
+ 123 │ │     }
+     │ ╰─────^
+     ·
+ 122 │         x / y
+     │           - abort happened here
      │
      =     at tests/sources/functional/arithm.move:121:5: div_by_zero_u64_incorrect (entry)
      =     at tests/sources/functional/arithm.move:122:11: div_by_zero_u64_incorrect (ABORTED)
      =         x = <redacted>,
      =         y = <redacted>
 
-error:  A postcondition might not hold on this return path.
+error: abort not covered by any of the `aborts_if` clauses
 
-     ┌── tests/sources/functional/arithm.move:177:9 ───
+     ┌── tests/sources/functional/arithm.move:173:5 ───
      │
- 177 │         aborts_if false;
-     │         ^^^^^^^^^^^^^^^^
+ 173 │ ╭     fun overflow_u128_add_incorrect(x: u128, y: u128): u128 {
+ 174 │ │         x + y
+ 175 │ │     }
+     │ ╰─────^
+     ·
+ 174 │         x + y
+     │           - abort happened here
      │
      =     at tests/sources/functional/arithm.move:173:5: overflow_u128_add_incorrect (entry)
      =     at tests/sources/functional/arithm.move:174:11: overflow_u128_add_incorrect (ABORTED)
      =         x = <redacted>,
      =         y = <redacted>
 
-error:  A postcondition might not hold on this return path.
+error: abort not covered by any of the `aborts_if` clauses
 
-     ┌── tests/sources/functional/arithm.move:230:9 ───
+     ┌── tests/sources/functional/arithm.move:226:5 ───
      │
- 230 │         aborts_if false;
-     │         ^^^^^^^^^^^^^^^^
+ 226 │ ╭     fun overflow_u128_mul_incorrect(x: u128, y: u128): u128 {
+ 227 │ │         x * y
+ 228 │ │     }
+     │ ╰─────^
+     ·
+ 227 │         x * y
+     │           - abort happened here
      │
      =     at tests/sources/functional/arithm.move:226:5: overflow_u128_mul_incorrect (entry)
      =     at tests/sources/functional/arithm.move:227:11: overflow_u128_mul_incorrect (ABORTED)
      =         x = <redacted>,
      =         y = <redacted>
 
-error:  A postcondition might not hold on this return path.
+error: abort not covered by any of the `aborts_if` clauses
 
-     ┌── tests/sources/functional/arithm.move:161:9 ───
+     ┌── tests/sources/functional/arithm.move:157:5 ───
      │
- 161 │         aborts_if false;
-     │         ^^^^^^^^^^^^^^^^
+ 157 │ ╭     fun overflow_u64_add_incorrect(x: u64, y: u64): u64 {
+ 158 │ │         x + y
+ 159 │ │     }
+     │ ╰─────^
+     ·
+ 158 │         x + y
+     │           - abort happened here
      │
      =     at tests/sources/functional/arithm.move:157:5: overflow_u64_add_incorrect (entry)
      =     at tests/sources/functional/arithm.move:158:11: overflow_u64_add_incorrect (ABORTED)
      =         x = <redacted>,
      =         y = <redacted>
 
-error:  A postcondition might not hold on this return path.
+error: abort not covered by any of the `aborts_if` clauses
 
-     ┌── tests/sources/functional/arithm.move:214:9 ───
+     ┌── tests/sources/functional/arithm.move:210:5 ───
      │
- 214 │         aborts_if false;
-     │         ^^^^^^^^^^^^^^^^
+ 210 │ ╭     fun overflow_u64_mul_incorrect(x: u64, y: u64): u64 {
+ 211 │ │         x * y
+ 212 │ │     }
+     │ ╰─────^
+     ·
+ 211 │         x * y
+     │           - abort happened here
      │
      =     at tests/sources/functional/arithm.move:210:5: overflow_u64_mul_incorrect (entry)
      =     at tests/sources/functional/arithm.move:211:11: overflow_u64_mul_incorrect (ABORTED)
      =         x = <redacted>,
      =         y = <redacted>
 
-error:  A postcondition might not hold on this return path.
+error: abort not covered by any of the `aborts_if` clauses
 
-     ┌── tests/sources/functional/arithm.move:145:9 ───
+     ┌── tests/sources/functional/arithm.move:141:5 ───
      │
- 145 │         aborts_if false;
-     │         ^^^^^^^^^^^^^^^^
+ 141 │ ╭     fun overflow_u8_add_incorrect(x: u8, y: u8): u8 {
+ 142 │ │         x + y
+ 143 │ │     }
+     │ ╰─────^
+     ·
+ 142 │         x + y
+     │           - abort happened here
      │
      =     at tests/sources/functional/arithm.move:141:5: overflow_u8_add_incorrect (entry)
      =     at tests/sources/functional/arithm.move:142:11: overflow_u8_add_incorrect (ABORTED)
      =         x = <redacted>,
      =         y = <redacted>
 
-error:  A postcondition might not hold on this return path.
+error: abort not covered by any of the `aborts_if` clauses
 
-     ┌── tests/sources/functional/arithm.move:198:9 ───
+     ┌── tests/sources/functional/arithm.move:194:5 ───
      │
- 198 │         aborts_if false;
-     │         ^^^^^^^^^^^^^^^^
+ 194 │ ╭     fun overflow_u8_mul_incorrect(x: u8, y: u8): u8 {
+ 195 │ │         x * y
+ 196 │ │     }
+     │ ╰─────^
+     ·
+ 195 │         x * y
+     │           - abort happened here
      │
      =     at tests/sources/functional/arithm.move:194:5: overflow_u8_mul_incorrect (entry)
      =     at tests/sources/functional/arithm.move:195:11: overflow_u8_mul_incorrect (ABORTED)

--- a/language/move-prover/tests/sources/functional/cast.exp
+++ b/language/move-prover/tests/sources/functional/cast.exp
@@ -1,24 +1,32 @@
 Move prover returns: exiting with boogie verification errors
-error:  A postcondition might not hold on this return path.
+error: abort not covered by any of the `aborts_if` clauses
 
-    ┌── tests/sources/functional/cast.move:44:9 ───
+    ┌── tests/sources/functional/cast.move:40:5 ───
     │
- 44 │         aborts_if false;
-    │         ^^^^^^^^^^^^^^^^
+ 40 │ ╭     fun aborting_u64_cast_incorrect(x: u128): u64 {
+ 41 │ │         (x as u64)
+ 42 │ │     }
+    │ ╰─────^
+    ·
+ 41 │         (x as u64)
+    │         ---------- abort happened here
     │
     =     at tests/sources/functional/cast.move:40:5: aborting_u64_cast_incorrect (entry)
-    =     at tests/sources/functional/cast.move:41:9: aborting_u64_cast_incorrect
+    =     at tests/sources/functional/cast.move:41:9: aborting_u64_cast_incorrect (ABORTED)
     =         x = <redacted>
-    =     at tests/sources/functional/cast.move:40:5: aborting_u64_cast_incorrect (exit)
 
-error:  A postcondition might not hold on this return path.
+error: abort not covered by any of the `aborts_if` clauses
 
-    ┌── tests/sources/functional/cast.move:30:9 ───
+    ┌── tests/sources/functional/cast.move:26:5 ───
     │
- 30 │         aborts_if false;
-    │         ^^^^^^^^^^^^^^^^
+ 26 │ ╭     fun aborting_u8_cast_incorrect(x: u64): u8 {
+ 27 │ │         (x as u8)
+ 28 │ │     }
+    │ ╰─────^
+    ·
+ 27 │         (x as u8)
+    │         --------- abort happened here
     │
     =     at tests/sources/functional/cast.move:26:5: aborting_u8_cast_incorrect (entry)
-    =     at tests/sources/functional/cast.move:27:9: aborting_u8_cast_incorrect
+    =     at tests/sources/functional/cast.move:27:9: aborting_u8_cast_incorrect (ABORTED)
     =         x = <redacted>
-    =     at tests/sources/functional/cast.move:26:5: aborting_u8_cast_incorrect (exit)

--- a/language/move-prover/tests/sources/functional/pragma.exp
+++ b/language/move-prover/tests/sources/functional/pragma.exp
@@ -1,12 +1,16 @@
 Move prover returns: exiting with boogie verification errors
-error:  A postcondition might not hold on this return path.
+error: abort not covered by any of the `aborts_if` clauses
 
-    ┌── tests/sources/functional/pragma.move:15:9 ───
+    ┌── tests/sources/functional/pragma.move:10:5 ───
     │
- 15 │         aborts_if _c;
-    │         ^^^^^^^^^^^^^
+ 10 │ ╭     fun always_aborts_with_verify_incorrect(_c: bool) {
+ 11 │ │         abort(1)
+ 12 │ │     }
+    │ ╰─────^
+    ·
+ 11 │         abort(1)
+    │         -------- abort happened here
     │
     =     at tests/sources/functional/pragma.move:10:5: always_aborts_with_verify_incorrect (entry)
-    =     at tests/sources/functional/pragma.move:11:9: always_aborts_with_verify_incorrect
+    =     at tests/sources/functional/pragma.move:11:9: always_aborts_with_verify_incorrect (ABORTED)
     =         _c = <redacted>
-    =     at tests/sources/functional/pragma.move:10:5: always_aborts_with_verify_incorrect (exit)

--- a/language/move-prover/tests/sources/functional/schema_exp.exp
+++ b/language/move-prover/tests/sources/functional/schema_exp.exp
@@ -1,15 +1,19 @@
 Move prover returns: exiting with boogie verification errors
-error:  A postcondition might not hold on this return path.
+error: abort not covered by any of the `aborts_if` clauses
 
-   ┌── tests/sources/functional/schema_exp.move:8:9 ───
-   │
- 8 │         aborts_if false;
-   │         ^^^^^^^^^^^^^^^^
-   │
-   =     at tests/sources/functional/schema_exp.move:20:5: bar_incorrect (entry)
-   =     at tests/sources/functional/schema_exp.move:21:9: bar_incorrect
-   =         c = <redacted>
-   =     at tests/sources/functional/schema_exp.move:20:5: bar_incorrect (exit)
+    ┌── tests/sources/functional/schema_exp.move:20:5 ───
+    │
+ 20 │ ╭     fun bar_incorrect(c: bool) {
+ 21 │ │         if (!c) abort(1);
+ 22 │ │     }
+    │ ╰─────^
+    ·
+ 21 │         if (!c) abort(1);
+    │         ---------------- abort happened here
+    │
+    =     at tests/sources/functional/schema_exp.move:20:5: bar_incorrect (entry)
+    =     at tests/sources/functional/schema_exp.move:21:9: bar_incorrect (ABORTED)
+    =         c = <redacted>
 
 error:  A postcondition might not hold on this return path.
 

--- a/language/move-prover/tests/sources/functional/script_incorrect.exp
+++ b/language/move-prover/tests/sources/functional/script_incorrect.exp
@@ -1,15 +1,19 @@
 Move prover returns: exiting with boogie verification errors
-error:  A postcondition might not hold on this return path.
+error: abort not covered by any of the `aborts_if` clauses
 
-    ┌── tests/sources/functional/script_incorrect.move:10:5 ───
+   ┌── tests/sources/functional/script_incorrect.move:5:1 ───
+   │
+ 5 │ ╭ fun main<Token>() {
+ 6 │ │     ScriptProvider::register<Token>();
+ 7 │ │ }
+   │ ╰─^
+   │
+   =     at tests/sources/functional/script_incorrect.move:5:1: main (entry)
+   =     at tests/sources/functional/script_provider.move:9:5: register (entry)
+   =     at tests/sources/functional/script_provider.move:10:9: register (ABORTED)
+
+    ┌── tests/sources/functional/script_provider.move:10:9 ───
     │
- 10 │     aborts_if false;
-    │     ^^^^^^^^^^^^^^^^
+ 10 │         Transaction::assert(Transaction::sender() == 0x1, 1);
+    │         ---------------------------------------------------- abort happened here
     │
-    =     at tests/sources/functional/script_incorrect.move:5:1: main (entry)
-    =     at tests/sources/functional/script_provider.move:9:5: register (entry)
-    =     at tests/sources/functional/script_provider.move:10:9: register
-    =     at tests/sources/functional/script_provider.move:12:5: register
-    =     at tests/sources/functional/script_provider.move:9:5: register (exit)
-    =     at tests/sources/functional/script_incorrect.move:6:21: main
-    =     at tests/sources/functional/script_incorrect.move:5:1: main (exit)

--- a/language/move-prover/tests/sources/stdlib/modules/libra.move
+++ b/language/move-prover/tests/sources/stdlib/modules/libra.move
@@ -40,11 +40,11 @@ module Libra {
 
     // There is a MintCapability for Token iff the token is registered
     spec schema MintCapabilityCountInvariant<Token> {
-         invariant !token_is_registered<Token>() ==> mint_capability_count<Token> == 0;
-         invariant token_is_registered<Token>() ==> mint_capability_count<Token> == 1;
+         invariant module !token_is_registered<Token>() ==> mint_capability_count<Token> == 0;
+         invariant module token_is_registered<Token>() ==> mint_capability_count<Token> == 1;
     }
     spec module {
-        apply MintCapabilityCountInvariant<Token> to *<Token>;
+        apply MintCapabilityCountInvariant<Token> to public *<Token>;
     }
 
     resource struct Info<Token> {
@@ -89,12 +89,12 @@ module Libra {
          // Note: What is the value of a ghost variable in the genesis state?
          // State machine with two states (not registered/registered), so write as two invariants.
 
-         invariant !token_is_registered<Token>() ==> sum_of_token_values<Token> == 0;
-         invariant token_is_registered<Token>()
+         invariant module !token_is_registered<Token>() ==> sum_of_token_values<Token> == 0;
+         invariant module token_is_registered<Token>()
                      ==> sum_of_token_values<Token> == global<Info<Token>>(0xA550C18).total_value;
     }
     spec module {
-        apply SumOfTokenValuesInvariant<Token> to *<Token>;
+        apply SumOfTokenValuesInvariant<Token> to public *<Token>;
     }
 
     // A holding area where funds that will subsequently be burned wait while their underyling

--- a/language/move-prover/tests/sources/stdlib/modules/libra_account.exp
+++ b/language/move-prover/tests/sources/stdlib/modules/libra_account.exp
@@ -1,0 +1,85 @@
+Move prover returns: exiting with boogie verification errors
+error: abort not covered by any of the `aborts_if` clauses
+
+     ┌── tests/sources/stdlib/modules/libra_account.move:784:5 ───
+     │
+ 784 │ ╭     public fun create_account(fresh_address: address, auth_key_prefix: vector<u8>) {
+ 785 │ │         let generator = EventHandleGenerator {counter: 0};
+ 786 │ │         let authentication_key = auth_key_prefix;
+ 787 │ │         Vector::append(&mut authentication_key, LCS::to_bytes(&fresh_address));
+ 788 │ │         Transaction::assert(Vector::length(&authentication_key) == 32, 12);
+ 789 │ │
+ 790 │ │         save_account(
+ 791 │ │             Balance{
+ 792 │ │                 coin: Libra::zero<LBR::T>()
+ 793 │ │             },
+ 794 │ │             T {
+ 795 │ │                 authentication_key,
+ 796 │ │                 delegated_key_rotation_capability: false,
+ 797 │ │                 delegated_withdrawal_capability: false,
+ 798 │ │                 received_events: new_event_handle_impl<ReceivedPaymentEvent>(&mut generator, fresh_address),
+ 799 │ │                 sent_events: new_event_handle_impl<SentPaymentEvent>(&mut generator, fresh_address),
+ 800 │ │                 sequence_number: 0,
+ 801 │ │                 event_generator: generator,
+ 802 │ │             },
+ 803 │ │             fresh_address,
+ 804 │ │         );
+ 805 │ │     }
+     │ ╰─────^
+     ·
+ 790 │         save_account(
+     │         ------------ abort happened here
+     │
+     =     at tests/sources/stdlib/modules/libra_account.move:784:5: create_account (entry)
+     =     at tests/sources/stdlib/modules/libra_account.move:785:13: create_account
+     =         fresh_address = <redacted>,
+     =         auth_key_prefix = <redacted>,
+     =         generator = <redacted>
+     =     at tests/sources/stdlib/modules/libra_account.move:786:34: create_account
+     =         authentication_key = <redacted>
+     =     at tests/sources/stdlib/modules/libra_account.move:787:24: create_account
+     =     at tests/sources/stdlib/modules/libra_account.move:788:37: create_account
+     =         $t4 = <redacted>
+     =     at tests/sources/stdlib/modules/libra.move:429:5: zero (entry)
+     =     at tests/sources/stdlib/modules/libra.move:137:5: assert_is_registered (entry)
+     =     at tests/sources/stdlib/modules/libra.move:138:9: assert_is_registered
+     =         $t0 = <redacted>
+     =     at tests/sources/stdlib/modules/libra.move:137:5: assert_is_registered (exit)
+     =     at tests/sources/stdlib/modules/libra.move:431:9: zero
+     =     at tests/sources/stdlib/modules/libra.move:432:9: zero
+     =         result = <redacted>
+     =     at tests/sources/stdlib/modules/libra.move:429:5: zero (exit)
+     =     at tests/sources/stdlib/modules/libra_account.move:1271:5: new_event_handle_impl (entry)
+     =     at tests/sources/stdlib/modules/libra_account.move:1255:5: fresh_guid (entry)
+     =     at tests/sources/stdlib/modules/libra_account.move:1256:33: fresh_guid
+     =         counter = <redacted>,
+     =         sender = <redacted>,
+     =         sender_bytes = <redacted>
+     =     at tests/sources/stdlib/modules/libra_account.move:1257:42: fresh_guid
+     =         count_bytes = <redacted>
+     =     at tests/sources/stdlib/modules/libra_account.move:1258:27: fresh_guid
+     =         counter = <redacted>
+     =     at tests/sources/stdlib/modules/libra_account.move:1261:24: fresh_guid
+     =         counter = <redacted>
+     =     at tests/sources/stdlib/modules/libra_account.move:1263:9: fresh_guid
+     =         result = <redacted>
+     =     at tests/sources/stdlib/modules/libra_account.move:1255:5: fresh_guid (exit)
+     =     at tests/sources/stdlib/modules/libra_account.move:1272:43: new_event_handle_impl
+     =         counter = <redacted>,
+     =         counter = <redacted>,
+     =         sender = <redacted>,
+     =         result = <redacted>
+     =     at tests/sources/stdlib/modules/libra_account.move:1271:5: new_event_handle_impl (exit)
+     =     at tests/sources/stdlib/modules/libra_account.move:798:34: create_account
+     =     at tests/sources/stdlib/modules/libra_account.move:1271:5: new_event_handle_impl (entry)
+     =     at tests/sources/stdlib/modules/libra_account.move:1255:5: fresh_guid (entry)
+     =     at tests/sources/stdlib/modules/libra_account.move:1256:33: fresh_guid
+     =     at tests/sources/stdlib/modules/libra_account.move:1257:42: fresh_guid
+     =     at tests/sources/stdlib/modules/libra_account.move:1258:27: fresh_guid
+     =     at tests/sources/stdlib/modules/libra_account.move:1261:24: fresh_guid
+     =     at tests/sources/stdlib/modules/libra_account.move:1263:9: fresh_guid
+     =     at tests/sources/stdlib/modules/libra_account.move:1255:5: fresh_guid (exit)
+     =     at tests/sources/stdlib/modules/libra_account.move:1272:43: new_event_handle_impl
+     =     at tests/sources/stdlib/modules/libra_account.move:1271:5: new_event_handle_impl (exit)
+     =     at tests/sources/stdlib/modules/libra_account.move:799:30: create_account
+     =     at tests/sources/stdlib/modules/libra_account.move:790:9: create_account (ABORTED)


### PR DESCRIPTION
This PR fixes a number of issues, most of them related to the problems Junkil found when specifiying libra account:

- The reporting of aborts had regressed. Now boogie_wrapper again finds aborts agains and reports them in a more meaningful way. Closes #2979.
- The boogie conditions for aborts has been split into parts such that we get a more precise error. The `ensures (P1 || .. || Pn) <=> abort_flag` doesn't work well as boogie only reports failures for the whole ensures, but not for individual parts. Now we generate `ensures P1 ==> abort_flag; ...; ensures Pn ==> abort_flag` which gives as a good error if the function should fail but doesn't; as well as `ensures abort_flag ==> (P1 || .. || Pn)` which covers the case where the function aborts but has no aborts_if.
- A bug was fixed in module invariants which weren't correctly assumed in all cases when a module is called from the outside. This lead to failures in libra_account calling libra with David's new global specs. Also the schemas there now use `invariant module` instead of `invariant`.
- Type assumptions for vectors are strengthened. If we know the element type of a vector, it will be assumed for all elements. This wasn't an issue in this case but resulted as a side-effect from debugging.

Moreover, the prover now detects deps which are not introduced by a `use` in Move but use absolute references in code. This previously lead to a failure with missing Testnet declaration in one of the stdlib sources.

Libra account still has a bug around `create_account` and `save_account`. Instead of holding this PR up on this one, I decided to move forward with this and submit, and fixing this in a followup.

## Motivation

Fixing bugs.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

Updated baselines.

## Related PRs

NA
