### PR TITLE
[move-prover] Attempt to fix Boogie crash by setting TMPDIR.

### DIFF
--- a/language/move-prover/tests/testsuite.rs
+++ b/language/move-prover/tests/testsuite.rs
@@ -25,6 +25,14 @@ fn test_runner(path: &Path) -> datatest_stable::Result<()> {
 
     let temp_dir = TempPath::new();
     std::fs::create_dir_all(temp_dir.path())?;
+
+    // We appear to have a racing condition on files Boogie creates. It's unknown at this point
+    // which files this are (looks like the SMTLIB file). This sets  $TMPDIR to our temp_dir to
+    // mitigate.
+    // TODO: This is an experiment to fix the spurious racing conditions. Either remove if
+    //   it doesn't help, or document better.
+    std::env::set_var("TMPDIR", temp_dir.path().to_string_lossy().to_string());
+
     let (flags, baseline_path) = get_flags(temp_dir.path(), path)?;
 
     let mut args = vec!["mvp_test".to_string()];


### PR DESCRIPTION
This is an attempt to fix the boogie racing condition by setting TMPDIR to our temporary test directory. Dotnet seems to consume this env variable to determine where to put temporary files (verified with opensnoop). Its a blind shot because the issue is not locally re-producable.

## Motivation

Test flakiness.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

NA

## Related PRs

NA
