### PR TITLE
[cluster-test] Cleanup ClusterSwarm trait

### DIFF
--- a/testsuite/cluster-test/src/cluster_swarm/mod.rs
+++ b/testsuite/cluster-test/src/cluster_swarm/mod.rs
@@ -16,34 +16,16 @@ use futures::{future::try_join_all, try_join};
 pub trait ClusterSwarm {
     async fn remove_all_network_effects(&self) -> Result<()>;
 
-    /// Runs the given command in a container against the given Instance
-    async fn run(
-        &self,
-        k8s_node: &str,
-        docker_image: &str,
-        command: String,
-        job_name: &str,
-    ) -> Result<()>;
-
-    /// Inserts an into the ClusterSwarm if it doesn't exist. If it
-    /// exists, then updates the instance.
-    async fn upsert_node(
-        &self,
-        instance_config: InstanceConfig,
-        delete_data: bool,
-    ) -> Result<Instance>;
-
-    /// Deletes a node from the ClusterSwarm
-    async fn delete_node(&self, instance_config: &InstanceConfig) -> Result<()>;
+    /// Spawns a new instance.
+    async fn spawn_new_instance(&self, instance_config: InstanceConfig) -> Result<Instance>;
 
     /// Creates a set of validators with the given `image_tag`
-    async fn create_validator_set(
+    async fn spawn_validator_set(
         &self,
         num_validators: u32,
         num_fullnodes_per_validator: u32,
         image_tag: &str,
         config_overrides: Vec<String>,
-        delete_data: bool,
     ) -> Result<Vec<Instance>> {
         let validators = (0..num_validators).map(|i| {
             let validator_config = ValidatorConfig {
@@ -53,20 +35,19 @@ pub trait ClusterSwarm {
                 image_tag: image_tag.to_string(),
                 config_overrides: config_overrides.clone(),
             };
-            self.upsert_node(Validator(validator_config), delete_data)
+            self.spawn_new_instance(Validator(validator_config))
         });
         let validators = try_join_all(validators).await?;
         Ok(validators)
     }
 
     /// Creates a set of fullnodes with the given `image_tag`
-    async fn create_fullnode_set(
+    async fn spawn_fullnode_set(
         &self,
         num_validators: u32,
         num_fullnodes_per_validator: u32,
         image_tag: &str,
         config_overrides: Vec<String>,
-        delete_data: bool,
     ) -> Result<Vec<Instance>> {
         let fullnodes = (0..num_validators).flat_map(move |validator_index| {
             let config_overrides = config_overrides.clone();
@@ -79,7 +60,7 @@ pub trait ClusterSwarm {
                     image_tag: image_tag.to_string(),
                     config_overrides: config_overrides.clone(),
                 };
-                self.upsert_node(Fullnode(fullnode_config), delete_data)
+                self.spawn_new_instance(Fullnode(fullnode_config))
             })
         });
         let fullnodes = try_join_all(fullnodes).await?;
@@ -87,27 +68,24 @@ pub trait ClusterSwarm {
     }
 
     /// Creates a set of validators and fullnodes with the given parameters
-    async fn create_validator_and_fullnode_set(
+    async fn spawn_validator_and_fullnode_set(
         &self,
         num_validators: u32,
         num_fullnodes_per_validator: u32,
         image_tag: &str,
-        delete_data: bool,
     ) -> Result<(Vec<Instance>, Vec<Instance>)> {
         try_join!(
-            self.create_validator_set(
+            self.spawn_validator_set(
                 num_validators,
                 num_fullnodes_per_validator,
                 image_tag,
                 vec![],
-                delete_data
             ),
-            self.create_fullnode_set(
+            self.spawn_fullnode_set(
                 num_validators,
                 num_fullnodes_per_validator,
                 image_tag,
                 vec![],
-                delete_data
             ),
         )
     }

--- a/testsuite/cluster-test/src/instance.rs
+++ b/testsuite/cluster-test/src/instance.rs
@@ -3,7 +3,7 @@
 
 #![forbid(unsafe_code)]
 
-use crate::cluster_swarm::{cluster_swarm_kube::ClusterSwarmKube, ClusterSwarm};
+use crate::cluster_swarm::cluster_swarm_kube::ClusterSwarmKube;
 use anyhow::{format_err, Result};
 use libra_config::config::NodeConfig;
 use libra_json_rpc_client::{JsonRpcAsyncClient, JsonRpcBatch};
@@ -169,11 +169,6 @@ impl Instance {
 
     pub fn json_rpc_url(&self) -> Url {
         Url::from_str(&format!("http://{}:{}", self.ip(), self.ac_port())).expect("Invalid URL.")
-    }
-
-    #[deprecated(note = "Avoid using this method as it expose backend details outside of Instance")]
-    pub fn k8s_node(&self) -> &str {
-        &self.k8s_backend().k8s_node
     }
 
     fn k8s_backend(&self) -> &K8sInstanceInfo {

--- a/testsuite/cluster-test/src/main.rs
+++ b/testsuite/cluster-test/src/main.rs
@@ -451,14 +451,13 @@ impl ClusterUtil {
             .await
             .unwrap_or_else(|_| panic!("{} scaling failed", asg_name));
             let (validators, fullnodes) = cluster_swarm
-                .create_validator_and_fullnode_set(
+                .spawn_validator_and_fullnode_set(
                     args.k8s_num_validators,
                     args.k8s_fullnodes_per_validator,
                     &image_tag,
-                    true,
                 )
                 .await
-                .expect("Failed to create_validator_and_fullnode_set");
+                .expect("Failed to spawn_validator_and_fullnode_set");
             info!("Deployment complete");
             let cluster = Cluster::new(validators, fullnodes);
 


### PR DESCRIPTION
This diff clean ups duplication methods between ClusterSwarm and Instance.

ClusterSwarm trait no longer have methods to upsert/delete/run methods, as they are replaced with Instance::{start, stop, util_cmd}.

Instead, ClusterSwarm has `spawn_new_instance` and the family.

upsert/delete/run are moved out of ClusterSwarm trait into ClusterSwarmKube.

If we have some other implementation for ClusterSwarm, we'll need to update Instance methods to handle those(we can make InstanceBackend a trait for example, or smth like that).
