### PR TITLE
[functional-tests] Print transaction status in functional-tests error message

### DIFF
--- a/language/functional-tests/src/errors.rs
+++ b/language/functional-tests/src/errors.rs
@@ -8,7 +8,7 @@ use thiserror::Error;
 /// Defines all errors in this crate.
 #[derive(Clone, Debug, Error)]
 pub enum ErrorKind {
-    #[error("an error occurred when executing the transaction")]
+    #[error("an error occurred when executing the transaction, txn status {:?}", .0.status())]
     VMExecutionFailure(TransactionOutput),
     #[error("the transaction was discarded")]
     DiscardedTransaction(TransactionOutput),


### PR DESCRIPTION
<!--
Thank you for sending a PR. We appreciate you spending time to help improve the Libra project.

The project is undergoing daily changes. Pull Requests will be reviewed and responded to as time permits.
-->

## Motivation

Print transaction status in functional-tests error message for debugging.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?

Y

## Test Plan

Unit test

## Related PRs


