### PR TITLE
[language] fix some bugs in bytestring literals and use them in the stdlib

### DIFF
--- a/language/move-lang/tests/move_check/parser/byte_string_success.move
+++ b/language/move-lang/tests/move_check/parser/byte_string_success.move
@@ -14,4 +14,7 @@ module M {
     public fun byte_string_with_hex(): vector<u8> {
         b"\x00\x01\x02"
     }
+    public fun escaped_backslash_before_quote(): vector<u8> {
+        b"\\"
+    }
 }

--- a/language/move-lang/tests/move_check/parser/comments_ok.move
+++ b/language/move-lang/tests/move_check/parser/comments_ok.move
@@ -12,5 +12,10 @@ module M {
     // This is a line comment which contains unbalanced /* delimiter.
     fun h() {}
 
+    // Comments in strings are not comments at all.
+    fun str(): vector<u8> {
+        b"http://libra.org"
+    }
+
     // This is a regular comment which appears where a doc comment would not be allowed.
 }

--- a/language/stdlib/modules/coin1.move
+++ b/language/stdlib/modules/coin1.move
@@ -16,7 +16,7 @@ module Coin1 {
             false,   // is_synthetic
             1000000, // scaling_factor = 10^6
             100,     // fractional_part = 10^2
-            x"436F696E31", // UTF8 encoding of "Coin1" in hex
+            b"Coin1",
         )
     }
 }

--- a/language/stdlib/modules/coin2.move
+++ b/language/stdlib/modules/coin2.move
@@ -16,7 +16,7 @@ module Coin2 {
             false,   // is_synthetic
             1000000, // scaling_factor = 10^6
             100,     // fractional_part = 10^2
-            x"436F696E32", // UTF8 encoding of "Coin2" in hex
+            b"Coin2",
         )
     }
 }

--- a/language/stdlib/modules/lbr.move
+++ b/language/stdlib/modules/lbr.move
@@ -44,7 +44,7 @@ module LBR {
             true,    // is_synthetic
             1000000, // scaling_factor = 10^6
             1000,    // fractional_part = 10^3
-            x"4C4252" // UTF8-encoded "LBR" as a hex string
+            b"LBR"
         );
         let preburn_cap = Libra::new_preburn_with_capability(&burn_cap);
         let coin1 = ReserveComponent<Coin1::T> {

--- a/language/stdlib/modules/libra.move
+++ b/language/stdlib/modules/libra.move
@@ -29,14 +29,14 @@ module Libra {
     struct MintEvent {
         // funds added to the system
         amount: u64,
-        // UTF-8 encoded symbol for the coin type (e.g., "LBR")
+        // ASCII encoded symbol for the coin type (e.g., "LBR")
         currency_code: vector<u8>,
     }
 
     struct BurnEvent {
         // funds removed from the system
         amount: u64,
-        // UTF-8 encoded symbol for the coin type (e.g., "LBR")
+        // ASCII encoded symbol for the coin type (e.g., "LBR")
         currency_code: vector<u8>,
         // address with the Preburn resource that stored the now-burned funds
         preburn_address: address,
@@ -45,7 +45,7 @@ module Libra {
     struct PreburnEvent {
         // funds waiting to be removed from the system
         amount: u64,
-        // UTF-8 encoded symbol for the coin type (e.g., "LBR")
+        // ASCII encoded symbol for the coin type (e.g., "LBR")
         currency_code: vector<u8>,
         // address with the Preburn resource that now holds the funds
         preburn_address: address,
@@ -54,7 +54,7 @@ module Libra {
     struct CancelBurnEvent {
         // funds returned
         amount: u64,
-        // UTF-8 encoded symbol for the coin type (e.g., "LBR")
+        // ASCII encoded symbol for the coin type (e.g., "LBR")
         currency_code: vector<u8>,
         // address with the Preburn resource that holds the now-returned funds
         preburn_address: address,
@@ -82,7 +82,7 @@ module Libra {
         // used in the human-readable representation for the currency (e.g.
         // 10^2 for Coin1 cents)
         fractional_part: u64,
-        // The code symbol for this `CoinType`. UTF-8 encoded.
+        // The code symbol for this `CoinType`. ASCII encoded.
         // e.g. for "LBR" this is x"4C4252". No character limit.
         currency_code: vector<u8>,
         // We may want to disable the ability to mint further coins of a

--- a/language/stdlib/modules/libra_account.move
+++ b/language/stdlib/modules/libra_account.move
@@ -274,8 +274,7 @@ module LibraAccount {
             // sanity check of signature validity
             Transaction::assert(Vector::length(&metadata_signature) == 64, 9001);
             // message should be metadata | sender_address | amount | domain_separator
-            // separator is the UTF8-encoded string @@$$LIBRA_ATTEST$$@@
-            let domain_separator = x"404024244C494252415F41545445535424244040";
+            let domain_separator = b"@@$$LIBRA_ATTEST$$@@";
             let message = copy metadata;
             Vector::append(&mut message, LCS::to_bytes(&sender));
             Vector::append(&mut message, LCS::to_bytes(&deposit_value));
@@ -539,10 +538,8 @@ module LibraAccount {
         Transaction::assert(Testnet::is_testnet(), 10042);
         let vasp_parent =
             VASP::create_parent_vasp_credential(
-                // "testnet"
-                x"746573746E6574",
-                // "https://libra.org"
-                x"68747470733A2F2F6C696272612E6F72672F",
+                b"testnet",
+                b"https://libra.org",
                 // An empty compliance key
                 x"00000000000000000000000000000000"
             );


### PR DESCRIPTION
There were a few character strings (actually vector<u8>) in the stdlib that were described as having UTF-8 encodings. However, these are all limited to ASCII characters, so we can use the new bytestring literal syntax to specify the values. We want to avoid getting into Unicode complexities, at least for now.

That change exposed a problem with comment markers inside strings. The addition of byte string literals to Move means that we can have comment-starting characters that occur inside a string, e.g., "//". The code to identify and strip comments needs to understand the string syntax so that it can avoid treating those characters as comments when they are used inside strings.

Finally, while fixing that comment problem, I happened to notice an issue with escaped backslashes before the closing quote of a string. The previous code looked for a closing quote that was not immediately preceded by a backslash. But, that doesn't handle the case where there is an escaped backslash before the quote.

## Motivation

Fix bugs and make the stdlib code more readable

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

Added tests for the bytestring bugs and ran them