### PR TITLE
[x] add lint to ensure workspace member list is canonical

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -766,6 +766,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "colored-diff"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "ansi_term 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "difference 2.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "itertools 0.7.11 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "compiler"
 version = "0.1.0"
 dependencies = [
@@ -1944,6 +1954,14 @@ dependencies = [
  "libra-workspace-hack 0.1.0",
  "move-core-types 0.1.0",
  "move-ir-types 0.1.0",
+]
+
+[[package]]
+name = "itertools"
+version = "0.7.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "either 1.5.3 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -6278,6 +6296,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow 1.0.28 (registry+https://github.com/rust-lang/crates.io-index)",
  "chrono 0.4.11 (registry+https://github.com/rust-lang/crates.io-index)",
+ "colored-diff 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "env_logger 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "guppy 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "libra-workspace-hack 0.1.0",
@@ -6306,6 +6325,7 @@ dependencies = [
  "guppy 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "libra-workspace-hack 0.1.0",
  "once_cell 1.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.106 (registry+https://github.com/rust-lang/crates.io-index)",
  "x-core 0.1.0",
 ]
 
@@ -6428,6 +6448,7 @@ dependencies = [
 "checksum codespan 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)" = "52899426b69706219a1aaee2e95868fd01a0bd8006bb163f069578a0af5b5bb2"
 "checksum codespan-reporting 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)" = "600c3317d4705222ff820139aaa76a3a208024ffc41f894da565a4c3b949d4c9"
 "checksum colored 1.9.3 (registry+https://github.com/rust-lang/crates.io-index)" = "f4ffc801dacf156c5854b9df4f425a626539c3a6ef7893cc0c5084a23f0b6c59"
+"checksum colored-diff 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "516f260afc909bb0d056b76891ad91b3275b83682d851b566792077eee946efd"
 "checksum constant_time_eq 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "245097e9a4535ee1e3e3931fcfcd55a796a44c643e8596ff6566d68f09b87bbc"
 "checksum cookie 0.13.3 (registry+https://github.com/rust-lang/crates.io-index)" = "0c60ef6d0bbf56ad2674249b6bb74f2c6aeb98b98dd57b5d3e37cace33011d69"
 "checksum core-foundation 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "57d24c7a13c43e870e37c1556b74555437870a04514f7685f5b354e090567171"
@@ -6510,6 +6531,7 @@ dependencies = [
 "checksum indexmap 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)" = "076f042c5b7b98f31d205f1249267e12a6518c1481e9dae9764af19b707d2292"
 "checksum input_buffer 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "19a8a95243d5a0398cae618ec29477c6e3cb631152be5c19481f80bc71559754"
 "checksum iovec 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)" = "b2b3ea6ff95e175473f8ffe6a7eb7c00d054240321b84c57051175fe3c1e075e"
+"checksum itertools 0.7.11 (registry+https://github.com/rust-lang/crates.io-index)" = "0d47946d458e94a1b7bcabbf6521ea7c037062c81f534615abcad76e84d4970d"
 "checksum itertools 0.8.2 (registry+https://github.com/rust-lang/crates.io-index)" = "f56a2d0bc861f9165be4eb3442afd3c236d8a98afd426f65d92324ae1091a484"
 "checksum itertools 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)" = "284f18f85651fe11e8a991b2adb42cb078325c996ed026d994719efcfca1d54b"
 "checksum itoa 0.4.5 (registry+https://github.com/rust-lang/crates.io-index)" = "b8b7a7c0c47db5545ed3fef7468ee7bb5b74691498139e4b3f6a20685dc6dd8e"

--- a/devtools/x-lint/Cargo.toml
+++ b/devtools/x-lint/Cargo.toml
@@ -11,4 +11,5 @@ license = "Apache-2.0"
 guppy = "0.4.1"
 libra-workspace-hack = { path = "../../common/workspace-hack", version = "0.1.0" }
 once_cell = "1.3.1"
+serde = "1"
 x-core = { version = "0.1.0", path = "../x-core" }

--- a/devtools/x-lint/src/errors.rs
+++ b/devtools/x-lint/src/errors.rs
@@ -1,6 +1,7 @@
 // Copyright (c) The Libra Core Contributors
 // SPDX-License-Identifier: Apache-2.0
 
+use serde::{de, ser};
 use std::{borrow::Cow, error, fmt, io, process::ExitStatus, result};
 
 /// Type alias for the return type for `run` methods.
@@ -19,6 +20,10 @@ pub enum SystemError {
         context: Cow<'static, str>,
         err: io::Error,
     },
+    Serde {
+        context: Cow<'static, str>,
+        err: Box<dyn error::Error + Send + Sync>,
+    },
 }
 
 impl SystemError {
@@ -26,6 +31,26 @@ impl SystemError {
         SystemError::Io {
             context: context.into(),
             err,
+        }
+    }
+
+    pub fn de(
+        context: impl Into<Cow<'static, str>>,
+        err: impl de::Error + Send + Sync + 'static,
+    ) -> Self {
+        SystemError::Serde {
+            context: context.into(),
+            err: Box::new(err),
+        }
+    }
+
+    pub fn ser(
+        context: impl Into<Cow<'static, str>>,
+        err: impl ser::Error + Send + Sync + 'static,
+    ) -> Self {
+        SystemError::Serde {
+            context: context.into(),
+            err: Box::new(err),
         }
     }
 }
@@ -37,7 +62,9 @@ impl fmt::Display for SystemError {
                 Some(code) => write!(f, "'{}' failed with exit code {}", cmd, code),
                 None => write!(f, "'{}' terminated by signal", cmd),
             },
-            SystemError::Io { context, .. } => write!(f, "while {}", context),
+            SystemError::Io { context, .. } | SystemError::Serde { context, .. } => {
+                write!(f, "while {}", context)
+            }
             SystemError::Guppy(err) => write!(f, "guppy error: {}", err),
         }
     }
@@ -49,6 +76,7 @@ impl error::Error for SystemError {
             SystemError::Exec { .. } => None,
             SystemError::Io { err, .. } => Some(err),
             SystemError::Guppy(err) => Some(err),
+            SystemError::Serde { err, .. } => Some(err.as_ref()),
         }
     }
 }

