### PR TITLE
[language] add support for u8 & u128 as transaction arguments

### DIFF
--- a/language/functional-tests/src/tests/preprocessor_tests.rs
+++ b/language/functional-tests/src/tests/preprocessor_tests.rs
@@ -2,14 +2,13 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::{
-    config::global::Config as GlobalConfig,
     errors::*,
-    preprocessor::{build_transactions, split_input},
+    preprocessor::{build_transactions, extract_global_config, split_input},
 };
 
 fn parse_input(input: &str) -> Result<()> {
-    let (config, _, transactions) = split_input(input.lines())?;
-    let config = GlobalConfig::build(&config)?;
+    let config = extract_global_config("".lines())?;
+    let (_, transactions) = split_input(input.lines(), &config)?;
     build_transactions(&config, &transactions)?;
     Ok(())
 }

--- a/language/functional-tests/src/testsuite.rs
+++ b/language/functional-tests/src/testsuite.rs
@@ -4,9 +4,8 @@
 use crate::{
     checker::*,
     compiler::Compiler,
-    config::global::Config as GlobalConfig,
     evaluator::{eval, EvaluationOutput},
-    preprocessor::{build_transactions, split_input},
+    preprocessor::{build_transactions, extract_global_config, split_input},
 };
 use std::{env, fs::read_to_string, io::Write, iter, path::Path};
 use termcolor::{BufferWriter, Color, ColorChoice, ColorSpec, WriteColor};
