### PR TITLE
[move-prover] Initial user guide + fixes in error reporting

### DIFF
--- a/language/move-prover/README.md
+++ b/language/move-prover/README.md
@@ -4,12 +4,24 @@ title: Formal verification code
 custom_edit_url: https://github.com/libra/libra/edit/master/language/move-prover/README.md
 ---
 
-# Code supporting formal verification for Move programs
+
 
 ## Code under this subtree is experimental. It is out of scope for [the Libra Bug Bounty](https://hackerone.com/libra) until it is no longer marked experimental.
 
-## Debugging tips
+# The Move Prover
 
-During development, we sometimes want to edit the boogie file and run boogie on it explicitly.  You can see the boogie command line by cd'ing to the bytecode-to-boogie subdirectory and typing something like:
+The Move Prover supports formal specification and verification of Move programs. It can automatically prove
+logical properties of Move smart contracts, while providing a user experience similar to a type checker or linter.
+It's purpose is to make contracts more *trustworthy*, specifically:
 
-cargo run -- --verbose debug ../../stdlib/modules/vector.mvir test_mvir/verify_vector.mvir
+- Protect massive assets managed by the Libra blockchain from smart contract bugs
+- Protect against well-resourced adversaries
+- Anticipate justified regulator scrutiny and compliance requirements
+- Allow domain experts with mathematical background, but not necessarily software engineering background, to
+  understand what smart contracts do
+
+For more information, refer to the documentation:
+
+-  [Move Prover User Guide](./doc/user/prover-guide.md)
+-  [To be done] Move Specification Language
+-  [To be done] Move Prover Developer Guide

