### PR TITLE
[move source language] Added inner scope uses

### DIFF
--- a/language/move-lang/src/parser/ast.rs
+++ b/language/move-lang/src/parser/ast.rs
@@ -504,7 +504,7 @@ pub type Exp = Spanned<Exp_>;
 // { e1; ... ; en }
 // { e1; ... ; en; }
 // The Loc field holds the source location of the final semicolon, if there is one.
-pub type Sequence = (Vec<SequenceItem>, Option<Loc>, Box<Option<Exp>>);
+pub type Sequence = (Vec<Use>, Vec<SequenceItem>, Option<Loc>, Box<Option<Exp>>);
 #[derive(Debug, PartialEq)]
 #[allow(clippy::large_enum_variant)]
 pub enum SequenceItem_ {
@@ -1133,9 +1133,13 @@ impl AstDebug for ModuleAccess_ {
     }
 }
 
-impl AstDebug for (Vec<SequenceItem>, Option<Loc>, Box<Option<Exp>>) {
+impl AstDebug for (Vec<Use>, Vec<SequenceItem>, Option<Loc>, Box<Option<Exp>>) {
     fn ast_debug(&self, w: &mut AstWriter) {
-        let (seq, _, last_e) = self;
+        let (uses, seq, _, last_e) = self;
+        for u in uses {
+            u.ast_debug(w);
+            w.new_line();
+        }
         w.semicolon(seq, |w, item| item.ast_debug(w));
         if !seq.is_empty() {
             w.writeln(";")

--- a/language/move-lang/src/parser/syntax.rs
+++ b/language/move-lang/src/parser/syntax.rs
@@ -544,11 +544,16 @@ fn parse_sequence_item<'input>(tokens: &mut Lexer<'input>) -> Result<SequenceIte
 }
 
 // Parse a sequence:
-//      Sequence = (<SequenceItem> ";")* <Exp>? "}"
+//      Sequence = <UseDecl>* (<SequenceItem> ";")* <Exp>? "}"
 //
 // Note that this does not include the opening brace of a block but it
 // does consume the closing right brace.
 fn parse_sequence<'input>(tokens: &mut Lexer<'input>) -> Result<Sequence, Error> {
+    let mut uses = vec![];
+    while tokens.peek() == Tok::Use {
+        uses.push(parse_use_decl(tokens)?);
+    }
+
     let mut seq: Vec<SequenceItem> = vec![];
     let mut last_semicolon_loc = None;
     let mut eopt = None;
@@ -573,7 +578,7 @@ fn parse_sequence<'input>(tokens: &mut Lexer<'input>) -> Result<Sequence, Error>
         consume_token(tokens, Tok::Semicolon)?;
     }
     tokens.advance()?; // consume the RBrace
-    Ok((seq, last_semicolon_loc, Box::new(eopt)))
+    Ok((uses, seq, last_semicolon_loc, Box::new(eopt)))
 }
 
 //**************************************************************************************************

--- a/language/move-lang/tests/move_check/expansion/use_inner_scope.move
+++ b/language/move-lang/tests/move_check/expansion/use_inner_scope.move
@@ -1,0 +1,27 @@
+address 0x1 {
+module M {
+    struct S1 { b: bool }
+    struct S2 { u: u64 }
+    fun check(): bool {
+        false
+    }
+    fun num(): u64 {
+        0
+    }
+
+    fun t() {
+        use 0x1::M::{check as num, num as check, S1 as S2, S2 as S1};
+        num() && false;
+        check() + 1;
+        S1 { u: 0 };
+        S2 { b: false };
+        {
+            use 0x1::M::{check, num, S1, S2};
+            check() && false;
+            num() + 1;
+            S2 { u: 0 };
+            S1 { b: false };
+        }
+    }
+}
+}

