### PR TITLE
[LCS hashing] Improve LCS-based implementations of CryptoHash

### DIFF
--- a/common/lcs/src/de.rs
+++ b/common/lcs/src/de.rs
@@ -525,8 +525,8 @@ impl<'de, 'a> de::EnumAccess<'de> for &'a mut Deserializer<'de> {
         V: DeserializeSeed<'de>,
     {
         let variant_index = self.parse_u32_from_uleb128()?;
-        let value = seed.deserialize(variant_index.into_deserializer())?;
-        Ok((value, self))
+        let result: Result<V::Value> = seed.deserialize(variant_index.into_deserializer());
+        Ok((result?, self))
     }
 }
 

--- a/common/lcs/src/error.rs
+++ b/common/lcs/src/error.rs
@@ -11,6 +11,8 @@ pub type Result<T, E = Error> = std::result::Result<T, E>;
 pub enum Error {
     #[error("unexpected end of input")]
     Eof,
+    #[error("I/O error: {0}")]
+    Io(String),
     #[error("exceeded max sequence length")]
     ExceededMaxLen(usize),
     #[error("expected boolean")]
@@ -37,6 +39,12 @@ pub enum Error {
     NonCanonicalUleb128Encoding,
     #[error("ULEB128-encoded integer did not fit in the target size")]
     IntegerOverflowDuringUleb128Decoding,
+}
+
+impl From<std::io::Error> for Error {
+    fn from(err: std::io::Error) -> Self {
+        Error::Io(err.to_string())
+    }
 }
 
 impl ser::Error for Error {

--- a/common/lcs/src/lib.rs
+++ b/common/lcs/src/lib.rs
@@ -284,4 +284,4 @@ pub const MAX_SEQUENCE_LENGTH: usize = 1 << 31;
 
 pub use de::{from_bytes, from_bytes_seed};
 pub use error::{Error, Result};
-pub use ser::{is_human_readable, to_bytes};
+pub use ser::{is_human_readable, serialize_into, serialized_size, to_bytes};

--- a/common/lcs/tests/serde.rs
+++ b/common/lcs/tests/serde.rs
@@ -4,7 +4,9 @@
 // For some reason deriving `Arbitrary` results in clippy firing a `unit_arg` violation
 #![allow(clippy::unit_arg)]
 
-use libra_canonical_serialization::{from_bytes, to_bytes, Error, MAX_SEQUENCE_LENGTH};
+use libra_canonical_serialization::{
+    from_bytes, serialized_size, to_bytes, Error, MAX_SEQUENCE_LENGTH,
+};
 use proptest::prelude::*;
 use proptest_derive::Arbitrary;
 use serde::{de::DeserializeOwned, Deserialize, Serialize};
@@ -20,6 +22,7 @@ where
     let bytes = to_bytes(&t).unwrap();
     let s: T = from_bytes(&bytes).unwrap();
     assert_eq!(t, s);
+    assert_eq!(bytes.len(), serialized_size(&t).unwrap());
 }
 
 // TODO deriving `Arbitrary` is currently broken for enum types

--- a/consensus/consensus-types/src/block_data.rs
+++ b/consensus/consensus-types/src/block_data.rs
@@ -206,7 +206,7 @@ where
     fn hash(&self) -> HashValue {
         let bytes = lcs::to_bytes(self).expect("BlockData serialization failed");
         let mut state = Self::Hasher::default();
-        state.write(bytes.as_ref());
+        state.update(bytes.as_ref());
         state.finish()
     }
 }

--- a/consensus/consensus-types/src/block_data.rs
+++ b/consensus/consensus-types/src/block_data.rs
@@ -204,9 +204,8 @@ where
     type Hasher = BlockDataHasher;
 
     fn hash(&self) -> HashValue {
-        let bytes = lcs::to_bytes(self).expect("BlockData serialization failed");
         let mut state = Self::Hasher::default();
-        state.update(bytes.as_ref());
+        lcs::serialize_into(&mut state, self).expect("BlockData serialization failed");
         state.finish()
     }
 }

--- a/consensus/consensus-types/src/timeout.rs
+++ b/consensus/consensus-types/src/timeout.rs
@@ -52,7 +52,7 @@ impl CryptoHash for Timeout {
     fn hash(&self) -> HashValue {
         let bytes = lcs::to_bytes(self).expect("Timeout serialization failed");
         let mut state = Self::Hasher::default();
-        state.write(bytes.as_ref());
+        state.update(bytes.as_ref());
         state.finish()
     }
 }

