### PR TITLE
[move-prover] Fixed debug function spec counter

### DIFF
--- a/language/move-prover/src/bytecode_translator.rs
+++ b/language/move-prover/src/bytecode_translator.rs
@@ -349,7 +349,7 @@ impl<'env> ModuleTranslator<'env> {
             if !func_env.is_native() {
                 num_fun += 1;
             }
-            if !func_env.get_spec().has_conditions() && !func_env.is_native() {
+            if func_env.get_spec().has_conditions() && !func_env.is_native() {
                 num_fun_specified += 1;
             }
             self.writer.set_location(&func_env.get_loc());


### PR DESCRIPTION
Counter was reversed and printing (n-m)/n functions
are specified instead of m/n, where n is the total
number of functions and m is the number of functions
with specifications.

Fixes issue #4184 

<!--
Thank you for sending a PR. We appreciate you spending time to help improve the Libra project.

The project is undergoing daily changes. Pull Requests will be reviewed and responded to as time permits.
-->

## Motivation

(Write your motivation for proposed changes here.)

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

Just verify any move file with methods.

## Related PRs

None