### PR TITLE
[cleanup][common][crypto][storage][...] Remove 18 more untested, unused methods

### DIFF
--- a/common/metrics/src/lib.rs
+++ b/common/metrics/src/lib.rs
@@ -25,15 +25,10 @@ pub use prometheus::{
 
 use anyhow::Result;
 use libra_logger::prelude::*;
-use prometheus::{
-    core::{Collector, Metric},
-    proto::MetricType,
-    Encoder, TextEncoder,
-};
+use prometheus::{core::Collector, proto::MetricType, Encoder, TextEncoder};
 use std::{
     collections::HashMap,
     fs::{create_dir_all, File, OpenOptions},
-    hash::BuildHasher,
     io::Write,
     path::Path,
     thread, time,
@@ -121,18 +116,6 @@ pub fn dump_all_metrics_to_file_periodically<P: AsRef<Path>>(
         }
         thread::sleep(time::Duration::from_millis(interval));
     });
-}
-
-pub fn export_counter<M, S>(col: &mut HashMap<String, String, S>, counter: &M)
-where
-    M: Metric,
-    S: BuildHasher,
-{
-    let c = counter.metric();
-    col.insert(
-        c.get_label()[0].get_name().to_string(),
-        c.get_counter().get_value().to_string(),
-    );
 }
 
 pub fn get_metric_name<M>(metric: &M) -> String

--- a/common/metrics/src/lib.rs
+++ b/common/metrics/src/lib.rs
@@ -25,7 +25,7 @@ pub use prometheus::{
 
 use anyhow::Result;
 use libra_logger::prelude::*;
-use prometheus::{core::Collector, proto::MetricType, Encoder, TextEncoder};
+use prometheus::{proto::MetricType, Encoder, TextEncoder};
 use std::{
     collections::HashMap,
     fs::{create_dir_all, File, OpenOptions},
@@ -116,11 +116,4 @@ pub fn dump_all_metrics_to_file_periodically<P: AsRef<Path>>(
         }
         thread::sleep(time::Duration::from_millis(interval));
     });
-}
-
-pub fn get_metric_name<M>(metric: &M) -> String
-where
-    M: Collector,
-{
-    metric.collect()[0].get_name().to_string()
 }

--- a/common/metrics/src/op_counters.rs
+++ b/common/metrics/src/op_counters.rs
@@ -7,8 +7,8 @@
 use prometheus::{
     core::{Collector, Desc},
     proto::MetricFamily,
-    Histogram, HistogramOpts, HistogramTimer, HistogramVec, IntCounter, IntCounterVec, IntGauge,
-    IntGaugeVec, Opts,
+    Histogram, HistogramOpts, HistogramTimer, HistogramVec, IntCounterVec, IntGauge, IntGaugeVec,
+    Opts,
 };
 
 use std::time::Duration;
