### PR TITLE
[cluster-test] Update deletion logic and add logs during retry

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2702,6 +2702,7 @@ dependencies = [
 name = "libra-retrier"
 version = "0.1.0"
 dependencies = [
+ "libra-logger 0.1.0",
  "libra-workspace-hack 0.1.0",
  "tokio 0.2.21 (registry+https://github.com/rust-lang/crates.io-index)",
 ]

--- a/common/retrier/Cargo.toml
+++ b/common/retrier/Cargo.toml
@@ -12,3 +12,4 @@ edition = "2018"
 [dependencies]
 libra-workspace-hack = { path = "..//workspace-hack", version = "0.1.0" }
 tokio = { version = "0.2.21", features = ["time"] }
+libra-logger = { path = "../../common/logger", version = "0.1.0"}


### PR DESCRIPTION
## Summary

* For the deletion of k8s resource, we were calling delete once and polling in a retry fashion to check if it has deleted. In the new logic, we call the delete api during every retry.

* Also update the libra-retrier to log the error message which causes libra-retrier to retry