### PR TITLE
[mempool] gc by block timestamp for successful txn commits

### DIFF
--- a/consensus/src/state_replication.rs
+++ b/consensus/src/state_replication.rs
@@ -22,11 +22,13 @@ pub trait TxnManager: Send + Sync {
     ) -> Result<Self::Payload>;
 
     /// Notifies TxnManager about the payload of the committed block including the state compute
-    /// result, which includes the specifics of what transactions succeeded and failed.
+    /// result, which includes the specifics of what transactions succeeded and failed, and the
+    /// timestamp of the committed block
     async fn commit_txns(
         &mut self,
         txns: &Self::Payload,
         compute_result: &StateComputeResult,
+        block_timestamp_usecs: u64,
     ) -> Result<()>;
 
     /// Bypass the trait object non-clonable limit.

--- a/consensus/src/test_utils/mock_txn_manager.rs
+++ b/consensus/src/test_utils/mock_txn_manager.rs
@@ -73,6 +73,7 @@ impl TxnManager for MockTransactionManager {
         &mut self,
         txns: &Self::Payload,
         compute_results: &StateComputeResult,
+        block_timestamp_usecs: u64,
     ) -> Result<()> {
         if self.mempool_proxy.is_some() {
             let mock_compute_result = StateComputeResult::new(
@@ -87,7 +88,7 @@ impl TxnManager for MockTransactionManager {
                 .mempool_proxy
                 .as_mut()
                 .unwrap()
-                .commit_txns(&vec![], &mock_compute_result)
+                .commit_txns(&vec![], &mock_compute_result, block_timestamp_usecs)
                 .await
                 .is_ok());
         }

--- a/mempool/src/shared_mempool/tasks.rs
+++ b/mempool/src/shared_mempool/tasks.rs
@@ -376,9 +376,9 @@ pub(crate) async fn process_consensus_request(mempool: &Mutex<CoreMempool>, req:
 
             (ConsensusResponse::GetBlockResponse(transactions), callback)
         }
-        ConsensusRequest::RejectNotification(transactions, callback) => {
+        ConsensusRequest::CommitNotification(block_timestamp_usecs, transactions, callback) => {
             // handle rejected txns
-            commit_txns(mempool, transactions, 0, true).await;
+            commit_txns(mempool, transactions, block_timestamp_usecs, true).await;
             (ConsensusResponse::CommitResponse(), callback)
         }
     };

--- a/mempool/src/shared_mempool/types.rs
+++ b/mempool/src/shared_mempool/types.rs
@@ -128,9 +128,11 @@ pub enum ConsensusRequest {
         // callback to send response back to sender
         oneshot::Sender<Result<ConsensusResponse>>,
     ),
-    /// notifications about *rejected* committed txns
-    RejectNotification(
-        // committed transactions
+    /// notifications about commit
+    CommitNotification(
+        // timestamp of committed block
+        u64,
+        // *rejected* committed transactions
         Vec<CommittedTransaction>,
         // callback to send response back to sender
         oneshot::Sender<Result<ConsensusResponse>>,

--- a/mempool/src/tests/shared_mempool_test.rs
+++ b/mempool/src/tests/shared_mempool_test.rs
@@ -627,7 +627,7 @@ fn test_consensus_events_rejected_txns() {
         sequence_number: committed_txn.sequence_number(),
     }];
     let (callback, callback_rcv) = oneshot::channel();
-    let req = ConsensusRequest::RejectNotification(committed_txns, callback);
+    let req = ConsensusRequest::CommitNotification(0, committed_txns, callback);
     let mut consensus_sender = smp.consensus_sender.clone();
     block_on(async {
         assert!(consensus_sender.send(req).await.is_ok());


### PR DESCRIPTION
## Motivation

Mempool wasn't gc'ing by block timestamp. Make sure mempool actually gc's txns by block timestamp (both with successful and failed txns)
