### PR TITLE
[Safety Rules] Support configurable structured logging to endpoint

### DIFF
--- a/consensus/safety-rules/src/main.rs
+++ b/consensus/safety-rules/src/main.rs
@@ -28,7 +28,10 @@ fn main() {
         .is_async(config.logger.is_async)
         .level(config.logger.level)
         .init();
+    libra_logger::init_struct_log_from_env().expect("Failed to initialize structured logging");
+
     MetricsPusher::new(COUNTERS.clone()).start();
+
     let mut service = Process::new(config);
     service.start();
 }

--- a/docker/safety-rules/run-safety-rules.sh
+++ b/docker/safety-rules/run-safety-rules.sh
@@ -3,18 +3,28 @@
 # SPDX-License-Identifier: Apache-2.0
 set -e
 
-# Example Usage (arguments that are not specified will be assigned defaults):
-# ./run-safety-rules.sh <IMAGE> <CFG_NODE_INDEX> <CFG_SAFETY_RULES_LISTEN_ADDR>
+# Example Usage:
+# ./run-safety-rules.sh <IMAGE> <CFG_NODE_INDEX> <CFG_SAFETY_RULES_LISTEN_ADDR> <STRUCT_LOGGER> <STRUCT_LOGGER_LOCATION>
+#
+# Note:
+# (i) if arguments are not specified they will be assigned defaults.
+# (ii) structured logger (STRUCT_LOGGER) must be one of STRUCT_LOG_FILE or STRUCT_LOG_UDP_ADDR, with
+#      STRUCT_LOGGER_LOCATION set according to the chosen logger.
+
 
 IMAGE="${1:-libra_safety_rules:latest}"
 CFG_NODE_INDEX="${2:-0}"
 CFG_SAFETY_RULES_LISTEN_ADDR="${3:-0.0.0.0:8888}"
+STRUCT_LOGGER="${4:-STRUCT_LOG_UDP_ADDR}"
+STRUCT_LOGGER_LOCATION="${5:-127.0.0.1:5044}"
 
 docker network create --subnet 172.18.0.0/24 testnet || true
 
 docker run \
     -e CFG_NODE_INDEX="$CFG_NODE_INDEX" \
     -e CFG_SAFETY_RULES_LISTEN_ADDR="$CFG_SAFETY_RULES_LISTEN_ADDR" \
+    -e STRUCT_LOGGER="$STRUCT_LOGGER" \
+    -e STRUCT_LOGGER_LOCATION="$STRUCT_LOGGER_LOCATION" \
     --ip 172.18.0.2 \
     --network testnet \
     "$IMAGE"

--- a/docker/safety-rules/safety-rules.sh
+++ b/docker/safety-rules/safety-rules.sh
@@ -3,6 +3,7 @@
 # SPDX-License-Identifier: Apache-2.0
 set -e
 
+# Parse parameters and execute config builder
 declare -a params
 if [ -n "${CFG_BASE_CONFIG}" ]; then # Path to base config
 	    echo "${CFG_BASE_CONFIG}" > /opt/libra/etc/base.config.toml
@@ -38,4 +39,15 @@ fi
     --output-dir /opt/libra/etc/ \
     ${params[@]}
 
-exec /opt/libra/bin/safety-rules /opt/libra/etc/node.config.toml
+# Parse logger environment variables and execute safety rules
+declare logger
+if [ -n "${STRUCT_LOGGER}" ]; then
+    if [ -n "${STRUCT_LOGGER_LOCATION}" ]; then
+      logger="env ${STRUCT_LOGGER}=${STRUCT_LOGGER_LOCATION}"
+    else
+      echo "STRUCT_LOGGER has been set but STRUCT_LOGGER_LOCATION is not set!"
+      exit 1
+    fi
+fi
+
+exec ${logger} /opt/libra/bin/safety-rules /opt/libra/etc/node.config.toml


### PR DESCRIPTION
## Motivation

This small PR updates Safety Rules to support structured logging to a configurable logging endpoint.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?

Yes.

## Test Plan

I tested this by running the docker container. When the flag is set to log to a file, I verified that the log file exists. When the flag is set to log to a logstash endpoint, I verified that the logstash instance (also running locally), correctly receives the logs.

## Related PRs

We previously did this for the Key Manager, here: https://github.com/libra/libra/pull/4386
