### PR TITLE
[move-prover] Quantification of addresses in specs

### DIFF
--- a/language/move-prover/spec-lang/src/ast.rs
+++ b/language/move-prover/spec-lang/src/ast.rs
@@ -281,6 +281,7 @@ pub enum Operation {
     Result(usize),
     Index,
     Slice,
+    Addresses,
 
     // Binary operators
     Range,

--- a/language/move-prover/spec-lang/src/translate.rs
+++ b/language/move-prover/spec-lang/src/translate.rs
@@ -322,6 +322,8 @@ impl<'env> Translator<'env> {
         let num_t = &Type::new_prim(PrimitiveType::Num);
         let range_t = &Type::new_prim(PrimitiveType::Range);
         let address_t = &Type::new_prim(PrimitiveType::Address);
+        let addresses_t = &Type::new_prim(PrimitiveType::Addresses);
+
         let param_t = &Type::TypeParameter(0);
         let add_builtin = |trans: &mut Translator, name: QualifiedSymbol, entry: SpecFunEntry| {
             trans
@@ -415,6 +417,7 @@ impl<'env> Translator<'env> {
             let vector_t = &Type::Vector(Box::new(param_t.clone()));
             let pred_t = &Type::Fun(vec![param_t.clone()], Box::new(bool_t.clone()));
             let pred_num_t = &Type::Fun(vec![num_t.clone()], Box::new(bool_t.clone()));
+            let pred_address_t = &Type::Fun(vec![address_t.clone()], Box::new(bool_t.clone()));
 
             // Transaction metadata
             add_builtin(
@@ -556,6 +559,43 @@ impl<'env> Translator<'env> {
                     oper: Operation::Exists,
                     type_params: vec![param_t.clone()],
                     arg_types: vec![address_t.clone()],
+                    result_type: bool_t.clone(),
+                },
+            );
+
+            // address quantifiers
+            // addresses() is set of all addresses
+            add_builtin(
+                self,
+                self.builtin_fun_symbol("addresses"),
+                SpecFunEntry {
+                    loc: loc.clone(),
+                    oper: Operation::Addresses,
+                    type_params: vec![],
+                    arg_types: vec![],
+                    result_type: addresses_t.clone(),
+                },
+            );
+
+            add_builtin(
+                self,
+                self.builtin_fun_symbol("all"),
+                SpecFunEntry {
+                    loc: loc.clone(),
+                    oper: Operation::All,
+                    type_params: vec![],
+                    arg_types: vec![addresses_t.clone(), pred_address_t.clone()],
+                    result_type: bool_t.clone(),
+                },
+            );
+            add_builtin(
+                self,
+                self.builtin_fun_symbol("any"),
+                SpecFunEntry {
+                    loc: loc.clone(),
+                    oper: Operation::Any,
+                    type_params: vec![],
+                    arg_types: vec![addresses_t.clone(), pred_address_t.clone()],
                     result_type: bool_t.clone(),
                 },
             );

--- a/language/move-prover/spec-lang/src/ty.rs
+++ b/language/move-prover/spec-lang/src/ty.rs
@@ -42,7 +42,7 @@ pub enum PrimitiveType {
     U128,
     Address,
     Signer,
-
+    Addresses, // set of addresses, for quantification
     // Types only appearing in specifications
     Num,
     Range,
@@ -533,6 +533,7 @@ impl fmt::Display for PrimitiveType {
             U128 => f.write_str("u128"),
             Address => f.write_str("address"),
             Signer => f.write_str("signer"),
+            Addresses => f.write_str("addresses"),
             Range => f.write_str("range"),
             Num => f.write_str("num"),
         }

--- a/language/move-prover/src/boogie_helpers.rs
+++ b/language/move-prover/src/boogie_helpers.rs
@@ -99,6 +99,7 @@ pub fn boogie_type_value(env: &GlobalEnv, ty: &Type) -> String {
             PrimitiveType::Address => "AddressType()".to_string(),
             // TODO fix this for a real boogie type
             PrimitiveType::Signer => "AddressType()".to_string(),
+            PrimitiveType::Addresses => "AddressesType()".to_string(),
             PrimitiveType::Range => "RangeType()".to_string(),
         },
         Type::Vector(t) => format!("$Vector_type_value({})", boogie_type_value(env, t)),
@@ -185,6 +186,7 @@ fn boogie_well_formed_expr_impl(
             PrimitiveType::Address => conds.push(format!("is#Address({})", name)),
             // TODO fix this for a real boogie check
             PrimitiveType::Signer => conds.push(format!("is#Address({})", name)),
+            PrimitiveType::Addresses => (), // not needed
             PrimitiveType::Range => conds.push(format!("$IsValidRange({})", name)),
         },
         Type::Vector(elem_ty) => {

--- a/language/move-prover/src/prelude.bpl
+++ b/language/move-prover/src/prelude.bpl
@@ -701,18 +701,35 @@ procedure {:inline 1} $Sub(src1: Value, src2: Value) returns (dst: Value)
     dst := Integer(i#Integer(src1) - i#Integer(src2));
 }
 
+// This deals only with narrow special cases. Src2 must be constant
+// 32 or 64, which is what we use now.  Obviously, it could be extended
+// to src2 == any integer value from 0..127.
+// Left them out for brevity
+function power_of_2 (power:Value): int {
+    (var p := i#Integer(power);
+     if p == 32 then 4294967296
+     else if p == 64 then 18446744073709551616
+     // value is undefined, otherwise.
+     else -1
+     )
+}
+
 procedure {:inline 1} $Shl(src1: Value, src2: Value) returns (dst: Value)
-{{type_requires}} is#Integer(src1) && is#Integer(src2);
+requires is#Integer(src1) && is#Integer(src2);
 {
-    // TOOD: implement
-    assert false;
+    var po2: int;
+    po2 := power_of_2(src2);
+    assert po2 >= 1;   // po2 < 0 if src2 not 32 or 63
+    dst := Integer(i#Integer(src2) * po2);
 }
 
 procedure {:inline 1} $Shr(src1: Value, src2: Value) returns (dst: Value)
-{{type_requires}} is#Integer(src1) && is#Integer(src2);
+requires is#Integer(src1) && is#Integer(src2);
 {
-    // TOOD: implement
-    assert false;
+    var po2: int;
+    po2 := power_of_2(src2);
+    assert po2 >= 1;   // po2 < 0 if src2 not 32 or 63
+    dst := Integer(i#Integer(src2) div po2);
 }
 
 procedure {:inline 1} $MulU8(src1: Value, src2: Value) returns (dst: Value)

--- a/language/move-prover/tests/sources/functional/address_quant.exp
+++ b/language/move-prover/tests/sources/functional/address_quant.exp
@@ -1,0 +1,11 @@
+Move prover returns: exiting with boogie verification errors
+error:  A postcondition might not hold on this return path.
+
+    ┌── tests/sources/functional/address_quant.move:57:10 ───
+    │
+ 57 │          invariant atMostOne();
+    │          ^^^^^^^^^^^^^^^^^^^^^^
+    │
+    =     at tests/sources/functional/address_quant.move:50:5: multiple_copy_incorrect (entry)
+    =     at tests/sources/functional/address_quant.move:51:9: multiple_copy_incorrect
+    =     at tests/sources/functional/address_quant.move:50:5: multiple_copy_incorrect (exit)

--- a/language/move-prover/tests/sources/functional/address_quant.move
+++ b/language/move-prover/tests/sources/functional/address_quant.move
@@ -1,0 +1,65 @@
+// Tests of quantification over addresses.
+module AddressQuant {
+    use 0x0::Transaction;
+
+    resource struct R {
+        x: u64
+    }
+
+    spec module {
+        pragma verify = true;
+    }
+
+    spec module {
+       // helper functions
+       define atMostOne(): bool {
+            all(addresses(),
+                |a| all(addresses(),
+                        |b| exists<R>(a) && exists<R>(b) ==> a == b))
+
+        }
+        define atLeastOne(): bool {
+            any(addresses(),
+                |a| exists<R>(a))
+        }
+    }
+
+    public fun initialize(special_addr: address) {
+        Transaction::assert(Transaction::sender() == special_addr, 0);
+        move_to_sender<R>(R{x:1});
+    }
+    spec fun initialize {
+        requires all(addresses(), |a| !exists<R>(a)); // forall a: address :: !exists<R>(a)
+        ensures all(addresses(), |a| exists<R>(a) ==> a == special_addr);
+        ensures atMostOne();
+        ensures atLeastOne();
+    }
+
+    // This is tricky. If it doesn't abort on the borrow_global,
+    // or on overflow, it will successfully increment a.x
+    public fun f(addr: address) acquires R {
+        let x_ref = borrow_global_mut<R>(addr);
+        x_ref.x = x_ref.x + 1;
+    }
+    spec fun f {
+        ensures global<R>(addr).x == old(global<R>(addr).x) + 1;
+    }
+
+    // sender() might be different from special_addr,
+    // so this should violate the invariant.
+    public fun multiple_copy_incorrect() {
+        move_to_sender<R>(R{x:1});
+    }
+
+    // This asserts that there is at must one address with an R.
+    // Literally, if addresses a and b have an R, then a and b are the same.
+    spec schema ExactlyOne{
+         invariant atMostOne();
+         invariant atLeastOne();
+    }
+
+    spec module {
+        apply ExactlyOne to * except initialize;
+    }
+
+}


### PR DESCRIPTION
Prior to this extension, we had quantification over finite ranges and vectors.
So, you could say all(1..10, |i| i < 20) (universal quantification) or
any(1..10, |i| < 3) (existential quantification).

This extension allows formulas to be quantified over all addresses. For
example, the property:
    all(addresses(), |a| exists<R1>(a) ==> !exists<R2>(a))
says that no address with an R1 resource may have an R2 resource,
and
    any(addresses(),  exists<R1>(a))
says that there is some address with an R1 resource.

Such properties are often useful in module invariants to assert that a
top-level resource exists at at most one address, that top-level
resources are mutually exclusive, that if there is resource R1, there
is always a resource R2 at the same address, etc.

IMPLEMENTATION:
I added a new type "addresses" representing the set of all addresses, and
a new native function addresses().  When the translator encounter an "any"
or "all" where the first argument is the "addresses" type, e.g.
    all(addresses(), |a| P(a)), it generates Boogie code:
    forall a : Value :: is#address(a) ==> <boogie for P(a)>
For any(addresses(), |a| P(a)), it generates Boogie code:
    exists a : Value :: is#address(a) && <boogie for P(a)>

There is a new test file
tests/sources/functional/address_quant.move

<!--
Thank you for sending a PR. We appreciate you spending time to help improve the Libra project.

The project is undergoing daily changes. Pull Requests will be reviewed and responded to as time permits.
-->

## Motivation

I often want to include properties like this as global specifications.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

New test file address_quant.move

## Related PRs
