### PR TITLE
[move-prover] Updating the Boogie translation to reflect new memory model

### DIFF
--- a/language/move-prover/src/boogie_helpers.rs
+++ b/language/move-prover/src/boogie_helpers.rs
@@ -224,7 +224,7 @@ fn boogie_well_formed_expr_impl(
             };
             conds.push(boogie_well_formed_expr_impl(
                 env,
-                &format!("$Dereference($m, {})", name),
+                &format!("$Dereference({})", name),
                 rtype,
                 mode,
                 nest + 1,
@@ -300,10 +300,6 @@ pub fn boogie_global_declarator(
     } else {
         format!("{} : Value", name)
     }
-}
-
-pub fn boogie_var_before_borrow(idx: usize) -> String {
-    format!("$before_borrow_{}", idx)
 }
 
 pub fn boogie_byte_blob(val: &[u8]) -> String {

--- a/language/move-prover/src/spec_translator.rs
+++ b/language/move-prover/src/spec_translator.rs
@@ -3,7 +3,7 @@
 
 //! This module translates specification conditions to Boogie code.
 
-use std::{cell::RefCell, collections::BTreeMap};
+use std::{cell::RefCell, rc::Rc};
 
 use spec_lang::{
     env::{FieldId, Loc, ModuleEnv, ModuleId, NodeId, SpecFunId, StructEnv, StructId},
@@ -45,13 +45,13 @@ pub struct SpecTranslator<'env> {
     supports_native_old: bool,
     /// Whether we are currently in the context of translating an `old(...)` expression.
     in_old: RefCell<bool>,
+    /// Whether we are currently translating an ensures specification.
+    in_ensures: RefCell<bool>,
     /// The current target for invariant fields, a pair of strings for current and old value.
     invariant_target: RefCell<(String, String)>,
     /// Counter for generating fresh variables.  It's a RefCell so we can increment it without
     /// making a ton of &self arguments mutable.
     fresh_var_count: RefCell<u64>,
-    /// Local variable name to local index in bytecode
-    name_to_idx_map: BTreeMap<Symbol, usize>,
     // If we are translating in the context of a type instantiation, the type arguments.
     type_args_opt: Option<Vec<Type>>,
 }
@@ -89,9 +89,9 @@ impl<'env> SpecTranslator<'env> {
             writer,
             supports_native_old,
             in_old: RefCell::new(false),
+            in_ensures: RefCell::new(false),
             invariant_target: RefCell::new(("".to_string(), "".to_string())),
             fresh_var_count: RefCell::new(0),
-            name_to_idx_map: BTreeMap::new(),
             type_args_opt: None,
         }
     }
@@ -107,11 +107,9 @@ impl<'env> SpecTranslator<'env> {
             writer,
             supports_native_old,
             in_old: RefCell::new(false),
+            in_ensures: RefCell::new(false),
             invariant_target: RefCell::new(("".to_string(), "".to_string())),
             fresh_var_count: RefCell::new(0),
-            name_to_idx_map: (0..func_target.get_local_count())
-                .map(|idx| (func_target.get_local_name(idx), idx))
-                .collect(),
             type_args_opt: None,
         }
     }
@@ -368,12 +366,14 @@ impl<'env> SpecTranslator<'env> {
         // Generate ensures
         let ensures = spec.filter_kind(ConditionKind::Ensures).collect_vec();
         if !ensures.is_empty() {
+            *self.in_ensures.borrow_mut() = true;
             self.translate_seq(ensures.iter(), "\n", |cond| {
                 self.writer.set_location(&cond.loc);
                 emit!(self.writer, "ensures !$abort_flag ==> (b#Boolean(");
                 self.translate_exp(&cond.exp);
                 emit!(self.writer, "));")
             });
+            *self.in_ensures.borrow_mut() = false;
             emitln!(self.writer);
         }
     }
@@ -495,20 +495,13 @@ impl<'env> SpecTranslator<'env> {
     }
 
     /// Determines whether a before-update invariant is generated for this struct.
-    ///
-    /// We currently support two models for dealing with global spec var updates.
-    /// If the specification has explicitly provided update invariants for spec vars, we use those.
-    /// If not, we use the unpack invariants before the update, and the pack invariants
-    /// after. This function is only true for the later case.
     pub fn has_before_update_invariant(struct_env: &StructEnv<'_>) -> bool {
-        let spec = struct_env.get_spec();
-        let no_explict_update = !spec.any(|c| matches!(c.kind, ConditionKind::VarUpdate(..)));
-        let has_pack = spec.any(|c| matches!(c.kind, ConditionKind::VarPack(..)));
-        no_explict_update && has_pack
-            // If any of the fields has it, it inherits to the struct.
-            || struct_env.get_fields().any(|fe| {
-                Self::has_before_update_invariant_ty(struct_env.module_env.env, &fe.get_type())
-            })
+        use ConditionKind::*;
+        struct_env.get_spec().any(|c| matches!(c.kind, VarUpdate(..)|VarUnpack(..)|Invariant))
+                // If any of the fields has it, it inherits to the struct.
+                || struct_env.get_fields().any(|fe| {
+                    Self::has_before_update_invariant_ty(struct_env.module_env.env, &fe.get_type())
+                })
     }
 
     /// Determines whether a before-update invariant is generated for this type.
@@ -566,6 +559,15 @@ impl<'env> SpecTranslator<'env> {
             }
         }
 
