### PR TITLE
[network][connmgr] Improve logging of peer address updates

### DIFF
--- a/network/src/connectivity_manager/mod.rs
+++ b/network/src/connectivity_manager/mod.rs
@@ -391,6 +391,7 @@ where
                 // Keep track of if any peer's addresses have actually changed, so
                 // we can log without too much spam.
                 let mut have_any_changed = false;
+                let self_peer_id = self.self_peer_id.short_str();
 
                 for (peer_id, addrs) in address_map {
                     // Do not include self_peer_id in the address list for dialing
@@ -410,18 +411,23 @@ where
                         if let Some(dial_state) = self.dial_states.get_mut(&peer_id) {
                             dial_state.reset_addr();
                         }
+
+                        // Log the change to this peer's addresses.
+                        let peer_id = peer_id.short_str();
+                        let addrs = curr_addrs;
+                        info!(
+                            "[{}] addresses updated for peer: {}, update src: {:?}, addrs: {}",
+                            self_peer_id, peer_id, src, addrs,
+                        );
                     }
                 }
 
-                // Only log if a peer's addresses have actually changed.
+                // Only log the total state if anything has actually changed.
                 if have_any_changed {
-                    let self_peer_id = self.self_peer_id.short_str();
                     let peer_addresses = &self.peer_addresses;
                     info!(
-                        "[{}] Received updated addresses from discovery: {:?}. All peer addresses: {}",
-                        self_peer_id,
-                        src,
-                        peer_addresses,
+                        "[{}] current addresses: update src: {:?}, all peer addresses: {}",
+                        self_peer_id, src, peer_addresses,
                     );
                 }
             }

--- a/network/src/connectivity_manager/mod.rs
+++ b/network/src/connectivity_manager/mod.rs
@@ -42,8 +42,8 @@ use libra_types::PeerId;
 use num_variants::NumVariants;
 use std::{
     cmp::min,
-    collections::HashMap,
-    fmt::Debug,
+    collections::{hash_map, HashMap},
+    fmt,
     sync::{Arc, RwLock},
     time::{Duration, Instant},
 };
@@ -61,7 +61,7 @@ pub struct ConnectivityManager<TTicker, TBackoff> {
     /// PeerId and address of remote peers to which this peer is connected.
     connected: HashMap<PeerId, NetworkAddress>,
     /// Addresses of peers received from discovery sources.
-    peer_addresses: HashMap<PeerId, Addresses>,
+    peer_addresses: PeerAddresses,
     /// Ticker to trigger connectivity checks to provide the guarantees stated above.
     ticker: TTicker,
     /// Channel to send connection requests to PeerManager.
@@ -106,8 +106,12 @@ pub enum ConnectivityRequest {
     GetDialQueueSize(oneshot::Sender<usize>),
 }
 
-/// A set of NetworkAddress's for a peer, bucketed by DiscoverySource in priority order.
-#[derive(Clone, Debug, Default)]
+/// The set of `NetworkAddress`'s for all peers.
+struct PeerAddresses(HashMap<PeerId, Addresses>);
+
+/// A set of `NetworkAddress`'s for a single peer, bucketed by DiscoverySource in
+/// priority order.
+#[derive(Clone, Default)]
 struct Addresses([Vec<NetworkAddress>; DiscoverySource::NUM_VARIANTS]);
 
 #[derive(Debug)]
@@ -147,18 +151,25 @@ where
     ) -> Self {
         // Ensure seed peers doesn't contain our own address (we want to avoid
         // pointless self-dials).
-        let peer_addresses = seed_peers
-            .into_iter()
-            .filter(|(peer_id, _)| *peer_id != self_peer_id)
-            .map(|(peer_id, seed_addrs)| {
-                (
-                    peer_id,
-                    Addresses::from_addrs(DiscoverySource::Config, seed_addrs),
-                )
-            })
-            .collect::<HashMap<PeerId, Addresses>>();
+        let peer_addresses = PeerAddresses::new(
+            seed_peers
+                .into_iter()
+                .filter(|(peer_id, _)| peer_id != &self_peer_id)
+                .map(|(peer_id, seed_addrs)| {
+                    (
+                        peer_id,
+                        Addresses::from_addrs(DiscoverySource::Config, seed_addrs),
+                    )
+                })
+                .collect(),
+        );
 
-        info!("ConnectivityManager: {} seed peers", peer_addresses.len());
+        info!(
+            "[{}] ConnectivityManager init: num_seed_peers: {}, peer addresses: {}",
+            self_peer_id.short_str(),
+            peer_addresses.len(),
+            peer_addresses,
+        );
 
         Self {
             self_peer_id,
@@ -287,7 +298,7 @@ where
                     - ((self.dial_queue.len() + to_connect.len()) as f64
                         / eligible
                             .iter()
-                            .filter(|(peer_id, _)| self.peer_addresses.contains_key(peer_id))
+                            .filter(|(peer_id, _)| self.peer_addresses.contains_peer(&peer_id))
                             .count() as f64))) as u64,
         );
 