@@ -63,9 +62,8 @@ pub fn functional_tests<TComp: Compiler>(
     let input = read_to_string(path)?;
 
     let lines: Vec<String> = input.lines().map(|line| line.to_string()).collect();
-
-    let (config, directives, transactions) = split_input(&lines)?;
-    let config = GlobalConfig::build(&config)?;
+    let config = extract_global_config(&lines)?;
+    let (directives, transactions) = split_input(&lines, &config)?;
     let commands = build_transactions(&config, &transactions)?;
 
     let log = eval(&config, compiler, &commands)?;

--- a/language/ir-testsuite/tests/transactions/tx_args_of_all_possible_types.mvir
+++ b/language/ir-testsuite/tests/transactions/tx_args_of_all_possible_types.mvir
@@ -1,0 +1,5 @@
+//! args: 10u8, 10, 10u64, 10u128, true, false, 0x123, b"deadbeef"
+
+main(a: u8, b: u64, c: u64, d: u128, e: bool, f: bool, g: address, h: vector<u8>) {
+    return;
+}

--- a/language/libra-vm/src/libra_vm.rs
+++ b/language/libra-vm/src/libra_vm.rs
@@ -1032,7 +1032,9 @@ enum VerifiedTransactionPayload {
 fn convert_txn_args(args: &[TransactionArgument]) -> Vec<Value> {
     args.iter()
         .map(|arg| match arg {
+            TransactionArgument::U8(i) => Value::u8(*i),
             TransactionArgument::U64(i) => Value::u64(*i),
+            TransactionArgument::U128(i) => Value::u128(*i),
             TransactionArgument::Address(a) => Value::address(*a),
             TransactionArgument::Bool(b) => Value::bool(*b),
             TransactionArgument::U8Vector(v) => Value::vector_u8(v.clone()),

--- a/language/move-core/types/src/parser.rs
+++ b/language/move-core/types/src/parser.rs
@@ -5,28 +5,33 @@ use crate::{
     account_address::AccountAddress,
     identifier::Identifier,
     language_storage::{StructTag, TypeTag},
+    transaction_argument::TransactionArgument,
 };
 use anyhow::{bail, Result};
 use std::iter::Peekable;
 
 #[derive(Eq, PartialEq, Debug)]
 enum Token {
-    U8,
-    U64,
-    U128,
-    Bool,
+    U8Type,
+    U64Type,
+    U128Type,
+    BoolType,
     AddressType,
-    Vector,
+    VectorType,
     Whitespace(String),
     Name(String),
     Address(String),
+    U8(String),
+    U64(String),
+    U128(String),
+    Bytes(String),
+    True,
+    False,
     ColonColon,
     Lt,
     Gt,
     Comma,
     EOF,
-    LBraceBrace,
-    RBraceBrace,
 }
 
 impl Token {
@@ -40,19 +45,54 @@ impl Token {
 
 fn name_token(s: String) -> Token {
     match s.as_str() {
-        "u8" => Token::U8,
-        "u64" => Token::U64,
-        "u128" => Token::U128,
-        "bool" => Token::Bool,
+        "u8" => Token::U8Type,
+        "u64" => Token::U64Type,
+        "u128" => Token::U128Type,
+        "bool" => Token::BoolType,
         "address" => Token::AddressType,
-        "vector" => Token::Vector,
+        "vector" => Token::VectorType,
+        "true" => Token::True,
+        "false" => Token::False,
         _ => Token::Name(s),
+    }
+}
+
+fn next_number(initial: char, mut it: impl Iterator<Item = char>) -> Result<(Token, usize)> {
+    let mut num = String::new();
+    num.push(initial);
+    loop {
+        match it.next() {
+            Some(c) if c.is_ascii_digit() => num.push(c),
+            Some(c) if c.is_alphanumeric() => {
+                let mut suffix = String::new();
+                suffix.push(c);
+                loop {
+                    match it.next() {
+                        Some(c) if c.is_ascii_alphanumeric() => suffix.push(c),
+                        _ => {
+                            let len = num.len() + suffix.len();
+                            let tok = match suffix.as_str() {
+                                "u8" => Token::U8(num),
+                                "u64" => Token::U64(num),
+                                "u128" => Token::U128(num),
+                                _ => bail!("invalid suffix"),
+                            };
+                            return Ok((tok, len));
+                        }
+                    }
+                }
+            }
+            _ => {
+                let len = num.len();
+                return Ok((Token::U64(num), len));
+            }
+        }
     }
 }
 
 #[allow(clippy::many_single_char_names)]
 fn next_token(s: &str) -> Result<Option<(Token, usize)>> {
-    let mut it = s.chars();
+    let mut it = s.chars().peekable();
     match it.next() {
         None => Ok(None),
         Some(c) => Ok(Some(match c {
@@ -63,63 +103,66 @@ fn next_token(s: &str) -> Result<Option<(Token, usize)>> {
                 Some(':') => (Token::ColonColon, 2),
                 _ => bail!("unrecognized token"),
             },
-            '{' => match it.next() {
-                Some('{') => (Token::LBraceBrace, 2),
-                _ => bail!("unrecognized token"),
-            },
-            '}' => match it.next() {
-                Some('}') => (Token::RBraceBrace, 2),
-                _ => bail!("unrecognized token"),
-            },
-            '0' => match it.next() {
-                Some(x @ 'x') | Some(x @ 'X') => match it.next() {
+            '0' if it.peek() == Some(&'x') || it.peek() == Some(&'X') => {
+                it.next().unwrap();
+                match it.next() {
                     Some(c) if c.is_ascii_hexdigit() => {
-                        let mut n: usize = 3;
                         let mut r = String::new();
                         r.push('0');
-                        r.push(x);
+                        r.push('x');
                         r.push(c);
                         for c in it {
                             if c.is_ascii_hexdigit() {
                                 r.push(c);
-                                n += 1;
                             } else {
                                 break;
                             }
                         }
-                        (Token::Address(r), n)
+                        let len = r.len();
+                        (Token::Address(r), len)
                     }
                     _ => bail!("unrecognized token"),
-                },
-                _ => bail!("unrecognized token"),
-            },
+                }
+            }
+            c if c.is_ascii_digit() => next_number(c, it)?,
+            'b' if it.peek() == Some(&'"') => {
+                it.next().unwrap();
+                let mut r = String::new();
+                loop {
+                    match it.next() {
+                        Some('"') => break,
+                        Some(c) if c.is_ascii_hexdigit() => r.push(c),
+                        _ => bail!("unrecognized token"),
+                    }
+                }
+                let len = r.len() + 3;
+                (Token::Bytes(r), len)
+            }
             c if c.is_ascii_whitespace() => {
-                let mut n = 1;
                 let mut r = String::new();
                 r.push(c);
                 for c in it {
                     if c.is_ascii_whitespace() {
                         r.push(c);
-                        n += 1;
                     } else {
                         break;
                     }
                 }
-                (Token::Whitespace(r), n)
+                let len = r.len();
+                (Token::Whitespace(r), len)
             }
             c if c.is_ascii_alphabetic() => {
-                let mut n = 1;
                 let mut r = String::new();
                 r.push(c);
                 for c in it {
                     if c.is_ascii_alphanumeric() {
                         r.push(c);
-                        n += 1;
                     } else {
                         break;
                     }
                 }
-                (name_token(r), n)
+                let len = r.len();
+                (name_token(r), len)
             }
             _ => bail!("unrecognized token"),
         })),
@@ -193,12 +236,12 @@ impl<I: Iterator<Item = Token>> Parser<I> {
 
     fn parse_type_tag(&mut self) -> Result<TypeTag> {
         Ok(match self.next()? {
-            Token::U8 => TypeTag::U8,
-            Token::U64 => TypeTag::U64,
-            Token::U128 => TypeTag::U128,
-            Token::Bool => TypeTag::Bool,
+            Token::U8Type => TypeTag::U8,
+            Token::U64Type => TypeTag::U64,
+            Token::U128Type => TypeTag::U128,
+            Token::BoolType => TypeTag::Bool,
             Token::AddressType => TypeTag::Address,
-            Token::Vector => {
+            Token::VectorType => {
                 self.consume(Token::Lt)?;
                 let ty = self.parse_type_tag()?;
                 self.consume(Token::Gt)?;
@@ -239,17 +282,129 @@ impl<I: Iterator<Item = Token>> Parser<I> {
             tok => bail!("unexpected token {:?}, expected type tag", tok),
         })
     }
+
+    fn parse_transaction_argument(&mut self) -> Result<TransactionArgument> {
+        Ok(match self.next()? {
+            Token::U8(s) => TransactionArgument::U8(s.parse()?),
+            Token::U64(s) => TransactionArgument::U64(s.parse()?),
+            Token::U128(s) => TransactionArgument::U128(s.parse()?),
+            Token::True => TransactionArgument::Bool(true),
+            Token::False => TransactionArgument::Bool(false),
+            Token::Address(addr) => {
+                TransactionArgument::Address(AccountAddress::from_hex_literal(&addr)?)
+            }
+            Token::Bytes(s) => TransactionArgument::U8Vector(hex::decode(s)?),
+            tok => bail!("unexpected token {:?}, expected transaction argument", tok),
+        })
+    }
 }
 
-pub fn parse_type_tags(s: &str) -> Result<Vec<TypeTag>> {
+fn parse<F, T>(s: &str, f: F) -> Result<T>
+where
+    F: Fn(&mut Parser<std::vec::IntoIter<Token>>) -> Result<T>,
+{
     let mut tokens: Vec<_> = tokenize(s)?
         .into_iter()
         .filter(|tok| !tok.is_whitespace())
         .collect();
     tokens.push(Token::EOF);
     let mut parser = Parser::new(tokens);
-    let tags = parser.parse_comma_list(|parser| parser.parse_type_tag(), Token::EOF, true);
-    let tags = tags?;
+    let res = f(&mut parser)?;
     parser.consume(Token::EOF)?;
-    Ok(tags)
+    Ok(res)
+}
+
+pub fn parse_type_tags(s: &str) -> Result<Vec<TypeTag>> {
+    parse(s, |parser| {
+        parser.parse_comma_list(|parser| parser.parse_type_tag(), Token::EOF, true)
+    })
+}
+
+pub fn parse_transaction_arguments(s: &str) -> Result<Vec<TransactionArgument>> {
+    parse(s, |parser| {
+        parser.parse_comma_list(
+            |parser| parser.parse_transaction_argument(),
+            Token::EOF,
+            true,
+        )
+    })
+}
+
+pub fn parse_transaction_argument(s: &str) -> Result<TransactionArgument> {
+    parse(s, |parser| parser.parse_transaction_argument())
+}
+
+#[allow(clippy::unreadable_literal)]
+#[test]
+fn tests_parse_transaction_argument_positive() {
+    use TransactionArgument as T;
+
+    for (s, expected) in &[
+        ("  0u8", T::U8(0)),
+        ("0u8", T::U8(0)),
+        ("255u8", T::U8(255)),
+        ("0", T::U64(0)),
+        ("0123", T::U64(123)),
+        ("0u64", T::U64(0)),
+        ("18446744073709551615", T::U64(18446744073709551615)),
+        ("18446744073709551615u64", T::U64(18446744073709551615)),
+        ("0u128", T::U128(0)),
+        (
+            "340282366920938463463374607431768211455u128",
+            T::U128(340282366920938463463374607431768211455),
+        ),
+        ("true", T::Bool(true)),
+        ("false", T::Bool(false)),
+        (
+            "0x0",
+            T::Address(AccountAddress::from_hex_literal("0x0").unwrap()),
+        ),
+        (
+            "0x54afa3526",
+            T::Address(AccountAddress::from_hex_literal("0x54afa3526").unwrap()),
+        ),
+        (
+            "0X54afa3526",
+            T::Address(AccountAddress::from_hex_literal("0x54afa3526").unwrap()),
+        ),
+        ("b\"7fff\"", T::U8Vector(vec![0x7f, 0xff])),
+        ("b\"\"", T::U8Vector(vec![])),
+        ("b\"00\"", T::U8Vector(vec![0x00])),
+        ("b\"deadbeef\"", T::U8Vector(vec![0xde, 0xad, 0xbe, 0xef])),
+    ] {
+        assert_eq!(&parse_transaction_argument(s).unwrap(), expected)
+    }
+}
+
+#[test]
+fn tests_parse_transaction_argument_negative() {
+    for s in &[
+        "-3",
+        "0u42",
+        "0u645",
+        "0u64x",
+        "0u6 4",
+        "0u",
+        "256u8",
+        "18446744073709551616",
+        "18446744073709551616u64",
+        "340282366920938463463374607431768211456u128",
+        "0xg",
+        "0x00g0",
+        "0x",
+        "0x_",
+        "",
+        "b\"ffff",
+        "b\"a \"",
+        "b\" \"",
+        "b\"0g\"",
+        "b\"0\"",
+        "garbage",
+        "true3",
+        "3false",
+        "3 false",
+        "",
+    ] {
+        assert!(parse_transaction_argument(s).is_err())
+    }
 }

--- a/language/move-core/types/src/transaction_argument.rs
+++ b/language/move-core/types/src/transaction_argument.rs
@@ -2,14 +2,14 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::account_address::AccountAddress;
-use anyhow::Result;
 use serde::{Deserialize, Serialize};
-use std::{convert::TryFrom, fmt};
-use thiserror::Error;
+use std::fmt;
 
 #[derive(Clone, Hash, Eq, PartialEq, Serialize, Deserialize)]
 pub enum TransactionArgument {
+    U8(u8),
     U64(u64),
+    U128(u128),
     Address(AccountAddress),
     U8Vector(Vec<u8>),
     Bool(bool),
@@ -18,161 +18,14 @@ pub enum TransactionArgument {
 impl fmt::Debug for TransactionArgument {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
+            TransactionArgument::U8(value) => write!(f, "{{U8: {}}}", value),
             TransactionArgument::U64(value) => write!(f, "{{U64: {}}}", value),
+            TransactionArgument::U128(value) => write!(f, "{{U128: {}}}", value),
             TransactionArgument::Bool(boolean) => write!(f, "{{BOOL: {}}}", boolean),
             TransactionArgument::Address(address) => write!(f, "{{ADDRESS: {:?}}}", address),
             TransactionArgument::U8Vector(vector) => {
                 write!(f, "{{U8Vector: 0x{}}}", hex::encode(vector))
             }
-        }
-    }
-}
-
-#[derive(Clone, Debug, Error)]
-pub enum ErrorKind {
-    #[error("ParseError: {0}")]
-    ParseError(String),
-}
-
-/// Parses the given string as address.
-pub fn parse_as_address(s: &str) -> Result<TransactionArgument> {
-    let mut s = s.to_ascii_lowercase();
-    if !s.starts_with("0x") {
-        return Err(ErrorKind::ParseError("address must start with '0x'".to_string()).into());
-    }
-    if s.len() == 2 {
-        return Err(ErrorKind::ParseError("address cannot be empty".to_string()).into());
-    }
-    if s.len() % 2 != 0 {
-        s = format!("0x0{}", &s[2..]);
-    }
-    let mut addr = hex::decode(&s[2..])?;
-    if addr.len() > AccountAddress::LENGTH {
-        return Err(ErrorKind::ParseError(format!(
-            "address must be {} bytes or less",
-            AccountAddress::LENGTH
-        ))
-        .into());
-    }
-    if addr.len() < AccountAddress::LENGTH {
-        addr = vec![0u8; AccountAddress::LENGTH - addr.len()]
-            .into_iter()
-            .chain(addr.into_iter())
-            .collect();
-    }
-    Ok(TransactionArgument::Address(AccountAddress::try_from(
-        addr,
-    )?))
-}
-
-/// Parses the given string as bytearray.
-pub fn parse_as_u8_vector(s: &str) -> Result<TransactionArgument> {
-    if s.starts_with("b\"") && s.ends_with('"') && s.len() >= 3 {
-        let s = &s[2..s.len() - 1];
-        if s.is_empty() {
-            return Err(ErrorKind::ParseError("vector<u8> cannot be empty".to_string()).into());
-        }
-        let s = if s.len() % 2 == 0 {
-            s.to_string()
-        } else {
-            format!("0{}", s)
-        };
-        Ok(TransactionArgument::U8Vector(hex::decode(&s)?))
-    } else {
-        Err(ErrorKind::ParseError(format!("\"{}\" is not a vector<u8>", s)).into())
-    }
-}
-
-/// Parses the given string as u64.
-pub fn parse_as_u64(s: &str) -> Result<TransactionArgument> {
-    Ok(TransactionArgument::U64(s.parse::<u64>()?))
-}
-
-/// Parses the given string as a bool.
-pub fn parse_as_bool(s: &str) -> Result<TransactionArgument> {
-    Ok(TransactionArgument::Bool(s.parse::<bool>()?))
-}
-
-macro_rules! return_if_ok {
-    ($e: expr) => {{
-        if let Ok(res) = $e {
-            return Ok(res);
-        }
-    }};
-}
-
-/// Parses the given string as any transaction argument type.
-pub fn parse_as_transaction_argument(s: &str) -> Result<TransactionArgument> {
-    return_if_ok!(parse_as_address(s));
-    return_if_ok!(parse_as_u64(s));
-    return_if_ok!(parse_as_bool(s));
-    return_if_ok!(parse_as_u8_vector(s));
-    Err(ErrorKind::ParseError(format!("cannot parse \"{}\" as transaction argument", s)).into())
-}
-
-#[cfg(test)]
-mod test_transaction_argument {
-    use super::*;
-
-    #[test]
-    fn parse_u64() {
-        for s in &["0", "42", "18446744073709551615"] {
-            parse_as_u64(s).unwrap();
-        }
-        for s in &["xx", "", "-3"] {
-            parse_as_u64(s).unwrap_err();
-        }
-    }
-
-    #[test]
-    fn parse_bool() {
-        parse_as_bool("true").unwrap();
-        parse_as_bool("false").unwrap();
-    }
-
-    #[test]
-    fn parse_address() {
-        for s in &[
-            "0x0",
-            "0x1",
-            "0x00",
-            "0x05",
-            "0x100",
-            "0x0123456789ABCDEF0123456789ABCDEF",
-        ] {
-            parse_as_address(s).unwrap();
-        }
-
-        for s in &[
-            "0x",
-            "100",
-            "",
-            "0xG",
-            "0x0123456789ABCDEF0123456789ABCDEFA",
-        ] {
-            parse_as_address(s).unwrap_err();
-        }
-    }
-
-    #[test]
-    fn parse_byte_array() {
-        for s in &["0", "00", "deadbeef", "aaa"] {
-            parse_as_u8_vector(&format!("b\"{}\"", s)).unwrap();
-        }
-
-        for s in &["", "b\"\"", "123", "b\"G\""] {
-            parse_as_u8_vector(s).unwrap_err();
-        }
-    }
-
-    #[test]
-    fn parse_args() {
-        for s in &["123", "0xf", "b\"aaa\""] {
-            parse_as_transaction_argument(s).unwrap();
-        }
-
-        for s in &["garbage", ""] {
-            parse_as_transaction_argument(s).unwrap_err();
         }
     }
 }

--- a/language/tools/vm-genesis/src/genesis_context.rs
+++ b/language/tools/vm-genesis/src/genesis_context.rs
@@ -75,7 +75,9 @@ impl<'a> GenesisContext<'a> {
     fn convert_txn_args(args: &[TransactionArgument]) -> Vec<Value> {
         args.iter()
             .map(|arg| match arg {
+                TransactionArgument::U8(i) => Value::u8(*i),
                 TransactionArgument::U64(i) => Value::u64(*i),
+                TransactionArgument::U128(i) => Value::u128(*i),
                 TransactionArgument::Address(a) => Value::address(*a),
                 TransactionArgument::Bool(b) => Value::bool(*b),
                 TransactionArgument::U8Vector(v) => Value::vector_u8(v.clone()),

--- a/testsuite/cli/src/client_proxy.rs
+++ b/testsuite/cli/src/client_proxy.rs
@@ -30,7 +30,7 @@ use libra_types::{
     transaction::{
         authenticator::AuthenticationKey,
         helpers::{create_unsigned_txn, create_user_txn, TransactionSigner},
-        parse_as_transaction_argument, Module, RawTransaction, Script, SignedTransaction,
+        parse_transaction_argument, Module, RawTransaction, Script, SignedTransaction,
         TransactionArgument, TransactionPayload, Version,
     },
     waypoint::Waypoint,
@@ -788,7 +788,7 @@ impl ClientProxy {
         let script_bytes = fs::read(space_delim_strings[2])?;
         let arguments: Vec<_> = space_delim_strings[3..]
             .iter()
-            .filter_map(|arg| parse_as_transaction_argument_for_client(arg).ok())
+            .filter_map(|arg| parse_transaction_argument_for_client(arg).ok())
             .collect();
         // TODO: support type arguments in the client.
         self.submit_program(
@@ -1305,12 +1305,12 @@ impl ClientProxy {
     }
 }
 
-fn parse_as_transaction_argument_for_client(s: &str) -> Result<TransactionArgument> {
+fn parse_transaction_argument_for_client(s: &str) -> Result<TransactionArgument> {
     if is_address(s) {
         let account_address = ClientProxy::address_from_strings(s)?;
         return Ok(TransactionArgument::Address(account_address));
     }
-    parse_as_transaction_argument(s)
+    parse_transaction_argument(s)
 }
 
 fn format_parse_data_error<T: std::fmt::Debug>(

--- a/testsuite/generate-format/tests/staged/libra.yaml
+++ b/testsuite/generate-format/tests/staged/libra.yaml
@@ -116,17 +116,23 @@ Transaction:
 TransactionArgument:
   ENUM:
     0:
+      U8:
+        NEWTYPE: U8
+    1:
       U64:
         NEWTYPE: U64
-    1:
+    2:
+      U128:
+        NEWTYPE: U128
+    3:
       Address:
         NEWTYPE:
           TYPENAME: AccountAddress
-    2:
+    4:
       U8Vector:
         NEWTYPE:
           SEQ: U8
-    3:
+    5:
       Bool:
         NEWTYPE: BOOL
 TransactionAuthenticator:

--- a/types/src/transaction/mod.rs
+++ b/types/src/transaction/mod.rs
@@ -45,7 +45,7 @@ pub use module::Module;
 pub use script::{Script, SCRIPT_HASH_LENGTH};
 
 use std::ops::Deref;
-pub use transaction_argument::{parse_as_transaction_argument, TransactionArgument};
+pub use transaction_argument::{parse_transaction_argument, TransactionArgument};
 
 pub type Version = u64; // Height - also used for MVCC in StateDB
 

--- a/types/src/transaction/transaction_argument.rs
+++ b/types/src/transaction/transaction_argument.rs
@@ -1,6 +1,6 @@
 // Copyright (c) The Libra Core Contributors
 // SPDX-License-Identifier: Apache-2.0
 
-pub use move_core_types::transaction_argument::{
-    parse_as_transaction_argument, TransactionArgument,
+pub use move_core_types::{
+    parser::parse_transaction_argument, transaction_argument::TransactionArgument,
 };

--- a/types/src/unit_tests/canonical_serialization_examples.rs
+++ b/types/src/unit_tests/canonical_serialization_examples.rs
@@ -60,7 +60,7 @@ fn test_program_canonical_serialization_example() {
     let input = get_common_program();
 
     let expected_output: Vec<u8> = vec![
-        0x04, 0x6D, 0x6F, 0x76, 0x65, 0x00, 0x01, 0x00, 0xEF, 0xBE, 0xAD, 0xDE, 0x0D, 0xD0, 0xFE,
+        0x04, 0x6D, 0x6F, 0x76, 0x65, 0x00, 0x01, 0x01, 0xEF, 0xBE, 0xAD, 0xDE, 0x0D, 0xD0, 0xFE,
         0xCA,
     ];
 
@@ -85,7 +85,7 @@ fn test_raw_transaction_with_a_program_canonical_serialization_example() {
 
     let expected_output = vec![
         58, 36, 166, 30, 5, 209, 41, 202, 206, 158, 14, 252, 139, 201, 227, 56, 32, 0, 0, 0, 0, 0,
-        0, 0, 2, 4, 109, 111, 118, 101, 0, 1, 0, 239, 190, 173, 222, 13, 208, 254, 202, 16, 39, 0,
+        0, 0, 2, 4, 109, 111, 118, 101, 0, 1, 1, 239, 190, 173, 222, 13, 208, 254, 202, 16, 39, 0,
         0, 0, 0, 0, 0, 32, 78, 0, 0, 0, 0, 0, 0, 3, 76, 66, 82, 128, 81, 1, 0, 0, 0, 0, 0,
     ];
 
@@ -125,7 +125,7 @@ fn test_transaction_argument_address_canonical_serialization_example() {
     ]));
 
     let expected_output: Vec<u8> = vec![
-        0x01, 0x2C, 0x25, 0x99, 0x17, 0x85, 0x34, 0x3B, 0x23, 0xAE, 0x07, 0x3A, 0x50, 0xE5, 0xFD,
+        0x03, 0x2C, 0x25, 0x99, 0x17, 0x85, 0x34, 0x3B, 0x23, 0xAE, 0x07, 0x3A, 0x50, 0xE5, 0xFD,
         0x80, 0x9A,
     ];
 
@@ -138,7 +138,7 @@ fn test_transaction_argument_address_canonical_serialization_example() {
 fn test_transaction_argument_byte_array_canonical_serialization_example() {
     let input = TransactionArgument::U8Vector(vec![0xCA, 0xFE, 0xD0, 0x0D]);
 
-    let expected_output: Vec<u8> = vec![0x02, 0x04, 0xCA, 0xFE, 0xD0, 0x0D];
+    let expected_output: Vec<u8> = vec![0x04, 0x04, 0xCA, 0xFE, 0xD0, 0x0D];
 
     let actual_output = to_bytes(&input).unwrap();
     assert_eq!(expected_output, actual_output);
@@ -147,7 +147,7 @@ fn test_transaction_argument_byte_array_canonical_serialization_example() {
 #[test]
 fn test_transaction_argument_u64_canonical_serialization_example() {
     let input = TransactionArgument::U64(9_213_671_392_124_193_148);
-    let expected_output: Vec<u8> = vec![0x00, 0x7C, 0xC9, 0xBD, 0xA4, 0x50, 0x89, 0xDD, 0x7F];
+    let expected_output: Vec<u8> = vec![0x01, 0x7C, 0xC9, 0xBD, 0xA4, 0x50, 0x89, 0xDD, 0x7F];
 
     let actual_output = to_bytes(&input).unwrap();
     assert_eq!(expected_output, actual_output);
@@ -158,7 +158,7 @@ fn test_transaction_payload_with_a_program_canonical_serialization_example() {
     let input = TransactionPayload::Script(get_common_program());
 
     let expected_output = vec![
-        0x02, 0x04, 0x6D, 0x6F, 0x76, 0x65, 0x00, 0x01, 0x00, 0xEF, 0xBE, 0xAD, 0xDE, 0x0D, 0xD0,
+        0x02, 0x04, 0x6D, 0x6F, 0x76, 0x65, 0x00, 0x01, 0x01, 0xEF, 0xBE, 0xAD, 0xDE, 0x0D, 0xD0,
         0xFE, 0xCA,
     ];
 


### PR DESCRIPTION
## Summary
This adds support for u8 and u128 as transaction arguments in tests & client cli. Transaction arguments are now parsed using a proper parser. 

## Test Plan
cargo test