### PR TITLE
Block Executor with Strategies

### DIFF
--- a/language/e2e-tests/src/execution_strategies/basic_strategy.rs
+++ b/language/e2e-tests/src/execution_strategies/basic_strategy.rs
@@ -1,0 +1,54 @@
+// Copyright (c) The Libra Core Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+#![forbid(unsafe_code)]
+
+use crate::{
+    execution_strategies::types::{Block, Executor, ExecutorResult, PartitionStrategy},
+    executor::FakeExecutor,
+};
+use libra_types::{transaction::SignedTransaction, vm_error::VMStatus};
+
+#[derive(Debug, Clone)]
+pub struct BasicStrategy;
+
+impl PartitionStrategy for BasicStrategy {
+    type Txn = SignedTransaction;
+    fn partition(&mut self, block: Block<Self::Txn>) -> Vec<Block<SignedTransaction>> {
+        vec![block]
+    }
+}
+
+#[derive(Debug)]
+pub struct BasicExecutor {
+    executor: FakeExecutor,
+    strategy: BasicStrategy,
+}
+
+impl Default for BasicExecutor {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl BasicExecutor {
+    pub fn new() -> Self {
+        Self {
+            executor: FakeExecutor::from_genesis_file(),
+            strategy: BasicStrategy,
+        }
+    }
+}
+
+impl Executor for BasicExecutor {
+    type Txn = <BasicStrategy as PartitionStrategy>::Txn;
+    type BlockResult = VMStatus;
+    fn execute_block(&mut self, txns: Block<Self::Txn>) -> ExecutorResult<Self::BlockResult> {
+        let mut block = self.strategy.partition(txns);
+        let outputs = self.executor.execute_block(block.remove(0))?;
+        for output in &outputs {
+            self.executor.apply_write_set(output.write_set())
+        }
+        Ok(outputs)
+    }
+}

--- a/language/e2e-tests/src/execution_strategies/guided_strategy.rs
+++ b/language/e2e-tests/src/execution_strategies/guided_strategy.rs
@@ -1,0 +1,86 @@
+// Copyright (c) The Libra Core Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+#![forbid(unsafe_code)]
+use crate::{
+    execution_strategies::types::{Block, Executor, ExecutorResult, PartitionStrategy},
+    executor::FakeExecutor,
+};
+use libra_types::{transaction::SignedTransaction, vm_error::VMStatus};
+
+#[derive(Debug, Clone, PartialEq)]
+pub enum AnnotatedTransaction {
+    Block,
+    Txn(Box<SignedTransaction>),
+}
+
+#[derive(Debug, Clone)]
+pub struct PartitionedGuidedStrategy;
+
+impl PartitionStrategy for PartitionedGuidedStrategy {
+    type Txn = AnnotatedTransaction;
+    fn partition(&mut self, block: Block<Self::Txn>) -> Vec<Block<SignedTransaction>> {
+        block
+            .split(|atxn| atxn == &AnnotatedTransaction::Block)
+            .map(move |block| {
+                block
+                    .iter()
+                    .map(move |atxn| match atxn {
+                        AnnotatedTransaction::Block => unreachable!(),
+                        AnnotatedTransaction::Txn(txn) => *txn.clone(),
+                    })
+                    .collect()
+            })
+            .collect()
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct UnPartitionedGuidedStrategy;
+
+impl PartitionStrategy for UnPartitionedGuidedStrategy {
+    type Txn = AnnotatedTransaction;
+    fn partition(&mut self, block: Block<Self::Txn>) -> Vec<Block<SignedTransaction>> {
+        vec![block
+            .into_iter()
+            .filter_map(|atxn| match atxn {
+                AnnotatedTransaction::Block => None,
+                AnnotatedTransaction::Txn(txn) => Some(*txn),
+            })
+            .collect()]
+    }
+}
+
+pub struct GuidedExecutor<Strategy: PartitionStrategy> {
+    strategy: Strategy,
+    executor: FakeExecutor,
+}
+
+impl<Strategy: PartitionStrategy> GuidedExecutor<Strategy> {
+    pub fn new(strategy: Strategy) -> Self {
+        Self {
+            strategy,
+            executor: FakeExecutor::from_genesis_file(),
+        }
+    }
+}
+
+impl<Strategy: PartitionStrategy> Executor for GuidedExecutor<Strategy> {
+    type Txn = Strategy::Txn;
+    type BlockResult = VMStatus;
+    fn execute_block(&mut self, block: Block<Self::Txn>) -> ExecutorResult<Self::BlockResult> {
+        let mut outputs = vec![];
+        for block in self.strategy.partition(block).into_iter() {
+            outputs.extend(
+                self.executor
+                    .execute_block(block)?
+                    .into_iter()
+                    .map(|output| {
+                        self.executor.apply_write_set(output.write_set());
+                        output
+                    }),
+            )
+        }
+        Ok(outputs)
+    }
+}

--- a/language/e2e-tests/src/execution_strategies/mod.rs
+++ b/language/e2e-tests/src/execution_strategies/mod.rs
@@ -1,0 +1,10 @@
+// Copyright (c) The Libra Core Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+#![forbid(unsafe_code)]
+
+pub mod basic_strategy;
+pub mod guided_strategy;
+pub mod multi_strategy;
+pub mod random_strategy;
+pub mod types;

--- a/language/e2e-tests/src/execution_strategies/multi_strategy.rs
+++ b/language/e2e-tests/src/execution_strategies/multi_strategy.rs
@@ -1,0 +1,88 @@
+// Copyright (c) The Libra Core Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+#![forbid(unsafe_code)]
+use crate::execution_strategies::types::{Block, Executor, ExecutorResult};
+use libra_types::transaction::TransactionOutput;
+use std::{collections::BTreeMap, error::Error, fmt};
+
+#[derive(Debug)]
+pub enum MultiResult<E: Error> {
+    NonMatchingOutput(TransactionOutput, TransactionOutput),
+    OtherResult(E),
+}
+
+impl<E: Error> std::fmt::Display for MultiResult<E> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            MultiResult::OtherResult(err) => std::fmt::Display::fmt(&err, f),
+            MultiResult::NonMatchingOutput(output1, output2) => {
+                write!(f, "{:?} != {:?}", output1, output2)
+            }
+        }
+    }
+}
+
+impl<E: Error> Error for MultiResult<E> {
+    fn source(&self) -> Option<&(dyn Error + 'static)> {
+        match self {
+            MultiResult::OtherResult(err) => err.source(),
+            MultiResult::NonMatchingOutput(_output1, _output2) => None,
+        }
+    }
+}
+
+pub struct MultiExecutor<TxnType, E: Error> {
+    executors: Vec<Box<dyn Executor<Txn = TxnType, BlockResult = E>>>,
+}
+
+impl<TxnType, E: Error> Default for MultiExecutor<TxnType, E> {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl<TxnType, E: Error> MultiExecutor<TxnType, E> {
+    pub fn new() -> Self {
+        Self {
+            executors: Vec::new(),
+        }
+    }
+
+    pub fn add_executor(
+        &mut self,
+        executor: impl Executor<Txn = TxnType, BlockResult = E> + 'static,
+    ) {
+        self.executors.push(Box::new(executor))
+    }
+}
+
+impl<TxnType: Clone, E: Error> Executor for MultiExecutor<TxnType, E> {
+    type BlockResult = MultiResult<E>;
+    type Txn = TxnType;
+    fn execute_block(&mut self, block: Block<Self::Txn>) -> ExecutorResult<Self::BlockResult> {
+        let mut results = BTreeMap::new();
+        for executor in self.executors.iter_mut() {
+            let block = match executor.execute_block(block.clone()) {
+                Err(err) => return Err(MultiResult::OtherResult(err)),
+                Ok(block) => block,
+            };
+            for (index, output) in block.into_iter().enumerate() {
+                match results.get(&index) {
+                    None => {
+                        results.insert(index, output);
+                    }
+                    Some(previous_output) => {
+                        if &output != previous_output {
+                            return Err(MultiResult::NonMatchingOutput(
+                                output,
+                                previous_output.clone(),
+                            ));
+                        }
+                    }
+                }
+            }
+        }
+        Ok(results.into_iter().map(|(_, v)| v).collect())
+    }
+}

--- a/language/e2e-tests/src/execution_strategies/random_strategy.rs
+++ b/language/e2e-tests/src/execution_strategies/random_strategy.rs
@@ -1,0 +1,85 @@
+// Copyright (c) The Libra Core Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+#![forbid(unsafe_code)]
+use crate::{
+    execution_strategies::types::{Block, Executor, ExecutorResult, PartitionStrategy},
+    executor::FakeExecutor,
+};
+use libra_types::{transaction::SignedTransaction, vm_error::VMStatus};
+use rand::{
+    rngs::{OsRng, StdRng},
+    Rng, SeedableRng,
+};
+
+#[derive(Debug, Clone)]
+pub struct RandomizedStrategy {
+    gen: StdRng,
+}
+
+impl RandomizedStrategy {
+    pub fn from_seed(seed: [u8; 32]) -> Self {
+        Self {
+            gen: StdRng::from_seed(seed),
+        }
+    }
+
+    pub fn from_os_rng() -> Self {
+        let mut seed_rng = OsRng;
+        let seed: [u8; 32] = seed_rng.gen();
+        Self::from_seed(seed)
+    }
+}
+
+impl PartitionStrategy for RandomizedStrategy {
+    type Txn = SignedTransaction;
+    fn partition(&mut self, mut block: Block<Self::Txn>) -> Vec<Block<SignedTransaction>> {
+        let mut blocks = vec![];
+        while !block.is_empty() {
+            let block_size = self.gen.gen_range(0, block.len());
+            let new_block: Vec<_> = block.drain(0..block_size + 1).collect();
+            blocks.push(new_block);
+        }
+        blocks
+    }
+}
+
+#[derive(Debug)]
+pub struct RandomExecutor {
+    strategy: RandomizedStrategy,
+    executor: FakeExecutor,
+}
+
+impl RandomExecutor {
+    pub fn from_seed(seed: [u8; 32]) -> Self {
+        Self {
+            executor: FakeExecutor::from_genesis_file(),
+            strategy: RandomizedStrategy::from_seed(seed),
+        }
+    }
+
+    pub fn from_os_rng() -> Self {
+        RandomExecutor::from_seed(OsRng.gen::<[u8; 32]>())
+    }
+}
+
+impl Executor for RandomExecutor {
+    type Txn = SignedTransaction;
+    type BlockResult = VMStatus;
+    fn execute_block(&mut self, block: Block<Self::Txn>) -> ExecutorResult<Self::BlockResult> {
+        let blocks = self.strategy.partition(block);
+        let mut results = vec![];
+        for block in blocks.into_iter() {
+            results.extend(
+                self.executor
+                    .execute_block(block)?
+                    .into_iter()
+                    .map(|output| {
+                        self.executor.apply_write_set(output.write_set());
+                        output
+                    }),
+            )
+        }
+        Ok(results)
+    }
+}

--- a/language/e2e-tests/src/execution_strategies/types.rs
+++ b/language/e2e-tests/src/execution_strategies/types.rs
@@ -1,0 +1,19 @@
+// Copyright (c) The Libra Core Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+#![forbid(unsafe_code)]
+use libra_types::transaction::{SignedTransaction, TransactionOutput};
+
+pub type Block<Txn> = Vec<Txn>;
+pub type ExecutorResult<T> = Result<Vec<TransactionOutput>, T>;
+
+pub trait Executor {
+    type Txn;
+    type BlockResult: std::error::Error;
+    fn execute_block(&mut self, txns: Block<Self::Txn>) -> ExecutorResult<Self::BlockResult>;
+}
+
+pub trait PartitionStrategy {
+    type Txn;
+    fn partition(&mut self, block: Block<Self::Txn>) -> Vec<Block<SignedTransaction>>;
+}

--- a/language/e2e-tests/src/lib.rs
+++ b/language/e2e-tests/src/lib.rs
@@ -17,6 +17,7 @@ pub mod account_universe;
 pub mod common_transactions;
 pub mod compile;
 pub mod data_store;
+pub mod execution_strategies;
 pub mod executor;
 pub mod gas_costs;
 pub mod keygen;

--- a/language/e2e-tests/src/tests.rs
+++ b/language/e2e-tests/src/tests.rs
@@ -12,6 +12,7 @@
 mod account_universe;
 mod create_account;
 mod data_store;
+mod execution_strategies;
 mod failed_transaction_tests;
 mod genesis;
 mod mint;

--- a/language/e2e-tests/src/tests/execution_strategies.rs
+++ b/language/e2e-tests/src/tests/execution_strategies.rs
@@ -1,0 +1,114 @@
+// Copyright (c) The Libra Core Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::{
+    account::Account,
+    common_transactions::create_account_txn,
+    execution_strategies::{
+        basic_strategy::BasicExecutor,
+        guided_strategy::{
+            AnnotatedTransaction, GuidedExecutor, PartitionedGuidedStrategy,
+            UnPartitionedGuidedStrategy,
+        },
+        multi_strategy::MultiExecutor,
+        random_strategy::RandomExecutor,
+        types::Executor,
+    },
+};
+use libra_types::{transaction::SignedTransaction, vm_error::VMStatus};
+
+fn txn(seq_num: u64) -> SignedTransaction {
+    let account = Account::new();
+    let assoc = Account::new_association();
+    create_account_txn(&assoc, &account, seq_num + 1, 0)
+}
+
+#[test]
+fn test_execution_strategies() {
+    {
+        println!("===========================================================================");
+        println!("TESTING BASIC STRATEGY");
+        println!("===========================================================================");
+        let big_block = (0..10).map(txn).collect();
+        let mut exec = BasicExecutor::new();
+        exec.execute_block(big_block).unwrap();
+    }
+
+    {
+        println!("===========================================================================");
+        println!("TESTING RANDOM STRATEGY");
+        println!("===========================================================================");
+        let big_block = (0..10).map(txn).collect();
+        let mut exec = RandomExecutor::from_os_rng();
+        exec.execute_block(big_block).unwrap();
+    }
+
+    {
+        println!("===========================================================================");
+        println!("TESTING GUIDED STRATEGY");
+        println!("===========================================================================");
+        let mut block1: Vec<_> = (0..10)
+            .map(|i| AnnotatedTransaction::Txn(Box::new(txn(i))))
+            .collect();
+        block1.push(AnnotatedTransaction::Block);
+        let mut block = (0..5)
+            .map(|i| AnnotatedTransaction::Txn(Box::new(txn(i + 10))))
+            .collect();
+        block1.append(&mut block);
+        block1.push(AnnotatedTransaction::Block);
+        let mut block: Vec<_> = (0..7)
+            .map(|i| AnnotatedTransaction::Txn(Box::new(txn(i + 15))))
+            .collect();
+        block1.append(&mut block);
+        block1.push(AnnotatedTransaction::Block);
+        let mut block = (0..20)
+            .map(|i| AnnotatedTransaction::Txn(Box::new(txn(i + 22))))
+            .collect();
+        block1.append(&mut block);
+
+        let mut exec = GuidedExecutor::new(PartitionedGuidedStrategy);
+        exec.execute_block(block1).unwrap();
+    }
+
+    {
+        println!("===========================================================================");
+        println!("TESTING COMPOSED STRATEGY 1");
+        println!("===========================================================================");
+        let mut block1: Vec<_> = (0..10)
+            .map(|i| AnnotatedTransaction::Txn(Box::new(txn(i))))
+            .collect();
+        block1.push(AnnotatedTransaction::Block);
+        let mut block = (0..5)
+            .map(|i| AnnotatedTransaction::Txn(Box::new(txn(i + 10))))
+            .collect();
+        block1.append(&mut block);
+        block1.push(AnnotatedTransaction::Block);
+        let mut block: Vec<_> = (0..7)
+            .map(|i| AnnotatedTransaction::Txn(Box::new(txn(i + 15))))
+            .collect();
+        block1.append(&mut block);
+        block1.push(AnnotatedTransaction::Block);
+        let mut block = (0..20)
+            .map(|i| AnnotatedTransaction::Txn(Box::new(txn(i + 22))))
+            .collect();
+        block1.append(&mut block);
+
+        let mut exec = MultiExecutor::<AnnotatedTransaction, VMStatus>::new();
+        exec.add_executor(GuidedExecutor::new(PartitionedGuidedStrategy));
+        exec.add_executor(GuidedExecutor::new(UnPartitionedGuidedStrategy));
+        exec.execute_block(block1).unwrap();
+    }
+
+    {
+        println!("===========================================================================");
+        println!("TESTING COMPOSED STRATEGY 2");
+        println!("===========================================================================");
+        let block = (0..10).map(txn).collect();
+
+        let mut exec = MultiExecutor::<SignedTransaction, VMStatus>::new();
+        exec.add_executor(RandomExecutor::from_os_rng());
+        exec.add_executor(RandomExecutor::from_os_rng());
+        exec.add_executor(RandomExecutor::from_os_rng());
+        exec.execute_block(block).unwrap();
+    }
+}


### PR DESCRIPTION
This PR proposes a block executor interface that allows user-defined strategies for testing out different block packings of transactions. You can see example strategy definitions in `basic_strategy`, `guided_strategy`, and `random_strategy`.

The basic premise of this is that it takes in a block and executes that block. From the caller's perspective, this is no different from executing a normal block.

However, it can also segment that block into different sub-blocks based upon the strategy used in order to provide different segmentations of that same block (given by the `schedule` function). 

You can see examples of how to use this in the new test, and examples strategies under `execution_strategies`. 