### PR TITLE
[tf] fix log paths for nonpersistent logrotation

### DIFF
--- a/terraform/templates/ec2_user_data.sh
+++ b/terraform/templates/ec2_user_data.sh
@@ -13,6 +13,9 @@ if [ -e /dev/nvme1n1 ]; then
 	mkdir /data
 	mount /data
 
+	export log_path="/data/libra/${host_log_path}"
+	export structlog_path="/data/libra/${host_structlog_path}"
+
 	# non-persistent storage is managed by Docker under data-root
 	if ! ${persistent} ; then
 		cat >> /etc/fstab <<-EOF
@@ -20,6 +23,8 @@ if [ -e /dev/nvme1n1 ]; then
 		EOF
 		mkdir -p /var/lib/docker/volumes
 		mount /var/lib/docker/volumes
+		export log_path="/data/*/_data/${host_log_path}"
+		export structlog_path="/data/*/_data/${host_structlog_path}"
 
 		# give some helptul tips
 		cat > /data/README <<-EOF
@@ -52,7 +57,7 @@ EOF
 {% if enable_logrotate %}
 cat > /etc/logrotate.d/libra <<EOF
 hourly
-${host_log_path} {
+${log_path} {
 	maxsize 500M
 	rotate 100
 	compress
@@ -60,7 +65,7 @@ ${host_log_path} {
 	copytruncate
 }
 
-${host_structlog_path} {
+${structlog_path} {
 	maxsize 500M
 	rotate 100
 	compress

--- a/terraform/validators.tf
+++ b/terraform/validators.tf
@@ -131,8 +131,8 @@ data "template_file" "user_data" {
   vars = {
     persistent          = var.persist_libra_data
     ecs_cluster         = aws_ecs_cluster.testnet.name
-    host_log_path       = "/data/libra/libra.log"
-    host_structlog_path = "/data/libra/libra_structlog.log"
+    host_log_path       = "libra.log"
+    host_structlog_path = "libra_structlog.log"
     enable_logrotate    = var.log_to_file || var.enable_logstash
   }
 }

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -156,14 +156,15 @@ variable "log_to_file" {
 }
 
 variable "log_path" {
+  description = "Log path relative to data mount point"
   type    = string
-  default = "/opt/libra/data/libra.log"
+  default = "libra.log"
 }
 
 variable "structlog_path" {
-  description = "Structured log path"
+  description = "Structured log path relative to data mount point"
   type        = string
-  default     = "/opt/libra/data/libra_structlog.log"
+  default     = "libra_structlog.log"
 }
 
 variable "enable_logstash" {


### PR DESCRIPTION
<!--
Thank you for sending a PR. We appreciate you spending time to help improve the Libra project.

The project is undergoing daily changes. Pull Requests will be reviewed and responded to as time permits.
-->

## Motivation

Fixes log rotation on docker-managed /data mounts for non-persistent storage. Also changes the `log_path` and `structlog_path` tf variables to be relative to the data mount point for each container, which can be `/data` for persistent storage, or `/data/<container_id>/_data` for non-persistent storage.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

Changed the logstash configs on a validator in dev and ran logstash debug mode, which looks like it handles everything we need. 

```
[root:validator@ip-10-0-0-120 /etc/logrotate.d]$ cat libra
hourly
"/data/*/_data/libra.log" {
maxsize 500M
rotate 100
compress
delaycompress
copytruncate
}

"/data/*/_data/libra_structlog.log" {
maxsize 500M
rotate 100
compress
delaycompress
copytruncate
}


```

```
[root:validator@ip-10-0-0-120 /etc/logrotate.d]$ logrotate -d -f libra
reading config file libra
Allocating hash table for state file, size 15360 B

Handling 2 logs

rotating pattern: "/data/*/_data/libra.log"  forced from command line (100 rotations)
empty log files are rotated, log files >= 524288000 are rotated earlier, old logs are removed
considering log /data/ecs-dev-validator-0-518-libra-data-dac69bdda7f1df8fe201/_data/libra.log
  log needs rotating
rotating log /data/ecs-dev-validator-0-518-libra-data-dac69bdda7f1df8fe201/_data/libra.log, log->rotateCount is 100
dateext suffix '-2020051317'
glob pattern '-[0-9][0-9][0-9][0-9][0-9][0-9][0-9][0-9][0-9][0-9]'
previous log /data/ecs-dev-validator-0-518-libra-data-dac69bdda7f1df8fe201/_data/libra.log.1 does not exist
renaming /data/ecs-dev-validator-0-518-libra-data-dac69bdda7f1df8fe201/_data/libra.log.100.gz to /data/ecs-dev-validator-0-518-libra-data-dac69bdda7f1df8fe201/_data/libra.log.101.gz (rotatecount 100, logstart 1, i 100),
renaming /data/ecs-dev-validator-0-518-libra-data-dac69bdda7f1df8fe201/_data/libra.log.99.gz to /data/ecs-dev-validator-0-518-libra-data-dac69bdda7f1df8fe201/_data/libra.log.100.gz (rotatecount 100, logstart 1, i 99),
renaming /data/ecs-dev-validator-0-518-libra-data-dac69bdda7f1df8fe201/_data/libra.log.98.gz to /data/ecs-dev-validator-0-518-libra-data-dac69bdda7f1df8fe201/_data/libra.log.99.gz (rotatecount 100, logstart 1, i 98),
renaming /data/ecs-dev-validator-0-518-libra-data-dac69bdda7f1df8fe201/_data/libra.log.97.gz to /data/ecs-dev-validator-0-518-libra-data-dac69bdda7f1df8fe201/_data/libra.log.98.gz (rotatecount 100, logstart 1, i 97),
renaming /data/ecs-dev-validator-0-518-libra-data-dac69bdda7f1df8fe201/_data/libra.log.96.gz to /data/ecs-dev-validator-0-518-libra-data-dac69bdda7f1df8fe201/_data/libra.log.97.gz (rotatecount 100, logstart 1, i 96),
renaming /data/ecs-dev-validator-0-518-libra-data-dac69bdda7f1df8fe201/_data/libra.log.95.gz to /data/ecs-dev-validator-0-518-libra-data-dac69bdda7f1df8fe201/_data/libra.log.96.gz (rotatecount 100, logstart 1, i 95)
```

## Related PRs

(If this PR adds or changes functionality, please take some time to update the docs at https://github.com/libra/website, and link to your PR here.)
