### PR TITLE
[secure-storage] Refactoring

### DIFF
--- a/config/management/src/layout.rs
+++ b/config/management/src/layout.rs
@@ -62,7 +62,7 @@ impl SetLayout {
 
         let value = Value::String(data);
         remote
-            .create_with_default_policy(LAYOUT, value)
+            .set(LAYOUT, value)
             .map_err(|e| Error::RemoteStorageWriteError(e.to_string()))?;
 
         Ok(layout)

--- a/config/management/src/lib.rs
+++ b/config/management/src/lib.rs
@@ -262,7 +262,7 @@ impl Command {
             }
 
             remote
-                .create_with_default_policy(key_name, key)
+                .set(key_name, key)
                 .map_err(|e| Error::RemoteStorageWriteError(e.to_string()))?;
         }
 
@@ -515,16 +515,10 @@ pub mod tests {
         storage.create_key(OPERATOR_KEY, &policy).unwrap();
         storage.create_key(VALIDATOR_NETWORK_KEY, &policy).unwrap();
 
-        storage.create(EPOCH, Value::U64(0), &policy).unwrap();
-        storage
-            .create(LAST_VOTED_ROUND, Value::U64(0), &policy)
-            .unwrap();
-        storage
-            .create(PREFERRED_ROUND, Value::U64(0), &policy)
-            .unwrap();
-        storage
-            .create(WAYPOINT, Value::String("".into()), &policy)
-            .unwrap();
+        storage.set(EPOCH, Value::U64(0)).unwrap();
+        storage.set(LAST_VOTED_ROUND, Value::U64(0)).unwrap();
+        storage.set(PREFERRED_ROUND, Value::U64(0)).unwrap();
+        storage.set(WAYPOINT, Value::String("".into())).unwrap();
     }
 
     fn association_key(local_ns: &str, remote_ns: &str) -> Result<Ed25519PublicKey, Error> {

--- a/config/management/src/validator_config.rs
+++ b/config/management/src/validator_config.rs
@@ -96,7 +96,7 @@ impl ValidatorConfig {
 
             let txn = Value::Transaction(txn.clone());
             remote
-                .create_with_default_policy(VALIDATOR_CONFIG, txn)
+                .set(VALIDATOR_CONFIG, txn)
                 .map_err(|e| Error::RemoteStorageWriteError(e.to_string()))?;
         }
 

--- a/config/src/config/secure_config.rs
+++ b/config/src/config/secure_config.rs
@@ -66,6 +66,10 @@ pub struct VaultConfig {
 pub struct OnDiskStorageConfig {
     // Required path for on disk storage
     pub path: PathBuf,
+    /// A namespace is an optional portion of the path to a key stored within OnDiskStorage. For
+    /// example, a key, S, without a namespace would be available in S, with a namespace, N, it
+    /// would be in N/S.
+    pub namespace: Option<String>,
     #[serde(skip)]
     data_dir: PathBuf,
 }
@@ -73,6 +77,7 @@ pub struct OnDiskStorageConfig {
 impl Default for OnDiskStorageConfig {
     fn default() -> Self {
         Self {
+            namespace: None,
             path: PathBuf::from("safety_rules.toml"),
             data_dir: PathBuf::from("/opt/libra/data/common"),
         }

--- a/consensus/safety-rules/src/persistent_safety_storage.rs
+++ b/consensus/safety-rules/src/persistent_safety_storage.rs
@@ -5,7 +5,7 @@ use anyhow::Result;
 use consensus_types::common::Round;
 use libra_crypto::ed25519::Ed25519PrivateKey;
 use libra_global_constants::{CONSENSUS_KEY, EPOCH, LAST_VOTED_ROUND, PREFERRED_ROUND, WAYPOINT};
-use libra_secure_storage::{InMemoryStorage, Policy, Storage, Value};
+use libra_secure_storage::{InMemoryStorage, Storage, Value};
 use libra_types::waypoint::Waypoint;
 use std::str::FromStr;
 
@@ -41,20 +41,11 @@ impl PersistentSafetyStorage {
         private_key: Ed25519PrivateKey,
         waypoint: Waypoint,
     ) -> Result<()> {
-        let perms = Policy::public();
-        internal_store.create_if_not_exists(
-            CONSENSUS_KEY,
-            Value::Ed25519PrivateKey(private_key),
-            &perms,
-        )?;
-        internal_store.create_if_not_exists(EPOCH, Value::U64(1), &perms)?;
-        internal_store.create_if_not_exists(LAST_VOTED_ROUND, Value::U64(0), &perms)?;
-        internal_store.create_if_not_exists(PREFERRED_ROUND, Value::U64(0), &perms)?;
-        internal_store.create_if_not_exists(
-            WAYPOINT,
-            Value::String(waypoint.to_string()),
-            &perms,
-        )?;
+        internal_store.set(CONSENSUS_KEY, Value::Ed25519PrivateKey(private_key))?;
+        internal_store.set(EPOCH, Value::U64(1))?;
+        internal_store.set(LAST_VOTED_ROUND, Value::U64(0))?;
+        internal_store.set(PREFERRED_ROUND, Value::U64(0))?;
+        internal_store.set(WAYPOINT, Value::String(waypoint.to_string()))?;
         Ok(())
     }
 

--- a/secure/storage/Cargo.toml
+++ b/secure/storage/Cargo.toml
@@ -31,3 +31,4 @@ rand = "0.7.3"
 
 [features]
 fuzzing = ["libra-crypto/fuzzing"]
+testing = []

--- a/secure/storage/src/crypto_kv_storage.rs
+++ b/secure/storage/src/crypto_kv_storage.rs
@@ -14,18 +14,15 @@ use rand::{rngs::OsRng, Rng, SeedableRng};
 pub trait CryptoKVStorage: KVStorage {}
 
 impl<T: CryptoKVStorage> CryptoStorage for T {
-    fn create_key(&mut self, name: &str, policy: &Policy) -> Result<Ed25519PublicKey, Error> {
+    fn create_key(&mut self, name: &str, _policy: &Policy) -> Result<Ed25519PublicKey, Error> {
         // Generate and store the new named key pair
         let (private_key, public_key) = new_ed25519_key_pair()?;
-        self.create(name, Value::Ed25519PrivateKey(private_key), policy)?;
+        self.set(name, Value::Ed25519PrivateKey(private_key))?;
 
-        // Set the previous key pair version to be the newly generated key pair. This is useful so
-        // that we can also set the appropriate policy permissions on the previous key pair version
-        // now, and not have to do it later on a rotation.
-        self.create(
+        // Set the previous key pair version to be the newly generated key pair.
+        self.set(
             &get_previous_version_name(name),
             Value::Ed25519PrivateKey(self.export_private_key(name)?),
-            policy,
         )?;
 
         Ok(public_key)

--- a/secure/storage/src/crypto_storage.rs
+++ b/secure/storage/src/crypto_storage.rs
@@ -15,6 +15,8 @@ use std::time::{Duration, SystemTime};
 /// https://www.vaultproject.io/docs/secrets/transit/index.html).
 pub trait CryptoStorage: Send + Sync {
     /// Securely generates a new named Ed25519 key pair and returns the corresponding public key.
+    /// There are no guarantees about the state of the system after calling this multiple times.
+    /// The behavior is implementation specific.
     ///
     /// The new key pair is named according to the 'name' and is held in secure storage
     /// under the given 'policy'. To access or use the key pair (e.g., sign or encrypt data),

--- a/secure/storage/src/in_memory.rs
+++ b/secure/storage/src/in_memory.rs
@@ -1,7 +1,7 @@
 // Copyright (c) The Libra Core Contributors
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::{CryptoKVStorage, Error, GetResponse, KVStorage, Policy, Storage, Value};
+use crate::{CryptoKVStorage, Error, GetResponse, KVStorage, Storage, Value};
 use libra_secure_time::{RealTimeService, TimeService};
 use std::collections::HashMap;
 
@@ -44,18 +44,6 @@ impl<T: Send + Sync + TimeService> KVStorage for InMemoryStorageInternal<T> {
         true
     }
 
-    fn create(&mut self, key: &str, value: Value, _policy: &Policy) -> Result<(), Error> {
-        if self.data.contains_key(key) {
-            return Err(Error::KeyAlreadyExists(key.to_string()));
-        }
-
-        self.data.insert(
-            key.to_string(),
-            GetResponse::new(value, self.time_service.now()),
-        );
-        Ok(())
-    }
-
     fn get(&self, key: &str) -> Result<GetResponse, Error> {
         let response = self
             .data
@@ -81,9 +69,6 @@ impl<T: Send + Sync + TimeService> KVStorage for InMemoryStorageInternal<T> {
     }
 
     fn set(&mut self, key: &str, value: Value) -> Result<(), Error> {
-        if !self.data.contains_key(key) {
-            return Err(Error::KeyNotSet(key.to_string()));
-        }
         self.data.insert(
             key.to_string(),
             GetResponse::new(value, self.time_service.now()),

--- a/secure/storage/src/in_memory.rs
+++ b/secure/storage/src/in_memory.rs
@@ -76,6 +76,7 @@ impl<T: Send + Sync + TimeService> KVStorage for InMemoryStorageInternal<T> {
         Ok(())
     }
 
+    #[cfg(any(test, feature = "testing"))]
     fn reset_and_clear(&mut self) -> Result<(), Error> {
         self.data.clear();
         Ok(())

--- a/secure/storage/src/kv_storage.rs
+++ b/secure/storage/src/kv_storage.rs
@@ -20,10 +20,10 @@ pub trait KVStorage: Send + Sync {
     /// invalid permissions.
     fn set(&mut self, key: &str, value: Value) -> Result<(), Error>;
 
-    // @TODO(davidiw): Make this accessible only to tests.
     /// Resets and clears all data held in the storage engine.
     /// Note: this should only be exposed and used for testing. Resetting the storage engine is not
     /// something that should be supported in production.
+    #[cfg(any(test, feature = "testing"))]
     fn reset_and_clear(&mut self) -> Result<(), Error>;
 }
 

--- a/secure/storage/src/kv_storage.rs
+++ b/secure/storage/src/kv_storage.rs
@@ -1,7 +1,7 @@
 // Copyright (c) The Libra Core Contributors
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::{Error, Policy, Value};
+use crate::{Error, Value};
 use serde::{Deserialize, Serialize};
 
 /// A secure key/value storage engine. Create takes a policy that is enforced internally by the
@@ -12,33 +12,12 @@ pub trait KVStorage: Send + Sync {
     /// Returns true if the backend service is online and available.
     fn available(&self) -> bool;
 
-    /// Creates a new value in storage and fails if it already exists
-    fn create(&mut self, key: &str, value: Value, policy: &Policy) -> Result<(), Error>;
-
-    fn create_with_default_policy(&mut self, key: &str, value: Value) -> Result<(), Error> {
-        self.create(key, value, &Policy::default())
-    }
-
-    /// Creates a new value if it does not exist fails only if there is some other issue.
-    fn create_if_not_exists(
-        &mut self,
-        key: &str,
-        value: Value,
-        policy: &Policy,
-    ) -> Result<(), Error> {
-        self.create(key, value, policy).or_else(|err| {
-            if let Error::KeyAlreadyExists(_) = err {
-                Ok(())
-            } else {
-                Err(err)
-            }
-        })
-    }
-
-    /// Retrieves a value from storage and fails if invalid permissions or it does not exist
+    /// Retrieves a value from storage and fails if the backend is unavailable or the process has
+    /// invalid permissions.
     fn get(&self, key: &str) -> Result<GetResponse, Error>;
 
-    /// Sets a value in storage and fails if invalid permissions or it does not exist
+    /// Sets a value in storage and fails if the backend is unavailable or the process has
+    /// invalid permissions.
     fn set(&mut self, key: &str, value: Value) -> Result<(), Error>;
 
     // @TODO(davidiw): Make this accessible only to tests.

--- a/secure/storage/src/lib.rs
+++ b/secure/storage/src/lib.rs
@@ -36,7 +36,14 @@ impl From<&SecureBackend> for Box<dyn Storage> {
     fn from(backend: &SecureBackend) -> Self {
         match backend {
             SecureBackend::InMemoryStorage => Box::new(InMemoryStorage::new()),
-            SecureBackend::OnDiskStorage(config) => Box::new(OnDiskStorage::new(config.path())),
+            SecureBackend::OnDiskStorage(config) => {
+                let storage = OnDiskStorage::new(config.path());
+                if let Some(namespace) = &config.namespace {
+                    Box::new(NamespacedStorage::new(storage, namespace.clone()))
+                } else {
+                    Box::new(storage)
+                }
+            }
             SecureBackend::Vault(config) => Box::new(VaultStorage::new(
                 config.server.clone(),
                 config.token.clone(),

--- a/secure/storage/src/namespaced_storage.rs
+++ b/secure/storage/src/namespaced_storage.rs
@@ -26,6 +26,7 @@ impl<T: KVStorage> KVStorage for NamespacedStorage<T> {
     }
 
     /// Note: This is not a namespace function
+    #[cfg(any(test, feature = "testing"))]
     fn reset_and_clear(&mut self) -> Result<(), Error> {
         self.inner.reset_and_clear()
     }

--- a/secure/storage/src/namespaced_storage.rs
+++ b/secure/storage/src/namespaced_storage.rs
@@ -1,7 +1,7 @@
 // Copyright (c) The Libra Core Contributors
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::{Error, GetResponse, KVStorage, Policy, Value};
+use crate::{Error, GetResponse, KVStorage, Value};
 
 /// This provides a light wrapper around KV storages to support a namespace. That namespace is
 /// effectively prefixing all keys with then namespace value and "/" so a namespace of foo and a
@@ -15,10 +15,6 @@ pub struct NamespacedStorage<T> {
 impl<T: KVStorage> KVStorage for NamespacedStorage<T> {
     fn available(&self) -> bool {
         self.inner.available()
-    }
-
-    fn create(&mut self, key: &str, value: Value, policy: &Policy) -> Result<(), Error> {
-        self.inner.create(&self.ns_name(key), value, policy)
     }
 
     fn get(&self, key: &str) -> Result<GetResponse, Error> {
@@ -79,11 +75,9 @@ mod test {
         let storage = OnDiskStorage::new(path_buf);
         let mut nss1 = NamespacedStorage::new(storage, Some(ns1.into()));
 
-        let policy = Policy::public();
-
-        nss_default.create(key, Value::U64(0), &policy).unwrap();
-        nss0.create(key, Value::U64(1), &policy).unwrap();
-        nss1.create(key, Value::U64(2), &policy).unwrap();
+        nss_default.set(key, Value::U64(0)).unwrap();
+        nss0.set(key, Value::U64(1)).unwrap();
+        nss1.set(key, Value::U64(2)).unwrap();
 
         assert_eq!(nss_default.get(key).unwrap().value, Value::U64(0));
         assert_eq!(nss0.get(key).unwrap().value, Value::U64(1));
@@ -106,7 +100,7 @@ mod test {
         let storage = OnDiskStorage::new(path_buf);
         let another_nss = NamespacedStorage::new(storage, Some(ns.into()));
 
-        nss.create(key, Value::U64(1), &Policy::public()).unwrap();
+        nss.set(key, Value::U64(1)).unwrap();
         nss_default.get(key).unwrap_err();
         assert_eq!(nss.get(key).unwrap().value, Value::U64(1));
         assert_eq!(another_nss.get(key).unwrap().value, Value::U64(1));

--- a/secure/storage/src/on_disk.rs
+++ b/secure/storage/src/on_disk.rs
@@ -93,6 +93,7 @@ impl<T: Send + Sync + TimeService> KVStorage for OnDiskStorageInternal<T> {
         self.write(&data)
     }
 
+    #[cfg(any(test, feature = "testing"))]
     fn reset_and_clear(&mut self) -> Result<(), Error> {
         self.write(&HashMap::new())
     }

--- a/secure/storage/src/on_disk.rs
+++ b/secure/storage/src/on_disk.rs
@@ -1,7 +1,7 @@
 // Copyright (c) The Libra Core Contributors
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::{CryptoKVStorage, Error, GetResponse, KVStorage, Policy, Storage, Value};
+use crate::{CryptoKVStorage, Error, GetResponse, KVStorage, Storage, Value};
 use libra_secure_time::{RealTimeService, TimeService};
 use libra_temppath::TempPath;
 use std::{
@@ -78,18 +78,6 @@ impl<T: Send + Sync + TimeService> KVStorage for OnDiskStorageInternal<T> {
         true
     }
 
-    fn create(&mut self, key: &str, value: Value, _policy: &Policy) -> Result<(), Error> {
-        let mut data = self.read()?;
-        if data.contains_key(key) {
-            return Err(Error::KeyAlreadyExists(key.to_string()));
-        }
-        data.insert(
-            key.to_string(),
-            GetResponse::new(value, self.time_service.now()),
-        );
-        self.write(&data)
-    }
-
     fn get(&self, key: &str) -> Result<GetResponse, Error> {
         let mut data = self.read()?;
         data.remove(key)
@@ -98,9 +86,6 @@ impl<T: Send + Sync + TimeService> KVStorage for OnDiskStorageInternal<T> {
 
     fn set(&mut self, key: &str, value: Value) -> Result<(), Error> {
         let mut data = self.read()?;
-        if !data.contains_key(key) {
-            return Err(Error::KeyNotSet(key.to_string()));
-        }
         data.insert(
             key.to_string(),
             GetResponse::new(value, self.time_service.now()),

--- a/secure/storage/src/storage.rs
+++ b/secure/storage/src/storage.rs
@@ -31,6 +31,7 @@ impl KVStorage for BoxStorage {
         self.0.set(key, value)
     }
 
+    #[cfg(any(test, feature = "testing"))]
     fn reset_and_clear(&mut self) -> Result<(), Error> {
         self.0.reset_and_clear()
     }

--- a/secure/storage/src/storage.rs
+++ b/secure/storage/src/storage.rs
@@ -23,10 +23,6 @@ impl KVStorage for BoxStorage {
         self.0.available()
     }
 
-    fn create(&mut self, key: &str, value: Value, policy: &Policy) -> Result<(), Error> {
-        self.0.create(key, value, policy)
-    }
-
     fn get(&self, key: &str) -> Result<GetResponse, Error> {
         self.0.get(key)
     }

--- a/secure/storage/src/tests/vault.rs
+++ b/secure/storage/src/tests/vault.rs
@@ -15,12 +15,6 @@ const VAULT_NAMESPACE_1: &str = "namespace_1";
 const VAULT_NAMESPACE_2: &str = "namespace_2";
 const VAULT_NAMESPACE_3: &str = "namespace_3";
 
-/// Storage data constants for testing purposes.
-const U64_KEY_1: &str = "U64 Key 1";
-const U64_KEY_2: &str = "U64 Key 2";
-const U64_VALUE_1: u64 = 10;
-const U64_VALUE_2: u64 = 304;
-
 /// This holds the canonical list of vault storage tests. This is required because vault tests
 /// cannot currently be run in parallel, as each test uses the same vault instance and
 /// storage resets can interfere between tests. To avoid this, we run each test sequentially, and
@@ -29,8 +23,6 @@ const VAULT_TESTS: &[fn()] = &[
     test_vault_crypto_policies,
     test_vault_key_value_policies,
     test_suite_multiple_namespaces,
-    test_vault_namespace_reset,
-    test_vault_no_namespace_reset,
     test_suite_no_namespaces,
 ];
 
@@ -51,41 +43,6 @@ fn execute_storage_tests_vault() {
             .reset_and_clear()
             .expect("Failed to reset storage engine between tests!");
     }
-}
-
-/// Verifies that when calling reset on a VaultStorage instance, if the instance was created with
-/// a namespace, only the secrets within the namespace are removed. This helps to ensure operations
-/// across namespaces do not interfere.
-fn test_vault_namespace_reset() {
-    let mut storage_1 = create_vault_with_namespace(Some(VAULT_NAMESPACE_1.into()));
-    let mut storage_2 = create_vault_with_namespace(Some(VAULT_NAMESPACE_2.into()));
-    storage_1.set(U64_KEY_1, Value::U64(U64_VALUE_1)).unwrap();
-    storage_2.set(U64_KEY_1, Value::U64(U64_VALUE_1)).unwrap();
-
-    // Verify resets do not occur across namespaces
-    storage_1
-        .reset_and_clear()
-        .expect("Failed to reset VaultStorage with namespace!");
-    assert!(storage_1.get(U64_KEY_1).is_err());
-    assert_eq!(
-        storage_2.get(U64_KEY_1).unwrap().value.u64().unwrap(),
-        U64_VALUE_1
-    );
-}
-
-/// Verifies that when calling reset on a VaultStorage instance, if the instance was created without
-/// a namespace, all data in the storage engine will be cleared
-fn test_vault_no_namespace_reset() {
-    let mut storage_1 = create_vault_with_namespace(Some(VAULT_NAMESPACE_1.into()));
-    let mut storage_2 = create_vault_with_namespace(Some(VAULT_NAMESPACE_2.into()));
-    storage_1.set(U64_KEY_1, Value::U64(U64_VALUE_1)).unwrap();
-    storage_2.set(U64_KEY_2, Value::U64(U64_VALUE_2)).unwrap();
-
-    // Create a VaultStorage without a namespace, reset the instance, and ensure all data is cleared
-    // regardless of namespaces.
-    create_vault_with_namespace(None).reset_and_clear().unwrap();
-    assert!(storage_1.get(U64_KEY_1).is_err());
-    assert!(storage_2.get(U64_KEY_2).is_err());
 }
 
 /// Runs the test suite on a VaultStorage instance that does not use distinct namespaces

--- a/secure/storage/src/tests/vault.rs
+++ b/secure/storage/src/tests/vault.rs
@@ -2,8 +2,9 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::{
-    tests::suite, vault::VaultStorage, Capability, CryptoStorage, Error, Identity, KVStorage,
-    Permission, Policy, Value,
+    tests::suite,
+    vault::{VaultEngine, VaultStorage},
+    Capability, CryptoStorage, Error, Identity, KVStorage, Permission, Policy, Value,
 };
 use libra_crypto::{HashValue, Signature};
 
@@ -58,12 +59,8 @@ fn execute_storage_tests_vault() {
 fn test_vault_namespace_reset() {
     let mut storage_1 = create_vault_with_namespace(Some(VAULT_NAMESPACE_1.into()));
     let mut storage_2 = create_vault_with_namespace(Some(VAULT_NAMESPACE_2.into()));
-    storage_1
-        .create(U64_KEY_1, Value::U64(U64_VALUE_1), &Policy::public())
-        .unwrap();
-    storage_2
-        .create(U64_KEY_1, Value::U64(U64_VALUE_1), &Policy::public())
-        .unwrap();
+    storage_1.set(U64_KEY_1, Value::U64(U64_VALUE_1)).unwrap();
+    storage_2.set(U64_KEY_1, Value::U64(U64_VALUE_1)).unwrap();
 
     // Verify resets do not occur across namespaces
     storage_1
@@ -81,18 +78,12 @@ fn test_vault_namespace_reset() {
 fn test_vault_no_namespace_reset() {
     let mut storage_1 = create_vault_with_namespace(Some(VAULT_NAMESPACE_1.into()));
     let mut storage_2 = create_vault_with_namespace(Some(VAULT_NAMESPACE_2.into()));
-    storage_1
-        .create(U64_KEY_1, Value::U64(U64_VALUE_1), &Policy::public())
-        .unwrap();
-    storage_2
-        .create(U64_KEY_2, Value::U64(U64_VALUE_2), &Policy::public())
-        .unwrap();
+    storage_1.set(U64_KEY_1, Value::U64(U64_VALUE_1)).unwrap();
+    storage_2.set(U64_KEY_2, Value::U64(U64_VALUE_2)).unwrap();
 
     // Create a VaultStorage without a namespace, reset the instance, and ensure all data is cleared
     // regardless of namespaces.
-    create_vault_with_namespace(None)
-        .reset_and_clear()
-        .expect("Failed to reset VaultStorage without namespace!");
+    create_vault_with_namespace(None).reset_and_clear().unwrap();
     assert!(storage_1.get(U64_KEY_1).is_err());
     assert!(storage_2.get(U64_KEY_2).is_err());
 }
@@ -153,10 +144,25 @@ fn test_vault_key_value_policies() {
 
     // Initialize data and policies
 
-    storage.create("anyone", Value::U64(1), &anyone).unwrap();
-    storage.create("root", Value::U64(2), &root).unwrap();
-    storage.create("partial", Value::U64(3), &partial).unwrap();
-    storage.create("full", Value::U64(4), &full).unwrap();
+    storage.set("anyone", Value::U64(1)).unwrap();
+    storage
+        .set_policies("anyone", &VaultEngine::KVSecrets, &anyone)
+        .unwrap();
+
+    storage.set("root", Value::U64(2)).unwrap();
+    storage
+        .set_policies("root", &VaultEngine::KVSecrets, &root)
+        .unwrap();
+
+    storage.set("partial", Value::U64(3)).unwrap();
+    storage
+        .set_policies("partial", &VaultEngine::KVSecrets, &partial)
+        .unwrap();
+
+    storage.set("full", Value::U64(4)).unwrap();
+    storage
+        .set_policies("full", &VaultEngine::KVSecrets, &full)
+        .unwrap();
 
     // Verify initial reading works correctly
 

--- a/secure/storage/src/vault.rs
+++ b/secure/storage/src/vault.rs
@@ -239,6 +239,7 @@ impl KVStorage for VaultStorage {
         Ok(())
     }
 
+    #[cfg(any(test, feature = "testing"))]
     fn reset_and_clear(&mut self) -> Result<(), Error> {
         self.reset()
     }


### PR DESCRIPTION
This addresses a lot of lingering issues that we've seen as we add more features and expand the utility of secure storage:

* Policy wasn't being used, no platforms had a create function, so we eliminated policy from KV and create from everywhere -- this doesn't affect the crypto api which has different expectations -- some create_key operations allow repetition and others do not...
* moved reset and clear to test only -- not really sure why we call it reset_and_clear reset is sufficient -- maybe I'll add one more commit
* NamespacedStorage doesn't have per namespace reset, this removes it from vault as well as it just added more technical complexity for a /test/ only feature
* SecureBackend can now leverage NamespacedStorage for OnDisk