### PR TITLE
[consensus] Eliminate unused code intended to update the connectivity…

### DIFF
--- a/consensus/src/network_tests.rs
+++ b/consensus/src/network_tests.rs
@@ -376,12 +376,11 @@ mod tests {
                 libra_channel::new(QueueStyle::FIFO, NonZeroUsize::new(8).unwrap(), None);
             let (consensus_tx, consensus_rx) =
                 libra_channel::new(QueueStyle::FIFO, NonZeroUsize::new(8).unwrap(), None);
-            let (conn_mgr_reqs_tx, conn_mgr_reqs_rx) = channel::new_test(8);
+            let (_conn_mgr_reqs_tx, conn_mgr_reqs_rx) = channel::new_test(8);
             let (_, conn_status_rx) = conn_notifs_channel::new();
             let network_sender = ConsensusNetworkSender::new(
                 PeerManagerRequestSender::new(network_reqs_tx),
                 ConnectionRequestSender::new(connection_reqs_tx),
-                conn_mgr_reqs_tx,
             );
             let network_events = ConsensusNetworkEvents::new(consensus_rx, conn_status_rx);
 
@@ -457,12 +456,11 @@ mod tests {
                 libra_channel::new(QueueStyle::FIFO, NonZeroUsize::new(8).unwrap(), None);
             let (consensus_tx, consensus_rx) =
                 libra_channel::new(QueueStyle::FIFO, NonZeroUsize::new(8).unwrap(), None);
-            let (conn_mgr_reqs_tx, conn_mgr_reqs_rx) = channel::new_test(8);
+            let (_conn_mgr_reqs_tx, conn_mgr_reqs_rx) = channel::new_test(8);
             let (_, conn_status_rx) = conn_notifs_channel::new();
             let network_sender = ConsensusNetworkSender::new(
                 PeerManagerRequestSender::new(network_reqs_tx),
                 ConnectionRequestSender::new(connection_reqs_tx),
-                conn_mgr_reqs_tx,
             );
             let network_events = ConsensusNetworkEvents::new(consensus_rx, conn_status_rx);
 

--- a/consensus/src/round_manager_fuzzing.rs
+++ b/consensus/src/round_manager_fuzzing.rs
@@ -92,11 +92,9 @@ fn create_node_for_fuzzing() -> RoundManager {
         libra_channel::new(QueueStyle::FIFO, NonZeroUsize::new(8).unwrap(), None);
     let (connection_reqs_tx, _) =
         libra_channel::new(QueueStyle::FIFO, NonZeroUsize::new(8).unwrap(), None);
-    let (conn_mgr_reqs_tx, _conn_mgr_reqs_rx) = channel::new_test(8);
     let network_sender = ConsensusNetworkSender::new(
         PeerManagerRequestSender::new(network_reqs_tx),
         ConnectionRequestSender::new(connection_reqs_tx),
-        conn_mgr_reqs_tx,
     );
     let (self_sender, _self_receiver) = channel::new_test(8);
 

--- a/consensus/src/round_manager_test.rs
+++ b/consensus/src/round_manager_test.rs
@@ -137,12 +137,11 @@ impl NodeSetup {
             libra_channel::new(QueueStyle::FIFO, NonZeroUsize::new(8).unwrap(), None);
         let (consensus_tx, consensus_rx) =
             libra_channel::new(QueueStyle::FIFO, NonZeroUsize::new(8).unwrap(), None);
-        let (conn_mgr_reqs_tx, conn_mgr_reqs_rx) = channel::new_test(8);
+        let (_conn_mgr_reqs_tx, conn_mgr_reqs_rx) = channel::new_test(8);
         let (_, conn_status_rx) = conn_notifs_channel::new();
         let network_sender = ConsensusNetworkSender::new(
             PeerManagerRequestSender::new(network_reqs_tx),
             ConnectionRequestSender::new(connection_reqs_tx),
-            conn_mgr_reqs_tx,
         );
         let network_events = ConsensusNetworkEvents::new(consensus_rx, conn_status_rx);
         let network_events = network_events.map_err(Into::<anyhow::Error>::into);

--- a/consensus/src/twins_test.rs
+++ b/consensus/src/twins_test.rs
@@ -60,12 +60,11 @@ impl SMRNode {
             libra_channel::new(QueueStyle::FIFO, NonZeroUsize::new(8).unwrap(), None);
         let (consensus_tx, consensus_rx) =
             libra_channel::new(QueueStyle::FIFO, NonZeroUsize::new(8).unwrap(), None);
-        let (conn_mgr_reqs_tx, conn_mgr_reqs_rx) = channel::new_test(8);
+        let (_conn_mgr_reqs_tx, conn_mgr_reqs_rx) = channel::new_test(8);
         let (_, conn_notifs_channel) = conn_notifs_channel::new();
         let network_sender = ConsensusNetworkSender::new(
             PeerManagerRequestSender::new(network_reqs_tx),
             ConnectionRequestSender::new(connection_reqs_tx),
-            conn_mgr_reqs_tx,
         );
         let network_events = ConsensusNetworkEvents::new(consensus_rx, conn_notifs_channel);
         playground.add_node(author, consensus_tx, network_reqs_rx, conn_mgr_reqs_rx);


### PR DESCRIPTION
… manager network configurations

<!--
Thank you for sending a PR. We appreciate you spending time to help improve the Libra project.

The project is undergoing daily changes. Pull Requests will be reviewed and responded to as time permits.
-->

## Motivation

Eliminate unused code that connects the ConsensusNetworkSender to the ConnectivityManager.

I stumbled onto this code while attempting to refactor/consolidate/clean the network_builder.  Upon inspection, it turns out that the `conn_mgr_reqs_tx` field of ConsensusNetworkSender is only accessed in `update_eligible_nodes` which is not used anywhere in the codebase or in tests.  Ergo, the feature should be unnecessary.

I am currently attempting to re-organize/refactor/simplify the main_node.rs specifically in relation to the network_builder and `setup_network` call.  This specific feature of consensus mildly interferes with that work.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?

yes
## Test Plan

Do not break existing unit or integration tests.

## Related PRs

(If this PR adds or changes functionality, please take some time to update the docs at https://github.com/libra/website, and link to your PR here.)
