### PR TITLE
[network] filter ip's from DNS resolver according to protocol

### DIFF
--- a/network/netcore/src/transport/tcp.rs
+++ b/network/netcore/src/transport/tcp.rs
@@ -99,7 +99,8 @@ impl Transport for TcpTransport {
         // ensure addr is well formed to save some work before potentially
         // spawning a dial task that will fail anyway.
         // TODO(philiphayes): base tcp transport should not allow trailing protocols
-        None.or_else(|| parse_ip_tcp(protos).map(|_| ()))
+        parse_ip_tcp(protos)
+            .map(|_| ())
             .or_else(|| parse_dns_tcp(protos).map(|_| ()))
             .ok_or_else(|| invalid_addr_error(&addr))?;
 

--- a/network/netcore/src/transport/tcp.rs
+++ b/network/netcore/src/transport/tcp.rs
@@ -9,16 +9,17 @@ use futures::{
     ready,
     stream::Stream,
 };
-use libra_network_address::{parse_dns_tcp, parse_ip_tcp, NetworkAddress, Protocol};
+use libra_network_address::{parse_dns_tcp, parse_ip_tcp, IpFilter, NetworkAddress};
 use std::{
     convert::TryFrom,
     fmt::Debug,
     io,
+    net::SocketAddr,
     pin::Pin,
     task::{Context, Poll},
     time::Duration,
 };
-use tokio::net::{TcpListener, TcpStream};
+use tokio::net::{lookup_host, TcpListener, TcpStream};
 
 /// Transport to build TCP connections
 #[derive(Debug, Clone, Default)]
@@ -93,20 +94,76 @@ impl Transport for TcpTransport {
     }
 
     fn dial(&self, addr: NetworkAddress) -> Result<Self::Outbound, Self::Error> {
-        let (addr_string, _addr_suffix) =
-            parse_addr_and_port(addr.as_slice()).ok_or_else(|| invalid_addr_error(&addr))?;
+        let protos = addr.as_slice();
+
+        // ensure addr is well formed to save some work before potentially
+        // spawning a dial task that will fail anyway.
         // TODO(philiphayes): base tcp transport should not allow trailing protocols
-        // TODO(philiphayes): use `tokio::net::lookup_host()` then filter the results
-        // so e.g. `Protocol::Dns4` only returns `SocketAddrV4`s and `Protocol::Dns6`
-        // only returns `SocketAddrV6`.
+        None.or_else(|| parse_ip_tcp(protos).map(|_| ()))
+            .or_else(|| parse_dns_tcp(protos).map(|_| ()))
+            .ok_or_else(|| invalid_addr_error(&addr))?;
+
         let f: Pin<Box<dyn Future<Output = io::Result<TcpStream>> + Send + 'static>> =
-            Box::pin(TcpStream::connect(addr_string));
+            Box::pin(resolve_and_connect(addr));
 
         Ok(TcpOutbound {
             inner: f,
             config: self.clone(),
         })
     }
+}
+
+/// Try to lookup the dns name, then filter addrs according to the `IpFilter`.
+fn resolve_with_filter<'a>(
+    ip_filter: IpFilter,
+    dns_name: &'a str,
+    port: u16,
+) -> impl Future<Output = io::Result<impl Iterator<Item = SocketAddr> + 'a>> + 'a {
+    async move {
+        Ok(lookup_host((dns_name, port))
+            .await?
+            .filter(move |socketaddr| ip_filter.matches(socketaddr.ip())))
+    }
+}
+
+/// Note: we need to take ownership of this `NetworkAddress` (instead of just
+/// borrowing the `&[Protocol]` slice) so this future can be `Send + 'static`.
+async fn resolve_and_connect(addr: NetworkAddress) -> io::Result<TcpStream> {
+    let protos = addr.as_slice();
+
+    if let Some(((ipaddr, port), _addr_suffix)) = parse_ip_tcp(protos) {
+        // this is an /ip4 or /ip6 address, so we can just connect without any
+        // extra resolving or filtering.
+        TcpStream::connect((ipaddr, port)).await
+    } else if let Some(((ip_filter, dns_name, port), _addr_suffix)) = parse_dns_tcp(protos) {
+        // resolve dns name and filter
+        let socketaddr_iter = resolve_with_filter(ip_filter, dns_name.as_ref(), port).await?;
+        let mut last_err = None;
+
+        // try to connect until the first succeeds
+        for socketaddr in socketaddr_iter {
+            match TcpStream::connect(socketaddr).await {
+                Ok(stream) => return Ok(stream),
+                Err(err) => last_err = Some(err),
+            }
+        }
+
+        Err(last_err.unwrap_or_else(|| {
+            io::Error::new(
+                io::ErrorKind::InvalidInput,
+                "could not resolve to any address",
+            )
+        }))
+    } else {
+        Err(invalid_addr_error(&addr))
+    }
+}
+
+fn invalid_addr_error(addr: &NetworkAddress) -> io::Error {
+    io::Error::new(
+        io::ErrorKind::InvalidInput,
+        format!("Invalid NetworkAddress: '{}'", addr),
+    )
 }
 
 #[must_use = "streams do nothing unless polled"]
