### PR TITLE
[network] support server only authentication

### DIFF
--- a/config/config-builder/src/full_node_config.rs
+++ b/config/config-builder/src/full_node_config.rs
@@ -5,8 +5,7 @@ use crate::{BuildSwarm, Error, ValidatorConfig};
 use anyhow::{ensure, Result};
 use libra_config::{
     config::{
-        DiscoveryMethod, NetworkPeerInfo, NetworkPeersConfig, NodeConfig, PeerNetworkId, RoleType,
-        UpstreamConfig,
+        DiscoveryMethod, NetworkPeersConfig, NodeConfig, PeerNetworkId, RoleType, UpstreamConfig,
     },
     generator,
     network_id::NetworkId,
@@ -185,12 +184,10 @@ impl FullNodeConfig {
 
             network_peers.peers.insert(
                 network.identity.peer_id_from_config().unwrap(),
-                NetworkPeerInfo {
-                    identity_public_key: network
-                        .identity
-                        .public_key_from_config()
-                        .ok_or(Error::MissingNetworkKeyPairs)?,
-                },
+                network
+                    .identity
+                    .public_key_from_config()
+                    .ok_or(Error::MissingNetworkKeyPairs)?,
             );
 
             configs.push(config);

--- a/config/config-builder/src/full_node_config.rs
+++ b/config/config-builder/src/full_node_config.rs
@@ -28,7 +28,7 @@ pub struct FullNodeConfig {
     pub num_full_nodes: usize,
     pub genesis: Option<Transaction>,
     pub listen_address: NetworkAddress,
-    pub enable_remote_authentication: bool,
+    pub mutual_authentication: bool,
     template: NodeConfig,
     validator_config: ValidatorConfig,
 }
@@ -50,7 +50,7 @@ impl Default for FullNodeConfig {
             num_full_nodes: 1,
             genesis: None,
             listen_address: NetworkAddress::from_str(DEFAULT_LISTEN_ADDRESS).unwrap(),
-            enable_remote_authentication: true,
+            mutual_authentication: true,
             template,
             validator_config: ValidatorConfig::new(),
         }
@@ -180,7 +180,7 @@ impl FullNodeConfig {
             network.network_id = NetworkId::vfn_network();
             network.listen_address = utils::get_available_port_in_multiaddr(true);
             network.advertised_address = network.listen_address.clone();
-            network.enable_remote_authentication = self.enable_remote_authentication;
+            network.mutual_authentication = self.mutual_authentication;
 
             network_peers.peers.insert(
                 network.identity.peer_id_from_config().unwrap(),

--- a/config/config-builder/src/main.rs
+++ b/config/config-builder/src/main.rs
@@ -288,7 +288,7 @@ fn build_full_node_config_builder(args: &FullNodeArgs) -> FullNodeConfig {
     }
 
     if args.public {
-        config_builder.enable_remote_authentication = false;
+        config_builder.mutual_authentication = false;
     }
 
     if let Some(seed) = args.seed.as_ref() {

--- a/config/config-builder/src/validator_config.rs
+++ b/config/config-builder/src/validator_config.rs
@@ -10,7 +10,6 @@ use libra_config::{
         VaultConfig, WaypointConfig,
     },
     generator,
-    network_id::NetworkId,
 };
 use libra_crypto::{ed25519::Ed25519PrivateKey, PrivateKey, Uniform};
 use libra_network_address::NetworkAddress;
@@ -87,7 +86,6 @@ impl ValidatorConfig {
             .validator_network
             .as_mut()
             .ok_or(Error::MissingValidatorNetwork)?;
-        validator_network.network_id = NetworkId::Validator;
         validator_network.listen_address = self.listen_address.clone();
         validator_network.advertised_address = self.advertised_address.clone();
         validator_network.seed_peers = seed_peers;

--- a/config/management/src/smoke_test.rs
+++ b/config/management/src/smoke_test.rs
@@ -6,7 +6,7 @@ use config_builder::{BuildSwarm, SwarmConfig};
 use libra_config::{
     config::{
         DiscoveryMethod, Identity, NetworkConfig, NodeConfig, OnDiskStorageConfig, RoleType,
-        SecureBackend, WaypointConfig,
+        SecureBackend, SeedPeersConfig, WaypointConfig, HANDSHAKE_VERSION,
     },
     network_id::NetworkId,
 };
@@ -76,8 +76,9 @@ fn smoke_test() {
         network.discovery_method = DiscoveryMethod::None;
         config.validator_network = Some(network);
 
-        let mut network = NetworkConfig::network_with_id(NetworkId::vfn_network());
+        let mut network = NetworkConfig::network_with_id(NetworkId::Public);
         network.discovery_method = DiscoveryMethod::None;
+        network.enable_remote_authentication = false;
         config.full_node_networks = vec![network];
         config.randomize_ports();
 
@@ -137,14 +138,18 @@ fn smoke_test() {
         config.execution.genesis = Some(genesis.clone());
     }
 
-    // Step 6) Build configuration for Swarm
+    // Step 6) Prepare ecosystem
+    let full_node_config =
+        attach_validator_full_node(&helper, &mut configs[0], &swarm_path, 0.to_string());
+
+    // Step 7) Build configuration for Swarm
     let faucet_key = helper
         .storage(association.into())
         .export_private_key(libra_global_constants::ASSOCIATION_KEY)
         .unwrap();
     let management_builder = ManagementBuilder {
         configs,
-        faucet_key,
+        faucet_key: faucet_key.clone(),
     };
 
     let mut swarm = LibraSwarm {
@@ -153,8 +158,99 @@ fn smoke_test() {
         config: SwarmConfig::build(&management_builder, &swarm_path).unwrap(),
     };
 
-    // Step 7) Launch and exit!
+    // Step 8) Launch validators
     swarm.launch_attempt(RoleType::Validator, false).unwrap();
+
+    // Step 9) Launch ecosystem
+    let management_builder = ManagementBuilder {
+        configs: vec![full_node_config],
+        faucet_key,
+    };
+
+    let temppath = TempPath::new();
+    temppath.create_as_dir().unwrap();
+    let swarm_path = temppath.path().to_path_buf();
+
+    let mut swarm = LibraSwarm {
+        dir: LibraSwarmDir::Temporary(temppath),
+        nodes: std::collections::HashMap::new(),
+        config: SwarmConfig::build(&management_builder, &swarm_path).unwrap(),
+    };
+    swarm.launch_attempt(RoleType::FullNode, false).unwrap();
+    // This currently doesn't pass, the goal over the next set of commits is to make it succeed
+    // assert!(check_connectivity(&mut swarm, 1));
+}
+
+fn check_connectivity(swarm: &mut LibraSwarm, expected_peers: i64) -> bool {
+    for node in swarm.nodes.iter_mut() {
+        let mut timed_out = true;
+        for i in 0..60 {
+            println!("Wait for connectivity attempt: {} {}", node.0, i);
+            std::thread::sleep(std::time::Duration::from_secs(1));
+            if node.1.check_connectivity(expected_peers) {
+                timed_out = false;
+                break;
+            }
+        }
+        if timed_out {
+            return false;
+        }
+    }
+    true
+}
+
+fn attach_validator_full_node(
+    helper: &StorageHelper,
+    validator_config: &mut NodeConfig,
+    swarm_path: &Path,
+    ns: String,
+) -> NodeConfig {
+    // Create two vfns, we'll pass one to the validator later
+    let fn_vfn = NetworkConfig::network_with_id(NetworkId::vfn_network());
+    let v_vfn = NetworkConfig::network_with_id(NetworkId::vfn_network());
+
+    let mut full_node_config = NodeConfig::default();
+    full_node_config.full_node_networks = vec![fn_vfn, v_vfn];
+    full_node_config.randomize_ports();
+
+    // Now let's swap the full node network on the validator with the PFN on the fullnode, since
+    // that's the VFN and what we want clients to connect to.
+    let internal_fn = full_node_config.full_node_networks.swap_remove(1);
+    let pfn = validator_config.full_node_networks.swap_remove(0);
+    full_node_config.full_node_networks.push(pfn);
+    validator_config.full_node_networks.push(internal_fn);
+
+    // Now let's prepare the full nodes internal network to communicate with the validators
+    // internal network
+
+    let v_vfn = &mut validator_config.full_node_networks[0];
+    v_vfn.discovery_method = DiscoveryMethod::None;
+    v_vfn.enable_remote_authentication = false;
+    v_vfn.identity = Identity::from_storage(
+        libra_global_constants::FULLNODE_NETWORK_KEY.into(),
+        libra_global_constants::OPERATOR_ACCOUNT.into(),
+        secure_backend(helper.path(), &swarm_path, &ns, "pfn_full_node"),
+    );
+
+    let v_vfn_network_address = v_vfn.listen_address.clone();
+    let v_vfn_pub_key = libra_secure_storage::config::identity_key(v_vfn).public_key();
+    let v_vfn_network_address =
+        v_vfn_network_address.append_prod_protos(v_vfn_pub_key, HANDSHAKE_VERSION);
+    let v_vfn_id = libra_secure_storage::config::peer_id(v_vfn);
+    let mut seed_peers = SeedPeersConfig::default();
+    seed_peers
+        .seed_peers
+        .insert(v_vfn_id, vec![v_vfn_network_address]);
+
+    let fn_vfn = &mut full_node_config.full_node_networks[0];
+    fn_vfn.discovery_method = DiscoveryMethod::None;
+    fn_vfn.enable_remote_authentication = false;
+    fn_vfn.seed_peers = seed_peers;
+
+    full_node_config.base.waypoint = validator_config.base.waypoint.clone();
+    full_node_config.base.role = RoleType::FullNode;
+    full_node_config.execution.genesis = validator_config.execution.genesis.clone();
+    full_node_config
 }
 
 fn secure_backend(original: &Path, dst_base: &Path, ns: &str, usage: &str) -> SecureBackend {

--- a/config/management/src/smoke_test.rs
+++ b/config/management/src/smoke_test.rs
@@ -176,9 +176,9 @@ fn smoke_test() {
         nodes: std::collections::HashMap::new(),
         config: SwarmConfig::build(&management_builder, &swarm_path).unwrap(),
     };
+
     swarm.launch_attempt(RoleType::FullNode, false).unwrap();
-    // This currently doesn't pass, the goal over the next set of commits is to make it succeed
-    // assert!(check_connectivity(&mut swarm, 1));
+    assert!(check_connectivity(&mut swarm, 1));
 }
 
 fn check_connectivity(swarm: &mut LibraSwarm, expected_peers: i64) -> bool {

--- a/config/management/src/smoke_test.rs
+++ b/config/management/src/smoke_test.rs
@@ -74,11 +74,11 @@ fn smoke_test() {
 
         let mut network = NetworkConfig::network_with_id(NetworkId::Validator);
         network.discovery_method = DiscoveryMethod::None;
+        network.mutual_authentication = true;
         config.validator_network = Some(network);
 
         let mut network = NetworkConfig::network_with_id(NetworkId::Public);
         network.discovery_method = DiscoveryMethod::None;
-        network.enable_remote_authentication = false;
         config.full_node_networks = vec![network];
         config.randomize_ports();
 
@@ -225,7 +225,6 @@ fn attach_validator_full_node(
 
     let v_vfn = &mut validator_config.full_node_networks[0];
     v_vfn.discovery_method = DiscoveryMethod::None;
-    v_vfn.enable_remote_authentication = false;
     v_vfn.identity = Identity::from_storage(
         libra_global_constants::FULLNODE_NETWORK_KEY.into(),
         libra_global_constants::OPERATOR_ACCOUNT.into(),
@@ -244,7 +243,6 @@ fn attach_validator_full_node(
 
     let fn_vfn = &mut full_node_config.full_node_networks[0];
     fn_vfn.discovery_method = DiscoveryMethod::None;
-    fn_vfn.enable_remote_authentication = false;
     fn_vfn.seed_peers = seed_peers;
 
     full_node_config.base.waypoint = validator_config.base.waypoint.clone();

--- a/config/src/config/mod.rs
+++ b/config/src/config/mod.rs
@@ -269,12 +269,16 @@ impl NodeConfig {
 
         if let Some(network) = self.validator_network.as_mut() {
             network.listen_address = crate::utils::get_available_port_in_multiaddr(true);
-            network.advertised_address = network.listen_address.clone();
+            if let DiscoveryMethod::Gossip(config) = &mut network.discovery_method {
+                config.advertised_address = network.listen_address.clone();
+            }
         }
 
         for network in self.full_node_networks.iter_mut() {
             network.listen_address = crate::utils::get_available_port_in_multiaddr(true);
-            network.advertised_address = network.listen_address.clone();
+            if let DiscoveryMethod::Gossip(config) = &mut network.discovery_method {
+                config.advertised_address = network.listen_address.clone();
+            }
         }
     }
 
@@ -410,7 +414,6 @@ mod test {
             .as_mut()
             .expect("Missing expected network config");
 
-        expected_network.advertised_address = actual_network.advertised_address.clone();
         expected_network.listen_address = actual_network.listen_address.clone();
         expected_network.identity = actual_network.identity.clone();
         expected_network.network_peers = actual_network.network_peers.clone();

--- a/config/src/config/network_config.rs
+++ b/config/src/config/network_config.rs
@@ -39,19 +39,17 @@ pub struct NetworkConfig {
     pub advertised_address: NetworkAddress,
     pub discovery_interval_ms: u64,
     pub connectivity_check_interval_ms: u64,
-    // If the network uses remote authentication, only trusted peers are allowed to connect.
-    // Otherwise, any node can connect.
-    // TODO(philiphayes): rename this flag. should reflect `AuthenticationMode` in
-    // `NetworkBuilder`, i.e., `Mutual` vs `ServerOnly` authentication.
-    pub enable_remote_authentication: bool,
+    // Select this to enforce that both peers should authenticate each other, otherwise
+    // authentication only occurs for outgoing connections.
+    pub mutual_authentication: bool,
     // Enable this network to use either gossip discovery or onchain discovery.
     pub discovery_method: DiscoveryMethod,
-    // network peers are the nodes allowed to connect when the network is started in authenticated
-    // mode.
+    // Leveraged by mutual_authentication for incoming peers that may not have a well-defined
+    // network address.
     #[serde(skip)]
     pub network_peers: NetworkPeersConfig,
     pub network_peers_file: PathBuf,
-    // seed_peers act as seed nodes for the discovery protocol.
+    // Initial set of peers to connect to
     #[serde(skip)]
     pub seed_peers: SeedPeersConfig,
     pub seed_peers_file: PathBuf,
@@ -73,7 +71,7 @@ impl NetworkConfig {
             advertised_address: "/ip4/127.0.0.1/tcp/6180".parse().unwrap(),
             discovery_interval_ms: 1000,
             connectivity_check_interval_ms: 5000,
-            enable_remote_authentication: true,
+            mutual_authentication: false,
             discovery_method: DiscoveryMethod::Gossip,
             identity: Identity::None,
             network_peers_file: PathBuf::new(),
@@ -96,7 +94,7 @@ impl NetworkConfig {
             advertised_address: self.advertised_address.clone(),
             discovery_interval_ms: self.discovery_interval_ms,
             connectivity_check_interval_ms: self.connectivity_check_interval_ms,
-            enable_remote_authentication: self.enable_remote_authentication,
+            mutual_authentication: self.mutual_authentication,
             discovery_method: self.discovery_method,
             identity: Identity::None,
             network_peers_file: self.network_peers_file.clone(),

--- a/config/src/config/network_config.rs
+++ b/config/src/config/network_config.rs
@@ -224,19 +224,13 @@ impl SeedPeersConfig {
 pub struct NetworkPeersConfig {
     #[serde(flatten)]
     #[serde(serialize_with = "utils::serialize_ordered_map")]
-    pub peers: HashMap<PeerId, NetworkPeerInfo>,
+    pub peers: HashMap<PeerId, x25519::PublicKey>,
 }
 
 impl std::fmt::Debug for NetworkPeersConfig {
     fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
         write!(f, "<{} keys>", self.peers.len())
     }
-}
-
-#[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
-pub struct NetworkPeerInfo {
-    #[serde(rename = "ni")]
-    pub identity_public_key: x25519::PublicKey,
 }
 
 #[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]

--- a/config/src/config/test_data/random.complete.node.config.toml
+++ b/config/src/config/test_data/random.complete.node.config.toml
@@ -76,7 +76,7 @@ listen_address = "/ip4/0.0.0.0/tcp/6180"
 advertised_address = "/ip4/127.0.0.1/tcp/6180"
 discovery_interval_ms = 1000
 connectivity_check_interval_ms = 5000
-enable_remote_authentication = true
+mutual_authentication = false
 network_peers_file = ""
 seed_peers_file = "31893204fa402143c11b26ce8a89ea1d.seed_peers.toml"
 

--- a/config/src/config/test_data/random.complete.node.config.toml
+++ b/config/src/config/test_data/random.complete.node.config.toml
@@ -73,8 +73,6 @@ initialize_storage = true
 
 [validator_network]
 listen_address = "/ip4/0.0.0.0/tcp/6180"
-advertised_address = "/ip4/127.0.0.1/tcp/6180"
-discovery_interval_ms = 1000
 connectivity_check_interval_ms = 5000
 mutual_authentication = false
 network_peers_file = ""

--- a/config/src/config/test_data/single.node.config.toml
+++ b/config/src/config/test_data/single.node.config.toml
@@ -41,7 +41,7 @@ listen_address = "/ip4/0.0.0.0/tcp/65206"
 advertised_address = "/ip4/0.0.0.0/tcp/65206"
 discovery_interval_ms = 1000
 connectivity_check_interval_ms = 5000
-enable_remote_authentication = true
+mutual_authentication = false
 network_peers_file = ""
 seed_peers_file = ""
 

--- a/config/src/config/test_data/single.node.config.toml
+++ b/config/src/config/test_data/single.node.config.toml
@@ -38,8 +38,6 @@ initialize_storage = true
 
 [validator_network]
 listen_address = "/ip4/0.0.0.0/tcp/65206"
-advertised_address = "/ip4/0.0.0.0/tcp/65206"
-discovery_interval_ms = 1000
 connectivity_check_interval_ms = 5000
 mutual_authentication = false
 network_peers_file = ""

--- a/config/src/generator.rs
+++ b/config/src/generator.rs
@@ -5,7 +5,9 @@
 //! genesis.blob.
 
 use crate::{
-    config::{NetworkConfig, NodeConfig, SeedPeersConfig, TestConfig, HANDSHAKE_VERSION},
+    config::{
+        DiscoveryMethod, NetworkConfig, NodeConfig, SeedPeersConfig, TestConfig, HANDSHAKE_VERSION,
+    },
     network_id::NetworkId,
 };
 use libra_network_address::NetworkAddress;
@@ -35,6 +37,7 @@ pub fn validator_swarm(
         node.upstream
             .primary_networks
             .push(network.identity.peer_id_from_config().unwrap());
+        network.discovery_method = DiscoveryMethod::gossip(network.listen_address.clone());
         network.mutual_authentication = true;
         network.network_id = NetworkId::Validator;
 
@@ -43,7 +46,8 @@ pub fn validator_swarm(
 
     // set the first validator as every validators' initial configured seed peer.
     let seed_config = &nodes[0].validator_network.as_ref().unwrap();
-    let seed_peers = build_seed_peers(&seed_config, seed_config.advertised_address.clone());
+    let advertised_address = seed_config.discovery_method.advertised_address();
+    let seed_peers = build_seed_peers(&seed_config, advertised_address);
     for node in &mut nodes {
         let network = node.validator_network.as_mut().unwrap();
         network.seed_peers = seed_peers.clone();

--- a/config/src/generator.rs
+++ b/config/src/generator.rs
@@ -4,7 +4,10 @@
 //! Convenience structs and functions for generating a random set of Libra ndoes without the
 //! genesis.blob.
 
-use crate::config::{NetworkConfig, NodeConfig, SeedPeersConfig, TestConfig, HANDSHAKE_VERSION};
+use crate::{
+    config::{NetworkConfig, NodeConfig, SeedPeersConfig, TestConfig, HANDSHAKE_VERSION},
+    network_id::NetworkId,
+};
 use libra_network_address::NetworkAddress;
 use rand::{rngs::StdRng, SeedableRng};
 
@@ -32,6 +35,8 @@ pub fn validator_swarm(
         node.upstream
             .primary_networks
             .push(network.identity.peer_id_from_config().unwrap());
+        network.mutual_authentication = true;
+        network.network_id = NetworkId::Validator;
 
         nodes.push(node);
     }

--- a/language/tools/vm-genesis/src/lib.rs
+++ b/language/tools/vm-genesis/src/lib.rs
@@ -307,8 +307,8 @@ pub fn validator_registrations(node_configs: &[NodeConfig]) -> Vec<ValidatorRegi
             let identity_key = network.identity.public_key_from_config().unwrap();
 
             let advertised_address = network
-                .advertised_address
-                .clone()
+                .discovery_method
+                .advertised_address()
                 .append_prod_protos(identity_key, HANDSHAKE_VERSION);
             let raw_advertised_address = RawNetworkAddress::try_from(&advertised_address).unwrap();
 

--- a/libra-node/src/main_node.rs
+++ b/libra-node/src/main_node.rs
@@ -86,7 +86,7 @@ pub fn setup_network(
     );
     network_builder.add_connection_monitoring();
 
-    if config.enable_remote_authentication {
+    if config.mutual_authentication {
         // Sanity check seed peer addresses.
         config
             .seed_peers

--- a/libra-node/src/main_node.rs
+++ b/libra-node/src/main_node.rs
@@ -108,7 +108,6 @@ pub fn setup_network(
         );
 
         network_builder
-            .advertised_address(config.advertised_address.clone())
             .authentication_mode(AuthenticationMode::Mutual(identity_key))
             .trusted_peers(trusted_peers)
             .seed_peers(seed_peers)
@@ -116,9 +115,7 @@ pub fn setup_network(
             .add_connectivity_manager();
     } else {
         // Enforce the outgoing connection (dialer) verifies the identity of the listener (server)
-        network_builder
-            .authentication_mode(AuthenticationMode::ServerOnly(identity_key))
-            .advertised_address(config.advertised_address.clone());
+        network_builder.authentication_mode(AuthenticationMode::ServerOnly(identity_key));
         if !seed_peers.is_empty() {
             network_builder
                 .seed_peers(seed_peers)
@@ -126,10 +123,11 @@ pub fn setup_network(
         }
     }
 
-    match config.discovery_method {
-        DiscoveryMethod::Gossip => {
+    match &config.discovery_method {
+        DiscoveryMethod::Gossip(gossip_config) => {
             network_builder
-                .discovery_interval_ms(config.discovery_interval_ms)
+                .advertised_address(gossip_config.advertised_address.clone())
+                .discovery_interval_ms(gossip_config.discovery_interval_ms)
                 .add_gossip_discovery();
         }
         DiscoveryMethod::Onchain => {

--- a/network/simple-onchain-discovery/src/lib.rs
+++ b/network/simple-onchain-discovery/src/lib.rs
@@ -13,10 +13,7 @@ use libra_types::{
     on_chain_config::{OnChainConfigPayload, ValidatorSet, ON_CHAIN_CONFIG_REGISTRY},
     validator_config::ValidatorConfig,
 };
-use network::{
-    common::NetworkPublicKeys,
-    connectivity_manager::{ConnectivityRequest, DiscoverySource},
-};
+use network::connectivity_manager::{ConnectivityRequest, DiscoverySource};
 use once_cell::sync::Lazy;
 use std::{convert::TryFrom, time::Instant};
 use subscription_service::ReconfigSubscription;
@@ -98,14 +95,7 @@ fn extract_updates(role: RoleType, node_set: ValidatorSet) -> Vec<ConnectivityRe
     updates.push(ConnectivityRequest::UpdateEligibleNodes(
         node_list
             .into_iter()
-            .map(|node| {
-                (
-                    *node.account_address(),
-                    NetworkPublicKeys {
-                        identity_public_key: public_key(role, node.config()),
-                    },
-                )
-            })
+            .map(|node| (*node.account_address(), public_key(role, node.config())))
             .collect(),
     ));
 

--- a/network/src/common.rs
+++ b/network/src/common.rs
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::ProtocolId;
-use libra_config::config::NetworkPeerInfo;
 use std::fmt;
 
 /// A Negotiated substream encapsulates a protocol and a substream for which that protocol has been
@@ -23,6 +22,3 @@ impl<TSubstream> fmt::Debug for NegotiatedSubstream<TSubstream> {
         )
     }
 }
-
-/// Public keys used at the network layer
-pub type NetworkPublicKeys = NetworkPeerInfo;

--- a/network/src/connectivity_manager/test.rs
+++ b/network/src/connectivity_manager/test.rs
@@ -41,10 +41,7 @@ fn setup_conn_mgr(
         .into_iter()
         .map(|peer_id| {
             let identity_public_key = x25519::PrivateKey::generate(&mut rng).public_key();
-            let pubkeys = NetworkPublicKeys {
-                identity_public_key,
-            };
-            (peer_id, pubkeys)
+            (peer_id, identity_public_key)
         })
         .collect::<HashMap<_, _>>();
 
@@ -70,16 +67,11 @@ fn setup_conn_mgr(
     )
 }
 
-fn gen_peer() -> (PeerId, NetworkPublicKeys) {
+fn gen_peer() -> (PeerId, x25519::PublicKey) {
     let peer_id = PeerId::random();
     let mut rng = StdRng::from_seed(TEST_SEED);
     let identity_public_key = x25519::PrivateKey::generate(&mut rng).public_key();
-    (
-        peer_id,
-        NetworkPublicKeys {
-            identity_public_key,
-        },
-    )
+    (peer_id, identity_public_key)
 }
 
 async fn get_dial_queue_size(conn_mgr_reqs_tx: &mut channel::Sender<ConnectivityRequest>) -> usize {

--- a/network/src/connectivity_manager/test.rs
+++ b/network/src/connectivity_manager/test.rs
@@ -184,6 +184,10 @@ fn connect_to_seeds_on_startup() {
     let mut rt = Runtime::new().unwrap();
     let seed_peer_id = PeerId::random();
     let seed_addr = NetworkAddress::from_str("/ip4/127.0.0.1/tcp/9090").unwrap();
+    let seed_addr = seed_addr.append_prod_protos(
+        x25519::PrivateKey::generate_for_testing().public_key(),
+        libra_config::config::HANDSHAKE_VERSION,
+    );
     let seed_peers = vec![(seed_peer_id, vec![seed_addr.clone()])]
         .into_iter()
         .collect::<HashMap<_, _>>();

--- a/network/src/lib.rs
+++ b/network/src/lib.rs
@@ -6,8 +6,6 @@
 #![recursion_limit = "1024"]
 // </Black magic>
 
-// Public exports
-pub use common::NetworkPublicKeys;
 pub use interface::NetworkProvider;
 
 pub mod common;

--- a/network/src/noise/mod.rs
+++ b/network/src/noise/mod.rs
@@ -13,14 +13,12 @@
 //! ```
 //! use network::{
 //!     noise::{HandshakeAuthMode, NoiseUpgrader},
-//!     NetworkPublicKeys,
 //! };
 //! use futures::{executor, future, io::{AsyncReadExt, AsyncWriteExt}};
 //! use memsocket::MemorySocket;
 //! use libra_crypto::{x25519, ed25519, Uniform, PrivateKey, test_utils::TEST_SEED};
 //! use rand::{rngs::StdRng, SeedableRng};
 //! use libra_types::PeerId;
-//! use libra_config::config::NetworkPeerInfo;
 //! use std::{collections::HashMap, sync::{Arc, RwLock}};
 //!
 //! fn example() -> std::io::Result<()> {
@@ -37,12 +35,8 @@
 //! // create list of trusted peers
 //! let mut trusted_peers = Arc::new(RwLock::new(HashMap::new()));
 //! {
-//!     trusted_peers.write().unwrap().insert(client_peer_id, NetworkPublicKeys {
-//!        identity_public_key: client_public,
-//!     });
-//!     trusted_peers.write().unwrap().insert(server_peer_id, NetworkPublicKeys {
-//!        identity_public_key: server_public,
-//!     });
+//!     trusted_peers.write().unwrap().insert(client_peer_id, client_public);
+//!     trusted_peers.write().unwrap().insert(server_peer_id, server_public);
 //! }
 //!
 //! let client_auth = HandshakeAuthMode::mutual(trusted_peers.clone());

--- a/network/src/protocols/network/dummy.rs
+++ b/network/src/protocols/network/dummy.rs
@@ -13,7 +13,7 @@ use crate::{
     validator_network::network_builder::{
         AuthenticationMode, NetworkBuilder, NETWORK_CHANNEL_SIZE,
     },
-    NetworkPublicKeys, ProtocolId,
+    ProtocolId,
 };
 use channel::message_queues::QueueStyle;
 use futures::{executor::block_on, StreamExt};
@@ -116,18 +116,8 @@ pub fn setup_network() -> DummyNetwork {
 
     // Setup trusted peers.
     let trusted_peers: HashMap<_, _> = vec![
-        (
-            dialer_peer_id,
-            NetworkPublicKeys {
-                identity_public_key: dialer_identity_public_key,
-            },
-        ),
-        (
-            listener_peer_id,
-            NetworkPublicKeys {
-                identity_public_key: listener_identity_public_key,
-            },
-        ),
+        (dialer_peer_id, dialer_identity_public_key),
+        (listener_peer_id, listener_identity_public_key),
     ]
     .into_iter()
     .collect();

--- a/network/src/validator_network/network_builder.rs
+++ b/network/src/validator_network/network_builder.rs
@@ -10,7 +10,6 @@
 //! connect to or accept connections from an end-point running in authenticated mode as
 //! long as the latter is in its trusted peers set.
 use crate::{
-    common::NetworkPublicKeys,
     connectivity_manager::{ConnectivityManager, ConnectivityRequest},
     counters,
     peer_manager::{
@@ -106,7 +105,7 @@ pub struct NetworkBuilder {
     listen_address: NetworkAddress,
     advertised_address: Option<NetworkAddress>,
     seed_peers: HashMap<PeerId, Vec<NetworkAddress>>,
-    trusted_peers: Arc<RwLock<HashMap<PeerId, NetworkPublicKeys>>>,
+    trusted_peers: Arc<RwLock<HashMap<PeerId, x25519::PublicKey>>>,
     authentication_mode: Option<AuthenticationMode>,
     channel_size: usize,
     direct_send_protocols: Vec<ProtocolId>,
@@ -202,7 +201,7 @@ impl NetworkBuilder {
     /// Set trusted peers.
     pub fn trusted_peers(
         &mut self,
-        trusted_peers: HashMap<PeerId, NetworkPublicKeys>,
+        trusted_peers: HashMap<PeerId, x25519::PublicKey>,
     ) -> &mut Self {
         *self.trusted_peers.write().unwrap() = trusted_peers;
         self

--- a/state-synchronizer/src/tests/integration_tests.rs
+++ b/state-synchronizer/src/tests/integration_tests.rs
@@ -22,10 +22,7 @@ use libra_types::{
     validator_info::ValidatorInfo, validator_signer::ValidatorSigner,
     validator_verifier::random_validator_verifier, waypoint::Waypoint,
 };
-use network::{
-    validator_network::network_builder::{AuthenticationMode, NetworkBuilder},
-    NetworkPublicKeys,
-};
+use network::validator_network::network_builder::{AuthenticationMode, NetworkBuilder};
 use rand::{rngs::StdRng, SeedableRng};
 use std::{
     collections::HashMap,
@@ -237,9 +234,7 @@ impl SynchronizerEnv {
             .map(|public_keys| {
                 (
                     *public_keys.account_address(),
-                    NetworkPublicKeys {
-                        identity_public_key: public_keys.network_identity_public_key(),
-                    },
+                    public_keys.network_identity_public_key(),
                 )
             })
             .collect();

--- a/testsuite/libra-swarm/src/swarm.rs
+++ b/testsuite/libra-swarm/src/swarm.rs
@@ -332,8 +332,8 @@ impl LibraSwarm {
             full_node_builder.extend_validator(&mut validator_config)?;
             validator_config.save(&upstream_config_file)?;
             full_node_builder.bootstrap = validator_config.full_node_networks[0]
-                .advertised_address
-                .clone();
+                .discovery_method
+                .advertised_address();
             SwarmConfig::build(&full_node_builder, config_path)?
         };
 


### PR DESCRIPTION
This does several things:
1) Adds a proper smoke test to ensure this works
2) fixes the naming of enable_remote_authentication
3) handles all the quirks of networking to make it work

It then does to ancillary things that are relevant for simplifying configs:
1) Move all gossip config stuff into a GossipConfig
2) Eliminate the NetworkPeerInfo / NetworkPublicKeys in favor of just exposing the x25519::PublicKey