### PR TITLE
[language] Make verifier aware of generic vs non generic instructions

### DIFF
--- a/language/bytecode-verifier/bytecode-verifier-tests/src/unit_tests/generic_ops_tests.rs
+++ b/language/bytecode-verifier/bytecode-verifier-tests/src/unit_tests/generic_ops_tests.rs
@@ -1,0 +1,738 @@
+// Copyright (c) The Libra Core Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+use bytecode_verifier::InstructionConsistency;
+use libra_types::vm_error::StatusCode;
+use move_core_types::{account_address::AccountAddress, identifier::Identifier};
+use vm::file_format::*;
+
+// Make a Module with 2 structs and 2 resources with one field each, and 2 functions.
+// One of the struct/resource and one of the function is generic, the other "normal".
+// Also make a test function whose body will be filled by given test cases.
+fn make_module() -> CompiledModuleMut {
+    CompiledModuleMut {
+        module_handles: vec![
+            // only self module
+            ModuleHandle {
+                address: AddressIdentifierIndex(0),
+                name: IdentifierIndex(0),
+            },
+        ],
+        self_module_handle_idx: ModuleHandleIndex(0),
+        identifiers: vec![
+            Identifier::new("M").unwrap(),       // Module name
+            Identifier::new("S").unwrap(),       // Struct name
+            Identifier::new("GS").unwrap(),      // Generic struct name
+            Identifier::new("R").unwrap(),       // Resource name
+            Identifier::new("GR").unwrap(),      // Generic resource name
+            Identifier::new("f").unwrap(),       // Field name
+            Identifier::new("fn").unwrap(),      // Function name
+            Identifier::new("g_fn").unwrap(),    // Generic function name
+            Identifier::new("test_fn").unwrap(), // Test function name
+        ],
+        address_identifiers: vec![
+            AccountAddress::default(), // Module address
+        ],
+        struct_handles: vec![
+            StructHandle {
+                module: ModuleHandleIndex(0),
+                name: IdentifierIndex(1),
+                is_nominal_resource: false,
+                type_parameters: vec![],
+            },
+            StructHandle {
+                module: ModuleHandleIndex(0),
+                name: IdentifierIndex(2),
+                is_nominal_resource: false,
+                type_parameters: vec![Kind::Copyable],
+            },
+            StructHandle {
+                module: ModuleHandleIndex(0),
+                name: IdentifierIndex(3),
+                is_nominal_resource: true,
+                type_parameters: vec![],
+            },
+            StructHandle {
+                module: ModuleHandleIndex(0),
+                name: IdentifierIndex(4),
+                is_nominal_resource: true,
+                type_parameters: vec![Kind::Copyable],
+            },
+        ],
+        struct_defs: vec![
+            // struct S { f: u64 }
+            StructDefinition {
+                struct_handle: StructHandleIndex(0),
+                field_information: StructFieldInformation::Declared(vec![FieldDefinition {
+                    name: IdentifierIndex(5),
+                    signature: TypeSignature(SignatureToken::U64),
+                }]),
+            },
+            // struct GS<T> { f: T }
+            StructDefinition {
+                struct_handle: StructHandleIndex(1),
+                field_information: StructFieldInformation::Declared(vec![FieldDefinition {
+                    name: IdentifierIndex(5),
+                    signature: TypeSignature(SignatureToken::TypeParameter(0)),
+                }]),
+            },
+            // resource R { f: u64 }
+            StructDefinition {
+                struct_handle: StructHandleIndex(2),
+                field_information: StructFieldInformation::Declared(vec![FieldDefinition {
+                    name: IdentifierIndex(5),
+                    signature: TypeSignature(SignatureToken::U64),
+                }]),
+            },
+            // resource GR<T> { f: T }
+            StructDefinition {
+                struct_handle: StructHandleIndex(3),
+                field_information: StructFieldInformation::Declared(vec![FieldDefinition {
+                    name: IdentifierIndex(5),
+                    signature: TypeSignature(SignatureToken::TypeParameter(0)),
+                }]),
+            },
+        ],
+        function_handles: vec![
+            // fun fn()
+            FunctionHandle {
+                module: ModuleHandleIndex(0),
+                name: IdentifierIndex(6),
+                parameters: SignatureIndex(0),
+                return_: SignatureIndex(0),
+                type_parameters: vec![],
+            },
+            // fun g_fn<T>()
+            FunctionHandle {
+                module: ModuleHandleIndex(0),
+                name: IdentifierIndex(7),
+                parameters: SignatureIndex(0),
+                return_: SignatureIndex(0),
+                type_parameters: vec![Kind::Resource],
+            },
+            // fun test_fn(Sender)
+            FunctionHandle {
+                module: ModuleHandleIndex(0),
+                name: IdentifierIndex(8),
+                parameters: SignatureIndex(1),
+                return_: SignatureIndex(0),
+                type_parameters: vec![],
+            },
+        ],
+        function_defs: vec![
+            // fun fn() { return; }
+            FunctionDefinition {
+                function: FunctionHandleIndex(0),
+                is_public: true,
+                acquires_global_resources: vec![],
+                code: Some(CodeUnit {
+                    locals: SignatureIndex(0),
+                    code: vec![Bytecode::Ret],
+                }),
+            },
+            // fun g_fn<T>() { return; }
+            FunctionDefinition {
+                function: FunctionHandleIndex(1),
+                is_public: false,
+                acquires_global_resources: vec![],
+                code: Some(CodeUnit {
+                    locals: SignatureIndex(0),
+                    code: vec![Bytecode::Ret],
+                }),
+            },
+            // fun test_fn() { ... } - tests will fill up the code
+            FunctionDefinition {
+                function: FunctionHandleIndex(2),
+                is_public: false,
+                acquires_global_resources: vec![],
+                code: Some(CodeUnit {
+                    locals: SignatureIndex(0),
+                    code: vec![],
+                }),
+            },
+        ],
+        signatures: vec![
+            Signature(vec![]),                       // void
+            Signature(vec![SignatureToken::Signer]), // Signer
+        ],
+        constant_pool: vec![
+            // an address
+            Constant {
+                type_: SignatureToken::Address,
+                data: AccountAddress::random().to_vec(),
+            },
+        ],
+        field_handles: vec![],
+        struct_def_instantiations: vec![],
+        function_instantiations: vec![],
+        field_instantiations: vec![],
+    }
+}
+
+#[test]
+fn generic_call_to_non_generic_func() {
+    let mut module = make_module();
+    // bogus `CallGeneric fn()`
+    module.function_defs[2].code = Some(CodeUnit {
+        locals: SignatureIndex(0),
+        code: vec![
+            Bytecode::CallGeneric(FunctionInstantiationIndex(0)),
+            Bytecode::Ret,
+        ],
+    });
+    module.function_instantiations.push(FunctionInstantiation {
+        handle: FunctionHandleIndex(0),
+        type_parameters: SignatureIndex(2),
+    });
+    module.signatures.push(Signature(vec![SignatureToken::U64]));
+    let err = InstructionConsistency::new(&module.freeze().expect("module must be valid"))
+        .verify()
+        .expect_err("CallGeneric to non generic function must fail");
+    assert_eq!(err.major_status, StatusCode::GENERIC_MEMBER_OPCODE_MISMATCH);
+}
+
+#[test]
+fn non_generic_call_to_generic_func() {
+    let mut module = make_module();
+    // bogus `Call g_fn<T>()`
+    module.function_defs[2].code = Some(CodeUnit {
+        locals: SignatureIndex(0),
+        code: vec![Bytecode::Call(FunctionHandleIndex(1)), Bytecode::Ret],
+    });
+    let err = InstructionConsistency::new(&module.freeze().expect("module must be valid"))
+        .verify()
+        .expect_err("Call to generic function must fail");
+    assert_eq!(err.major_status, StatusCode::GENERIC_MEMBER_OPCODE_MISMATCH);
+}
+
+#[test]
+fn generic_pack_on_non_generic_struct() {
+    let mut module = make_module();
+    // bogus `PackGeneric S`
+    module.function_defs[2].code = Some(CodeUnit {
+        locals: SignatureIndex(0),
+        code: vec![
+            Bytecode::LdU64(10),
+            Bytecode::PackGeneric(StructDefInstantiationIndex(0)),
+            Bytecode::Pop,
+            Bytecode::Ret,
+        ],
+    });
+    module
+        .struct_def_instantiations
+        .push(StructDefInstantiation {
+            def: StructDefinitionIndex(0),
+            type_parameters: SignatureIndex(2),
+        });
+    module.signatures.push(Signature(vec![SignatureToken::U64]));
+    let err = InstructionConsistency::new(&module.freeze().expect("module must be valid"))
+        .verify()
+        .expect_err("PackGeneric to non generic struct must fail");
+    assert_eq!(err.major_status, StatusCode::GENERIC_MEMBER_OPCODE_MISMATCH);
+}
+
+#[test]
+fn non_generic_pack_on_generic_struct() {
+    let mut module = make_module();
+    // bogus `Pack GS<T>`
+    module.function_defs[2].code = Some(CodeUnit {
+        locals: SignatureIndex(0),
+        code: vec![
+            Bytecode::LdU64(10),
+            Bytecode::Pack(StructDefinitionIndex(1)),
+            Bytecode::Pop,
+            Bytecode::Ret,
+        ],
+    });
+    let err = InstructionConsistency::new(&module.freeze().expect("module must be valid"))
+        .verify()
+        .expect_err("Pack to generic struct must fail");
+    assert_eq!(err.major_status, StatusCode::GENERIC_MEMBER_OPCODE_MISMATCH);
+}
+
+#[test]
+fn generic_unpack_on_non_generic_struct() {
+    let mut module = make_module();
+    // bogus `UnpackGeneric S`
+    module.function_defs[2].code = Some(CodeUnit {
+        locals: SignatureIndex(0),
+        code: vec![
+            Bytecode::LdU64(10),
+            Bytecode::Pack(StructDefinitionIndex(0)),
+            Bytecode::UnpackGeneric(StructDefInstantiationIndex(0)),
+            Bytecode::Pop,
+            Bytecode::Ret,
+        ],
+    });
+    module
+        .struct_def_instantiations
+        .push(StructDefInstantiation {
+            def: StructDefinitionIndex(0),
+            type_parameters: SignatureIndex(2),
+        });
+    module.signatures.push(Signature(vec![SignatureToken::U64]));
+    let err = InstructionConsistency::new(&module.freeze().expect("module must be valid"))
+        .verify()
+        .expect_err("UnpackGeneric to non generic struct must fail");
+    assert_eq!(err.major_status, StatusCode::GENERIC_MEMBER_OPCODE_MISMATCH);
+}
+
+#[test]
+fn non_generic_unpack_on_generic_struct() {
+    let mut module = make_module();
+    // bogus `Unpack GS<T>`
+    module.function_defs[2].code = Some(CodeUnit {
+        locals: SignatureIndex(0),
+        code: vec![
+            Bytecode::LdU64(10),
+            Bytecode::PackGeneric(StructDefInstantiationIndex(0)),
+            Bytecode::Unpack(StructDefinitionIndex(1)),
+            Bytecode::Pop,
+            Bytecode::Ret,
+        ],
+    });
+    module
+        .struct_def_instantiations
+        .push(StructDefInstantiation {
+            def: StructDefinitionIndex(1),
+            type_parameters: SignatureIndex(2),
+        });
+    module.signatures.push(Signature(vec![SignatureToken::U64]));
+    let err = InstructionConsistency::new(&module.freeze().expect("module must be valid"))
+        .verify()
+        .expect_err("Unpack to generic struct must fail");
+    assert_eq!(err.major_status, StatusCode::GENERIC_MEMBER_OPCODE_MISMATCH);
+}
+
+#[test]
+fn generic_mut_borrow_field_on_non_generic_struct() {
+    let mut module = make_module();
+    // bogus `MutBorrowFieldGeneric S.t`
+    module.function_defs[2].code = Some(CodeUnit {
+        locals: SignatureIndex(0),
+        code: vec![
+            Bytecode::LdU64(10),
+            Bytecode::Pack(StructDefinitionIndex(0)),
+            Bytecode::MutBorrowFieldGeneric(FieldInstantiationIndex(0)),
+            Bytecode::Pop,
+            Bytecode::Ret,
+        ],
+    });
+    module.field_instantiations.push(FieldInstantiation {
+        handle: FieldHandleIndex(0),
+        type_parameters: SignatureIndex(2),
+    });
+    module.field_handles.push(FieldHandle {
+        owner: StructDefinitionIndex(0),
+        field: 0,
+    });
+    module.signatures.push(Signature(vec![SignatureToken::U64]));
+    let err = InstructionConsistency::new(&module.freeze().expect("module must be valid"))
+        .verify()
+        .expect_err("MutBorrowFieldGeneric to non generic struct must fail");
+    assert_eq!(err.major_status, StatusCode::GENERIC_MEMBER_OPCODE_MISMATCH);
+}
+
+#[test]
+fn non_generic_mut_borrow_field_on_generic_struct() {
+    let mut module = make_module();
+    // bogus `MutBorrowField GS<T>.f`
+    module.function_defs[2].code = Some(CodeUnit {
+        locals: SignatureIndex(0),
+        code: vec![
+            Bytecode::LdU64(10),
+            Bytecode::PackGeneric(StructDefInstantiationIndex(0)),
+            Bytecode::MutBorrowField(FieldHandleIndex(0)),
+            Bytecode::Pop,
+            Bytecode::Ret,
+        ],
+    });
+    module
+        .struct_def_instantiations
+        .push(StructDefInstantiation {
+            def: StructDefinitionIndex(1),
+            type_parameters: SignatureIndex(2),
+        });
+    module.field_handles.push(FieldHandle {
+        owner: StructDefinitionIndex(1),
+        field: 0,
+    });
+    module.signatures.push(Signature(vec![SignatureToken::U64]));
+    let err = InstructionConsistency::new(&module.freeze().expect("module must be valid"))
+        .verify()
+        .expect_err("MutBorrowField to generic struct must fail");
+    assert_eq!(err.major_status, StatusCode::GENERIC_MEMBER_OPCODE_MISMATCH);
+}
+
+#[test]
+fn generic_borrow_field_on_non_generic_struct() {
+    let mut module = make_module();
+    // bogus `ImmBorrowFieldGeneric S.f`
+    module.function_defs[2].code = Some(CodeUnit {
+        locals: SignatureIndex(0),
+        code: vec![
+            Bytecode::LdU64(10),
+            Bytecode::Pack(StructDefinitionIndex(0)),
+            Bytecode::ImmBorrowFieldGeneric(FieldInstantiationIndex(0)),
+            Bytecode::Pop,
+            Bytecode::Ret,
+        ],
+    });
+    module.field_instantiations.push(FieldInstantiation {
+        handle: FieldHandleIndex(0),
+        type_parameters: SignatureIndex(2),
+    });
+    module.field_handles.push(FieldHandle {
+        owner: StructDefinitionIndex(0),
+        field: 0,
+    });
+    module.signatures.push(Signature(vec![SignatureToken::U64]));
+    let err = InstructionConsistency::new(&module.freeze().expect("module must be valid"))
+        .verify()
+        .expect_err("ImmBorrowFieldGeneric to non generic struct must fail");
+    assert_eq!(err.major_status, StatusCode::GENERIC_MEMBER_OPCODE_MISMATCH);
+}
+
+#[test]
+fn non_generic_borrow_field_on_generic_struct() {
+    let mut module = make_module();
+    // bogus `ImmBorrowField GS<T>.f`
+    module.function_defs[2].code = Some(CodeUnit {
+        locals: SignatureIndex(0),
+        code: vec![
+            Bytecode::LdU64(10),
+            Bytecode::PackGeneric(StructDefInstantiationIndex(0)),
+            Bytecode::ImmBorrowField(FieldHandleIndex(0)),
+            Bytecode::Pop,
+            Bytecode::Ret,
+        ],
+    });
+    module
+        .struct_def_instantiations
+        .push(StructDefInstantiation {
+            def: StructDefinitionIndex(1),
+            type_parameters: SignatureIndex(2),
+        });
+    module.field_handles.push(FieldHandle {
+        owner: StructDefinitionIndex(1),
+        field: 0,
+    });
+    module.signatures.push(Signature(vec![SignatureToken::U64]));
+    let err = InstructionConsistency::new(&module.freeze().expect("module must be valid"))
+        .verify()
+        .expect_err("ImmBorrowField to generic struct must fail");
+    assert_eq!(err.major_status, StatusCode::GENERIC_MEMBER_OPCODE_MISMATCH);
+}
+
+#[test]
+fn generic_mut_borrow_global_to_non_generic_struct() {
+    let mut module = make_module();
+    // bogus `MutBorrowGlobalGeneric R`
+    module.function_defs[2]
+        .acquires_global_resources
+        .push(StructDefinitionIndex(2));
+    module.function_defs[2].code = Some(CodeUnit {
+        locals: SignatureIndex(0),
+        code: vec![
+            Bytecode::LdConst(ConstantPoolIndex(0)),
+            Bytecode::MutBorrowGlobalGeneric(StructDefInstantiationIndex(0)),
+            Bytecode::Pop,
+            Bytecode::Ret,
+        ],
+    });
+    module
+        .struct_def_instantiations
+        .push(StructDefInstantiation {
+            def: StructDefinitionIndex(2),
+            type_parameters: SignatureIndex(2),
+        });
+    module.signatures.push(Signature(vec![SignatureToken::U64]));
+    let err = InstructionConsistency::new(&module.freeze().expect("module must be valid"))
+        .verify()
+        .expect_err("MutBorrowGlobalGeneric to non generic function must fail");
+    assert_eq!(err.major_status, StatusCode::GENERIC_MEMBER_OPCODE_MISMATCH);
+}
+
+#[test]
+fn non_generic_mut_borrow_global_to_generic_struct() {
+    let mut module = make_module();
+    // bogus `MutBorrowGlobal GR<T>`
+    module.function_defs[2]
+        .acquires_global_resources
+        .push(StructDefinitionIndex(3));
+    module.function_defs[2].code = Some(CodeUnit {
+        locals: SignatureIndex(0),
+        code: vec![
+            Bytecode::LdConst(ConstantPoolIndex(0)),
+            Bytecode::MutBorrowGlobal(StructDefinitionIndex(3)),
+            Bytecode::Pop,
+            Bytecode::Ret,
+        ],
+    });
+    let err = InstructionConsistency::new(&module.freeze().expect("module must be valid"))
+        .verify()
+        .expect_err("MutBorrowGlobal to generic function must fail");
+    assert_eq!(err.major_status, StatusCode::GENERIC_MEMBER_OPCODE_MISMATCH);
+}
+
+#[test]
+fn generic_immut_borrow_global_to_non_generic_struct() {
+    let mut module = make_module();
+    // bogus `ImmBorrowGlobalGeneric R`
+    module.function_defs[2]
+        .acquires_global_resources
+        .push(StructDefinitionIndex(2));
+    module.function_defs[2].code = Some(CodeUnit {
+        locals: SignatureIndex(0),
+        code: vec![
+            Bytecode::LdConst(ConstantPoolIndex(0)),
+            Bytecode::ImmBorrowGlobalGeneric(StructDefInstantiationIndex(0)),
+            Bytecode::Pop,
+            Bytecode::Ret,
+        ],
+    });
+    module
+        .struct_def_instantiations
+        .push(StructDefInstantiation {
+            def: StructDefinitionIndex(2),
+            type_parameters: SignatureIndex(2),
+        });
+    module.signatures.push(Signature(vec![SignatureToken::U64]));
+    let err = InstructionConsistency::new(&module.freeze().expect("module must be valid"))
+        .verify()
+        .expect_err("ImmBorrowGlobalGeneric to non generic function must fail");
+    assert_eq!(err.major_status, StatusCode::GENERIC_MEMBER_OPCODE_MISMATCH);
+}
+
+#[test]
+fn non_generic_immut_borrow_global_to_generic_struct() {
+    let mut module = make_module();
+    // bogus `ImmBorrowGlobal GR<T>`
+    module.function_defs[2]
+        .acquires_global_resources
+        .push(StructDefinitionIndex(3));
+    module.function_defs[2].code = Some(CodeUnit {
+        locals: SignatureIndex(0),
+        code: vec![
+            Bytecode::LdConst(ConstantPoolIndex(0)),
+            Bytecode::ImmBorrowGlobal(StructDefinitionIndex(3)),
+            Bytecode::Pop,
+            Bytecode::Ret,
+        ],
+    });
+    let err = InstructionConsistency::new(&module.freeze().expect("module must be valid"))
+        .verify()
+        .expect_err("ImmBorrowGlobal to generic function must fail");
+    assert_eq!(err.major_status, StatusCode::GENERIC_MEMBER_OPCODE_MISMATCH);
+}
+
+#[test]
+fn generic_exists_to_non_generic_struct() {
+    let mut module = make_module();
+    // bogus `ExistsGeneric R`
+    module.function_defs[2].code = Some(CodeUnit {
+        locals: SignatureIndex(0),
+        code: vec![
+            Bytecode::LdConst(ConstantPoolIndex(0)),
+            Bytecode::ExistsGeneric(StructDefInstantiationIndex(0)),
+            Bytecode::Pop,
+            Bytecode::Ret,
+        ],
+    });
+    module
+        .struct_def_instantiations
+        .push(StructDefInstantiation {
+            def: StructDefinitionIndex(2),
+            type_parameters: SignatureIndex(2),
+        });
+    module.signatures.push(Signature(vec![SignatureToken::U64]));
+    let err = InstructionConsistency::new(&module.freeze().expect("module must be valid"))
+        .verify()
+        .expect_err("ExistsGeneric to non generic function must fail");
+    assert_eq!(err.major_status, StatusCode::GENERIC_MEMBER_OPCODE_MISMATCH);
+}
+
+#[test]
+fn non_generic_exists_to_generic_struct() {
+    let mut module = make_module();
+    // bogus `Exists GR<T>`
+    module.function_defs[2].code = Some(CodeUnit {
+        locals: SignatureIndex(0),
+        code: vec![
+            Bytecode::LdConst(ConstantPoolIndex(0)),
+            Bytecode::Exists(StructDefinitionIndex(3)),
+            Bytecode::Pop,
+            Bytecode::Ret,
+        ],
+    });
+    let err = InstructionConsistency::new(&module.freeze().expect("module must be valid"))
+        .verify()
+        .expect_err("Exists to generic function must fail");
+    assert_eq!(err.major_status, StatusCode::GENERIC_MEMBER_OPCODE_MISMATCH);
+}
+
+#[test]
+fn generic_move_from_to_non_generic_struct() {
+    let mut module = make_module();
+    // bogus `MoveFromGeneric R`
+    module.function_defs[2]
+        .acquires_global_resources
+        .push(StructDefinitionIndex(2));
+    module.function_defs[2].code = Some(CodeUnit {
+        locals: SignatureIndex(0),
+        code: vec![
+            Bytecode::LdConst(ConstantPoolIndex(0)),
+            Bytecode::MoveFromGeneric(StructDefInstantiationIndex(0)),
+            Bytecode::Unpack(StructDefinitionIndex(2)),
+            Bytecode::Pop,
+            Bytecode::Ret,
+        ],
+    });
+    module
+        .struct_def_instantiations
+        .push(StructDefInstantiation {
+            def: StructDefinitionIndex(2),
+            type_parameters: SignatureIndex(2),
+        });
+    module.signatures.push(Signature(vec![SignatureToken::U64]));
+    let err = InstructionConsistency::new(&module.freeze().expect("module must be valid"))
+        .verify()
+        .expect_err("MoveFromGeneric to non generic function must fail");
+    assert_eq!(err.major_status, StatusCode::GENERIC_MEMBER_OPCODE_MISMATCH);
+}
+
+#[test]
+fn non_generic_move_from_to_generic_struct() {
+    let mut module = make_module();
+    // bogus `MoveFrom GR<T>`
+    module.function_defs[2]
+        .acquires_global_resources
+        .push(StructDefinitionIndex(3));
+    module.function_defs[2].code = Some(CodeUnit {
+        locals: SignatureIndex(0),
+        code: vec![
+            Bytecode::LdConst(ConstantPoolIndex(0)),
+            Bytecode::MoveFrom(StructDefinitionIndex(3)),
+            Bytecode::UnpackGeneric(StructDefInstantiationIndex(0)),
+            Bytecode::Pop,
+            Bytecode::Ret,
+        ],
+    });
+    module
+        .struct_def_instantiations
+        .push(StructDefInstantiation {
+            def: StructDefinitionIndex(3),
+            type_parameters: SignatureIndex(2),
+        });
+    module.signatures.push(Signature(vec![SignatureToken::U64]));
+    let err = InstructionConsistency::new(&module.freeze().expect("module must be valid"))
+        .verify()
+        .expect_err("MoveFrom to generic function must fail");
+    assert_eq!(err.major_status, StatusCode::GENERIC_MEMBER_OPCODE_MISMATCH);
+}
+
+#[test]
+fn generic_move_to_sender_on_non_generic_struct() {
+    let mut module = make_module();
+    // bogus `MoveToSenderGeneric R`
+    module.function_defs[2].code = Some(CodeUnit {
+        locals: SignatureIndex(0),
+        code: vec![
+            Bytecode::LdU64(10),
+            Bytecode::Pack(StructDefinitionIndex(2)),
+            Bytecode::MoveToSenderGeneric(StructDefInstantiationIndex(0)),
+            Bytecode::Ret,
+        ],
+    });
+    module
+        .struct_def_instantiations
+        .push(StructDefInstantiation {
+            def: StructDefinitionIndex(2),
+            type_parameters: SignatureIndex(2),
+        });
+    module.signatures.push(Signature(vec![SignatureToken::U64]));
+    let err = InstructionConsistency::new(&module.freeze().expect("module must be valid"))
+        .verify()
+        .expect_err("MoveToSenderGeneric to non generic struct must fail");
+    assert_eq!(err.major_status, StatusCode::GENERIC_MEMBER_OPCODE_MISMATCH);
+}
+
+#[test]
+fn non_generic_move_to_sender_on_generic_struct() {
+    let mut module = make_module();
+    // bogus `MoveToSender GR<T>`
+    module.function_defs[2].code = Some(CodeUnit {
+        locals: SignatureIndex(0),
+        code: vec![
+            Bytecode::LdU64(10),
+            Bytecode::PackGeneric(StructDefInstantiationIndex(0)),
+            Bytecode::MoveToSender(StructDefinitionIndex(3)),
+            Bytecode::Ret,
+        ],
+    });
+    module
+        .struct_def_instantiations
+        .push(StructDefInstantiation {
+            def: StructDefinitionIndex(3),
+            type_parameters: SignatureIndex(2),
+        });
+    module.signatures.push(Signature(vec![SignatureToken::U64]));
+    let err = InstructionConsistency::new(&module.freeze().expect("module must be valid"))
+        .verify()
+        .expect_err("MoveToSender to generic struct must fail");
+    assert_eq!(err.major_status, StatusCode::GENERIC_MEMBER_OPCODE_MISMATCH);
+}
+
+#[test]
+fn generic_move_to_on_non_generic_struct() {
+    let mut module = make_module();
+    // bogus `MoveToSenderGeneric R`
+    module.function_defs[2].code = Some(CodeUnit {
+        locals: SignatureIndex(0),
+        code: vec![
+            Bytecode::MoveLoc(0),
+            Bytecode::LdU64(10),
+            Bytecode::Pack(StructDefinitionIndex(2)),
+            Bytecode::MoveToGeneric(StructDefInstantiationIndex(0)),
+            Bytecode::Ret,
+        ],
+    });
+    module
+        .struct_def_instantiations
+        .push(StructDefInstantiation {
+            def: StructDefinitionIndex(2),
+            type_parameters: SignatureIndex(2),
+        });
+    module.signatures.push(Signature(vec![SignatureToken::U64]));
+    let err = InstructionConsistency::new(&module.freeze().expect("module must be valid"))
+        .verify()
+        .expect_err("MoveToGeneric to non generic struct must fail");
+    assert_eq!(err.major_status, StatusCode::GENERIC_MEMBER_OPCODE_MISMATCH);
+}
+
+#[test]
+fn non_generic_move_to_on_generic_struct() {
+    let mut module = make_module();
+    // bogus `MoveToSender GR<T>`
+    module.function_defs[2].code = Some(CodeUnit {
+        locals: SignatureIndex(0),
+        code: vec![
+            Bytecode::MoveLoc(0),
+            Bytecode::LdU64(10),
+            Bytecode::PackGeneric(StructDefInstantiationIndex(0)),
+            Bytecode::MoveTo(StructDefinitionIndex(3)),
+            Bytecode::Ret,
+        ],
+    });
+    module
+        .struct_def_instantiations
+        .push(StructDefInstantiation {
+            def: StructDefinitionIndex(3),
+            type_parameters: SignatureIndex(2),
+        });
+    module.signatures.push(Signature(vec![SignatureToken::U64]));
+    let err = InstructionConsistency::new(&module.freeze().expect("module must be valid"))
+        .verify()
+        .expect_err("MoveTo to generic struct must fail");
+    assert_eq!(err.major_status, StatusCode::GENERIC_MEMBER_OPCODE_MISMATCH);
+}

