### PR TITLE
[cluster-test] LSR and Vault integration with cluster-test

### DIFF
--- a/docker/build-aws.sh
+++ b/docker/build-aws.sh
@@ -26,7 +26,7 @@ while [[ "$1" =~ ^- ]]; do case $1 in
     BUILD_PROJECTS=(libra-validator libra-cluster-test libra-init libra-mint libra-safety-rules)
     ;;
   --build-all-cti )
-    BUILD_PROJECTS=(libra-validator libra-cluster-test libra-safety-rules)
+    BUILD_PROJECTS=(libra-validator libra-cluster-test libra-init libra-safety-rules)
     ;;
   --build-cluster-test )
     BUILD_PROJECTS=(libra-cluster-test)

--- a/testsuite/cluster-test/src/cluster_swarm/fullnode_spec_template.yaml
+++ b/testsuite/cluster-test/src/cluster_swarm/fullnode_spec_template.yaml
@@ -11,13 +11,13 @@ metadata:
 spec:
   hostNetwork: true
   dnsPolicy: ClusterFirstWithHostNet
-  serviceAccountName: fullnode
+  serviceAccountName: clustertest
   nodeSelector:
     nodeType: validators
   nodeName: "{node_name}"
   initContainers:
   - name: init
-    image: 853397791086.dkr.ecr.us-west-2.amazonaws.com/libra_init:master
+    image: 853397791086.dkr.ecr.us-west-2.amazonaws.com/libra_init:{image_tag}
     volumeMounts:
     - mountPath: /opt/libra/data
       name: data

--- a/testsuite/cluster-test/src/cluster_swarm/lsr_service_template.yaml
+++ b/testsuite/cluster-test/src/cluster_swarm/lsr_service_template.yaml
@@ -1,0 +1,19 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: lsr-{validator_index}
+  labels:
+    app: libra-lsr
+    libra-node: "true"
+    peer_id: lsr-{validator_index}
+spec:
+  type: ClusterIP
+  publishNotReadyAddresses: true
+  selector:
+    app: libra-lsr
+    libra-node: "true"
+    peer_id: lsr-{validator_index}
+  ports:
+  - name: safety-rules
+    protocol: TCP
+    port: 6185

