### PR TITLE
[language] Align move-lang compiler and move-prover command line syntax

### DIFF
--- a/language/move-lang/Cargo.toml
+++ b/language/move-lang/Cargo.toml
@@ -7,6 +7,7 @@ edition = "2018"
 license = "Apache-2.0"
 
 [dependencies]
+anyhow = "1.0"
 codespan = "0.8.0"
 codespan-reporting = "0.8.0"
 hex = "0.4.2"
@@ -29,7 +30,6 @@ lcs = { path = "../../common/lcs", version = "0.1.0", package = "libra-canonical
 
 
 [dev-dependencies]
-anyhow = "1.0"
 functional-tests = { path = "../functional-tests", version = "0.1.0" }
 tempfile = "3.1.0"
 

--- a/language/move-lang/README.md
+++ b/language/move-lang/README.md
@@ -68,16 +68,18 @@ move-check 0.0.1
 Check Move source code, without compiling to bytecode.
 
 USAGE:
-    move-check [OPTIONS]
+    move-check [OPTIONS] [--] [PATH_TO_SOURCE_FILE]...
 
 FLAGS:
     -h, --help       Prints help information
     -V, --version    Prints version information
 
 OPTIONS:
-    -s, --sender <address>                             The sender address for modules and scripts
-    -d, --dependencies <path-to-dependency-file>...    The library files needed as dependencies
-    -f, --source-files <path-to-source-file>...        The source files to check/build
+    -s, --sender <ADDRESS>                           The sender address for modules and scripts
+    -d, --dependency <PATH_TO_DEPENDENCY_FILE>...    The library files needed as dependencies
+
+ARGS:
+    <PATH_TO_SOURCE_FILE>...    The source files to check
 ```
 
 Move build is a command line tool for checking Move programs and producing serialized bytecode.
@@ -88,17 +90,20 @@ move-build 0.0.1
 Compile Move source to Move bytecode.
 
 USAGE:
-    move-build [OPTIONS]
+    move-build [FLAGS] [OPTIONS] [--] [PATH_TO_SOURCE_FILE]...
 
 FLAGS:
-    -h, --help       Prints help information
-    -V, --version    Prints version information
+    -m, --source-map    Save bytecode source map to disk
+    -h, --help          Prints help information
+    -V, --version       Prints version information
 
 OPTIONS:
-    -s, --sender <address>                             The sender address for modules and scripts
-    -d, --dependencies <path-to-dependency-file>...    The library files needed as dependencies
-    -o, --out-dir <path-to-output-directory>           The Move bytecode output directory [default: move_build_output]
-    -f, --source-files <path-to-source-file>...        The source files to check and compile
+    -s, --sender <ADDRESS>                           The sender address for modules and scripts
+    -d, --dependency <PATH_TO_DEPENDENCY_FILE>...    The library files needed as dependencies
+    -o, --out-dir <PATH_TO_OUTPUT_DIRECTORY>         The Move bytecode output directory [default: move_build_output]
+
+ARGS:
+    <PATH_TO_SOURCE_FILE>...    The source files to check and compile
 ```
 
 ## Folder Structure

--- a/language/move-lang/src/bin/move-build.rs
+++ b/language/move-lang/src/bin/move-build.rs
@@ -55,17 +55,7 @@ pub struct Options {
     pub emit_source_map: bool,
 }
 
-pub fn main() {
-    std::process::exit(match main_impl() {
-        Ok(_) => 0,
-        Err(e) => {
-            eprintln!("error: {}", e);
-            1
-        }
-    });
-}
-
-fn main_impl() -> std::io::Result<()> {
+pub fn main() -> anyhow::Result<()> {
     let Options {
         source_files,
         dependencies,

--- a/language/move-lang/src/bin/move-build.rs
+++ b/language/move-lang/src/bin/move-build.rs
@@ -13,18 +13,14 @@ use structopt::*;
 #[structopt(name = "Move Build", about = "Compile Move source to Move bytecode.")]
 pub struct Options {
     /// The source files to check and compile
-    #[structopt(
-        name = "PATH_TO_SOURCE_FILE",
-        short = cli::SOURCE_FILES_SHORT,
-        long = cli::SOURCE_FILES,
-    )]
+    #[structopt(name = "PATH_TO_SOURCE_FILE")]
     pub source_files: Vec<String>,
 
     /// The library files needed as dependencies
     #[structopt(
         name = "PATH_TO_DEPENDENCY_FILE",
-        short = cli::DEPENDENCIES_SHORT,
-        long = cli::DEPENDENCIES,
+        short = cli::DEPENDENCY_SHORT,
+        long = cli::DEPENDENCY,
     )]
     pub dependencies: Vec<String>,
 

--- a/language/move-lang/src/bin/move-check.rs
+++ b/language/move-lang/src/bin/move-check.rs
@@ -16,18 +16,14 @@ use structopt::*;
 )]
 pub struct Options {
     /// The source files to check
-    #[structopt(
-        name = "PATH_TO_SOURCE_FILE",
-        short = cli::SOURCE_FILES_SHORT,
-        long = cli::SOURCE_FILES,
-    )]
+    #[structopt(name = "PATH_TO_SOURCE_FILE")]
     pub source_files: Vec<String>,
 
     /// The library files needed as dependencies
     #[structopt(
         name = "PATH_TO_DEPENDENCY_FILE",
