### PR TITLE
[json-rpc] add get_network_status endpoint

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2488,6 +2488,7 @@ dependencies = [
  "libra-workspace-hack 0.1.0",
  "libradb 0.1.0",
  "move-core-types 0.1.0",
+ "network 0.1.0",
  "once_cell 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "proptest 0.9.6 (git+https://github.com/mimoo/proptest.git?branch=fuzzing)",
  "reqwest 0.10.5 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/client/json-rpc/src/client.rs
+++ b/client/json-rpc/src/client.rs
@@ -109,6 +109,10 @@ impl JsonRpcBatch {
             ],
         );
     }
+
+    pub fn add_get_network_status_request(&mut self) {
+        self.add_request("get_network_status".to_string(), vec![]);
+    }
 }
 
 #[derive(Clone)]

--- a/client/json-rpc/src/response.rs
+++ b/client/json-rpc/src/response.rs
@@ -7,7 +7,7 @@ use crate::views::{
 };
 use anyhow::{ensure, format_err, Error, Result};
 
-use serde_json::Value;
+use serde_json::{Number, Value};
 use std::convert::TryFrom;
 
 #[allow(clippy::large_enum_variant)]
@@ -22,6 +22,7 @@ pub enum JsonRpcResponse {
     BlockMetadataResponse(BlockMetadata),
     CurrenciesResponse(Vec<CurrencyInfoView>),
     AccountStateWithProofResponse(AccountStateWithProofView),
+    NetworkStatusResponse(Number),
     UnknownResponse(Value),
 }
 
@@ -83,6 +84,12 @@ impl TryFrom<(String, Value)> for JsonRpcResponse {
             "get_transactions" => {
                 let txns: Vec<TransactionView> = serde_json::from_value(value)?;
                 Ok(JsonRpcResponse::TransactionsResponse(txns))
+            }
+            "get_network_status" => {
+                let connected_peers_count: Number = serde_json::from_value(value)?;
+                Ok(JsonRpcResponse::NetworkStatusResponse(
+                    connected_peers_count,
+                ))
             }
             _ => Ok(JsonRpcResponse::UnknownResponse(value)),
         }

--- a/json-rpc/Cargo.toml
+++ b/json-rpc/Cargo.toml
@@ -39,7 +39,7 @@ network = { path = "../network", version = "0.1.0" }
 storage-interface = { path = "../storage/storage-interface", version = "0.1.0" }
 
 [dev-dependencies]
-libra-json-rpc-client = { path = "../client/json-rpc", version = "0.1.0"}
+libra-json-rpc-client = { path = "../client/json-rpc", version = "0.1.0" }
 vm-validator = { path = "../vm-validator", version = "0.1.0" }
 
 [features]

--- a/json-rpc/Cargo.toml
+++ b/json-rpc/Cargo.toml
@@ -35,6 +35,7 @@ libra-types = { path = "../types", version = "0.1.0" }
 libra-temppath = { path = "../common/temppath", version = "0.1.0", optional = true }
 libra-workspace-hack = { path = "../common/workspace-hack", version = "0.1.0" }
 move-core-types = { path = "../language/move-core/types", version = "0.1.0" }
+network = { path = "../network", version = "0.1.0" }
 storage-interface = { path = "../storage/storage-interface", version = "0.1.0" }
 
 [dev-dependencies]

--- a/json-rpc/src/fuzzing.rs
+++ b/json-rpc/src/fuzzing.rs
@@ -1,7 +1,7 @@
 // Copyright (c) The Libra Core Contributors
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::runtime::bootstrap;
+use crate::test_bootstrap;
 use libra_config::utils;
 use libra_mempool::mocks::MockSharedMempool;
 use libra_proptest_helpers::ValueGenerator;
