### PR TITLE
Refactor config builder

### DIFF
--- a/config/config-builder/src/full_node_config.rs
+++ b/config/config-builder/src/full_node_config.rs
@@ -61,7 +61,7 @@ impl FullNodeConfig {
     }
 
     pub fn validators(&mut self, nodes: usize) -> &mut Self {
-        self.validator_config.nodes = nodes;
+        self.validator_config.num_nodes = nodes;
         self
     }
 

--- a/config/config-builder/src/full_node_config.rs
+++ b/config/config-builder/src/full_node_config.rs
@@ -19,14 +19,14 @@ use std::{
 };
 
 pub struct FullNodeConfig {
-    advertised: NetworkAddress,
-    bootstrap: NetworkAddress,
-    full_node_index: usize,
-    full_node_seed: [u8; 32],
-    full_nodes: usize,
-    genesis: Option<Transaction>,
-    listen: NetworkAddress,
-    enable_remote_authentication: bool,
+    pub advertised: NetworkAddress,
+    pub bootstrap: NetworkAddress,
+    pub full_node_index: usize,
+    pub full_node_seed: [u8; 32],
+    pub full_nodes: usize,
+    pub genesis: Option<Transaction>,
+    pub listen: NetworkAddress,
+    pub enable_remote_authentication: bool,
     template: NodeConfig,
     validator_config: ValidatorConfig,
 }
@@ -60,53 +60,8 @@ impl FullNodeConfig {
         Self::default()
     }
 
-    pub fn advertised(&mut self, advertised: NetworkAddress) -> &mut Self {
-        self.advertised = advertised;
-        self
-    }
-
-    pub fn bootstrap(&mut self, bootstrap: NetworkAddress) -> &mut Self {
-        self.bootstrap = bootstrap;
-        self
-    }
-
-    pub fn full_node_index(&mut self, full_node_index: usize) -> &mut Self {
-        self.full_node_index = full_node_index;
-        self
-    }
-
-    pub fn full_nodes(&mut self, full_nodes: usize) -> &mut Self {
-        self.full_nodes = full_nodes;
-        self
-    }
-
-    pub fn full_node_seed(&mut self, full_node_seed: [u8; 32]) -> &mut Self {
-        self.full_node_seed = full_node_seed;
-        self
-    }
-
-    pub fn genesis(&mut self, genesis: Transaction) -> &mut Self {
-        self.genesis = Some(genesis);
-        self
-    }
-
-    pub fn listen(&mut self, listen: NetworkAddress) -> &mut Self {
-        self.listen = listen;
-        self
-    }
-
     pub fn validators(&mut self, nodes: usize) -> &mut Self {
         self.validator_config.nodes = nodes;
-        self
-    }
-
-    pub fn enable_remote_authentication(&mut self) -> &mut Self {
-        self.enable_remote_authentication = true;
-        self
-    }
-
-    pub fn public(&mut self) -> &mut Self {
-        self.enable_remote_authentication = false;
         self
     }
 
