### PR TITLE
[move-prover] added informal specs for fixedpoint32.move and lbr.move

### DIFF
--- a/language/stdlib/modules/FixedPoint32.move
+++ b/language/stdlib/modules/FixedPoint32.move
@@ -74,6 +74,95 @@ module FixedPoint32 {
     public fun get_raw_value(num: T): u64 {
         num.value
     }
+
+    // **************** SPECIFICATIONS ****************
+
+    /*
+    This module defines the fixed-point numeric type, the constructors and the operations (mul, div) for that type.
+    It is unlike that this module would have any module invariant (or global property) because it does not declare
+    any resource type whose value can be stored and retained in the global state. However, it is possible that
+    FixedPoint32::T is used in the invariants of other modules.
+
+    An apparent local property to check is that the fixed-point operations (including the constructors) are implemented
+    correctly. However, what this rigorously means is not obvious because it requires the mathematical model of
+    fixed-point operations to check the implementations against. Mathematically, a finite-precision arithmetic operation
+    (like the fixed-point one's) can be defined using the notion of "exact rounding". This means that such an operation
+    is defined as the corresponding operation over real numbers followed by a pre-defined rounding operation which maps
+    the resulting real number into a certain finite-precision number (depending on the rounding mode).
+
+    From this viewpoint, the local specifications of this module can be defined as follows:
+    * Let FP32 refer to FixedPoint32::T which is the 64-bit unsigned fixed-point numeric type with 32 factional bits.
+    * Let FP0 refer to u64 which can be seen as the 64-bit unsigned fixed-point numeric type with 0 factional bits.
+    * round_FP32: R -> FP32 is a function that takes a real number as an input and returns the largest FP32 number which
+      is less than or equal to the input.
+    * round_FP0: R -> FP0 is a function that takes a real number as an input and returns the largest FP0 number which is
+      less than or equal to the input.
+    * Let mul_R and div_R be the multiplication and the division function over real numbers respectively.
+    */
+
+    spec fun multiply_u64 {
+        // aborts_if mul_R(num, multiplier) >= max_u64() + 1; // overflow (note that max_u64() == max_FP0())
+        // aborts_if 0 < mul_R(num, multiplier) < 1; // underflow (note that 1 is the smallest non-zero FP0);
+        // ensures result == round_FP0(mul_R(num, multiplier)); // exactly rounded
+    }
+
+    spec fun divide_u64 {
+        // aborts_if div_R(num, divisor) >= max_u64() + 1; // overflow
+        // aborts_if 0 < div_R(num, divisor) < 1; // underflow
+        // aborts_if divisor == 0; // div by zero
+        // ensures result == round_FP0(div_R(num, divisor)); // exactly rounded
+    }
+
+    spec fun create_from_rational {
+        // aborts_if denominator == 0; // div by zero
+        // aborts_if 0 < div_R(numerator, denominator) < smallest_non_zero_FP32(); // underflow
+        // ensures result == round_FP32(div_R(numerator, denominator)); // exactly rounded
+    }
+
+    spec fun create_from_raw_value {
+        aborts_if false;
+        ensures result == T { value };
+    }
+
+    spec fun get_raw_value {
+        aborts_if false;
+        ensures result == num.value;
+    }
+
+    /*
+    Another approach to assuring this module is perhaps not formally verifying it, but carefully reviewing it and
+    arguing its correctness informally (or looking for some pragmatic solution). It is because quite a bit of efforts is
+    expected in rigorously specifying and formally verifying it, but it is not clear for now how much the benefit and
+    the impact are compared to the expected effort. Currently, this module (FixedPoint32) is used in the following
+    places (note that this is the complete list):
+
+    coin1.move
+    15:            FixedPoint32::create_from_rational(1, 2), // exchange rate to LBR
+
+    coin2.move
+    15:            FixedPoint32::create_from_rational(1, 2), // exchange rate to LBR
+
+    libra.move
+    73:        to_lbr_exchange_rate: FixedPoint32::T,
+    446:        to_lbr_exchange_rate: FixedPoint32::T,
+    489:        FixedPoint32::multiply_u64(from_value, lbr_exchange_rate)
+    535:        lbr_exchange_rate: FixedPoint32::T
+    543:    public fun lbr_exchange_rate<CoinType>(): FixedPoint32::T
+
+    lbr.move
+    19:        ratio: FixedPoint32::T,
+    43:            FixedPoint32::create_from_rational(1, 1), // exchange rate to LBR
+    51:            ratio: FixedPoint32::create_from_rational(1, 2),
+    55:            ratio: FixedPoint32::create_from_rational(1, 2),
+    72:        let lbr_num_coin1 = FixedPoint32::divide_u64(coin1_value - 1, *&reserve.coin1.ratio);
+    73:        let lbr_num_coin2 = FixedPoint32::divide_u64(coin2_value - 1, *&reserve.coin2.ratio);
+    93:        let num_coin1 = 1 + FixedPoint32::multiply_u64(amount_lbr, *&reserve.coin1.ratio);
+    94:        let num_coin2 = 1 + FixedPoint32::multiply_u64(amount_lbr, *&reserve.coin2.ratio);
+    111:        let coin1_amount = FixedPoint32::multiply_u64(ratio_multiplier, *&reserve.coin1.ratio);
+    112:        let coin2_amount = FixedPoint32::multiply_u64(ratio_multiplier, *&reserve.coin2.ratio);
+    122:        let num_coin1 = 1 + FixedPoint32::multiply_u64(amount_lbr, *&reserve.coin1.ratio);
+    123:        let num_coin2 = 1 + FixedPoint32::multiply_u64(amount_lbr, *&reserve.coin2.ratio);
+    */
 }
 
 }

