### PR TITLE
[config] explicit getters for OnChainConfig

### DIFF
--- a/consensus/src/epoch_manager.rs
+++ b/consensus/src/epoch_manager.rs
@@ -369,7 +369,7 @@ impl<T: Payload> EpochManager<T> {
 
     pub async fn start_processor(&mut self, payload: OnChainConfigPayload) {
         let validator_set: ValidatorSet = payload
-            .get()
+            .validator_set()
             .expect("failed to get ValidatorSet from payload");
         let epoch_info = EpochInfo {
             epoch: payload.epoch(),

--- a/state-synchronizer/src/tests/on_chain_config_tests.rs
+++ b/state-synchronizer/src/tests/on_chain_config_tests.rs
@@ -137,7 +137,7 @@ fn test_on_chain_config_pub_sub() {
 
     let receive_reconfig = async {
         let payload = reconfig_receiver.select_next_some().await;
-        let received_config = payload.get::<VMConfig>().unwrap();
+        let received_config = payload.vm_config().unwrap();
         assert_eq!(received_config.publishing_option, vm_publishing_option);
     };
 

--- a/types/src/on_chain_config/mod.rs
+++ b/types/src/on_chain_config/mod.rs
@@ -50,10 +50,10 @@ impl ConfigID {
 
 /// State sync will panic if the value of any config in this registry is uninitialized
 pub const ON_CHAIN_CONFIG_REGISTRY: &[ConfigID] = &[
-    VMConfig::CONFIG_ID,
     LibraVersion::CONFIG_ID,
-    ValidatorSet::CONFIG_ID,
     RegisteredCurrencies::CONFIG_ID,
+    ValidatorSet::CONFIG_ID,
+    VMConfig::CONFIG_ID,
 ];
 
 #[derive(Clone, Debug, PartialEq)]
@@ -67,16 +67,37 @@ impl OnChainConfigPayload {
         Self { epoch, configs }
     }
 
+    /// Returns the configuration epoch.
     pub fn epoch(&self) -> u64 {
         self.epoch
     }
 
-    pub fn get<T: OnChainConfig>(&self) -> Result<T> {
+    fn get<T: OnChainConfig>(&self) -> Result<T> {
         let bytes = self
             .configs
             .get(&T::CONFIG_ID)
             .ok_or_else(|| format_err!("[on-chain cfg] config not in payload"))?;
         T::deserialize_into_config(bytes)
+    }
+
+    /// Returns the LibraVersion if it exists and an error otherwise.
+    pub fn libra_version(&self) -> Result<LibraVersion> {
+        self.get()
+    }
+
+    /// Returns the RegisteredCurrencies if it exists and an error otherwise.
+    pub fn registered_currencies(&self) -> Result<RegisteredCurrencies> {
+        self.get()
+    }
+
+    /// Returns the ValidatorSet if it exists and an error otherwise.
+    pub fn validator_set(&self) -> Result<ValidatorSet> {
+        self.get()
+    }
+
+    /// Returns the VMConfig if it exists and an error otherwise.
+    pub fn vm_config(&self) -> Result<VMConfig> {
+        self.get()
     }
 
     pub fn configs(&self) -> &HashMap<ConfigID, Vec<u8>> {

--- a/vm-validator/src/vm_validator.rs
+++ b/vm-validator/src/vm_validator.rs
@@ -1,16 +1,18 @@
 // Copyright (c) The Libra Core Contributors
 // SPDX-License-Identifier: Apache-2.0
 
+use std::{convert::TryFrom, sync::Arc};
+
 use anyhow::Result;
+
 use libra_types::{
     account_address::AccountAddress,
     account_config::AccountResource,
-    on_chain_config::{LibraVersion, OnChainConfigPayload, VMConfig},
+    on_chain_config::OnChainConfigPayload,
     transaction::{SignedTransaction, VMValidatorResult},
 };
 use libra_vm::LibraVM;
 use scratchpad::SparseMerkleTree;
-use std::{convert::TryFrom, sync::Arc};
 use storage_interface::{state_view::VerifiedStateView, DbReader};
 
 #[cfg(test)]
@@ -63,8 +65,8 @@ impl TransactionValidation for VMValidator {
     }
 
     fn restart(&mut self, config: OnChainConfigPayload) -> Result<()> {
-        let vm_config = config.get::<VMConfig>()?;
-        let version = config.get::<LibraVersion>()?;
+        let vm_config = config.vm_config()?;
+        let version = config.libra_version()?;
 
         self.vm = LibraVM::init_with_config(version, vm_config);
         Ok(())


### PR DESCRIPTION
<!--
Thank you for sending a PR. We appreciate you spending time to help improve the Libra project.

The project is undergoing daily changes. Pull Requests will be reviewed and responded to as time permits.
-->

## Motivation

This is a small PR intended to make the usage of OnChainConfig more readable and explicit.

The change itself makes the parameterized get<T> function private and replaces it with explicit getters for the four config types currently contained in the OnChainConfig.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?

Yes.

## Test Plan

(Share your test plan here. If you changed code, please provide us with clear instructions for verifying that your changes work.)

Cosmetic only change, ensure that existing tests continue to pass.

## Related PRs

(If this PR adds or changes functionality, please take some time to update the docs at https://github.com/libra/website, and link to your PR here.)
