### PR TITLE
[aws][code-build] Enable ad-hoc code build for all images

### DIFF
--- a/docker/build-aws.sh
+++ b/docker/build-aws.sh
@@ -23,13 +23,22 @@ BUILD_PROJECTS=()
 
 while [[ "$1" =~ ^- ]]; do case $1 in
   --build-all )
-    BUILD_PROJECTS=(libra-validator libra-cluster-test)
+    BUILD_PROJECTS=(libra-validator libra-cluster-test libra-init libra-mint libra-safety-rules)
     ;;
   --build-cluster-test )
     BUILD_PROJECTS=(libra-cluster-test)
     ;;
   --build-validator )
     BUILD_PROJECTS=(libra-validator)
+    ;;
+  --build-init )
+    BUILD_PROJECTS=(libra-init)
+    ;;
+  --build-mint )
+    BUILD_PROJECTS=(libra-mint)
+    ;;
+  --build-safety-rules )
+    BUILD_PROJECTS=(libra-safety-rules)
     ;;
   --version )
     shift;

--- a/docker/init/buildspec.yaml
+++ b/docker/init/buildspec.yaml
@@ -1,0 +1,21 @@
+# This buildspec is for AWS Codebuild
+version: 0.2
+
+phases:
+  install:
+    runtime-versions:
+      docker: 18
+  pre_build:
+    commands:
+      - echo Logging in to Amazon ECR...
+      - $(aws ecr get-login --no-include-email --region us-west-2)
+  build:
+    commands:
+      - echo Build started on `date`
+      - echo Building the Docker image...
+      - bash docker/init/build.sh
+  post_build:
+    commands:
+      - echo Build completed on `date`
+      # Tag and push the docker images
+      - SOURCE=libra_init:latest TARGET_REPO=$LIBRA_INIT_REPO TARGET_TAGS="${TAGS}:dev_$(git rev-parse --short=8  HEAD)" docker/tag-and-push.sh

--- a/docker/mint/buildspec.yaml
+++ b/docker/mint/buildspec.yaml
@@ -1,0 +1,21 @@
+# This buildspec is for AWS Codebuild
+version: 0.2
+
+phases:
+  install:
+    runtime-versions:
+      docker: 18
+  pre_build:
+    commands:
+      - echo Logging in to Amazon ECR...
+      - $(aws ecr get-login --no-include-email --region us-west-2)
+  build:
+    commands:
+      - echo Build started on `date`
+      - echo Building the Docker image...
+      - bash docker/mint/build.sh
+  post_build:
+    commands:
+      - echo Build completed on `date`
+      # Tag and push the docker images
+      - SOURCE=libra_faucet:latest TARGET_REPO=$LIBRA_FAUCET_REPO TARGET_TAGS="${TAGS}:dev_$(git rev-parse --short=8  HEAD)" docker/tag-and-push.sh

--- a/docker/mint/buildspec.yaml
+++ b/docker/mint/buildspec.yaml
@@ -18,4 +18,4 @@ phases:
     commands:
       - echo Build completed on `date`
       # Tag and push the docker images
-      - SOURCE=libra_faucet:latest TARGET_REPO=$LIBRA_FAUCET_REPO TARGET_TAGS="${TAGS}:dev_$(git rev-parse --short=8  HEAD)" docker/tag-and-push.sh
+      - SOURCE=libra_mint:latest TARGET_REPO=$LIBRA_MINT_REPO TARGET_TAGS="${TAGS}:dev_$(git rev-parse --short=8  HEAD)" docker/tag-and-push.sh

--- a/docker/safety-rules/buildspec.yaml
+++ b/docker/safety-rules/buildspec.yaml
@@ -1,0 +1,21 @@
+# This buildspec is for AWS Codebuild
+version: 0.2
+
+phases:
+  install:
+    runtime-versions:
+      docker: 18
+  pre_build:
+    commands:
+      - echo Logging in to Amazon ECR...
+      - $(aws ecr get-login --no-include-email --region us-west-2)
+  build:
+    commands:
+      - echo Build started on `date`
+      - echo Building the Docker image...
+      - bash docker/safety-rules/build.sh
+  post_build:
+    commands:
+      - echo Build completed on `date`
+      # Tag and push the docker images
+      - SOURCE=libra_safety_rules:latest TARGET_REPO=$LIBRA_SAFETY_RULES_REPO TARGET_TAGS="${TAGS}:dev_$(git rev-parse --short=8  HEAD)" docker/tag-and-push.sh


### PR DESCRIPTION
<!--
Thank you for sending a PR. We appreciate you spending time to help improve the Libra project.

The project is undergoing daily changes. Pull Requests will be reviewed and responded to as time permits.
-->

## Motivation

Add CodeBuild support for init, mint, and safety-rules so we can build those images ad-hoc instead of waiting for continuous push.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

When configs have been added on AWS side:

```
./docker/build-aws.sh --build-all --version pull/4135
```

## Related PRs

(If this PR adds or changes functionality, please take some time to update the docs at https://github.com/libra/website, and link to your PR here.)
