### PR TITLE
[OnchainDiscovery] incremental change to make OnchainDiscovery setup …

### DIFF
--- a/libra-node/src/main_node.rs
+++ b/libra-node/src/main_node.rs
@@ -24,6 +24,7 @@ use network::validator_network::network_builder::{AuthenticationMode, NetworkBui
 use network_simple_onchain_discovery::{
     gen_simple_discovery_reconfig_subscription, ConfigurationChangeListener,
 };
+use onchain_discovery::builder::OnchainDiscoveryBuilder;
 use state_synchronizer::StateSynchronizer;
 use std::{boxed::Box, collections::HashMap, net::ToSocketAddrs, sync::Arc, thread, time::Instant};
 use storage_interface::{DbReader, DbReaderWriter};
@@ -133,14 +134,21 @@ pub fn setup_network(
                 .add_gossip_discovery();
         }
         DiscoveryMethod::Onchain => {
-            onchain_discovery::setup_onchain_discovery(
-                &mut network_builder,
+            let (network_tx, discovery_events) =
+                onchain_discovery::network_interface::add_to_network(&mut network_builder);
+            let onchain_discovery_builder = OnchainDiscoveryBuilder::build(
+                network_builder
+                    .conn_mgr_reqs_tx()
+                    .expect("ConnectivityManager must be installed"),
+                network_tx,
+                discovery_events,
                 peer_id,
                 role,
                 libra_db,
                 waypoint,
                 runtime.handle(),
             );
+            onchain_discovery_builder.start(runtime.handle());
         }
         DiscoveryMethod::None => {}
     }

--- a/libra-node/src/main_node.rs
+++ b/libra-node/src/main_node.rs
@@ -80,10 +80,14 @@ pub fn setup_onchain_discovery(
     waypoint: Waypoint,
     executor: &Handle,
 ) {
-    let (network_tx, peer_mgr_notifs_rx, conn_notifs_rx) =
+    let (network_tx, discovery_events) =
         onchain_discovery::network_interface::add_to_network(network);
     let outbound_rpc_timeout = Duration::from_secs(30);
     let max_concurrent_inbound_queries = 8;
+    let (peer_mgr_notifs_rx, conn_notifs_rx) = (
+        discovery_events.peer_mgr_notifs_rx,
+        discovery_events.connection_notifs_rx,
+    );
 
     let onchain_discovery_service = OnchainDiscoveryService::new(
         executor.clone(),
@@ -102,6 +106,9 @@ pub fn setup_onchain_discovery(
             role,
             waypoint,
             network_tx,
+            network
+                .conn_mgr_reqs_tx()
+                .expect("ConnecitivtyManager not enabled"),
             conn_notifs_rx,
             libra_db,
             peer_query_ticker,

--- a/libra-node/src/main_node.rs
+++ b/libra-node/src/main_node.rs
@@ -7,7 +7,7 @@ use consensus::{consensus_provider::start_consensus, gen_consensus_reconfig_subs
 use debug_interface::node_debug_service::NodeDebugService;
 use executor::{db_bootstrapper::bootstrap_db_if_empty, Executor};
 use executor_types::ChunkExecutor;
-use futures::{channel::mpsc::channel, executor::block_on, stream::StreamExt};
+use futures::{channel::mpsc::channel, executor::block_on};
 use libra_config::{
     config::{DiscoveryMethod, NetworkConfig, NodeConfig, RoleType},
     utils::get_genesis_txn,
@@ -17,29 +17,18 @@ use libra_logger::prelude::*;
 use libra_mempool::gen_mempool_reconfig_subscription;
 use libra_metrics::metric_server;
 use libra_secure_storage::config;
-use libra_types::{waypoint::Waypoint, PeerId};
+use libra_types::waypoint::Waypoint;
 use libra_vm::LibraVM;
 use libradb::LibraDB;
 use network::validator_network::network_builder::{AuthenticationMode, NetworkBuilder};
 use network_simple_onchain_discovery::{
     gen_simple_discovery_reconfig_subscription, ConfigurationChangeListener,
 };
-use onchain_discovery::{client::OnchainDiscovery, service::OnchainDiscoveryService};
 use state_synchronizer::StateSynchronizer;
-use std::{
-    boxed::Box,
-    collections::HashMap,
-    net::ToSocketAddrs,
-    sync::Arc,
-    thread,
-    time::{Duration, Instant},
-};
+use std::{boxed::Box, collections::HashMap, net::ToSocketAddrs, sync::Arc, thread, time::Instant};
 use storage_interface::{DbReader, DbReaderWriter};
 use storage_service::start_storage_service_with_db;
-use tokio::{
-    runtime::{Builder, Handle, Runtime},
-    time::interval,
-};
+use tokio::runtime::{Builder, Runtime};
 
 const AC_SMP_CHANNEL_BUFFER_SIZE: usize = 1_024;
 const INTRA_NODE_CHANNEL_BUFFER_SIZE: usize = 1;
@@ -70,53 +59,6 @@ fn setup_debug_interface(config: &NodeConfig) -> NodeDebugService {
     .unwrap();
 
     NodeDebugService::new(addr)
-}
-
-pub fn setup_onchain_discovery(
-    network: &mut NetworkBuilder,
-    peer_id: PeerId,
-    role: RoleType,
-    libra_db: Arc<dyn DbReader>,
-    waypoint: Waypoint,
-    executor: &Handle,
-) {
-    let (network_tx, discovery_events) =
-        onchain_discovery::network_interface::add_to_network(network);
-    let outbound_rpc_timeout = Duration::from_secs(30);
-    let max_concurrent_inbound_queries = 8;
-    let (peer_mgr_notifs_rx, conn_notifs_rx) = (
-        discovery_events.peer_mgr_notifs_rx,
-        discovery_events.connection_notifs_rx,
-    );
-
-    let onchain_discovery_service = OnchainDiscoveryService::new(
-        executor.clone(),
-        peer_mgr_notifs_rx,
-        Arc::clone(&libra_db),
-        max_concurrent_inbound_queries,
-    );
-    executor.spawn(onchain_discovery_service.start());
-
-    let onchain_discovery = executor.enter(move || {
-        let peer_query_ticker = interval(Duration::from_secs(30)).fuse();
-        let storage_query_ticker = interval(Duration::from_secs(30)).fuse();
-
-        OnchainDiscovery::new(
-            peer_id,
-            role,
-            waypoint,
-            network_tx,
-            network
-                .conn_mgr_reqs_tx()
-                .expect("ConnecitivtyManager not enabled"),
-            conn_notifs_rx,
-            libra_db,
-            peer_query_ticker,
-            storage_query_ticker,
-            outbound_rpc_timeout,
-        )
-    });
-    executor.spawn(onchain_discovery.start());
 }
 
 // TODO(abhayb): Move to network crate (similar to consensus).
@@ -191,7 +133,7 @@ pub fn setup_network(
                 .add_gossip_discovery();
         }
         DiscoveryMethod::Onchain => {
-            setup_onchain_discovery(
+            onchain_discovery::setup_onchain_discovery(
                 &mut network_builder,
                 peer_id,
                 role,

--- a/network/onchain-discovery/src/builder.rs
+++ b/network/onchain-discovery/src/builder.rs
@@ -74,9 +74,11 @@ impl OnchainDiscoveryBuilder {
         }
     }
 
-    /// Starts the provided onchain_discovery_service and onchain_discovery.
-    pub fn start(self, executor: &Handle) {
+    /// Starts the provided onchain_discovery_service and onchain_discovery.  Should be called at
+    /// most once.
+    pub fn start(mut self, executor: &Handle) {
         assert!(!self.started);
+        self.started = true;
         executor.spawn(self.onchain_discovery_service.start());
         executor.spawn(self.onchain_discovery.start());
     }

--- a/network/onchain-discovery/src/builder.rs
+++ b/network/onchain-discovery/src/builder.rs
@@ -1,0 +1,83 @@
+// Copyright (c) The Libra Core Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::{
+    client::OnchainDiscovery,
+    network_interface::{OnchainDiscoveryNetworkEvents, OnchainDiscoveryNetworkSender},
+    service::OnchainDiscoveryService,
+};
+use futures::stream::{Fuse, StreamExt};
+use libra_config::config::RoleType;
+use libra_types::{waypoint::Waypoint, PeerId};
+use network::connectivity_manager::ConnectivityRequest;
+use std::{sync::Arc, time::Duration};
+use storage_interface::DbReader;
+use tokio::{
+    runtime::Handle,
+    time::{interval, Interval},
+};
+
+pub struct OnchainDiscoveryBuilder {
+    onchain_discovery_service: OnchainDiscoveryService,
+    onchain_discovery: OnchainDiscovery<Fuse<Interval>>,
+    started: bool,
+}
+
+impl OnchainDiscoveryBuilder {
+    /// Setup OnchainDiscovery to work with the provided tx and rx channels.  Returns a tuple
+    /// (OnChainDiscoveryService, OnChainDiscovery) which must be started by the caller.
+    pub fn build(
+        conn_mgr_reqs_tx: channel::Sender<ConnectivityRequest>,
+        network_tx: OnchainDiscoveryNetworkSender,
+        discovery_events: OnchainDiscoveryNetworkEvents,
+        peer_id: PeerId,
+        role: RoleType,
+        libra_db: Arc<dyn DbReader>,
+        waypoint: Waypoint,
+        executor: &Handle,
+    ) -> Self {
+        let outbound_rpc_timeout = Duration::from_secs(30);
+        let max_concurrent_inbound_queries = 8;
+        let (peer_mgr_notifs_rx, conn_notifs_rx) = (
+            discovery_events.peer_mgr_notifs_rx,
+            discovery_events.connection_notifs_rx,
+        );
+
+        let onchain_discovery_service = OnchainDiscoveryService::new(
+            executor.clone(),
+            peer_mgr_notifs_rx,
+            Arc::clone(&libra_db),
+            max_concurrent_inbound_queries,
+        );
+
+        let onchain_discovery = executor.enter(move || {
+            let peer_query_ticker = interval(Duration::from_secs(30)).fuse();
+            let storage_query_ticker = interval(Duration::from_secs(30)).fuse();
+
+            OnchainDiscovery::new(
+                peer_id,
+                role,
+                waypoint,
+                network_tx,
+                conn_mgr_reqs_tx,
+                conn_notifs_rx,
+                libra_db,
+                peer_query_ticker,
+                storage_query_ticker,
+                outbound_rpc_timeout,
+            )
+        });
+        Self {
+            onchain_discovery_service,
+            onchain_discovery,
+            started: false,
+        }
+    }
+
+    /// Starts the provided onchain_discovery_service and onchain_discovery.
+    pub fn start(self, executor: &Handle) {
+        assert!(!self.started);
+        executor.spawn(self.onchain_discovery_service.start());
+        executor.spawn(self.onchain_discovery.start());
+    }
+}

--- a/network/onchain-discovery/src/lib.rs
+++ b/network/onchain-discovery/src/lib.rs
@@ -47,13 +47,22 @@
 //! 4. notifies the connectivity_manager with updated network info whenever we
 //!    detect a newer discovery set
 
-use crate::types::{QueryDiscoverySetRequest, QueryDiscoverySetResponse};
+use crate::{
+    client::OnchainDiscovery,
+    service::OnchainDiscoveryService,
+    types::{QueryDiscoverySetRequest, QueryDiscoverySetResponse},
+};
 use anyhow::{Context as AnyhowContext, Result};
-use futures::future::{Future, FutureExt};
-use libra_types::account_config;
-use std::sync::Arc;
+use futures::{
+    future::{Future, FutureExt},
+    stream::StreamExt,
+};
+use libra_config::config::RoleType;
+use libra_types::{account_config, waypoint::Waypoint, PeerId};
+use network::validator_network::network_builder::NetworkBuilder;
+use std::{sync::Arc, time::Duration};
 use storage_interface::DbReader;
-use tokio::task;
+use tokio::{runtime::Handle, task, time::interval};
 
 #[cfg(test)]
 mod test;
@@ -117,4 +126,50 @@ fn storage_query_discovery_set_async(
         // flatten errors
         res.map_err(anyhow::Error::from).and_then(|res| res)
     })
+}
+
+pub fn setup_onchain_discovery(
+    network: &mut NetworkBuilder,
+    peer_id: PeerId,
+    role: RoleType,
+    libra_db: Arc<dyn DbReader>,
+    waypoint: Waypoint,
+    executor: &Handle,
+) {
+    let (network_tx, discovery_events) = network_interface::add_to_network(network);
+    let outbound_rpc_timeout = Duration::from_secs(30);
+    let max_concurrent_inbound_queries = 8;
+    let (peer_mgr_notifs_rx, conn_notifs_rx) = (
+        discovery_events.peer_mgr_notifs_rx,
+        discovery_events.connection_notifs_rx,
+    );
+
+    let onchain_discovery_service = OnchainDiscoveryService::new(
+        executor.clone(),
+        peer_mgr_notifs_rx,
+        Arc::clone(&libra_db),
+        max_concurrent_inbound_queries,
+    );
+    executor.spawn(onchain_discovery_service.start());
+
+    let onchain_discovery = executor.enter(move || {
+        let peer_query_ticker = interval(Duration::from_secs(30)).fuse();
+        let storage_query_ticker = interval(Duration::from_secs(30)).fuse();
+
+        OnchainDiscovery::new(
+            peer_id,
+            role,
+            waypoint,
+            network_tx,
+            network
+                .conn_mgr_reqs_tx()
+                .expect("ConnecitivtyManager not enabled"),
+            conn_notifs_rx,
+            libra_db,
+            peer_query_ticker,
+            storage_query_ticker,
+            outbound_rpc_timeout,
+        )
+    });
+    executor.spawn(onchain_discovery.start());
 }

--- a/network/onchain-discovery/src/network_interface.rs
+++ b/network/onchain-discovery/src/network_interface.rs
@@ -18,10 +18,9 @@ use std::time::Duration;
 
 /// The interface from Network to OnchainDiscovery layer.
 ///
-/// `OnchainDiscoveryNetworkEvents` is a `Stream` of `PeerManagerNotification` where the
-/// raw `Bytes` rpc messages are deserialized into
-/// `OnchainDiscoveryMsg` types. `OnchainDiscoveryNetworkEvents` is a thin wrapper
-/// around an `channel::Receiver<PeerManagerNotification>`.
+/// `OnchainDiscoveryNetworkEvents` is a wrapper around streams of `PeerManagerNotification` and
+/// `ConnectionNotification` events. Unlike other *NetworkEvents, it is not itself a `Stream` and
+/// serves only as a transient holder of the underlying Streams during setup and initialization.
 pub struct OnchainDiscoveryNetworkEvents {
     pub peer_mgr_notifs_rx: libra_channel::Receiver<(PeerId, ProtocolId), PeerManagerNotification>,
     pub connection_notifs_rx: libra_channel::Receiver<PeerId, ConnectionNotification>,

--- a/network/onchain-discovery/src/test.rs
+++ b/network/onchain-discovery/src/test.rs
@@ -207,8 +207,7 @@ fn setup_onchain_discovery(
     let (conn_reqs_tx, _) =
         libra_channel::new(QueueStyle::FIFO, NonZeroUsize::new(8).unwrap(), None);
     let conn_reqs_tx = ConnectionRequestSender::new(conn_reqs_tx);
-    let network_reqs_tx =
-        OnchainDiscoveryNetworkSender::new(peer_mgr_reqs_tx, conn_reqs_tx, conn_mgr_reqs_tx);
+    let network_reqs_tx = OnchainDiscoveryNetworkSender::new(peer_mgr_reqs_tx, conn_reqs_tx);
     // let network_notifs_rx = OnchainDiscoveryNetworkEvents::new(peer_mgr_notifs_rx, conn_notifs_rx);
     let (peer_query_ticker_tx, peer_query_ticker_rx) = channel::new_test::<()>(1);
     let (storage_query_ticker_tx, storage_query_ticker_rx) = channel::new_test::<()>(1);
@@ -221,6 +220,7 @@ fn setup_onchain_discovery(
         role,
         waypoint,
         network_reqs_tx,
+        conn_mgr_reqs_tx,
         conn_notifs_rx,
         Arc::clone(&libra_db),
         peer_query_ticker_rx,


### PR DESCRIPTION
…look more similar to other network using components

<!--
Thank you for sending a PR. We appreciate you spending time to help improve the Libra project.

The project is undergoing daily changes. Pull Requests will be reviewed and responded to as time permits.
-->

## Motivation

This is a collection of refactorings around setting up OnchainDiscovery to simplify main_node and bring more clarity to the building process.

1.  Move setup_onchain_discovery out of main_node.rs and into the OnchainDiscovery crate.
2.  Make the construction of the OnChainDiscoverySender match the general NetworkSender pattern.
3.  Create a onchain_discovery_builder to encapsulate the logic of setup_onchain_discovery

The second change effectively moves maintenance of the connecion_mgr_tx from the OnChaindiscoverySender struct to the client/OnchainDiscovery struct.  This specific change benefits follow up work on clarifying main_node, network_builder, and the overall building process.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?

yes
## Test Plan

don't break existing integration/unit tests

## Related PRs

(If this PR adds or changes functionality, please take some time to update the docs at https://github.com/libra/website, and link to your PR here.)
