### PR TITLE
[move prover] Add type requires for generated code

### DIFF
--- a/language/move-prover/src/boogie_helpers.rs
+++ b/language/move-prover/src/boogie_helpers.rs
@@ -259,6 +259,23 @@ pub fn boogie_well_formed_check(
     }
 }
 
+/// Create boogie well-formed preconditions. The result will be either an empty
+/// string or a newline-terminated requires statement.
+pub fn boogie_requires_well_formed(
+    env: &GlobalEnv,
+    name: &str,
+    ty: &Type,
+    mode: WellFormedMode,
+    type_requires_str: &str,
+) -> String {
+    let expr = boogie_well_formed_expr(env, name, ty, mode);
+    if !expr.is_empty() {
+        format!("{} {};\n", type_requires_str, expr)
+    } else {
+        "".to_string()
+    }
+}
+
 /// Create boogie global variable with type constraint. No references allowed.
 pub fn boogie_declare_global(env: &GlobalEnv, name: &str, param_count: usize, ty: &Type) -> String {
     let declarator = boogie_global_declarator(env, name, param_count, ty);

--- a/language/move-prover/tests/sources/functional/invariants.exp
+++ b/language/move-prover/tests/sources/functional/invariants.exp
@@ -28,9 +28,9 @@ error:  This assertion might not hold.
 
 error:  This assertion might not hold.
 
-     ┌── tests/sources/functional/invariants.move:143:9 ───
+     ┌── tests/sources/functional/invariants.move:150:9 ───
      │
- 143 │         invariant x > 1;
+ 150 │         invariant y > 1;
      │         ^^^^^^^^^^^^^^^^
      │
      =     at tests/sources/functional/invariants.move:153:5: lifetime_invalid_S_branching (entry)


### PR DESCRIPTION
<!--
Thank you for sending a PR. We appreciate you spending time to help improve the Libra project.

The project is undergoing daily changes. Pull Requests will be reviewed and responded to as time permits.
-->

## Motivation

This PR adds pre-conditions requiring that function parameters are well-formed in generated code. If `type-requires` option is set to true, `requires` is used; otherwise `free requires` is used.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

cargo test

