### PR TITLE
[libra-crypto-derive] fix proc-macro declaration

### DIFF
--- a/crypto/crypto-derive/Cargo.toml
+++ b/crypto/crypto-derive/Cargo.toml
@@ -9,7 +9,7 @@ license = "Apache-2.0"
 edition = "2018"
 
 [lib]
-proc_macro = true
+proc-macro = true
 
 [dependencies]
 libra-workspace-hack = { path = "../../common/workspace-hack", version = "0.1.0" }


### PR DESCRIPTION
`proc_macro` appears to work with the v1 resolver and for `cargo metadata` (and therefore `guppy`), but the v2 resolver requires it to be `proc-macro`.