### PR TITLE
[state sync] tweak intra-node communication timeout values to handle high txn submission traffic

### DIFF
--- a/state-synchronizer/src/coordinator.rs
+++ b/state-synchronizer/src/coordinator.rs
@@ -362,7 +362,7 @@ impl<T: ExecutorProxyTrait> SyncCoordinator<T> {
             );
             msg = "state sync failed to send commit notif to shared mempool";
         }
-        if let Err(e) = timeout(Duration::from_secs(1), callback_rcv).await {
+        if let Err(e) = timeout(Duration::from_secs(5), callback_rcv).await {
             error!(
                 "[state sync] did not receive ACK for commit notification sent to mempool: {:?}",
                 e

--- a/state-synchronizer/src/synchronizer.rs
+++ b/state-synchronizer/src/synchronizer.rs
@@ -171,7 +171,7 @@ impl StateSyncClient {
                 ))
                 .await?;
 
-            match timeout(Duration::from_secs(1), callback_rcv).await {
+            match timeout(Duration::from_secs(5), callback_rcv).await {
                 Err(_) => {
                     Err(format_err!("[state sync client] failed to receive commit ACK from state synchronizer on time"))
                 }


### PR DESCRIPTION
## Motivation

In high txn submission traffic, mempool is overwhelmed and therefore slower to process commits. This results in timeouts b/w consensus/state-sync and state-sync/mempool with timeout values at one second. This PR increases the timeout value to 5 seconds for the consensus-state-sync-mempool commit flow to be resilient against high traffic. 

## Test Plan

Confirmed in high-traffic cluster test that we no longer see state sync channel timeouts 
