### PR TITLE
[fuzzing] suppress leak in json-rpc runtime mock

### DIFF
--- a/testsuite/libra-fuzzer/lsan_suppressions.txt
+++ b/testsuite/libra-fuzzer/lsan_suppressions.txt
@@ -1,3 +1,4 @@
 leak:lazy_static
 leak:backtrace
 leak:libc
+leak:libra_mempool::tests::mocks::MockSharedMempool


### PR DESCRIPTION
## Motivation
Suppress the indirect mem leak in json-rpc's mempool runtime mock.

## Test Plan
Tested with local fuzzing runs.