### PR TITLE
[backup] CommandAdapter backup storage

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -205,6 +205,7 @@ dependencies = [
  "libra-canonical-serialization 0.1.0",
  "libra-config 0.1.0",
  "libra-crypto 0.1.0",
+ "libra-logger 0.1.0",
  "libra-proptest-helpers 0.1.0",
  "libra-temppath 0.1.0",
  "libra-types 0.1.0",
@@ -219,6 +220,7 @@ dependencies = [
  "structopt 0.3.14 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio 0.2.21 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-util 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "toml 0.5.6 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]

--- a/storage/backup/backup-cli/Cargo.toml
+++ b/storage/backup/backup-cli/Cargo.toml
@@ -21,11 +21,13 @@ reqwest = { version = "0.10.6", features = ["stream"], default-features = false 
 serde = { version = "1.0.112", features = ["derive"] }
 serde_json = "1.0.55"
 structopt = "0.3.14"
+toml = "0.5.6"
 tokio = "0.2.21"
 tokio-util = { version = "0.3.1", features = ["compat"] }
 
 lcs = { path = "../../../common/lcs", package = "libra-canonical-serialization", version = "0.1.0" }
 libra-crypto = { path = "../../../crypto/crypto", version = "0.1.0" }
+libra-logger = { path = "../../../common/logger", version = "0.1.0" }
 libra-types = { path = "../../../types", version = "0.1.0" }
 libra-workspace-hack = { path = "../../../common/workspace-hack", version = "0.1.0" }
 libradb = { path = "../../libradb", version = "0.1.0" }

--- a/storage/backup/backup-cli/src/backup.rs
+++ b/storage/backup/backup-cli/src/backup.rs
@@ -23,7 +23,7 @@ use tokio_util::compat::FuturesAsyncReadCompatExt;
 pub struct BackupServiceClientOpt {
     #[structopt(
         long = "backup-service-port",
-        about = "Backup service port. The service must listen on localhost."
+        help = "Backup service port. The service must listen on localhost."
     )]
     pub port: u16,
 }
@@ -95,7 +95,7 @@ impl BackupServiceClient {
 
 #[derive(StructOpt)]
 pub struct GlobalBackupOpt {
-    #[structopt(long = "max-chunk-size", about = "Maximum chunk file size in bytes.")]
+    #[structopt(long = "max-chunk-size", help = "Maximum chunk file size in bytes.")]
     pub max_chunk_size: usize,
 }
 
@@ -103,7 +103,7 @@ pub struct GlobalBackupOpt {
 pub struct StateSnapshotBackupOpt {
     #[structopt(
         long = "state-version",
-        about = "Version at which a state snapshot to be taken."
+        help = "Version at which a state snapshot to be taken."
     )]
     pub version: Version,
 }

