### PR TITLE
[cov] bigger machines to prevent test compilation erroring out

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -383,7 +383,7 @@ jobs:
       - build_teardown
   code-coverage:
     description: Run code coverage
-    executor: test-executor
+    executor: build-executor
     environment:
       MESSAGE_PAYLOAD_FILE: "/tmp/message_payload"
     steps:


### PR DESCRIPTION
## Motivation

Often times code coverage test runs fail for individual crates because they are recompiling some binary in the test....   like:

```
test tests::spawned_process::test ... test tests::spawned_process::test has been running for over 60 seconds
test tests::spawned_process::test ... FAILED

failures:

---- tests::spawned_process::test stdout ----
thread 'tests::spawned_process::test' panicked at '
    Unable to build all workspace binaries. Cannot continue running tests.

    Try running 'cargo build --all --bins --exclude cluster-test' yourself.
', <::std::macros::panic macros>:2:4
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace


failures:
    tests::spawned_process::test

test result: FAILED. 6 passed; 1 failed; 1 ignored; 0 measured; 0 filtered out
```

Usually saftey-rules and config-management.

### Have you read the [Contributing Guidelines on pull requests]

y

## Test Plan

next daily CI

## Related PRs

none
