### PR TITLE
[move-prover] Fixing a bug with multiple return values.

### DIFF
--- a/language/move-prover/src/boogie_wrapper.rs
+++ b/language/move-prover/src/boogie_wrapper.rs
@@ -1061,7 +1061,7 @@ impl LocalDescriptor {
         let n = func_target.get_local_count();
         let var_name = if self.var_idx >= n {
             if func_target.get_return_count() > 1 {
-                format!("result_{}", self.var_idx - n)
+                format!("result_{}", self.var_idx - n + 1)
             } else {
                 "result".to_string()
             }

--- a/language/move-prover/stackless-bytecode-generator/src/stackless_bytecode_generator.rs
+++ b/language/move-prover/stackless-bytecode-generator/src/stackless_bytecode_generator.rs
@@ -474,7 +474,6 @@ impl<'a> StacklessBytecodeGenerator<'a> {
                     self.temp_count += 1;
                 }
                 arg_temp_indices.reverse();
-                return_temp_indices.reverse();
                 let callee_env = self.func_env.module_env.get_called_function(*idx);
                 self.code.push(mk_call(
                     Operation::Function(

--- a/language/move-prover/tests/sources/functional/aborts-if.exp
+++ b/language/move-prover/tests/sources/functional/aborts-if.exp
@@ -11,18 +11,22 @@ error:  A postcondition might not hold on this return path.
     =         _x = <redacted>,
     =         _y = <redacted>
 
-error:  A postcondition might not hold on this return path.
+error: abort not covered by any of the `aborts_if` clauses
 
-    ┌── tests/sources/functional/aborts-if.move:47:9 ───
+    ┌── tests/sources/functional/aborts-if.move:43:5 ───
     │
- 47 │         aborts_if x <= y;
-    │         ^^^^^^^^^^^^^^^^^
+ 43 │ ╭     fun abort4_incorrect(x: u64, y: u64) {
+ 44 │ │         if (x > y) abort 1
+ 45 │ │     }
+    │ ╰─────^
+    ·
+ 44 │         if (x > y) abort 1
+    │         ------------------ abort happened here
     │
     =     at tests/sources/functional/aborts-if.move:43:5: abort4_incorrect (entry)
-    =     at tests/sources/functional/aborts-if.move:44:9: abort4_incorrect
+    =     at tests/sources/functional/aborts-if.move:44:9: abort4_incorrect (ABORTED)
     =         x = <redacted>,
     =         y = <redacted>
-    =     at tests/sources/functional/aborts-if.move:43:5: abort4_incorrect (exit)
 
 error: abort not covered by any of the `aborts_if` clauses
 

--- a/language/move-prover/tests/sources/functional/hash_model.exp
+++ b/language/move-prover/tests/sources/functional/hash_model.exp
@@ -14,8 +14,8 @@ error:  A postcondition might not hold on this return path.
     =     at tests/sources/functional/hash_model.move:38:33: hash_test1_incorrect
     =         h2 = <redacted>
     =     at tests/sources/functional/hash_model.move:39:10: hash_test1_incorrect
-    =         result_0 = <redacted>,
-    =         result_1 = <redacted>
+    =         result_1 = <redacted>,
+    =         result_2 = <redacted>
     =     at tests/sources/functional/hash_model.move:35:5: hash_test1_incorrect (exit)
 
 error:  A postcondition might not hold on this return path.
@@ -33,6 +33,6 @@ error:  A postcondition might not hold on this return path.
     =     at tests/sources/functional/hash_model.move:81:33: hash_test2_incorrect
     =         h2 = <redacted>
     =     at tests/sources/functional/hash_model.move:82:10: hash_test2_incorrect
-    =         result_0 = <redacted>,
-    =         result_1 = <redacted>
+    =         result_1 = <redacted>,
+    =         result_2 = <redacted>
     =     at tests/sources/functional/hash_model.move:78:5: hash_test2_incorrect (exit)

--- a/language/move-prover/tests/sources/functional/hash_model_invalid.exp
+++ b/language/move-prover/tests/sources/functional/hash_model_invalid.exp
@@ -14,8 +14,8 @@ error:  A postcondition might not hold on this return path.
     =     at tests/sources/functional/hash_model_invalid.move:9:33: hash_test1
     =         h2 = <redacted>
     =     at tests/sources/functional/hash_model_invalid.move:10:10: hash_test1
-    =         result_0 = <redacted>,
-    =         result_1 = <redacted>
+    =         result_1 = <redacted>,
+    =         result_2 = <redacted>
     =     at tests/sources/functional/hash_model_invalid.move:6:5: hash_test1 (exit)
 
 error:  A postcondition might not hold on this return path.
@@ -33,6 +33,6 @@ error:  A postcondition might not hold on this return path.
     =     at tests/sources/functional/hash_model_invalid.move:24:33: hash_test2
     =         h2 = <redacted>
     =     at tests/sources/functional/hash_model_invalid.move:25:10: hash_test2
-    =         result_0 = <redacted>,
-    =         result_1 = <redacted>
+    =         result_1 = <redacted>,
+    =         result_2 = <redacted>
     =     at tests/sources/functional/hash_model_invalid.move:21:5: hash_test2 (exit)

--- a/language/move-prover/tests/sources/functional/return_values.exp
+++ b/language/move-prover/tests/sources/functional/return_values.exp
@@ -1,36 +1,36 @@
-Move prover returns: exiting with checking errors
-error: no matching declaration of `==`
+Move prover returns: exiting with boogie verification errors
+error:  A postcondition might not hold on this return path.
 
-    ┌── tests/sources/functional/return_values.move:54:17 ───
+    ┌── tests/sources/functional/return_values.move:16:9 ───
     │
- 54 │         ensures result_1 == 1;
-    │                 ^^^^^^^^^^^^^
+ 16 │         ensures result_1 == 2;
+    │         ^^^^^^^^^^^^^^^^^^^^^^
     │
-    = outruled candidate `==(#0, #0): bool` (expected `bool` but found `u128` for argument 2)
+    =     at tests/sources/functional/return_values.move:29:5: one_two_wrapper_incorrect (entry)
+    =     at tests/sources/functional/return_values.move:2:5: one_two (entry)
+    =     at tests/sources/functional/return_values.move:3:9: one_two
+    =         result_1 = <redacted>,
+    =         result_2 = <redacted>
+    =     at tests/sources/functional/return_values.move:2:5: one_two (exit)
+    =     at tests/sources/functional/return_values.move:30:9: one_two_wrapper_incorrect
+    =         result_1 = <redacted>,
+    =         result_2 = <redacted>
+    =     at tests/sources/functional/return_values.move:29:5: one_two_wrapper_incorrect (exit)
 
-error: no matching declaration of `==`
+error:  A postcondition might not hold on this return path.
 
-    ┌── tests/sources/functional/return_values.move:55:17 ───
+    ┌── tests/sources/functional/return_values.move:59:9 ───
     │
- 55 │         ensures result_2 == true;
-    │                 ^^^^^^^^^^^^^^^^
+ 59 │         ensures false;
+    │         ^^^^^^^^^^^^^^
     │
-    = outruled candidate `==(#0, #0): bool` (expected `u64` but found `bool` for argument 2)
-
-error: no matching declaration of `==`
-
-    ┌── tests/sources/functional/return_values.move:82:17 ───
-    │
- 82 │         ensures result_1 == 1;
-    │                 ^^^^^^^^^^^^^
-    │
-    = outruled candidate `==(#0, #0): bool` (expected `bool` but found `u128` for argument 2)
-
-error: no matching declaration of `==`
-
-    ┌── tests/sources/functional/return_values.move:83:17 ───
-    │
- 83 │         ensures result_2 == true;
-    │                 ^^^^^^^^^^^^^^^^
-    │
-    = outruled candidate `==(#0, #0): bool` (expected `u64` but found `bool` for argument 2)
+    =     at tests/sources/functional/return_values.move:55:5: true_one_wrapper_incorrect (entry)
+    =     at tests/sources/functional/return_values.move:38:5: true_one (entry)
+    =     at tests/sources/functional/return_values.move:39:9: true_one
+    =         result_1 = <redacted>,
+    =         result_2 = <redacted>
+    =     at tests/sources/functional/return_values.move:38:5: true_one (exit)
+    =     at tests/sources/functional/return_values.move:56:9: true_one_wrapper_incorrect
+    =         result_1 = <redacted>,
+    =         result_2 = <redacted>
+    =     at tests/sources/functional/return_values.move:55:5: true_one_wrapper_incorrect (exit)

--- a/language/move-prover/tests/sources/functional/return_values.move
+++ b/language/move-prover/tests/sources/functional/return_values.move
@@ -1,6 +1,5 @@
 module TestReturnValue {
-
-    fun one_two(): (u64, u64) {
+    public fun one_two(): (u64, u64) {
         (1, 2)
     }
     spec fun one_two {
@@ -9,36 +8,34 @@ module TestReturnValue {
         ensures result_2 == 2;
     }
 
-    fun one_two_incorrect(): (u64, u64) {
+    public fun one_two_incorrect(): (u64, u64) {
         (1, 2)
     }
-    spec fun one_two_wrapper_incorrect { // FIXME: `result_0` and `result_1` appear in the counterexample. `result_1` and `result_2` should instead.
+    spec fun one_two_wrapper_incorrect {
         aborts_if false;
         ensures result_1 == 2;
         ensures result_2 == 1;
     }
 
-    fun one_two_wrapper(): (u64, u64) {
+    public fun one_two_wrapper(): (u64, u64) {
         one_two()
     }
-    spec fun one_two_wrapper { // FIXME: This is not verified, but should be.
-        pragma verify=false; // TODO: remove this line
+    spec fun one_two_wrapper {
         aborts_if false;
         ensures result_1 == 1;
         ensures result_2 == 2;
     }
 
-    fun one_two_wrapper_incorrect(): (u64, u64) {
+    public fun one_two_wrapper_incorrect(): (u64, u64) {
         one_two()
     }
-    spec fun one_two_wrapper_incorrect { // FIXME: This is verified, but should not be.
-        pragma verify=false; // TODO: remove this line
+    spec fun one_two_wrapper_incorrect {
         aborts_if false;
         ensures result_1 == 2;
         ensures result_2 == 1;
     }
 
-    fun true_one(): (bool, u64) {
+    public fun true_one(): (bool, u64) {
         (true, 1)
     }
     spec fun true_one {
@@ -47,15 +44,7 @@ module TestReturnValue {
         ensures result_2 == 1;
     }
 
-    fun true_one_incorrect(): (bool, u64) {
-        (true, 1)
-    }
-    spec fun true_one_incorrect { // Type checker correctly complains about this spec.
-        ensures result_1 == 1;
-        ensures result_2 == true;
-    }
-
-    fun true_one_wrapper(): (bool, u64) {
+    public fun true_one_wrapper(): (bool, u64) {
         true_one()
     }
     spec fun true_one_wrapper {
@@ -63,23 +52,14 @@ module TestReturnValue {
         ensures result_2 == 1;
     }
 
-    fun true_one_wrapper_incorrect(): (bool, u64) {
+    public fun true_one_wrapper_incorrect(): (bool, u64) {
         true_one()
     }
     spec fun true_one_wrapper_incorrect {
-        pragma verify=false; // TODO: remove this line
-        ensures false; // FIXME: generated boogie code introduces a contradiction among assumptions, thus making "false" to be proved
+        ensures false;
         ensures result_1 == true;
         ensures result_1 == false;
         ensures result_2 == 0;
         ensures result_2 == 1;
-    }
-
-    fun another_true_one_wrapper_incorrect(): (bool, u64) {
-        true_one()
-    }
-    spec fun another_true_one_wrapper_incorrect { // Type checker correctly complains about this spec.
-        ensures result_1 == 1;
-        ensures result_2 == true;
     }
 }

--- a/language/move-prover/tests/sources/functional/serialize_model.exp
+++ b/language/move-prover/tests/sources/functional/serialize_model.exp
@@ -14,6 +14,6 @@ error:  A postcondition might not hold on this return path.
     =     at tests/sources/functional/serialize_model.move:24:32: lcs_test1_incorrect
     =         s2 = <redacted>
     =     at tests/sources/functional/serialize_model.move:25:10: lcs_test1_incorrect
-    =         result_0 = <redacted>,
-    =         result_1 = <redacted>
+    =         result_1 = <redacted>,
+    =         result_2 = <redacted>
     =     at tests/sources/functional/serialize_model.move:21:5: lcs_test1_incorrect (exit)


### PR DESCRIPTION
Stackless bytecode generator reverted indices for returns from calls incorrectly, which is fixed here. Also aligning boogie wrapper with language to print out `result_1` instead of `result_0`.

## Motivation

Bug fix.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?

Yes.

## Test Plan

cargo test

## Related PRs

NA
