### PR TITLE
[libra_vm] Create a testing strategy for generating randomly invalid transactions

### DIFF
--- a/language/e2e-tests/src/account_universe.rs
+++ b/language/e2e-tests/src/account_universe.rs
@@ -11,10 +11,12 @@
 //! For examples of property-based tests written against this model, see the
 //! `tests/account_universe` directory.
 
+mod bad_transaction;
 mod create_account;
 mod peer_to_peer;
 mod rotate_key;
 mod universe;
+pub use bad_transaction::*;
 pub use create_account::*;
 pub use peer_to_peer::*;
 pub use rotate_key::*;

--- a/language/e2e-tests/src/account_universe/bad_transaction.rs
+++ b/language/e2e-tests/src/account_universe/bad_transaction.rs
@@ -1,0 +1,173 @@
+// Copyright (c) The Libra Core Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::{
+    account::Account,
+    account_universe::{AUTransactionGen, AccountUniverse},
+    common_transactions::{empty_txn, EMPTY_SCRIPT},
+    gas_costs,
+};
+use libra_crypto::{
+    ed25519::{self, Ed25519PrivateKey, Ed25519PublicKey},
+    test_utils::KeyPair,
+};
+use libra_proptest_helpers::Index;
+use libra_types::{
+    account_config::LBR_NAME,
+    transaction::{SignedTransaction, TransactionStatus},
+    vm_error::{StatusCode, VMStatus},
+};
+use move_core_types::gas_schedule::{AbstractMemorySize, GasAlgebra, GasCarrier, GasConstants};
+use move_vm_types::gas_schedule::calculate_intrinsic_gas;
+use proptest::prelude::*;
+use proptest_derive::Arbitrary;
+/// Represents a sequence number mismatch transaction
+///
+#[derive(Arbitrary, Clone, Debug)]
+#[proptest(params = "(u64, u64)")]
+pub struct SequenceNumberMismatchGen {
+    sender: Index,
+    #[proptest(strategy = "params.0 ..= params.1")]
+    seq: u64,
+}
+
+impl AUTransactionGen for SequenceNumberMismatchGen {
+    fn apply(
+        &self,
+        universe: &mut AccountUniverse,
+    ) -> (SignedTransaction, (TransactionStatus, u64)) {
+        let sender = universe.pick(self.sender).1;
+
+        let seq = if sender.sequence_number == self.seq {
+            self.seq + 1
+        } else {
+            self.seq
+        };
+
+        let txn = empty_txn(
+            sender.account(),
+            seq,
+            gas_costs::TXN_RESERVED,
+            0,
+            LBR_NAME.to_string(),
+        );
+
+        (
+            txn,
+            (
+                if seq >= sender.sequence_number {
+                    TransactionStatus::Discard(VMStatus::new(StatusCode::SEQUENCE_NUMBER_TOO_NEW))
+                } else {
+                    TransactionStatus::Discard(VMStatus::new(StatusCode::SEQUENCE_NUMBER_TOO_OLD))
+                },
+                0,
+            ),
+        )
+    }
+}
+
+/// Represents a insufficient balance transaction
+///
+#[derive(Arbitrary, Clone, Debug)]
+#[proptest(params = "(u64, u64)")]
+pub struct InsufficientBalanceGen {
+    sender: Index,
+    #[proptest(strategy = "params.0 ..= params.1")]
+    gas_unit_price: u64,
+}
+
+impl AUTransactionGen for InsufficientBalanceGen {
+    fn apply(
+        &self,
+        universe: &mut AccountUniverse,
+    ) -> (SignedTransaction, (TransactionStatus, u64)) {
+        let sender = universe.pick(self.sender).1;
+
+        let max_gas_unit = (sender.balance / self.gas_unit_price) + 1;
+
+        let txn = empty_txn(
+            sender.account(),
+            sender.sequence_number,
+            max_gas_unit,
+            self.gas_unit_price,
+            LBR_NAME.to_string(),
+        );
+
+        // TODO: Move such config to AccountUniverse
+        let default_constants = GasConstants::default();
+        let raw_bytes_len = AbstractMemorySize::new(txn.raw_txn_bytes_len() as GasCarrier);
+        let min_cost = calculate_intrinsic_gas(raw_bytes_len, &GasConstants::default()).get();
+
+        (
+            txn,
+            (
+                if max_gas_unit > default_constants.maximum_number_of_gas_units.get() {
+                    TransactionStatus::Discard(VMStatus::new(
+                        StatusCode::MAX_GAS_UNITS_EXCEEDS_MAX_GAS_UNITS_BOUND,
+                    ))
+                } else if max_gas_unit < min_cost {
+                    TransactionStatus::Discard(VMStatus::new(
+                        StatusCode::MAX_GAS_UNITS_BELOW_MIN_TRANSACTION_GAS_UNITS,
+                    ))
+                } else if self.gas_unit_price > default_constants.max_price_per_gas_unit.get() {
+                    TransactionStatus::Discard(VMStatus::new(
+                        StatusCode::GAS_UNIT_PRICE_ABOVE_MAX_BOUND,
+                    ))
+                } else if self.gas_unit_price < default_constants.min_price_per_gas_unit.get() {
+                    TransactionStatus::Discard(VMStatus::new(
+                        StatusCode::GAS_UNIT_PRICE_BELOW_MIN_BOUND,
+                    ))
+                } else {
+                    TransactionStatus::Discard(VMStatus::new(
+                        StatusCode::INSUFFICIENT_BALANCE_FOR_TRANSACTION_FEE,
+                    ))
+                },
+                0,
+            ),
+        )
+    }
+}
+
+/// Represents a authkey mismatch transaction
+///
+#[derive(Arbitrary, Clone, Debug)]
+#[proptest(no_params)]
+pub struct InvalidAuthkeyGen {
+    sender: Index,
+    #[proptest(strategy = "ed25519::keypair_strategy()")]
+    new_keypair: KeyPair<Ed25519PrivateKey, Ed25519PublicKey>,
+}
+
+impl AUTransactionGen for InvalidAuthkeyGen {
+    fn apply(
+        &self,
+        universe: &mut AccountUniverse,
+    ) -> (SignedTransaction, (TransactionStatus, u64)) {
+        let sender = universe.pick(self.sender).1;
+
+        let txn = Account::create_raw_txn_with_args(
+            *sender.account().address(),
+            EMPTY_SCRIPT.clone(),
+            vec![],
+            vec![],
+            sender.sequence_number,
+            gas_costs::TXN_RESERVED,
+            0,
+            LBR_NAME.to_owned(),
+        )
+        .sign(
+            &self.new_keypair.private_key,
+            self.new_keypair.public_key.clone(),
+        )
+        .unwrap()
+        .into_inner();
+
+        (
+            txn,
+            (
+                TransactionStatus::Discard(VMStatus::new(StatusCode::INVALID_AUTH_KEY)),
+                0,
+            ),
+        )
+    }
+}

