### PR TITLE
[tf]use same override image tag for validator and safety-rules

### DIFF
--- a/terraform/validators.tf
+++ b/terraform/validators.tf
@@ -233,7 +233,7 @@ data "template_file" "ecs_task_definition" {
     logstash_version           = local.logstash_image_version
     logstash_config            = local.logstash_config
     safety_rules_image         = local.safety_rules_image_repo
-    safety_rules_image_version = local.safety_rules_image_version
+    safety_rules_image_version = local.override_image_versions == [] ? local.safety_rules_image_version : local.override_image_versions[count.index % length(local.override_image_versions)]
     push_metrics_endpoint      = "http://${aws_instance.monitoring.private_ip}:9092/metrics/job/safety_rules/role/validator/peer_id/val-${count.index}"
     cfg_vault_addr             = "http://${aws_instance.vault.private_ip}:8200"
     cfg_vault_namespace        = "val-${count.index}"


### PR DESCRIPTION
<!--
Thank you for sending a PR. We appreciate you spending time to help improve the Libra project.

The project is undergoing daily changes. Pull Requests will be reviewed and responded to as time permits.
-->

## Motivation

If override image tag variable is set, use it for both validator and safety-rules

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

terraform apply on my workspace
http://prometheus.sherryxiao.aws.hlw3truzy4ls.com:9091/d/overview10/overview?orgId=1&from=now-15m&to=now

## Related PRs

(If this PR adds or changes functionality, please take some time to update the docs at https://github.com/libra/website, and link to your PR here.)
