### PR TITLE
[move-prover] Disallow old in aborts_if + fix test

### DIFF
--- a/language/move-prover/spec-lang/src/ast.rs
+++ b/language/move-prover/spec-lang/src/ast.rs
@@ -77,7 +77,7 @@ impl ConditionKind {
     /// Returns true of this condition allows the `old(..)` expression.
     pub fn allows_old(&self) -> bool {
         use ConditionKind::*;
-        matches!(self, Ensures | AbortsIf | InvariantUpdate | VarUpdate(..))
+        matches!(self, Ensures | InvariantUpdate | VarUpdate(..))
     }
 
     /// Returns true if this condition is allowed on a public function declaration.

--- a/language/move-prover/tests/sources/functional/simple_vector_client.move
+++ b/language/move-prover/tests/sources/functional/simple_vector_client.move
@@ -437,7 +437,7 @@ module TestVector {
         x
     }
     spec fun test_borrow_mut {
-        aborts_if len(old(v)) == 0;
+        aborts_if len(v) == 0;
     }
 
 

--- a/language/move-prover/tests/sources/functional/verify_vector.move
+++ b/language/move-prover/tests/sources/functional/verify_vector.move
@@ -223,7 +223,7 @@ module VerifyVector {
         Vector::pop_back(v)
     }
     spec fun verify_remove { // TODO: cannot verify loop
-        //aborts_if i >= len(old(v)); //! A postcondition might not hold on this return path.
+        //aborts_if i >= len(v); //! A postcondition might not hold on this return path.
         //ensures len(v) == len(old(v)) - 1; //! A postcondition might not hold on this return path.
         //ensures v[0..i] == old(v[0..i]); //! A postcondition might not hold on this return path.
         //ensures v[i..len(v)] == old(v[i+1..len(v)]); //! A postcondition might not hold on this return path.
@@ -236,7 +236,7 @@ module VerifyVector {
         Vector::remove(v, i) // inlining the built-in Boogie procedure.
     }
     spec fun verify_model_remove {
-        aborts_if i >= len(old(v));
+        aborts_if i >= len(v);
         ensures len(v) == len(old(v)) - 1;
         ensures v[0..i] == old(v[0..i]);
         ensures v[i..len(v)] == old(v[i+1..len(v)]);
@@ -252,7 +252,7 @@ module VerifyVector {
         Vector::pop_back(v)
     }
     spec fun verify_swap_remove {
-        aborts_if i >= len(old(v));
+        aborts_if i >= len(v);
         ensures len(v) == len(old(v)) - 1;
         ensures v == old(update(v,i,v[len(v)-1])[0..len(v)-1]);
         ensures old(v[i]) == result;
@@ -265,7 +265,7 @@ module VerifyVector {
         Vector::swap_remove(v, i) // inlining the built-in Boogie procedure.
     }
     spec fun verify_model_swap_remove {
-        aborts_if i >= len(old(v));
+        aborts_if i >= len(v);
         ensures len(v) == len(old(v)) - 1;
         ensures v == old(update(v,i,v[len(v)-1])[0..len(v)-1]);
         ensures old(v[i]) == result;

--- a/language/move-prover/tests/sources/stdlib/modules/libra.move
+++ b/language/move-prover/tests/sources/stdlib/modules/libra.move
@@ -87,10 +87,10 @@ module Libra {
     spec fun burn {
         aborts_if !exists<MintCapability<Token>>(sender());
         aborts_if !exists<Preburn<Token>>(preburn_address);
-        aborts_if old(len(global<Preburn<Token>>(preburn_address).requests)) == 0;
+        aborts_if len(global<Preburn<Token>>(preburn_address).requests) == 0;
         aborts_if !exists<Info<Token>>(0xA550C18);
-        aborts_if old(global<Info<Token>>(0xA550C18).total_value) < old(global<Preburn<Token>>(preburn_address).requests[0].value);
-        aborts_if old(global<Info<Token>>(0xA550C18).preburn_value) < old(global<Preburn<Token>>(preburn_address).requests[0].value);
+        aborts_if global<Info<Token>>(0xA550C18).total_value < global<Preburn<Token>>(preburn_address).requests[0].value;
+        aborts_if global<Info<Token>>(0xA550C18).preburn_value < global<Preburn<Token>>(preburn_address).requests[0].value;
         ensures eq_pop_front(global<Preburn<Token>>(preburn_address).requests, old(global<Preburn<Token>>(preburn_address).requests));
         ensures global<Info<Token>>(0xA550C18).total_value == old(global<Info<Token>>(0xA550C18).total_value) - old(global<Preburn<Token>>(preburn_address).requests[0].value);
         ensures global<Info<Token>>(0xA550C18).preburn_value == old(global<Info<Token>>(0xA550C18).preburn_value) - old(global<Preburn<Token>>(preburn_address).requests[0].value);
@@ -109,9 +109,9 @@ module Libra {
     spec fun cancel_burn {
         aborts_if !exists<MintCapability<Token>>(sender());
         aborts_if !exists<Preburn<Token>>(preburn_address);
-        aborts_if old(len(global<Preburn<Token>>(preburn_address).requests)) == 0;
+        aborts_if len(global<Preburn<Token>>(preburn_address).requests) == 0;
         aborts_if !exists<Info<Token>>(0xA550C18);
-        aborts_if old(global<Info<Token>>(0xA550C18).preburn_value) < old(global<Preburn<Token>>(preburn_address).requests[0].value);
+        aborts_if global<Info<Token>>(0xA550C18).preburn_value < global<Preburn<Token>>(preburn_address).requests[0].value;
         ensures eq_pop_front(global<Preburn<Token>>(preburn_address).requests, old(global<Preburn<Token>>(preburn_address).requests));
         ensures global<Info<Token>>(0xA550C18).preburn_value == old(global<Info<Token>>(0xA550C18).preburn_value) - old(global<Preburn<Token>>(preburn_address).requests[0].value);
         ensures result == old(global<Preburn<Token>>(preburn_address).requests[0]);
@@ -189,7 +189,7 @@ module Libra {
     spec fun preburn {
         // aborts_if !preburn_ref.is_approved; // TODO: bring this back once we can automate approvals in testnet
         aborts_if !exists<Info<Token>>(0xA550C18);
-        aborts_if old(global<Info<Token>>(0xA550C18).preburn_value) + coin.value > max_u64();
+        aborts_if global<Info<Token>>(0xA550C18).preburn_value + coin.value > max_u64();
         ensures global<Info<Token>>(0xA550C18).preburn_value == old(global<Info<Token>>(0xA550C18).preburn_value) + coin.value;
         ensures eq_push_back(preburn_ref.requests, old(preburn_ref.requests), coin);
     }
@@ -204,7 +204,7 @@ module Libra {
         // aborts_if !preburn_ref.is_approved; // TODO: bring this back once we can automate approvals in testnet
         aborts_if !exists<Info<Token>>(0xA550C18);
         aborts_if !exists<Preburn<Token>>(sender());
-        aborts_if old(global<Info<Token>>(0xA550C18).preburn_value) + coin.value > max_u64();
+        aborts_if global<Info<Token>>(0xA550C18).preburn_value + coin.value > max_u64();
         ensures global<Info<Token>>(0xA550C18).preburn_value == old(global<Info<Token>>(0xA550C18).preburn_value) + coin.value;
         ensures eq_push_back(global<Preburn<Token>>(sender()).requests, old(global<Preburn<Token>>(sender()).requests), coin);
     }
@@ -228,10 +228,10 @@ module Libra {
     }
     spec fun burn_with_capability {
         aborts_if !exists<Preburn<Token>>(preburn_address);
-        aborts_if old(len(global<Preburn<Token>>(preburn_address).requests)) == 0;
+        aborts_if len(global<Preburn<Token>>(preburn_address).requests) == 0;
         aborts_if !exists<Info<Token>>(0xA550C18);
-        aborts_if old(global<Info<Token>>(0xA550C18).total_value) < old(global<Preburn<Token>>(preburn_address).requests[0].value);
-        aborts_if old(global<Info<Token>>(0xA550C18).preburn_value) < old(global<Preburn<Token>>(preburn_address).requests[0].value);
+        aborts_if global<Info<Token>>(0xA550C18).total_value < global<Preburn<Token>>(preburn_address).requests[0].value;
+        aborts_if global<Info<Token>>(0xA550C18).preburn_value < global<Preburn<Token>>(preburn_address).requests[0].value;
         ensures eq_pop_front(global<Preburn<Token>>(preburn_address).requests, old(global<Preburn<Token>>(preburn_address).requests));
         ensures global<Info<Token>>(0xA550C18).total_value == old(global<Info<Token>>(0xA550C18).total_value) - old(global<Preburn<Token>>(preburn_address).requests[0].value);
         ensures global<Info<Token>>(0xA550C18).preburn_value == old(global<Info<Token>>(0xA550C18).preburn_value) - old(global<Preburn<Token>>(preburn_address).requests[0].value);
@@ -257,9 +257,9 @@ module Libra {
     }
     spec fun cancel_burn_with_capability {
         aborts_if !exists<Preburn<Token>>(preburn_address);
-        aborts_if old(len(global<Preburn<Token>>(preburn_address).requests)) == 0;
+        aborts_if len(global<Preburn<Token>>(preburn_address).requests) == 0;
         aborts_if !exists<Info<Token>>(0xA550C18);
-        aborts_if old(global<Info<Token>>(0xA550C18).preburn_value) < old(global<Preburn<Token>>(preburn_address).requests[0].value);
+        aborts_if global<Info<Token>>(0xA550C18).preburn_value < global<Preburn<Token>>(preburn_address).requests[0].value;
         ensures eq_pop_front(global<Preburn<Token>>(preburn_address).requests, old(global<Preburn<Token>>(preburn_address).requests));
         ensures global<Info<Token>>(0xA550C18).preburn_value == old(global<Info<Token>>(0xA550C18).preburn_value) - old(global<Preburn<Token>>(preburn_address).requests[0].value);
         ensures result == old(global<Preburn<Token>>(preburn_address).requests[0]);

--- a/language/move-prover/tests/sources/stdlib/modules/verify_vector.move
+++ b/language/move-prover/tests/sources/stdlib/modules/verify_vector.move
@@ -29,7 +29,7 @@ module VerifyVector {
         Vector::pop_back(v)
     }
     spec fun verify_swap_remove {
-        aborts_if i >= len(old(v));
+        aborts_if i >= len(v);
         ensures len(v) == len(old(v)) - 1;
         ensures v == old(update(v,i,v[len(v)-1])[0..len(v)-1]);
         ensures old(v[i]) == result;


### PR DESCRIPTION
Disallow the use of old in aborts_if. Aborts_if already refers to
the old variables (at the beginning of a procedure). It is
confusing to allow someone to write old(v) and v in
aborts_if while both refer to the same value.

Changes:
    - Disallow old in aborts_if
    - Fix all tests by removing old in aborts_if conditions

## Motivation

Refer to description above.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?

Yes.

## Test Plan

Existing test suite. Run the following:

```
cargo test
```

## Related PRs

None.