### PR TITLE
[backup] BackupServiceClient explict no_proxy()

### DIFF
--- a/storage/backup/backup-cli/src/backup.rs
+++ b/storage/backup/backup-cli/src/backup.rs
@@ -23,7 +23,10 @@ impl BackupServiceClient {
     pub fn new(port: u16) -> Self {
         Self {
             port,
-            client: reqwest::Client::new(),
+            client: reqwest::Client::builder()
+                .no_proxy()
+                .build()
+                .expect("Http client should build."),
         }
     }
 


### PR DESCRIPTION


## Motivation
reqwest::Client doesn't respect $no_proxy env variable, causing the BackupServiceClient to route traffic to the proxy when $http_proxy env var is set.  There's PR open for that, but in our case we do not want to use proxy at all at this point, because the backup service is open to localhost only anyways.

https://github.com/seanmonstar/reqwest/pull/877


### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?
yes

## Test Plan

existing coverage when $http_proxy is set.

## Related PRs

(If this PR adds or changes functionality, please take some time to update the docs at https://github.com/libra/website, and link to your PR here.)
