### PR TITLE
[generate-format] upgrade to serde-reflection 0.3.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1676,7 +1676,7 @@ dependencies = [
  "proptest 0.9.6 (git+https://github.com/mimoo/proptest.git?branch=fuzzing)",
  "rand 0.7.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.110 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde-reflection 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde-reflection 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_yaml 0.8.12 (registry+https://github.com/rust-lang/crates.io-index)",
  "structopt 0.3.14 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -4872,7 +4872,7 @@ dependencies = [
 
 [[package]]
 name = "serde-reflection"
-version = "0.2.0"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "serde 1.0.110 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -6878,7 +6878,7 @@ dependencies = [
 "checksum semver 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)" = "1d7eb9ef2c18661902cc47e535f9bc51b78acd254da71d375c2f6720d9a40403"
 "checksum semver-parser 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "388a1df253eca08550bef6c72392cfe7c30914bf41df5269b68cbd6ff8f570a3"
 "checksum serde 1.0.110 (registry+https://github.com/rust-lang/crates.io-index)" = "99e7b308464d16b56eba9964e4972a3eee817760ab60d88c3f86e1fecb08204c"
-"checksum serde-reflection 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "d330d242b7ffc4733c7f6d47f9a6434a4c602139b7e22ea9eb8832950a537dff"
+"checksum serde-reflection 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "5820d2a74b1f0694d959f48660bc52fa922239d5c2f6dcc17261c5307967b9e5"
 "checksum serde-value 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)" = "5a65a7291a8a568adcae4c10a677ebcedbc6c9cec91c054dee2ce40b0e3290eb"
 "checksum serde_bytes 0.11.4 (registry+https://github.com/rust-lang/crates.io-index)" = "3bf487fbf5c6239d7ea2ff8b10cb6b811cd4b5080d1c2aeed1dec18753c06e10"
 "checksum serde_derive 1.0.110 (registry+https://github.com/rust-lang/crates.io-index)" = "818fbf6bfa9a42d3bfcaca148547aa00c7b915bec71d1757aa2d44ca68771984"

--- a/testsuite/generate-format/Cargo.toml
+++ b/testsuite/generate-format/Cargo.toml
@@ -13,7 +13,7 @@ edition = "2018"
 proptest = "0.9.6"
 rand = "0.7.3"
 serde = { version = "1.0.110", features = ["derive"] }
-serde-reflection = "0.2.0"
+serde-reflection = "0.3.0"
 serde_yaml = "0.8"
 structopt = "0.3.14"
 

--- a/testsuite/generate-format/tests/detect_format_change.rs
+++ b/testsuite/generate-format/tests/detect_format_change.rs
@@ -2,21 +2,17 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use generate_format::Corpus;
-use serde_reflection::RegistryOwned;
+use serde_reflection::Registry;
 
 #[test]
 fn test_that_recorded_formats_did_not_change() {
     for corpus in Corpus::values() {
-        let registry: RegistryOwned = corpus
-            .get_registry()
-            .into_iter()
-            .map(|(k, v)| (k.to_string(), v))
-            .collect();
+        let registry = corpus.get_registry();
 
         // Some corpus may not be recorded on disk.
         if let Some(path) = corpus.output_file() {
             let content = std::fs::read_to_string(path).unwrap();
-            let expected = serde_yaml::from_str::<RegistryOwned>(content.as_str()).unwrap();
+            let expected = serde_yaml::from_str::<Registry>(content.as_str()).unwrap();
             assert_registry_has_not_changed(&corpus.to_string(), path, registry, expected);
         }
     }
@@ -31,12 +27,7 @@ Please verify the changes to the recorded file(s) and consider tagging your pull
     )
 }
 
-fn assert_registry_has_not_changed(
-    name: &str,
-    path: &str,
-    registry: RegistryOwned,
-    expected: RegistryOwned,
-) {
+fn assert_registry_has_not_changed(name: &str, path: &str, registry: Registry, expected: Registry) {
     for (key, value) in expected.iter() {
         assert_eq!(
             Some(value),
@@ -89,8 +80,8 @@ Person:
       FullName: UNIT
 "#;
 
-    let value1 = serde_yaml::from_str::<RegistryOwned>(yaml1).unwrap();
-    let value2 = serde_yaml::from_str::<RegistryOwned>(yaml2).unwrap();
+    let value1 = serde_yaml::from_str::<Registry>(yaml1).unwrap();
+    let value2 = serde_yaml::from_str::<Registry>(yaml2).unwrap();
     assert_ne!(value1, value2);
     assert_ne!(value1.get("Person").unwrap(), value2.get("Person").unwrap());
 }


### PR DESCRIPTION
## Motivation

Upgrade to serde-reflection 0.3.0 (where `RegistryOwned` is replacing `Registry`).

## Test Plan

```
cargo x test -p generate-format
```

## Related PRs

https://github.com/facebookincubator/serde-reflection/pull/11