### PR TITLE
[client] Detect and report failed transactions

### DIFF
--- a/testsuite/cli/src/client_proxy.rs
+++ b/testsuite/cli/src/client_proxy.rs
@@ -623,17 +623,17 @@ impl ClientProxy {
                 .get_txn_by_acc_seq(account, sequence_number - 1, true)
             {
                 Ok(Some(txn_view)) => {
-                    if txn_view.vm_status != StatusCode::EXECUTED {
-                        break Err(format_err!(
-                            "transaction failed to execute; status: {:?}!",
-                            txn_view.vm_status
-                        ));
-                    } else {
-                        println!("transaction is stored!");
+                    if txn_view.vm_status == StatusCode::EXECUTED {
+                        println!("transaction executed!");
                         if txn_view.events.is_empty() {
                             println!("no events emitted");
                         }
                         break Ok(());
+                    } else {
+                        break Err(format_err!(
+                            "transaction failed to execute; status: {:?}!",
+                            txn_view.vm_status
+                        ));
                     }
                 }
                 Err(e) => {

--- a/testsuite/cli/src/client_proxy.rs
+++ b/testsuite/cli/src/client_proxy.rs
@@ -33,6 +33,7 @@ use libra_types::{
         parse_transaction_argument, Module, RawTransaction, Script, SignedTransaction,
         TransactionArgument, TransactionPayload, Version,
     },
+    vm_error::StatusCode,
     waypoint::Waypoint,
 };
 use libra_wallet::{io_utils, WalletLibrary};
@@ -391,7 +392,7 @@ impl ClientProxy {
         self.client
             .submit_transaction(self.accounts.get_mut(sender_ref_id), txn)?;
         if is_blocking {
-            self.wait_for_transaction(sender_address, sequence_number);
+            self.wait_for_transaction(sender_address, sequence_number)?;
         }
         Ok(())
     }
@@ -598,13 +599,17 @@ impl ClientProxy {
         )?;
         self.client.submit_transaction(Some(&mut sender), txn)?;
         if is_blocking {
-            self.wait_for_transaction(sender.address, sender.sequence_number);
+            self.wait_for_transaction(sender.address, sender.sequence_number)?;
         }
         Ok(())
     }
 
     /// Waits for the next transaction for a specific address and prints it
-    pub fn wait_for_transaction(&mut self, account: AccountAddress, sequence_number: u64) {
+    pub fn wait_for_transaction(
+        &mut self,
+        account: AccountAddress,
+        sequence_number: u64,
+    ) -> Result<()> {
         let mut max_iterations = 5000;
         print!(
             "waiting for {} with sequence number {}",
@@ -618,11 +623,18 @@ impl ClientProxy {
                 .get_txn_by_acc_seq(account, sequence_number - 1, true)
             {
                 Ok(Some(txn_view)) => {
-                    println!("transaction is stored!");
-                    if txn_view.events.is_empty() {
-                        println!("no events emitted");
+                    if txn_view.vm_status != StatusCode::EXECUTED {
+                        break Err(format_err!(
+                            "transaction failed to execute; status: {:?}!",
+                            txn_view.vm_status
+                        ));
+                    } else {
+                        println!("transaction is stored!");
+                        if txn_view.events.is_empty() {
+                            println!("no events emitted");
+                        }
+                        break Ok(());
                     }
-                    break;
                 }
                 Err(e) => {
                     println!("Response with error: {:?}", e);
@@ -689,7 +701,7 @@ impl ClientProxy {
         }
 
         if is_blocking {
-            self.wait_for_transaction(sender_address, sender_sequence);
+            self.wait_for_transaction(sender_address, sender_sequence)?;
         }
 
         Ok(IndexAndSequence {
@@ -873,9 +885,7 @@ impl ClientProxy {
 
         self.client.submit_transaction(None, transaction)?;
         // blocking by default (until transaction completion)
-        self.wait_for_transaction(sender_address, sender_sequence + 1);
-
-        Ok(())
+        self.wait_for_transaction(sender_address, sender_sequence + 1)
     }
 
     fn submit_program(
@@ -893,9 +903,7 @@ impl ClientProxy {
 
         self.client
             .submit_transaction(self.accounts.get_mut(sender_ref_id), txn)?;
-        self.wait_for_transaction(sender_address, sequence_number + 1);
-
-        Ok(())
+        self.wait_for_transaction(sender_address, sequence_number + 1)
     }
 
     /// Publish Move module
@@ -1334,7 +1342,7 @@ impl ClientProxy {
             self.wait_for_transaction(
                 sender_address,
                 self.faucet_account.as_ref().unwrap().sequence_number,
-            );
+            )?;
         }
         resp
     }
@@ -1369,7 +1377,7 @@ impl ClientProxy {
         }
         let sequence_number = body.parse::<u64>()?;
         if is_blocking {
-            self.wait_for_transaction(association_address(), sequence_number);
+            self.wait_for_transaction(association_address(), sequence_number)?;
         }
 
         Ok(())

--- a/testsuite/tests/libratest/smoke_test.rs
+++ b/testsuite/tests/libratest/smoke_test.rs
@@ -542,7 +542,9 @@ fn test_startup_sync_state() {
     let mut client_proxy_0 = env.get_validator_ac_client(0, None);
     let sender_address = accounts[0].address;
     client_proxy_0.set_accounts(accounts);
-    client_proxy_0.wait_for_transaction(sender_address, 1);
+    client_proxy_0
+        .wait_for_transaction(sender_address, 1)
+        .unwrap();
     assert!(compare_balances(
         vec![(90.0, "LBR".to_string())],
         client_proxy_0.get_balances(&["b", "0"]).unwrap()
@@ -554,7 +556,9 @@ fn test_startup_sync_state() {
     client_proxy_1
         .transfer_coins(&["tb", "0", "1", "10", "LBR"], true)
         .unwrap();
-    client_proxy_0.wait_for_transaction(sender_address, 2);
+    client_proxy_0
+        .wait_for_transaction(sender_address, 2)
+        .unwrap();
     assert!(compare_balances(
         vec![(80.0, "LBR".to_string())],
         client_proxy_0.get_balances(&["b", "0"]).unwrap()
@@ -609,7 +613,9 @@ fn test_startup_sync_state_with_empty_consensus_db() {
     let mut client_proxy_0 = env.get_validator_ac_client(0, None);
     let sender_address = accounts[0].address;
     client_proxy_0.set_accounts(accounts);
-    client_proxy_0.wait_for_transaction(sender_address, 1);
+    client_proxy_0
+        .wait_for_transaction(sender_address, 1)
+        .unwrap();
     assert!(compare_balances(
         vec![(90.0, "LBR".to_string())],
         client_proxy_0.get_balances(&["b", "0"]).unwrap()
@@ -621,7 +627,9 @@ fn test_startup_sync_state_with_empty_consensus_db() {
     client_proxy_1
         .transfer_coins(&["tb", "0", "1", "10", "LBR"], true)
         .unwrap();
-    client_proxy_0.wait_for_transaction(sender_address, 2);
+    client_proxy_0
+        .wait_for_transaction(sender_address, 2)
+        .unwrap();
     assert!(compare_balances(
         vec![(80.0, "LBR".to_string())],
         client_proxy_0.get_balances(&["b", "0"]).unwrap()
@@ -755,8 +763,8 @@ fn test_external_transaction_signer() {
     );
     let receiver_auth_key = receiver_auth_key_opt.unwrap();
     let amount = 1_000_000;
-    let gas_unit_price = 123;
-    let max_gas_amount = 1000;
+    let gas_unit_price = 1;
+    let max_gas_amount = 1000000;
 
     // mint to the sender address
     client_proxy
@@ -876,7 +884,9 @@ fn test_full_node_basic_flow() {
 
     // ensure the client has up-to-date sequence number after test_smoke_script(3 minting)
     let sender_account = association_address();
-    full_node_client.wait_for_transaction(sender_account, 4);
+    full_node_client
+        .wait_for_transaction(sender_account, 4)
+        .unwrap();
     for idx in 0..3 {
         validator_ac_client.create_next_account(false).unwrap();
         full_node_client.create_next_account(false).unwrap();
@@ -915,7 +925,9 @@ fn test_full_node_basic_flow() {
     let sequence = full_node_client
         .get_sequence_number(&sequence_reset_command)
         .unwrap();
-    validator_ac_client.wait_for_transaction(sender_account, sequence);
+    validator_ac_client
+        .wait_for_transaction(sender_account, sequence)
+        .unwrap();
     assert!(compare_balances(
         vec![(10.0, "LBR".to_string())],
         validator_ac_client.get_balances(&["b", "3"]).unwrap()
@@ -940,7 +952,9 @@ fn test_full_node_basic_flow() {
     let sequence = validator_ac_client
         .get_sequence_number(&sequence_reset_command)
         .unwrap();
-    full_node_client.wait_for_transaction(sender_account, sequence);
+    full_node_client
+        .wait_for_transaction(sender_account, sequence)
+        .unwrap();
 
     assert!(compare_balances(
         vec![(10.0, "LBR".to_string())],
@@ -973,7 +987,9 @@ fn test_full_node_basic_flow() {
     let sequence = validator_ac_client
         .get_sequence_number(&["sequence", &format!("{}", account3), "true"])
         .unwrap();
-    full_node_client_2.wait_for_transaction(account3, sequence);
+    full_node_client_2
+        .wait_for_transaction(account3, sequence)
+        .unwrap();
     assert!(compare_balances(
         vec![(0.0, "LBR".to_string())],
         full_node_client_2.get_balances(&["b", "3"]).unwrap()
@@ -999,7 +1015,9 @@ fn test_e2e_reconfiguration() {
         client_proxy_1.get_balances(&["b", "0"]).unwrap()
     ));
     // wait for the mint txn in node 0
-    client_proxy_0.wait_for_transaction(association_address(), 2);
+    client_proxy_0
+        .wait_for_transaction(association_address(), 2)
+        .unwrap();
     assert!(compare_balances(
         vec![(10.0, "LBR".to_string())],
         client_proxy_0.get_balances(&["b", "0"]).unwrap()
@@ -1031,7 +1049,9 @@ fn test_e2e_reconfiguration() {
         .add_validator(&["add_validator", &peer_id], true)
         .unwrap();
     // Wait for it catches up, mint1 + remove + mint2 + add => seq == 5
-    client_proxy_0.wait_for_transaction(association_address(), 5);
+    client_proxy_0
+        .wait_for_transaction(association_address(), 5)
+        .unwrap();
     assert!(compare_balances(
         vec![(20.0, "LBR".to_string())],
         client_proxy_0.get_balances(&["b", "0"]).unwrap()
@@ -1196,7 +1216,7 @@ fn test_malformed_script() {
     // the script expects two arguments. Passing only one in the test, which will cause a failure.
     client_proxy
         .execute_script(&["execute", "0", &script_compiled_path[..], "10"])
-        .unwrap();
+        .expect_err("malformed script did not fail!");
 
     // Previous transaction should not choke the system.
     client_proxy

--- a/testsuite/tests/libratest/smoke_test.rs
+++ b/testsuite/tests/libratest/smoke_test.rs
@@ -764,7 +764,7 @@ fn test_external_transaction_signer() {
     let receiver_auth_key = receiver_auth_key_opt.unwrap();
     let amount = 1_000_000;
     let gas_unit_price = 1;
-    let max_gas_amount = 1000000;
+    let max_gas_amount = 1_000_000;
 
     // mint to the sender address
     client_proxy


### PR DESCRIPTION
The client code has not been checking the VM status to determine if transactions executed successfully. This changes to check for a status of EXECUTED and reports an error otherwise. This exposed an issue where the external_transaction_signer test in smoke_test.rs has been failing because it ran out of gas, so this also adjusts the gas parameters for that test to make it pass.

https://github.com/libra/libra/issues/3663

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

Ran existing tests and fixed the issues that were exposed