### PR TITLE
[move-prover] Bound size of serialization output to work around termination problem

### DIFF
--- a/language/move-prover/src/cli.rs
+++ b/language/move-prover/src/cli.rs
@@ -304,7 +304,8 @@ impl Options {
                     .require_equals(true)
                     .help(
                         "a bound for the length of the result vector of LCS::to_bytes(). \
-                        Currently, solver runtime increases exponentially with the size of this value."
+                        Currently, solver runtime increases exponentially with the size of this value. \
+                        Use 0 for no bound"
                     ),
             )
             .arg(

--- a/language/move-prover/src/prelude.bpl
+++ b/language/move-prover/src/prelude.bpl
@@ -1086,7 +1086,11 @@ axiom (forall v1, v2: Value ::  IsEqual($LCS_serialize_core(v1), $LCS_serialize_
            ==> IsEqual(v1, v2));
 
 // This says that serialize returns a non-empty vec<u8>
+{{#if (eq serialize_bound 0)}}
+axiom (forall v: Value :: ( var r := $LCS_serialize_core(v); $IsValidU8Vector(r) && $vlen(r) > 0 ));
+{{else}}
 axiom (forall v: Value :: ( var r := $LCS_serialize_core(v); $IsValidU8Vector(r) && $vlen(r) > 0 && $vlen(r) < {{serialize_bound}} ));
+{{/if}}
 
 procedure $LCS_to_bytes(ta: TypeValue, v: Value) returns (res: Value);
 ensures res == $LCS_serialize($m, $txn, ta, v);

--- a/language/move-prover/src/prelude.bpl
+++ b/language/move-prover/src/prelude.bpl
@@ -1082,13 +1082,12 @@ axiom (forall v1,v2: Value :: IsEqual(v1, v2) ==> IsEqual($LCS_serialize_core(v1
 
 
 // This says that serialize is an injection
-axiom (forall v1, v2: Value :: IsEqual($LCS_serialize_core(v1), $LCS_serialize_core(v2))
+axiom (forall v1, v2: Value ::  IsEqual($LCS_serialize_core(v1), $LCS_serialize_core(v2))
            ==> IsEqual(v1, v2));
 
 // This says that serialize returns a non-empty vec<u8>
-axiom (forall v: Value :: ( var r := $LCS_serialize_core(v); $IsValidU8Vector(r) && $vlen(r) > 0 ) );
+axiom (forall v: Value :: ( var r := $LCS_serialize_core(v); $IsValidU8Vector(r) && $vlen(r) > 0 && $vlen(r) < {{serialize_bound}} ));
 
 procedure $LCS_to_bytes(ta: TypeValue, v: Value) returns (res: Value);
-ensures res == $LCS_serialize_core(v);
+ensures res == $LCS_serialize($m, $txn, ta, v);
 ensures $IsValidU8Vector(res);    // result is a legal vector of U8s.
-ensures $vlen(res) > 0;

--- a/language/move-prover/tests/sources/regression/performance_200511.exp
+++ b/language/move-prover/tests/sources/regression/performance_200511.exp
@@ -1,0 +1,55 @@
+Move prover returns: exiting with boogie verification errors
+error:  A postcondition might not hold on this return path.
+
+    ┌── tests/sources/regression/performance_200511.move:85:9 ───
+    │
+ 85 │         ensures eq_append(global<T>(sender()).received_events.guid, LCS::serialize(2), LCS::serialize(fresh_address));
+    │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    │
+    =     at tests/sources/regression/performance_200511.move:59:5: create (entry)
+    =     at tests/sources/regression/performance_200511.move:60:13: create
+    =         fresh_address = <redacted>,
+    =         auth_key_prefix = <redacted>,
+    =         generator = <redacted>
+    =     at tests/sources/regression/performance_200511.move:61:34: create
+    =         authentication_key = <redacted>
+    =     at tests/sources/regression/performance_200511.move:62:24: create
+    =     at tests/sources/regression/performance_200511.move:63:37: create
+    =         $t4 = <redacted>
+    =     at tests/sources/regression/performance_200511.move:50:5: new_event_handle_impl (entry)
+    =     at tests/sources/regression/performance_200511.move:36:5: fresh_guid (entry)
+    =     at tests/sources/regression/performance_200511.move:37:33: fresh_guid
+    =         counter = <redacted>,
+    =         sender = <redacted>,
+    =         sender_bytes = <redacted>
+    =     at tests/sources/regression/performance_200511.move:38:42: fresh_guid
+    =         count_bytes = <redacted>
+    =     at tests/sources/regression/performance_200511.move:39:27: fresh_guid
+    =         counter = <redacted>
+    =     at tests/sources/regression/performance_200511.move:41:24: fresh_guid
+    =         counter = <redacted>
+    =     at tests/sources/regression/performance_200511.move:43:9: fresh_guid
+    =         result = <redacted>
+    =     at tests/sources/regression/performance_200511.move:36:5: fresh_guid (exit)
+    =     at tests/sources/regression/performance_200511.move:51:43: new_event_handle_impl
+    =         counter = <redacted>,
+    =         counter = <redacted>,
+    =         sender = <redacted>,
+    =         result = <redacted>
+    =     at tests/sources/regression/performance_200511.move:50:5: new_event_handle_impl (exit)
+    =     at tests/sources/regression/performance_200511.move:67:30: create
+    =     at tests/sources/regression/performance_200511.move:50:5: new_event_handle_impl (entry)
+    =     at tests/sources/regression/performance_200511.move:36:5: fresh_guid (entry)
+    =     at tests/sources/regression/performance_200511.move:37:33: fresh_guid
+    =     at tests/sources/regression/performance_200511.move:38:42: fresh_guid
+    =     at tests/sources/regression/performance_200511.move:39:27: fresh_guid
+    =     at tests/sources/regression/performance_200511.move:41:24: fresh_guid
+    =     at tests/sources/regression/performance_200511.move:43:9: fresh_guid
+    =     at tests/sources/regression/performance_200511.move:36:5: fresh_guid (exit)
+    =     at tests/sources/regression/performance_200511.move:51:43: new_event_handle_impl
+    =     at tests/sources/regression/performance_200511.move:50:5: new_event_handle_impl (exit)
+    =     at tests/sources/regression/performance_200511.move:68:26: create
+    =     at tests/sources/regression/performance_200511.move:66:9: create
+    =     at tests/sources/regression/performance_200511.move:71:9: create
+    =         result = <redacted>
+    =     at tests/sources/regression/performance_200511.move:59:5: create (exit)

--- a/language/move-prover/tests/sources/regression/performance_200511.move
+++ b/language/move-prover/tests/sources/regression/performance_200511.move
@@ -72,7 +72,7 @@ module Test {
     }
     spec fun create {
         // To reproduce, put this to true.
-        pragma verify=false;
+        pragma verify=true;
 
         // The next two aborts_if and ensures are correct. However, if they are removed, verification terminates
         // with the expected result.
@@ -80,7 +80,8 @@ module Test {
         aborts_if exists<T>(sender());
         ensures eq_append(result, auth_key_prefix, LCS::serialize(fresh_address));
 
-        // These two ensures are wrong and should produce an error. Instead, the solver hangs.
+        // These two ensures are wrong and should produce an error. Instead, the solver hangs without binding
+        // serialization result size. To reproduce, set --serialize-bound=N with N a high value.
         ensures eq_append(global<T>(sender()).received_events.guid, LCS::serialize(2), LCS::serialize(fresh_address));
         ensures eq_append(global<T>(sender()).sent_events.guid, LCS::serialize(3), LCS::serialize(fresh_address));
 

--- a/language/move-prover/tests/sources/regression/performance_200511.move
+++ b/language/move-prover/tests/sources/regression/performance_200511.move
@@ -80,8 +80,8 @@ module Test {
         aborts_if exists<T>(sender());
         ensures eq_append(result, auth_key_prefix, LCS::serialize(fresh_address));
 
-        // These two ensures are wrong and should produce an error. Instead, the solver hangs without binding
-        // serialization result size. To reproduce, set --serialize-bound=N with N a high value.
+        // These two ensures are wrong and should produce an error. Instead, the solver hangs without bounding
+        // serialization result size. To reproduce, set --serialize-bound=0 to remove any bound.
         ensures eq_append(global<T>(sender()).received_events.guid, LCS::serialize(2), LCS::serialize(fresh_address));
         ensures eq_append(global<T>(sender()).sent_events.guid, LCS::serialize(3), LCS::serialize(fresh_address));
 

--- a/language/move-prover/tests/testsuite.rs
+++ b/language/move-prover/tests/testsuite.rs
@@ -11,6 +11,9 @@ use libra_temppath::TempPath;
 use move_prover::{cli::Options, run_move_prover};
 use test_utils::{baseline_test::verify_or_update_baseline, extract_test_directives, read_env_var};
 
+#[allow(unused_imports)]
+use log::warn;
+
 const STDLIB_FLAGS: &[&str] = &["--search-path=../stdlib/modules"];
 const STDLIB_FLAGS_UNVERIFIED: &[&str] = &["--search-path=../stdlib/modules", "--verify=none"];
 const LEGACY_STDLIB_FLAGS: &[&str] = &["--search-path=tests/sources/stdlib/modules"];


### PR DESCRIPTION
This introduces a new flag `--serialize-bound=N` which bounds the length of the vector created by LCS::to_bytes. It turns out that this lets the non-termination in `regression/performance_200511` go away.

The value defaults to 4 right now. Experiments on the above example show:

- bound=4 ==> takes a few seconds
- bound=8 ==> takes about 40 seconds
- bound=16 ==> takes hundreds of seconds
- no bound ==> does not terminate

The above behavior is independent of whether we keep the axioms for serialization or not.

Why this seems to fix the problem is unclear. Notice that termination is really about finding an error; if termination happens, a valid counter example is printed out, even though Z3 marks the problem as inconclusive (`(:reason-unknown "(incomplete quantifiers)")`). So this might not be the last word for this problem, but it isolates it further and unblocks us.

Restricting the size to 4 should be (mostly) sound because in theory, a perfect serializer could manage to do something like this, as long as properties like injectivity et. al are satisfied.

As part of this PR we also introduce a new flag `--generate-smt=true|false` which let the prover generate an smtlib file per verification problem. This aids debugging on Z3 level.

## Motivation

Performance.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

Regression test now passes.

## Related PRs

NA