--- a/storage/backup/backup-cli/src/backup.rs
+++ b/storage/backup/backup-cli/src/backup.rs
@@ -262,9 +262,8 @@ impl StateSnapshotBackupController {
         chunks: Vec<StateSnapshotChunk>,
     ) -> Result<FileHandle> {
         let proof_bytes = self.client.get_state_root_proof(self.version).await?;
-        let (txn_info, ledger_info): (TransactionInfoWithProof, LedgerInfoWithSignatures) =
+        let (txn_info, _): (TransactionInfoWithProof, LedgerInfoWithSignatures) =
             lcs::from_bytes(&proof_bytes)?;
-        assert_eq!(ledger_info.ledger_info().version(), self.version);
 
         let (proof_handle, mut proof_file) = self
             .storage

--- a/storage/backup/backup-cli/src/storage/command_adapter/config.rs
+++ b/storage/backup/backup-cli/src/storage/command_adapter/config.rs
@@ -1,0 +1,79 @@
+// Copyright (c) The Libra Core Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::storage::{BackupHandle, FileHandle};
+use anyhow::Result;
+use serde::Deserialize;
+use std::path::PathBuf;
+use tokio::io::AsyncReadExt;
+
+#[derive(Clone, Debug, Deserialize)]
+pub struct EnvVar {
+    pub key: String,
+    pub value: String,
+}
+
+impl EnvVar {
+    pub fn backup_name(value: String) -> Self {
+        Self::new("BACKUP_NAME".to_string(), value)
+    }
+
+    pub fn file_name(value: String) -> Self {
+        Self::new("FILE_NAME".to_string(), value)
+    }
+
+    pub fn file_handle(value: FileHandle) -> Self {
+        Self::new("FILE_HANDLE".to_string(), value)
+    }
+
+    pub fn backup_handle(value: BackupHandle) -> Self {
+        Self::new("BACKUP_HANDLE".to_string(), value)
+    }
+
+    pub fn new(key: String, value: String) -> Self {
+        Self { key, value }
+    }
+}
+
+#[derive(Deserialize)]
+pub struct Commands {
+    /// Command line to create backup.
+    /// input env vars:
+    ///     $BACKUP_NAME
+    /// expected output on stdout:
+    ///     BackupHandle, without trailing new line.
+    pub create_backup: String,
+    /// Command line to open a file for writing.
+    /// input env vars:
+    ///     $BACKUP_HANDLE returned from the previous command
+    ///     $FILE_NAME
+    /// stdin will be fed with byte stream.
+    /// expected output on stdout:
+    ///     FileHandle, without trailing new line.
+    pub create_for_write: String,
+    /// Command line to open a file for reading.
+    /// input env vars:
+    ///     $FILE_NAME
+    /// expected stdout to stream out bytes of the file.
+    pub open_for_read: String,
+}
+
+#[derive(Deserialize)]
+pub struct CommandAdapterConfig {
+    pub commands: Commands,
+    pub env_vars: Vec<EnvVar>,
+}
+
+impl CommandAdapterConfig {
+    pub async fn load_from_file(path: &PathBuf) -> Result<Self> {
+        let mut file = tokio::fs::File::open(path).await?;
+        let mut content = Vec::new();
+        file.read_to_end(&mut content).await?;
+
+        Ok(toml::from_slice(&content)?)
+    }
+
+    pub fn load_from_str(content: &str) -> Result<Self> {
+        Ok(toml::from_str(content)?)
+    }
+}

--- a/storage/backup/backup-cli/src/storage/command_adapter/config.rs
+++ b/storage/backup/backup-cli/src/storage/command_adapter/config.rs
@@ -60,7 +60,9 @@ pub struct Commands {
 
 #[derive(Deserialize)]
 pub struct CommandAdapterConfig {
+    /// Command lines that implements `BackupStorage` APIs.
     pub commands: Commands,
+    /// Additional environment variables to be set when command lines are spawned.
     pub env_vars: Vec<EnvVar>,
 }
 

--- a/storage/backup/backup-cli/src/storage/command_adapter/local_folder.sample.toml
+++ b/storage/backup/backup-cli/src/storage/command_adapter/local_folder.sample.toml
@@ -1,0 +1,8 @@
+[[env_vars]]
+key = "FOLDER"
+value = "{}"
+
+[commands]
+create_backup = 'cd -- "$FOLDER" && mkdir -- "$BACKUP_NAME" && echo -n "$BACKUP_NAME"'
+create_for_write = 'cd -- "$FOLDER" && cd -- "$BACKUP_HANDLE" && test ! -f "$FILE_NAME" && touch -- "$FILE_NAME" && echo -n `pwd`/"$FILE_NAME" && exec >&- && cat > "$FILE_NAME"'
+open_for_read = 'cat "$FILE_HANDLE"'

--- a/storage/backup/backup-cli/src/storage/command_adapter/mod.rs
+++ b/storage/backup/backup-cli/src/storage/command_adapter/mod.rs
@@ -25,6 +25,8 @@ pub struct CommandAdapterOpt {
     config: PathBuf,
 }
 
+/// A BackupStorage that delegates required APIs to configured command lines.
+/// see `CommandAdapterConfig`.
 pub struct CommandAdapter {
     config: CommandAdapterConfig,
 }

--- a/storage/backup/backup-cli/src/storage/command_adapter/mod.rs
+++ b/storage/backup/backup-cli/src/storage/command_adapter/mod.rs
@@ -1,0 +1,142 @@
+// Copyright (c) The Libra Core Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+mod config;
+
+#[cfg(test)]
+mod tests;
+
+use crate::storage::{
+    command_adapter::config::{CommandAdapterConfig, EnvVar},
+    BackupHandle, BackupHandleRef, BackupStorage, FileHandle, FileHandleRef,
+};
+use anyhow::{anyhow, ensure, Result};
+use async_trait::async_trait;
+use std::{path::PathBuf, process::Stdio};
+use structopt::StructOpt;
+use tokio::io::{AsyncRead, AsyncReadExt, AsyncWrite};
+
+#[derive(StructOpt)]
+pub struct CommandAdapterOpt {
+    #[structopt(
+        long = "config",
+        help = "Config file for the command adapter backup store."
+    )]
+    config: PathBuf,
+}
+
+pub struct CommandAdapter {
+    config: CommandAdapterConfig,
+}
+
+impl CommandAdapter {
+    pub fn new(config: CommandAdapterConfig) -> Self {
+        Self { config }
+    }
+
+    pub async fn new_with_opt(opt: CommandAdapterOpt) -> Result<Self> {
+        let config = CommandAdapterConfig::load_from_file(&opt.config).await?;
+
+        Ok(Self::new(config))
+    }
+
+    fn cmd(&self, cmd_str: &str, mut env_vars: Vec<EnvVar>) -> Command {
+        env_vars.extend_from_slice(&self.config.env_vars);
+        Command::new(cmd_str.to_string(), env_vars)
+    }
+}
+
+#[async_trait]
+impl BackupStorage for CommandAdapter {
+    async fn create_backup(&self, name: &str) -> Result<BackupHandle> {
+        let mut cmd = self.cmd(
+            &self.config.commands.create_backup,
+            vec![EnvVar::backup_name(name.to_string())],
+        );
+        let output = cmd.spawn().await?.wait_with_output().await?;
+        ensure!(
+            output.status.success(),
+            "Failed running command: {:?}, Exit code: {:?}",
+            cmd,
+            output.status.code(),
+        );
+        Ok(BackupHandle::from_utf8(output.stdout)?)
+    }
+
+    async fn create_for_write(
+        &self,
+        backup_handle: &BackupHandleRef,
+        name: &str,
+    ) -> Result<(FileHandle, Box<dyn AsyncWrite + Send + Unpin>)> {
+        let mut child = self
+            .cmd(
+                &self.config.commands.create_for_write,
+                vec![
+                    EnvVar::backup_handle(backup_handle.to_string()),
+                    EnvVar::file_name(name.to_string()),
+                ],
+            )
+            .spawn()
+            .await?;
+        let stdin = child
+            .stdin
+            .take()
+            .ok_or_else(|| anyhow!("Child process stdin is None."))?;
+        let mut stdout = child
+            .stdout
+            .take()
+            .ok_or_else(|| anyhow!("Child process stdout is None."))?;
+        let mut file_handle = FileHandle::new();
+        stdout.read_to_string(&mut file_handle).await?;
+        Ok((file_handle, Box::new(stdin)))
+    }
+
+    async fn open_for_read(
+        &self,
+        file_handle: &FileHandleRef,
+    ) -> Result<Box<dyn AsyncRead + Send + Unpin>> {
+        let mut child = self
+            .cmd(
+                &self.config.commands.open_for_read,
+                vec![EnvVar::file_handle(file_handle.to_string())],
+            )
+            .spawn()
+            .await?;
+        let stdout = child
+            .stdout
+            .take()
+            .ok_or_else(|| anyhow!("Child process stdout is None."))?;
+        Ok(Box::new(stdout))
+    }
+}
+
+#[derive(Debug)]
+struct Command {
+    cmd_str: String,
+    env_vars: Vec<EnvVar>,
+}
+
+impl Command {
+    pub fn new(cmd_str: String, env_vars: Vec<EnvVar>) -> Self {
+        Self { cmd_str, env_vars }
+    }
+
+    fn tokio_cmd(&self, cmd_str: &str) -> tokio::process::Command {
+        let mut cmd = tokio::process::Command::new("sh");
+        cmd.args(&["-c", cmd_str]);
+        cmd.stdin(Stdio::piped())
+            .stdout(Stdio::piped())
+            .stderr(Stdio::inherit());
+
+        for v in &self.env_vars {
+            cmd.env(&v.key, &v.value);
+        }
+
+        cmd
+    }
+
+    async fn spawn(&mut self) -> Result<tokio::process::Child> {
+        println!("Spawning {:?}", self);
+        Ok(self.tokio_cmd(&self.cmd_str).spawn()?)
+    }
+}