--- a/language/move-prover/doc/user/prover-guide.md
+++ b/language/move-prover/doc/user/prover-guide.md
@@ -1,0 +1,198 @@
+# Move Prover User Guide (DRAFT)
+
+This is the user guide for the Move prover. This document does not describe the Move specification language
+or the conceptual design of the Move prover; we refer to elsewhere for this.
+
+## Running the Prover
+
+To run the Move prover while working in the Libra tree, we recommend to use `cargo run`. You can define an alias
+as below in your `.bashrc` (or other shell configuration) to simplify this:
+
+```shell script
+alias mvp="cargo run --release --quiet --package move-prover --"
+```
+
+The `--release` flag can also be omitted if you prefer faster compilation over faster execution. However, once the
+prover has been build by cargo, and provided sources have not changed, the cargo command will quickly proceed.
+Note that the Rust code of the prover (and the underlying Move compiler) is by about a factor of 20 faster in
+release mode than in debug mode.
+
+In the sequel, we assume that `mvp` invokes the binary of the prover, either via an alias as above, or by
+other means.
+
+## Command Line Interface and Configuration
+
+The Move prover has a traditional compiler-style command line interface: you pass a set of sources, tell it where to
+look for dependencies of those sources, and optionally provide flags to control operation:
+
+```shell script
+> mvp --dependency . source.move
+> # Short form:
+> mvp -d . source.move
+```
+
+Above, we process a file `source.move` in the current directory, and tell the prover to look up any dependencies this source
+might have in the current directory (`.`). If verification succeeds, the prover will terminate with printing
+some statistics dependent on the configured verbosity level. Otherwise, it will print diagnosis, as will be
+discussed below.
+
+## Configuration File
+
+All options available via the command line, plus some more, can be also configured via a file. Moreover, you can
+set an environment variable which contains a path to the default configuration file the prover should use. This is handy,
+for example, to let the prover automatically find dependencies to the Move standard library, as shown below:
+
+```shell script
+> echo "move_deps = [\"<path-to-libra>/language/stdlib/modules\"]" > ~/.mvprc
+> export MOVE_PROVER_CONFIG=~/.mvprc
+```
+
+To see the full format of the configuration file use `mvp --print-config`. This will print out the toml for
+all available options. You can use this output as a blueprint for creating your own configuration
+file.
+
+## Diagnosis
+
+When the prover finds a verification error it prints out diagnosis in a style similar to a compiler or a debugger. We
+explain the different types of diagnoses below, based on the following evolving example:
+
+```move
+module M {
+  resource struct Counter {
+      value: u8,
+  }
+
+  public fun increment(a: address) acquires Counter {
+      let r = borrow_global_mut<Counter>(a);
+      r.value = r.value + 1;
+  }
+
+  spec fun increment {
+      aborts_if aborts_if !exists<Counter>(a);
+      ensures global<Counter>(a).value == old(global<Counter>(a)).value + 1;
+  }
+}
+```
+
+We will modify this example as we demonstrate different types of diagnoses.
+
+### Unexpected Abort
+
+If we run the Move prover on the above example, we get the following error:
+
+```
+error: abort not covered by any of the `aborts_if` clauses
+
+   ┌── tutorial.move:6:3 ───
+   │
+ 6 │ ╭   public fun increment(a: address) acquires Counter {
+ 7 │ │       let r = borrow_global_mut<Counter>(a);
+ 8 │ │       r.value = r.value + 1;
+ 9 │ │   }
+   │ ╰───^
+   ·
+ 8 │       r.value = r.value + 1;
+   │                         - abort happened here
+   │
+   =     at tutorial.move:6:3: increment (entry)
+   =     at tutorial.move:7:15: increment
+   =         a = 0x5,
+   =         r = &M.Counter{value = 255u8}
+   =     at tutorial.move:8:17: increment (ABORTED)
+```
+
+The prover has generated a counter example which leads to an overflow when adding 1 the value of 255 for an `u8`.
+This happens if the function specification states something abort abort behavior, but the condition under which
+the function is aborting is not covered by the specification. And in fact, with `aborts_if !exists<Counter>(a)` we
+only cover the abort if the resource does not exists, but not the overflow.
+
+Let's fix the above and add the following condition:
+
+```move
+spec fun increment {
+    aborts_if global<Counter>(a).value == 255;
+}
+```
+
+With this, the prover will succeed without any errors.
+
+### Postcondition might not hold
+
+Let us inject an error into the `ensures` condition of the above example:
+
+```move
+spec increment {
+    ensures global<Counter>(a).value == /*old*/(global<Counter>(a).value) + 1;
+}
+```
+
+With this, the prover will produce the following diagnosis:
+
+```
+error:  A postcondition might not hold on this return path.
+
+    ┌── tutorial.move:14:7 ───
+    │
+ 14 │       ensures global<Counter>(a).value == global<Counter>(a).value + 1;
+    │       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    │
+    =     at tutorial.move:6:3: increment (entry)
+    =     at tutorial.move:7:15: increment
+    =         a = 0x5,
+    =         r = &M.Counter{value = 50u8}
+    =     at tutorial.move:8:17: increment
+    =         r = &M.Counter{value = 50u8}
+    =     at tutorial.move:6:3: increment
+    =     at tutorial.move:6:3: increment (exit)
+```
+
+While we know what the error is (we just injected it), looking at the printed information makes it not particular
+obvious. This is because we don't directly see on which values the `ensures` condition was actually evaluated. To
+inspect those, we have two options. First, we can run the prover with the `--trace` option. The output then
+looks as below:
+
+```
+error:  A postcondition might not hold on this return path.
+
+    ┌── tutorial.move:14:7 ───
+    │
+ 14 │       ensures global<Counter>(a).value == global<Counter>(a).value + 1;
+    │       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    ·
+ 12 │       aborts_if !exists<Counter>(a);
+    │                                  - 0x5
+    ·
+ 12 │       aborts_if !exists<Counter>(a);
+    │                  ------------------ true
+    ·
+ 14 │       ensures global<Counter>(a).value == global<Counter>(a).value + 1;
+    │               ------------------ M.Counter{value = 244u8}
+    ·
+ 14 │       ensures global<Counter>(a).value == global<Counter>(a).value + 1;
+    │                                           ------------------ M.Counter{value = 244u8}
+    │
+    =     at tutorial.move:6:3: increment (entry)
+    =     at tutorial.move:7:15: increment
+    =         a = 0x5,
+    =         r = &M.Counter{value = 243u8}
+    =     at tutorial.move:8:17: increment
+    =         r = &M.Counter{value = 243u8}
+    =     at tutorial.move:6:3: increment
+    =     at tutorial.move:6:3: increment (exit)
+```
+
+> Note: the `--trace` option is currently known to sometimes produce false positives.
+
+Instead of the `--trace` option, one can also use the builtin function `TRACE(exp)` in conditions to explicitly
+mark expressions whose value should be printed on verification failures.
+
+## Debugging
+
+The Move prover is still an evolving tool with bugs and deficiencies. Sometimes it might be necessary to debug
+a problem based on the output it passes to the underlying backends. There are two options to this end:
+
+- By default, the prover will place the generated Boogie code in a file `output.bpl`, and the errors Boogie reported
+  in a file `output.bpl.log`.
+- With the option `-C backend.generate_smt=true` the prover will generate, for each verification problem, a file in
+  the smtlib format. The file is named after the verified function. This file contains the output Boogie
+  passes on to Z3 or other connected SMT solvers.

