### PR TITLE
[move-prover] Specified Offer.move.

### DIFF
--- a/language/stdlib/modules/Offer.move
+++ b/language/stdlib/modules/Offer.move
@@ -35,6 +35,96 @@ module Offer {
   public fun address_of<Offered>(offer_address: address): address acquires Offer {
     borrow_global<Offer<Offered>>(offer_address).for
   }
+
+  // **************** SPECIFICATIONS ****************
+
+  /*
+  This module defines a resource T that is used as a permissioned trading scheme between accounts.
+  It defines two main functions for creating and retrieving a struct offered by some user
+  inside the resource T under the offerer's account.
+
+  Currently, the only other module that depends on this module is LibraConfig, where it's used to
+  pass a capability to an account that allows it to modify a config.
+  */
+
+  /// # Module specification
+
+  spec module {
+    /// Verify all functions in this module
+    pragma verify = true;
+    /// Helper function that returns whether or not the `recipient` is an intended
+    /// recipient of the offered struct in the T<Offered> resource at the address `offer_address`
+    define is_offer_recipient<Offered>(offer_addr: address, recipient: address): bool {
+      recipient == global<T<Offered>>(offer_addr).for || recipient == offer_addr
+    }
+  }
+
+  // Switch documentation context back to module level.
+  spec module {}
+
+  /// ## Creation of Offers
+
+  spec schema OnlyCreateCanCreateOffer {
+    /// Only `Self::create` can create an Offer.T under an address.
+    ///
+    /// **Informally:** No function can create an offer. If there didn't
+    /// exist an Offer under some `addr`, then it continues not to have one.
+    ensures all(domain<type>(), |ty|
+              all(domain<address>(), |addr|
+                !old(exists<T<ty>>(addr)) ==> !exists<T<ty>>(addr)));
+  }
+  spec module {
+    /// Apply OnlyCreateCanCreateOffer
+    apply OnlyCreateCanCreateOffer to *<Offered>, * except create;
+  }
+  spec fun create {
+    /// Offer a struct to the account under address `for` by
+    /// placing the Offer under the signer's address
+    aborts_if exists<T<Offered>>(Signer::get_address(account));
+    ensures exists<T<Offered>>(Signer::get_address(account));
+    ensures global<T<Offered>>(Signer::get_address(account)) == T<Offered> { offered: offered, for: for };
+  }
+
+  // Switch documentation context back to module level.
+  spec module {}
+
+  /// ## Removal of Offers
+
+  spec schema OnlyRedeemCanRemoveOffer {
+    /// Only `Self::redeem` can remove an Offer.T.
+    ///
+    /// **Informally:** No other function except for `redeem` can remove an Offer from an account
+    ensures all(domain<type>(), |ty|
+              all(domain<address>(), |addr|
+                old(exists<T<ty>>(addr))
+                  ==> (exists<T<ty>>(addr) && old(global<T<ty>>(addr)) == global<T<ty>>(addr))));
+  }
+  spec module {
+    /// Show that every function except `Self::redeem` can remove an Offer.T from the global store
+    apply OnlyRedeemCanRemoveOffer to *<Offered>, * except redeem;
+  }
+  spec fun redeem {
+    /// **Informally:** Redeems an offer (T) under the account at `offer_address`
+    aborts_if !exists<T<Offered>>(offer_address);
+    aborts_if !is_offer_recipient<Offered>(offer_address, Signer::get_address(account));
+    ensures old(exists<T<Offered>>(offer_address)) && !exists<T<Offered>>(offer_address);
+    ensures result == old(global<T<Offered>>(offer_address).offered);
+  }
+
+  // Switch documentation context back to module level.
+  spec module {}
+
+  spec fun exists_at {
+    /// Returns whether or not an offer (T) is under the given address `offer_address`
+    ensures result == exists<T<Offered>>(offer_address);
+  }
+
+  spec fun address_of {
+    /// Returns the address of the intended recipient of the Offer under
+    /// the `offer_address` if one exists
+    aborts_if !exists<T<Offered>>(offer_address);
+    ensures result == global<T<Offered>>(offer_address).for;
+  }
 }
 
 }

