### PR TITLE
[cleanup][consensus][types] Remove 26 untested, unused methods

### DIFF
--- a/consensus/consensus-types/src/executed_block.rs
+++ b/consensus/consensus-types/src/executed_block.rs
@@ -42,10 +42,6 @@ impl ExecutedBlock {
         &self.block
     }
 
-    pub fn root_hash(&self) -> HashValue {
-        self.state_compute_result.root_hash()
-    }
-
     pub fn epoch(&self) -> u64 {
         self.block().epoch()
     }

--- a/consensus/consensus-types/src/executed_block.rs
+++ b/consensus/consensus-types/src/executed_block.rs
@@ -81,8 +81,4 @@ impl ExecutedBlock {
             self.compute_result().epoch_state().clone(),
         )
     }
-
-    pub fn is_nil_block(&self) -> bool {
-        self.block().is_nil_block()
-    }
 }

--- a/consensus/consensus-types/src/timeout.rs
+++ b/consensus/consensus-types/src/timeout.rs
@@ -1,7 +1,7 @@
 // Copyright (c) The Libra Core Contributors
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::{block::Block, common::Round};
+use crate::common::Round;
 use libra_crypto::{ed25519::Ed25519Signature, hash::CryptoHash};
 use libra_crypto_derive::{CryptoHasher, LCSCryptoHash};
 use libra_types::validator_signer::ValidatorSigner;