--- a/language/e2e-tests/src/common_transactions.rs
+++ b/language/e2e-tests/src/common_transactions.rs
@@ -42,6 +42,23 @@ pub static CREATE_ACCOUNT_SCRIPT: Lazy<Vec<u8>> = Lazy::new(|| {
         .expect("Failed to compile")
 });
 
+pub static EMPTY_SCRIPT: Lazy<Vec<u8>> = Lazy::new(|| {
+    let code = "
+    main<Token>(account: &signer) {
+      return;
+    }
+";
+
+    let compiler = Compiler {
+        address: account_config::CORE_CODE_ADDRESS,
+        extra_deps: vec![],
+        ..Compiler::default()
+    };
+    compiler
+        .into_script_blob("file_name", code)
+        .expect("Failed to compile")
+});
+
 /// Returns a transaction to add a new validator
 pub fn add_validator_txn(
     sender: &Account,
@@ -59,6 +76,24 @@ pub fn add_validator_txn(
         gas_costs::TXN_RESERVED * 2,
         0,
         LBR_NAME.to_owned(),
+    )
+}
+
+pub fn empty_txn(
+    sender: &Account,
+    seq_num: u64,
+    max_gas_amount: u64,
+    gas_unit_price: u64,
+    gas_currency_code: String,
+) -> SignedTransaction {
+    sender.create_signed_txn_with_args(
+        EMPTY_SCRIPT.to_vec(),
+        vec![],
+        vec![],
+        seq_num,
+        max_gas_amount,
+        gas_unit_price,
+        gas_currency_code,
     )
 }
 

