### PR TITLE
[move-prover] Syntactic sugar for forall and exists.

### DIFF
--- a/language/move-lang/src/expansion/translate.rs
+++ b/language/move-lang/src/expansion/translate.rs
@@ -1161,10 +1161,7 @@ fn exp_(context: &mut Context, sp!(loc, pe_): P::Exp) -> E::Exp {
         PE::Loop(ploop) => EE::Loop(exp(context, *ploop)),
         PE::Block(seq) => EE::Block(sequence(context, loc, seq)),
         PE::Lambda(pbs, pe) => {
-            if !context.require_spec_context(
-                loc,
-                "`|_| _` lambda expression only allowed in specifications",
-            ) {
+            if !context.require_spec_context(loc, "expression only allowed in specifications") {
                 assert!(context.has_errors());
                 EE::UnresolvedError
             } else {

--- a/language/move-lang/src/parser/lexer.rs
+++ b/language/move-lang/src/parser/lexer.rs
@@ -215,6 +215,18 @@ impl<'input> Lexer<'input> {
         Ok(tok)
     }
 
+    // Look ahead to the next two tokens after the current one and return them without advancing
+    // the state of the lexer.
+    pub fn lookahead2(&self) -> Result<(Tok, Tok), Error> {
+        let text = self.text[self.cur_end..].trim_start();
+        let offset = self.text.len() - text.len();
+        let (first, length) = find_token(self.file, text, offset)?;
+        let text2 = self.text[offset + length..].trim_start();
+        let offset2 = self.text.len() - text2.len();
+        let (second, _) = find_token(self.file, text2, offset2)?;
+        Ok((first, second))
+    }
+
     // Matches the doc comments after the last token (or the beginning of the file) to the position
     // of the current token. This moves the comments out of `doc_comments` and
     // into `matched_doc_comments`. At the end of parsing, if `doc_comments` is not empty, errors

--- a/language/move-lang/tests/move_check/parser/spec_parsing_lambda_fail.exp
+++ b/language/move-lang/tests/move_check/parser/spec_parsing_lambda_fail.exp
@@ -3,6 +3,6 @@ error:
    ┌── tests/move_check/parser/spec_parsing_lambda_fail.move:3:15 ───
    │
  3 │       let _ = |y| x + y;
-   │               ^^^^^^^^^ `|_| _` lambda expression only allowed in specifications
+   │               ^^^^^^^^^ expression only allowed in specifications
    │
 

--- a/language/move-lang/tests/move_check/parser/spec_parsing_ok.move
+++ b/language/move-lang/tests/move_check/parser/spec_parsing_ok.move
@@ -132,4 +132,10 @@ module M {
         apply ModuleInvariant<X, Y> to *foo*<Y, X>, bar except public *, internal baz<X>;
         pragma do_not_verify, timeout = 60;
     }
+
+    spec module {
+        invariant forall x: num, y: num, z: num : x == y && y == z ==> x == z;
+        invariant forall x: num : exists y: num : y >= x;
+        invariant exists x in 1..10, y in 8..12 : x == y;
+    }
 }

--- a/language/move-lang/tests/move_check/parser/spec_parsing_quantifier_fail.exp
+++ b/language/move-lang/tests/move_check/parser/spec_parsing_quantifier_fail.exp
@@ -1,0 +1,11 @@
+error: 
+
+   ┌── tests/move_check/parser/spec_parsing_quantifier_fail.move:3:33 ───
+   │
+ 3 │         invariant forall x: num y: num : x == y;
+   │                                 ^ Unexpected 'y'
+   ·
+ 3 │         invariant forall x: num y: num : x == y;
+   │                                 - Expected ':'
+   │
+

--- a/language/move-lang/tests/move_check/parser/spec_parsing_quantifier_fail.move
+++ b/language/move-lang/tests/move_check/parser/spec_parsing_quantifier_fail.move
@@ -1,0 +1,5 @@
+module M {
+    spec module {
+        invariant forall x: num y: num : x == y;
+    }
+}

--- a/language/move-prover/doc/user/spec-lang.md
+++ b/language/move-prover/doc/user/spec-lang.md
@@ -72,8 +72,14 @@ The available expressions in Spec language are a subset of the Move language, pl
 - If-then-else is supported.
 - A [spec variable](#specification-variables-and-packunpack-invariants) can be generic, and therefore the
   notation `name<T>` (or `Module::name<T>`) is supported. In Move, type arguments can only be provided to calls.
-- A form of lambda, denoted as `|x| x + 1`, is supported. The lambda can only appear as a parameter of the `all`
-  or `any` function (see next section).
+- Universal and existential quantification are supported:
+  - General form is `forall <binding>, ..., <binding> [ where <exp> ] : <exp>`. Similar for `exists`.
+  - Bindings can either be of the form `name: <type>` or `name in <exp>`. For the second form, the expression
+    currently must either be a `range` or a vector.
+  - The optional constraint `where <exp>` allows to restrict the quantified range. `forall x: T where p: q`
+    is equivalent to `forall x: T : p ==> q` and `exists x: T where p: q` is equivalent to
+    `exists x: T : p && q`.
+
 
 ## Builtin Functions
 
@@ -87,11 +93,6 @@ The Spec language supports a number of builtin functions. Most of them are not a
 - `update(vector<T>, num, T>): vector<T>` returns a new vector with the element replaced at the given index.
 - `type<T>()` returns an opaque value of Spec language type `type` which represents
    the type T. Type values can be only compared for equality.
-- `domain<T>()` returns the set of all values of type T. This expression can only be used as a parameter for
-   the `all` or `any` function.
-- `all(vector<T>, |T|bool`, `all(range, |num|bool)`, `all(domain<T>, |T|bool)` is universal quantification over
-   the values in a vector, the numbers in a range, or the whole type T. The second parameter must be a lambda expression.
-- `any(vector<T>, |T|bool`, `any(range, |num|bool)`, `any(domain<T>, |T|bool)` is existential quantification.
 - `old(T): T` delivers the value of the passed argument at point of entry into a Move function. This is only allowed
   in `ensures` post-conditions and certain forms of invariants, as discussed later.
 - `TRACE(T): T` is semantically the identity function and causes visualization of the argument's value in error messages created by the

--- a/language/move-prover/tests/sources/functional/address_quant.exp
+++ b/language/move-prover/tests/sources/functional/address_quant.exp
@@ -1,11 +1,11 @@
 Move prover returns: exiting with boogie verification errors
 error:  A postcondition might not hold on this return path.
 
-    ┌── tests/sources/functional/address_quant.move:57:10 ───
+    ┌── tests/sources/functional/address_quant.move:53:10 ───
     │
- 57 │          invariant atMostOne();
+ 53 │          invariant atMostOne();
     │          ^^^^^^^^^^^^^^^^^^^^^^
     │
-    =     at tests/sources/functional/address_quant.move:50:5: multiple_copy_incorrect (entry)
-    =     at tests/sources/functional/address_quant.move:51:9: multiple_copy_incorrect
-    =     at tests/sources/functional/address_quant.move:50:5: multiple_copy_incorrect (exit)
+    =     at tests/sources/functional/address_quant.move:46:5: multiple_copy_incorrect (entry)
+    =     at tests/sources/functional/address_quant.move:47:9: multiple_copy_incorrect
+    =     at tests/sources/functional/address_quant.move:46:5: multiple_copy_incorrect (exit)

--- a/language/move-prover/tests/sources/functional/address_quant.move
+++ b/language/move-prover/tests/sources/functional/address_quant.move
@@ -12,15 +12,11 @@ module AddressQuant {
 
     spec module {
        // helper functions
-       define atMostOne(): bool {
-            all(domain<address>(),
-                |a| all(domain<address>(),
-                        |b| exists<R>(a) && exists<R>(b) ==> a == b))
-
+        define atMostOne(): bool {
+            forall a: address, b: address where exists<R>(a) && exists<R>(b) : a == b
         }
         define atLeastOne(): bool {
-            any(domain<address>(),
-                |a| exists<R>(a))
+            exists a: address : exists<R>(a)
         }
     }
 
@@ -29,8 +25,8 @@ module AddressQuant {
         move_to_sender<R>(R{x:1});
     }
     spec fun initialize {
-        requires all(domain<address>(), |a| !exists<R>(a)); // forall a: address :: !exists<R>(a)
-        ensures all(domain<address>(), |a| exists<R>(a) ==> a == special_addr);
+        requires forall a: address : !exists<R>(a);
+        ensures forall a: address where exists<R>(a) : a == special_addr;
         ensures atMostOne();
         ensures atLeastOne();
     }

--- a/language/move-prover/tests/sources/functional/simple_vector_client.move
+++ b/language/move-prover/tests/sources/functional/simple_vector_client.move
@@ -198,8 +198,8 @@ module TestVector {
         v
     }
     spec fun vector_of_proper_positives {
-      ensures all(result, |n| n > 0);
-      ensures all(0..len(result), (|i| all(0..len(result), (|j| result[i] == result[j] ==> i == j))));
+      ensures forall n in result: n > 0;
+      ensures forall i in 0..len(result), j in 0..len(result) where result[i] == result[j] : i == j;
     }
 
     // succeeds. 7 == 7.
@@ -280,11 +280,11 @@ module TestVector {
         ensures result_1[1] == 2;
         ensures result_1[2] == 3;
         ensures result_1[3] == 5;
-        ensures any(result_1,|x| x==1);
-        ensures any(result_1,|x| x==2);
-        ensures any(result_1,|x| x==3);
-        ensures !any(result_1,|x| x==4);
-        ensures any(result_1,|x| x==5);
+        ensures exists x in result_1: x == 1;
+        ensures exists x in result_1: x == 2;
+        ensures exists x in result_1: x == 3;
+        ensures !(exists x in result_1: x == 4);
+        ensures exists x in result_1: x == 5;
     }
 
     fun test_index_of(): (vector<u64>, bool, u64, bool, u64) {

--- a/language/move-prover/tests/sources/functional/type_values.exp
+++ b/language/move-prover/tests/sources/functional/type_values.exp
@@ -3,8 +3,8 @@ error:  A postcondition might not hold on this return path.
 
     ┌── tests/sources/functional/type_values.move:25:9 ───
     │
- 25 │         invariant all(domain<type>(), |t| resource_invariant_globally_defined(t));
-    │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+ 25 │         invariant forall t: type : resource_invariant_globally_defined(t);
+    │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
     │
     =     at tests/sources/functional/type_values.move:37:5: add_R_incorrect (entry)
     =     at tests/sources/functional/type_values.move:38:9: add_R_incorrect

--- a/language/move-prover/tests/sources/functional/type_values.move
+++ b/language/move-prover/tests/sources/functional/type_values.move
@@ -22,11 +22,11 @@ module TestTypeValues {
 
     spec module {
         // Quantify over the domain of types, passing the type value to a helper function.
-        invariant all(domain<type>(), |t| resource_invariant_globally_defined(t));
+        invariant forall t: type : resource_invariant_globally_defined(t);
 
         // Quantify over the domain of addresses, and take the type parameter to check a resource.
         define resource_invariant_globally_defined(t: type): bool {
-            all(domain<address>(), |addr| exists<R<t>>(addr) ==> global<R<t>>(addr).x >= 1)
+            forall addr: address where exists<R<t>>(addr) : global<R<t>>(addr).x >= 1
         }
     }
 

--- a/language/move-prover/tests/sources/functional/verify_vector.move
+++ b/language/move-prover/tests/sources/functional/verify_vector.move
@@ -121,7 +121,7 @@ module VerifyVector {
     }
     spec fun verify_model_reverse {
         aborts_if false;
-        ensures all(0..len(v), |i| old(v[i]) == v[len(v)-1-i]);
+        ensures forall i in 0..len(v): old(v[i]) == v[len(v)-1-i];
     }
 
     // Moves all of the elements of the `other` vector into the `lhs` vector.
@@ -169,7 +169,7 @@ module VerifyVector {
         let len = Vector::length(v);
         while ({
             spec {
-                assert !any(0..i,|j| v[j]==e);
+                assert !(exists j in 0..i: v[j]==e);
             };
             i < len
         }) {
@@ -180,9 +180,9 @@ module VerifyVector {
     }
     spec fun verify_index_of {
 //        aborts_if false; // FIXME: this should be verified.
-        ensures result_1 == any(v,|x| x==e); // whether v contains e or not
+        ensures result_1 == (exists x in v: x==e); // whether v contains e or not
         ensures result_1 ==> v[result_2] == e; // if true, return the index where v contains e
-        ensures result_1 ==> all(0..result_2,|i| v[i]!=e); // ensure the smallest index
+        ensures result_1 ==> (forall i in 0..result_2: v[i]!=e); // ensure the smallest index
         ensures !result_1 ==> result_2 == 0; // return 0 if v does not contain e
     }
 
@@ -191,9 +191,9 @@ module VerifyVector {
     }
     spec fun verify_model_index_of {
         aborts_if false;
-        ensures result_1 == any(v,|x| x==e); // whether v contains e or not
+        ensures result_1 == (exists x in v: x==e); // whether v contains e or not
         ensures result_1 ==> v[result_2] == e; // if true, return the index where v contains e
-        ensures result_1 ==> all(0..result_2,|i| v[i]!=e); // ensure the smallest index
+        ensures result_1 ==> (forall i in 0..result_2: v[i]!=e); // ensure the smallest index
         ensures !result_1 ==> result_2 == 0; // return 0 if v does not contain e
     }
 
@@ -203,7 +203,7 @@ module VerifyVector {
         let len = Vector::length(v);
         while ({
             spec {
-               assert !any(0..i,|j| v[j]==e);
+               assert !(exists j in 0..i: v[j]==e);
             };
             i < len
         }) {
@@ -211,13 +211,13 @@ module VerifyVector {
             i = i + 1;
         };
         spec {
-           assert !any(v,|x| x==e);
+           assert !(exists x in v: x==e);
         };
         false
     }
     spec fun verify_contains {
         //aborts_if false; // FIXME: This should be verified
-        ensures result == any(v,|x| x==e);
+        ensures result == (exists x in v: x==e);
     }
 
     // Return true if `e` is in the vector `v`
@@ -226,7 +226,7 @@ module VerifyVector {
     }
     spec fun verify_model_contains {
         aborts_if false;
-        ensures result == any(v,|x| x==e);
+        ensures result == (exists x in v: x==e);
     }
 
     // Remove the `i`th element E of the vector, shifting all subsequent elements


### PR DESCRIPTION
This adds logic to the parser to recognize the standard forall and exists syntax often found in specification languages. Those constructs are immediatly reduced to all/any so no changes in any subsequent logic are required. For a description of the new syntax, see spec-lang.md. Existing prover tests have been updated to use the new syntax.

## Motivation

Readability of specs.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

New tests

## Related PRs

NA
