### PR TITLE
[cleanup][types] Remove 6 unused, untested functions from account_config

### DIFF
--- a/types/src/account_config/constants/account.rs
+++ b/types/src/account_config/constants/account.rs
@@ -4,7 +4,7 @@
 use crate::account_config::constants::CORE_CODE_ADDRESS;
 use move_core_types::{
     identifier::{IdentStr, Identifier},
-    language_storage::{ModuleId, StructTag},
+    language_storage::ModuleId,
 };
 use once_cell::sync::Lazy;
 
@@ -30,13 +30,4 @@ pub fn sent_event_name() -> &'static IdentStr {
 
 pub fn received_event_name() -> &'static IdentStr {
     &*RECEIVED_EVENT_NAME
-}
-
-pub fn received_payment_tag() -> StructTag {
-    StructTag {
-        address: CORE_CODE_ADDRESS,
-        module: ACCOUNT_MODULE_IDENTIFIER.clone(),
-        name: received_event_name().to_owned(),
-        type_params: vec![],
-    }
 }

--- a/types/src/account_config/constants/account.rs
+++ b/types/src/account_config/constants/account.rs
@@ -13,7 +13,6 @@ pub const ACCOUNT_MODULE_NAME: &str = "LibraAccount";
 // Account
 static ACCOUNT_MODULE_IDENTIFIER: Lazy<Identifier> =
     Lazy::new(|| Identifier::new("LibraAccount").unwrap());
-static ACCOUNT_STRUCT_NAME: Lazy<Identifier> = Lazy::new(|| Identifier::new("T").unwrap());
 
 /// The ModuleId for the Account module.
 pub static ACCOUNT_MODULE: Lazy<ModuleId> =
@@ -31,15 +30,6 @@ pub fn sent_event_name() -> &'static IdentStr {
 
 pub fn received_event_name() -> &'static IdentStr {
     &*RECEIVED_EVENT_NAME
-}
-
-pub fn account_struct_tag() -> StructTag {
-    StructTag {
-        address: CORE_CODE_ADDRESS,
-        module: ACCOUNT_MODULE_IDENTIFIER.clone(),
-        name: ACCOUNT_STRUCT_NAME.to_owned(),
-        type_params: vec![],
-    }
 }
 
 pub fn sent_payment_tag() -> StructTag {

--- a/types/src/account_config/constants/account.rs
+++ b/types/src/account_config/constants/account.rs
@@ -14,8 +14,6 @@ pub const ACCOUNT_MODULE_NAME: &str = "LibraAccount";
 static ACCOUNT_MODULE_IDENTIFIER: Lazy<Identifier> =
     Lazy::new(|| Identifier::new("LibraAccount").unwrap());
 static ACCOUNT_STRUCT_NAME: Lazy<Identifier> = Lazy::new(|| Identifier::new("T").unwrap());
-static ACCOUNT_BALANCE_STRUCT_NAME: Lazy<Identifier> =
-    Lazy::new(|| Identifier::new("Balance").unwrap());
 
 /// The ModuleId for the Account module.
 pub static ACCOUNT_MODULE: Lazy<ModuleId> =
@@ -26,10 +24,6 @@ static SENT_EVENT_NAME: Lazy<Identifier> =
     Lazy::new(|| Identifier::new("SentPaymentEvent").unwrap());
 static RECEIVED_EVENT_NAME: Lazy<Identifier> =
     Lazy::new(|| Identifier::new("ReceivedPaymentEvent").unwrap());
-
-pub fn account_balance_struct_name() -> &'static IdentStr {
-    &*ACCOUNT_BALANCE_STRUCT_NAME
-}
 
 pub fn sent_event_name() -> &'static IdentStr {
     &*SENT_EVENT_NAME

--- a/types/src/account_config/constants/account.rs
+++ b/types/src/account_config/constants/account.rs
@@ -32,15 +32,6 @@ pub fn received_event_name() -> &'static IdentStr {
     &*RECEIVED_EVENT_NAME
 }
 
-pub fn sent_payment_tag() -> StructTag {
-    StructTag {
-        address: CORE_CODE_ADDRESS,
-        module: ACCOUNT_MODULE_IDENTIFIER.clone(),
-        name: sent_event_name().to_owned(),
-        type_params: vec![],
-    }
-}
-
 pub fn received_payment_tag() -> StructTag {
     StructTag {
         address: CORE_CODE_ADDRESS,

--- a/types/src/account_config/constants/coins.rs
+++ b/types/src/account_config/constants/coins.rs
@@ -17,12 +17,3 @@ pub fn coin1_tag() -> TypeTag {
         type_params: vec![],
     })
 }
-
-pub fn coin2_tag() -> TypeTag {
-    TypeTag::Struct(StructTag {
-        address: CORE_CODE_ADDRESS,
-        module: from_currency_code_string(COIN2_NAME).unwrap(),
-        name: coin_struct_name().to_owned(),
-        type_params: vec![],
-    })
-}

--- a/types/src/account_config/constants/libra.rs
+++ b/types/src/account_config/constants/libra.rs
@@ -15,10 +15,6 @@ static COIN_STRUCT_NAME: Lazy<Identifier> = Lazy::new(|| Identifier::new("T").un
 pub static COIN_MODULE: Lazy<ModuleId> =
     Lazy::new(|| ModuleId::new(CORE_CODE_ADDRESS, COIN_MODULE_NAME.clone()));
 
-pub fn coin_module_name() -> &'static IdentStr {
-    &*COIN_MODULE_NAME
-}
-
 pub fn coin_struct_name() -> &'static IdentStr {
     &*COIN_STRUCT_NAME
 }


### PR DESCRIPTION
This PR removes 6 untested, unused functions from `types::account_config`. The value of the PR may reside more in the signaling of the nature of those untested, unused methods rather than actual removal.

I do hope & expect that reviewers will come up with valid reasons why one or another of those methods should be part of our public API — I've hence separated commits per method so that those valid methods can be kept, by omitting the commit that removes them. Just say so in review, plz :slightly_smiling_face: 

(I also have found 9 such unused, untested functions that might be removed in `language/`, 
https://gist.github.com/2f8ddffbbc18df783f1bad0b22375613
which I won't submit for a PR, as requested  [[1]](https://github.com/libra/libra/pull/3879#issuecomment-628976319) [[2]](https://github.com/libra/libra/pull/3879#issuecomment-629417720) )