### PR TITLE
[move-prover] Added `aborts_if true;` smoke test.

### DIFF
--- a/language/move-prover/spec-lang/src/env.rs
+++ b/language/move-prover/spec-lang/src/env.rs
@@ -70,6 +70,9 @@ pub const ABORTS_IF_IS_STRICT_PRAGMA: &str = "aborts_if_is_strict";
 /// Pragma indicating that requires are also enforced if the aborts condition is true.
 pub const REQUIRES_IF_ABORTS: &str = "requires_if_aborts";
 
+/// Pragma indicating that the function will run smoke tests
+pub const SMOKE_TEST_PRAGMA: &str = "smoke_test";
+
 // =================================================================================================
 /// # Locations
 

--- a/language/move-prover/tests/sources/functional/aborts_if_true.exp
+++ b/language/move-prover/tests/sources/functional/aborts_if_true.exp
@@ -1,0 +1,25 @@
+Move prover returns: exiting with boogie verification errors
+error: function aborts_if_true_smoke_test_fails always aborts.
+
+    ┌── tests/sources/functional/aborts_if_true.move:14:5 ───
+    │
+ 14 │ ╭     public fun aborts_if_true_smoke_test_fails() {
+ 15 │ │         abort 1
+ 16 │ │     }
+    │ ╰─────^
+    │
+
+error: function aborts_if_true_smoke_test_fails_2 always aborts.
+
+    ┌── tests/sources/functional/aborts_if_true.move:22:5 ───
+    │
+ 22 │ ╭     public fun aborts_if_true_smoke_test_fails_2(): u64 {
+ 23 │ │         let x: u64;
+ 24 │ │         x = 1;
+ 25 │ │         if (x > 0) {
+ 26 │ │             abort 1
+ 27 │ │         };
+ 28 │ │         x
+ 29 │ │     }
+    │ ╰─────^
+    │

--- a/language/move-prover/tests/sources/functional/aborts_if_true.move
+++ b/language/move-prover/tests/sources/functional/aborts_if_true.move
@@ -1,0 +1,33 @@
+module TestEnsuresFalseSmokeTest {
+    spec module {
+        pragma verify = true;
+    }
+
+    /// Expect this not to return any errors
+    public fun aborts_if_true_succeeds() {
+    }
+    spec fun aborts_if_true_succeeds {
+        pragma smoke_test = true;
+    }
+
+    /// Expect this to return an error because it passes the ensures false
+    public fun aborts_if_true_smoke_test_fails() {
+        abort 1
+    }
+    spec fun aborts_if_true_smoke_test_fails {
+        pragma smoke_test = true;
+    }
+
+    /// More complicated example where smoke test should catch an error
+    public fun aborts_if_true_smoke_test_fails_2(): u64 {
+        let x: u64;
+        x = 1;
+        if (x > 0) {
+            abort 1
+        };
+        x
+    }
+    spec fun aborts_if_true_smoke_test_fails_2 {
+        pragma smoke_test = true;
+    }
+}


### PR DESCRIPTION
Added `aborts_if true;` smoke test to the move-prover.
This can be turned on for specific functions by declaring
`pragma smoke_test = true;` inside of a spec fun block.
An error is reported if the function being verified can prove
$abort_flag is always true.

Related to issue #3665.


Note: Had a discussion with David about smoke testing ensures false in Boogie vs at the Move language and decided on the latter / to check for `aborts_if true;` (at the Move level). This is not the same as the soundness check for assert false.

## Motivation

When writing Move programs, it's possible that a combination of implementation and specifications will force the procedure to always abort. In these situations, we want to report an error to the user informing them about this issue.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?

Yes.

## Test Plan

Existing test suite.

## Related PRs

None.