### PR TITLE
[move-prover] Revised serialization axioms

### DIFF
--- a/language/move-prover/src/prelude.bpl
+++ b/language/move-prover/src/prelude.bpl
@@ -1134,16 +1134,11 @@ function {:inline} $LCS_serialize($m: Memory, $txn: Transaction, ta: TypeValue, 
 }
 
 function $LCS_serialize_core(v: Value): Value;
-
-// This says that $serialize respects isEquals (substitution property)
-// Without this, Boogie will get false positives where v1, v2 differ at invalid
-// indices.
-axiom (forall v1,v2: Value :: IsEqual(v1, v2) ==> IsEqual($LCS_serialize_core(v1), $LCS_serialize_core(v2)));
-
-
-// This says that serialize is an injection
-axiom (forall v1, v2: Value ::  IsEqual($LCS_serialize_core(v1), $LCS_serialize_core(v2))
-           ==> IsEqual(v1, v2));
+function $LCS_serialize_core_inv(v: Value): Value;
+// Needed only because IsEqual(v1, v2) is weaker than v1 == v2 in case there is a vector nested inside v1 or v2.
+axiom (forall v1, v2: Value :: IsEqual(v1, v2) ==> $LCS_serialize_core(v1) == $LCS_serialize_core(v2));
+// Injectivity
+axiom (forall v: Value :: $LCS_serialize_core_inv($LCS_serialize_core(v)) == v);
 
 // This says that serialize returns a non-empty vec<u8>
 {{#if (eq serialize_bound 0)}}


### PR DESCRIPTION
## Motivation

The current axioms for $LCS_serialize_core seem complicated and expensive.  This PR attempts to simplify them.

Specifically:
- The congruence axiom can soundly assume == on the right side of the implication provided we ensure that the Boogie runtime of the Move Prover satisfies (forall v1, v2 :: IsEqual(v1, v2) ==> v1 == v2). 
- The injectivity axiom can be more efficiently encoded using a quantifier with a single bound variable vs two variables (linear vs potentially quadratic instantiations).

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

Existing tests

## Related PRs

