### PR TITLE
[move-prover] Performance tuning

### DIFF
--- a/language/move-prover/spec-lang/src/env.rs
+++ b/language/move-prover/spec-lang/src/env.rs
@@ -1128,6 +1128,11 @@ impl<'env> StructEnv<'env> {
             })
     }
 
+    /// Return the number of fields in the struct.
+    pub fn get_field_count(&self) -> usize {
+        self.data.field_data.len()
+    }
+
     /// Gets a field by its id.
     pub fn get_field(&'env self, id: FieldId) -> FieldEnv<'env> {
         let data = self.data.field_data.get(&id).expect("FieldId undefined");

--- a/language/move-prover/src/boogie_helpers.rs
+++ b/language/move-prover/src/boogie_helpers.rs
@@ -186,19 +186,15 @@ fn boogie_well_formed_expr_impl(
         Type::Vector(elem_ty) => {
             conds.push(format!("$Vector_is_well_formed({})", name));
             if !matches!(**elem_ty, Type::TypeParameter(..)) {
+                let nest_value = &format!("$vmap({})[$${}]", name, nest);
                 conds.push(format!(
-                    "(forall $${}: int :: $${} >= 0 && $${} < $vlen({}) ==> {})",
+                    "(forall $${}: int :: {{{}}} $${} >= 0 && $${} < $vlen({}) ==> {})",
                     nest,
+                    nest_value,
                     nest,
                     nest,
                     name,
-                    boogie_well_formed_expr_impl(
-                        env,
-                        &format!("$vmap({})[$${}]", name, nest),
-                        &elem_ty,
-                        mode,
-                        nest + 1
-                    )
+                    boogie_well_formed_expr_impl(env, nest_value, &elem_ty, mode, nest + 1)
                 ));
             }
         }

--- a/language/move-prover/src/cli.rs
+++ b/language/move-prover/src/cli.rs
@@ -449,9 +449,15 @@ impl Options {
         }
         if self.use_array_theory {
             add(&["-useArrayTheory"]);
-        } else {
-            add(&["-proverOpt:O:smt.QI.EAGER_THRESHOLD=100"]);
         }
+        add(&["-proverOpt:O:smt.QI.EAGER_THRESHOLD=100"]);
+        add(&["-proverOpt:O:smt.QI.LAZY_THRESHOLD=100"]);
+        // TODO: see what we can make out of these flags.
+        //add(&["-proverOpt:O:smt.QI.PROFILE=true"]);
+        //add(&["-proverOpt:O:trace=true"]);
+        //add(&["-proverOpt:VERBOSITY=3"]);
+        //add(&["-proverOpt:C:-st"]);
+        //add(&["-proverLog:@PROC@.log"]);
         for f in &self.boogie_flags {
             add(&[f.as_str()]);
         }

--- a/language/move-prover/src/prelude.bpl
+++ b/language/move-prover/src/prelude.bpl
@@ -84,6 +84,7 @@ function {:constructor} AddressType() : TypeValue;
 function {:constructor} StrType() : TypeValue;
 function {:constructor} VectorType(t: TypeValue) : TypeValue;
 function {:constructor} StructType(name: TypeName, ps: TypeValueArray, ts: TypeValueArray) : TypeValue;
+function {:constructor} AbstractType(num: int): TypeValue;
 function {:constructor} ErrorType() : TypeValue;
 const DefaultTypeValue: TypeValue;
 axiom DefaultTypeValue == ErrorType();
@@ -94,11 +95,6 @@ function {:constructor} TypeValueArray(v: [int]TypeValue, l: int): TypeValueArra
 const EmptyTypeValueArray: TypeValueArray;
 axiom l#TypeValueArray(EmptyTypeValueArray) == 0;
 axiom v#TypeValueArray(EmptyTypeValueArray) == MapConstTypeValue(DefaultTypeValue);
-
-function {:inline} ExtendTypeValueArray(ta: TypeValueArray, tv: TypeValue): TypeValueArray {
-    (var len := l#TypeValueArray(ta);
-     TypeValueArray(v#TypeValueArray(ta)[len := tv], len + 1))
-}
 
 
 // Values
@@ -129,7 +125,7 @@ function {:inline} $IsValidU8(v: Value): bool {
 
 function {:inline} $IsValidU8Vector(vec: Value): bool {
   $Vector_is_well_formed(vec)
-  && (forall i: int :: 0 <= i && i < $vlen(vec) ==> $IsValidU8($vmap(vec)[i]))
+  && (forall i: int :: {$vmap(vec)[i]} 0 <= i && i < $vlen(vec) ==> $IsValidU8($vmap(vec)[i]))
 }
 
 function {:inline} $IsValidU64(v: Value): bool {
@@ -786,7 +782,7 @@ function {:inline} $Vector_is_well_formed(v: Value): bool {
         (
             var l := l#ValueArray(va);
             0 <= l &&
-            (forall x: int :: x < 0 || x >= l ==> v#ValueArray(va)[x] == DefaultValue)
+            (forall x: int :: {v#ValueArray(va)[x]} x < 0 || x >= l ==> v#ValueArray(va)[x] == DefaultValue)
         )
     )
 }

--- a/language/move-prover/src/spec_translator.rs
+++ b/language/move-prover/src/spec_translator.rs
@@ -383,6 +383,11 @@ impl<'env> SpecTranslator<'env> {
     pub fn assume_preconditions(&self) {
         emitln!(self.writer, "assume $ExistsTxnSenderAccount($m, $txn);");
         let func_target = self.function_target();
+        // Assume abstract types for type parameters.
+        for (i, _) in func_target.get_type_parameters().iter().enumerate() {
+            emitln!(self.writer, "assume is#AbstractType($tv{});", i);
+        }
+        // Assume requires.
         let requires = func_target
             .get_spec()
             .filter(|c| match c.kind {

--- a/language/move-prover/tests/sources/stdlib/modules/libra_account.move
+++ b/language/move-prover/tests/sources/stdlib/modules/libra_account.move
@@ -523,7 +523,7 @@ fun simplified_pay_from_capability(
     };
 }
 spec fun simplified_pay_from_capability {
-    // TODO: this currently does not terminate if set to true. See above.
+    // TODO: this currently takes 30s to verify. It also produces an error which need to be investigated.
     pragma verify=false;
 
     // capability check


### PR DESCRIPTION
This PR does a number of things to improve performance. The overall result is a meager 10% improvement, as measured with the new `--bench-repeat` flag. Also, the function `simplified_pay_from_capability` now terminates verification, which it did not previously. However, the timing is infeasible (>30s for a small problem), so it stays excluded from tests. Also array theory does still not terminate on the `LibraAccount::create_account` problem.

Here are the improvements:

- Assume the type parameters of a top-level verification problem to be of new TypeValue constractor variant `AbstractType(n)`, where n is some number. This makes native equality on type values both be more correct and more efficient because (a) we have an AbstractType for unknown types (b) all other types are constructed from MapConstTypeValue, so extensional equality should work for them. Notice that native equality on type values is important because we index global memory with types, so I believe this change also fixed correctness bugs which we did not hit yet. This change brought a few % of performance improvement.
- Got rid of ExtendValueArray and ExtendTypeValueArray by generating code which directly initializes arrays.  This added another 5%.
- Annotated some of the (few) quantifiers in the prelude with E-matching patterns. I think this brought another few percent.
- Also setting the Z3 QI.LAZY_THRESHOLD to a value of 100. (Not sure what the difference to Eager is). This did not had an observable effect.

## Motivation

Performance.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

cargo test

## Related PRs

NA
