### PR TITLE
[Key Manager] Moved the Key Manager Config out of Node Config.

### DIFF
--- a/config/src/config/key_manager_config.rs
+++ b/config/src/config/key_manager_config.rs
@@ -1,0 +1,64 @@
+// Copyright (c) The Libra Core Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::config::{LoggerConfig, PersistableConfig, SecureBackend};
+use anyhow::Result;
+use libra_types::account_address::AccountAddress;
+use serde::{Deserialize, Serialize};
+use std::path::{Path, PathBuf};
+
+const DEFAULT_JSON_RPC_ENDPOINT: &str = "https://127.0.0.1:8080";
+
+// Timing related defaults
+const DEFAULT_ROTATION_PERIOD_SECS: u64 = 604_800; // 1 week
+const DEFAULT_SLEEP_PERIOD_SECS: u64 = 600; // 10 minutes
+const DEFAULT_TXN_EXPIRATION_SECS: u64 = 3600; // 1 hour
+
+#[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
+#[serde(default, deny_unknown_fields)]
+pub struct KeyManagerConfig {
+    pub rotation_period_secs: u64,
+    pub sleep_period_secs: u64,
+    pub txn_expiration_secs: u64,
+
+    pub json_rpc_endpoint: String,
+    pub validator_account: AccountAddress,
+
+    pub logger: LoggerConfig,
+    pub secure_backend: SecureBackend,
+}
+
+impl Default for KeyManagerConfig {
+    fn default() -> KeyManagerConfig {
+        KeyManagerConfig {
+            json_rpc_endpoint: DEFAULT_JSON_RPC_ENDPOINT.into(),
+            logger: LoggerConfig::default(),
+            rotation_period_secs: DEFAULT_ROTATION_PERIOD_SECS,
+            secure_backend: SecureBackend::InMemoryStorage,
+            sleep_period_secs: DEFAULT_SLEEP_PERIOD_SECS,
+            txn_expiration_secs: DEFAULT_TXN_EXPIRATION_SECS,
+            validator_account: AccountAddress::default(),
+        }
+    }
+}
+
+impl KeyManagerConfig {
+    /// Reads the key manager config file from the given input_path. Paths used in the config are
+    /// either absolute or relative to the config location
+    pub fn load<P: AsRef<Path>>(input_path: P) -> Result<Self> {
+        let config = Self::load_config(&input_path)?;
+        Ok(config)
+    }
+
+    /// Saves the key manager config file to the given output_path.
+    pub fn save<P: AsRef<Path>>(&mut self, output_path: P) -> Result<()> {
+        self.save_config(&output_path)?;
+        Ok(())
+    }
+
+    pub fn set_data_dir(&mut self, data_dir: PathBuf) {
+        if let SecureBackend::OnDiskStorage(backend) = &mut self.secure_backend {
+            backend.set_data_dir(data_dir);
+        }
+    }
+}

--- a/config/src/config/mod.rs
+++ b/config/src/config/mod.rs
@@ -23,6 +23,8 @@ mod debug_interface_config;
 pub use debug_interface_config::*;
 mod execution_config;
 pub use execution_config::*;
+mod key_manager_config;
+pub use key_manager_config::*;
 mod logger_config;
 pub use logger_config::*;
 mod metrics_config;
@@ -31,8 +33,8 @@ mod mempool_config;
 pub use mempool_config::*;
 mod network_config;
 pub use network_config::*;
-mod secure_config;
-pub use secure_config::*;
+mod secure_backend_config;
+pub use secure_backend_config::*;
 mod state_sync_config;
 pub use state_sync_config::*;
 mod storage_config;
