### PR TITLE
[move-prover] Enabling `signer` in move prover and unblocking prover tests.

### DIFF
--- a/language/move-prover/spec-lang/src/translate.rs
+++ b/language/move-prover/spec-lang/src/translate.rs
@@ -3077,6 +3077,9 @@ impl<'env, 'translator, 'module_translator> ExpTranslator<'env, 'translator, 'mo
                         "address" => {
                             return check_zero_args(self, Type::new_prim(PrimitiveType::Address))
                         }
+                        "signer" => {
+                            return check_zero_args(self, Type::new_prim(PrimitiveType::Signer))
+                        }
                         "type" => {
                             return check_zero_args(self, Type::new_prim(PrimitiveType::TypeValue))
                         }

--- a/language/move-prover/src/prelude.bpl
+++ b/language/move-prover/src/prelude.bpl
@@ -1123,6 +1123,17 @@ procedure {:inline 1} $Event_write_to_event_store(ta: TypeValue, guid: Value, co
 }
 
 // ==================================================================================
+// Native signer
+
+procedure {:inline 1} $Signer_borrow_address(signer: Value) returns (res: Value)
+    {{type_requires}} is#Address(signer);
+{
+    // A signer is currently identical to an address.
+    res := signer;
+}
+
+// TODO: implement the below methods
+// ==================================================================================
 // Native signature
 
 // TODO: implement the below methods


### PR DESCRIPTION
The type `signer` was already introduced before by the language team, but our type checker wasn't updated to actually recognize it, which broke our tests. Also the prelude did not had native function implementations for it.

For now `signer` is represented by its underlying address, so `address` and `signer` are identical on boogie level.

## Motivation

Unblock prover tests.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

Existing tests.

## Related PRs

NA
