### PR TITLE
[tf][roar] override safetyrules tags separately

### DIFF
--- a/devtools/compat/record_and_replay.py
+++ b/devtools/compat/record_and_replay.py
@@ -14,24 +14,25 @@ from subprocess import check_call, check_output, DEVNULL, CalledProcessError
 from pyhelpers.cli import execute_cmd_with_text_output, execute_cmd_with_json_output
 from pyhelpers.aws import list_tasks, describe_tasks
 
+
 def gen_tf_var_str(var_name: str, val: str) -> str:
     return f'{var_name} = "{val}"'
 
 
 def gen_tf_var_list(var_name: str, vals: list) -> str:
-    list_str = ','.join(f'"{v}"' for v in vals)
-    return f'{var_name} = [{list_str}]'
+    list_str = ",".join(f'"{v}"' for v in vals)
+    return f"{var_name} = [{list_str}]"
 
 
 parser = argparse.ArgumentParser(
-    description='Record state from a terraform workspace for replay in another.')
+    description="Record state from a terraform workspace for replay in another."
+)
 
-parser.add_argument('--source', '-s', required=True, help='source workspace')
-parser.add_argument('--tf-dir', '-t', required=True,
-                    help='terraform directory')
+parser.add_argument("--source", "-s", required=True, help="source workspace")
+parser.add_argument("--tf-dir", "-t", required=True, help="terraform directory")
 
-parser.add_argument('--var-file', '-f', help='terraform tfvars file to extend')
-parser.add_argument('--out-file', '-o', help='name of output tfvars file')
+parser.add_argument("--var-file", "-f", help="terraform tfvars file to extend")
+parser.add_argument("--out-file", "-o", help="name of output tfvars file")
 
 args = parser.parse_args()
 
@@ -42,55 +43,54 @@ print(f"Searching workspaces in {tf_dir}")
 # check if source exists
 
 try:
-    check_call(['terraform', 'workspace', 'select', args.source], cwd=tf_dir, stdout=DEVNULL, stderr=DEVNULL)
+    check_call(
+        ["terraform", "workspace", "select", args.source],
+        cwd=tf_dir,
+        stdout=DEVNULL,
+        stderr=DEVNULL,
+    )
 except CalledProcessError:
-    print(f"ERROR: Could not find source workspace \"{args.source}\". Is it initialized?")
+    print(f'ERROR: Could not find source workspace "{args.source}". Is it initialized?')
     raise
 
-print(f"Using source workspace \"{args.source}\"")
+print(f'Using source workspace "{args.source}"')
 
 # get source state with terraform show
 out = execute_cmd_with_json_output(
-    ['terraform', 'show', '-json'],
-    tf_dir,
-    "could not read info from terraform"
+    ["terraform", "show", "-json"], tf_dir, "could not read info from terraform"
 )
 
 # get resources of importance
 validators = []
 fullnodes = []
-validators_ecs = []
-for res in out.get('values').get('root_module').get('resources'):
-    addr = res.get('address')
-    if 'aws_instance.validator' in addr:
+for res in out.get("values").get("root_module").get("resources"):
+    addr = res.get("address")
+    if "aws_instance.validator" in addr:
         validators.append(res)
-    elif 'aws_instance.fullnode' in addr:
+    elif "aws_instance.fullnode" in addr:
         fullnodes.append(res)
-    elif 'ecs_task_definition.validator' in addr:
-        validators_ecs.append(res)
 
 
 # terraform show not guaranteed to be sorted
-list.sort(validators, key=lambda x: x.get('index'))
-list.sort(fullnodes, key=lambda x: x.get('index'))
-list.sort(validators_ecs, key=lambda x: x.get('index'))
+list.sort(validators, key=lambda x: x.get("index"))
+list.sort(fullnodes, key=lambda x: x.get("index"))
 
 
 # parse validators
 validator_ips = []
 validator_restore_vols = []
 for validator in validators:
