### PR TITLE
[cluster-test] Update cluster swarm API to return Instance on creation

### DIFF
--- a/testsuite/cluster-test/src/cluster.rs
+++ b/testsuite/cluster-test/src/cluster.rs
@@ -4,7 +4,6 @@
 #![forbid(unsafe_code)]
 
 use crate::instance::Instance;
-use anyhow::Result;
 use config_builder::ValidatorConfig;
 use libra_crypto::{
     ed25519::{Ed25519PrivateKey, Ed25519PublicKey},
@@ -54,16 +53,13 @@ impl Cluster {
         KeyPair::from(mint_key)
     }
 
-    pub fn new_k8s(
-        validator_instances: Vec<Instance>,
-        fullnode_instances: Vec<Instance>,
-    ) -> Result<Self> {
-        Ok(Self {
+    pub fn new(validator_instances: Vec<Instance>, fullnode_instances: Vec<Instance>) -> Self {
+        Self {
             validator_instances,
             fullnode_instances,
             prometheus_ip: None,
             mint_key_pair: Self::get_mint_key_pair(),
-        })
+        }
     }
 
     pub fn random_validator_instance(&self) -> Instance {

--- a/testsuite/cluster-test/src/cluster.rs
+++ b/testsuite/cluster-test/src/cluster.rs
@@ -17,7 +17,6 @@ pub struct Cluster {
     // guaranteed non-empty
     validator_instances: Vec<Instance>,
     fullnode_instances: Vec<Instance>,
-    prometheus_ip: Option<String>,
     mint_key_pair: KeyPair<Ed25519PrivateKey, Ed25519PublicKey>,
 }
 
@@ -38,7 +37,6 @@ impl Cluster {
         Self {
             validator_instances: instances,
             fullnode_instances: vec![],
-            prometheus_ip: None,
             mint_key_pair,
         }
     }
@@ -57,7 +55,6 @@ impl Cluster {
         Self {
             validator_instances,
             fullnode_instances,
-            prometheus_ip: None,
             mint_key_pair: Self::get_mint_key_pair(),
         }
     }
@@ -86,10 +83,6 @@ impl Cluster {
 
     pub fn into_fullnode_instances(self) -> Vec<Instance> {
         self.fullnode_instances
-    }
-
-    pub fn prometheus_ip(&self) -> Option<&String> {
-        self.prometheus_ip.as_ref()
     }
 
     pub fn mint_key_pair(&self) -> &KeyPair<Ed25519PrivateKey, Ed25519PublicKey> {
@@ -143,7 +136,6 @@ impl Cluster {
         Cluster {
             validator_instances: instances,
             fullnode_instances: vec![],
-            prometheus_ip: self.prometheus_ip.clone(),
             mint_key_pair: self.mint_key_pair.clone(),
         }
     }
@@ -152,7 +144,6 @@ impl Cluster {
         Cluster {
             validator_instances: vec![],
             fullnode_instances: instances,
-            prometheus_ip: self.prometheus_ip.clone(),
             mint_key_pair: self.mint_key_pair.clone(),
         }
     }

--- a/testsuite/cluster-test/src/cluster_swarm/cluster_swarm_kube.rs
+++ b/testsuite/cluster-test/src/cluster_swarm/cluster_swarm_kube.rs
@@ -495,20 +495,22 @@ impl ClusterSwarm for ClusterSwarmKube {
             Err(e) => bail!("Failed to create service : {}", e),
         }
         let (node_name, pod_ip) = self.get_pod_node_and_ip(&pod_name).await?;
+        assert!(
+            !node_name.is_empty(),
+            "get_pod_node_and_ip returned empty node_name"
+        );
         let ac_port = DEFAULT_JSON_RPC_PORT as u32;
         let instance = Instance::new_k8s(
             pod_name,
             pod_ip,
             ac_port,
-            Some(node_name.clone()),
+            node_name.clone(),
             instance_config.clone(),
         );
-        if node_name.is_empty() {
-            self.node_map
-                .lock()
-                .await
-                .insert(instance_config, instance.clone());
-        }
+        self.node_map
+            .lock()
+            .await
+            .insert(instance_config, instance.clone());
         Ok(instance)
     }
 

--- a/testsuite/cluster-test/src/instance.rs
+++ b/testsuite/cluster-test/src/instance.rs
@@ -63,14 +63,14 @@ impl Instance {
         peer_name: String,
         ip: String,
         ac_port: u32,
-        k8s_node: Option<String>,
+        k8s_node: String,
         instance_config: InstanceConfig,
     ) -> Instance {
         Instance {
             peer_name,
             ip,
             ac_port,
-            k8s_node,
+            k8s_node: Some(k8s_node),
             instance_config: Some(instance_config),
         }
     }

--- a/testsuite/cluster-test/src/main.rs
+++ b/testsuite/cluster-test/src/main.rs
@@ -412,7 +412,7 @@ impl ClusterUtil {
             )
             .await
             .unwrap_or_else(|_| panic!("{} scaling failed", asg_name));
-            cluster_swarm
+            let (validators, fullnodes) = cluster_swarm
                 .create_validator_and_fullnode_set(
                     args.k8s_num_validators,
                     args.k8s_fullnodes_per_validator,
@@ -422,11 +422,7 @@ impl ClusterUtil {
                 .await
                 .expect("Failed to create_validator_and_fullnode_set");
             info!("Deployment complete");
-            let cluster = Cluster::new_k8s(
-                cluster_swarm.validator_instances().await,
-                cluster_swarm.fullnode_instances().await,
-            )
-            .unwrap();
+            let cluster = Cluster::new(validators, fullnodes);
 
             let cluster = if args.peers.is_empty() {
                 cluster


### PR DESCRIPTION
This changes updates upsert_node api so it returns Instance, instead of `()`. This will allow to use it in test like reconfiguration, where you need to add new validator and then do something with it.

It also updates API calls like `create_validator_set` etc to return Vec<Instance>.
