### PR TITLE
[cluster-test] Support --health-check in swarm mode

### DIFF
--- a/testsuite/cluster-test/src/cluster.rs
+++ b/testsuite/cluster-test/src/cluster.rs
@@ -23,7 +23,7 @@ pub struct Cluster {
 }
 
 impl Cluster {
-    pub fn from_host_port(peers: Vec<(String, u32)>, mint_file: &str) -> Self {
+    pub fn from_host_port(peers: Vec<(String, u32, Option<u32>)>, mint_file: &str) -> Self {
         let instances: Vec<Instance> = peers
             .into_iter()
             .map(|host_port| {
@@ -31,6 +31,7 @@ impl Cluster {
                     format!("{}:{}", &host_port.0, host_port.1), /* short_hash */
                     host_port.0,
                     host_port.1,
+                    host_port.2,
                 )
             })
             .collect();

--- a/testsuite/cluster-test/src/health/debug_interface_log_tail.rs
+++ b/testsuite/cluster-test/src/health/debug_interface_log_tail.rs
@@ -42,7 +42,11 @@ impl DebugPortLogThread {
         for instance in cluster.all_instances() {
             let (started_sender, started_receiver) = mpsc::channel();
             started_receivers.push(started_receiver);
-            let client = NodeDebugClient::new(instance.ip(), 6191);
+            let debug_interface_port = instance
+                .debug_interface_port()
+                .expect("Debug interface port is not found")
+                as u16;
+            let client = NodeDebugClient::new(instance.ip(), debug_interface_port);
             let debug_port_log_thread = DebugPortLogThread {
                 instance: instance.clone(),
                 client,

--- a/testsuite/cluster-test/src/instance.rs
+++ b/testsuite/cluster-test/src/instance.rs
@@ -4,6 +4,7 @@
 #![forbid(unsafe_code)]
 
 use anyhow::{ensure, format_err, Result};
+use libra_config::config::NodeConfig;
 use libra_json_rpc_client::{JsonRpcAsyncClient, JsonRpcBatch};
 use once_cell::sync::Lazy;
 use regex::Regex;
@@ -46,16 +47,23 @@ pub struct Instance {
     ac_port: u32,
     k8s_node: Option<String>,
     instance_config: Option<InstanceConfig>,
+    debug_interface_port: Option<u32>,
 }
 
 impl Instance {
-    pub fn new(peer_name: String, ip: String, ac_port: u32) -> Instance {
+    pub fn new(
+        peer_name: String,
+        ip: String,
+        ac_port: u32,
+        debug_interface_port: Option<u32>,
+    ) -> Instance {
         Instance {
             peer_name,
             ip,
             ac_port,
             k8s_node: None,
             instance_config: None,
+            debug_interface_port,
         }
     }
 
@@ -72,6 +80,11 @@ impl Instance {
             ac_port,
             k8s_node,
             instance_config: Some(instance_config),
+            debug_interface_port: Some(
+                NodeConfig::default()
+                    .debug_interface
+                    .admission_control_node_debug_port as u32,
+            ),
         }
     }
 
@@ -211,6 +224,10 @@ impl Instance {
 
     pub fn instance_config(&self) -> Option<&InstanceConfig> {
         self.instance_config.as_ref()
+    }
+
+    pub fn debug_interface_port(&self) -> Option<u32> {
+        self.debug_interface_port
     }
 }
 

--- a/testsuite/libra-swarm/src/main.rs
+++ b/testsuite/libra-swarm/src/main.rs
@@ -98,20 +98,35 @@ fn main() {
         waypoint,
     );
 
-    let node_address_list = validator_swarm
-        .config
-        .config_files
-        .iter()
-        .map(|config| {
-            let port = NodeConfig::load(config).unwrap().rpc.address.port();
-            format!("localhost:{}", port)
-        })
+    let ports = validator_swarm.config.config_files.iter().map(|config| {
+        let validator_config = NodeConfig::load(config).unwrap();
+        let port = validator_config.rpc.address.port();
+        let debug_interface_port = validator_config
+            .debug_interface
+            .admission_control_node_debug_port;
+        (port, debug_interface_port)
+    });
+
+    let node_address_list = ports
+        .clone()
+        .map(|port| format!("localhost:{}", port.0))
         .collect::<Vec<String>>()
         .join(",");
 
     println!("To run transaction generator run:");
     println!(
         "\tcargo run -p cluster-test -- --mint-file {:?} --swarm --peers {:?} --emit-tx --workers-per-ac 1",
+        faucet_key_file_path, node_address_list,
+    );
+
+    let node_address_list = ports
+        .map(|port| format!("localhost:{}:{}", port.0, port.1))
+        .collect::<Vec<String>>()
+        .join(",");
+
+    println!("To run health check:");
+    println!(
+        "\tcargo run -p cluster-test -- --mint-file {:?} --swarm --peers {:?} --health-check --duration 30",
         faucet_key_file_path, node_address_list,
     );
 


### PR DESCRIPTION
Closes: #4065
Manually test cargo run -p libra-swarm and cargo run -p cluster-test --swarm --peers <as printed by libra swarm> --health-check --duration 10. Also rechecked ./scripts/cti --pr <your PR> --health-check --duration 10 in normal (aws) mode.