### PR TITLE
[move-prover] Fixed version issue in association.move specs

### DIFF
--- a/language/stdlib/modules/association.move
+++ b/language/stdlib/modules/association.move
@@ -149,7 +149,7 @@ module Association {
         // in a schema and as a post-condition to `initialize`
         // Informally: "Only the root address has a Root{} resource."
         define only_root_addr_has_root_privilege(): bool {
-            all(addresses(), |addr| exists<Root>(addr) ==> (addr == spec_root_address()))
+            all(domain<address>(), |addr| exists<Root>(addr) ==> (addr == spec_root_address()))
         }
     }
     spec schema OnlyRootAddressHasRootPrivilege {
@@ -171,7 +171,7 @@ module Association {
         // "initialize" establishes the invariant, so it's a special case.
         // Before initialize, no addresses have a Root{} resource.
         // Afterwards, only Root {} has the root resource.
-        requires all(addresses(), |addr| !exists<Root>(addr));
+        requires all(domain<address>(), |addr| !exists<Root>(addr));
         ensures only_root_addr_has_root_privilege();
     }
 
@@ -194,7 +194,7 @@ module Association {
     // state, or, even if it did exist in the old state, it is deleted by
     // "remove_privilege."
     spec schema OnlyGrantCanCertify<Privilege> {
-       ensures all(addresses(),
+       ensures all(domain<address>(),
                    |addr1| old(!exists<PrivilegedCapability<Privilege>>(addr1)
                               || !global<PrivilegedCapability<Privilege>>(addr1).is_certified)
                         ==> (!exists<PrivilegedCapability<Privilege>>(addr1)
@@ -212,7 +212,7 @@ module Association {
 
     // *Informally:* Only remove_privilege can remove privileges
     spec schema OnlyRemoveCanRemovePrivileges<Privilege> {
-         ensures any(addresses(), |a| (old(exists<PrivilegedCapability<Privilege>>(a))
+         ensures any(domain<address>(), |a| (old(exists<PrivilegedCapability<Privilege>>(a))
                                        && !exists<PrivilegedCapability<Privilege>>(a))
                                        ==> sender() == spec_root_address());
     }
@@ -238,7 +238,7 @@ module Association {
     // > remove_privilege<T>(root_address()).
     // > I have therefore commented out the "apply"
     spec schema RootAddressIsAssociationAddress {
-        invariant all(addresses(), |a| exists<Root>(a) ==> spec_addr_is_association(a));
+        invariant all(domain<address>(), |a| exists<Root>(a) ==> spec_addr_is_association(a));
     }
     spec module {
         // except functions called from initialize before invariant is established.

--- a/language/stdlib/modules/libra.move
+++ b/language/stdlib/modules/libra.move
@@ -579,6 +579,8 @@ module Libra {
         pragma verify = true;
     }
 
+    // ## Currency registration
+
     spec module {
         // Address at which currencies should be registered (mirrors currency_addr)
         define spec_currency_addr(): address { 0xA550C18 }
@@ -590,6 +592,7 @@ module Libra {
         }
     }
 
+    // Sanity check -- after register_currency is called, currency should be registered.
     spec fun register_currency {
         // This doesn't verify because:
         //  1. is_registered assumes the currency is registered at the fixed
@@ -600,10 +603,7 @@ module Libra {
         //     Genesis::initialize_association(association_root_addr).
         // If the AddCurrency privilege is on an address different from
         // currency_addr(), the currency will appear not to be registered.
-        // TODO: There are many more aborts conditions and I don't want
-        // to specify them all yet.
-        // aborts_if is_registered<CoinType>();
-        // if you change next to "true", prover will report an error.
+        // If you change next to "true", prover will report an error.
         pragma verify = false;
 
         // SPEC: After register_currency, the currency is an official currency.


### PR DESCRIPTION
We had two PRs land in the wrong order, and assocation.move needed
some changes to be consistent with new generalized quantification.

<!--
Thank you for sending a PR. We appreciate you spending time to help improve the Libra project.

The project is undergoing daily changes. Pull Requests will be reviewed and responded to as time permits.
-->

## Motivation

(Write your motivation for proposed changes here.)

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?

(Write your answer here.)

## Test Plan

(Share your test plan here. If you changed code, please provide us with clear instructions for verifying that your changes work.)

## Related PRs

(If this PR adds or changes functionality, please take some time to update the docs at https://github.com/libra/website, and link to your PR here.)
