### PR TITLE
[mempool] add rebroadcasting txn failures for MempoolIsFull and TooManyTransactions

### DIFF
--- a/mempool/Cargo.toml
+++ b/mempool/Cargo.toml
@@ -44,4 +44,4 @@ rand = "0.7.3"
 
 [features]
 default = []
-fuzzing = ["libra-types/fuzzing", "storage-interface/fuzzing"]
+fuzzing = ["libra-types/fuzzing", "storage-interface/fuzzing", "libra-config/fuzzing"]

--- a/mempool/src/core_mempool/index.rs
+++ b/mempool/src/core_mempool/index.rs
@@ -201,6 +201,11 @@ impl TimelineIndex {
         }
     }
 
+    /// get transaction at `timeline_id`
+    pub(crate) fn get_timeline_entry(&mut self, timeline_id: u64) -> Option<(AccountAddress, u64)> {
+        self.timeline.get(&timeline_id).cloned()
+    }
+
     /// read all transactions from timeline since <timeline_id>
     pub(crate) fn read_timeline(
         &mut self,
@@ -216,22 +221,6 @@ impl TimelineIndex {
             if batch.len() == count {
                 break;
             }
-        }
-        batch
-    }
-
-    /// read all transactions from timeline for timeline id in range (`start_timeline_id`, `end_timeline_id`]
-    pub(crate) fn range(
-        &mut self,
-        start_timeline_id: u64,
-        end_timeline_id: u64,
-    ) -> Vec<(AccountAddress, u64)> {
-        let mut batch = vec![];
-        for (_, &(address, sequence_number)) in self.timeline.range((
-            Bound::Excluded(start_timeline_id),
-            Bound::Included(end_timeline_id),
-        )) {
-            batch.push((address, sequence_number));
         }
         batch
     }

