### PR TITLE
[move source language] Improved trailing semi warnings

### DIFF
--- a/language/move-lang/src/cfgir/borrows/mod.rs
+++ b/language/move-lang/src/cfgir/borrows/mod.rs
@@ -242,7 +242,7 @@ fn exp(context: &mut Context, parent_e: &Exp) -> Values {
             values
         }
 
-        E::Unit | E::Value(_) | E::Spec(_, _) | E::UnresolvedError => svalue(),
+        E::Unit { .. } | E::Value(_) | E::Spec(_, _) | E::UnresolvedError => svalue(),
         E::Cast(e, _) | E::UnaryExp(_, e) => {
             let v = exp(context, e);
             assert!(!assert_single_value(v).is_ref());

--- a/language/move-lang/src/cfgir/cfg.rs
+++ b/language/move-lang/src/cfgir/cfg.rs
@@ -175,7 +175,7 @@ fn unreachable_loc_exp(parent_e: &Exp) -> Option<Loc> {
     use UnannotatedExp_ as E;
     match &parent_e.exp.value {
         E::Unreachable => Some(parent_e.exp.loc),
-        E::Unit
+        E::Unit { .. }
         | E::Value(_)
         | E::Spec(_, _)
         | E::UnresolvedError

--- a/language/move-lang/src/cfgir/eliminate_locals.rs
+++ b/language/move-lang/src/cfgir/eliminate_locals.rs
@@ -133,7 +133,7 @@ mod count {
     fn exp(context: &mut Context, parent_e: &Exp) {
         use UnannotatedExp_ as E;
         match &parent_e.exp.value {
-            E::Unit | E::Value(_) | E::UnresolvedError => (),
+            E::Unit { .. } | E::Value(_) | E::UnresolvedError => (),
             E::Spec(_, used_locals) => {
                 used_locals.keys().for_each(|var| context.used(var, false));
             }
@@ -205,7 +205,7 @@ mod count {
             | E::Move { .. }
             | E::Borrow(_, _, _) => false,
 
-            E::Unit | E::Value(_) => true,
+            E::Unit { .. } | E::Value(_) => true,
 
             E::Cast(e, _) => can_subst_exp_single(e),
             E::UnaryExp(op, e) => can_subst_exp_unary(op) && can_subst_exp_single(e),
@@ -370,7 +370,11 @@ mod eliminate {
                 }
             }
 
-            E::Unit | E::Value(_) | E::Spec(_, _) | E::UnresolvedError | E::BorrowLocal(_, _) => (),
+            E::Unit { .. }
+            | E::Value(_)
+            | E::Spec(_, _)
+            | E::UnresolvedError
+            | E::BorrowLocal(_, _) => (),
 
             E::ModuleCall(mcall) => exp(context, &mut mcall.arguments),
             E::Builtin(_, e)
@@ -459,6 +463,9 @@ mod eliminate {
     }
 
     fn unit(loc: Loc) -> Exp {
-        H::exp(sp(loc, Type_::Unit), sp(loc, UnannotatedExp_::Unit))
+        H::exp(
+            sp(loc, Type_::Unit),
+            sp(loc, UnannotatedExp_::Unit { trailing: false }),
+        )
     }
 }

--- a/language/move-lang/src/cfgir/liveness/mod.rs
+++ b/language/move-lang/src/cfgir/liveness/mod.rs
@@ -118,7 +118,7 @@ fn lvalue(state: &mut LivenessState, sp!(_, l_): &LValue) {
 fn exp(state: &mut LivenessState, parent_e: &Exp) {
     use UnannotatedExp_ as E;
     match &parent_e.exp.value {
-        E::Unit | E::Value(_) | E::UnresolvedError => (),
+        E::Unit { .. } | E::Value(_) | E::UnresolvedError => (),
 
         E::BorrowLocal(_, var) | E::Copy { var, .. } | E::Move { var, .. } => {
             state.0.insert(var.clone());
@@ -314,7 +314,7 @@ mod last_usage {
     fn exp(context: &mut Context, parent_e: &mut Exp) {
         use UnannotatedExp_ as E;
         match &mut parent_e.exp.value {
-            E::Unit | E::Value(_) | E::UnresolvedError => (),
+            E::Unit { .. } | E::Value(_) | E::UnresolvedError => (),
 
             E::BorrowLocal(_, var) | E::Move { var, .. } => {
                 // remove it from context to prevent accidental dropping in previous usages

--- a/language/move-lang/src/cfgir/locals/mod.rs
+++ b/language/move-lang/src/cfgir/locals/mod.rs
@@ -222,7 +222,7 @@ fn exp(context: &mut Context, parent_e: &Exp) {
     use UnannotatedExp_ as E;
     let eloc = &parent_e.exp.loc;
     match &parent_e.exp.value {
-        E::Unit | E::Value(_) | E::Spec(_, _) | E::UnresolvedError => (),
+        E::Unit { .. } | E::Value(_) | E::Spec(_, _) | E::UnresolvedError => (),
 
         E::BorrowLocal(_, var) | E::Copy { var, .. } => use_local(context, eloc, var),
 

--- a/language/move-lang/src/expansion/ast.rs
+++ b/language/move-lang/src/expansion/ast.rs
@@ -245,7 +245,7 @@ pub enum Exp_ {
     BinopExp(Box<Exp>, BinOp, Box<Exp>),
 
     ExpList(Vec<Exp>),
-    Unit,
+    Unit { trailing: bool },
 
     Borrow(bool, Box<Exp>),
     ExpDotted(Box<ExpDotted>),
@@ -666,7 +666,10 @@ impl AstDebug for Exp_ {
     fn ast_debug(&self, w: &mut AstWriter) {
         use Exp_ as E;
         match self {
-            E::Unit => w.write("()"),
+            E::Unit { trailing } if !trailing => w.write("()"),
+            E::Unit {
+                trailing: _trailing,
+            } => w.write("/*()*/"),
             E::InferredNum(u) => w.write(&format!("{}", u)),
             E::Value(v) => v.ast_debug(w),
             E::Move(v) => w.write(&format!("move {}", v)),

--- a/language/move-lang/src/expansion/translate.rs
+++ b/language/move-lang/src/expansion/translate.rs
@@ -1024,7 +1024,7 @@ fn sequence(context: &mut Context, loc: Loc, seq: P::Sequence) -> E::Sequence {
                 Some(l) => l,
                 None => loc,
             };
-            sp(last_semicolon_loc, E::Exp_::Unit)
+            sp(last_semicolon_loc, E::Exp_::Unit { trailing: true })
         }
         Some(e) => e,
     };
@@ -1081,7 +1081,7 @@ fn exp_(context: &mut Context, sp!(loc, pe_): P::Exp) -> E::Exp {
     use E::Exp_ as EE;
     use P::Exp_ as PE;
     let e_ = match pe_ {
-        PE::Unit => EE::Unit,
+        PE::Unit => EE::Unit { trailing: false },
         PE::Value(pv) => match value(context, pv) {
             Some(v) => EE::Value(v),
             None => {
@@ -1152,7 +1152,7 @@ fn exp_(context: &mut Context, sp!(loc, pe_): P::Exp) -> E::Exp {
             let eb = exp(context, *pb);
             let et = exp(context, *pt);
             let ef = match pf_opt {
-                None => Box::new(sp(loc, EE::Unit)),
+                None => Box::new(sp(loc, EE::Unit { trailing: false })),
                 Some(pf) => exp(context, *pf),
             };
             EE::IfElse(eb, et, ef)
@@ -1199,7 +1199,7 @@ fn exp_(context: &mut Context, sp!(loc, pe_): P::Exp) -> E::Exp {
         }
         PE::Return(pe_opt) => {
             let ev = match pe_opt {
-                None => Box::new(sp(loc, EE::Unit)),
+                None => Box::new(sp(loc, EE::Unit { trailing: false })),
                 Some(pe) => exp(context, *pe),
             };
             EE::Return(ev)
@@ -1469,7 +1469,7 @@ fn unbound_names_exp(unbound: &mut BTreeSet<Name>, sp!(_, e_): &E::Exp) {
         | EE::Continue
         | EE::UnresolvedError
         | EE::Name(sp!(_, E::ModuleAccess_::ModuleAccess(..)), _)
-        | EE::Unit => (),
+        | EE::Unit { .. } => (),
         EE::Copy(v) | EE::Move(v) => {
             unbound.insert(v.0.clone());
         }

--- a/language/move-lang/src/hlir/ast.rs
+++ b/language/move-lang/src/hlir/ast.rs
@@ -225,7 +225,7 @@ pub type BuiltinFunction = Spanned<BuiltinFunction_>;
 
 #[derive(Debug, PartialEq)]
 pub enum UnannotatedExp_ {
-    Unit,
+    Unit { trailing: bool },
     Value(Value),
     Move { from_user: bool, var: Var },
     Copy { from_user: bool, var: Var },
@@ -343,7 +343,9 @@ impl Exp {
 impl UnannotatedExp_ {
     pub fn is_unit(&self) -> bool {
         match self {
-            UnannotatedExp_::Unit => true,
+            UnannotatedExp_::Unit {
+                trailing: _trailing,
+            } => true,
             _ => false,
         }
     }
@@ -815,7 +817,10 @@ impl AstDebug for UnannotatedExp_ {
     fn ast_debug(&self, w: &mut AstWriter) {
         use UnannotatedExp_ as E;
         match self {
-            E::Unit => w.write("()"),
+            E::Unit { trailing } if !trailing => w.write("()"),
+            E::Unit {
+                trailing: _trailing,
+            } => w.write("/*()*/"),
             E::Value(v) => v.ast_debug(w),
             E::Move {
                 from_user: false,

--- a/language/move-lang/src/naming/ast.rs
+++ b/language/move-lang/src/naming/ast.rs
@@ -229,7 +229,9 @@ pub enum Exp_ {
 
     Pack(ModuleIdent, StructName, Option<Vec<Type>>, Fields<Exp>),
     ExpList(Vec<Exp>),
-    Unit,
+    Unit {
+        trailing: bool,
+    },
 
     DerefBorrow(ExpDotted),
     Borrow(bool, ExpDotted),
@@ -744,7 +746,10 @@ impl AstDebug for Exp_ {
     fn ast_debug(&self, w: &mut AstWriter) {
         use Exp_ as E;
         match self {
-            E::Unit => w.write("()"),
+            E::Unit { trailing } if !trailing => w.write("()"),
+            E::Unit {
+                trailing: _trailing,
+            } => w.write("/*()*/"),
             E::Value(v) => v.ast_debug(w),
             E::InferredNum(u) => w.write(&format!("{}", u)),
             E::Move(v) => w.write(&format!("move {}", v)),

--- a/language/move-lang/src/naming/translate.rs
+++ b/language/move-lang/src/naming/translate.rs
@@ -613,7 +613,7 @@ fn exp_(context: &mut Context, e: E::Exp) -> N::Exp {
     use N::Exp_ as NE;
     let sp!(eloc, e_) = e;
     let ne_ = match e_ {
-        EE::Unit => NE::Unit,
+        EE::Unit { trailing } => NE::Unit { trailing },
         EE::InferredNum(u) => NE::InferredNum(u),
         EE::Value(val) => NE::Value(val),
         EE::Move(v) => NE::Move(v),
@@ -722,14 +722,15 @@ fn exp_(context: &mut Context, e: E::Exp) -> N::Exp {
             let ty_args = tys_opt.map(|tys| types(context, tys));
             let nes = call_args(context, rhs);
             match ma_ {
-                EA::Name(n) if N::BuiltinFunction_::all_names().contains(&n.value.as_str()) =>
-                        match resolve_builtin_function(context, eloc, &n, ty_args) {
-                            None => {
-                                assert!(context.has_errors());
-                                NE::UnresolvedError
-                            }
-                            Some(f) => NE::Builtin(sp(mloc, f), nes),
-                        },
+                EA::Name(n) if N::BuiltinFunction_::all_names().contains(&n.value.as_str()) => {
+                    match resolve_builtin_function(context, eloc, &n, ty_args) {
+                        None => {
+                            assert!(context.has_errors());
+                            NE::UnresolvedError
+                        }
+                        Some(f) => NE::Builtin(sp(mloc, f), nes),
+                    }
+                }
 
                 EA::Name(n) => {
                     context.error(vec![(

--- a/language/move-lang/src/naming/uses.rs
+++ b/language/move-lang/src/naming/uses.rs
@@ -222,7 +222,7 @@ fn lvalue(context: &mut Context, sp!(loc, a_): &N::LValue) {
 fn exp(context: &mut Context, sp!(loc, e_): &N::Exp) {
     use N::Exp_ as E;
     match e_ {
-        E::Unit
+        E::Unit { .. }
         | E::UnresolvedError
         | E::Break
         | E::Continue

--- a/language/move-lang/src/to_bytecode/translate.rs
+++ b/language/move-lang/src/to_bytecode/translate.rs
@@ -737,7 +737,7 @@ fn exp_(context: &mut Context, code: &mut IR::BytecodeBlock, e: H::Exp) {
     match e_ {
         E::Unreachable => panic!("ICE should not compile dead code"),
         E::UnresolvedError => panic!("ICE should not have reached compilation if there are errors"),
-        E::Unit => (),
+        E::Unit { .. } => (),
         // remember to switch to orig_name
         E::Spec(id, used_locals) => code.push(sp(loc, B::Nop(Some(context.spec(id, used_locals))))),
         E::Value(v) => {

--- a/language/move-lang/src/typing/ast.rs
+++ b/language/move-lang/src/typing/ast.rs
@@ -121,7 +121,7 @@ pub type BuiltinFunction = Spanned<BuiltinFunction_>;
 
 #[derive(Debug, PartialEq)]
 pub enum UnannotatedExp_ {
-    Unit,
+    Unit { trailing: bool },
     Value(Value),
     InferredNum(u128),
     Move { from_user: bool, var: Var },
@@ -338,7 +338,10 @@ impl AstDebug for UnannotatedExp_ {
     fn ast_debug(&self, w: &mut AstWriter) {
         use UnannotatedExp_ as E;
         match self {
-            E::Unit => w.write("()"),
+            E::Unit { trailing } if !trailing => w.write("()"),
+            E::Unit {
+                trailing: _trailing,
+            } => w.write("/*()*/"),
             E::Value(v) => v.ast_debug(w),
             E::InferredNum(u) => w.write(&format!("{}", u)),
             E::Move {

--- a/language/move-lang/src/typing/expand.rs
+++ b/language/move-lang/src/typing/expand.rs
@@ -210,7 +210,7 @@ fn exp(context: &mut Context, e: &mut T::Exp) {
 
         E::Spec(_, used_locals) => used_locals.values_mut().for_each(|ty| type_(context, ty)),
 
-        E::Unit
+        E::Unit { .. }
         | E::Value(_)
         | E::Move { .. }
         | E::Copy { .. }

--- a/language/move-lang/src/typing/globals.rs
+++ b/language/move-lang/src/typing/globals.rs
@@ -82,7 +82,7 @@ fn exp(
     match &e.exp.value {
         E::InferredNum(_) | E::Use(_) => panic!("ICE should have been expanded"),
 
-        E::Unit
+        E::Unit { .. }
         | E::Value(_)
         | E::Move { .. }
         | E::Copy { .. }

--- a/language/move-lang/src/typing/infinite_instantiations.rs
+++ b/language/move-lang/src/typing/infinite_instantiations.rs
@@ -207,7 +207,7 @@ fn exp(context: &mut Context, e: &T::Exp) {
     match &e.exp.value {
         E::InferredNum(_) | E::Use(_) => panic!("ICE should have been expanded"),
 
-        E::Unit
+        E::Unit { .. }
         | E::Value(_)
         | E::Move { .. }
         | E::Copy { .. }

--- a/language/move-lang/src/typing/translate.rs
+++ b/language/move-lang/src/typing/translate.rs
@@ -509,7 +509,7 @@ fn exp_(context: &mut Context, sp!(eloc, ne_): N::Exp) -> T::Exp {
     use N::Exp_ as NE;
     use T::UnannotatedExp_ as TE;
     let (ty, e_) = match ne_ {
-        NE::Unit => (sp(eloc, Type_::Unit), TE::Unit),
+        NE::Unit { trailing } => (sp(eloc, Type_::Unit), TE::Unit { trailing }),
         NE::Value(sp!(vloc, v)) => (v.type_(vloc), TE::Value(sp(vloc, v))),
         NE::InferredNum(v) => (core::make_num_tvar(context, eloc), TE::InferredNum(v)),
 
@@ -1503,7 +1503,10 @@ fn call_args<S: std::fmt::Display, F: Fn() -> S>(
     let tys = args.iter().map(|e| e.ty.clone()).collect();
     let tys = make_arg_types(context, loc, msg, arity, argloc, tys);
     let arg = match args.len() {
-        0 => T::exp(sp(argloc, Type_::Unit), sp(argloc, TE::Unit)),
+        0 => T::exp(
+            sp(argloc, Type_::Unit),
+            sp(argloc, TE::Unit { trailing: false }),
+        ),
         1 => args.pop().unwrap(),
         _ => {
             let ty = Type_::multiple(argloc, tys.clone());

--- a/language/move-lang/tests/move_check/liveness/loop_weirdness.exp
+++ b/language/move-lang/tests/move_check/liveness/loop_weirdness.exp
@@ -3,6 +3,12 @@ error:
    ┌── tests/move_check/liveness/loop_weirdness.move:9:43 ───
    │
  9 │                 if (my_local >= 0) { break; };
-   │                                           ^ Unreachable code. This statement (and any following statements) will not be executed. In some cases, this will result in unused resource values.
+   │                                           ^ Invalid trailing ';'
+   ·
+ 9 │                 if (my_local >= 0) { break; };
+   │                                      ----- Any code after this expression will not be reached
+   ·
+ 9 │                 if (my_local >= 0) { break; };
+   │                                           - A trailing ';' in an expression block implicitly adds a '()' value after the semicolon. That '()' value will not be reachable
    │
 

--- a/language/move-lang/tests/move_check/liveness/trailing_semi.exp
+++ b/language/move-lang/tests/move_check/liveness/trailing_semi.exp
@@ -1,0 +1,134 @@
+error: 
+
+   ┌── tests/move_check/liveness/trailing_semi.move:3:15 ───
+   │
+ 3 │         return;
+   │               ^ Invalid trailing ';'
+   ·
+ 3 │         return;
+   │         ------ Any code after this expression will not be reached
+   ·
+ 3 │         return;
+   │               - A trailing ';' in an expression block implicitly adds a '()' value after the semicolon. That '()' value will not be reachable
+   │
+
+error: 
+
+   ┌── tests/move_check/liveness/trailing_semi.move:9:16 ───
+   │
+ 9 │         abort 0;
+   │                ^ Invalid trailing ';'
+   ·
+ 9 │         abort 0;
+   │         ------- Any code after this expression will not be reached
+   ·
+ 9 │         abort 0;
+   │                - A trailing ';' in an expression block implicitly adds a '()' value after the semicolon. That '()' value will not be reachable
+   │
+
+error: 
+
+    ┌── tests/move_check/liveness/trailing_semi.move:15:19 ───
+    │
+ 15 │         { return };
+    │                   ^ Invalid trailing ';'
+    ·
+ 15 │         { return };
+    │           ------ Any code after this expression will not be reached
+    ·
+ 15 │         { return };
+    │                   - A trailing ';' in an expression block implicitly adds a '()' value after the semicolon. That '()' value will not be reachable
+    │
+
+error: 
+
+    ┌── tests/move_check/liveness/trailing_semi.move:21:20 ───
+    │
+ 21 │         { abort 0 };
+    │                    ^ Invalid trailing ';'
+    ·
+ 21 │         { abort 0 };
+    │           ------- Any code after this expression will not be reached
+    ·
+ 21 │         { abort 0 };
+    │                    - A trailing ';' in an expression block implicitly adds a '()' value after the semicolon. That '()' value will not be reachable
+    │
+
+error: 
+
+    ┌── tests/move_check/liveness/trailing_semi.move:29:19 ───
+    │
+ 29 │             return;
+    │                   ^ Invalid trailing ';'
+    ·
+ 29 │             return;
+    │             ------ Any code after this expression will not be reached
+    ·
+ 29 │             return;
+    │                   - A trailing ';' in an expression block implicitly adds a '()' value after the semicolon. That '()' value will not be reachable
+    │
+
+error: 
+
+    ┌── tests/move_check/liveness/trailing_semi.move:43:14 ───
+    │
+ 43 │             };
+    │              ^ Invalid trailing ';'
+    ·
+ 39 │ ╭             if (cond) {
+ 40 │ │                 return
+ 41 │ │             } else {
+ 42 │ │                 abort 0
+ 43 │ │             };
+    │ ╰─────────────' Any code after this expression will not be reached
+    ·
+ 43 │             };
+    │              - A trailing ';' in an expression block implicitly adds a '()' value after the semicolon. That '()' value will not be reachable
+    │
+
+error: 
+
+    ┌── tests/move_check/liveness/trailing_semi.move:52:24 ───
+    │
+ 52 │                 abort 0;
+    │                        ^ Invalid trailing ';'
+    ·
+ 52 │                 abort 0;
+    │                 ------- Any code after this expression will not be reached
+    ·
+ 52 │                 abort 0;
+    │                        - A trailing ';' in an expression block implicitly adds a '()' value after the semicolon. That '()' value will not be reachable
+    │
+
+error: 
+
+    ┌── tests/move_check/liveness/trailing_semi.move:54:23 ───
+    │
+ 54 │                 return;
+    │                       ^ Invalid trailing ';'
+    ·
+ 54 │                 return;
+    │                 ------ Any code after this expression will not be reached
+    ·
+ 54 │                 return;
+    │                       - A trailing ';' in an expression block implicitly adds a '()' value after the semicolon. That '()' value will not be reachable
+    │
+
+error: 
+
+    ┌── tests/move_check/liveness/trailing_semi.move:55:14 ───
+    │
+ 55 │             };
+    │              ^ Invalid trailing ';'
+    ·
+ 51 │ ╭             if (cond) {
+ 52 │ │                 abort 0;
+ 53 │ │             } else {
+ 54 │ │                 return;
+ 55 │ │             };
+    │ ╰─────────────' Any code after this expression will not be reached
+    ·
+ 55 │             };
+    │              - A trailing ';' in an expression block implicitly adds a '()' value after the semicolon. That '()' value will not be reachable
+    │
+

--- a/language/move-lang/tests/move_check/liveness/trailing_semi.move
+++ b/language/move-lang/tests/move_check/liveness/trailing_semi.move
@@ -1,0 +1,58 @@
+script {
+    fun main() {
+        return;
+    }
+}
+
+script {
+    fun main() {
+        abort 0;
+    }
+}
+
+script {
+    fun main() {
+        { return };
+    }
+}
+
+script {
+    fun main() {
+        { abort 0 };
+    }
+}
+
+
+script {
+    fun main(cond: bool) {
+        if (cond) {
+            return;
+        } else {
+            ()
+        }
+    }
+}
+
+script {
+    fun main(cond: bool) {
+        {
+            if (cond) {
+                return
+            } else {
+                abort 0
+            };
+        }
+    }
+}
+
+script {
+    fun main(cond: bool) {
+        {
+            if (cond) {
+                abort 0;
+            } else {
+                return;
+            };
+        }
+    }
+}

--- a/language/move-lang/tests/move_check/liveness/trailing_semi_loops.exp
+++ b/language/move-lang/tests/move_check/liveness/trailing_semi_loops.exp
@@ -1,0 +1,229 @@
+error: 
+
+   ┌── tests/move_check/liveness/trailing_semi_loops.move:3:16 ───
+   │
+ 3 │         loop ();
+   │                ^ Invalid trailing ';'
+   ·
+ 3 │         loop ();
+   │         ------- Any code after this expression will not be reached
+   ·
+ 3 │         loop ();
+   │                - A trailing ';' in an expression block implicitly adds a '()' value after the semicolon. That '()' value will not be reachable
+   │
+
+error: 
+
+   ┌── tests/move_check/liveness/trailing_semi_loops.move:9:26 ───
+   │
+ 9 │         { (loop (): ()) };
+   │                          ^ Invalid trailing ';'
+   ·
+ 9 │         { (loop (): ()) };
+   │            ------- Any code after this expression will not be reached
+   ·
+ 9 │         { (loop (): ()) };
+   │                          - A trailing ';' in an expression block implicitly adds a '()' value after the semicolon. That '()' value will not be reachable
+   │
+
+error: 
+
+    ┌── tests/move_check/liveness/trailing_semi_loops.move:18:10 ───
+    │
+ 18 │         };
+    │          ^ Invalid trailing ';'
+    ·
+ 15 │ ╭         loop {
+ 16 │ │             let x = 0;
+ 17 │ │             0 + x + 0;
+ 18 │ │         };
+    │ ╰─────────' Any code after this expression will not be reached
+    ·
+ 18 │         };
+    │          - A trailing ';' in an expression block implicitly adds a '()' value after the semicolon. That '()' value will not be reachable
+    │
+
+error: 
+
+    ┌── tests/move_check/liveness/trailing_semi_loops.move:27:26 ───
+    │
+ 27 │             let x: u64 = if (true) break else break;
+    │                          ^^^^^^^^^^^^^^^^^^^^^^^^^^ Invalid use of a divergent expression. The code following the evaluation of this expression will be dead and should be removed. In some cases, this is necessary to prevent unused resource values.
+    │
+
+error: 
+
+    ┌── tests/move_check/liveness/trailing_semi_loops.move:35:18 ───
+    │
+ 35 │             break;
+    │                  ^ Invalid trailing ';'
+    ·
+ 35 │             break;
+    │             ----- Any code after this expression will not be reached
+    ·
+ 35 │             break;
+    │                  - A trailing ';' in an expression block implicitly adds a '()' value after the semicolon. That '()' value will not be reachable
+    │
+
+error: 
+
+    ┌── tests/move_check/liveness/trailing_semi_loops.move:44:22 ───
+    │
+ 44 │                 break;
+    │                      ^ Invalid trailing ';'
+    ·
+ 44 │                 break;
+    │                 ----- Any code after this expression will not be reached
+    ·
+ 44 │                 break;
+    │                      - A trailing ';' in an expression block implicitly adds a '()' value after the semicolon. That '()' value will not be reachable
+    │
+
+error: 
+
+    ┌── tests/move_check/liveness/trailing_semi_loops.move:55:42 ───
+    │
+ 55 │             if (cond) continue else break;
+    │                                          ^ Invalid trailing ';'
+    ·
+ 55 │             if (cond) continue else break;
+    │             ----------------------------- Any code after this expression will not be reached
+    ·
+ 55 │             if (cond) continue else break;
+    │                                          - A trailing ';' in an expression block implicitly adds a '()' value after the semicolon. That '()' value will not be reachable
+    │
+
+error: 
+
+    ┌── tests/move_check/liveness/trailing_semi_loops.move:63:42 ───
+    │
+ 63 │             if (cond) abort 0 else return;
+    │                                          ^ Invalid trailing ';'
+    ·
+ 63 │             if (cond) abort 0 else return;
+    │             ----------------------------- Any code after this expression will not be reached
+    ·
+ 63 │             if (cond) abort 0 else return;
+    │                                          - A trailing ';' in an expression block implicitly adds a '()' value after the semicolon. That '()' value will not be reachable
+    │
+
+error: 
+
+    ┌── tests/move_check/liveness/trailing_semi_loops.move:76:17 ───
+    │
+ 76 │                 x = 2;
+    │                 ^ Unused assignment or binding for local 'x'. Consider removing or replacing it with '_'
+    │
+
+error: 
+
+    ┌── tests/move_check/liveness/trailing_semi_loops.move:78:14 ───
+    │
+ 78 │             };
+    │              ^ Invalid trailing ';'
+    ·
+ 72 │ ╭             if (cond) {
+ 73 │ │                 x = 1;
+ 74 │ │                 break
+ 75 │ │             } else {
+ 76 │ │                 x = 2;
+ 77 │ │                 continue
+ 78 │ │             };
+    │ ╰─────────────' Any code after this expression will not be reached
+    ·
+ 78 │             };
+    │              - A trailing ';' in an expression block implicitly adds a '()' value after the semicolon. That '()' value will not be reachable
+    │
+
+error: 
+
+    ┌── tests/move_check/liveness/trailing_semi_loops.move:88:22 ───
+    │
+ 88 │                 break;
+    │                      ^ Invalid trailing ';'
+    ·
+ 88 │                 break;
+    │                 ----- Any code after this expression will not be reached
+    ·
+ 88 │                 break;
+    │                      - A trailing ';' in an expression block implicitly adds a '()' value after the semicolon. That '()' value will not be reachable
+    │
+
+error: 
+
+    ┌── tests/move_check/liveness/trailing_semi_loops.move:90:25 ───
+    │
+ 90 │                 continue;
+    │                         ^ Invalid trailing ';'
+    ·
+ 90 │                 continue;
+    │                 -------- Any code after this expression will not be reached
+    ·
+ 90 │                 continue;
+    │                         - A trailing ';' in an expression block implicitly adds a '()' value after the semicolon. That '()' value will not be reachable
+    │
+
+error: 
+
+    ┌── tests/move_check/liveness/trailing_semi_loops.move:91:14 ───
+    │
+ 91 │             };
+    │              ^ Invalid trailing ';'
+    ·
+ 87 │ ╭             if (cond) {
+ 88 │ │                 break;
+ 89 │ │             } else {
+ 90 │ │                 continue;
+ 91 │ │             };
+    │ ╰─────────────' Any code after this expression will not be reached
+    ·
+ 91 │             };
+    │              - A trailing ';' in an expression block implicitly adds a '()' value after the semicolon. That '()' value will not be reachable
+    │
+
+error: 
+
+     ┌── tests/move_check/liveness/trailing_semi_loops.move:100:23 ───
+     │
+ 100 │                 return;
+     │                       ^ Invalid trailing ';'
+     ·
+ 100 │                 return;
+     │                 ------ Any code after this expression will not be reached
+     ·
+ 100 │                 return;
+     │                       - A trailing ';' in an expression block implicitly adds a '()' value after the semicolon. That '()' value will not be reachable
+     │
+
+error: 
+
+     ┌── tests/move_check/liveness/trailing_semi_loops.move:102:24 ───
+     │
+ 102 │                 abort 0;
+     │                        ^ Invalid trailing ';'
+     ·
+ 102 │                 abort 0;
+     │                 ------- Any code after this expression will not be reached
+     ·
+ 102 │                 abort 0;
+     │                        - A trailing ';' in an expression block implicitly adds a '()' value after the semicolon. That '()' value will not be reachable
+     │
+
+error: 
+
+     ┌── tests/move_check/liveness/trailing_semi_loops.move:103:14 ───
+     │
+ 103 │             };
+     │              ^ Invalid trailing ';'
+     ·
+  99 │ ╭             if (cond) {
+ 100 │ │                 return;
+ 101 │ │             } else {
+ 102 │ │                 abort 0;
+ 103 │ │             };
+     │ ╰─────────────' Any code after this expression will not be reached
+     ·
+ 103 │             };
+     │              - A trailing ';' in an expression block implicitly adds a '()' value after the semicolon. That '()' value will not be reachable
+     │
+

--- a/language/move-lang/tests/move_check/liveness/trailing_semi_loops.move
+++ b/language/move-lang/tests/move_check/liveness/trailing_semi_loops.move
@@ -1,0 +1,106 @@
+script {
+    fun main() {
+        loop ();
+    }
+}
+
+script {
+    fun main() {
+        { (loop (): ()) };
+    }
+}
+
+script {
+    fun main() {
+        loop {
+            let x = 0;
+            0 + x + 0;
+        };
+    }
+}
+
+script {
+    fun main() {
+        loop {
+            // TODO can probably improve this message,
+            // but its different than the normal trailing case
+            let x: u64 = if (true) break else break;
+        }
+    }
+}
+
+script {
+    fun main() {
+        loop {
+            break;
+        }
+    }
+}
+
+script {
+    fun main(cond: bool) {
+        loop {
+            if (cond) {
+                break;
+            } else {
+                ()
+            }
+        }
+    }
+}
+
+script {
+    fun main(cond: bool) {
+        loop {
+            if (cond) continue else break;
+        }
+    }
+}
+
+script {
+    fun main(cond: bool) {
+        loop {
+            if (cond) abort 0 else return;
+        }
+    }
+}
+
+script {
+    fun main(cond: bool) {
+        let x;
+        loop {
+            if (cond) {
+                x = 1;
+                break
+            } else {
+                x = 2;
+                continue
+            };
+        };
+        x;
+    }
+}
+
+script {
+    fun main(cond: bool) {
+        loop {
+            if (cond) {
+                break;
+            } else {
+                continue;
+            };
+        }
+    }
+}
+
+script {
+    fun main(cond: bool) {
+        loop {
+            if (cond) {
+                return;
+            } else {
+                abort 0;
+            };
+        }
+    }
+}

--- a/language/move-lang/tests/move_check/locals/use_after_move_loop.exp
+++ b/language/move-lang/tests/move_check/locals/use_after_move_loop.exp
@@ -2,19 +2,11 @@ error:
 
    ┌── tests/move_check/locals/use_after_move_loop.move:4:20 ───
    │
- 4 │         loop { _ = move x };
+ 4 │         loop { _ = move x }
    │                    ^^^^^^ Invalid usage of local 'x'
    ·
- 4 │         loop { _ = move x };
+ 4 │         loop { _ = move x }
    │                    ------ The local might not have a value due to this position. The local must be assigned a value before being used
-   │
-
-error: 
-
-   ┌── tests/move_check/locals/use_after_move_loop.move:4:28 ───
-   │
- 4 │         loop { _ = move x };
-   │                            ^ Unreachable code. This statement (and any following statements) will not be executed. In some cases, this will result in unused resource values.
    │
 
 error: 

--- a/language/move-lang/tests/move_check/locals/use_after_move_loop.move
+++ b/language/move-lang/tests/move_check/locals/use_after_move_loop.move
@@ -1,7 +1,7 @@
 module M {
     fun tmove1() {
         let x = 0;
-        loop { _ = move x };
+        loop { _ = move x }
     }
 
     fun tmove2(cond: bool) {

--- a/language/move-prover/spec-lang/src/translate.rs
+++ b/language/move-prover/spec-lang/src/translate.rs
@@ -3304,7 +3304,7 @@ impl<'env, 'translator, 'module_translator> ExpTranslator<'env, 'translator, 'mo
                 let id = self.new_node_id_with_type_loc(&ty, &loc);
                 Exp::Call(id, Operation::Tuple, exps)
             }
-            EA::Exp_::Unit => {
+            EA::Exp_::Unit { .. } => {
                 let ty = self.check_type(
                     &loc,
                     &Type::Tuple(vec![]),


### PR DESCRIPTION
## Motivation

- Long standing TODO to improve error messages for unnecessary trailing semicolons
- Explained why they are unnecessary and in some sense "dead code"
- See https://community.libra.org/t/odd-error-when-semi-is-put-after-break-or-continue/2868 for more discussion

## Test Plan

- new tests