### PR TITLE
[move source language] Add aliasing to spec contexts

### DIFF
--- a/language/move-lang/tests/move_check/expansion/duplicate_alias.exp
+++ b/language/move-lang/tests/move_check/expansion/duplicate_alias.exp
@@ -3,7 +3,7 @@ error:
    ┌── tests/move_check/expansion/duplicate_alias.move:8:19 ───
    │
  8 │     use 0x1::Y as Z;
-   │                   ^ Duplicate module alias 'Z'. Module aliases must be unique within a given module
+   │                   ^ Duplicate module alias 'Z'. Module aliases must be unique within a given namespace
    ·
  7 │     use 0x1::X as Z;
    │                   - Previously defined here

--- a/language/move-lang/tests/move_check/expansion/duplicate_function_in_module.exp
+++ b/language/move-lang/tests/move_check/expansion/duplicate_function_in_module.exp
@@ -3,7 +3,7 @@ error:
    ┌── tests/move_check/expansion/duplicate_function_in_module.move:3:9 ───
    │
  3 │     fun foo() { }
-   │         ^^^ Duplicate module member or alias 'foo'. Top level names in a module must be unique
+   │         ^^^ Duplicate module member or alias 'foo'. Top level names in a namespace must be unique
    ·
  2 │     fun foo() { }
    │         --- Previously defined here

--- a/language/move-lang/tests/move_check/expansion/duplicate_struct.exp
+++ b/language/move-lang/tests/move_check/expansion/duplicate_struct.exp
@@ -3,7 +3,7 @@ error:
    ┌── tests/move_check/expansion/duplicate_struct.move:3:12 ───
    │
  3 │     struct S {}
-   │            ^ Duplicate module member or alias 'S'. Top level names in a module must be unique
+   │            ^ Duplicate module member or alias 'S'. Top level names in a namespace must be unique
    ·
  2 │     struct S {}
    │            - Previously defined here

