### PR TITLE
[testing] correct features to allow tests to pass in secure/key-manager crate

### DIFF
--- a/secure/key-manager/Cargo.toml
+++ b/secure/key-manager/Cargo.toml
@@ -42,4 +42,5 @@ storage-interface= { path = "../../storage/storage-interface", version = "0.1.0"
 vm-validator = { path = "../../vm-validator", version = "0.1.0" }
 
 [features]
-fuzzing = ["libradb/fuzzing", "libra-json-rpc/fuzzing", "libradb/fuzzing", "libra-config/fuzzing", "libra-secure-storage/testing" ]
+testing = [ "libra-secure-storage/testing" ]
+fuzzing = ["libradb/fuzzing", "libra-json-rpc/fuzzing", "libra-config/fuzzing" ]

--- a/secure/key-manager/Cargo.toml
+++ b/secure/key-manager/Cargo.toml
@@ -14,7 +14,7 @@ once_cell = "1.4.0"
 serde = { version = "1.0.110", features = ["rc"], default-features = false }
 thiserror = "1.0"
 
-libra-config = { path = "../../config", version = "0.1.0", features = ["fuzzing"]}
+libra-config = { path = "../../config", version = "0.1.0"}
 libra-crypto = { path = "../../crypto/crypto", version = "0.1.0" }
 libra-global-constants = { path = "../../config/global-constants", version = "0.1.0"}
 libra-logger = { path = "../../common/logger", version = "0.1.0" }
@@ -42,4 +42,4 @@ storage-interface= { path = "../../storage/storage-interface", version = "0.1.0"
 vm-validator = { path = "../../vm-validator", version = "0.1.0" }
 
 [features]
-fuzzing = ["libradb/fuzzing", "libra-json-rpc/fuzzing"]
+fuzzing = ["libradb/fuzzing", "libra-json-rpc/fuzzing", "libradb/fuzzing", "libra-config/fuzzing", "libra-secure-storage/testing" ]


### PR DESCRIPTION
<!--
Thank you for sending a PR. We appreciate you spending time to help improve the Libra project.

The project is undergoing daily changes. Pull Requests will be reviewed and responded to as time permits.
-->

## Motivation

allow code coverage and individual tests to run against the  secure/key-manager crate.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

breaks locally,  fixed, tested locally, wont appear as a broken crate list in slack the next day.
Also removed an unintentional fuzzing featured added in to a regular dependency.

## Related PRs

None.
