### PR TITLE
[network] add connection bench

### DIFF
--- a/network/socket-bench-server/src/lib.rs
+++ b/network/socket-bench-server/src/lib.rs
@@ -10,7 +10,7 @@ use futures::{
     stream::{Stream, StreamExt},
 };
 use libra_crypto::test_utils::TEST_SEED;
-use libra_logger::error;
+use libra_logger::prelude::*;
 use libra_network_address::NetworkAddress;
 use memsocket::MemorySocket;
 use netcore::{
@@ -97,29 +97,34 @@ pub fn build_tcp_noise_transport() -> impl Transport<Output = NoiseSocket<TcpSoc
 
 /// Server side handler for send throughput benchmark when the messages are sent
 /// over a simple stream (tcp or in-memory).
-pub async fn server_stream_handler<L, I, S, E>(server_listener: L, executor: Handle)
+pub async fn server_stream_handler<L, I, S, E>(server_listener: L)
 where
     L: Stream<Item = Result<(I, NetworkAddress), E>> + Unpin,
-    I: Future<Output = Result<S, E>>,
+    I: Future<Output = Result<S, E>> + Send + 'static,
     S: AsyncRead + AsyncWrite + Unpin + Send + 'static,
-    E: ::std::error::Error,
+    E: ::std::error::Error + Send,
 {
-    // Wait for next inbound connection
+    // Wait for next inbound connection, this simulated the TransportHandler
+    // which is single-threaded asynchronous accepting new connections.
     server_listener
-        .for_each_concurrent(1024, |result| async {
+        .for_each_concurrent(None, |result| async {
             match result {
                 Ok((f_stream, _)) => {
-                    let stream = f_stream.await.unwrap();
-                    let mut stream =
-                        Framed::new(IoCompat::new(stream), LengthDelimitedCodec::new());
+                    match f_stream.await {
+                        Ok(stream) => {
+                            let mut stream =
+                                Framed::new(IoCompat::new(stream), LengthDelimitedCodec::new());
 
-                    // Drain all messages from the client.
-                    executor.spawn(async move {
-                        while let Some(_) = stream.next().await {}
-                        stream.close().await.unwrap();
-                    });
+                            tokio::task::spawn(async move {
+                                // Drain all messages from the client.
+                                while let Some(_) = stream.next().await {}
+                                stream.close().await.unwrap();
+                            });
+                        }
+                        Err(e) => error!("Connection upgrade failed {:?}", e),
+                    };
                 }
-                Err(e) => error!("{:?}", e),
+                Err(e) => error!("Stream failed {:?}", e),
             }
         })
         .await
@@ -138,6 +143,6 @@ where
     E: ::std::error::Error + Send + Sync + 'static,
 {
     let (listener, server_addr) = executor.enter(move || transport.listen_on(listen_addr).unwrap());
-    executor.spawn(server_stream_handler(listener, executor.clone()));
+    executor.spawn(server_stream_handler(listener));
     server_addr
 }

--- a/network/socket-bench-server/src/main.rs
+++ b/network/socket-bench-server/src/main.rs
@@ -9,24 +9,29 @@
 //! You can run `socket_bench` across a real network by running this bench
 //! server remotely. For example,
 //!
-//! `TCP_ADDR=/ip6/::1/tcp/12345 cargo run --release --bin socket-bench-server`
+//! `TCP_ADDR=/ip6/::1/tcp/12345 cargo run --release -p socket-bench-server`
 //!
 //! will run the socket bench server handling the remote_tcp benchmark. A
 //! corresponding client would exercise this benchmark using
 //!
-//! `TCP_ADDR=/ip6/::1/tcp/12345 cargo bench -p network remote_tcp`
+//! `TCP_ADDR=/ip6/::1/tcp/12345 cargo x bench -p network remote_tcp`
 
 use libra_logger::info;
 use netcore::transport::tcp::TcpTransport;
 use socket_bench_server::{build_tcp_noise_transport, start_stream_server, Args};
-use tokio::runtime::Runtime;
+use tokio::runtime::Builder;
 
 fn main() {
     ::libra_logger::Logger::new().init();
 
     let args = Args::from_env();
 
-    let rt = Runtime::new().unwrap();
+    let rt = Builder::new()
+        .threaded_scheduler()
+        .core_threads(32)
+        .enable_all()
+        .build()
+        .unwrap();
     let executor = rt.handle();
 
     if let Some(addr) = args.tcp_addr {


### PR DESCRIPTION
<!--
Thank you for sending a PR. We appreciate you spending time to help improve the Libra project.

The project is undergoing daily changes. Pull Requests will be reviewed and responded to as time permits.
-->

## Motivation

Add a bench that concurrently dial the socket-bench-server and reports the connection throughput.

I got a bunch of `ERROR 2020-05-09 02:15:13 network/benches/socket_bench.rs:335 Failed to upgrade Os { code: 35, kind: WouldBlock, message: "Resource temporarily unavailable" }` during the bench locally

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?

Y

## Test Plan
connection_throughput/noise_connections/8
                        time:   [7.3759 ms 21.138 ms 31.734 ms]
                        thrpt:  [252.10  elem/s 378.46  elem/s 1.0846 Kelem/s]
                 change:
                        time:   [-99.660% -98.887% -92.724%] (p = 0.13 > 0.05)
                        thrpt:  [+1274.5% +8882.4% +29290%]
                        No change in performance detected.
connection_throughput/noise_connections/16
                        time:   [22.851 ms 35.741 ms 53.560 ms]
                        thrpt:  [298.73  elem/s 447.67  elem/s 700.19  elem/s]
                 change:
                        time:   [-79.029% -36.994% +285.42%] (p = 0.97 > 0.05)
                        thrpt:  [-74.055% +58.716% +376.85%]
                        No change in performance detected.
connection_throughput/noise_connections/32
                        time:   [43.750 ms 93.395 ms 204.73 ms]
                        thrpt:  [156.30  elem/s 342.63  elem/s 731.42  elem/s]
                 change:
                        time:   [-71.189% -22.611% +144.78%] (p = 0.87 > 0.05)
                        thrpt:  [-59.147% +29.218% +247.09%]
                        No change in performance detected.
Found 1 outliers among 10 measurements (10.00%)
  1 (10.00%) high severe
connection_throughput/noise_connections/64
                        time:   [96.859 ms 167.15 ms 251.88 ms]
                        thrpt:  [254.09  elem/s 382.88  elem/s 660.76  elem/s]
                 change:
                        time:   [-62.148% -31.225% +32.208%] (p = 0.38 > 0.05)
                        thrpt:  [-24.362% +45.401% +164.19%]
                        No change in performance detected.

## Related PRs

(If this PR adds or changes functionality, please take some time to update the docs at https://github.com/libra/website, and link to your PR here.)