--- a/language/move-lang/tests/move_check/expansion/invalid_spec_schema_name.exp
+++ b/language/move-lang/tests/move_check/expansion/invalid_spec_schema_name.exp
@@ -1,0 +1,8 @@
+error: 
+
+   ┌── tests/move_check/expansion/invalid_spec_schema_name.move:2:17 ───
+   │
+ 2 │     spec schema foo<T> {
+   │                 ^^^ Invalid schema name 'foo'. Schema names must start with 'A'..'Z'
+   │
+

--- a/language/move-lang/tests/move_check/expansion/invalid_spec_schema_name.move
+++ b/language/move-lang/tests/move_check/expansion/invalid_spec_schema_name.move
@@ -1,0 +1,5 @@
+module M {
+    spec schema foo<T> {
+        ensures true;
+    }
+}

--- a/language/move-lang/tests/move_check/expansion/spec_block_uses.move
+++ b/language/move-lang/tests/move_check/expansion/spec_block_uses.move
@@ -1,0 +1,20 @@
+address 0x1 {
+module M {
+    resource struct S {}
+    resource struct R<T> {}
+
+    fun t1(): (R<u64>, S) {
+        abort 0
+    }
+
+    spec module {
+        use 0x1::M::{S as R, R as S};
+        ensures exists<S<u64>>(0x1) == exists<R>(0x1);
+    }
+
+    fun t2(): (R<u64>, S) {
+        abort 0
+    }
+
+}
+}

--- a/language/move-lang/tests/move_check/expansion/spec_block_uses_shadows_defines.move
+++ b/language/move-lang/tests/move_check/expansion/spec_block_uses_shadows_defines.move
@@ -1,0 +1,24 @@
+address 0x1 {
+module M {
+    resource struct R1 {}
+    resource struct R2<T> {}
+
+    fun t1(): (R2<u64>, R1) {
+        abort 0
+    }
+
+    spec module {
+        use 0x1::M::{R1 as R, R2 as S};
+        // TODO syntax change to move spec heleprs outside of blocks
+        define S(): bool { false }
+        define R(): bool { false }
+
+        ensures exists<S<u64>>(0x1) == exists<R>(0x1);
+    }
+
+    fun t2(): (R2<u64>, R1) {
+        abort 0
+    }
+
+}
+}

--- a/language/move-lang/tests/move_check/expansion/spec_function_member_conflicts.exp
+++ b/language/move-lang/tests/move_check/expansion/spec_function_member_conflicts.exp
@@ -1,0 +1,55 @@
+error: 
+
+   ┌── tests/move_check/expansion/spec_function_member_conflicts.move:7:12 ───
+   │
+ 7 │     struct Foo {}
+   │            ^^^ Duplicate module member or alias 'Foo'. Top level names in a namespace must be unique
+   ·
+ 5 │         define Foo(): bool { true }
+   │                --- Previously defined here
+   │
+
+error: 
+
+    ┌── tests/move_check/expansion/spec_function_member_conflicts.move:14:17 ───
+    │
+ 14 │     spec schema Foo<T> {
+    │                 ^^^ Duplicate module member or alias 'Foo'. Top level names in a namespace must be unique
+    ·
+ 12 │         define Foo(): bool { true }
+    │                --- Previously defined here
+    │
+
+error: 
+
+    ┌── tests/move_check/expansion/spec_function_member_conflicts.move:23:9 ───
+    │
+ 23 │     fun Foo() {}
+    │         ^^^ Duplicate module member or alias 'Foo'. Top level names in a namespace must be unique
+    ·
+ 21 │         define Foo(): bool { true }
+    │                --- Previously defined here
+    │
+
+error: 
+
+    ┌── tests/move_check/expansion/spec_function_member_conflicts.move:30:9 ───
+    │
+ 30 │     fun foo() {}
+    │         ^^^ Duplicate module member or alias 'foo'. Top level names in a namespace must be unique
+    ·
+ 28 │         define foo(): bool { true }
+    │                --- Previously defined here
+    │
+
+error: 
+
+    ┌── tests/move_check/expansion/spec_function_member_conflicts.move:38:16 ───
+    │
+ 38 │         define foo(): bool { true }
+    │                ^^^ Duplicate module member or alias 'foo'. Top level names in a namespace must be unique
+    ·
+ 35 │         define foo(): bool { true }
+    │                --- Previously defined here
+    │
+

--- a/language/move-lang/tests/move_check/expansion/spec_function_member_conflicts.move
+++ b/language/move-lang/tests/move_check/expansion/spec_function_member_conflicts.move
@@ -1,0 +1,41 @@
+address 0x1 {
+
+module X1 {
+    spec module {
+        define Foo(): bool { true }
+    }
+    struct Foo {}
+}
+
+module X2 {
+    spec module {
+        define Foo(): bool { true }
+    }
+    spec schema Foo<T> {
+        ensures true;
+    }
+}
+
+module X3 {
+    spec module {
+        define Foo(): bool { true }
+    }
+    fun Foo() {}
+}
+
+module X4 {
+    spec module {
+        define foo(): bool { true }
+    }
+    fun foo() {}
+}
+
+module X5 {
+    spec module {
+        define foo(): bool { true }
+    }
+    spec module {
+        define foo(): bool { true }
+    }
+}
+}

--- a/language/move-lang/tests/move_check/expansion/spec_schema_member_conflicts.exp
+++ b/language/move-lang/tests/move_check/expansion/spec_schema_member_conflicts.exp
@@ -1,0 +1,44 @@
+error: 
+
+   ┌── tests/move_check/expansion/spec_schema_member_conflicts.move:7:12 ───
+   │
+ 7 │     struct Foo {}
+   │            ^^^ Duplicate module member or alias 'Foo'. Top level names in a namespace must be unique
+   ·
+ 4 │     spec schema Foo<T> {
+   │                 --- Previously defined here
+   │
+
+error: 
+
+    ┌── tests/move_check/expansion/spec_schema_member_conflicts.move:14:17 ───
+    │
+ 14 │     spec schema Foo<T> {
+    │                 ^^^ Duplicate module member or alias 'Foo'. Top level names in a namespace must be unique
+    ·
+ 11 │     spec schema Foo<T> {
+    │                 --- Previously defined here
+    │
+
+error: 
+
+    ┌── tests/move_check/expansion/spec_schema_member_conflicts.move:23:9 ───
+    │
+ 23 │     fun Foo() {}
+    │         ^^^ Duplicate module member or alias 'Foo'. Top level names in a namespace must be unique
+    ·
+ 20 │     spec schema Foo<T> {
+    │                 --- Previously defined here
+    │
+
+error: 
+
+    ┌── tests/move_check/expansion/spec_schema_member_conflicts.move:31:16 ───
+    │
+ 31 │         define Foo(): bool { false }
+    │                ^^^ Duplicate module member or alias 'Foo'. Top level names in a namespace must be unique
+    ·
+ 27 │     spec schema Foo<T> {
+    │                 --- Previously defined here
+    │
+

--- a/language/move-lang/tests/move_check/expansion/spec_schema_member_conflicts.move
+++ b/language/move-lang/tests/move_check/expansion/spec_schema_member_conflicts.move
@@ -1,0 +1,35 @@
+address 0x1 {
+
+module X1 {
+    spec schema Foo<T> {
+        ensures true;
+    }
+    struct Foo {}
+}
+
+module X2 {
+    spec schema Foo<T> {
+        ensures true;
+    }
+    spec schema Foo<T> {
+        ensures true;
+    }
+}
+
+module X3 {
+    spec schema Foo<T> {
+        ensures true;
+    }
+    fun Foo() {}
+}
+
+module X4 {
+    spec schema Foo<T> {
+        ensures true;
+    }
+    spec module {
+        define Foo(): bool { false }
+    }
+}
+
+}

--- a/language/move-lang/tests/move_check/expansion/use_function_same_name_as_function.exp
+++ b/language/move-lang/tests/move_check/expansion/use_function_same_name_as_function.exp
@@ -3,7 +3,7 @@ error:
     ┌── tests/move_check/expansion/use_function_same_name_as_function.move:10:9 ───
     │
  10 │     fun u() {
-    │         ^ Duplicate module member or alias 'u'. Top level names in a module must be unique
+    │         ^ Duplicate module member or alias 'u'. Top level names in a namespace must be unique
     ·
   9 │     use 0x1::X::u;
     │                 - Previously defined here
@@ -14,7 +14,7 @@ error:
     ┌── tests/move_check/expansion/use_function_same_name_as_function.move:17:22 ───
     │
  17 │     use 0x1::X::u as bar;
-    │                      ^^^ Duplicate module member or alias 'bar'. Top level names in a module must be unique
+    │                      ^^^ Duplicate module member or alias 'bar'. Top level names in a namespace must be unique
     ·
  15 │     fun bar() {
     │         --- Previously defined here

--- a/language/move-lang/tests/move_check/expansion/use_function_same_name_as_struct.exp
+++ b/language/move-lang/tests/move_check/expansion/use_function_same_name_as_struct.exp
@@ -3,7 +3,7 @@ error:
     ┌── tests/move_check/expansion/use_function_same_name_as_struct.move:10:12 ───
     │
  10 │     struct u {}
-    │            ^ Duplicate module member or alias 'u'. Top level names in a module must be unique
+    │            ^ Duplicate module member or alias 'u'. Top level names in a namespace must be unique
     ·
   9 │     use 0x1::X::u;
     │                 - Previously defined here
@@ -22,7 +22,7 @@ error:
     ┌── tests/move_check/expansion/use_function_same_name_as_struct.move:15:22 ───
     │
  15 │     use 0x1::X::u as Bar;
-    │                      ^^^ Duplicate module member or alias 'Bar'. Top level names in a module must be unique
+    │                      ^^^ Duplicate module member or alias 'Bar'. Top level names in a namespace must be unique
     ·
  14 │     struct Bar {}
     │            --- Previously defined here

--- a/language/move-lang/tests/move_check/expansion/use_nested_self_duplicate.exp
+++ b/language/move-lang/tests/move_check/expansion/use_nested_self_duplicate.exp
@@ -3,7 +3,7 @@ error:
    ┌── tests/move_check/expansion/use_nested_self_duplicate.move:9:14 ───
    │
  9 │     use 0x1::X::Self;
-   │              ^ Duplicate module alias 'X'. Module aliases must be unique within a given module
+   │              ^ Duplicate module alias 'X'. Module aliases must be unique within a given namespace
    ·
  8 │     use 0x1::X;
    │              - Previously defined here

--- a/language/move-lang/tests/move_check/expansion/use_spec_function.move
+++ b/language/move-lang/tests/move_check/expansion/use_spec_function.move
@@ -1,0 +1,20 @@
+address 0x1 {
+module X {
+    spec module {
+        define foo(): bool { true }
+        define bar(): bool { true }
+    }
+}
+
+module M {
+    use 0x1::X::{foo, bar as baz};
+    fun t() {
+    }
+
+    spec fun t {
+        ensures foo();
+        ensures baz();
+    }
+}
+
+}

--- a/language/move-lang/tests/move_check/expansion/use_spec_function_as_normal_function.exp
+++ b/language/move-lang/tests/move_check/expansion/use_spec_function_as_normal_function.exp
@@ -1,0 +1,16 @@
+error: 
+
+    ┌── tests/move_check/expansion/use_spec_function_as_normal_function.move:12:9 ───
+    │
+ 12 │         foo();
+    │         ^^^ Invalid module access. Unbound function 'foo' in module '0x1::X'
+    │
+
+error: 
+
+    ┌── tests/move_check/expansion/use_spec_function_as_normal_function.move:13:9 ───
+    │
+ 13 │         baz();
+    │         ^^^ Invalid module access. Unbound function 'bar' in module '0x1::X'
+    │
+

--- a/language/move-lang/tests/move_check/expansion/use_spec_function_as_normal_function.move
+++ b/language/move-lang/tests/move_check/expansion/use_spec_function_as_normal_function.move
@@ -1,0 +1,17 @@
+address 0x1 {
+module X {
+    spec module {
+        define foo(): bool { true }
+        define bar(): bool { true }
+    }
+}
+
+module M {
+    use 0x1::X::{foo, bar as baz};
+    fun t() {
+        foo();
+        baz();
+    }
+}
+
+}

--- a/language/move-lang/tests/move_check/expansion/use_spec_schema.move
+++ b/language/move-lang/tests/move_check/expansion/use_spec_schema.move
@@ -1,0 +1,24 @@
+address 0x1 {
+module X {
+    spec schema Foo<T> {
+        ensures true;
+    }
+
+    spec schema Bar<T> {
+        ensures true;
+    }
+}
+
+module M {
+    use 0x1::X::{Foo, Bar as Baz};
+    struct S {}
+    fun t() {
+    }
+
+    spec fun t {
+        apply Foo<S> to t;
+        apply Baz<S> to t;
+    }
+}
+
+}

--- a/language/move-lang/tests/move_check/expansion/use_spec_schema_as_struct.exp
+++ b/language/move-lang/tests/move_check/expansion/use_spec_schema_as_struct.exp
@@ -1,0 +1,8 @@
+error: 
+
+    ┌── tests/move_check/expansion/use_spec_schema_as_struct.move:10:14 ───
+    │
+ 10 │     fun t(): Foo<u64> {
+    │              ^^^ Invalid module access. Unbound struct 'Foo' in module '0x1::X'
+    │
+

--- a/language/move-lang/tests/move_check/expansion/use_spec_schema_as_struct.move
+++ b/language/move-lang/tests/move_check/expansion/use_spec_schema_as_struct.move
@@ -1,0 +1,15 @@
+address 0x1 {
+module X {
+    spec schema Foo<T> {
+        ensures true;
+    }
+}
+
+module M {
+    use 0x1::X::Foo;
+    fun t(): Foo<u64> {
+        abort 0
+    }
+}
+
+}

--- a/language/move-lang/tests/move_check/expansion/use_spec_schema_invalid_as.exp
+++ b/language/move-lang/tests/move_check/expansion/use_spec_schema_invalid_as.exp
@@ -1,0 +1,8 @@
+error: 
+
+   ┌── tests/move_check/expansion/use_spec_schema_invalid_as.move:9:25 ───
+   │
+ 9 │     use 0x1::X::{Foo as foo};
+   │                         ^^^ Invalid schema alias name 'foo'. Schema alias names must start with 'A'..'Z'
+   │
+

--- a/language/move-lang/tests/move_check/expansion/use_spec_schema_invalid_as.move
+++ b/language/move-lang/tests/move_check/expansion/use_spec_schema_invalid_as.move
@@ -1,0 +1,17 @@
+address 0x1 {
+module X {
+    spec schema Foo<T> {
+        ensures true;
+    }
+}
+
+module M {
+    use 0x1::X::{Foo as foo};
+    struct S {}
+
+    spec fun t {
+        apply foo<S> to t;
+    }
+}
+
+}

--- a/language/move-lang/tests/move_check/expansion/use_struct_same_name_as_function.exp
+++ b/language/move-lang/tests/move_check/expansion/use_struct_same_name_as_function.exp
@@ -3,7 +3,7 @@ error:
     ┌── tests/move_check/expansion/use_struct_same_name_as_function.move:10:9 ───
     │
  10 │     fun U() {}
-    │         ^ Duplicate module member or alias 'U'. Top level names in a module must be unique
+    │         ^ Duplicate module member or alias 'U'. Top level names in a namespace must be unique
     ·
   8 │     use 0x1::X::{U, U as U2};
     │                  - Previously defined here
@@ -14,7 +14,7 @@ error:
     ┌── tests/move_check/expansion/use_struct_same_name_as_function.move:11:9 ───
     │
  11 │     fun U2() {}
-    │         ^^ Duplicate module member or alias 'U2'. Top level names in a module must be unique
+    │         ^^ Duplicate module member or alias 'U2'. Top level names in a namespace must be unique
     ·
   8 │     use 0x1::X::{U, U as U2};
     │                          -- Previously defined here
@@ -25,7 +25,7 @@ error:
     ┌── tests/move_check/expansion/use_struct_same_name_as_function.move:15:18 ───
     │
  15 │     use 0x1::X::{R, R as R2};
-    │                  ^ Duplicate module member or alias 'R'. Top level names in a module must be unique
+    │                  ^ Duplicate module member or alias 'R'. Top level names in a namespace must be unique
     ·
  12 │     fun R() {}
     │         - Previously defined here
@@ -44,7 +44,7 @@ error:
     ┌── tests/move_check/expansion/use_struct_same_name_as_function.move:15:26 ───
     │
  15 │     use 0x1::X::{R, R as R2};
-    │                          ^^ Duplicate module member or alias 'R2'. Top level names in a module must be unique
+    │                          ^^ Duplicate module member or alias 'R2'. Top level names in a namespace must be unique
     ·
  13 │     fun R2() {}
     │         -- Previously defined here

--- a/language/move-lang/tests/move_check/expansion/use_struct_same_name_as_struct.exp
+++ b/language/move-lang/tests/move_check/expansion/use_struct_same_name_as_struct.exp
@@ -3,7 +3,7 @@ error:
     ┌── tests/move_check/expansion/use_struct_same_name_as_struct.move:10:12 ───
     │
  10 │     struct U {}
-    │            ^ Duplicate module member or alias 'U'. Top level names in a module must be unique
+    │            ^ Duplicate module member or alias 'U'. Top level names in a namespace must be unique
     ·
   8 │     use 0x1::X::{U, U as U2};
     │                  - Previously defined here
@@ -14,7 +14,7 @@ error:
     ┌── tests/move_check/expansion/use_struct_same_name_as_struct.move:11:12 ───
     │
  11 │     struct U2 {}
-    │            ^^ Duplicate module member or alias 'U2'. Top level names in a module must be unique
+    │            ^^ Duplicate module member or alias 'U2'. Top level names in a namespace must be unique
     ·
   8 │     use 0x1::X::{U, U as U2};
     │                          -- Previously defined here
@@ -25,7 +25,7 @@ error:
     ┌── tests/move_check/expansion/use_struct_same_name_as_struct.move:15:18 ───
     │
  15 │     use 0x1::X::{R, R as R2};
-    │                  ^ Duplicate module member or alias 'R'. Top level names in a module must be unique
+    │                  ^ Duplicate module member or alias 'R'. Top level names in a namespace must be unique
     ·
  13 │     struct R {}
     │            - Previously defined here
@@ -44,7 +44,7 @@ error:
     ┌── tests/move_check/expansion/use_struct_same_name_as_struct.move:15:26 ───
     │
  15 │     use 0x1::X::{R, R as R2};
-    │                          ^^ Duplicate module member or alias 'R2'. Top level names in a module must be unique
+    │                          ^^ Duplicate module member or alias 'R2'. Top level names in a namespace must be unique
     ·
  12 │     struct R2 {}
     │            -- Previously defined here

--- a/language/move-prover/spec-lang/tests/sources/expressions_err.exp
+++ b/language/move-prover/spec-lang/tests/sources/expressions_err.exp
@@ -39,39 +39,29 @@ error: expected `(num, bool)` but found `bool` in expression
     │       ^^^^^
     │
 
-error: no matching declaration of `wrongly_typed_callee`
+error: no matching declaration of `M::wrongly_typed_callee`
 
     ┌── tests/sources/expressions_err.move:37:42 ───
     │
  37 │     define wrongly_typed_caller(): num { wrongly_typed_callee(1, 1) }
     │                                          ^^^^^^^^^^^^^^^^^^^^^^^^^^
     │
-    = outruled candidate `wrongly_typed_callee(num, bool): num` (expected `bool` but found `u128` for argument 2)
+    = outruled candidate `M::wrongly_typed_callee(num, bool): num` (expected `bool` but found `u128` for argument 2)
 
-error: no matching declaration of `wrongly_typed_fun_arg_callee`
+error: no matching declaration of `M::wrongly_typed_fun_arg_callee`
 
     ┌── tests/sources/expressions_err.move:41:50 ───
     │
  41 │     define wrongly_typed_fun_arg_caller(): num { wrongly_typed_fun_arg_callee(|x| false) }
     │                                                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
     │
-    = outruled candidate `wrongly_typed_fun_arg_callee(|num|num): num` (expected `num` but found `bool` for argument 1)
+    = outruled candidate `M::wrongly_typed_fun_arg_callee(|num|num): num` (expected `num` but found `bool` for argument 1)
 
-error: ambiguous application of `ambigous_callee`
+error: no matching declaration of `M::wrong_instantiation`
 
-    ┌── tests/sources/expressions_err.move:48:7 ───
+    ┌── tests/sources/expressions_err.move:46:7 ───
     │
- 48 │       ambigous_callee()
-    │       ^^^^^^^^^^^^^^^^^
-    │
-    = matching candidate `ambigous_callee(): num`
-    = matching candidate `ambigous_callee(): num`
-
-error: no matching declaration of `wrong_instantiation`
-
-    ┌── tests/sources/expressions_err.move:54:7 ───
-    │
- 54 │       wrong_instantiation<u64>(x)
+ 46 │       wrong_instantiation<u64>(x)
     │       ^^^^^^^^^^^^^^^^^^^^^^^^^^^
     │
-    = outruled candidate `wrong_instantiation(#0): #0` (generic count mismatch (expected 2 but found 1))
+    = outruled candidate `M::wrong_instantiation(#0): #0` (generic count mismatch (expected 2 but found 1))

--- a/language/move-prover/spec-lang/tests/sources/expressions_err.move
+++ b/language/move-prover/spec-lang/tests/sources/expressions_err.move
@@ -28,7 +28,7 @@ module M {
     }
 
     // Wrong result type tuple.
-    define wrong_result_type(): (num, bool) {
+    define wrong_result_type2(): (num, bool) {
       false
     }
 
@@ -39,14 +39,6 @@ module M {
     // Wrongly typed function argument.
     define wrongly_typed_fun_arg_callee(f: |num|num): num { 0 }
     define wrongly_typed_fun_arg_caller(): num { wrongly_typed_fun_arg_callee(|x| false) }
-
-    // Ambiguous application
-    // TODO: we actually want to see the error at the declaration, but currently we see it at the call.
-    define ambigous_callee(): num { 0 }
-    define ambigous_callee(): num { 0 }
-    define amdbigous_caller(): num {
-      ambigous_callee()
-    }
 
     // Wrong instantiation
     define wrong_instantiation<T1, T2>(x: T1): T1 { x }

--- a/language/move-prover/tests/sources/stdlib/modules/libra_account.move
+++ b/language/move-prover/tests/sources/stdlib/modules/libra_account.move
@@ -99,10 +99,10 @@ module LibraAccount {
     }
     spec fun deposit {
         aborts_if to_deposit.value == 0;
-        aborts_if !exists<T>(sender());
+        aborts_if !::exists<T>(sender());
         aborts_if global<T>(sender()).sent_events.counter + 1 > max_u64();
-        aborts_if !exists<T>(payee);
-        aborts_if !exists<Balance<Token>>(payee);
+        aborts_if !::exists<T>(payee);
+        aborts_if !::exists<Balance<Token>>(payee);
         aborts_if global<Balance<Token>>(payee).coin.value + to_deposit.value > max_u64();
         aborts_if global<T>(payee).received_events.counter + 1 > max_u64();
         ensures global<T>(sender()).sent_events.counter == old(global<T>(sender()).sent_events.counter) + 1;
@@ -116,9 +116,9 @@ module LibraAccount {
     }
     spec fun deposit_to_sender {
         aborts_if to_deposit.value == 0;
-        aborts_if !exists<T>(sender());
+        aborts_if !::exists<T>(sender());
         aborts_if global<T>(sender()).sent_events.counter + 1 > max_u64();
-        aborts_if !exists<Balance<Token>>(sender());
+        aborts_if !::exists<Balance<Token>>(sender());
         aborts_if global<Balance<Token>>(sender()).coin.value + to_deposit.value > max_u64();
         aborts_if global<T>(sender()).received_events.counter + 1 > max_u64();
         ensures global<T>(sender()).sent_events.counter == old(global<T>(sender()).sent_events.counter) + 1;
@@ -141,10 +141,10 @@ module LibraAccount {
     }
     spec fun deposit_with_metadata {
         aborts_if to_deposit.value == 0;
-        aborts_if !exists<T>(sender());
+        aborts_if !::exists<T>(sender());
         aborts_if global<T>(sender()).sent_events.counter + 1 > max_u64();
-        aborts_if !exists<T>(payee);
-        aborts_if !exists<Balance<Token>>(payee);
+        aborts_if !::exists<T>(payee);
+        aborts_if !::exists<Balance<Token>>(payee);
         aborts_if global<Balance<Token>>(payee).coin.value + to_deposit.value > max_u64();
         aborts_if global<T>(payee).received_events.counter + 1 > max_u64();
         ensures global<T>(sender()).sent_events.counter == old(global<T>(sender()).sent_events.counter) + 1;
@@ -193,10 +193,10 @@ module LibraAccount {
     }
     spec fun deposit_with_sender_and_metadata {
         aborts_if to_deposit.value == 0;
-        aborts_if !exists<T>(sender);
+        aborts_if !::exists<T>(sender);
         aborts_if global<T>(sender).sent_events.counter + 1 > max_u64();
-        aborts_if !exists<T>(payee);
-        aborts_if !exists<Balance<Token>>(payee);
+        aborts_if !::exists<T>(payee);
+        aborts_if !::exists<Balance<Token>>(payee);
         aborts_if global<Balance<Token>>(payee).coin.value + to_deposit.value > max_u64();
         aborts_if global<T>(payee).received_events.counter + 1 > max_u64();
         ensures global<T>(sender).sent_events.counter == old(global<T>(sender).sent_events.counter) + 1;
@@ -237,18 +237,18 @@ module LibraAccount {
     }
     spec fun cancel_burn {
         // derived from Libra::cancel_burn
-        aborts_if !exists<Libra::MintCapability<Token>>(sender());
-        aborts_if !exists<Libra::Preburn<Token>>(preburn_address);
+        aborts_if !::exists<Libra::MintCapability<Token>>(sender());
+        aborts_if !::exists<Libra::Preburn<Token>>(preburn_address);
         aborts_if len(global<Libra::Preburn<Token>>(preburn_address).requests) == 0;
-        aborts_if !exists<Libra::Info<Token>>(0xA550C18);
+        aborts_if !::exists<Libra::Info<Token>>(0xA550C18);
         aborts_if global<Libra::Info<Token>>(0xA550C18).preburn_value < global<Libra::Preburn<Token>>(preburn_address).requests[0].value;
 
         // derived from Self::deposit
         aborts_if to_return<Token>(preburn_address).value == 0;
-        aborts_if !exists<T>(sender());
+        aborts_if !::exists<T>(sender());
         aborts_if global<T>(sender()).sent_events.counter + 1 > max_u64();
-        aborts_if !exists<T>(preburn_address);
-        aborts_if !exists<Balance<Token>>(preburn_address);
+        aborts_if !::exists<T>(preburn_address);
+        aborts_if !::exists<Balance<Token>>(preburn_address);
         aborts_if global<Balance<Token>>(preburn_address).coin.value + to_return<Token>(preburn_address).value > max_u64();
         aborts_if global<T>(preburn_address).received_events.counter + 1 > max_u64();
 
@@ -282,8 +282,8 @@ module LibraAccount {
         withdraw_from_balance<Token>(sender_balance, amount)
     }
     spec fun withdraw_from_sender {
-        aborts_if !exists<T>(sender());
-        aborts_if !exists<Balance<Token>>(sender());
+        aborts_if !::exists<T>(sender());
+        aborts_if !::exists<Balance<Token>>(sender());
         aborts_if global<T>(sender()).delegated_withdrawal_capability;
         aborts_if global<Balance<Token>>(sender()).coin.value < amount;
         ensures global<Balance<Token>>(sender()).coin.value == old(global<Balance<Token>>(sender()).coin.value) - amount;
@@ -298,7 +298,7 @@ module LibraAccount {
         withdraw_from_balance<Token>(balance , amount)
     }
     spec fun withdraw_with_capability {
-        aborts_if !exists<Balance<Token>>(cap.account_address);
+        aborts_if !::exists<Balance<Token>>(cap.account_address);
         aborts_if global<Balance<Token>>(cap.account_address).coin.value < amount;
         ensures global<Balance<Token>>(cap.account_address).coin.value == old(global<Balance<Token>>(cap.account_address).coin.value) - amount;
         ensures result.value == amount;
@@ -317,7 +317,7 @@ module LibraAccount {
         WithdrawalCapability { account_address: sender }
     }
     spec fun extract_sender_withdrawal_capability {
-        aborts_if !exists<T>(sender());
+        aborts_if !::exists<T>(sender());
         aborts_if global<T>(sender()).delegated_withdrawal_capability == true;
         ensures global<T>(sender()).delegated_withdrawal_capability == true;
         ensures result.account_address == sender();
@@ -334,7 +334,7 @@ module LibraAccount {
         account.delegated_withdrawal_capability = false;
     }
     spec fun restore_withdrawal_capability {
-        aborts_if !exists<T>(cap.account_address);
+        aborts_if !::exists<T>(cap.account_address);
         ensures global<T>(cap.account_address).delegated_withdrawal_capability == false;
     }
 
@@ -378,41 +378,41 @@ module LibraAccount {
     }
     spec fun pay_from_sender_with_metadata {
         // derived from create_account
-        aborts_if !exists<T>(payee) && len(LCS::serialize(payee)) + len(auth_key_prefix) != 32; // modified
-        aborts_if !exists<T>(payee) && exists<Balance<Token>>(payee); // modified
-        aborts_if !exists<T>(payee) && !exists<Libra::Info<Token>>(0xA550C18); // modified
+        aborts_if !::exists<T>(payee) && len(LCS::serialize(payee)) + len(auth_key_prefix) != 32; // modified
+        aborts_if !::exists<T>(payee) && ::exists<Balance<Token>>(payee); // modified
+        aborts_if !::exists<T>(payee) && !::exists<Libra::Info<Token>>(0xA550C18); // modified
         // derived from withdraw_from_sender
-        aborts_if sender() != payee && !exists<T>(sender()); // modified
-        aborts_if sender() != payee && !exists<Balance<Token>>(sender()); // modified
-        aborts_if sender() == payee && exists<T>(payee) && !exists<Balance<Token>>(sender()); // modified
-        aborts_if exists<T>(sender()) && global<T>(sender()).delegated_withdrawal_capability; // modified
-        aborts_if sender() == payee && !exists<T>(payee);
-        aborts_if exists<Balance<Token>>(sender()) && global<Balance<Token>>(sender()).coin.value < amount; // modified
+        aborts_if sender() != payee && !::exists<T>(sender()); // modified
+        aborts_if sender() != payee && !::exists<Balance<Token>>(sender()); // modified
+        aborts_if sender() == payee && ::exists<T>(payee) && !::exists<Balance<Token>>(sender()); // modified
+        aborts_if ::exists<T>(sender()) && global<T>(sender()).delegated_withdrawal_capability; // modified
+        aborts_if sender() == payee && !::exists<T>(payee);
+        aborts_if ::exists<Balance<Token>>(sender()) && global<Balance<Token>>(sender()).coin.value < amount; // modified
         // derived from deposit_with_metadata
         aborts_if amount == 0;
-        aborts_if exists<T>(sender()) && global<T>(sender()).sent_events.counter + 1 > max_u64();
-        aborts_if exists<T>(payee) && !exists<Balance<Token>>(payee); // modified
-        aborts_if sender() != payee && exists<Balance<Token>>(payee) && global<Balance<Token>>(payee).coin.value + amount > max_u64(); // modified
-        aborts_if exists<T>(payee) && global<T>(payee).received_events.counter + 1 > max_u64();
+        aborts_if ::exists<T>(sender()) && global<T>(sender()).sent_events.counter + 1 > max_u64();
+        aborts_if ::exists<T>(payee) && !::exists<Balance<Token>>(payee); // modified
+        aborts_if sender() != payee && ::exists<Balance<Token>>(payee) && global<Balance<Token>>(payee).coin.value + amount > max_u64(); // modified
+        aborts_if ::exists<T>(payee) && global<T>(payee).received_events.counter + 1 > max_u64();
         // derived from create_account
-        ensures old(!exists<T>(payee)) ==> exists<Balance<Token>>(payee);
-        ensures old(!exists<T>(payee)) ==> global<Balance<Token>>(payee).coin.value == amount;
-        ensures old(!exists<T>(payee)) ==> exists<T>(payee);
-        ensures old(!exists<T>(payee)) ==> Vector::eq_append(global<T>(payee).authentication_key, auth_key_prefix, LCS::serialize(payee));
-        ensures old(!exists<T>(payee)) ==> global<T>(payee).delegated_key_rotation_capability == false;
-        ensures old(!exists<T>(payee)) ==> global<T>(payee).delegated_withdrawal_capability == false;
-        ensures old(!exists<T>(payee)) ==> global<T>(payee).sequence_number == 0;
-        ensures old(!exists<T>(payee)) ==> global<T>(payee).event_generator.counter == 2;
-        ensures old(!exists<T>(payee)) ==> global<T>(payee).received_events.counter == 1;
-        ensures old(!exists<T>(payee)) ==> Vector::eq_append(global<T>(payee).received_events.guid, LCS::serialize(0), LCS::serialize(payee));
-        ensures old(!exists<T>(payee)) ==> global<T>(payee).sent_events.counter == 0;
-        ensures old(!exists<T>(payee)) ==> Vector::eq_append(global<T>(payee).sent_events.guid, LCS::serialize(1), LCS::serialize(payee));
+        ensures old(!::exists<T>(payee)) ==> ::exists<Balance<Token>>(payee);
+        ensures old(!::exists<T>(payee)) ==> global<Balance<Token>>(payee).coin.value == amount;
+        ensures old(!::exists<T>(payee)) ==> ::exists<T>(payee);
+        ensures old(!::exists<T>(payee)) ==> Vector::eq_append(global<T>(payee).authentication_key, auth_key_prefix, LCS::serialize(payee));
+        ensures old(!::exists<T>(payee)) ==> global<T>(payee).delegated_key_rotation_capability == false;
+        ensures old(!::exists<T>(payee)) ==> global<T>(payee).delegated_withdrawal_capability == false;
+        ensures old(!::exists<T>(payee)) ==> global<T>(payee).sequence_number == 0;
+        ensures old(!::exists<T>(payee)) ==> global<T>(payee).event_generator.counter == 2;
+        ensures old(!::exists<T>(payee)) ==> global<T>(payee).received_events.counter == 1;
+        ensures old(!::exists<T>(payee)) ==> Vector::eq_append(global<T>(payee).received_events.guid, LCS::serialize(0), LCS::serialize(payee));
+        ensures old(!::exists<T>(payee)) ==> global<T>(payee).sent_events.counter == 0;
+        ensures old(!::exists<T>(payee)) ==> Vector::eq_append(global<T>(payee).sent_events.guid, LCS::serialize(1), LCS::serialize(payee));
         // derived from withdraw_from_sender
         ensures payee != sender() ==> global<Balance<Token>>(sender()).coin.value == old(global<Balance<Token>>(sender()).coin.value) - amount;
         // derived from deposit_with_metadata
         ensures global<T>(sender()).sent_events.counter == old(global<T>(sender()).sent_events.counter) + 1;
-        ensures old(exists<T>(payee)) ==> global<T>(payee).received_events.counter == old(global<T>(payee).received_events.counter) + 1;
-        ensures old(exists<T>(payee)) && payee != sender() ==> global<Balance<Token>>(payee).coin.value == old(global<Balance<Token>>(payee).coin.value) + amount;
+        ensures old(::exists<T>(payee)) ==> global<T>(payee).received_events.counter == old(global<T>(payee).received_events.counter) + 1;
+        ensures old(::exists<T>(payee)) && payee != sender() ==> global<Balance<Token>>(payee).coin.value == old(global<Balance<Token>>(payee).coin.value) + amount;
     }
 
 
@@ -428,41 +428,41 @@ module LibraAccount {
     }
     spec fun pay_from_sender {
         // derived from create_account
-        aborts_if !exists<T>(payee) && len(LCS::serialize(payee)) + len(auth_key_prefix) != 32; // modified
-        aborts_if !exists<T>(payee) && exists<Balance<Token>>(payee); // modified
-        aborts_if !exists<T>(payee) && !exists<Libra::Info<Token>>(0xA550C18); // modified
+        aborts_if !::exists<T>(payee) && len(LCS::serialize(payee)) + len(auth_key_prefix) != 32; // modified
+        aborts_if !::exists<T>(payee) && ::exists<Balance<Token>>(payee); // modified
+        aborts_if !::exists<T>(payee) && !::exists<Libra::Info<Token>>(0xA550C18); // modified
         // derived from withdraw_from_sender
-        aborts_if sender() != payee && !exists<T>(sender()); // modified
-        aborts_if sender() != payee && !exists<Balance<Token>>(sender()); // modified
-        aborts_if sender() == payee && exists<T>(payee) && !exists<Balance<Token>>(sender()); // modified
-        aborts_if exists<T>(sender()) && global<T>(sender()).delegated_withdrawal_capability; // modified
-        aborts_if sender() == payee && !exists<T>(payee); // added. If this holds, delegated_withdrawal_capability is false.
-        aborts_if exists<Balance<Token>>(sender()) && global<Balance<Token>>(sender()).coin.value < amount; // modified
+        aborts_if sender() != payee && !::exists<T>(sender()); // modified
+        aborts_if sender() != payee && !::exists<Balance<Token>>(sender()); // modified
+        aborts_if sender() == payee && ::exists<T>(payee) && !::exists<Balance<Token>>(sender()); // modified
+        aborts_if ::exists<T>(sender()) && global<T>(sender()).delegated_withdrawal_capability; // modified
+        aborts_if sender() == payee && !::exists<T>(payee); // added. If this holds, delegated_withdrawal_capability is false.
+        aborts_if ::exists<Balance<Token>>(sender()) && global<Balance<Token>>(sender()).coin.value < amount; // modified
         // derived from deposit_with_metadata
         aborts_if amount == 0;
-        aborts_if exists<T>(sender()) && global<T>(sender()).sent_events.counter + 1 > max_u64(); // modified
-        aborts_if exists<T>(payee) && !exists<Balance<Token>>(payee); // modified
-        aborts_if sender() != payee && exists<Balance<Token>>(payee) && global<Balance<Token>>(payee).coin.value + amount > max_u64(); // modified
-        aborts_if exists<T>(payee) && global<T>(payee).received_events.counter + 1 > max_u64();
+        aborts_if ::exists<T>(sender()) && global<T>(sender()).sent_events.counter + 1 > max_u64(); // modified
+        aborts_if ::exists<T>(payee) && !::exists<Balance<Token>>(payee); // modified
+        aborts_if sender() != payee && ::exists<Balance<Token>>(payee) && global<Balance<Token>>(payee).coin.value + amount > max_u64(); // modified
+        aborts_if ::exists<T>(payee) && global<T>(payee).received_events.counter + 1 > max_u64();
         // derived from create_account
-        ensures old(!exists<T>(payee)) ==> exists<Balance<Token>>(payee);
-        ensures old(!exists<T>(payee)) ==> global<Balance<Token>>(payee).coin.value == amount;
-        ensures old(!exists<T>(payee)) ==> exists<T>(payee);
-        ensures old(!exists<T>(payee)) ==> Vector::eq_append(global<T>(payee).authentication_key, auth_key_prefix, LCS::serialize(payee));
-        ensures old(!exists<T>(payee)) ==> global<T>(payee).delegated_key_rotation_capability == false;
-        ensures old(!exists<T>(payee)) ==> global<T>(payee).delegated_withdrawal_capability == false;
-        ensures old(!exists<T>(payee)) ==> global<T>(payee).sequence_number == 0;
-        ensures old(!exists<T>(payee)) ==> global<T>(payee).event_generator.counter == 2;
-        ensures old(!exists<T>(payee)) ==> global<T>(payee).received_events.counter == 1;
-        ensures old(!exists<T>(payee)) ==> Vector::eq_append(global<T>(payee).received_events.guid, LCS::serialize(0), LCS::serialize(payee));
-        ensures old(!exists<T>(payee)) ==> global<T>(payee).sent_events.counter == 0;
-        ensures old(!exists<T>(payee)) ==> Vector::eq_append(global<T>(payee).sent_events.guid, LCS::serialize(1), LCS::serialize(payee));
+        ensures old(!::exists<T>(payee)) ==> ::exists<Balance<Token>>(payee);
+        ensures old(!::exists<T>(payee)) ==> global<Balance<Token>>(payee).coin.value == amount;
+        ensures old(!::exists<T>(payee)) ==> ::exists<T>(payee);
+        ensures old(!::exists<T>(payee)) ==> Vector::eq_append(global<T>(payee).authentication_key, auth_key_prefix, LCS::serialize(payee));
+        ensures old(!::exists<T>(payee)) ==> global<T>(payee).delegated_key_rotation_capability == false;
+        ensures old(!::exists<T>(payee)) ==> global<T>(payee).delegated_withdrawal_capability == false;
+        ensures old(!::exists<T>(payee)) ==> global<T>(payee).sequence_number == 0;
+        ensures old(!::exists<T>(payee)) ==> global<T>(payee).event_generator.counter == 2;
+        ensures old(!::exists<T>(payee)) ==> global<T>(payee).received_events.counter == 1;
+        ensures old(!::exists<T>(payee)) ==> Vector::eq_append(global<T>(payee).received_events.guid, LCS::serialize(0), LCS::serialize(payee));
+        ensures old(!::exists<T>(payee)) ==> global<T>(payee).sent_events.counter == 0;
+        ensures old(!::exists<T>(payee)) ==> Vector::eq_append(global<T>(payee).sent_events.guid, LCS::serialize(1), LCS::serialize(payee));
         // derived from withdraw_from_sender
         ensures payee != sender() ==> global<Balance<Token>>(sender()).coin.value == old(global<Balance<Token>>(sender()).coin.value) - amount;
         // derived from deposit_with_metadata
         ensures global<T>(sender()).sent_events.counter == old(global<T>(sender()).sent_events.counter) + 1;
-        ensures old(exists<T>(payee)) ==> global<T>(payee).received_events.counter == old(global<T>(payee).received_events.counter) + 1;
-        ensures old(exists<T>(payee)) && payee != sender() ==> global<Balance<Token>>(payee).coin.value == old(global<Balance<Token>>(payee).coin.value) + amount;
+        ensures old(::exists<T>(payee)) ==> global<T>(payee).received_events.counter == old(global<T>(payee).received_events.counter) + 1;
+        ensures old(::exists<T>(payee)) && payee != sender() ==> global<Balance<Token>>(payee).coin.value == old(global<Balance<Token>>(payee).coin.value) + amount;
     }
 
     fun rotate_authentication_key_for_account(account: &mut T, new_authentication_key: vector<u8>) {
@@ -488,7 +488,7 @@ module LibraAccount {
         );
     }
     spec fun rotate_authentication_key {
-        aborts_if !exists<T>(sender());
+        aborts_if !::exists<T>(sender());
         aborts_if global<T>(sender()).delegated_key_rotation_capability == true;
         aborts_if len(new_authentication_key) != 32;
         ensures global<T>(sender()).authentication_key == new_authentication_key;
@@ -505,7 +505,7 @@ module LibraAccount {
         );
     }
     spec fun rotate_authentication_key_with_capability {
-        aborts_if !exists<T>(cap.account_address);
+        aborts_if !::exists<T>(cap.account_address);
         aborts_if len(new_authentication_key) != 32;
         ensures global<T>(cap.account_address).authentication_key == new_authentication_key;
     }
@@ -520,7 +520,7 @@ module LibraAccount {
         KeyRotationCapability { account_address: sender }
     }
     spec fun extract_sender_key_rotation_capability {
-        aborts_if !exists<T>(sender());
+        aborts_if !::exists<T>(sender());
         aborts_if global<T>(sender()).delegated_key_rotation_capability == true;
         ensures global<T>(sender()).delegated_key_rotation_capability == true;
         ensures result.account_address == sender();
@@ -537,7 +537,7 @@ module LibraAccount {
         account.delegated_key_rotation_capability = false;
     }
     spec fun restore_key_rotation_capability {
-        aborts_if !exists<T>(cap.account_address);
+        aborts_if !::exists<T>(cap.account_address);
         ensures global<T>(cap.account_address).delegated_key_rotation_capability == false;
     }
 
@@ -569,12 +569,12 @@ module LibraAccount {
     }
     spec fun create_account {
         aborts_if len(LCS::serialize(fresh_address)) + len(auth_key_prefix) != 32;
-        aborts_if exists<Balance<Token>>(fresh_address);
-        aborts_if exists<T>(fresh_address);
-        aborts_if !exists<Libra::Info<Token>>(0xA550C18);
-        ensures exists<Balance<Token>>(fresh_address);
+        aborts_if ::exists<Balance<Token>>(fresh_address);
+        aborts_if ::exists<T>(fresh_address);
+        aborts_if !::exists<Libra::Info<Token>>(0xA550C18);
+        ensures ::exists<Balance<Token>>(fresh_address);
         ensures global<Balance<Token>>(fresh_address).coin.value == 0;
-        ensures exists<T>(fresh_address);
+        ensures ::exists<T>(fresh_address);
         ensures Vector::eq_append(global<T>(fresh_address).authentication_key, auth_key_prefix, LCS::serialize(fresh_address));
         ensures global<T>(fresh_address).delegated_key_rotation_capability == false;
         ensures global<T>(fresh_address).delegated_withdrawal_capability == false;
@@ -605,22 +605,22 @@ module LibraAccount {
     spec fun create_new_account {
         // derived from create_account
         aborts_if len(LCS::serialize(fresh_address)) + len(auth_key_prefix) != 32;
-        aborts_if exists<Balance<Token>>(fresh_address);
-        aborts_if exists<T>(fresh_address);
-        aborts_if !exists<Libra::Info<Token>>(0xA550C18);
+        aborts_if ::exists<Balance<Token>>(fresh_address);
+        aborts_if ::exists<T>(fresh_address);
+        aborts_if !::exists<Libra::Info<Token>>(0xA550C18);
         // derived from withdraw_from_sender
-        aborts_if initial_balance > 0 && !exists<T>(sender()); // modified
-        aborts_if initial_balance > 0 && !exists<Balance<Token>>(sender()); // modified
+        aborts_if initial_balance > 0 && !::exists<T>(sender()); // modified
+        aborts_if initial_balance > 0 && !::exists<Balance<Token>>(sender()); // modified
         aborts_if initial_balance > 0 && global<T>(sender()).delegated_withdrawal_capability; // modified
         aborts_if initial_balance > 0 && global<Balance<Token>>(sender()).coin.value < initial_balance; // modified
         // derived from deposit_with_metadata
         aborts_if initial_balance > 0 && initial_balance == 0; // modified
-        aborts_if initial_balance > 0 && fresh_address != sender() && !exists<T>(sender()); // modified
+        aborts_if initial_balance > 0 && fresh_address != sender() && !::exists<T>(sender()); // modified
         aborts_if initial_balance > 0 && global<T>(sender()).sent_events.counter + 1 > max_u64(); // modified
         // derived from create_account
-        ensures exists<Balance<Token>>(fresh_address);
+        ensures ::exists<Balance<Token>>(fresh_address);
         ensures global<Balance<Token>>(fresh_address).coin.value == initial_balance; // modified
-        ensures exists<T>(fresh_address);
+        ensures ::exists<T>(fresh_address);
         ensures Vector::eq_append(global<T>(fresh_address).authentication_key, auth_key_prefix, LCS::serialize(fresh_address));
         ensures global<T>(fresh_address).delegated_key_rotation_capability == false;
         ensures global<T>(fresh_address).delegated_withdrawal_capability == false;
@@ -656,7 +656,7 @@ module LibraAccount {
         balance_for(borrow_global<Balance<Token>>(addr))
     }
     spec fun balance {
-        aborts_if !exists<Balance<Token>>(addr);
+        aborts_if !::exists<Balance<Token>>(addr);
         ensures result == global<Balance<Token>>(addr).coin.value;
     }
 
@@ -673,7 +673,7 @@ module LibraAccount {
         sequence_number_for_account(borrow_global<T>(addr))
     }
     spec fun sequence_number {
-        aborts_if !exists<T>(addr);
+        aborts_if !::exists<T>(addr);
         ensures result == global<T>(addr).sequence_number;
     }
 
@@ -682,7 +682,7 @@ module LibraAccount {
         *&borrow_global<T>(addr).authentication_key
     }
     spec fun authentication_key {
-        aborts_if !exists<T>(addr);
+        aborts_if !::exists<T>(addr);
         ensures result == global<T>(addr).authentication_key;
     }
 
@@ -691,7 +691,7 @@ module LibraAccount {
         borrow_global<T>(addr).delegated_key_rotation_capability
     }
     spec fun delegated_key_rotation_capability {
-        aborts_if !exists<T>(addr);
+        aborts_if !::exists<T>(addr);
         ensures result == global<T>(addr).delegated_key_rotation_capability;
     }
 
@@ -700,7 +700,7 @@ module LibraAccount {
         borrow_global<T>(addr).delegated_withdrawal_capability
     }
     spec fun delegated_withdrawal_capability {
-        aborts_if !exists<T>(addr);
+        aborts_if !::exists<T>(addr);
         ensures result == global<T>(addr).delegated_withdrawal_capability;
     }
 
@@ -725,7 +725,7 @@ module LibraAccount {
         ::exists<T>(check_addr)
     }
     spec fun exists {
-        ensures result == exists<T>(check_addr);
+        ensures result == ::exists<T>(check_addr);
     }
 
     // The prologue is invoked at the beginning of every transaction
@@ -834,7 +834,7 @@ module LibraAccount {
         new_event_handle_impl<E>(&mut sender_account_ref.event_generator, Transaction::sender())
     }
     spec fun new_event_handle {
-        aborts_if !exists<T>(sender());
+        aborts_if !::exists<T>(sender());
         aborts_if global<T>(sender()).event_generator.counter + 1 > max_u64();
         ensures Vector::eq_append(result.guid, LCS::serialize(old(global<T>(sender()).event_generator.counter)), LCS::serialize(sender()));
         ensures result.counter == 0;


### PR DESCRIPTION
## Motivation

- Spec functions and schemas added to a Modules set of module members
  - Implies implicit aliasing
  - Cannot conflict with function/struct/constant names
- Added restriction to spec schema names (same as structs/constants)

## Test Plan

- new tests
- cargo test