@@ -73,8 +75,6 @@ pub struct NodeConfig {
     pub metrics: MetricsConfig,
     #[serde(default)]
     pub mempool: MempoolConfig,
-    #[serde(default)]
-    pub secure: SecureConfig,
     #[serde(default)]
     pub state_sync: StateSyncConfig,
     #[serde(default)]
@@ -156,7 +156,6 @@ impl NodeConfig {
         self.base.data_dir = data_dir.clone();
         self.consensus.set_data_dir(data_dir.clone());
         self.metrics.set_data_dir(data_dir.clone());
-        self.secure.set_data_dir(data_dir.clone());
         self.storage.set_data_dir(data_dir);
     }
 
@@ -179,7 +178,6 @@ impl NodeConfig {
             metrics: self.metrics.clone(),
             mempool: self.mempool.clone(),
             state_sync: self.state_sync.clone(),
-            secure: self.secure.clone(),
             storage: self.storage.clone(),
             test: None,
             upstream: self.upstream.clone(),

--- a/config/src/config/secure_backend_config.rs
+++ b/config/src/config/secure_backend_config.rs
@@ -5,57 +5,6 @@ use anyhow::{anyhow, Result};
 use serde::{Deserialize, Serialize};
 use std::{fs::File, io::Read, path::PathBuf};
 
-// JSON RPC endpoint related defaults
-const DEFAULT_JSON_RPC_ENDPOINT: &str = "https://127.0.0.1:8080";
-
-// Key manager timing related defaults
-const DEFAULT_ROTATION_PERIOD_SECS: u64 = 604_800; // 1 week
-const DEFAULT_SLEEP_PERIOD_SECS: u64 = 600; // 10 minutes
-const DEFAULT_TXN_EXPIRATION_SECS: u64 = 3600; // 1 hour
-
-#[derive(Clone, Debug, Default, Deserialize, PartialEq, Serialize)]
-#[serde(default, deny_unknown_fields)]
-pub struct SecureConfig {
-    pub key_manager: KeyManagerConfig,
-}
-
-impl SecureConfig {
-    pub fn set_data_dir(&mut self, data_dir: PathBuf) {
-        self.key_manager.set_data_dir(data_dir);
-    }
-}
-
-#[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
-#[serde(default, deny_unknown_fields)]
-pub struct KeyManagerConfig {
-    pub rotation_period_secs: u64,
-    pub sleep_period_secs: u64,
-    pub txn_expiration_secs: u64,
-
-    pub json_rpc_endpoint: String,
-    pub secure_backend: SecureBackend,
-}
-
-impl Default for KeyManagerConfig {
-    fn default() -> KeyManagerConfig {
-        KeyManagerConfig {
-            rotation_period_secs: DEFAULT_ROTATION_PERIOD_SECS,
-            sleep_period_secs: DEFAULT_SLEEP_PERIOD_SECS,
-            txn_expiration_secs: DEFAULT_TXN_EXPIRATION_SECS,
-            json_rpc_endpoint: DEFAULT_JSON_RPC_ENDPOINT.into(),
-            secure_backend: SecureBackend::InMemoryStorage,
-        }
-    }
-}
-
-impl KeyManagerConfig {
-    pub fn set_data_dir(&mut self, data_dir: PathBuf) {
-        if let SecureBackend::OnDiskStorage(backend) = &mut self.secure_backend {
-            backend.set_data_dir(data_dir);
-        }
-    }
-}
-
 #[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
 #[serde(tag = "type")]
 #[serde(rename_all = "snake_case")]

--- a/secure/key-manager/src/main.rs
+++ b/secure/key-manager/src/main.rs
@@ -5,7 +5,7 @@
 
 #![forbid(unsafe_code)]
 
-use libra_config::config::{KeyManagerConfig, NetworkConfig, NodeConfig};
+use libra_config::config::KeyManagerConfig;
 use libra_key_manager::{
     counters::COUNTERS, libra_interface::JsonRpcLibraInterface, Error, KeyManager,
 };
@@ -23,39 +23,28 @@ fn main() {
         process::exit(1);
     }
 
-    let config = NodeConfig::load(&args[1]).unwrap_or_else(|e| {
+    let key_manager_config = KeyManagerConfig::load(&args[1]).unwrap_or_else(|e| {
         eprintln!(
-            "Error! Unable to load provided config: {}, error: {}",
+            "Error! Unable to load provided key manager config: {}, error: {}",
             args[1], e
         );
         process::exit(1);
     });
 
-    if config.validator_network.is_none() {
-        eprintln!("Error! Validator config missing from node config.");
-        process::exit(1);
-    }
-    let network_config = config.validator_network.unwrap();
-    let key_manager_config = config.secure.key_manager;
-
     libra_logger::Logger::new()
-        .channel_size(config.logger.chan_size)
-        .is_async(config.logger.is_async)
-        .level(config.logger.level)
+        .channel_size(key_manager_config.logger.chan_size)
+        .is_async(key_manager_config.logger.is_async)
+        .level(key_manager_config.logger.level)
         .init();
     MetricsPusher::new(COUNTERS.clone()).start();
 
-    create_and_execute_key_manager(network_config, key_manager_config).unwrap_or_else(|e| {
+    create_and_execute_key_manager(key_manager_config).unwrap_or_else(|e| {
         eprintln!("Error! The Key Manager has failed during execution: {}", e);
         process::exit(1);
     });
 }
 
-fn create_and_execute_key_manager(
-    network_config: NetworkConfig,
-    key_manager_config: KeyManagerConfig,
-) -> Result<(), Error> {
-    let account = network_config.peer_id;
+fn create_and_execute_key_manager(key_manager_config: KeyManagerConfig) -> Result<(), Error> {
     let libra_interface = create_libra_interface(key_manager_config.json_rpc_endpoint);
     let storage: Box<dyn Storage> = (&key_manager_config.secure_backend)
         .try_into()
@@ -63,7 +52,7 @@ fn create_and_execute_key_manager(
     let time_service = RealTimeService::new();
 
     KeyManager::new(
-        account,
+        key_manager_config.validator_account,
         libra_interface,
         BoxStorage(storage),
         time_service,

--- a/secure/key-manager/src/tests.rs
+++ b/secure/key-manager/src/tests.rs
@@ -6,7 +6,11 @@ use anyhow::Result;
 use executor::{db_bootstrapper, Executor};
 use executor_types::BlockExecutor;
 use futures::{channel::mpsc::channel, StreamExt};
-use libra_config::{config::NodeConfig, utils, utils::get_genesis_txn};
+use libra_config::{
+    config::{KeyManagerConfig, NodeConfig},
+    utils,
+    utils::get_genesis_txn,
+};
 use libra_crypto::{ed25519::Ed25519PrivateKey, HashValue, PrivateKey, Uniform};
 use libra_global_constants::OPERATOR_KEY;
 use libra_secure_storage::{InMemoryStorageInternal, KVStorage, Value};
@@ -284,24 +288,41 @@ impl LibraInterface for MockLibraInterface {
     }
 }
 
+// Creates and returns NodeConfig and KeyManagerConfig structs that are consistent for testing.
+fn create_test_configs() -> (NodeConfig, KeyManagerConfig) {
+    let (node_config, _genesis_key) = config_builder::test_config();
+
+    let mut key_manager_config = KeyManagerConfig::default();
+    key_manager_config.validator_account = node_config.validator_network.clone().unwrap().peer_id;
+
+    (node_config, key_manager_config)
+}
+
 // Creates and returns a test node that uses the JsonRpcLibraInterface.
 // This setup is useful for testing nodes as they operate in a production environment.
-fn setup_node_using_json_rpc(config: &NodeConfig) -> (Node<JsonRpcLibraInterface>, Runtime) {
-    let (_storage, db_rw) = setup_libra_db(config);
+fn setup_node_using_json_rpc() -> (Node<JsonRpcLibraInterface>, Runtime) {
+    let (node_config, key_manager_config) = create_test_configs();
+
+    let (_storage, db_rw) = setup_libra_db(&node_config);
     let (libra, server) = setup_libra_interface_and_json_server(db_rw.clone());
     let executor = Executor::new(db_rw);
 
-    (setup_node(config, executor, libra), server)
+    (
+        setup_node(&node_config, &key_manager_config, executor, libra),
+        server,
+    )
 }
 
 // Creates and returns a Node using the MockLibraInterface implementation.
 // This setup is useful for testing and verifying new development features quickly.
-fn setup_node_using_test_mocks(config: &NodeConfig) -> Node<MockLibraInterface> {
-    let (storage, db_rw) = setup_libra_db(config);
+fn setup_node_using_test_mocks() -> Node<MockLibraInterface> {
+    let (node_config, key_manager_config) = create_test_configs();
+
+    let (storage, db_rw) = setup_libra_db(&node_config);
     let libra = MockLibraInterface { storage };
     let executor = Executor::new(db_rw);
 
-    setup_node(config, executor, libra)
+    setup_node(&node_config, &key_manager_config, executor, libra)
 }
 
 // Creates and returns a libra database and database reader/writer pair bootstrapped with genesis.
@@ -316,19 +337,19 @@ fn setup_libra_db(config: &NodeConfig) -> (Arc<LibraDB>, DbReaderWriter) {
 // Creates and returns a node for testing using the given config, executor and libra interface
 // wrapper implementation.
 fn setup_node<T: LibraInterface + Clone>(
-    config: &NodeConfig,
+    node_config: &NodeConfig,
+    key_manager_config: &KeyManagerConfig,
     executor: Executor<LibraVM>,
     libra: T,
 ) -> Node<T> {
-    let account = config.validator_network.as_ref().unwrap().peer_id;
+    let account = key_manager_config.validator_account;
     let time = MockTimeService::new();
     let libra_test_harness = LibraInterfaceTestHarness::new(libra);
-    let key_manager_config = &config.secure.key_manager;
 
     let key_manager = KeyManager::new(
         account,
         libra_test_harness.clone(),
-        setup_secure_storage(&config, time.clone()),
+        setup_secure_storage(&node_config, time.clone()),
         time.clone(),
         key_manager_config.rotation_period_secs,
         key_manager_config.sleep_period_secs,
@@ -402,13 +423,11 @@ fn setup_libra_interface_and_json_server(
 // This simple test just proves that genesis took effect and the values are on-chain (in storage).
 fn test_ability_to_read_move_data() {
     // Test the mock libra interface implementation
-    let (config, _genesis_key) = config_builder::test_config();
-    let node = setup_node_using_test_mocks(&config);
+    let node = setup_node_using_test_mocks();
     verify_ability_to_read_move_data(node);
 
     // Test the json libra interface implementation
-    let (config, _genesis_key) = config_builder::test_config();
-    let (node, _runtime) = setup_node_using_json_rpc(&config);
+    let (node, _runtime) = setup_node_using_json_rpc();
     verify_ability_to_read_move_data(node);
 }
 
@@ -426,18 +445,17 @@ fn verify_ability_to_read_move_data<T: LibraInterface>(node: Node<T>) {
 // transaction manually and executes the transaction on-chain.
 fn test_manual_rotation_on_chain() {
     // Test the mock libra interface implementation
-    let (config, _genesis_key) = config_builder::test_config();
-    let node = setup_node_using_test_mocks(&config);
-    verify_manual_rotation_on_chain(config, node);
+    let node = setup_node_using_test_mocks();
+    verify_manual_rotation_on_chain(node);
 
     // Test the json libra interface implementation
-    let (config, _genesis_key) = config_builder::test_config();
-    let (node, _runtime) = setup_node_using_json_rpc(&config);
-    verify_manual_rotation_on_chain(config, node);
+    let (node, _runtime) = setup_node_using_json_rpc();
+    verify_manual_rotation_on_chain(node);
 }
 
-fn verify_manual_rotation_on_chain<T: LibraInterface>(config: NodeConfig, mut node: Node<T>) {
-    let test_config = config.test.unwrap();
+fn verify_manual_rotation_on_chain<T: LibraInterface>(mut node: Node<T>) {
+    let (node_config, _) = create_test_configs();
+    let test_config = node_config.test.unwrap();
     let account_prikey = test_config
         .operator_keypair
         .unwrap()
@@ -484,13 +502,11 @@ fn verify_manual_rotation_on_chain<T: LibraInterface>(config: NodeConfig, mut no
 // This verifies that the key manager is properly setup and that a basic rotation can be performed.
 fn test_key_manager_init_and_basic_rotation() {
     // Test the mock libra interface implementation
-    let (config, _genesis_key) = config_builder::test_config();
-    let node = setup_node_using_test_mocks(&config);
+    let node = setup_node_using_test_mocks();
     verify_init_and_basic_rotation(node);
 
     // Test the json libra interface implementation
-    let (config, _genesis_key) = config_builder::test_config();
-    let (node, _runtime) = setup_node_using_json_rpc(&config);
+    let (node, _runtime) = setup_node_using_json_rpc();
     verify_init_and_basic_rotation(node);
 }
 
@@ -543,24 +559,24 @@ fn verify_init_and_basic_rotation<T: LibraInterface>(mut node: Node<T>) {
 // loop.
 fn test_execute() {
     // Test the mock libra interface implementation
-    let (config, _genesis_key) = config_builder::test_config();
-    let node = setup_node_using_test_mocks(&config);
-    verify_execute(&config, node);
+    let node = setup_node_using_test_mocks();
+    verify_execute(node);
 
     // Test the json libra interface implementation
-    let (config, _genesis_key) = config_builder::test_config();
-    let (node, _runtime) = setup_node_using_json_rpc(&config);
-    verify_execute(&config, node);
+    let (node, _runtime) = setup_node_using_json_rpc();
+    verify_execute(node);
 }
 
-fn verify_execute<T: LibraInterface>(config: &NodeConfig, mut node: Node<T>) {
+fn verify_execute<T: LibraInterface>(mut node: Node<T>) {
+    let (_, key_manager_config) = create_test_configs();
+
     // Verify correct initial state (i.e., nothing to be done by key manager)
     assert_eq!(0, node.time.now());
     assert_eq!(0, node.libra.last_reconfiguration().unwrap());
 
     // Verify rotation required after enough time
     node.time
-        .increment_by(config.secure.key_manager.rotation_period_secs);
+        .increment_by(key_manager_config.rotation_period_secs);
     node.update_libra_timestamp();
     assert_eq!(
         Action::FullKeyRotation,
@@ -580,7 +596,7 @@ fn verify_execute<T: LibraInterface>(config: &NodeConfig, mut node: Node<T>) {
 
     // Verify rotation transaction not executed, now expired
     node.time
-        .increment_by(config.secure.key_manager.txn_expiration_secs);
+        .increment_by(key_manager_config.txn_expiration_secs);
     node.update_libra_timestamp();
     assert_eq!(
         Action::SubmitKeyRotationTransaction,
@@ -611,13 +627,11 @@ fn verify_execute<T: LibraInterface>(config: &NodeConfig, mut node: Node<T>) {
 // wrong.
 fn test_execute_error() {
     // Test the mock libra interface implementation
-    let (config, _genesis_key) = config_builder::test_config();
-    let node = setup_node_using_test_mocks(&config);
+    let node = setup_node_using_test_mocks();
     verify_execute_error(node);
 
     // Test the json libra interface implementation
-    let (config, _genesis_key) = config_builder::test_config();
-    let (node, _runtime) = setup_node_using_json_rpc(&config);
+    let (node, _runtime) = setup_node_using_json_rpc();
     verify_execute_error(node);
 }
 


### PR DESCRIPTION
## Motivation

At present, the KeyManagerConfig lives inside NodeConfig. This is problematic from a deployment perspective, as the Key Manager is a self-contained entity that should be deployable without requiring irrelevant configuration details (e.g., ValidatorConfig). This PR moves KeyManagerConfig out of NodeConfig and into its own high-level domain. To achieve this, we offer two commits:

1. We define a key_manager_config, remove secure_config and create secure_backend_config for secure storage related configurations.

2. We update all key manager related tests (including the smoke test).

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?

Yes.

## Test Plan

All tests still pass (including the smoke test).

## Related PRs

None.
