### PR TITLE
InsertWaypoint

### DIFF
--- a/config/management/src/error.rs
+++ b/config/management/src/error.rs
@@ -12,17 +12,19 @@ pub enum Error {
     BackendMissingBackendKey,
     #[error("Backend parsing error: {0}")]
     BackendParsingError(String),
+    #[error("Invalid arguments: {0}")]
+    CommandArgumentError(String),
     #[error("Local storage unavailable, please check your configuration: {0}")]
     LocalStorageUnavailable(String),
     #[error("Failed to read, {0}, from local storage: {1}")]
     LocalStorageReadError(&'static str, String),
     #[error("Failed to sign {0} with {1} using local storage: {2}")]
     LocalStorageSigningError(&'static str, &'static str, String),
-    #[error("Failed to write, {0}, to local storage: {0}")]
+    #[error("Failed to write, {0}, to local storage: {1}")]
     LocalStorageWriteError(&'static str, String),
-    #[error("Failed to read, {0}, from remote storage: {0}")]
+    #[error("Failed to read, {0}, from remote storage: {1}")]
     RemoteStorageReadError(&'static str, String),
-    #[error("Failed to write, {0}, to remote storage: {0}")]
+    #[error("Failed to write, {0}, to remote storage: {1}")]
     RemoteStorageWriteError(&'static str, String),
     #[error("Remote storage unavailable, please check your configuration: {0}")]
     RemoteStorageUnavailable(String),

--- a/config/management/src/lib.rs
+++ b/config/management/src/lib.rs
@@ -44,6 +44,8 @@ pub enum Command {
     CreateWaypoint(crate::waypoint::CreateWaypoint),
     #[structopt(about = "Retrieves data from a store to produce genesis")]
     Genesis(crate::genesis::Genesis),
+    #[structopt(about = "Insert a waypoint")]
+    InsertWaypoint(crate::waypoint::InsertWaypoint),
     #[structopt(about = "Submits an Ed25519PublicKey for the operator")]
     OperatorKey(crate::key::OperatorKey),
     #[structopt(about = "Submits an Ed25519PublicKey for the owner")]
@@ -61,6 +63,7 @@ pub enum CommandName {
     AssociationKey,
     CreateWaypoint,
     Genesis,
+    InsertWaypoint,
     OperatorKey,
     OwnerKey,
     SetLayout,
@@ -74,6 +77,7 @@ impl From<&Command> for CommandName {
             Command::AssociationKey(_) => CommandName::AssociationKey,
             Command::CreateWaypoint(_) => CommandName::CreateWaypoint,
             Command::Genesis(_) => CommandName::Genesis,
+            Command::InsertWaypoint(_) => CommandName::InsertWaypoint,
             Command::OperatorKey(_) => CommandName::OperatorKey,
             Command::OwnerKey(_) => CommandName::OwnerKey,
             Command::SetLayout(_) => CommandName::SetLayout,
@@ -89,6 +93,7 @@ impl std::fmt::Display for CommandName {
             CommandName::AssociationKey => "association-key",
             CommandName::CreateWaypoint => "create-waypoint",
             CommandName::Genesis => "genesis",
+            CommandName::InsertWaypoint => "insert-waypoint",
             CommandName::OperatorKey => "operator-key",
             CommandName::OwnerKey => "owner-key",
             CommandName::SetLayout => "set-layout",
@@ -105,6 +110,7 @@ impl Command {
             Command::AssociationKey(_) => self.association_key().unwrap().to_string(),
             Command::CreateWaypoint(_) => self.create_waypoint().unwrap().to_string(),
             Command::Genesis(_) => format!("{:?}", self.genesis().unwrap()),
+            Command::InsertWaypoint(_) => self.insert_waypoint().unwrap().to_string(),
             Command::OperatorKey(_) => self.operator_key().unwrap().to_string(),
             Command::OwnerKey(_) => self.owner_key().unwrap().to_string(),
             Command::SetLayout(_) => self.set_layout().unwrap().to_string(),
@@ -141,6 +147,17 @@ impl Command {
         } else {
             Err(Error::UnexpectedCommand(
                 CommandName::Genesis,
+                CommandName::from(&self),
+            ))
+        }
+    }
+
+    pub fn insert_waypoint(self) -> Result<Waypoint, Error> {
+        if let Command::InsertWaypoint(insert_waypoint) = self {
+            insert_waypoint.execute()
+        } else {
+            Err(Error::UnexpectedCommand(
+                CommandName::InsertWaypoint,
                 CommandName::from(&self),
             ))
         }

--- a/config/management/src/secure_backend.rs
+++ b/config/management/src/secure_backend.rs
@@ -16,6 +16,12 @@ pub const GITHUB: &str = "github";
 pub const MEMORY: &str = "memory";
 pub const VAULT: &str = "vault";
 
+#[derive(Copy, Clone, Debug)]
+pub enum RelativePosition {
+    Local,
+    Remote,
+}
+
 /// SecureBackend is a parameter that is stored as set of semi-colon separated key/value pairs. The
 /// only expected key is backend which defines which of the SecureBackends the parameters refer to.
 /// Some backends require parameters others do not, so that requires a conversion into the

--- a/config/management/src/smoke_test.rs
+++ b/config/management/src/smoke_test.rs
@@ -1,7 +1,7 @@
 // Copyright (c) The Libra Core Contributors
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::{layout::Layout, storage_helper::StorageHelper};
+use crate::{constants, layout::Layout, storage_helper::StorageHelper};
 use config_builder::{BuildSwarm, SwarmConfig};
 use libra_config::{
     config::{
@@ -117,10 +117,13 @@ fn smoke_test() {
     genesis_path.create_as_file().unwrap();
     let genesis = helper.genesis(genesis_path.path()).unwrap();
 
+    // Save the waypoint into shared secure storage so that validators can perform insert_waypoint
+    let waypoint = helper.create_waypoint(constants::COMMON_NS).unwrap();
+
     // Step 5) Introduce waypoint and genesis into the configs and verify along the way
     for (i, mut config) in configs.iter_mut().enumerate() {
         let ns = i.to_string();
-        let waypoint = helper.create_waypoint(&ns).unwrap();
+        helper.insert_waypoint(&ns, constants::COMMON_NS).unwrap();
         let output = helper.verify_genesis(&ns, genesis_path.path()).unwrap();
         // 4 matches = 5 splits
         assert_eq!(output.split("match").count(), 5);

--- a/config/management/src/storage_helper.rs
+++ b/config/management/src/storage_helper.rs
@@ -120,6 +120,28 @@ impl StorageHelper {
         command.genesis()
     }
 
+    pub fn insert_waypoint(&self, local_ns: &str, remote_ns: &str) -> Result<Waypoint, Error> {
+        let args = format!(
+            "
+                management
+                insert-waypoint
+                --local backend={backend};\
+                    path={path};\
+                    namespace={local_ns}
+                --remote backend={backend};\
+                    path={path};\
+                    namespace={remote_ns}
+            ",
+            backend = crate::secure_backend::DISK,
+            path = self.path_string(),
+            local_ns = local_ns,
+            remote_ns = remote_ns,
+        );
+
+        let command = Command::from_iter(args.split_whitespace());
+        command.insert_waypoint()
+    }
+
     pub fn operator_key(&self, local_ns: &str, remote_ns: &str) -> Result<Ed25519PublicKey, Error> {
         let args = format!(
             "


### PR DESCRIPTION
Added an `insert-waypoint` command for the `config/management` crate.

`insert-waypoint --local BACKEND [--remote BACKEND] [--waypoint WAYPOINT_VALUE]`
where one any only one of `--remote` and `--waypoint` must be provided.

Issue: #4378 

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan
Modified the `smoke_test` in the management crate to test `insert_waypoint`.