--- a/storage/backup/backup-cli/src/storage/command_adapter/s3.sample.toml
+++ b/storage/backup/backup-cli/src/storage/command_adapter/s3.sample.toml
@@ -1,0 +1,8 @@
+[[env_vars]]
+key = "BUCKET"
+value = "libra-backup"
+
+[commands]
+create_backup = 'echo -n "$BACKUP_NAME"'
+create_for_write = 'echo -n "s3://$BUCKET/$BACKUP_HANDLE/$FILE_NAME" && exec >&- && aws s3 cp - "s3://$BUCKET/$BACKUP_HANDLE/$FILE_NAME"'
+open_for_read = 'aws s3 cp "$FILE_HANDLE" -'

--- a/storage/backup/backup-cli/src/storage/command_adapter/tests.rs
+++ b/storage/backup/backup-cli/src/storage/command_adapter/tests.rs
@@ -1,0 +1,37 @@
+// Copyright (c) The Libra Core Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+use super::*;
+use crate::storage::test_util::{arb_backups, test_write_and_read_impl};
+use libra_temppath::TempPath;
+use proptest::prelude::*;
+use tokio::runtime::Runtime;
+
+proptest! {
+    #![proptest_config(ProptestConfig::with_cases(10))]
+
+    #[test]
+    fn test_write_and_read(
+        backups in arb_backups()
+    ) {
+        let mut rt = Runtime::new().unwrap();
+        let tmpdir = TempPath::new();
+        tmpdir.create_as_dir().unwrap();
+
+        let config = CommandAdapterConfig::load_from_str(
+            &format!(r#"
+                [[env_vars]]
+                key = "FOLDER"
+                value = "{}"
+
+                [commands]
+                create_backup = 'cd -- "$FOLDER" && mkdir -- "$BACKUP_NAME" && echo -n "$BACKUP_NAME"'
+                create_for_write = 'cd -- "$FOLDER" && cd -- "$BACKUP_HANDLE" && test ! -f "$FILE_NAME" && touch -- "$FILE_NAME" && echo -n `pwd`/"$FILE_NAME" && exec >&- && cat > "$FILE_NAME"'
+                open_for_read = 'cat "$FILE_HANDLE"'
+            "#, tmpdir.path().to_str().unwrap()),
+        ).unwrap();
+
+        let store = CommandAdapter::new(config);
+        rt.block_on(test_write_and_read_impl(Box::new(store), &tmpdir, backups));
+    }
+}

--- a/storage/backup/backup-cli/src/storage/local_fs/mod.rs
+++ b/storage/backup/backup-cli/src/storage/local_fs/mod.rs
@@ -19,7 +19,7 @@ use tokio::{
 #[derive(StructOpt)]
 pub struct LocalFsOpt {
     #[structopt(
-        long = "local-backup-store",
+        long = "dir",
         parse(from_os_str),
         help = "Target local dir to hold backups."
     )]

--- a/storage/backup/backup-cli/src/storage/local_fs/tests.rs
+++ b/storage/backup/backup-cli/src/storage/local_fs/tests.rs
@@ -2,74 +2,23 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use super::*;
+use crate::storage::test_util::{arb_backups, test_write_and_read_impl};
 use libra_temppath::TempPath;
-use proptest::{
-    collection::{hash_map, vec},
-    prelude::*,
-};
-use std::{collections::HashMap, pin::Pin};
-use tokio::{
-    io::{AsyncReadExt, AsyncWriteExt},
-    runtime::Runtime,
-};
-
-fn to_file_name(tmpdir: &TempPath, backup_name: &str, file_name: &str) -> String {
-    tmpdir
-        .path()
-        .to_path_buf()
-        .join(backup_name)
-        .join(file_name)
-        .into_os_string()
-        .into_string()
-        .unwrap()
-}
-
-async fn test_write_and_read_impl(backups: HashMap<String, HashMap<String, Vec<u8>>>) {
-    let tmpdir = TempPath::new();
-    tmpdir.create_as_dir().unwrap();
-    let store = LocalFs::new(tmpdir.path().to_path_buf());
-
-    for (backup_name, files) in &backups {
-        let backup_handle = store.create_backup(backup_name).await.unwrap();
-        assert_eq!(&backup_handle, backup_name);
-        for (name, content) in files {
-            let (handle, file) = store.create_for_write(&backup_handle, name).await.unwrap();
-            assert_eq!(handle, to_file_name(&tmpdir, backup_name, name));
-            Pin::new(file).write_all(content).await.unwrap();
-        }
-    }
-
-    for (backup_name, files) in &backups {
-        for (name, content) in files {
-            let handle = to_file_name(&tmpdir, backup_name, name);
-            let mut file = store.open_for_read(&handle).await.unwrap();
-            let mut buf = Vec::new();
-            file.read_to_end(&mut buf).await.unwrap();
-            assert_eq!(content, &buf);
-        }
-    }
-}
-
-fn arb_file_name() -> impl Strategy<Value = String> {
-    r"[-A-Za-z0-9_.]{1, 50}".prop_filter("no . and ..", |s| s != "." && s != "..")
-}
+use proptest::prelude::*;
+use tokio::runtime::Runtime;
 
 proptest! {
     #![proptest_config(ProptestConfig::with_cases(10))]
 
     #[test]
     fn test_write_and_read(
-        backups in hash_map(
-            arb_file_name(), // backup_name
-            hash_map(
-                arb_file_name(), // file name
-                vec(any::<u8>(), 1..1000), // file content
-                1..10
-            ),
-            1..10
-        )
+        backups in arb_backups()
     ) {
+        let tmpdir = TempPath::new();
+        tmpdir.create_as_dir().unwrap();
+        let store = LocalFs::new(tmpdir.path().to_path_buf());
+
         let mut rt = Runtime::new().unwrap();
-        rt.block_on(test_write_and_read_impl(backups));
+        rt.block_on(test_write_and_read_impl(Box::new(store), &tmpdir, backups));
     }
 }

--- a/storage/backup/backup-cli/src/storage/test_util.rs
+++ b/storage/backup/backup-cli/src/storage/test_util.rs
@@ -1,0 +1,64 @@
+// Copyright (c) The Libra Core Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::storage::BackupStorage;
+use libra_temppath::TempPath;
+use proptest::{
+    collection::{hash_map, vec},
+    prelude::*,
+};
+use std::collections::HashMap;
+use tokio::io::{AsyncReadExt, AsyncWriteExt};
+
+fn to_file_name(tmpdir: &TempPath, backup_name: &str, file_name: &str) -> String {
+    tmpdir
+        .path()
+        .to_path_buf()
+        .join(backup_name)
+        .join(file_name)
+        .into_os_string()
+        .into_string()
+        .unwrap()
+}
+
+pub async fn test_write_and_read_impl(
+    store: Box<dyn BackupStorage>,
+    tmpdir: &TempPath,
+    backups: HashMap<String, HashMap<String, Vec<u8>>>,
+) {
+    for (backup_name, files) in &backups {
+        let backup_handle = store.create_backup(backup_name).await.unwrap();
+        assert_eq!(&backup_handle, backup_name);
+        for (name, content) in files {
+            let (handle, mut file) = store.create_for_write(&backup_handle, name).await.unwrap();
+            assert_eq!(handle, to_file_name(&tmpdir, backup_name, name));
+            file.write_all(content).await.unwrap();
+        }
+    }
+
+    for (backup_name, files) in &backups {
+        for (name, content) in files {
+            let handle = to_file_name(&tmpdir, backup_name, name);
+            let mut file = store.open_for_read(&handle).await.unwrap();
+            let mut buf = Vec::new();
+            file.read_to_end(&mut buf).await.unwrap();
+            assert_eq!(content, &buf);
+        }
+    }
+}
+
+fn arb_file_name() -> impl Strategy<Value = String> {
+    r"[-A-Za-z0-9_.]{1, 50}".prop_filter("no . and ..", |s| s != "." && s != "..")
+}
+
+pub fn arb_backups() -> impl Strategy<Value = HashMap<String, HashMap<String, Vec<u8>>>> {
+    hash_map(
+        arb_file_name(), // backup_name
+        hash_map(
+            arb_file_name(),           // file name
+            vec(any::<u8>(), 1..1000), // file content
+            1..10,
+        ),
+        1..10,
+    )
+}


### PR DESCRIPTION
## Motivation

To connect the backup and restore CLI with external commnads (aws s3 client in mind.)
For the three BackupStorate trait interfaces, a comand line is configured for each. Inputs are strings and fed via env vars. Output are via stdout (string output and stream for reading) and stdin (stream for writing). Stderr is inherited.

Demonstrated with sample config file containing standard linux commands doing local IO (mimicing what the LocaFs store does.)

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?
yes
## Test Plan
unit tests

and manually for s3:

**$ RUST_BACKTRACE=full cargo run -p backup-cli --bin backup -- --max-chunk-size 100000000 --backup-service-port 49039 --state-version 1700 command-adapter --config storage/backup/backup-cli/src/storage/com
mand_adapter/s3.sample.toml**
    Finished dev [unoptimized + debuginfo] target(s) in 0.35s
     Running `target/debug/backup --max-chunk-size 100000000 --backup-service-port 49039 --state-version 1700 command-adapter --config storage/backup/backup-cli/src/storage/command_adapter/s3.sample.toml`
Spawning Command { cmd_str: "echo -n \"$BACKUP_NAME\"", env_vars: [EnvVar { key: "BACKUP_NAME", value: "state_ver_1700" }, EnvVar { key: "BUCKET", value: "libra-aldenhu/test/libra-backup" }] }
Last chunk.
Asking proof for key: HashValue(f1c91ebc002f3efc035bf7f22949356af8bae9665bb8ccfb6542939fdd78cc5d)
Spawning Command { cmd_str: "echo -n \"s3://$BUCKET/$BACKUP_HANDLE/$FILE_NAME\" && exec >&- && aws s3 cp - \"s3://$BUCKET/$BACKUP_HANDLE/$FILE_NAME\"", env_vars: [EnvVar { key: "BACKUP_HANDLE", value: "state_ver_1700" }, EnvVar { key: "FILE_NAME", value: "0-.chunk" }, EnvVar { key: "BUCKET", value: "libra-aldenhu/test/libra-backup" }] }
Spawning Command { cmd_str: "echo -n \"s3://$BUCKET/$BACKUP_HANDLE/$FILE_NAME\" && exec >&- && aws s3 cp - \"s3://$BUCKET/$BACKUP_HANDLE/$FILE_NAME\"", env_vars: [EnvVar { key: "BACKUP_HANDLE", value: "state_ver_1700" }, EnvVar { key: "FILE_NAME", value: "0-10.proof" }, EnvVar { key: "BUCKET", value: "libra-aldenhu/test/libra-backup" }] }
Spawning Command { cmd_str: "echo -n \"s3://$BUCKET/$BACKUP_HANDLE/$FILE_NAME\" && exec >&- && aws s3 cp - \"s3://$BUCKET/$BACKUP_HANDLE/$FILE_NAME\"", env_vars: [EnvVar { key: "BACKUP_HANDLE", value: "state_ver_1700" }, EnvVar { key: "FILE_NAME", value: "state.proof" }, EnvVar { key: "BUCKET", value: "libra-aldenhu/test/libra-backup" }] }
Spawning Command { cmd_str: "echo -n \"s3://$BUCKET/$BACKUP_HANDLE/$FILE_NAME\" && exec >&- && aws s3 cp - \"s3://$BUCKET/$BACKUP_HANDLE/$FILE_NAME\"", env_vars: [EnvVar { key: "BACKUP_HANDLE", value: "state_ver_1700" }, EnvVar { key: "FILE_NAME", value: "state.manifest" }, EnvVar { key: "BUCKET", value: "libra-aldenhu/test/libra-backup" }] }
**Success. Manifest saved to s3://libra-aldenhu/test/libra-backup/state_ver_1700/state.manifest**

**$ cargo run -p backup-cli --bin restore -- --target-db-dir /tmp/a768a000d30ce664a9ffe876bd85f2b1/restore --state-manifest "s3://libra-aldenhu/test/libra-backup/state_ver_1700/state.manifest" --state-into-
version 1700 command-adapter --config  storage/backup/backup-cli/src/storage/command_adapter/s3.sample.toml**
    Finished dev [unoptimized + debuginfo] target(s) in 0.37s
     Running `target/debug/restore --target-db-dir /tmp/a768a000d30ce664a9ffe876bd85f2b1/restore --state-manifest 's3://libra-aldenhu/test/libra-backup/state_ver_1700/state.manifest' --state-into-version 1700 command-adapter --config storage/backup/backup-cli/src/storage/command_adapter/s3.sample.toml`
Spawning Command { cmd_str: "aws s3 cp \"$FILE_HANDLE\" -", env_vars: [EnvVar { key: "FILE_HANDLE", value: "s3://libra-aldenhu/test/libra-backup/state_ver_1700/state.manifest" }, EnvVar { key: "BUCKET", value: "libra-aldenhu/test/libra-backup" }] }
Spawning Command { cmd_str: "aws s3 cp \"$FILE_HANDLE\" -", env_vars: [EnvVar { key: "FILE_HANDLE", value: "s3://libra-aldenhu/test/libra-backup/state_ver_1700/0-.chunk" }, EnvVar { key: "BUCKET", value: "libra-aldenhu/test/libra-backup" }] }
Spawning Command { cmd_str: "aws s3 cp \"$FILE_HANDLE\" -", env_vars: [EnvVar { key: "FILE_HANDLE", value: "s3://libra-aldenhu/test/libra-backup/state_ver_1700/0-10.proof" }, EnvVar { key: "BUCKET", value: "libra-aldenhu/test/libra-backup" }] }
**Finished restoring account state.**

## Related PRs

(If this PR adds or changes functionality, please take some time to update the docs at https://github.com/libra/website, and link to your PR here.)
