### PR TITLE
[language][functional tests] add fuzzing feature flag for dependency

### DIFF
--- a/language/functional-tests/Cargo.toml
+++ b/language/functional-tests/Cargo.toml
@@ -16,7 +16,7 @@ libra-vm = { path = "../libra-vm",  version = "0.1.0" }
 vm = { path = "../vm", version = "0.1.0" }
 bytecode-verifier = { path = "../bytecode-verifier", version = "0.1.0" }
 language-e2e-tests = { path = "../e2e-tests", version = "0.1.0" }
-libra-config = { path = "../../config", version = "0.1.0" }
+libra-config = { path = "../../config", version = "0.1.0", features = ["fuzzing"] }
 libra-crypto = { path = "../../crypto/crypto", version = "0.1.0" }
 libra-workspace-hack = { path = "../../common/workspace-hack", version = "0.1.0" }
 once_cell = "1.4.0"


### PR DESCRIPTION
## Summary
Currently now IR & Move functional tests are broken due to the fuzzing feature flag being missing. This gets it fixed.

## Test Plan
run `cargo test -p ir-testsuite` manually. 