### PR TITLE
[move-prover] Removing AbstractType because it is not sound.

### DIFF
--- a/language/move-prover/src/prelude.bpl
+++ b/language/move-prover/src/prelude.bpl
@@ -82,7 +82,6 @@ function {:constructor} AddressType() : TypeValue;
 function {:constructor} StrType() : TypeValue;
 function {:constructor} VectorType(t: TypeValue) : TypeValue;
 function {:constructor} StructType(name: TypeName, ps: TypeValueArray, ts: TypeValueArray) : TypeValue;
-function {:constructor} AbstractType(num: int): TypeValue;
 function {:constructor} ErrorType() : TypeValue;
 const DefaultTypeValue: TypeValue;
 axiom DefaultTypeValue == ErrorType();

--- a/language/move-prover/src/spec_translator.rs
+++ b/language/move-prover/src/spec_translator.rs
@@ -382,10 +382,6 @@ impl<'env> SpecTranslator<'env> {
     pub fn assume_preconditions(&self) {
         emitln!(self.writer, "assume $ExistsTxnSenderAccount($m, $txn);");
         let func_target = self.function_target();
-        // Assume abstract types for type parameters.
-        for (i, _) in func_target.get_type_parameters().iter().enumerate() {
-            emitln!(self.writer, "assume is#AbstractType($tv{});", i);
-        }
         // Assume requires.
         let requires = func_target
             .get_spec()

--- a/language/move-prover/tests/sources/regression/generic_invariant200518.exp
+++ b/language/move-prover/tests/sources/regression/generic_invariant200518.exp
@@ -1,0 +1,16 @@
+Move prover returns: exiting with boogie verification errors
+error:  A postcondition might not hold on this return path.
+
+    ┌── tests/sources/regression/generic_invariant200518.move:63:9 ───
+    │
+ 63 │         invariant spec_addr_is_association(sender());
+    │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    │
+    =     at tests/sources/regression/generic_invariant200518.move:24:5: remove_privilege (entry)
+    =     at tests/sources/regression/generic_invariant200518.move:40:5: root_address (entry)
+    =     at tests/sources/regression/generic_invariant200518.move:40:5: root_address (exit)
+    =         result = <redacted>
+    =     at tests/sources/regression/generic_invariant200518.move:26:9: remove_privilege
+    =         $t1 = <redacted>
+    =     at tests/sources/regression/generic_invariant200518.move:28:46: remove_privilege
+    =     at tests/sources/regression/generic_invariant200518.move:24:5: remove_privilege (exit)

--- a/language/move-prover/tests/sources/regression/generic_invariant200518.move
+++ b/language/move-prover/tests/sources/regression/generic_invariant200518.move
@@ -1,0 +1,70 @@
+address 0x0 {
+
+module GenericBug {
+    use 0x0::Transaction;
+
+    resource struct PrivilegedCapability<Privilege> { }
+
+    struct T { }
+
+    public fun initialize() {
+        let sender = Transaction::sender();
+        Transaction::assert(sender == root_address(), 1000);
+        move_to_sender(PrivilegedCapability<T>{ });
+    }
+
+    // Publish a specific privilege under the sending account.
+    public fun apply_for_privilege<Privilege>() {
+        if (::exists<PrivilegedCapability<Privilege>>(Transaction::sender())) return;
+        move_to_sender(PrivilegedCapability<Privilege>{ });
+    }
+
+    // Remove the `Privilege` from the address at `addr`. The sender must
+    // be the root association account.
+    public fun remove_privilege<Privilege>(addr: address)
+    acquires PrivilegedCapability {
+        Transaction::assert(Transaction::sender() == root_address(), 1001);
+        //Transaction::assert(exists<PrivilegedCapability<Privilege>>(addr), 1004);
+        PrivilegedCapability<Privilege>{ } = move_from<PrivilegedCapability<Privilege>>(addr);
+    }
+
+    // **FIXED** BUG: Without this, the prover is [was] happy.
+    // With this function, it reports an invariant violation.
+    // However, the invariant violation is there in any case, because
+    // remove_privilege<T>(addr) is defined.
+    //public  fun stupid_root() acquires PrivilegedCapability {
+    //     remove_privilege<T>(root_address());
+    //}
+
+    // The address at which the root account will be published.
+    public fun root_address(): address { 0xA550C18 }
+
+    // **************** SPECIFICATIONS ****************
+    spec module {
+        pragma verify = true;
+
+        // This mirrors the Move function root_address()
+        define spec_root_address(): address { 0xA550C18 }
+
+        // mirrors Move addr_is_association
+        define spec_addr_is_association(addr: address): bool {
+            exists<PrivilegedCapability<T>>(addr)
+        }
+     }
+
+    // Invariant: Root address is always an association address.
+    // SOUNDNESS BUG: Root can remove its own association privilege, by calling
+    // remove_privilege<T>(root_address()).  The prover overlooks a violation of the
+    // invariant when it verifies public fun remove_privilege<Privilege>(addr: address),
+    // possibly because it doesn't realize Privilege can be T?
+    // To demo, I added "stupid_root" above, which actually removes the privilege, and that
+    // causes a violation if commented in.
+    spec schema RootAddressIsAssociationAddress {
+        invariant spec_addr_is_association(sender());
+    }
+    spec module {
+        apply RootAddressIsAssociationAddress to *<Privilege>, *
+            except addr_is_association, assert_addr_is_association;
+    }
+}
+}


### PR DESCRIPTION
A while ago we introduced a special type constructor `AbstractType` which we assigned to type parameters for top-level entry points. This was meant to make extensional equality of types working, and also was a candidate for the performance problem with Z3 we observed. However, this is unsound because then Z3 can prove that `R<u64> != R<T>` for any type parameter T. This PR removes AbstractType and adds a regression test to ensure this continues to work.

However, with this PR it's again unclear whether we can assume equality to work for type values, which we need because we index global memory with them. For this, we may need to come up with a different solution.

## Motivation

Bug fix. Closes #3941

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

Added regression test.

## Related PRs

NA
