### PR TITLE
[network] Consolidate UpdateAddress interface

### DIFF
--- a/network/src/connectivity_manager/test.rs
+++ b/network/src/connectivity_manager/test.rs
@@ -217,8 +217,10 @@ fn connect_to_seeds_on_startup() {
         conn_mgr_reqs_tx
             .send(ConnectivityRequest::UpdateAddresses(
                 DiscoverySource::Gossip,
-                seed_peer_id,
-                vec![seed_addr.clone()],
+                [(seed_peer_id, vec![seed_addr.clone()])]
+                    .iter()
+                    .cloned()
+                    .collect(),
             ))
             .await
             .unwrap();
@@ -233,8 +235,10 @@ fn connect_to_seeds_on_startup() {
         conn_mgr_reqs_tx
             .send(ConnectivityRequest::UpdateAddresses(
                 DiscoverySource::Gossip,
-                seed_peer_id,
-                vec![new_seed_addr.clone()],
+                [(seed_peer_id, vec![new_seed_addr.clone()])]
+                    .iter()
+                    .cloned()
+                    .collect(),
             ))
             .await
             .unwrap();
@@ -312,8 +316,10 @@ fn addr_change() {
         conn_mgr_reqs_tx
             .send(ConnectivityRequest::UpdateAddresses(
                 DiscoverySource::Gossip,
-                other_peer_id,
-                vec![other_address.clone()],
+                [(other_peer_id, vec![other_address.clone()])]
+                    .iter()
+                    .cloned()
+                    .collect(),
             ))
             .await
             .unwrap();
@@ -342,8 +348,10 @@ fn addr_change() {
         conn_mgr_reqs_tx
             .send(ConnectivityRequest::UpdateAddresses(
                 DiscoverySource::Gossip,
-                other_peer_id,
-                vec![other_address.clone()],
+                [(other_peer_id, vec![other_address.clone()])]
+                    .iter()
+                    .cloned()
+                    .collect(),
             ))
             .await
             .unwrap();
@@ -358,8 +366,10 @@ fn addr_change() {
         conn_mgr_reqs_tx
             .send(ConnectivityRequest::UpdateAddresses(
                 DiscoverySource::Gossip,
-                other_peer_id,
-                vec![other_address_new.clone()],
+                [(other_peer_id, vec![other_address_new.clone()])]
+                    .iter()
+                    .cloned()
+                    .collect(),
             ))
             .await
             .unwrap();
@@ -420,8 +430,10 @@ fn lost_connection() {
         conn_mgr_reqs_tx
             .send(ConnectivityRequest::UpdateAddresses(
                 DiscoverySource::Gossip,
-                other_peer_id,
-                vec![other_address.clone()],
+                [(other_peer_id, vec![other_address.clone()])]
+                    .iter()
+                    .cloned()
+                    .collect(),
             ))
             .await
             .unwrap();
@@ -494,8 +506,10 @@ fn disconnect() {
         conn_mgr_reqs_tx
             .send(ConnectivityRequest::UpdateAddresses(
                 DiscoverySource::Gossip,
-                other_peer_id,
-                vec![other_address.clone()],
+                [(other_peer_id, vec![other_address.clone()])]
+                    .iter()
+                    .cloned()
+                    .collect(),
             ))
             .await
             .unwrap();
@@ -561,8 +575,10 @@ fn retry_on_failure() {
         conn_mgr_reqs_tx
             .send(ConnectivityRequest::UpdateAddresses(
                 DiscoverySource::Gossip,
-                other_peer_id,
-                vec![other_address.clone()],
+                [(other_peer_id, vec![other_address.clone()])]
+                    .iter()
+                    .cloned()
+                    .collect(),
             ))
             .await
             .unwrap();
@@ -665,8 +681,10 @@ fn no_op_requests() {
         conn_mgr_reqs_tx
             .send(ConnectivityRequest::UpdateAddresses(
                 DiscoverySource::Gossip,
-                other_peer_id,
-                vec![other_address.clone()],
+                [(other_peer_id, vec![other_address.clone()])]
+                    .iter()
+                    .cloned()
+                    .collect(),
             ))
             .await
             .unwrap();
@@ -774,8 +792,10 @@ fn backoff_on_failure() {
         conn_mgr_reqs_tx
             .send(ConnectivityRequest::UpdateAddresses(
                 DiscoverySource::Gossip,
-                peer_a,
-                vec![peer_a_address.clone()],
+                [(peer_a, vec![peer_a_address.clone()])]
+                    .iter()
+                    .cloned()
+                    .collect(),
             ))
             .await
             .unwrap();
@@ -784,8 +804,10 @@ fn backoff_on_failure() {
         conn_mgr_reqs_tx
             .send(ConnectivityRequest::UpdateAddresses(
                 DiscoverySource::Gossip,
-                peer_b,
-                vec![peer_b_address.clone()],
+                [(peer_b, vec![peer_b_address.clone()])]
+                    .iter()
+                    .cloned()
+                    .collect(),
             ))
             .await
             .unwrap();
@@ -853,8 +875,13 @@ fn multiple_addrs_basic() {
         conn_mgr_reqs_tx
             .send(ConnectivityRequest::UpdateAddresses(
                 DiscoverySource::Gossip,
-                other_peer_id,
-                vec![other_addr_1.clone(), other_addr_2.clone()],
+                [(
+                    other_peer_id,
+                    vec![other_addr_1.clone(), other_addr_2.clone()],
+                )]
+                .iter()
+                .cloned()
+                .collect(),
             ))
             .await
             .unwrap();
@@ -921,8 +948,13 @@ fn multiple_addrs_wrapping() {
         conn_mgr_reqs_tx
             .send(ConnectivityRequest::UpdateAddresses(
                 DiscoverySource::Gossip,
-                other_peer_id,
-                vec![other_addr_1.clone(), other_addr_2.clone()],
+                [(
+                    other_peer_id,
+                    vec![other_addr_1.clone(), other_addr_2.clone()],
+                )]
+                .iter()
+                .cloned()
+                .collect(),
             ))
             .await
             .unwrap();
@@ -1006,12 +1038,17 @@ fn multiple_addrs_shrinking() {
         conn_mgr_reqs_tx
             .send(ConnectivityRequest::UpdateAddresses(
                 DiscoverySource::Gossip,
-                other_peer_id,
-                vec![
-                    other_addr_1.clone(),
-                    other_addr_2.clone(),
-                    other_addr_3.clone(),
-                ],
+                [(
+                    other_peer_id,
+                    vec![
+                        other_addr_1.clone(),
+                        other_addr_2.clone(),
+                        other_addr_3.clone(),
+                    ],
+                )]
+                .iter()
+                .cloned()
+                .collect(),
             ))
             .await
             .unwrap();
@@ -1042,8 +1079,13 @@ fn multiple_addrs_shrinking() {
         conn_mgr_reqs_tx
             .send(ConnectivityRequest::UpdateAddresses(
                 DiscoverySource::Gossip,
-                other_peer_id,
-                vec![other_addr_4.clone(), other_addr_5.clone()],
+                [(
+                    other_peer_id,
+                    vec![other_addr_4.clone(), other_addr_5.clone()],
+                )]
+                .iter()
+                .cloned()
+                .collect(),
             ))
             .await
             .unwrap();

--- a/network/src/protocols/discovery/mod.rs
+++ b/network/src/protocols/discovery/mod.rs
@@ -319,6 +319,7 @@ where
     // Updates local state by reconciling with notes received from some remote peer.
     // Assumption: `remote_notes` have already been verified for signature validity and content.
     async fn reconcile(&mut self, remote_peer: PeerId, remote_notes: Vec<VerifiedNote>) {
+        let mut change_detected = false;
         // If a peer is previously unknown, or has a newer epoch number, we update its
         // corresponding entry in the map.
         for mut note in remote_notes.into_iter() {
@@ -374,22 +375,28 @@ where
                         self.note = VerifiedNote(unverified_note);
                         note = self.note.clone();
                     } else {
-                        // The network addresses in the peer's discovery Note.
-                        let peer_addrs = note.as_note().addrs().clone();
-
-                        self.conn_mgr_reqs_tx
-                            .send(ConnectivityRequest::UpdateAddresses(
-                                DiscoverySource::Gossip,
-                                note.as_note().peer_id,
-                                peer_addrs,
-                            ))
-                            .await
-                            .expect("ConnectivityRequest::UpdateAddresses send");
+                        change_detected = true;
                     }
                     // Update internal state of the peer with new Note.
                     self.known_peers.insert(note.as_note().peer_id, note);
                 }
             }
+        }
+
+        if change_detected {
+            self.conn_mgr_reqs_tx
+                .send(ConnectivityRequest::UpdateAddresses(
+                    DiscoverySource::Gossip,
+                    self.known_peers
+                        .clone()
+                        .iter()
+                        .map(|(peer_id, verified_note)| {
+                            (*peer_id, verified_note.as_note().addrs().clone())
+                        })
+                        .collect(),
+                ))
+                .await
+                .expect("ConnectivityRequest::UpdateAddresses send");
         }
     }
 


### PR DESCRIPTION
<!--
Thank you for sending a PR. We appreciate you spending time to help improve the Libra project.

The project is undergoing daily changes. Pull Requests will be reviewed and responded to as time permits.
-->

## Motivation

Consolidate the ConnectivityManager _UpdateAddress()_ request to Update a set of addresses rather than just one.  This is a first step towards consolidating the update address and update eligible peers commands into one.

In the context of existing code, it consolidates potentially many changes into a single larger batch change.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?

yes

## Test Plan

Unit tests updated and smoke/integration tests should continue to pass.

## Related PRs

(If this PR adds or changes functionality, please take some time to update the docs at https://github.com/libra/website, and link to your PR here.)
