### PR TITLE
[crypto, test-only] add a `sign_arbitrary_message` to Crypto API 

### DIFF
--- a/crypto/crypto-derive/src/unions.rs
+++ b/crypto/crypto-derive/src/unions.rs
@@ -202,11 +202,15 @@ pub fn impl_enum_signingkey(
     let st: syn::Type = signature_type.parse().unwrap();
 
     let mut match_arms = quote! {};
+    let mut match_arms_arbitrary = quote! {};
     for variant in variants.variants.iter() {
         let variant_ident = &variant.ident;
 
         match_arms.extend(quote! {
             #name::#variant_ident(key) => Self::SignatureMaterial::#variant_ident(key.sign_message(message)),
+        });
+        match_arms_arbitrary.extend(quote! {
+            #name::#variant_ident(key) => Self::SignatureMaterial::#variant_ident(key.sign_arbitrary_message(message)),
         });
     }
     let res = quote! {
@@ -217,6 +221,13 @@ pub fn impl_enum_signingkey(
             fn sign_message(&self, message: &libra_crypto::HashValue) -> Self::SignatureMaterial {
                 match self {
                     #match_arms
+                }
+            }
+
+            #[cfg(test)]
+            fn sign_arbitrary_message(&self, message: &[u8]) -> Self::SignatureMaterial {
+                match self {
+                    #match_arms_arbitrary
                 }
             }
         }

--- a/crypto/crypto/src/multi_ed25519.rs
+++ b/crypto/crypto/src/multi_ed25519.rs
@@ -153,6 +153,23 @@ impl SigningKey for MultiEd25519PrivateKey {
         );
         MultiEd25519Signature { signatures, bitmap }
     }
+
+    #[cfg(test)]
+    fn sign_arbitrary_message(&self, message: &[u8]) -> MultiEd25519Signature {
+        let mut signatures: Vec<Ed25519Signature> = Vec::with_capacity(self.threshold as usize);
+        let mut bitmap = [0u8; BITMAP_NUM_OF_BYTES];
+        signatures.extend(
+            self.private_keys
+                .iter()
+                .take(self.threshold as usize)
+                .enumerate()
+                .map(|(i, item)| {
+                    bitmap_set_bit(&mut bitmap, i);
+                    item.sign_arbitrary_message(message)
+                }),
+        );
+        MultiEd25519Signature { signatures, bitmap }
+    }
 }
 
 // Generating a random K out-of N key for testing.

--- a/crypto/crypto/src/traits.rs
+++ b/crypto/crypto/src/traits.rs
@@ -122,6 +122,9 @@ pub trait SigningKey:
     /// Signs an input message.
     fn sign_message(&self, message: &HashValue) -> Self::SignatureMaterial;
 
+    #[cfg(test)]
+    fn sign_arbitrary_message(&self, message: &[u8]) -> Self::SignatureMaterial;
+
     /// Returns the associated verifying key
     fn verifying_key(&self) -> Self::VerifyingKeyMaterial {
         self.public_key()


### PR DESCRIPTION
This is gated under `#[cfg(test)]` until we figure out a policy for tagging and domain separation (also known as [contexts](https://github.com/dalek-cryptography/ed25519-dalek/blob/36a51acbf0ca2c10d974940182c0ff63f530c9d3/src/ed25519.rs#L189-L206)).

Note this bypasses sha3-hashing and/or lcs by request. 

Review by AND of @leiwei @kchalkias @sblackshear,
appreciated looks from @valerini @davidiw  for good measure,