### PR TITLE
[secure-storage] Support HTTPS proxy for Github backend

### DIFF
--- a/secure/storage/github/src/lib.rs
+++ b/secure/storage/github/src/lib.rs
@@ -5,6 +5,7 @@
 
 use serde::{Deserialize, Serialize};
 use serde_json::json;
+use std::env;
 use thiserror::Error;
 
 /// Request timeout for github operations
@@ -173,7 +174,15 @@ impl Client {
             .set("Authorization", &format!("token {}", self.token))
             .set(ACCEPT_HEADER, ACCEPT_VALUE)
             .timeout_connect(TIMEOUT);
-        request
+        match env::var("https_proxy") {
+            Ok(proxy) => request
+                .set_proxy(
+                    ureq::Proxy::new(proxy)
+                        .expect("Unable to parse https_proxy environment variable"),
+                )
+                .build(),
+            Err(_e) => request,
+        }
     }
 
     /// Get can read files or directories, this makes it easier to use


### PR DESCRIPTION
## Motivation

If the `https_proxy` environment variable is set, use it with ureq for
Github requests.

## Test Plan

 Ran upload without `https_proxy` set, failed as before. Set
`https_proxy`, started working.