--- a/language/stdlib/modules/LBR.move
+++ b/language/stdlib/modules/LBR.move
@@ -128,5 +128,29 @@ module LBR {
         Libra::destroy_zero(leftover2);
         lbr
     }
+
+    // **************** SPECIFICATIONS ****************
+
+    /*
+    This module defines the synthetic coin type called LBR and the operations on LBR coins. A global property that this
+    module has to satisfy is as follows: LBR must be backed by the reserve of fiat coins in order to exist. In the
+    current system, there are two fiat coins called coin1 and coin2. So, there must be a sufficient amounts of coin1
+    and coin2 respectively in the reserve to be backing LBR. Here, the "sufficient amount" is determined by the
+    pre-defined ratio of each of the fiat coins to the total value of LBR. To define this global property more precisely,
+
+    let reserve_coin1 refer to global<Reserve>(0xA550C18).coin1 (the reserve of coin1 backing LBR)
+    let reserve_coin2 refer to global<Reserve>(0xA550C18).coin2 (the reserve of coin2 backing LBR).
+    Let lbr_total_value be the synthetic variable that represents the total amount of LBR that exists.
+    Note: lbr_total_value could refer to global<Libra::CurrencyInfo<LBR::T>>(0xA550C18).total_value, but this may make
+    verification harder because one need prove a relational invariant of two modules (such as Libra and LBR).
+    The module invariant can be formulated as:
+    (1) lbr_total_value * r_coin1.ratio <= reserve_coin1.backing.value, and
+    (2) lbr_total_value * r_coin2.ratio <= reserve_coin2.backing.value
+    where '*' is the multiplication over real numbers. (Yet, it could be the FP multiplication. It should not matter.)
+
+    Note that to argue this, the system needs to satisfy the following property (beyond the scope of this module):
+    LBR coins should be created only through LBR::create, and there is no other way in the system. Specifically,
+    Libra::mint<LBR::T> should not be able to create LBR coins because if so, the invariant above may not be guaranteed.
+    */
 }
 }


### PR DESCRIPTION
- added the informal specs for both modules FixedPoint32 and LBR

## Motivation

To specify the standard library

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

cargo test
