### PR TITLE
[move prover] generate warnings about unused schemas

### DIFF
--- a/language/move-prover/src/lib.rs
+++ b/language/move-prover/src/lib.rs
@@ -64,6 +64,10 @@ pub fn run_move_prover<W: WriteColor>(
         env.report_errors(error_writer);
         return Err(anyhow!("exiting with checking errors"));
     }
+    if env.has_warnings() {
+        env.report_warnings(error_writer);
+    }
+
     // Until this point, prover and docgen have same code. Here we part ways.
     if options.docgen {
         return run_docgen(&env, &options, now);

--- a/language/move-prover/tests/sources/functional/unused_schema.exp
+++ b/language/move-prover/tests/sources/functional/unused_schema.exp
@@ -1,0 +1,11 @@
+warning: unused schema TestUnusedSchema::AddsThree
+
+    ┌── tests/sources/functional/unused_schema.move:21:5 ───
+    │
+ 21 │ ╭     spec schema AddsThree {
+ 22 │ │         i: num;
+ 23 │ │         result: num;
+ 24 │ │         ensures result == i + 3;
+ 25 │ │     }
+    │ ╰─────^
+    │

--- a/language/move-prover/tests/sources/functional/unused_schema.move
+++ b/language/move-prover/tests/sources/functional/unused_schema.move
@@ -1,0 +1,34 @@
+module TestUnusedSchema {
+
+    spec module {
+        pragma verify = true;
+    }
+
+    spec schema AddsOne {
+        i: num;
+        result: num;
+        ensures result >= i + 1;
+    }
+
+    spec schema AddsTwo {
+        i: num;
+        result: num;
+        ensures result == i + 2;
+        include AddsOne;
+    }
+
+    // AddsThree is the only unused schema
+    spec schema AddsThree {
+        i: num;
+        result: num;
+        ensures result == i + 3;
+    }
+
+    fun foo(i: u64): u64 {
+        if (i > 10) { i + 2 } else { i + 1 }
+    }
+
+    spec fun foo {
+        include i > 10 ==> AddsTwo;
+    }
+}


### PR DESCRIPTION
<!--
Thank you for sending a PR. We appreciate you spending time to help improve the Libra project.

The project is undergoing daily changes. Pull Requests will be reviewed and responded to as time permits.
-->

## Motivation

This PR adds the generation of warnings about schemas that are defined but not used. Warnings are generated after spec checker phase. And unlike errors, Move Prover will not immediately exit after warnings.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?

Yes.

## Test Plan

Added a test `functional/unused_schema.move`.

