### PR TITLE
Ensure that all edges from test-only crates turn on the fuzzing feature if available

### DIFF
--- a/devtools/x-core/src/workspace_subset.rs
+++ b/devtools/x-core/src/workspace_subset.rs
@@ -149,3 +149,13 @@ pub enum WorkspaceStatus {
     /// This package ID is not a dependency of the workspace subset.
     Absent,
 }
+
+impl WorkspaceStatus {
+    /// Returns true if this package is a root member or dependency (i.e. not absent).
+    pub fn is_present(self) -> bool {
+        match self {
+            WorkspaceStatus::RootMember | WorkspaceStatus::Dependency => true,
+            WorkspaceStatus::Absent => false,
+        }
+    }
+}

--- a/devtools/x/src/lint/guppy.rs
+++ b/devtools/x/src/lint/guppy.rs
@@ -3,12 +3,11 @@
 
 //! Project and package linters that run queries on guppy.
 
-use crate::config::{BannedDepsConfig, EnforcedAttributesConfig, OverlayConfig};
-use guppy::{graph::feature::FeatureFilterFn, Version};
+use crate::config::{BannedDepsConfig, EnforcedAttributesConfig};
+use guppy::Version;
 use std::{
     collections::{BTreeMap, HashMap},
     ffi::OsStr,
-    iter,
 };
 use x_core::WorkspaceStatus;
 use x_lint::prelude::*;
@@ -307,107 +306,5 @@ impl ProjectLinter for DirectDepDups {
         }
 
         Ok(RunStatus::Executed)
-    }
-}
-
-/// Assertions for "overlay" features.
-///
-/// An "overlay" feature is a feature name used throughout the codebase, whose purpose it is to
-/// augment each package with extra code (e.g. proptest generators). Overlay features shouldn't be
-/// enabled by anything except overlay features on workspace members, but may be enabled by default
-/// by test-only or other non-default workspace members.
-#[derive(Debug)]
-pub struct OverlayFeatures<'cfg> {
-    config: &'cfg OverlayConfig,
-}
-
-impl<'cfg> OverlayFeatures<'cfg> {
-    pub fn new(config: &'cfg OverlayConfig) -> Self {
-        Self { config }
-    }
-
-    fn is_overlay(&self, feature: Option<&str>) -> bool {
-        match feature {
-            Some(feature) => self.config.features.iter().any(|f| *f == feature),
-            // The base feature isn't banned.
-            None => false,
-        }
-    }
-}
-
-impl<'cfg> Linter for OverlayFeatures<'cfg> {
-    fn name(&self) -> &'static str {
-        "overlay-features"
-    }
-}
-
-impl<'cfg> PackageLinter for OverlayFeatures<'cfg> {
-    fn run<'l>(
-        &self,
-        ctx: &PackageContext<'l>,
-        out: &mut LintFormatter<'l, '_>,
-    ) -> Result<RunStatus<'l>> {
-        let package = ctx.metadata();
-        if !ctx.is_default_member() {
-            return Ok(RunStatus::Skipped(SkipReason::UnsupportedPackage(
-                package.id(),
-            )));
-        }
-
-        let filter = FeatureFilterFn::new(|_, feature_id| {
-            // Accept all features except for overlay ones.
-            !self.is_overlay(feature_id.feature())
-        });
-
-        let package_graph = ctx.package_graph();
-
-        let package_query = package_graph
-            .query_forward(iter::once(package.id()))
-            .expect("valid package ID");
-        let feature_query = package_graph
-            .feature_graph()
-            .query_packages(&package_query, filter);
-
-        let mut overlays: Vec<(Option<&str>, &str, Option<&str>)> = vec![];
-
-        feature_query.resolve_with_fn(|_, link| {
-            // Consider the dependency even if it's dev-only since the v1 resolver unifies these.
-            // TODO: might be able to relax this for the v2 resolver.
-            let (from, to) = link.endpoints();
-            let to_package = to.package();
-            if to_package.in_workspace() && self.is_overlay(to.feature_id().feature()) {
-                overlays.push((
-                    from.feature_id().feature(),
-                    to_package.name(),
-                    to.feature_id().feature(),
-                ));
-            }
-
-            // Don't need to traverse past direct dependencies.
-            false
-        });
-
-        if !overlays.is_empty() {
-            let mut msg = "overlay features enabled by default:\n".to_string();
-            for (from_feature, to_package, to_feature) in overlays {
-                msg.push_str(&format!(
-                    "  * {} -> {}/{}\n",
-                    feature_str(from_feature),
-                    to_package,
-                    feature_str(to_feature)
-                ));
-            }
-            msg.push_str("Use a line in the [features] section instead.\n");
-            out.write(LintLevel::Error, msg);
-        }
-
-        Ok(RunStatus::Executed)
-    }
-}
-
-fn feature_str(feature: Option<&str>) -> &str {
-    match feature {
-        Some(feature) => feature,
-        None => "[base]",
     }
 }

