### PR TITLE
Update coverage reporting scripts to work with bot

### DIFF
--- a/language/move-lang/tests/functional/dummy.move
+++ b/language/move-lang/tests/functional/dummy.move
@@ -1,3 +1,4 @@
+//! new-transaction
 script {
 fun main() {
 

--- a/language/tools/move-coverage/baseline/coverage_report
+++ b/language/tools/move-coverage/baseline/coverage_report
@@ -1,0 +1,80 @@
++-------------------------+
+| Move Coverage Summary   |
++-------------------------+
+Module 00000000000000000000000000000000::Debug
+>>> % Module coverage: NaN
+Module 00000000000000000000000000000000::Testnet
+>>> % Module coverage: 100.00
+Module 00000000000000000000000000000000::LibraTimestamp
+>>> % Module coverage: 100.00
+Module 00000000000000000000000000000000::Association
+>>> % Module coverage: 100.00
+Module 00000000000000000000000000000000::AccountLimits
+>>> % Module coverage: 96.87
+Module 00000000000000000000000000000000::Vector
+>>> % Module coverage: 100.00
+Module 00000000000000000000000000000000::Empty
+>>> % Module coverage: 100.00
+Module 00000000000000000000000000000000::AccountType
+>>> % Module coverage: 100.00
+Module 00000000000000000000000000000000::VASP
+>>> % Module coverage: 100.00
+Module 00000000000000000000000000000000::Unhosted
+>>> % Module coverage: 100.00
+Module 00000000000000000000000000000000::AccountTrack
+>>> % Module coverage: 88.96
+Module 00000000000000000000000000000000::LCS
+>>> % Module coverage: NaN
+Module 00000000000000000000000000000000::Hash
+>>> % Module coverage: NaN
+Module 00000000000000000000000000000000::Authenticator
+>>> % Module coverage: 100.00
+Module 00000000000000000000000000000000::Offer
+>>> % Module coverage: 100.00
+Module 00000000000000000000000000000000::Event
+>>> % Module coverage: 92.25
+Module 00000000000000000000000000000000::LibraConfig
+>>> % Module coverage: 100.00
+Module 00000000000000000000000000000000::RegisteredCurrencies
+>>> % Module coverage: 100.00
+Module 00000000000000000000000000000000::FixedPoint32
+>>> % Module coverage: 100.00
+Module 00000000000000000000000000000000::Libra
+>>> % Module coverage: 100.00
+Module 00000000000000000000000000000000::Coin1
+>>> % Module coverage: 100.00
+Module 00000000000000000000000000000000::Coin2
+>>> % Module coverage: 100.00
+Module 00000000000000000000000000000000::Compare
+>>> % Module coverage: 100.00
+Module 00000000000000000000000000000000::Option
+>>> % Module coverage: 100.00
+Module 00000000000000000000000000000000::Signature
+>>> % Module coverage: NaN
+Module 00000000000000000000000000000000::LibraTransactionTimeout
+>>> % Module coverage: 100.00
+Module 00000000000000000000000000000000::LibraAccount
+>>> % Module coverage: 100.00
+Module 00000000000000000000000000000000::ValidatorConfig
+>>> % Module coverage: 100.00
+Module 00000000000000000000000000000000::LibraSystem
+>>> % Module coverage: 98.98
+Module 00000000000000000000000000000000::TransactionFee
+>>> % Module coverage: 100.00
+Module 00000000000000000000000000000000::LibraWriteSetManager
+>>> % Module coverage: 100.00
+Module 00000000000000000000000000000000::LibraBlock
+>>> % Module coverage: 100.00
+Module 00000000000000000000000000000000::LBR
+>>> % Module coverage: 100.00
+Module 00000000000000000000000000000000::Genesis
+>>> % Module coverage: 100.00
+Module 00000000000000000000000000000000::LibraVMConfig
+>>> % Module coverage: 100.00
+Module 00000000000000000000000000000000::LibraVersion
+>>> % Module coverage: 100.00
+Module 00000000000000000000000000000000::SharedEd25519PublicKey
+>>> % Module coverage: 100.00
++-------------------------+
+| % Move Coverage: 99.14  |
++-------------------------+

--- a/language/tools/move-coverage/gather_stats.bash
+++ b/language/tools/move-coverage/gather_stats.bash
@@ -6,6 +6,12 @@ TRACE_PATH=$HOME/trace
 
 export MOVE_VM_TRACE=$TRACE_PATH
 
+echo "Removing account universe from test..."
+pushd ../../e2e-tests || exit 1
+sed -i.bak '/mod account_universe;$/d' src/tests.rs
+rm -rf src/tests.rs.bak
+popd || exit 1
+
 echo "Rebuilding stdlib..."
 pushd ../../stdlib || exit 1
 cargo run
@@ -30,7 +36,8 @@ popd || exit 1
 echo "Converting trace file..."
 cargo run --bin move-trace-conversion -- -f "$TRACE_PATH" -o trace.mvcov
 echo "Producing coverage summaries..."
-cargo run --bin coverage-summaries -- -t trace.mvcov -s ../../stdlib/staged/stdlib.mv -c -o new_coverage_summary.csv
+cargo run --bin coverage-summaries -- -t trace.mvcov -s ../../stdlib/staged/stdlib.mv -o "$1"
+cat ./baseline/coverage_report > "$2"
 
 unset MOVE_VM_TRACE
 


### PR DESCRIPTION
This PR updates the move-coverage script to work in with the MIRAI bot. 

Hopefully, you should see a report posted by it in this PR with the current report.