### PR TITLE
[cluster_test] Pre allocate node manually - Flexible config 1/n

### DIFF
--- a/testsuite/cluster-test/src/cluster_swarm/job_template.yaml
+++ b/testsuite/cluster-test/src/cluster_swarm/job_template.yaml
@@ -19,11 +19,20 @@ spec:
       containers:
       - name: main
         image: {image}
+        volumeMounts:
+          - mountPath: /opt/libra/data
+            name: data
         imagePullPolicy: Always
         command: ["sh",  "-c", "{command}"]
         securityContext:
+          runAsUser: 0 # To get permissions to write to /opt/libra/data
           privileged: true
           capabilities:
             add: ["SYS_ADMIN"]
       restartPolicy: Never
+      volumes:
+        - name: data
+          hostPath:
+            path: /data
+            type: DirectoryOrCreate
   backoffLimit: {back_off_limit}


### PR DESCRIPTION
This diff is part of series of changes that aim to move away from libra_init usage in cluster test and generate configs inside cluster test binary. This will allow for higher flexibility for different scenarios and will make cluster test setup closer to production (that is not going to use libra_init).

In this diff we pre-allocate node manually, instead of relying on kubernetes to do so. This will be needed later to populate config on the node before running it.

Also, update job_template to allow utilities to access node data dir.