### PR TITLE
[move vm] Added &signer to transaction scripts

### DIFF
--- a/language/ir-testsuite/tests/signer/address_arg_is_not_signer.mvir
+++ b/language/ir-testsuite/tests/signer/address_arg_is_not_signer.mvir
@@ -1,0 +1,39 @@
+module M {
+    resource R { s: signer }
+    public store_signer(s: signer) {
+        move_to_sender<R>(R { s: move(s) });
+        return;
+    }
+}
+
+//! new-transaction
+//! args: 0x0
+import {{default}}.M;
+main(s: signer) {
+    M.store_signer(move(s));
+    return;
+}
+// check: INVALID_MAIN_FUNCTION_SIGNATURE
+
+//! new-transaction
+//! args: 0x0
+main(s: &signer) {
+    return;
+}
+// check: TYPE_MISMATCH
+
+//! new-transaction
+//! args: 0x0
+import {{default}}.M;
+main(s: &signer, s2: signer) {
+    M.store_signer(move(s2));
+    return;
+}
+// check: INVALID_MAIN_FUNCTION_SIGNATURE
+
+//! new-transaction
+//! args: 0x0
+main(s: &signer, s2: &signer) {
+    return;
+}
+// check: INVALID_MAIN_FUNCTION_SIGNATURE

--- a/language/ir-testsuite/tests/signer/double_signer.mvir
+++ b/language/ir-testsuite/tests/signer/double_signer.mvir
@@ -1,0 +1,18 @@
+main(s: &signer, s2: &signer) {
+    return;
+}
+// check: INVALID_MAIN_FUNCTION_SIGNATURE
+
+//! new-transaction
+//! args: 0
+main(s: &signer, s2: &signer,  u: u64,) {
+    return;
+}
+// check: INVALID_MAIN_FUNCTION_SIGNATURE
+
+//! new-transaction
+//! args: 0
+main(s: &signer, u: u64, s2: &signer) {
+    return;
+}
+// check: INVALID_MAIN_FUNCTION_SIGNATURE

--- a/language/ir-testsuite/tests/signer/equality.mvir
+++ b/language/ir-testsuite/tests/signer/equality.mvir
@@ -1,0 +1,5 @@
+main(s: &signer) {
+    assert(copy(s) == copy(s), 42);
+    assert(!(copy(s) != move(s)), 42);
+    return;
+}

--- a/language/ir-testsuite/tests/signer/misplaced_signer_arg.mvir
+++ b/language/ir-testsuite/tests/signer/misplaced_signer_arg.mvir
@@ -1,0 +1,12 @@
+//! args: 0
+main(u: u64, s: &signer) {
+    return;
+}
+// check: INVALID_MAIN_FUNCTION_SIGNATURE
+
+//! new-transaction
+//! args: 0, 1
+main(u: u64, s: &signer, u2: u64) {
+    return;
+}
+// check: INVALID_MAIN_FUNCTION_SIGNATURE

--- a/language/ir-testsuite/tests/signer/runtime_dummy.mvir
+++ b/language/ir-testsuite/tests/signer/runtime_dummy.mvir
@@ -1,0 +1,15 @@
+main(s: &signer) {
+    return;
+}
+
+//! new-transaction
+//! args: 0
+main(s: &signer, u: u64) {
+    return;
+}
+
+//! new-transaction
+//! args: 0, 0x1
+main(s: &signer, u: u64, b: address) {
+    return;
+}

--- a/language/ir-testsuite/tests/signer/runtime_move_to.mvir
+++ b/language/ir-testsuite/tests/signer/runtime_move_to.mvir
@@ -1,0 +1,62 @@
+module M {
+    resource R1 { f: bool }
+    resource R2<T> { f: T }
+
+    public store(sender: &signer, f: bool) {
+        move_to<R1>(copy(sender), R1 { f: move(f) });
+        return;
+    }
+
+    public store_gen<T>(sender: &signer, t: T) {
+        move_to<R2<T>>(copy(sender), R2<T> { f: move(t) });
+        return;
+    }
+
+    // TODO migrate to use signer
+    public read(): bool acquires R1 {
+        return *&(borrow_global<R1>(get_txn_sender())).f;
+    }
+
+    // TODO migrate to use signer
+    public read_gen<T: copyable>(): T acquires R2 {
+        return *&(borrow_global<R2<T>>(get_txn_sender())).f;
+    }
+}
+
+
+//! new-transaction
+import {{default}}.M;
+main(sender: &signer) {
+    M.store(copy(sender), false);
+    assert((M.read() == false), 42);
+
+    M.store_gen<bool>(copy(sender), true);
+    assert((M.read_gen<bool>() == true), 42);
+
+    M.store_gen<u64>(copy(sender), 112);
+    assert((M.read_gen<u64>() == 112), 42);
+
+    return;
+}
+
+
+//! account: alice, 90000
+//! new-transaction
+//! sender: alice
+import {{default}}.M;
+main(sender: &signer) {
+    M.store(copy(sender), false);
+    M.store_gen<bool>(copy(sender), true);
+    M.store_gen<u64>(copy(sender), 112);
+    return;
+}
+
+//! new-transaction
+//! sender: alice
+import {{default}}.M;
+main(sender: &signer) {
+    assert((M.read() == false), 42);
+    assert((M.read_gen<bool>() == true), 42);
+    assert((M.read_gen<u64>() == 112), 42);
+    return;
+}

--- a/language/move-vm/runtime/src/interpreter.rs
+++ b/language/move-vm/runtime/src/interpreter.rs
@@ -1163,8 +1163,12 @@ impl Frame {
                     }
                     Bytecode::MoveTo(sd_idx) => {
                         let resource = interpreter.operand_stack.pop_as::<Struct>()?;
-                        let signer_reference = interpreter.operand_stack.pop_as::<Reference>()?;
-                        let addr = signer_reference.read_ref()?.value_as::<AccountAddress>()?;
+                        let signer_reference = interpreter.operand_stack.pop_as::<StructRef>()?;
+                        let addr = signer_reference
+                            .borrow_field(0)?
+                            .value_as::<Reference>()?
+                            .read_ref()?
+                            .value_as::<AccountAddress>()?;
                         let size = interpreter.global_data_op(
                             resolver,
                             context,
@@ -1176,8 +1180,12 @@ impl Frame {
                     }
                     Bytecode::MoveToGeneric(si_idx) => {
                         let resource = interpreter.operand_stack.pop_as::<Struct>()?;
-                        let signer_reference = interpreter.operand_stack.pop_as::<Reference>()?;
-                        let addr = signer_reference.read_ref()?.value_as::<AccountAddress>()?;
+                        let signer_reference = interpreter.operand_stack.pop_as::<StructRef>()?;
+                        let addr = signer_reference
+                            .borrow_field(0)?
+                            .value_as::<Reference>()?
+                            .read_ref()?
+                            .value_as::<AccountAddress>()?;
                         let size = interpreter.global_data_op_generic(
                             resolver,
                             context,


### PR DESCRIPTION
##  Motivation

- Transaction scripts can now take &signer as the first argument
- If `&signer` is the first argument, it is manifested automatically in execute_script
  - This method of opting in to the `&signer` will let us slowly migrate older endpoints
  - It cannot be done on the LibraVM side as it does not know the script argument signature
  - Possibly even long term, this method of automatically populating might be the right story for singe sender transactions
- For multi sender transaction in the future, we will need some better story to populate these signers

For the runtime:
- I made `Signer` a sort of "native struct"
- Think of it as a specialized struct with a single field
- Thus to access the inner address you borrow field at index `0`

## Test Plan

- New tests
