### PR TITLE
[network] propagate noise pubkey in addr everywhere

### DIFF
--- a/config/management/src/lib.rs
+++ b/config/management/src/lib.rs
@@ -36,7 +36,7 @@ pub mod constants {
     pub const MAX_GAS_AMOUNT: u64 = 1_000_000;
     pub const GAS_CURRENCY_CODE: &str = LBR_NAME;
     pub const TXN_EXPIRATION_SECS: u64 = 3600;
-    pub const GENESIS_HANDSHAKE_VERSION: u8 = 0;
+    pub const HANDSHAKE_VERSION: u8 = 0;
 }
 
 #[derive(Debug, StructOpt)]

--- a/config/management/src/lib.rs
+++ b/config/management/src/lib.rs
@@ -36,6 +36,7 @@ pub mod constants {
     pub const MAX_GAS_AMOUNT: u64 = 1_000_000;
     pub const GAS_CURRENCY_CODE: &str = LBR_NAME;
     pub const TXN_EXPIRATION_SECS: u64 = 3600;
+    pub const GENESIS_HANDSHAKE_VERSION: u8 = 0;
 }
 
 #[derive(Debug, StructOpt)]

--- a/config/management/src/validator_config.rs
+++ b/config/management/src/validator_config.rs
@@ -49,14 +49,14 @@ impl ValidatorConfig {
 
         let validator_address = self.validator_address.clone().into_prod(
             validator_network_key.clone(),
-            crate::constants::GENESIS_HANDSHAKE_VERSION,
+            crate::constants::HANDSHAKE_VERSION,
         );
         let raw_validator_address = RawNetworkAddress::try_from(&validator_address)
             .map_err(|e| Error::UnexpectedError(format!("(raw_validator_address) {}", e)))?;
 
         let fullnode_address = self.fullnode_address.clone().into_prod(
             fullnode_network_key.clone(),
-            crate::constants::GENESIS_HANDSHAKE_VERSION,
+            crate::constants::HANDSHAKE_VERSION,
         );
         let raw_fullnode_address = RawNetworkAddress::try_from(&fullnode_address)
             .map_err(|e| Error::UnexpectedError(format!("(raw_fullnode_address) {}", e)))?;

--- a/config/management/src/validator_config.rs
+++ b/config/management/src/validator_config.rs
@@ -47,14 +47,14 @@ impl ValidatorConfig {
 
         // append ln-noise-ik and ln-handshake protocols to base network addresses
 
-        let validator_address = self.validator_address.clone().into_prod(
+        let validator_address = self.validator_address.clone().append_prod_protos(
             validator_network_key.clone(),
             crate::constants::HANDSHAKE_VERSION,
         );
         let raw_validator_address = RawNetworkAddress::try_from(&validator_address)
             .map_err(|e| Error::UnexpectedError(format!("(raw_validator_address) {}", e)))?;
 
-        let fullnode_address = self.fullnode_address.clone().into_prod(
+        let fullnode_address = self.fullnode_address.clone().append_prod_protos(
             fullnode_network_key.clone(),
             crate::constants::HANDSHAKE_VERSION,
         );

--- a/config/src/config/network_config.rs
+++ b/config/src/config/network_config.rs
@@ -20,9 +20,6 @@ use std::{collections::HashMap, convert::TryFrom, path::PathBuf, string::ToStrin
 const NETWORK_PEERS_DEFAULT: &str = "network_peers.config.toml";
 const SEED_PEERS_DEFAULT: &str = "seed_peers.toml";
 
-// TODO(philiphayes): extract handshake types into separate crate and use that enum
-const LIBRANET_HANDSHAKE_VERSION: u8 = 0;
-
 #[cfg_attr(any(test, feature = "fuzzing"), derive(Clone, PartialEq))]
 #[derive(Debug, Deserialize, Serialize)]
 #[serde(default, deny_unknown_fields)]
@@ -33,9 +30,6 @@ pub struct NetworkConfig {
     pub listen_address: NetworkAddress,
     // The address that this node advertises to other nodes for the discovery protocol.
     pub advertised_address: NetworkAddress,
-    // TODO(philiphayes): use the enum type
-    // the supported libranet negotiation protocol version
-    pub handshake_version: u8,
     pub discovery_interval_ms: u64,
     pub connectivity_check_interval_ms: u64,
     // Flag to toggle if Noise is used for encryption and authentication.
@@ -64,7 +58,6 @@ impl Default for NetworkConfig {
             peer_id: PeerId::default(),
             listen_address: "/ip4/0.0.0.0/tcp/6180".parse().unwrap(),
             advertised_address: "/ip4/127.0.0.1/tcp/6180".parse().unwrap(),
-            handshake_version: LIBRANET_HANDSHAKE_VERSION,
             discovery_interval_ms: 1000,
             connectivity_check_interval_ms: 5000,
             enable_noise: true,
@@ -87,7 +80,6 @@ impl NetworkConfig {
             peer_id: self.peer_id,
             listen_address: self.listen_address.clone(),
             advertised_address: self.advertised_address.clone(),
-            handshake_version: self.handshake_version,
             discovery_interval_ms: self.discovery_interval_ms,
             connectivity_check_interval_ms: self.connectivity_check_interval_ms,
             enable_noise: self.enable_noise,

--- a/config/src/config/network_config.rs
+++ b/config/src/config/network_config.rs
@@ -20,6 +20,9 @@ use std::{collections::HashMap, convert::TryFrom, path::PathBuf, string::ToStrin
 const NETWORK_PEERS_DEFAULT: &str = "network_peers.config.toml";
 const SEED_PEERS_DEFAULT: &str = "seed_peers.toml";
 
+// TODO(philiphayes): extract handshake types into separate crate and use that enum
+const LIBRANET_HANDSHAKE_VERSION: u8 = 0;
+
 #[cfg_attr(any(test, feature = "fuzzing"), derive(Clone, PartialEq))]
 #[derive(Debug, Deserialize, Serialize)]
 #[serde(default, deny_unknown_fields)]
@@ -30,6 +33,9 @@ pub struct NetworkConfig {
     pub listen_address: NetworkAddress,
     // The address that this node advertises to other nodes for the discovery protocol.
     pub advertised_address: NetworkAddress,
+    // TODO(philiphayes): use the enum type
+    // the supported libranet negotiation protocol version
+    pub handshake_version: u8,
     pub discovery_interval_ms: u64,
     pub connectivity_check_interval_ms: u64,
     // Flag to toggle if Noise is used for encryption and authentication.
@@ -58,6 +64,7 @@ impl Default for NetworkConfig {
             peer_id: PeerId::default(),
             listen_address: "/ip4/0.0.0.0/tcp/6180".parse().unwrap(),
             advertised_address: "/ip4/127.0.0.1/tcp/6180".parse().unwrap(),
+            handshake_version: LIBRANET_HANDSHAKE_VERSION,
             discovery_interval_ms: 1000,
             connectivity_check_interval_ms: 5000,
             enable_noise: true,
@@ -80,6 +87,7 @@ impl NetworkConfig {
             peer_id: self.peer_id,
             listen_address: self.listen_address.clone(),
             advertised_address: self.advertised_address.clone(),
+            handshake_version: self.handshake_version,
             discovery_interval_ms: self.discovery_interval_ms,
             connectivity_check_interval_ms: self.connectivity_check_interval_ms,
             enable_noise: self.enable_noise,

--- a/config/src/utils.rs
+++ b/config/src/utils.rs
@@ -57,9 +57,7 @@ pub fn get_available_port_in_multiaddr(is_ipv4: bool) -> NetworkAddress {
     } else {
         Protocol::Ip6("::1".parse().unwrap())
     };
-    let mut addr = NetworkAddress::from(ip_proto);
-    addr.push(Protocol::Tcp(get_available_port()));
-    addr
+    NetworkAddress::from(ip_proto).push(Protocol::Tcp(get_available_port()))
 }
 
 /// Serialize HashMaps as BTreeMaps for consistent ordering

--- a/language/tools/vm-genesis/src/lib.rs
+++ b/language/tools/vm-genesis/src/lib.rs
@@ -37,6 +37,9 @@ const GENESIS_SEED: [u8; 32] = [42; 32];
 
 const GENESIS_MODULE_NAME: &str = "Genesis";
 
+// TODO(philiphayes): probably not the right place to put this...
+const HANDSHAKE_VERSION: u8 = 0;
+
 pub static GENESIS_KEYPAIR: Lazy<(Ed25519PrivateKey, Ed25519PublicKey)> = Lazy::new(|| {
     let mut rng = StdRng::from_seed(GENESIS_SEED);
     let private_key = Ed25519PrivateKey::generate(&mut rng);
@@ -385,14 +388,12 @@ pub fn validator_registrations(node_configs: &[NodeConfig]) -> Vec<ValidatorRegi
             let network = n.validator_network.as_ref().unwrap();
             let network_keypairs = network.network_keypairs.as_ref().unwrap();
             let signing_key = network_keypairs.signing_keypair.public_key();
-
             let identity_key = network_keypairs.identity_keypair.public_key();
-            let handshake_version = network.handshake_version;
 
             let advertised_address = network
                 .advertised_address
                 .clone()
-                .into_prod(identity_key, handshake_version);
+                .append_prod_protos(identity_key, HANDSHAKE_VERSION);
             let raw_advertised_address = RawNetworkAddress::try_from(&advertised_address).unwrap();
 
             // TODO(philiphayes): do something with n.full_node_networks instead

--- a/libra-node/src/main_node.rs
+++ b/libra-node/src/main_node.rs
@@ -192,6 +192,11 @@ pub fn setup_network(
             })
             .collect();
 
+        info!(
+            "network setup: role: {}, seed_peers: {:?}, network_peers: {:?}",
+            role, seed_peers, network_peers,
+        );
+
         let trusted_peers = if role == RoleType::Validator {
             // for validators, trusted_peers is empty will be populated from consensus
             HashMap::new()

--- a/libra-node/src/main_node.rs
+++ b/libra-node/src/main_node.rs
@@ -22,7 +22,9 @@ use libra_metrics::metric_server;
 use libra_types::{on_chain_config::ON_CHAIN_CONFIG_REGISTRY, waypoint::Waypoint, PeerId};
 use libra_vm::LibraVM;
 use libradb::LibraDB;
-use network::validator_network::network_builder::{AuthMode, NetworkBuilder, HANDSHAKE_VERSION};
+use network::validator_network::network_builder::{
+    AuthenticationMode, NetworkBuilder, HANDSHAKE_VERSION,
+};
 use onchain_discovery::{client::OnchainDiscovery, service::OnchainDiscoveryService};
 use state_synchronizer::StateSynchronizer;
 use std::{
@@ -206,7 +208,7 @@ pub fn setup_network(
 
         network_builder
             .advertised_address(config.advertised_address.clone())
-            .auth_mode(AuthMode::Mutual(identity_key))
+            .authentication_mode(AuthenticationMode::Mutual(identity_key))
             .trusted_peers(trusted_peers)
             .seed_peers(seed_peers)
             .signing_keypair((signing_private, signing_public))
@@ -225,12 +227,12 @@ pub fn setup_network(
         // its identity to another peer it connects to. For this, we use TCP + Noise but without
         // enforcing a trusted peers set.
         network_builder
-            .auth_mode(AuthMode::ClientOnly(identity_key))
+            .authentication_mode(AuthenticationMode::ServerOnly(identity_key))
             .advertised_address(config.advertised_address.clone());
     } else {
         // TODO(philiphayes): probably remove this branch since there are no
         // current no noise or no client auth use cases.
-        network_builder.auth_mode(AuthMode::Unauthed);
+        network_builder.authentication_mode(AuthenticationMode::Unauthenticated);
     }
 
     match config.discovery_method {

--- a/network/netcore/src/transport/tcp.rs
+++ b/network/netcore/src/transport/tcp.rs
@@ -80,8 +80,10 @@ impl Transport for TcpTransport {
         let listener = ::std::net::TcpListener::bind(&socket_addr)?;
         let listener = TcpListener::try_from(listener)?;
 
-        let mut actual_addr = NetworkAddress::from(listener.local_addr()?);
-        actual_addr.extend_from_slice(addr_suffix);
+        // append the addr_suffix so any trailing protocols get included in the
+        // actual listening adddress we return
+        let actual_addr =
+            NetworkAddress::from(listener.local_addr()?).extend_from_slice(addr_suffix);
 
         Ok((
             TcpListenerStream {

--- a/network/netcore/src/transport/tcp.rs
+++ b/network/netcore/src/transport/tcp.rs
@@ -74,18 +74,21 @@ impl Transport for TcpTransport {
         &self,
         addr: NetworkAddress,
     ) -> Result<(Self::Listener, NetworkAddress), Self::Error> {
-        let socket_addr = multiaddr_to_socketaddr(&addr)?;
+        let (socket_addr, addr_suffix) = parse_socketaddr(&addr)?;
         let config = self.clone();
+
         let listener = ::std::net::TcpListener::bind(&socket_addr)?;
-        let local_addr = NetworkAddress::from(listener.local_addr()?);
         let listener = TcpListener::try_from(listener)?;
+
+        let mut actual_addr = NetworkAddress::from(listener.local_addr()?);
+        actual_addr.extend_from_slice(addr_suffix);
 
         Ok((
             TcpListenerStream {
                 inner: listener,
                 config,
             },
-            local_addr,
+            actual_addr,
         ))
     }
 
@@ -193,36 +196,32 @@ impl AsyncWrite for TcpSocket {
     }
 }
 
-fn multiaddr_to_socketaddr(addr: &NetworkAddress) -> ::std::io::Result<SocketAddr> {
-    let mut iter = addr.as_slice().iter();
-    let proto1 = iter.next().ok_or_else(|| {
-        io::Error::new(
-            io::ErrorKind::InvalidInput,
-            format!("Invalid NetworkAddress '{:?}'", addr),
-        )
-    })?;
-    let proto2 = iter.next().ok_or_else(|| {
-        io::Error::new(
-            io::ErrorKind::InvalidInput,
-            format!("Invalid NetworkAddress '{:?}'", addr),
-        )
-    })?;
-
-    if iter.next().is_some() {
+/// parse the `NetworkAddress` into the `/ip4/<ip>/tcp/<port>` or
+/// `/ip6/<ip>/tcp/<port>` prefix and unparsed `&[Protocol]` suffix.
+fn parse_socketaddr<'a>(
+    addr: &'a NetworkAddress,
+) -> ::std::io::Result<(SocketAddr, &'a [Protocol])> {
+    if addr.len() < 2 {
         return Err(io::Error::new(
             io::ErrorKind::InvalidInput,
             format!("Invalid NetworkAddress '{:?}'", addr),
         ));
     }
 
-    match (proto1, proto2) {
-        (Protocol::Ip4(ip), Protocol::Tcp(port)) => Ok(SocketAddr::new((*ip).into(), *port)),
-        (Protocol::Ip6(ip), Protocol::Tcp(port)) => Ok(SocketAddr::new((*ip).into(), *port)),
-        _ => Err(io::Error::new(
-            io::ErrorKind::InvalidInput,
-            format!("Invalid NetworkAddress '{:?}'", addr),
-        )),
-    }
+    let (prefix, suffix) = addr.as_slice().split_at(2);
+
+    let socket_addr = match prefix {
+        [Protocol::Ip4(ip), Protocol::Tcp(port)] => SocketAddr::new((*ip).into(), *port),
+        [Protocol::Ip6(ip), Protocol::Tcp(port)] => SocketAddr::new((*ip).into(), *port),
+        _ => {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidInput,
+                format!("Invalid NetworkAddress '{:?}'", addr),
+            ))
+        }
+    };
+
+    Ok((socket_addr, suffix))
 }
 
 fn multiaddr_to_string(addr: &NetworkAddress) -> ::std::io::Result<String> {
@@ -239,13 +238,6 @@ fn multiaddr_to_string(addr: &NetworkAddress) -> ::std::io::Result<String> {
             format!("Invalid NetworkAddress '{:?}'", addr),
         )
     })?;
-
-    if iter.next().is_some() {
-        return Err(io::Error::new(
-            io::ErrorKind::InvalidInput,
-            format!("Invalid NetworkAddress '{:?}'", addr),
-        ));
-    }
 
     match (proto1, proto2) {
         (Protocol::Ip4(ip), Protocol::Tcp(port)) => Ok(format!("{}:{}", ip, port)),

--- a/network/network-address/src/lib.rs
+++ b/network/network-address/src/lib.rs
@@ -134,7 +134,7 @@ pub enum Protocol {
     Tcp(u16),
     Memory(u16),
     // human-readable x25519::PublicKey is lower-case hex encoded
-    NoiseIk(x25519::PublicKey),
+    NoiseIK(x25519::PublicKey),
     // TODO(philiphayes): use actual handshake::MessagingProtocolVersion. we
     // probably need to move network wire into its own crate to avoid circular
     // dependency b/w network and types.
@@ -303,7 +303,7 @@ impl NetworkAddress {
         network_pubkey: x25519::PublicKey,
         handshake_version: u8,
     ) -> Self {
-        self.push(Protocol::NoiseIk(network_pubkey))
+        self.push(Protocol::NoiseIK(network_pubkey))
             .push(Protocol::Handshake(handshake_version))
     }
 
@@ -326,7 +326,7 @@ impl NetworkAddress {
     /// "monolithic" transport model.
     pub fn find_noise_proto(&self) -> Option<&x25519::PublicKey> {
         self.0.iter().find_map(|proto| match proto {
-            Protocol::NoiseIk(pubkey) => Some(pubkey),
+            Protocol::NoiseIK(pubkey) => Some(pubkey),
             _ => None,
         })
     }
@@ -497,7 +497,7 @@ impl fmt::Display for Protocol {
             Dns6(domain) => write!(f, "/dns6/{}", domain),
             Tcp(port) => write!(f, "/tcp/{}", port),
             Memory(port) => write!(f, "/memory/{}", port),
-            NoiseIk(pubkey) => write!(
+            NoiseIK(pubkey) => write!(
                 f,
                 "/ln-noise-ik/{}",
                 pubkey
@@ -532,7 +532,7 @@ impl Protocol {
             "dns6" => Protocol::Dns6(parse_one(args)?),
             "tcp" => Protocol::Tcp(parse_one(args)?),
             "memory" => Protocol::Memory(parse_one(args)?),
-            "ln-noise-ik" => Protocol::NoiseIk(x25519::PublicKey::from_encoded_string(
+            "ln-noise-ik" => Protocol::NoiseIK(x25519::PublicKey::from_encoded_string(
                 args.next().ok_or(ParseError::UnexpectedEnd)?,
             )?),
             "ln-handshake" => Protocol::Handshake(parse_one(args)?),
@@ -704,7 +704,7 @@ mod test {
                 vec![
                     Dns(DnsName("example.com".to_owned())),
                     Tcp(1234),
-                    NoiseIk(pubkey),
+                    NoiseIK(pubkey),
                     Handshake(5),
                 ],
             ),

--- a/network/network-address/src/lib.rs
+++ b/network/network-address/src/lib.rs
@@ -269,6 +269,10 @@ impl NetworkAddress {
         self.0.len()
     }
 
+    pub fn is_empty(&self) -> bool {
+        self.0.is_empty()
+    }
+
     pub fn as_slice(&self) -> &[Protocol] {
         self.0.as_slice()
     }

--- a/network/src/protocols/network/dummy.rs
+++ b/network/src/protocols/network/dummy.rs
@@ -10,7 +10,9 @@ use crate::{
         network::{Event, NetworkEvents, NetworkSender},
         rpc::error::RpcError,
     },
-    validator_network::network_builder::{AuthMode, NetworkBuilder, NETWORK_CHANNEL_SIZE},
+    validator_network::network_builder::{
+        AuthenticationMode, NetworkBuilder, NETWORK_CHANNEL_SIZE,
+    },
     NetworkPublicKeys, ProtocolId,
 };
 use channel::message_queues::QueueStyle;
@@ -145,7 +147,7 @@ pub fn setup_network() -> DummyNetwork {
         listener_addr,
     );
     network_builder
-        .auth_mode(AuthMode::Mutual(listener_identity_private_key))
+        .authentication_mode(AuthenticationMode::Mutual(listener_identity_private_key))
         .trusted_peers(trusted_peers.clone())
         .add_connectivity_manager();
     let (listener_sender, mut listener_events) = add_to_network(&mut network_builder);
@@ -159,7 +161,7 @@ pub fn setup_network() -> DummyNetwork {
         dialer_addr,
     );
     network_builder
-        .auth_mode(AuthMode::Mutual(dialer_identity_private_key))
+        .authentication_mode(AuthenticationMode::Mutual(dialer_identity_private_key))
         .trusted_peers(trusted_peers)
         .seed_peers(
             [(listener_peer_id, vec![listener_addr])]

--- a/network/src/transport.rs
+++ b/network/src/transport.rs
@@ -157,7 +157,7 @@ fn expect_noise_pubkey(
         let expected_remote_static_key = addr.find_noise_proto().ok_or_else(|| {
             io::Error::new(
                 io::ErrorKind::InvalidData,
-                format!("Invalid NetworkAddress, no NoiseIk protocol: '{}'", addr),
+                format!("Invalid NetworkAddress, no NoiseIK protocol: '{}'", addr),
             )
         })?;
 

--- a/network/src/transport.rs
+++ b/network/src/transport.rs
@@ -147,6 +147,7 @@ fn identity_key_to_peer_id(
 
 /// temporary checks to make sure noise pubkeys are actually getting propagated correctly.
 // TODO(philiphayes): remove this after Transport refactor
+#[allow(dead_code)]
 fn expect_noise_pubkey(
     addr: &NetworkAddress,
     remote_static_key: &[u8],
@@ -217,11 +218,12 @@ pub fn build_memory_noise_transport(
     own_handshake.add(SUPPORTED_MESSAGING_PROTOCOL, application_protocols);
 
     memory_transport
-        .and_then(move |socket, addr, origin| async move {
+        .and_then(move |socket, _addr, origin| async move {
             let (remote_static_key, socket) =
                 noise_config.upgrade_connection(socket, origin).await?;
 
-            expect_noise_pubkey(&addr, remote_static_key.as_slice(), origin)?;
+            // TODO(philiphayes): reenable after seed peers are always fully rendered
+            // expect_noise_pubkey(&addr, remote_static_key.as_slice(), origin)?;
 
             if let Some(peer_id) = identity_key_to_peer_id(&trusted_peers, &remote_static_key) {
                 Ok((peer_id, socket))
@@ -246,12 +248,13 @@ pub fn build_unauthenticated_memory_noise_transport(
     own_handshake.add(SUPPORTED_MESSAGING_PROTOCOL, application_protocols);
 
     memory_transport
-        .and_then(move |socket, addr, origin| {
+        .and_then(move |socket, _addr, origin| {
             async move {
                 let (remote_static_key, socket) =
                     noise_config.upgrade_connection(socket, origin).await?;
 
-                expect_noise_pubkey(&addr, remote_static_key.as_slice(), origin)?;
+                // TODO(philiphayes): reenable after seed peers are always fully rendered
+                // expect_noise_pubkey(&addr, remote_static_key.as_slice(), origin)?;
 
                 // Generate PeerId from x25519::PublicKey.
                 // Note: This is inconsistent with current types because AccountAddress is derived
@@ -301,11 +304,12 @@ pub fn build_tcp_noise_transport(
     own_handshake.add(SUPPORTED_MESSAGING_PROTOCOL, application_protocols);
 
     LIBRA_TCP_TRANSPORT
-        .and_then(move |socket, addr, origin| async move {
+        .and_then(move |socket, _addr, origin| async move {
             let (remote_static_key, socket) =
                 noise_config.upgrade_connection(socket, origin).await?;
 
-            expect_noise_pubkey(&addr, remote_static_key.as_slice(), origin)?;
+            // TODO(philiphayes): reenable after seed peers are always fully rendered
+            // expect_noise_pubkey(&addr, remote_static_key.as_slice(), origin)?;
 
             if let Some(peer_id) = identity_key_to_peer_id(&trusted_peers, &remote_static_key) {
                 Ok((peer_id, socket))
@@ -336,12 +340,13 @@ pub fn build_unauthenticated_tcp_noise_transport(
     own_handshake.add(SUPPORTED_MESSAGING_PROTOCOL, application_protocols);
 
     LIBRA_TCP_TRANSPORT
-        .and_then(move |socket, addr, origin| {
+        .and_then(move |socket, _addr, origin| {
             async move {
                 let (remote_static_key, socket) =
                     noise_config.upgrade_connection(socket, origin).await?;
 
-                expect_noise_pubkey(&addr, remote_static_key.as_slice(), origin)?;
+                // TODO(philiphayes): reenable after seed peers are always fully rendered
+                // expect_noise_pubkey(&addr, remote_static_key.as_slice(), origin)?;
 
                 // Generate PeerId from x25519::PublicKey.
                 // Note: This is inconsistent with current types because AccountAddress is derived

--- a/network/src/transport.rs
+++ b/network/src/transport.rs
@@ -11,7 +11,7 @@ use crate::{
 use futures::io::{AsyncRead, AsyncWrite};
 use libra_crypto::{traits::ValidCryptoMaterial, x25519};
 use libra_logger::prelude::*;
-use libra_network_address::NetworkAddress;
+use libra_network_address::{NetworkAddress, Protocol};
 use libra_security_logger::{security_log, SecurityEvent};
 use libra_types::PeerId;
 use netcore::transport::{boxed, memory, tcp, ConnectionOrigin, TransportExt};
@@ -145,6 +145,43 @@ fn identity_key_to_peer_id(
     None
 }
 
+/// A temporary, hacky function to parse out the first `/ln-noise-ik/<pubkey>` from
+/// a `NetworkAddress`. We can remove this soon, when we move to the interim
+/// "monolithic" transport model.
+fn parse_noise_pubkey(addr: NetworkAddress) -> Result<x25519::PublicKey, io::Error> {
+    addr.into_iter()
+        .find_map(|proto| match proto {
+            Protocol::NoiseIk(pubkey) => Some(pubkey),
+            _ => None,
+        })
+        .ok_or_else(|| io::Error::new(io::ErrorKind::InvalidInput, "Invalid NetworkAddress"))
+}
+
+/// temporary checks to make sure noise pubkeys are actually getting propagated correctly.
+// TODO(philiphayes): remove this after Transport refactor
+fn expect_noise_pubkey(
+    addr: NetworkAddress,
+    remote_static_key: &[u8],
+    origin: ConnectionOrigin,
+) -> Result<(), io::Error> {
+    if let ConnectionOrigin::Outbound = origin {
+        if let Ok(expected_remote_static_key) = parse_noise_pubkey(addr) {
+            if remote_static_key != expected_remote_static_key.as_slice() {
+                return Err(io::Error::new(
+                    io::ErrorKind::InvalidData,
+                    format!(
+                        "remote static key did not match expected: actual: {:?}, expected: {:?}",
+                        remote_static_key,
+                        expected_remote_static_key.as_slice()
+                    ),
+                ));
+            }
+        }
+    }
+
+    Ok(())
+}
+
 pub async fn perform_handshake<T: TSocket>(
     peer_id: PeerId,
     mut socket: T,
@@ -188,9 +225,12 @@ pub fn build_memory_noise_transport(
     own_handshake.add(SUPPORTED_MESSAGING_PROTOCOL, application_protocols);
 
     memory_transport
-        .and_then(move |socket, _addr, origin| async move {
+        .and_then(move |socket, addr, origin| async move {
             let (remote_static_key, socket) =
                 noise_config.upgrade_connection(socket, origin).await?;
+
+            expect_noise_pubkey(addr, remote_static_key.as_slice(), origin)?;
+
             if let Some(peer_id) = identity_key_to_peer_id(&trusted_peers, &remote_static_key) {
                 Ok((peer_id, socket))
             } else {
@@ -214,10 +254,13 @@ pub fn build_unauthenticated_memory_noise_transport(
     own_handshake.add(SUPPORTED_MESSAGING_PROTOCOL, application_protocols);
 
     memory_transport
-        .and_then(move |socket, _addr, origin| {
+        .and_then(move |socket, addr, origin| {
             async move {
                 let (remote_static_key, socket) =
                     noise_config.upgrade_connection(socket, origin).await?;
+
+                expect_noise_pubkey(addr, remote_static_key.as_slice(), origin)?;
+
                 // Generate PeerId from x25519::PublicKey.
                 // Note: This is inconsistent with current types because AccountAddress is derived
                 // from consensus key which is of type Ed25519PublicKey. Since AccountAddress does
@@ -266,9 +309,12 @@ pub fn build_tcp_noise_transport(
     own_handshake.add(SUPPORTED_MESSAGING_PROTOCOL, application_protocols);
 
     LIBRA_TCP_TRANSPORT
-        .and_then(move |socket, _addr, origin| async move {
+        .and_then(move |socket, addr, origin| async move {
             let (remote_static_key, socket) =
                 noise_config.upgrade_connection(socket, origin).await?;
+
+            expect_noise_pubkey(addr, remote_static_key.as_slice(), origin)?;
+
             if let Some(peer_id) = identity_key_to_peer_id(&trusted_peers, &remote_static_key) {
                 Ok((peer_id, socket))
             } else {
@@ -298,10 +344,13 @@ pub fn build_unauthenticated_tcp_noise_transport(
     own_handshake.add(SUPPORTED_MESSAGING_PROTOCOL, application_protocols);
 
     LIBRA_TCP_TRANSPORT
-        .and_then(move |socket, _addr, origin| {
+        .and_then(move |socket, addr, origin| {
             async move {
                 let (remote_static_key, socket) =
                     noise_config.upgrade_connection(socket, origin).await?;
+
+                expect_noise_pubkey(addr, remote_static_key.as_slice(), origin)?;
+
                 // Generate PeerId from x25519::PublicKey.
                 // Note: This is inconsistent with current types because AccountAddress is derived
                 // from consensus key which is of type Ed25519PublicKey. Since AccountAddress does

--- a/network/src/validator_network/network_builder.rs
+++ b/network/src/validator_network/network_builder.rs
@@ -20,7 +20,7 @@ use crate::{
     protocols::{
         discovery::{self, Discovery},
         health_checker::{self, HealthChecker},
-        wire::handshake::v1::SupportedProtocols,
+        wire::handshake::v1::{MessagingProtocolVersion, SupportedProtocols},
     },
     transport,
     transport::*,
@@ -66,15 +66,36 @@ pub const MAX_CONCURRENT_NETWORK_REQS: usize = 100;
 pub const MAX_CONCURRENT_NETWORK_NOTIFS: usize = 100;
 pub const MAX_CONNECTION_DELAY_MS: u64 = 10 * 60 * 1000 /* 10 minutes */;
 
-/// The type of the transport layer, i.e., running on memory or TCP stream,
-/// with or without Noise encryption
-pub enum TransportType {
-    Memory,
-    MemoryNoise(Option<x25519::PrivateKey>),
-    PermissionlessMemoryNoise(Option<x25519::PrivateKey>),
-    Tcp,
-    TcpNoise(Option<x25519::PrivateKey>),
-    PermissionlessTcpNoise(Option<x25519::PrivateKey>),
+// TODO(philiphayes): remove when transport returns fully rendered network address
+pub const HANDSHAKE_VERSION: u8 = MessagingProtocolVersion::V1 as u8;
+
+#[derive(Debug)]
+pub enum AuthMode {
+    /// Inbound and outbound connections are unauthenticated and unencrypted, using
+    /// a simple PeerId exchange protocol to share each peer's PeerId in-band.
+    /// This mode is obviously insecure and should never be used in production.
+    // TODO(philiphayes): remove? gate with cfg(test)? should never use this in prod.
+    Unauthed,
+    /// Inbound and outbound connections are secured with NoiseIK; however, only
+    /// clients/dialers will authenticate the servers/listeners. More specifically,
+    /// dialers will pin the connection to a specific, expected pubkey while
+    /// listeners will accept any inbound dialer's pubkey.
+    ClientOnly(x25519::PrivateKey),
+    /// Inbound and outbound connections are secured with NoiseIK. Both dialer and
+    /// listener will only accept connections that successfully authenticate to a
+    /// pubkey in their "trusted peers" set.
+    Mutual(x25519::PrivateKey),
+}
+
+/// Append the correct libranet protocols to the given base address, depending on
+/// the configured authentication mode.
+fn append_libranet_protocols(addr: NetworkAddress, auth_mode: &AuthMode) -> NetworkAddress {
+    match auth_mode {
+        AuthMode::Unauthed => addr.append_test_protos(HANDSHAKE_VERSION),
+        AuthMode::ClientOnly(key) | AuthMode::Mutual(key) => {
+            addr.append_prod_protos(key.public_key(), HANDSHAKE_VERSION)
+        }
+    }
 }
 
 /// Build Network module with custom configuration values.
@@ -89,11 +110,11 @@ pub struct NetworkBuilder {
     peer_id: PeerId,
     role: RoleType,
     // TODO(philiphayes): better support multiple listening addrs
-    listen_address: Option<NetworkAddress>,
+    listen_address: NetworkAddress,
     advertised_address: Option<NetworkAddress>,
     seed_peers: HashMap<PeerId, Vec<NetworkAddress>>,
     trusted_peers: Arc<RwLock<HashMap<PeerId, NetworkPublicKeys>>>,
-    transport: TransportType,
+    auth_mode: Option<AuthMode>,
     channel_size: usize,
     direct_send_protocols: Vec<ProtocolId>,
     rpc_protocols: Vec<ProtocolId>,
@@ -117,12 +138,16 @@ pub struct NetworkBuilder {
     max_concurrent_network_notifs: usize,
     max_connection_delay_ms: u64,
     signing_keypair: Option<(Ed25519PrivateKey, Ed25519PublicKey)>,
-    enable_remote_authentication: bool,
 }
 
 impl NetworkBuilder {
     /// Return a new NetworkBuilder initialized with default configuration values.
-    pub fn new(executor: Handle, peer_id: PeerId, role: RoleType) -> NetworkBuilder {
+    pub fn new(
+        executor: Handle,
+        peer_id: PeerId,
+        role: RoleType,
+        listen_address: NetworkAddress,
+    ) -> NetworkBuilder {
         // Setup channel to send requests to peer manager.
         let (pm_reqs_tx, pm_reqs_rx) = libra_channel::new(
             QueueStyle::FIFO,
@@ -139,10 +164,11 @@ impl NetworkBuilder {
             executor,
             peer_id,
             role,
-            listen_address: None,
+            listen_address,
             advertised_address: None,
             seed_peers: HashMap::new(),
             trusted_peers: Arc::new(RwLock::new(HashMap::new())),
+            auth_mode: None,
             channel_size: NETWORK_CHANNEL_SIZE,
             direct_send_protocols: vec![],
             rpc_protocols: vec![],
@@ -153,7 +179,6 @@ impl NetworkBuilder {
             connection_reqs_tx,
             connection_reqs_rx,
             conn_mgr_reqs_tx: None,
-            transport: TransportType::Memory,
             discovery_interval_ms: DISCOVERY_INTERVAL_MS,
             ping_interval_ms: PING_INTERVAL_MS,
             ping_timeout_ms: PING_TIMEOUT_MS,
@@ -166,19 +191,12 @@ impl NetworkBuilder {
             max_concurrent_network_notifs: MAX_CONCURRENT_NETWORK_NOTIFS,
             max_connection_delay_ms: MAX_CONNECTION_DELAY_MS,
             signing_keypair: None,
-            enable_remote_authentication: true,
         }
     }
 
-    /// Set transport type, i.e., Memory or Tcp transports.
-    pub fn transport(&mut self, transport: TransportType) -> &mut Self {
-        self.transport = transport;
-        self
-    }
-
-    /// Set an address to listen on
-    pub fn listen_address(&mut self, listen_address: NetworkAddress) -> &mut Self {
-        self.listen_address = Some(listen_address);
+    /// Set network authentication mode.
+    pub fn auth_mode(&mut self, auth_mode: AuthMode) -> &mut Self {
+        self.auth_mode = Some(auth_mode);
         self
     }
 
@@ -289,15 +307,6 @@ impl NetworkBuilder {
         self
     }
 
-    /// Set the enable_remote_authentication flag to make the network operate with remote authentication.
-    pub fn enable_remote_authentication(
-        &mut self,
-        enable_remote_authentication: bool,
-    ) -> &mut Self {
-        self.enable_remote_authentication = enable_remote_authentication;
-        self
-    }
-
     pub fn conn_mgr_reqs_tx(&self) -> Option<channel::Sender<ConnectivityRequest>> {
         self.conn_mgr_reqs_tx.clone()
     }
@@ -400,9 +409,6 @@ impl NetworkBuilder {
     /// by exchanging the full set of known peer network addresses with connected
     /// peers as a network protocol.
     pub fn add_gossip_discovery(&mut self) -> &mut Self {
-        // Note: We use the `enable_remote_authentication` flag as a proxy for
-        // whether we need to run the discovery module or not. We should make this
-        // more explicit eventually.
         let peer_id = self.peer_id;
         let conn_mgr_reqs_tx = self
             .conn_mgr_reqs_tx()
@@ -412,12 +418,27 @@ impl NetworkBuilder {
         // Get handles for network events and sender.
         let (discovery_network_tx, discovery_network_rx) = discovery::add_to_network(self);
 
+        // TODO(philiphayes): the current setup for gossip discovery doesn't work
+        // when we don't have an `advertised_address` set, since it uses the
+        // `listen_address`, which might not be bound to a port yet. For example,
+        // if our `listen_address` is "/ip6/::1/tcp/0" and `advertised_address` is
+        // `None`, then this will set our `advertised_address` to something like
+        // "/ip6/::1/tcp/0/ln-noise-ik/<pubkey>/ln-handshake/0", which is wrong
+        // since the actual bound port will be something > 0.
+
+        // TODO(philiphayes): in network_builder setup, only bind the channels.
+        // wait until PeerManager is running to actual setup gossip discovery.
+
         let advertised_address = self
             .advertised_address
+            .clone()
+            .unwrap_or_else(|| self.listen_address.clone());
+        let auth_mode = self
+            .auth_mode
             .as_ref()
-            .or_else(|| self.listen_address.as_ref())
-            .expect("Either advertised_address or listen_address must be set to enable gossip discovery")
-            .clone();
+            .expect("Authentication Mode not set");
+        let advertised_address = append_libranet_protocols(advertised_address, auth_mode);
+
         let addrs = vec![advertised_address];
         let trusted_peers = self.trusted_peers.clone();
         let role = self.role;
@@ -463,48 +484,59 @@ impl NetworkBuilder {
     /// Create the configured transport and start PeerManager.
     /// Return the actual NetworkAddress over which this peer is listening.
     pub fn build(mut self) -> NetworkAddress {
+        use libra_network_address::Protocol::*;
+
         let peer_id = self.peer_id;
-        let supported_protocols = self.supported_protocols();
-        // Build network based on the transport type
+        let protos = self.supported_protocols();
+
         let trusted_peers = self.trusted_peers.clone();
-        match self.transport {
-            TransportType::Memory => {
-                self.build_with_transport(build_memory_transport(peer_id, supported_protocols))
+        let auth_mode = self.auth_mode.take().expect("Authentication Mode not set");
+
+        // formatting the listen address here is a temporary hack until `transport.rs`
+        // gets refactored and returns the fully rendered listen_addr in
+        // `Transport::listen_on()`.
+
+        // would like to do this in `build_with_transport` but ownership is very
+        // tricky here since the private keys aren't cloneable and we don't have
+        // a safe key container yet...
+        let unbound_listen_addr = self.listen_address.clone();
+        let unbound_len = unbound_listen_addr.len();
+        let unbound_listen_addr = append_libranet_protocols(unbound_listen_addr, &auth_mode);
+
+        let bound_listen_addr = match self.listen_address.as_slice() {
+            [Ip4(_), Tcp(_)] | [Ip6(_), Tcp(_)] => match auth_mode {
+                AuthMode::Unauthed => {
+                    self.build_with_transport(build_tcp_transport(peer_id, protos))
+                }
+                AuthMode::ClientOnly(key) => self
+                    .build_with_transport(build_unauthenticated_tcp_noise_transport(key, protos)),
+                AuthMode::Mutual(key) => {
+                    self.build_with_transport(build_tcp_noise_transport(key, trusted_peers, protos))
+                }
+            },
+            [Memory(_)] => {
+                match auth_mode {
+                    AuthMode::Unauthed => {
+                        self.build_with_transport(build_memory_transport(peer_id, protos))
+                    }
+                    AuthMode::ClientOnly(key) => self.build_with_transport(
+                        build_unauthenticated_memory_noise_transport(key, protos),
+                    ),
+                    AuthMode::Mutual(key) => self.build_with_transport(
+                        build_memory_noise_transport(key, trusted_peers, protos),
+                    ),
+                }
             }
-            TransportType::MemoryNoise(ref mut keys) => {
-                let keys = keys.take().expect("Identity keys not set");
-                self.build_with_transport(build_memory_noise_transport(
-                    keys,
-                    trusted_peers,
-                    supported_protocols,
-                ))
-            }
-            TransportType::PermissionlessMemoryNoise(ref mut keys) => {
-                let keys = keys.take().expect("Identity keys not set");
-                self.build_with_transport(build_unauthenticated_memory_noise_transport(
-                    keys,
-                    supported_protocols,
-                ))
-            }
-            TransportType::Tcp => {
-                self.build_with_transport(build_tcp_transport(peer_id, supported_protocols))
-            }
-            TransportType::TcpNoise(ref mut keys) => {
-                let keys = keys.take().expect("Identity keys not set");
-                self.build_with_transport(build_tcp_noise_transport(
-                    keys,
-                    trusted_peers,
-                    supported_protocols,
-                ))
-            }
-            TransportType::PermissionlessTcpNoise(ref mut keys) => {
-                let keys = keys.take().expect("Identity keys not set");
-                self.build_with_transport(build_unauthenticated_tcp_noise_transport(
-                    keys,
-                    supported_protocols,
-                ))
-            }
-        }
+            _ => panic!(
+                "Unsupported listen_address: '{}', expected '/memory/<port>', \
+                 '/ip4/<addr>/tcp/<port>', or '/ip6/<addr>/tcp/<port>'.",
+                self.listen_address
+            ),
+        };
+
+        // do some surgery here...
+        let libranet_protos = &unbound_listen_addr.as_slice()[unbound_len..];
+        bound_listen_addr.extend_from_slice(libranet_protos)
     }
 
     /// Given a transport build and launch PeerManager.
@@ -521,7 +553,7 @@ impl NetworkBuilder {
             self.role,
             // TODO(philiphayes): peer manager should take `Vec<NetworkAddress>`
             // (which could be empty, like in client use case)
-            self.listen_address.expect("listen_address must be set"),
+            self.listen_address,
             self.pm_reqs_rx,
             self.connection_reqs_rx,
             self.upstream_handlers,
@@ -531,8 +563,10 @@ impl NetworkBuilder {
             self.channel_size,
         );
         let listen_addr = peer_mgr.listen_addr().clone();
+
         self.executor.spawn(peer_mgr.start());
         debug!("Started peer manager");
+
         listen_addr
     }
 }

--- a/state-synchronizer/src/tests/integration_tests.rs
+++ b/state-synchronizer/src/tests/integration_tests.rs
@@ -23,7 +23,7 @@ use libra_types::{
     validator_verifier::random_validator_verifier, waypoint::Waypoint,
 };
 use network::{
-    validator_network::network_builder::{AuthMode, NetworkBuilder},
+    validator_network::network_builder::{AuthenticationMode, NetworkBuilder},
     NetworkPublicKeys,
 };
 use rand::{rngs::StdRng, SeedableRng};
@@ -254,7 +254,7 @@ impl SynchronizerEnv {
             addr,
         );
         network_builder
-            .auth_mode(AuthMode::Unauthed)
+            .authentication_mode(AuthenticationMode::Unauthenticated)
             .trusted_peers(trusted_peers)
             .seed_peers(seed_peers)
             .signing_keypair((

--- a/state-synchronizer/src/tests/integration_tests.rs
+++ b/state-synchronizer/src/tests/integration_tests.rs
@@ -250,10 +250,10 @@ impl SynchronizerEnv {
         let mut network_builder = NetworkBuilder::new(
             self.runtime.handle().clone(),
             self.peer_ids[new_peer_idx],
-            addr,
             RoleType::Validator,
         );
         network_builder
+            .listen_address(addr)
             .signing_keypair((
                 self.network_signers[new_peer_idx].clone(),
                 self.public_keys[new_peer_idx]

--- a/state-synchronizer/src/tests/integration_tests.rs
+++ b/state-synchronizer/src/tests/integration_tests.rs
@@ -23,7 +23,7 @@ use libra_types::{
     validator_verifier::random_validator_verifier, waypoint::Waypoint,
 };
 use network::{
-    validator_network::network_builder::{NetworkBuilder, TransportType},
+    validator_network::network_builder::{AuthMode, NetworkBuilder},
     NetworkPublicKeys,
 };
 use rand::{rngs::StdRng, SeedableRng};
@@ -251,18 +251,18 @@ impl SynchronizerEnv {
             self.runtime.handle().clone(),
             self.peer_ids[new_peer_idx],
             RoleType::Validator,
+            addr,
         );
         network_builder
-            .listen_address(addr)
+            .auth_mode(AuthMode::Unauthed)
+            .trusted_peers(trusted_peers)
+            .seed_peers(seed_peers)
             .signing_keypair((
                 self.network_signers[new_peer_idx].clone(),
                 self.public_keys[new_peer_idx]
                     .network_signing_public_key()
                     .clone(),
             ))
-            .trusted_peers(trusted_peers)
-            .seed_peers(seed_peers)
-            .transport(TransportType::Memory)
             .add_connectivity_manager()
             .add_gossip_discovery();
 

--- a/testsuite/generate-format/tests/staged/network.yaml
+++ b/testsuite/generate-format/tests/staged/network.yaml
@@ -103,6 +103,8 @@ Protocol:
     8:
       Handshake:
         NEWTYPE: U8
+    9:
+      PeerIdExchange: UNIT
 ProtocolId:
   ENUM:
     0:

--- a/testsuite/generate-format/tests/staged/network.yaml
+++ b/testsuite/generate-format/tests/staged/network.yaml
@@ -97,7 +97,7 @@ Protocol:
       Memory:
         NEWTYPE: U16
     7:
-      NoiseIk:
+      NoiseIK:
         NEWTYPE:
           TYPENAME: PublicKey
     8:


### PR DESCRIPTION
+ For the main validator and full node network use cases, the noise and
handshake protocols should both be present in the `NetworkAddress`es
throughout the system.

+ The only discrepancy is that `NetworkConfig` currently contains the
"base" network address (e.g., `"/ip6/::1/tcp/6180"`) for both listen and
advertised addresses, which are then rendered into the "prod" address
(e.g., `"/ip6/::1/tcp/6180/ln-noise-ik/<pubkey>/ln-handshake/<version>"`)
just before they're handed to `NetworkBuilder`.

+ It would be cleaner and easier to specify protocol upgrades if the
addresses in configs were always fully rendered. Some future steps in
this direction include (1) modify ops code to always fully render
addresses, (2) configs and network should store a `Vec<NetworkAddress>`
for listen and advertisement, (3) support listening on multiple addrs.

+ With this change, we're now much closer to full noise ik integration,
since the noise pubkey is pushed down all the way to the transport when
dialing.

+ All on-chain network addrs are fully rendered.

+ There are some hacky bits since this PR is an intermediate step in the
overall `Transport` refactor. Specifically, the current `Transport` API
is not amenable to incrementally parsing the `NetworkAddress`.
Consequently, the parsing in this PR is pretty loose though this should
change soon when monolithic Transports are introduced. By "loose parsing"
I mean dialing on a Memory transport with
`/memory/123/ip4/1.2.3.4/dns/foo.example` which is clearly non-sensical
will actually succeed as the Memory transport is only parsing out the
`/memory/123` prefix while the suffix is ignored.
