### PR TITLE
[secure-storage] GitHub Wrapper

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2678,6 +2678,7 @@ dependencies = [
 name = "libra-secure-storage"
 version = "0.1.0"
 dependencies = [
+ "base64 0.12.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "chrono 0.4.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "libra-canonical-serialization 0.1.0",
  "libra-config 0.1.0",

--- a/config/src/config/secure_config.rs
+++ b/config/src/config/secure_config.rs
@@ -45,9 +45,24 @@ impl Default for KeyManagerConfig {
 #[serde(tag = "type")]
 #[serde(rename_all = "snake_case")]
 pub enum SecureBackend {
+    GitHub(GitHubConfig),
     InMemoryStorage,
     Vault(VaultConfig),
     OnDiskStorage(OnDiskStorageConfig),
+}
+
+#[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
+pub struct GitHubConfig {
+    /// The owner or account that hosts a repository
+    pub owner: String,
+    /// The repository where storage will mount
+    pub repository: String,
+    /// The authorization token for accessing the repository
+    pub token: String,
+    /// A namespace is an optional portion of the path to a key stored within OnDiskStorage. For
+    /// example, a key, S, without a namespace would be available in S, with a namespace, N, it
+    /// would be in N/S.
+    pub namespace: Option<String>,
 }
 
 #[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]

--- a/secure/storage/Cargo.toml
+++ b/secure/storage/Cargo.toml
@@ -10,7 +10,14 @@ publish = false
 edition = "2018"
 
 [dependencies]
+base64 = "0.12.1"
 chrono = "0.4.9"
+rand = "0.7.3"
+serde = { version = "1.0.110", features = ["rc"], default-features = false }
+serde_json = "1.0.53"
+thiserror = "1.0"
+toml = { version = "0.5.3", default-features = false }
+
 lcs = { path = "../../common/lcs", version = "0.1.0", package = "libra-canonical-serialization" }
 libra-config = { path = "../../config", version = "0.1.0" }
 libra-crypto = { path = "../../crypto/crypto", version = "0.1.0" }
@@ -20,11 +27,6 @@ libra-types = { path = "../../types", version = "0.1.0" }
 libra-vault-client = { path = "vault", version = "0.1.0" }
 libra-github-client = { path = "github", version = "0.1.0" }
 libra-workspace-hack = { path = "../../common/workspace-hack", version = "0.1.0" }
-rand = "0.7.3"
-serde = { version = "1.0.110", features = ["rc"], default-features = false }
-serde_json = "1.0.53"
-thiserror = "1.0"
-toml = { version = "0.5.3", default-features = false }
 
 [dev-dependencies]
 rand = "0.7.3"

--- a/secure/storage/src/error.rs
+++ b/secure/storage/src/error.rs
@@ -25,6 +25,12 @@ pub enum Error {
     KeyVersionNotFound(String),
 }
 
+impl From<base64::DecodeError> for Error {
+    fn from(error: base64::DecodeError) -> Self {
+        Self::SerializationError(format!("{}", error))
+    }
+}
+
 impl From<chrono::format::ParseError> for Error {
     fn from(error: chrono::format::ParseError) -> Self {
         Self::SerializationError(format!("{}", error))
@@ -66,6 +72,16 @@ impl From<libra_vault_client::Error> for Error {
         match error {
             libra_vault_client::Error::NotFound(_, key) => Self::KeyNotSet(key),
             libra_vault_client::Error::HttpError(403, _) => Self::PermissionDenied,
+            _ => Self::InternalError(format!("{}", error)),
+        }
+    }
+}
+
+impl From<libra_github_client::Error> for Error {
+    fn from(error: libra_github_client::Error) -> Self {
+        match error {
+            libra_github_client::Error::NotFound(key) => Self::KeyNotSet(key),
+            libra_github_client::Error::HttpError(403, _) => Self::PermissionDenied,
             _ => Self::InternalError(format!("{}", error)),
         }
     }

--- a/secure/storage/src/github.rs
+++ b/secure/storage/src/github.rs
@@ -1,0 +1,53 @@
+// Copyright (c) The Libra Core Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::{CryptoKVStorage, Error, GetResponse, KVStorage, Value};
+use libra_github_client::Client;
+use libra_secure_time::{RealTimeService, TimeService};
+
+/// GitHubStorage leverages a GitHub repository to provide a file system approach to key / value
+/// storage.  This is not intended for storing private data but for organizing public data.
+pub struct GitHubStorage {
+    client: Client,
+    time_service: RealTimeService,
+}
+
+impl GitHubStorage {
+    pub fn new(owner: String, repository: String, token: String) -> Self {
+        Self {
+            client: Client::new(owner, repository, token),
+            time_service: RealTimeService::new(),
+        }
+    }
+}
+
+impl KVStorage for GitHubStorage {
+    fn available(&self) -> bool {
+        match self.client.get_branches() {
+            Ok(branches) => !branches.is_empty(),
+            _ => false,
+        }
+    }
+
+    fn get(&self, key: &str) -> Result<GetResponse, Error> {
+        let data = self.client.get_file(key)?;
+        let data = base64::decode(&data)?;
+        let data = std::str::from_utf8(&data).unwrap();
+        serde_json::from_str(&data).map_err(|e| e.into())
+    }
+
+    fn set(&mut self, key: &str, value: Value) -> Result<(), Error> {
+        let data = GetResponse::new(value, self.time_service.now());
+        let data = serde_json::to_string(&data)?;
+        let data = base64::encode(&data);
+        self.client.put(key, &data)?;
+        Ok(())
+    }
+
+    #[cfg(any(test, feature = "testing"))]
+    fn reset_and_clear(&mut self) -> Result<(), Error> {
+        self.client.delete_directory("/").map_err(|e| e.into())
+    }
+}
+
+impl CryptoKVStorage for GitHubStorage {}

--- a/secure/storage/src/lib.rs
+++ b/secure/storage/src/lib.rs
@@ -9,6 +9,7 @@ use std::convert::From;
 mod crypto_kv_storage;
 mod crypto_storage;
 mod error;
+mod github;
 mod in_memory;
 mod kv_storage;
 mod namespaced_storage;
@@ -22,6 +23,7 @@ pub use crate::{
     crypto_kv_storage::CryptoKVStorage,
     crypto_storage::{CryptoStorage, PublicKeyResponse},
     error::Error,
+    github::GitHubStorage,
     in_memory::{InMemoryStorage, InMemoryStorageInternal},
     kv_storage::{GetResponse, KVStorage},
     namespaced_storage::NamespacedStorage,

--- a/secure/storage/src/lib.rs
+++ b/secure/storage/src/lib.rs
@@ -37,6 +37,18 @@ pub use crate::{
 impl From<&SecureBackend> for Box<dyn Storage> {
     fn from(backend: &SecureBackend) -> Self {
         match backend {
+            SecureBackend::GitHub(config) => {
+                let storage = GitHubStorage::new(
+                    config.owner.clone(),
+                    config.repository.clone(),
+                    config.token.clone(),
+                );
+                if let Some(namespace) = &config.namespace {
+                    Box::new(NamespacedStorage::new(storage, namespace.clone()))
+                } else {
+                    Box::new(storage)
+                }
+            }
             SecureBackend::InMemoryStorage => Box::new(InMemoryStorage::new()),
             SecureBackend::OnDiskStorage(config) => {
                 let storage = OnDiskStorage::new(config.path());

--- a/secure/storage/src/tests/github.rs
+++ b/secure/storage/src/tests/github.rs
@@ -1,0 +1,22 @@
+// Copyright (c) The Libra Core Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::{tests::suite, GitHubStorage};
+
+const OWNER: &str = "OWNER";
+const REPOSITORY: &str = "REPOSITORY";
+const TOKEN: &str = "TOKEN";
+
+// These tests must be run in series via: `cargo xtest -- --ignored --test-threads=1`
+// Also the constants above must be defined with proper values -- never commit these values to the
+// repository.
+#[ignore]
+#[test]
+fn github_storage() {
+    let mut storage = Box::new(GitHubStorage::new(
+        OWNER.into(),
+        REPOSITORY.into(),
+        TOKEN.into(),
+    ));
+    suite::execute_all_storage_tests(storage.as_mut());
+}

--- a/secure/storage/src/tests/mod.rs
+++ b/secure/storage/src/tests/mod.rs
@@ -1,6 +1,7 @@
 // Copyright (c) The Libra Core Contributors
 // SPDX-License-Identifier: Apache-2.0
 
+mod github;
 mod in_memory;
 mod on_disk;
 mod suite;


### PR DESCRIPTION
This introduces GitHub as another solution to secure-storage and
identifies several other interesting bits along the way:

* GitHub inserts newlines every 60 characters in their base64 encodings -- I don't understand but it means we need to remove them before decoding.
* In order to recursively delete everything, we add a delete_directory and also annotate directories in the "get_directory" query with an extra "/" -- which is exactly how vault does it
* Added a proper liveness check via branch checking
* The actual GitHubStorage is actually rather trivial -- but all tests pass
* Removed a duplicate test on key generation, rotation, exporting

This builds on previous PR: https://github.com/libra/libra/pull/3812