### PR TITLE
[Key Management] Support configurable structured logging to endpoint.

### DIFF
--- a/docker/safety-rules/key-manager.sh
+++ b/docker/safety-rules/key-manager.sh
@@ -3,10 +3,11 @@
 # SPDX-License-Identifier: Apache-2.0
 set -e
 
+# Parse parameters and execute config builder
 declare -a params
-if [ -n "${CFG_BASE_CONFIG}" ]; then # Path to base config
-    echo "${CFG_BASE_CONFIG}" > /opt/libra/etc/base.config.toml
-    params+="--template /opt/libra/etc/base.config.toml "
+if [ -n "${KEY_MANAGER_CONFIG}" ]; then # Path to key manager config
+    echo "${KEY_MANAGER_CONFIG}" > /opt/libra/etc/key_manager.config.toml
+    params+="--template /opt/libra/etc/key_manager.config.toml "
 fi
 if [ -n "${JSON_RPC_ENDPOINT}" ]; then
     params+="--json-rpc-endpoint ${JSON_RPC_ENDPOINT} "
@@ -35,4 +36,15 @@ fi
     --output-dir /opt/libra/etc/ \
     ${params[@]}
 
-exec /opt/libra/bin/libra-key-manager /opt/libra/etc/key_manager.config.toml
+# Parse logger environment variables and execute the key manager
+declare logger
+if [ -n "${STRUCT_LOGGER}" ]; then
+    if [ -n "${STRUCT_LOGGER_LOCATION}" ]; then
+      logger="env ${STRUCT_LOGGER}=${STRUCT_LOGGER_LOCATION}"
+    else
+      echo "STRUCT_LOGGER has been set but STRUCT_LOGGER_LOCATION is not set!"
+      exit 1
+    fi
+fi
+
+exec ${logger} /opt/libra/bin/libra-key-manager /opt/libra/etc/key_manager.config.toml

--- a/docker/safety-rules/run-key-manager.sh
+++ b/docker/safety-rules/run-key-manager.sh
@@ -3,20 +3,29 @@
 # SPDX-License-Identifier: Apache-2.0
 set -e
 
-# Example Usage (arguments that are not specified will be assigned defaults):
-# ./run-key-manager.sh <IMAGE> <JSON_RPC_ENDPOINT> <ROTATION_PERIOD_SECS> <VALIDATOR_ACCOUNT> <VAULT_HOST> <VAULT_TOKEN>
+# Example Usage:
+# ./run-key-manager.sh <IMAGE> <JSON_RPC_ENDPOINT> <ROTATION_PERIOD_SECS> <STRUCT_LOGGER> <STRUCT_LOGGER_LOCATION> <VAULT_HOST> <VAULT_TOKEN>
+#
+# Note:
+# (i) if arguments are not specified they will be assigned defaults.
+# (ii) structured logger (STRUCT_LOGGER) must be one of STRUCT_LOG_FILE or STRUCT_LOG_UDP_ADDR, with
+#      STRUCT_LOGGER_LOCATION set according to the chosen logger.
 
 IMAGE="${1:-libra_safety_rules:latest}"
 JSON_RPC_ENDPOINT="${2:-http://127.0.0.1:8080}"
 ROTATION_PERIOD_SECS="${3:-3600}"
-VAULT_HOST="${4:-http://127.0.0.1:8200}"
-VAULT_TOKEN="${5:-root_token}"
+STRUCT_LOGGER="${4:-STRUCT_LOG_UDP_ADDR}"
+STRUCT_LOGGER_LOCATION="${5:-127.0.0.1:5044}"
+VAULT_HOST="${6:-http://127.0.0.1:8200}"
+VAULT_TOKEN="${7:-root_token}"
 
 docker network create --subnet 172.18.0.0/24 testnet || true
 
 docker run \
     -e JSON_RPC_ENDPOINT="$JSON_RPC_ENDPOINT" \
     -e ROTATION_PERIOD_SECS="$ROTATION_PERIOD_SECS" \
