### PR TITLE
[libra-trace] Add custom sampling to libra trace

### DIFF
--- a/common/debug-interface/src/lib.rs
+++ b/common/debug-interface/src/lib.rs
@@ -1,8 +1,6 @@
 // Copyright (c) The Libra Core Contributors
 // SPDX-License-Identifier: Apache-2.0
 
-#![forbid(unsafe_code)]
-
 use crate::json_log::JsonLogEntry;
 use anyhow::Result;
 use reqwest::blocking;
@@ -13,8 +11,12 @@ pub mod libra_trace;
 pub mod node_debug_service;
 
 pub mod prelude {
-    pub use crate::{end_trace, event, trace_code_block, trace_edge, trace_event};
+    pub use crate::{
+        end_trace, event, node_sampling_data, trace_code_block, trace_edge, trace_event,
+    };
 }
+
+pub use libra_trace::{is_selected, libra_trace_set, set_libra_trace};
 
 /// Implement default utility client for NodeDebugInterface
 pub struct NodeDebugClient {

--- a/config/src/config/debug_interface_config.rs
+++ b/config/src/config/debug_interface_config.rs
@@ -3,6 +3,7 @@
 
 use crate::utils;
 use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
 
 #[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
 #[serde(default, deny_unknown_fields)]
@@ -12,6 +13,7 @@ pub struct DebugInterfaceConfig {
     pub metrics_server_port: u16,
     pub public_metrics_server_port: u16,
     pub address: String,
+    pub libra_trace: LibraTraceConfig,
 }
 
 impl Default for DebugInterfaceConfig {
@@ -21,6 +23,7 @@ impl Default for DebugInterfaceConfig {
             metrics_server_port: 9101,
             public_metrics_server_port: 9102,
             address: "0.0.0.0".to_string(),
+            libra_trace: LibraTraceConfig::default(),
         }
     }
 }
@@ -30,5 +33,20 @@ impl DebugInterfaceConfig {
         self.admission_control_node_debug_port = utils::get_available_port();
         self.metrics_server_port = utils::get_available_port();
         self.public_metrics_server_port = utils::get_available_port();
+    }
+}
+
+#[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
+#[serde(default, deny_unknown_fields)]
+pub struct LibraTraceConfig {
+    pub sampling: HashMap<String, String>,
+}
+
+impl Default for LibraTraceConfig {
+    fn default() -> LibraTraceConfig {
+        let mut map = HashMap::new();
+        map.insert(String::from("txn"), String::from("1/100"));
+        map.insert(String::from("block"), String::from("1/1"));
+        LibraTraceConfig { sampling: map }
     }
 }

--- a/libra-node/src/main_node.rs
+++ b/libra-node/src/main_node.rs
@@ -30,6 +30,8 @@ use storage_interface::{DbReader, DbReaderWriter};
 use storage_service::start_storage_service_with_db;
 use tokio::runtime::{Builder, Runtime};
 
+use debug_interface::libra_trace;
+
 const AC_SMP_CHANNEL_BUFFER_SIZE: usize = 1_024;
 const INTRA_NODE_CHANNEL_BUFFER_SIZE: usize = 1;
 
@@ -56,6 +58,9 @@ fn setup_debug_interface(config: &NodeConfig) -> NodeDebugService {
     .unwrap()
     .next()
     .unwrap();
+
+    libra_trace::set_libra_trace(&config.debug_interface.libra_trace.sampling)
+        .expect("Failed to set libra trace sampling rate.");
 
     NodeDebugService::new(addr)
 }


### PR DESCRIPTION
Using default sampling rate to sample trace event.
Using the leading 6 hex of account address to hash for txn and using the leading 6 hex of block hashvalue to hash. Any suggestion? I found there is an event_edge (txn -> block), if the block sampling rate is not 1:1, then potentially, we would sample some transactions such that we lose the block that the transaction belongs to.