### PR TITLE
[fuzzer] Create a fuzzer for Transation Universe

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2338,6 +2338,7 @@ dependencies = [
  "consensus-types 0.1.0",
  "datatest-stable 0.1.0",
  "hex 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "language-e2e-tests 0.1.0",
  "libra-canonical-serialization 0.1.0",
  "libra-json-rpc 0.1.0",
  "libra-proptest-helpers 0.1.0",

--- a/common/proptest-helpers/src/value_generator.rs
+++ b/common/proptest-helpers/src/value_generator.rs
@@ -3,7 +3,7 @@
 
 use proptest::{
     strategy::{Strategy, ValueTree},
-    test_runner::TestRunner,
+    test_runner::{Config, TestRng, TestRunner},
 };
 
 /// Context for generating single values out of strategies.
@@ -20,6 +20,13 @@ impl ValueGenerator {
     /// Creates a new value generator with the default RNG.
     pub fn new() -> Self {
         Default::default()
+    }
+
+    /// Creates a new value generator with provided RNG
+    pub fn new_with_rng(rng: TestRng) -> Self {
+        Self {
+            runner: TestRunner::new_with_rng(Config::default(), rng),
+        }
     }
 
     /// Creates a new value generator with a deterministic RNG.

--- a/language/e2e-tests/src/account_universe/bad_transaction.rs
+++ b/language/e2e-tests/src/account_universe/bad_transaction.rs
@@ -21,6 +21,8 @@ use move_core_types::gas_schedule::{AbstractMemorySize, GasAlgebra, GasCarrier, 
 use move_vm_types::gas_schedule::calculate_intrinsic_gas;
 use proptest::prelude::*;
 use proptest_derive::Arbitrary;
+use std::sync::Arc;
+
 /// Represents a sequence number mismatch transaction
 ///
 #[derive(Arbitrary, Clone, Debug)]
@@ -170,4 +172,12 @@ impl AUTransactionGen for InvalidAuthkeyGen {
             ),
         )
     }
+}
+
+pub fn bad_txn_strategy() -> impl Strategy<Value = Arc<dyn AUTransactionGen + 'static>> {
+    prop_oneof![
+        1 => any_with::<SequenceNumberMismatchGen>((0, 10_000)).prop_map(SequenceNumberMismatchGen::arced),
+        1 => any_with::<InvalidAuthkeyGen>(()).prop_map(InvalidAuthkeyGen::arced),
+        1 => any_with::<InsufficientBalanceGen>((1, 20_000)).prop_map(InsufficientBalanceGen::arced),
+    ]
 }

--- a/language/e2e-tests/src/account_universe/create_account.rs
+++ b/language/e2e-tests/src/account_universe/create_account.rs
@@ -16,6 +16,7 @@ use libra_types::{
 };
 use proptest::prelude::*;
 use proptest_derive::Arbitrary;
+use std::sync::Arc;
 
 /// Represents a create-account transaction performed in the account universe.
 ///
@@ -120,4 +121,16 @@ impl AUTransactionGen for CreateExistingAccountGen {
 
         (txn, (status, gas_used))
     }
+}
+
+pub fn create_account_strategy(
+    min: u64,
+    max: u64,
+) -> impl Strategy<Value = Arc<dyn AUTransactionGen + 'static>> {
+    prop_oneof![
+        3 => any_with::<CreateAccountGen>((min, max)).prop_map(CreateAccountGen::arced),
+        1 => any_with::<CreateExistingAccountGen>((min, max)).prop_map(
+            CreateExistingAccountGen::arced,
+        ),
+    ]
 }

--- a/language/e2e-tests/src/account_universe/peer_to_peer.rs
+++ b/language/e2e-tests/src/account_universe/peer_to_peer.rs
@@ -11,6 +11,7 @@ use libra_types::{
 };
 use proptest::prelude::*;
 use proptest_derive::Arbitrary;
+use std::sync::Arc;
 
 /// Represents a peer-to-peer transaction performed in the account universe.
 ///
@@ -101,4 +102,13 @@ impl AUTransactionGen for P2PTransferGen {
 
         (txn, (status, gas_used))
     }
+}
+
+pub fn p2p_strategy(
+    min: u64,
+    max: u64,
+) -> impl Strategy<Value = Arc<dyn AUTransactionGen + 'static>> {
+    prop_oneof![
+        3 => any_with::<P2PTransferGen>((min, max)).prop_map(P2PTransferGen::arced),
+    ]
 }

