### PR TITLE
[network] added structured logging for event loops

### DIFF
--- a/config/src/network_id.rs
+++ b/config/src/network_id.rs
@@ -8,7 +8,7 @@ use std::fmt;
 /// A grouping of common information between all networking code for logging.
 /// This should greatly reduce the groupings between these given everywhere, and will allow
 /// for logging accordingly.  TODO: Figure out how to split these as structured logging
-#[derive(Clone, Debug, Eq, PartialEq)]
+#[derive(Clone, Debug, Eq, PartialEq, Serialize)]
 pub struct NetworkContext {
     network_id: NetworkId,
     role: RoleType,

--- a/network/onchain-discovery/src/client.rs
+++ b/network/onchain-discovery/src/client.rs
@@ -16,7 +16,7 @@ use futures::{
     stream::{FusedStream, Stream, StreamExt},
 };
 use libra_config::network_id::NetworkContext;
-use libra_logger::prelude::*;
+use libra_logger::{prelude::*, StructuredLogEntry};
 use libra_types::{
     on_chain_config::ValidatorSet,
     trusted_state::{TrustedState, TrustedStateChange},
@@ -25,6 +25,7 @@ use libra_types::{
 };
 use network::{
     connectivity_manager::{ConnectivityRequest, DiscoverySource},
+    logging,
     peer_manager::{conn_notifs_channel, ConnectionNotification},
 };
 use option_future::OptionFuture;
@@ -115,17 +116,30 @@ where
         // we have an up-to-date discovery set to connect with.
         let f_query_storage = self.handle_storage_query_tick().boxed();
         let mut pending_storage_query = OptionFuture::new(Some(f_query_storage));
-
+        send_struct_log!(
+            StructuredLogEntry::new_named(logging::ONCHAIN_DISCOVERY_LOOP)
+                .field(&logging::NETWORK_CONTEXT, &self.network_context)
+                .data(logging::TYPE, logging::START)
+        );
         debug!("{} starting onchain discovery", self.network_context);
         loop {
             self.event_id = self.event_id.wrapping_add(1);
             futures::select! {
                 notif = self.conn_notifs_rx.select_next_some() => {
-                    trace!("{} event id: {}, type: ConnectionNotification", self.network_context, self.event_id);
+                    send_struct_log!(StructuredLogEntry::new_named(logging::ONCHAIN_DISCOVERY_LOOP)
+                        .data(logging::TYPE, "connection_notification")
+                        .field(&logging::NETWORK_CONTEXT, &self.network_context)
+                        .field(&logging::EVENT_ID, &self.event_id)
+                        .field(&logging::CONNECTION_NOTIFICATION, &notif)
+                    );
                     self.handle_connection_notif(notif);
                 },
                 _ = self.peer_query_ticker.select_next_some() => {
-                    trace!("{} event id: {}, type: PeerQueryTick", self.network_context, self.event_id);
+                    send_struct_log!(StructuredLogEntry::new_named(logging::ONCHAIN_DISCOVERY_LOOP)
+                        .data(logging::TYPE, "peer_query_tick")
+                        .field(&logging::NETWORK_CONTEXT, &self.network_context)
+                        .field(&logging::EVENT_ID, &self.event_id)
+                    );
                     pending_outbound_rpc
                         .or_insert_with(|| {
                             self.handle_peer_query_tick()
@@ -133,19 +147,36 @@ where
                         });
                 },
                 query_res = pending_outbound_rpc => {
-                    trace!("{} event id: {}, type: QueryResponse", self.network_context, self.event_id);
+                    send_struct_log!(StructuredLogEntry::new_named(logging::ONCHAIN_DISCOVERY_LOOP)
+                        .data(logging::TYPE, "rpc_query_response")
+                        .field(&logging::NETWORK_CONTEXT, &self.network_context)
+                        .field(&logging::EVENT_ID, &self.event_id)
+                    );
                     self.handle_outbound_query_res(query_res).await;
                 },
                 _ = self.storage_query_ticker.select_next_some() => {
-                    trace!("{} event id: {}, type: StorageQueryTick", self.network_context, self.event_id);
+                    send_struct_log!(StructuredLogEntry::new_named(logging::ONCHAIN_DISCOVERY_LOOP)
+                        .data(logging::TYPE, "storage_query_tick")
+                        .field(&logging::NETWORK_CONTEXT, &self.network_context)
+                        .field(&logging::EVENT_ID, &self.event_id)
+                    );
                     pending_storage_query
                         .or_insert_with(|| Some(self.handle_storage_query_tick().boxed()));
                 },
                 query_res = pending_storage_query => {
-                    trace!("{} event id: {}, type: QueryResponse", self.network_context, self.event_id);
+                    send_struct_log!(StructuredLogEntry::new_named(logging::ONCHAIN_DISCOVERY_LOOP)
+                        .data(logging::TYPE, "storage_query_response")
+                        .field(&logging::NETWORK_CONTEXT, &self.network_context)
+                        .field(&logging::EVENT_ID, &self.event_id)
+                    );
                     self.handle_outbound_query_res(query_res).await;
                 }
                 complete => {
+                    send_struct_log!(StructuredLogEntry::new_named(logging::ONCHAIN_DISCOVERY_LOOP)
+                        .data(logging::TYPE, logging::TERMINATION)
+                        .field(&logging::NETWORK_CONTEXT, &self.network_context)
+                        .critical()
+                    );
                     crit!("{} onchain discovery terminated", self.network_context);
                     break;
                 }

--- a/network/src/lib.rs
+++ b/network/src/lib.rs
@@ -12,6 +12,7 @@ pub mod common;
 pub mod connectivity_manager;
 pub mod error;
 pub mod interface;
+pub mod logging;
 pub mod peer_manager;
 pub mod protocols;
 pub mod validator_network;

--- a/network/src/logging.rs
+++ b/network/src/logging.rs
@@ -1,0 +1,26 @@
+// Copyright (c) The Libra Core Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::{peer_manager::ConnectionNotification, ConnectivityRequest};
+use libra_config::network_id::NetworkContext;
+use libra_logger::LoggingField;
+use libra_types::PeerId;
+
+/// This file contains constants used for structured logging data types so that there is
+/// consistency among structured logs.
+pub const CONNECTIVITY_MANAGER_LOOP: &str = "connectivity_manager_loop";
+pub const ONCHAIN_DISCOVERY_LOOP: &str = "onchain_discovery_loop";
+
+/// Common terms
+pub const TYPE: &str = "type";
+pub const START: &str = "start";
+pub const TERMINATION: &str = "termination";
+
+/// Specific fields for logging
+pub const NETWORK_CONTEXT: LoggingField<&NetworkContext> = LoggingField::new("network_context");
+pub const EVENT_ID: LoggingField<&u32> = LoggingField::new("event_id");
+pub const REMOTE_PEER: LoggingField<&PeerId> = LoggingField::new("remote_peer");
+pub const CONNECTION_NOTIFICATION: LoggingField<&ConnectionNotification> =
+    LoggingField::new("conn_notification");
+pub const CONNECTIVITY_REQUEST: LoggingField<&ConnectivityRequest> =
+    LoggingField::new("conn_request");

--- a/network/src/peer/mod.rs
+++ b/network/src/peer/mod.rs
@@ -22,6 +22,7 @@ use futures::{
 use libra_logger::prelude::*;
 use libra_types::PeerId;
 use netcore::compat::IoCompat;
+use serde::Serialize;
 use std::{fmt::Debug, io, time::Duration};
 use stream_ratelimiter::*;
 use tokio::runtime::Handle;
@@ -44,7 +45,7 @@ pub enum PeerRequest {
     CloseConnection,
 }
 
-#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize)]
 pub enum DisconnectReason {
     Requested,
     ConnectionLost,

--- a/network/src/peer_manager/mod.rs
+++ b/network/src/peer_manager/mod.rs
@@ -35,6 +35,7 @@ use libra_logger::prelude::*;
 use libra_network_address::NetworkAddress;
 use libra_types::PeerId;
 use netcore::transport::{ConnectionOrigin, Transport};
+use serde::Serialize;
 use std::{
     collections::{hash_map::Entry, HashMap},
     fmt::Debug,
@@ -79,7 +80,7 @@ pub enum ConnectionRequest {
     DisconnectPeer(PeerId, oneshot::Sender<Result<(), PeerManagerError>>),
 }
 
-#[derive(Debug, PartialEq, Eq)]
+#[derive(Debug, PartialEq, Eq, Serialize)]
 pub enum ConnectionNotification {
     /// Connection with a new peer has been established.
     NewPeer(PeerId, NetworkAddress),


### PR DESCRIPTION
As a first attempt at using the StructuredLogging API, I'm adding next
to the already existing trace! logs, a structured log that keeps track
of what's going on in loops in onchain-discovery and
connectivity_manager as a starting place.

### My thoughts about structured logging
1. They help the parsing a lot, and they work great in my testing.  I think its a great addition, and I'm sure it'll help a lot in Kibana!
2. We should have an environment variable that can let us turn them on for local log testing, rather than making a static function call.
3. I think we need guidelines on what level of logging we want in structured logging, and if we want different levels of it such that we don't overfill the logs / can filter out the important things, more than just the `critical` and `warning` levels, but I could be persuaded otherwise.
4. Let's make a centralized place for common terms, and maybe some examples of how to use the paradigm.  I think what I've created here is decent as a first step, but I'm willing if this isn't the best way to do it another way.
5. Do we want common fields hard typed into the structured logging?  For example, `PeerId` should always be a `PeerId` rather than possibly a string, which could cause accidental mistakes by putting the wrong value in.
6. Serialization is nice and simple, but it does cause us to think strongly about what we do and do not want to serialize at any one point in time for logging purposes, at the same time we think about serialization for into a file or across a wire.

### Testing

I added `init_println_struct_log()` to the front of some tests to check it out.  Here are some of the logs from my changes at least for `ConnectivityManager`
```
{"name":"connectivity_manager_loop","module":"network::connectivity_manager","location":"network/src/connectivity_manager/mod.rs:220","timestamp":"2020-06-12 22:09:08","data":{"type":"start","network_context":{"network_id":{"type":"Validator"},"peer_id":"42daa04d56535e51816f1074f40f3f49","role":"validator"}}}
{"name":"connectivity_manager_loop","module":"network::connectivity_manager","location":"network/src/connectivity_manager/mod.rs:220","timestamp":"2020-06-12 22:09:08","data":{"network_context":{"network_id":{"type":"Validator"},"peer_id":"262840ce151585da276e25a315a68529","role":"validator"},"type":"start"}}
{"name":"connectivity_manager_loop","module":"network::connectivity_manager","location":"network/src/connectivity_manager/mod.rs:220","timestamp":"2020-06-12 22:09:08","data":{"network_context":{"network_id":{"type":"Validator"},"peer_id":"e3d468c1f89164029d38845fe7672635","role":"validator"},"type":"start"}}
{"name":"connectivity_manager_loop","module":"network::connectivity_manager","location":"network/src/connectivity_manager/mod.rs:220","timestamp":"2020-06-12 22:09:08","data":{"network_context":{"network_id":{"type":"Validator"},"peer_id":"b65e208fb8c1a31eb2f9261277e3e929","role":"validator"},"type":"start"}}
{"name":"connectivity_manager_loop","module":"network::connectivity_manager","location":"network/src/connectivity_manager/mod.rs:220","timestamp":"2020-06-12 22:09:08","data":{"type":"start","network_context":{"network_id":{"type":"Validator"},"peer_id":"8c45f1749333432fb19304e34b2a86f0","role":"validator"}}}
{"name":"connectivity_manager_loop","module":"network::connectivity_manager","location":"network/src/connectivity_manager/mod.rs:220","timestamp":"2020-06-12 22:09:08","data":{"type":"start","network_context":{"network_id":{"type":"Validator"},"peer_id":"00deb9cd9804c546953f5b13b16106c4","role":"validator"}}}
{"name":"connectivity_manager_loop","module":"network::connectivity_manager","location":"network/src/connectivity_manager/mod.rs:220","timestamp":"2020-06-12 22:09:08","data":{"network_context":{"network_id":{"type":"Validator"},"peer_id":"07850f8e166d97bebdb738cd1e0fdee7","role":"validator"},"type":"start"}}
{"name":"connectivity_manager_loop","module":"network::connectivity_manager","location":"network/src/connectivity_manager/mod.rs:228","timestamp":"2020-06-12 22:09:08","data":{"request":{"UpdateAddresses":["Gossip",{"fe2c04e2c71b68674172ad7261812671":["/ip4/127.0.0.1/tcp/9090"]}]},"event_id":1,"type":"connectivity_request","network_context":{"network_id":{"type":"Validator"},"peer_id":"262840ce151585da276e25a315a68529","role":"validator"}}}
```