### PR TITLE
[move-prover] Repro for false positive in the presence of TRACE.

### DIFF
--- a/language/move-prover/src/cli.rs
+++ b/language/move-prover/src/cli.rs
@@ -355,8 +355,12 @@ impl Options {
                 _ => unreachable!("should not happen"),
             }
         }
-        options.move_sources = get_vec("sources");
-        options.move_deps = get_vec("dependencies");
+        if matches.occurrences_of("sources") > 0 {
+            options.move_sources = get_vec("sources");
+        }
+        if matches.occurrences_of("dependencies") > 0 {
+            options.move_deps = get_vec("dependencies");
+        }
         if matches.is_present("verify") {
             options.prover.verify_scope = match matches.value_of("verify").unwrap() {
                 "public" => VerificationScope::Public,

--- a/language/move-prover/tests/sources/regression/trace200527.exp
+++ b/language/move-prover/tests/sources/regression/trace200527.exp
@@ -1,0 +1,18 @@
+Move prover returns: exiting with boogie verification errors
+error:  A postcondition might not hold on this return path.
+
+    ┌── tests/sources/regression/trace200527.move:31:9 ───
+    │
+ 31 │         ensures sender() == root_address();
+    │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    ·
+ 15 │             all(domain<address>(), |addr| exists<Root>(TRACE(addr)) ==> TRACE(addr) == root_address())
+    │                                                        ----------- <redacted>
+    ·
+ 15 │             all(domain<address>(), |addr| exists<Root>(TRACE(addr)) ==> TRACE(addr) == root_address())
+    │                                                                         ----------- <redacted>
+    │
+    =     at tests/sources/regression/trace200527.move:20:5: assert_sender_is_root (entry)
+    =     at tests/sources/regression/trace200527.move:22:9: assert_sender_is_root
+    =         $t0 = <redacted>
+    =     at tests/sources/regression/trace200527.move:20:5: assert_sender_is_root (exit)

--- a/language/move-prover/tests/sources/regression/trace200527.move
+++ b/language/move-prover/tests/sources/regression/trace200527.move
@@ -1,0 +1,34 @@
+address 0x0 {
+
+module TraceBug {
+    use 0x0::Transaction;
+
+    resource struct Root { }
+
+    spec module {
+        define only_root_addr_has_root_privilege(): bool {
+            // With no TRACE, everything is fine.
+            //   all(domain<address>(), |addr| exists<Root>(addr) ==> addr == root_address())
+            // With one TRACE, everything is fine.
+            //   all(domain<address>(), |addr| exists<Root>(addr) ==> TRACE(addr) == root_address())
+            // BUG: With two TRACE, verification fails
+            all(domain<address>(), |addr| exists<Root>(TRACE(addr)) ==> TRACE(addr) == root_address())
+        }
+        define root_address(): address { 0xA550C18 }
+    }
+
+    public fun assert_sender_is_root() {
+        // Here we abort if the sender does not have Root privilege.
+        Transaction::assert(exists<Root>(Transaction::sender()), 1001);
+    }
+    spec fun assert_sender_is_root {
+        // The following two conditions usually come from invariants, but we have expanded them here for
+        // minimality.
+        requires only_root_addr_has_root_privilege();
+        ensures only_root_addr_has_root_privilege();
+
+        // Here we state that from the invariant it follows that the sender has root address.
+        ensures sender() == root_address();
+    }
+}
+}


### PR DESCRIPTION
Although TRACE is mapped to a Boogie function defined as identity as such:

```
function $DebugTrackExp(module_id: int, node_id: int, value: Value) : Value { value }
```

... adding it in certain scenarios leads to false positives -- that is, the prover reports an error whereas it verifies successfully without the TRACE. This PR adds a repro as a regression test.

As a side-effect, also fixing an issue with the new config file format. The dependency path and source files where overridden from command line defaults even without any flags, which is fixed now.


## Motivation

Bug hunt.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

Added regression test.

## Related PRs

NA
