### PR TITLE
[move-prover] Added inferred invariant about proxy references

### DIFF
--- a/language/move-prover/src/bytecode_translator.rs
+++ b/language/move-prover/src/bytecode_translator.rs
@@ -834,6 +834,17 @@ impl<'env> ModuleTranslator<'env> {
                 self.writer.unindent();
                 emitln!(self.writer, "L{}:", label.as_usize());
                 emitln!(self.writer, "assume !$abort_flag;");
+                for idx in 0..func_target.get_local_count() {
+                    if let Some(ref_proxy_idx) = func_target.get_ref_proxy_index(idx) {
+                        let ref_proxy_var_name = str_local(*ref_proxy_idx);
+                        let proxy_idx = func_target.get_proxy_index(idx).unwrap();
+                        emitln!(self.writer,
+                            "assume l#$Reference({}) == $Local({}) && p#$Reference({}) == $EmptyPath;",
+                            ref_proxy_var_name,
+                            proxy_idx,
+                            ref_proxy_var_name);
+                    }
+                }
                 self.writer.indent();
             }
             Jump(_, target) => emitln!(self.writer, "goto L{};", target.as_usize()),


### PR DESCRIPTION
## Motivation

@kkmc attempt to verify reverse exposed yet another issue with loop targets, in addition to the problem discovered by @junkil-park with $abort_flag.  Here is a summary of the issue.

The memory model encoding of a Move program treats an input reference parameter as a value parameter whose updated value is returned as an extra output parameter.  While the function is executing, a proxy local reference variable in the Boogie translation of the function is used to represent a reference to this value variable. This proxy reference is a target of a loop that writes through this reference (the loop in reverse is an example) and Boogie havocs this variable to treat loops soundly.  So, we need a loop invariant to constrain the value of this reference variable to indicate that despite the havocing, this reference is still a reference to the value variable that will be eventually returned as as output of the function.  This loop invariant cannot be expressed at the Move level, of course.  The consequence is that even though Move Prover is able to prove the loop invariant which is referring to the reference, it cannot prove the postcondition which is referring to the value.  I did add the requisite loop invariant directly in the generated Boogie program and Boogie was then able to verify the postcondition.  This PR automatically generates the invariant in the translated Boogie code.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

Existing tests (upcoming test in a PR by @kkmc will add another test)

## Related PRs

#4319 