-    vals = validator.get('values')
-    validator_ips.append(vals.get('private_ip'))
-    for vol in vals.get('ebs_block_device'):
-        if vol.get('device_name') == '/dev/xvdb':
-            validator_restore_vols.append(vol.get('volume_id'))
+    vals = validator.get("values")
+    validator_ips.append(vals.get("private_ip"))
+    for vol in vals.get("ebs_block_device"):
+        if vol.get("device_name") == "/dev/xvdb":
+            validator_restore_vols.append(vol.get("volume_id"))
 
 
 # parse fullnodes
 fullnode_ips = []
 for fullnode in fullnodes:
-    fullnode_ips.append(fullnode.get('values').get('private_ip'))
+    fullnode_ips.append(fullnode.get("values").get("private_ip"))
 
 
 # Get image and version for ECS
@@ -100,42 +100,27 @@ safetyrules_image = None
 logstash_version = None
 validator_versions = []
 safetyrules_versions = []
-# Used to match the 'group' in task instance with 'family' in task definition. Why?
-# The index isn't available in task instance but in task definition so we iterate
-# over task definitions in order and use the mapping to extract the image and version
-# from the corresponding task instance
-validator_image_map = {}
-safetyrules_image_map = {}
 
 ecs_tasks = list_tasks(args.source, dir=tf_dir)
 
-for task in ecs_tasks.get('taskArns'):
+for task in ecs_tasks.get("taskArns"):
     task_details = describe_tasks(args.source, task, dir=tf_dir)
     extract_image_tag = lambda container: (
-        re.split('[@:]', container.get("image"))[0],
-        container.get("imageDigest")
+        re.split("[@:]", container.get("image"))[0],
+        container.get("imageDigest"),
     )
     for container in task_details.get("tasks")[0].get("containers"):
         name = container.get("name")
-        if not logstash_image and name == 'logstash':
+        if not logstash_image and name == "logstash":
             logstash_image, logstash_version = extract_image_tag(container)
-        elif not safetyrules_image and name == 'safety-rules':
-            key = task_details.get("tasks")[0].get("group").split("service:",1)[1]
-            safetyrules_image_map[key] = extract_image_tag(container)
-        elif name == 'validator':
-            key = task_details.get("tasks")[0].get("group").split("service:",1)[1]
-            validator_image_map[key] = extract_image_tag(container)
-
-for ecs in validators_ecs:
-    if ecs.get("name") == "validator":
-        key = ecs.get("values").get("family")
-        if key in validator_image_map:
-            validator_image, version = validator_image_map[key]
-            validator_versions.append(version)
-            safetyrules_image, safetyrules_version = safetyrules_image_map[key]
+        elif name == "safety-rules":
+            key = task_details.get("tasks")[0].get("group").split("service:", 1)[1]
+            safetyrules_image, safetyrules_version = extract_image_tag(container)
             safetyrules_versions.append(safetyrules_version)
-        else:
-            print(f"ERROR: didn't find task corresponding to definition {key} in {validator_image_map.keys()}")
+        elif name == "validator":
+            key = task_details.get("tasks")[0].get("group").split("service:", 1)[1]
+            validator_image, version = extract_image_tag(container)
+            validator_versions.append(version)
 
 print(f"logstash_image          : {logstash_image}")
 print(f"logstash_version        : {logstash_version}")
@@ -149,39 +134,41 @@ print(f"validator_restore_vols  : {validator_restore_vols}")
 
 # build the var strings
 vars = []
-vars.append(gen_tf_var_list('restore_vol_ids', validator_restore_vols))
+vars.append(gen_tf_var_list("restore_vol_ids", validator_restore_vols))
 
-vars.append(gen_tf_var_list('override_validator_ips', validator_ips))
-vars.append(gen_tf_var_list('override_fullnode_ips', fullnode_ips))
+vars.append(gen_tf_var_list("override_validator_ips", validator_ips))
+vars.append(gen_tf_var_list("override_fullnode_ips", fullnode_ips))
 
