### PR TITLE
Move setup_network out of main_node

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2647,9 +2647,8 @@ dependencies = [
  "libra-vm 0.1.0",
  "libra-workspace-hack 0.1.0",
  "libradb 0.1.0",
- "network 0.1.0",
+ "network-builder 0.1.0",
  "network-simple-onchain-discovery 0.1.0",
- "onchain-discovery 0.1.0",
  "rayon 1.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "state-synchronizer 0.1.0",
  "storage-client 0.1.0",
@@ -3416,6 +3415,7 @@ dependencies = [
  "libra-workspace-hack 0.1.0",
  "memsocket 0.1.0",
  "netcore 0.1.0",
+ "network-builder 0.1.0",
  "num-variants 0.1.0",
  "once_cell 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "pin-project 0.4.22 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -3431,6 +3431,31 @@ dependencies = [
  "tokio 0.2.21 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-retry 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-util 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "network-builder"
+version = "0.1.0"
+dependencies = [
+ "channel 0.1.0",
+ "futures 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libra-canonical-serialization 0.1.0",
+ "libra-config 0.1.0",
+ "libra-crypto 0.1.0",
+ "libra-logger 0.1.0",
+ "libra-metrics 0.1.0",
+ "libra-network-address 0.1.0",
+ "libra-secure-storage 0.1.0",
+ "libra-types 0.1.0",
+ "libra-workspace-hack 0.1.0",
+ "netcore 0.1.0",
+ "network 0.1.0",
+ "onchain-discovery 0.1.0",
+ "rand 0.7.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.112 (registry+https://github.com/rust-lang/crates.io-index)",
+ "storage-interface 0.1.0",
+ "tokio 0.2.21 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio-retry 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -4982,6 +5007,7 @@ dependencies = [
  "memsocket 0.1.0",
  "netcore 0.1.0",
  "network 0.1.0",
+ "network-builder 0.1.0",
  "rand 0.7.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio 0.2.21 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-util 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -5086,6 +5112,7 @@ dependencies = [
  "libra-workspace-hack 0.1.0",
  "libradb 0.1.0",
  "network 0.1.0",
+ "network-builder 0.1.0",
  "once_cell 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.7.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.112 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3649,6 +3649,7 @@ dependencies = [
  "libra-config 0.1.0",
  "libra-crypto 0.1.0",
  "libra-logger 0.1.0",
+ "libra-metrics 0.1.0",
  "libra-network-address 0.1.0",
  "libra-types 0.1.0",
  "libra-vm 0.1.0",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -87,6 +87,7 @@ members = [
     "libra-node",
     "mempool",
     "network",
+    "network/builder",
     "network/memsocket",
     "network/netcore",
     "network/network-address",

--- a/consensus/src/network_interface.rs
+++ b/consensus/src/network_interface.rs
@@ -12,6 +12,7 @@ use consensus_types::{
     sync_info::SyncInfo,
     vote_msg::VoteMsg,
 };
+use libra_metrics::IntCounterVec;
 use libra_types::{epoch_change::EpochChangeProof, PeerId};
 use network::{
     error::NetworkError,
@@ -20,7 +21,7 @@ use network::{
         network::{NetworkEvents, NetworkSender, NewNetworkSender},
         rpc::error::RpcError,
     },
-    validator_network::network_builder::{NetworkBuilder, NETWORK_CHANNEL_SIZE},
+    validator_network::network_builder::NETWORK_CHANNEL_SIZE,
     ProtocolId,
 };
 use serde::{Deserialize, Serialize};
@@ -69,19 +70,21 @@ pub struct ConsensusNetworkSender {
     network_sender: NetworkSender<ConsensusMsg>,
 }
 
-/// Create a new Sender that only sends for the `CONSENSUS_DIRECT_SEND_PROTOCOL` and
-/// `CONSENSUS_RPC_PROTOCOL` ProtocolId and a Receiver (Events) that explicitly returns only said
-/// ProtocolId.
-pub fn add_to_network(
-    network: &mut NetworkBuilder,
-) -> (ConsensusNetworkSender, ConsensusNetworkEvents) {
-    network.add_protocol_handler((
+/// Configuration for the network endpoints to support consensus.
+pub fn network_endpoint_config() -> (
+    Vec<ProtocolId>,
+    Vec<ProtocolId>,
+    QueueStyle,
+    usize,
+    Option<&'static IntCounterVec>,
+) {
+    (
         vec![ProtocolId::ConsensusRpc],
         vec![ProtocolId::ConsensusDirectSend],
         QueueStyle::LIFO,
         NETWORK_CHANNEL_SIZE,
         Some(&counters::PENDING_CONSENSUS_NETWORK_EVENTS),
-    ))
+    )
 }
 
 impl NewNetworkSender for ConsensusNetworkSender {

--- a/consensus/src/network_interface.rs
+++ b/consensus/src/network_interface.rs
@@ -15,13 +15,13 @@ use consensus_types::{
 use libra_metrics::IntCounterVec;
 use libra_types::{epoch_change::EpochChangeProof, PeerId};
 use network::{
+    constants::NETWORK_CHANNEL_SIZE,
     error::NetworkError,
     peer_manager::{ConnectionRequestSender, PeerManagerRequestSender},
     protocols::{
         network::{NetworkEvents, NetworkSender, NewNetworkSender},
         rpc::error::RpcError,
     },
-    validator_network::network_builder::NETWORK_CHANNEL_SIZE,
     ProtocolId,
 };
 use serde::{Deserialize, Serialize};

--- a/consensus/src/network_tests.rs
+++ b/consensus/src/network_tests.rs
@@ -23,7 +23,10 @@ use network::{
         conn_notifs_channel, ConnectionRequestSender, PeerManagerNotification, PeerManagerRequest,
         PeerManagerRequestSender,
     },
-    protocols::rpc::InboundRpcRequest,
+    protocols::{
+        network::{NewNetworkEvents, NewNetworkSender},
+        rpc::InboundRpcRequest,
+    },
     ProtocolId,
 };
 use std::{

--- a/consensus/src/round_manager_fuzzing.rs
+++ b/consensus/src/round_manager_fuzzing.rs
@@ -27,7 +27,10 @@ use libra_types::{
     validator_signer::ValidatorSigner,
     validator_verifier::ValidatorVerifier,
 };
-use network::peer_manager::{ConnectionRequestSender, PeerManagerRequestSender};
+use network::{
+    peer_manager::{ConnectionRequestSender, PeerManagerRequestSender},
+    protocols::network::NewNetworkSender,
+};
 use once_cell::sync::Lazy;
 use safety_rules::{test_utils, SafetyRules, TSafetyRules};
 use std::{collections::BTreeMap, num::NonZeroUsize, sync::Arc, time::Duration};

--- a/consensus/src/round_manager_test.rs
+++ b/consensus/src/round_manager_test.rs
@@ -51,7 +51,7 @@ use libra_types::{
 };
 use network::{
     peer_manager::{conn_notifs_channel, ConnectionRequestSender, PeerManagerRequestSender},
-    protocols::network::Event,
+    protocols::network::{Event, NewNetworkEvents, NewNetworkSender},
 };
 use safety_rules::{ConsensusState, PersistentSafetyStorage, SafetyRulesManager};
 use std::{num::NonZeroUsize, sync::Arc, time::Duration};

--- a/consensus/src/twins_test.rs
+++ b/consensus/src/twins_test.rs
@@ -28,8 +28,9 @@ use libra_types::{
     validator_info::ValidatorInfo,
     waypoint::Waypoint,
 };
-use network::peer_manager::{
-    conn_notifs_channel, ConnectionRequestSender, PeerManagerRequestSender,
+use network::{
+    peer_manager::{conn_notifs_channel, ConnectionRequestSender, PeerManagerRequestSender},
+    protocols::network::{NewNetworkEvents, NewNetworkSender},
 };
 use std::{collections::HashMap, num::NonZeroUsize, sync::Arc};
 use tokio::runtime::{Builder, Runtime};

--- a/libra-node/Cargo.toml
+++ b/libra-node/Cargo.toml
@@ -33,9 +33,8 @@ libra-types = { path = "../types", version = "0.1.0" }
 libra-vm = { path = "../language/libra-vm", version = "0.1.0" }
 libra-workspace-hack = { path = "../common/workspace-hack", version = "0.1.0" }
 libradb = { path = "../storage/libradb", version = "0.1.0" }
-network = { path = "../network", version = "0.1.0" }
+network-builder = { path = "../network/builder", version = "0.1.0" }
 network-simple-onchain-discovery = { path = "../network/simple-onchain-discovery", version = "0.1.0"}
-onchain-discovery = { path = "../network/onchain-discovery", version = "0.1.0" }
 storage-client = { path = "../storage/storage-client", version = "0.1.0" }
 state-synchronizer = { path = "../state-synchronizer", version = "0.1.0" }
 storage-interface= { path = "../storage/storage-interface", version = "0.1.0" }

--- a/libra-node/src/main_node.rs
+++ b/libra-node/src/main_node.rs
@@ -235,8 +235,8 @@ pub fn setup_environment(node_config: &mut NodeConfig) -> LibraHandle {
         let peer_id = network_builder.peer_id();
 
         // Create the endpoints to connect the Network to StateSynchronizer.
-        let (state_sync_sender, state_sync_events) =
-            state_synchronizer::network::add_to_network(&mut network_builder);
+        let (state_sync_sender, state_sync_events) = network_builder
+            .add_protocol_handler(state_synchronizer::network::network_endpoint_config());
         state_sync_network_handles.push((peer_id, state_sync_sender, state_sync_events));
 
         // Create the endpoints to connect the network to MemPool.

--- a/libra-node/src/main_node.rs
+++ b/libra-node/src/main_node.rs
@@ -239,11 +239,12 @@ pub fn setup_environment(node_config: &mut NodeConfig) -> LibraHandle {
             .add_protocol_handler(state_synchronizer::network::network_endpoint_config());
         state_sync_network_handles.push((peer_id, state_sync_sender, state_sync_events));
 
-        // Create the endpoints to connect the network to MemPool.
-        let (mempool_sender, mempool_events) = libra_mempool::network::add_to_network(
-            &mut network_builder,
-            node_config.mempool.max_broadcasts_per_peer,
-        );
+        // Create the endpoints t connect the Network to MemPool.
+        let (mempool_sender, mempool_events) =
+            network_builder.add_protocol_handler(libra_mempool::network::network_endpoint_config(
+                // TODO:  Make this configuration option more clear.
+                node_config.mempool.max_broadcasts_per_peer,
+            ));
         mempool_network_handles.push((peer_id, mempool_sender, mempool_events));
 
         match role {

--- a/libra-node/src/main_node.rs
+++ b/libra-node/src/main_node.rs
@@ -133,8 +133,9 @@ pub fn setup_network(
                 .add_gossip_discovery();
         }
         DiscoveryMethod::Onchain => {
-            let (network_tx, discovery_events) =
-                onchain_discovery::network_interface::add_to_network(&mut network_builder);
+            let (network_tx, discovery_events) = network_builder.add_protocol_handler(
+                onchain_discovery::network_interface::network_endpoint_config(),
+            );
             let onchain_discovery_builder = OnchainDiscoveryBuilder::build(
                 network_builder
                     .conn_mgr_reqs_tx()

--- a/libra-node/src/main_node.rs
+++ b/libra-node/src/main_node.rs
@@ -268,9 +268,10 @@ pub fn setup_environment(node_config: &mut NodeConfig) -> LibraHandle {
                         .spawn(network_config_listener.start(simple_discovery_reconfig_rx));
                 };
 
-                consensus_network_handles = Some(consensus::network_interface::add_to_network(
-                    &mut network_builder,
-                ));
+                consensus_network_handles =
+                    Some(network_builder.add_protocol_handler(
+                        consensus::network_interface::network_endpoint_config(),
+                    ));
             }
             // Currently no FullNode network specific steps.
             RoleType::FullNode => (),

--- a/mempool/src/shared_mempool/network.rs
+++ b/mempool/src/shared_mempool/network.rs
@@ -5,12 +5,12 @@
 
 use crate::counters;
 use channel::message_queues::QueueStyle;
+use libra_metrics::IntCounterVec;
 use libra_types::{transaction::SignedTransaction, PeerId};
 use network::{
     error::NetworkError,
     peer_manager::{ConnectionRequestSender, PeerManagerRequestSender},
     protocols::network::{NetworkEvents, NetworkSender, NewNetworkSender},
-    validator_network::network_builder::NetworkBuilder,
     ProtocolId,
 };
 use serde::{Deserialize, Serialize};
@@ -62,17 +62,22 @@ pub struct MempoolNetworkSender {
 
 /// Create a new Sender that only sends for the `MEMPOOL_DIRECT_SEND_PROTOCOL` ProtocolId and a
 /// Receiver (Events) that explicitly returns only said ProtocolId.
-pub fn add_to_network(
-    network: &mut NetworkBuilder,
+pub fn network_endpoint_config(
     max_broadcasts_per_peer: usize,
-) -> (MempoolNetworkSender, MempoolNetworkEvents) {
-    network.add_protocol_handler((
+) -> (
+    Vec<ProtocolId>,
+    Vec<ProtocolId>,
+    QueueStyle,
+    usize,
+    Option<&'static IntCounterVec>,
+) {
+    (
         vec![],
         vec![ProtocolId::MempoolDirectSend],
         QueueStyle::KLAST,
         max_broadcasts_per_peer,
         Some(&counters::PENDING_MEMPOOL_NETWORK_EVENTS),
-    ))
+    )
 }
 
 impl NewNetworkSender for MempoolNetworkSender {

--- a/mempool/src/tests/mocks.rs
+++ b/mempool/src/tests/mocks.rs
@@ -15,8 +15,9 @@ use libra_config::{
     network_id::NetworkId,
 };
 use libra_types::{mempool_status::MempoolStatusCode, transaction::SignedTransaction};
-use network::peer_manager::{
-    conn_notifs_channel, ConnectionRequestSender, PeerManagerRequestSender,
+use network::{
+    peer_manager::{conn_notifs_channel, ConnectionRequestSender, PeerManagerRequestSender},
+    protocols::network::{NewNetworkEvents, NewNetworkSender},
 };
 use std::{
     num::NonZeroUsize,

--- a/mempool/src/tests/shared_mempool_test.rs
+++ b/mempool/src/tests/shared_mempool_test.rs
@@ -31,6 +31,7 @@ use network::{
         conn_notifs_channel, ConnectionNotification, ConnectionRequestSender,
         PeerManagerNotification, PeerManagerRequest, PeerManagerRequestSender,
     },
+    protocols::network::{NewNetworkEvents, NewNetworkSender},
     DisconnectReason, ProtocolId,
 };
 use std::{

--- a/network/Cargo.toml
+++ b/network/Cargo.toml
@@ -15,9 +15,11 @@ bytes = { version = "0.5.4", features = ["serde"] }
 futures = "0.3.5"
 hex = "0.4.2"
 once_cell = "1.4.0"
-pin-project = "0.4.22"
+pin-project = "0.4.20"
+proptest = { version = "0.10.0", default-features = true, optional = true }
 rand = "0.7.3"
-serde = { version = "1.0.112", default-features = false }
+rand_core = { version = "0.5.1", optional = true }
+serde = { version = "1.0.111", default-features = false }
 serde_bytes = "0.11.5"
 thiserror = "1.0.20"
 tokio = { version = "0.2.21", features = ["full"] }
@@ -32,22 +34,22 @@ libra-crypto = { path = "../crypto/crypto", version = "0.1.0" }
 libra-crypto-derive = { path = "../crypto/crypto-derive", version = "0.1.0" }
 libra-logger = { path = "../common/logger", version = "0.1.0" }
 libra-metrics = { path = "../common/metrics", version = "0.1.0" }
-libra-network-address = { path = "network-address", version = "0.1.0" }
+libra-network-address = { path = "../network/network-address", version = "0.1.0" }
 libra-proptest-helpers = { path = "../common/proptest-helpers", version = "0.1.0", optional = true }
 libra-security-logger = { path = "../common/security-logger", version = "0.1.0" }
 libra-types = { path = "../types", version = "0.1.0" }
 libra-workspace-hack = { path = "../common/workspace-hack", version = "0.1.0" }
-memsocket = { path = "memsocket", version = "0.1.0" }
-netcore = { path = "netcore", version = "0.1.0" }
+memsocket = { path = "../network/memsocket", version = "0.1.0" }
+netcore = { path = "../network/netcore", version = "0.1.0" }
 num-variants = { path = "../common/num-variants", version = "0.1.0" }
-proptest = { version = "0.10.0", default-features = true, optional = true }
 stream-ratelimiter = { path = "../common/stream-ratelimiter", version = "0.1.0" }
-rand_core = { version = "0.5.1", optional = true }
 
 [dev-dependencies]
 criterion = "0.3.2"
 serial_test = "0.4.0"
-socket-bench-server = { path = "socket-bench-server", version = "0.1.0" }
+
+network-builder = {path = "../network/builder", version = "0.1.0"}
+socket-bench-server = { path = "../network/socket-bench-server", version = "0.1.0" }
 
 [features]
 default = []

--- a/network/benches/network_bench.rs
+++ b/network/benches/network_bench.rs
@@ -20,13 +20,8 @@ use futures::{
     stream::{FuturesUnordered, StreamExt},
 };
 use libra_types::PeerId;
-use network::protocols::{
-    network::{
-        dummy::{setup_network, DummyMsg, DummyNetworkSender},
-        Event,
-    },
-    rpc::error::RpcError,
-};
+use network::protocols::{network::Event, rpc::error::RpcError};
+use network_builder::dummy::{setup_network, DummyMsg, DummyNetworkSender};
 use std::time::Duration;
 
 const KiB: usize = 1 << 10;

--- a/network/builder/Cargo.toml
+++ b/network/builder/Cargo.toml
@@ -1,0 +1,29 @@
+[package]
+name = "network-builder"
+version = "0.1.0"
+authors = ["Libra Association <opensource@libra.org>"]
+description = "Libra Onchain Discovery Protocol"
+repository = "https://github.com/libra/libra"
+homepage = "https://libra.org"
+license = "Apache-2.0"
+publish = false
+edition = "2018"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+futures = "0.3.5"
+tokio = { version = "0.2.21", features = ["full"] }
+tokio-retry = "0.2.0"
+
+
+channel = { path = "../../common/channel", version = "0.1.0" }
+network = { path = "../", version = "0.1.0" }
+libra-config = { path = "../../config", version = "0.1.0" }
+libra-crypto = { path = "../../crypto/crypto", version = "0.1.0" }
+libra-logger = { path = "../../common/logger", version = "0.1.0" }
+libra-metrics = {path = "../../common/metrics", version = "0.1.0"}
+libra-network-address = { path = "../network-address", version = "0.1.0" }
+libra-types = { path = "../../types", version = "0.1.0" }
+libra-workspace-hack = { path = "../../common/workspace-hack", version = "0.1.0" }
+netcore = { path = "../../network/netcore", version = "0.1.0" }

--- a/network/builder/Cargo.toml
+++ b/network/builder/Cargo.toml
@@ -13,17 +13,23 @@ edition = "2018"
 
 [dependencies]
 futures = "0.3.5"
+rand = "0.7.3"
+serde = { version = "1.0.111", default-features = false }
 tokio = { version = "0.2.21", features = ["full"] }
 tokio-retry = "0.2.0"
 
 
 channel = { path = "../../common/channel", version = "0.1.0" }
-network = { path = "../", version = "0.1.0" }
+lcs = { path = "../../common/lcs", version = "0.1.0", package = "libra-canonical-serialization" }
 libra-config = { path = "../../config", version = "0.1.0" }
 libra-crypto = { path = "../../crypto/crypto", version = "0.1.0" }
 libra-logger = { path = "../../common/logger", version = "0.1.0" }
 libra-metrics = {path = "../../common/metrics", version = "0.1.0"}
-libra-network-address = { path = "../network-address", version = "0.1.0" }
+libra-network-address = { path = "../../network/network-address", version = "0.1.0" }
+libra-secure-storage = { path = "../../secure/storage", version = "0.1.0" }
 libra-types = { path = "../../types", version = "0.1.0" }
 libra-workspace-hack = { path = "../../common/workspace-hack", version = "0.1.0" }
 netcore = { path = "../../network/netcore", version = "0.1.0" }
+network = { path = "../../network", version = "0.1.0" }
+onchain-discovery = { path = "../../network/onchain-discovery", version = "0.1.0" }
+storage-interface= { path = "../../storage/storage-interface", version = "0.1.0" }

--- a/network/builder/src/dummy.rs
+++ b/network/builder/src/dummy.rs
@@ -3,17 +3,7 @@
 
 //! Integration tests for validator_network.
 
-use crate::{
-    constants::NETWORK_CHANNEL_SIZE,
-    error::NetworkError,
-    peer_manager::{ConnectionRequestSender, PeerManagerRequestSender},
-    protocols::{
-        network::{Event, NetworkEvents, NetworkSender, NewNetworkSender},
-        rpc::error::RpcError,
-    },
-    validator_network::network_builder::{AuthenticationMode, NetworkBuilder},
-    ProtocolId,
-};
+use crate::builder::{AuthenticationMode, NetworkBuilder};
 use channel::message_queues::QueueStyle;
 use futures::{executor::block_on, StreamExt};
 use libra_config::{chain_id::ChainId, config::RoleType, network_id::NetworkId};
@@ -21,6 +11,16 @@ use libra_crypto::{test_utils::TEST_SEED, x25519, Uniform};
 use libra_metrics::IntCounterVec;
 use libra_network_address::NetworkAddress;
 use libra_types::PeerId;
+use network::{
+    constants::NETWORK_CHANNEL_SIZE,
+    error::NetworkError,
+    peer_manager::{ConnectionRequestSender, PeerManagerRequestSender},
+    protocols::{
+        network::{Event, NetworkEvents, NetworkSender, NewNetworkSender},
+        rpc::error::RpcError,
+    },
+    ProtocolId,
+};
 use rand::{rngs::StdRng, SeedableRng};
 use serde::{Deserialize, Serialize};
 use std::{collections::HashMap, time::Duration};

--- a/network/builder/src/lib.rs
+++ b/network/builder/src/lib.rs
@@ -1,0 +1,5 @@
+// Copyright (c) The Libra Core Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+pub use network::protocols::rpc::error::RpcError;
+pub mod builder;

--- a/network/builder/src/lib.rs
+++ b/network/builder/src/lib.rs
@@ -3,3 +3,11 @@
 
 pub use network::protocols::rpc::error::RpcError;
 pub mod builder;
+
+// TODO:  This module should be test-only, e.g., #[cfg(any(feature = "testing", test))]
+// At present it cannot be because network_builder must be a separate crate and the current
+// factoring of DummyNetwork requires use of network_builder.  A holistic review of the
+// network directory is needed to break internal circular dependencies.
+pub mod dummy;
+#[cfg(test)]
+mod test;

--- a/network/builder/src/test.rs
+++ b/network/builder/src/test.rs
@@ -2,9 +2,9 @@
 // SPDX-License-Identifier: Apache-2.0
 
 //! Integration tests for validator_network.
-use super::*;
-use crate::protocols::network::dummy::{setup_network, DummyMsg};
+use crate::dummy::{setup_network, DummyMsg};
 use futures::{future::join, StreamExt};
+use network::protocols::network::Event;
 use std::time::Duration;
 
 #[test]

--- a/network/onchain-discovery/Cargo.toml
+++ b/network/onchain-discovery/Cargo.toml
@@ -23,6 +23,7 @@ lcs = { path = "../../common/lcs", version = "0.1.0", package = "libra-canonical
 libra-config = { path = "../../config", version = "0.1.0" }
 libra-crypto = { path = "../../crypto/crypto", version = "0.1.0" }
 libra-logger = { path = "../../common/logger", version = "0.1.0" }
+libra-metrics = {path = "../../common/metrics", version = "0.1.0"}
 libra-network-address = { path = "../network-address", version = "0.1.0" }
 libra-types = { path = "../../types", version = "0.1.0" }
 libra-workspace-hack = { path = "../../common/workspace-hack", version = "0.1.0" }

--- a/network/onchain-discovery/src/network_interface.rs
+++ b/network/onchain-discovery/src/network_interface.rs
@@ -7,6 +7,7 @@ use channel::{libra_channel, message_queues::QueueStyle};
 use libra_metrics::IntCounterVec;
 use libra_types::PeerId;
 use network::{
+    constants::NETWORK_CHANNEL_SIZE,
     peer_manager::{
         ConnectionNotification, ConnectionRequestSender, PeerManagerNotification,
         PeerManagerRequestSender,
@@ -15,7 +16,6 @@ use network::{
         network::{NetworkSender, NewNetworkEvents, NewNetworkSender},
         rpc::error::RpcError,
     },
-    validator_network::network_builder::NETWORK_CHANNEL_SIZE,
     ProtocolId,
 };
 use std::time::Duration;

--- a/network/onchain-discovery/src/network_interface.rs
+++ b/network/onchain-discovery/src/network_interface.rs
@@ -4,6 +4,7 @@
 //! Protobuf based interface between OnchainDiscovery and Network layers.
 use crate::types::{OnchainDiscoveryMsg, QueryDiscoverySetRequest, QueryDiscoverySetResponse};
 use channel::{libra_channel, message_queues::QueueStyle};
+use libra_metrics::IntCounterVec;
 use libra_types::PeerId;
 use network::{
     peer_manager::{
@@ -14,7 +15,7 @@ use network::{
         network::{NetworkSender, NewNetworkEvents, NewNetworkSender},
         rpc::error::RpcError,
     },
-    validator_network::network_builder::{NetworkBuilder, NETWORK_CHANNEL_SIZE},
+    validator_network::network_builder::NETWORK_CHANNEL_SIZE,
     ProtocolId,
 };
 use std::time::Duration;
@@ -83,12 +84,15 @@ impl OnchainDiscoveryNetworkSender {
     }
 }
 
-/// Construct OnchainDiscoveryNetworkSender/Events and register them with the
-/// given network builder.
-pub fn add_to_network(
-    network: &mut NetworkBuilder,
-) -> (OnchainDiscoveryNetworkSender, OnchainDiscoveryNetworkEvents) {
-    network.add_protocol_handler((
+/// Provides the configuration parameters for the network endpoint.
+pub fn network_endpoint_config() -> (
+    Vec<ProtocolId>,
+    Vec<ProtocolId>,
+    QueueStyle,
+    usize,
+    Option<&'static IntCounterVec>,
+) {
+    (
         vec![ProtocolId::OnchainDiscoveryRpc],
         vec![],
         QueueStyle::LIFO,
@@ -96,5 +100,5 @@ pub fn add_to_network(
         // Some(&counters::PENDING_CONSENSUS_NETWORK_EVENTS),
         // TODO(philiphayes): add a counter for onchain discovery
         None,
-    ))
+    )
 }

--- a/network/onchain-discovery/src/test.rs
+++ b/network/onchain-discovery/src/test.rs
@@ -34,7 +34,10 @@ use network::{
         ConnectionNotification, ConnectionRequestSender, PeerManagerNotification,
         PeerManagerRequest, PeerManagerRequestSender,
     },
-    protocols::rpc::{InboundRpcRequest, OutboundRpcRequest},
+    protocols::{
+        network::NewNetworkSender,
+        rpc::{InboundRpcRequest, OutboundRpcRequest},
+    },
     ProtocolId,
 };
 use std::{

--- a/network/socket-bench-server/Cargo.toml
+++ b/network/socket-bench-server/Cargo.toml
@@ -19,7 +19,8 @@ libra-logger = { path = "../../common/logger", version = "0.1.0" }
 libra-network-address = { path = "../network-address", version = "0.1.0" }
 libra-types = { path = "../../types" }
 libra-workspace-hack = { path = "../../common/workspace-hack", version = "0.1.0" }
-memsocket = { path = "../memsocket", version = "0.1.0" }
-netcore = { path = "../netcore", version = "0.1.0" }
-network = { path = "../", version = "0.1.0", features = ["testing"] }
+memsocket = { path = "../../network/memsocket", version = "0.1.0" }
+netcore = { path = "../../network/netcore", version = "0.1.0" }
+network = { path = "../../network", version = "0.1.0", features = ["testing"] }
+network-builder = { path = "../../network/builder", version = "0.1.0"}
 rand = "0.7.3"

--- a/network/src/constants.rs
+++ b/network/src/constants.rs
@@ -1,0 +1,24 @@
+// Copyright (c) The Libra Core Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+/// A collection of constants and default values for configuring various network components.
+
+// NB: Almost all of these values are educated guesses, and not determined using any empirical
+// data. If you run into a limit and believe that it is unreasonably tight, please submit a PR
+// with your use-case. If you do change a value, please add a comment linking to the PR which
+// advocated the change.
+// TODO:  Each of these should be commented with semantic meaning, intended use place, and justification for the value.
+// TODO:  Better --- these should be encapsulated in configurations somewhere.
+pub const NETWORK_CHANNEL_SIZE: usize = 1024;
+pub const DISCOVERY_INTERVAL_MS: u64 = 1000;
+pub const PING_INTERVAL_MS: u64 = 1000;
+pub const PING_TIMEOUT_MS: u64 = 10_000;
+pub const DISOVERY_MSG_TIMEOUT_MS: u64 = 10_000;
+pub const CONNECTIVITY_CHECK_INTERNAL_MS: u64 = 5000;
+pub const INBOUND_RPC_TIMEOUT_MS: u64 = 10_000;
+pub const MAX_CONCURRENT_OUTBOUND_RPCS: u32 = 100;
+pub const MAX_CONCURRENT_INBOUND_RPCS: u32 = 100;
+pub const PING_FAILURES_TOLERATED: u64 = 10;
+pub const MAX_CONCURRENT_NETWORK_REQS: usize = 100;
+pub const MAX_CONCURRENT_NETWORK_NOTIFS: usize = 100;
+pub const MAX_CONNECTION_DELAY_MS: u64 = 60_000; /* 1 minute */

--- a/network/src/interface/mod.rs
+++ b/network/src/interface/mod.rs
@@ -12,7 +12,7 @@
 //! [`NetworkProvider`] actor. Inbound RPC requests are forwarded to the appropriate
 //! handler, determined using the protocol negotiated on the RPC substream.
 use crate::{
-    counters,
+    constants, counters,
     peer::{Peer, PeerHandle, PeerNotification},
     peer_manager::TransportNotification,
     protocols::{
@@ -20,7 +20,7 @@ use crate::{
         rpc::{InboundRpcRequest, OutboundRpcRequest, Rpc, RpcNotification},
     },
     transport::Connection,
-    validator_network, ProtocolId,
+    ProtocolId,
 };
 use channel::{self, libra_channel, message_queues::QueueStyle};
 use futures::{
@@ -129,9 +129,9 @@ where
             rpc_reqs_rx,
             peer_rpc_notifs_rx,
             rpc_notifs_tx,
-            Duration::from_millis(validator_network::network_builder::INBOUND_RPC_TIMEOUT_MS),
-            validator_network::network_builder::MAX_CONCURRENT_OUTBOUND_RPCS,
-            validator_network::network_builder::MAX_CONCURRENT_INBOUND_RPCS,
+            Duration::from_millis(constants::INBOUND_RPC_TIMEOUT_MS),
+            constants::MAX_CONCURRENT_OUTBOUND_RPCS,
+            constants::MAX_CONCURRENT_INBOUND_RPCS,
         );
         executor.spawn(rpc.start());
 

--- a/network/src/lib.rs
+++ b/network/src/lib.rs
@@ -16,12 +16,11 @@ pub mod interface;
 pub mod logging;
 pub mod peer_manager;
 pub mod protocols;
-pub mod validator_network;
 
 pub mod counters;
 mod peer;
 mod sink;
-mod transport;
+pub mod transport;
 
 #[cfg(not(any(feature = "testing", feature = "fuzzing")))]
 mod noise;

--- a/network/src/lib.rs
+++ b/network/src/lib.rs
@@ -10,6 +10,7 @@ pub use interface::NetworkProvider;
 
 pub mod common;
 pub mod connectivity_manager;
+pub mod constants;
 pub mod error;
 pub mod interface;
 pub mod logging;

--- a/network/src/protocols/discovery/mod.rs
+++ b/network/src/protocols/discovery/mod.rs
@@ -35,11 +35,11 @@
 
 use crate::{
     connectivity_manager::{ConnectivityRequest, DiscoverySource},
+    constants::NETWORK_CHANNEL_SIZE,
     counters,
     error::NetworkError,
     peer_manager::{ConnectionRequestSender, PeerManagerRequestSender},
     protocols::network::{Event, NetworkEvents, NetworkSender, NewNetworkSender},
-    validator_network::network_builder::NETWORK_CHANNEL_SIZE,
     ProtocolId,
 };
 use bytes::Bytes;

--- a/network/src/protocols/discovery/mod.rs
+++ b/network/src/protocols/discovery/mod.rs
@@ -39,7 +39,7 @@ use crate::{
     error::NetworkError,
     peer_manager::{ConnectionRequestSender, PeerManagerRequestSender},
     protocols::network::{Event, NetworkEvents, NetworkSender, NewNetworkSender},
-    validator_network::network_builder::{NetworkBuilder, NETWORK_CHANNEL_SIZE},
+    validator_network::network_builder::NETWORK_CHANNEL_SIZE,
     ProtocolId,
 };
 use bytes::Bytes;
@@ -51,6 +51,7 @@ use futures::{
 use libra_config::network_id::NetworkContext;
 use libra_crypto_derive::{CryptoHasher, LCSCryptoHash};
 use libra_logger::prelude::*;
+use libra_metrics::IntCounterVec;
 use libra_network_address::NetworkAddress;
 use libra_security_logger::{security_log, SecurityEvent};
 use libra_types::PeerId;
@@ -87,18 +88,21 @@ pub struct DiscoveryNetworkSender {
     inner: NetworkSender<DiscoveryMsg>,
 }
 
-/// Register the discovery sender and event handler with network and return interfaces for those
-/// actors.
-pub fn add_to_network(
-    network: &mut NetworkBuilder,
-) -> (DiscoveryNetworkSender, DiscoveryNetworkEvents) {
-    network.add_protocol_handler((
+/// Configuration for the network endpoints to support Discovery.
+pub fn network_endpoint_config() -> (
+    Vec<ProtocolId>,
+    Vec<ProtocolId>,
+    QueueStyle,
+    usize,
+    Option<&'static IntCounterVec>,
+) {
+    (
         vec![],
         vec![ProtocolId::DiscoveryDirectSend],
         QueueStyle::LIFO,
         NETWORK_CHANNEL_SIZE,
         Some(&counters::PENDING_DISCOVERY_NETWORK_EVENTS),
-    ))
+    )
 }
 
 impl NewNetworkSender for DiscoveryNetworkSender {

--- a/network/src/protocols/discovery/test.rs
+++ b/network/src/protocols/discovery/test.rs
@@ -8,7 +8,10 @@ use crate::{
         self, conn_notifs_channel, ConnectionRequestSender, PeerManagerNotification,
         PeerManagerRequest,
     },
-    protocols::direct_send::Message,
+    protocols::{
+        direct_send::Message,
+        network::{NewNetworkEvents, NewNetworkSender},
+    },
     ProtocolId,
 };
 use anyhow::anyhow;

--- a/network/src/protocols/health_checker/mod.rs
+++ b/network/src/protocols/health_checker/mod.rs
@@ -25,7 +25,7 @@ use crate::{
         network::{Event, NetworkEvents, NetworkSender, NewNetworkSender},
         rpc::error::RpcError,
     },
-    validator_network::network_builder::{NetworkBuilder, NETWORK_CHANNEL_SIZE},
+    validator_network::network_builder::NETWORK_CHANNEL_SIZE,
     ProtocolId,
 };
 use bytes::Bytes;
@@ -36,6 +36,7 @@ use futures::{
 };
 use libra_config::network_id::NetworkContext;
 use libra_logger::prelude::*;
+use libra_metrics::IntCounterVec;
 use libra_security_logger::{security_log, SecurityEvent};
 use libra_types::PeerId;
 use rand::{rngs::SmallRng, seq::SliceRandom, Rng, SeedableRng};
@@ -66,16 +67,21 @@ pub struct HealthCheckerNetworkSender {
     inner: NetworkSender<HealthCheckerMsg>,
 }
 
-pub fn add_to_network(
-    network: &mut NetworkBuilder,
-) -> (HealthCheckerNetworkSender, HealthCheckerNetworkEvents) {
-    network.add_protocol_handler((
+/// Configuration for the network endpoints to support HealthChecker.
+pub fn network_endpoint_config() -> (
+    Vec<ProtocolId>,
+    Vec<ProtocolId>,
+    QueueStyle,
+    usize,
+    Option<&'static IntCounterVec>,
+) {
+    (
         vec![ProtocolId::HealthCheckerRpc],
         vec![],
         QueueStyle::LIFO,
         NETWORK_CHANNEL_SIZE,
         Some(&counters::PENDING_HEALTH_CHECKER_NETWORK_EVENTS),
-    ))
+    )
 }
 
 impl NewNetworkSender for HealthCheckerNetworkSender {

--- a/network/src/protocols/health_checker/mod.rs
+++ b/network/src/protocols/health_checker/mod.rs
@@ -18,6 +18,7 @@
 //! - Use successful inbound pings as a sign of remote note being healthy
 //! - Ping a peer only in periods of no application-level communication with the peer
 use crate::{
+    constants::NETWORK_CHANNEL_SIZE,
     counters,
     error::NetworkError,
     peer_manager::{ConnectionRequestSender, PeerManagerRequestSender},
@@ -25,7 +26,6 @@ use crate::{
         network::{Event, NetworkEvents, NetworkSender, NewNetworkSender},
         rpc::error::RpcError,
     },
-    validator_network::network_builder::NETWORK_CHANNEL_SIZE,
     ProtocolId,
 };
 use bytes::Bytes;

--- a/network/src/protocols/health_checker/test.rs
+++ b/network/src/protocols/health_checker/test.rs
@@ -6,7 +6,10 @@ use crate::{
     peer_manager::{
         self, conn_notifs_channel, ConnectionRequest, PeerManagerNotification, PeerManagerRequest,
     },
-    protocols::rpc::InboundRpcRequest,
+    protocols::{
+        network::{NewNetworkEvents, NewNetworkSender},
+        rpc::InboundRpcRequest,
+    },
     ProtocolId,
 };
 use channel::{libra_channel, message_queues::QueueStyle};

--- a/network/src/protocols/network/dummy.rs
+++ b/network/src/protocols/network/dummy.rs
@@ -4,15 +4,14 @@
 //! Integration tests for validator_network.
 
 use crate::{
+    constants::NETWORK_CHANNEL_SIZE,
     error::NetworkError,
     peer_manager::{ConnectionRequestSender, PeerManagerRequestSender},
     protocols::{
         network::{Event, NetworkEvents, NetworkSender, NewNetworkSender},
         rpc::error::RpcError,
     },
-    validator_network::network_builder::{
-        AuthenticationMode, NetworkBuilder, NETWORK_CHANNEL_SIZE,
-    },
+    validator_network::network_builder::{AuthenticationMode, NetworkBuilder},
     ProtocolId,
 };
 use channel::message_queues::QueueStyle;

--- a/network/src/protocols/network/mod.rs
+++ b/network/src/protocols/network/mod.rs
@@ -25,11 +25,6 @@ use pin_project::pin_project;
 use serde::{de::DeserializeOwned, Serialize};
 use std::{marker::PhantomData, pin::Pin, time::Duration};
 
-#[cfg(any(feature = "testing", test))]
-pub mod dummy;
-#[cfg(test)]
-mod test;
-
 pub trait Message: DeserializeOwned + Serialize {}
 impl<T: DeserializeOwned + Serialize> Message for T {}
 

--- a/network/src/protocols/network/mod.rs
+++ b/network/src/protocols/network/mod.rs
@@ -95,8 +95,16 @@ pub struct NetworkEvents<TMessage> {
     _marker: PhantomData<TMessage>,
 }
 
-impl<TMessage: Message> NetworkEvents<TMessage> {
-    pub fn new(
+/// Trait specifying the signature for `new()` `NetworkEvents`
+pub trait NewNetworkEvents {
+    fn new(
+        peer_mgr_notifs_rx: libra_channel::Receiver<(PeerId, ProtocolId), PeerManagerNotification>,
+        connection_notifs_rx: libra_channel::Receiver<PeerId, ConnectionNotification>,
+    ) -> Self;
+}
+
+impl<TMessage: Message> NewNetworkEvents for NetworkEvents<TMessage> {
+    fn new(
         peer_mgr_notifs_rx: libra_channel::Receiver<(PeerId, ProtocolId), PeerManagerNotification>,
         connection_notifs_rx: libra_channel::Receiver<PeerId, ConnectionNotification>,
     ) -> Self {
@@ -178,8 +186,16 @@ pub struct NetworkSender<TMessage> {
     _marker: PhantomData<TMessage>,
 }
 
-impl<TMessage> NetworkSender<TMessage> {
-    pub fn new(
+/// Trait specifying the signature for `new()` `NetworkSender`s
+pub trait NewNetworkSender {
+    fn new(
+        peer_mgr_reqs_tx: PeerManagerRequestSender,
+        connection_reqs_tx: ConnectionRequestSender,
+    ) -> Self;
+}
+
+impl<TMessage> NewNetworkSender for NetworkSender<TMessage> {
+    fn new(
         peer_mgr_reqs_tx: PeerManagerRequestSender,
         connection_reqs_tx: ConnectionRequestSender,
     ) -> Self {
@@ -189,7 +205,9 @@ impl<TMessage> NetworkSender<TMessage> {
             _marker: PhantomData,
         }
     }
+}
 
+impl<TMessage> NetworkSender<TMessage> {
     /// Request that a given Peer be dialed at the provided `NetworkAddress` and
     /// synchronously wait for the request to be performed.
     pub async fn dial_peer(

--- a/network/src/validator_network/mod.rs
+++ b/network/src/validator_network/mod.rs
@@ -1,7 +1,0 @@
-// Copyright (c) The Libra Core Contributors
-// SPDX-License-Identifier: Apache-2.0
-
-//! Network API for Libra
-
-pub use crate::protocols::rpc::error::RpcError;
-pub mod network_builder;

--- a/network/src/validator_network/network_builder.rs
+++ b/network/src/validator_network/network_builder.rs
@@ -340,7 +340,8 @@ impl NetworkBuilder {
             .conn_mgr_reqs_tx()
             .expect("ConnectivityManager not enabled");
         // Get handles for network events and sender.
-        let (discovery_network_tx, discovery_network_rx) = discovery::add_to_network(self);
+        let (discovery_network_tx, discovery_network_rx) =
+            self.add_protocol_handler(discovery::network_endpoint_config());
 
         // TODO(philiphayes): the current setup for gossip discovery doesn't work
         // when we don't have an `advertised_address` set, since it uses the

--- a/network/src/validator_network/network_builder.rs
+++ b/network/src/validator_network/network_builder.rs
@@ -11,7 +11,7 @@
 //! long as the latter is in its trusted peers set.
 use crate::{
     connectivity_manager::{ConnectivityManager, ConnectivityRequest},
-    counters,
+    constants, counters,
     peer_manager::{
         conn_notifs_channel, ConnectionRequest, ConnectionRequestSender, PeerManager,
         PeerManagerNotification, PeerManagerRequest, PeerManagerRequestSender,
@@ -47,24 +47,6 @@ use std::{
 };
 use tokio::{runtime::Handle, time::interval};
 use tokio_retry::strategy::ExponentialBackoff;
-
-// NB: Almost all of these values are educated guesses, and not determined using any empirical
-// data. If you run into a limit and believe that it is unreasonably tight, please submit a PR
-// with your use-case. If you do change a value, please add a comment linking to the PR which
-// advocated the change.
-pub const NETWORK_CHANNEL_SIZE: usize = 1024;
-pub const DISCOVERY_INTERVAL_MS: u64 = 1000;
-pub const PING_INTERVAL_MS: u64 = 1000;
-pub const PING_TIMEOUT_MS: u64 = 10_000;
-pub const DISOVERY_MSG_TIMEOUT_MS: u64 = 10_000;
-pub const CONNECTIVITY_CHECK_INTERNAL_MS: u64 = 5000;
-pub const INBOUND_RPC_TIMEOUT_MS: u64 = 10_000;
-pub const MAX_CONCURRENT_OUTBOUND_RPCS: u32 = 100;
-pub const MAX_CONCURRENT_INBOUND_RPCS: u32 = 100;
-pub const PING_FAILURES_TOLERATED: u64 = 10;
-pub const MAX_CONCURRENT_NETWORK_REQS: usize = 100;
-pub const MAX_CONCURRENT_NETWORK_NOTIFS: usize = 100;
-pub const MAX_CONNECTION_DELAY_MS: u64 = 60_000; /* 1 minute */
 
 #[derive(Debug)]
 pub enum AuthenticationMode {
@@ -144,13 +126,13 @@ impl NetworkBuilder {
         // Setup channel to send requests to peer manager.
         let (pm_reqs_tx, pm_reqs_rx) = libra_channel::new(
             QueueStyle::FIFO,
-            NonZeroUsize::new(NETWORK_CHANNEL_SIZE).unwrap(),
+            NonZeroUsize::new(constants::NETWORK_CHANNEL_SIZE).unwrap(),
             Some(&counters::PENDING_PEER_MANAGER_REQUESTS),
         );
         // Setup channel to send connection requests to peer manager.
         let (connection_reqs_tx, connection_reqs_rx) = libra_channel::new(
             QueueStyle::FIFO,
-            NonZeroUsize::new(NETWORK_CHANNEL_SIZE).unwrap(),
+            NonZeroUsize::new(constants::NETWORK_CHANNEL_SIZE).unwrap(),
             None,
         );
         NetworkBuilder {
@@ -162,7 +144,7 @@ impl NetworkBuilder {
             seed_peers: HashMap::new(),
             trusted_peers: Arc::new(RwLock::new(HashMap::new())),
             authentication_mode: None,
-            channel_size: NETWORK_CHANNEL_SIZE,
+            channel_size: constants::NETWORK_CHANNEL_SIZE,
             direct_send_protocols: vec![],
             rpc_protocols: vec![],
             upstream_handlers: HashMap::new(),
@@ -172,14 +154,14 @@ impl NetworkBuilder {
             connection_reqs_tx,
             connection_reqs_rx,
             conn_mgr_reqs_tx: None,
-            discovery_interval_ms: DISCOVERY_INTERVAL_MS,
-            ping_interval_ms: PING_INTERVAL_MS,
-            ping_timeout_ms: PING_TIMEOUT_MS,
-            ping_failures_tolerated: PING_FAILURES_TOLERATED,
-            connectivity_check_interval_ms: CONNECTIVITY_CHECK_INTERNAL_MS,
-            max_concurrent_network_reqs: MAX_CONCURRENT_NETWORK_REQS,
-            max_concurrent_network_notifs: MAX_CONCURRENT_NETWORK_NOTIFS,
-            max_connection_delay_ms: MAX_CONNECTION_DELAY_MS,
+            discovery_interval_ms: constants::DISCOVERY_INTERVAL_MS,
+            ping_interval_ms: constants::PING_INTERVAL_MS,
+            ping_timeout_ms: constants::PING_TIMEOUT_MS,
+            ping_failures_tolerated: constants::PING_FAILURES_TOLERATED,
+            connectivity_check_interval_ms: constants::CONNECTIVITY_CHECK_INTERNAL_MS,
+            max_concurrent_network_reqs: constants::MAX_CONCURRENT_NETWORK_REQS,
+            max_concurrent_network_notifs: constants::MAX_CONCURRENT_NETWORK_NOTIFS,
+            max_connection_delay_ms: constants::MAX_CONNECTION_DELAY_MS,
         }
     }
 

--- a/network/src/validator_network/network_builder.rs
+++ b/network/src/validator_network/network_builder.rs
@@ -384,7 +384,8 @@ impl NetworkBuilder {
 
     pub fn add_connection_monitoring(&mut self) -> &mut Self {
         // Initialize and start HealthChecker.
-        let (hc_network_tx, hc_network_rx) = health_checker::add_to_network(self);
+        let (hc_network_tx, hc_network_rx) =
+            self.add_protocol_handler(health_checker::network_endpoint_config());
         let ping_interval_ms = self.ping_interval_ms;
         let ping_timeout_ms = self.ping_timeout_ms;
         let ping_failures_tolerated = self.ping_failures_tolerated;

--- a/state-synchronizer/Cargo.toml
+++ b/state-synchronizer/Cargo.toml
@@ -29,6 +29,7 @@ libra-metrics = { path = "../common/metrics", version = "0.1.0" }
 libra-types = { path = "../types", version = "0.1.0" }
 libra-workspace-hack = { path = "../common/workspace-hack", version = "0.1.0" }
 network = { path = "../network", version = "0.1.0" }
+network-builder = {path  = "../network/builder", version = "0.1.0"}
 storage-interface = { path = "../storage/storage-interface", version = "0.1.0" }
 subscription-service = { path = "../common/subscription-service", version = "0.1.0" }
 libra-vm = { path = "../language/libra-vm", version = "0.1.0" }

--- a/state-synchronizer/src/network.rs
+++ b/state-synchronizer/src/network.rs
@@ -5,12 +5,12 @@
 
 use crate::{chunk_request::GetChunkRequest, chunk_response::GetChunkResponse, counters};
 use channel::message_queues::QueueStyle;
+use libra_metrics::IntCounterVec;
 use libra_types::PeerId;
 use network::{
     error::NetworkError,
     peer_manager::{ConnectionRequestSender, PeerManagerRequestSender},
     protocols::network::{NetworkEvents, NetworkSender, NewNetworkSender},
-    validator_network::network_builder::NetworkBuilder,
     ProtocolId,
 };
 use serde::{Deserialize, Serialize};
@@ -43,16 +43,22 @@ pub struct StateSynchronizerSender {
     inner: NetworkSender<StateSynchronizerMsg>,
 }
 
-pub fn add_to_network(
-    network: &mut NetworkBuilder,
-) -> (StateSynchronizerSender, StateSynchronizerEvents) {
-    network.add_protocol_handler((
+/// Configuration for the network endpoints to support StateSynchronizer.
+pub fn network_endpoint_config() -> (
+    Vec<ProtocolId>,
+    Vec<ProtocolId>,
+    QueueStyle,
+    usize,
+    Option<&'static IntCounterVec>,
+) {
+    (
         vec![],
         vec![ProtocolId::StateSynchronizerDirectSend],
         QueueStyle::LIFO,
+        // TODO:  Name this as a constant.
         1,
         Some(&counters::PENDING_STATE_SYNCHRONIZER_NETWORK_EVENTS),
-    ))
+    )
 }
 
 impl NewNetworkSender for StateSynchronizerSender {

--- a/state-synchronizer/src/tests/integration_tests.rs
+++ b/state-synchronizer/src/tests/integration_tests.rs
@@ -23,7 +23,7 @@ use libra_types::{
     validator_info::ValidatorInfo, validator_signer::ValidatorSigner,
     validator_verifier::random_validator_verifier, waypoint::Waypoint,
 };
-use network::validator_network::network_builder::{AuthenticationMode, NetworkBuilder};
+use network_builder::builder::{AuthenticationMode, NetworkBuilder};
 use rand::{rngs::StdRng, SeedableRng};
 use std::{
     collections::HashMap,

--- a/state-synchronizer/src/tests/integration_tests.rs
+++ b/state-synchronizer/src/tests/integration_tests.rs
@@ -269,7 +269,8 @@ impl SynchronizerEnv {
             .add_connectivity_manager()
             .add_gossip_discovery();
 
-        let (sender, events) = crate::network::add_to_network(&mut network_builder);
+        let (sender, events) =
+            network_builder.add_protocol_handler(crate::network::network_endpoint_config());
         let peer_addr = network_builder.build();
 
         let mut config = config_builder::test_config().0;


### PR DESCRIPTION
<!--
Thank you for sending a PR. We appreciate you spending time to help improve the Libra project.

The project is undergoing daily changes. Pull Requests will be reviewed and responded to as time permits.
-->

## Motivation

Move setup_network out of main_node to clean up main and consolidate the network construction logic.

An important side piece of this change is to move network_builder into its own crate in order to eliminate a dependency loop.

This change sets the groundwork for being able to directly simplify the setup_network logic in a focused and narrow scope.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?

yes

## Test Plan

Don't break existing unit and integration tests.

## Related PRs

(If this PR adds or changes functionality, please take some time to update the docs at https://github.com/libra/website, and link to your PR here.)
