### PR TITLE
[management] Improve test framework

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2720,7 +2720,6 @@ dependencies = [
  "serde 1.0.110 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.53 (registry+https://github.com/rust-lang/crates.io-index)",
  "thiserror 1.0.17 (registry+https://github.com/rust-lang/crates.io-index)",
- "toml 0.5.6 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]

--- a/config/management/Cargo.toml
+++ b/config/management/Cargo.toml
@@ -28,3 +28,6 @@ vm-genesis = { path = "../../language/tools/vm-genesis", version = "0.1.0" }
 
 [dev-dependencies]
 libra-temppath = { path = "../../common/temppath", version = "0.1.0" }
+
+[features]
+testing = ["libra-secure-storage/testing"]

--- a/config/management/src/genesis.rs
+++ b/config/management/src/genesis.rs
@@ -1,12 +1,7 @@
 // Copyright (c) The Libra Core Contributors
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::{
-    error::Error,
-    layout::Layout,
-    management_constants::{COMMON_NS, LAYOUT, VALIDATOR_CONFIG},
-    SingleBackend,
-};
+use crate::{error::Error, layout::Layout, SingleBackend};
 use libra_crypto::ed25519::Ed25519PublicKey;
 use libra_global_constants::{ASSOCIATION_KEY, OPERATOR_KEY};
 use libra_secure_storage::Storage;
@@ -62,11 +57,11 @@ impl Genesis {
         let mut common_config = self.backend.backend.clone();
         common_config
             .parameters
-            .insert("namespace".into(), COMMON_NS.into());
+            .insert("namespace".into(), crate::constants::COMMON_NS.into());
         let common: Box<dyn Storage> = common_config.try_into()?;
 
         let layout = common
-            .get(LAYOUT)
+            .get(crate::constants::LAYOUT)
             .map_err(|e| Error::RemoteStorageReadError(e.to_string()))?
             .value
             .string()
@@ -92,7 +87,7 @@ impl Genesis {
                 .map_err(|e| Error::RemoteStorageReadError(e.to_string()))?;
 
             let txn = validator
-                .get(VALIDATOR_CONFIG)
+                .get(crate::constants::VALIDATOR_CONFIG)
                 .map_err(|e| Error::RemoteStorageReadError(e.to_string()))?
                 .value;
             let txn = txn.transaction().unwrap();

--- a/config/management/src/layout.rs
+++ b/config/management/src/layout.rs
@@ -1,7 +1,7 @@
 // Copyright (c) The Libra Core Contributors
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::{error::Error, management_constants::LAYOUT, SingleBackend};
+use crate::{error::Error, SingleBackend};
 use libra_secure_storage::{Storage, Value};
 use serde::{Deserialize, Serialize};
 use std::{
@@ -15,7 +15,7 @@ use structopt::StructOpt;
 /// Layout defines the set of roles to identities within genesis. In practice, these identities
 /// will map to distinct namespaces where the expected data should be stored in the deterministic
 /// location as defined within this tool.
-#[derive(Debug, Deserialize, Serialize)]
+#[derive(Debug, Default, Deserialize, Serialize)]
 pub struct Layout {
     pub operators: Vec<String>,
     pub owners: Vec<String>,
@@ -33,6 +33,10 @@ impl Layout {
 
     pub fn parse(contents: &str) -> Result<Self, Error> {
         toml::from_str(&contents).map_err(|e| Error::UnexpectedError(e.to_string()))
+    }
+
+    pub fn to_toml(&self) -> Result<String, Error> {
+        toml::to_string(&self).map_err(|e| Error::UnexpectedError(e.to_string()))
     }
 }
 
@@ -53,7 +57,7 @@ pub struct SetLayout {
 impl SetLayout {
     pub fn execute(self) -> Result<Layout, Error> {
         let layout = Layout::from_disk(&self.path)?;
-        let data = toml::to_string(&layout).map_err(|e| Error::UnexpectedError(e.to_string()))?;
+        let data = layout.to_toml()?;
 
         let mut remote: Box<dyn Storage> = self.backend.backend.try_into()?;
         if !remote.available() {
@@ -62,7 +66,7 @@ impl SetLayout {
 
         let value = Value::String(data);
         remote
-            .set(LAYOUT, value)
+            .set(crate::constants::LAYOUT, value)
             .map_err(|e| Error::RemoteStorageWriteError(e.to_string()))?;
 
         Ok(layout)

--- a/config/management/src/lib.rs
+++ b/config/management/src/lib.rs
@@ -20,7 +20,7 @@ use libra_types::{transaction::Transaction, waypoint::Waypoint};
 use std::{convert::TryInto, fmt::Write, str::FromStr};
 use structopt::StructOpt;
 
-pub mod management_constants {
+pub mod constants {
     pub const COMMON_NS: &str = "common";
     pub const LAYOUT: &str = "layout";
     pub const VALIDATOR_CONFIG: &str = "validator_config";
@@ -308,7 +308,6 @@ pub struct SingleBackend {
 #[cfg(test)]
 pub mod tests {
     use super::*;
-    use crate::management_constants::{COMMON_NS, LAYOUT, VALIDATOR_CONFIG};
     use libra_network_address::NetworkAddress;
     use libra_secure_storage::{Policy, Value, VaultStorage};
     use libra_types::account_address::AccountAddress;
@@ -334,7 +333,7 @@ pub mod tests {
         // Step 1) Define and upload the layout specifying which identities have which roles. This
         // is uplaoded to the common namespace.
 
-        let mut common = default_storage(COMMON_NS.into());
+        let mut common = default_storage(constants::COMMON_NS.into());
         common.reset_and_clear().unwrap();
 
         // Note: owners are irrelevant currently
@@ -351,7 +350,7 @@ pub mod tests {
             .unwrap();
         file.sync_all().unwrap();
 
-        set_layout(temppath.path().to_str().unwrap(), COMMON_NS).unwrap();
+        set_layout(temppath.path().to_str().unwrap(), crate::constants::COMMON_NS).unwrap();
 
         // Step 2) Upload the association key:
 
@@ -411,7 +410,7 @@ pub mod tests {
             .unwrap();
         file.sync_all().unwrap();
         set_layout(temppath.path().to_str().unwrap(), namespace).unwrap();
-        let stored_layout = storage.get(LAYOUT).unwrap().value.string().unwrap();
+        let stored_layout = storage.get(constants::LAYOUT).unwrap().value.string().unwrap();
         assert_eq!(layout_text, stored_layout);
     }
 
@@ -435,7 +434,7 @@ pub mod tests {
         )
         .unwrap();
 
-        let remote_txn = remote.get(VALIDATOR_CONFIG).unwrap().value;
+        let remote_txn = remote.get(constants::VALIDATOR_CONFIG).unwrap().value;
         let remote_txn = remote_txn.transaction().unwrap();
 
         assert_eq!(local_txn, remote_txn);

--- a/config/management/src/secure_backend.rs
+++ b/config/management/src/secure_backend.rs
@@ -75,6 +75,7 @@ impl TryInto<config::SecureBackend> for SecureBackend {
                     .remove("path")
                     .ok_or_else(|| Error::BackendParsingError("missing path".into()))?;
                 config.path = PathBuf::from(path);
+                config.namespace = self.parameters.remove("namespace");
                 config::SecureBackend::OnDiskStorage(config)
             }
             MEMORY => config::SecureBackend::InMemoryStorage,

--- a/config/management/src/storage_helper.rs
+++ b/config/management/src/storage_helper.rs
@@ -1,0 +1,212 @@
+// Copyright (c) The Libra Core Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::{error::Error, Command};
+use libra_crypto::ed25519::Ed25519PublicKey;
+use libra_global_constants::{
+    ASSOCIATION_KEY, CONSENSUS_KEY, EPOCH, FULLNODE_NETWORK_KEY, LAST_VOTED_ROUND, OPERATOR_KEY,
+    OWNER_KEY, PREFERRED_ROUND, VALIDATOR_NETWORK_KEY, WAYPOINT,
+};
+use libra_network_address::NetworkAddress;
+use libra_secure_storage::{NamespacedStorage, OnDiskStorage, Policy, Storage, Value};
+use libra_types::{account_address::AccountAddress, transaction::Transaction};
+use std::fs::File;
+use structopt::StructOpt;
+
+pub struct StorageHelper {
+    temppath: libra_temppath::TempPath,
+}
+
+impl StorageHelper {
+    pub fn new() -> Self {
+        let temppath = libra_temppath::TempPath::new();
+        temppath.create_as_file().unwrap();
+        File::create(temppath.path()).unwrap();
+        Self { temppath }
+    }
+
+    pub fn storage(&self, namespace: String) -> Box<dyn Storage> {
+        let storage = OnDiskStorage::new(self.temppath.path().to_path_buf());
+        Box::new(NamespacedStorage::new(storage, namespace))
+    }
+
+    pub fn path_string(&self) -> &str {
+        self.temppath.path().to_str().unwrap()
+    }
+
+    pub fn initialize(&self, namespace: String) {
+        let policy = Policy::public();
+        let mut storage = self.storage(namespace);
+
+        storage.create_key(ASSOCIATION_KEY, &policy).unwrap();
+        storage.create_key(CONSENSUS_KEY, &policy).unwrap();
+        storage.create_key(FULLNODE_NETWORK_KEY, &policy).unwrap();
+        storage.create_key(OWNER_KEY, &policy).unwrap();
+        storage.create_key(OPERATOR_KEY, &policy).unwrap();
+        storage.create_key(VALIDATOR_NETWORK_KEY, &policy).unwrap();
+
+        storage.set(EPOCH, Value::U64(0)).unwrap();
+        storage.set(LAST_VOTED_ROUND, Value::U64(0)).unwrap();
+        storage.set(PREFERRED_ROUND, Value::U64(0)).unwrap();
+        storage.set(WAYPOINT, Value::String("".into())).unwrap();
+    }
+
+    pub fn association_key(
+        &self,
+        local_ns: &str,
+        remote_ns: &str,
+    ) -> Result<Ed25519PublicKey, Error> {
+        let args = format!(
+            "
+                management
+                association-key
+                --local backend={backend};\
+                    path={path};\
+                    namespace={local_ns}
+                --remote backend={backend};\
+                    path={path};\
+                    namespace={remote_ns}\
+            ",
+            backend = crate::secure_backend::DISK,
+            path = self.path_string(),
+            local_ns = local_ns,
+            remote_ns = remote_ns,
+        );
+
+        let command = Command::from_iter(args.split_whitespace());
+        command.association_key()
+    }
+
+    pub fn genesis(&self) -> Result<Transaction, Error> {
+        let args = format!(
+            "
+                management
+                genesis
+                --backend backend={backend};\
+                    path={path}
+            ",
+            backend = crate::secure_backend::DISK,
+            path = self.path_string(),
+        );
+
+        let command = Command::from_iter(args.split_whitespace());
+        command.genesis()
+    }
+
+    pub fn operator_key(&self, local_ns: &str, remote_ns: &str) -> Result<Ed25519PublicKey, Error> {
+        let args = format!(
+            "
+                management
+                operator-key
+                --local backend={backend};\
+                    path={path};\
+                    namespace={local_ns}
+                --remote backend={backend};\
+                    path={path};\
+                    namespace={remote_ns}\
+            ",
+            backend = crate::secure_backend::DISK,
+            path = self.path_string(),
+            local_ns = local_ns,
+            remote_ns = remote_ns,
+        );
+
+        let command = Command::from_iter(args.split_whitespace());
+        command.operator_key()
+    }
+
+    pub fn owner_key(&self, local_ns: &str, remote_ns: &str) -> Result<Ed25519PublicKey, Error> {
+        let args = format!(
+            "
+                management
+                owner-key
+                --local backend={backend};\
+                    path={path};\
+                    namespace={local_ns}
+                --remote backend={backend};\
+                    path={path};\
+                    namespace={remote_ns}\
+            ",
+            backend = crate::secure_backend::DISK,
+            path = self.path_string(),
+            local_ns = local_ns,
+            remote_ns = remote_ns,
+        );
+
+        let command = Command::from_iter(args.split_whitespace());
+        command.owner_key()
+    }
+
+    pub fn set_layout(&self, path: &str, namespace: &str) -> Result<crate::layout::Layout, Error> {
+        let args = format!(
+            "
+                validator_config
+                set-layout
+                --path {path}
+                --backend backend={backend};\
+                    path={storage_path};\
+                    namespace={ns}
+            ",
+            path = path,
+            backend = crate::secure_backend::DISK,
+            storage_path = self.path_string(),
+            ns = namespace,
+        );
+
+        let command = Command::from_iter(args.split_whitespace());
+        command.set_layout()
+    }
+
+    pub fn validator_config(
+        &self,
+        owner_address: AccountAddress,
+        validator_address: NetworkAddress,
+        fullnode_address: NetworkAddress,
+        local_ns: &str,
+        remote_ns: &str,
+    ) -> Result<Transaction, Error> {
+        let args = format!(
+            "
+                management
+                validator-config
+                --owner-address {owner_address}
+                --validator-address {validator_address}
+                --fullnode-address {fullnode_address}
+                --local backend={backend};\
+                    path={path};\
+                    namespace={local_ns}
+                --remote backend={backend};\
+                    path={path};\
+                    namespace={remote_ns}\
+            ",
+            owner_address = owner_address,
+            validator_address = validator_address,
+            fullnode_address = fullnode_address,
+            backend = crate::secure_backend::DISK,
+            path = self.path_string(),
+            local_ns = local_ns,
+            remote_ns = remote_ns,
+        );
+
+        let command = Command::from_iter(args.split_whitespace());
+        command.validator_config()
+    }
+
+    pub fn verify(&self, namespace: &str) -> Result<String, Error> {
+        let args = format!(
+            "
+                validator_config
+                verify
+                --backend backend={backend};\
+                    path={path};\
+                    namespace={ns}
+            ",
+            backend = crate::secure_backend::DISK,
+            path = self.path_string(),
+            ns = namespace,
+        );
+
+        let command = Command::from_iter(args.split_whitespace());
+        command.verify()
+    }
+}

--- a/config/management/src/validator_config.rs
+++ b/config/management/src/validator_config.rs
@@ -1,11 +1,7 @@
 // Copyright (c) The Libra Core Contributors
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::{
-    error::Error,
-    management_constants::{GAS_UNIT_PRICE, MAX_GAS_AMOUNT, TXN_EXPIRATION_SECS, VALIDATOR_CONFIG},
-    SecureBackends,
-};
+use crate::{error::Error, SecureBackends};
 use libra_crypto::{ed25519::Ed25519PublicKey, hash::CryptoHash, x25519, ValidCryptoMaterial};
 use libra_global_constants::{
     CONSENSUS_KEY, FULLNODE_NETWORK_KEY, OWNER_KEY, VALIDATOR_NETWORK_KEY,
@@ -71,13 +67,13 @@ impl ValidatorConfig {
         // TODO(davidiw): In genesis this is irrelevant -- afterward we need to obtain the
         // current sequence number by querying the blockchain.
         let sequence_number = 0;
-        let expiration_time = RealTimeService::new().now() + TXN_EXPIRATION_SECS;
+        let expiration_time = RealTimeService::new().now() + crate::constants::TXN_EXPIRATION_SECS;
         let raw_transaction = RawTransaction::new_script(
             sender,
             sequence_number,
             script,
-            MAX_GAS_AMOUNT,
-            GAS_UNIT_PRICE,
+            crate::constants::MAX_GAS_AMOUNT,
+            crate::constants::GAS_UNIT_PRICE,
             Duration::from_secs(expiration_time),
         );
         let signature = local
@@ -96,7 +92,7 @@ impl ValidatorConfig {
 
             let txn = Value::Transaction(txn.clone());
             remote
-                .set(VALIDATOR_CONFIG, txn)
+                .set(crate::constants::VALIDATOR_CONFIG, txn)
                 .map_err(|e| Error::RemoteStorageWriteError(e.to_string()))?;
         }
 

--- a/secure/storage/Cargo.toml
+++ b/secure/storage/Cargo.toml
@@ -16,7 +16,6 @@ rand = "0.7.3"
 serde = { version = "1.0.110", features = ["rc"], default-features = false }
 serde_json = "1.0.53"
 thiserror = "1.0"
-toml = { version = "0.5.3", default-features = false }
 
 lcs = { path = "../../common/lcs", version = "0.1.0", package = "libra-canonical-serialization" }
 libra-config = { path = "../../config", version = "0.1.0" }

--- a/secure/storage/src/error.rs
+++ b/secure/storage/src/error.rs
@@ -55,18 +55,6 @@ impl From<serde_json::Error> for Error {
     }
 }
 
-impl From<toml::de::Error> for Error {
-    fn from(error: toml::de::Error) -> Self {
-        Self::SerializationError(format!("{}", error))
-    }
-}
-
-impl From<toml::ser::Error> for Error {
-    fn from(error: toml::ser::Error) -> Self {
-        Self::SerializationError(format!("{}", error))
-    }
-}
-
 impl From<libra_vault_client::Error> for Error {
     fn from(error: libra_vault_client::Error) -> Self {
         match error {

--- a/secure/storage/src/on_disk.rs
+++ b/secure/storage/src/on_disk.rs
@@ -60,12 +60,15 @@ impl<T: TimeService> OnDiskStorageInternal<T> {
         let mut file = File::open(&self.file_path)?;
         let mut contents = String::new();
         file.read_to_string(&mut contents)?;
-        let data = toml::from_str(&contents)?;
+        if contents.is_empty() {
+            return Ok(HashMap::new());
+        }
+        let data = serde_json::from_str(&contents)?;
         Ok(data)
     }
 
     fn write(&self, data: &HashMap<String, GetResponse>) -> Result<(), Error> {
-        let contents = toml::to_vec(data)?;
+        let contents = serde_json::to_vec(data)?;
         let mut file = File::create(self.temp_path.path())?;
         file.write_all(&contents)?;
         fs::rename(&self.temp_path, &self.file_path)?;


### PR DESCRIPTION
This is an incremental step toward building smoke tests that leverage this framework -- we needed to be able to generate a genesis using an integration test friendly storage solution and the framework had to be reusable. This PR does that an just a tad more:

* Fixup constants to match the original style -- yes I am being anal here
* Swap json in for toml, toml is a really bad format for the way we are storing data in secure-storage and is actually broken for Transaction
* Replace vault for disk in the tests for management
* Move the API interaction for tests in management accessible (StorageHelper)