### PR TITLE
[docker] Add tools image with libra-management

### DIFF
--- a/docker/tools/Dockerfile
+++ b/docker/tools/Dockerfile
@@ -1,0 +1,35 @@
+FROM debian:buster AS toolchain
+
+# To use http/https proxy while building, use:
+# docker build --build-arg https_proxy=http://fwdproxy:8080 --build-arg http_proxy=http://fwdproxy:8080
+
+RUN apt-get update && apt-get install -y cmake curl clang git
+
+RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --default-toolchain none
+ENV PATH "$PATH:/root/.cargo/bin"
+
+WORKDIR /libra
+COPY rust-toolchain /libra/rust-toolchain
+RUN rustup install $(cat rust-toolchain)
+
+FROM toolchain AS builder
+
+COPY . /libra
+
+ENV RUSTFLAGS "-Ctarget-cpu=skylake -Ctarget-feature=+aes,+sse2,+sse4.1,+ssse3"
+RUN cargo build --release -p libra-management && cd target/release && rm -r build deps incremental
+RUN strip target/release/libra-management
+
+### Production Image ###
+FROM debian:buster-slim AS prod
+
+COPY --from=builder /libra/target/release/libra-management /usr/local/bin
+
+ARG BUILD_DATE
+ARG GIT_REV
+ARG GIT_UPSTREAM
+
+LABEL org.label-schema.schema-version="1.0"
+LABEL org.label-schema.build-date=$BUILD_DATE
+LABEL org.label-schema.vcs-ref=$GIT_REV
+LABEL vcs-upstream=$GIT_UPSTREAM

--- a/docker/tools/build.sh
+++ b/docker/tools/build.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+# Copyright (c) The Libra Core Contributors
+# SPDX-License-Identifier: Apache-2.0
+
+DIR="$( cd "$( dirname "$0" )" && pwd )"
+
+PROXY=""
+if [ "$https_proxy" ]; then
+    PROXY=" --build-arg https_proxy=$https_proxy --build-arg http_proxy=$http_proxy"
+fi
+
+for ((i = 0; i < 30; i++)); do
+  docker build -f $DIR/Dockerfile $DIR/../.. --tag libra_tools --build-arg GIT_REV="$(git rev-parse HEAD)" --build-arg GIT_UPSTREAM="$(git merge-base HEAD origin/master)" --build-arg BUILD_DATE="$(date -u +'%Y-%m-%dT%H:%M:%SZ')" $PROXY "$@"
+  if [[ $? -eq 0 ]]; then
+    echo "docker build succeeded"
+    exit 0
+  fi
+  echo "docker build failed. retrying in 10 secs."
+  sleep 10
+done
+exit 1


### PR DESCRIPTION
This will make it easier for partners to run the `libra-management` tool.

Test Plan: Built it.