### PR TITLE
[network] Add a builder configuration for connectivity manager.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3362,6 +3362,7 @@ dependencies = [
  "channel 0.1.0",
  "criterion 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "futures-util 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "hex 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "libra-bitvec 0.1.0",
  "libra-canonical-serialization 0.1.0",

--- a/network/Cargo.toml
+++ b/network/Cargo.toml
@@ -13,6 +13,7 @@ edition = "2018"
 anyhow = "1.0.31"
 bytes = { version = "0.5.4", features = ["serde"] }
 futures = "0.3.5"
+futures-util = "0.3.5"
 hex = "0.4.2"
 once_cell = "1.4.0"
 pin-project = "0.4.20"

--- a/network/src/connectivity_manager/mod.rs
+++ b/network/src/connectivity_manager/mod.rs
@@ -33,6 +33,7 @@ use futures::{
     future::{BoxFuture, FutureExt},
     stream::{FusedStream, FuturesUnordered, Stream, StreamExt},
 };
+use futures_util::stream::Fuse;
 use libra_config::network_id::NetworkContext;
 use libra_crypto::x25519;
 use libra_logger::prelude::*;
@@ -46,7 +47,12 @@ use std::{
     sync::{Arc, RwLock},
     time::{Duration, Instant},
 };
-use tokio::time;
+use tokio::{
+    runtime::Handle,
+    time,
+    time::{interval, Interval},
+};
+use tokio_retry::strategy::ExponentialBackoff;
 
 #[cfg(test)]
 mod test;
@@ -632,4 +638,64 @@ where
     fn next_backoff_delay(&mut self, max_delay: Duration) -> Duration {
         min(max_delay, self.backoff.next().unwrap_or(max_delay))
     }
+}
+
+/// The configuration fields for ConnectivityManager
+pub struct ConnectivityManagerBuilderConfig {
+    network_context: NetworkContext,
+    eligible: Arc<RwLock<HashMap<PeerId, x25519::PublicKey>>>,
+    seed_peers: HashMap<PeerId, Vec<NetworkAddress>>,
+    connectivity_check_interval_ms: u64,
+    backoff_base: u64,
+    max_connection_delay_ms: u64,
+    connection_reqs_tx: ConnectionRequestSender,
+    connection_notifs_rx: conn_notifs_channel::Receiver,
+    requests_rx: channel::Receiver<ConnectivityRequest>,
+}
+
+impl ConnectivityManagerBuilderConfig {
+    pub fn new(
+        network_context: NetworkContext,
+        eligible: Arc<RwLock<HashMap<PeerId, x25519::PublicKey>>>,
+        seed_peers: HashMap<PeerId, Vec<NetworkAddress>>,
+        connectivity_check_interval_ms: u64,
+        backoff_base: u64,
+        max_connection_delay_ms: u64,
+        connection_reqs_tx: ConnectionRequestSender,
+        connection_notifs_rx: conn_notifs_channel::Receiver,
+        requests_rx: channel::Receiver<ConnectivityRequest>,
+    ) -> Self {
+        Self {
+            network_context,
+            eligible,
+            seed_peers,
+            connectivity_check_interval_ms,
+            backoff_base,
+            max_connection_delay_ms,
+            connection_reqs_tx,
+            connection_notifs_rx,
+            requests_rx,
+        }
+    }
+}
+
+pub type ConnectivityManagerService = ConnectivityManager<Fuse<Interval>, ExponentialBackoff>;
+
+pub fn build_connectivity_manager_from_config(
+    executor: &Handle,
+    config: ConnectivityManagerBuilderConfig,
+) -> ConnectivityManagerService {
+    executor.enter(|| {
+        ConnectivityManager::new(
+            config.network_context,
+            config.eligible,
+            config.seed_peers,
+            interval(Duration::from_millis(config.connectivity_check_interval_ms)).fuse(),
+            config.connection_reqs_tx,
+            config.connection_notifs_rx,
+            config.requests_rx,
+            ExponentialBackoff::from_millis(config.backoff_base).factor(1000),
+            config.max_connection_delay_ms,
+        )
+    })
 }


### PR DESCRIPTION
This is a mild cosmetic cleanup within connectivity manager and a significant piece of preparatory work for transitioning network-builder into a staged configure/build/start process.

<!--
Thank you for sending a PR. We appreciate you spending time to help improve the Libra project.

The project is undergoing daily changes. Pull Requests will be reviewed and responded to as time permits.
-->

## Motivation

Add.a builder configuration  to ConnectivityManager.  

This change is one part cleanup to simplify the construction of ConnectivityManager and one part preparation for cleaning up network_builder and transitioning it into a clean phased configure/build/start process.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

dont break existing tests

## Related PRs

(If this PR adds or changes functionality, please take some time to update the docs at https://github.com/libra/website, and link to your PR here.)
