### PR TITLE
[consensus] add monitor macro

### DIFF
--- a/consensus/src/counters.rs
+++ b/consensus/src/counters.rs
@@ -11,6 +11,9 @@ use once_cell::sync::Lazy;
 // HEALTH COUNTERS
 //////////////////////
 
+pub static OP_COUNTERS: Lazy<libra_metrics::OpMetrics> =
+    Lazy::new(|| libra_metrics::OpMetrics::new_and_registered("consensus"));
+
 /// Counter of pending network events to Consensus
 pub static PENDING_CONSENSUS_NETWORK_EVENTS: Lazy<IntCounterVec> = Lazy::new(|| {
     register_int_counter_vec!(

--- a/consensus/src/state_computer.rs
+++ b/consensus/src/state_computer.rs
@@ -7,6 +7,7 @@ use consensus_types::block::Block;
 use executor_types::{BlockExecutor, StateComputeResult};
 use libra_crypto::HashValue;
 use libra_logger::prelude::*;
+use libra_metrics::monitor;
 use libra_types::{ledger_info::LedgerInfoWithSignatures, transaction::Transaction};
 use state_synchronizer::StateSyncClient;
 use std::{
@@ -64,29 +65,32 @@ impl StateComputer for ExecutionProxy {
         );
 
         // TODO: figure out error handling for the prologue txn
-        self.execution_correctness_client
-            .lock()
-            .unwrap()
-            .execute_block(
-                (block.id(), Self::transactions_from_block(block)),
-                parent_block_id,
-            )
-            .map_err(Error::from)
-            .and_then(|result| {
-                let execution_duration = pre_execution_instant.elapsed();
-                let num_txns = result.transaction_info_hashes().len();
-                ensure!(num_txns > 0, "metadata txn failed to execute");
-                counters::BLOCK_EXECUTION_DURATION_S.observe_duration(execution_duration);
-                if let Ok(nanos_per_txn) =
-                    u64::try_from(execution_duration.as_nanos() / num_txns as u128)
-                {
-                    // TODO: use duration_float once it's stable
-                    // Tracking: https://github.com/rust-lang/rust/issues/54361
-                    counters::TXN_EXECUTION_DURATION_S
-                        .observe_duration(Duration::from_nanos(nanos_per_txn));
-                }
-                Ok(result)
-            })
+        monitor!(
+            "execute_block",
+            self.execution_correctness_client
+                .lock()
+                .unwrap()
+                .execute_block(
+                    (block.id(), Self::transactions_from_block(block)),
+                    parent_block_id,
+                )
+                .map_err(Error::from)
+                .and_then(|result| {
+                    let execution_duration = pre_execution_instant.elapsed();
+                    let num_txns = result.transaction_info_hashes().len();
+                    ensure!(num_txns > 0, "metadata txn failed to execute");
+                    counters::BLOCK_EXECUTION_DURATION_S.observe_duration(execution_duration);
+                    if let Ok(nanos_per_txn) =
+                        u64::try_from(execution_duration.as_nanos() / num_txns as u128)
+                    {
+                        // TODO: use duration_float once it's stable
+                        // Tracking: https://github.com/rust-lang/rust/issues/54361
+                        counters::TXN_EXECUTION_DURATION_S
+                            .observe_duration(Duration::from_nanos(nanos_per_txn));
+                    }
+                    Ok(result)
+                })
+        )
     }
 
     /// Send a successful commit. A future is fulfilled when the state is finalized.
@@ -100,11 +104,13 @@ impl StateComputer for ExecutionProxy {
 
         let pre_commit_instant = Instant::now();
 
-        let (committed_txns, reconfig_events) = self
-            .execution_correctness_client
-            .lock()
-            .unwrap()
-            .commit_blocks(block_ids, finality_proof)?;
+        let (committed_txns, reconfig_events) = monitor!(
+            "commit_block",
+            self.execution_correctness_client
+                .lock()
+                .unwrap()
+                .commit_blocks(block_ids, finality_proof)?
+        );
         counters::BLOCK_COMMIT_DURATION_S.observe_duration(pre_commit_instant.elapsed());
         if let Err(e) = self
             .synchronizer
@@ -124,7 +130,7 @@ impl StateComputer for ExecutionProxy {
         // commitments, the the sync state of ChunkExecutor may be not up to date so
         // it is required to reset the cache of ChunkExecutor in StateSynchronizer
         // when requested to sync.
-        let res = self.synchronizer.sync_to(target).await;
+        let res = monitor!("sync_to", self.synchronizer.sync_to(target).await);
         // Similarily, after the state synchronization, we have to reset the cache
         // of BlockExecutor to guarantee the latest committed state is up to date.
         self.execution_correctness_client.lock().unwrap().reset()?;


### PR DESCRIPTION
<!--
Thank you for sending a PR. We appreciate you spending time to help improve the Libra project.

The project is undergoing daily changes. Pull Requests will be reviewed and responded to as time permits.
-->

## Motivation

Added a macro to simplify counters which can record the call_count,
latency and whether it's running.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?

Y

## Test Plan

Existing tests.

## Related PRs

(If this PR adds or changes functionality, please take some time to update the docs at https://github.com/libra/website, and link to your PR here.)
