### PR TITLE
[move prover] specify TestNet.move

### DIFF
--- a/language/stdlib/modules/Testnet.move
+++ b/language/stdlib/modules/Testnet.move
@@ -21,5 +21,96 @@ module Testnet {
         Transaction::assert(Signer::address_of(account) == 0xA550C18, 0);
         IsTestnet{} = move_from<IsTestnet>(0xA550C18);
     }
+
+    // **************** SPECIFICATIONS ****************
+
+    /**
+       This module is used by Genesis, LibraAccount and Unhosted as part of
+       the initialization and to check whether the transaction is on the
+       testnet.
+    **/
+
+    /// # Module Specification
+
+    spec module {
+        /// Verify all functions in this module, including private ones.
+        pragma verify = true;
+
+        /// Returns the association root address.
+        define spec_root_address(): address { 0xA550C18 }
+
+        /// Returns true if the testnet has been initialized.
+        /// Initialization can be reversed by function `remove_testnet`.
+        define spec_is_initialized(): bool {
+            exists<IsTestnet>(spec_root_address())
+        }
+    }
+
+    /// ## Management of TestNet
+
+    spec module {
+        /// Returns true if no address has IsTestNet resource.
+        define spec_no_addr_has_testnet(): bool {
+            all(domain<address>(), |addr| !exists<IsTestnet>(addr))
+        }
+
+        /// Returns true if only the root address has an IsTestNet resource.
+        define spec_only_root_addr_has_testnet(): bool {
+            all(domain<address>(), |addr|
+                exists<IsTestnet>(addr)
+                    ==> addr == spec_root_address())
+        }
+    }
+
+    spec schema OnlyRootAddressHasTestNet {
+        /// Base case of the induction before the association address is
+        /// initialized with IsTestnet.
+        invariant module !spec_is_initialized()
+                            ==> spec_no_addr_has_testnet();
+
+        /// Inductive step after the initialization is complete.
+        invariant module spec_is_initialized()
+                            ==> spec_only_root_addr_has_testnet();
+    }
+
+    spec schema TestNetStaysInitialized {
+        ensures old(spec_is_initialized()) ==> spec_is_initialized();
+    }
+
+    spec module {
+        /// Apply 'OnlyRootAddressHasTestNet' to all functions.
+        apply OnlyRootAddressHasTestNet to *;
+
+        /// Apply 'TestNetStaysInitialized' to all functions except
+        /// `remove_testnet`
+        apply TestNetStaysInitialized to * except remove_testnet;
+    }
+
+
+    /// ## Specifications for individual functions
+
+    spec module {
+        /// Returns true if IsTestNet exists at the address of the account.
+        define spec_exists_testnet(account: signer): bool {
+            exists<IsTestnet>(Signer::get_address(account))
+        }
+    }
+
+    spec fun initialize {
+        aborts_if Signer::get_address(account) != spec_root_address();
+        aborts_if spec_exists_testnet(account);
+        ensures spec_exists_testnet(account);
+    }
+
+    spec fun is_testnet {
+        aborts_if false;
+        ensures result == exists<IsTestnet>(spec_root_address());
+    }
+
+    spec fun remove_testnet {
+        aborts_if Signer::get_address(account) != spec_root_address();
+        aborts_if !spec_exists_testnet(account);
+        ensures !spec_exists_testnet(account);
+    }
 }
 }

