### PR TITLE
[deps] use cargo-edit's cargo upgrade command to cleanup project tomls

### DIFF
--- a/admission-control/admission-control-proto/Cargo.toml
+++ b/admission-control/admission-control-proto/Cargo.toml
@@ -10,10 +10,10 @@ publish = false
 edition = "2018"
 
 [dependencies]
-anyhow = "1.0"
-tonic = "0.2"
+anyhow = "1.0.31"
+tonic = "0.2.1"
 tokio = { version = "0.2.21", features = ["full"] }
-prost = "0.6"
+prost = "0.6.1"
 
 grpc-types = { path = "../../grpc/types", version = "0.1.0"}
 libra-logger = { path = "../../common/logger", version = "0.1.0" }
@@ -21,7 +21,7 @@ libra-types = { path = "../../types", version = "0.1.0" }
 libra-workspace-hack = { path = "../../common/workspace-hack", version = "0.1.0" }
 
 [build-dependencies]
-tonic-build = "0.2"
+tonic-build = "0.2.0"
 
 [features]
 default = []

--- a/admission-control/admission-control-service/Cargo.toml
+++ b/admission-control/admission-control-service/Cargo.toml
@@ -10,13 +10,13 @@ publish = false
 edition = "2018"
 
 [dependencies]
-anyhow = "1.0"
+anyhow = "1.0.31"
 futures = "0.3.5"
 once_cell = "1.4.0"
 rand = "0.7.3"
-serde_json = "1.0"
+serde_json = "1.0.53"
 tokio = { version = "0.2.21", features = ["full"] }
-tonic = "0.2"
+tonic = "0.2.1"
 
 admission-control-proto = { path = "../admission-control-proto", version = "0.1.0" }
 debug-interface = { path = "../../common/debug-interface", version = "0.1.0" }

--- a/client/json-rpc/Cargo.toml
+++ b/client/json-rpc/Cargo.toml
@@ -10,7 +10,7 @@ publish = false
 edition = "2018"
 
 [dependencies]
-anyhow = "1.0"
+anyhow = "1.0.31"
 hex = "0.4.2"
 reqwest = { version = "0.10.6", features = ["blocking", "json"], default_features = false }
 serde = { version = "1.0.111", default-features = false }

--- a/client/libra-dev/Cargo.toml
+++ b/client/libra-dev/Cargo.toml
@@ -11,7 +11,7 @@ edition = "2018"
 
 [dependencies]
 libc = "0.2.71"
-static_assertions = "1.0.0"
+static_assertions = "1.1.0"
 
 grpc-types = {path = "../../grpc/types", version = "0.1.0"}
 lcs = { path = "../../common/lcs", version = "0.1.0", package = "libra-canonical-serialization" }

--- a/common/bitvec/Cargo.toml
+++ b/common/bitvec/Cargo.toml
@@ -16,4 +16,4 @@ serde = { version = "1.0.111", features = ["derive"] }
 [dev-dependencies]
 lcs = { path = "../lcs", version = "0.1.0", package = "libra-canonical-serialization" }
 libra-proptest-helpers = { path = "../proptest-helpers", version = "0.1.0"}
-proptest = { version = "0.10.0", default-features = true}
+proptest = { version = "0.10.0", default-features = true }

--- a/common/channel/Cargo.toml
+++ b/common/channel/Cargo.toml
@@ -10,7 +10,7 @@ publish = false
 edition = "2018"
 
 [dependencies]
-anyhow = "1.0"
+anyhow = "1.0.31"
 futures = "0.3.5"
 once_cell = "1.4.0"
 libra-logger = { path = "../logger", version = "0.1.0" }

--- a/common/crash-handler/Cargo.toml
+++ b/common/crash-handler/Cargo.toml
@@ -11,7 +11,7 @@ edition = "2018"
 
 [dependencies]
 backtrace = "0.3.48"
-toml = "0.5.3"
+toml = "0.5.6"
 
 libra-logger = { path = "../logger", version = "0.1.0" }
 libra-workspace-hack = { path = "../workspace-hack", version = "0.1.0" }

--- a/common/datatest-stable/Cargo.toml
+++ b/common/datatest-stable/Cargo.toml
@@ -13,9 +13,9 @@ edition = "2018"
 
 [dependencies]
 regex = "1.3.9"
-walkdir = "2.2.9"
+walkdir = "2.3.1"
 structopt = "0.3.14"
-termcolor = "1.0.5"
+termcolor = "1.1.0"
 libra-workspace-hack = { path = "../workspace-hack", version = "0.1.0" }
 
 [[test]]

--- a/common/debug-interface/Cargo.toml
+++ b/common/debug-interface/Cargo.toml
@@ -10,13 +10,13 @@ publish = false
 edition = "2018"
 
 [dependencies]
-anyhow = "1.0"
+anyhow = "1.0.31"
 tokio = { version = "0.2.21", features = ["full"] }
-serde_json = "1.0"
+serde_json = "1.0.53"
 reqwest = { version = "0.10.6", features = ["blocking", "json"], default_features = false }
-serde = "1.0"
+serde = "1.0.111"
 once_cell = "1.4.0"
-warp = "0.2.2"
+warp = "0.2.3"
 
 libra-logger = { path = "../logger", version = "0.1.0" }
 libra-metrics = { path = "../metrics", version = "0.1.0" }

--- a/common/lcs/Cargo.toml
+++ b/common/lcs/Cargo.toml
@@ -11,11 +11,11 @@ edition = "2018"
 
 [dependencies]
 libra-workspace-hack = { path = "../workspace-hack", version = "0.1.0" }
-thiserror = "1.0"
-serde = { version = "1.0", features = ["derive"] }
+thiserror = "1.0.19"
+serde = { version = "1.0.111", features = ["derive"] }
 
 [dev-dependencies]
-criterion = "=0.3.2"
+criterion = "0.3.2"
 proptest = "0.10.0"
 proptest-derive = "0.2.0"
 

--- a/common/logger/Cargo.toml
+++ b/common/logger/Cargo.toml
@@ -12,7 +12,7 @@ edition = "2018"
 # Do NOT add any inter-project dependencies.
 # This is to avoid ever having a circular dependency with the libra-logger crate.
 [dependencies]
-chrono = "0.4.9"
+chrono = "0.4.11"
 env_logger = { version = "0.7.1", default-features = false }
 libra-workspace-hack = { path = "../workspace-hack", version = "0.1.0" }
 log = "0.4.8"

--- a/common/metrics/Cargo.toml
+++ b/common/metrics/Cargo.toml
@@ -10,15 +10,15 @@ publish = false
 edition = "2018"
 
 [dependencies]
-anyhow = "1.0"
+anyhow = "1.0.31"
 futures = "0.3.5"
-hyper = "0.13"
+hyper = "0.13.6"
 libra-logger = { path = "../logger", version = "0.1.0" }
 libra-workspace-hack = { path = "../workspace-hack", version = "0.1.0" }
 once_cell = "1.4.0"
 prometheus = { version = "0.9.0", default-features = false }
 serde_json = "1.0.53"
-tokio = "0.2"
+tokio = "0.2.21"
 
 [dev-dependencies]
 rusty-fork = "0.3.0"

--- a/common/proptest-helpers/Cargo.toml
+++ b/common/proptest-helpers/Cargo.toml
@@ -10,7 +10,7 @@ publish = false
 edition = "2018"
 
 [dependencies]
-crossbeam = "0.7.2"
+crossbeam = "0.7.3"
 libra-workspace-hack = { path = "../workspace-hack", version = "0.1.0" }
 proptest = "0.10.0"
 proptest-derive = "0.2.0"

--- a/common/prost-test-helpers/Cargo.toml
+++ b/common/prost-test-helpers/Cargo.toml
@@ -12,4 +12,4 @@ edition = "2018"
 [dependencies]
 bytes = "0.5.4"
 libra-workspace-hack = { path = "../workspace-hack", version = "0.1.0" }
-prost = "0.6"
+prost = "0.6.1"