--- a/language/e2e-tests/src/tests/account_universe.rs
+++ b/language/e2e-tests/src/tests/account_universe.rs
@@ -7,17 +7,14 @@ mod peer_to_peer;
 mod rotate_key;
 
 use crate::{
-    account,
     account_universe::{
-        default_num_accounts, default_num_transactions, log_balance_strategy, AUTransactionGen,
-        AccountCurrent, AccountPairGen, AccountPickStyle, AccountUniverse, AccountUniverseGen,
-        RotateKeyGen,
+        all_transactions_strategy, default_num_accounts, default_num_transactions,
+        log_balance_strategy, run_and_assert_universe, AccountCurrent, AccountPairGen,
+        AccountPickStyle, AccountUniverseGen,
     },
     executor::FakeExecutor,
-    transaction_status_eq,
 };
 use proptest::{collection::vec, prelude::*};
-use std::sync::Arc;
 
 proptest! {
     // These tests are pretty slow but quite comprehensive, so run a smaller number of them.
@@ -84,122 +81,4 @@ proptest! {
 
         run_and_assert_universe(universe, transactions)?;
     }
-}
-
-/// A strategy that returns a random transaction.
-fn all_transactions_strategy(
-    min: u64,
-    max: u64,
-) -> impl Strategy<Value = Arc<dyn AUTransactionGen + 'static>> {
-    prop_oneof![
-        // Most transactions should be p2p payments.
-        8 => peer_to_peer::p2p_strategy(min, max),
-        1 => create_account::create_account_strategy(min, max),
-        1 => any::<RotateKeyGen>().prop_map(RotateKeyGen::arced),
-        1 => bad_transaction::bad_txn_strategy(),
-    ]
-}
-
-/// Run these transactions and make sure that they all cost the same amount of gas.
-pub(crate) fn run_and_assert_gas_cost_stability(
-    universe: AccountUniverseGen,
-    transaction_gens: Vec<impl AUTransactionGen + Clone>,
-) -> Result<(), TestCaseError> {
-    let mut executor = FakeExecutor::from_genesis_file();
-    let mut universe = universe.setup_gas_cost_stability(&mut executor);
-    let (transactions, expected_values): (Vec<_>, Vec<_>) = transaction_gens
-        .iter()
-        .map(|transaction_gen| transaction_gen.clone().apply(&mut universe))
-        .unzip();
-    let outputs = executor.execute_block(transactions).unwrap();
-
-    for (idx, (output, expected_value)) in outputs.iter().zip(&expected_values).enumerate() {
-        prop_assert!(
-            transaction_status_eq(output.status(), &expected_value.0),
-            "unexpected status for transaction {}",
-            idx
-        );
-        prop_assert_eq!(
-            output.gas_used(),
-            expected_value.1,
-            "transaction at idx {} did not have expected gas cost",
-            idx,
-        );
-    }
-    Ok(())
-}
-
-/// Run these transactions and verify the expected output.
-pub(crate) fn run_and_assert_universe(
-    universe: AccountUniverseGen,
-    transaction_gens: Vec<impl AUTransactionGen + Clone>,
-) -> Result<(), TestCaseError> {
-    let mut executor = FakeExecutor::from_genesis_file();
-    let mut universe = universe.setup(&mut executor);
-    let (transactions, expected_values): (Vec<_>, Vec<_>) = transaction_gens
-        .iter()
-        .map(|transaction_gen| transaction_gen.clone().apply(&mut universe))
-        .unzip();
-    let outputs = executor.execute_block(transactions).unwrap();
-
-    prop_assert_eq!(outputs.len(), expected_values.len());
-
-    for (idx, (output, expected)) in outputs.iter().zip(&expected_values).enumerate() {
-        prop_assert!(
-            transaction_status_eq(output.status(), &expected.0),
-            "unexpected status for transaction {}",
-            idx
-        );
-        executor.apply_write_set(output.write_set());
-    }
-
-    assert_accounts_match(&universe, &executor)
-}
-
-/// Verify that the account information in the universe matches the information in the executor.
-pub(crate) fn assert_accounts_match(
-    universe: &AccountUniverse,
-    executor: &FakeExecutor,
-) -> Result<(), TestCaseError> {
-    for (idx, account) in universe.accounts().iter().enumerate() {
-        let resource = executor
-            .read_account_resource(&account.account())
-            .expect("account resource must exist");
-        let resource_balance = executor
-            .read_balance_resource(account.account(), account::lbr_currency_code())
-            .expect("account balance resource must exist");
-        let auth_key = account.account().auth_key();
-        prop_assert_eq!(
-            auth_key.as_slice(),
-            resource.authentication_key(),
-            "account {} should have correct auth key",
-            idx
-        );
-        prop_assert_eq!(
-            account.balance(),
-            resource_balance.coin(),
-            "account {} should have correct balance",
-            idx
-        );
-        // XXX These two don't work at the moment because the VM doesn't bump up event counts.
-        //        prop_assert_eq!(
-        //            account.received_events_count(),
-        //            AccountResource::read_received_events_count(&resource),
-        //            "account {} should have correct received_events_count",
-        //            idx
-        //        );
-        //        prop_assert_eq!(
-        //            account.sent_events_count(),
-        //            AccountResource::read_sent_events_count(&resource),
-        //            "account {} should have correct sent_events_count",
-        //            idx
-        //        );
-        prop_assert_eq!(
-            account.sequence_number(),
-            resource.sequence_number(),
-            "account {} should have correct sequence number",
-            idx
-        );
-    }
-    Ok(())
 }