--- a/consensus/consensus-types/src/timeout.rs
+++ b/consensus/consensus-types/src/timeout.rs
@@ -6,14 +6,14 @@ use libra_crypto::{
     ed25519::Ed25519Signature,
     hash::{CryptoHash, CryptoHasher, HashValue},
 };
-use libra_crypto_derive::CryptoHasher;
+use libra_crypto_derive::{CryptoHasher, LCSCryptoHash};
 use libra_types::validator_signer::ValidatorSigner;
 use serde::{Deserialize, Serialize};
 use std::fmt::{Display, Formatter};
 
 /// This structure contains all the information necessary to construct a signature
 /// on the equivalent of a timeout message
-#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize, CryptoHasher)]
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize, CryptoHasher, LCSCryptoHash)]
 pub struct Timeout {
     /// Epoch number corresponds to the set of validators that are active for this round.
     epoch: u64,
@@ -43,17 +43,6 @@ impl Timeout {
 
     pub fn sign(&self, signer: &ValidatorSigner) -> Ed25519Signature {
         signer.sign_message(self.hash())
-    }
-}
-
-impl CryptoHash for Timeout {
-    type Hasher = TimeoutHasher;
-
-    fn hash(&self) -> HashValue {
-        let bytes = lcs::to_bytes(self).expect("Timeout serialization failed");
-        let mut state = Self::Hasher::default();
-        state.update(bytes.as_ref());
-        state.finish()
     }
 }
 

--- a/consensus/consensus-types/src/vote_data.rs
+++ b/consensus/consensus-types/src/vote_data.rs
@@ -1,17 +1,14 @@
 // Copyright (c) The Libra Core Contributors
 // SPDX-License-Identifier: Apache-2.0
 
-use libra_crypto::{
-    hash::{CryptoHash, CryptoHasher},
-    HashValue,
-};
-use libra_crypto_derive::CryptoHasher;
+use libra_crypto::{hash::CryptoHasher, HashValue};
+use libra_crypto_derive::{CryptoHasher, LCSCryptoHash};
 use libra_types::block_info::BlockInfo;
 use serde::{Deserialize, Serialize};
 use std::fmt::{Display, Formatter};
 
 /// VoteData keeps the information about the block, and its parent.
-#[derive(Deserialize, Serialize, Clone, Debug, PartialEq, Eq, CryptoHasher)]
+#[derive(Deserialize, Serialize, Clone, Debug, PartialEq, Eq, CryptoHasher, LCSCryptoHash)]
 pub struct VoteData {
     /// Contains all the block information needed for voting for the proposed round.
     proposed: BlockInfo,
@@ -62,15 +59,5 @@ impl VoteData {
             "Proposed version is less than parent version",
         );
         Ok(())
-    }
-}
-
-impl CryptoHash for VoteData {
-    type Hasher = VoteDataHasher;
-
-    fn hash(&self) -> HashValue {
-        let mut state = Self::Hasher::default();
-        state.update(lcs::to_bytes(self).expect("Should serialize.").as_ref());
-        state.finish()
     }
 }

--- a/consensus/consensus-types/src/vote_data.rs
+++ b/consensus/consensus-types/src/vote_data.rs
@@ -70,7 +70,7 @@ impl CryptoHash for VoteData {
 
     fn hash(&self) -> HashValue {
         let mut state = Self::Hasher::default();
-        state.write(lcs::to_bytes(self).expect("Should serialize.").as_ref());
+        state.update(lcs::to_bytes(self).expect("Should serialize.").as_ref());
         state.finish()
     }
 }

--- a/crypto/crypto-derive/src/lib.rs
+++ b/crypto/crypto-derive/src/lib.rs
@@ -366,8 +366,8 @@ pub fn hasher_dispatch(input: TokenStream) -> TokenStream {
                 self.0.finish()
             }
 
-            fn write(&mut self, bytes: &[u8]) -> &mut Self {
-                self.0.write(bytes);
+            fn update(&mut self, bytes: &[u8]) -> &mut Self {
+                self.0.update(bytes);
                 self
             }
         }

--- a/crypto/crypto/benches/hash.rs
+++ b/crypto/crypto/benches/hash.rs
@@ -19,7 +19,7 @@ impl CryptoHash for HashBencher {
     type Hasher = SparseMerkleInternalHasher;
     fn hash(&self) -> HashValue {
         let mut state = Self::Hasher::default();
-        state.write(self.0);
+        state.update(self.0);
         state.finish()
     }
 }

--- a/crypto/crypto/src/ed25519.rs
+++ b/crypto/crypto/src/ed25519.rs
@@ -17,7 +17,7 @@
 //! use rand::{rngs::StdRng, SeedableRng};
 //!
 //! let mut hasher = TestOnlyHasher::default();
