### PR TITLE
[CI] detect CLI breaking change

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,5 +1,8 @@
 version: 2.1
 
+orbs:
+  slack: circleci/slack@3.3.0
+
 executors:
   build-executor:
     docker:
@@ -91,6 +94,7 @@ commands:
     description: Save cargo package cache for subsequent jobs
     steps:
       - save_cache:
+          name: Save cargo package cache
           key: cargo-package-cache-{{ checksum "Cargo.lock" }}
           # paths are relative to /home/circleci/project/
           paths:
@@ -101,12 +105,29 @@ commands:
     description: Restore Cargo package cache from prev job
     steps:
       - restore_cache:
+          name: Restore cargo package cache
           key: cargo-package-cache-{{ checksum "Cargo.lock" }}
       - run:
           name: Check cargo package cache
           command: |
             ls -all /usr/local/cargo
             du -ssh /usr/local/cargo
+  save_breaking_change_rev:
+    description: Save the breaking change rev since last testnet update.
+    steps:
+      - save_cache:
+          name: Save breaking change rev
+          key: testnet-{{ checksum "testnet_rev" }}
+          # paths are relative to /home/circleci/project/
+          paths:
+            - breaking_change_rev
+          when: on_fail
+  restore_breaking_change_rev:
+    description: Restore the breaking change rev since last testnet update
+    steps:
+      - restore_cache:
+          name: Restore breaking change rev
+          key: testnet-{{ checksum "testnet_rev" }}
   send_message:
     description: Send message to the specified webhook, if no webhook is set simply return.
     parameters:
@@ -430,7 +451,71 @@ jobs:
                 echo "$docker_file is renamed or removed in pull request."
               fi
             done
-
+  check-breaking-change:
+    executor: audit-executor
+    description: Detect breaking change in CLI
+    environment:
+      # NOTE The  built-in save_cache and restore_cache cmds dont accept cache
+      # path or cache key defined via env var on the fly. As a result, if you
+      # change BREAKING_CHANGE_REV_FILE or TESTNET_REV_FILE, make sure to change
+      # save_breaking_change_rev and restore_breaking_change_rev accordingly.
+      BREAKING_CHANGE_REV_FILE: "breaking_change_rev"
+      TESTNET_REV_FILE: "testnet_rev"
+    steps:
+      - build_setup
+      - run:
+          name: Prepare cache key for breaking change rev lookup
+          # NOTE save_cache and restore_cache dont take cache key defined via
+          # env var on the fly. So we are going to store the testnet rev in a
+          # file and use its checksum as cache key.
+          command: |
+            echo 'export GIT_REV=$(git rev-parse HEAD)' >> $BASH_ENV
+            git rev-parse origin/testnet > ${TESTNET_REV_FILE}
+      - restore_breaking_change_rev
+      - run:
+          name: Check exiting breaking change rev
+          command: |
+            pwd
+            if [ -f "${BREAKING_CHANGE_REV_FILE}" ]; then
+              echo "master already has breaking change $(cat ${BREAKING_CHANGE_REV_FILE})"
+              echo "Nothing to do. Halting CI..."
+              circleci step halt
+            else
+              echo "No existing breacking change rev. Will continue CI."
+            fi
+      - restore_cargo_package_cache
+      - run:
+          name: Construct CLI cmds
+          command: |
+            echo "
+              a c
+              a m 0 10 LBR false
+              q b 0
+              a c
+              a m 1 11 LBR false
+              q b 1
+              t 0 1 1 LBR
+              q b 0
+              q b 1
+              quit
+            " > /tmp/cli
+      - run:
+          name: Connect to testnet
+          # NOTE +e to disable exit immediately on failure
+          command: |
+            set +e
+            ./scripts/cli/start_cli_testnet.sh < /tmp/cli
+            status=$?
+            if [[ $status != 0 ]] ; then
+              git rev-parse HEAD > ${BREAKING_CHANGE_REV_FILE}
+              echo "Will save breaking change rev $(cat ${BREAKING_CHANGE_REV_FILE})"
+            fi
+            exit $status
+      - save_breaking_change_rev
+      - slack/status:
+          fail_only: true
+          webhook: "${WEBHOOK_BREAKING_CHANGE}"
+          failure_message: ":red_circle: <@channel> breaking change in *${GIT_REV}*"
   # build-docs and deploy-docs are adapted from
   # https://circleci.com/blog/deploying-documentation-to-github-pages-with-continuous-integration/.
   build-docs:
@@ -517,6 +602,12 @@ workflows:
           filters:
             branches:
               only: master
+      - check-breaking-change:
+          requires:
+            - prefetch-crates
+          filters:
+           branches:
+             only: master
 
   scheduled-workflow:
     triggers:


### PR DESCRIPTION
## Motivation
We want to find out if there is CLI breaking change after a PR lands in
master. The signal is expected to give the downstream client
applications a heads-up of impending integration breakage. For now, we
don't want to block the PR from landing due to breaking change. However,
this could change when we start stabilization.

The new workflow builds the CLI, connects to testnet and attempts to
execute a few simple transactions. The workflow will run for every PR
landed in master until the first breaking change is detected.

The known limitation is that if the PR doesnt squash its commits before
landing, the workflow will only identify and alert the first commit in
the PR that causes breakage. Also, the workflow does not support bisect
at the moment.

## Test Plan
CI
1. Canary with 4edd44c in https://app.circleci.com/pipelines/github/libra/libra/18135/workflows/672c85aa-b59a-499a-a873-da8cb8020d2a/jobs/102215/steps
We already had a breaking change in trunk since this week's testnet release (4bc10151d) on Wednesday, so the job failed. The failed git rev (the canary itself) is cached.

<img width="1445" alt="image" src="https://user-images.githubusercontent.com/7528420/83341166-1a1a9d00-a295-11ea-9b3a-f4d4d5c99bce.png">

2. Re-run the same canary in https://app.circleci.com/pipelines/github/libra/libra/18135/workflows/8de030f2-6882-4732-aed9-408c5b8082a0/jobs/102232/steps
The workflow hit the cache in an early step and the remaining steps were skipped.  Thus the job passed.

<img width="1467" alt="image" src="https://user-images.githubusercontent.com/7528420/83341170-27378c00-a295-11ea-8a2a-7c61a70e2692.png">

3. Canary with cac44df in https://app.circleci.com/pipelines/github/libra/libra/18139/workflows/9d795da3-1660-4a14-ab1f-fb52235caf0d/jobs/102241/steps
The canary force-checked out a51f08157 (the commit right after origin/testnet, 4bc10151d). Since the breaking change is further down, the CLI check passed.

<img width="1457" alt="image" src="https://user-images.githubusercontent.com/7528420/83341212-8f866d80-a295-11ea-9423-726cf617c59d.png">