--- a/mempool/src/core_mempool/index.rs
+++ b/mempool/src/core_mempool/index.rs
@@ -211,13 +211,13 @@ impl TimelineIndex {
         &mut self,
         timeline_id: u64,
         count: usize,
-    ) -> Vec<(AccountAddress, u64)> {
+    ) -> Vec<(u64, (AccountAddress, u64))> {
         let mut batch = vec![];
-        for (_, &(address, sequence_number)) in self
+        for (timeline_id, &(address, sequence_number)) in self
             .timeline
             .range((Bound::Excluded(timeline_id), Bound::Unbounded))
         {
-            batch.push((address, sequence_number));
+            batch.push((*timeline_id, (address, sequence_number)));
             if batch.len() == count {
                 break;
             }

--- a/mempool/src/core_mempool/mempool.rs
+++ b/mempool/src/core_mempool/mempool.rs
@@ -254,14 +254,12 @@ impl Mempool {
         self.transactions.read_timeline(timeline_id, count)
     }
 
-    /// Read transactions from timeline whose timeline id is in range
-    /// `start_timeline_id` (exclusive) to `end_timeline_id` (inclusive)
-    pub(crate) fn timeline_range(
+    /// Read transactions as (timeline_id, transaction) with timeline IDs in `timeline_ids`
+    /// Note for some requested timeline IDs, the corresponding transaction may not be in the timeline
+    pub(crate) fn filter_read_timeline(
         &mut self,
-        start_timeline_id: u64,
-        end_timeline_id: u64,
-    ) -> Vec<SignedTransaction> {
-        self.transactions
-            .timeline_range(start_timeline_id, end_timeline_id)
+        timeline_ids: Vec<u64>,
+    ) -> Vec<(u64, SignedTransaction)> {
+        self.transactions.filter_read_timeline(timeline_ids)
     }
 }

--- a/mempool/src/core_mempool/mempool.rs
+++ b/mempool/src/core_mempool/mempool.rs
@@ -250,7 +250,7 @@ impl Mempool {
         &mut self,
         timeline_id: u64,
         count: usize,
-    ) -> (Vec<SignedTransaction>, u64) {
+    ) -> (Vec<(u64, SignedTransaction)>, u64) {
         self.transactions.read_timeline(timeline_id, count)
     }
 

--- a/mempool/src/core_mempool/transaction_store.rs
+++ b/mempool/src/core_mempool/transaction_store.rs
@@ -304,16 +304,18 @@ impl TransactionStore {
         &mut self,
         timeline_id: u64,
         count: usize,
-    ) -> (Vec<SignedTransaction>, u64) {
+    ) -> (Vec<(u64, SignedTransaction)>, u64) {
         let mut batch = vec![];
         let mut last_timeline_id = timeline_id;
-        for (address, sequence_number) in self.timeline_index.read_timeline(timeline_id, count) {
+        for (id, (address, sequence_number)) in
+            self.timeline_index.read_timeline(timeline_id, count)
+        {
             if let Some(txn) = self
                 .transactions
                 .get_mut(&address)
                 .and_then(|txns| txns.get(&sequence_number))
             {
-                batch.push(txn.txn.clone());
+                batch.push((id, txn.txn.clone()));
                 if let TimelineState::Ready(timeline_id) = txn.timeline_state {
                     last_timeline_id = timeline_id;
                 }

--- a/mempool/src/shared_mempool/coordinator.rs
+++ b/mempool/src/shared_mempool/coordinator.rs
@@ -143,7 +143,8 @@ pub(crate) async fn coordinator<V>(
                                             .await;
                                     }
                                     MempoolSyncMsg::BroadcastTransactionsResponse{request_id, retry_txns} => {
-                                        tasks::process_broadcast_ack(&mempool, request_id, retry_txns, is_validator);
+                                        let peer = PeerNetworkId(network_id, peer_id);
+                                        tasks::process_broadcast_ack(&mempool, peer, request_id, retry_txns, is_validator, peer_manager.clone());
                                         notify_subscribers(SharedMempoolNotification::ACK, &smp.subscribers);
                                     }
                                 };

--- a/mempool/src/shared_mempool/coordinator.rs
+++ b/mempool/src/shared_mempool/coordinator.rs
@@ -142,8 +142,8 @@ pub(crate) async fn coordinator<V>(
                                             ))
                                             .await;
                                     }
-                                    MempoolSyncMsg::BroadcastTransactionsResponse{request_id} => {
-                                        tasks::process_broadcast_ack(&mempool, request_id, is_validator);
+                                    MempoolSyncMsg::BroadcastTransactionsResponse{request_id, retry_txns} => {
+                                        tasks::process_broadcast_ack(&mempool, request_id, retry_txns, is_validator);
                                         notify_subscribers(SharedMempoolNotification::ACK, &smp.subscribers);
                                     }
                                 };

--- a/mempool/src/shared_mempool/network.rs
+++ b/mempool/src/shared_mempool/network.rs
@@ -29,6 +29,8 @@ pub enum MempoolSyncMsg {
     BroadcastTransactionsResponse {
         /// unique id of received broadcast request
         request_id: String,
+        /// indices of transactions that failed that may succeed on resend
+        retry_txns: Vec<u64>,
     },
 }
 

--- a/mempool/src/shared_mempool/peer_manager.rs
+++ b/mempool/src/shared_mempool/peer_manager.rs
@@ -3,7 +3,7 @@
 
 use libra_config::config::{PeerNetworkId, UpstreamConfig};
 use std::{
-    collections::{HashMap, HashSet},
+    collections::{BTreeSet, HashMap, HashSet},
     sync::Mutex,
 };
 
@@ -31,14 +31,14 @@ pub struct BroadcastInfo {
     // broadcasts that have not been ACK'ed for yet
     pub sent_batches: HashMap<String, Vec<u64>>,
     // timeline IDs of all txns that need to be retried and ACKed for
-    pub total_retry_txns: HashSet<u64>,
+    pub total_retry_txns: BTreeSet<u64>,
 }
 
 impl BroadcastInfo {
     fn new() -> Self {
         Self {
             sent_batches: HashMap::new(),
-            total_retry_txns: HashSet::new(),
+            total_retry_txns: BTreeSet::new(),
         }
     }
 }
@@ -114,7 +114,7 @@ impl PeerManager {
             .iter()
             .filter(|x| *x >= &earliest_timeline_id)
             .cloned()
-            .collect::<HashSet<_>>();
+            .collect::<BTreeSet<_>>();
 
         sync_state.broadcast_info.total_retry_txns = gc_retry_txns;
     }

--- a/mempool/src/shared_mempool/peer_manager.rs
+++ b/mempool/src/shared_mempool/peer_manager.rs
@@ -130,6 +130,18 @@ impl PeerManager {
         }
     }
 
+    pub fn get_broadcast_batch(&self, peer: PeerNetworkId, batch_id: &str) -> Option<Vec<u64>> {
+        self.peer_info
+            .lock()
+            .expect("failed to acquire lock")
+            .get(&peer)
+            .expect("missing peer")
+            .broadcast_info
+            .sent_batches
+            .get(batch_id)
+            .cloned()
+    }
+
     pub fn is_upstream_peer(&self, peer: PeerNetworkId) -> bool {
         self.upstream_config.is_upstream_peer(peer)
     }

--- a/mempool/src/tests/core_mempool_test.rs
+++ b/mempool/src/tests/core_mempool_test.rs
@@ -261,20 +261,24 @@ fn test_timeline() {
             .collect()
     };
     let (timeline, _) = pool.read_timeline(0, 10);
+    let timeline = timeline.into_iter().map(|(_id, txn)| txn).collect();
     assert_eq!(view(timeline), vec![0, 1]);
 
     // add txn 2 to unblock txn3
     add_txns_to_mempool(&mut pool, vec![TestTransaction::new(1, 2, 1)]);
     let (timeline, _) = pool.read_timeline(0, 10);
+    let timeline = timeline.into_iter().map(|(_id, txn)| txn).collect();
     assert_eq!(view(timeline), vec![0, 1, 2, 3]);
 
     // try different start read position
     let (timeline, _) = pool.read_timeline(2, 10);
+    let timeline = timeline.into_iter().map(|(_id, txn)| txn).collect();
     assert_eq!(view(timeline), vec![2, 3]);
 
     // simulate callback from consensus to unblock txn 5
     pool.remove_transaction(&TestTransaction::get_address(1), 4, false);
     let (timeline, _) = pool.read_timeline(0, 10);
+    let timeline = timeline.into_iter().map(|(_id, txn)| txn).collect();
     assert_eq!(view(timeline), vec![5]);
 }
 
@@ -385,6 +389,10 @@ fn test_gc_ready_transaction() {
     assert_eq!(block[0].sequence_number(), 0);
 
     let (timeline, _) = pool.read_timeline(0, 10);
+    let timeline = timeline
+        .into_iter()
+        .map(|(_id, txn)| txn)
+        .collect::<Vec<_>>();
     assert_eq!(timeline.len(), 1);
     assert_eq!(timeline[0].sequence_number(), 0);
 }

--- a/mempool/src/tests/mocks.rs
+++ b/mempool/src/tests/mocks.rs
@@ -137,6 +137,10 @@ impl MockSharedMempool {
             .mempool
             .lock()
             .expect("[mock shared mempool] failed to acquire mempool lock");
-        pool.read_timeline(timeline_id, count).0
+        pool.read_timeline(timeline_id, count)
+            .0
+            .into_iter()
+            .map(|(_, txn)| txn)
+            .collect()
     }
 }