--- a/language/move-lang/tests/move_check/expansion/use_inner_scope_duplicates.exp
+++ b/language/move-lang/tests/move_check/expansion/use_inner_scope_duplicates.exp
@@ -1,0 +1,38 @@
+error: 
+
+    ┌── tests/move_check/expansion/use_inner_scope_duplicates.move:13:43 ───
+    │
+ 13 │         use 0x1::M::{check as foo, num as foo};
+    │                                           ^^^ Duplicate module member or alias 'foo'. Top level names in a namespace must be unique
+    ·
+ 13 │         use 0x1::M::{check as foo, num as foo};
+    │                               --- Previously defined here
+    │
+
+error: 
+
+    ┌── tests/move_check/expansion/use_inner_scope_duplicates.move:13:43 ───
+    │
+ 13 │         use 0x1::M::{check as foo, num as foo};
+    │                                           ^^^ Unused 'use' of alias 'foo'. Consider removing it
+    │
+
+error: 
+
+    ┌── tests/move_check/expansion/use_inner_scope_duplicates.move:15:23 ───
+    │
+ 15 │         use 0x1::M as N;
+    │                       ^ Duplicate module alias 'N'. Module aliases must be unique within a given namespace
+    ·
+ 14 │         use 0x1::M as N;
+    │                       - Previously defined here
+    │
+
+error: 
+
+    ┌── tests/move_check/expansion/use_inner_scope_duplicates.move:15:23 ───
+    │
+ 15 │         use 0x1::M as N;
+    │                       ^ Unused 'use' of alias 'N'. Consider removing it
+    │
+

--- a/language/move-lang/tests/move_check/expansion/use_inner_scope_duplicates.move
+++ b/language/move-lang/tests/move_check/expansion/use_inner_scope_duplicates.move
@@ -1,0 +1,19 @@
+address 0x1 {
+module M {
+    struct S1 { b: bool }
+    struct S2 { u: u64 }
+    fun check(): bool {
+        false
+    }
+    fun num(): u64 {
+        0
+    }
+
+    fun t() {
+        use 0x1::M::{check as foo, num as foo};
+        use 0x1::M as N;
+        use 0x1::M as N;
+
+    }
+}
+}

--- a/language/move-lang/tests/move_check/expansion/use_inner_scope_invalid.exp
+++ b/language/move-lang/tests/move_check/expansion/use_inner_scope_invalid.exp
@@ -1,0 +1,24 @@
+error: 
+
+    ┌── tests/move_check/expansion/use_inner_scope_invalid.move:17:23 ───
+    │
+ 17 │         use 0x1::M as Self;
+    │                       ^^^^ Invalid module alias name 'Self'. 'Self' is restricted and cannot be used to name a module alias
+    │
+
+error: 
+
+    ┌── tests/move_check/expansion/use_inner_scope_invalid.move:18:28 ───
+    │
+ 18 │         use 0x1::M::{S1 as s1, Foo as foo};
+    │                            ^^ Invalid struct alias name 's1'. Struct alias names must start with 'A'..'Z'
+    │
+
+error: 
+
+    ┌── tests/move_check/expansion/use_inner_scope_invalid.move:18:39 ───
+    │
+ 18 │         use 0x1::M::{S1 as s1, Foo as foo};
+    │                                       ^^^ Invalid schema alias name 'foo'. Schema alias names must start with 'A'..'Z'
+    │
+

--- a/language/move-lang/tests/move_check/expansion/use_inner_scope_invalid.move
+++ b/language/move-lang/tests/move_check/expansion/use_inner_scope_invalid.move
@@ -1,0 +1,22 @@
+address 0x1 {
+module M {
+    struct S1 { b: bool }
+    struct S2 { u: u64 }
+    fun check(): bool {
+        false
+    }
+    fun num(): u64 {
+        0
+    }
+
+    spec schema Foo<T> {
+        ensures true;
+    }
+
+    fun t() {
+        use 0x1::M as Self;
+        use 0x1::M::{S1 as s1, Foo as foo};
+
+    }
+}
+}