--- a/testsuite/cluster-test/src/cluster_swarm/lsr_spec_template.yaml
+++ b/testsuite/cluster-test/src/cluster_swarm/lsr_spec_template.yaml
@@ -1,0 +1,123 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: lsr-{validator_index}
+  labels:
+    app: libra-lsr
+    libra-node: "true"
+    peer_id: lsr-{validator_index}
+spec:
+  hostNetwork: true
+  dnsPolicy: ClusterFirstWithHostNet
+  serviceAccountName: clustertest
+  nodeSelector:
+    nodeType: validators
+  nodeName: "{node_name}"
+  initContainers:
+    - name: init
+      image: 853397791086.dkr.ecr.us-west-2.amazonaws.com/libra_init:{image_tag}
+      imagePullPolicy: Always
+      command:
+        - bash
+        - -c
+        - |
+          set -x
+          while true; do
+            health_out=$(wget --content-on-error -O- http://vault-{validator_index}.default.svc.cluster.local:8200/v1/sys/health)
+            if [[ "$health_out" != *'"initialized":true'* ]] || [[ "$health_out" != *'"sealed":false'* ]]; then
+              echo "healthcheck failed for vault. healthcheck msg: $health_out. Retrying in 5 secs"
+              sleep 5
+            else
+              echo "healthcheck passed for vault"
+              break
+            fi
+          done
+          while true; do
+            transit_keys=$(wget --content-on-error --method LIST -O- --header 'X-Vault-Token: root' http://vault-{validator_index}.default.svc.cluster.local:8200/v1/transit/keys)
+            if [[ "$transit_keys" == *'no handler for route'* ]]; then
+              echo "transit_keys not yet enabled for vault. transit_keys msg: $transit_keys. Retrying in 5 secs"
+              sleep 5
+            else
+              echo "transit_keys enabled for vault"
+              break
+            fi
+          done
+          /opt/libra/bin/config-builder safety-rules -n "{num_validators}" -g "{num_validators}" -i "{validator_index}" -s "$VALIDATOR_SEED" -o built/ --safety-rules-addr "0.0.0.0:6185" --safety-rules-backend=vault --safety-rules-host=http://vault-{validator_index}.default.svc.cluster.local:8200 --safety-rules-token=root -d /opt/libra/data
+      workingDir: /opt/libra/etc
+      volumeMounts:
+        - name: config-built
+          mountPath: /opt/libra/etc/built
+        - name: libra-data
+          mountPath: /opt/libra/data
+        - name: tmp
+          mountPath: /tmp
+      env:
+        - name: VALIDATOR_SEED
+          value: "{cfg_seed}"
+        - name: RUST_BACKTRACE
+          value: "1"
+      securityContext:
+        readOnlyRootFilesystem: true
+        allowPrivilegeEscalation: false
+        capabilities:
+          drop:
+            - ALL
+  containers:
+    - name: safety-rules
+      image: 853397791086.dkr.ecr.us-west-2.amazonaws.com/libra_safety_rules:{image_tag}
+      imagePullPolicy: Always
+      command: ["/opt/libra/bin/safety-rules", "/opt/libra/etc/node.config.toml"]
+      ports:
+        - containerPort: 6185
+      volumeMounts:
+        - name: config-built
+          mountPath: /opt/libra/etc
+          readOnly: true
+        - name: libra-data
+          mountPath: /opt/libra/data
+        - name: vault-token
+          mountPath: /opt/vault
+      env:
+        - name: RUST_LOG
+          value: debug
+        - name: RUST_BACKTRACE
+          value: "1"
+      securityContext:
+        readOnlyRootFilesystem: true
+        allowPrivilegeEscalation: false
+        capabilities:
+          drop:
+            - ALL
+  securityContext:
+    runAsNonRoot: true
+    runAsUser: 6180
+    runAsGroup: 6180
+    fsGroup: 6180
+  volumes:
+    - name: config-built
+      emptyDir: {{}}
+    - name: libra-data
+      hostPath:
+        path: /data
+        type: DirectoryOrCreate
+    - name: tmp
+      emptyDir: {{}}
+    - name: vault-token
+      emptyDir:
+        medium: Memory
+  affinity:
+    podAntiAffinity:
+      requiredDuringSchedulingIgnoredDuringExecution:
+        - labelSelector:
+            matchExpressions:
+              - key: libra-node
+                operator: Exists
+          topologyKey: "kubernetes.io/hostname"
+  terminationGracePeriodSeconds: 5
+  tolerations:
+    - key: "validators"
+      operator: "Exists"
+      effect: "NoSchedule"
+    - key: "node.kubernetes.io/not-ready"
+      operator: "Exists"
+      effect: "NoSchedule"

--- a/testsuite/cluster-test/src/cluster_swarm/validator_spec_template.yaml
+++ b/testsuite/cluster-test/src/cluster_swarm/validator_spec_template.yaml
@@ -11,13 +11,13 @@ metadata:
 spec:
   hostNetwork: true
   dnsPolicy: ClusterFirstWithHostNet
-  serviceAccountName: validator
+  serviceAccountName: clustertest
   nodeSelector:
     nodeType: validators
   nodeName: "{node_name}"
   initContainers:
   - name: init
-    image: 853397791086.dkr.ecr.us-west-2.amazonaws.com/libra_init:master
+    image: 853397791086.dkr.ecr.us-west-2.amazonaws.com/libra_init:{image_tag}
     volumeMounts:
     - mountPath: /opt/libra/data
       name: data
@@ -83,6 +83,16 @@ spec:
           Retry_Limit     False
           Logstash_Prefix kubernetes_cluster
       EOF
+      touch /opt/libra/data/safety_rules_addr
+      if [[ {enable_lsr} = true ]]; then
+        CFG_LSR_IP=$(kubectl get pod/lsr-{index} -o=jsonpath='{{.status.podIP}}');
+        while [ -z "${{CFG_LSR_IP}}" ]; do
+          sleep 5;
+          CFG_LSR_IP=$(kubectl get pod/lsr-{index} -o=jsonpath='{{.status.podIP}}');
+          echo "Waiting for pod/lsr-{index} IP Address";
+        done;
+        echo "${{CFG_LSR_IP}}:6185" > /opt/libra/data/safety_rules_addr
+      fi
       CFG_SEED_PEER_IP=$(kubectl get pod/val-0 -o=jsonpath='{{.status.podIP}}');
       while [ -z "${{CFG_SEED_PEER_IP}}" ]; do
         sleep 5;
@@ -149,6 +159,9 @@ spec:
         set -x;
         export CFG_LISTEN_ADDR=$MY_POD_IP;
         export CFG_SEED_PEER_IP=$(cat /opt/libra/data/seed_peer_ip);
+        if [[ {enable_lsr} = true ]]; then
+          export CFG_SAFETY_RULES_ADDR=$(cat /opt/libra/data/safety_rules_addr);
+        fi
         exec bash /docker-run-dynamic.sh &> /opt/libra/data/libra.log
   volumes:
   - name: data

--- a/testsuite/cluster-test/src/cluster_swarm/vault_service_template.yaml
+++ b/testsuite/cluster-test/src/cluster_swarm/vault_service_template.yaml
@@ -1,0 +1,25 @@
+# Source: helm chart for vault
+apiVersion: v1
+kind: Service
+metadata:
+  name: vault-{validator_index}
+  labels:
+    app: libra-vault
+    libra-node: "true"
+    peer_id: vault-{validator_index}
+  annotations:
+    service.alpha.kubernetes.io/tolerate-unready-endpoints: "true"
+spec:
+  type: ClusterIP
+  publishNotReadyAddresses: true
+  ports:
+  - name: "http"
+    port: 8200
+    targetPort: 8200
+  - name: internal
+    port: 8201
+    targetPort: 8201
+  selector:
+    app: libra-vault
+    libra-node: "true"
+    peer_id: vault-{validator_index}

--- a/testsuite/cluster-test/src/cluster_swarm/vault_spec_template.yaml
+++ b/testsuite/cluster-test/src/cluster_swarm/vault_spec_template.yaml
@@ -1,0 +1,134 @@
+# Source: helm chart for vault
+apiVersion: v1
+kind: Pod
+metadata:
+  name: vault-{validator_index}
+  labels:
+    app: libra-vault
+    libra-node: "true"
+    peer_id: vault-{validator_index}
+spec:
+  hostNetwork: true
+  dnsPolicy: ClusterFirstWithHostNet
+  serviceAccountName: clustertest
+  nodeSelector:
+    nodeType: validators
+  nodeName: "{node_name}"
+  securityContext:
+    runAsNonRoot: true
+    runAsGroup: 1000
+    runAsUser: 100
+    fsGroup: 1000
+  volumes:
+  containers:
+    - name: vault
+      securityContext:
+        capabilities:
+          add: ["IPC_LOCK"]
+      image: vault:1.4.0
+      imagePullPolicy: IfNotPresent
+      command:
+      args:
+      env:
+        - name: HOST_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.hostIP
+        - name: POD_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.podIP
+        - name: VAULT_K8S_POD_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.name
+        - name: VAULT_K8S_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        - name: VAULT_ADDR
+          value: "http://127.0.0.1:8200"
+        - name: VAULT_API_ADDR
+          value: "http://$(POD_IP):8200"
+        - name: SKIP_CHOWN
+          value: "true"
+        - name: SKIP_SETCAP
+          value: "true"
+        - name: HOSTNAME
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.name
+        - name: VAULT_CLUSTER_ADDR
+          value: "https://$(HOSTNAME).vault:8201"
+        - name: VAULT_DEV_ROOT_TOKEN_ID
+          value: "root"
+      volumeMounts:
+      ports:
+        - containerPort: 8200
+          name: http
+        - containerPort: 8201
+          name: internal
+        - containerPort: 8202
+          name: replication
+      readinessProbe:
+        exec:
+          command: ["/bin/sh", "-ec", "vault status -tls-skip-verify"]
+        failureThreshold: 2
+        initialDelaySeconds: 5
+        periodSeconds: 3
+        successThreshold: 1
+        timeoutSeconds: 5
+      lifecycle:
+        # Vault container doesn't receive SIGTERM from Kubernetes
+        # and after the grace period ends, Kube sends SIGKILL.  This
+        # causes issues with graceful shutdowns such as deregistering itself
+        # from Consul (zombie services).
+        preStop:
+          exec:
+            command: [
+              "/bin/sh", "-c",
+              # Adding a sleep here to give the pod eviction a
+              # chance to propagate, so requests will not be made
+              # to this pod while it's terminating
+              "sleep 5 && kill -SIGTERM $(pidof vault)",
+            ]
+    - name: vault-initialize
+      securityContext:
+        capabilities:
+          add: ["IPC_LOCK"]
+      image: vault:1.4.0
+      imagePullPolicy: IfNotPresent
+      command:
+        - "sh"
+        - "-c"
+        - |
+          vault secrets enable transit
+          while true; do
+            sleep 10000
+          done
+      args:
+      env:
+        - name: VAULT_ADDR
+          value: "http://127.0.0.1:8200"
+        - name: SKIP_CHOWN
+          value: "true"
+        - name: SKIP_SETCAP
+          value: "true"
+        - name: VAULT_TOKEN
+          value: "root"
+  affinity:
+    podAntiAffinity:
+      requiredDuringSchedulingIgnoredDuringExecution:
+        - labelSelector:
+            matchExpressions:
+              - key: libra-node
+                operator: Exists
+          topologyKey: "kubernetes.io/hostname"
+  terminationGracePeriodSeconds: 5
+  tolerations:
+    - key: "validators"
+      operator: "Exists"
+      effect: "NoSchedule"
+    - key: "node.kubernetes.io/not-ready"
+      operator: "Exists"
+      effect: "NoSchedule"

--- a/testsuite/cluster-test/src/instance.rs
+++ b/testsuite/cluster-test/src/instance.rs
@@ -20,6 +20,20 @@ static FULLNODE_REGEX: Lazy<Regex> = Lazy::new(|| Regex::new(r"fn-(\d+)").unwrap
 pub enum InstanceConfig {
     Validator(ValidatorConfig),
     Fullnode(FullnodeConfig),
+    LSR(LSRConfig),
+    Vault(VaultConfig),
+}
+
+#[derive(Clone, PartialEq, Eq, Hash)]
+pub struct VaultConfig {
+    pub index: u32,
+}
+
+#[derive(Clone, PartialEq, Eq, Hash)]
+pub struct LSRConfig {
+    pub index: u32,
+    pub num_validators: u32,
+    pub image_tag: String,
 }
 
 #[derive(Clone, PartialEq, Eq, Hash)]
@@ -27,6 +41,7 @@ pub struct ValidatorConfig {
     pub index: u32,
     pub num_validators: u32,
     pub num_fullnodes: u32,
+    pub enable_lsr: bool,
     pub image_tag: String,
     pub config_overrides: Vec<String>,
 }


### PR DESCRIPTION
## Summary

LSR and Vault integration with cluster-test

* Update set_asg_size so that it can handle cluster-size of more than 100 by using `next_token` 
* Add LSR and Vault pod and service specs
* Update validator spec to take another boolean - `enable_lsr`
* Use single service account - clustertest for all pods
* Add VaultConfig and LSRConfig to InstanceConfig enum
* Take `enable_lsr` as a boolean flag in cluster test main.rs