### PR TITLE
[network] Allow pulling network identity from secure storage

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2797,6 +2797,7 @@ dependencies = [
  "libra-logger 0.1.0",
  "libra-mempool 0.1.0",
  "libra-metrics 0.1.0",
+ "libra-secure-storage 0.1.0",
  "libra-types 0.1.0",
  "libra-vm 0.1.0",
  "libra-workspace-hack 0.1.0",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2961,6 +2961,7 @@ dependencies = [
  "libra-config 0.1.0",
  "libra-crypto 0.1.0",
  "libra-logger 0.1.0",
+ "libra-secure-storage 0.1.0",
  "libra-temppath 0.1.0",
  "libra-types 0.1.0",
  "libra-workspace-hack 0.1.0",

--- a/config/config-builder/src/full_node_config.rs
+++ b/config/config-builder/src/full_node_config.rs
@@ -226,10 +226,9 @@ impl FullNodeConfig {
                 network.peer_id,
                 NetworkPeerInfo {
                     identity_public_key: network
-                        .identity_keypair
-                        .as_ref()
-                        .ok_or(Error::MissingNetworkKeyPairs)?
-                        .public_key(),
+                        .identity_key
+                        .public_key_from_config()
+                        .ok_or(Error::MissingNetworkKeyPairs)?,
                 },
             );
 

--- a/config/config-builder/src/main.rs
+++ b/config/config-builder/src/main.rs
@@ -87,7 +87,7 @@ struct FullNodeArgs {
     /// 'extend' will update the NodeConfig to include a new FullNode network configuration.
     output_dir: PathBuf,
     #[structopt(short = "p", long)]
-    /// Public network, doesn't use any authentication or encryption
+    /// Public network, doesn't require remote authentication
     public: bool,
     #[structopt(short = "t", long, parse(from_os_str))]
     /// Path to a template NodeConfig.

--- a/config/config-builder/src/validator_config.rs
+++ b/config/config-builder/src/validator_config.rs
@@ -309,7 +309,7 @@ mod test {
         network.seed_peers.verify_libranet_addrs().unwrap();
         let (seed_peer_id, seed_addrs) = network.seed_peers.seed_peers.iter().next().unwrap();
         assert_eq!(seed_addrs.len(), 1);
-        assert_ne!(&network.peer_id, seed_peer_id);
+        assert_ne!(&network.peer_id(), seed_peer_id);
         assert_ne!(&network.advertised_address, &seed_addrs[0]);
 
         assert_eq!(

--- a/config/global-constants/src/lib.rs
+++ b/config/global-constants/src/lib.rs
@@ -12,7 +12,9 @@
 pub const ASSOCIATION_KEY: &str = "association";
 pub const CONSENSUS_KEY: &str = "consensus";
 pub const FULLNODE_NETWORK_KEY: &str = "fullnode_network";
+pub const OPERATOR_ACCOUNT: &str = "operator_account";
 pub const OPERATOR_KEY: &str = "operator";
+pub const OWNER_ACCOUNT: &str = "owner_account";
 pub const OWNER_KEY: &str = "owner";
 pub const VALIDATOR_NETWORK_KEY: &str = "validator_network";
 

--- a/config/management/src/error.rs
+++ b/config/management/src/error.rs
@@ -18,6 +18,8 @@ pub enum Error {
     LocalStorageReadError(&'static str, String),
     #[error("Failed to sign {0} with {1} using local storage: {2}")]
     LocalStorageSigningError(&'static str, &'static str, String),
+    #[error("Failed to write, {0}, to local storage: {0}")]
+    LocalStorageWriteError(&'static str, String),
     #[error("Failed to read, {0}, from remote storage: {0}")]
     RemoteStorageReadError(&'static str, String),
     #[error("Failed to write, {0}, to remote storage: {0}")]

--- a/config/management/src/smoke_test.rs
+++ b/config/management/src/smoke_test.rs
@@ -4,7 +4,7 @@
 use crate::{layout::Layout, storage_helper::StorageHelper};
 use config_builder::{BuildSwarm, SwarmConfig};
 use libra_config::config::{
-    DiscoveryMethod, IdentityKey, NetworkConfig, NodeConfig, OnDiskStorageConfig, RoleType,
+    DiscoveryMethod, Identity, NetworkConfig, NodeConfig, OnDiskStorageConfig, RoleType,
     SecureBackend,
 };
 use libra_crypto::ed25519::Ed25519PrivateKey;
@@ -71,7 +71,6 @@ fn smoke_test() {
 
         let mut network = NetworkConfig::default();
         network.discovery_method = DiscoveryMethod::Onchain;
-        network.peer_id = validator_account;
         config.validator_network = Some(network);
 
         let mut network = NetworkConfig::default();
@@ -81,15 +80,17 @@ fn smoke_test() {
 
         let validator_network = config.validator_network.as_mut().unwrap();
         let validator_network_address = validator_network.listen_address.clone();
-        validator_network.identity_key = IdentityKey::from_storage(
+        validator_network.identity = Identity::from_storage(
             libra_global_constants::VALIDATOR_NETWORK_KEY.into(),
-            secure_backend(helper.path(), &swarm_path, &ns, "full_node"),
+            libra_global_constants::OPERATOR_ACCOUNT.into(),
+            secure_backend(helper.path(), &swarm_path, &ns, "validator"),
         );
 
         let fullnode_network = &mut config.full_node_networks[0];
         let fullnode_network_address = fullnode_network.listen_address.clone();
-        fullnode_network.identity_key = IdentityKey::from_storage(
+        fullnode_network.identity = Identity::from_storage(
             libra_global_constants::FULLNODE_NETWORK_KEY.into(),
+            libra_global_constants::OPERATOR_ACCOUNT.into(),
             secure_backend(helper.path(), &swarm_path, &ns, "full_node"),
         );
 

--- a/config/management/src/smoke_test.rs
+++ b/config/management/src/smoke_test.rs
@@ -120,12 +120,8 @@ fn smoke_test() {
         // 4 matches = 5 splits
         assert_eq!(output.split("match").count(), 5);
 
-        config.consensus.safety_rules.backend = secure_backend(
-            helper.path(),
-            &swarm_path,
-            &ns,
-            "safety-rules",
-        );
+        config.consensus.safety_rules.backend =
+            secure_backend(helper.path(), &swarm_path, &ns, "safety-rules");
 
         // TODO: this should be exclusively acquired via secure storage
         config.base.waypoint = Some(waypoint);

--- a/config/management/src/smoke_test.rs
+++ b/config/management/src/smoke_test.rs
@@ -3,11 +3,9 @@
 
 use crate::{layout::Layout, storage_helper::StorageHelper};
 use config_builder::{BuildSwarm, SwarmConfig};
-use libra_config::{
-    config::{
-        DiscoveryMethod, NetworkConfig, NodeConfig, OnDiskStorageConfig, RoleType, SecureBackend,
-    },
-    keys::KeyPair,
+use libra_config::config::{
+    DiscoveryMethod, IdentityKey, NetworkConfig, NodeConfig, OnDiskStorageConfig, RoleType,
+    SecureBackend,
 };
 use libra_crypto::{ed25519::Ed25519PrivateKey, x25519};
 use libra_secure_storage::Value;
@@ -85,7 +83,7 @@ fn smoke_test() {
             .unwrap();
         let identity_key =
             x25519::PrivateKey::from_ed25519_private_bytes(&identity_key.to_bytes()).unwrap();
-        validator_network.identity_keypair = Some(KeyPair::load(identity_key));
+        validator_network.identity_key = IdentityKey::from_config(identity_key);
 
         let fullnode_network = &mut config.full_node_networks[0];
         let identity_key = storage
@@ -93,7 +91,7 @@ fn smoke_test() {
             .unwrap();
         let identity_key =
             x25519::PrivateKey::from_ed25519_private_bytes(&identity_key.to_bytes()).unwrap();
-        fullnode_network.identity_keypair = Some(KeyPair::load(identity_key));
+        fullnode_network.identity_key = IdentityKey::from_config(identity_key);
         let fullnode_network_address = fullnode_network.listen_address.clone();
 
         configs.push(config);

--- a/config/management/src/storage_helper.rs
+++ b/config/management/src/storage_helper.rs
@@ -30,6 +30,10 @@ impl StorageHelper {
         Box::new(NamespacedStorage::new(storage, namespace))
     }
 
+    pub fn path(&self) -> &Path {
+        self.temppath.path()
+    }
+
     pub fn path_string(&self) -> &str {
         self.temppath.path().to_str().unwrap()
     }

--- a/config/src/config/mod.rs
+++ b/config/src/config/mod.rs
@@ -380,7 +380,7 @@ mod test {
 
         expected_network.advertised_address = actual_network.advertised_address.clone();
         expected_network.listen_address = actual_network.listen_address.clone();
-        expected_network.identity_key = actual_network.identity_key.clone();
+        expected_network.identity = actual_network.identity.clone();
         expected_network.network_peers = actual_network.network_peers.clone();
         expected_network.seed_peers = actual_network.seed_peers.clone();
         expected_network.seed_peers_file = actual_network.seed_peers_file.clone();

--- a/config/src/config/mod.rs
+++ b/config/src/config/mod.rs
@@ -159,7 +159,7 @@ impl NodeConfig {
         self.storage.set_data_dir(data_dir);
     }
 
-    /// This clones the underlying data except for the keypair so that this config can be used as a
+    /// This clones the underlying data except for the keys so that this config can be used as a
     /// template for another config.
     pub fn clone_for_template(&self) -> Self {
         Self {
@@ -380,7 +380,7 @@ mod test {
 
         expected_network.advertised_address = actual_network.advertised_address.clone();
         expected_network.listen_address = actual_network.listen_address.clone();
-        expected_network.identity_keypair = actual_network.identity_keypair.clone();
+        expected_network.identity_key = actual_network.identity_key.clone();
         expected_network.network_peers = actual_network.network_peers.clone();
         expected_network.seed_peers = actual_network.seed_peers.clone();
         expected_network.seed_peers_file = actual_network.seed_peers_file.clone();

--- a/config/src/config/network_config.rs
+++ b/config/src/config/network_config.rs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::{
-    config::{PersistableConfig, RoleType, RootPath},
+    config::{PersistableConfig, RoleType, RootPath, SecureBackend},
     keys::KeyPair,
     utils,
 };
@@ -263,12 +263,8 @@ impl IdentityKey {
         IdentityKey::FromConfig(KeyFromConfig { keypair })
     }
 
-    pub fn private_key_from_config(&mut self) -> Option<x25519::PrivateKey> {
-        if let IdentityKey::FromConfig(config) = self {
-            config.keypair.take_private()
-        } else {
-            None
-        }
+    pub fn from_storage(key_name: String, backend: SecureBackend) -> Self {
+        IdentityKey::FromStorage(KeyFromStorage { key_name, backend })
     }
 
     pub fn public_key_from_config(&self) -> Option<x25519::PublicKey> {
@@ -294,6 +290,7 @@ pub struct KeyFromConfig {
 #[derive(Debug, Deserialize, Serialize)]
 pub struct KeyFromStorage {
     pub key_name: String,
+    pub backend: SecureBackend,
 }
 
 #[cfg(test)]

--- a/config/src/config/test_data/random.complete.node.config.toml
+++ b/config/src/config/test_data/random.complete.node.config.toml
@@ -72,7 +72,6 @@ consensus_private_key = "2f8b53541ed20ddaa5dea1b78f1fc08446de1f93b0e07080f7f2ee9
 initialize_storage = true
 
 [validator_network]
-peer_id = "31893204fa402143c11b26ce8a89ea1d"
 listen_address = "/ip4/0.0.0.0/tcp/6180"
 advertised_address = "/ip4/127.0.0.1/tcp/6180"
 discovery_interval_ms = 1000
@@ -80,6 +79,8 @@ connectivity_check_interval_ms = 5000
 enable_remote_authentication = true
 network_peers_file = ""
 seed_peers_file = "31893204fa402143c11b26ce8a89ea1d.seed_peers.toml"
-[validator_network.identity_key]
+
+[validator_network.identity]
 type = "from_config"
 key = "60dd107034b4582a2ef42c5e1ea475f2fea477a10a9f1d75b3635243b2506b72"
+peer_id = "31893204fa402143c11b26ce8a89ea1d"

--- a/config/src/config/test_data/random.complete.node.config.toml
+++ b/config/src/config/test_data/random.complete.node.config.toml
@@ -81,4 +81,6 @@ enable_noise = true
 enable_remote_authentication = true
 network_peers_file = ""
 seed_peers_file = "31893204fa402143c11b26ce8a89ea1d.seed_peers.toml"
-identity_private_key = "60dd107034b4582a2ef42c5e1ea475f2fea477a10a9f1d75b3635243b2506b72"
+[validator_network.identity_key]
+type = "from_config"
+key = "60dd107034b4582a2ef42c5e1ea475f2fea477a10a9f1d75b3635243b2506b72"

--- a/config/src/config/test_data/random.complete.node.config.toml
+++ b/config/src/config/test_data/random.complete.node.config.toml
@@ -77,7 +77,6 @@ listen_address = "/ip4/0.0.0.0/tcp/6180"
 advertised_address = "/ip4/127.0.0.1/tcp/6180"
 discovery_interval_ms = 1000
 connectivity_check_interval_ms = 5000
-enable_noise = true
 enable_remote_authentication = true
 network_peers_file = ""
 seed_peers_file = "31893204fa402143c11b26ce8a89ea1d.seed_peers.toml"

--- a/config/src/config/test_data/random.default.node.config.toml
+++ b/config/src/config/test_data/random.default.node.config.toml
@@ -1,10 +1,10 @@
 [validator_network]
-peer_id = "31893204fa402143c11b26ce8a89ea1d"
 seed_peers_file = "31893204fa402143c11b26ce8a89ea1d.seed_peers.toml"
 
-[validator_network.identity_key]
+[validator_network.identity]
 type = "from_config"
 key = "60dd107034b4582a2ef42c5e1ea475f2fea477a10a9f1d75b3635243b2506b72"
+peer_id = "31893204fa402143c11b26ce8a89ea1d"
 
 [test]
 auth_key = "837e3b2b2b32ee2543c24676ee66326431893204fa402143c11b26ce8a89ea1d"

--- a/config/src/config/test_data/random.default.node.config.toml
+++ b/config/src/config/test_data/random.default.node.config.toml
@@ -1,7 +1,10 @@
 [validator_network]
 peer_id = "31893204fa402143c11b26ce8a89ea1d"
 seed_peers_file = "31893204fa402143c11b26ce8a89ea1d.seed_peers.toml"
-identity_private_key = "60dd107034b4582a2ef42c5e1ea475f2fea477a10a9f1d75b3635243b2506b72"
+
+[validator_network.identity_key]
+type = "from_config"
+key = "60dd107034b4582a2ef42c5e1ea475f2fea477a10a9f1d75b3635243b2506b72"
 
 [test]
 auth_key = "837e3b2b2b32ee2543c24676ee66326431893204fa402143c11b26ce8a89ea1d"

--- a/config/src/config/test_data/single.node.config.toml
+++ b/config/src/config/test_data/single.node.config.toml
@@ -42,7 +42,6 @@ listen_address = "/ip4/0.0.0.0/tcp/65206"
 advertised_address = "/ip4/0.0.0.0/tcp/65206"
 discovery_interval_ms = 1000
 connectivity_check_interval_ms = 5000
-enable_noise = true
 enable_remote_authentication = true
 network_peers_file = ""
 seed_peers_file = ""

--- a/config/src/config/test_data/single.node.config.toml
+++ b/config/src/config/test_data/single.node.config.toml
@@ -37,7 +37,6 @@ consensus_private_key = "9f07e7be5551387a98ba977c732d080dcb0f29a048e3656912c6533
 initialize_storage = true
 
 [validator_network]
-peer_id = "1a398451c5c11e1e76e64cdc7b588510"
 listen_address = "/ip4/0.0.0.0/tcp/65206"
 advertised_address = "/ip4/0.0.0.0/tcp/65206"
 discovery_interval_ms = 1000
@@ -45,6 +44,11 @@ connectivity_check_interval_ms = 5000
 enable_remote_authentication = true
 network_peers_file = ""
 seed_peers_file = ""
+
+[validator_network.identity]
+type = "from_config"
+key = "60dd107034b4582a2ef42c5e1ea475f2fea477a10a9f1d75b3635243b2506b72"
+peer_id = "31893204fa402143c11b26ce8a89ea1d"
 
 [consensus]
 max_block_size = 1000

--- a/config/src/generator.rs
+++ b/config/src/generator.rs
@@ -59,10 +59,10 @@ pub fn build_seed_peers(
     seed_base_addr: NetworkAddress,
 ) -> SeedPeersConfig {
     let seed_pubkey = seed_config
-        .identity_keypair
-        .as_ref()
-        .expect("Missing identity keypair")
-        .public_key();
+        .identity_key
+        .public_key_from_config()
+        .expect("Missing identity key");
+
     let seed_addr = seed_base_addr.append_prod_protos(seed_pubkey, HANDSHAKE_VERSION);
 
     let mut seed_peers = SeedPeersConfig::default();

--- a/config/src/generator.rs
+++ b/config/src/generator.rs
@@ -29,7 +29,9 @@ pub fn validator_swarm(
 
         // For a validator node, any of its validator peers are considered an upstream peer
         let network = node.validator_network.as_mut().unwrap();
-        node.upstream.primary_networks.push(network.peer_id);
+        node.upstream
+            .primary_networks
+            .push(network.identity.peer_id_from_config().unwrap());
 
         nodes.push(node);
     }
@@ -59,16 +61,16 @@ pub fn build_seed_peers(
     seed_base_addr: NetworkAddress,
 ) -> SeedPeersConfig {
     let seed_pubkey = seed_config
-        .identity_key
+        .identity
         .public_key_from_config()
         .expect("Missing identity key");
-
     let seed_addr = seed_base_addr.append_prod_protos(seed_pubkey, HANDSHAKE_VERSION);
 
     let mut seed_peers = SeedPeersConfig::default();
-    seed_peers
-        .seed_peers
-        .insert(seed_config.peer_id, vec![seed_addr]);
+    seed_peers.seed_peers.insert(
+        seed_config.identity.peer_id_from_config().unwrap(),
+        vec![seed_addr],
+    );
     seed_peers
         .verify_libranet_addrs()
         .expect("Expect LibraNet addresses");

--- a/consensus/safety-rules/src/process_client_wrapper.rs
+++ b/consensus/safety-rules/src/process_client_wrapper.rs
@@ -52,7 +52,13 @@ impl<T: Payload> ProcessClientWrapper<T> {
         let mut config = NodeConfig::random();
 
         let mut test_config = config.test.as_ref().unwrap().clone();
-        let author = config.validator_network.as_ref().unwrap().peer_id;
+        let author = config
+            .validator_network
+            .as_ref()
+            .unwrap()
+            .identity
+            .peer_id_from_config()
+            .unwrap();
         let private_key = test_config
             .consensus_keypair
             .as_mut()

--- a/consensus/safety-rules/src/safety_rules_manager.rs
+++ b/consensus/safety-rules/src/safety_rules_manager.rs
@@ -13,7 +13,7 @@ use crate::{
 };
 use consensus_types::common::{Author, Payload};
 use libra_config::config::{NodeConfig, SafetyRulesService};
-use libra_secure_storage::Storage;
+use libra_secure_storage::{config, Storage};
 use std::{
     convert::TryInto,
     net::SocketAddr,
@@ -21,11 +21,12 @@ use std::{
 };
 
 pub fn extract_service_inputs(config: &mut NodeConfig) -> (Author, PersistentSafetyStorage) {
-    let author = config
-        .validator_network
-        .as_ref()
-        .expect("Missing validator network")
-        .peer_id;
+    let author = config::peer_id(
+        config
+            .validator_network
+            .as_ref()
+            .expect("Missing validator network"),
+    );
 
     let backend = &config.consensus.safety_rules.backend;
     let internal_storage: Box<dyn Storage> =

--- a/consensus/src/epoch_manager.rs
+++ b/consensus/src/epoch_manager.rs
@@ -27,6 +27,7 @@ use consensus_types::{
 use futures::{select, StreamExt};
 use libra_config::config::{ConsensusConfig, ConsensusProposerType, NodeConfig};
 use libra_logger::prelude::*;
+use libra_secure_storage::config;
 use libra_types::{
     account_address::AccountAddress,
     epoch_change::EpochChangeProof,
@@ -92,7 +93,7 @@ impl<T: Payload> EpochManager<T> {
         state_computer: Arc<dyn StateComputer<Payload = T>>,
         storage: Arc<dyn PersistentLivenessStorage<T>>,
     ) -> Self {
-        let author = node_config.validator_network.as_ref().unwrap().peer_id;
+        let author = config::peer_id(node_config.validator_network.as_ref().unwrap());
         let config = node_config.consensus.clone();
         let safety_rules_manager = SafetyRulesManager::new(node_config);
         Self {

--- a/consensus/src/twins_test.rs
+++ b/consensus/src/twins_test.rs
@@ -53,7 +53,7 @@ impl SMRNode {
         smr_id: usize,
         storage: Arc<MockStorage<TestPayload>>,
     ) -> Self {
-        let author = config.validator_network.as_ref().unwrap().peer_id;
+        let author = config.validator_network.as_ref().unwrap().peer_id();
 
         let (network_reqs_tx, network_reqs_rx) =
             libra_channel::new(QueueStyle::FIFO, NonZeroUsize::new(8).unwrap(), None);
@@ -138,7 +138,7 @@ impl SMRNode {
                 .iter()
                 .map(|config| {
                     ValidatorInfo::new_with_test_network_keys(
-                        config.validator_network.as_ref().unwrap().peer_id, // account address
+                        config.validator_network.as_ref().unwrap().peer_id(), // account address
                         config
                             .test
                             .as_ref()
@@ -147,7 +147,7 @@ impl SMRNode {
                             .as_ref()
                             .unwrap()
                             .public_key(), // consensus pubkey
-                        1,                                                  // voting power
+                        1,                                                    // voting power
                     )
                 })
                 .collect(),

--- a/execution/executor-test-helpers/src/lib.rs
+++ b/execution/executor-test-helpers/src/lib.rs
@@ -49,7 +49,7 @@ pub fn gen_ledger_info_with_sigs(
 
 pub fn extract_signer(config: &mut NodeConfig) -> ValidatorSigner {
     ValidatorSigner::new(
-        config.validator_network.as_ref().unwrap().peer_id,
+        config.validator_network.as_ref().unwrap().peer_id(),
         config
             .test
             .as_mut()

--- a/execution/executor/tests/storage_integration_test.rs
+++ b/execution/executor/tests/storage_integration_test.rs
@@ -81,7 +81,7 @@ fn test_reconfiguration() {
 
     let genesis_account = association_address();
     let network_config = config.validator_network.as_ref().unwrap();
-    let validator_account = network_config.peer_id;
+    let validator_account = network_config.peer_id();
     let keys = config
         .test
         .as_mut()
@@ -172,7 +172,7 @@ fn test_change_publishing_option_to_custom() {
 
     let genesis_account = association_address();
     let network_config = config.validator_network.as_ref().unwrap();
-    let validator_account = network_config.peer_id;
+    let validator_account = network_config.peer_id();
     let keys = config
         .test
         .as_mut()
@@ -339,7 +339,7 @@ fn test_extend_whitelist() {
 
     let genesis_account = association_address();
     let network_config = config.validator_network.as_ref().unwrap();
-    let validator_account = network_config.peer_id;
+    let validator_account = network_config.peer_id();
     let keys = config
         .test
         .as_mut()

--- a/language/functional-tests/src/config/global.rs
+++ b/language/functional-tests/src/config/global.rs
@@ -166,7 +166,7 @@ impl Config {
                 .nodes
                 .iter_mut()
                 .map(|c| {
-                    let peer_id = c.validator_network.as_ref().unwrap().peer_id;
+                    let peer_id = c.validator_network.as_ref().unwrap().peer_id();
                     let account_keypair =
                         c.test.as_mut().unwrap().operator_keypair.as_mut().unwrap();
                     let privkey = account_keypair.take_private().unwrap();

--- a/language/tools/vm-genesis/src/lib.rs
+++ b/language/tools/vm-genesis/src/lib.rs
@@ -334,7 +334,7 @@ pub fn validator_registrations(node_configs: &[NodeConfig]) -> Vec<ValidatorRegi
             let account_key = test.operator_keypair.as_ref().unwrap().public_key();
             let consensus_key = test.consensus_keypair.as_ref().unwrap().public_key();
             let network = n.validator_network.as_ref().unwrap();
-            let identity_key = network.identity_key.public_key_from_config().unwrap();
+            let identity_key = network.identity.public_key_from_config().unwrap();
 
             let advertised_address = network
                 .advertised_address

--- a/language/tools/vm-genesis/src/lib.rs
+++ b/language/tools/vm-genesis/src/lib.rs
@@ -334,7 +334,7 @@ pub fn validator_registrations(node_configs: &[NodeConfig]) -> Vec<ValidatorRegi
             let account_key = test.operator_keypair.as_ref().unwrap().public_key();
             let consensus_key = test.consensus_keypair.as_ref().unwrap().public_key();
             let network = n.validator_network.as_ref().unwrap();
-            let identity_key = network.identity_keypair.as_ref().unwrap().public_key();
+            let identity_key = network.identity_key.public_key_from_config().unwrap();
 
             let advertised_address = network
                 .advertised_address

--- a/libra-node/Cargo.toml
+++ b/libra-node/Cargo.toml
@@ -20,29 +20,30 @@ tonic = "0.2.1"
 admission-control-proto = { path = "../admission-control/admission-control-proto", version = "0.1.0" }
 admission-control-service = { path = "../admission-control/admission-control-service", version = "0.1.0" }
 backup-service = { path = "../storage/backup/backup-service", version = "0.1.0" }
-libra-config = { path = "../config", version = "0.1.0" }
-libradb = { path = "../storage/libradb", version = "0.1.0" }
 consensus = { path = "../consensus", version = "0.1.0" }
 crash-handler = { path = "../common/crash-handler", version = "0.1.0" }
 debug-interface = { path = "../common/debug-interface", version = "0.1.0" }
 executor = { path = "../execution/executor", version = "0.1.0" }
 executor-types = { path = "../execution/executor-types", version = "0.1.0" }
+libra-config = { path = "../config", version = "0.1.0" }
+libra-crypto = { path = "../crypto/crypto", version = "0.1.0" }
+libra-json-rpc = { path = "../json-rpc", version = "0.1.0" }
 libra-logger = { path = "../common/logger", version = "0.1.0" }
 libra-mempool = { path = "../mempool", version = "0.1.0" }
 libra-metrics = { path = "../common/metrics", version = "0.1.0" }
-libra-crypto = { path = "../crypto/crypto", version = "0.1.0" }
+libra-secure-storage = { path = "../secure/storage", version = "0.1.0" }
+libra-types = { path = "../types", version = "0.1.0" }
+libra-vm = { path = "../language/libra-vm", version = "0.1.0" }
+libra-workspace-hack = { path = "../common/workspace-hack", version = "0.1.0" }
+libradb = { path = "../storage/libradb", version = "0.1.0" }
 network = { path = "../network", version = "0.1.0" }
 network-simple-onchain-discovery = { path = "../network/simple-onchain-discovery", version = "0.1.0"}
 onchain-discovery = { path = "../network/onchain-discovery", version = "0.1.0" }
-libra-json-rpc = { path = "../json-rpc", version = "0.1.0" }
 storage-client = { path = "../storage/storage-client", version = "0.1.0" }
 state-synchronizer = { path = "../state-synchronizer", version = "0.1.0" }
 storage-interface= { path = "../storage/storage-interface", version = "0.1.0" }
 storage-service = { path = "../storage/storage-service", version = "0.1.0" }
 subscription-service = { path = "../common/subscription-service", version = "0.1.0" }
-libra-types = { path = "../types", version = "0.1.0" }
-libra-vm = { path = "../language/libra-vm", version = "0.1.0" }
-libra-workspace-hack = { path = "../common/workspace-hack", version = "0.1.0" }
 
 [features]
 default = []

--- a/libra-node/src/main.rs
+++ b/libra-node/src/main.rs
@@ -4,6 +4,7 @@
 #![forbid(unsafe_code)]
 
 use libra_config::config::NodeConfig;
+use libra_secure_storage::config;
 use libra_types::PeerId;
 use std::{
     path::PathBuf,
@@ -46,11 +47,13 @@ fn main() {
 
     if config.metrics.enabled {
         for network in &config.full_node_networks {
-            setup_metrics(network.peer_id, &config);
+            let peer_id = config::peer_id(&network);
+            setup_metrics(peer_id, &config);
         }
 
         if let Some(network) = config.validator_network.as_ref() {
-            setup_metrics(network.peer_id, &config);
+            let peer_id = config::peer_id(&network);
+            setup_metrics(peer_id, &config);
         }
     }
 

--- a/libra-node/src/main_node.rs
+++ b/libra-node/src/main_node.rs
@@ -153,10 +153,8 @@ pub fn setup_network(
         let seed_peers = config.seed_peers.seed_peers.clone();
 
         let identity_key = config
-            .identity_keypair
-            .as_mut()
-            .expect("identity keypair should be present")
-            .take_private()
+            .identity_key
+            .private_key_from_config()
             .expect("identity key should be present");
 
         let trusted_peers = if role == RoleType::Validator {
@@ -181,10 +179,8 @@ pub fn setup_network(
             .add_connectivity_manager();
     } else if config.enable_noise {
         let identity_key = config
-            .identity_keypair
-            .as_mut()
-            .expect("identity keypairs should be present")
-            .take_private()
+            .identity_key
+            .private_key_from_config()
             .expect("identity key should be present");
 
         // Even if a network end-point operates without remote authentication, it might want to prove

--- a/libra-node/src/main_node.rs
+++ b/libra-node/src/main_node.rs
@@ -138,12 +138,6 @@ pub fn setup_network(
     // config per "archetype"?
 
     if config.enable_remote_authentication {
-        // If the node wants to run in permissioned mode, it should also have authentication and
-        // encryption.
-        assert!(
-            config.enable_noise,
-            "Permissioned network end-points must use authentication"
-        );
         // Sanity check seed peer addresses.
         config
             .seed_peers
@@ -175,7 +169,7 @@ pub fn setup_network(
             .connectivity_check_interval_ms(config.connectivity_check_interval_ms)
             // TODO:  Why is the connectivity manager related to remote_authentication?
             .add_connectivity_manager();
-    } else if config.enable_noise {
+    } else {
         let identity_key = retrieve_network_identity_key(config);
 
         // Even if a network end-point operates without remote authentication, it might want to prove
@@ -184,10 +178,6 @@ pub fn setup_network(
         network_builder
             .authentication_mode(AuthenticationMode::ServerOnly(identity_key))
             .advertised_address(config.advertised_address.clone());
-    } else {
-        // TODO(philiphayes): probably remove this branch since there are no
-        // current no noise or no client auth use cases.
-        network_builder.authentication_mode(AuthenticationMode::Unauthenticated);
     }
 
     match config.discovery_method {

--- a/mempool/src/tests/mocks.rs
+++ b/mempool/src/tests/mocks.rs
@@ -11,7 +11,7 @@ use anyhow::{format_err, Result};
 use channel::{self, libra_channel, message_queues::QueueStyle};
 use futures::channel::{mpsc, oneshot};
 use libra_config::config::{NetworkConfig, NodeConfig};
-use libra_types::{mempool_status::MempoolStatusCode, transaction::SignedTransaction, PeerId};
+use libra_types::{mempool_status::MempoolStatusCode, transaction::SignedTransaction};
 use network::peer_manager::{
     conn_notifs_channel, ConnectionRequestSender, PeerManagerRequestSender,
 };
@@ -48,11 +48,9 @@ impl MockSharedMempool {
             .build()
             .expect("[mock shared mempool] failed to create runtime");
 
-        let peer_id = PeerId::random();
-        let mut validator_network_config = NetworkConfig::default();
-        validator_network_config.peer_id = peer_id;
         let mut config = NodeConfig::random();
-        config.validator_network = Some(validator_network_config);
+        config.validator_network = Some(NetworkConfig::default());
+        let peer_id = config.validator_network.as_ref().unwrap().peer_id();
 
         let mempool = Arc::new(Mutex::new(CoreMempool::new(&config)));
         let (network_reqs_tx, _network_reqs_rx) =

--- a/mempool/src/tests/shared_mempool_test.rs
+++ b/mempool/src/tests/shared_mempool_test.rs
@@ -181,11 +181,9 @@ impl SharedMempoolNetwork {
         let mut peers = vec![];
 
         for _ in 0..validator_nodes_count {
-            let peer_id = PeerId::random();
-            let mut validator_network_config = NetworkConfig::default();
-            validator_network_config.peer_id = peer_id;
             let mut config = NodeConfig::random();
-            config.validator_network = Some(validator_network_config);
+            config.validator_network = Some(NetworkConfig::default());
+            let peer_id = config.validator_network.as_ref().unwrap().peer_id();
             config.mempool.shared_mempool_batch_size = broadcast_batch_size;
             config.upstream = UpstreamConfig::default();
             config.upstream.primary_networks.push(peer_id);

--- a/network/onchain-discovery/src/test.rs
+++ b/network/onchain-discovery/src/test.rs
@@ -258,7 +258,7 @@ fn service_handles_remote_query() {
     ::libra_logger::Logger::new().environment_only(true).init();
     let mut rt = Runtime::new().unwrap();
     let config = gen_configs(1).swap_remove(0);
-    let self_peer_id = config.validator_network.as_ref().unwrap().peer_id;
+    let self_peer_id = config.validator_network.as_ref().unwrap().peer_id();
     let role = config.base.role;
 
     let (libra_db, _executor, waypoint) = setup_storage_service_and_executor(&config);
@@ -315,7 +315,7 @@ fn queries_storage_on_tick() {
     ::libra_logger::Logger::new().environment_only(true).init();
     let mut rt = Runtime::new().unwrap();
     let config = gen_configs(1).swap_remove(0);
-    let self_peer_id = config.validator_network.as_ref().unwrap().peer_id;
+    let self_peer_id = config.validator_network.as_ref().unwrap().peer_id();
     let role = config.base.role;
 
     let (libra_db, _executor, waypoint) = setup_storage_service_and_executor(&config);
@@ -375,7 +375,7 @@ fn queries_peers_on_tick() {
     // server setup
 
     let server_config = configs.swap_remove(0);
-    let server_peer_id = server_config.validator_network.as_ref().unwrap().peer_id;
+    let server_peer_id = server_config.validator_network.as_ref().unwrap().peer_id();
     let server_role = server_config.base.role;
 
     let (server_libra_db, _server_executor, waypoint) =
@@ -400,7 +400,7 @@ fn queries_peers_on_tick() {
     // client setup
 
     let client_config = configs.swap_remove(0);
-    let client_peer_id = client_config.validator_network.as_ref().unwrap().peer_id;
+    let client_peer_id = client_config.validator_network.as_ref().unwrap().peer_id();
     let client_role = client_config.base.role;
 
     let (libra_db, _executor, waypoint) = setup_storage_service_and_executor(&client_config);

--- a/network/src/validator_network/network_builder.rs
+++ b/network/src/validator_network/network_builder.rs
@@ -183,6 +183,10 @@ impl NetworkBuilder {
         }
     }
 
+    pub fn peer_id(&self) -> PeerId {
+        self.peer_id
+    }
+
     /// Set network authentication mode.
     pub fn authentication_mode(&mut self, authentication_mode: AuthenticationMode) -> &mut Self {
         self.authentication_mode = Some(authentication_mode);

--- a/secure/key-manager/src/main.rs
+++ b/secure/key-manager/src/main.rs
@@ -52,6 +52,8 @@ fn create_and_execute_key_manager(key_manager_config: KeyManagerConfig) -> Resul
     let time_service = RealTimeService::new();
 
     KeyManager::new(
+        // TODO(joshlind/davidiw): This needs to be pulled from storage OPERATOR_ACCOUNT for now
+        // and eventually OWNER_ACCOUNT
         key_manager_config.validator_account,
         libra_interface,
         BoxStorage(storage),

--- a/secure/key-manager/src/tests.rs
+++ b/secure/key-manager/src/tests.rs
@@ -293,7 +293,7 @@ fn create_test_configs() -> (NodeConfig, KeyManagerConfig) {
     let (node_config, _genesis_key) = config_builder::test_config();
 
     let mut key_manager_config = KeyManagerConfig::default();
-    key_manager_config.validator_account = node_config.validator_network.clone().unwrap().peer_id;
+    key_manager_config.validator_account = node_config.validator_network.clone().unwrap().peer_id();
 
     (node_config, key_manager_config)
 }

--- a/secure/storage/src/config.rs
+++ b/secure/storage/src/config.rs
@@ -1,0 +1,48 @@
+// Copyright (c) The Libra Core Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::Storage;
+use libra_config::config::{Identity, NetworkConfig};
+use libra_crypto::x25519;
+use libra_types::PeerId;
+use std::convert::TryInto;
+
+pub fn identity_key(config: &mut NetworkConfig) -> x25519::PrivateKey {
+    let key = match &mut config.identity {
+        Identity::FromConfig(config) => config.keypair.take_private(),
+        Identity::FromStorage(config) => {
+            let storage: Box<dyn Storage> = (&config.backend).into();
+            let key = storage
+                .export_private_key(&config.key_name)
+                .expect("Unable to read key");
+            let key = x25519::PrivateKey::from_ed25519_private_bytes(&key.to_bytes())
+                .expect("Unable to convert key");
+            Some(key)
+        }
+        Identity::None => None,
+    };
+    key.expect("identity key should be present")
+}
+
+pub fn peer_id(config: &NetworkConfig) -> PeerId {
+    let key = match &config.identity {
+        Identity::FromConfig(config) => Some(config.peer_id),
+        Identity::FromStorage(config) => {
+            let storage: Box<dyn Storage> = (&config.backend).into();
+            println!(
+                "{} {:?}",
+                config.peer_id_name,
+                storage.get(&config.peer_id_name)
+            );
+            let peer_id = storage
+                .get(&config.peer_id_name)
+                .expect("Unable to read peer id")
+                .value
+                .string()
+                .expect("Expected string for peer id");
+            Some(peer_id.try_into().expect("Unable to parse peer id"))
+        }
+        Identity::None => None,
+    };
+    key.expect("peer id should be present")
+}

--- a/secure/storage/src/lib.rs
+++ b/secure/storage/src/lib.rs
@@ -6,6 +6,7 @@
 use libra_config::config::SecureBackend;
 use std::convert::From;
 
+pub mod config;
 mod crypto_kv_storage;
 mod crypto_storage;
 mod error;

--- a/state-synchronizer/src/tests/integration_tests.rs
+++ b/state-synchronizer/src/tests/integration_tests.rs
@@ -257,11 +257,9 @@ impl SynchronizerEnv {
         let peer_addr = network_builder.build();
 
         let mut config = config_builder::test_config().0;
-        let mut network = config.validator_network.unwrap();
-        let mut network_id = network.peer_id;
+        let network = config.validator_network.unwrap();
+        let network_id = network.peer_id();
         if !role.is_validator() {
-            network.peer_id = PeerId::default();
-            network_id = network.peer_id;
             config.full_node_networks = vec![network];
             config.validator_network = None;
         }

--- a/state-synchronizer/src/tests/on_chain_config_tests.rs
+++ b/state-synchronizer/src/tests/on_chain_config_tests.rs
@@ -75,7 +75,7 @@ fn test_on_chain_config_pub_sub() {
     //////////////////////////////////////////////////
     let genesis_account = association_address();
     let network_config = config.validator_network.as_ref().unwrap();
-    let validator_account = network_config.peer_id;
+    let validator_account = network_config.peer_id();
     let keys = config
         .test
         .as_mut()

--- a/testsuite/libra-swarm/Cargo.toml
+++ b/testsuite/libra-swarm/Cargo.toml
@@ -18,8 +18,9 @@ config-builder = { path = "../../config/config-builder", version = "0.1.0" }
 libra-config = { path = "../../config", version = "0.1.0", features = ["fuzzing"] }
 debug-interface = { path = "../../common/debug-interface", version = "0.1.0" }
 generate-key = { path = "../../config/generate-key", version = "0.1.0" }
-libra-logger = { path = "../../common/logger", version = "0.1.0" }
 libra-crypto = { path = "../../crypto/crypto", version = "0.1.0", features = ["cloneable-private-keys"] }
+libra-logger = { path = "../../common/logger", version = "0.1.0" }
+libra-secure-storage = { path = "../../secure/storage", version = "0.1.0" }
 libra-temppath = { path = "../../common/temppath", version = "0.1.0" }
 libra-types = { path = "../../types", version = "0.1.0" }
 libra-workspace-hack = { path = "../../common/workspace-hack", version = "0.1.0" }

--- a/testsuite/libra-swarm/src/swarm.rs
+++ b/testsuite/libra-swarm/src/swarm.rs
@@ -6,6 +6,7 @@ use config_builder::{FullNodeConfig, SwarmConfig, ValidatorConfig};
 use debug_interface::NodeDebugClient;
 use libra_config::config::{NodeConfig, RoleType};
 use libra_logger::prelude::*;
+use libra_secure_storage::config;
 use libra_temppath::TempPath;
 use libra_types::account_address::AccountAddress;
 use std::{
@@ -71,7 +72,9 @@ impl LibraNode {
             .unwrap_or_else(|_| panic!("Failed to load NodeConfig from file: {:?}", config_path));
         let log_file = File::create(&log_path)?;
         let validator_peer_id = match role {
-            RoleType::Validator => Some(config.validator_network.unwrap().peer_id),
+            RoleType::Validator => {
+                Some(config::peer_id(config.validator_network.as_ref().unwrap()))
+            }
             RoleType::FullNode => None,
         };
         let mut node_command = Command::new(workspace_builder::get_bin(LIBRA_NODE_BIN));

--- a/testsuite/tests/libratest/smoke_test.rs
+++ b/testsuite/tests/libratest/smoke_test.rs
@@ -1286,7 +1286,7 @@ fn test_key_manager_consensus_rotation() {
     key_manager_config.json_rpc_endpoint = json_rpc_endpoint.clone();
     key_manager_config.rotation_period_secs = 10;
     key_manager_config.sleep_period_secs = 10;
-    key_manager_config.validator_account = node_config.validator_network.clone().unwrap().peer_id;
+    key_manager_config.validator_account = node_config.validator_network.clone().unwrap().peer_id();
     let mut on_disk_storage_config = OnDiskStorageConfig::default();
     on_disk_storage_config.path =
         node_config_path.with_file_name(on_disk_storage_config.path.clone());
@@ -1313,7 +1313,7 @@ fn test_key_manager_consensus_rotation() {
 
     // Create a json-rpc connection to the blockchain and verify storage matches the on-chain state.
     let libra_interface = JsonRpcLibraInterface::new(json_rpc_endpoint);
-    let account = node_config.validator_network.clone().unwrap().peer_id;
+    let account = node_config.validator_network.clone().unwrap().peer_id();
     let current_consensus = storage.get_public_key(CONSENSUS_KEY).unwrap().public_key;
     let validator_info = libra_interface.retrieve_validator_info(account).unwrap();
     assert_eq!(&current_consensus, validator_info.consensus_public_key());


### PR DESCRIPTION
This PR is pretty straight forward:

* Add a means to specify where the networking key is coming from (config or storage)
* Actually enable pulling the keys from storage
* Enable pulling peer id from storage
* Update management smoke test to ensure proper end-to-end correctness, so awesome
* Remove no noise transports from config
* Make the default networking config valid by having a key / peer id
* Updates the peer id config handling to match our hardening issue: https://github.com/libra/libra/issues/3985

The management smoke tests is the proof of correctness