### PR TITLE
[vm/types] Remove `TransactionPayload::Program`

### DIFF
--- a/execution/executor/src/lib.rs
+++ b/execution/executor/src/lib.rs
@@ -352,9 +352,7 @@ where
                             bail!("Write set should be a subset of read set.")
                         }
                         Transaction::UserTransaction(txn) => match txn.payload() {
-                            TransactionPayload::Program
-                            | TransactionPayload::Module(_)
-                            | TransactionPayload::Script(_) => {
+                            TransactionPayload::Module(_) | TransactionPayload::Script(_) => {
                                 bail!("Write set should be a subset of read set.")
                             }
                             TransactionPayload::WriteSet(_) => (),

--- a/execution/executor/src/mock_vm/mod.rs
+++ b/execution/executor/src/mock_vm/mod.rs
@@ -370,9 +370,6 @@ fn decode_transaction(txn: &SignedTransaction) -> MockVMTransaction {
             // Use WriteSet for reconfig only for testing.
             MockVMTransaction::Reconfiguration
         }
-        TransactionPayload::Program => {
-            unimplemented!("MockVM does not support Program transaction payload.")
-        }
         TransactionPayload::Module(_) => {
             unimplemented!("MockVM does not support Module transaction payload.")
         }

--- a/json-rpc/types/src/views.rs
+++ b/json-rpc/types/src/views.rs
@@ -428,7 +428,6 @@ impl From<TransactionPayload> for ScriptView {
         let unknown_currency = "unknown_currency".to_string();
 
         let (code, args, ty_args) = match value {
-            TransactionPayload::Program => ("deprecated".to_string(), empty_vec, empty_ty_vec),
             TransactionPayload::WriteSet(_) => ("genesis".to_string(), empty_vec, empty_ty_vec),
             TransactionPayload::Script(script) => (
                 get_transaction_name(script.code()),

--- a/language/e2e-tests/src/account.rs
+++ b/language/e2e-tests/src/account.rs
@@ -226,15 +226,6 @@ impl Account {
         gas_currency_code: String,
     ) -> RawTransaction {
         match payload {
-            TransactionPayload::Program => RawTransaction::new(
-                address,
-                sequence_number,
-                TransactionPayload::Program,
-                max_gas_amount,
-                gas_unit_price,
-                gas_currency_code,
-                Duration::from_secs(DEFAULT_EXPIRATION_TIME),
-            ),
             TransactionPayload::WriteSet(writeset) => {
                 RawTransaction::new_change_set(address, sequence_number, writeset)
             }

--- a/language/ir-testsuite/_old_move_ir_tests/src/tests/transactions.rs
+++ b/language/ir-testsuite/_old_move_ir_tests/src/tests/transactions.rs
@@ -17,7 +17,7 @@ fn write_set_txn_roundtrip() {
     proptest!(|(signed_txn in SignedTransaction::genesis_strategy())| {
         let write_set = match signed_txn.payload() {
             TransactionPayload::WriteSet(write_set) => write_set.clone(),
-            TransactionPayload::Program | TransactionPayload::Script(_) | TransactionPayload::Module(_) => unreachable!(
+            TransactionPayload::Script(_) | TransactionPayload::Module(_) => unreachable!(
                 "write set strategy should only generate write set transactions",
             ),
         };

--- a/language/ir-testsuite/_old_move_ir_tests/src/tests/verify_transaction.rs
+++ b/language/ir-testsuite/_old_move_ir_tests/src/tests/verify_transaction.rs
@@ -124,7 +124,7 @@ fn verify_txn_rejects_genesis_deletion() {
     proptest!(|(txn in SignedTransaction::write_set_strategy())| {
         let write_set = match txn.payload() {
             TransactionPayload::WriteSet(write_set) => write_set,
-            TransactionPayload::Program | TransactionPayload::Script(_) | TransactionPayload::Module(_) => panic!(
+            TransactionPayload::Script(_) | TransactionPayload::Module(_) => panic!(
                 "write_set_strategy shouldn't generate other transactions",
             ),
         };

--- a/language/libra-vm/src/libra_vm.rs
+++ b/language/libra-vm/src/libra_vm.rs
@@ -285,7 +285,6 @@ impl LibraVM {
         self.check_gas(transaction)?;
         let txn_data = TransactionMetadata::new(transaction);
         match transaction.payload() {
-            TransactionPayload::Program => Err(VMStatus::new(StatusCode::UNKNOWN_SCRIPT)),
             TransactionPayload::Script(script) => {
                 self.verify_script(remote_cache, script, txn_data, account_currency_symbol)
             }
@@ -304,7 +303,6 @@ impl LibraVM {
     ) -> VMResult<()> {
         let txn_data = TransactionMetadata::new(transaction);
         match transaction.payload() {
-            TransactionPayload::Program => Err(VMStatus::new(StatusCode::UNKNOWN_SCRIPT)),
             TransactionPayload::Script(script) => {
                 self.check_gas(transaction)?;
                 self.verify_script(remote_cache, script, txn_data, account_currency_symbol)?;

--- a/testsuite/generate-format/tests/staged/consensus.yaml
+++ b/testsuite/generate-format/tests/staged/consensus.yaml
@@ -320,16 +320,14 @@ TransactionAuthenticator:
 TransactionPayload:
   ENUM:
     0:
-      Program: UNIT
-    1:
       WriteSet:
         NEWTYPE:
           TYPENAME: ChangeSet
-    2:
+    1:
       Script:
         NEWTYPE:
           TYPENAME: Script
-    3:
+    2:
       Module:
         NEWTYPE:
           TYPENAME: Module

--- a/testsuite/generate-format/tests/staged/libra.yaml
+++ b/testsuite/generate-format/tests/staged/libra.yaml
@@ -154,16 +154,14 @@ TransactionAuthenticator:
 TransactionPayload:
   ENUM:
     0:
-      Program: UNIT
-    1:
       WriteSet:
         NEWTYPE:
           TYPENAME: ChangeSet
-    2:
+    1:
       Script:
         NEWTYPE:
           TYPENAME: Script
-    3:
+    2:
       Module:
         NEWTYPE:
           TYPENAME: Module

--- a/types/src/proptest_types.rs
+++ b/types/src/proptest_types.rs
@@ -289,15 +289,6 @@ fn new_raw_transaction(
     expiration_time_secs: u64,
 ) -> RawTransaction {
     match payload {
-        TransactionPayload::Program => RawTransaction::new(
-            sender,
-            sequence_number,
-            TransactionPayload::Program,
-            max_gas_amount,
-            gas_unit_price,
-            gas_currency_code,
-            Duration::from_secs(expiration_time_secs),
-        ),
         TransactionPayload::Module(module) => RawTransaction::new_module(
             sender,
             sequence_number,
@@ -543,7 +534,6 @@ impl Arbitrary for TransactionPayload {
             4 => Self::script_strategy(),
             1 => Self::module_strategy(),
             1 => Self::write_set_strategy(),
-            1 => Just(TransactionPayload::Program),
         ]
         .boxed()
     }

--- a/types/src/transaction/mod.rs
+++ b/types/src/transaction/mod.rs
@@ -255,9 +255,6 @@ impl RawTransaction {
     pub fn format_for_client(&self, get_transaction_name: impl Fn(&[u8]) -> String) -> String {
         let empty_vec = vec![];
         let (code, args) = match &self.payload {
-            TransactionPayload::Program => {
-                return "Deprecated".to_string();
-            }
             TransactionPayload::WriteSet(_) => ("genesis".to_string(), &empty_vec[..]),
             TransactionPayload::Script(script) => {
                 (get_transaction_name(script.code()), script.args())
@@ -300,9 +297,6 @@ impl RawTransaction {
 
 #[derive(Clone, Debug, Hash, Eq, PartialEq, Serialize, Deserialize)]
 pub enum TransactionPayload {
-    /// Deprecated. See https://developers.libra.org/blog/2019/10/22/simplifying-payloads for more
-    /// details.
-    Program,
     WriteSet(ChangeSet),
     /// A transaction that executes code.
     Script(Script),

--- a/types/src/unit_tests/canonical_serialization_examples.rs
+++ b/types/src/unit_tests/canonical_serialization_examples.rs
@@ -85,7 +85,7 @@ fn test_raw_transaction_with_a_program_canonical_serialization_example() {
 
     let expected_output = vec![
         58, 36, 166, 30, 5, 209, 41, 202, 206, 158, 14, 252, 139, 201, 227, 56, 32, 0, 0, 0, 0, 0,
-        0, 0, 2, 4, 109, 111, 118, 101, 0, 1, 1, 239, 190, 173, 222, 13, 208, 254, 202, 16, 39, 0,
+        0, 0, 1, 4, 109, 111, 118, 101, 0, 1, 1, 239, 190, 173, 222, 13, 208, 254, 202, 16, 39, 0,
         0, 0, 0, 0, 0, 32, 78, 0, 0, 0, 0, 0, 0, 3, 76, 66, 82, 128, 81, 1, 0, 0, 0, 0, 0,
     ];
 
@@ -106,7 +106,7 @@ fn test_raw_transaction_with_a_write_set_canonical_serialization_example() {
 
     let expected_output = vec![
         195, 57, 138, 89, 154, 111, 59, 159, 48, 182, 53, 175, 41, 242, 186, 4, 32, 0, 0, 0, 0, 0,
-        0, 0, 1, 2, 167, 29, 118, 250, 162, 210, 213, 195, 34, 78, 195, 212, 29, 235, 41, 57, 33,
+        0, 0, 0, 2, 167, 29, 118, 250, 162, 210, 213, 195, 34, 78, 195, 212, 29, 235, 41, 57, 33,
         1, 33, 125, 166, 198, 179, 225, 159, 24, 37, 207, 178, 103, 109, 174, 204, 227, 191, 61,
         224, 60, 242, 102, 71, 199, 141, 240, 11, 55, 27, 37, 204, 151, 0, 196, 198, 63, 128, 199,
         75, 17, 38, 62, 66, 30, 191, 132, 134, 164, 227, 9, 1, 33, 125, 166, 198, 179, 225, 159,
@@ -158,7 +158,7 @@ fn test_transaction_payload_with_a_program_canonical_serialization_example() {
     let input = TransactionPayload::Script(get_common_program());
 
     let expected_output = vec![
-        0x02, 0x04, 0x6D, 0x6F, 0x76, 0x65, 0x00, 0x01, 0x01, 0xEF, 0xBE, 0xAD, 0xDE, 0x0D, 0xD0,
+        0x01, 0x04, 0x6D, 0x6F, 0x76, 0x65, 0x00, 0x01, 0x01, 0xEF, 0xBE, 0xAD, 0xDE, 0x0D, 0xD0,
         0xFE, 0xCA,
     ];
 
@@ -171,12 +171,11 @@ fn test_transaction_payload_with_a_write_set_canonical_serialization_example() {
     let input = TransactionPayload::WriteSet(ChangeSet::new(get_common_write_set(), vec![]));
 
     let expected_output = vec![
-        0x01, 0x02, 0xA7, 0x1D, 0x76, 0xFA, 0xA2, 0xD2, 0xD5, 0xC3, 0x22, 0x4E, 0xC3, 0xD4, 0x1D,
-        0xEB, 0x29, 0x39, 0x21, 0x01, 0x21, 0x7D, 0xA6, 0xC6, 0xB3, 0xE1, 0x9F, 0x18, 0x25, 0xCF,
-        0xB2, 0x67, 0x6D, 0xAE, 0xCC, 0xE3, 0xBF, 0x3D, 0xE0, 0x3C, 0xF2, 0x66, 0x47, 0xC7, 0x8D,
-        0xF0, 0x0B, 0x37, 0x1B, 0x25, 0xCC, 0x97, 0x00, 0xC4, 0xC6, 0x3F, 0x80, 0xC7, 0x4B, 0x11,
-        0x26, 0x3E, 0x42, 0x1E, 0xBF, 0x84, 0x86, 0xA4, 0xE3, 0x09, 0x01, 0x21, 0x7D, 0xA6, 0xC6,
-        0xB3, 0xE1, 0x9F, 0x18, 0x01, 0x04, 0xCA, 0xFE, 0xD0, 0x0D, 0x00,
+        0, 2, 167, 29, 118, 250, 162, 210, 213, 195, 34, 78, 195, 212, 29, 235, 41, 57, 33, 1, 33,
+        125, 166, 198, 179, 225, 159, 24, 37, 207, 178, 103, 109, 174, 204, 227, 191, 61, 224, 60,
+        242, 102, 71, 199, 141, 240, 11, 55, 27, 37, 204, 151, 0, 196, 198, 63, 128, 199, 75, 17,
+        38, 62, 66, 30, 191, 132, 134, 164, 227, 9, 1, 33, 125, 166, 198, 179, 225, 159, 24, 1, 4,
+        202, 254, 208, 13, 0,
     ];
 
     let actual_output = to_bytes(&input).unwrap();


### PR DESCRIPTION
This was some dead code still laying around from the removal of `Program`. 
