### PR TITLE
[safety-rules] Handling key verification during epoch changes

### DIFF
--- a/consensus/safety-rules/src/consensus_state.rs
+++ b/consensus/safety-rules/src/consensus_state.rs
@@ -15,6 +15,7 @@ pub struct ConsensusState {
     last_voted_round: Round,
     preferred_round: Round,
     waypoint: Waypoint,
+    in_validator_set: bool,
 }
 
 impl Display for ConsensusState {
@@ -26,8 +27,13 @@ impl Display for ConsensusState {
              \tlast_voted_round = {},\n\
              \tpreferred_round = {}\n\
              \twaypoint = {}\n\
+             \tin_validator_set = {}\n\
              ]",
-            self.epoch, self.last_voted_round, self.preferred_round, self.waypoint,
+            self.epoch,
+            self.last_voted_round,
+            self.preferred_round,
+            self.waypoint,
+            self.in_validator_set,
         )
     }
 }
@@ -38,12 +44,14 @@ impl ConsensusState {
         last_voted_round: Round,
         preferred_round: Round,
         waypoint: Waypoint,
+        in_validator_set: bool,
     ) -> Self {
         Self {
             epoch,
             last_voted_round,
             preferred_round,
             waypoint,
+            in_validator_set,
         }
     }
 
@@ -66,5 +74,10 @@ impl ConsensusState {
     /// Last known checkpoint this should map to a LedgerInfo that contains a new ValidatorSet
     pub fn waypoint(&self) -> Waypoint {
         self.waypoint
+    }
+
+    /// Indicating whether the validator is validator set
+    pub fn in_validator_set(&self) -> bool {
+        self.in_validator_set
     }
 }