@@ -347,7 +302,7 @@ mod test {
         let config_one = FullNodeConfig::new().build().unwrap();
         let mut config_two = FullNodeConfig::new().build().unwrap();
         let mut fnc = FullNodeConfig::new();
-        fnc.full_node_seed([33u8; 32]);
+        fnc.full_node_seed = [33u8; 32];
         fnc.extend(&mut config_two).unwrap();
         assert_eq!(
             config_one.full_node_networks[0],

--- a/config/config-builder/src/full_node_config.rs
+++ b/config/config-builder/src/full_node_config.rs
@@ -96,7 +96,7 @@ impl FullNodeConfig {
     }
 
     pub fn validators(&mut self, nodes: usize) -> &mut Self {
-        self.validator_config.validators(nodes);
+        self.validator_config.nodes = nodes;
         self
     }
 
@@ -111,7 +111,7 @@ impl FullNodeConfig {
     }
 
     pub fn seed(&mut self, seed: [u8; 32]) -> &mut Self {
-        self.validator_config.seed(seed);
+        self.validator_config.seed = seed;
         self
     }
 

--- a/config/config-builder/src/key_manager_config.rs
+++ b/config/config-builder/src/key_manager_config.rs
@@ -6,18 +6,18 @@ use libra_config::config::{KeyManagerConfig as KMConfig, SecureBackend, Token, V
 use libra_types::account_address::AccountAddress;
 
 pub struct KeyManagerConfig {
-    rotation_period_secs: Option<u64>,
-    sleep_period_secs: Option<u64>,
-    txn_expiration_secs: Option<u64>,
+    pub rotation_period_secs: Option<u64>,
+    pub sleep_period_secs: Option<u64>,
+    pub txn_expiration_secs: Option<u64>,
 
-    json_rpc_endpoint: String,
-    validator_account: AccountAddress,
+    pub json_rpc_endpoint: String,
+    pub validator_account: AccountAddress,
 
-    vault_host: String,
-    vault_namespace: Option<String>,
-    vault_token: String,
+    pub vault_host: String,
+    pub vault_namespace: Option<String>,
+    pub vault_token: String,
 
-    template: KMConfig,
+    pub template: KMConfig,
 }
 
 impl Default for KeyManagerConfig {
@@ -40,45 +40,6 @@ impl Default for KeyManagerConfig {
 impl KeyManagerConfig {
     pub fn new() -> Self {
         Self::default()
-    }
-
-    pub fn json_rpc_endpoint(&mut self, json_rpc_endpoint: String) -> &mut Self {
-        self.json_rpc_endpoint = json_rpc_endpoint;
-        self
-    }
-
-    pub fn time_constants(
-        &mut self,
-        rotation_period_secs: Option<u64>,
-        sleep_period_secs: Option<u64>,
-        txn_expiration_secs: Option<u64>,
-    ) -> &mut Self {
-        self.rotation_period_secs = rotation_period_secs;
-        self.sleep_period_secs = sleep_period_secs;
-        self.txn_expiration_secs = txn_expiration_secs;
-        self
-    }
-
-    pub fn validator_account(&mut self, validator_account: AccountAddress) -> &mut Self {
-        self.validator_account = validator_account;
-        self
-    }
-
-    pub fn vault_storage(
-        &mut self,
-        vault_host: String,
-        vault_namespace: Option<String>,
-        vault_token: String,
-    ) -> &mut Self {
-        self.vault_host = vault_host;
-        self.vault_namespace = vault_namespace;
-        self.vault_token = vault_token;
-        self
-    }
-
-    pub fn template(&mut self, template: KMConfig) -> &mut Self {
-        self.template = template;
-        self
     }
 
     pub fn build(&self) -> Result<KMConfig> {
@@ -114,18 +75,18 @@ mod test {
     fn verify_generation() {
         let json_rpc_endpoint = "http://127.12.12.12:7873";
         let rotation_period_secs = 100;
+        let validator_account = AccountAddress::default();
         let vault_host = "182.0.0.1:8080";
         let vault_token = "root_token";
-        let validator_account = AccountAddress::default();
 
         let mut key_manager_config = KeyManagerConfig::new();
-        let key_manager_config = key_manager_config
-            .json_rpc_endpoint(json_rpc_endpoint.into())
-            .time_constants(Some(rotation_period_secs), None, None)
-            .validator_account(validator_account)
-            .vault_storage(vault_host.into(), None, vault_token.into())
-            .build()
-            .unwrap();
+        key_manager_config.json_rpc_endpoint = json_rpc_endpoint.into();
+        key_manager_config.rotation_period_secs = Some(rotation_period_secs);
+        key_manager_config.validator_account = validator_account;
+        key_manager_config.vault_host = vault_host.into();
+        key_manager_config.vault_token = vault_token.into();
+
+        let key_manager_config = key_manager_config.build().unwrap();
 
         assert_eq!(json_rpc_endpoint, key_manager_config.json_rpc_endpoint);
         assert_eq!(validator_account, key_manager_config.validator_account);

--- a/config/config-builder/src/main.rs
+++ b/config/config-builder/src/main.rs
@@ -216,7 +216,7 @@ fn main() {
 
 fn build_faucet(args: FaucetArgs) {
     let mut config_builder = ValidatorConfig::new();
-    config_builder.nodes = args.validators_in_genesis;
+    config_builder.num_nodes = args.validators_in_genesis;
 
     if let Some(seed) = args.seed.as_ref() {
         let seed = hex::decode(seed).expect("Invalid hex in seed.");
@@ -346,12 +346,12 @@ fn build_validator(args: ValidatorArgs) {
     }
 
     let mut config_builder = safety_rules_common(&args.validator_common);
-    config_builder.advertised = args.advertised;
+    config_builder.advertised_address = args.advertised;
     config_builder.bootstrap = args.bootstrap;
-    config_builder.index = args.validator_common.validator_index;
-    config_builder.listen = args.listen;
-    config_builder.nodes = args.validator_common.validators;
-    config_builder.nodes_in_genesis = args.validator_common.validators_in_genesis;
+    config_builder.node_index = args.validator_common.validator_index;
+    config_builder.listen_address = args.listen;
+    config_builder.num_nodes = args.validator_common.validators;
+    config_builder.num_nodes_in_genesis = args.validator_common.validators_in_genesis;
 
     if let Some(seed) = args.validator_common.seed.as_ref() {
         config_builder.seed = parse_seed(seed);
@@ -367,8 +367,8 @@ fn build_validator(args: ValidatorArgs) {
 fn safety_rules_common(args: &ValidatorCommonArgs) -> ValidatorConfig {
     let mut config_builder = ValidatorConfig::new();
 
-    config_builder.index = args.validator_index;
-    config_builder.nodes = args.validators;
+    config_builder.node_index = args.validator_index;
+    config_builder.num_nodes = args.validators;
     config_builder.safety_rules_addr = args.safety_rules_addr;
     config_builder.safety_rules_backend = args.safety_rules_backend.clone();
     config_builder.safety_rules_host = args.safety_rules_host.clone();

--- a/config/config-builder/src/main.rs
+++ b/config/config-builder/src/main.rs
@@ -278,13 +278,13 @@ fn build_full_node(command: FullNodeCommand) {
 
 fn build_full_node_config_builder(args: &FullNodeArgs) -> FullNodeConfig {
     let mut config_builder = FullNodeConfig::new();
-    config_builder.advertised = args.advertised.clone();
+    config_builder.advertised_address = args.advertised.clone();
     config_builder.bootstrap = args.bootstrap.clone();
     config_builder.full_node_index = args.full_node_index;
-    config_builder.full_nodes = args.full_nodes;
-    config_builder.listen = args.listen.clone();
+    config_builder.num_full_nodes = args.full_nodes;
+    config_builder.listen_address = args.listen.clone();
     config_builder
-        .validators(args.validators)
+        .num_validator_nodes(args.validators)
         .template(load_node_template(args.template.as_ref()));
 
     if let Some(fn_seed) = args.full_node_seed.as_ref() {
@@ -296,7 +296,7 @@ fn build_full_node_config_builder(args: &FullNodeArgs) -> FullNodeConfig {
     }
 
     if let Some(seed) = args.seed.as_ref() {
-        config_builder.seed(parse_seed(seed));
+        config_builder.validator_seed(parse_seed(seed));
     }
 
     config_builder

--- a/config/config-builder/src/main.rs
+++ b/config/config-builder/src/main.rs
@@ -309,20 +309,18 @@ fn build_key_manager(args: KeyManagerArgs) {
     }
 
     let mut config_builder = KeyManagerConfig::new();
-    config_builder
-        .json_rpc_endpoint(args.json_rpc_endpoint.clone())
-        .time_constants(
-            args.rotation_period_secs.clone(),
-            args.sleep_period_secs.clone(),
-            args.txn_expiration_secs.clone(),
-        )
-        .validator_account(args.validator_account.clone())
-        .vault_storage(
-            args.vault_host.clone(),
-            args.vault_namespace.clone(),
-            args.vault_token.clone(),
-        )
-        .template(load_key_manager_template(args.template.as_ref()));
+    config_builder.rotation_period_secs = args.rotation_period_secs;
+    config_builder.sleep_period_secs = args.sleep_period_secs;
+    config_builder.txn_expiration_secs = args.txn_expiration_secs;
+
+    config_builder.json_rpc_endpoint = args.json_rpc_endpoint.clone();
+    config_builder.validator_account = args.validator_account;
+
+    config_builder.vault_host = args.vault_host.clone();
+    config_builder.vault_namespace = args.vault_namespace.clone();
+    config_builder.vault_token = args.vault_token.clone();
+
+    config_builder.template = load_key_manager_template(args.template.as_ref());
 
     let mut key_manager_config = config_builder.build().expect("ConfigBuilder failed");
     key_manager_config.set_data_dir(args.data_dir);

--- a/config/config-builder/src/main.rs
+++ b/config/config-builder/src/main.rs
@@ -216,11 +216,11 @@ fn main() {
 
 fn build_faucet(args: FaucetArgs) {
     let mut config_builder = ValidatorConfig::new();
-    config_builder.validators(args.validators_in_genesis);
+    config_builder.nodes = args.validators_in_genesis;
 
     if let Some(seed) = args.seed.as_ref() {
         let seed = hex::decode(seed).expect("Invalid hex in seed.");
-        config_builder.seed(seed[..32].try_into().expect("Invalid seed"));
+        config_builder.seed = seed[..32].try_into().expect("Invalid seed");
     }
 
     let (faucet_key, waypoint) = config_builder
@@ -346,16 +346,15 @@ fn build_validator(args: ValidatorArgs) {
     }
 
     let mut config_builder = safety_rules_common(&args.validator_common);
-    config_builder
-        .advertised(args.advertised)
-        .bootstrap(args.bootstrap)
-        .validator_index(args.validator_common.validator_index)
-        .listen(args.listen)
-        .validators(args.validator_common.validators)
-        .validators_in_genesis(args.validator_common.validators_in_genesis);
+    config_builder.advertised = args.advertised;
+    config_builder.bootstrap = args.bootstrap;
+    config_builder.index = args.validator_common.validator_index;
+    config_builder.listen = args.listen;
+    config_builder.nodes = args.validator_common.validators;
+    config_builder.nodes_in_genesis = args.validator_common.validators_in_genesis;
 
     if let Some(seed) = args.validator_common.seed.as_ref() {
-        config_builder.seed(parse_seed(seed));
+        config_builder.seed = parse_seed(seed);
     }
 
     let mut node_config = config_builder.build().expect("ConfigBuilder failed");
@@ -368,20 +367,17 @@ fn build_validator(args: ValidatorArgs) {
 fn safety_rules_common(args: &ValidatorCommonArgs) -> ValidatorConfig {
     let mut config_builder = ValidatorConfig::new();
 
-    config_builder
-        .validator_index(args.validator_index)
-        .validators(args.validators)
-        .safety_rules_addr(args.safety_rules_addr.clone())
-        .safety_rules_backend(
-            args.safety_rules_backend.clone(),
-            args.safety_rules_host.clone(),
-            args.safety_rules_namespace.clone(),
-            args.safety_rules_token.clone(),
-        )
-        .template(load_node_template(args.template.as_ref()));
+    config_builder.index = args.validator_index;
+    config_builder.nodes = args.validators;
+    config_builder.safety_rules_addr = args.safety_rules_addr;
+    config_builder.safety_rules_backend = args.safety_rules_backend.clone();
+    config_builder.safety_rules_host = args.safety_rules_host.clone();
+    config_builder.safety_rules_namespace = args.safety_rules_namespace.clone();
+    config_builder.safety_rules_token = args.safety_rules_token.clone();
+    config_builder.template = load_node_template(args.template.as_ref());
 
     if let Some(seed) = args.seed.as_ref() {
-        config_builder.seed(parse_seed(seed));
+        config_builder.seed = parse_seed(seed);
     }
 
     config_builder

--- a/config/config-builder/src/main.rs
+++ b/config/config-builder/src/main.rs
@@ -278,21 +278,21 @@ fn build_full_node(command: FullNodeCommand) {
 
 fn build_full_node_config_builder(args: &FullNodeArgs) -> FullNodeConfig {
     let mut config_builder = FullNodeConfig::new();
+    config_builder.advertised = args.advertised.clone();
+    config_builder.bootstrap = args.bootstrap.clone();
+    config_builder.full_node_index = args.full_node_index;
+    config_builder.full_nodes = args.full_nodes;
+    config_builder.listen = args.listen.clone();
     config_builder
-        .advertised(args.advertised.clone())
-        .bootstrap(args.bootstrap.clone())
-        .full_node_index(args.full_node_index)
-        .full_nodes(args.full_nodes)
-        .listen(args.listen.clone())
         .validators(args.validators)
         .template(load_node_template(args.template.as_ref()));
 
     if let Some(fn_seed) = args.full_node_seed.as_ref() {
-        config_builder.full_node_seed(parse_seed(fn_seed));
+        config_builder.full_node_seed = parse_seed(fn_seed);
     }
 
     if args.public {
-        config_builder.public();
+        config_builder.enable_remote_authentication = false;
     }
 
     if let Some(seed) = args.seed.as_ref() {

--- a/config/config-builder/src/validator_config.rs
+++ b/config/config-builder/src/validator_config.rs
@@ -22,17 +22,17 @@ use std::{net::SocketAddr, str::FromStr};
 use storage_interface::DbReaderWriter;
 
 const DEFAULT_SEED: [u8; 32] = [13u8; 32];
-const DEFAULT_ADVERTISED: &str = "/ip4/127.0.0.1/tcp/6180";
-const DEFAULT_LISTEN: &str = "/ip4/0.0.0.0/tcp/6180";
+const DEFAULT_ADVERTISED_ADDRESS: &str = "/ip4/127.0.0.1/tcp/6180";
+const DEFAULT_LISTEN_ADDRESS: &str = "/ip4/0.0.0.0/tcp/6180";
 
 pub struct ValidatorConfig {
-    pub advertised: NetworkAddress,
+    pub advertised_address: NetworkAddress,
     pub build_waypoint: bool,
     pub bootstrap: NetworkAddress,
-    pub index: usize,
-    pub listen: NetworkAddress,
-    pub nodes: usize,
-    pub nodes_in_genesis: Option<usize>,
+    pub node_index: usize,
+    pub listen_address: NetworkAddress,
+    pub num_nodes: usize,
+    pub num_nodes_in_genesis: Option<usize>,
     pub safety_rules_addr: Option<SocketAddr>,
     pub safety_rules_backend: Option<String>,
     pub safety_rules_host: Option<String>,
@@ -45,13 +45,13 @@ pub struct ValidatorConfig {
 impl Default for ValidatorConfig {
     fn default() -> Self {
         Self {
-            advertised: NetworkAddress::from_str(DEFAULT_ADVERTISED).unwrap(),
-            bootstrap: NetworkAddress::from_str(DEFAULT_ADVERTISED).unwrap(),
+            advertised_address: NetworkAddress::from_str(DEFAULT_ADVERTISED_ADDRESS).unwrap(),
+            bootstrap: NetworkAddress::from_str(DEFAULT_ADVERTISED_ADDRESS).unwrap(),
             build_waypoint: true,
-            index: 0,
-            listen: NetworkAddress::from_str(DEFAULT_LISTEN).unwrap(),
-            nodes: 1,
-            nodes_in_genesis: None,
+            node_index: 0,
+            listen_address: NetworkAddress::from_str(DEFAULT_LISTEN_ADDRESS).unwrap(),
+            num_nodes: 1,
+            num_nodes_in_genesis: None,
             safety_rules_addr: None,
             safety_rules_backend: None,
             safety_rules_host: None,
@@ -80,14 +80,14 @@ impl ValidatorConfig {
         let seed_peers = generator::build_seed_peers(&seed_config, self.bootstrap.clone());
 
         // Pull out this specific node from the generated validator configs.
-        let mut config = configs.swap_remove(self.index);
+        let mut config = configs.swap_remove(self.node_index);
 
         let validator_network = config
             .validator_network
             .as_mut()
             .ok_or(Error::MissingValidatorNetwork)?;
-        validator_network.listen_address = self.listen.clone();
-        validator_network.advertised_address = self.advertised.clone();
+        validator_network.listen_address = self.listen_address.clone();
+        validator_network.advertised_address = self.advertised_address.clone();
         validator_network.seed_peers = seed_peers;
 
         self.build_safety_rules(&mut config)?;
@@ -115,27 +115,31 @@ impl ValidatorConfig {
         &self,
         randomize_ports: bool,
     ) -> Result<(Vec<NodeConfig>, Ed25519PrivateKey)> {
-        ensure!(self.nodes > 0, Error::NonZeroNetwork);
+        ensure!(self.num_nodes > 0, Error::NonZeroNetwork);
         ensure!(
-            self.index < self.nodes,
+            self.node_index < self.num_nodes,
             Error::IndexError {
-                index: self.index,
-                nodes: self.nodes
+                index: self.node_index,
+                nodes: self.num_nodes
             }
         );
 
         let (faucet_key, config_seed) = self.build_faucet_key();
-        let generator::ValidatorSwarm { mut nodes, .. } =
-            generator::validator_swarm(&self.template, self.nodes, config_seed, randomize_ports);
+        let generator::ValidatorSwarm { mut nodes, .. } = generator::validator_swarm(
+            &self.template,
+            self.num_nodes,
+            config_seed,
+            randomize_ports,
+        );
 
         ensure!(
-            nodes.len() == self.nodes,
+            nodes.len() == self.num_nodes,
             Error::MissingConfigs { found: nodes.len() }
         );
 
         // Optionally choose a limited subset of generated validators to be
         // present at genesis time.
-        let nodes_in_genesis = self.nodes_in_genesis.unwrap_or(self.nodes);
+        let nodes_in_genesis = self.num_nodes_in_genesis.unwrap_or(self.num_nodes);
 
         let validators = vm_genesis::validator_registrations(&nodes[..nodes_in_genesis]);
 
@@ -234,8 +238,8 @@ mod test {
     #[test]
     fn verify_correctness() {
         let mut validator_config = ValidatorConfig::new();
-        validator_config.nodes = 2;
-        validator_config.index = 1;
+        validator_config.num_nodes = 2;
+        validator_config.node_index = 1;
 
         let config = validator_config.build().unwrap();
         let network = config.validator_network.as_ref().unwrap();
@@ -248,11 +252,11 @@ mod test {
 
         assert_eq!(
             network.advertised_address,
-            NetworkAddress::from_str(DEFAULT_ADVERTISED).unwrap()
+            NetworkAddress::from_str(DEFAULT_ADVERTISED_ADDRESS).unwrap()
         );
         assert_eq!(
             network.listen_address,
-            NetworkAddress::from_str(DEFAULT_LISTEN).unwrap()
+            NetworkAddress::from_str(DEFAULT_LISTEN_ADDRESS).unwrap()
         );
 
         assert!(config.execution.genesis.is_some());
@@ -261,14 +265,14 @@ mod test {
     #[test]
     fn verify_same_genesis() {
         let mut config1 = ValidatorConfig::new();
-        config1.nodes = 10;
-        config1.index = 1;
+        config1.num_nodes = 10;
+        config1.node_index = 1;
         let config1 = config1.build().unwrap();
 
         let mut config2 = ValidatorConfig::new();
-        config2.nodes = 13;
-        config2.index = 12;
-        config2.nodes_in_genesis = Some(10);
+        config2.num_nodes = 13;
+        config2.node_index = 12;
+        config2.num_nodes_in_genesis = Some(10);
         let config2 = config2.build().unwrap();
 
         assert_eq!(config1.execution.genesis, config2.execution.genesis);

--- a/config/config-builder/src/validator_config.rs
+++ b/config/config-builder/src/validator_config.rs
@@ -26,20 +26,20 @@ const DEFAULT_ADVERTISED: &str = "/ip4/127.0.0.1/tcp/6180";
 const DEFAULT_LISTEN: &str = "/ip4/0.0.0.0/tcp/6180";
 
 pub struct ValidatorConfig {
-    advertised: NetworkAddress,
-    build_waypoint: bool,
-    bootstrap: NetworkAddress,
-    index: usize,
-    listen: NetworkAddress,
-    nodes: usize,
-    nodes_in_genesis: Option<usize>,
-    safety_rules_addr: Option<SocketAddr>,
-    safety_rules_backend: Option<String>,
-    safety_rules_host: Option<String>,
-    safety_rules_namespace: Option<String>,
-    safety_rules_token: Option<String>,
-    seed: [u8; 32],
-    template: NodeConfig,
+    pub advertised: NetworkAddress,
+    pub build_waypoint: bool,
+    pub bootstrap: NetworkAddress,
+    pub index: usize,
+    pub listen: NetworkAddress,
+    pub nodes: usize,
+    pub nodes_in_genesis: Option<usize>,
+    pub safety_rules_addr: Option<SocketAddr>,
+    pub safety_rules_backend: Option<String>,
+    pub safety_rules_host: Option<String>,
+    pub safety_rules_namespace: Option<String>,
+    pub safety_rules_token: Option<String>,
+    pub seed: [u8; 32],
+    pub template: NodeConfig,
 }
 
 impl Default for ValidatorConfig {
@@ -66,71 +66,6 @@ impl Default for ValidatorConfig {
 impl ValidatorConfig {
     pub fn new() -> Self {
         Self::default()
-    }
-
-    pub fn advertised(&mut self, advertised: NetworkAddress) -> &mut Self {
-        self.advertised = advertised;
-        self
-    }
-
-    pub fn bootstrap(&mut self, bootstrap: NetworkAddress) -> &mut Self {
-        self.bootstrap = bootstrap;
-        self
-    }
-
-    pub fn build_waypoint(&mut self, enabled: bool) -> &mut Self {
-        self.build_waypoint = enabled;
-        self
-    }
-
-    pub fn validator_index(&mut self, index: usize) -> &mut Self {
-        self.index = index;
-        self
-    }
-
-    pub fn listen(&mut self, listen: NetworkAddress) -> &mut Self {
-        self.listen = listen;
-        self
-    }
-
-    pub fn validators(&mut self, nodes: usize) -> &mut Self {
-        self.nodes = nodes;
-        self
-    }
-
-    pub fn validators_in_genesis(&mut self, nodes_in_genesis: Option<usize>) -> &mut Self {
-        self.nodes_in_genesis = nodes_in_genesis;
-        self
-    }
-
-    pub fn safety_rules_addr(&mut self, safety_rules_addr: Option<SocketAddr>) -> &mut Self {
-        self.safety_rules_addr = safety_rules_addr;
-        self
-    }
-
-    pub fn safety_rules_backend(
-        &mut self,
-        safety_rules_backend: Option<String>,
-        safety_rules_host: Option<String>,
-        safety_rules_namespace: Option<String>,
-        safety_rules_token: Option<String>,
-    ) -> &mut Self {
-        self.safety_rules_backend = safety_rules_backend;
-        self.safety_rules_host = safety_rules_host;
-        self.safety_rules_namespace = safety_rules_namespace;
-        self.safety_rules_token = safety_rules_token;
-
-        self
-    }
-
-    pub fn seed(&mut self, seed: [u8; 32]) -> &mut Self {
-        self.seed = seed;
-        self
-    }
-
-    pub fn template(&mut self, template: NodeConfig) -> &mut Self {
-        self.template = template;
-        self
     }
 
     pub fn build(&self) -> Result<NodeConfig> {
@@ -299,11 +234,10 @@ mod test {
     #[test]
     fn verify_correctness() {
         let mut validator_config = ValidatorConfig::new();
-        let config = validator_config
-            .validators(2)
-            .validator_index(1)
-            .build()
-            .unwrap();
+        validator_config.nodes = 2;
+        validator_config.index = 1;
+
+        let config = validator_config.build().unwrap();
         let network = config.validator_network.as_ref().unwrap();
 
         network.seed_peers.verify_libranet_addrs().unwrap();
@@ -326,17 +260,16 @@ mod test {
 
     #[test]
     fn verify_same_genesis() {
-        let config1 = ValidatorConfig::new()
-            .validators(10)
-            .validator_index(1)
-            .build()
-            .unwrap();
-        let config2 = ValidatorConfig::new()
-            .validators(13)
-            .validator_index(12)
-            .validators_in_genesis(Some(10))
-            .build()
-            .unwrap();
+        let mut config1 = ValidatorConfig::new();
+        config1.nodes = 10;
+        config1.index = 1;
+        let config1 = config1.build().unwrap();
+
+        let mut config2 = ValidatorConfig::new();
+        config2.nodes = 13;
+        config2.index = 12;
+        config2.nodes_in_genesis = Some(10);
+        let config2 = config2.build().unwrap();
 
         assert_eq!(config1.execution.genesis, config2.execution.genesis);
     }

--- a/execution/executor/src/executor_test.rs
+++ b/execution/executor/src/executor_test.rs
@@ -25,10 +25,8 @@ use std::collections::BTreeMap;
 
 fn build_test_config() -> (NodeConfig, Ed25519PrivateKey) {
     let mut validator_config = config_builder::ValidatorConfig::new();
-    let (mut configs, key) = validator_config
-        .build_waypoint(false)
-        .build_common(false)
-        .unwrap();
+    validator_config.build_waypoint = false;
+    let (mut configs, key) = validator_config.build_common(false).unwrap();
     (configs.swap_remove(0), key)
 }
 

--- a/network/onchain-discovery/src/test.rs
+++ b/network/onchain-discovery/src/test.rs
@@ -163,11 +163,9 @@ fn read_validator_set(libra_db: &Arc<dyn DbReader>) -> ValidatorSet {
 }
 
 fn gen_configs(count: usize) -> Vec<NodeConfig> {
-    config_builder::ValidatorConfig::new()
-        .validators(count)
-        .build_common(false)
-        .unwrap()
-        .0
+    let mut node_config = config_builder::ValidatorConfig::new();
+    node_config.nodes = count;
+    node_config.build_common(false).unwrap().0
 }
 
 fn setup_storage_service_and_executor(

--- a/network/onchain-discovery/src/test.rs
+++ b/network/onchain-discovery/src/test.rs
@@ -164,7 +164,7 @@ fn read_validator_set(libra_db: &Arc<dyn DbReader>) -> ValidatorSet {
 
 fn gen_configs(count: usize) -> Vec<NodeConfig> {
     let mut node_config = config_builder::ValidatorConfig::new();
-    node_config.nodes = count;
+    node_config.num_nodes = count;
     node_config.build_common(false).unwrap().0
 }
 

--- a/testsuite/cluster-test/src/cluster.rs
+++ b/testsuite/cluster-test/src/cluster.rs
@@ -48,7 +48,9 @@ impl Cluster {
         let seed = "1337133713371337133713371337133713371337133713371337133713371337";
         let seed = hex::decode(seed).expect("Invalid hex in seed.");
         let seed = seed[..32].try_into().expect("Invalid seed");
-        let (mint_key, _) = ValidatorConfig::new().seed(seed).build_faucet_key();
+        let mut validator_config = ValidatorConfig::new();
+        validator_config.seed = seed;
+        let (mint_key, _) = validator_config.build_faucet_key();
         KeyPair::from(mint_key)
     }
 

--- a/testsuite/libra-swarm/src/swarm.rs
+++ b/testsuite/libra-swarm/src/swarm.rs
@@ -317,7 +317,7 @@ impl LibraSwarm {
         let config = if role.is_validator() {
             let mut validator_builder = ValidatorConfig::new();
             validator_builder.template = node_config;
-            validator_builder.nodes = num_nodes;
+            validator_builder.num_nodes = num_nodes;
             SwarmConfig::build(&validator_builder, config_path)?
         } else {
             let upstream_config_dir = upstream_config_dir.expect("No upstream node for full nodes");

--- a/testsuite/libra-swarm/src/swarm.rs
+++ b/testsuite/libra-swarm/src/swarm.rs
@@ -325,7 +325,7 @@ impl LibraSwarm {
             let mut validator_config = NodeConfig::load(&upstream_config_file)?;
             let genesis = validator_config.execution.genesis.as_ref();
             let mut full_node_builder = FullNodeConfig::new();
-            full_node_builder.full_nodes = num_nodes;
+            full_node_builder.num_full_nodes = num_nodes;
             full_node_builder.genesis =
                 Some(genesis.expect("Missing genesis from validator").clone());
             full_node_builder.template(node_config);

--- a/testsuite/libra-swarm/src/swarm.rs
+++ b/testsuite/libra-swarm/src/swarm.rs
@@ -325,17 +325,15 @@ impl LibraSwarm {
             let mut validator_config = NodeConfig::load(&upstream_config_file)?;
             let genesis = validator_config.execution.genesis.as_ref();
             let mut full_node_builder = FullNodeConfig::new();
-            full_node_builder
-                .full_nodes(num_nodes)
-                .genesis(genesis.expect("Missing genesis from validator").clone())
-                .template(node_config);
+            full_node_builder.full_nodes = num_nodes;
+            full_node_builder.genesis =
+                Some(genesis.expect("Missing genesis from validator").clone());
+            full_node_builder.template(node_config);
             full_node_builder.extend_validator(&mut validator_config)?;
             validator_config.save(&upstream_config_file)?;
-            full_node_builder.bootstrap(
-                validator_config.full_node_networks[0]
-                    .advertised_address
-                    .clone(),
-            );
+            full_node_builder.bootstrap = validator_config.full_node_networks[0]
+                .advertised_address
+                .clone();
             SwarmConfig::build(&full_node_builder, config_path)?
         };
 

--- a/testsuite/libra-swarm/src/swarm.rs
+++ b/testsuite/libra-swarm/src/swarm.rs
@@ -316,9 +316,8 @@ impl LibraSwarm {
         let config_path = &swarm_config_dir.as_ref().to_path_buf();
         let config = if role.is_validator() {
             let mut validator_builder = ValidatorConfig::new();
-            validator_builder
-                .template(node_config)
-                .validators(num_nodes);
+            validator_builder.template = node_config;
+            validator_builder.nodes = num_nodes;
             SwarmConfig::build(&validator_builder, config_path)?
         } else {
             let upstream_config_dir = upstream_config_dir.expect("No upstream node for full nodes");


### PR DESCRIPTION
## Motivation

At present, config builder is a little confusing and inconsistent; it contains a lot of unnecessary code complexity which makes it difficult to reason about with respect to the actual generated configs. This PR takes some steps to simplifying config builder. It does so in 6 commits:

- Commits 1 - 3 refactor key manager config, validator config and full node config, respectively. Here, we avoid using setter methods() where appropriate and simply make the internal fields public. This not only removes a lot of code, but it makes future refactors easier and helps to avoid potential errors: for example, full node config currently has two methods (public() and enable_remote_authentication()) which both modify the same internal field "enable_remote_authentication".. and one of the methods appears to be unused in the code base? Moreover, as public() is undocumented (and arguably, not well named) it's unclear what this method should actually do..

- Commit 4 renames some of the fields in validator config builder: (i) to provide more self clarity; and (ii) to be consistent with the names in validator config. This helps avoid confusion about what config builder is doing.

- Commit 5 renames some of the fields in full node config builder to be consistent with validator config and the rest of the config code.

Note: in commits 4 and 5, this PR does not change the fields/arguments exposed by config-builder/main.rs. This is because changes to the names of these arguments may break external dependencies (e.g., docker containers). If we think it's worth fixing these arguments, this can be done in a future PR.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?

Yes.

## Test Plan

All existing tests still pass.

## Related PRs

None.
