### PR TITLE
[move-prover] Specified Offer.move.

### DIFF
--- a/language/stdlib/modules/Offer.move
+++ b/language/stdlib/modules/Offer.move
@@ -35,6 +35,97 @@ module Offer {
   public fun address_of<Offered>(offer_address: address): address acquires T {
     borrow_global<T<Offered>>(offer_address).for
   }
+
+  // **************** SPECIFICATIONS ****************
+
+  /*
+  This module defines a resource T that is used as a permissioned trading scheme between accounts.
+  It defines two main functions for creating and retrieving a struct offered by some user
+  inside the resource T under the offerer's account.
+
+  Currently, the only other module that depends on this module is LibraConfig, where it's used to
+  pass a capability to an account that allows it to modify a config.
+  */
+
+  /// # Module specification
+
+  spec module {
+    /// Verify all functions in this module
+    pragma verify = true;
+    /// Helper function that returns whether or not the `recipient` is an intended 
+    /// recipient of the offered struct in the T<Offered> resource at the address `offer_address`
+    define is_offer_recipient<Offered>(offer_addr: address, recipient: address): bool {
+      recipient == global<T<Offered>>(offer_addr).for || recipient == offer_addr
+    }
+  }
+
+  // Switch documentation context back to module level.
+  spec module {}
+
+  /// ## Creation of Offers
+
+  spec schema OnlyCreateCanCreateOffer {
+    /// Only `Self::create` can create an Offer.T under an address.
+    ///
+    /// **Informally:** No function can create an offer. If there didn't
+    /// exist an Offer under some `addr`, then it continues not to have one. 
+    ensures all(domain<type>(), |ty|
+              all(domain<address>(), |addr|
+                !old(exists<T<ty>>(addr)) ==> !exists<T<ty>>(addr)));
+  }
+  spec module {
+    /// Apply OnlyCreateCanCreateOffer
+    apply OnlyCreateCanCreateOffer to *<Offered>, * except create;
+  }
+  spec fun create {
+    /// Offer a struct to the account under address `for` by 
+    /// placing the Offer under the signer's address
+    aborts_if exists<T<Offered>>(Signer::get_address(account));
+    ensures exists<T<Offered>>(Signer::get_address(account));
+    ensures global<T<Offered>>(Signer::get_address(account)) == T<Offered> { offered: offered, for: for };
+  }
+
+  // Switch documentation context back to module level.
+  spec module {}
+
+  /// ## Removal of Offers
+
+  spec schema OnlyRedeemCanRemoveOffer {
+    /// Only `Self::redeem` can remove an Offer.T.
+    ///
+    /// **Informally:** No other function except for `redeem` can remove an Offer from an account
+    ensures all(domain<type>(), |ty|
+              all(domain<address>(), |addr|
+                old(exists<T<ty>>(addr)) ==>
+                  (exists<T<ty>>(addr) &&
+                    old(global<T<ty>>(addr)) == global<T<ty>>(addr))));
+  }
+  spec module {
+    /// Show that every function except `Self::redeem` can remove an Offer.T from the global store
+    apply OnlyRedeemCanRemoveOffer to *<Offered>, * except redeem;
+  }
+  spec fun redeem {
+    /// **Informally:** Redeems an offer (T) under the account at `offer_address`
+    aborts_if !exists<T<Offered>>(offer_address);
+    aborts_if !is_offer_recipient<Offered>(offer_address, Signer::get_address(account));
+    ensures old(exists<T<Offered>>(offer_address)) && !exists<T<Offered>>(offer_address);
+    ensures result == old(global<T<Offered>>(offer_address).offered);
+  }
+
+  // Switch documentation context back to module level.
+  spec module {}
+
+  spec fun exists_at {
+    /// Returns whether or not an offer (T) is under the given address `offer_address`
+    ensures result == exists<T<Offered>>(offer_address);
+  }
+
+  spec fun address_of {
+    /// Returns the address of the intended recipient of the Offer under 
+    /// the `offer_address` if one exists
+    aborts_if !exists<T<Offered>>(offer_address);
+    ensures result == global<T<Offered>>(offer_address).for;
+  }
 }
 
 }


### PR DESCRIPTION
Wrote functional specifications for all four functions and
two global specifications to restrict creation and removal of
Offer.T resources to the create and remove functions.

Additional notes: In an earlier implementation, I was able to write
a more general property that states that only the sender or the intended
recipient (i.e. Offer<T<Offered>>.for) of an Offer could receive the
offered struct (refer to the properties below). This would allow
for additional functions that change the Offer to be implemented without
changing the specification (e.g. if an update offer function is
implemented).

```
/// **Informally:** If the Offer is removed from an address, then the sender
///                 must be the intended recipient
ensures all(domain<address>(), |addr|
  (old(exists<T<Offered>>(addr)) && !exists<T<Offered>>(addr)) ==>
  (old(sender_is_offer_recipient<Offered>(addr))));
/// **Informally:** An offer under an account is unchanged if it is not the sender's
///                 account or if the sender is not the recipient
ensures all(domain<address>(), |addr|
  (old(exists<T<Offered>>(addr)) && old(!sender_is_offer_recipient<Offered>(addr))) ==>
  (exists<T<Offered>>(addr) && old(global<T<Offered>>(addr)) == global<T<Offered>>(addr)));
/// **Informally:** An offer under an account is unchanged if the intended
///                 recipient does not redeem it
ensures all(domain<address>(), |addr|
  (old(exists<T<Offered>>(addr)) && exists<T<Offered>>(addr)) ==>
  (old(global<T<Offered>>(addr)) == global<T<Offered>>(addr)));
```

However, with the introduction of signers the property is false
without the precondition / assumption that the signer is the sender,

<!--
Thank you for sending a PR. We appreciate you spending time to help improve the Libra project.

The project is undergoing daily changes. Pull Requests will be reviewed and responded to as time permits.
-->

## Motivation

First draft of formal specifications for functional and global properties of the Offer module. 
 
### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?

Yes.

## Test Plan

Current test suite. 

To verify the specifications, run the following command at the move-prover directory:

```
cargo run -- --verbose debug ../stdlib/modules/transaction.move ../stdlib/modules/Signer.move ../stdlib/modules/Offer.move
```

## Related PRs

None.