--- a/common/subscription-service/Cargo.toml
+++ b/common/subscription-service/Cargo.toml
@@ -10,7 +10,7 @@ publish = false
 edition = "2018"
 
 [dependencies]
-anyhow = "1.0"
+anyhow = "1.0.31"
 
 libra-types = { path = "../../types", version = "0.1.0" }
 libra-workspace-hack = { path = "../../common/workspace-hack", version = "0.1.0" }

--- a/config/Cargo.toml
+++ b/config/Cargo.toml
@@ -10,14 +10,14 @@ publish = false
 edition = "2018"
 
 [dependencies]
-anyhow = "1.0"
+anyhow = "1.0.31"
 get_if_addrs = { version = "0.5.3", default-features = false }
 mirai-annotations = "1.8.0"
 rand = "0.7.3"
 serde = { version = "1.0.111", features = ["rc"], default-features = false }
 log = { version = "0.4.8", features = ["serde"] }
-thiserror = "1.0"
-toml = { version = "0.5.3", default-features = false }
+thiserror = "1.0.19"
+toml = { version = "0.5.6", default-features = false }
 
 lcs = { path = "../common/lcs", version = "0.1.0", package = "libra-canonical-serialization" }
 libra-crypto = { path = "../crypto/crypto", version = "0.1.0" }

--- a/config/config-builder/Cargo.toml
+++ b/config/config-builder/Cargo.toml
@@ -10,11 +10,11 @@ publish = false
 edition = "2018"
 
 [dependencies]
-anyhow = "1.0"
+anyhow = "1.0.31"
 hex = "0.4.2"
 rand = "0.7.3"
 structopt = "0.3.14"
-thiserror = "1.0"
+thiserror = "1.0.19"
 
 executor = { path = "../../execution/executor", version = "0.1.0" }
 generate-key = { path = "../../config/generate-key", version = "0.1.0" }

--- a/config/management/Cargo.toml
+++ b/config/management/Cargo.toml
@@ -10,11 +10,11 @@ publish = false
 edition = "2018"
 
 [dependencies]
-anyhow = "1.0"
+anyhow = "1.0.31"
 serde = { version = "1.0.111", features = ["rc"], default-features = false }
 structopt = "0.3.14"
-thiserror = "1.0"
-toml = { version = "0.5.3", default-features = false }
+thiserror = "1.0.19"
+toml = { version = "0.5.6", default-features = false }
 
 executor = { path = "../../execution/executor", version = "0.1.0" }
 lcs = { path = "../../common/lcs", version = "0.1.0", package = "libra-canonical-serialization" }

--- a/consensus/Cargo.toml
+++ b/consensus/Cargo.toml
@@ -10,21 +10,21 @@ publish = false
 edition = "2018"
 
 [dependencies]
-anyhow = "1.0"
-async-trait = "0.1"
-byteorder = { version = "1.3.2", default-features = false }
+anyhow = "1.0.31"
+async-trait = "0.1.32"
+byteorder = { version = "1.3.4", default-features = false }
 bytes = "0.5.4"
 futures = "0.3.5"
 mirai-annotations = { version = "1.8.0", default-features = false }
 num-derive = { version = "0.3.0", default-features = false }
-num-traits = { version = "0.2.8", default-features = false }
+num-traits = { version = "0.2.11", default-features = false }
 once_cell = "1.4.0"
 proptest = { version = "0.10.0", optional = true }
 rand = { version = "0.7.3", default-features = false }
 serde = { version = "1.0.111", default-features = false }
-serde_json = "1.0"
-termion = { version = "1.5.3", default-features = false }
-thiserror = "1.0"
+serde_json = "1.0.53"
+termion = { version = "1.5.5", default-features = false }
+thiserror = "1.0.19"
 tokio = { version = "0.2.21", features = ["full"] }
 
 channel = { path = "../common/channel", version = "0.1.0" }

--- a/consensus/consensus-types/Cargo.toml
+++ b/consensus/consensus-types/Cargo.toml
@@ -7,7 +7,7 @@ publish = false
 edition = "2018"
 
 [dependencies]
-anyhow = "1.0"
+anyhow = "1.0.31"
 mirai-annotations = { version = "1.8.0", default-features = false }
 proptest = { version = "0.10.0", optional = true }
 serde = { version = "1.0.111", default-features = false }

--- a/consensus/safety-rules/Cargo.toml
+++ b/consensus/safety-rules/Cargo.toml
@@ -7,7 +7,7 @@ publish = false
 edition = "2018"
 
 [dependencies]
-anyhow = "1.0"
+anyhow = "1.0.31"
 once_cell = "1.4.0"
 rand = { version = "0.7.3", default-features = false }
 
@@ -24,10 +24,10 @@ libra-temppath = { path = "../../common/temppath", version = "0.1.0" }
 libra-types = { path = "../../types", version = "0.1.0" }
 libra-workspace-hack = { path = "../../common/workspace-hack", version = "0.1.0" }
 serde = { version = "1.0.111", default-features = false }
-thiserror = "1.0"
+thiserror = "1.0.19"
 
 [dev-dependencies]
-criterion = "0.3"
+criterion = "0.3.2"
 tempfile = "3.1.0"
 workspace-builder = { path = "../../common/workspace-builder", version = "0.1.0" }
 

--- a/crypto/crypto-derive/Cargo.toml
+++ b/crypto/crypto-derive/Cargo.toml
@@ -18,4 +18,4 @@ quote = "1.0.6"
 proc-macro2 = "1.0.18"
 
 [dev-dependencies]
-anyhow = "1.0"
+anyhow = "1.0.31"

--- a/crypto/crypto/Cargo.toml
+++ b/crypto/crypto/Cargo.toml
@@ -10,7 +10,7 @@ publish = false
 edition = "2018"
 
 [dependencies]
-anyhow = "1.0"
+anyhow = "1.0.31"
 bytes = "0.5.4"
 curve25519-dalek = { git = "https://github.com/calibra/curve25519-dalek.git", branch = "fiat2", default-features = false }
 digest = "0.8.1"
@@ -24,27 +24,27 @@ proptest-derive = { version = "0.2.0", optional = true }
 rand = "0.7.3"
 rand_core = { version = "0.5.1", default-features = false }
 serde = { version = "1.0.111", features = ["derive"] }
-serde_bytes = "0.11"
-serde-name = "0.1"
+serde_bytes = "0.11.4"
+serde-name = "0.1.0"
 sha2 = "0.8.2"
-static_assertions = { version = "1.0.0", optional = true }
-thiserror = "1.0"
-tiny-keccak = { version = "2.0.2", features = ["sha3"]}
+static_assertions = { version = "1.1.0", optional = true }
+thiserror = "1.0.19"
+tiny-keccak = { version = "2.0.2", features = ["sha3"] }
 sha3 = "0.8.2"
 x25519-dalek = { git = "https://github.com/calibra/x25519-dalek.git", branch = "fiat2", default-features = false }
-aes-gcm = "0.5.0" # used in noise
+aes-gcm = "0.5.0"
 libra-crypto-derive = { path = "../crypto-derive", version = "0.1.0" }
 lcs = { path = "../../common/lcs", version = "0.1.0", package = "libra-canonical-serialization" }
 libra-nibble = { path = "../../common/nibble", version = "0.1.0" }
 libra-workspace-hack = { path = "../../common/workspace-hack", version = "0.1.0" }
 
 [dev-dependencies]
-bitvec = "0.17.3"
-byteorder = "1.3.2"
-proptest = { version = "0.10.0"}
-proptest-derive = { version = "0.2.0"}
+bitvec = "0.17.4"
+byteorder = "1.3.4"
+proptest = "0.10.0"
+proptest-derive = "0.2.0"
 ripemd160 = "0.8.0"
-criterion = "0.3"
+criterion = "0.3.2"
 sha3 = "0.8.2"
 serde_json = "1.0.53"
 

