### PR TITLE
[types] Add account role resource to the account state blob, plumb into json-rpc

### DIFF
--- a/json-rpc/src/methods.rs
+++ b/json-rpc/src/methods.rs
@@ -117,7 +117,9 @@ async fn get_account_state(
         let account_state = AccountState::try_from(&blob)?;
         if let Some(account) = account_state.get_account_resource()? {
             let balances = account_state.get_balance_resources(&currencies)?;
-            return Ok(Some(AccountView::new(&account, balances)));
+            if let Some(account_role) = account_state.get_account_role()? {
+                return Ok(Some(AccountView::new(&account, balances, account_role)));
+            }
         }
     }
     Ok(None)

--- a/testsuite/tests/libratest/smoke_test.rs
+++ b/testsuite/tests/libratest/smoke_test.rs
@@ -817,6 +817,7 @@ fn test_external_transaction_signer() {
             sender: p_sender,
             sequence_number: p_sequence_number,
             gas_unit_price: p_gas_unit_price,
+            gas_currency: p_gas_currency,
             max_gas_amount: p_max_gas_amount,
             script,
             ..
@@ -824,17 +825,20 @@ fn test_external_transaction_signer() {
             assert_eq!(p_sender, sender_address.to_string());
             assert_eq!(p_sequence_number, sequence_number);
             assert_eq!(p_gas_unit_price, gas_unit_price);
+            assert_eq!(p_gas_currency, currency_code.to_string());
             assert_eq!(p_max_gas_amount, max_gas_amount);
             match script {
                 ScriptView::PeerToPeer {
                     receiver: p_receiver,
                     amount: p_amount,
+                    currency: p_currency,
                     auth_key_prefix,
                     metadata,
                     metadata_signature,
                 } => {
                     assert_eq!(p_receiver, receiver_address.to_string());
                     assert_eq!(p_amount, amount);
+                    assert_eq!(p_currency, currency_code.to_string());
                     assert_eq!(
                         auth_key_prefix
                             .into_bytes()

--- a/types/src/account_config/resources/mod.rs
+++ b/types/src/account_config/resources/mod.rs
@@ -5,8 +5,12 @@ pub mod account;
 pub mod association_capability;
 pub mod balance;
 pub mod currency_info;
+pub mod role;
+pub mod vasp;
 
 pub use account::*;
 pub use association_capability::*;
 pub use balance::*;
 pub use currency_info::*;
+pub use role::*;
+pub use vasp::*;

--- a/types/src/account_config/resources/role.rs
+++ b/types/src/account_config/resources/role.rs
@@ -1,0 +1,101 @@
+// Copyright (c) The Libra Core Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::{
+    access_path::AccessPath,
+    account_config::{
+        constants::{ACCOUNT_MODULE_NAME, CORE_CODE_ADDRESS},
+        resources::{ChildVASP, ParentVASP},
+    },
+};
+use move_core_types::{
+    language_storage::{StructTag, TypeTag},
+    move_resource::MoveResource,
+};
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Serialize, Deserialize)]
+pub enum AccountRole {
+    ParentVASP(ParentVASP),
+    ChildVASP(ChildVASP),
+    Empty,
+    Unhosted,
+    Unknown,
+}
+
+impl AccountRole {
+    pub fn parent_vasp_data(&self) -> Option<&ParentVASP> {
+        match self {
+            AccountRole::ParentVASP(vasp) => Some(vasp),
+            _ => None,
+        }
+    }
+
+    pub fn child_vasp_data(&self) -> Option<&ChildVASP> {
+        match self {
+            AccountRole::ChildVASP(vasp) => Some(vasp),
+            _ => None,
+        }
+    }
+
+    pub fn is_unhosted(&self) -> bool {
+        match self {
+            AccountRole::Unhosted => true,
+            _ => false,
+        }
+    }
+
+    pub fn is_empty(&self) -> bool {
+        match self {
+            AccountRole::Empty => true,
+            _ => false,
+        }
+    }
+
+    pub fn access_path_for<Role: MoveResource>() -> Vec<u8> {
+        let role_type_tag = TypeTag::Struct(Role::struct_tag());
+        let tag = StructTag {
+            address: CORE_CODE_ADDRESS,
+            name: AccountRole::struct_identifier(),
+            module: AccountRole::module_identifier(),
+            type_params: vec![role_type_tag],
+        };
+        AccessPath::resource_access_vec(&tag)
+    }
+}
+
+impl MoveResource for AccountRole {
+    const MODULE_NAME: &'static str = ACCOUNT_MODULE_NAME;
+    const STRUCT_NAME: &'static str = "Role";
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct ParentVASPRole {
+    pub role: ParentVASP,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct ChildVASPRole {
+    pub role: ChildVASP,
+}
+
+// Empty Move resources have a dummy boolean field
+#[derive(Debug, Serialize, Deserialize)]
+pub struct EmptyRole {
+    _dummy: bool,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct UnhostedRole {
+    _dummy: bool,
+}
+
+impl MoveResource for EmptyRole {
+    const MODULE_NAME: &'static str = "Empty";
+    const STRUCT_NAME: &'static str = "T";
+}
+
+impl MoveResource for UnhostedRole {
+    const MODULE_NAME: &'static str = "Unhosted";
+    const STRUCT_NAME: &'static str = "T";
+}

--- a/types/src/account_config/resources/vasp.rs
+++ b/types/src/account_config/resources/vasp.rs
@@ -1,0 +1,56 @@
+// Copyright (c) The Libra Core Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::account_address::AccountAddress;
+use move_core_types::move_resource::MoveResource;
+#[cfg(any(test, feature = "fuzzing"))]
+use proptest_derive::Arbitrary;
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct ParentVASP {
+    human_name: String,
+    base_url: String,
+    expiration_date: u64,
+    compliance_public_key: Vec<u8>,
+}
+
+impl ParentVASP {
+    pub fn human_name(&self) -> &str {
+        &self.human_name
+    }
+
+    pub fn base_url(&self) -> &str {
+        &self.base_url
+    }
+
+    pub fn expiration_date(&self) -> u64 {
+        self.expiration_date
+    }
+
+    pub fn compliance_public_key(&self) -> &[u8] {
+        &self.compliance_public_key
+    }
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+#[cfg_attr(any(test, feature = "fuzzing"), derive(Arbitrary))]
+pub struct ChildVASP {
+    parent_vasp_addr: AccountAddress,
+}
+
+impl ChildVASP {
+    pub fn parent_vasp_addr(&self) -> AccountAddress {
+        self.parent_vasp_addr
+    }
+}
+
+impl MoveResource for ParentVASP {
+    const MODULE_NAME: &'static str = "VASP";
+    const STRUCT_NAME: &'static str = "ParentVASP";
+}
+
+impl MoveResource for ChildVASP {
+    const MODULE_NAME: &'static str = "VASP";
+    const STRUCT_NAME: &'static str = "ChildVASP";
+}


### PR DESCRIPTION
This adds the account role to the AccountView in json-rpc, and the `AccountState`. This also adds the currency field to the gas price for a `UserTransaction` in JSON-RPC. 

Output: 

```
❯ curl -X POST -H "Content-Type: application/json" --data '{"jsonrpc":"2.0", "method":"get_account_state","params":["e0372b4f465415dcc4c103d66f237ecb"],"id":1}' 127.0.0.1:50537
{"id":1,"jsonrpc":"2.0","result":{"authentication_key":"2ee7110c881f5e62d168fb8e757fead0e0372b4f465415dcc4c103d66f237ecb","balances":[{"amount":100000000000,"currency":"LBR"}],"delegated_key_rotation_capability":false,"delegated_withdrawal_capability":false,"received_events_key":"0000000000000000e0372b4f465415dcc4c103d66f237ecb","role":{"parent_vasp":{"base_url":"https://libra.org/","compliance_key":"00000000000000000000000000000000","expiration_time":18446744073709551615,"human_name":"testnet"}},"sent_events_key":"0100000000000000e0372b4f465415dcc4c103d66f237ecb","sequence_number":0}}%

libra/testsuite/libra-swarm git/vasp_account_state
❯ curl -X POST -H "Content-Type: application/json" --data '{"jsonrpc":"2.0", "method":"get_account_state","params":["0000000000000000000000000a550c18"],"id":1}' 127.0.0.1:50537
{"id":1,"jsonrpc":"2.0","result":{"authentication_key":"99d62d1c5bb90cee62c7eee5a6027bf0010054b89da104ab1c52b29f4eb60ab9","balances":[{"amount":0,"currency":"LBR"}],"delegated_key_rotation_capability":false,"delegated_withdrawal_capability":false,"received_events_key":"0e000000000000000000000000000000000000000a550c18","role":"empty","sent_events_key":"0f000000000000000000000000000000000000000a550c18","sequence_number":2}}
```