### PR TITLE
[crypto] x25519::PrivateKey -> x25519::X25519PrivateKey

### DIFF
--- a/config/management/src/smoke_test.rs
+++ b/config/management/src/smoke_test.rs
@@ -84,7 +84,7 @@ fn smoke_test() {
             .export_private_key(libra_global_constants::VALIDATOR_NETWORK_KEY)
             .unwrap();
         let identity_key =
-            x25519::PrivateKey::from_ed25519_private_bytes(&identity_key.to_bytes()).unwrap();
+            x25519::X25519PrivateKey::from_ed25519_private_bytes(&identity_key.to_bytes()).unwrap();
         validator_network.identity_keypair = Some(KeyPair::load(identity_key));
 
         let fullnode_network = &mut config.full_node_networks[0];
@@ -92,7 +92,7 @@ fn smoke_test() {
             .export_private_key(libra_global_constants::FULLNODE_NETWORK_KEY)
             .unwrap();
         let identity_key =
-            x25519::PrivateKey::from_ed25519_private_bytes(&identity_key.to_bytes()).unwrap();
+            x25519::X25519PrivateKey::from_ed25519_private_bytes(&identity_key.to_bytes()).unwrap();
         fullnode_network.identity_keypair = Some(KeyPair::load(identity_key));
         let fullnode_network_address = fullnode_network.listen_address.clone();
 

--- a/config/management/src/validator_config.rs
+++ b/config/management/src/validator_config.rs
@@ -128,8 +128,8 @@ fn ed25519_from_storage(
 fn x25519_from_storage(
     key_name: &'static str,
     storage: &dyn Storage,
-) -> Result<x25519::PublicKey, Error> {
+) -> Result<x25519::X25519PublicKey, Error> {
     let edkey = ed25519_from_storage(key_name, storage)?;
-    x25519::PublicKey::from_ed25519_public_bytes(&edkey.to_bytes())
+    x25519::X25519PublicKey::from_ed25519_public_bytes(&edkey.to_bytes())
         .map_err(|e| Error::UnexpectedError(e.to_string()))
 }

--- a/config/management/src/verify.rs
+++ b/config/management/src/verify.rs
@@ -277,7 +277,7 @@ fn ed25519_from_storage(
 fn x25519_from_storage(
     key_name: &'static str,
     storage: &dyn Storage,
-) -> Result<x25519::PublicKey, String> {
+) -> Result<x25519::X25519PublicKey, String> {
     let edkey = ed25519_from_storage(key_name, storage)?;
-    x25519::PublicKey::from_ed25519_public_bytes(&edkey.to_bytes()).map_err(|e| e.to_string())
+    x25519::X25519PublicKey::from_ed25519_public_bytes(&edkey.to_bytes()).map_err(|e| e.to_string())
 }

--- a/config/src/config/network_config.rs
+++ b/config/src/config/network_config.rs
@@ -54,7 +54,7 @@ pub struct NetworkConfig {
     pub seed_peers: SeedPeersConfig,
     pub seed_peers_file: PathBuf,
     #[serde(rename = "identity_private_key")]
-    pub identity_keypair: Option<KeyPair<x25519::PrivateKey>>,
+    pub identity_keypair: Option<KeyPair<x25519::X25519PrivateKey>>,
 }
 
 impl Default for NetworkConfig {
@@ -185,7 +185,7 @@ impl NetworkConfig {
     }
 
     pub fn random_with_peer_id(&mut self, rng: &mut StdRng, peer_id: Option<PeerId>) {
-        let identity_key = x25519::PrivateKey::generate(rng);
+        let identity_key = x25519::X25519PrivateKey::generate(rng);
         self.peer_id = if let Some(peer_id) = peer_id {
             peer_id
         } else {
@@ -237,7 +237,7 @@ impl std::fmt::Debug for NetworkPeersConfig {
 #[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
 pub struct NetworkPeerInfo {
     #[serde(rename = "ni")]
-    pub identity_public_key: x25519::PublicKey,
+    pub identity_public_key: x25519::X25519PublicKey,
 }
 
 #[derive(Clone, Copy, Debug, Deserialize, Eq, PartialEq, Serialize)]

--- a/crypto/crypto/benches/noise.rs
+++ b/crypto/crypto/benches/noise.rs
@@ -28,9 +28,9 @@ fn benchmarks(c: &mut Criterion) {
         Benchmark::new("xx", |b| {
             // setup keys first
             let mut rng = ::rand::rngs::StdRng::from_seed(TEST_SEED);
-            let initiator_static = x25519::PrivateKey::generate(&mut rng);
+            let initiator_static = x25519::X25519PrivateKey::generate(&mut rng);
             let initiator_static = initiator_static.to_bytes();
-            let responder_static = x25519::PrivateKey::generate(&mut rng);
+            let responder_static = x25519::X25519PrivateKey::generate(&mut rng);
             let responder_public = responder_static.public_key();
             let responder_static = responder_static.to_bytes();
 
@@ -39,9 +39,11 @@ fn benchmarks(c: &mut Criterion) {
 
             b.iter(|| {
                 let initiator_static =
-                    x25519::PrivateKey::try_from(initiator_static.clone().as_slice()).unwrap();
+                    x25519::X25519PrivateKey::try_from(initiator_static.clone().as_slice())
+                        .unwrap();
                 let responder_static =
-                    x25519::PrivateKey::try_from(responder_static.clone().as_slice()).unwrap();
+                    x25519::X25519PrivateKey::try_from(responder_static.clone().as_slice())
+                        .unwrap();
 
                 let initiator = NoiseConfig::new(initiator_static);
                 let responder = NoiseConfig::new(responder_static);
@@ -80,8 +82,8 @@ fn benchmarks(c: &mut Criterion) {
 
             // setup keys first
             let mut rng = ::rand::rngs::StdRng::from_seed(TEST_SEED);
-            let initiator_static = x25519::PrivateKey::generate(&mut rng);
-            let responder_static = x25519::PrivateKey::generate(&mut rng);
+            let initiator_static = x25519::X25519PrivateKey::generate(&mut rng);
+            let responder_static = x25519::X25519PrivateKey::generate(&mut rng);
             let responder_public = responder_static.public_key();
 
             // handshake first

--- a/crypto/crypto/src/unit_tests/ed25519_test.rs
+++ b/crypto/crypto/src/unit_tests/ed25519_test.rs
@@ -29,10 +29,10 @@ proptest! {
 
     #[test]
     fn convert_from_ed25519_publickey(keypair in uniform_keypair_strategy::<Ed25519PrivateKey, Ed25519PublicKey>()) {
-        let x25519_public_key = x25519::PublicKey::from_ed25519_public_bytes(&keypair.public_key.to_bytes()[..]).unwrap();
+        let x25519_public_key = x25519::X25519PublicKey::from_ed25519_public_bytes(&keypair.public_key.to_bytes()[..]).unwrap();
 
         // Let's construct an x25519 private key from the ed25519 private key.
-        let x25519_privatekey = x25519::PrivateKey::from_ed25519_private_bytes(&keypair.private_key.to_bytes()[..]);
+        let x25519_privatekey = x25519::X25519PrivateKey::from_ed25519_private_bytes(&keypair.private_key.to_bytes()[..]);
 
         // This is the important part! We abandon the entire test if an x25519 private
         // key can't be built from this ed25519 private key, thus "grinding"
@@ -46,24 +46,24 @@ proptest! {
     }
 
     #[test]
-    fn ed25519_and_x25519_privkeys(keypair in uniform_keypair_strategy::<x25519::PrivateKey, x25519::PublicKey>()){
+    fn ed25519_and_x25519_privkeys(keypair in uniform_keypair_strategy::<x25519::X25519PrivateKey, x25519::X25519PublicKey>()){
         let x25519_public_bytes = keypair.public_key.to_bytes();
         let x25519_private_bytes = keypair.private_key.to_bytes();
         //sanity-check
-        prop_assert_eq!(x25519_public_bytes.clone(), x25519::PublicKey::from(&keypair.private_key).to_bytes());
+        prop_assert_eq!(x25519_public_bytes.clone(), x25519::X25519PublicKey::from(&keypair.private_key).to_bytes());
 
         // always pass false if you hope to ever get back to the original public key
         let ed25519_public = Ed25519PublicKey::from_x25519_public_bytes(&x25519_public_bytes, false).unwrap();
-        let x25519_backconverted_public = x25519::PublicKey::from_ed25519_public_bytes(&ed25519_public.to_bytes()[..]).unwrap();
+        let x25519_backconverted_public = x25519::X25519PublicKey::from_ed25519_public_bytes(&ed25519_public.to_bytes()[..]).unwrap();
 
         let ed25519_private = Ed25519PrivateKey::try_from(&x25519_private_bytes[..]).unwrap();
-        let x25519_backconverted_private = x25519::PrivateKey::try_from(&ed25519_private.to_bytes()[..]).unwrap();
+        let x25519_backconverted_private = x25519::X25519PrivateKey::try_from(&ed25519_private.to_bytes()[..]).unwrap();
 
         // Test that you can always retrieve a valid x25519 keypair after
         // "serialization" as an ed25519 keypair
         prop_assert_eq!(keypair.public_key, x25519_backconverted_public);
         prop_assert_eq!(keypair.private_key, x25519_backconverted_private.clone());
-        prop_assert_eq!(x25519_backconverted_public, x25519::PublicKey::from(&x25519_backconverted_private));
+        prop_assert_eq!(x25519_backconverted_public, x25519::X25519PublicKey::from(&x25519_backconverted_private));
         // Note that the reverse is not true: converting to an x25519 private
         // key mangles the ed25519 private key bits irreversibly !
     }
@@ -71,7 +71,7 @@ proptest! {
     #[test]
     fn ed25519_to_x25519_roundtrip(keypair in uniform_keypair_strategy::<Ed25519PrivateKey, Ed25519PublicKey>()){
         let ed25519_bytes = keypair.public_key.to_bytes();
-        let x25519 = x25519::PublicKey::from_ed25519_public_bytes(&ed25519_bytes).unwrap();
+        let x25519 = x25519::X25519PublicKey::from_ed25519_public_bytes(&ed25519_bytes).unwrap();
         let x25519_bytes = x25519.as_slice();
         let backconverted_ed_positive = Ed25519PublicKey::from_x25519_public_bytes(x25519_bytes, false).unwrap();
         let backconverted_ed_negative = Ed25519PublicKey::from_x25519_public_bytes(x25519_bytes, true).unwrap();

--- a/crypto/crypto/src/unit_tests/noise_test.rs
+++ b/crypto/crypto/src/unit_tests/noise_test.rs
@@ -16,9 +16,9 @@ use serde::*;
 fn simple_handshake() {
     // setup peers
     let mut rng = ::rand::rngs::StdRng::from_seed(TEST_SEED);
-    let initiator_private = x25519::PrivateKey::generate(&mut rng);
+    let initiator_private = x25519::X25519PrivateKey::generate(&mut rng);
     let initiator_public = initiator_private.public_key();
-    let responder_private = x25519::PrivateKey::generate(&mut rng);
+    let responder_private = x25519::X25519PrivateKey::generate(&mut rng);
     let responder_public = responder_private.public_key();
     let initiator = NoiseConfig::new(initiator_private);
     let responder = NoiseConfig::new(responder_private);
@@ -172,11 +172,11 @@ fn test_vectors() {
     // initiate peers with test vector
     use crate::traits::ValidCryptoMaterialStringExt;
     let initiator_private =
-        x25519::PrivateKey::from_encoded_string(&test_vector.init_static.as_ref().unwrap())
+        x25519::X25519PrivateKey::from_encoded_string(&test_vector.init_static.as_ref().unwrap())
             .unwrap();
     let initiator_public = initiator_private.public_key();
     let responder_private =
-        x25519::PrivateKey::from_encoded_string(&test_vector.resp_static.as_ref().unwrap())
+        x25519::X25519PrivateKey::from_encoded_string(&test_vector.resp_static.as_ref().unwrap())
             .unwrap();
     let responder_public = responder_private.public_key();
 
@@ -322,8 +322,8 @@ fn test_vectors() {
 fn wrong_buffer_sizes() {
     // setup peers
     let mut rng = ::rand::rngs::StdRng::from_seed(TEST_SEED);
-    let initiator_private = x25519::PrivateKey::generate(&mut rng);
-    let responder_private = x25519::PrivateKey::generate(&mut rng);
+    let initiator_private = x25519::X25519PrivateKey::generate(&mut rng);
+    let responder_private = x25519::X25519PrivateKey::generate(&mut rng);
     let responder_public = responder_private.public_key();
     let initiator = NoiseConfig::new(initiator_private);
     let responder = NoiseConfig::new(responder_private);

--- a/grpc/types/src/converters/validator_info.rs
+++ b/grpc/types/src/converters/validator_info.rs
@@ -19,10 +19,10 @@ impl TryFrom<crate::proto::types::ValidatorInfo> for ValidatorInfo {
         let consensus_voting_power = proto.consensus_voting_power;
 
         let validator_network_identity_public_key =
-            x25519::PublicKey::try_from(&proto.validator_network_identity_public_key[..])?;
+            x25519::X25519PublicKey::try_from(&proto.validator_network_identity_public_key[..])?;
         let validator_network_address = RawNetworkAddress::new(proto.validator_network_address);
         let full_node_network_identity_public_key =
-            x25519::PublicKey::try_from(&proto.full_node_network_identity_public_key[..])?;
+            x25519::X25519PublicKey::try_from(&proto.full_node_network_identity_public_key[..])?;
         let full_node_network_address = RawNetworkAddress::new(proto.full_node_network_address);
 
         let config = ValidatorConfig::new(

--- a/network/onchain-discovery/src/types.rs
+++ b/network/onchain-discovery/src/types.rs
@@ -171,7 +171,7 @@ impl DiscoverySetInternal {
 }
 
 #[derive(Clone, Debug, Eq, PartialEq)]
-pub struct DiscoveryInfoInternal(pub x25519::PublicKey, pub Vec<NetworkAddress>);
+pub struct DiscoveryInfoInternal(pub x25519::X25519PublicKey, pub Vec<NetworkAddress>);
 
 impl DiscoveryInfoInternal {
     pub fn try_from_validator_info(

--- a/network/simple-onchain-discovery/src/lib.rs
+++ b/network/simple-onchain-discovery/src/lib.rs
@@ -58,7 +58,7 @@ fn network_address(role: RoleType, config: &ValidatorConfig) -> Result<NetworkAd
 }
 
 /// Extracts the public key from the provided config, depending on role.
-fn public_key(role: RoleType, config: &ValidatorConfig) -> x25519::PublicKey {
+fn public_key(role: RoleType, config: &ValidatorConfig) -> x25519::X25519PublicKey {
     match role {
         RoleType::Validator => config.validator_network_identity_public_key,
         RoleType::FullNode => config.full_node_network_identity_public_key,

--- a/network/socket-bench-server/src/lib.rs
+++ b/network/socket-bench-server/src/lib.rs
@@ -79,7 +79,7 @@ impl Args {
 pub fn build_memsocket_noise_transport() -> impl Transport<Output = NoiseStream<MemorySocket>> {
     MemoryTransport::default().and_then(move |socket, addr, origin| async move {
         let mut rng: StdRng = SeedableRng::from_seed(TEST_SEED);
-        let private = x25519::PrivateKey::generate(&mut rng);
+        let private = x25519::X25519PrivateKey::generate(&mut rng);
         let noise_config = Arc::new(NoiseWrapper::new(private));
         let remote_public_key = addr.find_noise_proto();
         let (_remote_static_key, socket) = noise_config
@@ -93,7 +93,7 @@ pub fn build_memsocket_noise_transport() -> impl Transport<Output = NoiseStream<
 pub fn build_tcp_noise_transport() -> impl Transport<Output = NoiseStream<TcpSocket>> {
     TcpTransport::default().and_then(move |socket, addr, origin| async move {
         let mut rng: StdRng = SeedableRng::from_seed(TEST_SEED);
-        let private = x25519::PrivateKey::generate(&mut rng);
+        let private = x25519::X25519PrivateKey::generate(&mut rng);
         let noise_config = Arc::new(NoiseWrapper::new(private));
         let remote_public_key = addr.find_noise_proto();
         let (_remote_static_key, socket) = noise_config

--- a/network/src/connectivity_manager/test.rs
+++ b/network/src/connectivity_manager/test.rs
@@ -38,7 +38,7 @@ fn setup_conn_mgr(
     let eligible_peers = eligible_peers
         .into_iter()
         .map(|peer_id| {
-            let identity_public_key = x25519::PrivateKey::generate(&mut rng).public_key();
+            let identity_public_key = x25519::X25519PrivateKey::generate(&mut rng).public_key();
             let pubkeys = NetworkPublicKeys {
                 identity_public_key,
             };
@@ -71,7 +71,7 @@ fn setup_conn_mgr(
 fn gen_peer() -> (PeerId, NetworkPublicKeys) {
     let peer_id = PeerId::random();
     let mut rng = StdRng::from_seed(TEST_SEED);
-    let identity_public_key = x25519::PrivateKey::generate(&mut rng).public_key();
+    let identity_public_key = x25519::X25519PrivateKey::generate(&mut rng).public_key();
     (
         peer_id,
         NetworkPublicKeys {

--- a/network/src/noise_wrapper/fuzzing.rs
+++ b/network/src/noise_wrapper/fuzzing.rs
@@ -94,9 +94,9 @@ impl AsyncRead for ExposingSocket {
 //
 
 // let's cache the deterministic keypair
-pub static KEYPAIR: Lazy<(x25519::PrivateKey, x25519::PublicKey)> = Lazy::new(|| {
+pub static KEYPAIR: Lazy<(x25519::X25519PrivateKey, x25519::X25519PublicKey)> = Lazy::new(|| {
     let mut rng = ::rand::rngs::StdRng::from_seed(TEST_SEED);
-    let private_key = x25519::PrivateKey::generate(&mut rng);
+    let private_key = x25519::X25519PrivateKey::generate(&mut rng);
     let public_key = private_key.public_key();
     (private_key, public_key)
 });

--- a/network/src/noise_wrapper/mod.rs
+++ b/network/src/noise_wrapper/mod.rs
@@ -23,11 +23,11 @@
 //! fn example() -> std::io::Result<()> {
 //! // create client and server NoiseWrapper
 //! let mut rng = StdRng::from_seed(TEST_SEED);
-//! let client_private = x25519::PrivateKey::generate(&mut rng);
+//! let client_private = x25519::X25519PrivateKey::generate(&mut rng);
 //! let client_public = client_private.public_key();
 //! let client = NoiseWrapper::new(client_private);
 //!
-//! let server_private = x25519::PrivateKey::generate(&mut rng);
+//! let server_private = x25519::X25519PrivateKey::generate(&mut rng);
 //! let server_public = server_private.public_key();
 //! let server = NoiseWrapper::new(server_private);
 //!

--- a/network/src/noise_wrapper/stream.rs
+++ b/network/src/noise_wrapper/stream.rs
@@ -58,7 +58,7 @@ impl<TSocket> NoiseStream<TSocket> {
     }
 
     /// Pull out the static public key of the remote
-    pub fn get_remote_static(&self) -> x25519::PublicKey {
+    pub fn get_remote_static(&self) -> x25519::X25519PublicKey {
         self.session.get_remote_static()
     }
 
@@ -572,15 +572,15 @@ mod test {
 
     /// helper to setup two testing peers
     fn build_peers() -> (
-        (NoiseWrapper, x25519::PublicKey),
-        (NoiseWrapper, x25519::PublicKey),
+        (NoiseWrapper, x25519::X25519PublicKey),
+        (NoiseWrapper, x25519::X25519PublicKey),
     ) {
         let mut rng = ::rand::rngs::StdRng::from_seed(TEST_SEED);
 
-        let client_private = x25519::PrivateKey::generate(&mut rng);
+        let client_private = x25519::X25519PrivateKey::generate(&mut rng);
         let client_public = client_private.public_key();
 
-        let server_private = x25519::PrivateKey::generate(&mut rng);
+        let server_private = x25519::X25519PrivateKey::generate(&mut rng);
         let server_public = server_private.public_key();
 
         let client = NoiseWrapper::new(client_private);
@@ -592,7 +592,7 @@ mod test {
     /// helper to perform a noise handshake with two peers
     fn perform_handshake(
         client: NoiseWrapper,
-        server_public_key: x25519::PublicKey,
+        server_public_key: x25519::X25519PublicKey,
         server: NoiseWrapper,
         trusted_peers: Option<&Arc<RwLock<HashMap<PeerId, NetworkPeerInfo>>>>,
     ) -> io::Result<(NoiseStream<MemorySocket>, NoiseStream<MemorySocket>)> {

--- a/network/src/protocols/network/dummy.rs
+++ b/network/src/protocols/network/dummy.rs
@@ -102,11 +102,11 @@ pub fn setup_network() -> DummyNetwork {
 
     // Setup keys for dialer.
     let mut rng = StdRng::from_seed(TEST_SEED);
-    let dialer_identity_private_key = x25519::PrivateKey::generate(&mut rng);
+    let dialer_identity_private_key = x25519::X25519PrivateKey::generate(&mut rng);
     let dialer_identity_public_key = dialer_identity_private_key.public_key();
 
     // Setup keys for listener.
-    let listener_identity_private_key = x25519::PrivateKey::generate(&mut rng);
+    let listener_identity_private_key = x25519::X25519PrivateKey::generate(&mut rng);
     let listener_identity_public_key = listener_identity_private_key.public_key();
 
     // Setup listen addresses

--- a/network/src/transport.rs
+++ b/network/src/transport.rs
@@ -208,7 +208,7 @@ pub async fn perform_handshake<T: TSocket>(
 }
 
 pub fn build_memory_noise_transport(
-    identity_key: x25519::PrivateKey,
+    identity_key: x25519::X25519PrivateKey,
     trusted_peers: Arc<RwLock<HashMap<PeerId, NetworkPublicKeys>>>,
     application_protocols: SupportedProtocols,
 ) -> boxed::BoxedTransport<Connection<impl TSocket>, impl ::std::error::Error> {
@@ -247,7 +247,7 @@ pub fn build_memory_noise_transport(
 }
 
 pub fn build_unauthenticated_memory_noise_transport(
-    identity_key: x25519::PrivateKey,
+    identity_key: x25519::X25519PrivateKey,
     application_protocols: SupportedProtocols,
 ) -> boxed::BoxedTransport<Connection<impl TSocket>, impl ::std::error::Error> {
     let memory_transport = memory::MemoryTransport::default();
@@ -263,7 +263,7 @@ pub fn build_unauthenticated_memory_noise_transport(
                     .upgrade_connection(socket, origin, None, remote_public_key, None)
                     .await?;
 
-                // Generate PeerId from x25519::PublicKey.
+                // Generate PeerId from x25519::X25519PublicKey.
                 // Note: This is inconsistent with current types because AccountAddress is derived
                 // from consensus key which is of type Ed25519PublicKey. Since AccountAddress does
                 // not mean anything in a setting without remote authentication, we use the network
@@ -302,7 +302,7 @@ pub fn build_memory_transport(
 
 //TODO(bmwill) Maybe create an Either Transport so we can merge the building of Memory + Tcp
 pub fn build_tcp_noise_transport(
-    identity_key: x25519::PrivateKey,
+    identity_key: x25519::X25519PrivateKey,
     trusted_peers: Arc<RwLock<HashMap<PeerId, NetworkPublicKeys>>>,
     application_protocols: SupportedProtocols,
 ) -> boxed::BoxedTransport<Connection<impl TSocket>, impl ::std::error::Error> {
@@ -347,7 +347,7 @@ pub fn build_tcp_noise_transport(
 // Transport based on TCP + Noise, but without remote authentication (i.e., any
 // node is allowed to connect).
 pub fn build_unauthenticated_tcp_noise_transport(
-    identity_key: x25519::PrivateKey,
+    identity_key: x25519::X25519PrivateKey,
     application_protocols: SupportedProtocols,
 ) -> boxed::BoxedTransport<Connection<impl TSocket>, impl ::std::error::Error> {
     let noise_config = Arc::new(NoiseWrapper::new(identity_key));
@@ -362,7 +362,7 @@ pub fn build_unauthenticated_tcp_noise_transport(
                     .upgrade_connection(socket, origin, None, remote_public_key, None)
                     .await?;
 
-                // Generate PeerId from x25519::PublicKey.
+                // Generate PeerId from x25519::X25519PublicKey.
                 // Note: This is inconsistent with current types because AccountAddress is derived
                 // from consensus key which is of type Ed25519PublicKey. Since AccountAddress does
                 // not mean anything in a setting without remote authentication, we use the network

--- a/network/src/validator_network/network_builder.rs
+++ b/network/src/validator_network/network_builder.rs
@@ -74,11 +74,11 @@ pub enum AuthenticationMode {
     /// clients/dialers will authenticate the servers/listeners. More specifically,
     /// dialers will pin the connection to a specific, expected pubkey while
     /// listeners will accept any inbound dialer's pubkey.
-    ServerOnly(x25519::PrivateKey),
+    ServerOnly(x25519::X25519PrivateKey),
     /// Inbound and outbound connections are secured with NoiseIK. Both dialer and
     /// listener will only accept connections that successfully authenticate to a
     /// pubkey in their "trusted peers" set.
-    Mutual(x25519::PrivateKey),
+    Mutual(x25519::X25519PrivateKey),
 }
 
 /// Append the correct libranet protocols to the given base address, depending on

--- a/state-synchronizer/src/tests/integration_tests.rs
+++ b/state-synchronizer/src/tests/integration_tests.rs
@@ -127,7 +127,7 @@ impl SynchronizerEnv {
         // Setup identity public keys.
         let mut rng = StdRng::from_seed(TEST_SEED);
         let identity_private_keys: Vec<_> = (0..count)
-            .map(|_| x25519::PrivateKey::generate(&mut rng))
+            .map(|_| x25519::X25519PrivateKey::generate(&mut rng))
             .collect();
 
         let mut validators_keys = vec![];

--- a/testsuite/cli/src/client_proxy.rs
+++ b/testsuite/cli/src/client_proxy.rs
@@ -596,10 +596,10 @@ impl ClientProxy {
         let (address, _) = self.get_account_address_from_parameter(space_delim_strings[1])?;
         let private_key = Ed25519PrivateKey::from_encoded_string(space_delim_strings[2])?;
         let consensus_public_key = Ed25519PublicKey::from_encoded_string(space_delim_strings[3])?;
-        let network_identity_key = x25519::PublicKey::from_encoded_string(space_delim_strings[4])?;
+        let network_identity_key = x25519::X25519PublicKey::from_encoded_string(space_delim_strings[4])?;
         let network_address = NetworkAddress::from_str(space_delim_strings[5])?;
         let network_address = RawNetworkAddress::try_from(&network_address)?;
-        let fullnode_identity_key = x25519::PublicKey::from_encoded_string(space_delim_strings[6])?;
+        let fullnode_identity_key = x25519::X25519PublicKey::from_encoded_string(space_delim_strings[6])?;
         let fullnode_network_address = NetworkAddress::from_str(space_delim_strings[7])?;
         let fullnode_network_address = RawNetworkAddress::try_from(&fullnode_network_address)?;
         let mut sender = Self::get_account_data_from_address(

--- a/testsuite/generate-format/src/network.rs
+++ b/testsuite/generate-format/src/network.rs
@@ -3,7 +3,7 @@
 
 use libra_crypto::{
     traits::Uniform,
-    x25519::{PrivateKey, PublicKey},
+    x25519,
 };
 use libra_network_address as address;
 use network::protocols::wire::{handshake, messaging};
@@ -19,8 +19,8 @@ pub fn output_file() -> Option<&'static str> {
 /// Record sample values for crypto types used by network.
 fn trace_crypto_values(tracer: &mut Tracer, samples: &mut Samples) -> Result<()> {
     let mut rng: StdRng = SeedableRng::from_seed([0; 32]);
-    let private_key = PrivateKey::generate(&mut rng);
-    let public_key: PublicKey = (&private_key).into();
+    let private_key = x25519::X25519PrivateKey::generate(&mut rng);
+    let public_key = private_key.public_key();
 
     tracer.trace_value(samples, &public_key)?;
     Ok(())

--- a/testsuite/generate-format/tests/staged/network.yaml
+++ b/testsuite/generate-format/tests/staged/network.yaml
@@ -99,7 +99,7 @@ Protocol:
     7:
       NoiseIK:
         NEWTYPE:
-          TYPENAME: PublicKey
+          TYPENAME: X25519PublicKey
     8:
       Handshake:
         NEWTYPE: U8
@@ -123,8 +123,6 @@ ProtocolId:
       IdentityDirectSend: UNIT
     7:
       OnchainDiscoveryRpc: UNIT
-PublicKey:
-  NEWTYPESTRUCT: BYTES
 RawNetworkAddress:
   NEWTYPESTRUCT: BYTES
 RpcRequest:
@@ -142,3 +140,5 @@ RpcResponse:
 SupportedProtocols:
   NEWTYPESTRUCT:
     SEQ: U8
+X25519PublicKey:
+  NEWTYPESTRUCT: BYTES

--- a/types/src/validator_config.rs
+++ b/types/src/validator_config.rs
@@ -24,18 +24,18 @@ impl MoveResource for ValidatorConfigResource {
 #[cfg_attr(any(test, feature = "fuzzing"), derive(Arbitrary))]
 pub struct ValidatorConfig {
     pub consensus_public_key: Ed25519PublicKey,
-    pub validator_network_identity_public_key: x25519::PublicKey,
+    pub validator_network_identity_public_key: x25519::X25519PublicKey,
     pub validator_network_address: RawNetworkAddress,
-    pub full_node_network_identity_public_key: x25519::PublicKey,
+    pub full_node_network_identity_public_key: x25519::X25519PublicKey,
     pub full_node_network_address: RawNetworkAddress,
 }
 
 impl ValidatorConfig {
     pub fn new(
         consensus_public_key: Ed25519PublicKey,
-        validator_network_identity_public_key: x25519::PublicKey,
+        validator_network_identity_public_key: x25519::X25519PublicKey,
         validator_network_address: RawNetworkAddress,
-        full_node_network_identity_public_key: x25519::PublicKey,
+        full_node_network_identity_public_key: x25519::X25519PublicKey,
         full_node_network_address: RawNetworkAddress,
     ) -> Self {
         ValidatorConfig {

--- a/types/src/validator_info.rs
+++ b/types/src/validator_info.rs
@@ -59,12 +59,12 @@ impl ValidatorInfo {
         consensus_public_key: Ed25519PublicKey,
         consensus_voting_power: u64,
     ) -> Self {
-        let private_key = x25519::PrivateKey::generate_for_testing();
+        let private_key = x25519::X25519PrivateKey::generate_for_testing();
         let validator_network_identity_public_key = private_key.public_key();
         let network_address = NetworkAddress::from_str("/ip4/127.0.0.1/tcp/1234").unwrap();
         let validator_network_address = RawNetworkAddress::try_from(&network_address).unwrap();
 
-        let private_key = x25519::PrivateKey::generate_for_testing();
+        let private_key = x25519::X25519PrivateKey::generate_for_testing();
         let full_node_network_identity_public_key = private_key.public_key();
         let full_node_network_address = RawNetworkAddress::try_from(&network_address).unwrap();
         let config = ValidatorConfig::new(
@@ -99,7 +99,7 @@ impl ValidatorInfo {
     }
 
     /// Returns the key that establishes a validator's identity in the p2p network
-    pub fn network_identity_public_key(&self) -> x25519::PublicKey {
+    pub fn network_identity_public_key(&self) -> x25519::X25519PublicKey {
         self.config.validator_network_identity_public_key
     }
 


### PR DESCRIPTION
Currently other types of keys in crypto/ are fully named.
For example ed25519::Ed25519PrivateKey.

Let's keep it consistent.
