### PR TITLE
[network] Add a HealthCheckerConfig

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3362,6 +3362,7 @@ dependencies = [
  "channel 0.1.0",
  "criterion 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "futures-util 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "hex 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "libra-bitvec 0.1.0",
  "libra-canonical-serialization 0.1.0",

--- a/network/Cargo.toml
+++ b/network/Cargo.toml
@@ -13,6 +13,7 @@ edition = "2018"
 anyhow = "1.0.31"
 bytes = { version = "0.5.4", features = ["serde"] }
 futures = "0.3.5"
+futures-util = "0.3.5"
 hex = "0.4.2"
 once_cell = "1.4.0"
 pin-project = "0.4.20"

--- a/network/src/protocols/health_checker/mod.rs
+++ b/network/src/protocols/health_checker/mod.rs
@@ -401,6 +401,8 @@ pub struct HealthCheckerBuilderConfig {
     ping_interval_ms: u64,
     ping_timeout_ms: u64,
     ping_failures_tolerated: u64,
+    network_tx: HealthCheckerNetworkSender,
+    network_rx: HealthCheckerNetworkEvents,
 }
 
 impl HealthCheckerBuilderConfig {
@@ -409,31 +411,33 @@ impl HealthCheckerBuilderConfig {
         ping_interval_ms: u64,
         ping_timeout_ms: u64,
         ping_failures_tolerated: u64,
+        network_tx: HealthCheckerNetworkSender,
+        network_rx: HealthCheckerNetworkEvents,
     ) -> Self {
         Self {
             network_context,
             ping_interval_ms,
             ping_timeout_ms,
             ping_failures_tolerated,
+            network_tx,
+            network_rx,
         }
     }
 }
 
-type HealthCheckerService = HealthChecker<Fuse<Interval>>;
+pub type HealthCheckerService = HealthChecker<Fuse<Interval>>;
 
 /// Build a HealthChecker service from the provided HealthCheckerBuilderConfig.
 pub fn build_health_checker_from_config(
     executor: &Handle,
     config: HealthCheckerBuilderConfig,
-    network_tx: HealthCheckerNetworkSender,
-    network_rx: HealthCheckerNetworkEvents,
 ) -> HealthCheckerService {
     executor.enter(|| {
         HealthChecker::new(
             config.network_context,
             interval(Duration::from_millis(config.ping_interval_ms)).fuse(),
-            network_tx,
-            network_rx,
+            config.network_tx,
+            config.network_rx,
             Duration::from_millis(config.ping_timeout_ms),
             config.ping_failures_tolerated,
         )

--- a/network/src/protocols/health_checker/mod.rs
+++ b/network/src/protocols/health_checker/mod.rs
@@ -34,6 +34,7 @@ use futures::{
     channel::oneshot,
     stream::{FusedStream, FuturesUnordered, Stream, StreamExt},
 };
+use futures_util::stream::Fuse;
 use libra_config::network_id::NetworkContext;
 use libra_logger::prelude::*;
 use libra_security_logger::{security_log, SecurityEvent};
@@ -41,6 +42,10 @@ use libra_types::PeerId;
 use rand::{rngs::SmallRng, seq::SliceRandom, Rng, SeedableRng};
 use serde::{Deserialize, Serialize};
 use std::{collections::HashMap, time::Duration};
+use tokio::{
+    runtime::Handle,
+    time::{interval, Interval},
+};
 
 #[cfg(test)]
 mod test;
@@ -388,4 +393,49 @@ where
     fn sample_nonce(&mut self) -> u32 {
         self.rng.gen::<u32>()
     }
+}
+
+/// Configuration for a HealthCheckerBuilder.
+pub struct HealthCheckerBuilderConfig {
+    network_context: NetworkContext,
+    ping_interval_ms: u64,
+    ping_timeout_ms: u64,
+    ping_failures_tolerated: u64,
+}
+
+impl HealthCheckerBuilderConfig {
+    pub fn new(
+        network_context: NetworkContext,
+        ping_interval_ms: u64,
+        ping_timeout_ms: u64,
+        ping_failures_tolerated: u64,
+    ) -> Self {
+        Self {
+            network_context,
+            ping_interval_ms,
+            ping_timeout_ms,
+            ping_failures_tolerated,
+        }
+    }
+}
+
+type HealthCheckerService = HealthChecker<Fuse<Interval>>;
+
+/// Build a HealthChecker service from the provided HealthCheckerBuilderConfig.
+pub fn build_health_checker_from_config(
+    executor: &Handle,
+    config: HealthCheckerBuilderConfig,
+    network_tx: HealthCheckerNetworkSender,
+    network_rx: HealthCheckerNetworkEvents,
+) -> HealthCheckerService {
+    executor.enter(|| {
+        HealthChecker::new(
+            config.network_context,
+            interval(Duration::from_millis(config.ping_interval_ms)).fuse(),
+            network_tx,
+            network_rx,
+            Duration::from_millis(config.ping_timeout_ms),
+            config.ping_failures_tolerated,
+        )
+    })
 }

--- a/network/src/validator_network/network_builder.rs
+++ b/network/src/validator_network/network_builder.rs
@@ -18,7 +18,7 @@ use crate::{
     },
     protocols::{
         discovery::{self, Discovery},
-        health_checker::{self, HealthChecker},
+        health_checker::{self, HealthCheckerBuilderConfig},
         wire::handshake::v1::SupportedProtocols,
     },
     transport::{self, Connection, LibraNetTransport, LIBRA_TCP_TRANSPORT},
@@ -379,19 +379,18 @@ impl NetworkBuilder {
     pub fn add_connection_monitoring(&mut self) -> &mut Self {
         // Initialize and start HealthChecker.
         let (hc_network_tx, hc_network_rx) = health_checker::add_to_network(self);
-        let ping_interval_ms = self.ping_interval_ms;
-        let ping_timeout_ms = self.ping_timeout_ms;
-        let ping_failures_tolerated = self.ping_failures_tolerated;
-        let health_checker = self.executor.enter(|| {
-            HealthChecker::new(
-                self.network_context.clone(),
-                interval(Duration::from_millis(ping_interval_ms)).fuse(),
-                hc_network_tx,
-                hc_network_rx,
-                Duration::from_millis(ping_timeout_ms),
-                ping_failures_tolerated,
-            )
-        });
+        let health_checker_config = HealthCheckerBuilderConfig::new(
+            self.network_context.clone(),
+            self.ping_interval_ms,
+            self.ping_timeout_ms,
+            self.ping_failures_tolerated,
+        );
+        let health_checker = health_checker::build_health_checker_from_config(
+            &self.executor,
+            health_checker_config,
+            hc_network_tx,
+            hc_network_rx,
+        );
         self.executor.spawn(health_checker.start());
         debug!("{} Started health checker", self.network_context);
         self


### PR DESCRIPTION
This change is part cosmetic cleanup and part preparation for refactoring network-builder into a clean configure/build/start phased process.

<!--
Thank you for sending a PR. We appreciate you spending time to help improve the Libra project.

The project is undergoing daily changes. Pull Requests will be reviewed and responded to as time permits.
-->

## Motivation

Add a configuration struct to the HealthChecker service.

This change is one part cleanup to simplify the construction of HealthChecker and one part preparation for cleaning up network_builder and transitioning it into a clean phased configure/build/start process.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

Don't break existing tests

## Related PRs

(If this PR adds or changes functionality, please take some time to update the docs at https://github.com/libra/website, and link to your PR here.)
