### PR TITLE
[cluster-test] Introduce Instance::{start, stop, util_cmd}

### DIFF
--- a/testsuite/cluster-test/src/cluster_swarm/mod.rs
+++ b/testsuite/cluster-test/src/cluster_swarm/mod.rs
@@ -19,7 +19,7 @@ pub trait ClusterSwarm {
     /// Runs the given command in a container against the given Instance
     async fn run(
         &self,
-        instance: &Instance,
+        k8s_node: &str,
         docker_image: &str,
         command: String,
         job_name: &str,
@@ -34,7 +34,7 @@ pub trait ClusterSwarm {
     ) -> Result<Instance>;
 
     /// Deletes a node from the ClusterSwarm
-    async fn delete_node(&self, instance: &Instance) -> Result<()>;
+    async fn delete_node(&self, instance_config: &InstanceConfig) -> Result<()>;
 
     /// Creates a set of validators with the given `image_tag`
     async fn create_validator_set(

--- a/testsuite/cluster-test/src/experiments/cpu_flamegraph.rs
+++ b/testsuite/cluster-test/src/experiments/cpu_flamegraph.rs
@@ -17,7 +17,6 @@ use async_trait::async_trait;
 
 use crate::{
     cluster::Cluster,
-    cluster_swarm::ClusterSwarm,
     experiments::{Context, Experiment, ExperimentParam},
     instance,
     instance::Instance,
@@ -75,12 +74,7 @@ impl Experiment for CpuFlamegraph {
                 .collect::<String>()
         );
         let command = generate_perf_flamegraph_command(&filename, self.duration_secs);
-        let flame_graph = context.cluster_swarm.run(
-            &self.perf_instance,
-            "853397791086.dkr.ecr.us-west-2.amazonaws.com/cluster-test-util:latest",
-            command,
-            "generate-flamegraph",
-        );
+        let flame_graph = self.perf_instance.util_cmd(command, "generate-flamegraph");
         let flame_graph_future = tokio::time::delay_for(buffer)
             .then(|_| async move { flame_graph.await })
             .boxed();


### PR DESCRIPTION
This diff introduces convenience methods on the Instance.

They only available in k8s right now, and calls to appropriate methods in ClusterSwarmKube.

This allows to have Instance as a self-sufficient entity and not to pass reference to swarm to every place where we need to manipulate instance state

Also removes legacy(and no longer working) Instance:run_cmd/scp and family
