### PR TITLE
[consensus] fix deadlock in sync_up

### DIFF
--- a/consensus/consensus-types/src/sync_info.rs
+++ b/consensus/consensus-types/src/sync_info.rs
@@ -21,15 +21,14 @@ pub struct SyncInfo {
 impl Display for SyncInfo {
     fn fmt(&self, f: &mut Formatter) -> std::fmt::Result {
         let htc_repr = match self.highest_timeout_certificate() {
-            Some(tc) => format!("TC for round {}", tc.round()),
+            Some(tc) => format!("{}", tc.round()),
             None => "None".to_string(),
         };
         write!(
             f,
-            "SyncInfo[round: {}, HQC: {}, HCC: {}, HTC: {}]",
-            self.highest_round(),
-            self.highest_quorum_cert,
-            self.highest_commit_cert,
+            "SyncInfo[HQC: {}, HCC: {}, HTC: {}]",
+            self.highest_certified_round(),
+            self.highest_commit_round(),
             htc_repr,
         )
     }
@@ -120,8 +119,9 @@ impl SyncInfo {
         self.highest_quorum_cert.certified_block().epoch()
     }
 
-    pub fn is_stale(&self, other: &SyncInfo) -> bool {
-        self.highest_round() < other.highest_round()
-            || self.highest_commit_round() < other.highest_commit_round()
+    pub fn has_newer_certificates(&self, other: &SyncInfo) -> bool {
+        self.highest_certified_round() > other.highest_certified_round()
+            || self.highest_timeout_round() > other.highest_timeout_round()
+            || self.highest_commit_round() > other.highest_commit_round()
     }
 }

--- a/consensus/src/network.rs
+++ b/consensus/src/network.rs
@@ -184,10 +184,6 @@ impl<T: Payload> NetworkSender<T> {
     /// The future is fulfilled as soon as the message is added to the internal network channel
     /// (does not indicate whether the message is delivered or sent out).
     pub fn send_sync_info(&self, sync_info: SyncInfo, recipient: Author) {
-        if recipient == self.author {
-            error!("An attempt to deliver sync info msg to itself: ignore.");
-            return;
-        }
         let msg = ConsensusMsg::SyncInfo::<T>(Box::new(sync_info));
         let mut network_sender = self.network_sender.clone();
         if let Err(e) = network_sender.send_to(recipient, msg) {


### PR DESCRIPTION
<!--
Thank you for sending a PR. We appreciate you spending time to help improve the Libra project.

The project is undergoing daily changes. Pull Requests will be reviewed and responded to as time permits.
-->

## Motivation

The short circuit return after help remote causes the deadlock because
the is_stale check is not symmetric, a.is_stale(b) == true and
b.is_stale(a) == true can both hold and result in deadlock this case (peers both think others are stale and bounce sync info back and forth without processing).

This commit removes the return statement which fixed the problem and rename
is_stale to has_newer_certificate (hopefully it's less confusing).

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?

Y

## Test Plan

Added tests.

## Related PRs
https://github.com/libra/libra/issues/4125
(If this PR adds or changes functionality, please take some time to update the docs at https://github.com/libra/website, and link to your PR here.)
