### PR TITLE
[Move] transaction builder codegen in python (and Rust)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4667,6 +4667,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde-generate"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "maplit 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.111 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde-reflection 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_bytes 0.11.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_yaml 0.8.13 (registry+https://github.com/rust-lang/crates.io-index)",
+ "structopt 0.3.14 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "serde-name"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5574,6 +5587,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "transaction-builder-generator"
+version = "0.1.0"
+dependencies = [
+ "generate-format 0.1.0",
+ "libra-types 0.1.0",
+ "libra-workspace-hack 0.1.0",
+ "move-core-types 0.1.0",
+ "serde-generate 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde-reflection 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_yaml 0.8.13 (registry+https://github.com/rust-lang/crates.io-index)",
+ "structopt 0.3.14 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tempfile 3.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "textwrap 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "transaction-builder 0.1.0",
+]
+
+[[package]]
 name = "try-lock"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6445,6 +6475,7 @@ dependencies = [
 "checksum semver 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)" = "1d7eb9ef2c18661902cc47e535f9bc51b78acd254da71d375c2f6720d9a40403"
 "checksum semver-parser 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "388a1df253eca08550bef6c72392cfe7c30914bf41df5269b68cbd6ff8f570a3"
 "checksum serde 1.0.111 (registry+https://github.com/rust-lang/crates.io-index)" = "c9124df5b40cbd380080b2cc6ab894c040a3070d995f5c9dc77e18c34a8ae37d"
+"checksum serde-generate 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "cd00f25f89ad8f3331224ce569b3423cdaa04402292b9ea8fc24cd9c8233676a"
 "checksum serde-name 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "92bb32dbe1df50291d7d00b5e573acb2c70b783baf3d1bce2d19c86be11c709e"
 "checksum serde-reflection 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "5820d2a74b1f0694d959f48660bc52fa922239d5c2f6dcc17261c5307967b9e5"
 "checksum serde-value 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)" = "5a65a7291a8a568adcae4c10a677ebcedbc6c9cec91c054dee2ce40b0e3290eb"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -81,6 +81,7 @@ members = [
     "language/tools/utils",
     "language/tools/vm-genesis",
     "language/transaction-builder",
+    "language/transaction-builder-generator",
     "language/vm",
     "language/vm/serializer-tests",
     "libra-node",

--- a/language/transaction-builder-generator/Cargo.toml
+++ b/language/transaction-builder-generator/Cargo.toml
@@ -1,0 +1,34 @@
+[package]
+name = "transaction-builder-generator"
+version = "0.1.0"
+authors = ["Libra Association <opensource@libra.org>"]
+description = "Libra transaction-builder"
+repository = "https://github.com/libra/libra"
+homepage = "https://libra.org"
+license = "Apache-2.0"
+edition = "2018"
+
+[dependencies]
+structopt = "0.3.12"
+textwrap = "0.11"
+
+libra-types = { path = "../../types", version = "0.1.0" }
+libra-workspace-hack = { path = "../../common/workspace-hack", version = "0.1.0" }
+move-core-types = { path = "../move-core/types", version = "0.1.0" }
+transaction-builder = { path = "../transaction-builder", version = "0.1.0" }
+
+[dev-dependencies]
+serde_yaml = "0.8"
+serde-generate = "0.2"
+serde-reflection = "0.3"
+tempfile = "3.1"
+
+generate-format = { path = "../../testsuite/generate-format", version = "0.1.0" }
+
+[features]
+default = []
+
+[[bin]]
+name = "serdegen"
+path = "src/generate.rs"
+test = false

--- a/language/transaction-builder-generator/src/generate.rs
+++ b/language/transaction-builder-generator/src/generate.rs
@@ -1,0 +1,39 @@
+// Copyright (c) The Libra Core Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+//! # Code generator for Move script builders
+//!
+//! '''bash
+//! cargo run -p transaction-builder-generator -- --help
+//! '''
+
+use structopt::{clap::arg_enum, StructOpt};
+use transaction_builder_generator::python3;
+
+arg_enum! {
+#[derive(Debug, StructOpt)]
+enum Language {
+    Python3,
+}
+}
+
+#[derive(Debug, StructOpt)]
+#[structopt(
+    name = "Transaction builder generator",
+    about = "Generate code for Move script builders"
+)]
+struct Options {
+    #[structopt(long, possible_values = &Language::variants(), case_insensitive = true, default_value = "Python3")]
+    language: Language,
+}
+
+fn main() {
+    let options = Options::from_args();
+    let abis = transaction_builder::get_stdlib_script_abis();
+
+    let mut out = std::io::stdout();
+
+    match options.language {
+        Language::Python3 => python3::output(&mut out, &abis).unwrap(),
+    }
+}

--- a/language/transaction-builder-generator/src/generate.rs
+++ b/language/transaction-builder-generator/src/generate.rs
@@ -8,12 +8,13 @@
 //! '''
 
 use structopt::{clap::arg_enum, StructOpt};
-use transaction_builder_generator::python3;
+use transaction_builder_generator::{python3, rust};
 
 arg_enum! {
 #[derive(Debug, StructOpt)]
 enum Language {
     Python3,
+    Rust,
 }
 }
 
@@ -35,5 +36,6 @@ fn main() {
 
     match options.language {
         Language::Python3 => python3::output(&mut out, &abis).unwrap(),
+        Language::Rust => rust::output(&mut out, &abis).unwrap(),
     }
 }

--- a/language/transaction-builder-generator/src/lib.rs
+++ b/language/transaction-builder-generator/src/lib.rs
@@ -5,6 +5,8 @@ use move_core_types::language_storage::TypeTag;
 
 /// Support for code-generation in Python 3
 pub mod python3;
+/// Support for code-generation in Rust
+pub mod rust;
 
 /// Useful error message.
 fn type_not_allowed(type_tag: &TypeTag) -> ! {

--- a/language/transaction-builder-generator/src/lib.rs
+++ b/language/transaction-builder-generator/src/lib.rs
@@ -1,0 +1,15 @@
+// Copyright (c) The Libra Core Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+use move_core_types::language_storage::TypeTag;
+
+/// Support for code-generation in Python 3
+pub mod python3;
+
+/// Useful error message.
+fn type_not_allowed(type_tag: &TypeTag) -> ! {
+    panic!(
+        "Transaction scripts cannot take arguments of type {}.",
+        type_tag
+    );
+}

--- a/language/transaction-builder-generator/src/python3.rs
+++ b/language/transaction-builder-generator/src/python3.rs
@@ -1,0 +1,140 @@
+// Copyright (c) The Libra Core Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::type_not_allowed;
+use libra_types::transaction::{ArgumentABI, ScriptABI, TypeArgumentABI};
+use move_core_types::language_storage::TypeTag;
+
+use std::io::{Result, Write};
+
+pub fn output(out: &mut dyn Write, abis: &[ScriptABI]) -> Result<()> {
+    output_preamble(out)?;
+    for abi in abis {
+        output_builder(out, abi)?;
+    }
+    Ok(())
+}
+
+fn output_preamble(out: &mut dyn Write) -> Result<()> {
+    writeln!(
+        out,
+        r#"# pyre-ignore-all-errors
+import libra_types as libra
+import typing
+import serde_types as st"#
+    )
+}
+
+fn output_builder(out: &mut dyn Write, abi: &ScriptABI) -> Result<()> {
+    writeln!(
+        out,
+        "\ndef encode_{}_script({}) -> libra.Script:",
+        abi.name(),
+        [
+            quote_type_parameters(abi.ty_args()),
+            quote_parameters(abi.args()),
+        ]
+        .concat()
+        .join(", ")
+    )?;
+    writeln!(out, "{}", quote_doc(abi.doc()))?;
+    writeln!(
+        out,
+        r#"    return libra.Script(
+        code={},
+        ty_args=[{}],
+        args=[{}],
+    )"#,
+        quote_code(abi.code()),
+        quote_type_arguments(abi.ty_args()),
+        quote_arguments(abi.args()),
+    )?;
+    Ok(())
+}
+
+fn quote_doc(doc: &str) -> String {
+    let s: Vec<_> = doc.splitn(2, |c| c == '.').collect();
+    if s.len() <= 1 || s[1].is_empty() {
+        format!("    \"\"\"{}.\"\"\"", s[0])
+    } else {
+        format!(
+            r#"    """{}.
+
+{}    """"#,
+            s[0],
+            textwrap::indent(&textwrap::fill(&textwrap::dedent(s[1]), 86), "    "),
+        )
+    }
+}
+
+fn quote_type_parameters(ty_args: &[TypeArgumentABI]) -> Vec<String> {
+    ty_args
+        .iter()
+        .map(|ty_arg| format!("{}: libra.TypeTag", ty_arg.name()))
+        .collect()
+}
+
+fn quote_parameters(args: &[ArgumentABI]) -> Vec<String> {
+    args.iter()
+        .map(|arg| format!("{}: {}", arg.name(), quote_type(arg.type_tag())))
+        .collect()
+}
+
+fn quote_code(code: &[u8]) -> String {
+    format!(
+        "bytes([{}])",
+        code.iter()
+            .map(|x| format!("{}", x))
+            .collect::<Vec<_>>()
+            .join(", ")
+    )
+}
+
+fn quote_type_arguments(ty_args: &[TypeArgumentABI]) -> String {
+    ty_args
+        .iter()
+        .map(|ty_arg| ty_arg.name().to_string())
+        .collect::<Vec<_>>()
+        .join(", ")
+}
+
+fn quote_arguments(args: &[ArgumentABI]) -> String {
+    args.iter()
+        .map(|arg| make_transaction_argument(arg.type_tag(), arg.name()))
+        .collect::<Vec<_>>()
+        .join(", ")
+}
+
+fn quote_type(type_tag: &TypeTag) -> String {
+    use TypeTag::*;
+    match type_tag {
+        Bool => "st.bool".into(),
+        U8 => "st.uint8".into(),
+        U64 => "st.uint64".into(),
+        U128 => "st.uint128".into(),
+        Address => "libra.AccountAddress".into(),
+        Vector(type_tag) => match type_tag.as_ref() {
+            U8 => "bytes".into(),
+            _ => type_not_allowed(type_tag),
+        },
+
+        Struct(_) | Signer => type_not_allowed(type_tag),
+    }
+}
+
+fn make_transaction_argument(type_tag: &TypeTag, name: &str) -> String {
+    use TypeTag::*;
+    match type_tag {
+        Bool => format!("libra.TransactionArgument.Bool({})", name),
+        U8 => format!("libra.TransactionArgument.U8({})", name),
+        U64 => format!("libra.TransactionArgument.U64({})", name),
+        U128 => format!("libra.TransactionArgument.U128({})", name),
+        Address => format!("libra.TransactionArgument.Address({})", name),
+        Vector(type_tag) => match type_tag.as_ref() {
+            U8 => format!("libra.TransactionArgument.U8Vector({})", name),
+            _ => type_not_allowed(type_tag),
+        },
+
+        Struct(_) | Signer => type_not_allowed(type_tag),
+    }
+}

--- a/language/transaction-builder-generator/src/rust.rs
+++ b/language/transaction-builder-generator/src/rust.rs
@@ -1,0 +1,125 @@
+// Copyright (c) The Libra Core Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::type_not_allowed;
+use libra_types::transaction::{ArgumentABI, ScriptABI, TypeArgumentABI};
+use move_core_types::language_storage::TypeTag;
+
+use std::io::{Result, Write};
+
+pub fn output(out: &mut dyn Write, abis: &[ScriptABI]) -> Result<()> {
+    output_preamble(out)?;
+    for abi in abis {
+        output_builder(out, abi)?;
+    }
+    Ok(())
+}
+
+fn output_preamble(out: &mut dyn Write) -> Result<()> {
+    writeln!(out, "use libra_types as libra;",)
+}
+
+fn output_builder(out: &mut dyn Write, abi: &ScriptABI) -> Result<()> {
+    write!(out, "\n{}", quote_doc(abi.doc()))?;
+    writeln!(
+        out,
+        "pub fn encode_{}_script({}) -> libra::Script {{",
+        abi.name(),
+        [
+            quote_type_parameters(abi.ty_args()),
+            quote_parameters(abi.args()),
+        ]
+        .concat()
+        .join(", ")
+    )?;
+    writeln!(
+        out,
+        r#"    libra::Script {{
+        code: {},
+        ty_args: vec![{}],
+        args: vec![{}],
+    }}"#,
+        quote_code(abi.code()),
+        quote_type_arguments(abi.ty_args()),
+        quote_arguments(abi.args()),
+    )?;
+    writeln!(out, "}}")?;
+    Ok(())
+}
+
+fn quote_doc(doc: &str) -> String {
+    let text = textwrap::fill(doc, 86);
+    textwrap::indent(&text, "/// ")
+}
+
+fn quote_type_parameters(ty_args: &[TypeArgumentABI]) -> Vec<String> {
+    ty_args
+        .iter()
+        .map(|ty_arg| format!("{}: libra::TypeTag", ty_arg.name()))
+        .collect()
+}
+
+fn quote_parameters(args: &[ArgumentABI]) -> Vec<String> {
+    args.iter()
+        .map(|arg| format!("{}: {}", arg.name(), quote_type(arg.type_tag())))
+        .collect()
+}
+
+fn quote_code(code: &[u8]) -> String {
+    format!(
+        "vec![{}]",
+        code.iter()
+            .map(|x| format!("{}", x))
+            .collect::<Vec<_>>()
+            .join(", ")
+    )
+}
+
+fn quote_type_arguments(ty_args: &[TypeArgumentABI]) -> String {
+    ty_args
+        .iter()
+        .map(|ty_arg| ty_arg.name().to_string())
+        .collect::<Vec<_>>()
+        .join(", ")
+}
+
+fn quote_arguments(args: &[ArgumentABI]) -> String {
+    args.iter()
+        .map(|arg| make_transaction_argument(arg.type_tag(), arg.name()))
+        .collect::<Vec<_>>()
+        .join(", ")
+}
+
+fn quote_type(type_tag: &TypeTag) -> String {
+    use TypeTag::*;
+    match type_tag {
+        Bool => "bool".into(),
+        U8 => "u8".into(),
+        U64 => "u64".into(),
+        U128 => "u128".into(),
+        Address => "libra::AccountAddress".into(),
+        Vector(type_tag) => match type_tag.as_ref() {
+            U8 => "Vec<u8>".into(),
+            _ => type_not_allowed(type_tag),
+        },
+
+        Struct(_) | Signer => type_not_allowed(type_tag),
+    }
+}
+
+fn make_transaction_argument(type_tag: &TypeTag, name: &str) -> String {
+    use TypeTag::*;
+    match type_tag {
+        Bool => format!("libra::TransactionArgument::Bool({})", name),
+        U8 => format!("libra::TransactionArgument::U8({})", name),
+        U64 => format!("libra::TransactionArgument::U64({})", name),
+        U128 => format!("libra::TransactionArgument::U128({})", name),
+        Address => format!("libra::TransactionArgument::Address({})", name),
+        Vector(type_tag) => match type_tag.as_ref() {
+            U8 => format!("libra::TransactionArgument::U8Vector({})", name),
+            _ => type_not_allowed(type_tag),
+        },
+
+        Struct(_) | Signer => type_not_allowed(type_tag),
+    }
+}

--- a/language/transaction-builder-generator/tests/generation.rs
+++ b/language/transaction-builder-generator/tests/generation.rs
@@ -1,0 +1,51 @@
+// Copyright (c) The Libra Core Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+use generate_format::Corpus;
+use serde_generate as serdegen;
+use serde_generate::SourceInstaller;
+use serde_reflection::Registry;
+use std::process::Command;
+use tempfile::tempdir;
+use transaction_builder::get_stdlib_script_abis;
+use transaction_builder_generator as buildgen;
+
+fn get_libra_registry() -> Registry {
+    let path =
+        "../../testsuite/generate-format/".to_string() + Corpus::Libra.output_file().unwrap();
+    let content = std::fs::read_to_string(path).unwrap();
+    serde_yaml::from_str::<Registry>(content.as_str()).unwrap()
+}
+
+#[test]
+#[ignore]
+fn test_that_python_code_parses() {
+    let registry = get_libra_registry();
+    let abis = get_stdlib_script_abis();
+    let dir = tempdir().unwrap();
+
+    let installer = serdegen::python3::Installer::new(dir.path().to_path_buf());
+    installer.install_module("libra_types", &registry).unwrap();
+    installer.install_serde_runtime().unwrap();
+
+    let dir_path = dir.path().join("libra_builders");
+    std::fs::create_dir_all(dir_path.clone()).unwrap();
+    let source_path = dir_path.join("__init__.py");
+
+    let mut source = std::fs::File::create(&source_path).unwrap();
+    buildgen::python3::output(&mut source, &abis).unwrap();
+
+    let python_path = format!(
+        "{}:{}",
+        std::env::var("PYTHONPATH").unwrap_or_default(),
+        dir.path().to_string_lossy(),
+    );
+    let output = Command::new("python3")
+        .arg("-c")
+        .arg("import serde_types; import libra_types; import libra_builders")
+        .env("PYTHONPATH", python_path)
+        .output()
+        .unwrap();
+    assert_eq!(String::new(), String::from_utf8_lossy(&output.stderr));
+    assert!(output.status.success());
+}

--- a/language/transaction-builder/src/lib.rs
+++ b/language/transaction-builder/src/lib.rs
@@ -145,10 +145,10 @@ register_all_txn_scripts! {
     builder: encode_add_recovery_rotation_capability,
     type_args: [],
     args: [recovery_address: Address],
-    doc: "Add the `KeyRotationCapability` for `to_recover_account` to the `RecoveryAddress`\
-          resource under `recovery_address`. Aborts if `to_recovery_account` and\
-          `to_recovery_address belong to different VASPs, if `recovery_address` does not have a\
-          `RecoveryAddress` resource, or if `to_recover_account` has already extracted its\
+    doc: "Add the `KeyRotationCapability` for `to_recover_account` to the `RecoveryAddress` \
+          resource under `recovery_address`. Aborts if `to_recovery_account` and \
+          `to_recovery_address belong to different VASPs, if `recovery_address` does not have a \
+          `RecoveryAddress` resource, or if `to_recover_account` has already extracted its \
           `KeyRotationCapability`."
 }
 
@@ -157,8 +157,8 @@ register_all_txn_scripts! {
     builder: encode_add_validator_script,
     type_args: [],
     args: [new_validator: Address],
-    doc: "Encode a program adding `new_validator` to the pending validator set. Fails if the\
-          `new_validator` address is already in the validator set, already in the pending validator set,\
+    doc: "Encode a program adding `new_validator` to the pending validator set. Fails if the \
+          `new_validator` address is already in the validator set, already in the pending validator set, \
           or does not have a `ValidatorConfig` resource stored at the address"
 }
 
@@ -167,8 +167,8 @@ register_all_txn_scripts! {
     builder: encode_burn_script,
     type_args: [type_],
     args: [nonce: U64, preburn_address: Address],
-    doc: "Permanently destroy the coins stored in the oldest burn request under the `Preburn`\
-          resource stored at `preburn_address`. This will only succeed if the sender has a\
+    doc: "Permanently destroy the coins stored in the oldest burn request under the `Preburn` \
+          resource stored at `preburn_address`. This will only succeed if the sender has a \
           `MintCapability` stored under their account and `preburn_address` has a pending burn request"
 }
 
@@ -177,7 +177,7 @@ register_all_txn_scripts! {
     builder: encode_burn_txn_fees_script,
     type_args: [currency],
     args: [],
-    doc: "Burn transaction fees that have been collected in the given `currency`,\
+    doc: "Burn transaction fees that have been collected in the given `currency`, \
           and relinquish to the association. The currency must be non-synthetic."
 }
 
@@ -186,7 +186,7 @@ register_all_txn_scripts! {
     builder: encode_cancel_burn_script,
     type_args: [type_],
     args: [preburn_address: Address],
-    doc: "Cancel the oldest burn request from `preburn_address` and return the funds to\
+    doc: "Cancel the oldest burn request from `preburn_address` and return the funds to \
           `preburn_address`.  Fails if the sender does not have a published `MintCapability`."
 }
 
@@ -195,10 +195,10 @@ register_all_txn_scripts! {
     builder: encode_create_recovery_address,
     type_args: [],
     args: [],
-    doc: "Extract the `KeyRotationCapability` for `recovery_account` and publish it in a\
-          `RecoveryAddress` resource under  `recovery_account`. Aborts if `recovery_account` has\
-           delegated its `KeyRotationCapability`, already has a`RecoveryAddress` resource, or is\
-           not a VASP. Cancel the oldest burn request from `preburn_address` and return the funds\
+    doc: "Extract the `KeyRotationCapability` for `recovery_account` and publish it in a \
+          `RecoveryAddress` resource under  `recovery_account`. Aborts if `recovery_account` has \
+           delegated its `KeyRotationCapability`, already has a`RecoveryAddress` resource, or is \
+           not a VASP. Cancel the oldest burn request from `preburn_address` and return the funds \
            to `preburn_address`.  Fails if the sender does not have a published `MintCapability`."
 }
 
@@ -207,11 +207,11 @@ register_all_txn_scripts! {
     builder: encode_transfer_with_metadata_script,
     type_args: [coin_type],
     args: [recipient_address: Address, amount: U64, metadata: Bytes, metadata_signature: Bytes],
-    doc: "Encode a program transferring `amount` coins to `recipient_address` with (optional)\
-          associated metadata `metadata` and (optional) `signature` on the metadata, amount, and\
-          sender address. The `metadata` and `signature` parameters are only required if\
-          `amount` >= 1000 LBR and the sender and recipient of the funds are two distinct VASPs.\
-          Fails if there is no account at the recipient address or if the sender's balance is lower\
+    doc: "Encode a program transferring `amount` coins to `recipient_address` with (optional) \
+          associated metadata `metadata` and (optional) `signature` on the metadata, amount, and \
+          sender address. The `metadata` and `signature` parameters are only required if \
+          `amount` >= 1000 LBR and the sender and recipient of the funds are two distinct VASPs. \
+          Fails if there is no account at the recipient address or if the sender's balance is lower \
           than `amount`"
 }
 
@@ -220,7 +220,7 @@ register_all_txn_scripts! {
     builder: encode_preburn_script,
     type_args: [type_],
     args: [amount: U64],
-    doc: "Preburn `amount` coins from the sender's account. This will only succeed if the sender\
+    doc: "Preburn `amount` coins from the sender's account. This will only succeed if the sender \
           already has a published `Preburn` resource."
 }
 
@@ -229,10 +229,10 @@ register_all_txn_scripts! {
     builder: encode_publish_shared_ed25519_public_key_script,
     type_args: [],
     args: [public_key: Bytes],
-    doc: "(1) Rotate the authentication key of the sender to `public_key`\
-          (2) Publish a resource containing a 32-byte ed25519 public key and the rotation capability\
-          of the sender under the sender's address.\
-          Aborts if the sender already has a `SharedEd25519PublicKey` resource.\
+    doc: "(1) Rotate the authentication key of the sender to `public_key` \
+          (2) Publish a resource containing a 32-byte ed25519 public key and the rotation capability \
+          of the sender under the sender's address. \
+          Aborts if the sender already has a `SharedEd25519PublicKey` resource. \
           Aborts if the length of `new_public_key` is not 32."
 }
 
@@ -241,7 +241,7 @@ register_all_txn_scripts! {
     builder: encode_add_currency_to_account_script,
     type_args: [currency],
     args: [],
-    doc: "Add the currency identified by the type `currency` to the sending accounts.\
+    doc: "Add the currency identified by the type `currency` to the sending accounts. \
           Aborts if the account already holds a balance fo `currency` type."
 }
 
@@ -250,7 +250,7 @@ register_all_txn_scripts! {
     builder: encode_register_preburner_script,
     type_args: [type_],
     args: [],
-    doc: "Publish a newly created `Preburn` resource under the sender's account.\
+    doc: "Publish a newly created `Preburn` resource under the sender's account. \
           This will fail if the sender already has a published `Preburn` resource."
 }
 
@@ -265,8 +265,8 @@ register_all_txn_scripts! {
         fullnodes_network_identity_pubkey: Bytes,
         fullnodes_network_address: Bytes
     ],
-    doc: "Encode a program registering the sender as a candidate validator with the given key information.\
-         `network_identity_pubkey` should be a X25519 public key\
+    doc: "Encode a program registering the sender as a candidate validator with the given key information. \
+         `network_identity_pubkey` should be a X25519 public key \
          `consensus_pubkey` should be a Ed25519 public c=key."
 }
 
@@ -275,7 +275,7 @@ register_all_txn_scripts! {
     builder: encode_remove_validator_script,
     type_args: [],
     args: [to_remove: Address],
-    doc: "Encode a program adding `to_remove` to the set of pending validator removals. Fails if\
+    doc: "Encode a program adding `to_remove` to the set of pending validator removals. Fails if \
           the `to_remove` address is already in the validator set or already in the pending removals."
 }
 
@@ -308,7 +308,7 @@ register_all_txn_scripts! {
     builder: encode_rotate_authentication_key_script,
     type_args: [],
     args: [new_hashed_key: Bytes],
-    doc: "Encode a program that rotates the sender's authentication key to `new_key`. `new_key`\
+    doc: "Encode a program that rotates the sender's authentication key to `new_key`. `new_key` \
           should be a 256 bit sha3 hash of an ed25519 public key."
 }
 
@@ -317,8 +317,8 @@ register_all_txn_scripts! {
     builder: encode_rotate_authentication_key_with_recovery_address_script,
     type_args: [],
     args: [recovery_address: Address, to_recover: Address, new_key: Bytes],
-    doc: "Rotate the authentication key of `to_recover` to `new_key`. Can be invoked by either\
-          `recovery_address` or `to_recover`. Aborts if `recovery_address` does not have the\
+    doc: "Rotate the authentication key of `to_recover` to `new_key`. Can be invoked by either \
+          `recovery_address` or `to_recover`. Aborts if `recovery_address` does not have the \
           `KeyRotationCapability` for `to_recover`."
 }
 
@@ -327,11 +327,11 @@ register_all_txn_scripts! {
     builder: encode_rotate_shared_ed25519_public_key_script,
     type_args: [],
     args: [new_public_key: Bytes],
-    doc: "(1) rotate the public key stored in the sender's `SharedEd25519PublicKey` resource to\
-          `new_public_key`\
-          (2) rotate the authentication key using the capability stored in the sender's\
-          `SharedEd25519PublicKey` to a new value derived from `new_public_key`\
-          Aborts if the sender does not have a `SharedEd25519PublicKey` resource.\
+    doc: "(1) rotate the public key stored in the sender's `SharedEd25519PublicKey` resource to \
+          `new_public_key` \
+          (2) rotate the authentication key using the capability stored in the sender's \
+          `SharedEd25519PublicKey` to a new value derived from `new_public_key` \
+          Aborts if the sender does not have a `SharedEd25519PublicKey` resource. \
           Aborts if the length of `new_public_key` is not 32."
 }
 
@@ -376,7 +376,7 @@ register_all_txn_scripts! {
     builder: encode_mint_lbr,
     type_args: [],
     args: [amount_lbr: U64],
-    doc: "Mints `amount_lbr` LBR from the sending account's constituent coins and deposits the\
+    doc: "Mints `amount_lbr` LBR from the sending account's constituent coins and deposits the \
           resulting LBR into the sending account."
 }
 
@@ -385,14 +385,13 @@ register_all_txn_scripts! {
     builder: encode_unmint_lbr,
     type_args: [],
     args: [amount_lbr: U64],
-    doc: "Unmints `amount_lbr` LBR from the sending account into the constituent coins and deposits\
+    doc: "Unmints `amount_lbr` LBR from the sending account into the constituent coins and deposits \
           the resulting coins into the sending account."
 }
 
 //...........................................................................
 //  Association-related scripts
 //...........................................................................
-
 
 {
     script: UpdateMintingAbility,
@@ -411,9 +410,9 @@ register_all_txn_scripts! {
     builder: encode_create_parent_vasp_account,
     type_args: [currency],
     args: [address: Address, auth_key_prefix: Bytes, human_name: Bytes, base_url: Bytes, compliance_public_key: Bytes, add_all_currencies: Bool],
-    doc: "Create an account with the ParentVASP role at `address` with authentication key\
-          `auth_key_prefix` | `new_account_address` and a 0 balance of type `currency`. If\
-          `add_all_currencies` is true, 0 balances for all available currencies in the system will\
+    doc: "Create an account with the ParentVASP role at `address` with authentication key \
+          `auth_key_prefix` | `new_account_address` and a 0 balance of type `currency`. If \
+          `add_all_currencies` is true, 0 balances for all available currencies in the system will \
           also be added. This can only be invoked by an Association account."
 }
 
@@ -422,10 +421,10 @@ register_all_txn_scripts! {
     builder: encode_create_child_vasp_account,
     type_args: [currency],
     args: [address: Address, auth_key_prefix: Bytes, add_all_currencies: Bool, initial_balance: U64],
-    doc: "Create an account with the ChildVASP role at `address` with authentication key\
-          `auth_key_prefix` | `new_account_address` and `initial_balance` of type `currency`\
-          transferred from the sender. If `add_all_currencies` is true, 0 balances for all\
-          available currencies in the system will also be added to the account. This account will\
+    doc: "Create an account with the ChildVASP role at `address` with authentication key \
+          `auth_key_prefix` | `new_account_address` and `initial_balance` of type `currency` \
+          transferred from the sender. If `add_all_currencies` is true, 0 balances for all \
+          available currencies in the system will also be added to the account. This account will \
           be a child of the transaction sender, which must be a ParentVASP."
 }
 
@@ -438,8 +437,8 @@ register_all_txn_scripts! {
     builder: encode_tiered_mint,
     type_args: [coin_type],
     args: [nonce: U64, designated_dealer_address: Address, mint_amount: U64, tier_index: U64],
-    doc: "Mints 'mint_amount' to 'designated_dealer_address' for 'tier_index' tier.\
-          Max valid tier index is 3 since there are max 4 tiers per DD.
+    doc: "Mints 'mint_amount' to 'designated_dealer_address' for 'tier_index' tier. \
+          Max valid tier index is 3 since there are max 4 tiers per DD. \
           Sender should be treasury compliance account and receiver authorized DD"
 }
 
@@ -472,7 +471,7 @@ register_all_txn_scripts! {
     builder: encode_rotate_authentication_key_script_with_nonce,
     type_args: [],
     args: [nonce: U64, new_hashed_key: Bytes],
-    doc: "Encode a program that rotates the sender's authentication key to `new_key`. `new_key`\
+    doc: "Encode a program that rotates the sender's authentication key to `new_key`. `new_key` \
           should be a 256 bit sha3 hash of an ed25519 public key. This script also takes nonce"
 }
 

--- a/types/src/transaction/script.rs
+++ b/types/src/transaction/script.rs
@@ -106,7 +106,7 @@ impl ScriptABI {
     }
 
     pub fn doc(&self) -> &str {
-        &self.name
+        &self.doc
     }
 
     pub fn code(&self) -> &[u8] {

--- a/x.toml
+++ b/x.toml
@@ -56,6 +56,7 @@ members = [
     "language/ir-testsuite",
     "language/move-lang/functional-tests",
     "language/move-prover/test-utils",
+    "language/transaction-builder-generator",
     "language/tools/test-generation",
     "language/tools/utils",
     "language/vm/serializer-tests",


### PR DESCRIPTION
## Motivation

* Generate some python code equivalent to what is currently generated by Rust macros in the `transaction-builder` crate.

* For testing purposes, I also generate Rust transaction builders from scratch.

Note that the ABI described by macros in `language/transaction-builder` seems currently out of date compared to the Move code.

## Test Plan

```
# Spit out the python code
cargo run -p transaction-builder-generator

# Verify that the generated Rust code compiles
cargo test -p transaction-builder-generator

# Run test on the python codegen (not supported by CI)
cargo test -p transaction-builder-generator -- --ignored 
```

## Related PRs

#4367