### PR TITLE
[CI] remove uneeded step in e2e test runner

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -245,8 +245,6 @@ jobs:
       MESSAGE_PAYLOAD_FILE: "/tmp/message_payload"
     steps:
       - build_setup
-      - attach_workspace:
-          at: /home/circleci/project
       - restore_cargo_package_cache
       - run:
           name: Determine test targets for this container.


### PR DESCRIPTION
## Motivation
Removed the attach_workspace step from run-e2e-test job as there is no
prior build artifacts to restore from a prev job.

## Test Plan
CI