### PR TITLE
[easy] Remove a few panics

### DIFF
--- a/json-rpc/src/methods.rs
+++ b/json-rpc/src/methods.rs
@@ -111,8 +111,8 @@ async fn get_account_state(
     let currency_info = currencies_info(service, request).await?;
     let currencies: Vec<_> = currency_info
         .into_iter()
-        .map(|info| from_currency_code_string(&info.code).unwrap())
-        .collect();
+        .map(|info| from_currency_code_string(&info.code))
+        .collect::<Result<_, _>>()?;
     if let Some(blob) = response {
         let account_state = AccountState::try_from(&blob)?;
         if let Some(account) = account_state.get_account_resource()? {

--- a/network/src/peer_manager/mod.rs
+++ b/network/src/peer_manager/mod.rs
@@ -171,12 +171,10 @@ impl PeerManagerRequestSender {
             res_tx,
             timeout,
         };
-        self.inner
-            .push(
-                (peer_id, protocol),
-                PeerManagerRequest::SendRpc(peer_id, request),
-            )
-            .unwrap();
+        self.inner.push(
+            (peer_id, protocol),
+            PeerManagerRequest::SendRpc(peer_id, request),
+        )?;
         res_rx.await?
     }
 }

--- a/secure/key-manager/src/tests.rs
+++ b/secure/key-manager/src/tests.rs
@@ -220,7 +220,7 @@ impl LibraInterface for MockLibraInterface {
             .storage
             .get_latest_account_state(account)?
             .ok_or_else(|| Error::DataDoesNotExist("AccountState".into()))?;
-        let account_state = AccountState::try_from(&blob).unwrap();
+        let account_state = AccountState::try_from(&blob)?;
         Ok(account_state
             .get_libra_timestamp_resource()?
             .ok_or_else(|| Error::DataDoesNotExist("LibraTimestampResource".into()))?
@@ -238,7 +238,7 @@ impl LibraInterface for MockLibraInterface {
             .storage
             .get_latest_account_state(account)?
             .ok_or_else(|| Error::DataDoesNotExist("AccountState".into()))?;
-        let account_state = AccountState::try_from(&blob).unwrap();
+        let account_state = AccountState::try_from(&blob)?;
         Ok(account_state
             .get_account_resource()?
             .ok_or_else(|| Error::DataDoesNotExist("AccountResource".into()))?
@@ -254,7 +254,7 @@ impl LibraInterface for MockLibraInterface {
             .storage
             .get_latest_account_state(account)?
             .ok_or_else(|| Error::DataDoesNotExist("AccountState".into()))?;
-        let account_state = AccountState::try_from(&blob).unwrap();
+        let account_state = AccountState::try_from(&blob)?;
         Ok(account_state
             .get_validator_config_resource()?
             .ok_or_else(|| Error::DataDoesNotExist("ValidatorConfigResource".into()))?

--- a/vm-validator/src/mocks/mock_vm_validator.rs
+++ b/vm-validator/src/mocks/mock_vm_validator.rs
@@ -41,20 +41,18 @@ impl TransactionValidation for MockVMValidator {
         };
 
         let sender = txn.sender();
-        let account_dne_test_add =
-            AccountAddress::try_from(&[0 as u8; AccountAddress::LENGTH]).unwrap();
-        let invalid_sig_test_add =
-            AccountAddress::try_from(&[1 as u8; AccountAddress::LENGTH]).unwrap();
+        let account_dne_test_add = AccountAddress::try_from(&[0 as u8; AccountAddress::LENGTH])?;
+        let invalid_sig_test_add = AccountAddress::try_from(&[1 as u8; AccountAddress::LENGTH])?;
         let insufficient_balance_test_add =
-            AccountAddress::try_from(&[2 as u8; AccountAddress::LENGTH]).unwrap();
+            AccountAddress::try_from(&[2 as u8; AccountAddress::LENGTH])?;
         let seq_number_too_new_test_add =
-            AccountAddress::try_from(&[3 as u8; AccountAddress::LENGTH]).unwrap();
+            AccountAddress::try_from(&[3 as u8; AccountAddress::LENGTH])?;
         let seq_number_too_old_test_add =
-            AccountAddress::try_from(&[4 as u8; AccountAddress::LENGTH]).unwrap();
+            AccountAddress::try_from(&[4 as u8; AccountAddress::LENGTH])?;
         let txn_expiration_time_test_add =
-            AccountAddress::try_from(&[5 as u8; AccountAddress::LENGTH]).unwrap();
+            AccountAddress::try_from(&[5 as u8; AccountAddress::LENGTH])?;
         let invalid_auth_key_test_add =
-            AccountAddress::try_from(&[6 as u8; AccountAddress::LENGTH]).unwrap();
+            AccountAddress::try_from(&[6 as u8; AccountAddress::LENGTH])?;
         let ret = if sender == account_dne_test_add {
             Some(VMStatus::new(StatusCode::SENDING_ACCOUNT_DOES_NOT_EXIST))
         } else if sender == invalid_sig_test_add {


### PR DESCRIPTION
This collapses a potential panic into the `Result` of its enclosing function, keeping the error semantics but turning those into a managed outcome.

By request [[1]](https://github.com/libra/libra/pull/3879#issuecomment-628976319) [[2]](https://github.com/libra/libra/pull/3879#issuecomment-629417720) this does NOT include eight such panics in `language/` that could be so collapsed in the `Error` case of their `Result`:
https://gist.github.com/huitseeker/e6272a1b523e033979c29ebb7d4cf072
