### PR TITLE
[crypto] fix hashing in network/discovery + improve inline docs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3441,6 +3441,7 @@ dependencies = [
  "libra-canonical-serialization 0.1.0",
  "libra-config 0.1.0",
  "libra-crypto 0.1.0",
+ "libra-crypto-derive 0.1.0",
  "libra-logger 0.1.0",
  "libra-metrics 0.1.0",
  "libra-network-address 0.1.0",

--- a/consensus/consensus-types/src/timeout.rs
+++ b/consensus/consensus-types/src/timeout.rs
@@ -2,10 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::{block::Block, common::Round};
-use libra_crypto::{
-    ed25519::Ed25519Signature,
-    hash::{CryptoHash, CryptoHasher, HashValue},
-};
+use libra_crypto::{ed25519::Ed25519Signature, hash::CryptoHash};
 use libra_crypto_derive::{CryptoHasher, LCSCryptoHash};
 use libra_types::validator_signer::ValidatorSigner;
 use serde::{Deserialize, Serialize};

--- a/consensus/consensus-types/src/vote_data.rs
+++ b/consensus/consensus-types/src/vote_data.rs
@@ -1,7 +1,6 @@
 // Copyright (c) The Libra Core Contributors
 // SPDX-License-Identifier: Apache-2.0
 
-use libra_crypto::{hash::CryptoHasher, HashValue};
 use libra_crypto_derive::{CryptoHasher, LCSCryptoHash};
 use libra_types::block_info::BlockInfo;
 use serde::{Deserialize, Serialize};

--- a/crypto/crypto-derive/src/lib.rs
+++ b/crypto/crypto-derive/src/lib.rs
@@ -362,7 +362,7 @@ pub fn hasher_dispatch(input: TokenStream) -> TokenStream {
         }
 
         impl libra_crypto::hash::CryptoHasher for #hasher_name {
-            fn finish(self) -> HashValue {
+            fn finish(self) -> libra_crypto::hash::HashValue {
                 self.0.finish()
             }
 
@@ -401,7 +401,9 @@ pub fn lcs_crypto_hash_dispatch(input: TokenStream) -> TokenStream {
         impl libra_crypto::hash::CryptoHash for #name {
             type Hasher = #hasher_name;
 
-            fn hash(&self) -> HashValue {
+            fn hash(&self) -> libra_crypto::hash::HashValue {
+                use libra_crypto::hash::CryptoHasher;
+
                 let mut state = Self::Hasher::default();
                 lcs::serialize_into(&mut state, &self).expect(#error_msg);
                 state.finish()

--- a/crypto/crypto-derive/src/lib.rs
+++ b/crypto/crypto-derive/src/lib.rs
@@ -346,7 +346,7 @@ pub fn hasher_dispatch(input: TokenStream) -> TokenStream {
                 let f_name = #fn_name;
 
                 #hasher_name(
-                    libra_crypto::hash::DefaultHasher::new_with_salt(&format!("{}::{}", mp, f_name).as_bytes()))
+                    libra_crypto::hash::DefaultHasher::new(&format!("{}::{}", mp, f_name).as_bytes()))
             }
         }
 
@@ -362,13 +362,12 @@ pub fn hasher_dispatch(input: TokenStream) -> TokenStream {
         }
 
         impl libra_crypto::hash::CryptoHasher for #hasher_name {
-            fn finish(self) -> libra_crypto::hash::HashValue {
-                self.0.finish()
+            fn update(&mut self, bytes: &[u8]) {
+                self.0.update(bytes);
             }
 
-            fn update(&mut self, bytes: &[u8]) -> &mut Self {
-                self.0.update(bytes);
-                self
+            fn finish(self) -> libra_crypto::hash::HashValue {
+                self.0.finish()
             }
         }
 

--- a/crypto/crypto/src/hash.rs
+++ b/crypto/crypto/src/hash.rs
@@ -568,11 +568,6 @@ define_hasher! {
     (TestOnlyHasher, TEST_ONLY_HASHER, b"")
 }
 
-define_hasher! {
-    /// The hasher used to compute the hash of a DiscoveryMsg object.
-    (DiscoveryMsgHasher, DISCOVERY_MSG_HASHER, b"DiscoveryMsg")
-}
-
 fn create_literal_hash(word: &str) -> HashValue {
     let mut s = word.as_bytes().to_vec();
     assert!(s.len() <= HashValue::LENGTH);

--- a/language/move-core/types/src/language_storage.rs
+++ b/language/move-core/types/src/language_storage.rs
@@ -5,7 +5,7 @@ use crate::{
     account_address::AccountAddress,
     identifier::{IdentStr, Identifier},
 };
-use libra_crypto::hash::{CryptoHash, CryptoHasher, HashValue};
+use libra_crypto::hash::CryptoHash;
 use libra_crypto_derive::{CryptoHasher, LCSCryptoHash};
 #[cfg(any(test, feature = "fuzzing"))]
 use proptest_derive::Arbitrary;

--- a/network/Cargo.toml
+++ b/network/Cargo.toml
@@ -28,6 +28,7 @@ channel = { path = "../common/channel", version = "0.1.0" }
 lcs = { path = "../common/lcs", version = "0.1.0", package = "libra-canonical-serialization" }
 libra-config = { path = "../config", version = "0.1.0" }
 libra-crypto = { path = "../crypto/crypto", version = "0.1.0" }
+libra-crypto-derive = { path = "../crypto/crypto-derive", version = "0.1.0" }
 libra-logger = { path = "../common/logger", version = "0.1.0" }
 libra-metrics = { path = "../common/metrics", version = "0.1.0" }
 libra-network-address = { path = "network-address", version = "0.1.0" }

--- a/network/src/protocols/discovery/mod.rs
+++ b/network/src/protocols/discovery/mod.rs
@@ -49,8 +49,8 @@ use futures::{
 use libra_config::config::RoleType;
 use libra_crypto::{
     ed25519::{Ed25519PrivateKey, Ed25519PublicKey, Ed25519Signature},
-    hash::{CryptoHash, CryptoHasher},
-    HashValue, Signature, SigningKey,
+    hash::CryptoHash,
+    Signature, SigningKey,
 };
 use libra_crypto_derive::{CryptoHasher, LCSCryptoHash};
 use libra_logger::prelude::*;

--- a/types/src/contract_event.rs
+++ b/types/src/contract_event.rs
@@ -11,10 +11,7 @@ use crate::{
     transaction::Version,
 };
 use anyhow::{ensure, Error, Result};
-use libra_crypto::{
-    hash::{CryptoHash, CryptoHasher},
-    HashValue,
-};
+use libra_crypto::hash::CryptoHash;
 use libra_crypto_derive::{CryptoHasher, LCSCryptoHash};
 use move_core_types::{language_storage::TypeTag, move_resource::MoveResource};
 

--- a/types/src/ledger_info.rs
+++ b/types/src/ledger_info.rs
@@ -11,7 +11,7 @@ use crate::{
 };
 use libra_crypto::{
     ed25519::Ed25519Signature,
-    hash::{CryptoHash, CryptoHasher, HashValue},
+    hash::{CryptoHash, HashValue},
 };
 use libra_crypto_derive::{CryptoHasher, LCSCryptoHash};
 #[cfg(any(test, feature = "fuzzing"))]

--- a/types/src/transaction/mod.rs
+++ b/types/src/transaction/mod.rs
@@ -15,7 +15,7 @@ use crate::{
 use anyhow::{ensure, format_err, Error, Result};
 use libra_crypto::{
     ed25519::*,
-    hash::{CryptoHash, CryptoHasher, EventAccumulatorHasher},
+    hash::{CryptoHash, EventAccumulatorHasher},
     multi_ed25519::{MultiEd25519PublicKey, MultiEd25519Signature},
     traits::SigningKey,
     HashValue,

--- a/types/src/waypoint.rs
+++ b/types/src/waypoint.rs
@@ -8,7 +8,7 @@ use crate::{
     transaction::Version,
 };
 use anyhow::{ensure, format_err, Error, Result};
-use libra_crypto::hash::{CryptoHash, CryptoHasher, HashValue};
+use libra_crypto::hash::{CryptoHash, HashValue};
 use libra_crypto_derive::{CryptoHasher, LCSCryptoHash};
 use serde::{Deserialize, Serialize};
 use std::{


### PR DESCRIPTION
## Motivation

* Fix potential confusion attacks between signed `PeerInfo` and `FullNodeInfo` objects in the discovery protocol.
* Improve inline docs after https://github.com/libra/libra/pull/3845 to make it clearer that manual implementations of `CryptoHash` are not recommended.
* Reduce the number of `use` declarations for users in the process.
* Hide (and minimize the code of) `DefaultHasher`

## Test Plan

```
cargo x test -p libra-crypto
cargo doc -p libra-crypto --open
```

## Related PRs

https://github.com/libra/libra/pull/3845