--- a/devtools/x/src/lint/mod.rs
+++ b/devtools/x/src/lint/mod.rs
@@ -32,7 +32,7 @@ pub fn run(args: Args, xctx: XContext) -> crate::Result<()> {
         &guppy::CrateNamesPaths,
         &guppy::IrrelevantBuildDeps,
         &guppy::WorkspaceHack,
-        &overlay::OverlayFeatures::new(&workspace_config.overlay),
+        &overlay::OverlayFeatures::new(&workspace_config.overlay, &workspace_config.test_only),
         &workspace_classify::DefaultOrTestOnly::new(&workspace_config.test_only),
     ];
 

--- a/devtools/x/src/lint/mod.rs
+++ b/devtools/x/src/lint/mod.rs
@@ -8,6 +8,7 @@ use x_lint::{prelude::*, LintEngineConfig};
 
 mod guppy;
 mod license;
+mod overlay;
 mod toml;
 mod whitespace;
 mod workspace_classify;
@@ -30,8 +31,8 @@ pub fn run(args: Args, xctx: XContext) -> crate::Result<()> {
         &guppy::EnforcedAttributes::new(&workspace_config.enforced_attributes),
         &guppy::CrateNamesPaths,
         &guppy::IrrelevantBuildDeps,
-        &guppy::OverlayFeatures::new(&workspace_config.overlay),
         &guppy::WorkspaceHack,
+        &overlay::OverlayFeatures::new(&workspace_config.overlay),
         &workspace_classify::DefaultOrTestOnly::new(&workspace_config.test_only),
     ];
 

--- a/devtools/x/src/lint/overlay.rs
+++ b/devtools/x/src/lint/overlay.rs
@@ -1,8 +1,11 @@
 // Copyright (c) The Libra Core Contributors
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::config::OverlayConfig;
-use guppy::graph::feature::FeatureFilterFn;
+use crate::config::{OverlayConfig, TestOnlyConfig};
+use guppy::graph::feature::{default_filter, FeatureFilterFn, FeatureQuery};
+use guppy::graph::DependencyDirection;
+use guppy::DependencyKind;
+use std::collections::BTreeMap;
 use std::iter;
 use x_lint::prelude::*;
 
@@ -10,25 +13,12 @@ use x_lint::prelude::*;
 ///
 /// An "overlay" feature is a feature name used throughout the codebase, whose purpose it is to
 /// augment each package with extra code (e.g. proptest generators). Overlay features shouldn't be
-/// enabled by anything except overlay features on workspace members, but may be enabled by default
-/// by test-only or other non-default workspace members.
+/// enabled by anything except overlay features on workspace members, but must be enabled by default
+/// by test-only workspace members.
 #[derive(Debug)]
 pub struct OverlayFeatures<'cfg> {
-    config: &'cfg OverlayConfig,
-}
-
-impl<'cfg> OverlayFeatures<'cfg> {
-    pub fn new(config: &'cfg OverlayConfig) -> Self {
-        Self { config }
-    }
-
-    fn is_overlay(&self, feature: Option<&str>) -> bool {
-        match feature {
-            Some(feature) => self.config.features.iter().any(|f| *f == feature),
-            // The base feature isn't banned.
-            None => false,
-        }
-    }
+    overlay_config: &'cfg OverlayConfig,
+    test_only_config: &'cfg TestOnlyConfig,
 }
 
 impl<'cfg> Linter for OverlayFeatures<'cfg> {
@@ -43,13 +33,44 @@ impl<'cfg> PackageLinter for OverlayFeatures<'cfg> {
         ctx: &PackageContext<'l>,
         out: &mut LintFormatter<'l, '_>,
     ) -> Result<RunStatus<'l>> {
-        let package = ctx.metadata();
-        if !ctx.is_default_member() {
-            return Ok(RunStatus::Skipped(SkipReason::UnsupportedPackage(
-                package.id(),
-            )));
+        if ctx.is_default_member() {
+            self.default_lint(ctx, out)
+        } else if self.test_only_config.members.contains(ctx.workspace_path()) {
+            self.test_only_lint(ctx, out)
+        } else {
+            // Neither a default member nor test-only. The test-only lint will catch this.
+            Ok(RunStatus::Skipped(SkipReason::UnsupportedPackage(
+                ctx.metadata().id(),
+            )))
         }
+    }
+}
 
