### PR TITLE
[language][vm] implement additional resource safety checks

### DIFF
--- a/language/e2e-tests/src/account.rs
+++ b/language/e2e-tests/src/account.rs
@@ -432,7 +432,7 @@ impl Balance {
 
     /// Returns the Move Value for the account balance
     pub fn to_value(&self) -> Value {
-        Value::struct_(Struct::pack(vec![Value::u64(self.coin)]))
+        Value::struct_(Struct::pack(vec![Value::u64(self.coin)], true))
     }
 
     /// Returns the value layout for the account balance
@@ -574,27 +574,35 @@ impl AccountType {
     /// Returns the Move Value representation of the AccountType.
     pub fn to_value(&self) -> Value {
         let inner_type_structure = match self.account_specifier {
-            AccountTypeSpecifier::Empty => Struct::pack(vec![Value::bool(false)]),
-            AccountTypeSpecifier::Vasp => Struct::pack(vec![Value::struct_(Struct::pack(vec![
-                Value::vector_u8(vec![]),
-                Value::vector_u8(vec![]),
-                Value::u64(u64::MAX),
-                Value::vector_u8(vec![0u8; 16]),
-            ]))]),
-            AccountTypeSpecifier::Unhosted => {
-                Struct::pack(vec![Value::struct_(Struct::pack(vec![
-                    Value::u64(0),
-                    Value::u64(0),
-                    Value::u64(0),
-                    Value::u64(0),
-                ]))])
-            }
+            AccountTypeSpecifier::Empty => Struct::pack(vec![Value::bool(false)], false),
+            AccountTypeSpecifier::Vasp => Struct::pack(
+                vec![Value::struct_(Struct::pack(
+                    vec![
+                        Value::vector_u8(vec![]),
+                        Value::vector_u8(vec![]),
+                        Value::u64(u64::MAX),
+                        Value::vector_u8(vec![0u8; 16]),
+                    ],
+                    false,
+                ))],
+                false,
+            ),
+            AccountTypeSpecifier::Unhosted => Struct::pack(
+                vec![Value::struct_(Struct::pack(
+                    vec![Value::u64(0), Value::u64(0), Value::u64(0), Value::u64(0)],
+                    false,
+                ))],
+                false,
+            ),
         };
-        Value::struct_(Struct::pack(vec![
-            Value::bool(true),
-            Value::struct_(inner_type_structure),
-            Value::address(self.self_address),
-        ]))
+        Value::struct_(Struct::pack(
+            vec![
+                Value::bool(true),
+                Value::struct_(inner_type_structure),
+                Value::address(self.self_address),
+            ],
+            true,
+        ))
     }
 
     pub fn type_(account_specifier: AccountTypeSpecifier) -> FatStructType {
@@ -631,10 +639,10 @@ impl EventHandleGenerator {
     }
 
     pub fn to_value(&self) -> Value {
-        Value::struct_(Struct::pack(vec![
-            Value::u64(self.counter),
-            Value::address(self.addr),
-        ]))
+        Value::struct_(Struct::pack(
+            vec![Value::u64(self.counter), Value::address(self.addr)],
+            true,
+        ))
     }
 
     pub fn type_() -> FatStructType {
@@ -855,22 +863,31 @@ impl AccountData {
             .collect();
         let assoc_cap = self.account_type.to_value();
         let event_generator = self.event_generator.to_value();
-        let account = Value::struct_(Struct::pack(vec![
-            // TODO: this needs to compute the auth key instead
-            Value::vector_u8(AuthenticationKey::ed25519(&self.account.pubkey).to_vec()),
-            Value::bool(self.delegated_key_rotation_capability),
-            Value::bool(self.delegated_withdrawal_capability),
-            Value::struct_(Struct::pack(vec![
-                Value::u64(self.received_events.count()),
-                Value::vector_u8(self.received_events.key().to_vec()),
-            ])),
-            Value::struct_(Struct::pack(vec![
-                Value::u64(self.sent_events.count()),
-                Value::vector_u8(self.sent_events.key().to_vec()),
-            ])),
-            Value::u64(self.sequence_number),
-            Value::bool(self.is_frozen),
-        ]));
+        let account = Value::struct_(Struct::pack(
+            vec![
+                // TODO: this needs to compute the auth key instead
+                Value::vector_u8(AuthenticationKey::ed25519(&self.account.pubkey).to_vec()),
+                Value::bool(self.delegated_key_rotation_capability),
+                Value::bool(self.delegated_withdrawal_capability),
+                Value::struct_(Struct::pack(
+                    vec![
+                        Value::u64(self.received_events.count()),
+                        Value::vector_u8(self.received_events.key().to_vec()),
+                    ],
+                    true,
+                )),
+                Value::struct_(Struct::pack(
+                    vec![
+                        Value::u64(self.sent_events.count()),
+                        Value::vector_u8(self.sent_events.key().to_vec()),
+                    ],
+                    true,
+                )),
+                Value::u64(self.sequence_number),
+                Value::bool(self.is_frozen),
+            ],
+            true,
+        ));
         (account, balances, assoc_cap, event_generator)
     }
 

--- a/language/move-vm/runtime/src/loader.rs
+++ b/language/move-vm/runtime/src/loader.rs
@@ -728,6 +728,10 @@ impl<'a> Resolver<'a> {
         self.loader.type_to_fat_type(ty)
     }
 
+    pub(crate) fn is_resource(&self, ty: &Type) -> VMResult<bool> {
+        self.loader.is_resource(ty)
+    }
+
     pub(crate) fn make_fat_type(
         &self,
         token: &SignatureToken,

--- a/language/move-vm/runtime/src/native_functions.rs
+++ b/language/move-vm/runtime/src/native_functions.rs
@@ -182,4 +182,8 @@ impl<'a> NativeContext for FunctionContext<'a> {
             .map(|ty| self.resolver.type_to_fat_type(ty))
             .collect()
     }
+
+    fn is_resource(&self, ty: &Type) -> VMResult<bool> {
+        self.resolver.is_resource(ty)
+    }
 }

--- a/language/move-vm/types/src/natives/function.rs
+++ b/language/move-vm/types/src/natives/function.rs
@@ -56,6 +56,8 @@ pub trait NativeContext {
     fn save_event(&mut self, event: ContractEvent) -> VMResult<()>;
     /// Converts types to fet types.
     fn convert_to_fat_types(&self, types: Vec<Type>) -> VMResult<Vec<FatType>>;
+    /// Whether a type is a resource or not.
+    fn is_resource(&self, ty: &Type) -> VMResult<bool>;
 }
 
 /// Result of a native function execution requires charges for execution cost.

--- a/language/move-vm/types/src/unit_tests/mod.rs
+++ b/language/move-vm/types/src/unit_tests/mod.rs
@@ -1,4 +1,5 @@
 // Copyright (c) The Libra Core Contributors
 // SPDX-License-Identifier: Apache-2.0
 
+#[cfg(feature = "fuzzing")]
 mod identifier_prop_tests;


### PR DESCRIPTION
## Summary
This introduces Container::Resource, making it possible to determine the kinds of the values. A few checks were added to prevent resources from being copied or implicitly destroyed.

Note this is an additional safety net in case the verifier is bugged. Our vision is to start safe, and as we gradually gain trust on the verifier running in production, we may consider removing these checks, if performance ends up being an issue.

## Test Plan
cargo test

Note: still a WIP. Existing functional tests are passing but need to write a few unit tests.