### PR TITLE
[move-prover] Fix bound for serialization.

### DIFF
--- a/language/move-prover/src/prelude.bpl
+++ b/language/move-prover/src/prelude.bpl
@@ -1089,7 +1089,7 @@ axiom (forall v1, v2: Value ::  IsEqual($LCS_serialize_core(v1), $LCS_serialize_
 {{#if (eq serialize_bound 0)}}
 axiom (forall v: Value :: ( var r := $LCS_serialize_core(v); $IsValidU8Vector(r) && $vlen(r) > 0 ));
 {{else}}
-axiom (forall v: Value :: ( var r := $LCS_serialize_core(v); $IsValidU8Vector(r) && $vlen(r) > 0 && $vlen(r) < {{serialize_bound}} ));
+axiom (forall v: Value :: ( var r := $LCS_serialize_core(v); $IsValidU8Vector(r) && $vlen(r) > 0 && $vlen(r) <= {{serialize_bound}} ));
 {{/if}}
 
 procedure $LCS_to_bytes(ta: TypeValue, v: Value) returns (res: Value);


### PR DESCRIPTION
Minor fix, it should be `<= bound` instead of `< bound`.

## Motivation

Bug fix.


### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

cargo test

## Related PRs

NA