+impl<'cfg> OverlayFeatures<'cfg> {
+    pub fn new(
+        overlay_config: &'cfg OverlayConfig,
+        test_only_config: &'cfg TestOnlyConfig,
+    ) -> Self {
+        Self {
+            overlay_config,
+            test_only_config,
+        }
+    }
+
+    fn is_overlay(&self, feature: Option<&str>) -> bool {
+        match feature {
+            Some(feature) => self.overlay_config.features.iter().any(|f| *f == feature),
+            // The base feature isn't banned.
+            None => false,
+        }
+    }
+
+    fn default_lint<'l>(
+        &self,
+        ctx: &PackageContext<'l>,
+        out: &mut LintFormatter<'l, '_>,
+    ) -> Result<RunStatus<'l>> {
+        let package = ctx.metadata();
         let filter = FeatureFilterFn::new(|_, feature_id| {
             // Accept all features except for overlay ones.
             !self.is_overlay(feature_id.feature())
@@ -98,6 +119,93 @@ impl<'cfg> PackageLinter for OverlayFeatures<'cfg> {
         }
 
         Ok(RunStatus::Executed)
+    }
+
+    /// Ensure that links from test-only to default members always enable the fuzzing feature if
+    /// available.
+    fn test_only_lint<'l>(
+        &self,
+        ctx: &PackageContext<'l>,
+        out: &mut LintFormatter<'l, '_>,
+    ) -> Result<RunStatus<'l>> {
+        let package = ctx.metadata();
+        let package_graph = ctx.package_graph();
+        let feature_graph = package_graph.feature_graph();
+
+        let package_query = package_graph
+            .query_forward(iter::once(package.id()))
+            .expect("valid package ID");
+        // Do the query with default features.
+        // TODO: should this be stricter -- no features?
+        let feature_query = feature_graph.query_packages(&package_query, default_filter());
+
+        let missing_overlays = self.missing_overlays(ctx, feature_query)?;
+
+        if !missing_overlays.is_empty() {
+            let mut msg = "missing overlay features from test-only package:\n".to_string();
+            for (name, (kind, overlay_feature)) in &missing_overlays {
+                msg.push_str(&format!(
+                    "  * {} dependency '{}' missing feature '{}'\n",
+                    kind, name, overlay_feature
+                ));
+            }
+            msg.push_str(
+                "Enable overlay features in test-only packages through [dependencies] etc.",
+            );
+            out.write(LintLevel::Error, msg);
+        }
+
+        Ok(RunStatus::Executed)
+    }
+
+    fn missing_overlays<'l>(
+        &self,
+        ctx: &PackageContext<'l>,
+        feature_query: FeatureQuery<'l>,
+    ) -> Result<BTreeMap<&'l str, (DependencyKind, &'cfg str)>> {
+        let package = ctx.metadata();
+        let feature_graph = ctx.package_graph().feature_graph();
+        let default_members = ctx.project_ctx().default_members()?;
+
+        // TODO: guppy should provide an easier way to get all features for a package.
+        let all_feature_set = feature_graph.resolve_all();
+
+        let mut missing_overlays = BTreeMap::new();
+
+        for kind in &[DependencyKind::Normal, DependencyKind::Build] {
+            let feature_set = feature_query.clone().resolve_with_fn(|_, link| {
+                let (from, to) = link.endpoints();
+
+                // Look for edges to default members.
+                let to_package = to.package();
+                let consider_link = from.package().id() == package.id()
+                    && to_package.in_workspace()
+                    && default_members.status_of(to_package.id()).is_present();
+                consider_link && link.status_for_kind(*kind).is_present()
+            });
+
+            // Check that the feature set for all members includes overlay features if available.
+            for feature_list in feature_set.packages_with_features(DependencyDirection::Forward) {
+                let package = feature_list.package();
+                if !default_members.status_of(package.id()).is_present() {
+                    // Skip non-default members.
+                    continue;
+                }
+
+                let all_features = all_feature_set
+                    .features_for(package.id())
+                    .expect("all_feature_set contains all packages");
+                for overlay_feature in &self.overlay_config.features {
+                    if all_features.contains(overlay_feature)
+                        && !feature_list.contains(overlay_feature)
+                    {
+                        missing_overlays.insert(package.name(), (*kind, overlay_feature.as_str()));
+                    }
+                }
+            }
+        }
+
+        Ok(missing_overlays)
     }
 }
 