--- a/language/move-lang/tests/move_check/expansion/use_inner_scope_shadows.move
+++ b/language/move-lang/tests/move_check/expansion/use_inner_scope_shadows.move
@@ -1,0 +1,42 @@
+address 0x1 {
+module M {
+    struct S1 { b: bool }
+    struct S2 { u: u64 }
+    struct S3 { a: address }
+    fun check(): bool {
+        false
+    }
+    fun num(u: u64): u64 {
+        u + 1
+    }
+    spec schema Foo<T> {
+        ensures true;
+    }
+
+    fun t<T>(): S3 {
+        use 0x1::M::{check as num, num as t, S1 as S2, S2 as Foo, S3 as T};
+        num() && true;
+        t(0) + 1;
+        S2 { b: false };
+        Foo { u: 0 };
+        T { a: 0x0 }
+    }
+
+    fun t2<T>(x: T) {
+        {
+            use 0x1::M::{check as num, num as t, S1 as S2, S2 as Foo, S3 as T};
+            num() && true;
+            t(0) + 1;
+            S2 { b: false };
+            Foo { u: 0 };
+            T { a: 0x0 }
+        };
+        check() && true;
+        num(0) + 1;
+        t2<T>(x);
+        S1 { b: false };
+        S2 { u: 0 };
+        S3 { a: 0x0 };
+    }
+}
+}

