### PR TITLE
[client] Add a command to upgrade stdlib modules

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6119,6 +6119,7 @@ dependencies = [
  "mirai-annotations 1.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "move-core-types 0.1.0",
  "stdlib 0.1.0",
+ "vm 0.1.0",
 ]
 
 [[package]]

--- a/language/transaction-builder/Cargo.toml
+++ b/language/transaction-builder/Cargo.toml
@@ -17,6 +17,7 @@ stdlib = { path = "../stdlib", version = "0.1.0" }
 libra-types = { path = "../../types", version = "0.1.0" }
 libra-workspace-hack = { path = "../../common/workspace-hack", version = "0.1.0" }
 lcs = { path = "../../common/lcs", version = "0.1.0", package = "libra-canonical-serialization" }
+vm = { path = "../vm", version = "0.1.0" }
 
 [features]
 default = []

--- a/testsuite/cli/src/dev_commands.rs
+++ b/testsuite/cli/src/dev_commands.rs
@@ -24,6 +24,7 @@ impl Command for DevCommand {
             Box::new(DevCommandCompile {}),
             Box::new(DevCommandPublish {}),
             Box::new(DevCommandExecute {}),
+            Box::new(DevCommandUpgradeStdlib {}),
             Box::new(DevCommandAddValidator {}),
             Box::new(DevCommandRemoveValidator {}),
             Box::new(DevCommandGenWaypoint {}),
@@ -168,6 +169,33 @@ impl Command for DevCommandDisableCustomScript {
             return;
         }
         match client.disable_custom_script(params, true) {
+            Ok(_) => println!("Successfully finished execution"),
+            Err(e) => println!("{}", e),
+        }
+    }
+}
+
+pub struct DevCommandUpgradeStdlib {}
+
+impl Command for DevCommandUpgradeStdlib {
+    fn get_aliases(&self) -> Vec<&'static str> {
+        vec!["upgrade_stdlib"]
+    }
+
+    fn get_params_help(&self) -> &'static str {
+        ""
+    }
+
+    fn get_description(&self) -> &'static str {
+        "Upgrade the move stdlib used for the blockchain"
+    }
+
+    fn execute(&self, client: &mut ClientProxy, params: &[&str]) {
+        if params.len() != 1 {
+            println!("Invalid number of arguments");
+            return;
+        }
+        match client.upgrade_stdlib(params, true) {
             Ok(_) => println!("Successfully finished execution"),
             Err(e) => println!("{}", e),
         }


### PR DESCRIPTION
<!--
Thank you for sending a PR. We appreciate you spending time to help improve the Libra project.

The project is undergoing daily changes. Pull Requests will be reviewed and responded to as time permits.
-->

## Motivation

Implement a command to upgrade/rebuild the stdlib modules on chain.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

I ran a one shot test as following:
1. Run a libra_swarm locally via 
`cargo run -p libra-swarm -- -s --enable-logging`
2. Create two accounts and transfer some funds between them.
3. Add an assertion such that deposit will abort when the transfer amount is equal to a magic number.
4. Run `dev upgrade_stdlib`
5. Transfer the same amount and see payment will only fail when you try to send that special transfer amount.