--- a/devtools/x/src/lint/overlay.rs
+++ b/devtools/x/src/lint/overlay.rs
@@ -1,0 +1,109 @@
+// Copyright (c) The Libra Core Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::config::OverlayConfig;
+use guppy::graph::feature::FeatureFilterFn;
+use std::iter;
+use x_lint::prelude::*;
+
+/// Assertions for "overlay" features.
+///
+/// An "overlay" feature is a feature name used throughout the codebase, whose purpose it is to
+/// augment each package with extra code (e.g. proptest generators). Overlay features shouldn't be
+/// enabled by anything except overlay features on workspace members, but may be enabled by default
+/// by test-only or other non-default workspace members.
+#[derive(Debug)]
+pub struct OverlayFeatures<'cfg> {
+    config: &'cfg OverlayConfig,
+}
+
+impl<'cfg> OverlayFeatures<'cfg> {
+    pub fn new(config: &'cfg OverlayConfig) -> Self {
+        Self { config }
+    }
+
+    fn is_overlay(&self, feature: Option<&str>) -> bool {
+        match feature {
+            Some(feature) => self.config.features.iter().any(|f| *f == feature),
+            // The base feature isn't banned.
+            None => false,
+        }
+    }
+}
+
+impl<'cfg> Linter for OverlayFeatures<'cfg> {
+    fn name(&self) -> &'static str {
+        "overlay-features"
+    }
+}
+
+impl<'cfg> PackageLinter for OverlayFeatures<'cfg> {
+    fn run<'l>(
+        &self,
+        ctx: &PackageContext<'l>,
+        out: &mut LintFormatter<'l, '_>,
+    ) -> Result<RunStatus<'l>> {
+        let package = ctx.metadata();
+        if !ctx.is_default_member() {
+            return Ok(RunStatus::Skipped(SkipReason::UnsupportedPackage(
+                package.id(),
+            )));
+        }
+
+        let filter = FeatureFilterFn::new(|_, feature_id| {
+            // Accept all features except for overlay ones.
+            !self.is_overlay(feature_id.feature())
+        });
+
+        let package_graph = ctx.package_graph();
+
+        let package_query = package_graph
+            .query_forward(iter::once(package.id()))
+            .expect("valid package ID");
+        let feature_query = package_graph
+            .feature_graph()
+            .query_packages(&package_query, filter);
+
+        let mut overlays: Vec<(Option<&str>, &str, Option<&str>)> = vec![];
+
+        feature_query.resolve_with_fn(|_, link| {
+            // Consider the dependency even if it's dev-only since the v1 resolver unifies these.
+            // TODO: might be able to relax this for the v2 resolver.
+            let (from, to) = link.endpoints();
+            let to_package = to.package();
+            if to_package.in_workspace() && self.is_overlay(to.feature_id().feature()) {
+                overlays.push((
+                    from.feature_id().feature(),
+                    to_package.name(),
+                    to.feature_id().feature(),
+                ));
+            }
+
+            // Don't need to traverse past direct dependencies.
+            false
+        });
+
+        if !overlays.is_empty() {
+            let mut msg = "overlay features enabled by default:\n".to_string();
+            for (from_feature, to_package, to_feature) in overlays {
+                msg.push_str(&format!(
+                    "  * {} -> {}/{}\n",
+                    feature_str(from_feature),
+                    to_package,
+                    feature_str(to_feature)
+                ));
+            }
+            msg.push_str("Use a line in the [features] section instead.\n");
+            out.write(LintLevel::Error, msg);
+        }
+
+        Ok(RunStatus::Executed)
+    }
+}
+
+fn feature_str(feature: Option<&str>) -> &str {
+    match feature {
+        Some(feature) => feature,
+        None => "[base]",
+    }
+}

--- a/execution/executor-benchmark/Cargo.toml
+++ b/execution/executor-benchmark/Cargo.toml
@@ -15,19 +15,19 @@ rand = "0.7.3"
 rayon = "1.3.0"
 structopt = "0.3.14"
 
-config-builder = { path = "../../config/config-builder", version = "0.1.0" }
-executor = { path = "../executor", version = "0.1.0" }
-executor-types = { path = "../executor-types", version = "0.1.0" }
-libradb = { path = "../../storage/libradb", version = "0.1.0" }
-libra-config = { path = "../../config", version = "0.1.0" }
-libra-crypto = { path = "../../crypto/crypto", version = "0.1.0" }
+config-builder = { path = "../../config/config-builder", version = "0.1.0", features = ["fuzzing"] }
+executor = { path = "../executor", version = "0.1.0", features = ["fuzzing"] }
+executor-types = { path = "../executor-types", version = "0.1.0", features = ["fuzzing"] }
+libradb = { path = "../../storage/libradb", version = "0.1.0", features = ["fuzzing"] }
+libra-config = { path = "../../config", version = "0.1.0", features = ["fuzzing"] }
+libra-crypto = { path = "../../crypto/crypto", version = "0.1.0", features = ["fuzzing"] }
 libra-logger = { path = "../../common/logger", version = "0.1.0" }
-libra-types = { path = "../../types", version = "0.1.0" }
-libra-vm= { path = "../../language/libra-vm", version = "0.1.0" }
+libra-types = { path = "../../types", version = "0.1.0", features = ["fuzzing"] }
+libra-vm = { path = "../../language/libra-vm", version = "0.1.0", features = ["fuzzing"] }
 libra-workspace-hack = { path = "../../common/workspace-hack", version = "0.1.0" }
 storage-client = { path = "../../storage/storage-client", version = "0.1.0" }
-storage-interface = { path = "../../storage/storage-interface", version = "0.1.0" }
-storage-service = { path = "../../storage/storage-service", version = "0.1.0" }
+storage-interface = { path = "../../storage/storage-interface", version = "0.1.0", features = ["fuzzing"] }
+storage-service = { path = "../../storage/storage-service", version = "0.1.0", features = ["fuzzing"] }
 transaction-builder = { path = "../../language/transaction-builder", version = "0.1.0" }
 
 [features]

