### PR TITLE
[aws][codebuild] add flag for building just cti images

### DIFF
--- a/.github/workflows/land-blocking.yml
+++ b/.github/workflows/land-blocking.yml
@@ -32,7 +32,7 @@ jobs:
           RETRYABLE_EXIT_CODE=2
           for ((i = 0; i < 3; i++)); do
             echo "Build attempt $i"
-            docker/build-aws.sh --build-all --version $LIBRA_GIT_REV --addl_tags canary,${TEST_TAG}
+            docker/build-aws.sh --build-all-cti --version $LIBRA_GIT_REV --addl_tags canary,${TEST_TAG}
             return_code=$?
             if [[ $return_code -eq 0 ]]; then
               echo "Build successful"

--- a/docker/build-aws.sh
+++ b/docker/build-aws.sh
@@ -25,6 +25,9 @@ while [[ "$1" =~ ^- ]]; do case $1 in
   --build-all )
     BUILD_PROJECTS=(libra-validator libra-cluster-test libra-init libra-mint libra-safety-rules)
     ;;
+  --build-all-cti )
+    BUILD_PROJECTS=(libra-validator libra-cluster-test libra-safety-rules)
+    ;;
   --build-cluster-test )
     BUILD_PROJECTS=(libra-cluster-test)
     ;;

--- a/scripts/cti
+++ b/scripts/cti
@@ -198,7 +198,7 @@ fi
 
 if [ -z "$TAG" ]; then
     aws codebuild list-projects >/dev/null || (echo "Failed to access codebuild, try awsmfa?"; exit 1)
-    ./docker/build-aws.sh --build-all --version pull/$PR
+    ./docker/build-aws.sh --build-all-cti --version pull/$PR
     TAG=dev_${USER}_pull_${PR}
     echo "**TIP Use cti -T $TAG <...> to restart this run with same tag without rebuilding it"
 fi


### PR DESCRIPTION
<!--
Thank you for sending a PR. We appreciate you spending time to help improve the Libra project.

The project is undergoing daily changes. Pull Requests will be reviewed and responded to as time permits.
-->

## Motivation

Save resources by only building validator, cluster-test, and safety-rules in `cti` and `land-blocking.yml`. These two use cases now rely on `./buils-aws.sh` with the `--build-all-cti` flag.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

(Share your test plan here. If you changed code, please provide us with clear instructions for verifying that your changes work.)

## Related PRs

Follow up from https://github.com/libra/libra/pull/4135