--- a/mempool/src/tests/shared_mempool_test.rs
+++ b/mempool/src/tests/shared_mempool_test.rs
@@ -642,7 +642,7 @@ fn test_consensus_events_rejected_txns() {
         .expect("[mempool test] failed to acquire mempool lock");
     let (timeline, _) = pool.read_timeline(0, 10);
     assert_eq!(timeline.len(), 1);
-    assert!(timeline.contains(&kept_txn));
+    assert_eq!(timeline.get(0).unwrap().1, kept_txn);
 }
 
 #[test]
@@ -696,7 +696,7 @@ fn test_state_sync_events_committed_txns() {
         .expect("[mempool test] failed to acquire mempool lock");
     let (timeline, _) = pool.read_timeline(0, 10);
     assert_eq!(timeline.len(), 1);
-    assert!(timeline.contains(&kept_txn));
+    assert_eq!(timeline.get(0).unwrap().1, kept_txn);
 }
 
 #[test]

--- a/types/src/mempool_status.rs
+++ b/types/src/mempool_status.rs
@@ -8,11 +8,10 @@ use anyhow::Result;
 use proptest::prelude::*;
 #[cfg(any(test, feature = "fuzzing"))]
 use proptest_derive::Arbitrary;
-use serde::{Deserialize, Serialize};
 use std::convert::TryFrom;
 
 /// A `MempoolStatus` is represented as a required status code that is semantic coupled with an optional sub status and message.
-#[derive(Clone, PartialEq, Eq, PartialOrd, Ord, Debug, Hash, Deserialize, Serialize)]
+#[derive(Clone, PartialEq, Eq, PartialOrd, Ord, Debug, Hash)]
 #[cfg_attr(any(test, feature = "fuzzing"), derive(Arbitrary))]
 #[cfg_attr(any(test, feature = "fuzzing"), proptest(no_params))]
 pub struct MempoolStatus {
@@ -37,7 +36,7 @@ impl MempoolStatus {
     }
 }
 
-#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq, PartialOrd, Ord, Deserialize, Serialize)]
+#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq, PartialOrd, Ord)]
 #[cfg_attr(any(test, feature = "fuzzing"), derive(Arbitrary))]
 #[repr(u64)]
 pub enum MempoolStatusCode {

--- a/types/src/mempool_status.rs
+++ b/types/src/mempool_status.rs
@@ -8,10 +8,11 @@ use anyhow::Result;
 use proptest::prelude::*;
 #[cfg(any(test, feature = "fuzzing"))]
 use proptest_derive::Arbitrary;
+use serde::{Deserialize, Serialize};
 use std::convert::TryFrom;
 
 /// A `MempoolStatus` is represented as a required status code that is semantic coupled with an optional sub status and message.
-#[derive(Clone, PartialEq, Eq, PartialOrd, Ord, Debug, Hash)]
+#[derive(Clone, PartialEq, Eq, PartialOrd, Ord, Debug, Hash, Deserialize, Serialize)]
 #[cfg_attr(any(test, feature = "fuzzing"), derive(Arbitrary))]
 #[cfg_attr(any(test, feature = "fuzzing"), proptest(no_params))]
 pub struct MempoolStatus {
@@ -36,7 +37,7 @@ impl MempoolStatus {
     }
 }
 
-#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq, PartialOrd, Ord)]
+#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq, PartialOrd, Ord, Deserialize, Serialize)]
 #[cfg_attr(any(test, feature = "fuzzing"), derive(Arbitrary))]
 #[repr(u64)]
 pub enum MempoolStatusCode {


### PR DESCRIPTION
## Motivation

There are some mempool txn submissions that fail that may succeed on retry (e.g. when mempool is full, or an account has too many txns for that mempool locally). This PR adds best-effort rebroadcasting behavior for such txn submission failures. 

## Test Plan

Existing tests, more tests coming up