--- a/execution/executor-test-helpers/Cargo.toml
+++ b/execution/executor-test-helpers/Cargo.toml
@@ -10,8 +10,8 @@ publish = false
 edition = "2018"
 
 [dependencies]
-executor-types = { path = "../executor-types", version = "0.1.0" }
-libra-config = { path = "../../config", version = "0.1.0" }
-libra-crypto = { path = "../../crypto/crypto", version = "0.1.0" }
+executor-types = { path = "../executor-types", version = "0.1.0", features = ["fuzzing"] }
+libra-config = { path = "../../config", version = "0.1.0", features = ["fuzzing"] }
+libra-crypto = { path = "../../crypto/crypto", version = "0.1.0", features = ["fuzzing"] }
 libra-types = { path = "../../types", version = "0.1.0", features = ["fuzzing"] }
 libra-workspace-hack = { path = "../../common/workspace-hack", version = "0.1.0" }

--- a/language/benchmarks/Cargo.toml
+++ b/language/benchmarks/Cargo.toml
@@ -14,18 +14,18 @@ anyhow = "1.0.31"
 criterion = "0.3.2"
 proptest = "0.10.0"
 
-bytecode-verifier = { path = "../bytecode-verifier", version = "0.1.0" }
+bytecode-verifier = { path = "../bytecode-verifier", version = "0.1.0", features = ["fuzzing"] }
 language-e2e-tests = { path = "../e2e-tests", version = "0.1.0" }
 libra-proptest-helpers = { path = "../../common/proptest-helpers", version = "0.1.0" }
-libra-state-view = { path = "../../storage/state-view", version = "0.1.0" }
+libra-state-view = { path = "../../storage/state-view", version = "0.1.0", features = ["fuzzing"] }
 libra-types = { path = "../../types", version = "0.1.0", features = ["fuzzing"] }
 libra-workspace-hack = { path = "../../common/workspace-hack", version = "0.1.0" }
-move-core-types = { path = "../move-core/types", version = "0.1.0" }
+move-core-types = { path = "../move-core/types", version = "0.1.0", features = ["fuzzing"] }
 move-lang = { path = "../move-lang", version = "0.0.1" }
-move-vm-runtime = { path = "../move-vm/runtime", version = "0.1.0" }
-move-vm-types = { path = "../move-vm/types", version = "0.1.0" }
-vm = { path = "../vm", version = "0.1.0" }
-libra-vm = { path = "../libra-vm", version = "0.1.0" }
+move-vm-runtime = { path = "../move-vm/runtime", version = "0.1.0", features = ["fuzzing"] }
+move-vm-types = { path = "../move-vm/types", version = "0.1.0", features = ["fuzzing"] }
+vm = { path = "../vm", version = "0.1.0", features = ["fuzzing"] }
+libra-vm = { path = "../libra-vm", version = "0.1.0", features = ["fuzzing"] }
 
 [[bench]]
 name = "benchmarks"

--- a/language/bytecode-verifier/invalid-mutations/Cargo.toml
+++ b/language/bytecode-verifier/invalid-mutations/Cargo.toml
@@ -10,12 +10,8 @@ license = "Apache-2.0"
 publish = false
 
 [dependencies]
-vm = { path = "../../vm", version = "0.1.0" }
-libra-types = { path = "../../../types", version = "0.1.0" }
+vm = { path = "../../vm", version = "0.1.0", features = ["fuzzing"] }
+libra-types = { path = "../../../types", version = "0.1.0", features = ["fuzzing"] }
 proptest = "0.10.0"
 libra-proptest-helpers = { path = "../../../common/proptest-helpers", version = "0.1.0" }
 libra-workspace-hack = { path = "../../../common/workspace-hack", version = "0.1.0" }
-
-[features]
-default = []
-fuzzing = ["libra-types/fuzzing"]

--- a/language/e2e-tests/Cargo.toml
+++ b/language/e2e-tests/Cargo.toml
@@ -11,26 +11,26 @@ publish = false
 
 [dependencies]
 anyhow = "1.0.31"
-bytecode-verifier = { path = "../bytecode-verifier", version = "0.1.0" }
+bytecode-verifier = { path = "../bytecode-verifier", version = "0.1.0", features = ["fuzzing"] }
 lcs = { path = "../../common/lcs", version = "0.1.0", package = "libra-canonical-serialization" }
-compiler = { path = "../compiler", version = "0.1.0" }
+compiler = { path = "../compiler", version = "0.1.0", features = ["fuzzing"] }
 once_cell = "1.4.0"
 libra-crypto = { path = "../../crypto/crypto", version = "0.1.0", features = ["fuzzing"] }
 rand = "0.7.3"
