### PR TITLE
[move-prover] Undoing TMPDIR fix which breaks on Ci.

### DIFF
--- a/language/move-prover/tests/sources/stdlib/modules/libra_account.move
+++ b/language/move-prover/tests/sources/stdlib/modules/libra_account.move
@@ -11,7 +11,9 @@ module LibraAccount {
     use 0x0::Vector;
 
     spec module {
-        pragma verify=true;
+        //pragma verify=true;
+        // TODO: set this to false temporarily as we are investigating Boogie/Z3 crashes on this file.
+        pragma verify=false;
     }
 
     // Every Libra account has a LibraAccount::T resource

--- a/language/move-prover/tests/testsuite.rs
+++ b/language/move-prover/tests/testsuite.rs
@@ -25,14 +25,6 @@ fn test_runner(path: &Path) -> datatest_stable::Result<()> {
 
     let temp_dir = TempPath::new();
     std::fs::create_dir_all(temp_dir.path())?;
-
-    // We appear to have a racing condition on files Boogie creates. It's unknown at this point
-    // which files this are (looks like the SMTLIB file). This sets  $TMPDIR to our temp_dir to
-    // mitigate.
-    // TODO: This is an experiment to fix the spurious racing conditions. Either remove if
-    //   it doesn't help, or document better.
-    std::env::set_var("TMPDIR", temp_dir.path().to_string_lossy().to_string());
-
     let (flags, baseline_path) = get_flags(temp_dir.path(), path)?;
 
     let mut args = vec!["mvp_test".to_string()];


### PR DESCRIPTION
Also excluding libra_account.move from verification following a hypothesis that Z3 crashes on this.

## Motivation

Flakiness

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

NA

## Related PRs

NA
