### PR TITLE
[move-prover] Generalized quantifiers and types-as-values

### DIFF
--- a/language/move-prover/spec-lang/src/ast.rs
+++ b/language/move-prover/spec-lang/src/ast.rs
@@ -281,7 +281,6 @@ pub enum Operation {
     Result(usize),
     Index,
     Slice,
-    Addresses,
 
     // Binary operators
     Range,
@@ -312,6 +311,8 @@ pub enum Operation {
     Len,
     All,
     Any,
+    TypeValue,
+    TypeDomain,
     Global,
     Exists,
     Old,

--- a/language/move-prover/src/prelude.bpl
+++ b/language/move-prover/src/prelude.bpl
@@ -82,6 +82,7 @@ function {:constructor} AddressType() : TypeValue;
 function {:constructor} StrType() : TypeValue;
 function {:constructor} VectorType(t: TypeValue) : TypeValue;
 function {:constructor} StructType(name: TypeName, ps: TypeValueArray, ts: TypeValueArray) : TypeValue;
+function {:constructor} $TypeType(): TypeValue;
 function {:constructor} ErrorType() : TypeValue;
 const DefaultTypeValue: TypeValue;
 axiom DefaultTypeValue == ErrorType();
@@ -111,6 +112,7 @@ function {:constructor} Integer(i: int): Value;
 function {:constructor} Address(a: int): Value;
 function {:constructor} Vector(v: ValueArray): Value; // used to both represent move Struct and Vector
 function {:constructor} $Range(lb: Value, ub: Value): Value;
+function {:constructor} $Type(t: TypeValue): Value;
 function {:constructor} Error(): Value;
 const DefaultValue: Value;
 axiom DefaultValue == Error();

--- a/language/move-prover/tests/sources/functional/address_quant.move
+++ b/language/move-prover/tests/sources/functional/address_quant.move
@@ -13,13 +13,13 @@ module AddressQuant {
     spec module {
        // helper functions
        define atMostOne(): bool {
-            all(addresses(),
-                |a| all(addresses(),
+            all(domain<address>(),
+                |a| all(domain<address>(),
                         |b| exists<R>(a) && exists<R>(b) ==> a == b))
 
         }
         define atLeastOne(): bool {
-            any(addresses(),
+            any(domain<address>(),
                 |a| exists<R>(a))
         }
     }
@@ -29,8 +29,8 @@ module AddressQuant {
         move_to_sender<R>(R{x:1});
     }
     spec fun initialize {
-        requires all(addresses(), |a| !exists<R>(a)); // forall a: address :: !exists<R>(a)
-        ensures all(addresses(), |a| exists<R>(a) ==> a == special_addr);
+        requires all(domain<address>(), |a| !exists<R>(a)); // forall a: address :: !exists<R>(a)
+        ensures all(domain<address>(), |a| exists<R>(a) ==> a == special_addr);
         ensures atMostOne();
         ensures atLeastOne();
     }

--- a/language/move-prover/tests/sources/functional/type_values.exp
+++ b/language/move-prover/tests/sources/functional/type_values.exp
@@ -1,0 +1,23 @@
+Move prover returns: exiting with boogie verification errors
+error:  A postcondition might not hold on this return path.
+
+    ┌── tests/sources/functional/type_values.move:25:9 ───
+    │
+ 25 │         invariant all(domain<type>(), |t| resource_invariant_globally_defined(t));
+    │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    │
+    =     at tests/sources/functional/type_values.move:37:5: add_R_incorrect (entry)
+    =     at tests/sources/functional/type_values.move:38:9: add_R_incorrect
+    =     at tests/sources/functional/type_values.move:37:5: add_R_incorrect (exit)
+
+error:  A postcondition might not hold on this return path.
+
+    ┌── tests/sources/functional/type_values.move:18:9 ───
+    │
+ 18 │         ensures result == (type<T1>() != type<T2>());
+    │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    │
+    =     at tests/sources/functional/type_values.move:14:5: simple_type_equality_incorrect (entry)
+    =     at tests/sources/functional/type_values.move:15:9: simple_type_equality_incorrect
+    =         result = <redacted>
+    =     at tests/sources/functional/type_values.move:14:5: simple_type_equality_incorrect (exit)

--- a/language/move-prover/tests/sources/functional/type_values.move
+++ b/language/move-prover/tests/sources/functional/type_values.move
@@ -1,0 +1,40 @@
+module TestTypeValues {
+
+    spec module {
+        pragma verify = true;
+    }
+
+    fun simple_type_equality<T>(): bool {
+        true
+    }
+    spec fun simple_type_equality {
+        ensures result == (type<T>() == type<T>());
+    }
+
+    fun simple_type_equality_incorrect<T1, T2>(): bool {
+        true
+    }
+    spec fun simple_type_equality_incorrect {
+        ensures result == (type<T1>() != type<T2>());
+    }
+
+    resource struct R<T> { x: u64 }
+
+    spec module {
+        // Quantify over the domain of types, passing the type value to a helper function.
+        invariant all(domain<type>(), |t| resource_invariant_globally_defined(t));
+
+        // Quantify over the domain of addresses, and take the type parameter to check a resource.
+        define resource_invariant_globally_defined(t: type): bool {
+            all(domain<address>(), |addr| exists<R<t>>(addr) ==> global<R<t>>(addr).x >= 1)
+        }
+    }
+
+    public fun add_R<T>() {
+        move_to_sender(R<T>{x: 1})
+    }
+
+    public fun add_R_incorrect<T>() {
+        move_to_sender(R<T>{x: 0})
+    }
+}


### PR DESCRIPTION
This PR adds a lot of new fire power (also to shoot in your foot) for specifications with a few extensions:

1. We now support types as values. You can write `type<T>()` to construct a value which represents type T. The only operation available on type values  is equality. The type of types is called `type`, so one can e.g. do
   ```
   define helper(t: type, addr: address): bool { exists<R<t>>(addr) }
   ```
   Notice the use of the type value `t` in the instantiation of `exists`.

2. The quantification over addresses David added recently has beeen generalized to arbitrary types. You can write `all(domain<address>(), |addr| P(addr))` to quantify over addresses, for example. This also works for types using `domain<type>()`.

This was technically relative simple because the boogie encoding already deals with types as values.

The example in the test case `type_values.move` demonstrates that this mechanism can be used to express resource invariants, in the presence of generic types, as module invariants, which -- surprisingly -- seems to work well. Similarly, this should allow to write schemas which can apply to all functions in a module and do not require type parameters (resp. use old-style module invariants directly).

The syntax we have choosen for quantifiers may not be totally adequate any longer, as it was oriented towards bounded quantification over vectors or ranges. We may want to change it in the near future.

## Motivation

Global specifications.

Closes #3708 

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

New Tests

## Related PRs

NA
