### PR TITLE
[safety-rules] address sign_proposal TODOs

### DIFF
--- a/consensus/consensus-types/src/block.rs
+++ b/consensus/consensus-types/src/block.rs
@@ -120,6 +120,10 @@ impl Block {
         )
     }
 
+    pub fn block_data(&self) -> &BlockData {
+        &self.block_data
+    }
+
     pub fn is_genesis_block(&self) -> bool {
         self.block_data.is_genesis_block()
     }

--- a/consensus/safety-rules/src/error.rs
+++ b/consensus/safety-rules/src/error.rs
@@ -20,6 +20,9 @@ pub enum Error {
     #[error("Internal error: {:?}", error)]
     InternalError { error: String },
 
+    #[error("Invalid proposal: {}", {0})]
+    InvalidProposal(String),
+
     #[error("Unable to verify that the new tree extneds the parent: {:?}", error)]
     InvalidAccumulatorExtension { error: String },
 


### PR DESCRIPTION
<!--
Thank you for sending a PR. We appreciate you spending time to help improve the Libra project.

The project is undergoing daily changes. Pull Requests will be reviewed and responded to as time permits.
-->

## Motivation

sign_proposal safety rules are for leaders to make safe proposal for other validators to vote on.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

The sign_proposal is called and exercised in the _consensus_ package which continously generates new proposal to sign by fuzzing.
The test only checks the method won't crash under fuzzing. It, however, does not check the _correctness_ of the methods (e.g. if the rules are correctly implemented).

## Related PRs

(If this PR adds or changes functionality, please take some time to update the docs at https://github.com/libra/website, and link to your PR here.)