-vars.append(gen_tf_var_str('image_repo', validator_image))
-vars.append(gen_tf_var_list('override_image_tags', validator_versions))
-vars.append(gen_tf_var_str('logstash_image', logstash_image))
-vars.append(gen_tf_var_str('logstash_version', logstash_version))
-vars.append(gen_tf_var_str('safety_rules_image_repo', safetyrules_image))
-vars.append(gen_tf_var_list('override_safety_rules_image_tags', safetyrules_versions))
+vars.append(gen_tf_var_str("image_repo", validator_image))
+vars.append(gen_tf_var_list("override_image_tags", validator_versions))
+vars.append(gen_tf_var_str("logstash_image", logstash_image))
+vars.append(gen_tf_var_str("logstash_version", logstash_version))
+vars.append(gen_tf_var_str("safety_rules_image_repo", safetyrules_image))
+vars.append(gen_tf_var_list("override_safety_rules_image_tags", safetyrules_versions))
 
 if args.var_file:
-    with open(args.var_file, 'r') as f:
+    with open(args.var_file, "r") as f:
         source_varfile_text = f.read()
 
 # write all vars to file
-out_file = os.path.abspath(args.out_file) if args.out_file else 'roar.tfvars'
-with open(out_file, 'w') as f:
+out_file = os.path.abspath(args.out_file) if args.out_file else "roar.tfvars"
+with open(out_file, "w") as f:
     if args.var_file:
         f.write(source_varfile_text)
-        f.write('\n')
+        f.write("\n")
         f.write(
-            f'# Auto generated record and replay vars from file {os.path.abspath(args.var_file)}\n')
+            f"# Auto generated record and replay vars from file {os.path.abspath(args.var_file)}\n"
+        )
     else:
         f.write(
-            f'# Auto generated record and replay vars inferred from workspace \"{args.source}\"\n')
+            f'# Auto generated record and replay vars inferred from workspace "{args.source}"\n'
+        )
     for var in vars:
         # avoid collision if var previously specified
-        if args.var_file and var.split('=')[0] in source_varfile_text:
+        if args.var_file and var.split("=")[0] in source_varfile_text:
             continue
         f.write(var)
-        f.write('\n')
+        f.write("\n")
 
 print("\nInstructions:")
 print(f"cd {tf_dir}")

