### PR TITLE
[move-prover] Add "assume !$abort_flag" at each label

### DIFF
--- a/language/move-prover/src/bytecode_translator.rs
+++ b/language/move-prover/src/bytecode_translator.rs
@@ -662,7 +662,7 @@ impl<'env> ModuleTranslator<'env> {
         emitln!(self.writer, "var $saved_m: $Memory;");
 
         emitln!(self.writer, "\n// initialize function execution");
-        emitln!(self.writer, "assert !$abort_flag;");
+        emitln!(self.writer, "assume !$abort_flag;");
         emitln!(self.writer, "$saved_m := $m;");
 
         emitln!(self.writer, "\n// track values of parameters at entry time");
@@ -832,6 +832,7 @@ impl<'env> ModuleTranslator<'env> {
             Label(_, label) => {
                 self.writer.unindent();
                 emitln!(self.writer, "L{}:", label.as_usize());
+                emitln!(self.writer, "assume !$abort_flag;");
                 self.writer.indent();
             }
             Jump(_, target) => emitln!(self.writer, "goto L{};", target.as_usize()),

--- a/language/move-prover/tests/sources/functional/loops.exp
+++ b/language/move-prover/tests/sources/functional/loops.exp
@@ -1,0 +1,40 @@
+Move prover returns: exiting with boogie verification errors
+error: abort not covered by any of the `aborts_if` clauses
+
+    ┌── tests/sources/functional/loops.move:75:5 ───
+    │
+ 75 │ ╭     public fun iter10_abort_incorrect() {
+ 76 │ │         let i = 0;
+ 77 │ │         while ({
+ 78 │ │             spec { assert i <= 7; };
+ 79 │ │             (i <= 10)
+ 80 │ │         }) {
+ 81 │ │             if (i == 7) abort 7;
+ 82 │ │             i = i + 1;
+ 83 │ │         }
+ 84 │ │     }
+    │ ╰─────^
+    ·
+ 81 │             if (i == 7) abort 7;
+    │             ------------------- abort happened here
+    │
+    =     at tests/sources/functional/loops.move:75:5: iter10_abort_incorrect (entry)
+    =     at tests/sources/functional/loops.move:76:13: iter10_abort_incorrect
+    =     at tests/sources/functional/loops.move:78:13: iter10_abort_incorrect
+    =         i = <redacted>
+    =     at tests/sources/functional/loops.move:77:9: iter10_abort_incorrect
+    =     at tests/sources/functional/loops.move:81:13: iter10_abort_incorrect (ABORTED)
+
+error:  A postcondition might not hold on this return path.
+
+    ┌── tests/sources/functional/loops.move:58:9 ───
+    │
+ 58 │         aborts_if true;
+    │         ^^^^^^^^^^^^^^^
+    │
+    =     at tests/sources/functional/loops.move:47:5: iter10_no_abort_incorrect (entry)
+    =     at tests/sources/functional/loops.move:48:13: iter10_no_abort_incorrect
+    =     at tests/sources/functional/loops.move:50:13: iter10_no_abort_incorrect
+    =         i = <redacted>
+    =     at tests/sources/functional/loops.move:49:9: iter10_no_abort_incorrect
+    =     at tests/sources/functional/loops.move:47:5: iter10_no_abort_incorrect (exit)

--- a/language/move-prover/tests/sources/functional/loops.move
+++ b/language/move-prover/tests/sources/functional/loops.move
@@ -1,7 +1,7 @@
 module VerifyLoops {
 
     spec module {
-        pragma verify=false;
+        pragma verify=true;
     }
 
     // ----------------------
@@ -36,11 +36,11 @@ module VerifyLoops {
             spec { assert i <= 11; };
             (i <= 10)
         }) {
-            if (i > 10) { spec { assert false; }; abort 10 };
+            if (i > 10) abort 10;
             i = i + 1;
         }
     }
-    spec fun iter10_no_abort { // FIXME: Should be proved.
+    spec fun iter10_no_abort { // Verified. Abort cannot happen.
         aborts_if false;
     }
 
@@ -54,35 +54,35 @@ module VerifyLoops {
             i = i + 1;
         }
     }
-    spec fun iter10_no_abort_incorrect { // FIXME: Should be disproved.
+    spec fun iter10_no_abort_incorrect { // Disproved. Abort cannot happen.
         aborts_if true;
     }
 
     public fun iter10_abort() {
         let i = 0;
         while ({
-            spec { assert i <= 11; };
+            spec { assert i <= 7; };
             (i <= 10)
         }) {
             if (i == 7) abort 7;
             i = i + 1;
         }
     }
-    spec fun iter10_abort { // FIXME: Should be proved.
+    spec fun iter10_abort { // Verified. Abort always happens.
         aborts_if true;
     }
 
     public fun iter10_abort_incorrect() {
         let i = 0;
         while ({
-            spec { assert i <= 11; };
+            spec { assert i <= 7; };
             (i <= 10)
         }) {
             if (i == 7) abort 7;
             i = i + 1;
         }
     }
-    spec fun iter10_abort_incorrect { // FIXME: Should be disproved.
+    spec fun iter10_abort_incorrect { // Disproved. Abort always happens.
         aborts_if false;
     }
 }


### PR DESCRIPTION
## Motivation

This PR makes the following changes:
- add "assume  !$abort_flag" at each label
- replace "assert !$abort_flag$ at the beginning of a procedure with "assume !$abort_flag"
- enable loops.move test

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

Enabled a test.

## Related PRs