@@ -44,7 +44,7 @@ pub fn fuzzer(data: &[u8]) {
 
     let port = utils::get_available_port();
     let address = format!("0.0.0.0:{}", port);
-    let _runtime = bootstrap(address.parse().unwrap(), Arc::new(db), smp.ac_client);
+    let _runtime = test_bootstrap(address.parse().unwrap(), Arc::new(db), smp.ac_client);
 
     let client = Client::new();
     let url = format!("http://{}", address);

--- a/json-rpc/src/lib.rs
+++ b/json-rpc/src/lib.rs
@@ -27,5 +27,7 @@ pub use runtime::{bootstrap, bootstrap_from_config};
 #[cfg(any(feature = "fuzzing", test))]
 /// Fuzzer for JSON RPC service
 pub mod fuzzing;
-#[cfg(test)]
+#[cfg(any(test, feature = "fuzzing"))]
 mod tests;
+#[cfg(any(test, feature = "fuzzing"))]
+pub use tests::test_bootstrap;

--- a/json-rpc/src/methods.rs
+++ b/json-rpc/src/methods.rs
@@ -27,11 +27,10 @@ use libra_types::{
     on_chain_config::{OnChainConfig, RegisteredCurrencies},
     transaction::SignedTransaction,
 };
+use network::counters;
 use serde_json::Value;
 use std::{collections::HashMap, convert::TryFrom, ops::Deref, pin::Pin, str::FromStr, sync::Arc};
 use storage_interface::DbReader;
-
-use network::counters;
 
 #[derive(Clone)]
 pub(crate) struct JsonRpcService {

--- a/json-rpc/src/runtime.rs
+++ b/json-rpc/src/runtime.rs
@@ -7,7 +7,7 @@ use crate::{
     methods::{build_registry, JsonRpcRequest, JsonRpcService, RpcRegistry},
 };
 use futures::future::join_all;
-use libra_config::config::NodeConfig;
+use libra_config::config::{NodeConfig, RoleType};
 use libra_mempool::MempoolClientSender;
 use libra_types::ledger_info::LedgerInfoWithSignatures;
 use serde_json::{map::Map, Value};
@@ -25,6 +25,7 @@ pub fn bootstrap(
     address: SocketAddr,
     libra_db: Arc<dyn DbReader>,
     mp_sender: MempoolClientSender,
+    //    role: RoleType
 ) -> Runtime {
     let runtime = Builder::new()
         .thread_name("rpc-")
@@ -34,7 +35,7 @@ pub fn bootstrap(
         .expect("[rpc] failed to create runtime");
 
     let registry = Arc::new(build_registry());
-    let service = JsonRpcService::new(libra_db, mp_sender);
+    let service = JsonRpcService::new(libra_db, mp_sender, RoleType::Validator);
 
     let handler = warp::any()
         .and(warp::path::end())

--- a/json-rpc/src/runtime.rs
+++ b/json-rpc/src/runtime.rs
@@ -25,7 +25,7 @@ pub fn bootstrap(
     address: SocketAddr,
     libra_db: Arc<dyn DbReader>,
     mp_sender: MempoolClientSender,
-    //    role: RoleType
+    role: RoleType,
 ) -> Runtime {
     let runtime = Builder::new()
         .thread_name("rpc-")
@@ -35,7 +35,7 @@ pub fn bootstrap(
         .expect("[rpc] failed to create runtime");
 
     let registry = Arc::new(build_registry());
-    let service = JsonRpcService::new(libra_db, mp_sender, RoleType::Validator);
+    let service = JsonRpcService::new(libra_db, mp_sender, role);
 
     let handler = warp::any()
         .and(warp::path::end())
@@ -64,7 +64,7 @@ pub fn bootstrap_from_config(
     libra_db: Arc<dyn DbReader>,
     mp_sender: MempoolClientSender,
 ) -> Runtime {
-    bootstrap(config.rpc.address, libra_db, mp_sender)
+    bootstrap(config.rpc.address, libra_db, mp_sender, config.base.role)
 }
 
 /// JSON RPC entry point

--- a/json-rpc/src/tests/mod.rs
+++ b/json-rpc/src/tests/mod.rs
@@ -1,5 +1,8 @@
 // Copyright (c) The Libra Core Contributors
 // SPDX-License-Identifier: Apache-2.0
 
-mod mock_db;
+#[cfg(test)]
 mod unit_tests;
+mod utils;
+
+pub use utils::test_bootstrap;

--- a/json-rpc/src/tests/unit_tests.rs
+++ b/json-rpc/src/tests/unit_tests.rs
@@ -584,6 +584,23 @@ fn test_get_state_proof() {
     assert_eq!(li.ledger_info().version(), version);
 }
 
+#[test]
+fn test_get_network_status() {
+    let (mock_db, client, mut runtime) = create_database_client_and_runtime(1);
+
+    let mut batch = JsonRpcBatch::default();
+    batch.add_get_network_status_request();
+
+    if let JsonRpcResponse::NetworkStatusResponse(connected_peers) =
+        execute_batch_and_get_first_response(&client, &mut runtime, batch)
+    {
+        // expect no connected peers when no network is running
+        assert_eq!(connected_peers.as_u64().unwrap(), 0);
+    } else {
+        panic!("did not receive expected json rpc response");
+    }
+}
+
 /// Creates and returns a MockLibraDB, JsonRpcAsyncClient and corresponding server Runtime tuple for
 /// testing. The given channel_buffer specifies the buffer size of the mempool client sender channel.
 fn create_database_client_and_runtime(

--- a/json-rpc/src/tests/unit_tests.rs
+++ b/json-rpc/src/tests/unit_tests.rs
@@ -3,8 +3,7 @@
 
 use crate::{
     errors::{JsonRpcError, ServerCode},
-    runtime::bootstrap,
-    tests::mock_db::MockLibraDB,
+    tests::utils::{test_bootstrap, MockLibraDB},
 };
 use futures::{channel::mpsc::channel, StreamExt};
 use libra_config::utils;
@@ -129,7 +128,7 @@ fn test_json_rpc_protocol() {
     let address = format!("0.0.0.0:{}", utils::get_available_port());
     let mock_db = mock_db();
     let mp_sender = channel(1024).0;
-    let _runtime = bootstrap(address.parse().unwrap(), Arc::new(mock_db), mp_sender);
+    let _runtime = test_bootstrap(address.parse().unwrap(), Arc::new(mock_db), mp_sender);
     let client = reqwest::blocking::Client::new();
 
     // check that only root path is accessible
@@ -182,7 +181,7 @@ fn test_transaction_submission() {
     let mock_db = mock_db();
     let port = utils::get_available_port();
     let address = format!("0.0.0.0:{}", port);
-    let mut runtime = bootstrap(address.parse().unwrap(), Arc::new(mock_db), mp_sender);
+    let mut runtime = test_bootstrap(address.parse().unwrap(), Arc::new(mock_db), mp_sender);
     let client = JsonRpcAsyncClient::new(
         reqwest::Url::from_str(format!("http://{}:{}", "127.0.0.1", port).as_str())
             .expect("invalid url"),
@@ -586,7 +585,7 @@ fn test_get_state_proof() {
 
 #[test]
 fn test_get_network_status() {
-    let (mock_db, client, mut runtime) = create_database_client_and_runtime(1);
+    let (_mock_db, client, mut runtime) = create_database_client_and_runtime(1);
 
     let mut batch = JsonRpcBatch::default();
     batch.add_get_network_status_request();
@@ -613,7 +612,7 @@ fn create_database_client_and_runtime(
     let address = format!("{}:{}", host, port);
     let mp_sender = channel(channel_buffer).0;
 
-    let runtime = bootstrap(
+    let runtime = test_bootstrap(
         address.parse().unwrap(),
         Arc::new(mock_db.clone()),
         mp_sender,

--- a/json-rpc/src/tests/utils.rs
+++ b/json-rpc/src/tests/utils.rs
@@ -2,7 +2,9 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use anyhow::{Error, Result};
+use libra_config::config::RoleType;
 use libra_crypto::HashValue;
+use libra_mempool::MempoolClientSender;
 use libra_types::{
     account_address::AccountAddress,
     account_state_blob::{AccountStateBlob, AccountStateWithProof},
@@ -20,8 +22,19 @@ use libra_types::{
     },
     vm_error::StatusCode,
 };
-use std::collections::BTreeMap;
+use std::{collections::BTreeMap, net::SocketAddr, sync::Arc};
 use storage_interface::{DbReader, StartupInfo, TreeState};
+use tokio::runtime::Runtime;
+
+/// Creates JSON RPC server for a Validator node
+/// Should only be used for unit-tests
+pub fn test_bootstrap(
+    address: SocketAddr,
+    libra_db: Arc<dyn DbReader>,
+    mp_sender: MempoolClientSender,
+) -> Runtime {
+    crate::bootstrap(address, libra_db, mp_sender, RoleType::Validator)
+}
 
 /// Lightweight mock of LibraDB
 #[derive(Clone)]

--- a/network/src/lib.rs
+++ b/network/src/lib.rs
@@ -18,7 +18,7 @@ pub mod peer_manager;
 pub mod protocols;
 pub mod validator_network;
 
-mod counters;
+pub mod counters;
 mod peer;
 mod sink;
 mod transport;

--- a/network/src/peer_manager/mod.rs
+++ b/network/src/peer_manager/mod.rs
@@ -381,7 +381,6 @@ where
                 counters::LIBRA_NETWORK_PEERS
                     .with_label_values(&[self.role.as_str(), "connected"])
                     .set(self.active_peers.len() as i64);
-
                 // If the connection was explicitly closed by an upstream client, send an ACK.
                 if let Some(oneshot_tx) = self
                     .outstanding_disconnect_requests

--- a/network/src/peer_manager/mod.rs
+++ b/network/src/peer_manager/mod.rs
@@ -381,6 +381,7 @@ where
                 counters::LIBRA_NETWORK_PEERS
                     .with_label_values(&[self.role.as_str(), "connected"])
                     .set(self.active_peers.len() as i64);
+
                 // If the connection was explicitly closed by an upstream client, send an ACK.
                 if let Some(oneshot_tx) = self
                     .outstanding_disconnect_requests

--- a/secure/json-rpc/src/lib.rs
+++ b/secure/json-rpc/src/lib.rs
@@ -272,7 +272,7 @@ mod test {
     use futures::{channel::mpsc::channel, StreamExt};
     use libra_config::utils;
     use libra_crypto::{ed25519::Ed25519PrivateKey, HashValue, PrivateKey, Uniform};
-    use libra_json_rpc::bootstrap;
+    use libra_json_rpc::test_bootstrap;
     use libra_types::{
         account_address::AccountAddress,
         account_config::{AccountResource, BalanceResource},
@@ -413,7 +413,7 @@ mod test {
         let port = utils::get_available_port();
         let host = format!("{}:{}", address, port);
         let (mp_sender, mut mp_events) = channel(1024);
-        let server = bootstrap(host.parse().unwrap(), Arc::new(db), mp_sender);
+        let server = test_bootstrap(host.parse().unwrap(), Arc::new(db), mp_sender);
 
         let url = format!("http://{}", host);
         let client = JsonRpcClient::new(url);

--- a/secure/key-manager/src/tests.rs
+++ b/secure/key-manager/src/tests.rs
@@ -371,7 +371,7 @@ fn setup_libra_interface_and_json_server(
     let host = format!("{}:{}", address, port);
 
     let (mp_sender, mut mp_events) = channel(1024);
-    let server = libra_json_rpc::bootstrap(host.parse().unwrap(), db_rw.reader, mp_sender);
+    let server = libra_json_rpc::test_bootstrap(host.parse().unwrap(), db_rw.reader, mp_sender);
 
     // Provide a VMValidator to the runtime.
     server.spawn(async move {


### PR DESCRIPTION
## Summary

Adding `get_network_status` that returns the number of peers the node is connected to, to gauge network health
Refactored some test code accordingly

## Test Plan

Existing/new tests

