### PR TITLE
[cluster-test] Improve logging during k8s resource deletion

### DIFF
--- a/common/retrier/src/lib.rs
+++ b/common/retrier/src/lib.rs
@@ -3,7 +3,7 @@
 
 #![forbid(unsafe_code)]
 
-use libra_logger::error;
+use libra_logger::debug;
 use std::{future::Future, pin::Pin, thread, time::Duration};
 
 /// Given an operation retries it successfully sleeping everytime it fails
@@ -40,7 +40,7 @@ where
             Ok(value) => return Ok(value),
             Err(err) => {
                 if let Some(delay) = iterator.next() {
-                    error!("Error: {}. Retrying in {} seconds..", err, delay.as_secs());
+                    debug!("{}. Retrying in {} seconds..", err, delay.as_secs());
                     tokio::time::delay_for(delay).await;
                 } else {
                     return Err(err);


### PR DESCRIPTION
## Summary

* During retries, we were printing logs which shouldn't've been at the ERROR level as they can be false indication that there is a problem with cluster test
* Handle `resource_api.delete` error logging more carefully - don't log if the resource has already been deleted

## Test Plan

Ran cti