### PR TITLE
[cluster-test]retry logic for failed query to prometheus

### DIFF
--- a/testsuite/cluster-test/src/stats.rs
+++ b/testsuite/cluster-test/src/stats.rs
@@ -6,12 +6,14 @@ use anyhow::{format_err, Result};
 use std::time::Duration;
 
 pub fn avg_txns_per_block(prometheus: &Prometheus, start: Duration, end: Duration) -> Result<f64> {
-    prometheus
-        .query_range_avg(
-            "irate(libra_consensus_num_txns_per_block_sum[1m])/irate(libra_consensus_num_txns_per_block_count[1m])".to_string(),
-            &start,
-            &end,
-            10, /* step */
-        )
-        .map_err(|e| format_err!("No txns_per_block data: {}", e))
+    libra_retrier::retry(libra_retrier::fixed_retry_strategy(1_000, 5), || {
+        prometheus
+            .query_range_avg(
+                "irate(libra_consensus_num_txns_per_block_sum[1m])/irate(libra_consensus_num_txns_per_block_count[1m])".to_string(),
+                &start,
+                &end,
+                10, /* step */
+            )
+            .map_err(|e| format_err!("No txns_per_block data: {}", e))
+    })
 }


### PR DESCRIPTION
<!--
Thank you for sending a PR. We appreciate you spending time to help improve the Libra project.

The project is undergoing daily changes. Pull Requests will be reviewed and responded to as time permits.
-->

## Motivation

Added retry logic for failed query to prometheus instead of crushing test directly

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?

(Write your answer here.)

## Test Plan

(Share your test plan here. If you changed code, please provide us with clear instructions for verifying that your changes work.)

## Related PRs

(If this PR adds or changes functionality, please take some time to update the docs at https://github.com/libra/website, and link to your PR here.)