@@ -21,13 +21,6 @@ pub struct Timeout {
 impl Timeout {
     pub fn new(epoch: u64, round: Round) -> Self {
         Self { epoch, round }
-    }
-
-    pub fn from_block(block: &Block) -> Self {
-        Self {
-            epoch: block.epoch(),
-            round: block.round(),
-        }
     }
 
     pub fn epoch(&self) -> u64 {

--- a/types/src/access_path.rs
+++ b/types/src/access_path.rs
@@ -37,13 +37,10 @@
 
 use crate::{
     account_address::AccountAddress,
-    account_config::{AccountResource, ACCOUNT_RECEIVED_EVENT_PATH, ACCOUNT_SENT_EVENT_PATH},
+    account_config::{ACCOUNT_RECEIVED_EVENT_PATH, ACCOUNT_SENT_EVENT_PATH},
 };
 use libra_crypto::hash::HashValue;
-use move_core_types::{
-    language_storage::{ModuleId, ResourceKey, StructTag, CODE_TAG, RESOURCE_TAG},
-    move_resource::MoveResource,
-};
+use move_core_types::language_storage::{ModuleId, ResourceKey, StructTag, CODE_TAG, RESOURCE_TAG};
 #[cfg(any(test, feature = "fuzzing"))]
 use proptest_derive::Arbitrary;
 use serde::{Deserialize, Serialize};
@@ -62,11 +59,6 @@ impl AccessPath {
 
     pub fn new(address: AccountAddress, path: Vec<u8>) -> Self {
         AccessPath { address, path }
-    }
-
-    /// Given an address, returns the corresponding access path that stores the Account resource.
-    pub fn new_for_account(address: AccountAddress) -> Self {
-        Self::new(address, AccountResource::resource_path())
     }
 
     /// Create an AccessPath to the event for the sender account in a deposit operation.

--- a/types/src/account_config/events/new_block.rs
+++ b/types/src/account_config/events/new_block.rs
@@ -24,10 +24,6 @@ impl NewBlockEvent {
         self.proposer
     }
 
-    pub fn previous_block_votes(&self) -> &[AccountAddress] {
-        &self.previous_block_votes
-    }
-
     pub fn proposed_time(&self) -> u64 {
         self.time_micro_seconds
     }

--- a/types/src/account_config/events/new_block.rs
+++ b/types/src/account_config/events/new_block.rs
@@ -1,7 +1,7 @@
 // Copyright (c) The Libra Core Contributors
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::{account_address::AccountAddress, event::EventKey};
+use crate::account_address::AccountAddress;
 use anyhow::Result;
 use move_core_types::move_resource::MoveResource;
 use serde::{Deserialize, Serialize};
@@ -30,10 +30,6 @@ impl NewBlockEvent {
 
     pub fn try_from_bytes(bytes: &[u8]) -> Result<Self> {
         lcs::from_bytes(bytes).map_err(Into::into)
-    }
-
-    pub fn event_key() -> EventKey {
-        crate::block_metadata::new_block_event_key()
     }
 }
 

--- a/types/src/account_config/events/received_payment.rs
+++ b/types/src/account_config/events/received_payment.rs
@@ -31,21 +31,6 @@ pub struct ReceivedPaymentEvent {
 }
 
 impl ReceivedPaymentEvent {
-    // TODO: should only be used for libra client testing and be removed eventually
-    pub fn new(
-        amount: u64,
-        currency_code: Identifier,
-        sender: AccountAddress,
-        metadata: Vec<u8>,
-    ) -> Self {
-        Self {
-            amount,
-            currency_code,
-            sender,
-            metadata,
-        }
-    }
-
     pub fn try_from_bytes(bytes: &[u8]) -> Result<Self> {
         lcs::from_bytes(bytes).map_err(Into::into)
     }

--- a/types/src/account_config/events/upgrade.rs
+++ b/types/src/account_config/events/upgrade.rs
@@ -1,7 +1,6 @@
 // Copyright (c) The Libra Core Contributors
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::{account_config::CORE_CODE_ADDRESS, event::EventKey};
 use anyhow::Result;
 use move_core_types::move_resource::MoveResource;
 use serde::{Deserialize, Serialize};
@@ -20,10 +19,6 @@ impl UpgradeEvent {
 
     pub fn try_from_bytes(bytes: &[u8]) -> Result<Self> {
         lcs::from_bytes(bytes).map_err(Into::into)
-    }
-
-    pub fn event_key() -> EventKey {
-        EventKey::new_from_address(&CORE_CODE_ADDRESS, 15)
     }
 }
 

--- a/types/src/account_state.rs
+++ b/types/src/account_state.rs
@@ -92,15 +92,6 @@ impl AccountState {
         }
     }
 
-    pub fn get_currency_info_resource(
-        &self,
-        currency_code: Identifier,
-    ) -> Result<Option<BalanceResource>> {
-        // TODO: update this to use BalanceResource::resource_path once that takes type
-        // parameters
-        self.get_resource(&CurrencyInfoResource::access_path_for(currency_code))
-    }
-
     pub fn get_validator_set(&self) -> Result<Option<ValidatorSet>> {
         self.get_resource(&ValidatorSet::CONFIG_ID.access_path().path)
     }

--- a/types/src/account_state.rs
+++ b/types/src/account_state.rs
@@ -5,7 +5,7 @@ use crate::{
     account_address::AccountAddress,
     account_config::{
         type_tag_for_currency_code, AccountResource, AccountRole, BalanceResource, ChildVASP,
-        ChildVASPRole, CurrencyInfoResource, EmptyRole, ParentVASP, ParentVASPRole, UnhostedRole,
+        ChildVASPRole, EmptyRole, ParentVASP, ParentVASPRole, UnhostedRole,
         ACCOUNT_RECEIVED_EVENT_PATH, ACCOUNT_SENT_EVENT_PATH,
     },
     block_metadata::{LibraBlockResource, NEW_BLOCK_EVENT_PATH},
@@ -135,10 +135,6 @@ impl AccountState {
 
     pub fn remove(&mut self, key: &[u8]) -> Option<Vec<u8>> {
         self.0.remove(key)
-    }
-
-    pub fn is_empty(&self) -> bool {
-        self.0.is_empty()
     }
 
     pub fn iter(&self) -> impl std::iter::Iterator<Item = (&Vec<u8>, &Vec<u8>)> {

--- a/types/src/account_state_blob.rs
+++ b/types/src/account_state_blob.rs
@@ -28,12 +28,6 @@ pub struct AccountStateBlob {
     blob: Vec<u8>,
 }
 
-impl AccountStateBlob {
-    pub fn blob(&self) -> &Vec<u8> {
-        &self.blob
-    }
-}
-
 impl fmt::Debug for AccountStateBlob {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         let decoded = lcs::from_bytes(&self.blob)

--- a/types/src/block_metadata.rs
+++ b/types/src/block_metadata.rs
@@ -66,10 +66,6 @@ impl BlockMetadata {
     pub fn proposer(&self) -> AccountAddress {
         self.proposer
     }
-
-    pub fn voters(&self) -> Vec<AccountAddress> {
-        self.previous_block_votes.clone()
-    }
 }
 
 pub fn new_block_event_key() -> EventKey {

--- a/types/src/get_with_proof.rs
+++ b/types/src/get_with_proof.rs
@@ -388,15 +388,6 @@ pub enum ResponseItem {
 }
 
 impl ResponseItem {
-    pub fn into_get_account_state_response(self) -> Result<AccountStateWithProof> {
-        match self {
-            ResponseItem::GetAccountState {
-                account_state_with_proof,
-            } => Ok(account_state_with_proof),
-            _ => bail!("Not ResponseItem::GetAccountState."),
-        }
-    }
-
     pub fn into_get_account_txn_by_seq_num_response(
         self,
     ) -> Result<(Option<TransactionWithProof>, Option<AccountStateWithProof>)> {

--- a/types/src/get_with_proof.rs
+++ b/types/src/get_with_proof.rs
@@ -399,13 +399,4 @@ impl ResponseItem {
             _ => bail!("Not ResponseItem::GetAccountTransactionBySequenceNumber."),
         }
     }
-
-    pub fn into_get_transactions_response(self) -> Result<TransactionListWithProof> {
-        match self {
-            ResponseItem::GetTransactions {
-                txn_list_with_proof,
-            } => Ok(txn_list_with_proof),
-            _ => bail!("Not ResponseItem::GetTransactions."),
-        }
-    }
 }

--- a/types/src/get_with_proof.rs
+++ b/types/src/get_with_proof.rs
@@ -400,18 +400,6 @@ impl ResponseItem {
         }
     }
 
-    pub fn into_get_events_by_access_path_response(
-        self,
-    ) -> Result<(Vec<EventWithProof>, AccountStateWithProof)> {
-        match self {
-            ResponseItem::GetEventsByEventAccessPath {
-                events_with_proof,
-                proof_of_latest_event,
-            } => Ok((events_with_proof, proof_of_latest_event)),
-            _ => bail!("Not ResponseItem::GetEventsByEventAccessPath."),
-        }
-    }
-
     pub fn into_get_transactions_response(self) -> Result<TransactionListWithProof> {
         match self {
             ResponseItem::GetTransactions {

--- a/types/src/on_chain_config/registered_currencies.rs
+++ b/types/src/on_chain_config/registered_currencies.rs
@@ -31,10 +31,6 @@ impl RegisteredCurrencies {
         &self.currency_codes
     }
 
-    pub fn empty() -> Self {
-        Self::new(Vec::new())
-    }
-
     pub fn from_bytes(bytes: &[u8]) -> Result<Self> {
         lcs::from_bytes(bytes).map_err(Into::into)
     }

--- a/types/src/on_chain_config/validator_set.rs
+++ b/types/src/on_chain_config/validator_set.rs
@@ -41,10 +41,6 @@ impl ValidatorSet {
         }
     }
 
-    pub fn scheme(&self) -> ConsensusScheme {
-        self.scheme
-    }
-
     pub fn payload(&self) -> &[ValidatorInfo] {
         &self.payload
     }

--- a/types/src/on_chain_config/validator_set.rs
+++ b/types/src/on_chain_config/validator_set.rs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::{on_chain_config::OnChainConfig, validator_info::ValidatorInfo};
-use anyhow::Result;
+
 #[cfg(any(test, feature = "fuzzing"))]
 use proptest_derive::Arbitrary;
 use serde::{Deserialize, Serialize};
@@ -47,10 +47,6 @@ impl ValidatorSet {
 
     pub fn empty() -> Self {
         ValidatorSet::new(Vec::new())
-    }
-
-    pub fn from_bytes(bytes: &[u8]) -> Result<Self> {
-        lcs::from_bytes(bytes).map_err(Into::into)
     }
 }
 

--- a/types/src/proof/definition.rs
+++ b/types/src/proof/definition.rs
@@ -796,8 +796,4 @@ impl<H: CryptoHasher> AccumulatorExtensionProof<H> {
 
         Ok(original_tree.append(self.leaves.as_slice()))
     }
-
-    pub fn leaves(&self) -> &Vec<HashValue> {
-        &self.leaves
-    }
 }

--- a/types/src/transaction/authenticator.rs
+++ b/types/src/transaction/authenticator.rs
@@ -228,11 +228,6 @@ impl AuthenticationKeyPreimage {
         Self::new(public_key.to_bytes(), Scheme::MultiEd25519)
     }
 
-    /// Construct a slice from this authentication key
-    pub fn to_bytes(&self) -> &[u8] {
-        &self.0
-    }
-
     /// Construct a vector from this authentication key
     pub fn into_vec(self) -> Vec<u8> {
         self.0

--- a/types/src/transaction/authenticator.rs
+++ b/types/src/transaction/authenticator.rs
@@ -189,11 +189,6 @@ impl AuthenticationKey {
         array
     }
 
-    /// Return an abbreviated representation of this authentication key
-    pub fn short_str(&self) -> String {
-        hex::encode(&self.0[..4])
-    }
-
     /// Construct a vector from this authentication key
     pub fn to_vec(&self) -> Vec<u8> {
         self.0.to_vec()

--- a/types/src/transaction/module.rs
+++ b/types/src/transaction/module.rs
@@ -17,10 +17,6 @@ impl Module {
     pub fn code(&self) -> &[u8] {
         &self.code
     }
-
-    pub fn into_inner(self) -> Vec<u8> {
-        self.code
-    }
 }
 
 impl fmt::Debug for Module {

--- a/types/src/validator_verifier.rs
+++ b/types/src/validator_verifier.rs
@@ -59,10 +59,6 @@ impl ValidatorConsensusInfo {
         }
     }
 
-    pub fn public_key(&self) -> &Ed25519PublicKey {
-        &self.public_key
-    }
-
     pub fn voting_power(&self) -> u64 {
         self.voting_power
     }

--- a/types/src/write_set.rs
+++ b/types/src/write_set.rs
@@ -48,11 +48,6 @@ pub struct WriteSet(WriteSetMut);
 
 impl WriteSet {
     #[inline]
-    pub fn len(&self) -> usize {
-        self.0.len()
-    }
-
-    #[inline]
     pub fn is_empty(&self) -> bool {
         self.0.is_empty()
     }
@@ -83,11 +78,6 @@ impl WriteSetMut {
 
     pub fn push(&mut self, item: (AccessPath, WriteOp)) {
         self.write_set.push(item);
-    }
-
-    #[inline]
-    pub fn len(&self) -> usize {
-        self.write_set.len()
     }
 
     #[inline]


### PR DESCRIPTION
This PR removes 26 untested, unused methods from `consensus` and `types`. The value of the PR may reside more in the signaling of the nature of those untested, unused methods rather than actual removal.

I do hope & expect that reviewers will come up with valid reasons why one or another of those methods should be part of our public API — I've hence separated commits per method so that those valid methods can be kept, by omitting the commit that removes them. Just say so in review, plz :slightly_smiling_face: 

(I also have found 72 such unused, untested members that might be removed in `language/`, 
https://gist.github.com/huitseeker/3e783ef9758e22693a1204d16c2a2ee2
which I won't submit for a PR, as requested  [[1]](https://github.com/libra/libra/pull/3879#issuecomment-628976319) [[2]](https://github.com/libra/libra/pull/3879#issuecomment-629417720) )