### PR TITLE
[move-prover] Changed translation of local variables in assert/assume specs

### DIFF
--- a/language/move-prover/stackless-bytecode-generator/src/eliminate_mut_refs.rs
+++ b/language/move-prover/stackless-bytecode-generator/src/eliminate_mut_refs.rs
@@ -53,6 +53,7 @@ impl FunctionTargetProcessor for EliminateMutRefsProcessor {
             }
         }
         data.param_proxy_map = param_proxy_map.clone();
+        data.ref_param_proxy_map = ref_param_proxy_map.clone();
 
         let mut max_ref_params_per_type = BTreeMap::new();
         for bytecode in &data.code {

--- a/language/move-prover/stackless-bytecode-generator/src/function_target.rs
+++ b/language/move-prover/stackless-bytecode-generator/src/function_target.rs
@@ -51,6 +51,7 @@ pub struct FunctionTargetData {
     pub local_types: Vec<Type>,
     pub return_types: Vec<Type>,
     pub param_proxy_map: BTreeMap<usize, usize>,
+    pub ref_param_proxy_map: BTreeMap<usize, usize>,
     pub ref_param_return_map: BTreeMap<usize, usize>,
     pub acquires_global_resources: Vec<StructId>,
     pub locations: BTreeMap<AttrId, Loc>,
@@ -238,6 +239,11 @@ impl<'env> FunctionTarget<'env> {
     /// Gets index of mutable proxy variable for an input parameter
     pub fn get_proxy_index(&self, idx: usize) -> Option<&usize> {
         self.data.param_proxy_map.get(&idx)
+    }
+
+    /// Gets index of mutable proxy variable for an input ref parameter
+    pub fn get_ref_proxy_index(&self, idx: usize) -> Option<&usize> {
+        self.data.ref_param_proxy_map.get(&idx)
     }
 
     /// Returns whether a call to this function ends lifetime of input references

--- a/language/move-prover/stackless-bytecode-generator/src/stackless_bytecode_generator.rs
+++ b/language/move-prover/stackless-bytecode-generator/src/stackless_bytecode_generator.rs
@@ -103,6 +103,7 @@ impl<'a> StacklessBytecodeGenerator<'a> {
             local_types: self.local_types,
             return_types: self.func_env.get_return_types(),
             param_proxy_map: BTreeMap::new(),
+            ref_param_proxy_map: BTreeMap::new(),
             ref_param_return_map: BTreeMap::new(),
             acquires_global_resources: self.func_env.get_acquires_global_resources(),
             locations: self.location_table,

--- a/language/move-prover/tests/sources/functional/specs_in_fun_ref.exp
+++ b/language/move-prover/tests/sources/functional/specs_in_fun_ref.exp
@@ -1,25 +1,16 @@
 Move prover returns: exiting with boogie verification errors
-error:  This assertion might not hold.
-
-    ┌── tests/sources/functional/specs_in_fun_ref.move:35:13 ───
-    │
- 35 │             assert x == y;
-    │             ^^^^^^^^^^^^^^
-    │
-    =     at tests/sources/functional/specs_in_fun_ref.move:32:5: simple3 (entry)
-
 error:  This loop invariant might not be maintained by the loop.
 
-     ┌── tests/sources/functional/specs_in_fun_ref.move:115:17 ───
+     ┌── tests/sources/functional/specs_in_fun_ref.move:109:17 ───
      │
- 115 │                 assert x == 0;
+ 109 │                 assert x == 0;
      │                 ^^^^^^^^^^^^^^
      │
-     =     at tests/sources/functional/specs_in_fun_ref.move:110:5: simple7 (entry)
-     =     at tests/sources/functional/specs_in_fun_ref.move:111:13: simple7
+     =     at tests/sources/functional/specs_in_fun_ref.move:104:5: simple7 (entry)
+     =     at tests/sources/functional/specs_in_fun_ref.move:105:13: simple7
      =         n = <redacted>
-     =     at tests/sources/functional/specs_in_fun_ref.move:114:13: simple7
+     =     at tests/sources/functional/specs_in_fun_ref.move:108:13: simple7
      =         x = <redacted>
-     =     at tests/sources/functional/specs_in_fun_ref.move:113:9: simple7
+     =     at tests/sources/functional/specs_in_fun_ref.move:107:9: simple7
      =         x = <redacted>
-     =     at tests/sources/functional/specs_in_fun_ref.move:119:19: simple7
+     =     at tests/sources/functional/specs_in_fun_ref.move:113:19: simple7

--- a/language/move-prover/tests/sources/functional/specs_in_fun_ref.move
+++ b/language/move-prover/tests/sources/functional/specs_in_fun_ref.move
@@ -25,10 +25,7 @@ module TestAssertWithReferences {
         };
     }
 
-    // This function fails.
-    // Feature: Updates to y span the spec block.  The partial update before
-    // the spec block is written back only when y dies at the end of the function.
-    // Hence, the first assert fails but the second verifies.
+    // This function verifies.
     fun simple3(x: &mut u64, y: &mut u64) {
         *y = *x;
         spec {
@@ -41,9 +38,6 @@ module TestAssertWithReferences {
     }
 
     // This function verifies.
-    // Feature: Updates to y span the spec block.  To work around the problem of
-    // delayed writeback, either read y or freeze y and use the resulting value
-    // in the spec block.
     fun simple4(x: &mut u64, y: &mut u64) {
         let z;
         *y = *x;


### PR DESCRIPTION
## Motivation

This PR changes the translation of local variables in assert/assume specifications.  A mutable reference parameter is translated as follows: 
- It is converted into a value parameter according to the new memory model.
- A copy of the parameter is made into a Boogie local variable since input parameters in Boogie are immutable.
- A reference to this copied value is taken; this reference serves as proxy for the input parameter in the rest of the function.
Note that copying an input parameter into a Boogie local variable is done even if the input parameter is a value rather than a reference. 

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?

Yes.

## Test Plan

Existing tests.

## Related PRs
#4319 

The fix attempted by this PR was triggered by a bug report from Kevin Cheang (see #4319) where Vector::reverse could be verified when input parameter is a value but not when it is a reference.  After my fix, both versions can be verified. 