### PR TITLE
[proptest] upgrade to proptest 0.10.0, proptest-derive 0.2.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -18,7 +18,7 @@ dependencies = [
  "libra-types 0.1.0",
  "libra-workspace-hack 0.1.0",
  "mirai-annotations 1.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "proptest 0.9.6 (git+https://github.com/mimoo/proptest.git?branch=fuzzing)",
+ "proptest 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.7.3 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -284,7 +284,7 @@ dependencies = [
  "libra-types 0.1.0",
  "libra-workspace-hack 0.1.0",
  "libradb 0.1.0",
- "proptest 0.9.6 (git+https://github.com/mimoo/proptest.git?branch=fuzzing)",
+ "proptest 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.7.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "reqwest 0.10.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "storage-interface 0.1.0",
@@ -548,7 +548,7 @@ dependencies = [
  "libra-workspace-hack 0.1.0",
  "move-core-types 0.1.0",
  "petgraph 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "proptest 0.9.6 (git+https://github.com/mimoo/proptest.git?branch=fuzzing)",
+ "proptest 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "stdlib 0.1.0",
  "vm 0.1.0",
 ]
@@ -728,7 +728,7 @@ dependencies = [
  "libra-wallet 0.1.0",
  "libra-workspace-hack 0.1.0",
  "num-traits 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
- "proptest 0.9.6 (git+https://github.com/mimoo/proptest.git?branch=fuzzing)",
+ "proptest 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "reqwest 0.10.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "resource-viewer 0.1.0",
  "rust_decimal 1.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -906,7 +906,7 @@ dependencies = [
  "num-derive 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "num-traits 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "once_cell 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "proptest 0.9.6 (git+https://github.com/mimoo/proptest.git?branch=fuzzing)",
+ "proptest 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.7.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "safety-rules 0.1.0",
  "schemadb 0.1.0",
@@ -934,7 +934,7 @@ dependencies = [
  "libra-types 0.1.0",
  "libra-workspace-hack 0.1.0",
  "mirai-annotations 1.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "proptest 0.9.6 (git+https://github.com/mimoo/proptest.git?branch=fuzzing)",
+ "proptest 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.110 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -1393,7 +1393,7 @@ dependencies = [
  "libradb 0.1.0",
  "move-core-types 0.1.0",
  "once_cell 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "proptest 0.9.6 (git+https://github.com/mimoo/proptest.git?branch=fuzzing)",
+ "proptest 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.7.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "scratchpad 0.1.0",
  "serde_json 1.0.53 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1665,7 +1665,7 @@ dependencies = [
  "libra-workspace-hack 0.1.0",
  "move-core-types 0.1.0",
  "network 0.1.0",
- "proptest 0.9.6 (git+https://github.com/mimoo/proptest.git?branch=fuzzing)",
+ "proptest 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.7.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.110 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde-reflection 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1766,7 +1766,7 @@ dependencies = [
  "libra-prost-test-helpers 0.1.0",
  "libra-types 0.1.0",
  "libra-workspace-hack 0.1.0",
- "proptest 0.9.6 (git+https://github.com/mimoo/proptest.git?branch=fuzzing)",
+ "proptest 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "prost 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "prost-build 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -2011,7 +2011,7 @@ dependencies = [
  "libra-proptest-helpers 0.1.0",
  "libra-types 0.1.0",
  "libra-workspace-hack 0.1.0",
- "proptest 0.9.6 (git+https://github.com/mimoo/proptest.git?branch=fuzzing)",
+ "proptest 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "vm 0.1.0",
 ]
 
@@ -2114,8 +2114,8 @@ dependencies = [
  "mirai-annotations 1.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "num-derive 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "num-traits 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
- "proptest 0.9.6 (git+https://github.com/mimoo/proptest.git?branch=fuzzing)",
- "proptest-derive 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "proptest 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "proptest-derive 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.7.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.110 (registry+https://github.com/rust-lang/crates.io-index)",
  "thiserror 1.0.19 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2230,7 +2230,7 @@ dependencies = [
  "move-lang 0.0.1",
  "move-vm-runtime 0.1.0",
  "move-vm-types 0.1.0",
- "proptest 0.9.6 (git+https://github.com/mimoo/proptest.git?branch=fuzzing)",
+ "proptest 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "vm 0.1.0",
 ]
 
@@ -2254,8 +2254,8 @@ dependencies = [
  "move-vm-runtime 0.1.0",
  "move-vm-types 0.1.0",
  "once_cell 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "proptest 0.9.6 (git+https://github.com/mimoo/proptest.git?branch=fuzzing)",
- "proptest-derive 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "proptest 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "proptest-derive 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.7.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "stdlib 0.1.0",
  "transaction-builder 0.1.0",
@@ -2303,7 +2303,7 @@ dependencies = [
  "libra-canonical-serialization 0.1.0",
  "libra-proptest-helpers 0.1.0",
  "libra-workspace-hack 0.1.0",
- "proptest 0.9.6 (git+https://github.com/mimoo/proptest.git?branch=fuzzing)",
+ "proptest 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.110 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -2313,8 +2313,8 @@ version = "0.1.0"
 dependencies = [
  "criterion 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "libra-workspace-hack 0.1.0",
- "proptest 0.9.6 (git+https://github.com/mimoo/proptest.git?branch=fuzzing)",
- "proptest-derive 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "proptest 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "proptest-derive 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.110 (registry+https://github.com/rust-lang/crates.io-index)",
  "thiserror 1.0.19 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -2362,8 +2362,8 @@ dependencies = [
  "libra-workspace-hack 0.1.0",
  "mirai-annotations 1.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "once_cell 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "proptest 0.9.6 (git+https://github.com/mimoo/proptest.git?branch=fuzzing)",
- "proptest-derive 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "proptest 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "proptest-derive 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.7.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand_core 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "ripemd160 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2439,7 +2439,7 @@ dependencies = [
  "network 0.1.0",
  "noise 0.1.0",
  "once_cell 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "proptest 0.9.6 (git+https://github.com/mimoo/proptest.git?branch=fuzzing)",
+ "proptest 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "prost 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.7.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "rusty-fork 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2489,7 +2489,7 @@ dependencies = [
  "libradb 0.1.0",
  "move-core-types 0.1.0",
  "once_cell 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "proptest 0.9.6 (git+https://github.com/mimoo/proptest.git?branch=fuzzing)",
+ "proptest 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "reqwest 0.10.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.110 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.53 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2660,8 +2660,8 @@ dependencies = [
  "libra-canonical-serialization 0.1.0",
  "libra-crypto 0.1.0",
  "libra-workspace-hack 0.1.0",
- "proptest 0.9.6 (git+https://github.com/mimoo/proptest.git?branch=fuzzing)",
- "proptest-derive 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "proptest 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "proptest-derive 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.110 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_bytes 0.11.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "thiserror 1.0.19 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2672,7 +2672,7 @@ name = "libra-nibble"
 version = "0.1.0"
 dependencies = [
  "libra-workspace-hack 0.1.0",
- "proptest 0.9.6 (git+https://github.com/mimoo/proptest.git?branch=fuzzing)",
+ "proptest 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.110 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -2719,8 +2719,8 @@ version = "0.1.0"
 dependencies = [
  "crossbeam 0.7.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "libra-workspace-hack 0.1.0",
- "proptest 0.9.6 (git+https://github.com/mimoo/proptest.git?branch=fuzzing)",
- "proptest-derive 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "proptest 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "proptest-derive 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -2902,8 +2902,8 @@ dependencies = [
  "mirai-annotations 1.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "move-core-types 0.1.0",
  "once_cell 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "proptest 0.9.6 (git+https://github.com/mimoo/proptest.git?branch=fuzzing)",
- "proptest-derive 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "proptest 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "proptest-derive 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "radix_trie 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.7.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "regex 1.3.9 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2945,7 +2945,7 @@ dependencies = [
  "move-vm-runtime 0.1.0",
  "move-vm-types 0.1.0",
  "once_cell 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "proptest 0.9.6 (git+https://github.com/mimoo/proptest.git?branch=fuzzing)",
+ "proptest 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "rayon 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.110 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.53 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -3012,8 +3012,8 @@ dependencies = [
  "num-traits 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "num-variants 0.1.0",
  "once_cell 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "proptest 0.9.6 (git+https://github.com/mimoo/proptest.git?branch=fuzzing)",
- "proptest-derive 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "proptest 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "proptest-derive 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.7.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "schemadb 0.1.0",
  "serde 1.0.110 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -3233,8 +3233,8 @@ dependencies = [
  "libra-workspace-hack 0.1.0",
  "mirai-annotations 1.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "once_cell 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "proptest 0.9.6 (git+https://github.com/mimoo/proptest.git?branch=fuzzing)",
- "proptest-derive 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "proptest 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "proptest-derive 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.7.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "ref-cast 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "regex 1.3.9 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -3369,7 +3369,7 @@ dependencies = [
  "move-vm-natives 0.1.0",
  "move-vm-types 0.1.0",
  "once_cell 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "proptest 0.9.6 (git+https://github.com/mimoo/proptest.git?branch=fuzzing)",
+ "proptest 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "vm 0.1.0",
 ]
 
@@ -3384,7 +3384,7 @@ dependencies = [
  "mirai-annotations 1.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "move-core-types 0.1.0",
  "once_cell 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "proptest 0.9.6 (git+https://github.com/mimoo/proptest.git?branch=fuzzing)",
+ "proptest 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.110 (registry+https://github.com/rust-lang/crates.io-index)",
  "sha2 0.8.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "vm 0.1.0",
@@ -3486,7 +3486,7 @@ dependencies = [
  "num-variants 0.1.0",
  "once_cell 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "pin-project 0.4.17 (registry+https://github.com/rust-lang/crates.io-index)",
- "proptest 0.9.6 (git+https://github.com/mimoo/proptest.git?branch=fuzzing)",
+ "proptest 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.7.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.110 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_bytes 0.11.4 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -3533,7 +3533,7 @@ dependencies = [
  "memsocket 0.1.0",
  "netcore 0.1.0",
  "once_cell 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "proptest 0.9.6 (git+https://github.com/mimoo/proptest.git?branch=fuzzing)",
+ "proptest 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.7.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand_core 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "snow 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -4037,8 +4037,8 @@ dependencies = [
 
 [[package]]
 name = "proptest"
-version = "0.9.6"
-source = "git+https://github.com/mimoo/proptest.git?branch=fuzzing#6c8b41b44d4bd97f77776b73220f6fe3c03edbf1"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "bit-set 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "bitflags 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -4050,13 +4050,13 @@ dependencies = [
  "rand_chacha 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand_xorshift 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "regex-syntax 0.6.18 (registry+https://github.com/rust-lang/crates.io-index)",
- "rusty-fork 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rusty-fork 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "tempfile 3.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "proptest-derive"
-version = "0.1.2"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "proc-macro2 0.4.30 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -4703,17 +4703,6 @@ dependencies = [
 
 [[package]]
 name = "rusty-fork"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "fnv 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "quick-error 1.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "tempfile 3.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "wait-timeout 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "rusty-fork"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
@@ -4804,7 +4793,7 @@ dependencies = [
  "libra-temppath 0.1.0",
  "libra-workspace-hack 0.1.0",
  "once_cell 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "proptest 0.9.6 (git+https://github.com/mimoo/proptest.git?branch=fuzzing)",
+ "proptest 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "rocksdb 0.14.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "tempfile 3.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -4827,7 +4816,7 @@ dependencies = [
  "libra-crypto 0.1.0",
  "libra-types 0.1.0",
  "libra-workspace-hack 0.1.0",
- "proptest 0.9.6 (git+https://github.com/mimoo/proptest.git?branch=fuzzing)",
+ "proptest 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -4983,8 +4972,8 @@ name = "serializer-tests"
 version = "0.1.0"
 dependencies = [
  "libra-workspace-hack 0.1.0",
- "proptest 0.9.6 (git+https://github.com/mimoo/proptest.git?branch=fuzzing)",
- "proptest-derive 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "proptest 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "proptest-derive 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "vm 0.1.0",
 ]
 
@@ -5286,7 +5275,7 @@ dependencies = [
  "libra-types 0.1.0",
  "libra-workspace-hack 0.1.0",
  "libradb 0.1.0",
- "proptest 0.9.6 (git+https://github.com/mimoo/proptest.git?branch=fuzzing)",
+ "proptest 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.7.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "storage-client 0.1.0",
  "storage-interface 0.1.0",
@@ -6203,8 +6192,8 @@ dependencies = [
  "move-core-types 0.1.0",
  "num-variants 0.1.0",
  "once_cell 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "proptest 0.9.6 (git+https://github.com/mimoo/proptest.git?branch=fuzzing)",
- "proptest-derive 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "proptest 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "proptest-derive 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "ref-cast 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.53 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -6228,8 +6217,8 @@ dependencies = [
  "move-vm-runtime 0.1.0",
  "move-vm-types 0.1.0",
  "once_cell 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "proptest 0.9.6 (git+https://github.com/mimoo/proptest.git?branch=fuzzing)",
- "proptest-derive 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "proptest 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "proptest-derive 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.7.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "stdlib 0.1.0",
  "transaction-builder 0.1.0",
@@ -6825,8 +6814,8 @@ dependencies = [
 "checksum proc-macro2 0.4.30 (registry+https://github.com/rust-lang/crates.io-index)" = "cf3d2011ab5c909338f7887f4fc896d35932e29146c12c8d01da6b22a80ba759"
 "checksum proc-macro2 1.0.17 (registry+https://github.com/rust-lang/crates.io-index)" = "1502d12e458c49a4c9cbff560d0fe0060c252bc29799ed94ca2ed4bb665a0101"
 "checksum prometheus 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)" = "dd0ced56dee39a6e960c15c74dc48849d614586db2eaada6497477af7c7811cd"
-"checksum proptest 0.9.6 (git+https://github.com/mimoo/proptest.git?branch=fuzzing)" = "<none>"
-"checksum proptest-derive 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "d31edb17edac73aeacc947bd61462dda15220584268896a58e12f053d767f15b"
+"checksum proptest 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)" = "2520fe6373cf6a3a61e2d200e987c183778ade8d9248ac3e6614ab0edfe4a0c1"
+"checksum proptest-derive 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "051d9d20dbe9e9dfe594328b6eaab72ccf571fee818991dd1c1ba5469b5f32d4"
 "checksum prost 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)" = "ce49aefe0a6144a45de32927c77bd2859a5f7677b55f220ae5b744e87389c212"
 "checksum prost-build 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)" = "02b10678c913ecbd69350e8535c3aef91a8676c0773fc1d7b95cdd196d7f2f26"
 "checksum prost-derive 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)" = "537aa19b95acde10a12fec4301466386f757403de4cd4e5b4fa78fb5ecb18f72"
@@ -6885,7 +6874,6 @@ dependencies = [
 "checksum rustc_version 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "138e3e0acb6c9fb258b19b67cb8abd63c00679d2851805ea151465464fe9030a"
 "checksum rustls 0.17.0 (registry+https://github.com/rust-lang/crates.io-index)" = "c0d4a31f5d68413404705d6982529b0e11a9aacd4839d1d6222ee3b8cb4015e1"
 "checksum rustversion 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)" = "b3bba175698996010c4f6dce5e7f173b6eb781fce25d2cfc45e27091ce0b79f6"
-"checksum rusty-fork 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "3dd93264e10c577503e926bd1430193eeb5d21b059148910082245309b424fae"
 "checksum rusty-fork 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "cb3dcc6e454c328bb824492db107ab7c0ae8fcffe4ad210136ef014458c1bc4f"
 "checksum rustyline 6.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "1cd20b28d972040c627e209eb29f19c24a71a19d661cc5a220089176e20ee202"
 "checksum ryu 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)" = "bfa8506c1de11c9c4e4c38863ccbe02a305c8188e85a05a784c9e11e1c3910c8"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -156,6 +156,3 @@ lto = 'thin'
 
 [profile.bench]
 debug = true
-
-[patch.crates-io]
-proptest = { git = "https://github.com/mimoo/proptest.git", branch = "fuzzing" }

--- a/common/bitvec/Cargo.toml
+++ b/common/bitvec/Cargo.toml
@@ -16,4 +16,4 @@ serde = { version = "1.0.110", features = ["derive"] }
 [dev-dependencies]
 lcs = { path = "../lcs", version = "0.1.0", package = "libra-canonical-serialization" }
 libra-proptest-helpers = { path = "../proptest-helpers", version = "0.1.0"}
-proptest = { version = "0.9.6", default-features = true}
+proptest = { version = "0.10.0", default-features = true}

--- a/common/lcs/Cargo.toml
+++ b/common/lcs/Cargo.toml
@@ -16,8 +16,8 @@ serde = { version = "1.0", features = ["derive"] }
 
 [dev-dependencies]
 criterion = "=0.3.2"
-proptest = "0.9.6"
-proptest-derive = "0.1.2"
+proptest = "0.10.0"
+proptest-derive = "0.2.0"
 
 [[bench]]
 name = "lcs_bench"

--- a/common/nibble/Cargo.toml
+++ b/common/nibble/Cargo.toml
@@ -11,7 +11,7 @@ edition = "2018"
 
 [dependencies]
 libra-workspace-hack = { path = "../workspace-hack", version = "0.1.0" }
-proptest = { version = "0.9.6", optional = true }
+proptest = { version = "0.10.0", optional = true }
 serde = { version = "1.0.110", features = ["derive"] }
 
 [features]

--- a/common/proptest-helpers/Cargo.toml
+++ b/common/proptest-helpers/Cargo.toml
@@ -12,5 +12,5 @@ edition = "2018"
 [dependencies]
 crossbeam = "0.7.2"
 libra-workspace-hack = { path = "../workspace-hack", version = "0.1.0" }
-proptest = "0.9.6"
-proptest-derive = "0.1.2"
+proptest = "0.10.0"
+proptest-derive = "0.2.0"

--- a/consensus/Cargo.toml
+++ b/consensus/Cargo.toml
@@ -19,7 +19,7 @@ mirai-annotations = { version = "1.8.0", default-features = false }
 num-derive = { version = "0.3.0", default-features = false }
 num-traits = { version = "0.2.8", default-features = false }
 once_cell = "1.4.0"
-proptest = { version = "0.9.6", optional = true }
+proptest = { version = "0.10.0", optional = true }
 rand = { version = "0.7.3", default-features = false }
 serde = { version = "1.0.110", default-features = false }
 serde_json = "1.0"
@@ -54,7 +54,7 @@ storage-interface = { path = "../storage/storage-interface", version = "0.1.0" }
 
 [dev-dependencies]
 cached = "0.12.0"
-proptest = "0.9.6"
+proptest = "0.10.0"
 tempfile = "3.1.0"
 
 vm-genesis = { path = "../language/tools/vm-genesis", version = "0.1.0" }

--- a/consensus/consensus-types/Cargo.toml
+++ b/consensus/consensus-types/Cargo.toml
@@ -9,7 +9,7 @@ edition = "2018"
 [dependencies]
 anyhow = "1.0"
 mirai-annotations = { version = "1.8.0", default-features = false }
-proptest = { version = "0.9.6", optional = true }
+proptest = { version = "0.10.0", optional = true }
 serde = { version = "1.0.110", default-features = false }
 
 lcs = { path = "../../common/lcs", version = "0.1.0", package = "libra-canonical-serialization" }
@@ -20,7 +20,7 @@ libra-types = { path = "../../types", version = "0.1.0" }
 libra-workspace-hack = { path = "../../common/workspace-hack", version = "0.1.0" }
 
 [dev-dependencies]
-proptest = "0.9.6"
+proptest = "0.10.0"
 
 [features]
 default = []

--- a/crypto/crypto/Cargo.toml
+++ b/crypto/crypto/Cargo.toml
@@ -19,8 +19,8 @@ hex = "0.4.2"
 hmac = "0.7.1"
 once_cell = "1.4.0"
 mirai-annotations = "1.8.0"
-proptest = { version = "0.9.6", optional = true }
-proptest-derive = { version = "0.1.2", optional = true }
+proptest = { version = "0.10.0", optional = true }
+proptest-derive = { version = "0.2.0", optional = true }
 rand = "0.7.3"
 rand_core = { version = "0.5.1", default-features = false }
 serde = { version = "1.0.110", features = ["derive"] }
@@ -41,8 +41,8 @@ libra-workspace-hack = { path = "../../common/workspace-hack", version = "0.1.0"
 [dev-dependencies]
 bitvec = "0.17.3"
 byteorder = "1.3.2"
-proptest = { version = "0.9.6"}
-proptest-derive = { version = "0.1.2"}
+proptest = { version = "0.10.0"}
+proptest-derive = { version = "0.2.0"}
 ripemd160 = "0.8.0"
 criterion = "0.3"
 sha3 = "0.8.2"

--- a/execution/executor/Cargo.toml
+++ b/execution/executor/Cargo.toml
@@ -32,7 +32,7 @@ scratchpad = { path = "../../storage/scratchpad", version = "0.1.0" }
 storage-interface = { path = "../../storage/storage-interface", version = "0.1.0" }
 
 [dev-dependencies]
-proptest = "0.9.6"
+proptest = "0.10.0"
 rand = "0.7.3"
 
 config-builder = { path = "../../config/config-builder", version = "0.1.0" }

--- a/grpc/types/Cargo.toml
+++ b/grpc/types/Cargo.toml
@@ -12,7 +12,7 @@ edition = "2018"
 [dependencies]
 anyhow = "1.0"
 prost = "0.6"
-proptest = { version = "0.9.6", default-features = false, optional = true }
+proptest = { version = "0.10.0", default-features = false, optional = true }
 
 lcs = { path = "../../common/lcs", version = "0.1.0", package = "libra-canonical-serialization" }
 libra-crypto = {path = "../../crypto/crypto", version = "0.1.0"}

--- a/json-rpc/Cargo.toml
+++ b/json-rpc/Cargo.toml
@@ -19,7 +19,7 @@ serde = { version = "1.0.110", default-features = false }
 tokio = { version = "0.2.21", features = ["full"] }
 warp = "0.2.2"
 reqwest = { version = "0.10.5", features = ["blocking", "json"], default_features = false, optional = true }
-proptest = { version = "0.9.6", optional = true }
+proptest = { version = "0.10.0", optional = true }
 
 debug-interface = { path = "../common/debug-interface", version = "0.1.0" }
 lcs = { path = "../common/lcs", version = "0.1.0", package = "libra-canonical-serialization" }

--- a/language/benchmarks/Cargo.toml
+++ b/language/benchmarks/Cargo.toml
@@ -12,7 +12,7 @@ edition = "2018"
 [dependencies]
 anyhow = "1.0"
 criterion = "0.3.2"
-proptest = "0.9.6"
+proptest = "0.10.0"
 
 bytecode-verifier = { path = "../bytecode-verifier", version = "0.1.0" }
 language-e2e-tests = { path = "../e2e-tests", version = "0.1.0" }

--- a/language/bytecode-verifier/bytecode-verifier-tests/Cargo.toml
+++ b/language/bytecode-verifier/bytecode-verifier-tests/Cargo.toml
@@ -11,7 +11,7 @@ edition = "2018"
 
 [dev-dependencies]
 petgraph = "0.5.1"
-proptest = "0.9.6"
+proptest = "0.10.0"
 
 bytecode-verifier = { path = "../", version = "0.1.0" }
 libra-types = { path = "../../../types", version = "0.1.0" }

--- a/language/bytecode-verifier/invalid-mutations/Cargo.toml
+++ b/language/bytecode-verifier/invalid-mutations/Cargo.toml
@@ -12,7 +12,7 @@ publish = false
 [dependencies]
 vm = { path = "../../vm", version = "0.1.0" }
 libra-types = { path = "../../../types", version = "0.1.0" }
-proptest = "0.9.6"
+proptest = "0.10.0"
 libra-proptest-helpers = { path = "../../../common/proptest-helpers", version = "0.1.0" }
 libra-workspace-hack = { path = "../../../common/workspace-hack", version = "0.1.0" }
 

--- a/language/e2e-tests/Cargo.toml
+++ b/language/e2e-tests/Cargo.toml
@@ -27,8 +27,8 @@ transaction-builder = { path = "../transaction-builder", version = "0.1.0", feat
 vm = { path = "../vm", version = "0.1.0" }
 vm-genesis = { path = "../tools/vm-genesis", version = "0.1.0" }
 libra-vm = { path = "../libra-vm", version = "0.1.0" }
-proptest = "0.9.6"
-proptest-derive = "0.1.2"
+proptest = "0.10.0"
+proptest-derive = "0.2.0"
 libra-proptest-helpers = { path = "../../common/proptest-helpers", version = "0.1.0" }
 libra-config =  { path = "../../config", version = "0.1.0" }
 libra-logger = { path = "../../common/logger", version = "0.1.0" }

--- a/language/libra-vm/Cargo.toml
+++ b/language/libra-vm/Cargo.toml
@@ -30,7 +30,7 @@ serde_json = "1.0"
 serde = { version = "1.0.110", default-features = false }
 
 [dev-dependencies]
-proptest = "0.9.6"
+proptest = "0.10.0"
 
 [features]
 default = []

--- a/language/move-core/types/Cargo.toml
+++ b/language/move-core/types/Cargo.toml
@@ -13,9 +13,9 @@ edition = "2018"
 anyhow = "1.0"
 hex = "0.4.2"
 rand = "0.7.3"
-proptest = { version = "0.9.6", default-features = false, optional = true }
+proptest = { version = "0.10.0", default-features = false, optional = true }
 mirai-annotations = "1.8.0"
-proptest-derive = { version = "0.1.2", default-features = false, optional = true }
+proptest-derive = { version = "0.2.0", default-features = false, optional = true }
 ref-cast = "1.0"
 serde = { version = "1.0.110", default-features = false }
 thiserror = "1.0"
@@ -27,8 +27,8 @@ libra-crypto-derive = { path = "../../../crypto/crypto-derive", version = "0.1.0
 
 [dev-dependencies]
 once_cell = "1.4.0"
-proptest = "0.9.6"
-proptest-derive = "0.1.2"
+proptest = "0.10.0"
+proptest-derive = "0.2.0"
 regex = "1.3.9"
 serde_json = "1.0.53"
 

--- a/language/move-vm/runtime/Cargo.toml
+++ b/language/move-vm/runtime/Cargo.toml
@@ -28,7 +28,7 @@ vm = { path = "../../vm", version = "0.1.0" }
 [dev-dependencies]
 anyhow = "1.0"
 hex = "0.4.2"
-proptest = "0.9.6"
+proptest = "0.10.0"
 
 compiler = { path = "../../compiler", version = "0.1.0" }
 libra-state-view = { path = "../../../storage/state-view", version = "0.1.0" }

--- a/language/move-vm/types/Cargo.toml
+++ b/language/move-vm/types/Cargo.toml
@@ -12,7 +12,7 @@ edition = "2018"
 [dependencies]
 mirai-annotations = "1.8.0"
 once_cell = "1.4.0"
-proptest = { version = "0.9.6", optional = true }
+proptest = { version = "0.10.0", optional = true }
 sha2 = "0.8.2"
 serde = { version = "1.0", features = ["derive", "rc"] }
 
@@ -24,7 +24,7 @@ move-core-types = { path = "../../move-core/types", version = "0.1.0" }
 vm = { path = "../../vm", version = "0.1.0" }
 
 [dev-dependencies]
-proptest = "0.9.6"
+proptest = "0.10.0"
 
 [features]
 default = []

--- a/language/tools/vm-genesis/Cargo.toml
+++ b/language/tools/vm-genesis/Cargo.toml
@@ -31,8 +31,8 @@ vm = { path = "../../vm", version = "0.1.0" }
 libra-vm = { path = "../../libra-vm", version = "0.1.0" }
 
 [dev-dependencies]
-proptest = "0.9.6"
-proptest-derive = "0.1.2"
+proptest = "0.10.0"
+proptest-derive = "0.2.0"
 libra-proptest-helpers = { path = "../../../common/proptest-helpers", version = "0.1.0" }
 
 [features]

--- a/language/vm/Cargo.toml
+++ b/language/vm/Cargo.toml
@@ -14,8 +14,8 @@ anyhow = "1.0"
 byteorder = "1.3.2"
 once_cell = "1.4.0"
 mirai-annotations = "1.8.0"
-proptest = { version = "0.9.6", optional = true }
-proptest-derive = { version = "0.1.2", optional = true }
+proptest = { version = "0.10.0", optional = true }
+proptest-derive = { version = "0.2.0", optional = true }
 ref-cast = "1.0"
 libra-crypto = { path = "../../crypto/crypto", version = "0.1.0" }
 libra-proptest-helpers = { path = "../../common/proptest-helpers", version = "0.1.0", optional = true }
@@ -25,8 +25,8 @@ move-core-types = { path = "../move-core/types", version = "0.1.0" }
 num-variants = { path = "../../common/num-variants", version = "0.1.0" }
 
 [dev-dependencies]
-proptest = "0.9.6"
-proptest-derive = "0.1.2"
+proptest = "0.10.0"
+proptest-derive = "0.2.0"
 libra-proptest-helpers = { path = "../../common/proptest-helpers", version = "0.1.0" }
 serde_json = "1"
 

--- a/language/vm/serializer-tests/Cargo.toml
+++ b/language/vm/serializer-tests/Cargo.toml
@@ -11,8 +11,8 @@ edition = "2018"
 
 [dev-dependencies]
 libra-workspace-hack = { path = "../../../common/workspace-hack", version = "0.1.0" }
-proptest = "0.9.6"
-proptest-derive = "0.1.2"
+proptest = "0.10.0"
+proptest-derive = "0.2.0"
 vm = { path = "../", version = "0.1.0" }
 
 [features]

--- a/network/Cargo.toml
+++ b/network/Cargo.toml
@@ -40,7 +40,7 @@ memsocket = { path = "memsocket", version = "0.1.0" }
 netcore = { path = "netcore", version = "0.1.0" }
 noise = { path = "noise", version = "0.1.0" }
 num-variants = { path = "../common/num-variants", version = "0.1.0" }
-proptest = { version = "0.9.6", default-features = true, optional = true }
+proptest = { version = "0.10.0", default-features = true, optional = true }
 stream-ratelimiter = { path = "../common/stream-ratelimiter", version = "0.1.0" }
 
 [dev-dependencies]

--- a/network/network-address/Cargo.toml
+++ b/network/network-address/Cargo.toml
@@ -10,8 +10,8 @@ publish = false
 edition = "2018"
 
 [dependencies]
-proptest = { version = "0.9.6", optional = true }
-proptest-derive = { version = "0.1.2", optional = true }
+proptest = { version = "0.10.0", optional = true }
+proptest-derive = { version = "0.2.0", optional = true }
 serde = { version = "1.0.110", default-features = false }
 serde_bytes = "0.11.4"
 thiserror = "1.0"
@@ -22,8 +22,8 @@ libra-workspace-hack = { path = "../../common/workspace-hack", version = "0.1.0"
 
 [dev-dependencies]
 anyhow = "1.0"
-proptest = "0.9.6"
-proptest-derive = "0.1.2"
+proptest = "0.10.0"
+proptest-derive = "0.2.0"
 
 [features]
 default = []

--- a/network/noise/Cargo.toml
+++ b/network/noise/Cargo.toml
@@ -23,7 +23,7 @@ rand = { version = "0.7.3", optional = true }
 # used by fuzzing
 libra-proptest-helpers = { path = "../../common/proptest-helpers", optional = true }
 once_cell = { version = "1.4.0", optional = true }
-proptest = { version = "0.9.6", default-features = false, optional = true }
+proptest = { version = "0.10.0", default-features = false, optional = true }
 memsocket = { path = "../memsocket", version = "0.1.0", optional = true }
 rand_core = { version = "0.5.1", optional = true }
 
@@ -31,7 +31,7 @@ rand_core = { version = "0.5.1", optional = true }
 memsocket = { path = "../memsocket", version = "0.1.0" }
 libra-proptest-helpers = { path = "../../common/proptest-helpers"}
 once_cell = "1.4.0"
-proptest = { version = "0.9.6", default-features = false }
+proptest = { version = "0.10.0", default-features = false }
 rand_core = "0.5.1"
 
 [features]

--- a/storage/accumulator/Cargo.toml
+++ b/storage/accumulator/Cargo.toml
@@ -18,7 +18,7 @@ libra-workspace-hack = { path = "../../common/workspace-hack", version = "0.1.0"
 
 [dev-dependencies]
 rand = "0.7.3"
-proptest = "0.9.6"
+proptest = "0.10.0"
 
 [features]
 default = []

--- a/storage/backup/backup-cli/Cargo.toml
+++ b/storage/backup/backup-cli/Cargo.toml
@@ -29,7 +29,7 @@ libra-workspace-hack = { path = "../../../common/workspace-hack", version = "0.1
 libradb = { path = "../../libradb", version = "0.1.0" }
 
 [dev-dependencies]
-proptest = "0.9.6"
+proptest = "0.10.0"
 
 backup-service = { path = "../backup-service", version = "0.1.0" }
 libra-config = { path = "../../../config", version = "0.1.0" }

--- a/storage/jellyfish-merkle/Cargo.toml
+++ b/storage/jellyfish-merkle/Cargo.toml
@@ -15,8 +15,8 @@ byteorder = "1.3.2"
 mirai-annotations = "1.8.0"
 num-derive = "0.3.0"
 num-traits = "0.2"
-proptest = { version = "0.9.6", optional = true }
-proptest-derive = { version = "0.1.2", optional = true }
+proptest = { version = "0.10.0", optional = true }
+proptest-derive = { version = "0.2.0", optional = true }
 serde = { version = "1.0.110", features = ["derive"] }
 thiserror = "1.0"
 
@@ -29,8 +29,8 @@ libra-workspace-hack = { path = "../../common/workspace-hack", version = "0.1.0"
 
 [dev-dependencies]
 rand = "0.7.3"
-proptest = "0.9.6"
-proptest-derive = "0.1.2"
+proptest = "0.10.0"
+proptest-derive = "0.2.0"
 
 [features]
 default = []

--- a/storage/libradb/Cargo.toml
+++ b/storage/libradb/Cargo.toml
@@ -17,8 +17,8 @@ itertools = "0.9.0"
 once_cell = "1.4.0"
 num-derive = "0.3.0"
 num-traits = "0.2"
-proptest = { version = "0.9.6", optional = true }
-proptest-derive = { version = "0.1.2", optional = true }
+proptest = { version = "0.10.0", optional = true }
+proptest-derive = { version = "0.2.0", optional = true }
 serde = "1.0.110"
 thiserror = "1.0"
 
@@ -37,8 +37,8 @@ libra-workspace-hack = { path = "../../common/workspace-hack", version = "0.1.0"
 num-variants = { path = "../../common/num-variants", version = "0.1.0" }
 
 [dev-dependencies]
-proptest = "0.9.6"
-proptest-derive = "0.1.2"
+proptest = "0.10.0"
+proptest-derive = "0.2.0"
 rand = "0.7.3"
 
 libra-proptest-helpers = { path = "../../common/proptest-helpers", version = "0.1.0" }

--- a/storage/schemadb/Cargo.toml
+++ b/storage/schemadb/Cargo.toml
@@ -22,6 +22,6 @@ features = ["lz4"]
 
 [dev-dependencies]
 byteorder = "1.3.2"
-proptest = "0.9.6"
+proptest = "0.10.0"
 tempfile = "3.1.0"
 libra-temppath = { path = "../../common/temppath", version = "0.1.0" }

--- a/storage/scratchpad/Cargo.toml
+++ b/storage/scratchpad/Cargo.toml
@@ -17,7 +17,7 @@ libra-types = { path = "../../types", version = "0.1.0" }
 libra-workspace-hack = { path = "../../common/workspace-hack", version = "0.1.0" }
 
 [dev-dependencies]
-proptest = "0.9.6"
+proptest = "0.10.0"
 
 [features]
 default = []

--- a/storage/storage-service/Cargo.toml
+++ b/storage/storage-service/Cargo.toml
@@ -27,12 +27,12 @@ libra-types = { path = "../../types", version = "0.1.0" }
 libra-workspace-hack = { path = "../../common/workspace-hack", version = "0.1.0" }
 rand = { version = "0.7.3", optional = true }
 storage-client = { path = "../storage-client", version = "0.1.0", optional = true }
-proptest = { version = "0.9.6", optional = true }
+proptest = { version = "0.10.0", optional = true }
 
 [dev-dependencies]
 itertools = "0.9.0"
 libra-temppath = { path = "../../common/temppath", version = "0.1.0" }
-proptest = "0.9.6"
+proptest = "0.10.0"
 
 [features]
 default = []

--- a/testsuite/cli/Cargo.toml
+++ b/testsuite/cli/Cargo.toml
@@ -14,7 +14,7 @@ anyhow = "1.0"
 chrono = "0.4.11"
 tonic = "0.2"
 hex = "0.4.2"
-proptest = { version = "0.9.6", optional = true }
+proptest = { version = "0.10.0", optional = true }
 rustyline = "6.1.2"
 rust_decimal = "1.6.0"
 num-traits = "0.2"
@@ -42,7 +42,7 @@ stdlib = { path = "../../language/stdlib", version = "0.1.0" }
 transaction-builder = { path = "../../language/transaction-builder", version = "0.1.0" }
 
 [dev-dependencies]
-proptest = "0.9.6"
+proptest = "0.10.0"
 
 [features]
 default = []

--- a/testsuite/generate-format/Cargo.toml
+++ b/testsuite/generate-format/Cargo.toml
@@ -10,7 +10,7 @@ publish = false
 edition = "2018"
 
 [dependencies]
-proptest = "0.9.6"
+proptest = "0.10.0"
 rand = "0.7.3"
 serde = { version = "1.0.110", features = ["derive"] }
 serde-reflection = "0.3.0"

--- a/testsuite/libra-fuzzer/Cargo.toml
+++ b/testsuite/libra-fuzzer/Cargo.toml
@@ -14,7 +14,7 @@ anyhow = "1.0"
 byteorder = { version = "1.3.2", default-features = false }
 hex = "0.4.2"
 once_cell = "1.4.0"
-proptest = { version = "0.9.6", default-features = false }
+proptest = { version = "0.10.0", default-features = false }
 prost = "0.6"
 rusty-fork = { version = "0.3.0", default-features = false }
 sha-1 = { version = "0.8.1", default-features = false }

--- a/types/Cargo.toml
+++ b/types/Cargo.toml
@@ -17,8 +17,8 @@ hex = "0.4.2"
 itertools = { version = "0.9.0", default-features = false }
 once_cell = "1.4.0"
 mirai-annotations = "1.8.0"
-proptest = { version = "0.9.6", default-features = false, optional = true }
-proptest-derive = { version = "0.1.2", default-features = false, optional = true }
+proptest = { version = "0.10.0", default-features = false, optional = true }
+proptest-derive = { version = "0.2.0", default-features = false, optional = true }
 radix_trie = { version = "0.1.4", default-features = false }
 rand = "0.7.3"
 serde = { version = "1.0.110", default-features = false }
@@ -36,8 +36,8 @@ move-core-types = { path = "../language/move-core/types", version = "0.1.0" }
 
 [dev-dependencies]
 regex = "1.3.9"
-proptest = "0.9.6"
-proptest-derive = "0.1.2"
+proptest = "0.10.0"
+proptest-derive = "0.2.0"
 libra-prost-test-helpers = { path = "../common/prost-test-helpers", version = "0.1.0" }
 serde_json = "1.0.53"
 


### PR DESCRIPTION
These upgrades mean that we no longer have to maintain a patch.