### PR TITLE
[fuzzing] adding storage structured fuzzer

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -18,7 +18,7 @@ dependencies = [
  "libra-types 0.1.0",
  "libra-workspace-hack 0.1.0",
  "mirai-annotations 1.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "proptest 0.9.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "proptest 0.9.6 (git+https://github.com/mimoo/proptest.git?branch=fuzzing)",
  "rand 0.7.3 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -284,7 +284,7 @@ dependencies = [
  "libra-types 0.1.0",
  "libra-workspace-hack 0.1.0",
  "libradb 0.1.0",
- "proptest 0.9.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "proptest 0.9.6 (git+https://github.com/mimoo/proptest.git?branch=fuzzing)",
  "rand 0.7.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "reqwest 0.10.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "storage-client 0.1.0",
@@ -524,7 +524,7 @@ dependencies = [
  "libra-workspace-hack 0.1.0",
  "move-core-types 0.1.0",
  "petgraph 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "proptest 0.9.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "proptest 0.9.6 (git+https://github.com/mimoo/proptest.git?branch=fuzzing)",
  "stdlib 0.1.0",
  "vm 0.1.0",
 ]
@@ -704,7 +704,7 @@ dependencies = [
  "libra-wallet 0.1.0",
  "libra-workspace-hack 0.1.0",
  "num-traits 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
- "proptest 0.9.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "proptest 0.9.6 (git+https://github.com/mimoo/proptest.git?branch=fuzzing)",
  "reqwest 0.10.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "resource-viewer 0.1.0",
  "rust_decimal 1.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -883,7 +883,7 @@ dependencies = [
  "num-derive 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "num-traits 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "once_cell 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "proptest 0.9.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "proptest 0.9.6 (git+https://github.com/mimoo/proptest.git?branch=fuzzing)",
  "rand 0.7.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "safety-rules 0.1.0",
  "schemadb 0.1.0",
@@ -911,7 +911,7 @@ dependencies = [
  "libra-types 0.1.0",
  "libra-workspace-hack 0.1.0",
  "mirai-annotations 1.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "proptest 0.9.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "proptest 0.9.6 (git+https://github.com/mimoo/proptest.git?branch=fuzzing)",
  "serde 1.0.110 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -1348,7 +1348,7 @@ dependencies = [
  "libradb 0.1.0",
  "move-core-types 0.1.0",
  "once_cell 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "proptest 0.9.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "proptest 0.9.6 (git+https://github.com/mimoo/proptest.git?branch=fuzzing)",
  "rand 0.7.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "scratchpad 0.1.0",
  "serde_json 1.0.53 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1627,7 +1627,7 @@ dependencies = [
  "libra-workspace-hack 0.1.0",
  "move-core-types 0.1.0",
  "network 0.1.0",
- "proptest 0.9.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "proptest 0.9.6 (git+https://github.com/mimoo/proptest.git?branch=fuzzing)",
  "rand 0.7.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.110 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde-reflection 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1728,7 +1728,7 @@ dependencies = [
  "libra-prost-ext 0.1.0",
  "libra-types 0.1.0",
  "libra-workspace-hack 0.1.0",
- "proptest 0.9.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "proptest 0.9.6 (git+https://github.com/mimoo/proptest.git?branch=fuzzing)",
  "prost 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "prost-build 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -1973,7 +1973,7 @@ dependencies = [
  "libra-proptest-helpers 0.1.0",
  "libra-types 0.1.0",
  "libra-workspace-hack 0.1.0",
- "proptest 0.9.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "proptest 0.9.6 (git+https://github.com/mimoo/proptest.git?branch=fuzzing)",
  "vm 0.1.0",
 ]
 
@@ -2077,7 +2077,7 @@ dependencies = [
  "mirai-annotations 1.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "num-derive 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "num-traits 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
- "proptest 0.9.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "proptest 0.9.6 (git+https://github.com/mimoo/proptest.git?branch=fuzzing)",
  "proptest-derive 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.7.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.110 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2194,7 +2194,7 @@ dependencies = [
  "move-vm-runtime 0.1.0",
  "move-vm-state 0.1.0",
  "move-vm-types 0.1.0",
- "proptest 0.9.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "proptest 0.9.6 (git+https://github.com/mimoo/proptest.git?branch=fuzzing)",
  "vm 0.1.0",
 ]
 
@@ -2219,7 +2219,7 @@ dependencies = [
  "move-vm-state 0.1.0",
  "move-vm-types 0.1.0",
  "once_cell 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "proptest 0.9.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "proptest 0.9.6 (git+https://github.com/mimoo/proptest.git?branch=fuzzing)",
  "proptest-derive 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.7.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "stdlib 0.1.0",
@@ -2268,7 +2268,7 @@ dependencies = [
  "libra-canonical-serialization 0.1.0",
  "libra-proptest-helpers 0.1.0",
  "libra-workspace-hack 0.1.0",
- "proptest 0.9.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "proptest 0.9.6 (git+https://github.com/mimoo/proptest.git?branch=fuzzing)",
  "serde 1.0.110 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -2278,7 +2278,7 @@ version = "0.1.0"
 dependencies = [
  "criterion 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "libra-workspace-hack 0.1.0",
- "proptest 0.9.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "proptest 0.9.6 (git+https://github.com/mimoo/proptest.git?branch=fuzzing)",
  "proptest-derive 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.110 (registry+https://github.com/rust-lang/crates.io-index)",
  "thiserror 1.0.17 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2327,7 +2327,7 @@ dependencies = [
  "libra-workspace-hack 0.1.0",
  "mirai-annotations 1.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "once_cell 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "proptest 0.9.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "proptest 0.9.6 (git+https://github.com/mimoo/proptest.git?branch=fuzzing)",
  "proptest-derive 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.7.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand_core 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2398,12 +2398,14 @@ dependencies = [
  "libra-prost-ext 0.1.0",
  "libra-types 0.1.0",
  "libra-workspace-hack 0.1.0",
+ "libradb 0.1.0",
  "move-vm-types 0.1.0",
  "network 0.1.0",
  "noise 0.1.0",
  "once_cell 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "proptest 0.9.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "proptest 0.9.6 (git+https://github.com/mimoo/proptest.git?branch=fuzzing)",
  "prost 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand 0.7.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "rusty-fork 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "sha-1 0.8.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "stats_alloc 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2451,7 +2453,7 @@ dependencies = [
  "libradb 0.1.0",
  "move-core-types 0.1.0",
  "once_cell 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "proptest 0.9.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "proptest 0.9.6 (git+https://github.com/mimoo/proptest.git?branch=fuzzing)",
  "reqwest 0.10.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.110 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.53 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2614,7 +2616,7 @@ dependencies = [
  "libra-canonical-serialization 0.1.0",
  "libra-crypto 0.1.0",
  "libra-workspace-hack 0.1.0",
- "proptest 0.9.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "proptest 0.9.6 (git+https://github.com/mimoo/proptest.git?branch=fuzzing)",
  "proptest-derive 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.110 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_bytes 0.11.4 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2626,7 +2628,7 @@ name = "libra-nibble"
 version = "0.1.0"
 dependencies = [
  "libra-workspace-hack 0.1.0",
- "proptest 0.9.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "proptest 0.9.6 (git+https://github.com/mimoo/proptest.git?branch=fuzzing)",
  "serde 1.0.110 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -2673,7 +2675,7 @@ version = "0.1.0"
 dependencies = [
  "crossbeam 0.7.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "libra-workspace-hack 0.1.0",
- "proptest 0.9.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "proptest 0.9.6 (git+https://github.com/mimoo/proptest.git?branch=fuzzing)",
  "proptest-derive 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -2848,7 +2850,7 @@ dependencies = [
  "mirai-annotations 1.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "move-core-types 0.1.0",
  "once_cell 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "proptest 0.9.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "proptest 0.9.6 (git+https://github.com/mimoo/proptest.git?branch=fuzzing)",
  "proptest-derive 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "radix_trie 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.7.3 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2899,7 +2901,7 @@ dependencies = [
  "move-vm-state 0.1.0",
  "move-vm-types 0.1.0",
  "once_cell 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "proptest 0.9.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "proptest 0.9.6 (git+https://github.com/mimoo/proptest.git?branch=fuzzing)",
  "rayon 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.110 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.53 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2966,7 +2968,7 @@ dependencies = [
  "num-traits 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "num-variants 0.1.0",
  "once_cell 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "proptest 0.9.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "proptest 0.9.6 (git+https://github.com/mimoo/proptest.git?branch=fuzzing)",
  "proptest-derive 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.7.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "schemadb 0.1.0",
@@ -3188,7 +3190,7 @@ dependencies = [
  "libra-workspace-hack 0.1.0",
  "mirai-annotations 1.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "once_cell 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "proptest 0.9.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "proptest 0.9.6 (git+https://github.com/mimoo/proptest.git?branch=fuzzing)",
  "proptest-derive 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.7.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "ref-cast 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -3323,7 +3325,7 @@ dependencies = [
  "move-vm-state 0.1.0",
  "move-vm-types 0.1.0",
  "once_cell 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "proptest 0.9.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "proptest 0.9.6 (git+https://github.com/mimoo/proptest.git?branch=fuzzing)",
  "vm 0.1.0",
 ]
 
@@ -3353,7 +3355,7 @@ dependencies = [
  "mirai-annotations 1.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "move-core-types 0.1.0",
  "once_cell 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "proptest 0.9.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "proptest 0.9.6 (git+https://github.com/mimoo/proptest.git?branch=fuzzing)",
  "serde 1.0.110 (registry+https://github.com/rust-lang/crates.io-index)",
  "sha2 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "vm 0.1.0",
@@ -3454,7 +3456,7 @@ dependencies = [
  "num-variants 0.1.0",
  "once_cell 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "pin-project 0.4.16 (registry+https://github.com/rust-lang/crates.io-index)",
- "proptest 0.9.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "proptest 0.9.6 (git+https://github.com/mimoo/proptest.git?branch=fuzzing)",
  "rand 0.7.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.110 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_bytes 0.11.4 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -3501,7 +3503,7 @@ dependencies = [
  "memsocket 0.1.0",
  "netcore 0.1.0",
  "once_cell 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "proptest 0.9.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "proptest 0.9.6 (git+https://github.com/mimoo/proptest.git?branch=fuzzing)",
  "rand 0.7.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand_core 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "snow 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -4006,7 +4008,7 @@ dependencies = [
 [[package]]
 name = "proptest"
 version = "0.9.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
+source = "git+https://github.com/mimoo/proptest.git?branch=fuzzing#6c8b41b44d4bd97f77776b73220f6fe3c03edbf1"
 dependencies = [
  "bit-set 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "bitflags 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -4014,9 +4016,9 @@ dependencies = [
  "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "num-traits 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "quick-error 1.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "rand 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "rand_chacha 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "rand_xorshift 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand 0.7.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand_chacha 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand_xorshift 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "regex-syntax 0.6.17 (registry+https://github.com/rust-lang/crates.io-index)",
  "rusty-fork 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "tempfile 3.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -4286,6 +4288,14 @@ version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "rand_core 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "rand_xorshift"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "rand_core 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -4748,7 +4758,7 @@ dependencies = [
  "libra-temppath 0.1.0",
  "libra-workspace-hack 0.1.0",
  "once_cell 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "proptest 0.9.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "proptest 0.9.6 (git+https://github.com/mimoo/proptest.git?branch=fuzzing)",
  "rocksdb 0.14.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "tempfile 3.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -4771,7 +4781,7 @@ dependencies = [
  "libra-crypto 0.1.0",
  "libra-types 0.1.0",
  "libra-workspace-hack 0.1.0",
- "proptest 0.9.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "proptest 0.9.6 (git+https://github.com/mimoo/proptest.git?branch=fuzzing)",
 ]
 
 [[package]]
@@ -4918,7 +4928,7 @@ name = "serializer-tests"
 version = "0.1.0"
 dependencies = [
  "libra-workspace-hack 0.1.0",
- "proptest 0.9.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "proptest 0.9.6 (git+https://github.com/mimoo/proptest.git?branch=fuzzing)",
  "proptest-derive 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "vm 0.1.0",
 ]
@@ -5227,7 +5237,7 @@ dependencies = [
  "libra-prost-ext 0.1.0",
  "libra-types 0.1.0",
  "libra-workspace-hack 0.1.0",
- "proptest 0.9.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "proptest 0.9.6 (git+https://github.com/mimoo/proptest.git?branch=fuzzing)",
  "proptest-derive 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "prost 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.110 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -5255,7 +5265,7 @@ dependencies = [
  "libra-types 0.1.0",
  "libra-workspace-hack 0.1.0",
  "libradb 0.1.0",
- "proptest 0.9.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "proptest 0.9.6 (git+https://github.com/mimoo/proptest.git?branch=fuzzing)",
  "rand 0.7.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "simple-storage-client 0.1.0",
  "storage-client 0.1.0",
@@ -6183,7 +6193,7 @@ dependencies = [
  "move-core-types 0.1.0",
  "num-variants 0.1.0",
  "once_cell 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "proptest 0.9.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "proptest 0.9.6 (git+https://github.com/mimoo/proptest.git?branch=fuzzing)",
  "proptest-derive 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "ref-cast 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.53 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -6209,7 +6219,7 @@ dependencies = [
  "move-vm-state 0.1.0",
  "move-vm-types 0.1.0",
  "once_cell 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "proptest 0.9.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "proptest 0.9.6 (git+https://github.com/mimoo/proptest.git?branch=fuzzing)",
  "proptest-derive 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.7.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "stdlib 0.1.0",
@@ -6811,7 +6821,7 @@ dependencies = [
 "checksum proc-macro2 0.4.30 (registry+https://github.com/rust-lang/crates.io-index)" = "cf3d2011ab5c909338f7887f4fc896d35932e29146c12c8d01da6b22a80ba759"
 "checksum proc-macro2 1.0.12 (registry+https://github.com/rust-lang/crates.io-index)" = "8872cf6f48eee44265156c111456a700ab3483686b3f96df4cf5481c89157319"
 "checksum prometheus 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)" = "b0575e258dab62268e7236d7307caa38848acbda7ec7ab87bd9093791e999d20"
-"checksum proptest 0.9.6 (registry+https://github.com/rust-lang/crates.io-index)" = "01c477819b845fe023d33583ebf10c9f62518c8d79a0960ba5c36d6ac8a55a5b"
+"checksum proptest 0.9.6 (git+https://github.com/mimoo/proptest.git?branch=fuzzing)" = "<none>"
 "checksum proptest-derive 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "d31edb17edac73aeacc947bd61462dda15220584268896a58e12f053d767f15b"
 "checksum prost 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)" = "ce49aefe0a6144a45de32927c77bd2859a5f7677b55f220ae5b744e87389c212"
 "checksum prost-build 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)" = "02b10678c913ecbd69350e8535c3aef91a8676c0773fc1d7b95cdd196d7f2f26"
@@ -6840,6 +6850,7 @@ dependencies = [
 "checksum rand_pcg 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "abf9b09b01790cfe0364f52bf32995ea3c39f4d2dd011eac241d2914146d0b44"
 "checksum rand_pcg 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "16abd0c1b639e9eb4d7c50c0b8100b0d0f849be2349829c740fe8e6eb4816429"
 "checksum rand_xorshift 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "cbf7e9e623549b0e21f6e97cf8ecf247c1a8fd2e8a992ae265314300b2455d5c"
+"checksum rand_xorshift 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "77d416b86801d23dde1aa643023b775c3a462efc0ed96443add11546cdf1dca8"
 "checksum rayon 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "db6ce3297f9c85e16621bb8cca38a06779ffc31bb8184e1be4bed2be4678a098"
 "checksum rayon-core 1.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "08a89b46efaf957e52b18062fb2f4660f8b8a4dde1807ca002690868ef2c85a9"
 "checksum rdrand 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "678054eb77286b51581ba43620cc911abf02758c91f93f479767aed0f90458b2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -146,3 +146,6 @@ lto = 'thin'
 
 [profile.bench]
 debug = true
+
+[patch.crates-io]
+proptest = { git = "https://github.com/mimoo/proptest.git", branch = "fuzzing" }

--- a/storage/libradb/src/lib.rs
+++ b/storage/libradb/src/lib.rs
@@ -26,8 +26,12 @@ mod state_store;
 mod system_store;
 mod transaction_store;
 
-#[cfg(test)]
+#[cfg(any(test, feature = "fuzzing"))]
+#[allow(dead_code)]
 mod libradb_test;
+
+#[cfg(feature = "fuzzing")]
+pub use libradb_test::test_save_blocks_impl;
 
 use crate::{
     backup::BackupHandler,

--- a/storage/libradb/src/libradb_test.rs
+++ b/storage/libradb/src/libradb_test.rs
@@ -2,13 +2,16 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use super::*;
+#[allow(unused_imports)]
 use crate::{
     schema::jellyfish_merkle_node::JellyfishMerkleNodeSchema,
     test_helper::{arb_blocks_to_commit, arb_mock_genesis},
 };
+#[allow(unused_imports)]
 use jellyfish_merkle::node_type::{Node, NodeKey};
 use libra_crypto::hash::CryptoHash;
 use libra_temppath::TempPath;
+#[allow(unused_imports)]
 use libra_types::{
     account_config::AccountResource, contract_event::ContractEvent, ledger_info::LedgerInfo,
     proof::SparseMerkleLeafNode, vm_error::StatusCode,
@@ -29,7 +32,7 @@ fn verify_epochs(db: &LibraDB, ledger_infos_with_sigs: &[LedgerInfoWithSignature
     );
 }
 
-fn test_save_blocks_impl(input: Vec<(Vec<TransactionToCommit>, LedgerInfoWithSignatures)>) {
+pub fn test_save_blocks_impl(input: Vec<(Vec<TransactionToCommit>, LedgerInfoWithSignatures)>) {
     let tmp_dir = TempPath::new();
     let db = LibraDB::new_for_test(&tmp_dir);
 

--- a/testsuite/libra-fuzzer/Cargo.toml
+++ b/testsuite/libra-fuzzer/Cargo.toml
@@ -19,6 +19,7 @@ prost = "0.6"
 rusty-fork = { version = "0.2.2", default-features = false }
 sha-1 = { version = "0.8.1", default-features = false }
 structopt = "0.3.14"
+rand = "0.7.3"
 
 lcs = { path = "../../common/lcs", version = "0.1.0", package = "libra-canonical-serialization" }
 libra-proptest-helpers = { path = "../../common/proptest-helpers", version = "0.1.0" }
@@ -35,6 +36,7 @@ move-vm-types = { path = "../../language/move-vm/types", version = "0.1.0", feat
 network = { path = "../../network", version = "0.1.0", features = ["fuzzing"] }
 noise = { path = "../../network/noise", features = ["fuzzing"]}
 vm = { path = "../../language/vm", version = "0.1.0", features = ["fuzzing"] }
+libradb = { path = "../../storage/libradb", version = "0.1.0", features = ["fuzzing"] }
 
 [dev-dependencies]
 rusty-fork = "0.2.2"

--- a/testsuite/libra-fuzzer/src/fuzz_targets.rs
+++ b/testsuite/libra-fuzzer/src/fuzz_targets.rs
@@ -65,21 +65,23 @@ mod network_noise_initiator;
 mod network_noise_responder;
 mod signed_transaction;
 mod sparse_merkle_proof;
+mod storage_save_blocks;
 mod vm_value;
 
 static ALL_TARGETS: Lazy<BTreeMap<&'static str, Box<dyn FuzzTargetImpl>>> = Lazy::new(|| {
     let targets: Vec<Box<dyn FuzzTargetImpl>> = vec![
         // List fuzz targets here in this format.
         Box::new(compiled_module::CompiledModuleTarget::default()),
-        Box::new(signed_transaction::SignedTransactionTarget::default()),
-        Box::new(inner_signed_transaction::SignedTransactionTarget::default()),
-        Box::new(sparse_merkle_proof::SparseMerkleProofTarget::default()),
-        Box::new(vm_value::ValueTarget::default()),
         Box::new(consensus_proposal::ConsensusProposal::default()),
-        Box::new(json_rpc_service::JsonRpcSubmitTransactionRequest::default()),
         Box::new(inbound_rpc_protocol::RpcInboundRequest::default()),
+        Box::new(inner_signed_transaction::SignedTransactionTarget::default()),
+        Box::new(json_rpc_service::JsonRpcSubmitTransactionRequest::default()),
         Box::new(network_noise_initiator::NetworkNoiseInitiator::default()),
         Box::new(network_noise_responder::NetworkNoiseResponder::default()),
+        Box::new(signed_transaction::SignedTransactionTarget::default()),
+        Box::new(sparse_merkle_proof::SparseMerkleProofTarget::default()),
+        Box::new(storage_save_blocks::StorageSaveBlocks::default()),
+        Box::new(vm_value::ValueTarget::default()),
     ];
     targets
         .into_iter()

--- a/testsuite/libra-fuzzer/src/fuzz_targets/storage_save_blocks.rs
+++ b/testsuite/libra-fuzzer/src/fuzz_targets/storage_save_blocks.rs
@@ -1,0 +1,48 @@
+// Copyright (c) The Libra Core Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::FuzzTargetImpl;
+use libra_proptest_helpers::ValueGenerator;
+use libradb::{test_helper::arb_blocks_to_commit, test_save_blocks_impl};
+use proptest::{
+    strategy::{Strategy, ValueTree},
+    test_runner::{self, TestRunner},
+};
+use rand::RngCore;
+
+#[derive(Clone, Debug, Default)]
+pub struct StorageSaveBlocks;
+
+impl FuzzTargetImpl for StorageSaveBlocks {
+    fn name(&self) -> &'static str {
+        module_name!()
+    }
+
+    fn description(&self) -> &'static str {
+        "Storage save blocks"
+    }
+
+    fn generate(&self, _idx: usize, _gen: &mut ValueGenerator) -> Option<Vec<u8>> {
+        let mut output = vec![0u8; 4096];
+        let mut rng = rand::thread_rng();
+        rng.fill_bytes(&mut output);
+        Some(output)
+    }
+
+    fn fuzz(&self, data: &[u8]) {
+        let passthrough_rng =
+            test_runner::TestRng::from_seed(test_runner::RngAlgorithm::PassThrough, &data);
+
+        let config = test_runner::Config::default();
+        let mut runner = TestRunner::new_with_rng(config, passthrough_rng);
+
+        let strategy = arb_blocks_to_commit();
+        let strategy_tree = match strategy.new_tree(&mut runner) {
+            Ok(x) => x,
+            Err(_) => return,
+        };
+        let data = strategy_tree.current();
+
+        test_save_blocks_impl(data);
+    }
+}


### PR DESCRIPTION
This PR adds a new structured fuzzer for storage.
Meaning we can now fuzz functions that expect a struct as input (as opposed to a bytearray).

The way it works is that the fuzzer gives the function a random string of bytes,
and the function pretends that the random bytearray is the ouptut of an RNG it can use to construct the struct.
This is called a "passthrough" RNG and we use the proptest library to build such structs from random data.

The current behavior of a passthrough RNG (in the proptest library we depend on)
is to crash if the input is not large enough to build the struct.
This is not ideal, so to make it work the PR also patches proptest to make pass-through RNGs return 0s after they depleted the input given to them.