### PR TITLE
change type_tag_parser to pub

### DIFF
--- a/language/functional-tests/src/config/mod.rs
+++ b/language/functional-tests/src/config/mod.rs
@@ -4,4 +4,4 @@
 pub mod block_metadata;
 pub mod global;
 pub mod transaction;
-mod type_tag_parser;
+pub mod type_tag_parser;


### PR DESCRIPTION
There's pub func `parse_type_tags` in type_tag_parser,
It's useful for developer to parse type tags in their third-party tools



