### PR TITLE
[move-prover] Upgrade Z3 and Boogie versions

### DIFF
--- a/language/move-prover/scripts/install-boogie.sh
+++ b/language/move-prover/scripts/install-boogie.sh
@@ -3,4 +3,4 @@
 # Copyright (c) The Libra Core Contributors
 # SPDX-License-Identifier: Apache-2.0
 
-dotnet tool update --global Boogie --version 2.5.7
+dotnet tool update --global Boogie --version 2.6.17

--- a/language/move-prover/scripts/install-z3.sh
+++ b/language/move-prover/scripts/install-z3.sh
@@ -3,8 +3,8 @@
 # Copyright (c) The Libra Core Contributors
 # SPDX-License-Identifier: Apache-2.0
 
-curl -LO https://github.com/Z3Prover/z3/releases/download/z3-4.8.7/z3-4.8.7-x64-osx-10.14.6.zip
-unzip z3-4.8.7-x64-osx-10.14.6.zip
-sudo cp z3-4.8.7-x64-osx-10.14.6/bin/z3 /usr/local/bin/
-rm -rf z3-4.8.7-x64-osx-10.14.6
-rm -rf z3-4.8.7-x64-osx-10.14.6.zip
+curl -LO https://github.com/Z3Prover/z3/releases/download/z3-4.8.8/z3-4.8.8-x64-osx-10.14.6.zip
+unzip z3-4.8.8-x64-osx-10.14.6.zip
+sudo cp z3-4.8.8-x64-osx-10.14.6/bin/z3 /usr/local/bin/
+rm -rf z3-4.8.8-x64-osx-10.14.6
+rm -rf z3-4.8.8-x64-osx-10.14.6.zip

--- a/language/move-prover/src/cli.rs
+++ b/language/move-prover/src/cli.rs
@@ -22,7 +22,6 @@ pub const INLINE_PRELUDE: &str = "<inline-prelude>";
 
 const DEFAULT_BOOGIE_FLAGS: &[&str] = &[
     "-doModSetAnalysis",
-    "-noinfer",
     "-printVerifiedProceduresCount:0",
     "-printModel:4",
     // Right now, we let boogie only produce one error per procedure. The boogie wrapper isn't


### PR DESCRIPTION
- Upgrade Z3 from 4.8.7 to 4.8.8
- Upgrade Boogie from 2.5.7 to 2.6.17
- Removed "-noinfer" from the default Boogie flags of Prover because it's incompatible with the latest Boogie
- Check that no baseline files need to update
- This PR resolves https://github.com/libra/libra/issues/4256

## Motivation

To upgrade Z3 and Boogie versions

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

cargo test