### PR TITLE
[language, move] Introduce public key validation

### DIFF
--- a/language/move-lang/tests/functional/approved_payment/rotate_key.move
+++ b/language/move-lang/tests/functional/approved_payment/rotate_key.move
@@ -2,6 +2,7 @@
 
 //! account: alice
 //! account: bob
+//! account: charlie
 
 // setup: alice publishes an approved payment resource, then rotates the key
 
@@ -31,3 +32,19 @@ fun main() {
 }
 }
 // check: EXECUTED
+
+// charlie publishes an approved payment resource, then tries to rotate to an invalid key
+
+//! new-transaction
+//! sender: charlie
+script {
+use 0x0::ApprovedPayment;
+fun main() {
+    let pubkey = x"3d4017c3e843895a92b70aa74d1b7ebc9c982ccf2ec4968cc0cd55f12af4660c";
+    ApprovedPayment::publish(pubkey);
+    // rotate to an invalid key
+    ApprovedPayment::rotate_sender_key(x"0000000000000000000000000000000000000000000000000000000000000000");
+}
+}
+// check: ABORTED
+// check: 9003

--- a/language/move-lang/tests/functional/approved_payment/signature_checks.move
+++ b/language/move-lang/tests/functional/approved_payment/signature_checks.move
@@ -4,6 +4,7 @@
 
 //! account: alice
 //! account: bob
+//! account: charlie
 
 // setup: alice publishes an approved payment resource
 
@@ -15,7 +16,6 @@ fun main() {
     ApprovedPayment::publish(pubkey)
 }
 }
-
 // check: EXECUTED
 
 // offline: alice generates payment id 0, signs it, and sends ID + signature to bob
@@ -32,7 +32,6 @@ fun main() {
     ApprovedPayment::deposit_to_payee<LBR::T>({{alice}}, 1000, payment_id, signature);
 }
 }
-
 // check: EXECUTED
 
 // same as above, but with an invalid signature. should now abort
@@ -48,6 +47,46 @@ fun main() {
     ApprovedPayment::deposit_to_payee<LBR::T>({{alice}}, 1000, payment_id, signature);
 }
 }
-
 // check: ABORTED
 // check: 9002
+
+// charlie publishes an invalid approved payment resource (key too long)
+//! new-transaction
+//! sender: charlie
+script {
+use 0x0::ApprovedPayment;
+fun main() {
+    let pubkey = x"10000000000000000000000000000000000000000000000000000000000000000";
+    ApprovedPayment::publish(pubkey);
+}
+}
+// check: ABORTED
+// check: 9003
+
+
+// charlie publishes an invalid approved payment resource (key too short)
+//! new-transaction
+//! sender: charlie
+script {
+use 0x0::ApprovedPayment;
+fun main() {
+    let pubkey = x"100";
+    ApprovedPayment::publish(pubkey);
+}
+}
+// check: ABORTED
+// check: 9003
+
+// charlie publishes an invalid approved payment resource (correct length,
+// invalid key),
+//! new-transaction
+//! sender: charlie
+script {
+use 0x0::ApprovedPayment;
+fun main() {
+    let pubkey = x"0000000000000000000000000000000000000000000000000000000000000000";
+    ApprovedPayment::publish(pubkey);
+}
+}
+// check: ABORTED
+// check: 9003

--- a/language/move-lang/tests/functional/natives/signature.move
+++ b/language/move-lang/tests/functional/natives/signature.move
@@ -1,0 +1,21 @@
+// Test fot public key validation
+
+script {
+use 0x0::Signature;
+use 0x0::Transaction;
+
+fun main() {
+
+    // from RFC 8032
+    let valid_pubkey =  x"3d4017c3e843895a92b70aa74d1b7ebc9c982ccf2ec4968cc0cd55f12af4660c";
+    let short_pubkey = x"100";
+    // concatenation of the two above
+    let long_pubkey = x"1003d4017c3e843895a92b70aa74d1b7ebc9c982ccf2ec4968cc0cd55f12af4660c";
+    let invalid_pubkey = x"0000000000000000000000000000000000000000000000000000000000000000";
+
+    Transaction::assert(Signature::ed25519_validate_pubkey(valid_pubkey), 9003);
+    Transaction::assert(!Signature::ed25519_validate_pubkey(short_pubkey), 9003);
+    Transaction::assert(!Signature::ed25519_validate_pubkey(long_pubkey), 9003);
+    Transaction::assert(!Signature::ed25519_validate_pubkey(invalid_pubkey), 9003);
+}
+}