--- a/consensus/safety-rules/src/error.rs
+++ b/consensus/safety-rules/src/error.rs
@@ -32,8 +32,8 @@ pub enum Error {
     #[error("Invalid QC: {}", {0})]
     InvalidQuorumCertificate(String),
 
-    #[error("validator_verifier is not set, SafetyRules is not initialized")]
-    NotInitialized,
+    #[error("{0} is not set, SafetyRules is not initialized")]
+    NotInitialized(String),
 
     /// This proposal's round is less than round of preferred block.
     /// Returns the id of the preferred block.

--- a/consensus/safety-rules/src/persistent_safety_storage.rs
+++ b/consensus/safety-rules/src/persistent_safety_storage.rs
@@ -55,12 +55,6 @@ impl PersistentSafetyStorage {
         Self { internal_store }
     }
 
-    pub fn consensus_key(&self) -> Result<Ed25519PrivateKey> {
-        self.internal_store
-            .export_private_key(CONSENSUS_KEY)
-            .map_err(|e| e.into())
-    }
-
     pub fn consensus_key_for_version(
         &self,
         version: Ed25519PublicKey,

--- a/consensus/safety-rules/src/persistent_safety_storage.rs
+++ b/consensus/safety-rules/src/persistent_safety_storage.rs
@@ -115,8 +115,8 @@ impl PersistentSafetyStorage {
     }
 
     #[cfg(any(test, feature = "testing"))]
-    pub fn internal_store(&mut self) -> &mut dyn Storage {
-        self.internal_store.as_mut()
+    pub fn internal_store(&mut self) -> &mut BoxedStorage {
+        &mut self.internal_store
     }
 }
 

--- a/consensus/safety-rules/src/persistent_safety_storage.rs
+++ b/consensus/safety-rules/src/persistent_safety_storage.rs
@@ -120,10 +120,9 @@ impl PersistentSafetyStorage {
         Ok(())
     }
 
-    pub fn rotate_consensus_key(&mut self) -> Result<Ed25519PublicKey> {
-        self.internal_store
-            .rotate_key(CONSENSUS_KEY)
-            .map_err(|e| e.into())
+    #[cfg(any(test, feature = "testing"))]
+    pub fn internal_store(&mut self) -> &mut dyn Storage {
+        self.internal_store.as_mut()
     }
 }
 

--- a/consensus/safety-rules/src/test_utils.rs
+++ b/consensus/safety-rules/src/test_utils.rs
@@ -1,7 +1,7 @@
 // Copyright (c) The Libra Core Contributors
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::{error::Error, persistent_safety_storage::PersistentSafetyStorage};
+use crate::persistent_safety_storage::PersistentSafetyStorage;
 use consensus_types::{
     block::Block,
     common::{Payload, Round},

--- a/consensus/safety-rules/src/test_utils.rs
+++ b/consensus/safety-rules/src/test_utils.rs
@@ -1,7 +1,7 @@
 // Copyright (c) The Libra Core Contributors
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::persistent_safety_storage::PersistentSafetyStorage;
+use crate::{error::Error, persistent_safety_storage::PersistentSafetyStorage};
 use consensus_types::{
     block::Block,
     common::{Payload, Round},

--- a/consensus/safety-rules/src/test_utils.rs
+++ b/consensus/safety-rules/src/test_utils.rs
@@ -15,6 +15,7 @@ use libra_crypto::hash::{CryptoHash, TransactionAccumulatorHasher};
 use libra_secure_storage::{BoxedStorage, InMemoryStorage};
 use libra_types::{
     block_info::BlockInfo,
+    epoch_state::EpochState,
     ledger_info::{LedgerInfo, LedgerInfoWithSignatures},
     on_chain_config::ValidatorSet,
     proof::AccumulatorExtensionProof,
@@ -71,6 +72,7 @@ pub fn make_proposal_with_parent_and_overrides(
     committed: Option<&VoteProposal>,
     validator_signer: &ValidatorSigner,
     epoch: Option<u64>,
+    next_epoch_state: Option<EpochState>,
 ) -> VoteProposal {
     let block_epoch = match epoch {
         Some(e) => e,
@@ -128,7 +130,7 @@ pub fn make_proposal_with_parent_and_overrides(
                 tree.root_hash(),
                 tree.version(),
                 committed.block().timestamp_usecs(),
-                None,
+                next_epoch_state,
             );
             LedgerInfo::new(commit_block_info, vote_data.hash())
         }
@@ -165,6 +167,7 @@ pub fn make_proposal_with_parent(
         parent,
         committed,
         validator_signer,
+        None,
         None,
     )
 }

--- a/consensus/safety-rules/src/tests/suite.rs
+++ b/consensus/safety-rules/src/tests/suite.rs
@@ -71,8 +71,8 @@ pub fn run_test_suite(func: Callback) {
     test_sign_proposal_with_early_preferred_round(func);
     test_uninitialized_signer(func);
     test_reconcile_key(func);
-    test_a_missing_validator(func);
-    // test_a_missing_validator_key(func);
+    test_validator_not_in_set(func);
+    // test_key_not_in_store(func);
 }
 
 fn test_bad_execution_output(func: Callback) {
@@ -630,7 +630,7 @@ fn test_uninitialized_signer(func: Callback) {
 // during key reconciliation!). For more fail cases, refer to debug messages in
 // reconcile_key()
 #[allow(dead_code)]
-fn test_a_missing_validator_key(func: Callback) {
+fn test_key_not_in_store(func: Callback) {
     let (mut safety_rules, signer) = func();
     let (proof, genesis_qc) = make_genesis(&signer);
     let round = genesis_qc.certified_block().round();
@@ -656,8 +656,8 @@ fn test_a_missing_validator_key(func: Callback) {
     safety_rules.update(a2.block().quorum_cert()).unwrap_err();
 }
 
-fn test_a_missing_validator(func: Callback) {
-    // Testing for an validator missing from the validator set
+fn test_validator_not_in_set(func: Callback) {
+    // Testing for a validator missing from the validator set
     // It does so by updating the safey rule to an epoch state, which does not contain the
     // current validator. The validator later fails to verify QC since it is no longer in the
     // validator set.

--- a/consensus/src/round_manager_test.rs
+++ b/consensus/src/round_manager_test.rs
@@ -334,7 +334,10 @@ fn vote_on_successful_proposal() {
         assert_eq!(vote_msg.vote().vote_data().proposed().id(), proposal_id);
         let consensus_state = node.round_manager.consensus_state();
         let waypoint = consensus_state.waypoint();
-        assert_eq!(consensus_state, ConsensusState::new(1, 1, 0, waypoint));
+        assert_eq!(
+            consensus_state,
+            ConsensusState::new(1, 1, 0, waypoint, true)
+        );
     });
 }
 
@@ -668,7 +671,7 @@ fn recover_on_restart() {
     let waypoint = consensus_state.waypoint();
     assert_eq!(
         consensus_state,
-        ConsensusState::new(1, num_proposals, 0, waypoint)
+        ConsensusState::new(1, num_proposals, 0, waypoint, true)
     );
     for (block, _) in data {
         assert_eq!(node.block_store.block_exists(block.id()), true);


### PR DESCRIPTION
<!--
Thank you for sending a PR. We appreciate you spending time to help improve the Libra project.

The project is undergoing daily changes. Pull Requests will be reviewed and responded to as time permits.
-->

## Motivation

This PR addresses the consensus key verification during epoch changes. Specifically, it verifiers the validator consensus key whenever there is a new epoch, started by start_new_epoch(). It ensures that the key is in the keys of validator set, otherwise it retrieves the appropriate one from the storage. 

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

The test considers the following cases:
1) when the validator's account address is not in the validator set,
2) when the account address is in but the key does not match.
  1. the retrieved key matches ==> the right path
  2. the retrieved key does not match (TODO: address) 

## Related PRs

(If this PR adds or changes functionality, please take some time to update the docs at https://github.com/libra/website, and link to your PR here.)