--- a/language/e2e-tests/src/tests/account_universe/bad_transaction.rs
+++ b/language/e2e-tests/src/tests/account_universe/bad_transaction.rs
@@ -1,15 +1,11 @@
 // Copyright (c) The Libra Core Contributors
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::{
-    account_universe::{
-        default_num_transactions, AUTransactionGen, AccountUniverseGen, InsufficientBalanceGen,
-        InvalidAuthkeyGen, SequenceNumberMismatchGen,
-    },
-    tests::account_universe::run_and_assert_gas_cost_stability,
+use crate::account_universe::{
+    default_num_transactions, run_and_assert_gas_cost_stability, AccountUniverseGen,
+    InsufficientBalanceGen, InvalidAuthkeyGen, SequenceNumberMismatchGen,
 };
 use proptest::{collection::vec, prelude::*};
-use std::sync::Arc;
 
 proptest! {
     // These tests are pretty slow but quite comprehensive, so run a smaller number of them.
@@ -38,12 +34,4 @@ proptest! {
     ) {
         run_and_assert_gas_cost_stability(universe, txns)?;
     }
-}
-
-pub(super) fn bad_txn_strategy() -> impl Strategy<Value = Arc<dyn AUTransactionGen + 'static>> {
-    prop_oneof![
-        1 => any_with::<SequenceNumberMismatchGen>((0, 10_000)).prop_map(SequenceNumberMismatchGen::arced),
-        1 => any_with::<InvalidAuthkeyGen>(()).prop_map(InvalidAuthkeyGen::arced),
-        1 => any_with::<InsufficientBalanceGen>((1, 20_000)).prop_map(InsufficientBalanceGen::arced),
-    ]
 }

--- a/language/e2e-tests/src/tests/account_universe/create_account.rs
+++ b/language/e2e-tests/src/tests/account_universe/create_account.rs
@@ -1,15 +1,12 @@
 // Copyright (c) The Libra Core Contributors
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::{
-    account_universe::{
-        default_num_accounts, default_num_transactions, log_balance_strategy, AUTransactionGen,
-        AccountUniverseGen, CreateAccountGen, CreateExistingAccountGen,
-    },
-    tests::account_universe::{run_and_assert_gas_cost_stability, run_and_assert_universe},
+use crate::account_universe::{
+    create_account_strategy, default_num_accounts, default_num_transactions, log_balance_strategy,
+    run_and_assert_gas_cost_stability, run_and_assert_universe, AccountUniverseGen,
+    CreateAccountGen, CreateExistingAccountGen,
 };
 use proptest::{collection::vec, prelude::*};
-use std::sync::Arc;
 
 proptest! {
     // These tests are pretty slow but quite comprehensive, so run a smaller number of them.
@@ -81,16 +78,4 @@ proptest! {
     ) {
         run_and_assert_universe(universe, transfers)?;
     }
-}
-
-pub(super) fn create_account_strategy(
-    min: u64,
-    max: u64,
-) -> impl Strategy<Value = Arc<dyn AUTransactionGen + 'static>> {
-    prop_oneof![
-        3 => any_with::<CreateAccountGen>((min, max)).prop_map(CreateAccountGen::arced),
-        1 => any_with::<CreateExistingAccountGen>((min, max)).prop_map(
-            CreateExistingAccountGen::arced,
-        ),
-    ]
 }

