### PR TITLE
[network] ensure seed peers are fully rendered libranet addrs

### DIFF
--- a/config/config-builder/src/full_node_config.rs
+++ b/config/config-builder/src/full_node_config.rs
@@ -6,6 +6,7 @@ use anyhow::{ensure, Result};
 use libra_config::{
     config::{
         NetworkPeersConfig, NodeConfig, PeerNetworkId, RoleType, SeedPeersConfig, UpstreamConfig,
+        HANDSHAKE_VERSION,
     },
     utils,
 };
@@ -252,7 +253,6 @@ impl FullNodeConfig {
             .last()
             .ok_or(Error::MissingFullNodeNetwork)?;
 
-        let seed_handshake = 0;
         let seed_pubkey = seed_config
             .network_keypairs
             .as_ref()
@@ -260,7 +260,7 @@ impl FullNodeConfig {
             .identity_keypair
             .public_key();
         let seed_base_addr = self.bootstrap.clone();
-        let seed_addr = seed_base_addr.append_prod_protos(seed_pubkey, seed_handshake);
+        let seed_addr = seed_base_addr.append_prod_protos(seed_pubkey, HANDSHAKE_VERSION);
 
         let mut seed_peers = SeedPeersConfig::default();
         seed_peers

--- a/config/config-builder/src/full_node_config.rs
+++ b/config/config-builder/src/full_node_config.rs
@@ -251,7 +251,22 @@ impl FullNodeConfig {
             .full_node_networks
             .last()
             .ok_or(Error::MissingFullNodeNetwork)?;
-        seed_config.build_seed_peers(self.bootstrap.clone())
+
+        let seed_handshake = 0;
+        let seed_pubkey = seed_config
+            .network_keypairs
+            .as_ref()
+            .ok_or(Error::MissingNetworkKeyPairs)?
+            .identity_keypair
+            .public_key();
+        let seed_base_addr = self.bootstrap.clone();
+        let seed_addr = seed_base_addr.append_prod_protos(seed_pubkey, seed_handshake);
+
+        let mut seed_peers = SeedPeersConfig::default();
+        seed_peers
+            .seed_peers
+            .insert(seed_config.peer_id, vec![seed_addr]);
+        Ok(seed_peers)
     }
 }
 

--- a/config/config-builder/src/validator_config.rs
+++ b/config/config-builder/src/validator_config.rs
@@ -7,7 +7,7 @@ use executor::db_bootstrapper;
 use libra_config::{
     config::{
         ConsensusType, NodeConfig, RemoteService, SafetyRulesService, SecureBackend,
-        SeedPeersConfig, Token, VaultConfig,
+        SeedPeersConfig, Token, VaultConfig, HANDSHAKE_VERSION,
     },
     generator,
 };
@@ -284,7 +284,6 @@ impl ValidatorConfig {
             .as_ref()
             .ok_or(Error::MissingValidatorNetwork)?;
 
-        let seed_handshake = 0;
         let seed_pubkey = seed_config
             .network_keypairs
             .as_ref()
@@ -292,7 +291,7 @@ impl ValidatorConfig {
             .identity_keypair
             .public_key();
         let seed_base_addr = self.bootstrap.clone();
-        let seed_addr = seed_base_addr.append_prod_protos(seed_pubkey, seed_handshake);
+        let seed_addr = seed_base_addr.append_prod_protos(seed_pubkey, HANDSHAKE_VERSION);
 
         let mut seed_peers = SeedPeersConfig::default();
         seed_peers

--- a/config/config-builder/src/validator_config.rs
+++ b/config/config-builder/src/validator_config.rs
@@ -6,8 +6,8 @@ use anyhow::{ensure, format_err, Result};
 use executor::db_bootstrapper;
 use libra_config::{
     config::{
-        ConsensusType, NodeConfig, RemoteService, SafetyRulesService, SecureBackend,
-        SeedPeersConfig, Token, VaultConfig,
+        ConsensusType, NodeConfig, RemoteService, SafetyRulesService, SecureBackend, Token,
+        VaultConfig,
     },
     generator,
 };
@@ -18,7 +18,7 @@ use libra_types::waypoint::Waypoint;
 use libra_vm::LibraVM;
 use libradb::LibraDB;
 use rand::{rngs::StdRng, Rng, SeedableRng};
-use std::{collections::HashMap, net::SocketAddr, str::FromStr};
+use std::{net::SocketAddr, str::FromStr};
 use storage_interface::DbReaderWriter;
 
 const DEFAULT_SEED: [u8; 32] = [13u8; 32];
@@ -140,24 +140,24 @@ impl ValidatorConfig {
 
     pub fn build(&self) -> Result<NodeConfig> {
         let mut configs = self.build_set()?;
-        let first_peer_id = configs[0]
+
+        // Extract and format first node's advertised address for the cluster
+        // bootstrap.
+
+        let seed_config = configs[0]
             .validator_network
             .as_ref()
-            .ok_or(Error::MissingValidatorNetwork)?
-            .peer_id;
-        let mut config = configs.swap_remove(self.index);
+            .ok_or(Error::MissingValidatorNetwork)?;
+        let seed_peers = seed_config.build_seed_peers(self.bootstrap.clone())?;
 
+        let mut config = configs.swap_remove(self.index);
         let validator_network = config
             .validator_network
             .as_mut()
             .ok_or(Error::MissingValidatorNetwork)?;
         validator_network.listen_address = self.listen.clone();
         validator_network.advertised_address = self.advertised.clone();
-
-        let mut seed_peers = HashMap::new();
-        seed_peers.insert(first_peer_id, vec![self.bootstrap.clone()]);
-        let seed_peers_config = SeedPeersConfig { seed_peers };
-        validator_network.seed_peers = seed_peers_config;
+        validator_network.seed_peers = seed_peers;
 
         self.build_safety_rules(&mut config)?;
 
@@ -309,10 +309,13 @@ mod test {
             .build()
             .unwrap();
         let network = config.validator_network.as_ref().unwrap();
-        let (seed_peer_id, seed_peer_ips) = network.seed_peers.seed_peers.iter().next().unwrap();
-        assert!(&network.peer_id != seed_peer_id);
-        // These equal cause we didn't set
-        assert_eq!(network.advertised_address, seed_peer_ips[0]);
+
+        network.seed_peers.verify_libranet_addrs().unwrap();
+        let (seed_peer_id, seed_addrs) = network.seed_peers.seed_peers.iter().next().unwrap();
+        assert_eq!(seed_addrs.len(), 1);
+        assert_ne!(&network.peer_id, seed_peer_id);
+        assert_ne!(&network.advertised_address, &seed_addrs[0]);
+
         assert_eq!(
             network.advertised_address,
             NetworkAddress::from_str(DEFAULT_ADVERTISED).unwrap()
@@ -321,6 +324,7 @@ mod test {
             network.listen_address,
             NetworkAddress::from_str(DEFAULT_LISTEN).unwrap()
         );
+
         assert!(config.execution.genesis.is_some());
     }
 

--- a/config/management/src/lib.rs
+++ b/config/management/src/lib.rs
@@ -33,7 +33,6 @@ pub mod constants {
     pub const MAX_GAS_AMOUNT: u64 = 1_000_000;
     pub const GAS_CURRENCY_CODE: &str = LBR_NAME;
     pub const TXN_EXPIRATION_SECS: u64 = 3600;
-    pub const HANDSHAKE_VERSION: u8 = 0;
 }
 
 #[derive(Debug, StructOpt)]

--- a/config/management/src/validator_config.rs
+++ b/config/management/src/validator_config.rs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::{constants, error::Error, SecureBackends};
+use libra_config::config::HANDSHAKE_VERSION;
 use libra_crypto::{ed25519::Ed25519PublicKey, hash::CryptoHash, x25519, ValidCryptoMaterial};
 use libra_global_constants::{
     CONSENSUS_KEY, FULLNODE_NETWORK_KEY, OPERATOR_KEY, VALIDATOR_NETWORK_KEY,
@@ -50,14 +51,14 @@ impl ValidatorConfig {
         let validator_address = self
             .validator_address
             .clone()
-            .append_prod_protos(validator_network_key.clone(), constants::HANDSHAKE_VERSION);
+            .append_prod_protos(validator_network_key.clone(), HANDSHAKE_VERSION);
         let raw_validator_address = RawNetworkAddress::try_from(&validator_address)
             .map_err(|e| Error::UnexpectedError(format!("(raw_validator_address) {}", e)))?;
 
         let fullnode_address = self
             .fullnode_address
             .clone()
-            .append_prod_protos(fullnode_network_key.clone(), constants::HANDSHAKE_VERSION);
+            .append_prod_protos(fullnode_network_key.clone(), HANDSHAKE_VERSION);
         let raw_fullnode_address = RawNetworkAddress::try_from(&fullnode_address)
             .map_err(|e| Error::UnexpectedError(format!("(raw_fullnode_address) {}", e)))?;
 

--- a/config/src/config/network_config.rs
+++ b/config/src/config/network_config.rs
@@ -20,6 +20,13 @@ use std::{collections::HashMap, convert::TryFrom, path::PathBuf, string::ToStrin
 const NETWORK_PEERS_DEFAULT: &str = "network_peers.config.toml";
 const SEED_PEERS_DEFAULT: &str = "seed_peers.toml";
 
+/// Current supported protocol negotiation handshake version.
+///
+/// See [`perform_handshake`] in `network/src/transport.rs`
+// TODO(philiphayes): ideally this constant lives somewhere in network/ ...
+// might need to extract into a separate network_constants crate or something.
+pub const HANDSHAKE_VERSION: u8 = 0;
+
 #[cfg_attr(any(test, feature = "fuzzing"), derive(Clone, PartialEq))]
 #[derive(Debug, Deserialize, Serialize)]
 #[serde(default, deny_unknown_fields)]

--- a/config/src/generator.rs
+++ b/config/src/generator.rs
@@ -4,7 +4,7 @@
 //! Convenience structs and functions for generating a random set of Libra ndoes without the
 //! genesis.blob.
 
-use crate::config::{NodeConfig, SeedPeersConfig, TestConfig};
+use crate::config::{NodeConfig, SeedPeersConfig, TestConfig, HANDSHAKE_VERSION};
 use rand::{rngs::StdRng, SeedableRng};
 
 pub struct ValidatorSwarm {
@@ -51,7 +51,6 @@ pub fn validator_swarm_for_testing(nodes: usize) -> ValidatorSwarm {
 
 fn build_seed_peers(config: &NodeConfig) -> SeedPeersConfig {
     let seed_config = config.validator_network.as_ref().unwrap();
-    let seed_handshake = 0;
     let seed_pubkey = seed_config
         .network_keypairs
         .as_ref()
@@ -59,7 +58,7 @@ fn build_seed_peers(config: &NodeConfig) -> SeedPeersConfig {
         .identity_keypair
         .public_key();
     let seed_base_addr = seed_config.advertised_address.clone();
-    let seed_addr = seed_base_addr.append_prod_protos(seed_pubkey, seed_handshake);
+    let seed_addr = seed_base_addr.append_prod_protos(seed_pubkey, HANDSHAKE_VERSION);
 
     let mut seed_peers = SeedPeersConfig::default();
     seed_peers

--- a/config/src/generator.rs
+++ b/config/src/generator.rs
@@ -4,7 +4,8 @@
 //! Convenience structs and functions for generating a random set of Libra ndoes without the
 //! genesis.blob.
 
-use crate::config::{NodeConfig, SeedPeersConfig, TestConfig, HANDSHAKE_VERSION};
+use crate::config::{NetworkConfig, NodeConfig, SeedPeersConfig, TestConfig, HANDSHAKE_VERSION};
+use libra_network_address::NetworkAddress;
 use rand::{rngs::StdRng, SeedableRng};
 
 pub struct ValidatorSwarm {
@@ -34,7 +35,8 @@ pub fn validator_swarm(
     }
 
     // set the first validator as every validators' initial configured seed peer.
-    let seed_peers = build_seed_peers(&nodes[0]);
+    let seed_config = &nodes[0].validator_network.as_ref().unwrap();
+    let seed_peers = build_seed_peers(&seed_config, seed_config.advertised_address.clone());
     for node in &mut nodes {
         let network = node.validator_network.as_mut().unwrap();
         network.seed_peers = seed_peers.clone();
@@ -49,20 +51,27 @@ pub fn validator_swarm_for_testing(nodes: usize) -> ValidatorSwarm {
     validator_swarm(&NodeConfig::default(), nodes, [1u8; 32], true)
 }
 
-fn build_seed_peers(config: &NodeConfig) -> SeedPeersConfig {
-    let seed_config = config.validator_network.as_ref().unwrap();
+/// Convenience function that builds a `SeedPeersConfig` containing a single peer
+/// with a fully formatted `NetworkAddress` containing its network identity pubkey
+/// and handshake protocol version.
+pub fn build_seed_peers(
+    seed_config: &NetworkConfig,
+    seed_base_addr: NetworkAddress,
+) -> SeedPeersConfig {
     let seed_pubkey = seed_config
         .network_keypairs
         .as_ref()
-        .unwrap()
+        .expect("Expect network keypairs")
         .identity_keypair
         .public_key();
-    let seed_base_addr = seed_config.advertised_address.clone();
     let seed_addr = seed_base_addr.append_prod_protos(seed_pubkey, HANDSHAKE_VERSION);
 
     let mut seed_peers = SeedPeersConfig::default();
     seed_peers
         .seed_peers
         .insert(seed_config.peer_id, vec![seed_addr]);
+    seed_peers
+        .verify_libranet_addrs()
+        .expect("Expect LibraNet addresses");
     seed_peers
 }

--- a/config/src/generator.rs
+++ b/config/src/generator.rs
@@ -4,7 +4,7 @@
 //! Convenience structs and functions for generating a random set of Libra ndoes without the
 //! genesis.blob.
 
-use crate::config::{NodeConfig, SeedPeersConfig, TestConfig};
+use crate::config::{NodeConfig, TestConfig};
 use rand::{rngs::StdRng, SeedableRng};
 
 pub struct ValidatorSwarm {
@@ -33,11 +33,12 @@ pub fn validator_swarm(
         nodes.push(node);
     }
 
-    let mut seed_peers = SeedPeersConfig::default();
-    let network = nodes[0].validator_network.as_ref().unwrap();
-    seed_peers
-        .seed_peers
-        .insert(network.peer_id, vec![network.listen_address.clone()]);
+    // set the first validator as every validators' initial configured seed peer.
+
+    let seed_config = nodes[0].validator_network.as_ref().unwrap();
+    let seed_peers = seed_config
+        .build_seed_peers(seed_config.advertised_address.clone())
+        .expect("Failed to build seed_peers");
 
     for node in &mut nodes {
         let network = node.validator_network.as_mut().unwrap();

--- a/language/tools/vm-genesis/src/lib.rs
+++ b/language/tools/vm-genesis/src/lib.rs
@@ -11,7 +11,7 @@ use crate::{
     genesis_gas_schedule::INITIAL_GAS_SCHEDULE,
 };
 use bytecode_verifier::VerifiedModule;
-use libra_config::config::NodeConfig;
+use libra_config::config::{NodeConfig, HANDSHAKE_VERSION};
 use libra_crypto::{
     ed25519::{Ed25519PrivateKey, Ed25519PublicKey},
     PrivateKey, Uniform, ValidCryptoMaterial,
@@ -36,9 +36,6 @@ use vm::access::ModuleAccess;
 const GENESIS_SEED: [u8; 32] = [42; 32];
 
 const GENESIS_MODULE_NAME: &str = "Genesis";
-
-// TODO(philiphayes): probably not the right place to put this...
-const HANDSHAKE_VERSION: u8 = 0;
 
 pub static GENESIS_KEYPAIR: Lazy<(Ed25519PrivateKey, Ed25519PublicKey)> = Lazy::new(|| {
     let mut rng = StdRng::from_seed(GENESIS_SEED);

--- a/libra-node/src/main_node.rs
+++ b/libra-node/src/main_node.rs
@@ -22,9 +22,7 @@ use libra_metrics::metric_server;
 use libra_types::{on_chain_config::ON_CHAIN_CONFIG_REGISTRY, waypoint::Waypoint, PeerId};
 use libra_vm::LibraVM;
 use libradb::LibraDB;
-use network::validator_network::network_builder::{
-    AuthenticationMode, NetworkBuilder, HANDSHAKE_VERSION,
-};
+use network::validator_network::network_builder::{AuthenticationMode, NetworkBuilder};
 use onchain_discovery::{client::OnchainDiscovery, service::OnchainDiscoveryService};
 use state_synchronizer::StateSynchronizer;
 use std::{
@@ -151,8 +149,14 @@ pub fn setup_network(
             config.enable_noise,
             "Permissioned network end-points must use authentication"
         );
-        let seed_peers = config.seed_peers.seed_peers.clone();
+        // Sanity check seed peer addresses.
+        config
+            .seed_peers
+            .verify_libranet_addrs()
+            .expect("Seed peer addresses must be well-formed");
+
         let network_peers = config.network_peers.peers.clone();
+        let seed_peers = config.seed_peers.seed_peers.clone();
 
         let network_keypairs = config
             .network_keypairs
@@ -169,42 +173,17 @@ pub fn setup_network(
             .take_private()
             .expect("identity key should be present");
 
-        // TODO(philiphayes): seed peers should be fully rendered. then we can
-        // also get rid of `network_peers`. we'll need to make some changes to
-        // ops code since it only specifies the base address.
-        let seed_peers: HashMap<_, _> = seed_peers
-            .into_iter()
-            .map(|(peer_id, addrs)| {
-                let opt_id_pubkey = network_peers
-                    .get(&peer_id)
-                    .map(|info| info.identity_public_key);
-
-                match opt_id_pubkey {
-                    Some(id_pubkey) => {
-                        let addrs = addrs
-                            .into_iter()
-                            .map(|addr| addr.append_prod_protos(id_pubkey, HANDSHAKE_VERSION))
-                            .collect();
-                        (peer_id, addrs)
-                    }
-                    // TODO(philiphayes): can skip these when transport actually
-                    // uses pubkey
-                    None => (peer_id, addrs),
-                }
-            })
-            .collect();
-
-        info!(
-            "network setup: role: {}, seed_peers: {:?}, network_peers: {:?}",
-            role, seed_peers, network_peers,
-        );
-
         let trusted_peers = if role == RoleType::Validator {
             // for validators, trusted_peers is empty will be populated from consensus
             HashMap::new()
         } else {
             network_peers
         };
+
+        info!(
+            "network setup: role: {}, seed_peers: {:?}, trusted_peers: {:?}",
+            role, seed_peers, trusted_peers,
+        );
 
         network_builder
             .advertised_address(config.advertised_address.clone())

--- a/network/netcore/src/transport/memory.rs
+++ b/network/netcore/src/transport/memory.rs
@@ -3,7 +3,7 @@
 
 use crate::transport::Transport;
 use futures::{future, stream::Stream};
-use libra_network_address::{NetworkAddress, Protocol};
+use libra_network_address::{parse_memory, NetworkAddress, Protocol};
 use memsocket::{MemoryListener, MemorySocket};
 use std::{
     io,
@@ -26,7 +26,7 @@ impl Transport for MemoryTransport {
         &self,
         addr: NetworkAddress,
     ) -> Result<(Self::Listener, NetworkAddress), Self::Error> {
-        let (port, addr_suffix) = addr.parse_memory_proto().ok_or_else(|| {
+        let (port, addr_suffix) = parse_memory(addr.as_slice()).ok_or_else(|| {
             io::Error::new(
                 io::ErrorKind::InvalidData,
                 format!("Invalid NetworkAddress: '{}'", addr),
@@ -44,7 +44,7 @@ impl Transport for MemoryTransport {
     }
 
     fn dial(&self, addr: NetworkAddress) -> Result<Self::Outbound, Self::Error> {
-        let (port, _addr_suffix) = addr.parse_memory_proto().ok_or_else(|| {
+        let (port, _addr_suffix) = parse_memory(addr.as_slice()).ok_or_else(|| {
             io::Error::new(
                 io::ErrorKind::InvalidData,
                 format!("Invalid NetworkAddress: '{}'", addr),

--- a/network/src/transport.rs
+++ b/network/src/transport.rs
@@ -218,12 +218,10 @@ pub fn build_memory_noise_transport(
     own_handshake.add(SUPPORTED_MESSAGING_PROTOCOL, application_protocols);
 
     memory_transport
-        .and_then(move |socket, _addr, origin| async move {
+        .and_then(move |socket, addr, origin| async move {
             let (remote_static_key, socket) =
                 noise_config.upgrade_connection(socket, origin).await?;
-
-            // TODO(philiphayes): reenable after seed peers are always fully rendered
-            // expect_noise_pubkey(&addr, remote_static_key.as_slice(), origin)?;
+            expect_noise_pubkey(&addr, remote_static_key.as_slice(), origin)?;
 
             if let Some(peer_id) = identity_key_to_peer_id(&trusted_peers, &remote_static_key) {
                 Ok((peer_id, socket))
@@ -248,13 +246,11 @@ pub fn build_unauthenticated_memory_noise_transport(
     own_handshake.add(SUPPORTED_MESSAGING_PROTOCOL, application_protocols);
 
     memory_transport
-        .and_then(move |socket, _addr, origin| {
+        .and_then(move |socket, addr, origin| {
             async move {
                 let (remote_static_key, socket) =
                     noise_config.upgrade_connection(socket, origin).await?;
-
-                // TODO(philiphayes): reenable after seed peers are always fully rendered
-                // expect_noise_pubkey(&addr, remote_static_key.as_slice(), origin)?;
+                expect_noise_pubkey(&addr, remote_static_key.as_slice(), origin)?;
 
                 // Generate PeerId from x25519::PublicKey.
                 // Note: This is inconsistent with current types because AccountAddress is derived
@@ -304,12 +300,10 @@ pub fn build_tcp_noise_transport(
     own_handshake.add(SUPPORTED_MESSAGING_PROTOCOL, application_protocols);
 
     LIBRA_TCP_TRANSPORT
-        .and_then(move |socket, _addr, origin| async move {
+        .and_then(move |socket, addr, origin| async move {
             let (remote_static_key, socket) =
                 noise_config.upgrade_connection(socket, origin).await?;
-
-            // TODO(philiphayes): reenable after seed peers are always fully rendered
-            // expect_noise_pubkey(&addr, remote_static_key.as_slice(), origin)?;
+            expect_noise_pubkey(&addr, remote_static_key.as_slice(), origin)?;
 
             if let Some(peer_id) = identity_key_to_peer_id(&trusted_peers, &remote_static_key) {
                 Ok((peer_id, socket))
@@ -340,13 +334,11 @@ pub fn build_unauthenticated_tcp_noise_transport(
     own_handshake.add(SUPPORTED_MESSAGING_PROTOCOL, application_protocols);
 
     LIBRA_TCP_TRANSPORT
-        .and_then(move |socket, _addr, origin| {
+        .and_then(move |socket, addr, origin| {
             async move {
                 let (remote_static_key, socket) =
                     noise_config.upgrade_connection(socket, origin).await?;
-
-                // TODO(philiphayes): reenable after seed peers are always fully rendered
-                // expect_noise_pubkey(&addr, remote_static_key.as_slice(), origin)?;
+                expect_noise_pubkey(&addr, remote_static_key.as_slice(), origin)?;
 
                 // Generate PeerId from x25519::PublicKey.
                 // Note: This is inconsistent with current types because AccountAddress is derived

--- a/network/src/transport.rs
+++ b/network/src/transport.rs
@@ -148,7 +148,7 @@ fn identity_key_to_peer_id(
 /// temporary checks to make sure noise pubkeys are actually getting propagated correctly.
 // TODO(philiphayes): remove this after Transport refactor
 #[allow(dead_code)]
-fn expect_noise_pubkey(
+fn verify_noise_pubkey(
     addr: &NetworkAddress,
     remote_static_key: &[u8],
     origin: ConnectionOrigin,
@@ -221,7 +221,7 @@ pub fn build_memory_noise_transport(
         .and_then(move |socket, addr, origin| async move {
             let (remote_static_key, socket) =
                 noise_config.upgrade_connection(socket, origin).await?;
-            expect_noise_pubkey(&addr, remote_static_key.as_slice(), origin)?;
+            verify_noise_pubkey(&addr, remote_static_key.as_slice(), origin)?;
 
             if let Some(peer_id) = identity_key_to_peer_id(&trusted_peers, &remote_static_key) {
                 Ok((peer_id, socket))
@@ -250,7 +250,7 @@ pub fn build_unauthenticated_memory_noise_transport(
             async move {
                 let (remote_static_key, socket) =
                     noise_config.upgrade_connection(socket, origin).await?;
-                expect_noise_pubkey(&addr, remote_static_key.as_slice(), origin)?;
+                verify_noise_pubkey(&addr, remote_static_key.as_slice(), origin)?;
 
                 // Generate PeerId from x25519::PublicKey.
                 // Note: This is inconsistent with current types because AccountAddress is derived
@@ -303,7 +303,7 @@ pub fn build_tcp_noise_transport(
         .and_then(move |socket, addr, origin| async move {
             let (remote_static_key, socket) =
                 noise_config.upgrade_connection(socket, origin).await?;
-            expect_noise_pubkey(&addr, remote_static_key.as_slice(), origin)?;
+            verify_noise_pubkey(&addr, remote_static_key.as_slice(), origin)?;
 
             if let Some(peer_id) = identity_key_to_peer_id(&trusted_peers, &remote_static_key) {
                 Ok((peer_id, socket))
@@ -338,7 +338,7 @@ pub fn build_unauthenticated_tcp_noise_transport(
             async move {
                 let (remote_static_key, socket) =
                     noise_config.upgrade_connection(socket, origin).await?;
-                expect_noise_pubkey(&addr, remote_static_key.as_slice(), origin)?;
+                verify_noise_pubkey(&addr, remote_static_key.as_slice(), origin)?;
 
                 // Generate PeerId from x25519::PublicKey.
                 // Note: This is inconsistent with current types because AccountAddress is derived

--- a/network/src/validator_network/network_builder.rs
+++ b/network/src/validator_network/network_builder.rs
@@ -20,7 +20,7 @@ use crate::{
     protocols::{
         discovery::{self, Discovery},
         health_checker::{self, HealthChecker},
-        wire::handshake::v1::{MessagingProtocolVersion, SupportedProtocols},
+        wire::handshake::v1::SupportedProtocols,
     },
     transport,
     transport::*,
@@ -28,7 +28,7 @@ use crate::{
 };
 use channel::{self, libra_channel, message_queues::QueueStyle};
 use futures::stream::StreamExt;
-use libra_config::config::RoleType;
+use libra_config::config::{RoleType, HANDSHAKE_VERSION};
 use libra_crypto::{
     ed25519::{Ed25519PrivateKey, Ed25519PublicKey},
     x25519,
@@ -65,9 +65,6 @@ pub const PING_FAILURES_TOLERATED: u64 = 10;
 pub const MAX_CONCURRENT_NETWORK_REQS: usize = 100;
 pub const MAX_CONCURRENT_NETWORK_NOTIFS: usize = 100;
 pub const MAX_CONNECTION_DELAY_MS: u64 = 10 * 60 * 1000 /* 10 minutes */;
-
-// TODO(philiphayes): remove when transport returns fully rendered network address
-pub const HANDSHAKE_VERSION: u8 = MessagingProtocolVersion::V1 as u8;
 
 #[derive(Debug)]
 pub enum AuthenticationMode {


### PR DESCRIPTION
+ Follow up PR to #3849.

+ Previously, seed peer addresses were just base transport (e.g.,
`"/ip6/::1/tcp/1234"`). With this diff they are fully rendered and so
include the pubkey `"/ln-noise-ik/<pubkey>"` and handshake protocol
`"/ln-handshake/0"`.

+ All addresses in seed peer configs generated via config builder and
e2e smoke test config generators are now fully rendered libranet
addresses w/ noise pubkey and handshake protocol.

+ Remove hacky seed_peers formatting in `libra-node/src/main_node.rs`.

+ Re-enable transport checks to assert noise pubkeys are present in the
outbound dial addresses.