### PR TITLE
Let NetworkBuilder Consume NetworkConfig

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3585,6 +3585,7 @@ dependencies = [
  "libra-metrics 0.1.0",
  "libra-network-address 0.1.0",
  "libra-proptest-helpers 0.1.0",
+ "libra-secure-storage 0.1.0",
  "libra-security-logger 0.1.0",
  "libra-types 0.1.0",
  "libra-workspace-hack 0.1.0",

--- a/config/src/config/mod.rs
+++ b/config/src/config/mod.rs
@@ -9,6 +9,7 @@ use std::{
     fmt,
     fs::File,
     io::{Read, Write},
+    mem,
     path::{Path, PathBuf},
     str::FromStr,
 };
@@ -206,6 +207,25 @@ impl NodeConfig {
                 .as_ref()
                 .map(|n| n.clone_for_template()),
         }
+    }
+
+    pub fn split_off_full_node_networks_identity(mut self) -> (Self, Vec<NetworkConfig>) {
+        let mut full_node_networks: Vec<NetworkConfig> = self
+            .full_node_networks
+            .iter()
+            .map(|config| config.clone_for_template())
+            .collect();
+        mem::swap(&mut self.full_node_networks, &mut full_node_networks);
+        (self, full_node_networks)
+    }
+
+    pub fn split_off_validator_networks_identity(mut self) -> (Self, Option<NetworkConfig>) {
+        let mut validator_network = self
+            .validator_network
+            .as_ref()
+            .map(|config| config.clone_for_template());
+        mem::swap(&mut self.validator_network, &mut validator_network);
+        (self, validator_network)
     }
 
     /// Reads the config file and returns the configuration object in addition to doing some

--- a/config/src/keys.rs
+++ b/config/src/keys.rs
@@ -58,6 +58,13 @@ where
         }
     }
 
+    pub fn only_public_key(public_key: T::PublicKeyMaterial) -> Self {
+        KeyPair {
+            public_key,
+            private_key: None,
+        }
+    }
+
     /// Takes the key from the data structure, calling this function a second time will return None.
     pub fn take_private(&mut self) -> Option<T> {
         self.private_key.take()

--- a/libra-node/src/main.rs
+++ b/libra-node/src/main.rs
@@ -32,7 +32,7 @@ static ALLOC: jemallocator::Jemalloc = jemallocator::Jemalloc;
 fn main() {
     let args = Args::from_args();
 
-    let mut config = NodeConfig::load(args.config).expect("Failed to load node config");
+    let config = NodeConfig::load(args.config).expect("Failed to load node config");
     println!("Using node config {:?}", &config);
     crash_handler::setup_panic_handler();
 
@@ -57,7 +57,7 @@ fn main() {
         }
     }
 
-    let _node_handle = libra_node::main_node::setup_environment(&mut config);
+    let _node_handle = libra_node::main_node::setup_environment(config);
 
     let term = Arc::new(AtomicBool::new(false));
 

--- a/network/Cargo.toml
+++ b/network/Cargo.toml
@@ -33,6 +33,7 @@ libra-logger = { path = "../common/logger", version = "0.1.0" }
 libra-metrics = { path = "../common/metrics", version = "0.1.0" }
 libra-network-address = { path = "network-address", version = "0.1.0" }
 libra-proptest-helpers = { path = "../common/proptest-helpers", version = "0.1.0", optional = true }
+libra-secure-storage = { path = "../secure/storage", version = "0.1.0" }
 libra-security-logger = { path = "../common/security-logger", version = "0.1.0" }
 libra-types = { path = "../types", version = "0.1.0" }
 libra-workspace-hack = { path = "../common/workspace-hack", version = "0.1.0" }


### PR DESCRIPTION
## Motivation

Right now both `NetworkBuilder` and `NetworkConfig` have these fields:
- `peer_id`
- `network_id`
- `listen_address`
- `advertised_address`
- `discovery_interval_ms`
- `connectivity_check_interval_ms`


This PR will let `NetworkBuilder` incorporate `NetworkConfig` as a member to avoid the duplication of these fields.

Added `fn clone_without_private_key` to `network_config::Identity` so that `clone_for_template` preserves the `Identity` enum variant for `NetworkConfig`.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

cargo test

