### PR TITLE
[management] Do not enable any discovery for validators

### DIFF
--- a/config/management/src/smoke_test.rs
+++ b/config/management/src/smoke_test.rs
@@ -70,7 +70,7 @@ fn smoke_test() {
         let mut config = NodeConfig::default();
 
         let mut network = NetworkConfig::default();
-        network.discovery_method = DiscoveryMethod::Onchain;
+        network.discovery_method = DiscoveryMethod::None;
         config.validator_network = Some(network);
 
         let mut network = NetworkConfig::default();


### PR DESCRIPTION
@agclement made it so that we have a dead simple onchain discovery protocol, this ensures that we use it and only it to avoid races.

@mgorven, what are you specifying right now in the network configs for discovery methd?