--- a/terraform/validators.tf
+++ b/terraform/validators.tf
@@ -141,6 +141,7 @@ locals {
   image_repo                 = var.image_repo
   image_version              = substr(var.image_tag, 0, 6) == "sha256" ? "@${var.image_tag}" : ":${var.image_tag}"
   override_image_versions    = [for img in var.override_image_tags : substr(img, 0, 6) == "sha256" ? "@${img}" : ":${img}"]
+  override_safety_rules_image_versions  = [for img in var.override_safety_rules_image_tags : substr(img, 0, 6) == "sha256" ? "@${img}" : ":${img}"]
   logstash_image_repo        = var.logstash_image
   logstash_image_version     = substr(var.logstash_version, 0, 6) == "sha256" ? "@${var.logstash_version}" : ":${var.logstash_version}"
   safety_rules_image_repo    = var.safety_rules_image_repo
@@ -233,7 +234,7 @@ data "template_file" "ecs_task_definition" {
     logstash_version           = local.logstash_image_version
     logstash_config            = local.logstash_config
     safety_rules_image         = local.safety_rules_image_repo
-    safety_rules_image_version = local.override_image_versions == [] ? local.safety_rules_image_version : local.override_image_versions[count.index % length(local.override_image_versions)]
+    safety_rules_image_version = local.override_safety_rules_image_versions == [] ? local.safety_rules_image_version : local.override_safety_rules_image_versions[count.index % length(local.override_safety_rules_image_versions)]
     push_metrics_endpoint      = "http://${aws_instance.monitoring.private_ip}:9092/metrics/job/safety_rules/role/validator/peer_id/val-${count.index}"
     cfg_vault_addr             = "http://${aws_instance.vault.private_ip}:8200"
     cfg_vault_namespace        = "val-${count.index}"

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -216,6 +216,12 @@ variable "override_image_tags" {
   description = "List of Docker image tags to be used in record and replay test, overrides image_tag"
 }
 
+variable "override_safety_rules_image_tags" {
+  type        = list(string)
+  default     = []
+  description = "Similar to override_image_tags but for safety rules, overrides safety_rules_image_tag"
+}
+
 variable "vault_type" {
   description = "EC2 instance type of Vault instances"
   default     = "c5.large"


### PR DESCRIPTION
<!--
Thank you for sending a PR. We appreciate you spending time to help improve the Libra project.

The project is undergoing daily changes. Pull Requests will be reviewed and responded to as time permits.
-->

## Motivation

Bug fix. Recent change to override safety rules image tags (https://github.com/libra/libra/pull/4252) was not compatible with earlier change to use image digest over tags in ROAR (https://github.com/libra/libra/pull/4057). This is because while safetyrules and validators might share the same image tag, their digests are different. This PR adds a new TF variable `override_safety_rules_image_tags` to do the safetyrules override separately explicitly.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?

yes

## Test Plan

ROAR on devnet and tf apply: http://prometheus.rustielin.aws.hlw3truzy4ls.com:9091/d/overview10/overview?orgId=1

ROAR'ed tfvars file:
```
# enable test runner instance so we can generate traffic on dev
cluster_test_runner = true
num_fullnode_networks = 2
enable_dashboard = true
enable_logstash  = true
logstash_image   = "853397791086.dkr.ecr.us-west-2.amazonaws.com/libra_logstash"
persist_libra_data = false
log_to_file = true

# Auto generated record and replay vars from file /Users/rustielin/libra-ops/terraform/testnet/facebook/dev.tfvars
restore_vol_ids = ["vol-0dc30ebdc129666d2","vol-0361de6609cfc0405","vol-03dc84d3215901813","vol-02653c0914eca0b1f"]
override_validator_ips = ["10.0.2.177","10.0.6.209","10.0.11.61","10.0.2.76"]
override_fullnode_ips = ["10.0.1.108","10.0.4.56"]
image_repo = "853397791086.dkr.ecr.us-west-2.amazonaws.com/libra_validator"
override_image_tags = ["sha256:920c0570e0af900520d859f570cea9f7d85290fce8db6aa23df79a3723f156c0","sha256:920c0570e0af900520d859f570cea9f7d85290fce8db6aa23df79a3723f156c0","sha256:920c0570e0af900520d859f570cea9f7d85290fce8db6aa23df79a3723f156c0","sha256:920c0570e0af900520d859f570cea9f7d85290fce8db6aa23df79a3723f156c0"]
logstash_version = "sha256:95343ef74362e1a4c06142ac99d036b4db1cc8255eaf697b1b19b64870a2e618"
safety_rules_image_repo = "853397791086.dkr.ecr.us-west-2.amazonaws.com/libra_safety_rules"
override_safety_rules_image_tags = ["sha256:2e7c7d2ccbb01173b541fd787f8fd01f327a7735e64b5656a301bfcd9dfdddde","sha256:2e7c7d2ccbb01173b541fd787f8fd01f327a7735e64b5656a301bfcd9dfdddde","sha256:2e7c7d2ccbb01173b541fd787f8fd01f327a7735e64b5656a301bfcd9dfdddde","sha256:2e7c7d2ccbb01173b541fd787f8fd01f327a7735e64b5656a301bfcd9dfdddde"]
```



## Related PRs

(If this PR adds or changes functionality, please take some time to update the docs at https://github.com/libra/website, and link to your PR here.)