--- a/language/stdlib/modules/doc/Offer.md
+++ b/language/stdlib/modules/doc/Offer.md
@@ -10,6 +10,14 @@
 -  [Function `redeem`](#0x0_Offer_redeem)
 -  [Function `exists_at`](#0x0_Offer_exists_at)
 -  [Function `address_of`](#0x0_Offer_address_of)
+-  [Specification](#0x0_Offer_Specification)
+    -  [Module specification](#0x0_Offer_@Module_specification)
+        -  [Creation of Offers](#0x0_Offer_@Creation_of_Offers)
+        -  [Removal of Offers](#0x0_Offer_@Removal_of_Offers)
+    -  [Function `create`](#0x0_Offer_Specification_create)
+    -  [Function `redeem`](#0x0_Offer_Specification_redeem)
+    -  [Function `exists_at`](#0x0_Offer_Specification_exists_at)
+    -  [Function `address_of`](#0x0_Offer_Specification_address_of)
 
 
 
@@ -147,3 +155,208 @@
 
 
 </details>
+
+<a name="0x0_Offer_Specification"></a>
+
+## Specification
+
+
+<a name="0x0_Offer_@Module_specification"></a>
+
+### Module specification
+
+
+This module defines a resource
+<code><a href="#0x0_Offer">Offer</a></code> that is used as a permissioned trading scheme between accounts.
+It defines two main functions for creating and retrieving a struct offered by some user
+inside the resource
+<code><a href="#0x0_Offer">Offer</a></code> under the offerer's account.
+
+Currently, the only other module that depends on this module is LibraConfig, where it's used to
+pass a capability to an account that allows it to modify a config.
+
+
+Verify all functions in this module
+
+
+<pre><code>pragma verify = <b>true</b>;
+</code></pre>
+
+
+Helper function that returns whether or not the
+<code>recipient</code> is an intended
+recipient of the offered struct in the
+<code><a href="#0x0_Offer">Offer</a>&lt;Offered&gt;</code> resource at the address
+<code>offer_address</code>
+Returns true if the recipient is allowed to redeem
+<code><a href="#0x0_Offer">Offer</a>&lt;Offered&gt;</code> at
+<code>offer_address</code>
+and false otherwise.
+
+
+<a name="0x0_Offer_is_allowed_recipient"></a>
+
+
+<pre><code><b>define</b> <a href="#0x0_Offer_is_allowed_recipient">is_allowed_recipient</a>&lt;Offered&gt;(offer_addr: address, recipient: address): bool {
+  recipient == <b>global</b>&lt;<a href="#0x0_Offer">Offer</a>&lt;Offered&gt;&gt;(offer_addr).for || recipient == offer_addr
+}
+</code></pre>
+
+
+
+<a name="0x0_Offer_@Creation_of_Offers"></a>
+
+#### Creation of Offers
+
+
+
+<a name="0x0_Offer_OnlyCreateCanCreateOffer"></a>
+
+Only
+<code><a href="#0x0_Offer_create">Self::create</a></code> can create a resource
+<code><a href="#0x0_Offer">Offer</a></code> under an address.
+
+**Informally:** No function to which this is applied can create an offer.
+If there didn't exist an offer under some
+<code>addr</code>, then it continues
+not to have one.
+
+
+<pre><code><b>schema</b> <a href="#0x0_Offer_OnlyCreateCanCreateOffer">OnlyCreateCanCreateOffer</a> {
+    <b>ensures</b> forall ty: type, addr: address where !<b>old</b>(exists&lt;<a href="#0x0_Offer">Offer</a>&lt;ty&gt;&gt;(addr)) : !exists&lt;<a href="#0x0_Offer">Offer</a>&lt;ty&gt;&gt;(addr);
+}
+</code></pre>
+
+
+
+Apply OnlyCreateCanCreateOffer
+
+
+<pre><code><b>apply</b> <a href="#0x0_Offer_OnlyCreateCanCreateOffer">OnlyCreateCanCreateOffer</a> <b>to</b> *&lt;Offered&gt;, * <b>except</b> create;
+</code></pre>
+
+
+
+
+<a name="0x0_Offer_@Removal_of_Offers"></a>
+
+#### Removal of Offers
+
+
+
+<a name="0x0_Offer_OnlyRedeemCanRemoveOffer"></a>
+
+Only
+<code><a href="#0x0_Offer_redeem">Self::redeem</a></code> can remove the
+<code><a href="#0x0_Offer">Offer</a></code> resource from an account.
+
+**Informally:** No other function except for
+<code>redeem</code> can remove an offer from an account.
+
+
+<pre><code><b>schema</b> <a href="#0x0_Offer_OnlyRedeemCanRemoveOffer">OnlyRedeemCanRemoveOffer</a> {
+    <b>ensures</b> forall ty: type, addr: address where <b>old</b>(exists&lt;<a href="#0x0_Offer">Offer</a>&lt;ty&gt;&gt;(addr)) :
+              (exists&lt;<a href="#0x0_Offer">Offer</a>&lt;ty&gt;&gt;(addr) && <b>global</b>&lt;<a href="#0x0_Offer">Offer</a>&lt;ty&gt;&gt;(addr) == <b>old</b>(<b>global</b>&lt;<a href="#0x0_Offer">Offer</a>&lt;ty&gt;&gt;(addr)));
+}
+</code></pre>
+
+
+
+Enforce that every function except
+<code><a href="#0x0_Offer_redeem">Self::redeem</a></code> can remove an offer from the global store.
+
+
+<pre><code><b>apply</b> <a href="#0x0_Offer_OnlyRedeemCanRemoveOffer">OnlyRedeemCanRemoveOffer</a> <b>to</b> *&lt;Offered&gt;, * <b>except</b> redeem;
+</code></pre>
+
+
+
+
+<a name="0x0_Offer_Specification_create"></a>
+
+### Function `create`
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="#0x0_Offer_create">create</a>&lt;Offered&gt;(account: &signer, offered: Offered, for: address)
+</code></pre>
+
+
+
+Offer a struct to the account under address
+<code>for</code> by
+placing the offer under the signer's address
+
+
+<pre><code><b>aborts_if</b> exists&lt;<a href="#0x0_Offer">Offer</a>&lt;Offered&gt;&gt;(<a href="Signer.md#0x0_Signer_get_address">Signer::get_address</a>(account));
+<b>ensures</b> exists&lt;<a href="#0x0_Offer">Offer</a>&lt;Offered&gt;&gt;(<a href="Signer.md#0x0_Signer_get_address">Signer::get_address</a>(account));
+<b>ensures</b> <b>global</b>&lt;<a href="#0x0_Offer">Offer</a>&lt;Offered&gt;&gt;(<a href="Signer.md#0x0_Signer_get_address">Signer::get_address</a>(account)) == <a href="#0x0_Offer">Offer</a>&lt;Offered&gt; { offered: offered, for: for };
+</code></pre>
+
+
+
+<a name="0x0_Offer_Specification_redeem"></a>
+
+### Function `redeem`
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="#0x0_Offer_redeem">redeem</a>&lt;Offered&gt;(account: &signer, offer_address: address): Offered
+</code></pre>
+
+
+
+Aborts if there is no offer under
+<code>offer_address</code> or if the account
+cannot redeem the offer.
+Ensures that the offered struct under
+<code>offer_address</code> is removed is returned.
+
+
+<pre><code><b>aborts_if</b> !exists&lt;<a href="#0x0_Offer">Offer</a>&lt;Offered&gt;&gt;(offer_address);
+<b>aborts_if</b> !<a href="#0x0_Offer_is_allowed_recipient">is_allowed_recipient</a>&lt;Offered&gt;(offer_address, <a href="Signer.md#0x0_Signer_get_address">Signer::get_address</a>(account));
+<b>ensures</b> <b>old</b>(exists&lt;<a href="#0x0_Offer">Offer</a>&lt;Offered&gt;&gt;(offer_address)) && !exists&lt;<a href="#0x0_Offer">Offer</a>&lt;Offered&gt;&gt;(offer_address);
+<b>ensures</b> result == <b>old</b>(<b>global</b>&lt;<a href="#0x0_Offer">Offer</a>&lt;Offered&gt;&gt;(offer_address).offered);
+</code></pre>
+
+
+
+<a name="0x0_Offer_Specification_exists_at"></a>
+
+### Function `exists_at`
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="#0x0_Offer_exists_at">exists_at</a>&lt;Offered&gt;(offer_address: address): bool
+</code></pre>
+
+
+
+Returns whether or not an
+<code><a href="#0x0_Offer">Offer</a></code> resource is under the given address
+<code>offer_address</code>.
+
+
+<pre><code><b>ensures</b> result == exists&lt;<a href="#0x0_Offer">Offer</a>&lt;Offered&gt;&gt;(offer_address);
+</code></pre>
+
+
+
+<a name="0x0_Offer_Specification_address_of"></a>
+
+### Function `address_of`
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="#0x0_Offer_address_of">address_of</a>&lt;Offered&gt;(offer_address: address): address
+</code></pre>
+
+
+
+Aborts is there is no offer resource
+<code><a href="#0x0_Offer">Offer</a></code> at the
+<code>offer_address</code>.
+Returns the address of the intended recipient of the Offer
+under the
+<code>offer_address</code>.
+
+
+<pre><code><b>aborts_if</b> !exists&lt;<a href="#0x0_Offer">Offer</a>&lt;Offered&gt;&gt;(offer_address);
+<b>ensures</b> result == <b>global</b>&lt;<a href="#0x0_Offer">Offer</a>&lt;Offered&gt;&gt;(offer_address).for;
+</code></pre>


### PR DESCRIPTION
Wrote functional specifications for all four functions and
two global specifications to restrict creation and removal of
Offer.T resources to the create and remove functions.

Additional notes: In an earlier implementation, I was able to write
a weaker property that states that only the sender or the intended
recipient (i.e. Offer<T<Offered>>.for) of an Offer could receive the
offered struct (refer to the properties below). This would allow
for additional functions that change the Offer to be implemented without
changing the specification (e.g. if an update offer function is
implemented).

```
/// **Informally:** If the Offer is removed from an address, then the sender
///                 must be the intended recipient
ensures all(domain<address>(), |addr|
  (old(exists<T<Offered>>(addr)) && !exists<T<Offered>>(addr)) ==>
  (old(sender_is_offer_recipient<Offered>(addr))));
/// **Informally:** An offer under an account is unchanged if it is not the sender's
///                 account or if the sender is not the recipient
ensures all(domain<address>(), |addr|
  (old(exists<T<Offered>>(addr)) && old(!sender_is_offer_recipient<Offered>(addr))) ==>
  (exists<T<Offered>>(addr) && old(global<T<Offered>>(addr)) == global<T<Offered>>(addr)));
/// **Informally:** An offer under an account is unchanged if the intended
///                 recipient does not redeem it
ensures all(domain<address>(), |addr|
  (old(exists<T<Offered>>(addr)) && exists<T<Offered>>(addr)) ==>
  (old(global<T<Offered>>(addr)) == global<T<Offered>>(addr)));
```

However, with the introduction of signers the property is false
without the precondition / assumption that the signer is the sender,

<!--
Thank you for sending a PR. We appreciate you spending time to help improve the Libra project.

The project is undergoing daily changes. Pull Requests will be reviewed and responded to as time permits.
-->

## Motivation

To write a first draft specification of the Offer module.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?

Yes.

## Test Plan

Existing test suite. Run the following command in the move-prover directory:

```
cargo run -- --verbose debug ../stdlib/modules/transaction.move ../stdlib/modules/Signer.move ../stdlib/modules/Offer.move
```

## Related PRs

None.