-libra-state-view = { path = "../../storage/state-view", version = "0.1.0" }
+libra-state-view = { path = "../../storage/state-view", version = "0.1.0", features = ["fuzzing"] }
 libra-types = { path = "../../types", version = "0.1.0", features = ["fuzzing"] }
 libra-workspace-hack = { path = "../../common/workspace-hack", version = "0.1.0" }
-move-core-types = { path = "../move-core/types", version = "0.1.0" }
+move-core-types = { path = "../move-core/types", version = "0.1.0", features = ["fuzzing"] }
 move-vm-natives = { path = "../move-vm/natives", version = "0.1.0", features = ["debug_module"] }
-move-vm-runtime = { path = "../move-vm/runtime", version = "0.1.0", features = ["debug_module"] }
-move-vm-types = { path = "../move-vm/types", version = "0.1.0" }
+move-vm-runtime = { path = "../move-vm/runtime", version = "0.1.0", features = ["debug_module", "fuzzing"] }
+move-vm-types = { path = "../move-vm/types", version = "0.1.0", features = ["fuzzing"] }
 transaction-builder = { path = "../transaction-builder", version = "0.1.0"}
-vm = { path = "../vm", version = "0.1.0" }
-vm-genesis = { path = "../tools/vm-genesis", version = "0.1.0" }
-libra-vm = { path = "../libra-vm", version = "0.1.0" }
+vm = { path = "../vm", version = "0.1.0", features = ["fuzzing"] }
+vm-genesis = { path = "../tools/vm-genesis", version = "0.1.0", features = ["fuzzing"] }
+libra-vm = { path = "../libra-vm", version = "0.1.0", features = ["fuzzing"] }
 proptest = "0.10.0"
 proptest-derive = "0.2.0"
 libra-proptest-helpers = { path = "../../common/proptest-helpers", version = "0.1.0" }
-libra-config =  { path = "../../config", version = "0.1.0" }
+libra-config =  { path = "../../config", version = "0.1.0", features = ["fuzzing"] }
 libra-logger = { path = "../../common/logger", version = "0.1.0" }
-stdlib = { path = "../stdlib", version = "0.1.0" }
+stdlib = { path = "../stdlib", version = "0.1.0", features = ["fuzzing"] }

--- a/language/functional-tests/Cargo.toml
+++ b/language/functional-tests/Cargo.toml
@@ -10,14 +10,14 @@ edition = "2018"
 
 [dependencies]
 anyhow = "1.0.31"
-libra-state-view = { path = "../../storage/state-view", version = "0.1.0" }
-libra-types = { path = "../../types", version = "0.1.0" }
-libra-vm = { path = "../libra-vm",  version = "0.1.0" }
-vm = { path = "../vm", version = "0.1.0" }
-bytecode-verifier = { path = "../bytecode-verifier", version = "0.1.0" }
+libra-state-view = { path = "../../storage/state-view", version = "0.1.0", features = ["fuzzing"] }
+libra-types = { path = "../../types", version = "0.1.0", features = ["fuzzing"] }
+libra-vm = { path = "../libra-vm",  version = "0.1.0", features = ["fuzzing"] }
+vm = { path = "../vm", version = "0.1.0", features = ["fuzzing"] }
+bytecode-verifier = { path = "../bytecode-verifier", version = "0.1.0", features = ["fuzzing"] }
 language-e2e-tests = { path = "../e2e-tests", version = "0.1.0" }
-libra-config = { path = "../../config", version = "0.1.0" }
-libra-crypto = { path = "../../crypto/crypto", version = "0.1.0" }
+libra-config = { path = "../../config", version = "0.1.0", features = ["fuzzing"] }
+libra-crypto = { path = "../../crypto/crypto", version = "0.1.0", features = ["fuzzing"] }
 libra-workspace-hack = { path = "../../common/workspace-hack", version = "0.1.0" }
 once_cell = "1.4.0"
 regex = { version = "1.3.9", default-features = false, features = ["std", "perf"] }
@@ -26,5 +26,5 @@ aho-corasick = "0.7.10"
 termcolor = "1.1.0"
 datatest-stable = { path = "../../common/datatest-stable", version = "0.1.0" }
 mirai-annotations = "1.8.0"
-move-core-types = { path = "../move-core/types", version = "0.1.0" }
-stdlib = { path = "../stdlib", version = "0.1.0" }
+move-core-types = { path = "../move-core/types", version = "0.1.0", features = ["fuzzing"] }
+stdlib = { path = "../stdlib", version = "0.1.0", features = ["fuzzing"] }

--- a/language/tools/test-generation/Cargo.toml
+++ b/language/tools/test-generation/Cargo.toml
@@ -19,18 +19,18 @@ hex = "0.4.2"
 getrandom = "0.1.14"
 crossbeam-channel = "0.4.2"
 
-bytecode-verifier = { path = "../../bytecode-verifier", version = "0.1.0" }
-libra-config = { path = "../../../config", version = "0.1.0" }
+bytecode-verifier = { path = "../../bytecode-verifier", version = "0.1.0", features = ["fuzzing"] }
+libra-config = { path = "../../../config", version = "0.1.0", features = ["fuzzing"] }
 libra-logger = { path = "../../../common/logger", version = "0.1.0" }
