### PR TITLE
abstraction above the file system for the compiler.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3235,6 +3235,7 @@ dependencies = [
  "libra-canonical-serialization 0.1.0",
  "libra-crypto 0.1.0",
  "libra-crypto-derive 0.1.0",
+ "libra-temppath 0.1.0",
  "libra-workspace-hack 0.1.0",
  "mirai-annotations 1.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "once_cell 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -3246,6 +3247,7 @@ dependencies = [
  "serde 1.0.110 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.53 (registry+https://github.com/rust-lang/crates.io-index)",
  "thiserror 1.0.19 (registry+https://github.com/rust-lang/crates.io-index)",
+ "walkdir 2.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -3299,13 +3301,13 @@ dependencies = [
  "libra-canonical-serialization 0.1.0",
  "libra-types 0.1.0",
  "libra-workspace-hack 0.1.0",
+ "move-core-types 0.1.0",
  "move-ir-types 0.1.0",
  "petgraph 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand 0.7.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "regex 1.3.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "structopt 0.3.14 (registry+https://github.com/rust-lang/crates.io-index)",
- "tempfile 3.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "vm 0.1.0",
- "walkdir 2.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -3325,6 +3327,7 @@ dependencies = [
  "libra-types 0.1.0",
  "libra-workspace-hack 0.1.0",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "move-core-types 0.1.0",
  "move-ir-types 0.1.0",
  "move-lang 0.0.1",
  "num 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -5205,6 +5208,7 @@ dependencies = [
  "libra-types 0.1.0",
  "libra-workspace-hack 0.1.0",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "move-core-types 0.1.0",
  "move-lang 0.0.1",
  "move-prover 0.1.0",
  "once_cell 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/language/benchmarks/src/move_vm.rs
+++ b/language/benchmarks/src/move_vm.rs
@@ -8,6 +8,7 @@ use libra_state_view::StateView;
 use libra_types::{access_path::AccessPath, account_address::AccountAddress};
 use libra_vm::data_cache::StateViewCache;
 use move_core_types::{
+    fs::AFS,
     gas_schedule::{GasAlgebra, GasUnits},
     identifier::{IdentStr, Identifier},
     language_storage::ModuleId,
@@ -30,12 +31,10 @@ pub fn bench(c: &mut Criterion, fun: &str) {
 // Compile `bench.move`
 fn compile_module() -> VerifiedModule {
     // TODO: this has only been tried with `cargo bench` from `libra/src/language/benchmarks`
-    let mut path = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
-    path.push("src/bench.move");
-    let s = path.to_str().expect("no path specified").to_owned();
-
-    let (_, mut modules) =
-        move_lang::move_compile(&[s], &[], Some(Address::default())).expect("Error compiling...");
+    let fs = AFS::with_path(PathBuf::from(env!("CARGO_MANIFEST_DIR")));
+    let s = "src/bench.move".to_owned();
+    let (_, mut modules) = move_lang::move_compile(&[s], &[], Some(Address::default()), &fs)
+        .expect("Error compiling...");
     match modules.remove(0) {
         CompiledUnit::Module { module, .. } => {
             VerifiedModule::new(module).expect("Cannot verify code in file")

--- a/language/compiler/bytecode-source-map/src/utils.rs
+++ b/language/compiler/bytecode-source-map/src/utils.rs
@@ -12,9 +12,10 @@ use codespan_reporting::{
         Config,
     },
 };
+use move_core_types::fs::FileName;
 use move_ir_types::location::Loc;
 use serde::{de::DeserializeOwned, Deserialize, Serialize};
-use std::{collections::HashMap, fs::File, io::Read, path::Path};
+use std::{fs::File, io::Read, path::Path};
 
 pub type Error = (Loc, String);
 pub type Errors = Vec<Error>;
@@ -64,13 +65,9 @@ pub struct OwnedLoc {
 }
 
 pub fn remap_owned_loc_to_loc(m: SourceMap<OwnedLoc>) -> SourceMap<Loc> {
-    let mut table: HashMap<String, &'static str> = HashMap::new();
     let mut f = |owned| {
         let OwnedLoc { file, span } = owned;
-        let file = *table
-            .entry(file.clone())
-            .or_insert_with(|| Box::leak(Box::new(file)));
-        Loc::new(file, span)
+        Loc::new(FileName::new(&file), span)
     };
     m.remap_locations(&mut f)
 }

--- a/language/compiler/ir-to-bytecode/src/parser.rs
+++ b/language/compiler/ir-to-bytecode/src/parser.rs
@@ -13,6 +13,7 @@ use codespan_reporting::{
 };
 use ir_to_bytecode_syntax::syntax::{self, ParseError};
 use libra_types::account_address::AccountAddress;
+use move_core_types::fs::AFS;
 use move_ir_types::{ast, location::*};
 
 /// Determine if a character is an allowed eye-visible (printable) character.
@@ -85,6 +86,7 @@ fn strip_comments_and_verify(string: &str) -> Result<String> {
 /// Given the raw input of a file, creates a `ScriptOrModule` enum
 /// Fails with `Err(_)` if the text cannot be parsed`
 pub fn parse_script_or_module(file_name: &str, s: &str) -> Result<ast::ScriptOrModule> {
+    let _fs = AFS::in_memory();
     let stripped_string = &strip_comments_and_verify(s)?;
     syntax::parse_script_or_module_string(file_name, stripped_string)
         .or_else(|e| handle_error(e, s))
@@ -93,6 +95,7 @@ pub fn parse_script_or_module(file_name: &str, s: &str) -> Result<ast::ScriptOrM
 /// Given the raw input of a file, creates a `Script` struct
 /// Fails with `Err(_)` if the text cannot be parsed
 pub fn parse_script(file_name: &str, script_str: &str) -> Result<ast::Script> {
+    let _fs = AFS::in_memory();
     let stripped_string = &strip_comments_and_verify(script_str)?;
     syntax::parse_script_string(file_name, stripped_string)
         .or_else(|e| handle_error(e, stripped_string))
@@ -101,6 +104,7 @@ pub fn parse_script(file_name: &str, script_str: &str) -> Result<ast::Script> {
 /// Given the raw input of a file, creates a single `ModuleDefinition` struct
 /// Fails with `Err(_)` if the text cannot be parsed
 pub fn parse_module(file_name: &str, modules_str: &str) -> Result<ast::ModuleDefinition> {
+    let _fs = AFS::in_memory();
     let stripped_string = &strip_comments_and_verify(modules_str)?;
     syntax::parse_module_string(file_name, stripped_string)
         .or_else(|e| handle_error(e, stripped_string))

--- a/language/compiler/ir-to-bytecode/syntax/src/lexer.rs
+++ b/language/compiler/ir-to-bytecode/syntax/src/lexer.rs
@@ -3,6 +3,7 @@
 
 use crate::syntax::ParseError;
 use codespan::{ByteIndex, Span};
+use move_core_types::fs::FileName;
 use move_ir_types::location::*;
 
 #[derive(Copy, Clone, Debug, PartialEq, Eq, PartialOrd, Ord)]
@@ -128,7 +129,7 @@ impl Tok {
 
 pub struct Lexer<'input> {
     pub spec_mode: bool,
-    file: &'static str,
+    file: FileName,
     text: &'input str,
     prev_end: usize,
     cur_start: usize,
@@ -137,7 +138,7 @@ pub struct Lexer<'input> {
 }
 
 impl<'input> Lexer<'input> {
-    pub fn new(file: &'static str, s: &'input str) -> Lexer<'input> {
+    pub fn new(file: FileName, s: &'input str) -> Lexer<'input> {
         Lexer {
             spec_mode: false, // read tokens without trailing punctuation during specs.
             file,
@@ -157,7 +158,7 @@ impl<'input> Lexer<'input> {
         &self.text[self.cur_start..self.cur_end]
     }
 
-    pub fn file_name(&self) -> &'static str {
+    pub fn file_name(&self) -> FileName {
         self.file
     }
 

--- a/language/compiler/ir-to-bytecode/syntax/src/syntax.rs
+++ b/language/compiler/ir-to-bytecode/syntax/src/syntax.rs
@@ -7,7 +7,10 @@ use std::{fmt, str::FromStr};
 
 use crate::lexer::*;
 use libra_types::account_address::AccountAddress;
-use move_core_types::identifier::{IdentStr, Identifier};
+use move_core_types::{
+    fs::FileName,
+    identifier::{IdentStr, Identifier},
+};
 use move_ir_types::{ast::*, location::*, spec_language_ast::*};
 
 // FIXME: The following simplified version of ParseError copied from
@@ -39,7 +42,7 @@ where
     }
 }
 
-fn make_loc(file: &'static str, start: usize, end: usize) -> Loc {
+fn make_loc(file: FileName, start: usize, end: usize) -> Loc {
     Loc::new(
         file,
         Span::new(ByteIndex(start as u32), ByteIndex(end as u32)),
@@ -55,7 +58,7 @@ fn current_token_loc<'input>(tokens: &Lexer<'input>) -> Loc {
     )
 }
 
-fn spanned<T>(file: &'static str, start: usize, end: usize, value: T) -> Spanned<T> {
+fn spanned<T>(file: FileName, start: usize, end: usize, value: T) -> Spanned<T> {
     Spanned {
         loc: make_loc(file, start, end),
         value,
@@ -2086,7 +2089,7 @@ fn parse_script_or_module<'input>(
 }
 
 pub fn parse_cmd_string(file: &str, input: &str) -> Result<Cmd_, ParseError<Loc, anyhow::Error>> {
-    let mut tokens = Lexer::new(leak_str(file), input);
+    let mut tokens = Lexer::new(FileName::new(file), input);
     tokens.advance()?;
     parse_cmd_(&mut tokens)
 }
@@ -2095,7 +2098,7 @@ pub fn parse_module_string(
     file: &str,
     input: &str,
 ) -> Result<ModuleDefinition, ParseError<Loc, anyhow::Error>> {
-    let mut tokens = Lexer::new(leak_str(file), input);
+    let mut tokens = Lexer::new(FileName::new(file), input);
     tokens.advance()?;
     parse_module(&mut tokens)
 }
@@ -2104,7 +2107,7 @@ pub fn parse_script_string(
     file: &str,
     input: &str,
 ) -> Result<Script, ParseError<Loc, anyhow::Error>> {
-    let mut tokens = Lexer::new(leak_str(file), input);
+    let mut tokens = Lexer::new(FileName::new(file), input);
     tokens.advance()?;
     parse_script(&mut tokens)
 }
@@ -2113,12 +2116,7 @@ pub fn parse_script_or_module_string(
     file: &str,
     input: &str,
 ) -> Result<ScriptOrModule, ParseError<Loc, anyhow::Error>> {
-    let mut tokens = Lexer::new(leak_str(file), input);
+    let mut tokens = Lexer::new(FileName::new(file), input);
     tokens.advance()?;
     parse_script_or_module(&mut tokens)
-}
-
-// TODO replace with some sort of intern table
-fn leak_str(s: &str) -> &'static str {
-    Box::leak(Box::new(s.to_owned()))
 }

--- a/language/move-core/types/Cargo.toml
+++ b/language/move-core/types/Cargo.toml
@@ -19,11 +19,13 @@ proptest-derive = { version = "0.1.2", default-features = false, optional = true
 ref-cast = "1.0"
 serde = { version = "1.0.110", default-features = false }
 thiserror = "1.0"
+walkdir = "2.3.1"
 
 lcs = { path = "../../../common/lcs", version = "0.1.0", package = "libra-canonical-serialization" }
 libra-workspace-hack = { path = "../../../common/workspace-hack", version = "0.1.0" }
 libra-crypto = { path = "../../../crypto/crypto", version = "0.1.0" }
 libra-crypto-derive = { path = "../../../crypto/crypto-derive", version = "0.1.0" }
+libra-temppath = { path = "../../../common/temppath", version = "0.1.0"}
 
 [dev-dependencies]
 once_cell = "1.4.0"

--- a/language/move-core/types/src/fs.rs
+++ b/language/move-core/types/src/fs.rs
@@ -1,0 +1,535 @@
+// Copyright (c) The Libra Core Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+use serde::{de, export::Formatter, Deserialize, Deserializer, Serialize, Serializer};
+use std::{
+    cell::RefCell,
+    cmp::Ordering,
+    collections::HashMap,
+    ffi::OsString,
+    fmt, fs,
+    fs::{File, OpenOptions},
+    io::{Error, ErrorKind, Read, Write},
+    path::{Path, PathBuf},
+};
+
+thread_local! {
+     static DESCRIPTORS: RefCell<Option<Descriptors>> = RefCell::new(None);
+}
+
+#[derive(Debug)]
+struct Descriptors {
+    fs_counter: usize,
+    paths: Vec<String>,
+}
+
+impl Descriptors {
+    pub fn in_context<A, R>(action: A) -> R
+    where
+        A: Fn(&[String]) -> R,
+    {
+        DESCRIPTORS.with(|descriptors| {
+            descriptors
+                .borrow()
+                .as_ref()
+                .map(|descriptors| action(&descriptors.paths))
+                .expect("Expected AFS in context.")
+        })
+    }
+
+    pub fn in_context_mut<A, R>(action: A) -> R
+    where
+        A: Fn(&mut Vec<String>) -> R,
+    {
+        DESCRIPTORS.with(|descriptors| {
+            descriptors
+                .borrow_mut()
+                .as_mut()
+                .map(|descriptors| action(&mut descriptors.paths))
+                .expect("Expected AFS in context.")
+        })
+    }
+
+    pub fn on_crate_fs() {
+        DESCRIPTORS.with(|descriptors| {
+            let mut descriptors = descriptors.borrow_mut();
+            if let Some(descriptors) = descriptors.as_mut() {
+                descriptors.fs_counter += 1;
+            } else {
+                *descriptors = Some(Descriptors {
+                    fs_counter: 1,
+                    paths: vec![],
+                });
+            }
+        });
+    }
+
+    pub fn on_drop_fs() {
+        DESCRIPTORS.with(|descriptors| {
+            let mut descriptors = descriptors.borrow_mut();
+            let drop = if let Some(descriptors) = descriptors.as_mut() {
+                descriptors.fs_counter -= 1;
+                descriptors.fs_counter == 0
+            } else {
+                false
+            };
+
+            if drop {
+                *descriptors = None;
+            }
+        });
+    }
+
+    pub fn has_context() -> bool {
+        DESCRIPTORS.with(|descriptors| descriptors.borrow().is_some())
+    }
+}
+
+/// File identifier.
+#[derive(Copy, Clone, PartialEq, Eq, Hash)]
+pub struct FileName(usize);
+
+impl FileName {
+    pub fn new(name: &str) -> Self {
+        Descriptors::in_context_mut(|desc| {
+            match desc.iter().enumerate().find(|(_, v)| *v == name) {
+                Some((id, _)) => FileName(id),
+                None => {
+                    desc.push(name.to_owned());
+                    FileName(desc.len() - 1)
+                }
+            }
+        })
+    }
+
+    pub fn name(self) -> String {
+        Descriptors::in_context(|desc| desc[self.0].to_owned())
+    }
+
+    pub fn has_suffix(self, suffix: &str) -> bool {
+        Descriptors::in_context(|desc| desc[self.0].ends_with(suffix))
+    }
+
+    pub fn has_context() -> bool {
+        Descriptors::has_context()
+    }
+
+    pub fn into_path_buf(self) -> PathBuf {
+        PathBuf::from(self.name())
+    }
+}
+
+impl From<PathBuf> for FileName {
+    fn from(path: PathBuf) -> Self {
+        FileName::new(path.to_string_lossy().as_ref())
+    }
+}
+
+impl From<&PathBuf> for FileName {
+    fn from(path: &PathBuf) -> Self {
+        FileName::new(path.to_string_lossy().as_ref())
+    }
+}
+
+impl From<&Path> for FileName {
+    fn from(path: &Path) -> Self {
+        FileName::new(path.to_string_lossy().as_ref())
+    }
+}
+
+impl Ord for FileName {
+    fn cmp(&self, other: &Self) -> Ordering {
+        Descriptors::in_context(|desc| desc[self.0].cmp(&desc[other.0]))
+    }
+}
+
+impl PartialOrd for FileName {
+    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+        Descriptors::in_context(|desc| desc[self.0].partial_cmp(&desc[other.0]))
+    }
+}
+
+impl Serialize for FileName {
+    fn serialize<S>(&self, serializer: S) -> Result<<S as Serializer>::Ok, <S as Serializer>::Error>
+    where
+        S: Serializer,
+    {
+        serializer.serialize_str(&self.name())
+    }
+}
+
+impl Into<OsString> for FileName {
+    fn into(self) -> OsString {
+        OsString::from(self.name())
+    }
+}
+
+impl fmt::Display for FileName {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}", self.name())
+    }
+}
+
+impl fmt::Debug for FileName {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{:?}", self.name())
+    }
+}
+
+struct FIdVisitor;
+
+impl<'de> de::Visitor<'de> for FIdVisitor {
+    type Value = FileName;
+
+    fn expecting(&self, formatter: &mut Formatter) -> fmt::Result {
+        formatter.write_str("a string")
+    }
+
+    fn visit_str<E>(self, v: &str) -> Result<Self::Value, E>
+    where
+        E: de::Error,
+    {
+        Ok(FileName::new(v))
+    }
+
+    fn visit_borrowed_str<E>(self, v: &'de str) -> Result<Self::Value, E>
+    where
+        E: de::Error,
+    {
+        Ok(FileName::new(v))
+    }
+
+    fn visit_string<E>(self, v: String) -> Result<Self::Value, E>
+    where
+        E: de::Error,
+    {
+        Ok(FileName::new(&v))
+    }
+}
+
+impl<'de> Deserialize<'de> for FileName {
+    fn deserialize<D>(deserializer: D) -> Result<Self, <D as Deserializer<'de>>::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        deserializer.deserialize_str(FIdVisitor)
+    }
+}
+
+pub trait FS {
+    fn has_entry(&self, name: FileName) -> bool;
+    fn find_with_prefix(&self, name: FileName) -> Result<Vec<FileName>, Error>;
+    fn load(&self, name: FileName) -> Result<String, Error>;
+    fn load_bytes(&self, name: FileName) -> Result<Vec<u8>, Error>;
+    fn store(&self, name: FileName, data: String) -> Result<(), Error>;
+    fn store_bytes(&self, name: FileName, data: Vec<u8>) -> Result<(), Error>;
+    fn delete(&self, name: FileName) -> Result<(), Error>;
+}
+
+#[derive(Debug)]
+pub enum AFS {
+    FS {
+        base_path: Option<PathBuf>,
+    },
+    InMemory {
+        store: RefCell<HashMap<FileName, Vec<u8>>>,
+    },
+}
+
+impl AFS {
+    pub fn new() -> AFS {
+        Descriptors::on_crate_fs();
+        AFS::FS { base_path: None }
+    }
+
+    pub fn with_path(base_path: PathBuf) -> AFS {
+        Descriptors::on_crate_fs();
+        AFS::FS {
+            base_path: Some(base_path),
+        }
+    }
+
+    pub fn in_memory() -> AFS {
+        Descriptors::on_crate_fs();
+        AFS::InMemory {
+            store: RefCell::new(Default::default()),
+        }
+    }
+
+    fn make_path(&self, path: String) -> PathBuf {
+        if let AFS::FS { base_path } = self {
+            if let Some(base_path) = base_path {
+                base_path.join(path)
+            } else {
+                PathBuf::from(path)
+            }
+        } else {
+            PathBuf::from(path)
+        }
+    }
+}
+
+impl Drop for AFS {
+    fn drop(&mut self) {
+        Descriptors::on_drop_fs();
+    }
+}
+
+impl FS for AFS {
+    fn has_entry(&self, id: FileName) -> bool {
+        match self {
+            AFS::FS { base_path: _ } => {
+                let path = self.make_path(id.name());
+                path.is_file() && path.exists()
+            }
+            AFS::InMemory { store } => store.borrow().contains_key(&id),
+        }
+    }
+
+    fn find_with_prefix(&self, prefix_id: FileName) -> Result<Vec<FileName>, Error> {
+        match self {
+            AFS::FS { base_path } => {
+                let path = self.make_path(prefix_id.name());
+
+                walkdir::WalkDir::new(path)
+                    .into_iter()
+                    .filter_map(|e| e.ok())
+                    .filter(|e| e.file_type().is_file())
+                    .map(|e| {
+                        let path = e.into_path();
+                        let path = if let Some(base_path) = base_path {
+                            path.strip_prefix(base_path)
+                                .expect("Unreachable.")
+                                .to_path_buf()
+                        } else {
+                            path
+                        };
+
+                        if let Some(name) = path.to_str() {
+                            Ok(FileName::new(name))
+                        } else {
+                            Err(std::io::Error::new(
+                                ErrorKind::Other,
+                                "non-Unicode file name",
+                            ))
+                        }
+                    })
+                    .collect::<Result<Vec<_>, _>>()
+            }
+            AFS::InMemory { store } => {
+                let prefix = prefix_id.name();
+                let store = store.borrow();
+                Ok(Descriptors::in_context(|d| {
+                    d.iter()
+                        .enumerate()
+                        .map(|(i, name)| (FileName(i), name))
+                        .filter_map(|(i, name)| {
+                            if name.starts_with(&prefix) && store.contains_key(&i) {
+                                Some(i)
+                            } else {
+                                None
+                            }
+                        })
+                        .collect()
+                }))
+            }
+        }
+    }
+
+    fn load(&self, id: FileName) -> Result<String, Error> {
+        self.load_bytes(id).and_then(|buff| {
+            String::from_utf8(buff).map_err(|err| {
+                std::io::Error::new(
+                    ErrorKind::InvalidData,
+                    format!("Expected valid UTF-8 '{}' {:?}", id.name(), err),
+                )
+            })
+        })
+    }
+
+    fn load_bytes(&self, id: FileName) -> Result<Vec<u8>, Error> {
+        match self {
+            AFS::FS { base_path: _ } => {
+                let path = self.make_path(id.name());
+                let mut file = File::open(path).map_err(|err| {
+                    std::io::Error::new(err.kind(), format!("{}: {}", err, id.name()))
+                })?;
+
+                let mut buffer = Vec::new();
+                file.read_to_end(&mut buffer)?;
+
+                Ok(buffer)
+            }
+            AFS::InMemory { store } => store
+                .borrow()
+                .get(&id)
+                .map(|buf| buf.to_owned())
+                .ok_or_else(|| {
+                    std::io::Error::new(
+                        ErrorKind::NotFound,
+                        format!("No such file or directory '{}'", id.name()),
+                    )
+                }),
+        }
+    }
+
+    fn store(&self, id: FileName, data: String) -> Result<(), Error> {
+        self.store_bytes(id, data.into_bytes())
+    }
+
+    fn store_bytes(&self, id: FileName, data: Vec<u8>) -> Result<(), Error> {
+        match self {
+            AFS::FS { base_path: _ } => {
+                let path = self.make_path(id.name());
+
+                if let Some(parent) = path.parent() {
+                    if !parent.exists() {
+                        fs::create_dir_all(&parent)?;
+                    }
+                }
+
+                let mut file = OpenOptions::new().write(true).create(true).open(path)?;
+                file.set_len(0)?;
+                file.write_all(&data)?;
+                Ok(())
+            }
+            AFS::InMemory { store } => {
+                let mut store = store.borrow_mut();
+                store.insert(id, data);
+                Ok(())
+            }
+        }
+    }
+
+    fn delete(&self, id: FileName) -> Result<(), Error> {
+        match self {
+            AFS::FS { base_path: _ } => {
+                let path = self.make_path(id.name());
+                if path.exists() {
+                    fs::remove_file(path)?;
+                }
+                Ok(())
+            }
+            AFS::InMemory { store } => {
+                let mut store = store.borrow_mut();
+                store.remove(&id);
+                Ok(())
+            }
+        }
+    }
+}
+
+impl Default for AFS {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use crate::fs::{FileName, AFS, FS};
+    use libra_temppath::TempPath;
+
+    macro_rules! name {
+        ($name:expr) => {
+            FileName::new($name)
+        };
+    }
+
+    #[test]
+    #[should_panic]
+    fn test_create_file_name_without_context() {
+        name!("test");
+    }
+
+    #[test]
+    fn test_create_file_name_in_context() {
+        let _fs = AFS::new();
+        assert_eq!("test_name.move", name!("test_name.move").to_string())
+    }
+
+    #[test]
+    fn test_identical_names_identical_id() {
+        let _fs = AFS::new();
+        assert_eq!(name!("test_name.move").0, name!("test_name.move").0);
+        assert_eq!(name!("test_name_1.move").0, name!("test_name_1.move").0);
+        assert_ne!(name!("test_name.move").0, name!("test_name_1.move").0);
+    }
+
+    #[test]
+    fn test_drop_descriptors_context() {
+        {
+            let _fs = AFS::new();
+            name!("test");
+            assert!(FileName::has_context());
+            {
+                let _fs = AFS::in_memory();
+                name!("test_1");
+                assert!(FileName::has_context());
+            }
+            assert!(FileName::has_context());
+        }
+        assert!(!FileName::has_context());
+    }
+
+    #[test]
+    #[should_panic]
+    fn test_file_name_without_context() {
+        let f_name = {
+            let _fs = AFS::in_memory();
+            name!("test_1")
+        };
+        f_name.name();
+    }
+
+    #[test]
+    fn test_suffix() {
+        let _fs = AFS::in_memory();
+        assert!(name!("test_1.move").has_suffix("move"));
+    }
+
+    #[test]
+    fn test_in_memory_fs() {
+        let fs = AFS::in_memory();
+        test_fs(&fs);
+    }
+
+    #[test]
+    fn test_in_fs() {
+        let temp_dir = TempPath::new();
+        let fs = AFS::with_path(temp_dir.path().to_path_buf());
+        test_fs(&fs);
+    }
+
+    fn test_fs(fs: &AFS) {
+        fs.store(name!("a/1"), "Test data 1".to_owned()).unwrap();
+        fs.store(name!("a/2"), "Test data 2".to_owned()).unwrap();
+        fs.store_bytes(name!("a/3"), b"Test data 3".to_vec())
+            .unwrap();
+        fs.store_bytes(name!("b/1"), b"Test data b1".to_vec())
+            .unwrap();
+
+        assert!(fs.has_entry(name!("a/2")));
+        assert!(!fs.has_entry(name!("c/2")));
+
+        let mut files_with_prefix = fs.find_with_prefix(name!("a")).unwrap();
+        files_with_prefix.sort_unstable();
+        let mut expected_files = vec![name!("a/1"), name!("a/2"), name!("a/3")];
+        expected_files.sort_unstable();
+
+        assert_eq!(files_with_prefix, expected_files);
+        assert_eq!(fs.find_with_prefix(name!("c")).unwrap(), vec![]);
+
+        assert_eq!(&fs.load(name!("b/1")).unwrap(), "Test data b1");
+        assert_eq!(&fs.load(name!("a/1")).unwrap(), "Test data 1");
+        assert_eq!(
+            fs.load_bytes(name!("a/1")).unwrap(),
+            b"Test data 1".to_vec()
+        );
+
+        assert!(fs.load_bytes(name!("a/10")).is_err());
+
+        fs.delete(name!("a/1")).unwrap();
+        assert!(fs.load_bytes(name!("a/1")).is_err());
+    }
+}

--- a/language/move-core/types/src/lib.rs
+++ b/language/move-core/types/src/lib.rs
@@ -4,6 +4,7 @@
 //! Core types for Move.
 
 pub mod account_address;
+pub mod fs;
 pub mod gas_schedule;
 pub mod identifier;
 pub mod language_storage;

--- a/language/move-ir/types/src/location.rs
+++ b/language/move-ir/types/src/location.rs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use codespan::Span;
+use move_core_types::fs::FileName;
 use serde::{Deserialize, Serialize};
 use std::{
     cmp::Ordering,
@@ -15,15 +16,15 @@ use std::{
 
 #[derive(Debug, Copy, Clone, Eq, PartialEq, Serialize, Deserialize)]
 pub struct Loc {
-    file: &'static str,
+    file: FileName,
     span: Span,
 }
 impl Loc {
-    pub fn new(file: &'static str, span: Span) -> Loc {
+    pub fn new(file: FileName, span: Span) -> Loc {
         Loc { file, span }
     }
 
-    pub fn file(self) -> &'static str {
+    pub fn file(self) -> FileName {
         self.file
     }
 
@@ -34,7 +35,7 @@ impl Loc {
 
 impl PartialOrd for Loc {
     fn partial_cmp(&self, other: &Loc) -> Option<Ordering> {
-        let file_ord = self.file.partial_cmp(other.file)?;
+        let file_ord = self.file.partial_cmp(&other.file)?;
         if file_ord != Ordering::Equal {
             return Some(file_ord);
         }
@@ -50,7 +51,7 @@ impl PartialOrd for Loc {
 
 impl Ord for Loc {
     fn cmp(&self, other: &Loc) -> Ordering {
-        self.file.cmp(other.file).then_with(|| {
+        self.file.cmp(&other.file).then_with(|| {
             self.span
                 .start()
                 .cmp(&other.span.start())
@@ -78,7 +79,7 @@ impl<T> Spanned<T> {
     pub fn unsafe_no_loc(value: T) -> Spanned<T> {
         Spanned {
             value,
-            loc: Loc::new(Self::NO_LOC_FILE, Span::default()),
+            loc: Loc::new(FileName::new(Self::NO_LOC_FILE), Span::default()),
         }
     }
 }

--- a/language/move-lang/Cargo.toml
+++ b/language/move-lang/Cargo.toml
@@ -16,7 +16,6 @@ structopt = "0.3.14"
 difference = "2.0"
 petgraph = "0.5.1"
 datatest-stable = { path = "../../common/datatest-stable", version = "0.1.0" }
-walkdir = "2.3.1"
 
 move-vm = { path = "../vm", package = "vm" }
 move-bytecode-verifier = { path = "../bytecode-verifier", package = "bytecode-verifier" }
@@ -27,11 +26,11 @@ ir-to-bytecode = {path = "../compiler/ir-to-bytecode" }
 borrow-graph = { path = "../borrow-graph" }
 bytecode-source-map = { path = "../compiler/bytecode-source-map" }
 lcs = { path = "../../common/lcs", version = "0.1.0", package = "libra-canonical-serialization" }
-
+move-core-types = { path = "../move-core/types", version = "0.1.0" }
 
 [dev-dependencies]
 functional-tests = { path = "../functional-tests", version = "0.1.0" }
-tempfile = "3.1.0"
+rand = "0.7.3"
 
 [[test]]
 name = "move_check_testsuite"

--- a/language/move-lang/src/bin/move-build.rs
+++ b/language/move-lang/src/bin/move-build.rs
@@ -3,6 +3,7 @@
 
 #![forbid(unsafe_code)]
 
+use move_core_types::fs::AFS;
 use move_lang::{
     command_line::{self as cli},
     shared::*,
@@ -59,6 +60,8 @@ pub fn main() -> anyhow::Result<()> {
         out_dir,
         emit_source_map,
     } = Options::from_args();
-    let (files, compiled_units) = move_lang::move_compile(&source_files, &dependencies, sender)?;
-    move_lang::output_compiled_units(emit_source_map, files, compiled_units, &out_dir)
+    let fs = AFS::new();
+    let (files, compiled_units) =
+        move_lang::move_compile(&source_files, &dependencies, sender, &fs)?;
+    move_lang::output_compiled_units(emit_source_map, files, compiled_units, &out_dir, &fs)
 }

--- a/language/move-lang/src/bin/move-check.rs
+++ b/language/move-lang/src/bin/move-check.rs
@@ -3,6 +3,7 @@
 
 #![forbid(unsafe_code)]
 
+use move_core_types::fs::AFS;
 use move_lang::{
     command_line::{self as cli},
     shared::*,
@@ -43,5 +44,6 @@ pub fn main() -> anyhow::Result<()> {
         dependencies,
         sender,
     } = Options::from_args();
-    move_lang::move_check(&source_files, &dependencies, sender)
+    let fs = AFS::new();
+    move_lang::move_check(&source_files, &dependencies, sender, &fs)
 }

--- a/language/move-lang/src/errors/mod.rs
+++ b/language/move-lang/src/errors/mod.rs
@@ -10,6 +10,7 @@ use codespan_reporting::{
         Config,
     },
 };
+use move_core_types::fs::FileName;
 use move_ir_types::location::*;
 use std::collections::{HashMap, HashSet};
 
@@ -20,11 +21,11 @@ use std::collections::{HashMap, HashSet};
 pub type Errors = Vec<Error>;
 pub type Error = Vec<(Loc, String)>;
 pub type ErrorSlice = [(Loc, String)];
-pub type HashableError = Vec<(&'static str, usize, usize, String)>;
+pub type HashableError = Vec<(FileName, usize, usize, String)>;
 
-pub type FilesSourceText = HashMap<&'static str, String>;
+pub type FilesSourceText = HashMap<FileName, String>;
 
-type FileMapping = HashMap<&'static str, FileId>;
+type FileMapping = HashMap<FileName, FileId>;
 
 //**************************************************************************************************
 // Utils
@@ -110,7 +111,7 @@ fn render_errors<W: WriteColor>(
 
 fn convert_loc(files: &Files<String>, file_mapping: &FileMapping, loc: Loc) -> (FileId, Span) {
     let fname = loc.file();
-    let id = *file_mapping.get(fname).unwrap();
+    let id = *file_mapping.get(&fname).unwrap();
     let offset = files.source_span(id).start().to_usize();
     let begin_index = (loc.span().start().to_usize() + offset) as u32;
     let end_index = (loc.span().end().to_usize() + offset) as u32;

--- a/language/move-lang/src/parser/lexer.rs
+++ b/language/move-lang/src/parser/lexer.rs
@@ -3,6 +3,7 @@
 
 use crate::{errors::*, parser::syntax::make_loc, FileCommentMap, MatchedFileCommentMap};
 use codespan::{ByteIndex, Span};
+use move_core_types::fs::FileName;
 use move_ir_types::location::Loc;
 use std::{collections::BTreeMap, fmt};
 
@@ -159,7 +160,7 @@ impl fmt::Display for Tok {
 
 pub struct Lexer<'input> {
     text: &'input str,
-    file: &'static str,
+    file: FileName,
     doc_comments: FileCommentMap,
     matched_doc_comments: MatchedFileCommentMap,
     prev_end: usize,
@@ -171,7 +172,7 @@ pub struct Lexer<'input> {
 impl<'input> Lexer<'input> {
     pub fn new(
         text: &'input str,
-        file: &'static str,
+        file: FileName,
         doc_comments: BTreeMap<Span, String>,
     ) -> Lexer<'input> {
         Lexer {
@@ -194,7 +195,7 @@ impl<'input> Lexer<'input> {
         &self.text[self.cur_start..self.cur_end]
     }
 
-    pub fn file_name(&self) -> &'static str {
+    pub fn file_name(&self) -> FileName {
         self.file
     }
 
@@ -283,7 +284,7 @@ impl<'input> Lexer<'input> {
 }
 
 // Find the next token and its length without changing the state of the lexer.
-fn find_token(file: &'static str, text: &str, start_offset: usize) -> Result<(Tok, usize), Error> {
+fn find_token(file: FileName, text: &str, start_offset: usize) -> Result<(Tok, usize), Error> {
     let c: char = match text.chars().next() {
         Some(next_char) => next_char,
         None => {

--- a/language/move-lang/src/parser/syntax.rs
+++ b/language/move-lang/src/parser/syntax.rs
@@ -10,6 +10,7 @@ use crate::{
     parser::{ast::*, lexer::*},
     shared::*,
 };
+use move_core_types::fs::FileName;
 use std::collections::BTreeMap;
 
 // In the informal grammar comments in this file, Comma<T> is shorthand for:
@@ -37,7 +38,7 @@ fn unexpected_token_error<'input>(tokens: &Lexer<'input>, expected: &str) -> Err
 // Miscellaneous Utilities
 //**************************************************************************************************
 
-pub fn make_loc(file: &'static str, start: usize, end: usize) -> Loc {
+pub fn make_loc(file: FileName, start: usize, end: usize) -> Loc {
     Loc::new(
         file,
         Span::new(ByteIndex(start as u32), ByteIndex(end as u32)),
@@ -53,7 +54,7 @@ fn current_token_loc<'input>(tokens: &Lexer<'input>) -> Loc {
     )
 }
 
-fn spanned<T>(file: &'static str, start: usize, end: usize, value: T) -> Spanned<T> {
+fn spanned<T>(file: FileName, start: usize, end: usize, value: T) -> Spanned<T> {
     Spanned {
         loc: make_loc(file, start, end),
         value,
@@ -2024,7 +2025,7 @@ fn parse_file<'input>(tokens: &mut Lexer<'input>) -> Result<Vec<Definition>, Err
 /// result as either a pair of FileDefinition and doc comments or some Errors. The `file` name
 /// is used to identify source locations in error messages.
 pub fn parse_file_string(
-    file: &'static str,
+    file: FileName,
     input: &str,
     comment_map: BTreeMap<Span, String>,
 ) -> Result<(Vec<Definition>, BTreeMap<ByteIndex, String>), Errors> {

--- a/language/move-lang/tests/move_check_testsuite.rs
+++ b/language/move-lang/tests/move_check_testsuite.rs
@@ -4,6 +4,7 @@
 use move_lang::{move_compile_no_report, shared::Address};
 use std::{fs, path::Path};
 
+use move_core_types::fs::AFS;
 use move_lang::test_utils::*;
 
 const OUT_EXT: &str = "out";
@@ -45,6 +46,7 @@ fn format_diff(expected: String, actual: String) -> String {
 
 // Runs all tests under the test/testsuite directory.
 fn move_check_testsuite(path: &Path) -> datatest_stable::Result<()> {
+    let fs = AFS::new();
     let targets: Vec<String> = vec![path.to_str().unwrap().to_owned()];
     let deps = stdlib_files();
     let sender = Some(Address::parse_str(SENDER).unwrap());
@@ -52,7 +54,7 @@ fn move_check_testsuite(path: &Path) -> datatest_stable::Result<()> {
     let exp_path = path.with_extension(EXP_EXT);
     let out_path = path.with_extension(OUT_EXT);
 
-    let (files, units_or_errors) = move_compile_no_report(&targets, &deps, sender)?;
+    let (files, units_or_errors) = move_compile_no_report(&targets, &deps, sender, &fs)?;
     let errors = match units_or_errors {
         Err(errors) => errors,
         Ok(units) => move_lang::compiled_unit::verify_units(units).1,

--- a/language/move-lang/tests/stdlib_sanity_check.rs
+++ b/language/move-lang/tests/stdlib_sanity_check.rs
@@ -4,6 +4,7 @@
 use move_lang::{move_compile_no_report, shared::Address};
 use std::{fs, path::Path};
 
+use move_core_types::fs::AFS;
 use move_lang::test_utils::*;
 
 const OUT_EXT: &str = "out";
@@ -12,13 +13,14 @@ const KEEP_TMP: &str = "KEEP";
 
 // Runs all tests under the test/testsuite directory.
 fn sanity_check_testsuite(path: &Path) -> datatest_stable::Result<()> {
+    let fs = AFS::new();
     let mut targets = vec![path.to_str().unwrap().to_owned()];
     targets.append(&mut stdlib_files());
     let sender = Some(Address::LIBRA_CORE);
 
     let out_path = path.with_extension(OUT_EXT);
 
-    let (files, units_or_errors) = move_compile_no_report(&targets, &[], sender)?;
+    let (files, units_or_errors) = move_compile_no_report(&targets, &[], sender, &fs)?;
     let errors = match units_or_errors {
         Err(errors) => errors,
         Ok(units) => move_lang::compiled_unit::verify_units(units).1,

--- a/language/move-prover/Cargo.toml
+++ b/language/move-prover/Cargo.toml
@@ -18,6 +18,7 @@ libra-temppath = { path = "../../common/temppath", version = "0.1.0" }
 libra-workspace-hack = { path = "../../common/workspace-hack", version = "0.1.0" }
 bytecode-source-map = { path = "../compiler/bytecode-source-map", version = "0.1.0" }
 move-ir-types = { path = "../move-ir/types", version = "0.1.0" }
+move-core-types = { path = "../move-core/types", version = "0.1.0" }
 
 
 # external dependencies

--- a/language/move-prover/spec-lang/tests/testsuite.rs
+++ b/language/move-prover/spec-lang/tests/testsuite.rs
@@ -5,6 +5,7 @@ use std::path::Path;
 
 use codespan_reporting::term::termcolor::Buffer;
 
+use move_core_types::fs::AFS;
 use spec_lang::run_spec_lang_compiler;
 use test_utils::{baseline_test::verify_or_update_baseline, DEFAULT_SENDER};
 
@@ -12,8 +13,8 @@ fn test_runner(path: &Path) -> datatest_stable::Result<()> {
     let targets = vec![path.to_str().unwrap().to_string()];
     let deps = vec![];
     let address_opt = Some(DEFAULT_SENDER);
-
-    let env = run_spec_lang_compiler(targets, deps, address_opt)?;
+    let fs = AFS::new();
+    let env = run_spec_lang_compiler(targets, deps, address_opt, &fs)?;
     let diags = if env.has_errors() {
         let mut writer = Buffer::no_color();
         env.report_errors(&mut writer);

--- a/language/move-prover/stackless-bytecode-generator/tests/testsuite.rs
+++ b/language/move-prover/stackless-bytecode-generator/tests/testsuite.rs
@@ -6,6 +6,7 @@ use std::path::Path;
 
 use codespan_reporting::term::termcolor::Buffer;
 
+use move_core_types::fs::AFS;
 use spec_lang::{env::GlobalEnv, run_spec_lang_compiler};
 use stackless_bytecode_generator::{
     borrow_analysis::BorrowAnalysisProcessor,
@@ -88,7 +89,8 @@ fn get_tested_transformation_pipeline(
 fn test_runner(path: &Path) -> datatest_stable::Result<()> {
     let mut sources = extract_test_directives(path, "// dep:")?;
     sources.push(path.to_string_lossy().to_string());
-    let env: GlobalEnv = run_spec_lang_compiler(sources, vec![], Some("0x2345467"))?;
+    let fs = AFS::new();
+    let env: GlobalEnv = run_spec_lang_compiler(sources, vec![], Some("0x2345467"), &fs)?;
     let out = if env.has_errors() {
         let mut error_writer = Buffer::no_color();
         env.report_errors(&mut error_writer);

--- a/language/stdlib/Cargo.toml
+++ b/language/stdlib/Cargo.toml
@@ -18,6 +18,7 @@ libra-crypto = { path = "../../crypto/crypto", version = "0.1.0" }
 libra-types = { path = "../../types", version = "0.1.0" }
 libra-workspace-hack = { path = "../../common/workspace-hack", version = "0.1.0" }
 datatest-stable = { path = "../../common/datatest-stable", version = "0.1.0" }
+move-core-types = { path = "../move-core/types", version = "0.1.0"}
 lcs = { path = "../../common/lcs", version = "0.1.0", package = "libra-canonical-serialization" }
 vm = { path = "../vm", version = "0.1.0" }
 once_cell = "1.4.0"

--- a/language/stdlib/src/lib.rs
+++ b/language/stdlib/src/lib.rs
@@ -7,6 +7,7 @@ pub mod transaction_scripts;
 
 use bytecode_verifier::{batch_verify_modules, VerifiedModule};
 use log::LevelFilter;
+use move_core_types::fs::AFS;
 use move_lang::{compiled_unit::CompiledUnit, move_compile, shared::Address};
 use once_cell::sync::Lazy;
 use std::path::PathBuf;
@@ -119,8 +120,9 @@ pub fn stdlib_files() -> Vec<String> {
 }
 
 pub fn build_stdlib() -> Vec<VerifiedModule> {
+    let fs = AFS::new();
     let (_, compiled_units) =
-        move_compile(&stdlib_files(), &[], Some(Address::LIBRA_CORE)).unwrap();
+        move_compile(&stdlib_files(), &[], Some(Address::LIBRA_CORE), &fs).unwrap();
     batch_verify_modules(
         compiled_units
             .into_iter()
@@ -133,10 +135,12 @@ pub fn build_stdlib() -> Vec<VerifiedModule> {
 }
 
 pub fn compile_script(source_file_str: String) -> Vec<u8> {
+    let fs = AFS::new();
     let (_, mut compiled_program) = move_compile(
         &[source_file_str],
         &stdlib_files(),
         Some(Address::LIBRA_CORE),
+        &fs,
     )
     .unwrap();
     let mut script_bytes = vec![];

--- a/language/tools/disassembler/src/main.rs
+++ b/language/tools/disassembler/src/main.rs
@@ -9,6 +9,7 @@ use bytecode_source_map::{
     utils::{remap_owned_loc_to_loc, source_map_from_file, OwnedLoc},
 };
 use disassembler::disassembler::{Disassembler, DisassemblerOptions};
+use move_core_types::fs::AFS;
 use move_coverage::coverage_map::CoverageMap;
 use move_ir_types::location::Spanned;
 use std::{fs, path::Path};
@@ -55,6 +56,7 @@ struct Args {
 
 fn main() {
     let args = Args::from_args();
+    let _fs = AFS::new();
 
     let move_extension = "move";
     let mv_bytecode_extension = "mv";

--- a/language/tools/move-coverage/src/bin/source-coverage.rs
+++ b/language/tools/move-coverage/src/bin/source-coverage.rs
@@ -4,6 +4,7 @@
 #![forbid(unsafe_code)]
 
 use bytecode_source_map::utils::{remap_owned_loc_to_loc, source_map_from_file, OwnedLoc};
+use move_core_types::fs::AFS;
 use move_coverage::{coverage_map::CoverageMap, source_coverage::SourceCoverageBuilder};
 use std::{
     fs,
@@ -39,6 +40,8 @@ struct Args {
 
 fn main() {
     let args = Args::from_args();
+    let _fs = AFS::new();
+
     let source_map_extension = "mvsm";
     let coverage_map = if args.is_raw_trace_file {
         CoverageMap::from_trace_file(&args.input_trace_path)

--- a/language/tools/utils/tests/tests.rs
+++ b/language/tools/utils/tests/tests.rs
@@ -2,12 +2,15 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use bytecode_verifier::VerifiedModule;
+use move_core_types::fs::AFS;
 use rand::{rngs::StdRng, SeedableRng};
 use utils::module_generation::{generate_module, ModuleGeneratorOptions};
 
 #[test]
 fn module_generation() {
     let mut rng = StdRng::from_entropy();
+    let _fs = AFS::new();
+
     for _ in 0..50 {
         let module = generate_module(&mut rng, ModuleGeneratorOptions::default());
         VerifiedModule::new(module).unwrap();


### PR DESCRIPTION
Implements the abstraction above the file system for the compiler.
Fixed memory leak.

## Motivation

We use the compiler as a service. For distributed compilation purposes. We are prevented by leak_str and the fact that the compiler uses files as a source. It would be nice to have abstraction above the file system.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?

yes.

## Test Plan
Unit test.

## Related PRs
--