### PR TITLE
[move prover] warn unused schema when modules are targets and escape …

### DIFF
--- a/language/move-prover/tests/sources/functional/unused_schema.move
+++ b/language/move-prover/tests/sources/functional/unused_schema.move
@@ -24,6 +24,12 @@ module TestUnusedSchema {
         ensures result == i + 3;
     }
 
+    spec schema UNUSED_AddsFour {
+        i: num;
+        result: num;
+        ensures result == i + 4;
+    }
+
     fun foo(i: u64): u64 {
         if (i > 10) { i + 2 } else { i + 1 }
     }


### PR DESCRIPTION
…with UNUSED prefix

<!--
Thank you for sending a PR. We appreciate you spending time to help improve the Libra project.

The project is undergoing daily changes. Pull Requests will be reviewed and responded to as time permits.
-->

## Motivation

This PR improves warning experience such that Move Prover only warns about unused schemas defined in target modules and who names don't start with "UNUSED".

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?

Yes.

## Test Plan

Added in the test file a schema whose name starts with UNUSED and gets ignored.


