### PR TITLE
[move-prover][BUG?]

### DIFF
--- a/language/move-prover/tests/sources/functional/generic_bug.move
+++ b/language/move-prover/tests/sources/functional/generic_bug.move
@@ -1,0 +1,70 @@
+address 0x0 {
+
+module GenericBug {
+    use 0x0::Transaction;
+
+    resource struct PrivilegedCapability<Privilege> { }
+
+    struct T { }
+
+    public fun initialize() {
+        let sender = Transaction::sender();
+        Transaction::assert(sender == root_address(), 1000);
+        move_to_sender(PrivilegedCapability<T>{ });
+    }
+
+    // Publish a specific privilege under the sending account.
+    public fun apply_for_privilege<Privilege>() {
+        if (::exists<PrivilegedCapability<Privilege>>(Transaction::sender())) return;
+        move_to_sender(PrivilegedCapability<Privilege>{ });
+    }
+
+    // Remove the `Privilege` from the address at `addr`. The sender must
+    // be the root association account.
+    public fun remove_privilege<Privilege>(addr: address)
+    acquires PrivilegedCapability {
+        Transaction::assert(Transaction::sender() == root_address(), 1001);
+        Transaction::assert(exists<PrivilegedCapability<Privilege>>(addr), 1004);
+        PrivilegedCapability<Privilege>{ } = move_from<PrivilegedCapability<Privilege>>(addr);
+    }
+
+    // BUG: Without this, the prover is happy.
+    // With this function, it reports an invariant violation.
+    // However, the invariant violation is there in any case, because
+    // remove_privilege<T>(addr) is defined.
+    // public  fun stupid_root() acquires PrivilegedCapability {
+    //     remove_privilege<T>(root_address());
+    // }
+
+    // The address at which the root account will be published.
+    public fun root_address(): address { 0xA550C18 }
+
+// **************** SPECIFICATIONS ****************
+    spec module {
+        pragma verify = true;
+
+        // This mirrors the Move function root_address()
+        define spec_root_address(): address { 0xA550C18 }
+
+        // mirrors Move addr_is_association
+        define spec_addr_is_association(addr: address): bool {
+            exists<PrivilegedCapability<T>>(addr)
+        }
+     }
+
+    // Invariant: Root address is always an association address.
+    // SOUNDNESS BUG: Root can remove its own association privilege, by calling
+    // remove_privilege<T>(root_address()).  The prover overlooks a violation of the
+    // invariant when it verifies public fun remove_privilege<Privilege>(addr: address),
+    // possibly because it doesn't realize Privilege can be T?
+    // To demo, I added "stupid_root" above, which actually removes the privilege, and that
+    // causes a violation if commented in.
+    spec schema RootAddressIsAssociationAddress {
+        invariant spec_addr_is_association(sender());
+    }
+    spec module {
+        apply RootAddressIsAssociationAddress to *<Privilege>, *
+            except addr_is_association, assert_addr_is_association;
+    }
+}
+}


### PR DESCRIPTION
The file tests/sources/functional/generic_bug has a reduced version of a
problem I ran into in association.move.  It is probably the case that
spec schema and apply do exactly what we said we wanted them to do, but
maybe that's not what we want.

This file has generic functions to add and remove "Privileges" (which
are just resources). "apply_for_privilege<Privilege>" creates the
resource PrivilegedCapability<Privilege> and stores it at the sender's
address, and "remove_privilege<Privilege>" removes that if the sender
== root_address().

"initialize" stores a PrivilegedCapability<T> at the root_address().

I tried to specify and prove an invariant that "the root address
always has a PrivilegedCapability<T>", which the Prover happily proved.
I don't think it understands that someone could call
remove_privilege<GenericBug::T> to remove the privilege.

There is a commented-out function stupid_root that does
remove_privilege<T>(root_address()).  If this function is commented in,
the prover reports a violation of the invariant.

I don't fully understand this behavior. I think it has something to do
with universal quantification over generic parameters, but haven't
thought through the details.  The key is that remove_privilege can be
used to remove any PrivilegedCapability if the sender is root,
including the PrivilegedCapability<T> that appears in the specified
property, but I'm not sure how to tell Boogie about that.

<!--
Thank you for sending a PR. We appreciate you spending time to help improve the Libra project.

The project is undergoing daily changes. Pull Requests will be reviewed and responded to as time permits.
-->

## Motivation

(Write your motivation for proposed changes here.)

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?

(Write your answer here.)

## Test Plan

(Share your test plan here. If you changed code, please provide us with clear instructions for verifying that your changes work.)

## Related PRs

(If this PR adds or changes functionality, please take some time to update the docs at https://github.com/libra/website, and link to your PR here.)