--- a/language/bytecode-verifier/bytecode-verifier-tests/src/unit_tests/mod.rs
+++ b/language/bytecode-verifier/bytecode-verifier-tests/src/unit_tests/mod.rs
@@ -6,6 +6,7 @@ pub mod code_unit_tests;
 pub mod constants_tests;
 pub mod control_flow_tests;
 pub mod duplication_tests;
+pub mod generic_ops_tests;
 pub mod negative_stack_size_tests;
 pub mod resources_tests;
 pub mod signature_tests;

--- a/language/bytecode-verifier/src/instruction_consistency.rs
+++ b/language/bytecode-verifier/src/instruction_consistency.rs
@@ -1,0 +1,170 @@
+// Copyright (c) The Libra Core Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+//! This module defines the transfer functions for verifying type safety of a procedure body.
+//! It does not utilize control flow, but does check each block independently
+
+use libra_types::vm_error::StatusCode;
+use vm::{
+    access::ModuleAccess,
+    errors::{err_at_offset, VMResult},
+    file_format::{
+        Bytecode, CodeUnit, CompiledModule, FieldHandleIndex, FunctionHandleIndex,
+        StructDefinitionIndex,
+    },
+};
+
+pub struct InstructionConsistency<'a> {
+    module: &'a CompiledModule,
+}
+
+impl<'a> InstructionConsistency<'a> {
+    pub fn new(module: &'a CompiledModule) -> Self {
+        Self { module }
+    }
+
+    pub fn verify(self) -> VMResult<()> {
+        for func_def in self.module.function_defs() {
+            match &func_def.code {
+                None => (),
+                Some(code) => self.check_instructions(code)?,
+            }
+        }
+        Ok(())
+    }
+
+    fn check_instructions(&self, code: &CodeUnit) -> VMResult<()> {
+        for (offset, instr) in code.code.iter().enumerate() {
+            match instr {
+                Bytecode::MutBorrowField(field_handle_index) => {
+                    self.check_field_op(offset, *field_handle_index, /* generic */ false)?;
+                }
+                Bytecode::MutBorrowFieldGeneric(field_inst_index) => {
+                    let field_inst = self.module.field_instantiation_at(*field_inst_index);
+                    self.check_field_op(offset, field_inst.handle, /* generic */ true)?;
+                }
+                Bytecode::ImmBorrowField(field_handle_index) => {
+                    self.check_field_op(offset, *field_handle_index, /* generic */ false)?;
+                }
+                Bytecode::ImmBorrowFieldGeneric(field_inst_index) => {
+                    let field_inst = self.module.field_instantiation_at(*field_inst_index);
+                    self.check_field_op(offset, field_inst.handle, /* non_ */ true)?;
+                }
+                Bytecode::Call(idx) => {
+                    self.check_function_op(offset, *idx, /* generic */ false)?;
+                }
+                Bytecode::CallGeneric(idx) => {
+                    let func_inst = self.module.function_instantiation_at(*idx);
+                    self.check_function_op(offset, func_inst.handle, /* generic */ true)?;
+                }
+                Bytecode::Pack(idx) => {
+                    self.check_type_op(offset, *idx, /* generic */ false)?;
+                }
+                Bytecode::PackGeneric(idx) => {
+                    let struct_inst = self.module.struct_instantiation_at(*idx);
+                    self.check_type_op(offset, struct_inst.def, /* generic */ true)?;
+                }
+                Bytecode::Unpack(idx) => {
+                    self.check_type_op(offset, *idx, /* generic */ false)?;
+                }
+                Bytecode::UnpackGeneric(idx) => {
+                    let struct_inst = self.module.struct_instantiation_at(*idx);
+                    self.check_type_op(offset, struct_inst.def, /* generic */ true)?;
+                }
+                Bytecode::MutBorrowGlobal(idx) => {
+                    self.check_type_op(offset, *idx, /* generic */ false)?;
+                }
+                Bytecode::MutBorrowGlobalGeneric(idx) => {
+                    let struct_inst = self.module.struct_instantiation_at(*idx);
+                    self.check_type_op(offset, struct_inst.def, /* generic */ true)?;
+                }
+                Bytecode::ImmBorrowGlobal(idx) => {
+                    self.check_type_op(offset, *idx, /* generic */ false)?;
+                }
+                Bytecode::ImmBorrowGlobalGeneric(idx) => {
+                    let struct_inst = self.module.struct_instantiation_at(*idx);
+                    self.check_type_op(offset, struct_inst.def, /* generic */ true)?;
+                }
+                Bytecode::Exists(idx) => {
+                    self.check_type_op(offset, *idx, /* generic */ false)?;
+                }
+                Bytecode::ExistsGeneric(idx) => {
+                    let struct_inst = self.module.struct_instantiation_at(*idx);
+                    self.check_type_op(offset, struct_inst.def, /* generic */ true)?;
+                }
+                Bytecode::MoveFrom(idx) => {
+                    self.check_type_op(offset, *idx, /* generic */ false)?;
+                }
+                Bytecode::MoveFromGeneric(idx) => {
+                    let struct_inst = self.module.struct_instantiation_at(*idx);
+                    self.check_type_op(offset, struct_inst.def, /* generic */ true)?;
+                }
+                Bytecode::MoveToSender(idx) => {
+                    self.check_type_op(offset, *idx, /* generic */ false)?;
+                }
+                Bytecode::MoveToSenderGeneric(idx) => {
+                    let struct_inst = self.module.struct_instantiation_at(*idx);
+                    self.check_type_op(offset, struct_inst.def, /* generic */ true)?;
+                }
+                Bytecode::MoveTo(idx) => {
+                    self.check_type_op(offset, *idx, /* generic */ false)?;
+                }
+                Bytecode::MoveToGeneric(idx) => {
+                    let struct_inst = self.module.struct_instantiation_at(*idx);
+                    self.check_type_op(offset, struct_inst.def, /* generic */ true)?;
+                }
+                _ => (),
+            }
+        }
+        Ok(())
+    }
+
+    //
+    // Helpers for instructions that come in a generic and non generic form.
+    // Verifies the generic form uses a generic member and the non generic form
+    // a non generic one.
+    //
+
+    fn check_field_op(
+        &self,
+        offset: usize,
+        field_handle_index: FieldHandleIndex,
+        generic: bool,
+    ) -> VMResult<()> {
+        let field_handle = self.module.field_handle_at(field_handle_index);
+        self.check_type_op(offset, field_handle.owner, generic)
+    }
+
+    fn check_type_op(
+        &self,
+        offset: usize,
+        struct_def_index: StructDefinitionIndex,
+        generic: bool,
+    ) -> VMResult<()> {
+        let struct_def = self.module.struct_def_at(struct_def_index);
+        let struct_handle = self.module.struct_handle_at(struct_def.struct_handle);
+        if struct_handle.type_parameters.is_empty() == generic {
+            return Err(err_at_offset(
+                StatusCode::GENERIC_MEMBER_OPCODE_MISMATCH,
+                offset,
+            ));
+        }
+        Ok(())
+    }
+
+    fn check_function_op(
+        &self,
+        offset: usize,
+        func_handle_index: FunctionHandleIndex,
+        generic: bool,
+    ) -> VMResult<()> {
+        let function_handle = self.module.function_handle_at(func_handle_index);
+        if function_handle.type_parameters.is_empty() == generic {
+            return Err(err_at_offset(
+                StatusCode::GENERIC_MEMBER_OPCODE_MISMATCH,
+                offset,
+            ));
+        }
+        Ok(())
+    }
+}

