### PR TITLE
[move-prover] Disable two-state invariants temporarily

### DIFF
--- a/language/move-prover/spec-lang/src/ast.rs
+++ b/language/move-prover/spec-lang/src/ast.rs
@@ -82,16 +82,13 @@ impl ConditionKind {
     /// Returns true if this condition is allowed on a public function declaration.
     pub fn allowed_on_public_fun_decl(&self) -> bool {
         use ConditionKind::*;
-        matches!(
-            self,
-            Requires | RequiresModule | AbortsIf | Ensures | VarUpdate(..)
-        )
+        matches!(self, Requires | RequiresModule | AbortsIf | Ensures)
     }
 
     /// Returns true if this condition is allowed on a private function declaration.
     pub fn allowed_on_private_fun_decl(&self) -> bool {
         use ConditionKind::*;
-        matches!(self, Requires | AbortsIf | Ensures | VarUpdate(..))
+        matches!(self, Requires | AbortsIf | Ensures)
     }
 
     /// Returns true if this condition is allowed in a function body.
@@ -103,10 +100,7 @@ impl ConditionKind {
     /// Returns true if this condition is allowed on a struct.
     pub fn allowed_on_struct(&self) -> bool {
         use ConditionKind::*;
-        matches!(
-            self,
-            Invariant | InvariantUpdate | VarUpdate(..) | VarPack(..) | VarUnpack(..)
-        )
+        matches!(self, Invariant | VarPack(..) | VarUnpack(..))
     }
 
     /// Returns true if this condition is allowed on a module.

--- a/language/move-prover/spec-lang/tests/sources/invariants_err.exp.old
+++ b/language/move-prover/spec-lang/tests/sources/invariants_err.exp.old
@@ -14,6 +14,14 @@ error: `old(..)` expression not allowed in this context
     │               ^^^^^^
     │
 
+error: `old(..old(..)..)` not allowed
+
+    ┌── tests/sources/invariants_err.move:13:26 ───
+    │
+ 13 │     invariant update old(old(x)) > 0;
+    │                          ^^^^^^
+    │
+
 error: data invariants cannot depend on global state (directly or indirectly uses a global spec var or resource storage).
 
     ┌── tests/sources/invariants_err.move:15:5 ───

--- a/language/move-prover/spec-lang/tests/sources/invariants_err.move
+++ b/language/move-prover/spec-lang/tests/sources/invariants_err.move
@@ -10,7 +10,7 @@ module M {
     // Old expression in data invariant
     invariant old(x) > 0;
     // Nested old expression.
-    invariant update old(old(x)) > 0;
+    // invariant update old(old(x)) > 0;
     // Direct dependency from global state
     invariant exists<S>(0x0);
     invariant global<S>(0x0).x == x;

--- a/language/move-prover/spec-lang/tests/sources/invariants_ok.move
+++ b/language/move-prover/spec-lang/tests/sources/invariants_ok.move
@@ -11,7 +11,7 @@ module M {
 
   spec struct S {
     invariant x > 0 == y;
-    invariant update old(x) < x;
+    // invariant update old(x) < x;
   }
 
   spec struct R {

--- a/language/move-prover/spec-lang/tests/sources/schemas_ok.move
+++ b/language/move-prover/spec-lang/tests/sources/schemas_ok.move
@@ -43,7 +43,7 @@ module M {
 
     spec schema InvariantIsEqual<T> {
         x: T;
-        invariant update x == old(x);
+        // invariant update x == old(x);
     }
     struct S<X> { x: X }
     spec struct S {

--- a/language/move-prover/spec-lang/tests/sources/variables_err.exp
+++ b/language/move-prover/spec-lang/tests/sources/variables_err.exp
@@ -1,27 +1,3 @@
-error: spec global `M::ticks` undeclared
-
-    ┌── tests/sources/variables_err.move:11:22 ───
-    │
- 11 │     invariant update ticks = tick + 1;
-    │                      ^^^^^
-    │
-
-error: assignment only allowed in spec var updates
-
-    ┌── tests/sources/variables_err.move:11:22 ───
-    │
- 11 │     invariant update ticks = tick + 1;
-    │                      ^^^^^^^^^^^^^^^^
-    │
-
-error: expected `num` but found `bool` in expression
-
-    ┌── tests/sources/variables_err.move:14:29 ───
-    │
- 14 │     invariant update tick = false;
-    │                             ^^^^^
-    │
-
 error: assignment only allowed in spec var updates
 
     ┌── tests/sources/variables_err.move:17:15 ───

--- a/language/move-prover/spec-lang/tests/sources/variables_err.exp.old
+++ b/language/move-prover/spec-lang/tests/sources/variables_err.exp.old
@@ -1,0 +1,47 @@
+error: spec global `M::ticks` undeclared
+
+    ┌── tests/sources/variables_err.move:11:22 ───
+    │
+ 11 │     invariant update ticks = tick + 1;
+    │                      ^^^^^
+    │
+
+error: assignment only allowed in spec var updates
+
+    ┌── tests/sources/variables_err.move:11:22 ───
+    │
+ 11 │     invariant update ticks = tick + 1;
+    │                      ^^^^^^^^^^^^^^^^
+    │
+
+error: expected `num` but found `bool` in expression
+
+    ┌── tests/sources/variables_err.move:14:29 ───
+    │
+ 14 │     invariant update tick = false;
+    │                             ^^^^^
+    │
+
+error: assignment only allowed in spec var updates
+
+    ┌── tests/sources/variables_err.move:17:15 ───
+    │
+ 17 │     invariant tick = x;
+    │               ^^^^^^^^
+    │
+
+error: expected assignment to spec variable
+
+    ┌── tests/sources/variables_err.move:20:20 ───
+    │
+ 20 │     invariant pack x == 0;
+    │                    ^^^^^^
+    │
+
+error: expected assignment to spec variable
+
+    ┌── tests/sources/variables_err.move:21:22 ───
+    │
+ 21 │     invariant unpack x == 0;
+    │                      ^^^^^^
+    │

--- a/language/move-prover/spec-lang/tests/sources/variables_err.move
+++ b/language/move-prover/spec-lang/tests/sources/variables_err.move
@@ -8,10 +8,10 @@ module M {
     global tick: num;
 
     // Undeclared
-    invariant update ticks = tick + 1;
+    // invariant update ticks = tick + 1;
 
     // Wrong type
-    invariant update tick = false;
+    // invariant update tick = false;
 
     // Cannot have assignment
     invariant tick = x;

--- a/language/move-prover/spec-lang/tests/sources/variables_ok.move
+++ b/language/move-prover/spec-lang/tests/sources/variables_ok.move
@@ -6,7 +6,6 @@ module M {
 
   spec struct S {
     global sum: num;
-    invariant update sum = sum - old(x) + x;
     invariant pack sum = sum + x;
     invariant unpack sum = sum - x;
   }

--- a/language/move-prover/tests/sources/functional/global_vars.exp
+++ b/language/move-prover/tests/sources/functional/global_vars.exp
@@ -1,83 +1,83 @@
 Move prover returns: exiting with boogie verification errors
 error:  A postcondition might not hold on this return path.
 
-     ┌── tests/sources/functional/global_vars.move:119:9 ───
+     ┌── tests/sources/functional/global_vars.move:118:9 ───
      │
- 119 │         ensures sum_of_T == old(sum_of_T) + 2;
+ 118 │         ensures sum_of_T == old(sum_of_T) + 2;
      │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
      │
-     =     at tests/sources/functional/global_vars.move:111:5: combi_incorrect (entry)
-     =     at tests/sources/functional/global_vars.move:113:13: combi_incorrect
-     =     at tests/sources/functional/global_vars.move:114:17: combi_incorrect
+     =     at tests/sources/functional/global_vars.move:110:5: combi_incorrect (entry)
+     =     at tests/sources/functional/global_vars.move:112:13: combi_incorrect
+     =     at tests/sources/functional/global_vars.move:113:17: combi_incorrect
      =         r = <redacted>,
      =         s = <redacted>
-     =     at tests/sources/functional/global_vars.move:115:15: combi_incorrect
+     =     at tests/sources/functional/global_vars.move:114:15: combi_incorrect
      =         s = <redacted>
-     =     at tests/sources/functional/global_vars.move:112:21: combi_incorrect
-     =     at tests/sources/functional/global_vars.move:111:5: combi_incorrect (exit)
+     =     at tests/sources/functional/global_vars.move:111:21: combi_incorrect
+     =     at tests/sources/functional/global_vars.move:110:5: combi_incorrect (exit)
 
 error:  A postcondition might not hold on this return path.
 
-    ┌── tests/sources/functional/global_vars.move:35:9 ───
+    ┌── tests/sources/functional/global_vars.move:34:9 ───
     │
- 35 │         ensures sum_of_T == old(sum_of_T) + 1;
+ 34 │         ensures sum_of_T == old(sum_of_T) + 1;
     │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
     │
-    =     at tests/sources/functional/global_vars.move:31:5: pack_incorrect (entry)
-    =     at tests/sources/functional/global_vars.move:32:9: pack_incorrect
+    =     at tests/sources/functional/global_vars.move:30:5: pack_incorrect (entry)
+    =     at tests/sources/functional/global_vars.move:31:9: pack_incorrect
     =         result = <redacted>
-    =     at tests/sources/functional/global_vars.move:31:5: pack_incorrect (exit)
+    =     at tests/sources/functional/global_vars.move:30:5: pack_incorrect (exit)
 
 error:  A postcondition might not hold on this return path.
 
-    ┌── tests/sources/functional/global_vars.move:58:9 ───
+    ┌── tests/sources/functional/global_vars.move:57:9 ───
     │
- 58 │         ensures sum_of_T == old(sum_of_T);
+ 57 │         ensures sum_of_T == old(sum_of_T);
     │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
     │
-    =     at tests/sources/functional/global_vars.move:53:5: unpack_incorrect (entry)
-    =     at tests/sources/functional/global_vars.move:54:19: unpack_incorrect
+    =     at tests/sources/functional/global_vars.move:52:5: unpack_incorrect (entry)
+    =     at tests/sources/functional/global_vars.move:53:19: unpack_incorrect
     =         t = <redacted>
-    =     at tests/sources/functional/global_vars.move:55:9: unpack_incorrect
+    =     at tests/sources/functional/global_vars.move:54:9: unpack_incorrect
     =         x = <redacted>
-    =     at tests/sources/functional/global_vars.move:53:5: unpack_incorrect (exit)
+    =     at tests/sources/functional/global_vars.move:52:5: unpack_incorrect (exit)
     =         result = <redacted>
 
 error:  A postcondition might not hold on this return path.
 
-     ┌── tests/sources/functional/global_vars.move:154:9 ───
+     ┌── tests/sources/functional/global_vars.move:153:9 ───
      │
- 154 │         ensures sum_of_S == old(sum_of_S) + 1;
+ 153 │         ensures sum_of_S == old(sum_of_S) + 1;
      │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
      │
-     =     at tests/sources/functional/global_vars.move:147:5: update_S_incorrect (entry)
-     =     at tests/sources/functional/global_vars.move:148:13: update_S_incorrect
-     =     at tests/sources/functional/global_vars.move:149:17: update_S_incorrect
+     =     at tests/sources/functional/global_vars.move:146:5: update_S_incorrect (entry)
+     =     at tests/sources/functional/global_vars.move:147:13: update_S_incorrect
+     =     at tests/sources/functional/global_vars.move:148:17: update_S_incorrect
      =         r = <redacted>,
      =         s = <redacted>
-     =     at tests/sources/functional/global_vars.move:150:15: update_S_incorrect
+     =     at tests/sources/functional/global_vars.move:149:15: update_S_incorrect
      =         r = <redacted>
-     =     at tests/sources/functional/global_vars.move:151:9: update_S_incorrect
-     =     at tests/sources/functional/global_vars.move:147:5: update_S_incorrect (exit)
+     =     at tests/sources/functional/global_vars.move:150:9: update_S_incorrect
+     =     at tests/sources/functional/global_vars.move:146:5: update_S_incorrect (exit)
      =         result = <redacted>
 
 error:  A postcondition might not hold on this return path.
 
-    ┌── tests/sources/functional/global_vars.move:92:9 ───
+    ┌── tests/sources/functional/global_vars.move:91:9 ───
     │
- 92 │         ensures sum_of_T == old(sum_of_T);
+ 91 │         ensures sum_of_T == old(sum_of_T);
     │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
     │
-    =     at tests/sources/functional/global_vars.move:85:5: update_incorrect (entry)
-    =     at tests/sources/functional/global_vars.move:86:13: update_incorrect
-    =     at tests/sources/functional/global_vars.move:87:37: update_incorrect
+    =     at tests/sources/functional/global_vars.move:84:5: update_incorrect (entry)
+    =     at tests/sources/functional/global_vars.move:85:13: update_incorrect
+    =     at tests/sources/functional/global_vars.move:86:37: update_incorrect
     =         t = <redacted>
-    =     at tests/sources/functional/global_vars.move:67:5: update_valid_still_mutating (entry)
-    =     at tests/sources/functional/global_vars.move:68:19: update_valid_still_mutating
+    =     at tests/sources/functional/global_vars.move:66:5: update_valid_still_mutating (entry)
+    =     at tests/sources/functional/global_vars.move:67:19: update_valid_still_mutating
     =         t = <redacted>,
     =         t = <redacted>
-    =     at tests/sources/functional/global_vars.move:67:5: update_valid_still_mutating (exit)
+    =     at tests/sources/functional/global_vars.move:66:5: update_valid_still_mutating (exit)
+    =     at tests/sources/functional/global_vars.move:86:9: update_incorrect
     =     at tests/sources/functional/global_vars.move:87:9: update_incorrect
-    =     at tests/sources/functional/global_vars.move:88:9: update_incorrect
-    =     at tests/sources/functional/global_vars.move:85:5: update_incorrect (exit)
+    =     at tests/sources/functional/global_vars.move:84:5: update_incorrect (exit)
     =         result = <redacted>

--- a/language/move-prover/tests/sources/functional/global_vars.move
+++ b/language/move-prover/tests/sources/functional/global_vars.move
@@ -13,7 +13,6 @@ module TestGlobalVars {
     spec struct T {
       invariant pack sum_of_T = sum_of_T + i;
       invariant unpack sum_of_T = sum_of_T - i;
-      invariant update sum_of_T = sum_of_T - old(i) + i;
     }
 
 

--- a/language/move-prover/tests/sources/functional/invariants.exp
+++ b/language/move-prover/tests/sources/functional/invariants.exp
@@ -10,73 +10,6 @@ error:  This assertion might not hold.
 
 error:  This assertion might not hold.
 
-    ┌── tests/sources/functional/invariants.move:19:9 ───
-    │
- 19 │         invariant update x <= old(x) && tautology();
-    │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-    │
-    =     at tests/sources/functional/invariants.move:64:5: invalid_R_update (entry)
-    =     at tests/sources/functional/invariants.move:65:13: invalid_R_update
-    =     at tests/sources/functional/invariants.move:66:17: invalid_R_update
-    =         r = <redacted>,
-    =         t = <redacted>
-    =     at tests/sources/functional/invariants.move:67:20: invalid_R_update
-    =         r = <redacted>
-
-error:  This assertion might not hold.
-
-    ┌── tests/sources/functional/invariants.move:19:9 ───
-    │
- 19 │         invariant update x <= old(x) && tautology();
-    │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-    │
-    =     at tests/sources/functional/invariants.move:93:5: invalid_R_update_branching (entry)
-    =     at tests/sources/functional/invariants.move:94:13: invalid_R_update_branching
-    =         b = <redacted>,
-    =         t1 = <redacted>
-    =     at tests/sources/functional/invariants.move:95:24: invalid_R_update_branching
-    =         t2 = <redacted>
-    =     at tests/sources/functional/invariants.move:97:13: invalid_R_update_branching
-    =     at tests/sources/functional/invariants.move:102:13: invalid_R_update_branching
-    =     at tests/sources/functional/invariants.move:104:20: invalid_R_update_branching
-    =         r = <redacted>,
-    =         r = <redacted>
-    =     at tests/sources/functional/invariants.move:105:10: invalid_R_update_branching
-
-error:  This assertion might not hold.
-
-    ┌── tests/sources/functional/invariants.move:19:9 ───
-    │
- 19 │         invariant update x <= old(x) && tautology();
-    │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-    │
-    =     at tests/sources/functional/invariants.move:84:5: invalid_R_update_indirectly (entry)
-    =     at tests/sources/functional/invariants.move:85:13: invalid_R_update_indirectly
-    =     at tests/sources/functional/invariants.move:86:28: invalid_R_update_indirectly
-    =         t = <redacted>
-    =     at tests/sources/functional/invariants.move:89:5: update_helper (entry)
-    =     at tests/sources/functional/invariants.move:90:9: update_helper
-    =         r = <redacted>,
-    =         r = <redacted>
-    =     at tests/sources/functional/invariants.move:86:9: invalid_R_update_indirectly
-
-error:  This assertion might not hold.
-
-    ┌── tests/sources/functional/invariants.move:19:9 ───
-    │
- 19 │         invariant update x <= old(x) && tautology();
-    │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-    │
-    =     at tests/sources/functional/invariants.move:74:5: invalid_R_update_ref (entry)
-    =     at tests/sources/functional/invariants.move:75:13: invalid_R_update_ref
-    =     at tests/sources/functional/invariants.move:76:22: invalid_R_update_ref
-    =         r = <redacted>,
-    =         t = <redacted>
-    =     at tests/sources/functional/invariants.move:77:14: invalid_R_update_ref
-    =         r = <redacted>
-
-error:  This assertion might not hold.
-
     ┌── tests/sources/functional/invariants.move:16:9 ───
     │
  16 │         invariant greater_one(x);
@@ -90,34 +23,6 @@ error:  This assertion might not hold.
     =     at tests/sources/functional/invariants.move:115:26: lifetime_invalid_R
     =         x_ref = <redacted>
     =     at tests/sources/functional/invariants.move:116:18: lifetime_invalid_R
-    =         r_ref = <redacted>,
-    =         x_ref = <redacted>
-
-error:  This assertion might not hold.
-
-    ┌── tests/sources/functional/invariants.move:19:9 ───
-    │
- 19 │         invariant update x <= old(x) && tautology();
-    │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-    │
-    =     at tests/sources/functional/invariants.move:125:5: lifetime_invalid_R_2 (entry)
-    =     at tests/sources/functional/invariants.move:126:13: lifetime_invalid_R_2
-    =     at tests/sources/functional/invariants.move:127:21: lifetime_invalid_R_2
-    =         r = <redacted>,
-    =         r_ref = <redacted>
-    =     at tests/sources/functional/invariants.move:128:26: lifetime_invalid_R_2
-    =         x_ref = <redacted>
-    =     at tests/sources/functional/invariants.move:129:18: lifetime_invalid_R_2
-    =         r_ref = <redacted>,
-    =         x_ref = <redacted>
-    =     at tests/sources/functional/invariants.move:130:18: lifetime_invalid_R_2
-    =         r_ref = <redacted>,
-    =         x_ref = <redacted>
-    =     at tests/sources/functional/invariants.move:132:17: lifetime_invalid_R_2
-    =         r_ref = <redacted>
-    =     at tests/sources/functional/invariants.move:133:22: lifetime_invalid_R_2
-    =         x_ref = <redacted>
-    =     at tests/sources/functional/invariants.move:134:18: lifetime_invalid_R_2
     =         r_ref = <redacted>,
     =         x_ref = <redacted>
 

--- a/language/move-prover/tests/sources/functional/invariants.exp.old
+++ b/language/move-prover/tests/sources/functional/invariants.exp.old
@@ -1,0 +1,149 @@
+Move prover returns: exiting with boogie verification errors
+error:  This assertion might not hold.
+
+    ┌── tests/sources/functional/invariants.move:16:9 ───
+    │
+ 16 │         invariant greater_one(x);
+    │         ^^^^^^^^^^^^^^^^^^^^^^^^^
+    │
+    =     at tests/sources/functional/invariants.move:42:5: invalid_R_pack (entry)
+
+error:  This assertion might not hold.
+
+    ┌── tests/sources/functional/invariants.move:19:9 ───
+    │
+ 19 │         invariant update x <= old(x) && tautology();
+    │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    │
+    =     at tests/sources/functional/invariants.move:64:5: invalid_R_update (entry)
+    =     at tests/sources/functional/invariants.move:65:13: invalid_R_update
+    =     at tests/sources/functional/invariants.move:66:17: invalid_R_update
+    =         r = <redacted>,
+    =         t = <redacted>
+    =     at tests/sources/functional/invariants.move:67:20: invalid_R_update
+    =         r = <redacted>
+
+error:  This assertion might not hold.
+
+    ┌── tests/sources/functional/invariants.move:19:9 ───
+    │
+ 19 │         invariant update x <= old(x) && tautology();
+    │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    │
+    =     at tests/sources/functional/invariants.move:93:5: invalid_R_update_branching (entry)
+    =     at tests/sources/functional/invariants.move:94:13: invalid_R_update_branching
+    =         b = <redacted>,
+    =         t1 = <redacted>
+    =     at tests/sources/functional/invariants.move:95:24: invalid_R_update_branching
+    =         t2 = <redacted>
+    =     at tests/sources/functional/invariants.move:97:13: invalid_R_update_branching
+    =     at tests/sources/functional/invariants.move:102:13: invalid_R_update_branching
+    =     at tests/sources/functional/invariants.move:104:20: invalid_R_update_branching
+    =         r = <redacted>,
+    =         r = <redacted>
+    =     at tests/sources/functional/invariants.move:105:10: invalid_R_update_branching
+
+error:  This assertion might not hold.
+
+    ┌── tests/sources/functional/invariants.move:19:9 ───
+    │
+ 19 │         invariant update x <= old(x) && tautology();
+    │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    │
+    =     at tests/sources/functional/invariants.move:84:5: invalid_R_update_indirectly (entry)
+    =     at tests/sources/functional/invariants.move:85:13: invalid_R_update_indirectly
+    =     at tests/sources/functional/invariants.move:86:28: invalid_R_update_indirectly
+    =         t = <redacted>
+    =     at tests/sources/functional/invariants.move:89:5: update_helper (entry)
+    =     at tests/sources/functional/invariants.move:90:9: update_helper
+    =         r = <redacted>,
+    =         r = <redacted>
+    =     at tests/sources/functional/invariants.move:86:9: invalid_R_update_indirectly
+
+error:  This assertion might not hold.
+
+    ┌── tests/sources/functional/invariants.move:19:9 ───
+    │
+ 19 │         invariant update x <= old(x) && tautology();
+    │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    │
+    =     at tests/sources/functional/invariants.move:74:5: invalid_R_update_ref (entry)
+    =     at tests/sources/functional/invariants.move:75:13: invalid_R_update_ref
+    =     at tests/sources/functional/invariants.move:76:22: invalid_R_update_ref
+    =         r = <redacted>,
+    =         t = <redacted>
+    =     at tests/sources/functional/invariants.move:77:14: invalid_R_update_ref
+    =         r = <redacted>
+
+error:  This assertion might not hold.
+
+    ┌── tests/sources/functional/invariants.move:16:9 ───
+    │
+ 16 │         invariant greater_one(x);
+    │         ^^^^^^^^^^^^^^^^^^^^^^^^^
+    │
+    =     at tests/sources/functional/invariants.move:112:5: lifetime_invalid_R (entry)
+    =     at tests/sources/functional/invariants.move:113:13: lifetime_invalid_R
+    =     at tests/sources/functional/invariants.move:114:21: lifetime_invalid_R
+    =         r = <redacted>,
+    =         r_ref = <redacted>
+    =     at tests/sources/functional/invariants.move:115:26: lifetime_invalid_R
+    =         x_ref = <redacted>
+    =     at tests/sources/functional/invariants.move:116:18: lifetime_invalid_R
+    =         r_ref = <redacted>,
+    =         x_ref = <redacted>
+
+error:  This assertion might not hold.
+
+    ┌── tests/sources/functional/invariants.move:19:9 ───
+    │
+ 19 │         invariant update x <= old(x) && tautology();
+    │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    │
+    =     at tests/sources/functional/invariants.move:125:5: lifetime_invalid_R_2 (entry)
+    =     at tests/sources/functional/invariants.move:126:13: lifetime_invalid_R_2
+    =     at tests/sources/functional/invariants.move:127:21: lifetime_invalid_R_2
+    =         r = <redacted>,
+    =         r_ref = <redacted>
+    =     at tests/sources/functional/invariants.move:128:26: lifetime_invalid_R_2
+    =         x_ref = <redacted>
+    =     at tests/sources/functional/invariants.move:129:18: lifetime_invalid_R_2
+    =         r_ref = <redacted>,
+    =         x_ref = <redacted>
+    =     at tests/sources/functional/invariants.move:130:18: lifetime_invalid_R_2
+    =         r_ref = <redacted>,
+    =         x_ref = <redacted>
+    =     at tests/sources/functional/invariants.move:132:17: lifetime_invalid_R_2
+    =         r_ref = <redacted>
+    =     at tests/sources/functional/invariants.move:133:22: lifetime_invalid_R_2
+    =         x_ref = <redacted>
+    =     at tests/sources/functional/invariants.move:134:18: lifetime_invalid_R_2
+    =         r_ref = <redacted>,
+    =         x_ref = <redacted>
+
+error:  This assertion might not hold.
+
+     ┌── tests/sources/functional/invariants.move:150:9 ───
+     │
+ 150 │         invariant y > 1;
+     │         ^^^^^^^^^^^^^^^^
+     │
+     =     at tests/sources/functional/invariants.move:153:5: lifetime_invalid_S_branching (entry)
+     =     at tests/sources/functional/invariants.move:154:11: lifetime_invalid_S_branching
+     =         cond = <redacted>
+     =     at tests/sources/functional/invariants.move:155:21: lifetime_invalid_S_branching
+     =         a = <redacted>,
+     =         b = <redacted>
+     =     at tests/sources/functional/invariants.move:156:19: lifetime_invalid_S_branching
+     =         a_ref = <redacted>
+     =     at tests/sources/functional/invariants.move:157:19: lifetime_invalid_S_branching
+     =         b_ref = <redacted>
+     =     at tests/sources/functional/invariants.move:158:23: lifetime_invalid_S_branching
+     =         $t5 = <redacted>,
+     =         x_ref = <redacted>
+     =     at tests/sources/functional/invariants.move:160:11: lifetime_invalid_S_branching
+     =     at tests/sources/functional/invariants.move:163:11: lifetime_invalid_S_branching
+     =         a_ref = <redacted>,
+     =         b_ref = <redacted>,
+     =         $t5 = <redacted>,
+     =         x_ref = <redacted>

--- a/language/move-prover/tests/sources/functional/invariants.move
+++ b/language/move-prover/tests/sources/functional/invariants.move
@@ -16,7 +16,7 @@ module TestInvariants {
         invariant greater_one(x);
 
         // When we update via a reference, the new value must be smaller or equal the old one.
-        invariant update x <= old(x) && tautology();
+        // invariant update x <= old(x) && tautology();
     }
 
     spec module {

--- a/language/move-prover/tests/sources/functional/marketcap.exp
+++ b/language/move-prover/tests/sources/functional/marketcap.exp
@@ -6,11 +6,11 @@ error:  A postcondition might not hold on this return path.
  16 │         invariant global<MarketCap>(0xA550C18).total_value == sum_of_coins;
     │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
     │
-    =     at tests/sources/functional/marketcap.move:49:6: deposit_invalid (entry)
-    =     at tests/sources/functional/marketcap.move:50:18: deposit_invalid
+    =     at tests/sources/functional/marketcap.move:48:6: deposit_invalid (entry)
+    =     at tests/sources/functional/marketcap.move:49:18: deposit_invalid
     =         coin_ref = <redacted>,
     =         check = <redacted>,
     =         value = <redacted>
-    =     at tests/sources/functional/marketcap.move:51:27: deposit_invalid
+    =     at tests/sources/functional/marketcap.move:50:27: deposit_invalid
     =         coin_ref = <redacted>
-    =     at tests/sources/functional/marketcap.move:49:6: deposit_invalid (exit)
+    =     at tests/sources/functional/marketcap.move:48:6: deposit_invalid (exit)

--- a/language/move-prover/tests/sources/functional/marketcap.move
+++ b/language/move-prover/tests/sources/functional/marketcap.move
@@ -25,7 +25,6 @@ module TestMarketCap {
         // maintain true sum_of_coins
         invariant pack sum_of_coins = sum_of_coins + value;
         invariant unpack sum_of_coins = sum_of_coins - value;
-        invariant update sum_of_coins = sum_of_coins - old(value) + value;
     }
 
     resource struct MarketCap {

--- a/language/move-prover/tests/sources/functional/marketcap_as_schema.exp
+++ b/language/move-prover/tests/sources/functional/marketcap_as_schema.exp
@@ -6,11 +6,11 @@ error:  A postcondition might not hold on this return path.
  16 │         invariant module global<MarketCap>(0xA550C18).total_value == sum_of_coins<X>;
     │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
     │
-    =     at tests/sources/functional/marketcap_as_schema.move:59:6: deposit_invalid (entry)
-    =     at tests/sources/functional/marketcap_as_schema.move:60:18: deposit_invalid
+    =     at tests/sources/functional/marketcap_as_schema.move:58:6: deposit_invalid (entry)
+    =     at tests/sources/functional/marketcap_as_schema.move:59:18: deposit_invalid
     =         coin_ref = <redacted>,
     =         check = <redacted>,
     =         value = <redacted>
-    =     at tests/sources/functional/marketcap_as_schema.move:61:27: deposit_invalid
+    =     at tests/sources/functional/marketcap_as_schema.move:60:27: deposit_invalid
     =         coin_ref = <redacted>
-    =     at tests/sources/functional/marketcap_as_schema.move:59:6: deposit_invalid (exit)
+    =     at tests/sources/functional/marketcap_as_schema.move:58:6: deposit_invalid (exit)

--- a/language/move-prover/tests/sources/functional/marketcap_as_schema.move
+++ b/language/move-prover/tests/sources/functional/marketcap_as_schema.move
@@ -28,7 +28,6 @@ module TestMarketCapWithSchemas {
         value: num;
         invariant pack sum_of_coins<X> = sum_of_coins<X> + value;
         invariant unpack sum_of_coins<X> = sum_of_coins<X> - value;
-        invariant update sum_of_coins<X> = sum_of_coins<X> - old(value) + value;
     }
 
 

--- a/language/move-prover/tests/sources/functional/marketcap_generic.exp
+++ b/language/move-prover/tests/sources/functional/marketcap_generic.exp
@@ -1,16 +1,16 @@
 Move prover returns: exiting with boogie verification errors
 error:  A postcondition might not hold on this return path.
 
-    ┌── tests/sources/functional/marketcap_generic.move:69:10 ───
+    ┌── tests/sources/functional/marketcap_generic.move:68:10 ───
     │
- 69 │          ensures sum_of_coins_invariant<X>();
+ 68 │          ensures sum_of_coins_invariant<X>();
     │          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
     │
-    =     at tests/sources/functional/marketcap_generic.move:62:6: deposit_invalid (entry)
-    =     at tests/sources/functional/marketcap_generic.move:63:18: deposit_invalid
+    =     at tests/sources/functional/marketcap_generic.move:61:6: deposit_invalid (entry)
+    =     at tests/sources/functional/marketcap_generic.move:62:18: deposit_invalid
     =         coin_ref = <redacted>,
     =         check = <redacted>,
     =         value = <redacted>
-    =     at tests/sources/functional/marketcap_generic.move:64:27: deposit_invalid
+    =     at tests/sources/functional/marketcap_generic.move:63:27: deposit_invalid
     =         coin_ref = <redacted>
-    =     at tests/sources/functional/marketcap_generic.move:62:6: deposit_invalid (exit)
+    =     at tests/sources/functional/marketcap_generic.move:61:6: deposit_invalid (exit)

--- a/language/move-prover/tests/sources/functional/marketcap_generic.move
+++ b/language/move-prover/tests/sources/functional/marketcap_generic.move
@@ -32,7 +32,6 @@ module TestMarketCapGeneric {
         // maintain true sum_of_coins
         invariant pack sum_of_coins<X> = sum_of_coins<X> + value;
         invariant unpack sum_of_coins<X> = sum_of_coins<X> - value;
-        invariant update sum_of_coins<X> = sum_of_coins<X> - old(value) + value;
     }
 
     resource struct MarketCap<X> {

--- a/language/move-prover/tests/sources/functional/nested_invariants.move
+++ b/language/move-prover/tests/sources/functional/nested_invariants.move
@@ -16,7 +16,7 @@ module TestNestedInvariants {
         invariant x > 0;
 
         // When we update via a reference, the new value must be smaller or equal the old one.
-        invariant update x <= old(x);
+        // invariant update x <= old(x);
     }
 
     struct Outer {
@@ -32,7 +32,7 @@ module TestNestedInvariants {
         invariant n.x < y;
 
         // Update invariant for own field.
-        invariant update y <= old(y);
+        // invariant update y <= old(y);
     }
 
     fun new(): Outer {

--- a/language/move-prover/tests/sources/stdlib/modules/libra.move
+++ b/language/move-prover/tests/sources/stdlib/modules/libra.move
@@ -24,7 +24,6 @@ module Libra {
     spec struct T {
         invariant pack sum_of_token_values<Token> = sum_of_token_values<Token> + value;
         invariant unpack sum_of_token_values<Token> = sum_of_token_values<Token> - value;
-        invariant update sum_of_token_values<Token> = sum_of_token_values<Token> - old(value) + value;
     }
 
     // A singleton resource that grants access to `Libra::mint`. Only the Association has one.


### PR DESCRIPTION
## Motivation

This PR temporarily disables two-state invariants in the test cases to make it easier to land 
the new memory model. Specifically:
1. Two-state invariants in invariants.move and nested-invariants.move have been commented out. invariants.exp is updated and the old file checked in as invariants.exp.old.  nested-invariants.exp did not change because the two-state invariants inside it did not result in errors.
2. In all other files, the use of two-state invariants was redundant since it was already covered by invariant pack/unpack.  Deletion resulted in shifted line numbers and .exp files were updated.
3. Disabled VarUpdate and InvariantUpdate in annotations in spec-lang/src/ast.rs. Consequently, commented out "invariant update" in the unit tests there.  Two .exp files changed.  I checked in their old version: invariants_err.exp.old, variables_err.exp.old.

After landing the new memory model, we will revisit two-state invariants.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?

Yes.

## Test Plan

Existing tests.

## Related PRs