--- a/language/move-prover/src/bytecode_translator.rs
+++ b/language/move-prover/src/bytecode_translator.rs
@@ -661,6 +661,16 @@ impl<'env> ModuleTranslator<'env> {
         emitln!(self.writer, "assert !$abort_flag;");
         emitln!(self.writer, "$saved_m := $m;");
 
+        emitln!(self.writer, "\n// track values of parameters at entry time");
+        for i in 0..func_target.get_parameter_count() {
+            let local_name = func_target.get_local_name(i);
+            let local_str = format!("{}", local_name.display(func_target.symbol_pool()));
+            let s = self.track_local(func_target, func_target.get_loc(), i, &local_str);
+            if !s.is_empty() {
+                emitln!(self.writer, &s);
+            }
+        }
+
         emitln!(self.writer, "\n// bytecode translation starts here");
 
         // Generate bytecode

--- a/language/move-prover/src/cli.rs
+++ b/language/move-prover/src/cli.rs
@@ -278,7 +278,7 @@ impl Options {
                 Arg::with_name("docgen")
                     .long("docgen")
                     .help("run the documentation generator instead of the prover. \
-                    Generated docs will be written into the directory at `--output=<path>`"),
+                    Generated docs will be written into the directory `./doc` unless configured otherwise via toml"),
             )
             .arg(
                 Arg::with_name("verify")

--- a/language/move-prover/src/lib.rs
+++ b/language/move-prover/src/lib.rs
@@ -85,7 +85,7 @@ pub fn run_move_prover<W: WriteColor>(
         env.report_errors(error_writer);
         return Err(anyhow!("exiting with boogie generation errors"));
     }
-    debug!("writing boogie to {}", &options.output_path);
+    debug!("writing boogie to `{}`", &options.output_path);
     writer.process_result(|result| fs::write(&options.output_path, result))?;
     let translator_elapsed = now.elapsed();
     if !options.prover.generate_only {

--- a/language/move-prover/src/spec_translator.rs
+++ b/language/move-prover/src/spec_translator.rs
@@ -934,7 +934,7 @@ impl<'env> SpecTranslator<'env> {
             true
         } else if self.options.prover.debug_trace {
             // Option for automatic tracing has been enabled
-            if item != TraceItem::Exp {
+            if item == TraceItem::Exp {
                 // Some arbitrary exp
                 true
             } else {

--- a/language/move-prover/tests/sources/functional/aborts_if.exp
+++ b/language/move-prover/tests/sources/functional/aborts_if.exp
@@ -8,6 +8,8 @@ error:  A postcondition might not hold on this return path.
     │
     =     at tests/sources/functional/aborts_if.move:32:5: abort2_incorrect (entry)
     =     at tests/sources/functional/aborts_if.move:32:5: abort2_incorrect (exit)
+    =         _x = <redacted>,
+    =         _y = <redacted>
 
 error:  A postcondition might not hold on this return path.
 
@@ -18,6 +20,8 @@ error:  A postcondition might not hold on this return path.
     │
     =     at tests/sources/functional/aborts_if.move:47:5: abort4_incorrect (entry)
     =     at tests/sources/functional/aborts_if.move:48:9: abort4_incorrect
+    =         x = <redacted>,
+    =         y = <redacted>
     =     at tests/sources/functional/aborts_if.move:47:5: abort4_incorrect (exit)
 
 error: abort not covered by any of the `aborts_if` clauses
@@ -34,6 +38,8 @@ error: abort not covered by any of the `aborts_if` clauses
     │
     =     at tests/sources/functional/aborts_if.move:55:5: abort5_incorrect (entry)
     =     at tests/sources/functional/aborts_if.move:56:9: abort5_incorrect (ABORTED)
+    =         x = <redacted>,
+    =         y = <redacted>
 
 error:  A postcondition might not hold on this return path.
 
@@ -44,6 +50,8 @@ error:  A postcondition might not hold on this return path.
     │
     =     at tests/sources/functional/aborts_if.move:63:5: abort6_incorrect (entry)
     =     at tests/sources/functional/aborts_if.move:64:9: abort6_incorrect
+    =         x = <redacted>,
+    =         y = <redacted>
     =     at tests/sources/functional/aborts_if.move:63:5: abort6_incorrect (exit)
 
 error:  A postcondition might not hold on this return path.
@@ -55,6 +63,8 @@ error:  A postcondition might not hold on this return path.
     │
     =     at tests/sources/functional/aborts_if.move:85:5: multi_abort2_incorrect (entry)
     =     at tests/sources/functional/aborts_if.move:86:9: multi_abort2_incorrect
+    =         x = <redacted>,
+    =         y = <redacted>
     =     at tests/sources/functional/aborts_if.move:85:5: multi_abort2_incorrect (exit)
 
 error: abort not covered by any of the `aborts_if` clauses
@@ -71,6 +81,8 @@ error: abort not covered by any of the `aborts_if` clauses
     │
     =     at tests/sources/functional/aborts_if.move:94:5: multi_abort3_incorrect (entry)
     =     at tests/sources/functional/aborts_if.move:95:9: multi_abort3_incorrect (ABORTED)
+    =         _x = <redacted>,
+    =         _y = <redacted>
 
 error:  A postcondition might not hold on this return path.
 
@@ -81,4 +93,5 @@ error:  A postcondition might not hold on this return path.
      │
      =     at tests/sources/functional/aborts_if.move:112:5: multi_abort5_incorrect (entry)
      =     at tests/sources/functional/aborts_if.move:113:9: multi_abort5_incorrect
+     =         x = <redacted>
      =     at tests/sources/functional/aborts_if.move:112:5: multi_abort5_incorrect (exit)

--- a/language/move-prover/tests/sources/functional/arithm.exp
+++ b/language/move-prover/tests/sources/functional/arithm.exp
@@ -13,6 +13,8 @@ error: abort not covered by any of the `aborts_if` clauses
      │
      =     at tests/sources/functional/arithm.move:125:5: div_by_zero_u64_incorrect (entry)
      =     at tests/sources/functional/arithm.move:126:11: div_by_zero_u64_incorrect (ABORTED)
+     =         x = <redacted>,
+     =         y = <redacted>
 
 error: abort not covered by any of the `aborts_if` clauses
 
@@ -28,6 +30,8 @@ error: abort not covered by any of the `aborts_if` clauses
      │
      =     at tests/sources/functional/arithm.move:177:5: overflow_u128_add_incorrect (entry)
      =     at tests/sources/functional/arithm.move:178:11: overflow_u128_add_incorrect (ABORTED)
+     =         x = <redacted>,
+     =         y = <redacted>
 
 error: abort not covered by any of the `aborts_if` clauses
 
@@ -43,6 +47,8 @@ error: abort not covered by any of the `aborts_if` clauses
      │
      =     at tests/sources/functional/arithm.move:230:5: overflow_u128_mul_incorrect (entry)
      =     at tests/sources/functional/arithm.move:231:11: overflow_u128_mul_incorrect (ABORTED)
+     =         x = <redacted>,
+     =         y = <redacted>
 
 error: abort not covered by any of the `aborts_if` clauses
 
@@ -58,6 +64,8 @@ error: abort not covered by any of the `aborts_if` clauses
      │
      =     at tests/sources/functional/arithm.move:161:5: overflow_u64_add_incorrect (entry)
      =     at tests/sources/functional/arithm.move:162:11: overflow_u64_add_incorrect (ABORTED)
+     =         x = <redacted>,
+     =         y = <redacted>
 
 error: abort not covered by any of the `aborts_if` clauses
 
@@ -73,6 +81,8 @@ error: abort not covered by any of the `aborts_if` clauses
      │
      =     at tests/sources/functional/arithm.move:214:5: overflow_u64_mul_incorrect (entry)
      =     at tests/sources/functional/arithm.move:215:11: overflow_u64_mul_incorrect (ABORTED)
+     =         x = <redacted>,
+     =         y = <redacted>
 
 error: abort not covered by any of the `aborts_if` clauses
 
@@ -88,6 +98,8 @@ error: abort not covered by any of the `aborts_if` clauses
      │
      =     at tests/sources/functional/arithm.move:145:5: overflow_u8_add_incorrect (entry)
      =     at tests/sources/functional/arithm.move:146:11: overflow_u8_add_incorrect (ABORTED)
+     =         x = <redacted>,
+     =         y = <redacted>
 
 error: abort not covered by any of the `aborts_if` clauses
 
@@ -103,3 +115,5 @@ error: abort not covered by any of the `aborts_if` clauses
      │
      =     at tests/sources/functional/arithm.move:198:5: overflow_u8_mul_incorrect (entry)
      =     at tests/sources/functional/arithm.move:199:11: overflow_u8_mul_incorrect (ABORTED)
+     =         x = <redacted>,
+     =         y = <redacted>

--- a/language/move-prover/tests/sources/functional/cast.exp
+++ b/language/move-prover/tests/sources/functional/cast.exp
@@ -13,6 +13,7 @@ error: abort not covered by any of the `aborts_if` clauses
     │
     =     at tests/sources/functional/cast.move:44:5: aborting_u64_cast_incorrect (entry)
     =     at tests/sources/functional/cast.move:45:9: aborting_u64_cast_incorrect (ABORTED)
+    =         x = <redacted>
 
 error: abort not covered by any of the `aborts_if` clauses
 
@@ -28,3 +29,4 @@ error: abort not covered by any of the `aborts_if` clauses
     │
     =     at tests/sources/functional/cast.move:30:5: aborting_u8_cast_incorrect (entry)
     =     at tests/sources/functional/cast.move:31:9: aborting_u8_cast_incorrect (ABORTED)
+    =         x = <redacted>

--- a/language/move-prover/tests/sources/functional/global_vars.exp
+++ b/language/move-prover/tests/sources/functional/global_vars.exp
@@ -37,6 +37,7 @@ error:  A postcondition might not hold on this return path.
     │
     =     at tests/sources/functional/global_vars.move:52:5: unpack_incorrect (entry)
     =     at tests/sources/functional/global_vars.move:53:19: unpack_incorrect
+    =         t = <redacted>
     =     at tests/sources/functional/global_vars.move:54:9: unpack_incorrect
     =         x = <redacted>
     =     at tests/sources/functional/global_vars.move:52:5: unpack_incorrect (exit)
@@ -74,6 +75,7 @@ error:  A postcondition might not hold on this return path.
     =         t = <redacted>
     =     at tests/sources/functional/global_vars.move:66:5: update_valid_still_mutating (entry)
     =     at tests/sources/functional/global_vars.move:67:19: update_valid_still_mutating
+    =         t = <redacted>
     =     at tests/sources/functional/global_vars.move:66:5: update_valid_still_mutating (exit)
     =         result = <redacted>
     =     at tests/sources/functional/global_vars.move:87:9: update_incorrect

--- a/language/move-prover/tests/sources/functional/hash_model.exp
+++ b/language/move-prover/tests/sources/functional/hash_model.exp
@@ -8,6 +8,8 @@ error:  A postcondition might not hold on this return path.
     │
     =     at tests/sources/functional/hash_model.move:39:5: hash_test1_incorrect (entry)
     =     at tests/sources/functional/hash_model.move:41:24: hash_test1_incorrect
+    =         v1 = <redacted>,
+    =         v2 = <redacted>,
     =         h1 = <redacted>
     =     at tests/sources/functional/hash_model.move:42:33: hash_test1_incorrect
     =         h2 = <redacted>
@@ -25,6 +27,8 @@ error:  A postcondition might not hold on this return path.
     │
     =     at tests/sources/functional/hash_model.move:82:5: hash_test2_incorrect (entry)
     =     at tests/sources/functional/hash_model.move:84:24: hash_test2_incorrect
+    =         v1 = <redacted>,
+    =         v2 = <redacted>,
     =         h1 = <redacted>
     =     at tests/sources/functional/hash_model.move:85:33: hash_test2_incorrect
     =         h2 = <redacted>

--- a/language/move-prover/tests/sources/functional/hash_model_invalid.exp
+++ b/language/move-prover/tests/sources/functional/hash_model_invalid.exp
@@ -8,6 +8,8 @@ error:  A postcondition might not hold on this return path.
     │
     =     at tests/sources/functional/hash_model_invalid.move:11:5: hash_test1 (entry)
     =     at tests/sources/functional/hash_model_invalid.move:13:24: hash_test1
+    =         v1 = <redacted>,
+    =         v2 = <redacted>,
     =         h1 = <redacted>
     =     at tests/sources/functional/hash_model_invalid.move:14:33: hash_test1
     =         h2 = <redacted>
@@ -25,6 +27,8 @@ error:  A postcondition might not hold on this return path.
     │
     =     at tests/sources/functional/hash_model_invalid.move:26:5: hash_test2 (entry)
     =     at tests/sources/functional/hash_model_invalid.move:28:24: hash_test2
+    =         v1 = <redacted>,
+    =         v2 = <redacted>,
     =         h1 = <redacted>
     =     at tests/sources/functional/hash_model_invalid.move:29:33: hash_test2
     =         h2 = <redacted>

--- a/language/move-prover/tests/sources/functional/invariants.exp
+++ b/language/move-prover/tests/sources/functional/invariants.exp
@@ -35,6 +35,7 @@ error:  This assertion might not hold.
      │
      =     at tests/sources/functional/invariants.move:153:5: lifetime_invalid_S_branching (entry)
      =     at tests/sources/functional/invariants.move:154:11: lifetime_invalid_S_branching
+     =         cond = <redacted>
      =     at tests/sources/functional/invariants.move:155:21: lifetime_invalid_S_branching
      =         a = <redacted>,
      =         b = <redacted>

--- a/language/move-prover/tests/sources/functional/marketcap.exp
+++ b/language/move-prover/tests/sources/functional/marketcap.exp
@@ -8,6 +8,8 @@ error:  A postcondition might not hold on this return path.
     │
     =     at tests/sources/functional/marketcap.move:48:6: deposit_invalid (entry)
     =     at tests/sources/functional/marketcap.move:49:18: deposit_invalid
+    =         coin_ref = <redacted>,
+    =         check = <redacted>,
     =         value = <redacted>
     =     at tests/sources/functional/marketcap.move:50:27: deposit_invalid
     =     at tests/sources/functional/marketcap.move:48:6: deposit_invalid (exit)

--- a/language/move-prover/tests/sources/functional/marketcap_as_schema.exp
+++ b/language/move-prover/tests/sources/functional/marketcap_as_schema.exp
@@ -8,6 +8,8 @@ error:  A postcondition might not hold on this return path.
     │
     =     at tests/sources/functional/marketcap_as_schema.move:58:6: deposit_invalid (entry)
     =     at tests/sources/functional/marketcap_as_schema.move:59:18: deposit_invalid
+    =         coin_ref = <redacted>,
+    =         check = <redacted>,
     =         value = <redacted>
     =     at tests/sources/functional/marketcap_as_schema.move:60:27: deposit_invalid
     =     at tests/sources/functional/marketcap_as_schema.move:58:6: deposit_invalid (exit)

--- a/language/move-prover/tests/sources/functional/marketcap_as_schema_apply.exp
+++ b/language/move-prover/tests/sources/functional/marketcap_as_schema_apply.exp
@@ -8,6 +8,8 @@ error:  A postcondition might not hold on this return path.
     │
     =     at tests/sources/functional/marketcap_as_schema_apply.move:67:5: deposit_incorrect (entry)
     =     at tests/sources/functional/marketcap_as_schema_apply.move:68:17: deposit_incorrect
+    =         coin_ref = <redacted>,
+    =         check = <redacted>,
     =         value = <redacted>
     =     at tests/sources/functional/marketcap_as_schema_apply.move:69:26: deposit_incorrect
     =     at tests/sources/functional/marketcap_as_schema_apply.move:67:5: deposit_incorrect (exit)

--- a/language/move-prover/tests/sources/functional/marketcap_generic.exp
+++ b/language/move-prover/tests/sources/functional/marketcap_generic.exp
@@ -8,6 +8,8 @@ error:  A postcondition might not hold on this return path.
     │
     =     at tests/sources/functional/marketcap_generic.move:61:6: deposit_invalid (entry)
     =     at tests/sources/functional/marketcap_generic.move:62:18: deposit_invalid
+    =         coin_ref = <redacted>,
+    =         check = <redacted>,
     =         value = <redacted>
     =     at tests/sources/functional/marketcap_generic.move:63:27: deposit_invalid
     =     at tests/sources/functional/marketcap_generic.move:61:6: deposit_invalid (exit)

--- a/language/move-prover/tests/sources/functional/module_invariants.exp
+++ b/language/move-prover/tests/sources/functional/module_invariants.exp
@@ -8,6 +8,7 @@ error:  A postcondition might not hold on this return path.
     │
     =     at tests/sources/functional/module_invariants.move:51:5: delete_S_incorrect (entry)
     =     at tests/sources/functional/module_invariants.move:51:5: delete_S_incorrect (exit)
+    =         x = <redacted>
 
 error:  A precondition for this call might not hold.
 

--- a/language/move-prover/tests/sources/functional/mut_ref_accross_modules.exp
+++ b/language/move-prover/tests/sources/functional/mut_ref_accross_modules.exp
@@ -8,6 +8,7 @@ error:  This assertion might not hold.
     │
     =     at tests/sources/functional/mut_ref_accross_modules.move:64:5: decrement_invalid (entry)
     =     at tests/sources/functional/mut_ref_accross_modules.move:65:27: decrement_invalid
+    =         x = <redacted>,
     =         r = <redacted>
 
 error:  A postcondition might not hold on this return path.
@@ -19,6 +20,7 @@ error:  A postcondition might not hold on this return path.
     │
     =     at tests/sources/functional/mut_ref_accross_modules.move:58:5: increment_invalid (entry)
     =     at tests/sources/functional/mut_ref_accross_modules.move:59:27: increment_invalid
+    =         x = <redacted>
     =     at tests/sources/functional/mut_ref_accross_modules.move:58:5: increment_invalid (exit)
     =         result = <redacted>
 

--- a/language/move-prover/tests/sources/functional/pragma.exp
+++ b/language/move-prover/tests/sources/functional/pragma.exp
@@ -13,3 +13,4 @@ error: abort not covered by any of the `aborts_if` clauses
     │
     =     at tests/sources/functional/pragma.move:10:5: always_aborts_with_verify_incorrect (entry)
     =     at tests/sources/functional/pragma.move:11:9: always_aborts_with_verify_incorrect (ABORTED)
+    =         _c = <redacted>

--- a/language/move-prover/tests/sources/functional/references.exp
+++ b/language/move-prover/tests/sources/functional/references.exp
@@ -15,6 +15,7 @@ error:  A postcondition might not hold on this return path.
     =     at tests/sources/functional/references.move:61:15: mut_ref_incorrect
     =     at tests/sources/functional/references.move:43:5: mut_b (entry)
     =     at tests/sources/functional/references.move:44:16: mut_b
+    =         b = <redacted>
     =     at tests/sources/functional/references.move:43:9: mut_b
     =     at tests/sources/functional/references.move:58:5: mut_ref_incorrect
     =         b = <redacted>

--- a/language/move-prover/tests/sources/functional/schema_exp.exp
+++ b/language/move-prover/tests/sources/functional/schema_exp.exp
@@ -13,6 +13,7 @@ error: abort not covered by any of the `aborts_if` clauses
     │
     =     at tests/sources/functional/schema_exp.move:25:5: bar_incorrect (entry)
     =     at tests/sources/functional/schema_exp.move:26:9: bar_incorrect (ABORTED)
+    =         c = <redacted>
 
 error:  A postcondition might not hold on this return path.
 
@@ -23,5 +24,6 @@ error:  A postcondition might not hold on this return path.
     │
     =     at tests/sources/functional/schema_exp.move:53:5: baz_incorrect (entry)
     =     at tests/sources/functional/schema_exp.move:54:11: baz_incorrect
+    =         i = <redacted>,
     =         result = <redacted>
     =     at tests/sources/functional/schema_exp.move:53:5: baz_incorrect (exit)

--- a/language/move-prover/tests/sources/functional/serialize_model.exp
+++ b/language/move-prover/tests/sources/functional/serialize_model.exp
@@ -8,6 +8,8 @@ error:  A postcondition might not hold on this return path.
     │
     =     at tests/sources/functional/serialize_model.move:26:5: lcs_test1_incorrect (entry)
     =     at tests/sources/functional/serialize_model.move:28:23: lcs_test1_incorrect
+    =         v1 = <redacted>,
+    =         v2 = <redacted>,
     =         s1 = <redacted>
     =     at tests/sources/functional/serialize_model.move:29:32: lcs_test1_incorrect
     =         s2 = <redacted>

--- a/language/move-prover/tests/sources/functional/specs_in_fun.exp
+++ b/language/move-prover/tests/sources/functional/specs_in_fun.exp
@@ -8,6 +8,8 @@ error:  This assertion might not hold.
     │
     =     at tests/sources/functional/specs_in_fun.move:42:5: simple1_incorrect (entry)
     =     at tests/sources/functional/specs_in_fun.move:43:9: simple1_incorrect
+    =         x = <redacted>,
+    =         y = <redacted>
 
 error:  This assertion might not hold.
 
@@ -18,6 +20,7 @@ error:  This assertion might not hold.
     │
     =     at tests/sources/functional/specs_in_fun.move:49:5: simple2_incorrect (entry)
     =     at tests/sources/functional/specs_in_fun.move:51:15: simple2_incorrect
+    =         x = <redacted>,
     =         y = <redacted>
     =     at tests/sources/functional/specs_in_fun.move:53:13: simple2_incorrect
 
@@ -39,5 +42,7 @@ error:  This assertion might not hold.
     │
     =     at tests/sources/functional/specs_in_fun.move:64:5: simple4_incorrect (entry)
     =     at tests/sources/functional/specs_in_fun.move:66:15: simple4_incorrect
+    =         x = <redacted>,
+    =         y = <redacted>,
     =         z = <redacted>
     =     at tests/sources/functional/specs_in_fun.move:68:13: simple4_incorrect

--- a/language/move-prover/tests/sources/functional/specs_in_fun_ref.exp
+++ b/language/move-prover/tests/sources/functional/specs_in_fun_ref.exp
@@ -17,6 +17,7 @@ error:  This loop invariant might not be maintained by the loop.
      │
      =     at tests/sources/functional/specs_in_fun_ref.move:110:5: simple7 (entry)
      =     at tests/sources/functional/specs_in_fun_ref.move:111:13: simple7
+     =         n = <redacted>
      =     at tests/sources/functional/specs_in_fun_ref.move:114:13: simple7
      =         x = <redacted>
      =     at tests/sources/functional/specs_in_fun_ref.move:113:9: simple7

--- a/language/move-prover/tests/sources/regression/generic_invariant200518.exp
+++ b/language/move-prover/tests/sources/regression/generic_invariant200518.exp
@@ -11,6 +11,7 @@ error:  A postcondition might not hold on this return path.
     =     at tests/sources/regression/generic_invariant200518.move:40:5: root_address (exit)
     =         result = <redacted>
     =     at tests/sources/regression/generic_invariant200518.move:26:9: remove_privilege
+    =         addr = <redacted>,
     =         $t1 = <redacted>
     =     at tests/sources/regression/generic_invariant200518.move:28:46: remove_privilege
     =     at tests/sources/regression/generic_invariant200518.move:24:5: remove_privilege (exit)

--- a/language/move-prover/tests/sources/regression/type_param_bug_200228.exp
+++ b/language/move-prover/tests/sources/regression/type_param_bug_200228.exp
@@ -8,5 +8,6 @@ error:  A postcondition might not hold on this return path.
     │
     =     at tests/sources/regression/type_param_bug_200228.move:6:3: type_param_bug (entry)
     =     at tests/sources/regression/type_param_bug_200228.move:7:5: type_param_bug
+    =         addr = <redacted>,
     =         result = <redacted>
     =     at tests/sources/regression/type_param_bug_200228.move:6:3: type_param_bug (exit)


### PR DESCRIPTION
This provides an initial version of a user guide for the Move prover. It does not cover yet the specification language, or has material for a developer guide.

In cause of writing this, a few problems with error reporting where identified and fixed:

- The memory model PR accidentally removed debug tracking of function parameters on entry. This has been brought back which leads to a lot of updates in baselines.
- When `$` was introduced for all prelude names, boogie_wrapper wasn't updated, which broke the visualization of values in error reports. This has been fixed.

## Motivation

Documentation.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

Existing tests.

## Related PRs

NA