+    -e STRUCT_LOGGER="$STRUCT_LOGGER" \
+    -e STRUCT_LOGGER_LOCATION="$STRUCT_LOGGER_LOCATION" \
     -e VAULT_HOST="$VAULT_HOST" \
     -e VAULT_TOKEN="$VAULT_TOKEN" \
     --ip 172.18.0.3 \

--- a/secure/key-manager/src/lib.rs
+++ b/secure/key-manager/src/lib.rs
@@ -137,7 +137,14 @@ where
                         Error::LivenessError(last_value, current_value).to_string()
                     );
                 }
-                Err(e) => return Err(e), // Unexpected error that we can't handle -- throw!
+                Err(e) => {
+                    // Unexpected error that we can't handle -- throw!
+                    error!(
+                        "Encountered error, cannot continue to operate: {}",
+                        e.to_string()
+                    );
+                    return Err(e);
+                }
             };
 
             info!("Going to sleep for {} seconds.", self.sleep_period_secs);

--- a/secure/key-manager/src/main.rs
+++ b/secure/key-manager/src/main.rs
@@ -36,6 +36,8 @@ fn main() {
         .is_async(key_manager_config.logger.is_async)
         .level(key_manager_config.logger.level)
         .init();
+    libra_logger::init_struct_log_from_env().expect("Failed to initialize structured logging");
+
     MetricsPusher::new(COUNTERS.clone()).start();
 
     create_and_execute_key_manager(key_manager_config).unwrap_or_else(|e| {


### PR DESCRIPTION
## Motivation

This small PR updates the Key Manager to support structured logging to a configurable logging endpoint.

Note: in this PR, we also:
(i) add an error log to the Key Manager when it fails, so that this failure is now obvious in the logs;
(ii) fix the template config argument for the Key Manager script.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?

Yes.

## Test Plan

- To test logging to file, I simply verified that the logs we were written as expected to the specified location.

- To test udp logging, I spawned a local instance of logstash, and pointed the key manager to it. I then verified that the logs generated by the key manager were forwarded to the logstash instance. Here's an example of the key manager starting up and failing:

{"location":"secure/key-manager/src/lib.rs:133","host":"127.0.0.1","log":"Checking the status of the keys.","pattern":"Checking the status of the keys.","@version":"1","timestamp":"2020-06-09 23:53:49","@timestamp":"2020-06-09T23:53:49.487Z","module":"libra_key_manager"}
{"location":"secure/key-manager/src/lib.rs:131","host":"127.0.0.1","log":"The key manager has been created and is starting execution.","pattern":"The key manager has been created and is starting execution.","@version":"1","timestamp":"2020-06-09 23:53:49","@timestamp":"2020-06-09T23:53:49.487Z","module":"libra_key_manager"}
{"location":"secure/key-manager/src/main.rs:71","host":"127.0.0.1","log":"Creating a libra interface that talks to the JSON RPC endpoint at: \"http://127.0.0.1:8080\".","pattern":"Creating a libra interface that talks to the JSON RPC endpoint at: {:?}.","data":{"json_rpc_endpoint":"\"http://127.0.0.1:8080\""},"@version":"1","timestamp":"2020-06-09 23:53:49","@timestamp":"2020-06-09T23:53:49.472Z","module":"libra_key_manager"}
{"location":"secure/push-metrics/src/pusher.rs:48","host":"127.0.0.1","log":"PUSH_METRICS_ENDPOINT env var is not set. Skipping sending metrics.","pattern":"PUSH_METRICS_ENDPOINT env var is not set. Skipping sending metrics.","@version":"1","timestamp":"2020-06-09 23:53:49","@timestamp":"2020-06-09T23:53:49.472Z","module":"libra_secure_push_metrics::pusher"}
~                                                                                                                             

## Related PRs

None.