@@ -376,20 +387,39 @@ where
     fn handle_request(&mut self, req: ConnectivityRequest) {
         match req {
             ConnectivityRequest::UpdateAddresses(src, address_map) => {
+                // Keep track of if any peer's addresses have actually changed, so
+                // we can log without too much spam.
+                let mut has_changed = false;
+
                 for (peer_id, addrs) in address_map {
-                    trace!(
-                        "Received updated addresses for peer: {} from {:?} discovery source",
-                        peer_id.short_str(),
-                        src,
-                    );
-                    // Do not include self_peer_id in the address list for dialing.
-                    if peer_id != self.self_peer_id {
-                        self.update_peer_addrs(src, peer_id, addrs);
-                        // Ensure that the next dial attempt starts from the first addr.
+                    // Do not include self_peer_id in the address list for dialing
+                    // to avoid pointless self-dials.
+                    if peer_id == self.self_peer_id {
+                        continue;
+                    }
+
+                    if self.peer_addresses.update(peer_id, src, addrs) {
+                        // At least one peer's addresses have actually changed.
+                        has_changed = true;
+
+                        // Ensure that the next dial attempt starts from the first
+                        // address if the addresses have actually changed.
                         if let Some(dial_state) = self.dial_states.get_mut(&peer_id) {
                             dial_state.reset_addr();
                         }
                     }
+                }
+
+                // Only log if a peer's addresses have actually changed.
+                if has_changed {
+                    let self_peer_id = self.self_peer_id.short_str();
+                    let peer_addresses = &self.peer_addresses;
+                    info!(
+                        "[{}] Received updated addresses from discovery: {:?}. All peer addresses: {}",
+                        self_peer_id,
+                        src,
+                        peer_addresses,
+                    );
                 }
             }
             ConnectivityRequest::UpdateEligibleNodes(nodes) => {
@@ -400,18 +430,6 @@ where
                 sender.send(self.dial_queue.len()).unwrap();
             }
         }
-    }
-
-    fn update_peer_addrs(
-        &mut self,
-        src: DiscoverySource,
-        peer_id: PeerId,
-        addrs: Vec<NetworkAddress>,
-    ) {
-        self.peer_addresses
-            .entry(peer_id)
-            .or_default()
-            .update(src, addrs);
     }
 
     fn handle_control_notification(&mut self, notif: peer_manager::ConnectionNotification) {
@@ -473,6 +491,54 @@ fn log_dial_result(peer_id: PeerId, addr: NetworkAddress, dial_result: DialResul
     }
 }
 
+impl PeerAddresses {
+    fn new(peer_addresses: HashMap<PeerId, Addresses>) -> Self {
+        Self(peer_addresses)
+    }
+
+    fn len(&self) -> usize {
+        self.0.len()
+    }
+
+    fn iter(&self) -> hash_map::Iter<PeerId, Addresses> {
+        self.0.iter()
+    }
+
+    fn contains_peer(&self, peer_id: &PeerId) -> bool {
+        self.0.contains_key(&peer_id)
+    }
+
+    /// Update our view of a peer's addresses from a particular `DiscoverySource`.
+    /// If the peer's addresses have actually changed, return `true` else `false`.
+    fn update(
+        &mut self,
+        peer_id: PeerId,
+        src: DiscoverySource,
+        addrs: Vec<NetworkAddress>,
+    ) -> bool {
+        self.0.entry(peer_id).or_default().update(src, addrs)
+    }
+}
+
+impl fmt::Display for PeerAddresses {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        // Write the normal HashMap-style debug format, but shorten the peer_id's
+        // so the output isn't as noisy.
+        f.debug_map()
+            .entries(
+                self.iter()
+                    .map(|(peer_id, addrs)| (peer_id.short_str(), addrs)),
+            )
+            .finish()
+    }
+}
+
+impl fmt::Debug for PeerAddresses {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}", self)
+    }
+}
+
 impl Addresses {
     fn new() -> Self {
         Default::default()
@@ -492,13 +558,34 @@ impl Addresses {
         self.len() == 0
     }
 
-    fn update(&mut self, src: DiscoverySource, addrs: Vec<NetworkAddress>) {
-        let idx = src as u8 as usize;
-        self.0[idx] = addrs;
+    /// Update the addresses for the `DiscoverySource` bucket. Return `true` if
+    /// the addresses have actually changed.
+    fn update(&mut self, src: DiscoverySource, addrs: Vec<NetworkAddress>) -> bool {
+        let src_idx = src as u8 as usize;
+        if self.0[src_idx] != addrs {
+            self.0[src_idx] = addrs;
+            true
+        } else {
+            false
+        }
     }
 
     fn get(&self, idx: usize) -> Option<&NetworkAddress> {
         self.0.iter().flatten().nth(idx)
+    }
+}
+
+impl fmt::Display for Addresses {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        // Write without the typical "Addresses(..)" around the output to reduce
+        // debug noise.
+        write!(f, "{:?}", self.0)
+    }
+}
+
+impl fmt::Debug for Addresses {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}", self)
     }
 }
 


### PR DESCRIPTION
Recently, while debugging some connectivity issues, it was noticeably
difficult to glean the current state of the discovery info in connectivity
manager.

This diff is a first step in trying to improve network debuggability by
ensuring that we actually log updates to the peer_addresses set (with
some small tweaks so we only log when it actually updates).