### PR TITLE
Network/connectivity

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -896,6 +896,7 @@ dependencies = [
  "libra-logger 0.1.0",
  "libra-mempool 0.1.0",
  "libra-metrics 0.1.0",
+ "libra-network-address 0.1.0",
  "libra-secure-storage 0.1.0",
  "libra-security-logger 0.1.0",
  "libra-temppath 0.1.0",

--- a/consensus/Cargo.toml
+++ b/consensus/Cargo.toml
@@ -40,6 +40,7 @@ libra-crypto = { path = "../crypto/crypto", version = "0.1.0" }
 libra-logger = { path = "../common/logger", version = "0.1.0" }
 libra-mempool = { path = "../mempool", version = "0.1.0" }
 libra-metrics = { path = "../common/metrics", version = "0.1.0" }
+libra-network-address = { path = "../network/network-address", version = "0.1.0"}
 libra-secure-storage = { path = "../secure/storage", version = "0.1.0" }
 libra-security-logger = { path = "../common/security-logger", version = "0.1.0" }
 libra-temppath = { path = "../common/temppath", version = "0.1.0" }

--- a/network/onchain-discovery/src/client.rs
+++ b/network/onchain-discovery/src/client.rs
@@ -338,7 +338,8 @@ where
                                 addrs.push(addr);
                             }
                         }
-
+// TODO:  This is the UpdateAddress that I cannot conver to UpdateConfiguration because the eligible peers are not available.
+                        // It could easily be consolidated into a UpdateGroupAddresses, however.
                         Some(ConnectivityRequest::UpdateAddresses(
                             DiscoverySource::OnChain,
                             peer_id,

--- a/network/onchain-discovery/src/client.rs
+++ b/network/onchain-discovery/src/client.rs
@@ -317,6 +317,7 @@ where
         // advertising new addresses. In an effort to maintain
         // connectivity, we will also merge in the previous advertised
         // addresses.
+        let change_detected = false;
         let update_addr_reqs = latest_discovery_set
             .0
             .into_iter()


### PR DESCRIPTION
<!--
Thank you for sending a PR. We appreciate you spending time to help improve the Libra project.

The project is undergoing daily changes. Pull Requests will be reviewed and responded to as time permits.
-->

## Motivation

NOT FOR SUBMISSION

This PR is an effort to consolidate the ConnectivityManager updates into one _UpdateConfiguration_ request as opposed to the current two _UpdateAddresses_ and _UpdateEligiblePeers_.


While this PR largely shows that it is mostly feasible, it highlights a couple of difficulties with the approach:

1).  Currently, different sources update only addresses or only peers.  It is no immediately obvious if this is an accident of implementation or fundamental to the design.
2).  the current configuration objects sometimes contain information about only validators, sometimes only full_nodes, and sometimes both.  Appropriately tracking that context is tricky at best.

*Takeaways:*
0) I do not think this approach is promising
1)  consolidating UpdateAddresses and UpdateEligiblePeers into a single Meta-Update appears to be very challenging and may be undesirable from a logical/safety perspective.
2)   Replacing `UpdateAddresses(peerId, vec<address>)` with `UpdateAddresses(map<peerId, vec<addresses>)` appears to be a very sensible step.



### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?

(Write your answer here.)

## Test Plan

(Share your test plan here. If you changed code, please provide us with clear instructions for verifying that your changes work.)

## Related PRs

(If this PR adds or changes functionality, please take some time to update the docs at https://github.com/libra/website, and link to your PR here.)
