### PR TITLE
[move-prover] Documentation generator.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1243,6 +1243,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "docgen"
+version = "0.1.0"
+dependencies = [
+ "anyhow 1.0.31 (registry+https://github.com/rust-lang/crates.io-index)",
+ "codespan 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "codespan-reporting 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "datatest-stable 0.1.0",
+ "itertools 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libra-temppath 0.1.0",
+ "libra-workspace-hack 0.1.0",
+ "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "move-prover 0.1.0",
+ "num 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "regex 1.3.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.110 (registry+https://github.com/rust-lang/crates.io-index)",
+ "spec-lang 0.1.0",
+ "stackless-bytecode-generator 0.1.0",
+ "test-utils 0.1.0",
+]
+
+[[package]]
 name = "dtoa"
 version = "0.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3279,6 +3300,7 @@ dependencies = [
  "codespan 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "codespan-reporting 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "datatest-stable 0.1.0",
+ "docgen 0.1.0",
  "handlebars 3.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "itertools 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "libra-temppath 0.1.0",
@@ -3292,7 +3314,7 @@ dependencies = [
  "regex 1.3.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.110 (registry+https://github.com/rust-lang/crates.io-index)",
  "simplelog 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "spec-lang 0.0.1",
+ "spec-lang 0.1.0",
  "stackless-bytecode-generator 0.1.0",
  "test-utils 0.1.0",
  "vm 0.1.0",
@@ -5063,7 +5085,7 @@ dependencies = [
 
 [[package]]
 name = "spec-lang"
-version = "0.0.1"
+version = "0.1.0"
 dependencies = [
  "anyhow 1.0.31 (registry+https://github.com/rust-lang/crates.io-index)",
  "bytecode-source-map 0.1.0",
@@ -5107,7 +5129,7 @@ dependencies = [
  "libra-workspace-hack 0.1.0",
  "move-vm-types 0.1.0",
  "num 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "spec-lang 0.0.1",
+ "spec-lang 0.1.0",
  "test-utils 0.1.0",
  "vm 0.1.0",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -66,6 +66,7 @@ members = [
     "language/move-ir/types",
     "language/move-lang",
     "language/move-prover",
+    "language/move-prover/docgen",
     "language/move-prover/spec-lang",
     "language/move-prover/stackless-bytecode-generator",
     "language/move-prover/test-utils",

--- a/language/move-prover/Cargo.toml
+++ b/language/move-prover/Cargo.toml
@@ -9,7 +9,8 @@ license = "Apache-2.0"
 [dependencies]
 # libra dependencies
 move-lang = { path = "../move-lang", version = "0.0.1" }
-spec-lang = { path = "spec-lang", version = "0.0.1" }
+spec-lang = { path = "spec-lang", version = "0.1.0" }
+docgen = { path = "docgen", version = "0.1.0" }
 stackless-bytecode-generator = { path = "stackless-bytecode-generator", version = "0.1.0"}
 vm = { path = "../vm", version = "0.1.0" }
 libra-types = { path = "../../types", version = "0.1.0" }

--- a/language/move-prover/docgen/Cargo.toml
+++ b/language/move-prover/docgen/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "spec-lang"
+name = "docgen"
 version = "0.1.0"
 authors = ["Libra Association <opensource@libra.org>"]
 publish = false
@@ -8,15 +8,9 @@ license = "Apache-2.0"
 
 [dependencies]
 # libra dependencies
-move-lang = { path = "../../move-lang", version = "0.0.1" }
-bytecode-verifier = { path = "../../bytecode-verifier", version = "0.1.0" }
-vm = { path = "../../vm", version = "0.1.0" }
-libra-types = { path = "../../../types", version = "0.1.0" }
+spec-lang = { path = "../spec-lang", version = "0.1.0" }
+stackless-bytecode-generator = { path = "../stackless-bytecode-generator", version = "0.1.0"}
 libra-workspace-hack = { path = "../../../common/workspace-hack", version = "0.1.0" }
-bytecode-source-map = { path = "../../compiler/bytecode-source-map", version = "0.1.0" }
-move-ir-types = { path = "../../move-ir/types", version = "0.1.0" }
-move-vm-types = { path = "../../move-vm/types", version = "0.1.0" }
-move-core-types = { path = "../../move-core/types", version = "0.1.0" }
 
 # external dependencies
 codespan = "0.8.0"
@@ -26,10 +20,13 @@ log = "0.4.8"
 num = "0.2.0"
 regex = "1.3.7"
 anyhow = "1.0.*"
+serde = { version = "1.0.110", features = ["derive"] }
 
 [dev-dependencies]
+move-prover = { path = "..", version = "0.1.0" }
 datatest-stable = { path = "../../../common/datatest-stable", version = "0.1.0" }
 test-utils = { path = "../test-utils", version = "0.1.0" }
+libra-temppath = { path = "../../../common/temppath", version = "0.1.0" }
 
 [[test]]
 name = "testsuite"

--- a/language/move-prover/docgen/README.md
+++ b/language/move-prover/docgen/README.md
@@ -1,0 +1,195 @@
+
+# Documentation Generator
+
+This crate provides a simple documentation generator for Move including Move specifications. The documentation
+generator is embedded in the Move Prover. This is not only for technical reasons but also because eventually,
+we want to use the Prover to derive information for docs using formal reasoning, as well as mark verification
+results in the generated docs.
+
+For an example of generated docs, see e.g. [the baseline test here](tests/sources/libra.spec_inline.md).
+
+## Calling the Generator
+
+The generator is called from within the libra tree as such:
+
+```shell script
+> cargo run -p move-prover -- --docgen <flags> .. <sources>
+```
+
+... where most commonly used flags are:
+
+-  `-s=<path>`: search path for dependencies.
+-  `--doc-spec-inline=true|false`: whether specs should be included together with function declarations or in
+    a separate section at the end of the document. Default is true.
+-  `--doc-include-impl=true|false`: whether function implementation bodies shall be included. Default is true.
+-  `--doc-include-private=true|false`: whether private functions shall be included. Default is false.
+-  `--output=<path>`: file where to store generated markdown.
+
+For full command line help, use `cargo run -p move-prover -- --help`.
+
+## Guide for Documentation Writers
+
+### Documentation Comments
+
+Documentation comments in the Move source start either with `///` or `/**`. Like in many similar other tools,
+documentation comments must be placed before the item being documented. Currently, the following items in the
+Move source can have documentation comments:
+
+-  Modules
+-  Structs
+-  Struct fields
+-  Functions
+-  Spec blocks
+-  Individual spec block members
+
+A series of comments in front of one item is collapsed into on documentation block. For example, the following
+fragments are all equivalent and associate documentation with function `f`:
+
+```move
+struct T {}
+/// This is a line
+
+/// This is another line
+fun f() { ... }
+```
+
+```move
+struct T {}
+/// This is a line
+/// This is another line
+fun f() { ... }
+```
+
+```move
+struct T {}
+/// This is a line
+/** This is another line */
+fun f() { ... }
+```
+
+```move
+struct T {}
+/**
+This is a line
+This is another line
+*/
+fun f() { ... }
+```
+
+### Markdown in Comments
+
+Documentation comments can use arbitrary markdown (we recommend to use a Markdown flavor which is compatible with
+Github). One can also use section headers in documentation comments; those headers are placed one level underneath
+the context in which they are included in the overall doc. For example:
+
+```move
+/// This is the Libra account module
+///
+/// # Overview
+///
+/// This module does fancy things!
+///
+/// # Details
+///
+/// The following details need to be considered:
+/// ...
+module LibraAccount {
+   ...
+}
+```
+
+If the module documentation is included in a larger context, the section tags will be adjusted in the generated
+doc:
+
+```move
+# Module `0x0::LibraAccount`
+
+This is the Libra account module.
+
+## Overview
+...
+
+## Details
+...
+```
+
+### Code Decoration
+
+Code (either in single back-quotes inline of the markdown text, or code which is produced by the generator itself) is
+decorated as follows:
+
+-  Keywords are highlighted. Note since specifically the Move spec language has a number of "weak" keywords (identifiers
+   which play a special role in a particular syntactic context but are not reserved), highlighting may have some false
+   positives, as the generator does not analyze the syntax right now.
+
+-  Identifiers are attempted to resolve against the documented code and on success, hyperlinked to the declaration.
+   For example, within the `LibraAccount` module, all occurences of `T`, `Self::T`, `LibraAccount::T`, and
+   `0x0::LibraAccount:T` will resolve into a link to the declaration. This resolution is heuristic and may have
+   positive and negative false positives. Specifically, it currently does not consider aliases and use-declarations.
+
+   If you use a simple name in code comments. like `foo`, it will not resolve against a function `foo` in the current
+   module unless it is either followed by `(` or `<`. This to avoid false positives of matching functions. You can
+   use `foo()` or `Self::foo` instead.
+
+### Organization of Specification Blocks
+
+Specification blocks can be placed anywhere in the Move source, which creates a certain challenge to place them
+in the appropriate place in the documentation. This specifically applies to schema and module spec blocks, which
+have no specified target like a function or struct spec block.
+
+The documentation generator associates all schema and module spec blocks with any **preceding** function or struct
+spec block, or, if no previous one exists, with the module. Example:
+
+```move
+module M {
+    spec module {
+        // Associated with the module.
+    }
+    spec schema Some {
+        // Associated with module.
+    }
+    struct S { .. }
+    spec schema Other {
+        // Gotcha! Still associated with module, as there is no struct spec block before.
+    }
+    spec struct S {
+        // Associated with S because of named spec block target. Notice that this can be in fact anywhere in
+        // the file (before declaration of S, at the end of the file, etc.).
+    }
+    spec schema YetAnother {
+        // Associated with S because of preceding spec block.
+    }
+    spec module {
+        // Associated with S because of preceding spec block.
+    }
+    fun f() { ... }
+    spec schema FAbortsIf {
+        // Gotcha! The last explicitly targeted spec block was for S, not for f, so this will go with S.
+    }
+    spec fun f {
+        // Associated with f because of named spec block target.
+    }
+    spec schema FEnsures {
+        // Associated with f because of preceding spec block.
+    }
+}
+```
+
+Notice that one can enforce an association of subsequent spec blocks by introducing a dummy, empty spec block.
+Because such blocks don't declare properties, they are not appearing in the generated docs:
+
+```move
+module M {
+    fn f() { ... }
+    spec fun f {
+        // I wan't the next spec blocks go with f!
+    }
+    spec schema S {
+        // Goes with f
+    }
+    spec fun f {
+        // I prefer bottom up organization of my specs, so this goes last.
+        include S;
+    }
+}
+```

--- a/language/move-prover/docgen/README.md
+++ b/language/move-prover/docgen/README.md
@@ -47,31 +47,31 @@ fragments are all equivalent and associate documentation with function `f`:
 
 ```move
 struct T {}
-/// This is a line
+/// This is a documentation comment for `f`.
 
-/// This is another line
+/// This is another documentation comment for `f`.
 fun f() { ... }
 ```
 
 ```move
 struct T {}
-/// This is a line
-/// This is another line
+/// This is a documentation comment for `f`.
+/// This is another documentation comment for `f`.
 fun f() { ... }
 ```
 
 ```move
 struct T {}
-/// This is a line
-/** This is another line */
+/// This is a documentation comment for `f`.
+/** This is another documentation comment for `f`. */
 fun f() { ... }
 ```
 
 ```move
 struct T {}
 /**
-This is a line
-This is another line
+This is a documentation comment for `f`.
+This is another documentation comment for `f`.
 */
 fun f() { ... }
 ```
@@ -176,7 +176,7 @@ module M {
 ```
 
 Notice that one can enforce an association of subsequent spec blocks by introducing a dummy, empty spec block.
-Because such blocks don't declare properties, they are not appearing in the generated docs:
+Because such blocks don't declare properties, they do not appear in the generated docs:
 
 ```move
 module M {

--- a/language/move-prover/docgen/src/docgen.rs
+++ b/language/move-prover/docgen/src/docgen.rs
@@ -30,10 +30,8 @@ const KEYWORDS: &[&str] = &[
     "continue",
     "copy",
     "copyable",
-    "",
     "else",
     "false",
-    "fun",
     "if",
     "invariant",
     "let",
@@ -49,6 +47,8 @@ const KEYWORDS: &[&str] = &[
     "true",
     "use",
     "while",
+    "fun",
+    "script",
 ];
 
 const WEAK_KEYWORDS: &[&str] = &[
@@ -86,7 +86,7 @@ pub struct DocgenOptions {
     pub specs_inlined: bool,
     /// Whether to include Move implementations.
     pub include_impl: bool,
-    /// Max depth of entries in table-of-contents
+    /// Max depth to which sections are displayed in table-of-contents.
     pub toc_depth: usize,
     /// Whether to use collapsed sections (<details>) for impl and specs
     pub collapsed_sections: bool,
@@ -114,7 +114,7 @@ pub struct Docgen<'env> {
     toc: RefCell<VecDeque<Vec<TocEntry>>>,
 }
 
-/// A table-of-content entry.
+/// A table-of-contents entry.
 #[derive(Debug, Default)]
 struct TocEntry {
     label: String,
@@ -148,7 +148,7 @@ impl<'env> Docgen<'env> {
     pub fn gen(&mut self) {
         emitln!(
             self.writer,
-            "{} Table of Content",
+            "{} Table of Contents",
             self.repeat_str("#", self.options.section_level_start + 1)
         );
         let toc_label = self.writer.create_label();
@@ -437,7 +437,7 @@ impl<'env> Docgen<'env> {
                 block.target,
                 SpecBlockTarget::Schema(..) | SpecBlockTarget::Module
             ) {
-                // Switch target if its not a schema or module. Those will be associated with
+                // Switch target if it's not a schema or module. Those will be associated with
                 // the last target.
                 current_target = block.target.clone();
             }

--- a/language/move-prover/docgen/src/docgen.rs
+++ b/language/move-prover/docgen/src/docgen.rs
@@ -1,0 +1,930 @@
+// Copyright (c) The Libra Core Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+#[allow(unused_imports)]
+use log::{info, warn};
+
+use itertools::Itertools;
+use num::BigUint;
+use regex::Regex;
+use serde::Serialize;
+use spec_lang::{
+    ast::{ModuleName, SpecBlockInfo, SpecBlockTarget},
+    code_writer::CodeWriter,
+    emit, emitln,
+    env::{FunctionEnv, GlobalEnv, ModuleEnv, Parameter, StructEnv, TypeConstraint, TypeParameter},
+    symbol::Symbol,
+    ty::TypeDisplayContext,
+};
+use std::{
+    cell::RefCell,
+    collections::{BTreeMap, VecDeque},
+    rc::Rc,
+};
+
+const KEYWORDS: &[&str] = &[
+    "abort",
+    "acquires",
+    "as",
+    "break",
+    "continue",
+    "copy",
+    "copyable",
+    "",
+    "else",
+    "false",
+    "fun",
+    "if",
+    "invariant",
+    "let",
+    "loop",
+    "module",
+    "move",
+    "native",
+    "public",
+    "resource",
+    "return",
+    "spec",
+    "struct",
+    "true",
+    "use",
+    "while",
+];
+
+const WEAK_KEYWORDS: &[&str] = &[
+    "apply",
+    "assert",
+    "assume",
+    "decreases",
+    "aborts_if",
+    "ensures",
+    "requires",
+    "pack",
+    "unpack",
+    "update",
+    "to",
+    "schema",
+    "include",
+    "old",
+    "except",
+    "global",
+    "mut",
+];
+
+/// Options passed into the documentation generator.
+#[derive(Debug, Clone, Serialize)]
+pub struct DocgenOptions {
+    /// The level where we start sectioning. Often markdown sections are rendered with
+    /// unnecessary large section fonts, setting this value high reduces the size.
+    pub section_level_start: usize,
+    /// Whether to include private functions in the generated docs.
+    pub include_private_fun: bool,
+    /// Whether to include specifications in the generated docs.
+    pub include_specs: bool,
+    /// Whether to put specifications in the same section as a declaration or put them all
+    /// into an independent section.
+    pub specs_inlined: bool,
+    /// Whether to include Move implementations.
+    pub include_impl: bool,
+    /// Max depth of entries in table-of-contents
+    pub toc_depth: usize,
+    /// Whether to use collapsed sections (<details>) for impl and specs
+    pub collapsed_sections: bool,
+}
+
+impl Default for DocgenOptions {
+    fn default() -> Self {
+        Self {
+            section_level_start: 1,
+            include_private_fun: false,
+            include_specs: true,
+            specs_inlined: true,
+            include_impl: true,
+            toc_depth: 3,
+            collapsed_sections: true,
+        }
+    }
+}
+
+/// The documentation generator.
+pub struct Docgen<'env> {
+    env: &'env GlobalEnv,
+    options: &'env DocgenOptions,
+    writer: CodeWriter,
+    toc: RefCell<VecDeque<Vec<TocEntry>>>,
+}
+
+/// A table-of-content entry.
+#[derive(Debug, Default)]
+struct TocEntry {
+    label: String,
+    title: String,
+    sub_entries: Vec<TocEntry>,
+}
+
+/// A map from spec block targets to associated spec blocks.
+type SpecBlockMap<'a> = BTreeMap<SpecBlockTarget, Vec<&'a SpecBlockInfo>>;
+
+impl<'env> Docgen<'env> {
+    /// Creates a new documentation generator.
+    pub fn new(env: &'env GlobalEnv, options: &'env DocgenOptions) -> Self {
+        let mut toc = VecDeque::new();
+        toc.push_back(Vec::new());
+        Self {
+            env,
+            options,
+            writer: CodeWriter::new(env.unknown_loc()),
+            toc: RefCell::new(toc),
+        }
+    }
+
+    /// Returns the code writer of this generator, consuming it.
+    pub fn into_code_writer(self) -> CodeWriter {
+        self.writer
+    }
+
+    /// Generate documentation for all modules in the environment which are not in the dependency
+    /// set.
+    pub fn gen(&mut self) {
+        emitln!(
+            self.writer,
+            "{} Table of Content",
+            self.repeat_str("#", self.options.section_level_start + 1)
+        );
+        let toc_label = self.writer.create_label();
+        for m in self.env.get_modules() {
+            if !m.is_in_dependency() {
+                self.gen_module(&m);
+            }
+        }
+
+        // Generate table of contents. We put this into a separate code writer which we then
+        // merge into the main one.
+        let mut toc_writer = CodeWriter::new(self.env.unknown_loc());
+        let writer = std::mem::replace(&mut self.writer, toc_writer);
+        let toc = self.toc.borrow();
+        assert_eq!(toc.len(), 1, "unbalanced sectioning");
+        self.begin_items();
+        for entry in toc.front().unwrap() {
+            self.gen_toc(entry, 1);
+        }
+        self.end_items();
+        toc_writer = std::mem::replace(&mut self.writer, writer);
+        toc_writer.process_result(|s| self.writer.insert_at_label(toc_label, s));
+    }
+
+    /// Generates a toc-entry, recursively.
+    fn gen_toc(&self, entry: &TocEntry, depth: usize) {
+        if depth > self.options.toc_depth {
+            return;
+        }
+        self.item_text(None, &format!("[{}](#{})", entry.title, entry.label));
+        if !entry.sub_entries.is_empty() {
+            self.writer.indent();
+            self.begin_items();
+            for sub_entry in &entry.sub_entries {
+                self.gen_toc(sub_entry, depth + 1);
+            }
+            self.end_items();
+            self.writer.unindent();
+        }
+    }
+
+    /// Generates documentation for a module.
+    fn gen_module(&self, module_env: &ModuleEnv<'_>) {
+        let module_name = format!(
+            "{}",
+            module_env.get_name().display_full(module_env.symbol_pool())
+        );
+        self.section_header(
+            &format!("Module `{}`", module_name),
+            &self.label_for_module(module_env),
+        );
+        self.increment_section_nest();
+        self.doc_text(module_env, module_env.get_doc());
+
+        let spec_block_map = self.organize_spec_blocks(module_env);
+
+        if self.options.specs_inlined {
+            self.gen_spec_blocks(module_env, "", &SpecBlockTarget::Module, &spec_block_map);
+        }
+
+        if !module_env.get_structs().count() > 0 {
+            for s in module_env
+                .get_structs()
+                .sorted_by(|a, b| Ord::cmp(&a.get_loc(), &b.get_loc()))
+            {
+                self.gen_struct(&spec_block_map, &s);
+            }
+        }
+
+        let funs = module_env
+            .get_functions()
+            .filter(|f| self.options.include_private_fun || f.is_public())
+            .sorted_by(|a, b| Ord::cmp(&a.get_loc(), &b.get_loc()))
+            .collect_vec();
+        if !funs.is_empty() {
+            for f in funs {
+                self.gen_function(&spec_block_map, &f);
+            }
+        }
+
+        if !self.options.specs_inlined {
+            self.gen_spec_section(module_env, &spec_block_map);
+        }
+        self.decrement_section_nest();
+    }
+
+    /// Generates documentation for a struct.
+    fn gen_struct(&self, spec_block_map: &SpecBlockMap<'_>, struct_env: &StructEnv<'_>) {
+        let name = self.name_string(struct_env.get_name());
+        self.section_header(&format!("Struct `{}`", name), name.as_str());
+        self.increment_section_nest();
+        self.doc_text(&struct_env.module_env, struct_env.get_doc());
+        self.code_block(
+            &struct_env.module_env,
+            &self.struct_header_display(struct_env),
+        );
+
+        if self.options.include_impl || (self.options.include_specs && self.options.specs_inlined) {
+            // Include field documentation if either impls or specs are present and inlined,
+            // because they are used by both.
+            self.begin_collapsed("Fields");
+            self.gen_struct_fields(struct_env);
+            self.end_collapsed();
+        }
+
+        if self.options.specs_inlined {
+            self.gen_spec_blocks(
+                &struct_env.module_env,
+                "Specification",
+                &SpecBlockTarget::Struct(struct_env.module_env.get_id(), struct_env.get_id()),
+                spec_block_map,
+            );
+        }
+        self.decrement_section_nest();
+    }
+
+    /// Generates code signature for a struct.
+    fn struct_header_display(&self, struct_env: &StructEnv<'_>) -> String {
+        let name = self.name_string(struct_env.get_name());
+        let kind = if struct_env.is_resource() {
+            "resource struct"
+        } else {
+            "struct"
+        };
+        format!(
+            "{} {}{}",
+            kind,
+            name,
+            self.type_parameter_list_display(&struct_env.get_named_type_parameters()),
+        )
+    }
+
+    fn gen_struct_fields(&self, struct_env: &StructEnv<'_>) {
+        let tctx = self.type_display_context_for_struct(struct_env);
+        self.begin_definitions();
+        for field in struct_env.get_fields() {
+            self.definition_text(
+                Some(&struct_env.module_env),
+                &format!(
+                    "`{}: {}`",
+                    self.name_string(field.get_name()),
+                    field.get_type().display(&tctx)
+                ),
+                field.get_doc(),
+            );
+        }
+        self.end_definitions();
+    }
+
+    /// Generates documentation for a function.
+    fn gen_function(&self, spec_block_map: &SpecBlockMap<'_>, func_env: &FunctionEnv<'_>) {
+        let name = self.name_string(func_env.get_name());
+        self.section_header(&format!("Function `{}`", name), name.as_str());
+        self.increment_section_nest();
+        self.doc_text(&func_env.module_env, func_env.get_doc());
+        let sig = self.function_header_display(func_env);
+        self.code_block(&func_env.module_env, &sig);
+        if self.options.specs_inlined {
+            self.gen_spec_blocks(
+                &func_env.module_env,
+                "Specification",
+                &SpecBlockTarget::Function(func_env.module_env.get_id(), func_env.get_id()),
+                spec_block_map,
+            )
+        }
+        if self.options.include_impl {
+            self.begin_collapsed("Implementation");
+            let source = match self.env.get_source(&func_env.get_loc()) {
+                Ok(s) => s,
+                Err(_) => "<source unavailable>",
+            };
+            self.code_block(&func_env.module_env, &self.fix_indent(source));
+            self.end_collapsed();
+        }
+        self.decrement_section_nest();
+    }
+
+    /// Generates documentation for a function signature.
+    fn function_header_display(&self, func_env: &FunctionEnv<'_>) -> String {
+        let name = self.name_string(func_env.get_name());
+        let visibility = if func_env.is_public() { "public " } else { "" };
+        let tctx = &self.type_display_context_for_fun(&func_env);
+        let params = func_env
+            .get_parameters()
+            .iter()
+            .map(|Parameter(name, ty)| format!("{}: {}", self.name_string(*name), ty.display(tctx)))
+            .join(", ");
+        let return_types = func_env.get_return_types();
+        let return_str = match return_types.len() {
+            0 => "".to_owned(),
+            1 => format!(": {}", return_types[0].display(tctx)),
+            _ => format!(
+                ": ({})",
+                return_types.iter().map(|ty| ty.display(tctx)).join(", ")
+            ),
+        };
+        format!(
+            "{}fun {}{}({}){}",
+            visibility,
+            name,
+            self.type_parameter_list_display(&func_env.get_named_type_parameters()),
+            params,
+            return_str
+        )
+    }
+
+    /// Generates documentation for a series of spec blocks associated with spec block target.
+    fn gen_spec_blocks(
+        &self,
+        module_env: &ModuleEnv<'_>,
+        title: &str,
+        target: &SpecBlockTarget,
+        spec_block_map: &SpecBlockMap,
+    ) {
+        let no_blocks = &vec![];
+        let blocks = spec_block_map.get(target).unwrap_or(no_blocks);
+        if blocks.is_empty() || !self.options.include_specs {
+            return;
+        }
+        if !title.is_empty() {
+            self.begin_collapsed(title);
+        }
+        for block in blocks {
+            self.doc_text(module_env, self.env.get_doc(&block.loc));
+            let mut in_code = false;
+            let (is_schema, schema_header) =
+                if let SpecBlockTarget::Schema(_, sid, type_params) = &block.target {
+                    (
+                        true,
+                        format!(
+                            "schema {}{} {{",
+                            self.name_string(sid.symbol()),
+                            self.type_parameter_list_display(type_params)
+                        ),
+                    )
+                } else {
+                    (false, "".to_owned())
+                };
+            let begin_code = |in_code: &mut bool| {
+                if !*in_code {
+                    self.begin_code();
+                    if is_schema {
+                        self.code_text(module_env, &schema_header);
+                        self.writer.indent();
+                    }
+                    *in_code = true;
+                }
+            };
+            let end_code = |in_code: &mut bool| {
+                if *in_code {
+                    if is_schema {
+                        self.writer.unindent();
+                        self.code_text(module_env, "}");
+                    }
+                    self.end_code();
+                    *in_code = false;
+                }
+            };
+            for loc in &block.member_locs {
+                let doc = self.env.get_doc(loc);
+                if !doc.is_empty() {
+                    end_code(&mut in_code);
+                    self.doc_text(module_env, doc);
+                }
+                let member_source = match self.env.get_source(loc) {
+                    Ok(s) => s,
+                    Err(_) => "<unknown source>",
+                };
+                begin_code(&mut in_code);
+                self.code_text(module_env, member_source);
+            }
+            end_code(&mut in_code);
+        }
+        if !title.is_empty() {
+            self.end_collapsed();
+        }
+    }
+
+    /// Organizes spec blocks in the module such that free items like schemas and module blocks
+    /// are associated with the context they appear in.
+    fn organize_spec_blocks(&self, module_env: &'env ModuleEnv<'env>) -> SpecBlockMap<'env> {
+        let mut result = BTreeMap::new();
+        let mut current_target = SpecBlockTarget::Module;
+        for block in module_env.get_spec_block_infos() {
+            if !matches!(
+                block.target,
+                SpecBlockTarget::Schema(..) | SpecBlockTarget::Module
+            ) {
+                // Switch target if its not a schema or module. Those will be associated with
+                // the last target.
+                current_target = block.target.clone();
+            }
+            result
+                .entry(current_target.clone())
+                .or_insert_with(Vec::new)
+                .push(block);
+        }
+        result
+    }
+
+    /// Generates standalone spec section. This is used if `options.specs_inlined` is false.
+    fn gen_spec_section(&self, module_env: &ModuleEnv<'_>, spec_block_map: &SpecBlockMap<'_>) {
+        if spec_block_map.is_empty() || !self.options.include_specs {
+            return;
+        }
+        self.section_header("Specification", "Specification");
+        self.increment_section_nest();
+        self.gen_spec_blocks(module_env, "", &SpecBlockTarget::Module, spec_block_map);
+        for struct_env in module_env
+            .get_structs()
+            .sorted_by(|a, b| Ord::cmp(&a.get_loc(), &b.get_loc()))
+        {
+            let target =
+                SpecBlockTarget::Struct(struct_env.module_env.get_id(), struct_env.get_id());
+            if spec_block_map.contains_key(&target) {
+                let name = self.name_string(struct_env.get_name());
+                self.section_header(&format!("Struct `{}`", name), name.as_str());
+                self.code_block(module_env, &self.struct_header_display(&struct_env));
+                self.gen_struct_fields(&struct_env);
+                self.gen_spec_blocks(module_env, "", &target, spec_block_map);
+            }
+        }
+        for func_env in module_env
+            .get_functions()
+            .sorted_by(|a, b| Ord::cmp(&a.get_loc(), &b.get_loc()))
+        {
+            let target = SpecBlockTarget::Function(func_env.module_env.get_id(), func_env.get_id());
+            if spec_block_map.contains_key(&target) {
+                let name = self.name_string(func_env.get_name());
+                self.section_header(&format!("Function `{}`", name), name.as_str());
+                self.code_block(
+                    &func_env.module_env,
+                    &self.function_header_display(&func_env),
+                );
+                self.gen_spec_blocks(module_env, "", &target, spec_block_map);
+            }
+        }
+        self.decrement_section_nest();
+    }
+
+    // ============================================================================================
+    // Helpers
+
+    /// Returns a string for a name symbol.
+    fn name_string(&self, name: Symbol) -> Rc<String> {
+        self.env.symbol_pool().string(name)
+    }
+
+    /// Creates a type display context for a function.
+    fn type_display_context_for_fun(&self, func_env: &FunctionEnv<'_>) -> TypeDisplayContext<'_> {
+        let type_param_names = Some(
+            func_env
+                .get_named_type_parameters()
+                .iter()
+                .map(|TypeParameter(name, _)| *name)
+                .collect_vec(),
+        );
+        TypeDisplayContext::WithEnv {
+            env: self.env,
+            type_param_names,
+        }
+    }
+
+    /// Creates a type display context for a struct.
+    fn type_display_context_for_struct(
+        &self,
+        struct_env: &StructEnv<'_>,
+    ) -> TypeDisplayContext<'_> {
+        let type_param_names = Some(
+            struct_env
+                .get_named_type_parameters()
+                .iter()
+                .map(|TypeParameter(name, _)| *name)
+                .collect_vec(),
+        );
+        TypeDisplayContext::WithEnv {
+            env: self.env,
+            type_param_names,
+        }
+    }
+
+    /// Increments section nest.
+    fn increment_section_nest(&self) {
+        self.toc.borrow_mut().push_back(Vec::new());
+    }
+
+    /// Decrements section nest, committing sub-sections to the table-of-contents map.
+    fn decrement_section_nest(&self) {
+        let mut toc = self.toc.borrow_mut();
+        let sub_sections = toc.pop_back().expect("unbalanced sections");
+        if !sub_sections.is_empty() {
+            let entry = toc
+                .back_mut()
+                .expect("balanced section nest")
+                .last_mut()
+                .expect("linear sectioning");
+            entry.sub_entries = sub_sections;
+        }
+    }
+
+    /// Creates a new section header and inserts a table-of-contents entry into the generator.
+    fn section_header(&self, s: &str, relative_label: &str) {
+        let level = self.toc.borrow().len();
+        let parent_label = if level > 1 {
+            self.toc.borrow()[level - 2]
+                .last()
+                .map(|entry| entry.label.to_string())
+        } else {
+            None
+        };
+        let qualified_label = if let Some(l) = parent_label {
+            format!("{}_{}", l, relative_label)
+        } else {
+            relative_label.to_string()
+        };
+        emitln!(self.writer);
+        emitln!(self.writer, "<a name=\"{}\"></a>", qualified_label);
+        emitln!(self.writer);
+        emitln!(
+            self.writer,
+            "{} {}",
+            self.repeat_str(
+                "#",
+                self.options.section_level_start + self.toc.borrow().len()
+            ),
+            s,
+        );
+        emitln!(self.writer);
+        let entry = TocEntry {
+            title: s.to_owned(),
+            label: qualified_label,
+            sub_entries: vec![],
+        };
+        self.toc
+            .borrow_mut()
+            .back_mut()
+            .expect("linear sectioning")
+            .push(entry);
+    }
+
+    /// Begins a collapsed section.
+    fn begin_collapsed(&self, summary: &str) {
+        if self.options.collapsed_sections {
+            emitln!(self.writer);
+            emitln!(self.writer, "<details>");
+            emitln!(self.writer, "<summary>{}</summary>", summary);
+            emitln!(self.writer);
+        } else {
+            emitln!(self.writer);
+            emitln!(self.writer, "##### {}", summary);
+            emitln!(self.writer);
+        }
+    }
+
+    /// Ends a collapsed section.
+    fn end_collapsed(&self) {
+        if self.options.collapsed_sections {
+            emitln!(self.writer);
+            emitln!(self.writer, "</details>");
+        }
+    }
+
+    /// Outputs documentation text.
+    fn doc_text(&self, module_env: &ModuleEnv<'_>, text: &str) {
+        for line in self.decorate_text(module_env, text).lines() {
+            let line = line.trim();
+            if line.starts_with('#') {
+                // Add current section level
+                emitln!(
+                    self.writer,
+                    "{}{}",
+                    self.repeat_str(
+                        "#",
+                        self.options.section_level_start + self.toc.borrow().len() - 1
+                    ),
+                    line
+                );
+            } else {
+                emitln!(self.writer, line)
+            }
+        }
+        // Always be sure to have an empty line at the end of block.
+        emitln!(self.writer);
+    }
+
+    /// Decorates documentation text, identifying code fragments and decorating them
+    /// as code.
+    fn decorate_text(&self, module_env: &ModuleEnv<'_>, text: &str) -> String {
+        let rex = Regex::new(r"(?m)`[^`]+`").unwrap();
+        let mut r = String::new();
+        let mut at = 0;
+        while let Some(m) = rex.find(&text[at..]) {
+            r += &text[at..at + m.start()];
+            // If the current text does not start on a newline, we need to add one.
+            // Some markdown processors won't recognize a <code> if its not on a new
+            // line. However, if we insert a blank line, we get a paragraph break, so we
+            // need to avoid this.
+            if !r.trim_end_matches(' ').ends_with('\n') {
+                r += "\n";
+            }
+            r += &format!(
+                "<code>{}</code>",
+                &self.decorate_code(module_env, &m.as_str()[1..&m.as_str().len() - 1])
+            );
+            at += m.end();
+        }
+        r += &text[at..];
+        r
+    }
+
+    /// Begins a code block. This uses html, not markdown code blocks, so we are able to
+    /// insert style and links into the code.
+    fn begin_code(&self) {
+        emitln!(self.writer);
+        // If we newline after <pre><code>, an empty line will be created. So we don't.
+        // This, however, creates some ugliness with indented code.
+        emit!(self.writer, "<pre><code>");
+    }
+
+    /// Ends a code block.
+    fn end_code(&self) {
+        emitln!(self.writer, "</code></pre>\n");
+        // Always be sure to have an empty line at the end of block.
+        emitln!(self.writer);
+    }
+
+    /// Outputs decorated code text in context of a module.
+    fn code_text(&self, module_env: &ModuleEnv<'_>, code: &str) {
+        emitln!(self.writer, &self.decorate_code(module_env, code));
+    }
+
+    /// Decorates a code fragment, for use in an html block. Replaces < and >, bolds keywords and
+    /// tries to resolve and cross-link references.
+    fn decorate_code(&self, module_env: &ModuleEnv<'_>, code: &str) -> String {
+        let rex = Regex::new(
+            r"(?P<ident>(\b\w+\b\s*::\s*)*\b\w+\b)(?P<call>\s*[(<])?|(?P<lt><)|(?P<gt>>)",
+        )
+        .unwrap();
+        let mut r = String::new();
+        let mut at = 0;
+        while let Some(cap) = rex.captures(&code[at..]) {
+            let replacement = {
+                if cap.name("lt").is_some() {
+                    "&lt;".to_owned()
+                } else if cap.name("gt").is_some() {
+                    "&gt;".to_owned()
+                } else if let Some(m) = cap.name("ident") {
+                    let is_call = cap.name("call").is_some();
+                    let s = m.as_str();
+                    if KEYWORDS.contains(&s) || WEAK_KEYWORDS.contains(&s) {
+                        format!("<b>{}</b>", &code[at + m.start()..at + m.end()])
+                    } else if let Some(label) = self.resolve_to_label(module_env, s, is_call) {
+                        format!("<a href=\"#{}\">{}</a>", label, s)
+                    } else {
+                        "".to_owned()
+                    }
+                } else {
+                    "".to_owned()
+                }
+            };
+            if replacement.is_empty() {
+                r += &code[at..at + cap.get(0).unwrap().end()].replace("<", "&lt;");
+            } else {
+                r += &code[at..at + cap.get(0).unwrap().start()];
+                r += &replacement;
+                if let Some(m) = cap.name("call") {
+                    // Append the call or generic open we may have also matched to distinguish
+                    // a simple name from a function call or generic instantiation. Need to
+                    // replace the `<` as well.
+                    r += &m.as_str().replace("<", "&lt;");
+                }
+            }
+            at += cap.get(0).unwrap().end();
+        }
+        r += &code[at..];
+        r
+    }
+
+    /// Resolve a string of the form `ident`, `ident::ident`, or `0xN::ident::ident` into
+    /// the label for the declaration inside of this documentation. This uses a
+    /// heuristic and may not work in all cases or produce wrong results (for instance, it
+    /// ignores aliases). To improve on this, we would need best direct support by the compiler.
+    fn resolve_to_label(
+        &self,
+        module_env: &ModuleEnv<'_>,
+        s: &str,
+        is_followed_by_open: bool,
+    ) -> Option<String> {
+        let parts_data: Vec<&str> = s.splitn(3, "::").collect();
+        let mut parts = parts_data.as_slice();
+        let skip_dependency = |module: ModuleEnv<'env>| -> Option<ModuleEnv<'env>> {
+            if module.is_in_dependency() {
+                // Don't create references for code not part of this documentation.
+                None
+            } else {
+                Some(module)
+            }
+        };
+        let module_opt = if parts[0].starts_with("0x") {
+            if parts.len() == 1 {
+                // Cannot resolve.
+                return None;
+            }
+            let addr = BigUint::parse_bytes(&parts[0][2..].as_bytes(), 16)?;
+            let mname = ModuleName::new(addr, self.env.symbol_pool().make(parts[1]));
+            parts = &parts[2..];
+            Some(self.env.find_module(&mname)?).and_then(skip_dependency)
+        } else {
+            None
+        };
+        let try_func_or_struct = |module: &ModuleEnv<'_>, name: Symbol, is_qualified: bool| {
+            // Below we only resolve a simple name to a function if it is followed by a ( or <.
+            // Otherwise we get too many false positives where names are resolved to functions
+            // but were actual fields.
+            if module.find_struct(name).is_some()
+                || ((is_qualified || is_followed_by_open) && module.find_function(name).is_some())
+            {
+                Some(self.label_for_module_item(&module, name))
+            } else {
+                None
+            }
+        };
+        let parts_sym = parts
+            .iter()
+            .map(|p| self.env.symbol_pool().make(p))
+            .collect_vec();
+
+        match (module_opt, parts_sym.len()) {
+            (Some(module), 0) => Some(self.label_for_module(&module)),
+            (Some(module), 1) => try_func_or_struct(&module, parts_sym[0], true),
+            (None, 0) => None,
+            (None, 1) => {
+                // A simple name. Resolve either to module or to item in current module.
+                if let Some(module) = self
+                    .env
+                    .find_module_by_name(parts_sym[0])
+                    .and_then(skip_dependency)
+                {
+                    Some(self.label_for_module(&module))
+                } else {
+                    try_func_or_struct(module_env, parts_sym[0], false)
+                }
+            }
+            (None, 2) => {
+                // A qualified name, but without the address. This must be an item in a module
+                // denoted by the first name.
+                let module_opt = if parts[0] == "Self" {
+                    Some(module_env.clone())
+                } else {
+                    self.env
+                        .find_module_by_name(parts_sym[0])
+                        .and_then(skip_dependency)
+                };
+                if let Some(module) = module_opt {
+                    try_func_or_struct(&module, parts_sym[1], true)
+                } else {
+                    None
+                }
+            }
+            (_, _) => None,
+        }
+    }
+
+    /// Return the link label for a module.
+    fn label_for_module(&self, module_env: &ModuleEnv<'_>) -> String {
+        module_env
+            .get_name()
+            .display_full(self.env.symbol_pool())
+            .to_string()
+            .replace("::", "_")
+    }
+
+    /// Return the link label for an item in a module.
+    fn label_for_module_item(&self, module_env: &ModuleEnv<'_>, item: Symbol) -> String {
+        format!(
+            "{}_{}",
+            self.label_for_module(module_env),
+            item.display(self.env.symbol_pool())
+        )
+    }
+
+    /// Shortcut for code_block in a module context.
+    fn code_block(&self, module_env: &ModuleEnv<'_>, code: &str) {
+        self.begin_code();
+        self.code_text(module_env, code);
+        self.end_code();
+    }
+
+    /// Begin an itemized list.
+    fn begin_items(&self) {}
+
+    /// End an itemized list.
+    fn end_items(&self) {}
+
+    /// Emit an item. With use the optional module env to do text decoration.
+    fn item_text(&self, module_env_opt: Option<&ModuleEnv<'_>>, text: &str) {
+        match module_env_opt {
+            Some(module_env) => emitln!(self.writer, "-  {}", self.decorate_text(module_env, text)),
+            None => emitln!(self.writer, "-  {}", text),
+        }
+    }
+
+    /// Begin a definition list.
+    fn begin_definitions(&self) {
+        emitln!(self.writer);
+        emitln!(self.writer, "<dl>");
+    }
+
+    /// End a definition list.
+    fn end_definitions(&self) {
+        emitln!(self.writer, "</dl>");
+        emitln!(self.writer);
+    }
+
+    /// Emit a definition.
+    fn definition_text(&self, module_env_opt: Option<&ModuleEnv<'_>>, term: &str, def: &str) {
+        let decorate = |s| match module_env_opt {
+            Some(m) => self.decorate_text(m, s),
+            None => s.to_string(),
+        };
+        emitln!(self.writer, "<dt>\n{}\n</dt>", decorate(term));
+        emitln!(self.writer, "<dd>\n{}\n</dd>", decorate(def));
+    }
+
+    /// Display a type parameter.
+    fn type_parameter_display(&self, tp: &TypeParameter) -> String {
+        format!(
+            "{}{}",
+            self.name_string(tp.0),
+            match tp.1 {
+                TypeConstraint::None => "",
+                TypeConstraint::Resource => ": resource",
+                TypeConstraint::Copyable => ": copyable",
+            }
+        )
+    }
+
+    /// Display a type parameter list.
+    fn type_parameter_list_display(&self, tps: &[TypeParameter]) -> String {
+        if tps.is_empty() {
+            "".to_owned()
+        } else {
+            format!(
+                "<{}>",
+                tps.iter()
+                    .map(|tp| self.type_parameter_display(tp))
+                    .join(", ")
+            )
+        }
+    }
+
+    /// Fixes indentation of source code as obtained via original source.
+    /// Typically code has the first line unindented because location tracking starts
+    /// at the first keyword of the item (e.g. `public fun`), but subsequent lines are then
+    /// indented. This uses a heuristic by taking the indentation of the last line as a basis.
+    fn fix_indent(&self, s: &str) -> String {
+        let lines = s.lines().collect_vec();
+        if lines.is_empty() {
+            return s.to_owned();
+        }
+        let last_line = lines[lines.len() - 1];
+        let last_indent = last_line.len() - last_line.trim_start().len();
+        lines
+            .iter()
+            .map(|l| {
+                let mut i = 0;
+                while i < last_indent && l.starts_with(' ') {
+                    i += 1;
+                }
+                &l[i..]
+            })
+            .join("\n")
+    }
+
+    /// Repeats a string n times.
+    fn repeat_str(&self, s: &str, n: usize) -> String {
+        (0..n).map(|_| s).collect::<String>()
+    }
+}

--- a/language/move-prover/docgen/src/lib.rs
+++ b/language/move-prover/docgen/src/lib.rs
@@ -1,0 +1,6 @@
+// Copyright (c) The Libra Core Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+#![forbid(unsafe_code)]
+
+pub mod docgen;

--- a/language/move-prover/docgen/tests/sources/libra.move
+++ b/language/move-prover/docgen/tests/sources/libra.move
@@ -1,0 +1,544 @@
+address 0x0 {
+
+/// The Libra module defines basic functionality around coins.
+///
+/// # Note
+///
+/// This is not a consistent and up-to-date implementation, specification, or documentation
+/// of the `Libra` module. It is rather a playground for testing the documentation generator.
+///
+/// > We use block quotes like this to mark documentation text which is specific to docgen testing.
+/// >
+/// > We can refer to a module like in `LibraDocTest` -- if it is unambiguous -- or like
+/// `0x0::LibraDocTest`.
+module LibraDocTest {
+    use 0x0::Transaction;
+    use 0x0::Vector;
+
+    /// # Settings for Verification
+    ///
+    /// > Spec module blocks which are associated with the module do not have an implicit header and
+    /// > are directly included in the module doc (or Specification sub-section if `--doc-spec-inline=false`).
+    /// > To get a header, one needs to be explicitly assigned like we do here.
+    spec module {
+        /// Verify also private functions.
+        pragma verify = true;
+    }
+
+    /// A resource representing a fungible token
+    resource struct T<Token> {
+        /// The value of the token. May be zero
+        value: u64,
+    }
+
+    /// Maintains sum_of_token
+    spec struct T {
+        invariant pack sum_of_token_values<Token> = sum_of_token_values<Token> + value;
+        invariant unpack sum_of_token_values<Token> = sum_of_token_values<Token> - value;
+    }
+
+    spec module {
+         /// This ghost variable is defined to have the true sum values of all instances of Token
+         global sum_of_token_values<Token>: num;
+    }
+    spec schema SumRemainsSame<Token> {
+         ensures sum_of_token_values<Token> == old(sum_of_token_values<Token>);
+    }
+    spec module {
+        /// Only mint/burn & with capability versions can change the total amount of currency.
+        /// skip mint, burn, mint_with_capability, burn_with_capability.
+        /// Burn always aborts because Preburn.is_approved is always false.
+        apply SumRemainsSame<Token> to *<Token> except mint*<Token>, burn*<Token>;
+    }
+
+    spec schema SumOfTokenValuesInvariant<Token> {
+         /// SPEC: MarketCap == Sum of all the instances of a particular token.
+
+         /// Note: this works even though the verifier does not
+         /// know that each existing token.value must be <= sum_of_token_values. I assume that
+         /// total_value is constrained to be non-negative, so it all works. I should check this out.
+
+         /// Note: What is the value of a ghost variable in the genesis state?
+         /// State machine with two states (not registered/registered), so write as two invariants.
+
+         invariant module !token_is_registered<Token>() ==> sum_of_token_values<Token> == 0;
+         invariant module token_is_registered<Token>()
+               ==> sum_of_token_values<Token> == global<Info<Token>>(0xA550C18).total_value;
+    }
+    spec module {
+        apply SumOfTokenValuesInvariant<Token> to public *<Token>;
+    }
+
+
+    /// A singleton resource that grants access to `LibraDocTest::mint`. Only the Association has one.
+    ///
+    /// > Instead of `LibraDocTest::mint` we can also write `0x0::LibraDocTest::mint`, `Self::mint`, or just `mint()`
+    /// > (for functions from enclosing module) to get a hyper link in documentation text.
+    resource struct MintCapability<Token> { }
+
+    /// Maintain mint_capability_count
+    spec struct MintCapability {
+        invariant pack mint_capability_count<Token> = mint_capability_count<Token> + 1;
+        invariant unpack mint_capability_count<Token> = mint_capability_count<Token> - 1;
+    }
+    spec module {
+        /// Ghost variable representing the total number of MintCapability instances for Token (0 or 1).
+        global mint_capability_count<Token>: num;
+
+        /// Helper to check whether sender has MintCapability.
+        define exists_sender_mint_capability<Token>(): bool { exists<MintCapability<Token>>(sender()) }
+    }
+    /// There is a MintCapability for Token iff the token is registered
+    /// > For the below schema, we have documentation comments on members. In the case of module/function/struct
+    /// > spec blocks, we can just flatten all spec block members with possibly
+    /// > attached member documentation into the section. For schemas this is not possible.
+    /// > So we repeat a schema declaration multiple times, "extending" it.
+    spec schema MintCapabilityCountInvariant<Token> {
+        /// If token is not registered, there can be no capability.
+        invariant module !token_is_registered<Token>() ==> mint_capability_count<Token> == 0;
+        /// If token is registered, there is exactly one capability.
+        invariant module token_is_registered<Token>() ==> mint_capability_count<Token> == 1;
+    }
+    spec module {
+       apply MintCapabilityCountInvariant<Token> to public *<Token>;
+    }
+
+    resource struct Info<Token> {
+        /// The sum of the values of all `LibraDocTest::T` resources in the system
+        total_value: u128,
+        /// Value of funds that are in the process of being burned
+        preburn_value: u64,
+    }
+
+    spec struct Info {}
+
+    /// Specifications helpers for working with Info<Token> at association address.
+    spec module {
+       define association_address(): address { 0xA550C18 }
+       define token_is_registered<Token>(): bool { exists<Info<Token>>(association_address()) }
+       define info<Token>(): Info<Token> { global<Info<Token>>(association_address()) }
+    }
+
+    /// Once registered, a token stays registered forever.
+    spec schema RegistrationPersists<Token> {
+         ensures old(token_is_registered<Token>()) ==> token_is_registered<Token>();
+    }
+    spec module {
+        apply RegistrationPersists<Token> to *<Token>;
+    }
+
+     /// A holding area where funds that will subsequently be burned wait while their underyling
+    /// assets are sold off-chain.
+    /// This resource can only be created by the holder of the MintCapability. An account that
+    /// contains this address has the authority to initiate a burn request. A burn request can be
+    /// resolved by the holder of the MintCapability by either (1) burning the funds, or (2)
+    /// returning the funds to the account that initiated the burn request.
+    /// This design supports multiple preburn requests in flight at the same time, including multiple
+    /// burn requests from the same account. However, burn requests from the same account must be
+    /// resolved in FIFO order.
+    resource struct Preburn<Token> {
+        /// Queue of pending burn requests
+        requests: vector<T<Token>>,
+        /// Boolean that is true if the holder of the MintCapability has approved this account as a
+        /// preburner
+        is_approved: bool,
+    }
+
+    public fun register<Token>() {
+        // Only callable by the Association address
+        Transaction::assert(Transaction::sender() == 0xA550C18, 1);
+        move_to_sender(MintCapability<Token>{ });
+        move_to_sender(Info<Token> { total_value: 0u128, preburn_value: 0 });
+    }
+    spec fun register {
+        include RegisterAbortsIf<Token>;
+        ensures exists_sender_mint_capability<Token>();
+        ensures token_is_registered<Token>();
+        ensures info<Token>().total_value == 0;
+        ensures info<Token>().preburn_value == 0;
+    }
+    spec schema RegisterAbortsIf<Token>{
+        aborts_if sender() != association_address();
+        aborts_if exists_sender_mint_capability<Token>();
+        aborts_if token_is_registered<Token>();
+    }
+
+
+
+    fun assert_is_registered<Token>() {
+        Transaction::assert(exists<Info<Token>>(0xA550C18), 12);
+    }
+    spec fun assert_is_registered {
+        aborts_if !token_is_registered<Token>();
+    }
+
+    /// Return `amount` coins.
+    /// Fails if the sender does not have a published MintCapability.
+    public fun mint<Token>(amount: u64): T<Token> acquires Info, MintCapability {
+        mint_with_capability(amount, borrow_global<MintCapability<Token>>(Transaction::sender()))
+    }
+    spec fun mint {
+        include MintAbortsIf<Token>;
+        aborts_if !exists_sender_mint_capability<Token>();
+        include MintEnsures<Token>;
+    }
+    spec schema MintAbortsIf<Token> {
+        amount: u64;
+        aborts_if !token_is_registered<Token>();
+        aborts_if amount > 1000000000 * 1000000;
+        aborts_if info<Token>().total_value + amount > max_u128();
+    }
+    spec schema MintEnsures<Token> {
+        amount: u64;
+        result: T<Token>;
+        ensures info<Token>().total_value == old(info<Token>().total_value) + amount;
+        ensures result.value == amount;
+    }
+
+    /// Burn the coins currently held in the preburn holding area under `preburn_address`.
+    /// Fails if the sender does not have a published MintCapability.
+    public fun burn<Token>(
+        preburn_address: address
+    ) acquires Info, MintCapability, Preburn {
+        burn_with_capability(
+            preburn_address,
+            borrow_global<MintCapability<Token>>(Transaction::sender())
+        )
+    }
+    spec fun burn {
+        aborts_if !exists_sender_mint_capability<Token>();
+        include BurnAbortsIf<Token>;
+        include BurnEnsures<Token>;
+    }
+    /// Properties applying both to burn and to burn_cancel functions.
+    spec schema BasicBurnAbortsIf<Token> {
+        preburn_address: address;
+        aborts_if !exists<Preburn<Token>>(preburn_address);
+        aborts_if len(global<Preburn<Token>>(preburn_address).requests) == 0;
+        aborts_if !token_is_registered<Token>();
+        aborts_if info<Token>().preburn_value < global<Preburn<Token>>(preburn_address).requests[0].value;
+    }
+    spec schema BurnAbortsIf<Token> {
+        include BasicBurnAbortsIf<Token>;
+        aborts_if info<Token>().total_value < global<Preburn<Token>>(preburn_address).requests[0].value;
+    }
+    spec schema BurnEnsures<Token> {
+        preburn_address: address;
+        ensures Vector::eq_pop_front(
+            global<Preburn<Token>>(preburn_address).requests,
+            old(global<Preburn<Token>>(preburn_address).requests)
+        );
+        ensures info<Token>().total_value ==
+            old(info<Token>().total_value)
+                - old(global<Preburn<Token>>(preburn_address).requests[0].value);
+        ensures info<Token>().preburn_value ==
+            old(info<Token>().preburn_value)
+                - old(global<Preburn<Token>>(preburn_address).requests[0].value);
+    }
+
+    /// Cancel the oldest burn request from `preburn_address`
+    /// Fails if the sender does not have a published MintCapability.
+    public fun cancel_burn<Token>(
+        preburn_address: address
+    ): T<Token> acquires Info, MintCapability, Preburn {
+        cancel_burn_with_capability(
+            preburn_address,
+            borrow_global<MintCapability<Token>>(Transaction::sender())
+        )
+    }
+    spec fun cancel_burn {
+        aborts_if !exists_sender_mint_capability<Token>();
+        include BasicBurnAbortsIf<Token>;
+        include CancelBurnEnsures<Token>;
+    }
+    spec schema CancelBurnEnsures<Token> {
+        preburn_address: address;
+        result: T<Token>;
+        ensures Vector::eq_pop_front(
+            global<Preburn<Token>>(preburn_address).requests,
+            old(global<Preburn<Token>>(preburn_address).requests)
+        );
+        ensures info<Token>().preburn_value ==
+            old(info<Token>().preburn_value) - old(global<Preburn<Token>>(preburn_address).requests[0].value);
+        ensures result == old(global<Preburn<Token>>(preburn_address).requests[0]);
+    }
+
+    /// Create a new Preburn resource
+    public fun new_preburn<Token>(): Preburn<Token> {
+        assert_is_registered<Token>();
+        Preburn<Token> { requests: Vector::empty(), is_approved: false, }
+    }
+    spec fun new_preburn {
+        aborts_if !token_is_registered<Token>();
+        ensures len(result.requests) == 0;
+        ensures result.is_approved == false;
+    }
+
+    /// Mint a new `LibraDocTest::T` worth `value`. The caller must have a reference to a MintCapability.
+    /// Only the Association account can acquire such a reference, and it can do so only via
+    /// `borrow_sender_mint_capability`.
+    public fun mint_with_capability<Token>(
+        value: u64,
+        _capability: &MintCapability<Token>
+    ): T<Token> acquires Info {
+        assert_is_registered<Token>();
+        // TODO: temporary measure for testnet only: limit minting to 1B Libra at a time.
+        // this is to prevent the market cap's total value from hitting u64_max due to excessive
+        // minting. This will not be a problem in the production Libra system because coins will
+        // be backed with real-world assets, and thus minting will be correspondingly rarer.
+        // * 1000000 here because the unit is microlibra
+        Transaction::assert(value <= 1000000000 * 1000000, 11);
+        // update market cap resource to reflect minting
+        let market_cap = borrow_global_mut<Info<Token>>(0xA550C18);
+        market_cap.total_value = market_cap.total_value + (value as u128);
+
+        T<Token> { value }
+    }
+    spec fun mint_with_capability {
+        include MintAbortsIf<Token>{amount: value};
+        include MintEnsures<Token>{amount: value};
+    }
+
+    /// Send coin to the preburn holding area `preburn_ref`, where it will wait to be burned.
+    public fun preburn<Token>(
+        preburn_ref: &mut Preburn<Token>,
+        coin: T<Token>
+    ) acquires Info {
+        // TODO: bring this back once we can automate approvals in testnet
+        // Transaction::assert(preburn_ref.is_approved, 13);
+        let coin_value = value(&coin);
+        Vector::push_back(
+            &mut preburn_ref.requests,
+            coin
+        );
+        let market_cap = borrow_global_mut<Info<Token>>(0xA550C18);
+        market_cap.preburn_value = market_cap.preburn_value + coin_value
+    }
+    spec fun preburn {
+        include PreburnAbortsIf<Token>;
+        include PreburnEnsures<Token>;
+    }
+    spec schema PreburnAbortsIf<Token> {
+        coin: T<Token>;
+        // aborts_if !preburn_ref.is_approved; // TODO: bring this back once we can automate approvals in testnet
+        aborts_if !token_is_registered<Token>();
+        aborts_if info<Token>().preburn_value + coin.value > max_u64();
+    }
+    spec schema PreburnEnsures<Token> {
+        preburn_ref: &mut Preburn<Token>;
+        coin: T<Token>;
+        ensures info<Token>().preburn_value == old(info<Token>().preburn_value) + coin.value;
+        ensures Vector::eq_push_back(preburn_ref.requests, old(preburn_ref.requests), coin);
+    }
+
+    /// Send coin to the preburn holding area, where it will wait to be burned.
+    /// Fails if the sender does not have a published Preburn resource
+    public fun preburn_to_sender<Token>(coin: T<Token>) acquires Info, Preburn {
+        preburn(borrow_global_mut<Preburn<Token>>(Transaction::sender()), coin)
+    }
+
+    spec fun preburn_to_sender {
+        include PreburnAbortsIf<Token>;
+        aborts_if !exists<Preburn<Token>>(sender());
+        include PreburnEnsures<Token>{preburn_ref: global<Preburn<Token>>(sender())};
+    }
+
+    /// Permanently remove the coins held in the `Preburn` resource stored at `preburn_address` and
+    /// update the market cap accordingly. If there are multiple preburn requests in progress, this
+    /// will remove the oldest one.
+    /// Can only be invoked by the holder of the MintCapability. Fails if the there is no `Preburn`
+    /// resource under `preburn_address` or has one with no pending burn requests.
+    public fun burn_with_capability<Token>(
+        preburn_address: address,
+        _capability: &MintCapability<Token>
+    ) acquires Info, Preburn {
+        // destroy the coin at the head of the preburn queue
+        let preburn = borrow_global_mut<Preburn<Token>>(preburn_address);
+        let T { value } = Vector::remove(&mut preburn.requests, 0);
+        // update the market cap
+        let market_cap = borrow_global_mut<Info<Token>>(0xA550C18);
+        market_cap.total_value = market_cap.total_value - (value as u128);
+        market_cap.preburn_value = market_cap.preburn_value - value
+    }
+    spec fun burn_with_capability {
+        include BurnAbortsIf<Token>;
+        aborts_if info<Token>().total_value < global<Preburn<Token>>(preburn_address).requests[0].value;
+        include BurnEnsures<Token>;
+    }
+
+    /// Cancel the burn request in the `Preburn` resource stored at `preburn_address` and
+    /// return the coins to the caller.
+    /// If there are multiple preburn requests in progress, this will cancel the oldest one.
+    /// Can only be invoked by the holder of the MintCapability. Fails if the transaction sender
+    /// does not have a published Preburn resource or has one with no pending burn requests.
+    public fun cancel_burn_with_capability<Token>(
+        preburn_address: address,
+        _capability: &MintCapability<Token>
+    ): T<Token> acquires Info, Preburn {
+        // destroy the coin at the head of the preburn queue
+        let preburn = borrow_global_mut<Preburn<Token>>(preburn_address);
+        let coin = Vector::remove(&mut preburn.requests, 0);
+        // update the market cap
+        let market_cap = borrow_global_mut<Info<Token>>(0xA550C18);
+        market_cap.preburn_value = market_cap.preburn_value - value(&coin);
+
+        coin
+    }
+    spec fun cancel_burn_with_capability {
+        include BasicBurnAbortsIf<Token>;
+        include CancelBurnEnsures<Token>;
+    }
+
+    /// Publish `preburn` under the sender's account
+    public fun publish_preburn<Token>(preburn: Preburn<Token>) {
+        move_to_sender(preburn)
+    }
+    spec fun publish_preburn {
+        aborts_if exists<Preburn<Token>>(sender());
+        ensures exists<Preburn<Token>>(sender());
+        ensures global<Preburn<Token>>(sender()) == preburn;
+    }
+
+    /// Remove and return the `Preburn` resource under the sender's account
+    public fun remove_preburn<Token>(): Preburn<Token> acquires Preburn {
+        move_from<Preburn<Token>>(Transaction::sender())
+    }
+    spec fun remove_preburn {
+        aborts_if !exists<Preburn<Token>>(sender());
+        ensures !exists<Preburn<Token>>(sender());
+        ensures result == old(global<Preburn<Token>>(sender()));
+    }
+
+    /// Destroys the given preburn resource.
+    /// Aborts if `requests` is non-empty
+    public fun destroy_preburn<Token>(preburn: Preburn<Token>) {
+        let Preburn { requests, is_approved: _ } = preburn;
+        Vector::destroy_empty(requests)
+    }
+    spec fun destroy_preburn {
+        aborts_if len(preburn.requests) > 0;
+    }
+
+    /// Publish `capability` under the sender's account
+    public fun publish_mint_capability<Token>(capability: MintCapability<Token>) {
+        move_to_sender(capability)
+    }
+    spec fun publish_mint_capability {
+        aborts_if exists_sender_mint_capability<Token>();
+        ensures exists_sender_mint_capability<Token>();
+        ensures capability == global<MintCapability<Token>>(sender());
+    }
+
+    /// Remove and return the MintCapability from the sender's account. Fails if the sender does
+    /// not have a published MintCapability
+    public fun remove_mint_capability<Token>(): MintCapability<Token> acquires MintCapability {
+        move_from<MintCapability<Token>>(Transaction::sender())
+    }
+    spec fun remove_mint_capability {
+        aborts_if !exists_sender_mint_capability<Token>();
+        ensures !exists_sender_mint_capability<Token>();
+        ensures result == old(global<MintCapability<Token>>(sender()));
+    }
+
+    /// Return the total value of all Libra in the system
+    public fun market_cap<Token>(): u128 acquires Info {
+        borrow_global<Info<Token>>(0xA550C18).total_value
+    }
+    spec fun market_cap {
+        aborts_if !token_is_registered<Token>();
+        ensures result == info<Token>().total_value;
+    }
+
+    /// Return the total value of Libra to be burned
+    public fun preburn_value<Token>(): u64 acquires Info {
+        borrow_global<Info<Token>>(0xA550C18).preburn_value
+    }
+    spec fun preburn_value {
+        aborts_if !token_is_registered<Token>();
+        ensures result == info<Token>().preburn_value;
+    }
+
+    /// Create a new `LibraDocTest::T` with a value of 0
+    public fun zero<Token>(): T<Token> {
+        // prevent silly coin types (e.g., Libra<bool>) from being created
+        assert_is_registered<Token>();
+        T { value: 0 }
+    }
+    spec fun zero {
+        aborts_if !token_is_registered<Token>();
+        ensures result.value == 0;
+    }
+
+    /// Public accessor for the value of a coin
+    public fun value<Token>(coin_ref: &T<Token>): u64 {
+        coin_ref.value
+    }
+    spec fun value {
+        ensures result == coin_ref.value;
+    }
+
+    /// Splits the given coin into two and returns them both
+    /// It leverages `withdraw` for any verifications of the values
+    public fun split<Token>(coin: T<Token>, amount: u64): (T<Token>, T<Token>) {
+        let other = withdraw(&mut coin, amount);
+        (coin, other)
+    }
+    spec fun split {
+        aborts_if coin.value < amount;
+        ensures result_1.value == coin.value - amount;
+        ensures result_2.value == amount;
+    }
+
+    /// "Divides" the given coin into two, where original coin is modified in place
+    /// The original coin will have value = original value - `value`
+    /// The new coin will have a value = `value`
+    /// Fails if the coins value is less than `value`
+    public fun withdraw<Token>(coin_ref: &mut T<Token>, value: u64): T<Token> {
+        // Check that `amount` is less than the coin's value
+        Transaction::assert(coin_ref.value >= value, 10);
+
+        // Split the coin
+        coin_ref.value = coin_ref.value - value;
+        T { value }
+    }
+    spec fun withdraw {
+        aborts_if coin_ref.value < value;
+        ensures coin_ref.value == old(coin_ref.value) - value;
+        ensures result.value == value;
+    }
+
+    /// Merges two coins and returns a new coin whose value is equal to the sum of the two inputs
+    public fun join<Token>(coin1: T<Token>, coin2: T<Token>): T<Token>  {
+        deposit(&mut coin1, coin2);
+        coin1
+    }
+    spec fun join {
+        aborts_if coin1.value + coin2.value > max_u64();
+        ensures result.value == coin1.value + coin2.value;
+    }
+
+    /// "Merges" the two coins
+    /// The coin passed in by reference will have a value equal to the sum of the two coins
+    /// The `check` coin is consumed in the process
+    public fun deposit<Token>(coin_ref: &mut T<Token>, check: T<Token>) {
+        let T { value } = check;
+        coin_ref.value= coin_ref.value + value;
+    }
+    spec fun deposit {
+        aborts_if coin_ref.value + check.value > max_u64();
+        ensures coin_ref.value == old(coin_ref.value) + check.value;
+    }
+
+    /// Destroy a coin
+    /// Fails if the value is non-zero
+    /// The amount of `LibraDocTest::T` in the system is a tightly controlled property,
+    /// so you cannot "burn" any non-zero amount of `LibraDocTest::T`
+    public fun destroy_zero<Token>(coin: T<Token>) {
+        let T<Token> { value } = coin;
+        Transaction::assert(value == 0, 11);
+    }
+    spec fun destroy_zero {
+        aborts_if coin.value > 0;
+    }
+}
+}

--- a/language/move-prover/docgen/tests/sources/libra.spec_inline.md
+++ b/language/move-prover/docgen/tests/sources/libra.spec_inline.md
@@ -1,0 +1,1551 @@
+## Table of Content
+-  [Module `0x0::LibraDocTest`](#0x0_LibraDocTest)
+    -  [Struct `T`](#0x0_LibraDocTest_T)
+    -  [Struct `MintCapability`](#0x0_LibraDocTest_MintCapability)
+    -  [Struct `Info`](#0x0_LibraDocTest_Info)
+    -  [Struct `Preburn`](#0x0_LibraDocTest_Preburn)
+    -  [Function `register`](#0x0_LibraDocTest_register)
+    -  [Function `assert_is_registered`](#0x0_LibraDocTest_assert_is_registered)
+    -  [Function `mint`](#0x0_LibraDocTest_mint)
+    -  [Function `burn`](#0x0_LibraDocTest_burn)
+    -  [Function `cancel_burn`](#0x0_LibraDocTest_cancel_burn)
+    -  [Function `new_preburn`](#0x0_LibraDocTest_new_preburn)
+    -  [Function `mint_with_capability`](#0x0_LibraDocTest_mint_with_capability)
+    -  [Function `preburn`](#0x0_LibraDocTest_preburn)
+    -  [Function `preburn_to_sender`](#0x0_LibraDocTest_preburn_to_sender)
+    -  [Function `burn_with_capability`](#0x0_LibraDocTest_burn_with_capability)
+    -  [Function `cancel_burn_with_capability`](#0x0_LibraDocTest_cancel_burn_with_capability)
+    -  [Function `publish_preburn`](#0x0_LibraDocTest_publish_preburn)
+    -  [Function `remove_preburn`](#0x0_LibraDocTest_remove_preburn)
+    -  [Function `destroy_preburn`](#0x0_LibraDocTest_destroy_preburn)
+    -  [Function `publish_mint_capability`](#0x0_LibraDocTest_publish_mint_capability)
+    -  [Function `remove_mint_capability`](#0x0_LibraDocTest_remove_mint_capability)
+    -  [Function `market_cap`](#0x0_LibraDocTest_market_cap)
+    -  [Function `preburn_value`](#0x0_LibraDocTest_preburn_value)
+    -  [Function `zero`](#0x0_LibraDocTest_zero)
+    -  [Function `value`](#0x0_LibraDocTest_value)
+    -  [Function `split`](#0x0_LibraDocTest_split)
+    -  [Function `withdraw`](#0x0_LibraDocTest_withdraw)
+    -  [Function `join`](#0x0_LibraDocTest_join)
+    -  [Function `deposit`](#0x0_LibraDocTest_deposit)
+    -  [Function `destroy_zero`](#0x0_LibraDocTest_destroy_zero)
+
+<a name="0x0_LibraDocTest"></a>
+
+## Module `0x0::LibraDocTest`
+
+The Libra module defines basic functionality around coins.
+
+### Note
+
+This is not a consistent and up-to-date implementation, specification, or documentation
+of the
+<code>Libra</code> module. It is rather a playground for testing the documentation generator.
+
+> We use block quotes like this to mark documentation text which is specific to docgen testing.
+>
+> We can refer to a module like in
+<code><a href="#0x0_LibraDocTest">LibraDocTest</a></code> -- if it is unambiguous -- or like
+<code><a href="#0x0_LibraDocTest">0x0::LibraDocTest</a></code>.
+
+### Settings for Verification
+
+> Spec module blocks which are associated with the module do not have an implicit header and
+> are directly included in the module doc (or Specification sub-section if
+<code>--doc-<b>spec</b>-inline=<b>false</b></code>).
+> To get a header, one needs to be explicitly assigned like we do here.
+
+Verify also private functions.
+
+
+<pre><code>pragma verify = <b>true</b>;
+</code></pre>
+
+
+
+<a name="0x0_LibraDocTest_T"></a>
+
+### Struct `T`
+
+A resource representing a fungible token
+
+
+<pre><code><b>resource</b> <b>struct</b> <a href="#0x0_LibraDocTest_T">T</a>&lt;Token&gt;
+</code></pre>
+
+
+
+<details>
+<summary>Fields</summary>
+
+
+<dl>
+<dt>
+
+<code>value: u64</code>
+</dt>
+<dd>
+ The value of the token. May be zero
+</dd>
+</dl>
+
+
+</details>
+
+<details>
+<summary>Specification</summary>
+
+Maintains sum_of_token
+
+
+<pre><code><b>invariant</b> <b>pack</b> sum_of_token_values&lt;Token&gt; = sum_of_token_values&lt;Token&gt; + value;
+<b>invariant</b> <b>unpack</b> sum_of_token_values&lt;Token&gt; = sum_of_token_values&lt;Token&gt; - value;
+</code></pre>
+
+
+
+This ghost variable is defined to have the true sum values of all instances of Token
+
+
+<pre><code><b>global</b> sum_of_token_values&lt;Token&gt;: num;
+</code></pre>
+
+
+
+
+<pre><code><b>schema</b> SumRemainsSame&lt;Token&gt; {
+    <b>ensures</b> sum_of_token_values&lt;Token&gt; == <b>old</b>(sum_of_token_values&lt;Token&gt;);
+}
+</code></pre>
+
+
+
+Only mint/burn & with capability versions can change the total amount of currency.
+skip mint, burn, mint_with_capability, burn_with_capability.
+Burn always aborts because Preburn.is_approved is always false.
+
+
+<pre><code><b>apply</b> SumRemainsSame&lt;Token&gt; <b>to</b> *&lt;Token&gt; <b>except</b> mint*&lt;Token&gt;, burn*&lt;Token&gt;;
+</code></pre>
+
+
+
+SPEC: MarketCap == Sum of all the instances of a particular token.
+Note: this works even though the verifier does not
+know that each existing token.value must be <= sum_of_token_values. I assume that
+total_value is constrained to be non-negative, so it all works. I should check this out.
+Note: What is the value of a ghost variable in the genesis state?
+State machine with two states (not registered/registered), so write as two invariants.
+
+
+<pre><code><b>schema</b> SumOfTokenValuesInvariant&lt;Token&gt; {
+    <b>invariant</b> <b>module</b> !token_is_registered&lt;Token&gt;() ==&gt; sum_of_token_values&lt;Token&gt; == 0;
+    <b>invariant</b> <b>module</b> token_is_registered&lt;Token&gt;()
+                   ==&gt; sum_of_token_values&lt;Token&gt; == <b>global</b>&lt;<a href="#0x0_LibraDocTest_Info">Info</a>&lt;Token&gt;&gt;(0xA550C18).total_value;
+}
+</code></pre>
+
+
+
+
+<pre><code><b>apply</b> SumOfTokenValuesInvariant&lt;Token&gt; <b>to</b> <b>public</b> *&lt;Token&gt;;
+</code></pre>
+
+
+
+</details>
+
+<a name="0x0_LibraDocTest_MintCapability"></a>
+
+### Struct `MintCapability`
+
+A singleton resource that grants access to
+<code><a href="#0x0_LibraDocTest_mint">LibraDocTest::mint</a></code>. Only the Association has one.
+
+> Instead of
+<code><a href="#0x0_LibraDocTest_mint">LibraDocTest::mint</a></code> we can also write
+<code><a href="#0x0_LibraDocTest_mint">0x0::LibraDocTest::mint</a></code>,
+<code><a href="#0x0_LibraDocTest_mint">Self::mint</a></code>, or just
+<code><a href="#0x0_LibraDocTest_mint">mint</a>()</code>
+> (for functions from enclosing module) to get a hyper link in documentation text.
+
+
+<pre><code><b>resource</b> <b>struct</b> <a href="#0x0_LibraDocTest_MintCapability">MintCapability</a>&lt;Token&gt;
+</code></pre>
+
+
+
+<details>
+<summary>Fields</summary>
+
+
+<dl>
+<dt>
+
+<code>dummy_field: bool</code>
+</dt>
+<dd>
+
+</dd>
+</dl>
+
+
+</details>
+
+<details>
+<summary>Specification</summary>
+
+Maintain mint_capability_count
+
+
+<pre><code><b>invariant</b> <b>pack</b> mint_capability_count&lt;Token&gt; = mint_capability_count&lt;Token&gt; + 1;
+<b>invariant</b> <b>unpack</b> mint_capability_count&lt;Token&gt; = mint_capability_count&lt;Token&gt; - 1;
+</code></pre>
+
+
+
+Ghost variable representing the total number of MintCapability instances for Token (0 or 1).
+
+
+<pre><code><b>global</b> mint_capability_count&lt;Token&gt;: num;
+</code></pre>
+
+
+Helper to check whether sender has MintCapability.
+
+
+<pre><code>define exists_sender_mint_capability&lt;Token&gt;(): bool { exists&lt;<a href="#0x0_LibraDocTest_MintCapability">MintCapability</a>&lt;Token&gt;&gt;(sender()) }
+</code></pre>
+
+
+There is a MintCapability for Token iff the token is registered
+> For the below schema, we have documentation comments on members. In the case of module/function/struct
+> spec blocks, we can just flatten all spec block members with possibly
+> attached member documentation into the section. For schemas this is not possible.
+> So we repeat a schema declaration multiple times, "extending" it.
+
+If token is not registered, there can be no capability.
+
+
+<pre><code><b>schema</b> MintCapabilityCountInvariant&lt;Token&gt; {
+    <b>invariant</b> <b>module</b> !token_is_registered&lt;Token&gt;() ==&gt; mint_capability_count&lt;Token&gt; == 0;
+}
+</code></pre>
+
+
+If token is registered, there is exactly one capability.
+
+
+<pre><code><b>schema</b> MintCapabilityCountInvariant&lt;Token&gt; {
+    <b>invariant</b> <b>module</b> token_is_registered&lt;Token&gt;() ==&gt; mint_capability_count&lt;Token&gt; == 1;
+}
+</code></pre>
+
+
+
+
+<pre><code><b>apply</b> MintCapabilityCountInvariant&lt;Token&gt; <b>to</b> <b>public</b> *&lt;Token&gt;;
+</code></pre>
+
+
+
+</details>
+
+<a name="0x0_LibraDocTest_Info"></a>
+
+### Struct `Info`
+
+
+
+<pre><code><b>resource</b> <b>struct</b> <a href="#0x0_LibraDocTest_Info">Info</a>&lt;Token&gt;
+</code></pre>
+
+
+
+<details>
+<summary>Fields</summary>
+
+
+<dl>
+<dt>
+
+<code>total_value: u128</code>
+</dt>
+<dd>
+ The sum of the values of all
+<code><a href="#0x0_LibraDocTest_T">LibraDocTest::T</a></code> resources in the system
+</dd>
+<dt>
+
+<code>preburn_value: u64</code>
+</dt>
+<dd>
+ Value of funds that are in the process of being burned
+</dd>
+</dl>
+
+
+</details>
+
+<details>
+<summary>Specification</summary>
+
+
+Specifications helpers for working with Info<Token> at association address.
+
+
+<pre><code>define association_address(): address { 0xA550C18 }
+define token_is_registered&lt;Token&gt;(): bool { exists&lt;<a href="#0x0_LibraDocTest_Info">Info</a>&lt;Token&gt;&gt;(association_address()) }
+define info&lt;Token&gt;(): <a href="#0x0_LibraDocTest_Info">Info</a>&lt;Token&gt; { <b>global</b>&lt;<a href="#0x0_LibraDocTest_Info">Info</a>&lt;Token&gt;&gt;(association_address()) }
+</code></pre>
+
+
+Once registered, a token stays registered forever.
+
+
+<pre><code><b>schema</b> RegistrationPersists&lt;Token&gt; {
+    <b>ensures</b> <b>old</b>(token_is_registered&lt;Token&gt;()) ==&gt; token_is_registered&lt;Token&gt;();
+}
+</code></pre>
+
+
+
+
+<pre><code><b>apply</b> RegistrationPersists&lt;Token&gt; <b>to</b> *&lt;Token&gt;;
+</code></pre>
+
+
+
+</details>
+
+<a name="0x0_LibraDocTest_Preburn"></a>
+
+### Struct `Preburn`
+
+A holding area where funds that will subsequently be burned wait while their underyling
+assets are sold off-chain.
+This resource can only be created by the holder of the MintCapability. An account that
+contains this address has the authority to initiate a burn request. A burn request can be
+resolved by the holder of the MintCapability by either (1) burning the funds, or (2)
+returning the funds to the account that initiated the burn request.
+This design supports multiple preburn requests in flight at the same time, including multiple
+burn requests from the same account. However, burn requests from the same account must be
+resolved in FIFO order.
+
+
+<pre><code><b>resource</b> <b>struct</b> <a href="#0x0_LibraDocTest_Preburn">Preburn</a>&lt;Token&gt;
+</code></pre>
+
+
+
+<details>
+<summary>Fields</summary>
+
+
+<dl>
+<dt>
+
+<code>requests: vector&lt;<a href="#0x0_LibraDocTest_T">LibraDocTest::T</a>&lt;Token&gt;&gt;</code>
+</dt>
+<dd>
+ Queue of pending burn requests
+</dd>
+<dt>
+
+<code>is_approved: bool</code>
+</dt>
+<dd>
+ Boolean that is true if the holder of the MintCapability has approved this account as a
+ preburner
+</dd>
+</dl>
+
+
+</details>
+
+<a name="0x0_LibraDocTest_register"></a>
+
+### Function `register`
+
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="#0x0_LibraDocTest_register">register</a>&lt;Token&gt;()
+</code></pre>
+
+
+
+<details>
+<summary>Specification</summary>
+
+
+
+<pre><code><b>include</b> RegisterAbortsIf&lt;Token&gt;;
+<b>ensures</b> exists_sender_mint_capability&lt;Token&gt;();
+<b>ensures</b> token_is_registered&lt;Token&gt;();
+<b>ensures</b> info&lt;Token&gt;().total_value == 0;
+<b>ensures</b> info&lt;Token&gt;().preburn_value == 0;
+</code></pre>
+
+
+
+
+<pre><code><b>schema</b> RegisterAbortsIf&lt;Token&gt; {
+    <b>aborts_if</b> sender() != association_address();
+    <b>aborts_if</b> exists_sender_mint_capability&lt;Token&gt;();
+    <b>aborts_if</b> token_is_registered&lt;Token&gt;();
+}
+</code></pre>
+
+
+
+</details>
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="#0x0_LibraDocTest_register">register</a>&lt;Token&gt;() {
+    // Only callable by the Association address
+    Transaction::assert(Transaction::sender() == 0xA550C18, 1);
+    move_to_sender(<a href="#0x0_LibraDocTest_MintCapability">MintCapability</a>&lt;Token&gt;{ });
+    move_to_sender(<a href="#0x0_LibraDocTest_Info">Info</a>&lt;Token&gt; { total_value: 0u128, preburn_value: 0 });
+}
+</code></pre>
+
+
+
+</details>
+
+<a name="0x0_LibraDocTest_assert_is_registered"></a>
+
+### Function `assert_is_registered`
+
+
+
+<pre><code><b>fun</b> <a href="#0x0_LibraDocTest_assert_is_registered">assert_is_registered</a>&lt;Token&gt;()
+</code></pre>
+
+
+
+<details>
+<summary>Specification</summary>
+
+
+
+<pre><code><b>aborts_if</b> !token_is_registered&lt;Token&gt;();
+</code></pre>
+
+
+
+</details>
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>fun</b> <a href="#0x0_LibraDocTest_assert_is_registered">assert_is_registered</a>&lt;Token&gt;() {
+    Transaction::assert(exists&lt;<a href="#0x0_LibraDocTest_Info">Info</a>&lt;Token&gt;&gt;(0xA550C18), 12);
+}
+</code></pre>
+
+
+
+</details>
+
+<a name="0x0_LibraDocTest_mint"></a>
+
+### Function `mint`
+
+Return
+<code>amount</code> coins.
+Fails if the sender does not have a published MintCapability.
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="#0x0_LibraDocTest_mint">mint</a>&lt;Token&gt;(amount: u64): <a href="#0x0_LibraDocTest_T">LibraDocTest::T</a>&lt;Token&gt;
+</code></pre>
+
+
+
+<details>
+<summary>Specification</summary>
+
+
+
+<pre><code><b>include</b> MintAbortsIf&lt;Token&gt;;
+<b>aborts_if</b> !exists_sender_mint_capability&lt;Token&gt;();
+<b>include</b> MintEnsures&lt;Token&gt;;
+</code></pre>
+
+
+
+
+<pre><code><b>schema</b> MintAbortsIf&lt;Token&gt; {
+    amount: u64;
+    <b>aborts_if</b> !token_is_registered&lt;Token&gt;();
+    <b>aborts_if</b> amount &gt; 1000000000 * 1000000;
+    <b>aborts_if</b> info&lt;Token&gt;().total_value + amount &gt; max_u128();
+}
+</code></pre>
+
+
+
+
+<pre><code><b>schema</b> MintEnsures&lt;Token&gt; {
+    amount: u64;
+    result: <a href="#0x0_LibraDocTest_T">T</a>&lt;Token&gt;;
+    <b>ensures</b> info&lt;Token&gt;().total_value == <b>old</b>(info&lt;Token&gt;().total_value) + amount;
+    <b>ensures</b> result.value == amount;
+}
+</code></pre>
+
+
+
+</details>
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="#0x0_LibraDocTest_mint">mint</a>&lt;Token&gt;(amount: u64): <a href="#0x0_LibraDocTest_T">T</a>&lt;Token&gt; <b>acquires</b> <a href="#0x0_LibraDocTest_Info">Info</a>, <a href="#0x0_LibraDocTest_MintCapability">MintCapability</a> {
+    <a href="#0x0_LibraDocTest_mint_with_capability">mint_with_capability</a>(amount, borrow_global&lt;<a href="#0x0_LibraDocTest_MintCapability">MintCapability</a>&lt;Token&gt;&gt;(Transaction::sender()))
+}
+</code></pre>
+
+
+
+</details>
+
+<a name="0x0_LibraDocTest_burn"></a>
+
+### Function `burn`
+
+Burn the coins currently held in the preburn holding area under
+<code>preburn_address</code>.
+Fails if the sender does not have a published MintCapability.
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="#0x0_LibraDocTest_burn">burn</a>&lt;Token&gt;(preburn_address: address)
+</code></pre>
+
+
+
+<details>
+<summary>Specification</summary>
+
+
+
+<pre><code><b>aborts_if</b> !exists_sender_mint_capability&lt;Token&gt;();
+<b>include</b> BurnAbortsIf&lt;Token&gt;;
+<b>include</b> BurnEnsures&lt;Token&gt;;
+</code></pre>
+
+
+Properties applying both to burn and to burn_cancel functions.
+
+
+<pre><code><b>schema</b> BasicBurnAbortsIf&lt;Token&gt; {
+    preburn_address: address;
+    <b>aborts_if</b> !exists&lt;<a href="#0x0_LibraDocTest_Preburn">Preburn</a>&lt;Token&gt;&gt;(preburn_address);
+    <b>aborts_if</b> len(<b>global</b>&lt;<a href="#0x0_LibraDocTest_Preburn">Preburn</a>&lt;Token&gt;&gt;(preburn_address).requests) == 0;
+    <b>aborts_if</b> !token_is_registered&lt;Token&gt;();
+    <b>aborts_if</b> info&lt;Token&gt;().<a href="#0x0_LibraDocTest_preburn_value">preburn_value</a> &lt; <b>global</b>&lt;<a href="#0x0_LibraDocTest_Preburn">Preburn</a>&lt;Token&gt;&gt;(preburn_address).requests[0].value;
+}
+</code></pre>
+
+
+
+
+<pre><code><b>schema</b> BurnAbortsIf&lt;Token&gt; {
+    <b>include</b> BasicBurnAbortsIf&lt;Token&gt;;
+    <b>aborts_if</b> info&lt;Token&gt;().total_value &lt; <b>global</b>&lt;<a href="#0x0_LibraDocTest_Preburn">Preburn</a>&lt;Token&gt;&gt;(preburn_address).requests[0].value;
+}
+</code></pre>
+
+
+
+
+<pre><code><b>schema</b> BurnEnsures&lt;Token&gt; {
+    preburn_address: address;
+    <b>ensures</b> Vector::eq_pop_front(
+                <b>global</b>&lt;<a href="#0x0_LibraDocTest_Preburn">Preburn</a>&lt;Token&gt;&gt;(preburn_address).requests,
+                <b>old</b>(<b>global</b>&lt;<a href="#0x0_LibraDocTest_Preburn">Preburn</a>&lt;Token&gt;&gt;(preburn_address).requests)
+            );
+    <b>ensures</b> info&lt;Token&gt;().total_value ==
+                <b>old</b>(info&lt;Token&gt;().total_value)
+                    - <b>old</b>(<b>global</b>&lt;<a href="#0x0_LibraDocTest_Preburn">Preburn</a>&lt;Token&gt;&gt;(preburn_address).requests[0].value);
+    <b>ensures</b> info&lt;Token&gt;().preburn_value ==
+                <b>old</b>(info&lt;Token&gt;().preburn_value)
+                    - <b>old</b>(<b>global</b>&lt;<a href="#0x0_LibraDocTest_Preburn">Preburn</a>&lt;Token&gt;&gt;(preburn_address).requests[0].value);
+}
+</code></pre>
+
+
+
+</details>
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="#0x0_LibraDocTest_burn">burn</a>&lt;Token&gt;(
+    preburn_address: address
+) <b>acquires</b> <a href="#0x0_LibraDocTest_Info">Info</a>, <a href="#0x0_LibraDocTest_MintCapability">MintCapability</a>, <a href="#0x0_LibraDocTest_Preburn">Preburn</a> {
+    <a href="#0x0_LibraDocTest_burn_with_capability">burn_with_capability</a>(
+        preburn_address,
+        borrow_global&lt;<a href="#0x0_LibraDocTest_MintCapability">MintCapability</a>&lt;Token&gt;&gt;(Transaction::sender())
+    )
+}
+</code></pre>
+
+
+
+</details>
+
+<a name="0x0_LibraDocTest_cancel_burn"></a>
+
+### Function `cancel_burn`
+
+Cancel the oldest burn request from
+<code>preburn_address</code>
+Fails if the sender does not have a published MintCapability.
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="#0x0_LibraDocTest_cancel_burn">cancel_burn</a>&lt;Token&gt;(preburn_address: address): <a href="#0x0_LibraDocTest_T">LibraDocTest::T</a>&lt;Token&gt;
+</code></pre>
+
+
+
+<details>
+<summary>Specification</summary>
+
+
+
+<pre><code><b>aborts_if</b> !exists_sender_mint_capability&lt;Token&gt;();
+<b>include</b> BasicBurnAbortsIf&lt;Token&gt;;
+<b>include</b> CancelBurnEnsures&lt;Token&gt;;
+</code></pre>
+
+
+
+
+<pre><code><b>schema</b> CancelBurnEnsures&lt;Token&gt; {
+    preburn_address: address;
+    result: <a href="#0x0_LibraDocTest_T">T</a>&lt;Token&gt;;
+    <b>ensures</b> Vector::eq_pop_front(
+                <b>global</b>&lt;<a href="#0x0_LibraDocTest_Preburn">Preburn</a>&lt;Token&gt;&gt;(preburn_address).requests,
+                <b>old</b>(<b>global</b>&lt;<a href="#0x0_LibraDocTest_Preburn">Preburn</a>&lt;Token&gt;&gt;(preburn_address).requests)
+            );
+    <b>ensures</b> info&lt;Token&gt;().preburn_value ==
+                <b>old</b>(info&lt;Token&gt;().preburn_value) - <b>old</b>(<b>global</b>&lt;<a href="#0x0_LibraDocTest_Preburn">Preburn</a>&lt;Token&gt;&gt;(preburn_address).requests[0].value);
+    <b>ensures</b> result == <b>old</b>(<b>global</b>&lt;<a href="#0x0_LibraDocTest_Preburn">Preburn</a>&lt;Token&gt;&gt;(preburn_address).requests[0]);
+}
+</code></pre>
+
+
+
+</details>
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="#0x0_LibraDocTest_cancel_burn">cancel_burn</a>&lt;Token&gt;(
+    preburn_address: address
+): <a href="#0x0_LibraDocTest_T">T</a>&lt;Token&gt; <b>acquires</b> <a href="#0x0_LibraDocTest_Info">Info</a>, <a href="#0x0_LibraDocTest_MintCapability">MintCapability</a>, <a href="#0x0_LibraDocTest_Preburn">Preburn</a> {
+    <a href="#0x0_LibraDocTest_cancel_burn_with_capability">cancel_burn_with_capability</a>(
+        preburn_address,
+        borrow_global&lt;<a href="#0x0_LibraDocTest_MintCapability">MintCapability</a>&lt;Token&gt;&gt;(Transaction::sender())
+    )
+}
+</code></pre>
+
+
+
+</details>
+
+<a name="0x0_LibraDocTest_new_preburn"></a>
+
+### Function `new_preburn`
+
+Create a new Preburn resource
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="#0x0_LibraDocTest_new_preburn">new_preburn</a>&lt;Token&gt;(): <a href="#0x0_LibraDocTest_Preburn">LibraDocTest::Preburn</a>&lt;Token&gt;
+</code></pre>
+
+
+
+<details>
+<summary>Specification</summary>
+
+
+
+<pre><code><b>aborts_if</b> !token_is_registered&lt;Token&gt;();
+<b>ensures</b> len(result.requests) == 0;
+<b>ensures</b> result.is_approved == <b>false</b>;
+</code></pre>
+
+
+
+</details>
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="#0x0_LibraDocTest_new_preburn">new_preburn</a>&lt;Token&gt;(): <a href="#0x0_LibraDocTest_Preburn">Preburn</a>&lt;Token&gt; {
+    <a href="#0x0_LibraDocTest_assert_is_registered">assert_is_registered</a>&lt;Token&gt;();
+    <a href="#0x0_LibraDocTest_Preburn">Preburn</a>&lt;Token&gt; { requests: Vector::empty(), is_approved: <b>false</b>, }
+}
+</code></pre>
+
+
+
+</details>
+
+<a name="0x0_LibraDocTest_mint_with_capability"></a>
+
+### Function `mint_with_capability`
+
+Mint a new
+<code><a href="#0x0_LibraDocTest_T">LibraDocTest::T</a></code> worth
+<code>value</code>. The caller must have a reference to a MintCapability.
+Only the Association account can acquire such a reference, and it can do so only via
+<code>borrow_sender_mint_capability</code>.
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="#0x0_LibraDocTest_mint_with_capability">mint_with_capability</a>&lt;Token&gt;(value: u64, _capability: &<a href="#0x0_LibraDocTest_MintCapability">LibraDocTest::MintCapability</a>&lt;Token&gt;): <a href="#0x0_LibraDocTest_T">LibraDocTest::T</a>&lt;Token&gt;
+</code></pre>
+
+
+
+<details>
+<summary>Specification</summary>
+
+
+
+<pre><code><b>include</b> MintAbortsIf&lt;Token&gt;{amount: value};
+<b>include</b> MintEnsures&lt;Token&gt;{amount: value};
+</code></pre>
+
+
+
+</details>
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="#0x0_LibraDocTest_mint_with_capability">mint_with_capability</a>&lt;Token&gt;(
+    value: u64,
+    _capability: &<a href="#0x0_LibraDocTest_MintCapability">MintCapability</a>&lt;Token&gt;
+): <a href="#0x0_LibraDocTest_T">T</a>&lt;Token&gt; <b>acquires</b> <a href="#0x0_LibraDocTest_Info">Info</a> {
+    <a href="#0x0_LibraDocTest_assert_is_registered">assert_is_registered</a>&lt;Token&gt;();
+    // TODO: temporary measure for testnet only: limit minting <b>to</b> 1B Libra at a time.
+    // this is <b>to</b> prevent the market cap's total value from hitting u64_max due <b>to</b> excessive
+    // minting. This will not be a problem in the production Libra system because coins will
+    // be backed with real-world assets, and thus minting will be correspondingly rarer.
+    // * 1000000 here because the unit is microlibra
+    Transaction::assert(<a href="#0x0_LibraDocTest_value">value</a> &lt;= 1000000000 * 1000000, 11);
+    // <b>update</b> market cap <b>resource</b> <b>to</b> reflect minting
+    <b>let</b> market_cap = borrow_global_mut&lt;<a href="#0x0_LibraDocTest_Info">Info</a>&lt;Token&gt;&gt;(0xA550C18);
+    market_cap.total_value = market_cap.total_value + (value <b>as</b> u128);
+
+    <a href="#0x0_LibraDocTest_T">T</a>&lt;Token&gt; { value }
+}
+</code></pre>
+
+
+
+</details>
+
+<a name="0x0_LibraDocTest_preburn"></a>
+
+### Function `preburn`
+
+Send coin to the preburn holding area
+<code>preburn_ref</code>, where it will wait to be burned.
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="#0x0_LibraDocTest_preburn">preburn</a>&lt;Token&gt;(preburn_ref: &<b>mut</b> <a href="#0x0_LibraDocTest_Preburn">LibraDocTest::Preburn</a>&lt;Token&gt;, coin: <a href="#0x0_LibraDocTest_T">LibraDocTest::T</a>&lt;Token&gt;)
+</code></pre>
+
+
+
+<details>
+<summary>Specification</summary>
+
+
+
+<pre><code><b>include</b> PreburnAbortsIf&lt;Token&gt;;
+<b>include</b> PreburnEnsures&lt;Token&gt;;
+</code></pre>
+
+
+
+
+<pre><code><b>schema</b> PreburnAbortsIf&lt;Token&gt; {
+    coin: <a href="#0x0_LibraDocTest_T">T</a>&lt;Token&gt;;
+    <b>aborts_if</b> !token_is_registered&lt;Token&gt;();
+    <b>aborts_if</b> info&lt;Token&gt;().preburn_value + coin.value &gt; max_u64();
+}
+</code></pre>
+
+
+
+
+<pre><code><b>schema</b> PreburnEnsures&lt;Token&gt; {
+    preburn_ref: &<b>mut</b> <a href="#0x0_LibraDocTest_Preburn">Preburn</a>&lt;Token&gt;;
+    coin: <a href="#0x0_LibraDocTest_T">T</a>&lt;Token&gt;;
+    <b>ensures</b> info&lt;Token&gt;().preburn_value == <b>old</b>(info&lt;Token&gt;().preburn_value) + coin.value;
+    <b>ensures</b> Vector::eq_push_back(preburn_ref.requests, <b>old</b>(preburn_ref.requests), coin);
+}
+</code></pre>
+
+
+
+</details>
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="#0x0_LibraDocTest_preburn">preburn</a>&lt;Token&gt;(
+    preburn_ref: &<b>mut</b> <a href="#0x0_LibraDocTest_Preburn">Preburn</a>&lt;Token&gt;,
+    coin: <a href="#0x0_LibraDocTest_T">T</a>&lt;Token&gt;
+) <b>acquires</b> <a href="#0x0_LibraDocTest_Info">Info</a> {
+    // TODO: bring this back once we can automate approvals in testnet
+    // Transaction::assert(preburn_ref.is_approved, 13);
+    <b>let</b> coin_value = <a href="#0x0_LibraDocTest_value">value</a>(&coin);
+    Vector::push_back(
+        &<b>mut</b> preburn_ref.requests,
+        coin
+    );
+    <b>let</b> market_cap = borrow_global_mut&lt;<a href="#0x0_LibraDocTest_Info">Info</a>&lt;Token&gt;&gt;(0xA550C18);
+    market_cap.preburn_value = market_cap.preburn_value + coin_value
+}
+</code></pre>
+
+
+
+</details>
+
+<a name="0x0_LibraDocTest_preburn_to_sender"></a>
+
+### Function `preburn_to_sender`
+
+Send coin to the preburn holding area, where it will wait to be burned.
+Fails if the sender does not have a published Preburn resource
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="#0x0_LibraDocTest_preburn_to_sender">preburn_to_sender</a>&lt;Token&gt;(coin: <a href="#0x0_LibraDocTest_T">LibraDocTest::T</a>&lt;Token&gt;)
+</code></pre>
+
+
+
+<details>
+<summary>Specification</summary>
+
+
+
+<pre><code><b>include</b> PreburnAbortsIf&lt;Token&gt;;
+<b>aborts_if</b> !exists&lt;<a href="#0x0_LibraDocTest_Preburn">Preburn</a>&lt;Token&gt;&gt;(sender());
+<b>include</b> PreburnEnsures&lt;Token&gt;{preburn_ref: <b>global</b>&lt;<a href="#0x0_LibraDocTest_Preburn">Preburn</a>&lt;Token&gt;&gt;(sender())};
+</code></pre>
+
+
+
+</details>
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="#0x0_LibraDocTest_preburn_to_sender">preburn_to_sender</a>&lt;Token&gt;(coin: <a href="#0x0_LibraDocTest_T">T</a>&lt;Token&gt;) <b>acquires</b> <a href="#0x0_LibraDocTest_Info">Info</a>, <a href="#0x0_LibraDocTest_Preburn">Preburn</a> {
+    <a href="#0x0_LibraDocTest_preburn">preburn</a>(borrow_global_mut&lt;<a href="#0x0_LibraDocTest_Preburn">Preburn</a>&lt;Token&gt;&gt;(Transaction::sender()), coin)
+}
+</code></pre>
+
+
+
+</details>
+
+<a name="0x0_LibraDocTest_burn_with_capability"></a>
+
+### Function `burn_with_capability`
+
+Permanently remove the coins held in the
+<code><a href="#0x0_LibraDocTest_Preburn">Preburn</a></code> resource stored at
+<code>preburn_address</code> and
+update the market cap accordingly. If there are multiple preburn requests in progress, this
+will remove the oldest one.
+Can only be invoked by the holder of the MintCapability. Fails if the there is no
+<code><a href="#0x0_LibraDocTest_Preburn">Preburn</a></code>
+resource under
+<code>preburn_address</code> or has one with no pending burn requests.
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="#0x0_LibraDocTest_burn_with_capability">burn_with_capability</a>&lt;Token&gt;(preburn_address: address, _capability: &<a href="#0x0_LibraDocTest_MintCapability">LibraDocTest::MintCapability</a>&lt;Token&gt;)
+</code></pre>
+
+
+
+<details>
+<summary>Specification</summary>
+
+
+
+<pre><code><b>include</b> BurnAbortsIf&lt;Token&gt;;
+<b>aborts_if</b> info&lt;Token&gt;().total_value &lt; <b>global</b>&lt;<a href="#0x0_LibraDocTest_Preburn">Preburn</a>&lt;Token&gt;&gt;(preburn_address).requests[0].value;
+<b>include</b> BurnEnsures&lt;Token&gt;;
+</code></pre>
+
+
+
+</details>
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="#0x0_LibraDocTest_burn_with_capability">burn_with_capability</a>&lt;Token&gt;(
+    preburn_address: address,
+    _capability: &<a href="#0x0_LibraDocTest_MintCapability">MintCapability</a>&lt;Token&gt;
+) <b>acquires</b> <a href="#0x0_LibraDocTest_Info">Info</a>, <a href="#0x0_LibraDocTest_Preburn">Preburn</a> {
+    // destroy the coin at the head of the preburn queue
+    <b>let</b> preburn = borrow_global_mut&lt;<a href="#0x0_LibraDocTest_Preburn">Preburn</a>&lt;Token&gt;&gt;(preburn_address);
+    <b>let</b> <a href="#0x0_LibraDocTest_T">T</a> { value } = Vector::remove(&<b>mut</b> preburn.requests, 0);
+    // <b>update</b> the market cap
+    <b>let</b> market_cap = borrow_global_mut&lt;<a href="#0x0_LibraDocTest_Info">Info</a>&lt;Token&gt;&gt;(0xA550C18);
+    market_cap.total_value = market_cap.total_value - (value <b>as</b> u128);
+    market_cap.preburn_value = market_cap.preburn_value - value
+}
+</code></pre>
+
+
+
+</details>
+
+<a name="0x0_LibraDocTest_cancel_burn_with_capability"></a>
+
+### Function `cancel_burn_with_capability`
+
+Cancel the burn request in the
+<code><a href="#0x0_LibraDocTest_Preburn">Preburn</a></code> resource stored at
+<code>preburn_address</code> and
+return the coins to the caller.
+If there are multiple preburn requests in progress, this will cancel the oldest one.
+Can only be invoked by the holder of the MintCapability. Fails if the transaction sender
+does not have a published Preburn resource or has one with no pending burn requests.
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="#0x0_LibraDocTest_cancel_burn_with_capability">cancel_burn_with_capability</a>&lt;Token&gt;(preburn_address: address, _capability: &<a href="#0x0_LibraDocTest_MintCapability">LibraDocTest::MintCapability</a>&lt;Token&gt;): <a href="#0x0_LibraDocTest_T">LibraDocTest::T</a>&lt;Token&gt;
+</code></pre>
+
+
+
+<details>
+<summary>Specification</summary>
+
+
+
+<pre><code><b>include</b> BasicBurnAbortsIf&lt;Token&gt;;
+<b>include</b> CancelBurnEnsures&lt;Token&gt;;
+</code></pre>
+
+
+
+</details>
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="#0x0_LibraDocTest_cancel_burn_with_capability">cancel_burn_with_capability</a>&lt;Token&gt;(
+    preburn_address: address,
+    _capability: &<a href="#0x0_LibraDocTest_MintCapability">MintCapability</a>&lt;Token&gt;
+): <a href="#0x0_LibraDocTest_T">T</a>&lt;Token&gt; <b>acquires</b> <a href="#0x0_LibraDocTest_Info">Info</a>, <a href="#0x0_LibraDocTest_Preburn">Preburn</a> {
+    // destroy the coin at the head of the preburn queue
+    <b>let</b> preburn = borrow_global_mut&lt;<a href="#0x0_LibraDocTest_Preburn">Preburn</a>&lt;Token&gt;&gt;(preburn_address);
+    <b>let</b> coin = Vector::remove(&<b>mut</b> preburn.requests, 0);
+    // <b>update</b> the market cap
+    <b>let</b> market_cap = borrow_global_mut&lt;<a href="#0x0_LibraDocTest_Info">Info</a>&lt;Token&gt;&gt;(0xA550C18);
+    market_cap.preburn_value = market_cap.preburn_value - <a href="#0x0_LibraDocTest_value">value</a>(&coin);
+
+    coin
+}
+</code></pre>
+
+
+
+</details>
+
+<a name="0x0_LibraDocTest_publish_preburn"></a>
+
+### Function `publish_preburn`
+
+Publish
+<code>preburn</code> under the sender's account
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="#0x0_LibraDocTest_publish_preburn">publish_preburn</a>&lt;Token&gt;(preburn: <a href="#0x0_LibraDocTest_Preburn">LibraDocTest::Preburn</a>&lt;Token&gt;)
+</code></pre>
+
+
+
+<details>
+<summary>Specification</summary>
+
+
+
+<pre><code><b>aborts_if</b> exists&lt;<a href="#0x0_LibraDocTest_Preburn">Preburn</a>&lt;Token&gt;&gt;(sender());
+<b>ensures</b> exists&lt;<a href="#0x0_LibraDocTest_Preburn">Preburn</a>&lt;Token&gt;&gt;(sender());
+<b>ensures</b> <b>global</b>&lt;<a href="#0x0_LibraDocTest_Preburn">Preburn</a>&lt;Token&gt;&gt;(sender()) == preburn;
+</code></pre>
+
+
+
+</details>
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="#0x0_LibraDocTest_publish_preburn">publish_preburn</a>&lt;Token&gt;(preburn: <a href="#0x0_LibraDocTest_Preburn">Preburn</a>&lt;Token&gt;) {
+    move_to_sender(preburn)
+}
+</code></pre>
+
+
+
+</details>
+
+<a name="0x0_LibraDocTest_remove_preburn"></a>
+
+### Function `remove_preburn`
+
+Remove and return the
+<code><a href="#0x0_LibraDocTest_Preburn">Preburn</a></code> resource under the sender's account
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="#0x0_LibraDocTest_remove_preburn">remove_preburn</a>&lt;Token&gt;(): <a href="#0x0_LibraDocTest_Preburn">LibraDocTest::Preburn</a>&lt;Token&gt;
+</code></pre>
+
+
+
+<details>
+<summary>Specification</summary>
+
+
+
+<pre><code><b>aborts_if</b> !exists&lt;<a href="#0x0_LibraDocTest_Preburn">Preburn</a>&lt;Token&gt;&gt;(sender());
+<b>ensures</b> !exists&lt;<a href="#0x0_LibraDocTest_Preburn">Preburn</a>&lt;Token&gt;&gt;(sender());
+<b>ensures</b> result == <b>old</b>(<b>global</b>&lt;<a href="#0x0_LibraDocTest_Preburn">Preburn</a>&lt;Token&gt;&gt;(sender()));
+</code></pre>
+
+
+
+</details>
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="#0x0_LibraDocTest_remove_preburn">remove_preburn</a>&lt;Token&gt;(): <a href="#0x0_LibraDocTest_Preburn">Preburn</a>&lt;Token&gt; <b>acquires</b> <a href="#0x0_LibraDocTest_Preburn">Preburn</a> {
+    move_from&lt;<a href="#0x0_LibraDocTest_Preburn">Preburn</a>&lt;Token&gt;&gt;(Transaction::sender())
+}
+</code></pre>
+
+
+
+</details>
+
+<a name="0x0_LibraDocTest_destroy_preburn"></a>
+
+### Function `destroy_preburn`
+
+Destroys the given preburn resource.
+Aborts if
+<code>requests</code> is non-empty
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="#0x0_LibraDocTest_destroy_preburn">destroy_preburn</a>&lt;Token&gt;(preburn: <a href="#0x0_LibraDocTest_Preburn">LibraDocTest::Preburn</a>&lt;Token&gt;)
+</code></pre>
+
+
+
+<details>
+<summary>Specification</summary>
+
+
+
+<pre><code><b>aborts_if</b> len(preburn.requests) &gt; 0;
+</code></pre>
+
+
+
+</details>
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="#0x0_LibraDocTest_destroy_preburn">destroy_preburn</a>&lt;Token&gt;(preburn: <a href="#0x0_LibraDocTest_Preburn">Preburn</a>&lt;Token&gt;) {
+    <b>let</b> <a href="#0x0_LibraDocTest_Preburn">Preburn</a> { requests, is_approved: _ } = preburn;
+    Vector::destroy_empty(requests)
+}
+</code></pre>
+
+
+
+</details>
+
+<a name="0x0_LibraDocTest_publish_mint_capability"></a>
+
+### Function `publish_mint_capability`
+
+Publish
+<code>capability</code> under the sender's account
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="#0x0_LibraDocTest_publish_mint_capability">publish_mint_capability</a>&lt;Token&gt;(capability: <a href="#0x0_LibraDocTest_MintCapability">LibraDocTest::MintCapability</a>&lt;Token&gt;)
+</code></pre>
+
+
+
+<details>
+<summary>Specification</summary>
+
+
+
+<pre><code><b>aborts_if</b> exists_sender_mint_capability&lt;Token&gt;();
+<b>ensures</b> exists_sender_mint_capability&lt;Token&gt;();
+<b>ensures</b> capability == <b>global</b>&lt;<a href="#0x0_LibraDocTest_MintCapability">MintCapability</a>&lt;Token&gt;&gt;(sender());
+</code></pre>
+
+
+
+</details>
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="#0x0_LibraDocTest_publish_mint_capability">publish_mint_capability</a>&lt;Token&gt;(capability: <a href="#0x0_LibraDocTest_MintCapability">MintCapability</a>&lt;Token&gt;) {
+    move_to_sender(capability)
+}
+</code></pre>
+
+
+
+</details>
+
+<a name="0x0_LibraDocTest_remove_mint_capability"></a>
+
+### Function `remove_mint_capability`
+
+Remove and return the MintCapability from the sender's account. Fails if the sender does
+not have a published MintCapability
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="#0x0_LibraDocTest_remove_mint_capability">remove_mint_capability</a>&lt;Token&gt;(): <a href="#0x0_LibraDocTest_MintCapability">LibraDocTest::MintCapability</a>&lt;Token&gt;
+</code></pre>
+
+
+
+<details>
+<summary>Specification</summary>
+
+
+
+<pre><code><b>aborts_if</b> !exists_sender_mint_capability&lt;Token&gt;();
+<b>ensures</b> !exists_sender_mint_capability&lt;Token&gt;();
+<b>ensures</b> result == <b>old</b>(<b>global</b>&lt;<a href="#0x0_LibraDocTest_MintCapability">MintCapability</a>&lt;Token&gt;&gt;(sender()));
+</code></pre>
+
+
+
+</details>
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="#0x0_LibraDocTest_remove_mint_capability">remove_mint_capability</a>&lt;Token&gt;(): <a href="#0x0_LibraDocTest_MintCapability">MintCapability</a>&lt;Token&gt; <b>acquires</b> <a href="#0x0_LibraDocTest_MintCapability">MintCapability</a> {
+    move_from&lt;<a href="#0x0_LibraDocTest_MintCapability">MintCapability</a>&lt;Token&gt;&gt;(Transaction::sender())
+}
+</code></pre>
+
+
+
+</details>
+
+<a name="0x0_LibraDocTest_market_cap"></a>
+
+### Function `market_cap`
+
+Return the total value of all Libra in the system
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="#0x0_LibraDocTest_market_cap">market_cap</a>&lt;Token&gt;(): u128
+</code></pre>
+
+
+
+<details>
+<summary>Specification</summary>
+
+
+
+<pre><code><b>aborts_if</b> !token_is_registered&lt;Token&gt;();
+<b>ensures</b> result == info&lt;Token&gt;().total_value;
+</code></pre>
+
+
+
+</details>
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="#0x0_LibraDocTest_market_cap">market_cap</a>&lt;Token&gt;(): u128 <b>acquires</b> <a href="#0x0_LibraDocTest_Info">Info</a> {
+    borrow_global&lt;<a href="#0x0_LibraDocTest_Info">Info</a>&lt;Token&gt;&gt;(0xA550C18).total_value
+}
+</code></pre>
+
+
+
+</details>
+
+<a name="0x0_LibraDocTest_preburn_value"></a>
+
+### Function `preburn_value`
+
+Return the total value of Libra to be burned
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="#0x0_LibraDocTest_preburn_value">preburn_value</a>&lt;Token&gt;(): u64
+</code></pre>
+
+
+
+<details>
+<summary>Specification</summary>
+
+
+
+<pre><code><b>aborts_if</b> !token_is_registered&lt;Token&gt;();
+<b>ensures</b> result == info&lt;Token&gt;().preburn_value;
+</code></pre>
+
+
+
+</details>
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="#0x0_LibraDocTest_preburn_value">preburn_value</a>&lt;Token&gt;(): u64 <b>acquires</b> <a href="#0x0_LibraDocTest_Info">Info</a> {
+    borrow_global&lt;<a href="#0x0_LibraDocTest_Info">Info</a>&lt;Token&gt;&gt;(0xA550C18).preburn_value
+}
+</code></pre>
+
+
+
+</details>
+
+<a name="0x0_LibraDocTest_zero"></a>
+
+### Function `zero`
+
+Create a new
+<code><a href="#0x0_LibraDocTest_T">LibraDocTest::T</a></code> with a value of 0
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="#0x0_LibraDocTest_zero">zero</a>&lt;Token&gt;(): <a href="#0x0_LibraDocTest_T">LibraDocTest::T</a>&lt;Token&gt;
+</code></pre>
+
+
+
+<details>
+<summary>Specification</summary>
+
+
+
+<pre><code><b>aborts_if</b> !token_is_registered&lt;Token&gt;();
+<b>ensures</b> result.value == 0;
+</code></pre>
+
+
+
+</details>
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="#0x0_LibraDocTest_zero">zero</a>&lt;Token&gt;(): <a href="#0x0_LibraDocTest_T">T</a>&lt;Token&gt; {
+    // prevent silly coin types (e.g., Libra&lt;bool&gt;) from being created
+    <a href="#0x0_LibraDocTest_assert_is_registered">assert_is_registered</a>&lt;Token&gt;();
+    <a href="#0x0_LibraDocTest_T">T</a> { value: 0 }
+}
+</code></pre>
+
+
+
+</details>
+
+<a name="0x0_LibraDocTest_value"></a>
+
+### Function `value`
+
+Public accessor for the value of a coin
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="#0x0_LibraDocTest_value">value</a>&lt;Token&gt;(coin_ref: &<a href="#0x0_LibraDocTest_T">LibraDocTest::T</a>&lt;Token&gt;): u64
+</code></pre>
+
+
+
+<details>
+<summary>Specification</summary>
+
+
+
+<pre><code><b>ensures</b> result == coin_ref.value;
+</code></pre>
+
+
+
+</details>
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="#0x0_LibraDocTest_value">value</a>&lt;Token&gt;(coin_ref: &<a href="#0x0_LibraDocTest_T">T</a>&lt;Token&gt;): u64 {
+    coin_ref.value
+}
+</code></pre>
+
+
+
+</details>
+
+<a name="0x0_LibraDocTest_split"></a>
+
+### Function `split`
+
+Splits the given coin into two and returns them both
+It leverages
+<code>withdraw</code> for any verifications of the values
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="#0x0_LibraDocTest_split">split</a>&lt;Token&gt;(coin: <a href="#0x0_LibraDocTest_T">LibraDocTest::T</a>&lt;Token&gt;, amount: u64): (<a href="#0x0_LibraDocTest_T">LibraDocTest::T</a>&lt;Token&gt;, <a href="#0x0_LibraDocTest_T">LibraDocTest::T</a>&lt;Token&gt;)
+</code></pre>
+
+
+
+<details>
+<summary>Specification</summary>
+
+
+
+<pre><code><b>aborts_if</b> coin.<a href="#0x0_LibraDocTest_value">value</a> &lt; amount;
+<b>ensures</b> result_1.value == coin.value - amount;
+<b>ensures</b> result_2.value == amount;
+</code></pre>
+
+
+
+</details>
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="#0x0_LibraDocTest_split">split</a>&lt;Token&gt;(coin: <a href="#0x0_LibraDocTest_T">T</a>&lt;Token&gt;, amount: u64): (<a href="#0x0_LibraDocTest_T">T</a>&lt;Token&gt;, <a href="#0x0_LibraDocTest_T">T</a>&lt;Token&gt;) {
+    <b>let</b> other = <a href="#0x0_LibraDocTest_withdraw">withdraw</a>(&<b>mut</b> coin, amount);
+    (coin, other)
+}
+</code></pre>
+
+
+
+</details>
+
+<a name="0x0_LibraDocTest_withdraw"></a>
+
+### Function `withdraw`
+
+"Divides" the given coin into two, where original coin is modified in place
+The original coin will have value = original value -
+<code>value</code>
+The new coin will have a value =
+<code>value</code>
+Fails if the coins value is less than
+<code>value</code>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="#0x0_LibraDocTest_withdraw">withdraw</a>&lt;Token&gt;(coin_ref: &<b>mut</b> <a href="#0x0_LibraDocTest_T">LibraDocTest::T</a>&lt;Token&gt;, value: u64): <a href="#0x0_LibraDocTest_T">LibraDocTest::T</a>&lt;Token&gt;
+</code></pre>
+
+
+
+<details>
+<summary>Specification</summary>
+
+
+
+<pre><code><b>aborts_if</b> coin_ref.<a href="#0x0_LibraDocTest_value">value</a> &lt; value;
+<b>ensures</b> coin_ref.value == <b>old</b>(coin_ref.value) - value;
+<b>ensures</b> result.value == value;
+</code></pre>
+
+
+
+</details>
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="#0x0_LibraDocTest_withdraw">withdraw</a>&lt;Token&gt;(coin_ref: &<b>mut</b> <a href="#0x0_LibraDocTest_T">T</a>&lt;Token&gt;, value: u64): <a href="#0x0_LibraDocTest_T">T</a>&lt;Token&gt; {
+    // Check that `amount` is less than the coin's value
+    Transaction::assert(coin_ref.value &gt;= value, 10);
+
+    // Split the coin
+    coin_ref.value = coin_ref.value - value;
+    <a href="#0x0_LibraDocTest_T">T</a> { value }
+}
+</code></pre>
+
+
+
+</details>
+
+<a name="0x0_LibraDocTest_join"></a>
+
+### Function `join`
+
+Merges two coins and returns a new coin whose value is equal to the sum of the two inputs
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="#0x0_LibraDocTest_join">join</a>&lt;Token&gt;(coin1: <a href="#0x0_LibraDocTest_T">LibraDocTest::T</a>&lt;Token&gt;, coin2: <a href="#0x0_LibraDocTest_T">LibraDocTest::T</a>&lt;Token&gt;): <a href="#0x0_LibraDocTest_T">LibraDocTest::T</a>&lt;Token&gt;
+</code></pre>
+
+
+
+<details>
+<summary>Specification</summary>
+
+
+
+<pre><code><b>aborts_if</b> coin1.value + coin2.value &gt; max_u64();
+<b>ensures</b> result.value == coin1.value + coin2.value;
+</code></pre>
+
+
+
+</details>
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="#0x0_LibraDocTest_join">join</a>&lt;Token&gt;(coin1: <a href="#0x0_LibraDocTest_T">T</a>&lt;Token&gt;, coin2: <a href="#0x0_LibraDocTest_T">T</a>&lt;Token&gt;): <a href="#0x0_LibraDocTest_T">T</a>&lt;Token&gt;  {
+    <a href="#0x0_LibraDocTest_deposit">deposit</a>(&<b>mut</b> coin1, coin2);
+    coin1
+}
+</code></pre>
+
+
+
+</details>
+
+<a name="0x0_LibraDocTest_deposit"></a>
+
+### Function `deposit`
+
+"Merges" the two coins
+The coin passed in by reference will have a value equal to the sum of the two coins
+The
+<code>check</code> coin is consumed in the process
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="#0x0_LibraDocTest_deposit">deposit</a>&lt;Token&gt;(coin_ref: &<b>mut</b> <a href="#0x0_LibraDocTest_T">LibraDocTest::T</a>&lt;Token&gt;, check: <a href="#0x0_LibraDocTest_T">LibraDocTest::T</a>&lt;Token&gt;)
+</code></pre>
+
+
+
+<details>
+<summary>Specification</summary>
+
+
+
+<pre><code><b>aborts_if</b> coin_ref.value + check.value &gt; max_u64();
+<b>ensures</b> coin_ref.value == <b>old</b>(coin_ref.value) + check.value;
+</code></pre>
+
+
+
+</details>
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="#0x0_LibraDocTest_deposit">deposit</a>&lt;Token&gt;(coin_ref: &<b>mut</b> <a href="#0x0_LibraDocTest_T">T</a>&lt;Token&gt;, check: <a href="#0x0_LibraDocTest_T">T</a>&lt;Token&gt;) {
+    <b>let</b> <a href="#0x0_LibraDocTest_T">T</a> { value } = check;
+    coin_ref.value= coin_ref.value + value;
+}
+</code></pre>
+
+
+
+</details>
+
+<a name="0x0_LibraDocTest_destroy_zero"></a>
+
+### Function `destroy_zero`
+
+Destroy a coin
+Fails if the value is non-zero
+The amount of
+<code><a href="#0x0_LibraDocTest_T">LibraDocTest::T</a></code> in the system is a tightly controlled property,
+so you cannot "burn" any non-zero amount of
+<code><a href="#0x0_LibraDocTest_T">LibraDocTest::T</a></code>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="#0x0_LibraDocTest_destroy_zero">destroy_zero</a>&lt;Token&gt;(coin: <a href="#0x0_LibraDocTest_T">LibraDocTest::T</a>&lt;Token&gt;)
+</code></pre>
+
+
+
+<details>
+<summary>Specification</summary>
+
+
+
+<pre><code><b>aborts_if</b> coin.value &gt; 0;
+</code></pre>
+
+
+
+</details>
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="#0x0_LibraDocTest_destroy_zero">destroy_zero</a>&lt;Token&gt;(coin: <a href="#0x0_LibraDocTest_T">T</a>&lt;Token&gt;) {
+    <b>let</b> <a href="#0x0_LibraDocTest_T">T</a>&lt;Token&gt; { value } = coin;
+    Transaction::assert(value == 0, 11);
+}
+</code></pre>
+
+
+
+</details>

--- a/language/move-prover/docgen/tests/sources/libra.spec_inline.md
+++ b/language/move-prover/docgen/tests/sources/libra.spec_inline.md
@@ -1,4 +1,4 @@
-## Table of Content
+## Table of Contents
 -  [Module `0x0::LibraDocTest`](#0x0_LibraDocTest)
     -  [Struct `T`](#0x0_LibraDocTest_T)
     -  [Struct `MintCapability`](#0x0_LibraDocTest_MintCapability)

--- a/language/move-prover/docgen/tests/sources/libra.spec_inline_no_fold.md
+++ b/language/move-prover/docgen/tests/sources/libra.spec_inline_no_fold.md
@@ -1,0 +1,1378 @@
+## Table of Content
+-  [Module `0x0::LibraDocTest`](#0x0_LibraDocTest)
+    -  [Struct `T`](#0x0_LibraDocTest_T)
+    -  [Struct `MintCapability`](#0x0_LibraDocTest_MintCapability)
+    -  [Struct `Info`](#0x0_LibraDocTest_Info)
+    -  [Struct `Preburn`](#0x0_LibraDocTest_Preburn)
+    -  [Function `register`](#0x0_LibraDocTest_register)
+    -  [Function `assert_is_registered`](#0x0_LibraDocTest_assert_is_registered)
+    -  [Function `mint`](#0x0_LibraDocTest_mint)
+    -  [Function `burn`](#0x0_LibraDocTest_burn)
+    -  [Function `cancel_burn`](#0x0_LibraDocTest_cancel_burn)
+    -  [Function `new_preburn`](#0x0_LibraDocTest_new_preburn)
+    -  [Function `mint_with_capability`](#0x0_LibraDocTest_mint_with_capability)
+    -  [Function `preburn`](#0x0_LibraDocTest_preburn)
+    -  [Function `preburn_to_sender`](#0x0_LibraDocTest_preburn_to_sender)
+    -  [Function `burn_with_capability`](#0x0_LibraDocTest_burn_with_capability)
+    -  [Function `cancel_burn_with_capability`](#0x0_LibraDocTest_cancel_burn_with_capability)
+    -  [Function `publish_preburn`](#0x0_LibraDocTest_publish_preburn)
+    -  [Function `remove_preburn`](#0x0_LibraDocTest_remove_preburn)
+    -  [Function `destroy_preburn`](#0x0_LibraDocTest_destroy_preburn)
+    -  [Function `publish_mint_capability`](#0x0_LibraDocTest_publish_mint_capability)
+    -  [Function `remove_mint_capability`](#0x0_LibraDocTest_remove_mint_capability)
+    -  [Function `market_cap`](#0x0_LibraDocTest_market_cap)
+    -  [Function `preburn_value`](#0x0_LibraDocTest_preburn_value)
+    -  [Function `zero`](#0x0_LibraDocTest_zero)
+    -  [Function `value`](#0x0_LibraDocTest_value)
+    -  [Function `split`](#0x0_LibraDocTest_split)
+    -  [Function `withdraw`](#0x0_LibraDocTest_withdraw)
+    -  [Function `join`](#0x0_LibraDocTest_join)
+    -  [Function `deposit`](#0x0_LibraDocTest_deposit)
+    -  [Function `destroy_zero`](#0x0_LibraDocTest_destroy_zero)
+
+<a name="0x0_LibraDocTest"></a>
+
+## Module `0x0::LibraDocTest`
+
+The Libra module defines basic functionality around coins.
+
+### Note
+
+This is not a consistent and up-to-date implementation, specification, or documentation
+of the
+<code>Libra</code> module. It is rather a playground for testing the documentation generator.
+
+> We use block quotes like this to mark documentation text which is specific to docgen testing.
+>
+> We can refer to a module like in
+<code><a href="#0x0_LibraDocTest">LibraDocTest</a></code> -- if it is unambiguous -- or like
+<code><a href="#0x0_LibraDocTest">0x0::LibraDocTest</a></code>.
+
+### Settings for Verification
+
+> Spec module blocks which are associated with the module do not have an implicit header and
+> are directly included in the module doc (or Specification sub-section if
+<code>--doc-<b>spec</b>-inline=<b>false</b></code>).
+> To get a header, one needs to be explicitly assigned like we do here.
+
+Verify also private functions.
+
+
+<pre><code>pragma verify = <b>true</b>;
+</code></pre>
+
+
+
+<a name="0x0_LibraDocTest_T"></a>
+
+### Struct `T`
+
+A resource representing a fungible token
+
+
+<pre><code><b>resource</b> <b>struct</b> <a href="#0x0_LibraDocTest_T">T</a>&lt;Token&gt;
+</code></pre>
+
+
+
+##### Fields
+
+
+<dl>
+<dt>
+
+<code>value: u64</code>
+</dt>
+<dd>
+ The value of the token. May be zero
+</dd>
+</dl>
+
+
+##### Specification
+
+Maintains sum_of_token
+
+
+<pre><code><b>invariant</b> <b>pack</b> sum_of_token_values&lt;Token&gt; = sum_of_token_values&lt;Token&gt; + value;
+<b>invariant</b> <b>unpack</b> sum_of_token_values&lt;Token&gt; = sum_of_token_values&lt;Token&gt; - value;
+</code></pre>
+
+
+
+This ghost variable is defined to have the true sum values of all instances of Token
+
+
+<pre><code><b>global</b> sum_of_token_values&lt;Token&gt;: num;
+</code></pre>
+
+
+
+
+<pre><code><b>schema</b> SumRemainsSame&lt;Token&gt; {
+    <b>ensures</b> sum_of_token_values&lt;Token&gt; == <b>old</b>(sum_of_token_values&lt;Token&gt;);
+}
+</code></pre>
+
+
+
+Only mint/burn & with capability versions can change the total amount of currency.
+skip mint, burn, mint_with_capability, burn_with_capability.
+Burn always aborts because Preburn.is_approved is always false.
+
+
+<pre><code><b>apply</b> SumRemainsSame&lt;Token&gt; <b>to</b> *&lt;Token&gt; <b>except</b> mint*&lt;Token&gt;, burn*&lt;Token&gt;;
+</code></pre>
+
+
+
+SPEC: MarketCap == Sum of all the instances of a particular token.
+Note: this works even though the verifier does not
+know that each existing token.value must be <= sum_of_token_values. I assume that
+total_value is constrained to be non-negative, so it all works. I should check this out.
+Note: What is the value of a ghost variable in the genesis state?
+State machine with two states (not registered/registered), so write as two invariants.
+
+
+<pre><code><b>schema</b> SumOfTokenValuesInvariant&lt;Token&gt; {
+    <b>invariant</b> <b>module</b> !token_is_registered&lt;Token&gt;() ==&gt; sum_of_token_values&lt;Token&gt; == 0;
+    <b>invariant</b> <b>module</b> token_is_registered&lt;Token&gt;()
+                   ==&gt; sum_of_token_values&lt;Token&gt; == <b>global</b>&lt;<a href="#0x0_LibraDocTest_Info">Info</a>&lt;Token&gt;&gt;(0xA550C18).total_value;
+}
+</code></pre>
+
+
+
+
+<pre><code><b>apply</b> SumOfTokenValuesInvariant&lt;Token&gt; <b>to</b> <b>public</b> *&lt;Token&gt;;
+</code></pre>
+
+
+
+<a name="0x0_LibraDocTest_MintCapability"></a>
+
+### Struct `MintCapability`
+
+A singleton resource that grants access to
+<code><a href="#0x0_LibraDocTest_mint">LibraDocTest::mint</a></code>. Only the Association has one.
+
+> Instead of
+<code><a href="#0x0_LibraDocTest_mint">LibraDocTest::mint</a></code> we can also write
+<code><a href="#0x0_LibraDocTest_mint">0x0::LibraDocTest::mint</a></code>,
+<code><a href="#0x0_LibraDocTest_mint">Self::mint</a></code>, or just
+<code><a href="#0x0_LibraDocTest_mint">mint</a>()</code>
+> (for functions from enclosing module) to get a hyper link in documentation text.
+
+
+<pre><code><b>resource</b> <b>struct</b> <a href="#0x0_LibraDocTest_MintCapability">MintCapability</a>&lt;Token&gt;
+</code></pre>
+
+
+
+##### Fields
+
+
+<dl>
+<dt>
+
+<code>dummy_field: bool</code>
+</dt>
+<dd>
+
+</dd>
+</dl>
+
+
+##### Specification
+
+Maintain mint_capability_count
+
+
+<pre><code><b>invariant</b> <b>pack</b> mint_capability_count&lt;Token&gt; = mint_capability_count&lt;Token&gt; + 1;
+<b>invariant</b> <b>unpack</b> mint_capability_count&lt;Token&gt; = mint_capability_count&lt;Token&gt; - 1;
+</code></pre>
+
+
+
+Ghost variable representing the total number of MintCapability instances for Token (0 or 1).
+
+
+<pre><code><b>global</b> mint_capability_count&lt;Token&gt;: num;
+</code></pre>
+
+
+Helper to check whether sender has MintCapability.
+
+
+<pre><code>define exists_sender_mint_capability&lt;Token&gt;(): bool { exists&lt;<a href="#0x0_LibraDocTest_MintCapability">MintCapability</a>&lt;Token&gt;&gt;(sender()) }
+</code></pre>
+
+
+There is a MintCapability for Token iff the token is registered
+> For the below schema, we have documentation comments on members. In the case of module/function/struct
+> spec blocks, we can just flatten all spec block members with possibly
+> attached member documentation into the section. For schemas this is not possible.
+> So we repeat a schema declaration multiple times, "extending" it.
+
+If token is not registered, there can be no capability.
+
+
+<pre><code><b>schema</b> MintCapabilityCountInvariant&lt;Token&gt; {
+    <b>invariant</b> <b>module</b> !token_is_registered&lt;Token&gt;() ==&gt; mint_capability_count&lt;Token&gt; == 0;
+}
+</code></pre>
+
+
+If token is registered, there is exactly one capability.
+
+
+<pre><code><b>schema</b> MintCapabilityCountInvariant&lt;Token&gt; {
+    <b>invariant</b> <b>module</b> token_is_registered&lt;Token&gt;() ==&gt; mint_capability_count&lt;Token&gt; == 1;
+}
+</code></pre>
+
+
+
+
+<pre><code><b>apply</b> MintCapabilityCountInvariant&lt;Token&gt; <b>to</b> <b>public</b> *&lt;Token&gt;;
+</code></pre>
+
+
+
+<a name="0x0_LibraDocTest_Info"></a>
+
+### Struct `Info`
+
+
+
+<pre><code><b>resource</b> <b>struct</b> <a href="#0x0_LibraDocTest_Info">Info</a>&lt;Token&gt;
+</code></pre>
+
+
+
+##### Fields
+
+
+<dl>
+<dt>
+
+<code>total_value: u128</code>
+</dt>
+<dd>
+ The sum of the values of all
+<code><a href="#0x0_LibraDocTest_T">LibraDocTest::T</a></code> resources in the system
+</dd>
+<dt>
+
+<code>preburn_value: u64</code>
+</dt>
+<dd>
+ Value of funds that are in the process of being burned
+</dd>
+</dl>
+
+
+##### Specification
+
+
+Specifications helpers for working with Info<Token> at association address.
+
+
+<pre><code>define association_address(): address { 0xA550C18 }
+define token_is_registered&lt;Token&gt;(): bool { exists&lt;<a href="#0x0_LibraDocTest_Info">Info</a>&lt;Token&gt;&gt;(association_address()) }
+define info&lt;Token&gt;(): <a href="#0x0_LibraDocTest_Info">Info</a>&lt;Token&gt; { <b>global</b>&lt;<a href="#0x0_LibraDocTest_Info">Info</a>&lt;Token&gt;&gt;(association_address()) }
+</code></pre>
+
+
+Once registered, a token stays registered forever.
+
+
+<pre><code><b>schema</b> RegistrationPersists&lt;Token&gt; {
+    <b>ensures</b> <b>old</b>(token_is_registered&lt;Token&gt;()) ==&gt; token_is_registered&lt;Token&gt;();
+}
+</code></pre>
+
+
+
+
+<pre><code><b>apply</b> RegistrationPersists&lt;Token&gt; <b>to</b> *&lt;Token&gt;;
+</code></pre>
+
+
+
+<a name="0x0_LibraDocTest_Preburn"></a>
+
+### Struct `Preburn`
+
+A holding area where funds that will subsequently be burned wait while their underyling
+assets are sold off-chain.
+This resource can only be created by the holder of the MintCapability. An account that
+contains this address has the authority to initiate a burn request. A burn request can be
+resolved by the holder of the MintCapability by either (1) burning the funds, or (2)
+returning the funds to the account that initiated the burn request.
+This design supports multiple preburn requests in flight at the same time, including multiple
+burn requests from the same account. However, burn requests from the same account must be
+resolved in FIFO order.
+
+
+<pre><code><b>resource</b> <b>struct</b> <a href="#0x0_LibraDocTest_Preburn">Preburn</a>&lt;Token&gt;
+</code></pre>
+
+
+
+##### Fields
+
+
+<dl>
+<dt>
+
+<code>requests: vector&lt;<a href="#0x0_LibraDocTest_T">LibraDocTest::T</a>&lt;Token&gt;&gt;</code>
+</dt>
+<dd>
+ Queue of pending burn requests
+</dd>
+<dt>
+
+<code>is_approved: bool</code>
+</dt>
+<dd>
+ Boolean that is true if the holder of the MintCapability has approved this account as a
+ preburner
+</dd>
+</dl>
+
+
+<a name="0x0_LibraDocTest_register"></a>
+
+### Function `register`
+
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="#0x0_LibraDocTest_register">register</a>&lt;Token&gt;()
+</code></pre>
+
+
+
+##### Specification
+
+
+
+<pre><code><b>include</b> RegisterAbortsIf&lt;Token&gt;;
+<b>ensures</b> exists_sender_mint_capability&lt;Token&gt;();
+<b>ensures</b> token_is_registered&lt;Token&gt;();
+<b>ensures</b> info&lt;Token&gt;().total_value == 0;
+<b>ensures</b> info&lt;Token&gt;().preburn_value == 0;
+</code></pre>
+
+
+
+
+<pre><code><b>schema</b> RegisterAbortsIf&lt;Token&gt; {
+    <b>aborts_if</b> sender() != association_address();
+    <b>aborts_if</b> exists_sender_mint_capability&lt;Token&gt;();
+    <b>aborts_if</b> token_is_registered&lt;Token&gt;();
+}
+</code></pre>
+
+
+
+##### Implementation
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="#0x0_LibraDocTest_register">register</a>&lt;Token&gt;() {
+    // Only callable by the Association address
+    Transaction::assert(Transaction::sender() == 0xA550C18, 1);
+    move_to_sender(<a href="#0x0_LibraDocTest_MintCapability">MintCapability</a>&lt;Token&gt;{ });
+    move_to_sender(<a href="#0x0_LibraDocTest_Info">Info</a>&lt;Token&gt; { total_value: 0u128, preburn_value: 0 });
+}
+</code></pre>
+
+
+
+<a name="0x0_LibraDocTest_assert_is_registered"></a>
+
+### Function `assert_is_registered`
+
+
+
+<pre><code><b>fun</b> <a href="#0x0_LibraDocTest_assert_is_registered">assert_is_registered</a>&lt;Token&gt;()
+</code></pre>
+
+
+
+##### Specification
+
+
+
+<pre><code><b>aborts_if</b> !token_is_registered&lt;Token&gt;();
+</code></pre>
+
+
+
+##### Implementation
+
+
+<pre><code><b>fun</b> <a href="#0x0_LibraDocTest_assert_is_registered">assert_is_registered</a>&lt;Token&gt;() {
+    Transaction::assert(exists&lt;<a href="#0x0_LibraDocTest_Info">Info</a>&lt;Token&gt;&gt;(0xA550C18), 12);
+}
+</code></pre>
+
+
+
+<a name="0x0_LibraDocTest_mint"></a>
+
+### Function `mint`
+
+Return
+<code>amount</code> coins.
+Fails if the sender does not have a published MintCapability.
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="#0x0_LibraDocTest_mint">mint</a>&lt;Token&gt;(amount: u64): <a href="#0x0_LibraDocTest_T">LibraDocTest::T</a>&lt;Token&gt;
+</code></pre>
+
+
+
+##### Specification
+
+
+
+<pre><code><b>include</b> MintAbortsIf&lt;Token&gt;;
+<b>aborts_if</b> !exists_sender_mint_capability&lt;Token&gt;();
+<b>include</b> MintEnsures&lt;Token&gt;;
+</code></pre>
+
+
+
+
+<pre><code><b>schema</b> MintAbortsIf&lt;Token&gt; {
+    amount: u64;
+    <b>aborts_if</b> !token_is_registered&lt;Token&gt;();
+    <b>aborts_if</b> amount &gt; 1000000000 * 1000000;
+    <b>aborts_if</b> info&lt;Token&gt;().total_value + amount &gt; max_u128();
+}
+</code></pre>
+
+
+
+
+<pre><code><b>schema</b> MintEnsures&lt;Token&gt; {
+    amount: u64;
+    result: <a href="#0x0_LibraDocTest_T">T</a>&lt;Token&gt;;
+    <b>ensures</b> info&lt;Token&gt;().total_value == <b>old</b>(info&lt;Token&gt;().total_value) + amount;
+    <b>ensures</b> result.value == amount;
+}
+</code></pre>
+
+
+
+##### Implementation
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="#0x0_LibraDocTest_mint">mint</a>&lt;Token&gt;(amount: u64): <a href="#0x0_LibraDocTest_T">T</a>&lt;Token&gt; <b>acquires</b> <a href="#0x0_LibraDocTest_Info">Info</a>, <a href="#0x0_LibraDocTest_MintCapability">MintCapability</a> {
+    <a href="#0x0_LibraDocTest_mint_with_capability">mint_with_capability</a>(amount, borrow_global&lt;<a href="#0x0_LibraDocTest_MintCapability">MintCapability</a>&lt;Token&gt;&gt;(Transaction::sender()))
+}
+</code></pre>
+
+
+
+<a name="0x0_LibraDocTest_burn"></a>
+
+### Function `burn`
+
+Burn the coins currently held in the preburn holding area under
+<code>preburn_address</code>.
+Fails if the sender does not have a published MintCapability.
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="#0x0_LibraDocTest_burn">burn</a>&lt;Token&gt;(preburn_address: address)
+</code></pre>
+
+
+
+##### Specification
+
+
+
+<pre><code><b>aborts_if</b> !exists_sender_mint_capability&lt;Token&gt;();
+<b>include</b> BurnAbortsIf&lt;Token&gt;;
+<b>include</b> BurnEnsures&lt;Token&gt;;
+</code></pre>
+
+
+Properties applying both to burn and to burn_cancel functions.
+
+
+<pre><code><b>schema</b> BasicBurnAbortsIf&lt;Token&gt; {
+    preburn_address: address;
+    <b>aborts_if</b> !exists&lt;<a href="#0x0_LibraDocTest_Preburn">Preburn</a>&lt;Token&gt;&gt;(preburn_address);
+    <b>aborts_if</b> len(<b>global</b>&lt;<a href="#0x0_LibraDocTest_Preburn">Preburn</a>&lt;Token&gt;&gt;(preburn_address).requests) == 0;
+    <b>aborts_if</b> !token_is_registered&lt;Token&gt;();
+    <b>aborts_if</b> info&lt;Token&gt;().<a href="#0x0_LibraDocTest_preburn_value">preburn_value</a> &lt; <b>global</b>&lt;<a href="#0x0_LibraDocTest_Preburn">Preburn</a>&lt;Token&gt;&gt;(preburn_address).requests[0].value;
+}
+</code></pre>
+
+
+
+
+<pre><code><b>schema</b> BurnAbortsIf&lt;Token&gt; {
+    <b>include</b> BasicBurnAbortsIf&lt;Token&gt;;
+    <b>aborts_if</b> info&lt;Token&gt;().total_value &lt; <b>global</b>&lt;<a href="#0x0_LibraDocTest_Preburn">Preburn</a>&lt;Token&gt;&gt;(preburn_address).requests[0].value;
+}
+</code></pre>
+
+
+
+
+<pre><code><b>schema</b> BurnEnsures&lt;Token&gt; {
+    preburn_address: address;
+    <b>ensures</b> Vector::eq_pop_front(
+                <b>global</b>&lt;<a href="#0x0_LibraDocTest_Preburn">Preburn</a>&lt;Token&gt;&gt;(preburn_address).requests,
+                <b>old</b>(<b>global</b>&lt;<a href="#0x0_LibraDocTest_Preburn">Preburn</a>&lt;Token&gt;&gt;(preburn_address).requests)
+            );
+    <b>ensures</b> info&lt;Token&gt;().total_value ==
+                <b>old</b>(info&lt;Token&gt;().total_value)
+                    - <b>old</b>(<b>global</b>&lt;<a href="#0x0_LibraDocTest_Preburn">Preburn</a>&lt;Token&gt;&gt;(preburn_address).requests[0].value);
+    <b>ensures</b> info&lt;Token&gt;().preburn_value ==
+                <b>old</b>(info&lt;Token&gt;().preburn_value)
+                    - <b>old</b>(<b>global</b>&lt;<a href="#0x0_LibraDocTest_Preburn">Preburn</a>&lt;Token&gt;&gt;(preburn_address).requests[0].value);
+}
+</code></pre>
+
+
+
+##### Implementation
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="#0x0_LibraDocTest_burn">burn</a>&lt;Token&gt;(
+    preburn_address: address
+) <b>acquires</b> <a href="#0x0_LibraDocTest_Info">Info</a>, <a href="#0x0_LibraDocTest_MintCapability">MintCapability</a>, <a href="#0x0_LibraDocTest_Preburn">Preburn</a> {
+    <a href="#0x0_LibraDocTest_burn_with_capability">burn_with_capability</a>(
+        preburn_address,
+        borrow_global&lt;<a href="#0x0_LibraDocTest_MintCapability">MintCapability</a>&lt;Token&gt;&gt;(Transaction::sender())
+    )
+}
+</code></pre>
+
+
+
+<a name="0x0_LibraDocTest_cancel_burn"></a>
+
+### Function `cancel_burn`
+
+Cancel the oldest burn request from
+<code>preburn_address</code>
+Fails if the sender does not have a published MintCapability.
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="#0x0_LibraDocTest_cancel_burn">cancel_burn</a>&lt;Token&gt;(preburn_address: address): <a href="#0x0_LibraDocTest_T">LibraDocTest::T</a>&lt;Token&gt;
+</code></pre>
+
+
+
+##### Specification
+
+
+
+<pre><code><b>aborts_if</b> !exists_sender_mint_capability&lt;Token&gt;();
+<b>include</b> BasicBurnAbortsIf&lt;Token&gt;;
+<b>include</b> CancelBurnEnsures&lt;Token&gt;;
+</code></pre>
+
+
+
+
+<pre><code><b>schema</b> CancelBurnEnsures&lt;Token&gt; {
+    preburn_address: address;
+    result: <a href="#0x0_LibraDocTest_T">T</a>&lt;Token&gt;;
+    <b>ensures</b> Vector::eq_pop_front(
+                <b>global</b>&lt;<a href="#0x0_LibraDocTest_Preburn">Preburn</a>&lt;Token&gt;&gt;(preburn_address).requests,
+                <b>old</b>(<b>global</b>&lt;<a href="#0x0_LibraDocTest_Preburn">Preburn</a>&lt;Token&gt;&gt;(preburn_address).requests)
+            );
+    <b>ensures</b> info&lt;Token&gt;().preburn_value ==
+                <b>old</b>(info&lt;Token&gt;().preburn_value) - <b>old</b>(<b>global</b>&lt;<a href="#0x0_LibraDocTest_Preburn">Preburn</a>&lt;Token&gt;&gt;(preburn_address).requests[0].value);
+    <b>ensures</b> result == <b>old</b>(<b>global</b>&lt;<a href="#0x0_LibraDocTest_Preburn">Preburn</a>&lt;Token&gt;&gt;(preburn_address).requests[0]);
+}
+</code></pre>
+
+
+
+##### Implementation
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="#0x0_LibraDocTest_cancel_burn">cancel_burn</a>&lt;Token&gt;(
+    preburn_address: address
+): <a href="#0x0_LibraDocTest_T">T</a>&lt;Token&gt; <b>acquires</b> <a href="#0x0_LibraDocTest_Info">Info</a>, <a href="#0x0_LibraDocTest_MintCapability">MintCapability</a>, <a href="#0x0_LibraDocTest_Preburn">Preburn</a> {
+    <a href="#0x0_LibraDocTest_cancel_burn_with_capability">cancel_burn_with_capability</a>(
+        preburn_address,
+        borrow_global&lt;<a href="#0x0_LibraDocTest_MintCapability">MintCapability</a>&lt;Token&gt;&gt;(Transaction::sender())
+    )
+}
+</code></pre>
+
+
+
+<a name="0x0_LibraDocTest_new_preburn"></a>
+
+### Function `new_preburn`
+
+Create a new Preburn resource
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="#0x0_LibraDocTest_new_preburn">new_preburn</a>&lt;Token&gt;(): <a href="#0x0_LibraDocTest_Preburn">LibraDocTest::Preburn</a>&lt;Token&gt;
+</code></pre>
+
+
+
+##### Specification
+
+
+
+<pre><code><b>aborts_if</b> !token_is_registered&lt;Token&gt;();
+<b>ensures</b> len(result.requests) == 0;
+<b>ensures</b> result.is_approved == <b>false</b>;
+</code></pre>
+
+
+
+##### Implementation
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="#0x0_LibraDocTest_new_preburn">new_preburn</a>&lt;Token&gt;(): <a href="#0x0_LibraDocTest_Preburn">Preburn</a>&lt;Token&gt; {
+    <a href="#0x0_LibraDocTest_assert_is_registered">assert_is_registered</a>&lt;Token&gt;();
+    <a href="#0x0_LibraDocTest_Preburn">Preburn</a>&lt;Token&gt; { requests: Vector::empty(), is_approved: <b>false</b>, }
+}
+</code></pre>
+
+
+
+<a name="0x0_LibraDocTest_mint_with_capability"></a>
+
+### Function `mint_with_capability`
+
+Mint a new
+<code><a href="#0x0_LibraDocTest_T">LibraDocTest::T</a></code> worth
+<code>value</code>. The caller must have a reference to a MintCapability.
+Only the Association account can acquire such a reference, and it can do so only via
+<code>borrow_sender_mint_capability</code>.
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="#0x0_LibraDocTest_mint_with_capability">mint_with_capability</a>&lt;Token&gt;(value: u64, _capability: &<a href="#0x0_LibraDocTest_MintCapability">LibraDocTest::MintCapability</a>&lt;Token&gt;): <a href="#0x0_LibraDocTest_T">LibraDocTest::T</a>&lt;Token&gt;
+</code></pre>
+
+
+
+##### Specification
+
+
+
+<pre><code><b>include</b> MintAbortsIf&lt;Token&gt;{amount: value};
+<b>include</b> MintEnsures&lt;Token&gt;{amount: value};
+</code></pre>
+
+
+
+##### Implementation
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="#0x0_LibraDocTest_mint_with_capability">mint_with_capability</a>&lt;Token&gt;(
+    value: u64,
+    _capability: &<a href="#0x0_LibraDocTest_MintCapability">MintCapability</a>&lt;Token&gt;
+): <a href="#0x0_LibraDocTest_T">T</a>&lt;Token&gt; <b>acquires</b> <a href="#0x0_LibraDocTest_Info">Info</a> {
+    <a href="#0x0_LibraDocTest_assert_is_registered">assert_is_registered</a>&lt;Token&gt;();
+    // TODO: temporary measure for testnet only: limit minting <b>to</b> 1B Libra at a time.
+    // this is <b>to</b> prevent the market cap's total value from hitting u64_max due <b>to</b> excessive
+    // minting. This will not be a problem in the production Libra system because coins will
+    // be backed with real-world assets, and thus minting will be correspondingly rarer.
+    // * 1000000 here because the unit is microlibra
+    Transaction::assert(<a href="#0x0_LibraDocTest_value">value</a> &lt;= 1000000000 * 1000000, 11);
+    // <b>update</b> market cap <b>resource</b> <b>to</b> reflect minting
+    <b>let</b> market_cap = borrow_global_mut&lt;<a href="#0x0_LibraDocTest_Info">Info</a>&lt;Token&gt;&gt;(0xA550C18);
+    market_cap.total_value = market_cap.total_value + (value <b>as</b> u128);
+
+    <a href="#0x0_LibraDocTest_T">T</a>&lt;Token&gt; { value }
+}
+</code></pre>
+
+
+
+<a name="0x0_LibraDocTest_preburn"></a>
+
+### Function `preburn`
+
+Send coin to the preburn holding area
+<code>preburn_ref</code>, where it will wait to be burned.
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="#0x0_LibraDocTest_preburn">preburn</a>&lt;Token&gt;(preburn_ref: &<b>mut</b> <a href="#0x0_LibraDocTest_Preburn">LibraDocTest::Preburn</a>&lt;Token&gt;, coin: <a href="#0x0_LibraDocTest_T">LibraDocTest::T</a>&lt;Token&gt;)
+</code></pre>
+
+
+
+##### Specification
+
+
+
+<pre><code><b>include</b> PreburnAbortsIf&lt;Token&gt;;
+<b>include</b> PreburnEnsures&lt;Token&gt;;
+</code></pre>
+
+
+
+
+<pre><code><b>schema</b> PreburnAbortsIf&lt;Token&gt; {
+    coin: <a href="#0x0_LibraDocTest_T">T</a>&lt;Token&gt;;
+    <b>aborts_if</b> !token_is_registered&lt;Token&gt;();
+    <b>aborts_if</b> info&lt;Token&gt;().preburn_value + coin.value &gt; max_u64();
+}
+</code></pre>
+
+
+
+
+<pre><code><b>schema</b> PreburnEnsures&lt;Token&gt; {
+    preburn_ref: &<b>mut</b> <a href="#0x0_LibraDocTest_Preburn">Preburn</a>&lt;Token&gt;;
+    coin: <a href="#0x0_LibraDocTest_T">T</a>&lt;Token&gt;;
+    <b>ensures</b> info&lt;Token&gt;().preburn_value == <b>old</b>(info&lt;Token&gt;().preburn_value) + coin.value;
+    <b>ensures</b> Vector::eq_push_back(preburn_ref.requests, <b>old</b>(preburn_ref.requests), coin);
+}
+</code></pre>
+
+
+
+##### Implementation
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="#0x0_LibraDocTest_preburn">preburn</a>&lt;Token&gt;(
+    preburn_ref: &<b>mut</b> <a href="#0x0_LibraDocTest_Preburn">Preburn</a>&lt;Token&gt;,
+    coin: <a href="#0x0_LibraDocTest_T">T</a>&lt;Token&gt;
+) <b>acquires</b> <a href="#0x0_LibraDocTest_Info">Info</a> {
+    // TODO: bring this back once we can automate approvals in testnet
+    // Transaction::assert(preburn_ref.is_approved, 13);
+    <b>let</b> coin_value = <a href="#0x0_LibraDocTest_value">value</a>(&coin);
+    Vector::push_back(
+        &<b>mut</b> preburn_ref.requests,
+        coin
+    );
+    <b>let</b> market_cap = borrow_global_mut&lt;<a href="#0x0_LibraDocTest_Info">Info</a>&lt;Token&gt;&gt;(0xA550C18);
+    market_cap.preburn_value = market_cap.preburn_value + coin_value
+}
+</code></pre>
+
+
+
+<a name="0x0_LibraDocTest_preburn_to_sender"></a>
+
+### Function `preburn_to_sender`
+
+Send coin to the preburn holding area, where it will wait to be burned.
+Fails if the sender does not have a published Preburn resource
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="#0x0_LibraDocTest_preburn_to_sender">preburn_to_sender</a>&lt;Token&gt;(coin: <a href="#0x0_LibraDocTest_T">LibraDocTest::T</a>&lt;Token&gt;)
+</code></pre>
+
+
+
+##### Specification
+
+
+
+<pre><code><b>include</b> PreburnAbortsIf&lt;Token&gt;;
+<b>aborts_if</b> !exists&lt;<a href="#0x0_LibraDocTest_Preburn">Preburn</a>&lt;Token&gt;&gt;(sender());
+<b>include</b> PreburnEnsures&lt;Token&gt;{preburn_ref: <b>global</b>&lt;<a href="#0x0_LibraDocTest_Preburn">Preburn</a>&lt;Token&gt;&gt;(sender())};
+</code></pre>
+
+
+
+##### Implementation
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="#0x0_LibraDocTest_preburn_to_sender">preburn_to_sender</a>&lt;Token&gt;(coin: <a href="#0x0_LibraDocTest_T">T</a>&lt;Token&gt;) <b>acquires</b> <a href="#0x0_LibraDocTest_Info">Info</a>, <a href="#0x0_LibraDocTest_Preburn">Preburn</a> {
+    <a href="#0x0_LibraDocTest_preburn">preburn</a>(borrow_global_mut&lt;<a href="#0x0_LibraDocTest_Preburn">Preburn</a>&lt;Token&gt;&gt;(Transaction::sender()), coin)
+}
+</code></pre>
+
+
+
+<a name="0x0_LibraDocTest_burn_with_capability"></a>
+
+### Function `burn_with_capability`
+
+Permanently remove the coins held in the
+<code><a href="#0x0_LibraDocTest_Preburn">Preburn</a></code> resource stored at
+<code>preburn_address</code> and
+update the market cap accordingly. If there are multiple preburn requests in progress, this
+will remove the oldest one.
+Can only be invoked by the holder of the MintCapability. Fails if the there is no
+<code><a href="#0x0_LibraDocTest_Preburn">Preburn</a></code>
+resource under
+<code>preburn_address</code> or has one with no pending burn requests.
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="#0x0_LibraDocTest_burn_with_capability">burn_with_capability</a>&lt;Token&gt;(preburn_address: address, _capability: &<a href="#0x0_LibraDocTest_MintCapability">LibraDocTest::MintCapability</a>&lt;Token&gt;)
+</code></pre>
+
+
+
+##### Specification
+
+
+
+<pre><code><b>include</b> BurnAbortsIf&lt;Token&gt;;
+<b>aborts_if</b> info&lt;Token&gt;().total_value &lt; <b>global</b>&lt;<a href="#0x0_LibraDocTest_Preburn">Preburn</a>&lt;Token&gt;&gt;(preburn_address).requests[0].value;
+<b>include</b> BurnEnsures&lt;Token&gt;;
+</code></pre>
+
+
+
+##### Implementation
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="#0x0_LibraDocTest_burn_with_capability">burn_with_capability</a>&lt;Token&gt;(
+    preburn_address: address,
+    _capability: &<a href="#0x0_LibraDocTest_MintCapability">MintCapability</a>&lt;Token&gt;
+) <b>acquires</b> <a href="#0x0_LibraDocTest_Info">Info</a>, <a href="#0x0_LibraDocTest_Preburn">Preburn</a> {
+    // destroy the coin at the head of the preburn queue
+    <b>let</b> preburn = borrow_global_mut&lt;<a href="#0x0_LibraDocTest_Preburn">Preburn</a>&lt;Token&gt;&gt;(preburn_address);
+    <b>let</b> <a href="#0x0_LibraDocTest_T">T</a> { value } = Vector::remove(&<b>mut</b> preburn.requests, 0);
+    // <b>update</b> the market cap
+    <b>let</b> market_cap = borrow_global_mut&lt;<a href="#0x0_LibraDocTest_Info">Info</a>&lt;Token&gt;&gt;(0xA550C18);
+    market_cap.total_value = market_cap.total_value - (value <b>as</b> u128);
+    market_cap.preburn_value = market_cap.preburn_value - value
+}
+</code></pre>
+
+
+
+<a name="0x0_LibraDocTest_cancel_burn_with_capability"></a>
+
+### Function `cancel_burn_with_capability`
+
+Cancel the burn request in the
+<code><a href="#0x0_LibraDocTest_Preburn">Preburn</a></code> resource stored at
+<code>preburn_address</code> and
+return the coins to the caller.
+If there are multiple preburn requests in progress, this will cancel the oldest one.
+Can only be invoked by the holder of the MintCapability. Fails if the transaction sender
+does not have a published Preburn resource or has one with no pending burn requests.
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="#0x0_LibraDocTest_cancel_burn_with_capability">cancel_burn_with_capability</a>&lt;Token&gt;(preburn_address: address, _capability: &<a href="#0x0_LibraDocTest_MintCapability">LibraDocTest::MintCapability</a>&lt;Token&gt;): <a href="#0x0_LibraDocTest_T">LibraDocTest::T</a>&lt;Token&gt;
+</code></pre>
+
+
+
+##### Specification
+
+
+
+<pre><code><b>include</b> BasicBurnAbortsIf&lt;Token&gt;;
+<b>include</b> CancelBurnEnsures&lt;Token&gt;;
+</code></pre>
+
+
+
+##### Implementation
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="#0x0_LibraDocTest_cancel_burn_with_capability">cancel_burn_with_capability</a>&lt;Token&gt;(
+    preburn_address: address,
+    _capability: &<a href="#0x0_LibraDocTest_MintCapability">MintCapability</a>&lt;Token&gt;
+): <a href="#0x0_LibraDocTest_T">T</a>&lt;Token&gt; <b>acquires</b> <a href="#0x0_LibraDocTest_Info">Info</a>, <a href="#0x0_LibraDocTest_Preburn">Preburn</a> {
+    // destroy the coin at the head of the preburn queue
+    <b>let</b> preburn = borrow_global_mut&lt;<a href="#0x0_LibraDocTest_Preburn">Preburn</a>&lt;Token&gt;&gt;(preburn_address);
+    <b>let</b> coin = Vector::remove(&<b>mut</b> preburn.requests, 0);
+    // <b>update</b> the market cap
+    <b>let</b> market_cap = borrow_global_mut&lt;<a href="#0x0_LibraDocTest_Info">Info</a>&lt;Token&gt;&gt;(0xA550C18);
+    market_cap.preburn_value = market_cap.preburn_value - <a href="#0x0_LibraDocTest_value">value</a>(&coin);
+
+    coin
+}
+</code></pre>
+
+
+
+<a name="0x0_LibraDocTest_publish_preburn"></a>
+
+### Function `publish_preburn`
+
+Publish
+<code>preburn</code> under the sender's account
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="#0x0_LibraDocTest_publish_preburn">publish_preburn</a>&lt;Token&gt;(preburn: <a href="#0x0_LibraDocTest_Preburn">LibraDocTest::Preburn</a>&lt;Token&gt;)
+</code></pre>
+
+
+
+##### Specification
+
+
+
+<pre><code><b>aborts_if</b> exists&lt;<a href="#0x0_LibraDocTest_Preburn">Preburn</a>&lt;Token&gt;&gt;(sender());
+<b>ensures</b> exists&lt;<a href="#0x0_LibraDocTest_Preburn">Preburn</a>&lt;Token&gt;&gt;(sender());
+<b>ensures</b> <b>global</b>&lt;<a href="#0x0_LibraDocTest_Preburn">Preburn</a>&lt;Token&gt;&gt;(sender()) == preburn;
+</code></pre>
+
+
+
+##### Implementation
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="#0x0_LibraDocTest_publish_preburn">publish_preburn</a>&lt;Token&gt;(preburn: <a href="#0x0_LibraDocTest_Preburn">Preburn</a>&lt;Token&gt;) {
+    move_to_sender(preburn)
+}
+</code></pre>
+
+
+
+<a name="0x0_LibraDocTest_remove_preburn"></a>
+
+### Function `remove_preburn`
+
+Remove and return the
+<code><a href="#0x0_LibraDocTest_Preburn">Preburn</a></code> resource under the sender's account
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="#0x0_LibraDocTest_remove_preburn">remove_preburn</a>&lt;Token&gt;(): <a href="#0x0_LibraDocTest_Preburn">LibraDocTest::Preburn</a>&lt;Token&gt;
+</code></pre>
+
+
+
+##### Specification
+
+
+
+<pre><code><b>aborts_if</b> !exists&lt;<a href="#0x0_LibraDocTest_Preburn">Preburn</a>&lt;Token&gt;&gt;(sender());
+<b>ensures</b> !exists&lt;<a href="#0x0_LibraDocTest_Preburn">Preburn</a>&lt;Token&gt;&gt;(sender());
+<b>ensures</b> result == <b>old</b>(<b>global</b>&lt;<a href="#0x0_LibraDocTest_Preburn">Preburn</a>&lt;Token&gt;&gt;(sender()));
+</code></pre>
+
+
+
+##### Implementation
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="#0x0_LibraDocTest_remove_preburn">remove_preburn</a>&lt;Token&gt;(): <a href="#0x0_LibraDocTest_Preburn">Preburn</a>&lt;Token&gt; <b>acquires</b> <a href="#0x0_LibraDocTest_Preburn">Preburn</a> {
+    move_from&lt;<a href="#0x0_LibraDocTest_Preburn">Preburn</a>&lt;Token&gt;&gt;(Transaction::sender())
+}
+</code></pre>
+
+
+
+<a name="0x0_LibraDocTest_destroy_preburn"></a>
+
+### Function `destroy_preburn`
+
+Destroys the given preburn resource.
+Aborts if
+<code>requests</code> is non-empty
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="#0x0_LibraDocTest_destroy_preburn">destroy_preburn</a>&lt;Token&gt;(preburn: <a href="#0x0_LibraDocTest_Preburn">LibraDocTest::Preburn</a>&lt;Token&gt;)
+</code></pre>
+
+
+
+##### Specification
+
+
+
+<pre><code><b>aborts_if</b> len(preburn.requests) &gt; 0;
+</code></pre>
+
+
+
+##### Implementation
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="#0x0_LibraDocTest_destroy_preburn">destroy_preburn</a>&lt;Token&gt;(preburn: <a href="#0x0_LibraDocTest_Preburn">Preburn</a>&lt;Token&gt;) {
+    <b>let</b> <a href="#0x0_LibraDocTest_Preburn">Preburn</a> { requests, is_approved: _ } = preburn;
+    Vector::destroy_empty(requests)
+}
+</code></pre>
+
+
+
+<a name="0x0_LibraDocTest_publish_mint_capability"></a>
+
+### Function `publish_mint_capability`
+
+Publish
+<code>capability</code> under the sender's account
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="#0x0_LibraDocTest_publish_mint_capability">publish_mint_capability</a>&lt;Token&gt;(capability: <a href="#0x0_LibraDocTest_MintCapability">LibraDocTest::MintCapability</a>&lt;Token&gt;)
+</code></pre>
+
+
+
+##### Specification
+
+
+
+<pre><code><b>aborts_if</b> exists_sender_mint_capability&lt;Token&gt;();
+<b>ensures</b> exists_sender_mint_capability&lt;Token&gt;();
+<b>ensures</b> capability == <b>global</b>&lt;<a href="#0x0_LibraDocTest_MintCapability">MintCapability</a>&lt;Token&gt;&gt;(sender());
+</code></pre>
+
+
+
+##### Implementation
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="#0x0_LibraDocTest_publish_mint_capability">publish_mint_capability</a>&lt;Token&gt;(capability: <a href="#0x0_LibraDocTest_MintCapability">MintCapability</a>&lt;Token&gt;) {
+    move_to_sender(capability)
+}
+</code></pre>
+
+
+
+<a name="0x0_LibraDocTest_remove_mint_capability"></a>
+
+### Function `remove_mint_capability`
+
+Remove and return the MintCapability from the sender's account. Fails if the sender does
+not have a published MintCapability
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="#0x0_LibraDocTest_remove_mint_capability">remove_mint_capability</a>&lt;Token&gt;(): <a href="#0x0_LibraDocTest_MintCapability">LibraDocTest::MintCapability</a>&lt;Token&gt;
+</code></pre>
+
+
+
+##### Specification
+
+
+
+<pre><code><b>aborts_if</b> !exists_sender_mint_capability&lt;Token&gt;();
+<b>ensures</b> !exists_sender_mint_capability&lt;Token&gt;();
+<b>ensures</b> result == <b>old</b>(<b>global</b>&lt;<a href="#0x0_LibraDocTest_MintCapability">MintCapability</a>&lt;Token&gt;&gt;(sender()));
+</code></pre>
+
+
+
+##### Implementation
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="#0x0_LibraDocTest_remove_mint_capability">remove_mint_capability</a>&lt;Token&gt;(): <a href="#0x0_LibraDocTest_MintCapability">MintCapability</a>&lt;Token&gt; <b>acquires</b> <a href="#0x0_LibraDocTest_MintCapability">MintCapability</a> {
+    move_from&lt;<a href="#0x0_LibraDocTest_MintCapability">MintCapability</a>&lt;Token&gt;&gt;(Transaction::sender())
+}
+</code></pre>
+
+
+
+<a name="0x0_LibraDocTest_market_cap"></a>
+
+### Function `market_cap`
+
+Return the total value of all Libra in the system
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="#0x0_LibraDocTest_market_cap">market_cap</a>&lt;Token&gt;(): u128
+</code></pre>
+
+
+
+##### Specification
+
+
+
+<pre><code><b>aborts_if</b> !token_is_registered&lt;Token&gt;();
+<b>ensures</b> result == info&lt;Token&gt;().total_value;
+</code></pre>
+
+
+
+##### Implementation
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="#0x0_LibraDocTest_market_cap">market_cap</a>&lt;Token&gt;(): u128 <b>acquires</b> <a href="#0x0_LibraDocTest_Info">Info</a> {
+    borrow_global&lt;<a href="#0x0_LibraDocTest_Info">Info</a>&lt;Token&gt;&gt;(0xA550C18).total_value
+}
+</code></pre>
+
+
+
+<a name="0x0_LibraDocTest_preburn_value"></a>
+
+### Function `preburn_value`
+
+Return the total value of Libra to be burned
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="#0x0_LibraDocTest_preburn_value">preburn_value</a>&lt;Token&gt;(): u64
+</code></pre>
+
+
+
+##### Specification
+
+
+
+<pre><code><b>aborts_if</b> !token_is_registered&lt;Token&gt;();
+<b>ensures</b> result == info&lt;Token&gt;().preburn_value;
+</code></pre>
+
+
+
+##### Implementation
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="#0x0_LibraDocTest_preburn_value">preburn_value</a>&lt;Token&gt;(): u64 <b>acquires</b> <a href="#0x0_LibraDocTest_Info">Info</a> {
+    borrow_global&lt;<a href="#0x0_LibraDocTest_Info">Info</a>&lt;Token&gt;&gt;(0xA550C18).preburn_value
+}
+</code></pre>
+
+
+
+<a name="0x0_LibraDocTest_zero"></a>
+
+### Function `zero`
+
+Create a new
+<code><a href="#0x0_LibraDocTest_T">LibraDocTest::T</a></code> with a value of 0
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="#0x0_LibraDocTest_zero">zero</a>&lt;Token&gt;(): <a href="#0x0_LibraDocTest_T">LibraDocTest::T</a>&lt;Token&gt;
+</code></pre>
+
+
+
+##### Specification
+
+
+
+<pre><code><b>aborts_if</b> !token_is_registered&lt;Token&gt;();
+<b>ensures</b> result.value == 0;
+</code></pre>
+
+
+
+##### Implementation
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="#0x0_LibraDocTest_zero">zero</a>&lt;Token&gt;(): <a href="#0x0_LibraDocTest_T">T</a>&lt;Token&gt; {
+    // prevent silly coin types (e.g., Libra&lt;bool&gt;) from being created
+    <a href="#0x0_LibraDocTest_assert_is_registered">assert_is_registered</a>&lt;Token&gt;();
+    <a href="#0x0_LibraDocTest_T">T</a> { value: 0 }
+}
+</code></pre>
+
+
+
+<a name="0x0_LibraDocTest_value"></a>
+
+### Function `value`
+
+Public accessor for the value of a coin
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="#0x0_LibraDocTest_value">value</a>&lt;Token&gt;(coin_ref: &<a href="#0x0_LibraDocTest_T">LibraDocTest::T</a>&lt;Token&gt;): u64
+</code></pre>
+
+
+
+##### Specification
+
+
+
+<pre><code><b>ensures</b> result == coin_ref.value;
+</code></pre>
+
+
+
+##### Implementation
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="#0x0_LibraDocTest_value">value</a>&lt;Token&gt;(coin_ref: &<a href="#0x0_LibraDocTest_T">T</a>&lt;Token&gt;): u64 {
+    coin_ref.value
+}
+</code></pre>
+
+
+
+<a name="0x0_LibraDocTest_split"></a>
+
+### Function `split`
+
+Splits the given coin into two and returns them both
+It leverages
+<code>withdraw</code> for any verifications of the values
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="#0x0_LibraDocTest_split">split</a>&lt;Token&gt;(coin: <a href="#0x0_LibraDocTest_T">LibraDocTest::T</a>&lt;Token&gt;, amount: u64): (<a href="#0x0_LibraDocTest_T">LibraDocTest::T</a>&lt;Token&gt;, <a href="#0x0_LibraDocTest_T">LibraDocTest::T</a>&lt;Token&gt;)
+</code></pre>
+
+
+
+##### Specification
+
+
+
+<pre><code><b>aborts_if</b> coin.<a href="#0x0_LibraDocTest_value">value</a> &lt; amount;
+<b>ensures</b> result_1.value == coin.value - amount;
+<b>ensures</b> result_2.value == amount;
+</code></pre>
+
+
+
+##### Implementation
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="#0x0_LibraDocTest_split">split</a>&lt;Token&gt;(coin: <a href="#0x0_LibraDocTest_T">T</a>&lt;Token&gt;, amount: u64): (<a href="#0x0_LibraDocTest_T">T</a>&lt;Token&gt;, <a href="#0x0_LibraDocTest_T">T</a>&lt;Token&gt;) {
+    <b>let</b> other = <a href="#0x0_LibraDocTest_withdraw">withdraw</a>(&<b>mut</b> coin, amount);
+    (coin, other)
+}
+</code></pre>
+
+
+
+<a name="0x0_LibraDocTest_withdraw"></a>
+
+### Function `withdraw`
+
+"Divides" the given coin into two, where original coin is modified in place
+The original coin will have value = original value -
+<code>value</code>
+The new coin will have a value =
+<code>value</code>
+Fails if the coins value is less than
+<code>value</code>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="#0x0_LibraDocTest_withdraw">withdraw</a>&lt;Token&gt;(coin_ref: &<b>mut</b> <a href="#0x0_LibraDocTest_T">LibraDocTest::T</a>&lt;Token&gt;, value: u64): <a href="#0x0_LibraDocTest_T">LibraDocTest::T</a>&lt;Token&gt;
+</code></pre>
+
+
+
+##### Specification
+
+
+
+<pre><code><b>aborts_if</b> coin_ref.<a href="#0x0_LibraDocTest_value">value</a> &lt; value;
+<b>ensures</b> coin_ref.value == <b>old</b>(coin_ref.value) - value;
+<b>ensures</b> result.value == value;
+</code></pre>
+
+
+
+##### Implementation
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="#0x0_LibraDocTest_withdraw">withdraw</a>&lt;Token&gt;(coin_ref: &<b>mut</b> <a href="#0x0_LibraDocTest_T">T</a>&lt;Token&gt;, value: u64): <a href="#0x0_LibraDocTest_T">T</a>&lt;Token&gt; {
+    // Check that `amount` is less than the coin's value
+    Transaction::assert(coin_ref.value &gt;= value, 10);
+
+    // Split the coin
+    coin_ref.value = coin_ref.value - value;
+    <a href="#0x0_LibraDocTest_T">T</a> { value }
+}
+</code></pre>
+
+
+
+<a name="0x0_LibraDocTest_join"></a>
+
+### Function `join`
+
+Merges two coins and returns a new coin whose value is equal to the sum of the two inputs
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="#0x0_LibraDocTest_join">join</a>&lt;Token&gt;(coin1: <a href="#0x0_LibraDocTest_T">LibraDocTest::T</a>&lt;Token&gt;, coin2: <a href="#0x0_LibraDocTest_T">LibraDocTest::T</a>&lt;Token&gt;): <a href="#0x0_LibraDocTest_T">LibraDocTest::T</a>&lt;Token&gt;
+</code></pre>
+
+
+
+##### Specification
+
+
+
+<pre><code><b>aborts_if</b> coin1.value + coin2.value &gt; max_u64();
+<b>ensures</b> result.value == coin1.value + coin2.value;
+</code></pre>
+
+
+
+##### Implementation
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="#0x0_LibraDocTest_join">join</a>&lt;Token&gt;(coin1: <a href="#0x0_LibraDocTest_T">T</a>&lt;Token&gt;, coin2: <a href="#0x0_LibraDocTest_T">T</a>&lt;Token&gt;): <a href="#0x0_LibraDocTest_T">T</a>&lt;Token&gt;  {
+    <a href="#0x0_LibraDocTest_deposit">deposit</a>(&<b>mut</b> coin1, coin2);
+    coin1
+}
+</code></pre>
+
+
+
+<a name="0x0_LibraDocTest_deposit"></a>
+
+### Function `deposit`
+
+"Merges" the two coins
+The coin passed in by reference will have a value equal to the sum of the two coins
+The
+<code>check</code> coin is consumed in the process
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="#0x0_LibraDocTest_deposit">deposit</a>&lt;Token&gt;(coin_ref: &<b>mut</b> <a href="#0x0_LibraDocTest_T">LibraDocTest::T</a>&lt;Token&gt;, check: <a href="#0x0_LibraDocTest_T">LibraDocTest::T</a>&lt;Token&gt;)
+</code></pre>
+
+
+
+##### Specification
+
+
+
+<pre><code><b>aborts_if</b> coin_ref.value + check.value &gt; max_u64();
+<b>ensures</b> coin_ref.value == <b>old</b>(coin_ref.value) + check.value;
+</code></pre>
+
+
+
+##### Implementation
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="#0x0_LibraDocTest_deposit">deposit</a>&lt;Token&gt;(coin_ref: &<b>mut</b> <a href="#0x0_LibraDocTest_T">T</a>&lt;Token&gt;, check: <a href="#0x0_LibraDocTest_T">T</a>&lt;Token&gt;) {
+    <b>let</b> <a href="#0x0_LibraDocTest_T">T</a> { value } = check;
+    coin_ref.value= coin_ref.value + value;
+}
+</code></pre>
+
+
+
+<a name="0x0_LibraDocTest_destroy_zero"></a>
+
+### Function `destroy_zero`
+
+Destroy a coin
+Fails if the value is non-zero
+The amount of
+<code><a href="#0x0_LibraDocTest_T">LibraDocTest::T</a></code> in the system is a tightly controlled property,
+so you cannot "burn" any non-zero amount of
+<code><a href="#0x0_LibraDocTest_T">LibraDocTest::T</a></code>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="#0x0_LibraDocTest_destroy_zero">destroy_zero</a>&lt;Token&gt;(coin: <a href="#0x0_LibraDocTest_T">LibraDocTest::T</a>&lt;Token&gt;)
+</code></pre>
+
+
+
+##### Specification
+
+
+
+<pre><code><b>aborts_if</b> coin.value &gt; 0;
+</code></pre>
+
+
+
+##### Implementation
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="#0x0_LibraDocTest_destroy_zero">destroy_zero</a>&lt;Token&gt;(coin: <a href="#0x0_LibraDocTest_T">T</a>&lt;Token&gt;) {
+    <b>let</b> <a href="#0x0_LibraDocTest_T">T</a>&lt;Token&gt; { value } = coin;
+    Transaction::assert(value == 0, 11);
+}
+</code></pre>

--- a/language/move-prover/docgen/tests/sources/libra.spec_inline_no_fold.md
+++ b/language/move-prover/docgen/tests/sources/libra.spec_inline_no_fold.md
@@ -1,4 +1,4 @@
-## Table of Content
+## Table of Contents
 -  [Module `0x0::LibraDocTest`](#0x0_LibraDocTest)
     -  [Struct `T`](#0x0_LibraDocTest_T)
     -  [Struct `MintCapability`](#0x0_LibraDocTest_MintCapability)

--- a/language/move-prover/docgen/tests/sources/libra.spec_separate.md
+++ b/language/move-prover/docgen/tests/sources/libra.spec_separate.md
@@ -1,0 +1,1736 @@
+## Table of Content
+-  [Module `0x0::LibraDocTest`](#0x0_LibraDocTest)
+    -  [Struct `T`](#0x0_LibraDocTest_T)
+    -  [Struct `MintCapability`](#0x0_LibraDocTest_MintCapability)
+    -  [Struct `Info`](#0x0_LibraDocTest_Info)
+    -  [Struct `Preburn`](#0x0_LibraDocTest_Preburn)
+    -  [Function `register`](#0x0_LibraDocTest_register)
+    -  [Function `assert_is_registered`](#0x0_LibraDocTest_assert_is_registered)
+    -  [Function `mint`](#0x0_LibraDocTest_mint)
+    -  [Function `burn`](#0x0_LibraDocTest_burn)
+    -  [Function `cancel_burn`](#0x0_LibraDocTest_cancel_burn)
+    -  [Function `new_preburn`](#0x0_LibraDocTest_new_preburn)
+    -  [Function `mint_with_capability`](#0x0_LibraDocTest_mint_with_capability)
+    -  [Function `preburn`](#0x0_LibraDocTest_preburn)
+    -  [Function `preburn_to_sender`](#0x0_LibraDocTest_preburn_to_sender)
+    -  [Function `burn_with_capability`](#0x0_LibraDocTest_burn_with_capability)
+    -  [Function `cancel_burn_with_capability`](#0x0_LibraDocTest_cancel_burn_with_capability)
+    -  [Function `publish_preburn`](#0x0_LibraDocTest_publish_preburn)
+    -  [Function `remove_preburn`](#0x0_LibraDocTest_remove_preburn)
+    -  [Function `destroy_preburn`](#0x0_LibraDocTest_destroy_preburn)
+    -  [Function `publish_mint_capability`](#0x0_LibraDocTest_publish_mint_capability)
+    -  [Function `remove_mint_capability`](#0x0_LibraDocTest_remove_mint_capability)
+    -  [Function `market_cap`](#0x0_LibraDocTest_market_cap)
+    -  [Function `preburn_value`](#0x0_LibraDocTest_preburn_value)
+    -  [Function `zero`](#0x0_LibraDocTest_zero)
+    -  [Function `value`](#0x0_LibraDocTest_value)
+    -  [Function `split`](#0x0_LibraDocTest_split)
+    -  [Function `withdraw`](#0x0_LibraDocTest_withdraw)
+    -  [Function `join`](#0x0_LibraDocTest_join)
+    -  [Function `deposit`](#0x0_LibraDocTest_deposit)
+    -  [Function `destroy_zero`](#0x0_LibraDocTest_destroy_zero)
+    -  [Specification](#0x0_LibraDocTest_Specification)
+        -  [Struct `T`](#0x0_LibraDocTest_Specification_T)
+        -  [Struct `MintCapability`](#0x0_LibraDocTest_Specification_MintCapability)
+        -  [Struct `Info`](#0x0_LibraDocTest_Specification_Info)
+        -  [Function `register`](#0x0_LibraDocTest_Specification_register)
+        -  [Function `assert_is_registered`](#0x0_LibraDocTest_Specification_assert_is_registered)
+        -  [Function `mint`](#0x0_LibraDocTest_Specification_mint)
+        -  [Function `burn`](#0x0_LibraDocTest_Specification_burn)
+        -  [Function `cancel_burn`](#0x0_LibraDocTest_Specification_cancel_burn)
+        -  [Function `new_preburn`](#0x0_LibraDocTest_Specification_new_preburn)
+        -  [Function `mint_with_capability`](#0x0_LibraDocTest_Specification_mint_with_capability)
+        -  [Function `preburn`](#0x0_LibraDocTest_Specification_preburn)
+        -  [Function `preburn_to_sender`](#0x0_LibraDocTest_Specification_preburn_to_sender)
+        -  [Function `burn_with_capability`](#0x0_LibraDocTest_Specification_burn_with_capability)
+        -  [Function `cancel_burn_with_capability`](#0x0_LibraDocTest_Specification_cancel_burn_with_capability)
+        -  [Function `publish_preburn`](#0x0_LibraDocTest_Specification_publish_preburn)
+        -  [Function `remove_preburn`](#0x0_LibraDocTest_Specification_remove_preburn)
+        -  [Function `destroy_preburn`](#0x0_LibraDocTest_Specification_destroy_preburn)
+        -  [Function `publish_mint_capability`](#0x0_LibraDocTest_Specification_publish_mint_capability)
+        -  [Function `remove_mint_capability`](#0x0_LibraDocTest_Specification_remove_mint_capability)
+        -  [Function `market_cap`](#0x0_LibraDocTest_Specification_market_cap)
+        -  [Function `preburn_value`](#0x0_LibraDocTest_Specification_preburn_value)
+        -  [Function `zero`](#0x0_LibraDocTest_Specification_zero)
+        -  [Function `value`](#0x0_LibraDocTest_Specification_value)
+        -  [Function `split`](#0x0_LibraDocTest_Specification_split)
+        -  [Function `withdraw`](#0x0_LibraDocTest_Specification_withdraw)
+        -  [Function `join`](#0x0_LibraDocTest_Specification_join)
+        -  [Function `deposit`](#0x0_LibraDocTest_Specification_deposit)
+        -  [Function `destroy_zero`](#0x0_LibraDocTest_Specification_destroy_zero)
+
+<a name="0x0_LibraDocTest"></a>
+
+## Module `0x0::LibraDocTest`
+
+The Libra module defines basic functionality around coins.
+
+### Note
+
+This is not a consistent and up-to-date implementation, specification, or documentation
+of the
+<code>Libra</code> module. It is rather a playground for testing the documentation generator.
+
+> We use block quotes like this to mark documentation text which is specific to docgen testing.
+>
+> We can refer to a module like in
+<code><a href="#0x0_LibraDocTest">LibraDocTest</a></code> -- if it is unambiguous -- or like
+<code><a href="#0x0_LibraDocTest">0x0::LibraDocTest</a></code>.
+
+
+<a name="0x0_LibraDocTest_T"></a>
+
+### Struct `T`
+
+A resource representing a fungible token
+
+
+<pre><code><b>resource</b> <b>struct</b> <a href="#0x0_LibraDocTest_T">T</a>&lt;Token&gt;
+</code></pre>
+
+
+
+<details>
+<summary>Fields</summary>
+
+
+<dl>
+<dt>
+
+<code>value: u64</code>
+</dt>
+<dd>
+ The value of the token. May be zero
+</dd>
+</dl>
+
+
+</details>
+
+<a name="0x0_LibraDocTest_MintCapability"></a>
+
+### Struct `MintCapability`
+
+A singleton resource that grants access to
+<code><a href="#0x0_LibraDocTest_mint">LibraDocTest::mint</a></code>. Only the Association has one.
+
+> Instead of
+<code><a href="#0x0_LibraDocTest_mint">LibraDocTest::mint</a></code> we can also write
+<code><a href="#0x0_LibraDocTest_mint">0x0::LibraDocTest::mint</a></code>,
+<code><a href="#0x0_LibraDocTest_mint">Self::mint</a></code>, or just
+<code><a href="#0x0_LibraDocTest_mint">mint</a>()</code>
+> (for functions from enclosing module) to get a hyper link in documentation text.
+
+
+<pre><code><b>resource</b> <b>struct</b> <a href="#0x0_LibraDocTest_MintCapability">MintCapability</a>&lt;Token&gt;
+</code></pre>
+
+
+
+<details>
+<summary>Fields</summary>
+
+
+<dl>
+<dt>
+
+<code>dummy_field: bool</code>
+</dt>
+<dd>
+
+</dd>
+</dl>
+
+
+</details>
+
+<a name="0x0_LibraDocTest_Info"></a>
+
+### Struct `Info`
+
+
+
+<pre><code><b>resource</b> <b>struct</b> <a href="#0x0_LibraDocTest_Info">Info</a>&lt;Token&gt;
+</code></pre>
+
+
+
+<details>
+<summary>Fields</summary>
+
+
+<dl>
+<dt>
+
+<code>total_value: u128</code>
+</dt>
+<dd>
+ The sum of the values of all
+<code><a href="#0x0_LibraDocTest_T">LibraDocTest::T</a></code> resources in the system
+</dd>
+<dt>
+
+<code>preburn_value: u64</code>
+</dt>
+<dd>
+ Value of funds that are in the process of being burned
+</dd>
+</dl>
+
+
+</details>
+
+<a name="0x0_LibraDocTest_Preburn"></a>
+
+### Struct `Preburn`
+
+A holding area where funds that will subsequently be burned wait while their underyling
+assets are sold off-chain.
+This resource can only be created by the holder of the MintCapability. An account that
+contains this address has the authority to initiate a burn request. A burn request can be
+resolved by the holder of the MintCapability by either (1) burning the funds, or (2)
+returning the funds to the account that initiated the burn request.
+This design supports multiple preburn requests in flight at the same time, including multiple
+burn requests from the same account. However, burn requests from the same account must be
+resolved in FIFO order.
+
+
+<pre><code><b>resource</b> <b>struct</b> <a href="#0x0_LibraDocTest_Preburn">Preburn</a>&lt;Token&gt;
+</code></pre>
+
+
+
+<details>
+<summary>Fields</summary>
+
+
+<dl>
+<dt>
+
+<code>requests: vector&lt;<a href="#0x0_LibraDocTest_T">LibraDocTest::T</a>&lt;Token&gt;&gt;</code>
+</dt>
+<dd>
+ Queue of pending burn requests
+</dd>
+<dt>
+
+<code>is_approved: bool</code>
+</dt>
+<dd>
+ Boolean that is true if the holder of the MintCapability has approved this account as a
+ preburner
+</dd>
+</dl>
+
+
+</details>
+
+<a name="0x0_LibraDocTest_register"></a>
+
+### Function `register`
+
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="#0x0_LibraDocTest_register">register</a>&lt;Token&gt;()
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="#0x0_LibraDocTest_register">register</a>&lt;Token&gt;() {
+    // Only callable by the Association address
+    Transaction::assert(Transaction::sender() == 0xA550C18, 1);
+    move_to_sender(<a href="#0x0_LibraDocTest_MintCapability">MintCapability</a>&lt;Token&gt;{ });
+    move_to_sender(<a href="#0x0_LibraDocTest_Info">Info</a>&lt;Token&gt; { total_value: 0u128, preburn_value: 0 });
+}
+</code></pre>
+
+
+
+</details>
+
+<a name="0x0_LibraDocTest_assert_is_registered"></a>
+
+### Function `assert_is_registered`
+
+
+
+<pre><code><b>fun</b> <a href="#0x0_LibraDocTest_assert_is_registered">assert_is_registered</a>&lt;Token&gt;()
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>fun</b> <a href="#0x0_LibraDocTest_assert_is_registered">assert_is_registered</a>&lt;Token&gt;() {
+    Transaction::assert(exists&lt;<a href="#0x0_LibraDocTest_Info">Info</a>&lt;Token&gt;&gt;(0xA550C18), 12);
+}
+</code></pre>
+
+
+
+</details>
+
+<a name="0x0_LibraDocTest_mint"></a>
+
+### Function `mint`
+
+Return
+<code>amount</code> coins.
+Fails if the sender does not have a published MintCapability.
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="#0x0_LibraDocTest_mint">mint</a>&lt;Token&gt;(amount: u64): <a href="#0x0_LibraDocTest_T">LibraDocTest::T</a>&lt;Token&gt;
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="#0x0_LibraDocTest_mint">mint</a>&lt;Token&gt;(amount: u64): <a href="#0x0_LibraDocTest_T">T</a>&lt;Token&gt; <b>acquires</b> <a href="#0x0_LibraDocTest_Info">Info</a>, <a href="#0x0_LibraDocTest_MintCapability">MintCapability</a> {
+    <a href="#0x0_LibraDocTest_mint_with_capability">mint_with_capability</a>(amount, borrow_global&lt;<a href="#0x0_LibraDocTest_MintCapability">MintCapability</a>&lt;Token&gt;&gt;(Transaction::sender()))
+}
+</code></pre>
+
+
+
+</details>
+
+<a name="0x0_LibraDocTest_burn"></a>
+
+### Function `burn`
+
+Burn the coins currently held in the preburn holding area under
+<code>preburn_address</code>.
+Fails if the sender does not have a published MintCapability.
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="#0x0_LibraDocTest_burn">burn</a>&lt;Token&gt;(preburn_address: address)
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="#0x0_LibraDocTest_burn">burn</a>&lt;Token&gt;(
+    preburn_address: address
+) <b>acquires</b> <a href="#0x0_LibraDocTest_Info">Info</a>, <a href="#0x0_LibraDocTest_MintCapability">MintCapability</a>, <a href="#0x0_LibraDocTest_Preburn">Preburn</a> {
+    <a href="#0x0_LibraDocTest_burn_with_capability">burn_with_capability</a>(
+        preburn_address,
+        borrow_global&lt;<a href="#0x0_LibraDocTest_MintCapability">MintCapability</a>&lt;Token&gt;&gt;(Transaction::sender())
+    )
+}
+</code></pre>
+
+
+
+</details>
+
+<a name="0x0_LibraDocTest_cancel_burn"></a>
+
+### Function `cancel_burn`
+
+Cancel the oldest burn request from
+<code>preburn_address</code>
+Fails if the sender does not have a published MintCapability.
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="#0x0_LibraDocTest_cancel_burn">cancel_burn</a>&lt;Token&gt;(preburn_address: address): <a href="#0x0_LibraDocTest_T">LibraDocTest::T</a>&lt;Token&gt;
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="#0x0_LibraDocTest_cancel_burn">cancel_burn</a>&lt;Token&gt;(
+    preburn_address: address
+): <a href="#0x0_LibraDocTest_T">T</a>&lt;Token&gt; <b>acquires</b> <a href="#0x0_LibraDocTest_Info">Info</a>, <a href="#0x0_LibraDocTest_MintCapability">MintCapability</a>, <a href="#0x0_LibraDocTest_Preburn">Preburn</a> {
+    <a href="#0x0_LibraDocTest_cancel_burn_with_capability">cancel_burn_with_capability</a>(
+        preburn_address,
+        borrow_global&lt;<a href="#0x0_LibraDocTest_MintCapability">MintCapability</a>&lt;Token&gt;&gt;(Transaction::sender())
+    )
+}
+</code></pre>
+
+
+
+</details>
+
+<a name="0x0_LibraDocTest_new_preburn"></a>
+
+### Function `new_preburn`
+
+Create a new Preburn resource
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="#0x0_LibraDocTest_new_preburn">new_preburn</a>&lt;Token&gt;(): <a href="#0x0_LibraDocTest_Preburn">LibraDocTest::Preburn</a>&lt;Token&gt;
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="#0x0_LibraDocTest_new_preburn">new_preburn</a>&lt;Token&gt;(): <a href="#0x0_LibraDocTest_Preburn">Preburn</a>&lt;Token&gt; {
+    <a href="#0x0_LibraDocTest_assert_is_registered">assert_is_registered</a>&lt;Token&gt;();
+    <a href="#0x0_LibraDocTest_Preburn">Preburn</a>&lt;Token&gt; { requests: Vector::empty(), is_approved: <b>false</b>, }
+}
+</code></pre>
+
+
+
+</details>
+
+<a name="0x0_LibraDocTest_mint_with_capability"></a>
+
+### Function `mint_with_capability`
+
+Mint a new
+<code><a href="#0x0_LibraDocTest_T">LibraDocTest::T</a></code> worth
+<code>value</code>. The caller must have a reference to a MintCapability.
+Only the Association account can acquire such a reference, and it can do so only via
+<code>borrow_sender_mint_capability</code>.
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="#0x0_LibraDocTest_mint_with_capability">mint_with_capability</a>&lt;Token&gt;(value: u64, _capability: &<a href="#0x0_LibraDocTest_MintCapability">LibraDocTest::MintCapability</a>&lt;Token&gt;): <a href="#0x0_LibraDocTest_T">LibraDocTest::T</a>&lt;Token&gt;
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="#0x0_LibraDocTest_mint_with_capability">mint_with_capability</a>&lt;Token&gt;(
+    value: u64,
+    _capability: &<a href="#0x0_LibraDocTest_MintCapability">MintCapability</a>&lt;Token&gt;
+): <a href="#0x0_LibraDocTest_T">T</a>&lt;Token&gt; <b>acquires</b> <a href="#0x0_LibraDocTest_Info">Info</a> {
+    <a href="#0x0_LibraDocTest_assert_is_registered">assert_is_registered</a>&lt;Token&gt;();
+    // TODO: temporary measure for testnet only: limit minting <b>to</b> 1B Libra at a time.
+    // this is <b>to</b> prevent the market cap's total value from hitting u64_max due <b>to</b> excessive
+    // minting. This will not be a problem in the production Libra system because coins will
+    // be backed with real-world assets, and thus minting will be correspondingly rarer.
+    // * 1000000 here because the unit is microlibra
+    Transaction::assert(<a href="#0x0_LibraDocTest_value">value</a> &lt;= 1000000000 * 1000000, 11);
+    // <b>update</b> market cap <b>resource</b> <b>to</b> reflect minting
+    <b>let</b> market_cap = borrow_global_mut&lt;<a href="#0x0_LibraDocTest_Info">Info</a>&lt;Token&gt;&gt;(0xA550C18);
+    market_cap.total_value = market_cap.total_value + (value <b>as</b> u128);
+
+    <a href="#0x0_LibraDocTest_T">T</a>&lt;Token&gt; { value }
+}
+</code></pre>
+
+
+
+</details>
+
+<a name="0x0_LibraDocTest_preburn"></a>
+
+### Function `preburn`
+
+Send coin to the preburn holding area
+<code>preburn_ref</code>, where it will wait to be burned.
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="#0x0_LibraDocTest_preburn">preburn</a>&lt;Token&gt;(preburn_ref: &<b>mut</b> <a href="#0x0_LibraDocTest_Preburn">LibraDocTest::Preburn</a>&lt;Token&gt;, coin: <a href="#0x0_LibraDocTest_T">LibraDocTest::T</a>&lt;Token&gt;)
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="#0x0_LibraDocTest_preburn">preburn</a>&lt;Token&gt;(
+    preburn_ref: &<b>mut</b> <a href="#0x0_LibraDocTest_Preburn">Preburn</a>&lt;Token&gt;,
+    coin: <a href="#0x0_LibraDocTest_T">T</a>&lt;Token&gt;
+) <b>acquires</b> <a href="#0x0_LibraDocTest_Info">Info</a> {
+    // TODO: bring this back once we can automate approvals in testnet
+    // Transaction::assert(preburn_ref.is_approved, 13);
+    <b>let</b> coin_value = <a href="#0x0_LibraDocTest_value">value</a>(&coin);
+    Vector::push_back(
+        &<b>mut</b> preburn_ref.requests,
+        coin
+    );
+    <b>let</b> market_cap = borrow_global_mut&lt;<a href="#0x0_LibraDocTest_Info">Info</a>&lt;Token&gt;&gt;(0xA550C18);
+    market_cap.preburn_value = market_cap.preburn_value + coin_value
+}
+</code></pre>
+
+
+
+</details>
+
+<a name="0x0_LibraDocTest_preburn_to_sender"></a>
+
+### Function `preburn_to_sender`
+
+Send coin to the preburn holding area, where it will wait to be burned.
+Fails if the sender does not have a published Preburn resource
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="#0x0_LibraDocTest_preburn_to_sender">preburn_to_sender</a>&lt;Token&gt;(coin: <a href="#0x0_LibraDocTest_T">LibraDocTest::T</a>&lt;Token&gt;)
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="#0x0_LibraDocTest_preburn_to_sender">preburn_to_sender</a>&lt;Token&gt;(coin: <a href="#0x0_LibraDocTest_T">T</a>&lt;Token&gt;) <b>acquires</b> <a href="#0x0_LibraDocTest_Info">Info</a>, <a href="#0x0_LibraDocTest_Preburn">Preburn</a> {
+    <a href="#0x0_LibraDocTest_preburn">preburn</a>(borrow_global_mut&lt;<a href="#0x0_LibraDocTest_Preburn">Preburn</a>&lt;Token&gt;&gt;(Transaction::sender()), coin)
+}
+</code></pre>
+
+
+
+</details>
+
+<a name="0x0_LibraDocTest_burn_with_capability"></a>
+
+### Function `burn_with_capability`
+
+Permanently remove the coins held in the
+<code><a href="#0x0_LibraDocTest_Preburn">Preburn</a></code> resource stored at
+<code>preburn_address</code> and
+update the market cap accordingly. If there are multiple preburn requests in progress, this
+will remove the oldest one.
+Can only be invoked by the holder of the MintCapability. Fails if the there is no
+<code><a href="#0x0_LibraDocTest_Preburn">Preburn</a></code>
+resource under
+<code>preburn_address</code> or has one with no pending burn requests.
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="#0x0_LibraDocTest_burn_with_capability">burn_with_capability</a>&lt;Token&gt;(preburn_address: address, _capability: &<a href="#0x0_LibraDocTest_MintCapability">LibraDocTest::MintCapability</a>&lt;Token&gt;)
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="#0x0_LibraDocTest_burn_with_capability">burn_with_capability</a>&lt;Token&gt;(
+    preburn_address: address,
+    _capability: &<a href="#0x0_LibraDocTest_MintCapability">MintCapability</a>&lt;Token&gt;
+) <b>acquires</b> <a href="#0x0_LibraDocTest_Info">Info</a>, <a href="#0x0_LibraDocTest_Preburn">Preburn</a> {
+    // destroy the coin at the head of the preburn queue
+    <b>let</b> preburn = borrow_global_mut&lt;<a href="#0x0_LibraDocTest_Preburn">Preburn</a>&lt;Token&gt;&gt;(preburn_address);
+    <b>let</b> <a href="#0x0_LibraDocTest_T">T</a> { value } = Vector::remove(&<b>mut</b> preburn.requests, 0);
+    // <b>update</b> the market cap
+    <b>let</b> market_cap = borrow_global_mut&lt;<a href="#0x0_LibraDocTest_Info">Info</a>&lt;Token&gt;&gt;(0xA550C18);
+    market_cap.total_value = market_cap.total_value - (value <b>as</b> u128);
+    market_cap.preburn_value = market_cap.preburn_value - value
+}
+</code></pre>
+
+
+
+</details>
+
+<a name="0x0_LibraDocTest_cancel_burn_with_capability"></a>
+
+### Function `cancel_burn_with_capability`
+
+Cancel the burn request in the
+<code><a href="#0x0_LibraDocTest_Preburn">Preburn</a></code> resource stored at
+<code>preburn_address</code> and
+return the coins to the caller.
+If there are multiple preburn requests in progress, this will cancel the oldest one.
+Can only be invoked by the holder of the MintCapability. Fails if the transaction sender
+does not have a published Preburn resource or has one with no pending burn requests.
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="#0x0_LibraDocTest_cancel_burn_with_capability">cancel_burn_with_capability</a>&lt;Token&gt;(preburn_address: address, _capability: &<a href="#0x0_LibraDocTest_MintCapability">LibraDocTest::MintCapability</a>&lt;Token&gt;): <a href="#0x0_LibraDocTest_T">LibraDocTest::T</a>&lt;Token&gt;
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="#0x0_LibraDocTest_cancel_burn_with_capability">cancel_burn_with_capability</a>&lt;Token&gt;(
+    preburn_address: address,
+    _capability: &<a href="#0x0_LibraDocTest_MintCapability">MintCapability</a>&lt;Token&gt;
+): <a href="#0x0_LibraDocTest_T">T</a>&lt;Token&gt; <b>acquires</b> <a href="#0x0_LibraDocTest_Info">Info</a>, <a href="#0x0_LibraDocTest_Preburn">Preburn</a> {
+    // destroy the coin at the head of the preburn queue
+    <b>let</b> preburn = borrow_global_mut&lt;<a href="#0x0_LibraDocTest_Preburn">Preburn</a>&lt;Token&gt;&gt;(preburn_address);
+    <b>let</b> coin = Vector::remove(&<b>mut</b> preburn.requests, 0);
+    // <b>update</b> the market cap
+    <b>let</b> market_cap = borrow_global_mut&lt;<a href="#0x0_LibraDocTest_Info">Info</a>&lt;Token&gt;&gt;(0xA550C18);
+    market_cap.preburn_value = market_cap.preburn_value - <a href="#0x0_LibraDocTest_value">value</a>(&coin);
+
+    coin
+}
+</code></pre>
+
+
+
+</details>
+
+<a name="0x0_LibraDocTest_publish_preburn"></a>
+
+### Function `publish_preburn`
+
+Publish
+<code>preburn</code> under the sender's account
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="#0x0_LibraDocTest_publish_preburn">publish_preburn</a>&lt;Token&gt;(preburn: <a href="#0x0_LibraDocTest_Preburn">LibraDocTest::Preburn</a>&lt;Token&gt;)
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="#0x0_LibraDocTest_publish_preburn">publish_preburn</a>&lt;Token&gt;(preburn: <a href="#0x0_LibraDocTest_Preburn">Preburn</a>&lt;Token&gt;) {
+    move_to_sender(preburn)
+}
+</code></pre>
+
+
+
+</details>
+
+<a name="0x0_LibraDocTest_remove_preburn"></a>
+
+### Function `remove_preburn`
+
+Remove and return the
+<code><a href="#0x0_LibraDocTest_Preburn">Preburn</a></code> resource under the sender's account
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="#0x0_LibraDocTest_remove_preburn">remove_preburn</a>&lt;Token&gt;(): <a href="#0x0_LibraDocTest_Preburn">LibraDocTest::Preburn</a>&lt;Token&gt;
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="#0x0_LibraDocTest_remove_preburn">remove_preburn</a>&lt;Token&gt;(): <a href="#0x0_LibraDocTest_Preburn">Preburn</a>&lt;Token&gt; <b>acquires</b> <a href="#0x0_LibraDocTest_Preburn">Preburn</a> {
+    move_from&lt;<a href="#0x0_LibraDocTest_Preburn">Preburn</a>&lt;Token&gt;&gt;(Transaction::sender())
+}
+</code></pre>
+
+
+
+</details>
+
+<a name="0x0_LibraDocTest_destroy_preburn"></a>
+
+### Function `destroy_preburn`
+
+Destroys the given preburn resource.
+Aborts if
+<code>requests</code> is non-empty
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="#0x0_LibraDocTest_destroy_preburn">destroy_preburn</a>&lt;Token&gt;(preburn: <a href="#0x0_LibraDocTest_Preburn">LibraDocTest::Preburn</a>&lt;Token&gt;)
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="#0x0_LibraDocTest_destroy_preburn">destroy_preburn</a>&lt;Token&gt;(preburn: <a href="#0x0_LibraDocTest_Preburn">Preburn</a>&lt;Token&gt;) {
+    <b>let</b> <a href="#0x0_LibraDocTest_Preburn">Preburn</a> { requests, is_approved: _ } = preburn;
+    Vector::destroy_empty(requests)
+}
+</code></pre>
+
+
+
+</details>
+
+<a name="0x0_LibraDocTest_publish_mint_capability"></a>
+
+### Function `publish_mint_capability`
+
+Publish
+<code>capability</code> under the sender's account
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="#0x0_LibraDocTest_publish_mint_capability">publish_mint_capability</a>&lt;Token&gt;(capability: <a href="#0x0_LibraDocTest_MintCapability">LibraDocTest::MintCapability</a>&lt;Token&gt;)
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="#0x0_LibraDocTest_publish_mint_capability">publish_mint_capability</a>&lt;Token&gt;(capability: <a href="#0x0_LibraDocTest_MintCapability">MintCapability</a>&lt;Token&gt;) {
+    move_to_sender(capability)
+}
+</code></pre>
+
+
+
+</details>
+
+<a name="0x0_LibraDocTest_remove_mint_capability"></a>
+
+### Function `remove_mint_capability`
+
+Remove and return the MintCapability from the sender's account. Fails if the sender does
+not have a published MintCapability
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="#0x0_LibraDocTest_remove_mint_capability">remove_mint_capability</a>&lt;Token&gt;(): <a href="#0x0_LibraDocTest_MintCapability">LibraDocTest::MintCapability</a>&lt;Token&gt;
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="#0x0_LibraDocTest_remove_mint_capability">remove_mint_capability</a>&lt;Token&gt;(): <a href="#0x0_LibraDocTest_MintCapability">MintCapability</a>&lt;Token&gt; <b>acquires</b> <a href="#0x0_LibraDocTest_MintCapability">MintCapability</a> {
+    move_from&lt;<a href="#0x0_LibraDocTest_MintCapability">MintCapability</a>&lt;Token&gt;&gt;(Transaction::sender())
+}
+</code></pre>
+
+
+
+</details>
+
+<a name="0x0_LibraDocTest_market_cap"></a>
+
+### Function `market_cap`
+
+Return the total value of all Libra in the system
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="#0x0_LibraDocTest_market_cap">market_cap</a>&lt;Token&gt;(): u128
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="#0x0_LibraDocTest_market_cap">market_cap</a>&lt;Token&gt;(): u128 <b>acquires</b> <a href="#0x0_LibraDocTest_Info">Info</a> {
+    borrow_global&lt;<a href="#0x0_LibraDocTest_Info">Info</a>&lt;Token&gt;&gt;(0xA550C18).total_value
+}
+</code></pre>
+
+
+
+</details>
+
+<a name="0x0_LibraDocTest_preburn_value"></a>
+
+### Function `preburn_value`
+
+Return the total value of Libra to be burned
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="#0x0_LibraDocTest_preburn_value">preburn_value</a>&lt;Token&gt;(): u64
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="#0x0_LibraDocTest_preburn_value">preburn_value</a>&lt;Token&gt;(): u64 <b>acquires</b> <a href="#0x0_LibraDocTest_Info">Info</a> {
+    borrow_global&lt;<a href="#0x0_LibraDocTest_Info">Info</a>&lt;Token&gt;&gt;(0xA550C18).preburn_value
+}
+</code></pre>
+
+
+
+</details>
+
+<a name="0x0_LibraDocTest_zero"></a>
+
+### Function `zero`
+
+Create a new
+<code><a href="#0x0_LibraDocTest_T">LibraDocTest::T</a></code> with a value of 0
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="#0x0_LibraDocTest_zero">zero</a>&lt;Token&gt;(): <a href="#0x0_LibraDocTest_T">LibraDocTest::T</a>&lt;Token&gt;
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="#0x0_LibraDocTest_zero">zero</a>&lt;Token&gt;(): <a href="#0x0_LibraDocTest_T">T</a>&lt;Token&gt; {
+    // prevent silly coin types (e.g., Libra&lt;bool&gt;) from being created
+    <a href="#0x0_LibraDocTest_assert_is_registered">assert_is_registered</a>&lt;Token&gt;();
+    <a href="#0x0_LibraDocTest_T">T</a> { value: 0 }
+}
+</code></pre>
+
+
+
+</details>
+
+<a name="0x0_LibraDocTest_value"></a>
+
+### Function `value`
+
+Public accessor for the value of a coin
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="#0x0_LibraDocTest_value">value</a>&lt;Token&gt;(coin_ref: &<a href="#0x0_LibraDocTest_T">LibraDocTest::T</a>&lt;Token&gt;): u64
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="#0x0_LibraDocTest_value">value</a>&lt;Token&gt;(coin_ref: &<a href="#0x0_LibraDocTest_T">T</a>&lt;Token&gt;): u64 {
+    coin_ref.value
+}
+</code></pre>
+
+
+
+</details>
+
+<a name="0x0_LibraDocTest_split"></a>
+
+### Function `split`
+
+Splits the given coin into two and returns them both
+It leverages
+<code>withdraw</code> for any verifications of the values
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="#0x0_LibraDocTest_split">split</a>&lt;Token&gt;(coin: <a href="#0x0_LibraDocTest_T">LibraDocTest::T</a>&lt;Token&gt;, amount: u64): (<a href="#0x0_LibraDocTest_T">LibraDocTest::T</a>&lt;Token&gt;, <a href="#0x0_LibraDocTest_T">LibraDocTest::T</a>&lt;Token&gt;)
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="#0x0_LibraDocTest_split">split</a>&lt;Token&gt;(coin: <a href="#0x0_LibraDocTest_T">T</a>&lt;Token&gt;, amount: u64): (<a href="#0x0_LibraDocTest_T">T</a>&lt;Token&gt;, <a href="#0x0_LibraDocTest_T">T</a>&lt;Token&gt;) {
+    <b>let</b> other = <a href="#0x0_LibraDocTest_withdraw">withdraw</a>(&<b>mut</b> coin, amount);
+    (coin, other)
+}
+</code></pre>
+
+
+
+</details>
+
+<a name="0x0_LibraDocTest_withdraw"></a>
+
+### Function `withdraw`
+
+"Divides" the given coin into two, where original coin is modified in place
+The original coin will have value = original value -
+<code>value</code>
+The new coin will have a value =
+<code>value</code>
+Fails if the coins value is less than
+<code>value</code>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="#0x0_LibraDocTest_withdraw">withdraw</a>&lt;Token&gt;(coin_ref: &<b>mut</b> <a href="#0x0_LibraDocTest_T">LibraDocTest::T</a>&lt;Token&gt;, value: u64): <a href="#0x0_LibraDocTest_T">LibraDocTest::T</a>&lt;Token&gt;
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="#0x0_LibraDocTest_withdraw">withdraw</a>&lt;Token&gt;(coin_ref: &<b>mut</b> <a href="#0x0_LibraDocTest_T">T</a>&lt;Token&gt;, value: u64): <a href="#0x0_LibraDocTest_T">T</a>&lt;Token&gt; {
+    // Check that `amount` is less than the coin's value
+    Transaction::assert(coin_ref.value &gt;= value, 10);
+
+    // Split the coin
+    coin_ref.value = coin_ref.value - value;
+    <a href="#0x0_LibraDocTest_T">T</a> { value }
+}
+</code></pre>
+
+
+
+</details>
+
+<a name="0x0_LibraDocTest_join"></a>
+
+### Function `join`
+
+Merges two coins and returns a new coin whose value is equal to the sum of the two inputs
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="#0x0_LibraDocTest_join">join</a>&lt;Token&gt;(coin1: <a href="#0x0_LibraDocTest_T">LibraDocTest::T</a>&lt;Token&gt;, coin2: <a href="#0x0_LibraDocTest_T">LibraDocTest::T</a>&lt;Token&gt;): <a href="#0x0_LibraDocTest_T">LibraDocTest::T</a>&lt;Token&gt;
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="#0x0_LibraDocTest_join">join</a>&lt;Token&gt;(coin1: <a href="#0x0_LibraDocTest_T">T</a>&lt;Token&gt;, coin2: <a href="#0x0_LibraDocTest_T">T</a>&lt;Token&gt;): <a href="#0x0_LibraDocTest_T">T</a>&lt;Token&gt;  {
+    <a href="#0x0_LibraDocTest_deposit">deposit</a>(&<b>mut</b> coin1, coin2);
+    coin1
+}
+</code></pre>
+
+
+
+</details>
+
+<a name="0x0_LibraDocTest_deposit"></a>
+
+### Function `deposit`
+
+"Merges" the two coins
+The coin passed in by reference will have a value equal to the sum of the two coins
+The
+<code>check</code> coin is consumed in the process
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="#0x0_LibraDocTest_deposit">deposit</a>&lt;Token&gt;(coin_ref: &<b>mut</b> <a href="#0x0_LibraDocTest_T">LibraDocTest::T</a>&lt;Token&gt;, check: <a href="#0x0_LibraDocTest_T">LibraDocTest::T</a>&lt;Token&gt;)
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="#0x0_LibraDocTest_deposit">deposit</a>&lt;Token&gt;(coin_ref: &<b>mut</b> <a href="#0x0_LibraDocTest_T">T</a>&lt;Token&gt;, check: <a href="#0x0_LibraDocTest_T">T</a>&lt;Token&gt;) {
+    <b>let</b> <a href="#0x0_LibraDocTest_T">T</a> { value } = check;
+    coin_ref.value= coin_ref.value + value;
+}
+</code></pre>
+
+
+
+</details>
+
+<a name="0x0_LibraDocTest_destroy_zero"></a>
+
+### Function `destroy_zero`
+
+Destroy a coin
+Fails if the value is non-zero
+The amount of
+<code><a href="#0x0_LibraDocTest_T">LibraDocTest::T</a></code> in the system is a tightly controlled property,
+so you cannot "burn" any non-zero amount of
+<code><a href="#0x0_LibraDocTest_T">LibraDocTest::T</a></code>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="#0x0_LibraDocTest_destroy_zero">destroy_zero</a>&lt;Token&gt;(coin: <a href="#0x0_LibraDocTest_T">LibraDocTest::T</a>&lt;Token&gt;)
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="#0x0_LibraDocTest_destroy_zero">destroy_zero</a>&lt;Token&gt;(coin: <a href="#0x0_LibraDocTest_T">T</a>&lt;Token&gt;) {
+    <b>let</b> <a href="#0x0_LibraDocTest_T">T</a>&lt;Token&gt; { value } = coin;
+    Transaction::assert(value == 0, 11);
+}
+</code></pre>
+
+
+
+</details>
+
+<a name="0x0_LibraDocTest_Specification"></a>
+
+### Specification
+
+#### Settings for Verification
+
+> Spec module blocks which are associated with the module do not have an implicit header and
+> are directly included in the module doc (or Specification sub-section if
+<code>--doc-<b>spec</b>-inline=<b>false</b></code>).
+> To get a header, one needs to be explicitly assigned like we do here.
+
+Verify also private functions.
+
+
+<pre><code>pragma verify = <b>true</b>;
+</code></pre>
+
+
+
+<a name="0x0_LibraDocTest_Specification_T"></a>
+
+#### Struct `T`
+
+
+<pre><code><b>resource</b> <b>struct</b> <a href="#0x0_LibraDocTest_T">T</a>&lt;Token&gt;
+</code></pre>
+
+
+
+<dl>
+<dt>
+
+<code>value: u64</code>
+</dt>
+<dd>
+ The value of the token. May be zero
+</dd>
+</dl>
+
+Maintains sum_of_token
+
+
+<pre><code><b>invariant</b> <b>pack</b> sum_of_token_values&lt;Token&gt; = sum_of_token_values&lt;Token&gt; + value;
+<b>invariant</b> <b>unpack</b> sum_of_token_values&lt;Token&gt; = sum_of_token_values&lt;Token&gt; - value;
+</code></pre>
+
+
+
+This ghost variable is defined to have the true sum values of all instances of Token
+
+
+<pre><code><b>global</b> sum_of_token_values&lt;Token&gt;: num;
+</code></pre>
+
+
+
+
+<pre><code><b>schema</b> SumRemainsSame&lt;Token&gt; {
+    <b>ensures</b> sum_of_token_values&lt;Token&gt; == <b>old</b>(sum_of_token_values&lt;Token&gt;);
+}
+</code></pre>
+
+
+
+Only mint/burn & with capability versions can change the total amount of currency.
+skip mint, burn, mint_with_capability, burn_with_capability.
+Burn always aborts because Preburn.is_approved is always false.
+
+
+<pre><code><b>apply</b> SumRemainsSame&lt;Token&gt; <b>to</b> *&lt;Token&gt; <b>except</b> mint*&lt;Token&gt;, burn*&lt;Token&gt;;
+</code></pre>
+
+
+
+SPEC: MarketCap == Sum of all the instances of a particular token.
+Note: this works even though the verifier does not
+know that each existing token.value must be <= sum_of_token_values. I assume that
+total_value is constrained to be non-negative, so it all works. I should check this out.
+Note: What is the value of a ghost variable in the genesis state?
+State machine with two states (not registered/registered), so write as two invariants.
+
+
+<pre><code><b>schema</b> SumOfTokenValuesInvariant&lt;Token&gt; {
+    <b>invariant</b> <b>module</b> !token_is_registered&lt;Token&gt;() ==&gt; sum_of_token_values&lt;Token&gt; == 0;
+    <b>invariant</b> <b>module</b> token_is_registered&lt;Token&gt;()
+                   ==&gt; sum_of_token_values&lt;Token&gt; == <b>global</b>&lt;<a href="#0x0_LibraDocTest_Info">Info</a>&lt;Token&gt;&gt;(0xA550C18).total_value;
+}
+</code></pre>
+
+
+
+
+<pre><code><b>apply</b> SumOfTokenValuesInvariant&lt;Token&gt; <b>to</b> <b>public</b> *&lt;Token&gt;;
+</code></pre>
+
+
+
+<a name="0x0_LibraDocTest_Specification_MintCapability"></a>
+
+#### Struct `MintCapability`
+
+
+<pre><code><b>resource</b> <b>struct</b> <a href="#0x0_LibraDocTest_MintCapability">MintCapability</a>&lt;Token&gt;
+</code></pre>
+
+
+
+<dl>
+<dt>
+
+<code>dummy_field: bool</code>
+</dt>
+<dd>
+
+</dd>
+</dl>
+
+Maintain mint_capability_count
+
+
+<pre><code><b>invariant</b> <b>pack</b> mint_capability_count&lt;Token&gt; = mint_capability_count&lt;Token&gt; + 1;
+<b>invariant</b> <b>unpack</b> mint_capability_count&lt;Token&gt; = mint_capability_count&lt;Token&gt; - 1;
+</code></pre>
+
+
+
+Ghost variable representing the total number of MintCapability instances for Token (0 or 1).
+
+
+<pre><code><b>global</b> mint_capability_count&lt;Token&gt;: num;
+</code></pre>
+
+
+Helper to check whether sender has MintCapability.
+
+
+<pre><code>define exists_sender_mint_capability&lt;Token&gt;(): bool { exists&lt;<a href="#0x0_LibraDocTest_MintCapability">MintCapability</a>&lt;Token&gt;&gt;(sender()) }
+</code></pre>
+
+
+There is a MintCapability for Token iff the token is registered
+> For the below schema, we have documentation comments on members. In the case of module/function/struct
+> spec blocks, we can just flatten all spec block members with possibly
+> attached member documentation into the section. For schemas this is not possible.
+> So we repeat a schema declaration multiple times, "extending" it.
+
+If token is not registered, there can be no capability.
+
+
+<pre><code><b>schema</b> MintCapabilityCountInvariant&lt;Token&gt; {
+    <b>invariant</b> <b>module</b> !token_is_registered&lt;Token&gt;() ==&gt; mint_capability_count&lt;Token&gt; == 0;
+}
+</code></pre>
+
+
+If token is registered, there is exactly one capability.
+
+
+<pre><code><b>schema</b> MintCapabilityCountInvariant&lt;Token&gt; {
+    <b>invariant</b> <b>module</b> token_is_registered&lt;Token&gt;() ==&gt; mint_capability_count&lt;Token&gt; == 1;
+}
+</code></pre>
+
+
+
+
+<pre><code><b>apply</b> MintCapabilityCountInvariant&lt;Token&gt; <b>to</b> <b>public</b> *&lt;Token&gt;;
+</code></pre>
+
+
+
+<a name="0x0_LibraDocTest_Specification_Info"></a>
+
+#### Struct `Info`
+
+
+<pre><code><b>resource</b> <b>struct</b> <a href="#0x0_LibraDocTest_Info">Info</a>&lt;Token&gt;
+</code></pre>
+
+
+
+<dl>
+<dt>
+
+<code>total_value: u128</code>
+</dt>
+<dd>
+ The sum of the values of all
+<code><a href="#0x0_LibraDocTest_T">LibraDocTest::T</a></code> resources in the system
+</dd>
+<dt>
+
+<code>preburn_value: u64</code>
+</dt>
+<dd>
+ Value of funds that are in the process of being burned
+</dd>
+</dl>
+
+
+Specifications helpers for working with Info<Token> at association address.
+
+
+<pre><code>define association_address(): address { 0xA550C18 }
+define token_is_registered&lt;Token&gt;(): bool { exists&lt;<a href="#0x0_LibraDocTest_Info">Info</a>&lt;Token&gt;&gt;(association_address()) }
+define info&lt;Token&gt;(): <a href="#0x0_LibraDocTest_Info">Info</a>&lt;Token&gt; { <b>global</b>&lt;<a href="#0x0_LibraDocTest_Info">Info</a>&lt;Token&gt;&gt;(association_address()) }
+</code></pre>
+
+
+Once registered, a token stays registered forever.
+
+
+<pre><code><b>schema</b> RegistrationPersists&lt;Token&gt; {
+    <b>ensures</b> <b>old</b>(token_is_registered&lt;Token&gt;()) ==&gt; token_is_registered&lt;Token&gt;();
+}
+</code></pre>
+
+
+
+
+<pre><code><b>apply</b> RegistrationPersists&lt;Token&gt; <b>to</b> *&lt;Token&gt;;
+</code></pre>
+
+
+
+<a name="0x0_LibraDocTest_Specification_register"></a>
+
+#### Function `register`
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="#0x0_LibraDocTest_register">register</a>&lt;Token&gt;()
+</code></pre>
+
+
+
+
+<pre><code><b>include</b> RegisterAbortsIf&lt;Token&gt;;
+<b>ensures</b> exists_sender_mint_capability&lt;Token&gt;();
+<b>ensures</b> token_is_registered&lt;Token&gt;();
+<b>ensures</b> info&lt;Token&gt;().total_value == 0;
+<b>ensures</b> info&lt;Token&gt;().preburn_value == 0;
+</code></pre>
+
+
+
+
+<pre><code><b>schema</b> RegisterAbortsIf&lt;Token&gt; {
+    <b>aborts_if</b> sender() != association_address();
+    <b>aborts_if</b> exists_sender_mint_capability&lt;Token&gt;();
+    <b>aborts_if</b> token_is_registered&lt;Token&gt;();
+}
+</code></pre>
+
+
+
+<a name="0x0_LibraDocTest_Specification_assert_is_registered"></a>
+
+#### Function `assert_is_registered`
+
+
+<pre><code><b>fun</b> <a href="#0x0_LibraDocTest_assert_is_registered">assert_is_registered</a>&lt;Token&gt;()
+</code></pre>
+
+
+
+
+<pre><code><b>aborts_if</b> !token_is_registered&lt;Token&gt;();
+</code></pre>
+
+
+
+<a name="0x0_LibraDocTest_Specification_mint"></a>
+
+#### Function `mint`
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="#0x0_LibraDocTest_mint">mint</a>&lt;Token&gt;(amount: u64): <a href="#0x0_LibraDocTest_T">LibraDocTest::T</a>&lt;Token&gt;
+</code></pre>
+
+
+
+
+<pre><code><b>include</b> MintAbortsIf&lt;Token&gt;;
+<b>aborts_if</b> !exists_sender_mint_capability&lt;Token&gt;();
+<b>include</b> MintEnsures&lt;Token&gt;;
+</code></pre>
+
+
+
+
+<pre><code><b>schema</b> MintAbortsIf&lt;Token&gt; {
+    amount: u64;
+    <b>aborts_if</b> !token_is_registered&lt;Token&gt;();
+    <b>aborts_if</b> amount &gt; 1000000000 * 1000000;
+    <b>aborts_if</b> info&lt;Token&gt;().total_value + amount &gt; max_u128();
+}
+</code></pre>
+
+
+
+
+<pre><code><b>schema</b> MintEnsures&lt;Token&gt; {
+    amount: u64;
+    result: <a href="#0x0_LibraDocTest_T">T</a>&lt;Token&gt;;
+    <b>ensures</b> info&lt;Token&gt;().total_value == <b>old</b>(info&lt;Token&gt;().total_value) + amount;
+    <b>ensures</b> result.value == amount;
+}
+</code></pre>
+
+
+
+<a name="0x0_LibraDocTest_Specification_burn"></a>
+
+#### Function `burn`
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="#0x0_LibraDocTest_burn">burn</a>&lt;Token&gt;(preburn_address: address)
+</code></pre>
+
+
+
+
+<pre><code><b>aborts_if</b> !exists_sender_mint_capability&lt;Token&gt;();
+<b>include</b> BurnAbortsIf&lt;Token&gt;;
+<b>include</b> BurnEnsures&lt;Token&gt;;
+</code></pre>
+
+
+Properties applying both to burn and to burn_cancel functions.
+
+
+<pre><code><b>schema</b> BasicBurnAbortsIf&lt;Token&gt; {
+    preburn_address: address;
+    <b>aborts_if</b> !exists&lt;<a href="#0x0_LibraDocTest_Preburn">Preburn</a>&lt;Token&gt;&gt;(preburn_address);
+    <b>aborts_if</b> len(<b>global</b>&lt;<a href="#0x0_LibraDocTest_Preburn">Preburn</a>&lt;Token&gt;&gt;(preburn_address).requests) == 0;
+    <b>aborts_if</b> !token_is_registered&lt;Token&gt;();
+    <b>aborts_if</b> info&lt;Token&gt;().<a href="#0x0_LibraDocTest_preburn_value">preburn_value</a> &lt; <b>global</b>&lt;<a href="#0x0_LibraDocTest_Preburn">Preburn</a>&lt;Token&gt;&gt;(preburn_address).requests[0].value;
+}
+</code></pre>
+
+
+
+
+<pre><code><b>schema</b> BurnAbortsIf&lt;Token&gt; {
+    <b>include</b> BasicBurnAbortsIf&lt;Token&gt;;
+    <b>aborts_if</b> info&lt;Token&gt;().total_value &lt; <b>global</b>&lt;<a href="#0x0_LibraDocTest_Preburn">Preburn</a>&lt;Token&gt;&gt;(preburn_address).requests[0].value;
+}
+</code></pre>
+
+
+
+
+<pre><code><b>schema</b> BurnEnsures&lt;Token&gt; {
+    preburn_address: address;
+    <b>ensures</b> Vector::eq_pop_front(
+                <b>global</b>&lt;<a href="#0x0_LibraDocTest_Preburn">Preburn</a>&lt;Token&gt;&gt;(preburn_address).requests,
+                <b>old</b>(<b>global</b>&lt;<a href="#0x0_LibraDocTest_Preburn">Preburn</a>&lt;Token&gt;&gt;(preburn_address).requests)
+            );
+    <b>ensures</b> info&lt;Token&gt;().total_value ==
+                <b>old</b>(info&lt;Token&gt;().total_value)
+                    - <b>old</b>(<b>global</b>&lt;<a href="#0x0_LibraDocTest_Preburn">Preburn</a>&lt;Token&gt;&gt;(preburn_address).requests[0].value);
+    <b>ensures</b> info&lt;Token&gt;().preburn_value ==
+                <b>old</b>(info&lt;Token&gt;().preburn_value)
+                    - <b>old</b>(<b>global</b>&lt;<a href="#0x0_LibraDocTest_Preburn">Preburn</a>&lt;Token&gt;&gt;(preburn_address).requests[0].value);
+}
+</code></pre>
+
+
+
+<a name="0x0_LibraDocTest_Specification_cancel_burn"></a>
+
+#### Function `cancel_burn`
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="#0x0_LibraDocTest_cancel_burn">cancel_burn</a>&lt;Token&gt;(preburn_address: address): <a href="#0x0_LibraDocTest_T">LibraDocTest::T</a>&lt;Token&gt;
+</code></pre>
+
+
+
+
+<pre><code><b>aborts_if</b> !exists_sender_mint_capability&lt;Token&gt;();
+<b>include</b> BasicBurnAbortsIf&lt;Token&gt;;
+<b>include</b> CancelBurnEnsures&lt;Token&gt;;
+</code></pre>
+
+
+
+
+<pre><code><b>schema</b> CancelBurnEnsures&lt;Token&gt; {
+    preburn_address: address;
+    result: <a href="#0x0_LibraDocTest_T">T</a>&lt;Token&gt;;
+    <b>ensures</b> Vector::eq_pop_front(
+                <b>global</b>&lt;<a href="#0x0_LibraDocTest_Preburn">Preburn</a>&lt;Token&gt;&gt;(preburn_address).requests,
+                <b>old</b>(<b>global</b>&lt;<a href="#0x0_LibraDocTest_Preburn">Preburn</a>&lt;Token&gt;&gt;(preburn_address).requests)
+            );
+    <b>ensures</b> info&lt;Token&gt;().preburn_value ==
+                <b>old</b>(info&lt;Token&gt;().preburn_value) - <b>old</b>(<b>global</b>&lt;<a href="#0x0_LibraDocTest_Preburn">Preburn</a>&lt;Token&gt;&gt;(preburn_address).requests[0].value);
+    <b>ensures</b> result == <b>old</b>(<b>global</b>&lt;<a href="#0x0_LibraDocTest_Preburn">Preburn</a>&lt;Token&gt;&gt;(preburn_address).requests[0]);
+}
+</code></pre>
+
+
+
+<a name="0x0_LibraDocTest_Specification_new_preburn"></a>
+
+#### Function `new_preburn`
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="#0x0_LibraDocTest_new_preburn">new_preburn</a>&lt;Token&gt;(): <a href="#0x0_LibraDocTest_Preburn">LibraDocTest::Preburn</a>&lt;Token&gt;
+</code></pre>
+
+
+
+
+<pre><code><b>aborts_if</b> !token_is_registered&lt;Token&gt;();
+<b>ensures</b> len(result.requests) == 0;
+<b>ensures</b> result.is_approved == <b>false</b>;
+</code></pre>
+
+
+
+<a name="0x0_LibraDocTest_Specification_mint_with_capability"></a>
+
+#### Function `mint_with_capability`
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="#0x0_LibraDocTest_mint_with_capability">mint_with_capability</a>&lt;Token&gt;(value: u64, _capability: &<a href="#0x0_LibraDocTest_MintCapability">LibraDocTest::MintCapability</a>&lt;Token&gt;): <a href="#0x0_LibraDocTest_T">LibraDocTest::T</a>&lt;Token&gt;
+</code></pre>
+
+
+
+
+<pre><code><b>include</b> MintAbortsIf&lt;Token&gt;{amount: value};
+<b>include</b> MintEnsures&lt;Token&gt;{amount: value};
+</code></pre>
+
+
+
+<a name="0x0_LibraDocTest_Specification_preburn"></a>
+
+#### Function `preburn`
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="#0x0_LibraDocTest_preburn">preburn</a>&lt;Token&gt;(preburn_ref: &<b>mut</b> <a href="#0x0_LibraDocTest_Preburn">LibraDocTest::Preburn</a>&lt;Token&gt;, coin: <a href="#0x0_LibraDocTest_T">LibraDocTest::T</a>&lt;Token&gt;)
+</code></pre>
+
+
+
+
+<pre><code><b>include</b> PreburnAbortsIf&lt;Token&gt;;
+<b>include</b> PreburnEnsures&lt;Token&gt;;
+</code></pre>
+
+
+
+
+<pre><code><b>schema</b> PreburnAbortsIf&lt;Token&gt; {
+    coin: <a href="#0x0_LibraDocTest_T">T</a>&lt;Token&gt;;
+    <b>aborts_if</b> !token_is_registered&lt;Token&gt;();
+    <b>aborts_if</b> info&lt;Token&gt;().preburn_value + coin.value &gt; max_u64();
+}
+</code></pre>
+
+
+
+
+<pre><code><b>schema</b> PreburnEnsures&lt;Token&gt; {
+    preburn_ref: &<b>mut</b> <a href="#0x0_LibraDocTest_Preburn">Preburn</a>&lt;Token&gt;;
+    coin: <a href="#0x0_LibraDocTest_T">T</a>&lt;Token&gt;;
+    <b>ensures</b> info&lt;Token&gt;().preburn_value == <b>old</b>(info&lt;Token&gt;().preburn_value) + coin.value;
+    <b>ensures</b> Vector::eq_push_back(preburn_ref.requests, <b>old</b>(preburn_ref.requests), coin);
+}
+</code></pre>
+
+
+
+<a name="0x0_LibraDocTest_Specification_preburn_to_sender"></a>
+
+#### Function `preburn_to_sender`
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="#0x0_LibraDocTest_preburn_to_sender">preburn_to_sender</a>&lt;Token&gt;(coin: <a href="#0x0_LibraDocTest_T">LibraDocTest::T</a>&lt;Token&gt;)
+</code></pre>
+
+
+
+
+<pre><code><b>include</b> PreburnAbortsIf&lt;Token&gt;;
+<b>aborts_if</b> !exists&lt;<a href="#0x0_LibraDocTest_Preburn">Preburn</a>&lt;Token&gt;&gt;(sender());
+<b>include</b> PreburnEnsures&lt;Token&gt;{preburn_ref: <b>global</b>&lt;<a href="#0x0_LibraDocTest_Preburn">Preburn</a>&lt;Token&gt;&gt;(sender())};
+</code></pre>
+
+
+
+<a name="0x0_LibraDocTest_Specification_burn_with_capability"></a>
+
+#### Function `burn_with_capability`
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="#0x0_LibraDocTest_burn_with_capability">burn_with_capability</a>&lt;Token&gt;(preburn_address: address, _capability: &<a href="#0x0_LibraDocTest_MintCapability">LibraDocTest::MintCapability</a>&lt;Token&gt;)
+</code></pre>
+
+
+
+
+<pre><code><b>include</b> BurnAbortsIf&lt;Token&gt;;
+<b>aborts_if</b> info&lt;Token&gt;().total_value &lt; <b>global</b>&lt;<a href="#0x0_LibraDocTest_Preburn">Preburn</a>&lt;Token&gt;&gt;(preburn_address).requests[0].value;
+<b>include</b> BurnEnsures&lt;Token&gt;;
+</code></pre>
+
+
+
+<a name="0x0_LibraDocTest_Specification_cancel_burn_with_capability"></a>
+
+#### Function `cancel_burn_with_capability`
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="#0x0_LibraDocTest_cancel_burn_with_capability">cancel_burn_with_capability</a>&lt;Token&gt;(preburn_address: address, _capability: &<a href="#0x0_LibraDocTest_MintCapability">LibraDocTest::MintCapability</a>&lt;Token&gt;): <a href="#0x0_LibraDocTest_T">LibraDocTest::T</a>&lt;Token&gt;
+</code></pre>
+
+
+
+
+<pre><code><b>include</b> BasicBurnAbortsIf&lt;Token&gt;;
+<b>include</b> CancelBurnEnsures&lt;Token&gt;;
+</code></pre>
+
+
+
+<a name="0x0_LibraDocTest_Specification_publish_preburn"></a>
+
+#### Function `publish_preburn`
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="#0x0_LibraDocTest_publish_preburn">publish_preburn</a>&lt;Token&gt;(preburn: <a href="#0x0_LibraDocTest_Preburn">LibraDocTest::Preburn</a>&lt;Token&gt;)
+</code></pre>
+
+
+
+
+<pre><code><b>aborts_if</b> exists&lt;<a href="#0x0_LibraDocTest_Preburn">Preburn</a>&lt;Token&gt;&gt;(sender());
+<b>ensures</b> exists&lt;<a href="#0x0_LibraDocTest_Preburn">Preburn</a>&lt;Token&gt;&gt;(sender());
+<b>ensures</b> <b>global</b>&lt;<a href="#0x0_LibraDocTest_Preburn">Preburn</a>&lt;Token&gt;&gt;(sender()) == preburn;
+</code></pre>
+
+
+
+<a name="0x0_LibraDocTest_Specification_remove_preburn"></a>
+
+#### Function `remove_preburn`
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="#0x0_LibraDocTest_remove_preburn">remove_preburn</a>&lt;Token&gt;(): <a href="#0x0_LibraDocTest_Preburn">LibraDocTest::Preburn</a>&lt;Token&gt;
+</code></pre>
+
+
+
+
+<pre><code><b>aborts_if</b> !exists&lt;<a href="#0x0_LibraDocTest_Preburn">Preburn</a>&lt;Token&gt;&gt;(sender());
+<b>ensures</b> !exists&lt;<a href="#0x0_LibraDocTest_Preburn">Preburn</a>&lt;Token&gt;&gt;(sender());
+<b>ensures</b> result == <b>old</b>(<b>global</b>&lt;<a href="#0x0_LibraDocTest_Preburn">Preburn</a>&lt;Token&gt;&gt;(sender()));
+</code></pre>
+
+
+
+<a name="0x0_LibraDocTest_Specification_destroy_preburn"></a>
+
+#### Function `destroy_preburn`
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="#0x0_LibraDocTest_destroy_preburn">destroy_preburn</a>&lt;Token&gt;(preburn: <a href="#0x0_LibraDocTest_Preburn">LibraDocTest::Preburn</a>&lt;Token&gt;)
+</code></pre>
+
+
+
+
+<pre><code><b>aborts_if</b> len(preburn.requests) &gt; 0;
+</code></pre>
+
+
+
+<a name="0x0_LibraDocTest_Specification_publish_mint_capability"></a>
+
+#### Function `publish_mint_capability`
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="#0x0_LibraDocTest_publish_mint_capability">publish_mint_capability</a>&lt;Token&gt;(capability: <a href="#0x0_LibraDocTest_MintCapability">LibraDocTest::MintCapability</a>&lt;Token&gt;)
+</code></pre>
+
+
+
+
+<pre><code><b>aborts_if</b> exists_sender_mint_capability&lt;Token&gt;();
+<b>ensures</b> exists_sender_mint_capability&lt;Token&gt;();
+<b>ensures</b> capability == <b>global</b>&lt;<a href="#0x0_LibraDocTest_MintCapability">MintCapability</a>&lt;Token&gt;&gt;(sender());
+</code></pre>
+
+
+
+<a name="0x0_LibraDocTest_Specification_remove_mint_capability"></a>
+
+#### Function `remove_mint_capability`
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="#0x0_LibraDocTest_remove_mint_capability">remove_mint_capability</a>&lt;Token&gt;(): <a href="#0x0_LibraDocTest_MintCapability">LibraDocTest::MintCapability</a>&lt;Token&gt;
+</code></pre>
+
+
+
+
+<pre><code><b>aborts_if</b> !exists_sender_mint_capability&lt;Token&gt;();
+<b>ensures</b> !exists_sender_mint_capability&lt;Token&gt;();
+<b>ensures</b> result == <b>old</b>(<b>global</b>&lt;<a href="#0x0_LibraDocTest_MintCapability">MintCapability</a>&lt;Token&gt;&gt;(sender()));
+</code></pre>
+
+
+
+<a name="0x0_LibraDocTest_Specification_market_cap"></a>
+
+#### Function `market_cap`
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="#0x0_LibraDocTest_market_cap">market_cap</a>&lt;Token&gt;(): u128
+</code></pre>
+
+
+
+
+<pre><code><b>aborts_if</b> !token_is_registered&lt;Token&gt;();
+<b>ensures</b> result == info&lt;Token&gt;().total_value;
+</code></pre>
+
+
+
+<a name="0x0_LibraDocTest_Specification_preburn_value"></a>
+
+#### Function `preburn_value`
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="#0x0_LibraDocTest_preburn_value">preburn_value</a>&lt;Token&gt;(): u64
+</code></pre>
+
+
+
+
+<pre><code><b>aborts_if</b> !token_is_registered&lt;Token&gt;();
+<b>ensures</b> result == info&lt;Token&gt;().preburn_value;
+</code></pre>
+
+
+
+<a name="0x0_LibraDocTest_Specification_zero"></a>
+
+#### Function `zero`
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="#0x0_LibraDocTest_zero">zero</a>&lt;Token&gt;(): <a href="#0x0_LibraDocTest_T">LibraDocTest::T</a>&lt;Token&gt;
+</code></pre>
+
+
+
+
+<pre><code><b>aborts_if</b> !token_is_registered&lt;Token&gt;();
+<b>ensures</b> result.value == 0;
+</code></pre>
+
+
+
+<a name="0x0_LibraDocTest_Specification_value"></a>
+
+#### Function `value`
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="#0x0_LibraDocTest_value">value</a>&lt;Token&gt;(coin_ref: &<a href="#0x0_LibraDocTest_T">LibraDocTest::T</a>&lt;Token&gt;): u64
+</code></pre>
+
+
+
+
+<pre><code><b>ensures</b> result == coin_ref.value;
+</code></pre>
+
+
+
+<a name="0x0_LibraDocTest_Specification_split"></a>
+
+#### Function `split`
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="#0x0_LibraDocTest_split">split</a>&lt;Token&gt;(coin: <a href="#0x0_LibraDocTest_T">LibraDocTest::T</a>&lt;Token&gt;, amount: u64): (<a href="#0x0_LibraDocTest_T">LibraDocTest::T</a>&lt;Token&gt;, <a href="#0x0_LibraDocTest_T">LibraDocTest::T</a>&lt;Token&gt;)
+</code></pre>
+
+
+
+
+<pre><code><b>aborts_if</b> coin.<a href="#0x0_LibraDocTest_value">value</a> &lt; amount;
+<b>ensures</b> result_1.value == coin.value - amount;
+<b>ensures</b> result_2.value == amount;
+</code></pre>
+
+
+
+<a name="0x0_LibraDocTest_Specification_withdraw"></a>
+
+#### Function `withdraw`
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="#0x0_LibraDocTest_withdraw">withdraw</a>&lt;Token&gt;(coin_ref: &<b>mut</b> <a href="#0x0_LibraDocTest_T">LibraDocTest::T</a>&lt;Token&gt;, value: u64): <a href="#0x0_LibraDocTest_T">LibraDocTest::T</a>&lt;Token&gt;
+</code></pre>
+
+
+
+
+<pre><code><b>aborts_if</b> coin_ref.<a href="#0x0_LibraDocTest_value">value</a> &lt; value;
+<b>ensures</b> coin_ref.value == <b>old</b>(coin_ref.value) - value;
+<b>ensures</b> result.value == value;
+</code></pre>
+
+
+
+<a name="0x0_LibraDocTest_Specification_join"></a>
+
+#### Function `join`
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="#0x0_LibraDocTest_join">join</a>&lt;Token&gt;(coin1: <a href="#0x0_LibraDocTest_T">LibraDocTest::T</a>&lt;Token&gt;, coin2: <a href="#0x0_LibraDocTest_T">LibraDocTest::T</a>&lt;Token&gt;): <a href="#0x0_LibraDocTest_T">LibraDocTest::T</a>&lt;Token&gt;
+</code></pre>
+
+
+
+
+<pre><code><b>aborts_if</b> coin1.value + coin2.value &gt; max_u64();
+<b>ensures</b> result.value == coin1.value + coin2.value;
+</code></pre>
+
+
+
+<a name="0x0_LibraDocTest_Specification_deposit"></a>
+
+#### Function `deposit`
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="#0x0_LibraDocTest_deposit">deposit</a>&lt;Token&gt;(coin_ref: &<b>mut</b> <a href="#0x0_LibraDocTest_T">LibraDocTest::T</a>&lt;Token&gt;, check: <a href="#0x0_LibraDocTest_T">LibraDocTest::T</a>&lt;Token&gt;)
+</code></pre>
+
+
+
+
+<pre><code><b>aborts_if</b> coin_ref.value + check.value &gt; max_u64();
+<b>ensures</b> coin_ref.value == <b>old</b>(coin_ref.value) + check.value;
+</code></pre>
+
+
+
+<a name="0x0_LibraDocTest_Specification_destroy_zero"></a>
+
+#### Function `destroy_zero`
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="#0x0_LibraDocTest_destroy_zero">destroy_zero</a>&lt;Token&gt;(coin: <a href="#0x0_LibraDocTest_T">LibraDocTest::T</a>&lt;Token&gt;)
+</code></pre>
+
+
+
+
+<pre><code><b>aborts_if</b> coin.value &gt; 0;
+</code></pre>

--- a/language/move-prover/docgen/tests/sources/libra.spec_separate.md
+++ b/language/move-prover/docgen/tests/sources/libra.spec_separate.md
@@ -1,4 +1,4 @@
-## Table of Content
+## Table of Contents
 -  [Module `0x0::LibraDocTest`](#0x0_LibraDocTest)
     -  [Struct `T`](#0x0_LibraDocTest_T)
     -  [Struct `MintCapability`](#0x0_LibraDocTest_MintCapability)

--- a/language/move-prover/docgen/tests/testsuite.rs
+++ b/language/move-prover/docgen/tests/testsuite.rs
@@ -1,0 +1,79 @@
+// Copyright (c) The Libra Core Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+use std::path::Path;
+
+use codespan_reporting::term::termcolor::Buffer;
+
+use libra_temppath::TempPath;
+use move_prover::{cli::Options, run_move_prover};
+use test_utils::baseline_test::verify_or_update_baseline;
+
+use itertools::Itertools;
+#[allow(unused_imports)]
+use log::warn;
+use std::{fs::File, io::Read};
+
+const FLAGS: &[&str] = &[
+    "--verbose=warn",
+    // This currently points to the legacy stdlib copy in prover tests. Replace this
+    // by real stdlib once we have a good example based on it.
+    "--search-path=../tests/sources/stdlib/modules",
+    "--docgen",
+];
+
+fn test_runner(path: &Path) -> datatest_stable::Result<()> {
+    let mut args = vec!["mvp_test".to_string()];
+    args.extend(FLAGS.iter().map(|s| (*s).to_string()).collect_vec());
+    args.push(path.to_string_lossy().to_string());
+
+    let mut options = Options::default();
+    options.initialize_from_args(&args)?;
+    options.setup_logging_for_test();
+
+    options.docgen_options.include_specs = true;
+    options.docgen_options.include_impl = true;
+    options.docgen_options.include_private_fun = true;
+
+    options.docgen_options.specs_inlined = true;
+    test_docgen(path, options.clone(), "spec_inline.md")?;
+
+    options.docgen_options.specs_inlined = false;
+    test_docgen(path, options.clone(), "spec_separate.md")?;
+
+    options.docgen_options.specs_inlined = true;
+    options.docgen_options.collapsed_sections = false;
+    test_docgen(path, options.clone(), "spec_inline_no_fold.md")?;
+
+    Ok(())
+}
+
+fn test_docgen(path: &Path, mut options: Options, suffix: &str) -> anyhow::Result<()> {
+    let temp_path = TempPath::new();
+    temp_path.create_as_dir()?;
+    let base_name = format!("{}.md", path.file_stem().unwrap().to_str().unwrap());
+    let md_output = temp_path
+        .path()
+        .join(base_name)
+        .to_str()
+        .unwrap()
+        .to_string();
+    options.output_path = md_output.clone();
+
+    let mut error_writer = Buffer::no_color();
+    let mut output = match run_move_prover(&mut error_writer, options) {
+        Ok(()) => {
+            let mut contents = String::new();
+            let mut file = File::open(md_output)?;
+            file.read_to_string(&mut contents)?;
+            contents
+        }
+        Err(err) => format!("Move prover docgen returns: {}\n", err),
+    };
+    output += &String::from_utf8_lossy(&error_writer.into_inner()).to_string();
+    let baseline_path = path.with_extension(suffix);
+    verify_or_update_baseline(baseline_path.as_path(), &output)?;
+    Ok(())
+}
+
+datatest_stable::harness!(test_runner, "tests/sources", r".*\.move",);

--- a/language/move-prover/docgen/tests/testsuite.rs
+++ b/language/move-prover/docgen/tests/testsuite.rs
@@ -43,7 +43,7 @@ fn test_runner(path: &Path) -> datatest_stable::Result<()> {
 
     options.docgen_options.specs_inlined = true;
     options.docgen_options.collapsed_sections = false;
-    test_docgen(path, options.clone(), "spec_inline_no_fold.md")?;
+    test_docgen(path, options, "spec_inline_no_fold.md")?;
 
     Ok(())
 }

--- a/language/move-prover/spec-lang/src/ast.rs
+++ b/language/move-prover/spec-lang/src/ast.rs
@@ -17,6 +17,7 @@ use std::{
 };
 use vm::file_format::CodeOffset;
 
+use crate::env::{FunId, SchemaId, TypeParameter};
 use std::collections::BTreeSet;
 
 // =================================================================================================
@@ -181,6 +182,30 @@ impl Spec {
     pub fn any_kind(&self, kind: ConditionKind) -> bool {
         self.any(move |c| c.kind == kind)
     }
+}
+
+/// Information about a specification block in the source. This is used for documentation
+/// generation. In the object model, the original locations and documentation of spec blocks
+/// is reduced to conditions on a `Spec`, with expansion of schemas. This data structure
+/// allows us to disover the original spec blocks and their content.
+#[derive(Debug, Clone)]
+pub struct SpecBlockInfo {
+    /// The location of the entire spec block.
+    pub loc: Loc,
+    /// The target of the spec block.
+    pub target: SpecBlockTarget,
+    /// The locations of all members of the spec block.
+    pub member_locs: Vec<Loc>,
+}
+
+/// Describes the target of a spec block.
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
+pub enum SpecBlockTarget {
+    Module,
+    Struct(ModuleId, StructId),
+    Function(ModuleId, FunId),
+    FunctionCode(ModuleId, FunId, usize),
+    Schema(ModuleId, SchemaId, Vec<TypeParameter>),
 }
 
 // =================================================================================================

--- a/language/move-prover/spec-lang/src/env.rs
+++ b/language/move-prover/spec-lang/src/env.rs
@@ -9,7 +9,7 @@ use log::info;
 
 use std::cell::RefCell;
 
-use codespan::{ByteIndex, ByteOffset, FileId, Files, Location, Span};
+use codespan::{ByteIndex, ByteOffset, FileId, Files, Location, Span, SpanOutOfBoundsError};
 use codespan_reporting::{
     diagnostic::{Diagnostic, Label, Severity},
     term::{emit, termcolor::WriteColor, Config},
@@ -34,7 +34,7 @@ use vm::{
 };
 
 use crate::{
-    ast::{ModuleName, PropertyBag, Spec, SpecFunDecl, SpecVarDecl, Value},
+    ast::{ModuleName, PropertyBag, Spec, SpecBlockInfo, SpecFunDecl, SpecVarDecl, Value},
     symbol::{Symbol, SymbolPool},
     ty::{PrimitiveType, Type},
 };
@@ -131,6 +131,10 @@ pub struct FieldId(Symbol);
 #[derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash, Clone, Copy)]
 pub struct FunId(Symbol);
 
+/// Identifier for a schema.
+#[derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash, Clone, Copy)]
+pub struct SchemaId(Symbol);
+
 /// Identifier for a specification function, relative to module.
 #[derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash, Clone, Copy)]
 pub struct SpecFunId(RawIndex);
@@ -145,6 +149,16 @@ pub struct SpecVarId(RawIndex);
 pub struct NodeId(RawIndex);
 
 impl FunId {
+    pub fn new(sym: Symbol) -> Self {
+        Self(sym)
+    }
+
+    pub fn symbol(self) -> Symbol {
+        self.0
+    }
+}
+
+impl SchemaId {
     pub fn new(sym: Symbol) -> Self {
         Self(sym)
     }
@@ -218,6 +232,10 @@ impl ModuleId {
 pub struct GlobalEnv {
     /// A Files database for the codespan crate which supports diagnostics.
     source_files: Files<String>,
+    /// A map of FileId in the Files database to information about documentation comments in a file.
+    /// The comments are represented as map from ByteIndex into string, where the index is the
+    /// start position of the associated language item in the source.
+    doc_comments: BTreeMap<FileId, BTreeMap<ByteIndex, String>>,
     /// A mapping from file names to associated FileId. Though this information is
     /// already in `source_files`, we can't get it out of there so need to book keep here.
     file_name_map: BTreeMap<String, FileId>,
@@ -268,6 +286,7 @@ impl GlobalEnv {
         let internal_loc = fake_loc("<internal>");
         GlobalEnv {
             source_files,
+            doc_comments: Default::default(),
             unknown_loc,
             unknown_move_ir_loc,
             internal_loc,
@@ -297,6 +316,11 @@ impl GlobalEnv {
             self.file_id_is_dep.insert(file_id);
         }
         file_id
+    }
+
+    /// Adds documentation for a file.
+    pub fn add_documentation(&mut self, file_id: FileId, docs: BTreeMap<ByteIndex, String>) {
+        self.doc_comments.insert(file_id, docs);
     }
 
     /// Adds diagnostic to the environment.
@@ -336,14 +360,15 @@ impl GlobalEnv {
     /// TODO: move-lang should use FileId as well so we don't need this here. There is already
     /// a todo in their code to remove the current use of `&'static str` for file names in Loc.
     pub fn to_loc(&self, loc: &MoveIrLoc) -> Loc {
-        let file_id = self
-            .file_name_map
-            .get(loc.file())
-            .expect("file name undefined");
         Loc {
-            file_id: *file_id,
+            file_id: self.get_file_id(loc.file()).expect("file name undefined"),
             span: loc.span(),
         }
+    }
+
+    /// Returns the file id for a file name, if defined.
+    pub fn get_file_id(&self, fname: &str) -> Option<FileId> {
+        self.file_name_map.get(fname).cloned()
     }
 
     /// Maps a FileId to an index which can be mapped back to a FileId.
@@ -376,6 +401,11 @@ impl GlobalEnv {
                     line_column,
                 )
             })
+    }
+
+    /// Return the source text for the given location.
+    pub fn get_source(&self, loc: &Loc) -> Result<&str, SpanOutOfBoundsError> {
+        self.source_files.source_slice(loc.file_id, loc.span)
     }
 
     // Gets the number of source files in this environment.
@@ -414,6 +444,7 @@ impl GlobalEnv {
         loc_map: BTreeMap<NodeId, Loc>,
         type_map: BTreeMap<NodeId, Type>,
         instantiation_map: BTreeMap<NodeId, Vec<Type>>,
+        spec_block_infos: Vec<SpecBlockInfo>,
     ) {
         let idx = self.module_data.len();
         let name = ModuleName::from_str(
@@ -455,6 +486,7 @@ impl GlobalEnv {
             loc_map,
             type_map,
             instantiation_map,
+            spec_block_infos,
         });
     }
 
@@ -645,6 +677,14 @@ impl GlobalEnv {
             self.symbol_pool.make(storage_id.name().as_str()),
         )
     }
+
+    /// Get documentation associated with an item at Loc.
+    pub fn get_doc(&self, loc: &Loc) -> &str {
+        self.doc_comments
+            .get(&loc.file_id)
+            .and_then(|comments| comments.get(&loc.span.start()).map(|s| s.as_str()))
+            .unwrap_or("")
+    }
 }
 
 impl Default for GlobalEnv {
@@ -703,6 +743,9 @@ pub struct ModuleData {
 
     /// A map from node id to associated instantiation of type parameters.
     pub instantiation_map: BTreeMap<NodeId, Vec<Type>>,
+
+    /// A list of spec block infos, for documentation generation.
+    pub spec_block_infos: Vec<SpecBlockInfo>,
 }
 
 /// Represents a module environment.
@@ -735,6 +778,16 @@ impl<'env> ModuleEnv<'env> {
     pub fn is_in_dependency(&self) -> bool {
         let file_id = self.data.loc.file_id;
         self.env.file_id_is_dep.contains(&file_id)
+    }
+
+    /// Returns documentation associated with this module.
+    pub fn get_doc(&self) -> &str {
+        self.env.get_doc(&self.data.loc)
+    }
+
+    /// Returns spec block documentation infos.
+    pub fn get_spec_block_infos(&self) -> &[SpecBlockInfo] {
+        &self.data.spec_block_infos
     }
 
     /// Shortcut for accessing the symbol pool.
@@ -1079,6 +1132,11 @@ impl<'env> StructEnv<'env> {
         self.data.loc.clone()
     }
 
+    /// Get documentation associated with this struct.
+    pub fn get_doc(&self) -> &str {
+        self.module_env.env.get_doc(&self.data.loc)
+    }
+
     /// Returns properties from pragmas.
     pub fn get_properties(&self) -> &PropertyBag {
         &self.data.spec.properties
@@ -1178,7 +1236,34 @@ impl<'env> StructEnv<'env> {
             .map(|(i, k)| {
                 TypeParameter(
                     self.module_env.env.symbol_pool.make(&format!("$tv{}", i)),
-                    *k,
+                    TypeConstraint::from(*k),
+                )
+            })
+            .collect_vec()
+    }
+
+    /// Returns the type parameters associated with this struct, with actual names.
+    pub fn get_named_type_parameters(&self) -> Vec<TypeParameter> {
+        let view = StructDefinitionView::new(
+            &self.module_env.data.module,
+            self.module_env.data.module.struct_def_at(self.data.def_idx),
+        );
+        view.type_parameters()
+            .iter()
+            .enumerate()
+            .map(|(i, k)| {
+                let name = self
+                    .module_env
+                    .data
+                    .source_map
+                    .get_struct_source_map(self.data.def_idx)
+                    .ok()
+                    .and_then(|smap| smap.type_parameters.get(i))
+                    .map(|(s, _)| s.as_str())
+                    .unwrap_or_else(|| "?");
+                TypeParameter(
+                    self.module_env.env.symbol_pool.make(name),
+                    TypeConstraint::from(*k),
                 )
             })
             .collect_vec()
@@ -1230,6 +1315,26 @@ impl<'env> FieldEnv<'env> {
         FieldId(self.data.name)
     }
 
+    /// Get documentation associated with this field.
+    pub fn get_doc(&self) -> &str {
+        if let Ok(smap) = self
+            .struct_env
+            .module_env
+            .data
+            .source_map
+            .get_struct_source_map(self.data.def_idx)
+        {
+            let loc = self
+                .struct_env
+                .module_env
+                .env
+                .to_loc(&smap.fields[self.data.offset]);
+            self.struct_env.module_env.env.get_doc(&loc)
+        } else {
+            ""
+        }
+    }
+
     /// Gets the type of this field.
     pub fn get_type(&self) -> Type {
         let struct_def = self
@@ -1257,8 +1362,25 @@ impl<'env> FieldEnv<'env> {
 /// # Function Environment
 
 /// Represents a type parameter.
-#[derive(Debug, Clone)]
-pub struct TypeParameter(pub Symbol, pub Kind);
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
+pub struct TypeParameter(pub Symbol, pub TypeConstraint);
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+pub enum TypeConstraint {
+    None,
+    Copyable,
+    Resource,
+}
+
+impl TypeConstraint {
+    fn from(k: Kind) -> Self {
+        match k {
+            Kind::All => TypeConstraint::None,
+            Kind::Copyable => TypeConstraint::Copyable,
+            Kind::Resource => TypeConstraint::Resource,
+        }
+    }
+}
 
 /// Represents a parameter.
 #[derive(Debug, Clone)]
@@ -1306,6 +1428,11 @@ impl<'env> FunctionEnv<'env> {
     /// Gets the id of this function.
     pub fn get_id(&self) -> FunId {
         FunId(self.data.name)
+    }
+
+    /// Get documentation associated with this function.
+    pub fn get_doc(&self) -> &str {
+        self.module_env.env.get_doc(&self.data.loc)
     }
 
     /// Gets the definition index of this function.
@@ -1400,7 +1527,31 @@ impl<'env> FunctionEnv<'env> {
             .map(|(i, k)| {
                 TypeParameter(
                     self.module_env.env.symbol_pool.make(&format!("$tv{}", i)),
-                    *k,
+                    TypeConstraint::from(*k),
+                )
+            })
+            .collect_vec()
+    }
+
+    /// Returns the type parameters with the real names.
+    pub fn get_named_type_parameters(&self) -> Vec<TypeParameter> {
+        let view = self.definition_view();
+        view.type_parameters()
+            .iter()
+            .enumerate()
+            .map(|(i, k)| {
+                let name = self
+                    .module_env
+                    .data
+                    .source_map
+                    .get_function_source_map(self.data.def_idx)
+                    .ok()
+                    .and_then(|fmap| fmap.type_parameters.get(i))
+                    .map(|(s, _)| s.as_str())
+                    .unwrap_or_else(|| "?");
+                TypeParameter(
+                    self.module_env.env.symbol_pool.make(name),
+                    TypeConstraint::from(*k),
                 )
             })
             .collect_vec()

--- a/language/move-prover/src/boogie_wrapper.rs
+++ b/language/move-prover/src/boogie_wrapper.rs
@@ -21,11 +21,12 @@ use pretty::RcDoc;
 use regex::Regex;
 
 use spec_lang::{
+    code_writer::CodeWriter,
     env::{FunId, GlobalEnv, Loc, ModuleId, StructId},
     ty::{PrimitiveType, Type},
 };
 
-use crate::{cli::Options, code_writer::CodeWriter};
+use crate::cli::Options;
 // DENUG
 // use backtrace::Backtrace;
 use stackless_bytecode_generator::{

--- a/language/move-prover/src/bytecode_translator.rs
+++ b/language/move-prover/src/bytecode_translator.rs
@@ -10,6 +10,8 @@ use itertools::Itertools;
 use log::{debug, info, log, warn, Level};
 
 use spec_lang::{
+    code_writer::CodeWriter,
+    emit, emitln,
     env::{GlobalEnv, Loc, ModuleEnv, StructEnv, TypeParameter},
     ty::{PrimitiveType, Type},
 };
@@ -32,7 +34,6 @@ use crate::{
         boogie_var_before_borrow, boogie_well_formed_check, WellFormedMode,
     },
     cli::{Options, VerificationScope},
-    code_writer::CodeWriter,
     spec_translator::SpecTranslator,
 };
 

--- a/language/move-prover/src/lib.rs
+++ b/language/move-prover/src/lib.rs
@@ -7,16 +7,16 @@ use crate::{
     boogie_wrapper::BoogieWrapper,
     bytecode_translator::BoogieTranslator,
     cli::{Options, INLINE_PRELUDE},
-    code_writer::CodeWriter,
     prelude_template_helpers::StratificationHelper,
 };
 use anyhow::anyhow;
 use codespan_reporting::term::termcolor::WriteColor;
+use docgen::docgen::Docgen;
 use handlebars::Handlebars;
 #[allow(unused_imports)]
 use log::{debug, info, warn};
 use regex::Regex;
-use spec_lang::{env::GlobalEnv, run_spec_lang_compiler};
+use spec_lang::{code_writer::CodeWriter, emit, emitln, env::GlobalEnv, run_spec_lang_compiler};
 use stackless_bytecode_generator::{
     eliminate_imm_refs::EliminateImmRefsProcessor,
     function_target_pipeline::{FunctionTargetPipeline, FunctionTargetsHolder},
@@ -30,9 +30,6 @@ use std::{
     path::{Path, PathBuf},
     time::Instant,
 };
-
-#[macro_use]
-mod code_writer;
 
 mod boogie_helpers;
 mod boogie_wrapper;
@@ -68,6 +65,10 @@ pub fn run_move_prover<W: WriteColor>(
     if env.has_errors() {
         env.report_errors(error_writer);
         return Err(anyhow!("exiting with transformation errors"));
+    }
+    // Until this point, prover and docgen have same code. Here we part ways.
+    if options.docgen {
+        return run_docgen(&env, &options, &targets);
     }
     let writer = CodeWriter::new(env.internal_loc());
     add_prelude(&options, &writer)?;
@@ -112,6 +113,21 @@ pub fn run_move_prover<W: WriteColor>(
             return Err(anyhow!("exiting with boogie verification errors"));
         }
     }
+    Ok(())
+}
+
+fn run_docgen(
+    env: &GlobalEnv,
+    options: &Options,
+    _func_targets: &FunctionTargetsHolder,
+) -> anyhow::Result<()> {
+    let path = Path::new(&options.output_path).with_extension("md");
+    let mut generator = Docgen::new(env, &options.docgen_options);
+    info!("generating documentation");
+    generator.gen();
+    generator
+        .into_code_writer()
+        .process_result(move |content| fs::write(path.as_path(), content))?;
     Ok(())
 }
 
@@ -227,7 +243,7 @@ fn calculate_file_map(search_path: &[String]) -> anyhow::Result<BTreeMap<String,
 /// Extracts matches out of some text file. `pat` must be a regular expression with one anonymous
 /// group. The list of the content of this group is returned. Use as in in
 /// `extract_matches(file, "use 0x0::([a-zA-Z_]+)")`
-pub fn extract_matches(path: &Path, pat: &str) -> anyhow::Result<Vec<String>> {
+fn extract_matches(path: &Path, pat: &str) -> anyhow::Result<Vec<String>> {
     let rex = Regex::new(&format!("(?m){}", pat))?;
     let mut content = String::new();
     let mut file = File::open(path)?;

--- a/language/move-prover/src/spec_translator.rs
+++ b/language/move-prover/src/spec_translator.rs
@@ -13,17 +13,16 @@ use spec_lang::{
 #[allow(unused_imports)]
 use log::{debug, info, warn};
 
-use crate::{
-    boogie_helpers::{
-        boogie_byte_blob, boogie_declare_global, boogie_field_name, boogie_global_declarator,
-        boogie_local_type, boogie_spec_fun_name, boogie_spec_var_name, boogie_struct_name,
-        boogie_type_value, boogie_well_formed_expr, WellFormedMode,
-    },
-    code_writer::CodeWriter,
+use crate::boogie_helpers::{
+    boogie_byte_blob, boogie_declare_global, boogie_field_name, boogie_global_declarator,
+    boogie_local_type, boogie_spec_fun_name, boogie_spec_var_name, boogie_struct_name,
+    boogie_type_value, boogie_well_formed_expr, WellFormedMode,
 };
 use itertools::Itertools;
 use spec_lang::{
     ast::{Condition, ConditionKind, Exp, LocalVarDecl, Operation, Value},
+    code_writer::CodeWriter,
+    emit, emitln,
     env::GlobalEnv,
     symbol::Symbol,
 };

--- a/language/move-prover/stackless-bytecode-generator/Cargo.toml
+++ b/language/move-prover/stackless-bytecode-generator/Cargo.toml
@@ -10,7 +10,7 @@ publish = false
 edition = "2018"
 
 [dependencies]
-spec-lang = { path = "../spec-lang", version = "0.0.1" }
+spec-lang = { path = "../spec-lang", version = "0.1.0" }
 vm = { path = "../../vm", version = "0.1.0" }
 bytecode-verifier = { path = "../../bytecode-verifier", version = "0.1.0" }
 borrow-graph = { path = "../../borrow-graph", version = "0.0.1" }

--- a/language/move-prover/stackless-bytecode-generator/src/function_target.rs
+++ b/language/move-prover/stackless-bytecode-generator/src/function_target.rs
@@ -273,6 +273,7 @@ impl<'env> fmt::Display for FunctionTarget<'env> {
         }
         let tctx = TypeDisplayContext::WithEnv {
             env: self.global_env(),
+            type_param_names: None,
         };
         write!(f, "(")?;
         for i in 0..self.get_parameter_count() {

--- a/language/move-prover/stackless-bytecode-generator/src/stackless_bytecode.rs
+++ b/language/move-prover/stackless-bytecode-generator/src/stackless_bytecode.rs
@@ -180,6 +180,7 @@ impl<'env> fmt::Display for BorrowNodeDisplay<'env> {
                 let ty = Type::Struct(s.module_id, s.struct_id, vec![]);
                 let tctx = TypeDisplayContext::WithEnv {
                     env: self.func_target.global_env(),
+                    type_param_names: None,
                 };
                 write!(f, "{}", ty.display(&tctx))?;
             }
@@ -588,6 +589,7 @@ impl<'env> OperationDisplay<'env> {
         if !targs.is_empty() {
             let tctx = TypeDisplayContext::WithEnv {
                 env: self.func_target.global_env(),
+                type_param_names: None,
             };
             write!(f, "<")?;
             for (i, ty) in targs.iter().enumerate() {
@@ -605,6 +607,7 @@ impl<'env> OperationDisplay<'env> {
         let ty = Type::Struct(mid, sid, targs.to_vec());
         let tctx = TypeDisplayContext::WithEnv {
             env: self.func_target.global_env(),
+            type_param_names: None,
         };
         format!("{}", ty.display(&tctx))
     }


### PR DESCRIPTION
This PR provides the initial implementation of a documentation generator for Move, including declarations, specifications, and implementations.

The generators produces markdown files which are tailored to work on github.  For a description of the generator, see `language/move-prover/docgen/README.md`. For an example of a final result, you can take a look at the generated doc [here](https://github.com/wrwg/libra/blob/docgen/language/move-prover/docgen/tests/sources/libra.spec_inline.md) which is part of a baseline test for this PR.



## Motivation

Beautiful specs.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

New tests.

## Related PRs

NA