-libra-state-view = { path = "../../../storage/state-view", version = "0.1.0" }
+libra-state-view = { path = "../../../storage/state-view", version = "0.1.0", features = ["fuzzing"] }
 libra-workspace-hack = { path = "../../../common/workspace-hack", version = "0.1.0" }
-move-core-types = { path = "../../move-core/types", version = "0.1.0" }
-move-vm-types = { path = "../../move-vm/types", version = "0.1.0" }
+move-core-types = { path = "../../move-core/types", version = "0.1.0", features = ["fuzzing"] }
+move-vm-types = { path = "../../move-vm/types", version = "0.1.0", features = ["fuzzing"] }
 utils = { path = "../utils", version = "0.1.0" }
-vm = { path = "../../vm", version = "0.1.0" }
-libra-vm = { path = "../../libra-vm", version = "0.1.0" }
+vm = { path = "../../vm", version = "0.1.0", features = ["fuzzing"] }
+libra-vm = { path = "../../libra-vm", version = "0.1.0", features = ["fuzzing"] }
 language-e2e-tests = { path = "../../e2e-tests", version = "0.1.0" }
-libra-types = { path = "../../../types", version = "0.1.0" }
+libra-types = { path = "../../../types", version = "0.1.0", features = ["fuzzing"] }
 
 [features]
 mirai-contracts = []

--- a/language/tools/utils/Cargo.toml
+++ b/language/tools/utils/Cargo.toml
@@ -12,13 +12,13 @@ edition = "2018"
 [dependencies]
 rand = "0.7.3"
 
-bytecode-verifier = { path = "../../bytecode-verifier", version = "0.1.0" }
-ir-to-bytecode = { path = "../../compiler/ir-to-bytecode", version = "0.1.0" }
-move-core-types = { path = "../../move-core/types", version = "0.1.0" }
+bytecode-verifier = { path = "../../bytecode-verifier", version = "0.1.0", features = ["fuzzing"] }
+ir-to-bytecode = { path = "../../compiler/ir-to-bytecode", version = "0.1.0", features = ["fuzzing"] }
+move-core-types = { path = "../../move-core/types", version = "0.1.0", features = ["fuzzing"] }
 move-ir-types = { path = "../../move-ir/types", version = "0.1.0" }
-libra-types = { path = "../../../types", version = "0.1.0" }
+libra-types = { path = "../../../types", version = "0.1.0", features = ["fuzzing"] }
 libra-workspace-hack = { path = "../../../common/workspace-hack", version = "0.1.0" }
-vm = { path = "../../vm", version = "0.1.0" }
+vm = { path = "../../vm", version = "0.1.0", features = ["fuzzing"] }
 
 [features]
 default = []

--- a/network/socket-bench-server/Cargo.toml
+++ b/network/socket-bench-server/Cargo.toml
@@ -14,11 +14,11 @@ futures = "0.3.5"
 tokio = { version = "0.2.21", features = ["full"] }
 tokio-util = { version = "0.3.1", features = ["codec"] }
 
-libra-crypto = { path = "../../crypto/crypto" }
+libra-crypto = { path = "../../crypto/crypto", features = ["fuzzing"] }
 libra-logger = { path = "../../common/logger", version = "0.1.0" }
-libra-network-address = { path = "../network-address", version = "0.1.0" }
+libra-network-address = { path = "../network-address", version = "0.1.0", features = ["fuzzing"] }
 libra-workspace-hack = { path = "../../common/workspace-hack", version = "0.1.0" }
 memsocket = { path = "../memsocket", version = "0.1.0" }
 netcore = { path = "../netcore", version = "0.1.0" }
-network = { path = "../", version = "0.1.0", features = ["testing"] }
+network = { path = "../", version = "0.1.0", features = ["testing", "fuzzing"] }
 rand = "0.7.3"

