### PR TITLE
[move-prover] convert sender to signer in Move Prover functional tests.

### DIFF
--- a/language/move-prover/tests/sources/functional/address_quant.exp
+++ b/language/move-prover/tests/sources/functional/address_quant.exp
@@ -8,4 +8,5 @@ error:  A postcondition might not hold on this return path.
     │
     =     at tests/sources/functional/address_quant.move:46:5: multiple_copy_incorrect (entry)
     =     at tests/sources/functional/address_quant.move:47:9: multiple_copy_incorrect
+    =         sndr = <redacted>
     =     at tests/sources/functional/address_quant.move:46:5: multiple_copy_incorrect (exit)

--- a/language/move-prover/tests/sources/functional/address_quant.move
+++ b/language/move-prover/tests/sources/functional/address_quant.move
@@ -1,6 +1,6 @@
 // Tests of quantification over addresses.
 module AddressQuant {
-    use 0x1::Transaction;
+    use 0x1::Signer;
 
     resource struct R {
         x: u64
@@ -20,9 +20,9 @@ module AddressQuant {
         }
     }
 
-    public fun initialize(special_addr: address) {
-        assert(Transaction::sender() == special_addr, 0);
-        move_to_sender<R>(R{x:1});
+    public fun initialize(sndr: &signer, special_addr: address) {
+        assert(Signer::address_of(sndr) == special_addr, 0);
+        move_to<R>(sndr, R{x:1});
     }
     spec fun initialize {
         requires forall a: address : !exists<R>(a);
@@ -43,8 +43,8 @@ module AddressQuant {
 
     // sender() might be different from special_addr,
     // so this should violate the invariant.
-    public fun multiple_copy_incorrect() {
-        move_to_sender<R>(R{x:1});
+    public fun multiple_copy_incorrect(sndr: &signer) {
+        move_to<R>(sndr, R{x:1});
     }
 
     // This asserts that there is at must one address with an R.

--- a/language/move-prover/tests/sources/functional/invariants.move
+++ b/language/move-prover/tests/sources/functional/invariants.move
@@ -24,7 +24,7 @@ module TestInvariants {
         define greater_one(x: num): bool { x > 1 }
 
         // Impure function to be used in update invariants.
-        define tautology() : bool { sender() == 0x0 || sender() != 0x0 }
+        define tautology() : bool { global<R>(0x5551212) == R {x: 2} || global<R>(0x5551212) != R {x: 2} }
     }
 
 

--- a/language/move-prover/tests/sources/functional/resources.exp
+++ b/language/move-prover/tests/sources/functional/resources.exp
@@ -1,11 +1,17 @@
 Move prover returns: exiting with boogie verification errors
 error:  A postcondition might not hold on this return path.
 
-    ┌── tests/sources/functional/resources.move:40:6 ───
+    ┌── tests/sources/functional/resources.move:39:6 ───
     │
- 40 │      ensures exists<R>(sender());
-    │      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+ 39 │      ensures exists<R>(Signer::get_address(account));
+    │      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
     │
-    =     at tests/sources/functional/resources.move:33:5: create_resource_incorrect (entry)
-    =     at tests/sources/functional/resources.move:34:9: create_resource_incorrect
-    =     at tests/sources/functional/resources.move:33:5: create_resource_incorrect (exit)
+    =     at tests/sources/functional/resources.move:32:5: create_resource_incorrect (entry)
+    =     at ../stdlib/modules/Signer.move:13:5: address_of (entry)
+    =     at ../stdlib/modules/Signer.move:10:23: borrow_address
+    =     at ../stdlib/modules/Signer.move:14:9: address_of
+    =         s = <redacted>,
+    =         result = <redacted>
+    =     at tests/sources/functional/resources.move:33:30: create_resource_incorrect
+    =         account = <redacted>
+    =     at tests/sources/functional/resources.move:32:5: create_resource_incorrect (exit)

--- a/language/move-prover/tests/sources/functional/script.move
+++ b/language/move-prover/tests/sources/functional/script.move
@@ -2,8 +2,10 @@
 script {
 use 0x1::ScriptProvider;
 
-fun main<Token>() {
-    ScriptProvider::register<Token>();
+// TODO: This file inherits an error from ScriptProvider.
+
+fun main<Token>(account: &signer) {
+    ScriptProvider::register<Token>(account);
 }
 
 spec fun main {

--- a/language/move-prover/tests/sources/functional/script_incorrect.exp
+++ b/language/move-prover/tests/sources/functional/script_incorrect.exp
@@ -1,19 +1,26 @@
 Move prover returns: exiting with boogie verification errors
 error: abort not covered by any of the `aborts_if` clauses
 
-   ┌── tests/sources/functional/script_incorrect.move:5:1 ───
+   ┌── tests/sources/functional/script_incorrect.move:7:1 ───
    │
- 5 │ ╭ fun main<Token>() {
- 6 │ │     ScriptProvider::register<Token>();
- 7 │ │ }
+ 7 │ ╭ fun main<Token>(account: &signer) {
+ 8 │ │     ScriptProvider::register<Token>(account);
+ 9 │ │ }
    │ ╰─^
    │
-   =     at tests/sources/functional/script_incorrect.move:5:1: main (entry)
-   =     at tests/sources/functional/script_provider.move:14:5: register (entry)
-   =     at tests/sources/functional/script_provider.move:15:9: register (ABORTED)
+   =     at tests/sources/functional/script_incorrect.move:7:1: main (entry)
+   =     at tests/sources/functional/script_provider.move:16:5: register (entry)
+   =     at ../stdlib/modules/Signer.move:13:5: address_of (entry)
+   =     at ../stdlib/modules/Signer.move:10:23: borrow_address
+   =     at ../stdlib/modules/Signer.move:14:9: address_of
+   =         s = <redacted>,
+   =         result = <redacted>
+   =     at tests/sources/functional/script_provider.move:17:24: register (ABORTED)
+   =         account = <redacted>,
+   =         $t1 = <redacted>
 
-    ┌── tests/sources/functional/script_provider.move:15:9 ───
+    ┌── tests/sources/functional/script_provider.move:17:24 ───
     │
- 15 │         assert(Transaction::sender() == 0x1, 1);
-    │         --------------------------------------- abort happened here
+ 17 │         assert(Signer::address_of(account) == 0x1, 1);
+    │                        ---------- abort happened here
     │

--- a/language/move-prover/tests/sources/functional/script_incorrect.move
+++ b/language/move-prover/tests/sources/functional/script_incorrect.move
@@ -2,8 +2,10 @@
 script {
 use 0x1::ScriptProvider;
 
-fun main<Token>() {
-    ScriptProvider::register<Token>();
+// TODO: This file inherits an error from ScriptProvider.
+
+fun main<Token>(account: &signer) {
+    ScriptProvider::register<Token>(account);
 }
 
 spec fun main {

--- a/language/move-prover/tests/sources/functional/script_provider.move
+++ b/language/move-prover/tests/sources/functional/script_provider.move
@@ -1,8 +1,10 @@
 // A module providing functionality to the script*.move tests
 address 0x1 {
 
+// TODO: This file gets errors for reasons I do not understand.
+
 module ScriptProvider {
-    use 0x1::Transaction;
+    use 0x1::Signer;
 
     spec module {
         pragma verify = true;
@@ -11,12 +13,13 @@ module ScriptProvider {
 
     resource struct Info<T> {}
 
-    public fun register<T>() {
-        assert(Transaction::sender() == 0x1, 1);
-        move_to_sender(Info<T>{})
+    public fun register<T>(account: &signer) {
+        assert(Signer::address_of(account) == 0x1, 1);
+        move_to(account, Info<T>{})
     }
     spec schema RegisterConditions<T> {
-        aborts_if sender() != 0x1;
+        account: signer;
+        aborts_if Signer::get_address(account) != 0x1;
         aborts_if exists<Info<T>>(0x1);
         ensures exists<Info<T>>(0x1);
     }

--- a/language/move-prover/tests/sources/functional/type_values.exp
+++ b/language/move-prover/tests/sources/functional/type_values.exp
@@ -8,6 +8,7 @@ error:  A postcondition might not hold on this return path.
     │
     =     at tests/sources/functional/type_values.move:37:5: add_R_incorrect (entry)
     =     at tests/sources/functional/type_values.move:38:9: add_R_incorrect
+    =         account = <redacted>
     =     at tests/sources/functional/type_values.move:37:5: add_R_incorrect (exit)
 
 error:  A postcondition might not hold on this return path.

--- a/language/move-prover/tests/sources/functional/type_values.move
+++ b/language/move-prover/tests/sources/functional/type_values.move
@@ -30,11 +30,11 @@ module TestTypeValues {
         }
     }
 
-    public fun add_R<T>() {
-        move_to_sender(R<T>{x: 1})
+    public fun add_R<T>(account: &signer) {
+        move_to(account, R<T>{x: 1})
     }
 
-    public fun add_R_incorrect<T>() {
-        move_to_sender(R<T>{x: 0})
+    public fun add_R_incorrect<T>(account: &signer) {
+        move_to(account, R<T>{x: 0})
     }
 }

--- a/language/move-prover/tests/sources/stdlib/modules/Signer.move
+++ b/language/move-prover/tests/sources/stdlib/modules/Signer.move
@@ -1,0 +1,21 @@
+address 0x1 {
+module Signer {
+    // Borrows the address of the signer
+    // Conceptually, you can think of the `signer` as being a resource struct wrapper arround an
+    // address
+    // ```
+    // resource struct Signer { addr: address }
+    // ```
+    // `borrow_address` borrows this inner field
+    native public fun borrow_address(s: &signer): &address;
+
+    // Copies the address of the signer
+    public fun address_of(s: &signer): address {
+        *borrow_address(s)
+    }
+
+    spec module {
+        native define get_address(account: signer): address;
+    }
+}
+}


### PR DESCRIPTION
Converted all .move files in tests/sources/functional to use signer
instead of sender except for txn.move, whose sole purpose seems to be
to test sender(). Once we have definitely retired sender() for good, we can just delete
that test, I think.

Some .exp files changed because of details in the error reports.

<!--
Thank you for sending a PR. We appreciate you spending time to help improve the Libra project.

The project is undergoing daily changes. Pull Requests will be reviewed and responded to as time permits.
-->

## Motivation

(Write your motivation for proposed changes here.)

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?

(Write your answer here.)

## Test Plan

(Share your test plan here. If you changed code, please provide us with clear instructions for verifying that your changes work.)

## Related PRs

(If this PR adds or changes functionality, please take some time to update the docs at https://github.com/libra/website, and link to your PR here.)
