### PR TITLE
[network] Add a listener for receiving connnectivity config updates f…

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3473,7 +3473,9 @@ version = "0.1.0"
 dependencies = [
  "channel 0.1.0",
  "futures 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libra-canonical-serialization 0.1.0",
  "libra-config 0.1.0",
+ "libra-crypto 0.1.0",
  "libra-logger 0.1.0",
  "libra-metrics 0.1.0",
  "libra-network-address 0.1.0",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3467,6 +3467,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "network-simple-onchain-discovery"
+version = "0.1.0"
+dependencies = [
+ "channel 0.1.0",
+ "futures 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libra-config 0.1.0",
+ "libra-logger 0.1.0",
+ "libra-metrics 0.1.0",
+ "libra-network-address 0.1.0",
+ "libra-types 0.1.0",
+ "libra-workspace-hack 0.1.0",
+ "network 0.1.0",
+ "once_cell 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "nibble_vec"
 version = "0.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2666,6 +2666,7 @@ dependencies = [
  "libra-workspace-hack 0.1.0",
  "libradb 0.1.0",
  "network 0.1.0",
+ "network-simple-onchain-discovery 0.1.0",
  "onchain-discovery 0.1.0",
  "rayon 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "state-synchronizer 0.1.0",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -91,6 +91,7 @@ members = [
     "network/netcore",
     "network/network-address",
     "network/onchain-discovery",
+    "network/simple-onchain-discovery",
     "network/socket-bench-server",
     "secure/json-rpc",
     "secure/key-manager",

--- a/consensus/src/epoch_manager.rs
+++ b/consensus/src/epoch_manager.rs
@@ -373,12 +373,6 @@ impl<T: Payload> EpochManager<T> {
             epoch: payload.epoch(),
             verifier: (&validator_set).into(),
         };
-        let validator_keys = validator_set.payload().to_vec();
-        info!("Update Network about new validators");
-        self.network_sender
-            .update_eligible_nodes(validator_keys)
-            .await
-            .expect("Unable to update network's eligible peers");
 
         match self.storage.start() {
             LivenessStorageData::RecoveryData(initial_data) => {

--- a/libra-node/Cargo.toml
+++ b/libra-node/Cargo.toml
@@ -32,6 +32,7 @@ libra-mempool = { path = "../mempool", version = "0.1.0" }
 libra-metrics = { path = "../common/metrics", version = "0.1.0" }
 libra-crypto = { path = "../crypto/crypto", version = "0.1.0" }
 network = { path = "../network", version = "0.1.0" }
+network-simple-onchain-discovery = { path = "../network/simple-onchain-discovery", version = "0.1.0"}
 onchain-discovery = { path = "../network/onchain-discovery", version = "0.1.0" }
 libra-json-rpc = { path = "../json-rpc", version = "0.1.0" }
 storage-client = { path = "../storage/storage-client", version = "0.1.0" }

--- a/network/simple-onchain-discovery/Cargo.toml
+++ b/network/simple-onchain-discovery/Cargo.toml
@@ -1,0 +1,23 @@
+[package]
+name = "network-simple-onchain-discovery"
+version = "0.1.0"
+authors = ["Libra Association <opensource@libra.org>"]
+description = "Libra socket bench server"
+repository = "https://github.com/libra/libra"
+homepage = "https://libra.org"
+license = "Apache-2.0"
+publish = false
+edition = "2018"
+
+[dependencies]
+futures = { version = "0.3.5"  }
+once_cell = { version = "1.4.0"}
+
+channel = {path = "../../common/channel", version = "0.1.0"}
+libra-config = { path = "../../config", version = "0.1.0"}
+libra-logger = {path = "../../common/logger", version = "0.1.0"}
+libra-metrics = {path = "../../common/metrics", version = "0.1.0"}
+libra-network-address = {path = "../../network/network-address", version = "0.1.0"}
+libra-types = {path = "../../types", version = "0.1.0"}
+libra-workspace-hack = { path = "../../common/workspace-hack", version = "0.1.0" }
+network = {path = "../../network", version = "0.1.0"}

--- a/network/simple-onchain-discovery/Cargo.toml
+++ b/network/simple-onchain-discovery/Cargo.toml
@@ -14,7 +14,9 @@ futures = { version = "0.3.5"  }
 once_cell = { version = "1.4.0"}
 
 channel = {path = "../../common/channel", version = "0.1.0"}
+libra-canonical-serialization = {path = "../../common/lcs", version = "0.1.0"}
 libra-config = { path = "../../config", version = "0.1.0"}
+libra-crypto = {path = "../../crypto/crypto", version = "0.1.0"}
 libra-logger = {path = "../../common/logger", version = "0.1.0"}
 libra-metrics = {path = "../../common/metrics", version = "0.1.0"}
 libra-network-address = {path = "../../network/network-address", version = "0.1.0"}

--- a/network/simple-onchain-discovery/src/lib.rs
+++ b/network/simple-onchain-discovery/src/lib.rs
@@ -1,0 +1,193 @@
+// Copyright (c) The Libra Core Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+use channel::libra_channel;
+use futures::{sink::SinkExt, StreamExt};
+use libra_config::config::RoleType;
+use libra_logger::prelude::*;
+use libra_metrics::{register_histogram, DurationHistogram};
+use libra_network_address::NetworkAddress;
+use libra_types::on_chain_config::{OnChainConfigPayload, ValidatorSet};
+use network::{
+    common::NetworkPublicKeys,
+    connectivity_manager::{ConnectivityRequest, DiscoverySource},
+};
+use once_cell::sync::Lazy;
+use std::{convert::TryFrom, time::Instant};
+
+/// Histogram of idle time of spent in event processing loop
+pub static EVENT_PROCESSING_LOOP_IDLE_DURATION_S: Lazy<DurationHistogram> = Lazy::new(|| {
+    DurationHistogram::new(
+        register_histogram!(
+            "simple_onchain_discovery_event_processing_loop_idle_duration_s",
+            "Histogram of idle time of spent in event processing loop"
+        )
+        .unwrap(),
+    )
+});
+
+/// Histogram of busy time of spent in event processing loop
+pub static EVENT_PROCESSING_LOOP_BUSY_DURATION_S: Lazy<DurationHistogram> = Lazy::new(|| {
+    DurationHistogram::new(
+        register_histogram!(
+            "simple_onchain_discovery_event_processing_loop_busy_duration_s",
+            "Histogram of busy time of spent in event processing loop"
+        )
+        .unwrap(),
+    )
+});
+
+/// Listener which converts published  updates from the OnChainConfig to ConnectivityRequests
+/// for the ConnectivityManager.
+pub struct ConfigurationChangeListener {
+    conn_mgr_reqs_tx: channel::Sender<ConnectivityRequest>,
+    role: RoleType,
+}
+
+/// Extracts a set of ConnectivityRequests from a ValidatorSet which are appropriate for a Validator Network.
+fn extract_validator_updates(validator_set: ValidatorSet) -> Vec<ConnectivityRequest> {
+    let validator_keys = validator_set.payload().to_vec();
+
+    let mut updates = Vec::new();
+
+    // Collect the set of address updates.
+    let address_map = validator_keys
+        .iter()
+        .map(|validator| {
+            (
+                validator.account_address().clone(),
+                vec![
+                    NetworkAddress::try_from(&validator.config().validator_network_address)
+                        .expect("WTF"),
+                ],
+            )
+        })
+        .collect();
+
+    let update_address_req =
+        ConnectivityRequest::UpdateAddresses(DiscoverySource::OnChain, address_map);
+
+    updates.push(update_address_req);
+
+    // Collect the set of EligibleNodes
+    updates.push(ConnectivityRequest::UpdateEligibleNodes(
+        validator_keys
+            .into_iter()
+            .map(|validator| {
+                (
+                    *validator.account_address(),
+                    NetworkPublicKeys {
+                        identity_public_key: validator.network_identity_public_key(),
+                        signing_public_key: validator.network_signing_public_key().clone(),
+                    },
+                )
+            })
+            .collect(),
+    ));
+
+    updates
+}
+
+/// Extracts a set of ConnectivityRequests from a ValidatorSet which are appropriate for a FullNode Network.
+fn extract_full_node_updates(full_node_set: ValidatorSet) -> Vec<ConnectivityRequest> {
+    let full_node_infos = full_node_set.payload().to_vec();
+
+    let mut updates = Vec::new();
+
+    // Collect the set of updated addresses.
+    let address_map = full_node_infos
+        .iter()
+        .map(|full_node| {
+            (
+                full_node.account_address().clone(),
+                vec![NetworkAddress::try_from(
+                    &full_node.config().full_node_network_address.clone(),
+                )
+                .expect("WTF")],
+            )
+        })
+        .collect();
+
+    let update_address_req =
+        ConnectivityRequest::UpdateAddresses(DiscoverySource::OnChain, address_map);
+    updates.push(update_address_req);
+
+    // Collect the EligibleNodes
+    updates.push(ConnectivityRequest::UpdateEligibleNodes(
+        full_node_infos
+            .into_iter()
+            .map(|full_node| {
+                (
+                    full_node.account_address().clone(),
+                    NetworkPublicKeys {
+                        identity_public_key: full_node
+                            .config()
+                            .full_node_network_identity_public_key
+                            .clone(),
+                        // TODO: this overload of the validator key onto the full_node network is
+                        // confusing at best and misleading at worst.
+                        signing_public_key: full_node
+                            .config()
+                            .validator_network_signing_public_key
+                            .clone(),
+                    },
+                )
+            })
+            .collect(),
+    ));
+
+    updates
+}
+
+impl ConfigurationChangeListener {
+    /// Creates a new ConfigurationListener
+    pub fn new(conn_mgr_reqs_tx: channel::Sender<ConnectivityRequest>, role: RoleType) -> Self {
+        Self {
+            conn_mgr_reqs_tx,
+            role,
+        }
+    }
+
+    /// Processes a received OnChainConfigPayload.  Depending on role (Validator or FullNode), parses
+    /// the appropriate configuration changes and passes it to the ConnectionManager channel.
+    async fn process_payload(&mut self, payload: OnChainConfigPayload) {
+        let node_set: ValidatorSet = payload
+            .get()
+            .expect("failed to get ValidatorSet from payload");
+
+        let updates = match self.role {
+            RoleType::Validator => extract_validator_updates(node_set),
+            RoleType::FullNode => extract_full_node_updates(node_set),
+        };
+
+        info!(
+            "Update {} Network about new Node IDs",
+            self.role.to_string()
+        );
+
+        for update in updates {
+            match self.conn_mgr_reqs_tx.send(update).await {
+                Ok(()) => (),
+                Err(e) => warn!("Failed to send update to ConnectivityManager {}", e),
+            }
+        }
+    }
+
+    /// Starts the listener to wait on reconfiguration events.  Creates an infinite loop.
+    pub async fn start(
+        mut self,
+        mut reconfig_events: libra_channel::Receiver<(), OnChainConfigPayload>,
+    ) {
+        loop {
+            let start_idle_time = Instant::now();
+            let payload = reconfig_events.select_next_some().await;
+            let idle_duration = start_idle_time.elapsed();
+            let start_process_time = Instant::now();
+            self.process_payload(payload).await;
+            let process_duration = start_process_time.elapsed();
+
+            EVENT_PROCESSING_LOOP_IDLE_DURATION_S.observe_duration(idle_duration);
+            EVENT_PROCESSING_LOOP_BUSY_DURATION_S.observe_duration(process_duration);
+        }
+    }
+}

--- a/network/simple-onchain-discovery/src/lib.rs
+++ b/network/simple-onchain-discovery/src/lib.rs
@@ -3,11 +3,16 @@
 
 use channel::libra_channel;
 use futures::{sink::SinkExt, StreamExt};
+use libra_canonical_serialization as lcs;
 use libra_config::config::RoleType;
+use libra_crypto::x25519;
 use libra_logger::prelude::*;
 use libra_metrics::{register_histogram, DurationHistogram};
 use libra_network_address::NetworkAddress;
-use libra_types::on_chain_config::{OnChainConfigPayload, ValidatorSet};
+use libra_types::{
+    on_chain_config::{OnChainConfigPayload, ValidatorSet},
+    validator_config::ValidatorConfig,
+};
 use network::{
     common::NetworkPublicKeys,
     connectivity_manager::{ConnectivityRequest, DiscoverySource},
@@ -44,23 +49,37 @@ pub struct ConfigurationChangeListener {
     role: RoleType,
 }
 
-/// Extracts a set of ConnectivityRequests from a ValidatorSet which are appropriate for a Validator Network.
-fn extract_validator_updates(validator_set: ValidatorSet) -> Vec<ConnectivityRequest> {
-    let validator_keys = validator_set.payload().to_vec();
+/// Extract the network_address from the provided config, depending on role.
+fn network_address(role: RoleType, config: &ValidatorConfig) -> Result<NetworkAddress, lcs::Error> {
+    match role {
+        RoleType::Validator => NetworkAddress::try_from(&config.validator_network_address),
+        RoleType::FullNode => NetworkAddress::try_from(&config.full_node_network_address),
+    }
+}
+
+/// Extracts the public key from the provided config, depending on role.
+fn public_key(role: RoleType, config: &ValidatorConfig) -> x25519::PublicKey {
+    match role {
+        RoleType::Validator => config.validator_network_identity_public_key,
+        RoleType::FullNode => config.full_node_network_identity_public_key,
+    }
+}
+
+/// Extracts a set of ConnectivityRequests from a ValidatorSet which are appropriate for a network with type role.
+fn extract_updates(role: RoleType, node_set: ValidatorSet) -> Vec<ConnectivityRequest> {
+    let node_list = node_set.payload().to_vec();
 
     let mut updates = Vec::new();
 
     // Collect the set of address updates.
-    let address_map = validator_keys
+    let address_map = node_list
         .iter()
-        .map(|validator| {
-            (
-                validator.account_address().clone(),
-                vec![
-                    NetworkAddress::try_from(&validator.config().validator_network_address)
-                        .expect("WTF"),
-                ],
-            )
+        .flat_map(|node| match network_address(role, node.config()) {
+            Ok(addr) => Some((*node.account_address(), vec![addr])),
+            Err(e) => {
+                warn!("Cannot parse network address {}", e);
+                None
+            }
         })
         .collect();
 
@@ -71,65 +90,13 @@ fn extract_validator_updates(validator_set: ValidatorSet) -> Vec<ConnectivityReq
 
     // Collect the set of EligibleNodes
     updates.push(ConnectivityRequest::UpdateEligibleNodes(
-        validator_keys
+        node_list
             .into_iter()
-            .map(|validator| {
+            .map(|node| {
                 (
-                    *validator.account_address(),
+                    *node.account_address(),
                     NetworkPublicKeys {
-                        identity_public_key: validator.network_identity_public_key(),
-                        signing_public_key: validator.network_signing_public_key().clone(),
-                    },
-                )
-            })
-            .collect(),
-    ));
-
-    updates
-}
-
-/// Extracts a set of ConnectivityRequests from a ValidatorSet which are appropriate for a FullNode Network.
-fn extract_full_node_updates(full_node_set: ValidatorSet) -> Vec<ConnectivityRequest> {
-    let full_node_infos = full_node_set.payload().to_vec();
-
-    let mut updates = Vec::new();
-
-    // Collect the set of updated addresses.
-    let address_map = full_node_infos
-        .iter()
-        .map(|full_node| {
-            (
-                full_node.account_address().clone(),
-                vec![NetworkAddress::try_from(
-                    &full_node.config().full_node_network_address.clone(),
-                )
-                .expect("WTF")],
-            )
-        })
-        .collect();
-
-    let update_address_req =
-        ConnectivityRequest::UpdateAddresses(DiscoverySource::OnChain, address_map);
-    updates.push(update_address_req);
-
-    // Collect the EligibleNodes
-    updates.push(ConnectivityRequest::UpdateEligibleNodes(
-        full_node_infos
-            .into_iter()
-            .map(|full_node| {
-                (
-                    full_node.account_address().clone(),
-                    NetworkPublicKeys {
-                        identity_public_key: full_node
-                            .config()
-                            .full_node_network_identity_public_key
-                            .clone(),
-                        // TODO: this overload of the validator key onto the full_node network is
-                        // confusing at best and misleading at worst.
-                        signing_public_key: full_node
-                            .config()
-                            .validator_network_signing_public_key
-                            .clone(),
+                        identity_public_key: public_key(role, node.config()),
                     },
                 )
             })
@@ -156,8 +123,8 @@ impl ConfigurationChangeListener {
             .expect("failed to get ValidatorSet from payload");
 
         let updates = match self.role {
-            RoleType::Validator => extract_validator_updates(node_set),
-            RoleType::FullNode => extract_full_node_updates(node_set),
+            RoleType::Validator => extract_updates(self.role, node_set),
+            RoleType::FullNode => extract_updates(self.role, node_set),
         };
 
         info!(


### PR DESCRIPTION
…rom statesync

<!--
Thank you for sending a PR. We appreciate you spending time to help improve the Libra project.

The project is undergoing daily changes. Pull Requests will be reviewed and responded to as time permits.
-->

## Motivation

This is an initial step to address #3925.  

The PR does three things.

1.  It introduces a  ConfigurationListener intended to stand between the ConnectivityManager and any source of network updates.

1.  It wires the ConfigurationListener into the **validator** network via network_builder in main_node

1.  It eliminates the link between consensus/epoch_manager and updates to ConnectivityManager in favor of the direct link of the previous step.


### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?

yes.

## Test Plan

There is no integration/unit test written yet.  Ideally that should be in place before the code is committed, but given time pressures that may not be viable.  @davidiw @phlip9  for judgment.

smoke_tests pass in CI.

## Related PRs

(If this PR adds or changes functionality, please take some time to update the docs at https://github.com/libra/website, and link to your PR here.)
