### PR TITLE
[swarm] improve testability

### DIFF
--- a/config/management/src/smoke_test.rs
+++ b/config/management/src/smoke_test.rs
@@ -9,7 +9,7 @@ use libra_config::config::{
 };
 use libra_crypto::{ed25519::Ed25519PrivateKey, x25519, Uniform};
 use libra_secure_storage::Value;
-use libra_swarm::swarm::{LibraSwarm, LibraSwarmDir};
+use libra_swarm::swarm::{LibraNode, LibraSwarm, LibraSwarmDir};
 use libra_temppath::TempPath;
 use libra_types::account_address::AccountAddress;
 use std::path::PathBuf;
@@ -27,6 +27,7 @@ impl BuildSwarm for ManagementBuilder {
 
 #[test]
 fn smoke_test() {
+    LibraNode::prepare();
     let helper = StorageHelper::new();
     let num_validators = 5;
     let shared = "_shared";

--- a/testsuite/libra-swarm/src/swarm.rs
+++ b/testsuite/libra-swarm/src/swarm.rs
@@ -50,6 +50,15 @@ impl Drop for LibraNode {
 }
 
 impl LibraNode {
+    /// Prior to using LibraSwarm this should be run. LibraSwarm will acquire ephemeral networking
+    /// ports that are only reserved in a safe state for a brief period of time.
+    /// workspace_builder::get_bin actually compiles all of the Libra code base which can take
+    /// substantially longer time than the networking ports are reserved. Calling prior to
+    /// reserving those ports will reduce the liklihood of issues.
+    pub fn prepare() {
+        Command::new(workspace_builder::get_bin(LIBRA_NODE_BIN));
+    }
+
     pub fn launch(
         node_id: String,
         role: RoleType,
@@ -289,6 +298,8 @@ impl LibraSwarm {
         template: Option<NodeConfig>,
         upstream_config_dir: Option<String>,
     ) -> Result<LibraSwarm> {
+        LibraNode::prepare();
+
         let swarm_config_dir = Self::setup_config_dir(&config_dir);
         info!("logs at {:?}", swarm_config_dir);
 


### PR DESCRIPTION
always build binaries before configuring to ensure as small time as
possible between configuring and execution.