### PR TITLE
[libra-dev] Add function to create different transaction scripts

### DIFF
--- a/client/libra-dev/include/data.h
+++ b/client/libra-dev/include/data.h
@@ -120,20 +120,45 @@ enum LibraStatus libra_LibraAccountResource_from(const uint8_t *buf, size_t len,
  * To get the serialized transaction in a memory safe manner, the client needs to pass in a pointer to a pointer to the allocated memory in rust
  * and call free on the memory address with `libra_free_bytes_buffer`.
  * @param[in] sender_private_key is sender's private key
- * @param[in] receiver is the receiver's authentication key.
  * @param[in] sequence is the sequence number of this transaction corresponding to sender's account.
- * @param[in] identifier is the identifier of the coin to be sent.
- * @param[in] num_coins is the amount of money to be sent.
  * @param[in] max_gas_amount is the maximal total gas specified by wallet to spend for this transaction.
  * @param[in] gas_unit_price is the maximal price can be paid per gas.
  * @param[in] gas_identifier is the identifier of the coin to be used as gas.
  * @param[in] expiration_time_secs is the time this TX remain valid, the format is unix timestamp.
- * @param[in] metadata_bytes is the metadata bytes for given transaction.
- * @param[in] metadata_len is the length of metadata_bytes array.
+ * @param[in] script_bytes is the script bytes for given transaction.
+ * @param[in] script_len is the length of script_bytes array.
  * @param[out] ptr_buf is the pointer that will be filled with the memory address of the transaction allocated in rust. User takes ownership of pointer returned by *buf, which needs to be freed using libra_free_bytes_buffer
  * @param[out] ptr_len is the length of the signed transaction memory buffer.
 */
-enum LibraStatus libra_SignedTransactionBytes_from(const uint8_t sender_private_key[LIBRA_PRIVKEY_SIZE], const uint8_t receiver[LIBRA_PUBKEY_SIZE], uint64_t sequence, const char* identifier, uint64_t num_coins, uint64_t max_gas_amount, uint64_t gas_unit_price, const char* gas_identifier, uint64_t expiration_time_secs, const uint8_t* metadata_bytes, size_t metadata_len,  const uint8_t* metadata_signature_bytes, size_t metadata_signature_len, uint8_t **ptr_buf, size_t *ptr_len);
+enum LibraStatus libra_SignedTransactionBytes_from(const uint8_t sender_private_key[LIBRA_PRIVKEY_SIZE], uint64_t sequence, uint64_t max_gas_amount, uint64_t gas_unit_price, const char* gas_identifier, uint64_t expiration_time_secs, const uint8_t *script_bytes, size_t script_len, uint8_t **ptr_buf, size_t *ptr_len);
+
+/*!
+ *  Get script bytes for a P2P transaction
+ *
+ * To get the serialized script in a memory safe manner, the client needs to pass in a pointer to a pointer to the allocated memory in rust
+ * and call free on the memory address with `libra_free_bytes_buffer`.
+ * @param[in] receiver is the receiver's authentication key.
+ * @param[in] identifier is the identifier of the coin to be sent.
+ * @param[in] num_coins is the amount of money to be sent.
+ * @param[in] metadata_bytes is the metadata bytes for given transaction.
+ * @param[in] metadata_len is the length of metadata_bytes array.
+ * @param[in] metadata_signature_bytes is the metadata signature bytes for given transaction.
+ * @param[in] metadata_signature_len is the length of metadata_signature_bytes array.
+ * @param[out] ptr_buf is the pointer that will be filled with the memory address of the script allocated in rust. User takes ownership of pointer returned by *buf, which needs to be freed using libra_free_bytes_buffer
+ * @param[out] ptr_len is the length of the script memory buffer.
+*/
+enum LibraStatus libra_TransactionP2PScript_from(const uint8_t receiver[LIBRA_PUBKEY_SIZE], const char* identifier, uint64_t num_coins, const uint8_t* metadata_bytes, size_t metadata_len, const uint8_t* metadata_signature_bytes, size_t metadata_signature_len, uint8_t **ptr_buf, size_t *ptr_len);
+
+/*!
+ *  Get script bytes for add currency to account transaction
+ *
+ * To get the serialized script in a memory safe manner, the client needs to pass in a pointer to a pointer to the allocated memory in rust
+ * and call free on the memory address with `libra_free_bytes_buffer`.
+ * @param[in] identifier is the identifier of the coin to be sent.
+ * @param[out] ptr_buf is the pointer that will be filled with the memory address of the script allocated in rust. User takes ownership of pointer returned by *buf, which needs to be freed using libra_free_bytes_buffer
+ * @param[out] ptr_len is the length of the script memory buffer.
+*/
+enum LibraStatus libra_TransactionAddCurrencyScript_from(const char* identifier, uint8_t **ptr_buf, size_t *ptr_len);
 
 /*!
  * Function to free the allocation memory in rust for bytes


### PR DESCRIPTION
## Motivation

Adding function in libra-dev to create different transaction scripts. Refactored signed transaction function to take in bytes of script object rather than individual parameters. 

## Test Plan

cargo x test -p libra-dev