### PR TITLE
[libradb] fix get_ledger_info and rename to get_nearest_epoch_change_…

### DIFF
--- a/json-rpc/src/methods.rs
+++ b/json-rpc/src/methods.rs
@@ -131,7 +131,7 @@ async fn get_account_state(
 async fn get_metadata(service: JsonRpcService, request: JsonRpcRequest) -> Result<BlockMetadata> {
     let (version, timestamp) = match serde_json::from_value::<u64>(request.get_param(0)) {
         Ok(version) => {
-            let li = service.db.get_ledger_info(version)?;
+            let li = service.db.get_nearest_epoch_change_ledger_info(version)?;
             (version, li.ledger_info().timestamp_usecs())
         }
         _ => (

--- a/json-rpc/src/tests/utils.rs
+++ b/json-rpc/src/tests/utils.rs
@@ -260,7 +260,7 @@ impl DbReader for MockLibraDB {
         unimplemented!()
     }
 
-    fn get_ledger_info(&self, _: u64) -> Result<LedgerInfoWithSignatures> {
+    fn get_nearest_epoch_change_ledger_info(&self, _: u64) -> Result<LedgerInfoWithSignatures> {
         unimplemented!()
     }
 }

--- a/secure/json-rpc/src/lib.rs
+++ b/secure/json-rpc/src/lib.rs
@@ -627,7 +627,7 @@ mod test {
             unimplemented!()
         }
 
-        fn get_ledger_info(&self, _: u64) -> Result<LedgerInfoWithSignatures> {
+        fn get_nearest_epoch_change_ledger_info(&self, _: u64) -> Result<LedgerInfoWithSignatures> {
             unimplemented!()
         }
     }

--- a/state-synchronizer/src/executor_proxy.rs
+++ b/state-synchronizer/src/executor_proxy.rs
@@ -175,7 +175,7 @@ impl ExecutorProxyTrait for ExecutorProxy {
     }
 
     fn get_ledger_info(&self, version: u64) -> Result<LedgerInfoWithSignatures> {
-        let waypoint_li = self.storage.get_ledger_info(version)?;
+        let waypoint_li = self.storage.get_nearest_epoch_change_ledger_info(version)?;
         ensure!(
             waypoint_li.ledger_info().version() == version,
             "Version of Waypoint LI {} is different from requested waypoint version {}",

--- a/storage/libradb/src/lib.rs
+++ b/storage/libradb/src/lib.rs
@@ -46,7 +46,7 @@ use crate::{
     system_store::SystemStore,
     transaction_store::TransactionStore,
 };
-use anyhow::{ensure, format_err, Result};
+use anyhow::{ensure, Result};
 use itertools::{izip, zip_eq};
 use jellyfish_merkle::{restore::JellyfishMerkleRestore, TreeReader, TreeWriter};
 use libra_crypto::hash::{CryptoHash, HashValue, SPARSE_MERKLE_PLACEHOLDER_HASH};
@@ -756,16 +756,12 @@ impl DbReader for LibraDB {
         Ok(events)
     }
 
-    fn get_ledger_info(&self, known_version: u64) -> Result<LedgerInfoWithSignatures> {
-        let known_epoch = self.ledger_store.get_epoch(known_version)?;
-        let (mut ledger_infos_with_sigs, _more) =
-            self.get_epoch_change_ledger_infos(known_epoch, known_epoch + 1)?;
-        ledger_infos_with_sigs.pop().ok_or_else(|| {
-            format_err!(
-                "No waypoint ledger info found for version {}",
-                known_version
-            )
-        })
+    fn get_nearest_epoch_change_ledger_info(
+        &self,
+        known_version: u64,
+    ) -> Result<LedgerInfoWithSignatures> {
+        self.ledger_store
+            .get_nearest_epoch_change_ledger_info(known_version)
     }
 
     fn get_state_proof_with_ledger_info(

--- a/storage/libradb/src/test_helper.rs
+++ b/storage/libradb/src/test_helper.rs
@@ -91,7 +91,7 @@ prop_compose! {
         max_blocks: usize,
     )(
         mut universe in any_with::<AccountInfoUniverse>(num_accounts).no_shrink(),
-        batches in vec(
+        mut batches in vec(
             (
                 vec(any::<TransactionToCommitGen>(), 1..=max_txn_per_block),
                 any::<LedgerInfoWithSignaturesGen>(),
@@ -104,6 +104,9 @@ prop_compose! {
             LedgerInfoWithSignatures,
         )>
     {
+        // Truncate the first block to have only 1 txn.
+        batches[0].0.truncate(1);
+
         let partial_blocks = batches
             .into_iter()
             .map(|(txn_gens, ledger_info_gen)| {

--- a/storage/storage-client/src/lib.rs
+++ b/storage/storage-client/src/lib.rs
@@ -170,7 +170,7 @@ impl DbReader for StorageClient {
         unimplemented!()
     }
 
-    fn get_ledger_info(&self, _: u64) -> Result<LedgerInfoWithSignatures> {
+    fn get_nearest_epoch_change_ledger_info(&self, _: u64) -> Result<LedgerInfoWithSignatures> {
         unimplemented!()
     }
 }

--- a/storage/storage-interface/src/lib.rs
+++ b/storage/storage-interface/src/lib.rs
@@ -261,8 +261,11 @@ pub trait DbReader: Send + Sync {
     /// Used by the Db-bootstrapper.
     fn get_latest_tree_state(&self) -> Result<TreeState>;
 
-    /// Get the ledger info of the epoch that `known_version` belongs to.
-    fn get_ledger_info(&self, known_version: u64) -> Result<LedgerInfoWithSignatures>;
+    /// Get the last epoch-change ledger info that is earlier than `version`.
+    fn get_nearest_epoch_change_ledger_info(
+        &self,
+        version: Version,
+    ) -> Result<LedgerInfoWithSignatures>;
 }
 
 impl MoveStorage for &dyn DbReader {

--- a/storage/storage-interface/src/mock.rs
+++ b/storage/storage-interface/src/mock.rs
@@ -124,7 +124,10 @@ impl DbReader for MockDbReader {
         unimplemented!()
     }
 
-    fn get_ledger_info(&self, _known_version: u64) -> Result<LedgerInfoWithSignatures> {
+    fn get_nearest_epoch_change_ledger_info(
+        &self,
+        _version: u64,
+    ) -> Result<LedgerInfoWithSignatures> {
         unimplemented!()
     }
 }

--- a/types/src/proptest_types.rs
+++ b/types/src/proptest_types.rs
@@ -969,10 +969,19 @@ struct BlockInfoGen {
 }
 
 impl BlockInfoGen {
-    pub fn materialize(self, universe: &mut AccountInfoUniverse, block_size: usize) -> BlockInfo {
+    pub fn materialize(
+        self,
+        universe: &mut AccountInfoUniverse,
+        mut block_size: usize,
+    ) -> BlockInfo {
         assert!(block_size > 0, "No empty blocks are allowed.");
 
         let current_epoch = universe.get_epoch();
+
+        if current_epoch == 0 {
+            block_size = 1;
+        }
+
         // The first LedgerInfo should always carry a validator set.
         let (epoch, next_epoch_state) = if current_epoch == 0 || self.new_epoch {
             (


### PR DESCRIPTION
…ledger_info

## Motivation
The current implementation name is confusing.
```
JsonRpcError { code: -32000, message: "Server error: DB corruption: the last ledger info of epoch 1 is missing next epoch info", data: None }
```
libradb::get_ledger_info(v) has a flaw: when v is in the latest epoch it raises the above error

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?

Y

## Test Plan

add new test plan