--- a/language/e2e-tests/src/tests/account_universe/peer_to_peer.rs
+++ b/language/e2e-tests/src/tests/account_universe/peer_to_peer.rs
@@ -1,15 +1,11 @@
 // Copyright (c) The Libra Core Contributors
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::{
-    account_universe::{
-        default_num_accounts, default_num_transactions, log_balance_strategy, AUTransactionGen,
-        AccountUniverseGen, P2PTransferGen,
-    },
-    tests::account_universe::{run_and_assert_gas_cost_stability, run_and_assert_universe},
+use crate::account_universe::{
+    default_num_accounts, default_num_transactions, log_balance_strategy, p2p_strategy,
+    run_and_assert_gas_cost_stability, run_and_assert_universe, AccountUniverseGen, P2PTransferGen,
 };
 use proptest::{collection::vec, prelude::*};
-use std::sync::Arc;
 
 proptest! {
     // These tests are pretty slow but quite comprehensive, so run a smaller number of them.
@@ -57,13 +53,4 @@ proptest! {
     ) {
         run_and_assert_universe(universe, transfers)?;
     }
-}
-
-pub(super) fn p2p_strategy(
-    min: u64,
-    max: u64,
-) -> impl Strategy<Value = Arc<dyn AUTransactionGen + 'static>> {
-    prop_oneof![
-        3 => any_with::<P2PTransferGen>((min, max)).prop_map(P2PTransferGen::arced),
-    ]
 }

--- a/language/e2e-tests/src/tests/account_universe/rotate_key.rs
+++ b/language/e2e-tests/src/tests/account_universe/rotate_key.rs
@@ -1,11 +1,9 @@
 // Copyright (c) The Libra Core Contributors
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::{
-    account_universe::{
-        default_num_accounts, default_num_transactions, AccountUniverseGen, RotateKeyGen,
-    },
-    tests::account_universe::{run_and_assert_gas_cost_stability, run_and_assert_universe},
+use crate::account_universe::{
+    default_num_accounts, default_num_transactions, run_and_assert_gas_cost_stability,
+    run_and_assert_universe, AccountUniverseGen, RotateKeyGen,
 };
 use proptest::{collection::vec, prelude::*};
 

--- a/testsuite/libra-fuzzer/Cargo.toml
+++ b/testsuite/libra-fuzzer/Cargo.toml
@@ -33,6 +33,7 @@ move-vm-types = { path = "../../language/move-vm/types", version = "0.1.0", feat
 network = { path = "../../network", version = "0.1.0", features = ["fuzzing"] }
 vm = { path = "../../language/vm", version = "0.1.0", features = ["fuzzing"] }
 libradb = { path = "../../storage/libradb", version = "0.1.0", features = ["fuzzing"] }
+language-e2e-tests = { path = "../../language/e2e-tests", version = "0.1.0" }
 
 [dev-dependencies]
 rusty-fork = "0.3.0"

--- a/testsuite/libra-fuzzer/src/fuzz_targets.rs
+++ b/testsuite/libra-fuzzer/src/fuzz_targets.rs
@@ -22,6 +22,7 @@ mod consensus_proposal;
 mod inbound_rpc_protocol;
 mod inner_signed_transaction;
 mod json_rpc_service;
+mod language_transaction_execution;
 mod network_noise_initiator;
 mod network_noise_responder;
 //mod storage_save_blocks;

--- a/testsuite/libra-fuzzer/src/fuzz_targets/language_transaction_execution.rs
+++ b/testsuite/libra-fuzzer/src/fuzz_targets/language_transaction_execution.rs
@@ -6,11 +6,7 @@ use language_e2e_tests::account_universe::{
     all_transactions_strategy, log_balance_strategy, run_and_assert_universe, AccountUniverseGen,
 };
 use libra_proptest_helpers::ValueGenerator;
-use proptest::{
-    collection::vec,
-    strategy::{Strategy, ValueTree},
-    test_runner::{self, TestRunner},
-};
+use proptest::{collection::vec, test_runner};
 use rand::RngCore;
 
 #[derive(Clone, Debug, Default)]


### PR DESCRIPTION
<!--
Thank you for sending a PR. We appreciate you spending time to help improve the Libra project.

The project is undergoing daily changes. Pull Requests will be reviewed and responded to as time permits.
-->

## Motivation

We've implemented an AccountUniverse previously that can:
1. Generate a random sets of accounts
2. Generate a random sets of transactions and execute them to see if they matches expectation, including:
    - p2p payment txn
    - mint txn
    - key rotation txn
    - invalid txn 

This PR refactors the existing code so that fuzzer can use this existing framework to generate transactions that might break the system.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?

Yes