### PR TITLE
[testcompile] fix cargo toml to allow test compilation

### DIFF
--- a/execution/executor-utils/Cargo.toml
+++ b/execution/executor-utils/Cargo.toml
@@ -27,3 +27,4 @@ libra-types = { path = "../../types", version = "0.1.0" }
 
 [features]
 testing = []
+fuzzing = [ "libra-types/fuzzing" ]


### PR DESCRIPTION
<!--
Thank you for sending a PR. We appreciate you spending time to help improve the Libra project.

The project is undergoing daily changes. Pull Requests will be reviewed and responded to as time permits.
-->

## Motivation

Allow this crate to compile on it's own (and if tests are ever added test on its own).

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

Failed local compile in executor-util, fix, successful compile.

## Related PRs

None