### PR TITLE
[secure-storage] Implement an optional ability to import keys

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2883,6 +2883,7 @@ name = "libra-vault-client"
 version = "0.1.0"
 dependencies = [
  "base64 0.12.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "chrono 0.4.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "libra-crypto 0.1.0",
  "libra-workspace-hack 0.1.0",
  "rustls 0.17.0 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/consensus/safety-rules/src/persistent_safety_storage.rs
+++ b/consensus/safety-rules/src/persistent_safety_storage.rs
@@ -41,7 +41,7 @@ impl PersistentSafetyStorage {
         private_key: Ed25519PrivateKey,
         waypoint: Waypoint,
     ) -> Result<()> {
-        internal_store.set(CONSENSUS_KEY, Value::Ed25519PrivateKey(private_key))?;
+        internal_store.import_private_key(CONSENSUS_KEY, private_key)?;
         internal_store.set(EPOCH, Value::U64(1))?;
         internal_store.set(LAST_VOTED_ROUND, Value::U64(0))?;
         internal_store.set(PREFERRED_ROUND, Value::U64(0))?;
@@ -56,16 +56,9 @@ impl PersistentSafetyStorage {
     }
 
     pub fn consensus_key(&self) -> Result<Ed25519PrivateKey> {
-        Ok(self
-            .internal_store
-            .get(CONSENSUS_KEY)
-            .and_then(|r| r.value.ed25519_private_key())?)
-    }
-
-    pub fn set_consensus_key(&mut self, consensus_key: Ed25519PrivateKey) -> Result<()> {
         self.internal_store
-            .set(CONSENSUS_KEY, Value::Ed25519PrivateKey(consensus_key))?;
-        Ok(())
+            .export_private_key(CONSENSUS_KEY)
+            .map_err(|e| e.into())
     }
 
     pub fn epoch(&self) -> Result<u64> {

--- a/secure/storage/src/crypto_storage.rs
+++ b/secure/storage/src/crypto_storage.rs
@@ -29,6 +29,15 @@ pub trait CryptoStorage: Send + Sync {
     /// retrieve the private key, this call will fail with an error.
     fn export_private_key(&self, name: &str) -> Result<Ed25519PrivateKey, Error>;
 
+    /// An optional API that allows importing private keys. It will store the key at the given
+    /// name. This is not expected to be used in production and the API may throw unimplemented if
+    /// not used correctly. As this is purely a testing API, there is no defined behavior for
+    /// importing a key for a given name if that name already exists.  It only exists to allow
+    /// Libra to be run in test environments where a set of deterministic keys must be generated.
+    fn import_private_key(&mut self, _name: &str, _key: Ed25519PrivateKey) -> Result<(), Error> {
+        unimplemented!();
+    }
+
     /// Returns the private key for a given Ed25519 key pair version, as identified by the
     /// 'name' and 'version'. If the key pair at the specified version doesn't
     /// exist, or the caller doesn't have the appropriate permissions to retrieve the private key,

--- a/secure/storage/src/tests/vault.rs
+++ b/secure/storage/src/tests/vault.rs
@@ -20,10 +20,10 @@ const VAULT_NAMESPACE_3: &str = "namespace_3";
 /// storage resets can interfere between tests. To avoid this, we run each test sequentially, and
 /// reset the storage engine only after each test.
 const VAULT_TESTS: &[fn()] = &[
-    test_vault_crypto_policies,
-    test_vault_key_value_policies,
     test_suite_multiple_namespaces,
     test_suite_no_namespaces,
+    test_vault_crypto_policies,
+    test_vault_key_value_policies,
 ];
 
 /// A test for verifying VaultStorage properly implements the LibraSecureStorage API and enforces

--- a/secure/storage/vault/Cargo.toml
+++ b/secure/storage/vault/Cargo.toml
@@ -11,6 +11,7 @@ edition = "2018"
 
 [dependencies]
 base64 = "0.12.1"
+chrono = "0.4.9"
 rustls = "0.17.0"
 serde = { version = "1.0.111", features = ["derive"], default-features = false }
 serde_json = "1.0.53"


### PR DESCRIPTION
May the crypto gods forgive me... but moving forward, we will probably
have cluster test and various test networks using vault yet test
networks depend on the ability to generate keys deterministically. So we
introduce a means to "import" keys into various secure storages. Because
this is for testing only, it is optional to implement and users should be
extremely careful using it.