### PR TITLE
[testing] fix safety-rules testing

### DIFF
--- a/consensus/safety-rules/Cargo.toml
+++ b/consensus/safety-rules/Cargo.toml
@@ -38,4 +38,4 @@ harness = false
 [features]
 default = []
 fuzzing = ["consensus-types/fuzzing", "libra-config/fuzzing"]
-testing = []
+testing = ["libra-secure-storage/testing"]


### PR DESCRIPTION
<!--
Thank you for sending a PR. We appreciate you spending time to help improve the Libra project.

The project is undergoing daily changes. Pull Requests will be reviewed and responded to as time permits.
-->

## Motivation

allow safety-rules to compile and test on it's own with cargo xtest.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?

yes

## Test Plan

cargo xtest watch it fail, cargo xtest, watch it work.

## Related PRs

none