--- a/language/move-lang/tests/move_check/expansion/use_inner_scope_unbound.exp
+++ b/language/move-lang/tests/move_check/expansion/use_inner_scope_unbound.exp
@@ -1,0 +1,19 @@
+error: 
+
+    ┌── tests/move_check/expansion/use_inner_scope_unbound.move:13:13 ───
+    │
+ 13 │         use 0x1::N;
+    │             ^^^^^^ Invalid 'use'. Unbound module: '0x1::N'
+    │
+
+error: 
+
+    ┌── tests/move_check/expansion/use_inner_scope_unbound.move:14:21 ───
+    │
+ 14 │         use 0x1::M::foo;
+    │                     ^^^ Invalid 'use'. Unbound member 'foo' in module '0x1::M'
+    ·
+  2 │ module M {
+    │        - Module '0x1::M' declared here
+    │
+

--- a/language/move-lang/tests/move_check/expansion/use_inner_scope_unbound.move
+++ b/language/move-lang/tests/move_check/expansion/use_inner_scope_unbound.move
@@ -1,0 +1,18 @@
+address 0x1 {
+module M {
+    struct S1 { b: bool }
+    struct S2 { u: u64 }
+    fun check(): bool {
+        false
+    }
+    fun num(): u64 {
+        0
+    }
+
+    fun t() {
+        use 0x1::N;
+        use 0x1::M::foo;
+
+    }
+}
+}

--- a/language/move-lang/tests/move_check/expansion/use_inner_scope_unused.exp
+++ b/language/move-lang/tests/move_check/expansion/use_inner_scope_unused.exp
@@ -1,0 +1,24 @@
+error: 
+
+    ┌── tests/move_check/expansion/use_inner_scope_unused.move:13:23 ───
+    │
+ 13 │         use 0x1::M as X;
+    │                       ^ Unused 'use' of alias 'X'. Consider removing it
+    │
+
+error: 
+
+    ┌── tests/move_check/expansion/use_inner_scope_unused.move:14:31 ───
+    │
+ 14 │         use 0x1::M::{check as f, S1 as S8};
+    │                               ^ Unused 'use' of alias 'f'. Consider removing it
+    │
+
+error: 
+
+    ┌── tests/move_check/expansion/use_inner_scope_unused.move:14:40 ───
+    │
+ 14 │         use 0x1::M::{check as f, S1 as S8};
+    │                                        ^^ Unused 'use' of alias 'S8'. Consider removing it
+    │
+

--- a/language/move-lang/tests/move_check/expansion/use_inner_scope_unused.move
+++ b/language/move-lang/tests/move_check/expansion/use_inner_scope_unused.move
@@ -1,0 +1,18 @@
+address 0x1 {
+module M {
+    struct S1 { b: bool }
+    struct S2 { u: u64 }
+    fun check(): bool {
+        false
+    }
+    fun num(): u64 {
+        0
+    }
+
+    fun t() {
+        use 0x1::M as X;
+        use 0x1::M::{check as f, S1 as S8};
+
+    }
+}
+}

--- a/language/move-lang/tests/move_check/parser/use_inner_scope.exp
+++ b/language/move-lang/tests/move_check/parser/use_inner_scope.exp
@@ -1,0 +1,128 @@
+error: 
+
+   ┌── tests/move_check/parser/use_inner_scope.move:5:13 ───
+   │
+ 5 │         use 0x1::Mango;
+   │             ^^^^^^^^^^ Invalid 'use'. Unbound module: '0x1::Mango'
+   │
+
+error: 
+
+   ┌── tests/move_check/parser/use_inner_scope.move:6:13 ───
+   │
+ 6 │         use 0x1::Mango as M;
+   │             ^^^^^^^^^^ Invalid 'use'. Unbound module: '0x1::Mango'
+   │
+
+error: 
+
+   ┌── tests/move_check/parser/use_inner_scope.move:7:13 ───
+   │
+ 7 │         use 0x1::Mango::baz;
+   │             ^^^^^^^^^^ Invalid 'use'. Unbound module: '0x1::Mango'
+   │
+
+error: 
+
+   ┌── tests/move_check/parser/use_inner_scope.move:8:13 ───
+   │
+ 8 │         use 0x1::Salsa::{Self, foo as bar, foo};
+   │             ^^^^^^^^^^ Invalid 'use'. Unbound module: '0x1::Salsa'
+   │
+
+error: 
+
+    ┌── tests/move_check/parser/use_inner_scope.move:10:17 ───
+    │
+ 10 │             use 0x1::Mango;
+    │                 ^^^^^^^^^^ Invalid 'use'. Unbound module: '0x1::Mango'
+    │
+
+error: 
+
+    ┌── tests/move_check/parser/use_inner_scope.move:11:17 ───
+    │
+ 11 │             use 0x2::Mango as M;
+    │                 ^^^^^^^^^^ Invalid 'use'. Unbound module: '0x2::Mango'
+    │
+
+error: 
+
+    ┌── tests/move_check/parser/use_inner_scope.move:12:17 ───
+    │
+ 12 │             use 0x2::Mango::baz;
+    │                 ^^^^^^^^^^ Invalid 'use'. Unbound module: '0x2::Mango'
+    │
+
+error: 
+
+    ┌── tests/move_check/parser/use_inner_scope.move:13:17 ───
+    │
+ 13 │             use 0x2::Salsa::{Self, foo as bar, foo};
+    │                 ^^^^^^^^^^ Invalid 'use'. Unbound module: '0x2::Salsa'
+    │
+
+error: 
+
+    ┌── tests/move_check/parser/use_inner_scope.move:27:53 ───
+    │
+ 27 │                                                 use 0x1::Mango;
+    │                                                     ^^^^^^^^^^ Invalid 'use'. Unbound module: '0x1::Mango'
+    │
+
+error: 
+
+    ┌── tests/move_check/parser/use_inner_scope.move:28:53 ───
+    │
+ 28 │                                                 use 0x2::Mango as M;
+    │                                                     ^^^^^^^^^^ Invalid 'use'. Unbound module: '0x2::Mango'
+    │
+
+error: 
+
+    ┌── tests/move_check/parser/use_inner_scope.move:29:53 ───
+    │
+ 29 │                                                 use 0x2::Mango::baz;
+    │                                                     ^^^^^^^^^^ Invalid 'use'. Unbound module: '0x2::Mango'
+    │
+
+error: 
+
+    ┌── tests/move_check/parser/use_inner_scope.move:30:53 ───
+    │
+ 30 │                                                 use 0x2::Salsa::{Self, foo as bar, foo};
+    │                                                     ^^^^^^^^^^ Invalid 'use'. Unbound module: '0x2::Salsa'
+    │
+
+error: 
+
+    ┌── tests/move_check/parser/use_inner_scope.move:43:17 ───
+    │
+ 43 │             use 0x1::Mango;
+    │                 ^^^^^^^^^^ Invalid 'use'. Unbound module: '0x1::Mango'
+    │
+
+error: 
+
+    ┌── tests/move_check/parser/use_inner_scope.move:44:17 ───
+    │
+ 44 │             use 0x2::Mango as M;
+    │                 ^^^^^^^^^^ Invalid 'use'. Unbound module: '0x2::Mango'
+    │
+
+error: 
+
+    ┌── tests/move_check/parser/use_inner_scope.move:45:17 ───
+    │
+ 45 │             use 0x2::Mango::baz;
+    │                 ^^^^^^^^^^ Invalid 'use'. Unbound module: '0x2::Mango'
+    │
+
+error: 
+
+    ┌── tests/move_check/parser/use_inner_scope.move:46:17 ───
+    │
+ 46 │             use 0x2::Salsa::{Self, foo as bar, foo};
+    │                 ^^^^^^^^^^ Invalid 'use'. Unbound module: '0x2::Salsa'
+    │
+

--- a/language/move-lang/tests/move_check/parser/use_inner_scope.move
+++ b/language/move-lang/tests/move_check/parser/use_inner_scope.move
@@ -1,0 +1,51 @@
+address 0x1 {
+module M {
+
+    fun t() {
+        use 0x1::Mango;
+        use 0x1::Mango as M;
+        use 0x1::Mango::baz;
+        use 0x1::Salsa::{Self, foo as bar, foo};
+        let x = {
+            use 0x1::Mango;
+            use 0x2::Mango as M;
+            use 0x2::Mango::baz;
+            use 0x2::Salsa::{Self, foo as bar, foo};
+
+            0
+        };
+        {
+            {
+                {
+                    {
+                        {
+                            {
+                                {
+                                    {
+                                        {
+                                            {
+                                                use 0x1::Mango;
+                                                use 0x2::Mango as M;
+                                                use 0x2::Mango::baz;
+                                                use 0x2::Salsa::{Self, foo as bar, foo};
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        };
+
+        while (true) {
+            use 0x1::Mango;
+            use 0x2::Mango as M;
+            use 0x2::Mango::baz;
+            use 0x2::Salsa::{Self, foo as bar, foo};
+
+        }
+    }
+}
+}

--- a/language/move-lang/tests/move_check/parser/use_inner_scope_invalid.exp
+++ b/language/move-lang/tests/move_check/parser/use_inner_scope_invalid.exp
@@ -1,0 +1,11 @@
+error: 
+
+   ┌── tests/move_check/parser/use_inner_scope_invalid.move:6:9 ───
+   │
+ 6 │         use 0x0::M::foo;
+   │         ^^^ Unexpected 'use'
+   ·
+ 6 │         use 0x0::M::foo;
+   │         --- Expected an expression term
+   │
+

--- a/language/move-lang/tests/move_check/parser/use_inner_scope_invalid.move
+++ b/language/move-lang/tests/move_check/parser/use_inner_scope_invalid.move
@@ -1,0 +1,9 @@
+address 0x1 {
+module M {
+    fun t() {
+        let x = 0;
+
+        use 0x0::M::foo;
+        foo(x)
+    }
+}

--- a/language/move-lang/tests/move_check/parser/use_inner_scope_invalid_inner.exp
+++ b/language/move-lang/tests/move_check/parser/use_inner_scope_invalid_inner.exp
@@ -1,0 +1,11 @@
+error: 
+
+   ┌── tests/move_check/parser/use_inner_scope_invalid_inner.move:4:19 ───
+   │
+ 4 │         if (cond) use 0x1::M;
+   │                   ^^^ Unexpected 'use'
+   ·
+ 4 │         if (cond) use 0x1::M;
+   │                   --- Expected an expression term
+   │
+

--- a/language/move-lang/tests/move_check/parser/use_inner_scope_invalid_inner.move
+++ b/language/move-lang/tests/move_check/parser/use_inner_scope_invalid_inner.move
@@ -1,0 +1,6 @@
+address 0x1 {
+module M {
+    fun t() {
+        if (cond) use 0x1::M;
+    }
+}


### PR DESCRIPTION
- Can now add `use` declarations at the beginning of any expression block/sequence

## Motivation

- Useful for one-off alias

## Test Plan

- new tests
- cargo test