### PR TITLE
[node] Refactor the network setup code to eliminate redundancies

### DIFF
--- a/libra-node/src/main_node.rs
+++ b/libra-node/src/main_node.rs
@@ -240,7 +240,7 @@ pub fn setup_environment(node_config: &mut NodeConfig) -> LibraHandle {
     let mut network_runtimes = vec![];
     let mut state_sync_network_handles = vec![];
     let mut mempool_network_handles = vec![];
-    let mut validator_network_provider = None;
+    let mut consensus_network_handles = None;
     let mut reconfig_subscriptions = vec![];
 
     let (mempool_reconfig_subscription, mempool_reconfig_events) =
@@ -265,7 +265,7 @@ pub fn setup_environment(node_config: &mut NodeConfig) -> LibraHandle {
     }
 
     let mut validator_count = 0;
-    // Instantiate every network.
+    // Instantiate every network and collect the requisite endpoints for state_sync, mempool, and consensus.
     for (role, network_config) in network_configs {
         // Perform common instantiation steps
         let (runtime, mut network_builder) =
@@ -284,13 +284,14 @@ pub fn setup_environment(node_config: &mut NodeConfig) -> LibraHandle {
         );
         mempool_network_handles.push((peer_id, mempool_sender, mempool_events));
 
-        // Perform actions specific to a particular network type.
         match role {
+            // Perform steps relevant specifically to Validator networks.
             RoleType::Validator => {
                 validator_count += 1;
                 // A valid config is allowed to have exactly one ValidatorNetwork
                 assert_eq!(1, validator_count);
                 // Set up to listen for network configuration changes from StateSync.
+                // TODO:  move this inside network_builder.
                 if let Some(conn_mgr_reqs_tx) = network_builder.conn_mgr_reqs_tx() {
                     let (simple_discovery_reconfig_subscription, simple_discovery_reconfig_rx) =
                         gen_simple_discovery_reconfig_subscription();
@@ -302,18 +303,19 @@ pub fn setup_environment(node_config: &mut NodeConfig) -> LibraHandle {
                         .spawn(network_config_listener.start(simple_discovery_reconfig_rx));
                 };
 
-                // Cache the network information to be started later.
-                validator_network_provider = Some((peer_id, runtime, network_builder));
+                consensus_network_handles = Some(consensus::network_interface::add_to_network(
+                    &mut network_builder,
+                ));
             }
-            RoleType::FullNode => {
-                // Cache the runtime so it does not go out of scope immediately.
-                network_runtimes.push(runtime);
-
-                // Start the network provider.  FullNode networks can operate silently.3
-                let _listen_addr = network_builder.build();
-                debug!("Network started for peer_id: {}", peer_id);
-            }
+            // Currently no FullNode network specific steps.
+            RoleType::FullNode => (),
         }
+
+        // Start the network and cache the runtime so it does not go out of scope.
+        // TODO:  move all 'start' commands to a second phase at the end of setup_environment.  Target is to have one pass to wire the pieces together and a second pass to start processing in an appropriate order.
+        let _listen_addr = network_builder.build();
+        network_runtimes.push(runtime);
+        debug!("Network started for peer_id: {}", peer_id);
     }
 
     // TODO set up on-chain discovery network based on UpstreamConfig.fallback_network
@@ -350,22 +352,16 @@ pub fn setup_environment(node_config: &mut NodeConfig) -> LibraHandle {
     );
     debug!("Mempool started in {} ms", instant.elapsed().as_millis());
 
-    if let Some((peer_id, runtime, mut network_builder)) = validator_network_provider {
-        // Note: We need to start network provider before consensus, because the consensus
-        // initialization is blocked on state synchronizer to sync to the initial root ledger
-        // info, which in turn cannot make progress before network initialization
-        // because the NewPeer events which state synchronizer uses to know its
-        // peers are delivered by network provider. If we were to start network
-        // provider after consensus, we create a cyclic dependency from
-        // network provider -> consensus -> state synchronizer -> network provider. This deadlock
-        // was observed in GitHub Issue #749. A long term fix might be make
-        // consensus initialization async instead of blocking on state synchronizer.
-        let (consensus_network_sender, consensus_network_events) =
-            consensus::network_interface::add_to_network(&mut network_builder);
-        let _listen_addr = network_builder.build();
-        network_runtimes.push(runtime);
-        debug!("Network started for peer_id: {}", peer_id);
-
+    // Note: We need to start network provider before consensus, because the consensus
+    // initialization is blocked on state synchronizer to sync to the initial root ledger
+    // info, which in turn cannot make progress before network initialization
+    // because the NewPeer events which state synchronizer uses to know its
+    // peers are delivered by network provider. If we were to start network
+    // provider after consensus, we create a cyclic dependency from
+    // network provider -> consensus -> state synchronizer -> network provider. This deadlock
+    // was observed in GitHub Issue #749. A long term fix might be make
+    // consensus initialization async instead of blocking on state synchronizer.
+    if let Some((consensus_network_sender, consensus_network_events)) = consensus_network_handles {
         // Make sure that state synchronizer is caught up at least to its waypoint
         // (in case it's present). There is no sense to start consensus prior to that.
         // TODO: Note that we need the networking layer to be able to discover & connect to the

--- a/libra-node/src/main_node.rs
+++ b/libra-node/src/main_node.rs
@@ -253,61 +253,67 @@ pub fn setup_environment(node_config: &mut NodeConfig) -> LibraHandle {
 
     let waypoint = config::waypoint(&node_config.base.waypoint);
 
-    if let Some(network) = node_config.validator_network.as_mut() {
-        let (runtime, mut network_builder) = setup_network(
-            network,
-            RoleType::Validator,
-            Arc::clone(&db_rw.reader),
-            waypoint,
-        );
-        let peer_id = network_builder.peer_id();
-
-        // Set up to listen for network configuration changes from StateSync.
-        if let Some(conn_mgr_reqs_tx) = network_builder.conn_mgr_reqs_tx() {
-            let (simple_discovery_reconfig_subscription, simple_discovery_reconfig_rx) =
-                gen_simple_discovery_reconfig_subscription();
-            reconfig_subscriptions.push(simple_discovery_reconfig_subscription);
-            let network_config_listener =
-                ConfigurationChangeListener::new(conn_mgr_reqs_tx, RoleType::Validator);
-            runtime
-                .handle()
-                .spawn(network_config_listener.start(simple_discovery_reconfig_rx));
-        };
-
-        let (state_sync_sender, state_sync_events) =
-            state_synchronizer::network::add_to_network(&mut network_builder);
-        state_sync_network_handles.push((peer_id, state_sync_sender, state_sync_events));
-
-        let (mempool_sender, mempool_events) = libra_mempool::network::add_to_network(
-            &mut network_builder,
-            node_config.mempool.max_broadcasts_per_peer,
-        );
-        mempool_network_handles.push((peer_id, mempool_sender, mempool_events));
-        validator_network_provider = Some((peer_id, runtime, network_builder));
+    // Gather all network configs into a single vector.
+    // TODO:  consider explicitly encoding the role in the NetworkConfig
+    let mut network_configs: Vec<(RoleType, &mut NetworkConfig)> = node_config
+        .full_node_networks
+        .iter_mut()
+        .map(|network_config| (RoleType::FullNode, network_config))
+        .collect();
+    if let Some(network_config) = node_config.validator_network.as_mut() {
+        network_configs.push((RoleType::Validator, network_config));
     }
 
-    for mut full_node_network in node_config.full_node_networks.iter_mut() {
-        let (runtime, mut network_builder) = setup_network(
-            &mut full_node_network,
-            RoleType::FullNode,
-            Arc::clone(&db_rw.reader),
-            waypoint,
-        );
+    let mut validator_count = 0;
+    // Instantiate every network.
+    for (role, network_config) in network_configs {
+        // Perform common instantiation steps
+        let (runtime, mut network_builder) =
+            setup_network(network_config, role, Arc::clone(&db_rw.reader), waypoint);
         let peer_id = network_builder.peer_id();
 
-        network_runtimes.push(runtime);
+        // Create the endpoints to connect the Network to StateSynchronizer.
         let (state_sync_sender, state_sync_events) =
             state_synchronizer::network::add_to_network(&mut network_builder);
         state_sync_network_handles.push((peer_id, state_sync_sender, state_sync_events));
+
+        // Create the endpoints to connect the network to MemPool.
         let (mempool_sender, mempool_events) = libra_mempool::network::add_to_network(
             &mut network_builder,
             node_config.mempool.max_broadcasts_per_peer,
         );
         mempool_network_handles.push((peer_id, mempool_sender, mempool_events));
 
-        // Start the network provider.
-        let _listen_addr = network_builder.build();
-        debug!("Network started for peer_id: {}", peer_id);
+        // Perform actions specific to a particular network type.
+        match role {
+            RoleType::Validator => {
+                validator_count += 1;
+                // A valid config is allowed to have exactly one ValidatorNetwork
+                assert_eq!(1, validator_count);
+                // Set up to listen for network configuration changes from StateSync.
+                if let Some(conn_mgr_reqs_tx) = network_builder.conn_mgr_reqs_tx() {
+                    let (simple_discovery_reconfig_subscription, simple_discovery_reconfig_rx) =
+                        gen_simple_discovery_reconfig_subscription();
+                    reconfig_subscriptions.push(simple_discovery_reconfig_subscription);
+                    let network_config_listener =
+                        ConfigurationChangeListener::new(conn_mgr_reqs_tx, RoleType::Validator);
+                    runtime
+                        .handle()
+                        .spawn(network_config_listener.start(simple_discovery_reconfig_rx));
+                };
+
+                // Cache the network information to be started later.
+                validator_network_provider = Some((peer_id, runtime, network_builder));
+            }
+            RoleType::FullNode => {
+                // Cache the runtime so it does not go out of scope immediately.
+                network_runtimes.push(runtime);
+
+                // Start the network provider.  FullNode networks can operate silently.3
+                let _listen_addr = network_builder.build();
+                debug!("Network started for peer_id: {}", peer_id);
+            }
+        }
     }
 
     // TODO set up on-chain discovery network based on UpstreamConfig.fallback_network

--- a/libra-node/src/main_node.rs
+++ b/libra-node/src/main_node.rs
@@ -264,7 +264,6 @@ pub fn setup_environment(node_config: &mut NodeConfig) -> LibraHandle {
         network_configs.push((RoleType::Validator, network_config));
     }
 
-    let mut validator_count = 0;
     // Instantiate every network and collect the requisite endpoints for state_sync, mempool, and consensus.
     for (role, network_config) in network_configs {
         // Perform common instantiation steps
@@ -287,9 +286,12 @@ pub fn setup_environment(node_config: &mut NodeConfig) -> LibraHandle {
         match role {
             // Perform steps relevant specifically to Validator networks.
             RoleType::Validator => {
-                validator_count += 1;
-                // A valid config is allowed to have exactly one ValidatorNetwork
-                assert_eq!(1, validator_count);
+                // A valid config is allowed to have at most one ValidatorNetwork
+                // TODO:  `expect_none` would be perfect here, once it is stable.
+                if consensus_network_handles.is_some() {
+                    panic!("There can be at most one validator network!");
+                }
+
                 // Set up to listen for network configuration changes from StateSync.
                 // TODO:  move this inside network_builder.
                 if let Some(conn_mgr_reqs_tx) = network_builder.conn_mgr_reqs_tx() {


### PR DESCRIPTION
<!--
Thank you for sending a PR. We appreciate you spending time to help improve the Libra project.

The project is undergoing daily changes. Pull Requests will be reviewed and responded to as time permits.
-->

## Motivation

Simplify main_node by eliminating code redundancies and streamlining the steps for constructing a libra node.

This is an isolated baby step along the path to a simpler main_node/network_builder endgoal.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?

yes
## Test Plan

don't break existing integration/unit tests.

## Related PRs

(If this PR adds or changes functionality, please take some time to update the docs at https://github.com/libra/website, and link to your PR here.)
