### PR TITLE
[cleanup][network] Remove 12 untested, unused methods from network

### DIFF
--- a/network/network-address/src/lib.rs
+++ b/network/network-address/src/lib.rs
@@ -212,10 +212,6 @@ impl RawNetworkAddress {
         Self(bytes)
     }
 
-    pub fn empty() -> Self {
-        Self(Vec::new())
-    }
-
     pub fn len(&self) -> usize {
         self.0.len()
     }

--- a/network/network-address/src/lib.rs
+++ b/network/network-address/src/lib.rs
@@ -631,10 +631,6 @@ impl DnsName {
             Ok(())
         }
     }
-
-    pub fn as_str(&self) -> &str {
-        self.0.as_str()
-    }
 }
 
 impl Into<String> for DnsName {

--- a/network/src/validator_network/network_builder.rs
+++ b/network/src/validator_network/network_builder.rs
@@ -222,12 +222,6 @@ impl NetworkBuilder {
         self
     }
 
-    /// Set ping timeout.
-    pub fn ping_timeout_ms(&mut self, ping_timeout_ms: u64) -> &mut Self {
-        self.ping_timeout_ms = ping_timeout_ms;
-        self
-    }
-
     /// Set connectivity check ticker interval
     pub fn connectivity_check_interval_ms(
         &mut self,

--- a/network/src/validator_network/network_builder.rs
+++ b/network/src/validator_network/network_builder.rs
@@ -222,12 +222,6 @@ impl NetworkBuilder {
         self
     }
 
-    /// Set ping interval.
-    pub fn ping_interval_ms(&mut self, ping_interval_ms: u64) -> &mut Self {
-        self.ping_interval_ms = ping_interval_ms;
-        self
-    }
-
     /// Set number of ping failures tolerated.
     pub fn ping_failures_tolerated(&mut self, ping_failures_tolerated: u64) -> &mut Self {
         self.ping_failures_tolerated = ping_failures_tolerated;

--- a/network/src/validator_network/network_builder.rs
+++ b/network/src/validator_network/network_builder.rs
@@ -128,7 +128,6 @@ pub struct NetworkBuilder {
     connection_reqs_rx: libra_channel::Receiver<PeerId, ConnectionRequest>,
     conn_mgr_reqs_tx: Option<channel::Sender<ConnectivityRequest>>,
     connectivity_check_interval_ms: u64,
-    inbound_rpc_timeout_ms: u64,
     max_concurrent_outbound_rpcs: u32,
     max_concurrent_inbound_rpcs: u32,
     max_concurrent_network_reqs: usize,
@@ -180,7 +179,6 @@ impl NetworkBuilder {
             ping_timeout_ms: PING_TIMEOUT_MS,
             ping_failures_tolerated: PING_FAILURES_TOLERATED,
             connectivity_check_interval_ms: CONNECTIVITY_CHECK_INTERNAL_MS,
-            inbound_rpc_timeout_ms: INBOUND_RPC_TIMEOUT_MS,
             max_concurrent_outbound_rpcs: MAX_CONCURRENT_OUTBOUND_RPCS,
             max_concurrent_inbound_rpcs: MAX_CONCURRENT_INBOUND_RPCS,
             max_concurrent_network_reqs: MAX_CONCURRENT_NETWORK_REQS,
@@ -228,12 +226,6 @@ impl NetworkBuilder {
         connectivity_check_interval_ms: u64,
     ) -> &mut Self {
         self.connectivity_check_interval_ms = connectivity_check_interval_ms;
-        self
-    }
-
-    /// Set inbound rpc timeout.
-    pub fn inbound_rpc_timeout_ms(&mut self, inbound_rpc_timeout_ms: u64) -> &mut Self {
-        self.inbound_rpc_timeout_ms = inbound_rpc_timeout_ms;
         self
     }
 

--- a/network/src/validator_network/network_builder.rs
+++ b/network/src/validator_network/network_builder.rs
@@ -225,12 +225,6 @@ impl NetworkBuilder {
         self
     }
 
-    /// Set the size of the channels between different network actors.
-    pub fn channel_size(&mut self, channel_size: usize) -> &mut Self {
-        self.channel_size = channel_size;
-        self
-    }
-
     pub fn conn_mgr_reqs_tx(&self) -> Option<channel::Sender<ConnectivityRequest>> {
         self.conn_mgr_reqs_tx.clone()
     }

--- a/network/src/validator_network/network_builder.rs
+++ b/network/src/validator_network/network_builder.rs
@@ -128,7 +128,6 @@ pub struct NetworkBuilder {
     connection_reqs_rx: libra_channel::Receiver<PeerId, ConnectionRequest>,
     conn_mgr_reqs_tx: Option<channel::Sender<ConnectivityRequest>>,
     connectivity_check_interval_ms: u64,
-    max_concurrent_inbound_rpcs: u32,
     max_concurrent_network_reqs: usize,
     max_concurrent_network_notifs: usize,
     max_connection_delay_ms: u64,
@@ -178,7 +177,6 @@ impl NetworkBuilder {
             ping_timeout_ms: PING_TIMEOUT_MS,
             ping_failures_tolerated: PING_FAILURES_TOLERATED,
             connectivity_check_interval_ms: CONNECTIVITY_CHECK_INTERNAL_MS,
-            max_concurrent_inbound_rpcs: MAX_CONCURRENT_INBOUND_RPCS,
             max_concurrent_network_reqs: MAX_CONCURRENT_NETWORK_REQS,
             max_concurrent_network_notifs: MAX_CONCURRENT_NETWORK_NOTIFS,
             max_connection_delay_ms: MAX_CONNECTION_DELAY_MS,
@@ -224,12 +222,6 @@ impl NetworkBuilder {
         connectivity_check_interval_ms: u64,
     ) -> &mut Self {
         self.connectivity_check_interval_ms = connectivity_check_interval_ms;
-        self
-    }
-
-    /// The maximum number of concurrent inbound rpc requests we will service.
-    pub fn max_concurrent_inbound_rpcs(&mut self, max_concurrent_inbound_rpcs: u32) -> &mut Self {
-        self.max_concurrent_inbound_rpcs = max_concurrent_inbound_rpcs;
         self
     }
 

--- a/network/src/validator_network/network_builder.rs
+++ b/network/src/validator_network/network_builder.rs
@@ -225,16 +225,6 @@ impl NetworkBuilder {
         self
     }
 
-    /// The maximum number of concurrent Notifications from each actor we will service in
-    /// NetworkProvider.
-    pub fn max_concurrent_network_notifs(
-        &mut self,
-        max_concurrent_network_notifs: usize,
-    ) -> &mut Self {
-        self.max_concurrent_network_notifs = max_concurrent_network_notifs;
-        self
-    }
-
     /// The maximum duration (in milliseconds) we should wait before dialing a peer we should
     /// connect to.
     pub fn max_connection_delay_ms(&mut self, max_connection_delay_ms: u64) -> &mut Self {

--- a/network/src/validator_network/network_builder.rs
+++ b/network/src/validator_network/network_builder.rs
@@ -128,7 +128,6 @@ pub struct NetworkBuilder {
     connection_reqs_rx: libra_channel::Receiver<PeerId, ConnectionRequest>,
     conn_mgr_reqs_tx: Option<channel::Sender<ConnectivityRequest>>,
     connectivity_check_interval_ms: u64,
-    max_concurrent_outbound_rpcs: u32,
     max_concurrent_inbound_rpcs: u32,
     max_concurrent_network_reqs: usize,
     max_concurrent_network_notifs: usize,
@@ -179,7 +178,6 @@ impl NetworkBuilder {
             ping_timeout_ms: PING_TIMEOUT_MS,
             ping_failures_tolerated: PING_FAILURES_TOLERATED,
             connectivity_check_interval_ms: CONNECTIVITY_CHECK_INTERNAL_MS,
-            max_concurrent_outbound_rpcs: MAX_CONCURRENT_OUTBOUND_RPCS,
             max_concurrent_inbound_rpcs: MAX_CONCURRENT_INBOUND_RPCS,
             max_concurrent_network_reqs: MAX_CONCURRENT_NETWORK_REQS,
             max_concurrent_network_notifs: MAX_CONCURRENT_NETWORK_NOTIFS,
@@ -226,12 +224,6 @@ impl NetworkBuilder {
         connectivity_check_interval_ms: u64,
     ) -> &mut Self {
         self.connectivity_check_interval_ms = connectivity_check_interval_ms;
-        self
-    }
-
-    /// The maximum number of concurrent outbound rpc requests we will service.
-    pub fn max_concurrent_outbound_rpcs(&mut self, max_concurrent_outbound_rpcs: u32) -> &mut Self {
-        self.max_concurrent_outbound_rpcs = max_concurrent_outbound_rpcs;
         self
     }
 

--- a/network/src/validator_network/network_builder.rs
+++ b/network/src/validator_network/network_builder.rs
@@ -222,12 +222,6 @@ impl NetworkBuilder {
         self
     }
 
-    /// Set number of ping failures tolerated.
-    pub fn ping_failures_tolerated(&mut self, ping_failures_tolerated: u64) -> &mut Self {
-        self.ping_failures_tolerated = ping_failures_tolerated;
-        self
-    }
-
     /// Set ping timeout.
     pub fn ping_timeout_ms(&mut self, ping_timeout_ms: u64) -> &mut Self {
         self.ping_timeout_ms = ping_timeout_ms;

--- a/network/src/validator_network/network_builder.rs
+++ b/network/src/validator_network/network_builder.rs
@@ -225,13 +225,6 @@ impl NetworkBuilder {
         self
     }
 
-    /// The maximum duration (in milliseconds) we should wait before dialing a peer we should
-    /// connect to.
-    pub fn max_connection_delay_ms(&mut self, max_connection_delay_ms: u64) -> &mut Self {
-        self.max_connection_delay_ms = max_connection_delay_ms;
-        self
-    }
-
     /// Set the size of the channels between different network actors.
     pub fn channel_size(&mut self, channel_size: usize) -> &mut Self {
         self.channel_size = channel_size;

--- a/network/src/validator_network/network_builder.rs
+++ b/network/src/validator_network/network_builder.rs
@@ -225,12 +225,6 @@ impl NetworkBuilder {
         self
     }
 
-    /// The maximum number of concurrent NetworkRequests we will service in NetworkProvider.
-    pub fn max_concurrent_network_reqs(&mut self, max_concurrent_network_reqs: usize) -> &mut Self {
-        self.max_concurrent_network_reqs = max_concurrent_network_reqs;
-        self
-    }
-
     /// The maximum number of concurrent Notifications from each actor we will service in
     /// NetworkProvider.
     pub fn max_concurrent_network_notifs(


### PR DESCRIPTION
This PR removes 13 untested, unused methods from `network`. The value of the PR may reside more in the signaling of the nature of those untested, unused methods rather than actual removal.

I do hope & expect that reviewers will come up with valid reasons why one or another of those methods should be part of our public API — I've hence separated commits per method so that those valid methods can be kept, by omitting the commit that removes them. Just say so in review, plz :slightly_smiling_face: 