+        // Emit data invariants for this struct.
+        let spec = struct_env.get_spec();
+        self.emit_invariants_assume_or_assert(
+            "$before",
+            "",
+            true,
+            spec.filter_kind(ConditionKind::Invariant),
+        );
+
         // Emit call to spec var updates via unpack invariants.
         self.emit_spec_var_updates(
             "$before",
@@ -611,7 +613,7 @@ impl<'env> SpecTranslator<'env> {
             boogie_struct_name(struct_env),
             Self::translate_type_parameters(struct_env)
                 .into_iter()
-                .chain(vec!["$before: Value, $after: Value".to_string()])
+                .chain(vec!["$after: Value".to_string()])
                 .join(", "),
         );
         self.writer.indent();
@@ -626,13 +628,7 @@ impl<'env> SpecTranslator<'env> {
                     let args = ty_args
                         .iter()
                         .map(|ty| self.translate_type(ty))
-                        .chain(
-                            vec![format!(
-                                "$SelectField($before, {}), $SelectField($after, {})",
-                                field_name, field_name
-                            )]
-                            .into_iter(),
-                        )
+                        .chain(vec![format!("$SelectField($after, {})", field_name)].into_iter())
                         .join(", ");
                     emitln!(
                         self.writer,
@@ -860,17 +856,20 @@ impl<'env> SpecTranslator<'env> {
 
     fn translate_local_var(&self, node_id: NodeId, name: Symbol) {
         let mut ty = &self.module_env().get_node_type(node_id);
+        let mut var_name = self.module_env().symbol_pool().string(name);
         // overwrite ty if func_target provides a binding for name
         if let SpecEnv::Function(func_target) = self.spec_env {
             if let Some(local_index) = func_target.get_local_index(name) {
                 ty = func_target.get_local_type(*local_index);
+                if *self.in_ensures.borrow() && !*self.in_old.borrow() {
+                    if let Some(return_index) = func_target.get_return_index(*local_index) {
+                        var_name = Rc::new(format!("$ret{}", return_index));
+                    }
+                }
             }
         };
         self.auto_dref(ty, || {
-            emit!(
-                self.writer,
-                self.module_env().symbol_pool().string(name).as_ref()
-            );
+            emit!(self.writer, var_name.as_ref());
         });
     }
 
@@ -880,7 +879,7 @@ impl<'env> SpecTranslator<'env> {
     {
         if ty.is_reference() {
             // Automatically dereference
-            emit!(self.writer, "$Dereference($m, ");
+            emit!(self.writer, "$Dereference(");
         }
         f();
         if ty.is_reference() {
@@ -917,11 +916,7 @@ impl<'env> SpecTranslator<'env> {
                 self.translate_select(*module_id, *struct_id, *field_id, args)
             }
             Operation::Local(sym) => {
-                emit!(
-                    self.writer,
-                    "$GetLocal($m, $frame + {})",
-                    self.name_to_idx_map[sym],
-                );
+                self.translate_local_var(node_id, *sym);
             }
             Operation::Result(pos) => {
                 self.auto_dref(self.function_target().get_return_type(*pos), || {
@@ -1150,7 +1145,9 @@ impl<'env> SpecTranslator<'env> {
 
     fn translate_old(&self, args: &[Exp]) {
         if self.supports_native_old {
+            *self.in_old.borrow_mut() = true;
             self.translate_primitive_call("old", args);
+            *self.in_old.borrow_mut() = false;
         } else {
             *self.in_old.borrow_mut() = true;
             self.translate_exp(&args[0]);

--- a/language/move-prover/stackless-bytecode-generator/src/borrow_analysis.rs
+++ b/language/move-prover/stackless-bytecode-generator/src/borrow_analysis.rs
@@ -33,11 +33,23 @@ pub struct BorrowInfo {
 }
 
 impl BorrowInfo {
-    fn is_empty(&self) -> bool {
+    pub fn all_refs(&self) -> BTreeSet<TempIndex> {
+        let filter_fn = |node: &BorrowNode| {
+            if let BorrowNode::Reference(idx) = node {
+                Some(*idx)
+            } else {
+                None
+            }
+        };
+        let borrowed_by_refs = self.borrowed_by.keys().filter_map(filter_fn).collect();
+        self.live_refs.union(&borrowed_by_refs).cloned().collect()
+    }
+
+    pub fn is_empty(&self) -> bool {
         self.live_refs.is_empty() && self.borrowed_by.is_empty() && self.borrows_from.is_empty()
     }
 
-    fn borrow_info_str(&self, func_target: &FunctionTarget<'_>) -> String {
+    pub fn borrow_info_str(&self, func_target: &FunctionTarget<'_>) -> String {
         let live_refs_str = format!(
             "live_refs: {}",
             self.live_refs

--- a/language/move-prover/stackless-bytecode-generator/src/dataflow_analysis.rs
+++ b/language/move-prover/stackless-bytecode-generator/src/dataflow_analysis.rs
@@ -83,7 +83,7 @@ pub trait DataflowAnalysis: TransferFunctions {
                                     // The pre changed. Schedule the next block.
                                     work_list.push_back(*next_block_id);
                                 }
-                                _ => unreachable!(), // There shouldn't be any error at this point
+                                _ => unimplemented!(),
                             }
                         }
                         None => {

--- a/language/move-prover/stackless-bytecode-generator/src/eliminate_mut_refs.rs
+++ b/language/move-prover/stackless-bytecode-generator/src/eliminate_mut_refs.rs
@@ -33,6 +33,9 @@ impl FunctionTargetProcessor for EliminateMutRefsProcessor {
         func_env: &FunctionEnv<'_>,
         mut data: FunctionTargetData,
     ) -> FunctionTargetData {
+        if func_env.is_native() {
+            return data;
+        }
         let local_types = &mut data.local_types;
         let return_types = &mut data.return_types;
 
@@ -45,6 +48,7 @@ impl FunctionTargetProcessor for EliminateMutRefsProcessor {
                 let ty = local_types[idx].clone();
                 ref_param_proxy_map.insert(idx, local_types.len());
                 local_types.push(ty.clone());
+                data.ref_param_map.insert(idx, return_types.len());
                 return_types.push(EliminateMutRefs::transform_type(ty));
             }
         }

--- a/language/move-prover/stackless-bytecode-generator/src/function_target.rs
+++ b/language/move-prover/stackless-bytecode-generator/src/function_target.rs
@@ -36,6 +36,7 @@ pub struct FunctionTargetData {
     pub code: Vec<Bytecode>,
     pub local_types: Vec<Type>,
     pub return_types: Vec<Type>,
+    pub ref_param_map: BTreeMap<usize, usize>,
     pub acquires_global_resources: Vec<StructId>,
     pub locations: BTreeMap<AttrId, Loc>,
     pub annotations: Annotations,
@@ -212,6 +213,15 @@ impl<'env> FunctionTarget<'env> {
     /// Gets acquired resources
     pub fn get_acquires_global_resources(&self) -> &[StructId] {
         &self.data.acquires_global_resources
+    }
+
+    /// Gets index of return parameter for a reference input parameter
+    pub fn get_return_index(&self, idx: usize) -> Option<&usize> {
+        self.data.ref_param_map.get(&idx)
+    }
+
+    pub fn call_ends_lifetime(&self) -> bool {
+        self.is_public() && self.get_return_types().iter().all(|ty| !ty.is_reference())
     }
 }
 

--- a/language/move-prover/stackless-bytecode-generator/src/livevar_analysis.rs
+++ b/language/move-prover/stackless-bytecode-generator/src/livevar_analysis.rs
@@ -173,10 +173,12 @@ impl<'a> LiveVarAnalysis<'a> {
                 }
                 Bytecode::Assign(attr_id, dest, _, _) => {
                     let annotation_at = &annotations[&(code_offset as CodeOffset)];
-                    if annotation_at.after.contains(&dest) {
-                        transformed_code.push(bytecode);
-                    } else {
+                    if self.func_target.get_local_type(dest).is_reference()
+                        && !annotation_at.after.contains(&dest)
+                    {
                         transformed_code.push(Bytecode::Nop(attr_id));
+                    } else {
+                        transformed_code.push(bytecode);
                     }
                 }
                 _ => {

--- a/language/move-prover/stackless-bytecode-generator/src/stackless_bytecode.rs
+++ b/language/move-prover/stackless-bytecode-generator/src/stackless_bytecode.rs
@@ -223,11 +223,10 @@ pub enum Bytecode {
     Nop(AttrId),
 
     WriteBack(AttrId, BorrowNode, TempIndex),
+    Splice(AttrId, TempIndex, BTreeMap<usize, TempIndex>),
 
     UnpackRef(AttrId, TempIndex),
     PackRef(AttrId, TempIndex),
-
-    Splice(AttrId, TempIndex, BTreeMap<usize, TempIndex>),
 }
 
 impl Bytecode {
@@ -249,6 +248,10 @@ impl Bytecode {
             | PackRef(id, ..)
             | Splice(id, ..) => *id,
         }
+    }
+
+    pub fn is_exit(&self) -> bool {
+        matches!(self, Bytecode::Ret(..) | Bytecode::Abort(..))
     }
 
     pub fn is_return(&self) -> bool {

--- a/language/move-prover/stackless-bytecode-generator/src/stackless_bytecode_generator.rs
+++ b/language/move-prover/stackless-bytecode-generator/src/stackless_bytecode_generator.rs
@@ -103,6 +103,7 @@ impl<'a> StacklessBytecodeGenerator<'a> {
             code: self.code,
             local_types: self.local_types,
             return_types: self.func_env.get_return_types(),
+            ref_param_map: BTreeMap::new(),
             acquires_global_resources: self.func_env.get_acquires_global_resources(),
             locations: self.location_table,
             annotations: Annotations::default(),

--- a/language/move-prover/stackless-bytecode-generator/src/stackless_control_flow_graph.rs
+++ b/language/move-prover/stackless-bytecode-generator/src/stackless_control_flow_graph.rs
@@ -47,7 +47,7 @@ impl StacklessControlFlowGraph {
             entry_block_ids: blocks
                 .iter()
                 .map(|(block_id, block)| {
-                    if code[block.upper as usize].is_return() {
+                    if code[block.upper as usize].is_exit() {
                         Some(*block_id)
                     } else {
                         None

--- a/language/move-prover/stackless-bytecode-generator/tests/borrow/basic_test.exp
+++ b/language/move-prover/stackless-bytecode-generator/tests/borrow/basic_test.exp
@@ -153,72 +153,97 @@ fun TestBorrow::test7(b: bool) {
 }
 
 
-fun TestBorrow::test8(n: u64, r_ref: &mut TestBorrow::R) {
+fun TestBorrow::test8(b: bool, n: u64, r_ref: &mut TestBorrow::R) {
     var r1: TestBorrow::R
     var r2: TestBorrow::R
-    var $t4: u64
-    var $t5: TestBorrow::R
+    var t_ref: &mut TestBorrow::R
     var $t6: u64
     var $t7: TestBorrow::R
     var $t8: u64
-    var $t9: u64
-    var $t10: bool
-    var $t11: &mut TestBorrow::R
+    var $t9: TestBorrow::R
+    var $t10: &mut TestBorrow::R
+    var $t11: u64
     var $t12: u64
-    var $t13: u64
-    var $t14: u64
+    var $t13: bool
+    var $t14: &mut TestBorrow::R
     var $t15: u64
-    var $t16: bool
-    var $t17: &mut TestBorrow::R
-    var $t18: &mut TestBorrow::R
-    var $t19: u64
-    var $t20: u64
-    var $t21: u64
-    var $t22: &mut TestBorrow::R
+    var $t16: u64
+    var $t17: u64
+    var $t18: u64
+    var $t19: bool
+    var $t20: &mut TestBorrow::R
+    var $t21: &mut TestBorrow::R
+    var $t22: u64
     var $t23: u64
-    $t4 := 3
-    $t5 := pack TestBorrow::R($t4)
-    r1 := $t5
-    $t6 := 4
+    var $t24: u64
+    var $t25: bool
+    var $t26: &mut TestBorrow::R
+    var $t27: &mut TestBorrow::R
+    var $t28: u64
+    var $t29: &mut TestBorrow::R
+    var $t30: &mut TestBorrow::R
+    var $t31: u64
+    $t6 := 3
     $t7 := pack TestBorrow::R($t6)
-    r2 := $t7
+    r1 := $t7
+    $t8 := 4
+    $t9 := pack TestBorrow::R($t8)
+    r2 := $t9
+    $t10 := borrow_local(r2)
+    t_ref := $t10
     goto L7
     L7:
-    $t8 := 0
-    $t9 := copy(n)
-    $t10 := <($t8, $t9)
-    if ($t10) goto L0 else goto L1
+    $t11 := 0
+    $t12 := copy(n)
+    $t13 := <($t11, $t12)
+    if ($t13) goto L0 else goto L1
     L1:
     goto L2
     L0:
-    $t11 := move(r_ref)
-    destroy($t11)
-    $t12 := copy(n)
-    $t13 := 2
-    $t14 := /($t12, $t13)
-    $t15 := 0
-    $t16 := ==($t14, $t15)
-    if ($t16) goto L3 else goto L4
+    $t14 := move(t_ref)
+    destroy($t14)
+    $t15 := copy(n)
+    $t16 := 2
+    $t17 := /($t15, $t16)
+    $t18 := 0
+    $t19 := ==($t17, $t18)
+    if ($t19) goto L3 else goto L4
     L4:
     goto L5
     L3:
-    $t17 := borrow_local(r1)
-    r_ref := $t17
+    $t20 := borrow_local(r1)
+    t_ref := $t20
     goto L6
     L5:
-    $t18 := borrow_local(r2)
-    r_ref := $t18
+    $t21 := borrow_local(r2)
+    t_ref := $t21
     goto L6
     L6:
-    $t19 := copy(n)
-    $t20 := 1
-    $t21 := -($t19, $t20)
-    n := $t21
+    $t22 := copy(n)
+    $t23 := 1
+    $t24 := -($t22, $t23)
+    n := $t24
     goto L7
     L2:
-    $t22 := move(r_ref)
-    $t23 := 0
-    TestBorrow::test3($t22, $t23)
+    $t25 := copy(b)
+    if ($t25) goto L8 else goto L9
+    L9:
+    goto L10
+    L8:
+    $t26 := move(t_ref)
+    destroy($t26)
+    $t27 := move(r_ref)
+    $t28 := 0
+    TestBorrow::test3($t27, $t28)
+    goto L11
+    L10:
+    $t29 := move(r_ref)
+    destroy($t29)
+    $t30 := move(t_ref)
+    $t31 := 0
+    TestBorrow::test3($t30, $t31)
+    goto L11
+    L11:
     return ()
 }
 
@@ -421,102 +446,154 @@ fun TestBorrow::test7(b: bool) {
 }
 
 
-fun TestBorrow::test8(n: u64, r_ref: &mut TestBorrow::R) {
+fun TestBorrow::test8(b: bool, n: u64, r_ref: &mut TestBorrow::R) {
     var r1: TestBorrow::R
     var r2: TestBorrow::R
-    var $t4: u64
-    var $t5: TestBorrow::R
+    var t_ref: &mut TestBorrow::R
     var $t6: u64
     var $t7: TestBorrow::R
     var $t8: u64
-    var $t9: u64
-    var $t10: bool
-    var $t11: &mut TestBorrow::R
+    var $t9: TestBorrow::R
+    var $t10: &mut TestBorrow::R
+    var $t11: u64
     var $t12: u64
-    var $t13: u64
-    var $t14: u64
+    var $t13: bool
+    var $t14: &mut TestBorrow::R
     var $t15: u64
-    var $t16: bool
-    var $t17: &mut TestBorrow::R
-    var $t18: &mut TestBorrow::R
-    var $t19: u64
-    var $t20: u64
-    var $t21: u64
-    var $t22: &mut TestBorrow::R
+    var $t16: u64
+    var $t17: u64
+    var $t18: u64
+    var $t19: bool
+    var $t20: &mut TestBorrow::R
+    var $t21: &mut TestBorrow::R
+    var $t22: u64
     var $t23: u64
+    var $t24: u64
+    var $t25: bool
+    var $t26: &mut TestBorrow::R
+    var $t27: &mut TestBorrow::R
+    var $t28: u64
+    var $t29: &mut TestBorrow::R
+    var $t30: &mut TestBorrow::R
+    var $t31: u64
     // live_refs: r_ref borrowed_by: LocalRoot(r_ref) -> {Reference(r_ref)} borrows_from: Reference(r_ref) -> {LocalRoot(r_ref)}
-    $t4 := 3
-    // live_refs: r_ref borrowed_by: LocalRoot(r_ref) -> {Reference(r_ref)} borrows_from: Reference(r_ref) -> {LocalRoot(r_ref)}
-    $t5 := pack TestBorrow::R($t4)
-    // live_refs: r_ref borrowed_by: LocalRoot(r_ref) -> {Reference(r_ref)} borrows_from: Reference(r_ref) -> {LocalRoot(r_ref)}
-    r1 := $t5
-    // live_refs: r_ref borrowed_by: LocalRoot(r_ref) -> {Reference(r_ref)} borrows_from: Reference(r_ref) -> {LocalRoot(r_ref)}
-    $t6 := 4
+    $t6 := 3
     // live_refs: r_ref borrowed_by: LocalRoot(r_ref) -> {Reference(r_ref)} borrows_from: Reference(r_ref) -> {LocalRoot(r_ref)}
     $t7 := pack TestBorrow::R($t6)
     // live_refs: r_ref borrowed_by: LocalRoot(r_ref) -> {Reference(r_ref)} borrows_from: Reference(r_ref) -> {LocalRoot(r_ref)}
-    r2 := $t7
+    r1 := $t7
     // live_refs: r_ref borrowed_by: LocalRoot(r_ref) -> {Reference(r_ref)} borrows_from: Reference(r_ref) -> {LocalRoot(r_ref)}
+    $t8 := 4
+    // live_refs: r_ref borrowed_by: LocalRoot(r_ref) -> {Reference(r_ref)} borrows_from: Reference(r_ref) -> {LocalRoot(r_ref)}
+    $t9 := pack TestBorrow::R($t8)
+    // live_refs: r_ref borrowed_by: LocalRoot(r_ref) -> {Reference(r_ref)} borrows_from: Reference(r_ref) -> {LocalRoot(r_ref)}
+    r2 := $t9
+    // live_refs: r_ref borrowed_by: LocalRoot(r_ref) -> {Reference(r_ref)} borrows_from: Reference(r_ref) -> {LocalRoot(r_ref)}
+    $t10 := borrow_local(r2)
+    // live_refs: r_ref, $t10 borrowed_by: LocalRoot(r_ref) -> {Reference(r_ref)}, LocalRoot(r2) -> {Reference($t10)} borrows_from: Reference(r_ref) -> {LocalRoot(r_ref)}, Reference($t10) -> {LocalRoot(r2)}
+    t_ref := $t10
+    // live_refs: r_ref, t_ref borrowed_by: LocalRoot(r_ref) -> {Reference(r_ref)}, LocalRoot(r2) -> {Reference(t_ref)} borrows_from: Reference(r_ref) -> {LocalRoot(r_ref)}, Reference(t_ref) -> {LocalRoot(r2)}
     goto L7
-    // live_refs: r_ref borrowed_by: LocalRoot(r_ref) -> {Reference(r_ref)}, LocalRoot(r1) -> {Reference(r_ref)}, LocalRoot(r2) -> {Reference(r_ref)} borrows_from: Reference(r_ref) -> {LocalRoot(r_ref), LocalRoot(r1), LocalRoot(r2)}
+    // live_refs: r_ref, t_ref borrowed_by: LocalRoot(r_ref) -> {Reference(r_ref)}, LocalRoot(r1) -> {Reference(t_ref)}, LocalRoot(r2) -> {Reference(t_ref)} borrows_from: Reference(r_ref) -> {LocalRoot(r_ref)}, Reference(t_ref) -> {LocalRoot(r1), LocalRoot(r2)}
     L7:
-    // live_refs: r_ref borrowed_by: LocalRoot(r_ref) -> {Reference(r_ref)}, LocalRoot(r1) -> {Reference(r_ref)}, LocalRoot(r2) -> {Reference(r_ref)} borrows_from: Reference(r_ref) -> {LocalRoot(r_ref), LocalRoot(r1), LocalRoot(r2)}
-    $t8 := 0
-    // live_refs: r_ref borrowed_by: LocalRoot(r_ref) -> {Reference(r_ref)}, LocalRoot(r1) -> {Reference(r_ref)}, LocalRoot(r2) -> {Reference(r_ref)} borrows_from: Reference(r_ref) -> {LocalRoot(r_ref), LocalRoot(r1), LocalRoot(r2)}
-    $t9 := copy(n)
-    // live_refs: r_ref borrowed_by: LocalRoot(r_ref) -> {Reference(r_ref)}, LocalRoot(r1) -> {Reference(r_ref)}, LocalRoot(r2) -> {Reference(r_ref)} borrows_from: Reference(r_ref) -> {LocalRoot(r_ref), LocalRoot(r1), LocalRoot(r2)}
-    $t10 := <($t8, $t9)
-    // live_refs: r_ref borrowed_by: LocalRoot(r_ref) -> {Reference(r_ref)}, LocalRoot(r1) -> {Reference(r_ref)}, LocalRoot(r2) -> {Reference(r_ref)} borrows_from: Reference(r_ref) -> {LocalRoot(r_ref), LocalRoot(r1), LocalRoot(r2)}
-    if ($t10) goto L0 else goto L1
-    // live_refs: r_ref borrowed_by: LocalRoot(r_ref) -> {Reference(r_ref)}, LocalRoot(r1) -> {Reference(r_ref)}, LocalRoot(r2) -> {Reference(r_ref)} borrows_from: Reference(r_ref) -> {LocalRoot(r_ref), LocalRoot(r1), LocalRoot(r2)}
-    L1:
-    // live_refs: r_ref borrowed_by: LocalRoot(r_ref) -> {Reference(r_ref)}, LocalRoot(r1) -> {Reference(r_ref)}, LocalRoot(r2) -> {Reference(r_ref)} borrows_from: Reference(r_ref) -> {LocalRoot(r_ref), LocalRoot(r1), LocalRoot(r2)}
-    goto L2
-    // live_refs: r_ref borrowed_by: LocalRoot(r_ref) -> {Reference(r_ref)}, LocalRoot(r1) -> {Reference(r_ref)}, LocalRoot(r2) -> {Reference(r_ref)} borrows_from: Reference(r_ref) -> {LocalRoot(r_ref), LocalRoot(r1), LocalRoot(r2)}
-    L0:
-    // live_refs: r_ref borrowed_by: LocalRoot(r_ref) -> {Reference(r_ref)}, LocalRoot(r1) -> {Reference(r_ref)}, LocalRoot(r2) -> {Reference(r_ref)} borrows_from: Reference(r_ref) -> {LocalRoot(r_ref), LocalRoot(r1), LocalRoot(r2)}
-    $t11 := move(r_ref)
-    // live_refs: $t11 borrowed_by: LocalRoot(r_ref) -> {Reference($t11)}, LocalRoot(r1) -> {Reference($t11)}, LocalRoot(r2) -> {Reference($t11)} borrows_from: Reference($t11) -> {LocalRoot(r_ref), LocalRoot(r1), LocalRoot(r2)}
-    destroy($t11)
+    // live_refs: r_ref, t_ref borrowed_by: LocalRoot(r_ref) -> {Reference(r_ref)}, LocalRoot(r1) -> {Reference(t_ref)}, LocalRoot(r2) -> {Reference(t_ref)} borrows_from: Reference(r_ref) -> {LocalRoot(r_ref)}, Reference(t_ref) -> {LocalRoot(r1), LocalRoot(r2)}
+    $t11 := 0
+    // live_refs: r_ref, t_ref borrowed_by: LocalRoot(r_ref) -> {Reference(r_ref)}, LocalRoot(r1) -> {Reference(t_ref)}, LocalRoot(r2) -> {Reference(t_ref)} borrows_from: Reference(r_ref) -> {LocalRoot(r_ref)}, Reference(t_ref) -> {LocalRoot(r1), LocalRoot(r2)}
     $t12 := copy(n)
-    $t13 := 2
-    $t14 := /($t12, $t13)
-    $t15 := 0
-    $t16 := ==($t14, $t15)
-    if ($t16) goto L3 else goto L4
+    // live_refs: r_ref, t_ref borrowed_by: LocalRoot(r_ref) -> {Reference(r_ref)}, LocalRoot(r1) -> {Reference(t_ref)}, LocalRoot(r2) -> {Reference(t_ref)} borrows_from: Reference(r_ref) -> {LocalRoot(r_ref)}, Reference(t_ref) -> {LocalRoot(r1), LocalRoot(r2)}
+    $t13 := <($t11, $t12)
+    // live_refs: r_ref, t_ref borrowed_by: LocalRoot(r_ref) -> {Reference(r_ref)}, LocalRoot(r1) -> {Reference(t_ref)}, LocalRoot(r2) -> {Reference(t_ref)} borrows_from: Reference(r_ref) -> {LocalRoot(r_ref)}, Reference(t_ref) -> {LocalRoot(r1), LocalRoot(r2)}
+    if ($t13) goto L0 else goto L1
+    // live_refs: r_ref, t_ref borrowed_by: LocalRoot(r_ref) -> {Reference(r_ref)}, LocalRoot(r1) -> {Reference(t_ref)}, LocalRoot(r2) -> {Reference(t_ref)} borrows_from: Reference(r_ref) -> {LocalRoot(r_ref)}, Reference(t_ref) -> {LocalRoot(r1), LocalRoot(r2)}
+    L1:
+    // live_refs: r_ref, t_ref borrowed_by: LocalRoot(r_ref) -> {Reference(r_ref)}, LocalRoot(r1) -> {Reference(t_ref)}, LocalRoot(r2) -> {Reference(t_ref)} borrows_from: Reference(r_ref) -> {LocalRoot(r_ref)}, Reference(t_ref) -> {LocalRoot(r1), LocalRoot(r2)}
+    goto L2
+    // live_refs: r_ref, t_ref borrowed_by: LocalRoot(r_ref) -> {Reference(r_ref)}, LocalRoot(r1) -> {Reference(t_ref)}, LocalRoot(r2) -> {Reference(t_ref)} borrows_from: Reference(r_ref) -> {LocalRoot(r_ref)}, Reference(t_ref) -> {LocalRoot(r1), LocalRoot(r2)}
+    L0:
+    // live_refs: r_ref, t_ref borrowed_by: LocalRoot(r_ref) -> {Reference(r_ref)}, LocalRoot(r1) -> {Reference(t_ref)}, LocalRoot(r2) -> {Reference(t_ref)} borrows_from: Reference(r_ref) -> {LocalRoot(r_ref)}, Reference(t_ref) -> {LocalRoot(r1), LocalRoot(r2)}
+    $t14 := move(t_ref)
+    // live_refs: r_ref, $t14 borrowed_by: LocalRoot(r_ref) -> {Reference(r_ref)}, LocalRoot(r1) -> {Reference($t14)}, LocalRoot(r2) -> {Reference($t14)} borrows_from: Reference(r_ref) -> {LocalRoot(r_ref)}, Reference($t14) -> {LocalRoot(r1), LocalRoot(r2)}
+    destroy($t14)
+    // live_refs: r_ref borrowed_by: LocalRoot(r_ref) -> {Reference(r_ref)} borrows_from: Reference(r_ref) -> {LocalRoot(r_ref)}
+    $t15 := copy(n)
+    // live_refs: r_ref borrowed_by: LocalRoot(r_ref) -> {Reference(r_ref)} borrows_from: Reference(r_ref) -> {LocalRoot(r_ref)}
+    $t16 := 2
+    // live_refs: r_ref borrowed_by: LocalRoot(r_ref) -> {Reference(r_ref)} borrows_from: Reference(r_ref) -> {LocalRoot(r_ref)}
+    $t17 := /($t15, $t16)
+    // live_refs: r_ref borrowed_by: LocalRoot(r_ref) -> {Reference(r_ref)} borrows_from: Reference(r_ref) -> {LocalRoot(r_ref)}
+    $t18 := 0
+    // live_refs: r_ref borrowed_by: LocalRoot(r_ref) -> {Reference(r_ref)} borrows_from: Reference(r_ref) -> {LocalRoot(r_ref)}
+    $t19 := ==($t17, $t18)
+    // live_refs: r_ref borrowed_by: LocalRoot(r_ref) -> {Reference(r_ref)} borrows_from: Reference(r_ref) -> {LocalRoot(r_ref)}
+    if ($t19) goto L3 else goto L4
+    // live_refs: r_ref borrowed_by: LocalRoot(r_ref) -> {Reference(r_ref)} borrows_from: Reference(r_ref) -> {LocalRoot(r_ref)}
     L4:
+    // live_refs: r_ref borrowed_by: LocalRoot(r_ref) -> {Reference(r_ref)} borrows_from: Reference(r_ref) -> {LocalRoot(r_ref)}
     goto L5
+    // live_refs: r_ref borrowed_by: LocalRoot(r_ref) -> {Reference(r_ref)} borrows_from: Reference(r_ref) -> {LocalRoot(r_ref)}
     L3:
-    $t17 := borrow_local(r1)
-    // live_refs: $t17 borrowed_by: LocalRoot(r1) -> {Reference($t17)} borrows_from: Reference($t17) -> {LocalRoot(r1)}
-    r_ref := $t17
-    // live_refs: r_ref borrowed_by: LocalRoot(r1) -> {Reference(r_ref)} borrows_from: Reference(r_ref) -> {LocalRoot(r1)}
+    // live_refs: r_ref borrowed_by: LocalRoot(r_ref) -> {Reference(r_ref)} borrows_from: Reference(r_ref) -> {LocalRoot(r_ref)}
+    $t20 := borrow_local(r1)
+    // live_refs: r_ref, $t20 borrowed_by: LocalRoot(r_ref) -> {Reference(r_ref)}, LocalRoot(r1) -> {Reference($t20)} borrows_from: Reference(r_ref) -> {LocalRoot(r_ref)}, Reference($t20) -> {LocalRoot(r1)}
+    t_ref := $t20
+    // live_refs: r_ref, t_ref borrowed_by: LocalRoot(r_ref) -> {Reference(r_ref)}, LocalRoot(r1) -> {Reference(t_ref)} borrows_from: Reference(r_ref) -> {LocalRoot(r_ref)}, Reference(t_ref) -> {LocalRoot(r1)}
     goto L6
+    // live_refs: r_ref borrowed_by: LocalRoot(r_ref) -> {Reference(r_ref)} borrows_from: Reference(r_ref) -> {LocalRoot(r_ref)}
     L5:
-    $t18 := borrow_local(r2)
-    // live_refs: $t18 borrowed_by: LocalRoot(r2) -> {Reference($t18)} borrows_from: Reference($t18) -> {LocalRoot(r2)}
-    r_ref := $t18
-    // live_refs: r_ref borrowed_by: LocalRoot(r2) -> {Reference(r_ref)} borrows_from: Reference(r_ref) -> {LocalRoot(r2)}
+    // live_refs: r_ref borrowed_by: LocalRoot(r_ref) -> {Reference(r_ref)} borrows_from: Reference(r_ref) -> {LocalRoot(r_ref)}
+    $t21 := borrow_local(r2)
+    // live_refs: r_ref, $t21 borrowed_by: LocalRoot(r_ref) -> {Reference(r_ref)}, LocalRoot(r2) -> {Reference($t21)} borrows_from: Reference(r_ref) -> {LocalRoot(r_ref)}, Reference($t21) -> {LocalRoot(r2)}
+    t_ref := $t21
+    // live_refs: r_ref, t_ref borrowed_by: LocalRoot(r_ref) -> {Reference(r_ref)}, LocalRoot(r2) -> {Reference(t_ref)} borrows_from: Reference(r_ref) -> {LocalRoot(r_ref)}, Reference(t_ref) -> {LocalRoot(r2)}
     goto L6
-    // live_refs: r_ref borrowed_by: LocalRoot(r1) -> {Reference(r_ref)}, LocalRoot(r2) -> {Reference(r_ref)} borrows_from: Reference(r_ref) -> {LocalRoot(r1), LocalRoot(r2)}
+    // live_refs: r_ref, t_ref borrowed_by: LocalRoot(r_ref) -> {Reference(r_ref)}, LocalRoot(r1) -> {Reference(t_ref)}, LocalRoot(r2) -> {Reference(t_ref)} borrows_from: Reference(r_ref) -> {LocalRoot(r_ref)}, Reference(t_ref) -> {LocalRoot(r1), LocalRoot(r2)}
     L6:
-    // live_refs: r_ref borrowed_by: LocalRoot(r1) -> {Reference(r_ref)}, LocalRoot(r2) -> {Reference(r_ref)} borrows_from: Reference(r_ref) -> {LocalRoot(r1), LocalRoot(r2)}
-    $t19 := copy(n)
-    // live_refs: r_ref borrowed_by: LocalRoot(r1) -> {Reference(r_ref)}, LocalRoot(r2) -> {Reference(r_ref)} borrows_from: Reference(r_ref) -> {LocalRoot(r1), LocalRoot(r2)}
-    $t20 := 1
-    // live_refs: r_ref borrowed_by: LocalRoot(r1) -> {Reference(r_ref)}, LocalRoot(r2) -> {Reference(r_ref)} borrows_from: Reference(r_ref) -> {LocalRoot(r1), LocalRoot(r2)}
-    $t21 := -($t19, $t20)
-    // live_refs: r_ref borrowed_by: LocalRoot(r1) -> {Reference(r_ref)}, LocalRoot(r2) -> {Reference(r_ref)} borrows_from: Reference(r_ref) -> {LocalRoot(r1), LocalRoot(r2)}
-    n := $t21
-    // live_refs: r_ref borrowed_by: LocalRoot(r1) -> {Reference(r_ref)}, LocalRoot(r2) -> {Reference(r_ref)} borrows_from: Reference(r_ref) -> {LocalRoot(r1), LocalRoot(r2)}
+    // live_refs: r_ref, t_ref borrowed_by: LocalRoot(r_ref) -> {Reference(r_ref)}, LocalRoot(r1) -> {Reference(t_ref)}, LocalRoot(r2) -> {Reference(t_ref)} borrows_from: Reference(r_ref) -> {LocalRoot(r_ref)}, Reference(t_ref) -> {LocalRoot(r1), LocalRoot(r2)}
+    $t22 := copy(n)
+    // live_refs: r_ref, t_ref borrowed_by: LocalRoot(r_ref) -> {Reference(r_ref)}, LocalRoot(r1) -> {Reference(t_ref)}, LocalRoot(r2) -> {Reference(t_ref)} borrows_from: Reference(r_ref) -> {LocalRoot(r_ref)}, Reference(t_ref) -> {LocalRoot(r1), LocalRoot(r2)}
+    $t23 := 1
+    // live_refs: r_ref, t_ref borrowed_by: LocalRoot(r_ref) -> {Reference(r_ref)}, LocalRoot(r1) -> {Reference(t_ref)}, LocalRoot(r2) -> {Reference(t_ref)} borrows_from: Reference(r_ref) -> {LocalRoot(r_ref)}, Reference(t_ref) -> {LocalRoot(r1), LocalRoot(r2)}
+    $t24 := -($t22, $t23)
+    // live_refs: r_ref, t_ref borrowed_by: LocalRoot(r_ref) -> {Reference(r_ref)}, LocalRoot(r1) -> {Reference(t_ref)}, LocalRoot(r2) -> {Reference(t_ref)} borrows_from: Reference(r_ref) -> {LocalRoot(r_ref)}, Reference(t_ref) -> {LocalRoot(r1), LocalRoot(r2)}
+    n := $t24
+    // live_refs: r_ref, t_ref borrowed_by: LocalRoot(r_ref) -> {Reference(r_ref)}, LocalRoot(r1) -> {Reference(t_ref)}, LocalRoot(r2) -> {Reference(t_ref)} borrows_from: Reference(r_ref) -> {LocalRoot(r_ref)}, Reference(t_ref) -> {LocalRoot(r1), LocalRoot(r2)}
     goto L7
-    // live_refs: r_ref borrowed_by: LocalRoot(r_ref) -> {Reference(r_ref)}, LocalRoot(r1) -> {Reference(r_ref)}, LocalRoot(r2) -> {Reference(r_ref)} borrows_from: Reference(r_ref) -> {LocalRoot(r_ref), LocalRoot(r1), LocalRoot(r2)}
+    // live_refs: r_ref, t_ref borrowed_by: LocalRoot(r_ref) -> {Reference(r_ref)}, LocalRoot(r1) -> {Reference(t_ref)}, LocalRoot(r2) -> {Reference(t_ref)} borrows_from: Reference(r_ref) -> {LocalRoot(r_ref)}, Reference(t_ref) -> {LocalRoot(r1), LocalRoot(r2)}
     L2:
-    // live_refs: r_ref borrowed_by: LocalRoot(r_ref) -> {Reference(r_ref)}, LocalRoot(r1) -> {Reference(r_ref)}, LocalRoot(r2) -> {Reference(r_ref)} borrows_from: Reference(r_ref) -> {LocalRoot(r_ref), LocalRoot(r1), LocalRoot(r2)}
-    $t22 := move(r_ref)
-    // live_refs: $t22 borrowed_by: LocalRoot(r_ref) -> {Reference($t22)}, LocalRoot(r1) -> {Reference($t22)}, LocalRoot(r2) -> {Reference($t22)} borrows_from: Reference($t22) -> {LocalRoot(r_ref), LocalRoot(r1), LocalRoot(r2)}
-    $t23 := 0
-    // live_refs: $t22 borrowed_by: LocalRoot(r_ref) -> {Reference($t22)}, LocalRoot(r1) -> {Reference($t22)}, LocalRoot(r2) -> {Reference($t22)} borrows_from: Reference($t22) -> {LocalRoot(r_ref), LocalRoot(r1), LocalRoot(r2)}
-    TestBorrow::test3($t22, $t23)
+    // live_refs: r_ref, t_ref borrowed_by: LocalRoot(r_ref) -> {Reference(r_ref)}, LocalRoot(r1) -> {Reference(t_ref)}, LocalRoot(r2) -> {Reference(t_ref)} borrows_from: Reference(r_ref) -> {LocalRoot(r_ref)}, Reference(t_ref) -> {LocalRoot(r1), LocalRoot(r2)}
+    $t25 := copy(b)
+    // live_refs: r_ref, t_ref borrowed_by: LocalRoot(r_ref) -> {Reference(r_ref)}, LocalRoot(r1) -> {Reference(t_ref)}, LocalRoot(r2) -> {Reference(t_ref)} borrows_from: Reference(r_ref) -> {LocalRoot(r_ref)}, Reference(t_ref) -> {LocalRoot(r1), LocalRoot(r2)}
+    if ($t25) goto L8 else goto L9
+    // live_refs: r_ref, t_ref borrowed_by: LocalRoot(r_ref) -> {Reference(r_ref)}, LocalRoot(r1) -> {Reference(t_ref)}, LocalRoot(r2) -> {Reference(t_ref)} borrows_from: Reference(r_ref) -> {LocalRoot(r_ref)}, Reference(t_ref) -> {LocalRoot(r1), LocalRoot(r2)}
+    L9:
+    // live_refs: r_ref, t_ref borrowed_by: LocalRoot(r_ref) -> {Reference(r_ref)}, LocalRoot(r1) -> {Reference(t_ref)}, LocalRoot(r2) -> {Reference(t_ref)} borrows_from: Reference(r_ref) -> {LocalRoot(r_ref)}, Reference(t_ref) -> {LocalRoot(r1), LocalRoot(r2)}
+    goto L10
+    // live_refs: r_ref, t_ref borrowed_by: LocalRoot(r_ref) -> {Reference(r_ref)}, LocalRoot(r1) -> {Reference(t_ref)}, LocalRoot(r2) -> {Reference(t_ref)} borrows_from: Reference(r_ref) -> {LocalRoot(r_ref)}, Reference(t_ref) -> {LocalRoot(r1), LocalRoot(r2)}
+    L8:
+    // live_refs: r_ref, t_ref borrowed_by: LocalRoot(r_ref) -> {Reference(r_ref)}, LocalRoot(r1) -> {Reference(t_ref)}, LocalRoot(r2) -> {Reference(t_ref)} borrows_from: Reference(r_ref) -> {LocalRoot(r_ref)}, Reference(t_ref) -> {LocalRoot(r1), LocalRoot(r2)}
+    $t26 := move(t_ref)
+    // live_refs: r_ref, $t26 borrowed_by: LocalRoot(r_ref) -> {Reference(r_ref)}, LocalRoot(r1) -> {Reference($t26)}, LocalRoot(r2) -> {Reference($t26)} borrows_from: Reference(r_ref) -> {LocalRoot(r_ref)}, Reference($t26) -> {LocalRoot(r1), LocalRoot(r2)}
+    destroy($t26)
+    // live_refs: r_ref borrowed_by: LocalRoot(r_ref) -> {Reference(r_ref)} borrows_from: Reference(r_ref) -> {LocalRoot(r_ref)}
+    $t27 := move(r_ref)
+    // live_refs: $t27 borrowed_by: LocalRoot(r_ref) -> {Reference($t27)} borrows_from: Reference($t27) -> {LocalRoot(r_ref)}
+    $t28 := 0
+    // live_refs: $t27 borrowed_by: LocalRoot(r_ref) -> {Reference($t27)} borrows_from: Reference($t27) -> {LocalRoot(r_ref)}
+    TestBorrow::test3($t27, $t28)
+    goto L11
+    // live_refs: r_ref, t_ref borrowed_by: LocalRoot(r_ref) -> {Reference(r_ref)}, LocalRoot(r1) -> {Reference(t_ref)}, LocalRoot(r2) -> {Reference(t_ref)} borrows_from: Reference(r_ref) -> {LocalRoot(r_ref)}, Reference(t_ref) -> {LocalRoot(r1), LocalRoot(r2)}
+    L10:
+    // live_refs: r_ref, t_ref borrowed_by: LocalRoot(r_ref) -> {Reference(r_ref)}, LocalRoot(r1) -> {Reference(t_ref)}, LocalRoot(r2) -> {Reference(t_ref)} borrows_from: Reference(r_ref) -> {LocalRoot(r_ref)}, Reference(t_ref) -> {LocalRoot(r1), LocalRoot(r2)}
+    $t29 := move(r_ref)
+    // live_refs: t_ref, $t29 borrowed_by: LocalRoot(r_ref) -> {Reference($t29)}, LocalRoot(r1) -> {Reference(t_ref)}, LocalRoot(r2) -> {Reference(t_ref)} borrows_from: Reference(t_ref) -> {LocalRoot(r1), LocalRoot(r2)}, Reference($t29) -> {LocalRoot(r_ref)}
+    destroy($t29)
+    // live_refs: t_ref borrowed_by: LocalRoot(r1) -> {Reference(t_ref)}, LocalRoot(r2) -> {Reference(t_ref)} borrows_from: Reference(t_ref) -> {LocalRoot(r1), LocalRoot(r2)}
+    $t30 := move(t_ref)
+    // live_refs: $t30 borrowed_by: LocalRoot(r1) -> {Reference($t30)}, LocalRoot(r2) -> {Reference($t30)} borrows_from: Reference($t30) -> {LocalRoot(r1), LocalRoot(r2)}
+    $t31 := 0
+    // live_refs: $t30 borrowed_by: LocalRoot(r1) -> {Reference($t30)}, LocalRoot(r2) -> {Reference($t30)} borrows_from: Reference($t30) -> {LocalRoot(r1), LocalRoot(r2)}
+    TestBorrow::test3($t30, $t31)
+    goto L11
+    L11:
     return ()
 }

--- a/language/move-prover/stackless-bytecode-generator/tests/borrow/basic_test.move
+++ b/language/move-prover/stackless-bytecode-generator/tests/borrow/basic_test.move
@@ -49,17 +49,22 @@ module TestBorrow {
         test3(r_ref, 0)
     }
 
-    fun test8(n: u64, r_ref: &mut R) {
+    fun test8(b: bool, n: u64, r_ref: &mut R) {
         let r1 = R {x: 3};
         let r2 = R {x: 4};
+        let t_ref = &mut r2;
         while (0 < n) {
             if (n/2 == 0) {
-                r_ref = &mut r1
+                t_ref = &mut r1
             } else {
-                r_ref = &mut r2;
+                t_ref = &mut r2;
             };
             n = n - 1
         };
-        test3(r_ref, 0)
+        if (b) {
+            test3(r_ref, 0);
+        } else {
+            test3(t_ref, 0);
+        }
     }
 }

--- a/language/move-prover/stackless-bytecode-generator/tests/eliminate_mut_refs/basic_test.exp
+++ b/language/move-prover/stackless-bytecode-generator/tests/eliminate_mut_refs/basic_test.exp
@@ -153,72 +153,97 @@ fun TestEliminateMutRefs::test7(b: bool) {
 }
 
 
-fun TestEliminateMutRefs::test8(n: u64, r_ref: &mut TestEliminateMutRefs::R) {
+fun TestEliminateMutRefs::test8(b: bool, n: u64, r_ref: &mut TestEliminateMutRefs::R) {
     var r1: TestEliminateMutRefs::R
     var r2: TestEliminateMutRefs::R
-    var $t4: u64
-    var $t5: TestEliminateMutRefs::R
+    var t_ref: &mut TestEliminateMutRefs::R
     var $t6: u64
     var $t7: TestEliminateMutRefs::R
     var $t8: u64
-    var $t9: u64
-    var $t10: bool
-    var $t11: &mut TestEliminateMutRefs::R
+    var $t9: TestEliminateMutRefs::R
+    var $t10: &mut TestEliminateMutRefs::R
+    var $t11: u64
     var $t12: u64
-    var $t13: u64
-    var $t14: u64
+    var $t13: bool
+    var $t14: &mut TestEliminateMutRefs::R
     var $t15: u64
-    var $t16: bool
-    var $t17: &mut TestEliminateMutRefs::R
-    var $t18: &mut TestEliminateMutRefs::R
-    var $t19: u64
-    var $t20: u64
-    var $t21: u64
-    var $t22: &mut TestEliminateMutRefs::R
+    var $t16: u64
+    var $t17: u64
+    var $t18: u64
+    var $t19: bool
+    var $t20: &mut TestEliminateMutRefs::R
+    var $t21: &mut TestEliminateMutRefs::R
+    var $t22: u64
     var $t23: u64
-    $t4 := 3
-    $t5 := pack TestEliminateMutRefs::R($t4)
-    r1 := $t5
-    $t6 := 4
+    var $t24: u64
+    var $t25: bool
+    var $t26: &mut TestEliminateMutRefs::R
+    var $t27: &mut TestEliminateMutRefs::R
+    var $t28: u64
+    var $t29: &mut TestEliminateMutRefs::R
+    var $t30: &mut TestEliminateMutRefs::R
+    var $t31: u64
+    $t6 := 3
     $t7 := pack TestEliminateMutRefs::R($t6)
-    r2 := $t7
+    r1 := $t7
+    $t8 := 4
+    $t9 := pack TestEliminateMutRefs::R($t8)
+    r2 := $t9
+    $t10 := borrow_local(r2)
+    t_ref := $t10
     goto L7
     L7:
-    $t8 := 0
-    $t9 := copy(n)
-    $t10 := <($t8, $t9)
-    if ($t10) goto L0 else goto L1
+    $t11 := 0
+    $t12 := copy(n)
+    $t13 := <($t11, $t12)
+    if ($t13) goto L0 else goto L1
     L1:
     goto L2
     L0:
-    $t11 := move(r_ref)
-    destroy($t11)
-    $t12 := copy(n)
-    $t13 := 2
-    $t14 := /($t12, $t13)
-    $t15 := 0
-    $t16 := ==($t14, $t15)
-    if ($t16) goto L3 else goto L4
+    $t14 := move(t_ref)
+    destroy($t14)
+    $t15 := copy(n)
+    $t16 := 2
+    $t17 := /($t15, $t16)
+    $t18 := 0
+    $t19 := ==($t17, $t18)
+    if ($t19) goto L3 else goto L4
     L4:
     goto L5
     L3:
-    $t17 := borrow_local(r1)
-    r_ref := $t17
+    $t20 := borrow_local(r1)
+    t_ref := $t20
     goto L6
     L5:
-    $t18 := borrow_local(r2)
-    r_ref := $t18
+    $t21 := borrow_local(r2)
+    t_ref := $t21
     goto L6
     L6:
-    $t19 := copy(n)
-    $t20 := 1
-    $t21 := -($t19, $t20)
-    n := $t21
+    $t22 := copy(n)
+    $t23 := 1
+    $t24 := -($t22, $t23)
+    n := $t24
     goto L7
     L2:
-    $t22 := move(r_ref)
-    $t23 := 0
-    TestEliminateMutRefs::test3($t22, $t23)
+    $t25 := copy(b)
+    if ($t25) goto L8 else goto L9
+    L9:
+    goto L10
+    L8:
+    $t26 := move(t_ref)
+    destroy($t26)
+    $t27 := move(r_ref)
+    $t28 := 0
+    TestEliminateMutRefs::test3($t27, $t28)
+    goto L11
+    L10:
+    $t29 := move(r_ref)
+    destroy($t29)
+    $t30 := move(t_ref)
+    $t31 := 0
+    TestEliminateMutRefs::test3($t30, $t31)
+    goto L11
+    L11:
     return ()
 }
 
@@ -272,7 +297,6 @@ fun TestEliminateMutRefs::test2(x_ref: u64, v: u64): u64 {
     $t3 := move($t5)
     write_ref($t3, $t2)
     LocalRoot($t4) <- $t3
-    PackRef($t3)
     return $t4
 }
 
@@ -305,7 +329,6 @@ pub fun TestEliminateMutRefs::test3(r_ref: TestEliminateMutRefs::R, v: u64): Tes
     Reference($t3) <- $t5
     PackRef($t3)
     PackRef($t5)
-    PackRef($t8)
     return $t7
 }
 
@@ -450,92 +473,127 @@ fun TestEliminateMutRefs::test7(b: bool) {
 }
 
 
-fun TestEliminateMutRefs::test8(n: u64, r_ref: TestEliminateMutRefs::R): TestEliminateMutRefs::R {
+fun TestEliminateMutRefs::test8(b: bool, n: u64, r_ref: TestEliminateMutRefs::R): TestEliminateMutRefs::R {
     var r1: TestEliminateMutRefs::R
     var r2: TestEliminateMutRefs::R
-    var $t4: u64
-    var $t5: TestEliminateMutRefs::R
+    var t_ref: &mut TestEliminateMutRefs::R
     var $t6: u64
     var $t7: TestEliminateMutRefs::R
     var $t8: u64
-    var $t9: u64
-    var $t10: bool
-    var $t11: &mut TestEliminateMutRefs::R
+    var $t9: TestEliminateMutRefs::R
+    var $t10: &mut TestEliminateMutRefs::R
+    var $t11: u64
     var $t12: u64
-    var $t13: u64
-    var $t14: u64
+    var $t13: bool
+    var $t14: &mut TestEliminateMutRefs::R
     var $t15: u64
-    var $t16: bool
-    var $t17: &mut TestEliminateMutRefs::R
-    var $t18: &mut TestEliminateMutRefs::R
-    var $t19: u64
-    var $t20: u64
-    var $t21: u64
-    var $t22: &mut TestEliminateMutRefs::R
+    var $t16: u64
+    var $t17: u64
+    var $t18: u64
+    var $t19: bool
+    var $t20: &mut TestEliminateMutRefs::R
+    var $t21: &mut TestEliminateMutRefs::R
+    var $t22: u64
     var $t23: u64
     var $t24: u64
-    var $t25: TestEliminateMutRefs::R
+    var $t25: bool
     var $t26: &mut TestEliminateMutRefs::R
-    var $t27: TestEliminateMutRefs::R
-    $t24 := move(n)
-    $t25 := move(r_ref)
-    $t26 := borrow_local($t25)
-    $t4 := 3
-    $t5 := pack TestEliminateMutRefs::R($t4)
-    r1 := $t5
-    $t6 := 4
+    var $t27: &mut TestEliminateMutRefs::R
+    var $t28: u64
+    var $t29: &mut TestEliminateMutRefs::R
+    var $t30: &mut TestEliminateMutRefs::R
+    var $t31: u64
+    var $t32: bool
+    var $t33: u64
+    var $t34: TestEliminateMutRefs::R
+    var $t35: &mut TestEliminateMutRefs::R
+    var $t36: TestEliminateMutRefs::R
+    $t32 := move(b)
+    $t33 := move(n)
+    $t34 := move(r_ref)
+    $t35 := borrow_local($t34)
+    $t6 := 3
     $t7 := pack TestEliminateMutRefs::R($t6)
-    r2 := $t7
+    r1 := $t7
+    $t8 := 4
+    $t9 := pack TestEliminateMutRefs::R($t8)
+    r2 := $t9
+    $t10 := borrow_local(r2)
+    UnpackRef($t10)
+    t_ref := $t10
     goto L7
     L7:
-    $t8 := 0
-    $t9 := copy($t24)
-    $t10 := <($t8, $t9)
-    if ($t10) goto L0 else goto L1
+    $t11 := 0
+    $t12 := copy($t33)
+    $t13 := <($t11, $t12)
+    if ($t13) goto L0 else goto L1
     L1:
     goto L2
     L0:
-    $t11 := move($t26)
-    destroy($t11)
-    LocalRoot($t25) <- $t11
-    LocalRoot(r1) <- $t11
-    LocalRoot(r2) <- $t11
-    PackRef($t11)
-    $t12 := copy($t24)
-    $t13 := 2
-    $t14 := /($t12, $t13)
-    $t15 := 0
-    $t16 := ==($t14, $t15)
-    if ($t16) goto L3 else goto L4
+    $t14 := move(t_ref)
+    destroy($t14)
+    LocalRoot(r1) <- $t14
+    LocalRoot(r2) <- $t14
+    PackRef($t14)
+    $t15 := copy($t33)
+    $t16 := 2
+    $t17 := /($t15, $t16)
+    $t18 := 0
+    $t19 := ==($t17, $t18)
+    if ($t19) goto L3 else goto L4
     L4:
     goto L5
     L3:
-    $t17 := borrow_local(r1)
-    UnpackRef($t17)
-    $t26 := $t17
+    $t20 := borrow_local(r1)
+    UnpackRef($t20)
+    t_ref := $t20
     goto L6
     L5:
-    $t18 := borrow_local(r2)
-    UnpackRef($t18)
-    $t26 := $t18
+    $t21 := borrow_local(r2)
+    UnpackRef($t21)
+    t_ref := $t21
     goto L6
     L6:
-    $t19 := copy($t24)
-    $t20 := 1
-    $t21 := -($t19, $t20)
-    $t24 := $t21
+    $t22 := copy($t33)
+    $t23 := 1
+    $t24 := -($t22, $t23)
+    $t33 := $t24
     goto L7
     L2:
-    $t22 := move($t26)
-    $t23 := 0
-    PackRef($t22)
-    $t27 := read_ref($t22)
-    $t27 := TestEliminateMutRefs::test3($t27, $t23)
-    write_ref($t22, $t27)
-    LocalRoot($t25) <- $t22
-    LocalRoot(r1) <- $t22
-    LocalRoot(r2) <- $t22
-    UnpackRef($t22)
-    PackRef($t22)
-    return $t25
+    $t25 := copy($t32)
+    if ($t25) goto L8 else goto L9
+    L9:
+    goto L10
+    L8:
+    $t26 := move(t_ref)
+    destroy($t26)
+    LocalRoot(r1) <- $t26
+    LocalRoot(r2) <- $t26
+    PackRef($t26)
+    $t27 := move($t35)
+    $t28 := 0
+    PackRef($t27)
+    $t36 := read_ref($t27)
+    $t36 := TestEliminateMutRefs::test3($t36, $t28)
+    write_ref($t27, $t36)
+    LocalRoot($t34) <- $t27
+    UnpackRef($t27)
+    goto L11
+    L10:
+    $t29 := move($t35)
+    destroy($t29)
+    LocalRoot($t34) <- $t29
+    $t30 := move(t_ref)
+    $t31 := 0
+    PackRef($t30)
+    $t36 := read_ref($t30)
+    $t36 := TestEliminateMutRefs::test3($t36, $t31)
+    write_ref($t30, $t36)
+    LocalRoot(r1) <- $t30
+    LocalRoot(r2) <- $t30
+    UnpackRef($t30)
+    PackRef($t30)
+    goto L11
+    L11:
+    return $t34
 }

--- a/language/move-prover/stackless-bytecode-generator/tests/eliminate_mut_refs/basic_test.move
+++ b/language/move-prover/stackless-bytecode-generator/tests/eliminate_mut_refs/basic_test.move
@@ -50,17 +50,22 @@ module TestEliminateMutRefs {
         test3(r_ref, 0)
     }
 
-    fun test8(n: u64, r_ref: &mut R) {
+    fun test8(b: bool, n: u64, r_ref: &mut R) {
         let r1 = R {x: 3};
         let r2 = R {x: 4};
+        let t_ref = &mut r2;
         while (0 < n) {
             if (n/2 == 0) {
-                r_ref = &mut r1
+                t_ref = &mut r1
             } else {
-                r_ref = &mut r2;
+                t_ref = &mut r2;
             };
             n = n - 1
         };
-        test3(r_ref, 0)
+        if (b) {
+            test3(r_ref, 0);
+        } else {
+            test3(t_ref, 0);
+        }
     }
 }

--- a/language/move-prover/stackless-bytecode-generator/tests/packref/basic_test.exp
+++ b/language/move-prover/stackless-bytecode-generator/tests/packref/basic_test.exp
@@ -153,72 +153,97 @@ fun TestPackref::test7(b: bool) {
 }
 
 
-fun TestPackref::test8(n: u64, r_ref: &mut TestPackref::R) {
+fun TestPackref::test8(b: bool, n: u64, r_ref: &mut TestPackref::R) {
     var r1: TestPackref::R
     var r2: TestPackref::R
-    var $t4: u64
-    var $t5: TestPackref::R
+    var t_ref: &mut TestPackref::R
     var $t6: u64
     var $t7: TestPackref::R
     var $t8: u64
-    var $t9: u64
-    var $t10: bool
-    var $t11: &mut TestPackref::R
+    var $t9: TestPackref::R
+    var $t10: &mut TestPackref::R
+    var $t11: u64
     var $t12: u64
-    var $t13: u64
-    var $t14: u64
+    var $t13: bool
+    var $t14: &mut TestPackref::R
     var $t15: u64
-    var $t16: bool
-    var $t17: &mut TestPackref::R
-    var $t18: &mut TestPackref::R
-    var $t19: u64
-    var $t20: u64
-    var $t21: u64
-    var $t22: &mut TestPackref::R
+    var $t16: u64
+    var $t17: u64
+    var $t18: u64
+    var $t19: bool
+    var $t20: &mut TestPackref::R
+    var $t21: &mut TestPackref::R
+    var $t22: u64
     var $t23: u64
-    $t4 := 3
-    $t5 := pack TestPackref::R($t4)
-    r1 := $t5
-    $t6 := 4
+    var $t24: u64
+    var $t25: bool
+    var $t26: &mut TestPackref::R
+    var $t27: &mut TestPackref::R
+    var $t28: u64
+    var $t29: &mut TestPackref::R
+    var $t30: &mut TestPackref::R
+    var $t31: u64
+    $t6 := 3
     $t7 := pack TestPackref::R($t6)
-    r2 := $t7
+    r1 := $t7
+    $t8 := 4
+    $t9 := pack TestPackref::R($t8)
+    r2 := $t9
+    $t10 := borrow_local(r2)
+    t_ref := $t10
     goto L7
     L7:
-    $t8 := 0
-    $t9 := copy(n)
-    $t10 := <($t8, $t9)
-    if ($t10) goto L0 else goto L1
+    $t11 := 0
+    $t12 := copy(n)
+    $t13 := <($t11, $t12)
+    if ($t13) goto L0 else goto L1
     L1:
     goto L2
     L0:
-    $t11 := move(r_ref)
-    destroy($t11)
-    $t12 := copy(n)
-    $t13 := 2
-    $t14 := /($t12, $t13)
-    $t15 := 0
-    $t16 := ==($t14, $t15)
-    if ($t16) goto L3 else goto L4
+    $t14 := move(t_ref)
+    destroy($t14)
+    $t15 := copy(n)
+    $t16 := 2
+    $t17 := /($t15, $t16)
+    $t18 := 0
+    $t19 := ==($t17, $t18)
+    if ($t19) goto L3 else goto L4
     L4:
     goto L5
     L3:
-    $t17 := borrow_local(r1)
-    r_ref := $t17
+    $t20 := borrow_local(r1)
+    t_ref := $t20
     goto L6
     L5:
-    $t18 := borrow_local(r2)
-    r_ref := $t18
+    $t21 := borrow_local(r2)
+    t_ref := $t21
     goto L6
     L6:
-    $t19 := copy(n)
-    $t20 := 1
-    $t21 := -($t19, $t20)
-    n := $t21
+    $t22 := copy(n)
+    $t23 := 1
+    $t24 := -($t22, $t23)
+    n := $t24
     goto L7
     L2:
-    $t22 := move(r_ref)
-    $t23 := 0
-    TestPackref::test3($t22, $t23)
+    $t25 := copy(b)
+    if ($t25) goto L8 else goto L9
+    L9:
+    goto L10
+    L8:
+    $t26 := move(t_ref)
+    destroy($t26)
+    $t27 := move(r_ref)
+    $t28 := 0
+    TestPackref::test3($t27, $t28)
+    goto L11
+    L10:
+    $t29 := move(r_ref)
+    destroy($t29)
+    $t30 := move(t_ref)
+    $t31 := 0
+    TestPackref::test3($t30, $t31)
+    goto L11
+    L11:
     return ()
 }
 
@@ -270,7 +295,6 @@ fun TestPackref::test2(x_ref: &mut u64, v: u64) {
     // live_refs: x_ref borrowed_by: LocalRoot(x_ref) -> {Reference(x_ref)} borrows_from: Reference(x_ref) -> {LocalRoot(x_ref)}
     $t3 := move(x_ref)
     // live_refs: $t3 borrowed_by: LocalRoot(x_ref) -> {Reference($t3)} borrows_from: Reference($t3) -> {LocalRoot(x_ref)}
-    // before:  after: PackRef($t3)
     write_ref($t3, $t2)
     return ()
 }
@@ -297,7 +321,6 @@ pub fun TestPackref::test3(r_ref: &mut TestPackref::R, v: u64) {
     // live_refs: $t5 borrowed_by: LocalRoot(r_ref) -> {Reference($t5)}, Reference($t3) -> {Reference($t5)} borrows_from: Reference($t5) -> {LocalRoot(r_ref), Reference($t3)}
     // before:  after: PackRef($t3), PackRef($t5)
     TestPackref::test2($t5, $t6)
-    // before: PackRef(r_ref) after:
     return ()
 }
 
@@ -438,106 +461,161 @@ fun TestPackref::test7(b: bool) {
 }
 
 
-fun TestPackref::test8(n: u64, r_ref: &mut TestPackref::R) {
+fun TestPackref::test8(b: bool, n: u64, r_ref: &mut TestPackref::R) {
     var r1: TestPackref::R
     var r2: TestPackref::R
-    var $t4: u64
-    var $t5: TestPackref::R
+    var t_ref: &mut TestPackref::R
     var $t6: u64
     var $t7: TestPackref::R
     var $t8: u64
-    var $t9: u64
-    var $t10: bool
-    var $t11: &mut TestPackref::R
+    var $t9: TestPackref::R
+    var $t10: &mut TestPackref::R
+    var $t11: u64
     var $t12: u64
-    var $t13: u64
-    var $t14: u64
+    var $t13: bool
+    var $t14: &mut TestPackref::R
     var $t15: u64
-    var $t16: bool
-    var $t17: &mut TestPackref::R
-    var $t18: &mut TestPackref::R
-    var $t19: u64
-    var $t20: u64
-    var $t21: u64
-    var $t22: &mut TestPackref::R
+    var $t16: u64
+    var $t17: u64
+    var $t18: u64
+    var $t19: bool
+    var $t20: &mut TestPackref::R
+    var $t21: &mut TestPackref::R
+    var $t22: u64
     var $t23: u64
+    var $t24: u64
+    var $t25: bool
+    var $t26: &mut TestPackref::R
+    var $t27: &mut TestPackref::R
+    var $t28: u64
+    var $t29: &mut TestPackref::R
+    var $t30: &mut TestPackref::R
+    var $t31: u64
     // live_refs: r_ref borrowed_by: LocalRoot(r_ref) -> {Reference(r_ref)} borrows_from: Reference(r_ref) -> {LocalRoot(r_ref)}
-    $t4 := 3
-    // live_refs: r_ref borrowed_by: LocalRoot(r_ref) -> {Reference(r_ref)} borrows_from: Reference(r_ref) -> {LocalRoot(r_ref)}
-    $t5 := pack TestPackref::R($t4)
-    // live_refs: r_ref borrowed_by: LocalRoot(r_ref) -> {Reference(r_ref)} borrows_from: Reference(r_ref) -> {LocalRoot(r_ref)}
-    r1 := $t5
-    // live_refs: r_ref borrowed_by: LocalRoot(r_ref) -> {Reference(r_ref)} borrows_from: Reference(r_ref) -> {LocalRoot(r_ref)}
-    $t6 := 4
+    $t6 := 3
     // live_refs: r_ref borrowed_by: LocalRoot(r_ref) -> {Reference(r_ref)} borrows_from: Reference(r_ref) -> {LocalRoot(r_ref)}
     $t7 := pack TestPackref::R($t6)
     // live_refs: r_ref borrowed_by: LocalRoot(r_ref) -> {Reference(r_ref)} borrows_from: Reference(r_ref) -> {LocalRoot(r_ref)}
-    r2 := $t7
+    r1 := $t7
     // live_refs: r_ref borrowed_by: LocalRoot(r_ref) -> {Reference(r_ref)} borrows_from: Reference(r_ref) -> {LocalRoot(r_ref)}
+    $t8 := 4
+    // live_refs: r_ref borrowed_by: LocalRoot(r_ref) -> {Reference(r_ref)} borrows_from: Reference(r_ref) -> {LocalRoot(r_ref)}
+    $t9 := pack TestPackref::R($t8)
+    // live_refs: r_ref borrowed_by: LocalRoot(r_ref) -> {Reference(r_ref)} borrows_from: Reference(r_ref) -> {LocalRoot(r_ref)}
+    r2 := $t9
+    // live_refs: r_ref borrowed_by: LocalRoot(r_ref) -> {Reference(r_ref)} borrows_from: Reference(r_ref) -> {LocalRoot(r_ref)}
+    // before:  after: UnpackRef($t10)
+    $t10 := borrow_local(r2)
+    // live_refs: r_ref, $t10 borrowed_by: LocalRoot(r_ref) -> {Reference(r_ref)}, LocalRoot(r2) -> {Reference($t10)} borrows_from: Reference(r_ref) -> {LocalRoot(r_ref)}, Reference($t10) -> {LocalRoot(r2)}
+    t_ref := $t10
+    // live_refs: r_ref, t_ref borrowed_by: LocalRoot(r_ref) -> {Reference(r_ref)}, LocalRoot(r2) -> {Reference(t_ref)} borrows_from: Reference(r_ref) -> {LocalRoot(r_ref)}, Reference(t_ref) -> {LocalRoot(r2)}
     goto L7
-    // live_refs: r_ref borrowed_by: LocalRoot(r_ref) -> {Reference(r_ref)}, LocalRoot(r1) -> {Reference(r_ref)}, LocalRoot(r2) -> {Reference(r_ref)} borrows_from: Reference(r_ref) -> {LocalRoot(r_ref), LocalRoot(r1), LocalRoot(r2)}
+    // live_refs: r_ref, t_ref borrowed_by: LocalRoot(r_ref) -> {Reference(r_ref)}, LocalRoot(r1) -> {Reference(t_ref)}, LocalRoot(r2) -> {Reference(t_ref)} borrows_from: Reference(r_ref) -> {LocalRoot(r_ref)}, Reference(t_ref) -> {LocalRoot(r1), LocalRoot(r2)}
     L7:
-    // live_refs: r_ref borrowed_by: LocalRoot(r_ref) -> {Reference(r_ref)}, LocalRoot(r1) -> {Reference(r_ref)}, LocalRoot(r2) -> {Reference(r_ref)} borrows_from: Reference(r_ref) -> {LocalRoot(r_ref), LocalRoot(r1), LocalRoot(r2)}
-    $t8 := 0
-    // live_refs: r_ref borrowed_by: LocalRoot(r_ref) -> {Reference(r_ref)}, LocalRoot(r1) -> {Reference(r_ref)}, LocalRoot(r2) -> {Reference(r_ref)} borrows_from: Reference(r_ref) -> {LocalRoot(r_ref), LocalRoot(r1), LocalRoot(r2)}
-    $t9 := copy(n)
-    // live_refs: r_ref borrowed_by: LocalRoot(r_ref) -> {Reference(r_ref)}, LocalRoot(r1) -> {Reference(r_ref)}, LocalRoot(r2) -> {Reference(r_ref)} borrows_from: Reference(r_ref) -> {LocalRoot(r_ref), LocalRoot(r1), LocalRoot(r2)}
-    $t10 := <($t8, $t9)
-    // live_refs: r_ref borrowed_by: LocalRoot(r_ref) -> {Reference(r_ref)}, LocalRoot(r1) -> {Reference(r_ref)}, LocalRoot(r2) -> {Reference(r_ref)} borrows_from: Reference(r_ref) -> {LocalRoot(r_ref), LocalRoot(r1), LocalRoot(r2)}
-    if ($t10) goto L0 else goto L1
-    // live_refs: r_ref borrowed_by: LocalRoot(r_ref) -> {Reference(r_ref)}, LocalRoot(r1) -> {Reference(r_ref)}, LocalRoot(r2) -> {Reference(r_ref)} borrows_from: Reference(r_ref) -> {LocalRoot(r_ref), LocalRoot(r1), LocalRoot(r2)}
-    L1:
-    // live_refs: r_ref borrowed_by: LocalRoot(r_ref) -> {Reference(r_ref)}, LocalRoot(r1) -> {Reference(r_ref)}, LocalRoot(r2) -> {Reference(r_ref)} borrows_from: Reference(r_ref) -> {LocalRoot(r_ref), LocalRoot(r1), LocalRoot(r2)}
-    goto L2
-    // live_refs: r_ref borrowed_by: LocalRoot(r_ref) -> {Reference(r_ref)}, LocalRoot(r1) -> {Reference(r_ref)}, LocalRoot(r2) -> {Reference(r_ref)} borrows_from: Reference(r_ref) -> {LocalRoot(r_ref), LocalRoot(r1), LocalRoot(r2)}
-    L0:
-    // live_refs: r_ref borrowed_by: LocalRoot(r_ref) -> {Reference(r_ref)}, LocalRoot(r1) -> {Reference(r_ref)}, LocalRoot(r2) -> {Reference(r_ref)} borrows_from: Reference(r_ref) -> {LocalRoot(r_ref), LocalRoot(r1), LocalRoot(r2)}
-    $t11 := move(r_ref)
-    // live_refs: $t11 borrowed_by: LocalRoot(r_ref) -> {Reference($t11)}, LocalRoot(r1) -> {Reference($t11)}, LocalRoot(r2) -> {Reference($t11)} borrows_from: Reference($t11) -> {LocalRoot(r_ref), LocalRoot(r1), LocalRoot(r2)}
-    // before:  after: PackRef($t11)
-    destroy($t11)
+    // live_refs: r_ref, t_ref borrowed_by: LocalRoot(r_ref) -> {Reference(r_ref)}, LocalRoot(r1) -> {Reference(t_ref)}, LocalRoot(r2) -> {Reference(t_ref)} borrows_from: Reference(r_ref) -> {LocalRoot(r_ref)}, Reference(t_ref) -> {LocalRoot(r1), LocalRoot(r2)}
+    $t11 := 0
+    // live_refs: r_ref, t_ref borrowed_by: LocalRoot(r_ref) -> {Reference(r_ref)}, LocalRoot(r1) -> {Reference(t_ref)}, LocalRoot(r2) -> {Reference(t_ref)} borrows_from: Reference(r_ref) -> {LocalRoot(r_ref)}, Reference(t_ref) -> {LocalRoot(r1), LocalRoot(r2)}
     $t12 := copy(n)
-    $t13 := 2
-    $t14 := /($t12, $t13)
-    $t15 := 0
-    $t16 := ==($t14, $t15)
-    if ($t16) goto L3 else goto L4
+    // live_refs: r_ref, t_ref borrowed_by: LocalRoot(r_ref) -> {Reference(r_ref)}, LocalRoot(r1) -> {Reference(t_ref)}, LocalRoot(r2) -> {Reference(t_ref)} borrows_from: Reference(r_ref) -> {LocalRoot(r_ref)}, Reference(t_ref) -> {LocalRoot(r1), LocalRoot(r2)}
+    $t13 := <($t11, $t12)
+    // live_refs: r_ref, t_ref borrowed_by: LocalRoot(r_ref) -> {Reference(r_ref)}, LocalRoot(r1) -> {Reference(t_ref)}, LocalRoot(r2) -> {Reference(t_ref)} borrows_from: Reference(r_ref) -> {LocalRoot(r_ref)}, Reference(t_ref) -> {LocalRoot(r1), LocalRoot(r2)}
+    if ($t13) goto L0 else goto L1
+    // live_refs: r_ref, t_ref borrowed_by: LocalRoot(r_ref) -> {Reference(r_ref)}, LocalRoot(r1) -> {Reference(t_ref)}, LocalRoot(r2) -> {Reference(t_ref)} borrows_from: Reference(r_ref) -> {LocalRoot(r_ref)}, Reference(t_ref) -> {LocalRoot(r1), LocalRoot(r2)}
+    L1:
+    // live_refs: r_ref, t_ref borrowed_by: LocalRoot(r_ref) -> {Reference(r_ref)}, LocalRoot(r1) -> {Reference(t_ref)}, LocalRoot(r2) -> {Reference(t_ref)} borrows_from: Reference(r_ref) -> {LocalRoot(r_ref)}, Reference(t_ref) -> {LocalRoot(r1), LocalRoot(r2)}
+    goto L2
+    // live_refs: r_ref, t_ref borrowed_by: LocalRoot(r_ref) -> {Reference(r_ref)}, LocalRoot(r1) -> {Reference(t_ref)}, LocalRoot(r2) -> {Reference(t_ref)} borrows_from: Reference(r_ref) -> {LocalRoot(r_ref)}, Reference(t_ref) -> {LocalRoot(r1), LocalRoot(r2)}
+    L0:
+    // live_refs: r_ref, t_ref borrowed_by: LocalRoot(r_ref) -> {Reference(r_ref)}, LocalRoot(r1) -> {Reference(t_ref)}, LocalRoot(r2) -> {Reference(t_ref)} borrows_from: Reference(r_ref) -> {LocalRoot(r_ref)}, Reference(t_ref) -> {LocalRoot(r1), LocalRoot(r2)}
+    $t14 := move(t_ref)
+    // live_refs: r_ref, $t14 borrowed_by: LocalRoot(r_ref) -> {Reference(r_ref)}, LocalRoot(r1) -> {Reference($t14)}, LocalRoot(r2) -> {Reference($t14)} borrows_from: Reference(r_ref) -> {LocalRoot(r_ref)}, Reference($t14) -> {LocalRoot(r1), LocalRoot(r2)}
+    // before:  after: PackRef($t14)
+    destroy($t14)
+    // live_refs: r_ref borrowed_by: LocalRoot(r_ref) -> {Reference(r_ref)} borrows_from: Reference(r_ref) -> {LocalRoot(r_ref)}
+    $t15 := copy(n)
+    // live_refs: r_ref borrowed_by: LocalRoot(r_ref) -> {Reference(r_ref)} borrows_from: Reference(r_ref) -> {LocalRoot(r_ref)}
+    $t16 := 2
+    // live_refs: r_ref borrowed_by: LocalRoot(r_ref) -> {Reference(r_ref)} borrows_from: Reference(r_ref) -> {LocalRoot(r_ref)}
+    $t17 := /($t15, $t16)
+    // live_refs: r_ref borrowed_by: LocalRoot(r_ref) -> {Reference(r_ref)} borrows_from: Reference(r_ref) -> {LocalRoot(r_ref)}
+    $t18 := 0
+    // live_refs: r_ref borrowed_by: LocalRoot(r_ref) -> {Reference(r_ref)} borrows_from: Reference(r_ref) -> {LocalRoot(r_ref)}
+    $t19 := ==($t17, $t18)
+    // live_refs: r_ref borrowed_by: LocalRoot(r_ref) -> {Reference(r_ref)} borrows_from: Reference(r_ref) -> {LocalRoot(r_ref)}
+    if ($t19) goto L3 else goto L4
+    // live_refs: r_ref borrowed_by: LocalRoot(r_ref) -> {Reference(r_ref)} borrows_from: Reference(r_ref) -> {LocalRoot(r_ref)}
     L4:
+    // live_refs: r_ref borrowed_by: LocalRoot(r_ref) -> {Reference(r_ref)} borrows_from: Reference(r_ref) -> {LocalRoot(r_ref)}
     goto L5
+    // live_refs: r_ref borrowed_by: LocalRoot(r_ref) -> {Reference(r_ref)} borrows_from: Reference(r_ref) -> {LocalRoot(r_ref)}
     L3:
-    // before:  after: UnpackRef($t17)
-    $t17 := borrow_local(r1)
-    // live_refs: $t17 borrowed_by: LocalRoot(r1) -> {Reference($t17)} borrows_from: Reference($t17) -> {LocalRoot(r1)}
-    r_ref := $t17
-    // live_refs: r_ref borrowed_by: LocalRoot(r1) -> {Reference(r_ref)} borrows_from: Reference(r_ref) -> {LocalRoot(r1)}
+    // live_refs: r_ref borrowed_by: LocalRoot(r_ref) -> {Reference(r_ref)} borrows_from: Reference(r_ref) -> {LocalRoot(r_ref)}
+    // before:  after: UnpackRef($t20)
+    $t20 := borrow_local(r1)
+    // live_refs: r_ref, $t20 borrowed_by: LocalRoot(r_ref) -> {Reference(r_ref)}, LocalRoot(r1) -> {Reference($t20)} borrows_from: Reference(r_ref) -> {LocalRoot(r_ref)}, Reference($t20) -> {LocalRoot(r1)}
+    t_ref := $t20
+    // live_refs: r_ref, t_ref borrowed_by: LocalRoot(r_ref) -> {Reference(r_ref)}, LocalRoot(r1) -> {Reference(t_ref)} borrows_from: Reference(r_ref) -> {LocalRoot(r_ref)}, Reference(t_ref) -> {LocalRoot(r1)}
     goto L6
+    // live_refs: r_ref borrowed_by: LocalRoot(r_ref) -> {Reference(r_ref)} borrows_from: Reference(r_ref) -> {LocalRoot(r_ref)}
     L5:
-    // before:  after: UnpackRef($t18)
-    $t18 := borrow_local(r2)
-    // live_refs: $t18 borrowed_by: LocalRoot(r2) -> {Reference($t18)} borrows_from: Reference($t18) -> {LocalRoot(r2)}
-    r_ref := $t18
-    // live_refs: r_ref borrowed_by: LocalRoot(r2) -> {Reference(r_ref)} borrows_from: Reference(r_ref) -> {LocalRoot(r2)}
+    // live_refs: r_ref borrowed_by: LocalRoot(r_ref) -> {Reference(r_ref)} borrows_from: Reference(r_ref) -> {LocalRoot(r_ref)}
+    // before:  after: UnpackRef($t21)
+    $t21 := borrow_local(r2)
+    // live_refs: r_ref, $t21 borrowed_by: LocalRoot(r_ref) -> {Reference(r_ref)}, LocalRoot(r2) -> {Reference($t21)} borrows_from: Reference(r_ref) -> {LocalRoot(r_ref)}, Reference($t21) -> {LocalRoot(r2)}
+    t_ref := $t21
+    // live_refs: r_ref, t_ref borrowed_by: LocalRoot(r_ref) -> {Reference(r_ref)}, LocalRoot(r2) -> {Reference(t_ref)} borrows_from: Reference(r_ref) -> {LocalRoot(r_ref)}, Reference(t_ref) -> {LocalRoot(r2)}
     goto L6
-    // live_refs: r_ref borrowed_by: LocalRoot(r1) -> {Reference(r_ref)}, LocalRoot(r2) -> {Reference(r_ref)} borrows_from: Reference(r_ref) -> {LocalRoot(r1), LocalRoot(r2)}
+    // live_refs: r_ref, t_ref borrowed_by: LocalRoot(r_ref) -> {Reference(r_ref)}, LocalRoot(r1) -> {Reference(t_ref)}, LocalRoot(r2) -> {Reference(t_ref)} borrows_from: Reference(r_ref) -> {LocalRoot(r_ref)}, Reference(t_ref) -> {LocalRoot(r1), LocalRoot(r2)}
     L6:
-    // live_refs: r_ref borrowed_by: LocalRoot(r1) -> {Reference(r_ref)}, LocalRoot(r2) -> {Reference(r_ref)} borrows_from: Reference(r_ref) -> {LocalRoot(r1), LocalRoot(r2)}
-    $t19 := copy(n)
-    // live_refs: r_ref borrowed_by: LocalRoot(r1) -> {Reference(r_ref)}, LocalRoot(r2) -> {Reference(r_ref)} borrows_from: Reference(r_ref) -> {LocalRoot(r1), LocalRoot(r2)}
-    $t20 := 1
-    // live_refs: r_ref borrowed_by: LocalRoot(r1) -> {Reference(r_ref)}, LocalRoot(r2) -> {Reference(r_ref)} borrows_from: Reference(r_ref) -> {LocalRoot(r1), LocalRoot(r2)}
-    $t21 := -($t19, $t20)
-    // live_refs: r_ref borrowed_by: LocalRoot(r1) -> {Reference(r_ref)}, LocalRoot(r2) -> {Reference(r_ref)} borrows_from: Reference(r_ref) -> {LocalRoot(r1), LocalRoot(r2)}
-    n := $t21
-    // live_refs: r_ref borrowed_by: LocalRoot(r1) -> {Reference(r_ref)}, LocalRoot(r2) -> {Reference(r_ref)} borrows_from: Reference(r_ref) -> {LocalRoot(r1), LocalRoot(r2)}
+    // live_refs: r_ref, t_ref borrowed_by: LocalRoot(r_ref) -> {Reference(r_ref)}, LocalRoot(r1) -> {Reference(t_ref)}, LocalRoot(r2) -> {Reference(t_ref)} borrows_from: Reference(r_ref) -> {LocalRoot(r_ref)}, Reference(t_ref) -> {LocalRoot(r1), LocalRoot(r2)}
+    $t22 := copy(n)
+    // live_refs: r_ref, t_ref borrowed_by: LocalRoot(r_ref) -> {Reference(r_ref)}, LocalRoot(r1) -> {Reference(t_ref)}, LocalRoot(r2) -> {Reference(t_ref)} borrows_from: Reference(r_ref) -> {LocalRoot(r_ref)}, Reference(t_ref) -> {LocalRoot(r1), LocalRoot(r2)}
+    $t23 := 1
+    // live_refs: r_ref, t_ref borrowed_by: LocalRoot(r_ref) -> {Reference(r_ref)}, LocalRoot(r1) -> {Reference(t_ref)}, LocalRoot(r2) -> {Reference(t_ref)} borrows_from: Reference(r_ref) -> {LocalRoot(r_ref)}, Reference(t_ref) -> {LocalRoot(r1), LocalRoot(r2)}
+    $t24 := -($t22, $t23)
+    // live_refs: r_ref, t_ref borrowed_by: LocalRoot(r_ref) -> {Reference(r_ref)}, LocalRoot(r1) -> {Reference(t_ref)}, LocalRoot(r2) -> {Reference(t_ref)} borrows_from: Reference(r_ref) -> {LocalRoot(r_ref)}, Reference(t_ref) -> {LocalRoot(r1), LocalRoot(r2)}
+    n := $t24
+    // live_refs: r_ref, t_ref borrowed_by: LocalRoot(r_ref) -> {Reference(r_ref)}, LocalRoot(r1) -> {Reference(t_ref)}, LocalRoot(r2) -> {Reference(t_ref)} borrows_from: Reference(r_ref) -> {LocalRoot(r_ref)}, Reference(t_ref) -> {LocalRoot(r1), LocalRoot(r2)}
     goto L7
-    // live_refs: r_ref borrowed_by: LocalRoot(r_ref) -> {Reference(r_ref)}, LocalRoot(r1) -> {Reference(r_ref)}, LocalRoot(r2) -> {Reference(r_ref)} borrows_from: Reference(r_ref) -> {LocalRoot(r_ref), LocalRoot(r1), LocalRoot(r2)}
+    // live_refs: r_ref, t_ref borrowed_by: LocalRoot(r_ref) -> {Reference(r_ref)}, LocalRoot(r1) -> {Reference(t_ref)}, LocalRoot(r2) -> {Reference(t_ref)} borrows_from: Reference(r_ref) -> {LocalRoot(r_ref)}, Reference(t_ref) -> {LocalRoot(r1), LocalRoot(r2)}
     L2:
-    // live_refs: r_ref borrowed_by: LocalRoot(r_ref) -> {Reference(r_ref)}, LocalRoot(r1) -> {Reference(r_ref)}, LocalRoot(r2) -> {Reference(r_ref)} borrows_from: Reference(r_ref) -> {LocalRoot(r_ref), LocalRoot(r1), LocalRoot(r2)}
-    $t22 := move(r_ref)
-    // live_refs: $t22 borrowed_by: LocalRoot(r_ref) -> {Reference($t22)}, LocalRoot(r1) -> {Reference($t22)}, LocalRoot(r2) -> {Reference($t22)} borrows_from: Reference($t22) -> {LocalRoot(r_ref), LocalRoot(r1), LocalRoot(r2)}
-    $t23 := 0
-    // live_refs: $t22 borrowed_by: LocalRoot(r_ref) -> {Reference($t22)}, LocalRoot(r1) -> {Reference($t22)}, LocalRoot(r2) -> {Reference($t22)} borrows_from: Reference($t22) -> {LocalRoot(r_ref), LocalRoot(r1), LocalRoot(r2)}
-    // before: PackRef($t22) after: UnpackRef($t22), PackRef($t22)
-    TestPackref::test3($t22, $t23)
+    // live_refs: r_ref, t_ref borrowed_by: LocalRoot(r_ref) -> {Reference(r_ref)}, LocalRoot(r1) -> {Reference(t_ref)}, LocalRoot(r2) -> {Reference(t_ref)} borrows_from: Reference(r_ref) -> {LocalRoot(r_ref)}, Reference(t_ref) -> {LocalRoot(r1), LocalRoot(r2)}
+    $t25 := copy(b)
+    // live_refs: r_ref, t_ref borrowed_by: LocalRoot(r_ref) -> {Reference(r_ref)}, LocalRoot(r1) -> {Reference(t_ref)}, LocalRoot(r2) -> {Reference(t_ref)} borrows_from: Reference(r_ref) -> {LocalRoot(r_ref)}, Reference(t_ref) -> {LocalRoot(r1), LocalRoot(r2)}
+    if ($t25) goto L8 else goto L9
+    // live_refs: r_ref, t_ref borrowed_by: LocalRoot(r_ref) -> {Reference(r_ref)}, LocalRoot(r1) -> {Reference(t_ref)}, LocalRoot(r2) -> {Reference(t_ref)} borrows_from: Reference(r_ref) -> {LocalRoot(r_ref)}, Reference(t_ref) -> {LocalRoot(r1), LocalRoot(r2)}
+    L9:
+    // live_refs: r_ref, t_ref borrowed_by: LocalRoot(r_ref) -> {Reference(r_ref)}, LocalRoot(r1) -> {Reference(t_ref)}, LocalRoot(r2) -> {Reference(t_ref)} borrows_from: Reference(r_ref) -> {LocalRoot(r_ref)}, Reference(t_ref) -> {LocalRoot(r1), LocalRoot(r2)}
+    goto L10
+    // live_refs: r_ref, t_ref borrowed_by: LocalRoot(r_ref) -> {Reference(r_ref)}, LocalRoot(r1) -> {Reference(t_ref)}, LocalRoot(r2) -> {Reference(t_ref)} borrows_from: Reference(r_ref) -> {LocalRoot(r_ref)}, Reference(t_ref) -> {LocalRoot(r1), LocalRoot(r2)}
+    L8:
+    // live_refs: r_ref, t_ref borrowed_by: LocalRoot(r_ref) -> {Reference(r_ref)}, LocalRoot(r1) -> {Reference(t_ref)}, LocalRoot(r2) -> {Reference(t_ref)} borrows_from: Reference(r_ref) -> {LocalRoot(r_ref)}, Reference(t_ref) -> {LocalRoot(r1), LocalRoot(r2)}
+    $t26 := move(t_ref)
+    // live_refs: r_ref, $t26 borrowed_by: LocalRoot(r_ref) -> {Reference(r_ref)}, LocalRoot(r1) -> {Reference($t26)}, LocalRoot(r2) -> {Reference($t26)} borrows_from: Reference(r_ref) -> {LocalRoot(r_ref)}, Reference($t26) -> {LocalRoot(r1), LocalRoot(r2)}
+    // before:  after: PackRef($t26)
+    destroy($t26)
+    // live_refs: r_ref borrowed_by: LocalRoot(r_ref) -> {Reference(r_ref)} borrows_from: Reference(r_ref) -> {LocalRoot(r_ref)}
+    $t27 := move(r_ref)
+    // live_refs: $t27 borrowed_by: LocalRoot(r_ref) -> {Reference($t27)} borrows_from: Reference($t27) -> {LocalRoot(r_ref)}
+    $t28 := 0
+    // live_refs: $t27 borrowed_by: LocalRoot(r_ref) -> {Reference($t27)} borrows_from: Reference($t27) -> {LocalRoot(r_ref)}
+    // before: PackRef($t27) after: UnpackRef($t27)
+    TestPackref::test3($t27, $t28)
+    goto L11
+    // live_refs: r_ref, t_ref borrowed_by: LocalRoot(r_ref) -> {Reference(r_ref)}, LocalRoot(r1) -> {Reference(t_ref)}, LocalRoot(r2) -> {Reference(t_ref)} borrows_from: Reference(r_ref) -> {LocalRoot(r_ref)}, Reference(t_ref) -> {LocalRoot(r1), LocalRoot(r2)}
+    L10:
+    // live_refs: r_ref, t_ref borrowed_by: LocalRoot(r_ref) -> {Reference(r_ref)}, LocalRoot(r1) -> {Reference(t_ref)}, LocalRoot(r2) -> {Reference(t_ref)} borrows_from: Reference(r_ref) -> {LocalRoot(r_ref)}, Reference(t_ref) -> {LocalRoot(r1), LocalRoot(r2)}
+    $t29 := move(r_ref)
+    // live_refs: t_ref, $t29 borrowed_by: LocalRoot(r_ref) -> {Reference($t29)}, LocalRoot(r1) -> {Reference(t_ref)}, LocalRoot(r2) -> {Reference(t_ref)} borrows_from: Reference(t_ref) -> {LocalRoot(r1), LocalRoot(r2)}, Reference($t29) -> {LocalRoot(r_ref)}
+    destroy($t29)
+    // live_refs: t_ref borrowed_by: LocalRoot(r1) -> {Reference(t_ref)}, LocalRoot(r2) -> {Reference(t_ref)} borrows_from: Reference(t_ref) -> {LocalRoot(r1), LocalRoot(r2)}
+    $t30 := move(t_ref)
+    // live_refs: $t30 borrowed_by: LocalRoot(r1) -> {Reference($t30)}, LocalRoot(r2) -> {Reference($t30)} borrows_from: Reference($t30) -> {LocalRoot(r1), LocalRoot(r2)}
+    $t31 := 0
+    // live_refs: $t30 borrowed_by: LocalRoot(r1) -> {Reference($t30)}, LocalRoot(r2) -> {Reference($t30)} borrows_from: Reference($t30) -> {LocalRoot(r1), LocalRoot(r2)}
+    // before: PackRef($t30) after: UnpackRef($t30), PackRef($t30)
+    TestPackref::test3($t30, $t31)
+    goto L11
+    L11:
     return ()
 }

--- a/language/move-prover/stackless-bytecode-generator/tests/packref/basic_test.move
+++ b/language/move-prover/stackless-bytecode-generator/tests/packref/basic_test.move
@@ -49,17 +49,22 @@ module TestPackref {
         test3(r_ref, 0)
     }
 
-    fun test8(n: u64, r_ref: &mut R) {
+    fun test8(b: bool, n: u64, r_ref: &mut R) {
         let r1 = R {x: 3};
         let r2 = R {x: 4};
+        let t_ref = &mut r2;
         while (0 < n) {
             if (n/2 == 0) {
-                r_ref = &mut r1
+                t_ref = &mut r1
             } else {
-                r_ref = &mut r2;
+                t_ref = &mut r2;
             };
             n = n - 1
         };
-        test3(r_ref, 0)
+        if (b) {
+            test3(r_ref, 0);
+        } else {
+            test3(t_ref, 0);
+        }
     }
 }

--- a/language/move-prover/stackless-bytecode-generator/tests/packref/mut_ref.exp
+++ b/language/move-prover/stackless-bytecode-generator/tests/packref/mut_ref.exp
@@ -1,0 +1,645 @@
+============ initial translation from Move ================
+
+pub fun TestMutRefs::data_invariant(_x: &mut TestMutRefs::T) {
+    return ()
+}
+
+
+pub fun TestMutRefs::decrement_invalid(x: &mut TestMutRefs::T) {
+    var r: &mut TestMutRefs::TSum
+    var $t2: &mut TestMutRefs::T
+    var $t3: &u64
+    var $t4: u64
+    var $t5: u64
+    var $t6: u64
+    var $t7: &mut TestMutRefs::T
+    var $t8: &mut u64
+    var $t9: address
+    var $t10: &mut TestMutRefs::TSum
+    var $t11: &mut TestMutRefs::TSum
+    var $t12: &u64
+    var $t13: u64
+    var $t14: u64
+    var $t15: u64
+    var $t16: &mut TestMutRefs::TSum
+    var $t17: &mut u64
+    $t2 := copy(x)
+    $t3 := borrow_field<TestMutRefs::T>.value($t2)
+    $t4 := read_ref($t3)
+    $t5 := 1
+    $t6 := -($t4, $t5)
+    $t7 := move(x)
+    $t8 := borrow_field<TestMutRefs::T>.value($t7)
+    write_ref($t8, $t6)
+    $t9 := 0x0
+    $t10 := borrow_global<TestMutRefs::TSum>($t9)
+    r := $t10
+    $t11 := copy(r)
+    $t12 := borrow_field<TestMutRefs::TSum>.sum($t11)
+    $t13 := read_ref($t12)
+    $t14 := 1
+    $t15 := -($t13, $t14)
+    $t16 := move(r)
+    $t17 := borrow_field<TestMutRefs::TSum>.sum($t16)
+    write_ref($t17, $t15)
+    return ()
+}
+
+
+pub fun TestMutRefs::delete(x: TestMutRefs::T) {
+    var r: &mut TestMutRefs::TSum
+    var v: u64
+    var $t3: address
+    var $t4: &mut TestMutRefs::TSum
+    var $t5: TestMutRefs::T
+    var $t6: u64
+    var $t7: &mut TestMutRefs::TSum
+    var $t8: &u64
+    var $t9: u64
+    var $t10: u64
+    var $t11: u64
+    var $t12: &mut TestMutRefs::TSum
+    var $t13: &mut u64
+    $t3 := 0x0
+    $t4 := borrow_global<TestMutRefs::TSum>($t3)
+    r := $t4
+    $t5 := move(x)
+    $t6 := unpack TestMutRefs::T($t5)
+    v := $t6
+    $t7 := copy(r)
+    $t8 := borrow_field<TestMutRefs::TSum>.sum($t7)
+    $t9 := read_ref($t8)
+    $t10 := copy(v)
+    $t11 := -($t9, $t10)
+    $t12 := move(r)
+    $t13 := borrow_field<TestMutRefs::TSum>.sum($t12)
+    write_ref($t13, $t11)
+    return ()
+}
+
+
+pub fun TestMutRefs::increment(x: &mut TestMutRefs::T) {
+    var r: &mut TestMutRefs::TSum
+    var $t2: &mut TestMutRefs::T
+    var $t3: &u64
+    var $t4: u64
+    var $t5: u64
+    var $t6: u64
+    var $t7: &mut TestMutRefs::T
+    var $t8: &mut u64
+    var $t9: address
+    var $t10: &mut TestMutRefs::TSum
+    var $t11: &mut TestMutRefs::TSum
+    var $t12: &u64
+    var $t13: u64
+    var $t14: u64
+    var $t15: u64
+    var $t16: &mut TestMutRefs::TSum
+    var $t17: &mut u64
+    $t2 := copy(x)
+    $t3 := borrow_field<TestMutRefs::T>.value($t2)
+    $t4 := read_ref($t3)
+    $t5 := 1
+    $t6 := +($t4, $t5)
+    $t7 := move(x)
+    $t8 := borrow_field<TestMutRefs::T>.value($t7)
+    write_ref($t8, $t6)
+    $t9 := 0x0
+    $t10 := borrow_global<TestMutRefs::TSum>($t9)
+    r := $t10
+    $t11 := copy(r)
+    $t12 := borrow_field<TestMutRefs::TSum>.sum($t11)
+    $t13 := read_ref($t12)
+    $t14 := 1
+    $t15 := +($t13, $t14)
+    $t16 := move(r)
+    $t17 := borrow_field<TestMutRefs::TSum>.sum($t16)
+    write_ref($t17, $t15)
+    return ()
+}
+
+
+pub fun TestMutRefs::increment_invalid(x: &mut TestMutRefs::T) {
+    var $t1: &mut TestMutRefs::T
+    var $t2: &u64
+    var $t3: u64
+    var $t4: u64
+    var $t5: u64
+    var $t6: &mut TestMutRefs::T
+    var $t7: &mut u64
+    $t1 := copy(x)
+    $t2 := borrow_field<TestMutRefs::T>.value($t1)
+    $t3 := read_ref($t2)
+    $t4 := 1
+    $t5 := +($t3, $t4)
+    $t6 := move(x)
+    $t7 := borrow_field<TestMutRefs::T>.value($t6)
+    write_ref($t7, $t5)
+    return ()
+}
+
+
+pub fun TestMutRefs::new(x: u64): TestMutRefs::T {
+    var r: &mut TestMutRefs::TSum
+    var $t2: address
+    var $t3: &mut TestMutRefs::TSum
+    var $t4: &mut TestMutRefs::TSum
+    var $t5: &u64
+    var $t6: u64
+    var $t7: u64
+    var $t8: u64
+    var $t9: &mut TestMutRefs::TSum
+    var $t10: &mut u64
+    var $t11: u64
+    var $t12: TestMutRefs::T
+    $t2 := 0x0
+    $t3 := borrow_global<TestMutRefs::TSum>($t2)
+    r := $t3
+    $t4 := copy(r)
+    $t5 := borrow_field<TestMutRefs::TSum>.sum($t4)
+    $t6 := read_ref($t5)
+    $t7 := copy(x)
+    $t8 := +($t6, $t7)
+    $t9 := move(r)
+    $t10 := borrow_field<TestMutRefs::TSum>.sum($t9)
+    write_ref($t10, $t8)
+    $t11 := copy(x)
+    $t12 := pack TestMutRefs::T($t11)
+    return $t12
+}
+
+
+fun TestMutRefs::private_data_invariant_invalid(_x: &mut TestMutRefs::T) {
+    return ()
+}
+
+
+fun TestMutRefs::private_decrement(x: &mut TestMutRefs::T) {
+    var r: &mut TestMutRefs::TSum
+    var $t2: &mut TestMutRefs::T
+    var $t3: &u64
+    var $t4: u64
+    var $t5: u64
+    var $t6: u64
+    var $t7: &mut TestMutRefs::T
+    var $t8: &mut u64
+    var $t9: address
+    var $t10: &mut TestMutRefs::TSum
+    var $t11: &mut TestMutRefs::TSum
+    var $t12: &u64
+    var $t13: u64
+    var $t14: u64
+    var $t15: u64
+    var $t16: &mut TestMutRefs::TSum
+    var $t17: &mut u64
+    $t2 := copy(x)
+    $t3 := borrow_field<TestMutRefs::T>.value($t2)
+    $t4 := read_ref($t3)
+    $t5 := 1
+    $t6 := -($t4, $t5)
+    $t7 := move(x)
+    $t8 := borrow_field<TestMutRefs::T>.value($t7)
+    write_ref($t8, $t6)
+    $t9 := 0x0
+    $t10 := borrow_global<TestMutRefs::TSum>($t9)
+    r := $t10
+    $t11 := copy(r)
+    $t12 := borrow_field<TestMutRefs::TSum>.sum($t11)
+    $t13 := read_ref($t12)
+    $t14 := 1
+    $t15 := -($t13, $t14)
+    $t16 := move(r)
+    $t17 := borrow_field<TestMutRefs::TSum>.sum($t16)
+    write_ref($t17, $t15)
+    return ()
+}
+
+
+fun TestMutRefs::private_to_public_caller(r: &mut TestMutRefs::T) {
+    var $t1: &mut TestMutRefs::T
+    $t1 := move(r)
+    TestMutRefs::increment($t1)
+    return ()
+}
+
+
+fun TestMutRefs::private_to_public_caller_invalid_data_invariant() {
+    var r: &mut TestMutRefs::T
+    var x: TestMutRefs::T
+    var $t2: u64
+    var $t3: TestMutRefs::T
+    var $t4: &mut TestMutRefs::T
+    var $t5: &mut TestMutRefs::T
+    var $t6: &mut TestMutRefs::T
+    $t2 := 1
+    $t3 := TestMutRefs::new($t2)
+    x := $t3
+    $t4 := borrow_local(x)
+    r := $t4
+    $t5 := copy(r)
+    TestMutRefs::private_decrement($t5)
+    $t6 := move(r)
+    TestMutRefs::increment($t6)
+    return ()
+}
+
+
+pub fun TestMutRefsUser::valid() {
+    var x: TestMutRefs::T
+    var $t1: u64
+    var $t2: TestMutRefs::T
+    var $t3: &mut TestMutRefs::T
+    var $t4: TestMutRefs::T
+    $t1 := 4
+    $t2 := TestMutRefs::new($t1)
+    x := $t2
+    $t3 := borrow_local(x)
+    TestMutRefs::increment($t3)
+    $t4 := move(x)
+    TestMutRefs::delete($t4)
+    return ()
+}
+
+============ after pipeline `packref` ================
+
+pub fun TestMutRefs::data_invariant(_x: &mut TestMutRefs::T) {
+    // live_refs: _x borrowed_by: LocalRoot(_x) -> {Reference(_x)} borrows_from: Reference(_x) -> {LocalRoot(_x)}
+    // before: UnpackRef(_x), PackRef(_x) after:
+    return ()
+}
+
+
+pub fun TestMutRefs::decrement_invalid(x: &mut TestMutRefs::T) {
+    var r: &mut TestMutRefs::TSum
+    var $t2: &mut TestMutRefs::T
+    var $t3: u64
+    var $t4: u64
+    var $t5: u64
+    var $t6: u64
+    var $t7: &mut TestMutRefs::T
+    var $t8: &mut u64
+    var $t9: address
+    var $t10: &mut TestMutRefs::TSum
+    var $t11: &mut TestMutRefs::TSum
+    var $t12: u64
+    var $t13: u64
+    var $t14: u64
+    var $t15: u64
+    var $t16: &mut TestMutRefs::TSum
+    var $t17: &mut u64
+    // live_refs: x borrowed_by: LocalRoot(x) -> {Reference(x)} borrows_from: Reference(x) -> {LocalRoot(x)}
+    // before: UnpackRef(x) after:
+    $t2 := copy(x)
+    // live_refs: x, $t2 borrowed_by: LocalRoot(x) -> {Reference(x)}, Reference(x) -> {Reference($t2)} borrows_from: Reference(x) -> {LocalRoot(x)}, Reference($t2) -> {Reference(x)}
+    $t3 := get_field<TestMutRefs::T>.value($t2)
+    // live_refs: x borrowed_by: LocalRoot(x) -> {Reference(x)} borrows_from: Reference(x) -> {LocalRoot(x)}
+    $t4 := move($t3)
+    // live_refs: x borrowed_by: LocalRoot(x) -> {Reference(x)} borrows_from: Reference(x) -> {LocalRoot(x)}
+    $t5 := 1
+    // live_refs: x borrowed_by: LocalRoot(x) -> {Reference(x)} borrows_from: Reference(x) -> {LocalRoot(x)}
+    $t6 := -($t4, $t5)
+    // live_refs: x borrowed_by: LocalRoot(x) -> {Reference(x)} borrows_from: Reference(x) -> {LocalRoot(x)}
+    $t7 := move(x)
+    // live_refs: $t7 borrowed_by: LocalRoot(x) -> {Reference($t7)} borrows_from: Reference($t7) -> {LocalRoot(x)}
+    // before:  after: UnpackRef($t8)
+    $t8 := borrow_field<TestMutRefs::T>.value($t7)
+    // live_refs: $t8 borrowed_by: LocalRoot(x) -> {Reference($t8)}, Reference($t7) -> {Reference($t8)} borrows_from: Reference($t8) -> {LocalRoot(x), Reference($t7)}
+    // before:  after: PackRef($t7), PackRef($t8)
+    write_ref($t8, $t6)
+    $t9 := 0x0
+    // before:  after: UnpackRef($t10)
+    $t10 := borrow_global<TestMutRefs::TSum>($t9)
+    // live_refs: $t10 borrowed_by: TestMutRefs::TSum -> {Reference($t10)} borrows_from: Reference($t10) -> {TestMutRefs::TSum}
+    r := $t10
+    // live_refs: r borrowed_by: TestMutRefs::TSum -> {Reference(r)} borrows_from: Reference(r) -> {TestMutRefs::TSum}
+    $t11 := copy(r)
+    // live_refs: r, $t11 borrowed_by: TestMutRefs::TSum -> {Reference(r)}, Reference(r) -> {Reference($t11)} borrows_from: Reference(r) -> {TestMutRefs::TSum}, Reference($t11) -> {Reference(r)}
+    $t12 := get_field<TestMutRefs::TSum>.sum($t11)
+    // live_refs: r borrowed_by: TestMutRefs::TSum -> {Reference(r)} borrows_from: Reference(r) -> {TestMutRefs::TSum}
+    $t13 := move($t12)
+    // live_refs: r borrowed_by: TestMutRefs::TSum -> {Reference(r)} borrows_from: Reference(r) -> {TestMutRefs::TSum}
+    $t14 := 1
+    // live_refs: r borrowed_by: TestMutRefs::TSum -> {Reference(r)} borrows_from: Reference(r) -> {TestMutRefs::TSum}
+    $t15 := -($t13, $t14)
+    // live_refs: r borrowed_by: TestMutRefs::TSum -> {Reference(r)} borrows_from: Reference(r) -> {TestMutRefs::TSum}
+    $t16 := move(r)
+    // live_refs: $t16 borrowed_by: TestMutRefs::TSum -> {Reference($t16)} borrows_from: Reference($t16) -> {TestMutRefs::TSum}
+    // before:  after: UnpackRef($t17)
+    $t17 := borrow_field<TestMutRefs::TSum>.sum($t16)
+    // live_refs: $t17 borrowed_by: TestMutRefs::TSum -> {Reference($t17)}, Reference($t16) -> {Reference($t17)} borrows_from: Reference($t17) -> {TestMutRefs::TSum, Reference($t16)}
+    // before:  after: PackRef($t16), PackRef($t17)
+    write_ref($t17, $t15)
+    return ()
+}
+
+
+pub fun TestMutRefs::delete(x: TestMutRefs::T) {
+    var r: &mut TestMutRefs::TSum
+    var v: u64
+    var $t3: address
+    var $t4: &mut TestMutRefs::TSum
+    var $t5: TestMutRefs::T
+    var $t6: u64
+    var $t7: &mut TestMutRefs::TSum
+    var $t8: u64
+    var $t9: u64
+    var $t10: u64
+    var $t11: u64
+    var $t12: &mut TestMutRefs::TSum
+    var $t13: &mut u64
+    $t3 := 0x0
+    // before:  after: UnpackRef($t4)
+    $t4 := borrow_global<TestMutRefs::TSum>($t3)
+    // live_refs: $t4 borrowed_by: TestMutRefs::TSum -> {Reference($t4)} borrows_from: Reference($t4) -> {TestMutRefs::TSum}
+    r := $t4
+    // live_refs: r borrowed_by: TestMutRefs::TSum -> {Reference(r)} borrows_from: Reference(r) -> {TestMutRefs::TSum}
+    $t5 := move(x)
+    // live_refs: r borrowed_by: TestMutRefs::TSum -> {Reference(r)} borrows_from: Reference(r) -> {TestMutRefs::TSum}
+    $t6 := unpack TestMutRefs::T($t5)
+    // live_refs: r borrowed_by: TestMutRefs::TSum -> {Reference(r)} borrows_from: Reference(r) -> {TestMutRefs::TSum}
+    v := $t6
+    // live_refs: r borrowed_by: TestMutRefs::TSum -> {Reference(r)} borrows_from: Reference(r) -> {TestMutRefs::TSum}
+    $t7 := copy(r)
+    // live_refs: r, $t7 borrowed_by: TestMutRefs::TSum -> {Reference(r)}, Reference(r) -> {Reference($t7)} borrows_from: Reference(r) -> {TestMutRefs::TSum}, Reference($t7) -> {Reference(r)}
+    $t8 := get_field<TestMutRefs::TSum>.sum($t7)
+    // live_refs: r borrowed_by: TestMutRefs::TSum -> {Reference(r)} borrows_from: Reference(r) -> {TestMutRefs::TSum}
+    $t9 := move($t8)
+    // live_refs: r borrowed_by: TestMutRefs::TSum -> {Reference(r)} borrows_from: Reference(r) -> {TestMutRefs::TSum}
+    $t10 := copy(v)
+    // live_refs: r borrowed_by: TestMutRefs::TSum -> {Reference(r)} borrows_from: Reference(r) -> {TestMutRefs::TSum}
+    $t11 := -($t9, $t10)
+    // live_refs: r borrowed_by: TestMutRefs::TSum -> {Reference(r)} borrows_from: Reference(r) -> {TestMutRefs::TSum}
+    $t12 := move(r)
+    // live_refs: $t12 borrowed_by: TestMutRefs::TSum -> {Reference($t12)} borrows_from: Reference($t12) -> {TestMutRefs::TSum}
+    // before:  after: UnpackRef($t13)
+    $t13 := borrow_field<TestMutRefs::TSum>.sum($t12)
+    // live_refs: $t13 borrowed_by: TestMutRefs::TSum -> {Reference($t13)}, Reference($t12) -> {Reference($t13)} borrows_from: Reference($t13) -> {TestMutRefs::TSum, Reference($t12)}
+    // before:  after: PackRef($t12), PackRef($t13)
+    write_ref($t13, $t11)
+    return ()
+}
+
+
+pub fun TestMutRefs::increment(x: &mut TestMutRefs::T) {
+    var r: &mut TestMutRefs::TSum
+    var $t2: &mut TestMutRefs::T
+    var $t3: u64
+    var $t4: u64
+    var $t5: u64
+    var $t6: u64
+    var $t7: &mut TestMutRefs::T
+    var $t8: &mut u64
+    var $t9: address
+    var $t10: &mut TestMutRefs::TSum
+    var $t11: &mut TestMutRefs::TSum
+    var $t12: u64
+    var $t13: u64
+    var $t14: u64
+    var $t15: u64
+    var $t16: &mut TestMutRefs::TSum
+    var $t17: &mut u64
+    // live_refs: x borrowed_by: LocalRoot(x) -> {Reference(x)} borrows_from: Reference(x) -> {LocalRoot(x)}
+    // before: UnpackRef(x) after:
+    $t2 := copy(x)
+    // live_refs: x, $t2 borrowed_by: LocalRoot(x) -> {Reference(x)}, Reference(x) -> {Reference($t2)} borrows_from: Reference(x) -> {LocalRoot(x)}, Reference($t2) -> {Reference(x)}
+    $t3 := get_field<TestMutRefs::T>.value($t2)
+    // live_refs: x borrowed_by: LocalRoot(x) -> {Reference(x)} borrows_from: Reference(x) -> {LocalRoot(x)}
+    $t4 := move($t3)
+    // live_refs: x borrowed_by: LocalRoot(x) -> {Reference(x)} borrows_from: Reference(x) -> {LocalRoot(x)}
+    $t5 := 1
+    // live_refs: x borrowed_by: LocalRoot(x) -> {Reference(x)} borrows_from: Reference(x) -> {LocalRoot(x)}
+    $t6 := +($t4, $t5)
+    // live_refs: x borrowed_by: LocalRoot(x) -> {Reference(x)} borrows_from: Reference(x) -> {LocalRoot(x)}
+    $t7 := move(x)
+    // live_refs: $t7 borrowed_by: LocalRoot(x) -> {Reference($t7)} borrows_from: Reference($t7) -> {LocalRoot(x)}
+    // before:  after: UnpackRef($t8)
+    $t8 := borrow_field<TestMutRefs::T>.value($t7)
+    // live_refs: $t8 borrowed_by: LocalRoot(x) -> {Reference($t8)}, Reference($t7) -> {Reference($t8)} borrows_from: Reference($t8) -> {LocalRoot(x), Reference($t7)}
+    // before:  after: PackRef($t7), PackRef($t8)
+    write_ref($t8, $t6)
+    $t9 := 0x0
+    // before:  after: UnpackRef($t10)
+    $t10 := borrow_global<TestMutRefs::TSum>($t9)
+    // live_refs: $t10 borrowed_by: TestMutRefs::TSum -> {Reference($t10)} borrows_from: Reference($t10) -> {TestMutRefs::TSum}
+    r := $t10
+    // live_refs: r borrowed_by: TestMutRefs::TSum -> {Reference(r)} borrows_from: Reference(r) -> {TestMutRefs::TSum}
+    $t11 := copy(r)
+    // live_refs: r, $t11 borrowed_by: TestMutRefs::TSum -> {Reference(r)}, Reference(r) -> {Reference($t11)} borrows_from: Reference(r) -> {TestMutRefs::TSum}, Reference($t11) -> {Reference(r)}
+    $t12 := get_field<TestMutRefs::TSum>.sum($t11)
+    // live_refs: r borrowed_by: TestMutRefs::TSum -> {Reference(r)} borrows_from: Reference(r) -> {TestMutRefs::TSum}
+    $t13 := move($t12)
+    // live_refs: r borrowed_by: TestMutRefs::TSum -> {Reference(r)} borrows_from: Reference(r) -> {TestMutRefs::TSum}
+    $t14 := 1
+    // live_refs: r borrowed_by: TestMutRefs::TSum -> {Reference(r)} borrows_from: Reference(r) -> {TestMutRefs::TSum}
+    $t15 := +($t13, $t14)
+    // live_refs: r borrowed_by: TestMutRefs::TSum -> {Reference(r)} borrows_from: Reference(r) -> {TestMutRefs::TSum}
+    $t16 := move(r)
+    // live_refs: $t16 borrowed_by: TestMutRefs::TSum -> {Reference($t16)} borrows_from: Reference($t16) -> {TestMutRefs::TSum}
+    // before:  after: UnpackRef($t17)
+    $t17 := borrow_field<TestMutRefs::TSum>.sum($t16)
+    // live_refs: $t17 borrowed_by: TestMutRefs::TSum -> {Reference($t17)}, Reference($t16) -> {Reference($t17)} borrows_from: Reference($t17) -> {TestMutRefs::TSum, Reference($t16)}
+    // before:  after: PackRef($t16), PackRef($t17)
+    write_ref($t17, $t15)
+    return ()
+}
+
+
+pub fun TestMutRefs::increment_invalid(x: &mut TestMutRefs::T) {
+    var $t1: &mut TestMutRefs::T
+    var $t2: u64
+    var $t3: u64
+    var $t4: u64
+    var $t5: u64
+    var $t6: &mut TestMutRefs::T
+    var $t7: &mut u64
+    // live_refs: x borrowed_by: LocalRoot(x) -> {Reference(x)} borrows_from: Reference(x) -> {LocalRoot(x)}
+    // before: UnpackRef(x) after:
+    $t1 := copy(x)
+    // live_refs: x, $t1 borrowed_by: LocalRoot(x) -> {Reference(x)}, Reference(x) -> {Reference($t1)} borrows_from: Reference(x) -> {LocalRoot(x)}, Reference($t1) -> {Reference(x)}
+    $t2 := get_field<TestMutRefs::T>.value($t1)
+    // live_refs: x borrowed_by: LocalRoot(x) -> {Reference(x)} borrows_from: Reference(x) -> {LocalRoot(x)}
+    $t3 := move($t2)
+    // live_refs: x borrowed_by: LocalRoot(x) -> {Reference(x)} borrows_from: Reference(x) -> {LocalRoot(x)}
+    $t4 := 1
+    // live_refs: x borrowed_by: LocalRoot(x) -> {Reference(x)} borrows_from: Reference(x) -> {LocalRoot(x)}
+    $t5 := +($t3, $t4)
+    // live_refs: x borrowed_by: LocalRoot(x) -> {Reference(x)} borrows_from: Reference(x) -> {LocalRoot(x)}
+    $t6 := move(x)
+    // live_refs: $t6 borrowed_by: LocalRoot(x) -> {Reference($t6)} borrows_from: Reference($t6) -> {LocalRoot(x)}
+    // before:  after: UnpackRef($t7)
+    $t7 := borrow_field<TestMutRefs::T>.value($t6)
+    // live_refs: $t7 borrowed_by: LocalRoot(x) -> {Reference($t7)}, Reference($t6) -> {Reference($t7)} borrows_from: Reference($t7) -> {LocalRoot(x), Reference($t6)}
+    // before:  after: PackRef($t6), PackRef($t7)
+    write_ref($t7, $t5)
+    return ()
+}
+
+
+pub fun TestMutRefs::new(x: u64): TestMutRefs::T {
+    var r: &mut TestMutRefs::TSum
+    var $t2: address
+    var $t3: &mut TestMutRefs::TSum
+    var $t4: &mut TestMutRefs::TSum
+    var $t5: u64
+    var $t6: u64
+    var $t7: u64
+    var $t8: u64
+    var $t9: &mut TestMutRefs::TSum
+    var $t10: &mut u64
+    var $t11: u64
+    var $t12: TestMutRefs::T
+    $t2 := 0x0
+    // before:  after: UnpackRef($t3)
+    $t3 := borrow_global<TestMutRefs::TSum>($t2)
+    // live_refs: $t3 borrowed_by: TestMutRefs::TSum -> {Reference($t3)} borrows_from: Reference($t3) -> {TestMutRefs::TSum}
+    r := $t3
+    // live_refs: r borrowed_by: TestMutRefs::TSum -> {Reference(r)} borrows_from: Reference(r) -> {TestMutRefs::TSum}
+    $t4 := copy(r)
+    // live_refs: r, $t4 borrowed_by: TestMutRefs::TSum -> {Reference(r)}, Reference(r) -> {Reference($t4)} borrows_from: Reference(r) -> {TestMutRefs::TSum}, Reference($t4) -> {Reference(r)}
+    $t5 := get_field<TestMutRefs::TSum>.sum($t4)
+    // live_refs: r borrowed_by: TestMutRefs::TSum -> {Reference(r)} borrows_from: Reference(r) -> {TestMutRefs::TSum}
+    $t6 := move($t5)
+    // live_refs: r borrowed_by: TestMutRefs::TSum -> {Reference(r)} borrows_from: Reference(r) -> {TestMutRefs::TSum}
+    $t7 := copy(x)
+    // live_refs: r borrowed_by: TestMutRefs::TSum -> {Reference(r)} borrows_from: Reference(r) -> {TestMutRefs::TSum}
+    $t8 := +($t6, $t7)
+    // live_refs: r borrowed_by: TestMutRefs::TSum -> {Reference(r)} borrows_from: Reference(r) -> {TestMutRefs::TSum}
+    $t9 := move(r)
+    // live_refs: $t9 borrowed_by: TestMutRefs::TSum -> {Reference($t9)} borrows_from: Reference($t9) -> {TestMutRefs::TSum}
+    // before:  after: UnpackRef($t10)
+    $t10 := borrow_field<TestMutRefs::TSum>.sum($t9)
+    // live_refs: $t10 borrowed_by: TestMutRefs::TSum -> {Reference($t10)}, Reference($t9) -> {Reference($t10)} borrows_from: Reference($t10) -> {TestMutRefs::TSum, Reference($t9)}
+    // before:  after: PackRef($t9), PackRef($t10)
+    write_ref($t10, $t8)
+    $t11 := copy(x)
+    $t12 := pack TestMutRefs::T($t11)
+    return $t12
+}
+
+
+fun TestMutRefs::private_data_invariant_invalid(_x: &mut TestMutRefs::T) {
+    // live_refs: _x borrowed_by: LocalRoot(_x) -> {Reference(_x)} borrows_from: Reference(_x) -> {LocalRoot(_x)}
+    return ()
+}
+
+
+fun TestMutRefs::private_decrement(x: &mut TestMutRefs::T) {
+    var r: &mut TestMutRefs::TSum
+    var $t2: &mut TestMutRefs::T
+    var $t3: u64
+    var $t4: u64
+    var $t5: u64
+    var $t6: u64
+    var $t7: &mut TestMutRefs::T
+    var $t8: &mut u64
+    var $t9: address
+    var $t10: &mut TestMutRefs::TSum
+    var $t11: &mut TestMutRefs::TSum
+    var $t12: u64
+    var $t13: u64
+    var $t14: u64
+    var $t15: u64
+    var $t16: &mut TestMutRefs::TSum
+    var $t17: &mut u64
+    // live_refs: x borrowed_by: LocalRoot(x) -> {Reference(x)} borrows_from: Reference(x) -> {LocalRoot(x)}
+    $t2 := copy(x)
+    // live_refs: x, $t2 borrowed_by: LocalRoot(x) -> {Reference(x)}, Reference(x) -> {Reference($t2)} borrows_from: Reference(x) -> {LocalRoot(x)}, Reference($t2) -> {Reference(x)}
+    $t3 := get_field<TestMutRefs::T>.value($t2)
+    // live_refs: x borrowed_by: LocalRoot(x) -> {Reference(x)} borrows_from: Reference(x) -> {LocalRoot(x)}
+    $t4 := move($t3)
+    // live_refs: x borrowed_by: LocalRoot(x) -> {Reference(x)} borrows_from: Reference(x) -> {LocalRoot(x)}
+    $t5 := 1
+    // live_refs: x borrowed_by: LocalRoot(x) -> {Reference(x)} borrows_from: Reference(x) -> {LocalRoot(x)}
+    $t6 := -($t4, $t5)
+    // live_refs: x borrowed_by: LocalRoot(x) -> {Reference(x)} borrows_from: Reference(x) -> {LocalRoot(x)}
+    $t7 := move(x)
+    // live_refs: $t7 borrowed_by: LocalRoot(x) -> {Reference($t7)} borrows_from: Reference($t7) -> {LocalRoot(x)}
+    // before:  after: UnpackRef($t8)
+    $t8 := borrow_field<TestMutRefs::T>.value($t7)
+    // live_refs: $t8 borrowed_by: LocalRoot(x) -> {Reference($t8)}, Reference($t7) -> {Reference($t8)} borrows_from: Reference($t8) -> {LocalRoot(x), Reference($t7)}
+    // before:  after: PackRef($t8)
+    write_ref($t8, $t6)
+    $t9 := 0x0
+    // before:  after: UnpackRef($t10)
+    $t10 := borrow_global<TestMutRefs::TSum>($t9)
+    // live_refs: $t10 borrowed_by: TestMutRefs::TSum -> {Reference($t10)} borrows_from: Reference($t10) -> {TestMutRefs::TSum}
+    r := $t10
+    // live_refs: r borrowed_by: TestMutRefs::TSum -> {Reference(r)} borrows_from: Reference(r) -> {TestMutRefs::TSum}
+    $t11 := copy(r)
+    // live_refs: r, $t11 borrowed_by: TestMutRefs::TSum -> {Reference(r)}, Reference(r) -> {Reference($t11)} borrows_from: Reference(r) -> {TestMutRefs::TSum}, Reference($t11) -> {Reference(r)}
+    $t12 := get_field<TestMutRefs::TSum>.sum($t11)
+    // live_refs: r borrowed_by: TestMutRefs::TSum -> {Reference(r)} borrows_from: Reference(r) -> {TestMutRefs::TSum}
+    $t13 := move($t12)
+    // live_refs: r borrowed_by: TestMutRefs::TSum -> {Reference(r)} borrows_from: Reference(r) -> {TestMutRefs::TSum}
+    $t14 := 1
+    // live_refs: r borrowed_by: TestMutRefs::TSum -> {Reference(r)} borrows_from: Reference(r) -> {TestMutRefs::TSum}
+    $t15 := -($t13, $t14)
+    // live_refs: r borrowed_by: TestMutRefs::TSum -> {Reference(r)} borrows_from: Reference(r) -> {TestMutRefs::TSum}
+    $t16 := move(r)
+    // live_refs: $t16 borrowed_by: TestMutRefs::TSum -> {Reference($t16)} borrows_from: Reference($t16) -> {TestMutRefs::TSum}
+    // before:  after: UnpackRef($t17)
+    $t17 := borrow_field<TestMutRefs::TSum>.sum($t16)
+    // live_refs: $t17 borrowed_by: TestMutRefs::TSum -> {Reference($t17)}, Reference($t16) -> {Reference($t17)} borrows_from: Reference($t17) -> {TestMutRefs::TSum, Reference($t16)}
+    // before:  after: PackRef($t16), PackRef($t17)
+    write_ref($t17, $t15)
+    return ()
+}
+
+
+fun TestMutRefs::private_to_public_caller(r: &mut TestMutRefs::T) {
+    var $t1: &mut TestMutRefs::T
+    // live_refs: r borrowed_by: LocalRoot(r) -> {Reference(r)} borrows_from: Reference(r) -> {LocalRoot(r)}
+    $t1 := move(r)
+    // live_refs: $t1 borrowed_by: LocalRoot(r) -> {Reference($t1)} borrows_from: Reference($t1) -> {LocalRoot(r)}
+    // before: PackRef($t1) after: UnpackRef($t1)
+    TestMutRefs::increment($t1)
+    return ()
+}
+
+
+fun TestMutRefs::private_to_public_caller_invalid_data_invariant() {
+    var r: &mut TestMutRefs::T
+    var x: TestMutRefs::T
+    var $t2: u64
+    var $t3: TestMutRefs::T
+    var $t4: &mut TestMutRefs::T
+    var $t5: &mut TestMutRefs::T
+    var $t6: &mut TestMutRefs::T
+    $t2 := 1
+    $t3 := TestMutRefs::new($t2)
+    x := $t3
+    // before:  after: UnpackRef($t4)
+    $t4 := borrow_local(x)
+    // live_refs: $t4 borrowed_by: LocalRoot(x) -> {Reference($t4)} borrows_from: Reference($t4) -> {LocalRoot(x)}
+    r := $t4
+    // live_refs: r borrowed_by: LocalRoot(x) -> {Reference(r)} borrows_from: Reference(r) -> {LocalRoot(x)}
+    $t5 := copy(r)
+    // live_refs: r, $t5 borrowed_by: LocalRoot(x) -> {Reference(r)}, Reference(r) -> {Reference($t5)} borrows_from: Reference(r) -> {LocalRoot(x)}, Reference($t5) -> {Reference(r)}
+    TestMutRefs::private_decrement($t5)
+    // live_refs: r borrowed_by: LocalRoot(x) -> {Reference(r)} borrows_from: Reference(r) -> {LocalRoot(x)}
+    $t6 := move(r)
+    // live_refs: $t6 borrowed_by: LocalRoot(x) -> {Reference($t6)} borrows_from: Reference($t6) -> {LocalRoot(x)}
+    // before: PackRef($t6) after: UnpackRef($t6), PackRef($t6)
+    TestMutRefs::increment($t6)
+    return ()
+}
+
+
+pub fun TestMutRefsUser::valid() {
+    var x: TestMutRefs::T
+    var $t1: u64
+    var $t2: TestMutRefs::T
+    var $t3: &mut TestMutRefs::T
+    var $t4: TestMutRefs::T
+    $t1 := 4
+    $t2 := TestMutRefs::new($t1)
+    x := $t2
+    // before:  after: UnpackRef($t3)
+    $t3 := borrow_local(x)
+    // live_refs: $t3 borrowed_by: LocalRoot(x) -> {Reference($t3)} borrows_from: Reference($t3) -> {LocalRoot(x)}
+    // before: PackRef($t3) after: UnpackRef($t3), PackRef($t3)
+    TestMutRefs::increment($t3)
+    $t4 := move(x)
+    TestMutRefs::delete($t4)
+    return ()
+}

--- a/language/move-prover/stackless-bytecode-generator/tests/packref/mut_ref.move
+++ b/language/move-prover/stackless-bytecode-generator/tests/packref/mut_ref.move
@@ -1,0 +1,71 @@
+address 0x1 {
+module TestMutRefs {
+    struct T { value: u64 }
+
+    // Resource to track the sum of values in T
+    resource struct TSum {
+        sum: u64
+    }
+
+    public fun new(x: u64): T acquires TSum {
+        let r = borrow_global_mut<TSum>(0x0);
+        r.sum = r.sum + x;
+        T{value: x}
+    }
+
+    public fun delete(x: T) acquires TSum {
+        let r = borrow_global_mut<TSum>(0x0);
+        let T{value: v} = x;
+        r.sum = r.sum - v;
+    }
+
+    public fun increment(x: &mut T) acquires TSum {
+        x.value = x.value + 1;
+        let r = borrow_global_mut<TSum>(0x0);
+        r.sum = r.sum + 1;
+    }
+
+    public fun increment_invalid(x: &mut T) {
+        x.value = x.value + 1;
+    }
+
+    public fun decrement_invalid(x: &mut T) acquires TSum {
+        x.value = x.value - 1;
+        let r = borrow_global_mut<TSum>(0x0);
+        r.sum = r.sum - 1;
+    }
+
+    fun private_decrement(x: &mut T) acquires TSum {
+        x.value = x.value - 1;
+        let r = borrow_global_mut<TSum>(0x0);
+        r.sum = r.sum - 1;
+    }
+
+    public fun data_invariant(_x: &mut T) {
+    }
+
+    fun private_data_invariant_invalid(_x: &mut T) {
+    }
+
+    fun private_to_public_caller(r: &mut T) acquires TSum {
+        increment(r);
+    }
+
+    fun private_to_public_caller_invalid_data_invariant() acquires TSum {
+        let x = new(1);
+        let r = &mut x;
+        private_decrement(r);
+        increment(r);
+    }
+}
+
+module TestMutRefsUser {
+    use 0x1::TestMutRefs;
+
+    public fun valid() {
+        let x = TestMutRefs::new(4);
+        TestMutRefs::increment(&mut x);
+        TestMutRefs::delete(x);
+    }
+}
+}

--- a/language/move-prover/stackless-bytecode-generator/tests/writeback/basic_test.exp
+++ b/language/move-prover/stackless-bytecode-generator/tests/writeback/basic_test.exp
@@ -153,72 +153,97 @@ fun TestWriteback::test7(b: bool) {
 }
 
 
-fun TestWriteback::test8(n: u64, r_ref: &mut TestWriteback::R) {
+fun TestWriteback::test8(b: bool, n: u64, r_ref: &mut TestWriteback::R) {
     var r1: TestWriteback::R
     var r2: TestWriteback::R
-    var $t4: u64
-    var $t5: TestWriteback::R
+    var t_ref: &mut TestWriteback::R
     var $t6: u64
     var $t7: TestWriteback::R
     var $t8: u64
-    var $t9: u64
-    var $t10: bool
-    var $t11: &mut TestWriteback::R
+    var $t9: TestWriteback::R
+    var $t10: &mut TestWriteback::R
+    var $t11: u64
     var $t12: u64
-    var $t13: u64
-    var $t14: u64
+    var $t13: bool
+    var $t14: &mut TestWriteback::R
     var $t15: u64
-    var $t16: bool
-    var $t17: &mut TestWriteback::R
-    var $t18: &mut TestWriteback::R
-    var $t19: u64
-    var $t20: u64
-    var $t21: u64
-    var $t22: &mut TestWriteback::R
+    var $t16: u64
+    var $t17: u64
+    var $t18: u64
+    var $t19: bool
+    var $t20: &mut TestWriteback::R
+    var $t21: &mut TestWriteback::R
+    var $t22: u64
     var $t23: u64
-    $t4 := 3
-    $t5 := pack TestWriteback::R($t4)
-    r1 := $t5
-    $t6 := 4
+    var $t24: u64
+    var $t25: bool
+    var $t26: &mut TestWriteback::R
+    var $t27: &mut TestWriteback::R
+    var $t28: u64
+    var $t29: &mut TestWriteback::R
+    var $t30: &mut TestWriteback::R
+    var $t31: u64
+    $t6 := 3
     $t7 := pack TestWriteback::R($t6)
-    r2 := $t7
+    r1 := $t7
+    $t8 := 4
+    $t9 := pack TestWriteback::R($t8)
+    r2 := $t9
+    $t10 := borrow_local(r2)
+    t_ref := $t10
     goto L7
     L7:
-    $t8 := 0
-    $t9 := copy(n)
-    $t10 := <($t8, $t9)
-    if ($t10) goto L0 else goto L1
+    $t11 := 0
+    $t12 := copy(n)
+    $t13 := <($t11, $t12)
+    if ($t13) goto L0 else goto L1
     L1:
     goto L2
     L0:
-    $t11 := move(r_ref)
-    destroy($t11)
-    $t12 := copy(n)
-    $t13 := 2
-    $t14 := /($t12, $t13)
-    $t15 := 0
-    $t16 := ==($t14, $t15)
-    if ($t16) goto L3 else goto L4
+    $t14 := move(t_ref)
+    destroy($t14)
+    $t15 := copy(n)
+    $t16 := 2
+    $t17 := /($t15, $t16)
+    $t18 := 0
+    $t19 := ==($t17, $t18)
+    if ($t19) goto L3 else goto L4
     L4:
     goto L5
     L3:
-    $t17 := borrow_local(r1)
-    r_ref := $t17
+    $t20 := borrow_local(r1)
+    t_ref := $t20
     goto L6
     L5:
-    $t18 := borrow_local(r2)
-    r_ref := $t18
+    $t21 := borrow_local(r2)
+    t_ref := $t21
     goto L6
     L6:
-    $t19 := copy(n)
-    $t20 := 1
-    $t21 := -($t19, $t20)
-    n := $t21
+    $t22 := copy(n)
+    $t23 := 1
+    $t24 := -($t22, $t23)
+    n := $t24
     goto L7
     L2:
-    $t22 := move(r_ref)
-    $t23 := 0
-    TestWriteback::test3($t22, $t23)
+    $t25 := copy(b)
+    if ($t25) goto L8 else goto L9
+    L9:
+    goto L10
+    L8:
+    $t26 := move(t_ref)
+    destroy($t26)
+    $t27 := move(r_ref)
+    $t28 := 0
+    TestWriteback::test3($t27, $t28)
+    goto L11
+    L10:
+    $t29 := move(r_ref)
+    destroy($t29)
+    $t30 := move(t_ref)
+    $t31 := 0
+    TestWriteback::test3($t30, $t31)
+    goto L11
+    L11:
     return ()
 }
 
@@ -432,104 +457,159 @@ fun TestWriteback::test7(b: bool) {
 }
 
 
-fun TestWriteback::test8(n: u64, r_ref: &mut TestWriteback::R) {
+fun TestWriteback::test8(b: bool, n: u64, r_ref: &mut TestWriteback::R) {
     var r1: TestWriteback::R
     var r2: TestWriteback::R
-    var $t4: u64
-    var $t5: TestWriteback::R
+    var t_ref: &mut TestWriteback::R
     var $t6: u64
     var $t7: TestWriteback::R
     var $t8: u64
-    var $t9: u64
-    var $t10: bool
-    var $t11: &mut TestWriteback::R
+    var $t9: TestWriteback::R
+    var $t10: &mut TestWriteback::R
+    var $t11: u64
     var $t12: u64
-    var $t13: u64
-    var $t14: u64
+    var $t13: bool
+    var $t14: &mut TestWriteback::R
     var $t15: u64
-    var $t16: bool
-    var $t17: &mut TestWriteback::R
-    var $t18: &mut TestWriteback::R
-    var $t19: u64
-    var $t20: u64
-    var $t21: u64
-    var $t22: &mut TestWriteback::R
+    var $t16: u64
+    var $t17: u64
+    var $t18: u64
+    var $t19: bool
+    var $t20: &mut TestWriteback::R
+    var $t21: &mut TestWriteback::R
+    var $t22: u64
     var $t23: u64
+    var $t24: u64
+    var $t25: bool
+    var $t26: &mut TestWriteback::R
+    var $t27: &mut TestWriteback::R
+    var $t28: u64
+    var $t29: &mut TestWriteback::R
+    var $t30: &mut TestWriteback::R
+    var $t31: u64
     // live_refs: r_ref borrowed_by: LocalRoot(r_ref) -> {Reference(r_ref)} borrows_from: Reference(r_ref) -> {LocalRoot(r_ref)}
-    $t4 := 3
-    // live_refs: r_ref borrowed_by: LocalRoot(r_ref) -> {Reference(r_ref)} borrows_from: Reference(r_ref) -> {LocalRoot(r_ref)}
-    $t5 := pack TestWriteback::R($t4)
-    // live_refs: r_ref borrowed_by: LocalRoot(r_ref) -> {Reference(r_ref)} borrows_from: Reference(r_ref) -> {LocalRoot(r_ref)}
-    r1 := $t5
-    // live_refs: r_ref borrowed_by: LocalRoot(r_ref) -> {Reference(r_ref)} borrows_from: Reference(r_ref) -> {LocalRoot(r_ref)}
-    $t6 := 4
+    $t6 := 3
     // live_refs: r_ref borrowed_by: LocalRoot(r_ref) -> {Reference(r_ref)} borrows_from: Reference(r_ref) -> {LocalRoot(r_ref)}
     $t7 := pack TestWriteback::R($t6)
     // live_refs: r_ref borrowed_by: LocalRoot(r_ref) -> {Reference(r_ref)} borrows_from: Reference(r_ref) -> {LocalRoot(r_ref)}
-    r2 := $t7
+    r1 := $t7
     // live_refs: r_ref borrowed_by: LocalRoot(r_ref) -> {Reference(r_ref)} borrows_from: Reference(r_ref) -> {LocalRoot(r_ref)}
+    $t8 := 4
+    // live_refs: r_ref borrowed_by: LocalRoot(r_ref) -> {Reference(r_ref)} borrows_from: Reference(r_ref) -> {LocalRoot(r_ref)}
+    $t9 := pack TestWriteback::R($t8)
+    // live_refs: r_ref borrowed_by: LocalRoot(r_ref) -> {Reference(r_ref)} borrows_from: Reference(r_ref) -> {LocalRoot(r_ref)}
+    r2 := $t9
+    // live_refs: r_ref borrowed_by: LocalRoot(r_ref) -> {Reference(r_ref)} borrows_from: Reference(r_ref) -> {LocalRoot(r_ref)}
+    $t10 := borrow_local(r2)
+    // live_refs: r_ref, $t10 borrowed_by: LocalRoot(r_ref) -> {Reference(r_ref)}, LocalRoot(r2) -> {Reference($t10)} borrows_from: Reference(r_ref) -> {LocalRoot(r_ref)}, Reference($t10) -> {LocalRoot(r2)}
+    t_ref := $t10
+    // live_refs: r_ref, t_ref borrowed_by: LocalRoot(r_ref) -> {Reference(r_ref)}, LocalRoot(r2) -> {Reference(t_ref)} borrows_from: Reference(r_ref) -> {LocalRoot(r_ref)}, Reference(t_ref) -> {LocalRoot(r2)}
     goto L7
-    // live_refs: r_ref borrowed_by: LocalRoot(r_ref) -> {Reference(r_ref)}, LocalRoot(r1) -> {Reference(r_ref)}, LocalRoot(r2) -> {Reference(r_ref)} borrows_from: Reference(r_ref) -> {LocalRoot(r_ref), LocalRoot(r1), LocalRoot(r2)}
+    // live_refs: r_ref, t_ref borrowed_by: LocalRoot(r_ref) -> {Reference(r_ref)}, LocalRoot(r1) -> {Reference(t_ref)}, LocalRoot(r2) -> {Reference(t_ref)} borrows_from: Reference(r_ref) -> {LocalRoot(r_ref)}, Reference(t_ref) -> {LocalRoot(r1), LocalRoot(r2)}
     L7:
-    // live_refs: r_ref borrowed_by: LocalRoot(r_ref) -> {Reference(r_ref)}, LocalRoot(r1) -> {Reference(r_ref)}, LocalRoot(r2) -> {Reference(r_ref)} borrows_from: Reference(r_ref) -> {LocalRoot(r_ref), LocalRoot(r1), LocalRoot(r2)}
-    $t8 := 0
-    // live_refs: r_ref borrowed_by: LocalRoot(r_ref) -> {Reference(r_ref)}, LocalRoot(r1) -> {Reference(r_ref)}, LocalRoot(r2) -> {Reference(r_ref)} borrows_from: Reference(r_ref) -> {LocalRoot(r_ref), LocalRoot(r1), LocalRoot(r2)}
-    $t9 := copy(n)
-    // live_refs: r_ref borrowed_by: LocalRoot(r_ref) -> {Reference(r_ref)}, LocalRoot(r1) -> {Reference(r_ref)}, LocalRoot(r2) -> {Reference(r_ref)} borrows_from: Reference(r_ref) -> {LocalRoot(r_ref), LocalRoot(r1), LocalRoot(r2)}
-    $t10 := <($t8, $t9)
-    // live_refs: r_ref borrowed_by: LocalRoot(r_ref) -> {Reference(r_ref)}, LocalRoot(r1) -> {Reference(r_ref)}, LocalRoot(r2) -> {Reference(r_ref)} borrows_from: Reference(r_ref) -> {LocalRoot(r_ref), LocalRoot(r1), LocalRoot(r2)}
-    if ($t10) goto L0 else goto L1
-    // live_refs: r_ref borrowed_by: LocalRoot(r_ref) -> {Reference(r_ref)}, LocalRoot(r1) -> {Reference(r_ref)}, LocalRoot(r2) -> {Reference(r_ref)} borrows_from: Reference(r_ref) -> {LocalRoot(r_ref), LocalRoot(r1), LocalRoot(r2)}
-    L1:
-    // live_refs: r_ref borrowed_by: LocalRoot(r_ref) -> {Reference(r_ref)}, LocalRoot(r1) -> {Reference(r_ref)}, LocalRoot(r2) -> {Reference(r_ref)} borrows_from: Reference(r_ref) -> {LocalRoot(r_ref), LocalRoot(r1), LocalRoot(r2)}
-    goto L2
-    // live_refs: r_ref borrowed_by: LocalRoot(r_ref) -> {Reference(r_ref)}, LocalRoot(r1) -> {Reference(r_ref)}, LocalRoot(r2) -> {Reference(r_ref)} borrows_from: Reference(r_ref) -> {LocalRoot(r_ref), LocalRoot(r1), LocalRoot(r2)}
-    L0:
-    // live_refs: r_ref borrowed_by: LocalRoot(r_ref) -> {Reference(r_ref)}, LocalRoot(r1) -> {Reference(r_ref)}, LocalRoot(r2) -> {Reference(r_ref)} borrows_from: Reference(r_ref) -> {LocalRoot(r_ref), LocalRoot(r1), LocalRoot(r2)}
-    $t11 := move(r_ref)
-    // live_refs: $t11 borrowed_by: LocalRoot(r_ref) -> {Reference($t11)}, LocalRoot(r1) -> {Reference($t11)}, LocalRoot(r2) -> {Reference($t11)} borrows_from: Reference($t11) -> {LocalRoot(r_ref), LocalRoot(r1), LocalRoot(r2)}
-    // LocalRoot(r_ref) <- $t11, LocalRoot(r1) <- $t11, LocalRoot(r2) <- $t11
-    destroy($t11)
+    // live_refs: r_ref, t_ref borrowed_by: LocalRoot(r_ref) -> {Reference(r_ref)}, LocalRoot(r1) -> {Reference(t_ref)}, LocalRoot(r2) -> {Reference(t_ref)} borrows_from: Reference(r_ref) -> {LocalRoot(r_ref)}, Reference(t_ref) -> {LocalRoot(r1), LocalRoot(r2)}
+    $t11 := 0
+    // live_refs: r_ref, t_ref borrowed_by: LocalRoot(r_ref) -> {Reference(r_ref)}, LocalRoot(r1) -> {Reference(t_ref)}, LocalRoot(r2) -> {Reference(t_ref)} borrows_from: Reference(r_ref) -> {LocalRoot(r_ref)}, Reference(t_ref) -> {LocalRoot(r1), LocalRoot(r2)}
     $t12 := copy(n)
-    $t13 := 2
-    $t14 := /($t12, $t13)
-    $t15 := 0
-    $t16 := ==($t14, $t15)
-    if ($t16) goto L3 else goto L4
+    // live_refs: r_ref, t_ref borrowed_by: LocalRoot(r_ref) -> {Reference(r_ref)}, LocalRoot(r1) -> {Reference(t_ref)}, LocalRoot(r2) -> {Reference(t_ref)} borrows_from: Reference(r_ref) -> {LocalRoot(r_ref)}, Reference(t_ref) -> {LocalRoot(r1), LocalRoot(r2)}
+    $t13 := <($t11, $t12)
+    // live_refs: r_ref, t_ref borrowed_by: LocalRoot(r_ref) -> {Reference(r_ref)}, LocalRoot(r1) -> {Reference(t_ref)}, LocalRoot(r2) -> {Reference(t_ref)} borrows_from: Reference(r_ref) -> {LocalRoot(r_ref)}, Reference(t_ref) -> {LocalRoot(r1), LocalRoot(r2)}
+    if ($t13) goto L0 else goto L1
+    // live_refs: r_ref, t_ref borrowed_by: LocalRoot(r_ref) -> {Reference(r_ref)}, LocalRoot(r1) -> {Reference(t_ref)}, LocalRoot(r2) -> {Reference(t_ref)} borrows_from: Reference(r_ref) -> {LocalRoot(r_ref)}, Reference(t_ref) -> {LocalRoot(r1), LocalRoot(r2)}
+    L1:
+    // live_refs: r_ref, t_ref borrowed_by: LocalRoot(r_ref) -> {Reference(r_ref)}, LocalRoot(r1) -> {Reference(t_ref)}, LocalRoot(r2) -> {Reference(t_ref)} borrows_from: Reference(r_ref) -> {LocalRoot(r_ref)}, Reference(t_ref) -> {LocalRoot(r1), LocalRoot(r2)}
+    goto L2
+    // live_refs: r_ref, t_ref borrowed_by: LocalRoot(r_ref) -> {Reference(r_ref)}, LocalRoot(r1) -> {Reference(t_ref)}, LocalRoot(r2) -> {Reference(t_ref)} borrows_from: Reference(r_ref) -> {LocalRoot(r_ref)}, Reference(t_ref) -> {LocalRoot(r1), LocalRoot(r2)}
+    L0:
+    // live_refs: r_ref, t_ref borrowed_by: LocalRoot(r_ref) -> {Reference(r_ref)}, LocalRoot(r1) -> {Reference(t_ref)}, LocalRoot(r2) -> {Reference(t_ref)} borrows_from: Reference(r_ref) -> {LocalRoot(r_ref)}, Reference(t_ref) -> {LocalRoot(r1), LocalRoot(r2)}
+    $t14 := move(t_ref)
+    // live_refs: r_ref, $t14 borrowed_by: LocalRoot(r_ref) -> {Reference(r_ref)}, LocalRoot(r1) -> {Reference($t14)}, LocalRoot(r2) -> {Reference($t14)} borrows_from: Reference(r_ref) -> {LocalRoot(r_ref)}, Reference($t14) -> {LocalRoot(r1), LocalRoot(r2)}
+    // LocalRoot(r1) <- $t14, LocalRoot(r2) <- $t14
+    destroy($t14)
+    // live_refs: r_ref borrowed_by: LocalRoot(r_ref) -> {Reference(r_ref)} borrows_from: Reference(r_ref) -> {LocalRoot(r_ref)}
+    $t15 := copy(n)
+    // live_refs: r_ref borrowed_by: LocalRoot(r_ref) -> {Reference(r_ref)} borrows_from: Reference(r_ref) -> {LocalRoot(r_ref)}
+    $t16 := 2
+    // live_refs: r_ref borrowed_by: LocalRoot(r_ref) -> {Reference(r_ref)} borrows_from: Reference(r_ref) -> {LocalRoot(r_ref)}
+    $t17 := /($t15, $t16)
+    // live_refs: r_ref borrowed_by: LocalRoot(r_ref) -> {Reference(r_ref)} borrows_from: Reference(r_ref) -> {LocalRoot(r_ref)}
+    $t18 := 0
+    // live_refs: r_ref borrowed_by: LocalRoot(r_ref) -> {Reference(r_ref)} borrows_from: Reference(r_ref) -> {LocalRoot(r_ref)}
+    $t19 := ==($t17, $t18)
+    // live_refs: r_ref borrowed_by: LocalRoot(r_ref) -> {Reference(r_ref)} borrows_from: Reference(r_ref) -> {LocalRoot(r_ref)}
+    if ($t19) goto L3 else goto L4
+    // live_refs: r_ref borrowed_by: LocalRoot(r_ref) -> {Reference(r_ref)} borrows_from: Reference(r_ref) -> {LocalRoot(r_ref)}
     L4:
+    // live_refs: r_ref borrowed_by: LocalRoot(r_ref) -> {Reference(r_ref)} borrows_from: Reference(r_ref) -> {LocalRoot(r_ref)}
     goto L5
+    // live_refs: r_ref borrowed_by: LocalRoot(r_ref) -> {Reference(r_ref)} borrows_from: Reference(r_ref) -> {LocalRoot(r_ref)}
     L3:
-    $t17 := borrow_local(r1)
-    // live_refs: $t17 borrowed_by: LocalRoot(r1) -> {Reference($t17)} borrows_from: Reference($t17) -> {LocalRoot(r1)}
-    r_ref := $t17
-    // live_refs: r_ref borrowed_by: LocalRoot(r1) -> {Reference(r_ref)} borrows_from: Reference(r_ref) -> {LocalRoot(r1)}
+    // live_refs: r_ref borrowed_by: LocalRoot(r_ref) -> {Reference(r_ref)} borrows_from: Reference(r_ref) -> {LocalRoot(r_ref)}
+    $t20 := borrow_local(r1)
+    // live_refs: r_ref, $t20 borrowed_by: LocalRoot(r_ref) -> {Reference(r_ref)}, LocalRoot(r1) -> {Reference($t20)} borrows_from: Reference(r_ref) -> {LocalRoot(r_ref)}, Reference($t20) -> {LocalRoot(r1)}
+    t_ref := $t20
+    // live_refs: r_ref, t_ref borrowed_by: LocalRoot(r_ref) -> {Reference(r_ref)}, LocalRoot(r1) -> {Reference(t_ref)} borrows_from: Reference(r_ref) -> {LocalRoot(r_ref)}, Reference(t_ref) -> {LocalRoot(r1)}
     goto L6
+    // live_refs: r_ref borrowed_by: LocalRoot(r_ref) -> {Reference(r_ref)} borrows_from: Reference(r_ref) -> {LocalRoot(r_ref)}
     L5:
-    $t18 := borrow_local(r2)
-    // live_refs: $t18 borrowed_by: LocalRoot(r2) -> {Reference($t18)} borrows_from: Reference($t18) -> {LocalRoot(r2)}
-    r_ref := $t18
-    // live_refs: r_ref borrowed_by: LocalRoot(r2) -> {Reference(r_ref)} borrows_from: Reference(r_ref) -> {LocalRoot(r2)}
+    // live_refs: r_ref borrowed_by: LocalRoot(r_ref) -> {Reference(r_ref)} borrows_from: Reference(r_ref) -> {LocalRoot(r_ref)}
+    $t21 := borrow_local(r2)
+    // live_refs: r_ref, $t21 borrowed_by: LocalRoot(r_ref) -> {Reference(r_ref)}, LocalRoot(r2) -> {Reference($t21)} borrows_from: Reference(r_ref) -> {LocalRoot(r_ref)}, Reference($t21) -> {LocalRoot(r2)}
+    t_ref := $t21
+    // live_refs: r_ref, t_ref borrowed_by: LocalRoot(r_ref) -> {Reference(r_ref)}, LocalRoot(r2) -> {Reference(t_ref)} borrows_from: Reference(r_ref) -> {LocalRoot(r_ref)}, Reference(t_ref) -> {LocalRoot(r2)}
     goto L6
-    // live_refs: r_ref borrowed_by: LocalRoot(r1) -> {Reference(r_ref)}, LocalRoot(r2) -> {Reference(r_ref)} borrows_from: Reference(r_ref) -> {LocalRoot(r1), LocalRoot(r2)}
+    // live_refs: r_ref, t_ref borrowed_by: LocalRoot(r_ref) -> {Reference(r_ref)}, LocalRoot(r1) -> {Reference(t_ref)}, LocalRoot(r2) -> {Reference(t_ref)} borrows_from: Reference(r_ref) -> {LocalRoot(r_ref)}, Reference(t_ref) -> {LocalRoot(r1), LocalRoot(r2)}
     L6:
-    // live_refs: r_ref borrowed_by: LocalRoot(r1) -> {Reference(r_ref)}, LocalRoot(r2) -> {Reference(r_ref)} borrows_from: Reference(r_ref) -> {LocalRoot(r1), LocalRoot(r2)}
-    $t19 := copy(n)
-    // live_refs: r_ref borrowed_by: LocalRoot(r1) -> {Reference(r_ref)}, LocalRoot(r2) -> {Reference(r_ref)} borrows_from: Reference(r_ref) -> {LocalRoot(r1), LocalRoot(r2)}
-    $t20 := 1
-    // live_refs: r_ref borrowed_by: LocalRoot(r1) -> {Reference(r_ref)}, LocalRoot(r2) -> {Reference(r_ref)} borrows_from: Reference(r_ref) -> {LocalRoot(r1), LocalRoot(r2)}
-    $t21 := -($t19, $t20)
-    // live_refs: r_ref borrowed_by: LocalRoot(r1) -> {Reference(r_ref)}, LocalRoot(r2) -> {Reference(r_ref)} borrows_from: Reference(r_ref) -> {LocalRoot(r1), LocalRoot(r2)}
-    n := $t21
-    // live_refs: r_ref borrowed_by: LocalRoot(r1) -> {Reference(r_ref)}, LocalRoot(r2) -> {Reference(r_ref)} borrows_from: Reference(r_ref) -> {LocalRoot(r1), LocalRoot(r2)}
+    // live_refs: r_ref, t_ref borrowed_by: LocalRoot(r_ref) -> {Reference(r_ref)}, LocalRoot(r1) -> {Reference(t_ref)}, LocalRoot(r2) -> {Reference(t_ref)} borrows_from: Reference(r_ref) -> {LocalRoot(r_ref)}, Reference(t_ref) -> {LocalRoot(r1), LocalRoot(r2)}
+    $t22 := copy(n)
+    // live_refs: r_ref, t_ref borrowed_by: LocalRoot(r_ref) -> {Reference(r_ref)}, LocalRoot(r1) -> {Reference(t_ref)}, LocalRoot(r2) -> {Reference(t_ref)} borrows_from: Reference(r_ref) -> {LocalRoot(r_ref)}, Reference(t_ref) -> {LocalRoot(r1), LocalRoot(r2)}
+    $t23 := 1
+    // live_refs: r_ref, t_ref borrowed_by: LocalRoot(r_ref) -> {Reference(r_ref)}, LocalRoot(r1) -> {Reference(t_ref)}, LocalRoot(r2) -> {Reference(t_ref)} borrows_from: Reference(r_ref) -> {LocalRoot(r_ref)}, Reference(t_ref) -> {LocalRoot(r1), LocalRoot(r2)}
+    $t24 := -($t22, $t23)
+    // live_refs: r_ref, t_ref borrowed_by: LocalRoot(r_ref) -> {Reference(r_ref)}, LocalRoot(r1) -> {Reference(t_ref)}, LocalRoot(r2) -> {Reference(t_ref)} borrows_from: Reference(r_ref) -> {LocalRoot(r_ref)}, Reference(t_ref) -> {LocalRoot(r1), LocalRoot(r2)}
+    n := $t24
+    // live_refs: r_ref, t_ref borrowed_by: LocalRoot(r_ref) -> {Reference(r_ref)}, LocalRoot(r1) -> {Reference(t_ref)}, LocalRoot(r2) -> {Reference(t_ref)} borrows_from: Reference(r_ref) -> {LocalRoot(r_ref)}, Reference(t_ref) -> {LocalRoot(r1), LocalRoot(r2)}
     goto L7
-    // live_refs: r_ref borrowed_by: LocalRoot(r_ref) -> {Reference(r_ref)}, LocalRoot(r1) -> {Reference(r_ref)}, LocalRoot(r2) -> {Reference(r_ref)} borrows_from: Reference(r_ref) -> {LocalRoot(r_ref), LocalRoot(r1), LocalRoot(r2)}
+    // live_refs: r_ref, t_ref borrowed_by: LocalRoot(r_ref) -> {Reference(r_ref)}, LocalRoot(r1) -> {Reference(t_ref)}, LocalRoot(r2) -> {Reference(t_ref)} borrows_from: Reference(r_ref) -> {LocalRoot(r_ref)}, Reference(t_ref) -> {LocalRoot(r1), LocalRoot(r2)}
     L2:
-    // live_refs: r_ref borrowed_by: LocalRoot(r_ref) -> {Reference(r_ref)}, LocalRoot(r1) -> {Reference(r_ref)}, LocalRoot(r2) -> {Reference(r_ref)} borrows_from: Reference(r_ref) -> {LocalRoot(r_ref), LocalRoot(r1), LocalRoot(r2)}
-    $t22 := move(r_ref)
-    // live_refs: $t22 borrowed_by: LocalRoot(r_ref) -> {Reference($t22)}, LocalRoot(r1) -> {Reference($t22)}, LocalRoot(r2) -> {Reference($t22)} borrows_from: Reference($t22) -> {LocalRoot(r_ref), LocalRoot(r1), LocalRoot(r2)}
-    $t23 := 0
-    // live_refs: $t22 borrowed_by: LocalRoot(r_ref) -> {Reference($t22)}, LocalRoot(r1) -> {Reference($t22)}, LocalRoot(r2) -> {Reference($t22)} borrows_from: Reference($t22) -> {LocalRoot(r_ref), LocalRoot(r1), LocalRoot(r2)}
-    // LocalRoot(r_ref) <- $t22, LocalRoot(r1) <- $t22, LocalRoot(r2) <- $t22
-    TestWriteback::test3($t22, $t23)
+    // live_refs: r_ref, t_ref borrowed_by: LocalRoot(r_ref) -> {Reference(r_ref)}, LocalRoot(r1) -> {Reference(t_ref)}, LocalRoot(r2) -> {Reference(t_ref)} borrows_from: Reference(r_ref) -> {LocalRoot(r_ref)}, Reference(t_ref) -> {LocalRoot(r1), LocalRoot(r2)}
+    $t25 := copy(b)
+    // live_refs: r_ref, t_ref borrowed_by: LocalRoot(r_ref) -> {Reference(r_ref)}, LocalRoot(r1) -> {Reference(t_ref)}, LocalRoot(r2) -> {Reference(t_ref)} borrows_from: Reference(r_ref) -> {LocalRoot(r_ref)}, Reference(t_ref) -> {LocalRoot(r1), LocalRoot(r2)}
+    if ($t25) goto L8 else goto L9
+    // live_refs: r_ref, t_ref borrowed_by: LocalRoot(r_ref) -> {Reference(r_ref)}, LocalRoot(r1) -> {Reference(t_ref)}, LocalRoot(r2) -> {Reference(t_ref)} borrows_from: Reference(r_ref) -> {LocalRoot(r_ref)}, Reference(t_ref) -> {LocalRoot(r1), LocalRoot(r2)}
+    L9:
+    // live_refs: r_ref, t_ref borrowed_by: LocalRoot(r_ref) -> {Reference(r_ref)}, LocalRoot(r1) -> {Reference(t_ref)}, LocalRoot(r2) -> {Reference(t_ref)} borrows_from: Reference(r_ref) -> {LocalRoot(r_ref)}, Reference(t_ref) -> {LocalRoot(r1), LocalRoot(r2)}
+    goto L10
+    // live_refs: r_ref, t_ref borrowed_by: LocalRoot(r_ref) -> {Reference(r_ref)}, LocalRoot(r1) -> {Reference(t_ref)}, LocalRoot(r2) -> {Reference(t_ref)} borrows_from: Reference(r_ref) -> {LocalRoot(r_ref)}, Reference(t_ref) -> {LocalRoot(r1), LocalRoot(r2)}
+    L8:
+    // live_refs: r_ref, t_ref borrowed_by: LocalRoot(r_ref) -> {Reference(r_ref)}, LocalRoot(r1) -> {Reference(t_ref)}, LocalRoot(r2) -> {Reference(t_ref)} borrows_from: Reference(r_ref) -> {LocalRoot(r_ref)}, Reference(t_ref) -> {LocalRoot(r1), LocalRoot(r2)}
+    $t26 := move(t_ref)
+    // live_refs: r_ref, $t26 borrowed_by: LocalRoot(r_ref) -> {Reference(r_ref)}, LocalRoot(r1) -> {Reference($t26)}, LocalRoot(r2) -> {Reference($t26)} borrows_from: Reference(r_ref) -> {LocalRoot(r_ref)}, Reference($t26) -> {LocalRoot(r1), LocalRoot(r2)}
+    // LocalRoot(r1) <- $t26, LocalRoot(r2) <- $t26
+    destroy($t26)
+    // live_refs: r_ref borrowed_by: LocalRoot(r_ref) -> {Reference(r_ref)} borrows_from: Reference(r_ref) -> {LocalRoot(r_ref)}
+    $t27 := move(r_ref)
+    // live_refs: $t27 borrowed_by: LocalRoot(r_ref) -> {Reference($t27)} borrows_from: Reference($t27) -> {LocalRoot(r_ref)}
+    $t28 := 0
+    // live_refs: $t27 borrowed_by: LocalRoot(r_ref) -> {Reference($t27)} borrows_from: Reference($t27) -> {LocalRoot(r_ref)}
+    // LocalRoot(r_ref) <- $t27
+    TestWriteback::test3($t27, $t28)
+    goto L11
+    // live_refs: r_ref, t_ref borrowed_by: LocalRoot(r_ref) -> {Reference(r_ref)}, LocalRoot(r1) -> {Reference(t_ref)}, LocalRoot(r2) -> {Reference(t_ref)} borrows_from: Reference(r_ref) -> {LocalRoot(r_ref)}, Reference(t_ref) -> {LocalRoot(r1), LocalRoot(r2)}
+    L10:
+    // live_refs: r_ref, t_ref borrowed_by: LocalRoot(r_ref) -> {Reference(r_ref)}, LocalRoot(r1) -> {Reference(t_ref)}, LocalRoot(r2) -> {Reference(t_ref)} borrows_from: Reference(r_ref) -> {LocalRoot(r_ref)}, Reference(t_ref) -> {LocalRoot(r1), LocalRoot(r2)}
+    $t29 := move(r_ref)
+    // live_refs: t_ref, $t29 borrowed_by: LocalRoot(r_ref) -> {Reference($t29)}, LocalRoot(r1) -> {Reference(t_ref)}, LocalRoot(r2) -> {Reference(t_ref)} borrows_from: Reference(t_ref) -> {LocalRoot(r1), LocalRoot(r2)}, Reference($t29) -> {LocalRoot(r_ref)}
+    // LocalRoot(r_ref) <- $t29
+    destroy($t29)
+    // live_refs: t_ref borrowed_by: LocalRoot(r1) -> {Reference(t_ref)}, LocalRoot(r2) -> {Reference(t_ref)} borrows_from: Reference(t_ref) -> {LocalRoot(r1), LocalRoot(r2)}
+    $t30 := move(t_ref)
+    // live_refs: $t30 borrowed_by: LocalRoot(r1) -> {Reference($t30)}, LocalRoot(r2) -> {Reference($t30)} borrows_from: Reference($t30) -> {LocalRoot(r1), LocalRoot(r2)}
+    $t31 := 0
+    // live_refs: $t30 borrowed_by: LocalRoot(r1) -> {Reference($t30)}, LocalRoot(r2) -> {Reference($t30)} borrows_from: Reference($t30) -> {LocalRoot(r1), LocalRoot(r2)}
+    // LocalRoot(r1) <- $t30, LocalRoot(r2) <- $t30
+    TestWriteback::test3($t30, $t31)
+    goto L11
+    L11:
     return ()
 }

--- a/language/move-prover/stackless-bytecode-generator/tests/writeback/basic_test.move
+++ b/language/move-prover/stackless-bytecode-generator/tests/writeback/basic_test.move
@@ -49,17 +49,22 @@ module TestWriteback {
         test3(r_ref, 0)
     }
 
-    fun test8(n: u64, r_ref: &mut R) {
+    fun test8(b: bool, n: u64, r_ref: &mut R) {
         let r1 = R {x: 3};
         let r2 = R {x: 4};
+        let t_ref = &mut r2;
         while (0 < n) {
             if (n/2 == 0) {
-                r_ref = &mut r1
+                t_ref = &mut r1
             } else {
-                r_ref = &mut r2;
+                t_ref = &mut r2;
             };
             n = n - 1
         };
-        test3(r_ref, 0)
+        if (b) {
+            test3(r_ref, 0);
+        } else {
+            test3(t_ref, 0);
+        }
     }
 }

--- a/language/move-prover/stackless-bytecode-generator/tests/writeback/libra.exp
+++ b/language/move-prover/stackless-bytecode-generator/tests/writeback/libra.exp
@@ -1,0 +1,1922 @@
+============ initial translation from Move ================
+
+pub fun Vector::append<$tv0>(lhs: &mut vector<#0>, other: vector<#0>) {
+    var $t2: &mut vector<#0>
+    var $t3: &vector<#0>
+    var $t4: bool
+    var $t5: bool
+    var $t6: &mut vector<#0>
+    var $t7: &mut vector<#0>
+    var $t8: #0
+    var $t9: &mut vector<#0>
+    var $t10: vector<#0>
+    $t2 := borrow_local(other)
+    Vector::reverse<#0>($t2)
+    goto L3
+    L3:
+    $t3 := borrow_local(other)
+    $t4 := Vector::is_empty<#0>($t3)
+    $t5 := !($t4)
+    if ($t5) goto L0 else goto L1
+    L1:
+    goto L2
+    L0:
+    $t6 := copy(lhs)
+    $t7 := borrow_local(other)
+    $t8 := Vector::pop_back<#0>($t7)
+    Vector::push_back<#0>($t6, $t8)
+    goto L3
+    L2:
+    $t9 := move(lhs)
+    destroy($t9)
+    $t10 := move(other)
+    Vector::destroy_empty<#0>($t10)
+    return ()
+}
+
+
+pub fun Vector::borrow<$tv0>(v: &vector<#0>, i: u64): &#0 {
+}
+
+
+pub fun Vector::borrow_mut<$tv0>(v: &mut vector<#0>, idx: u64): &mut #0 {
+}
+
+
+pub fun Vector::contains<$tv0>(v: &vector<#0>, e: &#0): bool {
+    var i: u64
+    var len: u64
+    var $t4: u64
+    var $t5: &vector<#0>
+    var $t6: u64
+    var $t7: u64
+    var $t8: u64
+    var $t9: bool
+    var $t10: &vector<#0>
+    var $t11: u64
+    var $t12: &#0
+    var $t13: &#0
+    var $t14: bool
+    var $t15: &vector<#0>
+    var $t16: &#0
+    var $t17: bool
+    var $t18: u64
+    var $t19: u64
+    var $t20: u64
+    var $t21: &vector<#0>
+    var $t22: &#0
+    var $t23: bool
+    $t4 := 0
+    i := $t4
+    $t5 := copy(v)
+    $t6 := Vector::length<#0>($t5)
+    len := $t6
+    goto L6
+    L6:
+    $t7 := copy(i)
+    $t8 := copy(len)
+    $t9 := <($t7, $t8)
+    if ($t9) goto L0 else goto L1
+    L1:
+    goto L2
+    L0:
+    $t10 := copy(v)
+    $t11 := copy(i)
+    $t12 := Vector::borrow<#0>($t10, $t11)
+    $t13 := copy(e)
+    $t14 := ==($t12, $t13)
+    if ($t14) goto L3 else goto L4
+    L4:
+    goto L5
+    L3:
+    $t15 := move(v)
+    destroy($t15)
+    $t16 := move(e)
+    destroy($t16)
+    $t17 := true
+    return $t17
+    L5:
+    $t18 := copy(i)
+    $t19 := 1
+    $t20 := +($t18, $t19)
+    i := $t20
+    goto L6
+    L2:
+    $t21 := move(v)
+    destroy($t21)
+    $t22 := move(e)
+    destroy($t22)
+    $t23 := false
+    return $t23
+}
+
+
+pub fun Vector::destroy_empty<$tv0>(v: vector<#0>) {
+}
+
+
+pub fun Vector::empty<$tv0>(): vector<#0> {
+}
+
+
+pub fun Vector::is_empty<$tv0>(v: &vector<#0>): bool {
+    var $t1: &vector<#0>
+    var $t2: u64
+    var $t3: u64
+    var $t4: bool
+    $t1 := move(v)
+    $t2 := Vector::length<#0>($t1)
+    $t3 := 0
+    $t4 := ==($t2, $t3)
+    return $t4
+}
+
+
+pub fun Vector::length<$tv0>(v: &vector<#0>): u64 {
+}
+
+
+pub fun Vector::pop_back<$tv0>(v: &mut vector<#0>): #0 {
+}
+
+
+pub fun Vector::push_back<$tv0>(v: &mut vector<#0>, e: #0) {
+}
+
+
+pub fun Vector::remove<$tv0>(v: &mut vector<#0>, i: u64): #0 {
+    var len: u64
+    var $t3: u64
+    var $t4: &mut vector<#0>
+    var $t5: &mut vector<#0>
+    var $t6: &vector<#0>
+    var $t7: u64
+    var $t8: u64
+    var $t9: u64
+    var $t10: bool
+    var $t11: &mut vector<#0>
+    var $t12: u64
+    var $t13: u64
+    var $t14: u64
+    var $t15: u64
+    var $t16: u64
+    var $t17: u64
+    var $t18: bool
+    var $t19: &mut vector<#0>
+    var $t20: u64
+    var $t21: u64
+    var $t22: u64
+    var $t23: u64
+    var $t24: &mut vector<#0>
+    var $t25: u64
+    var $t26: u64
+    var $t27: &mut vector<#0>
+    var $t28: #0
+    $t5 := copy(v)
+    $t6 := freeze_ref($t5)
+    $t7 := Vector::length<#0>($t6)
+    len := $t7
+    $t8 := copy(i)
+    $t9 := copy(len)
+    $t10 := >=($t8, $t9)
+    if ($t10) goto L0 else goto L1
+    L1:
+    goto L2
+    L0:
+    $t11 := move(v)
+    destroy($t11)
+    $t12 := 10
+    abort($t12)
+    L2:
+    $t13 := copy(len)
+    $t14 := 1
+    $t15 := -($t13, $t14)
+    len := $t15
+    goto L6
+    L6:
+    $t16 := copy(i)
+    $t17 := copy(len)
+    $t18 := <($t16, $t17)
+    if ($t18) goto L3 else goto L4
+    L4:
+    goto L5
+    L3:
+    $t19 := copy(v)
+    $t4 := $t19
+    $t20 := copy(i)
+    $t3 := $t20
+    $t21 := copy(i)
+    $t22 := 1
+    $t23 := +($t21, $t22)
+    i := $t23
+    $t24 := move($t4)
+    $t25 := move($t3)
+    $t26 := copy(i)
+    Vector::swap<#0>($t24, $t25, $t26)
+    goto L6
+    L5:
+    $t27 := move(v)
+    $t28 := Vector::pop_back<#0>($t27)
+    return $t28
+}
+
+
+pub fun Vector::reverse<$tv0>(v: &mut vector<#0>) {
+    var back_index: u64
+    var front_index: u64
+    var len: u64
+    var $t4: &mut vector<#0>
+    var $t5: &vector<#0>
+    var $t6: u64
+    var $t7: u64
+    var $t8: u64
+    var $t9: bool
+    var $t10: &mut vector<#0>
+    var $t11: u64
+    var $t12: u64
+    var $t13: u64
+    var $t14: u64
+    var $t15: u64
+    var $t16: u64
+    var $t17: bool
+    var $t18: &mut vector<#0>
+    var $t19: u64
+    var $t20: u64
+    var $t21: u64
+    var $t22: u64
+    var $t23: u64
+    var $t24: u64
+    var $t25: u64
+    var $t26: u64
+    var $t27: &mut vector<#0>
+    $t4 := copy(v)
+    $t5 := freeze_ref($t4)
+    $t6 := Vector::length<#0>($t5)
+    len := $t6
+    $t7 := copy(len)
+    $t8 := 0
+    $t9 := ==($t7, $t8)
+    if ($t9) goto L0 else goto L1
+    L1:
+    goto L2
+    L0:
+    $t10 := move(v)
+    destroy($t10)
+    return ()
+    L2:
+    $t11 := 0
+    front_index := $t11
+    $t12 := copy(len)
+    $t13 := 1
+    $t14 := -($t12, $t13)
+    back_index := $t14
+    goto L6
+    L6:
+    $t15 := copy(front_index)
+    $t16 := copy(back_index)
+    $t17 := <($t15, $t16)
+    if ($t17) goto L3 else goto L4
+    L4:
+    goto L5
+    L3:
+    $t18 := copy(v)
+    $t19 := copy(front_index)
+    $t20 := copy(back_index)
+    Vector::swap<#0>($t18, $t19, $t20)
+    $t21 := copy(front_index)
+    $t22 := 1
+    $t23 := +($t21, $t22)
+    front_index := $t23
+    $t24 := copy(back_index)
+    $t25 := 1
+    $t26 := -($t24, $t25)
+    back_index := $t26
+    goto L6
+    L5:
+    $t27 := move(v)
+    destroy($t27)
+    return ()
+}
+
+
+pub fun Vector::swap<$tv0>(v: &mut vector<#0>, i: u64, j: u64) {
+}
+
+
+pub fun Vector::swap_remove<$tv0>(v: &mut vector<#0>, i: u64): #0 {
+    var last_idx: u64
+    var $t3: &mut vector<#0>
+    var $t4: &vector<#0>
+    var $t5: u64
+    var $t6: u64
+    var $t7: u64
+    var $t8: &mut vector<#0>
+    var $t9: u64
+    var $t10: u64
+    var $t11: &mut vector<#0>
+    var $t12: #0
+    $t3 := copy(v)
+    $t4 := freeze_ref($t3)
+    $t5 := Vector::length<#0>($t4)
+    $t6 := 1
+    $t7 := -($t5, $t6)
+    last_idx := $t7
+    $t8 := copy(v)
+    $t9 := copy(i)
+    $t10 := copy(last_idx)
+    Vector::swap<#0>($t8, $t9, $t10)
+    $t11 := move(v)
+    $t12 := Vector::pop_back<#0>($t11)
+    return $t12
+}
+
+
+fun Libra::assert_is_registered<$tv0>() {
+    var $t0: bool
+    var $t1: u64
+    var $t2: address
+    var $t3: bool
+    var $t4: bool
+    var $t5: u64
+    $t2 := 0xa550c18
+    $t3 := exists<Libra::Info<#0>>($t2)
+    $t0 := $t3
+    $t4 := move($t0)
+    if ($t4) goto L0 else goto L1
+    L1:
+    goto L2
+    L0:
+    goto L3
+    L2:
+    $t5 := 12
+    abort($t5)
+    L3:
+    return ()
+}
+
+
+pub fun Libra::burn<$tv0>(preburn_address: address) {
+    var $t1: address
+    var $t2: address
+    var $t3: &Libra::MintCapability<#0>
+    $t1 := copy(preburn_address)
+    $t2 := txn_sender
+    $t3 := borrow_global<Libra::MintCapability<#0>>($t2)
+    Libra::burn_with_capability<#0>($t1, $t3)
+    return ()
+}
+
+
+pub fun Libra::burn_with_capability<$tv0>(preburn_address: address, _capability: &Libra::MintCapability<#0>) {
+    var market_cap: &mut Libra::Info<#0>
+    var preburn: &mut Libra::Preburn<#0>
+    var value: u64
+    var $t5: address
+    var $t6: &mut Libra::Preburn<#0>
+    var $t7: &mut Libra::Preburn<#0>
+    var $t8: &mut vector<Libra::T<#0>>
+    var $t9: u64
+    var $t10: Libra::T<#0>
+    var $t11: u64
+    var $t12: address
+    var $t13: &mut Libra::Info<#0>
+    var $t14: &mut Libra::Info<#0>
+    var $t15: &u128
+    var $t16: u128
+    var $t17: u64
+    var $t18: u128
+    var $t19: u128
+    var $t20: &mut Libra::Info<#0>
+    var $t21: &mut u128
+    var $t22: &mut Libra::Info<#0>
+    var $t23: &u64
+    var $t24: u64
+    var $t25: u64
+    var $t26: u64
+    var $t27: &mut Libra::Info<#0>
+    var $t28: &mut u64
+    $t5 := copy(preburn_address)
+    $t6 := borrow_global<Libra::Preburn<#0>>($t5)
+    preburn := $t6
+    $t7 := move(preburn)
+    $t8 := borrow_field<Libra::Preburn<#0>>.requests($t7)
+    $t9 := 0
+    $t10 := Vector::remove<Libra::T<#0>>($t8, $t9)
+    $t11 := unpack Libra::T<#0>($t10)
+    value := $t11
+    $t12 := 0xa550c18
+    $t13 := borrow_global<Libra::Info<#0>>($t12)
+    market_cap := $t13
+    $t14 := copy(market_cap)
+    $t15 := borrow_field<Libra::Info<#0>>.total_value($t14)
+    $t16 := read_ref($t15)
+    $t17 := copy(value)
+    $t18 := (u128)($t17)
+    $t19 := -($t16, $t18)
+    $t20 := copy(market_cap)
+    $t21 := borrow_field<Libra::Info<#0>>.total_value($t20)
+    write_ref($t21, $t19)
+    $t22 := copy(market_cap)
+    $t23 := borrow_field<Libra::Info<#0>>.preburn_value($t22)
+    $t24 := read_ref($t23)
+    $t25 := copy(value)
+    $t26 := -($t24, $t25)
+    $t27 := move(market_cap)
+    $t28 := borrow_field<Libra::Info<#0>>.preburn_value($t27)
+    write_ref($t28, $t26)
+    return ()
+}
+
+
+pub fun Libra::cancel_burn<$tv0>(preburn_address: address): Libra::T<#0> {
+    var $t1: address
+    var $t2: address
+    var $t3: &Libra::MintCapability<#0>
+    var $t4: Libra::T<#0>
+    $t1 := copy(preburn_address)
+    $t2 := txn_sender
+    $t3 := borrow_global<Libra::MintCapability<#0>>($t2)
+    $t4 := Libra::cancel_burn_with_capability<#0>($t1, $t3)
+    return $t4
+}
+
+
+pub fun Libra::cancel_burn_with_capability<$tv0>(preburn_address: address, _capability: &Libra::MintCapability<#0>): Libra::T<#0> {
+    var coin: Libra::T<#0>
+    var market_cap: &mut Libra::Info<#0>
+    var preburn: &mut Libra::Preburn<#0>
+    var $t5: address
+    var $t6: &mut Libra::Preburn<#0>
+    var $t7: &mut Libra::Preburn<#0>
+    var $t8: &mut vector<Libra::T<#0>>
+    var $t9: u64
+    var $t10: Libra::T<#0>
+    var $t11: address
+    var $t12: &mut Libra::Info<#0>
+    var $t13: &mut Libra::Info<#0>
+    var $t14: &u64
+    var $t15: u64
+    var $t16: &Libra::T<#0>
+    var $t17: u64
+    var $t18: u64
+    var $t19: &mut Libra::Info<#0>
+    var $t20: &mut u64
+    var $t21: Libra::T<#0>
+    $t5 := copy(preburn_address)
+    $t6 := borrow_global<Libra::Preburn<#0>>($t5)
+    preburn := $t6
+    $t7 := move(preburn)
+    $t8 := borrow_field<Libra::Preburn<#0>>.requests($t7)
+    $t9 := 0
+    $t10 := Vector::remove<Libra::T<#0>>($t8, $t9)
+    coin := $t10
+    $t11 := 0xa550c18
+    $t12 := borrow_global<Libra::Info<#0>>($t11)
+    market_cap := $t12
+    $t13 := copy(market_cap)
+    $t14 := borrow_field<Libra::Info<#0>>.preburn_value($t13)
+    $t15 := read_ref($t14)
+    $t16 := borrow_local(coin)
+    $t17 := Libra::value<#0>($t16)
+    $t18 := -($t15, $t17)
+    $t19 := move(market_cap)
+    $t20 := borrow_field<Libra::Info<#0>>.preburn_value($t19)
+    write_ref($t20, $t18)
+    $t21 := move(coin)
+    return $t21
+}
+
+
+pub fun Libra::deposit<$tv0>(coin_ref: &mut Libra::T<#0>, check: Libra::T<#0>) {
+    var value: u64
+    var $t3: Libra::T<#0>
+    var $t4: u64
+    var $t5: &mut Libra::T<#0>
+    var $t6: &u64
+    var $t7: u64
+    var $t8: u64
+    var $t9: u64
+    var $t10: &mut Libra::T<#0>
+    var $t11: &mut u64
+    $t3 := move(check)
+    $t4 := unpack Libra::T<#0>($t3)
+    value := $t4
+    $t5 := copy(coin_ref)
+    $t6 := borrow_field<Libra::T<#0>>.value($t5)
+    $t7 := read_ref($t6)
+    $t8 := copy(value)
+    $t9 := +($t7, $t8)
+    $t10 := move(coin_ref)
+    $t11 := borrow_field<Libra::T<#0>>.value($t10)
+    write_ref($t11, $t9)
+    return ()
+}
+
+
+pub fun Libra::destroy_preburn<$tv0>(preburn: Libra::Preburn<#0>) {
+    var requests: vector<Libra::T<#0>>
+    var $t2: Libra::Preburn<#0>
+    var $t3: vector<Libra::T<#0>>
+    var $t4: bool
+    var $t5: vector<Libra::T<#0>>
+    $t2 := move(preburn)
+    ($t3, $t4) := unpack Libra::Preburn<#0>($t2)
+    destroy($t4)
+    requests := $t3
+    $t5 := move(requests)
+    Vector::destroy_empty<Libra::T<#0>>($t5)
+    return ()
+}
+
+
+pub fun Libra::preburn<$tv0>(preburn_ref: &mut Libra::Preburn<#0>, coin: Libra::T<#0>) {
+    var coin_value: u64
+    var market_cap: &mut Libra::Info<#0>
+    var $t4: &Libra::T<#0>
+    var $t5: u64
+    var $t6: &mut Libra::Preburn<#0>
+    var $t7: &mut vector<Libra::T<#0>>
+    var $t8: Libra::T<#0>
+    var $t9: address
+    var $t10: &mut Libra::Info<#0>
+    var $t11: &mut Libra::Info<#0>
+    var $t12: &u64
+    var $t13: u64
+    var $t14: u64
+    var $t15: u64
+    var $t16: &mut Libra::Info<#0>
+    var $t17: &mut u64
+    $t4 := borrow_local(coin)
+    $t5 := Libra::value<#0>($t4)
+    coin_value := $t5
+    $t6 := move(preburn_ref)
+    $t7 := borrow_field<Libra::Preburn<#0>>.requests($t6)
+    $t8 := move(coin)
+    Vector::push_back<Libra::T<#0>>($t7, $t8)
+    $t9 := 0xa550c18
+    $t10 := borrow_global<Libra::Info<#0>>($t9)
+    market_cap := $t10
+    $t11 := copy(market_cap)
+    $t12 := borrow_field<Libra::Info<#0>>.preburn_value($t11)
+    $t13 := read_ref($t12)
+    $t14 := copy(coin_value)
+    $t15 := +($t13, $t14)
+    $t16 := move(market_cap)
+    $t17 := borrow_field<Libra::Info<#0>>.preburn_value($t16)
+    write_ref($t17, $t15)
+    return ()
+}
+
+
+pub fun Libra::destroy_zero<$tv0>(coin: Libra::T<#0>) {
+    var $t1: bool
+    var $t2: u64
+    var value: u64
+    var $t4: Libra::T<#0>
+    var $t5: u64
+    var $t6: u64
+    var $t7: u64
+    var $t8: bool
+    var $t9: bool
+    var $t10: u64
+    $t4 := move(coin)
+    $t5 := unpack Libra::T<#0>($t4)
+    value := $t5
+    $t6 := copy(value)
+    $t7 := 0
+    $t8 := ==($t6, $t7)
+    $t1 := $t8
+    $t9 := move($t1)
+    if ($t9) goto L0 else goto L1
+    L1:
+    goto L2
+    L0:
+    goto L3
+    L2:
+    $t10 := 11
+    abort($t10)
+    L3:
+    return ()
+}
+
+
+pub fun Libra::join<$tv0>(coin1: Libra::T<#0>, coin2: Libra::T<#0>): Libra::T<#0> {
+    var $t2: &mut Libra::T<#0>
+    var $t3: Libra::T<#0>
+    var $t4: Libra::T<#0>
+    $t2 := borrow_local(coin1)
+    $t3 := move(coin2)
+    Libra::deposit<#0>($t2, $t3)
+    $t4 := move(coin1)
+    return $t4
+}
+
+
+pub fun Libra::market_cap<$tv0>(): u128 {
+    var $t0: address
+    var $t1: &Libra::Info<#0>
+    var $t2: &u128
+    var $t3: u128
+    $t0 := 0xa550c18
+    $t1 := borrow_global<Libra::Info<#0>>($t0)
+    $t2 := borrow_field<Libra::Info<#0>>.total_value($t1)
+    $t3 := read_ref($t2)
+    return $t3
+}
+
+
+pub fun Libra::mint<$tv0>(amount: u64): Libra::T<#0> {
+    var $t1: u64
+    var $t2: address
+    var $t3: &Libra::MintCapability<#0>
+    var $t4: Libra::T<#0>
+    $t1 := copy(amount)
+    $t2 := txn_sender
+    $t3 := borrow_global<Libra::MintCapability<#0>>($t2)
+    $t4 := Libra::mint_with_capability<#0>($t1, $t3)
+    return $t4
+}
+
+
+pub fun Libra::mint_with_capability<$tv0>(value: u64, _capability: &Libra::MintCapability<#0>): Libra::T<#0> {
+    var market_cap: &mut Libra::Info<#0>
+    var $t3: bool
+    var $t4: u64
+    var $t5: u64
+    var $t6: u64
+    var $t7: u64
+    var $t8: u64
+    var $t9: bool
+    var $t10: bool
+    var $t11: u64
+    var $t12: address
+    var $t13: &mut Libra::Info<#0>
+    var $t14: &mut Libra::Info<#0>
+    var $t15: &u128
+    var $t16: u128
+    var $t17: u64
+    var $t18: u128
+    var $t19: u128
+    var $t20: &mut Libra::Info<#0>
+    var $t21: &mut u128
+    var $t22: u64
+    var $t23: Libra::T<#0>
+    Libra::assert_is_registered<#0>()
+    $t5 := copy(value)
+    $t6 := 1000000000
+    $t7 := 1000000
+    $t8 := *($t6, $t7)
+    $t9 := <=($t5, $t8)
+    $t3 := $t9
+    $t10 := move($t3)
+    if ($t10) goto L0 else goto L1
+    L1:
+    goto L2
+    L0:
+    goto L3
+    L2:
+    $t11 := 11
+    abort($t11)
+    L3:
+    $t12 := 0xa550c18
+    $t13 := borrow_global<Libra::Info<#0>>($t12)
+    market_cap := $t13
+    $t14 := copy(market_cap)
+    $t15 := borrow_field<Libra::Info<#0>>.total_value($t14)
+    $t16 := read_ref($t15)
+    $t17 := copy(value)
+    $t18 := (u128)($t17)
+    $t19 := +($t16, $t18)
+    $t20 := move(market_cap)
+    $t21 := borrow_field<Libra::Info<#0>>.total_value($t20)
+    write_ref($t21, $t19)
+    $t22 := copy(value)
+    $t23 := pack Libra::T<#0>($t22)
+    return $t23
+}
+
+
+pub fun Libra::value<$tv0>(coin_ref: &Libra::T<#0>): u64 {
+    var $t1: &Libra::T<#0>
+    var $t2: &u64
+    var $t3: u64
+    $t1 := move(coin_ref)
+    $t2 := borrow_field<Libra::T<#0>>.value($t1)
+    $t3 := read_ref($t2)
+    return $t3
+}
+
+
+pub fun Libra::new_preburn<$tv0>(): Libra::Preburn<#0> {
+    var $t0: vector<Libra::T<#0>>
+    var $t1: bool
+    var $t2: Libra::Preburn<#0>
+    Libra::assert_is_registered<#0>()
+    $t0 := Vector::empty<Libra::T<#0>>()
+    $t1 := false
+    $t2 := pack Libra::Preburn<#0>($t0, $t1)
+    return $t2
+}
+
+
+pub fun Libra::preburn_to_sender<$tv0>(coin: Libra::T<#0>) {
+    var $t1: address
+    var $t2: &mut Libra::Preburn<#0>
+    var $t3: Libra::T<#0>
+    $t1 := txn_sender
+    $t2 := borrow_global<Libra::Preburn<#0>>($t1)
+    $t3 := move(coin)
+    Libra::preburn<#0>($t2, $t3)
+    return ()
+}
+
+
+pub fun Libra::preburn_value<$tv0>(): u64 {
+    var $t0: address
+    var $t1: &Libra::Info<#0>
+    var $t2: &u64
+    var $t3: u64
+    $t0 := 0xa550c18
+    $t1 := borrow_global<Libra::Info<#0>>($t0)
+    $t2 := borrow_field<Libra::Info<#0>>.preburn_value($t1)
+    $t3 := read_ref($t2)
+    return $t3
+}
+
+
+pub fun Libra::publish_mint_capability<$tv0>(capability: Libra::MintCapability<#0>) {
+    var $t1: Libra::MintCapability<#0>
+    $t1 := move(capability)
+    move_to_sender<Libra::MintCapability<#0>>($t1)
+    return ()
+}
+
+
+pub fun Libra::publish_preburn<$tv0>(preburn: Libra::Preburn<#0>) {
+    var $t1: Libra::Preburn<#0>
+    $t1 := move(preburn)
+    move_to_sender<Libra::Preburn<#0>>($t1)
+    return ()
+}
+
+
+pub fun Libra::register<$tv0>() {
+    var $t0: bool
+    var $t1: u64
+    var $t2: address
+    var $t3: address
+    var $t4: bool
+    var $t5: u64
+    var $t6: bool
+    var $t7: Libra::MintCapability<#0>
+    var $t8: u128
+    var $t9: u64
+    var $t10: Libra::Info<#0>
+    $t2 := txn_sender
+    $t3 := 0xa550c18
+    $t4 := ==($t2, $t3)
+    if ($t4) goto L0 else goto L1
+    L1:
+    goto L2
+    L0:
+    goto L3
+    L2:
+    $t5 := 1
+    abort($t5)
+    L3:
+    $t6 := false
+    $t7 := pack Libra::MintCapability<#0>($t6)
+    move_to_sender<Libra::MintCapability<#0>>($t7)
+    $t8 := 0
+    $t9 := 0
+    $t10 := pack Libra::Info<#0>($t8, $t9)
+    move_to_sender<Libra::Info<#0>>($t10)
+    return ()
+}
+
+
+pub fun Libra::remove_mint_capability<$tv0>(): Libra::MintCapability<#0> {
+    var $t0: address
+    var $t1: Libra::MintCapability<#0>
+    $t0 := txn_sender
+    $t1 := move_from<Libra::MintCapability<#0>>($t0)
+    return $t1
+}
+
+
+pub fun Libra::remove_preburn<$tv0>(): Libra::Preburn<#0> {
+    var $t0: address
+    var $t1: Libra::Preburn<#0>
+    $t0 := txn_sender
+    $t1 := move_from<Libra::Preburn<#0>>($t0)
+    return $t1
+}
+
+
+pub fun Libra::split<$tv0>(coin: Libra::T<#0>, amount: u64): (Libra::T<#0>, Libra::T<#0>) {
+    var other: Libra::T<#0>
+    var $t3: &mut Libra::T<#0>
+    var $t4: u64
+    var $t5: Libra::T<#0>
+    var $t6: Libra::T<#0>
+    var $t7: Libra::T<#0>
+    $t3 := borrow_local(coin)
+    $t4 := copy(amount)
+    $t5 := Libra::withdraw<#0>($t3, $t4)
+    other := $t5
+    $t6 := move(coin)
+    $t7 := move(other)
+    return ($t6, $t7)
+}
+
+
+pub fun Libra::withdraw<$tv0>(coin_ref: &mut Libra::T<#0>, value: u64): Libra::T<#0> {
+    var $t2: bool
+    var $t3: u64
+    var $t4: &mut Libra::T<#0>
+    var $t5: &u64
+    var $t6: u64
+    var $t7: u64
+    var $t8: bool
+    var $t9: bool
+    var $t10: &mut Libra::T<#0>
+    var $t11: u64
+    var $t12: &mut Libra::T<#0>
+    var $t13: &u64
+    var $t14: u64
+    var $t15: u64
+    var $t16: u64
+    var $t17: &mut Libra::T<#0>
+    var $t18: &mut u64
+    var $t19: u64
+    var $t20: Libra::T<#0>
+    $t4 := copy(coin_ref)
+    $t5 := borrow_field<Libra::T<#0>>.value($t4)
+    $t6 := read_ref($t5)
+    $t7 := copy(value)
+    $t8 := >=($t6, $t7)
+    $t2 := $t8
+    $t9 := move($t2)
+    if ($t9) goto L0 else goto L1
+    L1:
+    goto L2
+    L0:
+    goto L3
+    L2:
+    $t10 := move(coin_ref)
+    destroy($t10)
+    $t11 := 10
+    abort($t11)
+    L3:
+    $t12 := copy(coin_ref)
+    $t13 := borrow_field<Libra::T<#0>>.value($t12)
+    $t14 := read_ref($t13)
+    $t15 := copy(value)
+    $t16 := -($t14, $t15)
+    $t17 := move(coin_ref)
+    $t18 := borrow_field<Libra::T<#0>>.value($t17)
+    write_ref($t18, $t16)
+    $t19 := copy(value)
+    $t20 := pack Libra::T<#0>($t19)
+    return $t20
+}
+
+
+pub fun Libra::zero<$tv0>(): Libra::T<#0> {
+    var $t0: u64
+    var $t1: Libra::T<#0>
+    Libra::assert_is_registered<#0>()
+    $t0 := 0
+    $t1 := pack Libra::T<#0>($t0)
+    return $t1
+}
+
+============ after pipeline `writeback` ================
+
+pub fun Vector::append<$tv0>(lhs: &mut vector<#0>, other: vector<#0>) {
+    var $t2: &mut vector<#0>
+    var $t3: vector<#0>
+    var $t4: bool
+    var $t5: bool
+    var $t6: &mut vector<#0>
+    var $t7: &mut vector<#0>
+    var $t8: #0
+    var $t9: &mut vector<#0>
+    var $t10: vector<#0>
+    $t2 := borrow_local(other)
+    Vector::reverse<#0>($t2)
+    goto L3
+    L3:
+    $t3 := copy(other)
+    $t4 := Vector::is_empty<#0>($t3)
+    $t5 := !($t4)
+    if ($t5) goto L0 else goto L1
+    L1:
+    goto L2
+    L0:
+    $t6 := copy(lhs)
+    $t7 := borrow_local(other)
+    $t8 := Vector::pop_back<#0>($t7)
+    Vector::push_back<#0>($t6, $t8)
+    goto L3
+    L2:
+    $t9 := move(lhs)
+    destroy($t9)
+    $t10 := move(other)
+    Vector::destroy_empty<#0>($t10)
+    return ()
+}
+
+
+pub fun Vector::borrow<$tv0>(v: vector<#0>, i: u64): #0 {
+}
+
+
+pub fun Vector::borrow_mut<$tv0>(v: &mut vector<#0>, idx: u64): &mut #0 {
+}
+
+
+pub fun Vector::contains<$tv0>(v: vector<#0>, e: #0): bool {
+    var i: u64
+    var len: u64
+    var $t4: u64
+    var $t5: vector<#0>
+    var $t6: u64
+    var $t7: u64
+    var $t8: u64
+    var $t9: bool
+    var $t10: vector<#0>
+    var $t11: u64
+    var $t12: #0
+    var $t13: #0
+    var $t14: bool
+    var $t15: vector<#0>
+    var $t16: #0
+    var $t17: bool
+    var $t18: u64
+    var $t19: u64
+    var $t20: u64
+    var $t21: vector<#0>
+    var $t22: #0
+    var $t23: bool
+    $t4 := 0
+    i := $t4
+    $t5 := copy(v)
+    $t6 := Vector::length<#0>($t5)
+    len := $t6
+    goto L6
+    L6:
+    $t7 := copy(i)
+    $t8 := copy(len)
+    $t9 := <($t7, $t8)
+    if ($t9) goto L0 else goto L1
+    L1:
+    goto L2
+    L0:
+    $t10 := copy(v)
+    $t11 := copy(i)
+    $t12 := Vector::borrow<#0>($t10, $t11)
+    $t13 := copy(e)
+    $t14 := ==($t12, $t13)
+    if ($t14) goto L3 else goto L4
+    L4:
+    goto L5
+    L3:
+    $t15 := move(v)
+    destroy($t15)
+    $t16 := move(e)
+    destroy($t16)
+    $t17 := true
+    return $t17
+    L5:
+    $t18 := copy(i)
+    $t19 := 1
+    $t20 := +($t18, $t19)
+    i := $t20
+    goto L6
+    L2:
+    $t21 := move(v)
+    destroy($t21)
+    $t22 := move(e)
+    destroy($t22)
+    $t23 := false
+    return $t23
+}
+
+
+pub fun Vector::destroy_empty<$tv0>(v: vector<#0>) {
+}
+
+
+pub fun Vector::empty<$tv0>(): vector<#0> {
+}
+
+
+pub fun Vector::is_empty<$tv0>(v: vector<#0>): bool {
+    var $t1: vector<#0>
+    var $t2: u64
+    var $t3: u64
+    var $t4: bool
+    $t1 := move(v)
+    $t2 := Vector::length<#0>($t1)
+    $t3 := 0
+    $t4 := ==($t2, $t3)
+    return $t4
+}
+
+
+pub fun Vector::length<$tv0>(v: vector<#0>): u64 {
+}
+
+
+pub fun Vector::pop_back<$tv0>(v: &mut vector<#0>): #0 {
+}
+
+
+pub fun Vector::push_back<$tv0>(v: &mut vector<#0>, e: #0) {
+}
+
+
+pub fun Vector::remove<$tv0>(v: &mut vector<#0>, i: u64): #0 {
+    var len: u64
+    var $t3: u64
+    var $t4: &mut vector<#0>
+    var $t5: &mut vector<#0>
+    var $t6: vector<#0>
+    var $t7: u64
+    var $t8: u64
+    var $t9: u64
+    var $t10: bool
+    var $t11: &mut vector<#0>
+    var $t12: u64
+    var $t13: u64
+    var $t14: u64
+    var $t15: u64
+    var $t16: u64
+    var $t17: u64
+    var $t18: bool
+    var $t19: &mut vector<#0>
+    var $t20: u64
+    var $t21: u64
+    var $t22: u64
+    var $t23: u64
+    var $t24: &mut vector<#0>
+    var $t25: u64
+    var $t26: u64
+    var $t27: &mut vector<#0>
+    var $t28: #0
+    $t5 := copy(v)
+    $t6 := read_ref($t5)
+    $t7 := Vector::length<#0>($t6)
+    len := $t7
+    $t8 := copy(i)
+    $t9 := copy(len)
+    $t10 := >=($t8, $t9)
+    if ($t10) goto L0 else goto L1
+    L1:
+    goto L2
+    L0:
+    $t11 := move(v)
+    destroy($t11)
+    $t12 := 10
+    abort($t12)
+    L2:
+    $t13 := copy(len)
+    $t14 := 1
+    $t15 := -($t13, $t14)
+    len := $t15
+    goto L6
+    L6:
+    $t16 := copy(i)
+    $t17 := copy(len)
+    $t18 := <($t16, $t17)
+    if ($t18) goto L3 else goto L4
+    L4:
+    goto L5
+    L3:
+    $t19 := copy(v)
+    $t4 := $t19
+    $t20 := copy(i)
+    $t3 := $t20
+    $t21 := copy(i)
+    $t22 := 1
+    $t23 := +($t21, $t22)
+    i := $t23
+    $t24 := move($t4)
+    $t25 := move($t3)
+    $t26 := copy(i)
+    Vector::swap<#0>($t24, $t25, $t26)
+    goto L6
+    L5:
+    $t27 := move(v)
+    $t28 := Vector::pop_back<#0>($t27)
+    return $t28
+}
+
+
+pub fun Vector::reverse<$tv0>(v: &mut vector<#0>) {
+    var back_index: u64
+    var front_index: u64
+    var len: u64
+    var $t4: &mut vector<#0>
+    var $t5: vector<#0>
+    var $t6: u64
+    var $t7: u64
+    var $t8: u64
+    var $t9: bool
+    var $t10: &mut vector<#0>
+    var $t11: u64
+    var $t12: u64
+    var $t13: u64
+    var $t14: u64
+    var $t15: u64
+    var $t16: u64
+    var $t17: bool
+    var $t18: &mut vector<#0>
+    var $t19: u64
+    var $t20: u64
+    var $t21: u64
+    var $t22: u64
+    var $t23: u64
+    var $t24: u64
+    var $t25: u64
+    var $t26: u64
+    var $t27: &mut vector<#0>
+    $t4 := copy(v)
+    $t5 := read_ref($t4)
+    $t6 := Vector::length<#0>($t5)
+    len := $t6
+    $t7 := copy(len)
+    $t8 := 0
+    $t9 := ==($t7, $t8)
+    if ($t9) goto L0 else goto L1
+    L1:
+    goto L2
+    L0:
+    $t10 := move(v)
+    destroy($t10)
+    return ()
+    L2:
+    $t11 := 0
+    front_index := $t11
+    $t12 := copy(len)
+    $t13 := 1
+    $t14 := -($t12, $t13)
+    back_index := $t14
+    goto L6
+    L6:
+    $t15 := copy(front_index)
+    $t16 := copy(back_index)
+    $t17 := <($t15, $t16)
+    if ($t17) goto L3 else goto L4
+    L4:
+    goto L5
+    L3:
+    $t18 := copy(v)
+    $t19 := copy(front_index)
+    $t20 := copy(back_index)
+    Vector::swap<#0>($t18, $t19, $t20)
+    $t21 := copy(front_index)
+    $t22 := 1
+    $t23 := +($t21, $t22)
+    front_index := $t23
+    $t24 := copy(back_index)
+    $t25 := 1
+    $t26 := -($t24, $t25)
+    back_index := $t26
+    goto L6
+    L5:
+    $t27 := move(v)
+    destroy($t27)
+    return ()
+}
+
+
+pub fun Vector::swap<$tv0>(v: &mut vector<#0>, i: u64, j: u64) {
+}
+
+
+pub fun Vector::swap_remove<$tv0>(v: &mut vector<#0>, i: u64): #0 {
+    var last_idx: u64
+    var $t3: &mut vector<#0>
+    var $t4: vector<#0>
+    var $t5: u64
+    var $t6: u64
+    var $t7: u64
+    var $t8: &mut vector<#0>
+    var $t9: u64
+    var $t10: u64
+    var $t11: &mut vector<#0>
+    var $t12: #0
+    $t3 := copy(v)
+    $t4 := read_ref($t3)
+    $t5 := Vector::length<#0>($t4)
+    $t6 := 1
+    $t7 := -($t5, $t6)
+    last_idx := $t7
+    $t8 := copy(v)
+    $t9 := copy(i)
+    $t10 := copy(last_idx)
+    Vector::swap<#0>($t8, $t9, $t10)
+    $t11 := move(v)
+    $t12 := Vector::pop_back<#0>($t11)
+    return $t12
+}
+
+
+fun Libra::assert_is_registered<$tv0>() {
+    var $t0: bool
+    var $t1: u64
+    var $t2: address
+    var $t3: bool
+    var $t4: bool
+    var $t5: u64
+    $t2 := 0xa550c18
+    $t3 := exists<Libra::Info<#0>>($t2)
+    $t0 := $t3
+    $t4 := move($t0)
+    if ($t4) goto L0 else goto L1
+    L1:
+    goto L2
+    L0:
+    goto L3
+    L2:
+    $t5 := 12
+    abort($t5)
+    L3:
+    return ()
+}
+
+
+pub fun Libra::burn<$tv0>(preburn_address: address) {
+    var $t1: address
+    var $t2: address
+    var $t3: Libra::MintCapability<#0>
+    $t1 := copy(preburn_address)
+    $t2 := txn_sender
+    $t3 := get_global<Libra::MintCapability<#0>>($t2)
+    Libra::burn_with_capability<#0>($t1, $t3)
+    return ()
+}
+
+
+pub fun Libra::burn_with_capability<$tv0>(preburn_address: address, _capability: Libra::MintCapability<#0>) {
+    var market_cap: &mut Libra::Info<#0>
+    var preburn: &mut Libra::Preburn<#0>
+    var value: u64
+    var $t5: address
+    var $t6: &mut Libra::Preburn<#0>
+    var $t7: &mut Libra::Preburn<#0>
+    var $t8: &mut vector<Libra::T<#0>>
+    var $t9: u64
+    var $t10: Libra::T<#0>
+    var $t11: u64
+    var $t12: address
+    var $t13: &mut Libra::Info<#0>
+    var $t14: &mut Libra::Info<#0>
+    var $t15: u128
+    var $t16: u128
+    var $t17: u64
+    var $t18: u128
+    var $t19: u128
+    var $t20: &mut Libra::Info<#0>
+    var $t21: &mut u128
+    var $t22: &mut Libra::Info<#0>
+    var $t23: u64
+    var $t24: u64
+    var $t25: u64
+    var $t26: u64
+    var $t27: &mut Libra::Info<#0>
+    var $t28: &mut u64
+    $t5 := copy(preburn_address)
+    $t6 := borrow_global<Libra::Preburn<#0>>($t5)
+    // live_refs: $t6 borrowed_by: Libra::Preburn -> {Reference($t6)} borrows_from: Reference($t6) -> {Libra::Preburn}
+    preburn := $t6
+    // live_refs: preburn borrowed_by: Libra::Preburn -> {Reference(preburn)} borrows_from: Reference(preburn) -> {Libra::Preburn}
+    $t7 := move(preburn)
+    // live_refs: $t7 borrowed_by: Libra::Preburn -> {Reference($t7)} borrows_from: Reference($t7) -> {Libra::Preburn}
+    // Libra::Preburn <- $t7
+    $t8 := borrow_field<Libra::Preburn<#0>>.requests($t7)
+    // live_refs: $t8 borrowed_by: Libra::Preburn -> {Reference($t8)}, Reference($t7) -> {Reference($t8)} borrows_from: Reference($t8) -> {Libra::Preburn, Reference($t7)}
+    $t9 := 0
+    // live_refs: $t8 borrowed_by: Libra::Preburn -> {Reference($t8)}, Reference($t7) -> {Reference($t8)} borrows_from: Reference($t8) -> {Libra::Preburn, Reference($t7)}
+    // Libra::Preburn <- $t8, Reference($t7) <- $t8
+    $t10 := Vector::remove<Libra::T<#0>>($t8, $t9)
+    $t11 := unpack Libra::T<#0>($t10)
+    value := $t11
+    $t12 := 0xa550c18
+    $t13 := borrow_global<Libra::Info<#0>>($t12)
+    // live_refs: $t13 borrowed_by: Libra::Info -> {Reference($t13)} borrows_from: Reference($t13) -> {Libra::Info}
+    market_cap := $t13
+    // live_refs: market_cap borrowed_by: Libra::Info -> {Reference(market_cap)} borrows_from: Reference(market_cap) -> {Libra::Info}
+    $t14 := copy(market_cap)
+    // live_refs: market_cap, $t14 borrowed_by: Libra::Info -> {Reference(market_cap)}, Reference(market_cap) -> {Reference($t14)} borrows_from: Reference(market_cap) -> {Libra::Info}, Reference($t14) -> {Reference(market_cap)}
+    // Reference(market_cap) <- $t14
+    $t15 := get_field<Libra::Info<#0>>.total_value($t14)
+    // live_refs: market_cap borrowed_by: Libra::Info -> {Reference(market_cap)} borrows_from: Reference(market_cap) -> {Libra::Info}
+    $t16 := move($t15)
+    // live_refs: market_cap borrowed_by: Libra::Info -> {Reference(market_cap)} borrows_from: Reference(market_cap) -> {Libra::Info}
+    $t17 := copy(value)
+    // live_refs: market_cap borrowed_by: Libra::Info -> {Reference(market_cap)} borrows_from: Reference(market_cap) -> {Libra::Info}
+    $t18 := (u128)($t17)
+    // live_refs: market_cap borrowed_by: Libra::Info -> {Reference(market_cap)} borrows_from: Reference(market_cap) -> {Libra::Info}
+    $t19 := -($t16, $t18)
+    // live_refs: market_cap borrowed_by: Libra::Info -> {Reference(market_cap)} borrows_from: Reference(market_cap) -> {Libra::Info}
+    $t20 := copy(market_cap)
+    // live_refs: market_cap, $t20 borrowed_by: Libra::Info -> {Reference(market_cap)}, Reference(market_cap) -> {Reference($t20)} borrows_from: Reference(market_cap) -> {Libra::Info}, Reference($t20) -> {Reference(market_cap)}
+    // Reference(market_cap) <- $t20
+    $t21 := borrow_field<Libra::Info<#0>>.total_value($t20)
+    // live_refs: market_cap, $t21 borrowed_by: Libra::Info -> {Reference(market_cap)}, Reference(market_cap) -> {Reference($t21)}, Reference($t20) -> {Reference($t21)} borrows_from: Reference(market_cap) -> {Libra::Info}, Reference($t21) -> {Reference(market_cap), Reference($t20)}
+    // Reference(market_cap) <- $t21, Reference($t20) <- $t21
+    write_ref($t21, $t19)
+    // live_refs: market_cap borrowed_by: Libra::Info -> {Reference(market_cap)} borrows_from: Reference(market_cap) -> {Libra::Info}
+    $t22 := copy(market_cap)
+    // live_refs: market_cap, $t22 borrowed_by: Libra::Info -> {Reference(market_cap)}, Reference(market_cap) -> {Reference($t22)} borrows_from: Reference(market_cap) -> {Libra::Info}, Reference($t22) -> {Reference(market_cap)}
+    // Reference(market_cap) <- $t22
+    $t23 := get_field<Libra::Info<#0>>.preburn_value($t22)
+    // live_refs: market_cap borrowed_by: Libra::Info -> {Reference(market_cap)} borrows_from: Reference(market_cap) -> {Libra::Info}
+    $t24 := move($t23)
+    // live_refs: market_cap borrowed_by: Libra::Info -> {Reference(market_cap)} borrows_from: Reference(market_cap) -> {Libra::Info}
+    $t25 := copy(value)
+    // live_refs: market_cap borrowed_by: Libra::Info -> {Reference(market_cap)} borrows_from: Reference(market_cap) -> {Libra::Info}
+    $t26 := -($t24, $t25)
+    // live_refs: market_cap borrowed_by: Libra::Info -> {Reference(market_cap)} borrows_from: Reference(market_cap) -> {Libra::Info}
+    $t27 := move(market_cap)
+    // live_refs: $t27 borrowed_by: Libra::Info -> {Reference($t27)} borrows_from: Reference($t27) -> {Libra::Info}
+    // Libra::Info <- $t27
+    $t28 := borrow_field<Libra::Info<#0>>.preburn_value($t27)
+    // live_refs: $t28 borrowed_by: Libra::Info -> {Reference($t28)}, Reference($t27) -> {Reference($t28)} borrows_from: Reference($t28) -> {Libra::Info, Reference($t27)}
+    // Libra::Info <- $t28, Reference($t27) <- $t28
+    write_ref($t28, $t26)
+    return ()
+}
+
+
+pub fun Libra::cancel_burn<$tv0>(preburn_address: address): Libra::T<#0> {
+    var $t1: address
+    var $t2: address
+    var $t3: Libra::MintCapability<#0>
+    var $t4: Libra::T<#0>
+    $t1 := copy(preburn_address)
+    $t2 := txn_sender
+    $t3 := get_global<Libra::MintCapability<#0>>($t2)
+    $t4 := Libra::cancel_burn_with_capability<#0>($t1, $t3)
+    return $t4
+}
+
+
+pub fun Libra::cancel_burn_with_capability<$tv0>(preburn_address: address, _capability: Libra::MintCapability<#0>): Libra::T<#0> {
+    var coin: Libra::T<#0>
+    var market_cap: &mut Libra::Info<#0>
+    var preburn: &mut Libra::Preburn<#0>
+    var $t5: address
+    var $t6: &mut Libra::Preburn<#0>
+    var $t7: &mut Libra::Preburn<#0>
+    var $t8: &mut vector<Libra::T<#0>>
+    var $t9: u64
+    var $t10: Libra::T<#0>
+    var $t11: address
+    var $t12: &mut Libra::Info<#0>
+    var $t13: &mut Libra::Info<#0>
+    var $t14: u64
+    var $t15: u64
+    var $t16: Libra::T<#0>
+    var $t17: u64
+    var $t18: u64
+    var $t19: &mut Libra::Info<#0>
+    var $t20: &mut u64
+    var $t21: Libra::T<#0>
+    $t5 := copy(preburn_address)
+    $t6 := borrow_global<Libra::Preburn<#0>>($t5)
+    // live_refs: $t6 borrowed_by: Libra::Preburn -> {Reference($t6)} borrows_from: Reference($t6) -> {Libra::Preburn}
+    preburn := $t6
+    // live_refs: preburn borrowed_by: Libra::Preburn -> {Reference(preburn)} borrows_from: Reference(preburn) -> {Libra::Preburn}
+    $t7 := move(preburn)
+    // live_refs: $t7 borrowed_by: Libra::Preburn -> {Reference($t7)} borrows_from: Reference($t7) -> {Libra::Preburn}
+    // Libra::Preburn <- $t7
+    $t8 := borrow_field<Libra::Preburn<#0>>.requests($t7)
+    // live_refs: $t8 borrowed_by: Libra::Preburn -> {Reference($t8)}, Reference($t7) -> {Reference($t8)} borrows_from: Reference($t8) -> {Libra::Preburn, Reference($t7)}
+    $t9 := 0
+    // live_refs: $t8 borrowed_by: Libra::Preburn -> {Reference($t8)}, Reference($t7) -> {Reference($t8)} borrows_from: Reference($t8) -> {Libra::Preburn, Reference($t7)}
+    // Libra::Preburn <- $t8, Reference($t7) <- $t8
+    $t10 := Vector::remove<Libra::T<#0>>($t8, $t9)
+    coin := $t10
+    $t11 := 0xa550c18
+    $t12 := borrow_global<Libra::Info<#0>>($t11)
+    // live_refs: $t12 borrowed_by: Libra::Info -> {Reference($t12)} borrows_from: Reference($t12) -> {Libra::Info}
+    market_cap := $t12
+    // live_refs: market_cap borrowed_by: Libra::Info -> {Reference(market_cap)} borrows_from: Reference(market_cap) -> {Libra::Info}
+    $t13 := copy(market_cap)
+    // live_refs: market_cap, $t13 borrowed_by: Libra::Info -> {Reference(market_cap)}, Reference(market_cap) -> {Reference($t13)} borrows_from: Reference(market_cap) -> {Libra::Info}, Reference($t13) -> {Reference(market_cap)}
+    // Reference(market_cap) <- $t13
+    $t14 := get_field<Libra::Info<#0>>.preburn_value($t13)
+    // live_refs: market_cap borrowed_by: Libra::Info -> {Reference(market_cap)} borrows_from: Reference(market_cap) -> {Libra::Info}
+    $t15 := move($t14)
+    // live_refs: market_cap borrowed_by: Libra::Info -> {Reference(market_cap)} borrows_from: Reference(market_cap) -> {Libra::Info}
+    $t16 := copy(coin)
+    // live_refs: market_cap borrowed_by: Libra::Info -> {Reference(market_cap)} borrows_from: Reference(market_cap) -> {Libra::Info}
+    $t17 := Libra::value<#0>($t16)
+    // live_refs: market_cap borrowed_by: Libra::Info -> {Reference(market_cap)} borrows_from: Reference(market_cap) -> {Libra::Info}
+    $t18 := -($t15, $t17)
+    // live_refs: market_cap borrowed_by: Libra::Info -> {Reference(market_cap)} borrows_from: Reference(market_cap) -> {Libra::Info}
+    $t19 := move(market_cap)
+    // live_refs: $t19 borrowed_by: Libra::Info -> {Reference($t19)} borrows_from: Reference($t19) -> {Libra::Info}
+    // Libra::Info <- $t19
+    $t20 := borrow_field<Libra::Info<#0>>.preburn_value($t19)
+    // live_refs: $t20 borrowed_by: Libra::Info -> {Reference($t20)}, Reference($t19) -> {Reference($t20)} borrows_from: Reference($t20) -> {Libra::Info, Reference($t19)}
+    // Libra::Info <- $t20, Reference($t19) <- $t20
+    write_ref($t20, $t18)
+    $t21 := move(coin)
+    return $t21
+}
+
+
+pub fun Libra::deposit<$tv0>(coin_ref: &mut Libra::T<#0>, check: Libra::T<#0>) {
+    var value: u64
+    var $t3: Libra::T<#0>
+    var $t4: u64
+    var $t5: &mut Libra::T<#0>
+    var $t6: u64
+    var $t7: u64
+    var $t8: u64
+    var $t9: u64
+    var $t10: &mut Libra::T<#0>
+    var $t11: &mut u64
+    // live_refs: coin_ref borrowed_by: LocalRoot(coin_ref) -> {Reference(coin_ref)} borrows_from: Reference(coin_ref) -> {LocalRoot(coin_ref)}
+    $t3 := move(check)
+    // live_refs: coin_ref borrowed_by: LocalRoot(coin_ref) -> {Reference(coin_ref)} borrows_from: Reference(coin_ref) -> {LocalRoot(coin_ref)}
+    $t4 := unpack Libra::T<#0>($t3)
+    // live_refs: coin_ref borrowed_by: LocalRoot(coin_ref) -> {Reference(coin_ref)} borrows_from: Reference(coin_ref) -> {LocalRoot(coin_ref)}
+    value := $t4
+    // live_refs: coin_ref borrowed_by: LocalRoot(coin_ref) -> {Reference(coin_ref)} borrows_from: Reference(coin_ref) -> {LocalRoot(coin_ref)}
+    $t5 := copy(coin_ref)
+    // live_refs: coin_ref, $t5 borrowed_by: LocalRoot(coin_ref) -> {Reference(coin_ref)}, Reference(coin_ref) -> {Reference($t5)} borrows_from: Reference(coin_ref) -> {LocalRoot(coin_ref)}, Reference($t5) -> {Reference(coin_ref)}
+    // Reference(coin_ref) <- $t5
+    $t6 := get_field<Libra::T<#0>>.value($t5)
+    // live_refs: coin_ref borrowed_by: LocalRoot(coin_ref) -> {Reference(coin_ref)} borrows_from: Reference(coin_ref) -> {LocalRoot(coin_ref)}
+    $t7 := move($t6)
+    // live_refs: coin_ref borrowed_by: LocalRoot(coin_ref) -> {Reference(coin_ref)} borrows_from: Reference(coin_ref) -> {LocalRoot(coin_ref)}
+    $t8 := copy(value)
+    // live_refs: coin_ref borrowed_by: LocalRoot(coin_ref) -> {Reference(coin_ref)} borrows_from: Reference(coin_ref) -> {LocalRoot(coin_ref)}
+    $t9 := +($t7, $t8)
+    // live_refs: coin_ref borrowed_by: LocalRoot(coin_ref) -> {Reference(coin_ref)} borrows_from: Reference(coin_ref) -> {LocalRoot(coin_ref)}
+    $t10 := move(coin_ref)
+    // live_refs: $t10 borrowed_by: LocalRoot(coin_ref) -> {Reference($t10)} borrows_from: Reference($t10) -> {LocalRoot(coin_ref)}
+    // LocalRoot(coin_ref) <- $t10
+    $t11 := borrow_field<Libra::T<#0>>.value($t10)
+    // live_refs: $t11 borrowed_by: LocalRoot(coin_ref) -> {Reference($t11)}, Reference($t10) -> {Reference($t11)} borrows_from: Reference($t11) -> {LocalRoot(coin_ref), Reference($t10)}
+    // LocalRoot(coin_ref) <- $t11, Reference($t10) <- $t11
+    write_ref($t11, $t9)
+    return ()
+}
+
+
+pub fun Libra::destroy_preburn<$tv0>(preburn: Libra::Preburn<#0>) {
+    var requests: vector<Libra::T<#0>>
+    var $t2: Libra::Preburn<#0>
+    var $t3: vector<Libra::T<#0>>
+    var $t4: bool
+    var $t5: vector<Libra::T<#0>>
+    $t2 := move(preburn)
+    ($t3, $t4) := unpack Libra::Preburn<#0>($t2)
+    destroy($t4)
+    requests := $t3
+    $t5 := move(requests)
+    Vector::destroy_empty<Libra::T<#0>>($t5)
+    return ()
+}
+
+
+pub fun Libra::preburn<$tv0>(preburn_ref: &mut Libra::Preburn<#0>, coin: Libra::T<#0>) {
+    var coin_value: u64
+    var market_cap: &mut Libra::Info<#0>
+    var $t4: Libra::T<#0>
+    var $t5: u64
+    var $t6: &mut Libra::Preburn<#0>
+    var $t7: &mut vector<Libra::T<#0>>
+    var $t8: Libra::T<#0>
+    var $t9: address
+    var $t10: &mut Libra::Info<#0>
+    var $t11: &mut Libra::Info<#0>
+    var $t12: u64
+    var $t13: u64
+    var $t14: u64
+    var $t15: u64
+    var $t16: &mut Libra::Info<#0>
+    var $t17: &mut u64
+    // live_refs: preburn_ref borrowed_by: LocalRoot(preburn_ref) -> {Reference(preburn_ref)} borrows_from: Reference(preburn_ref) -> {LocalRoot(preburn_ref)}
+    $t4 := copy(coin)
+    // live_refs: preburn_ref borrowed_by: LocalRoot(preburn_ref) -> {Reference(preburn_ref)} borrows_from: Reference(preburn_ref) -> {LocalRoot(preburn_ref)}
+    $t5 := Libra::value<#0>($t4)
+    // live_refs: preburn_ref borrowed_by: LocalRoot(preburn_ref) -> {Reference(preburn_ref)} borrows_from: Reference(preburn_ref) -> {LocalRoot(preburn_ref)}
+    coin_value := $t5
+    // live_refs: preburn_ref borrowed_by: LocalRoot(preburn_ref) -> {Reference(preburn_ref)} borrows_from: Reference(preburn_ref) -> {LocalRoot(preburn_ref)}
+    $t6 := move(preburn_ref)
+    // live_refs: $t6 borrowed_by: LocalRoot(preburn_ref) -> {Reference($t6)} borrows_from: Reference($t6) -> {LocalRoot(preburn_ref)}
+    // LocalRoot(preburn_ref) <- $t6
+    $t7 := borrow_field<Libra::Preburn<#0>>.requests($t6)
+    // live_refs: $t7 borrowed_by: LocalRoot(preburn_ref) -> {Reference($t7)}, Reference($t6) -> {Reference($t7)} borrows_from: Reference($t7) -> {LocalRoot(preburn_ref), Reference($t6)}
+    $t8 := move(coin)
+    // live_refs: $t7 borrowed_by: LocalRoot(preburn_ref) -> {Reference($t7)}, Reference($t6) -> {Reference($t7)} borrows_from: Reference($t7) -> {LocalRoot(preburn_ref), Reference($t6)}
+    // LocalRoot(preburn_ref) <- $t7, Reference($t6) <- $t7
+    Vector::push_back<Libra::T<#0>>($t7, $t8)
+    $t9 := 0xa550c18
+    $t10 := borrow_global<Libra::Info<#0>>($t9)
+    // live_refs: $t10 borrowed_by: Libra::Info -> {Reference($t10)} borrows_from: Reference($t10) -> {Libra::Info}
+    market_cap := $t10
+    // live_refs: market_cap borrowed_by: Libra::Info -> {Reference(market_cap)} borrows_from: Reference(market_cap) -> {Libra::Info}
+    $t11 := copy(market_cap)
+    // live_refs: market_cap, $t11 borrowed_by: Libra::Info -> {Reference(market_cap)}, Reference(market_cap) -> {Reference($t11)} borrows_from: Reference(market_cap) -> {Libra::Info}, Reference($t11) -> {Reference(market_cap)}
+    // Reference(market_cap) <- $t11
+    $t12 := get_field<Libra::Info<#0>>.preburn_value($t11)
+    // live_refs: market_cap borrowed_by: Libra::Info -> {Reference(market_cap)} borrows_from: Reference(market_cap) -> {Libra::Info}
+    $t13 := move($t12)
+    // live_refs: market_cap borrowed_by: Libra::Info -> {Reference(market_cap)} borrows_from: Reference(market_cap) -> {Libra::Info}
+    $t14 := copy(coin_value)
+    // live_refs: market_cap borrowed_by: Libra::Info -> {Reference(market_cap)} borrows_from: Reference(market_cap) -> {Libra::Info}
+    $t15 := +($t13, $t14)
+    // live_refs: market_cap borrowed_by: Libra::Info -> {Reference(market_cap)} borrows_from: Reference(market_cap) -> {Libra::Info}
+    $t16 := move(market_cap)
+    // live_refs: $t16 borrowed_by: Libra::Info -> {Reference($t16)} borrows_from: Reference($t16) -> {Libra::Info}
+    // Libra::Info <- $t16
+    $t17 := borrow_field<Libra::Info<#0>>.preburn_value($t16)
+    // live_refs: $t17 borrowed_by: Libra::Info -> {Reference($t17)}, Reference($t16) -> {Reference($t17)} borrows_from: Reference($t17) -> {Libra::Info, Reference($t16)}
+    // Libra::Info <- $t17, Reference($t16) <- $t17
+    write_ref($t17, $t15)
+    return ()
+}
+
+
+pub fun Libra::destroy_zero<$tv0>(coin: Libra::T<#0>) {
+    var $t1: bool
+    var $t2: u64
+    var value: u64
+    var $t4: Libra::T<#0>
+    var $t5: u64
+    var $t6: u64
+    var $t7: u64
+    var $t8: bool
+    var $t9: bool
+    var $t10: u64
+    $t4 := move(coin)
+    $t5 := unpack Libra::T<#0>($t4)
+    value := $t5
+    $t6 := copy(value)
+    $t7 := 0
+    $t8 := ==($t6, $t7)
+    $t1 := $t8
+    $t9 := move($t1)
+    if ($t9) goto L0 else goto L1
+    L1:
+    goto L2
+    L0:
+    goto L3
+    L2:
+    $t10 := 11
+    abort($t10)
+    L3:
+    return ()
+}
+
+
+pub fun Libra::join<$tv0>(coin1: Libra::T<#0>, coin2: Libra::T<#0>): Libra::T<#0> {
+    var $t2: &mut Libra::T<#0>
+    var $t3: Libra::T<#0>
+    var $t4: Libra::T<#0>
+    $t2 := borrow_local(coin1)
+    // live_refs: $t2 borrowed_by: LocalRoot(coin1) -> {Reference($t2)} borrows_from: Reference($t2) -> {LocalRoot(coin1)}
+    $t3 := move(coin2)
+    // live_refs: $t2 borrowed_by: LocalRoot(coin1) -> {Reference($t2)} borrows_from: Reference($t2) -> {LocalRoot(coin1)}
+    // LocalRoot(coin1) <- $t2
+    Libra::deposit<#0>($t2, $t3)
+    $t4 := move(coin1)
+    return $t4
+}
+
+
+pub fun Libra::market_cap<$tv0>(): u128 {
+    var $t0: address
+    var $t1: Libra::Info<#0>
+    var $t2: u128
+    var $t3: u128
+    $t0 := 0xa550c18
+    $t1 := get_global<Libra::Info<#0>>($t0)
+    $t2 := get_field<Libra::Info<#0>>.total_value($t1)
+    $t3 := move($t2)
+    return $t3
+}
+
+
+pub fun Libra::mint<$tv0>(amount: u64): Libra::T<#0> {
+    var $t1: u64
+    var $t2: address
+    var $t3: Libra::MintCapability<#0>
+    var $t4: Libra::T<#0>
+    $t1 := copy(amount)
+    $t2 := txn_sender
+    $t3 := get_global<Libra::MintCapability<#0>>($t2)
+    $t4 := Libra::mint_with_capability<#0>($t1, $t3)
+    return $t4
+}
+
+
+pub fun Libra::mint_with_capability<$tv0>(value: u64, _capability: Libra::MintCapability<#0>): Libra::T<#0> {
+    var market_cap: &mut Libra::Info<#0>
+    var $t3: bool
+    var $t4: u64
+    var $t5: u64
+    var $t6: u64
+    var $t7: u64
+    var $t8: u64
+    var $t9: bool
+    var $t10: bool
+    var $t11: u64
+    var $t12: address
+    var $t13: &mut Libra::Info<#0>
+    var $t14: &mut Libra::Info<#0>
+    var $t15: u128
+    var $t16: u128
+    var $t17: u64
+    var $t18: u128
+    var $t19: u128
+    var $t20: &mut Libra::Info<#0>
+    var $t21: &mut u128
+    var $t22: u64
+    var $t23: Libra::T<#0>
+    Libra::assert_is_registered<#0>()
+    $t5 := copy(value)
+    $t6 := 1000000000
+    $t7 := 1000000
+    $t8 := *($t6, $t7)
+    $t9 := <=($t5, $t8)
+    $t3 := $t9
+    $t10 := move($t3)
+    if ($t10) goto L0 else goto L1
+    L1:
+    goto L2
+    L0:
+    goto L3
+    L2:
+    $t11 := 11
+    abort($t11)
+    L3:
+    $t12 := 0xa550c18
+    $t13 := borrow_global<Libra::Info<#0>>($t12)
+    // live_refs: $t13 borrowed_by: Libra::Info -> {Reference($t13)} borrows_from: Reference($t13) -> {Libra::Info}
+    market_cap := $t13
+    // live_refs: market_cap borrowed_by: Libra::Info -> {Reference(market_cap)} borrows_from: Reference(market_cap) -> {Libra::Info}
+    $t14 := copy(market_cap)
+    // live_refs: market_cap, $t14 borrowed_by: Libra::Info -> {Reference(market_cap)}, Reference(market_cap) -> {Reference($t14)} borrows_from: Reference(market_cap) -> {Libra::Info}, Reference($t14) -> {Reference(market_cap)}
+    // Reference(market_cap) <- $t14
+    $t15 := get_field<Libra::Info<#0>>.total_value($t14)
+    // live_refs: market_cap borrowed_by: Libra::Info -> {Reference(market_cap)} borrows_from: Reference(market_cap) -> {Libra::Info}
+    $t16 := move($t15)
+    // live_refs: market_cap borrowed_by: Libra::Info -> {Reference(market_cap)} borrows_from: Reference(market_cap) -> {Libra::Info}
+    $t17 := copy(value)
+    // live_refs: market_cap borrowed_by: Libra::Info -> {Reference(market_cap)} borrows_from: Reference(market_cap) -> {Libra::Info}
+    $t18 := (u128)($t17)
+    // live_refs: market_cap borrowed_by: Libra::Info -> {Reference(market_cap)} borrows_from: Reference(market_cap) -> {Libra::Info}
+    $t19 := +($t16, $t18)
+    // live_refs: market_cap borrowed_by: Libra::Info -> {Reference(market_cap)} borrows_from: Reference(market_cap) -> {Libra::Info}
+    $t20 := move(market_cap)
+    // live_refs: $t20 borrowed_by: Libra::Info -> {Reference($t20)} borrows_from: Reference($t20) -> {Libra::Info}
+    // Libra::Info <- $t20
+    $t21 := borrow_field<Libra::Info<#0>>.total_value($t20)
+    // live_refs: $t21 borrowed_by: Libra::Info -> {Reference($t21)}, Reference($t20) -> {Reference($t21)} borrows_from: Reference($t21) -> {Libra::Info, Reference($t20)}
+    // Libra::Info <- $t21, Reference($t20) <- $t21
+    write_ref($t21, $t19)
+    $t22 := copy(value)
+    $t23 := pack Libra::T<#0>($t22)
+    return $t23
+}
+
+
+pub fun Libra::value<$tv0>(coin_ref: Libra::T<#0>): u64 {
+    var $t1: Libra::T<#0>
+    var $t2: u64
+    var $t3: u64
+    $t1 := move(coin_ref)
+    $t2 := get_field<Libra::T<#0>>.value($t1)
+    $t3 := move($t2)
+    return $t3
+}
+
+
+pub fun Libra::new_preburn<$tv0>(): Libra::Preburn<#0> {
+    var $t0: vector<Libra::T<#0>>
+    var $t1: bool
+    var $t2: Libra::Preburn<#0>
+    Libra::assert_is_registered<#0>()
+    $t0 := Vector::empty<Libra::T<#0>>()
+    $t1 := false
+    $t2 := pack Libra::Preburn<#0>($t0, $t1)
+    return $t2
+}
+
+
+pub fun Libra::preburn_to_sender<$tv0>(coin: Libra::T<#0>) {
+    var $t1: address
+    var $t2: &mut Libra::Preburn<#0>
+    var $t3: Libra::T<#0>
+    $t1 := txn_sender
+    $t2 := borrow_global<Libra::Preburn<#0>>($t1)
+    // live_refs: $t2 borrowed_by: Libra::Preburn -> {Reference($t2)} borrows_from: Reference($t2) -> {Libra::Preburn}
+    $t3 := move(coin)
+    // live_refs: $t2 borrowed_by: Libra::Preburn -> {Reference($t2)} borrows_from: Reference($t2) -> {Libra::Preburn}
+    // Libra::Preburn <- $t2
+    Libra::preburn<#0>($t2, $t3)
+    return ()
+}
+
+
+pub fun Libra::preburn_value<$tv0>(): u64 {
+    var $t0: address
+    var $t1: Libra::Info<#0>
+    var $t2: u64
+    var $t3: u64
+    $t0 := 0xa550c18
+    $t1 := get_global<Libra::Info<#0>>($t0)
+    $t2 := get_field<Libra::Info<#0>>.preburn_value($t1)
+    $t3 := move($t2)
+    return $t3
+}
+
+
+pub fun Libra::publish_mint_capability<$tv0>(capability: Libra::MintCapability<#0>) {
+    var $t1: Libra::MintCapability<#0>
+    $t1 := move(capability)
+    move_to_sender<Libra::MintCapability<#0>>($t1)
+    return ()
+}
+
+
+pub fun Libra::publish_preburn<$tv0>(preburn: Libra::Preburn<#0>) {
+    var $t1: Libra::Preburn<#0>
+    $t1 := move(preburn)
+    move_to_sender<Libra::Preburn<#0>>($t1)
+    return ()
+}
+
+
+pub fun Libra::register<$tv0>() {
+    var $t0: bool
+    var $t1: u64
+    var $t2: address
+    var $t3: address
+    var $t4: bool
+    var $t5: u64
+    var $t6: bool
+    var $t7: Libra::MintCapability<#0>
+    var $t8: u128
+    var $t9: u64
+    var $t10: Libra::Info<#0>
+    $t2 := txn_sender
+    $t3 := 0xa550c18
+    $t4 := ==($t2, $t3)
+    if ($t4) goto L0 else goto L1
+    L1:
+    goto L2
+    L0:
+    goto L3
+    L2:
+    $t5 := 1
+    abort($t5)
+    L3:
+    $t6 := false
+    $t7 := pack Libra::MintCapability<#0>($t6)
+    move_to_sender<Libra::MintCapability<#0>>($t7)
+    $t8 := 0
+    $t9 := 0
+    $t10 := pack Libra::Info<#0>($t8, $t9)
+    move_to_sender<Libra::Info<#0>>($t10)
+    return ()
+}
+
+
+pub fun Libra::remove_mint_capability<$tv0>(): Libra::MintCapability<#0> {
+    var $t0: address
+    var $t1: Libra::MintCapability<#0>
+    $t0 := txn_sender
+    $t1 := move_from<Libra::MintCapability<#0>>($t0)
+    return $t1
+}
+
+
+pub fun Libra::remove_preburn<$tv0>(): Libra::Preburn<#0> {
+    var $t0: address
+    var $t1: Libra::Preburn<#0>
+    $t0 := txn_sender
+    $t1 := move_from<Libra::Preburn<#0>>($t0)
+    return $t1
+}
+
+
+pub fun Libra::split<$tv0>(coin: Libra::T<#0>, amount: u64): (Libra::T<#0>, Libra::T<#0>) {
+    var other: Libra::T<#0>
+    var $t3: &mut Libra::T<#0>
+    var $t4: u64
+    var $t5: Libra::T<#0>
+    var $t6: Libra::T<#0>
+    var $t7: Libra::T<#0>
+    $t3 := borrow_local(coin)
+    // live_refs: $t3 borrowed_by: LocalRoot(coin) -> {Reference($t3)} borrows_from: Reference($t3) -> {LocalRoot(coin)}
+    $t4 := copy(amount)
+    // live_refs: $t3 borrowed_by: LocalRoot(coin) -> {Reference($t3)} borrows_from: Reference($t3) -> {LocalRoot(coin)}
+    // LocalRoot(coin) <- $t3
+    $t5 := Libra::withdraw<#0>($t3, $t4)
+    other := $t5
+    $t6 := move(coin)
+    $t7 := move(other)
+    return ($t6, $t7)
+}
+
+
+pub fun Libra::withdraw<$tv0>(coin_ref: &mut Libra::T<#0>, value: u64): Libra::T<#0> {
+    var $t2: bool
+    var $t3: u64
+    var $t4: &mut Libra::T<#0>
+    var $t5: u64
+    var $t6: u64
+    var $t7: u64
+    var $t8: bool
+    var $t9: bool
+    var $t10: &mut Libra::T<#0>
+    var $t11: u64
+    var $t12: &mut Libra::T<#0>
+    var $t13: u64
+    var $t14: u64
+    var $t15: u64
+    var $t16: u64
+    var $t17: &mut Libra::T<#0>
+    var $t18: &mut u64
+    var $t19: u64
+    var $t20: Libra::T<#0>
+    // live_refs: coin_ref borrowed_by: LocalRoot(coin_ref) -> {Reference(coin_ref)} borrows_from: Reference(coin_ref) -> {LocalRoot(coin_ref)}
+    $t4 := copy(coin_ref)
+    // live_refs: coin_ref, $t4 borrowed_by: LocalRoot(coin_ref) -> {Reference(coin_ref)}, Reference(coin_ref) -> {Reference($t4)} borrows_from: Reference(coin_ref) -> {LocalRoot(coin_ref)}, Reference($t4) -> {Reference(coin_ref)}
+    // Reference(coin_ref) <- $t4
+    $t5 := get_field<Libra::T<#0>>.value($t4)
+    // live_refs: coin_ref borrowed_by: LocalRoot(coin_ref) -> {Reference(coin_ref)} borrows_from: Reference(coin_ref) -> {LocalRoot(coin_ref)}
+    $t6 := move($t5)
+    // live_refs: coin_ref borrowed_by: LocalRoot(coin_ref) -> {Reference(coin_ref)} borrows_from: Reference(coin_ref) -> {LocalRoot(coin_ref)}
+    $t7 := copy(value)
+    // live_refs: coin_ref borrowed_by: LocalRoot(coin_ref) -> {Reference(coin_ref)} borrows_from: Reference(coin_ref) -> {LocalRoot(coin_ref)}
+    $t8 := >=($t6, $t7)
+    // live_refs: coin_ref borrowed_by: LocalRoot(coin_ref) -> {Reference(coin_ref)} borrows_from: Reference(coin_ref) -> {LocalRoot(coin_ref)}
+    $t2 := $t8
+    // live_refs: coin_ref borrowed_by: LocalRoot(coin_ref) -> {Reference(coin_ref)} borrows_from: Reference(coin_ref) -> {LocalRoot(coin_ref)}
+    $t9 := move($t2)
+    // live_refs: coin_ref borrowed_by: LocalRoot(coin_ref) -> {Reference(coin_ref)} borrows_from: Reference(coin_ref) -> {LocalRoot(coin_ref)}
+    if ($t9) goto L0 else goto L1
+    // live_refs: coin_ref borrowed_by: LocalRoot(coin_ref) -> {Reference(coin_ref)} borrows_from: Reference(coin_ref) -> {LocalRoot(coin_ref)}
+    L1:
+    // live_refs: coin_ref borrowed_by: LocalRoot(coin_ref) -> {Reference(coin_ref)} borrows_from: Reference(coin_ref) -> {LocalRoot(coin_ref)}
+    goto L2
+    // live_refs: coin_ref borrowed_by: LocalRoot(coin_ref) -> {Reference(coin_ref)} borrows_from: Reference(coin_ref) -> {LocalRoot(coin_ref)}
+    L0:
+    // live_refs: coin_ref borrowed_by: LocalRoot(coin_ref) -> {Reference(coin_ref)} borrows_from: Reference(coin_ref) -> {LocalRoot(coin_ref)}
+    goto L3
+    // live_refs: coin_ref borrowed_by: LocalRoot(coin_ref) -> {Reference(coin_ref)} borrows_from: Reference(coin_ref) -> {LocalRoot(coin_ref)}
+    L2:
+    // live_refs: coin_ref borrowed_by: LocalRoot(coin_ref) -> {Reference(coin_ref)} borrows_from: Reference(coin_ref) -> {LocalRoot(coin_ref)}
+    $t10 := move(coin_ref)
+    // live_refs: $t10 borrowed_by: LocalRoot(coin_ref) -> {Reference($t10)} borrows_from: Reference($t10) -> {LocalRoot(coin_ref)}
+    // LocalRoot(coin_ref) <- $t10
+    destroy($t10)
+    $t11 := 10
+    abort($t11)
+    // live_refs: coin_ref borrowed_by: LocalRoot(coin_ref) -> {Reference(coin_ref)} borrows_from: Reference(coin_ref) -> {LocalRoot(coin_ref)}
+    L3:
+    // live_refs: coin_ref borrowed_by: LocalRoot(coin_ref) -> {Reference(coin_ref)} borrows_from: Reference(coin_ref) -> {LocalRoot(coin_ref)}
+    $t12 := copy(coin_ref)
+    // live_refs: coin_ref, $t12 borrowed_by: LocalRoot(coin_ref) -> {Reference(coin_ref)}, Reference(coin_ref) -> {Reference($t12)} borrows_from: Reference(coin_ref) -> {LocalRoot(coin_ref)}, Reference($t12) -> {Reference(coin_ref)}
+    // Reference(coin_ref) <- $t12
+    $t13 := get_field<Libra::T<#0>>.value($t12)
+    // live_refs: coin_ref borrowed_by: LocalRoot(coin_ref) -> {Reference(coin_ref)} borrows_from: Reference(coin_ref) -> {LocalRoot(coin_ref)}
+    $t14 := move($t13)
+    // live_refs: coin_ref borrowed_by: LocalRoot(coin_ref) -> {Reference(coin_ref)} borrows_from: Reference(coin_ref) -> {LocalRoot(coin_ref)}
+    $t15 := copy(value)
+    // live_refs: coin_ref borrowed_by: LocalRoot(coin_ref) -> {Reference(coin_ref)} borrows_from: Reference(coin_ref) -> {LocalRoot(coin_ref)}
+    $t16 := -($t14, $t15)
+    // live_refs: coin_ref borrowed_by: LocalRoot(coin_ref) -> {Reference(coin_ref)} borrows_from: Reference(coin_ref) -> {LocalRoot(coin_ref)}
+    $t17 := move(coin_ref)
+    // live_refs: $t17 borrowed_by: LocalRoot(coin_ref) -> {Reference($t17)} borrows_from: Reference($t17) -> {LocalRoot(coin_ref)}
+    // LocalRoot(coin_ref) <- $t17
+    $t18 := borrow_field<Libra::T<#0>>.value($t17)
+    // live_refs: $t18 borrowed_by: LocalRoot(coin_ref) -> {Reference($t18)}, Reference($t17) -> {Reference($t18)} borrows_from: Reference($t18) -> {LocalRoot(coin_ref), Reference($t17)}
+    // LocalRoot(coin_ref) <- $t18, Reference($t17) <- $t18
+    write_ref($t18, $t16)
+    $t19 := copy(value)
+    $t20 := pack Libra::T<#0>($t19)
+    return $t20
+}
+
+
+pub fun Libra::zero<$tv0>(): Libra::T<#0> {
+    var $t0: u64
+    var $t1: Libra::T<#0>
+    Libra::assert_is_registered<#0>()
+    $t0 := 0
+    $t1 := pack Libra::T<#0>($t0)
+    return $t1
+}

--- a/language/move-prover/stackless-bytecode-generator/tests/writeback/libra.move
+++ b/language/move-prover/stackless-bytecode-generator/tests/writeback/libra.move
@@ -1,0 +1,261 @@
+// dep: ../tests/sources/stdlib/modules/transaction.move
+// dep: ../tests/sources/stdlib/modules/vector.move
+
+address 0x0 {
+
+module Libra {
+    use 0x0::Transaction;
+    use 0x0::Vector;
+
+    // A resource representing a fungible token
+    resource struct T<Token> {
+        // The value of the token. May be zero
+        value: u64,
+    }
+
+    // A singleton resource that grants access to `Libra::mint`. Only the Association has one.
+    resource struct MintCapability<Token> { }
+
+    resource struct Info<Token> {
+        // The sum of the values of all Libra::T resources in the system
+        total_value: u128,
+        // Value of funds that are in the process of being burned
+        preburn_value: u64,
+    }
+
+    // A holding area where funds that will subsequently be burned wait while their underyling
+    // assets are sold off-chain.
+    // This resource can only be created by the holder of the MintCapability. An account that
+    // contains this address has the authority to initiate a burn request. A burn request can be
+    // resolved by the holder of the MintCapability by either (1) burning the funds, or (2)
+    // returning the funds to the account that initiated the burn request.
+    // This design supports multiple preburn requests in flight at the same time, including multiple
+    // burn requests from the same account. However, burn requests from the same account must be
+    // resolved in FIFO order.
+    resource struct Preburn<Token> {
+        // Queue of pending burn requests
+        requests: vector<T<Token>>,
+        // Boolean that is true if the holder of the MintCapability has approved this account as a
+        // preburner
+        is_approved: bool,
+    }
+
+    public fun register<Token>() {
+        // Only callable by the Association address
+        Transaction::assert(Transaction::sender() == 0xA550C18, 1);
+        move_to_sender(MintCapability<Token>{ });
+        move_to_sender(Info<Token> { total_value: 0u128, preburn_value: 0 });
+    }
+
+    fun assert_is_registered<Token>() {
+        Transaction::assert(exists<Info<Token>>(0xA550C18), 12);
+    }
+
+    // Return `amount` coins.
+    // Fails if the sender does not have a published MintCapability.
+    public fun mint<Token>(amount: u64): T<Token> acquires Info, MintCapability {
+        mint_with_capability(amount, borrow_global<MintCapability<Token>>(Transaction::sender()))
+    }
+
+    // Burn the coins currently held in the preburn holding area under `preburn_address`.
+    // Fails if the sender does not have a published MintCapability.
+    public fun burn<Token>(
+        preburn_address: address
+    ) acquires Info, MintCapability, Preburn {
+        burn_with_capability(
+            preburn_address,
+            borrow_global<MintCapability<Token>>(Transaction::sender())
+        )
+    }
+
+    // Cancel the oldest burn request from `preburn_address`
+    // Fails if the sender does not have a published MintCapability.
+    public fun cancel_burn<Token>(
+        preburn_address: address
+    ): T<Token> acquires Info, MintCapability, Preburn {
+        cancel_burn_with_capability(
+            preburn_address,
+            borrow_global<MintCapability<Token>>(Transaction::sender())
+        )
+    }
+
+    // Create a new Preburn resource
+    public fun new_preburn<Token>(): Preburn<Token> {
+        assert_is_registered<Token>();
+        Preburn<Token> { requests: Vector::empty(), is_approved: false, }
+    }
+
+    // Mint a new Libra::T worth `value`. The caller must have a reference to a MintCapability.
+    // Only the Association account can acquire such a reference, and it can do so only via
+    // `borrow_sender_mint_capability`
+    public fun mint_with_capability<Token>(
+        value: u64,
+        _capability: &MintCapability<Token>
+    ): T<Token> acquires Info {
+        assert_is_registered<Token>();
+        // TODO: temporary measure for testnet only: limit minting to 1B Libra at a time.
+        // this is to prevent the market cap's total value from hitting u64_max due to excessive
+        // minting. This will not be a problem in the production Libra system because coins will
+        // be backed with real-world assets, and thus minting will be correspondingly rarer.
+        // * 1000000 here because the unit is microlibra
+        Transaction::assert(value <= 1000000000 * 1000000, 11);
+        // update market cap resource to reflect minting
+        let market_cap = borrow_global_mut<Info<Token>>(0xA550C18);
+        market_cap.total_value = market_cap.total_value + (value as u128);
+
+        T<Token> { value }
+    }
+
+    // Send coin to the preburn holding area `preburn_ref`, where it will wait to be burned.
+    public fun preburn<Token>(
+        preburn_ref: &mut Preburn<Token>,
+        coin: T<Token>
+    ) acquires Info {
+        // TODO: bring this back once we can automate approvals in testnet
+        // Transaction::assert(preburn_ref.is_approved, 13);
+        let coin_value = value(&coin);
+        Vector::push_back(
+            &mut preburn_ref.requests,
+            coin
+        );
+        let market_cap = borrow_global_mut<Info<Token>>(0xA550C18);
+        market_cap.preburn_value = market_cap.preburn_value + coin_value
+    }
+
+    // Send coin to the preburn holding area, where it will wait to be burned.
+    // Fails if the sender does not have a published Preburn resource
+    public fun preburn_to_sender<Token>(coin: T<Token>) acquires Info, Preburn {
+        preburn(borrow_global_mut<Preburn<Token>>(Transaction::sender()), coin)
+    }
+
+    // Permanently remove the coins held in the `Preburn` resource stored at `preburn_address` and
+    // update the market cap accordingly. If there are multiple preburn requests in progress, this
+    // will remove the oldest one.
+    // Can only be invoked by the holder of the MintCapability. Fails if the there is no `Preburn`
+    // resource under `preburn_address` or has one with no pending burn requests.
+    public fun burn_with_capability<Token>(
+        preburn_address: address,
+        _capability: &MintCapability<Token>
+    ) acquires Info, Preburn {
+        // destroy the coin at the head of the preburn queue
+        let preburn = borrow_global_mut<Preburn<Token>>(preburn_address);
+        let T { value } = Vector::remove(&mut preburn.requests, 0);
+        // update the market cap
+        let market_cap = borrow_global_mut<Info<Token>>(0xA550C18);
+        market_cap.total_value = market_cap.total_value - (value as u128);
+        market_cap.preburn_value = market_cap.preburn_value - value
+    }
+
+    // Cancel the burn request in the `Preburn` resource stored at `preburn_address` and
+    // return the coins to the caller.
+    // If there are multiple preburn requests in progress, this will cancel the oldest one.
+    // Can only be invoked by the holder of the MintCapability. Fails if the transaction sender
+    // does not have a published Preburn resource or has one with no pending burn requests.
+    public fun cancel_burn_with_capability<Token>(
+        preburn_address: address,
+        _capability: &MintCapability<Token>
+    ): T<Token> acquires Info, Preburn {
+        // destroy the coin at the head of the preburn queue
+        let preburn = borrow_global_mut<Preburn<Token>>(preburn_address);
+        let coin = Vector::remove(&mut preburn.requests, 0);
+        // update the market cap
+        let market_cap = borrow_global_mut<Info<Token>>(0xA550C18);
+        market_cap.preburn_value = market_cap.preburn_value - value(&coin);
+
+        coin
+    }
+
+    // Publish `preburn` under the sender's account
+    public fun publish_preburn<Token>(preburn: Preburn<Token>) {
+        move_to_sender(preburn)
+    }
+
+    // Remove and return the `Preburn` resource under the sender's account
+    public fun remove_preburn<Token>(): Preburn<Token> acquires Preburn {
+        move_from<Preburn<Token>>(Transaction::sender())
+    }
+
+    // Destroys the given preburn resource.
+    // Aborts if `requests` is non-empty
+    public fun destroy_preburn<Token>(preburn: Preburn<Token>) {
+        let Preburn { requests, is_approved: _ } = preburn;
+        Vector::destroy_empty(requests)
+    }
+
+    // Publish `capability` under the sender's account
+    public fun publish_mint_capability<Token>(capability: MintCapability<Token>) {
+        move_to_sender(capability)
+    }
+
+    // Remove and return the MintCapability from the sender's account. Fails if the sender does
+    // not have a published MintCapability
+    public fun remove_mint_capability<Token>(): MintCapability<Token> acquires MintCapability {
+        move_from<MintCapability<Token>>(Transaction::sender())
+    }
+
+    // Return the total value of all Libra in the system
+    public fun market_cap<Token>(): u128 acquires Info {
+        borrow_global<Info<Token>>(0xA550C18).total_value
+    }
+
+    // Return the total value of Libra to be burned
+    public fun preburn_value<Token>(): u64 acquires Info {
+        borrow_global<Info<Token>>(0xA550C18).preburn_value
+    }
+
+    // Create a new Libra::T with a value of 0
+    public fun zero<Token>(): T<Token> {
+        // prevent silly coin types (e.g., Libra<bool>) from being created
+        assert_is_registered<Token>();
+        T { value: 0 }
+    }
+
+    // Public accessor for the value of a coin
+    public fun value<Token>(coin_ref: &T<Token>): u64 {
+        coin_ref.value
+    }
+
+    // Splits the given coin into two and returns them both
+    // It leverages `withdraw` for any verifications of the values
+    public fun split<Token>(coin: T<Token>, amount: u64): (T<Token>, T<Token>) {
+        let other = withdraw(&mut coin, amount);
+        (coin, other)
+    }
+
+    // "Divides" the given coin into two, where original coin is modified in place
+    // The original coin will have value = original value - `value`
+    // The new coin will have a value = `value`
+    // Fails if the coins value is less than `value`
+    public fun withdraw<Token>(coin_ref: &mut T<Token>, value: u64): T<Token> {
+        // Check that `amount` is less than the coin's value
+        Transaction::assert(coin_ref.value >= value, 10);
+
+        // Split the coin
+        coin_ref.value = coin_ref.value - value;
+        T { value }
+    }
+
+    // Merges two coins and returns a new coin whose value is equal to the sum of the two inputs
+    public fun join<Token>(coin1: T<Token>, coin2: T<Token>): T<Token>  {
+        deposit(&mut coin1, coin2);
+        coin1
+    }
+
+    // "Merges" the two coins
+    // The coin passed in by reference will have a value equal to the sum of the two coins
+    // The `check` coin is consumed in the process
+    public fun deposit<Token>(coin_ref: &mut T<Token>, check: T<Token>) {
+        let T { value } = check;
+        coin_ref.value= coin_ref.value + value;
+    }
+
+    // Destroy a coin
+    // Fails if the value is non-zero
+    // The amount of Libra::T in the system is a tightly controlled property,
+    // so you cannot "burn" any non-zero amount of Libra::T
+    public fun destroy_zero<Token>(coin: T<Token>) {
+        let T<Token> { value } = coin;
+        Transaction::assert(value == 0, 11);
+    }
+}
+}

--- a/language/move-prover/stackless-bytecode-generator/tests/writeback/nested_invariants.exp
+++ b/language/move-prover/stackless-bytecode-generator/tests/writeback/nested_invariants.exp
@@ -1,0 +1,288 @@
+============ initial translation from Move ================
+
+fun TestNestedInvariants::mutate() {
+    var o: TestNestedInvariants::Outer
+    var r: &mut TestNestedInvariants::Outer
+    var $t2: u64
+    var $t3: u64
+    var $t4: TestNestedInvariants::Nested
+    var $t5: TestNestedInvariants::Outer
+    var $t6: &mut TestNestedInvariants::Outer
+    var $t7: u64
+    var $t8: &mut TestNestedInvariants::Outer
+    var $t9: &mut u64
+    var $t10: u64
+    var $t11: &mut TestNestedInvariants::Outer
+    var $t12: &mut TestNestedInvariants::Nested
+    var $t13: &mut u64
+    $t2 := 3
+    $t3 := 2
+    $t4 := pack TestNestedInvariants::Nested($t3)
+    $t5 := pack TestNestedInvariants::Outer($t2, $t4)
+    o := $t5
+    $t6 := borrow_local(o)
+    r := $t6
+    $t7 := 2
+    $t8 := copy(r)
+    $t9 := borrow_field<TestNestedInvariants::Outer>.y($t8)
+    write_ref($t9, $t7)
+    $t10 := 1
+    $t11 := move(r)
+    $t12 := borrow_field<TestNestedInvariants::Outer>.n($t11)
+    $t13 := borrow_field<TestNestedInvariants::Nested>.x($t12)
+    write_ref($t13, $t10)
+    return ()
+}
+
+
+fun TestNestedInvariants::mutate_inner_data_invariant_invalid() {
+    var o: TestNestedInvariants::Outer
+    var r: &mut TestNestedInvariants::Outer
+    var $t2: u64
+    var $t3: u64
+    var $t4: TestNestedInvariants::Nested
+    var $t5: TestNestedInvariants::Outer
+    var $t6: &mut TestNestedInvariants::Outer
+    var $t7: u64
+    var $t8: &mut TestNestedInvariants::Outer
+    var $t9: &mut TestNestedInvariants::Nested
+    var $t10: &mut u64
+    $t2 := 3
+    $t3 := 2
+    $t4 := pack TestNestedInvariants::Nested($t3)
+    $t5 := pack TestNestedInvariants::Outer($t2, $t4)
+    o := $t5
+    $t6 := borrow_local(o)
+    r := $t6
+    $t7 := 0
+    $t8 := move(r)
+    $t9 := borrow_field<TestNestedInvariants::Outer>.n($t8)
+    $t10 := borrow_field<TestNestedInvariants::Nested>.x($t9)
+    write_ref($t10, $t7)
+    return ()
+}
+
+
+fun TestNestedInvariants::mutate_outer_data_invariant_invalid() {
+    var o: TestNestedInvariants::Outer
+    var r: &mut TestNestedInvariants::Outer
+    var $t2: u64
+    var $t3: u64
+    var $t4: TestNestedInvariants::Nested
+    var $t5: TestNestedInvariants::Outer
+    var $t6: &mut TestNestedInvariants::Outer
+    var $t7: u64
+    var $t8: &mut TestNestedInvariants::Outer
+    var $t9: &mut u64
+    $t2 := 3
+    $t3 := 2
+    $t4 := pack TestNestedInvariants::Nested($t3)
+    $t5 := pack TestNestedInvariants::Outer($t2, $t4)
+    o := $t5
+    $t6 := borrow_local(o)
+    r := $t6
+    $t7 := 2
+    $t8 := move(r)
+    $t9 := borrow_field<TestNestedInvariants::Outer>.y($t8)
+    write_ref($t9, $t7)
+    return ()
+}
+
+
+fun TestNestedInvariants::new(): TestNestedInvariants::Outer {
+    var $t0: u64
+    var $t1: u64
+    var $t2: TestNestedInvariants::Nested
+    var $t3: TestNestedInvariants::Outer
+    $t0 := 3
+    $t1 := 2
+    $t2 := pack TestNestedInvariants::Nested($t1)
+    $t3 := pack TestNestedInvariants::Outer($t0, $t2)
+    return $t3
+}
+
+
+fun TestNestedInvariants::new_inner_data_invariant_invalid(): TestNestedInvariants::Outer {
+    var $t0: u64
+    var $t1: u64
+    var $t2: TestNestedInvariants::Nested
+    var $t3: TestNestedInvariants::Outer
+    $t0 := 2
+    $t1 := 0
+    $t2 := pack TestNestedInvariants::Nested($t1)
+    $t3 := pack TestNestedInvariants::Outer($t0, $t2)
+    return $t3
+}
+
+
+fun TestNestedInvariants::new_outer_data_invariant_invalid(): TestNestedInvariants::Outer {
+    var $t0: u64
+    var $t1: u64
+    var $t2: TestNestedInvariants::Nested
+    var $t3: TestNestedInvariants::Outer
+    $t0 := 2
+    $t1 := 2
+    $t2 := pack TestNestedInvariants::Nested($t1)
+    $t3 := pack TestNestedInvariants::Outer($t0, $t2)
+    return $t3
+}
+
+============ after pipeline `writeback` ================
+
+fun TestNestedInvariants::mutate() {
+    var o: TestNestedInvariants::Outer
+    var r: &mut TestNestedInvariants::Outer
+    var $t2: u64
+    var $t3: u64
+    var $t4: TestNestedInvariants::Nested
+    var $t5: TestNestedInvariants::Outer
+    var $t6: &mut TestNestedInvariants::Outer
+    var $t7: u64
+    var $t8: &mut TestNestedInvariants::Outer
+    var $t9: &mut u64
+    var $t10: u64
+    var $t11: &mut TestNestedInvariants::Outer
+    var $t12: &mut TestNestedInvariants::Nested
+    var $t13: &mut u64
+    $t2 := 3
+    $t3 := 2
+    $t4 := pack TestNestedInvariants::Nested($t3)
+    $t5 := pack TestNestedInvariants::Outer($t2, $t4)
+    o := $t5
+    $t6 := borrow_local(o)
+    // live_refs: $t6 borrowed_by: LocalRoot(o) -> {Reference($t6)} borrows_from: Reference($t6) -> {LocalRoot(o)}
+    r := $t6
+    // live_refs: r borrowed_by: LocalRoot(o) -> {Reference(r)} borrows_from: Reference(r) -> {LocalRoot(o)}
+    $t7 := 2
+    // live_refs: r borrowed_by: LocalRoot(o) -> {Reference(r)} borrows_from: Reference(r) -> {LocalRoot(o)}
+    $t8 := copy(r)
+    // live_refs: r, $t8 borrowed_by: LocalRoot(o) -> {Reference(r)}, Reference(r) -> {Reference($t8)} borrows_from: Reference(r) -> {LocalRoot(o)}, Reference($t8) -> {Reference(r)}
+    // Reference(r) <- $t8
+    $t9 := borrow_field<TestNestedInvariants::Outer>.y($t8)
+    // live_refs: r, $t9 borrowed_by: LocalRoot(o) -> {Reference(r)}, Reference(r) -> {Reference($t9)}, Reference($t8) -> {Reference($t9)} borrows_from: Reference(r) -> {LocalRoot(o)}, Reference($t9) -> {Reference(r), Reference($t8)}
+    // Reference(r) <- $t9, Reference($t8) <- $t9
+    write_ref($t9, $t7)
+    // live_refs: r borrowed_by: LocalRoot(o) -> {Reference(r)} borrows_from: Reference(r) -> {LocalRoot(o)}
+    $t10 := 1
+    // live_refs: r borrowed_by: LocalRoot(o) -> {Reference(r)} borrows_from: Reference(r) -> {LocalRoot(o)}
+    $t11 := move(r)
+    // live_refs: $t11 borrowed_by: LocalRoot(o) -> {Reference($t11)} borrows_from: Reference($t11) -> {LocalRoot(o)}
+    // LocalRoot(o) <- $t11
+    $t12 := borrow_field<TestNestedInvariants::Outer>.n($t11)
+    // live_refs: $t12 borrowed_by: LocalRoot(o) -> {Reference($t12)}, Reference($t11) -> {Reference($t12)} borrows_from: Reference($t12) -> {LocalRoot(o), Reference($t11)}
+    // LocalRoot(o) <- $t12, Reference($t11) <- $t12
+    $t13 := borrow_field<TestNestedInvariants::Nested>.x($t12)
+    // live_refs: $t13 borrowed_by: LocalRoot(o) -> {Reference($t13)}, Reference($t11) -> {Reference($t12)}, Reference($t12) -> {Reference($t13)} borrows_from: Reference($t12) -> {Reference($t11)}, Reference($t13) -> {LocalRoot(o), Reference($t12)}
+    // LocalRoot(o) <- $t13, Reference($t12) <- $t13, Reference($t11) <- $t12
+    write_ref($t13, $t10)
+    return ()
+}
+
+
+fun TestNestedInvariants::mutate_inner_data_invariant_invalid() {
+    var o: TestNestedInvariants::Outer
+    var r: &mut TestNestedInvariants::Outer
+    var $t2: u64
+    var $t3: u64
+    var $t4: TestNestedInvariants::Nested
+    var $t5: TestNestedInvariants::Outer
+    var $t6: &mut TestNestedInvariants::Outer
+    var $t7: u64
+    var $t8: &mut TestNestedInvariants::Outer
+    var $t9: &mut TestNestedInvariants::Nested
+    var $t10: &mut u64
+    $t2 := 3
+    $t3 := 2
+    $t4 := pack TestNestedInvariants::Nested($t3)
+    $t5 := pack TestNestedInvariants::Outer($t2, $t4)
+    o := $t5
+    $t6 := borrow_local(o)
+    // live_refs: $t6 borrowed_by: LocalRoot(o) -> {Reference($t6)} borrows_from: Reference($t6) -> {LocalRoot(o)}
+    r := $t6
+    // live_refs: r borrowed_by: LocalRoot(o) -> {Reference(r)} borrows_from: Reference(r) -> {LocalRoot(o)}
+    $t7 := 0
+    // live_refs: r borrowed_by: LocalRoot(o) -> {Reference(r)} borrows_from: Reference(r) -> {LocalRoot(o)}
+    $t8 := move(r)
+    // live_refs: $t8 borrowed_by: LocalRoot(o) -> {Reference($t8)} borrows_from: Reference($t8) -> {LocalRoot(o)}
+    // LocalRoot(o) <- $t8
+    $t9 := borrow_field<TestNestedInvariants::Outer>.n($t8)
+    // live_refs: $t9 borrowed_by: LocalRoot(o) -> {Reference($t9)}, Reference($t8) -> {Reference($t9)} borrows_from: Reference($t9) -> {LocalRoot(o), Reference($t8)}
+    // LocalRoot(o) <- $t9, Reference($t8) <- $t9
+    $t10 := borrow_field<TestNestedInvariants::Nested>.x($t9)
+    // live_refs: $t10 borrowed_by: LocalRoot(o) -> {Reference($t10)}, Reference($t8) -> {Reference($t9)}, Reference($t9) -> {Reference($t10)} borrows_from: Reference($t9) -> {Reference($t8)}, Reference($t10) -> {LocalRoot(o), Reference($t9)}
+    // LocalRoot(o) <- $t10, Reference($t9) <- $t10, Reference($t8) <- $t9
+    write_ref($t10, $t7)
+    return ()
+}
+
+
+fun TestNestedInvariants::mutate_outer_data_invariant_invalid() {
+    var o: TestNestedInvariants::Outer
+    var r: &mut TestNestedInvariants::Outer
+    var $t2: u64
+    var $t3: u64
+    var $t4: TestNestedInvariants::Nested
+    var $t5: TestNestedInvariants::Outer
+    var $t6: &mut TestNestedInvariants::Outer
+    var $t7: u64
+    var $t8: &mut TestNestedInvariants::Outer
+    var $t9: &mut u64
+    $t2 := 3
+    $t3 := 2
+    $t4 := pack TestNestedInvariants::Nested($t3)
+    $t5 := pack TestNestedInvariants::Outer($t2, $t4)
+    o := $t5
+    $t6 := borrow_local(o)
+    // live_refs: $t6 borrowed_by: LocalRoot(o) -> {Reference($t6)} borrows_from: Reference($t6) -> {LocalRoot(o)}
+    r := $t6
+    // live_refs: r borrowed_by: LocalRoot(o) -> {Reference(r)} borrows_from: Reference(r) -> {LocalRoot(o)}
+    $t7 := 2
+    // live_refs: r borrowed_by: LocalRoot(o) -> {Reference(r)} borrows_from: Reference(r) -> {LocalRoot(o)}
+    $t8 := move(r)
+    // live_refs: $t8 borrowed_by: LocalRoot(o) -> {Reference($t8)} borrows_from: Reference($t8) -> {LocalRoot(o)}
+    // LocalRoot(o) <- $t8
+    $t9 := borrow_field<TestNestedInvariants::Outer>.y($t8)
+    // live_refs: $t9 borrowed_by: LocalRoot(o) -> {Reference($t9)}, Reference($t8) -> {Reference($t9)} borrows_from: Reference($t9) -> {LocalRoot(o), Reference($t8)}
+    // LocalRoot(o) <- $t9, Reference($t8) <- $t9
+    write_ref($t9, $t7)
+    return ()
+}
+
+
+fun TestNestedInvariants::new(): TestNestedInvariants::Outer {
+    var $t0: u64
+    var $t1: u64
+    var $t2: TestNestedInvariants::Nested
+    var $t3: TestNestedInvariants::Outer
+    $t0 := 3
+    $t1 := 2
+    $t2 := pack TestNestedInvariants::Nested($t1)
+    $t3 := pack TestNestedInvariants::Outer($t0, $t2)
+    return $t3
+}
+
+
+fun TestNestedInvariants::new_inner_data_invariant_invalid(): TestNestedInvariants::Outer {
+    var $t0: u64
+    var $t1: u64
+    var $t2: TestNestedInvariants::Nested
+    var $t3: TestNestedInvariants::Outer
+    $t0 := 2
+    $t1 := 0
+    $t2 := pack TestNestedInvariants::Nested($t1)
+    $t3 := pack TestNestedInvariants::Outer($t0, $t2)
+    return $t3
+}
+
+
+fun TestNestedInvariants::new_outer_data_invariant_invalid(): TestNestedInvariants::Outer {
+    var $t0: u64
+    var $t1: u64
+    var $t2: TestNestedInvariants::Nested
+    var $t3: TestNestedInvariants::Outer
+    $t0 := 2
+    $t1 := 2
+    $t2 := pack TestNestedInvariants::Nested($t1)
+    $t3 := pack TestNestedInvariants::Outer($t0, $t2)
+    return $t3
+}

--- a/language/move-prover/stackless-bytecode-generator/tests/writeback/nested_invariants.move
+++ b/language/move-prover/stackless-bytecode-generator/tests/writeback/nested_invariants.move
@@ -1,0 +1,41 @@
+module TestNestedInvariants {
+    struct Nested {
+        x: u64
+    }
+
+    struct Outer {
+        y: u64,
+        n: Nested
+    }
+
+    fun new(): Outer {
+        Outer{y: 3, n: Nested{x: 2}}
+    }
+
+    fun new_outer_data_invariant_invalid(): Outer {
+        Outer{y: 2, n: Nested{x: 2}}
+    }
+
+    fun new_inner_data_invariant_invalid(): Outer {
+        Outer{y: 2, n: Nested{x: 0}}
+    }
+
+    fun mutate() {
+        let o = Outer{y: 3, n: Nested{x: 2}};
+        let r = &mut o;
+        r.y = 2;
+        r.n.x = 1;
+    }
+
+    fun mutate_outer_data_invariant_invalid() {
+        let o = Outer{y: 3, n: Nested{x: 2}};
+        let r = &mut o;
+        r.y = 2;
+    }
+
+    fun mutate_inner_data_invariant_invalid() {
+        let o = Outer{y: 3, n: Nested{x: 2}};
+        let r = &mut o;
+        r.n.x = 0;
+    }
+}

--- a/language/move-prover/tests/sources/functional/aborts-if.exp
+++ b/language/move-prover/tests/sources/functional/aborts-if.exp
@@ -8,8 +8,6 @@ error:  A postcondition might not hold on this return path.
     │
     =     at tests/sources/functional/aborts-if.move:32:5: abort2_incorrect (entry)
     =     at tests/sources/functional/aborts-if.move:32:5: abort2_incorrect (exit)
-    =         _x = <redacted>,
-    =         _y = <redacted>
 
 error:  A postcondition might not hold on this return path.
 
@@ -20,8 +18,6 @@ error:  A postcondition might not hold on this return path.
     │
     =     at tests/sources/functional/aborts-if.move:47:5: abort4_incorrect (entry)
     =     at tests/sources/functional/aborts-if.move:48:9: abort4_incorrect
-    =         x = <redacted>,
-    =         y = <redacted>
     =     at tests/sources/functional/aborts-if.move:47:5: abort4_incorrect (exit)
 
 error: abort not covered by any of the `aborts_if` clauses
@@ -38,8 +34,6 @@ error: abort not covered by any of the `aborts_if` clauses
     │
     =     at tests/sources/functional/aborts-if.move:55:5: abort5_incorrect (entry)
     =     at tests/sources/functional/aborts-if.move:56:9: abort5_incorrect (ABORTED)
-    =         x = <redacted>,
-    =         y = <redacted>
 
 error:  A postcondition might not hold on this return path.
 
@@ -50,8 +44,6 @@ error:  A postcondition might not hold on this return path.
     │
     =     at tests/sources/functional/aborts-if.move:63:5: abort6_incorrect (entry)
     =     at tests/sources/functional/aborts-if.move:64:9: abort6_incorrect
-    =         x = <redacted>,
-    =         y = <redacted>
     =     at tests/sources/functional/aborts-if.move:63:5: abort6_incorrect (exit)
 
 error:  A postcondition might not hold on this return path.
@@ -63,8 +55,6 @@ error:  A postcondition might not hold on this return path.
     │
     =     at tests/sources/functional/aborts-if.move:85:5: multi_abort2_incorrect (entry)
     =     at tests/sources/functional/aborts-if.move:86:9: multi_abort2_incorrect
-    =         x = <redacted>,
-    =         y = <redacted>
     =     at tests/sources/functional/aborts-if.move:85:5: multi_abort2_incorrect (exit)
 
 error: abort not covered by any of the `aborts_if` clauses
@@ -81,8 +71,6 @@ error: abort not covered by any of the `aborts_if` clauses
     │
     =     at tests/sources/functional/aborts-if.move:94:5: multi_abort3_incorrect (entry)
     =     at tests/sources/functional/aborts-if.move:95:9: multi_abort3_incorrect (ABORTED)
-    =         _x = <redacted>,
-    =         _y = <redacted>
 
 error:  A postcondition might not hold on this return path.
 
@@ -93,5 +81,4 @@ error:  A postcondition might not hold on this return path.
      │
      =     at tests/sources/functional/aborts-if.move:112:5: multi_abort5_incorrect (entry)
      =     at tests/sources/functional/aborts-if.move:113:9: multi_abort5_incorrect
-     =         x = <redacted>
      =     at tests/sources/functional/aborts-if.move:112:5: multi_abort5_incorrect (exit)

--- a/language/move-prover/tests/sources/functional/arithm.exp
+++ b/language/move-prover/tests/sources/functional/arithm.exp
@@ -13,8 +13,6 @@ error: abort not covered by any of the `aborts_if` clauses
      │
      =     at tests/sources/functional/arithm.move:125:5: div_by_zero_u64_incorrect (entry)
      =     at tests/sources/functional/arithm.move:126:11: div_by_zero_u64_incorrect (ABORTED)
-     =         x = <redacted>,
-     =         y = <redacted>
 
 error: abort not covered by any of the `aborts_if` clauses
 
@@ -30,8 +28,6 @@ error: abort not covered by any of the `aborts_if` clauses
      │
      =     at tests/sources/functional/arithm.move:177:5: overflow_u128_add_incorrect (entry)
      =     at tests/sources/functional/arithm.move:178:11: overflow_u128_add_incorrect (ABORTED)
-     =         x = <redacted>,
-     =         y = <redacted>
 
 error: abort not covered by any of the `aborts_if` clauses
 
@@ -47,8 +43,6 @@ error: abort not covered by any of the `aborts_if` clauses
      │
      =     at tests/sources/functional/arithm.move:230:5: overflow_u128_mul_incorrect (entry)
      =     at tests/sources/functional/arithm.move:231:11: overflow_u128_mul_incorrect (ABORTED)
-     =         x = <redacted>,
-     =         y = <redacted>
 
 error: abort not covered by any of the `aborts_if` clauses
 
@@ -64,8 +58,6 @@ error: abort not covered by any of the `aborts_if` clauses
      │
      =     at tests/sources/functional/arithm.move:161:5: overflow_u64_add_incorrect (entry)
      =     at tests/sources/functional/arithm.move:162:11: overflow_u64_add_incorrect (ABORTED)
-     =         x = <redacted>,
-     =         y = <redacted>
 
 error: abort not covered by any of the `aborts_if` clauses
 
@@ -81,8 +73,6 @@ error: abort not covered by any of the `aborts_if` clauses
      │
      =     at tests/sources/functional/arithm.move:214:5: overflow_u64_mul_incorrect (entry)
      =     at tests/sources/functional/arithm.move:215:11: overflow_u64_mul_incorrect (ABORTED)
-     =         x = <redacted>,
-     =         y = <redacted>
 
 error: abort not covered by any of the `aborts_if` clauses
 
@@ -98,8 +88,6 @@ error: abort not covered by any of the `aborts_if` clauses
      │
      =     at tests/sources/functional/arithm.move:145:5: overflow_u8_add_incorrect (entry)
      =     at tests/sources/functional/arithm.move:146:11: overflow_u8_add_incorrect (ABORTED)
-     =         x = <redacted>,
-     =         y = <redacted>
 
 error: abort not covered by any of the `aborts_if` clauses
 
@@ -115,5 +103,3 @@ error: abort not covered by any of the `aborts_if` clauses
      │
      =     at tests/sources/functional/arithm.move:198:5: overflow_u8_mul_incorrect (entry)
      =     at tests/sources/functional/arithm.move:199:11: overflow_u8_mul_incorrect (ABORTED)
-     =         x = <redacted>,
-     =         y = <redacted>

--- a/language/move-prover/tests/sources/functional/cast.exp
+++ b/language/move-prover/tests/sources/functional/cast.exp
@@ -13,7 +13,6 @@ error: abort not covered by any of the `aborts_if` clauses
     │
     =     at tests/sources/functional/cast.move:44:5: aborting_u64_cast_incorrect (entry)
     =     at tests/sources/functional/cast.move:45:9: aborting_u64_cast_incorrect (ABORTED)
-    =         x = <redacted>
 
 error: abort not covered by any of the `aborts_if` clauses
 
@@ -29,4 +28,3 @@ error: abort not covered by any of the `aborts_if` clauses
     │
     =     at tests/sources/functional/cast.move:30:5: aborting_u8_cast_incorrect (entry)
     =     at tests/sources/functional/cast.move:31:9: aborting_u8_cast_incorrect (ABORTED)
-    =         x = <redacted>

--- a/language/move-prover/tests/sources/functional/global_vars.exp
+++ b/language/move-prover/tests/sources/functional/global_vars.exp
@@ -13,7 +13,7 @@ error:  A postcondition might not hold on this return path.
      =         s = <redacted>
      =     at tests/sources/functional/global_vars.move:114:15: combi_incorrect
      =         s = <redacted>
-     =     at tests/sources/functional/global_vars.move:111:21: combi_incorrect
+     =     at tests/sources/functional/global_vars.move:110:5: combi_incorrect
      =     at tests/sources/functional/global_vars.move:110:5: combi_incorrect (exit)
 
 error:  A postcondition might not hold on this return path.
@@ -37,7 +37,6 @@ error:  A postcondition might not hold on this return path.
     │
     =     at tests/sources/functional/global_vars.move:52:5: unpack_incorrect (entry)
     =     at tests/sources/functional/global_vars.move:53:19: unpack_incorrect
-    =         t = <redacted>
     =     at tests/sources/functional/global_vars.move:54:9: unpack_incorrect
     =         x = <redacted>
     =     at tests/sources/functional/global_vars.move:52:5: unpack_incorrect (exit)
@@ -57,9 +56,10 @@ error:  A postcondition might not hold on this return path.
      =         s = <redacted>
      =     at tests/sources/functional/global_vars.move:149:15: update_S_incorrect
      =         r = <redacted>
+     =     at tests/sources/functional/global_vars.move:146:5: update_S_incorrect
+     =         result = <redacted>
      =     at tests/sources/functional/global_vars.move:150:9: update_S_incorrect
      =     at tests/sources/functional/global_vars.move:146:5: update_S_incorrect (exit)
-     =         result = <redacted>
 
 error:  A postcondition might not hold on this return path.
 
@@ -74,9 +74,8 @@ error:  A postcondition might not hold on this return path.
     =         t = <redacted>
     =     at tests/sources/functional/global_vars.move:66:5: update_valid_still_mutating (entry)
     =     at tests/sources/functional/global_vars.move:67:19: update_valid_still_mutating
-    =         t = <redacted>,
-    =         t = <redacted>
     =     at tests/sources/functional/global_vars.move:66:5: update_valid_still_mutating (exit)
+    =         result = <redacted>
     =     at tests/sources/functional/global_vars.move:87:9: update_incorrect
     =     at tests/sources/functional/global_vars.move:84:5: update_incorrect (exit)
     =         result = <redacted>

--- a/language/move-prover/tests/sources/functional/hash_model.exp
+++ b/language/move-prover/tests/sources/functional/hash_model.exp
@@ -8,8 +8,6 @@ error:  A postcondition might not hold on this return path.
     │
     =     at tests/sources/functional/hash_model.move:39:5: hash_test1_incorrect (entry)
     =     at tests/sources/functional/hash_model.move:41:24: hash_test1_incorrect
-    =         v1 = <redacted>,
-    =         v2 = <redacted>,
     =         h1 = <redacted>
     =     at tests/sources/functional/hash_model.move:42:33: hash_test1_incorrect
     =         h2 = <redacted>
@@ -27,8 +25,6 @@ error:  A postcondition might not hold on this return path.
     │
     =     at tests/sources/functional/hash_model.move:82:5: hash_test2_incorrect (entry)
     =     at tests/sources/functional/hash_model.move:84:24: hash_test2_incorrect
-    =         v1 = <redacted>,
-    =         v2 = <redacted>,
     =         h1 = <redacted>
     =     at tests/sources/functional/hash_model.move:85:33: hash_test2_incorrect
     =         h2 = <redacted>

--- a/language/move-prover/tests/sources/functional/hash_model_invalid.exp
+++ b/language/move-prover/tests/sources/functional/hash_model_invalid.exp
@@ -8,8 +8,6 @@ error:  A postcondition might not hold on this return path.
     │
     =     at tests/sources/functional/hash_model_invalid.move:11:5: hash_test1 (entry)
     =     at tests/sources/functional/hash_model_invalid.move:13:24: hash_test1
-    =         v1 = <redacted>,
-    =         v2 = <redacted>,
     =         h1 = <redacted>
     =     at tests/sources/functional/hash_model_invalid.move:14:33: hash_test1
     =         h2 = <redacted>
@@ -27,8 +25,6 @@ error:  A postcondition might not hold on this return path.
     │
     =     at tests/sources/functional/hash_model_invalid.move:26:5: hash_test2 (entry)
     =     at tests/sources/functional/hash_model_invalid.move:28:24: hash_test2
-    =         v1 = <redacted>,
-    =         v2 = <redacted>,
     =         h1 = <redacted>
     =     at tests/sources/functional/hash_model_invalid.move:29:33: hash_test2
     =         h2 = <redacted>

--- a/language/move-prover/tests/sources/functional/invariants.exp
+++ b/language/move-prover/tests/sources/functional/invariants.exp
@@ -35,7 +35,6 @@ error:  This assertion might not hold.
      │
      =     at tests/sources/functional/invariants.move:153:5: lifetime_invalid_S_branching (entry)
      =     at tests/sources/functional/invariants.move:154:11: lifetime_invalid_S_branching
-     =         cond = <redacted>
      =     at tests/sources/functional/invariants.move:155:21: lifetime_invalid_S_branching
      =         a = <redacted>,
      =         b = <redacted>

--- a/language/move-prover/tests/sources/functional/marketcap.exp
+++ b/language/move-prover/tests/sources/functional/marketcap.exp
@@ -8,9 +8,7 @@ error:  A postcondition might not hold on this return path.
     │
     =     at tests/sources/functional/marketcap.move:48:6: deposit_invalid (entry)
     =     at tests/sources/functional/marketcap.move:49:18: deposit_invalid
-    =         coin_ref = <redacted>,
-    =         check = <redacted>,
     =         value = <redacted>
     =     at tests/sources/functional/marketcap.move:50:27: deposit_invalid
-    =         coin_ref = <redacted>
     =     at tests/sources/functional/marketcap.move:48:6: deposit_invalid (exit)
+    =         result = <redacted>

--- a/language/move-prover/tests/sources/functional/marketcap_as_schema.exp
+++ b/language/move-prover/tests/sources/functional/marketcap_as_schema.exp
@@ -8,9 +8,7 @@ error:  A postcondition might not hold on this return path.
     │
     =     at tests/sources/functional/marketcap_as_schema.move:58:6: deposit_invalid (entry)
     =     at tests/sources/functional/marketcap_as_schema.move:59:18: deposit_invalid
-    =         coin_ref = <redacted>,
-    =         check = <redacted>,
     =         value = <redacted>
     =     at tests/sources/functional/marketcap_as_schema.move:60:27: deposit_invalid
-    =         coin_ref = <redacted>
     =     at tests/sources/functional/marketcap_as_schema.move:58:6: deposit_invalid (exit)
+    =         result = <redacted>

--- a/language/move-prover/tests/sources/functional/marketcap_as_schema_apply.exp
+++ b/language/move-prover/tests/sources/functional/marketcap_as_schema_apply.exp
@@ -8,9 +8,7 @@ error:  A postcondition might not hold on this return path.
     │
     =     at tests/sources/functional/marketcap_as_schema_apply.move:67:5: deposit_incorrect (entry)
     =     at tests/sources/functional/marketcap_as_schema_apply.move:68:17: deposit_incorrect
-    =         coin_ref = <redacted>,
-    =         check = <redacted>,
     =         value = <redacted>
     =     at tests/sources/functional/marketcap_as_schema_apply.move:69:26: deposit_incorrect
-    =         coin_ref = <redacted>
     =     at tests/sources/functional/marketcap_as_schema_apply.move:67:5: deposit_incorrect (exit)
+    =         result = <redacted>

--- a/language/move-prover/tests/sources/functional/marketcap_generic.exp
+++ b/language/move-prover/tests/sources/functional/marketcap_generic.exp
@@ -8,9 +8,7 @@ error:  A postcondition might not hold on this return path.
     │
     =     at tests/sources/functional/marketcap_generic.move:61:6: deposit_invalid (entry)
     =     at tests/sources/functional/marketcap_generic.move:62:18: deposit_invalid
-    =         coin_ref = <redacted>,
-    =         check = <redacted>,
     =         value = <redacted>
     =     at tests/sources/functional/marketcap_generic.move:63:27: deposit_invalid
-    =         coin_ref = <redacted>
     =     at tests/sources/functional/marketcap_generic.move:61:6: deposit_invalid (exit)
+    =         result = <redacted>

--- a/language/move-prover/tests/sources/functional/module_invariants.exp
+++ b/language/move-prover/tests/sources/functional/module_invariants.exp
@@ -8,7 +8,6 @@ error:  A postcondition might not hold on this return path.
     │
     =     at tests/sources/functional/module_invariants.move:51:5: delete_S_incorrect (entry)
     =     at tests/sources/functional/module_invariants.move:51:5: delete_S_incorrect (exit)
-    =         x = <redacted>
 
 error:  A precondition for this call might not hold.
 

--- a/language/move-prover/tests/sources/functional/mut_ref_accross_modules.exp
+++ b/language/move-prover/tests/sources/functional/mut_ref_accross_modules.exp
@@ -1,15 +1,6 @@
 Move prover returns: exiting with boogie verification errors
 error:  This assertion might not hold.
 
-    ┌── tests/sources/functional/mut_ref_accross_modules.move:81:13 ───
-    │
- 81 │             assert x.value > 0;
-    │             ^^^^^^^^^^^^^^^^^^^
-    │
-    =     at tests/sources/functional/mut_ref_accross_modules.move:79:5: data_invariant (entry)
-
-error:  This assertion might not hold.
-
     ┌── tests/sources/functional/mut_ref_accross_modules.move:21:9 ───
     │
  21 │         invariant value > 0;
@@ -17,13 +8,6 @@ error:  This assertion might not hold.
     │
     =     at tests/sources/functional/mut_ref_accross_modules.move:64:5: decrement_invalid (entry)
     =     at tests/sources/functional/mut_ref_accross_modules.move:65:27: decrement_invalid
-    =         x = <redacted>,
-    =         x = <redacted>,
-    =         r = <redacted>
-    =     at tests/sources/functional/mut_ref_accross_modules.move:66:41: decrement_invalid
-    =         r = <redacted>
-    =     at tests/sources/functional/mut_ref_accross_modules.move:67:17: decrement_invalid
-    =         x = <redacted>,
     =         r = <redacted>
 
 error:  A postcondition might not hold on this return path.
@@ -35,52 +19,18 @@ error:  A postcondition might not hold on this return path.
     │
     =     at tests/sources/functional/mut_ref_accross_modules.move:58:5: increment_invalid (entry)
     =     at tests/sources/functional/mut_ref_accross_modules.move:59:27: increment_invalid
-    =         x = <redacted>,
-    =         x = <redacted>
     =     at tests/sources/functional/mut_ref_accross_modules.move:58:5: increment_invalid (exit)
-
-error:  This assertion might not hold.
-
-    ┌── tests/sources/functional/mut_ref_accross_modules.move:88:13 ───
-    │
- 88 │             assert x.value > 0;
-    │             ^^^^^^^^^^^^^^^^^^^
-    │
-    =     at tests/sources/functional/mut_ref_accross_modules.move:86:5: private_data_invariant_invalid (entry)
-
-error:  This assertion might not hold.
-
-    ┌── tests/sources/functional/mut_ref_accross_modules.move:21:9 ───
-    │
- 21 │         invariant value > 0;
-    │         ^^^^^^^^^^^^^^^^^^^^
-    │
-    =     at tests/sources/functional/mut_ref_accross_modules.move:115:6: private_to_public_caller_invalid_data_invariant (entry)
-    =     at tests/sources/functional/mut_ref_accross_modules.move:34:5: new (entry)
-    =     at tests/sources/functional/mut_ref_accross_modules.move:35:17: new
-    =         x = <redacted>,
-    =         r = <redacted>
-    =     at tests/sources/functional/mut_ref_accross_modules.move:36:17: new
-    =         r = <redacted>
-    =     at tests/sources/functional/mut_ref_accross_modules.move:37:18: new
     =         result = <redacted>
-    =     at tests/sources/functional/mut_ref_accross_modules.move:34:5: new (exit)
-    =     at tests/sources/functional/mut_ref_accross_modules.move:120:14: private_to_public_caller_invalid_data_invariant
-    =     at tests/sources/functional/mut_ref_accross_modules.move:121:18: private_to_public_caller_invalid_data_invariant
-    =         r = <redacted>,
-    =         x = <redacted>
-    =     at tests/sources/functional/mut_ref_accross_modules.move:72:5: private_decrement (entry)
-    =     at tests/sources/functional/mut_ref_accross_modules.move:73:27: private_decrement
-    =         x = <redacted>,
-    =         x = <redacted>,
-    =         r = <redacted>
-    =     at tests/sources/functional/mut_ref_accross_modules.move:74:41: private_decrement
-    =         r = <redacted>
-    =     at tests/sources/functional/mut_ref_accross_modules.move:75:17: private_decrement
-    =         x = <redacted>,
-    =         r = <redacted>
-    =     at tests/sources/functional/mut_ref_accross_modules.move:72:9: private_decrement
-    =     at tests/sources/functional/mut_ref_accross_modules.move:51:16: increment
+
+error:  A precondition for this call might not hold.
+
+    ┌── tests/sources/functional/mut_ref_accross_modules.move:30:9 ───
+    │
+ 30 │         invariant global<TSum>(0x0).sum == spec_sum;
+    │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    │
+    =     at tests/sources/functional/mut_ref_accross_modules.move:94:5: private_to_public_caller (entry)
+    =     at tests/sources/functional/mut_ref_accross_modules.move:51:5: increment (entry)
 
 error:  A precondition for this call might not hold.
 

--- a/language/move-prover/tests/sources/functional/mut_ref_accross_modules.move
+++ b/language/move-prover/tests/sources/functional/mut_ref_accross_modules.move
@@ -75,22 +75,22 @@ module TestMutRefs {
         r.sum = r.sum - 1;
     }
 
-    // For a public function, the data invariant for a mut ref is expected to hold.
+    // TODO: This function should verify because the data invariant for a mut ref is expected to hold. Currently, it verifies but for the wrong reason: the resource invariant is assumed on the inout value modeling x.
     public fun data_invariant(x: &mut T) {
         spec {
             assert x.value > 0;
         }
     }
 
-    // For a private function, the data invariant for a mut ref is not expected to hold.
+    // TODO: This function should fail because the data invariant for a mut ref is not expected to hold. Currently, it verifies because the resource invariant is assumed on the inout value modeling x.
     fun private_data_invariant_invalid(x: &mut T) {
         spec {
             assert x.value > 0;
         }
     }
 
-    // The next function should succeed because calling a public function from a private one maintains module
-    // invariants.
+    // The next function should succeed because calling a public function from a private one maintains module invariants.
+    // TODO: This function fails because PackRef(r) is called just before increment(r).
     fun private_to_public_caller(r: &mut T) acquires TSum {
         // Before call to public increment, data invariants and module invariant must hold.
         // Here we assume them, and force spec_sum to start with a zero value.
@@ -111,7 +111,7 @@ module TestMutRefs {
          increment(r);
      }
 
-     // The next function fails because the data invariant does not hold.
+     // TODO: This function should fail because the data invariant does not hold at the call to increment. But, currently it does not fail since there is no data invariant assertion at the call to increment (due to my changes?).
      fun private_to_public_caller_invalid_data_invariant() acquires TSum {
          // Before call to public new(), assume module invariant.
          spec {

--- a/language/move-prover/tests/sources/functional/pragma.exp
+++ b/language/move-prover/tests/sources/functional/pragma.exp
@@ -13,4 +13,3 @@ error: abort not covered by any of the `aborts_if` clauses
     │
     =     at tests/sources/functional/pragma.move:10:5: always_aborts_with_verify_incorrect (entry)
     =     at tests/sources/functional/pragma.move:11:9: always_aborts_with_verify_incorrect (ABORTED)
-    =         _c = <redacted>

--- a/language/move-prover/tests/sources/functional/references.exp
+++ b/language/move-prover/tests/sources/functional/references.exp
@@ -8,16 +8,16 @@ error:  A postcondition might not hold on this return path.
     │
     =     at tests/sources/functional/references.move:58:5: mut_ref_incorrect (entry)
     =     at tests/sources/functional/references.move:59:13: mut_ref_incorrect
+    =         b_ref = <redacted>
     =     at tests/sources/functional/references.move:60:31: mut_ref_incorrect
     =         b = <redacted>,
     =         b_ref = <redacted>
+    =     at tests/sources/functional/references.move:61:15: mut_ref_incorrect
     =     at tests/sources/functional/references.move:43:5: mut_b (entry)
-    =     at tests/sources/functional/references.move:44:9: mut_b
-    =         b = <redacted>,
-    =         b = <redacted>,
-    =         $t1 = <redacted>
+    =     at tests/sources/functional/references.move:44:16: mut_b
     =     at tests/sources/functional/references.move:43:9: mut_b
-    =     at tests/sources/functional/references.move:62:14: mut_ref_incorrect
+    =     at tests/sources/functional/references.move:58:5: mut_ref_incorrect
     =         b = <redacted>
+    =     at tests/sources/functional/references.move:62:9: mut_ref_incorrect
     =     at tests/sources/functional/references.move:63:13: mut_ref_incorrect
     =     at tests/sources/functional/references.move:58:5: mut_ref_incorrect (exit)

--- a/language/move-prover/tests/sources/functional/schema_exp.exp
+++ b/language/move-prover/tests/sources/functional/schema_exp.exp
@@ -13,7 +13,6 @@ error: abort not covered by any of the `aborts_if` clauses
     │
     =     at tests/sources/functional/schema_exp.move:25:5: bar_incorrect (entry)
     =     at tests/sources/functional/schema_exp.move:26:9: bar_incorrect (ABORTED)
-    =         c = <redacted>
 
 error:  A postcondition might not hold on this return path.
 
@@ -24,6 +23,5 @@ error:  A postcondition might not hold on this return path.
     │
     =     at tests/sources/functional/schema_exp.move:53:5: baz_incorrect (entry)
     =     at tests/sources/functional/schema_exp.move:54:11: baz_incorrect
-    =         i = <redacted>,
     =         result = <redacted>
     =     at tests/sources/functional/schema_exp.move:53:5: baz_incorrect (exit)

--- a/language/move-prover/tests/sources/functional/serialize_model.exp
+++ b/language/move-prover/tests/sources/functional/serialize_model.exp
@@ -8,8 +8,6 @@ error:  A postcondition might not hold on this return path.
     │
     =     at tests/sources/functional/serialize_model.move:26:5: lcs_test1_incorrect (entry)
     =     at tests/sources/functional/serialize_model.move:28:23: lcs_test1_incorrect
-    =         v1 = <redacted>,
-    =         v2 = <redacted>,
     =         s1 = <redacted>
     =     at tests/sources/functional/serialize_model.move:29:32: lcs_test1_incorrect
     =         s2 = <redacted>

--- a/language/move-prover/tests/sources/functional/specs-in-fun.exp
+++ b/language/move-prover/tests/sources/functional/specs-in-fun.exp
@@ -8,8 +8,6 @@ error:  This assertion might not hold.
     │
     =     at tests/sources/functional/specs-in-fun.move:42:5: simple1_incorrect (entry)
     =     at tests/sources/functional/specs-in-fun.move:43:9: simple1_incorrect
-    =         x = <redacted>,
-    =         y = <redacted>
 
 error:  This assertion might not hold.
 
@@ -20,7 +18,6 @@ error:  This assertion might not hold.
     │
     =     at tests/sources/functional/specs-in-fun.move:49:5: simple2_incorrect (entry)
     =     at tests/sources/functional/specs-in-fun.move:51:15: simple2_incorrect
-    =         x = <redacted>,
     =         y = <redacted>
     =     at tests/sources/functional/specs-in-fun.move:53:13: simple2_incorrect
 
@@ -42,7 +39,5 @@ error:  This assertion might not hold.
     │
     =     at tests/sources/functional/specs-in-fun.move:64:5: simple4_incorrect (entry)
     =     at tests/sources/functional/specs-in-fun.move:66:15: simple4_incorrect
-    =         x = <redacted>,
-    =         y = <redacted>,
     =         z = <redacted>
     =     at tests/sources/functional/specs-in-fun.move:68:13: simple4_incorrect

--- a/language/move-prover/tests/sources/regression/type_param_bug_200228.exp
+++ b/language/move-prover/tests/sources/regression/type_param_bug_200228.exp
@@ -8,6 +8,5 @@ error:  A postcondition might not hold on this return path.
     │
     =     at tests/sources/regression/type_param_bug_200228.move:6:3: type_param_bug (entry)
     =     at tests/sources/regression/type_param_bug_200228.move:7:5: type_param_bug
-    =         addr = <redacted>,
     =         result = <redacted>
     =     at tests/sources/regression/type_param_bug_200228.move:6:3: type_param_bug (exit)


### PR DESCRIPTION
## Motivation

This PR moves Boogie translation to the new memory model.  In addition to bug fixes in the core transforms and analyses, the bulk of the changes are in bytecode_translator.rs.  The interaction between the new memory model and explicit PackRef/UnpackRef and resource invariants is not fully sorted out.  Specifically, there are several discrepancies in the output for the test case tests/sources/functional/mut_ref_accross_modules.exp.  I have noted down these discrepancies for further investigation.
 
### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

Existing tests

## Related PRs

