### PR TITLE
[move source language] formatting cleanup

### DIFF
--- a/language/move-lang/src/cfgir/borrows/state.rs
+++ b/language/move-lang/src/cfgir/borrows/state.rs
@@ -128,8 +128,8 @@ impl BorrowState {
                 let field = match field_lbl {
                     Label::Field(f) => f,
                     Label::Local(_) | Label::Resource(_) => panic!(
-                        "ICE local/resource should not be field borrows \
-                         as they only exist from the virtual 'root' reference"
+                        "ICE local/resource should not be field borrows as they only exist from \
+                         the virtual 'root' reference"
                     ),
                 };
                 error.push((

--- a/language/move-lang/src/cfgir/cfg.rs
+++ b/language/move-lang/src/cfgir/cfg.rs
@@ -143,12 +143,12 @@ impl<'a> CFG for BlockCFG<'a> {
 }
 
 const DEAD_ERR_CMD: &str = "Unreachable code. This statement (and any following statements) will \
-     not be executed. In some cases, this will result in unused resource values.";
+                            not be executed. In some cases, this will result in unused resource \
+                            values.";
 
-const DEAD_ERR_EXP: &str =
-    "Invalid use of a divergent expression. The code following the evaluation of this \
-     expression will be dead and should be removed. In some cases, this is necessary to prevent \
-     unused resource values.";
+const DEAD_ERR_EXP: &str = "Invalid use of a divergent expression. The code following the \
+                            evaluation of this expression will be dead and should be removed. In \
+                            some cases, this is necessary to prevent unused resource values.";
 
 fn dead_code_error(block: &BasicBlock) -> Error {
     let first_command = block.front().unwrap();

--- a/language/move-lang/src/cfgir/liveness/mod.rs
+++ b/language/move-lang/src/cfgir/liveness/mod.rs
@@ -295,8 +295,8 @@ mod last_usage {
                         DisplayVar::Tmp => (),
                         DisplayVar::Orig(v_str) => {
                             let msg = format!(
-                                "Unused assignment or binding for local '{}'. Consider \
-                                 removing or replacing it with '_'",
+                                "Unused assignment or binding for local '{}'. Consider removing \
+                                 or replacing it with '_'",
                                 v_str
                             );
                             context.error(vec![(l.loc, msg)]);

--- a/language/move-lang/src/cfgir/locals/mod.rs
+++ b/language/move-lang/src/cfgir/locals/mod.rs
@@ -151,7 +151,8 @@ fn command(context: &mut Context, sp!(loc, cmd_): &Command) {
                                         format!("The parameter '{}' {} a resource value", l, verb)
                                     } else {
                                         format!(
-                                            "The local '{}' {} a resource value due to this assignment",
+                                            "The local '{}' {} a resource value due to this \
+                                             assignment",
                                             l, verb
                                         )
                                     }
@@ -201,8 +202,8 @@ fn lvalue(context: &mut Context, sp!(loc, l_): &LValue) {
                             DisplayVar::Orig(s) => s,
                         };
                         let msg = format!(
-                            "The local {} a resource value due to this assignment. The \
-                             resource must be used before you assign to this local again",
+                            "The local {} a resource value due to this assignment. The resource \
+                             must be used before you assign to this local again",
                             verb
                         );
                         context.error(vec![
@@ -275,8 +276,8 @@ fn use_local(context: &mut Context, loc: &Loc, local: &Var) {
                 DisplayVar::Orig(s) => s,
             };
             let msg = format!(
-                "The local {} not have a value due to this position. The local must be assigned \
-                 a value before being used",
+                "The local {} not have a value due to this position. The local must be assigned a \
+                 value before being used",
                 verb
             );
             context.error(vec![

--- a/language/move-lang/src/expansion/aliases.rs
+++ b/language/move-lang/src/expansion/aliases.rs
@@ -170,14 +170,16 @@ impl AliasMap {
         // propagate uses of aliases
         used_modules
             .iter()
-            .filter(|a| /* remove newly declared aliaes */ !inner_scope_modules.contains(a))
+            // remove newly declared aliaes
+            .filter(|a| !inner_scope_modules.contains(a))
             .for_each(|a| {
                 // get the module alias to mark it as used
                 outer_scope.module_alias_get(a);
             });
         used_members
             .iter()
-            .filter(|a| /* remove newly declared aliaes */ !inner_scope_members.contains(a))
+            // remove newly declared aliaes
+            .filter(|a| !inner_scope_members.contains(a))
             .for_each(|a| {
                 // get the member alias to mark it as used
                 outer_scope.member_alias_get(a);

--- a/language/move-lang/src/expansion/byte_string.rs
+++ b/language/move-lang/src/expansion/byte_string.rs
@@ -106,8 +106,8 @@ fn decode_(context: &mut Context, buffer: &mut Vec<u8>, chars: Vec<char>) {
                             None => "".to_string(),
                         };
                         let err_text = format!(
-                            "Invalid escape: '\\x{}'. Hex literals are represented by two symbols: \
-                            [\\x00-\\xFF].",
+                            "Invalid escape: '\\x{}'. Hex literals are represented by two \
+                             symbols: [\\x00-\\xFF].",
                             h
                         );
                         context.error(cur, len, err_text);

--- a/language/move-lang/src/expansion/translate.rs
+++ b/language/move-lang/src/expansion/translate.rs
@@ -99,11 +99,11 @@ impl Context {
 
     fn restricted_self_error(&mut self, case: &str, name: &Name) {
         let msg = format!(
-            "Invalid {case} name '{name}'. '{self_ident}' is restricted and cannot be used to name \
-            a {case}",
-            case=case,
-            name=name,
-            self_ident=ModuleName::SELF_NAME,
+            "Invalid {case} name '{name}'. '{self_ident}' is restricted and cannot be used to \
+             name a {case}",
+            case = case,
+            name = name,
+            self_ident = ModuleName::SELF_NAME,
         );
         self.error(vec![(name.loc, msg)])
     }
@@ -981,8 +981,8 @@ fn module_access(
         (Access::Term, PN::Name(n)) => EN::Name(n),
         (_, PN::Global(n)) => {
             let msg = format!(
-                "Invalid use of global name '::{}'. \
-                Global names can only be used in function calls",
+                "Invalid use of global name '::{}'. Global names can only be used in function \
+                 calls",
                 n
             );
             context.error(vec![(loc, msg)]);
@@ -1098,7 +1098,7 @@ fn exp_(context: &mut Context, sp!(loc, pe_): P::Exp) -> E::Exp {
             if !context.require_spec_context(
                 loc,
                 "Expected name to be followed by a brace-enclosed list of field expressions or a \
-              parenthesized list of arguments for a function call",
+                 parenthesized list of arguments for a function call",
             ) =>
         {
             assert!(context.has_errors());

--- a/language/move-lang/src/hlir/ast.rs
+++ b/language/move-lang/src/hlir/ast.rs
@@ -375,8 +375,8 @@ impl BaseType_ {
             BaseType_::Apply(k, _, _) => k.clone(),
             BaseType_::Param(TParam { kind, .. }) => kind.clone(),
             BaseType_::Unreachable | BaseType_::UnresolvedError => panic!(
-                "ICE unreachable/unresolved error has no kind. \
-                 Should only exist in dead code that should not be analyzed"
+                "ICE unreachable/unresolved error has no kind. Should only exist in dead code \
+                 that should not be analyzed"
             ),
         }
     }

--- a/language/move-lang/src/hlir/translate.rs
+++ b/language/move-lang/src/hlir/translate.rs
@@ -1439,11 +1439,16 @@ fn check_trailing_unit(context: &mut Context, block: &mut Block) {
     }
     macro_rules! trailing {
         ($uloc: pat) => {
-           hcmd!(_, C::IgnoreAndPop { exp: H::Exp { exp: sp!($uloc, E::Unit { trailing: true }), .. }, .. })
+           hcmd!(
+               _,
+               C::IgnoreAndPop {
+                    exp: H::Exp { exp: sp!($uloc, E::Unit { trailing: true }), .. }, ..
+                }
+            )
         }
     }
     macro_rules! trailing_returned {
-        ($uloc: pat) => {
+        ($uloc:pat) => {
             hcmd!(
                 _,
                 C::Return(H::Exp {
@@ -1468,7 +1473,7 @@ fn check_trailing_unit(context: &mut Context, block: &mut Block) {
             let semi_msg = "Invalid trailing ';'";
             let unreachable_msg = "Any code after this expression will not be reached";
             let info_msg = "A trailing ';' in an expression block implicitly adds a '()' value \
-            after the semicolon. That '()' value will not be reachable";
+                        after the semicolon. That '()' value will not be reachable";
             $context.error(vec![
                 ($uloc, semi_msg),
                 ($loc, unreachable_msg),

--- a/language/move-lang/src/lib.rs
+++ b/language/move-lang/src/lib.rs
@@ -190,25 +190,7 @@ pub fn output_compiled_units(
         let mut path = PathBuf::from(format!("{}/{}/{}", out_dir, SCRIPT_SUB_DIR, unit.name()));
         emit_unit!(path, unit);
     }
-    // let script_map = {
-    //     let mut m: BTreeMap<String, Vec<CompiledUnit>> = BTreeMap::new();
-    //     for u in scripts {
-    //         m.entry(u.name()).or_insert_with(Vec::new).push(u)
-    //     }
-    //     m
-    // };
-    // for (n, units) in script_map {
-    //     let num_units = units.len();
-    //     for (idx, unit) in units.into_iter().enumerate() {
-    //         let file_name = if num_units == 1 {
-    //             format!("{}", n)
-    //         } else {
-    //             format!("{}_{}", n, idx)
-    //         };
-    //         let mut path = PathBuf::from(format!("{}/{}/{}", out_dir, SCRIPT_SUB_DIR, file_name));
-    //         emit_unit!(path, unit);
-    //     }
-    // }
+
     if !ice_errors.is_empty() {
         errors::report_errors(files, ice_errors)
     }
@@ -405,9 +387,8 @@ fn verify_string(fname: &'static str, string: &str) -> Result<(), Errors> {
             let span = Span::new(ByteIndex(idx as u32), ByteIndex(idx as u32));
             let loc = Loc::new(fname, span);
             let msg = format!(
-                "Invalid character '{}' found when reading file. \
-                 Only ASCII printable characters, tabs (\\t), and line endings (\\n) \
-                 are permitted.",
+                "Invalid character '{}' found when reading file. Only ASCII printable characters, \
+                 tabs (\\t), and line endings (\\n) are permitted.",
                 chr
             );
             Err(vec![vec![(loc, msg)]])

--- a/language/move-lang/src/naming/translate.rs
+++ b/language/move-lang/src/naming/translate.rs
@@ -378,8 +378,8 @@ fn acquires_type_struct(
     };
     if !declared_in_current {
         let tmsg = format!(
-            "The struct '{}' was not declared in the current module. Global \
-             storage access is internal to the module'",
+            "The struct '{}' was not declared in the current module. Global storage access is \
+             internal to the module'",
             n
         );
         context.error(vec![(loc, "Invalid acquires item".into()), (n.loc(), tmsg)]);
@@ -439,8 +439,8 @@ fn check_no_nominal_resources(context: &mut Context, s: &StructName, field: &Fie
     match ty_ {
         T::Apply(Some(sp!(kloc, Kind_::Resource)), _, _) => {
             let field_msg = format!(
-                "Invalid resource field '{}' for struct '{}'. Structs cannot \
-                 contain resource types, except through type parameters",
+                "Invalid resource field '{}' for struct '{}'. Structs cannot contain resource \
+                 types, except through type parameters",
                 field, s
             );
             let tmsg = format!(
@@ -757,9 +757,8 @@ fn exp_(context: &mut Context, e: E::Exp) -> N::Exp {
             assert!(context.has_errors());
             NE::UnresolvedError
         }
-        EE::Index(..) | EE::Lambda(..) |
-        // matches name variants only allowed in specs (we handle the allowed ones above)
-        EE::Name(..) => {
+        // `Name` matches name variants only allowed in specs (we handle the allowed ones above)
+        EE::Index(..) | EE::Lambda(..) | EE::Name(..) => {
             panic!("ICE unexpected specification construct")
         }
     };

--- a/language/move-lang/src/parser/syntax.rs
+++ b/language/move-lang/src/parser/syntax.rs
@@ -511,7 +511,7 @@ fn parse_num(tokens: &mut Lexer) -> Result<u128, Error> {
             let end_loc = start_loc + tokens.content().len();
             let loc = make_loc(tokens.file_name(), start_loc, end_loc);
             let msg = "Invalid number literal. The given literal is too large to fit into the \
-                         largest number type 'u128'";
+                       largest number type 'u128'";
             Err(vec![(loc, msg.to_owned())])
         }
     };
@@ -1636,14 +1636,15 @@ fn parse_spec_block_member<'input>(tokens: &mut Lexer<'input>) -> Result<SpecBlo
         },
         _ => Err(unexpected_token_error(
             tokens,
-            "one of `assert`, `assume`, `decreases`, `aborts_if`, `ensures`,\
-                 `requires`, `include`, `apply`, `pragma`, `global`, or a name",
+            "one of `assert`, `assume`, `decreases`, `aborts_if`, `ensures`, `requires`, \
+             `include`, `apply`, `pragma`, `global`, or a name",
         )),
     }
 }
 
 // Parse a specification condition:
-//    SpecCondition = ("assert" | "assume" | "decreases" | "aborts_if" | "ensures" | "requires" ) <Exp> ";"
+//    SpecCondition =
+//        ("assert" | "assume" | "decreases" | "aborts_if" | "ensures" | "requires" ) <Exp> ";"
 fn parse_condition<'input>(tokens: &mut Lexer<'input>) -> Result<SpecBlockMember, Error> {
     let start_loc = tokens.start_loc();
     let kind = match tokens.content() {
@@ -1719,7 +1720,8 @@ fn parse_invariant<'input>(tokens: &mut Lexer<'input>) -> Result<SpecBlockMember
 // Parse a specification function.
 //     SpecFunction = "define" <SpecFunctionSignature> "{" <Sequence> "}"
 //                  | "native" "define" <SpecFunctionSignature> ";"
-//     SpecFunctionSignature = <Identifier> <OptionalTypeParameters> "(" Comma<Parameter> ")" ":" <Type>
+//     SpecFunctionSignature =
+//         <Identifier> <OptionalTypeParameters> "(" Comma<Parameter> ")" ":" <Type>
 fn parse_spec_function<'input>(tokens: &mut Lexer<'input>) -> Result<SpecBlockMember, Error> {
     let start_loc = tokens.start_loc();
     let native_opt = consume_optional_token_with_loc(tokens, Tok::Native)?;

--- a/language/move-lang/src/typing/globals.rs
+++ b/language/move-lang/src/typing/globals.rs
@@ -243,8 +243,8 @@ fn check_acquire_listed<F>(
 {
     if !annotated_acquires.contains_key(global_type_name) {
         let tmsg = format!(
-            "The call acquires '{}::{}', but the 'acquires' list for the current function does not \
-            contain this type. It must be present in the calling context's acquires list",
+            "The call acquires '{}::{}', but the 'acquires' list for the current function does \
+             not contain this type. It must be present in the calling context's acquires list",
             context.current_module.as_ref().unwrap(),
             global_type_name
         );

--- a/language/move-lang/src/typing/infinite_instantiations.rs
+++ b/language/move-lang/src/typing/infinite_instantiations.rs
@@ -309,8 +309,8 @@ fn cycle_error(context: &Context, graph: &DiGraphMap<&TParam, Edge>, scc: Vec<&T
     };
     let tparam_msg = format!(
         "The type parameter '{param_n}::{param_t}' was instantiated with the type {ty}, which \
-        contains the type parameter '{arg_n}::{arg_t}'. {case} causes the instantiation to recurse \
-        infinitely",
+         contains the type parameter '{arg_n}::{arg_t}'. {case} causes the instantiation to \
+         recurse infinitely",
         param_n = &param_info.name,
         param_t = &critical_head.user_specified_name,
         ty = ty_str,

--- a/language/move-lang/src/typing/translate.rs
+++ b/language/move-lang/src/typing/translate.rs
@@ -724,8 +724,8 @@ fn exp_(context: &mut Context, sp!(eloc, ne_): N::Exp) -> T::Exp {
                     let msg = format!("Invalid arguments to '{}'", &bop);
                     context.add_single_type_constraint(eloc, msg, ty.clone());
                     let msg = format!(
-                        "Cannot use '{}' on resource values. This would destroy the resource. \
-                         Try borrowing the values with '&' first.'",
+                        "Cannot use '{}' on resource values. This would destroy the resource. Try \
+                         borrowing the values with '&' first.'",
                         &bop
                     );
                     context.add_copyable_constraint(eloc, msg, ty.clone());
@@ -786,8 +786,8 @@ fn exp_(context: &mut Context, sp!(eloc, ne_): N::Exp) -> T::Exp {
             });
             if !context.is_current_module(&m) {
                 let msg = format!(
-                    "Invalid instantiation of '{}::{}'.\n\
-                     All structs can only be constructed in the module in which they are declared",
+                    "Invalid instantiation of '{}::{}'.\nAll structs can only be constructed in \
+                     the module in which they are declared",
                     &m, &n,
                 );
                 context.error(vec![(eloc, msg)])
@@ -1101,8 +1101,8 @@ fn lvalue(
             });
             if !context.is_current_module(&m) {
                 let msg = format!(
-                    "Invalid deconstruction {} of '{}::{}'.\n All \
-                     structs can only be deconstructed in the module in which they are declared",
+                    "Invalid deconstruction {} of '{}::{}'.\n All structs can only be \
+                     deconstructed in the module in which they are declared",
                     verb, &m, &n,
                 );
                 context.error(vec![(loc, msg)])
@@ -1161,8 +1161,8 @@ fn resolve_field(context: &mut Context, loc: Loc, ty: Type, field: &Field) -> Ty
         sp!(_, Apply(_, sp!(_, ModuleType(m, n)), targs)) => {
             if !context.is_current_module(&m) {
                 let msg = format!(
-                    "Invalid access of field '{}' on '{}::{}'. \
-                     Fields can only be accessed inside the struct's module",
+                    "Invalid access of field '{}' on '{}::{}'. Fields can only be accessed inside \
+                     the struct's module",
                     field, &m, &n
                 );
                 context.error(vec![(loc, msg)])
@@ -1199,8 +1199,8 @@ fn add_field_types<T>(
         N::StructFields::Defined(m) => m,
         N::StructFields::Native(nloc) => {
             let msg = format!(
-                "Invalid {} usage for native struct '{}::{}'. Native structs cannot \
-                 be directly constructed/deconstructd, and their fields cannot be dirctly accessed",
+                "Invalid {} usage for native struct '{}::{}'. Native structs cannot be directly \
+                 constructed/deconstructd, and their fields cannot be dirctly accessed",
                 verb, m, n
             );
             context.error(vec![(loc, msg), (nloc, "Declared 'native' here".into())]);


### PR DESCRIPTION
- Fixed spots that could not be formatted
- Fixed long lines
- Fixed string formatting

## Motivation

- I reran cargo fmt with 
  - error_on_unformatted=true 
  - error_on_line_overflow=true
  - format_strings=true 
  - format_macro_matchers=true
- The unformatted and format strings are the big ones. The multi line cases with strings were inconsistent through out move-lang
- I'm unsure if we can add these flags to a custom rustfmt config just to move-lang 

## Test Plan

- cargo test
- eyes