### PR TITLE
[json-rpc] update TransactionView and get_metadata

### DIFF
--- a/client/json-rpc/src/client.rs
+++ b/client/json-rpc/src/client.rs
@@ -47,8 +47,8 @@ impl JsonRpcBatch {
         );
     }
 
-    pub fn add_get_metadata_request(&mut self) {
-        self.add_request("get_metadata".to_string(), vec![]);
+    pub fn add_get_metadata_request(&mut self, version: Option<u64>) {
+        self.add_request("get_metadata".to_string(), vec![json!(version)]);
     }
 
     pub fn add_get_currencies_info(&mut self) {

--- a/json-rpc/src/methods.rs
+++ b/json-rpc/src/methods.rs
@@ -13,6 +13,7 @@ use anyhow::{ensure, format_err, Error, Result};
 use core::future::Future;
 use debug_interface::prelude::*;
 use futures::{channel::oneshot, SinkExt};
+use libra_crypto::hash::CryptoHash;
 use libra_mempool::MempoolClientSender;
 use libra_types::{
     account_address::AccountAddress,
@@ -172,6 +173,7 @@ async fn get_transactions(
 
         result.push(TransactionView {
             version: start_version + v as u64,
+            hash: tx.hash().to_string(),
             transaction: tx.into(),
             events,
             vm_status: info.major_status(),
@@ -214,6 +216,7 @@ async fn get_account_transaction(
 
         Ok(Some(TransactionView {
             version: tx_version,
+            hash: tx.transaction.hash().to_string(),
             transaction: tx.transaction.into(),
             events,
             vm_status: tx.proof.transaction_info().major_status(),

--- a/json-rpc/src/tests/unit_tests.rs
+++ b/json-rpc/src/tests/unit_tests.rs
@@ -312,7 +312,7 @@ fn test_get_metadata() {
 
     let (actual_version, actual_timestamp) = mock_db.get_latest_commit_metadata().unwrap();
     let mut batch = JsonRpcBatch::default();
-    batch.add_get_metadata_request();
+    batch.add_get_metadata_request(None);
 
     let result = execute_batch_and_get_first_response(&client, &mut runtime, batch);
 

--- a/json-rpc/src/tests/unit_tests.rs
+++ b/json-rpc/src/tests/unit_tests.rs
@@ -8,7 +8,7 @@ use crate::{
 };
 use futures::{channel::mpsc::channel, StreamExt};
 use libra_config::utils;
-use libra_crypto::{ed25519::Ed25519PrivateKey, HashValue, PrivateKey, Uniform};
+use libra_crypto::{ed25519::Ed25519PrivateKey, hash::CryptoHash, HashValue, PrivateKey, Uniform};
 use libra_json_rpc_client::{
     views::{
         AccountStateWithProofView, BlockMetadata, BytesView, EventView, StateProofView,
@@ -373,6 +373,7 @@ fn test_get_transactions() {
             let version = base_version + i as u64;
             assert_eq!(view.version, version);
             let (tx, status) = &mock_db.all_txns[version as usize];
+            assert_eq!(view.hash, tx.hash().to_string());
 
             // Check we returned correct events
             let expected_events = mock_db
@@ -447,6 +448,7 @@ fn test_get_account_transaction() {
                 .find_map(|(t, status)| {
                     if let Ok(x) = t.as_signed_user_txn() {
                         if x.sender() == *acc && x.sequence_number() == seq {
+                            assert_eq!(tx_view.hash, t.hash().to_string());
                             return Some((x, status));
                         }
                     }

--- a/json-rpc/types/src/views.rs
+++ b/json-rpc/types/src/views.rs
@@ -266,6 +266,7 @@ impl From<&Vec<u8>> for BytesView {
 pub struct TransactionView {
     pub version: u64,
     pub transaction: TransactionDataView,
+    pub hash: String,
     pub events: Vec<EventView>,
     pub vm_status: StatusCode,
     pub gas_used: u64,

--- a/testsuite/cli/src/libra_client.rs
+++ b/testsuite/cli/src/libra_client.rs
@@ -185,7 +185,7 @@ impl LibraClient {
     /// Gets the block metadata
     pub fn get_metadata(&mut self) -> Result<BlockMetadata> {
         let mut batch = JsonRpcBatch::new();
-        batch.add_get_metadata_request();
+        batch.add_get_metadata_request(None);
         let responses = self.client.execute(batch)?;
 
         match get_response_from_batch(0, &responses)? {


### PR DESCRIPTION
## Summary

- expose txn hash in TransactionView
- add optional version arg for get_metadata to support querying blockchain metadata for past versions, not just the most current one. If no version is provided, default to original behavior of returning current blockchain metadata

## Test Plan

Existing/updated tests