### PR TITLE
[network] add NetworkId to config to differentiate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1713,6 +1713,7 @@ dependencies = [
  "consensus 0.1.0",
  "consensus-types 0.1.0",
  "libra-canonical-serialization 0.1.0",
+ "libra-config 0.1.0",
  "libra-crypto 0.1.0",
  "libra-network-address 0.1.0",
  "libra-types 0.1.0",

--- a/config/config-builder/src/full_node_config.rs
+++ b/config/config-builder/src/full_node_config.rs
@@ -7,7 +7,9 @@ use libra_config::{
     config::{
         NetworkPeerInfo, NetworkPeersConfig, NodeConfig, PeerNetworkId, RoleType, UpstreamConfig,
     },
-    generator, utils,
+    generator,
+    network_id::NetworkId,
+    utils,
 };
 use libra_crypto::ed25519::Ed25519PrivateKey;
 use libra_network_address::NetworkAddress;
@@ -175,6 +177,7 @@ impl FullNodeConfig {
                 .full_node_networks
                 .get_mut(0)
                 .ok_or(Error::MissingFullNodeNetwork)?;
+            network.network_id = NetworkId::vfn_network();
             network.listen_address = utils::get_available_port_in_multiaddr(true);
             network.advertised_address = network.listen_address.clone();
             network.enable_remote_authentication = self.enable_remote_authentication;
@@ -208,6 +211,7 @@ impl FullNodeConfig {
                 .full_node_networks
                 .last_mut()
                 .ok_or(Error::MissingFullNodeNetwork)?;
+            network.network_id = NetworkId::Public;
             network.network_peers = network_peers.clone();
             network.seed_peers = seed_peers.clone();
             let mut upstream = UpstreamConfig::default();

--- a/config/config-builder/src/validator_config.rs
+++ b/config/config-builder/src/validator_config.rs
@@ -10,6 +10,7 @@ use libra_config::{
         VaultConfig,
     },
     generator,
+    network_id::NetworkId,
 };
 use libra_crypto::{ed25519::Ed25519PrivateKey, PrivateKey, Uniform};
 use libra_network_address::NetworkAddress;
@@ -86,6 +87,7 @@ impl ValidatorConfig {
             .validator_network
             .as_mut()
             .ok_or(Error::MissingValidatorNetwork)?;
+        validator_network.network_id = NetworkId::Validator;
         validator_network.listen_address = self.listen_address.clone();
         validator_network.advertised_address = self.advertised_address.clone();
         validator_network.seed_peers = seed_peers;

--- a/config/management/src/smoke_test.rs
+++ b/config/management/src/smoke_test.rs
@@ -3,9 +3,12 @@
 
 use crate::{layout::Layout, storage_helper::StorageHelper};
 use config_builder::{BuildSwarm, SwarmConfig};
-use libra_config::config::{
-    DiscoveryMethod, Identity, NetworkConfig, NodeConfig, OnDiskStorageConfig, RoleType,
-    SecureBackend,
+use libra_config::{
+    config::{
+        DiscoveryMethod, Identity, NetworkConfig, NodeConfig, OnDiskStorageConfig, RoleType,
+        SecureBackend,
+    },
+    network_id::NetworkId,
 };
 use libra_crypto::ed25519::Ed25519PrivateKey;
 use libra_secure_storage::Value;
@@ -69,11 +72,11 @@ fn smoke_test() {
         let validator_account = account_address::from_public_key(&operator_key);
         let mut config = NodeConfig::default();
 
-        let mut network = NetworkConfig::default();
+        let mut network = NetworkConfig::network_with_id(NetworkId::Validator);
         network.discovery_method = DiscoveryMethod::None;
         config.validator_network = Some(network);
 
-        let mut network = NetworkConfig::default();
+        let mut network = NetworkConfig::network_with_id(NetworkId::vfn_network());
         network.discovery_method = DiscoveryMethod::None;
         config.full_node_networks = vec![network];
         config.randomize_ports();

--- a/config/src/config/test_data/random.complete.node.config.toml
+++ b/config/src/config/test_data/random.complete.node.config.toml
@@ -84,3 +84,6 @@ seed_peers_file = "31893204fa402143c11b26ce8a89ea1d.seed_peers.toml"
 type = "from_config"
 key = "60dd107034b4582a2ef42c5e1ea475f2fea477a10a9f1d75b3635243b2506b72"
 peer_id = "31893204fa402143c11b26ce8a89ea1d"
+
+[validator_network.network_id]
+type = "Validator"

--- a/config/src/config/test_data/random.default.node.config.toml
+++ b/config/src/config/test_data/random.default.node.config.toml
@@ -6,6 +6,9 @@ type = "from_config"
 key = "60dd107034b4582a2ef42c5e1ea475f2fea477a10a9f1d75b3635243b2506b72"
 peer_id = "31893204fa402143c11b26ce8a89ea1d"
 
+[validator_network.network_id]
+type = "Validator"
+
 [test]
 auth_key = "837e3b2b2b32ee2543c24676ee66326431893204fa402143c11b26ce8a89ea1d"
 operator_private_key ="f6b898412f4ab061943167c1e23efaa2ba98e345a093f0b06da13bffdbd4b2c7"

--- a/config/src/config/test_data/single.node.config.toml
+++ b/config/src/config/test_data/single.node.config.toml
@@ -50,6 +50,9 @@ type = "from_config"
 key = "60dd107034b4582a2ef42c5e1ea475f2fea477a10a9f1d75b3635243b2506b72"
 peer_id = "31893204fa402143c11b26ce8a89ea1d"
 
+[validator_network.network_id]
+type = "Validator"
+
 [consensus]
 max_block_size = 1000
 max_pruned_blocks_in_mem = 10000

--- a/config/src/config/upstream_config.rs
+++ b/config/src/config/upstream_config.rs
@@ -7,19 +7,19 @@ use std::collections::HashSet;
 
 /// In general, a network ID is a PeerId that this node uses to uniquely identify a network it belongs to.
 /// This is equivalent to the `peer_id` field in the NetworkConfig of this NodeConfig
-pub type NetworkId = PeerId;
+pub type UpstreamNetworkId = PeerId;
 
 #[derive(Clone, Default, Debug, Deserialize, PartialEq, Serialize)]
 #[serde(default, deny_unknown_fields)]
 pub struct UpstreamConfig {
     // primary upstream network ids. All peers in such network are used as upstream for this node
-    pub primary_networks: Vec<NetworkId>,
+    pub primary_networks: Vec<UpstreamNetworkId>,
     // All upstream peers of this node, across all the networks that are statically defined in this node's config
     // this is mostly meaningful in VFN networks, where there is a strict hierarchy in a network
     pub upstream_peers: HashSet<PeerNetworkId>,
     // optional fallback network id. Used to as a failover if preferred upstream peers are not available
     // TODO replace PeerId with `NetworkConfig` to contain actual info needed to build fallback_network
-    pub fallback_networks: Vec<NetworkId>,
+    pub fallback_networks: Vec<UpstreamNetworkId>,
 }
 
 impl UpstreamConfig {
@@ -35,10 +35,10 @@ impl UpstreamConfig {
 
 #[derive(Copy, Clone, Debug, Deserialize, Eq, Hash, PartialEq, Serialize)]
 /// Identifier of a node, represented as (network_id, peer_id)
-pub struct PeerNetworkId(pub NetworkId, pub PeerId);
+pub struct PeerNetworkId(pub UpstreamNetworkId, pub PeerId);
 
 impl PeerNetworkId {
-    pub fn network_id(&self) -> NetworkId {
+    pub fn network_id(&self) -> UpstreamNetworkId {
         self.0
     }
 
@@ -47,6 +47,6 @@ impl PeerNetworkId {
     }
 
     pub fn random() -> Self {
-        Self(NetworkId::random(), PeerId::random())
+        Self(UpstreamNetworkId::random(), PeerId::random())
     }
 }

--- a/config/src/lib.rs
+++ b/config/src/lib.rs
@@ -6,4 +6,5 @@
 pub mod config;
 pub mod generator;
 pub mod keys;
+pub mod network_id;
 pub mod utils;

--- a/config/src/network_id.rs
+++ b/config/src/network_id.rs
@@ -1,0 +1,126 @@
+// Copyright (c) The Libra Core Contributors
+// SPDX-License-Identifier: Apache-2.0
+use serde::{Deserialize, Deserializer, Serialize, Serializer};
+
+#[derive(Clone, Debug, Deserialize, Eq, Hash, PartialEq, Serialize)]
+pub struct NetworkInfo {
+    name: String,
+}
+
+/// A representation of the network being used in communication.
+/// There should only be one of each NetworkId used for a single node, and handshakes should verify
+/// that the NetworkId being used is the same during a handshake, to effectively ensure communication
+/// is restricted to a network.  Network should be checked that it is not the `DEFAULT_NETWORK`
+#[derive(Clone, Debug, Eq, Hash, PartialEq)]
+pub enum NetworkId {
+    Validator,
+    Public,
+    Private(NetworkInfo),
+}
+
+/// Default needed to handle downstream structs that use `Default`
+impl Default for NetworkId {
+    fn default() -> NetworkId {
+        NetworkId::Public
+    }
+}
+
+impl NetworkId {
+    /// Convenience function to specify the VFN network
+    pub fn vfn_network() -> NetworkId {
+        NetworkId::private_network("VFN")
+    }
+
+    /// Creates a private network so we don't have to keep track of `NetworkInfo` outside of here.
+    pub fn private_network(name: &str) -> NetworkId {
+        NetworkId::Private(NetworkInfo {
+            name: name.to_string(),
+        })
+    }
+}
+
+#[derive(Serialize, Deserialize)]
+#[serde(tag = "type", rename = "NetworkId")]
+enum HumanReadableNetworkId {
+    Validator,
+    Public,
+    Private(NetworkInfo),
+}
+
+#[derive(Serialize, Deserialize)]
+#[serde(rename = "NetworkId")]
+enum NonHumanReadableNetworkId {
+    Validator,
+    Public,
+    Private(NetworkInfo),
+}
+
+impl Serialize for NetworkId {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        if serializer.is_human_readable() {
+            match self {
+                NetworkId::Validator => HumanReadableNetworkId::Validator,
+                NetworkId::Public => HumanReadableNetworkId::Public,
+                NetworkId::Private(info) => HumanReadableNetworkId::Private(info.clone()),
+            }
+            .serialize(serializer)
+        } else {
+            match self {
+                NetworkId::Validator => NonHumanReadableNetworkId::Validator,
+                NetworkId::Public => NonHumanReadableNetworkId::Public,
+                NetworkId::Private(info) => NonHumanReadableNetworkId::Private(info.clone()),
+            }
+            .serialize(serializer)
+        }
+    }
+}
+
+impl<'de> Deserialize<'de> for NetworkId {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        if deserializer.is_human_readable() {
+            Ok(match HumanReadableNetworkId::deserialize(deserializer)? {
+                HumanReadableNetworkId::Validator => NetworkId::Validator,
+                HumanReadableNetworkId::Public => NetworkId::Public,
+                HumanReadableNetworkId::Private(info) => NetworkId::Private(info),
+            })
+        } else {
+            Ok(
+                match NonHumanReadableNetworkId::deserialize(deserializer)? {
+                    NonHumanReadableNetworkId::Validator => NetworkId::Validator,
+                    NonHumanReadableNetworkId::Public => NetworkId::Public,
+                    NonHumanReadableNetworkId::Private(info) => NetworkId::Private(info),
+                },
+            )
+        }
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn test_serialization() {
+        let id = NetworkId::private_network("fooo");
+        let encoded = toml::to_string(&id).unwrap();
+        let decoded: NetworkId = toml::from_str(encoded.as_str()).unwrap();
+        assert_eq!(id, decoded);
+        let encoded = toml::to_vec(&id).unwrap();
+        let decoded: NetworkId = toml::from_slice(encoded.as_slice()).unwrap();
+        assert_eq!(id, decoded);
+
+        let id = NetworkId::Validator;
+        let encoded = toml::to_string(&id).unwrap();
+        let decoded: NetworkId = toml::from_str(encoded.as_str()).unwrap();
+        assert_eq!(id, decoded);
+        let encoded = toml::to_vec(&id).unwrap();
+        let decoded: NetworkId = toml::from_slice(encoded.as_slice()).unwrap();
+        assert_eq!(id, decoded);
+    }
+}

--- a/execution/execution-correctness/src/spawned_process.rs
+++ b/execution/execution-correctness/src/spawned_process.rs
@@ -18,7 +18,6 @@ impl SpawnedProcess {
         config_path.persist();
         config_path.create_as_file().unwrap();
         config.save_config(&config_path).unwrap();
-
         let service = &config.execution.service;
         let server_addr =
             if let ExecutionCorrectnessService::SpawnedProcess(remote_service) = service {

--- a/libra-node/src/main_node.rs
+++ b/libra-node/src/main_node.rs
@@ -131,6 +131,7 @@ pub fn setup_network(
 
     let mut network_builder = NetworkBuilder::new(
         runtime.handle().clone(),
+        config.network_id.clone(),
         peer_id,
         role,
         config.listen_address.clone(),

--- a/mempool/src/shared_mempool/coordinator.rs
+++ b/mempool/src/shared_mempool/coordinator.rs
@@ -23,7 +23,7 @@ use futures::{
     stream::{select_all, FuturesUnordered},
     StreamExt,
 };
-use libra_config::config::{NetworkId, NodeConfig, PeerNetworkId};
+use libra_config::config::{NodeConfig, PeerNetworkId, UpstreamNetworkId};
 use libra_logger::prelude::*;
 use libra_security_logger::{security_log, SecurityEvent};
 use libra_types::{on_chain_config::OnChainConfigPayload, transaction::SignedTransaction};
@@ -39,7 +39,7 @@ use vm_validator::vm_validator::TransactionValidation;
 pub(crate) async fn coordinator<V>(
     mut smp: SharedMempool<V>,
     executor: Handle,
-    network_events: Vec<(NetworkId, MempoolNetworkEvents)>,
+    network_events: Vec<(UpstreamNetworkId, MempoolNetworkEvents)>,
     mut client_events: mpsc::Receiver<(
         SignedTransaction,
         oneshot::Sender<Result<SubmissionStatus>>,

--- a/mempool/src/tests/mocks.rs
+++ b/mempool/src/tests/mocks.rs
@@ -10,7 +10,10 @@ use crate::{
 use anyhow::{format_err, Result};
 use channel::{self, libra_channel, message_queues::QueueStyle};
 use futures::channel::{mpsc, oneshot};
-use libra_config::config::{NetworkConfig, NodeConfig};
+use libra_config::{
+    config::{NetworkConfig, NodeConfig},
+    network_id::NetworkId,
+};
 use libra_types::{mempool_status::MempoolStatusCode, transaction::SignedTransaction};
 use network::peer_manager::{
     conn_notifs_channel, ConnectionRequestSender, PeerManagerRequestSender,
@@ -49,7 +52,7 @@ impl MockSharedMempool {
             .expect("[mock shared mempool] failed to create runtime");
 
         let mut config = NodeConfig::random();
-        config.validator_network = Some(NetworkConfig::default());
+        config.validator_network = Some(NetworkConfig::network_with_id(NetworkId::Validator));
         let peer_id = config.validator_network.as_ref().unwrap().peer_id();
 
         let mempool = Arc::new(Mutex::new(CoreMempool::new(&config)));

--- a/mempool/src/tests/shared_mempool_test.rs
+++ b/mempool/src/tests/shared_mempool_test.rs
@@ -20,7 +20,10 @@ use futures::{
     sink::SinkExt,
     StreamExt,
 };
-use libra_config::config::{NetworkConfig, NodeConfig, PeerNetworkId, RoleType, UpstreamConfig};
+use libra_config::{
+    config::{NetworkConfig, NodeConfig, PeerNetworkId, RoleType, UpstreamConfig},
+    network_id::NetworkId,
+};
 use libra_network_address::NetworkAddress;
 use libra_types::{transaction::SignedTransaction, PeerId};
 use network::{
@@ -182,7 +185,7 @@ impl SharedMempoolNetwork {
 
         for _ in 0..validator_nodes_count {
             let mut config = NodeConfig::random();
-            config.validator_network = Some(NetworkConfig::default());
+            config.validator_network = Some(NetworkConfig::network_with_id(NetworkId::Validator));
             let peer_id = config.validator_network.as_ref().unwrap().peer_id();
             config.mempool.shared_mempool_batch_size = broadcast_batch_size;
             config.upstream = UpstreamConfig::default();

--- a/network/src/protocols/identity.rs
+++ b/network/src/protocols/identity.rs
@@ -79,6 +79,7 @@ mod tests {
         ProtocolId,
     };
     use futures::{executor::block_on, future::join};
+    use libra_config::network_id::NetworkId;
     use libra_types::PeerId;
     use memsocket::MemorySocket;
 
@@ -88,10 +89,11 @@ mod tests {
 
     #[test]
     fn simple_handshake() {
+        let network_id = NetworkId::Validator;
         let (mut outbound, mut inbound) = build_test_connection();
 
         // Create client and server handshake messages.
-        let mut server_handshake = HandshakeMsg::new();
+        let mut server_handshake = HandshakeMsg::new(network_id.clone());
         server_handshake.add(
             MessagingProtocolVersion::V1,
             [
@@ -101,7 +103,7 @@ mod tests {
             .iter()
             .into(),
         );
-        let mut client_handshake = HandshakeMsg::new();
+        let mut client_handshake = HandshakeMsg::new(network_id);
         client_handshake.add(
             MessagingProtocolVersion::V1,
             [ProtocolId::ConsensusRpc, ProtocolId::ConsensusDirectSend]

--- a/network/src/protocols/network/dummy.rs
+++ b/network/src/protocols/network/dummy.rs
@@ -17,7 +17,7 @@ use crate::{
 };
 use channel::message_queues::QueueStyle;
 use futures::{executor::block_on, StreamExt};
-use libra_config::config::RoleType;
+use libra_config::{config::RoleType, network_id::NetworkId};
 use libra_crypto::{test_utils::TEST_SEED, x25519, Uniform};
 use libra_network_address::NetworkAddress;
 use libra_types::PeerId;
@@ -97,6 +97,7 @@ pub struct DummyNetwork {
 /// The following sets up a 2 peer network and verifies connectivity.
 pub fn setup_network() -> DummyNetwork {
     let runtime = Runtime::new().unwrap();
+    let network_id = NetworkId::Validator;
     let dialer_peer_id = PeerId::random();
     let listener_peer_id = PeerId::random();
 
@@ -134,6 +135,7 @@ pub fn setup_network() -> DummyNetwork {
     // Set up the listener network
     let mut network_builder = NetworkBuilder::new(
         runtime.handle().clone(),
+        network_id.clone(),
         listener_peer_id,
         RoleType::Validator,
         listener_addr,
@@ -148,6 +150,7 @@ pub fn setup_network() -> DummyNetwork {
     // Set up the dialer network
     let mut network_builder = NetworkBuilder::new(
         runtime.handle().clone(),
+        network_id,
         dialer_peer_id,
         RoleType::Validator,
         dialer_addr,

--- a/network/src/protocols/wire/handshake/v1/mod.rs
+++ b/network/src/protocols/wire/handshake/v1/mod.rs
@@ -10,6 +10,7 @@
 //! supported over that messaging protocol. On receipt, both ends will determine the highest
 //! intersecting messaging protocol version and use that for the remainder of the session.
 
+use libra_config::network_id::NetworkId;
 use serde::{Deserialize, Serialize};
 use std::{collections::BTreeMap, convert::TryInto, fmt, iter::Iterator};
 
@@ -61,6 +62,7 @@ pub struct SupportedProtocols(bitvec::BitVec);
 #[derive(Clone, Debug, Deserialize, Serialize, Default)]
 pub struct HandshakeMsg {
     pub supported_protocols: BTreeMap<MessagingProtocolVersion, SupportedProtocols>,
+    pub network_id: NetworkId,
 }
 
 /// Enum representing different versions of the Libra network protocol. These should be listed from
@@ -104,8 +106,11 @@ impl SupportedProtocols {
 }
 
 impl HandshakeMsg {
-    pub fn new() -> Self {
-        Self::default()
+    pub fn new(network_id: NetworkId) -> Self {
+        Self {
+            supported_protocols: Default::default(),
+            network_id,
+        }
     }
 
     pub fn add(

--- a/network/src/protocols/wire/handshake/v1/test.rs
+++ b/network/src/protocols/wire/handshake/v1/test.rs
@@ -29,6 +29,7 @@ fn protocols_to_from_vec() {
 
 #[test]
 fn common_protocols() {
+    let network_id = NetworkId::Validator;
     let h1: BTreeMap<_, _> = [(
         MessagingProtocolVersion::V1,
         [ProtocolId::ConsensusRpc, ProtocolId::DiscoveryDirectSend]
@@ -39,6 +40,7 @@ fn common_protocols() {
     .cloned()
     .collect();
     let h1 = HandshakeMsg {
+        network_id: network_id.clone(),
         supported_protocols: h1,
     };
 
@@ -53,6 +55,7 @@ fn common_protocols() {
     .cloned()
     .collect();
     let h2 = HandshakeMsg {
+        network_id: network_id.clone(),
         supported_protocols: h2,
     };
     assert_eq!(
@@ -65,6 +68,7 @@ fn common_protocols() {
 
     // Case 2: No intersecting messaging protocol version.
     let h2 = HandshakeMsg {
+        network_id: network_id.clone(),
         supported_protocols: BTreeMap::default(),
     };
     assert_eq!(None, h1.find_common_protocols(&h2));
@@ -75,6 +79,7 @@ fn common_protocols() {
         .cloned()
         .collect();
     let h2 = HandshakeMsg {
+        network_id,
         supported_protocols: h2,
     };
     assert_eq!(

--- a/state-synchronizer/src/coordinator.rs
+++ b/state-synchronizer/src/coordinator.rs
@@ -16,7 +16,9 @@ use futures::{
     stream::select_all,
     StreamExt,
 };
-use libra_config::config::{NetworkId, PeerNetworkId, RoleType, StateSyncConfig, UpstreamConfig};
+use libra_config::config::{
+    PeerNetworkId, RoleType, StateSyncConfig, UpstreamConfig, UpstreamNetworkId,
+};
 use libra_logger::prelude::*;
 use libra_mempool::{CommitNotification, CommitResponse, CommittedTransaction};
 use libra_types::{
@@ -94,7 +96,7 @@ pub(crate) struct SyncCoordinator<T> {
     // waypoint a node is not going to be abl
     waypoint: Option<Waypoint>,
     // network senders - (k, v) = (network ID, network sender)
-    network_senders: HashMap<NetworkId, StateSynchronizerSender>,
+    network_senders: HashMap<UpstreamNetworkId, StateSynchronizerSender>,
     // peers used for synchronization
     peer_manager: PeerManager,
     // Optional sync request to be called when the target sync is reached
@@ -112,7 +114,7 @@ impl<T: ExecutorProxyTrait> SyncCoordinator<T> {
     pub fn new(
         client_events: mpsc::UnboundedReceiver<CoordinatorMessage>,
         state_sync_to_mempool_sender: mpsc::Sender<CommitNotification>,
-        network_senders: HashMap<NetworkId, StateSynchronizerSender>,
+        network_senders: HashMap<UpstreamNetworkId, StateSynchronizerSender>,
         role: RoleType,
         waypoint: Option<Waypoint>,
         config: StateSyncConfig,

--- a/state-synchronizer/src/tests/integration_tests.rs
+++ b/state-synchronizer/src/tests/integration_tests.rs
@@ -8,7 +8,10 @@ use crate::{
 use anyhow::{bail, Result};
 use executor_types::ExecutedTrees;
 use futures::executor::block_on;
-use libra_config::config::{PeerNetworkId, RoleType};
+use libra_config::{
+    config::{PeerNetworkId, RoleType},
+    network_id::NetworkId,
+};
 use libra_crypto::{hash::ACCUMULATOR_PLACEHOLDER_HASH, test_utils::TEST_SEED, x25519, Uniform};
 use libra_mempool::mocks::MockSharedMempool;
 use libra_network_address::{NetworkAddress, RawNetworkAddress};
@@ -113,6 +116,7 @@ struct SynchronizerEnv {
     clients: Vec<Arc<StateSyncClient>>,
     storage_proxies: Vec<Arc<RwLock<MockStorage>>>, // to directly modify peers storage
     signers: Vec<ValidatorSigner>,
+    network_id: NetworkId,
     public_keys: Vec<ValidatorInfo>,
     peer_ids: Vec<PeerId>,
     peer_addresses: Vec<NetworkAddress>,
@@ -194,6 +198,7 @@ impl SynchronizerEnv {
             clients: vec![],
             storage_proxies: vec![],
             signers,
+            network_id: NetworkId::Validator,
             public_keys,
             peer_ids,
             peer_addresses: vec![],
@@ -242,6 +247,7 @@ impl SynchronizerEnv {
         }
         let mut network_builder = NetworkBuilder::new(
             self.runtime.handle().clone(),
+            self.network_id.clone(),
             self.peer_ids[new_peer_idx],
             RoleType::Validator,
             addr,

--- a/testsuite/generate-format/Cargo.toml
+++ b/testsuite/generate-format/Cargo.toml
@@ -20,6 +20,7 @@ structopt = "0.3.14"
 consensus = { path = "../../consensus", version = "0.1.0", features=["fuzzing"] }
 consensus-types = { path = "../../consensus/consensus-types", version = "0.1.0", features=["fuzzing"] }
 lcs = { path = "../../common/lcs", version = "0.1.0", package = "libra-canonical-serialization" }
+libra-config = { path = "../../config", version = "0.1.0" }
 libra-crypto = { path = "../../crypto/crypto", version = "0.1.0", features=["fuzzing"] }
 libra-types = { path = "../../types", version = "0.1.0", features=["fuzzing"] }
 libra-workspace-hack = { path = "../../common/workspace-hack", version = "0.1.0" }

--- a/testsuite/generate-format/src/network.rs
+++ b/testsuite/generate-format/src/network.rs
@@ -48,6 +48,7 @@ pub fn get_registry() -> Result<Registry> {
     tracer.trace_type::<messaging::v1::ErrorCode>(&samples)?;
     tracer.trace_type::<handshake::v1::ProtocolId>(&samples)?;
     tracer.trace_type::<address::Protocol>(&samples)?;
+    tracer.trace_type::<libra_config::network_id::NetworkId>(&samples)?;
 
     tracer.registry()
 }

--- a/testsuite/generate-format/tests/staged/network.yaml
+++ b/testsuite/generate-format/tests/staged/network.yaml
@@ -28,6 +28,8 @@ HandshakeMsg:
             TYPENAME: MessagingProtocolVersion
           VALUE:
             TYPENAME: SupportedProtocols
+    - network_id:
+        TYPENAME: NetworkId
 MessagingProtocolVersion:
   ENUM:
     0:
@@ -36,6 +38,19 @@ NetworkAddress:
   NEWTYPESTRUCT:
     SEQ:
       TYPENAME: Protocol
+NetworkId:
+  ENUM:
+    0:
+      Validator: UNIT
+    1:
+      Public: UNIT
+    2:
+      Private:
+        NEWTYPE:
+          TYPENAME: NetworkInfo
+NetworkInfo:
+  STRUCT:
+    - name: STR
 NetworkMessage:
   ENUM:
     0:


### PR DESCRIPTION
<!--
Thank you for sending a PR. We appreciate you spending time to help improve the Libra project.

The project is undergoing daily changes. Pull Requests will be reviewed and responded to as time permits.
-->

## Motivation

Each network device that is on a different network currently all log
the same way, which makes it difficult to determine which network that
one is looking at.  This allows us to differentiate both at a logging
level and later at a communication level between networks.

resolves #4012

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

Added tests to check that network handshakes work with the new network Ids.  This also means that both sides need to be updated for communication to work.

## Related PRs

(If this PR adds or changes functionality, please take some time to update the docs at https://github.com/libra/website, and link to your PR here.)