--- a/language/move-prover/src/prelude.bpl
+++ b/language/move-prover/src/prelude.bpl
@@ -1053,6 +1053,10 @@ procedure {:inline 1} $Event_write_to_event_store(ta: TypeValue, guid: Value, co
 
 // TODO: implement the below methods
 
+procedure {:inline 1} $Signature_ed25519_validate_pubkey(public_key: Value) returns (res: Value) {
+    assert false; // $Signature_ed25519_validate_pubkey not implemented
+}
+
 procedure {:inline 1} $Signature_ed25519_verify(signature: Value, public_key: Value, message: Value) returns (res: Value) {
     assert false; // $Signature_ed25519_verify not implemented
 }

--- a/language/move-prover/tests/sources/stdlib/modules/approved_payment.move
+++ b/language/move-prover/tests/sources/stdlib/modules/approved_payment.move
@@ -70,6 +70,13 @@ module ApprovedPayment {
     // Rotate the key used to sign approved payments. This will invalidate any approved payments
     // that are currently in flight
     public fun rotate_key(approved_payment: &mut T, new_public_key: vector<u8>) {
+        // Cryptographic check of public key validity
+        Transaction::assert(
+            Signature::ed25519_validate_pubkey(
+                copy new_public_key
+            ),
+            9003, // TODO: proper error code
+        );
         approved_payment.public_key = new_public_key
     }
 

--- a/language/move-prover/tests/sources/stdlib/modules/signature.move
+++ b/language/move-prover/tests/sources/stdlib/modules/signature.move
@@ -1,7 +1,11 @@
 address 0x0 {
 
 module Signature {
+    // Validation of an EdDSA public key, including invalid point & small subgroup checks
+    native public fun ed25519_validate_pubkey(public_key: vector<u8>): bool;
+    // EdDSA Signature Verification
     native public fun ed25519_verify(signature: vector<u8>, public_key: vector<u8>, message: vector<u8>): bool;
+    // k-out-of-n EdDSA Signature Verification, where the subset of signers are marked by a bitmap
     native public fun ed25519_threshold_verify(bitmap: vector<u8>, signature: vector<u8>, public_key: vector<u8>, message: vector<u8>): u64;
 }
 }

--- a/language/move-vm/runtime/src/native_functions.rs
+++ b/language/move-vm/runtime/src/native_functions.rs
@@ -28,6 +28,7 @@ pub(crate) enum NativeFunction {
     HashSha2_256,
     HashSha3_256,
     LCSToBytes,
+    PubED25519Validate,
     SigED25519Verify,
     SigED25519ThresholdVerify,
     VectorLength,
@@ -57,6 +58,7 @@ impl NativeFunction {
             (&CORE_CODE_ADDRESS, "Hash", "sha2_256") => HashSha2_256,
             (&CORE_CODE_ADDRESS, "Hash", "sha3_256") => HashSha3_256,
             (&CORE_CODE_ADDRESS, "LCS", "to_bytes") => LCSToBytes,
+            (&CORE_CODE_ADDRESS, "Signature", "ed25519_validate_pubkey") => PubED25519Validate,
             (&CORE_CODE_ADDRESS, "Signature", "ed25519_verify") => SigED25519Verify,
             (&CORE_CODE_ADDRESS, "Signature", "ed25519_threshold_verify") => {
                 SigED25519ThresholdVerify
@@ -87,6 +89,7 @@ impl NativeFunction {
         match self {
             Self::HashSha2_256 => hash::native_sha2_256(ctx, t, v),
             Self::HashSha3_256 => hash::native_sha3_256(ctx, t, v),
+            Self::PubED25519Validate => signature::native_ed25519_publickey_validation(ctx, t, v),
             Self::SigED25519Verify => signature::native_ed25519_signature_verification(ctx, t, v),
             Self::SigED25519ThresholdVerify => {
                 signature::native_ed25519_threshold_signature_verification(ctx, t, v)

--- a/language/move-vm/types/src/gas_schedule.rs
+++ b/language/move-vm/types/src/gas_schedule.rs
@@ -204,4 +204,5 @@ pub enum NativeCostIndex {
     DESTROY_EMPTY = 11,
     SWAP = 12,
     SAVE_ACCOUNT = 13,
+    ED25519_VALIDATE_KEY = 14,
 }

--- a/language/stdlib/modules/approved_payment.move
+++ b/language/stdlib/modules/approved_payment.move
@@ -66,6 +66,13 @@ module ApprovedPayment {
     // Rotate the key used to sign approved payments. This will invalidate any approved payments
     // that are currently in flight
     public fun rotate_key(approved_payment: &mut T, new_public_key: vector<u8>) {
+        // Cryptographic check of public key validity
+        Transaction::assert(
+            Signature::ed25519_validate_pubkey(
+                copy new_public_key
+            ),
+            9003, // TODO: proper error code
+        );
         approved_payment.public_key = new_public_key
     }
 
@@ -80,7 +87,12 @@ module ApprovedPayment {
     // `public_key`
     public fun publish(public_key: vector<u8>) {
         // Sanity check for key validity
-        Transaction::assert(Vector::length(&public_key) == 32, 9003); // TODO: proper error code
+        Transaction::assert(
+            Signature::ed25519_validate_pubkey(
+                copy public_key
+            ),
+            9003, // TODO: proper error code
+        );
         move_to_sender(T { public_key })
     }
 

--- a/language/stdlib/modules/shared_ed25519_public_key.move
+++ b/language/stdlib/modules/shared_ed25519_public_key.move
@@ -6,8 +6,8 @@ address 0x0 {
 module SharedEd25519PublicKey {
     use 0x0::Authenticator;
     use 0x0::LibraAccount;
+    use 0x0::Signature;
     use 0x0::Transaction;
-    use 0x0::Vector;
 
     // A resource that forces the account associated with `rotation_cap` to use a ed25519
     // authentication key derived from `key`
@@ -33,7 +33,11 @@ module SharedEd25519PublicKey {
     }
 
     fun rotate_key(shared_key: &mut T, new_public_key: vector<u8>) {
-        Transaction::assert(Vector::length(&new_public_key) == 32, 7000);
+        // Cryptographic check of public key validity
+        Transaction::assert(
+            Signature::ed25519_validate_pubkey(copy new_public_key),
+            9003, // TODO: proper error code
+        );
         LibraAccount::rotate_authentication_key_with_capability(
             &shared_key.rotation_cap,
             Authenticator::ed25519_authentication_key(copy new_public_key)

--- a/language/stdlib/modules/signature.move
+++ b/language/stdlib/modules/signature.move
@@ -1,6 +1,7 @@
 address 0x0 {
 
 module Signature {
+    native public fun ed25519_validate_pubkey(public_key: vector<u8>): bool;
     native public fun ed25519_verify(signature: vector<u8>, public_key: vector<u8>, message: vector<u8>): bool;
     native public fun ed25519_threshold_verify(bitmap: vector<u8>, signature: vector<u8>, public_key: vector<u8>, message: vector<u8>): u64;
 }


### PR DESCRIPTION
TL;DR: Introduce a native function for public key validation, and use it in TR key rotation.

This solves the problem that any 32-byte value would be accepted as a public key in the stdlib contracts, despite the length check being insufficient to protect against [invalid point attacks, small subgroup attacks](https://link.springer.com/content/pdf/10.1007/3-540-44598-6_8.pdf), and typos. 

In the last case, before this PR, a user would typically rotate their key to an invalid public key unwittingly, and then fail to produce signatures against that new key, ~~losing the balance of their account in the process~~ losing the ability to demonstrate the legality of their transactions. We'd rather have early failure.

This introduces a native function for checking the validity of this public key, and uses it upon rotation. It would probably be useful to call this public key validation function in a few more places - in fact, anywhere externally-controlled key material is registered on-chain. I have not looked beyond the key rotation contracts — Edit : and publication — for now.

A further step would be an opt-in proof of ownership (TBD).
