### PR TITLE
[tf] hotfix logrotate for nonpersistent

### DIFF
--- a/terraform/templates/ec2_user_data.sh
+++ b/terraform/templates/ec2_user_data.sh
@@ -57,7 +57,7 @@ EOF
 {% if enable_logrotate %}
 cat > /etc/logrotate.d/libra <<EOF
 hourly
-${log_path} {
+$log_path {
 	maxsize 500M
 	rotate 100
 	compress
@@ -65,7 +65,7 @@ ${log_path} {
 	copytruncate
 }
 
-${structlog_path} {
+$structlog_path {
 	maxsize 500M
 	rotate 100
 	compress

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -156,15 +156,14 @@ variable "log_to_file" {
 }
 
 variable "log_path" {
-  description = "Log path relative to data mount point"
   type    = string
-  default = "libra.log"
+  default = "/opt/libra/data/libra.log"
 }
 
 variable "structlog_path" {
-  description = "Structured log path relative to data mount point"
+  description = "Structured log path"
   type        = string
-  default     = "libra_structlog.log"
+  default     = "/opt/libra/data/libra_structlog.log"
 }
 
 variable "enable_logstash" {


### PR DESCRIPTION
<!--
Thank you for sending a PR. We appreciate you spending time to help improve the Libra project.

The project is undergoing daily changes. Pull Requests will be reviewed and responded to as time permits.
-->

## Motivation

Hotfix for nonpersistent logrotate from earlier today. Fixes an issue with tf variable interpolation and log path.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

tf apply and ssh:

```
[ec2-user:validator@ip-10-0-0-61 ~]$ ls /data/ecs-rustielin-validator-0-38-libra-data-94f995aef18ecae8ab01/_data/
common/              libra.log            libra_structlog.log
```

after redeploying validators ecs tasks, we have two volumes:

```

[ec2-user:validator@ip-10-0-0-61 ~]$ ls /data
ecs-rustielin-validator-0-38-libra-data-94f995aef18ecae8ab01  ecs-rustielin-validator-0-38-libra-data-bed4cbc3d8dff2f21a00  lost+found  README

[ec2-user:validator@ip-10-0-0-61 ~]$ ls /data/ecs-rustielin-validator-0-38-libra-data-bed4cbc3d8dff2f21a00/_data/
common  libra.log  libra_structlog.log
```

force a log rotate:

```
[ec2-user:validator@ip-10-0-0-61 ~]$ sudo logrotate -f /etc/logrotate.d/libra
[ec2-user:validator@ip-10-0-0-61 ~]$ ls /data/ecs-rustielin-validator-0-38-libra-data-bed4cbc3d8dff2f21a00/_data/
common  libra.log  libra.log.1  libra_structlog.log  libra_structlog.log.1
```

## Related PRs

Fixes https://github.com/libra/libra/pull/3864