### PR TITLE
[cli] Tweak some output messages

### DIFF
--- a/testsuite/cli/src/client_proxy.rs
+++ b/testsuite/cli/src/client_proxy.rs
@@ -606,7 +606,7 @@ impl ClientProxy {
     /// Waits for the next transaction for a specific address and prints it
     pub fn wait_for_transaction(&mut self, account: AccountAddress, sequence_number: u64) {
         let mut max_iterations = 5000;
-        print!(
+        println!(
             "waiting for {} with sequence number {}",
             account, sequence_number
         );

--- a/testsuite/cli/src/transfer_commands.rs
+++ b/testsuite/cli/src/transfer_commands.rs
@@ -20,7 +20,7 @@ impl Command for TransferCommand {
          Suffix 'b' is for blocking. "
     }
     fn get_description(&self) -> &'static str {
-        "Transfer coins (in libra) from account to another."
+        "Transfer coins from one account to another."
     }
     fn execute(&self, client: &mut ClientProxy, params: &[&str]) {
         if params.len() < 5 || params.len() > 7 {


### PR DESCRIPTION
Remove the "(in libra)" part of a message now that other stablecoins can be used and add a missing newline so that subsequent "INFO" messages are more readable.

## Motivation

I'm updating some documentation and noticed these minor issues in the cli output.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

N/A