### PR TITLE
[network] improve error reporting during connect

### DIFF
--- a/secure/net/src/lib.rs
+++ b/secure/net/src/lib.rs
@@ -86,7 +86,8 @@ impl NetworkClient {
             let mut stream = TcpStream::connect(self.server);
 
             let sleeptime = time::Duration::from_millis(100);
-            while stream.is_err() {
+            while let Err(e) = stream {
+                debug!("Failed to connect to upstream {} {:?}", self.server, e);
                 thread::sleep(sleeptime);
                 stream = TcpStream::connect(self.server);
             }


### PR DESCRIPTION
## Motivation

Currently, there isn't error reporting during repeated failures to
connect to a server in the network lib, which makes debugging failures
difficult.  The debug level message should prevent too much logging,
while allowing us to debug issues. resolves #3884

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

As requested in #3884, there should be logging in the event of connection failures on a client-server connection.  There should be something to test with directly from the errors that caused this issue.

## Related PRs

None