### PR TITLE
[language] Move all native functions in move-vm/natives

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2217,6 +2217,7 @@ dependencies = [
  "libra-vm 0.1.0",
  "libra-workspace-hack 0.1.0",
  "move-core-types 0.1.0",
+ "move-vm-natives 0.1.0",
  "move-vm-runtime 0.1.0",
  "move-vm-types 0.1.0",
  "once_cell 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/language/e2e-tests/Cargo.toml
+++ b/language/e2e-tests/Cargo.toml
@@ -21,8 +21,9 @@ libra-state-view = { path = "../../storage/state-view", version = "0.1.0" }
 libra-types = { path = "../../types", version = "0.1.0", features = ["fuzzing"] }
 libra-workspace-hack = { path = "../../common/workspace-hack", version = "0.1.0" }
 move-core-types = { path = "../move-core/types", version = "0.1.0" }
-move-vm-types = { path = "../move-vm/types", version = "0.1.0", features = ["debug_module"] }
+move-vm-natives = { path = "../move-vm/natives", version = "0.1.0", features = ["debug_module"] }
 move-vm-runtime = { path = "../move-vm/runtime", version = "0.1.0", features = ["debug_module"] }
+move-vm-types = { path = "../move-vm/types", version = "0.1.0" }
 transaction-builder = { path = "../transaction-builder", version = "0.1.0", features = ["fuzzing"]}
 vm = { path = "../vm", version = "0.1.0" }
 vm-genesis = { path = "../tools/vm-genesis", version = "0.1.0" }

--- a/language/move-vm/natives/src/debug.rs
+++ b/language/move-vm/natives/src/debug.rs
@@ -1,0 +1,57 @@
+// Copyright (c) The Libra Core Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+use move_core_types::gas_schedule::ZERO_GAS_UNITS;
+#[allow(unused_imports)]
+use move_vm_types::values::{values_impl::debug::print_reference, Reference};
+use move_vm_types::{
+    loaded_data::runtime_types::Type,
+    natives::function::{NativeContext, NativeResult},
+    values::Value,
+};
+use std::collections::VecDeque;
+use vm::errors::VMResult;
+
+#[allow(unused_mut)]
+#[allow(unused_variables)]
+pub fn native_print(
+    context: &mut impl NativeContext,
+    ty_args: Vec<Type>,
+    mut args: VecDeque<Value>,
+) -> VMResult<NativeResult> {
+    debug_assert!(ty_args.len() == 1);
+    debug_assert!(args.len() == 1);
+
+    // No-op if the feature flag is not present.
+    #[cfg(feature = "debug_module")]
+    {
+        let mut ty_args = context.convert_to_fat_types(ty_args)?;
+        let ty = ty_args.pop().unwrap();
+        let r = pop_arg!(args, Reference);
+
+        let mut buf = String::new();
+        print_reference(&mut buf, &ty, &r)?;
+        println!("[debug] {}", buf);
+    }
+
+    Ok(NativeResult::ok(ZERO_GAS_UNITS, vec![]))
+}
+
+#[allow(unused_variables)]
+pub fn native_print_stack_trace(
+    context: &mut impl NativeContext,
+    ty_args: Vec<Type>,
+    args: VecDeque<Value>,
+) -> VMResult<NativeResult> {
+    debug_assert!(ty_args.is_empty());
+    debug_assert!(args.is_empty());
+
+    #[cfg(feature = "debug_module")]
+    {
+        let mut s = String::new();
+        context.print_stack_trace(&mut s)?;
+        println!("{}", s);
+    }
+
+    Ok(NativeResult::ok(ZERO_GAS_UNITS, vec![]))
+}

--- a/language/move-vm/natives/src/lib.rs
+++ b/language/move-vm/natives/src/lib.rs
@@ -5,7 +5,10 @@
 extern crate move_vm_types;
 
 pub mod account;
+pub mod debug;
 pub mod event;
 pub mod hash;
 pub mod lcs;
 pub mod signature;
+pub mod signer;
+pub mod vector;

--- a/language/move-vm/natives/src/signer.rs
+++ b/language/move-vm/natives/src/signer.rs
@@ -1,0 +1,28 @@
+// Copyright (c) The Libra Core Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+use move_vm_types::{
+    gas_schedule::NativeCostIndex,
+    loaded_data::runtime_types::Type,
+    natives::function::{native_gas, NativeContext, NativeResult},
+    values::{values_impl::SignerRef, Value},
+};
+use std::collections::VecDeque;
+use vm::errors::VMResult;
+
+pub fn native_borrow_address(
+    context: &impl NativeContext,
+    _ty_args: Vec<Type>,
+    mut arguments: VecDeque<Value>,
+) -> VMResult<NativeResult> {
+    debug_assert!(_ty_args.is_empty());
+    debug_assert!(arguments.len() == 1);
+
+    let signer_reference = pop_arg!(arguments, SignerRef);
+    let cost = native_gas(context.cost_table(), NativeCostIndex::SIGNER_BORROW, 1);
+
+    Ok(NativeResult::ok(
+        cost,
+        vec![signer_reference.borrow_signer()?],
+    ))
+}

