### PR TITLE
[move core modules] parallelize generation of script binaries and docs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5322,6 +5322,7 @@ dependencies = [
  "move-lang 0.0.1",
  "move-prover 0.1.0",
  "once_cell 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rayon 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "vm 0.1.0",
 ]
 

--- a/language/stdlib/Cargo.toml
+++ b/language/stdlib/Cargo.toml
@@ -24,6 +24,7 @@ once_cell = "1.4.0"
 include_dir = "0.6.0"
 clap = "2.33.1"
 log = "0.4.8"
+rayon = "1.3.0"
 
 [features]
 default = []


### PR DESCRIPTION
Generating script binaries + docs sequentially takes about 10s (binaries) and 1m (docs), which is a bit painful. This PR uses parallel iterators to bring the time down to 3s for binaries and 14s for docs.

<!--
Thank you for sending a PR. We appreciate you spending time to help improve the Libra project.

The project is undergoing daily changes. Pull Requests will be reviewed and responded to as time permits.
-->

## Motivation

Improving dev experience for stdlib

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?

Y

## Test Plan

Ran before/after change to confirm speedup.
