### PR TITLE
[cluster_test] Convert all code in main.rs to async code

### DIFF
--- a/testsuite/cluster-test/src/experiments/mod.rs
+++ b/testsuite/cluster-test/src/experiments/mod.rs
@@ -58,6 +58,8 @@ pub struct Context<'a> {
     pub global_emit_job_request: &'a mut Option<EmitJobRequest>,
     pub emit_to_validator: bool,
     pub cluster_swarm: &'a ClusterSwarmKube,
+    /// Current docker image tag used by this run
+    pub current_tag: &'a str,
 }
 
 impl<'a> Context<'a> {
@@ -70,6 +72,7 @@ impl<'a> Context<'a> {
         emit_job_request: &'a mut Option<EmitJobRequest>,
         emit_to_validator: bool,
         cluster_swarm: &'a ClusterSwarmKube,
+        current_tag: &'a str,
     ) -> Self {
         Context {
             tx_emitter,
@@ -80,6 +83,7 @@ impl<'a> Context<'a> {
             global_emit_job_request: emit_job_request,
             emit_to_validator,
             cluster_swarm,
+            current_tag,
         }
     }
 }

--- a/testsuite/cluster-test/src/health/debug_interface_log_tail.rs
+++ b/testsuite/cluster-test/src/health/debug_interface_log_tail.rs
@@ -20,7 +20,7 @@ use std::{
     },
     time::Duration,
 };
-use tokio::{runtime::Runtime, time};
+use tokio::{runtime::Handle, time};
 
 pub struct DebugPortLogWorker {
     instance: Instance,
@@ -33,7 +33,8 @@ pub struct DebugPortLogWorker {
 }
 
 impl DebugPortLogWorker {
-    pub fn spawn_new(cluster: &Cluster, runtime: &Runtime) -> (LogTail, TraceTail) {
+    pub fn spawn_new(cluster: &Cluster) -> (LogTail, TraceTail) {
+        let runtime = Handle::current();
         let (event_sender, event_receiver) = mpsc::channel();
         let mut started_receivers = vec![];
         let pending_messages = Arc::new(AtomicI64::new(0));


### PR DESCRIPTION
main.rs was a strange mix of sync and async code.
At this point it actually becoming hard to read and reason about it, plus some functions like run_single_experiment became too complex because of this mix

This diff cleans this up - main function is now async tokio::main and everything else is async
