### PR TITLE
[mempool] add backpressure functionality

### DIFF
--- a/config/src/config/mempool_config.rs
+++ b/config/src/config/mempool_config.rs
@@ -8,6 +8,7 @@ use serde::{Deserialize, Serialize};
 pub struct MempoolConfig {
     pub broadcast_transactions: bool,
     pub shared_mempool_tick_interval_ms: u64,
+    pub shared_mempool_backoff_interval_ms: u64,
     pub shared_mempool_batch_size: usize,
     pub shared_mempool_max_concurrent_inbound_syncs: usize,
     pub shared_mempool_min_broadcast_recipient_count: Option<usize>,
@@ -24,6 +25,7 @@ impl Default for MempoolConfig {
         MempoolConfig {
             broadcast_transactions: true,
             shared_mempool_tick_interval_ms: 50,
+            shared_mempool_backoff_interval_ms: 30_000,
             shared_mempool_batch_size: 100,
             shared_mempool_max_concurrent_inbound_syncs: 100,
             shared_mempool_min_broadcast_recipient_count: None,

--- a/mempool/src/shared_mempool/coordinator.rs
+++ b/mempool/src/shared_mempool/coordinator.rs
@@ -142,7 +142,7 @@ pub(crate) async fn coordinator<V>(
                                             ))
                                             .await;
                                     }
-                                    MempoolSyncMsg::BroadcastTransactionsResponse{request_id, retry_txns} => {
+                                    MempoolSyncMsg::BroadcastTransactionsResponse{request_id, retry_txns, backoff} => {
                                         let peer = PeerNetworkId(network_id, peer_id);
                                         tasks::process_broadcast_ack(&mempool, peer, request_id, retry_txns, is_validator, peer_manager.clone());
                                         notify_subscribers(SharedMempoolNotification::ACK, &smp.subscribers);

--- a/mempool/src/shared_mempool/coordinator.rs
+++ b/mempool/src/shared_mempool/coordinator.rs
@@ -144,7 +144,7 @@ pub(crate) async fn coordinator<V>(
                                     }
                                     MempoolSyncMsg::BroadcastTransactionsResponse{request_id, retry_txns, backoff} => {
                                         let peer = PeerNetworkId(network_id, peer_id);
-                                        tasks::process_broadcast_ack(&mempool, peer, request_id, retry_txns, is_validator, peer_manager.clone());
+                                        tasks::process_broadcast_ack(&mempool, peer, request_id, retry_txns, backoff, is_validator, peer_manager.clone());
                                         notify_subscribers(SharedMempoolNotification::ACK, &smp.subscribers);
                                     }
                                 };

--- a/mempool/src/shared_mempool/coordinator.rs
+++ b/mempool/src/shared_mempool/coordinator.rs
@@ -90,8 +90,8 @@ pub(crate) async fn coordinator<V>(
                 .spawn(tasks::process_config_update(config_update, smp.validator.clone()))
                 .await;
             },
-            peer = scheduled_broadcasts.select_next_some() => {
-                tasks::execute_broadcast(peer, &mut smp, &mut scheduled_broadcasts, executor.clone());
+            (peer, backoff) = scheduled_broadcasts.select_next_some() => {
+                tasks::execute_broadcast(peer, backoff, &mut smp, &mut scheduled_broadcasts, executor.clone());
             },
             (network_id, event) = events.select_next_some() => {
                 match event {
@@ -105,7 +105,7 @@ pub(crate) async fn coordinator<V>(
                                 let is_new_peer = peer_manager.add_peer(peer);
                                 notify_subscribers(SharedMempoolNotification::PeerStateChange, &subscribers);
                                 if is_new_peer && peer_manager.is_upstream_peer(peer) {
-                                    tasks::execute_broadcast(peer, &mut smp, &mut scheduled_broadcasts, executor.clone());
+                                    tasks::execute_broadcast(peer, false, &mut smp, &mut scheduled_broadcasts, executor.clone());
                                 }
                             }
                             Event::LostPeer(peer_id) => {

--- a/mempool/src/shared_mempool/network.rs
+++ b/mempool/src/shared_mempool/network.rs
@@ -31,6 +31,8 @@ pub enum MempoolSyncMsg {
         request_id: String,
         /// indices of transactions that failed that may succeed on resend
         retry_txns: Vec<u64>,
+        /// backpressure signal from recipient when it is overwhelmed (e.g. mempool is full)
+        backoff: bool,
     },
 }
 

--- a/mempool/src/shared_mempool/peer_manager.rs
+++ b/mempool/src/shared_mempool/peer_manager.rs
@@ -32,6 +32,8 @@ pub struct BroadcastInfo {
     pub sent_batches: HashMap<String, Vec<u64>>,
     // timeline IDs of all txns that need to be retried and ACKed for
     pub total_retry_txns: BTreeSet<u64>,
+    // whether broadcasts are in backoff/backpressure mode, e.g. broadcasting at longer intervals
+    pub backoff_mode: bool,
 }
 
 impl BroadcastInfo {
@@ -39,6 +41,7 @@ impl BroadcastInfo {
         Self {
             sent_batches: HashMap::new(),
             total_retry_txns: BTreeSet::new(),
+            backoff_mode: false,
         }
     }
 }
@@ -124,6 +127,7 @@ impl PeerManager {
         peer: PeerNetworkId,
         batch_id: String,
         retry_txns: Vec<u64>,
+        backoff: bool,
     ) {
         let mut peer_info = self
             .peer_info
@@ -154,6 +158,7 @@ impl PeerManager {
                 }
             }
         }
+        sync_state.broadcast_info.backoff_mode = backoff;
     }
 
     pub fn get_broadcast_batch(&self, peer: PeerNetworkId, batch_id: &str) -> Option<Vec<u64>> {

--- a/mempool/src/shared_mempool/tasks.rs
+++ b/mempool/src/shared_mempool/tasks.rs
@@ -226,10 +226,7 @@ pub(crate) async fn process_transaction_broadcast<V>(
         .network_senders
         .get_mut(&peer.network_id())
         .expect("[shared mempool] missing network sender");
-    if let Err(e) = send_mempool_sync_msg(ack_response,
-        peer.peer_id(),
-        &mut network_sender,
-    ) {
+    if let Err(e) = send_mempool_sync_msg(ack_response, peer.peer_id(), &mut network_sender) {
         error!(
             "[shared mempool] failed to send ACK back to peer {:?}: {}",
             peer, e
@@ -391,6 +388,7 @@ pub(crate) fn process_broadcast_ack(
     peer: PeerNetworkId,
     request_id: String,
     retry_txns: Vec<u64>,
+    backoff: bool,
     is_validator: bool, // whether this node is a validator or not
     peer_manager: Arc<PeerManager>,
 ) {
@@ -415,7 +413,7 @@ pub(crate) fn process_broadcast_ack(
         }
     }
 
-    peer_manager.process_broadcast_ack(peer, request_id, retry_txns);
+    peer_manager.process_broadcast_ack(peer, request_id, retry_txns, backoff);
 }
 
 // ================================= //

--- a/mempool/src/shared_mempool/types.rs
+++ b/mempool/src/shared_mempool/types.rs
@@ -75,12 +75,14 @@ pub(crate) struct ScheduledBroadcast {
     deadline: Instant,
     /// broadcast recipient
     peer: PeerNetworkId,
+    /// whether this broadcast was scheduled in backoff mode
+    backoff: bool,
     /// the waker that will be used to notify the executor when the broadcast is ready
     waker: Arc<Mutex<Option<Waker>>>,
 }
 
 impl ScheduledBroadcast {
-    pub fn new(deadline: Instant, peer: PeerNetworkId, executor: Handle) -> Self {
+    pub fn new(deadline: Instant, peer: PeerNetworkId, backoff: bool, executor: Handle) -> Self {
         let waker: Arc<Mutex<Option<Waker>>> = Arc::new(Mutex::new(None));
         let waker_clone = waker.clone();
 
@@ -98,13 +100,14 @@ impl ScheduledBroadcast {
         Self {
             deadline,
             peer,
+            backoff,
             waker,
         }
     }
 }
 
 impl Future for ScheduledBroadcast {
-    type Output = PeerNetworkId;
+    type Output = (PeerNetworkId, bool); // (peer, whether this broadcast was scheduled as a backoff broadcast)
 
     fn poll(self: Pin<&mut Self>, context: &mut Context) -> Poll<Self::Output> {
         if Instant::now() < self.deadline {
@@ -114,7 +117,7 @@ impl Future for ScheduledBroadcast {
 
             Poll::Pending
         } else {
-            Poll::Ready(self.peer)
+            Poll::Ready((self.peer, self.backoff))
         }
     }
 }

--- a/mempool/src/tests/shared_mempool_test.rs
+++ b/mempool/src/tests/shared_mempool_test.rs
@@ -218,6 +218,7 @@ impl SharedMempoolNetwork {
         // validator config
         let mut config = NodeConfig::random();
         config.mempool.shared_mempool_batch_size = broadcast_batch_size;
+        config.mempool.shared_mempool_backoff_interval_ms = 50;
         if let Some(capacity) = mempool_size {
             config.mempool.capacity = capacity
         }
@@ -234,6 +235,7 @@ impl SharedMempoolNetwork {
         let mut fn_config = NodeConfig::random();
         fn_config.base.role = RoleType::FullNode;
         fn_config.mempool.shared_mempool_batch_size = broadcast_batch_size;
+        fn_config.mempool.shared_mempool_backoff_interval_ms = 50;
         if let Some(capacity) = mempool_size {
             fn_config.mempool.capacity = capacity
         }


### PR DESCRIPTION
## Motivation

Add backpressure functionality in mempool, s.t. if a recipient mempool can signal to the sender mempool that it is overwhelmed. 
Upon receiving such a signal, the sender mempool can send broadcasts at later intervals

