### PR TITLE
[network] decrease MAX_CONNECTION_DELAY_MS

### DIFF
--- a/network/src/validator_network/network_builder.rs
+++ b/network/src/validator_network/network_builder.rs
@@ -63,7 +63,7 @@ pub const MAX_CONCURRENT_INBOUND_RPCS: u32 = 100;
 pub const PING_FAILURES_TOLERATED: u64 = 10;
 pub const MAX_CONCURRENT_NETWORK_REQS: usize = 100;
 pub const MAX_CONCURRENT_NETWORK_NOTIFS: usize = 100;
-pub const MAX_CONNECTION_DELAY_MS: u64 = 10 * 60 * 1000 /* 10 minutes */;
+pub const MAX_CONNECTION_DELAY_MS: u64 = 10_000;
 
 #[derive(Debug)]
 pub enum AuthenticationMode {


### PR DESCRIPTION
10 minutes is too long for a maximum backoff, and it causes much longer
recovery times than expected.  It is now changed to 1 minute as a
maximum backoff to ensure that it retries every minute.
