### PR TITLE
[network][connmgr] reset both address and backoff on update

### DIFF
--- a/network/src/validator_network/network_builder.rs
+++ b/network/src/validator_network/network_builder.rs
@@ -63,7 +63,7 @@ pub const MAX_CONCURRENT_INBOUND_RPCS: u32 = 100;
 pub const PING_FAILURES_TOLERATED: u64 = 10;
 pub const MAX_CONCURRENT_NETWORK_REQS: usize = 100;
 pub const MAX_CONCURRENT_NETWORK_NOTIFS: usize = 100;
-pub const MAX_CONNECTION_DELAY_MS: u64 = 10_000;
+pub const MAX_CONNECTION_DELAY_MS: u64 = 1 * 60 * 1000; // 1 minute
 
 #[derive(Debug)]
 pub enum AuthenticationMode {

--- a/network/src/validator_network/network_builder.rs
+++ b/network/src/validator_network/network_builder.rs
@@ -63,7 +63,7 @@ pub const MAX_CONCURRENT_INBOUND_RPCS: u32 = 100;
 pub const PING_FAILURES_TOLERATED: u64 = 10;
 pub const MAX_CONCURRENT_NETWORK_REQS: usize = 100;
 pub const MAX_CONCURRENT_NETWORK_NOTIFS: usize = 100;
-pub const MAX_CONNECTION_DELAY_MS: u64 = 1 * 60 * 1000; // 1 minute
+pub const MAX_CONNECTION_DELAY_MS: u64 = 60_000; /* 1 minute */
 
 #[derive(Debug)]
 pub enum AuthenticationMode {


### PR DESCRIPTION
When receiving an updated set of address for a peer, we reset their dial
state (if we're already trying to dial them). As a result, we will begin
our next dial attempt from the first address (which might have changed)
and from a fresh backoff (since the current backoff delay might be maxed
out if we can't reach any of their previous addresses).

This change should help to mitigate some of the issues we've been having
with paritions healing very slowly (2-5 min!) when a peer has some
invalid or unreachable addresses in on-chain discovery.

This change also sets the maximum retry delay to 1 minute (up from 10
seconds prev, down from 10 minutes prev^2). 10 seconds is too aggressive
with this change and spams the logs too much. We already have logic to
reduce the max delay if we're not fully connected.