### PR TITLE
[move-prover] Added type name for LibraAccount.T to  prelude

### DIFF
--- a/language/move-prover/src/bytecode_translator.rs
+++ b/language/move-prover/src/bytecode_translator.rs
@@ -153,7 +153,11 @@ impl<'env> ModuleTranslator<'env> {
     fn translate_struct_type(&self, struct_env: &StructEnv<'_>) {
         // Emit TypeName
         let struct_name = boogie_struct_name(&struct_env);
-        emitln!(self.writer, "const unique {}: $TypeName;", struct_name);
+        // Special treatment of well-known resource LibraAccount_T. The type_name
+        // is forward-declared in the prelude.
+        if struct_name != "$LibraAccount_T" {
+            emitln!(self.writer, "const unique {}: $TypeName;", struct_name);
+        }
 
         // Emit FieldNames
         for (i, field_env) in struct_env.get_fields().enumerate() {

--- a/language/move-prover/src/prelude.bpl
+++ b/language/move-prover/src/prelude.bpl
@@ -469,8 +469,9 @@ function {:inline} $TxnSender(txn: $Transaction): $Value {
 
 // Forward declaration of type Value of LibraAccount. This is declared so we can define
 // $ExistsTxnSenderAccount and $LibraAccount_save_account
+const unique $LibraAccount_T: $TypeName;
 function $LibraAccount_T_type_value(): $TypeValue;
-
+axiom is#$StructType($LibraAccount_T_type_value()) && name#$StructType($LibraAccount_T_type_value()) == $LibraAccount_T;
 function $LibraAccount_Balance_type_value(tv: $TypeValue): $TypeValue;
 
 // ============================================================================================


### PR DESCRIPTION
## Motivation

LibraAccount.T occupies special status in the modeling of Move semantics in Move Prover.  An instance of this resource type must be published in the transaction sender account.  This PR adds an axiom about  the type value for LibraAccount.T which guarantees that when MoveFrom<T> is executed for some T that is not LibraAccount.T, T is known to be distinct from LibraAccount.T.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?

Yes.

## Test Plan

Existing tests.

## Related PRs

None.
