### PR TITLE
[crypto] Use Serde name for seeding

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2376,6 +2376,7 @@ dependencies = [
  "rand_core 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "ripemd160 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.110 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde-name 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_bytes 0.11.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.53 (registry+https://github.com/rust-lang/crates.io-index)",
  "sha2 0.8.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -4871,6 +4872,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde-name"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "serde 1.0.110 (registry+https://github.com/rust-lang/crates.io-index)",
+ "thiserror 1.0.19 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "serde-reflection"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6878,6 +6888,7 @@ dependencies = [
 "checksum semver 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)" = "1d7eb9ef2c18661902cc47e535f9bc51b78acd254da71d375c2f6720d9a40403"
 "checksum semver-parser 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "388a1df253eca08550bef6c72392cfe7c30914bf41df5269b68cbd6ff8f570a3"
 "checksum serde 1.0.110 (registry+https://github.com/rust-lang/crates.io-index)" = "99e7b308464d16b56eba9964e4972a3eee817760ab60d88c3f86e1fecb08204c"
+"checksum serde-name 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "92bb32dbe1df50291d7d00b5e573acb2c70b783baf3d1bce2d19c86be11c709e"
 "checksum serde-reflection 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "5820d2a74b1f0694d959f48660bc52fa922239d5c2f6dcc17261c5307967b9e5"
 "checksum serde-value 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)" = "5a65a7291a8a568adcae4c10a677ebcedbc6c9cec91c054dee2ce40b0e3290eb"
 "checksum serde_bytes 0.11.4 (registry+https://github.com/rust-lang/crates.io-index)" = "3bf487fbf5c6239d7ea2ff8b10cb6b811cd4b5080d1c2aeed1dec18753c06e10"

--- a/consensus/consensus-types/src/block_data.rs
+++ b/consensus/consensus-types/src/block_data.rs
@@ -6,8 +6,8 @@ use crate::{
     quorum_cert::QuorumCert,
     vote_data::VoteData,
 };
-use libra_crypto::hash::{CryptoHash, CryptoHasher, HashValue};
-use libra_crypto_derive::CryptoHasher;
+use libra_crypto::hash::HashValue;
+use libra_crypto_derive::{CryptoHasher, LCSCryptoHash};
 use libra_types::{
     block_info::BlockInfo,
     ledger_info::{LedgerInfo, LedgerInfoWithSignatures},
@@ -34,7 +34,7 @@ pub enum BlockType<T> {
     Genesis,
 }
 
-#[derive(Deserialize, Serialize, Clone, Debug, PartialEq, Eq, CryptoHasher)]
+#[derive(Deserialize, Serialize, Clone, Debug, PartialEq, Eq, CryptoHasher, LCSCryptoHash)]
 /// Block has the core data of a consensus block that should be persistent when necessary.
 /// Each block must know the id of its parent and keep the QuorurmCertificate to that parent.
 pub struct BlockData<T> {
@@ -194,18 +194,5 @@ where
             quorum_cert,
             block_type: BlockType::Proposal { payload, author },
         }
-    }
-}
-
-impl<T> CryptoHash for BlockData<T>
-where
-    T: Serialize,
-{
-    type Hasher = BlockDataHasher;
-
-    fn hash(&self) -> HashValue {
-        let mut state = Self::Hasher::default();
-        lcs::serialize_into(&mut state, self).expect("BlockData serialization failed");
-        state.finish()
     }
 }

--- a/crypto/crypto/Cargo.toml
+++ b/crypto/crypto/Cargo.toml
@@ -25,6 +25,7 @@ rand = "0.7.3"
 rand_core = { version = "0.5.1", default-features = false }
 serde = { version = "1.0.110", features = ["derive"] }
 serde_bytes = "0.11"
+serde-name = "0.1"
 sha2 = "0.8.2"
 static_assertions = { version = "1.0.0", optional = true }
 thiserror = "1.0"

--- a/crypto/crypto/src/hash.rs
+++ b/crypto/crypto/src/hash.rs
@@ -41,7 +41,7 @@
 //! ```
 //! use libra_crypto::hash::CryptoHash;
 //! use libra_crypto_derive::{CryptoHasher, LCSCryptoHash};
-//! use serde::{Serialize, Deserialize};
+//! use serde::{Deserialize, Serialize};
 //! #[derive(Serialize, Deserialize, CryptoHasher, LCSCryptoHash)]
 //! struct MyNewStruct { /*...*/ }
 //!
@@ -63,14 +63,14 @@
 //! use the derive macro [`CryptoHasher`](https://doc.rust-lang.org/reference/procedural-macros.html).
 //!
 //! ```
-//! # use libra_crypto_derive::CryptoHasher;
-//! # use serde::Deserialize;
+//! use libra_crypto_derive::CryptoHasher;
+//! use serde::Deserialize;
 //! #[derive(Deserialize, CryptoHasher)]
 //! #[serde(rename = "OptionalCustomSerdeName")]
 //! struct MyNewStruct { /*...*/ }
 //! ```
 //!
-//! The macro will define a hasher automatically called `MyNewStructHasher`, and derive a salt
+//! The macro `CryptoHasher` will define a hasher automatically called `MyNewStructHasher`, and derive a salt
 //! using the name of the type as seen by the Serde library. In the example above, this name
 //! was changed using the Serde parameter `rename`: the salt will be based on the value `OptionalCustomSerdeName`
 //! instead of the default name `MyNewStruct`.

--- a/crypto/crypto/src/lib.rs
+++ b/crypto/crypto/src/lib.rs
@@ -22,6 +22,8 @@ mod unit_tests;
 pub use self::traits::*;
 pub use hash::HashValue;
 
-// Reexport once_cell for use in CryptoHasher Derive implementation
+// Reexport once_cell and serde_name for use in CryptoHasher Derive implementation.
 #[doc(hidden)]
 pub use once_cell as _once_cell;
+#[doc(hidden)]
+pub use serde_name as _serde_name;

--- a/crypto/crypto/src/unit_tests/cryptohasher.rs
+++ b/crypto/crypto/src/unit_tests/cryptohasher.rs
@@ -22,6 +22,14 @@ pub struct Foo {
 // Used for testing the seed in FooHasher.
 pub struct Bar {}
 
+// Complex example with generics and serde-rename.
+#[derive(Serialize, Deserialize, CryptoHasher, LCSCryptoHash)]
+#[serde(rename = "Foo")]
+pub struct Baz<T> {
+    a: T,
+    b: u32,
+}
+
 impl CryptoHash for Bar {
     type Hasher = FooHasher;
 
@@ -45,7 +53,7 @@ fn test_cryptohasher_name() {
         hasher_bytes
     };
     let actual = CryptoHash::hash(&value);
-    assert_eq!(&expected, actual.as_ref(),);
+    assert_eq!(&expected, actual.as_ref());
 }
 
 #[test]
@@ -63,5 +71,13 @@ fn test_lcs_cryptohash() {
         hasher_bytes
     };
     let actual = CryptoHash::hash(&value);
-    assert_eq!(&expected, actual.as_ref(),);
+    assert_eq!(&expected, actual.as_ref());
+}
+
+#[test]
+fn test_lcs_cryptohash_with_generics() {
+    let value = Baz { a: 5u64, b: 1025 };
+    let expected = CryptoHash::hash(&Foo { a: 5, b: 1025 });
+    let actual = CryptoHash::hash(&value);
+    assert_eq!(expected, actual);
 }

--- a/crypto/crypto/src/unit_tests/cryptohasher.rs
+++ b/crypto/crypto/src/unit_tests/cryptohasher.rs
@@ -5,7 +5,7 @@
 
 use crate as libra_crypto;
 use crate::{
-    hash::{CryptoHash, CryptoHasher, LIBRA_HASH_SUFFIX},
+    hash::{CryptoHash, CryptoHasher, LIBRA_HASH_PREFIX},
     HashValue,
 };
 use libra_crypto_derive::{CryptoHasher, LCSCryptoHash};
@@ -33,51 +33,35 @@ impl CryptoHash for Bar {
 
 #[test]
 fn test_cryptohasher_name() {
-    let mut name = "libra_crypto::unit_tests::cryptohasher::Foo"
-        .as_bytes()
-        .to_vec();
-    name.extend_from_slice(LIBRA_HASH_SUFFIX);
+    let mut salt = LIBRA_HASH_PREFIX.to_vec();
+    salt.extend_from_slice(b"Foo");
 
     let value = Bar {};
     let expected = {
         let mut digest = Sha3::v256();
-        digest.update(HashValue::from_sha3_256(&name[..]).as_ref());
+        digest.update(HashValue::from_sha3_256(&salt[..]).as_ref());
         let mut hasher_bytes = [0u8; 32];
         digest.finalize(&mut hasher_bytes);
         hasher_bytes
     };
     let actual = CryptoHash::hash(&value);
-    assert_eq!(
-        &expected,
-        actual.as_ref(),
-        "\nexpected: {} actual: {}",
-        String::from_utf8_lossy(&expected),
-        String::from_utf8_lossy(actual.as_ref())
-    );
+    assert_eq!(&expected, actual.as_ref(),);
 }
 
 #[test]
 fn test_lcs_cryptohash() {
-    let mut name = "libra_crypto::unit_tests::cryptohasher::Foo"
-        .as_bytes()
-        .to_vec();
-    name.extend_from_slice(LIBRA_HASH_SUFFIX);
+    let mut salt = LIBRA_HASH_PREFIX.to_vec();
+    salt.extend_from_slice(b"Foo");
 
     let value = Foo { a: 5, b: 1025 };
     let expected = {
         let mut digest = Sha3::v256();
-        digest.update(HashValue::from_sha3_256(&name[..]).as_ref());
+        digest.update(HashValue::from_sha3_256(&salt[..]).as_ref());
         digest.update(&lcs::to_bytes(&value).unwrap());
         let mut hasher_bytes = [0u8; 32];
         digest.finalize(&mut hasher_bytes);
         hasher_bytes
     };
     let actual = CryptoHash::hash(&value);
-    assert_eq!(
-        &expected,
-        actual.as_ref(),
-        "\nexpected: {} actual: {}",
-        String::from_utf8_lossy(&expected),
-        String::from_utf8_lossy(actual.as_ref())
-    );
+    assert_eq!(&expected, actual.as_ref(),);
 }

--- a/language/move-core/types/src/unit_tests/address_test.rs
+++ b/language/move-core/types/src/unit_tests/address_test.rs
@@ -52,7 +52,7 @@ fn test_address() {
     });
 
     let hash_vec =
-        &Vec::from_hex("c965dfb50b4ebcf000d256a4b23d36ca49f0b05a905e8124ba2f8ff3112bf662")
+        &Vec::from_hex("c44c0a209ec51c8077b0007334988e11867842e152e05316f062a589ed6b606d")
             .expect("You must provide a valid Hex format");
 
     let mut hash = [0u8; 32];


### PR DESCRIPTION
## Motivation

* (breaking) Make hash seeds more specification-friendly and tooling-friendly by using the Serde name instead of Rust qualified name. Typically, a struct `Foo` has seed: `sha3_256("LIBRA::Foo")` instead of `sha3_256("some::rust::namespace::Foo@@$$LIBRA$$@@")`

* Add support for generics in derive macros CryptoHasher and LCSCryptoHash.
* Add a unit test to verify that Serde names don't clash between corpuses (or rather when they do, the Serde format must be identical).

## Test Plan

```
cargo x test -p libra-crypto -p generate-format
```

## Related PRs

https://github.com/libra/libra/pull/3845
https://github.com/libra/libra/pull/3895