--- a/devtools/x-core/Cargo.toml
+++ b/devtools/x-core/Cargo.toml
@@ -13,4 +13,4 @@ libra-workspace-hack = { path = "../../common/workspace-hack", version = "0.1.0"
 toml = "0.5.6"
 once_cell = "1.4.0"
 rental = "0.5.5"
-serde = { version = "1", features = ["derive"] }
+serde = { version = "1.0.111", features = ["derive"] }

--- a/devtools/x-lint/Cargo.toml
+++ b/devtools/x-lint/Cargo.toml
@@ -12,5 +12,5 @@ guppy = "0.4.1"
 libra-workspace-hack = { path = "../../common/workspace-hack", version = "0.1.0" }
 once_cell = "1.4.0"
 toml = "0.5.6"
-serde = { version = "1", features = ["derive"] }
+serde = { version = "1.0.111", features = ["derive"] }
 x-core = { version = "0.1.0", path = "../x-core" }

--- a/devtools/x/Cargo.toml
+++ b/devtools/x/Cargo.toml
@@ -8,10 +8,10 @@ publish = false
 license = "Apache-2.0"
 
 [dependencies]
-serde = { version = "1.0", features = ["derive"] }
+serde = { version = "1.0.111", features = ["derive"] }
 serde_json = "1.0.53"
 structopt = "0.3.14"
-anyhow = "1.0"
+anyhow = "1.0.31"
 colored-diff = "0.2.2"
 guppy = "0.4.1"
 toml = "0.5.6"

--- a/execution/db-bootstrapper/Cargo.toml
+++ b/execution/db-bootstrapper/Cargo.toml
@@ -10,7 +10,7 @@ publish = false
 edition = "2018"
 
 [dependencies]
-anyhow = "1.0"
+anyhow = "1.0.31"
 structopt = "0.3.14"
 
 executor = { path = "../executor", version = "0.1.0" }

--- a/execution/execution-correctness/Cargo.toml
+++ b/execution/execution-correctness/Cargo.toml
@@ -7,7 +7,7 @@ publish = false
 edition = "2018"
 
 [dependencies]
-anyhow = "1.0"
+anyhow = "1.0.31"
 rand = { version = "0.7.3", default-features = false }
 
 executor = { path = "../executor", version = "0.1.0" }
@@ -23,7 +23,7 @@ libra-vm = { path = "../../language/libra-vm", version = "0.1.0" }
 libra-workspace-hack = { path = "../../common/workspace-hack", version = "0.1.0" }
 serde = { version = "1.0.111", default-features = false }
 storage-client = { path = "../../storage/storage-client", version = "0.1.0" }
-thiserror = "1.0"
+thiserror = "1.0.19"
 
 [dev-dependencies]
 config-builder = { path = "../../config/config-builder", version = "0.1.0" }

--- a/execution/executor-benchmark/Cargo.toml
+++ b/execution/executor-benchmark/Cargo.toml
@@ -12,8 +12,8 @@ edition = "2018"
 [dependencies]
 itertools = { version = "0.9.0", default-features = false }
 rand = "0.7.3"
-rayon = "1"
-structopt = "0.3"
+rayon = "1.3.0"
+structopt = "0.3.14"
 
 config-builder = { path = "../../config/config-builder", version = "0.1.0" }
 executor = { path = "../executor", version = "0.1.0" }

--- a/execution/executor-types/Cargo.toml
+++ b/execution/executor-types/Cargo.toml
@@ -10,9 +10,9 @@ publish = false
 edition = "2018"
 
 [dependencies]
-anyhow = "1.0"
+anyhow = "1.0.31"
 serde = { version = "1.0.111", default-features = false }
-thiserror = "1.0"
+thiserror = "1.0.19"
 
 lcs = { path = "../../common/lcs", version = "0.1.0", package = "libra-canonical-serialization" }
 libra-crypto = { path = "../../crypto/crypto", version = "0.1.0" }

--- a/execution/executor/Cargo.toml
+++ b/execution/executor/Cargo.toml
@@ -10,10 +10,10 @@ publish = false
 edition = "2018"
 
 [dependencies]
-anyhow = "1.0"
+anyhow = "1.0.31"
 itertools = { version = "0.9.0", default-features = false }
 once_cell = "1.4.0"
-serde_json = "1.0"
+serde_json = "1.0.53"
 
 consensus-types = { path = "../../consensus/consensus-types", version = "0.1.0"}
 debug-interface = { path = "../../common/debug-interface", version = "0.1.0" }

--- a/grpc/types/Cargo.toml
+++ b/grpc/types/Cargo.toml
@@ -10,8 +10,8 @@ publish = false
 edition = "2018"
 
 [dependencies]
-anyhow = "1.0"
-prost = "0.6"
+anyhow = "1.0.31"
+prost = "0.6.1"
 proptest = { version = "0.10.0", default-features = false, optional = true }
 
 lcs = { path = "../../common/lcs", version = "0.1.0", package = "libra-canonical-serialization" }
@@ -26,7 +26,7 @@ libra-prost-test-helpers = { path = "../../common/prost-test-helpers", version =
 
 
 [build-dependencies]
-prost-build = "0.6"
+prost-build = "0.6.1"
 
 [features]
 default = []

--- a/json-rpc/Cargo.toml
+++ b/json-rpc/Cargo.toml
@@ -10,14 +10,14 @@ publish = false
 edition = "2018"
 
 [dependencies]
-anyhow = "1.0"
+anyhow = "1.0.31"
 futures = "0.3.5"
 hex = "0.4.2"
 once_cell = "1.4.0"
 serde_json = "1.0.53"
 serde = { version = "1.0.111", default-features = false }
 tokio = { version = "0.2.21", features = ["full"] }
-warp = "0.2.2"
+warp = "0.2.3"
 reqwest = { version = "0.10.6", features = ["blocking", "json"], default_features = false, optional = true }
 proptest = { version = "0.10.0", optional = true }
 

--- a/json-rpc/types/Cargo.toml
+++ b/json-rpc/types/Cargo.toml
@@ -10,7 +10,7 @@ publish = false
 edition = "2018"
 
 [dependencies]
-anyhow = "1.0"
+anyhow = "1.0.31"
 hex = "0.4.2"
 serde = { version = "1.0.111", default-features = false }
 serde_json = "1.0.53"

--- a/language/benchmarks/Cargo.toml
+++ b/language/benchmarks/Cargo.toml
@@ -10,7 +10,7 @@ publish = false
 edition = "2018"
 
 [dependencies]
-anyhow = "1.0"
+anyhow = "1.0.31"
 criterion = "0.3.2"
 proptest = "0.10.0"
 

--- a/language/bytecode-verifier/Cargo.toml
+++ b/language/bytecode-verifier/Cargo.toml
@@ -10,7 +10,7 @@ publish = false
 edition = "2018"
 
 [dependencies]
-anyhow = "1.0"
+anyhow = "1.0.31"
 mirai-annotations = "1.8.0"
 petgraph = "0.5.1"
 

--- a/language/compiler/Cargo.toml
+++ b/language/compiler/Cargo.toml
@@ -10,7 +10,7 @@ publish = false
 edition = "2018"
 
 [dependencies]
-anyhow = "1.0"
+anyhow = "1.0.31"
 bytecode-verifier = { path = "../bytecode-verifier", version = "0.1.0" }
 ir-to-bytecode = { path = "ir-to-bytecode", version = "0.1.0" }
 bytecode-source-map = { path = "bytecode-source-map", version = "0.1.0" }

--- a/language/compiler/bytecode-source-map/Cargo.toml
+++ b/language/compiler/bytecode-source-map/Cargo.toml
@@ -7,7 +7,7 @@ publish = false
 edition = "2018"
 
 [dependencies]
-anyhow = "1.0"
+anyhow = "1.0.31"
 libra-types = { path = "../../../types", version = "0.1.0" }
 libra-workspace-hack = { path = "../../../common/workspace-hack", version = "0.1.0" }
 move-core-types = { path = "../../move-core/types", version = "0.1.0" }

--- a/language/compiler/ir-to-bytecode/Cargo.toml
+++ b/language/compiler/ir-to-bytecode/Cargo.toml
@@ -10,7 +10,7 @@ publish = false
 edition = "2018"
 
 [dependencies]
-anyhow = "1.0"
+anyhow = "1.0.31"
 ir-to-bytecode-syntax = { path = "syntax", version = "0.1.0" }
 libra-types = { path = "../../../types", version = "0.1.0" }
 libra-workspace-hack = { path = "../../../common/workspace-hack", version = "0.1.0" }
@@ -18,10 +18,10 @@ move-core-types = { path = "../../move-core/types", version = "0.1.0" }
 move-ir-types = { path = "../../move-ir/types", version = "0.1.0" }
 vm = { path = "../../vm", version = "0.1.0" }
 bytecode-source-map = { path = "../bytecode-source-map", version = "0.1.0" }
-log = "0.4.7"
+log = "0.4.8"
 codespan = "0.8.0"
 codespan-reporting = "0.8.0"
-thiserror = "1.0"
+thiserror = "1.0.19"
 
 [features]
 default = []

--- a/language/compiler/ir-to-bytecode/syntax/Cargo.toml
+++ b/language/compiler/ir-to-bytecode/syntax/Cargo.toml
@@ -10,7 +10,7 @@ publish = false
 edition = "2018"
 
 [dependencies]
-anyhow = "1.0"
+anyhow = "1.0.31"
 codespan = { version = "0.8.0", features = ["serialization"] }
 hex = "0.4.2"
 move-ir-types = { path = "../../../move-ir/types", version = "0.1.0" }

--- a/language/e2e-tests/Cargo.toml
+++ b/language/e2e-tests/Cargo.toml
@@ -10,7 +10,7 @@ license = "Apache-2.0"
 publish = false
 
 [dependencies]
-anyhow = "1.0"
+anyhow = "1.0.31"
 bytecode-verifier = { path = "../bytecode-verifier", version = "0.1.0" }
 lcs = { path = "../../common/lcs", version = "0.1.0", package = "libra-canonical-serialization" }
 compiler = { path = "../compiler", version = "0.1.0" }

--- a/language/functional-tests/Cargo.toml
+++ b/language/functional-tests/Cargo.toml
@@ -9,7 +9,7 @@ license = "Apache-2.0"
 edition = "2018"
 
 [dependencies]
-anyhow = "1.0"
+anyhow = "1.0.31"
 libra-state-view = { path = "../../storage/state-view", version = "0.1.0" }
 libra-types = { path = "../../types", version = "0.1.0" }
 libra-vm = { path = "../libra-vm",  version = "0.1.0" }
@@ -21,9 +21,9 @@ libra-crypto = { path = "../../crypto/crypto", version = "0.1.0" }
 libra-workspace-hack = { path = "../../common/workspace-hack", version = "0.1.0" }
 once_cell = "1.4.0"
 regex = { version = "1.3.9", default-features = false, features = ["std", "perf"] }
-thiserror = "1.0"
+thiserror = "1.0.19"
 aho-corasick = "0.7.10"
-termcolor = "1.0.5"
+termcolor = "1.1.0"
 datatest-stable = { path = "../../common/datatest-stable", version = "0.1.0" }
 mirai-annotations = "1.8.0"
 move-core-types = { path = "../move-core/types", version = "0.1.0" }

--- a/language/ir-testsuite/Cargo.toml
+++ b/language/ir-testsuite/Cargo.toml
@@ -9,7 +9,7 @@ license = "Apache-2.0"
 edition = "2018"
 
 [dev-dependencies]
-anyhow = "1.0"
+anyhow = "1.0.31"
 bytecode-verifier = { path = "../bytecode-verifier", version = "0.1.0" }
 datatest-stable = { path = "../../common/datatest-stable", version = "0.1.0" }
 functional-tests = { path = "../functional-tests", version = "0.1.0" }

--- a/language/libra-vm/Cargo.toml
+++ b/language/libra-vm/Cargo.toml
@@ -11,7 +11,7 @@ edition = "2018"
 
 [dependencies]
 once_cell = "1.4.0"
-rayon = "1.1"
+rayon = "1.3.0"
 mirai-annotations = "1.8.0"
 
 lcs = { path = "../../common/lcs", version = "0.1.0", package = "libra-canonical-serialization" }
@@ -26,7 +26,7 @@ move-vm-runtime = { path = "../move-vm/runtime", version = "0.1.0" }
 move-vm-types = { path = "../move-vm/types", version = "0.1.0" }
 vm = { path = "../vm", version = "0.1.0" }
 debug-interface = { path = "../../common/debug-interface", version = "0.1.0" }
-serde_json = "1.0"
+serde_json = "1.0.53"
 serde = { version = "1.0.111", default-features = false }
 
 [dev-dependencies]

--- a/language/move-core/types/Cargo.toml
+++ b/language/move-core/types/Cargo.toml
@@ -10,15 +10,15 @@ publish = false
 edition = "2018"
 
 [dependencies]
-anyhow = "1.0"
+anyhow = "1.0.31"
 hex = "0.4.2"
 rand = "0.7.3"
 proptest = { version = "0.10.0", default-features = false, optional = true }
 mirai-annotations = "1.8.0"
 proptest-derive = { version = "0.2.0", default-features = false, optional = true }
-ref-cast = "1.0"
+ref-cast = "1.0.1"
 serde = { version = "1.0.111", default-features = false }
-thiserror = "1.0"
+thiserror = "1.0.19"
 
 lcs = { path = "../../../common/lcs", version = "0.1.0", package = "libra-canonical-serialization" }
 libra-workspace-hack = { path = "../../../common/workspace-hack", version = "0.1.0" }

--- a/language/move-ir/types/Cargo.toml
+++ b/language/move-ir/types/Cargo.toml
@@ -11,7 +11,7 @@ edition = "2018"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-anyhow = "1.0"
+anyhow = "1.0.31"
 codespan = { version = "0.8.0", features = ["serialization"] }
 serde = { version = "1.0.111", features = ["derive"] }
 hex = "0.4.2"

--- a/language/move-lang/Cargo.toml
+++ b/language/move-lang/Cargo.toml
@@ -7,13 +7,13 @@ edition = "2018"
 license = "Apache-2.0"
 
 [dependencies]
-anyhow = "1.0"
+anyhow = "1.0.31"
 codespan = "0.8.0"
 codespan-reporting = "0.8.0"
 hex = "0.4.2"
 regex = "1.3.9"
 structopt = "0.3.14"
-difference = "2.0"
+difference = "2.0.0"
 petgraph = "0.5.1"
 datatest-stable = { path = "../../common/datatest-stable", version = "0.1.0" }
 walkdir = "2.3.1"

--- a/language/move-prover/Cargo.toml
+++ b/language/move-prover/Cargo.toml
@@ -21,14 +21,14 @@ move-ir-types = { path = "../move-ir/types", version = "0.1.0" }
 
 
 # external dependencies
-anyhow = "1.0.*"
+anyhow = "1.0.31"
 clap = "2.33.1"
 codespan = "0.8.0"
 codespan-reporting = "0.8.0"
 handlebars = "3.1.0"
 itertools = "0.9.0"
 log = "0.4.8"
-num = "0.2.0"
+num = "0.2.1"
 pretty = "0.10.0"
 regex = "1.3.9"
 serde = { version = "1.0.111", features = ["derive"] }

--- a/language/move-prover/docgen/Cargo.toml
+++ b/language/move-prover/docgen/Cargo.toml
@@ -17,9 +17,9 @@ codespan = "0.8.0"
 codespan-reporting = "0.8.0"
 itertools = "0.9.0"
 log = "0.4.8"
-num = "0.2.0"
+num = "0.2.1"
 regex = "1.3.9"
-anyhow = "1.0.*"
+anyhow = "1.0.31"
 serde = { version = "1.0.111", features = ["derive"] }
 once_cell = "1.4.0"
 

--- a/language/move-prover/spec-lang/Cargo.toml
+++ b/language/move-prover/spec-lang/Cargo.toml
@@ -22,9 +22,9 @@ codespan = "0.8.0"
 codespan-reporting = "0.8.0"
 itertools = "0.9.0"
 log = "0.4.8"
-num = "0.2.0"
+num = "0.2.1"
 regex = "1.3.9"
-anyhow = "1.0.*"
+anyhow = "1.0.31"
 
 [dev-dependencies]
 datatest-stable = { path = "../../../common/datatest-stable", version = "0.1.0" }

--- a/language/move-prover/stackless-bytecode-generator/Cargo.toml
+++ b/language/move-prover/stackless-bytecode-generator/Cargo.toml
@@ -16,7 +16,7 @@ bytecode-verifier = { path = "../../bytecode-verifier", version = "0.1.0" }
 borrow-graph = { path = "../../borrow-graph", version = "0.0.1" }
 ir-to-bytecode = { path = "../../compiler/ir-to-bytecode", version = "0.1.0" }
 libra-workspace-hack = { path = "../../../common/workspace-hack", version = "0.1.0" }
-num = "0.2.0"
+num = "0.2.1"
 itertools = "0.9.0"
 libra-types = { path = "../../../types", version = "0.1.0" }
 move-core-types = { path = "../../move-core/types", version = "0.1.0" }
@@ -27,7 +27,7 @@ test-utils = { path = "../test-utils", version = "0.1.0" }
 codespan = "0.8.0"
 codespan-reporting = "0.8.0"
 libra-temppath = { path = "../../../common/temppath", version = "0.1.0" }
-anyhow = "1.0.*"
+anyhow = "1.0.31"
 
 [[test]]
 name = "testsuite"

--- a/language/move-prover/test-utils/Cargo.toml
+++ b/language/move-prover/test-utils/Cargo.toml
@@ -7,6 +7,6 @@ license = "Apache-2.0"
 
 [dependencies]
 prettydiff = "0.3.1"
-anyhow = "1.0.*"
+anyhow = "1.0.31"
 regex = "1.3.9"
 libra-workspace-hack = { path = "../../../common/workspace-hack", version = "0.1.0" }

--- a/language/move-vm/runtime/Cargo.toml
+++ b/language/move-vm/runtime/Cargo.toml
@@ -26,7 +26,7 @@ move-vm-types = { path = "../types", version = "0.1.0" }
 vm = { path = "../../vm", version = "0.1.0" }
 
 [dev-dependencies]
-anyhow = "1.0"
+anyhow = "1.0.31"
 hex = "0.4.2"
 proptest = "0.10.0"
 

--- a/language/move-vm/types/Cargo.toml
+++ b/language/move-vm/types/Cargo.toml
@@ -14,7 +14,7 @@ mirai-annotations = "1.8.0"
 once_cell = "1.4.0"
 proptest = { version = "0.10.0", optional = true }
 sha2 = "0.8.2"
-serde = { version = "1.0", features = ["derive", "rc"] }
+serde = { version = "1.0.111", features = ["derive", "rc"] }
 
 lcs = { path = "../../../common/lcs", version = "0.1.0", package = "libra-canonical-serialization" }
 libra-crypto = { path = "../../../crypto/crypto", version = "0.1.0"}

--- a/language/resource-viewer/Cargo.toml
+++ b/language/resource-viewer/Cargo.toml
@@ -19,9 +19,9 @@ move-vm-types = { path = "../move-vm/types", version = "0.1.0" }
 stdlib = { path = "../stdlib", version = "0.1.0" }
 vm = { path = "../vm", version = "0.1.0" }
 vm-genesis = { path = "../tools/vm-genesis", version = "0.1.0" }
-serde_json = "1.0"
-serde = { version = "1.0", features = ["derive", "rc"] }
+serde_json = "1.0.53"
+serde = { version = "1.0.111", features = ["derive", "rc"] }
 
-anyhow = "1.0"
+anyhow = "1.0.31"
 once_cell = "1.4.0"
 hex = "0.4.2"

--- a/language/stdlib/Cargo.toml
+++ b/language/stdlib/Cargo.toml
@@ -10,7 +10,7 @@ license = "Apache-2.0"
 publish = false
 
 [dependencies]
-anyhow = "1.0"
+anyhow = "1.0.31"
 bytecode-verifier = { path = "../bytecode-verifier", version = "0.1.0" }
 move-lang = { path = "../move-lang" }
 move-prover = { path = "../move-prover" }

--- a/language/tools/disassembler/Cargo.toml
+++ b/language/tools/disassembler/Cargo.toml
@@ -7,7 +7,7 @@ publish = false
 edition = "2018"
 
 [dependencies]
-anyhow = "1.0"
+anyhow = "1.0.31"
 colored = "1.9.3"
 
 bytecode-verifier = { path = "../../bytecode-verifier", version = "0.1.0" }

--- a/language/tools/move-coverage/Cargo.toml
+++ b/language/tools/move-coverage/Cargo.toml
@@ -13,7 +13,7 @@ edition = "2018"
 once_cell = "1.4.0"
 structopt = "0.3.14"
 serde = { version = "1.0.111", default-features = false }
-anyhow = "1.0"
+anyhow = "1.0.31"
 codespan = { version = "0.8.0", features = ["serialization"] }
 colored = "1.9.3"
 

--- a/language/tools/test-generation/Cargo.toml
+++ b/language/tools/test-generation/Cargo.toml
@@ -16,7 +16,7 @@ mirai-annotations = "1.8.0"
 structopt = "0.3.14"
 itertools = "0.9.0"
 hex = "0.4.2"
-getrandom = "0.1.13"
+getrandom = "0.1.14"
 crossbeam-channel = "0.4.2"
 
 bytecode-verifier = { path = "../../bytecode-verifier", version = "0.1.0" }

--- a/language/tools/vm-genesis/Cargo.toml
+++ b/language/tools/vm-genesis/Cargo.toml
@@ -10,7 +10,7 @@ license = "Apache-2.0"
 publish = false
 
 [dependencies]
-anyhow = "1.0"
+anyhow = "1.0.31"
 once_cell = "1.4.0"
 rand = "0.7.3"
 

--- a/language/vm/Cargo.toml
+++ b/language/vm/Cargo.toml
@@ -10,13 +10,13 @@ publish = false
 edition = "2018"
 
 [dependencies]
-anyhow = "1.0"
-byteorder = "1.3.2"
+anyhow = "1.0.31"
+byteorder = "1.3.4"
 once_cell = "1.4.0"
 mirai-annotations = "1.8.0"
 proptest = { version = "0.10.0", optional = true }
 proptest-derive = { version = "0.2.0", optional = true }
-ref-cast = "1.0"
+ref-cast = "1.0.1"
 libra-crypto = { path = "../../crypto/crypto", version = "0.1.0" }
 libra-proptest-helpers = { path = "../../common/proptest-helpers", version = "0.1.0", optional = true }
 libra-types = { path = "../../types", version = "0.1.0" }
@@ -28,7 +28,7 @@ num-variants = { path = "../../common/num-variants", version = "0.1.0" }
 proptest = "0.10.0"
 proptest-derive = "0.2.0"
 libra-proptest-helpers = { path = "../../common/proptest-helpers", version = "0.1.0" }
-serde_json = "1"
+serde_json = "1.0.53"
 
 [features]
 default = []

--- a/libra-node/Cargo.toml
+++ b/libra-node/Cargo.toml
@@ -12,10 +12,10 @@ edition = "2018"
 [dependencies]
 futures = "0.3.5"
 jemallocator = { version = "0.3.2", features = ["profiling", "unprefixed_malloc_on_supported_platforms"] }
-rayon = "1.2.0"
+rayon = "1.3.0"
 structopt = "0.3.14"
 tokio = { version = "0.2.21", features = ["full"] }
-tonic = "0.2"
+tonic = "0.2.1"
 
 admission-control-proto = { path = "../admission-control/admission-control-proto", version = "0.1.0" }
 admission-control-service = { path = "../admission-control/admission-control-service", version = "0.1.0" }

--- a/mempool/Cargo.toml
+++ b/mempool/Cargo.toml
@@ -10,7 +10,7 @@ publish = false
 edition = "2018"
 
 [dependencies]
-anyhow = "1.0"
+anyhow = "1.0.31"
 futures = "0.3.5"
 once_cell = "1.4.0"
 serde = { version = "1.0.111", default-features = false }
@@ -29,7 +29,7 @@ libra-types = { path = "../types", version = "0.1.0" }
 libra-workspace-hack = { path = "../common/workspace-hack", version = "0.1.0" }
 mirai-annotations = "1.8.0"
 network = { path = "../network", version = "0.1.0" }
-serde_json = "1.0"
+serde_json = "1.0.53"
 storage-interface = { path = "../storage/storage-interface", version = "0.1.0" }
 vm-validator = { path = "../vm-validator", version = "0.1.0" }
 

--- a/network/Cargo.toml
+++ b/network/Cargo.toml
@@ -10,7 +10,7 @@ publish = false
 edition = "2018"
 
 [dependencies]
-anyhow = "1.0"
+anyhow = "1.0.31"
 bytes = { version = "0.5.4", features = ["serde"] }
 futures = "0.3.5"
 once_cell = "1.4.0"
@@ -18,9 +18,9 @@ pin-project = "0.4.17"
 rand = "0.7.3"
 serde = { version = "1.0.111", default-features = false }
 serde_bytes = "0.11.4"
-thiserror = "1.0"
+thiserror = "1.0.19"
 tokio = { version = "0.2.21", features = ["full"] }
-tokio-util = { version = "0.3", features = ["codec"] }
+tokio-util = { version = "0.3.1", features = ["codec"] }
 tokio-retry = "0.2.0"
 
 bitvec = { path = "../common/bitvec", version = "0.1.0", package = "libra-bitvec" }
@@ -44,7 +44,7 @@ stream-ratelimiter = { path = "../common/stream-ratelimiter", version = "0.1.0" 
 rand_core = { version = "0.5.1", optional = true }
 
 [dev-dependencies]
-criterion = "=0.3.2"
+criterion = "0.3.2"
 serial_test = "0.4.0"
 socket-bench-server = { path = "socket-bench-server", version = "0.1.0" }
 

--- a/network/netcore/Cargo.toml
+++ b/network/netcore/Cargo.toml
@@ -10,9 +10,9 @@ publish = false
 edition = "2018"
 
 [dependencies]
-async-trait = "0.1"
+async-trait = "0.1.32"
 bytes = "0.5.4"
-futures = { version = "0.3.5"  }
+futures = "0.3.5"
 pin-project = "0.4.17"
 tokio = { version = "0.2.21", features = ["full"] }
 

--- a/network/network-address/Cargo.toml
+++ b/network/network-address/Cargo.toml
@@ -14,14 +14,14 @@ proptest = { version = "0.10.0", optional = true }
 proptest-derive = { version = "0.2.0", optional = true }
 serde = { version = "1.0.111", default-features = false }
 serde_bytes = "0.11.4"
-thiserror = "1.0"
+thiserror = "1.0.19"
 
 lcs = { path = "../../common/lcs", version = "0.1.0", package = "libra-canonical-serialization" }
 libra-crypto = { path = "../../crypto/crypto", version = "0.1.0" }
 libra-workspace-hack = { path = "../../common/workspace-hack", version = "0.1.0" }
 
 [dev-dependencies]
-anyhow = "1.0"
+anyhow = "1.0.31"
 proptest = "0.10.0"
 proptest-derive = "0.2.0"
 

--- a/network/onchain-discovery/Cargo.toml
+++ b/network/onchain-discovery/Cargo.toml
@@ -10,7 +10,7 @@ publish = false
 edition = "2018"
 
 [dependencies]
-anyhow = "1.0"
+anyhow = "1.0.31"
 bytes = "0.5.4"
 futures = "0.3.5"
 rand = "0.7.3"

--- a/network/simple-onchain-discovery/Cargo.toml
+++ b/network/simple-onchain-discovery/Cargo.toml
@@ -10,8 +10,8 @@ publish = false
 edition = "2018"
 
 [dependencies]
-futures = { version = "0.3.5"  }
-once_cell = { version = "1.4.0"}
+futures = "0.3.5"
+once_cell = "1.4.0"
 
 channel = {path = "../../common/channel", version = "0.1.0"}
 libra-canonical-serialization = {path = "../../common/lcs", version = "0.1.0"}

--- a/network/socket-bench-server/Cargo.toml
+++ b/network/socket-bench-server/Cargo.toml
@@ -10,9 +10,9 @@ publish = false
 edition = "2018"
 
 [dependencies]
-futures = { version = "0.3.5"  }
+futures = "0.3.5"
 tokio = { version = "0.2.21", features = ["full"] }
-tokio-util = { version = "0.3", features = ["codec"] }
+tokio-util = { version = "0.3.1", features = ["codec"] }
 
 libra-crypto = { path = "../../crypto/crypto" }
 libra-logger = { path = "../../common/logger", version = "0.1.0" }

--- a/secure/json-rpc/Cargo.toml
+++ b/secure/json-rpc/Cargo.toml
@@ -12,7 +12,7 @@ edition = "2018"
 [dependencies]
 hex = "0.4.2"
 serde_json = "1.0.53"
-thiserror = "1.0"
+thiserror = "1.0.19"
 ureq = { version = "1.1.1", features = ["json"] }
 
 lcs = { path = "../../common/lcs", version = "0.1.0", package = "libra-canonical-serialization" }
@@ -22,7 +22,7 @@ libra-workspace-hack = { path = "../../common/workspace-hack", version = "0.1.0"
 serde = { version = "1.0.111", features = ["derive"], default-features = false }
 
 [dev-dependencies]
-anyhow = "1.0"
+anyhow = "1.0.31"
 futures = "0.3.5"
 tokio = { version = "0.2.21", features = ["full"] }
 

--- a/secure/key-manager/Cargo.toml
+++ b/secure/key-manager/Cargo.toml
@@ -12,7 +12,7 @@ publish = false
 [dependencies]
 once_cell = "1.4.0"
 serde = { version = "1.0.111", features = ["rc"], default-features = false }
-thiserror = "1.0"
+thiserror = "1.0.19"
 
 libra-config = { path = "../../config", version = "0.1.0"}
 libra-crypto = { path = "../../crypto/crypto", version = "0.1.0" }
@@ -27,7 +27,7 @@ libra-types = { path = "../../types", version = "0.1.0" }
 libra-workspace-hack = { path = "../../common/workspace-hack", version = "0.1.0" }
 
 [dev-dependencies]
-anyhow = "1.0"
+anyhow = "1.0.31"
 futures = "0.3.5"
 rand = "0.7.3"
 tokio = { version = "0.2.21", features = ["full"] }

--- a/secure/net/Cargo.toml
+++ b/secure/net/Cargo.toml
@@ -12,7 +12,7 @@ edition = "2018"
 [dependencies]
 libra-logger = { path = "../../common/logger", version = "0.1.0" }
 libra-workspace-hack = { path = "../../common/workspace-hack", version = "0.1.0" }
-thiserror = "1.0"
+thiserror = "1.0.19"
 
 [dev-dependencies]
 libra-config = { path = "../../config", version = "0.1.0" }

--- a/secure/storage/Cargo.toml
+++ b/secure/storage/Cargo.toml
@@ -11,11 +11,11 @@ edition = "2018"
 
 [dependencies]
 base64 = "0.12.1"
-chrono = "0.4.9"
+chrono = "0.4.11"
 rand = "0.7.3"
 serde = { version = "1.0.111", features = ["rc"], default-features = false }
 serde_json = "1.0.53"
-thiserror = "1.0"
+thiserror = "1.0.19"
 
 lcs = { path = "../../common/lcs", version = "0.1.0", package = "libra-canonical-serialization" }
 libra-config = { path = "../../config", version = "0.1.0" }

--- a/secure/storage/github/Cargo.toml
+++ b/secure/storage/github/Cargo.toml
@@ -12,7 +12,7 @@ edition = "2018"
 [dependencies]
 serde = { version = "1.0.111", features = ["derive"], default-features = false }
 serde_json = "1.0.53"
-thiserror = "1.0"
+thiserror = "1.0.19"
 ureq = { version = "1.1.1", features = ["json"] }
 
 libra-crypto = { path = "../../../crypto/crypto", version = "0.1.0" }

--- a/secure/storage/vault/Cargo.toml
+++ b/secure/storage/vault/Cargo.toml
@@ -11,11 +11,11 @@ edition = "2018"
 
 [dependencies]
 base64 = "0.12.1"
-chrono = "0.4.9"
+chrono = "0.4.11"
 rustls = "0.17.0"
 serde = { version = "1.0.111", features = ["derive"], default-features = false }
 serde_json = "1.0.53"
-thiserror = "1.0"
+thiserror = "1.0.19"
 ureq = { version = "1.1.1", features = ["json"] }
 
 libra-crypto = { path = "../../../crypto/crypto", version = "0.1.0" }

--- a/state-synchronizer/Cargo.toml
+++ b/state-synchronizer/Cargo.toml
@@ -10,7 +10,7 @@ publish = false
 edition = "2018"
 
 [dependencies]
-anyhow = "1.0"
+anyhow = "1.0.31"
 futures = "0.3.5"
 serde = { version = "1.0.111", default-features = false }
 once_cell = "1.4.0"

--- a/storage/accumulator/Cargo.toml
+++ b/storage/accumulator/Cargo.toml
@@ -10,7 +10,7 @@ publish = false
 edition = "2018"
 
 [dependencies]
-anyhow = "1.0"
+anyhow = "1.0.31"
 libra-crypto = { path = "../../crypto/crypto", version = "0.1.0" }
 mirai-annotations = "1.8.0"
 libra-types = { path = "../../types", version = "0.1.0" }

--- a/storage/backup/backup-cli/Cargo.toml
+++ b/storage/backup/backup-cli/Cargo.toml
@@ -9,20 +9,20 @@ publish = false
 edition = "2018"
 
 [dependencies]
-anyhow = "1.0"
+anyhow = "1.0.31"
 async-trait = "0.1.32"
-byteorder = "1.3.2"
+byteorder = "1.3.4"
 bytes = "0.5.4"
-futures = "0.3.0"
+futures = "0.3.5"
 hex = "0.4.2"
-itertools = "0.9"
+itertools = "0.9.0"
 rand = "0.7.3"
 reqwest = { version = "0.10.6", features = ["stream"], default-features = false }
 serde = { version = "1.0.111", features = ["derive"] }
 serde_json = "1.0.53"
-structopt = "0.3"
-tokio = "0.2"
-tokio-util = { version = "0.3", features = ["compat"]}
+structopt = "0.3.14"
+tokio = "0.2.21"
+tokio-util = { version = "0.3.1", features = ["compat"] }
 
 lcs = { path = "../../../common/lcs", package = "libra-canonical-serialization", version = "0.1.0" }
 libra-crypto = { path = "../../../crypto/crypto", version = "0.1.0" }

--- a/storage/backup/backup-service/Cargo.toml
+++ b/storage/backup/backup-service/Cargo.toml
@@ -9,13 +9,13 @@ publish = false
 edition = "2018"
 
 [dependencies]
-anyhow = "1.0"
-bytes = "0.5.3"
+anyhow = "1.0.31"
+bytes = "0.5.4"
 futures = "0.3.5"
-hyper = "0.13"
+hyper = "0.13.6"
 serde = { version = "1.0.111", default-features = false }
-tokio = { version = "0.2", features=["full"]}
-warp = "0.2.2"
+tokio = { version = "0.2.21", features = ["full"] }
+warp = "0.2.3"
 
 lcs = { path = "../../../common/lcs", package = "libra-canonical-serialization", version = "0.1.0" }
 libra-crypto = { path = "../../../crypto/crypto", version = "0.1.0" }

--- a/storage/inspector/Cargo.toml
+++ b/storage/inspector/Cargo.toml
@@ -9,7 +9,7 @@ publish = false
 edition = "2018"
 
 [dependencies]
-anyhow = "1.0"
+anyhow = "1.0.31"
 structopt = "0.3.14"
 tempfile = "3.1.0"
 

--- a/storage/jellyfish-merkle/Cargo.toml
+++ b/storage/jellyfish-merkle/Cargo.toml
@@ -10,15 +10,15 @@ publish = false
 edition = "2018"
 
 [dependencies]
-anyhow = "1.0"
-byteorder = "1.3.2"
+anyhow = "1.0.31"
+byteorder = "1.3.4"
 mirai-annotations = "1.8.0"
 num-derive = "0.3.0"
-num-traits = "0.2"
+num-traits = "0.2.11"
 proptest = { version = "0.10.0", optional = true }
 proptest-derive = { version = "0.2.0", optional = true }
 serde = { version = "1.0.111", features = ["derive"] }
-thiserror = "1.0"
+thiserror = "1.0.19"
 
 lcs = { path = "../../common/lcs", version = "0.1.0", package = "libra-canonical-serialization" }
 libra-crypto = { path = "../../crypto/crypto", version = "0.1.0" }

--- a/storage/libradb/Cargo.toml
+++ b/storage/libradb/Cargo.toml
@@ -10,17 +10,17 @@ publish = false
 edition = "2018"
 
 [dependencies]
-anyhow = "1.0"
+anyhow = "1.0.31"
 arc-swap = "0.4.6"
-byteorder = "1.3.2"
+byteorder = "1.3.4"
 itertools = "0.9.0"
 once_cell = "1.4.0"
 num-derive = "0.3.0"
-num-traits = "0.2"
+num-traits = "0.2.11"
 proptest = { version = "0.10.0", optional = true }
 proptest-derive = { version = "0.2.0", optional = true }
 serde = "1.0.111"
-thiserror = "1.0"
+thiserror = "1.0.19"
 
 accumulator = { path = "../accumulator", version = "0.1.0" }
 lcs = { path = "../../common/lcs", version = "0.1.0", package = "libra-canonical-serialization" }

--- a/storage/schemadb/Cargo.toml
+++ b/storage/schemadb/Cargo.toml
@@ -10,18 +10,18 @@ publish = false
 edition = "2018"
 
 [dependencies]
-anyhow = "1.0"
+anyhow = "1.0.31"
 once_cell = "1.4.0"
 libra-metrics = { path = "../../common/metrics", version = "0.1.0" }
 libra-workspace-hack = { path = "../../common/workspace-hack", version = "0.1.0" }
 
 [dependencies.rocksdb]
-version = "0.14"
+version = "0.14.0"
 default-features = false
 features = ["lz4"]
 
 [dev-dependencies]
-byteorder = "1.3.2"
+byteorder = "1.3.4"
 proptest = "0.10.0"
 tempfile = "3.1.0"
 libra-temppath = { path = "../../common/temppath", version = "0.1.0" }

--- a/storage/state-view/Cargo.toml
+++ b/storage/state-view/Cargo.toml
@@ -10,7 +10,7 @@ publish = false
 edition = "2018"
 
 [dependencies]
-anyhow = "1.0"
+anyhow = "1.0.31"
 libra-types = { path = "../../types", version = "0.1.0" }
 libra-workspace-hack = { path = "../../common/workspace-hack", version = "0.1.0" }
 

--- a/storage/storage-client/Cargo.toml
+++ b/storage/storage-client/Cargo.toml
@@ -10,8 +10,8 @@ publish = false
 edition = "2018"
 
 [dependencies]
-anyhow = "1.0"
-serde = "1.0"
+anyhow = "1.0.31"
+serde = "1.0.111"
 
 lcs = { path = "../../common/lcs", version = "0.1.0", package = "libra-canonical-serialization" }
 libra-crypto = { path = "../../crypto/crypto", version = "0.1.0" }

--- a/storage/storage-interface/Cargo.toml
+++ b/storage/storage-interface/Cargo.toml
@@ -10,10 +10,10 @@ publish = false
 edition = "2018"
 
 [dependencies]
-anyhow = "1.0"
+anyhow = "1.0.31"
 itertools = "0.9.0"
 serde = { version = "1.0.111", default-features = false }
-thiserror = "1.0"
+thiserror = "1.0.19"
 
 lcs = { path = "../../common/lcs", version = "0.1.0", package = "libra-canonical-serialization" }
 libra-crypto = { path = "../../crypto/crypto", version = "0.1.0" }

--- a/storage/storage-service/Cargo.toml
+++ b/storage/storage-service/Cargo.toml
@@ -10,8 +10,8 @@ publish = false
 edition = "2018"
 
 [dependencies]
-anyhow = "1.0"
-async-trait = "0.1"
+anyhow = "1.0.31"
+async-trait = "0.1.32"
 tokio = { version = "0.2.21", features = ["full"] }
 futures = "0.3.5"
 

--- a/testsuite/Cargo.toml
+++ b/testsuite/Cargo.toml
@@ -13,10 +13,10 @@ edition = "2018"
 # running tests all binaries which are being tested under this testsuite
 # should have their crates listed as dev-dependencies.
 [dev-dependencies]
-num = "0.2.0"
-num-traits = "0.2"
+num = "0.2.1"
+num-traits = "0.2.11"
 rust_decimal = "1.6.0"
-statistical = "1"
+statistical = "1.0.0"
 
 cli = { path = "cli", version = "0.1.0" }
 debug-interface = { path = "../common/debug-interface", version = "0.1.0" }

--- a/testsuite/cli/Cargo.toml
+++ b/testsuite/cli/Cargo.toml
@@ -10,13 +10,13 @@ publish = false
 edition = "2018"
 
 [dependencies]
-anyhow = "1.0"
+anyhow = "1.0.31"
 chrono = "0.4.11"
 hex = "0.4.2"
 proptest = { version = "0.10.0", optional = true }
 rustyline = "6.1.2"
 rust_decimal = "1.6.0"
-num-traits = "0.2"
+num-traits = "0.2.11"
 reqwest = { version = "0.10.6", features = ["blocking", "json", "rustls-tls"], default-features = false }
 serde = { version = "1.0.111", features = ["derive"] }
 structopt = "0.3.14"

--- a/testsuite/cli/libra-wallet/Cargo.toml
+++ b/testsuite/cli/libra-wallet/Cargo.toml
@@ -10,16 +10,16 @@ publish = false
 edition = "2018"
 
 [dependencies]
-anyhow = "1.0"
+anyhow = "1.0.31"
 rand = "0.7.3"
 hex = "0.4.2"
 hmac = "0.7.1"
-byteorder = "1.3.2"
+byteorder = "1.3.4"
 pbkdf2 = "0.3.0"
 serde = "1.0.111"
 sha3 = "0.8.2"
 sha2 = "0.8.2"
-thiserror = "1"
+thiserror = "1.0.19"
 ed25519-dalek = { git = "https://github.com/calibra/ed25519-dalek.git", branch = "fiat2", default-features = false }
 libra-crypto = { path = "../../../crypto/crypto", version = "0.1.0" }
 libra-temppath = { path = "../../../common/temppath/", version = "0.1.0" }

--- a/testsuite/cluster-test/Cargo.toml
+++ b/testsuite/cluster-test/Cargo.toml
@@ -10,17 +10,17 @@ publish = false
 edition = "2018"
 
 [dependencies]
-anyhow = "1.0"
-flate2 = { version = "1.0", features = ["rust_backend"], default-features = false }
+anyhow = "1.0.31"
+flate2 = { version = "1.0.14", features = ["rust_backend"], default-features = false }
 hex = "0.4.2"
 itertools = "0.9.0"
 once_cell = "1.4.0"
 rand = "0.7.3"
 regex = { version = "1.3.9", default-features = false, features = ["std", "perf"] }
-reqwest = { version="0.10.6", features=["blocking", "json", "rustls-tls"], default_features = false }
-serde_json = "1.0"
+reqwest = { version = "0.10.6", features = ["blocking", "json", "rustls-tls"], default_features = false }
+serde_json = "1.0.53"
 serde_yaml = "0.8.12"
-termion = "1.5.3"
+termion = "1.5.5"
 serde = { version = "1.0.111", features = ["derive"] }
 structopt = "0.3.14"
 rusoto_core = "0.44.0"

--- a/testsuite/generate-format/Cargo.toml
+++ b/testsuite/generate-format/Cargo.toml
@@ -14,7 +14,7 @@ proptest = "0.10.0"
 rand = "0.7.3"
 serde = { version = "1.0.111", features = ["derive"] }
 serde-reflection = "0.3.0"
-serde_yaml = "0.8"
+serde_yaml = "0.8.12"
 structopt = "0.3.14"
 
 consensus = { path = "../../consensus", version = "0.1.0", features=["fuzzing"] }

--- a/testsuite/libra-fuzzer/Cargo.toml
+++ b/testsuite/libra-fuzzer/Cargo.toml
@@ -10,14 +10,14 @@ edition = "2018"
 
 # common dependencies
 [dependencies]
-anyhow = "1.0"
-byteorder = { version = "1.3.2", default-features = false }
+anyhow = "1.0.31"
+byteorder = { version = "1.3.4", default-features = false }
 hex = "0.4.2"
 once_cell = "1.4.0"
 proptest = { version = "0.10.0", default-features = false }
-prost = "0.6"
+prost = "0.6.1"
 rusty-fork = { version = "0.3.0", default-features = false }
-sha-1 = { version = "0.8.1", default-features = false }
+sha-1 = { version = "0.8.2", default-features = false }
 structopt = "0.3.14"
 rand = "0.7.3"
 

--- a/testsuite/libra-swarm/Cargo.toml
+++ b/testsuite/libra-swarm/Cargo.toml
@@ -10,10 +10,10 @@ publish = false
 edition = "2018"
 
 [dependencies]
-anyhow = "1.0"
+anyhow = "1.0.31"
 ctrlc = { version = "3.1.4", default-features = false }
 structopt = "0.3.14"
-thiserror = "1.0"
+thiserror = "1.0.19"
 config-builder = { path = "../../config/config-builder", version = "0.1.0" }
 libra-config = { path = "../../config", version = "0.1.0", features = ["fuzzing"] }
 debug-interface = { path = "../../common/debug-interface", version = "0.1.0" }

--- a/types/Cargo.toml
+++ b/types/Cargo.toml
@@ -10,7 +10,7 @@ publish = false
 edition = "2018"
 
 [dependencies]
-anyhow = "1.0"
+anyhow = "1.0.31"
 bytes = "0.5.4"
 chrono = { version = "0.4.11", default-features = false, features = ["clock"] }
 hex = "0.4.2"
@@ -19,11 +19,11 @@ once_cell = "1.4.0"
 mirai-annotations = "1.8.0"
 proptest = { version = "0.10.0", default-features = false, optional = true }
 proptest-derive = { version = "0.2.0", default-features = false, optional = true }
-radix_trie = { version = "0.1.4", default-features = false }
+radix_trie = { version = "0.1.6", default-features = false }
 rand = "0.7.3"
 serde = { version = "1.0.111", default-features = false }
 serde_bytes = "0.11.4"
-thiserror = "1.0"
+thiserror = "1.0.19"
 tiny-keccak = { version = "2.0.2", default-features = false, features = ["sha3"] }
 
 lcs = { path = "../common/lcs", version = "0.1.0", package = "libra-canonical-serialization" }

--- a/vm-validator/Cargo.toml
+++ b/vm-validator/Cargo.toml
@@ -10,7 +10,7 @@ publish = false
 edition = "2018"
 
 [dependencies]
-anyhow = "1.0"
+anyhow = "1.0.31"
 libra-config = { path = "../config", version = "0.1.0" }
 scratchpad = { path = "../storage/scratchpad", version = "0.1.0" }
 libra-state-view = { path = "../storage/state-view", version = "0.1.0" }


### PR DESCRIPTION
## Motivation

Our Cargo.toml files are inconsistent in how they define dependency versions.   Some use equal values to pin, others define partial versions (which cargo expands), and many define versions less than our lock file versions -- that they are never tested with.

Use cargo-edit's  `cargo upgrade --workspace --to-lockfile` to clean up our tomls.

### Have you read the [Contributing Guidelines on pull requests]

y

## Test Plan

ci

## Related PRs

none
