### PR TITLE
Replace add_to_network(network_builder) with a dedicated call in network_builder.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3649,6 +3649,7 @@ dependencies = [
  "libra-config 0.1.0",
  "libra-crypto 0.1.0",
  "libra-logger 0.1.0",
+ "libra-metrics 0.1.0",
  "libra-network-address 0.1.0",
  "libra-types 0.1.0",
  "libra-vm 0.1.0",

--- a/consensus/src/network_interface.rs
+++ b/consensus/src/network_interface.rs
@@ -12,6 +12,7 @@ use consensus_types::{
     sync_info::SyncInfo,
     vote_msg::VoteMsg,
 };
+use libra_metrics::IntCounterVec;
 use libra_types::{epoch_change::EpochChangeProof, PeerId};
 use network::{
     error::NetworkError,
@@ -20,7 +21,7 @@ use network::{
         network::{NetworkEvents, NetworkSender, NewNetworkSender},
         rpc::error::RpcError,
     },
-    validator_network::network_builder::{NetworkBuilder, NETWORK_CHANNEL_SIZE},
+    validator_network::network_builder::NETWORK_CHANNEL_SIZE,
     ProtocolId,
 };
 use serde::{Deserialize, Serialize};
@@ -69,19 +70,21 @@ pub struct ConsensusNetworkSender {
     network_sender: NetworkSender<ConsensusMsg>,
 }
 
-/// Create a new Sender that only sends for the `CONSENSUS_DIRECT_SEND_PROTOCOL` and
-/// `CONSENSUS_RPC_PROTOCOL` ProtocolId and a Receiver (Events) that explicitly returns only said
-/// ProtocolId.
-pub fn add_to_network(
-    network: &mut NetworkBuilder,
-) -> (ConsensusNetworkSender, ConsensusNetworkEvents) {
-    network.add_protocol_handler((
+/// Configuration for the network endpoints to support consensus.
+pub fn network_endpoint_config() -> (
+    Vec<ProtocolId>,
+    Vec<ProtocolId>,
+    QueueStyle,
+    usize,
+    Option<&'static IntCounterVec>,
+) {
+    (
         vec![ProtocolId::ConsensusRpc],
         vec![ProtocolId::ConsensusDirectSend],
         QueueStyle::LIFO,
         NETWORK_CHANNEL_SIZE,
         Some(&counters::PENDING_CONSENSUS_NETWORK_EVENTS),
-    ))
+    )
 }
 
 impl NewNetworkSender for ConsensusNetworkSender {

--- a/consensus/src/network_tests.rs
+++ b/consensus/src/network_tests.rs
@@ -23,7 +23,10 @@ use network::{
         conn_notifs_channel, ConnectionRequestSender, PeerManagerNotification, PeerManagerRequest,
         PeerManagerRequestSender,
     },
-    protocols::rpc::InboundRpcRequest,
+    protocols::{
+        network::{NewNetworkEvents, NewNetworkSender},
+        rpc::InboundRpcRequest,
+    },
     ProtocolId,
 };
 use std::{

--- a/consensus/src/round_manager_fuzzing.rs
+++ b/consensus/src/round_manager_fuzzing.rs
@@ -27,7 +27,10 @@ use libra_types::{
     validator_signer::ValidatorSigner,
     validator_verifier::ValidatorVerifier,
 };
-use network::peer_manager::{ConnectionRequestSender, PeerManagerRequestSender};
+use network::{
+    peer_manager::{ConnectionRequestSender, PeerManagerRequestSender},
+    protocols::network::NewNetworkSender,
+};
 use once_cell::sync::Lazy;
 use safety_rules::{test_utils, SafetyRules, TSafetyRules};
 use std::{collections::BTreeMap, num::NonZeroUsize, sync::Arc, time::Duration};

--- a/consensus/src/round_manager_test.rs
+++ b/consensus/src/round_manager_test.rs
@@ -51,7 +51,7 @@ use libra_types::{
 };
 use network::{
     peer_manager::{conn_notifs_channel, ConnectionRequestSender, PeerManagerRequestSender},
-    protocols::network::Event,
+    protocols::network::{Event, NewNetworkEvents, NewNetworkSender},
 };
 use safety_rules::{ConsensusState, PersistentSafetyStorage, SafetyRulesManager};
 use std::{num::NonZeroUsize, sync::Arc, time::Duration};

--- a/consensus/src/twins_test.rs
+++ b/consensus/src/twins_test.rs
@@ -28,8 +28,9 @@ use libra_types::{
     validator_info::ValidatorInfo,
     waypoint::Waypoint,
 };
-use network::peer_manager::{
-    conn_notifs_channel, ConnectionRequestSender, PeerManagerRequestSender,
+use network::{
+    peer_manager::{conn_notifs_channel, ConnectionRequestSender, PeerManagerRequestSender},
+    protocols::network::{NewNetworkEvents, NewNetworkSender},
 };
 use std::{collections::HashMap, num::NonZeroUsize, sync::Arc};
 use tokio::runtime::{Builder, Runtime};

--- a/libra-node/src/main_node.rs
+++ b/libra-node/src/main_node.rs
@@ -235,8 +235,8 @@ pub fn setup_environment(node_config: &mut NodeConfig) -> LibraHandle {
         let peer_id = network_builder.peer_id();
 
         // Create the endpoints to connect the Network to StateSynchronizer.
-        let (state_sync_sender, state_sync_events) =
-            state_synchronizer::network::add_to_network(&mut network_builder);
+        let (state_sync_sender, state_sync_events) = network_builder
+            .add_protocol_handler(state_synchronizer::network::network_endpoint_config());
         state_sync_network_handles.push((peer_id, state_sync_sender, state_sync_events));
 
         // Create the endpoints to connect the network to MemPool.

--- a/libra-node/src/main_node.rs
+++ b/libra-node/src/main_node.rs
@@ -239,11 +239,12 @@ pub fn setup_environment(node_config: &mut NodeConfig) -> LibraHandle {
             .add_protocol_handler(state_synchronizer::network::network_endpoint_config());
         state_sync_network_handles.push((peer_id, state_sync_sender, state_sync_events));
 
-        // Create the endpoints to connect the network to MemPool.
-        let (mempool_sender, mempool_events) = libra_mempool::network::add_to_network(
-            &mut network_builder,
-            node_config.mempool.max_broadcasts_per_peer,
-        );
+        // Create the endpoints t connect the Network to MemPool.
+        let (mempool_sender, mempool_events) =
+            network_builder.add_protocol_handler(libra_mempool::network::network_endpoint_config(
+                // TODO:  Make this configuration option more clear.
+                node_config.mempool.max_broadcasts_per_peer,
+            ));
         mempool_network_handles.push((peer_id, mempool_sender, mempool_events));
 
         match role {

--- a/libra-node/src/main_node.rs
+++ b/libra-node/src/main_node.rs
@@ -133,8 +133,9 @@ pub fn setup_network(
                 .add_gossip_discovery();
         }
         DiscoveryMethod::Onchain => {
-            let (network_tx, discovery_events) =
-                onchain_discovery::network_interface::add_to_network(&mut network_builder);
+            let (network_tx, discovery_events) = network_builder.add_protocol_handler(
+                onchain_discovery::network_interface::network_endpoint_config(),
+            );
             let onchain_discovery_builder = OnchainDiscoveryBuilder::build(
                 network_builder
                     .conn_mgr_reqs_tx()

--- a/libra-node/src/main_node.rs
+++ b/libra-node/src/main_node.rs
@@ -268,9 +268,10 @@ pub fn setup_environment(node_config: &mut NodeConfig) -> LibraHandle {
                         .spawn(network_config_listener.start(simple_discovery_reconfig_rx));
                 };
 
-                consensus_network_handles = Some(consensus::network_interface::add_to_network(
-                    &mut network_builder,
-                ));
+                consensus_network_handles =
+                    Some(network_builder.add_protocol_handler(
+                        consensus::network_interface::network_endpoint_config(),
+                    ));
             }
             // Currently no FullNode network specific steps.
             RoleType::FullNode => (),

--- a/mempool/src/shared_mempool/network.rs
+++ b/mempool/src/shared_mempool/network.rs
@@ -5,12 +5,12 @@
 
 use crate::counters;
 use channel::message_queues::QueueStyle;
+use libra_metrics::IntCounterVec;
 use libra_types::{transaction::SignedTransaction, PeerId};
 use network::{
     error::NetworkError,
     peer_manager::{ConnectionRequestSender, PeerManagerRequestSender},
     protocols::network::{NetworkEvents, NetworkSender, NewNetworkSender},
-    validator_network::network_builder::NetworkBuilder,
     ProtocolId,
 };
 use serde::{Deserialize, Serialize};
@@ -62,17 +62,22 @@ pub struct MempoolNetworkSender {
 
 /// Create a new Sender that only sends for the `MEMPOOL_DIRECT_SEND_PROTOCOL` ProtocolId and a
 /// Receiver (Events) that explicitly returns only said ProtocolId.
-pub fn add_to_network(
-    network: &mut NetworkBuilder,
+pub fn network_endpoint_config(
     max_broadcasts_per_peer: usize,
-) -> (MempoolNetworkSender, MempoolNetworkEvents) {
-    network.add_protocol_handler((
+) -> (
+    Vec<ProtocolId>,
+    Vec<ProtocolId>,
+    QueueStyle,
+    usize,
+    Option<&'static IntCounterVec>,
+) {
+    (
         vec![],
         vec![ProtocolId::MempoolDirectSend],
         QueueStyle::KLAST,
         max_broadcasts_per_peer,
         Some(&counters::PENDING_MEMPOOL_NETWORK_EVENTS),
-    ))
+    )
 }
 
 impl NewNetworkSender for MempoolNetworkSender {

--- a/mempool/src/tests/mocks.rs
+++ b/mempool/src/tests/mocks.rs
@@ -15,8 +15,9 @@ use libra_config::{
     network_id::NetworkId,
 };
 use libra_types::{mempool_status::MempoolStatusCode, transaction::SignedTransaction};
-use network::peer_manager::{
-    conn_notifs_channel, ConnectionRequestSender, PeerManagerRequestSender,
+use network::{
+    peer_manager::{conn_notifs_channel, ConnectionRequestSender, PeerManagerRequestSender},
+    protocols::network::{NewNetworkEvents, NewNetworkSender},
 };
 use std::{
     num::NonZeroUsize,

--- a/mempool/src/tests/shared_mempool_test.rs
+++ b/mempool/src/tests/shared_mempool_test.rs
@@ -31,6 +31,7 @@ use network::{
         conn_notifs_channel, ConnectionNotification, ConnectionRequestSender,
         PeerManagerNotification, PeerManagerRequest, PeerManagerRequestSender,
     },
+    protocols::network::{NewNetworkEvents, NewNetworkSender},
     DisconnectReason, ProtocolId,
 };
 use std::{

--- a/network/onchain-discovery/Cargo.toml
+++ b/network/onchain-discovery/Cargo.toml
@@ -23,6 +23,7 @@ lcs = { path = "../../common/lcs", version = "0.1.0", package = "libra-canonical
 libra-config = { path = "../../config", version = "0.1.0" }
 libra-crypto = { path = "../../crypto/crypto", version = "0.1.0" }
 libra-logger = { path = "../../common/logger", version = "0.1.0" }
+libra-metrics = {path = "../../common/metrics", version = "0.1.0"}
 libra-network-address = { path = "../network-address", version = "0.1.0" }
 libra-types = { path = "../../types", version = "0.1.0" }
 libra-workspace-hack = { path = "../../common/workspace-hack", version = "0.1.0" }

--- a/network/onchain-discovery/src/network_interface.rs
+++ b/network/onchain-discovery/src/network_interface.rs
@@ -4,6 +4,7 @@
 //! Protobuf based interface between OnchainDiscovery and Network layers.
 use crate::types::{OnchainDiscoveryMsg, QueryDiscoverySetRequest, QueryDiscoverySetResponse};
 use channel::{libra_channel, message_queues::QueueStyle};
+use libra_metrics::IntCounterVec;
 use libra_types::PeerId;
 use network::{
     peer_manager::{
@@ -14,7 +15,7 @@ use network::{
         network::{NetworkSender, NewNetworkEvents, NewNetworkSender},
         rpc::error::RpcError,
     },
-    validator_network::network_builder::{NetworkBuilder, NETWORK_CHANNEL_SIZE},
+    validator_network::network_builder::NETWORK_CHANNEL_SIZE,
     ProtocolId,
 };
 use std::time::Duration;
@@ -83,12 +84,15 @@ impl OnchainDiscoveryNetworkSender {
     }
 }
 
-/// Construct OnchainDiscoveryNetworkSender/Events and register them with the
-/// given network builder.
-pub fn add_to_network(
-    network: &mut NetworkBuilder,
-) -> (OnchainDiscoveryNetworkSender, OnchainDiscoveryNetworkEvents) {
-    network.add_protocol_handler((
+/// Provides the configuration parameters for the network endpoint.
+pub fn network_endpoint_config() -> (
+    Vec<ProtocolId>,
+    Vec<ProtocolId>,
+    QueueStyle,
+    usize,
+    Option<&'static IntCounterVec>,
+) {
+    (
         vec![ProtocolId::OnchainDiscoveryRpc],
         vec![],
         QueueStyle::LIFO,
@@ -96,5 +100,5 @@ pub fn add_to_network(
         // Some(&counters::PENDING_CONSENSUS_NETWORK_EVENTS),
         // TODO(philiphayes): add a counter for onchain discovery
         None,
-    ))
+    )
 }

--- a/network/onchain-discovery/src/test.rs
+++ b/network/onchain-discovery/src/test.rs
@@ -34,7 +34,10 @@ use network::{
         ConnectionNotification, ConnectionRequestSender, PeerManagerNotification,
         PeerManagerRequest, PeerManagerRequestSender,
     },
-    protocols::rpc::{InboundRpcRequest, OutboundRpcRequest},
+    protocols::{
+        network::NewNetworkSender,
+        rpc::{InboundRpcRequest, OutboundRpcRequest},
+    },
     ProtocolId,
 };
 use std::{

--- a/network/src/protocols/discovery/mod.rs
+++ b/network/src/protocols/discovery/mod.rs
@@ -39,7 +39,7 @@ use crate::{
     error::NetworkError,
     peer_manager::{ConnectionRequestSender, PeerManagerRequestSender},
     protocols::network::{Event, NetworkEvents, NetworkSender, NewNetworkSender},
-    validator_network::network_builder::{NetworkBuilder, NETWORK_CHANNEL_SIZE},
+    validator_network::network_builder::NETWORK_CHANNEL_SIZE,
     ProtocolId,
 };
 use bytes::Bytes;
@@ -51,6 +51,7 @@ use futures::{
 use libra_config::network_id::NetworkContext;
 use libra_crypto_derive::{CryptoHasher, LCSCryptoHash};
 use libra_logger::prelude::*;
+use libra_metrics::IntCounterVec;
 use libra_network_address::NetworkAddress;
 use libra_security_logger::{security_log, SecurityEvent};
 use libra_types::PeerId;
@@ -87,18 +88,21 @@ pub struct DiscoveryNetworkSender {
     inner: NetworkSender<DiscoveryMsg>,
 }
 
-/// Register the discovery sender and event handler with network and return interfaces for those
-/// actors.
-pub fn add_to_network(
-    network: &mut NetworkBuilder,
-) -> (DiscoveryNetworkSender, DiscoveryNetworkEvents) {
-    network.add_protocol_handler((
+/// Configuration for the network endpoints to support Discovery.
+pub fn network_endpoint_config() -> (
+    Vec<ProtocolId>,
+    Vec<ProtocolId>,
+    QueueStyle,
+    usize,
+    Option<&'static IntCounterVec>,
+) {
+    (
         vec![],
         vec![ProtocolId::DiscoveryDirectSend],
         QueueStyle::LIFO,
         NETWORK_CHANNEL_SIZE,
         Some(&counters::PENDING_DISCOVERY_NETWORK_EVENTS),
-    ))
+    )
 }
 
 impl NewNetworkSender for DiscoveryNetworkSender {

--- a/network/src/protocols/discovery/test.rs
+++ b/network/src/protocols/discovery/test.rs
@@ -8,7 +8,10 @@ use crate::{
         self, conn_notifs_channel, ConnectionRequestSender, PeerManagerNotification,
         PeerManagerRequest,
     },
-    protocols::direct_send::Message,
+    protocols::{
+        direct_send::Message,
+        network::{NewNetworkEvents, NewNetworkSender},
+    },
     ProtocolId,
 };
 use anyhow::anyhow;

--- a/network/src/protocols/health_checker/mod.rs
+++ b/network/src/protocols/health_checker/mod.rs
@@ -25,7 +25,7 @@ use crate::{
         network::{Event, NetworkEvents, NetworkSender, NewNetworkSender},
         rpc::error::RpcError,
     },
-    validator_network::network_builder::{NetworkBuilder, NETWORK_CHANNEL_SIZE},
+    validator_network::network_builder::NETWORK_CHANNEL_SIZE,
     ProtocolId,
 };
 use bytes::Bytes;
@@ -36,6 +36,7 @@ use futures::{
 };
 use libra_config::network_id::NetworkContext;
 use libra_logger::prelude::*;
+use libra_metrics::IntCounterVec;
 use libra_security_logger::{security_log, SecurityEvent};
 use libra_types::PeerId;
 use rand::{rngs::SmallRng, seq::SliceRandom, Rng, SeedableRng};
@@ -66,16 +67,21 @@ pub struct HealthCheckerNetworkSender {
     inner: NetworkSender<HealthCheckerMsg>,
 }
 
-pub fn add_to_network(
-    network: &mut NetworkBuilder,
-) -> (HealthCheckerNetworkSender, HealthCheckerNetworkEvents) {
-    network.add_protocol_handler((
+/// Configuration for the network endpoints to support HealthChecker.
+pub fn network_endpoint_config() -> (
+    Vec<ProtocolId>,
+    Vec<ProtocolId>,
+    QueueStyle,
+    usize,
+    Option<&'static IntCounterVec>,
+) {
+    (
         vec![ProtocolId::HealthCheckerRpc],
         vec![],
         QueueStyle::LIFO,
         NETWORK_CHANNEL_SIZE,
         Some(&counters::PENDING_HEALTH_CHECKER_NETWORK_EVENTS),
-    ))
+    )
 }
 
 impl NewNetworkSender for HealthCheckerNetworkSender {

--- a/network/src/protocols/health_checker/test.rs
+++ b/network/src/protocols/health_checker/test.rs
@@ -6,7 +6,10 @@ use crate::{
     peer_manager::{
         self, conn_notifs_channel, ConnectionRequest, PeerManagerNotification, PeerManagerRequest,
     },
-    protocols::rpc::InboundRpcRequest,
+    protocols::{
+        network::{NewNetworkEvents, NewNetworkSender},
+        rpc::InboundRpcRequest,
+    },
     ProtocolId,
 };
 use channel::{libra_channel, message_queues::QueueStyle};

--- a/network/src/protocols/network/mod.rs
+++ b/network/src/protocols/network/mod.rs
@@ -95,8 +95,16 @@ pub struct NetworkEvents<TMessage> {
     _marker: PhantomData<TMessage>,
 }
 
-impl<TMessage: Message> NetworkEvents<TMessage> {
-    pub fn new(
+/// Trait specifying the signature for `new()` `NetworkEvents`
+pub trait NewNetworkEvents {
+    fn new(
+        peer_mgr_notifs_rx: libra_channel::Receiver<(PeerId, ProtocolId), PeerManagerNotification>,
+        connection_notifs_rx: libra_channel::Receiver<PeerId, ConnectionNotification>,
+    ) -> Self;
+}
+
+impl<TMessage: Message> NewNetworkEvents for NetworkEvents<TMessage> {
+    fn new(
         peer_mgr_notifs_rx: libra_channel::Receiver<(PeerId, ProtocolId), PeerManagerNotification>,
         connection_notifs_rx: libra_channel::Receiver<PeerId, ConnectionNotification>,
     ) -> Self {
@@ -178,8 +186,16 @@ pub struct NetworkSender<TMessage> {
     _marker: PhantomData<TMessage>,
 }
 
-impl<TMessage> NetworkSender<TMessage> {
-    pub fn new(
+/// Trait specifying the signature for `new()` `NetworkSender`s
+pub trait NewNetworkSender {
+    fn new(
+        peer_mgr_reqs_tx: PeerManagerRequestSender,
+        connection_reqs_tx: ConnectionRequestSender,
+    ) -> Self;
+}
+
+impl<TMessage> NewNetworkSender for NetworkSender<TMessage> {
+    fn new(
         peer_mgr_reqs_tx: PeerManagerRequestSender,
         connection_reqs_tx: ConnectionRequestSender,
     ) -> Self {
@@ -189,7 +205,9 @@ impl<TMessage> NetworkSender<TMessage> {
             _marker: PhantomData,
         }
     }
+}
 
+impl<TMessage> NetworkSender<TMessage> {
     /// Request that a given Peer be dialed at the provided `NetworkAddress` and
     /// synchronously wait for the request to be performed.
     pub async fn dial_peer(

--- a/network/src/validator_network/network_builder.rs
+++ b/network/src/validator_network/network_builder.rs
@@ -340,7 +340,8 @@ impl NetworkBuilder {
             .conn_mgr_reqs_tx()
             .expect("ConnectivityManager not enabled");
         // Get handles for network events and sender.
-        let (discovery_network_tx, discovery_network_rx) = discovery::add_to_network(self);
+        let (discovery_network_tx, discovery_network_rx) =
+            self.add_protocol_handler(discovery::network_endpoint_config());
 
         // TODO(philiphayes): the current setup for gossip discovery doesn't work
         // when we don't have an `advertised_address` set, since it uses the

--- a/network/src/validator_network/network_builder.rs
+++ b/network/src/validator_network/network_builder.rs
@@ -384,7 +384,8 @@ impl NetworkBuilder {
 
     pub fn add_connection_monitoring(&mut self) -> &mut Self {
         // Initialize and start HealthChecker.
-        let (hc_network_tx, hc_network_rx) = health_checker::add_to_network(self);
+        let (hc_network_tx, hc_network_rx) =
+            self.add_protocol_handler(health_checker::network_endpoint_config());
         let ping_interval_ms = self.ping_interval_ms;
         let ping_timeout_ms = self.ping_timeout_ms;
         let ping_failures_tolerated = self.ping_failures_tolerated;

--- a/state-synchronizer/src/network.rs
+++ b/state-synchronizer/src/network.rs
@@ -5,12 +5,12 @@
 
 use crate::{chunk_request::GetChunkRequest, chunk_response::GetChunkResponse, counters};
 use channel::message_queues::QueueStyle;
+use libra_metrics::IntCounterVec;
 use libra_types::PeerId;
 use network::{
     error::NetworkError,
     peer_manager::{ConnectionRequestSender, PeerManagerRequestSender},
     protocols::network::{NetworkEvents, NetworkSender, NewNetworkSender},
-    validator_network::network_builder::NetworkBuilder,
     ProtocolId,
 };
 use serde::{Deserialize, Serialize};
@@ -43,16 +43,22 @@ pub struct StateSynchronizerSender {
     inner: NetworkSender<StateSynchronizerMsg>,
 }
 
-pub fn add_to_network(
-    network: &mut NetworkBuilder,
-) -> (StateSynchronizerSender, StateSynchronizerEvents) {
-    network.add_protocol_handler((
+/// Configuration for the network endpoints to support StateSynchronizer.
+pub fn network_endpoint_config() -> (
+    Vec<ProtocolId>,
+    Vec<ProtocolId>,
+    QueueStyle,
+    usize,
+    Option<&'static IntCounterVec>,
+) {
+    (
         vec![],
         vec![ProtocolId::StateSynchronizerDirectSend],
         QueueStyle::LIFO,
+        // TODO:  Name this as a constant.
         1,
         Some(&counters::PENDING_STATE_SYNCHRONIZER_NETWORK_EVENTS),
-    ))
+    )
 }
 
 impl NewNetworkSender for StateSynchronizerSender {

--- a/state-synchronizer/src/tests/integration_tests.rs
+++ b/state-synchronizer/src/tests/integration_tests.rs
@@ -269,7 +269,8 @@ impl SynchronizerEnv {
             .add_connectivity_manager()
             .add_gossip_discovery();
 
-        let (sender, events) = crate::network::add_to_network(&mut network_builder);
+        let (sender, events) =
+            network_builder.add_protocol_handler(crate::network::network_endpoint_config());
         let peer_addr = network_builder.build();
 
         let mut config = config_builder::test_config().0;


### PR DESCRIPTION
<!--
Thank you for sending a PR. We appreciate you spending time to help improve the Libra project.

The project is undergoing daily changes. Pull Requests will be reviewed and responded to as time permits.
-->

## Motivation

Broad goal at present is to cleanup and organizer main_node.rs and network_builder.rs

This PR is an intermediate step which will allow moving setup_network out of main_node.rs and into network_builder.

A core problem in the current paradigm of XXX::add_to_network(&mut network_builder) is that each component XXX  has an explicit dependency on the network_builder crate, so setup_network cannot be a part of network_builder without creating a circular dependency.

This change sidesteps this problem by taking away the explicit dependency from every component onto network_builder.


### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?

yes
## Test Plan

Don't break existing integration and unit tests.

## Related PRs

(If this PR adds or changes functionality, please take some time to update the docs at https://github.com/libra/website, and link to your PR here.)
