### PR TITLE
[json-rpc] Add the rough to_lbr exchange rate to the CurrencyInfoView

### DIFF
--- a/json-rpc/types/src/views.rs
+++ b/json-rpc/types/src/views.rs
@@ -498,6 +498,7 @@ pub struct CurrencyInfoView {
     pub code: String,
     pub scaling_factor: u64,
     pub fractional_part: u64,
+    pub to_lbr_exchange_rate: f32,
 }
 
 impl From<CurrencyInfoResource> for CurrencyInfoView {
@@ -506,6 +507,7 @@ impl From<CurrencyInfoResource> for CurrencyInfoView {
             code: info.currency_code().to_string(),
             scaling_factor: info.scaling_factor(),
             fractional_part: info.fractional_part(),
+            to_lbr_exchange_rate: info.exchange_rate(),
         }
     }
 }

--- a/types/src/account_config/resources/currency_info.rs
+++ b/types/src/account_config/resources/currency_info.rs
@@ -52,10 +52,17 @@ impl CurrencyInfoResource {
         self.fractional_part
     }
 
+    pub fn exchange_rate(&self) -> f32 {
+        // Exchange rates are represented as 32|32 fixed-point numbers on-chain. So we divide by the scaling
+        // factor (2^32) of the number to arrive at the floating point representation of the number.
+        // The exchange rate returned is the on-chain rate to two decimal places rounded up (e.g. 1.3333
+        // would be rounded to 1.34).
+        let unrounded = (self.to_lbr_exchange_rate as f32) / 2f32.powf(32f32);
+        (unrounded * 100.0).round() / 100.0
+    }
+
     pub fn convert_to_lbr(&self, amount: u64) -> u64 {
-        let mut mult = (amount as u128) * (self.to_lbr_exchange_rate as u128);
-        mult >>= 32;
-        mult as u64
+        (self.exchange_rate() * (amount as f32)) as u64
     }
 
     pub fn struct_tag_for(currency_code: Identifier) -> StructTag {


### PR DESCRIPTION
Adds the rough to_lbr exchange rate to the `CurrencyInfoView` in JSON-RPC. 

Sample output:
```
❯ curl -X POST -H "Content-Type: application/json" --data '{"jsonrpc":"2.0", "method":"get_currencies","params":[],"id":1}' 127.0.0.1:55379
{
   "id":1,
   "jsonrpc":"2.0",
   "result":[
      {
         "code":"Coin1",
         "fractional_part":100,
         "scaling_factor":1000000,
         "to_lbr_exchange_rate":0.5
      },
      {
         "code":"Coin2",
         "fractional_part":100,
         "scaling_factor":1000000,
         "to_lbr_exchange_rate":0.5
      },
      {
         "code":"LBR",
         "fractional_part":1000,
         "scaling_factor":1000000,
         "to_lbr_exchange_rate":1.0
      }
   ]
}%
```