### PR TITLE
[mempool] evict txn only for adding ready txn

### DIFF
--- a/mempool/src/core_mempool/transaction_store.rs
+++ b/mempool/src/core_mempool/transaction_store.rs
@@ -98,7 +98,7 @@ impl TransactionStore {
             ));
         }
 
-        if self.check_if_full() {
+        if self.check_if_full(&txn, current_sequence_number) {
             return MempoolStatus::new(MempoolStatusCode::MempoolIsFull).with_message(format!(
                 "mempool size: {}, capacity: {}",
                 self.system_ttl_index.size(),
@@ -145,8 +145,11 @@ impl TransactionStore {
 
     /// checks if Mempool is full
     /// If it's full, tries to free some space by evicting transactions from ParkingLot
-    fn check_if_full(&mut self) -> bool {
-        if self.system_ttl_index.size() >= self.capacity {
+    /// We only evict on attempt to insert a transaction that would be ready for broadcast upon insertion
+    fn check_if_full(&mut self, txn: &MempoolTransaction, curr_sequence_number: u64) -> bool {
+        if self.system_ttl_index.size() >= self.capacity
+            && self.check_txn_ready(txn, curr_sequence_number)
+        {
             // try to free some space in Mempool from ParkingLot
             if let Some((address, sequence_number)) = self.parking_lot_index.pop() {
                 if let Some(txn) = self
@@ -159,6 +162,32 @@ impl TransactionStore {
             }
         }
         self.system_ttl_index.size() >= self.capacity
+    }
+
+    /// check if a transaction would be ready for broadcast in mempool upon insertion (without inserting it)
+    /// Two ways this can happen:
+    /// 1. txn sequence number == curr_sequence_number
+    /// (this handles both cases where (1) txn is first possible txn for an account
+    /// and (2) previous txn is committed)
+    /// 2. the txn before this is ready for broadcast but not yet committed
+    fn check_txn_ready(&mut self, txn: &MempoolTransaction, curr_sequence_number: u64) -> bool {
+        let tx_sequence_number = txn.get_sequence_number();
+        if tx_sequence_number == curr_sequence_number {
+            return true;
+        } else if tx_sequence_number == 0 {
+            // shouldn't really get here because filtering out old txn sequence numbers happens earlier in workflow
+            unreachable!("[mempool] already committed txn detected, cannot be checked for readiness upon insertion");
+        }
+
+        // check previous txn in sequence is ready
+        if let Some(account_txns) = self.transactions.get(&txn.get_sender()) {
+            if let Some(prev_txn) = account_txns.get(&(tx_sequence_number - 1)) {
+                if let TimelineState::Ready(_) = prev_txn.timeline_state {
+                    return true;
+                }
+            }
+        }
+        false
     }
 
     /// check if transaction is already present in Mempool


### PR DESCRIPTION
## Motivation

originally, when adding a txn to a full mempool, we were evicting txns at the cost of inserting any txn. This is problematic when trying to add a non-ready txn with sequence number `x`, we evict a txn with sequence number `x+1`, which blocks progress for that account. This PR adds the restriction where we only evict txns from a full mempool for inserting a txn that will be ready for broadcast upon insertion. 

## Test Plan

Added new test, breaks without impl changes
