### PR TITLE
[move] Value and Constant refactor

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -511,7 +511,6 @@ dependencies = [
  "libra-workspace-hack 0.1.0",
  "mirai-annotations 1.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "move-core-types 0.1.0",
- "move-vm-types 0.1.0",
  "petgraph 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "vm 0.1.0",
 ]
@@ -2017,7 +2016,6 @@ dependencies = [
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "move-core-types 0.1.0",
  "move-ir-types 0.1.0",
- "move-vm-types 0.1.0",
  "thiserror 1.0.18 (registry+https://github.com/rust-lang/crates.io-index)",
  "vm 0.1.0",
 ]
@@ -5078,7 +5076,6 @@ dependencies = [
  "move-core-types 0.1.0",
  "move-ir-types 0.1.0",
  "move-lang 0.0.1",
- "move-vm-types 0.1.0",
  "num 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "regex 1.3.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "test-utils 0.1.0",
@@ -5105,7 +5102,7 @@ dependencies = [
  "libra-temppath 0.1.0",
  "libra-types 0.1.0",
  "libra-workspace-hack 0.1.0",
- "move-vm-types 0.1.0",
+ "move-core-types 0.1.0",
  "num 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "spec-lang 0.0.1",
  "test-utils 0.1.0",

--- a/language/bytecode-verifier/Cargo.toml
+++ b/language/bytecode-verifier/Cargo.toml
@@ -19,7 +19,6 @@ vm = { path = "../vm", version = "0.1.0" }
 libra-types = { path = "../../types", version = "0.1.0" }
 libra-workspace-hack = { path = "../../common/workspace-hack", version = "0.1.0" }
 move-core-types = { path = "../move-core/types", version = "0.1.0" }
-move-vm-types = { path = "../move-vm/types", version = "0.1.0" }
 
 [dev-dependencies]
 invalid-mutations = { path = "invalid-mutations", version = "0.1.0" }

--- a/language/bytecode-verifier/src/constants.rs
+++ b/language/bytecode-verifier/src/constants.rs
@@ -5,7 +5,6 @@
 //! - a constant's type only refers to primitive types
 //! - a constant's data serializes correctly for that type
 use libra_types::vm_error::StatusCode;
-use move_vm_types::values::Value;
 use vm::{
     access::ModuleAccess,
     errors::{verification_error, VMResult},
@@ -53,7 +52,7 @@ impl<'a> ConstantsChecker<'a> {
     }
 
     pub fn verify_constant_data(&self, idx: usize, constant: &Constant) -> VMResult<()> {
-        match Value::deserialize_constant(constant) {
+        match constant.deserialize_constant() {
             Some(_) => Ok(()),
             None => Err(verification_error(
                 IndexKind::ConstantPool,

--- a/language/compiler/ir-to-bytecode/Cargo.toml
+++ b/language/compiler/ir-to-bytecode/Cargo.toml
@@ -16,7 +16,6 @@ libra-types = { path = "../../../types", version = "0.1.0" }
 libra-workspace-hack = { path = "../../../common/workspace-hack", version = "0.1.0" }
 move-core-types = { path = "../../move-core/types", version = "0.1.0" }
 move-ir-types = { path = "../../move-ir/types", version = "0.1.0" }
-move-vm-types = { path = "../../move-vm/types", version = "0.1.0" }
 vm = { path = "../../vm", version = "0.1.0" }
 bytecode-source-map = { path = "../bytecode-source-map", version = "0.1.0" }
 log = "0.4.7"

--- a/language/move-core/types/src/lib.rs
+++ b/language/move-core/types/src/lib.rs
@@ -14,3 +14,4 @@ pub mod proptest_types;
 pub mod transaction_argument;
 #[cfg(test)]
 mod unit_tests;
+pub mod value;

--- a/language/move-core/types/src/value.rs
+++ b/language/move-core/types/src/value.rs
@@ -48,6 +48,10 @@ impl MoveValue {
     pub fn simple_serialize(&self) -> Option<Vec<u8>> {
         lcs::to_bytes(self).ok()
     }
+
+    pub fn vector_u8(v: Vec<u8>) -> Self {
+        MoveValue::Vector(v.into_iter().map(MoveValue::U8).collect())
+    }
 }
 
 impl MoveStruct {

--- a/language/move-prover/spec-lang/Cargo.toml
+++ b/language/move-prover/spec-lang/Cargo.toml
@@ -15,7 +15,6 @@ libra-types = { path = "../../../types", version = "0.1.0" }
 libra-workspace-hack = { path = "../../../common/workspace-hack", version = "0.1.0" }
 bytecode-source-map = { path = "../../compiler/bytecode-source-map", version = "0.1.0" }
 move-ir-types = { path = "../../move-ir/types", version = "0.1.0" }
-move-vm-types = { path = "../../move-vm/types", version = "0.1.0" }
 move-core-types = { path = "../../move-core/types", version = "0.1.0" }
 
 # external dependencies

--- a/language/move-prover/spec-lang/src/env.rs
+++ b/language/move-prover/spec-lang/src/env.rs
@@ -18,8 +18,7 @@ use itertools::Itertools;
 use num::{BigUint, Num};
 
 use bytecode_source_map::source_map::SourceMap;
-use move_core_types::{account_address::AccountAddress, language_storage};
-use move_vm_types::values::Value as VMValue;
+use move_core_types::{account_address::AccountAddress, language_storage, value::MoveValue};
 use vm::{
     access::ModuleAccess,
     file_format::{
@@ -950,9 +949,9 @@ impl<'env> ModuleEnv<'env> {
     }
 
     /// Converts a constant to the specified type. The type must correspond to the expected
-    /// cannonical representation as defined in `move_vm_types::values`
-    pub fn get_constant_value(&self, constant: &VMConstant) -> VMValue {
-        VMValue::deserialize_constant(constant).unwrap()
+    /// cannonical representation as defined in `move_core_types::values`
+    pub fn get_constant_value(&self, constant: &VMConstant) -> MoveValue {
+        VMConstant::deserialize_constant(constant).unwrap()
     }
 
     /// Retrieve an address identifier from the pool

--- a/language/move-prover/stackless-bytecode-generator/Cargo.toml
+++ b/language/move-prover/stackless-bytecode-generator/Cargo.toml
@@ -19,7 +19,7 @@ libra-workspace-hack = { path = "../../../common/workspace-hack", version = "0.1
 num = "0.2.0"
 itertools = "0.9.0"
 libra-types = { path = "../../../types", version = "0.1.0" }
-move-vm-types = { path = "../../move-vm/types", version = "0.1.0" }
+move-core-types = { path = "../../move-core/types", version = "0.1.0" }
 
 [dev-dependencies]
 datatest-stable = { path = "../../../common/datatest-stable", version = "0.1.0" }

--- a/language/move-vm/types/src/values/value_prop_tests.rs
+++ b/language/move-vm/types/src/values/value_prop_tests.rs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::values::{prop::layout_and_value_strategy, Value};
-use move_core_types::value::{MoveTypeLayout, MoveValue};
+use move_core_types::value::MoveValue;
 use proptest::prelude::*;
 use std::convert::TryInto;
 

--- a/language/move-vm/types/src/values/value_prop_tests.rs
+++ b/language/move-vm/types/src/values/value_prop_tests.rs
@@ -2,7 +2,9 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::values::{prop::layout_and_value_strategy, Value};
+use move_core_types::value::{MoveTypeLayout, MoveValue};
 use proptest::prelude::*;
+use std::convert::TryInto;
 
 proptest! {
     #[test]
@@ -10,5 +12,14 @@ proptest! {
         let blob = value.simple_serialize(&layout).expect("must serialize");
         let value_deserialized = Value::simple_deserialize(&blob, &layout).expect("must deserialize");
         assert!(value.equals(&value_deserialized).unwrap());
+
+        let ty = (&layout).try_into().unwrap();
+        let move_value = value.as_move_value(&layout);
+
+        let blob2 = move_value.simple_serialize().expect("must serialize");
+        assert_eq!(blob, blob2);
+
+        let move_value_deserialized = MoveValue::simple_deserialize(&blob2, &ty).expect("must deserialize.");
+        assert_eq!(move_value, move_value_deserialized);
     }
 }

--- a/language/move-vm/types/src/values/values_impl.rs
+++ b/language/move-vm/types/src/values/values_impl.rs
@@ -2440,12 +2440,6 @@ impl Value {
         let ty = Self::constant_sig_token_to_type(&constant.type_)?;
         Value::simple_deserialize(&constant.data, &ty).ok()
     }
-
-    pub fn serialize_constant(type_: SignatureToken, value: Value) -> Option<Constant> {
-        let ty = Self::constant_sig_token_to_type(&type_)?;
-        let data = value.simple_serialize(&ty)?;
-        Some(Constant { data, type_ })
-    }
 }
 
 /***************************************************************************************

--- a/language/vm/src/constant.rs
+++ b/language/vm/src/constant.rs
@@ -1,0 +1,50 @@
+// Copyright (c) The Libra Core Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::file_format::{Constant, SignatureToken};
+
+use move_core_types::value::{MoveTypeLayout, MoveValue};
+
+fn sig_to_ty(sig: &SignatureToken) -> Option<MoveTypeLayout> {
+    match sig {
+        SignatureToken::Signer => Some(MoveTypeLayout::Signer),
+        SignatureToken::Address => Some(MoveTypeLayout::Address),
+        SignatureToken::Bool => Some(MoveTypeLayout::Bool),
+        SignatureToken::U8 => Some(MoveTypeLayout::U8),
+        SignatureToken::U64 => Some(MoveTypeLayout::U64),
+        SignatureToken::U128 => Some(MoveTypeLayout::U128),
+        SignatureToken::Vector(v) => Some(MoveTypeLayout::Vector(Box::new(sig_to_ty(v.as_ref())?))),
+        SignatureToken::Reference(_)
+        | SignatureToken::MutableReference(_)
+        | SignatureToken::Struct(_)
+        | SignatureToken::TypeParameter(_)
+        | SignatureToken::StructInstantiation(_, _) => None,
+    }
+}
+
+fn ty_to_sig(ty: &MoveTypeLayout) -> Option<SignatureToken> {
+    match ty {
+        MoveTypeLayout::Address => Some(SignatureToken::Address),
+        MoveTypeLayout::Signer => Some(SignatureToken::Signer),
+        MoveTypeLayout::U8 => Some(SignatureToken::U8),
+        MoveTypeLayout::U64 => Some(SignatureToken::U64),
+        MoveTypeLayout::U128 => Some(SignatureToken::U128),
+        MoveTypeLayout::Vector(v) => Some(SignatureToken::Vector(Box::new(ty_to_sig(v.as_ref())?))),
+        MoveTypeLayout::Struct(_) => None,
+        MoveTypeLayout::Bool => Some(SignatureToken::Bool),
+    }
+}
+
+impl Constant {
+    pub fn serialize_constant(ty: &MoveTypeLayout, v: &MoveValue) -> Option<Self> {
+        Some(Self {
+            type_: ty_to_sig(ty)?,
+            data: v.simple_serialize()?,
+        })
+    }
+
+    pub fn deserialize_constant(&self) -> Option<MoveValue> {
+        let ty = sig_to_ty(&self.type_)?;
+        MoveValue::simple_deserialize(&self.data, &ty).ok()
+    }
+}

--- a/language/vm/src/lib.rs
+++ b/language/vm/src/lib.rs
@@ -12,6 +12,7 @@ pub mod access;
 pub mod check_bounds;
 #[macro_use]
 pub mod errors;
+pub mod constant;
 pub mod deserializer;
 pub mod file_format;
 pub mod file_format_common;


### PR DESCRIPTION
<!--
Thank you for sending a PR. We appreciate you spending time to help improve the Libra project.

The project is undergoing daily changes. Pull Requests will be reviewed and responded to as time permits.
-->

## Motivation

Refactored MoveValue into `move_core_types` and cleaned up the constants used in `bytecode-verifier`, `compiler` and `move-prover`. This allows us to get rid of the `move-vm` dependency in crates mentioned above.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?

Yes
