### PR TITLE
[crypto] Load the batch verification feature, but only in little endian …

### DIFF
--- a/crypto/crypto/Cargo.toml
+++ b/crypto/crypto/Cargo.toml
@@ -14,7 +14,6 @@ anyhow = "1.0"
 bytes = "0.5.4"
 curve25519-dalek = { git = "https://github.com/calibra/curve25519-dalek.git", branch = "fiat2", default-features = false }
 digest = "0.8.1"
-ed25519-dalek = { git = "https://github.com/calibra/ed25519-dalek.git", branch = "fiat2", features = ["serde"], default-features = false }
 hex = "0.4.2"
 hmac = "0.7.1"
 once_cell = "1.3.1"
@@ -36,6 +35,17 @@ libra-crypto-derive = { path = "../crypto-derive", version = "0.1.0" }
 lcs = { path = "../../common/lcs", version = "0.1.0", package = "libra-canonical-serialization" }
 libra-nibble = { path = "../../common/nibble", version = "0.1.0" }
 libra-workspace-hack = { path = "../../common/workspace-hack", version = "0.1.0" }
+
+# This duplicated custom loading of ed25519 is due to ed25519 with "batch"
+# feature depending on merlin, which in turn blocks compilation under BE
+# architectures (https://github.com/dalek-cryptography/merlin/issues/58). This
+# should be removed when it's fixed.
+[target.'cfg(target_endian = "big")'.dependencies]
+ed25519-dalek = { git = "https://github.com/calibra/ed25519-dalek.git", branch = "fiat2", features = ["serde"], default-features = false }
+
+[target.'cfg(target_endian = "little")'.dependencies]
+ed25519-dalek = { git = "https://github.com/calibra/ed25519-dalek.git", branch = "fiat2", features = ["serde", "batch"], default-features = false }
+
 
 [dev-dependencies]
 bitvec = "0.17.3"

--- a/crypto/crypto/src/ed25519.rs
+++ b/crypto/crypto/src/ed25519.rs
@@ -359,7 +359,7 @@ impl Signature for Ed25519Signature {
         self.0.to_bytes().to_vec()
     }
 
-    #[cfg(feature = "batch")]
+    #[cfg(target_endian = "little")]
     /// Batch signature verification as described in the original EdDSA article
     /// by Bernstein et al. "High-speed high-security signatures". Current implementation works for
     /// signatures on the same message and it checks for malleability.


### PR DESCRIPTION
…contexts

ed25519 becomes a target-specific dependency of crypto/crypto.
Context: this can be seen as a better version of  https://github.com/libra/libra/pull/3668
tested with `cargo --target powerpc-unkown-linux-gnu` 

I would appreciate a quick look from @metajack  on this one for the conditional dependency.
 
