### PR TITLE
[network] added chain-id to differentiate chains

### DIFF
--- a/config/src/chain_id.rs
+++ b/config/src/chain_id.rs
@@ -1,0 +1,18 @@
+// Copyright (c) The Libra Core Contributors
+// SPDX-License-Identifier: Apache-2.0
+use serde::{Deserialize, Serialize};
+
+#[derive(Clone, Debug, Deserialize, Eq, Hash, PartialEq, Serialize)]
+pub struct ChainId(pub String);
+
+impl Default for ChainId {
+    fn default() -> Self {
+        ChainId::new("default")
+    }
+}
+
+impl ChainId {
+    pub fn new(chain_id: &str) -> Self {
+        ChainId(chain_id.to_string())
+    }
+}

--- a/config/src/config/mod.rs
+++ b/config/src/config/mod.rs
@@ -43,7 +43,7 @@ pub use safety_rules_config::*;
 mod upstream_config;
 pub use upstream_config::*;
 mod test_config;
-use crate::network_id::NetworkId;
+use crate::{chain_id::ChainId, network_id::NetworkId};
 use libra_types::waypoint::Waypoint;
 pub use test_config::*;
 
@@ -89,6 +89,7 @@ pub struct NodeConfig {
 #[serde(default, deny_unknown_fields)]
 pub struct BaseConfig {
     data_dir: PathBuf,
+    pub chain_id: ChainId,
     pub role: RoleType,
     pub waypoint: WaypointConfig,
 }
@@ -97,6 +98,7 @@ impl Default for BaseConfig {
     fn default() -> BaseConfig {
         BaseConfig {
             data_dir: PathBuf::from("/opt/libra/data/commmon"),
+            chain_id: ChainId::default(),
             role: RoleType::Validator,
             waypoint: WaypointConfig::None,
         }

--- a/config/src/config/test_data/public_full_node.config.yaml
+++ b/config/src/config/test_data/public_full_node.config.yaml
@@ -1,4 +1,5 @@
 base:
+    chain_id: "some-test-id"
     data_dir: "/opt/libra/data/common"
     role: "full_node"
     waypoint:

--- a/config/src/config/test_data/validator.config.yaml
+++ b/config/src/config/test_data/validator.config.yaml
@@ -1,4 +1,5 @@
 base:
+    chain_id: "some-test-id"
     data_dir: "/opt/libra/data/common"
     role: "validator"
     waypoint:

--- a/config/src/config/test_data/validator_full_node.config.yaml
+++ b/config/src/config/test_data/validator_full_node.config.yaml
@@ -1,4 +1,5 @@
 base:
+    chain_id: "some-test-id"
     data_dir: "/opt/libra/data/common"
     role: "full_node"
     waypoint:

--- a/config/src/lib.rs
+++ b/config/src/lib.rs
@@ -3,6 +3,7 @@
 
 #![forbid(unsafe_code)]
 
+pub mod chain_id;
 pub mod config;
 pub mod generator;
 pub mod keys;

--- a/network/src/protocols/identity.rs
+++ b/network/src/protocols/identity.rs
@@ -49,7 +49,7 @@ mod tests {
         ProtocolId,
     };
     use futures::{executor::block_on, future::join};
-    use libra_config::network_id::NetworkId;
+    use libra_config::{chain_id::ChainId, network_id::NetworkId};
     use memsocket::MemorySocket;
 
     fn build_test_connection() -> (MemorySocket, MemorySocket) {
@@ -59,10 +59,11 @@ mod tests {
     #[test]
     fn simple_handshake() {
         let network_id = NetworkId::Validator;
+        let chain_id = ChainId::default();
         let (mut outbound, mut inbound) = build_test_connection();
 
         // Create client and server handshake messages.
-        let mut server_handshake = HandshakeMsg::new(network_id.clone());
+        let mut server_handshake = HandshakeMsg::new(chain_id.clone(), network_id.clone());
         server_handshake.add(
             MessagingProtocolVersion::V1,
             [
@@ -72,7 +73,7 @@ mod tests {
             .iter()
             .into(),
         );
-        let mut client_handshake = HandshakeMsg::new(network_id);
+        let mut client_handshake = HandshakeMsg::new(chain_id, network_id);
         client_handshake.add(
             MessagingProtocolVersion::V1,
             [ProtocolId::ConsensusRpc, ProtocolId::ConsensusDirectSend]

--- a/network/src/protocols/network/dummy.rs
+++ b/network/src/protocols/network/dummy.rs
@@ -17,7 +17,7 @@ use crate::{
 };
 use channel::message_queues::QueueStyle;
 use futures::{executor::block_on, StreamExt};
-use libra_config::{config::RoleType, network_id::NetworkId};
+use libra_config::{chain_id::ChainId, config::RoleType, network_id::NetworkId};
 use libra_crypto::{test_utils::TEST_SEED, x25519, Uniform};
 use libra_network_address::NetworkAddress;
 use libra_types::PeerId;
@@ -98,6 +98,7 @@ pub struct DummyNetwork {
 pub fn setup_network() -> DummyNetwork {
     let runtime = Runtime::new().unwrap();
     let network_id = NetworkId::Validator;
+    let chain_id = ChainId::default();
     let dialer_peer_id = PeerId::random();
     let listener_peer_id = PeerId::random();
 
@@ -125,9 +126,10 @@ pub fn setup_network() -> DummyNetwork {
     // Set up the listener network
     let mut network_builder = NetworkBuilder::new(
         runtime.handle().clone(),
+        chain_id.clone(),
         network_id.clone(),
-        listener_peer_id,
         RoleType::Validator,
+        listener_peer_id,
         listener_addr,
     );
     network_builder
@@ -140,9 +142,10 @@ pub fn setup_network() -> DummyNetwork {
     // Set up the dialer network
     let mut network_builder = NetworkBuilder::new(
         runtime.handle().clone(),
+        chain_id,
         network_id,
-        dialer_peer_id,
         RoleType::Validator,
+        dialer_peer_id,
         dialer_addr,
     );
     network_builder

--- a/network/src/protocols/wire/handshake/v1/test.rs
+++ b/network/src/protocols/wire/handshake/v1/test.rs
@@ -28,36 +28,45 @@ fn protocols_to_from_vec() {
 }
 
 #[test]
+fn represents_same_network() {
+    let network_id = NetworkId::private_network("h1");
+    let chain_id = ChainId::new("h1");
+
+    // Positive case
+    let h1 = HandshakeMsg::new(chain_id.clone(), network_id.clone());
+    let h2 = HandshakeMsg::new(chain_id.clone(), network_id.clone());
+    assert!(h1.verify(&h2));
+
+    // Negative cases
+    let h2 = HandshakeMsg::new(chain_id.clone(), NetworkId::private_network("h2"));
+    assert!(!h1.verify(&h2));
+    let h2 = HandshakeMsg::new(chain_id, NetworkId::Public);
+    assert!(!h1.verify(&h2));
+    let h2 = HandshakeMsg::new(ChainId::new("h2"), network_id);
+    assert!(!h1.verify(&h2));
+}
+
+#[test]
 fn common_protocols() {
-    let network_id = NetworkId::Validator;
-    let h1: BTreeMap<_, _> = [(
+    let network_id = NetworkId::default();
+    let chain_id = ChainId::default();
+
+    let mut h1 = HandshakeMsg::new(chain_id.clone(), network_id.clone());
+    h1.add(
         MessagingProtocolVersion::V1,
         [ProtocolId::ConsensusRpc, ProtocolId::DiscoveryDirectSend]
             .iter()
             .into(),
-    )]
-    .iter()
-    .cloned()
-    .collect();
-    let h1 = HandshakeMsg {
-        network_id: network_id.clone(),
-        supported_protocols: h1,
-    };
+    );
 
     // Case 1: One intersecting protocol is found for common messaging protocol version.
-    let h2: BTreeMap<_, _> = [(
+    let mut h2 = HandshakeMsg::new(chain_id.clone(), network_id.clone());
+    h2.add(
         MessagingProtocolVersion::V1,
         [ProtocolId::ConsensusRpc, ProtocolId::MempoolDirectSend]
             .iter()
             .into(),
-    )]
-    .iter()
-    .cloned()
-    .collect();
-    let h2 = HandshakeMsg {
-        network_id: network_id.clone(),
-        supported_protocols: h2,
-    };
+    );
     assert_eq!(
         Some((
             MessagingProtocolVersion::V1,
@@ -70,18 +79,13 @@ fn common_protocols() {
     let h2 = HandshakeMsg {
         network_id: network_id.clone(),
         supported_protocols: BTreeMap::default(),
+        chain_id: chain_id.clone(),
     };
     assert_eq!(None, h1.find_common_protocols(&h2));
 
     // Case 3: Intersecting messaging protocol version is present, but no intersecting protocols.
-    let h2: BTreeMap<_, _> = [(MessagingProtocolVersion::V1, SupportedProtocols::default())]
-        .iter()
-        .cloned()
-        .collect();
-    let h2 = HandshakeMsg {
-        network_id,
-        supported_protocols: h2,
-    };
+    let mut h2 = HandshakeMsg::new(chain_id, network_id);
+    h2.add(MessagingProtocolVersion::V1, SupportedProtocols::default());
     assert_eq!(
         Some((MessagingProtocolVersion::V1, [].iter().into())),
         h1.find_common_protocols(&h2)

--- a/state-synchronizer/src/tests/integration_tests.rs
+++ b/state-synchronizer/src/tests/integration_tests.rs
@@ -9,6 +9,7 @@ use anyhow::{bail, Result};
 use executor_types::ExecutedTrees;
 use futures::executor::block_on;
 use libra_config::{
+    chain_id::ChainId,
     config::{PeerNetworkId, RoleType},
     network_id::NetworkId,
 };
@@ -253,9 +254,10 @@ impl SynchronizerEnv {
         }
         let mut network_builder = NetworkBuilder::new(
             self.runtime.handle().clone(),
+            ChainId::default(),
             self.network_id.clone(),
-            self.peer_ids[new_peer_idx],
             RoleType::Validator,
+            self.peer_ids[new_peer_idx],
             addr,
         );
         network_builder

--- a/testsuite/generate-format/tests/staged/network.yaml
+++ b/testsuite/generate-format/tests/staged/network.yaml
@@ -28,12 +28,16 @@ HandshakeMsg:
             TYPENAME: MessagingProtocolVersion
           VALUE:
             TYPENAME: SupportedProtocols
+    - chain_id:
+        TYPENAME: ChainId
     - network_id:
         TYPENAME: NetworkId
 MessagingProtocolVersion:
   ENUM:
     0:
       V1: UNIT
+ChainId:
+  NEWTYPESTRUCT: STR
 NetworkAddress:
   NEWTYPESTRUCT:
     SEQ:


### PR DESCRIPTION
The chain-id is to differentiate between different blockchains, and is
enforced at the handshake level similar to network-id.
