### PR TITLE
[move-prover] Prelude templatemization and benchmark support.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1705,6 +1705,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "handlebars"
+version = "3.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "pest 2.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "pest_derive 2.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "quick-error 1.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.110 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_json 1.0.52 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "headers"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2939,6 +2952,11 @@ dependencies = [
 ]
 
 [[package]]
+name = "maplit"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
 name = "matches"
 version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3180,6 +3198,7 @@ dependencies = [
  "codespan 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "codespan-reporting 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "datatest-stable 0.1.0",
+ "handlebars 3.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "itertools 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "libra-temppath 0.1.0",
  "libra-types 0.1.0",
@@ -3190,6 +3209,7 @@ dependencies = [
  "num 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "pretty 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "regex 1.3.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.110 (registry+https://github.com/rust-lang/crates.io-index)",
  "simplelog 0.7.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "spec-lang 0.0.1",
  "stackless-bytecode-generator 0.1.0",
@@ -3666,6 +3686,45 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 name = "percent-encoding"
 version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "pest"
+version = "2.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "ucd-trie 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "pest_derive"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "pest 2.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "pest_generator 2.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "pest_generator"
+version = "2.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "pest 2.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "pest_meta 2.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "proc-macro2 1.0.12 (registry+https://github.com/rust-lang/crates.io-index)",
+ "quote 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 1.0.19 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "pest_meta"
+version = "2.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "maplit 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "pest 2.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "sha-1 0.8.2 (registry+https://github.com/rust-lang/crates.io-index)",
+]
 
 [[package]]
 name = "petgraph"
@@ -5877,6 +5936,11 @@ version = "1.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "ucd-trie"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
 name = "unicase"
 version = "1.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6539,6 +6603,7 @@ dependencies = [
 "checksum glob 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "9b919933a397b79c37e33b77bb2aa3dc8eb6e165ad809e58ff75bc7db2e34574"
 "checksum guppy 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)" = "a830ab35ef74099bb82f0c0ea223c4a9876e4ad3ccf103059ce5277f5dd5a5f6"
 "checksum h2 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "9d5c295d1c0c68e4e42003d75f908f5e16a1edd1cbe0b0d02e4dc2006a384f47"
+"checksum handlebars 3.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "ba758d094d31274eb49d15da6f326b96bf3185239a6359bf684f3d5321148900"
 "checksum headers 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "a72b4bd7cbbf0c22190e82f02517f456a6b9be24c25a6827b5802e478b8c2d70"
 "checksum headers-core 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "e7f66481bfee273957b1f20485a4ff3362987f85b2c236580d81b4eb7a326429"
 "checksum heck 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "20564e78d53d2bb135c343b3f47714a56af2061f1c928fdb541dc7b9fdd94205"
@@ -6580,6 +6645,7 @@ dependencies = [
 "checksum lock_api 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "79b2de95ecb4691949fea4716ca53cdbcfccb2c612e19644a8bad05edcf9f47b"
 "checksum log 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)" = "e19e8d5c34a3e0e2223db8e060f9e8264aeeb5c5fc64a4ee9965c062211c024b"
 "checksum log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)" = "14b6052be84e6b71ab17edffc2eeabf5c2c3ae1fdb464aae35ac50c67a44e1f7"
+"checksum maplit 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)" = "3e2e65a1a2e43cfcb47a895c4c8b10d1f4a61097f9f254f183aee60cad9c651d"
 "checksum matches 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)" = "7ffc5c5338469d4d3ea17d269fa8ea3512ad247247c30bd2df69e68309ed0a08"
 "checksum maybe-uninit 2.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "60302e4db3a61da70c0cb7991976248362f30319e88850c487b9b95bbf059e00"
 "checksum md5 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "490cc448043f947bae3cbee9c203358d62dbee0db12107a74be5c30ccfd09771"
@@ -6628,6 +6694,10 @@ dependencies = [
 "checksum pbkdf2 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "006c038a43a45995a9670da19e67600114740e8511d4333bf97a56e66a7542d9"
 "checksum peeking_take_while 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "19b17cddbe7ec3f8bc800887bab5e717348c95ea2ca0b1bf0837fb964dc67099"
 "checksum percent-encoding 2.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "d4fd5641d01c8f18a23da7b6fe29298ff4b55afcccdf78973b24cf3175fee32e"
+"checksum pest 2.1.3 (registry+https://github.com/rust-lang/crates.io-index)" = "10f4872ae94d7b90ae48754df22fd42ad52ce740b8f370b03da4835417403e53"
+"checksum pest_derive 2.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "833d1ae558dc601e9a60366421196a8d94bc0ac980476d0b67e1d0988d72b2d0"
+"checksum pest_generator 2.1.3 (registry+https://github.com/rust-lang/crates.io-index)" = "99b8db626e31e5b81787b9783425769681b347011cc59471e33ea46d2ea0cf55"
+"checksum pest_meta 2.1.3 (registry+https://github.com/rust-lang/crates.io-index)" = "54be6e404f5317079812fc8f9f5279de376d8856929e21c184ecf6bbd692a11d"
 "checksum petgraph 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)" = "29c127eea4a29ec6c85d153c59dc1213f33ec74cead30fe4730aecc88cc1fd92"
 "checksum phf 0.7.24 (registry+https://github.com/rust-lang/crates.io-index)" = "b3da44b85f8e8dfaec21adae67f95d93244b2ecf6ad2a692320598dcc8e6dd18"
 "checksum phf_codegen 0.7.24 (registry+https://github.com/rust-lang/crates.io-index)" = "b03e85129e324ad4166b06b2c7491ae27fe3ec353af72e72cd1654c7225d517e"
@@ -6810,6 +6880,7 @@ dependencies = [
 "checksum twoway 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)" = "59b11b2b5241ba34be09c3cc85a36e56e48f9888862e19cedf23336d35316ed1"
 "checksum typed-arena 2.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "0685c84d5d54d1c26f7d3eb96cd41550adb97baed141a761cf335d3d33bcd0ae"
 "checksum typenum 1.11.2 (registry+https://github.com/rust-lang/crates.io-index)" = "6d2783fe2d6b8c1101136184eb41be8b1ad379e4657050b8aaff0c79ee7575f9"
+"checksum ucd-trie 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)" = "56dee185309b50d1f11bfedef0fe6d036842e3fb77413abef29f8f8d1c5d4c1c"
 "checksum unicase 1.4.2 (registry+https://github.com/rust-lang/crates.io-index)" = "7f4765f83163b74f957c797ad9253caf97f103fb064d3999aea9568d09fc8a33"
 "checksum unicase 2.6.0 (registry+https://github.com/rust-lang/crates.io-index)" = "50f37be617794602aabbeee0be4f259dc1778fabe05e2d67ee8f79326d5cb4f6"
 "checksum unicode-bidi 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)" = "49f2bd0c6468a8230e1db229cff8029217cf623c767ea5d60bfbd42729ea54d5"

--- a/language/move-prover/Cargo.toml
+++ b/language/move-prover/Cargo.toml
@@ -24,11 +24,13 @@ anyhow = "1.0.*"
 clap = "2.33.0"
 codespan = "0.8.0"
 codespan-reporting = "0.8.0"
+handlebars = "3.0.1"
 itertools = "0.9.0"
 log = "0.4.8"
 num = "0.2.0"
 pretty = "0.10.0"
 regex = "1.3.7"
+serde = { version = "1.0.110", features = ["derive"] }
 simplelog = "0.7.6"
 
 [dev-dependencies]

--- a/language/move-prover/src/bytecode_translator.rs
+++ b/language/move-prover/src/bytecode_translator.rs
@@ -7,7 +7,7 @@ use std::collections::{BTreeMap, BTreeSet};
 
 use itertools::Itertools;
 #[allow(unused_imports)]
-use log::{debug, info, warn};
+use log::{debug, info, log, warn, Level};
 
 use spec_lang::{
     env::{GlobalEnv, Loc, ModuleEnv, StructEnv, TypeParameter},
@@ -123,7 +123,12 @@ impl<'env> ModuleTranslator<'env> {
 
     /// Translates this module.
     fn translate(&mut self) {
-        info!(
+        log!(
+            if self.module_env.is_in_dependency() {
+                Level::Debug
+            } else {
+                Level::Info
+            },
             "translating module {}",
             self.module_env
                 .get_name()
@@ -345,8 +350,8 @@ impl<'env> ModuleTranslator<'env> {
             self.writer.set_location(&func_env.get_loc());
             self.translate_function(&self.targets.get_target(&func_env));
         }
-        if num_fun > 0 {
-            info!(
+        if num_fun > 0 && !self.module_env.is_in_dependency() {
+            debug!(
                 "{} out of {} functions have (directly or indirectly) \
                  specifications in module `{}`",
                 num_fun_specified,

--- a/language/move-prover/src/main.rs
+++ b/language/move-prover/src/main.rs
@@ -11,7 +11,7 @@ use std::env;
 fn main() -> anyhow::Result<()> {
     let mut options = Options::default();
     let args: Vec<String> = env::args().collect();
-    options.initialize_from_args(&args);
+    options.initialize_from_args(&args)?;
     options.setup_logging();
     let mut error_writer = StandardStream::stderr(ColorChoice::Auto);
     run_move_prover(&mut error_writer, options)

--- a/language/move-prover/src/prelude_template_helpers.rs
+++ b/language/move-prover/src/prelude_template_helpers.rs
@@ -1,0 +1,59 @@
+// Copyright (c) The Libra Core Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+use handlebars::{
+    to_json, BlockContext, Context, Handlebars, Helper, HelperDef, HelperResult, Output,
+    RenderContext, RenderError, Renderable,
+};
+
+#[derive(Clone, Copy)]
+pub struct StratificationHelper {
+    depth: usize,
+}
+
+impl StratificationHelper {
+    pub fn new(depth: usize) -> Self {
+        Self { depth }
+    }
+}
+
+impl HelperDef for StratificationHelper {
+    fn call<'reg: 'rc, 'rc>(
+        &self,
+        h: &Helper<'reg, 'rc>,
+        r: &'reg Handlebars,
+        ctx: &'rc Context,
+        rc: &mut RenderContext<'reg, 'rc>,
+        out: &mut dyn Output,
+    ) -> HelperResult {
+        if !h.params().is_empty() {
+            return Err(RenderError::new("helper cannot have parameters"));
+        }
+        let templ = h
+            .template()
+            .ok_or_else(|| RenderError::new("expected block template"))?;
+        let inverse = h
+            .inverse()
+            .ok_or_else(|| RenderError::new("expected else template"))?;
+
+        for i in 0..self.depth {
+            let this_suffix = if i == 0 {
+                "stratified".to_owned()
+            } else {
+                format!("level{}", i)
+            };
+            let next_suffix = format!("level{}", i + 1);
+            rc.push_block(BlockContext::new());
+            let block = rc.block_mut().expect("block defined");
+            block.set_local_var("@this_suffix".to_owned(), to_json(this_suffix));
+            block.set_local_var("@next_suffix".to_owned(), to_json(next_suffix));
+            block.set_local_var("@this_level".to_owned(), to_json(i));
+            if i == self.depth - 1 {
+                inverse.render(r, ctx, rc, out)?;
+            } else {
+                templ.render(r, ctx, rc, out)?;
+            }
+        }
+        Ok(())
+    }
+}

--- a/language/move-prover/src/spec_translator.rs
+++ b/language/move-prover/src/spec_translator.rs
@@ -443,10 +443,10 @@ impl<'env> SpecTranslator<'env> {
     /// the struct is not mutated.
     fn translate_assume_well_formed(&self, struct_env: &StructEnv<'env>) {
         let emit_field_checks = |mode: WellFormedMode| {
-            emitln!(self.writer, "is#Vector($this)");
+            emitln!(self.writer, "$Vector_is_well_formed($this)");
             emitln!(
                 self.writer,
-                "  && $vlen($this) == {}",
+                "&& $vlen($this) == {}",
                 struct_env.get_fields().count()
             );
             for field in struct_env.get_fields() {

--- a/language/move-prover/tests/sources/functional/aborts-if.exp
+++ b/language/move-prover/tests/sources/functional/aborts-if.exp
@@ -1,101 +1,97 @@
 Move prover returns: exiting with boogie verification errors
 error:  A postcondition might not hold on this return path.
 
-    ┌── tests/sources/functional/aborts-if.move:31:9 ───
+    ┌── tests/sources/functional/aborts-if.move:35:9 ───
     │
- 31 │         aborts_if _x <= _y;
+ 35 │         aborts_if _x <= _y;
     │         ^^^^^^^^^^^^^^^^^^^
     │
-    =     at tests/sources/functional/aborts-if.move:28:5: abort2_incorrect (entry)
-    =     at tests/sources/functional/aborts-if.move:28:5: abort2_incorrect (exit)
+    =     at tests/sources/functional/aborts-if.move:32:5: abort2_incorrect (entry)
+    =     at tests/sources/functional/aborts-if.move:32:5: abort2_incorrect (exit)
     =         _x = <redacted>,
     =         _y = <redacted>
 
-error: abort not covered by any of the `aborts_if` clauses
+error:  A postcondition might not hold on this return path.
 
-    ┌── tests/sources/functional/aborts-if.move:43:5 ───
+    ┌── tests/sources/functional/aborts-if.move:51:9 ───
     │
- 43 │ ╭     fun abort4_incorrect(x: u64, y: u64) {
- 44 │ │         if (x > y) abort 1
- 45 │ │     }
-    │ ╰─────^
-    ·
- 44 │         if (x > y) abort 1
-    │         ------------------ abort happened here
+ 51 │         aborts_if x <= y;
+    │         ^^^^^^^^^^^^^^^^^
     │
-    =     at tests/sources/functional/aborts-if.move:43:5: abort4_incorrect (entry)
-    =     at tests/sources/functional/aborts-if.move:44:9: abort4_incorrect (ABORTED)
+    =     at tests/sources/functional/aborts-if.move:47:5: abort4_incorrect (entry)
+    =     at tests/sources/functional/aborts-if.move:48:9: abort4_incorrect
     =         x = <redacted>,
     =         y = <redacted>
+    =     at tests/sources/functional/aborts-if.move:47:5: abort4_incorrect (exit)
 
 error: abort not covered by any of the `aborts_if` clauses
 
-    ┌── tests/sources/functional/aborts-if.move:51:5 ───
+    ┌── tests/sources/functional/aborts-if.move:55:5 ───
     │
- 51 │ ╭     fun abort5_incorrect(x: u64, y: u64) {
- 52 │ │         if (x <= y) abort 1
- 53 │ │     }
+ 55 │ ╭     fun abort5_incorrect(x: u64, y: u64) {
+ 56 │ │         if (x <= y) abort 1
+ 57 │ │     }
     │ ╰─────^
     ·
- 52 │         if (x <= y) abort 1
+ 56 │         if (x <= y) abort 1
     │         ------------------- abort happened here
     │
-    =     at tests/sources/functional/aborts-if.move:51:5: abort5_incorrect (entry)
-    =     at tests/sources/functional/aborts-if.move:52:9: abort5_incorrect (ABORTED)
+    =     at tests/sources/functional/aborts-if.move:55:5: abort5_incorrect (entry)
+    =     at tests/sources/functional/aborts-if.move:56:9: abort5_incorrect (ABORTED)
     =         x = <redacted>,
     =         y = <redacted>
 
 error:  A postcondition might not hold on this return path.
 
-    ┌── tests/sources/functional/aborts-if.move:63:9 ───
+    ┌── tests/sources/functional/aborts-if.move:67:9 ───
     │
- 63 │         aborts_if x <= y;
+ 67 │         aborts_if x <= y;
     │         ^^^^^^^^^^^^^^^^^
     │
-    =     at tests/sources/functional/aborts-if.move:59:5: abort6_incorrect (entry)
-    =     at tests/sources/functional/aborts-if.move:60:9: abort6_incorrect
+    =     at tests/sources/functional/aborts-if.move:63:5: abort6_incorrect (entry)
+    =     at tests/sources/functional/aborts-if.move:64:9: abort6_incorrect
     =         x = <redacted>,
     =         y = <redacted>
-    =     at tests/sources/functional/aborts-if.move:59:5: abort6_incorrect (exit)
+    =     at tests/sources/functional/aborts-if.move:63:5: abort6_incorrect (exit)
 
 error:  A postcondition might not hold on this return path.
 
-    ┌── tests/sources/functional/aborts-if.move:86:9 ───
+    ┌── tests/sources/functional/aborts-if.move:90:9 ───
     │
- 86 │         aborts_if x == y;
+ 90 │         aborts_if x == y;
     │         ^^^^^^^^^^^^^^^^^
     │
-    =     at tests/sources/functional/aborts-if.move:81:5: multi_abort2_incorrect (entry)
-    =     at tests/sources/functional/aborts-if.move:82:9: multi_abort2_incorrect
+    =     at tests/sources/functional/aborts-if.move:85:5: multi_abort2_incorrect (entry)
+    =     at tests/sources/functional/aborts-if.move:86:9: multi_abort2_incorrect
     =         x = <redacted>,
     =         y = <redacted>
-    =     at tests/sources/functional/aborts-if.move:81:5: multi_abort2_incorrect (exit)
+    =     at tests/sources/functional/aborts-if.move:85:5: multi_abort2_incorrect (exit)
 
 error: abort not covered by any of the `aborts_if` clauses
 
-    ┌── tests/sources/functional/aborts-if.move:90:5 ───
+    ┌── tests/sources/functional/aborts-if.move:94:5 ───
     │
- 90 │ ╭     fun multi_abort3_incorrect(_x: u64, _y: u64) {
- 91 │ │         abort 1
- 92 │ │     }
+ 94 │ ╭     fun multi_abort3_incorrect(_x: u64, _y: u64) {
+ 95 │ │         abort 1
+ 96 │ │     }
     │ ╰─────^
     ·
- 91 │         abort 1
+ 95 │         abort 1
     │         ------- abort happened here
     │
-    =     at tests/sources/functional/aborts-if.move:90:5: multi_abort3_incorrect (entry)
-    =     at tests/sources/functional/aborts-if.move:91:9: multi_abort3_incorrect (ABORTED)
+    =     at tests/sources/functional/aborts-if.move:94:5: multi_abort3_incorrect (entry)
+    =     at tests/sources/functional/aborts-if.move:95:9: multi_abort3_incorrect (ABORTED)
     =         _x = <redacted>,
     =         _y = <redacted>
 
 error:  A postcondition might not hold on this return path.
 
-     ┌── tests/sources/functional/aborts-if.move:114:9 ───
+     ┌── tests/sources/functional/aborts-if.move:118:9 ───
      │
- 114 │         aborts_if true;
+ 118 │         aborts_if true;
      │         ^^^^^^^^^^^^^^^
      │
-     =     at tests/sources/functional/aborts-if.move:108:5: multi_abort5_incorrect (entry)
-     =     at tests/sources/functional/aborts-if.move:109:9: multi_abort5_incorrect
+     =     at tests/sources/functional/aborts-if.move:112:5: multi_abort5_incorrect (entry)
+     =     at tests/sources/functional/aborts-if.move:113:9: multi_abort5_incorrect
      =         x = <redacted>
-     =     at tests/sources/functional/aborts-if.move:108:5: multi_abort5_incorrect (exit)
+     =     at tests/sources/functional/aborts-if.move:112:5: multi_abort5_incorrect (exit)

--- a/language/move-prover/tests/sources/functional/aborts-if.move
+++ b/language/move-prover/tests/sources/functional/aborts-if.move
@@ -1,5 +1,9 @@
 module TestAbortsIf {
 
+    spec module {
+        pragma verify = true;
+    }
+
     // -------------------------
     // No `aborts_if` statements
     // -------------------------

--- a/language/move-prover/tests/sources/functional/arithm.exp
+++ b/language/move-prover/tests/sources/functional/arithm.exp
@@ -1,119 +1,119 @@
 Move prover returns: exiting with boogie verification errors
 error: abort not covered by any of the `aborts_if` clauses
 
-     ┌── tests/sources/functional/arithm.move:121:5 ───
+     ┌── tests/sources/functional/arithm.move:125:5 ───
      │
- 121 │ ╭     fun div_by_zero_u64_incorrect(x: u64, y: u64): u64 {
- 122 │ │         x / y
- 123 │ │     }
+ 125 │ ╭     fun div_by_zero_u64_incorrect(x: u64, y: u64): u64 {
+ 126 │ │         x / y
+ 127 │ │     }
      │ ╰─────^
      ·
- 122 │         x / y
+ 126 │         x / y
      │           - abort happened here
      │
-     =     at tests/sources/functional/arithm.move:121:5: div_by_zero_u64_incorrect (entry)
-     =     at tests/sources/functional/arithm.move:122:11: div_by_zero_u64_incorrect (ABORTED)
+     =     at tests/sources/functional/arithm.move:125:5: div_by_zero_u64_incorrect (entry)
+     =     at tests/sources/functional/arithm.move:126:11: div_by_zero_u64_incorrect (ABORTED)
      =         x = <redacted>,
      =         y = <redacted>
 
 error: abort not covered by any of the `aborts_if` clauses
 
-     ┌── tests/sources/functional/arithm.move:173:5 ───
+     ┌── tests/sources/functional/arithm.move:177:5 ───
      │
- 173 │ ╭     fun overflow_u128_add_incorrect(x: u128, y: u128): u128 {
- 174 │ │         x + y
- 175 │ │     }
+ 177 │ ╭     fun overflow_u128_add_incorrect(x: u128, y: u128): u128 {
+ 178 │ │         x + y
+ 179 │ │     }
      │ ╰─────^
      ·
- 174 │         x + y
+ 178 │         x + y
      │           - abort happened here
      │
-     =     at tests/sources/functional/arithm.move:173:5: overflow_u128_add_incorrect (entry)
-     =     at tests/sources/functional/arithm.move:174:11: overflow_u128_add_incorrect (ABORTED)
+     =     at tests/sources/functional/arithm.move:177:5: overflow_u128_add_incorrect (entry)
+     =     at tests/sources/functional/arithm.move:178:11: overflow_u128_add_incorrect (ABORTED)
      =         x = <redacted>,
      =         y = <redacted>
 
 error: abort not covered by any of the `aborts_if` clauses
 
-     ┌── tests/sources/functional/arithm.move:226:5 ───
+     ┌── tests/sources/functional/arithm.move:230:5 ───
      │
- 226 │ ╭     fun overflow_u128_mul_incorrect(x: u128, y: u128): u128 {
- 227 │ │         x * y
- 228 │ │     }
+ 230 │ ╭     fun overflow_u128_mul_incorrect(x: u128, y: u128): u128 {
+ 231 │ │         x * y
+ 232 │ │     }
      │ ╰─────^
      ·
- 227 │         x * y
+ 231 │         x * y
      │           - abort happened here
      │
-     =     at tests/sources/functional/arithm.move:226:5: overflow_u128_mul_incorrect (entry)
-     =     at tests/sources/functional/arithm.move:227:11: overflow_u128_mul_incorrect (ABORTED)
+     =     at tests/sources/functional/arithm.move:230:5: overflow_u128_mul_incorrect (entry)
+     =     at tests/sources/functional/arithm.move:231:11: overflow_u128_mul_incorrect (ABORTED)
      =         x = <redacted>,
      =         y = <redacted>
 
 error: abort not covered by any of the `aborts_if` clauses
 
-     ┌── tests/sources/functional/arithm.move:157:5 ───
+     ┌── tests/sources/functional/arithm.move:161:5 ───
      │
- 157 │ ╭     fun overflow_u64_add_incorrect(x: u64, y: u64): u64 {
- 158 │ │         x + y
- 159 │ │     }
+ 161 │ ╭     fun overflow_u64_add_incorrect(x: u64, y: u64): u64 {
+ 162 │ │         x + y
+ 163 │ │     }
      │ ╰─────^
      ·
- 158 │         x + y
+ 162 │         x + y
      │           - abort happened here
      │
-     =     at tests/sources/functional/arithm.move:157:5: overflow_u64_add_incorrect (entry)
-     =     at tests/sources/functional/arithm.move:158:11: overflow_u64_add_incorrect (ABORTED)
+     =     at tests/sources/functional/arithm.move:161:5: overflow_u64_add_incorrect (entry)
+     =     at tests/sources/functional/arithm.move:162:11: overflow_u64_add_incorrect (ABORTED)
      =         x = <redacted>,
      =         y = <redacted>
 
 error: abort not covered by any of the `aborts_if` clauses
 
-     ┌── tests/sources/functional/arithm.move:210:5 ───
+     ┌── tests/sources/functional/arithm.move:214:5 ───
      │
- 210 │ ╭     fun overflow_u64_mul_incorrect(x: u64, y: u64): u64 {
- 211 │ │         x * y
- 212 │ │     }
+ 214 │ ╭     fun overflow_u64_mul_incorrect(x: u64, y: u64): u64 {
+ 215 │ │         x * y
+ 216 │ │     }
      │ ╰─────^
      ·
- 211 │         x * y
+ 215 │         x * y
      │           - abort happened here
      │
-     =     at tests/sources/functional/arithm.move:210:5: overflow_u64_mul_incorrect (entry)
-     =     at tests/sources/functional/arithm.move:211:11: overflow_u64_mul_incorrect (ABORTED)
+     =     at tests/sources/functional/arithm.move:214:5: overflow_u64_mul_incorrect (entry)
+     =     at tests/sources/functional/arithm.move:215:11: overflow_u64_mul_incorrect (ABORTED)
      =         x = <redacted>,
      =         y = <redacted>
 
 error: abort not covered by any of the `aborts_if` clauses
 
-     ┌── tests/sources/functional/arithm.move:141:5 ───
+     ┌── tests/sources/functional/arithm.move:145:5 ───
      │
- 141 │ ╭     fun overflow_u8_add_incorrect(x: u8, y: u8): u8 {
- 142 │ │         x + y
- 143 │ │     }
+ 145 │ ╭     fun overflow_u8_add_incorrect(x: u8, y: u8): u8 {
+ 146 │ │         x + y
+ 147 │ │     }
      │ ╰─────^
      ·
- 142 │         x + y
+ 146 │         x + y
      │           - abort happened here
      │
-     =     at tests/sources/functional/arithm.move:141:5: overflow_u8_add_incorrect (entry)
-     =     at tests/sources/functional/arithm.move:142:11: overflow_u8_add_incorrect (ABORTED)
+     =     at tests/sources/functional/arithm.move:145:5: overflow_u8_add_incorrect (entry)
+     =     at tests/sources/functional/arithm.move:146:11: overflow_u8_add_incorrect (ABORTED)
      =         x = <redacted>,
      =         y = <redacted>
 
 error: abort not covered by any of the `aborts_if` clauses
 
-     ┌── tests/sources/functional/arithm.move:194:5 ───
+     ┌── tests/sources/functional/arithm.move:198:5 ───
      │
- 194 │ ╭     fun overflow_u8_mul_incorrect(x: u8, y: u8): u8 {
- 195 │ │         x * y
- 196 │ │     }
+ 198 │ ╭     fun overflow_u8_mul_incorrect(x: u8, y: u8): u8 {
+ 199 │ │         x * y
+ 200 │ │     }
      │ ╰─────^
      ·
- 195 │         x * y
+ 199 │         x * y
      │           - abort happened here
      │
-     =     at tests/sources/functional/arithm.move:194:5: overflow_u8_mul_incorrect (entry)
-     =     at tests/sources/functional/arithm.move:195:11: overflow_u8_mul_incorrect (ABORTED)
+     =     at tests/sources/functional/arithm.move:198:5: overflow_u8_mul_incorrect (entry)
+     =     at tests/sources/functional/arithm.move:199:11: overflow_u8_mul_incorrect (ABORTED)
      =         x = <redacted>,
      =         y = <redacted>

--- a/language/move-prover/tests/sources/functional/arithm.move
+++ b/language/move-prover/tests/sources/functional/arithm.move
@@ -1,5 +1,9 @@
 module TestArithmetic {
 
+    spec module {
+        pragma verify = true;
+    }
+
     // --------------------------
     // Basic arithmetic operation
     // --------------------------

--- a/language/move-prover/tests/sources/functional/cast.exp
+++ b/language/move-prover/tests/sources/functional/cast.exp
@@ -1,32 +1,32 @@
 Move prover returns: exiting with boogie verification errors
 error: abort not covered by any of the `aborts_if` clauses
 
-    ┌── tests/sources/functional/cast.move:40:5 ───
+    ┌── tests/sources/functional/cast.move:44:5 ───
     │
- 40 │ ╭     fun aborting_u64_cast_incorrect(x: u128): u64 {
- 41 │ │         (x as u64)
- 42 │ │     }
+ 44 │ ╭     fun aborting_u64_cast_incorrect(x: u128): u64 {
+ 45 │ │         (x as u64)
+ 46 │ │     }
     │ ╰─────^
     ·
- 41 │         (x as u64)
+ 45 │         (x as u64)
     │         ---------- abort happened here
     │
-    =     at tests/sources/functional/cast.move:40:5: aborting_u64_cast_incorrect (entry)
-    =     at tests/sources/functional/cast.move:41:9: aborting_u64_cast_incorrect (ABORTED)
+    =     at tests/sources/functional/cast.move:44:5: aborting_u64_cast_incorrect (entry)
+    =     at tests/sources/functional/cast.move:45:9: aborting_u64_cast_incorrect (ABORTED)
     =         x = <redacted>
 
 error: abort not covered by any of the `aborts_if` clauses
 
-    ┌── tests/sources/functional/cast.move:26:5 ───
+    ┌── tests/sources/functional/cast.move:30:5 ───
     │
- 26 │ ╭     fun aborting_u8_cast_incorrect(x: u64): u8 {
- 27 │ │         (x as u8)
- 28 │ │     }
+ 30 │ ╭     fun aborting_u8_cast_incorrect(x: u64): u8 {
+ 31 │ │         (x as u8)
+ 32 │ │     }
     │ ╰─────^
     ·
- 27 │         (x as u8)
+ 31 │         (x as u8)
     │         --------- abort happened here
     │
-    =     at tests/sources/functional/cast.move:26:5: aborting_u8_cast_incorrect (entry)
-    =     at tests/sources/functional/cast.move:27:9: aborting_u8_cast_incorrect (ABORTED)
+    =     at tests/sources/functional/cast.move:30:5: aborting_u8_cast_incorrect (entry)
+    =     at tests/sources/functional/cast.move:31:9: aborting_u8_cast_incorrect (ABORTED)
     =         x = <redacted>

--- a/language/move-prover/tests/sources/functional/cast.move
+++ b/language/move-prover/tests/sources/functional/cast.move
@@ -1,5 +1,9 @@
 module TestCast {
 
+    spec module {
+        pragma verify = true;
+    }
+
     // --------------
     // Type promotion
     // --------------

--- a/language/move-prover/tests/sources/functional/defines.move
+++ b/language/move-prover/tests/sources/functional/defines.move
@@ -1,6 +1,10 @@
 module TestDefines {
 
     spec module {
+        pragma verify = true;
+    }
+
+    spec module {
         define in_range(x: num, min: num, max: num): bool {
             x >= min && x <= max
         }

--- a/language/move-prover/tests/sources/functional/global_vars.exp
+++ b/language/move-prover/tests/sources/functional/global_vars.exp
@@ -1,83 +1,83 @@
 Move prover returns: exiting with boogie verification errors
 error:  A postcondition might not hold on this return path.
 
-     ┌── tests/sources/functional/global_vars.move:116:9 ───
+     ┌── tests/sources/functional/global_vars.move:119:9 ───
      │
- 116 │         ensures sum_of_T == old(sum_of_T) + 2;
+ 119 │         ensures sum_of_T == old(sum_of_T) + 2;
      │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
      │
-     =     at tests/sources/functional/global_vars.move:108:5: combi_incorrect (entry)
-     =     at tests/sources/functional/global_vars.move:110:13: combi_incorrect
-     =     at tests/sources/functional/global_vars.move:111:17: combi_incorrect
+     =     at tests/sources/functional/global_vars.move:111:5: combi_incorrect (entry)
+     =     at tests/sources/functional/global_vars.move:113:13: combi_incorrect
+     =     at tests/sources/functional/global_vars.move:114:17: combi_incorrect
      =         r = <redacted>,
      =         s = <redacted>
-     =     at tests/sources/functional/global_vars.move:112:15: combi_incorrect
+     =     at tests/sources/functional/global_vars.move:115:15: combi_incorrect
      =         s = <redacted>
-     =     at tests/sources/functional/global_vars.move:109:21: combi_incorrect
-     =     at tests/sources/functional/global_vars.move:108:5: combi_incorrect (exit)
+     =     at tests/sources/functional/global_vars.move:112:21: combi_incorrect
+     =     at tests/sources/functional/global_vars.move:111:5: combi_incorrect (exit)
 
 error:  A postcondition might not hold on this return path.
 
-    ┌── tests/sources/functional/global_vars.move:32:9 ───
+    ┌── tests/sources/functional/global_vars.move:35:9 ───
     │
- 32 │         ensures sum_of_T == old(sum_of_T) + 1;
+ 35 │         ensures sum_of_T == old(sum_of_T) + 1;
     │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
     │
-    =     at tests/sources/functional/global_vars.move:28:5: pack_incorrect (entry)
-    =     at tests/sources/functional/global_vars.move:29:9: pack_incorrect
+    =     at tests/sources/functional/global_vars.move:31:5: pack_incorrect (entry)
+    =     at tests/sources/functional/global_vars.move:32:9: pack_incorrect
     =         result = <redacted>
-    =     at tests/sources/functional/global_vars.move:28:5: pack_incorrect (exit)
+    =     at tests/sources/functional/global_vars.move:31:5: pack_incorrect (exit)
 
 error:  A postcondition might not hold on this return path.
 
-    ┌── tests/sources/functional/global_vars.move:55:9 ───
+    ┌── tests/sources/functional/global_vars.move:58:9 ───
     │
- 55 │         ensures sum_of_T == old(sum_of_T);
+ 58 │         ensures sum_of_T == old(sum_of_T);
     │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
     │
-    =     at tests/sources/functional/global_vars.move:50:5: unpack_incorrect (entry)
-    =     at tests/sources/functional/global_vars.move:51:19: unpack_incorrect
+    =     at tests/sources/functional/global_vars.move:53:5: unpack_incorrect (entry)
+    =     at tests/sources/functional/global_vars.move:54:19: unpack_incorrect
     =         t = <redacted>
-    =     at tests/sources/functional/global_vars.move:52:9: unpack_incorrect
+    =     at tests/sources/functional/global_vars.move:55:9: unpack_incorrect
     =         x = <redacted>
-    =     at tests/sources/functional/global_vars.move:50:5: unpack_incorrect (exit)
+    =     at tests/sources/functional/global_vars.move:53:5: unpack_incorrect (exit)
     =         result = <redacted>
 
 error:  A postcondition might not hold on this return path.
 
-     ┌── tests/sources/functional/global_vars.move:151:9 ───
+     ┌── tests/sources/functional/global_vars.move:154:9 ───
      │
- 151 │         ensures sum_of_S == old(sum_of_S) + 1;
+ 154 │         ensures sum_of_S == old(sum_of_S) + 1;
      │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
      │
-     =     at tests/sources/functional/global_vars.move:144:5: update_S_incorrect (entry)
-     =     at tests/sources/functional/global_vars.move:145:13: update_S_incorrect
-     =     at tests/sources/functional/global_vars.move:146:17: update_S_incorrect
+     =     at tests/sources/functional/global_vars.move:147:5: update_S_incorrect (entry)
+     =     at tests/sources/functional/global_vars.move:148:13: update_S_incorrect
+     =     at tests/sources/functional/global_vars.move:149:17: update_S_incorrect
      =         r = <redacted>,
      =         s = <redacted>
-     =     at tests/sources/functional/global_vars.move:147:15: update_S_incorrect
+     =     at tests/sources/functional/global_vars.move:150:15: update_S_incorrect
      =         r = <redacted>
-     =     at tests/sources/functional/global_vars.move:148:9: update_S_incorrect
-     =     at tests/sources/functional/global_vars.move:144:5: update_S_incorrect (exit)
+     =     at tests/sources/functional/global_vars.move:151:9: update_S_incorrect
+     =     at tests/sources/functional/global_vars.move:147:5: update_S_incorrect (exit)
      =         result = <redacted>
 
 error:  A postcondition might not hold on this return path.
 
-    ┌── tests/sources/functional/global_vars.move:89:9 ───
+    ┌── tests/sources/functional/global_vars.move:92:9 ───
     │
- 89 │         ensures sum_of_T == old(sum_of_T);
+ 92 │         ensures sum_of_T == old(sum_of_T);
     │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
     │
-    =     at tests/sources/functional/global_vars.move:82:5: update_incorrect (entry)
-    =     at tests/sources/functional/global_vars.move:83:13: update_incorrect
-    =     at tests/sources/functional/global_vars.move:84:37: update_incorrect
+    =     at tests/sources/functional/global_vars.move:85:5: update_incorrect (entry)
+    =     at tests/sources/functional/global_vars.move:86:13: update_incorrect
+    =     at tests/sources/functional/global_vars.move:87:37: update_incorrect
     =         t = <redacted>
-    =     at tests/sources/functional/global_vars.move:64:5: update_valid_still_mutating (entry)
-    =     at tests/sources/functional/global_vars.move:65:19: update_valid_still_mutating
+    =     at tests/sources/functional/global_vars.move:67:5: update_valid_still_mutating (entry)
+    =     at tests/sources/functional/global_vars.move:68:19: update_valid_still_mutating
     =         t = <redacted>,
     =         t = <redacted>
-    =     at tests/sources/functional/global_vars.move:64:5: update_valid_still_mutating (exit)
-    =     at tests/sources/functional/global_vars.move:84:9: update_incorrect
-    =     at tests/sources/functional/global_vars.move:85:9: update_incorrect
-    =     at tests/sources/functional/global_vars.move:82:5: update_incorrect (exit)
+    =     at tests/sources/functional/global_vars.move:67:5: update_valid_still_mutating (exit)
+    =     at tests/sources/functional/global_vars.move:87:9: update_incorrect
+    =     at tests/sources/functional/global_vars.move:88:9: update_incorrect
+    =     at tests/sources/functional/global_vars.move:85:5: update_incorrect (exit)
     =         result = <redacted>

--- a/language/move-prover/tests/sources/functional/global_vars.move
+++ b/language/move-prover/tests/sources/functional/global_vars.move
@@ -1,4 +1,7 @@
 module TestGlobalVars {
+    spec module {
+        pragma verify = true;
+    }
 
     spec module {
         global sum_of_T: u64;

--- a/language/move-prover/tests/sources/functional/hash_model.exp
+++ b/language/move-prover/tests/sources/functional/hash_model.exp
@@ -1,38 +1,38 @@
 Move prover returns: exiting with boogie verification errors
 error:  A postcondition might not hold on this return path.
 
-    ┌── tests/sources/functional/hash_model.move:44:9 ───
+    ┌── tests/sources/functional/hash_model.move:48:9 ───
     │
- 44 │         ensures len(result_1) > 0 ==> result_1[0] < max_u8(); // should be <=
+ 48 │         ensures len(result_1) > 0 ==> result_1[0] < max_u8(); // should be <=
     │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
     │
-    =     at tests/sources/functional/hash_model.move:35:5: hash_test1_incorrect (entry)
-    =     at tests/sources/functional/hash_model.move:37:24: hash_test1_incorrect
+    =     at tests/sources/functional/hash_model.move:39:5: hash_test1_incorrect (entry)
+    =     at tests/sources/functional/hash_model.move:41:24: hash_test1_incorrect
     =         v1 = <redacted>,
     =         v2 = <redacted>,
     =         h1 = <redacted>
-    =     at tests/sources/functional/hash_model.move:38:33: hash_test1_incorrect
+    =     at tests/sources/functional/hash_model.move:42:33: hash_test1_incorrect
     =         h2 = <redacted>
-    =     at tests/sources/functional/hash_model.move:39:10: hash_test1_incorrect
+    =     at tests/sources/functional/hash_model.move:43:10: hash_test1_incorrect
     =         result_1 = <redacted>,
     =         result_2 = <redacted>
-    =     at tests/sources/functional/hash_model.move:35:5: hash_test1_incorrect (exit)
+    =     at tests/sources/functional/hash_model.move:39:5: hash_test1_incorrect (exit)
 
 error:  A postcondition might not hold on this return path.
 
-    ┌── tests/sources/functional/hash_model.move:87:9 ───
+    ┌── tests/sources/functional/hash_model.move:91:9 ───
     │
- 87 │         ensures len(result_1) > 0 ==> result_1[0] < max_u8();
+ 91 │         ensures len(result_1) > 0 ==> result_1[0] < max_u8();
     │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
     │
-    =     at tests/sources/functional/hash_model.move:78:5: hash_test2_incorrect (entry)
-    =     at tests/sources/functional/hash_model.move:80:24: hash_test2_incorrect
+    =     at tests/sources/functional/hash_model.move:82:5: hash_test2_incorrect (entry)
+    =     at tests/sources/functional/hash_model.move:84:24: hash_test2_incorrect
     =         v1 = <redacted>,
     =         v2 = <redacted>,
     =         h1 = <redacted>
-    =     at tests/sources/functional/hash_model.move:81:33: hash_test2_incorrect
+    =     at tests/sources/functional/hash_model.move:85:33: hash_test2_incorrect
     =         h2 = <redacted>
-    =     at tests/sources/functional/hash_model.move:82:10: hash_test2_incorrect
+    =     at tests/sources/functional/hash_model.move:86:10: hash_test2_incorrect
     =         result_1 = <redacted>,
     =         result_2 = <redacted>
-    =     at tests/sources/functional/hash_model.move:78:5: hash_test2_incorrect (exit)
+    =     at tests/sources/functional/hash_model.move:82:5: hash_test2_incorrect (exit)

--- a/language/move-prover/tests/sources/functional/hash_model.move
+++ b/language/move-prover/tests/sources/functional/hash_model.move
@@ -2,6 +2,10 @@ module TestHash {
 
     use 0x0::Hash;
 
+    spec module {
+        pragma verify = true;
+    }
+
     // -----------
     // SHA-2 Tests
     // -----------

--- a/language/move-prover/tests/sources/functional/hash_model_invalid.exp
+++ b/language/move-prover/tests/sources/functional/hash_model_invalid.exp
@@ -1,38 +1,38 @@
 Move prover returns: exiting with boogie verification errors
 error:  A postcondition might not hold on this return path.
 
-    ┌── tests/sources/functional/hash_model_invalid.move:17:9 ───
+    ┌── tests/sources/functional/hash_model_invalid.move:22:9 ───
     │
- 17 │         ensures len(result_1) > 0 ==> result_1[0] < max_u8(); // should be <=
+ 22 │         ensures len(result_1) > 0 ==> result_1[0] < max_u8(); // should be <=
     │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
     │
-    =     at tests/sources/functional/hash_model_invalid.move:6:5: hash_test1 (entry)
-    =     at tests/sources/functional/hash_model_invalid.move:8:24: hash_test1
+    =     at tests/sources/functional/hash_model_invalid.move:11:5: hash_test1 (entry)
+    =     at tests/sources/functional/hash_model_invalid.move:13:24: hash_test1
     =         v1 = <redacted>,
     =         v2 = <redacted>,
     =         h1 = <redacted>
-    =     at tests/sources/functional/hash_model_invalid.move:9:33: hash_test1
+    =     at tests/sources/functional/hash_model_invalid.move:14:33: hash_test1
     =         h2 = <redacted>
-    =     at tests/sources/functional/hash_model_invalid.move:10:10: hash_test1
+    =     at tests/sources/functional/hash_model_invalid.move:15:10: hash_test1
     =         result_1 = <redacted>,
     =         result_2 = <redacted>
-    =     at tests/sources/functional/hash_model_invalid.move:6:5: hash_test1 (exit)
+    =     at tests/sources/functional/hash_model_invalid.move:11:5: hash_test1 (exit)
 
 error:  A postcondition might not hold on this return path.
 
-    ┌── tests/sources/functional/hash_model_invalid.move:30:9 ───
+    ┌── tests/sources/functional/hash_model_invalid.move:35:9 ───
     │
- 30 │         ensures len(result_1) > 0 ==> result_1[0] < max_u8();
+ 35 │         ensures len(result_1) > 0 ==> result_1[0] < max_u8();
     │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
     │
-    =     at tests/sources/functional/hash_model_invalid.move:21:5: hash_test2 (entry)
-    =     at tests/sources/functional/hash_model_invalid.move:23:24: hash_test2
+    =     at tests/sources/functional/hash_model_invalid.move:26:5: hash_test2 (entry)
+    =     at tests/sources/functional/hash_model_invalid.move:28:24: hash_test2
     =         v1 = <redacted>,
     =         v2 = <redacted>,
     =         h1 = <redacted>
-    =     at tests/sources/functional/hash_model_invalid.move:24:33: hash_test2
+    =     at tests/sources/functional/hash_model_invalid.move:29:33: hash_test2
     =         h2 = <redacted>
-    =     at tests/sources/functional/hash_model_invalid.move:25:10: hash_test2
+    =     at tests/sources/functional/hash_model_invalid.move:30:10: hash_test2
     =         result_1 = <redacted>,
     =         result_2 = <redacted>
-    =     at tests/sources/functional/hash_model_invalid.move:21:5: hash_test2 (exit)
+    =     at tests/sources/functional/hash_model_invalid.move:26:5: hash_test2 (exit)

--- a/language/move-prover/tests/sources/functional/hash_model_invalid.move
+++ b/language/move-prover/tests/sources/functional/hash_model_invalid.move
@@ -2,6 +2,11 @@ module TestHash {
 
     use 0x0::Hash;
 
+    spec module {
+        pragma verify = true;
+    }
+
+
     // sha2 test
     fun hash_test1(v1: vector<u8>, v2: vector<u8>): (vector<u8>, vector<u8>)
     {

--- a/language/move-prover/tests/sources/functional/invariants.exp
+++ b/language/move-prover/tests/sources/functional/invariants.exp
@@ -1,148 +1,148 @@
 Move prover returns: exiting with boogie verification errors
 error:  This assertion might not hold.
 
-    ┌── tests/sources/functional/invariants.move:11:9 ───
+    ┌── tests/sources/functional/invariants.move:16:9 ───
     │
- 11 │         invariant greater_one(x);
+ 16 │         invariant greater_one(x);
     │         ^^^^^^^^^^^^^^^^^^^^^^^^^
     │
-    =     at tests/sources/functional/invariants.move:37:5: invalid_R_pack (entry)
+    =     at tests/sources/functional/invariants.move:42:5: invalid_R_pack (entry)
 
 error:  This assertion might not hold.
 
-    ┌── tests/sources/functional/invariants.move:14:9 ───
+    ┌── tests/sources/functional/invariants.move:19:9 ───
     │
- 14 │         invariant update x <= old(x) && tautology();
+ 19 │         invariant update x <= old(x) && tautology();
     │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
     │
-    =     at tests/sources/functional/invariants.move:59:5: invalid_R_update (entry)
-    =     at tests/sources/functional/invariants.move:60:13: invalid_R_update
-    =     at tests/sources/functional/invariants.move:61:17: invalid_R_update
+    =     at tests/sources/functional/invariants.move:64:5: invalid_R_update (entry)
+    =     at tests/sources/functional/invariants.move:65:13: invalid_R_update
+    =     at tests/sources/functional/invariants.move:66:17: invalid_R_update
     =         r = <redacted>,
     =         t = <redacted>
-    =     at tests/sources/functional/invariants.move:62:20: invalid_R_update
+    =     at tests/sources/functional/invariants.move:67:20: invalid_R_update
     =         r = <redacted>
 
 error:  This assertion might not hold.
 
-    ┌── tests/sources/functional/invariants.move:14:9 ───
+    ┌── tests/sources/functional/invariants.move:19:9 ───
     │
- 14 │         invariant update x <= old(x) && tautology();
+ 19 │         invariant update x <= old(x) && tautology();
     │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
     │
-    =     at tests/sources/functional/invariants.move:88:5: invalid_R_update_branching (entry)
-    =     at tests/sources/functional/invariants.move:89:13: invalid_R_update_branching
+    =     at tests/sources/functional/invariants.move:93:5: invalid_R_update_branching (entry)
+    =     at tests/sources/functional/invariants.move:94:13: invalid_R_update_branching
     =         b = <redacted>,
     =         t1 = <redacted>
-    =     at tests/sources/functional/invariants.move:90:24: invalid_R_update_branching
+    =     at tests/sources/functional/invariants.move:95:24: invalid_R_update_branching
     =         t2 = <redacted>
-    =     at tests/sources/functional/invariants.move:92:13: invalid_R_update_branching
     =     at tests/sources/functional/invariants.move:97:13: invalid_R_update_branching
-    =     at tests/sources/functional/invariants.move:99:20: invalid_R_update_branching
+    =     at tests/sources/functional/invariants.move:102:13: invalid_R_update_branching
+    =     at tests/sources/functional/invariants.move:104:20: invalid_R_update_branching
     =         r = <redacted>,
     =         r = <redacted>
-    =     at tests/sources/functional/invariants.move:100:10: invalid_R_update_branching
+    =     at tests/sources/functional/invariants.move:105:10: invalid_R_update_branching
 
 error:  This assertion might not hold.
 
-    ┌── tests/sources/functional/invariants.move:14:9 ───
+    ┌── tests/sources/functional/invariants.move:19:9 ───
     │
- 14 │         invariant update x <= old(x) && tautology();
+ 19 │         invariant update x <= old(x) && tautology();
     │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
     │
-    =     at tests/sources/functional/invariants.move:79:5: invalid_R_update_indirectly (entry)
-    =     at tests/sources/functional/invariants.move:80:13: invalid_R_update_indirectly
-    =     at tests/sources/functional/invariants.move:81:28: invalid_R_update_indirectly
+    =     at tests/sources/functional/invariants.move:84:5: invalid_R_update_indirectly (entry)
+    =     at tests/sources/functional/invariants.move:85:13: invalid_R_update_indirectly
+    =     at tests/sources/functional/invariants.move:86:28: invalid_R_update_indirectly
     =         t = <redacted>
-    =     at tests/sources/functional/invariants.move:84:5: update_helper (entry)
-    =     at tests/sources/functional/invariants.move:85:9: update_helper
+    =     at tests/sources/functional/invariants.move:89:5: update_helper (entry)
+    =     at tests/sources/functional/invariants.move:90:9: update_helper
     =         r = <redacted>,
     =         r = <redacted>
-    =     at tests/sources/functional/invariants.move:81:9: invalid_R_update_indirectly
+    =     at tests/sources/functional/invariants.move:86:9: invalid_R_update_indirectly
 
 error:  This assertion might not hold.
 
-    ┌── tests/sources/functional/invariants.move:14:9 ───
+    ┌── tests/sources/functional/invariants.move:19:9 ───
     │
- 14 │         invariant update x <= old(x) && tautology();
+ 19 │         invariant update x <= old(x) && tautology();
     │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
     │
-    =     at tests/sources/functional/invariants.move:69:5: invalid_R_update_ref (entry)
-    =     at tests/sources/functional/invariants.move:70:13: invalid_R_update_ref
-    =     at tests/sources/functional/invariants.move:71:22: invalid_R_update_ref
+    =     at tests/sources/functional/invariants.move:74:5: invalid_R_update_ref (entry)
+    =     at tests/sources/functional/invariants.move:75:13: invalid_R_update_ref
+    =     at tests/sources/functional/invariants.move:76:22: invalid_R_update_ref
     =         r = <redacted>,
     =         t = <redacted>
-    =     at tests/sources/functional/invariants.move:72:14: invalid_R_update_ref
+    =     at tests/sources/functional/invariants.move:77:14: invalid_R_update_ref
     =         r = <redacted>
 
 error:  This assertion might not hold.
 
-    ┌── tests/sources/functional/invariants.move:11:9 ───
+    ┌── tests/sources/functional/invariants.move:16:9 ───
     │
- 11 │         invariant greater_one(x);
+ 16 │         invariant greater_one(x);
     │         ^^^^^^^^^^^^^^^^^^^^^^^^^
     │
-    =     at tests/sources/functional/invariants.move:107:5: lifetime_invalid_R (entry)
-    =     at tests/sources/functional/invariants.move:108:13: lifetime_invalid_R
-    =     at tests/sources/functional/invariants.move:109:21: lifetime_invalid_R
+    =     at tests/sources/functional/invariants.move:112:5: lifetime_invalid_R (entry)
+    =     at tests/sources/functional/invariants.move:113:13: lifetime_invalid_R
+    =     at tests/sources/functional/invariants.move:114:21: lifetime_invalid_R
     =         r = <redacted>,
     =         r_ref = <redacted>
-    =     at tests/sources/functional/invariants.move:110:26: lifetime_invalid_R
+    =     at tests/sources/functional/invariants.move:115:26: lifetime_invalid_R
     =         x_ref = <redacted>
-    =     at tests/sources/functional/invariants.move:111:18: lifetime_invalid_R
+    =     at tests/sources/functional/invariants.move:116:18: lifetime_invalid_R
     =         r_ref = <redacted>,
     =         x_ref = <redacted>
 
 error:  This assertion might not hold.
 
-    ┌── tests/sources/functional/invariants.move:14:9 ───
+    ┌── tests/sources/functional/invariants.move:19:9 ───
     │
- 14 │         invariant update x <= old(x) && tautology();
+ 19 │         invariant update x <= old(x) && tautology();
     │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
     │
-    =     at tests/sources/functional/invariants.move:120:5: lifetime_invalid_R_2 (entry)
-    =     at tests/sources/functional/invariants.move:121:13: lifetime_invalid_R_2
-    =     at tests/sources/functional/invariants.move:122:21: lifetime_invalid_R_2
+    =     at tests/sources/functional/invariants.move:125:5: lifetime_invalid_R_2 (entry)
+    =     at tests/sources/functional/invariants.move:126:13: lifetime_invalid_R_2
+    =     at tests/sources/functional/invariants.move:127:21: lifetime_invalid_R_2
     =         r = <redacted>,
     =         r_ref = <redacted>
-    =     at tests/sources/functional/invariants.move:123:26: lifetime_invalid_R_2
-    =         x_ref = <redacted>
-    =     at tests/sources/functional/invariants.move:124:18: lifetime_invalid_R_2
-    =         r_ref = <redacted>,
-    =         x_ref = <redacted>
-    =     at tests/sources/functional/invariants.move:125:18: lifetime_invalid_R_2
-    =         r_ref = <redacted>,
-    =         x_ref = <redacted>
-    =     at tests/sources/functional/invariants.move:127:17: lifetime_invalid_R_2
-    =         r_ref = <redacted>
-    =     at tests/sources/functional/invariants.move:128:22: lifetime_invalid_R_2
+    =     at tests/sources/functional/invariants.move:128:26: lifetime_invalid_R_2
     =         x_ref = <redacted>
     =     at tests/sources/functional/invariants.move:129:18: lifetime_invalid_R_2
     =         r_ref = <redacted>,
     =         x_ref = <redacted>
+    =     at tests/sources/functional/invariants.move:130:18: lifetime_invalid_R_2
+    =         r_ref = <redacted>,
+    =         x_ref = <redacted>
+    =     at tests/sources/functional/invariants.move:132:17: lifetime_invalid_R_2
+    =         r_ref = <redacted>
+    =     at tests/sources/functional/invariants.move:133:22: lifetime_invalid_R_2
+    =         x_ref = <redacted>
+    =     at tests/sources/functional/invariants.move:134:18: lifetime_invalid_R_2
+    =         r_ref = <redacted>,
+    =         x_ref = <redacted>
 
 error:  This assertion might not hold.
 
-     ┌── tests/sources/functional/invariants.move:145:9 ───
+     ┌── tests/sources/functional/invariants.move:150:9 ───
      │
- 145 │         invariant y > 1;
+ 150 │         invariant y > 1;
      │         ^^^^^^^^^^^^^^^^
      │
-     =     at tests/sources/functional/invariants.move:148:5: lifetime_invalid_S_branching (entry)
-     =     at tests/sources/functional/invariants.move:149:11: lifetime_invalid_S_branching
+     =     at tests/sources/functional/invariants.move:153:5: lifetime_invalid_S_branching (entry)
+     =     at tests/sources/functional/invariants.move:154:11: lifetime_invalid_S_branching
      =         cond = <redacted>
-     =     at tests/sources/functional/invariants.move:150:21: lifetime_invalid_S_branching
+     =     at tests/sources/functional/invariants.move:155:21: lifetime_invalid_S_branching
      =         a = <redacted>,
      =         b = <redacted>
-     =     at tests/sources/functional/invariants.move:151:19: lifetime_invalid_S_branching
+     =     at tests/sources/functional/invariants.move:156:19: lifetime_invalid_S_branching
      =         a_ref = <redacted>
-     =     at tests/sources/functional/invariants.move:152:19: lifetime_invalid_S_branching
+     =     at tests/sources/functional/invariants.move:157:19: lifetime_invalid_S_branching
      =         b_ref = <redacted>
-     =     at tests/sources/functional/invariants.move:153:23: lifetime_invalid_S_branching
+     =     at tests/sources/functional/invariants.move:158:23: lifetime_invalid_S_branching
      =         $t5 = <redacted>,
      =         x_ref = <redacted>
-     =     at tests/sources/functional/invariants.move:155:11: lifetime_invalid_S_branching
-     =     at tests/sources/functional/invariants.move:158:11: lifetime_invalid_S_branching
+     =     at tests/sources/functional/invariants.move:160:11: lifetime_invalid_S_branching
+     =     at tests/sources/functional/invariants.move:163:11: lifetime_invalid_S_branching
      =         a_ref = <redacted>,
      =         b_ref = <redacted>,
      =         $t5 = <redacted>,

--- a/language/move-prover/tests/sources/functional/invariants.move
+++ b/language/move-prover/tests/sources/functional/invariants.move
@@ -1,5 +1,10 @@
 module TestInvariants {
 
+    spec module {
+        pragma verify = true;
+    }
+
+
     // General invariant checking.
 
     struct R {

--- a/language/move-prover/tests/sources/functional/marketcap.exp
+++ b/language/move-prover/tests/sources/functional/marketcap.exp
@@ -1,16 +1,16 @@
 Move prover returns: exiting with boogie verification errors
 error:  A postcondition might not hold on this return path.
 
-    ┌── tests/sources/functional/marketcap.move:11:9 ───
+    ┌── tests/sources/functional/marketcap.move:16:9 ───
     │
- 11 │         invariant global<MarketCap>(0xA550C18).total_value == sum_of_coins;
+ 16 │         invariant global<MarketCap>(0xA550C18).total_value == sum_of_coins;
     │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
     │
-    =     at tests/sources/functional/marketcap.move:44:6: deposit_invalid (entry)
-    =     at tests/sources/functional/marketcap.move:45:18: deposit_invalid
+    =     at tests/sources/functional/marketcap.move:49:6: deposit_invalid (entry)
+    =     at tests/sources/functional/marketcap.move:50:18: deposit_invalid
     =         coin_ref = <redacted>,
     =         check = <redacted>,
     =         value = <redacted>
-    =     at tests/sources/functional/marketcap.move:46:27: deposit_invalid
+    =     at tests/sources/functional/marketcap.move:51:27: deposit_invalid
     =         coin_ref = <redacted>
-    =     at tests/sources/functional/marketcap.move:44:6: deposit_invalid (exit)
+    =     at tests/sources/functional/marketcap.move:49:6: deposit_invalid (exit)

--- a/language/move-prover/tests/sources/functional/marketcap.move
+++ b/language/move-prover/tests/sources/functional/marketcap.move
@@ -4,6 +4,11 @@ address 0x0 {
 module TestMarketCap {
 
     spec module {
+        pragma verify = true;
+    }
+
+
+    spec module {
         // SPEC: sum of values of all coins.
         global sum_of_coins: num;
 

--- a/language/move-prover/tests/sources/functional/marketcap_as_schema.exp
+++ b/language/move-prover/tests/sources/functional/marketcap_as_schema.exp
@@ -1,16 +1,16 @@
 Move prover returns: exiting with boogie verification errors
 error:  A postcondition might not hold on this return path.
 
-    ┌── tests/sources/functional/marketcap_as_schema.move:11:9 ───
+    ┌── tests/sources/functional/marketcap_as_schema.move:16:9 ───
     │
- 11 │         invariant module global<MarketCap>(0xA550C18).total_value == sum_of_coins<X>;
+ 16 │         invariant module global<MarketCap>(0xA550C18).total_value == sum_of_coins<X>;
     │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
     │
-    =     at tests/sources/functional/marketcap_as_schema.move:54:6: deposit_invalid (entry)
-    =     at tests/sources/functional/marketcap_as_schema.move:55:18: deposit_invalid
+    =     at tests/sources/functional/marketcap_as_schema.move:59:6: deposit_invalid (entry)
+    =     at tests/sources/functional/marketcap_as_schema.move:60:18: deposit_invalid
     =         coin_ref = <redacted>,
     =         check = <redacted>,
     =         value = <redacted>
-    =     at tests/sources/functional/marketcap_as_schema.move:56:27: deposit_invalid
+    =     at tests/sources/functional/marketcap_as_schema.move:61:27: deposit_invalid
     =         coin_ref = <redacted>
-    =     at tests/sources/functional/marketcap_as_schema.move:54:6: deposit_invalid (exit)
+    =     at tests/sources/functional/marketcap_as_schema.move:59:6: deposit_invalid (exit)

--- a/language/move-prover/tests/sources/functional/marketcap_as_schema.move
+++ b/language/move-prover/tests/sources/functional/marketcap_as_schema.move
@@ -4,6 +4,11 @@ address 0x0 {
 module TestMarketCapWithSchemas {
 
     spec module {
+        pragma verify = true;
+    }
+
+
+    spec module {
         global sum_of_coins<X>: num;
     }
 

--- a/language/move-prover/tests/sources/functional/marketcap_as_schema_apply.exp
+++ b/language/move-prover/tests/sources/functional/marketcap_as_schema_apply.exp
@@ -1,16 +1,16 @@
 Move prover returns: exiting with boogie verification errors
 error:  A postcondition might not hold on this return path.
 
-    ┌── tests/sources/functional/marketcap_as_schema_apply.move:11:9 ───
+    ┌── tests/sources/functional/marketcap_as_schema_apply.move:16:9 ───
     │
- 11 │         invariant module global<MarketCap>(0xA550C18).total_value == sum_of_coins<X>;
+ 16 │         invariant module global<MarketCap>(0xA550C18).total_value == sum_of_coins<X>;
     │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
     │
-    =     at tests/sources/functional/marketcap_as_schema_apply.move:62:5: deposit_incorrect (entry)
-    =     at tests/sources/functional/marketcap_as_schema_apply.move:63:17: deposit_incorrect
+    =     at tests/sources/functional/marketcap_as_schema_apply.move:67:5: deposit_incorrect (entry)
+    =     at tests/sources/functional/marketcap_as_schema_apply.move:68:17: deposit_incorrect
     =         coin_ref = <redacted>,
     =         check = <redacted>,
     =         value = <redacted>
-    =     at tests/sources/functional/marketcap_as_schema_apply.move:64:26: deposit_incorrect
+    =     at tests/sources/functional/marketcap_as_schema_apply.move:69:26: deposit_incorrect
     =         coin_ref = <redacted>
-    =     at tests/sources/functional/marketcap_as_schema_apply.move:62:5: deposit_incorrect (exit)
+    =     at tests/sources/functional/marketcap_as_schema_apply.move:67:5: deposit_incorrect (exit)

--- a/language/move-prover/tests/sources/functional/marketcap_as_schema_apply.move
+++ b/language/move-prover/tests/sources/functional/marketcap_as_schema_apply.move
@@ -4,6 +4,11 @@ address 0x0 {
 module TestMarketCapWithSchemas {
 
     spec module {
+        pragma verify = true;
+    }
+
+
+    spec module {
         global sum_of_coins<X>: num;
     }
 

--- a/language/move-prover/tests/sources/functional/marketcap_generic.exp
+++ b/language/move-prover/tests/sources/functional/marketcap_generic.exp
@@ -1,16 +1,16 @@
 Move prover returns: exiting with boogie verification errors
 error:  A postcondition might not hold on this return path.
 
-    ┌── tests/sources/functional/marketcap_generic.move:64:10 ───
+    ┌── tests/sources/functional/marketcap_generic.move:69:10 ───
     │
- 64 │          ensures sum_of_coins_invariant<X>();
+ 69 │          ensures sum_of_coins_invariant<X>();
     │          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
     │
-    =     at tests/sources/functional/marketcap_generic.move:57:6: deposit_invalid (entry)
-    =     at tests/sources/functional/marketcap_generic.move:58:18: deposit_invalid
+    =     at tests/sources/functional/marketcap_generic.move:62:6: deposit_invalid (entry)
+    =     at tests/sources/functional/marketcap_generic.move:63:18: deposit_invalid
     =         coin_ref = <redacted>,
     =         check = <redacted>,
     =         value = <redacted>
-    =     at tests/sources/functional/marketcap_generic.move:59:27: deposit_invalid
+    =     at tests/sources/functional/marketcap_generic.move:64:27: deposit_invalid
     =         coin_ref = <redacted>
-    =     at tests/sources/functional/marketcap_generic.move:57:6: deposit_invalid (exit)
+    =     at tests/sources/functional/marketcap_generic.move:62:6: deposit_invalid (exit)

--- a/language/move-prover/tests/sources/functional/marketcap_generic.move
+++ b/language/move-prover/tests/sources/functional/marketcap_generic.move
@@ -4,6 +4,11 @@ address 0x0 {
 module TestMarketCapGeneric {
 
     spec module {
+        pragma verify = true;
+    }
+
+
+    spec module {
         // SPEC: sum of values of all coins.
         global sum_of_coins<X>: num;
 

--- a/language/move-prover/tests/sources/functional/module_invariants.exp
+++ b/language/move-prover/tests/sources/functional/module_invariants.exp
@@ -1,21 +1,21 @@
 Move prover returns: exiting with boogie verification errors
 error:  A postcondition might not hold on this return path.
 
-    ┌── tests/sources/functional/module_invariants.move:24:9 ───
+    ┌── tests/sources/functional/module_invariants.move:29:9 ───
     │
- 24 │         invariant global<SCounter>(0x0).n == spec_count;
+ 29 │         invariant global<SCounter>(0x0).n == spec_count;
     │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
     │
-    =     at tests/sources/functional/module_invariants.move:46:5: delete_S_incorrect (entry)
-    =     at tests/sources/functional/module_invariants.move:46:5: delete_S_incorrect (exit)
+    =     at tests/sources/functional/module_invariants.move:51:5: delete_S_incorrect (entry)
+    =     at tests/sources/functional/module_invariants.move:51:5: delete_S_incorrect (exit)
     =         x = <redacted>
 
 error:  A precondition for this call might not hold.
 
-    ┌── tests/sources/functional/module_invariants.move:24:9 ───
+    ┌── tests/sources/functional/module_invariants.move:29:9 ───
     │
- 24 │         invariant global<SCounter>(0x0).n == spec_count;
+ 29 │         invariant global<SCounter>(0x0).n == spec_count;
     │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
     │
-    =     at tests/sources/functional/module_invariants.move:55:5: private_calls_public_incorrect (entry)
-    =     at tests/sources/functional/module_invariants.move:31:5: new_S (entry)
+    =     at tests/sources/functional/module_invariants.move:60:5: private_calls_public_incorrect (entry)
+    =     at tests/sources/functional/module_invariants.move:36:5: new_S (entry)

--- a/language/move-prover/tests/sources/functional/module_invariants.move
+++ b/language/move-prover/tests/sources/functional/module_invariants.move
@@ -1,6 +1,11 @@
 address 0x1 {
 module TestModuleInvariants {
 
+    spec module {
+        pragma verify = true;
+    }
+
+
     // Some structure.
     struct S {}
 

--- a/language/move-prover/tests/sources/functional/mut_ref_accross_modules.exp
+++ b/language/move-prover/tests/sources/functional/mut_ref_accross_modules.exp
@@ -1,94 +1,94 @@
 Move prover returns: exiting with boogie verification errors
 error:  This assertion might not hold.
 
-    ┌── tests/sources/functional/mut_ref_accross_modules.move:76:13 ───
+    ┌── tests/sources/functional/mut_ref_accross_modules.move:81:13 ───
     │
- 76 │             assert x.value > 0;
+ 81 │             assert x.value > 0;
     │             ^^^^^^^^^^^^^^^^^^^
     │
-    =     at tests/sources/functional/mut_ref_accross_modules.move:74:5: data_invariant (entry)
+    =     at tests/sources/functional/mut_ref_accross_modules.move:79:5: data_invariant (entry)
 
 error:  This assertion might not hold.
 
-    ┌── tests/sources/functional/mut_ref_accross_modules.move:16:9 ───
+    ┌── tests/sources/functional/mut_ref_accross_modules.move:21:9 ───
     │
- 16 │         invariant value > 0;
+ 21 │         invariant value > 0;
     │         ^^^^^^^^^^^^^^^^^^^^
     │
-    =     at tests/sources/functional/mut_ref_accross_modules.move:59:5: decrement_invalid (entry)
-    =     at tests/sources/functional/mut_ref_accross_modules.move:60:27: decrement_invalid
+    =     at tests/sources/functional/mut_ref_accross_modules.move:64:5: decrement_invalid (entry)
+    =     at tests/sources/functional/mut_ref_accross_modules.move:65:27: decrement_invalid
     =         x = <redacted>,
     =         x = <redacted>,
     =         r = <redacted>
-    =     at tests/sources/functional/mut_ref_accross_modules.move:61:41: decrement_invalid
+    =     at tests/sources/functional/mut_ref_accross_modules.move:66:41: decrement_invalid
     =         r = <redacted>
-    =     at tests/sources/functional/mut_ref_accross_modules.move:62:17: decrement_invalid
+    =     at tests/sources/functional/mut_ref_accross_modules.move:67:17: decrement_invalid
     =         x = <redacted>,
     =         r = <redacted>
 
 error:  A postcondition might not hold on this return path.
 
-    ┌── tests/sources/functional/mut_ref_accross_modules.move:25:9 ───
+    ┌── tests/sources/functional/mut_ref_accross_modules.move:30:9 ───
     │
- 25 │         invariant global<TSum>(0x0).sum == spec_sum;
+ 30 │         invariant global<TSum>(0x0).sum == spec_sum;
     │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
     │
-    =     at tests/sources/functional/mut_ref_accross_modules.move:53:5: increment_invalid (entry)
-    =     at tests/sources/functional/mut_ref_accross_modules.move:54:27: increment_invalid
+    =     at tests/sources/functional/mut_ref_accross_modules.move:58:5: increment_invalid (entry)
+    =     at tests/sources/functional/mut_ref_accross_modules.move:59:27: increment_invalid
     =         x = <redacted>,
     =         x = <redacted>
-    =     at tests/sources/functional/mut_ref_accross_modules.move:53:5: increment_invalid (exit)
+    =     at tests/sources/functional/mut_ref_accross_modules.move:58:5: increment_invalid (exit)
 
 error:  This assertion might not hold.
 
-    ┌── tests/sources/functional/mut_ref_accross_modules.move:83:13 ───
+    ┌── tests/sources/functional/mut_ref_accross_modules.move:88:13 ───
     │
- 83 │             assert x.value > 0;
+ 88 │             assert x.value > 0;
     │             ^^^^^^^^^^^^^^^^^^^
     │
-    =     at tests/sources/functional/mut_ref_accross_modules.move:81:5: private_data_invariant_invalid (entry)
+    =     at tests/sources/functional/mut_ref_accross_modules.move:86:5: private_data_invariant_invalid (entry)
 
 error:  This assertion might not hold.
 
-    ┌── tests/sources/functional/mut_ref_accross_modules.move:16:9 ───
+    ┌── tests/sources/functional/mut_ref_accross_modules.move:21:9 ───
     │
- 16 │         invariant value > 0;
+ 21 │         invariant value > 0;
     │         ^^^^^^^^^^^^^^^^^^^^
     │
-    =     at tests/sources/functional/mut_ref_accross_modules.move:110:6: private_to_public_caller_invalid_data_invariant (entry)
-    =     at tests/sources/functional/mut_ref_accross_modules.move:29:5: new (entry)
-    =     at tests/sources/functional/mut_ref_accross_modules.move:30:17: new
+    =     at tests/sources/functional/mut_ref_accross_modules.move:115:6: private_to_public_caller_invalid_data_invariant (entry)
+    =     at tests/sources/functional/mut_ref_accross_modules.move:34:5: new (entry)
+    =     at tests/sources/functional/mut_ref_accross_modules.move:35:17: new
     =         x = <redacted>,
     =         r = <redacted>
-    =     at tests/sources/functional/mut_ref_accross_modules.move:31:17: new
+    =     at tests/sources/functional/mut_ref_accross_modules.move:36:17: new
     =         r = <redacted>
-    =     at tests/sources/functional/mut_ref_accross_modules.move:32:18: new
+    =     at tests/sources/functional/mut_ref_accross_modules.move:37:18: new
     =         result = <redacted>
-    =     at tests/sources/functional/mut_ref_accross_modules.move:29:5: new (exit)
-    =     at tests/sources/functional/mut_ref_accross_modules.move:115:18: private_to_public_caller_invalid_data_invariant
+    =     at tests/sources/functional/mut_ref_accross_modules.move:34:5: new (exit)
+    =     at tests/sources/functional/mut_ref_accross_modules.move:120:18: private_to_public_caller_invalid_data_invariant
     =         x = <redacted>
-    =     at tests/sources/functional/mut_ref_accross_modules.move:116:18: private_to_public_caller_invalid_data_invariant
+    =     at tests/sources/functional/mut_ref_accross_modules.move:121:18: private_to_public_caller_invalid_data_invariant
     =         r = <redacted>
-    =     at tests/sources/functional/mut_ref_accross_modules.move:67:5: private_decrement (entry)
-    =     at tests/sources/functional/mut_ref_accross_modules.move:68:27: private_decrement
+    =     at tests/sources/functional/mut_ref_accross_modules.move:72:5: private_decrement (entry)
+    =     at tests/sources/functional/mut_ref_accross_modules.move:73:27: private_decrement
     =         x = <redacted>,
     =         x = <redacted>,
     =         r = <redacted>
-    =     at tests/sources/functional/mut_ref_accross_modules.move:69:41: private_decrement
+    =     at tests/sources/functional/mut_ref_accross_modules.move:74:41: private_decrement
     =         r = <redacted>
-    =     at tests/sources/functional/mut_ref_accross_modules.move:70:17: private_decrement
+    =     at tests/sources/functional/mut_ref_accross_modules.move:75:17: private_decrement
     =         x = <redacted>,
     =         r = <redacted>
-    =     at tests/sources/functional/mut_ref_accross_modules.move:119:10: private_to_public_caller_invalid_data_invariant
+    =     at tests/sources/functional/mut_ref_accross_modules.move:124:10: private_to_public_caller_invalid_data_invariant
     =         r = <redacted>
-    =     at tests/sources/functional/mut_ref_accross_modules.move:121:10: private_to_public_caller_invalid_data_invariant
+    =     at tests/sources/functional/mut_ref_accross_modules.move:126:10: private_to_public_caller_invalid_data_invariant
 
 error:  A precondition for this call might not hold.
 
-    ┌── tests/sources/functional/mut_ref_accross_modules.move:25:9 ───
+    ┌── tests/sources/functional/mut_ref_accross_modules.move:30:9 ───
     │
- 25 │         invariant global<TSum>(0x0).sum == spec_sum;
+ 30 │         invariant global<TSum>(0x0).sum == spec_sum;
     │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
     │
-    =     at tests/sources/functional/mut_ref_accross_modules.move:105:6: private_to_public_caller_invalid_precondition (entry)
-    =     at tests/sources/functional/mut_ref_accross_modules.move:46:5: increment (entry)
+    =     at tests/sources/functional/mut_ref_accross_modules.move:110:6: private_to_public_caller_invalid_precondition (entry)
+    =     at tests/sources/functional/mut_ref_accross_modules.move:51:5: increment (entry)

--- a/language/move-prover/tests/sources/functional/mut_ref_accross_modules.move
+++ b/language/move-prover/tests/sources/functional/mut_ref_accross_modules.move
@@ -1,6 +1,11 @@
 address 0x1 {
 module TestMutRefs {
 
+    spec module {
+        pragma verify = true;
+    }
+
+
     struct T { value: u64 }
 
     // Resource to track the sum of values in T

--- a/language/move-prover/tests/sources/functional/nested_invariants.exp
+++ b/language/move-prover/tests/sources/functional/nested_invariants.exp
@@ -1,48 +1,48 @@
 Move prover returns: exiting with boogie verification errors
 error:  This assertion might not hold.
 
-    ┌── tests/sources/functional/nested_invariants.move:11:9 ───
+    ┌── tests/sources/functional/nested_invariants.move:16:9 ───
     │
- 11 │         invariant x > 0;
+ 16 │         invariant x > 0;
     │         ^^^^^^^^^^^^^^^^
     │
-    =     at tests/sources/functional/nested_invariants.move:58:5: mutate_inner_data_invariant_invalid (entry)
-    =     at tests/sources/functional/nested_invariants.move:59:13: mutate_inner_data_invariant_invalid
-    =     at tests/sources/functional/nested_invariants.move:60:17: mutate_inner_data_invariant_invalid
+    =     at tests/sources/functional/nested_invariants.move:63:5: mutate_inner_data_invariant_invalid (entry)
+    =     at tests/sources/functional/nested_invariants.move:64:13: mutate_inner_data_invariant_invalid
+    =     at tests/sources/functional/nested_invariants.move:65:17: mutate_inner_data_invariant_invalid
     =         o = <redacted>,
     =         r = <redacted>
-    =     at tests/sources/functional/nested_invariants.move:61:17: mutate_inner_data_invariant_invalid
+    =     at tests/sources/functional/nested_invariants.move:66:17: mutate_inner_data_invariant_invalid
     =         r = <redacted>
 
 error:  This assertion might not hold.
 
-    ┌── tests/sources/functional/nested_invariants.move:27:9 ───
+    ┌── tests/sources/functional/nested_invariants.move:32:9 ───
     │
- 27 │         invariant n.x < y;
+ 32 │         invariant n.x < y;
     │         ^^^^^^^^^^^^^^^^^^
     │
-    =     at tests/sources/functional/nested_invariants.move:52:5: mutate_outer_data_invariant_invalid (entry)
-    =     at tests/sources/functional/nested_invariants.move:53:13: mutate_outer_data_invariant_invalid
-    =     at tests/sources/functional/nested_invariants.move:54:17: mutate_outer_data_invariant_invalid
+    =     at tests/sources/functional/nested_invariants.move:57:5: mutate_outer_data_invariant_invalid (entry)
+    =     at tests/sources/functional/nested_invariants.move:58:13: mutate_outer_data_invariant_invalid
+    =     at tests/sources/functional/nested_invariants.move:59:17: mutate_outer_data_invariant_invalid
     =         o = <redacted>,
     =         r = <redacted>
-    =     at tests/sources/functional/nested_invariants.move:55:15: mutate_outer_data_invariant_invalid
+    =     at tests/sources/functional/nested_invariants.move:60:15: mutate_outer_data_invariant_invalid
     =         r = <redacted>
 
 error:  This assertion might not hold.
 
-    ┌── tests/sources/functional/nested_invariants.move:11:9 ───
+    ┌── tests/sources/functional/nested_invariants.move:16:9 ───
     │
- 11 │         invariant x > 0;
+ 16 │         invariant x > 0;
     │         ^^^^^^^^^^^^^^^^
     │
-    =     at tests/sources/functional/nested_invariants.move:41:5: new_inner_data_invariant_invalid (entry)
+    =     at tests/sources/functional/nested_invariants.move:46:5: new_inner_data_invariant_invalid (entry)
 
 error:  This assertion might not hold.
 
-    ┌── tests/sources/functional/nested_invariants.move:27:9 ───
+    ┌── tests/sources/functional/nested_invariants.move:32:9 ───
     │
- 27 │         invariant n.x < y;
+ 32 │         invariant n.x < y;
     │         ^^^^^^^^^^^^^^^^^^
     │
-    =     at tests/sources/functional/nested_invariants.move:37:5: new_outer_data_invariant_invalid (entry)
+    =     at tests/sources/functional/nested_invariants.move:42:5: new_outer_data_invariant_invalid (entry)

--- a/language/move-prover/tests/sources/functional/nested_invariants.move
+++ b/language/move-prover/tests/sources/functional/nested_invariants.move
@@ -1,5 +1,10 @@
 module TestNestedInvariants {
 
+    spec module {
+        pragma verify = true;
+    }
+
+
     // Tests scenarios for invariants with nested structs
 
     struct Nested {

--- a/language/move-prover/tests/sources/functional/references.exp
+++ b/language/move-prover/tests/sources/functional/references.exp
@@ -1,23 +1,23 @@
 Move prover returns: exiting with boogie verification errors
 error:  A postcondition might not hold on this return path.
 
-    ┌── tests/sources/functional/references.move:61:9 ───
+    ┌── tests/sources/functional/references.move:66:9 ───
     │
- 61 │         aborts_if true;
+ 66 │         aborts_if true;
     │         ^^^^^^^^^^^^^^^
     │
-    =     at tests/sources/functional/references.move:53:5: mut_ref_incorrect (entry)
-    =     at tests/sources/functional/references.move:54:13: mut_ref_incorrect
-    =     at tests/sources/functional/references.move:55:31: mut_ref_incorrect
+    =     at tests/sources/functional/references.move:58:5: mut_ref_incorrect (entry)
+    =     at tests/sources/functional/references.move:59:13: mut_ref_incorrect
+    =     at tests/sources/functional/references.move:60:31: mut_ref_incorrect
     =         b = <redacted>,
     =         b_ref = <redacted>
-    =     at tests/sources/functional/references.move:38:5: mut_b (entry)
-    =     at tests/sources/functional/references.move:39:9: mut_b
+    =     at tests/sources/functional/references.move:43:5: mut_b (entry)
+    =     at tests/sources/functional/references.move:44:9: mut_b
     =         b = <redacted>,
     =         b = <redacted>
-    =     at tests/sources/functional/references.move:56:9: mut_ref_incorrect
+    =     at tests/sources/functional/references.move:61:9: mut_ref_incorrect
     =         b_ref = <redacted>
-    =     at tests/sources/functional/references.move:57:14: mut_ref_incorrect
+    =     at tests/sources/functional/references.move:62:14: mut_ref_incorrect
     =         b = <redacted>
-    =     at tests/sources/functional/references.move:58:13: mut_ref_incorrect
-    =     at tests/sources/functional/references.move:53:5: mut_ref_incorrect (exit)
+    =     at tests/sources/functional/references.move:63:13: mut_ref_incorrect
+    =     at tests/sources/functional/references.move:58:5: mut_ref_incorrect (exit)

--- a/language/move-prover/tests/sources/functional/references.move
+++ b/language/move-prover/tests/sources/functional/references.move
@@ -1,6 +1,11 @@
 module TestReferences {
     use 0x0::Vector;
 
+    spec module {
+        pragma verify = true;
+    }
+
+
     // ------------------------
     // References as parameters
     // ------------------------

--- a/language/move-prover/tests/sources/functional/resources.exp
+++ b/language/move-prover/tests/sources/functional/resources.exp
@@ -1,11 +1,11 @@
 Move prover returns: exiting with boogie verification errors
 error:  A postcondition might not hold on this return path.
 
-    ┌── tests/sources/functional/resources.move:27:6 ───
+    ┌── tests/sources/functional/resources.move:32:6 ───
     │
- 27 │      ensures exists<R>(sender());
+ 32 │      ensures exists<R>(sender());
     │      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
     │
-    =     at tests/sources/functional/resources.move:20:5: create_resource_incorrect (entry)
-    =     at tests/sources/functional/resources.move:21:9: create_resource_incorrect
-    =     at tests/sources/functional/resources.move:20:5: create_resource_incorrect (exit)
+    =     at tests/sources/functional/resources.move:25:5: create_resource_incorrect (entry)
+    =     at tests/sources/functional/resources.move:26:9: create_resource_incorrect
+    =     at tests/sources/functional/resources.move:25:5: create_resource_incorrect (exit)

--- a/language/move-prover/tests/sources/functional/resources.move
+++ b/language/move-prover/tests/sources/functional/resources.move
@@ -1,6 +1,11 @@
 module TestResources {
     use 0x0::Transaction;
 
+    spec module {
+        pragma verify = true;
+    }
+
+
     // ---------------
     // Simple resource
     // ---------------
@@ -9,7 +14,7 @@ module TestResources {
         x: u64
     }
 
-    fun create_resource() {
+    public fun create_resource() {
         move_to_sender<R>(R{x:1});
     }
     spec fun create_resource {
@@ -17,7 +22,7 @@ module TestResources {
         ensures exists<R>(sender());
     }
 
-    fun create_resource_incorrect() {
+    public fun create_resource_incorrect() {
         if(exists<R>(Transaction::sender())) {
             abort 1
         };
@@ -27,7 +32,7 @@ module TestResources {
      ensures exists<R>(sender());
     }
 
-    fun move_from_addr(a: address) acquires R {
+    public fun move_from_addr(a: address) acquires R {
         let r = move_from<R>(a);
         let R{x: _} = r;
     }
@@ -35,7 +40,7 @@ module TestResources {
         aborts_if !exists<R>(a);
     }
 
-    fun move_from_addr_to_sender(a: address) acquires R {
+    public fun move_from_addr_to_sender(a: address) acquires R {
         let r = move_from<R>(a);
         let R{x: x} = r;
         move_to_sender<R>(R{x: x});
@@ -49,7 +54,7 @@ module TestResources {
         ensures old(global<R>(a)) == global<R>(sender());
     }
 
-    fun move_from_addr_and_return(a: address): R acquires R {
+    public fun move_from_addr_and_return(a: address): R acquires R {
         let r = move_from<R>(a);
         let R{x: x} = r;
         R{x: x}
@@ -61,7 +66,7 @@ module TestResources {
         ensures result == old(global<R>(a));
     }
 
-    fun move_from_sender_and_return(): R acquires R {
+    public fun move_from_sender_and_return(): R acquires R {
         let r = move_from<R>(Transaction::sender());
         let R{x: x} = r;
         R{x: x}
@@ -72,7 +77,7 @@ module TestResources {
         ensures result == old(global<R>(sender()));
     }
 
-    fun move_from_sender_to_sender() acquires R {
+    public fun move_from_sender_to_sender() acquires R {
         let r = move_from<R>(Transaction::sender());
         let R{x: x} = r;
         move_to_sender<R>(R{x: x});
@@ -84,7 +89,7 @@ module TestResources {
         ensures old(global<R>(sender())) == global<R>(sender());
     }
 
-    fun borrow_global_mut_correct(a: address) acquires R {
+    public fun borrow_global_mut_correct(a: address) acquires R {
         let r = borrow_global_mut<R>(a);
         _ = r;
         let r2 = borrow_global_mut<R>(a);
@@ -114,7 +119,7 @@ module TestResources {
         b: B,
     }
 
-    fun identity(a: A, b: B, c: C): (A,B,C) {
+    public fun identity(a: A, b: B, c: C): (A,B,C) {
         (a, b, c)
     }
     spec fun identity {
@@ -124,7 +129,7 @@ module TestResources {
         ensures result_3 == c;
     }
 
-    fun pack_A(a: address, va: u64): A {
+    public fun pack_A(a: address, va: u64): A {
         A{ addr:a, val:va }
     }
     spec fun pack_A {
@@ -133,7 +138,7 @@ module TestResources {
         ensures result.val == va;
     }
 
-    fun pack_B(a: address, va: u64, vb: u64): B {
+    public fun pack_B(a: address, va: u64, vb: u64): B {
         let var_a = A{ addr: a, val: va };
         let var_b = B{ val: vb, a: var_a };
         var_b
@@ -145,7 +150,7 @@ module TestResources {
         ensures result.a.addr == a;
     }
 
-    fun pack_C(a: address, va: u64, vb: u64, vc: u64): C {
+    public fun pack_C(a: address, va: u64, vb: u64, vc: u64): C {
         let var_a = A{ addr: a, val: va };
         let var_b = B{ val: vb, a: var_a };
         let var_c = C{ val: vc, b: var_b };
@@ -159,7 +164,7 @@ module TestResources {
         ensures result.b.a.addr == a;
     }
 
-    fun unpack_A(a: address, va: u64): (address, u64) {
+    public fun unpack_A(a: address, va: u64): (address, u64) {
         let var_a = A{ addr:a, val:va };
         let A{addr: aa, val:v1} = var_a;
         (aa, v1)
@@ -170,7 +175,7 @@ module TestResources {
         ensures result_2 == va;
     }
 
-    fun unpack_B(a: address, va: u64, vb: u64): (address, u64, u64) {
+    public fun unpack_B(a: address, va: u64, vb: u64): (address, u64, u64) {
         let var_a = A{ addr: a, val: va };
         let var_b = B{ val: vb, a: var_a };
         let B{val: v2, a: A{ addr:aa, val: v1}} = var_b;
@@ -183,7 +188,7 @@ module TestResources {
         ensures result_3 == vb;
     }
 
-    fun unpack_C(a: address, va: u64, vb: u64, vc: u64): (address, u64, u64, u64) {
+    public fun unpack_C(a: address, va: u64, vb: u64, vc: u64): (address, u64, u64, u64) {
         let var_a = A{ addr: a, val: va };
         let var_b = B{ val: vb, a: var_a };
         let var_c = C{ val: vc, b: var_b };
@@ -198,7 +203,7 @@ module TestResources {
         ensures result_4 == vc;
     }
 
-    fun ref_A(a: address, b: bool): A {
+    public fun ref_A(a: address, b: bool): A {
         let var_a = if (b) A{ addr: a, val: 1 }
                     else A{ addr: a, val: 42 };
         let var_a_ref = &var_a;
@@ -217,7 +222,7 @@ module TestResources {
     // Packs in spec
     // ---------------
 
-    fun spec_pack_R(): R {
+    public fun spec_pack_R(): R {
         R{x: 7}
     }
     spec fun spec_pack_R {
@@ -226,7 +231,7 @@ module TestResources {
         ensures result == R{x: 7};
     }
 
-    fun spec_pack_A(): A {
+    public fun spec_pack_A(): A {
         A{ addr: Transaction::sender(), val: 7 }
     }
     spec fun spec_pack_A {
@@ -237,7 +242,7 @@ module TestResources {
         ensures result == A{ val: 7, addr: sender() };
     }
 
-    fun spec_pack_B(): B {
+    public fun spec_pack_B(): B {
         B{ val: 77, a: A{ addr: Transaction::sender(), val: 7 }}
     }
     spec fun spec_pack_B {

--- a/language/move-prover/tests/sources/functional/schema_exp.exp
+++ b/language/move-prover/tests/sources/functional/schema_exp.exp
@@ -1,29 +1,29 @@
 Move prover returns: exiting with boogie verification errors
 error: abort not covered by any of the `aborts_if` clauses
 
-    ┌── tests/sources/functional/schema_exp.move:20:5 ───
+    ┌── tests/sources/functional/schema_exp.move:25:5 ───
     │
- 20 │ ╭     fun bar_incorrect(c: bool) {
- 21 │ │         if (!c) abort(1);
- 22 │ │     }
+ 25 │ ╭     fun bar_incorrect(c: bool) {
+ 26 │ │         if (!c) abort(1);
+ 27 │ │     }
     │ ╰─────^
     ·
- 21 │         if (!c) abort(1);
+ 26 │         if (!c) abort(1);
     │         ---------------- abort happened here
     │
-    =     at tests/sources/functional/schema_exp.move:20:5: bar_incorrect (entry)
-    =     at tests/sources/functional/schema_exp.move:21:9: bar_incorrect (ABORTED)
+    =     at tests/sources/functional/schema_exp.move:25:5: bar_incorrect (entry)
+    =     at tests/sources/functional/schema_exp.move:26:9: bar_incorrect (ABORTED)
     =         c = <redacted>
 
 error:  A postcondition might not hold on this return path.
 
-    ┌── tests/sources/functional/schema_exp.move:42:9 ───
+    ┌── tests/sources/functional/schema_exp.move:47:9 ───
     │
- 42 │         ensures result == i + 2;
+ 47 │         ensures result == i + 2;
     │         ^^^^^^^^^^^^^^^^^^^^^^^^
     │
-    =     at tests/sources/functional/schema_exp.move:48:5: baz_incorrect (entry)
-    =     at tests/sources/functional/schema_exp.move:49:11: baz_incorrect
+    =     at tests/sources/functional/schema_exp.move:53:5: baz_incorrect (entry)
+    =     at tests/sources/functional/schema_exp.move:54:11: baz_incorrect
     =         i = <redacted>,
     =         result = <redacted>
-    =     at tests/sources/functional/schema_exp.move:48:5: baz_incorrect (exit)
+    =     at tests/sources/functional/schema_exp.move:53:5: baz_incorrect (exit)

--- a/language/move-prover/tests/sources/functional/schema_exp.move
+++ b/language/move-prover/tests/sources/functional/schema_exp.move
@@ -1,5 +1,10 @@
 module TestSchemaExp {
 
+    spec module {
+        pragma verify = true;
+    }
+
+
     spec schema Aborts {
         aborts_if true;
     }

--- a/language/move-prover/tests/sources/functional/script_incorrect.exp
+++ b/language/move-prover/tests/sources/functional/script_incorrect.exp
@@ -9,11 +9,11 @@ error: abort not covered by any of the `aborts_if` clauses
    │ ╰─^
    │
    =     at tests/sources/functional/script_incorrect.move:5:1: main (entry)
-   =     at tests/sources/functional/script_provider.move:9:5: register (entry)
-   =     at tests/sources/functional/script_provider.move:10:9: register (ABORTED)
+   =     at tests/sources/functional/script_provider.move:14:5: register (entry)
+   =     at tests/sources/functional/script_provider.move:15:9: register (ABORTED)
 
-    ┌── tests/sources/functional/script_provider.move:10:9 ───
+    ┌── tests/sources/functional/script_provider.move:15:9 ───
     │
- 10 │         Transaction::assert(Transaction::sender() == 0x1, 1);
+ 15 │         Transaction::assert(Transaction::sender() == 0x1, 1);
     │         ---------------------------------------------------- abort happened here
     │

--- a/language/move-prover/tests/sources/functional/script_provider.move
+++ b/language/move-prover/tests/sources/functional/script_provider.move
@@ -4,6 +4,11 @@ address 0x0 {
 module ScriptProvider {
     use 0x0::Transaction;
 
+    spec module {
+        pragma verify = true;
+    }
+
+
     resource struct Info<T> {}
 
     public fun register<T>() {

--- a/language/move-prover/tests/sources/functional/serialize_model.exp
+++ b/language/move-prover/tests/sources/functional/serialize_model.exp
@@ -1,19 +1,19 @@
 Move prover returns: exiting with boogie verification errors
 error:  A postcondition might not hold on this return path.
 
-    ┌── tests/sources/functional/serialize_model.move:29:9 ───
+    ┌── tests/sources/functional/serialize_model.move:34:9 ───
     │
- 29 │         ensures result_1 == result_2;
+ 34 │         ensures result_1 == result_2;
     │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
     │
-    =     at tests/sources/functional/serialize_model.move:21:5: lcs_test1_incorrect (entry)
-    =     at tests/sources/functional/serialize_model.move:23:23: lcs_test1_incorrect
+    =     at tests/sources/functional/serialize_model.move:26:5: lcs_test1_incorrect (entry)
+    =     at tests/sources/functional/serialize_model.move:28:23: lcs_test1_incorrect
     =         v1 = <redacted>,
     =         v2 = <redacted>,
     =         s1 = <redacted>
-    =     at tests/sources/functional/serialize_model.move:24:32: lcs_test1_incorrect
+    =     at tests/sources/functional/serialize_model.move:29:32: lcs_test1_incorrect
     =         s2 = <redacted>
-    =     at tests/sources/functional/serialize_model.move:25:10: lcs_test1_incorrect
+    =     at tests/sources/functional/serialize_model.move:30:10: lcs_test1_incorrect
     =         result_1 = <redacted>,
     =         result_2 = <redacted>
-    =     at tests/sources/functional/serialize_model.move:21:5: lcs_test1_incorrect (exit)
+    =     at tests/sources/functional/serialize_model.move:26:5: lcs_test1_incorrect (exit)

--- a/language/move-prover/tests/sources/functional/serialize_model.move
+++ b/language/move-prover/tests/sources/functional/serialize_model.move
@@ -2,6 +2,11 @@ module TestLCS {
 
     use 0x0::LCS;
 
+    spec module {
+        pragma verify = true;
+    }
+
+
     fun lcs_test1<Thing>(v1: &Thing, v2: &Thing): (vector<u8>, vector<u8>)
     {
         let s1 = LCS::to_bytes(v1);

--- a/language/move-prover/tests/sources/functional/simple_vector_client.move
+++ b/language/move-prover/tests/sources/functional/simple_vector_client.move
@@ -4,6 +4,11 @@
 module TestVector {
     use 0x0::Vector;
 
+    spec module {
+        pragma verify = true;
+    }
+
+
 
     // -----------------------------
     // Testing with concrete vectors

--- a/language/move-prover/tests/sources/functional/specs-in-fun.exp
+++ b/language/move-prover/tests/sources/functional/specs-in-fun.exp
@@ -1,48 +1,48 @@
 Move prover returns: exiting with boogie verification errors
 error:  This assertion might not hold.
 
-    ┌── tests/sources/functional/specs-in-fun.move:40:13 ───
+    ┌── tests/sources/functional/specs-in-fun.move:45:13 ───
     │
- 40 │             assert x == y;
+ 45 │             assert x == y;
     │             ^^^^^^^^^^^^^^
     │
-    =     at tests/sources/functional/specs-in-fun.move:37:5: simple1_incorrect (entry)
-    =     at tests/sources/functional/specs-in-fun.move:38:9: simple1_incorrect
+    =     at tests/sources/functional/specs-in-fun.move:42:5: simple1_incorrect (entry)
+    =     at tests/sources/functional/specs-in-fun.move:43:9: simple1_incorrect
     =         x = <redacted>,
     =         y = <redacted>
 
 error:  This assertion might not hold.
 
-    ┌── tests/sources/functional/specs-in-fun.move:48:13 ───
+    ┌── tests/sources/functional/specs-in-fun.move:53:13 ───
     │
- 48 │             assert x == y;
+ 53 │             assert x == y;
     │             ^^^^^^^^^^^^^^
     │
-    =     at tests/sources/functional/specs-in-fun.move:44:5: simple2_incorrect (entry)
-    =     at tests/sources/functional/specs-in-fun.move:46:15: simple2_incorrect
+    =     at tests/sources/functional/specs-in-fun.move:49:5: simple2_incorrect (entry)
+    =     at tests/sources/functional/specs-in-fun.move:51:15: simple2_incorrect
     =         x = <redacted>,
     =         y = <redacted>
-    =     at tests/sources/functional/specs-in-fun.move:48:13: simple2_incorrect
+    =     at tests/sources/functional/specs-in-fun.move:53:13: simple2_incorrect
 
 error:  This assertion might not hold.
 
-    ┌── tests/sources/functional/specs-in-fun.move:55:13 ───
+    ┌── tests/sources/functional/specs-in-fun.move:60:13 ───
     │
- 55 │             assert x > y;
+ 60 │             assert x > y;
     │             ^^^^^^^^^^^^^
     │
-    =     at tests/sources/functional/specs-in-fun.move:52:5: simple3_incorrect (entry)
+    =     at tests/sources/functional/specs-in-fun.move:57:5: simple3_incorrect (entry)
 
 error:  This assertion might not hold.
 
-    ┌── tests/sources/functional/specs-in-fun.move:64:13 ───
+    ┌── tests/sources/functional/specs-in-fun.move:69:13 ───
     │
- 64 │             assert z > 2*x;
+ 69 │             assert z > 2*x;
     │             ^^^^^^^^^^^^^^^
     │
-    =     at tests/sources/functional/specs-in-fun.move:59:5: simple4_incorrect (entry)
-    =     at tests/sources/functional/specs-in-fun.move:61:15: simple4_incorrect
+    =     at tests/sources/functional/specs-in-fun.move:64:5: simple4_incorrect (entry)
+    =     at tests/sources/functional/specs-in-fun.move:66:15: simple4_incorrect
     =         x = <redacted>,
     =         y = <redacted>,
     =         z = <redacted>
-    =     at tests/sources/functional/specs-in-fun.move:63:13: simple4_incorrect
+    =     at tests/sources/functional/specs-in-fun.move:68:13: simple4_incorrect

--- a/language/move-prover/tests/sources/functional/specs-in-fun.move
+++ b/language/move-prover/tests/sources/functional/specs-in-fun.move
@@ -1,6 +1,11 @@
 module TestAssertAndAssume {
     // Tests that should verify
 
+    spec module {
+        pragma verify = true;
+    }
+
+
     fun simple1(x: u64, y: u64) {
         if (!(x > y)) abort 1;
         spec {

--- a/language/move-prover/tests/sources/functional/txn.move
+++ b/language/move-prover/tests/sources/functional/txn.move
@@ -3,6 +3,11 @@ address 0x0 {
 module TestTransaction {
     use 0x0::Transaction;
 
+    spec module {
+        pragma verify = true;
+    }
+
+
     resource struct T {
         value: u128,
     }

--- a/language/move-prover/tests/sources/functional/verify_vector.move
+++ b/language/move-prover/tests/sources/functional/verify_vector.move
@@ -8,6 +8,11 @@
 module VerifyVector {
     use 0x0::Vector;
 
+    spec module {
+        pragma verify = true;
+    }
+
+
     fun verify_model_empty<Element>() : vector<Element> {
         Vector::empty<Element>() // inlining the built-in Boogie procedure
     }

--- a/language/move-prover/tests/sources/stdlib/modules/lbr.move
+++ b/language/move-prover/tests/sources/stdlib/modules/lbr.move
@@ -31,11 +31,7 @@ module LBR {
         // Does aborts_if P effectively imply requires !P?
         requires !Libra::token_is_registered<T>();
 
-        // FIXME:
-        // Another bug:
-        // Boogie reports:
-        // bug: output.bpl(3882,158): Error: undeclared identifier: $tv0
-        // include Libra::RegisterAbortsIf<T>;
+        include Libra::RegisterAbortsIf<T>;
     }
 }
 }

--- a/language/move-prover/tests/sources/stdlib/modules/libra.move
+++ b/language/move-prover/tests/sources/stdlib/modules/libra.move
@@ -4,6 +4,11 @@ module Libra {
     use 0x0::Transaction;
     use 0x0::Vector;
 
+    spec module {
+        // verify also private functions.
+        pragma verify = true;
+    }
+
     // A resource representing a fungible token
     resource struct T<Token> {
         // The value of the token. May be zero
@@ -44,7 +49,7 @@ module Libra {
          invariant module token_is_registered<Token>() ==> mint_capability_count<Token> == 1;
     }
     spec module {
-        apply MintCapabilityCountInvariant<Token> to public *<Token>;
+       apply MintCapabilityCountInvariant<Token> to public *<Token>;
     }
 
     resource struct Info<Token> {

--- a/language/move-prover/tests/testsuite.rs
+++ b/language/move-prover/tests/testsuite.rs
@@ -11,24 +11,22 @@ use libra_temppath::TempPath;
 use move_prover::{cli::Options, run_move_prover};
 use test_utils::{baseline_test::verify_or_update_baseline, extract_test_directives, read_env_var};
 
-const STDLIB_FLAGS: &[&str] = &["--search_path=../stdlib/modules"];
-const STDLIB_FLAGS_UNVERIFIED: &[&str] = &["--search_path=../stdlib/modules", "--verify=none"];
-const LEGACY_STDLIB_FLAGS: &[&str] = &["--search_path=tests/sources/stdlib/modules"];
+const STDLIB_FLAGS: &[&str] = &["--search-path=../stdlib/modules"];
+const STDLIB_FLAGS_UNVERIFIED: &[&str] = &["--search-path=../stdlib/modules", "--verify=none"];
+const LEGACY_STDLIB_FLAGS: &[&str] = &["--search-path=tests/sources/stdlib/modules"];
 
 fn test_runner(path: &Path) -> datatest_stable::Result<()> {
     let no_boogie = read_env_var("BOOGIE_EXE").is_empty() || read_env_var("Z3_EXE").is_empty();
     let baseline_valid =
         !no_boogie || !extract_test_directives(path, "// no-boogie-test")?.is_empty();
-    let (mut flags, baseline_path) = get_flags(path)?;
-    if flags.iter().find(|a| a.contains("--verify")).is_none() {
-        flags.push("--verify=all".to_string());
-    }
+    let (flags, baseline_path) = get_flags(path)?;
     let mut args = vec!["mvp_test".to_string()];
     args.extend(flags);
+    args.push("--verbose=warn".to_owned());
     args.push(path.to_string_lossy().to_string());
 
     let mut options = Options::default();
-    options.initialize_from_args(&args);
+    options.initialize_from_args(&args)?;
     options.setup_logging_for_test();
     if no_boogie {
         options.generate_only = true;


### PR DESCRIPTION
- Using now handlebars Rust templates for the prelude. This allows to generate a prelude from the same source via template expansion. The template parameters supported are:
  - `--use-array-theory=true|false`: if set, native equality will be generated from the prelude template. Default: false.
  - `--use-native-equality=true|false`: if set, native equality will be generated. This is automatically set to true on `--use-array-theory=true`.
  - `--stratification-depth=N`: determines the depth of stratification. A custom template helper is used in the prelude to generate stratified functions based on this option. Defaults to 4.
  - `--aggressive_func_inline=true|false`: if set some functions are inlined even if they are large. Defaults to false.
  - `--type-requires=true|false`: if true, prelude procedures require type correctness of their parameters, otherwise not (the generated Boogie uses `free requires`).
- A new option `--bench-repeat=N` has been introduced. This executes Boogie N times on the verification problem, for benchmarking. Defaults to 1.
- The driver prints out timing information about both translation and solving. This is only seen if `--verbose=info` is set. If `--bench-repeat` is set, the average of all runs will be printed.

Currently, array theory does not terminate on libra_account.move, and seems generally twice as slow. Therefore its turned off by default. This PR should make it simpler to play with it and try to find the culprit.

This PR also fixes something that I thought was already fixed before: that the tests in sources/{functional,stdlib} are run using the default flags, and cargo test thus behaves the same as cargo run for the test sources. The default for verification is to only verify public functions. To behave tests as expected under this default, either functions had to be made public, or the pragma `verify = true` had to be added to the source.


## Motivation

Improve options to fine tune prover.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

Existing tests pass.

## Related PRs

NA