--- a/language/stdlib/modules/doc/Testnet.md
+++ b/language/stdlib/modules/doc/Testnet.md
@@ -9,6 +9,13 @@
 -  [Function `initialize`](#0x0_Testnet_initialize)
 -  [Function `is_testnet`](#0x0_Testnet_is_testnet)
 -  [Function `remove_testnet`](#0x0_Testnet_remove_testnet)
+-  [Specification](#0x0_Testnet_Specification)
+    -  [Module Specification](#0x0_Testnet_@Module_Specification)
+        -  [Management of TestNet](#0x0_Testnet_@Management_of_TestNet)
+        -  [Specifications for individual functions](#0x0_Testnet_@Specifications_for_individual_functions)
+    -  [Function `initialize`](#0x0_Testnet_Specification_initialize)
+    -  [Function `is_testnet`](#0x0_Testnet_Specification_is_testnet)
+    -  [Function `remove_testnet`](#0x0_Testnet_Specification_remove_testnet)
 
 
 
@@ -114,3 +121,203 @@
 
 
 </details>
+
+<a name="0x0_Testnet_Specification"></a>
+
+## Specification
+
+
+This module is used by Genesis, LibraAccount and Unhosted as part of
+the initialization and to check whether the transaction is on the
+testnet.
+*
+
+<a name="0x0_Testnet_@Module_Specification"></a>
+
+### Module Specification
+
+
+Verify all functions in this module, including private ones.
+
+
+<pre><code>pragma verify = <b>true</b>;
+</code></pre>
+
+
+Returns the association root address.
+
+
+<a name="0x0_Testnet_spec_root_address"></a>
+
+
+<pre><code><b>define</b> <a href="#0x0_Testnet_spec_root_address">spec_root_address</a>(): address { 0xA550C18 }
+</code></pre>
+
+
+Returns true if the testnet has been initialized.
+Initialization can be reversed by function
+<code>remove_testnet</code>.
+
+
+<a name="0x0_Testnet_spec_is_initialized"></a>
+
+
+<pre><code><b>define</b> <a href="#0x0_Testnet_spec_is_initialized">spec_is_initialized</a>(): bool {
+    exists&lt;<a href="#0x0_Testnet_IsTestnet">IsTestnet</a>&gt;(<a href="#0x0_Testnet_spec_root_address">spec_root_address</a>())
+}
+</code></pre>
+
+
+
+<a name="0x0_Testnet_@Management_of_TestNet"></a>
+
+#### Management of TestNet
+
+
+Returns true if no address has IsTestNet resource.
+
+
+<a name="0x0_Testnet_spec_no_addr_has_testnet"></a>
+
+
+<pre><code><b>define</b> <a href="#0x0_Testnet_spec_no_addr_has_testnet">spec_no_addr_has_testnet</a>(): bool {
+    all(domain&lt;address&gt;(), |addr| !exists&lt;<a href="#0x0_Testnet_IsTestnet">IsTestnet</a>&gt;(addr))
+}
+</code></pre>
+
+
+Returns true if only the root address has an IsTestNet resource.
+
+
+<a name="0x0_Testnet_spec_only_root_addr_has_testnet"></a>
+
+
+<pre><code><b>define</b> <a href="#0x0_Testnet_spec_only_root_addr_has_testnet">spec_only_root_addr_has_testnet</a>(): bool {
+    all(domain&lt;address&gt;(), |addr|
+        exists&lt;<a href="#0x0_Testnet_IsTestnet">IsTestnet</a>&gt;(addr)
+            ==&gt; addr == <a href="#0x0_Testnet_spec_root_address">spec_root_address</a>())
+}
+</code></pre>
+
+
+
+
+<a name="0x0_Testnet_OnlyRootAddressHasTestNet"></a>
+
+Base case of the induction before the association address is
+initialized with IsTestnet.
+
+
+<pre><code><b>schema</b> <a href="#0x0_Testnet_OnlyRootAddressHasTestNet">OnlyRootAddressHasTestNet</a> {
+    <b>invariant</b> <b>module</b> !<a href="#0x0_Testnet_spec_is_initialized">spec_is_initialized</a>()
+                        ==&gt; <a href="#0x0_Testnet_spec_no_addr_has_testnet">spec_no_addr_has_testnet</a>();
+}
+</code></pre>
+
+
+Inductive step after the initialization is complete.
+
+
+<pre><code><b>schema</b> <a href="#0x0_Testnet_OnlyRootAddressHasTestNet">OnlyRootAddressHasTestNet</a> {
+    <b>invariant</b> <b>module</b> <a href="#0x0_Testnet_spec_is_initialized">spec_is_initialized</a>()
+                        ==&gt; <a href="#0x0_Testnet_spec_only_root_addr_has_testnet">spec_only_root_addr_has_testnet</a>();
+}
+</code></pre>
+
+
+
+
+<a name="0x0_Testnet_TestNetStaysInitialized"></a>
+
+
+<pre><code><b>schema</b> <a href="#0x0_Testnet_TestNetStaysInitialized">TestNetStaysInitialized</a> {
+    <b>ensures</b> <b>old</b>(<a href="#0x0_Testnet_spec_is_initialized">spec_is_initialized</a>()) ==&gt; <a href="#0x0_Testnet_spec_is_initialized">spec_is_initialized</a>();
+}
+</code></pre>
+
+
+
+Apply 'OnlyRootAddressHasTestNet' to all functions.
+
+
+<pre><code><b>apply</b> <a href="#0x0_Testnet_OnlyRootAddressHasTestNet">OnlyRootAddressHasTestNet</a> <b>to</b> *;
+</code></pre>
+
+
+Apply 'TestNetStaysInitialized' to all functions except
+<code>remove_testnet</code>
+
+
+<pre><code><b>apply</b> <a href="#0x0_Testnet_TestNetStaysInitialized">TestNetStaysInitialized</a> <b>to</b> * <b>except</b> remove_testnet;
+</code></pre>
+
+
+
+<a name="0x0_Testnet_@Specifications_for_individual_functions"></a>
+
+#### Specifications for individual functions
+
+
+Returns true if IsTestNet exists at the address of the account.
+
+
+<a name="0x0_Testnet_spec_exists_testnet"></a>
+
+
+<pre><code><b>define</b> <a href="#0x0_Testnet_spec_exists_testnet">spec_exists_testnet</a>(account: signer): bool {
+    exists&lt;<a href="#0x0_Testnet_IsTestnet">IsTestnet</a>&gt;(<a href="Signer.md#0x0_Signer_get_address">Signer::get_address</a>(account))
+}
+</code></pre>
+
+
+
+<a name="0x0_Testnet_Specification_initialize"></a>
+
+### Function `initialize`
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="#0x0_Testnet_initialize">initialize</a>(account: &signer)
+</code></pre>
+
+
+
+
+<pre><code><b>aborts_if</b> <a href="Signer.md#0x0_Signer_get_address">Signer::get_address</a>(account) != <a href="#0x0_Testnet_spec_root_address">spec_root_address</a>();
+<b>aborts_if</b> <a href="#0x0_Testnet_spec_exists_testnet">spec_exists_testnet</a>(account);
+<b>ensures</b> <a href="#0x0_Testnet_spec_exists_testnet">spec_exists_testnet</a>(account);
+</code></pre>
+
+
+
+<a name="0x0_Testnet_Specification_is_testnet"></a>
+
+### Function `is_testnet`
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="#0x0_Testnet_is_testnet">is_testnet</a>(): bool
+</code></pre>
+
+
+
+
+<pre><code><b>aborts_if</b> <b>false</b>;
+<b>ensures</b> result == exists&lt;<a href="#0x0_Testnet_IsTestnet">IsTestnet</a>&gt;(<a href="#0x0_Testnet_spec_root_address">spec_root_address</a>());
+</code></pre>
+
+
+
+<a name="0x0_Testnet_Specification_remove_testnet"></a>
+
+### Function `remove_testnet`
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="#0x0_Testnet_remove_testnet">remove_testnet</a>(account: &signer)
+</code></pre>
+
+
+
+
+<pre><code><b>aborts_if</b> <a href="Signer.md#0x0_Signer_get_address">Signer::get_address</a>(account) != <a href="#0x0_Testnet_spec_root_address">spec_root_address</a>();
+<b>aborts_if</b> !<a href="#0x0_Testnet_spec_exists_testnet">spec_exists_testnet</a>(account);
+<b>ensures</b> !<a href="#0x0_Testnet_spec_exists_testnet">spec_exists_testnet</a>(account);
+</code></pre>


### PR DESCRIPTION
<!--
Thank you for sending a PR. We appreciate you spending time to help improve the Libra project.

The project is undergoing daily changes. Pull Requests will be reviewed and responded to as time permits.
-->

## Motivation

Add global specifications and pre/post conditions to TestNet.move in stdlib

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?

Yes.

## Test Plan

```
cargo run -- ../stdlib/modules/Signer.move ../stdlib/modules/Transaction.move ../stdlib/modules/Testnet.move
```


