### PR TITLE
[cluster-test] Use .await when waiting for tx emitter jobs to complete

### DIFF
--- a/testsuite/cluster-test/src/main.rs
+++ b/testsuite/cluster-test/src/main.rs
@@ -375,7 +375,7 @@ impl BasicSwarmUtil {
             prev_stats = Some(stats);
             println!("{}", delta.rate(window));
         }
-        let stats = emitter.stop_job(job);
+        let stats = emitter.stop_job(job).await;
         println!("Total stats: {}", stats);
         println!("Average rate: {}", stats.rate(duration));
     }

--- a/testsuite/cluster-test/src/tx_emitter.rs
+++ b/testsuite/cluster-test/src/tx_emitter.rs
@@ -34,7 +34,7 @@ use rand::{
 };
 use tokio::runtime::{Handle, Runtime};
 
-use futures::{executor::block_on, future::FutureExt};
+use futures::future::FutureExt;
 use libra_json_rpc_client::JsonRpcAsyncClient;
 use libra_types::transaction::SignedTransaction;
 use reqwest::{Client, Url};
@@ -216,6 +216,7 @@ impl TxEmitter {
                 workers.push(Worker { join_handle });
             }
         }
+        info!("Tx emitter workers started");
         Ok(EmitJob {
             workers,
             stop,
@@ -313,11 +314,13 @@ impl TxEmitter {
         job.stats.accumulate()
     }
 
-    pub fn stop_job(&mut self, job: EmitJob) -> TxStats {
+    pub async fn stop_job(&mut self, job: EmitJob) -> TxStats {
         job.stop.store(true, Ordering::Relaxed);
         for worker in job.workers {
-            let mut accounts =
-                block_on(worker.join_handle).expect("TxEmitter worker thread failed");
+            let mut accounts = worker
+                .join_handle
+                .await
+                .expect("TxEmitter worker thread failed");
             self.accounts.append(&mut accounts);
         }
         job.stats.accumulate()
@@ -338,7 +341,7 @@ impl TxEmitter {
     ) -> Result<TxStats> {
         let job = self.start_job(emit_job_request).await?;
         tokio::time::delay_for(duration).await;
-        let stats = self.stop_job(job);
+        let stats = self.stop_job(job).await;
         Ok(stats)
     }
 


### PR DESCRIPTION
Previously we were calling block_on, which is not suppose to be used inside tokio runtime
