### PR TITLE
[consensus] fix notification to mempool

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -907,6 +907,7 @@ dependencies = [
  "executor 0.1.0",
  "executor-types 0.1.0",
  "futures 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "itertools 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "libra-canonical-serialization 0.1.0",
  "libra-config 0.1.0",
  "libra-crypto 0.1.0",

--- a/consensus/Cargo.toml
+++ b/consensus/Cargo.toml
@@ -15,6 +15,7 @@ async-trait = "0.1.33"
 byteorder = { version = "1.3.4", default-features = false }
 bytes = "0.5.4"
 futures = "0.3.5"
+itertools = { version = "0.9.0", default-features = false }
 mirai-annotations = { version = "1.8.0", default-features = false }
 num-derive = { version = "0.3.0", default-features = false }
 num-traits = { version = "0.2.11", default-features = false }


### PR DESCRIPTION

<!--
Thank you for sending a PR. We appreciate you spending time to help improve the Libra project.

The project is undergoing daily changes. Pull Requests will be reviewed and responded to as time permits.
-->

## Motivation

It's off-by-one because of the appended metadata txn, this commit fixes
it and ensures the lengths are equal.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?

Y

## Test Plan

It doesn't seem easy to test it, just zip_eq in place

## Related PRs

(If this PR adds or changes functionality, please take some time to update the docs at https://github.com/libra/website, and link to your PR here.)
