### PR TITLE
[client] Fix bad argument index's in client_proxy. Update mint name in json-rpc views

### DIFF
--- a/json-rpc/types/src/views.rs
+++ b/json-rpc/types/src/views.rs
@@ -403,7 +403,7 @@ impl From<TransactionPayload> for ScriptView {
                     Err(format_err!("Unable to parse PeerToPeer arguments"))
                 }
             }
-            "mint_transaction" => {
+            "mint" | "mint_lbr_to_address" => {
                 if let [TransactionArgument::Address(receiver), TransactionArgument::U8Vector(auth_key_prefix), TransactionArgument::U64(amount)] =
                     &args[..]
                 {

--- a/testsuite/cli/src/client_proxy.rs
+++ b/testsuite/cli/src/client_proxy.rs
@@ -346,9 +346,22 @@ impl ClientProxy {
         })?;
 
         let gas_unit_price = if space_delim_strings.len() > 3 {
-            Some(space_delim_strings[4].parse::<u64>().map_err(|error| {
+            Some(space_delim_strings[3].parse::<u64>().map_err(|error| {
                 format_parse_data_error(
                     "gas_unit_price",
+                    InputType::UnsignedInt,
+                    space_delim_strings[3],
+                    error,
+                )
+            })?)
+        } else {
+            None
+        };
+
+        let max_gas_amount = if space_delim_strings.len() > 4 {
+            Some(space_delim_strings[4].parse::<u64>().map_err(|error| {
+                format_parse_data_error(
+                    "max_gas_amount",
                     InputType::UnsignedInt,
                     space_delim_strings[4],
                     error,
@@ -358,21 +371,8 @@ impl ClientProxy {
             None
         };
 
-        let max_gas_amount = if space_delim_strings.len() > 4 {
-            Some(space_delim_strings[5].parse::<u64>().map_err(|error| {
-                format_parse_data_error(
-                    "max_gas_amount",
-                    InputType::UnsignedInt,
-                    space_delim_strings[5],
-                    error,
-                )
-            })?)
-        } else {
-            None
-        };
-
         let gas_currency_code = if space_delim_strings.len() > 5 {
-            Some(space_delim_strings[6].to_owned())
+            Some(space_delim_strings[5].to_owned())
         } else {
             None
         };


### PR DESCRIPTION
Invalid argument index's meant that you couldn't add a currency while specifying the gas currency. This fixes this so you can now do 
```
a addc 0 LBR 0 100000 Coin1
```

assuming account 0 has a Coin1 balance, and no LBR balance.

This also updates the script names for minting so that the JSON-RPC views report this correctly. This should be switched over to not be a string comparison, but instead grab the script from the hash and then check that. But that's for a later PR. 