--- a/language/move-vm/natives/src/vector.rs
+++ b/language/move-vm/natives/src/vector.rs
@@ -1,0 +1,124 @@
+// Copyright (c) The Libra Core Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+use move_core_types::gas_schedule::GasAlgebra;
+use move_vm_types::{
+    gas_schedule::NativeCostIndex,
+    loaded_data::runtime_types::Type,
+    natives::function::{native_gas, NativeContext, NativeResult},
+    values::{Value, Vector, VectorRef},
+};
+use std::collections::VecDeque;
+use vm::errors::VMResult;
+
+pub fn native_empty(
+    context: &impl NativeContext,
+    ty_args: Vec<Type>,
+    args: VecDeque<Value>,
+) -> VMResult<NativeResult> {
+    debug_assert!(ty_args.len() == 1);
+    debug_assert!(args.is_empty());
+
+    let cost = native_gas(context.cost_table(), NativeCostIndex::EMPTY, 1);
+    Vector::empty(cost, &ty_args[0], context)
+}
+
+pub fn native_length(
+    context: &impl NativeContext,
+    ty_args: Vec<Type>,
+    mut args: VecDeque<Value>,
+) -> VMResult<NativeResult> {
+    debug_assert!(ty_args.len() == 1);
+    debug_assert!(args.len() == 1);
+
+    let r = pop_arg!(args, VectorRef);
+
+    let cost = native_gas(context.cost_table(), NativeCostIndex::LENGTH, 1);
+
+    let len = r.len(&ty_args[0], context)?;
+    Ok(NativeResult::ok(cost, vec![len]))
+}
+
+pub fn native_push_back(
+    context: &impl NativeContext,
+    ty_args: Vec<Type>,
+    mut args: VecDeque<Value>,
+) -> VMResult<NativeResult> {
+    debug_assert!(ty_args.len() == 1);
+    debug_assert!(args.len() == 2);
+
+    let e = args.pop_back().unwrap();
+    let r = pop_arg!(args, VectorRef);
+
+    let cost = native_gas(
+        context.cost_table(),
+        NativeCostIndex::PUSH_BACK,
+        e.size().get() as usize,
+    );
+
+    r.push_back(e, &ty_args[0], context)?;
+    Ok(NativeResult::ok(cost, vec![]))
+}
+
+pub fn native_borrow(
+    context: &impl NativeContext,
+    ty_args: Vec<Type>,
+    mut args: VecDeque<Value>,
+) -> VMResult<NativeResult> {
+    debug_assert!(ty_args.len() == 1);
+    debug_assert!(args.len() == 2);
+
+    let idx = pop_arg!(args, u64) as usize;
+    let r = pop_arg!(args, VectorRef);
+
+    let cost = native_gas(context.cost_table(), NativeCostIndex::BORROW, 1);
+
+    r.borrow_elem(idx, cost, &ty_args[0], context)
+}
+
+pub fn native_pop(
+    context: &impl NativeContext,
+    ty_args: Vec<Type>,
+    mut args: VecDeque<Value>,
+) -> VMResult<NativeResult> {
+    debug_assert!(ty_args.len() == 1);
+    debug_assert!(args.len() == 1);
+
+    let r = pop_arg!(args, VectorRef);
+
+    let cost = native_gas(context.cost_table(), NativeCostIndex::POP_BACK, 1);
+
+    r.pop(cost, &ty_args[0], context)
+}
+
+pub fn native_destroy_empty(
+    context: &impl NativeContext,
+    ty_args: Vec<Type>,
+    mut args: VecDeque<Value>,
+) -> VMResult<NativeResult> {
+    debug_assert!(ty_args.len() == 1);
+    debug_assert!(args.len() == 1);
+
+    let v = pop_arg!(args, Vector);
+
+    let cost = native_gas(context.cost_table(), NativeCostIndex::DESTROY_EMPTY, 1);
+
+    v.destroy_empty(cost, &ty_args[0], context)
+}
+
+pub fn native_swap(
+    context: &impl NativeContext,
+    ty_args: Vec<Type>,
+    mut args: VecDeque<Value>,
+) -> VMResult<NativeResult> {
+    debug_assert!(ty_args.len() == 1);
+    debug_assert!(args.len() == 3);
+
+    let idx2 = pop_arg!(args, u64) as usize;
+    let idx1 = pop_arg!(args, u64) as usize;
+    let r = pop_arg!(args, VectorRef);
+
+    let cost = native_gas(context.cost_table(), NativeCostIndex::SWAP, 1);
+
+    r.swap(idx1, idx2, cost, &ty_args[0], context)
+}

--- a/language/move-vm/runtime/src/native_functions.rs
+++ b/language/move-vm/runtime/src/native_functions.rs
@@ -7,13 +7,13 @@ use libra_types::{
     contract_event::ContractEvent,
 };
 use move_core_types::{gas_schedule::CostTable, identifier::IdentStr, language_storage::ModuleId};
-use move_vm_natives::{account, event, hash, lcs, signature};
+use move_vm_natives::{account, debug, event, hash, lcs, signature, signer, vector};
 use move_vm_types::{
     data_store::DataStore,
     gas_schedule::CostStrategy,
     loaded_data::{runtime_types::Type, types::FatType},
     natives::function::{NativeContext, NativeResult},
-    values::{debug, signer, vector, Struct, Value},
+    values::{Struct, Value},
 };
 use std::{collections::VecDeque, fmt::Write};
 use vm::errors::VMResult;

--- a/language/move-vm/types/Cargo.toml
+++ b/language/move-vm/types/Cargo.toml
@@ -30,4 +30,3 @@ proptest = "0.10.0"
 default = []
 batch = ["libra-crypto/batch"]
 fuzzing = ["proptest", "libra-types/fuzzing", "vm/fuzzing"]
-debug_module = []


### PR DESCRIPTION
Isolate all native functions into the same crate.
The vector API will be reworked soon and that would make
this break up even cleaner.