-//! hasher.write("Test message".as_bytes());
+//! hasher.update("Test message".as_bytes());
 //! let hashed_message = hasher.finish();
 //!
 //! let mut rng: StdRng = SeedableRng::from_seed([0; 32]);

--- a/crypto/crypto/src/hash.rs
+++ b/crypto/crypto/src/hash.rs
@@ -66,26 +66,18 @@
 //! **Note**: The last argument for the `define_hasher` macro must be a unique string.
 //!
 //! ## The `CryptoHash` implementation (for both automatic and semi-automatic way)
-//! Then, the `CryptoHash` trait should be implemented:
+//! In most cases, the `CryptoHash` trait should be implemented using LCS serialization.
+//! The derive macro `LCSCryptoHash` generates such an implementation based on `serde::Serialize`,
+//! the LCS encoding, and `MyNewStructHasher`:
 //! ```
 //! # use libra_crypto::hash::*;
-//! # #[derive(Default)]
-//! # struct MyNewStructHasher;
-//! # impl CryptoHasher for MyNewStructHasher {
-//! #   fn finish(self) -> HashValue { unimplemented!() }
-//! #   fn update(&mut self, bytes: &[u8]) -> &mut Self { unimplemented!() }
-//! # }
-//! struct MyNewStruct;
+//! # use libra_crypto_derive::*;
+//! # use serde::Serialize;
+//! #[derive(Serialize, CryptoHasher, LCSCryptoHash)]
+//! struct MyNewStruct { /*...*/ }
 //!
-//! impl CryptoHash for MyNewStruct {
-//!     type Hasher = MyNewStructHasher; // use the above defined hasher here
-//!
-//!     fn hash(&self) -> HashValue {
-//!         let mut state = Self::Hasher::default();
-//!         state.update(b"Struct serialized into bytes here");
-//!         state.finish()
-//!     }
-//! }
+//! let value = MyNewStruct { /*...*/ };
+//! value.hash();
 //! ```
 
 use anyhow::{ensure, Result};
@@ -100,7 +92,7 @@ use serde::{de, ser};
 use std::{self, convert::AsRef, fmt};
 use tiny_keccak::{Hasher, Sha3};
 
-const LIBRA_HASH_SUFFIX: &[u8] = b"@@$$LIBRA$$@@";
+pub(crate) const LIBRA_HASH_SUFFIX: &[u8] = b"@@$$LIBRA$$@@";
 const SHORT_STRING_LENGTH: usize = 4;
 
 /// Output value of our hash function. Intentionally opaque for safety and modularity.
