### PR TITLE
[tf] Updated ROAR script to use sha256 as image version instead of tags

### DIFF
--- a/terraform/validators.tf
+++ b/terraform/validators.tf
@@ -141,6 +141,8 @@ locals {
   image_repo                 = var.image_repo
   image_version              = substr(var.image_tag, 0, 6) == "sha256" ? "@${var.image_tag}" : ":${var.image_tag}"
   override_image_versions    = [for img in var.override_image_tags : substr(img, 0, 6) == "sha256" ? "@${img}" : ":${img}"]
+  logstash_image_repo        = var.logstash_image
+  logstash_image_version     = substr(var.logstash_version, 0, 6) == "sha256" ? "@${var.logstash_version}" : ":${var.logstash_version}"
   safety_rules_image_repo    = var.safety_rules_image_repo
   safety_rules_image_version = substr(var.safety_rules_image_tag, 0, 6) == "sha256" ? "@${var.safety_rules_image_tag}" : ":${var.safety_rules_image_tag}"
   instance_public_ip         = true
@@ -227,8 +229,8 @@ data "template_file" "ecs_task_definition" {
     capabilities               = jsonencode(var.validator_linux_capabilities)
     command                    = local.validator_command
     logstash                   = var.enable_logstash
-    logstash_image             = var.logstash_image
-    logstash_version           = ":${var.logstash_version}"
+    logstash_image             = local.logstash_image_repo
+    logstash_version           = local.logstash_image_version
     logstash_config            = local.logstash_config
     safety_rules_image         = local.safety_rules_image_repo
     safety_rules_image_version = local.safety_rules_image_version


### PR DESCRIPTION
<!--
Thank you for sending a PR. We appreciate you spending time to help improve the Libra project.

The project is undergoing daily changes. Pull Requests will be reviewed and responded to as time permits.
-->

## Motivation

The ROAR script uses image tags for recording the instances of various nodes. This works well for testnet where each of our images are tagged a specific revision, but for devnet or one-off network deployments, the images are often tagged master or latest by default. This makes replaying networks more difficult over time, as those image tags change.

With this change we will extract the image digest from a running task instance in ec2 and use it to compose the image version, which should provide us deterministic replay in all environments.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?

YES

## Test Plan

Create an environment first
```
cd $LIBRA_OPS_ROOT/terraform/testnet
terraform workspace new asawhney
terraform apply --var-file=facebook/dev.tfvars
```

Without my changes...
```
asawhney@prittner-fedora-pc0urz61 testnet % py3 ~/Sandbox/libra/scripts/record_and_replay.py -s asawhney -t . -f facebook/dev.tfvars -o asawhney-roar-old.tfvars
Searching workspaces in /Users/asawhney/Sandbox/libra-ops/terraform/testnet
Using source workspace "asawhney"
logstash_image          : 853397791086.dkr.ecr.us-west-2.amazonaws.com/libra_logstash
logstash_version        : latest
safetyrules_image       : 853397791086.dkr.ecr.us-west-2.amazonaws.com/libra_safety_rules
safetyrules_version     : master
validator_image         : 853397791086.dkr.ecr.us-west-2.amazonaws.com/libra_validator
validator_versions      : ['master', 'master', 'master', 'master']
validator_ips           : ['10.0.2.33', '10.0.4.199', '10.0.9.97', '10.0.1.149']
fullnode_ips            : ['10.0.3.177', '10.0.6.177']
validator_restore_vols  : ['vol-07451a92530c38b66', 'vol-08294db8806a1951e', 'vol-069ff96771e987a6d', 'vol-06ceea642aba2e7bb']
```

With my changes....
```
asawhney@prittner-fedora-pc0urz61 testnet % py3 ~/Sandbox/libra/scripts/record_and_replay.py -s asawhney -t . -f facebook/dev.tfvars -o asawhney-roar-new.tfvars
Searching workspaces in /Users/asawhney/Sandbox/libra-ops/terraform/testnet
Using source workspace "asawhney"
logstash_image          : 853397791086.dkr.ecr.us-west-2.amazonaws.com/libra_logstash
logstash_version        : sha256:95343ef74362e1a4c06142ac99d036b4db1cc8255eaf697b1b19b64870a2e618
safetyrules_image       : 853397791086.dkr.ecr.us-west-2.amazonaws.com/libra_safety_rules
safetyrules_version     : sha256:8baab2d861300c63ec543cf9d11c009c8673b2a87a3aa843381eeb04d0ba6538
validator_image         : 853397791086.dkr.ecr.us-west-2.amazonaws.com/libra_validator
validator_versions      : ['sha256:39f26713d2c24fc77fc7d43bb18f22f91fb9ce51ca6e889c37071c7cb23fd0ba', 'sha256:39f26713d2c24fc77fc7d43bb18f22f91fb9ce51ca6e889c37071c7cb23fd0ba', 'sha256:39f26713d2c24fc77fc7d43bb18f22f91fb9ce51ca6e889c37071c7cb23fd0ba', 'sha256:39f26713d2c24fc77fc7d43bb18f22f91fb9ce51ca6e889c37071c7cb23fd0ba']
validator_ips           : ['10.0.2.33', '10.0.4.199', '10.0.9.97', '10.0.1.149']
fullnode_ips            : ['10.0.3.177', '10.0.6.177']
validator_restore_vols  : ['vol-07451a92530c38b66', 'vol-08294db8806a1951e', 'vol-069ff96771e987a6d', 'vol-06ceea642aba2e7bb']
```

Replay the recording to make sure it actually works

```
terraform workspace new asawhney-roar

terraform apply --var-file=/Users/asawhney/Sandbox/libra-ops/terraform/testnet/asawhney-roar-new.tfvars

asawhney@prittner-fedora-pc0urz61 testnet % py3 ~/Sandbox/libra/scripts/record_and_replay.py -s asawhney-roar -t . -f facebook/dev.tfvars -o asawhney-roar-replayed.tfvars
Searching workspaces in /Users/asawhney/Sandbox/libra-ops/terraform/testnet
Using source workspace "asawhney-roar"
logstash_image          : 853397791086.dkr.ecr.us-west-2.amazonaws.com/libra_logstash
logstash_version        : sha256:95343ef74362e1a4c06142ac99d036b4db1cc8255eaf697b1b19b64870a2e618
safetyrules_image       : 853397791086.dkr.ecr.us-west-2.amazonaws.com/libra_safety_rules
safetyrules_version     : sha256:8baab2d861300c63ec543cf9d11c009c8673b2a87a3aa843381eeb04d0ba6538
validator_image         : 853397791086.dkr.ecr.us-west-2.amazonaws.com/libra_validator
validator_versions      : ['sha256:39f26713d2c24fc77fc7d43bb18f22f91fb9ce51ca6e889c37071c7cb23fd0ba', 'sha256:39f26713d2c24fc77fc7d43bb18f22f91fb9ce51ca6e889c37071c7cb23fd0ba', 'sha256:39f26713d2c24fc77fc7d43bb18f22f91fb9ce51ca6e889c37071c7cb23fd0ba', 'sha256:39f26713d2c24fc77fc7d43bb18f22f91fb9ce51ca6e889c37071c7cb23fd0ba']
validator_ips           : ['10.0.2.33', '10.0.4.199', '10.0.9.97', '10.0.1.149']
fullnode_ips            : ['10.0.3.177', '10.0.6.177']
validator_restore_vols  : ['vol-0d68e93f318dae46a', 'vol-0fbe0d037a2f05801', 'vol-0c909e0d2682291d0', 'vol-095f3b0b03999f092']

Instructions:
cd /Users/asawhney/Sandbox/libra-ops/terraform/testnet
terraform workspace new <new_workspace>
terraform apply --var-file=/Users/asawhney/Sandbox/libra-ops/terraform/testnet/asawhney-roar-replayed.tfvars
```
Dashboard:
http://prometheus.asawhney-roar.aws.hlw3truzy4ls.com:9091/d/overview10/overview?orgId=1
