### PR TITLE
[cleanup][types, json-rpc, storage, consensus, network] Remove 22 more untested, unused items

### DIFF
--- a/consensus/consensus-types/src/executed_block.rs
+++ b/consensus/consensus-types/src/executed_block.rs
@@ -42,10 +42,6 @@ impl ExecutedBlock {
         &self.block
     }
 
-    pub fn epoch(&self) -> u64 {
-        self.block().epoch()
-    }
-
     pub fn id(&self) -> HashValue {
         self.block().id()
     }

--- a/consensus/consensus-types/src/proposal_msg.rs
+++ b/consensus/consensus-types/src/proposal_msg.rs
@@ -1,11 +1,7 @@
 // Copyright (c) The Libra Core Contributors
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::{
-    block::Block,
-    common::{Author, Round},
-    sync_info::SyncInfo,
-};
+use crate::{block::Block, common::Author, sync_info::SyncInfo};
 use anyhow::{ensure, format_err, Context, Result};
 use libra_types::validator_verifier::ValidatorVerifier;
 use serde::{Deserialize, Serialize};
@@ -101,10 +97,6 @@ impl ProposalMsg {
 
     pub fn sync_info(&self) -> &SyncInfo {
         &self.sync_info
-    }
-
-    pub fn round(&self) -> Round {
-        self.proposal.round()
     }
 
     pub fn proposer(&self) -> Author {

--- a/json-rpc/types/src/views.rs
+++ b/json-rpc/types/src/views.rs
@@ -374,13 +374,6 @@ pub enum ScriptView {
 
 impl ScriptView {
     // TODO cover all script types
-    pub fn get_name(&self) -> String {
-        match self {
-            ScriptView::PeerToPeer { .. } => "peer to peer transaction".to_string(),
-            ScriptView::Mint { .. } => "mint transaction".to_string(),
-            ScriptView::Unknown { .. } => "unknown transaction".to_string(),
-        }
-    }
 }
 
 impl From<Transaction> for TransactionDataView {

--- a/network/network-address/src/lib.rs
+++ b/network/network-address/src/lib.rs
@@ -209,10 +209,6 @@ impl RawNetworkAddress {
         Self(bytes)
     }
 
-    pub fn len(&self) -> usize {
-        self.0.len()
-    }
-
     pub fn is_empty(&self) -> bool {
         self.0.is_empty()
     }
@@ -261,9 +257,6 @@ impl NetworkAddress {
     }
 
     // TODO(philiphayes): could return NonZeroUsize?
-    pub fn len(&self) -> usize {
-        self.0.len()
-    }
 
     pub fn is_empty(&self) -> bool {
         self.0.is_empty()

--- a/network/network-address/src/lib.rs
+++ b/network/network-address/src/lib.rs
@@ -208,10 +208,6 @@ impl RawNetworkAddress {
     pub fn new(bytes: Vec<u8>) -> Self {
         Self(bytes)
     }
-
-    pub fn is_empty(&self) -> bool {
-        self.0.is_empty()
-    }
 }
 
 impl Into<Vec<u8>> for RawNetworkAddress {
@@ -254,12 +250,6 @@ impl Arbitrary for RawNetworkAddress {
 impl NetworkAddress {
     fn new(protocols: Vec<Protocol>) -> Self {
         Self(protocols)
-    }
-
-    // TODO(philiphayes): could return NonZeroUsize?
-
-    pub fn is_empty(&self) -> bool {
-        self.0.is_empty()
     }
 
     pub fn as_slice(&self) -> &[Protocol] {

--- a/network/onchain-discovery/src/types.rs
+++ b/network/onchain-discovery/src/types.rs
@@ -160,10 +160,6 @@ impl DiscoverySetInternal {
     pub fn empty() -> Self {
         Self(HashMap::new())
     }
-
-    pub fn len(&self) -> usize {
-        self.0.len()
-    }
 }
 
 #[derive(Clone, Debug, Eq, PartialEq)]

--- a/network/onchain-discovery/src/types.rs
+++ b/network/onchain-discovery/src/types.rs
@@ -161,10 +161,6 @@ impl DiscoverySetInternal {
         Self(HashMap::new())
     }
 
-    pub fn is_empty(&self) -> bool {
-        self.0.is_empty()
-    }
-
     pub fn len(&self) -> usize {
         self.0.len()
     }

--- a/storage/libradb/src/backup/mod.rs
+++ b/storage/libradb/src/backup/mod.rs
@@ -5,7 +5,7 @@
 mod test;
 
 use crate::{
-    ledger_store::{LedgerStore, TransactionInfoIter},
+    ledger_store::LedgerStore,
     state_store::StateStore,
     transaction_store::{TransactionIter, TransactionStore},
 };
@@ -49,16 +49,6 @@ impl BackupHandler {
     ) -> Result<TransactionIter> {
         self.transaction_store
             .get_transaction_iter(start_version, num_transactions)
-    }
-
-    /// Gets an iterator that yields a range of transaction infos.
-    pub fn get_transaction_info_iter(
-        &self,
-        start_version: Version,
-        num_transaction_infos: u64,
-    ) -> Result<TransactionInfoIter> {
-        self.ledger_store
-            .get_transaction_info_iter(start_version, num_transaction_infos)
     }
 
     /// Gets an iterator which can yield all accounts in the state tree.

--- a/storage/libradb/src/ledger_store/mod.rs
+++ b/storage/libradb/src/ledger_store/mod.rs
@@ -280,7 +280,8 @@ impl LedgerStore {
 
     /// Gets an iterator that yields `num_transaction_infos` transaction infos starting from
     /// `start_version`.
-    pub fn get_transaction_info_iter(
+    #[cfg(test)]
+    fn get_transaction_info_iter(
         &self,
         start_version: Version,
         num_transaction_infos: u64,

--- a/types/src/access_path.rs
+++ b/types/src/access_path.rs
@@ -35,10 +35,7 @@
 //! On the other hand, if you want to query only <Alice>/a/*, `address` will be set to Alice and
 //! `path` will be set to "/a" and use the `get_prefix()` method from statedb
 
-use crate::{
-    account_address::AccountAddress,
-    account_config::{ACCOUNT_RECEIVED_EVENT_PATH, ACCOUNT_SENT_EVENT_PATH},
-};
+use crate::account_address::AccountAddress;
 use libra_crypto::hash::HashValue;
 use move_core_types::language_storage::{ModuleId, ResourceKey, StructTag, CODE_TAG, RESOURCE_TAG};
 #[cfg(any(test, feature = "fuzzing"))]

--- a/types/src/access_path.rs
+++ b/types/src/access_path.rs
@@ -61,25 +61,6 @@ impl AccessPath {
         AccessPath { address, path }
     }
 
-    /// Create an AccessPath to the event for the sender account in a deposit operation.
-    /// The sent counter in LibraAccount.T (LibraAccount.T.sent_events_count) is used to generate
-    /// the AccessPath.
-    /// That AccessPath can be used as a key into the event storage to retrieve all sent
-    /// events for a given account.
-    pub fn new_for_sent_event(address: AccountAddress) -> Self {
-        Self::new(address, ACCOUNT_SENT_EVENT_PATH.to_vec())
-    }
-
-    /// Create an AccessPath to the event for the target account (the receiver)
-    /// in a deposit operation.
-    /// The received counter in LibraAccount.T (LibraAccount.T.received_events_count) is used to
-    /// generate the AccessPath.
-    /// That AccessPath can be used as a key into the event storage to retrieve all received
-    /// events for a given account.
-    pub fn new_for_received_event(address: AccountAddress) -> Self {
-        Self::new(address, ACCOUNT_RECEIVED_EVENT_PATH.to_vec())
-    }
-
     pub fn resource_access_vec(tag: &StructTag) -> Vec<u8> {
         tag.access_vector()
     }

--- a/types/src/account_config/resources/currency_info.rs
+++ b/types/src/account_config/resources/currency_info.rs
@@ -75,10 +75,6 @@ impl CurrencyInfoResource {
         AccessPath::resource_access_path(&resource_key)
     }
 
-    pub fn access_path_for(currency_code: Identifier) -> Vec<u8> {
-        AccessPath::resource_access_vec(&CurrencyInfoResource::struct_tag_for(currency_code))
-    }
-
     pub fn try_from_bytes(bytes: &[u8]) -> Result<Self> {
         lcs::from_bytes(bytes).map_err(Into::into)
     }

--- a/types/src/account_config/resources/key_rotation_capability.rs
+++ b/types/src/account_config/resources/key_rotation_capability.rs
@@ -13,8 +13,6 @@ pub struct KeyRotationCapabilityResource {
     account_address: AccountAddress,
 }
 
-impl KeyRotationCapabilityResource {}
-
 impl MoveResource for KeyRotationCapabilityResource {
     const MODULE_NAME: &'static str = ACCOUNT_MODULE_NAME;
     const STRUCT_NAME: &'static str = "KeyRotationCapability";

--- a/types/src/account_config/resources/key_rotation_capability.rs
+++ b/types/src/account_config/resources/key_rotation_capability.rs
@@ -13,11 +13,7 @@ pub struct KeyRotationCapabilityResource {
     account_address: AccountAddress,
 }
 
-impl KeyRotationCapabilityResource {
-    pub fn account_address(&self) -> &AccountAddress {
-        &self.account_address
-    }
-}
+impl KeyRotationCapabilityResource {}
 
 impl MoveResource for KeyRotationCapabilityResource {
     const MODULE_NAME: &'static str = ACCOUNT_MODULE_NAME;

--- a/types/src/account_config/resources/role.rs
+++ b/types/src/account_config/resources/role.rs
@@ -15,13 +15,6 @@ pub enum AccountRole {
 }
 
 impl AccountRole {
-    pub fn parent_vasp_data(&self) -> Option<&ParentVASP> {
-        match self {
-            AccountRole::ParentVASP(vasp) => Some(vasp),
-            _ => None,
-        }
-    }
-
     pub fn child_vasp_data(&self) -> Option<&ChildVASP> {
         match self {
             AccountRole::ChildVASP(vasp) => Some(vasp),

--- a/types/src/account_config/resources/role.rs
+++ b/types/src/account_config/resources/role.rs
@@ -15,13 +15,6 @@ pub enum AccountRole {
 }
 
 impl AccountRole {
-    pub fn child_vasp_data(&self) -> Option<&ChildVASP> {
-        match self {
-            AccountRole::ChildVASP(vasp) => Some(vasp),
-            _ => None,
-        }
-    }
-
     pub fn is_unhosted(&self) -> bool {
         match self {
             AccountRole::Unhosted => true,

--- a/types/src/account_config/resources/role.rs
+++ b/types/src/account_config/resources/role.rs
@@ -13,12 +13,3 @@ pub enum AccountRole {
     Unknown,
     // TODO: add other roles
 }
-
-impl AccountRole {
-    pub fn is_unhosted(&self) -> bool {
-        match self {
-            AccountRole::Unhosted => true,
-            _ => false,
-        }
-    }
-}

--- a/types/src/account_config/resources/withdraw_capability.rs
+++ b/types/src/account_config/resources/withdraw_capability.rs
@@ -13,8 +13,6 @@ pub struct WithdrawCapabilityResource {
     account_address: AccountAddress,
 }
 
-impl WithdrawCapabilityResource {}
-
 impl MoveResource for WithdrawCapabilityResource {
     const MODULE_NAME: &'static str = ACCOUNT_MODULE_NAME;
     const STRUCT_NAME: &'static str = "WithdrawCapability";

--- a/types/src/account_config/resources/withdraw_capability.rs
+++ b/types/src/account_config/resources/withdraw_capability.rs
@@ -13,11 +13,7 @@ pub struct WithdrawCapabilityResource {
     account_address: AccountAddress,
 }
 
-impl WithdrawCapabilityResource {
-    pub fn account_address(&self) -> &AccountAddress {
-        &self.account_address
-    }
-}
+impl WithdrawCapabilityResource {}
 
 impl MoveResource for WithdrawCapabilityResource {
     const MODULE_NAME: &'static str = ACCOUNT_MODULE_NAME;

--- a/types/src/on_chain_config/registered_currencies.rs
+++ b/types/src/on_chain_config/registered_currencies.rs
@@ -23,10 +23,6 @@ impl fmt::Display for RegisteredCurrencies {
 }
 
 impl RegisteredCurrencies {
-    pub fn new(currency_codes: Vec<Identifier>) -> Self {
-        Self { currency_codes }
-    }
-
     pub fn currency_codes(&self) -> &[Identifier] {
         &self.currency_codes
     }

--- a/types/src/proof/definition.rs
+++ b/types/src/proof/definition.rs
@@ -698,11 +698,6 @@ impl TransactionListProof {
         &self.transaction_infos
     }
 
-    /// Retursn the accumulator proof
-    pub fn ledger_info_to_transaction_infos_proof(&self) -> &TransactionAccumulatorRangeProof {
-        &self.ledger_info_to_transaction_infos_proof
-    }
-
     pub fn left_siblings(&self) -> &Vec<HashValue> {
         self.ledger_info_to_transaction_infos_proof.left_siblings()
     }

--- a/types/src/proof/definition.rs
+++ b/types/src/proof/definition.rs
@@ -640,11 +640,6 @@ impl EventProof {
         &self.transaction_info_with_proof
     }
 
-    /// Returns the `transaction_info_to_event_proof` object in this proof.
-    pub fn transaction_info_to_event_proof(&self) -> &EventAccumulatorProof {
-        &self.transaction_info_to_event_proof
-    }
-
     /// Verifies that a given event is correct using provided proof.
     pub fn verify(
         &self,

--- a/types/src/validator_verifier.rs
+++ b/types/src/validator_verifier.rs
@@ -58,10 +58,6 @@ impl ValidatorConsensusInfo {
             voting_power,
         }
     }
-
-    pub fn voting_power(&self) -> u64 {
-        self.voting_power
-    }
 }
 
 /// Supports validation of signatures for known authors with individual voting powers. This struct

--- a/types/src/vm_error.rs
+++ b/types/src/vm_error.rs
@@ -127,9 +127,6 @@ impl VMStatus {
     }
 
     /// Mutates the VMStatus sub status field to be the new `sub_status` passed in.
-    pub fn set_sub_status(&mut self, sub_status: u64) {
-        self.sub_status = Some(sub_status);
-    }
 
     /// Mutates the VMStatus message field to be the new `message` passed in.
     pub fn set_message(&mut self, message: String) {

--- a/types/src/vm_error.rs
+++ b/types/src/vm_error.rs
@@ -126,12 +126,6 @@ impl VMStatus {
         self
     }
 
-    /// Mutates the VMStatus sub status field to be the new `sub_status` passed in.
-
-    /// Mutates the VMStatus message field to be the new `message` passed in.
-    pub fn set_message(&mut self, message: String) {
-        self.message = Some(message);
-    }
     /// Append the message `message` to the message field of the VM status, and insert a seperator
     /// if the original message is non-empty.
     pub fn append_message_with_separator(mut self, separator: char, message: String) -> Self {


### PR DESCRIPTION
This PR removes ~~09~~ 22 untested, unused methods from `types` and various other modules. The value of the PR may reside more in the signaling of the nature of those untested, unused methods rather than actual removal.

I do hope & expect that reviewers will come up with valid reasons why one or another of those methods should be part of our public API — I've hence separated commits per method so that those valid methods can be kept, by omitting the commit that removes them. Just say so in review, plz :slightly_smiling_face: 
