### PR TITLE
[vm] Report gas used instead of transaction fee in transaction output.

### DIFF
--- a/language/e2e-tests/src/tests/failed_transaction_tests.rs
+++ b/language/e2e-tests/src/tests/failed_transaction_tests.rs
@@ -39,7 +39,7 @@ fn failed_transaction_cleanup_test() {
         &account::lbr_currency_code(),
     );
     assert!(!out1.write_set().is_empty());
-    assert!(out1.gas_used() == 180_000);
+    assert_eq!(out1.gas_used(), 90_000);
     assert!(!out1.status().is_discarded());
     assert_eq!(
         out1.status().vm_status().major_status,

--- a/language/libra-vm/src/libra_vm.rs
+++ b/language/libra-vm/src/libra_vm.rs
@@ -1125,7 +1125,6 @@ fn get_transaction_output(
     let gas_used: u64 = txn_data
         .max_gas_amount()
         .sub(cost_strategy.remaining_gas())
-        .mul(txn_data.gas_unit_price())
         .get();
     let write_set = data_store.make_write_set()?;
     TXN_TOTAL_GAS_USAGE.observe(gas_used as f64);


### PR DESCRIPTION
We were multiplying the gas used by the gas unit price, and we were actually reporting the transaction fee as opposed to the gas used for the transaction. 