### PR TITLE
[move-prover] Let spec-lang frontend handle scripts not called `main`

### DIFF
--- a/language/move-prover/docgen/tests/sources/some_script.move
+++ b/language/move-prover/docgen/tests/sources/some_script.move
@@ -1,0 +1,6 @@
+script {
+/// This script does really nothing but just aborts.
+fun some<T>(_account: &signer) {
+    abort 1
+}
+}

--- a/language/move-prover/docgen/tests/sources/some_script.spec_inline.md
+++ b/language/move-prover/docgen/tests/sources/some_script.spec_inline.md
@@ -1,0 +1,35 @@
+
+<a name="SCRIPT"></a>
+
+# Script `some_script.move`
+
+### Table of Contents
+
+-  [Function `some`](#SCRIPT_some)
+
+
+
+<a name="SCRIPT_some"></a>
+
+## Function `some`
+
+This script does really nothing but just aborts.
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="#SCRIPT_some">some</a>&lt;unknown#0&gt;(_account: &signer)
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>fun</b> <a href="#SCRIPT_some">some</a>&lt;T&gt;(_account: &signer) {
+    <b>abort</b> 1
+}
+</code></pre>
+
+
+
+</details>

--- a/language/move-prover/docgen/tests/sources/some_script.spec_inline_no_fold.md
+++ b/language/move-prover/docgen/tests/sources/some_script.spec_inline_no_fold.md
@@ -1,0 +1,30 @@
+
+<a name="SCRIPT"></a>
+
+# Script `some_script.move`
+
+### Table of Contents
+
+-  [Function `some`](#SCRIPT_some)
+
+
+
+<a name="SCRIPT_some"></a>
+
+## Function `some`
+
+This script does really nothing but just aborts.
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="#SCRIPT_some">some</a>&lt;unknown#0&gt;(_account: &signer)
+</code></pre>
+
+
+
+##### Implementation
+
+
+<pre><code><b>fun</b> <a href="#SCRIPT_some">some</a>&lt;T&gt;(_account: &signer) {
+    <b>abort</b> 1
+}
+</code></pre>

--- a/language/move-prover/docgen/tests/sources/some_script.spec_separate.md
+++ b/language/move-prover/docgen/tests/sources/some_script.spec_separate.md
@@ -1,0 +1,35 @@
+
+<a name="SCRIPT"></a>
+
+# Script `some_script.move`
+
+### Table of Contents
+
+-  [Function `some`](#SCRIPT_some)
+
+
+
+<a name="SCRIPT_some"></a>
+
+## Function `some`
+
+This script does really nothing but just aborts.
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="#SCRIPT_some">some</a>&lt;unknown#0&gt;(_account: &signer)
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>fun</b> <a href="#SCRIPT_some">some</a>&lt;T&gt;(_account: &signer) {
+    <b>abort</b> 1
+}
+</code></pre>
+
+
+
+</details>

--- a/language/move-prover/spec-lang/src/env.rs
+++ b/language/move-prover/spec-lang/src/env.rs
@@ -51,7 +51,6 @@ pub const SCRIPT_MODULE_NAME: &str = "<SELF>";
 
 /// Names used in the bytecode/AST to represent the main function of a script
 pub const SCRIPT_BYTECODE_FUN_NAME: &str = "<SELF>";
-pub const SCRIPT_AST_FUN_NAME: &str = "main";
 
 /// Pragma indicating whether verification should be performed for a function.
 pub const VERIFY_PRAGMA: &str = "verify";


### PR DESCRIPTION
The frontend did still hardwire the function name in a script as `main`, though this restriction was removed a while ago. This PR fixes this.

This was discovered via a docgen run (but would have also triggered the MIRAI bot via general prover run), therefore the test added is in docgen.

## Motivation

Bug fix.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

Added a docgen test.

## Related PRs

NA