@@ -94,11 +94,6 @@ impl OpMetrics {
     #[inline]
     pub fn peer_gauge(&self, name: &str, remote_peer_id: &str) -> IntGauge {
         self.peer_gauges.with_label_values(&[name, remote_peer_id])
-    }
-
-    #[inline]
-    pub fn counter(&self, name: &str) -> IntCounter {
-        self.counters.with_label_values(&[name])
     }
 
     #[inline]

--- a/common/metrics/src/op_counters.rs
+++ b/common/metrics/src/op_counters.rs
@@ -96,11 +96,6 @@ impl OpMetrics {
         self.peer_gauges.with_label_values(&[name, remote_peer_id])
     }
 
-    #[inline]
-    pub fn histogram(&self, name: &str) -> Histogram {
-        self.duration_histograms.with_label_values(&[name])
-    }
-
     pub fn duration_histogram(&self, name: &str) -> DurationHistogram {
         DurationHistogram::new(self.duration_histograms.with_label_values(&[name]))
     }

--- a/common/metrics/src/op_counters.rs
+++ b/common/metrics/src/op_counters.rs
@@ -96,10 +96,6 @@ impl OpMetrics {
         self.peer_gauges.with_label_values(&[name, remote_peer_id])
     }
 
-    pub fn duration_histogram(&self, name: &str) -> DurationHistogram {
-        DurationHistogram::new(self.duration_histograms.with_label_values(&[name]))
-    }
-
     #[inline]
     pub fn inc(&self, op: &str) {
         self.counters.with_label_values(&[op]).inc();

--- a/common/metrics/src/op_counters.rs
+++ b/common/metrics/src/op_counters.rs
@@ -109,16 +109,6 @@ impl OpMetrics {
     }
 
     #[inline]
-    pub fn add(&self, op: &str) {
-        self.gauges.with_label_values(&[op]).inc();
-    }
-
-    #[inline]
-    pub fn sub(&self, op: &str) {
-        self.gauges.with_label_values(&[op]).dec();
-    }
-
-    #[inline]
     pub fn set(&self, op: &str, v: usize) {
         // The underlying method is expecting i64, but most of the types
         // we're going to log are `u64` or `usize`.

--- a/crypto/crypto/src/hash.rs
+++ b/crypto/crypto/src/hash.rs
@@ -163,11 +163,6 @@ impl HashValue {
         }
     }
 
-    /// Check if the hash value is zero.
-    pub fn is_zero(&self) -> bool {
-        *self == HashValue::zero()
-    }
-
     /// Create a cryptographically random instance.
     pub fn random() -> Self {
         let mut rng = OsRng;

--- a/execution/executor/src/db_bootstrapper.rs
+++ b/execution/executor/src/db_bootstrapper.rs
@@ -59,10 +59,6 @@ impl<V: VMExecutor> GenesisCommitter<V> {
         })
     }
 
-    pub fn ledger_info_with_sigs(&self) -> &LedgerInfoWithSignatures {
-        &self.ledger_info_with_sigs
-    }
-
     pub fn waypoint(&self) -> Waypoint {
         self.waypoint
     }

--- a/json-rpc/types/src/views.rs
+++ b/json-rpc/types/src/views.rs
@@ -332,16 +332,6 @@ pub enum TransactionDataView {
     UnknownTransaction {},
 }
 
-impl TransactionView {
-    pub fn get_transaction_name(&self) -> String {
-        if let TransactionDataView::UserTransaction { script, .. } = &self.transaction {
-            script.get_name()
-        } else {
-            "".to_string()
-        }
-    }
-}
-
 #[derive(Clone, Debug, Deserialize, Serialize, PartialEq)]
 #[serde(tag = "type")]
 // TODO cover all script types

--- a/secure/push-metrics/src/counters.rs
+++ b/secure/push-metrics/src/counters.rs
@@ -26,10 +26,6 @@ impl BaseMetric {
     pub fn inc(&self) {
         self.inc_by(1);
     }
-
-    pub fn set(&self, i: i64) {
-        self.counter.store(i, Ordering::Relaxed);
-    }
 }
 
 /// PushMetricFormat contains a single function which converts the
@@ -88,11 +84,6 @@ impl Gauge {
             base_counter: BaseMetric::new(counter_name, counter_help),
             has_been_set: AtomicBool::new(false),
         }
-    }
-
-    pub fn set(&self, i: i64) {
-        self.has_been_set.store(true, Ordering::Relaxed);
-        self.base_counter.set(i);
     }
 }
 

--- a/secure/storage/src/crypto_storage.rs
+++ b/secure/storage/src/crypto_storage.rs
@@ -7,7 +7,6 @@ use libra_crypto::{
     HashValue,
 };
 use serde::{Deserialize, Serialize};
-use std::time::{Duration, SystemTime};
 
 /// CryptoStorage offers a secure storage engine for generating, using and managing cryptographic
 /// keys securely. The API offered here is inspired by the 'Transit Secret Engine' provided by
@@ -88,21 +87,4 @@ pub struct PublicKeyResponse {
     pub last_update: u64,
     /// Ed25519PublicKey stored at the provided key
     pub public_key: Ed25519PublicKey,
-}
-
-impl PublicKeyResponse {
-    /// Creates a PublicKeyResponse using the current time for the timestamp
-    pub fn new(public_key: Ed25519PublicKey) -> Self {
-        Self {
-            public_key,
-            last_update: Self::now().as_secs(),
-        }
-    }
-
-    /// Returns back a Duration encompassing the current system time less the Unix Epoch
-    fn now() -> Duration {
-        SystemTime::now()
-            .duration_since(SystemTime::UNIX_EPOCH)
-            .unwrap()
-    }
 }

