### PR TITLE
[tf] increase time until stopped containers removed

### DIFF
--- a/terraform/templates/ec2_user_data.sh
+++ b/terraform/templates/ec2_user_data.sh
@@ -45,6 +45,7 @@ fi
 mkdir -p /opt/libra /vault
 
 echo ECS_CLUSTER=${ecs_cluster} >> /etc/ecs/ecs.config
+echo ECS_ENGINE_TASK_CLEANUP_WAIT_DURATION=8h >>/etc/ecs/ecs.config
 systemctl try-restart ecs --no-block
 
 curl -o /tmp/node_exporter.rpm https://copr-be.cloud.fedoraproject.org/results/ibotty/prometheus-exporters/epel-7-x86_64/00935314-golang-github-prometheus-node_exporter/golang-github-prometheus-node_exporter-0.18.1-6.el7.x86_64.rpm


### PR DESCRIPTION
<!--
Thank you for sending a PR. We appreciate you spending time to help improve the Libra project.

The project is undergoing daily changes. Pull Requests will be reviewed and responded to as time permits.
-->

## Motivation

Change default ECS cleanup from 3h to 8h. This is not an issue for instances with persistent storage. 

For non-persistent storage, e.g. devnet, looks like with continuous push running it caps out at around 30-36% /data usage at a regular cadence. Bumping to 8h seems like a conservative limit.

http://prometheus.dev.aws.hlw3truzy4ls.com:9091/d/overview10/overview?viewPanel=57&orgId=1

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?

(Write your answer here.)

## Test Plan

(Share your test plan here. If you changed code, please provide us with clear instructions for verifying that your changes work.)

## Related PRs

(If this PR adds or changes functionality, please take some time to update the docs at https://github.com/libra/website, and link to your PR here.)