--- a/language/bytecode-verifier/src/lib.rs
+++ b/language/bytecode-verifier/src/lib.rs
@@ -14,6 +14,7 @@ pub mod constants;
 pub mod control_flow;
 pub mod control_flow_graph;
 pub mod instantiation_loops;
+pub mod instruction_consistency;
 pub mod locals_safety;
 pub mod reference_safety;
 pub mod resolver;
@@ -28,6 +29,7 @@ pub mod verifier;
 
 pub use check_duplication::DuplicationChecker;
 pub use code_unit_verifier::CodeUnitVerifier;
+pub use instruction_consistency::InstructionConsistency;
 pub use resources::ResourceTransitiveChecker;
 pub use signature::SignatureChecker;
 pub use stack_usage_verifier::StackUsageVerifier;

--- a/language/bytecode-verifier/src/verifier.rs
+++ b/language/bytecode-verifier/src/verifier.rs
@@ -4,7 +4,8 @@
 //! This module contains the public APIs supported by the bytecode verifier.
 use crate::{
     check_duplication::DuplicationChecker, code_unit_verifier::CodeUnitVerifier,
-    constants::ConstantsChecker, instantiation_loops::InstantiationLoopChecker, resolver::Resolver,
+    constants::ConstantsChecker, instantiation_loops::InstantiationLoopChecker,
+    instruction_consistency::InstructionConsistency, resolver::Resolver,
     resources::ResourceTransitiveChecker, signature::SignatureChecker,
     struct_defs::RecursiveStructDefChecker,
 };