@@ -424,7 +416,7 @@ pub trait CryptoHash {
 /// Instances of `CryptoHasher` usually represent state that is changed while hashing data.
 /// Similar to `std::hash::Hasher` but not same. CryptoHasher cannot be reused after finish() has
 /// been called.
-pub trait CryptoHasher: Default {
+pub trait CryptoHasher: Default + std::io::Write {
     /// Finish constructing the [`HashValue`].
     fn finish(self) -> HashValue;
     /// Write bytes into the hasher.
@@ -463,6 +455,16 @@ impl Default for DefaultHasher {
         DefaultHasher {
             state: Sha3::v256(),
         }
+    }
+}
+
+impl std::io::Write for DefaultHasher {
+    fn write(&mut self, bytes: &[u8]) -> std::io::Result<usize> {
+        self.update(bytes);
+        Ok(bytes.len())
+    }
+    fn flush(&mut self) -> std::io::Result<()> {
+        Ok(())
     }
 }
 
@@ -509,6 +511,16 @@ macro_rules! define_hasher {
             fn update(&mut self, bytes: &[u8]) -> &mut Self {
                 self.0.update(bytes);
                 self
+            }
+        }
+
+        impl std::io::Write for $hasher_type {
+            fn write(&mut self, bytes: &[u8]) -> std::io::Result<usize> {
+                self.0.update(bytes);
+                Ok(bytes.len())
+            }
+            fn flush(&mut self) -> std::io::Result<()> {
+                Ok(())
             }
         }
 

--- a/crypto/crypto/src/hash.rs
+++ b/crypto/crypto/src/hash.rs
@@ -28,7 +28,7 @@
 //! use libra_crypto::hash::{CryptoHasher, TestOnlyHasher};
 //!
 //! let mut hasher = TestOnlyHasher::default();
-//! hasher.write("Test message".as_bytes());
+//! hasher.update("Test message".as_bytes());
 //! let hash_value = hasher.finish();
 //! ```
 //! The output is of type [`HashValue`], which can be used as an input for signing.
@@ -73,7 +73,7 @@
 //! # struct MyNewStructHasher;
 //! # impl CryptoHasher for MyNewStructHasher {
 //! #   fn finish(self) -> HashValue { unimplemented!() }
-//! #   fn write(&mut self, bytes: &[u8]) -> &mut Self { unimplemented!() }
+//! #   fn update(&mut self, bytes: &[u8]) -> &mut Self { unimplemented!() }
 //! # }
 //! struct MyNewStruct;
 //!
@@ -82,7 +82,7 @@
 //!
 //!     fn hash(&self) -> HashValue {
 //!         let mut state = Self::Hasher::default();
-//!         state.write(b"Struct serialized into bytes here");
+//!         state.update(b"Struct serialized into bytes here");
 //!         state.finish()
 //!     }
 //! }
@@ -428,11 +428,7 @@ pub trait CryptoHasher: Default {
     /// Finish constructing the [`HashValue`].
     fn finish(self) -> HashValue;
     /// Write bytes into the hasher.
-    fn write(&mut self, bytes: &[u8]) -> &mut Self;
-    /// Write a single byte into the hasher.
-    fn write_u8(&mut self, byte: u8) {
-        self.write(&[byte]);
-    }
+    fn update(&mut self, bytes: &[u8]) -> &mut Self;
 }
 
 /// Our preferred hashing schema, outputting [`HashValue`]s.
@@ -456,7 +452,7 @@ impl CryptoHasher for DefaultHasher {
         hasher
     }
 
-    fn write(&mut self, bytes: &[u8]) -> &mut Self {
+    fn update(&mut self, bytes: &[u8]) -> &mut Self {
         self.state.update(bytes);
         self
     }
@@ -510,8 +506,8 @@ macro_rules! define_hasher {
                 self.0.finish()
             }
 
-            fn write(&mut self, bytes: &[u8]) -> &mut Self {
-                self.0.write(bytes);
+            fn update(&mut self, bytes: &[u8]) -> &mut Self {
+                self.0.update(bytes);
                 self
             }
         }
@@ -605,7 +601,7 @@ impl<T: ser::Serialize + ?Sized> TestOnlyHash for T {
     fn test_only_hash(&self) -> HashValue {
         let bytes = lcs::to_bytes(self).expect("serialize failed during hash.");
         let mut hasher = TestOnlyHasher::default();
-        hasher.write(&bytes);
+        hasher.update(&bytes);
         hasher.finish()
     }
 }

--- a/crypto/crypto/src/unit_tests/cryptohasher.rs
+++ b/crypto/crypto/src/unit_tests/cryptohasher.rs
@@ -1,62 +1,83 @@
 // Copyright (c) The Libra Core Contributors
 // SPDX-License-Identifier: Apache-2.0
 
+//! Test file for the procedural macros CryptoHasher and LCSCryptoHash.
+
 use crate as libra_crypto;
 use crate::{
-    hash::{CryptoHash, CryptoHasher},
+    hash::{CryptoHash, CryptoHasher, LIBRA_HASH_SUFFIX},
     HashValue,
 };
-use libra_crypto_derive::CryptoHasher;
+use libra_crypto_derive::{CryptoHasher, LCSCryptoHash};
+use serde::{Deserialize, Serialize};
 use tiny_keccak::{Hasher, Sha3};
 
-/// This file tests the CryptoHasher derive macro defined in the crypto-derive
-/// crate. This macro, as the comments there indicate, is meant to derive an
-/// instance of CryptoHasher (see `crate::hash`) for any type, which
-/// domain-separation tag is precisely the fully-qualified name of the
-/// struct. Here, we create a struct, manually "compute" its tag and compare it
-/// to the generated one.
+// The expected use case.
+#[derive(Serialize, Deserialize, CryptoHasher, LCSCryptoHash)]
+pub struct Foo {
+    a: u64,
+    b: u32,
+}
 
-#[derive(CryptoHasher)]
-pub struct Foo {}
+// Used for testing the seed in FooHasher.
+pub struct Bar {}
 
-impl CryptoHash for Foo {
+impl CryptoHash for Bar {
     type Hasher = FooHasher;
 
     fn hash(&self) -> HashValue {
-        // we voluntarily keep the contents empty, since we just want to test
-        // the hasher prefix
         let state = Self::Hasher::default();
         state.finish()
     }
 }
-
-// workaround of crate::hash::LIBRA_HASH_SUFFIX being private
-// the const below should always be a copy of it
-const LIBRA_HASH_SUFFIX_FOR_TESTING: &[u8] = b"@@$$LIBRA$$@@";
 
 #[test]
 fn test_cryptohasher_name() {
     let mut name = "libra_crypto::unit_tests::cryptohasher::Foo"
         .as_bytes()
         .to_vec();
-    name.extend_from_slice(LIBRA_HASH_SUFFIX_FOR_TESTING);
+    name.extend_from_slice(LIBRA_HASH_SUFFIX);
 
-    let mut digest = Sha3::v256();
-    digest.update(HashValue::from_sha3_256(&name[..]).as_ref());
-
+    let value = Bar {};
     let expected = {
+        let mut digest = Sha3::v256();
+        digest.update(HashValue::from_sha3_256(&name[..]).as_ref());
         let mut hasher_bytes = [0u8; 32];
         digest.finalize(&mut hasher_bytes);
         hasher_bytes
     };
-    let foo_instance = Foo {};
-    let foo_hash = CryptoHash::hash(&foo_instance);
-    let actual = foo_hash.as_ref();
+    let actual = CryptoHash::hash(&value);
     assert_eq!(
         &expected,
-        actual,
+        actual.as_ref(),
         "\nexpected: {} actual: {}",
         String::from_utf8_lossy(&expected),
-        String::from_utf8_lossy(actual)
+        String::from_utf8_lossy(actual.as_ref())
+    );
+}
+
+#[test]
+fn test_lcs_cryptohash() {
+    let mut name = "libra_crypto::unit_tests::cryptohasher::Foo"
+        .as_bytes()
+        .to_vec();
+    name.extend_from_slice(LIBRA_HASH_SUFFIX);
+
+    let value = Foo { a: 5, b: 1025 };
+    let expected = {
+        let mut digest = Sha3::v256();
+        digest.update(HashValue::from_sha3_256(&name[..]).as_ref());
+        digest.update(&lcs::to_bytes(&value).unwrap());
+        let mut hasher_bytes = [0u8; 32];
+        digest.finalize(&mut hasher_bytes);
+        hasher_bytes
+    };
+    let actual = CryptoHash::hash(&value);
+    assert_eq!(
+        &expected,
+        actual.as_ref(),
+        "\nexpected: {} actual: {}",
+        String::from_utf8_lossy(&expected),
+        String::from_utf8_lossy(actual.as_ref())
     );
 }

--- a/language/move-core/types/src/account_address.rs
+++ b/language/move-core/types/src/account_address.rs
@@ -84,7 +84,7 @@ impl CryptoHash for AccountAddress {
 
     fn hash(&self) -> HashValue {
         let mut state = Self::Hasher::default();
-        state.write(&self.0);
+        state.update(&self.0);
         state.finish()
     }
 }

--- a/language/move-core/types/src/language_storage.rs
+++ b/language/move-core/types/src/language_storage.rs
@@ -113,7 +113,7 @@ impl CryptoHash for ModuleId {
 
     fn hash(&self) -> HashValue {
         let mut state = Self::Hasher::default();
-        state.write(&lcs::to_bytes(self).unwrap());
+        state.update(&lcs::to_bytes(self).unwrap());
         state.finish()
     }
 }
@@ -123,7 +123,7 @@ impl CryptoHash for StructTag {
 
     fn hash(&self) -> HashValue {
         let mut state = Self::Hasher::default();
-        state.write(&lcs::to_bytes(self).unwrap());
+        state.update(&lcs::to_bytes(self).unwrap());
         state.finish()
     }
 }

--- a/language/move-core/types/src/language_storage.rs
+++ b/language/move-core/types/src/language_storage.rs
@@ -6,7 +6,7 @@ use crate::{
     identifier::{IdentStr, Identifier},
 };
 use libra_crypto::hash::{CryptoHash, CryptoHasher, HashValue};
-use libra_crypto_derive::CryptoHasher;
+use libra_crypto_derive::{CryptoHasher, LCSCryptoHash};
 #[cfg(any(test, feature = "fuzzing"))]
 use proptest_derive::Arbitrary;
 use serde::{Deserialize, Serialize};
@@ -30,7 +30,17 @@ pub enum TypeTag {
 }
 
 #[derive(
-    Serialize, Deserialize, Debug, PartialEq, Hash, Eq, Clone, PartialOrd, Ord, CryptoHasher,
+    Serialize,
+    Deserialize,
+    Debug,
+    PartialEq,
+    Hash,
+    Eq,
+    Clone,
+    PartialOrd,
+    Ord,
+    CryptoHasher,
+    LCSCryptoHash,
 )]
 pub struct StructTag {
     pub address: AccountAddress,
@@ -77,7 +87,17 @@ impl ResourceKey {
 /// Represents the initial key into global storage where we first index by the address, and then
 /// the struct tag
 #[derive(
-    Serialize, Deserialize, Debug, PartialEq, Hash, Eq, Clone, PartialOrd, Ord, CryptoHasher,
+    Serialize,
+    Deserialize,
+    Debug,
+    PartialEq,
+    Hash,
+    Eq,
+    Clone,
+    PartialOrd,
+    Ord,
+    CryptoHasher,
+    LCSCryptoHash,
 )]
 #[cfg_attr(any(test, feature = "fuzzing"), derive(Arbitrary))]
 #[cfg_attr(any(test, feature = "fuzzing"), proptest(no_params))]
@@ -105,26 +125,6 @@ impl ModuleId {
 
         key.append(&mut self.hash().to_vec());
         key
-    }
-}
-
-impl CryptoHash for ModuleId {
-    type Hasher = ModuleIdHasher;
-
-    fn hash(&self) -> HashValue {
-        let mut state = Self::Hasher::default();
-        state.update(&lcs::to_bytes(self).unwrap());
-        state.finish()
-    }
-}
-
-impl CryptoHash for StructTag {
-    type Hasher = StructTagHasher;
-
-    fn hash(&self) -> HashValue {
-        let mut state = Self::Hasher::default();
-        state.update(&lcs::to_bytes(self).unwrap());
-        state.finish()
     }
 }
 

--- a/network/src/protocols/discovery/mod.rs
+++ b/network/src/protocols/discovery/mod.rs
@@ -608,6 +608,6 @@ fn handle_discovery_msg(
 
 fn get_hash(msg: &[u8]) -> HashValue {
     let mut hasher = DiscoveryMsgHasher::default();
-    hasher.write(msg);
+    hasher.update(msg);
     hasher.finish()
 }

--- a/storage/jellyfish-merkle/src/jellyfish_merkle_test.rs
+++ b/storage/jellyfish-merkle/src/jellyfish_merkle_test.rs
@@ -2,7 +2,10 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use super::*;
-use libra_crypto::{hash::SPARSE_MERKLE_PLACEHOLDER_HASH, HashValue};
+use libra_crypto::{
+    hash::{CryptoHash, SPARSE_MERKLE_PLACEHOLDER_HASH},
+    HashValue,
+};
 use libra_nibble::Nibble;
 use libra_types::{proof::SparseMerkleInternalNode, transaction::PRE_GENESIS_VERSION};
 use mock_tree_store::MockTreeStore;

--- a/storage/jellyfish-merkle/src/lib.rs
+++ b/storage/jellyfish-merkle/src/lib.rs
@@ -81,7 +81,7 @@ mod test_helper;
 mod tree_cache;
 
 use anyhow::{bail, ensure, format_err, Result};
-use libra_crypto::{hash::CryptoHash, HashValue};
+use libra_crypto::HashValue;
 use libra_types::{
     account_state_blob::AccountStateBlob,
     proof::{SparseMerkleProof, SparseMerkleRangeProof},

--- a/testsuite/generate-format/src/consensus.rs
+++ b/testsuite/generate-format/src/consensus.rs
@@ -18,7 +18,7 @@ pub fn output_file() -> Option<&'static str> {
 /// Record sample values for crypto types used by consensus.
 fn trace_crypto_values(tracer: &mut Tracer, samples: &mut Samples) -> Result<()> {
     let mut hasher = TestOnlyHasher::default();
-    hasher.write(b"Test message");
+    hasher.update(b"Test message");
     let hashed_message = hasher.finish();
 
     let mut rng: StdRng = SeedableRng::from_seed([0; 32]);

--- a/testsuite/generate-format/src/libra.rs
+++ b/testsuite/generate-format/src/libra.rs
@@ -20,7 +20,7 @@ pub fn output_file() -> Option<&'static str> {
 /// Record sample values for crypto types used by transactions.
 fn trace_crypto_values(tracer: &mut Tracer, samples: &mut Samples) -> Result<()> {
     let mut hasher = TestOnlyHasher::default();
-    hasher.write(b"Test message");
+    hasher.update(b"Test message");
     let hashed_message = hasher.finish();
 
     let mut rng: StdRng = SeedableRng::from_seed([0; 32]);

--- a/types/src/account_state_blob.rs
+++ b/types/src/account_state_blob.rs
@@ -122,7 +122,7 @@ impl CryptoHash for AccountStateBlob {
 
     fn hash(&self) -> HashValue {
         let mut hasher = Self::Hasher::default();
-        hasher.write(&self.blob);
+        hasher.update(&self.blob);
         hasher.finish()
     }
 }
@@ -226,7 +226,7 @@ mod tests {
 
     fn hash_blob(blob: &[u8]) -> HashValue {
         let mut hasher = AccountStateBlobHasher::default();
-        hasher.write(blob);
+        hasher.update(blob);
         hasher.finish()
     }
 

--- a/types/src/contract_event.rs
+++ b/types/src/contract_event.rs
@@ -15,15 +15,16 @@ use libra_crypto::{
     hash::{CryptoHash, CryptoHasher},
     HashValue,
 };
-use libra_crypto_derive::CryptoHasher;
+use libra_crypto_derive::{CryptoHasher, LCSCryptoHash};
 use move_core_types::{language_storage::TypeTag, move_resource::MoveResource};
+
 #[cfg(any(test, feature = "fuzzing"))]
 use proptest_derive::Arbitrary;
 use serde::{Deserialize, Serialize};
 use std::{convert::TryFrom, ops::Deref};
 
 /// Support versioning of the data structure.
-#[derive(Hash, Clone, Eq, PartialEq, Serialize, Deserialize, CryptoHasher)]
+#[derive(Hash, Clone, Eq, PartialEq, Serialize, Deserialize, CryptoHasher, LCSCryptoHash)]
 pub enum ContractEvent {
     V0(ContractEventV0),
 }
@@ -197,16 +198,6 @@ impl std::fmt::Display for ContractEvent {
         } else {
             write!(f, "{:?}", self)
         }
-    }
-}
-
-impl CryptoHash for ContractEvent {
-    type Hasher = ContractEventHasher;
-
-    fn hash(&self) -> HashValue {
-        let mut state = Self::Hasher::default();
-        state.update(&lcs::to_bytes(self).expect("Failed to serialize."));
-        state.finish()
     }
 }
 

--- a/types/src/contract_event.rs
+++ b/types/src/contract_event.rs
@@ -205,7 +205,7 @@ impl CryptoHash for ContractEvent {
 
     fn hash(&self) -> HashValue {
         let mut state = Self::Hasher::default();
-        state.write(&lcs::to_bytes(self).expect("Failed to serialize."));
+        state.update(&lcs::to_bytes(self).expect("Failed to serialize."));
         state.finish()
     }
 }

--- a/types/src/ledger_info.rs
+++ b/types/src/ledger_info.rs
@@ -133,7 +133,7 @@ impl CryptoHash for LedgerInfo {
 
     fn hash(&self) -> HashValue {
         let mut state = Self::Hasher::default();
-        state.write(&lcs::to_bytes(self).expect("Serialization should work."));
+        state.update(&lcs::to_bytes(self).expect("Serialization should work."));
         state.finish()
     }
 }

--- a/types/src/ledger_info.rs
+++ b/types/src/ledger_info.rs
@@ -13,7 +13,7 @@ use libra_crypto::{
     ed25519::Ed25519Signature,
     hash::{CryptoHash, CryptoHasher, HashValue},
 };
-use libra_crypto_derive::CryptoHasher;
+use libra_crypto_derive::{CryptoHasher, LCSCryptoHash};
 #[cfg(any(test, feature = "fuzzing"))]
 use proptest_derive::Arbitrary;
 use serde::{Deserialize, Serialize};
@@ -40,7 +40,7 @@ use std::{
 /// LedgerInfo with the `version` being the latest version that will be committed if B gets 2f+1
 /// votes. It sets `consensus_data_hash` to represent B so that if those 2f+1 votes are gathered a
 /// QC is formed on B.
-#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize, CryptoHasher)]
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize, CryptoHasher, LCSCryptoHash)]
 #[cfg_attr(any(test, feature = "fuzzing"), derive(Arbitrary))]
 pub struct LedgerInfo {
     commit_info: BlockInfo,
@@ -125,16 +125,6 @@ impl LedgerInfo {
 
     pub fn set_consensus_data_hash(&mut self, consensus_data_hash: HashValue) {
         self.consensus_data_hash = consensus_data_hash;
-    }
-}
-
-impl CryptoHash for LedgerInfo {
-    type Hasher = LedgerInfoHasher;
-
-    fn hash(&self) -> HashValue {
-        let mut state = Self::Hasher::default();
-        state.update(&lcs::to_bytes(self).expect("Serialization should work."));
-        state.finish()
     }
 }
 

--- a/types/src/proof/mod.rs
+++ b/types/src/proof/mod.rs
@@ -83,8 +83,8 @@ impl<H: CryptoHasher> CryptoHash for MerkleTreeInternalNode<H> {
 
     fn hash(&self) -> HashValue {
         let mut state = Self::Hasher::default();
-        state.write(self.left_child.as_ref());
-        state.write(self.right_child.as_ref());
+        state.update(self.left_child.as_ref());
+        state.update(self.right_child.as_ref());
         state.finish()
     }
 }
@@ -120,8 +120,8 @@ impl CryptoHash for SparseMerkleLeafNode {
 
     fn hash(&self) -> HashValue {
         let mut state = Self::Hasher::default();
-        state.write(self.key.as_ref());
-        state.write(self.value_hash.as_ref());
+        state.update(self.key.as_ref());
+        state.update(self.value_hash.as_ref());
         state.finish()
     }
 }

--- a/types/src/transaction/mod.rs
+++ b/types/src/transaction/mod.rs
@@ -290,7 +290,7 @@ impl CryptoHash for RawTransaction {
 
     fn hash(&self) -> HashValue {
         let mut state = Self::Hasher::default();
-        state.write(
+        state.update(
             lcs::to_bytes(self)
                 .expect("Failed to serialize RawTransaction")
                 .as_slice(),
@@ -723,7 +723,7 @@ impl CryptoHash for TransactionInfo {
 
     fn hash(&self) -> HashValue {
         let mut state = Self::Hasher::default();
-        state.write(&lcs::to_bytes(self).expect("Serialization should work."));
+        state.update(&lcs::to_bytes(self).expect("Serialization should work."));
         state.finish()
     }
 }
@@ -934,7 +934,7 @@ impl CryptoHash for Transaction {
 
     fn hash(&self) -> HashValue {
         let mut state = Self::Hasher::default();
-        state.write(&lcs::to_bytes(self).expect("Failed to serialize Transaction."));
+        state.update(&lcs::to_bytes(self).expect("Failed to serialize Transaction."));
         state.finish()
     }
 }

--- a/types/src/waypoint.rs
+++ b/types/src/waypoint.rs
@@ -9,7 +9,7 @@ use crate::{
 };
 use anyhow::{ensure, format_err, Error, Result};
 use libra_crypto::hash::{CryptoHash, CryptoHasher, HashValue};
-use libra_crypto_derive::CryptoHasher;
+use libra_crypto_derive::{CryptoHasher, LCSCryptoHash};
 use serde::{Deserialize, Serialize};
 use std::{
     fmt::{Display, Formatter},
@@ -123,7 +123,7 @@ impl FromStr for Waypoint {
 /// Keeps the fields of LedgerInfo that are hashed for generating a waypoint.
 /// Note that not all the fields of LedgerInfo are included: some consensus-related fields
 /// might not be the same for all the participants.
-#[derive(Deserialize, Serialize, CryptoHasher)]
+#[derive(Deserialize, Serialize, CryptoHasher, LCSCryptoHash)]
 struct Ledger2WaypointConverter {
     epoch: u64,
     root_hash: HashValue,
@@ -141,17 +141,6 @@ impl Ledger2WaypointConverter {
             timestamp_usecs: ledger_info.timestamp_usecs(),
             next_epoch_info: ledger_info.next_epoch_info().cloned(),
         }
-    }
-}
-
-impl CryptoHash for Ledger2WaypointConverter {
-    type Hasher = Ledger2WaypointConverterHasher;
-
-    fn hash(&self) -> HashValue {
-        let bytes = lcs::to_bytes(self).expect("Ledger2WaypointConverter serialization failed");
-        let mut state = Self::Hasher::default();
-        state.update(bytes.as_ref());
-        state.finish()
     }
 }
 

--- a/types/src/waypoint.rs
+++ b/types/src/waypoint.rs
@@ -150,7 +150,7 @@ impl CryptoHash for Ledger2WaypointConverter {
     fn hash(&self) -> HashValue {
         let bytes = lcs::to_bytes(self).expect("Ledger2WaypointConverter serialization failed");
         let mut state = Self::Hasher::default();
-        state.write(bytes.as_ref());
+        state.update(bytes.as_ref());
         state.finish()
     }
 }


### PR DESCRIPTION
## Motivation

* Refactor LCS to avoid memory allocations when hashing bytes.
* Add a new procedural macro `LCSCryptoHash` that implements `CryptoHash` using the existing `CryptoHasher` framework plus the new API `lcs::serialize_into`
* Use it to remove many manual implementations of `CryptoHash` where `lcs::to_bytes` was used (this should be faster now)
* Not trying to convert manual hashing into LCS hashing yet until we figure out why benchmark results are so different.

## Test Plan

I used the benchmark below to test that hashing with `lcs::serialize_into` is faster than with the old `lcs::to_bytes`.

```
cargo x test -p libra-crypto
cargo bench -p libra-crypto hash
```
