### PR TITLE
[smoke test] increase the chunk limit to reduce flakiness

### DIFF
--- a/testsuite/tests/libratest/smoke_test.rs
+++ b/testsuite/tests/libratest/smoke_test.rs
@@ -52,7 +52,7 @@ impl TestEnvironment {
         ::libra_logger::Logger::new().init();
         let mut template = NodeConfig::default();
         template.test = Some(TestConfig::open_module());
-        template.state_sync.chunk_limit = 2;
+        template.state_sync.chunk_limit = 5;
         template.consensus.safety_rules.backend =
             SecureBackend::OnDiskStorage(OnDiskStorageConfig::default());
 
@@ -683,7 +683,7 @@ fn test_basic_state_synchronization() {
         client_proxy.get_balances(&["b", "1"]).unwrap()
     ));
 
-    // Test single chunk sync, chunk_size = 2
+    // Test single chunk sync, chunk_size = 5
     let node_to_restart = 0;
     env.validator_swarm.kill_node(node_to_restart);
     // All these are executed while one node is down


### PR DESCRIPTION
<!--
Thank you for sending a PR. We appreciate you spending time to help improve the Libra project.

The project is undergoing daily changes. Pull Requests will be reviewed and responded to as time permits.
-->

## Motivation

basic_state_sync and full_node_basic_flow is flaky because the node can't catch up fast enough.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?

Y

## Test Plan

Existing tests.

## Related PRs

(If this PR adds or changes functionality, please take some time to update the docs at https://github.com/libra/website, and link to your PR here.)