@@ -77,6 +78,7 @@ impl VerifiedModule {
 fn verify_module(module: &CompiledModule) -> VMResult<()> {
     DuplicationChecker::new(&module).verify()?;
     SignatureChecker::new(&module).verify()?;
+    InstructionConsistency::new(&module).verify()?;
     ResourceTransitiveChecker::new(&module).verify()?;
     ConstantsChecker::new(&module).verify()?;
     RecursiveStructDefChecker::new(&module).verify()?;

--- a/language/ir-testsuite/tests/epilogue/cant_call_epilogue_in_transaction.mvir
+++ b/language/ir-testsuite/tests/epilogue/cant_call_epilogue_in_transaction.mvir
@@ -1,7 +1,8 @@
 import 0x0.LibraAccount;
+import 0x0.Coin1;
 
 main() {
-    LibraAccount.epilogue(0, 0, 0, 0);
+    LibraAccount.epilogue<Coin1.T>(0, 0, 0, 0);
     return;
 }
 

--- a/types/src/vm_error.rs
+++ b/types/src/vm_error.rs
@@ -355,6 +355,7 @@ pub enum StatusCode {
     TOO_MANY_LOCALS = 1089,
     MOVETO_TYPE_MISMATCH_ERROR = 1090,
     MOVETO_NO_RESOURCE_ERROR = 1091,
+    GENERIC_MEMBER_OPCODE_MISMATCH = 1092,
 
     // These are errors that the VM might raise if a violation of internal
     // invariants takes place.


### PR DESCRIPTION
This is a fix for issue #3893.
The verifier never checked for generic instructions correctly referring
to generic member and non generic ones referring to non generic members.
This fix it by adding that check in the type safety pass.
It is not clear that is the best pass to check for this property and
maybe a single pass for generic or something similar may be a better
choice. We will find out in time...

It's interesting that calling a generic with the non generic form crashed the verifier, while calling a non generic with the generic form worked just fine!!! Not sure which was more messed up...