### PR TITLE
[move-prover] Add support for signer and move_to

### DIFF
--- a/language/move-prover/src/bytecode_translator.rs
+++ b/language/move-prover/src/bytecode_translator.rs
@@ -1181,15 +1181,29 @@ impl<'env> ModuleTranslator<'env> {
                         );
                         emitln!(self.writer, &update_and_track_local(dest, "$tmp"));
                     }
+                    MoveTo(mid, sid, type_actuals) => {
+                        let value = srcs[0];
+                        let signer = srcs[1];
+                        let resource_type =
+                            boogie_struct_type_value(self.module_env.env, *mid, *sid, type_actuals);
+                        emitln!(
+                            self.writer,
+                            "call $MoveTo({}, {}, {});",
+                            resource_type,
+                            str_local(value),
+                            str_local(signer),
+                        );
+                        emitln!(self.writer, &propagate_abort());
+                    }
                     MoveToSender(mid, sid, type_actuals) => {
-                        let src = srcs[0];
+                        let value = srcs[0];
                         let resource_type =
                             boogie_struct_type_value(self.module_env.env, *mid, *sid, type_actuals);
                         emitln!(
                             self.writer,
                             "call $MoveToSender({}, {});",
                             resource_type,
-                            str_local(src),
+                            str_local(value),
                         );
                         emitln!(self.writer, &propagate_abort());
                     }

--- a/language/move-prover/src/cli.rs
+++ b/language/move-prover/src/cli.rs
@@ -507,7 +507,7 @@ impl Options {
         } else if self.docgen {
             "doc".to_string()
         } else {
-            "ouput.bpl".to_string()
+            "output.bpl".to_string()
         };
         self.docgen_options.output_directory = self.output_path.clone();
         self.docgen_options.doc_path = get_vec("doc-path");

--- a/language/move-prover/stackless-bytecode-generator/src/stackless_bytecode.rs
+++ b/language/move-prover/stackless-bytecode-generator/src/stackless_bytecode.rs
@@ -95,6 +95,7 @@ pub enum Operation {
 
     // Resources
     MoveToSender(ModuleId, StructId, Vec<Type>),
+    MoveTo(ModuleId, StructId, Vec<Type>),
     MoveFrom(ModuleId, StructId, Vec<Type>),
     Exists(ModuleId, StructId, Vec<Type>),
 
@@ -533,6 +534,9 @@ impl<'env> fmt::Display for OperationDisplay<'env> {
             }
 
             // Resources
+            MoveTo(mid, sid, targs) => {
+                write!(f, "move_to<{}>", self.struct_str(*mid, *sid, targs))?;
+            }
             MoveToSender(mid, sid, targs) => {
                 write!(f, "move_to_sender<{}>", self.struct_str(*mid, *sid, targs))?;
             }

--- a/language/move-prover/stackless-bytecode-generator/src/stackless_bytecode_generator.rs
+++ b/language/move-prover/stackless-bytecode-generator/src/stackless_bytecode_generator.rs
@@ -1027,9 +1027,36 @@ impl<'a> StacklessBytecodeGenerator<'a> {
                 ));
             }
 
-            // TODO: translate these
-            MoveBytecode::MoveTo(_) => {}
-            MoveBytecode::MoveToGeneric(_) => {}
+            MoveBytecode::MoveTo(idx) => {
+                let value_operand_index = self.temp_stack.pop().unwrap();
+                let signer_operand_index = self.temp_stack.pop().unwrap();
+                self.code.push(mk_call(
+                    Operation::MoveTo(
+                        self.func_env.module_env.get_id(),
+                        self.func_env.module_env.get_struct_id(*idx),
+                        vec![],
+                    ),
+                    vec![],
+                    vec![value_operand_index, signer_operand_index],
+                ));
+            }
+
+            MoveBytecode::MoveToGeneric(idx) => {
+                let struct_instantiation = self.module.struct_instantiation_at(*idx);
+                let value_operand_index = self.temp_stack.pop().unwrap();
+                let signer_operand_index = self.temp_stack.pop().unwrap();
+                self.code.push(mk_call(
+                    Operation::MoveTo(
+                        self.func_env.module_env.get_id(),
+                        self.func_env
+                            .module_env
+                            .get_struct_id(struct_instantiation.def),
+                        self.get_type_params(struct_instantiation.type_parameters),
+                    ),
+                    vec![],
+                    vec![value_operand_index, signer_operand_index],
+                ));
+            }
 
             MoveBytecode::GetTxnSenderAddress => {
                 let temp_index = self.temp_count;

--- a/language/move-prover/tests/sources/functional/resources.exp
+++ b/language/move-prover/tests/sources/functional/resources.exp
@@ -1,11 +1,11 @@
 Move prover returns: exiting with boogie verification errors
 error:  A postcondition might not hold on this return path.
 
-    ┌── tests/sources/functional/resources.move:32:6 ───
+    ┌── tests/sources/functional/resources.move:40:6 ───
     │
- 32 │      ensures exists<R>(sender());
+ 40 │      ensures exists<R>(sender());
     │      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
     │
-    =     at tests/sources/functional/resources.move:25:5: create_resource_incorrect (entry)
-    =     at tests/sources/functional/resources.move:26:9: create_resource_incorrect
-    =     at tests/sources/functional/resources.move:25:5: create_resource_incorrect (exit)
+    =     at tests/sources/functional/resources.move:33:5: create_resource_incorrect (entry)
+    =     at tests/sources/functional/resources.move:34:9: create_resource_incorrect
+    =     at tests/sources/functional/resources.move:33:5: create_resource_incorrect (exit)

--- a/language/move-prover/tests/sources/functional/resources.move
+++ b/language/move-prover/tests/sources/functional/resources.move
@@ -1,10 +1,10 @@
 module TestResources {
     use 0x0::Transaction;
+    use 0x0::Signer;
 
     spec module {
         pragma verify = true;
     }
-
 
     // ---------------
     // Simple resource
@@ -12,6 +12,14 @@ module TestResources {
 
     resource struct R {
         x: u64
+    }
+
+    public fun create_resource_at_signer(account: &signer) {
+        move_to<R>(account, R{x:1});
+    }
+    spec fun create_resource_at_signer {
+        aborts_if exists<R>(Signer::get_address(account));
+        ensures exists<R>(Signer::get_address(account));
     }
 
     public fun create_resource() {

--- a/language/stdlib/modules/signer.move
+++ b/language/stdlib/modules/signer.move
@@ -13,5 +13,9 @@ module Signer {
     public fun address_of(s: &signer): address {
         *borrow_address(s)
     }
+
+    spec module {
+        native define get_address(account: signer): address;
+    }
 }
 }


### PR DESCRIPTION
## Motivation

This PR adds support for the primitive signer  type and for the new bytecode instruction move_to.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?

Yes.

## Test Plan

Existing tests and another test.

## Related PRs

None.