@@ -204,30 +261,16 @@ impl AsyncWrite for TcpSocket {
     }
 }
 
-fn invalid_addr_error(addr: &NetworkAddress) -> io::Error {
-    io::Error::new(
-        io::ErrorKind::InvalidInput,
-        format!("Invalid NetworkAddress: '{}'", addr),
-    )
-}
-
-fn parse_addr_and_port(protos: &[Protocol]) -> Option<(String, &[Protocol])> {
-    parse_ip_tcp(protos)
-        .map(|((ip, port), suffix)| (format!("{}:{}", ip, port), suffix))
-        .or_else(|| {
-            parse_dns_tcp(protos)
-                .map(|((dnsname, port), suffix)| (format!("{}:{}", dnsname, port), suffix))
-        })
-}
-
 #[cfg(test)]
 mod test {
-    use crate::transport::{tcp::TcpTransport, ConnectionOrigin, Transport, TransportExt};
+    use super::*;
+    use crate::transport::{ConnectionOrigin, Transport, TransportExt};
     use futures::{
         future::{join, FutureExt},
         io::{AsyncReadExt, AsyncWriteExt},
         stream::StreamExt,
     };
+    use tokio::runtime::Runtime;
 
     #[tokio::test]
     async fn simple_listen_and_dial() -> Result<(), ::std::io::Error> {
@@ -271,5 +314,38 @@ mod test {
 
         let result = t.dial("/memory/22".parse().unwrap());
         assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_resolve_with_filter() {
+        let mut rt = Runtime::new().unwrap();
+
+        // note: we only lookup "localhost", which is not really a DNS name, but
+        // should always resolve to something and keep this test from being flaky.
+
+        let f = async move {
+            // this should always return something
+            let addrs = resolve_with_filter(IpFilter::Any, "localhost", 1234)
+                .await
+                .unwrap()
+                .collect::<Vec<_>>();
+            assert!(!addrs.is_empty(), "addrs: {:?}", addrs);
+
+            // we should only get Ip4 addrs
+            let addrs = resolve_with_filter(IpFilter::OnlyIp4, "localhost", 1234)
+                .await
+                .unwrap()
+                .collect::<Vec<_>>();
+            assert!(addrs.iter().all(SocketAddr::is_ipv4), "addrs: {:?}", addrs);
+
+            // we should only get Ip6 addrs
+            let addrs = resolve_with_filter(IpFilter::OnlyIp6, "localhost", 1234)
+                .await
+                .unwrap()
+                .collect::<Vec<_>>();
+            assert!(addrs.iter().all(SocketAddr::is_ipv6), "addrs: {:?}", addrs);
+        };
+
+        rt.block_on(f);
     }
 }

--- a/network/netcore/src/transport/tcp.rs
+++ b/network/netcore/src/transport/tcp.rs
@@ -151,7 +151,11 @@ async fn resolve_and_connect(addr: NetworkAddress) -> io::Result<TcpStream> {
         Err(last_err.unwrap_or_else(|| {
             io::Error::new(
                 io::ErrorKind::InvalidInput,
-                "could not resolve to any address",
+                format!(
+                    "could not resolve dns name to any address: name: {}, ip filter: {:?}",
+                    dns_name.as_ref(),
+                    ip_filter,
+                ),
             )
         }))
     } else {

--- a/network/network-address/src/lib.rs
+++ b/network/network-address/src/lib.rs
@@ -773,8 +773,8 @@ fn parse_libranet_protos(protos: &[Protocol]) -> Option<&[Protocol]> {
     // <or> parse_dns_tcp
     // <or> cfg!(test) parse_memory
 
-    let transport_suffix = None
-        .or_else(|| parse_ip_tcp(protos).map(|x| x.1))
+    let transport_suffix = parse_ip_tcp(protos)
+        .map(|x| x.1)
         .or_else(|| parse_dns_tcp(protos).map(|x| x.1))
         .or_else(|| {
             if cfg!(test) {

--- a/network/network-address/src/lib.rs
+++ b/network/network-address/src/lib.rs
@@ -709,6 +709,7 @@ pub fn parse_ip_tcp(protos: &[Protocol]) -> Option<((IpAddr, u16), &[Protocol])>
     }
 }
 
+#[derive(Copy, Clone, Debug, Eq, PartialEq)]
 pub enum IpFilter {
     Any,
     OnlyIp4,
@@ -959,28 +960,28 @@ mod test {
         let expected_suffix: &[Protocol] = &[];
         assert_eq!(
             parse_dns_tcp(addr.as_slice()).unwrap(),
-            ((&dns_name, 123), expected_suffix)
+            ((IpFilter::Any, &dns_name, 123), expected_suffix)
         );
 
         let addr = NetworkAddress::from_str("/dns4/example.com/tcp/123").unwrap();
         let expected_suffix: &[Protocol] = &[];
         assert_eq!(
             parse_dns_tcp(addr.as_slice()).unwrap(),
-            ((&dns_name, 123), expected_suffix)
+            ((IpFilter::OnlyIp4, &dns_name, 123), expected_suffix)
         );
 
         let addr = NetworkAddress::from_str("/dns6/example.com/tcp/123").unwrap();
         let expected_suffix: &[Protocol] = &[];
         assert_eq!(
             parse_dns_tcp(addr.as_slice()).unwrap(),
-            ((&dns_name, 123), expected_suffix)
+            ((IpFilter::OnlyIp6, &dns_name, 123), expected_suffix)
         );
 
         let addr = NetworkAddress::from_str("/dns/example.com/tcp/123/memory/44").unwrap();
         let expected_suffix: &[Protocol] = &[Protocol::Memory(44)];
         assert_eq!(
             parse_dns_tcp(addr.as_slice()).unwrap(),
-            ((&dns_name, 123), expected_suffix)
+            ((IpFilter::Any, &dns_name, 123), expected_suffix)
         );
 
         let addr = NetworkAddress::from_str("/tcp/999/memory/123").unwrap();

--- a/network/src/transport.rs
+++ b/network/src/transport.rs
@@ -357,10 +357,10 @@ where
 
         // parse out the base transport protocol(s), which we will just ignore
         // and leave for the base_transport to actually parse and dial.
-        let (base_transport_protos, base_transport_suffix) = None
-            // TODO(philiphayes): protos[..X] is kinda hacky. `Transport` trait
-            // should handle this.
-            .or_else(|| parse_ip_tcp(protos).map(|x| (&protos[..2], x.1)))
+        // TODO(philiphayes): protos[..X] is kinda hacky. `Transport` trait
+        // should handle this.
+        let (base_transport_protos, base_transport_suffix) = parse_ip_tcp(protos)
+            .map(|x| (&protos[..2], x.1))
             .or_else(|| parse_dns_tcp(protos).map(|x| (&protos[..2], x.1)))
             .or_else(|| parse_memory(protos).map(|x| (&protos[..1], x.1)))
             .ok_or_else(|| {


### PR DESCRIPTION
`NetworkAddress` allows us to advertise a dns name but restrict a dialer
to only connect over IPv4 or IPv6. This diff actually enforces this
distinction in our tcp dialing logic, so we will never accidentally
connect over IPv4 if the address only allows IPv6 (and vice versa).

For example, dialing `"/dns4/example.com/tcp/8080"` will now only ever
connect over IPv4 and likewise for `"/dns6/example.com/tcp/8080"`.

Of course, if the address advertiser doesn't care (or supports both
protocols), we continue to support `"/dns/example.com/tcp/8080"`, which
does no filtering and will use whatever resolved SocketAddr that works
first.

Closes: #1200