### PR TITLE
[proof] TransactionInfoWithProof

### DIFF
--- a/grpc/types/src/unit_tests/proof_test.rs
+++ b/grpc/types/src/unit_tests/proof_test.rs
@@ -4,8 +4,8 @@
 use libra_prost_ext::test_helpers::assert_protobuf_encode_decode;
 use libra_types::proof::{
     AccountStateProof, AccumulatorConsistencyProof, EventProof, SparseMerkleProof,
-    SparseMerkleRangeProof, TestAccumulatorProof, TestAccumulatorRangeProof, TransactionListProof,
-    TransactionProof,
+    SparseMerkleRangeProof, TestAccumulatorProof, TestAccumulatorRangeProof,
+    TransactionInfoWithProof, TransactionListProof,
 };
 use proptest::prelude::*;
 
@@ -44,8 +44,8 @@ proptest! {
     }
 
     #[test]
-    fn test_transaction_proof_proto_roundtrip(proof in any::<TransactionProof>()) {
-        assert_protobuf_encode_decode::<crate::proto::types::TransactionProof, TransactionProof>(&proof);
+    fn test_transaction_proof_proto_roundtrip(proof in any::<TransactionInfoWithProof>()) {
+        assert_protobuf_encode_decode::<crate::proto::types::TransactionProof, TransactionInfoWithProof>(&proof);
     }
 
 

--- a/json-rpc/src/tests/mock_db.rs
+++ b/json-rpc/src/tests/mock_db.rs
@@ -13,7 +13,7 @@ use libra_types::{
     ledger_info::{LedgerInfo, LedgerInfoWithSignatures},
     proof::{
         AccumulatorConsistencyProof, AccumulatorRangeProof, SparseMerkleProof,
-        TransactionAccumulatorProof, TransactionListProof, TransactionProof,
+        TransactionAccumulatorProof, TransactionInfoWithProof, TransactionListProof,
     },
     transaction::{
         Transaction, TransactionInfo, TransactionListWithProof, TransactionWithProof, Version,
@@ -97,7 +97,7 @@ impl DbReader for MockLibraDB {
                 } else {
                     None
                 },
-                proof: TransactionProof::new(
+                proof: TransactionInfoWithProof::new(
                     TransactionAccumulatorProof::new(vec![]),
                     TransactionInfo::new(
                         Default::default(),

--- a/json-rpc/types/src/views.rs
+++ b/json-rpc/types/src/views.rs
@@ -511,10 +511,14 @@ impl TryFrom<AccountStateProof> for AccountStateProofView {
     fn try_from(account_state_proof: AccountStateProof) -> Result<AccountStateProofView, Error> {
         Ok(AccountStateProofView {
             ledger_info_to_transaction_info_proof: BytesView::from(&lcs::to_bytes(
-                account_state_proof.ledger_info_to_transaction_info_proof(),
+                account_state_proof
+                    .transaction_info_with_proof()
+                    .ledger_info_to_transaction_info_proof(),
             )?),
             transaction_info: BytesView::from(&lcs::to_bytes(
-                account_state_proof.transaction_info(),
+                account_state_proof
+                    .transaction_info_with_proof()
+                    .transaction_info(),
             )?),
             transaction_info_to_account_proof: BytesView::from(&lcs::to_bytes(
                 account_state_proof.transaction_info_to_account_proof(),

--- a/secure/json-rpc/src/lib.rs
+++ b/secure/json-rpc/src/lib.rs
@@ -286,6 +286,7 @@ mod test {
         mempool_status::{MempoolStatus, MempoolStatusCode},
         proof::{
             AccountStateProof, AccumulatorConsistencyProof, AccumulatorProof, SparseMerkleProof,
+            TransactionInfoWithProof,
         },
         test_helpers::transaction_test_helpers::get_test_signed_txn,
         transaction::{
@@ -446,8 +447,7 @@ mod test {
         );
 
         AccountStateProof::new(
-            AccumulatorProof::new(vec![]),
-            transaction_info,
+            TransactionInfoWithProof::new(AccumulatorProof::new(vec![]), transaction_info),
             SparseMerkleProof::new(None, vec![]),
         )
     }

--- a/storage/libradb/src/ledger_store/mod.rs
+++ b/storage/libradb/src/ledger_store/mod.rs
@@ -26,7 +26,7 @@ use libra_types::{
     ledger_info::LedgerInfoWithSignatures,
     proof::{
         definition::LeafCount, position::Position, AccumulatorConsistencyProof,
-        TransactionAccumulatorProof, TransactionAccumulatorRangeProof,
+        TransactionAccumulatorProof, TransactionAccumulatorRangeProof, TransactionInfoWithProof,
     },
     transaction::{TransactionInfo, Version},
 };
@@ -263,10 +263,10 @@ impl LedgerStore {
         &self,
         version: Version,
         ledger_version: Version,
-    ) -> Result<(TransactionInfo, TransactionAccumulatorProof)> {
-        Ok((
-            self.get_transaction_info(version)?,
+    ) -> Result<TransactionInfoWithProof> {
+        Ok(TransactionInfoWithProof::new(
             self.get_transaction_proof(version, ledger_version)?,
+            self.get_transaction_info(version)?,
         ))
     }
 

--- a/storage/libradb/src/ledger_store/transaction_info_test.rs
+++ b/storage/libradb/src/ledger_store/transaction_info_test.rs
@@ -19,12 +19,19 @@ fn verify(
         .for_each(|(idx, expected_txn_info)| {
             let version = first_version + idx as u64;
 
-            let (txn_info, proof) = store
+            let txn_info_with_proof = store
                 .get_transaction_info_with_proof(version, ledger_version)
                 .unwrap();
 
-            assert_eq!(&txn_info, expected_txn_info);
-            proof.verify(root_hash, txn_info.hash(), version).unwrap();
+            assert_eq!(txn_info_with_proof.transaction_info(), expected_txn_info);
+            txn_info_with_proof
+                .ledger_info_to_transaction_info_proof()
+                .verify(
+                    root_hash,
+                    txn_info_with_proof.transaction_info().hash(),
+                    version,
+                )
+                .unwrap();
         })
 }
 

--- a/storage/libradb/src/lib.rs
+++ b/storage/libradb/src/lib.rs
@@ -66,7 +66,7 @@ use libra_types::{
     ledger_info::LedgerInfoWithSignatures,
     proof::{
         AccountStateProof, AccumulatorConsistencyProof, EventProof, SparseMerkleProof,
-        SparseMerkleRangeProof, TransactionListProof, TransactionProof,
+        SparseMerkleRangeProof, TransactionListProof,
     },
     transaction::{
         TransactionInfo, TransactionListWithProof, TransactionToCommit, TransactionWithProof,
@@ -217,12 +217,9 @@ impl LibraDB {
         ledger_version: Version,
         fetch_events: bool,
     ) -> Result<TransactionWithProof> {
-        let proof = {
-            let (txn_info, txn_info_accumulator_proof) = self
-                .ledger_store
-                .get_transaction_info_with_proof(version, ledger_version)?;
-            TransactionProof::new(txn_info_accumulator_proof, txn_info)
-        };
+        let proof = self
+            .ledger_store
+            .get_transaction_info_with_proof(version, ledger_version)?;
         let transaction = self.transaction_store.get_transaction(version)?;
 
         // If events were requested, also fetch those.
@@ -509,10 +506,10 @@ impl LibraDB {
                     seq,
                     event.sequence_number()
                 );
-                let (txn_info, txn_info_proof) = self
+                let txn_info_with_proof = self
                     .ledger_store
                     .get_transaction_info_with_proof(ver, ledger_version)?;
-                let proof = EventProof::new(txn_info_proof, txn_info, event_proof);
+                let proof = EventProof::new(txn_info_with_proof, event_proof);
                 Ok(EventWithProof::new(ver, idx, event, proof))
             })
             .collect::<Result<Vec<_>>>()?;
@@ -830,7 +827,7 @@ impl DbReader for LibraDB {
             latest_version
         );
 
-        let (txn_info, txn_info_accumulator_proof) = self
+        let txn_info_with_proof = self
             .ledger_store
             .get_transaction_info_with_proof(version, ledger_version)?;
         let (account_state_blob, sparse_merkle_proof) = self
@@ -839,7 +836,7 @@ impl DbReader for LibraDB {
         Ok(AccountStateWithProof::new(
             version,
             account_state_blob,
-            AccountStateProof::new(txn_info_accumulator_proof, txn_info, sparse_merkle_proof),
+            AccountStateProof::new(txn_info_with_proof, sparse_merkle_proof),
         ))
     }
 

--- a/types/src/proof/mod.rs
+++ b/types/src/proof/mod.rs
@@ -31,8 +31,8 @@ use std::marker::PhantomData;
 pub use self::definition::{
     AccountStateProof, AccumulatorConsistencyProof, AccumulatorProof, AccumulatorRangeProof,
     EventAccumulatorProof, EventProof, SparseMerkleProof, SparseMerkleRangeProof,
-    TransactionAccumulatorProof, TransactionAccumulatorRangeProof, TransactionListProof,
-    TransactionProof,
+    TransactionAccumulatorProof, TransactionAccumulatorRangeProof, TransactionInfoWithProof,
+    TransactionListProof,
 };
 
 #[cfg(any(test, feature = "fuzzing"))]

--- a/types/src/proof/unit_tests/proof_conversion_test.rs
+++ b/types/src/proof/unit_tests/proof_conversion_test.rs
@@ -3,8 +3,8 @@
 
 use crate::proof::{
     AccountStateProof, AccumulatorConsistencyProof, EventProof, SparseMerkleProof,
-    SparseMerkleRangeProof, TestAccumulatorProof, TestAccumulatorRangeProof, TransactionListProof,
-    TransactionProof,
+    SparseMerkleRangeProof, TestAccumulatorProof, TestAccumulatorRangeProof,
+    TransactionInfoWithProof, TransactionListProof,
 };
 use lcs::test_helpers::assert_canonical_encode_decode;
 use proptest::prelude::*;
@@ -49,7 +49,7 @@ proptest! {
 
 
     #[test]
-    fn test_transaction_proof_lcs_roundtrip(proof in any::<TransactionProof>()) {
+    fn test_transaction_proof_lcs_roundtrip(proof in any::<TransactionInfoWithProof>()) {
         assert_canonical_encode_decode(proof);
     }
 


### PR DESCRIPTION
## Motivation

Renaming `TransactionProof` to `TransactionInfoWithProof`, because it is what it is. 
Use it to replace `(txn_info, txn_info_to_li_proff)` in EventProof & AcountStateProof, hence reduce usage of `verify_transaction_info()` to only one place.
Will use the newly named struct in the backup framework as well.

protobuf files kept untouched since they are going away.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?

(Write your answer here.)

## Test Plan

(Share your test plan here. If you changed code, please provide us with clear instructions for verifying that your changes work.)

## Related PRs

(If this PR adds or changes functionality, please take some time to update the docs at https://github.com/libra/website, and link to your PR here.)