--- a/secure/storage/src/namespaced_storage.rs
+++ b/secure/storage/src/namespaced_storage.rs
@@ -43,10 +43,6 @@ impl<T> NamespacedStorage<T> {
     fn ns_name(&self, key: &str) -> String {
         format!("{}/{}", self.namespace, key)
     }
-
-    pub fn namespace(&self) -> &str {
-        &self.namespace
-    }
 }
 
 impl<T: KVStorage> CryptoKVStorage for NamespacedStorage<T> {}

--- a/secure/storage/src/policy.rs
+++ b/secure/storage/src/policy.rs
@@ -14,10 +14,6 @@ impl Policy {
         Self { permissions }
     }
 
-    pub fn is_default(&self) -> bool {
-        Self::default() == *self
-    }
-
     pub fn public() -> Self {
         Self::new(vec![Permission::new(
             Identity::Anyone,

--- a/secure/storage/src/vault.rs
+++ b/secure/storage/src/vault.rs
@@ -39,10 +39,6 @@ impl VaultStorage {
         }
     }
 
-    pub fn namespace(&self) -> Option<String> {
-        self.namespace.clone()
-    }
-
     #[cfg(any(test, feature = "testing"))]
     fn reset_kv(&self, path: &str) -> Result<(), Error> {
         let secrets = self.client.list_secrets(path)?;

--- a/state-synchronizer/src/lib.rs
+++ b/state-synchronizer/src/lib.rs
@@ -9,8 +9,7 @@
 
 use executor_types::ExecutedTrees;
 use libra_types::{
-    account_address::AccountAddress, epoch_state::EpochState,
-    ledger_info::LedgerInfoWithSignatures, validator_verifier::ValidatorVerifier,
+    account_address::AccountAddress, epoch_state::EpochState, ledger_info::LedgerInfoWithSignatures,
 };
 pub use synchronizer::{StateSyncClient, StateSynchronizer};
 
@@ -66,10 +65,6 @@ impl SynchronizerState {
 
     pub fn epoch(&self) -> u64 {
         self.trusted_epoch.epoch
-    }
-
-    pub fn verifier(&self) -> &ValidatorVerifier {
-        &self.trusted_epoch.verifier
     }
 }
 

--- a/storage/jellyfish-merkle/src/node_type/mod.rs
+++ b/storage/jellyfish-merkle/src/node_type/mod.rs
@@ -521,11 +521,6 @@ impl LeafNode {
         self.account_key
     }
 
-    /// Gets the hash of associated blob.
-    pub fn blob_hash(&self) -> HashValue {
-        self.blob_hash
-    }
-
     /// Gets the associated blob itself.
     pub fn blob(&self) -> &AccountStateBlob {
         &self.blob

--- a/storage/jellyfish-merkle/src/node_type/mod.rs
+++ b/storage/jellyfish-merkle/src/node_type/mod.rs
@@ -334,11 +334,6 @@ impl InternalNode {
         self.children.get(&n)
     }
 
-    /// Return the total number of existing children.
-    pub fn num_children(&self) -> usize {
-        self.children.len()
-    }
-
     /// Generates `existence_bitmap` and `leaf_bitmap` as a pair of `u16`s: child at index `i`
     /// exists if `existence_bitmap[i]` is set; child at index `i` is leaf node if
     /// `leaf_bitmap[i]` is set.


### PR DESCRIPTION
This PR removes 18 untested, unused methods from various crates (see below). The value of the PR may reside more in the signaling of the nature of those untested, unused methods rather than actual removal.

I do hope & expect that reviewers will come up with valid reasons why one or another of those methods should be part of our public API — I've hence separated commits per method so that those valid methods can be kept, by omitting the commit that removes them. Just say so in review, plz :slightly_smiling_face: 