--- a/language/e2e-tests/src/tests/account_universe.rs
+++ b/language/e2e-tests/src/tests/account_universe.rs
@@ -1,6 +1,7 @@
 // Copyright (c) The Libra Core Contributors
 // SPDX-License-Identifier: Apache-2.0
 
+mod bad_transaction;
 mod create_account;
 mod peer_to_peer;
 mod rotate_key;
@@ -95,6 +96,7 @@ fn all_transactions_strategy(
         8 => peer_to_peer::p2p_strategy(min, max),
         1 => create_account::create_account_strategy(min, max),
         1 => any::<RotateKeyGen>().prop_map(RotateKeyGen::arced),
+        1 => bad_transaction::bad_txn_strategy(),
     ]
 }
 

--- a/language/e2e-tests/src/tests/account_universe/bad_transaction.rs
+++ b/language/e2e-tests/src/tests/account_universe/bad_transaction.rs
@@ -1,0 +1,49 @@
+// Copyright (c) The Libra Core Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::{
+    account_universe::{
+        default_num_transactions, AUTransactionGen, AccountUniverseGen, InsufficientBalanceGen,
+        InvalidAuthkeyGen, SequenceNumberMismatchGen,
+    },
+    tests::account_universe::run_and_assert_gas_cost_stability,
+};
+use proptest::{collection::vec, prelude::*};
+use std::sync::Arc;
+
+proptest! {
+    // These tests are pretty slow but quite comprehensive, so run a smaller number of them.
+    #![proptest_config(ProptestConfig::with_cases(32))]
+
+    #[test]
+    fn bad_sequence(
+        universe in AccountUniverseGen::success_strategy(2),
+        txns in vec(any_with::<SequenceNumberMismatchGen>((0, 10_000)), 0..default_num_transactions()),
+    ) {
+        run_and_assert_gas_cost_stability(universe, txns)?;
+    }
+
+    #[test]
+    fn bad_auth_key(
+        universe in AccountUniverseGen::success_strategy(2),
+        txns in vec(any_with::<InvalidAuthkeyGen>(()), 0..default_num_transactions()),
+    ) {
+        run_and_assert_gas_cost_stability(universe, txns)?;
+    }
+
+    #[test]
+    fn insufficient_balance(
+        universe in AccountUniverseGen::success_strategy(2),
+        txns in vec(any_with::<InsufficientBalanceGen>((1, 10_001)), 0..default_num_transactions()),
+    ) {
+        run_and_assert_gas_cost_stability(universe, txns)?;
+    }
+}
+
+pub(super) fn bad_txn_strategy() -> impl Strategy<Value = Arc<dyn AUTransactionGen + 'static>> {
+    prop_oneof![
+        1 => any_with::<SequenceNumberMismatchGen>((0, 10_000)).prop_map(SequenceNumberMismatchGen::arced),
+        1 => any_with::<InvalidAuthkeyGen>(()).prop_map(InvalidAuthkeyGen::arced),
+        1 => any_with::<InsufficientBalanceGen>((1, 20_000)).prop_map(InsufficientBalanceGen::arced),
+    ]
+}


### PR DESCRIPTION
## Motivation

Thanks to @sunshowers 's previous work, it is now relatively easy to describe a strategy to generate a random set of invalid transactions. This PR implements an easy strategy and the next step would be move the suite to fuzzer.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?

Yes
