### PR TITLE
[network] refactor NetworkBuilder

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2609,6 +2609,7 @@ version = "0.1.0"
 dependencies = [
  "admission-control-proto 0.1.0",
  "admission-control-service 0.1.0",
+ "channel 0.1.0",
  "consensus 0.1.0",
  "crash-handler 0.1.0",
  "debug-interface 0.1.0",

--- a/libra-node/Cargo.toml
+++ b/libra-node/Cargo.toml
@@ -19,6 +19,7 @@ tonic = "0.2"
 
 admission-control-proto = { path = "../admission-control/admission-control-proto", version = "0.1.0" }
 admission-control-service = { path = "../admission-control/admission-control-service", version = "0.1.0" }
+channel = { path = "../common/channel", version = "0.1.0" }
 libra-config = { path = "../config", version = "0.1.0" }
 libradb = { path = "../storage/libradb", version = "0.1.0" }
 consensus = { path = "../consensus", version = "0.1.0" }

--- a/network/src/lib.rs
+++ b/network/src/lib.rs
@@ -12,13 +12,14 @@ pub use interface::NetworkProvider;
 
 pub mod common;
 pub mod connectivity_manager;
+pub mod counters;
 pub mod error;
 pub mod interface;
 pub mod peer_manager;
 pub mod protocols;
+pub mod traits;
 pub mod validator_network;
 
-mod counters;
 mod peer;
 mod sink;
 mod transport;
@@ -26,3 +27,4 @@ mod transport;
 pub type DisconnectReason = peer::DisconnectReason;
 pub type ConnectivityRequest = connectivity_manager::ConnectivityRequest;
 pub type ProtocolId = protocols::wire::handshake::v1::ProtocolId;
+pub type ProtocolCategory = protocols::wire::handshake::v1::ProtocolCategory;

--- a/network/src/protocols/discovery/mod.rs
+++ b/network/src/protocols/discovery/mod.rs
@@ -37,6 +37,7 @@ use crate::{
     error::{NetworkError, NetworkErrorKind},
     peer_manager::{ConnectionRequestSender, PeerManagerRequestSender},
     protocols::network::{Event, NetworkEvents, NetworkSender},
+    traits::FromPeerManagerAndConnectionRequestSenders,
     validator_network::network_builder::{NetworkBuilder, NETWORK_CHANNEL_SIZE},
     NetworkPublicKeys, ProtocolId,
 };
@@ -124,6 +125,15 @@ impl DiscoveryNetworkSender {
     pub fn send_to(&mut self, peer: PeerId, msg: DiscoveryMsg) -> Result<(), NetworkError> {
         self.inner
             .send_to(peer, ProtocolId::DiscoveryDirectSend, msg)
+    }
+}
+
+impl FromPeerManagerAndConnectionRequestSenders for DiscoveryNetworkSender {
+    fn from_peer_manager_and_connection_request_senders(
+        pm_reqs_tx: PeerManagerRequestSender,
+        connection_reqs_tx: ConnectionRequestSender,
+    ) -> Self {
+        Self::new(pm_reqs_tx, connection_reqs_tx)
     }
 }
 

--- a/network/src/protocols/wire/handshake/v1/mod.rs
+++ b/network/src/protocols/wire/handshake/v1/mod.rs
@@ -45,12 +45,33 @@ impl ProtocolId {
             OnchainDiscoveryRpc => "OnchainDiscoveryRpc",
         }
     }
+
+    pub fn category(self) -> ProtocolCategory {
+        use ProtocolId::*;
+        use ProtocolCategory::*;
+        match self {
+            ConsensusRpc => RPC,
+            ConsensusDirectSend => DirectSend,
+            MempoolDirectSend => DirectSend,
+            StateSynchronizerDirectSend => DirectSend,
+            DiscoveryDirectSend => DirectSend,
+            HealthCheckerRpc => RPC,
+            IdentityDirectSend => DirectSend,
+            OnchainDiscoveryRpc => RPC,
+        }
+    }
 }
 
 impl fmt::Display for ProtocolId {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.as_str())
     }
+}
+
+#[derive(Clone, Copy, Debug, Hash, Eq, PartialEq)]
+pub enum ProtocolCategory {
+    RPC,
+    DirectSend
 }
 
 #[derive(Clone, Debug, Default, PartialEq, Deserialize, Serialize)]

--- a/network/src/traits.rs
+++ b/network/src/traits.rs
@@ -1,0 +1,52 @@
+use crate::{
+    connectivity_manager::ConnectivityRequest,
+    peer_manager::{
+        ConnectionRequest, ConnectionRequestSender, PeerManagerRequest, PeerManagerRequestSender,
+    },
+    ProtocolId,
+};
+use channel::libra_channel;
+use libra_types::PeerId;
+
+pub trait FromPeerManagerAndConnectionRequestSenders
+where
+    Self: std::marker::Sized,
+{
+    fn from_peer_manager_and_connection_request_senders(
+        pm_reqs_tx: PeerManagerRequestSender,
+        connection_reqs_tx: ConnectionRequestSender,
+    ) -> Self;
+
+    fn from_libra_channel_senders(
+        pm_reqs_tx: libra_channel::Sender<(PeerId, ProtocolId), PeerManagerRequest>,
+        connection_reqs_tx: libra_channel::Sender<PeerId, ConnectionRequest>,
+    ) -> Self {
+        Self::from_peer_manager_and_connection_request_senders(
+            PeerManagerRequestSender::new(pm_reqs_tx),
+            ConnectionRequestSender::new(connection_reqs_tx),
+        )
+    }
+}
+
+pub trait FromPeerManagerConnectionConnectivityRequestSenders
+where
+    Self: std::marker::Sized,
+{
+    fn from_peer_manager_connection_request_connection_manager_senders(
+        pm_reqs_tx: PeerManagerRequestSender,
+        connection_reqs_tx: ConnectionRequestSender,
+        connectivity_reqs_tx: channel::Sender<ConnectivityRequest>,
+    ) -> Self;
+
+    fn from_channel_senders(
+        pm_reqs_tx: libra_channel::Sender<(PeerId, ProtocolId), PeerManagerRequest>,
+        connection_reqs_tx: libra_channel::Sender<PeerId, ConnectionRequest>,
+        connectivity_reqs_tx: channel::Sender<ConnectivityRequest>,
+    ) -> Self {
+        Self::from_peer_manager_connection_request_connection_manager_senders(
+            PeerManagerRequestSender::new(pm_reqs_tx),
+            ConnectionRequestSender::new(connection_reqs_tx),
+            connectivity_reqs_tx,
+        )
+    }
+}


### PR DESCRIPTION
## Motivation

Partially Addresses #3342

Refactored away `NetworkBuilder`, in favor of a `NodeNetwork` struct that maintains fewer states.

Now that `NetworkBuilder` is no longer being used, let's discuss how to change the unit/integration tests.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

TBD

(If this PR adds or changes functionality, please take some time to update the docs at https://github.com/libra/website, and link to your PR here.)
