### PR TITLE
[move-lang] replace uses of Transaction::sender

### DIFF
--- a/language/move-lang/functional-tests/tests/validator_set/register_validator.move
+++ b/language/move-lang/functional-tests/tests/validator_set/register_validator.move
@@ -5,9 +5,11 @@
 // check that the validator account config works
 script{
     use 0x0::LibraSystem;
+    use 0x0::Signer;
 
-    fun main() {
-        0x0::Transaction::assert(!LibraSystem::is_validator(0x0::Transaction::sender()), 1);
+    fun main(account: &signer) {
+        let sender = Signer::address_of(account);
+        0x0::Transaction::assert(!LibraSystem::is_validator(sender), 1);
         0x0::Transaction::assert(!LibraSystem::is_validator({{alice}}), 2);
         0x0::Transaction::assert(LibraSystem::is_validator({{vivian}}), 3);
         0x0::Transaction::assert(LibraSystem::is_validator({{viola}}), 4);
@@ -26,8 +28,9 @@ script{
     use 0x0::LibraSystem;
 
     // check that sending from validator accounts works
-    fun main() {
-        0x0::Transaction::assert(LibraSystem::is_validator(0x0::Transaction::sender()), 8);
+    fun main(account: &signer) {
+        let sender = Signer::address_of(account);
+        0x0::Transaction::assert(LibraSystem::is_validator(sender), 8);
     }
 }
 
@@ -56,25 +59,26 @@ script{
 //     use 0x0::ValidatorConfig;
 
 //     // register Alice as a validator candidate, then rotate a key + check that it worked.
-//     fun main() {
+//     fun main(account: &signer) {
+//         let sender = Signer::address_of(account);
 //         // Alice registers as a validator candidate
-//         0x0::Transaction::assert(!ValidatorConfig::is_valid(0x0::Transaction::sender()), 9);
+//         0x0::Transaction::assert(!ValidatorConfig::is_valid(sender), 9);
 //         ValidatorConfig::set_config(0xAA, x"10", x"20", x"30", x"40", x"50", x"60");
 
 //         // Rotating the consensus_pubkey should work
-//         let config = ValidatorConfig::get_config(0x0::Transaction::sender());
+//         let config = ValidatorConfig::get_config(sender);
 //         0x0::Transaction::assert(*ValidatorConfig::get_consensus_pubkey(&config) == x"10", 11);
 //         ValidatorConfig::set_consensus_pubkey(0xAA, x"70");
 //         0x0::Transaction::assert(*ValidatorConfig::get_consensus_pubkey(&config) == x"10", 12);
-//         config = ValidatorConfig::get_config(0x0::Transaction::sender());
+//         config = ValidatorConfig::get_config(sender);
 //         0x0::Transaction::assert(*ValidatorConfig::get_consensus_pubkey(&config) == x"70", 15);
 
 //         // Rotating the validator's full config
 //         ValidatorConfig::set_config(0xAA, x"70", x"80", x"90", x"100", x"110", x"120");
-//         config = ValidatorConfig::get_config(0x0::Transaction::sender());
+//         config = ValidatorConfig::get_config(sender);
 //         0x0::Transaction::assert(*ValidatorConfig::get_validator_network_identity_pubkey(&config) == x"90", 13);
 //         ValidatorConfig::set_config(0xAA, x"70", x"80", x"55", x"100", x"110", x"120");
-//         config = ValidatorConfig::get_config(0x0::Transaction::sender());
+//         config = ValidatorConfig::get_config(sender);
 //         0x0::Transaction::assert(*ValidatorConfig::get_validator_network_identity_pubkey(&config) == x"55", 14);
 //     }
 // }

--- a/language/move-lang/functional-tests/tests/validator_set/register_validator.move
+++ b/language/move-lang/functional-tests/tests/validator_set/register_validator.move
@@ -26,6 +26,7 @@ script{
 //! sender: vivian
 script{
     use 0x0::LibraSystem;
+    use 0x0::Signer;
 
     // check that sending from validator accounts works
     fun main(account: &signer) {
@@ -56,6 +57,7 @@ script{
 // //! new-transaction
 // //! sender: 0xAA
 // script{
+//     use 0x0::Signer;
 //     use 0x0::ValidatorConfig;
 
 //     // register Alice as a validator candidate, then rotate a key + check that it worked.

--- a/language/move-lang/tests/move_check/translated_ir_tests/borrow_tests/borrow_global_acquires_1.move
+++ b/language/move-lang/tests/move_check/translated_ir_tests/borrow_tests/borrow_global_acquires_1.move
@@ -1,14 +1,14 @@
 module A {
-    use 0x0::Transaction;
+    use 0x0::Signer;
     resource struct T1 {v: u64}
 
-    public fun test() acquires T1 {
-        borrow_global_mut<T1>(Transaction::sender());
-        acquires_t1();
+    public fun test(account: &signer) acquires T1 {
+        borrow_global_mut<T1>(Signer::address_of(account));
+        acquires_t1(account);
     }
 
-    fun acquires_t1() acquires T1 {
-        T1 { v: _ } = move_from<T1>(Transaction::sender());
+    fun acquires_t1(account: &signer) acquires T1 {
+        T1 { v: _ } = move_from<T1>(Signer::address_of(account));
     }
 
 }

--- a/language/move-lang/tests/move_check/translated_ir_tests/borrow_tests/borrow_global_acquires_2.move
+++ b/language/move-lang/tests/move_check/translated_ir_tests/borrow_tests/borrow_global_acquires_2.move
@@ -1,33 +1,33 @@
 module A {
-    use 0x0::Transaction;
+    use 0x0::Signer;
     resource struct T1 {v: u64}
     resource struct T2 {v: u64}
 
-    public fun test1() acquires T1, T2 {
-        let x = borrow_global_mut<T1>(Transaction::sender());
-        acquires_t2();
+    public fun test1(account: &signer) acquires T1, T2 {
+        let x = borrow_global_mut<T1>(Signer::address_of(account));
+        acquires_t2(account);
         move x;
-        acquires_t1();
+        acquires_t1(account);
     }
 
-    public fun test2() acquires T1, T2 {
-        borrow_global_mut<T1>(Transaction::sender());
-        acquires_t1();
-        acquires_t2();
+    public fun test2(account: &signer) acquires T1, T2 {
+        borrow_global_mut<T1>(Signer::address_of(account));
+        acquires_t1(account);
+        acquires_t2(account);
     }
 
-    public fun test3() acquires T1, T2 {
-        borrow_global_mut<T1>(Transaction::sender());
-        acquires_t2();
-        acquires_t1();
+    public fun test3(account: &signer) acquires T1, T2 {
+        borrow_global_mut<T1>(Signer::address_of(account));
+        acquires_t2(account);
+        acquires_t1(account);
     }
 
-    fun acquires_t1() acquires T1 {
-        T1 { v: _ } = move_from<T1>(Transaction::sender())
+    fun acquires_t1(account: &signer) acquires T1 {
+        T1 { v: _ } = move_from<T1>(Signer::address_of(account))
     }
 
-    fun acquires_t2() acquires T2 {
-        T2 { v: _ } = move_from<T2>(Transaction::sender())
+    fun acquires_t2(account: &signer) acquires T2 {
+        T2 { v: _ } = move_from<T2>(Signer::address_of(account))
     }
 
 }

--- a/language/move-lang/tests/move_check/translated_ir_tests/borrow_tests/borrow_global_acquires_3.move
+++ b/language/move-lang/tests/move_check/translated_ir_tests/borrow_tests/borrow_global_acquires_3.move
@@ -1,42 +1,42 @@
 module A {
-    use 0x0::Transaction;
+    use 0x0::Signer;
     resource struct T1 {v: u64}
     resource struct T2 {v: u64}
 
-    public fun test1() acquires T1, T2 {
-        let x = borrow_global_mut<T1>(Transaction::sender());
+    public fun test1(account: &signer) acquires T1, T2 {
+        let x = borrow_global_mut<T1>(Signer::address_of(account));
         let y = get_v(x);
-        acquires_t2();
+        acquires_t2(account);
         move y;
-        acquires_t1();
+        acquires_t1(account);
     }
 
-    public fun test2() acquires T1, T2 {
-        let x = borrow_global_mut<T1>(Transaction::sender());
+    public fun test2(account: &signer) acquires T1, T2 {
+        let x = borrow_global_mut<T1>(Signer::address_of(account));
         let y = get_v(x);
         move y;
-        acquires_t1();
-        acquires_t2();
+        acquires_t1(account);
+        acquires_t2(account);
     }
 
-    public fun test3() acquires T1, T2 {
-        let x = borrow_global_mut<T1>(Transaction::sender());
+    public fun test3(account: &signer) acquires T1, T2 {
+        let x = borrow_global_mut<T1>(Signer::address_of(account));
         let y = get_v(x);
         move y;
-        acquires_t2();
-        acquires_t1();
+        acquires_t2(account);
+        acquires_t1(account);
     }
 
     fun get_v(x: &mut T1): &mut u64 {
         &mut x.v
     }
 
-    fun acquires_t1() acquires T1 {
-        T1 { v: _ } = move_from<T1>(Transaction::sender())
+    fun acquires_t1(account: &signer) acquires T1 {
+        T1 { v: _ } = move_from<T1>(Signer::address_of(account))
     }
 
-    fun acquires_t2() acquires T2 {
-        T2 { v: _ } = move_from<T2>(Transaction::sender())
+    fun acquires_t2(account: &signer) acquires T2 {
+        T2 { v: _ } = move_from<T2>(Signer::address_of(account))
     }
 
 }

--- a/language/move-lang/tests/move_check/translated_ir_tests/borrow_tests/borrow_global_acquires_duplicate_annotation.exp
+++ b/language/move-lang/tests/move_check/translated_ir_tests/borrow_tests/borrow_global_acquires_duplicate_annotation.exp
@@ -1,11 +1,11 @@
 error: 
 
-   ┌── tests/move_check/translated_ir_tests/borrow_tests/borrow_global_acquires_duplicate_annotation.move:5:36 ───
+   ┌── tests/move_check/translated_ir_tests/borrow_tests/borrow_global_acquires_duplicate_annotation.move:5:52 ───
    │
- 5 │     public fun test() acquires T1, T1 {
-   │                                    ^^ Duplicate acquires item
+ 5 │     public fun test(account: &signer) acquires T1, T1 {
+   │                                                    ^^ Duplicate acquires item
    ·
- 5 │     public fun test() acquires T1, T1 {
-   │                                -- Previously listed here
+ 5 │     public fun test(account: &signer) acquires T1, T1 {
+   │                                                -- Previously listed here
    │
 

--- a/language/move-lang/tests/move_check/translated_ir_tests/borrow_tests/borrow_global_acquires_duplicate_annotation.move
+++ b/language/move-lang/tests/move_check/translated_ir_tests/borrow_tests/borrow_global_acquires_duplicate_annotation.move
@@ -1,9 +1,9 @@
 module A {
-    use 0x0::Transaction;
-    resource struct T1{v: u64}
+    use 0x0::Signer;
+    resource struct T1 {v: u64}
 
-    public fun test() acquires T1, T1 {
-        borrow_global_mut<T1>(Transaction::sender());
+    public fun test(account: &signer) acquires T1, T1 {
+        borrow_global_mut<T1>(Signer::address_of(account));
     }
 }
 

--- a/language/move-lang/tests/move_check/translated_ir_tests/borrow_tests/borrow_global_acquires_invalid_1.exp
+++ b/language/move-lang/tests/move_check/translated_ir_tests/borrow_tests/borrow_global_acquires_invalid_1.exp
@@ -2,10 +2,10 @@ error:
 
    ┌── tests/move_check/translated_ir_tests/borrow_tests/borrow_global_acquires_invalid_1.move:7:9 ───
    │
- 7 │         acquires_t1();
-   │         ^^^^^^^^^^^^^ Invalid acquiring of resource 'T1'
+ 7 │         acquires_t1(account);
+   │         ^^^^^^^^^^^^^^^^^^^^ Invalid acquiring of resource 'T1'
    ·
- 6 │         let x = borrow_global_mut<T1>(Transaction::sender());
-   │                 -------------------------------------------- It is still being mutably borrowed by this reference
+ 6 │         let x = borrow_global_mut<T1>(Signer::address_of(account));
+   │                 -------------------------------------------------- It is still being mutably borrowed by this reference
    │
 

--- a/language/move-lang/tests/move_check/translated_ir_tests/borrow_tests/borrow_global_acquires_invalid_1.move
+++ b/language/move-lang/tests/move_check/translated_ir_tests/borrow_tests/borrow_global_acquires_invalid_1.move
@@ -1,15 +1,15 @@
 module A {
-    use 0x0::Transaction;
+    use 0x0::Signer;
     resource struct T1 {v: u64}
 
-    public fun test() acquires T1 {
-        let x = borrow_global_mut<T1>(Transaction::sender());
-        acquires_t1();
+    public fun test(account: &signer) acquires T1 {
+        let x = borrow_global_mut<T1>(Signer::address_of(account));
+        acquires_t1(account);
         move x;
     }
 
-    fun acquires_t1() acquires T1 {
-        T1 { v: _ } = move_from<T1>(Transaction::sender());
+    fun acquires_t1(account: &signer) acquires T1 {
+        T1 { v: _ } = move_from<T1>(Signer::address_of(account));
     }
 
 }

--- a/language/move-lang/tests/move_check/translated_ir_tests/borrow_tests/borrow_global_acquires_invalid_2.exp
+++ b/language/move-lang/tests/move_check/translated_ir_tests/borrow_tests/borrow_global_acquires_invalid_2.exp
@@ -2,32 +2,32 @@ error:
 
    ┌── tests/move_check/translated_ir_tests/borrow_tests/borrow_global_acquires_invalid_2.move:9:9 ───
    │
- 9 │         acquires_t1();
-   │         ^^^^^^^^^^^^^ Invalid acquiring of resource 'T1'
+ 9 │         acquires_t1(account);
+   │         ^^^^^^^^^^^^^^^^^^^^ Invalid acquiring of resource 'T1'
    ·
- 7 │         let x = borrow_global_mut<T1>(Transaction::sender());
-   │                 -------------------------------------------- It is still being mutably borrowed by this reference
+ 7 │         let x = borrow_global_mut<T1>(Signer::address_of(account));
+   │                 -------------------------------------------------- It is still being mutably borrowed by this reference
    │
 
 error: 
 
     ┌── tests/move_check/translated_ir_tests/borrow_tests/borrow_global_acquires_invalid_2.move:16:9 ───
     │
- 16 │         acquires_t1();
-    │         ^^^^^^^^^^^^^ Invalid acquiring of resource 'T1'
+ 16 │         acquires_t1(account);
+    │         ^^^^^^^^^^^^^^^^^^^^ Invalid acquiring of resource 'T1'
     ·
- 14 │         let x = borrow_global_mut<T1>(Transaction::sender());
-    │                 -------------------------------------------- It is still being mutably borrowed by this reference
+ 14 │         let x = borrow_global_mut<T1>(Signer::address_of(account));
+    │                 -------------------------------------------------- It is still being mutably borrowed by this reference
     │
 
 error: 
 
     ┌── tests/move_check/translated_ir_tests/borrow_tests/borrow_global_acquires_invalid_2.move:22:9 ───
     │
- 22 │         acquires_t1();
-    │         ^^^^^^^^^^^^^ Invalid acquiring of resource 'T1'
+ 22 │         acquires_t1(account);
+    │         ^^^^^^^^^^^^^^^^^^^^ Invalid acquiring of resource 'T1'
     ·
- 21 │         let x = borrow_global_mut<T1>(Transaction::sender());
-    │                 -------------------------------------------- It is still being mutably borrowed by this reference
+ 21 │         let x = borrow_global_mut<T1>(Signer::address_of(account));
+    │                 -------------------------------------------------- It is still being mutably borrowed by this reference
     │
 

--- a/language/move-lang/tests/move_check/translated_ir_tests/borrow_tests/borrow_global_acquires_invalid_2.move
+++ b/language/move-lang/tests/move_check/translated_ir_tests/borrow_tests/borrow_global_acquires_invalid_2.move
@@ -1,35 +1,35 @@
 module A {
-    use 0x0::Transaction;
+    use 0x0::Signer;
     resource struct T1 {v: u64}
     resource struct T2 {v: u64}
 
-    public fun test1() acquires T1, T2 {
-        let x = borrow_global_mut<T1>(Transaction::sender());
-        acquires_t2();
-        acquires_t1();
+    public fun test1(account: &signer) acquires T1, T2 {
+        let x = borrow_global_mut<T1>(Signer::address_of(account));
+        acquires_t2(account);
+        acquires_t1(account);
         move x;
     }
 
-    public fun test2() acquires T1, T2 {
-        let x = borrow_global_mut<T1>(Transaction::sender());
-        acquires_t2();
-        acquires_t1();
+    public fun test2(account: &signer) acquires T1, T2 {
+        let x = borrow_global_mut<T1>(Signer::address_of(account));
+        acquires_t2(account);
+        acquires_t1(account);
         move x;
     }
 
-    public fun test3() acquires T1, T2 {
-        let x = borrow_global_mut<T1>(Transaction::sender());
-        acquires_t1();
+    public fun test3(account: &signer) acquires T1, T2 {
+        let x = borrow_global_mut<T1>(Signer::address_of(account));
+        acquires_t1(account);
         move x;
-        acquires_t2();
+        acquires_t2(account);
     }
 
-    fun acquires_t1() acquires T1 {
-        T1 { v: _ } = move_from<T1>(Transaction::sender());
+    fun acquires_t1(account: &signer) acquires T1 {
+        T1 { v: _ } = move_from<T1>(Signer::address_of(account));
     }
 
-    fun acquires_t2() acquires T2 {
-        T2 { v: _ } = move_from<T2>(Transaction::sender());
+    fun acquires_t2(account: &signer) acquires T2 {
+        T2 { v: _ } = move_from<T2>(Signer::address_of(account));
     }
 
 }

--- a/language/move-lang/tests/move_check/translated_ir_tests/borrow_tests/borrow_global_acquires_invalid_3.exp
+++ b/language/move-lang/tests/move_check/translated_ir_tests/borrow_tests/borrow_global_acquires_invalid_3.exp
@@ -2,8 +2,8 @@ error:
 
    ┌── tests/move_check/translated_ir_tests/borrow_tests/borrow_global_acquires_invalid_3.move:9:9 ───
    │
- 9 │         acquires_t1();
-   │         ^^^^^^^^^^^^^ Invalid acquiring of resource 'T1'
+ 9 │         acquires_t1(account);
+   │         ^^^^^^^^^^^^^^^^^^^^ Invalid acquiring of resource 'T1'
    ·
  8 │         let y = get_v(x);
    │                 -------- It is still being mutably borrowed by this reference
@@ -13,8 +13,8 @@ error:
 
     ┌── tests/move_check/translated_ir_tests/borrow_tests/borrow_global_acquires_invalid_3.move:18:9 ───
     │
- 18 │         acquires_t1();
-    │         ^^^^^^^^^^^^^ Invalid acquiring of resource 'T1'
+ 18 │         acquires_t1(account);
+    │         ^^^^^^^^^^^^^^^^^^^^ Invalid acquiring of resource 'T1'
     ·
  16 │         let y = get_v(x);
     │                 -------- It is still being mutably borrowed by this reference
@@ -24,8 +24,8 @@ error:
 
     ┌── tests/move_check/translated_ir_tests/borrow_tests/borrow_global_acquires_invalid_3.move:25:9 ───
     │
- 25 │         acquires_t1();
-    │         ^^^^^^^^^^^^^ Invalid acquiring of resource 'T1'
+ 25 │         acquires_t1(account);
+    │         ^^^^^^^^^^^^^^^^^^^^ Invalid acquiring of resource 'T1'
     ·
  24 │         let y = get_v(x);
     │                 -------- It is still being mutably borrowed by this reference

--- a/language/move-lang/tests/move_check/translated_ir_tests/borrow_tests/borrow_global_acquires_invalid_3.move
+++ b/language/move-lang/tests/move_check/translated_ir_tests/borrow_tests/borrow_global_acquires_invalid_3.move
@@ -1,42 +1,42 @@
 module A {
-    use 0x0::Transaction;
+    use 0x0::Signer;
     resource struct T1 {v: u64}
     resource struct T2 {v: u64}
 
-    public fun test1() acquires T1, T2 {
-        let x = borrow_global_mut<T1>(Transaction::sender());
+    public fun test1(account: &signer) acquires T1, T2 {
+        let x = borrow_global_mut<T1>(Signer::address_of(account));
         let y = get_v(x);
-        acquires_t1();
-        acquires_t2();
+        acquires_t1(account);
+        acquires_t2(account);
         move y;
     }
 
-    public fun test2() acquires T1, T2 {
-        let x = borrow_global_mut<T1>(Transaction::sender());
+    public fun test2(account: &signer) acquires T1, T2 {
+        let x = borrow_global_mut<T1>(Signer::address_of(account));
         let y = get_v(x);
-        acquires_t2();
-        acquires_t1();
+        acquires_t2(account);
+        acquires_t1(account);
         move y;
     }
 
-    public fun test3() acquires T1, T2 {
-        let x = borrow_global_mut<T1>(Transaction::sender());
+    public fun test3(account: &signer) acquires T1, T2 {
+        let x = borrow_global_mut<T1>(Signer::address_of(account));
         let y = get_v(x);
-        acquires_t1();
+        acquires_t1(account);
         move y;
-        acquires_t2();
+        acquires_t2(account);
     }
 
     fun get_v(x: &mut T1): &mut u64 {
         &mut x.v
     }
 
-    fun acquires_t1() acquires T1 {
-        T1 { v: _ } = move_from<T1>(Transaction::sender())
+    fun acquires_t1(account: &signer) acquires T1 {
+        T1 { v: _ } = move_from<T1>(Signer::address_of(account))
     }
 
-    fun acquires_t2() acquires T2 {
-        T2 { v: _ } = move_from<T2>(Transaction::sender())
+    fun acquires_t2(account: &signer) acquires T2 {
+        T2 { v: _ } = move_from<T2>(Signer::address_of(account))
     }
 
 }

--- a/language/move-lang/tests/move_check/translated_ir_tests/borrow_tests/borrow_global_acquires_missing_annotation.exp
+++ b/language/move-lang/tests/move_check/translated_ir_tests/borrow_tests/borrow_global_acquires_missing_annotation.exp
@@ -2,10 +2,10 @@ error:
 
    ┌── tests/move_check/translated_ir_tests/borrow_tests/borrow_global_acquires_missing_annotation.move:6:9 ───
    │
- 6 │         borrow_global_mut<T1>(Transaction::sender());
-   │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Invalid call to borrow_global_mut.
+ 6 │         borrow_global_mut<T1>(Signer::address_of(account));
+   │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Invalid call to borrow_global_mut.
    ·
- 6 │         borrow_global_mut<T1>(Transaction::sender());
+ 6 │         borrow_global_mut<T1>(Signer::address_of(account));
    │                           -- The call acquires '0x8675309::A::T1', but the 'acquires' list for the current function does not contain this type. It must be present in the calling context's acquires list
    │
 

--- a/language/move-lang/tests/move_check/translated_ir_tests/borrow_tests/borrow_global_acquires_missing_annotation.move
+++ b/language/move-lang/tests/move_check/translated_ir_tests/borrow_tests/borrow_global_acquires_missing_annotation.move
@@ -1,9 +1,9 @@
 module A {
-    use 0x0::Transaction;
-    resource struct T1{v: u64}
+    use 0x0::Signer;
+    resource struct T1 {v: u64}
 
-    public fun test() {
-        borrow_global_mut<T1>(Transaction::sender());
+    public fun test(account: &signer) {
+        borrow_global_mut<T1>(Signer::address_of(account));
     }
 
 }

--- a/language/move-lang/tests/move_check/translated_ir_tests/borrow_tests/borrow_global_acquires_return_reference_1.move
+++ b/language/move-lang/tests/move_check/translated_ir_tests/borrow_tests/borrow_global_acquires_return_reference_1.move
@@ -1,21 +1,21 @@
 module A {
-    use 0x0::Transaction;
+    use 0x0::Signer;
     resource struct T1 {v: u64}
 
-    public fun test1(x: &mut T1) acquires T1 {
+    public fun test1(account: &signer, x: &mut T1) acquires T1 {
         // the acquire of t1 does not pollute y
-        let y = borrow_acquires_t1(x);
-        acquires_t1();
+        let y = borrow_acquires_t1(account, x);
+        acquires_t1(account);
         move y;
     }
 
-    fun borrow_acquires_t1(x: &mut T1): &mut u64 acquires T1 {
-        borrow_global_mut<T1>(Transaction::sender());
+    fun borrow_acquires_t1(account: &signer, x: &mut T1): &mut u64 acquires T1 {
+        borrow_global_mut<T1>(Signer::address_of(account));
         &mut x.v
     }
 
-    fun acquires_t1() acquires T1 {
-        T1 { v:_ } = move_from<T1>(Transaction::sender())
+    fun acquires_t1(account: &signer) acquires T1 {
+        T1 { v:_ } = move_from<T1>(Signer::address_of(account))
     }
 
 }

--- a/language/move-lang/tests/move_check/translated_ir_tests/borrow_tests/borrow_global_acquires_return_reference_invalid_1.exp
+++ b/language/move-lang/tests/move_check/translated_ir_tests/borrow_tests/borrow_global_acquires_return_reference_invalid_1.exp
@@ -2,10 +2,10 @@ error:
 
     ┌── tests/move_check/translated_ir_tests/borrow_tests/borrow_global_acquires_return_reference_invalid_1.move:10:9 ───
     │
- 10 │         borrow_global_mut<T1>(Transaction::sender())
-    │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Invalid return. Resource 'T1' is still being borrowed.
+ 10 │         borrow_global_mut<T1>(Signer::address_of(account))
+    │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Invalid return. Resource 'T1' is still being borrowed.
     ·
- 10 │         borrow_global_mut<T1>(Transaction::sender())
-    │         -------------------------------------------- It is still being mutably borrowed by this reference
+ 10 │         borrow_global_mut<T1>(Signer::address_of(account))
+    │         -------------------------------------------------- It is still being mutably borrowed by this reference
     │
 

--- a/language/move-lang/tests/move_check/translated_ir_tests/borrow_tests/borrow_global_acquires_return_reference_invalid_1.move
+++ b/language/move-lang/tests/move_check/translated_ir_tests/borrow_tests/borrow_global_acquires_return_reference_invalid_1.move
@@ -1,13 +1,13 @@
 module A {
-    use 0x0::Transaction;
+    use 0x0::Signer;
     resource struct T1 {v: u64}
 
-    public fun test1() acquires T1 {
-        borrow_acquires_t1();
+    public fun test1(account: &signer) acquires T1 {
+        borrow_acquires_t1(account);
     }
 
-    fun borrow_acquires_t1(): &mut T1 acquires T1 {
-        borrow_global_mut<T1>(Transaction::sender())
+    fun borrow_acquires_t1(account: &signer): &mut T1 acquires T1 {
+        borrow_global_mut<T1>(Signer::address_of(account))
     }
 }
 

--- a/language/move-lang/tests/move_check/translated_ir_tests/borrow_tests/borrow_global_bad0.move
+++ b/language/move-lang/tests/move_check/translated_ir_tests/borrow_tests/borrow_global_bad0.move
@@ -1,9 +1,9 @@
 module A {
-    use 0x0::Transaction;
+    use 0x0::Signer;
     resource struct T {v: u64}
 
-    public fun t0() acquires T {
-        let sender = Transaction::sender();
+    public fun t0(account: &signer) acquires T {
+        let sender = Signer::address_of(account);
         let x = borrow_global_mut<T>(sender);
         copy x;
         x = borrow_global_mut<T>(sender);

--- a/language/move-lang/tests/move_check/translated_ir_tests/borrow_tests/borrow_global_bad1.exp
+++ b/language/move-lang/tests/move_check/translated_ir_tests/borrow_tests/borrow_global_bad1.exp
@@ -1,11 +1,11 @@
 error: 
 
-   ┌── tests/move_check/translated_ir_tests/borrow_tests/borrow_global_bad1.move:7:17 ───
+   ┌── tests/move_check/translated_ir_tests/borrow_tests/borrow_global_bad1.move:8:17 ───
    │
- 7 │         let y = borrow_global_mut<T>(addr);
+ 8 │         let y = borrow_global_mut<T>(addr);
    │                 ^^^^^^^^^^^^^^^^^^^^^^^^^^ Invalid borrowing of resource 'T'
    ·
- 6 │         let x = borrow_global_mut<T>(Transaction::sender());
-   │                 ------------------------------------------- It is still being mutably borrowed by this reference
+ 7 │         let x = borrow_global_mut<T>(sender);
+   │                 ---------------------------- It is still being mutably borrowed by this reference
    │
 

--- a/language/move-lang/tests/move_check/translated_ir_tests/borrow_tests/borrow_global_bad1.move
+++ b/language/move-lang/tests/move_check/translated_ir_tests/borrow_tests/borrow_global_bad1.move
@@ -1,9 +1,10 @@
 module A {
-    use 0x0::Transaction;
+    use 0x0::Signer;
     resource struct T {v: u64}
 
-    public fun A0(addr: address) acquires T {
-        let x = borrow_global_mut<T>(Transaction::sender());
+    public fun A0(account: &signer, addr: address) acquires T {
+        let sender = Signer::address_of(account);
+        let x = borrow_global_mut<T>(sender);
         let y = borrow_global_mut<T>(addr);
         x;
         y;

--- a/language/move-lang/tests/move_check/translated_ir_tests/borrow_tests/borrow_global_bad2.move
+++ b/language/move-lang/tests/move_check/translated_ir_tests/borrow_tests/borrow_global_bad2.move
@@ -1,9 +1,9 @@
 module A {
-    use 0x0::Transaction;
+    use 0x0::Signer;
     resource struct T {v: u64}
 
-    public fun A2() acquires T {
-        let sender = Transaction::sender();
+    public fun A2(account: &signer) acquires T {
+        let sender = Signer::address_of(account);
         let t_ref = borrow_global_mut<T>(sender);
         T { v: _ } = move_from<T>(sender);
         t_ref;

--- a/language/move-lang/tests/move_check/translated_ir_tests/borrow_tests/borrow_global_bad5.exp
+++ b/language/move-lang/tests/move_check/translated_ir_tests/borrow_tests/borrow_global_bad5.exp
@@ -1,11 +1,11 @@
 error: 
 
-   ┌── tests/move_check/translated_ir_tests/borrow_tests/borrow_global_bad5.move:8:22 ───
+   ┌── tests/move_check/translated_ir_tests/borrow_tests/borrow_global_bad5.move:9:22 ───
    │
- 8 │         let t2_ref = borrow_global_mut<T>(Transaction::sender());
-   │                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Invalid borrowing of resource 'T'
+ 9 │         let t2_ref = borrow_global_mut<T>(sender);
+   │                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Invalid borrowing of resource 'T'
    ·
- 7 │         let t1_ref = if (b) borrow_global_mut<T>(Transaction::sender()) else &mut t;
-   │                             ------------------------------------------- It is still being mutably borrowed by this reference
+ 8 │         let t1_ref = if (b) borrow_global_mut<T>(sender) else &mut t;
+   │                             ---------------------------- It is still being mutably borrowed by this reference
    │
 

--- a/language/move-lang/tests/move_check/translated_ir_tests/borrow_tests/borrow_global_bad5.move
+++ b/language/move-lang/tests/move_check/translated_ir_tests/borrow_tests/borrow_global_bad5.move
@@ -1,11 +1,12 @@
 module A {
-    use 0x0::Transaction;
+    use 0x0::Signer;
     resource struct T {v: u64}
 
-    public fun A5(b: bool) acquires T {
+    public fun A5(account: &signer, b: bool) acquires T {
+        let sender = Signer::address_of(account);
         let t = T { v: 0 };
-        let t1_ref = if (b) borrow_global_mut<T>(Transaction::sender()) else &mut t;
-        let t2_ref = borrow_global_mut<T>(Transaction::sender());
+        let t1_ref = if (b) borrow_global_mut<T>(sender) else &mut t;
+        let t2_ref = borrow_global_mut<T>(sender);
         t1_ref;
         t2_ref;
         T { v: _ } = t;

--- a/language/move-lang/tests/move_check/translated_ir_tests/borrow_tests/borrow_global_good.move
+++ b/language/move-lang/tests/move_check/translated_ir_tests/borrow_tests/borrow_global_good.move
@@ -1,44 +1,45 @@
 module A {
-    use 0x0::Transaction;
+    use 0x0::Signer;
     resource struct T {v: u64}
     resource struct U {v: u64}
 
-    public fun A0() acquires T {
-        let sender = Transaction::sender();
+    public fun A0(account: &signer) acquires T {
+        let sender = Signer::address_of(account);
         let t_ref = borrow_global_mut<T>(sender);
         move t_ref;
         borrow_global_mut<T>(sender);
     }
 
-    public fun A1() acquires T, U {
-        let sender = Transaction::sender();
+    public fun A1(account: &signer) acquires T, U {
+        let sender = Signer::address_of(account);
         let t_ref = borrow_global_mut<T>(sender);
         let u_ref = borrow_global_mut<U>(sender);
         t_ref;
         u_ref;
     }
 
-    public fun A2(b: bool) acquires T {
-        let sender = Transaction::sender();
+    public fun A2(account: &signer, b: bool) acquires T {
+        let sender = Signer::address_of(account);
         let t_ref = if (b) borrow_global_mut<T>(sender) else borrow_global_mut<T>(sender);
         t_ref;
     }
 
-    public fun A3(b: bool) acquires T {
-        let sender = Transaction::sender();
+    public fun A3(account: &signer, b: bool) acquires T {
+        let sender = Signer::address_of(account);
         if (b) {
             borrow_global_mut<T>(sender);
         }
     }
 
     public fun A4(account: &signer) acquires T {
-        let sender = Transaction::sender();
+        let sender = Signer::address_of(account);
         let x = move_from<T>(sender);
         borrow_global_mut<T>(sender);
         move_to<T>(account, x);
     }
 
-    public fun A5() acquires T {
-        borrow_global<T>(Transaction::sender());
+    public fun A5(account: &signer) acquires T {
+        let sender = Signer::address_of(account);
+        borrow_global<T>(sender);
     }
 }

--- a/language/move-lang/tests/move_check/translated_ir_tests/borrow_tests/imm_borrow_loc.move
+++ b/language/move-lang/tests/move_check/translated_ir_tests/borrow_tests/imm_borrow_loc.move
@@ -1,23 +1,27 @@
 module Tester {
+    use 0x0::Signer;
+
     resource struct Data { v1: u64, v2: u64 }
     resource struct Box { f: u64 }
 
     // the resource struct is here to just give a feeling why the computation might not be reorderable
-    fun bump_and_pick(b1: &mut Box, b2: &mut Box): &u64 acquires Data {
-        let data = borrow_global_mut<Data>(0x0::Transaction::sender());
+    fun bump_and_pick(account: &signer, b1: &mut Box, b2: &mut Box): &u64 acquires Data {
+        let sender = Signer::address_of(account);
+        let data = borrow_global_mut<Data>(sender);
         b1.f = data.v1;
         b2.f = data.v2;
         if (b1.f > b2.f) &b1.f else &b2.f
     }
 
     fun larger_field(account: &signer, drop: address, result: &mut u64) acquires Box, Data {
-        let b1 = move_from<Box>(0x0::Transaction::sender());
+        let sender = Signer::address_of(account);
+        let b1 = move_from<Box>(sender);
         let b2 = move_from<Box>(drop);
 
         0x0::Transaction::assert(b1.f == 0, 42);
         0x0::Transaction::assert(b2.f == 0, 42);
 
-        let returned_ref = bump_and_pick(&mut b1, &mut b2);
+        let returned_ref = bump_and_pick(account, &mut b1, &mut b2);
 
         // imagine some more interesting check than these asserts
         0x0::Transaction::assert(b1.f != 0, 42);

--- a/language/move-lang/tests/move_check/translated_ir_tests/borrow_tests/imm_borrow_loc_valid.move
+++ b/language/move-lang/tests/move_check/translated_ir_tests/borrow_tests/imm_borrow_loc_valid.move
@@ -1,23 +1,27 @@
 module Tester {
+    use 0x0::Signer;
+
     resource struct Data { v1: u64, v2: u64 }
     resource struct Box { f: u64 }
 
     // the resource struct is here to just give a feeling why the computation might not be reorderable
-    fun bump_and_pick(b1: &mut Box, b2: &mut Box): &u64 acquires Data {
-        let data = borrow_global_mut<Data>(0x0::Transaction::sender());
+    fun bump_and_pick(account: &signer, b1: &mut Box, b2: &mut Box): &u64 acquires Data {
+        let sender = Signer::address_of(account);
+        let data = borrow_global_mut<Data>(sender);
         b1.f = data.v1;
         b2.f = data.v2;
         if (b1.f > b2.f) &b1.f else &b2.f
     }
 
     fun larger_field(account: &signer, drop: address, result: &mut u64) acquires Box, Data {
-        let b1 = move_from<Box>(0x0::Transaction::sender());
+        let sender = Signer::address_of(account);
+        let b1 = move_from<Box>(sender);
         let b2 = move_from<Box>(drop);
 
         0x0::Transaction::assert(b1.f == 0, 42);
         0x0::Transaction::assert(b2.f == 0, 42);
 
-        let returned_ref = bump_and_pick(&mut b1, &mut b2);
+        let returned_ref = bump_and_pick(account, &mut b1, &mut b2);
 
         // imagine some more interesting check than these asserts
         0x0::Transaction::assert(b1.f != 0, 42);

--- a/language/move-lang/tests/move_check/translated_ir_tests/borrow_tests/imm_borrow_on_mut.move
+++ b/language/move-lang/tests/move_check/translated_ir_tests/borrow_tests/imm_borrow_on_mut.move
@@ -1,10 +1,13 @@
 module Tester {
+    use 0x0::Signer;
+
     resource struct Initializer { x: u64, y: u64 }
     struct Point { x: u64, y: u64 }
 
     // the resource struct is here to just give a feeling why the computation might not be reorderable
-    fun set_and_pick(p: &mut Point): &mut u64 acquires Initializer {
-        let init = borrow_global_mut<Initializer>(0x0::Transaction::sender());
+    fun set_and_pick(account: &signer, p: &mut Point): &mut u64 acquires Initializer {
+        let sender = Signer::address_of(account);
+        let init = borrow_global_mut<Initializer>(sender);
         p.x = init.x;
         p.y = init.y;
         if (p.x >= p.y) &mut p.x else &mut p.y
@@ -15,11 +18,11 @@ module Tester {
         freeze(u)
     }
 
-    fun larger_field(point_ref: &mut Point): &u64 acquires Initializer {
+    fun larger_field(account: &signer, point_ref: &mut Point): &u64 acquires Initializer {
         0x0::Transaction::assert(point_ref.x == 0, 42);
         0x0::Transaction::assert(point_ref.y == 0, 42);
 
-        let field_ref = set_and_pick(point_ref);
+        let field_ref = set_and_pick(account, point_ref);
         let returned_ref = bump_and_give(field_ref);
 
         // imagine some more interesting check than this assert

--- a/language/move-lang/tests/move_check/translated_ir_tests/borrow_tests/imm_borrow_on_mut_invalid.exp
+++ b/language/move-lang/tests/move_check/translated_ir_tests/borrow_tests/imm_borrow_on_mut_invalid.exp
@@ -1,22 +1,22 @@
 error: 
 
-    ┌── tests/move_check/translated_ir_tests/borrow_tests/imm_borrow_on_mut_invalid.move:22:29 ───
+    ┌── tests/move_check/translated_ir_tests/borrow_tests/imm_borrow_on_mut_invalid.move:25:29 ───
     │
- 22 │         let x_val = *freeze(&mut point_ref.x);
+ 25 │         let x_val = *freeze(&mut point_ref.x);
     │                             ^^^^^^^^^^^^^^^^ Invalid mutable borrow at field 'x'.
     ·
- 21 │         let field_ref = set_and_pick(copy point_ref);
-    │                         ---------------------------- It is still being mutably borrowed by this reference
+ 24 │         let field_ref = set_and_pick(account, copy point_ref);
+    │                         ------------------------------------- It is still being mutably borrowed by this reference
     │
 
 error: 
 
-    ┌── tests/move_check/translated_ir_tests/borrow_tests/imm_borrow_on_mut_invalid.move:36:23 ───
+    ┌── tests/move_check/translated_ir_tests/borrow_tests/imm_borrow_on_mut_invalid.move:39:23 ───
     │
- 36 │         let x_val = *&freeze(point_ref).x;
+ 39 │         let x_val = *&freeze(point_ref).x;
     │                       ^^^^^^^^^^^^^^^^^ Invalid freeze.
     ·
- 35 │         let field_ref = set_and_pick(copy point_ref);
-    │                         ---------------------------- It is still being mutably borrowed by this reference
+ 38 │         let field_ref = set_and_pick(account, copy point_ref);
+    │                         ------------------------------------- It is still being mutably borrowed by this reference
     │
 

--- a/language/move-lang/tests/move_check/translated_ir_tests/borrow_tests/imm_borrow_on_mut_invalid.move
+++ b/language/move-lang/tests/move_check/translated_ir_tests/borrow_tests/imm_borrow_on_mut_invalid.move
@@ -1,10 +1,13 @@
 module Tester {
+    use 0x0::Signer;
+
     resource struct Initializer { x: u64, y: u64 }
     struct Point { x: u64, y: u64 }
 
     // the resource struct is here to just give a feeling why the computation might not be reorderable
-    fun set_and_pick(p: &mut Point): &mut u64 acquires Initializer {
-        let init = borrow_global_mut<Initializer>(0x0::Transaction::sender());
+    fun set_and_pick(account: &signer, p: &mut Point): &mut u64 acquires Initializer {
+        let sender = Signer::address_of(account);
+        let init = borrow_global_mut<Initializer>(sender);
         p.x = init.x;
         p.y = init.y;
         if (p.x >= p.y) &mut p.x else &mut p.y
@@ -15,10 +18,10 @@ module Tester {
         freeze(u)
     }
 
-    fun larger_field_1(point_ref: &mut Point): &u64 acquires Initializer {
+    fun larger_field_1(account: &signer, point_ref: &mut Point): &u64 acquires Initializer {
         0x0::Transaction::assert(point_ref.x == 0, 42);
         0x0::Transaction::assert(point_ref.y == 0, 42);
-        let field_ref = set_and_pick(copy point_ref);
+        let field_ref = set_and_pick(account, copy point_ref);
         let x_val = *freeze(&mut point_ref.x);
         let returned_ref = bump_and_give(field_ref);
         // imagine some more interesting check than this assert
@@ -29,10 +32,10 @@ module Tester {
         returned_ref
     }
 
-    fun larger_field_2(point_ref: &mut Point): &u64 acquires Initializer {
+    fun larger_field_2(account: &signer, point_ref: &mut Point): &u64 acquires Initializer {
         0x0::Transaction::assert(point_ref.x == 0, 42);
         0x0::Transaction::assert(point_ref.y == 0, 42);
-        let field_ref = set_and_pick(copy point_ref);
+        let field_ref = set_and_pick(account, copy point_ref);
         let x_val = *&freeze(point_ref).x;
         let returned_ref = bump_and_give(field_ref);
         // imagine some more interesting check than this assert

--- a/language/move-lang/tests/move_check/translated_ir_tests/generics/instantiation_loops/recursive_struct.exp
+++ b/language/move-lang/tests/move_check/translated_ir_tests/generics/instantiation_loops/recursive_struct.exp
@@ -22,34 +22,34 @@ error:
 
 error: 
 
-    ┌── tests/move_check/translated_ir_tests/generics/instantiation_loops/recursive_struct.move:20:35 ───
+    ┌── tests/move_check/translated_ir_tests/generics/instantiation_loops/recursive_struct.move:22:35 ───
     │
- 20 │     resource struct X { y: vector<Y> }
+ 22 │     resource struct X { y: vector<Y> }
     │                                   ^ Invalid field containing 'Y' in struct 'X'.
     ·
- 20 │     resource struct X { y: vector<Y> }
+ 22 │     resource struct X { y: vector<Y> }
     │                                   - Using this struct creates a cycle: 'Y' contains 'X' contains 'Y'
     │
 
 error: 
 
-    ┌── tests/move_check/translated_ir_tests/generics/instantiation_loops/recursive_struct.move:41:8 ───
+    ┌── tests/move_check/translated_ir_tests/generics/instantiation_loops/recursive_struct.move:45:8 ───
     │
- 41 │ module M3 {
+ 45 │ module M3 {
     │        ^^ Duplicate definition for module '0x42::M3'
     ·
- 34 │ module M3 {
+ 38 │ module M3 {
     │        -- Previously defined here
     │
 
 error: 
 
-    ┌── tests/move_check/translated_ir_tests/generics/instantiation_loops/recursive_struct.move:46:26 ───
+    ┌── tests/move_check/translated_ir_tests/generics/instantiation_loops/recursive_struct.move:50:26 ───
     │
- 46 │     struct C { d: vector<D> }
+ 50 │     struct C { d: vector<D> }
     │                          ^ Invalid field containing 'D' in struct 'C'.
     ·
- 46 │     struct C { d: vector<D> }
+ 50 │     struct C { d: vector<D> }
     │                          - Using this struct creates a cycle: 'D' contains 'A' contains 'B' contains 'C' contains 'D'
     │
 

--- a/language/move-lang/tests/move_check/translated_ir_tests/generics/instantiation_loops/recursive_struct.move
+++ b/language/move-lang/tests/move_check/translated_ir_tests/generics/instantiation_loops/recursive_struct.move
@@ -17,17 +17,21 @@ module M1 {
 }
 
 module M2 {
+    use 0x0::Signer;
+
     resource struct X { y: vector<Y> }
     resource struct Y { x: vector<X> }
 
     // blows up the vm
-    public fun ex(): bool {
-        exists<X>(0x0::Transaction::sender())
+    public fun ex(account: &signer): bool {
+        let sender = Signer::address_of(account);
+        exists<X>(sender)
     }
 
     // blows up the VM
-    public fun borrow() acquires X {
-        _ = borrow_global<X>(0x0::Transaction::sender())
+    public fun borrow(account: &signer) acquires X {
+        let sender = Signer::address_of(account);
+        _ = borrow_global<X>(sender)
     }
 }
 


### PR DESCRIPTION
## Motivation

Preparing to remove support for Transaction::sender

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

Updated tests and ran them