### PR TITLE
[fuzzing] removing google oss-fuzz hacks

### DIFF
--- a/testsuite/libra-fuzzer/fuzz/google-oss-fuzz/build.sh
+++ b/testsuite/libra-fuzzer/fuzz/google-oss-fuzz/build.sh
@@ -27,11 +27,6 @@ do
     rm -r fuzz/corpus/$line
 done
 
-# rust libfuzzer flags (https://github.com/rust-fuzz/libfuzzer/blob/master/build.rs#L12)
-export CUSTOM_LIBFUZZER_PATH="$LIB_FUZZING_ENGINE_DEPRECATED"
-export CUSTOM_LIBFUZZER_STD_CXX=c++
-# export CUSTOM_LIBFUZZER_STD_CXX=none
-
 # RUSTC_BOOTSTRAP: to get some nightly features like ASAN
 export RUSTC_BOOTSTRAP=1
 
@@ -39,9 +34,6 @@ export RUSTC_BOOTSTRAP=1
 RUSTFLAGS="$RUSTFLAGS --cfg fuzzing"          # used to change code logic
 RUSTFLAGS="$RUSTFLAGS -Cdebug-assertions"     # to get debug_assert in rust
 RUSTFLAGS="$RUSTFLAGS -Zsanitizer=address"    # address sanitizer (ASAN)
-
-RUSTFLAGS="$RUSTFLAGS -Cdebuginfo=1"
-RUSTFLAGS="$RUSTFLAGS -Cforce-frame-pointers"
 
 RUSTFLAGS="$RUSTFLAGS -Cpasses=sancov"
 RUSTFLAGS="$RUSTFLAGS -Cllvm-args=-sanitizer-coverage-level=4"


### PR DESCRIPTION
According to this PR we can now remove these flags: https://github.com/google/oss-fuzz/pull/3840/files

There were present presumably to work with a rust codebase and Google's environment.