--- a/devtools/x-lint/src/file.rs
+++ b/devtools/x-lint/src/file.rs
@@ -11,7 +11,6 @@ pub struct FileContext<'l> {
     file_path: &'l Path,
 }
 
-#[allow(dead_code)]
 impl<'l> FileContext<'l> {
     pub fn new(project_ctx: ProjectContext<'l>, file_path: &'l Path) -> Self {
         Self {
@@ -25,6 +24,7 @@ impl<'l> FileContext<'l> {
         self.project_ctx
     }
 
+    /// Returns the path of this file, relative to the root of the repository.
     pub fn file_path(&self) -> &'l Path {
         &self.file_path
     }

--- a/devtools/x-lint/src/lib.rs
+++ b/devtools/x-lint/src/lib.rs
@@ -88,6 +88,8 @@ pub enum SkipReason<'l> {
     NonUtf8,
     /// This extension was unsupported.
     UnsupportedExtension(Option<&'l str>),
+    /// The given file was unsupported by this linter.
+    UnsupportedFile(&'l Path),
     // TODO: Add more reasons.
 }
 

--- a/devtools/x/Cargo.toml
+++ b/devtools/x/Cargo.toml
@@ -12,6 +12,7 @@ serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0.52"
 structopt = "0.3.14"
 anyhow = "1.0"
+colored-diff = "0.2.2"
 guppy = "0.4.1"
 toml = "0.5.6"
 env_logger = "0.7.1"

--- a/devtools/x/src/lint/mod.rs
+++ b/devtools/x/src/lint/mod.rs
@@ -8,6 +8,7 @@ use x_lint::{prelude::*, LintEngineConfig};
 
 mod guppy;
 mod license;
+mod toml;
 mod whitespace;
 
 #[derive(Debug, StructOpt)]
@@ -33,6 +34,7 @@ pub fn run(args: Args, xctx: XContext) -> crate::Result<()> {
 
     let content_linters: &[&dyn ContentLinter] = &[
         &license::LicenseHeader,
+        &toml::RootToml,
         &whitespace::EofNewline,
         &whitespace::TrailingWhitespace,
     ];

--- a/devtools/x/src/lint/toml.rs
+++ b/devtools/x/src/lint/toml.rs
@@ -1,0 +1,105 @@
+// Copyright (c) The Libra Core Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+use colored_diff::PrettyDifference;
+use serde::{Deserialize, Serialize};
+use std::path::Path;
+use toml::{de, ser};
+use x_lint::prelude::*;
+
+/// Checks on the root toml.
+#[derive(Debug)]
+pub struct RootToml;
+
+impl Linter for RootToml {
+    fn name(&self) -> &'static str {
+        "root-toml"
+    }
+}
+
+impl ContentLinter for RootToml {
+    fn pre_run<'l>(&self, file_ctx: &FileContext<'l>) -> Result<RunStatus<'l>> {
+        let file_path = file_ctx.file_path();
+        if file_path == Path::new("Cargo.toml") {
+            Ok(RunStatus::Executed)
+        } else {
+            Ok(RunStatus::Skipped(SkipReason::UnsupportedFile(file_path)))
+        }
+    }
+
+    fn run<'l>(
+        &self,
+        ctx: &ContentContext<'l>,
+        out: &mut LintFormatter<'l, '_>,
+    ) -> Result<RunStatus<'l>> {
+        let contents: RootTomlContents<'_> = de::from_slice(ctx.content_bytes())
+            .map_err(|err| SystemError::de("deserializing root Cargo.toml", err))?;
+        let workspace = contents.workspace;
+
+        // Use guppy to produce a canonical list of workspace paths.
+        // This does two things:
+        // * ensure that workspace members are sorted.
+        // * ensure that every workspace member is listed. Cargo itself doesn't require every
+        //   workspace member to be listed (just leaf packages), but other tools might.
+        let package_graph = ctx.file_ctx().project_ctx().package_graph()?;
+        let expected = Workspace {
+            members: package_graph
+                .workspace()
+                .members()
+                .map(|(path, _)| path)
+                .collect(),
+        };
+
+        if workspace.members != expected.members {
+            // Serialize and compute the diff between them.
+            let expected = to_toml_string(&expected)
+                .map_err(|err| SystemError::ser("serializing expected workspace members", err))?;
+            let actual = to_toml_string(&workspace)
+                .map_err(|err| SystemError::ser("serializing actual workspace members", err))?;
+            // TODO: print out a context diff instead of the full diff.
+            out.write_kind(
+                LintKind::File(Path::new("Cargo.toml")),
+                LintLevel::Error,
+                format!(
+                    "workspace member list not canonical:\n\n{}",
+                    PrettyDifference {
+                        expected: &expected,
+                        actual: &actual
+                    }
+                ),
+            );
+        }
+
+        // TODO: autofix support would be really nice!
+
+        Ok(RunStatus::Executed)
+    }
+}
+
+/// Serializes some data to toml using this project's standard code style.
+fn to_toml_string<T: Serialize>(data: &T) -> Result<String, ser::Error> {
+    let mut dst = String::with_capacity(128);
+    let mut serializer = ser::Serializer::new(&mut dst);
+    serializer
+        .pretty_array(true)
+        .pretty_array_indent(4)
+        .pretty_array_trailing_comma(true)
+        .pretty_string_literal(true)
+        .pretty_string(false);
+    data.serialize(&mut serializer)?;
+    Ok(dst)
+}
+
+#[derive(Debug, Deserialize)]
+struct RootTomlContents<'a> {
+    #[serde(borrow)]
+    workspace: Workspace<'a>,
+    // Add other fields as necessary.
+}
+
+#[derive(Clone, Debug, Deserialize, Serialize)]
+struct Workspace<'a> {
+    #[serde(borrow)]
+    members: Vec<&'a Path>,
+    // Add other fields as necessary.
+}


### PR DESCRIPTION
This is a followup to #3790 which ensures that this doesn't break again.
﻿﻿﻿﻿﻿﻿﻿﻿﻿
Here's what it looks like:

![image](https://user-images.githubusercontent.com/180618/81357421-74ef1900-9088-11ea-9c7f-509864cf5491.png)
