### PR TITLE
[language] move type tag parser from functional_tests into move_core_types

### DIFF
--- a/language/functional-tests/src/config/mod.rs
+++ b/language/functional-tests/src/config/mod.rs
@@ -4,4 +4,3 @@
 pub mod block_metadata;
 pub mod global;
 pub mod transaction;
-pub mod type_tag_parser;

--- a/language/functional-tests/src/config/transaction.rs
+++ b/language/functional-tests/src/config/transaction.rs
@@ -1,15 +1,13 @@
 // Copyright (c) The Libra Core Contributors
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::{
-    common::strip,
-    config::{global::Config as GlobalConfig, type_tag_parser::parse_type_tags},
-    errors::*,
-    evaluator::Stage,
-};
+use crate::{common::strip, config::global::Config as GlobalConfig, errors::*, evaluator::Stage};
 use language_e2e_tests::account::Account;
-use libra_types::transaction::{parse_as_transaction_argument, TransactionArgument};
-use move_core_types::language_storage::TypeTag;
+use move_core_types::{
+    language_storage::TypeTag,
+    parser::parse_type_tags,
+    transaction_argument::{parse_as_transaction_argument, TransactionArgument},
+};
 use std::{collections::BTreeSet, str::FromStr, time::Duration};
 
 /// A partially parsed transaction argument.

--- a/language/move-core/types/src/lib.rs
+++ b/language/move-core/types/src/lib.rs
@@ -8,6 +8,7 @@ pub mod gas_schedule;
 pub mod identifier;
 pub mod language_storage;
 pub mod move_resource;
+pub mod parser;
 #[cfg(any(test, feature = "fuzzing"))]
 pub mod proptest_types;
 pub mod transaction_argument;

--- a/language/move-core/types/src/parser.rs
+++ b/language/move-core/types/src/parser.rs
@@ -1,12 +1,12 @@
 // Copyright (c) The Libra Core Contributors
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::errors::*;
-use libra_types::account_address::AccountAddress;
-use move_core_types::{
+use crate::{
+    account_address::AccountAddress,
     identifier::Identifier,
     language_storage::{StructTag, TypeTag},
 };
+use anyhow::{bail, Result};
 use std::iter::Peekable;
 
 #[derive(Eq, PartialEq, Debug)]


### PR DESCRIPTION
## Summary
This moves the type tag parser from functional_tests into move_core_types so that it can be reused for parsing transaction arguments. (Coming in a separate PR.)

## Test Plan
cargo test