### PR TITLE
[cluster-test] Add --lsr-backend flag to cluster-test

### DIFF
--- a/testsuite/cluster-test/src/cluster_swarm/cluster_swarm_kube.rs
+++ b/testsuite/cluster-test/src/cluster_swarm/cluster_swarm_kube.rs
@@ -92,6 +92,7 @@ impl ClusterSwarmKube {
         num_validators: u32,
         node_name: &str,
         image_tag: &str,
+        lsr_backend: &str,
     ) -> Result<(Pod, Service)> {
         let pod_yaml = format!(
             include_str!("lsr_spec_template.yaml"),
@@ -99,6 +100,7 @@ impl ClusterSwarmKube {
             num_validators = num_validators,
             image_tag = image_tag,
             node_name = node_name,
+            lsr_backend = lsr_backend,
             cfg_seed = CFG_SEED,
         );
         let pod_spec: serde_yaml::Value = serde_yaml::from_str(&pod_yaml)?;
@@ -546,6 +548,7 @@ impl ClusterSwarmKube {
                 lsr_config.num_validators,
                 &node_name,
                 &lsr_config.image_tag,
+                &lsr_config.lsr_backend,
             )?,
         };
         match pod_api.create(&PostParams::default(), &p).await {

--- a/testsuite/cluster-test/src/cluster_swarm/lsr_spec_template.yaml
+++ b/testsuite/cluster-test/src/cluster_swarm/lsr_spec_template.yaml
@@ -22,6 +22,7 @@ spec:
         - -c
         - |
           set -x
+          if [[ {lsr_backend} = "vault" ]]; then
           while true; do
             health_out=$(wget --content-on-error -O- http://vault-{validator_index}.default.svc.cluster.local:8200/v1/sys/health)
             if [[ "$health_out" != *'"initialized":true'* ]] || [[ "$health_out" != *'"sealed":false'* ]]; then
@@ -42,7 +43,13 @@ spec:
               break
             fi
           done
-          /opt/libra/bin/config-builder safety-rules -n "{num_validators}" -g "{num_validators}" -i "{validator_index}" -s "$VALIDATOR_SEED" -o built/ --safety-rules-addr "0.0.0.0:6185" --safety-rules-backend=vault --safety-rules-host=http://vault-{validator_index}.default.svc.cluster.local:8200 --safety-rules-token=root -d /opt/libra/data
+          until [ $(kubectl get pods -l app=libra-vault | grep ^vault | grep Running | grep '2/2' | wc -l) = "{num_validators}" ]; do
+            sleep 3;
+            echo "Waiting for all vaults to be healthy";
+          done
+          echo "All vaults are healthy.."
+          fi
+          /opt/libra/bin/config-builder safety-rules -n "{num_validators}" -g "{num_validators}" -i "{validator_index}" -s "$VALIDATOR_SEED" -o built/ --safety-rules-addr "0.0.0.0:6185" --safety-rules-backend={lsr_backend} --safety-rules-host=http://vault-{validator_index}.default.svc.cluster.local:8200 --safety-rules-token=root -d /opt/libra/data
       workingDir: /opt/libra/etc
       volumeMounts:
         - name: config-built
@@ -56,12 +63,6 @@ spec:
           value: "{cfg_seed}"
         - name: RUST_BACKTRACE
           value: "1"
-      securityContext:
-        readOnlyRootFilesystem: true
-        allowPrivilegeEscalation: false
-        capabilities:
-          drop:
-            - ALL
   containers:
     - name: safety-rules
       image: 853397791086.dkr.ecr.us-west-2.amazonaws.com/libra_safety_rules:{image_tag}
@@ -72,7 +73,6 @@ spec:
       volumeMounts:
         - name: config-built
           mountPath: /opt/libra/etc
-          readOnly: true
         - name: libra-data
           mountPath: /opt/libra/data
         - name: vault-token
@@ -82,17 +82,6 @@ spec:
           value: debug
         - name: RUST_BACKTRACE
           value: "1"
-      securityContext:
-        readOnlyRootFilesystem: true
-        allowPrivilegeEscalation: false
-        capabilities:
-          drop:
-            - ALL
-  securityContext:
-    runAsNonRoot: true
-    runAsUser: 6180
-    runAsGroup: 6180
-    fsGroup: 6180
   volumes:
     - name: config-built
       emptyDir: {{}}

--- a/testsuite/cluster-test/src/cluster_swarm/mod.rs
+++ b/testsuite/cluster-test/src/cluster_swarm/mod.rs
@@ -28,24 +28,28 @@ pub trait ClusterSwarm {
         num_validators: u32,
         num_fullnodes_per_validator: u32,
         enable_lsr: bool,
+        lsr_backend: &str,
         image_tag: &str,
         config_overrides: Vec<String>,
     ) -> Result<Vec<Instance>> {
         let mut lsrs = vec![];
         if enable_lsr {
-            let mut vault_instances: Vec<_> = (0..num_validators)
-                .map(|i| {
-                    let vault_config = VaultConfig { index: i };
-                    self.spawn_new_instance(Vault(vault_config))
-                })
-                .collect();
-            lsrs.append(&mut vault_instances);
+            if lsr_backend == "vault" {
+                let mut vault_instances: Vec<_> = (0..num_validators)
+                    .map(|i| {
+                        let vault_config = VaultConfig { index: i };
+                        self.spawn_new_instance(Vault(vault_config))
+                    })
+                    .collect();
+                lsrs.append(&mut vault_instances);
+            }
             let mut lsr_instances: Vec<_> = (0..num_validators)
                 .map(|i| {
                     let lsr_config = LSRConfig {
                         index: i,
                         num_validators,
                         image_tag: image_tag.to_string(),
+                        lsr_backend: lsr_backend.to_string(),
                     };
                     self.spawn_new_instance(LSR(lsr_config))
                 })
@@ -100,6 +104,7 @@ pub trait ClusterSwarm {
         num_validators: u32,
         num_fullnodes_per_validator: u32,
         enable_lsr: bool,
+        lsr_backend: &str,
         image_tag: &str,
     ) -> Result<(Vec<Instance>, Vec<Instance>)> {
         try_join!(
@@ -107,6 +112,7 @@ pub trait ClusterSwarm {
                 num_validators,
                 num_fullnodes_per_validator,
                 enable_lsr,
+                lsr_backend,
                 image_tag,
                 vec![],
             ),

--- a/testsuite/cluster-test/src/cluster_swarm/validator_spec_template.yaml
+++ b/testsuite/cluster-test/src/cluster_swarm/validator_spec_template.yaml
@@ -104,6 +104,14 @@ spec:
         sleep 3;
         echo "Waiting for all validator pods to be scheduled";
       done
+      if [[ {enable_lsr} = true ]]; then
+        until [ $(kubectl get pods -l app=libra-lsr | grep ^lsr | grep -e Running | wc -l) = "{num_validators}" ]; do
+          sleep 3;
+          echo "Waiting for all LSRs to be healthy";
+        done
+        echo "All LSRs are healthy.."
+      fi
+
   containers:
   - name: fluent-bit
     image: 853397791086.dkr.ecr.us-west-2.amazonaws.com/fluent-bit:1.3.9

--- a/testsuite/cluster-test/src/instance.rs
+++ b/testsuite/cluster-test/src/instance.rs
@@ -34,6 +34,7 @@ pub struct LSRConfig {
     pub index: u32,
     pub num_validators: u32,
     pub image_tag: String,
+    pub lsr_backend: String,
 }
 
 #[derive(Clone, PartialEq, Eq, Hash)]


### PR DESCRIPTION
## Summary

* `--lsr-backend` lets you specify the storage backend used by LSR. Options are in-memory, on-disk, vault
* Add health check to validators to ensure all LSRs are healthy before validators start
* Add health check to LSR to ensure all vaults are healthy before LSRs start 

## Test Plan

Ran against different backends