### PR TITLE
[move-lang] fix offset in error message for invalid hexstring characters

### DIFF
--- a/language/move-lang/src/parser/syntax.rs
+++ b/language/move-lang/src/parser/syntax.rs
@@ -434,14 +434,17 @@ fn parse_byte_string<'input>(tokens: &mut Lexer<'input>) -> Result<Vec<u8>, Erro
     let s = tokens.content();
     assert!(s.starts_with("x\""));
     let mut hex_string = String::from(&s[2..s.len() - 1]);
-    if hex_string.len() % 2 != 0 {
+    let adjust = if hex_string.len() % 2 != 0 {
         hex_string.insert(0, '0');
-    }
+        1
+    } else {
+        0
+    };
     tokens.advance()?;
     match hex::decode(hex_string.as_str()) {
         Ok(vec) => Ok(vec),
         Err(hex::FromHexError::InvalidHexCharacter { c, index }) => {
-            let offset = start_loc + 1 + index;
+            let offset = start_loc + 2 - adjust + index;
             let loc = make_loc(tokens.file_name(), offset, offset);
             Err(vec![(
                 loc,

--- a/language/move-lang/tests/move_check/parser/hexstring_bad_value1.exp
+++ b/language/move-lang/tests/move_check/parser/hexstring_bad_value1.exp
@@ -1,8 +1,8 @@
 error: 
 
-   ┌── tests/move_check/parser/hexstring_bad_value1.move:3:11 ───
+   ┌── tests/move_check/parser/hexstring_bad_value1.move:4:11 ───
    │
- 3 │         x"g"
+ 4 │         x"g"
    │           ^ Invalid hexadecimal character: 'g'
    │
 

--- a/language/move-lang/tests/move_check/parser/hexstring_bad_value1.move
+++ b/language/move-lang/tests/move_check/parser/hexstring_bad_value1.move
@@ -1,5 +1,6 @@
 module M {
     public fun bad_value1(): vector<u8> {
+	// Test with an odd number of characters
         x"g"
     }
 }

--- a/language/move-lang/tests/move_check/parser/hexstring_bad_value2.exp
+++ b/language/move-lang/tests/move_check/parser/hexstring_bad_value2.exp
@@ -1,8 +1,8 @@
 error: 
 
-   ┌── tests/move_check/parser/hexstring_bad_value2.move:3:17 ───
+   ┌── tests/move_check/parser/hexstring_bad_value2.move:4:16 ───
    │
- 3 │         x"abcdefg"
-   │                 ^ Invalid hexadecimal character: 'g'
+ 4 │         x"bcdefg"
+   │                ^ Invalid hexadecimal character: 'g'
    │
 

--- a/language/move-lang/tests/move_check/parser/hexstring_bad_value2.move
+++ b/language/move-lang/tests/move_check/parser/hexstring_bad_value2.move
@@ -1,5 +1,6 @@
 module M {
     public fun bad_value2(): vector<u8> {
-        x"abcdefg"
+	// Test with an even number of characters
+        x"bcdefg"
     }
 }


### PR DESCRIPTION
The previous code had the wrong offset for hexstrings containing an even number of characters.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

Adjusted the existing tests so that we cover both cases of even and odd length hex strings. Verified that they now pass.