### PR TITLE
[network] Rename NetworkId to UpstreamNetworkId

### DIFF
--- a/config/src/config/upstream_config.rs
+++ b/config/src/config/upstream_config.rs
@@ -7,19 +7,19 @@ use std::collections::HashSet;
 
 /// In general, a network ID is a PeerId that this node uses to uniquely identify a network it belongs to.
 /// This is equivalent to the `peer_id` field in the NetworkConfig of this NodeConfig
-pub type NetworkId = PeerId;
+pub type UpstreamNetworkId = PeerId;
 
 #[derive(Clone, Default, Debug, Deserialize, PartialEq, Serialize)]
 #[serde(default, deny_unknown_fields)]
 pub struct UpstreamConfig {
     // primary upstream network ids. All peers in such network are used as upstream for this node
-    pub primary_networks: Vec<NetworkId>,
+    pub primary_networks: Vec<UpstreamNetworkId>,
     // All upstream peers of this node, across all the networks that are statically defined in this node's config
     // this is mostly meaningful in VFN networks, where there is a strict hierarchy in a network
     pub upstream_peers: HashSet<PeerNetworkId>,
     // optional fallback network id. Used to as a failover if preferred upstream peers are not available
     // TODO replace PeerId with `NetworkConfig` to contain actual info needed to build fallback_network
-    pub fallback_networks: Vec<NetworkId>,
+    pub fallback_networks: Vec<UpstreamNetworkId>,
 }
 
 impl UpstreamConfig {
@@ -35,10 +35,10 @@ impl UpstreamConfig {
 
 #[derive(Copy, Clone, Debug, Deserialize, Eq, Hash, PartialEq, Serialize)]
 /// Identifier of a node, represented as (network_id, peer_id)
-pub struct PeerNetworkId(pub NetworkId, pub PeerId);
+pub struct PeerNetworkId(pub UpstreamNetworkId, pub PeerId);
 
 impl PeerNetworkId {
-    pub fn network_id(&self) -> NetworkId {
+    pub fn network_id(&self) -> UpstreamNetworkId {
         self.0
     }
 
@@ -47,6 +47,6 @@ impl PeerNetworkId {
     }
 
     pub fn random() -> Self {
-        Self(NetworkId::random(), PeerId::random())
+        Self(UpstreamNetworkId::random(), PeerId::random())
     }
 }

--- a/mempool/src/shared_mempool/coordinator.rs
+++ b/mempool/src/shared_mempool/coordinator.rs
@@ -23,7 +23,7 @@ use futures::{
     stream::{select_all, FuturesUnordered},
     StreamExt,
 };
-use libra_config::config::{NetworkId, NodeConfig, PeerNetworkId};
+use libra_config::config::{NodeConfig, PeerNetworkId, UpstreamNetworkId};
 use libra_logger::prelude::*;
 use libra_security_logger::{security_log, SecurityEvent};
 use libra_types::{on_chain_config::OnChainConfigPayload, transaction::SignedTransaction};
@@ -39,7 +39,7 @@ use vm_validator::vm_validator::TransactionValidation;
 pub(crate) async fn coordinator<V>(
     mut smp: SharedMempool<V>,
     executor: Handle,
-    network_events: Vec<(NetworkId, MempoolNetworkEvents)>,
+    network_events: Vec<(UpstreamNetworkId, MempoolNetworkEvents)>,
     mut client_events: mpsc::Receiver<(
         SignedTransaction,
         oneshot::Sender<Result<SubmissionStatus>>,

--- a/state-synchronizer/src/coordinator.rs
+++ b/state-synchronizer/src/coordinator.rs
@@ -16,7 +16,9 @@ use futures::{
     stream::select_all,
     StreamExt,
 };
-use libra_config::config::{NetworkId, PeerNetworkId, RoleType, StateSyncConfig, UpstreamConfig};
+use libra_config::config::{
+    PeerNetworkId, RoleType, StateSyncConfig, UpstreamConfig, UpstreamNetworkId,
+};
 use libra_logger::prelude::*;
 use libra_mempool::{CommitNotification, CommitResponse, CommittedTransaction};
 use libra_types::{
@@ -94,7 +96,7 @@ pub(crate) struct SyncCoordinator<T> {
     // waypoint a node is not going to be abl
     waypoint: Option<Waypoint>,
     // network senders - (k, v) = (network ID, network sender)
-    network_senders: HashMap<NetworkId, StateSynchronizerSender>,
+    network_senders: HashMap<UpstreamNetworkId, StateSynchronizerSender>,
     // peers used for synchronization
     peer_manager: PeerManager,
     // Optional sync request to be called when the target sync is reached
@@ -112,7 +114,7 @@ impl<T: ExecutorProxyTrait> SyncCoordinator<T> {
     pub fn new(
         client_events: mpsc::UnboundedReceiver<CoordinatorMessage>,
         state_sync_to_mempool_sender: mpsc::Sender<CommitNotification>,
-        network_senders: HashMap<NetworkId, StateSynchronizerSender>,
+        network_senders: HashMap<UpstreamNetworkId, StateSynchronizerSender>,
         role: RoleType,
         waypoint: Option<Waypoint>,
         config: StateSyncConfig,


### PR DESCRIPTION


<!--
Thank you for sending a PR. We appreciate you spending time to help improve the Libra project.

The project is undergoing daily changes. Pull Requests will be reviewed and responded to as time permits.
-->

## Motivation

To make room for the NetworkId used for handshakes, this upstream
network id will be renamed for now to prevent confusion.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

It's a rename, the CI should be fine.

## Related PRs

The main PR: https://github.com/libra/libra/pull/4088

This change had become too big and unwieldy to be able to figure out what was going on wrong, so I'm breaking it up into chunks that are appropriately atomic.