-        short = cli::DEPENDENCIES_SHORT,
-        long = cli::DEPENDENCIES,
+        short = cli::DEPENDENCY_SHORT,
+        long = cli::DEPENDENCY,
     )]
     pub dependencies: Vec<String>,
 

--- a/language/move-lang/src/bin/move-check.rs
+++ b/language/move-lang/src/bin/move-check.rs
@@ -41,17 +41,7 @@ pub struct Options {
     pub sender: Option<Address>,
 }
 
-pub fn main() {
-    std::process::exit(match main_impl() {
-        Ok(_) => 0,
-        Err(e) => {
-            eprintln!("error: {}", e);
-            1
-        }
-    });
-}
-
-pub fn main_impl() -> std::io::Result<()> {
+pub fn main() -> anyhow::Result<()> {
     let Options {
         source_files,
         dependencies,

--- a/language/move-lang/src/command_line/mod.rs
+++ b/language/move-lang/src/command_line/mod.rs
@@ -3,11 +3,8 @@
 
 use crate::shared::*;
 
-pub const SOURCE_FILES: &str = "source-files";
-pub const SOURCE_FILES_SHORT: &str = "f";
-
-pub const DEPENDENCIES: &str = "dependencies";
-pub const DEPENDENCIES_SHORT: &str = "d";
+pub const DEPENDENCY: &str = "dependency";
+pub const DEPENDENCY_SHORT: &str = "d";
 
 pub const SENDER: &str = "sender";
 pub const SENDER_SHORT: &str = "s";

--- a/language/move-prover/docgen/tests/testsuite.rs
+++ b/language/move-prover/docgen/tests/testsuite.rs
@@ -18,7 +18,7 @@ const FLAGS: &[&str] = &[
     "--verbose=warn",
     // This currently points to the legacy stdlib copy in prover tests. Replace this
     // by real stdlib once we have a good example based on it.
-    "--search-path=../tests/sources/stdlib/modules",
+    "--dependency=../tests/sources/stdlib/modules",
     "--docgen",
 ];
 

--- a/language/move-prover/src/cli.rs
+++ b/language/move-prover/src/cli.rs
@@ -3,7 +3,7 @@
 
 #![forbid(unsafe_code)]
 
-//! Functionality related to the command line interface of the move prover.
+//! Functionality related to the command line interface of the Move prover.
 
 use clap::{App, Arg};
 use docgen::docgen::DocgenOptions;
@@ -62,13 +62,11 @@ pub struct Options {
     pub account_address: String,
     /// Verbosity level for logging.
     pub verbosity_level: LevelFilter,
-    /// The paths to the move sources.
+    /// The paths to the Move sources.
     pub move_sources: Vec<String>,
-    /// The paths to any dependencies for the move sources. Those will not be verified but
+    /// The paths to any dependencies for the Move sources. Those will not be verified but
     /// can be used by `move_sources`.
     pub move_deps: Vec<String>,
-    /// Paths to directories where dependencies are looked up automatically.
-    pub search_path: Vec<String>,
     /// Path to the boogie executable.
     pub boogie_exe: String,
     /// Path to the z3 executable.
@@ -140,7 +138,6 @@ impl Default for Options {
             verbosity_level: LevelFilter::Info,
             move_sources: vec![],
             move_deps: vec![],
-            search_path: vec![],
             boogie_exe: "".to_string(),
             z3_exe: "".to_string(),
             use_cvc4: false,
@@ -416,31 +413,21 @@ impl Options {
                     ),
             )
             .arg(
-                Arg::with_name("search-path")
-                    .long("search-path")
-                    .short("s")
-                    .multiple(true)
-                    .number_of_values(1)
-                    .takes_value(true)
-                    .value_name("PATH")
-                    .help("path to a directory where dependencies are looked up automatically")
-            )
-            .arg(
                 Arg::with_name("dependencies")
-                    .long("dep")
+                    .long("dependency")
                     .short("d")
                     .multiple(true)
                     .number_of_values(1)
                     .takes_value(true)
-                    .value_name("MOVE_FILE")
-                    .help("path to a move file dependency, which will not be verified")
+                    .value_name("PATH_TO_DEPENDENCY_FILE")
+                    .help("the Move library files, which will not be verified")
             )
             .arg(
                 Arg::with_name("sources")
                     .multiple(true)
-                    .value_name("MOVE_FILE")
+                    .value_name("PATH_TO_SOURCE_FILE")
                     .min_values(1)
-                    .help("path to a move file (with embedded spec)"),
+                    .help("the source files to verify"),
             );
 
         // Parse the arguments. This will abort the program on parsing errors and print help.
@@ -476,7 +463,6 @@ impl Options {
         self.boogie_flags = get_vec("boogie-flags");
         self.move_sources = get_vec("sources");
         self.move_deps = get_vec("dependencies");
-        self.search_path = get_vec("search-path");
         self.stable_test_output = matches.is_present("stable-test-output");
         self.verify_scope = match get_with_default("verify").as_str() {
             "public" => VerificationScope::Public,

--- a/language/move-prover/tests/sources/functional/script.move
+++ b/language/move-prover/tests/sources/functional/script.move
@@ -1,4 +1,4 @@
-// flag: --dep=tests/sources/functional/script_provider.move
+// flag: --dependency=tests/sources/functional/script_provider.move
 script {
 use 0x0::ScriptProvider;
 

--- a/language/move-prover/tests/sources/functional/script_incorrect.move
+++ b/language/move-prover/tests/sources/functional/script_incorrect.move
@@ -1,4 +1,4 @@
-// flag: --dep=tests/sources/functional/script_provider.move
+// flag: --dependency=tests/sources/functional/script_provider.move
 script {
 use 0x0::ScriptProvider;
 

--- a/language/move-prover/tests/testsuite.rs
+++ b/language/move-prover/tests/testsuite.rs
@@ -14,9 +14,9 @@ use test_utils::{baseline_test::verify_or_update_baseline, extract_test_directiv
 #[allow(unused_imports)]
 use log::warn;
 
-const STDLIB_FLAGS: &[&str] = &["--search-path=../stdlib/modules"];
-const STDLIB_FLAGS_UNVERIFIED: &[&str] = &["--search-path=../stdlib/modules", "--verify=none"];
-const LEGACY_STDLIB_FLAGS: &[&str] = &["--search-path=tests/sources/stdlib/modules"];
+const STDLIB_FLAGS: &[&str] = &["--dependency=../stdlib/modules"];
+const STDLIB_FLAGS_UNVERIFIED: &[&str] = &["--dependency=../stdlib/modules", "--verify=none"];
+const LEGACY_STDLIB_FLAGS: &[&str] = &["--dependency=tests/sources/stdlib/modules"];
 
 fn test_runner(path: &Path) -> datatest_stable::Result<()> {
     let no_boogie = read_env_var("BOOGIE_EXE").is_empty() || read_env_var("Z3_EXE").is_empty();

--- a/language/tools/move-coverage/check_coverage.bash
+++ b/language/tools/move-coverage/check_coverage.bash
@@ -24,7 +24,7 @@ popd || exit 1
 echo "Running Move testsuite..."
 pushd ../../move-lang || exit 1
 cargo test
-cargo run --bin move-build -- -f ../stdlib/modules/* -m
+cargo run --bin move-build -- ../stdlib/modules -m
 popd || exit 1
 
 echo "Converting trace file..."

--- a/language/tools/move-coverage/gather_stats.bash
+++ b/language/tools/move-coverage/gather_stats.bash
@@ -24,7 +24,7 @@ popd || exit 1
 echo "Running Move testsuite..."
 pushd ../../move-lang || exit 1
 cargo test
-cargo run --bin move-build -- -f ../stdlib/modules/* -m
+cargo run --bin move-build -- ../stdlib/modules -m
 popd || exit 1
 
 echo "Converting trace file..."

--- a/testsuite/cli/src/client_proxy.rs
+++ b/testsuite/cli/src/client_proxy.rs
@@ -821,7 +821,7 @@ impl ClientProxy {
         self.temp_files.push(tmp_output_path.to_path_buf());
 
         let mut args = format!(
-            "run -p move-lang --bin move-build -- -f {} -s {} -o {}",
+            "run -p move-lang --bin move-build -- {} -s {} -o {}",
             file_path,
             address,
             tmp_output_path.display(),


### PR DESCRIPTION
This changes the command line syntax for both the compiler and prover, so that they are more consistent.

For the move-lang compiler:
- Replace the "--source-files" option with (non-optional) file name arguments
- Rename the "--dependencies" option to "--dependency"

For the move-prover:
- Remove the "--search-path" option
- Rename the "--dep" option to "--dependency"
- Allow both the source file and dependency paths to specify entire directories, which are then recursively searched for ".move" files in the same way as the compiler (but unlike the compiler, the prover will then prune out unused dependencies so that this won't cause the verification to blow up)

## Motivation

https://github.com/libra/libra/issues/3706

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

Updated the tests to use the new syntax