### PR TITLE
[language] Remove transaction size argument to MoveVM

### DIFF
--- a/language/benchmarks/src/move_vm.rs
+++ b/language/benchmarks/src/move_vm.rs
@@ -8,7 +8,7 @@ use libra_state_view::StateView;
 use libra_types::{access_path::AccessPath, account_address::AccountAddress};
 use libra_vm::data_cache::StateViewCache;
 use move_core_types::{
-    gas_schedule::{AbstractMemorySize, GasAlgebra, GasUnits},
+    gas_schedule::{GasAlgebra, GasUnits},
     identifier::{IdentStr, Identifier},
     language_storage::ModuleId,
 };
@@ -48,7 +48,7 @@ fn execute(c: &mut Criterion, move_vm: &MoveVM, module: VerifiedModule, fun: &st
     let gas_schedule = zero_cost_schedule();
     let data_cache = StateViewCache::new(&state);
     let mut data_store = TransactionDataCache::new(&data_cache);
-    let mut cost_strategy = CostStrategy::transaction(&gas_schedule, GasUnits::new(100_000_000));
+    let mut cost_strategy = CostStrategy::system(&gas_schedule, GasUnits::new(100_000_000));
 
     move_vm
         .cache_module(module, &mut data_store)
@@ -68,7 +68,6 @@ fn execute(c: &mut Criterion, move_vm: &MoveVM, module: VerifiedModule, fun: &st
                     vec![],
                     vec![],
                     AccountAddress::default(),
-                    AbstractMemorySize::new(0),
                     &mut data_store,
                     &mut cost_strategy,
                 )

--- a/language/move-vm/runtime/src/interpreter.rs
+++ b/language/move-vm/runtime/src/interpreter.rs
@@ -11,7 +11,6 @@ use libra_logger::prelude::*;
 use libra_types::{
     access_path::AccessPath,
     account_address::AccountAddress,
-    transaction::MAX_TRANSACTION_SIZE_IN_BYTES,
     vm_error::{StatusCode, StatusType, VMStatus},
 };
 use move_core_types::gas_schedule::{AbstractMemorySize, GasAlgebra, GasCarrier};
@@ -70,20 +69,13 @@ impl Interpreter {
         ty_args: Vec<Type>,
         args: Vec<Value>,
         sender: AccountAddress,
-        txn_size: AbstractMemorySize<GasCarrier>,
         data_store: &mut dyn DataStore,
         cost_strategy: &mut CostStrategy,
         loader: &Loader,
     ) -> VMResult<()> {
-        // The callers of this function verify the transaction before executing it. Transaction
-        // verification ensures the following condition.
-        // TODO: This is enforced by Libra but needs to be enforced by other callers of the Move VM
-        // as well.
-        assume!(txn_size.get() <= (MAX_TRANSACTION_SIZE_IN_BYTES as u64));
         // We count the intrinsic cost of the transaction here, since that needs to also cover the
         // setup of the function.
         let mut interp = Self::new(sender);
-        cost_strategy.charge_intrinsic_gas(txn_size)?;
         interp.execute(loader, data_store, cost_strategy, function, ty_args, args)
     }
 

--- a/language/move-vm/runtime/src/move_vm.rs
+++ b/language/move-vm/runtime/src/move_vm.rs
@@ -5,7 +5,6 @@ use crate::runtime::VMRuntime;
 use bytecode_verifier::VerifiedModule;
 use move_core_types::{
     account_address::AccountAddress,
-    gas_schedule::{AbstractMemorySize, GasCarrier},
     identifier::IdentStr,
     language_storage::{ModuleId, TypeTag},
 };
@@ -30,7 +29,6 @@ impl MoveVM {
         ty_args: Vec<TypeTag>,
         args: Vec<Value>,
         sender: AccountAddress,
-        txn_size: AbstractMemorySize<GasCarrier>,
         data_store: &mut dyn DataStore,
         cost_strategy: &mut CostStrategy,
     ) -> VMResult<()> {
@@ -40,7 +38,6 @@ impl MoveVM {
             ty_args,
             args,
             sender,
-            txn_size,
             data_store,
             cost_strategy,
         )
@@ -52,19 +49,11 @@ impl MoveVM {
         ty_args: Vec<TypeTag>,
         args: Vec<Value>,
         sender: AccountAddress,
-        txn_size: AbstractMemorySize<GasCarrier>,
         data_store: &mut dyn DataStore,
         cost_strategy: &mut CostStrategy,
     ) -> VMResult<()> {
-        self.runtime.execute_script(
-            script,
-            ty_args,
-            args,
-            sender,
-            txn_size,
-            data_store,
-            cost_strategy,
-        )
+        self.runtime
+            .execute_script(script, ty_args, args, sender, data_store, cost_strategy)
     }
 
     pub fn publish_module(

--- a/language/move-vm/runtime/src/runtime.rs
+++ b/language/move-vm/runtime/src/runtime.rs
@@ -7,7 +7,6 @@ use libra_logger::prelude::*;
 use libra_types::vm_error::{StatusCode, VMStatus};
 use move_core_types::{
     account_address::AccountAddress,
-    gas_schedule::{AbstractMemorySize, GasCarrier},
     identifier::IdentStr,
     language_storage::{ModuleId, TypeTag},
 };
@@ -77,7 +76,6 @@ impl VMRuntime {
         ty_args: Vec<TypeTag>,
         mut args: Vec<Value>,
         sender: AccountAddress,
-        txn_size: AbstractMemorySize<GasCarrier>,
         data_store: &mut dyn DataStore,
         cost_strategy: &mut CostStrategy,
     ) -> VMResult<()> {
@@ -108,7 +106,6 @@ impl VMRuntime {
             type_params,
             args,
             sender,
-            txn_size,
             data_store,
             cost_strategy,
             &self.loader,
@@ -122,7 +119,6 @@ impl VMRuntime {
         ty_args: Vec<TypeTag>,
         args: Vec<Value>,
         sender: AccountAddress,
-        txn_size: AbstractMemorySize<GasCarrier>,
         data_store: &mut dyn DataStore,
         cost_strategy: &mut CostStrategy,
     ) -> VMResult<()> {
@@ -144,7 +140,6 @@ impl VMRuntime {
             type_params,
             args,
             sender,
-            txn_size,
             data_store,
             cost_strategy,
             &self.loader,

--- a/language/move-vm/types/src/gas_schedule.rs
+++ b/language/move-vm/types/src/gas_schedule.rs
@@ -111,8 +111,11 @@ impl<'a> CostStrategy<'a> {
 
     /// Charge gas related to the overall size of a transaction and fail if not enough
     /// gas units are left.
-    pub fn charge_intrinsic_gas(&mut self, size: AbstractMemorySize<GasCarrier>) -> VMResult<()> {
-        let cost = calculate_intrinsic_gas(size, &self.cost_table.gas_constants);
+    pub fn charge_intrinsic_gas(
+        &mut self,
+        instrinsic_cost: AbstractMemorySize<GasCarrier>,
+    ) -> VMResult<()> {
+        let cost = calculate_intrinsic_gas(instrinsic_cost, &self.cost_table.gas_constants);
         self.deduct_gas(cost)
     }
 }

--- a/language/tools/test-generation/src/lib.rs
+++ b/language/tools/test-generation/src/lib.rs
@@ -26,7 +26,7 @@ use libra_state_view::StateView;
 use libra_types::{account_address::AccountAddress, vm_error::StatusCode};
 use libra_vm::LibraVM;
 use move_core_types::{
-    gas_schedule::{AbstractMemorySize, GasAlgebra, GasUnits},
+    gas_schedule::{GasAlgebra, GasUnits},
     language_storage::TypeTag,
 };
 use move_vm_types::{gas_schedule::CostStrategy, values::Value};
@@ -108,8 +108,7 @@ fn execute_function_in_module(
 
         let gas_schedule = internals.gas_schedule()?;
         internals.with_txn_data_cache(state_view, |mut txn_context| {
-            let mut cost_strategy =
-                CostStrategy::transaction(gas_schedule, GasUnits::new(100_000_000));
+            let mut cost_strategy = CostStrategy::system(gas_schedule, GasUnits::new(0));
             move_vm.cache_module(module.clone(), &mut txn_context)?;
             move_vm.execute_function(
                 &module_id,
@@ -117,7 +116,6 @@ fn execute_function_in_module(
                 ty_args,
                 args,
                 AccountAddress::default(),
-                AbstractMemorySize::new(0),
                 &mut txn_context,
                 &mut cost_strategy,
             )

--- a/language/tools/vm-genesis/src/genesis_context.rs
+++ b/language/tools/vm-genesis/src/genesis_context.rs
@@ -16,7 +16,7 @@ use libra_types::{
 };
 use libra_vm::data_cache::StateViewCache;
 use move_core_types::{
-    gas_schedule::{AbstractMemorySize, CostTable, GasAlgebra, GasUnits},
+    gas_schedule::{CostTable, GasAlgebra, GasUnits},
     identifier::Identifier,
     language_storage::{ModuleId, TypeTag},
 };
@@ -101,7 +101,6 @@ impl<'a> GenesisContext<'a> {
                 type_params,
                 args,
                 self.sender,
-                AbstractMemorySize::new(0),
                 &mut self.data_store,
                 &mut cost_strategy,
             )
@@ -117,7 +116,6 @@ impl<'a> GenesisContext<'a> {
                 script.ty_args().to_vec(),
                 Self::convert_txn_args(script.args()),
                 self.sender,
-                AbstractMemorySize::new(0),
                 &mut self.data_store,
                 &mut cost_strategy,
             )


### PR DESCRIPTION
This removes the size as an argument to the runtime.
It also removes the charging intrinsic gas from the runtime altogether.

I started with passing the size to the `CostStrategy` "constructor" and 
have the `Interpreter` call `charge_intrinsic_gas()` (as one of the 
possible solutions we talked about) but then realized it had the 
unpleasant side effect to make "charging intrinsic" part of any single 
call into the runtime, which seems hardly what we want.
The way it is is where I ended up after few iterations as it 
was the cleanest I could think of.

@runtian-zhou, @tzakian please let me know your thoughts 
