### PR TITLE
[network] Add a config to Discovery

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3362,6 +3362,7 @@ dependencies = [
  "channel 0.1.0",
  "criterion 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "futures-util 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "hex 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "libra-bitvec 0.1.0",
  "libra-canonical-serialization 0.1.0",

--- a/network/Cargo.toml
+++ b/network/Cargo.toml
@@ -13,6 +13,7 @@ edition = "2018"
 anyhow = "1.0.31"
 bytes = { version = "0.5.4", features = ["serde"] }
 futures = "0.3.5"
+futures-util = "0.3.5"
 hex = "0.4.2"
 once_cell = "1.4.0"
 pin-project = "0.4.20"

--- a/network/src/protocols/discovery/mod.rs
+++ b/network/src/protocols/discovery/mod.rs
@@ -469,6 +469,9 @@ pub struct DiscoveryBuilderConfig {
     network_context: NetworkContext,
     self_addrs: Vec<NetworkAddress>,
     discovery_interval_ms: u64,
+    network_reqs_tx: DiscoveryNetworkSender,
+    network_notifs_rx: DiscoveryNetworkEvents,
+    conn_mgr_reqs_tx: channel::Sender<ConnectivityRequest>,
 }
 
 impl DiscoveryBuilderConfig {
@@ -476,11 +479,17 @@ impl DiscoveryBuilderConfig {
         network_context: NetworkContext,
         self_addrs: Vec<NetworkAddress>,
         discovery_interval_ms: u64,
+        network_reqs_tx: DiscoveryNetworkSender,
+        network_notifs_rx: DiscoveryNetworkEvents,
+        conn_mgr_reqs_tx: channel::Sender<ConnectivityRequest>,
     ) -> Self {
         Self {
             network_context,
             self_addrs,
             discovery_interval_ms,
+            network_reqs_tx,
+            network_notifs_rx,
+            conn_mgr_reqs_tx,
         }
     }
 }
@@ -491,18 +500,15 @@ pub type DiscoveryService = Discovery<Fuse<Interval>>;
 pub fn build_discovery_from_config(
     executor: &Handle,
     config: DiscoveryBuilderConfig,
-    network_reqs_tx: DiscoveryNetworkSender,
-    network_notifs_rx: DiscoveryNetworkEvents,
-    conn_mgr_reqs_tx: channel::Sender<ConnectivityRequest>,
 ) -> DiscoveryService {
     executor.enter(|| {
         Discovery::new(
             config.network_context,
             config.self_addrs,
             interval(Duration::from_millis(config.discovery_interval_ms)).fuse(),
-            network_reqs_tx,
-            network_notifs_rx,
-            conn_mgr_reqs_tx,
+            config.network_reqs_tx,
+            config.network_notifs_rx,
+            config.conn_mgr_reqs_tx,
         )
     })
 }

--- a/network/src/validator_network/network_builder.rs
+++ b/network/src/validator_network/network_builder.rs
@@ -17,7 +17,7 @@ use crate::{
         PeerManagerNotification, PeerManagerRequest, PeerManagerRequestSender,
     },
     protocols::{
-        discovery::{self, Discovery},
+        discovery::{self, DiscoveryBuilderConfig},
         health_checker::{self, HealthChecker},
         wire::handshake::v1::SupportedProtocols,
     },
@@ -361,16 +361,15 @@ impl NetworkBuilder {
 
         let addrs = vec![advertised_address];
         let discovery_interval_ms = self.discovery_interval_ms;
-        let discovery = self.executor.enter(|| {
-            Discovery::new(
-                self.network_context.clone(),
-                addrs,
-                interval(Duration::from_millis(discovery_interval_ms)).fuse(),
-                discovery_network_tx,
-                discovery_network_rx,
-                conn_mgr_reqs_tx,
-            )
-        });
+        let discovery_cfg =
+            DiscoveryBuilderConfig::new(self.network_context.clone(), addrs, discovery_interval_ms);
+        let discovery = discovery::build_discovery_from_config(
+            &self.executor,
+            discovery_cfg,
+            discovery_network_tx,
+            discovery_network_rx,
+            conn_mgr_reqs_tx,
+        );
         self.executor.spawn(discovery.start());
         debug!("{} Started discovery protocol actor", self.network_context);
         self


### PR DESCRIPTION
Adds an internal config to the Discovery service for use in construction.  Preliminary step towards enabling a config/build/start process in network-builder

<!--
Thank you for sending a PR. We appreciate you spending time to help improve the Libra project.

The project is undergoing daily changes. Pull Requests will be reviewed and responded to as time permits.
-->

## Motivation

Add a configuration struct to the (Gossip) Discovery service.

This change is one part cleanup to simplify the construction of Discovery and one part preparation for cleaning up network_builder and transitioning it into a clean phased configure/build/start process.


### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?

yes
## Test Plan

don't break existing unit and integration tests.

## Related PRs

