### PR TITLE
[storage] enable "libradb/fuzzing" feature for using `LibraDB::new_for_test()`

### DIFF
--- a/execution/execution-correctness/Cargo.toml
+++ b/execution/execution-correctness/Cargo.toml
@@ -28,7 +28,7 @@ thiserror = "1.0"
 [dev-dependencies]
 config-builder = { path = "../../config/config-builder", version = "0.1.0" }
 executor-utils = { path = "../executor-utils", version = "0.1.0" }
-libradb = { path = "../../storage/libradb", version = "0.1.0"}
+libradb = { path = "../../storage/libradb", version = "0.1.0", features = ["fuzzing"] }
 storage-interface = { path = "../../storage/storage-interface", version = "0.1.0" }
 storage-service = { path = "../../storage/storage-service", version = "0.1.0" }
 tempfile = "3.1.0"

--- a/execution/executor-benchmark/src/lib.rs
+++ b/execution/executor-benchmark/src/lib.rs
@@ -263,7 +263,14 @@ impl TransactionExecutor {
 fn create_storage_service_and_executor(
     config: &NodeConfig,
 ) -> (Arc<dyn DbReader>, Executor<LibraVM>) {
-    let (db, db_rw) = DbReaderWriter::wrap(LibraDB::new_for_test(&config.storage.dir()));
+    let (db, db_rw) = DbReaderWriter::wrap(
+        LibraDB::open(
+            &config.storage.dir(),
+            false, /* readonly */
+            None,  /* pruner */
+        )
+        .expect("DB should open."),
+    );
     bootstrap_db_if_empty::<LibraVM>(&db_rw, get_genesis_txn(config).unwrap()).unwrap();
 
     let _handle = start_simple_storage_service_with_db(config, db.clone());

--- a/execution/executor/Cargo.toml
+++ b/execution/executor/Cargo.toml
@@ -38,7 +38,7 @@ config-builder = { path = "../../config/config-builder", version = "0.1.0" }
 executor-utils = { path = "../executor-utils", version = "0.1.0" }
 libra-config = { path = "../../config", version = "0.1.0" }
 libra-temppath = { path = "../../common/temppath", version = "0.1.0" }
-libradb = { path = "../../storage/libradb", version = "0.1.0" }
+libradb = { path = "../../storage/libradb", version = "0.1.0", features = ["fuzzing"] }
 stdlib = { path = "../../language/stdlib", version = "0.1.0" }
 transaction-builder = { path = "../../language/transaction-builder", version = "0.1.0" }
 vm-genesis = { path = "../../language/tools/vm-genesis", version = "0.1.0" }

--- a/json-rpc/Cargo.toml
+++ b/json-rpc/Cargo.toml
@@ -41,4 +41,4 @@ libra-json-rpc-client = { path = "../client/json-rpc", version = "0.1.0"}
 vm-validator = { path = "../vm-validator", version = "0.1.0" }
 
 [features]
-fuzzing = ["proptest", "libra-mempool/fuzzing", "libra-proptest-helpers", "libra-temppath", "libradb", "libradb/fuzzing", "reqwest"]
+fuzzing = ["proptest", "libra-mempool/fuzzing", "libra-proptest-helpers", "libra-temppath", "libradb/fuzzing", "reqwest"]

--- a/network/onchain-discovery/Cargo.toml
+++ b/network/onchain-discovery/Cargo.toml
@@ -34,7 +34,7 @@ storage-interface = { path = "../../storage/storage-interface", version = "0.1.0
 config-builder = { path = "../../config/config-builder", version = "0.1.0" }
 executor = { path = "../../execution/executor", version = "0.1.0" }
 libra-vm = { path = "../../language/libra-vm", version = "0.1.0" }
-libradb = { path = "../../storage/libradb", version = "0.1.0" }
+libradb = { path = "../../storage/libradb", version = "0.1.0", features = ["fuzzing"] }
 simple-storage-client = { path = "../../storage/simple-storage-client", version = "0.1.0" }
 storage-service = { path = "../../storage/storage-service", version = "0.1.0" }
 vm-genesis = { path = "../../language/tools/vm-genesis", version = "0.1.0" }

--- a/secure/key-manager/Cargo.toml
+++ b/secure/key-manager/Cargo.toml
@@ -35,7 +35,7 @@ tokio = { version = "0.2.13", features = ["full"] }
 config-builder = { path = "../../config/config-builder", version = "0.1.0" }
 executor = { path = "../../execution/executor", version = "0.1.0" }
 executor-types = { path = "../../execution/executor-types", version = "0.1.0" }
-libradb = { path = "../../storage/libradb", version = "0.1.0" }
+libradb = { path = "../../storage/libradb", version = "0.1.0", features = ["fuzzing"] }
 libra-json-rpc = { path = "../../json-rpc", version = "0.1.0", features = ["fuzzing"] }
 libra-vm = { path = "../../language/libra-vm", version = "0.1.0" }
 storage-interface= { path = "../../storage/storage-interface", version = "0.1.0" }

--- a/state-synchronizer/Cargo.toml
+++ b/state-synchronizer/Cargo.toml
@@ -39,7 +39,7 @@ bytes = "0.5.4"
 config-builder = { path = "../config/config-builder", version = "0.1.0" }
 libra-crypto = { path = "../crypto/crypto", version = "0.1.0" }
 libra-network-address = { path = "../network/network-address", version = "0.1.0" }
-libradb = { path = "../storage/libradb", version = "0.1.0" }
+libradb = { path = "../storage/libradb", version = "0.1.0", features = ["fuzzing"] }
 vm-genesis = { path = "../language/tools/vm-genesis", version = "0.1.0" }
 transaction-builder = { path = "../language/transaction-builder", version = "0.1.0" }
 channel = { path = "../common/channel", version = "0.1.0" }

--- a/vm-validator/Cargo.toml
+++ b/vm-validator/Cargo.toml
@@ -29,7 +29,7 @@ executor = { path = "../execution/executor", version = "0.1.0" }
 storage-service = { path = "../storage/storage-service", version = "0.1.0" }
 libra-vm = { path = "../language/libra-vm", version = "0.1.0" }
 transaction-builder = { path = "../language/transaction-builder", version = "0.1.0" }
-libradb = { path = "../storage/libradb", version = "0.1.0" }
+libradb = { path = "../storage/libradb", version = "0.1.0", features = ["fuzzing"] }
 
 [features]
 default = []


### PR DESCRIPTION

## Motivation

`LibraDB::new_for_test()` is guarded by cfg(any(test, feature="fuzzing)), we need to enable the fuzzing feature when used in tests of packages other than libradb itself.

It works before this fix for `cargo xtest` because it has --all-features enabled, but not for individual packages like `cargo xtest -p executor`.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?
yes

## Test Plan
existing coverage

## Related PRs

(If this PR adds or changes functionality, please take some time to update the docs at https://github.com/libra/website, and link to your PR here.)