--- a/testsuite/cluster-test/Cargo.toml
+++ b/testsuite/cluster-test/Cargo.toml
@@ -29,14 +29,14 @@ rusoto_sts = {version = "0.44.0", default-features = false, features = ["rustls"
 
 debug-interface = { path = "../../common/debug-interface", version = "0.1.0"}
 libra-json-rpc-client = { path = "../../client/json-rpc", version = "0.1.0"}
-admission-control-proto = { path = "../../admission-control/admission-control-proto", version = "0.1.0" }
+admission-control-proto = { path = "../../admission-control/admission-control-proto", version = "0.1.0", features = ["fuzzing"] }
 libra-retrier = { path = "../../common/retrier", version = "0.1.0" }
 num_cpus = "1.13.0"
 
-config-builder = { path = "../../config/config-builder", version = "0.1.0" }
+config-builder = { path = "../../config/config-builder", version = "0.1.0", features = ["fuzzing"] }
 generate-key = { path = "../../config/generate-key", version = "0.1.0" }
-libra-crypto = { path = "../../crypto/crypto", version = "0.1.0" }
-libra-config = { path = "../../config", version = "0.1.0" }
+libra-crypto = { path = "../../crypto/crypto", version = "0.1.0", features = ["fuzzing"] }
+libra-config = { path = "../../config", version = "0.1.0", features = ["fuzzing"] }
 libra-logger = { path = "../../common/logger", version = "0.1.0", features = ["no_struct_log"] }
 libra-types = { path = "../../types", version = "0.1.0", features = ["fuzzing"] }
 libra-workspace-hack = { path = "../../common/workspace-hack", version = "0.1.0" }

--- a/testsuite/generate-format/Cargo.toml
+++ b/testsuite/generate-format/Cargo.toml
@@ -20,11 +20,11 @@ structopt = "0.3.14"
 consensus = { path = "../../consensus", version = "0.1.0", features=["fuzzing"] }
 consensus-types = { path = "../../consensus/consensus-types", version = "0.1.0", features=["fuzzing"] }
 lcs = { path = "../../common/lcs", version = "0.1.0", package = "libra-canonical-serialization" }
-libra-config = { path = "../../config", version = "0.1.0" }
+libra-config = { path = "../../config", version = "0.1.0", features = ["fuzzing"] }
 libra-crypto = { path = "../../crypto/crypto", version = "0.1.0", features=["fuzzing"] }
 libra-types = { path = "../../types", version = "0.1.0", features=["fuzzing"] }
 libra-workspace-hack = { path = "../../common/workspace-hack", version = "0.1.0" }
-network = { path = "../../network", version = "0.1.0" }
+network = { path = "../../network", version = "0.1.0", features = ["fuzzing"] }
 libra-network-address = { path = "../../network/network-address", version = "0.1.0", features=["fuzzing"] }
 move-core-types = { path = "../../language/move-core/types", version = "0.1.0", features=["fuzzing"] }
 

--- a/testsuite/libra-fuzzer/Cargo.toml
+++ b/testsuite/libra-fuzzer/Cargo.toml
@@ -29,7 +29,7 @@ libra-workspace-hack = { path = "../../common/workspace-hack", version = "0.1.0"
 # List out modules with data structures being fuzzed here.
 consensus = { path = "../../consensus", version = "0.1.0", features = ["fuzzing"] }
 consensus-types = { path = "../../consensus/consensus-types", version = "0.1.0", features = ["fuzzing"] }
-grpc-types = { path = "../../grpc/types", version = "0.1.0"}
+grpc-types = { path = "../../grpc/types", version = "0.1.0", features = ["fuzzing"] }
 libra-json-rpc = { path = "../../json-rpc", version = "0.1.0", features = ["fuzzing"] }
 libra-types = { path = "../../types", version = "0.1.0", features = ["fuzzing"] }
 move-vm-types = { path = "../../language/move-vm/types", version = "0.1.0", features = ["fuzzing"] }

--- a/testsuite/libra-swarm/Cargo.toml
+++ b/testsuite/libra-swarm/Cargo.toml
@@ -14,14 +14,14 @@ anyhow = "1.0.31"
 ctrlc = { version = "3.1.4", default-features = false }
 structopt = "0.3.14"
 thiserror = "1.0.19"
-config-builder = { path = "../../config/config-builder", version = "0.1.0" }
+config-builder = { path = "../../config/config-builder", version = "0.1.0", features = ["fuzzing"] }
 libra-config = { path = "../../config", version = "0.1.0", features = ["fuzzing"] }
 debug-interface = { path = "../../common/debug-interface", version = "0.1.0" }
 generate-key = { path = "../../config/generate-key", version = "0.1.0" }
-libra-crypto = { path = "../../crypto/crypto", version = "0.1.0", features = ["cloneable-private-keys"] }
+libra-crypto = { path = "../../crypto/crypto", version = "0.1.0", features = ["fuzzing", "cloneable-private-keys"] }
 libra-logger = { path = "../../common/logger", version = "0.1.0" }
-libra-secure-storage = { path = "../../secure/storage", version = "0.1.0" }
+libra-secure-storage = { path = "../../secure/storage", version = "0.1.0", features = ["fuzzing"] }
 libra-temppath = { path = "../../common/temppath", version = "0.1.0" }
-libra-types = { path = "../../types", version = "0.1.0" }
+libra-types = { path = "../../types", version = "0.1.0", features = ["fuzzing"] }
 libra-workspace-hack = { path = "../../common/workspace-hack", version = "0.1.0" }
 workspace-builder = { path = "../../common/workspace-builder", version = "0.1.0" }


### PR DESCRIPTION
We'd keep having CI pass because of feature unification, but breakages if people tried to run tests locally.

There's another thing we need to do, to ensure that the fuzzing feature uniformly gets turned on for regular crates as well. Will do in another PR.