### PR TITLE
[cluster-test] Update delete_node API to take Instance

### DIFF
--- a/testsuite/cluster-test/src/cluster.rs
+++ b/testsuite/cluster-test/src/cluster.rs
@@ -10,6 +10,7 @@ use libra_crypto::{
     test_utils::KeyPair,
 };
 use rand::prelude::*;
+use reqwest::Client;
 use std::convert::TryInto;
 
 #[derive(Clone)]
@@ -22,6 +23,7 @@ pub struct Cluster {
 
 impl Cluster {
     pub fn from_host_port(peers: Vec<(String, u32, Option<u32>)>, mint_file: &str) -> Self {
+        let http_client = Client::new();
         let instances: Vec<Instance> = peers
             .into_iter()
             .map(|host_port| {
@@ -30,6 +32,7 @@ impl Cluster {
                     host_port.0,
                     host_port.1,
                     host_port.2,
+                    http_client.clone(),
                 )
             })
             .collect();
@@ -68,6 +71,7 @@ impl Cluster {
     pub fn validator_instances(&self) -> &[Instance] {
         &self.validator_instances
     }
+
     pub fn fullnode_instances(&self) -> &[Instance] {
         &self.fullnode_instances
     }

--- a/testsuite/cluster-test/src/cluster_swarm/mod.rs
+++ b/testsuite/cluster-test/src/cluster_swarm/mod.rs
@@ -34,7 +34,7 @@ pub trait ClusterSwarm {
     ) -> Result<Instance>;
 
     /// Deletes a node from the ClusterSwarm
-    async fn delete_node(&self, instance_config: InstanceConfig) -> Result<()>;
+    async fn delete_node(&self, instance: &Instance) -> Result<()>;
 
     /// Creates a set of validators with the given `image_tag`
     async fn create_validator_set(

--- a/testsuite/cluster-test/src/experiments/performance_benchmark.rs
+++ b/testsuite/cluster-test/src/experiments/performance_benchmark.rs
@@ -97,10 +97,10 @@ impl Experiment for PerformanceBenchmark {
     }
 
     async fn run(&mut self, context: &mut Context<'_>) -> Result<()> {
-        let instance_configs = instance::instance_configs(&self.down_validators)?;
-        let futures: Vec<_> = instance_configs
-            .into_iter()
-            .map(|ic| context.cluster_swarm.delete_node(ic.clone()))
+        let futures: Vec<_> = self
+            .down_validators
+            .iter()
+            .map(|instance| context.cluster_swarm.delete_node(instance))
             .collect();
         try_join_all(futures).await?;
         let buffer = Duration::from_secs(60);
@@ -163,7 +163,7 @@ impl Experiment for PerformanceBenchmark {
             "Tx status from client side: txn {}, avg latency {}",
             stats.committed as u64, avg_latency_client
         );
-        let instance_configs = instance::instance_configs(&self.down_validators)?;
+        let instance_configs = instance::instance_configs(&self.down_validators);
         let futures: Vec<_> = instance_configs
             .into_iter()
             .map(|ic| context.cluster_swarm.upsert_node(ic.clone(), false))

--- a/testsuite/cluster-test/src/experiments/reboot_random_validator.rs
+++ b/testsuite/cluster-test/src/experiments/reboot_random_validator.rs
@@ -56,13 +56,13 @@ impl Experiment for RebootRandomValidators {
     }
 
     async fn run(&mut self, context: &mut Context<'_>) -> anyhow::Result<()> {
-        let instance_configs = instance::instance_configs(&self.instances)?;
-        let futures: Vec<_> = instance_configs
-            .clone()
-            .into_iter()
-            .map(|ic| context.cluster_swarm.delete_node(ic.clone()))
+        let futures: Vec<_> = self
+            .instances
+            .iter()
+            .map(|instance| context.cluster_swarm.delete_node(instance))
             .collect();
         try_join_all(futures).await?;
+        let instance_configs = instance::instance_configs(&self.instances);
         let futures: Vec<_> = instance_configs
             .into_iter()
             .map(|ic| context.cluster_swarm.upsert_node(ic.clone(), false))

--- a/testsuite/cluster-test/src/instance.rs
+++ b/testsuite/cluster-test/src/instance.rs
@@ -220,12 +220,17 @@ impl Instance {
         Url::from_str(&format!("http://{}:{}", self.ip(), self.ac_port())).expect("Invalid URL.")
     }
 
-    pub fn k8s_node(&self) -> Option<&String> {
-        self.k8s_node.as_ref()
+    pub fn k8s_node(&self) -> &str {
+        self.k8s_node
+            .as_ref()
+            .expect("k8s_node was queried on non-k8s instance")
     }
 
-    pub fn instance_config(&self) -> Option<&InstanceConfig> {
-        self.instance_config.as_ref()
+    /// This method only works when run on k8s
+    pub fn instance_config(&self) -> &InstanceConfig {
+        self.instance_config
+            .as_ref()
+            .expect("instance_config was queried on non-k8s instance")
     }
 
     pub fn debug_interface_port(&self) -> Option<u32> {
@@ -257,13 +262,6 @@ pub fn instancelist_to_set(instances: &[Instance]) -> HashSet<String> {
     r
 }
 
-pub fn instance_configs(instances: &[Instance]) -> Result<Vec<&InstanceConfig>> {
-    instances
-        .iter()
-        .map(|instance| -> Result<&InstanceConfig> {
-            instance
-                .instance_config()
-                .ok_or_else(|| format_err!("Failed to find instance_config"))
-        })
-        .collect::<Result<_, _>>()
+pub fn instance_configs(instances: &[Instance]) -> Vec<&InstanceConfig> {
+    instances.iter().map(Instance::instance_config).collect()
 }


### PR DESCRIPTION
This allows to unify `ClusterSwarm` api to use Instance for both deletion and creation

Also, [cluster-test] Move http_client from TxEmitter to Instance
Previously only tx_emitter was only place keeping http client required for making jsonprc requests.

We actually have use cases where we want to make jsonrpc calls when having Instance, but not TxEmitter.

This diff adds `Instance::jsonrpc_client()` method and moves reference to global http client from TxEmitter to Instance
