### PR TITLE
[move_prover] Give closure an explicit return type

### DIFF
--- a/language/move-prover/spec-lang/src/ty.rs
+++ b/language/move-prover/spec-lang/src/ty.rs
@@ -459,7 +459,7 @@ impl Type {
 impl<'a> fmt::Display for TypeDisplay<'a> {
     fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
         use Type::*;
-        let comma_list = |f: &mut Formatter<'_>, ts: &[Type]| {
+        let comma_list = |f: &mut Formatter<'_>, ts: &[Type]| -> fmt::Result {
             let mut first = true;
             for t in ts {
                 if first {


### PR DESCRIPTION
## Summary

Without the explicit return type for closure, build fails for `libra/operations`

```
error[E0282]: type annotations needed for the closure `fn(&mut std::fmt::Formatter<'_>, &[ty::Type]) -> std::result::Result<(), _>`
   --> /usr/local/cargo/git/checkouts/libra-0f33c279f44a04b6/6560105/language/move-prover/spec-lang/src/ty.rs:468:21
    |
468 |                     f.write_str(", ")?;
    |                     ^^^^^^^^^^^^^^^^^^ cannot infer type
    |
help: give this closure an explicit return type without `_` placeholders
    |
462 |         let comma_list = |f: &mut Formatter<'_>, ts: &[Type]| -> std::result::Result<(), _> {
    |                                                               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

error: aborting due to previous error

```

## Test Plan

Built `libra/operations` successfully with this change